### PR TITLE
[NTOSKRNL] Fix IopValidateID using uninitialized var.

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -1793,6 +1793,7 @@ IopValidateID(
 
         case BusQueryHardwareIDs:
         case BusQueryCompatibleIDs:
+            MaxSeparators = 0
             IsMultiSz = TRUE;
             break;
 


### PR DESCRIPTION
Not sure if 0 makes sense here, if it does feel free to merge.
