### PR TITLE
[WDMAUD] Close mixers on cleanup. Should fix CORE-10735 definitely

### DIFF
--- a/drivers/wdm/audio/legacy/wdmaud/entry.c
+++ b/drivers/wdm/audio/legacy/wdmaud/entry.c
@@ -326,6 +326,7 @@ WdmAudCleanup(
            /* found an still open audio pin */
            ZwClose(pClient->hPins[Index].Handle);
        }
+       WdmAudCloseAllMixers(DeviceObject, pClient, Index);
     }
 
     /* free pin array */

--- a/drivers/wdm/audio/legacy/wdmaud/mmixer.c
+++ b/drivers/wdm/audio/legacy/wdmaud/mmixer.c
@@ -497,6 +497,34 @@ WdmAudControlCloseMixer(
     return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
 }
 
+VOID
+WdmAudCloseAllMixers(
+    IN PDEVICE_OBJECT DeviceObject,
+    IN PWDMAUD_CLIENT ClientInfo,
+    IN ULONG Index)
+{
+    ULONG DeviceCount, DeviceIndex;
+
+    /* Get all mixers */
+    DeviceCount = GetSysAudioDeviceCount(DeviceObject);
+
+    /* Close every mixer attached to the device */
+    for (DeviceIndex = 0; DeviceIndex < DeviceCount; DeviceIndex++)
+    {
+        if (MMixerClose(&MixerContext, DeviceIndex, ClientInfo, EventCallback))
+        {
+            DPRINT1("Failed to close mixer !\n");
+        }
+    }
+    
+    /* Dereference event */
+    if (ClientInfo->hPins[Index].NotifyEvent)
+    {
+        ObDereferenceObject(ClientInfo->hPins[Index].NotifyEvent);
+        ClientInfo->hPins[Index].NotifyEvent = NULL;
+    }
+}
+
 NTSTATUS
 NTAPI
 WdmAudGetControlDetails(

--- a/drivers/wdm/audio/legacy/wdmaud/mmixer.c
+++ b/drivers/wdm/audio/legacy/wdmaud/mmixer.c
@@ -480,7 +480,7 @@ WdmAudControlCloseMixer(
     IN  ULONG Index)
 {
     /* Remove event associated to this client */
-    if (MMixerClose(&MixerContext, DeviceInfo->DeviceIndex, ClientInfo, EventCallback))
+    if (MMixerClose(&MixerContext, DeviceInfo->DeviceIndex, ClientInfo, EventCallback) != MM_STATUS_SUCCESS)
     {
         DPRINT1("Failed to close mixer\n");
         return SetIrpIoStatus(Irp, STATUS_UNSUCCESSFUL, sizeof(WDMAUD_DEVICE_INFO));
@@ -511,9 +511,9 @@ WdmAudCloseAllMixers(
     /* Close every mixer attached to the device */
     for (DeviceIndex = 0; DeviceIndex < DeviceCount; DeviceIndex++)
     {
-        if (MMixerClose(&MixerContext, DeviceIndex, ClientInfo, EventCallback))
+        if (MMixerClose(&MixerContext, DeviceIndex, ClientInfo, EventCallback) != MM_STATUS_SUCCESS)
         {
-            DPRINT1("Failed to close mixer !\n");
+            DPRINT1("Failed to close mixer for device %lu\n", DeviceIndex);
         }
     }
     

--- a/drivers/wdm/audio/legacy/wdmaud/wdmaud.h
+++ b/drivers/wdm/audio/legacy/wdmaud/wdmaud.h
@@ -136,6 +136,12 @@ WdmAudControlCloseMixer(
     IN  PWDMAUD_CLIENT ClientInfo,
     IN  ULONG Index);
 
+VOID
+WdmAudCloseAllMixers(
+    IN PDEVICE_OBJECT DeviceObject,
+    IN PWDMAUD_CLIENT ClientInfo,
+    IN ULONG Index);
+
 NTSTATUS
 WdmAudControlOpenWave(
     IN  PDEVICE_OBJECT DeviceObject,


### PR DESCRIPTION
Here is the second part of the patch which closes all mixer events on device cleanup, which should kill CORE-10735 forever.