### PR TITLE
Add SEH/probes to user-accessible kdbg functions

### DIFF
--- a/ntoskrnl/include/internal/kd.h
+++ b/ntoskrnl/include/internal/kd.h
@@ -199,10 +199,11 @@ KdpPrintString(
 ULONG
 NTAPI
 KdpPrompt(
-    IN LPSTR InString,
-    IN USHORT InStringLength,
-    OUT LPSTR OutString,
-    IN USHORT OutStringLength
+    _In_reads_bytes_(InStringLength) PCHAR UnsafeInString,
+    _In_ USHORT InStringLength,
+    _Out_writes_bytes_(OutStringLength) PCHAR UnsafeOutString,
+    _In_ USHORT OutStringLength,
+    _In_ KPROCESSOR_MODE PreviousMode
 );
 
 BOOLEAN

--- a/ntoskrnl/include/internal/kd.h
+++ b/ntoskrnl/include/internal/kd.h
@@ -193,8 +193,8 @@ KdpCallGdb(
 ULONG
 NTAPI
 KdpPrintString(
-    LPSTR String,
-    ULONG Length);
+    _In_reads_bytes_(Length) PCHAR UnsafeString,
+    _In_ ULONG Length);
 
 ULONG
 NTAPI

--- a/ntoskrnl/kd/kdmain.c
+++ b/ntoskrnl/kd/kdmain.c
@@ -175,7 +175,8 @@ KdpEnterDebuggerException(IN PKTRAP_FRAME TrapFrame,
                                     (USHORT)ExceptionRecord->
                                     ExceptionInformation[2],
                                     OutString,
-                                    OutStringLength);
+                                    OutStringLength,
+                                    PreviousMode);
 
             /* Return the number of characters that we received */
             Context->Eax = ReturnValue;


### PR DESCRIPTION
## Purpose

Fix bugcheck when running ntdll_winetest:exception.

JIRA issue: [CORE-14057](https://jira.reactos.org/browse/CORE-14057)

This is in "working" state but will need some cleanup (consistency, comments etc).