### PR TITLE
[SWENUM] Add version info

### DIFF
--- a/drivers/ksfilter/swenum/CMakeLists.txt
+++ b/drivers/ksfilter/swenum/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(swenum SHARED swenum.c)
+add_library(swenum SHARED swenum.c swenum.rc)
 set_module_type(swenum kernelmodedriver)
 add_importlibs(swenum ks ntoskrnl hal)
 add_cd_file(TARGET swenum DESTINATION reactos/system32/drivers NO_CAB FOR all)

--- a/drivers/ksfilter/swenum/swenum.rc
+++ b/drivers/ksfilter/swenum/swenum.rc
@@ -1,0 +1,5 @@
+#define REACTOS_VERSION_DLL
+#define REACTOS_STR_FILE_DESCRIPTION  "Plug and Play Software Device Enumerator"
+#define REACTOS_STR_INTERNAL_NAME     "swenum"
+#define REACTOS_STR_ORIGINAL_FILENAME "swenum.sys"
+#include <reactos/version.rc>


### PR DESCRIPTION
## Purpose

This adds version information to swenum.sys. The installer for DirectX 9.0 looks for this version info, and fails if is not found.

JIRA issue: [CORE-14112](https://jira.reactos.org/browse/CORE-14112)
