### PR TITLE
CORE-12321. Round memory size up, "debug log" part

### DIFF
--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1580,8 +1580,9 @@ Phase1InitializationDiscard(IN PVOID Context)
                                WINDOWS_NT_INFO_STRING,
                                &MsgEntry);
 
-    /* Get total RAM size */
-    Size = MmNumberOfPhysicalPages * PAGE_SIZE / 1024 / 1024;
+    /* Get total RAM size, in MiB */
+    /* Round size up. Assumed to better match actual physical RAM size */
+    Size = ALIGN_UP_BY(MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
 
     /* Create the string */
     StringBuffer = InitBuffer->VersionBuffer;

--- a/ntoskrnl/kd/kdio.c
+++ b/ntoskrnl/kd/kdio.c
@@ -93,7 +93,8 @@ KdpGetMemorySizeInMBs(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
         }
     }
 
-    return NumberOfPhysicalPages * PAGE_SIZE / 1024 / 1024;
+    /* Round size up. Assumed to better match actual physical RAM size */
+    return ALIGN_UP_BY(NumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
 }
 
 /* See also: kd64\kdinit.c */
@@ -255,7 +256,8 @@ KdpInitDebugLog(PKD_DISPATCH_TABLE DispatchTable,
         KeInitializeSpinLock(&KdpDebugLogSpinLock);
 
         /* Display separator + ReactOS version at start of the debug log */
-        MemSizeMBs = MmNumberOfPhysicalPages * PAGE_SIZE / 1024 / 1024;
+        /* Round size up. Assumed to better match actual physical RAM size */
+        MemSizeMBs = ALIGN_UP_BY(MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
         KdpPrintBanner(MemSizeMBs);
     }
     else if (BootPhase == 2)
@@ -554,7 +556,8 @@ KdpScreenInit(PKD_DISPATCH_TABLE DispatchTable,
         KeInitializeSpinLock(&KdpDmesgLogSpinLock);
 
         /* Display separator + ReactOS version at start of the debug log */
-        MemSizeMBs = MmNumberOfPhysicalPages * PAGE_SIZE / 1024 / 1024;
+        /* Round size up. Assumed to better match actual physical RAM size */
+        MemSizeMBs = ALIGN_UP_BY(MmNumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
         KdpPrintBanner(MemSizeMBs);
     }
     else if (BootPhase == 2)

--- a/ntoskrnl/kd64/kdinit.c
+++ b/ntoskrnl/kd64/kdinit.c
@@ -62,7 +62,8 @@ KdpGetMemorySizeInMBs(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
         }
     }
 
-    return NumberOfPhysicalPages * PAGE_SIZE / 1024 / 1024;
+    /* Round size up. Assumed to better match actual physical RAM size */
+    return ALIGN_UP_BY(NumberOfPhysicalPages * PAGE_SIZE, 1024 * 1024) / (1024 * 1024);
 }
 
 /* See also: kd\kdio.c */


### PR DESCRIPTION
## Purpose

This fixes the "debug log" part of the issue.

JIRA issue: [CORE-12321](https://jira.reactos.org/browse/CORE-12321)

## Proposed changes

- Round memory size up. Assumed to better match actual physical RAM size.

## TODO

- [X] Port this to `kd` and `kd64`.
