### PR TITLE
Setup improvements n°3 -- FREELDR, NTOS

### DIFF
--- a/boot/bootdata/setupreg.inf
+++ b/boot/bootdata/setupreg.inf
@@ -1,0 +1,44 @@
+[Version]
+Signature = "$ReactOS$"
+
+[DelReg]
+
+; Critical Device Database
+;;
+;; WARNING! Keep it in sync with hivesys.inf
+;;
+
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0A03"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0A08"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0604"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0C08"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0C0300"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0C0310"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0C0320"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#Class_08&SubClass_06&Prot_50"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#COMPOSITE"
+;HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#CLASS_09"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#ROOT_HUB"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#ROOT_HUB20"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\GenDisk"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\USB#Class_03"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\GENERIC_HID_DEVICE"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\HID_DEVICE_SYSTEM_KEYBOARD"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\HID_DEVICE_SYSTEM_MOUSE"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0000"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0001"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0300"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PCI#CC_0301"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0303"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0F0E"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0F19"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\PS2_MOUSE"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0F13"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*IBM3780"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0F12"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\*PNP0F03"
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase\ROOT#SWENUM"
+
+HKLM,"SYSTEM\CurrentControlSet\Control\CriticalDeviceDatabase"
+
+; EOF

--- a/boot/freeldr/freeldr/include/winldr.h
+++ b/boot/freeldr/freeldr/include/winldr.h
@@ -22,20 +22,20 @@
 
 #include <arc/setupblk.h>
 
+// See freeldr/ntldr/winldr.h
 #define TAG_WLDR_DTE 'eDlW'
 #define TAG_WLDR_BDE 'dBlW'
 #define TAG_WLDR_NAME 'mNlW'
 
-/* Entry-point to kernel */
-typedef VOID (NTAPI *KERNEL_ENTRY_POINT) (PLOADER_PARAMETER_BLOCK LoaderBlock);
-
 
 // Some definitions
+
+// FIXME: This one has nothing to do here!!
 #define SECTOR_SIZE 512
 
 // Descriptors
-#define NUM_GDT 128 // Must be 128
-#define NUM_IDT 0x100 // only 16 are used though. Must be 0x100
+#define NUM_GDT 128     // Must be 128
+#define NUM_IDT 0x100   // Only 16 are used though. Must be 0x100
 
 #include <pshpack1.h>
 typedef struct  /* Root System Descriptor Pointer */
@@ -58,27 +58,6 @@ typedef struct _ARC_DISK_SIGNATURE_EX
     CHAR ArcName[MAX_PATH];
 } ARC_DISK_SIGNATURE_EX, *PARC_DISK_SIGNATURE_EX;
 
-#define MAX_OPTIONS_LENGTH 255
-
-typedef struct _LOADER_SYSTEM_BLOCK
-{
-    LOADER_PARAMETER_BLOCK LoaderBlock;
-    LOADER_PARAMETER_EXTENSION Extension;
-    SETUP_LOADER_BLOCK SetupBlock;
-#ifdef _M_IX86
-    HEADLESS_LOADER_BLOCK HeadlessLoaderBlock;
-#endif
-    NLS_DATA_BLOCK NlsDataBlock;
-    CHAR LoadOptions[MAX_OPTIONS_LENGTH+1];
-    CHAR ArcBootDeviceName[MAX_PATH+1];
-    // CHAR ArcHalDeviceName[MAX_PATH];
-    CHAR NtBootPathName[MAX_PATH+1];
-    CHAR NtHalPathName[MAX_PATH+1];
-    ARC_DISK_INFORMATION ArcDiskInformation;
-} LOADER_SYSTEM_BLOCK, *PLOADER_SYSTEM_BLOCK;
-
-extern PLOADER_SYSTEM_BLOCK WinLdrSystemBlock;
-
 ///////////////////////////////////////////////////////////////////////////////////////
 //
 // ReactOS Loading Functions
@@ -87,18 +66,22 @@ extern PLOADER_SYSTEM_BLOCK WinLdrSystemBlock;
 VOID LoadAndBootWindows(IN OperatingSystemItem* OperatingSystem,
                         IN USHORT OperatingSystemVersion);
 
-// conversion.c
+VOID
+LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
+                 IN USHORT OperatingSystemVersion);
+
+
+// conversion.c and conversion.h
 PVOID VaToPa(PVOID Va);
 PVOID PaToVa(PVOID Pa);
 VOID List_PaToVa(_In_ LIST_ENTRY *ListEntry);
-VOID ConvertConfigToVA(PCONFIGURATION_COMPONENT_DATA Start);
+
 
 // peloader.c
 BOOLEAN
 WinLdrLoadImage(IN PCHAR FileName,
                 TYPE_OF_MEMORY MemoryType,
                 OUT PVOID *ImageBasePA);
-
 
 BOOLEAN
 WinLdrAllocateDataTableEntry(IN OUT PLIST_ENTRY ModuleListHead,
@@ -112,54 +95,13 @@ WinLdrScanImportDescriptorTable(IN OUT PLIST_ENTRY ModuleListHead,
                                 IN PCCH DirectoryPath,
                                 IN PLDR_DATA_TABLE_ENTRY ScanDTE);
 
-// winldr.c
-PVOID WinLdrLoadModule(PCSTR ModuleName, ULONG *Size,
-                       TYPE_OF_MEMORY MemoryType);
-
-// wlmemory.c
-BOOLEAN
-WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock);
-
-// wlregistry.c
-BOOLEAN WinLdrInitSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
-                             IN LPCSTR DirectoryPath);
-
-BOOLEAN WinLdrScanSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
-                             IN LPCSTR DirectoryPath);
-
-
 BOOLEAN
 WinLdrCheckForLoadedDll(IN OUT PLIST_ENTRY ModuleListHead,
                         IN PCH DllName,
                         OUT PLDR_DATA_TABLE_ENTRY *LoadedEntry);
 
-VOID
-WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
-                       LPCSTR Options,
-                       LPCSTR SystemPath,
-                       LPCSTR BootPath,
-                       USHORT VersionToBoot);
-BOOLEAN
-WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
-                  IN LPCSTR DirectoryPath,
-                  IN LPCSTR AnsiFileName,
-                  IN LPCSTR OemFileName,
-                  IN LPCSTR LanguageFileName);
-BOOLEAN
-WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
-                      LPWSTR RegistryPath,
-                      LPWSTR ImagePath,
-                      LPWSTR ServiceName);
 
-VOID
-WinLdrpDumpMemoryDescriptors(PLOADER_PARAMETER_BLOCK LoaderBlock);
-
-VOID
-WinLdrpDumpBootDriver(PLOADER_PARAMETER_BLOCK LoaderBlock);
-
-VOID
-WinLdrpDumpArcDisks(PLOADER_PARAMETER_BLOCK LoaderBlock);
-
+// arch/xxx/winldr.c
 BOOLEAN
 MempSetupPaging(IN PFN_NUMBER StartPage,
                 IN PFN_NUMBER NumberOfPages,
@@ -169,19 +111,7 @@ VOID
 MempUnmapPage(PFN_NUMBER Page);
 
 VOID
-MempDump();
-
-VOID
-LoadAndBootWindowsCommon(
-    USHORT OperatingSystemVersion,
-    PLOADER_PARAMETER_BLOCK LoaderBlock,
-    LPCSTR BootOptions,
-    LPCSTR BootPath,
-    BOOLEAN Setup);
-
-VOID
-LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
-                 IN USHORT OperatingSystemVersion);
+MempDump(VOID);
 
 VOID
 WinLdrSetupMachineDependent(PLOADER_PARAMETER_BLOCK LoaderBlock);

--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -19,6 +19,7 @@
  */
 
 #include <freeldr.h>
+#include "winldr.h"
 
 #include <ndk/ldrtypes.h>
 #include <arc/setupblk.h>
@@ -27,12 +28,6 @@
 
 DBG_DEFAULT_CHANNEL(WINDOWS);
 #define TAG_BOOT_OPTIONS 'pOtB'
-
-void
-WinLdrSetupMachineDependent(PLOADER_PARAMETER_BLOCK LoaderBlock);
-
-VOID
-WinLdrSetProcessorContext(void);
 
 // TODO: Move to .h
 VOID AllocateAndInitLPB(PLOADER_PARAMETER_BLOCK *OutLoaderBlock);

--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -74,8 +74,13 @@ SetupLdrLoadNlsData(PLOADER_PARAMETER_BLOCK LoaderBlock, HINF InfHandle, LPCSTR 
         return;
     }
 
+    TRACE("NLS data %s %s %s\n", AnsiName, OemName, LangName);
+
     Success = WinLdrLoadNLSData(LoaderBlock, SearchPath, AnsiName, OemName, LangName);
     TRACE("NLS data loading %s\n", Success ? "successful" : "failed");
+
+    /* TODO: Load OEM HAL font */
+    // Value "OemHalFont"
 }
 
 static VOID
@@ -128,6 +133,9 @@ SetupLdrScanBootDrivers(PLIST_ENTRY BootDriverListHead, HINF InfHandle, LPCSTR S
     } while (InfFindNextLine(&InfContext, &InfContext));
 }
 
+
+/* SETUP STARTER **************************************************************/
+
 VOID
 LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
                  IN USHORT OperatingSystemVersion)
@@ -143,6 +151,7 @@ LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
     LPCSTR LoadOptions;
     LPSTR BootOptions;
     BOOLEAN BootFromFloppy;
+    BOOLEAN Success;
     ULONG i, ErrorLine;
     HINF InfHandle;
     INFCONTEXT InfContext;
@@ -162,6 +171,8 @@ LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
         "reactos\\",
         NULL
     };
+
+    UiDrawStatusText("Setup is loading...");
 
     /* Get OS setting value */
     SettingsValue[0] = ANSI_NULL;
@@ -303,8 +314,6 @@ LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
 
     TRACE("BootOptions: '%s'\n", BootOptions);
 
-    UiDrawStatusText("Setup is loading...");
-
     /* Allocate and minimalist-initialize LPB */
     AllocateAndInitLPB(&LoaderBlock);
 
@@ -315,16 +324,29 @@ LoadReactOSSetup(IN OperatingSystemItem* OperatingSystem,
     /* Set textmode setup flag */
     SetupBlock->Flags = SETUPLDR_TEXT_MODE;
 
-    /* Load NLS data, they are in system32 */
+    /* Load the system hive "setupreg.hiv" for setup */
+    UiDrawBackdrop();
+    UiDrawProgressBarCenter(15, 100, "Loading setup system hive...");
+    Success = WinLdrInitSystemHive(LoaderBlock, BootPath, TRUE);
+    TRACE("Setup SYSTEM hive %s\n", (Success ? "loaded" : "not loaded"));
+    /* Bail out if failure */
+    if (!Success)
+        return;
+
+    /* Load NLS data, they are in the System32 directory of the installation medium */
     strcpy(FileName, BootPath);
     strcat(FileName, "system32\\");
     SetupLdrLoadNlsData(LoaderBlock, InfHandle, FileName);
+
+    // UiDrawStatusText("Press F6 if you need to install a 3rd-party SCSI or RAID driver...");
 
     /* Get a list of boot drivers */
     SetupLdrScanBootDrivers(&LoaderBlock->BootDriverListHead, InfHandle, BootPath);
 
     /* Close the inf file */
     InfCloseFile(InfHandle);
+
+    UiDrawStatusText("The Setup program is starting...");
 
     /* Load ReactOS Setup */
     LoadAndBootWindowsCommon(_WIN32_WINNT_WS03,

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -20,6 +20,7 @@
  */
 
 #include <freeldr.h>
+#include "winldr.h"
 #include "registry.h"
 
 #include <ndk/ldrtypes.h>

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -750,7 +750,7 @@ LoadAndBootWindows(IN OperatingSystemItem* OperatingSystem,
     /* Load the system hive */
     UiDrawBackdrop();
     UiDrawProgressBarCenter(15, 100, "Loading system hive...");
-    Success = WinLdrInitSystemHive(LoaderBlock, BootPath);
+    Success = WinLdrInitSystemHive(LoaderBlock, BootPath, FALSE);
     TRACE("SYSTEM hive %s\n", (Success ? "loaded" : "not loaded"));
     /* Bail out if failure */
     if (!Success)

--- a/boot/freeldr/freeldr/ntldr/winldr.h
+++ b/boot/freeldr/freeldr/ntldr/winldr.h
@@ -1,0 +1,151 @@
+/*
+ *  FreeLoader
+ *  Copyright (C) 1998-2003  Brian Palmer    <brianp@sginet.com>
+ *  Copyright (C) 2006       Aleksey Bragin  <aleksey@reactos.org>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License along
+ *  with this program; if not, write to the Free Software Foundation, Inc.,
+ *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#pragma once
+
+#include <arc/setupblk.h>
+
+#if 0
+// See freeldr/include/winldr.h
+#define TAG_WLDR_DTE 'eDlW'
+#define TAG_WLDR_BDE 'dBlW'
+#define TAG_WLDR_NAME 'mNlW'
+
+#endif
+
+/* Entry-point to kernel */
+typedef VOID (NTAPI *KERNEL_ENTRY_POINT) (PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+
+// Some definitions
+
+#if 0
+
+// Descriptors
+#define NUM_GDT 128     // Must be 128
+#define NUM_IDT 0x100   // Only 16 are used though. Must be 0x100
+
+#include <pshpack1.h>
+typedef struct  /* Root System Descriptor Pointer */
+{
+    CHAR             signature [8];          /* contains "RSD PTR " */
+    UCHAR            checksum;               /* to make sum of struct == 0 */
+    CHAR             oem_id [6];             /* OEM identification */
+    UCHAR            revision;               /* Must be 0 for 1.0, 2 for 2.0 */
+    ULONG            rsdt_physical_address;  /* 32-bit physical address of RSDT */
+    ULONG            length;                 /* XSDT Length in bytes including hdr */
+    ULONGLONG        xsdt_physical_address;  /* 64-bit physical address of XSDT */
+    UCHAR            extended_checksum;      /* Checksum of entire table */
+    CHAR             reserved [3];           /* reserved field must be 0 */
+} RSDP_DESCRIPTOR, *PRSDP_DESCRIPTOR;
+#include <poppack.h>
+
+typedef struct _ARC_DISK_SIGNATURE_EX
+{
+    ARC_DISK_SIGNATURE DiskSignature;
+    CHAR ArcName[MAX_PATH];
+} ARC_DISK_SIGNATURE_EX, *PARC_DISK_SIGNATURE_EX;
+
+#endif
+
+#define MAX_OPTIONS_LENGTH 255
+
+typedef struct _LOADER_SYSTEM_BLOCK
+{
+    LOADER_PARAMETER_BLOCK LoaderBlock;
+    LOADER_PARAMETER_EXTENSION Extension;
+    SETUP_LOADER_BLOCK SetupBlock;
+#ifdef _M_IX86
+    HEADLESS_LOADER_BLOCK HeadlessLoaderBlock;
+#endif
+    NLS_DATA_BLOCK NlsDataBlock;
+    CHAR LoadOptions[MAX_OPTIONS_LENGTH+1];
+    CHAR ArcBootDeviceName[MAX_PATH+1];
+    // CHAR ArcHalDeviceName[MAX_PATH];
+    CHAR NtBootPathName[MAX_PATH+1];
+    CHAR NtHalPathName[MAX_PATH+1];
+    ARC_DISK_INFORMATION ArcDiskInformation;
+} LOADER_SYSTEM_BLOCK, *PLOADER_SYSTEM_BLOCK;
+
+extern PLOADER_SYSTEM_BLOCK WinLdrSystemBlock;
+
+
+// conversion.c
+#if 0
+PVOID VaToPa(PVOID Va);
+PVOID PaToVa(PVOID Pa);
+VOID List_PaToVa(_In_ LIST_ENTRY *ListEntry);
+#endif
+VOID ConvertConfigToVA(PCONFIGURATION_COMPONENT_DATA Start);
+
+
+// winldr.c
+PVOID WinLdrLoadModule(PCSTR ModuleName, ULONG *Size,
+                       TYPE_OF_MEMORY MemoryType);
+
+// wlmemory.c
+BOOLEAN
+WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+// wlregistry.c
+BOOLEAN
+WinLdrInitSystemHive(
+    IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
+    IN PCSTR SystemRoot,
+    IN BOOLEAN Setup);
+
+BOOLEAN WinLdrScanSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
+                             IN LPCSTR DirectoryPath);
+
+// winldr.c
+VOID
+WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
+                       LPCSTR Options,
+                       LPCSTR SystemPath,
+                       LPCSTR BootPath,
+                       USHORT VersionToBoot);
+BOOLEAN
+WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
+                  IN LPCSTR DirectoryPath,
+                  IN LPCSTR AnsiFileName,
+                  IN LPCSTR OemFileName,
+                  IN LPCSTR LanguageFileName);
+BOOLEAN
+WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
+                      LPWSTR RegistryPath,
+                      LPWSTR ImagePath,
+                      LPWSTR ServiceName);
+
+VOID
+WinLdrpDumpMemoryDescriptors(PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+VOID
+WinLdrpDumpBootDriver(PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+VOID
+WinLdrpDumpArcDisks(PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+VOID
+LoadAndBootWindowsCommon(
+    USHORT OperatingSystemVersion,
+    PLOADER_PARAMETER_BLOCK LoaderBlock,
+    LPCSTR BootOptions,
+    LPCSTR BootPath,
+    BOOLEAN Setup);

--- a/boot/freeldr/freeldr/ntldr/wlmemory.c
+++ b/boot/freeldr/freeldr/ntldr/wlmemory.c
@@ -9,6 +9,7 @@
 /* INCLUDES ***************************************************************/
 
 #include <freeldr.h>
+#include "winldr.h"
 
 #include <debug.h>
 

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -9,6 +9,7 @@
 /* INCLUDES ***************************************************************/
 
 #include <freeldr.h>
+#include "winldr.h"
 #include "registry.h"
 
 #include <debug.h>

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -30,20 +30,21 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
 
 /* FUNCTIONS **************************************************************/
 
-BOOLEAN
-WinLdrLoadSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
-                     IN LPCSTR DirectoryPath,
-                     IN LPCSTR HiveName)
+static BOOLEAN
+WinLdrLoadSystemHive(
+    IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
+    IN PCSTR DirectoryPath,
+    IN PCSTR HiveName)
 {
     ULONG FileId;
-    CHAR FullHiveName[256];
+    CHAR FullHiveName[MAX_PATH];
     ARC_STATUS Status;
     FILEINFORMATION FileInfo;
     ULONG HiveFileSize;
     ULONG_PTR HiveDataPhysical;
     PVOID HiveDataVirtual;
     ULONG BytesRead;
-    LPCWSTR FsService;
+    PCWSTR FsService;
 
     /* Concatenate path and filename to get the full name */
     strcpy(FullHiveName, DirectoryPath);
@@ -94,7 +95,7 @@ WinLdrLoadSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
         return FALSE;
     }
 
-    // Add boot filesystem driver to the list
+    /* Add boot filesystem driver to the list */
     FsService = FsGetServiceName(FileId);
     if (FsService)
     {
@@ -116,25 +117,40 @@ WinLdrLoadSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     return TRUE;
 }
 
-BOOLEAN WinLdrInitSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
-                             IN LPCSTR DirectoryPath)
+BOOLEAN
+WinLdrInitSystemHive(
+    IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
+    IN PCSTR SystemRoot,
+    IN BOOLEAN Setup)
 {
     CHAR SearchPath[1024];
+    PCSTR HiveName;
     BOOLEAN Success;
 
-    // There is a simple logic here: try to load usual hive (system), if it
-    // fails, then give system.alt a try, and finally try a system.sav
+    if (Setup)
+    {
+        strcpy(SearchPath, SystemRoot);
+        HiveName = "SETUPREG.HIV";
+    }
+    else
+    {
+        // There is a simple logic here: try to load usual hive (system), if it
+        // fails, then give system.alt a try, and finally try a system.sav
 
-    // FIXME: For now we only try system
-    strcpy(SearchPath, DirectoryPath);
-    strcat(SearchPath, "system32\\config\\");
-    Success = WinLdrLoadSystemHive(LoaderBlock, SearchPath, "SYSTEM");
+        // FIXME: For now we only try system
+        strcpy(SearchPath, SystemRoot);
+        strcat(SearchPath, "system32\\config\\");
+        HiveName = "SYSTEM";
+    }
 
-    // Fail if failed...
+    ERR("WinLdrInitSystemHive: try to load hive %s%s\n", SearchPath, HiveName);
+    Success = WinLdrLoadSystemHive(LoaderBlock, SearchPath, HiveName);
+
+    /* Fail if failed... */
     if (!Success)
         return FALSE;
 
-    // Import what was loaded
+    /* Import what was loaded */
     Success = RegImportBinaryHive(VaToPa(LoaderBlock->RegistryBase), LoaderBlock->RegistryLength);
     if (!Success)
     {
@@ -142,7 +158,7 @@ BOOLEAN WinLdrInitSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
         return FALSE;
     }
 
-    // Initialize the 'CurrentControlSet' link
+    /* Initialize the 'CurrentControlSet' link */
     if (RegInitCurrentControlSet(FALSE) != ERROR_SUCCESS)
     {
         UiMessageBox("Initializing CurrentControlSet link failed!");
@@ -159,10 +175,10 @@ BOOLEAN WinLdrScanSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     CHAR AnsiName[256], OemName[256], LangName[256];
     BOOLEAN Success;
 
-    // Scan registry and prepare boot drivers list
+    /* Scan registry and prepare boot drivers list */
     WinLdrScanRegistry(&LoaderBlock->BootDriverListHead, DirectoryPath);
 
-    // Get names of NLS files
+    /* Get names of NLS files */
     Success = WinLdrGetNLSNames(AnsiName, OemName, LangName);
     if (!Success)
     {
@@ -172,13 +188,15 @@ BOOLEAN WinLdrScanSystemHive(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
 
     TRACE("NLS data %s %s %s\n", AnsiName, OemName, LangName);
 
-    // Load NLS data
+    /* Load NLS data */
     strcpy(SearchPath, DirectoryPath);
     strcat(SearchPath, "system32\\");
     Success = WinLdrLoadNLSData(LoaderBlock, SearchPath, AnsiName, OemName, LangName);
     TRACE("NLS data loading %s\n", Success ? "successful" : "failed");
 
     /* TODO: Load OEM HAL font */
+    // In HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Nls\CodePage,
+    // REG_SZ value "OEMHAL"
 
     return TRUE;
 }
@@ -208,7 +226,7 @@ WinLdrGetNLSNames(LPSTR AnsiName,
         return FALSE;
     }
 
-    /* get ANSI codepage */
+    /* Get ANSI codepage */
     BufferSize = sizeof(szIdBuffer);
     rc = RegQueryValue(hKey, L"ACP", NULL, (PUCHAR)szIdBuffer, &BufferSize);
     if (rc != ERROR_SUCCESS)
@@ -227,7 +245,7 @@ WinLdrGetNLSNames(LPSTR AnsiName,
     }
     sprintf(AnsiName, "%S", NameBuffer);
 
-    /* get OEM codepage */
+    /* Get OEM codepage */
     BufferSize = sizeof(szIdBuffer);
     rc = RegQueryValue(hKey, L"OEMCP", NULL, (PUCHAR)szIdBuffer, &BufferSize);
     if (rc != ERROR_SUCCESS)
@@ -246,7 +264,7 @@ WinLdrGetNLSNames(LPSTR AnsiName,
     }
     sprintf(OemName, "%S", NameBuffer);
 
-    /* open the language key */
+    /* Open the language key */
     rc = RegOpenKey(NULL,
         L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language",
         &hKey);
@@ -256,7 +274,7 @@ WinLdrGetNLSNames(LPSTR AnsiName,
         return FALSE;
     }
 
-    /* get the Unicode case table */
+    /* Get the Unicode case table */
     BufferSize = sizeof(szIdBuffer);
     rc = RegQueryValue(hKey, L"Default", NULL, (PUCHAR)szIdBuffer, &BufferSize);
     if (rc != ERROR_SUCCESS)

--- a/ntoskrnl/config/cmlazy.c
+++ b/ntoskrnl/config/cmlazy.c
@@ -262,8 +262,9 @@ CmpCmdInit(IN BOOLEAN SetupBoot)
     /* Testing: Force Lazy Flushing */
     CmpHoldLazyFlush = FALSE;
 
-    /* Setup the hive list */
-    CmpInitializeHiveList(SetupBoot);
+    /* Setup the hive list if this is not a Setup boot */
+    if (!SetupBoot)
+        CmpInitializeHiveList();
 }
 
 NTSTATUS

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1166,75 +1166,27 @@ CmpCreateRegistryRoot(VOID)
     return TRUE;
 }
 
-NTSTATUS
-NTAPI
+static NTSTATUS
 CmpGetRegistryPath(OUT PWCHAR ConfigPath)
 {
-    OBJECT_ATTRIBUTES ObjectAttributes;
-    NTSTATUS Status;
-    HANDLE KeyHandle;
-    PKEY_VALUE_PARTIAL_INFORMATION ValueInfo;
-    UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\Machine\\HARDWARE");
-    UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"InstallPath");
-    ULONG BufferSize, ResultSize;
+    /* Just use default path */
+    wcscpy(ConfigPath, L"\\SystemRoot");
 
     /* Check if we are booted in setup */
-    if (ExpInTextModeSetup)
+    if (!ExpInTextModeSetup)
     {
-        DPRINT1("CmpGetRegistryPath TextMode setup HACK!!\n");
-
-        /* Setup the object attributes */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &KeyName,
-                                   OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
-                                   NULL,
-                                   NULL);
-        /* Open the key */
-        Status =  ZwOpenKey(&KeyHandle,
-                            KEY_ALL_ACCESS,
-                            &ObjectAttributes);
-        if (!NT_SUCCESS(Status)) return Status;
-
-        /* Allocate the buffer */
-        BufferSize = sizeof(KEY_VALUE_PARTIAL_INFORMATION) + 4096;
-        ValueInfo = ExAllocatePoolWithTag(PagedPool, BufferSize, TAG_CM);
-        if (!ValueInfo)
-        {
-            /* Fail */
-            ZwClose(KeyHandle);
-            return STATUS_INSUFFICIENT_RESOURCES;
-        }
-
-        /* Query the value */
-        Status = ZwQueryValueKey(KeyHandle,
-                                 &ValueName,
-                                 KeyValuePartialInformation,
-                                 ValueInfo,
-                                 BufferSize,
-                                 &ResultSize);
-        ZwClose(KeyHandle);
-        if (!NT_SUCCESS(Status))
-        {
-            /* Fail */
-            ExFreePoolWithTag(ValueInfo, TAG_CM);
-            return Status;
-        }
-
-        /* Copy the config path and null-terminate it */
-        RtlCopyMemory(ConfigPath,
-                      ValueInfo->Data,
-                      ValueInfo->DataLength);
-        ConfigPath[ValueInfo->DataLength / sizeof(WCHAR)] = UNICODE_NULL;
-        ExFreePoolWithTag(ValueInfo, TAG_CM);
+        /* Add registry path */
+#if 0
+        ResultSize = wcslen(ConfigPath);
+        if (ResultSize && ConfigPath[ResultSize - 1] == L'\\')
+            ConfigPath[ResultSize - 1] = UNICODE_NULL;
+#endif
+        wcscat(ConfigPath, L"\\System32\\Config\\");
     }
     else
     {
-        /* Just use default path */
-        wcscpy(ConfigPath, L"\\SystemRoot");
+        wcscat(ConfigPath, L"\\");
     }
-
-    /* Add registry path */
-    wcscat(ConfigPath, L"\\System32\\Config\\");
 
     DPRINT1("CmpGetRegistryPath: ConfigPath = '%S'\n", ConfigPath);
 

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -396,10 +396,11 @@ NTAPI
 INIT_FUNCTION
 CmpSetSystemValues(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-    OBJECT_ATTRIBUTES ObjectAttributes;
-    UNICODE_STRING KeyName, ValueName = { 0, 0, NULL };
-    HANDLE KeyHandle = NULL;
     NTSTATUS Status;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    HANDLE KeyHandle;
+    UNICODE_STRING KeyName, ValueName = { 0, 0, NULL };
+
     ASSERT(LoaderBlock != NULL);
 
     /* Setup attributes for loader options */
@@ -412,9 +413,10 @@ CmpSetSystemValues(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                                NULL,
                                NULL);
     Status = NtOpenKey(&KeyHandle, KEY_WRITE, &ObjectAttributes);
-    if (!NT_SUCCESS(Status)) goto Quickie;
+    if (!NT_SUCCESS(Status))
+        return Status;
 
-    /* Key opened, now write to the key */
+    /* Setup the value for the system start options */
     RtlInitUnicodeString(&KeyName, L"SystemStartOptions");
     Status = NtSetValueKey(KeyHandle,
                            &KeyName,
@@ -422,9 +424,10 @@ CmpSetSystemValues(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                            REG_SZ,
                            CmpLoadOptions.Buffer,
                            CmpLoadOptions.Length);
-    if (!NT_SUCCESS(Status)) goto Quickie;
+    if (!NT_SUCCESS(Status))
+        goto Quit;
 
-    /* Setup value name for system boot device in ARC format */
+    /* Setup the value for the system boot device in ARC format */
     RtlInitUnicodeString(&KeyName, L"SystemBootDevice");
     RtlCreateUnicodeStringFromAsciiz(&ValueName, LoaderBlock->ArcBootDeviceName);
     Status = NtSetValueKey(KeyHandle,
@@ -434,15 +437,13 @@ CmpSetSystemValues(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                            ValueName.Buffer,
                            ValueName.Length);
 
-Quickie:
-    /* Free the buffers */
+    /* Free the temporary string */
     RtlFreeUnicodeString(&ValueName);
 
+Quit:
     /* Close the key and return */
-    if (KeyHandle) NtClose(KeyHandle);
-
-    /* Return the status */
-    return (ExpInTextModeSetup ? STATUS_SUCCESS : Status);
+    NtClose(KeyHandle);
+    return Status;
 }
 
 static
@@ -1409,7 +1410,7 @@ CmpLoadHiveThread(IN PVOID StartContext)
 
 VOID
 NTAPI
-CmpInitializeHiveList(IN USHORT Flag)
+CmpInitializeHiveList(VOID)
 {
     WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH], ConfigPath[MAX_PATH];
     UNICODE_STRING TempName, FileName, RegName;

--- a/ntoskrnl/config/i386/cmhardwr.c
+++ b/ntoskrnl/config/i386/cmhardwr.c
@@ -401,12 +401,7 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
                          NULL,
                          REG_OPTION_NON_VOLATILE,
                          &Disposition);
-    if (ExpInTextModeSetup)
-    {
-        if (!NT_SUCCESS(Status))
-            BiosHandle = NULL;
-    }
-    else if (!NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         NtClose(SystemHandle);
         return Status;

--- a/ntoskrnl/config/ntapi.c
+++ b/ntoskrnl/config/ntapi.c
@@ -1302,7 +1302,8 @@ NtInitializeRegistry(IN USHORT Flag)
     PAGED_CODE();
 
     /* Always do this as kernel mode */
-    if (KeGetPreviousMode() == UserMode) return ZwInitializeRegistry(Flag);
+    if (KeGetPreviousMode() == UserMode)
+        return ZwInitializeRegistry(Flag);
 
     /* Enough of the system has booted by now */
     Ki386PerfEnd();
@@ -1344,8 +1345,8 @@ NtInitializeRegistry(IN USHORT Flag)
     if (!CmFirstTime) return STATUS_ACCESS_DENIED;
     CmFirstTime = FALSE;
 
-    /* Acquire registry lock */
-    //CmpLockRegistryExclusive();
+    /* Lock the registry exclusively */
+    CmpLockRegistryExclusive();
 
     /* Initialize the hives and lazy flusher */
     CmpCmdInit(SetupBoot);
@@ -1354,7 +1355,7 @@ NtInitializeRegistry(IN USHORT Flag)
     CmpSetVersionData();
 
     /* Release the registry lock */
-    //CmpUnlockRegistry();
+    CmpUnlockRegistry();
     return STATUS_SUCCESS;
 }
 

--- a/ntoskrnl/config/powerpc/cmhardwr.c
+++ b/ntoskrnl/config/powerpc/cmhardwr.c
@@ -306,12 +306,7 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
                          NULL,
                          REG_OPTION_NON_VOLATILE,
                          &Disposition);
-    if (ExpInTextModeSetup)
-    {
-        if (!NT_SUCCESS(Status))
-            BiosHandle = NULL;
-    }
-    else if (!NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         NtClose(SystemHandle);
         return Status;

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -963,7 +963,8 @@ ExpInitializeExecutive(IN ULONG Cpu,
     if (LoaderBlock->SetupLdrBlock)
     {
         /* Check if this is text-mode setup */
-        if (LoaderBlock->SetupLdrBlock->Flags & SETUPLDR_TEXT_MODE) ExpInTextModeSetup = TRUE;
+        if (LoaderBlock->SetupLdrBlock->Flags & SETUPLDR_TEXT_MODE)
+            ExpInTextModeSetup = TRUE;
 
         /* Check if this is network boot */
         if (LoaderBlock->SetupLdrBlock->Flags & SETUPLDR_REMOTE_BOOT)

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -859,7 +859,7 @@ CmpInitHiveFromFile(
 VOID
 NTAPI
 CmpInitializeHiveList(
-    IN USHORT Flag
+    VOID
 );
 
 //

--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -322,6 +322,7 @@ IopLoadServiceModule(
     if (ExpInTextModeSetup)
     {
         /* We have no registry, but luckily we know where all the drivers are */
+        DPRINT1("IopLoadServiceModule(%wZ, 0x%p) called in ExpInTextModeSetup mode...\n", ServiceName, ModuleObject);
 
         /* ServiceStart < 4 is all that matters */
         ServiceStart = 0;
@@ -1044,8 +1045,13 @@ IopInitializeBootDrivers(VOID)
                                           NULL,
                                           &BootEntry->RegistryPath,
                                           KEY_READ);
+            DPRINT1("IopOpenRegistryKeyEx(%wZ) returned 0x%08lx\n", &BootEntry->RegistryPath, Status);
+#if 0
+            if (NT_SUCCESS(Status))
+#else // Hack still needed...
             if ((NT_SUCCESS(Status)) || /* ReactOS HACK for SETUPLDR */
                 ((KeLoaderBlock->SetupLdrBlock) && ((KeyHandle = (PVOID)1)))) // yes, it's an assignment!
+#endif
             {
                 /* Save the handle */
                 DriverInfo->ServiceHandle = KeyHandle;
@@ -1122,7 +1128,7 @@ IopInitializeSystemDrivers(VOID)
     PUNICODE_STRING *DriverList, *SavedList;
 
     /* No system drivers on the boot cd */
-    if (KeLoaderBlock->SetupLdrBlock) return;
+    if (KeLoaderBlock->SetupLdrBlock) return; // ExpInTextModeSetup
 
     /* Get the driver list */
     SavedList = DriverList = CmGetSystemDriverList();

--- a/ntoskrnl/io/pnpmgr/pnpinit.c
+++ b/ntoskrnl/io/pnpmgr/pnpinit.c
@@ -56,17 +56,6 @@ PiInitCacheGroupInformation(VOID)
         RTL_CONSTANT_STRING(L"\\Registry\\Machine\\System\\CurrentControlSet"
                             L"\\Control\\ServiceGroupOrder");
 
-    /* ReactOS HACK for SETUPLDR */
-    if (KeLoaderBlock->SetupLdrBlock)
-    {
-        DPRINT1("WARNING!! In PiInitCacheGroupInformation, using ReactOS HACK for SETUPLDR!!\n");
-
-        /* Bogus data */
-        PiInitGroupOrderTableCount = 0;
-        PiInitGroupOrderTable = (PVOID)(ULONG_PTR)0xBABEB00BBABEB00BULL;
-        return STATUS_SUCCESS;
-    }
-
     /* Open the registry key */
     Status = IopOpenRegistryKeyEx(&KeyHandle,
                                   NULL,

--- a/ntoskrnl/io/pnpmgr/pnpreport.c
+++ b/ntoskrnl/io/pnpmgr/pnpreport.c
@@ -284,8 +284,7 @@ IoReportDetectedDevice(IN PDRIVER_OBJECT DriverObject,
     IopActionConfigureChildServices(DeviceNode, DeviceNode->Parent);
 
     /* Open a handle to the instance path key */
-    /* REG_OPTION_VOLATILE is a HACK!!! */
-    Status = IopCreateDeviceKeyPath(&DeviceNode->InstancePath, REG_OPTION_VOLATILE, &InstanceKey);
+    Status = IopCreateDeviceKeyPath(&DeviceNode->InstancePath, REG_OPTION_NON_VOLATILE, &InstanceKey);
     if (!NT_SUCCESS(Status))
         return Status;
 

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -811,7 +811,7 @@ function(create_registry_hives)
     # BootCD setup system hive
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/boot/bootdata/SETUPREG.HIV
-        COMMAND native-mkhive -h:SETUPREG -u -d:${CMAKE_BINARY_DIR}/boot/bootdata ${CMAKE_BINARY_DIR}/boot/bootdata/hivesys_utf16.inf
+        COMMAND native-mkhive -h:SETUPREG -u -d:${CMAKE_BINARY_DIR}/boot/bootdata ${CMAKE_BINARY_DIR}/boot/bootdata/hivesys_utf16.inf ${CMAKE_SOURCE_DIR}/boot/bootdata/setupreg.inf
         DEPENDS native-mkhive ${CMAKE_BINARY_DIR}/boot/bootdata/hivesys_utf16.inf)
 
     add_custom_target(bootcd_hives


### PR DESCRIPTION
- Make FreeLdr load a registry hive in setup mode.
- Remove ReactOS-specific NTOS registry 1-st-stage hacks.