### PR TITLE
[WIP] ROSTESTS-296. Let WVista tests load and soft fail on WS03 and WXP

### DIFF
--- a/modules/rostests/apitests/wlanapi/CMakeLists.txt
+++ b/modules/rostests/apitests/wlanapi/CMakeLists.txt
@@ -1,5 +1,7 @@
 
 add_executable(wlanapi_apitest wlanapi.c testlist.c)
 set_module_type(wlanapi_apitest win32cui)
-add_importlibs(wlanapi_apitest wlanapi msvcrt kernel32)
+# wlanapi is available on WXPsp3 and WVista (and ReactOS), but not on WS03.
+add_delay_importlibs(wlanapi_apitest wlanapi)
+add_importlibs(wlanapi_apitest msvcrt kernel32)
 add_rostests_file(TARGET wlanapi_apitest)

--- a/modules/rostests/apitests/wlanapi/wlanapi.c
+++ b/modules/rostests/apitests/wlanapi/wlanapi.c
@@ -220,6 +220,15 @@ static void WlanGetInterfaceCapability_test(void)
 
 START_TEST(wlanapi)
 {
+    // wlanapi is available on WXPsp3 and WVista (and ReactOS), but not on WS03.
+    if (!LoadLibraryW(L"wlanapi.dll"))
+    {
+        win_skip("LoadLibrary(\"wlanapi.dll\") failed. This is expected on WS03\n");
+        return;
+    }
+
+    // ToDo: Use __HrLoadAllImportsForDll("wlanapi.dll") after CORE-10957 is fixed.
+
     WlanOpenHandle_test();
     WlanCloseHandle_test();
     WlanConnect_test();

--- a/modules/rostests/winetests/bcrypt/CMakeLists.txt
+++ b/modules/rostests/winetests/bcrypt/CMakeLists.txt
@@ -2,5 +2,7 @@
 remove_definitions(-D_WIN32_WINNT=0x502)
 add_executable(bcrypt_winetest bcrypt.c testlist.c)
 set_module_type(bcrypt_winetest win32cui)
-add_importlibs(bcrypt_winetest bcrypt advapi32 user32 msvcrt kernel32)
+# bcrypt is available on WVista (and ReactOS), not on WS03.
+add_delay_importlibs(bcrypt_winetest bcrypt)
+add_importlibs(bcrypt_winetest advapi32 user32 msvcrt kernel32)
 add_rostests_file(TARGET bcrypt_winetest)

--- a/modules/rostests/winetests/bcrypt/CMakeLists.txt
+++ b/modules/rostests/winetests/bcrypt/CMakeLists.txt
@@ -3,6 +3,7 @@ remove_definitions(-D_WIN32_WINNT=0x502)
 add_executable(bcrypt_winetest bcrypt.c testlist.c)
 set_module_type(bcrypt_winetest win32cui)
 # bcrypt is available on WVista (and ReactOS), not on WS03.
-add_delay_importlibs(bcrypt_winetest bcrypt)
-add_importlibs(bcrypt_winetest advapi32 user32 msvcrt kernel32)
+# advapi32/RegGetValueW() is available on WXP-Pro-x64 and WS03sp1, not on WXP.
+add_delay_importlibs(bcrypt_winetest bcrypt advapi32)
+add_importlibs(bcrypt_winetest user32 msvcrt kernel32)
 add_rostests_file(TARGET bcrypt_winetest)

--- a/modules/rostests/winetests/bcrypt/bcrypt.c
+++ b/modules/rostests/winetests/bcrypt/bcrypt.c
@@ -760,6 +760,17 @@ START_TEST(bcrypt)
 {
     HMODULE module;
 
+#ifdef __REACTOS__
+    // bcrypt is available on WVista (and ReactOS), not on WS03.
+    if (!LoadLibraryW(L"bcrypt.dll"))
+    {
+       win_skip("LoadLibrary(\"bcrypt.dll\") failed. This is expected on WS03\n");
+       return;
+    }
+
+    // ToDo: Use __HrLoadAllImportsForDll("bcrypt.dll") after CORE-10957 is fixed.
+#endif
+
     module = GetModuleHandleA( "bcrypt.dll" );
 
     test_BCryptGenRandom();


### PR DESCRIPTION
## Purpose

JIRA issue: [ROSTESTS-296](https://jira.reactos.org/browse/ROSTESTS-296)

## Proposed changes

- Let WVista tests load and soft fail on WS03.
- Let WS03sp1 test load and soft fail on WXP.

## TODO

- [ ] Double-check on WS03. (Passes on WXP.)
