### PR TITLE
[NETAPI32_APITEST] Fix a NULL dereference of pInfo

### DIFF
--- a/modules/rostests/apitests/netapi32/DsRoleGetPrimaryDomainInformation.c
+++ b/modules/rostests/apitests/netapi32/DsRoleGetPrimaryDomainInformation.c
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Tests for DsRoleGetPrimaryDomainInformation
  * COPYRIGHT:   Copyright 2017 Colin Finck (colin@reactos.org)
+ *              Copyright 2018 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 #include <apitest.h>
@@ -20,8 +21,12 @@ START_TEST(DsRoleGetPrimaryDomainInformation)
     // Get information about the domain membership of this computer.
     dwErrorCode = DsRoleGetPrimaryDomainInformation(NULL, DsRolePrimaryDomainInfoBasic, (PBYTE*)&pInfo);
     ok(dwErrorCode == ERROR_SUCCESS, "DsRoleGetPrimaryDomainInformation returns %lu!\n", dwErrorCode);
-    ok(pInfo->MachineRole >= DsRole_RoleStandaloneWorkstation && pInfo->MachineRole <= DsRole_RolePrimaryDomainController, "pInfo->MachineRole is %u!\n", pInfo->MachineRole);
+    if (pInfo == NULL)
+    {
+        skip("pInfo is NULL\n");
+        return;
+    }
 
-    if (pInfo)
-        DsRoleFreeMemory(pInfo);
+    ok(pInfo->MachineRole >= DsRole_RoleStandaloneWorkstation && pInfo->MachineRole <= DsRole_RolePrimaryDomainController, "pInfo->MachineRole is %u!\n", pInfo->MachineRole);
+    DsRoleFreeMemory(pInfo);
 }


### PR DESCRIPTION
## Purpose

Added as is on [r75208](https://svn.reactos.org/svn/reactos?view=revision&revision=75208).

@ColinFinck

NB:
This PR is not aimed at fixing the main DPH issue.

## Proposed changes

- Fix a NULL dereference of pInfo

With DPH enabled,
{{
Unhandled exception
ExceptionCode:    c0000005
Faulting Address:        0
...
modules/rostests/apitests/netapi32/DsRoleGetPrimaryDomainInformation.c:23 (func_DsRoleGetPrimaryDomainInformation)
...
}}
