### PR TITLE
[CMD] Add missing memory allocation NULL checks. CORE-8304

### DIFF
--- a/base/shell/cmd/alias.c
+++ b/base/shell/cmd/alias.c
@@ -64,7 +64,10 @@ PrintAlias (VOID)
     /* allocate memory for an extra \0 char to make parsing easier */
     ptr = cmd_alloc(len + sizeof(TCHAR));
     if (!ptr)
+    {
+        WARN("Cannot allocate memory for ptr!\n");
         return;
+    }
 
     Aliases = ptr;
 
@@ -107,6 +110,7 @@ VOID ExpandAlias (LPTSTR cmd, INT maxlen)
     buffer = cmd_alloc(maxlen);
     if (!buffer)
     {
+        WARN("Cannot allocate memory for alias buffer!\n");
         cmd_free(tmp);
         return;
     }

--- a/base/shell/cmd/batch.c
+++ b/base/shell/cmd/batch.c
@@ -110,13 +110,14 @@ LPTSTR FindArg(TCHAR Char, BOOL *IsParam0)
  *
  */
 
-LPTSTR BatchParams (LPTSTR s1, LPTSTR s2)
+LPTSTR BatchParams(LPTSTR s1, LPTSTR s2)
 {
     LPTSTR dp = (LPTSTR)cmd_alloc ((_tcslen(s1) + _tcslen(s2) + 3) * sizeof (TCHAR));
 
     /* JPP 20-Jul-1998 added error checking */
     if (dp == NULL)
     {
+        WARN("Cannot allocate memory for dp!\n");
         error_out_of_memory();
         return NULL;
     }
@@ -158,7 +159,7 @@ LPTSTR BatchParams (LPTSTR s1, LPTSTR s2)
 /*
  * free the allocated memory of a batch file
  */
-VOID ClearBatch()
+VOID ClearBatch(VOID)
 {
     TRACE ("ClearBatch  mem = %08x    free = %d\n", bc->mem, bc->memfree);
 
@@ -182,7 +183,7 @@ VOID ClearBatch()
  * message
  */
 
-VOID ExitBatch()
+VOID ExitBatch(VOID)
 {
     ClearBatch();
 
@@ -234,7 +235,7 @@ void BatchFile2Mem(HANDLE hBatchFile)
  * The firstword parameter is the full filename of the batch file.
  *
  */
-INT Batch (LPTSTR fullname, LPTSTR firstword, LPTSTR param, PARSED_COMMAND *Cmd)
+INT Batch(LPTSTR fullname, LPTSTR firstword, LPTSTR param, PARSED_COMMAND *Cmd)
 {
     BATCH_CONTEXT new;
     LPFOR_CONTEXT saved_fc;
@@ -396,12 +397,18 @@ VOID AddBatchRedirection(REDIRECTION **RedirList)
  *   Read a single line from the batch file from the current batch/memory position.
  *   Almost a copy of FileGetString with same UNICODE handling
  */
-BOOL BatchGetString (LPTSTR lpBuffer, INT nBufferLength)
+BOOL BatchGetString(LPTSTR lpBuffer, INT nBufferLength)
 {
     LPSTR lpString;
     INT len = 0;
 #ifdef _UNICODE
     lpString = cmd_alloc(nBufferLength);
+    if (!lpString)
+    {
+        WARN("Cannot allocate memory for lpString\n");
+        error_out_of_memory();
+        return FALSE;
+    }
 #else
     lpString = lpBuffer;
 #endif
@@ -443,7 +450,7 @@ BOOL BatchGetString (LPTSTR lpBuffer, INT nBufferLength)
  *
  * Set eflag to 0 if line is not to be echoed else 1
  */
-LPTSTR ReadBatchLine ()
+LPTSTR ReadBatchLine(VOID)
 {
     TRACE ("ReadBatchLine ()\n");
 

--- a/base/shell/cmd/batch.h
+++ b/base/shell/cmd/batch.h
@@ -45,10 +45,10 @@ extern BOOL bEcho;       /* The echo flag */
 extern TCHAR textline[BATCH_BUFFSIZE]; /* Buffer for reading Batch file lines */
 
 
-LPTSTR FindArg (TCHAR, BOOL *);
-LPTSTR BatchParams (LPTSTR, LPTSTR);
-VOID   ExitBatch (VOID);
-INT    Batch (LPTSTR, LPTSTR, LPTSTR, PARSED_COMMAND *);
-BOOL   BatchGetString (LPTSTR lpBuffer, INT nBufferLength);
+LPTSTR FindArg(TCHAR, BOOL *);
+LPTSTR BatchParams(LPTSTR, LPTSTR);
+VOID   ExitBatch(VOID);
+INT    Batch(LPTSTR, LPTSTR, LPTSTR, PARSED_COMMAND *);
+BOOL   BatchGetString(LPTSTR lpBuffer, INT nBufferLength);
 LPTSTR ReadBatchLine(VOID);
 VOID   AddBatchRedirection(REDIRECTION **);

--- a/base/shell/cmd/cmd.h
+++ b/base/shell/cmd/cmd.h
@@ -214,12 +214,12 @@ INT cmd_goto (LPTSTR);
 /* Prototypes for HISTORY.C */
 #ifdef FEATURE_HISTORY
 LPCTSTR PeekHistory(INT);
-VOID History (INT, LPTSTR);/*add entries browse history*/
+VOID History(INT, LPTSTR);/*add entries browse history*/
 VOID History_move_to_bottom(VOID);/*F3*/
 VOID InitHistory(VOID);
 VOID CleanHistory(VOID);
 VOID History_del_current_entry(LPTSTR str);/*CTRL-D*/
-INT CommandHistory (LPTSTR param);
+INT CommandHistory(LPTSTR param);
 #endif
 
 /* Prototypes for IF.C */

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -245,7 +245,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
 #ifdef FEATURE_HISTORY
                         /* add to the history */
                         if (str[0])
-                            History (0, str);
+                            History(0, str);
 #endif /*FEATURE_HISTORY*/
                         str[charcount++] = _T('\n');
                         str[charcount] = _T('\0');
@@ -479,7 +479,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
 #ifdef FEATURE_HISTORY
                 /* add to the history */
                 if (str[0])
-                    History (0, str);
+                    History(0, str);
 #endif
                 str[charcount++] = _T('\n');
                 str[charcount] = _T('\0');
@@ -503,7 +503,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
 #ifdef FEATURE_HISTORY
                 /* get previous command from buffer */
                 ClearCommandLine (str, maxlen, orgx, orgy);
-                History (-1, str);
+                History(-1, str);
                 current = charcount = _tcslen (str);
                 if (((charcount + orgx) / maxx) + orgy > maxy - 1)
                     orgy += maxy - ((charcount + orgx) / maxx + orgy + 1);
@@ -516,7 +516,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
 #ifdef FEATURE_HISTORY
                 /* get next command from buffer */
                 ClearCommandLine (str, maxlen, orgx, orgy);
-                History (1, str);
+                History(1, str);
                 current = charcount = _tcslen (str);
                 if (((charcount + orgx) / maxx) + orgy > maxy - 1)
                     orgy += maxy - ((charcount + orgx) / maxx + orgy + 1);

--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1390,7 +1390,7 @@ DirList(IN OUT LPTSTR szFullPath,   /* [IN] The full path we are listing with tr
     ptrStartNode = cmd_alloc(sizeof(DIRFINDLISTNODE));
     if (ptrStartNode == NULL)
     {
-        WARN("DEBUG: Cannot allocate memory for ptrStartNode!\n");
+        WARN("Cannot allocate memory for ptrStartNode!\n");
         return 1;   /* Error cannot allocate memory for 1st object */
     }
     ptrStartNode->stInfo.ptrHead = NULL;
@@ -1408,7 +1408,7 @@ DirList(IN OUT LPTSTR szFullPath,   /* [IN] The full path we are listing with tr
                 ptrNextNode->ptrNext = cmd_alloc(sizeof(DIRFINDLISTNODE));
                 if (ptrNextNode->ptrNext == NULL)
                 {
-                    WARN("DEBUG: Cannot allocate memory for ptrNextNode->ptrNext!\n");
+                    WARN("Cannot allocate memory for ptrNextNode->ptrNext!\n");
                     DirNodeCleanup(ptrStartNode, &dwCount);
                     FindClose(hSearch);
                     return 1;
@@ -1458,7 +1458,7 @@ DirList(IN OUT LPTSTR szFullPath,   /* [IN] The full path we are listing with tr
                             *ptrCurNode = cmd_alloc(sizeof(DIRFINDSTREAMNODE));
                             if (*ptrCurNode == NULL)
                             {
-                                WARN("DEBUG: Cannot allocate memory for *ptrCurNode!\n");
+                                WARN("Cannot allocate memory for *ptrCurNode!\n");
                                 DirNodeCleanup(ptrStartNode, &dwCount);
                                 FindClose(hStreams);
                                 FindClose(hSearch);
@@ -1512,7 +1512,7 @@ DirList(IN OUT LPTSTR szFullPath,   /* [IN] The full path we are listing with tr
     ptrFileArray = cmd_alloc(sizeof(PDIRFINDINFO) * dwCount);
     if (ptrFileArray == NULL)
     {
-        WARN("DEBUG: Cannot allocate memory for ptrFileArray!\n");
+        WARN("Cannot allocate memory for ptrFileArray!\n");
         DirNodeCleanup(ptrStartNode, &dwCount);
         return 1;
     }

--- a/base/shell/cmd/dirstack.c
+++ b/base/shell/cmd/dirstack.c
@@ -37,7 +37,8 @@ PushDirectory (LPTSTR pszPath)
     LPDIRENTRY lpDir = cmd_alloc(FIELD_OFFSET(DIRENTRY, szPath[_tcslen(pszPath) + 1]));
     if (!lpDir)
     {
-        error_out_of_memory ();
+        WARN("Cannot allocate memory for lpDir\n");
+        error_out_of_memory();
         return -1;
     }
 

--- a/base/shell/cmd/for.c
+++ b/base/shell/cmd/for.c
@@ -96,9 +96,13 @@ static LPTSTR ReadFileContents(FILE *InputFile, TCHAR *Buffer)
 {
     SIZE_T Len = 0;
     SIZE_T AllocLen = 1000;
+
     LPTSTR Contents = cmd_alloc(AllocLen * sizeof(TCHAR));
     if (!Contents)
+    {
+        WARN("Cannot allocate memory for Contents!\n");
         return NULL;
+    }
 
     while (_fgetts(Buffer, CMDLINE_LENGTH, InputFile))
     {
@@ -109,6 +113,7 @@ static LPTSTR ReadFileContents(FILE *InputFile, TCHAR *Buffer)
             Contents = cmd_realloc(Contents, (AllocLen *= 2) * sizeof(TCHAR));
             if (!Contents)
             {
+                WARN("Cannot reallocate memory for Contents!\n");
                 cmd_free(OldContents);
                 return NULL;
             }
@@ -454,7 +459,7 @@ static INT ForRecursive(PARSED_COMMAND *Cmd, LPTSTR List, TCHAR *Buffer, TCHAR *
     return Ret;
 }
 
-BOOL
+INT
 ExecuteFor(PARSED_COMMAND *Cmd)
 {
     TCHAR Buffer[CMDLINE_LENGTH]; /* Buffer to hold the variable value */
@@ -470,6 +475,7 @@ ExecuteFor(PARSED_COMMAND *Cmd)
     lpNew = cmd_alloc(sizeof(FOR_CONTEXT));
     if (!lpNew)
     {
+        WARN("Cannot allocate memory for lpNew!\n");
         cmd_free(List);
         return 1;
     }

--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -188,18 +188,20 @@ BOOL add_entry (LPINT ac, LPTSTR **arg, LPCTSTR entry)
     LPTSTR *oldarg;
 
     q = cmd_alloc ((_tcslen(entry) + 1) * sizeof (TCHAR));
-    if (NULL == q)
+    if (!q)
     {
+        WARN("Cannot allocate memory for q!\n");
         return FALSE;
     }
 
     _tcscpy (q, entry);
     oldarg = *arg;
     *arg = cmd_realloc (oldarg, (*ac + 2) * sizeof (LPTSTR));
-    if (NULL == *arg)
+    if (!*arg)
     {
-        cmd_free (q);
+        WARN("Cannot reallocate memory for arg!\n");
         *arg = oldarg;
+        cmd_free (q);
         return FALSE;
     }
 
@@ -222,8 +224,9 @@ static BOOL expand (LPINT ac, LPTSTR **arg, LPCTSTR pattern)
     if (NULL != pathend)
     {
         dirpart = cmd_alloc((pathend - pattern + 2) * sizeof(TCHAR));
-        if (NULL == dirpart)
+        if (!dirpart)
         {
+            WARN("Cannot allocate memory for dirpart!\n");
             return FALSE;
         }
         memcpy(dirpart, pattern, pathend - pattern + 1);
@@ -241,8 +244,9 @@ static BOOL expand (LPINT ac, LPTSTR **arg, LPCTSTR pattern)
             if (NULL != dirpart)
             {
                 fullname = cmd_alloc((_tcslen(dirpart) + _tcslen(FindData.cFileName) + 1) * sizeof(TCHAR));
-                if (NULL == fullname)
+                if (!fullname)
                 {
+                    WARN("Cannot allocate memory for fullname!\n");
                     ok = FALSE;
                 }
                 else
@@ -286,7 +290,10 @@ LPTSTR *split (LPTSTR s, LPINT args, BOOL expand_wildcards, BOOL handle_plus)
 
     arg = cmd_alloc (sizeof (LPTSTR));
     if (!arg)
+    {
+        WARN("Cannot allocate memory for arg!\n");
         return NULL;
+    }
     *arg = NULL;
 
     ac = 0;
@@ -333,6 +340,7 @@ LPTSTR *split (LPTSTR s, LPINT args, BOOL expand_wildcards, BOOL handle_plus)
             q = cmd_alloc (((len = s - start) + 1) * sizeof (TCHAR));
             if (!q)
             {
+                WARN("Cannot allocate memory for q!\n");
                 return NULL;
             }
             memcpy (q, start, len * sizeof (TCHAR));
@@ -381,7 +389,10 @@ LPTSTR *splitspace (LPTSTR s, LPINT args)
 
     arg = cmd_alloc (sizeof (LPTSTR));
     if (!arg)
+    {
+        WARN("Cannot allocate memory for arg!\n");
         return NULL;
+    }
     *arg = NULL;
 
     ac = 0;
@@ -409,6 +420,7 @@ LPTSTR *splitspace (LPTSTR s, LPINT args)
             q = cmd_alloc (((len = s - start) + 1) * sizeof (TCHAR));
             if (!q)
             {
+                WARN("Cannot allocate memory for q!\n");
                 return NULL;
             }
             memcpy (q, start, len * sizeof (TCHAR));

--- a/base/shell/cmd/parser.c
+++ b/base/shell/cmd/parser.c
@@ -60,7 +60,7 @@ static TCHAR ParseChar(void)
     TCHAR Char;
 
     if (bParseError)
-        return CurChar = 0;
+        return (CurChar = 0);
 
 restart:
     /*
@@ -90,7 +90,7 @@ restart:
             }
         }
     }
-    return CurChar = Char;
+    return (CurChar = Char);
 }
 
 static void ParseError(void)
@@ -272,6 +272,11 @@ static BOOL ParseRedirection(REDIRECTION **List)
     }
 
     Redir = cmd_alloc(FIELD_OFFSET(REDIRECTION, Filename[_tcslen(Tok) + 1]));
+    if (!Redir)
+    {
+        WARN("Cannot allocate memory for Redir!\n");
+        goto fail;
+    }
     Redir->Next = NULL;
     Redir->OldHandle = INVALID_HANDLE_VALUE;
     Redir->Number = Number;
@@ -293,7 +298,15 @@ static PARSED_COMMAND *ParseCommandOp(int OpType);
 static PARSED_COMMAND *ParseBlock(REDIRECTION *RedirList)
 {
     PARSED_COMMAND *Cmd, *Sub, **NextPtr;
+
     Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+    if (!Cmd)
+    {
+        WARN("Cannot allocate memory for Cmd!\n");
+        ParseError();
+        FreeRedirection(RedirList);
+        return NULL;
+    }
     Cmd->Type = C_BLOCK;
     Cmd->Next = NULL;
     Cmd->Subcommands = NULL;
@@ -340,8 +353,16 @@ static PARSED_COMMAND *ParseBlock(REDIRECTION *RedirList)
 /* Parse an IF statement */
 static PARSED_COMMAND *ParseIf(void)
 {
-    PARSED_COMMAND *Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
     int Type;
+    PARSED_COMMAND *Cmd;
+
+    Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+    if (!Cmd)
+    {
+        WARN("Cannot allocate memory for Cmd!\n");
+        ParseError();
+        return NULL;
+    }
     memset(Cmd, 0, sizeof(PARSED_COMMAND));
     Cmd->Type = C_IF;
 
@@ -432,10 +453,17 @@ condition_done:
  */
 static PARSED_COMMAND *ParseFor(void)
 {
-    PARSED_COMMAND *Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+    PARSED_COMMAND *Cmd;
     TCHAR List[CMDLINE_LENGTH];
     TCHAR *Pos = List;
 
+    Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+    if (!Cmd)
+    {
+        WARN("Cannot allocate memory for Cmd!\n");
+        ParseError();
+        return NULL;
+    }
     memset(Cmd, 0, sizeof(PARSED_COMMAND));
     Cmd->Type = C_FOR;
 
@@ -609,6 +637,13 @@ static DECLSPEC_NOINLINE PARSED_COMMAND *ParseCommandPart(REDIRECTION *RedirList
     *Pos++ = _T('\0');
 
     Cmd = cmd_alloc(FIELD_OFFSET(PARSED_COMMAND, Command.First[Pos - ParsedLine]));
+    if (!Cmd)
+    {
+        WARN("Cannot allocate memory for Cmd!\n");
+        ParseError();
+        FreeRedirection(RedirList);
+        return NULL;
+    }
     Cmd->Type = C_COMMAND;
     Cmd->Next = NULL;
     Cmd->Subcommands = NULL;
@@ -647,6 +682,12 @@ static PARSED_COMMAND *ParsePrimary(void)
         PARSED_COMMAND *Cmd;
         ParseChar();
         Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+        if (!Cmd)
+        {
+            WARN("Cannot allocate memory for Cmd!\n");
+            ParseError();
+            return NULL;
+        }
         Cmd->Type = C_QUIET;
         Cmd->Next = NULL;
         /* @ acts like a unary operator with low precedence,
@@ -702,6 +743,14 @@ static PARSED_COMMAND *ParseCommandOp(int OpType)
         }
 
         Cmd = cmd_alloc(sizeof(PARSED_COMMAND));
+        if (!Cmd)
+        {
+            WARN("Cannot allocate memory for Cmd!\n");
+            ParseError();
+            FreeCommand(Left);
+            FreeCommand(Right);
+            return NULL;
+        }
         Cmd->Type = OpType;
         Cmd->Next = NULL;
         Cmd->Redirections = NULL;
@@ -840,8 +889,10 @@ EchoCommand(PARSED_COMMAND *Cmd)
     for (Redir = Cmd->Redirections; Redir; Redir = Redir->Next)
     {
         if (SubstituteForVars(Redir->Filename, Buf))
+        {
             ConOutPrintf(_T(" %c%s%s"), _T('0') + Redir->Number,
-                RedirString[Redir->Mode], Buf);
+                         RedirString[Redir->Mode], Buf);
+        }
     }
 }
 
@@ -862,19 +913,27 @@ Unparse(PARSED_COMMAND *Cmd, TCHAR *Out, TCHAR *OutEnd)
  * overflowing the supplied buffer, define some helper macros to make
  * this less painful.
  */
-#define CHAR(Char) { \
+#define CHAR(Char) \
+do { \
     if (Out == OutEnd) return NULL; \
-    *Out++ = Char; }
-#define STRING(String) { \
+    *Out++ = Char; \
+} while (0)
+#define STRING(String) \
+do { \
     if (Out + _tcslen(String) > OutEnd) return NULL; \
-    Out = _stpcpy(Out, String); }
-#define PRINTF(Format, ...) { \
+    Out = _stpcpy(Out, String); \
+} while (0)
+#define PRINTF(Format, ...) \
+do { \
     UINT Len = _sntprintf(Out, OutEnd - Out, Format, __VA_ARGS__); \
     if (Len > (UINT)(OutEnd - Out)) return NULL; \
-    Out += Len; }
-#define RECURSE(Subcommand) { \
+    Out += Len; \
+} while (0)
+#define RECURSE(Subcommand) \
+do { \
     Out = Unparse(Subcommand, Out, OutEnd); \
-    if (!Out) return NULL; }
+    if (!Out) return NULL; \
+} while (0)
 
     switch (Cmd->Type)
     {
@@ -883,70 +942,71 @@ Unparse(PARSED_COMMAND *Cmd, TCHAR *Out, TCHAR *OutEnd)
          * Windows doesn't bother escaping them, so for compatibility
          * we probably shouldn't do it either */
         if (!SubstituteForVars(Cmd->Command.First, Buf)) return NULL;
-        STRING(Buf)
+        STRING(Buf);
         if (!SubstituteForVars(Cmd->Command.Rest, Buf)) return NULL;
-        STRING(Buf)
+        STRING(Buf);
         break;
     case C_QUIET:
-        CHAR(_T('@'))
-        RECURSE(Cmd->Subcommands)
+        CHAR(_T('@'));
+        RECURSE(Cmd->Subcommands);
         break;
     case C_BLOCK:
-        CHAR(_T('('))
+        CHAR(_T('('));
         for (Sub = Cmd->Subcommands; Sub; Sub = Sub->Next)
         {
-            RECURSE(Sub)
+            RECURSE(Sub);
             if (Sub->Next)
-                CHAR(_T('&'))
+                CHAR(_T('&'));
         }
-        CHAR(_T(')'))
+        CHAR(_T(')'));
         break;
     case C_MULTI:
     case C_IFFAILURE:
     case C_IFSUCCESS:
     case C_PIPE:
         Sub = Cmd->Subcommands;
-        RECURSE(Sub)
-        PRINTF(_T(" %s "), OpString[Cmd->Type - C_OP_LOWEST])
-        RECURSE(Sub->Next)
+        RECURSE(Sub);
+        PRINTF(_T(" %s "), OpString[Cmd->Type - C_OP_LOWEST]);
+        RECURSE(Sub->Next);
         break;
     case C_IF:
-        STRING(_T("if"))
+        STRING(_T("if"));
         if (Cmd->If.Flags & IFFLAG_IGNORECASE)
-            STRING(_T(" /I"))
+            STRING(_T(" /I"));
         if (Cmd->If.Flags & IFFLAG_NEGATE)
-            STRING(_T(" not"))
+            STRING(_T(" not"));
         if (Cmd->If.LeftArg && SubstituteForVars(Cmd->If.LeftArg, Buf))
-            PRINTF(_T(" %s"), Buf)
+            PRINTF(_T(" %s"), Buf);
         PRINTF(_T(" %s"), IfOperatorString[Cmd->If.Operator]);
         if (!SubstituteForVars(Cmd->If.RightArg, Buf)) return NULL;
-        PRINTF(_T(" %s "), Buf)
+        PRINTF(_T(" %s "), Buf);
         Sub = Cmd->Subcommands;
-        RECURSE(Sub)
+        RECURSE(Sub);
         if (Sub->Next)
         {
-            STRING(_T(" else "))
-            RECURSE(Sub->Next)
+            STRING(_T(" else "));
+            RECURSE(Sub->Next);
         }
         break;
     case C_FOR:
-        STRING(_T("for"))
-        if (Cmd->For.Switches & FOR_DIRS)      STRING(_T(" /D"))
-        if (Cmd->For.Switches & FOR_F)         STRING(_T(" /F"))
-        if (Cmd->For.Switches & FOR_LOOP)      STRING(_T(" /L"))
-        if (Cmd->For.Switches & FOR_RECURSIVE) STRING(_T(" /R"))
+        STRING(_T("for"));
+        if (Cmd->For.Switches & FOR_DIRS)      STRING(_T(" /D"));
+        if (Cmd->For.Switches & FOR_F)         STRING(_T(" /F"));
+        if (Cmd->For.Switches & FOR_LOOP)      STRING(_T(" /L"));
+        if (Cmd->For.Switches & FOR_RECURSIVE) STRING(_T(" /R"));
         if (Cmd->For.Params)
-            PRINTF(_T(" %s"), Cmd->For.Params)
-        PRINTF(_T(" %%%c in (%s) do "), Cmd->For.Variable, Cmd->For.List)
-        RECURSE(Cmd->Subcommands)
+            PRINTF(_T(" %s"), Cmd->For.Params);
+        PRINTF(_T(" %%%c in (%s) do "), Cmd->For.Variable, Cmd->For.List);
+        RECURSE(Cmd->Subcommands);
         break;
     }
 
     for (Redir = Cmd->Redirections; Redir; Redir = Redir->Next)
     {
-        if (!SubstituteForVars(Redir->Filename, Buf)) return NULL;
+        if (!SubstituteForVars(Redir->Filename, Buf))
+            return NULL;
         PRINTF(_T(" %c%s%s"), _T('0') + Redir->Number,
-            RedirString[Redir->Mode], Buf)
+               RedirString[Redir->Mode], Buf);
     }
     return Out;
 }

--- a/base/shell/cmd/path.c
+++ b/base/shell/cmd/path.c
@@ -50,6 +50,12 @@ INT cmd_path (LPTSTR param)
         LPTSTR pszBuffer;
 
         pszBuffer = (LPTSTR)cmd_alloc (ENV_BUFFER_SIZE * sizeof(TCHAR));
+        if (!pszBuffer)
+        {
+            WARN("Cannot allocate memory for pszBuffer!\n");
+            return 1;
+        }
+
         dwBuffer = GetEnvironmentVariable (_T("PATH"), pszBuffer, ENV_BUFFER_SIZE);
         if (dwBuffer == 0)
         {
@@ -61,8 +67,9 @@ INT cmd_path (LPTSTR param)
         {
             LPTSTR pszOldBuffer = pszBuffer;
             pszBuffer = (LPTSTR)cmd_realloc (pszBuffer, dwBuffer * sizeof (TCHAR));
-            if (pszBuffer == NULL)
+            if (!pszBuffer)
             {
+                WARN("Cannot reallocate memory for pszBuffer!\n");
                 cmd_free(pszOldBuffer);
                 return 1;
             }

--- a/base/shell/cmd/setlocal.c
+++ b/base/shell/cmd/setlocal.c
@@ -49,6 +49,7 @@ INT cmd_setlocal(LPTSTR param)
     Saved = cmd_alloc(sizeof(SETLOCAL));
     if (!Saved)
     {
+        WARN("Cannot allocate memory for Saved!\n");
         error_out_of_memory();
         return 1;
     }

--- a/base/shell/cmd/start.c
+++ b/base/shell/cmd/start.c
@@ -178,8 +178,9 @@ INT cmd_start (LPTSTR Rest)
 
     /* get comspec */
     comspec = cmd_alloc ( MAX_PATH * sizeof(TCHAR));
-    if (comspec == NULL)
+    if (!comspec)
     {
+        WARN("Cannot allocate memory for start comspec!\n");
         error_out_of_memory();
         return 1;
     }

--- a/base/shell/cmd/where.c
+++ b/base/shell/cmd/where.c
@@ -149,13 +149,20 @@ SearchForExecutable (LPCTSTR pFileName, LPTSTR pFullName)
 
     /* load environment variable PATHEXT */
     pszPathExt = (LPTSTR)cmd_alloc (ENV_BUFFER_SIZE * sizeof(TCHAR));
+    if (!pszPathExt)
+    {
+        WARN("Cannot allocate memory for pszPathExt!\n");
+        return FALSE;
+    }
+
     dwBuffer = GetEnvironmentVariable (_T("PATHEXT"), pszPathExt, ENV_BUFFER_SIZE);
     if (dwBuffer > ENV_BUFFER_SIZE)
     {
         LPTSTR pszOldPathExt = pszPathExt;
         pszPathExt = (LPTSTR)cmd_realloc (pszPathExt, dwBuffer * sizeof (TCHAR));
-        if (pszPathExt == NULL)
+        if (!pszPathExt)
         {
+            WARN("Cannot reallocate memory for pszPathExt!\n");
             cmd_free(pszOldPathExt);
             return FALSE;
         }
@@ -187,13 +194,20 @@ SearchForExecutable (LPCTSTR pFileName, LPTSTR pFullName)
 
     /* load environment variable PATH into buffer */
     pszPath = (LPTSTR)cmd_alloc (ENV_BUFFER_SIZE * sizeof(TCHAR));
+    if (!pszPath)
+    {
+        WARN("Cannot allocate memory for pszPath!\n");
+        return FALSE;
+    }
+
     dwBuffer = GetEnvironmentVariable (_T("PATH"), pszPath, ENV_BUFFER_SIZE);
     if (dwBuffer > ENV_BUFFER_SIZE)
     {
         LPTSTR pszOldPath = pszPath;
         pszPath = (LPTSTR)cmd_realloc (pszPath, dwBuffer * sizeof (TCHAR));
-        if (pszPath == NULL)
+        if (!pszPath)
         {
+            WARN("Cannot reallocate memory for pszPath!\n");
             cmd_free(pszOldPath);
             cmd_free(pszPathExt);
             return FALSE;


### PR DESCRIPTION
Adapted from a patch by Jacob S. Preciado.

## Purpose

Add missing memory allocation NULL checks in the code.
I also want advice from people to know whether these WARN are OK or can be skipped.

JIRA issue: [CORE-8304](https://jira.reactos.org/browse/CORE-8304)