### PR TITLE
CORE-14607. [REACTOS] Warn if not using RosBE custom CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 cmake_minimum_required(VERSION 3.2.1)
 cmake_policy(VERSION 3.2.1)
 
+if(NOT CMAKE_VERSION MATCHES "ReactOS")
+    message(WARNING "Building with \"${CMAKE_COMMAND}\", which is not the custom CMake included in RosBE, might cause build issues...")
+endif()
+
 # Don't escape preprocessor definition values added via add_definitions
 cmake_policy(SET CMP0005 OLD)
 


### PR DESCRIPTION
## Purpose

Better be explicit immediately, than fail later without a clue.

JIRA issue: [CORE-14607](https://jira.reactos.org/browse/CORE-14607)

## TODO

Questions:

- [ ] Should this check be moved to a "later" place?
- [X] Should I test for `NOT MSVC_IDE` too?
No: errors with "CMake 3.11.1 + msbuild".
- [X] Should I do something about [grep of existing checks](https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=CMAKE_VERSION+MATCHES+%22ReactOS%22)?
No, as errorring out here is refused, so build will warn and continue.