### PR TITLE
[WIN32K] Check if the window being destroyed is currently tracked.

### DIFF
--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -342,6 +342,26 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
     return TRUE;
 }
 
+VOID
+FASTCALL
+IntRemoveTrackMouseEvent(
+    PDESKTOP pDesk)
+{
+    /* Generate a leave message */
+    if (pDesk->dwDTFlags & DF_TME_LEAVE)
+    {
+        UINT uMsg = (pDesk->htEx != HTCLIENT) ? WM_NCMOUSELEAVE : WM_MOUSELEAVE;
+        UserPostMessage(UserHMGetHandle(pDesk->spwndTrack), uMsg, 0, 0);
+    }
+    /* Kill the timer */
+    if (pDesk->dwDTFlags & DF_TME_HOVER)
+        IntKillTimer(pDesk->spwndTrack, ID_EVENT_SYSTIMER_MOUSEHOVER, TRUE);
+
+    /* Reset state */
+    pDesk->dwDTFlags &= ~(DF_TME_LEAVE|DF_TME_HOVER);
+    pDesk->spwndTrack = NULL;
+}
+
 BOOL
 FASTCALL
 IntQueryTrackMouseEvent(

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -381,6 +381,12 @@ DWORD FASTCALL IntGetWindowContextHelpId( PWND pWnd )
    return HelpId;
 }
 
+
+VOID
+FASTCALL
+IntRemoveTrackMouseEvent(
+    PDESKTOP pDesk);
+
 /***********************************************************************
  *           IntSendDestroyMsg
  */
@@ -426,20 +432,7 @@ static void IntSendDestroyMsg(HWND hWnd)
       /* If the window being destroyed is currently tracked... */
       if (ti->rpdesk->spwndTrack == Window)
       {
-          PDESKTOP pDesk = ti->rpdesk;
-          /* Generate a leave message */
-          if (pDesk->dwDTFlags & DF_TME_LEAVE)
-          {
-              UINT uMsg = (pDesk->htEx != HTCLIENT) ? WM_NCMOUSELEAVE : WM_MOUSELEAVE;
-              UserPostMessage(UserHMGetHandle(pDesk->spwndTrack), uMsg, 0, 0);
-          }
-          /* Kill the timer */
-          if (pDesk->dwDTFlags & DF_TME_HOVER)
-              IntKillTimer(pDesk->spwndTrack, ID_EVENT_SYSTIMER_MOUSEHOVER, TRUE);
-
-          /* Reset state */
-          pDesk->dwDTFlags &= ~(DF_TME_LEAVE|DF_TME_HOVER);
-          pDesk->spwndTrack = NULL;
+          IntRemoveTrackMouseEvent(ti->rpdesk);
       }
    }
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -422,6 +422,25 @@ static void IntSendDestroyMsg(HWND hWnd)
       {
          co_IntDestroyCaret(ti);
       }
+
+      /* If the window being destroyed is currently tracked... */
+      if (ti->rpdesk->spwndTrack == Window)
+      {
+          PDESKTOP pDesk = ti->rpdesk;
+          /* Generate a leave message */
+          if (pDesk->dwDTFlags & DF_TME_LEAVE)
+          {
+              UINT uMsg = (pDesk->htEx != HTCLIENT) ? WM_NCMOUSELEAVE : WM_MOUSELEAVE;
+              UserPostMessage(UserHMGetHandle(pDesk->spwndTrack), uMsg, 0, 0);
+          }
+          /* Kill the timer */
+          if (pDesk->dwDTFlags & DF_TME_HOVER)
+              IntKillTimer(pDesk->spwndTrack, ID_EVENT_SYSTIMER_MOUSEHOVER, TRUE);
+
+          /* Reset state */
+          pDesk->dwDTFlags &= ~(DF_TME_LEAVE|DF_TME_HOVER);
+          pDesk->spwndTrack = NULL;
+      }
    }
 
    /* If the window being destroyed is the current clipboard owner... */


### PR DESCRIPTION
This aims to fix crashes in `IntQueryTrackMouseEvent` caused by an invalid `spwndTrack`

JIRA issue: [CORE-13619](https://jira.reactos.org/browse/CORE-13619)

I am not entirely sure that setting `spwndTrack` to NULL is allowed?