### PR TITLE
CORE-13332. PcMemGetBiosMemoryMap(): Update ACPI (Extended Attributes) support.

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pcmem.c
+++ b/boot/freeldr/freeldr/arch/i386/pcmem.c
@@ -332,7 +332,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
         TRACE("BaseAddress: 0x%llx\n", PcBiosMemoryMap[PcBiosMapCount].BaseAddress);
         TRACE("Length: 0x%llx\n", PcBiosMemoryMap[PcBiosMapCount].Length);
         TRACE("Type: 0x%lx\n", PcBiosMemoryMap[PcBiosMapCount].Type);
-        TRACE("Reserved: 0x%lx\n", PcBiosMemoryMap[PcBiosMapCount].Reserved);
+        TRACE("ExtendedAttributesAsULONG: 0x%08lx\n", PcBiosMemoryMap[PcBiosMapCount].ExtendedAttributesAsULONG);
 
         if (PcBiosMemoryMap[PcBiosMapCount].Length == 0)
         {

--- a/boot/freeldr/freeldr/include/arch/pc/pcbios.h
+++ b/boot/freeldr/freeldr/include/arch/pc/pcbios.h
@@ -5,18 +5,51 @@
 
 typedef enum
 {
-    BiosMemoryUsable=1,
-    BiosMemoryReserved,
-    BiosMemoryAcpiReclaim,
-    BiosMemoryAcpiNvs
+    // ACPI 1.0.
+    BiosMemoryUsable        =  1,
+    BiosMemoryReserved      =  2,
+    BiosMemoryAcpiReclaim   =  3,
+    BiosMemoryAcpiNvs       =  4,
+    // ACPI 3.0.
+    BiosMemoryUnusable      =  5,
+    // ACPI 4.0.
+    BiosMemoryDisabled      =  6,
+    // ACPI 6.0.
+    BiosMemoryPersistent    =  7,
+    BiosMemoryUndefined08   =  8,
+    BiosMemoryUndefined09   =  9,
+    BiosMemoryUndefined10   = 10,
+    BiosMemoryUndefined11   = 11,
+    BiosMemoryOemDefined12  = 12
+    // BiosMemoryUndefinedNN   = 13-0xEFFFFFFF
+    // BiosMemoryOemDefinedNN  = 0xF0000000-0xFFFFFFFF
 } BIOS_MEMORY_TYPE;
 
 typedef struct
 {
-    ULONGLONG        BaseAddress;
-    ULONGLONG        Length;
-    ULONG        Type;
-    ULONG        Reserved;
+    // ACPI 1.0.
+    ULONGLONG   BaseAddress;
+    ULONGLONG   Length;
+    ULONG       Type;
+    // ACPI 3.0.
+    union
+    {
+        ULONG   Reserved;
+
+        struct
+        {
+            // Bit 0. ACPI 3.0. As of ACPI 4.0, became "Reserved -> must be 1".
+            ULONG Enabled_Reserved : 1;
+            // Bit 1. ACPI 3.0. As of ACPI 6.1, became "Unimplemented -> Deprecated".
+            ULONG NonVolatile_Deprecated : 1;
+            // Bit 2. ACPI 4.0. As of ACPI 6.1, became "Unimplemented -> Deprecated".
+            ULONG SlowAccess_Deprecated : 1;
+            // Bit 3. ACPI 4.0. ACPI 5.0-A added "Used only on PC-AT BIOS" (not UEFI).
+            ULONG ErrorLog : 1;
+            // Bits 4-31. ACPI 3.0.
+            ULONG Reserved : 28;
+        } ExtendedAttributes;
+    };
 } BIOS_MEMORY_MAP, *PBIOS_MEMORY_MAP;
 
 /* Int 15h AX=E820h Entry minimal size. */

--- a/boot/freeldr/freeldr/include/arch/pc/pcbios.h
+++ b/boot/freeldr/freeldr/include/arch/pc/pcbios.h
@@ -34,7 +34,7 @@ typedef struct
     // ACPI 3.0.
     union
     {
-        ULONG   Reserved;
+        ULONG   ExtendedAttributesAsULONG;
 
         struct
         {
@@ -53,7 +53,7 @@ typedef struct
 } BIOS_MEMORY_MAP, *PBIOS_MEMORY_MAP;
 
 /* Int 15h AX=E820h Entry minimal size. */
-C_ASSERT(FIELD_OFFSET(BIOS_MEMORY_MAP, Reserved) == 20);
+C_ASSERT(FIELD_OFFSET(BIOS_MEMORY_MAP, ExtendedAttributes) == 20);
 /* Int 15h AX=E820h Entry maximal size. */
 C_ASSERT(sizeof(BIOS_MEMORY_MAP) == 24);
 


### PR DESCRIPTION
## Purpose

Add ACPI 3.0 to 6.2-A support, especially its validity bit.

JIRA issue: [CORE-13332](https://jira.reactos.org/browse/CORE-13332)

## Proposed changes

- Update ACPI definitions to latest (6.2-A) specification,
- Check entry validity from E.A. bit.
- Some (un)related minor code updates too.

## TODO

I just want some early feedback, mainly wrt the 4 separate commits.

- [X] Review/Adapt rest of existing code to new ACPI 6.2-A definitions. // Nothing else needs update, at least right away.
