### PR TITLE
Respect the maximum receive buffer size for datagram sockets

### DIFF
--- a/drivers/network/afd/afd/bind.c
+++ b/drivers/network/afd/afd/bind.c
@@ -51,7 +51,7 @@ NTSTATUS WarmSocketForBind( PAFD_FCB FCB, ULONG ShareType ) {
                 Status = STATUS_NO_MEMORY;
         }
 
-        if (NT_SUCCESS(Status))
+        if (NT_SUCCESS(Status) && FCB->Recv.Content < FCB->Recv.Size)
         {
             Status = TdiReceiveDatagram(&FCB->ReceiveIrp.InFlightRequest,
                                         FCB->AddressFile.Object,

--- a/drivers/network/afd/afd/read.c
+++ b/drivers/network/afd/afd/read.c
@@ -681,7 +681,7 @@ PacketSocketRecvComplete(
     } else
         FCB->PollState &= ~AFD_EVENT_RECEIVE;
 
-    if( NT_SUCCESS(Irp->IoStatus.Status) ) {
+    if( NT_SUCCESS(Irp->IoStatus.Status) && FCB->Recv.Content < FCB->Recv.Size ) {
         /* Now relaunch the datagram request */
         Status = TdiReceiveDatagram
             ( &FCB->ReceiveIrp.InFlightRequest,


### PR DESCRIPTION
## Purpose

This avoids unlimited buildup of received data, leading to OOM.

JIRA issue: [CORE-14048](https://jira.reactos.org/browse/CORE-14048)