### PR TITLE
CORE-13048. [I8042PRT] keyboard.c: Restore 1 "Irql =" (which was lost in r30000).

### DIFF
--- a/drivers/input/i8042prt/keyboard.c
+++ b/drivers/input/i8042prt/keyboard.c
@@ -369,7 +369,7 @@ i8042KbdDpcRoutine(
 		DeviceExtension->KeyboardBuffer + KeysInBufferCopy,
 		&KeysTransferred);
 
-	KeAcquireInterruptSpinLock(PortDeviceExtension->HighestDIRQLInterrupt);
+	Irql = KeAcquireInterruptSpinLock(PortDeviceExtension->HighestDIRQLInterrupt);
 	DeviceExtension->KeysInBuffer -= KeysTransferred;
 	KeReleaseInterruptSpinLock(PortDeviceExtension->HighestDIRQLInterrupt, Irql);
 }

--- a/drivers/input/i8042prt/keyboard.c
+++ b/drivers/input/i8042prt/keyboard.c
@@ -344,10 +344,8 @@ i8042KbdDpcRoutine(
 	}
 
 	i8042PacketDpc(PortDeviceExtension);
-
 	if (!DeviceExtension->KeyComplete)
 		return;
-
 	/* We got the interrupt as it was being enabled, too bad */
 	if (!PortDeviceExtension->HighestDIRQLInterrupt)
 		return;
@@ -365,7 +363,6 @@ i8042KbdDpcRoutine(
 		return;
 
 	INFO_(I8042PRT, "Sending %lu key(s)\n", KeysInBufferCopy);
-
 	(*(PSERVICE_CALLBACK_ROUTINE)DeviceExtension->KeyboardData.ClassService)(
 		DeviceExtension->KeyboardData.ClassDeviceObject,
 		DeviceExtension->KeyboardBuffer,
@@ -376,9 +373,7 @@ i8042KbdDpcRoutine(
 	ASSERT(KeGetCurrentIrql() == Irql);
 
 	Irql = KeAcquireInterruptSpinLock(PortDeviceExtension->HighestDIRQLInterrupt);
-
 	DeviceExtension->KeysInBuffer -= KeysTransferred;
-
 	KeReleaseInterruptSpinLock(PortDeviceExtension->HighestDIRQLInterrupt, Irql);
 }
 


### PR DESCRIPTION
[CORE-13048](https://jira.reactos.org/browse/CORE-13048)
- keyboard.c: Restore 1 "Irql =" (which was lost in r30000).
