### PR TITLE
[SYSSETUP] Fix a DPH report about dwPageCount

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2503,7 +2503,7 @@ InstallWizard(VOID)
     PSETUPDATA pSetupData = NULL;
     HMODULE hNetShell = NULL;
     PFNREQUESTWIZARDPAGES pfn = NULL;
-    DWORD dwPageCount = 8, dwNetworkPageCount = 0;
+    DWORD dwPageCount = 9, dwNetworkPageCount = 0;
 
     LogItem(L"BEGIN_SECTION", L"InstallWizard");
 
@@ -2635,6 +2635,8 @@ InstallWizard(VOID)
     psp.pfnDlgProc = FinishDlgProc;
     psp.pszTemplate = MAKEINTRESOURCE(IDD_FINISHPAGE);
     phpage[nPages++] = CreatePropertySheetPage(&psp);
+
+    ASSERT(nPages == dwPageCount);
 
     /* Create the property sheet */
     psh.dwSize = sizeof(PROPSHEETHEADER);


### PR DESCRIPTION
## Purpose

This update was missed in [r75495](https://svn.reactos.org/svn/reactos?view=revision&revision=75495).

@yagoulas

## Proposed changes

- "(sdk/lib/rtl/heappage.c:1329) corrupted suffix pattern"
  detected at
  `dll/win32/syssetup/wizard.c:2672 (InstallWizard)`
- Add an ASSERT(), as hinted by Mark Jansen.
- Add a few comments.
- Remove a few extra blank lines.
