### PR TITLE
delete old font substitute setting on loading a font

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -798,6 +798,7 @@ DeleteFontSubstituteFromList(
 
             /* TODO: delete pListEntry */
             ret = TRUE;
+            break;
         }
     }
     IntUnLockFreeType;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1048,7 +1048,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
         FontGDI->CharSet = SYMBOL_CHARSET;
     }
 
-    /* delete font substitutes */
+    /* delete old font substitute */
     DeleteFontSubstFromList(&FontSubstListHead, &Entry->FaceName);
     DeleteFontSubstFromRegistry(&Entry->FaceName);
 


### PR DESCRIPTION
## Purpose

To load fonts correctly, we delete the target font substitutes on loading fonts.

JIRA issue: [CORE-14044](https://jira.reactos.org/browse/CORE-14044)

## Proposed changes

- Add DeleteFontSubstFromList and DeleteFontSubstFromRegistry functions.
- Call these two functions in IntGdiLoadFontsFromMemory function.

## TODO

- [x] Implement DeleteFontSubstFromList function.
- [x] Implement DeleteFontSubstFromRegistry function.
