### PR TITLE
[MSPAINT] Store subsequent changes to file selected via Save As

### DIFF
--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -94,6 +94,7 @@ void CMainWindow::saveImage(BOOL overwrite)
     else if (GetSaveFileName(&sfn) != 0)
     {
         imageModel.SaveImage(sfn.lpstrFile);
+        _tcsncpy(filepathname, sfn.lpstrFile, SIZEOF(filepathname));
         CString strTitle;
         strTitle.Format(IDS_WINDOWTITLE, (LPCTSTR)sfn.lpstrFileTitle);
         SetWindowText(strTitle);


### PR DESCRIPTION
## Purpose

Store subsequent changes to file selected via Save As.
Paint has erroneously been storing subsequent changes to Unnamed.bmp.

JIRA issue: [CORE-13291](https://jira.reactos.org/browse/CORE-13291)

## Proposed changes

This merely adds a forgotten `_tcsncpy`.
