### PR TITLE
[REGEDIT] fix importing very big *.reg files (HEX values commonly)

### DIFF
--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -851,8 +851,14 @@ static void processRegLinesW(FILE *in)
                 if(*s_eol == '\r' && *(s_eol+1) == '\n')
                     NextLine++;
 
-                while(*(NextLine+1) == ' ' || *(NextLine+1) == '\t')
+                while(isspaceW(*NextLine))
                     NextLine++;
+
+                if (!*NextLine)
+                {
+                    s = NextLine;
+                    break;
+                }
 
                 MoveMemory(s_eol - 1, NextLine, (CharsInBuf - (NextLine - s) + 1)*sizeof(WCHAR));
                 CharsInBuf -= NextLine - s_eol + 1;


### PR DESCRIPTION
This bug was found when i try to import *.reg with huge HEX value (about 500 and much more lines of hex text)

Such a big file i got exporting values from HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\TrayNotify on windows XP