### PR TITLE
Two ATL additions

### DIFF
--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -575,6 +575,17 @@ public:
         return ::GetDlgItemText(m_hWnd, nID, lpStr, nMaxCount);
     }
 
+#ifdef __ATLSTR_H__
+    UINT GetDlgItemText(int nID, CSimpleString& string)
+    {
+        HWND item = GetDlgItem(nID);
+        int len = ::GetWindowTextLength(item);
+        len = GetDlgItemText(nID, string.GetBuffer(len+1), len+1);
+        string.ReleaseBuffer(len);
+        return len;
+    }
+#endif
+
     BOOL GetDlgItemText(int nID, BSTR& bstrText) const
     {
         ATLASSERT(::IsWindow(m_hWnd));

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -1800,6 +1800,15 @@ public:                                                                         
             return TRUE;                                                                        \
     }
 
+#define COMMAND_CODE_HANDLER(code, func)                                                            \
+    if (uMsg == WM_COMMAND && code == HIWORD(wParam))                                                \
+    {                                                                                            \
+        bHandled = TRUE;                                                                        \
+        lResult = func(HIWORD(wParam), LOWORD(wParam), (HWND)lParam, bHandled);                    \
+        if (bHandled)                                                                            \
+            return TRUE;                                                                        \
+    }
+
 #define COMMAND_RANGE_HANDLER(idFirst, idLast, func)                                            \
     if (uMsg == WM_COMMAND && LOWORD(wParam) >= idFirst  && LOWORD(wParam) <= idLast)            \
     {                                                                                            \


### PR DESCRIPTION
Add the COMMAND_CODE_HANDLER macro and the CWindow::GetDlgItemText overload that takes a CString as parameter