### PR TITLE
[WIP] CORE-14269. ScmControlDriver(): After STOP, update reported service status too

### DIFF
--- a/base/system/services/driver.c
+++ b/base/system/services/driver.c
@@ -309,7 +309,7 @@ ScmControlDriver(PSERVICE lpService,
                 lpService->Status.dwControlsAccepted = 0;
                 lpService->Status.dwCurrentState = SERVICE_STOPPED;
             }
-            break;
+            // Fallthrough, to update lpServiceStatus.
 
         case SERVICE_CONTROL_INTERROGATE:
             dwError = ScmGetDriverStatus(lpService,


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14269](https://jira.reactos.org/browse/CORE-14269)

## Proposed changes

Big jump, though 1-liner.
Smaller impact alternatives:
- Update on success only.
- Update inline instead. Maybe some data only.

## TODO

- [ ] Do a `TEST KVM` run.
