### PR TITLE
CORE-14554 Unreachable line

### DIFF
--- a/drivers/storage/class/class2/class2.c
+++ b/drivers/storage/class/class2/class2.c
@@ -4170,8 +4170,6 @@ Return Value:
                 IoCompleteRequest(Irp, IO_NO_INCREMENT);
                 status = STATUS_INSUFFICIENT_RESOURCES;
                 goto SetStatusAndReturn;
-
-                break;
             }
 
             irp2->Tail.Overlay.Thread = Irp->Tail.Overlay.Thread;


### PR DESCRIPTION
## Purpose

The break statement is unnecessary because the goto on the line before it returns from the routine so it can never be reached.

JIRA issue: [CORE-14554](https://jira.reactos.org/browse/CORE-14554)

## Proposed changes

* Removal of the break statement