### PR TITLE
[CMD] Fix 'DIR .' and 'DIR ..' behavior

### DIFF
--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1419,7 +1419,7 @@ DirList(LPTSTR szPath,              /* [IN] The path that dir starts */
     pchDotExt = IntPathFindExtension(szFullPath);
     if (*pchDotExt == _T('.') && szFullPath < pchDotExt)
     {
-        if (wcschr(_T(".\\/"), *(pchDotExt - 1)) != NULL)
+        if (wcschr(_T(".\\/"), *(pchDotExt - 1)) == NULL)
         {
             /* Kill the dot-only extension */
             *pchDotExt = 0;


### PR DESCRIPTION
## Purpose

There was a problem in cmd.exe that 'DIR .' and 'DIR ..' commands won't show normal file.
This PR fixes it.

JIRA issue: [CORE-13961](https://jira.reactos.org/browse/CORE-13961)

## Proposed changes

- Add inline function "IsIgnoredDots".
- Fix the handling about dots.