### PR TITLE
[FASTFAT] Don't leak directories FILE_OBJECT, FCB and cache entries.

### DIFF
--- a/drivers/filesystems/fastfat/cleanup.c
+++ b/drivers/filesystems/fastfat/cleanup.c
@@ -107,6 +107,7 @@ VfatCleanupFile(
                 {
                     pFcb->FileObject = NULL;
                     CcUninitializeCacheMap(tmpFileObject, NULL, NULL);
+                    ClearFlag(pFcb->Flags, FCB_CACHE_INITIALIZED);
                     ObDereferenceObject(tmpFileObject);
                 }
 


### PR DESCRIPTION
## Purpose

Don't leak directories FILE_OBJECT, FCB and cache entries.

JIRA issue: [CORE-14557](https://jira.reactos.org/browse/CORE-14557)

## Proposed changes

Once a directory is crossed (opened or a child is opened), associated
FCB structure is created in FastFAT, but also a stream FO for caching.
Up to now, due to an extra reference taken by the stream file object,
even when the directory was no longer used, the directory was kept in
memory: the FCB was never deleted, the file object was never dereferenced,
and the cache never released.

The immediate effect of this bug is that our FAT driver was leaking every
directory that was used affecting the whole OS situation. In case of
directories intensive operation (like extraction the ReactOS source code
in ReactOS ;-)), we were just killin the whole OS RAM without any way to
release it and recover.

The other side effects: IOs were faster as half of the FS was always
permanant in RAM.

This commit fixes the issue by forcing the FSD to release the FO,
and the cache when a directory is no longer used, leading to its
destruction in RAM.
Downside: on IO intensive operation, expect slowdowns, obviously,
there's less caching now. But more efficient!
