### PR TITLE
[NETCFGX] Rename 'Network connection' to 'Network Connection'.

### DIFF
--- a/dll/win32/netcfgx/lang/da-DK.rc
+++ b/dll/win32/netcfgx/lang/da-DK.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/el-GR.rc
+++ b/dll/win32/netcfgx/lang/el-GR.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/en-US.rc
+++ b/dll/win32/netcfgx/lang/en-US.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/hu-HU.rc
+++ b/dll/win32/netcfgx/lang/hu-HU.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/id-ID.rc
+++ b/dll/win32/netcfgx/lang/id-ID.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/ja-JP.rc
+++ b/dll/win32/netcfgx/lang/ja-JP.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/nl-NL.rc
+++ b/dll/win32/netcfgx/lang/nl-NL.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/sk-SK.rc
+++ b/dll/win32/netcfgx/lang/sk-SK.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/lang/sv-SE.rc
+++ b/dll/win32/netcfgx/lang/sv-SE.rc
@@ -197,7 +197,7 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_NET_CONNECT "Network connection"
+    IDS_NET_CONNECT "Network Connection"
     IDS_NO_IPADDR_SET "The adapter requires at least one IP address. Please enter one."
     IDS_NO_SUBMASK_SET "You have entered an address that is missing its subnet mask. Please add a subnet mask."
     IDS_TCPFILTERDESC "TCP/IP filtering allows you to control the type of TCP/IP network traffic that reaches your computer."

--- a/dll/win32/netcfgx/netcfgx.c
+++ b/dll/win32/netcfgx/netcfgx.c
@@ -439,7 +439,7 @@ InstallNetDevice(
 
     if (!LoadStringW(netcfgx_hInstance, IDS_NET_CONNECT, szBuffer, sizeof(szBuffer)/sizeof(WCHAR)))
     {
-        wcscpy(szBuffer,L"Network Connection");
+        wcscpy(szBuffer, L"Network Connection");
     }
 
     rc = RegSetValueExW(hConnectionKey, L"Name", 0, REG_SZ, (const BYTE*)szBuffer, (wcslen(szBuffer) + 1) * sizeof(WCHAR));

--- a/dll/win32/netcfgx/netcfgx.c
+++ b/dll/win32/netcfgx/netcfgx.c
@@ -439,7 +439,7 @@ InstallNetDevice(
 
     if (!LoadStringW(netcfgx_hInstance, IDS_NET_CONNECT, szBuffer, sizeof(szBuffer)/sizeof(WCHAR)))
     {
-        wcscpy(szBuffer,L"Network connection");
+        wcscpy(szBuffer,L"Network Connection");
     }
 
     rc = RegSetValueExW(hConnectionKey, L"Name", 0, REG_SZ, (const BYTE*)szBuffer, (wcslen(szBuffer) + 1) * sizeof(WCHAR));


### PR DESCRIPTION
 It should look a little better both in the system tray and in the Network Connections folder.

## Purpose

Fix the capitalization to make it look better in the system tray and in the Network Connections folder.

At some point, numbering the network connections is needed but that's beyond my expertise level.
