### PR TITLE
CORE-11789. [SYSDM] AddUserProfile(): Call HeapFree() when _not_ NULL

### DIFF
--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -141,14 +141,14 @@ AddUserProfile(HWND hwndListView,
     ListView_InsertItem(hwndListView, &lvi);
 
 done:
-    if (pProfileData == NULL)
+    if (pProfileData != NULL)
         HeapFree(GetProcessHeap(), 0, pProfileData);
 
-    if (pszDomainName == NULL)
-        HeapFree(GetProcessHeap(), 0, pszDomainName);
-
-    if (pszAccountName == NULL)
+    if (pszAccountName != NULL)
         HeapFree(GetProcessHeap(), 0, pszAccountName);
+
+    if (pszDomainName != NULL)
+        HeapFree(GetProcessHeap(), 0, pszDomainName);
 
     if (pSid != NULL)
         LocalFree(pSid);


### PR DESCRIPTION
## Purpose

Typos in e3905cc68a0d85d183c86924f8b30fbcfda14c6b.

JIRA issue: [CORE-11789](https://jira.reactos.org/browse/CORE-11789)

@EricKohl

## Proposed changes

- Call `HeapFree()` when _not_ `NULL`
- Also use reverse order.
