### PR TITLE
[MSPAINT] Base dialog implementations on CDialogImpl

### DIFF
--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -10,257 +10,251 @@
 
 #include "precomp.h"
 
+#include "dialogs.h"
+
 #include <winnls.h>
+
+/* GLOBALS **********************************************************/
+
+CMirrorRotateDialog mirrorRotateDialog;
+CAttributesDialog attributesDialog;
+CStretchSkewDialog stretchSkewDialog;
 
 /* FUNCTIONS ********************************************************/
 
-INT_PTR CALLBACK
-MRDlgWinProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CMirrorRotateDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    switch (message)
+    CheckDlgButton(IDD_MIRRORROTATERB1, BST_CHECKED);
+    CheckDlgButton(IDD_MIRRORROTATERB4, BST_CHECKED);
+    return 0;
+}
+
+LRESULT CMirrorRotateDialog::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    EndDialog(0);
+    return 0;
+}
+
+LRESULT CMirrorRotateDialog::OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    if (IsDlgButtonChecked(IDD_MIRRORROTATERB1))
+        EndDialog(1);
+    else if (IsDlgButtonChecked(IDD_MIRRORROTATERB2))
+        EndDialog(2);
+    else if (IsDlgButtonChecked(IDD_MIRRORROTATERB4))
+        EndDialog(3);
+    else if (IsDlgButtonChecked(IDD_MIRRORROTATERB5))
+        EndDialog(4);
+    else if (IsDlgButtonChecked(IDD_MIRRORROTATERB6))
+        EndDialog(5);
+    return 0;
+}
+
+LRESULT CMirrorRotateDialog::OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    EndDialog(0);
+    return 0;
+}
+
+LRESULT CMirrorRotateDialog::OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB4), TRUE);
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB5), TRUE);
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB6), TRUE);
+    return 0;
+}
+
+LRESULT CMirrorRotateDialog::OnRadioButton12(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB4), FALSE);
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB5), FALSE);
+    ::EnableWindow(GetDlgItem(IDD_MIRRORROTATERB6), FALSE);
+    return 0;
+}
+
+
+
+LRESULT CAttributesDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    newWidth = imageModel.GetWidth();
+    newHeight = imageModel.GetHeight();
+
+    CheckDlgButton(IDD_ATTRIBUTESRB3, BST_CHECKED);
+    CheckDlgButton(IDD_ATTRIBUTESRB5, BST_CHECKED);
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT1, newWidth, FALSE);
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT2, newHeight, FALSE);
+
+    if (isAFile)
     {
-        case WM_INITDIALOG:
-            CheckDlgButton(hwnd, IDD_MIRRORROTATERB1, BST_CHECKED);
-            CheckDlgButton(hwnd, IDD_MIRRORROTATERB4, BST_CHECKED);
-            return TRUE;
-        case WM_CLOSE:
-            EndDialog(hwnd, 0);
-            break;
-        case WM_COMMAND:
-            switch (LOWORD(wParam))
-            {
-                case IDOK:
-                    if (IsDlgButtonChecked(hwnd, IDD_MIRRORROTATERB1))
-                        EndDialog(hwnd, 1);
-                    else if (IsDlgButtonChecked(hwnd, IDD_MIRRORROTATERB2))
-                        EndDialog(hwnd, 2);
-                    else if (IsDlgButtonChecked(hwnd, IDD_MIRRORROTATERB4))
-                        EndDialog(hwnd, 3);
-                    else if (IsDlgButtonChecked(hwnd, IDD_MIRRORROTATERB5))
-                        EndDialog(hwnd, 4);
-                    else if (IsDlgButtonChecked(hwnd, IDD_MIRRORROTATERB6))
-                        EndDialog(hwnd, 5);
-                    break;
-                case IDCANCEL:
-                    EndDialog(hwnd, 0);
-                    break;
-                case IDD_MIRRORROTATERB3:
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB4), TRUE);
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB5), TRUE);
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB6), TRUE);
-                    break;
-                case IDD_MIRRORROTATERB1:
-                case IDD_MIRRORROTATERB2:
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB4), FALSE);
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB5), FALSE);
-                    EnableWindow(GetDlgItem(hwnd, IDD_MIRRORROTATERB6), FALSE);
-                    break;
-            }
-            break;
-        default:
-            return FALSE;
+        TCHAR date[100];
+        TCHAR temp[100];
+        GetDateFormat(LOCALE_USER_DEFAULT, 0, &fileTime, NULL, date, SIZEOF(date));
+        GetTimeFormat(LOCALE_USER_DEFAULT, 0, &fileTime, NULL, temp, SIZEOF(temp));
+        _tcscat(date, _T(" "));
+        _tcscat(date, temp);
+        CString strSize;
+        strSize.Format(IDS_FILESIZE, fileSize);
+        SetDlgItemText(IDD_ATTRIBUTESTEXT6, date);
+        SetDlgItemText(IDD_ATTRIBUTESTEXT7, strSize);
     }
-    return TRUE;
+    CString strRes;
+    strRes.Format(IDS_PRINTRES, fileHPPM, fileVPPM);
+    SetDlgItemText(IDD_ATTRIBUTESTEXT8, strRes);
+    return 0;
 }
 
-int
-mirrorRotateDlg()
+LRESULT CAttributesDialog::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    return DialogBox(hProgInstance, MAKEINTRESOURCE(IDD_MIRRORROTATE), mainWindow.m_hWnd, MRDlgWinProc);
+    EndDialog(0);
+    return 0;
 }
 
-INT_PTR CALLBACK
-ATTDlgWinProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
+LRESULT CAttributesDialog::OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    switch (message)
+    EndDialog(1);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    EndDialog(0);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnDefault(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    newWidth = imageModel.GetWidth();
+    newHeight = imageModel.GetHeight();
+    CheckDlgButton(IDD_ATTRIBUTESRB3, BST_CHECKED);
+    CheckDlgButton(IDD_ATTRIBUTESRB5, BST_CHECKED);
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT1, newWidth, FALSE);
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT2, newHeight, FALSE);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    CString strNum;
+    strNum.Format(_T("%.3lf"), newWidth / (0.0254 * fileHPPM));
+    SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
+    strNum.Format(_T("%.3lf"), newHeight / (0.0254 * fileVPPM));
+    SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnRadioButton2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    CString strNum;
+    strNum.Format(_T("%.3lf"), newWidth * 100.0 / fileHPPM);
+    SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
+    strNum.Format(_T("%.3lf"), newHeight * 100.0 / fileVPPM);
+    SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT1, newWidth, FALSE);
+    SetDlgItemInt(IDD_ATTRIBUTESEDIT2, newHeight, FALSE);
+    return 0;
+}
+
+LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    if (Edit_GetModify(hWndCtl))
     {
-        case WM_INITDIALOG:
+        TCHAR tempS[100];
+        if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
-            widthSetInDlg = imageModel.GetWidth();
-            heightSetInDlg = imageModel.GetHeight();
-
-            CheckDlgButton(hwnd, IDD_ATTRIBUTESRB3, BST_CHECKED);
-            CheckDlgButton(hwnd, IDD_ATTRIBUTESRB5, BST_CHECKED);
-            SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT1, widthSetInDlg, FALSE);
-            SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT2, heightSetInDlg, FALSE);
-
-            if (isAFile)
-            {
-                TCHAR date[100];
-                TCHAR temp[100];
-                GetDateFormat(LOCALE_USER_DEFAULT, 0, &fileTime, NULL, date, SIZEOF(date));
-                GetTimeFormat(LOCALE_USER_DEFAULT, 0, &fileTime, NULL, temp, SIZEOF(temp));
-                _tcscat(date, _T(" "));
-                _tcscat(date, temp);
-                CString strSize;
-                strSize.Format(IDS_FILESIZE, fileSize);
-                SetDlgItemText(hwnd, IDD_ATTRIBUTESTEXT6, date);
-                SetDlgItemText(hwnd, IDD_ATTRIBUTESTEXT7, strSize);
-            }
-            CString strRes;
-            strRes.Format(IDS_PRINTRES, fileHPPM, fileVPPM);
-            SetDlgItemText(hwnd, IDD_ATTRIBUTESTEXT8, strRes);
-            return TRUE;
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
+            newWidth = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM * 0.0254));
         }
-        case WM_CLOSE:
-            EndDialog(hwnd, 0);
-            break;
-        case WM_COMMAND:
-            switch (LOWORD(wParam))
-            {
-                case IDOK:
-                    EndDialog(hwnd, 1);
-                    break;
-                case IDCANCEL:
-                    EndDialog(hwnd, 0);
-                    break;
-                case IDD_ATTRIBUTESSTANDARD:
-                    widthSetInDlg = imageModel.GetWidth();
-                    heightSetInDlg = imageModel.GetHeight();
-                    CheckDlgButton(hwnd, IDD_ATTRIBUTESRB3, BST_CHECKED);
-                    CheckDlgButton(hwnd, IDD_ATTRIBUTESRB5, BST_CHECKED);
-                    SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT1, widthSetInDlg, FALSE);
-                    SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT2, heightSetInDlg, FALSE);
-                    break;
-                case IDD_ATTRIBUTESRB1:
-                {
-                    CString strNum;
-                    strNum.Format(_T("%.3lf"), widthSetInDlg / (0.0254 * fileHPPM));
-                    SetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT1, strNum);
-                    strNum.Format(_T("%.3lf"), heightSetInDlg / (0.0254 * fileVPPM));
-                    SetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT2, strNum);
-                    break;
-                }
-                case IDD_ATTRIBUTESRB2:
-                {
-                    CString strNum;
-                    strNum.Format(_T("%.3lf"), widthSetInDlg * 100.0 / fileHPPM);
-                    SetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT1, strNum);
-                    strNum.Format(_T("%.3lf"), heightSetInDlg * 100.0 / fileVPPM);
-                    SetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT2, strNum);
-                    break;
-                }
-                case IDD_ATTRIBUTESRB3:
-                    SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT1, widthSetInDlg, FALSE);
-                    SetDlgItemInt(hwnd, IDD_ATTRIBUTESEDIT2, heightSetInDlg, FALSE);
-                    break;
-                case IDD_ATTRIBUTESEDIT1:
-                    if (Edit_GetModify((HWND)lParam))
-                    {
-                        TCHAR tempS[100];
-                        if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB1))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
-                            widthSetInDlg = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM * 0.0254));
-                        }
-                        else if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB2))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
-                            widthSetInDlg = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM / 100));
-                        }
-                        else if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB3))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
-                            widthSetInDlg = max(1, _tstoi(tempS));
-                        }
-                        Edit_SetModify((HWND)lParam, FALSE);
-                    }
-                    break;
-                case IDD_ATTRIBUTESEDIT2:
-                    if (Edit_GetModify((HWND)lParam))
-                    {
-                        TCHAR tempS[100];
-                        if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB1))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
-                            heightSetInDlg = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM * 0.0254));
-                        }
-                        else if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB2))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
-                            heightSetInDlg = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM / 100));
-                        }
-                        else if (IsDlgButtonChecked(hwnd, IDD_ATTRIBUTESRB3))
-                        {
-                            GetDlgItemText(hwnd, IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
-                            heightSetInDlg = max(1, _tstoi(tempS));
-                        }
-                        Edit_SetModify((HWND)lParam, FALSE);
-                    }
-                    break;
-            }
-            break;
-        default:
-            return FALSE;
+        else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
+        {
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
+            newWidth = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM / 100));
+        }
+        else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
+        {
+            GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, SIZEOF(tempS));
+            newWidth = max(1, _tstoi(tempS));
+        }
+        Edit_SetModify(hWndCtl, FALSE);
     }
-    return TRUE;
+    return 0;
 }
 
-int
-attributesDlg()
+LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    return DialogBox(hProgInstance, MAKEINTRESOURCE(IDD_ATTRIBUTES), mainWindow.m_hWnd, ATTDlgWinProc);
-}
-
-INT_PTR CALLBACK
-CHSIZEDlgWinProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam)
-{
-    switch (message)
+    if (Edit_GetModify(hWndCtl))
     {
-        case WM_INITDIALOG:
-            SetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITHSTRETCH, 100, FALSE);
-            SetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITVSTRETCH, 100, FALSE);
-            SetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITHSKEW, 0, FALSE);
-            SetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITVSKEW, 0, FALSE);
-            return TRUE;
-        case WM_CLOSE:
-            EndDialog(hwnd, 0);
-            break;
-        case WM_COMMAND:
-            switch (LOWORD(wParam))
-            {
-                case IDOK:
-                {
-                    TCHAR strrcIntNumbers[100];
-                    TCHAR strrcPercentage[100];
-                    TCHAR strrcAngle[100];
-                    BOOL tr1, tr2, tr3, tr4;
-
-                    LoadString(hProgInstance, IDS_INTNUMBERS, strrcIntNumbers, SIZEOF(strrcIntNumbers));
-                    LoadString(hProgInstance, IDS_PERCENTAGE, strrcPercentage, SIZEOF(strrcPercentage));
-                    LoadString(hProgInstance, IDS_ANGLE, strrcAngle, SIZEOF(strrcAngle));
-
-                    stretchSkew.percentage.x = GetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITHSTRETCH, &tr1, FALSE);
-                    stretchSkew.percentage.y = GetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITVSTRETCH, &tr2, FALSE);
-                    stretchSkew.angle.x = GetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITHSKEW, &tr3, TRUE);
-                    stretchSkew.angle.y = GetDlgItemInt(hwnd, IDD_STRETCHSKEWEDITVSKEW, &tr4, TRUE);
-
-                    if (!(tr1 && tr2 && tr3 && tr4))
-                        MessageBox(hwnd, strrcIntNumbers, NULL, MB_ICONEXCLAMATION);
-                    else if (stretchSkew.percentage.x < 1 || stretchSkew.percentage.x > 500
-                        || stretchSkew.percentage.y < 1 || stretchSkew.percentage.y > 500)
-                        MessageBox(hwnd, strrcPercentage, NULL, MB_ICONEXCLAMATION);
-                    else if (stretchSkew.angle.x < -89 || stretchSkew.angle.x > 89
-                        || stretchSkew.angle.y < -89 || stretchSkew.angle.y > 89)
-                        MessageBox(hwnd, strrcAngle, NULL, MB_ICONEXCLAMATION);
-                    else
-                        EndDialog(hwnd, 1);
-
-                    break;
-                }
-                case IDCANCEL:
-                    EndDialog(hwnd, 0);
-                    break;
-            }
-            break;
-        default:
-            return FALSE;
+        TCHAR tempS[100];
+        if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
+        {
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
+            newHeight = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM * 0.0254));
+        }
+        else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
+        {
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
+            newHeight = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM / 100));
+        }
+        else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
+        {
+            GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, SIZEOF(tempS));
+            newHeight = max(1, _tstoi(tempS));
+        }
+        Edit_SetModify(hWndCtl, FALSE);
     }
-    return TRUE;
+    return 0;
 }
 
-int
-changeSizeDlg()
+
+
+LRESULT CStretchSkewDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    return DialogBox(hProgInstance, MAKEINTRESOURCE(IDD_STRETCHSKEW), mainWindow.m_hWnd, CHSIZEDlgWinProc);
+    SetDlgItemInt(IDD_STRETCHSKEWEDITHSTRETCH, 100, FALSE);
+    SetDlgItemInt(IDD_STRETCHSKEWEDITVSTRETCH, 100, FALSE);
+    SetDlgItemInt(IDD_STRETCHSKEWEDITHSKEW, 0, FALSE);
+    SetDlgItemInt(IDD_STRETCHSKEWEDITVSKEW, 0, FALSE);
+    return 0;
+}
+
+LRESULT CStretchSkewDialog::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    EndDialog(0);
+    return 0;
+}
+
+LRESULT CStretchSkewDialog::OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    CString strrcIntNumbers;
+    CString strrcPercentage;
+    CString strrcAngle;
+    BOOL tr1, tr2, tr3, tr4;
+
+    strrcIntNumbers.LoadString(hProgInstance, IDS_INTNUMBERS);
+    strrcPercentage.LoadString(hProgInstance, IDS_PERCENTAGE);
+    strrcAngle.LoadString(hProgInstance, IDS_ANGLE);
+
+    percentage.x = GetDlgItemInt(IDD_STRETCHSKEWEDITHSTRETCH, &tr1, FALSE);
+    percentage.y = GetDlgItemInt(IDD_STRETCHSKEWEDITVSTRETCH, &tr2, FALSE);
+    angle.x = GetDlgItemInt(IDD_STRETCHSKEWEDITHSKEW, &tr3, TRUE);
+    angle.y = GetDlgItemInt(IDD_STRETCHSKEWEDITVSKEW, &tr4, TRUE);
+
+    if (!(tr1 && tr2 && tr3 && tr4))
+        MessageBox(strrcIntNumbers, NULL, MB_ICONEXCLAMATION);
+    else if (percentage.x < 1 || percentage.x > 500 || percentage.y < 1 || percentage.y > 500)
+        MessageBox(strrcPercentage, NULL, MB_ICONEXCLAMATION);
+    else if (angle.x < -89 || angle.x > 89 || angle.y < -89 || angle.y > 89)
+        MessageBox(strrcAngle, NULL, MB_ICONEXCLAMATION);
+    else
+        EndDialog(1);
+    return 0;
+}
+
+LRESULT CStretchSkewDialog::OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
+{
+    EndDialog(0);
+    return 0;
 }

--- a/base/applications/mspaint/dialogs.h
+++ b/base/applications/mspaint/dialogs.h
@@ -6,8 +6,81 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-int mirrorRotateDlg(void);
+class CMirrorRotateDialog : public CDialogImpl<CMirrorRotateDialog>
+{
+public:
+    enum { IDD = IDD_MIRRORROTATE };
 
-int attributesDlg(void);
+    BEGIN_MSG_MAP(CMirrorRotateDialog)
+        MESSAGE_HANDLER(WM_INITDIALOG, OnInitDialog)
+        MESSAGE_HANDLER(WM_CLOSE, OnClose)
+        COMMAND_ID_HANDLER(IDOK, OnOk)
+        COMMAND_ID_HANDLER(IDCANCEL, OnCancel)
+        COMMAND_ID_HANDLER(IDD_MIRRORROTATERB3, OnRadioButton3)
+        COMMAND_ID_HANDLER(IDD_MIRRORROTATERB1, OnRadioButton12)
+        COMMAND_ID_HANDLER(IDD_MIRRORROTATERB2, OnRadioButton12)
+    END_MSG_MAP()
 
-int changeSizeDlg(void);
+    LRESULT OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnRadioButton12(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+};
+
+class CAttributesDialog : public CDialogImpl<CAttributesDialog>
+{
+public:
+    enum { IDD = IDD_ATTRIBUTES };
+
+    BEGIN_MSG_MAP(CAttributesDialog)
+        MESSAGE_HANDLER(WM_INITDIALOG, OnInitDialog)
+        MESSAGE_HANDLER(WM_CLOSE, OnClose)
+        COMMAND_ID_HANDLER(IDOK, OnOk)
+        COMMAND_ID_HANDLER(IDCANCEL, OnCancel)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESSTANDARD, OnDefault)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESRB1, OnRadioButton1)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESRB1, OnRadioButton2)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESRB1, OnRadioButton3)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESEDIT1, OnEdit1)
+        COMMAND_ID_HANDLER(IDD_ATTRIBUTESEDIT1, OnEdit2)
+    END_MSG_MAP()
+
+    LRESULT OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnDefault(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnRadioButton2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+
+public:
+    int newWidth;
+    int newHeight;
+};
+
+class CStretchSkewDialog : public CDialogImpl<CStretchSkewDialog>
+{
+public:
+    enum { IDD = IDD_STRETCHSKEW };
+
+    BEGIN_MSG_MAP(CStretchSkewDialog)
+        MESSAGE_HANDLER(WM_INITDIALOG, OnInitDialog)
+        MESSAGE_HANDLER(WM_CLOSE, OnClose)
+        COMMAND_ID_HANDLER(IDOK, OnOk)
+        COMMAND_ID_HANDLER(IDCANCEL, OnCancel)
+    END_MSG_MAP()
+
+    LRESULT OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnOk(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+    LRESULT OnCancel(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled);
+
+public:
+    POINT percentage;
+    POINT angle;
+};

--- a/base/applications/mspaint/globalvar.h
+++ b/base/applications/mspaint/globalvar.h
@@ -6,19 +6,7 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* TYPES ************************************************************/
-
-typedef struct tagSTRETCHSKEW {
-    POINT percentage;
-    POINT angle;
-} STRETCHSKEW;
-
-/* VARIABLES declared in main.c *************************************/
-
-extern int widthSetInDlg;
-extern int heightSetInDlg;
-
-extern STRETCHSKEW stretchSkew;
+/* VARIABLES declared in main.cpp ***********************************/
 
 class RegistrySettings;
 extern RegistrySettings registrySettings;
@@ -103,7 +91,17 @@ extern CSizeboxWindow sizeboxCenterBottom;
 extern CSizeboxWindow sizeboxRightBottom;
 extern CTextEditWindow textEditWindow;
 
-/* VARIABLES declared in mouse.c ************************************/
+/* VARIABLES declared in dialogs.cpp ********************************/
+
+class CMirrorRotateDialog;
+class CAttributesDialog;
+class CStretchSkewDialog;
+
+extern CMirrorRotateDialog mirrorRotateDialog;
+extern CAttributesDialog attributesDialog;
+extern CStretchSkewDialog stretchSkewDialog;
+
+/* VARIABLES declared in mouse.cpp **********************************/
 
 extern POINT pointStack[256];
 extern short pointSP;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -12,11 +12,6 @@
 
 /* FUNCTIONS ********************************************************/
 
-int widthSetInDlg;
-int heightSetInDlg;
-
-STRETCHSKEW stretchSkew;
-
 POINT start;
 POINT last;
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -605,7 +605,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             imageArea.Invalidate(FALSE);
             break;
         case IDM_IMAGEROTATEMIRROR:
-            switch (mirrorRotateDlg())
+            switch (mirrorRotateDialog.DoModal(mainWindow.m_hWnd))
             {
                 case 1: /* flip horizontally */
                     if (selectionWindow.IsWindowVisible())
@@ -633,18 +633,18 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_IMAGEATTRIBUTES:
         {
-            if (attributesDlg())
+            if (attributesDialog.DoModal(mainWindow.m_hWnd))
             {
-                imageModel.Crop(widthSetInDlg, heightSetInDlg, 0, 0);
+                imageModel.Crop(attributesDialog.newWidth, attributesDialog.newHeight, 0, 0);
             }
             break;
         }
         case IDM_IMAGESTRETCHSKEW:
         {
-            if (changeSizeDlg())
+            if (stretchSkewDialog.DoModal(mainWindow.m_hWnd))
             {
-                imageModel.StretchSkew(stretchSkew.percentage.x, stretchSkew.percentage.y,
-                                       stretchSkew.angle.x, stretchSkew.angle.y);
+                imageModel.StretchSkew(stretchSkewDialog.percentage.x, stretchSkewDialog.percentage.y,
+                                       stretchSkewDialog.angle.x, stretchSkewDialog.angle.y);
             }
             break;
         }


### PR DESCRIPTION
- Wrap implementation of Mirror/Rotate, Stretch/Skew and Attributes dialog in subclasses of CDialogImpl
- Turn global variables from code that was moved into member functions into member variables
- Add global instances of all three dialog classes
- Use _global instance_.DoModal(...) instead of one-line wrappers
- Replace some TCHAR arrays with CStrings
