### PR TITLE
RFC: Eliminate tail calls in all software interrupt handlers

### DIFF
--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -576,7 +576,7 @@ HalpEnableInterruptHandler(IN UCHAR Flags,
 VOID NTAPI HalpInitializePICs(IN BOOLEAN EnableInterrupts);
 VOID __cdecl HalpApcInterrupt(VOID);
 VOID __cdecl HalpDispatchInterrupt(VOID);
-VOID __cdecl HalpDispatchInterrupt2(VOID);
+PHAL_SW_INTERRUPT_HANDLER __cdecl HalpDispatchInterrupt2(VOID);
 DECLSPEC_NORETURN VOID FASTCALL HalpApcInterrupt2ndEntry(IN PKTRAP_FRAME TrapFrame);
 DECLSPEC_NORETURN VOID FASTCALL HalpDispatchInterrupt2ndEntry(IN PKTRAP_FRAME TrapFrame);
 

--- a/hal/halx86/up/pic.S
+++ b/hal/halx86/up/pic.S
@@ -50,5 +50,6 @@ ENDM
 
 
 DEFINE_END_INTERRUPT_WRAPPER HalpEndSoftwareInterrupt, HalpEndSoftwareInterrupt2
+DEFINE_END_INTERRUPT_WRAPPER HalEndSystemInterrupt, HalEndSystemInterrupt2
 
 END

--- a/hal/halx86/up/pic.S
+++ b/hal/halx86/up/pic.S
@@ -75,5 +75,6 @@ DEFINE_END_INTERRUPT_WRAPPER HalpEndSoftwareInterrupt, HalpEndSoftwareInterrupt2
 DEFINE_END_INTERRUPT_WRAPPER HalEndSystemInterrupt, HalEndSystemInterrupt2
 
 DEFINE_INTERRUPT_WRAPPER HalpDispatchInterrupt, HalpDispatchInterrupt2
+DEFINE_INTERRUPT_WRAPPER HalpHardwareInterruptLevel, HalpHardwareInterruptLevel2
 
 END

--- a/hal/halx86/up/pic.S
+++ b/hal/halx86/up/pic.S
@@ -48,8 +48,32 @@ WrapperName&_CallIntHandler:
 .ENDP
 ENDM
 
+MACRO(DEFINE_INTERRUPT_WRAPPER, WrapperName, HandlerName)
+EXTERN _&HandlerName:PROC
+PUBLIC _&WrapperName
+.PROC _&WrapperName
+    FPO 0, 0, 0, 0, 0, FRAME_FPO
+
+    /* Call the C function */
+    call _&HandlerName
+
+    /* Check if we got a pointer back */
+    test eax, eax
+    jnz WrapperName&_CallIntHandler
+
+    /* No? Just return */
+    ret
+
+WrapperName&_CallIntHandler:
+    /* Optimize the tail call to avoid stack overflow */
+    jmp eax
+.ENDP
+ENDM
+
 
 DEFINE_END_INTERRUPT_WRAPPER HalpEndSoftwareInterrupt, HalpEndSoftwareInterrupt2
 DEFINE_END_INTERRUPT_WRAPPER HalEndSystemInterrupt, HalEndSystemInterrupt2
+
+DEFINE_INTERRUPT_WRAPPER HalpDispatchInterrupt, HalpDispatchInterrupt2
 
 END

--- a/hal/halx86/up/pic.S
+++ b/hal/halx86/up/pic.S
@@ -11,7 +11,7 @@
 
 #include <ks386.inc>
 
-EXTERN _HalpEndSoftwareInterrupt2@8:PROC
+EXTERN @HalpEndSoftwareInterrupt2@8:PROC
 
 /* GLOBALS *******************************************************************/
 
@@ -26,9 +26,9 @@ PUBLIC _HalpEndSoftwareInterrupt@8
     FPO 0, 2, 0, 0, 0, FRAME_FPO
 
     /* Call the C function with the same arguments we got */
-    push [esp+8]
-    push [esp+8]
-    call _HalpEndSoftwareInterrupt2@8
+    mov ecx, [esp+4]
+    mov edx, [esp+8]
+    call @HalpEndSoftwareInterrupt2@8
 
     /* Check if we got a pointer back */
     test eax, eax
@@ -39,7 +39,8 @@ PUBLIC _HalpEndSoftwareInterrupt@8
 
 CallIntHandler:
     /* We got a pointer to call. Since it won't return, free up our stack
-       space, or we could end up with some nasty deep recursion */
+       space. Otherwise we could end up with some nasty deep recursion.
+       The next function takes the trap frame as its (fastcall) argument. */
     mov ecx, [esp+8]
     add esp, 12
     jmp eax

--- a/hal/halx86/up/pic.S
+++ b/hal/halx86/up/pic.S
@@ -11,8 +11,6 @@
 
 #include <ks386.inc>
 
-EXTERN @HalpEndSoftwareInterrupt2@8:PROC
-
 /* GLOBALS *******************************************************************/
 
 .data
@@ -21,23 +19,26 @@ ASSUME CS:NOTHING, DS:NOTHING, ES:NOTHING, FS:NOTHING, GS:NOTHING
 /* FUNCTIONS *****************************************************************/
 
 .code
-PUBLIC _HalpEndSoftwareInterrupt@8
-.PROC _HalpEndSoftwareInterrupt@8
+
+MACRO(DEFINE_END_INTERRUPT_WRAPPER, WrapperName, HandlerName)
+EXTERN @&HandlerName&@8:PROC
+PUBLIC _&WrapperName&@8
+.PROC _&WrapperName&@8
     FPO 0, 2, 0, 0, 0, FRAME_FPO
 
     /* Call the C function with the same arguments we got */
     mov ecx, [esp+4]
     mov edx, [esp+8]
-    call @HalpEndSoftwareInterrupt2@8
+    call @&HandlerName&@8
 
     /* Check if we got a pointer back */
     test eax, eax
-    jnz CallIntHandler
+    jnz WrapperName&_CallIntHandler
 
     /* No? Just return */
     ret 8
 
-CallIntHandler:
+WrapperName&_CallIntHandler:
     /* We got a pointer to call. Since it won't return, free up our stack
        space. Otherwise we could end up with some nasty deep recursion.
        The next function takes the trap frame as its (fastcall) argument. */
@@ -45,5 +46,9 @@ CallIntHandler:
     add esp, 12
     jmp eax
 .ENDP
+ENDM
+
+
+DEFINE_END_INTERRUPT_WRAPPER HalpEndSoftwareInterrupt, HalpEndSoftwareInterrupt2
 
 END

--- a/hal/halx86/up/pic.c
+++ b/hal/halx86/up/pic.c
@@ -382,7 +382,7 @@ PHAL_SW_INTERRUPT_HANDLER SWInterruptHandlerTable[20] =
 {
     (PHAL_SW_INTERRUPT_HANDLER)KiUnexpectedInterrupt,
     HalpApcInterrupt,
-    HalpDispatchInterrupt2,
+    HalpDispatchInterrupt,
     (PHAL_SW_INTERRUPT_HANDLER)KiUnexpectedInterrupt,
     HalpHardwareInterrupt0,
     HalpHardwareInterrupt1,
@@ -1297,7 +1297,7 @@ HalpDispatchInterrupt2ndEntry(IN PKTRAP_FRAME TrapFrame)
     KiEoiHelper(TrapFrame);
 }
 
-VOID
+PHAL_SW_INTERRUPT_HANDLER
 __cdecl
 HalpDispatchInterrupt2(VOID)
 {
@@ -1330,8 +1330,10 @@ HalpDispatchInterrupt2(VOID)
         }
 
         /* Now handle pending interrupt */
-        SWInterruptHandlerTable[PendingIrql]();
+        return SWInterruptHandlerTable[PendingIrql];
     }
+
+    return NULL;
 }
 
 #else

--- a/hal/halx86/up/pic.c
+++ b/hal/halx86/up/pic.c
@@ -677,7 +677,7 @@ HalClearSoftwareInterrupt(IN KIRQL Irql)
 }
 
 PHAL_SW_INTERRUPT_HANDLER_2ND_ENTRY
-NTAPI
+FASTCALL
 HalpEndSoftwareInterrupt2(IN KIRQL OldIrql,
                           IN PKTRAP_FRAME TrapFrame)
 {

--- a/hal/halx86/up/pic.c
+++ b/hal/halx86/up/pic.c
@@ -1015,9 +1015,9 @@ HalpDismissIrq07Level(IN KIRQL Irql,
     return _HalpDismissIrqLevel(Irql, Irq, OldIrql);
 }
 
-VOID
+PHAL_SW_INTERRUPT_HANDLER
 __cdecl
-HalpHardwareInterruptLevel(VOID)
+HalpHardwareInterruptLevel2(VOID)
 {
     PKPCR Pcr = KeGetPcr();
     ULONG PendingIrqlMask, PendingIrql;
@@ -1027,7 +1027,7 @@ HalpHardwareInterruptLevel(VOID)
     if (PendingIrqlMask)
     {
         /* Check for in-service delayed interrupt */
-        if (Pcr->IrrActive & 0xFFFFFFF0) return;
+        if (Pcr->IrrActive & 0xFFFFFFF0) return NULL;
 
         /* Check if pending IRQL affects hardware state */
         BitScanReverse(&PendingIrql, PendingIrqlMask);
@@ -1036,8 +1036,10 @@ HalpHardwareInterruptLevel(VOID)
         Pcr->IRR ^= (1 << PendingIrql);
 
         /* Now handle pending interrupt */
-        SWInterruptHandlerTable[PendingIrql]();
+        return SWInterruptHandlerTable[PendingIrql];
     }
+
+    return NULL;
 }
 
 /* SYSTEM INTERRUPTS **********************************************************/


### PR DESCRIPTION
## Purpose

This uses wrapper functions to force tail call elimination, as already done in r71307.

JIRA issue: [CORE-14076](https://jira.reactos.org/browse/CORE-14076)

## Problem description

The practical issue is that we can end up with recursion too deep for the kernel stack if software interrupts are scheduled in quick succession. The linked Jira ticket gives an example; the original, [CORE-11123](https://jira.reactos.org/browse/CORE-11123), is another.

I see several solutions to this:
1. This PR. Create wrapper functions to force tail call elimination. This requires only small changes, and a small amount of assembly code, but has a bunch of duplication in the assembly, and feels a bit silly.
2. Write all of the corresponding functions in assembly to get complete control over the stack layout. This is what Microsoft does. We typically try to avoid this approach, to be different, and for easier portability.
3. Redesign the algorithm to avoid recursion. It should theoretically be possible to solve this with iteration. This would end up as a huge switch statement and likely be pretty complicated; can't say that for sure without trying though.
4. Somehow trick the compiler into eliminating the tail calls. From what I've read so far this seems impossible in any single compiler, let alone all of them.

Am I missing other options? Do any of you favor one of the other options? Is there a way to make this option less ugly? There are four functions here, with two each being almost identical to each other -- so the duplication could be avoided with a macro, at least at the source level.