### PR TITLE
CORE-14306. [DEVMGR] Fix a Clang-Cl warning about DriverInfoDetailData.SectionName

### DIFF
--- a/dll/win32/devmgr/properties/misc.cpp
+++ b/dll/win32/devmgr/properties/misc.cpp
@@ -1078,8 +1078,7 @@ FindCurrentDriver(IN HDEVINFO DeviceInfoSet,
             ERR("SetupDiGetDriverInfoDetail() failed with error 0x%lx\n", GetLastError());
             goto Cleanup;
         }
-        if (!_wcsicmp(DriverInfoDetailData.SectionName,
-                     InfSection) != 0)
+        if (_wcsicmp(DriverInfoDetailData.SectionName, InfSection) == 0)
         {
             /* We have found the right driver */
             Ret = TRUE;


### PR DESCRIPTION
## Purpose

Assumed fix...

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- "warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]"
