### PR TITLE
[KMTESTS:CC] Truncate file cache on uninitialize to avoid leaking a reference

### DIFF
--- a/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
@@ -156,6 +156,7 @@ TestIrpHandler(
     _In_ PIRP Irp,
     _In_ PIO_STACK_LOCATION IoStack)
 {
+    LARGE_INTEGER Zero = RTL_CONSTANT_LARGE_INTEGER(0LL);
     NTSTATUS Status;
     PTEST_FCB Fcb;
     CACHE_UNINITIALIZE_EVENT CacheUninitEvent;
@@ -307,7 +308,7 @@ TestIrpHandler(
     {
         ok_irql(PASSIVE_LEVEL);
         KeInitializeEvent(&CacheUninitEvent.Event, NotificationEvent, FALSE);
-        CcUninitializeCacheMap(IoStack->FileObject, NULL, &CacheUninitEvent);
+        CcUninitializeCacheMap(IoStack->FileObject, &Zero, &CacheUninitEvent);
         KeWaitForSingleObject(&CacheUninitEvent.Event, Executive, KernelMode, FALSE, NULL);
         Fcb = IoStack->FileObject->FsContext;
         ExFreePoolWithTag(Fcb, 'FwrI');

--- a/modules/rostests/kmtests/ntos_cc/CcMapData_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcMapData_drv.c
@@ -198,6 +198,7 @@ CleanupTest(
     ULONG TestId,
     PDEVICE_OBJECT DeviceObject)
 {
+    LARGE_INTEGER Zero = RTL_CONSTANT_LARGE_INTEGER(0LL);
     CACHE_UNINITIALIZE_EVENT CacheUninitEvent;
 
     ok_eq_pointer(TestDeviceObject, DeviceObject);
@@ -208,7 +209,7 @@ CleanupTest(
         if (CcIsFileCached(TestFileObject))
         {
             KeInitializeEvent(&CacheUninitEvent.Event, NotificationEvent, FALSE);
-            CcUninitializeCacheMap(TestFileObject, NULL, &CacheUninitEvent);
+            CcUninitializeCacheMap(TestFileObject, &Zero, &CacheUninitEvent);
             KeWaitForSingleObject(&CacheUninitEvent.Event, Executive, KernelMode, FALSE, NULL);
         }
 


### PR DESCRIPTION
Fixes driver unload failing on Windows.

ROSTESTS-264 ROSTESTS-300