### PR TITLE
[NTOSKRNL] Fix return of uninitialized variable in PspSetQuotaLimits

### DIFF
--- a/ntoskrnl/ps/quota.c
+++ b/ntoskrnl/ps/quota.c
@@ -444,6 +444,10 @@ PspSetQuotaLimits(
 
         Status = STATUS_SUCCESS;
     }
+    else
+    {
+        Status = STATUS_SUCCESS;
+    }
 
     return Status;
 }


### PR DESCRIPTION
Fix return of uninitialized variable in PspSetQuotaLimits
CID-1322247
