### PR TITLE
CORE-14306. Fix 3 Clang-Cl warnings in kmtests

### DIFF
--- a/modules/rostests/kmtests/npfs/NpfsHelpers.c
+++ b/modules/rostests/kmtests/npfs/NpfsHelpers.c
@@ -103,6 +103,11 @@ NpCreatePipe(
         ShareAccess = FILE_SHARE_READ;
     else if (NamedPipeConfiguration == FILE_PIPE_FULL_DUPLEX)
         ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    else
+    {
+        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!", FALSE);
+        return STATUS_INVALID_PARAMETER_6;
+    }
 
     DefaultTimeout.QuadPart = -50 * 1000 * 10;
 
@@ -185,6 +190,11 @@ NpOpenPipe(
         ShareAccess = FILE_SHARE_READ;
     else if (NamedPipeConfiguration == FILE_PIPE_FULL_DUPLEX)
         ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
+    else
+    {
+        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!", FALSE);
+        return STATUS_INVALID_PARAMETER_3;
+    }
 
     return NpOpenPipeEx(ClientHandle,
                         PipePath,

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -27,12 +27,13 @@ QueryFileInfo(
         Buffer = KmtAllocateGuarded(*Length);
         if (skip(Buffer != NULL, "Failed to allocate %Iu bytes\n", *Length))
             return STATUS_INSUFFICIENT_RESOURCES;
+
+        RtlFillMemory(Buffer, *Length, 0xdd);
     }
     else
     {
         Buffer = NULL;
     }
-    RtlFillMemory(Buffer, *Length, 0xDD);
     RtlFillMemory(&IoStatus, sizeof(IoStatus), 0x55);
     _SEH2_TRY
     {
@@ -55,8 +56,16 @@ QueryFileInfo(
         ok_eq_hex(Status, STATUS_SUCCESS);
         Status = IoStatus.Status;
     }
+
     *Length = IoStatus.Information;
-    *Info = Buffer;
+    if (NT_SUCCESS(Status))
+    {
+        *Info = Buffer;
+    }
+    else if (Buffer)
+    {
+        KmtFreeGuarded(Buffer);
+    }
     return Status;
 }
 
@@ -140,33 +149,35 @@ TestAllInformation(VOID)
     Length = FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + MAX_PATH * sizeof(WCHAR);
     Status = QueryFileInfo(FileHandle, (PVOID*)&FileAllInfo, &Length, FileAllInformation);
     ok_eq_hex(Status, STATUS_SUCCESS);
-    if (!skip(NT_SUCCESS(Status) && FileAllInfo != NULL, "No info\n"))
+    if (skip(NT_SUCCESS(Status) && FileAllInfo != NULL, "No info\n"))
     {
-        NameLength = FileAllInfo->NameInformation.FileNameLength;
-        ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength);
-        Name = ExAllocatePoolWithTag(PagedPool, NameLength + sizeof(UNICODE_NULL), 'sFmK');
-        if (!skip(Name != NULL, "Could not allocate %lu bytes\n", NameLength + (ULONG)sizeof(UNICODE_NULL)))
-        {
-            RtlCopyMemory(Name,
-                          FileAllInfo->NameInformation.FileName,
-                          NameLength);
-            Name[NameLength / sizeof(WCHAR)] = UNICODE_NULL;
-            ok(Name[0] == L'\\', "Name is %ls, expected first char to be \\\n", Name);
-            ok(NameLength >= Ntoskrnl.Length + sizeof(WCHAR), "NameLength %lu too short\n", NameLength);
-            if (NameLength >= Ntoskrnl.Length)
-            {
-                NamePart.Buffer = Name + (NameLength - Ntoskrnl.Length) / sizeof(WCHAR);
-                NamePart.Length = Ntoskrnl.Length;
-                NamePart.MaximumLength = NamePart.Length;
-                ok(RtlEqualUnicodeString(&NamePart, &Ntoskrnl, TRUE),
-                   "Name ends in '%wZ', expected %wZ\n", &NamePart, &Ntoskrnl);
-            }
-            ExFreePoolWithTag(Name, 'sFmK');
-        }
-        ok(FileAllInfo->NameInformation.FileName[NameLength / sizeof(WCHAR)] == 0xdddd,
-           "Char past FileName is %x\n",
-           FileAllInfo->NameInformation.FileName[NameLength / sizeof(WCHAR)]);
+        goto NoInfo;
     }
+
+    NameLength = FileAllInfo->NameInformation.FileNameLength;
+    ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength);
+    Name = ExAllocatePoolWithTag(PagedPool, NameLength + sizeof(UNICODE_NULL), 'sFmK');
+    if (!skip(Name != NULL, "Could not allocate %lu bytes\n", NameLength + (ULONG)sizeof(UNICODE_NULL)))
+    {
+        RtlCopyMemory(Name,
+                      FileAllInfo->NameInformation.FileName,
+                      NameLength);
+        Name[NameLength / sizeof(WCHAR)] = UNICODE_NULL;
+        ok(Name[0] == L'\\', "Name is %ls, expected first char to be \\\n", Name);
+        ok(NameLength >= Ntoskrnl.Length + sizeof(WCHAR), "NameLength %lu too short\n", NameLength);
+        if (NameLength >= Ntoskrnl.Length)
+        {
+            NamePart.Buffer = Name + (NameLength - Ntoskrnl.Length) / sizeof(WCHAR);
+            NamePart.Length = Ntoskrnl.Length;
+            NamePart.MaximumLength = NamePart.Length;
+            ok(RtlEqualUnicodeString(&NamePart, &Ntoskrnl, TRUE),
+               "Name ends in '%wZ', expected %wZ\n", &NamePart, &Ntoskrnl);
+        }
+        ExFreePoolWithTag(Name, 'sFmK');
+    }
+    ok(FileAllInfo->NameInformation.FileName[NameLength / sizeof(WCHAR)] == 0xdddd,
+       "Char past FileName is %x\n",
+       FileAllInfo->NameInformation.FileName[NameLength / sizeof(WCHAR)]);
     if (FileAllInfo)
         KmtFreeGuarded(FileAllInfo);
 
@@ -210,6 +221,7 @@ TestAllInformation(VOID)
     if (FileAllInfo)
         KmtFreeGuarded(FileAllInfo);
 
+NoInfo:
     Status = ObCloseHandle(FileHandle, KernelMode);
     ok_eq_hex(Status, STATUS_SUCCESS);
 }

--- a/modules/rostests/kmtests/ntos_io/IoFilesystem.c
+++ b/modules/rostests/kmtests/ntos_io/IoFilesystem.c
@@ -73,7 +73,7 @@ TestAllInformation(VOID)
     PFILE_ALL_INFORMATION FileAllInfo;
     SIZE_T Length;
     ULONG NameLength;
-    PWCHAR Name = NULL;
+    PWCHAR Name;
     UNICODE_STRING NamePart;
 
     InitializeObjectAttributes(&ObjectAttributes,
@@ -161,6 +161,7 @@ TestAllInformation(VOID)
                 ok(RtlEqualUnicodeString(&NamePart, &Ntoskrnl, TRUE),
                    "Name ends in '%wZ', expected %wZ\n", &NamePart, &Ntoskrnl);
             }
+            ExFreePoolWithTag(Name, 'sFmK');
         }
         ok(FileAllInfo->NameInformation.FileName[NameLength / sizeof(WCHAR)] == 0xdddd,
            "Char past FileName is %x\n",
@@ -208,8 +209,6 @@ TestAllInformation(VOID)
     ok_eq_size(Length, FIELD_OFFSET(FILE_ALL_INFORMATION, NameInformation.FileName) + NameLength);
     if (FileAllInfo)
         KmtFreeGuarded(FileAllInfo);
-
-    ExFreePoolWithTag(Name, 'sFmK');
 
     Status = ObCloseHandle(FileHandle, KernelMode);
     ok_eq_hex(Status, STATUS_SUCCESS);


### PR DESCRIPTION
## Purpose

Assumed fixes...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: variable 'ShareAccess' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]"
Added as is in r62695 by @ThFabba.
- "warning: variable 'NameLength' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]"
Added as is in r69897 by @ThFabba.
- Also make an ExFreePoolWithTag() call conditional.
Added as is in r69897 by @ThFabba.
