### PR TITLE
CID 1206831 Dereference after null check

### DIFF
--- a/sdk/lib/rtl/memstream.c
+++ b/sdk/lib/rtl/memstream.c
@@ -185,7 +185,8 @@ RtlReadMemoryStream(
 
     Stream->Current = (PUCHAR)Stream->Current + CopyLength;
 
-    *BytesRead = CopyLength;
+    if (BytesRead)
+        *BytesRead = CopyLength;
 
     return S_OK;
 }


### PR DESCRIPTION
BytesRead is an optional out parameter and must be checked before being written to.
