### PR TITLE
[RAPPS] Add support for no-length downloads indication

### DIFF
--- a/base/applications/rapps/include/dialogs.h
+++ b/base/applications/rapps/include/dialogs.h
@@ -15,6 +15,7 @@ class CDownloadManager
     static CDowloadingAppsListView DownloadsListView;
 
     static VOID Download(const DownloadInfo& DLInfo, BOOL bIsModal = FALSE);
+    static VOID SetProgressMarquee(HWND Item, BOOL Enable);
 
 public:
     static INT_PTR CALLBACK DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
## Purpose

Some download links may not tell the final content-length of the file.

This PR adds indication of currently downloaded file size, if content-length is not available.

## Proposed changes

Make use of `PBS_MARQUEE` and `PBM_SETMARQUEE` powers!

Cc @sanchaez 