### PR TITLE
[USETUP] Remove "Setup will now format the partition. Press ENTER to continue." message on screen while formatting is in progress.

### DIFF
--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -282,7 +282,6 @@ CONSOLE_SetTextXY(
         &Written);
 }
 
-static
 VOID
 CONSOLE_ClearTextXY(IN SHORT x,
                     IN SHORT y,

--- a/base/setup/usetup/consup.h
+++ b/base/setup/usetup/consup.h
@@ -118,6 +118,12 @@ CONSOLE_PrintTextXYN(
 	IN LPCSTR fmt, ...);
 
 VOID
+CONSOLE_ClearTextXY(
+    IN SHORT x,
+    IN SHORT y,
+    IN SHORT Length);
+
+VOID
 CONSOLE_SetCursorType(
 	IN BOOL bInsert,
 	IN BOOL bVisible);

--- a/base/setup/usetup/format.c
+++ b/base/setup/usetup/format.c
@@ -96,7 +96,7 @@ FormatPartition(
     if (!FileSystem || !FileSystem->FormatFunc)
         return STATUS_NOT_SUPPORTED;
 
-    CONSOLE_PrintTextXY(6, 10, "%100c", ' ');
+    CONSOLE_ClearTextXY(6, 10, 100);
 
     FormatProgressBar = CreateProgressBar(6,
                                           yScreen - 14,

--- a/base/setup/usetup/format.c
+++ b/base/setup/usetup/format.c
@@ -96,7 +96,7 @@ FormatPartition(
     if (!FileSystem || !FileSystem->FormatFunc)
         return STATUS_NOT_SUPPORTED;
 
-    CONSOLE_PrintTextXY(7, 11, "100%c", ' ');
+    CONSOLE_PrintTextXY(7, 11, "%100c", ' ');
 
     FormatProgressBar = CreateProgressBar(6,
                                           yScreen - 14,

--- a/base/setup/usetup/format.c
+++ b/base/setup/usetup/format.c
@@ -96,6 +96,8 @@ FormatPartition(
     if (!FileSystem || !FileSystem->FormatFunc)
         return STATUS_NOT_SUPPORTED;
 
+    /* Remove "Setup will now format the partition. 
+     * Press ENTER to continue." message */
     CONSOLE_ClearTextXY(6, 10, 100);
 
     FormatProgressBar = CreateProgressBar(6,

--- a/base/setup/usetup/format.c
+++ b/base/setup/usetup/format.c
@@ -96,6 +96,8 @@ FormatPartition(
     if (!FileSystem || !FileSystem->FormatFunc)
         return STATUS_NOT_SUPPORTED;
 
+    CONSOLE_PrintTextXY(7, 11, "100%c", ' ');
+
     FormatProgressBar = CreateProgressBar(6,
                                           yScreen - 14,
                                           xScreen - 7,

--- a/base/setup/usetup/format.c
+++ b/base/setup/usetup/format.c
@@ -96,7 +96,7 @@ FormatPartition(
     if (!FileSystem || !FileSystem->FormatFunc)
         return STATUS_NOT_SUPPORTED;
 
-    CONSOLE_PrintTextXY(7, 11, "%100c", ' ');
+    CONSOLE_PrintTextXY(6, 10, "%100c", ' ');
 
     FormatProgressBar = CreateProgressBar(6,
                                           yScreen - 14,


### PR DESCRIPTION
-  Remove "Setup will now format the partition.
  Press ENTER to continue." message on screen
  while formatting is in progress.

## Purpose

Remove "Setup will now format the partition. Press ENTER to continue." message on screen while formatting is in progress.

JIRA issue: [CORE-12683](https://jira.reactos.org/browse/CORE-12683)

## Proposed changes

- In format.c, add `CONSOLE_ClearTextXY()` function with proper arguments.
- In consup.c, remove `static` expression for `CONSOLE_ClearTextXY()` function definition 
- In consup.h, add `CONSOLE_ClearTextXY()` function declarartion.
