### PR TITLE
[MSI] Avoid an "Use After Free" in msiobj_release

### DIFF
--- a/dll/win32/msi/handle.c
+++ b/dll/win32/msi/handle.c
@@ -246,8 +246,8 @@ int msiobj_release( MSIOBJECTHDR *info )
     {
         if( info->destructor )
             info->destructor( info );
-        msi_free( info );
         TRACE("object %p destroyed\n", info);
+		msi_free( info );
     }
 
     return ret;


### PR DESCRIPTION
Free after the Trace to avoid a Use After Free

## Purpose

CID-714081

## Proposed changes
Fix an User After Free detected by Coverity