### PR TITLE
improve SHGetFileInfo

### DIFF
--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -591,8 +591,8 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
 
     if (flags & SHGFI_LINKOVERLAY)
         uGilFlags |= GIL_FORSHORTCUT;
-    else if ((flags & SHGFI_ADDOVERLAYS) ||
-             (flags & (SHGFI_ICON|SHGFI_SMALLICON)) == SHGFI_ICON)
+    else if ((flags&SHGFI_ADDOVERLAYS) ||
+             (flags&(SHGFI_ICON|SHGFI_SMALLICON))==SHGFI_ICON)
     {
         if (SHELL_IsShortcut(pidlLast))
             uGilFlags |= GIL_FORSHORTCUT;

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -812,7 +812,7 @@ DWORD_PTR WINAPI SHGetFileInfoA(LPCSTR path,DWORD dwFileAttributes,
               psfi->szTypeName, sizeof(psfi->szTypeName), NULL, NULL);
     }
     else
-        ret = SHGetFileInfoW(pathW, dwFileAttributes, NULL, sizeof(temppsfi), flags);
+        ret = SHGetFileInfoW(pathW, dwFileAttributes, NULL, 0, flags);
 
     HeapFree(GetProcessHeap(), 0, temppath);
 

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -430,7 +430,7 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
         return FALSE;
 
     /* windows initializes these values regardless of the flags */
-    if (psfi)
+    if (psfi != NULL)
     {
         psfi->szDisplayName[0] = '\0';
         psfi->szTypeName[0] = '\0';

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -457,12 +457,18 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
 
     if (flags & SHGFI_EXETYPE)
     {
-        if (!(flags & SHGFI_SYSICONINDEX) &&
-            GetFileAttributesW(szFullPath) != INVALID_FILE_ATTRIBUTES)
+        if (!(flags & SHGFI_SYSICONINDEX))
         {
-            return shgfi_get_exe_type(szFullPath);
+            if (flags & SHGFI_USEFILEATTRIBUTES)
+            {
+                return 1;
+            }
+            else if (GetFileAttributesW(szFullPath) != INVALID_FILE_ATTRIBUTES)
+            {
+                return shgfi_get_exe_type(szFullPath);
+            }
         }
-   }
+    }
 
     /*
      * psfi is NULL normally to query EXE type. If it is NULL, none of the

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -461,7 +461,7 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
         {
             if (flags & SHGFI_USEFILEATTRIBUTES)
             {
-                return 1;
+                return TRUE;
             }
             else if (GetFileAttributesW(szFullPath) != INVALID_FILE_ATTRIBUTES)
             {

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -520,8 +520,18 @@ DWORD_PTR WINAPI SHGetFileInfoW(LPCWSTR path,DWORD dwFileAttributes,
             psfi->dwAttributes = 0xffffffff;
         }
         if (psfParent)
-            IShellFolder_GetAttributesOf( psfParent, 1, (LPCITEMIDLIST*)&pidlLast,
-                                      &(psfi->dwAttributes) );
+        {
+            IShellFolder_GetAttributesOf(psfParent, 1, (LPCITEMIDLIST*)&pidlLast,
+                                         &(psfi->dwAttributes));
+        }
+    }
+
+    if (flags & SHGFI_USEFILEATTRIBUTES)
+    {
+        if (flags & SHGFI_ICON)
+        {
+            psfi->dwAttributes = 0;
+        }
     }
 
     /* get the displayname */

--- a/dll/win32/shell32/wine/shell32_main.c
+++ b/dll/win32/shell32/wine/shell32_main.c
@@ -789,12 +789,10 @@ DWORD_PTR WINAPI SHGetFileInfoA(LPCSTR path,DWORD dwFileAttributes,
         psfi->iIcon = temppsfi.iIcon;
         psfi->dwAttributes = temppsfi.dwAttributes;
 
-        len = lstrlenW(temppsfi.szDisplayName);
-        WideCharToMultiByte(CP_ACP, 0, temppsfi.szDisplayName, len + 1,
-              psfi->szDisplayName, len + 1, NULL, NULL);
+        WideCharToMultiByte(CP_ACP, 0, temppsfi.szDisplayName, -1,
+              psfi->szDisplayName, sizeof(psfi->szDisplayName), NULL, NULL);
 
-        len = lstrlenW(temppsfi.szTypeName);
-        WideCharToMultiByte(CP_ACP, 0, temppsfi.szTypeName, len + 1,
+        WideCharToMultiByte(CP_ACP, 0, temppsfi.szTypeName, -1,
               psfi->szTypeName, sizeof(psfi->szTypeName), NULL, NULL);
     }
     else


### PR DESCRIPTION
This patch reduces failures of SHGetFileInfo function. CORE-7159

## Purpose

Improve SHGetFileInfo.
JIRA issue: [CORE-7159](https://jira.reactos.org/browse/CORE-7159)

## TODO

- [x] Reduce all failures of SHGetFileInfo in shell32_winetest:shlfileop.