### PR TITLE
[CHARMAP:NEW] Italian language implementation

### DIFF
--- a/base/applications/charmap_new/lang/it-IT.rc
+++ b/base/applications/charmap_new/lang/it-IT.rc
@@ -1,8 +1,9 @@
 /*
  * PROJECT: ReactOS Character Map
+ * LICENSE: GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * FILE: base/applications/charmap_new/lang/it-IT.rc
  * PURPOSE: Italian Translation for ReactOS Character Map
- * TRANSLATORS: Bișoc George (fraizeraust99@gmail.com)
+ * COPYRIGHT: Bișoc George (fraizeraust99@gmail.com)
  */
  
  LANGUAGE LANG_ITALIAN, SUBLANG_NEUTRAL

--- a/base/applications/charmap_new/lang/it-IT.rc
+++ b/base/applications/charmap_new/lang/it-IT.rc
@@ -24,6 +24,6 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_ABOUT "&Informazioni su..."
+    IDS_ABOUT "&Informazioni su…"
     IDS_TITLE "Mappa caratteri"
 END

--- a/base/applications/charmap_new/lang/it-IT.rc
+++ b/base/applications/charmap_new/lang/it-IT.rc
@@ -1,7 +1,6 @@
 /*
  * PROJECT: ReactOS Character Map
  * LICENSE: GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
- * FILE: base/applications/charmap_new/lang/it-IT.rc
  * PURPOSE: Italian Translation for ReactOS Character Map
  * COPYRIGHT: Bișoc George (fraizeraust99@gmail.com)
  */

--- a/base/applications/charmap_new/lang/it-IT.rc
+++ b/base/applications/charmap_new/lang/it-IT.rc
@@ -1,0 +1,29 @@
+/*
+ * PROJECT: ReactOS Character Map
+ * FILE: base/applications/charmap_new/lang/it-IT.rc
+ * PURPOSE: Italian Translation for ReactOS Character Map
+ * TRANSLATORS: Bișoc George (fraizeraust99@gmail.com)
+ */
+ 
+ LANGUAGE LANG_ITALIAN, SUBLANG_NEUTRAL
+
+IDD_CHARMAP DIALOGEX 6, 6, 290, 224
+FONT 8, "MS Shell Dlg", 0, 0
+STYLE WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_SIZEBOX
+CAPTION "Mappa Caratteri di ReactOS"
+BEGIN
+    LTEXT "Font:", IDC_STATIC, 6, 7, 24, 9
+    COMBOBOX IDC_FONTCOMBO, 28, 5, 150, 210, WS_CHILD | WS_VISIBLE |
+             WS_VSCROLL | CBS_DROPDOWNLIST | CBS_SORT | CBS_HASSTRINGS
+    LTEXT "Caratteri da copiare:", IDC_STATIC, 6, 188, 66, 9
+    CONTROL "", IDC_TEXTBOX, RICHEDIT_CLASS, ES_AUTOHSCROLL | WS_BORDER |
+            WS_CHILD | WS_VISIBLE | WS_TABSTOP, 74, 186, 114, 13
+    DEFPUSHBUTTON "Selezionare", IDC_SELECT, 194, 186, 44, 13
+    PUSHBUTTON "Copiare", IDC_COPY, 242, 186, 44, 13, WS_DISABLED
+END
+
+STRINGTABLE
+BEGIN
+    IDS_ABOUT "&Informazioni su..."
+    IDS_TITLE "Mappa caratteri"
+END


### PR DESCRIPTION
## Purpose & Changes
This patch contains the Italian translation file for charmap_new (ReactOS Character Map) considering nobody have done it before.