### PR TITLE
[CHARMAP:NEW] Romanian language implementation

### DIFF
--- a/base/applications/charmap_new/lang/ro-RO.rc
+++ b/base/applications/charmap_new/lang/ro-RO.rc
@@ -1,7 +1,6 @@
 /*
  * PROJECT: ReactOS Character Map
  * LICENSE: GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
- * FILE: base/applications/charmap_new/lang/ro-RO.rc
  * PURPOSE: Romanian Translation for ReactOS Character Map
  * COPYRIGHT: Bișoc George (fraizeraust99@gmail.com)
  */

--- a/base/applications/charmap_new/lang/ro-RO.rc
+++ b/base/applications/charmap_new/lang/ro-RO.rc
@@ -1,8 +1,9 @@
 /*
  * PROJECT: ReactOS Character Map
+ * LICENSE: GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * FILE: base/applications/charmap_new/lang/ro-RO.rc
  * PURPOSE: Romanian Translation for ReactOS Character Map
- * TRANSLATORS: Bișoc George (fraizeraust99@gmail.com)
+ * COPYRIGHT: Bișoc George (fraizeraust99@gmail.com)
  */
  
  LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL

--- a/base/applications/charmap_new/lang/ro-RO.rc
+++ b/base/applications/charmap_new/lang/ro-RO.rc
@@ -1,0 +1,29 @@
+/*
+ * PROJECT: ReactOS Character Map
+ * FILE: base/applications/charmap_new/lang/ro-RO.rc
+ * PURPOSE: Romanian Translation for ReactOS Character Map
+ * TRANSLATORS: Bișoc George (fraizeraust99@gmail.com)
+ */
+ 
+ LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
+
+IDD_CHARMAP DIALOGEX 6, 6, 290, 224
+FONT 8, "MS Shell Dlg", 0, 0
+STYLE WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_SIZEBOX
+CAPTION "Hartă de caractere de ReactOS"
+BEGIN
+    LTEXT "Font:", IDC_STATIC, 6, 7, 24, 9
+    COMBOBOX IDC_FONTCOMBO, 28, 5, 150, 210, WS_CHILD | WS_VISIBLE |
+             WS_VSCROLL | CBS_DROPDOWNLIST | CBS_SORT | CBS_HASSTRINGS
+    LTEXT "Caractere de copiat:", IDC_STATIC, 6, 188, 66, 9
+    CONTROL "", IDC_TEXTBOX, RICHEDIT_CLASS, ES_AUTOHSCROLL | WS_BORDER |
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP, 74, 186, 114, 13
+    DEFPUSHBUTTON "Selectează", IDC_SELECT, 194, 186, 44, 13
+    PUSHBUTTON "Copiază", IDC_COPY, 242, 186, 44, 13, WS_DISABLED
+END
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUT "&Despre…"
+    IDS_TITLE "Hartă de caractere"
+END


### PR DESCRIPTION
## Purpose & Changes
The new ReactOS Character Map lacks a Romanian translation implementation, barely any. This patch adds the translation file for CHARMAP_NEW. 