### PR TITLE
Implement the hard error balloon

### DIFF
--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -1207,6 +1207,7 @@ void CNotifyToolbar::Initialize(HWND hWndParent, CBalloonQueue * queue)
 const WCHAR szSysPagerWndClass[] = L"SysPager";
 
 CSysPagerWnd::CSysPagerWnd() {}
+
 CSysPagerWnd::~CSysPagerWnd() {}
 
 LRESULT CSysPagerWnd::OnEraseBackground(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -204,6 +204,17 @@ BOOL WINAPI PaintMenuBar(HWND hWnd, HDC hDC, ULONG left, ULONG right, ULONG top,
 #define DrawCaptionTemp DrawCaptionTempA
 #endif
 
+//
+// Hard error balloon package
+//
+typedef struct _BALLOON_HARD_ERROR_DATA
+{
+    DWORD cbHeaderSize;
+    DWORD Status;
+    DWORD dwType; /* any combination of the MB_ message box types */
+    ULONG_PTR TitleOffset;
+    ULONG_PTR MessageOffset;
+} BALLOON_HARD_ERROR_DATA, *PBALLOON_HARD_ERROR_DATA;
 
 //
 // User api hook


### PR DESCRIPTION
TODOs:
- [ ] ~~The title sent to explorer is not correct yet but the part of explorer is ready.~~ This is a generic bug of the hard error support, not specific to hard error balloons. These balloons show exactly the same texts with their message box counterparts.