### PR TITLE
CORE-14306. Fix a Clang-Cl warning about Icon->ProcessId

### DIFF
--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -332,7 +332,7 @@ bool CIconWatcher::AddIconToWatcher(_In_ CONST NOTIFYICONDATA *iconData)
 
     IconWatcherData *Icon = new IconWatcherData(iconData);
     Icon->hProcess = hProcess;
-    Icon->ProcessId;
+    Icon->ProcessId = ProcessId;
 
     bool Added = false;
     EnterCriticalSection(&m_ListLock);


### PR DESCRIPTION
## Purpose

Assumed fix...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: expression result unused [-Wunused-value]"
Regressed in be2bf9b by @gedmurphy.
