### PR TITLE
Disable gcc threadsafe static init code.

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -72,7 +72,7 @@ if(DBG)
     add_compile_flags_language("-Wdeclaration-after-statement" "C")
 endif()
 
-add_compile_flags_language("-fno-rtti -fno-exceptions" "CXX")
+add_compile_flags_language("-fno-rtti -fno-exceptions -fno-threadsafe-statics" "CXX")
 
 #bug
 #file(TO_NATIVE_PATH ${REACTOS_SOURCE_DIR} REACTOS_SOURCE_DIR_NATIVE)


### PR DESCRIPTION
## Purpose

This disables gcc code that will guard the creation of statics with locks.
Our MSVC build does not do this either.

Binaries to check:

 - [x] base\applications\fltmc\fltmc.exe
 - [ ] base\applications\msconfig_new\msconfig_new.exe
 - [ ] base\applications\mspaint\mspaint.exe
 - [ ] base\applications\network\telnet\telnet.exe
 - [ ] base\applications\rapps\rapps.exe
 - [ ] base\shell\explorer\explorer.exe
 - [ ] base\shell\filebrowser\browseui.dll
 - [ ] bootcd\reactos\reactos\acppage.dll
 - [ ] bootcd\reactos\reactos\atl_apitest.exe
 - [ ] bootcd\reactos\reactos\browseui.dll
 - [ ] bootcd\reactos\reactos\devmgr.dll
 - [ ] bootcd\reactos\reactos\explorer.exe
 - [ ] bootcd\reactos\reactos\explorer_old.exe
 - [ ] bootcd\reactos\reactos\fltmc.exe
 - [ ] bootcd\reactos\reactos\fontsub.exe
 - [ ] bootcd\reactos\reactos\frag.exe
 - [ ] bootcd\reactos\reactos\msconfig_new.exe
 - [ ] bootcd\reactos\reactos\mspaint.exe
 - [ ] bootcd\reactos\reactos\netreg.exe
 - [ ] bootcd\reactos\reactos\rapps.exe
 - [ ] bootcd\reactos\reactos\rosautotest.exe
 - [ ] bootcd\reactos\reactos\roshttpd.exe
 - [ ] bootcd\reactos\reactos\shellbtrfs.dll
 - [ ] bootcd\reactos\reactos\stobject.dll
 - [ ] bootcd\reactos\reactos\telnet.exe
 - [ ] bootcd\reactos\reactos\unfrag.exe
 - [ ] dll\shellext\acppage\acppage.dll
 - [ ] dll\shellext\shellbtrfs\shellbtrfs.dll
 - [ ] dll\shellext\stobject\stobject.dll
 - [ ] dll\win32\browseui\browseui.dll
 - [ ] dll\win32\devmgr\devmgr.dll
 - [ ] dll\win32\shell32\shell32.dll
 - [ ] host-tools\utf16le.exe
 - [ ] host-tools\xml2sdb.exe
 - [ ] host-tools\sdk\tools\hhpcomp\hhpcomp.exe
 - [ ] modules\rosapps\applications\explorer-old\explorer_old.exe
 - [ ] modules\rosapps\applications\fraginator\frag.exe
 - [ ] modules\rosapps\applications\fraginator\unfrag.exe
 - [ ] modules\rosapps\applications\net\netreg\netreg.exe
 - [ ] modules\rosapps\applications\net\roshttpd\roshttpd.exe
 - [ ] modules\rosapps\applications\sysutils\fontsub\fontsub.exe
 - [ ] modules\rostests\apitests\atl\atl_apitest.exe
 - [ ] modules\rostests\apitests\browseui\browseui_apitest.exe
 - [ ] modules\rostests\rosautotest\rosautotest.exe