### PR TITLE
CORE-13910. Update NtReadFile() calls wrt ByteOffset param use.

### DIFF
--- a/base/setup/usetup/bootsup.c
+++ b/base/setup/usetup/bootsup.c
@@ -1001,7 +1001,6 @@ InstallFat32BootCodeToFile(
         return Status;
     }
 
-    FileOffset.QuadPart = 0ULL;
     Status = NtReadFile(FileHandle,
                         NULL,
                         NULL,

--- a/base/setup/usetup/native/utils/console.c
+++ b/base/setup/usetup/native/utils/console.c
@@ -170,7 +170,7 @@ FlushConsoleInputBuffer(
                             &InputData,
                             sizeof(KEYBOARD_INPUT_DATA),
                             &Offset,
-                            0);
+                            NULL);
         if (Status == STATUS_PENDING)
         {
             Timeout.QuadPart = -100;
@@ -208,7 +208,7 @@ ReadConsoleInput(
                         &InputData,
                         sizeof(KEYBOARD_INPUT_DATA),
                         &Offset,
-                        0);
+                        NULL);
     if (Status == STATUS_PENDING)
     {
         Status = NtWaitForSingleObject(hConsoleInput, FALSE, NULL);

--- a/modules/rosapps/applications/sysutils/utils/pice/module/utils.c
+++ b/modules/rosapps/applications/sysutils/utils/pice/module/utils.c
@@ -2233,9 +2233,9 @@ long PICE_read(HANDLE hFile, LPVOID lpBuffer, long lBytes)
 	ASSERT( lpBuffer );
 
 	if (!NT_SUCCESS(NtReadFile(
-		(HANDLE) hFile,
+		hFile,
 		NULL, NULL, NULL, &iosb,
-		(LPVOID) lpBuffer,
+		lpBuffer,
 		(DWORD) lBytes,
 		NULL,
 		NULL

--- a/sdk/lib/fslib/ext2lib/Disk.c
+++ b/sdk/lib/fslib/ext2lib/Disk.c
@@ -982,7 +982,7 @@ Ext2ReadDisk( PEXT2_FILESYS  Ext2Sys,
         Address.QuadPart = Offset;
 
         Status = NtReadFile(  Ext2Sys->MediaHandle,
-                              0,
+                              NULL,
                               NULL,
                               NULL,
                               &IoStatus,
@@ -1009,7 +1009,7 @@ Ext2ReadDisk( PEXT2_FILESYS  Ext2Sys,
         }
 
         Status = NtReadFile( Ext2Sys->MediaHandle,
-                             0,
+                             NULL,
                              NULL,
                              NULL,
                              &IoStatus,
@@ -1106,7 +1106,7 @@ Ext2WriteDisk( PEXT2_FILESYS  Ext2Sys,
         if ((AlignedLength != Length) || (Address.QuadPart != (LONGLONG)Offset))
         {
             Status = NtReadFile( Ext2Sys->MediaHandle,
-                                 0,
+                                 NULL,
                                  NULL,
                                  NULL,
                                  &IoStatus,


### PR DESCRIPTION
## Purpose

Update NtReadFile()/NtWriteFile() calls wrt ByteOffset param use.
(This is part 3/4.)

JIRA issue: [CORE-13910](https://jira.reactos.org/browse/CORE-13910)

## Proposed changes
- NtReadFile() calls: Remove unused 'ByteOffset = 0', Use explicit NULL instead of ambiguous 0, Remove casts to same type.
