### PR TITLE
CORE-11836. [CONFIGURE][CMAKE] Remove Visual Studio 9 (2008) support

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -62,7 +62,6 @@ if defined ROS_ARCH (
     cl 2>&1 | find "x86" > NUL && set ARCH=i386
     cl 2>&1 | find "x64" > NUL && set ARCH=amd64
     cl 2>&1 | find "ARM" > NUL && set ARCH=arm
-    cl 2>&1 | find "15.00." > NUL && set VS_VERSION=9
     cl 2>&1 | find "16.00." > NUL && set VS_VERSION=10
     cl 2>&1 | find "17.00." > NUL && set VS_VERSION=11
     cl 2>&1 | find "18.00." > NUL && set VS_VERSION=12
@@ -72,7 +71,7 @@ if defined ROS_ARCH (
     cl 2>&1 | find "19.12." > NUL && set VS_VERSION=15
     cl 2>&1 | find "19.13." > NUL && set VS_VERSION=15
     if not defined VS_VERSION (
-        echo Error: Visual Studio version too old or version detection failed.
+        echo Error: Visual Studio version too old ^(before 10 ^(2010^)^) or version detection failed.
         goto quit
     )
     set BUILD_ENVIRONMENT=VS
@@ -138,13 +137,7 @@ REM Parse command line parameters
                 set VS_VERSION=%3
                 echo Visual Studio Environment set to !BUILD_ENVIRONMENT!!VS_VERSION!-!ARCH!
             )
-            if "!VS_VERSION!" == "9" (
-                if "!ARCH!" == "amd64" (
-                    set CMAKE_GENERATOR="Visual Studio 9 2008 Win64"
-                ) else (
-                    set CMAKE_GENERATOR="Visual Studio 9 2008"
-                )
-            ) else if "!VS_VERSION!" == "10" (
+            if "!VS_VERSION!" == "10" (
                 if "!ARCH!" == "amd64" (
                     set CMAKE_GENERATOR="Visual Studio 10 Win64"
                 ) else (

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -149,15 +149,8 @@ if(MSVC_IDE AND (CMAKE_VERSION MATCHES "ReactOS"))
     # For VS builds we'll only have en-US in resource files
     add_definitions(/DLANGUAGE_EN_US)
 else()
-    # Only VS 10+ resource compiler supports /nologo
-    # CMAKE_CXX_SIMULATE_VERSION is a similar check for our clang-cl builds
-    if((MSVC_VERSION GREATER 1599) OR (CMAKE_CXX_SIMULATE_VERSION VERSION_GREATER 15.99))
-        set(rc_nologo_flag "/nologo")
-    else()
-        set(rc_nologo_flag)
-    endif()
     if(CMAKE_VERSION VERSION_LESS 3.4.0)
-        set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_nologo_flag} <FLAGS> <DEFINES> ${I18N_DEFS} /fo<OBJECT> <SOURCE>")
+        set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> /nologo <FLAGS> <DEFINES> ${I18N_DEFS} /fo<OBJECT> <SOURCE>")
         if(ARCH STREQUAL "arm")
             set(CMAKE_ASM_COMPILE_OBJECT
                 "cl ${cl_includes_flag} /nologo /X /I${REACTOS_SOURCE_DIR}/sdk/include/asm /I${REACTOS_BINARY_DIR}/sdk/include/asm <FLAGS> <DEFINES> /D__ASM__ /D_USE_ML /EP /c <SOURCE> > <OBJECT>.tmp"
@@ -168,7 +161,7 @@ else()
                 "<CMAKE_ASM_COMPILER> /nologo /Cp /Fo<OBJECT> /c /Ta <OBJECT>.tmp")
         endif()
     else()
-        set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> ${rc_nologo_flag} <INCLUDES> <FLAGS> <DEFINES> ${I18N_DEFS} /fo<OBJECT> <SOURCE>")
+        set(CMAKE_RC_COMPILE_OBJECT "<CMAKE_RC_COMPILER> /nologo <INCLUDES> <FLAGS> <DEFINES> ${I18N_DEFS} /fo<OBJECT> <SOURCE>")
         if(ARCH STREQUAL "arm")
             set(CMAKE_ASM_COMPILE_OBJECT
                 "cl ${cl_includes_flag} /nologo /X /I${REACTOS_SOURCE_DIR}/sdk/include/asm /I${REACTOS_BINARY_DIR}/sdk/include/asm <INCLUDES> <FLAGS> <DEFINES> /D__ASM__ /D_USE_ML /EP /c <SOURCE> > <OBJECT>.tmp"


### PR DESCRIPTION
## Purpose

ReactOS does not compile anymore with it. ([ninja](https://ci.appveyor.com/project/SergeGautherie/reactos/build/VS9-ninja.reactos.appveyor.495), [msbuild](https://ci.appveyor.com/project/SergeGautherie/reactos/build/reactos.appveyor.488))
VS9 is already officially unsupported. ([CMake](https://www.reactos.org/wiki/CMake), [Building ReactOS](https://www.reactos.org/wiki/Building_ReactOS))

JIRA issue: [CORE-11836](https://jira.reactos.org/browse/CORE-11836)

## Proposed changes

- Remove Visual Studio 9 (2008) support

## TODO

Question:

- [ ] Should `sdk/cmake` remain unchanged?
