### PR TITLE
 [APPVEYOR][CONFIGURE] Minor consistency improvements and one fix

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,10 +24,10 @@ init:
 build_script:
   - set PATH=C:\RosCMakeNinja\bin;%PATH%
   - if "%BuildType%" == "msvc-x64" (
-        call "C:\PROGRA~2\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
-      ) else (
-        call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
-      )
+      call "C:\PROGRA~2\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+    ) else (
+      call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
+    )
   - cmake --version
   - md c:\ros_build
   - cd c:\ros_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,13 @@ environment:
 version: reactos.appveyor.{build}
 skip_branch_with_pr: true
 clone_depth: 5
-clone_folder: c:\reactos-cov
+clone_folder: C:\reactos-cov
 
 init:
   - ps: (New-Object System.Net.WebClient).DownloadFile("https://svn.reactos.org/amine/RosCMakeNinja.zip","C:\RosCMakeNinja.zip")
   - 7z x C:\RosCMakeNinja.zip -oC:\RosCMakeNinja
   - ps: >-
-      If ($env:BuildType -Match "clang-cl") {
+      If ($env:BuildType -eq "clang-cl") {
         $env:clang_configure_option="clang"
         (New-Object System.Net.WebClient).DownloadFile("https://svn.reactos.org/amine/clang-cl.7z","C:\clang-cl.7z")
         7z x C:\clang-cl.7z -oC:\RosCMakeNinja\bin
@@ -24,13 +24,13 @@ init:
 build_script:
   - set PATH=C:\RosCMakeNinja\bin;%PATH%
   - if "%BuildType%" == "msvc-x64" (
-      call "C:\PROGRA~2\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
+      call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" amd64
     ) else (
       call "C:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\vcvarsall.bat" x86
     )
   - cmake --version
-  - md c:\ros_build
-  - cd c:\ros_build
+  - md C:\ros_build
+  - cd C:\ros_build
   - call %APPVEYOR_BUILD_FOLDER%\configure.cmd %clang_configure_option% -DENABLE_ROSTESTS=1
   - ps: >-
       & ninja -k0 2>&1 | select-string -pattern "\[\d+\/\d+\] " -NotMatch | %{$_.Line}

--- a/configure.cmd
+++ b/configure.cmd
@@ -9,7 +9,7 @@ setlocal enabledelayedexpansion
 
 REM Does the user need help?
 if /I "%1" == "help" goto help
-if /I "%1" == "/?" (
+if "%1" == "/?" (
 :help
     echo Help for configure script
     echo Syntax: path\to\source\configure.cmd [script-options] [Cmake-options]
@@ -110,7 +110,7 @@ REM Parse command line parameters
             goto quit
         ) else if /I "%1" == "RTC" (
             echo. && echo 	Warning: RTC switch is ignored outside of a Visual Studio environment. && echo.
-        ) else if /I "%1" NEQ "" (
+        ) else if "%1" NEQ "" (
             echo %1| find /I "-D" > NUL
             if %ERRORLEVEL% == 0 (
                 REM User is passing a switch to CMake
@@ -190,7 +190,7 @@ REM Parse command line parameters
         ) else if /I "%1" == "RTC" (
             echo Runtime checks enabled
             set VS_RUNTIME_CHECKS=1
-        ) else if /I "%1" NEQ "" (
+        ) else if "%1" NEQ "" (
             echo %1| find /I "-D" > NUL
             if %ERRORLEVEL% == 0 (
                 REM User is passing a switch to CMake
@@ -221,7 +221,7 @@ if "%VS_SOLUTION%" == "1" (
     set REACTOS_OUTPUT_PATH=%REACTOS_OUTPUT_PATH%-sln
 )
 
-if "%REACTOS_SOURCE_DIR%" == "%CD%\" (
+if /I "%REACTOS_SOURCE_DIR%" == "%CD%\" (
     set CD_SAME_AS_SOURCE=1
     echo Creating directories in %REACTOS_OUTPUT_PATH%
 

--- a/configure.cmd
+++ b/configure.cmd
@@ -246,7 +246,7 @@ if "%VS_SOLUTION%" == "1" (
     goto quit
 )
 
-if "%NEW_STYLE_BUILD%"=="0" (
+if "%NEW_STYLE_BUILD%" == "0" (
 
     if not exist host-tools (
         mkdir host-tools
@@ -278,7 +278,7 @@ if "%NEW_STYLE_BUILD%"=="0" (
 
 echo Preparing reactos...
 
-if "%NEW_STYLE_BUILD%"=="0" (
+if "%NEW_STYLE_BUILD%" == "0" (
     cd reactos
 )
 
@@ -287,7 +287,7 @@ if EXIST CMakeCache.txt (
     del host-tools\CMakeCache.txt /q
 )
 
-if "%NEW_STYLE_BUILD%"=="0" (
+if "%NEW_STYLE_BUILD%" == "0" (
     set BUILD_TOOLS_FLAG=-DREACTOS_BUILD_TOOLS_DIR:PATH="%REACTOS_BUILD_TOOLS_DIR%"
 )
 
@@ -299,7 +299,7 @@ if "%BUILD_ENVIRONMENT%" == "MinGW" (
     cmake -G %CMAKE_GENERATOR% -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=%ARCH% %BUILD_TOOLS_FLAG% -DRUNTIME_CHECKS:BOOL=%VS_RUNTIME_CHECKS% %* "%REACTOS_SOURCE_DIR%"
 )
 
-if "%NEW_STYLE_BUILD%"=="0" (
+if "%NEW_STYLE_BUILD%" == "0" (
     cd..
 )
 


### PR DESCRIPTION
## Purpose

These include both a workaround and the fix for `configure.cmd`
failing to detect custom building in source directory.
As, currently, `~dp0 != %CD%\` even when commenting out "ros_build" directory.

Noticed while working on
JIRA issue: [CORE-11836](https://jira.reactos.org/browse/CORE-11836)
