### PR TITLE
Fix NtGdiGetTextFaceW to report face name correctly

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4532,7 +4532,6 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
 
         Face = FontGdi->SharedFace->Face;
 
-
         //FontGdi->OriginalWeight = WeightFromStyle(Face->style_name);
 
         if (!FontGdi->OriginalItalic)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4504,6 +4504,7 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
     }
     else
     {
+        UNICODE_STRING NameW;
         PFONTGDI FontGdi = ObjToGDI(TextObj->Font, FONT);
         // Need hdev, when freetype is loaded need to create DEVOBJ for
         // Consumer and Producer.
@@ -4518,7 +4519,19 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
         else
             FontGdi->RequestWeight = FW_NORMAL;
 
+        /* store the localized family name */
+        RtlInitUnicodeString(&NameW, NULL);
+        Status = IntGetFontLocalizedName(&NameW, FontGdi->SharedFace,
+                                         TT_NAME_ID_FONT_FAMILY, gusLanguageID);
+        if (NT_SUCCESS(Status))
+        {
+            RtlCopyMemory(TextObj->FaceName, NameW.Buffer, NameW.Length);
+            TextObj->FaceName[NameW.Length / sizeof(WCHAR)] = UNICODE_NULL;
+            RtlFreeUnicodeString(&NameW);
+        }
+
         Face = FontGdi->SharedFace->Face;
+
 
         //FontGdi->OriginalWeight = WeightFromStyle(Face->style_name);
 

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -513,6 +513,8 @@ NtGdiGetTextFaceW(
     TextObj = RealizeFontInit(hFont);
     ASSERT(TextObj != NULL);
     fLen = wcslen(TextObj->FaceName) + 1;
+    if (fLen > LF_FACESIZE)
+        fLen = LF_FACESIZE;
 
     if (FaceName != NULL)
     {
@@ -525,7 +527,7 @@ NtGdiGetTextFaceW(
             return 0;
         }
         /* Terminate if we copied only part of the font name */
-        if (Count > 0 && Count < fLen)
+        if (0 < Count && Count <= fLen)
         {
             FaceName[Count - 1] = '\0';
         }

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -527,7 +527,7 @@ NtGdiGetTextFaceW(
             return 0;
         }
         /* Terminate if we copied only part of the font name */
-        if (0 < Count && Count <= fLen)
+        if (Count > 0 && Count <= fLen)
         {
             FaceName[Count - 1] = '\0';
         }

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -3,7 +3,11 @@
  * LICENSE:         GPL - See COPYING in the top level directory
  * FILE:            win32ss/gdi/ntgdi/text.c
  * PURPOSE:         Text/Font
- * PROGRAMMER:      Katayama Hirofumi MZ
+ * PROGRAMMERS:     Amine Khaldi <amine.khaldi@reactos.org>
+ *                  Hermes Belusca-Maito <hermes.belusca@sfr.fr>
+ *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *                  James Tabor <james.tabor@reactos.org>
+ *                  Timo Kreuzer <timo.kreuzer@reactos.org>
  */
 
 /** Includes ******************************************************************/

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -527,11 +527,19 @@ NtGdiGetTextFaceW(
             return 0;
         }
         /* Terminate if we copied only part of the font name */
+        ret = Count;
         if (Count > 0 && Count <= fLen)
         {
-            FaceName[Count - 1] = '\0';
+            _SEH2_TRY
+            {
+                FaceName[Count - 1] = '\0';
+            }
+            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+            {
+                ret = 0;
+            }
+            _SEH2_END
         }
-        ret = Count;
     }
     else
     {

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -542,7 +542,7 @@ NtGdiGetTextFaceW(
             {
                 ret = 0;
             }
-            _SEH2_END
+            _SEH2_END;
         }
     }
     else

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -4,10 +4,10 @@
  * FILE:            win32ss/gdi/ntgdi/text.c
  * PURPOSE:         Text/Font
  * PROGRAMMERS:     Amine Khaldi <amine.khaldi@reactos.org>
+ *                  Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                  James Tabor <james.tabor@reactos.org>
  *                  Hermes Belusca-Maito <hermes.belusca@sfr.fr>
  *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
- *                  James Tabor <james.tabor@reactos.org>
- *                  Timo Kreuzer <timo.kreuzer@reactos.org>
  */
 
 /** Includes ******************************************************************/

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -3,7 +3,7 @@
  * LICENSE:         GPL - See COPYING in the top level directory
  * FILE:            win32ss/gdi/ntgdi/text.c
  * PURPOSE:         Text/Font
- * PROGRAMMER:
+ * PROGRAMMER:      Katayama Hirofumi MZ
  */
 
 /** Includes ******************************************************************/
@@ -512,12 +512,12 @@ NtGdiGetTextFaceW(
 
     TextObj = RealizeFontInit(hFont);
     ASSERT(TextObj != NULL);
-    fLen = wcslen(TextObj->logfont.elfEnumLogfontEx.elfLogFont.lfFaceName) + 1;
+    fLen = wcslen(TextObj->FaceName) + 1;
 
     if (FaceName != NULL)
     {
         Count = min(Count, fLen);
-        Status = MmCopyToCaller(FaceName, TextObj->logfont.elfEnumLogfontEx.elfLogFont.lfFaceName, Count * sizeof(WCHAR));
+        Status = MmCopyToCaller(FaceName, TextObj->FaceName, Count * sizeof(WCHAR));
         if (!NT_SUCCESS(Status))
         {
             TEXTOBJ_UnlockText(TextObj);


### PR DESCRIPTION
## Purpose

This Pull Request fixes GetTextFace function to report the font face name correctly.
JIRA issue: [CORE-14071](https://jira.reactos.org/browse/CORE-14071)

## Proposed changes

- Initialize TEXTOBJ.FaceName member in TextIntRealizeFont function in "win32ss/gdi/ntgdi/freetype.c".
- Set the face name in NtGdiGetTextFaceW function by using TEXTOBJ.FaceName in "win32ss/gdi/ntgdi/text.c".
