### PR TITLE
[NTOSKRNL] Enhancements for hard-error code

### DIFF
--- a/ntoskrnl/ex/harderr.c
+++ b/ntoskrnl/ex/harderr.c
@@ -150,13 +150,15 @@ ExpRaiseHardError(IN NTSTATUS ErrorStatus,
                                   NumberOfParameters,
                                   UnicodeStringParameterMask,
                                   Parameters,
-                                  (PreviousMode != KernelMode) ? TRUE: FALSE);
+                                  (PreviousMode != KernelMode) ? TRUE : FALSE);
         }
     }
 
-    /* Enable hard error processing if it is enabled for the process
-     * or if the exception status forces it */
-    if ((Process->DefaultHardErrorProcessing & 1) ||
+    /*
+     * Enable hard error processing if it is enabled for the process
+     * or if the exception status forces it.
+     */
+    if ((Process->DefaultHardErrorProcessing & SEM_FAILCRITICALERRORS) ||
         (ErrorStatus & HARDERROR_OVERRIDE_ERRORMODE))
     {
         /* Check if we have an exception port */
@@ -199,7 +201,7 @@ ExpRaiseHardError(IN NTSTATUS ErrorStatus,
                                   NumberOfParameters,
                                   UnicodeStringParameterMask,
                                   Parameters,
-                                  (PreviousMode != KernelMode) ? TRUE: FALSE);
+                                  (PreviousMode != KernelMode) ? TRUE : FALSE);
 
             /* If we survived, return to caller */
             *Response = ResponseReturnToCaller;

--- a/ntoskrnl/ex/harderr.c
+++ b/ntoskrnl/ex/harderr.c
@@ -14,7 +14,7 @@
 
 #define TAG_ERR ' rrE'
 
-/* GLOBALS ****************************************************************/
+/* GLOBALS ******************************************************************/
 
 BOOLEAN ExReadyForErrors = FALSE;
 PVOID ExpDefaultErrorPort = NULL;
@@ -247,9 +247,12 @@ ExpRaiseHardError(IN NTSTATUS ErrorStatus,
     KeQuerySystemTime(&Message->ErrorTime);
 
     /* Copy the parameters */
-    if (Parameters) RtlMoveMemory(&Message->Parameters,
-                                  Parameters,
-                                  sizeof(ULONG_PTR) * NumberOfParameters);
+    if (Parameters)
+    {
+        RtlMoveMemory(&Message->Parameters,
+                      Parameters,
+                      sizeof(ULONG_PTR) * NumberOfParameters);
+    }
 
     /* Send the LPC Message */
     Status = LpcRequestWaitReplyPort(PortHandle,

--- a/ntoskrnl/ex/harderr.c
+++ b/ntoskrnl/ex/harderr.c
@@ -85,30 +85,15 @@ ExpSystemErrorHandler(IN NTSTATUS ErrorStatus,
 
 /*++
  * @name ExpRaiseHardError
+ * @implemented
  *
- * For now it's a stub
+ * See ExRaiseHardError and NtRaiseHardError, same parameters.
  *
- * @param ErrorStatus
- *        FILLME
- *
- * @param NumberOfParameters
- *        FILLME
- *
- * @param UnicodeStringParameterMask
- *        FILLME
- *
- * @param Parameters
- *        FILLME
- *
- * @param ValidResponseOptions
- *        FILLME
- *
- * @param Response
- *        FILLME
- *
- * @return None
- *
- * @remarks None
+ * This function performs the central work for both ExRaiseHardError
+ * and NtRaiseHardError. ExRaiseHardError is the service for kernel-mode
+ * that copies the parameters to user-mode, and NtRaiseHardError is the
+ * service for both kernel-mode and user-mode that performs parameters
+ * validation and capture if necessary.
  *
  *--*/
 NTSTATUS
@@ -342,7 +327,7 @@ ExSystemExceptionFilter(VOID)
  * @name ExRaiseHardError
  * @implemented
  *
- * See NtRaiseHardError
+ * See NtRaiseHardError and ExpRaiseHardError.
  *
  * @param ErrorStatus
  *        Error Code
@@ -362,9 +347,7 @@ ExSystemExceptionFilter(VOID)
  * @param Response
  *        Pointer to HARDERROR_RESPONSE enumeration
  *
- * @return None
- *
- * @remarks None
+ * @return Status
  *
  *--*/
 NTSTATUS
@@ -489,9 +472,9 @@ ExRaiseHardError(IN NTSTATUS ErrorStatus,
  * @name NtRaiseHardError
  * @implemented
  *
- * This function sends HARDERROR_MSG LPC message to listener
- * (typically CSRSS.EXE). See NtSetDefaultHardErrorPort for more information
- * See: http://undocumented.ntinternals.net/UserMode/Undocumented%20Functions/Error/NtRaiseHardError.html
+ * This function sends HARDERROR_MSG LPC message to a hard-error listener,
+ * typically CSRSS.EXE. See NtSetDefaultHardErrorPort for more information.
+ * See also: http://undocumented.ntinternals.net/UserMode/Undocumented%20Functions/Error/NtRaiseHardError.html
  *
  * @param ErrorStatus
  *        Error Code
@@ -513,8 +496,8 @@ ExRaiseHardError(IN NTSTATUS ErrorStatus,
  *
  * @return Status
  *
- * @remarks NtRaiseHardError is easy way to display message in GUI
- *          without loading Win32 API libraries
+ * @remarks NtRaiseHardError constitutes an easy way to display messages
+ *          in GUI without loading any Win32 API libraries.
  *
  *--*/
 NTSTATUS
@@ -696,11 +679,11 @@ NtRaiseHardError(IN NTSTATUS ErrorStatus,
  * @name NtSetDefaultHardErrorPort
  * @implemented
  *
- * NtSetDefaultHardErrorPort is typically called only once. After call,
- * kernel set BOOLEAN flag named ExReadyForErrors to TRUE, and all other
- * tries to change default port are broken with STATUS_UNSUCCESSFUL error code
- * See: http://www.windowsitlibrary.com/Content/356/08/2.html
- *      http://undocumented.ntinternals.net/UserMode/Undocumented%20Functions/Error/NtSetDefaultHardErrorPort.html
+ * NtSetDefaultHardErrorPort is typically called only once. After the call,
+ * the kernel sets a BOOLEAN flag named ExReadyForErrors to TRUE, and all other
+ * attempts to change the default port fail with STATUS_UNSUCCESSFUL error code.
+ * See: http://undocumented.ntinternals.net/UserMode/Undocumented%20Functions/Error/NtSetDefaultHardErrorPort.html
+ *      https://web.archive.org/web/20070716133753/http://www.windowsitlibrary.com/Content/356/08/2.html
  *
  * @param PortHandle
  *        Handle to named port object

--- a/ntoskrnl/ex/harderr.c
+++ b/ntoskrnl/ex/harderr.c
@@ -707,7 +707,7 @@ NtSetDefaultHardErrorPort(IN HANDLE PortHandle)
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();
     NTSTATUS Status = STATUS_UNSUCCESSFUL;
 
-    /* Check if we have the Privilege */
+    /* Check if we have the privileges */
     if (!SeSinglePrivilegeCheck(SeTcbPrivilege, PreviousMode))
     {
         DPRINT1("NtSetDefaultHardErrorPort: Caller requires "
@@ -718,7 +718,7 @@ NtSetDefaultHardErrorPort(IN HANDLE PortHandle)
     /* Only called once during bootup, make sure we weren't called yet */
     if (!ExReadyForErrors)
     {
-        /* Reference the port */
+        /* Reference the hard-error port */
         Status = ObReferenceObjectByHandle(PortHandle,
                                            0,
                                            LpcPortObjectType,
@@ -727,9 +727,11 @@ NtSetDefaultHardErrorPort(IN HANDLE PortHandle)
                                            NULL);
         if (NT_SUCCESS(Status))
         {
-            /* Save the data */
+            /* Keep also a reference to the process handling the hard errors */
             ExpDefaultErrorPortProcess = PsGetCurrentProcess();
+            ObReferenceObject(ExpDefaultErrorPortProcess);
             ExReadyForErrors = TRUE;
+            Status = STATUS_SUCCESS;
         }
     }
 

--- a/ntoskrnl/ex/shutdown.c
+++ b/ntoskrnl/ex/shutdown.c
@@ -14,6 +14,25 @@
 #define NDEBUG
 #include <debug.h>
 
+/* PRIVATE FUNCTIONS *********************************************************/
+
+VOID
+NTAPI
+ExShutdownSystem(VOID)
+{
+    /* Dereference the hard-error port and process objects */
+    if (ExpDefaultErrorPort)
+    {
+        ObDereferenceObject(ExpDefaultErrorPort);
+        ExpDefaultErrorPort = NULL;
+    }
+    if (ExpDefaultErrorPortProcess)
+    {
+        ObDereferenceObject(ExpDefaultErrorPortProcess);
+        ExpDefaultErrorPortProcess = NULL;
+    }
+}
+
 /* FUNCTIONS *****************************************************************/
 
 /*

--- a/ntoskrnl/include/internal/ex.h
+++ b/ntoskrnl/include/internal/ex.h
@@ -31,6 +31,9 @@ extern KSPIN_LOCK ExpPagedLookasideListLock;
 extern ULONG ExCriticalWorkerThreads;
 extern ULONG ExDelayedWorkerThreads;
 
+extern PVOID ExpDefaultErrorPort;
+extern PEPROCESS ExpDefaultErrorPortProcess;
+
 /*
  * NT/Cm Version Info variables
  */
@@ -60,6 +63,7 @@ extern WINKD_WORKER_STATE ExpDebuggerWork;
 extern PEPROCESS ExpDebuggerProcessAttach;
 extern PEPROCESS ExpDebuggerProcessKill;
 extern ULONG_PTR ExpDebuggerPageIn;
+
 VOID NTAPI ExpDebuggerWorker(IN PVOID Context);
 // #endif /* _WINKD_ */
 
@@ -226,6 +230,10 @@ ExpInitializeExecutive(
     IN ULONG Cpu,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock
 );
+
+VOID
+NTAPI
+ExShutdownSystem(VOID);
 
 BOOLEAN
 NTAPI

--- a/ntoskrnl/po/poshtdwn.c
+++ b/ntoskrnl/po/poshtdwn.c
@@ -278,6 +278,10 @@ PopGracefulShutdown(IN PVOID Context)
     DPRINT("Configuration Manager shutting down\n");
     CmShutdownSystem();
 
+    /* Shut down the Executive */
+    DPRINT("Executive shutting down\n");
+    ExShutdownSystem();
+
     /* Note that modified pages should be written here (MiShutdownSystem) */
 
     /* Flush all user files before we start shutting down IO */

--- a/ntoskrnl/ps/process.c
+++ b/ntoskrnl/ps/process.c
@@ -448,15 +448,14 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
     /* Check if we have a parent */
     if (Parent)
     {
-        /* Inherit PID and Hard Error Processing */
+        /* Inherit PID and hard-error processing */
         Process->InheritedFromUniqueProcessId = Parent->UniqueProcessId;
-        Process->DefaultHardErrorProcessing = Parent->
-                                              DefaultHardErrorProcessing;
+        Process->DefaultHardErrorProcessing = Parent->DefaultHardErrorProcessing;
     }
     else
     {
-        /* Use default hard error processing */
-        Process->DefaultHardErrorProcessing = TRUE;
+        /* Use default hard-error processing */
+        Process->DefaultHardErrorProcessing = SEM_FAILCRITICALERRORS;
     }
 
     /* Check for a section handle */
@@ -586,7 +585,8 @@ PspCreateProcess(OUT PHANDLE ProcessHandle,
                         PROCESS_PRIORITY_NORMAL,
                         Affinity,
                         DirectoryTableBase,
-                        (BOOLEAN)(Process->DefaultHardErrorProcessing & 4));
+                        BooleanFlagOn(Process->DefaultHardErrorProcessing,
+                                      SEM_NOALIGNMENTFAULTEXCEPT));
 
     /* Duplicate Parent Token */
     Status = PspInitializeProcessSecurity(Process, Parent);


### PR DESCRIPTION
- In addition to the hard-error port, reference also the process that handles the hard errors so that it doesn't disappear behind our back. On shutdown both the hard-error port and process are dereferenced.
- Forbid processes without the Tcb prvilege to perform a user-mode hard-error BSOD.
- Update Doxygen descriptions for NtRaiseHardError, ExRaiseHardError, ExpRaiseHardError and NtSetDefaultHardErrorPort.
- Don't hardcode flag values for DefaultHardErrorProcessing.
- Don't emit hard errors for the calling thread if hard errors have been disabled for this thread on user-mode side.
- ExRaiseHardError(): Protect strings copy to user-mode space inside a SEH block.
- Simplify NtRaiseHardError() by merging the terminating blocks. Return the status codes provided by the Ex(p)RaiseHardError() calls.
