### PR TITLE
Update thrdini.c

### DIFF
--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -78,7 +78,7 @@ KiThreadStartup(VOID)
     StartFrame->SystemRoutine(StartFrame->StartRoutine, StartFrame->StartContext);
 
     /* If we returned, we better be a user thread */
-    if (!StartFrame->UserThread) DbgBreakPoint();
+    if (!StartFrame->UserThread) KeBugCheck((ULONG)0x0000000EL); // NO_USER_MODE_CONTEXT
 
     /* Exit to user-mode */
     KiServiceExit2(TrapFrame);

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -78,7 +78,10 @@ KiThreadStartup(VOID)
     StartFrame->SystemRoutine(StartFrame->StartRoutine, StartFrame->StartContext);
 
     /* If we returned, we better be a user thread */
-    if (!StartFrame->UserThread) KeBugCheck(NO_USER_MODE_CONTEXT);
+    if (!StartFrame->UserThread)
+    {
+        KeBugCheck(NO_USER_MODE_CONTEXT);
+    }
 
     /* Exit to user-mode */
     KiServiceExit2(TrapFrame);

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -78,7 +78,7 @@ KiThreadStartup(VOID)
     StartFrame->SystemRoutine(StartFrame->StartRoutine, StartFrame->StartContext);
 
     /* If we returned, we better be a user thread */
-    if (!StartFrame->UserThread) KeBugCheck((ULONG)0x0000000EL); // NO_USER_MODE_CONTEXT
+    if (!StartFrame->UserThread) KeBugCheck(NO_USER_MODE_CONTEXT);
 
     /* Exit to user-mode */
     KiServiceExit2(TrapFrame);


### PR DESCRIPTION
Cause a corresponding bug check to occur for the reason of the user context flag being zero (a system thread), instead of using DbgBreakPoint.
