### PR TITLE
[SHELL32] Fix improper flag condition set

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1805,7 +1805,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     }
 
     /* process the IDList */
-    if (sei_tmp.fMask & SEE_MASK_IDLIST)
+    if ((sei_tmp.fMask & (SEE_MASK_IDLIST | SEE_MASK_INVOKEIDLIST)) == SEE_MASK_IDLIST)
     {
         CComPtr<IShellExecuteHookW> pSEH;
 


### PR DESCRIPTION
## Purpose
According to mudhead, `(sei_tmp.fMask & SEE_MASK_IDLIST)` would return either `SEE_MASK_IDLIST` or `SEE_MASK_INVOKEIDLIST` resulting in an improper flag set. The original patch is authored by him.

JIRA Issue: [CORE-14535](https://jira.reactos.org/browse/CORE-14535)