### PR TITLE
CORE-14463 Fix possible out of bounds access in EngBitBlt

### DIFF
--- a/win32ss/gdi/eng/bitblt_new.c
+++ b/win32ss/gdi/eng/bitblt_new.c
@@ -410,10 +410,11 @@ IntEngBitBlt(
     ASSERT(prclTrg);
 
     /* Clip the target rect to the extents of the target surface */
-    rcClipped.left = max(prclTrg->left, 0);
-    rcClipped.top = max(prclTrg->top, 0);
-    rcClipped.right = min(prclTrg->right, psoTrg->sizlBitmap.cx);
-    rcClipped.bottom = min(prclTrg->bottom, psoTrg->sizlBitmap.cy);
+    if (!RECTL_bClipRectBySize(&rcClipped, prclTrg, &psoTrg->sizlBitmap))
+    {
+        /* Nothing left */
+        return TRUE;
+    }
 
     /* If no clip object is given, use trivial one */
     if (!pco) pco = (CLIPOBJ*)&gxcoTrivial;

--- a/win32ss/gdi/ntgdi/rect.h
+++ b/win32ss/gdi/ntgdi/rect.h
@@ -67,6 +67,20 @@ RECTL_bIsWellOrdered(
             (prcl->top  <= prcl->bottom));
 }
 
+FORCEINLINE
+BOOL
+RECTL_bClipRectBySize(
+    _Out_ RECTL *prclDst,
+    _In_ const RECTL *prclSrc,
+    _In_ const SIZEL *pszl)
+{
+    prclDst->left = max(prclSrc->left, 0);
+    prclDst->top = max(prclSrc->top, 0);
+    prclDst->right = min(prclSrc->right, pszl->cx);
+    prclDst->bottom = min(prclSrc->bottom, pszl->cy);
+    return !RECTL_bIsEmptyRect(prclDst);
+}
+
 BOOL
 FASTCALL
 RECTL_bUnionRect(


### PR DESCRIPTION
[WIN32K] Implement RECTL_bClipRectBySize() and use it in IntEngBitBlt() to clip the target rect against the bounds of the target surface. Also clip the source rect against the source surface. Fixes remaining part of CORE-14463
