### PR TITLE
[WIN32K] Check for empty output rect in GreGradientFill

### DIFF
--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -945,6 +945,12 @@ GreGradientFill(
     rclExtent.top    += pdc->ptlDCOrig.y;
     rclExtent.bottom += pdc->ptlDCOrig.y;
 
+    if (RECTL_bIsEmptyRect(&rclExtent))
+    {
+        DC_UnlockDc(pdc);
+        return TRUE;
+    }
+
     ptlDitherOrg.x = ptlDitherOrg.y = 0;
     IntLPtoDP(pdc, (LPPOINT)&ptlDitherOrg, 1);
 


### PR DESCRIPTION
Fixes a failed ASSERT.
JIRA issue: [CORE-14148](https://jira.reactos.org/browse/CORE-14148)
