### PR TITLE
CORE-14306. [ADVAPI32] Fix a Clang-Cl warning about dwError

### DIFF
--- a/dll/win32/advapi32/service/sctrl.c
+++ b/dll/win32/advapi32/service/sctrl.c
@@ -537,6 +537,10 @@ ScControlService(PACTIVE_SERVICE lpService,
                                        0, NULL,
                                        lpService->HandlerContext);
     }
+    else
+    {
+        ASSERT(lpService->HandlerFunction || lpService->HandlerFunctionEx);
+    }
 
     TRACE("ScControlService() done\n");
 
@@ -652,7 +656,7 @@ RegisterServiceCtrlHandlerA(LPCSTR lpServiceName,
     UNICODE_STRING ServiceNameU;
     SERVICE_STATUS_HANDLE hServiceStatus;
 
-    TRACE("RegisterServiceCtrlHandlerA(%s %p %p)\n",
+    TRACE("RegisterServiceCtrlHandlerA(%s %p)\n",
           debugstr_a(lpServiceName), lpHandlerProc);
 
     RtlInitAnsiString(&ServiceNameA, lpServiceName);
@@ -682,7 +686,7 @@ RegisterServiceCtrlHandlerW(LPCWSTR lpServiceName,
 {
     PACTIVE_SERVICE Service;
 
-    TRACE("RegisterServiceCtrlHandlerW(%s %p %p)\n",
+    TRACE("RegisterServiceCtrlHandlerW(%s %p)\n",
           debugstr_w(lpServiceName), lpHandlerProc);
 
     Service = ScLookupServiceByServiceName(lpServiceName);

--- a/dll/win32/advapi32/service/sctrl.c
+++ b/dll/win32/advapi32/service/sctrl.c
@@ -517,8 +517,6 @@ static DWORD
 ScControlService(PACTIVE_SERVICE lpService,
                  PSCM_CONTROL_PACKET ControlPacket)
 {
-    DWORD dwError;
-
     TRACE("ScControlService(%p %p)\n",
           lpService, ControlPacket);
 
@@ -531,7 +529,6 @@ ScControlService(PACTIVE_SERVICE lpService,
     if (lpService->HandlerFunction)
     {
         (lpService->HandlerFunction)(ControlPacket->dwControl);
-        dwError = ERROR_SUCCESS;
     }
     else if (lpService->HandlerFunctionEx)
     {
@@ -539,12 +536,11 @@ ScControlService(PACTIVE_SERVICE lpService,
         (lpService->HandlerFunctionEx)(ControlPacket->dwControl,
                                        0, NULL,
                                        lpService->HandlerContext);
-        dwError = ERROR_SUCCESS;
     }
 
-    TRACE("ScControlService() done (Error %lu)\n", dwError);
+    TRACE("ScControlService() done\n");
 
-    return dwError;
+    return ERROR_SUCCESS;
 }
 
 


### PR DESCRIPTION
## Purpose

Assumed fix...
Unless we revert the `TRACE` use too and drop `dwError`. Would you prefer that?

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

- 91b50f9ccb530e9544a224df0f0a3e5630441ab6 (@HBelusca) is the culprit.
- aba6ce5b84e34ce02b14b689c66be3cc7830e9eb (@EricKohl) made it even more obvious.

## Proposed changes

- "warning: variable 'dwError' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]"

plus

- Add an ASSERT() if no HandlerFunction* is set (i.e. if RegisterServiceCtrlHandler*() was not called).
- Fix 2 TRACE() format copypastas.
