### PR TITLE
[USETUP] Display the ReactOS release status

### DIFF
--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -139,59 +139,65 @@ static MUI_ENTRY bgBGWelcomePageEntries[] =
 
 static MUI_ENTRY bgBGIntroPageEntries[] =
 {
-    {
+   {
         4,
         3,
-        " Слагане на РеактОС " KERNEL_VERSION_STR " . ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Настройвачът на РеактОС е в ранна степен на разработка. Все още",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "няма всички възможности на напълно използваемо настройващо приложение.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Съществуват следните ограничения:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Настройвачът поддържа само FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Проверката на файловата уредба все още не е готова.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Натиснете ENTER за слагане на РеактОС.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Натиснете F3 за изход без слагане на РеактОС.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "   ENTER = Продължаване   F3 = Изход",
-        TEXT_TYPE_STATUS
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -160,7 +160,7 @@ static MUI_ENTRY bgBGIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -178,7 +178,7 @@ static MUI_ENTRY bgBGIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -139,7 +139,7 @@ static MUI_ENTRY bgBGWelcomePageEntries[] =
 
 static MUI_ENTRY bgBGIntroPageEntries[] =
 {
-   {
+    {
         4,
         3,
         " ReactOS " KERNEL_VERSION_STR " Setup ",
@@ -160,7 +160,7 @@ static MUI_ENTRY bgBGIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -172,7 +172,7 @@ static MUI_ENTRY bgBGIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -151,7 +151,7 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -151,7 +151,7 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,7 +163,7 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -139,42 +139,48 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Setup is in an early development phase. It does not yet",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "support all the functions of a fully usable setup application.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "The following limitations apply:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Setup supports FAT file systems only.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- File system checks are not implemented yet.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Press ENTER to install ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
+        21,
         "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
@@ -182,7 +188,7 @@ static MUI_ENTRY bnBDIntroPageEntries[] =
         0,
         0,
         "ENTER = Continue   F3 = Quit",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -141,55 +141,61 @@ static MUI_ENTRY csCZIntroPageEntries[] =
     {
         4,
         3,
-        " Instalace ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Instalace ReactOS je v ran‚ vìvojov‚ f zi. Zat¡m nejsou podporov ny",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "vçechny funkce plnØ pou§iteln‚ instalaŸn¡ aplikace.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Plat¡ n sleduj¡c¡ omezen¡:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Instalace podporuje pouze souborovì syst‚m FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Kontroly souborovìch syst‚m… zat¡m nejsou implementov ny.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Stisknut¡m kl vesy ENTER zah j¡te instalaci ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Stisknut¡m F3 ukonŸ¡te instalaci ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = PokraŸovat   F3 = UkonŸit",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -159,7 +159,7 @@ static MUI_ENTRY csCZIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -177,7 +177,7 @@ static MUI_ENTRY csCZIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -159,7 +159,7 @@ static MUI_ENTRY csCZIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -171,7 +171,7 @@ static MUI_ENTRY csCZIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -151,7 +151,7 @@ static MUI_ENTRY daDKIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,7 +163,7 @@ static MUI_ENTRY daDKIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -133,62 +133,62 @@ static MUI_ENTRY daDKIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " installationen ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS installationen er i en tilelig udviklingsfase. Derfor",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "underst›tter den ikke alle funtionerne i et fult brugbart",
-        TEXT_STYLE_NORMAL
-    },
-	{
-        6,
-        10,
-        "installationsprogram.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Der er f›lgende begr‘ndsninger:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Installationen underst›tter kun FAT-filsystmet.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Tjek af filsystem er endnu ikke implementeret.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Tryk p† ENTER for at installere ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Tryk p† F3 for at afslutte uden at installere ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Forts‘t   F3 = Afslut",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -151,7 +151,7 @@ static MUI_ENTRY daDKIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY daDKIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -152,7 +152,7 @@ static MUI_ENTRY deDEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY deDEIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -140,50 +140,56 @@ static MUI_ENTRY deDEIntroPageEntries[] =
     {
         6,
         8,
-        "Der Installationsassistent befindet sich noch in der Entwicklungsphase.",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "Einige Funktionen werden noch nicht vollstÑndig unterstÅtzt.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Es existieren folgende BeschrÑnkungen:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Es werden nur FAT-Dateisysteme unterstÅtzt.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Die DateisystemÅberprÅfung ist noch nicht implementiert.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  DrÅcken Sie die EINGABETASTE, um ReactOS zu installieren.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  DrÅcken Sie F3, um die Installation abzubrechen.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "EINGABETASTE = Fortsetzen   F3 = Installation abbrechen",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -152,7 +152,7 @@ static MUI_ENTRY deDEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY deDEIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -134,56 +134,62 @@ static MUI_ENTRY elGRIntroPageEntries[] =
     {
         4,
         3,
-        " ДЪбШлсйлШйЮ лжм ReactOS " KERNEL_VERSION_STR,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
-        7,
-        "Ж ЬЪбШлсйлШйЮ лжм ReactOS ЩихйбЬлШа йЬ зищагж йлсЫаж ШдсзлмеЮк бШа",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6,
         8,
-        "ЫЬд мзжйлЮихЭЬа ШбцгШ цвЬк лак ЫмдШлцлЮлЬк гаШк звуижмк ЬЪбШлсйлШйЮк",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
         11,
-        "Ийочжмд жа зШиШбслр зЬиажиайгжх :",
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         12,
-        "- Ж ЬЪбШлсйлШйЮ мзжйлЮихЭЬа гцдж FAT ймйлугШлШ ШиоЬхрд.",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- ГЬд мзжйлЮихЭЬлШа ШбцгШ твЬЪожк йнШвгслрд йлШ ймлугШлШ ШиоЬхрд.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  ПШлуйлЬ ENTER ЪаШ дШ ЬЪбШлШйлуйЬлЬ лж ReactOS.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        25,
-        "\x07  ПШлуйлЬ F3 ЪаШ дШ ШзжориуйЬлЬ орихк дШ ЬЪбШлШйлуйЬлЬ лж ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "   ENTER = СмдтоЬаШ   F3 = АзжощиЮйЮ",
-        TEXT_TYPE_STATUS
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -152,7 +152,7 @@ static MUI_ENTRY elGRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY elGRIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -152,7 +152,7 @@ static MUI_ENTRY elGRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY elGRIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -139,42 +139,47 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Setup is in an early development phase. It does not yet",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "support all the functions of a fully usable setup application.",
+        11,
+        "ReactOS is an Alpha operating system, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "The following limitations apply:",
+        "and it's under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Setup supports FAT file systems only.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test in a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run in a real hardware."
+    },
+    {
+        8,
+        19,
+        "\x07  Press ENTER to continue the ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- File system checks are not implemented yet.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        23,
-        "\x07  Press ENTER to install ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
+        21,
         "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
@@ -182,7 +187,7 @@ static MUI_ENTRY enUSIntroPageEntries[] =
         0,
         0,
         "ENTER = Continue   F3 = Quit",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -151,7 +151,7 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,7 +163,7 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -145,13 +145,13 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         11,
-        "ReactOS is an Alpha operating system, meaning it is not feature-complete",
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "and it's under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,18 +163,19 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test in a secondary PC if you attempt",
+        "Backup your data or test on a secondary PC if you attempt",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         16,
-        "to run in a real hardware."
+        "to run on real hardware.",
+        TEXT_STYLE_NORMAL
     },
     {
         8,
         19,
-        "\x07  Press ENTER to continue the ReactOS Setup.",
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -151,7 +151,7 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY enUSIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -154,7 +154,7 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -166,7 +166,7 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -136,61 +136,61 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         4,
         3,
-        " Instalaci¢n de ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "El instalador de ReactOS se encuentra en una etapa preliminar.",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "A£n no posee todas las funciones de un instalador.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Se presentan las siguientes limitaciones:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- El instalador s¢lo puede utilizar el sistema de archivos FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
-        14,
-        "- El comprobador de integridad del sistema de archivos no est  a£n",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
+        6,
         15,
-        "  implementado.",
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        25,
-        "\x07  Presione INTRO para instalar ReactOS.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        27,
-        "\x07  Presione F3 para salir sin instalar ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "   INTRO = Continuar   F3 = Salir",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -154,7 +154,7 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -172,7 +172,7 @@ static MUI_ENTRY esESIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -151,7 +151,7 @@ static MUI_ENTRY etEEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY etEEIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -133,56 +133,62 @@ static MUI_ENTRY etEEIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " paigaldamine ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOSi paigaldusprogramm on varajases arendusfaasis. Praegu ei ole",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "veel k‰ik korraliku paigaldusprogrammi funktsioonid toetatud.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Kehtivad jÑrgmised piirangud:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Toetatud on ainult FAT failisÅsteem.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- FailisÅsteemi kontrollimist veel ei tehta.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Vajuta ENTER, et ReactOS paigaldada.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Vajuta F3, et vÑljuda ReactOSi paigaldamata.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = JÑtka   F3 = VÑlju",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -151,7 +151,7 @@ static MUI_ENTRY etEEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,7 +163,7 @@ static MUI_ENTRY etEEIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -131,7 +131,7 @@ static MUI_ENTRY frFRWelcomePageEntries[] =
 
 static MUI_ENTRY frFRIntroPageEntries[] =
 {
-   {
+    {
         4,
         3,
         " ReactOS " KERNEL_VERSION_STR " Setup ",
@@ -152,7 +152,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -131,64 +131,64 @@ static MUI_ENTRY frFRWelcomePageEntries[] =
 
 static MUI_ENTRY frFRIntroPageEntries[] =
 {
-    {
+   {
         4,
         3,
-        " Installation de ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "L'installation de ReactOS est en phase de dÇveloppement.",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "Elle ne supporte pas encore toutes les fonctions d'une application",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6,
-        10,
-        " d'installation entiärement utilisable.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Les limitations suivantes s'appliquent:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- L'installation supporte uniquement le systäme de fichiers FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Les vÇrifications de systäme de fichers ne sont pas implÇmentÇes.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Appuyer sur ENTRêE pour installer ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Appuyer sur F3 pour quitter sans installer ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTRêE = Continuer   F3 = Quitter",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -152,7 +152,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -152,7 +152,7 @@ static MUI_ENTRY heILIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY heILIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -152,7 +152,7 @@ static MUI_ENTRY heILIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY heILIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -134,56 +134,62 @@ static MUI_ENTRY heILIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " „—š„ ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "š‹…š €Œ ‰‰ƒ’ €‰„ .‰ƒ—… ‡…š‰” Œ™ š€– ReactOS š—š„",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        ".„€Œ š…‰™…‰™ ’ „—š„ …™‰‰ Œ™ š…‰…˜™”€„ Œ‹",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        ":š…™…‰ š…€„„ š…Œ‚„„",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Setup supports FAT file systems only.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- File system checks are not implemented yet.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Press ENTER to install ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
+        21,
         "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = „™Š   F3 = ˆŒ",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -132,64 +132,64 @@ static MUI_ENTRY itITWelcomePageEntries[] =
 static MUI_ENTRY itITIntroPageEntries[] =
 {
     {
-        4, 
+        4,
         3,
-        " Installazione di ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
-        4, 
-        3,
-        " Installazione di ReactOS " KERNEL_VERSION_STR " ",
-        TEXT_STYLE_UNDERLINE
+        6,
+        8,
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
-        6, 
-        8, 
-        "Il setup di ReactOS Š ancora in una fase preliminare.",
+        6,
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
-        6, 
-        9,
-        "Non ha ancora tutte le funzioni di installazione.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6, 
+        6,
         12,
-        "Si applicano le seguenti limitazioni:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8, 
-        13, 
-        "- Il setup supporta solamente il sistema FAT.",
+        6,
+        13,
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- File system checks are not implemented yet.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
-        8, 
-        23, 
-        "\x07  Premere INVIO per installare ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8, 
-        25, 
-        "\x07  Premere F3 per uscire senza installare ReactOS.",
+        8,
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
-        0, 
-        "   INVIO = Continua   F3 = Termina",
-        TEXT_TYPE_STATUS
+        0,
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -152,7 +152,7 @@ static MUI_ENTRY itITIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY itITIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -152,7 +152,7 @@ static MUI_ENTRY itITIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY itITIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -134,56 +134,62 @@ static MUI_ENTRY jaJPIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " ¾¯Ä±¯Ìß ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS ¾¯Ä±¯ÌßÊ ¼®·¶²ÊÂÀÞÝ¶²Æ ±ØÏ½¡ ¿ÉÀÒ¤ ÏÀÞ",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "¼Þ­³ÌÞÝÆ ØÖ³ÃÞ·Ù ¾¯Ä±¯Ìß ±ÌßØ¹°¼®ÝÉ ½ÍÞÃÉ ·É³Ê »Îß°Ä »ÚÏ¾Ý¡",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Â·ÞÉ ¾²Ô¸¶Þ Ã·Ö³ »ÚÏ½:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- ¾¯Ä±¯ÌßÊ FAT Ì§²Ù¼½ÃÑ ÉÐ »Îß°Ä ¼Ï½¡",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Ì§²Ù¼½ÃÑÉ Áª¯¸·É³Ê ÏÀÞ ¼Þ¯¿³ »ÚÃ ²Ï¾Ý¡",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  ReactOS ¦ ²Ý½Ä°Ù ½ÙÆÊ ENTER ·°¦ µ¼Ã ¸ÀÞ»²¡",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  ReactOS ¦ ²Ý½Ä°Ù¾½ÞÆ Á­³¼ ½Ù ÊÞ±²Ê F3 ·°¦ µ¼Ã ¸ÀÞ»²¡",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = ¿Þ¯º³   F3 = Á­³¼",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -152,7 +152,7 @@ static MUI_ENTRY jaJPIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY jaJPIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -152,7 +152,7 @@ static MUI_ENTRY jaJPIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY jaJPIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -161,7 +161,7 @@ static MUI_ENTRY ltLTIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -179,7 +179,7 @@ static MUI_ENTRY ltLTIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -161,7 +161,7 @@ static MUI_ENTRY ltLTIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -173,7 +173,7 @@ static MUI_ENTRY ltLTIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -143,55 +143,61 @@ static MUI_ENTRY ltLTIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " diegimo programa ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS Setup is in an early development phase. It does not yet",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "support all the functions of a fully usable setup application.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "The following limitations apply:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Setup supports FAT file systems only.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- File system checks are not implemented yet.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Press ENTER to install ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
+        21,
         "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = TÒsti   F3 = Baigti",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -151,7 +151,7 @@ static MUI_ENTRY msMYIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -163,7 +163,7 @@ static MUI_ENTRY msMYIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -133,56 +133,62 @@ static MUI_ENTRY msMYIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " Persediaan ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS persediaan sedang untuk fasa pembangunan awal. Ia tidak lagi",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "menyokong semua fungsi aplikasi persediaan sepenuhnya digunakan.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Kepada had berikut diguna pakai:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Persediaan menyokong sistem fail FAT sahaja.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Pemeriksaan sistem fail tidak dilaksanakan lagi.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Tekan ENTER untuk memasang ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Tekan F3 untuk keluar tanpa memasang ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Teruskan F3 = Keluar",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -151,7 +151,7 @@ static MUI_ENTRY msMYIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY msMYIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -167,7 +167,7 @@ static MUI_ENTRY nlNLIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -185,7 +185,7 @@ static MUI_ENTRY nlNLIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -155,62 +155,56 @@ static MUI_ENTRY nlNLIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Setup is nog in een vroege ontwikkelingsfase.",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "Het ondersteunt nog niet alle functies van een volledig",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6,
-        10,
-        "setup programma.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "De volgende beperkingen zijn van toepassing:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "\x07  Setup ondersteunt alleen FAT bestandssystemen.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "\x07  Bestandssysteemcontrole is nog niet ge\x8Bmplementeerd.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Druk op ENTER om ReactOS te installeren.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Druk op F3 als u Setup wilt afsluiten zonder ReactOS te",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        26,
-        "   installeren.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Doorgaan   F3 = Afsluiten",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -167,7 +167,7 @@ static MUI_ENTRY nlNLIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -179,7 +179,7 @@ static MUI_ENTRY nlNLIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -162,7 +162,7 @@ static MUI_ENTRY plPLIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -174,7 +174,7 @@ static MUI_ENTRY plPLIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -162,7 +162,7 @@ static MUI_ENTRY plPLIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -180,7 +180,7 @@ static MUI_ENTRY plPLIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -144,56 +144,62 @@ static MUI_ENTRY plPLIntroPageEntries[] =
     {
         4,
         3,
-        " Instalator ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Instalator ReactOS wci¥¾ jest we wczesnej fazie rozwoju. Nadal nie",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "obsˆuguje wszystkich funkcji, niezb©dnych dla programu instalacyjnego.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Najwa¾niejsze ograniczenia:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Instalator obsˆuguje jedynie system plik¢w FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Brakuje sprawdzenia poprawno˜ci systemu plik¢w.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Naci˜nij ENTER, aby zainstalowa† system ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Naci˜nij F3, aby wyj˜† bez instalacji systemu ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Kontynuacja   F3 = Wyj˜cie",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -152,7 +152,7 @@ static MUI_ENTRY ptBRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY ptBRIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -152,7 +152,7 @@ static MUI_ENTRY ptBRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY ptBRIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -134,61 +134,61 @@ static MUI_ENTRY ptBRIntroPageEntries[] =
     {
         4,
         3,
-        " Instalaá∆o do ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "O instalador do ReactOS est† em fase inicial de desenvolvimento e",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6,
-        9,
-        "ainda n∆o suporta todas as funá‰es de instalaá∆o.",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
         11,
-        "As seguintes limitaá‰es se aplicam:",
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         12,
-        "- O instalador suporta somente o sistema de arquivos FAT.",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- O verificador de integridade de sistema de arquivos ainda n∆o est†",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "  implementado.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        25,
-        "\x07  Para continuar a instalaá∆o do ReactOS, pressione ENTER.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        27,
-        "\x07  Para sair sem instalar o ReactOS, pressione F3.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER=Continuar  F3=Sair",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -165,7 +165,7 @@ static MUI_ENTRY roROIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -183,7 +183,7 @@ static MUI_ENTRY roROIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -147,74 +147,62 @@ static MUI_ENTRY roROIntroPageEntries[] =
     {
         4,
         3,
-        " Instalare ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Programul curent de instalare este încã într-un stadiu primar",
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
+    },
+    {
+        6,
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
-        9,
-        "de dezvoltare ºi nu conþine toate funcþionalitãþile unui",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        6,
-        10,
-        "program de instalare complet.",
+        12,
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         13,
-        "Sunt aplicabile urmãtoarele limitãri:",
+        "evaluation and testing purposes and not as your daily-usage OS.",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
-        14,
-        "- Programul curent de instalare poate opera doar cu sisteme",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
+        6,
         15,
-        "  de fiºiere FAT.",
+        "Backup your data or test on a secondary PC if you attempt",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         16,
-        "- Verificãrile de integritate pentru fiºiere nu sunt",
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        17,
-        "  încã implementate.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        26,
-        "\x07  Apãsaþi ENTER pentru a instala ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        28,
-        "\x07  Apãsaþi F3 pentru a ieºi fãrã a instala ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Continuare   F3 = Ieºire",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -165,7 +165,7 @@ static MUI_ENTRY roROIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -177,7 +177,7 @@ static MUI_ENTRY roROIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ru-RU.h
+++ b/base/setup/usetup/lang/ru-RU.h
@@ -152,7 +152,7 @@ static MUI_ENTRY ruRUIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -164,7 +164,7 @@ static MUI_ENTRY ruRUIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/ru-RU.h
+++ b/base/setup/usetup/lang/ru-RU.h
@@ -134,55 +134,61 @@ static MUI_ENTRY ruRUIntroPageEntries[] =
     {
         4,
         3,
-        " Установка ReactOS " KERNEL_VERSION_STR,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS находится в ранней стадии разработки и не поддерживает все",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "функции для полной совместимости с устанавливаемыми приложениями.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Имеются следующие ограничения:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- При установке поддерживается только файловая система FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Проверка файловой системы не осуществляется.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Нажмите ENTER для установки ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Нажмите F3 для выхода из установки ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Продолжить   F3 = Выход",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/ru-RU.h
+++ b/base/setup/usetup/lang/ru-RU.h
@@ -152,7 +152,7 @@ static MUI_ENTRY ruRUIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY ruRUIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -141,56 +141,62 @@ static MUI_ENTRY skSKIntroPageEntries[] =
     {
         4,
         3,
-        " Inçtal tor syst‚mu ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Inçtal tor syst‚mu ReactOS je v zaŸiatoŸnom çt diu vìvoja. Zatia–",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "nepodporuje vçetky funkcie plne vyu§¡vaj£ce program Inçtal tor.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "M  nasleduj£ce obmedzenia:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Inçtal tor podporuje iba s£borovì syst‚m FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Kontrola s£borov‚ho syst‚mu zatia– nie je implementovan .",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  StlaŸte ENTER pre nainçtalovanie syst‚mu ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  StlaŸte F3 pre skonŸenie inçtal cie, syst‚m ReactOS sa nenainçtaluje.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = PokraŸovaœ   F3 = SkonŸiœ",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -159,7 +159,7 @@ static MUI_ENTRY skSKIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -177,7 +177,7 @@ static MUI_ENTRY skSKIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -159,7 +159,7 @@ static MUI_ENTRY skSKIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -171,7 +171,7 @@ static MUI_ENTRY skSKIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -155,7 +155,7 @@ static MUI_ENTRY sqALIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -167,7 +167,7 @@ static MUI_ENTRY sqALIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -137,56 +137,62 @@ static MUI_ENTRY sqALIntroPageEntries[] =
     {
         4,
         3,
-        "Instalimi i  ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Instalimi i ReactOS ‰sht‰ n‰ fazat e para t‰ zhvillimit. Ajo ende nuk i",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "suporton te gjitha funksionet e nj‰ instalimit plot‰sisht t‰ p‰rdorsh‰m.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Kufizimet e meposhtme aplikohen:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Instalimi suporton vet‰m dokumentat FAT t‰ sistemit.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Kontrollet e dokumentave t‰ sistemit nuk jan‰ implementuar ende.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Kliko ENTER p‰r t‰ instaluar ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Kliko F3 t‰ dilni pa instaluar ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Vazhdo   F3 = Dil",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -155,7 +155,7 @@ static MUI_ENTRY sqALIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -173,7 +173,7 @@ static MUI_ENTRY sqALIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -137,7 +137,7 @@ static MUI_ENTRY svSEWelcomePageEntries[] =
 
 static MUI_ENTRY svSEIntroPageEntries[] =
 {
-   {
+    {
         4,
         3,
         " ReactOS " KERNEL_VERSION_STR " Setup ",
@@ -158,7 +158,7 @@ static MUI_ENTRY svSEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -170,7 +170,7 @@ static MUI_ENTRY svSEIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -137,7 +137,7 @@ static MUI_ENTRY svSEWelcomePageEntries[] =
 
 static MUI_ENTRY svSEIntroPageEntries[] =
 {
-    {
+   {
         4,
         3,
         " ReactOS " KERNEL_VERSION_STR " Setup ",
@@ -146,50 +146,56 @@ static MUI_ENTRY svSEIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Setup „r i en tidig utvecklingsfas och saknar d„rf”r ett antal",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "funktioner som kan f”rv„ntas av ett fullt anv„ndbart setup-program.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "F”ljande begr„nsningar g„ller:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Setup st”der endast filsystem av typen FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Kontrollering av h†rddiskens filsystem st”ds („nnu) ej.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Tryck p† ENTER f”r att installera ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Tryck p† F3 f”r att avbryta installationen.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "   ENTER = Forts„tt   F3 = Avbryt",
-        TEXT_TYPE_STATUS
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -158,7 +158,7 @@ static MUI_ENTRY svSEIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -176,7 +176,7 @@ static MUI_ENTRY svSEIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -155,7 +155,7 @@ static MUI_ENTRY trTRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -173,7 +173,7 @@ static MUI_ENTRY trTRIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -137,55 +137,61 @@ static MUI_ENTRY trTRIntroPageEntries[] =
     {
         4,
         3,
-        " ReactOS " KERNEL_VERSION_STR " Kur ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "ReactOS Kur, bir în geliüme evresindedir. Daha tÅmÅyle kullançülç",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "bir kurulum uygulamasçnçn tÅm iülevlerini desteklemez.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Aüaßçdaki kçsçtlamalar uygulançr:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Kur, yalnçzca FAT kÅtÅk dizgelerini destekler.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- KÅtÅk dizgesi denetimi daha bitirilmemiütir.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  ReactOS'u kurmak iáin Giriü'e basçnçz.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  ReactOS'u kurmadan áçkmak iáin F3'e basçnçz.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "Giriü = SÅrdÅr   F3 = Äçk",
+        "ENTER = Continue   F3 = Quit",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -155,7 +155,7 @@ static MUI_ENTRY trTRIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -167,7 +167,7 @@ static MUI_ENTRY trTRIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/uk-UA.h
+++ b/base/setup/usetup/lang/uk-UA.h
@@ -139,56 +139,62 @@ static MUI_ENTRY ukUAIntroPageEntries[] =
     {
         4,
         3,
-        " Встановлення ReactOS " KERNEL_VERSION_STR " ",
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
         TEXT_STYLE_UNDERLINE
     },
     {
         6,
         8,
-        "Встановлювач ReactOS знаходиться в раннiй стадiї розробки i ще не",
-        TEXT_STYLE_NORMAL
+        "ReactOS Version Status",
+        TEXT_STYLE_HIGHLIGHT
     },
     {
         6,
-        9,
-        "пiдтримує всi функцiї повноцiнної програми встановлення.",
+        11,
+        "ReactOS is in Alpha stage, meaning it is not feature-complete",
         TEXT_STYLE_NORMAL
     },
     {
         6,
         12,
-        "Присутнi наступнi обмеження:",
+        "and under heavy development. It is recommended to use only for",
         TEXT_STYLE_NORMAL
     },
     {
-        8,
+        6,
         13,
-        "- Встановлювач пiдтримує лише файлову систему FAT.",
+        "evaluation and testing purposes and not as your daily-usage OS.",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        15,
+        "Backup your data or test on a secondary PC if you attempt",
+        TEXT_STYLE_NORMAL
+    },
+    {
+        6,
+        16,
+        "to run on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        14,
-        "- Перевiрка файлової системи ще не впроваджена.",
+        19,
+        "\x07  Press ENTER to continue ReactOS Setup.",
         TEXT_STYLE_NORMAL
     },
     {
         8,
-        23,
-        "\x07  Натиснiть ENTER щоб встановити ReactOS.",
-        TEXT_STYLE_NORMAL
-    },
-    {
-        8,
-        25,
-        "\x07  Натиснiть F3 щоб вийти, не встановлюючи ReactOS.",
+        21,
+        "\x07  Press F3 to quit without installing ReactOS.",
         TEXT_STYLE_NORMAL
     },
     {
         0,
         0,
-        "ENTER = Продовжити   F3 = Вийти",
-        TEXT_TYPE_STATUS| TEXT_PADDING_BIG
+        "ENTER = Continue   F3 = Quit",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG
     },
     {
         0,

--- a/base/setup/usetup/lang/uk-UA.h
+++ b/base/setup/usetup/lang/uk-UA.h
@@ -157,7 +157,7 @@ static MUI_ENTRY ukUAIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use it only for",
+        "and is under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -175,7 +175,7 @@ static MUI_ENTRY ukUAIntroPageEntries[] =
     {
         6,
         16,
-        "to run on real hardware.",
+        "to run ReactOS on real hardware.",
         TEXT_STYLE_NORMAL
     },
     {

--- a/base/setup/usetup/lang/uk-UA.h
+++ b/base/setup/usetup/lang/uk-UA.h
@@ -157,7 +157,7 @@ static MUI_ENTRY ukUAIntroPageEntries[] =
     {
         6,
         12,
-        "and under heavy development. It is recommended to use only for",
+        "and under heavy development. It is recommended to use it only for",
         TEXT_STYLE_NORMAL
     },
     {
@@ -169,7 +169,7 @@ static MUI_ENTRY ukUAIntroPageEntries[] =
     {
         6,
         15,
-        "Backup your data or test on a secondary PC if you attempt",
+        "Backup your data or test on a secondary computer if you attempt",
         TEXT_STYLE_NORMAL
     },
     {


### PR DESCRIPTION
## Purpose
As you guys know, ReactOS is in Alpha and barely stable. Having a notification concerning ReactOS' release status is critical as it informs the user the risks of running this operating system considering ReactOS is under heavy development and many bugs are still in the wild.

Displaying the said message in the 1st stage setup is a viable option.

## Presentation
Image URL: https://imgur.com/a/kpo0DtS

## TODO
As you can see, I have only edited the `en-US.h` file because the actual statements aren't that perfect. For this reason, I've set the Pull Request in WIP state as I request review from the devs to check if the wording is alright (or there needs some changes so it can fit better). Once everything is OK I'll edit the other language files.

- [x] Add the message page for other languages