### PR TITLE
[NTOSKRNL] Fix CcIdleDelay initializer for old msvc versions

### DIFF
--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -71,10 +71,10 @@ ULONG CcTotalDirtyPages = 0;
 LIST_ENTRY CcDeferredWrites;
 KSPIN_LOCK CcDeferredWriteSpinLock;
 LIST_ENTRY CcCleanSharedCacheMapList;
-#ifndef _MSC_VER
+#if !defined(_MSC_VER) || _MSC_VER >= 1900
 LARGE_INTEGER CcIdleDelay = {.QuadPart = (LONGLONG)-1*1000*1000*10};
 #else
-LARGE_INTEGER CcIdleDelay = {(LONGLONG)-1*1000*1000*10};
+LARGE_INTEGER CcIdleDelay = { { -1*1000*1000*10, -1 } };
 #endif
 
 /* Internal vars (ROS):

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -71,11 +71,7 @@ ULONG CcTotalDirtyPages = 0;
 LIST_ENTRY CcDeferredWrites;
 KSPIN_LOCK CcDeferredWriteSpinLock;
 LIST_ENTRY CcCleanSharedCacheMapList;
-#if !defined(_MSC_VER) || _MSC_VER >= 1900
-LARGE_INTEGER CcIdleDelay = {.QuadPart = (LONGLONG)-1*1000*1000*10};
-#else
-LARGE_INTEGER CcIdleDelay = { { -1*1000*1000*10, -1 } };
-#endif
+LARGE_INTEGER CcIdleDelay = RTL_CONSTANT_LARGE_INTEGER((LONGLONG)-1*1000*1000*10);
 
 /* Internal vars (ROS):
  * - Event to notify lazy writer to shutdown

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -403,6 +403,18 @@ extern BOOLEAN NTSYSAPI NLS_MB_OEM_CODE_PAGE_TAG;
 
 #endif /* NTOS_MODE_USER */
 
+//
+// Constant Large Integer Macro
+//
+#ifdef NONAMELESSUNION
+C_ASSERT(FIELD_OFFSET(LARGE_INTEGER, u.LowPart) == 0);
+#else
+C_ASSERT(FIELD_OFFSET(LARGE_INTEGER, LowPart) == 0);
+#endif
+#define RTL_CONSTANT_LARGE_INTEGER(quad_part) { { (quad_part), (quad_part)>>32 } }
+#define RTL_MAKE_LARGE_INTEGER(low_part, high_part) { { (low_part), (high_part) } }
+
+
 #ifdef NTOS_MODE_USER
 
 //


### PR DESCRIPTION
Fixes booting with msvc after the CcIdleDelay commit.