### PR TITLE
add font substitute of 'Consolas' to 'Liberation Mono'

### DIFF
--- a/base/setup/usetup/muifonts.h
+++ b/base/setup/usetup/muifonts.h
@@ -22,6 +22,7 @@ MUI_SUBFONT LatinFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     { NULL, NULL }
 };
 
@@ -46,6 +47,7 @@ MUI_SUBFONT CyrillicFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     { NULL, NULL }
 };
 
@@ -70,6 +72,7 @@ MUI_SUBFONT GreekFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     { NULL, NULL }
 };
 
@@ -94,6 +97,7 @@ MUI_SUBFONT HebrewFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     { NULL, NULL }
 };
 
@@ -127,6 +131,7 @@ MUI_SUBFONT ChineseSimplifiedFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     /* localized names */
     { CSF_LocalName0,            L"Droid Sans Fallback" },
     { CSF_LocalName1,            L"Droid Sans Fallback" },
@@ -165,6 +170,7 @@ MUI_SUBFONT ChineseTraditionalFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     /* localized names */
     { CTF_LocalName0,     L"Droid Sans Fallback" },
     { CTF_LocalName1,     L"Droid Sans Fallback" },
@@ -202,6 +208,7 @@ MUI_SUBFONT JapaneseFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     /* localized names */
     { JF_LocalName0,      L"Droid Sans Fallback" },
     { JF_LocalName1,      L"Droid Sans Fallback" },
@@ -243,6 +250,7 @@ MUI_SUBFONT KoreanFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     /* localized names */
     { KF_LocalName0,      L"Droid Sans Fallback" },
     { KF_LocalName1,      L"Droid Sans Fallback" },
@@ -274,5 +282,6 @@ MUI_SUBFONT UnicodeFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Consolas",               L"Liberation Mono" },
     { NULL, NULL }
 };


### PR DESCRIPTION
## Purpose

This Pull Request adds a font substitute from 'Consolas' to 'Liberation Mono'.

JIRA issue: [CORE-14014](https://jira.reactos.org/browse/CORE-14014)
