### PR TITLE
CORE-12580. SetupApi: it is _WIN32_WINNT, not WIN32_WINNT

### DIFF
--- a/dll/win32/setupapi/driver.c
+++ b/dll/win32/setupapi/driver.c
@@ -565,7 +565,7 @@ done:
     return Result;
 }
 
-#if WIN32_WINNT < 0x0600
+#if _WIN32_WINNT < 0x0600
 /* WARNING:
  * This code has been copied from advapi32/reg/reg.c,
  * so this dll can be tested as is on Windows XP


### PR DESCRIPTION
## Purpose

Fix a typo.

JIRA issue: [CORE-12580](https://jira.reactos.org/browse/CORE-12580)

## Proposed changes

See [CORE-12580 comment](https://jira.reactos.org/browse/CORE-12580?focusedCommentId=87618&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-87618).