### PR TITLE
CORE-12657. Re-enable kmtest_.exe installation, so it runs on "Test WHS"

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -155,8 +155,7 @@ add_importlibs(kmtest fltlib advapi32 ws2_32 msvcrt kernel32 ntdll)
 add_target_compile_definitions(kmtest KMT_USER_MODE NTDDI_VERSION=NTDDI_WS03SP1)
 #add_pch(kmtest include/kmt_test.h)
 set_target_properties(kmtest PROPERTIES OUTPUT_NAME "kmtest_")
-#add_rostests_file(TARGET kmtest)
-add_cd_file(TARGET kmtest DESTINATION reactos/bin FOR all)
+add_rostests_file(TARGET kmtest)
 
 #
 # Group targets


### PR DESCRIPTION
## Purpose

ExPools and other tests don't break Windows Server 2003 anymore.

JIRA issue: [CORE-12657](https://jira.reactos.org/browse/CORE-12657)
Succeeds on WS03 (only): [WTB 40651](https://testbot.winehq.org/JobDetails.pl?Key=40651)

## Proposed changes

- Revert r73535, so KmTests run on "Test WHS" bot.
