### PR TITLE
Core 14023 : Fix SetWorldTransform for metafiles

### DIFF
--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -633,6 +633,7 @@ typedef enum _DCFUNC
     DCFUNC_SetViewportOrgEx,
     DCFUNC_SetWindowExtEx,
     DCFUNC_SetWindowOrgEx,
+    DCFUNC_SetWorldTransform,
     DCFUNC_StretchBlt,
     DCFUNC_StrokeAndFillPath,
     DCFUNC_StrokePath,

--- a/win32ss/gdi/gdi32/objects/coord.c
+++ b/win32ss/gdi/gdi32/objects/coord.c
@@ -302,6 +302,8 @@ SetWorldTransform(
     _In_ HDC hdc,
     _Out_ CONST XFORM *pxform)
 {
+    HANDLE_METADC(BOOL, SetWorldTransform, FALSE, hdc, pxform);
+   
     /* FIXME  shall we add undoc #define MWT_SETXFORM 4 ?? */
     return ModifyWorldTransform(hdc, pxform, MWT_MAX+1);
 }

--- a/win32ss/gdi/gdi32/objects/coord.c
+++ b/win32ss/gdi/gdi32/objects/coord.c
@@ -320,9 +320,13 @@ ModifyWorldTransform(
         return FALSE;
 
     if (dwMode == (MWT_MAX + 1))
+    {
         HANDLE_METADC(BOOL, SetWorldTransform, FALSE, hdc, pxform);
+    }
     else
+    {
         HANDLE_METADC(BOOL, ModifyWorldTransform, FALSE, hdc, pxform, dwMode);
+    }
 
     /* Get the DC attribute */
     pdcattr = GdiGetDcAttr(hdc);

--- a/win32ss/gdi/gdi32/objects/coord.c
+++ b/win32ss/gdi/gdi32/objects/coord.c
@@ -302,8 +302,6 @@ SetWorldTransform(
     _In_ HDC hdc,
     _Out_ CONST XFORM *pxform)
 {
-    HANDLE_METADC(BOOL, SetWorldTransform, FALSE, hdc, pxform);
-   
     /* FIXME  shall we add undoc #define MWT_SETXFORM 4 ?? */
     return ModifyWorldTransform(hdc, pxform, MWT_MAX+1);
 }
@@ -321,7 +319,10 @@ ModifyWorldTransform(
     if (GDI_HANDLE_GET_TYPE(hdc) == GDILoObjType_LO_METADC16_TYPE)
         return FALSE;
 
-    HANDLE_METADC(BOOL, ModifyWorldTransform, FALSE, hdc, pxform, dwMode);
+    if (dwMode == (MWT_MAX + 1))
+        HANDLE_METADC(BOOL, SetWorldTransform, FALSE, hdc, pxform);
+    else
+        HANDLE_METADC(BOOL, ModifyWorldTransform, FALSE, hdc, pxform, dwMode);
 
     /* Get the DC attribute */
     pdcattr = GdiGetDcAttr(hdc);

--- a/win32ss/gdi/gdi32/wine/gdi_private.h
+++ b/win32ss/gdi/gdi32/wine/gdi_private.h
@@ -181,8 +181,10 @@ HGDIOBJ WINAPI GdiFixUpHandle(HGDIOBJ hGdiObj);
 extern void push_dc_driver_ros(PHYSDEV *dev, PHYSDEV physdev, const struct gdi_dc_funcs *funcs);
 #define push_dc_driver push_dc_driver_ros
 
+#if 0
 BOOL WINAPI SetWorldTransformForMetafile(HDC hdc, const XFORM *pxform);
 #define SetWorldTransform SetWorldTransformForMetafile
+#endif
 
 #ifdef _M_ARM
 #define DbgRaiseAssertionFailure() __emit(0xdefc)

--- a/win32ss/gdi/gdi32/wine/rosglue.c
+++ b/win32ss/gdi/gdi32/wine/rosglue.c
@@ -14,6 +14,8 @@ BOOL nulldrv_AbortPath( PHYSDEV dev );
 BOOL nulldrv_CloseFigure( PHYSDEV dev );
 BOOL nulldrv_SelectClipPath( PHYSDEV dev, INT mode );
 BOOL nulldrv_FillPath( PHYSDEV dev );
+BOOL nulldrv_ModifyWorldTransform( PHYSDEV dev, const XFORM* xform, DWORD mode ) { return TRUE; }
+BOOL nulldrv_SetWorldTransform( PHYSDEV dev, const XFORM* xform ) { return TRUE; }
 BOOL nulldrv_StrokeAndFillPath( PHYSDEV dev );
 BOOL nulldrv_StrokePath( PHYSDEV dev );
 BOOL nulldrv_FlattenPath( PHYSDEV dev );
@@ -108,7 +110,7 @@ static const struct gdi_dc_funcs DummyPhysDevFuncs =
     NULL_IntersectClipRect, //INT      (*pIntersectClipRect)(PHYSDEV,INT,INT,INT,INT);
     (PVOID)NULL_Unused, //BOOL     (*pInvertRgn)(PHYSDEV,HRGN);
     (PVOID)NULL_Unused, //BOOL     (*pLineTo)(PHYSDEV,INT,INT);
-    (PVOID)NULL_Unused, //BOOL     (*pModifyWorldTransform)(PHYSDEV,const XFORM*,DWORD);
+    nulldrv_ModifyWorldTransform, //BOOL     (*pModifyWorldTransform)(PHYSDEV,const XFORM*,DWORD);
     (PVOID)NULL_Unused, //BOOL     (*pMoveTo)(PHYSDEV,INT,INT);
     NULL_OffsetClipRgn, //INT      (*pOffsetClipRgn)(PHYSDEV,INT,INT);
     (PVOID)NULL_Unused, //BOOL     (*pOffsetViewportOrgEx)(PHYSDEV,INT,INT,POINT*);
@@ -165,7 +167,7 @@ static const struct gdi_dc_funcs DummyPhysDevFuncs =
     NULL_SetViewportOrgEx, //BOOL     (*pSetViewportOrgEx)(PHYSDEV,INT,INT,POINT*);
     NULL_SetWindowExtEx, //BOOL     (*pSetWindowExtEx)(PHYSDEV,INT,INT,SIZE*);
     NULL_SetWindowOrgEx, //BOOL     (*pSetWindowOrgEx)(PHYSDEV,INT,INT,POINT*);
-    (PVOID)NULL_Unused, //BOOL     (*pSetWorldTransform)(PHYSDEV,const XFORM*);
+    nulldrv_SetWorldTransform, //BOOL     (*pSetWorldTransform)(PHYSDEV,const XFORM*);
     (PVOID)NULL_Unused, //INT      (*pStartDoc)(PHYSDEV,const DOCINFOW*);
     (PVOID)NULL_Unused, //INT      (*pStartPage)(PHYSDEV);
     (PVOID)NULL_Unused, //BOOL     (*pStretchBlt)(PHYSDEV,struct bitblt_coords*,PHYSDEV,struct bitblt_coords*,DWORD);

--- a/win32ss/gdi/gdi32/wine/rosglue.c
+++ b/win32ss/gdi/gdi32/wine/rosglue.c
@@ -1044,9 +1044,9 @@ DRIVER_Dispatch(
                                                    _va_arg_n(argptr, INT, 0), // X
                                                    _va_arg_n(argptr, INT, 1), // Y
                                                    _va_arg_n(argptr, LPPOINT, 2)); // lpPoint
-        case DCFUNC_SerWorldTransform:
+        case DCFUNC_SetWorldTransform:
             return physdev->funcs->pSetWorldTransform(physdev,
-                                                      _va_arg(argptr, const XFORM*));
+                                                      va_arg(argptr, const XFORM*));
 
         case DCFUNC_StretchBlt:
             return DRIVER_StretchBlt(physdev,

--- a/win32ss/gdi/gdi32/wine/rosglue.c
+++ b/win32ss/gdi/gdi32/wine/rosglue.c
@@ -1044,6 +1044,10 @@ DRIVER_Dispatch(
                                                    _va_arg_n(argptr, INT, 0), // X
                                                    _va_arg_n(argptr, INT, 1), // Y
                                                    _va_arg_n(argptr, LPPOINT, 2)); // lpPoint
+        case DCFUNC_SerWorldTransform:
+            return physdev->funcs->pSetWorldTransform(physdev,
+                                                      _va_arg(argptr, const XFORM*));
+
         case DCFUNC_StretchBlt:
             return DRIVER_StretchBlt(physdev,
                                      physdev->hdc,


### PR DESCRIPTION
## Purpose

Forward SetWorldTransform to wine's metafile implementation.

JIRA issue: [CORE-14023](https://jira.reactos.org/browse/CORE-14023)

## Proposed changes
- Do not forward it to ModifyWorldTransform, for which the metafile implementation doesn't know what to do with MWT_MAX+1