### PR TITLE
[SHELL] Fix usage of DeferWindowPos (fix of #544)

### DIFF
--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -1622,17 +1622,17 @@ NewExtDlg_OnAdvanced(HWND hwndDlg, NEWEXT_DIALOG *pNewExt)
     HDWP hDWP = BeginDeferWindowPos(3);
 
     if (hDWP)
-        DeferWindowPos(hDWP, GetDlgItem(hwndDlg, IDOK), NULL,
-                       rc1.left, rc1.top, rc1.right - rc1.left, rc1.bottom - rc1.top,
-                       SWP_NOACTIVATE | SWP_NOZORDER);
+        hDWP = DeferWindowPos(hDWP, GetDlgItem(hwndDlg, IDOK), NULL,
+                              rc1.left, rc1.top, rc1.right - rc1.left, rc1.bottom - rc1.top,
+                              SWP_NOACTIVATE | SWP_NOZORDER);
     if (hDWP)
-        DeferWindowPos(hDWP, GetDlgItem(hwndDlg, IDCANCEL), NULL,
-                       rc2.left, rc2.top, rc2.right - rc2.left, rc2.bottom - rc2.top,
-                       SWP_NOACTIVATE | SWP_NOZORDER);
+        hDWP = DeferWindowPos(hDWP, GetDlgItem(hwndDlg, IDCANCEL), NULL,
+                              rc2.left, rc2.top, rc2.right - rc2.left, rc2.bottom - rc2.top,
+                              SWP_NOACTIVATE | SWP_NOZORDER);
     if (hDWP)
-        DeferWindowPos(hDWP, hwndDlg, NULL,
-                       rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
-                       SWP_NOACTIVATE | SWP_NOZORDER);
+        hDWP = DeferWindowPos(hDWP, hwndDlg, NULL,
+                              rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
+                              SWP_NOACTIVATE | SWP_NOZORDER);
 
     if (hDWP)
         EndDeferWindowPos(hDWP);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12906](https://jira.reactos.org/browse/CORE-12906)

There are mistakes in usage of DeferWindowPos in #544. We should use the return value of DeferWindowPos. This PR fixes it.