### PR TITLE
CORE-13910. Update NtWriteFile() calls wrt ByteOffset param use.

### DIFF
--- a/base/setup/usetup/bootsup.c
+++ b/base/setup/usetup/bootsup.c
@@ -941,7 +941,6 @@ InstallFat16BootCodeToFile(
         return Status;
     }
 
-    FileOffset.QuadPart = 0ULL;
     Status = NtWriteFile(FileHandle,
                          NULL,
                          NULL,
@@ -1102,7 +1101,6 @@ InstallFat32BootCodeToFile(
         return Status;
     }
 
-    FileOffset.QuadPart = 0ULL;
     Status = NtWriteFile(FileHandle,
                          NULL,
                          NULL,

--- a/ntoskrnl/kdbg/i386/i386-dis.c
+++ b/ntoskrnl/kdbg/i386/i386-dis.c
@@ -3128,32 +3128,32 @@ append_seg (void)
   if (prefixes & PREFIX_CS)
     {
       used_prefixes |= PREFIX_CS;
-      oappend ("%cs:" + intel_syntax);
+      oappend (&"%cs:"[intel_syntax]);
     }
   if (prefixes & PREFIX_DS)
     {
       used_prefixes |= PREFIX_DS;
-      oappend ("%ds:" + intel_syntax);
+      oappend (&"%ds:"[intel_syntax]);
     }
   if (prefixes & PREFIX_SS)
     {
       used_prefixes |= PREFIX_SS;
-      oappend ("%ss:" + intel_syntax);
+      oappend (&"%ss:"[intel_syntax]);
     }
   if (prefixes & PREFIX_ES)
     {
       used_prefixes |= PREFIX_ES;
-      oappend ("%es:" + intel_syntax);
+      oappend (&"%es:"[intel_syntax]);
     }
   if (prefixes & PREFIX_FS)
     {
       used_prefixes |= PREFIX_FS;
-      oappend ("%fs:" + intel_syntax);
+      oappend (&"%fs:"[intel_syntax]);
     }
   if (prefixes & PREFIX_GS)
     {
       used_prefixes |= PREFIX_GS;
-      oappend ("%gs:" + intel_syntax);
+      oappend (&"%gs:"[intel_syntax]);
     }
 }
 
@@ -4029,7 +4029,7 @@ ptr_reg (int code, int sizeflag)
 static void
 OP_ESreg (int code, int sizeflag)
 {
-  oappend ("%es:" + intel_syntax);
+  oappend (&"%es:"[intel_syntax]);
   ptr_reg (code, sizeflag);
 }
 

--- a/sdk/lib/fslib/ext2lib/Disk.c
+++ b/sdk/lib/fslib/ext2lib/Disk.c
@@ -1077,7 +1077,7 @@ Ext2WriteDisk( PEXT2_FILESYS  Ext2Sys,
         Address.QuadPart = Offset;
 
         Status = NtWriteFile( Ext2Sys->MediaHandle,
-                              0,
+                              NULL,
                               NULL,
                               NULL,
                               &IoStatus,
@@ -1125,7 +1125,7 @@ Ext2WriteDisk( PEXT2_FILESYS  Ext2Sys,
                        Buffer, Length );
 
         Status = NtWriteFile( Ext2Sys->MediaHandle,
-                              0,
+                              NULL,
                               NULL,
                               NULL,
                               &IoStatus,


### PR DESCRIPTION
## Purpose

Update NtReadFile()/NtWriteFile() calls wrt ByteOffset param use.
(This is part 4/4.)

JIRA issue: CORE-13910

## Proposed changes
- NtWriteFile() calls: Remove unused 'ByteOffset = 0', Use explicit NULL instead of ambiguous 0.
