### PR TITLE
ROSTESTS-297. Fix/Extend ApiTest NtAllocateVirtualMemory on both WS03 and ROS

### DIFF
--- a/modules/rostests/apitests/ntdll/NtAllocateVirtualMemory.c
+++ b/modules/rostests/apitests/ntdll/NtAllocateVirtualMemory.c
@@ -1,8 +1,10 @@
 /*
- * PROJECT:         ReactOS API Tests
- * LICENSE:         GPLv2+ - See COPYING in the top level directory
- * PURPOSE:         Stress Test for virtual memory allocation
- * PROGRAMMER:      Thomas Faber <thomas.faber@reactos.org>
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for NtAllocateVirtualMemory
+ * COPYRIGHT:   Copyright 2011 Thomas Faber <thomas.faber@reactos.org>
+ *              Copyright 2013 Timo Kreuzer <timo.kreuzer@reactos.org>
+ *              Copyright 2015 Jérôme Gardou <jerome.gardou@reactos.org>
  */
 
 #include "precomp.h"
@@ -583,7 +585,7 @@ START_TEST(NtAllocateVirtualMemory)
                                      &Size1,
                                      MEM_RESERVE,
                                      PAGE_READWRITE);
-    ok_ntstatus(Status, STATUS_INVALID_PARAMETER_2);
+    ok_ntstatus(Status, STATUS_SUCCESS);
 
     /* Reserve memory at 0x10000 */
     Mem1 = UlongToPtr(0x10000);


### PR DESCRIPTION
## Purpose

JIRA issue: [ROSTESTS-297](https://jira.reactos.org/browse/ROSTESTS-297)

## Proposed changes

- Fix "Below 0x10000" check result.
- Create CheckSomeDefaultAddresses(), with additional checks.

## TODO

Documented with help of SysInternals VMMap too.
Tested on WXP and ReactOS/r76032.

- [X] Test it on WS03. // Thanks to @binarymaster. Updated related `trace()`.
- [X] Test it on recent ReactOS. // Skipped: too complicated to do on my VPC 2004 due to recent regressions. I don't expect any difference anyway.
- [X] Test/Adapt it on WS03/x64. // Can be done later. Using 1 `ok(FALSE)` and 1 `skip()` ftb.
- [X] Test/Adapt it on ReactOS/x64. // Can be done later. Using 1 `ok(FALSE)` and 1 `skip()` ftb.

  