### PR TITLE
Wrong char in Romanian newdev translation fix

### DIFF
--- a/dll/win32/newdev/lang/ro-RO.rc
+++ b/dll/win32/newdev/lang/ro-RO.rc
@@ -15,7 +15,7 @@ CAPTION "Asistent de instalare dispozitiv"
 FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Bun venit!", IDC_WELCOMETITLE, 120, 8, 195, 16
-    LTEXT "Acest asistent va instala modúle-pilot pentru dispozitivul:", IDC_STATIC, 120, 21, 195, 16
+    LTEXT "Acest asistent va instala module-pilot pentru dispozitivul:", IDC_STATIC, 120, 21, 195, 16
     LTEXT "Apăsați „Înainte” pentru a continua.", IDC_STATIC, 120, 169, 195, 16
     LTEXT "DISPOZITIV NECUNOSCUT", IDC_DEVICE, 148, 36, 147, 12
     LTEXT "AVERTISMENT: INSTALAREA UNUI DISPOZITIV NEOBIȘNUIT VĂ POATE SCOATE DIN FUNCȚIUNE CALCULATORUL!", IDC_STATIC, 120, 59, 195, 16


### PR DESCRIPTION
The PR itself is self-explanatory, not needed to describe more.