### PR TITLE
don't show error when closing disk prop sheet

### DIFF
--- a/dll/win32/shell32/dialogs/fprop.cpp
+++ b/dll/win32/shell32/dialogs/fprop.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright 2005 Johannes Anderwald
  * Copyright 2012 Rafal Harabien
+ * Copyright 2017 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -117,7 +118,7 @@ SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CH
 
     /* Handle drives */
     if (PathIsRootW(wszPath))
-        return SH_ShowDriveProperties(wszPath, pidlFolder, apidl);
+        return SUCCEEDED(SH_ShowDriveProperties(wszPath, pidlFolder, apidl));
 
     /* Handle files and folders */
     PROPSHEETHEADERW Header;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -215,9 +215,9 @@ HRESULT CALLBACK DrivesContextMenuCallback(IShellFolder *psf,
 
         if (wParam == DFM_CMD_PROPERTIES)
         {
-            if (!SH_ShowDriveProperties(wszBuf, pidlFolder, apidl))
+            hr = SH_ShowDriveProperties(wszBuf, pidlFolder, apidl);
+            if (FAILED(hr))
             {
-                hr = E_FAIL;
                 dwError = ERROR_CAN_NOT_COMPLETE;
                 nStringID = IDS_CANTSHOWPROPERTIES;
             }

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -184,7 +184,7 @@ BOOL SHELL_IsShortcut(LPCITEMIDLIST) DECLSPEC_HIDDEN;
 INT_PTR CALLBACK SH_FileGeneralDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 INT_PTR CALLBACK SH_FileVersionDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 HPROPSHEETPAGE SH_CreatePropertySheetPage(WORD wDialogId, DLGPROC pfnDlgProc, LPARAM lParam, LPCWSTR pwszTitle);
-BOOL SH_ShowDriveProperties(WCHAR *drive, LPCITEMIDLIST pidlFolder, PCUITEMID_CHILD_ARRAY apidl);
+HRESULT SH_ShowDriveProperties(WCHAR *drive, LPCITEMIDLIST pidlFolder, PCUITEMID_CHILD_ARRAY apidl);
 BOOL SH_ShowRecycleBinProperties(WCHAR sDrive);
 BOOL SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CHILD_ARRAY apidl);
 LPWSTR SH_FormatFileSizeWithBytes(PULARGE_INTEGER lpQwSize, LPWSTR pszBuf, UINT cchBuf);


### PR DESCRIPTION
## Purpose

Don't show error message when successful closing a disk property sheet.

JIRA issue: [CORE-14035](https://jira.reactos.org/browse/CORE-14035)

- Change the return value type of SH_ShowDriveProperties.
- Fix the return value of SH_ShowDriveProperties.
- Adapt DrivesContextMenuCallback and SH_ShowPropertiesDialog functions for this fix.