### PR TITLE
[WIN32SS] Fix 3 Clang-Cl warnings in 2 defwnd.c. CORE-14306

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -486,8 +486,7 @@ DefWndGetIcon(PWND pWnd, WPARAM wParam, LPARAM lParam)
         case ICON_SMALL2:
             hIconRet = UserGetProp(pWnd, gpsi->atomIconSmProp, TRUE);
             break;
-        default:
-            break;
+        DEFAULT_UNREACHABLE;
     }
     return (LRESULT)hIconRet;
 }
@@ -927,14 +926,23 @@ IntDefWindowProc(
       }
 
       case WM_MOUSEACTIVATE:
+         FIXME("CORE-14306 PR492 Debug: Wnd=0x%p\n", Wnd);
          if (Wnd->style & WS_CHILD)
          {
              LONG Ret;
              HWND hwndParent;
              PWND pwndParent = IntGetParent(Wnd);
              hwndParent = pwndParent ? UserHMGetHandle(pwndParent) : NULL;
-             if (hwndParent) Ret = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
-             if (Ret) return (Ret);
+             FIXME("CORE-14306 PR492 Debug: pwndParent=0x%p, hwndParent=0x%p\n", pwndParent, hwndParent);
+             ASSERT(hwndParent != NULL);
+             if (hwndParent)
+             {
+                 Ret = co_IntSendMessage(hwndParent, WM_MOUSEACTIVATE, wParam, lParam);
+                 if (Ret)
+                 {
+                     return Ret;
+                 }
+             }
          }
          return ( (HIWORD(lParam) == WM_LBUTTONDOWN && LOWORD(lParam) == HTCAPTION) ? MA_NOACTIVATE : MA_ACTIVATE );
 

--- a/win32ss/user/user32/windows/defwnd.c
+++ b/win32ss/user/user32/windows/defwnd.c
@@ -305,8 +305,7 @@ DefWndGetIcon(PWND pWnd, WPARAM wParam, LPARAM lParam)
         case ICON_SMALL2:
             hIconRet = UserGetProp(UserHMGetHandle(pWnd), gpsi->atomIconSmProp, TRUE);
             break;
-        default:
-            break;
+        DEFAULT_UNREACHABLE;
     }
     return (LRESULT)hIconRet;
 }


### PR DESCRIPTION
## Purpose

Assumed fixes...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- 2 "warning: variable 'hIconRet' is used uninitialized whenever switch default is taken [-Wsometimes-uninitialized]"
- 1 "warning: variable 'Ret' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]"
