### PR TITLE
ROSTESTS-263. KmTest: Add 1 usage check and 1 cleanup

### DIFF
--- a/modules/rostests/kmtests/kmtest/kmtest.c
+++ b/modules/rostests/kmtests/kmtest/kmtest.c
@@ -3,6 +3,7 @@
  * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
  * PURPOSE:     Kernel-Mode Test Suite loader application
  * COPYRIGHT:   Copyright 2011-2018 Thomas Faber <thomas.faber@reactos.org>
+ *              Copyright 2018 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 #define KMT_DEFINE_TEST_FUNCTIONS
@@ -316,8 +317,11 @@ main(
     if (ArgCount >= 1)
         AppName = Arguments[0];
 
-    if (ArgCount <= 1)
+    if (ArgCount != 2)
     {
+        if (ArgCount > 2)
+            printf("Error: Too many arguments\n\n");
+
         printf("Usage: %s <test_name>                 - run the specified test (creates/starts the driver(s) as appropriate)\n", AppName);
         printf("       %s --list                      - list available tests\n", AppName);
         printf("       %s --list-all                  - list available tests, including hidden\n", AppName);

--- a/modules/rostests/kmtests/kmtest/support.c
+++ b/modules/rostests/kmtests/kmtest/support.c
@@ -4,6 +4,7 @@
  * PURPOSE:     Kernel-Mode Test Suite user-mode support routines
  * COPYRIGHT:   Copyright 2011-2018 Thomas Faber <thomas.faber@reactos.org>
  *              Copyright 2013 Nikolay Borisov <nib9@aber.ac.uk>
+ *              Copyright 2018 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 #include <kmt_test.h>
@@ -141,15 +142,21 @@ KmtLoadDriver(
 
     if (Error)
     {
+        ok(FALSE, "KmtCreateAndStartService(\"%ls\") failed! (Error = 0x%08lx)\n", TestServiceName, Error);
+
         // TODO
         __debugbreak();
+    }
+    else
+    {
+        DPRINT("KmtCreateAndStartService(\"%ls\") succeeded\n", TestServiceName);
     }
 }
 
 /**
  * @name KmtUnloadDriver
  *
- * Unload special-purpose driver (stop the service)
+ * Unload special-purpose driver (stop and delete the service)
  */
 VOID
 KmtUnloadDriver(VOID)
@@ -160,8 +167,30 @@ KmtUnloadDriver(VOID)
 
     if (Error)
     {
+        ok(FALSE, "KmtStopService(\"%ls\") failed! (Error = 0x%08lx)\n", TestServiceName, Error);
+
         // TODO
         __debugbreak();
+
+        skip(FALSE, "KmtDeleteService(\"%ls\") will not be called...\n", TestServiceName);
+    }
+    else
+    {
+        DPRINT("KmtStopService(\"%ls\") succeeded\n", TestServiceName);
+
+        Error = KmtDeleteService(TestServiceName, &TestServiceHandle);
+
+        if (Error)
+        {
+            ok(FALSE, "KmtDeleteService(\"%ls\") failed! (Error = 0x%08lx)\n", TestServiceName, Error);
+
+            // TODO
+            __debugbreak();
+        }
+        else
+        {
+            DPRINT("KmtDeleteService(\"%ls\") succeeded\n", TestServiceName);
+        }
     }
 }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [ROSTESTS-263](https://jira.reactos.org/browse/ROSTESTS-263)

## Proposed changes

- kmtest.c: Add a check and report for "Too many arguments".
- support.c: Add a KmtDeleteService() call to KmtUnloadDriver(), Also add some result reports.
