### PR TITLE
CORE-13332. Add checks for entry sizes and bare handling of error case.

### DIFF
--- a/boot/freeldr/freeldr/include/arch/pc/pcbios.h
+++ b/boot/freeldr/freeldr/include/arch/pc/pcbios.h
@@ -19,6 +19,11 @@ typedef struct
     ULONG        Reserved;
 } BIOS_MEMORY_MAP, *PBIOS_MEMORY_MAP;
 
+/* Int 15h AX=E820h Entry minimal size. */
+C_ASSERT(FIELD_OFFSET(BIOS_MEMORY_MAP, Reserved) == 20);
+/* Int 15h AX=E820h Entry maximal size. */
+C_ASSERT(sizeof(BIOS_MEMORY_MAP) == 24);
+
 /* FIXME: Should be moved to NDK, and respective ACPI header files */
 typedef struct _ACPI_BIOS_DATA
 {


### PR DESCRIPTION
PcMemGetBiosMemoryMap(): Add checks for entry sizes and bare handling of error case.

CORE-13332
