### PR TITLE
[DRIVERS:RTL8139] MiniportInitialize(): Add a minimal 'CmResourceTypeMemory' case

### DIFF
--- a/drivers/network/dd/rtl8139/ndis.c
+++ b/drivers/network/dd/rtl8139/ndis.c
@@ -320,6 +320,12 @@ MiniportInitialize (
                 NDIS_DbgPrint(MID_TRACE, ("IRQ vector is %d\n", adapter->InterruptVector));
                 break;
 
+            case CmResourceTypeMemory:
+                NDIS_DbgPrint(MID_TRACE, ("Ignoring Memory resource type: Start = 0x%llx, Length = 0x%lx\n",
+                                          resourceList->PartialDescriptors[i].u.Memory.Start.QuadPart,
+                                          resourceList->PartialDescriptors[i].u.Memory.Length));
+                break;
+
             default:
                 NDIS_DbgPrint(MIN_TRACE, ("Unrecognized resource type: 0x%x\n", resourceList->PartialDescriptors[i].Type));
                 break;


### PR DESCRIPTION
## Purpose

So it is not reported as an "Unrecognized resource type".

JIRA issue: [CORE-10296](https://jira.reactos.org/browse/CORE-10296), on behalf of Jacob S. Preciado
Per @ThFabba's hint.
