### PR TITLE
Add -VS_VER flag as a workaround for our CMake in RosBE.

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -109,6 +109,11 @@ REM Parse command line parameters
             set CMAKE_GENERATOR="NMake Makefiles"
         ) else if /I "%1" == "VSSolution" (
             set VS_SOLUTION=1
+            REM explicitly set VS version for project generator
+            if /I "%2" == "-VS_VER" (
+                set VS_VERSION=%3
+                echo Visual Studio Environment set to !BUILD_ENVIRONMENT!!VS_VERSION!-!ARCH!
+            )
             if "!VS_VERSION!" == "9" (
                 if "!ARCH!" == "amd64" (
                     set CMAKE_GENERATOR="Visual Studio 9 2008 Win64"


### PR DESCRIPTION
## Purpose
A workaround for [ROSBE-121](https://jira.reactos.org/browse/ROSBE-121).

## Proposed changes
Add a flag to explicitly specify wanted version. Say, you want to create vssolutions for VS2017 using RosBE CMake. You can only create VS 2015 files, so you specify that using a flag with an argument:
```
configure vssolution -VS_VER 14 
```
