### PR TITLE
CORE-14306. Fix 2 Clang-Cl warnings about ok2

### DIFF
--- a/modules/rostests/apitests/appshim/versionlie.c
+++ b/modules/rostests/apitests/appshim/versionlie.c
@@ -62,7 +62,7 @@ static void verify_shima_imp(PHOOKAPI hook, const VersionLieInfo* info, PCSTR sh
 
     while (v1.dwOSVersionInfoSize)
     {
-        ok1 = GetVersionExA((LPOSVERSIONINFOA)&v1), ok2;
+        ok1 = GetVersionExA((LPOSVERSIONINFOA)&v1);
         hook->OriginalFunction = GetVersionExA;
 
         ok2 = ((GETVERSIONEXAPROC)hook->ReplacementFunction)(&v2);
@@ -127,7 +127,7 @@ static void verify_shimw_imp(PHOOKAPI hook, const VersionLieInfo* info, PCSTR sh
 
     while (v1.dwOSVersionInfoSize)
     {
-        ok1 = GetVersionExW((LPOSVERSIONINFOW)&v1), ok2;
+        ok1 = GetVersionExW((LPOSVERSIONINFOW)&v1);
         hook->OriginalFunction = GetVersionExW;
 
         ok2 = ((GETVERSIONEXWPROC)hook->ReplacementFunction)(&v2);


### PR DESCRIPTION
## Purpose

Assumed fixes...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: expression result unused [-Wunused-value]"
Added as is in r71442 by @learn-more.
