### PR TITLE
CORE-13126. Create Test_NtFreeVirtualMemory_Parameters().

### DIFF
--- a/modules/rostests/apitests/ntdll/NtFreeVirtualMemory.c
+++ b/modules/rostests/apitests/ntdll/NtFreeVirtualMemory.c
@@ -1,3 +1,9 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for NtFreeVirtualMemory
+ * COPYRIGHT:   Copyright 2011 Jérôme Gardou <jerome.gardou@reactos.org>
+ */
 
 #include "precomp.h"
 


### PR DESCRIPTION
## Purpose

Add an ApiTest, before fixing the actual code.

JIRA issue: [CORE-13126](https://jira.reactos.org/browse/CORE-13126)

## Proposed changes

- Code formatting fixes.
- Create `Test_NtFreeVirtualMemory_Parameters()`.

## TODO

- [X] Needs to be tested on WS03. (I can't do it. It passes on WXP.) // Done by @binarymaster.
