### PR TITLE
[BUS][ACPI] Silence the debug output of DPRINT1()

### DIFF
--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -313,7 +313,7 @@ ACPIDispatchDeviceControl(
               break;
            
            case IOCTL_BATTERY_QUERY_TAG:
-              DPRINT("Unsupported IOCTL with ID 294040.\n");
+              DPRINT("IOCTL_BATTERY_QUERY_TAG is not supported!\n");
               break;
 
            default:

--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -313,7 +313,7 @@ ACPIDispatchDeviceControl(
               break;
 
            default:
-              DPRINT1("Unsupported IOCTL: %x\n", irpStack->Parameters.DeviceIoControl.IoControlCode);
+              DPRINT("Unsupported IOCTL: %x\n", irpStack->Parameters.DeviceIoControl.IoControlCode);
               break;
        }
     }

--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -311,9 +311,14 @@ ACPIDispatchDeviceControl(
 
               status = STATUS_PENDING;
               break;
+               
+           // FIXME: When CORE-14134 gets fixed, IOCTL_BATTERY_QUERY_TAG case should be removed
+           case IOCTL_BATTERY_QUERY_TAG:
+              DPRINT("Unsupported IOCTL with ID 294040.\n");
+              break;
 
            default:
-              DPRINT("Unsupported IOCTL: %x\n", irpStack->Parameters.DeviceIoControl.IoControlCode);
+              DPRINT1("Unsupported IOCTL: %x\n", irpStack->Parameters.DeviceIoControl.IoControlCode);
               break;
        }
     }

--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -311,8 +311,7 @@ ACPIDispatchDeviceControl(
 
               status = STATUS_PENDING;
               break;
-               
-           // FIXME: When CORE-14134 gets fixed, IOCTL_BATTERY_QUERY_TAG case should be removed
+           
            case IOCTL_BATTERY_QUERY_TAG:
               DPRINT("Unsupported IOCTL with ID 294040.\n");
               break;


### PR DESCRIPTION
## Purpose & Changes
Since **0.4.7** release, ReactOS is subject to [CORE-14134](https://jira.reactos.org/browse/CORE-14134). The symptom of this is the repetitive output of `Unsupported IOCTL: 294040` bloating the debug log and it doesn't stop regardless. It's annoying.