### PR TITLE
CORE-14306. [DESK.CPL] Fix a Clang-Cl warning about "LogPixels"

### DIFF
--- a/dll/cpl/desk/general.c
+++ b/dll/cpl/desk/general.c
@@ -32,8 +32,8 @@ InitFontSizeList(HWND hWnd)
                 dwSize = MAX_PATH;
                 dwType = REG_DWORD;
 
-                if (!RegQueryValueEx(hKey, _T("LogPixels"), NULL,
-                                    &dwType, (LPBYTE)&dwValue, &dwSize) == ERROR_SUCCESS)
+                if (RegQueryValueEx(hKey, _T("LogPixels"), NULL, &dwType,
+                                    (LPBYTE)&dwValue, &dwSize) != ERROR_SUCCESS)
                 {
                     dwValue = 0;
                 }


### PR DESCRIPTION
## Purpose

Assumed fix...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]"
