### PR TITLE
CORE-14306. [UMPNPMGR] Fix a Clang-Cl warning about "CSConfigFlags"

### DIFF
--- a/base/services/umpnpmgr/umpnpmgr.c
+++ b/base/services/umpnpmgr/umpnpmgr.c
@@ -2423,12 +2423,12 @@ PNP_HwProfFlags(
          else
          {
              dwSize = sizeof(DWORD);
-             if (!RegQueryValueExW(hDeviceKey,
-                                   L"CSConfigFlags",
-                                   NULL,
-                                   NULL,
-                                   (LPBYTE)pulValue,
-                                   &dwSize) != ERROR_SUCCESS)
+             if (RegQueryValueExW(hDeviceKey,
+                                  L"CSConfigFlags",
+                                  NULL,
+                                  NULL,
+                                  (LPBYTE)pulValue,
+                                  &dwSize) != ERROR_SUCCESS)
              {
                  *pulValue = 0;
              }


### PR DESCRIPTION
## Purpose

Assumed fix...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]"
