### PR TITLE
[DESK.CPL] Fix hardcoded colors in classic theme preview

### DIFF
--- a/dll/cpl/desk/draw.c
+++ b/dll/cpl/desk/draw.c
@@ -611,10 +611,10 @@ MyDrawMenuBarTemp(HWND Wnd, HDC DC, LPRECT Rect, HMENU Menu, HFONT Font, COLOR_S
         if (i == 1)
         {
             ++rect.left; ++rect.top; ++rect.right; ++rect.bottom;
-            SetTextColor(DC, RGB(0xff, 0xff, 0xff));
+            SetTextColor(DC, scheme->crColor[COLOR_BTNHIGHLIGHT]);
             DrawTextW(DC, Text, -1, &rect, uFormat);
             --rect.left; --rect.top; --rect.right; --rect.bottom;
-            SetTextColor(DC, RGB(0x80, 0x80, 0x80));
+            SetTextColor(DC, scheme->crColor[COLOR_BTNSHADOW]);
         }
         DrawTextW(DC, Text, -1, &rect, uFormat);
     }


### PR DESCRIPTION
## Purpose

Fix text color for disabled menu in classic theme preview.

JIRA issue: [CORE-14238](https://jira.reactos.org/browse/CORE-14238)

## Proposed changes

- Remove hardcoded RGB's
- Obtain actual scheme colors from `crColor` array