### PR TITLE
[CMAKE] Add "--always" parameter to "git describe" call

### DIFF
--- a/sdk/include/reactos/version.cmake
+++ b/sdk/include/reactos/version.cmake
@@ -39,7 +39,7 @@ if(EXISTS "${REACTOS_SOURCE_DIR}/.git")
         endif()
 
         execute_process(
-            COMMAND "${GIT_EXECUTABLE}" describe --abbrev=7 --long
+            COMMAND "${GIT_EXECUTABLE}" describe --abbrev=7 --long --always
             WORKING_DIRECTORY ${REACTOS_SOURCE_DIR}
             OUTPUT_VARIABLE GIT_DESCRIBE_REVISION
             RESULT_VARIABLE GIT_CALL_RESULT


### PR DESCRIPTION
## Purpose

"fatal: No names found, cannot describe anything." message,
when called without enough history, i.e. appveyor.yml `clone_depth: 5`.

Same issue with a local shallow clone.

[git-describe](https://www.git-scm.com/docs/git-describe/2.9.3)