### PR TITLE
RFC: [FASTFAT] Introduce a KDBG extension.

### DIFF
--- a/drivers/filesystems/fastfat/CMakeLists.txt
+++ b/drivers/filesystems/fastfat/CMakeLists.txt
@@ -15,6 +15,7 @@ list(APPEND SOURCE
     flush.c
     fsctl.c
     iface.c
+    kdbg.c
     misc.c
     pnp.c
     rw.c

--- a/drivers/filesystems/fastfat/cleanup.c
+++ b/drivers/filesystems/fastfat/cleanup.c
@@ -137,6 +137,9 @@ VfatCleanupFile(
         }
 
         FileObject->Flags |= FO_CLEANUP_COMPLETE;
+#ifdef KDBG
+        pFcb->Flags |= FCB_CLEANED_UP;
+#endif
 
         ExReleaseResourceLite(&pFcb->PagingIoResource);
         ExReleaseResourceLite(&pFcb->MainResource);

--- a/drivers/filesystems/fastfat/close.c
+++ b/drivers/filesystems/fastfat/close.c
@@ -48,6 +48,9 @@ VfatCloseFile(
     }
     else
     {
+#ifdef KDBG
+        pFcb->Flags |= FCB_CLOSED;
+#endif
         vfatReleaseFCB(DeviceExt, pFcb);
     }
 

--- a/drivers/filesystems/fastfat/iface.c
+++ b/drivers/filesystems/fastfat/iface.c
@@ -34,6 +34,24 @@
 #pragma alloc_text(INIT, DriverEntry)
 #endif
 
+#ifdef KDBG
+NTSTATUS
+NTAPI
+KdSystemDebugControl(IN ULONG Command,
+                     IN PVOID InputBuffer,
+                     IN ULONG InputBufferLength,
+                     OUT PVOID OutputBuffer,
+                     IN ULONG OutputBufferLength,
+                     IN OUT PULONG ReturnLength,
+                     IN KPROCESSOR_MODE PreviousMode);
+
+BOOLEAN
+NTAPI
+vfatKdbgHandler(
+    IN PCHAR Command,
+    IN ULONG Argc,
+    IN PCH Argv[]);
+#endif
 
 /* GLOBALS *****************************************************************/
 
@@ -137,6 +155,16 @@ DriverEntry(
     ExInitializeResourceLite(&VfatGlobalData->VolumeListLock);
     InitializeListHead(&VfatGlobalData->VolumeListHead);
     IoRegisterFileSystem(DeviceObject);
+
+#ifdef KDBG
+    {
+        BOOLEAN Registered;
+
+        Registered = KdSystemDebugControl('RbdK', vfatKdbgHandler, FALSE, NULL, 0, NULL, KernelMode);
+        DPRINT1("FastFAT KDBG extension registered: %s\n", (Registered ? "yes" : "no"));
+    }
+#endif
+
     return STATUS_SUCCESS;
 }
 

--- a/drivers/filesystems/fastfat/kdbg.c
+++ b/drivers/filesystems/fastfat/kdbg.c
@@ -1,0 +1,161 @@
+/*
+* FILE:             drivers/filesystems/fastfat/kdbg.c
+* PURPOSE:          KDBG extension.
+* COPYRIGHT:        See COPYING in the top level directory
+* PROJECT:          ReactOS kernel
+* PROGRAMMER:       Pierre Schweitzer (pierre@reactos.org)
+*/
+
+/*  -------------------------------------------------------  INCLUDES  */
+
+#include "vfat.h"
+
+#define NDEBUG
+#include <debug.h>
+
+#include <stdio.h>
+
+/*  --------------------------------------------------------  DEFINES  */
+
+#ifdef KDBG
+UNICODE_STRING DebugFile = {0, 0, NULL};
+
+BOOLEAN
+NTAPI
+vfatKdbgHandler(
+    IN PCHAR Command,
+    IN ULONG Argc,
+    IN PCH Argv[])
+{
+    ULONG Len;
+
+    Len = strlen(Command);
+    if (Len < sizeof("?fat."))
+    {
+        return FALSE;
+    }
+
+    if (Command[0] != '?' || Command[1] != 'f' ||
+        Command[2] != 'a' || Command[3] != 't' ||
+        Command[4] != '.')
+    {
+        return FALSE;
+    }
+
+    Command += (sizeof("?fat.") - sizeof(ANSI_NULL));
+    if (strcmp(Command, "vols") == 0)
+    {
+        ULONG Count = 0;
+        PLIST_ENTRY ListEntry;
+        PDEVICE_EXTENSION DeviceExt;
+
+        for (ListEntry = VfatGlobalData->VolumeListHead.Flink;
+             ListEntry != &VfatGlobalData->VolumeListHead;
+             ListEntry = ListEntry->Flink)
+        {
+            DeviceExt = CONTAINING_RECORD(ListEntry, DEVICE_EXTENSION, VolumeListEntry);
+            DPRINT1("Volume: %p with VCB: %p\n", DeviceExt->VolumeDevice, DeviceExt);
+            ++Count;
+        }
+
+        if (Count == 0)
+        {
+            DPRINT1("No volume found\n");
+        }
+    }
+    else if (strcmp(Command, "files") == 0)
+    {
+        if (Argc != 2)
+        {
+            DPRINT1("Please provide a volume or a VCB!\n");
+        }
+        else
+        {
+            PLIST_ENTRY ListEntry;
+            PDEVICE_EXTENSION DeviceExt;
+
+            for (ListEntry = VfatGlobalData->VolumeListHead.Flink;
+                 ListEntry != &VfatGlobalData->VolumeListHead;
+                 ListEntry = ListEntry->Flink)
+            {
+                CHAR Volume[17];
+
+                DeviceExt = CONTAINING_RECORD(ListEntry, DEVICE_EXTENSION, VolumeListEntry);
+                sprintf(Volume, "%p", DeviceExt);
+                if (strcmp(Volume, Argv[1]) == 0)
+                {
+                    break;
+                }
+
+                sprintf(Volume, "%p", DeviceExt->VolumeDevice);
+                if (strcmp(Volume, Argv[1]) == 0)
+                {
+                    break;
+                }
+
+                DeviceExt = NULL;
+            }
+
+            if (DeviceExt == NULL)
+            {
+                DPRINT1("No volume %s found!\n", Argv[1]);
+            }
+            else
+            {
+                PVFATFCB Fcb;
+
+                for (ListEntry = DeviceExt->FcbListHead.Flink;
+                     ListEntry != &DeviceExt->FcbListHead;
+                     ListEntry = ListEntry->Flink)
+                {
+                    Fcb = CONTAINING_RECORD(ListEntry, VFATFCB, FcbListEntry);
+                    DPRINT1("FCB %p (ref: %d, oc: %d %s %s) for FO %p with path: %.*S\n",
+                            Fcb, Fcb->RefCount, Fcb->OpenHandleCount,
+                            ((Fcb->Flags & FCB_CLEANED_UP) ? "U" : "NU"),
+                            ((Fcb->Flags & FCB_CLOSED) ? "C" : "NC"),
+                            Fcb->FileObject, Fcb->PathNameU.Length, Fcb->PathNameU.Buffer);
+                }
+            }
+        }
+    }
+    else if (strcmp(Command, "setdbgfile") == 0)
+    {
+        if (Argc < 2)
+        {
+            if (DebugFile.Buffer != NULL)
+            {
+                ExFreePool(DebugFile.Buffer);
+                DebugFile.Length = 0;
+                DebugFile.MaximumLength = 0;
+            }
+
+            DPRINT1("Debug file reset\n");
+        }
+        else
+        {
+            NTSTATUS Status;
+            ANSI_STRING Source;
+
+            if (DebugFile.Buffer != NULL)
+            {
+                ExFreePool(DebugFile.Buffer);
+                DebugFile.Length = 0;
+                DebugFile.MaximumLength = 0;
+            }
+
+            RtlInitAnsiString(&Source, Argv[1]);
+            Status = RtlAnsiStringToUnicodeString(&DebugFile, &Source, TRUE);
+            if (NT_SUCCESS(Status))
+            {
+                DPRINT1("Debug file set to: %.*S\n", DebugFile.Length, DebugFile.Buffer);
+            }
+        }
+    }
+    else
+    {
+        DPRINT1("Unknown command: %s\n", Command);
+    }
+
+    return TRUE;
+}
+#endif

--- a/drivers/filesystems/fastfat/vfat.h
+++ b/drivers/filesystems/fastfat/vfat.h
@@ -409,6 +409,10 @@ extern PVFAT_GLOBAL_DATA VfatGlobalData;
 #define FCB_IS_PAGE_FILE        0x0008
 #define FCB_IS_VOLUME           0x0010
 #define FCB_IS_DIRTY            0x0020
+#ifdef KDBG
+#define FCB_CLEANED_UP          0x0040
+#define FCB_CLOSED              0x0080
+#endif
 
 #define NODE_TYPE_FCB ((CSHORT)0x0502)
 
@@ -898,14 +902,41 @@ vfatDestroyCCB(
     PVFATCCB pCcb);
 
 VOID
+#ifndef KDBG
 vfatGrabFCB(
+#else
+_vfatGrabFCB(
+#endif
     PDEVICE_EXTENSION pVCB,
-    PVFATFCB pFCB);
+    PVFATFCB pFCB
+#ifdef KDBG
+    ,
+    PCSTR File,
+    ULONG Line,
+    PCSTR Func
+#endif
+    );
 
 VOID
+#ifndef KDBG
 vfatReleaseFCB(
+#else
+_vfatReleaseFCB(
+#endif
     PDEVICE_EXTENSION pVCB,
-    PVFATFCB pFCB);
+    PVFATFCB pFCB
+#ifdef KDBG
+    ,
+    PCSTR File,
+    ULONG Line,
+    PCSTR Func
+#endif
+    );
+
+#ifdef KDBG
+#define vfatGrabFCB(v, f) _vfatGrabFCB(v, f, __FILE__, __LINE__, __FUNCTION__)
+#define vfatReleaseFCB(v, f) _vfatReleaseFCB(v, f, __FILE__, __LINE__, __FUNCTION__)
+#endif
 
 PVFATFCB
 vfatGrabFCBFromTable(


### PR DESCRIPTION
## Purpose

This is a RFC PR, the purpose is not to nitpick on "You poorly named your variable". The purpose is to agree on the fact such KDBG extensions can be of use in ReactOS, and whether we want them, in that way or in another.
FastFAT here just serves as playground for prototyping the thing.

## Proposed changes

This KDBG extension relies on the fact that KdSystemDebugControl() is stubbed and is an open door to KDBG for drivers. That way, drivers can register a KDBG CLI callback. Then, each time data is submitted to KDBG, it will go throught every registered callback, including the driver.

Obviously, the day KdSystemDebugControl() will be properly implemented, it's likely this hack will be gone and the extension will be removed. But we're not here yet!