### PR TITLE
[REACTOS] Switch 4 cases to UNIMPLEMENTED_ONCE

### DIFF
--- a/dll/win32/wshtcpip/wshtcpip.c
+++ b/dll/win32/wshtcpip/wshtcpip.c
@@ -363,7 +363,7 @@ WSHIoctl(
         return res;
     }
 
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
 
     DPRINT1("Ioctl: Unknown IOCTL code: %d\n", IoControlCode);
 

--- a/ntoskrnl/po/power.c
+++ b/ntoskrnl/po/power.c
@@ -618,7 +618,7 @@ VOID
 NTAPI
 PoStartNextPowerIrp(IN PIRP Irp)
 {
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
 }
 
 /*

--- a/sdk/lib/cmlib/hivewrt.c
+++ b/sdk/lib/cmlib/hivewrt.c
@@ -277,7 +277,7 @@ CMAPI
 HvHiveWillShrink(IN PHHIVE RegistryHive)
 {
     /* No shrinking yet */
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
     return FALSE;
 }
 

--- a/win32ss/gdi/gdi32/objects/icm.c
+++ b/win32ss/gdi/gdi32/objects/icm.c
@@ -182,7 +182,7 @@ GetICMProfileW(
 {
     if (!hdc || !size || !filename) return FALSE;
 
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
     SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
     return FALSE;
 }


### PR DESCRIPTION
## Purpose

Silence:
> 195 * WARNING:  PoStartNextPowerIrp at ntoskrnl/po/power.c:621 is UNIMPLEMENTED!
>  40 * WARNING:  HvHiveWillShrink at sdk/lib/cmlib/hivewrt.c:280 is UNIMPLEMENTED!
>  18 * WARNING:  WSHIoctl at dll/win32/wshtcpip/wshtcpip.c:366 is UNIMPLEMENTED!
>  18 * WARNING:  GetICMProfileW at win32ss/gdi/gdi32/objects/icm.c:185 is UNIMPLEMENTED!

From
Build log: [Test KVM 19613](https://build.reactos.org/builders/Test%20KVM/builds/19613/steps/test/logs/stdio)
