### PR TITLE
[REACTOS] Fix x64 build

### DIFF
--- a/drivers/crypto/ksecdd/random.c
+++ b/drivers/crypto/ksecdd/random.c
@@ -96,7 +96,7 @@ KsecGatherEntropyData(
     PTEB Teb;
     PPEB Peb;
     PWSTR String;
-    SIZE_T ReturnLength;
+    ULONG ReturnLength;
     NTSTATUS Status;
 
     /* Query some generic values */

--- a/drivers/filesystems/btrfs/create.c
+++ b/drivers/filesystems/btrfs/create.c
@@ -2266,6 +2266,18 @@ static NTSTATUS create_stream(_Requires_lock_held_(_Curr_->tree_lock) _Requires_
 
 // LXSS programs can be distinguished by the fact they have a NULL PEB.
 #ifdef _AMD64_
+#ifdef __REACTOS__
+NTSYSAPI
+NTSTATUS
+NTAPI
+ZwQueryInformationProcess (
+    _In_ HANDLE ProcessHandle,
+    _In_ PROCESSINFOCLASS ProcessInformationClass,
+    _Out_ PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength,
+    _Out_opt_ PULONG ReturnLength
+);
+#endif
 static __inline BOOL called_from_lxss() {
     NTSTATUS Status;
     PROCESS_BASIC_INFORMATION pbi;

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -407,7 +407,9 @@ set(PSEH_LIB "pseh")
 # Use a full path for the x86 version of ml when using x64 VS.
 # It's not a problem when using the DDK/WDK because, in x64 mode,
 # both the x86 and x64 versions of ml are available.
-if((ARCH STREQUAL "amd64") AND (DEFINED ENV{VCINSTALLDIR}))
+if((ARCH STREQUAL "amd64") AND (DEFINED ENV{VCToolsInstallDir}))
+    set(CMAKE_ASM16_COMPILER $ENV{VCToolsInstallDir}/bin/HostX86/x86/ml.exe)
+elseif((ARCH STREQUAL "amd64") AND (DEFINED ENV{VCINSTALLDIR}))
     set(CMAKE_ASM16_COMPILER $ENV{VCINSTALLDIR}/bin/ml.exe)
 elseif(ARCH STREQUAL "arm")
     set(CMAKE_ASM16_COMPILER armasm.exe)

--- a/sdk/include/psdk/basetsd.h
+++ b/sdk/include/psdk/basetsd.h
@@ -68,6 +68,7 @@ typedef unsigned __int64 HANDLE_PTR;
 typedef unsigned int UHALF_PTR, *PUHALF_PTR;
 typedef int HALF_PTR, *PHALF_PTR;
 #define ADDRESS_TAG_BIT 0x40000000000UI64
+#define Handle32ToHandle( h ) ((HANDLE)(LONG_PTR)(LONG)(h))
 #else /*  !_WIN64 */
 #define __int3264   __int32
 #define ADDRESS_TAG_BIT 0x80000000UL


### PR DESCRIPTION
- SIZE_T -> ULONG in KsecGatherEntropyData
- Add missing ZwQueryInformationProcess() prototype for x64 build of btrfs
- Fix ml.exe path for VS 2017 Community Edition
- Add missing Handle32ToHandle to basetsd.h
