### PR TITLE
[CHARMAP:NEW] Adding some indentation

### DIFF
--- a/base/applications/charmap_new/charmap.rc
+++ b/base/applications/charmap_new/charmap.rc
@@ -19,83 +19,83 @@ IDI_ICON ICON "res/charmap.ico"
 #pragma code_page(65001)
 
 #ifdef LANGUAGE_BG_BG
-#include "lang/bg-BG.rc"
+    #include "lang/bg-BG.rc"
 #endif
 #ifdef LANGUAGE_CA_ES
-#include "lang/ca-ES.rc"
+    #include "lang/ca-ES.rc"
 #endif
 #ifdef LANGUAGE_CS_CZ
-#include "lang/cs-CZ.rc"
+    #include "lang/cs-CZ.rc"
 #endif
 #ifdef LANGUAGE_DE_DE
-#include "lang/de-DE.rc"
+    #include "lang/de-DE.rc"
 #endif
 #ifdef LANGUAGE_EN_US
-#include "lang/en-US.rc"
+    #include "lang/en-US.rc"
 #endif
 #ifdef LANGUAGE_EL_GR
-#include "lang/el-GR.rc"
+    #include "lang/el-GR.rc"
 #endif
 #ifdef LANGUAGE_ES_ES
-#include "lang/es-ES.rc"
+    #include "lang/es-ES.rc"
 #endif
 #ifdef LANGUAGE_FR_FR
-#include "lang/fr-FR.rc"
+    #include "lang/fr-FR.rc"
 #endif
 #ifdef LANGUAGE_HE_IL
-#include "lang/he-IL.rc"
+    #include "lang/he-IL.rc"
 #endif
 #ifdef LANGUAGE_ID_ID
-#include "lang/id-ID.rc"
+    #include "lang/id-ID.rc"
 #endif
 #ifdef LANGUAGE_IT_IT
-#include "lang/it-IT.rc"
+    #include "lang/it-IT.rc"
 #endif
 #ifdef LANGUAGE_JA_JP
-#include "lang/ja-JP.rc"
+    #include "lang/ja-JP.rc"
 #endif
 #ifdef LANGUAGE_KO_KR
-#include "lang/ko-KR.rc"
+    #include "lang/ko-KR.rc"
 #endif
 #ifdef LANGUAGE_LT_LT
-#include "lang/lt-LT.rc"
+    #include "lang/lt-LT.rc"
 #endif
 #ifdef LANGUAGE_NL_NL
-#include "lang/nl-NL.rc"
+    #include "lang/nl-NL.rc"
 #endif
 #ifdef LANGUAGE_NB_NO
-#include "lang/no-NO.rc"
+    #include "lang/no-NO.rc"
 #endif
 #ifdef LANGUAGE_PL_PL
-#include "lang/pl-PL.rc"
+    #include "lang/pl-PL.rc"
 #endif
 #ifdef LANGUAGE_PT_BR
-#include "lang/pt-BR.rc"
+    #include "lang/pt-BR.rc"
 #endif
 #ifdef LANGUAGE_RO_RO
-#include "lang/ro-RO.rc"
+    #include "lang/ro-RO.rc"
 #endif
 #ifdef LANGUAGE_RU_RU
-#include "lang/ru-RU.rc"
+    #include "lang/ru-RU.rc"
 #endif
 #ifdef LANGUAGE_SK_SK
-#include "lang/sk-SK.rc"
+    #include "lang/sk-SK.rc"
 #endif
 #ifdef LANGUAGE_SQ_AL
-#include "lang/sq-AL.rc"
+    #include "lang/sq-AL.rc"
 #endif
 #ifdef LANGUAGE_SV_SE
-#include "lang/sv-SE.rc"
+    #include "lang/sv-SE.rc"
 #endif
 #ifdef LANGUAGE_TR_TR
-#include "lang/tr-TR.rc"
+    #include "lang/tr-TR.rc"
 #endif
 #ifdef LANGUAGE_UK_UA
-#include "lang/uk-UA.rc"
+    #include "lang/uk-UA.rc"
 #endif
 #ifdef LANGUAGE_ZH_CN
-#include "lang/zh-CN.rc"
+    #include "lang/zh-CN.rc"
 #endif
 #ifdef LANGUAGE_ZH_TW
-#include "lang/zh-TW.rc"
+    #include "lang/zh-TW.rc"
 #endif


### PR DESCRIPTION
## Purpose
As of now, charmap.rc lacks proper indentation for macro preprocessors especially `#include`. 
## Proposed changes
This patch doesn't bring any fancy stuff or the like, it just fixes the missing indentation. It is better to have an indented code so that it makes everyone's life easier.