### PR TITLE
[STORPORT] Fix x64 build

### DIFF
--- a/drivers/storage/port/storport/misc.c
+++ b/drivers/storage/port/storport/misc.c
@@ -321,4 +321,17 @@ AllocateAddressMapping(
     return STATUS_SUCCESS;
 }
 
+#if defined(_M_AMD64)
+/* KeQuerySystemTime is an inline function, 
+   so we cannot forward the export to ntoskrnl */
+STORPORT_API
+VOID
+NTAPI
+StorPortQuerySystemTime(
+    _Out_ PLARGE_INTEGER CurrentTime)
+{
+    KeQuerySystemTime(CurrentTime);
+}
+#endif /* defined(_M_AMD64) */
+
 /* EOF */

--- a/drivers/storage/port/storport/storport.spec
+++ b/drivers/storage/port/storport/storport.spec
@@ -24,7 +24,8 @@
 @ stdcall StorPortLogError(ptr ptr long long long long long)
 @ stdcall StorPortMoveMemory(ptr ptr long)
 @ cdecl StorPortNotification()
-@ stdcall StorPortQuerySystemTime(ptr) NTOSKRNL.KeQuerySystemTime
+@ stdcall -arch=i386 StorPortQuerySystemTime(ptr) NTOSKRNL.KeQuerySystemTime
+@ stdcall -arch=amd64 StorPortQuerySystemTime(ptr)
 @ stdcall StorPortPause(ptr long)
 @ stdcall StorPortPauseDevice(ptr long long long long)
 @ stdcall StorPortReadPortBufferUchar(ptr ptr ptr long)


### PR DESCRIPTION
On x64 StoportQuerySystemTime cannot be forwarded to ntoskrnl, since it is an inline only function. So implement a wrapper for it.