### PR TITLE
ntoskrnl: fix DPRINT format specifier in kdbg.c

### DIFF
--- a/ntoskrnl/kd/i386/kdbg.c
+++ b/ntoskrnl/kd/i386/kdbg.c
@@ -111,7 +111,7 @@ KdPortInitializeEx(
 
         /* Print message to blue screen */
         sprintf(buffer,
-                "\r\nKernel Debugger: Serial port found: COM%ld (Port 0x%lx) BaudRate %ld\r\n\r\n",
+                "\r\nKernel Debugger: Serial port found: COM%ld (Port 0x%p) BaudRate %ld\r\n\r\n",
                 ComPortNumber,
                 PortInformation->Address,
                 PortInformation->BaudRate);


### PR DESCRIPTION
## Purpose

I #undef'ed NDEBUG in File "ntoskrnl/kd/i386/kdbg.c", then my compiler complainted as follows:

```
../ntoskrnl/kd/i386/kdbg.c: In function 'KdPortInitializeEx':
../ntoskrnl/kd/i386/kdbg.c:117:17: error: format '%lx' expects argument of type 'long unsigned int', but argument 4 has type 'PUCHAR' [-Werror=format]
cc1.exe: all warnings being treated as errors
[254/537] Building C object ntoskrnl/n...les/ntkrnlmp.dir/__/mm/i386/page.c.obj
ninja: build stopped: subcommand failed.
```
JIRA issue: [CORE-14174](https://jira.reactos.org/browse/CORE-14174)

s/%lx/%p/