### PR TITLE
Set RosProcessCompatVersion from version shims

### DIFF
--- a/dll/appcompat/apphelp/apphelp.h
+++ b/dll/appcompat/apphelp/apphelp.h
@@ -90,6 +90,8 @@ BOOL WINAPI SdbIsNullGUID(CONST GUID *Guid);
 HRESULT WINAPI SdbGetAppPatchDir(HSDB db, LPWSTR path, DWORD size);
 LPWSTR WINAPI SdbGetStringTagPtr(PDB pdb, TAGID tagid);
 TAGID WINAPI SdbFindFirstNamedTag(PDB pdb, TAGID root, TAGID find, TAGID nametag, LPCWSTR find_name);
+DWORD WINAPI SdbQueryDataExTagID(PDB pdb, TAGID tiExe, LPCWSTR lpszDataName, LPDWORD lpdwDataType, LPVOID lpBuffer, LPDWORD lpcbBufferSize, TAGID *ptiData);
+
 
 /* sdbread.c */
 BOOL WINAPI SdbpReadData(PDB pdb, PVOID dest, DWORD offset, DWORD num);
@@ -101,6 +103,9 @@ DWORD WINAPI SdbReadDWORDTag(PDB pdb, TAGID tagid, DWORD ret);
 QWORD WINAPI SdbReadQWORDTag(PDB pdb, TAGID tagid, QWORD ret);
 TAGID WINAPI SdbGetFirstChild(PDB pdb, TAGID parent);
 TAGID WINAPI SdbGetNextChild(PDB pdb, TAGID parent, TAGID prev_child);
+DWORD WINAPI SdbGetTagDataSize(PDB pdb, TAGID tagid);
+LPWSTR WINAPI SdbpGetString(PDB pdb, TAGID tagid, PDWORD size);
+
 
 /* sdbfileattr.c*/
 BOOL WINAPI SdbGetFileAttributes(LPCWSTR path, PATTRINFO *attr_info_ret, LPDWORD attr_count);
@@ -116,6 +121,7 @@ BOOL WINAPI SdbGetMatchingExe(HSDB hsdb, LPCWSTR path, LPCWSTR module_name, LPCW
 BOOL WINAPI SdbTagIDToTagRef(HSDB hsdb, PDB pdb, TAGID tiWhich, TAGREF* ptrWhich);
 BOOL WINAPI SdbTagRefToTagID(HSDB hsdb, TAGREF trWhich, PDB* ppdb, TAGID* ptiWhich);
 BOOL WINAPI SdbUnpackAppCompatData(HSDB hsdb, LPCWSTR pszImageName, PVOID pData, PSDBQUERYRESULT pQueryResult);
+DWORD WINAPI SdbQueryData(HSDB hsdb, TAGREF trWhich, LPCWSTR lpszDataName, LPDWORD lpdwDataType, LPVOID lpBuffer, LPDWORD lpcbBufferSize);
 
 #define ATTRIBUTE_AVAILABLE 0x1
 #define ATTRIBUTE_FAILED 0x2

--- a/dll/appcompat/apphelp/apphelp.spec
+++ b/dll/appcompat/apphelp/apphelp.spec
@@ -108,9 +108,9 @@
 @ stub SdbQueryApphelpInformation
 @ stub SdbQueryBlockUpgrade
 @ stub SdbQueryContext
-@ stub SdbQueryData
-@ stub SdbQueryDataEx
-@ stub SdbQueryDataExTagID
+@ stdcall SdbQueryData(ptr long wstr ptr ptr ptr)
+@ stdcall SdbQueryDataEx(ptr long wstr ptr ptr ptr ptr)
+@ stdcall SdbQueryDataExTagID(ptr long wstr ptr ptr ptr ptr)
 @ stub SdbQueryFlagInfo
 @ stub SdbQueryName
 @ stub SdbQueryReinstallUpgrade

--- a/dll/appcompat/apphelp/hsdb.c
+++ b/dll/appcompat/apphelp/hsdb.c
@@ -686,6 +686,7 @@ BOOL WINAPI SdbPackAppCompatData(HSDB hsdb, PSDBQUERYRESULT pQueryResult, PVOID*
     ShimData* pData;
     HRESULT hr;
     DWORD n;
+    BOOL bCloseDatabase = FALSE;
 
     if (!pQueryResult || !ppData || !pdwSize)
     {
@@ -719,12 +720,33 @@ BOOL WINAPI SdbPackAppCompatData(HSDB hsdb, PSDBQUERYRESULT pQueryResult, PVOID*
               pData->Query.dwFlags, pData->dwMagic, pData->Query.atrExes[0], pData->Query.atrLayers[0]);
 
     /* Database List */
-    /* 0x0 {GUID} NAME */
+    /* 0x0 {GUID} NAME: Use to open HSDB */
+    if (hsdb == NULL)
+    {
+        hsdb = SdbInitDatabase(HID_DOS_PATHS | SDB_DATABASE_MAIN_SHIM, NULL);
+        bCloseDatabase = TRUE;
+    }
 
     for (n = 0; n < pQueryResult->dwLayerCount; ++n)
     {
+        DWORD dwValue = 0, dwType;
+        DWORD dwValueSize = sizeof(dwValue);
         SHIM_INFO("Layer 0x%x\n", pQueryResult->atrLayers[n]);
+
+        if (SdbQueryData(hsdb, pQueryResult->atrLayers[n], L"SHIMVERSIONNT", &dwType, &dwValue, &dwValueSize) == ERROR_SUCCESS &&
+            dwType == REG_DWORD && dwValueSize == sizeof(dwValue))
+        {
+            dwValue = (dwValue % 100) | ((dwValue / 100) << 8);
+            if (dwValue > pData->dwRosProcessCompatVersion)
+                pData->dwRosProcessCompatVersion = dwValue;
+        }
     }
+
+    if (pData->dwRosProcessCompatVersion)
+        SHIM_INFO("Setting ProcessCompatVersion 0x%x\n", pData->dwRosProcessCompatVersion);
+
+    if (bCloseDatabase)
+        SdbReleaseDatabase(hsdb);
 
     *ppData = pData;
     *pdwSize = pData->dwSize;

--- a/dll/appcompat/apphelp/hsdb.c
+++ b/dll/appcompat/apphelp/hsdb.c
@@ -753,7 +753,57 @@ DWORD WINAPI SdbGetAppCompatDataSize(ShimData* pData)
     if (!pData || pData->dwMagic != SHIMDATA_MAGIC)
         return 0;
 
-
     return pData->dwSize;
 }
 
+
+/**
+* Retrieve a Data entry
+*
+* @param [in]  hsdb                    The multi-database.
+* @param [in]  trExe                   The tagRef to start at
+* @param [in,opt]  lpszDataName        The name of the Data entry to find, or NULL to return all.
+* @param [out,opt]  lpdwDataType       Any of REG_SZ, REG_QWORD, REG_DWORD, ...
+* @param [out]  lpBuffer               The output buffer
+* @param [in,out,opt]  lpcbBufferSize  The size of lpBuffer in bytes
+* @param [out,opt]  ptrData            The tagRef of the data
+*
+* @return  ERROR_SUCCESS
+*/
+DWORD WINAPI SdbQueryDataEx(HSDB hsdb, TAGREF trWhich, LPCWSTR lpszDataName, LPDWORD lpdwDataType, LPVOID lpBuffer, LPDWORD lpcbBufferSize, TAGREF *ptrData)
+{
+    PDB pdb;
+    TAGID tiWhich, tiData;
+    DWORD dwResult;
+
+    if (!SdbTagRefToTagID(hsdb, trWhich, &pdb, &tiWhich))
+    {
+        SHIM_WARN("Unable to translate trWhich=0x%x\n", trWhich);
+        return ERROR_NOT_FOUND;
+    }
+
+    dwResult = SdbQueryDataExTagID(pdb, tiWhich, lpszDataName, lpdwDataType, lpBuffer, lpcbBufferSize, &tiData);
+
+    if (dwResult == ERROR_SUCCESS && ptrData)
+        SdbTagIDToTagRef(hsdb, pdb, tiData, ptrData);
+
+    return dwResult;
+}
+
+
+/**
+* Retrieve a Data entry
+*
+* @param [in]  hsdb                    The multi-database.
+* @param [in]  trExe                   The tagRef to start at
+* @param [in,opt]  lpszDataName        The name of the Data entry to find, or NULL to return all.
+* @param [out,opt]  lpdwDataType       Any of REG_SZ, REG_QWORD, REG_DWORD, ...
+* @param [out]  lpBuffer               The output buffer
+* @param [in,out,opt]  lpcbBufferSize  The size of lpBuffer in bytes
+*
+* @return  ERROR_SUCCESS
+*/
+DWORD WINAPI SdbQueryData(HSDB hsdb, TAGREF trWhich, LPCWSTR lpszDataName, LPDWORD lpdwDataType, LPVOID lpBuffer, LPDWORD lpcbBufferSize)
+{
+    return SdbQueryDataEx(hsdb, trWhich, lpszDataName, lpdwDataType, lpBuffer, lpcbBufferSize, NULL);
+}

--- a/dll/appcompat/apphelp/sdbread.c
+++ b/dll/appcompat/apphelp/sdbread.c
@@ -4,14 +4,11 @@
  * PURPOSE:     Shim database query functions
  * COPYRIGHT:   Copyright 2011 André Hentschel
  *              Copyright 2013 Mislav Blaževic
- *              Copyright 2015-2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2015-2018 Mark Jansen (mark.jansen@reactos.org)
  */
 
 #include "windef.h"
 #include "apphelp.h"
-
-
-DWORD WINAPI SdbGetTagDataSize(PDB pdb, TAGID tagid);
 
 
 BOOL WINAPI SdbpReadData(PDB pdb, PVOID dest, DWORD offset, DWORD num)
@@ -47,7 +44,7 @@ static DWORD WINAPI SdbpGetTagSize(PDB pdb, TAGID tagid)
     return size;
 }
 
-static LPWSTR WINAPI SdbpGetString(PDB pdb, TAGID tagid, PDWORD size)
+LPWSTR WINAPI SdbpGetString(PDB pdb, TAGID tagid, PDWORD size)
 {
     TAG tag;
     TAGID offset;
@@ -79,7 +76,7 @@ static LPWSTR WINAPI SdbpGetString(PDB pdb, TAGID tagid, PDWORD size)
     }
 
     /* Optionally read string size */
-    if (size && !SdbpReadData(pdb, size, tagid + sizeof(TAG), sizeof(*size)))
+    if (size && !SdbpReadData(pdb, size, offset - sizeof(TAGID), sizeof(*size)))
         return FALSE;
 
     return (LPWSTR)(&pdb->data[offset]);

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -283,38 +283,47 @@
         </LAYER>
         <LAYER NAME="VISTARTM">
             <SHIM_REF NAME="VistaRTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="VISTASP1">
             <SHIM_REF NAME="VistaSP1VersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="VISTASP2">
             <SHIM_REF NAME="VistaSP2VersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08">
             <SHIM_REF NAME="VistaRTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08SP1">
             <SHIM_REF NAME="VistaSP1VersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WINSRV08SP2">
             <SHIM_REF NAME="VistaSP2VersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="600" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN7RTM">
             <SHIM_REF NAME="Win7RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="601" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN8RTM">
             <SHIM_REF NAME="Win8RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="602" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN81RTM">
             <SHIM_REF NAME="Win81RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="603" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
 

--- a/modules/rostests/apitests/apphelp/testdb.xml
+++ b/modules/rostests/apitests/apphelp/testdb.xml
@@ -6,6 +6,14 @@
         <LIBRARY>
         </LIBRARY>
 
+        <LAYER NAME="DATA_LAYER">
+            <DATA NAME="TESTDATA1" DATA_DWORD="3333" />
+            <DATA NAME="TESTDATA2">
+                <DATA_QWORD>0x123456789</DATA_QWORD>
+            </DATA>
+            <DATA NAME="TeSTDaTa3" DATA_STRING="Test string" />
+            <!--<DATA NAME="TESTDATA4" DATA_BITS="90 90 90 90" />-->
+        </LAYER>
         <!-- Verify that we are able to match this -->
         <EXE>
             <NAME>test_match0.exe</NAME>

--- a/sdk/tools/xml2sdb/xml2sdb.h
+++ b/sdk/tools/xml2sdb/xml2sdb.h
@@ -91,6 +91,22 @@ struct Flag
 };
 
 
+struct Data
+{
+    Data() : Tagid(0), DataType(0), DWordData(0), QWordData(0) { ; }
+
+    bool fromXml(XMLHandle dbNode);
+    bool toSdb(PDB pdb, Database& db);
+
+    std::string Name;
+    TAGID Tagid;
+    DWORD DataType;
+
+    std::string StringData;
+    DWORD DWordData;
+    QWORD QWordData;
+};
+
 struct Layer
 {
     Layer() : Tagid(0) { ; }
@@ -102,6 +118,7 @@ struct Layer
     TAGID Tagid;
     std::list<ShimRef> ShimRefs;
     std::list<FlagRef> FlagRefs;
+    std::list<Data> Datas;
 };
 
 struct MatchingFile


### PR DESCRIPTION
Allows shims to override the RosProcessCompatVersion.
The SHIMVERSIONNT is in base-10 to stay windows-compatible.

