### PR TITLE
Use inline functions to acquire/release the PFN lock. 

### DIFF
--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -192,9 +192,9 @@ _MiFlushMappedSection(PVOID BaseAddress,
             (MmIsDirtyPageRmap(Page) || IS_DIRTY_SSE(Entry)) &&
             FileOffset.QuadPart < FileSize->QuadPart)
         {
-            OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+            OldIrql = MiAcquirePfnLock();
             MmReferencePage(Page);
-            KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+            MiReleasePfnLock(OldIrql);
             Pages[(PageAddress - BeginningAddress) >> PAGE_SHIFT] = Entry;
         }
         else

--- a/ntoskrnl/cache/section/fault.c
+++ b/ntoskrnl/cache/section/fault.c
@@ -236,9 +236,9 @@ MmNotPresentFaultCachePage (
             KeBugCheck(CACHE_MANAGER);
         }
 
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
         MmReferencePage(Page);
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         Status = MmCreateVirtualMapping(Process, Address, Attributes, &Page, 1);
         if (NT_SUCCESS(Status))

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -883,6 +883,28 @@ MiReleasePfnLock(
     KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
 }
 
+FORCEINLINE
+VOID
+MiAcquirePfnLockAtDpcLevel(VOID)
+{
+    PKSPIN_LOCK_QUEUE LockQueue;
+
+    ASSERT(KeGetCurrentIrql() >= DISPATCH_LEVEL);
+    LockQueue = &KeGetCurrentPrcb()->LockQueue[LockQueuePfnLock];
+    KeAcquireQueuedSpinLockAtDpcLevel(LockQueue);
+}
+
+FORCEINLINE
+VOID
+MiReleasePfnLockFromDpcLevel(VOID)
+{
+    PKSPIN_LOCK_QUEUE LockQueue;
+
+    LockQueue = &KeGetCurrentPrcb()->LockQueue[LockQueuePfnLock];
+    KeReleaseQueuedSpinLockFromDpcLevel(LockQueue);
+    ASSERT(KeGetCurrentIrql() >= DISPATCH_LEVEL);
+}
+
 #define MI_ASSERT_PFN_LOCK_HELD() ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL)
 
 FORCEINLINE

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -869,6 +869,23 @@ MmPageOutPhysicalAddress(PFN_NUMBER Page);
 /* freelist.c **********************************************************/
 
 FORCEINLINE
+KIRQL
+MiAcquirePfnLock(VOID)
+{
+    return KeAcquireQueuedSpinLock(LockQueuePfnLock);
+}
+
+FORCEINLINE
+VOID
+MiReleasePfnLock(
+    _In_ KIRQL OldIrql)
+{
+    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+}
+
+#define MI_ASSERT_PFN_LOCK_HELD() ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL)
+
+FORCEINLINE
 PMMPFN
 MiGetPfnEntry(IN PFN_NUMBER Pfn)
 {

--- a/ntoskrnl/mm/ARM3/contmem.c
+++ b/ntoskrnl/mm/ARM3/contmem.c
@@ -109,7 +109,7 @@ MiFindContiguousPages(IN PFN_NUMBER LowestPfn,
                 //
                 // Acquire the PFN lock
                 //
-                OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                OldIrql = MiAcquirePfnLock();
                 do
                 {
                     //
@@ -164,7 +164,7 @@ MiFindContiguousPages(IN PFN_NUMBER LowestPfn,
                         //
                         // Now it's safe to let go of the PFN lock
                         //
-                        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                        MiReleasePfnLock(OldIrql);
 
                         //
                         // Quick sanity check that the last PFN is consistent
@@ -196,7 +196,7 @@ MiFindContiguousPages(IN PFN_NUMBER LowestPfn,
                 // If we got here, something changed while we hadn't acquired
                 // the PFN lock yet, so we'll have to restart
                 //
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
                 Length = 0;
             }
         }
@@ -540,7 +540,7 @@ MiFreeContiguousMemory(IN PVOID BaseAddress)
     //
     // Lock the PFN database
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     //
     // Loop all the pages
@@ -556,7 +556,7 @@ MiFreeContiguousMemory(IN PVOID BaseAddress)
     //
     // Release the PFN lock
     //
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 }
 
 /* PUBLIC FUNCTIONS ***********************************************************/

--- a/ntoskrnl/mm/ARM3/dynamic.c
+++ b/ntoskrnl/mm/ARM3/dynamic.c
@@ -91,7 +91,7 @@ MmGetPhysicalMemoryRanges(VOID)
     //
     // Lock the PFN database
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     //
     // Make sure it hasn't changed before we had acquired the lock
@@ -121,6 +121,6 @@ MmGetPhysicalMemoryRanges(VOID)
     //
     // Release the lock and return
     //
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
     return Buffer;
 }

--- a/ntoskrnl/mm/ARM3/i386/init.c
+++ b/ntoskrnl/mm/ARM3/i386/init.c
@@ -487,7 +487,7 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     StartPde = MiAddressToPde(HYPER_SPACE);
 
     /* Lock PFN database */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     /* Allocate a page for hyperspace and create it */
     MI_SET_USAGE(MI_USAGE_PAGE_TABLE);
@@ -501,7 +501,7 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     KeFlushCurrentTb();
 
     /* Release the lock */
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     //
     // Zero out the page table now
@@ -532,7 +532,7 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     MiFirstReservedZeroingPte->u.Hard.PageFrameNumber = MI_ZERO_PTES - 1;
 
     /* Lock PFN database */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     /* Reset the ref/share count so that MmInitializeProcessAddressSpace works */
     Pfn1 = MiGetPfnEntry(PFN_FROM_PTE(MiAddressToPde(PDE_BASE)));
@@ -565,7 +565,7 @@ MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     }
 
     /* Release the lock */
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     /* Initialize the bogus address space */
     Flags = 0;

--- a/ntoskrnl/mm/ARM3/mdlsup.c
+++ b/ntoskrnl/mm/ARM3/mdlsup.c
@@ -218,9 +218,9 @@ MiMapLockedPagesInUserSpace(
 
         /* Acquire a share count */
         Pfn1 = MI_PFN_ELEMENT(PointerPde->u.Hard.PageFrameNumber);
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
         Pfn1->u2.ShareCount++;
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         /* Next page */
         MdlPages++;
@@ -293,7 +293,7 @@ MiUnmapLockedPagesInUserSpace(
     ASSERT(Process->VadRoot.NodeHint != Vad);
 
     PointerPte = MiAddressToPte(BaseAddress);
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
     while (NumberOfPages != 0 &&
            *MdlPages != LIST_HEAD)
     {
@@ -336,7 +336,7 @@ MiUnmapLockedPagesInUserSpace(
     }
 
     KeFlushProcessTb();
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
     MiUnlockProcessWorkingSetUnsafe(Process, Thread);
     MmUnlockAddressSpace(&Process->Vm);
     ExFreePoolWithTag(Vad, 'ldaV');
@@ -560,7 +560,7 @@ MmFreePagesFromMdl(IN PMDL Mdl)
     //
     // Acquire PFN lock
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     //
     // Loop all the MDL pages
@@ -618,7 +618,7 @@ MmFreePagesFromMdl(IN PMDL Mdl)
     //
     // Release the lock
     //
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     //
     // Remove the pages locked flag
@@ -1121,7 +1121,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
         // Use the PFN lock
         //
         UsePfnLock = TRUE;
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
     }
     else
     {
@@ -1180,7 +1180,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
                 //
                 // Release PFN lock
                 //
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
             }
             else
             {
@@ -1212,7 +1212,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
                 //
                 // Grab the PFN lock
                 //
-                OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                OldIrql = MiAcquirePfnLock();
             }
             else
             {
@@ -1250,7 +1250,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
                             //
                             // Release PFN lock
                             //
-                            KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                            MiReleasePfnLock(OldIrql);
                         }
                         else
                         {
@@ -1281,7 +1281,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
                             //
                             // Grab the PFN lock
                             //
-                            OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                            OldIrql = MiAcquirePfnLock();
                         }
                         else
                         {
@@ -1353,7 +1353,7 @@ MmProbeAndLockPages(IN PMDL Mdl,
         //
         // Release PFN lock
         //
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
     }
     else
     {
@@ -1381,7 +1381,7 @@ CleanupWithLock:
         //
         // Release PFN lock
         //
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
     }
     else
     {
@@ -1462,7 +1462,7 @@ MmUnlockPages(IN PMDL Mdl)
         //
         // Acquire PFN lock
         //
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
 
         //
         // Loop every page
@@ -1485,7 +1485,7 @@ MmUnlockPages(IN PMDL Mdl)
         //
         // Release the lock
         //
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         //
         // Check if we have a process
@@ -1564,7 +1564,7 @@ MmUnlockPages(IN PMDL Mdl)
     //
     // Now grab the PFN lock for the actual unlock and dereference
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
     do
     {
         /* Get the current entry and reference count */
@@ -1575,7 +1575,7 @@ MmUnlockPages(IN PMDL Mdl)
     //
     // Release the lock
     //
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     //
     // We're done

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -949,7 +949,7 @@ MiBuildPfnDatabaseFromLoaderBlock(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                 Pfn1 = MiGetPfnEntry(PageFrameIndex);
 
                 /* Lock the PFN Database */
-                OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                OldIrql = MiAcquirePfnLock();
                 while (PageCount--)
                 {
                     /* If the page really has no references, mark it as free */
@@ -966,7 +966,7 @@ MiBuildPfnDatabaseFromLoaderBlock(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                 }
 
                 /* Release PFN database */
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
 
                 /* Done with this block */
                 break;
@@ -1138,7 +1138,7 @@ MmFreeLoaderBlock(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     }
 
     /* Acquire the PFN lock */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     /* Loop the runs */
     LoaderPages = 0;
@@ -1180,7 +1180,7 @@ MmFreeLoaderBlock(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     /* Release the PFN lock and flush the TLB */
     DPRINT("Loader pages freed: %lx\n", LoaderPages);
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
     KeFlushCurrentTb();
 
     /* Free our run structure */
@@ -1829,7 +1829,7 @@ MiBuildPagedPool(VOID)
     //
     // Lock the PFN database
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
 #if (_MI_PAGING_LEVELS >= 3)
     /* On these systems, there's no double-mapping, so instead, the PPEs
@@ -1890,7 +1890,7 @@ MiBuildPagedPool(VOID)
     //
     // Release the PFN database lock
     //
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     //
     // We only have one PDE mapped for now... at fault time, additional PDEs

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -536,7 +536,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
             //
             // Lock the PFN database and loop pages
             //
-            OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+            OldIrql = MiAcquirePfnLock();
             do
             {
                 //
@@ -577,7 +577,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
             //
             // Release the PFN database lock
             //
-            KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+            MiReleasePfnLock(OldIrql);
 
             //
             // These pages are now available, clear their availablity bits

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -433,7 +433,6 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     PMMPFN Pfn1;
     PVOID BaseVa, BaseVaStart;
     PMMFREE_POOL_ENTRY FreeEntry;
-    PKSPIN_LOCK_QUEUE LockQueue;
 
     //
     // Figure out how big the allocation is in pages
@@ -844,8 +843,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     //
     // Lock the PFN database too
     //
-    LockQueue = &KeGetCurrentPrcb()->LockQueue[LockQueuePfnLock];
-    KeAcquireQueuedSpinLockAtDpcLevel(LockQueue);
+    MiAcquirePfnLockAtDpcLevel();
 
     //
     // Loop the pages
@@ -889,7 +887,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     //
     // Release the PFN and nonpaged pool lock
     //
-    KeReleaseQueuedSpinLockFromDpcLevel(LockQueue);
+    MiReleasePfnLockFromDpcLevel();
     KeReleaseQueuedSpinLock(LockQueueMmNonPagedPoolLock, OldIrql);
 
     //

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -176,7 +176,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
     DPRINT1("Loading: %wZ at %p with %lx pages\n", FileName, DriverBase, PteCount);
 
     /* Lock the PFN database */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     /* Loop the new driver PTEs */
     TempPte = ValidKernelPte;
@@ -213,7 +213,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
     }
 
     /* Release the PFN lock */
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     /* Copy the image */
     RtlCopyMemory(DriverBase, Base, PteCount << PAGE_SHIFT);

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -267,7 +267,7 @@ MiMakeSystemAddressValidPfn(IN PVOID VirtualAddress,
     while (!MmIsAddressValid(VirtualAddress))
     {
         /* Release the PFN database */
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         /* Fault it in */
         Status = MmAccessFault(FALSE, VirtualAddress, KernelMode, NULL);
@@ -285,7 +285,7 @@ MiMakeSystemAddressValidPfn(IN PVOID VirtualAddress,
         LockChange = TRUE;
 
         /* Lock the PFN database */
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
     }
 
     /* Let caller know what the lock state is */
@@ -337,7 +337,7 @@ MiDeleteSystemPageableVm(IN PMMPTE PointerPte,
                 Pfn2 = MiGetPfnEntry(PageTableIndex);
 
                 /* Lock the PFN database */
-                OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                OldIrql = MiAcquirePfnLock();
 
                 /* Delete it the page */
                 MI_SET_PFN_DELETED(Pfn1);
@@ -347,7 +347,7 @@ MiDeleteSystemPageableVm(IN PMMPTE PointerPte,
                 MiDecrementShareCount(Pfn2, PageTableIndex);
 
                 /* Release the PFN database */
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
 
                 /* Destroy the PTE */
                 MI_ERASE_PTE(PointerPte);
@@ -399,7 +399,7 @@ MiDeletePte(IN PMMPTE PointerPte,
     PMMPDE PointerPde;
 
     /* PFN lock must be held */
-    ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL);
+    MI_ASSERT_PFN_LOCK_HELD();
 
     /* Capture the PTE */
     TempPte = *PointerPte;
@@ -626,7 +626,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
         }
 
         /* Lock the PFN Database while we delete the PTEs */
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
         do
         {
             /* Capture the PDE and make sure it exists */
@@ -708,7 +708,7 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
         }
 
         /* Release the lock and get out if we're done */
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
         if (Va > EndingAddress) return;
 
         /* Otherwise, we exited because we hit a new PDE boundary, so start over */
@@ -1379,7 +1379,7 @@ MiGetPageProtection(IN PMMPTE PointerPte)
         {
             /* The PTE is valid, so we might need to get the protection from
                the PFN. Lock the PFN database */
-            OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+            OldIrql = MiAcquirePfnLock();
 
             /* Check if the PDE is still valid */
             if (MiAddressToPte(PointerPte)->u.Hard.Valid == 0)
@@ -1407,7 +1407,7 @@ MiGetPageProtection(IN PMMPTE PointerPte)
             }
 
             /* Release the PFN database */
-            KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+            MiReleasePfnLock(OldIrql);
         }
 
         /* Lock the working set again */
@@ -2301,7 +2301,7 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
                 if ((NewAccessProtection & PAGE_NOACCESS) ||
                     (NewAccessProtection & PAGE_GUARD))
                 {
-                    KIRQL OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                    KIRQL OldIrql = MiAcquirePfnLock();
 
                     /* Mark the PTE as transition and change its protection */
                     PteContents.u.Hard.Valid = 0;
@@ -2318,7 +2318,7 @@ MiProtectVirtualMemory(IN PEPROCESS Process,
                     KeInvalidateTlbEntry(MiPteToAddress(PointerPte));
 
                     /* We are done for this PTE */
-                    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                    MiReleasePfnLock(OldIrql);
                 }
                 else
                 {
@@ -2459,7 +2459,7 @@ MiProcessValidPteList(IN PMMPTE *ValidPteList,
     //
     // Acquire the PFN lock and loop all the PTEs in the list
     //
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
     for (i = 0; i != Count; i++)
     {
         //
@@ -2494,7 +2494,7 @@ MiProcessValidPteList(IN PMMPTE *ValidPteList,
     // and then release the PFN lock
     //
     KeFlushCurrentTb();
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 }
 
 ULONG

--- a/ntoskrnl/mm/ARM3/zeropage.c
+++ b/ntoskrnl/mm/ARM3/zeropage.c
@@ -67,7 +67,7 @@ MmZeroPageThread(VOID)
                                  FALSE,
                                  NULL,
                                  NULL);
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
         MmZeroingPageThreadActive = TRUE;
 
         while (TRUE)
@@ -75,7 +75,7 @@ MmZeroPageThread(VOID)
             if (!MmFreePageListHead.Total)
             {
                 MmZeroingPageThreadActive = FALSE;
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
                 break;
             }
 
@@ -97,14 +97,14 @@ MmZeroPageThread(VOID)
             }
 
             Pfn1->u1.Flink = LIST_HEAD;
-            KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+            MiReleasePfnLock(OldIrql);
 
             ZeroAddress = MiMapPagesInZeroSpace(Pfn1, 1);
             ASSERT(ZeroAddress);
             RtlZeroMemory(ZeroAddress, PAGE_SIZE);
             MiUnmapPagesInZeroSpace(ZeroAddress, 1);
 
-            OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+            OldIrql = MiAcquirePfnLock();
 
             MiInsertPageInList(&MmZeroedPageListHead, PageIndex);
         }

--- a/ntoskrnl/mm/amd64/page.c
+++ b/ntoskrnl/mm/amd64/page.c
@@ -165,7 +165,7 @@ MiGetPteForProcess(
         TmplPte.u.Flush.Owner = (Address < MmHighestUserAddress) ? 1 : 0;
 
         /* Lock the PFN database */
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
 
         /* Get the PXE */
         Pte = MiAddressToPxe(Address);
@@ -192,7 +192,7 @@ MiGetPteForProcess(
         }
 
         /* Unlock PFN database */
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
     }
     else
     {
@@ -610,7 +610,7 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     KeInitializeSpinLock(&Process->HyperSpaceLock);
 
     /* Lock PFN database */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+    OldIrql = MiAcquirePfnLock();
 
     /* Get a page for the table base and one for hyper space. The PFNs for
        these pages will be initialized in MmInitializeProcessAddressSpace,
@@ -622,7 +622,7 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     WorkingSetPfn = MiRemoveAnyPage(MI_GET_NEXT_PROCESS_COLOR(Process));
 
     /* Release PFN lock */
-    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     /* Zero pages */ /// FIXME:
     MiZeroPhysicalPage(HyperPfn);

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -357,7 +357,7 @@ MiBalancerThread(PVOID Unused)
                 PEPROCESS Process = PsGetCurrentProcess();
 
                 /* Acquire PFN lock */
-                KIRQL OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                KIRQL OldIrql = MiAcquirePfnLock();
                 PMMPDE pointerPde;
                 for (Address = (ULONG_PTR)MI_LOWEST_VAD_ADDRESS;
                         Address < (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS;
@@ -372,7 +372,7 @@ MiBalancerThread(PVOID Unused)
                     }
                 }
                 /* Release lock */
-                KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                MiReleasePfnLock(OldIrql);
             }
 #endif
             do
@@ -410,7 +410,7 @@ BOOLEAN MmRosNotifyAvailablePage(PFN_NUMBER Page)
     PMMPFN Pfn1;
 
     /* Make sure the PFN lock is held */
-    ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL);
+    MI_ASSERT_PFN_LOCK_HELD();
 
     if (!MiMinimumAvailablePages)
     {

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -332,12 +332,12 @@ MmFreeMemoryArea(
                 if (MiQueryPageTableReferences((PVOID)Address) == 0)
                 {
                     /* No PTE relies on this PDE. Release it */
-                    KIRQL OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+                    KIRQL OldIrql = MiAcquirePfnLock();
                     PMMPDE PointerPde = MiAddressToPde(Address);
                     ASSERT(PointerPde->u.Hard.Valid == 1);
                     MiDeletePte(PointerPde, MiPdeToPte(PointerPde), Process, NULL);
                     ASSERT(PointerPde->u.Hard.Valid == 0);
-                    KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+                    MiReleasePfnLock(OldIrql);
                 }
             }
 #endif
@@ -594,7 +594,7 @@ MmDeleteProcessAddressSpace(PEPROCESS Process)
         KeAttachProcess(&Process->Pcb);
 
         /* Acquire PFN lock */
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
 
         for (Address = MI_LOWEST_VAD_ADDRESS;
                 Address < MM_HIGHEST_VAD_ADDRESS;
@@ -619,7 +619,7 @@ MmDeleteProcessAddressSpace(PEPROCESS Process)
         }
 
         /* Release lock */
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         /* Detach */
         KeDetachProcess();

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -1982,9 +1982,9 @@ MmPageOutSectionView(PMMSUPPORT AddressSpace,
     }
     else
     {
-        OldIrql = KeAcquireQueuedSpinLock(LockQueuePfnLock);
+        OldIrql = MiAcquirePfnLock();
         MmReferencePage(Page);
-        KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
+        MiReleasePfnLock(OldIrql);
     }
 
     MmDeleteAllRmaps(Page, (PVOID)&Context, MmPageOutDeleteMapping);


### PR DESCRIPTION
Spin locks don't deadlock on UP, so this will allow better debugging.