### PR TITLE
Use KeClearEvent instead of KeResetEvent where the previous state is not needed

### DIFF
--- a/drivers/filters/mountmgr/mountmgr.c
+++ b/drivers/filters/mountmgr/mountmgr.c
@@ -872,7 +872,7 @@ MountMgrUnload(IN struct _DRIVER_OBJECT *DriverObject)
         NextEntry = RemoveHeadList(&(DeviceExtension->UniqueIdWorkerItemListHead));
         WorkItem = CONTAINING_RECORD(NextEntry, UNIQUE_ID_WORK_ITEM, UniqueIdWorkerItemListEntry);
 
-        KeResetEvent(&UnloadEvent);
+        KeClearEvent(&UnloadEvent);
         WorkItem->Event = &UnloadEvent;
 
         KeReleaseSemaphore(&(DeviceExtension->DeviceLock), IO_NO_INCREMENT,

--- a/drivers/hid/kbdhid/kbdhid.c
+++ b/drivers/hid/kbdhid/kbdhid.c
@@ -289,7 +289,7 @@ KbdHid_Create(
              DeviceExtension->FileObject = IoStack->FileObject;
 
              /* reset event */
-             KeResetEvent(&DeviceExtension->ReadCompletionEvent);
+             KeClearEvent(&DeviceExtension->ReadCompletionEvent);
 
              /* initiating read */
              Status = KbdHid_InitiateRead(DeviceExtension);

--- a/drivers/hid/mouhid/mouhid.c
+++ b/drivers/hid/mouhid/mouhid.c
@@ -497,7 +497,7 @@ MouHid_Create(
              DeviceExtension->FileObject = IoStack->FileObject;
 
              /* reset event */
-             KeResetEvent(&DeviceExtension->ReadCompletionEvent);
+             KeClearEvent(&DeviceExtension->ReadCompletionEvent);
 
              /* initiating read */
              Status = MouHid_InitiateRead(DeviceExtension);

--- a/drivers/input/sermouse/readmouse.c
+++ b/drivers/input/sermouse/readmouse.c
@@ -137,7 +137,7 @@ SermouseDeviceWorker(
 		if (Status != STATUS_TIMEOUT)
 		{
 			/* we need to stop the worker thread */
-			KeResetEvent(&DeviceExtension->StopWorkerThreadEvent);
+			KeClearEvent(&DeviceExtension->StopWorkerThreadEvent);
 			break;
 		}
 

--- a/drivers/network/ndis/ndis/control.c
+++ b/drivers/network/ndis/ndis/control.c
@@ -261,7 +261,7 @@ NdisResetEvent(
  *     Event = Pointer to the initialized event object to be reset
  */
 {
-  KeResetEvent(&Event->Event);
+  KeClearEvent(&Event->Event);
 }
 
 

--- a/drivers/network/ndis/ndis/io.c
+++ b/drivers/network/ndis/ndis/io.c
@@ -416,7 +416,7 @@ NdisMAllocateMapRegisters(
 
       NDIS_DbgPrint(MAX_TRACE, ("resetting event\n"));
 
-      KeResetEvent(&AllocationEvent);
+      KeClearEvent(&AllocationEvent);
     }
 
   NDIS_DbgPrint(MAX_TRACE, ("returning success\n"));

--- a/drivers/usb/usbhub_new/usbhub.c
+++ b/drivers/usb/usbhub_new/usbhub.c
@@ -2315,7 +2315,7 @@ USBH_ChangeIndication(IN PDEVICE_OBJECT DeviceObject,
 
     if (InterlockedIncrement(&HubExtension->ResetRequestCount) == 1)
     {
-        KeResetEvent(&HubExtension->ResetEvent);
+        KeClearEvent(&HubExtension->ResetEvent);
     }
 
     HubWorkItemBuffer->HubExtension = HubExtension;
@@ -2415,7 +2415,7 @@ USBH_SubmitStatusChangeTransfer(IN PUSBHUB_FDO_EXTENSION HubExtension)
                            TRUE,
                            TRUE);
 
-    KeResetEvent(&HubExtension->StatusChangeEvent);
+    KeClearEvent(&HubExtension->StatusChangeEvent);
 
     Status = IoCallDriver(HubExtension->LowerDevice, Irp);
 
@@ -2915,7 +2915,7 @@ USBD_RegisterRootHubCallBack(IN PUSBHUB_FDO_EXTENSION HubExtension)
         return STATUS_NOT_IMPLEMENTED;
     }
 
-    KeResetEvent(&HubExtension->RootHubNotificationEvent);
+    KeClearEvent(&HubExtension->RootHubNotificationEvent);
 
     return RootHubInitNotification(HubExtension->BusInterface.BusContext,
                                    HubExtension,
@@ -3828,7 +3828,7 @@ return; //HACK: delete it line after fixing Power Manager!!!
     if (IsHubCheck &&
         !(HubExtension->HubFlags & USBHUB_FDO_FLAG_WAIT_IDLE_REQUEST))
     {
-        KeResetEvent(&HubExtension->IdleEvent);
+        KeClearEvent(&HubExtension->IdleEvent);
         HubExtension->HubFlags |= USBHUB_FDO_FLAG_WAIT_IDLE_REQUEST;
         IsHubIdle = TRUE;
     }

--- a/drivers/usb/usbport/usbport.c
+++ b/drivers/usb/usbport/usbport.c
@@ -1393,7 +1393,7 @@ USBPORT_WorkerThread(IN PVOID StartContext)
         KeQuerySystemTime(&NewTime);
 
         KeAcquireSpinLock(&FdoExtension->WorkerThreadEventSpinLock, &OldIrql);
-        KeResetEvent(&FdoExtension->WorkerThreadEvent);
+        KeClearEvent(&FdoExtension->WorkerThreadEvent);
         KeReleaseSpinLock(&FdoExtension->WorkerThreadEventSpinLock, OldIrql);
         DPRINT_CORE("USBPORT_WorkerThread: run \n");
 

--- a/drivers/wdm/audio/legacy/stream/pnp.c
+++ b/drivers/wdm/audio/legacy/stream/pnp.c
@@ -413,7 +413,7 @@ StreamClassStartDevice(
     /* Setup get stream info struct */
     RequestBlock->Block.Command = SRB_GET_STREAM_INFO;
     RequestBlock->Block.CommandData.StreamBuffer = StreamDescriptor;
-    KeResetEvent(&RequestBlock->Event);
+    KeClearEvent(&RequestBlock->Event);
 
     /* send the request */
     DriverObjectExtension->Data.HwReceivePacket((PHW_STREAM_REQUEST_BLOCK)RequestBlock);

--- a/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
+++ b/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
@@ -458,7 +458,7 @@ DriverIoControl(
             RtlCopyMemory(Irp->AssociatedIrp.SystemBuffer, &WorkItem->Request, Length);
             Status = STATUS_SUCCESS;
 
-            KeResetEvent(&WorkList.NewWorkEvent);
+            KeClearEvent(&WorkList.NewWorkEvent);
             break;
 
         }

--- a/modules/rostests/kmtests/npfs/NpfsHelpers.c
+++ b/modules/rostests/kmtests/npfs/NpfsHelpers.c
@@ -709,7 +709,7 @@ TriggerWork(
                                    FALSE,
                                    NULL);
     ok_eq_hex(Status, STATUS_SUCCESS);
-    KeResetEvent(&Context->WorkCompleteEvent);
+    KeClearEvent(&Context->WorkCompleteEvent);
     KeSetEvent(&Context->StartWorkEvent, IO_NO_INCREMENT, TRUE);
     return WaitForWork(Context, MilliSeconds);
 }

--- a/ntoskrnl/fstub/disksup.c
+++ b/ntoskrnl/fstub/disksup.c
@@ -1014,7 +1014,7 @@ HalpGetFullGeometry(IN PDEVICE_OBJECT DeviceObject,
         }
 
         /* Reset event */
-        KeResetEvent(Event);
+        KeClearEvent(Event);
 
         /* Call the driver and check if it's pending */
         Status = IoCallDriver(DeviceObject, Irp);
@@ -1847,7 +1847,7 @@ xHalIoSetPartitionInformation(IN PDEVICE_OBJECT DeviceObject,
     do
     {
         /* Reset the event since we reuse it */
-        KeResetEvent(&Event);
+        KeClearEvent(&Event);
 
         /* Build the read IRP */
         Irp = IoBuildSynchronousFsdRequest(IRP_MJ_READ,
@@ -1912,7 +1912,7 @@ xHalIoSetPartitionInformation(IN PDEVICE_OBJECT DeviceObject,
                 PartitionDescriptor->PartitionType = (UCHAR)PartitionType;
 
                 /* Reset the reusable event */
-                KeResetEvent(&Event);
+                KeClearEvent(&Event);
 
                 /* Build the write IRP */
                 Irp = IoBuildSynchronousFsdRequest(IRP_MJ_WRITE,

--- a/ntoskrnl/io/iomgr/rawfs.c
+++ b/ntoskrnl/io/iomgr/rawfs.c
@@ -833,7 +833,7 @@ RawQueryFsSizeInfo(IN PVCB Vcb,
     else
     {
         /* Setup query IRP */
-        KeResetEvent(&Event);
+        KeClearEvent(&Event);
         Irp = IoBuildDeviceIoControlRequest(IOCTL_DISK_GET_PARTITION_INFO,
                                             RealDevice,
                                             NULL,

--- a/ntoskrnl/lpc/reply.c
+++ b/ntoskrnl/lpc/reply.c
@@ -608,7 +608,7 @@ NtReplyWaitReceivePortEx(IN HANDLE PortHandle,
         if (ReceivePort->Flags & LPCP_WAITABLE_PORT)
         {
             /* Reset its event */
-            KeResetEvent(&ReceivePort->WaitEvent);
+            KeClearEvent(&ReceivePort->WaitEvent);
         }
 
         /* Release the lock and fail */
@@ -630,7 +630,7 @@ NtReplyWaitReceivePortEx(IN HANDLE PortHandle,
         if (ReceivePort->Flags & LPCP_WAITABLE_PORT)
         {
             /* Reset its event */
-            KeResetEvent(&ReceivePort->WaitEvent);
+            KeClearEvent(&ReceivePort->WaitEvent);
         }
     }
 

--- a/sdk/lib/drivers/chew/workqueue.c
+++ b/sdk/lib/drivers/chew/workqueue.c
@@ -81,7 +81,7 @@ BOOLEAN ChewCreate(VOID (*Worker)(PVOID), PVOID WorkerContext)
         Item->Worker = Worker;
         Item->WorkerContext = WorkerContext;
         ExInterlockedInsertTailList(&WorkQueue, &Item->Entry, &WorkQueueLock);
-        KeResetEvent(&WorkQueueClear);
+        KeClearEvent(&WorkQueueClear);
         IoQueueWorkItem(Item->WorkItem, ChewWorkItem, DelayedWorkQueue, Item);
 
         return TRUE;

--- a/sdk/lib/drivers/rdbsslib/rdbss.c
+++ b/sdk/lib/drivers/rdbsslib/rdbss.c
@@ -4451,7 +4451,7 @@ RxCommonWrite(
                                           1,
                                           &RxStrucSupSpinLock) == 0)
                 {
-                    KeResetEvent(Fcb->NonPaged->OutstandingAsyncEvent);
+                    KeClearEvent(Fcb->NonPaged->OutstandingAsyncEvent);
                 }
 
                 UnwindOutstandingAsync = TRUE;

--- a/sdk/lib/drivers/rxce/rxce.c
+++ b/sdk/lib/drivers/rxce/rxce.c
@@ -7894,7 +7894,7 @@ RxScavengerTimerRoutine(
     {
         /* Done */
         Scavenger->State = RDBSS_SCAVENGER_ACTIVE;
-        KeResetEvent(&Scavenger->ScavengeEvent);
+        KeClearEvent(&Scavenger->ScavengeEvent);
 
         /* Scavenger the entries */
         RxReleaseScavengerMutex();
@@ -7982,7 +7982,7 @@ RxSpinUpRequestsDispatcher(
         {
             ListEntry = &RxDispatcher->SpinUpRequests;
         }
-        KeResetEvent(&RxDispatcher->SpinUpRequestsEvent);
+        KeClearEvent(&RxDispatcher->SpinUpRequestsEvent);
         KeReleaseSpinLock(&RxDispatcher->SpinUpRequestsLock, OldIrql);
 
         while (ListEntry != &RxDispatcher->SpinUpRequests)


### PR DESCRIPTION
This avoids having to acquire the dispatcher lock, thus improving performance.