### PR TITLE
[OLEAUT32] Sync oleaut32 with wine 3.2 + wine-staging 2.21

### DIFF
--- a/dll/win32/oleaut32/connpt.c
+++ b/dll/win32/oleaut32/connpt.c
@@ -22,9 +22,22 @@
  * comments just above that function for information.
  */
 
-#include "precomp.h"
-
 #include <assert.h>
+#include <stdarg.h>
+#include <string.h>
+
+#define COBJMACROS
+
+#include "winerror.h"
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "ole2.h"
+#include "olectl.h"
+#include "connpt.h"
+
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/dispatch.c
+++ b/dll/win32/oleaut32/dispatch.c
@@ -19,7 +19,23 @@
  *
  */
 
-#include "precomp.h"
+#include "config.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#define COBJMACROS
+
+#include "windef.h"
+#include "winbase.h"
+#include "objbase.h"
+#include "oleauto.h"
+#include "winerror.h"
+
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/hash.c
+++ b/dll/win32/oleaut32/hash.c
@@ -18,8 +18,14 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
+#include <stdarg.h>
 
-#include "precomp.h"
+#include "windef.h"
+#include "winbase.h"
+#include "winnls.h"
+#include "objbase.h"
+#include "oaidl.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/oleaut.c
+++ b/dll/win32/oleaut32/oleaut.c
@@ -117,7 +117,7 @@ static inline size_t bstr_alloc_size(size_t size)
 
 static inline bstr_t *bstr_from_str(BSTR str)
 {
-    return CONTAINING_RECORD((void *)str, bstr_t, u.str);
+    return CONTAINING_RECORD(str, bstr_t, u.str);
 }
 
 static inline bstr_cache_entry_t *get_cache_entry_from_idx(unsigned cache_idx)

--- a/dll/win32/oleaut32/oleaut.c
+++ b/dll/win32/oleaut32/oleaut.c
@@ -18,12 +18,29 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include "config.h"
 
-#include <initguid.h>
-#include <oleaut32_oaidl.h>
+#include <stdarg.h>
+#include <string.h>
+#include <limits.h>
 
+#define COBJMACROS
+
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "winerror.h"
+
+#include "ole2.h"
+#include "olectl.h"
+#include "oleauto.h"
+#include "initguid.h"
 #include "typelib.h"
+#include "oleaut32_oaidl.h"
+
+#include "wine/debug.h"
+#include "wine/unicode.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 WINE_DECLARE_DEBUG_CHANNEL(heap);

--- a/dll/win32/oleaut32/oleaut32.rc
+++ b/dll/win32/oleaut32/oleaut32.rc
@@ -18,8 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <windef.h>
-
 #include "resource.h"
 
 /* UTF-8 */
@@ -114,6 +112,8 @@
  *  I expect Chinese etc are localised in Asian Editions also.
  */
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 /* @makedep: oleaut32.rgs */
 1 WINE_REGISTRY oleaut32.rgs
 
@@ -126,4 +126,4 @@
 #define WINE_FILEVERSION_STR "6.0.6001.18000"
 #define WINE_EXTRAVALUES VALUE "OLESelfRegister",""
 
-#include <wine/wine_common_ver.rc>
+#include "wine/wine_common_ver.rc"

--- a/dll/win32/oleaut32/olefont.c
+++ b/dll/win32/oleaut32/olefont.c
@@ -21,8 +21,28 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
+#include <assert.h>
+#include <stdarg.h>
+#include <string.h>
 
-#include "precomp.h"
+#define COBJMACROS
+#define NONAMELESSUNION
+#define NONAMELESSSTRUCT
+
+#include "winerror.h"
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "wine/list.h"
+#include "wine/unicode.h"
+#include "objbase.h"
+#include "oleauto.h"    /* for SysAllocString(....) */
+#include "ole2.h"
+#include "olectl.h"
+#include "wine/debug.h"
+#include "connpt.h" /* for CreateConnectionPoint */
+#include "oaidl.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/olepicture.c
+++ b/dll/win32/oleaut32/olepicture.c
@@ -36,14 +36,34 @@
  *
  */
 
-#include "precomp.h"
+#include "config.h"
+#include "wine/port.h"
 
 #ifdef HAVE_UNISTD_H
 # include <unistd.h>
 #endif
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
 
-#include <initguid.h>
-#include <wincodec.h>
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "winerror.h"
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "ole2.h"
+#include "olectl.h"
+#include "oleauto.h"
+#include "connpt.h"
+#include "urlmon.h"
+#include "initguid.h"
+#include "wincodec.h"
+#include "wine/debug.h"
+#include "wine/unicode.h"
+#include "wine/library.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(olepicture);
 

--- a/dll/win32/oleaut32/olepropframe.c
+++ b/dll/win32/oleaut32/olepropframe.c
@@ -19,9 +19,18 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include <stdarg.h>
 
-#include <oledlg.h>
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "ole2.h"
+#include "olectl.h"
+#include "oledlg.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/recinfo.c
+++ b/dll/win32/oleaut32/recinfo.c
@@ -16,7 +16,20 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include <stdarg.h>
+
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "windef.h"
+#include "winbase.h"
+#include "objbase.h"
+#include "oaidl.h"
+#include "oleauto.h"
+#include "variant.h"
+
+#include "wine/unicode.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/resource.h
+++ b/dll/win32/oleaut32/resource.h
@@ -17,9 +17,10 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
-
 #ifndef WINE_OLEAUT32_RESOURCE_H
 #define WINE_OLEAUT32_RESOURCE_H
+
+#include <windef.h>
 
 /* Localised boolean text */
 #define IDS_TRUE  100

--- a/dll/win32/oleaut32/safearray.c
+++ b/dll/win32/oleaut32/safearray.c
@@ -31,7 +31,19 @@
  *  0x10: SAFEARRAYBOUNDS[0...]
  */
 
-#include "precomp.h"
+#include "config.h"
+
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#define COBJMACROS
+
+#include "windef.h"
+#include "winerror.h"
+#include "winbase.h"
+#include "variant.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(variant);
 

--- a/dll/win32/oleaut32/tmarshal.c
+++ b/dll/win32/oleaut32/tmarshal.c
@@ -21,11 +21,32 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include "config.h"
+#include "wine/port.h"
 
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
+
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "winerror.h"
+#include "windef.h"
+#include "winbase.h"
+#include "winnls.h"
+#include "winreg.h"
+#include "winuser.h"
+
+#include "ole2.h"
+#include "propidl.h" /* for LPSAFEARRAY_User* functions */
 #include "typelib.h"
-
-#include <wine/exception.h>
+#include "variant.h"
+#include "wine/debug.h"
+#include "wine/exception.h"
 
 static const WCHAR IDispatchW[] = { 'I','D','i','s','p','a','t','c','h',0};
 

--- a/dll/win32/oleaut32/tmarshal.c
+++ b/dll/win32/oleaut32/tmarshal.c
@@ -529,7 +529,7 @@ typedef struct _TMAsmProxy {
 } TMAsmProxy;
 #include "poppack.h"
 
-#else /* __i386__ */
+#else
 #ifdef _MSC_VER
 #pragma message("You need to implement stubless proxies for your architecture")
 #else

--- a/dll/win32/oleaut32/typelib.c
+++ b/dll/win32/oleaut32/typelib.c
@@ -47,12 +47,33 @@
  *
  */
 
-#include "precomp.h"
+#include "config.h"
+#include "wine/port.h"
 
-#include <winternl.h>
-#include <lzexpand.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <ctype.h>
 
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "winerror.h"
+#include "windef.h"
+#include "winbase.h"
+#include "winnls.h"
+#include "winreg.h"
+#include "winuser.h"
+#include "winternl.h"
+#include "lzexpand.h"
+
+#include "wine/unicode.h"
+#include "objbase.h"
 #include "typelib.h"
+#include "wine/debug.h"
+#include "variant.h"
+#include "wine/list.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 WINE_DECLARE_DEBUG_CHANNEL(typelib);

--- a/dll/win32/oleaut32/typelib.c
+++ b/dll/win32/oleaut32/typelib.c
@@ -3696,87 +3696,6 @@ static BOOL TLB_GUIDFromString(const char *str, GUID *guid)
   return TRUE;
 }
 
-struct bitstream
-{
-    const BYTE *buffer;
-    DWORD       length;
-    WORD        current;
-};
-
-static const char *lookup_code(const BYTE *table, DWORD table_size, struct bitstream *bits)
-{
-    const BYTE *p = table;
-
-    while (p < table + table_size && *p == 0x80)
-    {
-        if (p + 2 >= table + table_size) return NULL;
-
-        if (!(bits->current & 0xff))
-        {
-            if (!bits->length) return NULL;
-            bits->current = (*bits->buffer << 8) | 1;
-            bits->buffer++;
-            bits->length--;
-        }
-
-        if (bits->current & 0x8000)
-        {
-            p += 3;
-        }
-        else
-        {
-            p = table + (*(p + 2) | (*(p + 1) << 8));
-        }
-
-        bits->current <<= 1;
-    }
-
-    if (p + 1 < table + table_size && *(p + 1))
-    {
-        /* FIXME: Whats the meaning of *p? */
-        const BYTE *q = p + 1;
-        while (q < table + table_size && *q) q++;
-        return (q < table + table_size) ? (const char *)(p + 1) : NULL;
-    }
-
-    return NULL;
-}
-
-static const TLBString *decode_string(const BYTE *table, const char *stream, DWORD stream_length, ITypeLibImpl *lib)
-{
-    DWORD buf_size, table_size;
-    const char *p;
-    struct bitstream bits;
-    BSTR buf;
-    TLBString *tlbstr;
-
-    if (!stream_length) return NULL;
-
-    bits.buffer = (const BYTE *)stream;
-    bits.length = stream_length;
-    bits.current = 0;
-
-    buf_size = *(const WORD *)table;
-    table += sizeof(WORD);
-    table_size = *(const DWORD *)table;
-    table += sizeof(DWORD);
-
-    buf = SysAllocStringLen(NULL, buf_size);
-    buf[0] = 0;
-
-    while ((p = lookup_code(table, table_size, &bits)))
-    {
-        static const WCHAR spaceW[] = { ' ',0 };
-        if (buf[0]) strcatW(buf, spaceW);
-        MultiByteToWideChar(CP_ACP, 0, p, -1, buf + strlenW(buf), buf_size - strlenW(buf));
-    }
-
-    tlbstr = TLB_append_str(&lib->string_list, buf);
-    SysFreeString(buf);
-
-    return tlbstr;
-}
-
 static WORD SLTG_ReadString(const char *ptr, const TLBString **pStr, ITypeLibImpl *lib)
 {
     WORD bytelen;
@@ -4108,7 +4027,7 @@ static char *SLTG_DoImpls(char *pBlk, ITypeInfoImpl *pTI,
 }
 
 static void SLTG_DoVars(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI, unsigned short cVars,
-			const char *pNameTable, const sltg_ref_lookup_t *ref_lookup, const BYTE *hlp_strings)
+			const char *pNameTable, const sltg_ref_lookup_t *ref_lookup)
 {
   TLBVarDesc *pVarDesc;
   const TLBString *prevName = NULL;
@@ -4137,12 +4056,6 @@ static void SLTG_DoVars(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI, unsign
       TRACE_(typelib)("name: %s\n", debugstr_w(TLB_get_bstr(pVarDesc->Name)));
       TRACE_(typelib)("byte_offs = 0x%x\n", pItem->byte_offs);
       TRACE_(typelib)("memid = 0x%x\n", pItem->memid);
-
-      if (pItem->helpstring != 0xffff)
-      {
-          pVarDesc->HelpString = decode_string(hlp_strings, pBlk + pItem->helpstring, pNameTable - pBlk, pTI->pTypeLib);
-          TRACE_(typelib)("helpstring = %s\n", debugstr_w(pVarDesc->HelpString->str));
-      }
 
       if(pItem->flags & 0x02)
 	  pType = &pItem->type;
@@ -4225,8 +4138,7 @@ static void SLTG_DoVars(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI, unsign
 }
 
 static void SLTG_DoFuncs(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI,
-			 unsigned short cFuncs, char *pNameTable, const sltg_ref_lookup_t *ref_lookup,
-			 const BYTE *hlp_strings)
+			 unsigned short cFuncs, char *pNameTable, const sltg_ref_lookup_t *ref_lookup)
 {
     SLTG_Function *pFunc;
     unsigned short i;
@@ -4263,8 +4175,6 @@ static void SLTG_DoFuncs(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI,
 	pFuncDesc->funcdesc.cParams = pFunc->nacc >> 3;
 	pFuncDesc->funcdesc.cParamsOpt = (pFunc->retnextopt & 0x7e) >> 1;
 	pFuncDesc->funcdesc.oVft = pFunc->vtblpos & ~1;
-        if (pFunc->helpstring != 0xffff)
-            pFuncDesc->HelpString = decode_string(hlp_strings, pBlk + pFunc->helpstring, pNameTable - pBlk, pTI->pTypeLib);
 
 	if(pFunc->magic & SLTG_FUNCTION_FLAGS_PRESENT)
 	    pFuncDesc->funcdesc.wFuncFlags = pFunc->funcflags;
@@ -4283,7 +4193,7 @@ static void SLTG_DoFuncs(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI,
 	pArg = (WORD*)(pBlk + pFunc->arg_off);
 
 	for(param = 0; param < pFuncDesc->funcdesc.cParams; param++) {
-	    char *paramName = pNameTable + (*pArg & ~1);
+	    char *paramName = pNameTable + *pArg;
 	    BOOL HaveOffs;
 	    /* If arg type follows then paramName points to the 2nd
 	       letter of the name, else the next WORD is an offset to
@@ -4294,14 +4204,17 @@ static void SLTG_DoFuncs(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI,
 	       meaning that the next WORD is the type, the latter
 	       meaning that the next WORD is an offset to the type. */
 
-	    if(*pArg == 0xffff || *pArg == 0xfffe)
+	    HaveOffs = FALSE;
+	    if(*pArg == 0xffff)
 	        paramName = NULL;
+	    else if(*pArg == 0xfffe) {
+	        paramName = NULL;
+		HaveOffs = TRUE;
+	    }
+	    else if(paramName[-1] && !isalnum(paramName[-1]))
+	        HaveOffs = TRUE;
 
-	    HaveOffs = !(*pArg & 1);
 	    pArg++;
-
-            TRACE_(typelib)("param %d: paramName %s, *pArg %#x\n",
-                param, debugstr_a(paramName), *pArg);
 
 	    if(HaveOffs) { /* the next word is an offset to type */
 	        pType = (WORD*)(pBlk + *pArg);
@@ -4309,6 +4222,8 @@ static void SLTG_DoFuncs(char *pBlk, char *pFirstItem, ITypeInfoImpl *pTI,
 			    &pFuncDesc->funcdesc.lprgelemdescParam[param], ref_lookup);
 		pArg++;
 	    } else {
+		if(paramName)
+		  paramName--;
 		pArg = SLTG_DoElem(pArg, pBlk,
                                    &pFuncDesc->funcdesc.lprgelemdescParam[param], ref_lookup);
 	    }
@@ -4352,7 +4267,7 @@ static void SLTG_ProcessCoClass(char *pBlk, ITypeInfoImpl *pTI,
 
 static void SLTG_ProcessInterface(char *pBlk, ITypeInfoImpl *pTI,
 				  char *pNameTable, SLTG_TypeInfoHeader *pTIHeader,
-				  const SLTG_TypeInfoTail *pTITail, const BYTE *hlp_strings)
+				  const SLTG_TypeInfoTail *pTITail)
 {
     char *pFirstItem;
     sltg_ref_lookup_t *ref_lookup = NULL;
@@ -4369,7 +4284,7 @@ static void SLTG_ProcessInterface(char *pBlk, ITypeInfoImpl *pTI,
     }
 
     if (pTITail->funcs_off != 0xffff)
-        SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup, hlp_strings);
+        SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup);
 
     heap_free(ref_lookup);
 
@@ -4379,9 +4294,9 @@ static void SLTG_ProcessInterface(char *pBlk, ITypeInfoImpl *pTI,
 
 static void SLTG_ProcessRecord(char *pBlk, ITypeInfoImpl *pTI,
 			       const char *pNameTable, SLTG_TypeInfoHeader *pTIHeader,
-			       const SLTG_TypeInfoTail *pTITail, const BYTE *hlp_strings)
+			       const SLTG_TypeInfoTail *pTITail)
 {
-  SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, NULL, hlp_strings);
+  SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, NULL);
 }
 
 static void SLTG_ProcessAlias(char *pBlk, ITypeInfoImpl *pTI,
@@ -4414,7 +4329,7 @@ static void SLTG_ProcessAlias(char *pBlk, ITypeInfoImpl *pTI,
 
 static void SLTG_ProcessDispatch(char *pBlk, ITypeInfoImpl *pTI,
 				 char *pNameTable, SLTG_TypeInfoHeader *pTIHeader,
-				 const SLTG_TypeInfoTail *pTITail, const BYTE *hlp_strings)
+				 const SLTG_TypeInfoTail *pTITail)
 {
   sltg_ref_lookup_t *ref_lookup = NULL;
   if (pTIHeader->href_table != 0xffffffff)
@@ -4422,10 +4337,10 @@ static void SLTG_ProcessDispatch(char *pBlk, ITypeInfoImpl *pTI,
                                   pNameTable);
 
   if (pTITail->vars_off != 0xffff)
-    SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, ref_lookup, hlp_strings);
+    SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, ref_lookup);
 
   if (pTITail->funcs_off != 0xffff)
-    SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup, hlp_strings);
+    SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup);
 
   if (pTITail->impls_off != 0xffff)
     SLTG_DoImpls(pBlk + pTITail->impls_off, pTI, FALSE, ref_lookup);
@@ -4442,14 +4357,14 @@ static void SLTG_ProcessDispatch(char *pBlk, ITypeInfoImpl *pTI,
 
 static void SLTG_ProcessEnum(char *pBlk, ITypeInfoImpl *pTI,
 			     const char *pNameTable, SLTG_TypeInfoHeader *pTIHeader,
-			     const SLTG_TypeInfoTail *pTITail, const BYTE *hlp_strings)
+			     const SLTG_TypeInfoTail *pTITail)
 {
-  SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, NULL, hlp_strings);
+  SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, NULL);
 }
 
 static void SLTG_ProcessModule(char *pBlk, ITypeInfoImpl *pTI,
 			       char *pNameTable, SLTG_TypeInfoHeader *pTIHeader,
-			       const SLTG_TypeInfoTail *pTITail, const BYTE *hlp_strings)
+			       const SLTG_TypeInfoTail *pTITail)
 {
   sltg_ref_lookup_t *ref_lookup = NULL;
   if (pTIHeader->href_table != 0xffffffff)
@@ -4457,10 +4372,10 @@ static void SLTG_ProcessModule(char *pBlk, ITypeInfoImpl *pTI,
                                   pNameTable);
 
   if (pTITail->vars_off != 0xffff)
-    SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, ref_lookup, hlp_strings);
+    SLTG_DoVars(pBlk, pBlk + pTITail->vars_off, pTI, pTITail->cVars, pNameTable, ref_lookup);
 
   if (pTITail->funcs_off != 0xffff)
-    SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup, hlp_strings);
+    SLTG_DoFuncs(pBlk, pBlk + pTITail->funcs_off, pTI, pTITail->cFuncs, pNameTable, ref_lookup);
   heap_free(ref_lookup);
   if (TRACE_ON(typelib))
     dump_TypeInfo(pTI);
@@ -4469,17 +4384,17 @@ static void SLTG_ProcessModule(char *pBlk, ITypeInfoImpl *pTI,
 /* Because SLTG_OtherTypeInfo is such a painful struct, we make a more
    manageable copy of it into this */
 typedef struct {
+  WORD small_no;
   char *index_name;
   char *other_name;
   WORD res1a;
   WORD name_offs;
-  WORD hlpstr_len;
+  WORD more_bytes;
   char *extra;
   WORD res20;
   DWORD helpcontext;
   WORD res26;
   GUID uuid;
-  WORD typekind;
 } SLTG_InternalOtherTypeInfo;
 
 /****************************************************************************
@@ -4498,8 +4413,8 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
     LPVOID pBlk, pFirstBlk;
     SLTG_LibBlk *pLibBlk;
     SLTG_InternalOtherTypeInfo *pOtherTypeInfoBlks;
+    char *pAfterOTIBlks = NULL;
     char *pNameTable, *ptr;
-    const BYTE *hlp_strings;
     int i;
     DWORD len, order;
     ITypeInfoImpl **ppTypeInfoImpl;
@@ -4565,10 +4480,9 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
     len += 0x40;
 
     /* And now TypeInfoCount of SLTG_OtherTypeInfo */
-    pTypeLibImpl->TypeInfoCount = *(WORD *)((char *)pLibBlk + len);
-    len += sizeof(WORD);
 
     pOtherTypeInfoBlks = heap_alloc_zero(sizeof(*pOtherTypeInfoBlks) * pTypeLibImpl->TypeInfoCount);
+
 
     ptr = (char*)pLibBlk + len;
 
@@ -4576,44 +4490,43 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
 	WORD w, extra;
 	len = 0;
 
-	w = *(WORD*)ptr;
+	pOtherTypeInfoBlks[i].small_no = *(WORD*)ptr;
+
+	w = *(WORD*)(ptr + 2);
 	if(w != 0xffff) {
 	    len += w;
 	    pOtherTypeInfoBlks[i].index_name = heap_alloc(w+1);
-	    memcpy(pOtherTypeInfoBlks[i].index_name, ptr + 2, w);
+	    memcpy(pOtherTypeInfoBlks[i].index_name, ptr + 4, w);
 	    pOtherTypeInfoBlks[i].index_name[w] = '\0';
 	}
-	w = *(WORD*)(ptr + 2 + len);
+	w = *(WORD*)(ptr + 4 + len);
 	if(w != 0xffff) {
-	    TRACE_(typelib)("\twith %s\n", debugstr_an(ptr + 4 + len, w));
-	    pOtherTypeInfoBlks[i].other_name = heap_alloc(w+1);
-	    memcpy(pOtherTypeInfoBlks[i].other_name, ptr + 4 + len, w);
-	    pOtherTypeInfoBlks[i].other_name[w] = '\0';
+	    TRACE_(typelib)("\twith %s\n", debugstr_an(ptr + 6 + len, w));
 	    len += w;
+	    pOtherTypeInfoBlks[i].other_name = heap_alloc(w+1);
+	    memcpy(pOtherTypeInfoBlks[i].other_name, ptr + 6 + len, w);
+	    pOtherTypeInfoBlks[i].other_name[w] = '\0';
 	}
-	pOtherTypeInfoBlks[i].res1a = *(WORD*)(ptr + 4 + len);
-	pOtherTypeInfoBlks[i].name_offs = *(WORD*)(ptr + 6 + len);
-	extra = pOtherTypeInfoBlks[i].hlpstr_len = *(WORD*)(ptr + 8 + len);
+	pOtherTypeInfoBlks[i].res1a = *(WORD*)(ptr + len + 6);
+	pOtherTypeInfoBlks[i].name_offs = *(WORD*)(ptr + len + 8);
+	extra = pOtherTypeInfoBlks[i].more_bytes = *(WORD*)(ptr + 10 + len);
 	if(extra) {
 	    pOtherTypeInfoBlks[i].extra = heap_alloc(extra);
-	    memcpy(pOtherTypeInfoBlks[i].extra, ptr + 10 + len, extra);
+	    memcpy(pOtherTypeInfoBlks[i].extra, ptr + 12, extra);
 	    len += extra;
 	}
-	pOtherTypeInfoBlks[i].res20 = *(WORD*)(ptr + 10 + len);
-	pOtherTypeInfoBlks[i].helpcontext = *(DWORD*)(ptr + 12 + len);
-	pOtherTypeInfoBlks[i].res26 = *(WORD*)(ptr + 16 + len);
-	memcpy(&pOtherTypeInfoBlks[i].uuid, ptr + 18 + len, sizeof(GUID));
-	pOtherTypeInfoBlks[i].typekind = *(WORD*)(ptr + 18 + sizeof(GUID) + len);
+	pOtherTypeInfoBlks[i].res20 = *(WORD*)(ptr + 12 + len);
+	pOtherTypeInfoBlks[i].helpcontext = *(DWORD*)(ptr + 14 + len);
+	pOtherTypeInfoBlks[i].res26 = *(WORD*)(ptr + 18 + len);
+	memcpy(&pOtherTypeInfoBlks[i].uuid, ptr + 20 + len, sizeof(GUID));
 	len += sizeof(SLTG_OtherTypeInfo);
 	ptr += len;
     }
 
-    /* Get the next DWORD */
-    len = *(DWORD*)ptr;
+    pAfterOTIBlks = ptr;
 
-    hlp_strings = (const BYTE *)ptr + sizeof(DWORD);
-    TRACE("max help string length %#x, help strings length %#x\n",
-        *(WORD *)hlp_strings, *(DWORD *)(hlp_strings + 2));
+    /* Skip this WORD and get the next DWORD */
+    len = *(DWORD*)(pAfterOTIBlks + 2);
 
     /* Now add this to pLibBLk look at what we're pointing at and
        possibly add 0x20, then add 0x216, sprinkle a bit a magic
@@ -4679,7 +4592,6 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
       (*ppTypeInfoImpl)->index = i;
       (*ppTypeInfoImpl)->Name = SLTG_ReadName(pNameTable, pOtherTypeInfoBlks[i].name_offs, pTypeLibImpl);
       (*ppTypeInfoImpl)->dwHelpContext = pOtherTypeInfoBlks[i].helpcontext;
-      (*ppTypeInfoImpl)->DocString = decode_string(hlp_strings, pOtherTypeInfoBlks[i].extra, pOtherTypeInfoBlks[i].hlpstr_len, pTypeLibImpl);
       (*ppTypeInfoImpl)->guid = TLB_append_guid(&pTypeLibImpl->guid_list, &pOtherTypeInfoBlks[i].uuid, 2);
       (*ppTypeInfoImpl)->typeattr.typekind = pTIHeader->typekind;
       (*ppTypeInfoImpl)->typeattr.wMajorVerNum = pTIHeader->major_version;
@@ -4712,17 +4624,17 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
       switch(pTIHeader->typekind) {
       case TKIND_ENUM:
 	SLTG_ProcessEnum((char *)(pMemHeader + 1), *ppTypeInfoImpl, pNameTable,
-                         pTIHeader, pTITail, hlp_strings);
+                         pTIHeader, pTITail);
 	break;
 
       case TKIND_RECORD:
 	SLTG_ProcessRecord((char *)(pMemHeader + 1), *ppTypeInfoImpl, pNameTable,
-                           pTIHeader, pTITail, hlp_strings);
+                           pTIHeader, pTITail);
 	break;
 
       case TKIND_INTERFACE:
 	SLTG_ProcessInterface((char *)(pMemHeader + 1), *ppTypeInfoImpl, pNameTable,
-                              pTIHeader, pTITail, hlp_strings);
+                              pTIHeader, pTITail);
 	break;
 
       case TKIND_COCLASS:
@@ -4737,12 +4649,12 @@ static ITypeLib2* ITypeLib2_Constructor_SLTG(LPVOID pLib, DWORD dwTLBLength)
 
       case TKIND_DISPATCH:
 	SLTG_ProcessDispatch((char *)(pMemHeader + 1), *ppTypeInfoImpl, pNameTable,
-                             pTIHeader, pTITail, hlp_strings);
+                             pTIHeader, pTITail);
 	break;
 
       case TKIND_MODULE:
 	SLTG_ProcessModule((char *)(pMemHeader + 1), *ppTypeInfoImpl, pNameTable,
-                           pTIHeader, pTITail, hlp_strings);
+                           pTIHeader, pTITail);
 	break;
 
       default:

--- a/dll/win32/oleaut32/typelib.h
+++ b/dll/win32/oleaut32/typelib.h
@@ -596,26 +596,6 @@ WORD typeofarray
 
 #include "poppack.h"
 
-static inline void* __WINE_ALLOC_SIZE(1) heap_alloc( SIZE_T size )
-{
-    return HeapAlloc( GetProcessHeap(), 0, size );
-}
-
-static inline void* __WINE_ALLOC_SIZE(1) heap_alloc_zero( SIZE_T size )
-{
-    return HeapAlloc( GetProcessHeap(), HEAP_ZERO_MEMORY, size );
-}
-
-static inline void* __WINE_ALLOC_SIZE(2) heap_realloc( LPVOID mem, SIZE_T size )
-{
-    return HeapReAlloc( GetProcessHeap(), 0, mem, size );
-}
-
-static inline BOOL heap_free( LPVOID mem )
-{
-    return HeapFree( GetProcessHeap(), 0, mem );
-}
-
 HRESULT ITypeInfoImpl_GetInternalFuncDesc( ITypeInfo *iface, UINT index, const FUNCDESC **ppFuncDesc ) DECLSPEC_HIDDEN;
 
 extern DWORD _invoke(FARPROC func, CALLCONV callconv, int nrargs, DWORD_PTR *args) DECLSPEC_HIDDEN;

--- a/dll/win32/oleaut32/typelib.h
+++ b/dll/win32/oleaut32/typelib.h
@@ -387,18 +387,18 @@ typedef struct {
 /* we then get 0x40 bytes worth of 0xffff or small numbers followed by
    nrOfFileBlks - 2 of these */
 typedef struct {
+	WORD small_no;
 	SLTG_Name index_name; /* This refers to a name in the directory */
 	SLTG_Name other_name; /* Another one of these weird names */
 	WORD res1a;	      /* 0xffff */
 	WORD name_offs;	      /* offset to name in name table */
-	WORD hlpstr_len;      /* if this is non-zero we get this many
+	WORD more_bytes;      /* if this is non-zero we get this many
 				 bytes before the next element, which seem
 				 to reference the docstring of the type ? */
 	WORD res20;	      /* 0xffff */
 	DWORD helpcontext;
 	WORD res26;	      /* 0xffff */
         GUID uuid;
-        WORD typekind;
 } SLTG_OtherTypeInfo;
 
 /* Next we get WORD 0x0003 followed by a DWORD which if we add to

--- a/dll/win32/oleaut32/typelib.h
+++ b/dll/win32/oleaut32/typelib.h
@@ -21,6 +21,12 @@
 #ifndef _WINE_TYPELIB_H
 #define _WINE_TYPELIB_H
 
+#include <stdarg.h>
+
+#include "windef.h"
+#include "winbase.h"
+#include "oleauto.h"
+
 #define HELPDLLFLAG (0x0100)
 #define DO_NOT_SEEK (-1)
 

--- a/dll/win32/oleaut32/usrmarshal.c
+++ b/dll/win32/oleaut32/usrmarshal.c
@@ -19,7 +19,23 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include <stdarg.h>
+#include <string.h>
+
+#define COBJMACROS
+#define NONAMELESSUNION
+
+#include "windef.h"
+#include "winbase.h"
+#include "wingdi.h"
+#include "winuser.h"
+#include "winerror.h"
+
+#include "ole2.h"
+#include "oleauto.h"
+#include "typelib.h"
+#include "ocidl.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(ole);
 

--- a/dll/win32/oleaut32/varformat.c
+++ b/dll/win32/oleaut32/varformat.c
@@ -25,7 +25,19 @@
  *  Please submit a test case if you find a difference.
  */
 
-#include "precomp.h"
+#include "config.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include "windef.h"
+#include "winbase.h"
+#include "wine/unicode.h"
+#include "winerror.h"
+#include "variant.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(variant);
 

--- a/dll/win32/oleaut32/variant.c
+++ b/dll/win32/oleaut32/variant.c
@@ -25,7 +25,23 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#include "config.h"
+
+#include <string.h>
+#include <stdlib.h>
+#include <stdarg.h>
+
+#define COBJMACROS
+#define NONAMELESSUNION
+#define NONAMELESSSTRUCT
+
+#include "windef.h"
+#include "winbase.h"
+#include "wine/unicode.h"
+#include "winerror.h"
+#include "variant.h"
+#include "resource.h"
+#include "wine/debug.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(variant);
 

--- a/dll/win32/oleaut32/variant.c
+++ b/dll/win32/oleaut32/variant.c
@@ -2161,7 +2161,7 @@ HRESULT WINAPI VarNumFromParseNum(NUMPARSE *pNumprs, BYTE *rgbDig,
         multiplier10, divisor10);
 
   if (dwVtBits & (INTEGER_VTBITS|VTBIT_DECIMAL) &&
-      (!fractionalDigits || !(dwVtBits & (REAL_VTBITS|VTBIT_CY|VTBIT_DECIMAL))))
+      (!fractionalDigits || !(dwVtBits & (REAL_VTBITS|VTBIT_DECIMAL))))
   {
     /* We have one or more integer output choices, and either:
      *  1) An integer input value, or
@@ -2275,7 +2275,7 @@ HRESULT WINAPI VarNumFromParseNum(NUMPARSE *pNumprs, BYTE *rgbDig,
           V_I8(pVarDst) = -ul64;
           return S_OK;
         }
-        else if ((dwVtBits & REAL_VTBITS) == VTBIT_DECIMAL)
+        else if ((dwVtBits & (REAL_VTBITS|VTBIT_DECIMAL)) == VTBIT_DECIMAL)
         {
           /* Decimal is only output choice left - fast path */
           V_VT(pVarDst) = VT_DECIMAL;
@@ -2337,7 +2337,7 @@ HRESULT WINAPI VarNumFromParseNum(NUMPARSE *pNumprs, BYTE *rgbDig,
         V_UI8(pVarDst) = ul64;
         return S_OK;
       }
-      else if ((dwVtBits & REAL_VTBITS) == VTBIT_DECIMAL)
+      else if ((dwVtBits & (REAL_VTBITS|VTBIT_DECIMAL)) == VTBIT_DECIMAL)
       {
         /* Decimal is only output choice left - fast path */
         V_VT(pVarDst) = VT_DECIMAL;
@@ -2392,8 +2392,8 @@ HRESULT WINAPI VarNumFromParseNum(NUMPARSE *pNumprs, BYTE *rgbDig,
     {
       if (whole < dblMinimums[10] && whole != 0)
       {
-        dwVtBits &= ~(VTBIT_R4|VTBIT_R8|VTBIT_CY); /* Underflow */
-        bOverflow = TRUE;
+        whole = 0; /* ignore underflow */
+        divisor10 = 0;
         break;
       }
       whole = whole / dblMultipliers[10];
@@ -2403,8 +2403,8 @@ HRESULT WINAPI VarNumFromParseNum(NUMPARSE *pNumprs, BYTE *rgbDig,
     {
       if (whole < dblMinimums[divisor10] && whole != 0)
       {
-        dwVtBits &= ~(VTBIT_R4|VTBIT_R8|VTBIT_CY); /* Underflow */
-        bOverflow = TRUE;
+        whole = 0; /* ignore underflow */
+        divisor10 = 0;
       }
       else
         whole = whole / dblMultipliers[divisor10];

--- a/dll/win32/oleaut32/variant.h
+++ b/dll/win32/oleaut32/variant.h
@@ -19,7 +19,10 @@
  */
 
 #pragma once
-
+#include "windef.h"
+#include "winerror.h"
+#include "objbase.h"
+#include "oleauto.h"
 #include <math.h>
 
 /* Get just the type from a variant pointer */

--- a/dll/win32/oleaut32/vartype.c
+++ b/dll/win32/oleaut32/vartype.c
@@ -5372,7 +5372,7 @@ static HRESULT VARIANT_DI_normalize(VARIANT_DI * val, int exponent2, BOOL isDoub
        end of the bit representation, down to the precision guaranteed by the
        floating point number. */
     if (isDouble) {
-        while (exponent10 < 0 && (val->bitsnum[2] != 0 || (val->bitsnum[2] == 0 && (val->bitsnum[1] & 0xFFE00000) != 0))) {
+        while (exponent10 < 0 && (val->bitsnum[2] != 0 || (val->bitsnum[1] & 0xFFE00000) != 0)) {
             int rem10;
 
             rem10 = VARIANT_int_divbychar(val->bitsnum, 3, 10);

--- a/dll/win32/oleaut32/vartype.c
+++ b/dll/win32/oleaut32/vartype.c
@@ -18,7 +18,17 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "precomp.h"
+#define COBJMACROS
+#define NONAMELESSUNION
+#define NONAMELESSSTRUCT
+
+#include "wine/debug.h"
+#include "wine/unicode.h"
+#include "winbase.h"
+#include "winuser.h"
+#include "winnt.h"
+#include "variant.h"
+#include "resource.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(variant);
 

--- a/media/doc/README.WINE
+++ b/media/doc/README.WINE
@@ -141,7 +141,7 @@ reactos/dll/win32/odbc32              # Synced to WineStaging-2.9. Depends on po
 reactos/dll/win32/odbccp32            # Synced to WineStaging-2.9
 reactos/dll/win32/ole32               # Synced to Wine-3.0
 reactos/dll/win32/oleacc              # Synced to WineStaging-2.9
-reactos/dll/win32/oleaut32            # Synced to WineStaging-2.16
+reactos/dll/win32/oleaut32            # Synced to WineStaging-2.21 on Wine-3.2
 reactos/dll/win32/olecli32            # Synced to WineStaging-2.9
 reactos/dll/win32/oledlg              # Synced to WineStaging-2.9
 reactos/dll/win32/olepro32            # Synced to WineStaging-2.9

--- a/sdk/include/reactos/wine/heap.h
+++ b/sdk/include/reactos/wine/heap.h
@@ -1,0 +1,21 @@
+#pragma once
+
+static inline void* __WINE_ALLOC_SIZE(1) heap_alloc(SIZE_T size)
+{
+    return HeapAlloc(GetProcessHeap(), 0, size);
+}
+
+static inline void* __WINE_ALLOC_SIZE(1) heap_alloc_zero(SIZE_T size)
+{
+    return HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, size);
+}
+
+static inline void* __WINE_ALLOC_SIZE(2) heap_realloc(LPVOID mem, SIZE_T size)
+{
+    return HeapReAlloc(GetProcessHeap(), 0, mem, size);
+}
+
+static inline BOOL heap_free(LPVOID mem)
+{
+    return HeapFree(GetProcessHeap(), 0, mem);
+}

--- a/sdk/include/reactos/wine/wined3d.h
+++ b/sdk/include/reactos/wine/wined3d.h
@@ -30,7 +30,7 @@
 # error You must include config.h to use this header
 #endif
 
-#include <wine/list.h>
+#include "wine/list.h"
 
 #define WINED3D_OK                                              S_OK
 


### PR DESCRIPTION
## Sync oleaut32 with wine 3.2 + wine-staging 2.21 + ros-diffs
This massively reduces the diff to wine, since managing major differences just for the sake of "better includes" is not scalable / managable and the gains in terms of saving compile time are questionable.
Initial results of using the new wine repository. This was just a test to see how good it works and to try to establish a workflow.
