### PR TITLE
[CLASS2] Implement support for IOCTL_MOUNTDEV_QUERY_DEVICE_NAME

### DIFF
--- a/drivers/storage/class/class2/class2.c
+++ b/drivers/storage/class/class2/class2.c
@@ -4068,7 +4068,7 @@ Return Value:
         RtlZeroMemory(name, sizeof(MOUNTDEV_NAME));
         name->NameLength = deviceExtension->DeviceName.Length;
 
-        if (irpStack->Parameters.DeviceIoControl.OutputBufferLength < sizeof(USHORT) + name->NameLength) {
+        if (irpStack->Parameters.DeviceIoControl.OutputBufferLength < FIELD_OFFSET(MOUNTDEV_NAME, Name) + name->NameLength) {
 
             Irp->IoStatus.Information = sizeof(MOUNTDEV_NAME);
             Irp->IoStatus.Status = STATUS_BUFFER_OVERFLOW;
@@ -4081,7 +4081,7 @@ Return Value:
                       name->NameLength);
         status = STATUS_SUCCESS;
         Irp->IoStatus.Status = STATUS_SUCCESS;
-        Irp->IoStatus.Information = sizeof(USHORT) + name->NameLength;
+        Irp->IoStatus.Information = FIELD_OFFSET(MOUNTDEV_NAME, Name) + name->NameLength;
         IoCompleteRequest(Irp, IO_NO_INCREMENT);
         goto SetStatusAndReturn;
     }

--- a/drivers/storage/class/include/class2.h
+++ b/drivers/storage/class/include/class2.h
@@ -132,6 +132,7 @@ typedef struct _DEVICE_EXTENSION
   HANDLE MediaChangeEventHandle;
   BOOLEAN MediaChangeNoMedia;
   ULONG MediaChangeCount;
+  UNICODE_STRING DeviceName;
 } DEVICE_EXTENSION, *PDEVICE_EXTENSION;
 
 


### PR DESCRIPTION
- In ScsiClassCreateDeviceObject() don't drop received object name and store it in the device extension
- Implement support for the IOCTL_MOUNTDEV_QUERY_DEVICE_NAME IOCTL; return the store device name