### PR TITLE
[WIP] [KMTESTS] KmtXVSNPrintF(): Always end with a new line char

### DIFF
--- a/modules/rostests/kmtests/example/Example.c
+++ b/modules/rostests/kmtests/example/Example.c
@@ -11,11 +11,11 @@ START_TEST(Example)
 {
     KIRQL Irql;
 
-    ok(1, "This test should succeed.\n");
-    ok(0, "This test should fail.\n");
-    trace("Message from kernel, low-irql. %s. %ls.\n", "Format strings work", L"Even with Unicode");
+    ok(1, "This test should succeed.");
+    ok(0, "This test should fail.");
+    trace("Message from kernel, low-irql. %s. %ls.", "Format strings work", L"Even with Unicode");
     KeRaiseIrql(HIGH_LEVEL, &Irql);
-    trace("Message from kernel, high-irql. %s. %ls.\n", "Format strings work", L"Even with Unicode");
+    trace("Message from kernel, high-irql. %s. %ls.", "Format strings work", L"Even with Unicode");
 
     ok_irql(DISPATCH_LEVEL);
     ok_eq_int(5, 6);
@@ -33,10 +33,10 @@ START_TEST(Example)
     ok_eq_str("Hello", "world");
     ok_eq_wstr(L"ABC", L"DEF");
 
-    if (!skip(KeGetCurrentIrql() == HIGH_LEVEL, "This should only work on HIGH_LEVEL\n"))
+    if (!skip(KeGetCurrentIrql() == HIGH_LEVEL, "This should only work on HIGH_LEVEL"))
     {
         /* do tests depending on HIGH_LEVEL here */
-        ok(1, "This is fine\n");
+        ok(1, "This is fine");
     }
 
     KeLowerIrql(Irql);

--- a/modules/rostests/kmtests/example/Example_drv.c
+++ b/modules/rostests/kmtests/example/Example_drv.c
@@ -65,7 +65,7 @@ TestEntry(
 
     *DeviceName = L"Example";
 
-    trace("Hi, this is the example driver\n");
+    trace("Hi, this is the example driver");
 
     KmtRegisterIrpHandler(IRP_MJ_CREATE, NULL, TestIrpHandler);
     KmtRegisterIrpHandler(IRP_MJ_CLOSE, NULL, TestIrpHandler);
@@ -100,7 +100,7 @@ TestUnload(
     ok_irql(PASSIVE_LEVEL);
     ok_eq_pointer(DriverObject, TestDriverObject);
 
-    trace("Unloading example driver\n");
+    trace("Unloading example driver");
 }
 
 /**
@@ -142,7 +142,7 @@ TestMessageHandler(
             static int TimesReceived = 0;
 
             ++TimesReceived;
-            ok(TimesReceived == 1, "Received control code 1 %d times\n", TimesReceived);
+            ok(TimesReceived == 1, "Received control code 1 %d times", TimesReceived);
             ok_eq_pointer(Buffer, NULL);
             ok_eq_ulong((ULONG)InLength, 0LU);
             ok_eq_ulong((ULONG)*OutLength, 0LU);
@@ -155,13 +155,13 @@ TestMessageHandler(
             ANSI_STRING ReceivedString;
 
             ++TimesReceived;
-            ok(TimesReceived == 1, "Received control code 2 %d times\n", TimesReceived);
-            ok(Buffer != NULL, "Buffer is NULL\n");
+            ok(TimesReceived == 1, "Received control code 2 %d times", TimesReceived);
+            ok(Buffer != NULL, "Buffer is NULL");
             ok_eq_ulong((ULONG)InLength, (ULONG)ExpectedString.Length);
             ok_eq_ulong((ULONG)*OutLength, 0LU);
             ReceivedString.MaximumLength = ReceivedString.Length = (USHORT)InLength;
             ReceivedString.Buffer = Buffer;
-            ok(RtlCompareString(&ExpectedString, &ReceivedString, FALSE) == 0, "Received string: %Z\n", &ReceivedString);
+            ok(RtlCompareString(&ExpectedString, &ReceivedString, FALSE) == 0, "Received string: %Z", &ReceivedString);
             break;
         }
         case IOCTL_SEND_MYSTRUCT:
@@ -171,14 +171,14 @@ TestMessageHandler(
             MY_STRUCT ResultStruct = { 456, "!!!" };
 
             ++TimesReceived;
-            ok(TimesReceived == 1, "Received control code 3 %d times\n", TimesReceived);
-            ok(Buffer != NULL, "Buffer is NULL\n");
+            ok(TimesReceived == 1, "Received control code 3 %d times", TimesReceived);
+            ok(Buffer != NULL, "Buffer is NULL");
             ok_eq_ulong((ULONG)InLength, (ULONG)sizeof ExpectedStruct);
             ok_eq_ulong((ULONG)*OutLength, 2LU * sizeof ExpectedStruct);
-            if (!skip(Buffer && InLength >= sizeof ExpectedStruct, "Cannot read from buffer!\n"))
-                ok(RtlCompareMemory(&ExpectedStruct, Buffer, sizeof ExpectedStruct) == sizeof ExpectedStruct, "Buffer does not contain expected values\n");
+            if (!skip(Buffer && InLength >= sizeof ExpectedStruct, "Cannot read from buffer!"))
+                ok(RtlCompareMemory(&ExpectedStruct, Buffer, sizeof ExpectedStruct) == sizeof ExpectedStruct, "Buffer does not contain expected values");
 
-            if (!skip(Buffer && *OutLength >= 2 * sizeof ExpectedStruct, "Cannot write to buffer!\n"))
+            if (!skip(Buffer && *OutLength >= 2 * sizeof ExpectedStruct, "Cannot write to buffer!"))
             {
                 RtlCopyMemory((PCHAR)Buffer + sizeof ExpectedStruct, &ResultStruct, sizeof ResultStruct);
                 *OutLength = 2 * sizeof ExpectedStruct;
@@ -186,7 +186,7 @@ TestMessageHandler(
             break;
         }
         default:
-            ok(0, "Got an unknown message! DeviceObject=%p, ControlCode=%lu, Buffer=%p, In=%lu, Out=%lu bytes\n",
+            ok(0, "Got an unknown message! DeviceObject=%p, ControlCode=%lu, Buffer=%p, In=%lu, Out=%lu bytes",
                     DeviceObject, ControlCode, Buffer, InLength, *OutLength);
             break;
     }
@@ -230,11 +230,11 @@ TestIrpHandler(
     ok_eq_pointer(DeviceObject->DriverObject, TestDriverObject);
 
     if (IoStackLocation->MajorFunction == IRP_MJ_CREATE)
-        trace("Got IRP_MJ_CREATE!\n");
+        trace("Got IRP_MJ_CREATE!");
     else if (IoStackLocation->MajorFunction == IRP_MJ_CLOSE)
-        trace("Got IRP_MJ_CLOSE!\n");
+        trace("Got IRP_MJ_CLOSE!");
     else
-        trace("Got an IRP!\n");
+        trace("Got an IRP!");
 
     Irp->IoStatus.Status = Status;
     Irp->IoStatus.Information = 0;

--- a/modules/rostests/kmtests/example/Example_user.c
+++ b/modules/rostests/kmtests/example/Example_user.c
@@ -16,10 +16,10 @@ START_TEST(Example)
     MY_STRUCT MyStruct[2] = { { 123, ":D" }, { 0 } };
     DWORD Length = sizeof MyStruct;
 
-    trace("Message from user-mode\n");
+    trace("Message from user-mode");
 
     GetSystemInfo(&SystemInfo);
-    ok(SystemInfo.dwActiveProcessorMask != 0, "No active processors?!\n");
+    ok(SystemInfo.dwActiveProcessorMask != 0, "No active processors?!");
 
     /* now run the kernel-mode part (see Example.c).
      * If no user-mode part exists, this is what's done automatically */
@@ -27,18 +27,18 @@ START_TEST(Example)
 
     /* now start the special-purpose driver */
     KmtLoadDriver(L"Example", FALSE);
-    trace("After Entry\n");
+    trace("After Entry");
     KmtOpenDriver();
-    trace("After Create\n");
+    trace("After Create");
 
-    ok(KmtSendToDriver(IOCTL_NOTIFY) == ERROR_SUCCESS, "\n");
-    ok(KmtSendStringToDriver(IOCTL_SEND_STRING, "yay") == ERROR_SUCCESS, "\n");
-    ok(KmtSendBufferToDriver(IOCTL_SEND_MYSTRUCT, MyStruct, sizeof MyStruct[0], &Length) == ERROR_SUCCESS, "\n");
+    ok(KmtSendToDriver(IOCTL_NOTIFY) == ERROR_SUCCESS, "");
+    ok(KmtSendStringToDriver(IOCTL_SEND_STRING, "yay") == ERROR_SUCCESS, "");
+    ok(KmtSendBufferToDriver(IOCTL_SEND_MYSTRUCT, MyStruct, sizeof MyStruct[0], &Length) == ERROR_SUCCESS, "");
     ok_eq_int(MyStruct[1].a, 456);
     ok_eq_str(MyStruct[1].b, "!!!");
 
     KmtCloseDriver();
-    trace("After Close\n");
+    trace("After Close");
     KmtUnloadDriver();
-    trace("After Unload\n");
+    trace("After Unload");
 }


### PR DESCRIPTION
## Purpose

Makes the harness consistent and improves output.

## Proposed changes

- Plus: Update license header.
- Also: Simplify BufferLength with BufferStart.
- And update all callers.

## TODO

- [ ] Update rest of callers.
