### PR TITLE
[EXPLORER] WatchList should be freed with delete[], not delete

### DIFF
--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -479,7 +479,7 @@ UINT WINAPI CIconWatcher::WatcherThread(_In_opt_ LPVOID lpParam)
     }
 
     if (WatchList)
-        delete WatchList;
+        delete[] WatchList;
 
     return 0;
 }

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -413,7 +413,7 @@ UINT WINAPI CIconWatcher::WatcherThread(_In_opt_ LPVOID lpParam)
         ASSERT(Size <= MAXIMUM_WAIT_OBJECTS);
 
         if (WatchList)
-            delete WatchList;
+            delete[] WatchList;
         WatchList = new HANDLE[Size];
         WatchList[0] = This->m_WakeUpEvent;
 


### PR DESCRIPTION
## Purpose
WatchList gets declared as a single NULL pointer value and gets freed from the memory after. This is the correct behaviour, however in the 417 line, WatchList is created again but as a set of array objects with `new[]`. Freeing it later with `delete` but not `delete[]` will surely cause a undefined behaviour in the code.
## Changes
Using `delete[]` for deleting the variable and its array should be the correct way to avoid unexpected results.

**NOTE:** The idea of making this PR is not mine. A guy named maddin200 (source post: [click me!](https://www.reactos.org/forum/viewtopic.php?f=13&t=16923)) noticed this issue and for some reason he  can't create a patch so I decided to create the pull request for him.