### PR TITLE
[REACTOS] Improve the format of our debug traces - CORE-12671

### DIFF
--- a/sdk/include/reactos/wine/debug.h
+++ b/sdk/include/reactos/wine/debug.h
@@ -93,7 +93,7 @@ struct __wine_debug_channel
        __WINE_DBG_LOG
 
 #define __WINE_DBG_LOG(args...) \
-    ros_dbg_log( __dbcl, __dbch, __RELFILE__, __FUNCTION__, __LINE__, args); } } while(0)
+    ros_dbg_log( __dbcl, __dbch, __RELFILE__, __LINE__, __FUNCTION__, args); } } while(0)
 
 #define __WINE_PRINTF_ATTR(fmt,args) /*__attribute__((format (printf,fmt,args)))*/
 
@@ -139,7 +139,7 @@ struct __wine_debug_channel
 
 #define __WINE_DPRINTF(dbcl,dbch) \
     (!__WINE_GET_DEBUGGING(dbcl,(dbch)) || \
-     (ros_dbg_log(__WINE_DBCL##dbcl,(dbch),__FILE__,"",__LINE__,"") == -1)) ? \
+     (ros_dbg_log(__WINE_DBCL##dbcl,(dbch),__RELFILE__,__LINE__,__FUNCTION__,"") == -1)) ? \
      (void)0 : (void)wine_dbg_printf
 
 #define __WINE_PRINTF_ATTR(fmt, args)
@@ -154,7 +154,7 @@ struct __wine_debug_functions
     const char * (*dbgstr_wn)( const WCHAR *s, int n );
     int (*dbg_vprintf)( const char *format, va_list args );
     int (*dbg_vlog)( enum __wine_debug_class cls, struct __wine_debug_channel *channel,
-                     const char *file, const char *function, const int line, const char *format, va_list args );
+                     const char *file, const int line, const char *function, const char *format, va_list args );
 };
 
 extern unsigned char __wine_dbg_get_channel_flags( struct __wine_debug_channel *channel );
@@ -179,7 +179,7 @@ extern int wine_dbg_log( enum __wine_debug_class cls, struct __wine_debug_channe
                          const char *format, ... ) __WINE_PRINTF_ATTR(4,5);
 /* ReactOS compliant debug format */
 extern int ros_dbg_log( enum __wine_debug_class cls, struct __wine_debug_channel *ch, const char *file,
-                         const char *func, const int line, const char *format, ... ) __WINE_PRINTF_ATTR(6,7);
+                         const int line, const char *func, const char *format, ... ) __WINE_PRINTF_ATTR(6,7);
 
 static __inline const char *wine_dbgstr_a( const char *s )
 {


### PR DESCRIPTION
We currently use the following debug trace format:

    <debug_class>:(<file>:<line>) <message>

(with "debug_class" being "trace", "warn", "err"), and, in the cases where
we call the macros "FIXME()", "TRACE()", "WARN()" or "ERR()" without
specifying the function name, like in:

    FIXME("(%params) message\n", params);

which is what Wine does and what we therefore get with code syncs, we
generate incomplete traces:

    fixme:(<file>:<line>) (params) message

that do not mention the name of the function involved. This is opposite
to what Wine shows:

    fixme:<module>:SomeFunc(params) message

and this forces us to introduce bad hacks, for instance see: d9a3398 .

This patch attempts to fix this by including the function name in our
debug traces, while keeping a format that is readily understandable by
Testman & al. without any changes needed:

    <debug_class>:(<file>:<line>):<channel>:func <message>

As a final addition, the patch also adds support for displaying the current
process ID in addition to the (already existing support for) thread ID.
