### PR TITLE
[KERNEL32] Add version info to VerifyVersionInfo mismatch print.

### DIFF
--- a/dll/win32/kernel32/client/version.c
+++ b/dll/win32/kernel32/client/version.c
@@ -131,7 +131,18 @@ VerifyVersionInfoW(IN LPOSVERSIONINFOEXW lpVersionInformation,
             return FALSE;
 
         case STATUS_REVISION_MISMATCH:
-            DPRINT1("VerifyVersionInfo -- Version mismatch\n");
+            if (lpVersionInformation)
+            {
+                DPRINT1("VerifyVersionInfo -- Version mismatch(%d.%d.%d:%d)\n",
+                        (dwTypeMask & VER_MAJORVERSION) ? lpVersionInformation->dwMajorVersion : -1,
+                        (dwTypeMask & VER_MINORVERSION) ? lpVersionInformation->dwMinorVersion : -1,
+                        (dwTypeMask & VER_BUILDNUMBER) ? lpVersionInformation->dwBuildNumber : -1,
+                        (dwTypeMask & VER_PLATFORMID) ? lpVersionInformation->dwPlatformId : -1);
+            }
+            else
+            {
+                DPRINT1("VerifyVersionInfo -- Version mismatch(NULL)\n");
+            }
             SetLastError(ERROR_OLD_WIN_VERSION);
             return FALSE;
 


### PR DESCRIPTION
Changes the useless print `VerifyVersionInfo -- Version mismatch` into something usable by including some info about the requested version.