### PR TITLE
[SHELL32] Fix multiple selection of desktop icons, improve MFS

### DIFF
--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -858,6 +858,9 @@ HRESULT WINAPI CDesktopFolder::CallBack(IShellFolder *psf, HWND hwndOwner, IData
         return S_OK;
     }
 
+    if (uMsg != DFM_INVOKECOMMAND || wParam != DFM_CMD_PROPERTIES)
+        return S_OK;
+
     PIDLIST_ABSOLUTE pidlFolder;
     PUITEMID_CHILD *apidl;
     UINT cidl;


### PR DESCRIPTION
This fixes the following issue : when selecting multiple icons
on the desktop, and then right-clicking; the Properties sheet
would immediately be displayed, conflicting with the context
menu.

This improves the following issue : when selecting multiple
files, and then right-clicking -> Properties on the context
menu, we now display each file's Properties sheet one after
another.

CORE-12510

## Purpose

JIRA issue: [CORE-12510](https://jira.reactos.org/browse/CORE-12510)