### PR TITLE
CORE-14306. [NTFS] Fix 2 Clang-Cl warnings about CurrentKey->IndexEntry->Flags

### DIFF
--- a/drivers/filesystems/ntfs/btree.c
+++ b/drivers/filesystems/ntfs/btree.c
@@ -1257,7 +1257,7 @@ UpdateIndexAllocation(PDEVICE_EXTENSION DeviceExt,
             }
 
             // Is the Index Entry large enough to store the VCN?
-            if (!CurrentKey->IndexEntry->Flags & NTFS_INDEX_ENTRY_NODE)
+            if (!BooleanFlagOn(CurrentKey->IndexEntry->Flags, NTFS_INDEX_ENTRY_NODE))
             {
                 // Allocate memory for the larger index entry
                 PINDEX_ENTRY_ATTRIBUTE NewEntry = ExAllocatePoolWithTag(NonPagedPool,
@@ -1357,7 +1357,7 @@ UpdateIndexNode(PDEVICE_EXTENSION DeviceExt,
             }
             
             // Is the Index Entry large enough to store the VCN?
-            if (!CurrentKey->IndexEntry->Flags & NTFS_INDEX_ENTRY_NODE)
+            if (!BooleanFlagOn(CurrentKey->IndexEntry->Flags, NTFS_INDEX_ENTRY_NODE))
             {
                 // Allocate memory for the larger index entry
                 PINDEX_ENTRY_ATTRIBUTE NewEntry = ExAllocatePoolWithTag(NonPagedPool,


### PR DESCRIPTION
## Purpose

Assumed fix...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: logical not is only applied to the left hand side of this bitwise operator [-Wlogical-not-parentheses]"
