### PR TITLE
[MSPAINT] Fix crash on zoom out

### DIFF
--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -1,0 +1,14 @@
+/*
+ * PROJECT:     PAINT for ReactOS
+ * LICENSE:     LGPL
+ * FILE:        base/applications/mspaint/common.h
+ * PURPOSE:     Commonly used functions
+ * PROGRAMMERS: Benedikt Freisen
+ *              Stanislav Motylkov
+ */
+
+#pragma once
+
+/* FUNCTIONS ********************************************************/
+
+extern BOOL zoomTo(int, int, int);

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -16,9 +16,6 @@
 
 /* FUNCTIONS ********************************************************/
 
-extern void
-zoomTo(int newZoom, int mouseX, int mouseY);
-
 void
 updateCanvasAndScrollbars()
 {

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -21,6 +21,7 @@
 #include <shellapi.h>
 #include <htmlhelp.h>
 
+#include "common.h"
 #include "definitions.h"
 #include "drawing.h"
 #include "dib.h"

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -4,6 +4,7 @@
  * FILE:        base/applications/mspaint/toolsettings.cpp
  * PURPOSE:     Window procedure of the tool settings window
  * PROGRAMMERS: Benedikt Freisen
+ *              Stanislav Motylkov
  */
 
 /* INCLUDES *********************************************************/
@@ -11,8 +12,6 @@
 #include "precomp.h"
 
 /* FUNCTIONS ********************************************************/
-
-extern void zoomTo(int, int, int);
 
 LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, WINBOOL& bHandled)
 {
@@ -25,7 +24,10 @@ LRESULT CToolSettingsWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, W
 
 LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    zoomTo(125 << trackbarZoom.SendMessage(TBM_GETPOS, 0, 0), 0, 0);
+    if (!zoomTo(125 << trackbarZoom.SendMessage(TBM_GETPOS, 0, 0), 0, 0))
+    {
+        OnToolsModelZoomChanged(nMsg, wParam, lParam, bHandled);
+    }
     return 0;
 }
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -6,6 +6,7 @@
  *              hPalWin, hToolSettings and hSelection
  * PROGRAMMERS: Benedikt Freisen
  *              Katayama Hirofumi MZ
+ *              Stanislav Motylkov
  */
 
 /* INCLUDES *********************************************************/
@@ -16,7 +17,7 @@
 
 /* FUNCTIONS ********************************************************/
 
-void
+BOOL
 zoomTo(int newZoom, int mouseX, int mouseY)
 {
     RECT clientRectScrollbox;
@@ -24,8 +25,14 @@ zoomTo(int newZoom, int mouseX, int mouseY)
     int x, y, w, h;
     scrollboxWindow.GetClientRect(&clientRectScrollbox);
     imageArea.GetClientRect(&clientRectImageArea);
-    w = clientRectImageArea.right * clientRectScrollbox.right / (clientRectImageArea.right * newZoom / toolsModel.GetZoom());
-    h = clientRectImageArea.bottom * clientRectScrollbox.bottom / (clientRectImageArea.bottom * newZoom / toolsModel.GetZoom());
+    w = clientRectImageArea.right * newZoom / toolsModel.GetZoom();
+    h = clientRectImageArea.bottom * newZoom / toolsModel.GetZoom();
+    if (!w || !h)
+    {
+        return FALSE;
+    }
+    w = clientRectImageArea.right * clientRectScrollbox.right / w;
+    h = clientRectImageArea.bottom * clientRectScrollbox.bottom / h;
     x = max(0, min(clientRectImageArea.right - w, mouseX - w / 2)) * newZoom / toolsModel.GetZoom();
     y = max(0, min(clientRectImageArea.bottom - h, mouseY - h / 2)) * newZoom / toolsModel.GetZoom();
 
@@ -38,6 +45,7 @@ zoomTo(int newZoom, int mouseX, int mouseY)
 
     scrollboxWindow.SendMessage(WM_HSCROLL, MAKEWPARAM(SB_THUMBPOSITION, x), 0);
     scrollboxWindow.SendMessage(WM_VSCROLL, MAKEWPARAM(SB_THUMBPOSITION, y), 0);
+    return TRUE;
 }
 
 void CMainWindow::alignChildrenToMainWindow()


### PR DESCRIPTION
## Purpose

Fix Paint crash on zoom out.

JIRA issue: [CORE-14539](https://jira.reactos.org/browse/CORE-14539)

## Proposed changes

- Check the denominator for zero for both zoomed width and height.
- Do not allow to move zoom slider above possible position.
- Move commonly used `zoomTo` function into new header file.