### PR TITLE
[EXPLORER] systray watcher

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -28,10 +28,12 @@
 #include <atlcom.h>
 #include <atlwin.h>
 #include <atlstr.h>
+#include <atlcoll.h>
 #include <shellapi.h>
 #include <shlobj.h>
 #include <shlwapi.h>
 #include <uxtheme.h>
+#include <process.h>
 #include <strsafe.h>
 
 #include <undocuser.h>

--- a/base/shell/explorer/trayntfy.cpp
+++ b/base/shell/explorer/trayntfy.cpp
@@ -122,7 +122,7 @@ public:
             {
                 IconWatcherData *Icon;
                 Icon = m_WatcherList.GetAt(Pos);
-                CloseHandle(Icon->hProcess);
+                delete Icon;
             }
         }
         m_WatcherList.RemoveAll();

--- a/base/shell/explorer/trayntfy.cpp
+++ b/base/shell/explorer/trayntfy.cpp
@@ -119,7 +119,7 @@ public:
         EnterCriticalSection(&m_ListLock);
 
         POSITION Pos;
-        for (int i = 0; i < m_WatcherList.GetCount(); i++)
+        for (size_t i = 0; i < m_WatcherList.GetCount(); i++)
         {
             Pos = m_WatcherList.FindIndex(i);
             if (Pos)
@@ -170,7 +170,7 @@ public:
 
     IconWatcherData* GetListEntry(_In_opt_ NOTIFYICONDATA *iconData, _In_opt_ HANDLE hProcess, _In_ bool Remove)
     {
-        IconWatcherData *Entry = nullptr;
+        IconWatcherData *Entry = NULL;
         POSITION NextPosition = m_WatcherList.GetHeadPosition();
         POSITION Position;
         do
@@ -188,7 +188,7 @@ public:
                     break;
                 }
             }
-            Entry = nullptr;
+            Entry = NULL;
 
         } while (NextPosition != NULL);
 
@@ -214,7 +214,7 @@ private:
             WatchList[0] = This->m_WakeUpEvent;
 
             POSITION Pos;
-            for (int i = 0; i < This->m_WatcherList.GetCount(); i++)
+            for (size_t i = 0; i < This->m_WatcherList.GetCount(); i++)
             {
                 Pos = This->m_WatcherList.FindIndex(i);
                 if (Pos)

--- a/base/shell/explorer/trayntfy.cpp
+++ b/base/shell/explorer/trayntfy.cpp
@@ -80,6 +80,8 @@ public:
     virtual ~CIconWatcher()
     {
         Uninitialize();
+        DeleteCriticalSection(&m_ListLock);
+
         if (m_WakeUpEvent)
             CloseHandle(m_WakeUpEvent);
         if (m_hWatcherThread)


### PR DESCRIPTION
Initial implementation of a watcher for the systray (notification area) that removes icons if the owning process dies or terminates without removing it.

This fixes a long time 'bug' in windows (win95 - win10) where notification icons can exist in the tray without an owner. Only when you move your mouse cursor over them do they disappear. 

If we don't want this on by default, I could add a checkbox to the taskbar setting to toggle this functionality?

https://i.imgur.com/MeMALd4.gif
https://i.imgur.com/NJNuDrD.gif
