### PR TITLE
WIN32K: Add RFONT

### DIFF
--- a/win32ss/gdi/ntgdi/dc.h
+++ b/win32ss/gdi/ntgdi/dc.h
@@ -58,7 +58,7 @@ typedef struct _DCLEVEL
   POINTL            ptlBrushOrigin;
   PBRUSH            pbrFill;
   PBRUSH            pbrLine;
-  _Notnull_ struct _LFONT   * plfnt; /* LFONT* (TEXTOBJ*) */
+  _Notnull_ PLFONT  plfnt;
   HGDIOBJ           hPath; /* HPATH */
   FLONG             flPath;
   LINEATTRS         laPath; /* 0x20 bytes */
@@ -123,7 +123,7 @@ typedef struct _DC
   HFONT       hlfntCur;
   FLONG       flSimulationFlags;
   LONG        lEscapement;
-  PVOID       prfnt;    /* RFONT* */
+  PRFONT      prfnt;
   XCLIPOBJ    co;       /* CLIPOBJ */
   PVOID       pPFFList; /* PPFF* */
   PVOID       pClrxFormLnk;

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -112,7 +112,8 @@ DC_InitHack(PDC pdc)
         DC_vCopyState(pdc, defaultDCstate, TRUE);
     }
 
-    TextIntRealizeFont(pdc->pdcattr->hlfntNew,NULL);
+    pdc->prfnt = LFONT_Realize(pdc->dclevel.plfnt, pdc->ppdev, pdc->dhpdev);
+
     pdc->pdcattr->iCS_CP = ftGdiGetTextCharsetInfo(pdc,NULL,0);
 
     /* This should never fail */

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -368,6 +368,8 @@ DC_vCleanup(PVOID ObjectBody)
     /* Release font */
     if (pdc->dclevel.plfnt)
         LFONT_ShareUnlockFont(pdc->dclevel.plfnt);
+    if (pdc->prfnt)
+        RFONT_vDeleteRFONT(pdc->prfnt);
 
     /*  Free regions */
     if (pdc->dclevel.prgnClip)

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -112,10 +112,6 @@ DC_InitHack(PDC pdc)
         DC_vCopyState(pdc, defaultDCstate, TRUE);
     }
 
-    pdc->prfnt = LFONT_Realize(pdc->dclevel.plfnt, pdc->ppdev, pdc->dhpdev);
-
-    pdc->pdcattr->iCS_CP = ftGdiGetTextCharsetInfo(pdc,NULL,0);
-
     /* This should never fail */
     ASSERT(pdc->dclevel.ppal);
 }

--- a/win32ss/gdi/ntgdi/dcobjs.c
+++ b/win32ss/gdi/ntgdi/dcobjs.c
@@ -553,12 +553,7 @@ DC_hSelectFont(
 {
     PLFONT plfntNew;
     HFONT hlfntOld;
-
-    // Legacy crap that will die with font engine rewrite
-    if (!NT_SUCCESS(TextIntRealizeFont(hlfntNew, NULL)))
-    {
-        return NULL;
-    }
+    PRFONT prfnt;
 
     /* Get the current selected font */
     hlfntOld = pdc->dclevel.plfnt->BaseObject.hHmgr;
@@ -580,6 +575,15 @@ DC_hSelectFont(
             /* Update dirty flags */
             pdc->pdcattr->ulDirty_ |= DIRTY_CHARSET;
             pdc->pdcattr->ulDirty_ &= ~SLOW_WIDTHS;
+
+            // Legacy crap that will die with font engine rewrite
+            prfnt = LFONT_Realize(pdc->dclevel.plfnt, pdc->ppdev, pdc->dhpdev);
+            if (prfnt)
+            {
+                if (pdc->prfnt)
+                    RFONT_Free(pdc->prfnt);
+                pdc->prfnt = prfnt;
+            }
         }
         else
         {

--- a/win32ss/gdi/ntgdi/dcobjs.c
+++ b/win32ss/gdi/ntgdi/dcobjs.c
@@ -553,7 +553,6 @@ DC_hSelectFont(
 {
     PLFONT plfntNew;
     HFONT hlfntOld;
-    PRFONT prfnt;
 
     /* Get the current selected font */
     hlfntOld = pdc->dclevel.plfnt->BaseObject.hHmgr;
@@ -575,15 +574,6 @@ DC_hSelectFont(
             /* Update dirty flags */
             pdc->pdcattr->ulDirty_ |= DIRTY_CHARSET;
             pdc->pdcattr->ulDirty_ &= ~SLOW_WIDTHS;
-
-            // Legacy crap that will die with font engine rewrite
-            prfnt = LFONT_Realize(pdc->dclevel.plfnt, pdc->ppdev, pdc->dhpdev);
-            if (prfnt)
-            {
-                if (pdc->prfnt)
-                    RFONT_Free(pdc->prfnt);
-                pdc->prfnt = prfnt;
-            }
         }
         else
         {

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -51,10 +51,8 @@ GreGetKerningPairs(
     LPKERNINGPAIR krnpair)
 {
   PDC dc;
-  PDC_ATTR pdcattr;
-  PTEXTOBJ TextObj;
-  PFONTGDI FontGDI;
-  DWORD Count;
+  PRFONT prfnt;
+  DWORD Count, ret = 0;
   KERNINGPAIR *pKP;
 
   dc = DC_LockDc(hDC);
@@ -64,41 +62,39 @@ GreGetKerningPairs(
      return 0;
   }
 
-  pdcattr = dc->pdcattr;
-  TextObj = RealizeFontInit(pdcattr->hlfntNew);
-  DC_UnlockDc(dc);
-
-  if (!TextObj)
+  prfnt = DC_prfnt(dc);
+  if (!prfnt)
   {
      EngSetLastError(ERROR_INVALID_HANDLE);
-     return 0;
+     goto cleanup;
   }
 
-  FontGDI = ObjToGDI(TextObj->Font, FONT);
-  TEXTOBJ_UnlockText(TextObj);
-
-  Count = ftGdiGetKerningPairs(FontGDI,0,NULL);
+  Count = ftGdiGetKerningPairs(prfnt,0,NULL);
 
   if ( Count && krnpair )
   {
      if (Count > NumPairs)
      {
         EngSetLastError(ERROR_INSUFFICIENT_BUFFER);
-        return 0;
+        goto cleanup;
      }
      pKP = ExAllocatePoolWithTag(PagedPool, Count * sizeof(KERNINGPAIR), GDITAG_TEXT);
      if (!pKP)
      {
         EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
-        return 0;
+        goto cleanup;
      }
-     ftGdiGetKerningPairs(FontGDI,Count,pKP);
+     ftGdiGetKerningPairs(prfnt,Count,pKP);
 
      RtlCopyMemory(krnpair, pKP, Count * sizeof(KERNINGPAIR));
 
      ExFreePoolWithTag(pKP,GDITAG_TEXT);
   }
-  return Count;
+
+  ret = Count;
+cleanup:
+  DC_UnlockDc(dc);
+  return ret;
 }
 
 /*
@@ -288,9 +284,7 @@ GreGetCharacterPlacementW(
 }
 #endif
 
-ULONG
-FASTCALL
-FontGetObject(PTEXTOBJ plfont, ULONG cjBuffer, PVOID pvBuffer)
+ULONG LFONT_GetObject(PLFONT plfont, ULONG cjBuffer, PVOID pvBuffer)
 {
     ULONG cjMaxSize;
     ENUMLOGFONTEXDVW *plf = &plfont->logfont;
@@ -314,8 +308,7 @@ FASTCALL
 IntGetCharDimensions(HDC hdc, PTEXTMETRICW ptm, PDWORD height)
 {
   PDC pdc;
-  PDC_ATTR pdcattr;
-  PTEXTOBJ TextObj;
+  PRFONT prfnt;
   SIZE sz;
   TMW_INTERNAL tmwi;
   BOOL Good;
@@ -328,19 +321,14 @@ IntGetCharDimensions(HDC hdc, PTEXTMETRICW ptm, PDWORD height)
   if(!ftGdiGetTextMetricsW(hdc, &tmwi)) return 0;
 
   pdc = DC_LockDc(hdc);
-
   if (!pdc) return 0;
 
-  pdcattr = pdc->pdcattr;
+  prfnt = DC_prfnt(pdc);
+  if ( prfnt )
+     Good = TextIntGetTextExtentPoint(pdc, prfnt, alphabet, 52, 0, NULL, 0, &sz, 0);
+  else
+     Good = FALSE;
 
-  TextObj = RealizeFontInit(pdcattr->hlfntNew);
-  if ( !TextObj )
-  {
-     DC_UnlockDc(pdc);
-     return 0;
-  }
-  Good = TextIntGetTextExtentPoint(pdc, TextObj, alphabet, 52, 0, NULL, 0, &sz, 0);
-  TEXTOBJ_UnlockText(TextObj);
   DC_UnlockDc(pdc);
 
   if (!Good) return 0;
@@ -402,27 +390,11 @@ IntGetFontLanguageInfo(PDC Dc)
   return result;
 }
 
-PTEXTOBJ
-FASTCALL
-RealizeFontInit(HFONT hFont)
+PRFONT DC_prfnt(PDC pdc)
 {
-  NTSTATUS Status = STATUS_SUCCESS;
-  PTEXTOBJ pTextObj;
-
-  pTextObj = TEXTOBJ_LockText(hFont);
-
-  if ( pTextObj && !(pTextObj->fl & TEXTOBJECT_INIT))
-  {
-     Status = TextIntRealizeFont(hFont, pTextObj);
-     if (!NT_SUCCESS(Status))
-     {
-        TEXTOBJ_UnlockText(pTextObj);
-        return NULL;
-     }
-  }
-  return pTextObj;
+    /* FIXME! */
+    return pdc->prfnt;
 }
-
 
 /** Functions ******************************************************************/
 
@@ -577,52 +549,43 @@ NtGdiGetFontData(
    LPVOID Buffer,
    DWORD Size)
 {
-  PDC Dc;
-  PDC_ATTR pdcattr;
-  HFONT hFont;
-  PTEXTOBJ TextObj;
-  PFONTGDI FontGdi;
+  PDC dc;
+  PRFONT prfnt;
   DWORD Result = GDI_ERROR;
-  NTSTATUS Status = STATUS_SUCCESS;
 
   if (Buffer && Size)
   {
      _SEH2_TRY
      {
          ProbeForRead(Buffer, Size, 1);
+         /* FIXME: Capture is missing!!! */
      }
      _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
      {
-         Status = _SEH2_GetExceptionCode();
+         _SEH2_YIELD(return Result);
      }
      _SEH2_END
   }
 
-  if (!NT_SUCCESS(Status)) return Result;
-
-  Dc = DC_LockDc(hDC);
-  if (Dc == NULL)
-  {
-     EngSetLastError(ERROR_INVALID_HANDLE);
-     return GDI_ERROR;
-  }
-  pdcattr = Dc->pdcattr;
-
-  hFont = pdcattr->hlfntNew;
-  TextObj = RealizeFontInit(hFont);
-  DC_UnlockDc(Dc);
-
-  if (TextObj == NULL)
+  dc = DC_LockDc(hDC);
+  if (dc == NULL)
   {
      EngSetLastError(ERROR_INVALID_HANDLE);
      return GDI_ERROR;
   }
 
-  FontGdi = ObjToGDI(TextObj->Font, FONT);
+  prfnt = DC_prfnt(dc);
+  if (prfnt)
+  {
+    Result = ftGdiGetFontData(prfnt, Table, Offset, Buffer, Size);
+  }
+  else
+  {
+    EngSetLastError(ERROR_INVALID_HANDLE);
+    Result = GDI_ERROR;
+  }
 
-  Result = ftGdiGetFontData(FontGdi, Table, Offset, Buffer, Size);
-
-  TEXTOBJ_UnlockText(TextObj);
+  DC_UnlockDc(dc);
 
   return Result;
 }
@@ -637,13 +600,9 @@ NtGdiGetFontUnicodeRanges(
     OUT OPTIONAL LPGLYPHSET pgs)
 {
   PDC pDc;
-  PDC_ATTR pdcattr;
-  HFONT hFont;
-  PTEXTOBJ TextObj;
-  PFONTGDI FontGdi;
+  PRFONT prfnt;
   DWORD Size = 0;
   PGLYPHSET pgsSafe;
-  NTSTATUS Status = STATUS_SUCCESS;
 
   pDc = DC_LockDc(hdc);
   if (!pDc)
@@ -652,19 +611,13 @@ NtGdiGetFontUnicodeRanges(
      return 0;
   }
 
-  pdcattr = pDc->pdcattr;
-
-  hFont = pdcattr->hlfntNew;
-  TextObj = RealizeFontInit(hFont);
-
-  if ( TextObj == NULL)
+  prfnt = DC_prfnt(pDc);
+  if ( prfnt == NULL)
   {
      EngSetLastError(ERROR_INVALID_HANDLE);
      goto Exit;
   }
-  FontGdi = ObjToGDI(TextObj->Font, FONT);
-
-  Size = ftGetFontUnicodeRanges( FontGdi, NULL);
+  Size = ftGetFontUnicodeRanges( prfnt, NULL);
 
   if (Size && pgs)
   {
@@ -676,7 +629,7 @@ NtGdiGetFontUnicodeRanges(
         goto Exit;
      }
 
-     Size = ftGetFontUnicodeRanges( FontGdi, pgsSafe);
+     Size = ftGetFontUnicodeRanges( prfnt, pgsSafe);
 
      if (Size)
      {
@@ -687,16 +640,13 @@ NtGdiGetFontUnicodeRanges(
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-           Status = _SEH2_GetExceptionCode();
+           Size = 0;
         }
         _SEH2_END
-
-        if (!NT_SUCCESS(Status)) Size = 0;
      }
      ExFreePoolWithTag(pgsSafe, GDITAG_TEXT);
   }
 Exit:
-  TEXTOBJ_UnlockText(TextObj);
   DC_UnlockDc(pDc);
   return Size;
 }
@@ -793,12 +743,9 @@ NtGdiGetKerningPairs(HDC  hDC,
                      LPKERNINGPAIR  krnpair)
 {
   PDC dc;
-  PDC_ATTR pdcattr;
-  PTEXTOBJ TextObj;
-  PFONTGDI FontGDI;
-  DWORD Count;
+  PRFONT prfnt;
+  DWORD Count, ret = 0;
   KERNINGPAIR *pKP;
-  NTSTATUS Status = STATUS_SUCCESS;
 
   dc = DC_LockDc(hDC);
   if (!dc)
@@ -807,35 +754,29 @@ NtGdiGetKerningPairs(HDC  hDC,
      return 0;
   }
 
-  pdcattr = dc->pdcattr;
-  TextObj = RealizeFontInit(pdcattr->hlfntNew);
-  DC_UnlockDc(dc);
-
-  if (!TextObj)
+  prfnt = DC_prfnt(dc);
+  if (!prfnt)
   {
      EngSetLastError(ERROR_INVALID_HANDLE);
-     return 0;
+     goto cleanup;
   }
 
-  FontGDI = ObjToGDI(TextObj->Font, FONT);
-  TEXTOBJ_UnlockText(TextObj);
-
-  Count = ftGdiGetKerningPairs(FontGDI,0,NULL);
+  Count = ftGdiGetKerningPairs(prfnt,0,NULL);
 
   if ( Count && krnpair )
   {
      if (Count > NumPairs)
      {
         EngSetLastError(ERROR_INSUFFICIENT_BUFFER);
-        return 0;
+        goto cleanup;
      }
      pKP = ExAllocatePoolWithTag(PagedPool, Count * sizeof(KERNINGPAIR), GDITAG_TEXT);
      if (!pKP)
      {
         EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
-        return 0;
+        goto cleanup;
      }
-     ftGdiGetKerningPairs(FontGDI,Count,pKP);
+     ftGdiGetKerningPairs(prfnt,Count,pKP);
      _SEH2_TRY
      {
         ProbeForWrite(krnpair, Count * sizeof(KERNINGPAIR), 1);
@@ -843,17 +784,16 @@ NtGdiGetKerningPairs(HDC  hDC,
      }
      _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
      {
-        Status = _SEH2_GetExceptionCode();
-     }
-     _SEH2_END
-     if (!NT_SUCCESS(Status))
-     {
         EngSetLastError(ERROR_INVALID_PARAMETER);
         Count = 0;
      }
+     _SEH2_END
      ExFreePoolWithTag(pKP,GDITAG_TEXT);
   }
-  return Count;
+  ret = Count;
+cleanup:
+  DC_UnlockDc(dc);
+  return ret;
 }
 
 /*
@@ -868,13 +808,9 @@ NtGdiGetOutlineTextMetricsInternalW (HDC  hDC,
                                    TMDIFF *Tmd)
 {
   PDC dc;
-  PDC_ATTR pdcattr;
-  PTEXTOBJ TextObj;
-  PFONTGDI FontGDI;
-  HFONT hFont = 0;
-  ULONG Size;
+  PRFONT prfnt;
+  ULONG Size, ret = 0;
   OUTLINETEXTMETRICW *potm;
-  NTSTATUS Status = STATUS_SUCCESS;
 
   dc = DC_LockDc(hDC);
   if (!dc)
@@ -882,32 +818,33 @@ NtGdiGetOutlineTextMetricsInternalW (HDC  hDC,
      EngSetLastError(ERROR_INVALID_HANDLE);
      return 0;
   }
-  pdcattr = dc->pdcattr;
-  hFont = pdcattr->hlfntNew;
-  TextObj = RealizeFontInit(hFont);
-  DC_UnlockDc(dc);
-  if (!TextObj)
+
+  prfnt = DC_prfnt(dc);
+  if (!prfnt)
   {
      EngSetLastError(ERROR_INVALID_HANDLE);
-     return 0;
+     goto cleanup;
   }
-  FontGDI = ObjToGDI(TextObj->Font, FONT);
-  TextIntUpdateSize(dc, TextObj, FontGDI, TRUE);
-  TEXTOBJ_UnlockText(TextObj);
-  Size = IntGetOutlineTextMetrics(FontGDI, 0, NULL);
-  if (!otm) return Size;
+  TextIntUpdateSize(prfnt, TRUE);
+  Size = IntGetOutlineTextMetrics(prfnt, 0, NULL);
+  if (!otm)
+  {
+      ret = Size;
+      goto cleanup;
+  }
+
   if (Size > Data)
   {
       EngSetLastError(ERROR_INSUFFICIENT_BUFFER);
-      return 0;
+      goto cleanup;
   }
   potm = ExAllocatePoolWithTag(PagedPool, Size, GDITAG_TEXT);
   if (!potm)
   {
       EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
-      return 0;
+      goto cleanup;
   }
-  IntGetOutlineTextMetrics(FontGDI, Size, potm);
+  IntGetOutlineTextMetrics(prfnt, Size, potm);
   if (otm)
   {
      _SEH2_TRY
@@ -917,18 +854,16 @@ NtGdiGetOutlineTextMetricsInternalW (HDC  hDC,
      }
      _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
      {
-         Status = _SEH2_GetExceptionCode();
+         EngSetLastError(ERROR_INVALID_PARAMETER);
+         Size = 0;
      }
      _SEH2_END
-
-     if (!NT_SUCCESS(Status))
-     {
-        EngSetLastError(ERROR_INVALID_PARAMETER);
-        Size = 0;
-     }
+     ret = Size;
   }
   ExFreePoolWithTag(potm,GDITAG_TEXT);
-  return Size;
+cleanup:
+  DC_UnlockDc(dc);
+  return ret;
 }
 
 W32KAPI
@@ -1054,10 +989,8 @@ NtGdiGetRealizationInfo(
     IN HFONT hf)
 {
   PDC pDc;
-  PTEXTOBJ pTextObj;
-  PFONTGDI pFontGdi;
-  PDC_ATTR pdcattr;
-  BOOL Ret = FALSE;
+  PRFONT prfnt;
+  BOOL Ret;
   INT i = 0;
   REALIZATION_INFO ri;
 
@@ -1067,18 +1000,23 @@ NtGdiGetRealizationInfo(
      EngSetLastError(ERROR_INVALID_HANDLE);
      return 0;
   }
-  pdcattr = pDc->pdcattr;
-  pTextObj = RealizeFontInit(pdcattr->hlfntNew);
-  pFontGdi = ObjToGDI(pTextObj->Font, FONT);
-  TEXTOBJ_UnlockText(pTextObj);
+  
+  prfnt = DC_prfnt(pDc);
+  if (prfnt)
+  {
+     Ret = ftGdiRealizationInfo(prfnt, &ri);
+  }
+  else
+  {
+     Ret = FALSE;
+     EngSetLastError(ERROR_INVALID_HANDLE);
+  }
   DC_UnlockDc(pDc);
 
-  Ret = ftGdiRealizationInfo(pFontGdi, &ri);
   if (Ret)
   {
      if (pri)
      {
-        NTSTATUS Status = STATUS_SUCCESS;
         _SEH2_TRY
         {
             ProbeForWrite(pri, sizeof(REALIZATION_INFO), 1);
@@ -1086,15 +1024,10 @@ NtGdiGetRealizationInfo(
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            Status = _SEH2_GetExceptionCode();
+            SetLastNtError(_SEH2_GetExceptionCode());
+            _SEH2_YIELD(return FALSE);
         }
         _SEH2_END
-
-        if(!NT_SUCCESS(Status))
-        {
-            SetLastNtError(Status);
-            return FALSE;
-        }
      }
      do
      {
@@ -1141,7 +1074,6 @@ HfontCreate(
   plfont->lft = lft;
   plfont->fl  = fl;
   RtlCopyMemory (&plfont->logfont, pelfw, sizeof(ENUMLOGFONTEXDVW));
-  ExInitializePushLock(&plfont->lock);
 
   if (pelfw->elfEnumLogfontEx.elfLogFont.lfEscapement !=
       pelfw->elfEnumLogfontEx.elfLogFont.lfOrientation)

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -392,8 +392,41 @@ IntGetFontLanguageInfo(PDC Dc)
 
 PRFONT DC_prfnt(PDC pdc)
 {
-    /* FIXME! */
-    return pdc->prfnt;
+    PRFONT prfnt = 0;
+
+    /* Select "current" font */
+    DC_hSelectFont(pdc, pdc->pdcattr->hlfntNew);
+
+    /* Check if font is already realized */
+    if (pdc->hlfntCur != pdc->dclevel.plfnt->BaseObject.hHmgr)
+    {
+        prfnt = LFONT_prfntRealizeFont(pdc->dclevel.plfnt, pdc);
+
+        if (prfnt)
+        {
+            /* Dereference the old RFONT */
+            //RFONT_ShareUnlockFont(pdc->prfnt);
+            if (pdc->prfnt)
+                RFONT_vDeleteRFONT(pdc->prfnt);
+
+            pdc->prfnt = prfnt;
+
+            /* Set as new active font */
+            pdc->hlfntCur = pdc->pdcattr->hlfntNew;
+        }
+        else
+        {
+            /* Realize failed, lets keep using the previous font */
+            prfnt = pdc->prfnt;
+        }
+    }
+    else
+    {
+        prfnt = pdc->prfnt;
+    }
+
+    //ASSERT(prfnt);
+    return prfnt;
 }
 
 /** Functions ******************************************************************/

--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -319,7 +319,7 @@ InitGdiHandleTable(void)
     InitLookasideList(GDIObjType_PATH_TYPE, sizeof(PATH));
     InitLookasideList(GDIObjType_PAL_TYPE, sizeof(PALETTE));
     InitLookasideList(GDIObjType_ICMLCS_TYPE, sizeof(COLORSPACE));
-    InitLookasideList(GDIObjType_LFONT_TYPE, sizeof(TEXTOBJ));
+    InitLookasideList(GDIObjType_LFONT_TYPE, sizeof(LFONT));
     InitLookasideList(GDIObjType_BRUSH_TYPE, sizeof(BRUSH));
 
     return STATUS_SUCCESS;
@@ -1299,7 +1299,7 @@ GreGetObject(
             break;
 
         case GDILoObjType_LO_FONT_TYPE:
-            iResult = FontGetObject(pvObj, cbCount, pvBuffer);
+            iResult = LFONT_GetObject(pvObj, cbCount, pvBuffer);
             break;
 
         case GDILoObjType_LO_PALETTE_TYPE:

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -3,11 +3,7 @@
  * LICENSE:         GPL - See COPYING in the top level directory
  * FILE:            win32ss/gdi/ntgdi/text.c
  * PURPOSE:         Text/Font
- * PROGRAMMERS:     Amine Khaldi <amine.khaldi@reactos.org>
- *                  Timo Kreuzer <timo.kreuzer@reactos.org>
- *                  James Tabor <james.tabor@reactos.org>
- *                  Hermes Belusca-Maito <hermes.belusca@sfr.fr>
- *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * PROGRAMMER:
  */
 
 /** Includes ******************************************************************/
@@ -45,9 +41,8 @@ GreGetTextExtentW(
     UINT flOpts)
 {
     PDC pdc;
-    PDC_ATTR pdcattr;
+    PRFONT prfnt;
     BOOL Result;
-    PTEXTOBJ TextObj;
 
     if (!cwc)
     {
@@ -63,13 +58,11 @@ GreGetTextExtentW(
         return FALSE;
     }
 
-    pdcattr = pdc->pdcattr;
-
-    TextObj = RealizeFontInit(pdcattr->hlfntNew);
-    if ( TextObj )
+    prfnt = DC_prfnt(pdc);
+    if ( prfnt )
     {
         Result = TextIntGetTextExtentPoint( pdc,
-                                            TextObj,
+                                            prfnt,
                                             lpwsz,
                                             cwc,
                                             0,
@@ -77,7 +70,6 @@ GreGetTextExtentW(
                                             0,
                                             psize,
                                             flOpts);
-        TEXTOBJ_UnlockText(TextObj);
     }
     else
         Result = FALSE;
@@ -105,9 +97,8 @@ GreGetTextExtentExW(
     FLONG fl)
 {
     PDC pdc;
-    PDC_ATTR pdcattr;
+    PRFONT prfnt;
     BOOL Result;
-    PTEXTOBJ TextObj;
 
     if ( (!String && Count ) || !pSize )
     {
@@ -127,13 +118,12 @@ GreGetTextExtentExW(
         EngSetLastError(ERROR_INVALID_HANDLE);
         return FALSE;
     }
-    pdcattr = pdc->pdcattr;
 
-    TextObj = RealizeFontInit(pdcattr->hlfntNew);
-    if ( TextObj )
+    prfnt = DC_prfnt(pdc);
+    if ( prfnt )
     {
         Result = TextIntGetTextExtentPoint( pdc,
-                                            TextObj,
+                                            prfnt,
                                             String,
                                             Count,
                                             MaxExtent,
@@ -141,7 +131,6 @@ GreGetTextExtentExW(
                                             (LPINT)Dx,
                                             pSize,
                                             fl);
-        TEXTOBJ_UnlockText(TextObj);
     }
     else
         Result = FALSE;
@@ -296,14 +285,13 @@ NtGdiGetTextExtentExW(
 )
 {
     PDC dc;
-    PDC_ATTR pdcattr;
+    PRFONT prfnt;
     LPWSTR String;
     SIZE Size;
     NTSTATUS Status;
     BOOLEAN Result;
     INT Fit;
     LPINT Dx;
-    PTEXTOBJ TextObj;
 
     if ((LONG)Count < 0)
     {
@@ -371,12 +359,11 @@ NtGdiGetTextExtentExW(
         EngSetLastError(ERROR_INVALID_HANDLE);
         return FALSE;
     }
-    pdcattr = dc->pdcattr;
-    TextObj = RealizeFontInit(pdcattr->hlfntNew);
-    if ( TextObj )
+    prfnt = DC_prfnt(dc);
+    if ( prfnt )
     {
         Result = TextIntGetTextExtentPoint( dc,
-                                            TextObj,
+                                            prfnt,
                                             String,
                                             Count,
                                             MaxExtent,
@@ -384,7 +371,6 @@ NtGdiGetTextExtentExW(
                                             Dx,
                                             &Size,
                                             fl);
-        TEXTOBJ_UnlockText(TextObj);
     }
     else
         Result = FALSE;
@@ -496,9 +482,7 @@ NtGdiGetTextFaceW(
 )
 {
     PDC Dc;
-    PDC_ATTR pdcattr;
-    HFONT hFont;
-    PTEXTOBJ TextObj;
+    PRFONT prfnt;
     NTSTATUS Status;
     INT fLen, ret;
 
@@ -510,47 +494,42 @@ NtGdiGetTextFaceW(
         EngSetLastError(ERROR_INVALID_HANDLE);
         return FALSE;
     }
-    pdcattr = Dc->pdcattr;
-    hFont = pdcattr->hlfntNew;
-    DC_UnlockDc(Dc);
+    
+    prfnt = DC_prfnt(Dc);
+    if (prfnt == NULL)
+    {
+        EngSetLastError(ERROR_INVALID_HANDLE);
+        DC_UnlockDc(Dc);
+        return FALSE;
+    }
 
-    TextObj = RealizeFontInit(hFont);
-    ASSERT(TextObj != NULL);
-    fLen = wcslen(TextObj->FaceName) + 1;
+    fLen = wcslen(prfnt->FaceName) + 1;
     if (fLen > LF_FACESIZE)
         fLen = LF_FACESIZE;
 
     if (FaceName != NULL)
     {
         Count = min(Count, fLen);
-        Status = MmCopyToCaller(FaceName, TextObj->FaceName, Count * sizeof(WCHAR));
+        Status = MmCopyToCaller(FaceName, prfnt->FaceName, Count * sizeof(WCHAR));
         if (!NT_SUCCESS(Status))
         {
-            TEXTOBJ_UnlockText(TextObj);
+            DC_UnlockDc(Dc);
             SetLastNtError(Status);
             return 0;
         }
         /* Terminate if we copied only part of the font name */
-        ret = Count;
-        if (Count > 0 && Count <= fLen)
+        if (Count > 0 && Count < fLen)
         {
-            _SEH2_TRY
-            {
-                FaceName[Count - 1] = '\0';
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                ret = 0;
-            }
-            _SEH2_END;
+            FaceName[Count - 1] = '\0';
         }
+        ret = Count;
     }
     else
     {
         ret = fLen;
     }
 
-    TEXTOBJ_UnlockText(TextObj);
+    DC_UnlockDc(Dc);
     return ret;
 }
 

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -69,7 +69,7 @@ typedef struct _LFONT
 #define LFONT_ShareUnlockFont(plfnt) GDIOBJ_vDereferenceObject((POBJ)plfnt)
 #define LFONT_UnlockFont(plfnt) GDIOBJ_vUnlockObject((POBJ)plfnt)
 ULONG LFONT_GetObject(PLFONT plfont, ULONG cjBuffer, PVOID pvBuffer);
-PRFONT LFONT_Realize(PLFONT pLFont, PPDEVOBJ hdevConsumer, DHPDEV dhpdev);
+PRFONT LFONT_prfntRealizeFont(PLFONT pLFont, PDC pdc);
 
 /* Realized GDI font object */
 typedef struct _RFONT
@@ -92,9 +92,8 @@ typedef struct _RFONT
     BYTE lfQuality;
 } RFONT;
 
-#define RFONT_Alloc() ((PRFONT)ExAllocatePoolWithTag(PagedPool, sizeof(RFONT), GDITAG_TEXT))
-#define RFONT_Free(prfnt) (ExFreePoolWithTag(prfnt, GDITAG_TEXT))
-
+PRFONT NTAPI RFONT_AllocRFONT(void);
+VOID NTAPI RFONT_vDeleteRFONT(_Inout_ PRFONT prfnt);
 PRFONT DC_prfnt(PDC pdc);
 
 NTSTATUS FASTCALL TextIntCreateFontIndirect(CONST LPLOGFONTW lf, HFONT *NewFont);

--- a/win32ss/win32kp.h
+++ b/win32ss/win32kp.h
@@ -26,6 +26,8 @@
 
 /* Internal NtGdi Headers */
 typedef struct _DC *PDC;
+typedef struct _RFONT *PRFONT;
+typedef struct _LFONT *PLFONT;
 #include "gdi/ntgdi/rect.h"
 #include "gdi/ntgdi/misc.h"
 #include "gdi/ntgdi/gdiobj.h"


### PR DESCRIPTION
[NTGDI] Split TEXTOBJ to LFONT and RFONT. Isolate usage of FONTGDI to freetype.c

This is a quick and dirty approach to start having the RFONT. One part that I'm not sure about is how RFONT should be locked. Ideas are welcome. A second question is if DC_prfnt should be able to fail or not. ~~It compiles but isn't tested yet.~~ It does boot now.