### PR TITLE
Resource/manifest fix

### DIFF
--- a/dll/3rdparty/mbedtls/mbedtls.rc
+++ b/dll/3rdparty/mbedtls/mbedtls.rc
@@ -1,4 +1,5 @@
 #include <windef.h>
+#include <winuser.h>
 #define MBEDTLS_CONFIG_H
 #include <mbedtls/version.h>
 

--- a/dll/win32/serialui/serialui.rc
+++ b/dll/win32/serialui/serialui.rc
@@ -1,4 +1,5 @@
 #include <windef.h>
+#include <winuser.h>
 
 #include "resource.h"
 

--- a/sdk/include/reactos/manifest_dll.rc
+++ b/sdk/include/reactos/manifest_dll.rc
@@ -1,1 +1,6 @@
+
+#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
+#error please include winuser.h before including me!
+#endif
+
 ISOLATIONAWARE_MANIFEST_RESOURCE_ID RT_MANIFEST "manifest.xml"

--- a/sdk/include/reactos/manifest_exe.rc
+++ b/sdk/include/reactos/manifest_exe.rc
@@ -1,1 +1,6 @@
+
+#ifndef CREATEPROCESS_MANIFEST_RESOURCE_ID
+#error please include winuser.h before including me!
+#endif
+
 CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "manifest.xml"


### PR DESCRIPTION
## Purpose

Missing the <winuser.h> include before including the manifest rc's causes the manifest to be added under the id 'ISOLATIONAWARE_MANIFEST_RESOURCE_ID' (as string) instead of under the id 1.
