### PR TITLE
[WIDL] Sync with Wine Staging 2.16. CORE-13762

### DIFF
--- a/media/doc/README.WINE
+++ b/media/doc/README.WINE
@@ -16,7 +16,7 @@ wine-patches@winehq.com and ros-dev@reactos.org
 The following build tools are shared with Wine.
 
 reactos/sdk/tools/unicode               # Synced to WineStaging-2.9
-reactos/sdk/tools/widl                  # Synced to WineStaging-2.9
+reactos/sdk/tools/widl                  # Synced to WineStaging-2.16
 reactos/sdk/tools/wpp                   # Synced to WineStaging-2.9
 
 The following libraries are shared with Wine.


### PR DESCRIPTION
b42a155 widl: Handle C++ aggregate returns in a MSVC compatible way.
084fa63 widl: Only generate Proxy Stubs when functions have the call_as attribute.
fbdf119 widl: Try to find imported typelib using .tlb extension if it wasn't specified.