### PR TITLE
CORE-14306. [HALX86] Fix a Clang-Cl warning about KiUnexpectedInterrupt

### DIFF
--- a/hal/halx86/up/pic.c
+++ b/hal/halx86/up/pic.c
@@ -405,7 +405,7 @@ PHAL_SW_INTERRUPT_HANDLER SWInterruptHandlerTable[20] =
 /* Handlers for pending software interrupts when we already have a trap frame*/
 PHAL_SW_INTERRUPT_HANDLER_2ND_ENTRY SWInterruptHandlerTable2[3] =
 {
-    (PHAL_SW_INTERRUPT_HANDLER_2ND_ENTRY)KiUnexpectedInterrupt,
+    (PHAL_SW_INTERRUPT_HANDLER_2ND_ENTRY)(PVOID)KiUnexpectedInterrupt,
     HalpApcInterrupt2ndEntry,
     HalpDispatchInterrupt2ndEntry
 };


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

## Proposed changes

- Add a cast to `PVOID` and a comment.
- Also add an unrelated comment.
