### PR TITLE
[USER32] Fix unselected text after WM_CBLOSTTEXTFOCUS

### DIFF
--- a/win32ss/user/user32/controls/combo.c
+++ b/win32ss/user/user32/controls/combo.c
@@ -2261,16 +2261,14 @@ LRESULT WINAPI ComboWndProc_common( HWND hwnd, UINT message, WPARAM wParam, LPAR
         }
         break;
 
-        case WM_CBLOSTTEXTFOCUS: /* undocumented message - deselects the text when focus is lost */
+    case WM_CBLOSTTEXTFOCUS: /* undocumented message - deselects the text when focus is lost */
+        if (lphc->hWndEdit != NULL)
         {
-           if (lphc->hWndEdit != NULL)
-           {
-               SendMessage(lphc->self, WM_LBUTTONUP, 0, 0xFFFFFFFF);
-               SendMessage(lphc->hWndEdit, EM_SETSEL, 0, 0);
-               lphc->wState &= ~CBF_FOCUSED;   
-               CB_NOTIFY(lphc, CBN_KILLFOCUS);
-           } 
-        }
+            SendMessage(lphc->self, WM_LBUTTONUP, 0, 0xFFFFFFFF);
+            SendMessage(lphc->hWndEdit, EM_SETSEL, 0, 0);
+            lphc->wState &= ~(CBF_FOCUSED | CBF_BEENFOCUSED);
+            CB_NOTIFY(lphc, CBN_KILLFOCUS);
+        } 
         return TRUE;
 
 #endif

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3628,7 +3628,6 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
  */
 static LRESULT EDIT_WM_KillFocus(EDITSTATE *es)
 {
-#if 0 // See CORE-10266.
 	HWND hCombo;
 	LONG lStyles;
 
@@ -3649,15 +3648,7 @@ static LRESULT EDIT_WM_KillFocus(EDITSTATE *es)
 		if ((lStyles & CBS_DROPDOWN) || (lStyles & CBS_SIMPLE))
 			SendMessage(hCombo, WM_CBLOSTTEXTFOCUS, 0, 0);
 	}
-#else
-	es->flags &= ~EF_FOCUSED;
-	DestroyCaret();
-	if(!(es->style & ES_NOHIDESEL))
-		EDIT_InvalidateText(es, es->selection_start, es->selection_end);
-	EDIT_NOTIFY_PARENT(es, EN_KILLFOCUS);
-	/* throw away left over scroll when we lose focus */
-	es->wheelDeltaRemainder = 0;
-#endif
+
 	return 0;
 }
 


### PR DESCRIPTION
When we unselect text after the WM_CBLOSTTEXTFOCUS message,
make sure we also forget we have been focused at all;
otherwise the edit may become focused again, but with an
empty text selection.

CORE-10266

## Purpose
JIRA issue: [CORE-10266](https://jira.reactos.org/browse/CORE-10266)
