### PR TITLE
[BROWSEUI] Improve hackfix for Quick Launch title

### DIFF
--- a/dll/win32/browseui/shellbars/CISFBand.cpp
+++ b/dll/win32/browseui/shellbars/CISFBand.cpp
@@ -258,7 +258,7 @@ HRESULT CISFBand::CreateSimpleToolbar(HWND hWndParent)
             }
             if (pdbi->dwMask & DBIM_TITLE)
             {
-                if (m_QLaunch || !ILGetDisplayNameEx(NULL, m_pidl, pdbi->wszTitle, ILGDN_INFOLDER))
+                if (!ILGetDisplayNameEx(NULL, m_pidl, pdbi->wszTitle, ILGDN_INFOLDER))
                 {
                     pdbi->dwMask &= ~DBIM_TITLE;
                 }


### PR DESCRIPTION
Improve the hack used to hide Quick Launch title bar by default.

It's big copy-pasta, but still not as terrible as the previous hack. The behaviour now is the same as in Windows XP, so the title bar can be enabled. :smile: 

JIRA issue: [CORE-13995](https://jira.reactos.org/browse/CORE-13995)