### PR TITLE
Avoid read-ahead past end of file

### DIFF
--- a/ntoskrnl/cc/cacheman.c
+++ b/ntoskrnl/cc/cacheman.c
@@ -228,7 +228,7 @@ CcScheduleReadAhead (
         /* It's active now!
          * Be careful with the mask, you don't want to mess with node code
          */
-        InterlockedOr((volatile long *)&PrivateCacheMap->UlongFlags, 0x10000);
+        InterlockedOr((volatile long *)&PrivateCacheMap->UlongFlags, PRIVATE_CACHE_MAP_READ_AHEAD_ACTIVE);
         KeReleaseSpinLock(&PrivateCacheMap->ReadAheadSpinLock, OldIrql);
 
         /* Get a work item */
@@ -250,7 +250,7 @@ CcScheduleReadAhead (
 
         /* Fail path: lock again, and revert read ahead active */
         KeAcquireSpinLock(&PrivateCacheMap->ReadAheadSpinLock, &OldIrql);
-        InterlockedAnd((volatile long *)&PrivateCacheMap->UlongFlags, 0xFFFEFFFF);
+        InterlockedAnd((volatile long *)&PrivateCacheMap->UlongFlags, ~PRIVATE_CACHE_MAP_READ_AHEAD_ACTIVE);
     }
 
     /* Done (fail) */

--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -594,7 +594,7 @@ Clear:
     {
         /* Mark read ahead as unactive */
         KeAcquireSpinLockAtDpcLevel(&PrivateCacheMap->ReadAheadSpinLock);
-        InterlockedAnd((volatile long *)&PrivateCacheMap->UlongFlags, 0xFFFEFFFF);
+        InterlockedAnd((volatile long *)&PrivateCacheMap->UlongFlags, ~PRIVATE_CACHE_MAP_READ_AHEAD_ACTIVE);
         KeReleaseSpinLockFromDpcLevel(&PrivateCacheMap->ReadAheadSpinLock);
     }
     KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);

--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -517,6 +517,16 @@ CcPerformReadAhead(
     /* Remember it's locked */
     Locked = TRUE;
 
+    /* Don't read past the end of the file */
+    if (CurrentOffset >= SharedCacheMap->FileSize.QuadPart)
+    {
+        goto Clear;
+    }
+    if (CurrentOffset + Length > SharedCacheMap->FileSize.QuadPart)
+    {
+        Length = SharedCacheMap->FileSize.QuadPart - CurrentOffset;
+    }
+
     /* Next of the algorithm will lock like CcCopyData with the slight
      * difference that we don't copy data back to an user-backed buffer
      * We just bring data into Cc

--- a/sdk/include/ndk/cctypes.h
+++ b/sdk/include/ndk/cctypes.h
@@ -61,6 +61,9 @@ typedef struct _PRIVATE_CACHE_MAP_FLAGS
     ULONG Available:14;
 } PRIVATE_CACHE_MAP_FLAGS;
 
+#define PRIVATE_CACHE_MAP_READ_AHEAD_ACTIVE     (1 << 16)
+#define PRIVATE_CACHE_MAP_READ_AHEAD_ENABLED    (1 << 17)
+
 typedef struct _PRIVATE_CACHE_MAP
 {
     union


### PR DESCRIPTION
This avoids the following at the end of first stage:
```(ntoskrnl/cc/copy.c:568) Failed to request VACB: c000000d!```