### PR TITLE
[WIN32SS] Exclusively lock NtUser in Eng*Wnd functions

### DIFF
--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -201,4 +201,11 @@ PDEVOBJ_pdmMatchDevMode(
     PPDEVOBJ ppdev,
     PDEVMODEW pdm);
 
+FORCEINLINE
+VOID
+PDEVOBJ_vReference(PPDEVOBJ ppdev)
+{
+    InterlockedIncrement(&ppdev->cPdevRefs);
+}
+
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/surface.h
+++ b/win32ss/gdi/eng/surface.h
@@ -90,6 +90,13 @@ enum _SURFACEFLAGS
 /* NOTE: Use shared locks! */
 #define  SURFACE_ShareLockSurface(hBMObj) \
   ((PSURFACE) GDIOBJ_ShareLockObj ((HGDIOBJ) hBMObj, GDI_OBJECT_TYPE_BITMAP))
+FORCEINLINE
+VOID
+SURFACE_ShareLockByPointer(PSURFACE psurf)
+{
+    GDIOBJ_vReferenceObjectByPointer(&psurf->BaseObject);
+}
+
 #define  SURFACE_UnlockSurface(pBMObj)  \
   GDIOBJ_vUnlockObject ((POBJ)pBMObj)
 #define  SURFACE_ShareUnlockSurface(pBMObj)  \


### PR DESCRIPTION
## Purpose
Exclusively lock The NtUser implementation in EngCreateWnd and EngDeleteWnd, as needed by underlying internal functions.
For this, one needs to ensure that the Escape routine is called without any lock held.

JIRA issue: [CORE-7727](https://jira.reactos.org/browse/CORE-7727)

See https://msdn.microsoft.com/en-us/library/windows/hardware/ff564769(v=vs.85).aspx for a bit of documentation.

Also, managed to break my commit history, so meh...
