### PR TITLE
CORE-11836. VSSolution: Fix MSI_WINETEST compile error with VS10 and VS12

### DIFF
--- a/modules/rostests/winetests/msi/CMakeLists.txt
+++ b/modules/rostests/winetests/msi/CMakeLists.txt
@@ -3,6 +3,11 @@ add_definitions(
     -DUSE_WINE_TODOS
     -D__WINESRC__)
 
+if(MSVC_IDE)
+    # msi_winetest.rc: let rc.exe find custom.dll in its subdirectory, i.e. Debug.
+    include_directories($<TARGET_FILE_DIR:custom>)
+endif()
+
 spec2def(custom.dll custom.spec)
 add_library(custom SHARED custom.c ${CMAKE_CURRENT_BINARY_DIR}/custom.def)
 target_link_libraries(custom uuid)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11836](https://jira.reactos.org/browse/CORE-11836)

## Proposed changes

- MSVC_IDE: Add an 'include_directories()'