### PR TITLE
[CMAKE] MSVC_IDE: Enable 'unset(CMAKE_IMPORT_LIBRARY_SUFFIX)'

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,11 +106,8 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif()
 
 else()
-	# We don't need CMake importlib handling.
-	# FIXME: Remove the MSVC_IDE condition when the upcoming RosBE lands.
-	if(NOT MSVC_IDE)
-		unset(CMAKE_IMPORT_LIBRARY_SUFFIX)
-	endif()
+    # We don't need CMake importlib handling.
+    unset(CMAKE_IMPORT_LIBRARY_SUFFIX)
 
     if(NEW_STYLE_BUILD)
         include(sdk/cmake/host-tools.cmake)


### PR DESCRIPTION
## Purpose

Compiles fine with "CMake_321-ROS + VS10 + msbuild".

@AmineKhaldi

## Proposed changes

- Resolve [r67773](https://svn.reactos.org/svn/reactos?view=revision&revision=67773) "# FIXME: Remove the MSVC_IDE condition when the upcoming RosBE lands.".
