### PR TITLE
[NTOS:MM] Make x64 address space layout more like Vista+

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -5,22 +5,28 @@
 
 #define _MI_PAGING_LEVELS                   4
 
-/* Memory layout base addresses */
+/* Memory layout base addresses (This is based on Vista!) */
 #define MI_USER_PROBE_ADDRESS           (PVOID)0x000007FFFFFF0000ULL
 #define MI_DEFAULT_SYSTEM_RANGE_START   (PVOID)0xFFFF080000000000ULL
 #define MI_REAL_SYSTEM_RANGE_START             0xFFFF800000000000ULL
-#define HYPER_SPACE                            0xFFFFF70000000000ULL
+//#define MI_PAGE_TABLE_BASE                   0xFFFFF68000000000ULL // 512 GB page tables
+#define HYPER_SPACE                            0xFFFFF70000000000ULL // 512 GB hyper space [MiVaProcessSpace]
 #define HYPER_SPACE_END                        0xFFFFF77FFFFFFFFFULL
-#define MI_SYSTEM_CACHE_WS_START               0xFFFFF78000001000ULL
-#define MI_PAGED_POOL_START             (PVOID)0xFFFFF8A000000000ULL
-//#define MI_PAGED_POOL_END                      0xFFFFF8BFFFFFFFFFULL
-//#define MI_SESSION_SPACE_START                 0xFFFFF90000000000ULL
+//#define MI_SHARED_SYSTEM_PAGE                0xFFFFF78000000000ULL
+#define MI_SYSTEM_CACHE_WS_START               0xFFFFF78000001000ULL // 512 GB - 4 KB system cache working set
+//#define MI_LOADER_MAPPINGS                   0xFFFFF80000000000ULL // 512 GB loader mappings aka KSEG0_BASE (NDK) [MiVaBootLoaded]
+#define MM_SYSTEM_SPACE_START                  0xFFFFF88000000000ULL // 128 GB system PTEs [MiVaSystemPtes]
+#define MI_DEBUG_MAPPING                (PVOID)0xFFFFF89FFFFFF000ULL // FIXME should be allocated from System PTEs
+#define MI_PAGED_POOL_START             (PVOID)0xFFFFF8A000000000ULL // 128 GB paged pool [MiVaPagedPool]
+//#define MI_PAGED_POOL_END                    0xFFFFF8BFFFFFFFFFULL
+//#define MI_SESSION_SPACE_START               0xFFFFF90000000000ULL // 512 GB session space [MiVaSessionSpace]
 #define MI_SESSION_VIEW_END                    0xFFFFF97FFF000000ULL
 #define MI_SESSION_SPACE_END                   0xFFFFF97FFFFFFFFFULL
-#define MM_SYSTEM_SPACE_START                  0xFFFFF98000000000ULL
-#define MI_PFN_DATABASE                        0xFFFFFA8000000000ULL
-#define MI_DEBUG_MAPPING                (PVOID)0xFFFFFFFF80000000ULL // FIXME
+#define MI_SYSTEM_CACHE_START                  0xFFFFF98000000000ULL // 1 TB system cache (on Vista+ this is dynamic VA space) [MiVaSystemCache,MiVaSpecialPoolPaged,MiVaSpecialPoolNonPaged]
+#define MI_SYSTEM_CACHE_END                    0xFFFFFA7FFFFFFFFFULL
+#define MI_PFN_DATABASE                        0xFFFFFA8000000000ULL // up to 5.5 TB PFN database followed by non paged pool [MiVaPfnDatabase/MiVaNonPagedPool]
 #define MI_NONPAGED_POOL_END            (PVOID)0xFFFFFFFFFFBFFFFFULL
+//#define MM_HAL_VA_START                      0xFFFFFFFFFFC00000ULL // 4 MB HAL mappings, defined in NDK [MiVaHal]
 #define MI_HIGHEST_SYSTEM_ADDRESS       (PVOID)0xFFFFFFFFFFFFFFFFULL
 #define MmSystemRangeStart              ((PVOID)MI_REAL_SYSTEM_RANGE_START)
 

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -1779,6 +1779,8 @@ MiBuildPagedPool(VOID)
     TempPte.u.Hard.PageFrameNumber = MmSystemPageDirectory[0];
     MI_WRITE_VALID_PTE(PointerPte, TempPte);
 #endif
+
+#ifdef _M_IX86
     //
     // Let's get back to paged pool work: size it up.
     // By default, it should be twice as big as nonpaged pool.
@@ -1795,6 +1797,7 @@ MiBuildPagedPool(VOID)
         MmSizeOfPagedPoolInBytes = (ULONG_PTR)MmNonPagedSystemStart -
                                    (ULONG_PTR)MmPagedPoolStart;
     }
+#endif // _M_IX86
 
     //
     // Get the size in pages and make sure paged pool is at least 32MB.
@@ -1814,11 +1817,13 @@ MiBuildPagedPool(VOID)
     MmSizeOfPagedPoolInBytes = Size * PAGE_SIZE * 1024;
     MmSizeOfPagedPoolInPages = MmSizeOfPagedPoolInBytes >> PAGE_SHIFT;
 
+#ifdef _M_IX86
     //
     // Let's be really sure this doesn't overflow into nonpaged system VA
     //
     ASSERT((MmSizeOfPagedPoolInBytes + (ULONG_PTR)MmPagedPoolStart) <=
            (ULONG_PTR)MmNonPagedSystemStart);
+#endif // _M_IX86
 
     //
     // This is where paged pool ends


### PR DESCRIPTION
- Change MM_SYSTEM_SPACE_START to 0xFFFFF88000000000
- Move MI_DEBUG_MAPPING to the end of the system PTE range
- Add MI_SYSTEM_CACHE_START and MI_SYSTEM_CACHE_END, which is in the range that Vista uses as dynamic VA space for cache and other allocations
- Wrap x86 specific code that makes now invalid assumptions about the address space layout in #ifdef _M_IX86
