### PR TITLE
CORE-14306. [KMTEST] Fix 3 Clang-Cl warnings about Status and Callbacks

### DIFF
--- a/modules/rostests/kmtests/kmtest_drv/kmtest_fsminifilter.c
+++ b/modules/rostests/kmtests/kmtest_drv/kmtest_fsminifilter.c
@@ -439,7 +439,7 @@ KmtFilterRegisterCallbacks(
     _In_ CONST FLT_OPERATION_REGISTRATION *OperationRegistration)
 {
     ULONG Count = 0;
-    INT i;
+    ULONG i;
 
     if (Callbacks)
     {
@@ -463,7 +463,7 @@ KmtFilterRegisterCallbacks(
         return STATUS_INSUFFICIENT_RESOURCES;
     }
 
-    /* Copy the array, but using the our own pre/post callbacks */
+    /* Copy the array, but using our own pre/post callbacks */
     for (i = 0; i < Count; i++)
     {
         Callbacks[i].MajorFunction = OperationRegistration[i].MajorFunction;
@@ -519,7 +519,7 @@ FilterPreOperation(
 {
     FLT_PREOP_CALLBACK_STATUS Status;
     UCHAR MajorFunction;
-    INT i;
+    ULONG i;
 
     Status = FLT_PREOP_SUCCESS_NO_CALLBACK;
     MajorFunction = Data->Iopb->MajorFunction;
@@ -548,7 +548,7 @@ FilterPostOperation(
 {
     FLT_POSTOP_CALLBACK_STATUS Status;
     UCHAR MajorFunction;
-    INT i;
+    ULONG i;
 
     Status = FLT_POSTOP_FINISHED_PROCESSING;
     MajorFunction = Data->Iopb->MajorFunction;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

@gedmurphy

## Proposed changes

- 1 "warning: variable 'Status' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]"
Double-check this fix, as I am unsure which default value should be used.
- 2 "warning: comparison of unsigned expression < 0 is always false [-Wtautological-unsigned-zero-compare]"
- Also update license header.
Double-check this fix, as I assumed a year for Thomas, as I am unsure why he is listed here.

plus

- Use a consistent type for "i" and fix a comment
Mark, never look at this additional commit...
