### PR TITLE
font/freetype: PAN_PROP_EVEN_WIDTH fonts should be FIXED_PITCH fonts

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1665,6 +1665,7 @@ FillTMEx(TEXTMETRICW *TM, PFONTGDI FontGDI,
     {
         switch (pOS2->panose[PAN_PROPORTION_INDEX])
         {
+            case PAN_PROP_EVEN_WIDTH:
             case PAN_PROP_MONOSPACED:
                 TM->tmPitchAndFamily = 0;
                 break;


### PR DESCRIPTION
## Purpose

ReactOS East-Asian Commpand Prompt should accept "Unifont" font. This Pull Request fixes the font interpretation.

JIRA issue: [CORE-14188](https://jira.reactos.org/browse/CORE-14188)
