### PR TITLE
[MSPAINT] Fix call sequence in OnRButtonUp

### DIFF
--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -291,8 +291,8 @@ LRESULT CImgAreaWindow::OnRButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         }
         SendMessage(hStatusBar, SB_SETTEXT, 2, (LPARAM) "");
     }
-    ReleaseCapture();
     drawing = FALSE;
+    ReleaseCapture();
     return 0;
 }
 


### PR DESCRIPTION
This fixes unexpected undo action when zooming out with right mouse
click.

The call sequence in OnLButtonUp is already correct.

CORE-14539