### PR TITLE
[NTDLL][RTL] Remove UNIMPLEMENTED from RtlComputeImportTableHash()

### DIFF
--- a/dll/ntdll/rtl/libsupp.c
+++ b/dll/ntdll/rtl/libsupp.c
@@ -917,7 +917,6 @@ RtlComputeImportTableHash(IN HANDLE FileHandle,
                           OUT PCHAR Hash,
                           IN ULONG ImportTableHashSize)
 {
-    UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
 }
 


### PR DESCRIPTION
## Purpose
The function returns the NT status code `STATUS_NOT_IMPLEMENTED` yet there is `UNIMPLEMENTED` which is declared and that would mean RtlComputeImportTableHash() returns "unimplemented" status twice. IMHO, I find it unnecessary to belong there as there is STATUS_NOT_IMPLEMENTED for a reason.