### PR TITLE
CORE-14306. [APPSHIM_APITEST] Fix a Clang-Cl warning about n

### DIFF
--- a/modules/rostests/apitests/appshim/dispmode.c
+++ b/modules/rostests/apitests/appshim/dispmode.c
@@ -481,7 +481,7 @@ START_TEST(dispmode)
     else
     {
         n = (size_t)atoi(argv[2]);
-        if (n >= 0 && n < _countof(tests))
+        if (n < _countof(tests))
         {
             run_test(n, FALSE);
         }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

Cc @learn-more

## Proposed changes

- "warning: comparison of unsigned expression >= 0 is always true [-Wtautological-unsigned-zero-compare]"

## TODO

- [X] Do you want an input error-detecting fix with `sscanf()`, instead of `atoi()`? // Answer is "no".
