### PR TITLE
fonts: add GNU Unifont to the tree

### DIFF
--- a/media/fonts/CMakeLists.txt
+++ b/media/fonts/CMakeLists.txt
@@ -100,6 +100,7 @@ list(APPEND FONT_FILES
     UbuntuMono-RI.ttf
     Ubuntu-R.ttf
     Ubuntu-RI.ttf
+    unifont-10.0.07.ttf
     UniVGA16.ttf)
 
 foreach(item ${FONT_FILES})


### PR DESCRIPTION
## Purpose

This font is licensed under the GPLv2 and available from
http://unifoundry.com/unifont.html

Version 10.0.07 is included here, which has complete support for the
Basic Multilingual Plane of Unicode 10.0, and additional, but
incomplete, support for Plane 1.

JIRA issue: [CORE-14188](https://jira.reactos.org/browse/CORE-14188)

## Proposed changes

- Include Unifont, both the BMP and Plane 1 TTF files.