### PR TITLE
[SERVMAN] Fix return check on PropSheet_IsDialogMessage

### DIFF
--- a/base/applications/mscutils/servman/propsheet.c
+++ b/base/applications/mscutils/servman/propsheet.c
@@ -83,14 +83,14 @@ unsigned int __stdcall PropSheetThread(void* Param)
         /* Pump the message queue */
         while (GetMessageW(&Msg, NULL, 0, 0))
         {
-            if (PropSheet_GetCurrentPageHwnd(hDlg) == NULL)
+            if (!PropSheet_GetCurrentPageHwnd(hDlg))
             {
                 /* The user hit the ok / cancel button, pull it down */
                 EnableWindow(pServicePropSheet->Info->hMainWnd, TRUE);
                 DestroyWindow(hDlg);
             }
 
-            if (PropSheet_IsDialogMessage(hDlg, &Msg) != 0)
+            if (!PropSheet_IsDialogMessage(hDlg, &Msg))
             {
                 TranslateMessage(&Msg);
                 DispatchMessageW(&Msg);


### PR DESCRIPTION
Should fix the regression introduced in the last commit.