### PR TITLE
[LIBUSB] HACK: delay 100 ms

### DIFF
--- a/reactos/lib/drivers/libusb/hub_controller.cpp
+++ b/reactos/lib/drivers/libusb/hub_controller.cpp
@@ -324,7 +324,8 @@ CHubController::QueryStatusChangeEndpoint(
         m_Hardware->GetPortStatus(PortId, &PortStatus, &PortChange);
 
         DPRINT("[%s] Port %d: Status %x, Change %x\n", m_USBType, PortId, PortStatus, PortChange);
-
+DPRINT1("QueryStatusChangeEndpoint: FIXME KeStallExecutionProcessor(100000)\n");
+KeStallExecutionProcessor(100000); //100 msec
 
         //
         // If there's a flag in PortChange return TRUE so the SCE Irp will be completed


### PR DESCRIPTION
If delete (or "//") DPTINTs from USB-code, or select boot "not Debug" mode than you can see black screen.
This delay has been made experimentally.