### PR TITLE
ROSTESTS-274. TcpIpConnect: Fix a harmless typo

### DIFF
--- a/modules/rostests/kmtests/tcpip/TcpIp_user.c
+++ b/modules/rostests/kmtests/tcpip/TcpIp_user.c
@@ -57,7 +57,7 @@ AcceptProc(
     ok(Error == 0, "");
 
     ListenSocket = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    ok_bool_true(ListenSocket != INVALID_SOCKET, "socket failed");
+    ok(ListenSocket != INVALID_SOCKET, "socket failed");
 
     ZeroMemory(&ListenAddress, sizeof(ListenAddress));
     ListenAddress.sin_addr.S_un.S_addr = inet_addr("127.0.0.1");
@@ -77,7 +77,7 @@ AcceptProc(
     ok(AcceptSocket != INVALID_SOCKET, "\n");
     ok_eq_long(AcceptAddressLength, sizeof(AcceptAddress));
     ok_eq_hex(AcceptAddress.sin_addr.S_un.S_addr, inet_addr("127.0.0.1"));
-    ok_eq_hex(AcceptAddress.sin_port, ntohs(TEST_CONNECT_CLIENT_PORT));
+    ok_eq_hex(AcceptAddress.sin_port, htons(TEST_CONNECT_CLIENT_PORT));
 
     return 0;
 }


### PR DESCRIPTION
## Purpose

Trivial code fix. No functional changes.

JIRA issue: [ROSTESTS-274](https://jira.reactos.org/browse/ROSTESTS-274)

## Proposed changes

- 1 s/ok_bool_true/ok/, overkill though harmless.
- 1 s/ntohs/htons/, typo though harmless.
