### PR TITLE
[KERNEL32] Accept images for NT 3.1 and higher instead of bailing out at image versions > 5.01

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -124,9 +124,24 @@ BasepIsImageVersionOk(IN ULONG ImageMajorVersion,
                       IN ULONG ImageMinorVersion)
 {
     /* Accept images for NT 3.1 or higher */
-    return ((ImageMajorVersion >= 3) &&
-            ((ImageMajorVersion != 3) ||
-             (ImageMinorVersion >= 10)));
+    if (ImageMajorVersion > 3 ||
+        (ImageMajorVersion == 3 && ImageMinorVersion >= 10))
+    {
+        /* ReactOS-specific: Accept images even if they are newer than our internal NT version. */
+        if (ImageMajorVersion > SharedUserData->NtMajorVersion ||
+            (ImageMajorVersion == SharedUserData->NtMajorVersion && ImageMinorVersion > SharedUserData->NtMinorVersion))
+        {
+            DPRINT1("Accepting image version %lu.%lu, although ReactOS is an NT %hu.%hu OS!\n",
+                ImageMajorVersion,
+                ImageMinorVersion,
+                SharedUserData->NtMajorVersion,
+                SharedUserData->NtMinorVersion);
+        }
+
+        return TRUE;
+    }
+
+    return FALSE;
 }
 
 NTSTATUS

--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -123,13 +123,10 @@ WINAPI
 BasepIsImageVersionOk(IN ULONG ImageMajorVersion,
                       IN ULONG ImageMinorVersion)
 {
-    /* Accept images for NT 3.1 or higher, as long as they're not newer than us */
+    /* Accept images for NT 3.1 or higher */
     return ((ImageMajorVersion >= 3) &&
             ((ImageMajorVersion != 3) ||
-             (ImageMinorVersion >= 10)) &&
-            (ImageMajorVersion <= SharedUserData->NtMajorVersion) &&
-            ((ImageMajorVersion != SharedUserData->NtMajorVersion) ||
-             (ImageMinorVersion <= SharedUserData->NtMinorVersion)));
+             (ImageMinorVersion >= 10)));
 }
 
 NTSTATUS


### PR DESCRIPTION
In my opinion, there is no reason to fail at image versions > 5.01 as long as we don't have a better way to deal with them.

This change already gets a simple "Hello World" compiled by VS 2017 regular "v141" toolchain to run under ReactOS.
It reports many missing apisets but prints its "Hello World" message. As soon as [Mark's work on apisets](https://github.com/learn-more/reactos/commits/apisets) is imported, these messages should vanish and many more NT6+ applications should be supported.