### PR TITLE
CORE-14306. [CMAKE] USE_CLANG_CL: Add "-Wno-parentheses-equality"

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -97,8 +97,8 @@ endif()
 add_compile_flags("/w14115")
 
 if(USE_CLANG_CL)
-    add_compile_flags_language("-nostdinc -Wno-multichar -Wno-char-subscripts -Wno-microsoft-enum-forward-reference -Wno-pragma-pack -Wno-microsoft-anon-tag -Wno-unknown-pragmas" "C")
-    add_compile_flags_language("-nostdinc -Wno-multichar -Wno-char-subscripts -Wno-microsoft-enum-forward-reference -Wno-pragma-pack -Wno-microsoft-anon-tag -Wno-unknown-pragmas" "CXX")
+    add_compile_flags_language("-nostdinc -Wno-multichar -Wno-char-subscripts -Wno-microsoft-enum-forward-reference -Wno-pragma-pack -Wno-microsoft-anon-tag -Wno-parentheses-equality -Wno-unknown-pragmas" "C")
+    add_compile_flags_language("-nostdinc -Wno-multichar -Wno-char-subscripts -Wno-microsoft-enum-forward-reference -Wno-pragma-pack -Wno-microsoft-anon-tag -Wno-parentheses-equality -Wno-unknown-pragmas" "CXX")
 endif()
 
 # Debugging


### PR DESCRIPTION
## Purpose

Silence 5 current warnings, which are not bugs.

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

As suggested in #504.
Not touching `gcc.cmake`, as we have no build using that case.