### PR TITLE
CORE-13734. RedrawWindow: Add a DestroyWindow() call

### DIFF
--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -83,4 +83,5 @@ START_TEST(RedrawWindow)
     TRACE_CACHE();
 
     DeleteObject(hRgn);
+    DestroyWindow(hWnd);
 }


### PR DESCRIPTION
## Purpose

Match `CreateWindowExW()` call.

Addendum to 7905efdf357ad830d4abba23a428dcd9e6195247 by @ThFabba.
JIRA issue: [CORE-13734](https://jira.reactos.org/browse/CORE-13734)
