### PR TITLE
[TRANSLATION][WINLOGON] Romanian translation update

### DIFF
--- a/base/system/winlogon/lang/ro-RO.rc
+++ b/base/system/winlogon/lang/ro-RO.rc
@@ -31,14 +31,14 @@ END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
 STYLE DS_SHELLFONT | DS_MODALFRAME | DS_CENTER | WS_VISIBLE | WS_CAPTION | WS_POPUP
-CAPTION "System Shutdown"
+CAPTION "Sistem de oprire"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "Sistemul de oprire a fost inițializat. Salvați toate lucrările și închideți sesiunea. Toate lucrările nesalvate vor fi pierdute atunci când sistemul se va opri.", -1, 38, 7, 135, 40
+    LTEXT "Sistemul se va opri în:", -1, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Mesaj:", -1, 38, 65, 135, 8
     LTEXT "", IDC_SYSSHUTDOWNMESSAGE, 38, 75, 135, 58
 END
 


### PR DESCRIPTION
## Purpose
The part of the Shutdown System dialog wasn't translated at all. Here I am providing this PR which covers the untranslated strings. 