### PR TITLE
[IPHLPAPI] Fix getNumRoutes() return value, on Mib error

### DIFF
--- a/dll/win32/iphlpapi/ipstats_reactos.c
+++ b/dll/win32/iphlpapi/ipstats_reactos.c
@@ -387,9 +387,9 @@ DWORD getNumRoutes(void)
             memset( &isnmp, 0, sizeof( isnmp ) );
             status = tdiGetMibForIpEntity( tcpFile, &entitySet[i], &isnmp );
             if( !NT_SUCCESS(status) ) {
-                tdiFreeThingSet( entitySet );
-                closeTcpFile( tcpFile );
-                return status;
+                WARN("tdiGetMibForIpEntity failed for i = %d", i);
+                numRoutes = 0;
+                break;
             }
             numRoutes += isnmp.ipsi_numroutes;
         }


### PR DESCRIPTION
## Purpose

This code was added as is in r8194.

## Proposed changes

- Obviously not `status`. Not current `numRoutes` either, I assume.
