### PR TITLE
[REGEDIT] Support editing REG_FULL_RESOURCE_DESCRIPTOR values

### DIFF
--- a/base/applications/regedit/edit.c
+++ b/base/applications/regedit/edit.c
@@ -1279,6 +1279,36 @@ BOOL ModifyValue(HWND hwnd, HKEY hKey, LPCWSTR valueName, BOOL EditBin)
         {
         }
     }
+    else if (EditBin == FALSE && type == REG_FULL_RESOURCE_DESCRIPTOR)
+    {
+        if (valueDataLen > 0)
+        {
+            resourceValueData = HeapAlloc(GetProcessHeap(), 0, valueDataLen + sizeof(ULONG));
+            if (resourceValueData == NULL)
+            {
+                error(hwnd, IDS_TOO_BIG_VALUE, valueDataLen);
+                goto done;
+            }
+
+            lRet = RegQueryValueExW(hKey, valueName, 0, 0, (LPBYTE)&resourceValueData->List[0], &valueDataLen);
+            if (lRet != ERROR_SUCCESS)
+            {
+                error(hwnd, IDS_BAD_VALUE, valueName);
+                goto done;
+            }
+
+            resourceValueData->Count = 1;
+            fullResourceIndex = 0;
+        }
+        else
+        {
+            resourceValueData = NULL;
+        }
+
+        if (DialogBoxW(0, MAKEINTRESOURCEW(IDD_EDIT_RESOURCE), hwnd, modify_resource_dlgproc) == IDOK)
+        {
+        }
+    }
     else if ((EditBin != FALSE) || (type == REG_NONE) || (type == REG_BINARY))
     {
         if(valueDataLen > 0)


### PR DESCRIPTION
Add support for editing (or rather viewing, since like REG_RESOURCE_LIST the results are not written back) REG_FULL_RESOURCE_DESCRIPTOR registry values like HKEY_LOCAL_MACHINE\HARDWARE\DESCRIPTION\System\MultifunctionAdapter\1:ConfiguratonData aka "ACPI BIOS" / BIOS memory map, which itself seems to be broken in it's format, but that is for another patch...