### PR TITLE
input: Overwrite font substitutes settings on lang change

### DIFF
--- a/dll/cpl/input/input_list.c
+++ b/dll/cpl/input/input_list.c
@@ -2,11 +2,129 @@
 * PROJECT:         input.dll
 * FILE:            dll/cpl/input/input_list.c
 * PURPOSE:         input.dll
-* PROGRAMMER:      Dmitry Chapyshev (dmitry@reactos.org)
+* PROGRAMMERS:     Dmitry Chapyshev (dmitry@reactos.org)
+*                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
 */
 
 #include "input_list.h"
 
+typedef struct
+{
+    PWCHAR FontName;
+    PWCHAR SubFontName;
+} MUI_SUBFONT;
+
+#include "../../../base/setup/usetup/muifonts.h"
+
+BOOL UpdateRegistryForFontSubstitutes(MUI_SUBFONT *pSubstitutes)
+{
+    DWORD cbData;
+    HKEY hKey;
+    static const WCHAR pszKey[] =
+        L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\FontSubstitutes";
+
+    hKey = NULL;
+    RegOpenKeyExW(HKEY_LOCAL_MACHINE, pszKey, 0, KEY_ALL_ACCESS, &hKey);
+    if (hKey == NULL)
+        return FALSE;
+
+    /* Overwrite only */
+    for (; pSubstitutes->FontName; ++pSubstitutes)
+    {
+        cbData = (lstrlenW(pSubstitutes->SubFontName) + 1) * sizeof(WCHAR);
+        RegSetValueExW(hKey, pSubstitutes->FontName, 0,
+            REG_SZ, (LPBYTE)pSubstitutes->SubFontName, cbData);
+    }
+
+    RegCloseKey(hKey);
+
+    return TRUE;
+}
+
+BOOL
+InputList_SetFontSubstitutes(LCID dwLocaleId)
+{
+    MUI_SUBFONT *pSubstitutes;
+    WORD wLangID, wPrimaryLangID, wSubLangID;
+
+    wLangID = LANGIDFROMLCID(dwLocaleId);
+    wPrimaryLangID = PRIMARYLANGID(wLangID);
+    wSubLangID = SUBLANGID(wLangID);
+
+    /* FIXME: Add more if necessary */
+    switch (wPrimaryLangID)
+    {
+        default:
+            pSubstitutes = LatinFonts;
+            break;
+        case LANG_AZERI:
+        case LANG_BELARUSIAN:
+        case LANG_BULGARIAN:
+        case LANG_KAZAK:
+        case LANG_RUSSIAN:
+        case LANG_SERBIAN:
+        case LANG_TATAR:
+        case LANG_UKRAINIAN:
+        case LANG_UZBEK:
+            pSubstitutes = CyrillicFonts;
+            break;
+        case LANG_GREEK:
+            pSubstitutes = GreekFonts;
+            break;
+        case LANG_HEBREW:
+            pSubstitutes = HebrewFonts;
+            break;
+        case LANG_CHINESE:
+            switch (wSubLangID)
+            {
+                case SUBLANG_CHINESE_SIMPLIFIED:
+                case SUBLANG_CHINESE_SINGAPORE:
+                case SUBLANG_CHINESE_MACAU:
+                    pSubstitutes = ChineseSimplifiedFonts;
+                    break;
+                case SUBLANG_CHINESE_TRADITIONAL:
+                case SUBLANG_CHINESE_HONGKONG:
+                    pSubstitutes = ChineseTraditionalFonts;
+                    break;
+                default:
+                    pSubstitutes = NULL;
+                    DebugBreak();
+                    break;
+            }
+            break;
+        case LANG_JAPANESE:
+            pSubstitutes = JapaneseFonts;
+            break;
+        case LANG_KOREAN:
+            pSubstitutes = KoreanFonts;
+            break;
+        case LANG_ARABIC:
+        case LANG_ARMENIAN:
+        case LANG_BENGALI:
+        case LANG_FARSI:
+        case LANG_GEORGIAN:
+        case LANG_GUJARATI:
+        case LANG_HINDI:
+        case LANG_KONKANI:
+        case LANG_MARATHI:
+        case LANG_PUNJABI:
+        case LANG_SANSKRIT:
+        case LANG_TAMIL:
+        case LANG_TELUGU:
+        case LANG_THAI:
+        case LANG_URDU:
+        case LANG_VIETNAMESE:
+            pSubstitutes = UnicodeFonts;
+            break;
+    }
+
+    if (pSubstitutes)
+    {
+        UpdateRegistryForFontSubstitutes(pSubstitutes);
+        return TRUE;
+    }
+    return FALSE;
+}
 
 static INPUT_LIST_NODE *_InputList = NULL;
 
@@ -216,11 +334,12 @@ InputList_AddInputMethodToUserRegistry(DWORD dwIndex, INPUT_LIST_NODE *pNode)
 /*
  * Writes any changes in input methods to the registry
  */
-VOID
+BOOL
 InputList_Process(VOID)
 {
     INPUT_LIST_NODE *pCurrent;
     DWORD dwIndex;
+    BOOL bRet = FALSE;
 
     /* Process deleted and edited input methods */
     for (pCurrent = _InputList; pCurrent != NULL; pCurrent = pCurrent->pNext)
@@ -246,6 +365,7 @@ InputList_Process(VOID)
     {
         if (pCurrent->wFlags & INPUT_LIST_NODE_FLAG_DEFAULT)
         {
+            bRet = InputList_SetFontSubstitutes(pCurrent->pLocale->dwId);
             InputList_AddInputMethodToUserRegistry(1, pCurrent);
             break;
         }
@@ -279,6 +399,8 @@ InputList_Process(VOID)
 
         dwIndex++;
     }
+
+    return bRet;
 }
 
 

--- a/dll/cpl/input/input_list.h
+++ b/dll/cpl/input/input_list.h
@@ -30,7 +30,7 @@ typedef struct _INPUT_LIST_NODE
 VOID
 InputList_Create(VOID);
 
-VOID
+BOOL
 InputList_Process(VOID);
 
 BOOL

--- a/dll/cpl/input/lang/bg-BG.rc
+++ b/dll/cpl/input/lang/bg-BG.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT       "Ляв Alt+Shift"
     IDS_SWITCH_BET_INLANG    "Превключване на езиците за въвеждане"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/cs-CZ.rc
+++ b/dll/cpl/input/lang/cs-CZ.rc
@@ -111,6 +111,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Levý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Přepnout mezi vstupními jazyky"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/de-DE.rc
+++ b/dll/cpl/input/lang/de-DE.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Strg+Umschalt"
     IDS_LEFT_ALT_SHIFT "Alt links+Umschalt"
     IDS_SWITCH_BET_INLANG "Zwischen Eingabesprachen umschalten"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/el-GR.rc
+++ b/dll/cpl/input/lang/el-GR.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/en-US.rc
+++ b/dll/cpl/input/lang/en-US.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/es-ES.rc
+++ b/dll/cpl/input/lang/es-ES.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Mayús"
     IDS_LEFT_ALT_SHIFT "Alt Izq+Mayús"
     IDS_SWITCH_BET_INLANG "Cambiar entre los idiomas de entrada"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/fr-FR.rc
+++ b/dll/cpl/input/lang/fr-FR.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Maj"
     IDS_LEFT_ALT_SHIFT "Alt Gauche+Maj"
     IDS_SWITCH_BET_INLANG "Changer les langues de saisie"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 /* FIXME : À améliorer/compléter */

--- a/dll/cpl/input/lang/he-IL.rc
+++ b/dll/cpl/input/lang/he-IL.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "החלף בין שפות כתיבה"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/it-IT.rc
+++ b/dll/cpl/input/lang/it-IT.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt sinistro+Shift"
     IDS_SWITCH_BET_INLANG "Cambia lingua di digitazione"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ja-JP.rc
+++ b/dll/cpl/input/lang/ja-JP.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左Alt+Shift"
     IDS_SWITCH_BET_INLANG "入力言語の切り替え"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/no-NO.rc
+++ b/dll/cpl/input/lang/no-NO.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Venstre Alt+Shift"
     IDS_SWITCH_BET_INLANG "Bytt mellom inndataspråk"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pl-PL.rc
+++ b/dll/cpl/input/lang/pl-PL.rc
@@ -114,6 +114,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Lewy Alt+Shift"
     IDS_SWITCH_BET_INLANG "Przełącza pomiędzy układami klawiatury"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/pt-BR.rc
+++ b/dll/cpl/input/lang/pt-BR.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "CTRL+SHIFT"
     IDS_LEFT_ALT_SHIFT "ALT esquerdo+SHIFT"
     IDS_SWITCH_BET_INLANG "Alternar entre idiomas de entrada"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ro-RO.rc
+++ b/dll/cpl/input/lang/ro-RO.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "«Ctrl» + «Shift»"
     IDS_LEFT_ALT_SHIFT "«Alt» (stâng) + «Shift»"
     IDS_SWITCH_BET_INLANG "Comutarea între limbile de intrare"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/ru-RU.rc
+++ b/dll/cpl/input/lang/ru-RU.rc
@@ -106,6 +106,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt слева+Shift"
     IDS_SWITCH_BET_INLANG "Переключение между языками ввода"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sk-SK.rc
+++ b/dll/cpl/input/lang/sk-SK.rc
@@ -111,6 +111,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Ľavý Alt+Shift"
     IDS_SWITCH_BET_INLANG "Switch between input languages"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/sq-AL.rc
+++ b/dll/cpl/input/lang/sq-AL.rc
@@ -110,6 +110,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Left Alt+Shift"
     IDS_SWITCH_BET_INLANG "Ndërro ndër gjuhët hyrese"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/tr-TR.rc
+++ b/dll/cpl/input/lang/tr-TR.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "Denetim + Üst Damga"
     IDS_LEFT_ALT_SHIFT "Sol Seçenek + Üst Damga"
     IDS_SWITCH_BET_INLANG "Giriş dilleri arasında geçiş yap."
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/uk-UA.rc
+++ b/dll/cpl/input/lang/uk-UA.rc
@@ -114,6 +114,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "Alt зліва+Shift"
     IDS_SWITCH_BET_INLANG "Перемикання мов вводу"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-CN.rc
+++ b/dll/cpl/input/lang/zh-CN.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在输入语言间切换"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/lang/zh-TW.rc
+++ b/dll/cpl/input/lang/zh-TW.rc
@@ -108,6 +108,7 @@ BEGIN
     IDS_CTRL_SHIFT "Ctrl+Shift"
     IDS_LEFT_ALT_SHIFT "左 Alt+Shift"
     IDS_SWITCH_BET_INLANG "在輸入語言間切換"
+    IDS_REBOOT_NOW, "Reboot now?"
 END
 
 STRINGTABLE

--- a/dll/cpl/input/resource.h
+++ b/dll/cpl/input/resource.h
@@ -57,6 +57,7 @@
 #define IDS_LEFT_ALT_SHIFT       15
 #define IDS_SWITCH_BET_INLANG    16
 #define IDC_TURNOFFTEXTSVCS_CB   17
+#define IDS_REBOOT_NOW           18
 
 /* Layouts */
 #define IDS_US_LAYOUT                                  5000


### PR DESCRIPTION
## Purpose

If the system language was changed, then the system should overwrite the preferred settings of font substitutes.

JIRA issue: [CORE-13246](https://jira.reactos.org/browse/CORE-13246)
