### PR TITLE
[BROWSEUI] Improve relative path handling for explorer

### DIFF
--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -382,6 +382,12 @@ SHExplorerParseCmdLine(ExplorerCommandLineParseResults * pInfo)
             {
                 // Or just a plain old string.
 
+                WCHAR szPath[MAX_PATH];
+                DWORD result = GetFullPathNameW(strField, _countof(szPath), szPath, NULL);
+
+                if (result != 0 && result <= _countof(szPath) && PathFileExistsW(szPath))
+                    StringCchCopyW(strField, _countof(strField), szPath);
+
                 LPITEMIDLIST pidlPath = ILCreateFromPathW(strField);
 
                 pInfo->pidlPath = pidlPath;

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -45,6 +45,37 @@ UINT (WINAPI *SHExplorerParseCmdLine)(_Out_ PEXPLORER_INFO Info);
 
 #define InvalidPointer ((PVOID)0x5555555555555555ULL)
 
+DWORD ReplaceSubstr(
+_Out_ PWCHAR OutputStr,
+_In_ DWORD OutputLen,
+_In_ PCWSTR InputStr,
+_In_ PCWSTR ReplaceStr,
+_In_ PCWSTR ReplaceWith)
+{
+    DWORD result = 0;
+    PCWSTR pos;
+    PCWSTR pwc;
+
+    if (!OutputLen)
+        return result;
+
+    OutputStr[0] = 0;
+    pos = InputStr;
+    pwc = wcsstr(pos, ReplaceStr);
+    while (pwc)
+    {
+        if (StringCchCatNW(OutputStr, OutputLen, pos, pwc - pos) == STRSAFE_E_INSUFFICIENT_BUFFER)
+            break;
+        if (StringCchCatW(OutputStr, OutputLen, ReplaceWith) == STRSAFE_E_INSUFFICIENT_BUFFER)
+            break;
+        result++;
+        pos = pwc + wcslen(ReplaceStr);
+        pwc = wcsstr(pos, ReplaceStr);
+    }
+    StringCchCatW(OutputStr, OutputLen, pos);
+    return result;
+}
+
 static
 VOID
 TestCommandLine(
@@ -97,6 +128,33 @@ _Out_opt_ PUINT PWriteEnd)
         if (Info.pidl != NULL && Info.pidl != InvalidPointer)
         {
             WCHAR pidlPathName[MAX_PATH] = L"";
+            WCHAR pidlPathTest[MAX_PATH] = L"";
+            WCHAR rootDir[MAX_PATH] = L"";
+            WCHAR curDir[MAX_PATH] = L"";
+            WCHAR replaceName[MAX_PATH];
+
+            GetFullPathNameW(L"\\", _countof(rootDir), rootDir, NULL);
+
+            GetCurrentDirectoryW(_countof(curDir), curDir);
+            if (wcslen(curDir) != 0 && curDir[wcslen(curDir) - 1] != L'\\')
+                StringCchCatW(curDir, _countof(curDir), L"\\");
+
+            if (PidlPath)
+            {
+                StringCchCopyW(pidlPathTest, _countof(pidlPathTest), PidlPath);
+
+                if (wcsstr(pidlPathTest, L"::ROOT::") != NULL && wcslen(rootDir) > 0)
+                {
+                    if (ReplaceSubstr(replaceName, _countof(replaceName), pidlPathTest, L"::ROOT::", rootDir))
+                        StringCchCopyW(pidlPathTest, _countof(pidlPathTest), replaceName);
+                }
+
+                if (wcsstr(pidlPathTest, L"::CURDIR::") != NULL && wcslen(curDir) > 0)
+                {
+                    if (ReplaceSubstr(replaceName, _countof(replaceName), pidlPathTest, L"::CURDIR::", curDir))
+                        StringCchCopyW(pidlPathTest, _countof(pidlPathTest), replaceName);
+                }
+            }
 
             if (Info.pidl != NULL && Info.pidl != (LPITEMIDLIST) 0x55555555)
             {
@@ -105,7 +163,7 @@ _Out_opt_ PUINT PWriteEnd)
 
             if (ExpectedCsidl == PIDL_PATH_EQUALS_PATH)
             {
-                ok(wcsicmp(pidlPathName, PidlPath) == 0, "Path from pidl does not match; pidlPathName=%S\n", pidlPathName);
+                ok(wcsicmp(pidlPathName, pidlPathTest) == 0, "Path from pidl does not match; pidlPathName=%S\n", pidlPathName);
             }
             else if (ExpectedCsidl == PIDL_IS_EMPTY)
             {
@@ -115,12 +173,12 @@ _Out_opt_ PUINT PWriteEnd)
             {
                 if (ExpectedCsidl == PIDL_IS_PATH)
                 {
-                    ExpectedPidl = SHSimpleIDListFromPath(PidlPath);
+                    ExpectedPidl = SHSimpleIDListFromPath(pidlPathTest);
                     hr = ExpectedPidl == NULL ? E_FAIL : S_OK;
-                    ok(ExpectedPidl != NULL, "SHSimpleIDListFromPath(%S) failed. pidlPathName=%S\n", PidlPath, pidlPathName);
+                    ok(ExpectedPidl != NULL, "SHSimpleIDListFromPath(%S) failed. pidlPathName=%S\n", pidlPathTest, pidlPathName);
                     if (SUCCEEDED(hr))
                     {
-                        ok(ILIsEqual(Info.pidl, ExpectedPidl), "Unexpected pidl value %p; pidlPathName=%S PidlPath=%S\n", Info.pidl, pidlPathName, PidlPath);
+                        ok(ILIsEqual(Info.pidl, ExpectedPidl), "Unexpected pidl value %p; pidlPathName=%S pidlPathTest=%S\n", Info.pidl, pidlPathName, pidlPathTest);
                         ILFree(ExpectedPidl);
                     }
                 }
@@ -209,6 +267,7 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"%wrongdir%", TRUE, PIDL_IS_NULL, 0x02000000, L"%wrongdir%"},
         { __LINE__, L"%programfiles#", TRUE, PIDL_IS_NULL, 0x02000000, L"%programfiles#"},
         { __LINE__, L",", TRUE, PIDL_IS_EMPTY, 0x00000200},
+        { __LINE__, L"\\", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"::ROOT::" }, // disk letter depends on current directory
         { __LINE__, L"c:\\", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\" },
         { __LINE__, L"c:", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\" },
         { __LINE__, L"c", TRUE, PIDL_IS_NULL, 0x02000000, L"c"},
@@ -216,9 +275,12 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"c:\\Program Files\\", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
         { __LINE__, L"c:\\Program Files/", TRUE, PIDL_IS_NULL, 0x02000000, L"c:\\Program Files/"},
         { __LINE__, L"c:/Program Files/", TRUE, PIDL_IS_NULL, 0x02000000, L"c:/Program Files/"},
-        { __LINE__, L"fonts", TRUE, PIDL_IS_NULL, 0x02000000, L"fonts" },
-        { __LINE__, L"winsxs", TRUE, PIDL_IS_NULL, 0x02000000, L"winsxs" },
-        { __LINE__, L"system32", TRUE, PIDL_IS_NULL, 0x02000000, L"system32" },
+        { __LINE__, L"fonts", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"::CURDIR::fonts" }, // this would not fail if we are in Windows directory
+        { __LINE__, L"winsxs", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"::CURDIR::winsxs" },
+        { __LINE__, L"system32", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"::CURDIR::system32" },
+        { __LINE__, L"drivers", TRUE, PIDL_IS_NULL, 0x02000000, L"drivers" }, // this would fail since we are not in system32 directory
+        { __LINE__, L"spool", TRUE, PIDL_IS_NULL, 0x02000000, L"spool" },
+        { __LINE__, L"wbem", TRUE, PIDL_IS_NULL, 0x02000000, L"wbem" },
         { __LINE__, TEST_PATHW, TRUE, PIDL_IS_PATH, 0x00000200, NULL, TEST_PATHW },
         { __LINE__, L"\"c:\\\"\"program files\"", TRUE, PIDL_IS_NULL, 0x02000000, L"c:\\\"program files"},
         { __LINE__, L"\"c:\\\"program files", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
@@ -345,6 +407,7 @@ START_TEST(SHExplorerParseCmdLine)
     int i;
     UINT maxWrite = 0;
     FILE * ff;
+    WCHAR winDir[MAX_PATH];
 
     HMODULE browseui = LoadLibraryA("browseui.dll");
     SHExplorerParseCmdLine = (UINT (__stdcall *)(PEXPLORER_INFO))GetProcAddress(browseui, MAKEINTRESOURCEA(107));
@@ -359,6 +422,9 @@ START_TEST(SHExplorerParseCmdLine)
 
     ff = fopen(TEST_PATHA, "wb");
     fclose(ff);
+
+    GetWindowsDirectoryW(winDir, _countof(winDir));
+    SetCurrentDirectoryW(winDir);
 
     for (i = 0; i < TestCount; i++)
     {

--- a/modules/rostests/apitests/shell32/SHParseDisplayName.cpp
+++ b/modules/rostests/apitests/shell32/SHParseDisplayName.cpp
@@ -46,7 +46,11 @@ struct test_data Tests[] =
     {__LINE__, L" :", NULL, 0, E_INVALIDARG, 0},
     {__LINE__, L"/", NULL, 0, E_INVALIDARG, 0},
     {__LINE__, L"//", NULL, 0, E_INVALIDARG, 0},
+    /* This opens C:\ from Win+R and address bar */
     {__LINE__, L"\\", NULL, 0, E_INVALIDARG, 0},
+    /* These two opens "C:\Program Files" from Win+R and address bar */
+    {__LINE__, L"\\Program Files", NULL, 0, E_INVALIDARG, 0},
+    {__LINE__, L"\\Program Files\\", NULL, 0, E_INVALIDARG, 0},
     {__LINE__, L"\\\\?", NULL, 0, E_INVALIDARG, 0},
     {__LINE__, L"\\\\?\\", NULL, 0, E_INVALIDARG, 0},
     /* Tests for the shell: protocol */
@@ -139,6 +143,7 @@ UINT get_host_os_flag()
 START_TEST(SHParseDisplayName)
 {
     HRESULT hr;
+    WCHAR winDir[MAX_PATH];
     UINT os_flag = get_host_os_flag();
     ok (os_flag != 0, "Incompatible os version %d!", os_flag);
     if (os_flag == 0)
@@ -147,6 +152,9 @@ START_TEST(SHParseDisplayName)
     IShellFolder *psfDesktop;
     hr = SHGetDesktopFolder(&psfDesktop);
     ok(hr == S_OK, "hr = %lx\n", hr);
+
+    GetWindowsDirectoryW(winDir, _countof(winDir));
+    SetCurrentDirectoryW(winDir);
 
     for (UINT i = 0; i < _countof(Tests); i ++)
     {


### PR DESCRIPTION
## Purpose

Explorer should be able to parse relative paths specified in command line parameter, including paths from root directory (beginning with `\`) or from current directory.

JIRA issues: [CORE-12882](https://jira.reactos.org/browse/CORE-12882), [CORE-13847](https://jira.reactos.org/browse/CORE-13847)

This PR was expected to fix first issue, but it also **partially** fixes the second too! Partially because it allows to open `Fonts` folder, but not all available folders in a `PATH` environment variable.

## Proposed changes

- Fix SHExplorerParseCmdLine tests according to Windows 2003 behaviour
- Modify SHExplorerParseCmdLine to allow parsing relative paths from root or current directory
- Add more SHParseDisplayName tests to show that changes makes sense

Cc @yagoulas 