### PR TITLE
Fix Lenovo ACPI mistake.

### DIFF
--- a/drivers/input/i8042prt/i8042prt.h
+++ b/drivers/input/i8042prt/i8042prt.h
@@ -223,6 +223,8 @@ typedef struct _I8042_HOOK_WORKITEM
 #define MOUSE_ENAB         0xA8
 #define MOUSE_LINE_TEST    0xA9
 #define CTRL_SELF_TEST     0xAA
+#define KBD_CLK_DISABLE    0xAD
+#define KBD_CLK_ENABLE     0xAE
 #define CTRL_WRITE_MOUSE   0xD4
 
 /*-----------------------------------------------------

--- a/drivers/input/i8042prt/pnp.c
+++ b/drivers/input/i8042prt/pnp.c
@@ -274,6 +274,10 @@ i8042ConnectKeyboardInterrupt(
     TRACE_(I8042PRT, "i8042ConnectKeyboardInterrupt()\n");
 
     PortDeviceExtension = DeviceExtension->Common.PortDeviceExtension;
+
+    // Enable keyboard clock line
+    i8042Write(PortDeviceExtension, PortDeviceExtension->ControlPort, KBD_CLK_ENABLE);
+
     DirqlMax = MAX(
         PortDeviceExtension->KeyboardInterrupt.Dirql,
         PortDeviceExtension->MouseInterrupt.Dirql);


### PR DESCRIPTION
## Purpose

Fix Lenovo ACPI mistake when keyboard is not initializing.

JIRA issue: [CORE-14256](https://jira.reactos.org/browse/CORE-14256)

## Proposed changes

Sends 0xae to i8042 command register. SHOULD NOT AFFECT NON-PROBLEM MOTHERBOARDS!
