### PR TITLE
[ZIPFLDR] Typo fix

### DIFF
--- a/dll/shellext/zipfldr/zipfldr.rc
+++ b/dll/shellext/zipfldr/zipfldr.rc
@@ -24,7 +24,7 @@ STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 CAPTION "Select a Destination"
 FONT 8, "MS Shell Dlg", 400, 0, 0x0
 BEGIN
-    LTEXT           "Select the destionation directory",IDC_STATIC,6,12,174,8
+    LTEXT           "Select the destination directory",IDC_STATIC,6,12,174,8
     EDITTEXT        IDC_DIRECTORY,6,24,222,12,ES_AUTOHSCROLL
     PUSHBUTTON      "Browse...",IDC_BROWSE,174,42,54,14
     PUSHBUTTON      "Password",IDC_PASSWORD,174,66,54,14


### PR DESCRIPTION
## Purpose
Just a typo fix. Don't blame me, Mark Jansen was in a hurry while making the resources for ZIPFLDR implementation. :stuck_out_tongue_closed_eyes: 