### PR TITLE
Bump minimum cmake version to 3.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,20 +1,15 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.1)
+cmake_policy(VERSION 3.2.1)
 
-if(POLICY CMP0017)
-    # Shadow cmake provided modules
-    cmake_policy(SET CMP0017 OLD)
-endif()
+# Don't escape preprocessor definition values added via add_definitions
+cmake_policy(SET CMP0005 OLD)
 
-if(POLICY CMP0026)
-    # Allow use of the LOCATION property
-    cmake_policy(SET CMP0026 NEW)
-endif()
+# Shadow cmake provided modules
+cmake_policy(SET CMP0017 OLD)
 
-if(POLICY CMP0051)
-    # List TARGET_OBJECTS in SOURCES target property
-    cmake_policy(SET CMP0051 NEW)
-endif()
+# Honor CMAKE_SHARED_LIBRARY_<Lang>_FLAGS variable.
+cmake_policy(SET CMP0018 OLD)
 
 if(POLICY CMP0058)
     # Ninja requires custom command byproducts to be explicit
@@ -25,13 +20,6 @@ project(REACTOS)
 
 # Versioning
 include(sdk/include/reactos/version.cmake)
-
-# Don't escape preprocessor definition values added via add_definitions
-cmake_policy(SET CMP0005 OLD)
-cmake_policy(SET CMP0002 NEW)
-if(POLICY CMP0018)
-    cmake_policy(SET CMP0018 OLD)
-endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_DIRECTORIES_PROJECT_BEFORE ON)


### PR DESCRIPTION
Matching whats currently in rosbe
Remove policy checks already implied by the minimum version

## Purpose

Much of the cmake code in reactos can be simplified using features from cmake 3.0+, and as the patched version of cmake in rosbe is currently required it seems needless to restrict reactos to the cmake 2.8 feature set