### PR TITLE
[RSHELL] Remove a duplicated add_custom_command() call

### DIFF
--- a/base/shell/rshell/CMakeLists.txt
+++ b/base/shell/rshell/CMakeLists.txt
@@ -49,9 +49,3 @@ add_custom_command(TARGET rshell POST_BUILD
      "$<TARGET_FILE:rshell>"
      "$<TARGET_FILE_DIR:filebrowser>/$<TARGET_FILE_NAME:rshell>" 
   COMMENT "Copying to output directory")
-
-add_custom_command(TARGET rshell POST_BUILD 
-  COMMAND "${CMAKE_COMMAND}" -E copy 
-     "$<TARGET_FILE:rshell>"
-     "$<TARGET_FILE_DIR:filebrowser>/$<TARGET_FILE_NAME:rshell>" 
-  COMMENT "Copying to output directory")


### PR DESCRIPTION
## Purpose

I guess duplication is useless, isn't it?

Added on [r62448](https://svn.reactos.org/svn/reactos?view=revision&revision=62448), duplicated on [r62449](https://svn.reactos.org/svn/reactos?view=revision&revision=62449).

@gigaherz, simple copypasta? Or was one meant to be `explorer-new`?
