### PR TITLE
[WIP] CORE-14112. Create/Fix xxx.rc, with version resources

### DIFF
--- a/drivers/wdm/audio/filters/kmixer/CMakeLists.txt
+++ b/drivers/wdm/audio/filters/kmixer/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND SOURCE
     pin.c
     kmixer.h)
 
-add_library(kmixer SHARED ${SOURCE})
+add_library(kmixer SHARED ${SOURCE} kmixer.rc)
 set_module_type(kmixer kernelmodedriver)
 target_link_libraries(kmixer libcntpr libsamplerate)
 add_pch(kmixer kmixer.h SOURCE)

--- a/drivers/wdm/audio/filters/kmixer/kmixer.rc
+++ b/drivers/wdm/audio/filters/kmixer/kmixer.rc
@@ -1,0 +1,5 @@
+#define REACTOS_VERSION_DLL
+#define REACTOS_STR_FILE_DESCRIPTION  "Kernel Mode Audio Mixer"
+#define REACTOS_STR_INTERNAL_NAME     "kmixer"
+#define REACTOS_STR_ORIGINAL_FILENAME "kmixer.sys"
+#include <reactos/version.rc>


### PR DESCRIPTION
## Purpose

Add/Fix file version resources.

JIRA issue: [CORE-14112](https://jira.reactos.org/browse/CORE-14112)

All `.sys` should use `REACTOS_VERSION_DLL`, shouldn't they?
What are the use cases for `psdk\common.ver` and `reactos\version.rc`? (Wrt [r25847](https://www.reactos.org/pipermail/ros-diffs/2007-February/015556.html) "every component".)

## Proposed changes

- Create kmixer.rc, with version resources. (See CORE-14112 0-swenum-unpatched.png)

## TODO

- [ ] Find/Fix other affected files.
