### PR TITLE
CORE-13910. Update NtReadFile()/NtWriteFile() calls wrt ByteOffset param use

### DIFF
--- a/ntoskrnl/config/cmwraprs.c
+++ b/ntoskrnl/config/cmwraprs.c
@@ -83,8 +83,8 @@ CmpFileRead(IN PHHIVE RegistryHive,
     NTSTATUS Status;
 
     _FileOffset.QuadPart = *FileOffset;
-    Status = ZwReadFile(HiveHandle, 0, 0, 0, &IoStatusBlock,
-                       Buffer, (ULONG)BufferLength, &_FileOffset, 0);
+    Status = ZwReadFile(HiveHandle, NULL, NULL, NULL, &IoStatusBlock,
+                        Buffer, (ULONG)BufferLength, &_FileOffset, NULL);
     return NT_SUCCESS(Status) ? TRUE : FALSE;
 }
 

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -3622,7 +3622,7 @@ KdbpCliInit(VOID)
     }
 
     /* Load file into memory */
-    Status = ZwReadFile(hFile, 0, 0, 0, &Iosb, FileBuffer, FileSize, 0, 0);
+    Status = ZwReadFile(hFile, NULL, NULL, NULL, &Iosb, FileBuffer, FileSize, NULL, NULL);
     ZwClose(hFile);
 
     if (!NT_SUCCESS(Status) && Status != STATUS_END_OF_FILE)

--- a/sdk/lib/rossym/zwfile.c
+++ b/sdk/lib/rossym/zwfile.c
@@ -19,11 +19,11 @@ RosSymZwReadFile(PVOID FileContext, PVOID Buffer, ULONG Size)
   IO_STATUS_BLOCK IoStatusBlock;
 
   Status = ZwReadFile(*((HANDLE *) FileContext),
-                      0, 0, 0,
+                      NULL, NULL, NULL,
                       &IoStatusBlock,
                       Buffer,
                       Size,
-                      0, 0);
+                      NULL, NULL);
 
   return NT_SUCCESS(Status) && IoStatusBlock.Information == Size;
 }

--- a/sdk/lib/rossym_new/zwfile.c
+++ b/sdk/lib/rossym_new/zwfile.c
@@ -18,11 +18,11 @@ RosSymZwReadFile(PVOID FileContext, PVOID Buffer, ULONG Size)
   IO_STATUS_BLOCK IoStatusBlock;
 
   RosSymStatus = ZwReadFile(*((HANDLE *) FileContext),
-                      0, 0, 0,
+                      NULL, NULL, NULL,
                       &IoStatusBlock,
                       Buffer,
                       Size,
-                      0, 0);
+                      NULL, NULL);
 
   return NT_SUCCESS(RosSymStatus) && IoStatusBlock.Information == Size;
 }


### PR DESCRIPTION
## Purpose

Update NtReadFile()/NtWriteFile() calls wrt ByteOffset param use.

JIRA issue: [CORE-13910](https://jira.reactos.org/browse/CORE-13910)

## Proposed changes
- ZwReadFile() calls: Use explicit NULL instead of ambiguous 0, Set and use ByteOffset.

## TODO
- After review, I'll check/add the 3 other greps too.
