### PR TITLE
[EXT2FS][REISERFS] VSSolution: Disable C4189 errors, actually. CORE-11280

### DIFF
--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -94,8 +94,8 @@ endif()
 
 if(MSVC AND (NOT USE_CLANG_CL))
     # Disable warnings: "unreferenced local variable", "initialized, but not used variable", "benign include"
-    replace_compile_flags("/we\"4189\"" " ")
-    add_target_compile_flags(ext2fs "/wd\"4189\" /wd\"4142\" /wd\"4101\"")
+    replace_compile_flags("/we4189" " ")
+    add_target_compile_flags(ext2fs "/wd4189 /wd4142 /wd4101")
 else()
     add_target_compile_flags(ext2fs "-Wno-pointer-sign -Wno-unused-function")
     add_target_compile_flags(ext2fs "-Wno-unused-variable -Wno-missing-braces")

--- a/drivers/filesystems/reiserfs/CMakeLists.txt
+++ b/drivers/filesystems/reiserfs/CMakeLists.txt
@@ -86,8 +86,8 @@ if(USE_CLANG_CL OR (NOT MSVC))
     endif()
 else()
     #disable warnings: "unreferenced local variable", "initialized, but not used variable", "benign include"
-    replace_compile_flags("/we\"4189\"" " ")
-    add_target_compile_flags(reiserfs "/wd\"4189\" /wd\"4142\" /wd\"4101\"")
+    replace_compile_flags("/we4189" " ")
+    add_target_compile_flags(reiserfs "/wd4189 /wd4142 /wd4101")
 endif()
 
 target_link_libraries(reiserfs memcmp ${PSEH_LIB})


### PR DESCRIPTION
## Purpose

With VS12, multiple "error C4189: '[...]': local variable is initialized but not referenced".

JIRA issue: [CORE-11280](https://jira.reactos.org/browse/CORE-11280)

## Proposed changes

- Remove unwanted quotation marks.
