### PR TITLE
[ZIPFLDR] Implement MUI support

### DIFF
--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -232,7 +232,7 @@ public:
         }
 
     public:
-        enum { IDD = IDD_PROPPAGEDESTIONATION };
+        enum { IDD = IDD_PROPPAGEDESTINATION };
 
         BEGIN_MSG_MAP(CCompleteSettingsPage)
             COMMAND_ID_HANDLER(IDC_BROWSE, OnBrowse)

--- a/dll/shellext/zipfldr/lang/en-US.rc
+++ b/dll/shellext/zipfldr/lang/en-US.rc
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS Zip Shell Extension
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     English (United States) resource translation
+ * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+IDD_PROPPAGEDESTINATION DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Select a Destination"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "Select the destination directory",IDC_STATIC,6,12,174,8
+    EDITTEXT        IDC_DIRECTORY,6,24,222,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "Browse...",IDC_BROWSE,174,42,54,14
+    PUSHBUTTON      "Password",IDC_PASSWORD,174,66,54,14
+    LTEXT           "Extracting...",IDC_STATIC,6,114,42,8
+    CONTROL         "",IDC_PROGRESS,"msctls_progress32",WS_BORDER,6,126,222,6
+END
+
+IDD_PROPPAGECOMPLETE DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Extraction Complete"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "The files have been extracted to the following directory:",IDC_STATIC,6,12,222,18
+    LTEXT           "Target dir",IDC_DESTDIR,6,36,222,8
+    CONTROL         "Show extracted files",IDC_SHOW_EXTRACTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,66,81,10
+    LTEXT           "Press finish to continue.",IDC_STATIC,6,84,174,8
+END
+
+IDD_CONFIRM_FILE_REPLACE DIALOGEX 0, 0, 273, 56
+STYLE DS_MODALFRAME | DS_SHELLFONT | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Confirm File Replace"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "&Yes",IDYES,6,36,62,14
+    PUSHBUTTON      "Cancel",IDCANCEL,204,36,62,14
+    PUSHBUTTON      "Yes &To All",IDYESALL,72,36,62,14
+    PUSHBUTTON      "&No",IDNO,138,36,62,14
+    ICON            "",IDC_EXCLAMATION_ICON,6,6,24,22
+    LTEXT           "",IDC_MESSAGE,36,6,228,24
+END
+
+STRINGTABLE
+BEGIN
+    IDS_COL_NAME "Name"
+    IDS_COL_TYPE "Type"
+    IDS_COL_COMPRSIZE "Compressed size"
+    IDS_COL_PASSWORD "Password"
+    IDS_COL_SIZE "Size"
+    IDS_COL_RATIO "Ratio"
+    IDS_COL_DATE_MOD "Date modified"
+    IDS_YES "Yes"
+    IDS_NO "No"
+
+    IDS_WIZ_TITLE "Extraction Wizard"
+    IDS_WIZ_DEST_TITLE "Select a Destination"
+    IDS_WIZ_DEST_SUBTITLE "The files from the zip archive will be extracted to the location specified."
+    IDS_WIZ_COMPL_TITLE "Extraction Complete"
+    IDS_WIZ_COMPL_SUBTITLE "The files from the zip archive have been extracted."
+    IDS_WIZ_BROWSE_TITLE "Select the place where you want to extract the selected items."
+
+    IDS_OVERWRITEFILE_TEXT "This folder already contains a file called '%1'.\nDo you want to replace it?"
+
+    IDS_MENUITEM "Extract &All..."
+    IDS_HELPTEXT "Extracts folder contents"
+    IDS_FRIENDLYNAME "Compressed (zipped) Folder"
+END

--- a/dll/shellext/zipfldr/lang/it-IT.rc
+++ b/dll/shellext/zipfldr/lang/it-IT.rc
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS Zip Shell Extension
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Italian resource translation
+ * COPYRIGHT:   Copyright 2018 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+LANGUAGE LANG_ITALIAN, SUBLANG_NEUTRAL
+
+IDD_PROPPAGEDESTINATION DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Seleziona una Destinazione"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "Seleziona la cartella di destinazione",IDC_STATIC,6,12,174,8
+    EDITTEXT        IDC_DIRECTORY,6,24,222,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "Sfoglia...",IDC_BROWSE,174,42,54,14
+    PUSHBUTTON      "Password",IDC_PASSWORD,174,66,54,14
+    LTEXT           "Estrazione...",IDC_STATIC,6,114,42,8
+    CONTROL         "",IDC_PROGRESS,"msctls_progress32",WS_BORDER,6,126,222,6
+END
+
+IDD_PROPPAGECOMPLETE DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Estrazione Completa"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "I file sono stati estratti nella seguente cartella:",IDC_STATIC,6,12,222,18
+    LTEXT           "Cartella destinazione",IDC_DESTDIR,6,36,222,8
+    CONTROL         "Mostra i file estratti",IDC_SHOW_EXTRACTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,66,81,10
+    LTEXT           "Premi Fine per continuare.",IDC_STATIC,6,84,174,8
+END
+
+IDD_CONFIRM_FILE_REPLACE DIALOGEX 0, 0, 273, 56
+STYLE DS_MODALFRAME | DS_SHELLFONT | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Conferma Sostituzione File"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "&Sì",IDYES,6,36,62,14
+    PUSHBUTTON      "Annulla",IDCANCEL,204,36,62,14
+    PUSHBUTTON      "Sì &A Tutti",IDYESALL,72,36,62,14
+    PUSHBUTTON      "&No",IDNO,138,36,62,14
+    ICON            "",IDC_EXCLAMATION_ICON,6,6,24,22
+    LTEXT           "",IDC_MESSAGE,36,6,228,24
+END
+
+STRINGTABLE
+BEGIN
+    IDS_COL_NAME "Nome"
+    IDS_COL_TYPE "Tipo"
+    IDS_COL_COMPRSIZE "Dimensione Compressa"
+    IDS_COL_PASSWORD "Password"
+    IDS_COL_SIZE "Dimensione"
+    IDS_COL_RATIO "Rapporto"
+    IDS_COL_DATE_MOD "Data modificata"
+    IDS_YES "Sì"
+    IDS_NO "No"
+
+    IDS_WIZ_TITLE "Estrazione Guidata"
+    IDS_WIZ_DEST_TITLE "Seleziona una Destinazione"
+    IDS_WIZ_DEST_SUBTITLE "I file dall'archivio zip verranno estratti nella destinazione specificata."
+    IDS_WIZ_COMPL_TITLE "Estrazione Completa"
+    IDS_WIZ_COMPL_SUBTITLE "I file dall'archivio zip sono stati estratti."
+    IDS_WIZ_BROWSE_TITLE "Seleziona la destinazione in cui desideri estrarre gli elementi selezionati."
+
+    IDS_OVERWRITEFILE_TEXT "Questa cartella già contiene un file chiamato '%1'.\nVuoi sostituirla?"
+
+    IDS_MENUITEM "Estrai &Tutto..."
+    IDS_HELPTEXT "Estrae i contenuti della cartella"
+    IDS_FRIENDLYNAME "Cartella Compressa (zippata)"
+END

--- a/dll/shellext/zipfldr/lang/ro-RO.rc
+++ b/dll/shellext/zipfldr/lang/ro-RO.rc
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS Zip Shell Extension
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Romanian resource translation
+ * COPYRIGHT:   Copyright 2018 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+LANGUAGE LANG_ROMANIAN, SUBLANG_NEUTRAL
+
+IDD_PROPPAGEDESTINATION DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Selectați o Destinație"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "Selectați folderul de destinație",IDC_STATIC,6,12,174,8
+    EDITTEXT        IDC_DIRECTORY,6,24,222,12,ES_AUTOHSCROLL
+    PUSHBUTTON      "Răsfoiți...",IDC_BROWSE,174,42,54,14
+    PUSHBUTTON      "Parolă",IDC_PASSWORD,174,66,54,14
+    LTEXT           "Extragere...",IDC_STATIC,6,114,42,8
+    CONTROL         "",IDC_PROGRESS,"msctls_progress32",WS_BORDER,6,126,222,6
+END
+
+IDD_PROPPAGECOMPLETE DIALOGEX 0, 0, 235, 156
+STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
+CAPTION "Extragere Completă"
+FONT 8, "MS Shell Dlg", 400, 0, 0x0
+BEGIN
+    LTEXT           "Fișierele au fost extrase în folderul respectiv:",IDC_STATIC,6,12,222,18
+    LTEXT           "Ținta folder",IDC_DESTDIR,6,36,222,8
+    CONTROL         "Afișează fișierele extrase",IDC_SHOW_EXTRACTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,66,81,10
+    LTEXT           "Apăsați Termină pentru a continua.",IDC_STATIC,6,84,174,8
+END
+
+IDD_CONFIRM_FILE_REPLACE DIALOGEX 0, 0, 273, 56
+STYLE DS_MODALFRAME | DS_SHELLFONT | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "Confirmați Înlocuirea Fișier"
+FONT 8, "MS Shell Dlg", 400, 0, 0x1
+BEGIN
+    DEFPUSHBUTTON   "&Da",IDYES,6,36,62,14
+    PUSHBUTTON      "Anulează",IDCANCEL,204,36,62,14
+    PUSHBUTTON      "Da &Toți",IDYESALL,72,36,62,14
+    PUSHBUTTON      "&Nu",IDNO,138,36,62,14
+    ICON            "",IDC_EXCLAMATION_ICON,6,6,24,22
+    LTEXT           "",IDC_MESSAGE,36,6,228,24
+END
+
+STRINGTABLE
+BEGIN
+    IDS_COL_NAME "Nume"
+    IDS_COL_TYPE "Tip"
+    IDS_COL_COMPRSIZE "Dimensiune comprimată"
+    IDS_COL_PASSWORD "Parolă"
+    IDS_COL_SIZE "Dimensiune"
+    IDS_COL_RATIO "Raport"
+    IDS_COL_DATE_MOD "Data modificată"
+    IDS_YES "Da"
+    IDS_NO "Nu"
+
+    IDS_WIZ_TITLE "Asistent de extracție"
+    IDS_WIZ_DEST_TITLE "Selectați o Destinație"
+    IDS_WIZ_DEST_SUBTITLE "Fișierele din arhiva zip vor fi extrase în destinația specificată."
+    IDS_WIZ_COMPL_TITLE "Extragere Completă"
+    IDS_WIZ_COMPL_SUBTITLE "Fișierele din arhiva zip au fost extrase."
+    IDS_WIZ_BROWSE_TITLE "Selectați destinația unde doriți să extrageți elementele selectate."
+
+    IDS_OVERWRITEFILE_TEXT "Acest folder deja conține un fișier numit '%1'.\nDoriți să o înlocuiți?"
+
+    IDS_MENUITEM "Extrage &Tot..."
+    IDS_HELPTEXT "Extrage conținutul folderului"
+    IDS_FRIENDLYNAME "Folder comprimat (zip)"
+END

--- a/dll/shellext/zipfldr/resource.h
+++ b/dll/shellext/zipfldr/resource.h
@@ -6,7 +6,7 @@
 
 /* Dialogs */
 
-#define IDD_PROPPAGEDESTIONATION    1000
+#define IDD_PROPPAGEDESTINATION     1000
 #define IDC_DIRECTORY               1001
 #define IDC_BROWSE                  1002
 #define IDC_PASSWORD                1003

--- a/dll/shellext/zipfldr/zipfldr.rc
+++ b/dll/shellext/zipfldr/zipfldr.rc
@@ -21,3 +21,6 @@ IDR_ZIPFLDR REGISTRY "res/zipfldr.rgs"
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
 #endif
+#ifdef LANGUAGE_IT_IT
+    #include "lang/it-IT.rc"
+#endif

--- a/dll/shellext/zipfldr/zipfldr.rc
+++ b/dll/shellext/zipfldr/zipfldr.rc
@@ -3,8 +3,6 @@
 
 #include "resource.h"
 
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
-
 1 ICON "res/zipfldr.ico"
 
 #define REACTOS_VERSION_DLL
@@ -17,72 +15,9 @@ LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 IDR_ZIPFLDR REGISTRY "res/zipfldr.rgs"
 
+/* UTF-8 */
+#pragma code_page(65001)
 
-
-IDD_PROPPAGEDESTIONATION DIALOGEX 0, 0, 235, 156
-STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
-CAPTION "Select a Destination"
-FONT 8, "MS Shell Dlg", 400, 0, 0x0
-BEGIN
-    LTEXT           "Select the destination directory",IDC_STATIC,6,12,174,8
-    EDITTEXT        IDC_DIRECTORY,6,24,222,12,ES_AUTOHSCROLL
-    PUSHBUTTON      "Browse...",IDC_BROWSE,174,42,54,14
-    PUSHBUTTON      "Password",IDC_PASSWORD,174,66,54,14
-    LTEXT           "Extracting...",IDC_STATIC,6,114,42,8
-    CONTROL         "",IDC_PROGRESS,"msctls_progress32",WS_BORDER,6,126,222,6
-END
-
-
-IDD_PROPPAGECOMPLETE DIALOGEX 0, 0, 235, 156
-STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
-CAPTION "Extraction Complete"
-FONT 8, "MS Shell Dlg", 400, 0, 0x0
-BEGIN
-    LTEXT           "The files have been extracted to the following directory:",IDC_STATIC,6,12,222,18
-    LTEXT           "Target dir",IDC_DESTDIR,6,36,222,8
-    CONTROL         "Show extracted files",IDC_SHOW_EXTRACTED,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,6,66,81,10
-    LTEXT           "Press finish to continue.",IDC_STATIC,6,84,174,8
-END
-
-
-IDD_CONFIRM_FILE_REPLACE DIALOGEX 0, 0, 273, 56
-STYLE DS_MODALFRAME | DS_SHELLFONT | WS_POPUP | WS_CAPTION | WS_SYSMENU
-CAPTION "Confirm File Replace"
-FONT 8, "MS Shell Dlg", 400, 0, 0x1
-BEGIN
-    DEFPUSHBUTTON   "&Yes",IDYES,6,36,62,14
-    PUSHBUTTON      "Cancel",IDCANCEL,204,36,62,14
-    PUSHBUTTON      "Yes &To All",IDYESALL,72,36,62,14
-    PUSHBUTTON      "&No",IDNO,138,36,62,14
-    ICON            "",IDC_EXCLAMATION_ICON,6,6,24,22
-    LTEXT           "",IDC_MESSAGE,36,6,228,24
-END
-
-
-
-STRINGTABLE
-BEGIN
-    IDS_COL_NAME "Name"
-    IDS_COL_TYPE "Type"
-    IDS_COL_COMPRSIZE "Compressed size"
-    IDS_COL_PASSWORD "Password"
-    IDS_COL_SIZE "Size"
-    IDS_COL_RATIO "Ratio"
-    IDS_COL_DATE_MOD "Date modified"
-    IDS_YES "Yes"
-    IDS_NO "No"
-
-    IDS_WIZ_TITLE "Extraction Wizard"
-    IDS_WIZ_DEST_TITLE "Select a Destination"
-    IDS_WIZ_DEST_SUBTITLE "The files from the zip archive will be extracted to the location specified."
-    IDS_WIZ_COMPL_TITLE "Extraction Complete"
-    IDS_WIZ_COMPL_SUBTITLE "The files from the zip archive have been extracted."
-    IDS_WIZ_BROWSE_TITLE "Select the place where you want to extract the selected items."
-
-    IDS_OVERWRITEFILE_TEXT "This folder already contains a file called '%1'.\nDo you want to replace it?"
-
-    IDS_MENUITEM "Extract &All..."
-    IDS_HELPTEXT "Extracts folder contents"
-    IDS_FRIENDLYNAME "Compressed (zipped) Folder"
-
-END
+#ifdef LANGUAGE_EN_US
+    #include "lang/en-US.rc"
+#endif

--- a/dll/shellext/zipfldr/zipfldr.rc
+++ b/dll/shellext/zipfldr/zipfldr.rc
@@ -24,3 +24,6 @@ IDR_ZIPFLDR REGISTRY "res/zipfldr.rgs"
 #ifdef LANGUAGE_IT_IT
     #include "lang/it-IT.rc"
 #endif
+#ifdef LANGUAGE_RO_RO
+    #include "lang/ro-RO.rc"
+#endif


### PR DESCRIPTION
## Purpose
The zip shell extension currently only supports English by default without any support for multilingual interface. Here I am implementing the support for other languages other than English just like in any software written here for ReactOS.

## Changes

- Initial MUI implementation for Zip Shell Extension
- Romanian & Italian translations
- Typo fix in `IDD_PROPPAGEDESTIONATION` (should be IDD_PROPPAGEDESTINATION)