### PR TITLE
Enable DXTn by default, it is no longer  patent-protected

### DIFF
--- a/dll/3rdparty/CMakeLists.txt
+++ b/dll/3rdparty/CMakeLists.txt
@@ -1,8 +1,6 @@
 
 
 add_subdirectory(dxtn)
-
-
 add_subdirectory(libjpeg)
 add_subdirectory(libpng)
 add_subdirectory(libtiff)

--- a/sdk/cmake/config-amd64.cmake
+++ b/sdk/cmake/config-amd64.cmake
@@ -37,12 +37,6 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-
-
-
-
-
-
 set(USERMODE TRUE CACHE BOOL
 "Whether to compile any usermode parts. This is while kernel mode is under
  heavy development and usermode part not relevant for bootcd.")

--- a/sdk/cmake/config-amd64.cmake
+++ b/sdk/cmake/config-amd64.cmake
@@ -37,11 +37,11 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-set(NSWPAT FALSE CACHE BOOL
-"Whether to compile apps/libs with features covered software patents or not.
-If you live in a country where software patents are valid/apply, don't
-enable this (except they/you purchased a license from the patent owner).
-This settings is disabled (0) by default.")
+
+
+
+
+
 
 set(USERMODE TRUE CACHE BOOL
 "Whether to compile any usermode parts. This is while kernel mode is under

--- a/sdk/cmake/config-arm.cmake
+++ b/sdk/cmake/config-arm.cmake
@@ -38,12 +38,6 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-
-
-
-
-
-
 set(BUILD_MP TRUE CACHE BOOL
 "Whether to compile the multi processor versions for ntoskrnl and hal.")
 

--- a/sdk/cmake/config-arm.cmake
+++ b/sdk/cmake/config-arm.cmake
@@ -38,11 +38,11 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-set(NSWPAT FALSE CACHE BOOL
-"Whether to compile apps/libs with features covered software patents or not.
-If you live in a country where software patents are valid/apply, don't
-enable this (except they/you purchased a license from the patent owner).
-This settings is disabled (0) by default.")
+
+
+
+
+
 
 set(BUILD_MP TRUE CACHE BOOL
 "Whether to compile the multi processor versions for ntoskrnl and hal.")

--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -58,11 +58,11 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-set(NSWPAT FALSE CACHE BOOL
-"Whether to build apps/libs with features covered by software patents.
-If you live in a country where software patents are valid/apply, don't
-enable this (except they/you purchased a license from the patent owner).
-This setting is disabled by default.")
+
+
+
+
+
 
 set(BUILD_MP TRUE CACHE BOOL
 "Whether to build the multiprocessor versions of NTOSKRNL and HAL.")

--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -58,12 +58,6 @@ set(_ELF_ FALSE CACHE BOOL
 "Whether to compile support for ELF files.
 Do not enable unless you know what you're doing.")
 
-
-
-
-
-
-
 set(BUILD_MP TRUE CACHE BOOL
 "Whether to build the multiprocessor versions of NTOSKRNL and HAL.")
 


### PR DESCRIPTION
Enable DXTn in ReactOS by default, as it is no longer protected by the patent.

see https://jira.reactos.org/browse/CORE-13455 for the details.