### PR TITLE
[SC] Disable debug messages on user interface

### DIFF
--- a/base/applications/sc/sc.h
+++ b/base/applications/sc/sc.h
@@ -14,7 +14,8 @@
 #include <ndk/setypes.h>
 
 
-#define SCDBG
+// Uncomment to enable debug messages on user interface.
+// #define SCDBG
 
 typedef struct
 {


### PR DESCRIPTION
## Purpose

Whether this feature was activated on purpose or not, I assume it is not needed anymore, 11.5 years later.

Noticed in
JIRA issue: [CORE-14260](https://jira.reactos.org/browse/CORE-14260)

## Proposed changes

- Comment `#define SCDBG` out.
Uncommented in r23868 by @gedmurphy.
