### PR TITLE
CORE-12580. Add a reminder comment about removed Vista/+ functions

### DIFF
--- a/sdk/include/reactos/idl/pnp.idl
+++ b/sdk/include/reactos/idl/pnp.idl
@@ -925,6 +925,8 @@ cpp_quote("#if _WIN32_WINNT >= 0x0501")
         [out] DWORD *pulSSDIFlags,
         [in] DWORD ulFlags);
 
+    /* Functions 65 to 74 are Vista+, see r63565 */
+
 cpp_quote("#endif /* _WIN32_WINNT >= 0x0501 */")
 
 }


### PR DESCRIPTION
## Purpose

Fix a "WIN32_WINNT" typo.

JIRA issue: [CORE-12580](https://jira.reactos.org/browse/CORE-12580)

## Proposed changes

- [SDK] pnp.idl: Add a reminder comment about removed Vista/+ functions.
