### PR TITLE
CORE-14306. Fix 2 Clang-Cl "constant operand" warnings

### DIFF
--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -170,8 +170,11 @@ INT_PTR CALLBACK GeneralPageProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM 
             return TRUE;
 
         case WM_COMMAND:
-            if (LOWORD(wParam) == IDC_RENDERER || IDC_DEBUG_OUTPUT)
+            if (LOWORD(wParam) == IDC_RENDERER ||
+                LOWORD(wParam) == IDC_DEBUG_OUTPUT)
+            {
                 PropSheet_Changed(GetParent(hWndDlg), hWndDlg);
+            }
             break;
 
         case WM_NOTIFY:

--- a/win32ss/reactx/dxg/dd.c
+++ b/win32ss/reactx/dxg/dd.c
@@ -28,7 +28,7 @@ DxDdCanCreateSurface(
     // assign out DirectDrawGlobal to SurfaceData
     SurfaceData->lpDD = (PDD_DIRECTDRAW_GLOBAL)peDdGl;
 
-    if (peDdGl->ddCallbacks.dwFlags && DDHAL_CB32_CANCREATESURFACE)
+    if (peDdGl->ddCallbacks.dwFlags & DDHAL_CB32_CANCREATESURFACE)
     {
         RetVal = peDdGl->ddCallbacks.CanCreateSurface(SurfaceData);
     }


### PR DESCRIPTION
## Purpose

Assumed fixes...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- [OPENGLCFG] Fix a Clang-Cl warning about IDC_DEBUG_OUTPUT.
Added as is in r74208 by khornicek.
- [DXG] Fix a Clang-Cl warning about DDHAL_CB32_CANCREATESURFACE.
Added as is in r74181 by @gasioreks.
