### PR TITLE
CORE-14306. Fix 2 Clang-Cl warnings about __pfnDliNotifyHook2Default and __pfnDliFailureHook2Default

### DIFF
--- a/sdk/lib/delayimp/delayimp.c
+++ b/sdk/lib/delayimp/delayimp.c
@@ -15,14 +15,11 @@
 
 /**** Linker magic: provide a default (NULL) pointer, but allow the user to override it ****/
 
-#if defined(__GNUC__)
+/* The actual items we use */
 PfnDliHook __pfnDliNotifyHook2;
 PfnDliHook __pfnDliFailureHook2;
-#else
-/* The actual items we use */
-extern PfnDliHook __pfnDliNotifyHook2;
-extern PfnDliHook __pfnDliFailureHook2;
 
+#if !defined(__GNUC__)
 /* The fallback symbols */
 PfnDliHook __pfnDliNotifyHook2Default = NULL;
 PfnDliHook __pfnDliFailureHook2Default = NULL;

--- a/sdk/lib/delayimp/delayimp.c
+++ b/sdk/lib/delayimp/delayimp.c
@@ -24,8 +24,8 @@ extern PfnDliHook __pfnDliNotifyHook2;
 extern PfnDliHook __pfnDliFailureHook2;
 
 /* The fallback symbols */
-extern PfnDliHook __pfnDliNotifyHook2Default = NULL;
-extern PfnDliHook __pfnDliFailureHook2Default = NULL;
+PfnDliHook __pfnDliNotifyHook2Default = NULL;
+PfnDliHook __pfnDliFailureHook2Default = NULL;
 
 /* Tell the linker to use the fallback symbols */
 #if defined (_M_IX86)


### PR DESCRIPTION
## Purpose

Assumed fixes...
I don't have MsVC. This PR may need different solutions.

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: 'extern' variable has an initializer [-Wextern-initializer]"
Added as is in r71190 by @learn-more.

Plus:
-  Fix/Merge definitions of __pfnDliNotifyHook2 and __pfnDliFailureHook2.
NB: They are already declared `extern` in the `.h`.
