### PR TITLE
[USERINIT] [SYSSETUP] "sLanguage" relates to LOCALE_SABBREVLANGNAME a…

### DIFF
--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -465,7 +465,7 @@ InitializeDefaultUserLocale(
 
         /* Misc */
         {LOCALE_SCOUNTRY, L"sCountry"},
-        {LOCALE_SLANGUAGE, L"sLanguage"},
+        {LOCALE_SABBREVLANGNAME, L"sLanguage"},
         {LOCALE_ICOUNTRY, L"iCountry"},
         {0, NULL}};
 

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -1113,7 +1113,7 @@ InitializeDefaultUserLocale(VOID)
 
         /* Misc */
         {LOCALE_SCOUNTRY, L"sCountry"},
-        {LOCALE_SLANGUAGE, L"sLanguage"},
+        {LOCALE_SABBREVLANGNAME, L"sLanguage"},
         {LOCALE_ICOUNTRY, L"iCountry"},
         {0, NULL}};
 


### PR DESCRIPTION
…ctually, not LOCALE_SLANGUAGE.
CORE-13128