### PR TITLE
Warning window implementation for missing HTML Help support

### DIFF
--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -1352,9 +1352,12 @@ static INT_PTR CALLBACK DlgMainProc(HWND hWnd, UINT msg, WPARAM wp, LPARAM lp)
             return TRUE;
         }
         case IDM_HELP_HELP:
-#ifndef DISABLE_HTMLHELP_SUPPORT
-            HtmlHelp(hWnd, HTMLHELP_PATH("/general_information.htm"), HH_DISPLAY_TOPIC, (DWORD_PTR)NULL);
-#endif
+// #ifndef DISABLE_HTMLHELP_SUPPORT
+           // HtmlHelp(hWnd, HTMLHELP_PATH("/general_information.htm"), HH_DISPLAY_TOPIC, (DWORD_PTR)NULL);
+           // The line above (same thing for #ifndef and the end block) must be un-commented when ReactOS will get HTML Help support
+           MessageBox(hWnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
+           break;
+// #endif
             return TRUE;
         case IDM_VIEW_STANDARD:
             if (calc.layout != CALC_LAYOUT_STANDARD)

--- a/base/applications/charmap/charmap.c
+++ b/base/applications/charmap/charmap.c
@@ -399,6 +399,11 @@ CharMapDlgProc(HWND hDlg,
                         break;
                     }
                     break;
+                
+                // FIXME: MessageBox() must be removed when ReactOS will get HTML Help support
+                case IDC_CMHELP:
+                    MessageBox(hDlg, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
+                    break;
 
                 case IDC_COPY:
                     CopyCharacters(hDlg);

--- a/base/applications/clipbrd/clipbrd.c
+++ b/base/applications/clipbrd/clipbrd.c
@@ -250,7 +250,9 @@ static int ClipboardCommandHandler(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM l
 
         case CMD_HELP:
         {
-            HtmlHelpW(Globals.hMainWnd, L"clipbrd.chm", 0, 0);
+            // HtmlHelpW(Globals.hMainWnd, L"clipbrd.chm", 0, 0);
+            // ReactOS doesn't have HTML Help support yet, the line above will be commented for now
+            MessageBox(hWnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
             break;
         }
 

--- a/base/applications/games/solitaire/solitaire.cpp
+++ b/base/applications/games/solitaire/solitaire.cpp
@@ -709,7 +709,9 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
                 return 0;
 
             case IDM_HELP_CONTENTS:
-                WinHelp(hwnd, szHelpPath, HELP_CONTENTS, 0);//HELP_KEY, (DWORD)"How to play");
+                // WinHelp(hwnd, szHelpPath, HELP_CONTENTS, 0);//HELP_KEY, (DWORD)"How to play");
+                // FIXME: MessageBox() must be removed when ReactOS will get HTML Help support (as well as un-commenting the line above)
+                MessageBox(hwnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
                 return 0;
 
             case IDM_HELP_ABOUT:

--- a/base/applications/games/spider/spider.cpp
+++ b/base/applications/games/spider/spider.cpp
@@ -358,7 +358,9 @@ LRESULT CALLBACK WndProc (HWND hwnd, UINT iMsg, WPARAM wParam, LPARAM lParam)
                     return 0;
 
                 case IDM_HELP_CONTENTS:
-                    WinHelp(hwnd, szHelpPath, HELP_CONTENTS, 0);//HELP_KEY, (DWORD)"How to play");
+                    // WinHelp(hwnd, szHelpPath, HELP_CONTENTS, 0);//HELP_KEY, (DWORD)"How to play");
+                    // FIXME: MessageBox() must be removed when ReactOS will get HTML Help support (as well as un-commenting the line above)
+                    MessageBox(hwnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
                     return 0;
 
                 case IDM_HELP_ABOUT:

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -1188,6 +1188,12 @@ VOID DIALOG_HelpContents(VOID)
     WinHelp(Globals.hMainWnd, helpfile, HELP_INDEX, 0);
 }
 
+// Warning box function prototype -- This must be removed after ReactOS getting HTML Help support
+VOID DIALOG_WarningWindowBox(VOID)
+{
+    MessageBox(Globals.hMainWnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
+}
+
 VOID DIALOG_HelpAboutNotepad(VOID)
 {
     TCHAR szNotepad[MAX_STRING_LEN];

--- a/base/applications/notepad/dialog.h
+++ b/base/applications/notepad/dialog.h
@@ -53,6 +53,9 @@ VOID DIALOG_HelpLicense(VOID);
 VOID DIALOG_HelpNoWarranty(VOID);
 VOID DIALOG_HelpAboutNotepad(VOID);
 
+// Prototype definiton -- This must be removed after ReactOS getting HTML Help support
+VOID DIALOG_WarningWindowBox(VOID);
+
 VOID DIALOG_TimeDate(VOID);
 
 int DIALOG_StringMsgBox(HWND hParent, int formatId, LPCTSTR szString, DWORD dwFlags);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -86,7 +86,11 @@ static int NOTEPAD_MenuCommand(WPARAM wParam)
 
     case CMD_STATUSBAR: DIALOG_ViewStatusBar(); break;
 
-    case CMD_HELP_CONTENTS: DIALOG_HelpContents(); break;
+    case CMD_HELP_CONTENTS: 
+         // DIALOG_HelpContents();
+         // The line above must be un-commented when ReactOS will get HTML Help support
+         DIALOG_WarningWindowBox(); 
+         break;
 
     case CMD_ABOUT:
         DialogBox(GetModuleHandle(NULL),

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1093,7 +1093,9 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         toggle_child(hWnd, LOWORD(wParam), hStatusBar);
         return TRUE;
     case ID_HELP_HELPTOPICS:
-        WinHelpW(hWnd, getAppName(), HELP_FINDER, 0);
+        // WinHelpW(hWnd, getAppName(), HELP_FINDER, 0);
+        // The line above must be un-commented when ReactOS will get HTML Help support
+        MessageBox(hWnd, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
         return TRUE;
     case ID_HELP_ABOUT:
         ShowAboutBox(hWnd);

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -358,6 +358,10 @@ TaskManagerWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
         case ID_HELP_ABOUT:
             OnAbout();
             break;
+        // FIXME: MessageBox() must be removed when ReactOS will get HTML Help Support
+        case ID_HELP_TOPICS:
+            MessageBox(hDlg, L"ReactOS HTML Help support isn't implemented yet!", L"Warning", MB_OK | MB_ICONWARNING);
+            break;
         case ID_FILE_EXIT:
             EndDialog(hDlg, IDOK);
             break;


### PR DESCRIPTION
## Purpose
Currently ReactOS lacks the basic support for HTML Help component, barely any, which means the "Help Contents" buttons and the like won't output any thing. IMHO it would make sense if a warning message will be displayed instead informing the user that the implementation in question is still missing.

At the moment the PR is WIP, will let you informed when it can be ready for merging.

## TODO

- [x] Implement warning box for Task Manager
- [x] Implement warning box for Notepad
- [x] Implement warning box for Solitaire and Spider Solitaire games
- [x] Implement warning box for Registry Editor