### PR TITLE
[DLL][KERNEL32][HEAP] Implement HeapSize()

### DIFF
--- a/dll/win32/kernel32/client/heapmem.c
+++ b/dll/win32/kernel32/client/heapmem.c
@@ -363,6 +363,19 @@ HeapSetInformation(HANDLE HeapHandle,
 /*
  * @implemented
  */
+SIZE_T
+WINAPI
+HeapSize(HANDLE hHeap,
+         DWORD dwFlags,
+         LPCVOID lpMem)
+{
+    /* Execute RtlSizeHeap() from RTL API */
+    return RtlSizeHeap(hHeap, dwFlags, lpMem);
+}
+
+/*
+ * @implemented
+ */
 HGLOBAL
 NTAPI
 GlobalAlloc(UINT uFlags,


### PR DESCRIPTION
## Purpose
This is the implementation of the `HeapSize()` function, which returns the heap size value in bytes as per the Microsoft Development Documentation Network. If the function fails, the heap size won't be given but `(SIZE_T) -1` raised by `RtlSizeHeap()`.

If there's something that has to be improved then please notice me!
## Legal Notice
Even if the code is small, I affirm the following statements below (no stolen or leak code have been seen from my part):
> I hereby swear that I have not used nor seen the source code to any version of the Windows operating system nor any Microsoft product that may be related to the proposed project that is under a license incompatible with contribution to ReactOS, including but not limited to the leaked Windows 2000 source code and the Windows Research Kernel.