### PR TITLE
[BROWSEUI] Remove a duplicated add_custom_command() call

### DIFF
--- a/dll/win32/browseui/CMakeLists.txt
+++ b/dll/win32/browseui/CMakeLists.txt
@@ -62,9 +62,3 @@ add_custom_command(TARGET browseui POST_BUILD
      "$<TARGET_FILE:browseui>"
      "$<TARGET_FILE_DIR:filebrowser>/$<TARGET_FILE_NAME:browseui>" 
   COMMENT "Copying to output directory")
-
-add_custom_command(TARGET browseui POST_BUILD 
-  COMMAND "${CMAKE_COMMAND}" -E copy 
-     "$<TARGET_FILE:browseui>"
-     "$<TARGET_FILE_DIR:filebrowser>/$<TARGET_FILE_NAME:browseui>" 
-  COMMENT "Copying to output directory")


### PR DESCRIPTION
## Purpose

I guess duplication is useless, isn't it?

Double-added on [r65496](https://svn.reactos.org/svn/reactos?view=revision&revision=65496).

@AmineKhaldi, simple copypasta? Or, wild guess, was one meant to be maybe `explorer`?
