### PR TITLE
UNIMPLEMENTED_ONCE: Add a definition, Improve a use

### DIFF
--- a/ntoskrnl/cc/cacheman.c
+++ b/ntoskrnl/cc/cacheman.c
@@ -165,7 +165,6 @@ CcScheduleReadAhead (
     LARGE_INTEGER NewOffset;
     PROS_SHARED_CACHE_MAP SharedCacheMap;
     PPRIVATE_CACHE_MAP PrivateCacheMap;
-    static ULONG Warn;
 
     SharedCacheMap = FileObject->SectionObjectPointer->SharedCacheMap;
     PrivateCacheMap = FileObject->PrivateCacheMap;
@@ -215,7 +214,7 @@ CcScheduleReadAhead (
         {
             /* FIXME: handle the other cases */
             KeReleaseSpinLock(&PrivateCacheMap->ReadAheadSpinLock, OldIrql);
-	        if (!Warn++) UNIMPLEMENTED;
+            UNIMPLEMENTED_ONCE;
             return;
         }
     }

--- a/sdk/include/reactos/debug.h
+++ b/sdk/include/reactos/debug.h
@@ -132,11 +132,11 @@ RtlAssert(
 #else /* not DBG */
 
     /* On non-debug builds, we never show these */
+    #define UNIMPLEMENTED
+    #define UNIMPLEMENTED_ONCE
 #if defined(_MSC_VER)
     #define DPRINT1   __noop
     #define DPRINT    __noop
-
-    #define UNIMPLEMENTED
 
     #define ERR_(ch, ...)      __noop
     #define WARN_(ch, ...)     __noop
@@ -150,9 +150,6 @@ RtlAssert(
 #else
     #define DPRINT1(...) do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
     #define DPRINT(...) do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
-
-    #define UNIMPLEMENTED
-    #define UNIMPLEMENTED_ONCE
 
     #define ERR_(ch, ...) do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)
     #define WARN_(ch, ...) do { if(0) { DbgPrint(__VA_ARGS__); } } while(0)


### PR DESCRIPTION
## Proposed changes

- Define UNIMPLEMENTED_ONCE for "!DBG && _MSC_VER" too.
(Addendum to 81eb3bbceb518c331f3d8e4754ad61adc0e94d33.)
- Use UNIMPLEMENTED_ONCE instead of custom code.
(Rewrite e319f85e67b1d057fb1c0d0449a6756fa0d459ba.)
