### PR TITLE
ATL: Fix for COM_INTERFACE_ENTRY_FUNC_BLIND

### DIFF
--- a/modules/rostests/apitests/atl/CComObject.cpp
+++ b/modules/rostests/apitests/atl/CComObject.cpp
@@ -1,0 +1,149 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for CComObject
+ * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+
+#include <atlbase.h>
+#include <atlcom.h>
+
+#ifdef __REACTOS__
+    #include <apitest.h>
+#else
+    #include <stdlib.h>
+    #include <stdio.h>
+    #include <stdarg.h>
+    int g_tests_executed = 0;
+    int g_tests_failed = 0;
+    void ok_func(const char *file, int line, BOOL value, const char *fmt, ...)
+    {
+        va_list va;
+        va_start(va, fmt);
+        if (!value)
+        {
+            printf("%s (%d): ", file, line);
+            vprintf(fmt, va);
+            g_tests_failed++;
+        }
+        g_tests_executed++;
+        va_end(va);
+    }
+    #undef ok
+    #define ok(value, ...)  ok_func(__FILE__, __LINE__, value, __VA_ARGS__)
+    #define START_TEST(x)   int main(void)
+#endif
+
+
+static LONG g_CTOR = 0;
+static LONG g_DTOR = 0;
+static LONG g_BLIND = 0;
+
+class CTestObject :
+    public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IPersist,
+    public IStdMarshalInfo
+{
+public:
+    CTestObject()
+    {
+        InterlockedIncrement(&g_CTOR);
+    }
+    ~CTestObject()
+    {
+        InterlockedIncrement(&g_DTOR);
+    }
+
+    // *** IPersist methods ***
+    virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pClassID)
+    {
+        return E_NOTIMPL;
+    }
+
+    // *** IStdMarshalInfo methods ***
+    virtual HRESULT STDMETHODCALLTYPE GetClassForHandler(DWORD dwDestContext, void *pvDestContext, CLSID *pClsid)
+    {
+        return E_NOTIMPL;
+    }
+
+    static HRESULT WINAPI FuncBlind(void* pv, REFIID riid, LPVOID* ppv, DWORD dw)
+    {
+        InterlockedIncrement(&g_BLIND);
+        return E_FAIL;
+    }
+
+    DECLARE_NOT_AGGREGATABLE(CTestObject)
+    DECLARE_PROTECT_FINAL_CONSTRUCT()
+
+    BEGIN_COM_MAP(CTestObject)
+        COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist) /* First entry has to be a simple entry, otherwise ATL asserts */
+        COM_INTERFACE_ENTRY_FUNC_BLIND(0, FuncBlind)    /* Showing that even after a Blind func, entryies can be found */
+        COM_INTERFACE_ENTRY_IID(IID_IStdMarshalInfo, IStdMarshalInfo)
+    END_COM_MAP()
+};
+
+
+class CDumExe: public CAtlExeModuleT<CDumExe>
+{
+
+};
+CDumExe dum;
+
+
+START_TEST(CComObject)
+{
+    g_CTOR = g_DTOR = g_BLIND = 0;
+
+    CComObject<CTestObject>* pTest;
+    HRESULT hr = CComObject<CTestObject>::CreateInstance(&pTest);
+
+    ok(hr == S_OK, "Expected S_OK, got 0x%lx\n", hr);
+
+    ok(g_CTOR == 1, "Expected 1, got %lu\n", g_CTOR);
+    ok(g_DTOR == 0, "Expected 0, got %lu\n", g_DTOR);
+    ok(g_BLIND == 0, "Expected 0, got %lu\n", g_BLIND);
+
+    if (hr == S_OK)
+    {
+        ULONG ref = pTest->AddRef();
+        ok(ref == 1, "Expected 1, got %lu\n", ref);
+
+        {
+            CComPtr<IUnknown> ppv;
+            hr = pTest->QueryInterface(IID_IUnknown, (void **) &ppv);
+            ok(hr == S_OK, "Expected S_OK, got 0x%lx\n", hr);
+            ok(g_CTOR == 1, "Expected 1, got %lu\n", g_CTOR);
+            ok(g_DTOR == 0, "Expected 0, got %lu\n", g_DTOR);
+            ok(g_BLIND == 0, "Expected 0, got %lu\n", g_BLIND);
+
+            CComPtr<IPersist> ppersist;
+            hr = pTest->QueryInterface(IID_IPersist, (void **)&ppersist);
+            ok(hr == S_OK, "Expected S_OK, got 0x%lx\n", hr);
+            ok(g_CTOR == 1, "Expected 1, got %lu\n", g_CTOR);
+            ok(g_DTOR == 0, "Expected 0, got %lu\n", g_DTOR);
+            ok(g_BLIND == 0, "Expected 0, got %lu\n", g_BLIND);
+
+        }
+
+        {
+            CComPtr<IStdMarshalInfo> pstd;
+            hr = pTest->QueryInterface(IID_IStdMarshalInfo, (void **)&pstd);
+            ok(hr == S_OK, "Expected S_OK, got 0x%lx\n", hr);
+            ok(g_CTOR == 1, "Expected 1, got %lu\n", g_CTOR);
+            ok(g_DTOR == 0, "Expected 0, got %lu\n", g_DTOR);
+            ok(g_BLIND == 1, "Expected 1, got %lu\n", g_BLIND);
+        }
+
+        ref = pTest->Release();
+        ok(ref == 0, "Expected 0, got %lu\n", ref);
+        ok(g_CTOR == 1, "Expected 1, got %lu\n", g_CTOR);
+        ok(g_DTOR == 1, "Expected 1, got %lu\n", g_DTOR);
+        ok(g_BLIND == 1, "Expected 1, got %lu\n", g_BLIND);
+    }
+
+#ifndef __REACTOS__
+    printf("CImage: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
+    return g_tests_failed;
+#endif
+}

--- a/modules/rostests/apitests/atl/CMakeLists.txt
+++ b/modules/rostests/apitests/atl/CMakeLists.txt
@@ -8,6 +8,7 @@ list(APPEND SOURCE
     atltypes.cpp
     CComBSTR.cpp
     CComHeapPtr.cpp
+    CComObject.cpp
     CImage.cpp
     CRegKey.cpp
     CSimpleArray.cpp

--- a/modules/rostests/apitests/atl/devenv/ATLTest.sln
+++ b/modules/rostests/apitests/atl/devenv/ATLTest.sln
@@ -11,6 +11,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CSimpleMap", "CSimpleMap.vc
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CString", "CString.vcxproj", "{FBA6DAE7-7996-4DE1-BD03-9E44F7DB4ABD}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CComObject", "CComObject.vcxproj", "{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -51,6 +53,14 @@ Global
 		{FBA6DAE7-7996-4DE1-BD03-9E44F7DB4ABD}.Release|x64.Build.0 = Release|x64
 		{FBA6DAE7-7996-4DE1-BD03-9E44F7DB4ABD}.Release|x86.ActiveCfg = Release|Win32
 		{FBA6DAE7-7996-4DE1-BD03-9E44F7DB4ABD}.Release|x86.Build.0 = Release|Win32
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Debug|x64.ActiveCfg = Debug|x64
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Debug|x64.Build.0 = Debug|x64
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Debug|x86.ActiveCfg = Debug|Win32
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Debug|x86.Build.0 = Debug|Win32
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Release|x64.ActiveCfg = Release|x64
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Release|x64.Build.0 = Release|x64
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Release|x86.ActiveCfg = Release|Win32
+		{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/modules/rostests/apitests/atl/devenv/CComObject.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CComObject.vcxproj
@@ -19,7 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <PropertyGroup Label="Globals">
-    <ProjectGuid>{AE520E17-2DAE-40FF-B082-F32A7A935FB2}</ProjectGuid>
+    <ProjectGuid>{408AEF87-D169-4A2F-A9E3-FF3DD1D59E65}</ProjectGuid>
     <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
     <Keyword>AtlProj</Keyword>
   </PropertyGroup>
@@ -163,7 +163,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="../CImage.cpp">
+    <ClCompile Include="../CComObject.cpp">
       <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MultiThreaded</RuntimeLibrary>
       <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MultiThreadedDebug</RuntimeLibrary>
@@ -173,9 +173,6 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
     </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    <ResourceCompile Include="../atl_apitest.rc" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/modules/rostests/apitests/atl/testlist.c
+++ b/modules/rostests/apitests/atl/testlist.c
@@ -4,6 +4,7 @@
 extern void func_atltypes(void);
 extern void func_CComBSTR(void);
 extern void func_CComHeapPtr(void);
+extern void func_CComObject(void);
 extern void func_CComVariant(void);
 extern void func_CImage(void);
 extern void func_CRegKey(void);
@@ -16,6 +17,7 @@ const struct test winetest_testlist[] =
     { "atltypes", func_atltypes },
     { "CComBSTR", func_CComBSTR },
     { "CComHeapPtr", func_CComHeapPtr },
+    { "CComObject", func_CComObject },
     { "CComVariant", func_CComVariant },
     { "CImage", func_CImage },
     { "CRegKey", func_CRegKey },

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1545,10 +1545,11 @@ inline HRESULT __stdcall AtlInternalQueryInterface(void *pThis, const _ATL_INTMA
             else
             {
                 hResult = pEntries[i].pFunc(pThis, iid, ppvObject, 0);
-                if (hResult == S_OK || (FAILED(hResult) && pEntries[i].piid != NULL))
+                if (hResult == S_OK)
                     return hResult;
+                if (FAILED(hResult) && pEntries[i].piid != NULL)
+                    break;
             }
-            break;
         }
         i++;
     }


### PR DESCRIPTION
Interface enumeration should not stop after a failing COM_INTERFACE_ENTRY_FUNC_BLIND.
(This can be useful for logging).

Test written against MS's ATL.