### PR TITLE
[NTOS:EX] Don't dereference a keyed event that was never referenced.

### DIFF
--- a/ntoskrnl/ex/keyedevt.c
+++ b/ntoskrnl/ex/keyedevt.c
@@ -457,8 +457,11 @@ NtWaitForKeyedEvent(
     /* Do the wait */
     Status = ExpWaitForKeyedEvent(KeyedEvent, Key, Alertable, Timeout);
 
-    /* Dereference the keyed event */
-    ObDereferenceObject(KeyedEvent);
+    if (Handle != NULL)
+    {
+        /* Dereference the keyed event */
+        ObDereferenceObject(KeyedEvent);
+    }
 
     /* Return the status */
     return Status;
@@ -523,8 +526,11 @@ NtReleaseKeyedEvent(
     /* Do the wait */
     Status = ExpReleaseKeyedEvent(KeyedEvent, Key, Alertable, Timeout);
 
-    /* Dereference the keyed event */
-    ObDereferenceObject(KeyedEvent);
+    if (Handle != NULL)
+    {
+        /* Dereference the keyed event */
+        ObDereferenceObject(KeyedEvent);
+    }
 
     /* Return the status */
     return Status;


### PR DESCRIPTION
Don't dereference ExpCritSecOutOfMemoryEvent when it was never referenced.
