### PR TITLE
Fix definitions and usage of DWLP_MSGRESULT, DWLP_DLG…

### DIFF
--- a/base/applications/msconfig_new/systempage.cpp
+++ b/base/applications/msconfig_new/systempage.cpp
@@ -728,9 +728,9 @@ CommonWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
                          * to the message.
                          *
                          * If the dialog box procedure processes a message that requires a specific return value, the dialog box procedure
-                         * should set the desired return value by calling SetWindowLong(hwndDlg, DWL_MSGRESULT, lResult) immediately before
+                         * should set the desired return value by calling SetWindowLong(hwndDlg, DWLP_MSGRESULT, lResult) immediately before
                          * returning TRUE. Note that you must call SetWindowLong immediately before returning TRUE; doing so earlier may result
-                         * in the DWL_MSGRESULT value being overwritten by a nested dialog box message.
+                         * in the DWLP_MSGRESULT value being overwritten by a nested dialog box message.
                          *
                          * [...]
                          *

--- a/base/applications/mscutils/servman/propsheet_logon.c
+++ b/base/applications/mscutils/servman/propsheet_logon.c
@@ -137,7 +137,7 @@ OnQueryInitialFocus(
 {
     HWND hwnd = GetDlgItem(hwndDlg, pLogonData->bLocalSystem ? IDC_LOGON_SYSTEMACCOUNT : IDC_LOGON_THISACCOUNT);
 
-    SetWindowLong(hwndDlg, DWL_MSGRESULT, (LPARAM)hwnd);
+    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, (LPARAM)hwnd);
 
     return TRUE;
 }

--- a/base/setup/reactos/drivepage.c
+++ b/base/setup/reactos/drivepage.c
@@ -245,7 +245,7 @@ DriveDlgProc(
 
                 case PSN_QUERYCANCEL:
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      MessageBox(GetParent(hwndDlg),
                                                 pSetupData->szAbortMessage,
                                                 pSetupData->szAbortTitle,

--- a/base/setup/reactos/reactos.c
+++ b/base/setup/reactos/reactos.c
@@ -174,7 +174,7 @@ TypeDlgProc(HWND hwndDlg,
 
                 case PSN_QUERYCANCEL:
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      MessageBox(GetParent(hwndDlg),
                                                 pSetupData->szAbortMessage,
                                                 pSetupData->szAbortTitle,
@@ -262,7 +262,7 @@ DeviceDlgProc(HWND hwndDlg,
 
                 case PSN_QUERYCANCEL:
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      MessageBox(GetParent(hwndDlg),
                                                 pSetupData->szAbortMessage,
                                                 pSetupData->szAbortTitle,
@@ -350,7 +350,7 @@ SummaryDlgProc(HWND hwndDlg,
 
                 case PSN_QUERYCANCEL:
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      MessageBox(GetParent(hwndDlg),
                                                 pSetupData->szAbortMessage,
                                                 pSetupData->szAbortTitle,
@@ -401,7 +401,7 @@ ProcessDlgProc(HWND hwndDlg,
                    break;
                 case PSN_QUERYCANCEL:
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      MessageBox(GetParent(hwndDlg),
                                                 pSetupData->szAbortMessage,
                                                 pSetupData->szAbortTitle,

--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -231,7 +231,7 @@ WelcomeDlgProc(HWND hwndDlg,
                     }
                     SendDlgItemMessage(hwndDlg, IDC_SHORTCUT_LOCATION, EM_SETSEL, 0, -1);
                     SetFocus(GetDlgItem(hwndDlg, IDC_SHORTCUT_LOCATION));
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
                     return -1;
                 }
                 else

--- a/dll/cpl/hdwwiz/hdwwiz.c
+++ b/dll/cpl/hdwwiz/hdwwiz.c
@@ -172,9 +172,9 @@ IsConnectedPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 case PSN_WIZNEXT:
                 {
                     if (SendDlgItemMessage(hwndDlg, IDC_NOTCONNECTED, BM_GETCHECK, 0, 0) == BST_CHECKED)
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_NOTCONNECTEDPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_NOTCONNECTEDPAGE);
                     else
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_PROBELISTPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_PROBELISTPAGE);
 
                     return TRUE;
                 }
@@ -244,7 +244,7 @@ NotConnectedPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 case PSN_WIZBACK:
                 {
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_ISCONNECTEDPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_ISCONNECTEDPAGE);
                     return TRUE;
                 }
             }
@@ -429,7 +429,7 @@ ProbeListPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                     if (Index == 0)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_SELECTWAYPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_SELECTWAYPAGE);
                     }
                     else
                     {
@@ -443,7 +443,7 @@ ProbeListPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                         pts = (PWSTR) Item.lParam;
                         wcscpy(pDeviceStatusText, pts);
 
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_HWSTATUSPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_HWSTATUSPAGE);
                     }
                     return TRUE;
                 }
@@ -499,9 +499,9 @@ SelectWayPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 case PSN_WIZNEXT:
                 {
                     if (SendDlgItemMessage(hwndDlg, IDC_AUTOINSTALL, BM_GETCHECK, 0, 0) == BST_CHECKED)
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_PROGRESSPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_PROGRESSPAGE);
                     else
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_HWTYPESPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_HWTYPESPAGE);
 
                     return TRUE;
                 }
@@ -542,7 +542,7 @@ DevStatusPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 case PSN_WIZBACK:
                 {
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_PROBELISTPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_PROBELISTPAGE);
                     return TRUE;
                 }
             }
@@ -735,7 +735,7 @@ HdTypesPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 case PSN_WIZBACK:
                 {
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_SELECTWAYPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_SELECTWAYPAGE);
                     return TRUE;
                 }
             }
@@ -765,7 +765,7 @@ ProgressPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 case PSN_WIZBACK:
                 {
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_SELECTWAYPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_SELECTWAYPAGE);
                     return TRUE;
                 }
             }

--- a/dll/cpl/intl/advanced.c
+++ b/dll/cpl/intl/advanced.c
@@ -496,9 +496,9 @@ AdvancedPageProc(HWND hwndDlg,
             else if (((LPNMHDR)lParam)->idFrom == IDC_CONV_TABLES &&
                      ((LPNMHDR)lParam)->code == NM_CUSTOMDRAW)
             {
-                SetWindowLong(hwndDlg,
-                              DWL_MSGRESULT,
-                              (LONG)ListViewCustomDraw(lParam));
+                SetWindowLongPtr(hwndDlg,
+                                 DWLP_MSGRESULT,
+                                 (LONG_PTR)ListViewCustomDraw(lParam));
                 return TRUE;
             }
             break;

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -929,7 +929,7 @@ ApplyChanges(HWND hwndDlg)
     }
     RegCloseKey(hKey);
 
-    SetWindowLong(hwndDlg, DWL_MSGRESULT, (LONG)PSNRET_NOERROR);
+    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, (LONG_PTR)PSNRET_NOERROR);
     return TRUE;
 }
 

--- a/dll/cpl/timedate/dateandtime.c
+++ b/dll/cpl/timedate/dateandtime.c
@@ -100,7 +100,7 @@ SetLocalSystemTime(HWND hwnd)
         SystemSetTime(&Time, FALSE);
 
         SetWindowLongPtrW(hwnd,
-                          DWL_MSGRESULT,
+                          DWLP_MSGRESULT,
                           PSNRET_NOERROR);
 
         SendMessageW(GetDlgItem(hwnd,

--- a/dll/cpl/timedate/timezone.c
+++ b/dll/cpl/timedate/timezone.c
@@ -453,7 +453,7 @@ TimeZonePageProc(HWND hwndDlg,
                 {
                     SetAutoDaylightInfo(GetDlgItem(hwndDlg, IDC_AUTODAYLIGHT));
                     SetLocalTimeZone(GetDlgItem(hwndDlg, IDC_TIMEZONELIST));
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                     return TRUE;
                 }
 

--- a/dll/shellext/deskadp/deskadp.c
+++ b/dll/shellext/deskadp/deskadp.c
@@ -198,17 +198,14 @@ ListAllModesDlgProc(HWND hwndDlg,
 
     if (uMsg != WM_INITDIALOG)
     {
-        This = (PDESKDISPLAYADAPTER)GetWindowLongPtr(hwndDlg,
-                                                     DWL_USER);
+        This = (PDESKDISPLAYADAPTER)GetWindowLongPtr(hwndDlg, DWLP_USER);
     }
 
     switch (uMsg)
     {
         case WM_INITDIALOG:
             This = (PDESKDISPLAYADAPTER)lParam;
-            SetWindowLongPtr(hwndDlg,
-                             DWL_USER,
-                             (LONG_PTR)This);
+            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)This);
 
             InitListAllModesDialog(This,
                                    hwndDlg);
@@ -386,8 +383,7 @@ DisplayAdapterDlgProc(HWND hwndDlg,
 
     if (uMsg != WM_INITDIALOG)
     {
-        This = (PDESKDISPLAYADAPTER)GetWindowLongPtr(hwndDlg,
-                                                     DWL_USER);
+        This = (PDESKDISPLAYADAPTER)GetWindowLongPtr(hwndDlg, DWLP_USER);
     }
 
     switch (uMsg)
@@ -395,9 +391,7 @@ DisplayAdapterDlgProc(HWND hwndDlg,
         case WM_INITDIALOG:
             This = (PDESKDISPLAYADAPTER)((LPCPROPSHEETPAGE)lParam)->lParam;
             This->hwndDlg = hwndDlg;
-            SetWindowLongPtr(hwndDlg,
-                             DWL_USER,
-                             (LONG_PTR)This);
+            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)This);
 
             InitDisplayAdapterDialog(This);
             Ret = TRUE;
@@ -426,7 +420,7 @@ DisplayAdapterDlgProc(HWND hwndDlg,
                 case PSN_APPLY:
                 {
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      ApplyDisplayAdapterChanges(This));
                     break;
                 }

--- a/dll/shellext/deskmon/deskmon.c
+++ b/dll/shellext/deskmon/deskmon.c
@@ -485,8 +485,7 @@ MonitorDlgProc(HWND hwndDlg,
 
     if (uMsg != WM_INITDIALOG)
     {
-        This = (PDESKMONITOR)GetWindowLongPtr(hwndDlg,
-                                              DWL_USER);
+        This = (PDESKMONITOR)GetWindowLongPtr(hwndDlg, DWLP_USER);
     }
 
     switch (uMsg)
@@ -494,9 +493,7 @@ MonitorDlgProc(HWND hwndDlg,
         case WM_INITDIALOG:
             This = (PDESKMONITOR)((LPCPROPSHEETPAGE)lParam)->lParam;
             This->hwndDlg = hwndDlg;
-            SetWindowLongPtr(hwndDlg,
-                             DWL_USER,
-                             (LONG_PTR)This);
+            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)This);
 
             InitMonitorDialog(This);
             Ret = TRUE;
@@ -535,7 +532,7 @@ MonitorDlgProc(HWND hwndDlg,
                 case PSN_APPLY:
                 {
                     SetWindowLongPtr(hwndDlg,
-                                     DWL_MSGRESULT,
+                                     DWLP_MSGRESULT,
                                      ApplyMonitorChanges(This));
                     break;
                 }

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -784,7 +784,7 @@ LANStatusUiDlg(
             if (lppsn->hdr.code == PSN_APPLY || lppsn->hdr.code == PSN_RESET)
             {
                 pContext = (LANSTATUSUI_CONTEXT*)GetWindowLongPtr(hwndDlg, DWLP_USER);
-                SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                 pContext->hwndDlg = NULL;
                 return TRUE;
             }

--- a/dll/shellext/netshell/setup.cpp
+++ b/dll/shellext/netshell/setup.cpp
@@ -83,7 +83,7 @@ NetworkSettingsPageDlgProc(
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_NETWORKCOMPONENTPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_NETWORKCOMPONENTPAGE);
                         return TRUE;
                     }
                     break;
@@ -95,7 +95,7 @@ NetworkSettingsPageDlgProc(
                     if (IsDlgButtonChecked(hwndDlg, IDC_NETWORK_TYPICAL) == BST_CHECKED)
                     {
                         pNetworkSetupData->bTypicalNetworkSetup = TRUE;
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_NETWORKDOMAINPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_NETWORKDOMAINPAGE);
                         return TRUE;
                     }
                     break;
@@ -163,7 +163,7 @@ NetworkComponentPageDlgProc(
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_NETWORKDOMAINPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_NETWORKDOMAINPAGE);
                         return TRUE;
                     }
                     break;
@@ -251,7 +251,7 @@ NetworkDomainPageDlgProc(
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, pSetupData->uPostNetworkWizardPage);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, pSetupData->uPostNetworkWizardPage);
                         return TRUE;
                     }
                     break;
@@ -271,7 +271,7 @@ NetworkDomainPageDlgProc(
                         MessageBoxW(hwndDlg, ErrorName, Title, MB_ICONERROR | MB_OK);
 
                         SetFocus(GetDlgItem(hwndDlg, IDC_DOMAIN_NAME));
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
 
                         //TODO: Implement setting the Domain/Workgroup
 
@@ -285,7 +285,7 @@ NetworkDomainPageDlgProc(
                     /* If the Typical setup chosen, then skip back to the Settings Page */
                     if (pNetworkSetupData->bTypicalNetworkSetup == TRUE)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_NETWORKSETTINGSPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_NETWORKSETTINGSPAGE);
                         return TRUE;
                     }
                     break;

--- a/dll/win32/aclui/aclui.c
+++ b/dll/win32/aclui/aclui.c
@@ -1242,8 +1242,7 @@ SecurityPageProc(IN HWND hwndDlg,
     PSECURITY_PAGE sp;
     INT_PTR Ret = FALSE;
 
-    sp = (PSECURITY_PAGE)GetWindowLongPtr(hwndDlg,
-                                          DWL_USER);
+    sp = (PSECURITY_PAGE)GetWindowLongPtr(hwndDlg, DWLP_USER);
     if (sp != NULL || uMsg == WM_INITDIALOG)
     {
         switch (uMsg)
@@ -1382,9 +1381,7 @@ SecurityPageProc(IN HWND hwndDlg,
                     sp->SpecialPermCheckIndex = -1;
 
                     /* save the pointer to the structure */
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)sp);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)sp);
 
                     (void)ListView_SetExtendedListViewStyleEx(sp->hWndPrincipalsList,
                                                               LVS_EX_FULLROWSELECT,

--- a/dll/win32/devmgr/properties/advprop.cpp
+++ b/dll/win32/devmgr/properties/advprop.cpp
@@ -310,8 +310,7 @@ DriverDetailsDlgProc(IN HWND hwndDlg,
     PDEVADVPROP_INFO dap;
     INT_PTR Ret = FALSE;
 
-    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg,
-                                             DWL_USER);
+    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (dap != NULL || uMsg == WM_INITDIALOG)
     {
@@ -348,9 +347,7 @@ DriverDetailsDlgProc(IN HWND hwndDlg,
                 dap = (PDEVADVPROP_INFO)lParam;
                 if (dap != NULL)
                 {
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)dap);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)dap);
 
                     hDriversListView = GetDlgItem(hwndDlg,
                                                   IDC_DRIVERFILES);
@@ -572,8 +569,7 @@ AdvProcDriverDlgProc(IN HWND hwndDlg,
     PDEVADVPROP_INFO dap;
     INT_PTR Ret = FALSE;
 
-    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg,
-                                             DWL_USER);
+    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (dap != NULL || uMsg == WM_INITDIALOG)
     {
@@ -614,9 +610,7 @@ AdvProcDriverDlgProc(IN HWND hwndDlg,
                 dap = (PDEVADVPROP_INFO)((LPPROPSHEETPAGE)lParam)->lParam;
                 if (dap != NULL)
                 {
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)dap);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)dap);
 
                     UpdateDriverDlg(hwndDlg,
                                     dap);
@@ -1768,8 +1762,7 @@ AdvProcDetailsDlgProc(IN HWND hwndDlg,
     PDEVADVPROP_INFO dap;
     INT_PTR Ret = FALSE;
 
-    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg,
-                                             DWL_USER);
+    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (dap != NULL || uMsg == WM_INITDIALOG)
     {
@@ -1807,9 +1800,7 @@ AdvProcDetailsDlgProc(IN HWND hwndDlg,
                 dap = (PDEVADVPROP_INFO)((LPPROPSHEETPAGE)lParam)->lParam;
                 if (dap != NULL)
                 {
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)dap);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)dap);
 
                     UpdateDetailsDlg(hwndDlg,
                                      dap);
@@ -2609,8 +2600,7 @@ AdvPropGeneralDlgProc(IN HWND hwndDlg,
     PDEVADVPROP_INFO dap;
     INT_PTR Ret = FALSE;
 
-    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg,
-                                             DWL_USER);
+    dap = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (dap != NULL || uMsg == WM_INITDIALOG)
     {
@@ -2669,9 +2659,7 @@ AdvPropGeneralDlgProc(IN HWND hwndDlg,
 
                     dap->hWndGeneralPage = hwndDlg;
 
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)dap);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)dap);
 
                     /* subclass the parent window to always receive
                        WM_DEVICECHANGE messages */

--- a/dll/win32/devmgr/properties/hwpage.cpp
+++ b/dll/win32/devmgr/properties/hwpage.cpp
@@ -803,8 +803,7 @@ HardwareDlgProc(IN HWND hwndDlg,
     PHARDWARE_PAGE_DATA hpd;
     INT_PTR Ret = FALSE;
 
-    hpd = (PHARDWARE_PAGE_DATA)GetWindowLongPtr(hwndDlg,
-                                                DWL_USER);
+    hpd = (PHARDWARE_PAGE_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (hpd != NULL || uMsg == WM_INITDIALOG)
     {
@@ -889,9 +888,7 @@ HardwareDlgProc(IN HWND hwndDlg,
                     HWND hWndParent;
 
                     hpd->hWnd = hwndDlg;
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)hpd);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)hpd);
 
                     hpd->ClassImageListData.cbSize = sizeof(SP_CLASSIMAGELIST_DATA);
 
@@ -965,7 +962,7 @@ HardwareDlgProc(IN HWND hwndDlg,
             case WM_DESTROY:
             {
                 /* zero hpd pointer in window data, because it can be used later (WM_DESTROY has not to be last message) */
-                SetWindowLongPtr(hwndDlg, DWL_USER, (DWORD_PTR)NULL);
+                SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)NULL);
                 
                 /* free devices list */
                 FreeDevicesList(hpd);

--- a/dll/win32/devmgr/properties/hwresource.cpp
+++ b/dll/win32/devmgr/properties/hwresource.cpp
@@ -344,8 +344,7 @@ ResourcesProcDriverDlgProc(IN HWND hwndDlg,
     HWND hWndDevList;
     INT_PTR Ret = FALSE;
 
-    hpd = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg,
-                                                DWL_USER);
+    hpd = (PDEVADVPROP_INFO)GetWindowLongPtr(hwndDlg, DWLP_USER);
 
     if (hpd != NULL || uMsg == WM_INITDIALOG)
     {
@@ -360,13 +359,7 @@ ResourcesProcDriverDlgProc(IN HWND hwndDlg,
                 hpd = (PDEVADVPROP_INFO)((LPPROPSHEETPAGE)lParam)->lParam;
                 if (hpd != NULL)
                 {
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)hpd);
-
-                    SetWindowLongPtr(hwndDlg,
-                                     DWL_USER,
-                                     (DWORD_PTR)hpd);
+                    SetWindowLongPtr(hwndDlg, DWLP_USER, (DWORD_PTR)hpd);
 
                     UpdateDriverResourceDlg(hwndDlg, hpd);
                     AddResourceItems(hpd, hWndDevList);

--- a/dll/win32/netcfgx/tcpipconf_notify.c
+++ b/dll/win32/netcfgx/tcpipconf_notify.c
@@ -1319,7 +1319,7 @@ TcpipAdvancedIpDlg(
                 if (!This->pCurrentConfig->DhcpEnabled && ListView_GetItemCount(GetDlgItem(hwndDlg, IDC_IPLIST)) == 0)
                 {
                     DisplayError(IDS_NO_IPADDR_SET, IDS_TCPIP, MB_ICONWARNING);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, TRUE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
                     return TRUE;
                 }
             }
@@ -1332,7 +1332,7 @@ TcpipAdvancedIpDlg(
                 This->pCurrentConfig->Ip = NULL;
                 StoreIPSettings(GetDlgItem(hwndDlg, IDC_IPLIST), This, TRUE);
                 StoreIPSettings(GetDlgItem(hwndDlg, IDC_GWLIST), This, FALSE);
-                SetWindowLong(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                 return TRUE;
             }
             break;
@@ -1848,7 +1848,7 @@ TcpipAdvancedDnsDlg(
                     SendDlgItemMessageW(hwndDlg, IDC_DNSSUFFIXLIST, LB_GETCOUNT, 0, 0) == 0)
                 {
                     DisplayError(IDS_NO_SUFFIX, IDS_TCPIP, MB_ICONWARNING);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, TRUE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
                     return TRUE;
                 }
                 if (SendDlgItemMessageW(hwndDlg, IDC_SUFFIX, WM_GETTEXT, sizeof(szSuffix)/sizeof(WCHAR), (LPARAM)szSuffix))
@@ -1866,7 +1866,7 @@ TcpipAdvancedDnsDlg(
                                 szFormat[0] = L'\0';
 
                             MessageBoxW(hwndDlg, szBuffer, szFormat, MB_ICONWARNING);
-                            SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, TRUE);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
                             SetFocus(GetDlgItem(hwndDlg, IDC_SUFFIX));
                             return TRUE;
                         }
@@ -2502,9 +2502,9 @@ TcpipBasicDlg(
             {
                 This = (TcpipConfNotifyImpl*)GetWindowLongPtr(hwndDlg, DWLP_USER);
                 if (SUCCEEDED(StoreTcpipBasicSettings(hwndDlg, This, TRUE)))
-                    SetWindowLong(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                 else
-                    SetWindowLong(hwndDlg, DWL_MSGRESULT, PSNRET_INVALID);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID);
 
                 return TRUE;
             }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -778,7 +778,7 @@ SearchDrvDlgProc(
                 case PSN_KILLACTIVE:
                     if (hThread != 0)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, TRUE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
                         return TRUE;
                     }
                     break;
@@ -889,7 +889,7 @@ InstallDrvDlgProc(
                 case PSN_KILLACTIVE:
                     if (hThread != 0)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, TRUE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, TRUE);
                         return TRUE;
                     }
                     break;

--- a/dll/win32/serialui/serialui.c
+++ b/dll/win32/serialui/serialui.c
@@ -204,7 +204,7 @@ CommDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
 			INT i;
 
 			lpDlgInfo = (LPDIALOG_INFO)lParam;
-			SetWindowLongPtrW(hDlg, DWL_USER, (LONG_PTR)lpDlgInfo);
+			SetWindowLongPtrW(hDlg, DWLP_USER, (LONG_PTR)lpDlgInfo);
 
 			/* Set title */
 			if(LoadStringW(hDllInstance, IDS_TITLE, wstr, sizeof(wstr) / sizeof(wstr[0])))
@@ -364,7 +364,7 @@ VOID OkButton(HWND hDlg)
 	LPDIALOG_INFO lpDlgInfo;
 	UINT Index;
 
-	lpDlgInfo = (LPDIALOG_INFO) GetWindowLongPtrW(hDlg, DWL_USER);
+	lpDlgInfo = (LPDIALOG_INFO) GetWindowLongPtrW(hDlg, DWLP_USER);
 
 	/* Baud rate */
 	Index = SendMessageW(GetDlgItem(hDlg, IDC_BAUDRATE), CB_GETCURSEL, 0, 0);

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2846,7 +2846,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
                 {
                     // FIXME load localized error msg
                     MessageBoxW(hwndDlg, L"You cannot create a link to a shortcut", L"Error", MB_ICONERROR);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
                     return TRUE;
                 }
 
@@ -2854,7 +2854,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
                 {
                     // FIXME load localized error msg
                     MessageBoxW(hwndDlg, L"The specified file name in the target box is invalid", L"Error", MB_ICONERROR);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID_NOCHANGEPAGE);
                     return TRUE;
                 }
 
@@ -2868,7 +2868,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
 
                 TRACE("This %p m_sLinkPath %S\n", pThis, pThis->m_sLinkPath);
                 pThis->Save(pThis->m_sLinkPath, TRUE);
-                SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                 return TRUE;
             }
             break;

--- a/dll/win32/shell32/dialogs/drvdefext.cpp
+++ b/dll/win32/shell32/dialogs/drvdefext.cpp
@@ -460,7 +460,7 @@ CDrvDefExt::GeneralPageProc(
 
                     if (GetDlgItemTextW(hwndDlg, 14000, wszBuf, _countof(wszBuf)))
                         SetVolumeLabelW(pDrvDefExt->m_wszDrive, wszBuf);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                     return TRUE;
                 }
             }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -712,7 +712,7 @@ CFileDefExt::GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
                         ERR("MoveFileW failed\n");
                 }
 
-                SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR);
+                SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR);
                 return TRUE;
             }
             break;
@@ -767,7 +767,7 @@ CFileDefExt::InitVersionPage(HWND hwndDlg)
     AddVersionString(hwndDlg, L"ProductVersion");
 
     /* Attach file version to dialog window */
-    SetWindowLongPtr(hwndDlg, DWL_USER, (LONG_PTR)this);
+    SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)this);
 
     /* Select first item */
     HWND hDlgCtrl = GetDlgItem(hwndDlg, 14009);

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -1240,7 +1240,7 @@ FolderOptionsViewDlg(
                 case NM_CUSTOMDRAW:     // custom draw (for graying)
                     Draw = (NMTVCUSTOMDRAW *)lParam;
                     Result = ViewDlg_OnTreeCustomDraw(hwndDlg, Draw);
-                    SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, Result);
+                    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, Result);
                     return Result;
                 case TVN_KEYDOWN:       // key is down
                     ViewDlg_OnTreeViewKeyDown(hwndDlg, (TV_KEYDOWN *)lParam);

--- a/dll/win32/shell32/dialogs/recycler_prop.cpp
+++ b/dll/win32/shell32/dialogs/recycler_prop.cpp
@@ -334,7 +334,7 @@ RecycleBinDlg(
                 }
                 if (StoreDriveSettings(hwndDlg))
                 {
-                    SetWindowLongPtr( hwndDlg, DWL_MSGRESULT, PSNRET_NOERROR );
+                    SetWindowLongPtr( hwndDlg, DWLP_MSGRESULT, PSNRET_NOERROR );
                     return TRUE;
                 }
             }

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -246,7 +246,7 @@ WelcomeDlgProc(HWND hwndDlg,
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_ACKPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_ACKPAGE);
                         return TRUE;
                     }
                     break;
@@ -358,7 +358,7 @@ AckPageDlgProc(HWND hwndDlg,
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_LOCALEPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_LOCALEPAGE);
                         return TRUE;
                     }
                     break;
@@ -480,7 +480,7 @@ OwnerPageDlgProc(HWND hwndDlg,
                         SendMessage(GetDlgItem(hwndDlg, IDC_OWNERORGANIZATION), WM_SETTEXT, 0, (LPARAM)pSetupData->OwnerOrganization);
                         if (WriteOwnerSettings(pSetupData->OwnerName, pSetupData->OwnerOrganization))
                         {
-                            SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_COMPUTERPAGE);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_COMPUTERPAGE);
                             return TRUE;
                         }
                     }
@@ -501,7 +501,7 @@ OwnerPageDlgProc(HWND hwndDlg,
                         MessageBoxW(hwndDlg, ErrorName, Title, MB_ICONERROR | MB_OK);
 
                         SetFocus(GetDlgItem(hwndDlg, IDC_OWNERNAME));
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
 
                         return TRUE;
                     }
@@ -512,7 +512,7 @@ OwnerPageDlgProc(HWND hwndDlg,
                     if (!WriteOwnerSettings(OwnerName, OwnerOrganization))
                     {
                         SetFocus(GetDlgItem(hwndDlg, IDC_OWNERNAME));
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                         return TRUE;
                     }
 
@@ -706,7 +706,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (pSetupData->UnattendSetup && WriteComputerSettings(pSetupData->ComputerName, hwndDlg))
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_THEMEPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_THEMEPAGE);
                         return TRUE;
                     }
                     break;
@@ -721,7 +721,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                         }
                         MessageBoxW(hwndDlg, EmptyComputerName, Title, MB_ICONERROR | MB_OK);
                         SetFocus(GetDlgItem(hwndDlg, IDC_COMPUTERNAME));
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                         return TRUE;
                     }
 
@@ -731,7 +731,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                     if (!WriteComputerSettings(ComputerName, hwndDlg))
                     {
                         SetFocus(GetDlgItem(hwndDlg, IDC_COMPUTERNAME));
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                         return TRUE;
                     }
 
@@ -746,7 +746,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                             wcscpy(EmptyPassword, L"You must enter a password !");
                         }
                         MessageBoxW(hwndDlg, EmptyPassword, Title, MB_ICONERROR | MB_OK);
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                         return TRUE;
                     }
 #else
@@ -762,7 +762,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                             wcscpy(NotMatchPassword, L"The passwords you entered do not match. Please enter the desired password again.");
                         }
                         MessageBoxW(hwndDlg, NotMatchPassword, Title, MB_ICONERROR | MB_OK);
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                         return TRUE;
                     }
 
@@ -778,7 +778,7 @@ ComputerPageDlgProc(HWND hwndDlg,
                                 wcscpy(WrongPassword, L"The password you entered contains invalid characters. Please enter a cleaned password.");
                             }
                             MessageBoxW(hwndDlg, WrongPassword, Title, MB_ICONERROR | MB_OK);
-                            SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, -1);
+                            SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, -1);
                             return TRUE;
                         }
                         Password++;
@@ -998,7 +998,7 @@ LocalePageDlgProc(HWND hwndDlg,
                             RunControlPanelApplet(hwndDlg, L"intl.cpl,,/f:\"unattend.inf\"");
                         }
 
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, IDD_OWNERPAGE);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, IDD_OWNERPAGE);
                         return TRUE;
                     }
                     break;
@@ -1571,7 +1571,7 @@ DateTimePageDlgProc(HWND hwndDlg,
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (SetupData->UnattendSetup && WriteDateTimeSettings(hwndDlg, SetupData))
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, SetupData->uFirstNetworkWizardPage);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, SetupData->uFirstNetworkWizardPage);
                         return TRUE;
                     }
                     SetTimer(hwndDlg, 1, 1000, NULL);
@@ -1666,7 +1666,7 @@ ThemePageDlgProc(HWND hwndDlg,
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (SetupData->UnattendSetup)
                     {
-                        SetWindowLongPtr(hwndDlg, DWL_MSGRESULT, SetupData->uFirstNetworkWizardPage);
+                        SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, SetupData->uFirstNetworkWizardPage);
                         return TRUE;
                     }
                     break;

--- a/modules/rosapps/applications/explorer-old/dialogs/settings.cpp
+++ b/modules/rosapps/applications/explorer-old/dialogs/settings.cpp
@@ -102,7 +102,7 @@ int DesktopSettingsDlg::Notify(int id, NMHDR* pnmh)
 {
 	switch(pnmh->code) {
 	  case PSN_QUERYINITIALFOCUS:
-		SetWindowLongPtr(_hwnd, DWL_MSGRESULT, (LPARAM)GetDlgItem(_hwnd, IDC_ICON_ALIGN_0+_alignment_cur));
+		SetWindowLongPtr(_hwnd, DWLP_MSGRESULT, (LPARAM)GetDlgItem(_hwnd, IDC_ICON_ALIGN_0+_alignment_cur));
 		break;
 
 	  case PSN_APPLY:

--- a/modules/rosapps/applications/screensavers/matrix/matrix.c
+++ b/modules/rosapps/applications/screensavers/matrix/matrix.c
@@ -288,12 +288,12 @@ void DestroyMatrix(MATRIX *matrix)
 
 MATRIX *GetMatrix(HWND hwnd)
 {
-	return (MATRIX *)GetWindowLong(hwnd, 0);
+	return (MATRIX *)GetWindowLongPtr(hwnd, GWLP_USERDATA);
 }
 
 void SetMatrix(HWND hwnd, MATRIX *matrix)
 {
-	SetWindowLong(hwnd, 0, (LONG)matrix);
+	SetWindowLongPtr(hwnd, GWLP_USERDATA, (LONG_PTR)matrix);
 }
 
 //

--- a/modules/rosapps/lib/vfdlib/vfdguiopen.c
+++ b/modules/rosapps/lib/vfdlib/vfdguiopen.c
@@ -47,7 +47,11 @@
 //
 //	local functions
 //
+#ifndef __REACTOS__
 static INT CALLBACK OpenDialogProc(
+#else
+static INT_PTR CALLBACK OpenDialogProc(
+#endif
 	HWND			hDlg,
 	UINT			uMsg,
 	WPARAM			wParam,
@@ -89,7 +93,11 @@ DWORD WINAPI VfdGuiOpen(
 //
 // Open image dialog procedure
 //
+#ifndef __REACTOS__
 INT CALLBACK OpenDialogProc(
+#else
+INT_PTR CALLBACK OpenDialogProc(
+#endif
 	HWND			hDlg,
 	UINT			uMsg,
 	WPARAM			wParam,

--- a/modules/rosapps/lib/vfdlib/vfdguisave.c
+++ b/modules/rosapps/lib/vfdlib/vfdguisave.c
@@ -35,7 +35,11 @@
 //
 //	local functions
 //
+#ifndef __REACTOS__
 static INT CALLBACK SaveDialogProc(
+#else
+static INT_PTR CALLBACK SaveDialogProc(
+#endif
 	HWND			hDlg,
 	UINT			uMsg,
 	WPARAM			wParam,
@@ -119,7 +123,11 @@ DWORD GuiSaveParam(
 //
 // The dialog procedure
 //
+#ifndef __REACTOS__
 INT CALLBACK SaveDialogProc(
+#else
+INT_PTR CALLBACK SaveDialogProc(
+#endif
 	HWND			hDlg,
 	UINT			uMsg,
 	WPARAM			wParam,

--- a/modules/rosapps/lib/vfdlib/vfdlib.h
+++ b/modules/rosapps/lib/vfdlib/vfdlib.h
@@ -10,6 +10,10 @@
 #ifndef _VFDLIB_H_
 #define _VFDLIB_H_
 
+#ifdef __REACTOS__
+#define DWL_USER DWLP_USER
+#endif
+
 #define VFD_LIBRARY_FILENAME	"vfd.dll"
 
 #ifdef VFD_EMBED_DRIVER

--- a/modules/rosapps/lib/vfdlib/vfdshext.h
+++ b/modules/rosapps/lib/vfdlib/vfdshext.h
@@ -67,7 +67,11 @@ public:
 		LPCMINVOKECOMMANDINFO lpcmi);
 
 	STDMETHODIMP GetCommandString(
+#ifndef __REACTOS__
 		UINT			idCmd,
+#else
+        UINT_PTR		idCmd,
+#endif
 		UINT			uFlags,
 		UINT			*reserved,
 		LPSTR			pszName,

--- a/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshmenu.cpp
@@ -267,7 +267,11 @@ STDMETHODIMP CVfdShExt::QueryContextMenu(
 //
 
 STDMETHODIMP CVfdShExt::GetCommandString(
+#ifndef __REACTOS__
 	UINT			idCmd,
+#else
+    UINT_PTR		idCmd,
+#endif
 	UINT			uFlags,
 	UINT			*reserved,
 	LPSTR			pszName,

--- a/modules/rosapps/lib/vfdlib/vfdshprop.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshprop.cpp
@@ -237,7 +237,11 @@ void OnControl(
 	CHAR			module_path[MAX_PATH];
 	CHAR			full_path[MAX_PATH];
 	PSTR			file_name;
+#ifndef __REACTOS__
 	DWORD			ret;
+#else
+	DWORD_PTR		ret;
+#endif
 
 	ret = GetModuleFileName(
 		g_hDllModule, module_path, sizeof(module_path));
@@ -258,8 +262,13 @@ void OnControl(
 
 	VFDTRACE(0, ("Starting %s\n", full_path));
 
+#ifndef __REACTOS__
 	ret = (DWORD)ShellExecute(
 		hDlg, NULL, full_path, NULL, NULL, SW_SHOW);
+#else
+	ret = (DWORD_PTR)ShellExecute(
+		hDlg, NULL, full_path, NULL, NULL, SW_SHOW);
+#endif
 
 	if (ret > 32) {
 		PropSheet_PressButton(GetParent(hDlg), PSBTN_CANCEL);

--- a/modules/rosapps/lib/vfdlib/vfdshprop.cpp
+++ b/modules/rosapps/lib/vfdlib/vfdshprop.cpp
@@ -35,7 +35,11 @@
 //
 //	local functions
 //
+#ifndef __REACTOS__
 static BOOL CALLBACK VfdPageDlgProc(
+#else
+static INT_PTR CALLBACK VfdPageDlgProc(
+#endif
 	HWND			hDlg,
 	UINT			uMessage,
 	WPARAM			wParam,
@@ -76,7 +80,11 @@ UINT CALLBACK VfdPageCallback(
 //
 //	property page dialog procedure
 //
+#ifndef __REACTOS__
 BOOL CALLBACK VfdPageDlgProc(
+#else
+INT_PTR CALLBACK VfdPageDlgProc(
+#endif
 	HWND			hDlg,
 	UINT			uMessage,
 	WPARAM			wParam,
@@ -87,7 +95,11 @@ BOOL CALLBACK VfdPageDlgProc(
 
 	switch (uMessage) {
 	case WM_INITDIALOG:
+#ifndef __REACTOS__
 		SetWindowLong(hDlg, DWL_USER, lParam);
+#else
+		SetWindowLongPtr(hDlg, DWLP_USER, lParam);
+#endif
 
 		if (lParam) {
 			lpcs = (LPCVFDSHEXT)((LPPROPSHEETPAGE)lParam)->lParam;
@@ -98,7 +110,11 @@ BOOL CALLBACK VfdPageDlgProc(
 		return TRUE;
 
 	case WM_COMMAND:
+#ifndef __REACTOS__
 		psp = (LPPROPSHEETPAGE)GetWindowLong(hDlg, DWL_USER);
+#else
+		psp = (LPPROPSHEETPAGE)GetWindowLongPtr(hDlg, DWLP_USER);
+#endif
 
 		if (!psp) {
 			break;
@@ -165,7 +181,11 @@ BOOL CALLBACK VfdPageDlgProc(
 
 	default:
 		if (uMessage == g_nNotifyMsg) {
+#ifndef __REACTOS__
 			psp = (LPPROPSHEETPAGE)GetWindowLong(hDlg, DWL_USER);
+#else
+			psp = (LPPROPSHEETPAGE)GetWindowLongPtr(hDlg, DWLP_USER);
+#endif
 
 			if (!psp) {
 				break;

--- a/modules/rosapps/templates/dialog/dialog.c
+++ b/modules/rosapps/templates/dialog/dialog.c
@@ -123,7 +123,7 @@ LRESULT CALLBACK DlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
     LPNMHDR pnmh;
     LPCREATESTRUCT lpCS;
     LONG nThisApp = 0;
-    DialogData* pData = (DialogData*)GetWindowLong(hDlg, DWL_USER);
+    DialogData* pData = (DialogData*)GetWindowLongPtr(hDlg, DWLP_USER);
     if (pData) nThisApp = pData->lData;
 
     switch (message) {
@@ -136,7 +136,7 @@ LRESULT CALLBACK DlgProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 
     case WM_INITDIALOG:
         pData = (DialogData*)lParam;
-        SetWindowLong(hDlg, DWL_USER, (LONG)pData);
+        SetWindowLongPtr(hDlg, DWLP_USER, (LONG_PTR)pData);
         if (pData) nThisApp = pData->lData;
         return OnCreate(hDlg, nThisApp);
 

--- a/sdk/include/psdk/windowsx.h
+++ b/sdk/include/psdk/windowsx.h
@@ -485,7 +485,21 @@
 #define SelectBrush(hdc,hbr) ((HBRUSH)SelectObject((hdc),(HGDIOBJ)(HBRUSH)(hbr)))
 #define SelectFont(hdc,hfont) ((HFONT)SelectObject((hdc),(HGDIOBJ)(HFONT)(hfont)))
 #define SelectPen(hdc,hpen) ((HPEN)SelectObject((hdc),(HGDIOBJ)(HPEN)(hpen)))
-#define SetDlgMsgResult(hwnd,msg,result) (( (msg) == WM_CTLCOLORMSGBOX || (msg) == WM_CTLCOLOREDIT || (msg) == WM_CTLCOLORLISTBOX || (msg) == WM_CTLCOLORBTN || (msg) == WM_CTLCOLORDLG || (msg) == WM_CTLCOLORSCROLLBAR || (msg) == WM_CTLCOLORSTATIC || (msg) == WM_COMPAREITEM || (msg) == WM_VKEYTOITEM || (msg) == WM_CHARTOITEM || (msg) == WM_QUERYDRAGICON || (msg) == WM_INITDIALOG ) ? (BOOL)(result) : (SetWindowLong((hwnd),DWL_MSGRESULT,(LPARAM)(LRESULT)(result)),TRUE))
+#define SetDlgMsgResult(hwnd,msg,result) \
+     (( ((msg) == WM_CTLCOLORMSGBOX) || \
+        ((msg) == WM_CTLCOLOREDIT) || \
+        ((msg) == WM_CTLCOLORLISTBOX) || \
+        ((msg) == WM_CTLCOLORBTN) || \
+        ((msg) == WM_CTLCOLORDLG) || \
+        ((msg) == WM_CTLCOLORSCROLLBAR) || \
+        ((msg) == WM_CTLCOLORSTATIC) || \
+        ((msg) == WM_COMPAREITEM) || \
+        ((msg) == WM_VKEYTOITEM) || \
+        ((msg) == WM_CHARTOITEM) || \
+        ((msg) == WM_QUERYDRAGICON) || \
+        ((msg) == WM_INITDIALOG) ) ? \
+        (BOOL)(result) : \
+        (SetWindowLongPtr((hwnd), DWLP_MSGRESULT, (LPARAM)(LRESULT)(result)), TRUE) )
 #define SetWindowFont(hwnd,hfont,fRedraw) FORWARD_WM_SETFONT((hwnd),(hfont),(fRedraw),SendMessage)
 #define SetWindowRedraw(hwnd,fRedraw) ((void)SendMessage(hwnd,WM_SETREDRAW,(WPARAM)(BOOL)(fRedraw),0))
 #define Static_Enable(hwndCtl,fEnable) EnableWindow((hwndCtl),(fEnable))

--- a/sdk/include/psdk/winuser.h
+++ b/sdk/include/psdk/winuser.h
@@ -849,12 +849,17 @@ extern "C" {
 #define GWLP_ID (-12)
 #define GWL_USERDATA (-21)
 #define GWLP_USERDATA (-21)
-#define DWL_DLGPROC 4
-#define DWLP_DLGPROC 4
+
+#ifndef __REACTOS__ // NEVER USE THESE!
 #define DWL_MSGRESULT 0
-#define DWLP_MSGRESULT 0
+#define DWL_DLGPROC 4
 #define DWL_USER 8
-#define DWLP_USER 8
+#endif
+
+#define DWLP_MSGRESULT 0
+#define DWLP_DLGPROC (DWLP_MSGRESULT + sizeof(LRESULT))
+#define DWLP_USER (DWLP_DLGPROC + sizeof(DLGPROC))
+
 #if (_WIN32_WINNT >= 0x0501)
 #define QS_ALLEVENTS 1215
 #define QS_ALLINPUT 1279

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -28,6 +28,7 @@
 #define Unused(x)    (x);
 #endif // __GNUC__
 
+#if !defined(_WIN64)
 #ifdef SetWindowLongPtr
 #undef SetWindowLongPtr
 inline LONG_PTR SetWindowLongPtr(HWND hWnd, int nIndex, LONG_PTR dwNewLong)
@@ -43,6 +44,7 @@ inline LONG_PTR GetWindowLongPtr(HWND hWnd, int nIndex)
     return (LONG_PTR)GetWindowLong(hWnd, nIndex);
 }
 #endif
+#endif // !_WIN64
 
 #pragma push_macro("SubclassWindow")
 #undef SubclassWindow


### PR DESCRIPTION
## Fix definitions and usage of DWLP_MSGRESULT, DWLP_DLGPROC, and DWLP_USER
- Make sure the DWLP_* values are correct on _WIN64
- Don't use the DWL_* constants, they are not portable. Enforce this by removing them entirely from winuser.h
- Make sure Get/SetWindowLong*Ptr* is used and pointers are not truncated to LONG
