### PR TITLE
CORE-13910. Update ZwWriteFile() calls wrt ByteOffset param use.

### DIFF
--- a/drivers/filters/mountmgr/database.c
+++ b/drivers/filters/mountmgr/database.c
@@ -70,7 +70,7 @@ AddRemoteDatabaseEntry(IN HANDLE Database,
     /* Get size to append data */
     Size.QuadPart = GetRemoteDatabaseSize(Database);
 
-    return ZwWriteFile(Database, 0, NULL, NULL,
+    return ZwWriteFile(Database, NULL, NULL, NULL,
                        &IoStatusBlock, Entry,
                        Entry->EntrySize, &Size, NULL);
 }

--- a/ntoskrnl/config/cmwraprs.c
+++ b/ntoskrnl/config/cmwraprs.c
@@ -103,8 +103,8 @@ CmpFileWrite(IN PHHIVE RegistryHive,
     NTSTATUS Status;
 
     _FileOffset.QuadPart = *FileOffset;
-    Status = ZwWriteFile(HiveHandle, 0, 0, 0, &IoStatusBlock,
-                       Buffer, (ULONG)BufferLength, &_FileOffset, 0);
+    Status = ZwWriteFile(HiveHandle, NULL, NULL, NULL, &IoStatusBlock,
+                         Buffer, (ULONG)BufferLength, &_FileOffset, NULL);
     return NT_SUCCESS(Status) ? TRUE : FALSE;
 }
 


### PR DESCRIPTION
## Purpose

Update NtReadFile()/NtWriteFile() calls wrt ByteOffset param use.
(This is part 2/4.)

JIRA issue: [CORE-13910](https://jira.reactos.org/browse/CORE-13910)

## Proposed changes
- ZwWriteFile() calls: Use explicit NULL instead of ambiguous 0.
