### PR TITLE
Additions for window station handling.

### DIFF
--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -17,6 +17,8 @@
 #include <userenv.h>
 #include <strsafe.h>
 
+#include <reactos/undocuser.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -1674,6 +1676,7 @@ ScmStartUserModeService(PSERVICE Service,
     if ((NoInteractiveServices == 0) &&
         (Service->Status.dwServiceType & SERVICE_INTERACTIVE_PROCESS))
     {
+        StartupInfo.dwFlags |= STARTF_INHERITDESKTOP;
         StartupInfo.lpDesktop = L"WinSta0\\Default";
     }
 

--- a/base/system/winlogon/screensaver.c
+++ b/base/system/winlogon/screensaver.c
@@ -327,7 +327,7 @@ StartScreenSaver(
     ZeroMemory(&StartupInfo, sizeof(STARTUPINFOW));
     ZeroMemory(&ProcessInformation, sizeof(PROCESS_INFORMATION));
     StartupInfo.cb = sizeof(STARTUPINFOW);
-    StartupInfo.dwFlags = STARTF_SCRNSAVER;
+    StartupInfo.dwFlags = STARTF_SCREENSAVER;
 
     /* FIXME: run the screen saver on the screen saver desktop */
     ret = CreateProcessW(szApplicationName,

--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -156,8 +156,11 @@ extern "C" {
 #define DFCS_MENUARROWUP   0x0008
 #define DFCS_MENUARROWDOWN 0x0010
 
-
-#define STARTF_SCRNSAVER 0x80000000
+//
+// Undocumented flags for CreateProcess
+//
+#define STARTF_INHERITDESKTOP   0x40000000
+#define STARTF_SCREENSAVER      0x80000000
 
 #define MOD_WINLOGON_SAS 0x8000
 

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2912,11 +2912,11 @@ NtUserRemoveProp(
     ATOM Atom);
 
 HDESK
-APIENTRY
+NTAPI
 NtUserResolveDesktop(
     IN HANDLE ProcessHandle,
     IN PUNICODE_STRING DesktopPath,
-    DWORD dwUnknown,
+    IN BOOL bInherit,
     OUT HWINSTA* phWinSta);
 
 DWORD

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -447,139 +447,726 @@ GetSystemVersionString(OUT PWSTR pwszzVersion,
 }
 
 
-NTSTATUS FASTCALL
-IntParseDesktopPath(PEPROCESS Process,
-                    PUNICODE_STRING DesktopPath,
-                    HWINSTA *hWinSta,
-                    HDESK *hDesktop)
-{
-    OBJECT_ATTRIBUTES ObjectAttributes;
-    UNICODE_STRING ObjectName;
-    NTSTATUS Status;
-    WCHAR wstrWinstaFullName[MAX_PATH], *pwstrWinsta = NULL, *pwstrDesktop = NULL;
+/*
+ * IntResolveDesktop
+ *
+ * The IntResolveDesktop function attempts to retrieve valid handles to
+ * a desktop and a window station suitable for the specified process.
+ * The specified desktop path string is used only as a hint for the resolution.
+ *
+ * - If the process is already assigned to a window station and a desktop,
+ *   handles to these objects are returned directly regardless of the specified
+ *   desktop path string. This is what happens when this function is called for
+ *   a process that has been already started and connected to the Win32 USER.
+ *
+ * - If the process is being connected to the Win32 USER, or is in a state
+ *   where a window station is assigned to it but no desktop yet, the desktop
+ *   path string is used as a hint for the resolution.
+ *   A specified window station (if any, otherwise "WinSta0" is used as default)
+ *   is tested for existence and accessibility. If the checks are OK a handle
+ *   to it is returned. Otherwise we either fail (the window station does not
+ *   exist) or, in case a default window station was used, we attempt to open
+ *   or create a non-interactive Service-0xXXXX-YYYY$ window station. This is
+ *   typically what happens when a non-interactive process is started while
+ *   the WinSta0 window station was used as the default one.
+ *   A specified desktop (if any, otherwise "Default" is used as default)
+ *   is then tested for existence on the opened window station.
+ *
+ * - Rules for the choice of the default window station, when none is specified
+ *   in the desktop path:
+ *
+ *   1. By default, a SYSTEM process connects to a non-interactive window
+ *      station, either the Service-0x0-3e7$ (from the SYSTEM LUID) station,
+ *      or one that has been inherited and that is non-interactive.
+ *      Only when the interactive window station WinSta0 is specified that
+ *      the process can connect to it (e.g. the case of interactive services).
+ *
+ *   2. An interactive process, i.e. a process whose LUID is the same as the
+ *      one assigned to WinSta0 by Winlogon on user logon, connects by default
+ *      to the WinSta0 window station, unless it has inherited from another
+ *      interactive window station (which must be... none other than WinSta0).
+ *
+ *   3. A non-interactive (but not SYSTEM) process connects by default to
+ *      a non-interactive Service-0xXXXX-YYYY$ window station (whose name
+ *      is derived from the process' LUID), or to another non-interactive
+ *      window station that has been inherited.
+ *      Otherwise it may be able connect to the interactive WinSta0 only if
+ *      it has explicit access rights to it.
+ *
+ * Parameters
+ *    Process
+ *       The user process object.
+ *
+ *    DesktopPath
+ *       The desktop path string used as a hint for desktop resolution.
+ *
+ *    bInherit
+ *       Whether or not the returned handles are inheritable.
+ *
+ *    phWinSta
+ *       Pointer to a window station handle.
+ *
+ *    phDesktop
+ *       Pointer to a desktop handle.
+ *
+ * Return Value
+ *    Status code.
+ */
 
-    ASSERT(hWinSta);
-    ASSERT(hDesktop);
+NTSTATUS
+FASTCALL
+IntResolveDesktop(
+    IN PEPROCESS Process,
+    IN PUNICODE_STRING DesktopPath,
+    IN BOOL bInherit,
+    OUT HWINSTA* phWinSta,
+    OUT HDESK* phDesktop)
+{
+    NTSTATUS Status;
+    HWINSTA hWinSta = NULL, hWinStaDup = NULL;
+    HDESK hDesktop = NULL, hDesktopDup = NULL;
+    PPROCESSINFO ppi;
+    HANDLE hProcess = NULL;
+    LUID ProcessLuid;
+    USHORT StrSize;
+    SIZE_T MemSize;
+    POBJECT_ATTRIBUTES ObjectAttributes = NULL;
+    PUNICODE_STRING ObjectName;
+    UNICODE_STRING WinStaName, DesktopName;
+    const UNICODE_STRING WinSta0Name = RTL_CONSTANT_STRING(L"WinSta0");
+    PWINSTATION_OBJECT WinStaObject;
+    HWINSTA hTempWinSta = NULL;
+    BOOLEAN bUseDefaultWinSta = FALSE;
+    BOOLEAN bInteractive = FALSE;
+    BOOLEAN bAccessAllowed = FALSE;
+
+    ASSERT(phWinSta);
+    ASSERT(phDesktop);
     ASSERT(DesktopPath);
 
-    *hWinSta = NULL;
-    *hDesktop = NULL;
+    *phWinSta  = NULL;
+    *phDesktop = NULL;
 
-    if (DesktopPath->Buffer != NULL && DesktopPath->Length > sizeof(WCHAR))
+    ppi = PsGetProcessWin32Process(Process);
+    /* ppi is typically NULL for console applications that connect to Win32 USER */
+    if (!ppi) TRACE("IntResolveDesktop: ppi is NULL!\n");
+
+    if (ppi && ppi->hwinsta != NULL && ppi->hdeskStartup != NULL)
     {
         /*
-         * Parse the desktop path string which can be in the form "WinSta\Desktop"
-         * or just "Desktop". In latter case WinSta0 will be used.
+         * If this process is the current one, just return the cached handles.
+         * Otherwise, open the window station and desktop objects.
          */
-
-        pwstrDesktop = wcschr(DesktopPath->Buffer, L'\\');
-        if (pwstrDesktop != NULL)
+        if (Process == PsGetCurrentProcess())
         {
-            *pwstrDesktop = 0;
-            pwstrDesktop++;
-            pwstrWinsta = DesktopPath->Buffer;
+            hWinSta  = ppi->hwinsta;
+            hDesktop = ppi->hdeskStartup;
         }
         else
         {
-            pwstrDesktop = DesktopPath->Buffer;
-            pwstrWinsta = NULL;
+            Status = ObOpenObjectByPointer(ppi->prpwinsta,
+                                           0,
+                                           NULL,
+                                           MAXIMUM_ALLOWED,
+                                           ExWindowStationObjectType,
+                                           UserMode,
+                                           (PHANDLE)&hWinSta);
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("IntResolveDesktop: Could not reference window station 0x%p\n", ppi->prpwinsta);
+                SetLastNtError(Status);
+                return Status;
+            }
+
+            Status = ObOpenObjectByPointer(ppi->rpdeskStartup,
+                                           0,
+                                           NULL,
+                                           MAXIMUM_ALLOWED,
+                                           ExDesktopObjectType,
+                                           UserMode,
+                                           (PHANDLE)&hDesktop);
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("IntResolveDesktop: Could not reference desktop 0x%p\n", ppi->rpdeskStartup);
+                ObCloseHandle(hWinSta, UserMode);
+                SetLastNtError(Status);
+                return Status;
+            }
         }
 
-        TRACE("IntParseDesktopPath pwstrWinsta:%S pwstrDesktop:%S\n", pwstrWinsta, pwstrDesktop);
+        *phWinSta  = hWinSta;
+        *phDesktop = hDesktop;
+        return STATUS_SUCCESS;
     }
 
-#if 0
-    /* Search the process handle table for (inherited) window station
-       handles, use a more appropriate one than WinSta0 if possible. */
-    if (!ObFindHandleForObject(Process,
-                               NULL,
-                               ExWindowStationObjectType,
-                               NULL,
-                               (PHANDLE)hWinSta))
-#endif
+    /* We will by default use the default window station and desktop */
+    RtlInitEmptyUnicodeString(&WinStaName, NULL, 0);
+    RtlInitEmptyUnicodeString(&DesktopName, NULL, 0);
+
+    /*
+     * Parse the desktop path string which can be of the form "WinSta\Desktop"
+     * or just "Desktop". In the latter case we use the default window station
+     * on which the process is attached to (or if none, "WinSta0").
+     */
+    if (DesktopPath->Buffer != NULL && DesktopPath->Length > sizeof(WCHAR))
     {
-        /* We had no luck searching for opened handles, use WinSta0 now */
-        if (!pwstrWinsta)
-            pwstrWinsta = L"WinSta0";
+        DesktopName = *DesktopPath;
+
+        /* Find the separator */
+        while (DesktopName.Length > 0 && *DesktopName.Buffer &&
+               *DesktopName.Buffer != OBJ_NAME_PATH_SEPARATOR)
+        {
+            DesktopName.Buffer++;
+            DesktopName.Length -= sizeof(WCHAR);
+            DesktopName.MaximumLength -= sizeof(WCHAR);
+        }
+        if (DesktopName.Length > 0)
+        {
+            RtlInitEmptyUnicodeString(&WinStaName, DesktopPath->Buffer,
+                                      DesktopPath->Length - DesktopName.Length);
+            // (USHORT)((ULONG_PTR)DesktopName.Buffer - (ULONG_PTR)DesktopPath->Buffer);
+            WinStaName.Length = WinStaName.MaximumLength;
+
+            /* Skip the separator */
+            DesktopName.Buffer++;
+            DesktopName.Length -= sizeof(WCHAR);
+            DesktopName.MaximumLength -= sizeof(WCHAR);
+        }
+        else
+        {
+            RtlInitEmptyUnicodeString(&WinStaName, NULL, 0);
+            DesktopName = *DesktopPath;
+        }
     }
 
-#if 0
-    /* Search the process handle table for (inherited) desktop
-       handles, use a more appropriate one than Default if possible. */
-    if (!ObFindHandleForObject(Process,
-                               NULL,
-                               ExDesktopObjectType,
-                               NULL,
-                               (PHANDLE)hDesktop))
-#endif
+    TRACE("IntResolveDesktop: WinStaName:'%wZ' ; DesktopName:'%wZ'\n", &WinStaName, &DesktopName);
+
+    /* Retrieve the process LUID */
+    Status = GetProcessLuid(NULL, Process, &ProcessLuid);
+    if (!NT_SUCCESS(Status))
     {
-        /* We had no luck searching for opened handles, use Desktop now */
-        if (!pwstrDesktop)
-            pwstrDesktop = L"Default";
+        ERR("IntResolveDesktop: Failed to retrieve the process LUID, Status 0x%08lx\n", Status);
+        SetLastNtError(Status);
+        return Status;
     }
 
-    if (*hWinSta == NULL)
+    /*
+     * If this process is not the current one, obtain a temporary handle
+     * to it so that we can perform handles duplication later.
+     */
+    if (Process != PsGetCurrentProcess())
     {
-        swprintf(wstrWinstaFullName, L"%wZ\\%ws", &gustrWindowStationsDir, pwstrWinsta);
-        RtlInitUnicodeString( &ObjectName, wstrWinstaFullName);
-
-        TRACE("parsed initial winsta: %wZ\n", &ObjectName);
-
-        /* Open the window station */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &ObjectName,
-                                   OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-
-        Status = ObOpenObjectByName(&ObjectAttributes,
-                                    ExWindowStationObjectType,
-                                    KernelMode,
-                                    NULL,
-                                    WINSTA_ACCESS_ALL,
-                                    NULL,
-                                    (HANDLE*)hWinSta);
-
+        Status = ObOpenObjectByPointer(Process,
+                                       OBJ_KERNEL_HANDLE,
+                                       NULL,
+                                       0,
+                                       *PsProcessType,
+                                       KernelMode,
+                                       &hProcess);
         if (!NT_SUCCESS(Status))
         {
+            ERR("IntResolveDesktop: Failed to obtain a handle to process 0x%p, Status 0x%08lx\n", Process, Status);
             SetLastNtError(Status);
-            ERR("Failed to reference window station %wZ PID: --!\n", &ObjectName );
             return Status;
+        }
+        ASSERT(hProcess);
+    }
+
+    /*
+     * If no window station has been specified, search the process handle table
+     * for inherited window station handles, otherwise use a default one.
+     */
+    if (WinStaName.Buffer == NULL)
+    {
+        /*
+         * We want to find a suitable default window station.
+         * For applications that can be interactive, i.e. that have allowed
+         * access to the single interactive window station on the system,
+         * the default window station is 'WinSta0'.
+         * For applications that cannot be interactive, i.e. that do not have
+         * access to 'WinSta0' (e.g. non-interactive services), the default
+         * window station is 'Service-0xXXXX-YYYY$' (created if needed).
+         * Precedence will however be taken by any inherited window station
+         * that possesses the required interactivity property.
+         */
+        bUseDefaultWinSta = TRUE;
+
+        /*
+         * Use the default 'WinSta0' window station. Whether we should
+         * use 'Service-0xXXXX-YYYY$' instead will be determined later.
+         */
+        // RtlInitUnicodeString(&WinStaName, L"WinSta0");
+        WinStaName = WinSta0Name;
+
+        if (ObFindHandleForObject(Process,
+                                  NULL,
+                                  ExWindowStationObjectType,
+                                  NULL,
+                                  (PHANDLE)&hWinSta))
+        {
+            TRACE("IntResolveDesktop: Inherited window station is: 0x%p\n", hWinSta);
         }
     }
 
-    if (*hDesktop == NULL)
+    /*
+     * If no desktop has been specified, search the process handle table
+     * for inherited desktop handles, otherwise use the Default desktop.
+     * Note that the inherited desktop that we may use, may not belong
+     * to the window station we will connect to.
+     */
+    if (DesktopName.Buffer == NULL)
     {
-        RtlInitUnicodeString(&ObjectName, pwstrDesktop);
+        /* Use a default desktop name */
+        RtlInitUnicodeString(&DesktopName, L"Default");
 
-        TRACE("parsed initial desktop: %wZ\n", &ObjectName);
+        if (ObFindHandleForObject(Process,
+                                  NULL,
+                                  ExDesktopObjectType,
+                                  NULL,
+                                  (PHANDLE)&hDesktop))
+        {
+            TRACE("IntResolveDesktop: Inherited desktop is: 0x%p\n", hDesktop);
+        }
+    }
+
+
+    /*
+     * We are going to open either a window station or a desktop.
+     * Even if this operation is done from kernel-mode, we should
+     * "emulate" an opening from user-mode (i.e. using an ObjectAttributes
+     * allocated in user-mode, with AccessMode == UserMode) for the
+     * Object Manager to perform proper access validation to the
+     * window station or desktop.
+     */
+
+    /*
+     * Estimate the maximum size needed for the window station name
+     * and desktop name to be given to ObjectAttributes->ObjectName.
+     */
+    StrSize = 0;
+
+    /* Window station name */
+    MemSize = _scwprintf(L"Service-0x%x-%x$", MAXULONG, MAXULONG) * sizeof(WCHAR);
+    MemSize = gustrWindowStationsDir.Length + sizeof(OBJ_NAME_PATH_SEPARATOR)
+              + max(WinStaName.Length, MemSize) + sizeof(UNICODE_NULL);
+    if (MemSize > MAXUSHORT)
+    {
+        ERR("IntResolveDesktop: Window station name length is too long.\n");
+        Status = STATUS_NAME_TOO_LONG;
+        goto Quit;
+    }
+    StrSize = max(StrSize, (USHORT)MemSize);
+
+    /* Desktop name */
+    MemSize = max(DesktopName.Length + sizeof(UNICODE_NULL), sizeof(L"Default"));
+    StrSize = max(StrSize, (USHORT)MemSize);
+
+    /* Size for the OBJECT_ATTRIBUTES */
+    MemSize = ALIGN_UP(sizeof(OBJECT_ATTRIBUTES), sizeof(PVOID));
+
+    /* Add the string size */
+    MemSize += ALIGN_UP(sizeof(UNICODE_STRING), sizeof(PVOID));
+    MemSize += StrSize;
+
+    /* Allocate the memory in user-mode */
+    Status = ZwAllocateVirtualMemory(ZwCurrentProcess(),
+                                     (PVOID*)&ObjectAttributes,
+                                     0,
+                                     &MemSize,
+                                     MEM_COMMIT,
+                                     PAGE_READWRITE);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("ZwAllocateVirtualMemory() failed, Status 0x%08lx\n", Status);
+        goto Quit;
+    }
+
+    ObjectName = (PUNICODE_STRING)((ULONG_PTR)ObjectAttributes +
+                     ALIGN_UP(sizeof(OBJECT_ATTRIBUTES), sizeof(PVOID)));
+
+    RtlInitEmptyUnicodeString(ObjectName,
+                              (PWCHAR)((ULONG_PTR)ObjectName +
+                                  ALIGN_UP(sizeof(UNICODE_STRING), sizeof(PVOID))),
+                              StrSize);
+
+
+    /* If we got an inherited window station handle, duplicate and use it */
+    if (hWinSta)
+    {
+        ASSERT(bUseDefaultWinSta);
+
+        /* Duplicate the handle if it belongs to another process than the current one */
+        if (Process != PsGetCurrentProcess())
+        {
+            ASSERT(hProcess);
+            Status = ZwDuplicateObject(hProcess,
+                                       hWinSta,
+                                       ZwCurrentProcess(),
+                                       (PHANDLE)&hWinStaDup,
+                                       0,
+                                       0,
+                                       DUPLICATE_SAME_ACCESS);
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("IntResolveDesktop: Failed to duplicate the window station handle, Status 0x%08lx\n", Status);
+                /* We will use a default window station */
+                hWinSta = NULL;
+            }
+            else
+            {
+                hWinSta = hWinStaDup;
+            }
+        }
+    }
+
+    /*
+     * If we have an inherited window station, check whether
+     * it is interactive and remember that for later.
+     */
+    if (hWinSta)
+    {
+        ASSERT(bUseDefaultWinSta);
+
+        /* Reference the inherited window station */
+        Status = ObReferenceObjectByHandle(hWinSta,
+                                           0,
+                                           ExWindowStationObjectType,
+                                           KernelMode,
+                                           (PVOID*)&WinStaObject,
+                                           NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            ERR("Failed to reference the inherited window station, Status 0x%08lx\n", Status);
+            /* We will use a default window station */
+            if (hWinStaDup)
+            {
+                ASSERT(hWinSta == hWinStaDup);
+                ObCloseHandle(hWinStaDup, UserMode);
+                hWinStaDup = NULL;
+            }
+            hWinSta = NULL;
+        }
+        else
+        {
+            ERR("Process LUID is: 0x%x-%x, inherited window station LUID is: 0x%x-%x\n",
+                ProcessLuid.HighPart, ProcessLuid.LowPart,
+                WinStaObject->luidUser.HighPart, WinStaObject->luidUser.LowPart);
+
+            /* Check whether this window station is interactive, and remember it for later */
+            bInteractive = !(WinStaObject->Flags & WSS_NOIO);
+
+            /* Dereference the window station */
+            ObDereferenceObject(WinStaObject);
+        }
+    }
+
+    /* Build a valid window station name */
+    Status = RtlStringCbPrintfW(ObjectName->Buffer,
+                                ObjectName->MaximumLength,
+                                L"%wZ\\%wZ",
+                                &gustrWindowStationsDir,
+                                &WinStaName);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("Impossible to build a valid window station name, Status 0x%08lx\n", Status);
+        goto Quit;
+    }
+    ObjectName->Length = (USHORT)(wcslen(ObjectName->Buffer) * sizeof(WCHAR));
+
+    TRACE("Parsed initial window station: '%wZ'\n", ObjectName);
+
+    /* Try to open the window station */
+    InitializeObjectAttributes(ObjectAttributes,
+                               ObjectName,
+                               OBJ_CASE_INSENSITIVE,
+                               NULL,
+                               NULL);
+    if (bInherit)
+        ObjectAttributes->Attributes |= OBJ_INHERIT;
+
+    Status = ObOpenObjectByName(ObjectAttributes,
+                                ExWindowStationObjectType,
+                                UserMode,
+                                NULL,
+                                WINSTA_ACCESS_ALL,
+                                NULL,
+                                (PHANDLE)&hTempWinSta);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("Failed to open the window station '%wZ', Status 0x%08lx\n", ObjectName, Status);
+    }
+    else
+    {
+        //
+        // FIXME TODO: Perform a window station access check!!
+        // If we fail AND bUseDefaultWinSta == FALSE we just quit.
+        //
+
+        /*
+         * Check whether we are opening the (single) interactive
+         * window station, and if so, perform an access check.
+         */
+        /* Check whether we are allowed to perform interactions */
+        if (RtlEqualUnicodeString(&WinStaName, &WinSta0Name, TRUE))
+        {
+            LUID SystemLuid = SYSTEM_LUID;
+
+            /* Interactive window station: check for user LUID */
+            WinStaObject = InputWindowStation;
+
+            Status = STATUS_ACCESS_DENIED;
+
+            // TODO: Check also that we compare wrt. window station WinSta0
+            // which is the only one that can be interactive on the system.
+            if (((!bUseDefaultWinSta || bInherit) && RtlEqualLuid(&ProcessLuid, &SystemLuid)) ||
+                 RtlEqualLuid(&ProcessLuid, &WinStaObject->luidUser))
+            {
+                /* We are interactive on this window station */
+                bAccessAllowed = TRUE;
+                Status = STATUS_SUCCESS;
+            }
+        }
+        else
+        {
+            /* Non-interactive window station: we have access since we were able to open it */
+            bAccessAllowed = TRUE;
+            Status = STATUS_SUCCESS;
+        }
+    }
+
+    /* If we failed, bail out if we were not trying to open the default window station */
+    if (!NT_SUCCESS(Status) && !bUseDefaultWinSta) // if (!bAccessAllowed)
+        goto Quit;
+
+    if (/* bAccessAllowed && */ bInteractive || !bAccessAllowed)
+    {
+        /*
+         * Close WinSta0 if the inherited window station is interactive so that
+         * we can use it, or we do not have access to the interactive WinSta0.
+         */
+        ObCloseHandle(hTempWinSta, UserMode);
+        hTempWinSta = NULL;
+    }
+    if (bInteractive == bAccessAllowed)
+    {
+        /* Keep using the inherited window station */
+        NOTHING;
+    }
+    else // if (bInteractive != bAccessAllowed)
+    {
+        /*
+         * Close the inherited window station, we will either keep using
+         * the interactive WinSta0, or use Service-0xXXXX-YYYY$.
+         */
+        if (hWinStaDup)
+        {
+            ASSERT(hWinSta == hWinStaDup);
+            ObCloseHandle(hWinStaDup, UserMode);
+            hWinStaDup = NULL;
+        }
+        hWinSta = hTempWinSta; // hTempWinSta is NULL in case bAccessAllowed == FALSE
+    }
+
+    if (bUseDefaultWinSta)
+    {
+        if (hWinSta == NULL && !bInteractive)
+        {
+            /* Build a valid window station name from the LUID */
+            Status = RtlStringCbPrintfW(ObjectName->Buffer,
+                                        ObjectName->MaximumLength,
+                                        L"%wZ\\Service-0x%x-%x$",
+                                        &gustrWindowStationsDir,
+                                        ProcessLuid.HighPart,
+                                        ProcessLuid.LowPart);
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("Impossible to build a valid window station name, Status 0x%08lx\n", Status);
+                goto Quit;
+            }
+            ObjectName->Length = (USHORT)(wcslen(ObjectName->Buffer) * sizeof(WCHAR));
+
+            /*
+             * Create or open the non-interactive window station.
+             * NOTE: The non-interactive window station handle is never inheritable.
+             */
+            // FIXME: Set security!
+            InitializeObjectAttributes(ObjectAttributes,
+                                       ObjectName,
+                                       OBJ_CASE_INSENSITIVE | OBJ_OPENIF,
+                                       NULL,
+                                       NULL);
+
+            Status = IntCreateWindowStation(&hWinSta,
+                                            ObjectAttributes,
+                                            UserMode,
+                                            KernelMode,
+                                            MAXIMUM_ALLOWED,
+                                            0, 0, 0, 0, 0);
+            if (!NT_SUCCESS(Status))
+            {
+                ASSERT(hWinSta == NULL);
+                ERR("Failed to create or open the non-interactive window station '%wZ', Status 0x%08lx\n",
+                    ObjectName, Status);
+                goto Quit;
+            }
+
+            //
+            // FIXME: We might not need to always create or open the "Default"
+            // desktop on the Service-0xXXXX-YYYY$ window station; we may need
+            // to use another one....
+            //
+
+            /* Create or open the Default desktop on the window station */
+            Status = RtlStringCbCopyW(ObjectName->Buffer,
+                                      ObjectName->MaximumLength,
+                                      L"Default");
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("Impossible to build a valid desktop name, Status 0x%08lx\n", Status);
+                goto Quit;
+            }
+            ObjectName->Length = (USHORT)(wcslen(ObjectName->Buffer) * sizeof(WCHAR));
+
+            /* NOTE: The non-interactive desktop handle is never inheritable. */
+            // FIXME: Set security!
+            InitializeObjectAttributes(ObjectAttributes,
+                                       ObjectName,
+                                       OBJ_CASE_INSENSITIVE | OBJ_OPENIF,
+                                       hWinSta,
+                                       NULL);
+
+            Status = IntCreateDesktop(&hDesktop,
+                                      ObjectAttributes,
+                                      UserMode,
+                                      NULL,
+                                      NULL,
+                                      0,
+                                      MAXIMUM_ALLOWED);
+            if (!NT_SUCCESS(Status))
+            {
+                ASSERT(hDesktop == NULL);
+                ERR("Failed to create or open the desktop '%wZ' on window station 0x%p, Status 0x%08lx\n",
+                    ObjectName, hWinSta, Status);
+            }
+
+            goto Quit;
+        }
+/*
+        if (hWinSta == NULL)
+        {
+            Status = STATUS_UNSUCCESSFUL;
+            goto Quit;
+        }
+*/
+    }
+
+    /*
+     * If we got an inherited desktop handle, duplicate and use it,
+     * otherwise open a new desktop.
+     */
+    if (hDesktop != NULL)
+    {
+        /* Duplicate the handle if it belongs to another process than the current one */
+        if (Process != PsGetCurrentProcess())
+        {
+            ASSERT(hProcess);
+            Status = ZwDuplicateObject(hProcess,
+                                       hDesktop,
+                                       ZwCurrentProcess(),
+                                       (PHANDLE)&hDesktopDup,
+                                       0,
+                                       0,
+                                       DUPLICATE_SAME_ACCESS);
+            if (!NT_SUCCESS(Status))
+            {
+                ERR("IntResolveDesktop: Failed to duplicate the desktop handle, Status 0x%08lx\n", Status);
+                /* We will use a default desktop */
+                hDesktop = NULL;
+            }
+            else
+            {
+                hDesktop = hDesktopDup;
+            }
+        }
+    }
+
+    if ((hWinSta != NULL) && (hDesktop == NULL))
+    {
+        Status = RtlStringCbCopyNW(ObjectName->Buffer,
+                                   ObjectName->MaximumLength,
+                                   DesktopName.Buffer,
+                                   DesktopName.Length);
+        if (!NT_SUCCESS(Status))
+        {
+            ERR("Impossible to build a valid desktop name, Status 0x%08lx\n", Status);
+            goto Quit;
+        }
+        ObjectName->Length = (USHORT)(wcslen(ObjectName->Buffer) * sizeof(WCHAR));
+
+        TRACE("Parsed initial desktop: '%wZ'\n", ObjectName);
 
         /* Open the desktop object */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &ObjectName,
+        InitializeObjectAttributes(ObjectAttributes,
+                                   ObjectName,
                                    OBJ_CASE_INSENSITIVE,
-                                   *hWinSta,
+                                   hWinSta,
                                    NULL);
+        if (bInherit)
+            ObjectAttributes->Attributes |= OBJ_INHERIT;
 
-        Status = ObOpenObjectByName(&ObjectAttributes,
+        Status = ObOpenObjectByName(ObjectAttributes,
                                     ExDesktopObjectType,
-                                    KernelMode,
+                                    UserMode,
                                     NULL,
                                     DESKTOP_ALL_ACCESS,
                                     NULL,
-                                    (HANDLE*)hDesktop);
-
+                                    (PHANDLE)&hDesktop);
         if (!NT_SUCCESS(Status))
         {
-            *hDesktop = NULL;
-            NtClose(*hWinSta);
-            *hWinSta = NULL;
-            SetLastNtError(Status);
-            ERR("Failed to reference desktop %wZ PID: --!\n", &ObjectName);
-            return Status;
+            ERR("Failed to open the desktop '%wZ' on window station 0x%p, Status 0x%08lx\n",
+                ObjectName, hWinSta, Status);
+            goto Quit;
         }
     }
-    return STATUS_SUCCESS;
+
+Quit:
+    /* Release the object attributes */
+    if (ObjectAttributes)
+    {
+        MemSize = 0;
+        ZwFreeVirtualMemory(ZwCurrentProcess(),
+                            (PVOID*)&ObjectAttributes,
+                            &MemSize,
+                            MEM_RELEASE);
+    }
+
+    /* Close the temporary process handle */
+    if (hProcess) // if (Process != PsGetCurrentProcess())
+        ObCloseHandle(hProcess, KernelMode);
+
+    if (NT_SUCCESS(Status))
+    {
+        *phWinSta  = hWinSta;
+        *phDesktop = hDesktop;
+        return STATUS_SUCCESS;
+    }
+    else
+    {
+        ERR("IntResolveDesktop(%wZ) failed, Status 0x%08lx\n", DesktopPath, Status);
+
+        if (hDesktopDup)
+            ObCloseHandle(hDesktopDup, UserMode);
+        if (hWinStaDup)
+            ObCloseHandle(hWinStaDup, UserMode);
+
+        if (hDesktop)
+            ObCloseHandle(hDesktop, UserMode);
+        if (hWinSta)
+            ObCloseHandle(hWinSta, UserMode);
+
+        SetLastNtError(Status);
+        return Status;
+    }
 }
 
 /*
@@ -2115,15 +2702,24 @@ NtUserPaintDesktop(HDC hDC)
 /*
  * NtUserResolveDesktop
  *
- * The NtUserResolveDesktop function retrieves handles to the desktop and
- * the window station specified by the desktop path string.
+ * The NtUserResolveDesktop function attempts to retrieve valid handles to
+ * a desktop and a window station suitable for the specified process.
+ * The specified desktop path string is used only as a hint for the resolution.
+ *
+ * See the description of IntResolveDesktop for more details.
  *
  * Parameters
  *    ProcessHandle
  *       Handle to a user process.
  *
  *    DesktopPath
- *       The desktop path string.
+ *       The desktop path string used as a hint for desktop resolution.
+ *
+ *    bInherit
+ *       Whether or not the returned handles are inheritable.
+ *
+ *    phWinSta
+ *       Pointer to a window station handle.
  *
  * Return Value
  *    Handle to the desktop (direct return value) and
@@ -2138,17 +2734,18 @@ NtUserPaintDesktop(HDC hDC)
  */
 
 HDESK
-APIENTRY
+NTAPI
 NtUserResolveDesktop(
     IN HANDLE ProcessHandle,
     IN PUNICODE_STRING DesktopPath,
-    DWORD dwUnknown,
+    IN BOOL bInherit,
     OUT HWINSTA* phWinSta)
 {
     NTSTATUS Status;
-    PEPROCESS Process = NULL;
+    PEPROCESS Process;
     HWINSTA hWinSta = NULL;
     HDESK hDesktop  = NULL;
+    UNICODE_STRING CapturedDesktopPath;
 
     /* Allow only the Console Server to perform this operation (via CSRSS) */
     if (PsGetCurrentProcess() != gpepCSRSS)
@@ -2161,43 +2758,62 @@ NtUserResolveDesktop(
                                        UserMode,
                                        (PVOID*)&Process,
                                        NULL);
-    if (!NT_SUCCESS(Status)) return NULL;
+    if (!NT_SUCCESS(Status))
+        return NULL;
 
     // UserEnterShared();
 
     _SEH2_TRY
     {
-        UNICODE_STRING CapturedDesktopPath;
-
-        /* Capture the user desktop path string */
-        Status = IntSafeCopyUnicodeStringTerminateNULL(&CapturedDesktopPath,
-                                                       DesktopPath);
-        if (!NT_SUCCESS(Status)) _SEH2_YIELD(goto Quit);
-
-        /* Call the internal function */
-        Status = IntParseDesktopPath(Process,
-                                     &CapturedDesktopPath,
-                                     &hWinSta,
-                                     &hDesktop);
-        if (!NT_SUCCESS(Status))
-        {
-            ERR("IntParseDesktopPath failed, Status = 0x%08lx\n", Status);
-            hWinSta  = NULL;
-            hDesktop = NULL;
-        }
-
-        /* Return the window station handle */
-        *phWinSta = hWinSta;
-
-        /* Free the captured string */
-        if (CapturedDesktopPath.Buffer)
-            ExFreePoolWithTag(CapturedDesktopPath.Buffer, TAG_STRING);
+        /* Probe the handle pointer */
+        // ProbeForWriteHandle
+        ProbeForWrite(phWinSta, sizeof(HWINSTA), sizeof(HWINSTA));
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
         Status = _SEH2_GetExceptionCode();
+        _SEH2_YIELD(goto Quit);
     }
     _SEH2_END;
+
+    /* Capture the user desktop path string */
+    Status = ProbeAndCaptureUnicodeString(&CapturedDesktopPath,
+                                          UserMode,
+                                          DesktopPath);
+    if (!NT_SUCCESS(Status))
+        goto Quit;
+
+    /* Call the internal function */
+    Status = IntResolveDesktop(Process,
+                               &CapturedDesktopPath,
+                               bInherit,
+                               &hWinSta,
+                               &hDesktop);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntResolveDesktop failed, Status 0x%08lx\n", Status);
+        hWinSta  = NULL;
+        hDesktop = NULL;
+    }
+
+    _SEH2_TRY
+    {
+        /* Return the window station handle */
+        *phWinSta = hWinSta;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        Status = _SEH2_GetExceptionCode();
+
+        /* We failed, close the opened desktop and window station */
+        if (hDesktop) ObCloseHandle(hDesktop, UserMode);
+        hDesktop = NULL;
+        if (hWinSta) ObCloseHandle(hWinSta, UserMode);
+    }
+    _SEH2_END;
+
+    /* Free the captured string */
+    ReleaseCapturedUnicodeString(&CapturedDesktopPath, UserMode);
 
 Quit:
     // UserLeave();

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -1753,7 +1753,7 @@ IntCreateDesktop(
     /* In case the object was not created (eg if it existed), return now */
     if (Context == FALSE)
     {
-        TRACE("NtUserCreateDesktop opened desktop %wZ\n", ObjectAttributes->ObjectName);
+        TRACE("IntCreateDesktop opened desktop '%wZ'\n", ObjectAttributes->ObjectName);
         Status = STATUS_SUCCESS;
         goto Quit;
     }
@@ -1825,8 +1825,8 @@ IntCreateDesktop(
     Cs.cx = Cs.cy = 100;
     Cs.style = WS_POPUP|WS_CLIPCHILDREN;
     Cs.hInstance = hModClient; // hModuleWin; // Server side winproc!
-    Cs.lpszName = (LPCWSTR) &WindowName;
-    Cs.lpszClass = (LPCWSTR) &ClassName;
+    Cs.lpszName = (LPCWSTR)&WindowName;
+    Cs.lpszClass = (LPCWSTR)&ClassName;
     pWnd = IntCreateWindow(&Cs, &WindowName, pcls, NULL, NULL, NULL, pdesk);
     if (pWnd == NULL)
     {
@@ -2050,7 +2050,7 @@ NtUserCloseDesktop(HDESK hDesktop)
     NTSTATUS Status;
     DECLARE_RETURN(BOOL);
 
-    TRACE("NtUserCloseDesktop called (0x%p)\n", hDesktop);
+    TRACE("NtUserCloseDesktop(0x%p) called\n", hDesktop);
     UserEnterExclusive();
 
     if (hDesktop == gptiCurrent->hdesk || hDesktop == gptiCurrent->ppi->hdeskStartup)
@@ -2060,10 +2060,10 @@ NtUserCloseDesktop(HDESK hDesktop)
         RETURN(FALSE);
     }
 
-    Status = IntValidateDesktopHandle( hDesktop, UserMode, 0, &pdesk);
+    Status = IntValidateDesktopHandle(hDesktop, UserMode, 0, &pdesk);
     if (!NT_SUCCESS(Status))
     {
-        ERR("Validation of desktop handle (0x%p) failed\n", hDesktop);
+        ERR("Validation of desktop handle 0x%p failed\n", hDesktop);
         RETURN(FALSE);
     }
 
@@ -2236,10 +2236,10 @@ NtUserSwitchDesktop(HDESK hdesk)
     UserEnterExclusive();
     TRACE("Enter NtUserSwitchDesktop(0x%p)\n", hdesk);
 
-    Status = IntValidateDesktopHandle( hdesk, UserMode, 0, &pdesk);
+    Status = IntValidateDesktopHandle(hdesk, UserMode, 0, &pdesk);
     if (!NT_SUCCESS(Status))
     {
-        ERR("Validation of desktop handle (0x%p) failed\n", hdesk);
+        ERR("Validation of desktop handle 0x%p failed\n", hdesk);
         RETURN(FALSE);
     }
 
@@ -2539,10 +2539,10 @@ IntSetThreadDesktop(IN HDESK hDesktop,
     if (hDesktop != NULL)
     {
         /* Validate the new desktop. */
-        Status = IntValidateDesktopHandle( hDesktop, UserMode, 0, &pdesk);
+        Status = IntValidateDesktopHandle(hDesktop, UserMode, 0, &pdesk);
         if (!NT_SUCCESS(Status))
         {
-            ERR("Validation of desktop handle (0x%p) failed\n", hDesktop);
+            ERR("Validation of desktop handle 0x%p failed\n", hDesktop);
             return FALSE;
         }
 
@@ -2583,7 +2583,7 @@ IntSetThreadDesktop(IN HDESK hDesktop,
             return FALSE;
         }
 
-        pctiNew = DesktopHeapAlloc( pdesk, sizeof(CLIENTTHREADINFO));
+        pctiNew = DesktopHeapAlloc(pdesk, sizeof(CLIENTTHREADINFO));
         if (pctiNew == NULL)
         {
             ERR("Failed to allocate new pcti\n");

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -2656,7 +2656,7 @@ NtUserCloseDesktop(HDESK hDesktop)
 
     ObDereferenceObject(pdesk);
 
-    Status = ZwClose(hDesktop);
+    Status = ObCloseHandle(hDesktop, UserMode);
     if (!NT_SUCCESS(Status))
     {
         ERR("Failed to close desktop handle 0x%p\n", hDesktop);

--- a/win32ss/user/ntuser/desktop.h
+++ b/win32ss/user/ntuser/desktop.h
@@ -161,6 +161,15 @@ IntHideDesktop(PDESKTOP Desktop);
 BOOL IntSetThreadDesktop(IN HDESK hDesktop,
                          IN BOOL FreeOnFailure);
 
+NTSTATUS
+FASTCALL
+IntResolveDesktop(
+    IN PEPROCESS Process,
+    IN PUNICODE_STRING DesktopPath,
+    IN BOOL bInherit,
+    OUT HWINSTA* phWinSta,
+    OUT HDESK* phDesktop);
+
 NTSTATUS FASTCALL
 IntValidateDesktopHandle(
    HDESK Desktop,
@@ -178,12 +187,6 @@ IntCreateDesktop(
     IN LPDEVMODEW lpdmw OPTIONAL,
     IN DWORD dwFlags,
     IN ACCESS_MASK dwDesiredAccess);
-
-NTSTATUS FASTCALL
-IntParseDesktopPath(PEPROCESS Process,
-                    PUNICODE_STRING DesktopPath,
-                    HWINSTA *hWinSta,
-                    HDESK *hDesktop);
 
 VOID APIENTRY UserRedrawDesktop(VOID);
 BOOL IntRegisterShellHookWindow(HWND hWnd);

--- a/win32ss/user/ntuser/desktop.h
+++ b/win32ss/user/ntuser/desktop.h
@@ -168,6 +168,17 @@ IntValidateDesktopHandle(
    ACCESS_MASK DesiredAccess,
    PDESKTOP *Object);
 
+NTSTATUS
+FASTCALL
+IntCreateDesktop(
+    OUT HDESK* phDesktop,
+    IN POBJECT_ATTRIBUTES ObjectAttributes,
+    IN KPROCESSOR_MODE AccessMode,
+    IN PUNICODE_STRING lpszDesktopDevice OPTIONAL,
+    IN LPDEVMODEW lpdmw OPTIONAL,
+    IN DWORD dwFlags,
+    IN ACCESS_MASK dwDesiredAccess);
+
 NTSTATUS FASTCALL
 IntParseDesktopPath(PEPROCESS Process,
                     PUNICODE_STRING DesktopPath,

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -577,7 +577,8 @@ InitThreadCallback(PETHREAD Thread)
      */
     // if (ptiCurrent->ppi->hdeskStartup == NULL && InputWindowStation != NULL)
     /* Last things to do only if we are not a SYSTEM or CSRSS thread */
-    if (!(ptiCurrent->TIF_flags & (TIF_SYSTEMTHREAD | TIF_CSRSSTHREAD)) &&
+    // HACK Part #1: Temporarily disabled to have our current USERSRV running, but normally this is its duty to connect itself to the required desktop!
+    if (// !(ptiCurrent->TIF_flags & (TIF_SYSTEMTHREAD | TIF_CSRSSTHREAD)) &&
         /**/ptiCurrent->ppi->hdeskStartup == NULL &&/**/
         InputWindowStation != NULL)
     {
@@ -585,6 +586,10 @@ InitThreadCallback(PETHREAD Thread)
         HDESK hDesk = NULL;
         UNICODE_STRING DesktopPath;
         PDESKTOP pdesk;
+
+        // HACK Part #2: We force USERSRV to connect to WinSta0 by setting the STARTF_INHERITDESKTOP flag.
+        if (ptiCurrent->TIF_flags & (TIF_SYSTEMTHREAD | TIF_CSRSSTHREAD))
+            ProcessParams->WindowFlags |= STARTF_INHERITDESKTOP;
 
         /*
          * Inherit the thread desktop and process window station (if not yet inherited)

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -165,8 +165,8 @@ UserProcessCreate(PEPROCESS Process)
 
     /* Setup process flags */
     ppiCurrent->W32PF_flags |= W32PF_PROCESSCONNECTED;
-    if ( Process->Peb->ProcessParameters &&
-         Process->Peb->ProcessParameters->WindowFlags & STARTF_SCRNSAVER )
+    if (Process->Peb->ProcessParameters &&
+        (Process->Peb->ProcessParameters->WindowFlags & STARTF_SCREENSAVER))
     {
         ppiScrnSaver = ppiCurrent;
         ppiCurrent->W32PF_flags |= W32PF_SCREENSAVER;
@@ -603,7 +603,7 @@ InitThreadCallback(PETHREAD Thread)
 
         Status = IntResolveDesktop(Process,
                                    &DesktopPath,
-                                   FALSE,
+                                   !!(ProcessParams->WindowFlags & STARTF_INHERITDESKTOP),
                                    &hWinSta,
                                    &hDesk);
 

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -9,6 +9,30 @@
 #include <win32k.h>
 DBG_DEFAULT_CHANNEL(UserMisc);
 
+
+/*
+ * NOTE: _scwprintf() is NOT exported by ntoskrnl.exe,
+ * only _vscwprintf() is, so we need to implement it here.
+ * Code comes from sdk/lib/crt/printf/_scwprintf.c .
+ * See also win32ss/user/winsrv/usersrv/harderror.c .
+ */
+int
+__cdecl
+_scwprintf(
+    const wchar_t *format,
+    ...)
+{
+    int len;
+    va_list args;
+
+    va_start(args, format);
+    len = _vscwprintf(format, args);
+    va_end(args);
+
+    return len;
+}
+
+
 /*
  * Test the Thread to verify and validate it. Hard to the core tests are required.
  */

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -762,4 +762,41 @@ GetW32ThreadInfo(VOID)
     return (PTHREADINFO)PsGetCurrentThreadWin32Thread();
 }
 
+
+NTSTATUS
+GetProcessLuid(
+    IN PETHREAD Thread OPTIONAL,
+    OUT PLUID Luid)
+{
+    NTSTATUS Status;
+    PACCESS_TOKEN Token;
+    SECURITY_IMPERSONATION_LEVEL ImpersonationLevel;
+    BOOLEAN CopyOnOpen, EffectiveOnly;
+
+    if (Thread == NULL)
+        Thread = PsGetCurrentThread();
+
+    /* Use a thread token */
+    Token = PsReferenceImpersonationToken(Thread,
+                                          &CopyOnOpen,
+                                          &EffectiveOnly,
+                                          &ImpersonationLevel);
+    if (Token == NULL)
+    {
+        /* We don't have a thread token, use a process token */
+        Token = PsReferencePrimaryToken(PsGetThreadProcess(Thread));
+
+        /* If no token, fail */
+        if (Token == NULL)
+            return STATUS_NO_TOKEN;
+    }
+
+    /* Query the LUID */
+    Status = SeQueryAuthenticationIdToken(Token, Luid);
+
+    /* Get rid of the token and return */
+    ObDereferenceObject(Token);
+    return Status;
+}
+
 /* EOF */

--- a/win32ss/user/ntuser/shutdown.c
+++ b/win32ss/user/ntuser/shutdown.c
@@ -88,42 +88,6 @@ IntClientShutdown(IN PWND pWindow,
     return lResult;
 }
 
-
-NTSTATUS
-GetProcessLuid(IN PETHREAD Thread OPTIONAL,
-               OUT PLUID Luid)
-{
-    NTSTATUS Status;
-    PACCESS_TOKEN Token;
-    SECURITY_IMPERSONATION_LEVEL ImpersonationLevel;
-    BOOLEAN CopyOnOpen, EffectiveOnly;
-
-    if (Thread == NULL)
-        Thread = PsGetCurrentThread();
-
-    /* Use a thread token */
-    Token = PsReferenceImpersonationToken(Thread,
-                                          &CopyOnOpen,
-                                          &EffectiveOnly,
-                                          &ImpersonationLevel);
-    if (Token == NULL)
-    {
-        /* We don't have a thread token, use a process token */
-        Token = PsReferencePrimaryToken(PsGetThreadProcess(Thread));
-
-        /* If no token, fail */
-        if (Token == NULL)
-            return STATUS_NO_TOKEN;
-    }
-
-    /* Query the LUID */
-    Status = SeQueryAuthenticationIdToken(Token, Luid);
-
-    /* Get rid of the token and return */
-    ObDereferenceObject(Token);
-    return Status;
-}
-
 BOOLEAN
 HasPrivilege(IN PPRIVILEGE_SET Privilege)
 {

--- a/win32ss/user/ntuser/shutdown.c
+++ b/win32ss/user/ntuser/shutdown.c
@@ -181,7 +181,7 @@ UserInitiateShutdown(IN PETHREAD Thread,
     TRACE("UserInitiateShutdown\n");
 
     /* Get the caller's LUID */
-    Status = GetProcessLuid(Thread, &CallerLuid);
+    Status = GetProcessLuid(Thread, NULL, &CallerLuid);
     if (!NT_SUCCESS(Status))
     {
         ERR("UserInitiateShutdown: GetProcessLuid failed\n");
@@ -302,10 +302,10 @@ UserEndShutdown(IN PETHREAD Thread,
      */
     //STUB;
 
-    Status = GetProcessLuid(Thread, &CallerLuid);
+    Status = GetProcessLuid(Thread, NULL, &CallerLuid);
     if (!NT_SUCCESS(Status))
     {
-        ERR("GetProcessLuid failed\n");
+        ERR("UserEndShutdown: GetProcessLuid failed\n");
         return Status;
     }
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -33,7 +33,8 @@ BOOL g_PaintDesktopVersion = FALSE;
         } \
         else \
         { \
-            ERR("NtUserSystemParametersInfo requires interactive window station (current is %wZ)\n", &GetW32ProcessInfo()->prpwinsta->Name); \
+            ERR("NtUserSystemParametersInfo requires interactive window station (current is %wZ)\n", \
+                &(OBJECT_HEADER_TO_NAME_INFO(OBJECT_TO_OBJECT_HEADER(GetW32ProcessInfo()->prpwinsta))->Name)); \
         } \
         EngSetLastError(err); \
         return 0; \

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -25,6 +25,7 @@ BOOL g_PaintDesktopVersion = FALSE;
 #define METRIC2REG(met) (-((((met) * 1440)- 0) / dpi))
 
 #define REQ_INTERACTIVE_WINSTA(err) \
+do { \
     if (GetW32ProcessInfo()->prpwinsta != InputWindowStation) \
     { \
         if (GetW32ProcessInfo()->prpwinsta == NULL) \
@@ -33,12 +34,13 @@ BOOL g_PaintDesktopVersion = FALSE;
         } \
         else \
         { \
-            ERR("NtUserSystemParametersInfo requires interactive window station (current is %wZ)\n", \
+            ERR("NtUserSystemParametersInfo requires interactive window station (current is '%wZ')\n", \
                 &(OBJECT_HEADER_TO_NAME_INFO(OBJECT_TO_OBJECT_HEADER(GetW32ProcessInfo()->prpwinsta))->Name)); \
         } \
         EngSetLastError(err); \
         return 0; \
-    }
+    } \
+} while (0)
 
 static const WCHAR* KEY_MOUSE = L"Control Panel\\Mouse";
 static const WCHAR* VAL_MOUSE1 = L"MouseThreshold1";

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -105,6 +105,11 @@ PTHREADINFO FASTCALL IntTID2PTI(HANDLE);
 HBRUSH FASTCALL GetControlBrush(PWND,HDC,UINT);
 HBRUSH FASTCALL GetControlColor(PWND,PWND,HDC,UINT);
 
+NTSTATUS
+GetProcessLuid(
+    IN PETHREAD Thread OPTIONAL,
+    OUT PLUID Luid);
+
 /*************** MESSAGE.C ***************/
 
 BOOL FASTCALL UserPostMessage(HWND Wnd,UINT Msg, WPARAM wParam, LPARAM lParam);

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -92,6 +92,12 @@ HKL FASTCALL UserGetKeyboardLayout(DWORD dwThreadId);
 
 /*************** MISC.C ***************/
 
+int
+__cdecl
+_scwprintf(
+    const wchar_t *format,
+    ...);
+
 BOOL FASTCALL
 UserSystemParametersInfo(
   UINT uiAction,

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -108,6 +108,7 @@ HBRUSH FASTCALL GetControlColor(PWND,PWND,HDC,UINT);
 NTSTATUS
 GetProcessLuid(
     IN PETHREAD Thread OPTIONAL,
+    IN PEPROCESS Process OPTIONAL,
     OUT PLUID Luid);
 
 /*************** MESSAGE.C ***************/

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -971,7 +971,7 @@ NtUserCloseWindowStation(
                                             UserMode,
                                             0,
                                             &Object,
-                                            0);
+                                            NULL);
 
     if (!NT_SUCCESS(Status))
     {
@@ -1449,7 +1449,7 @@ NtUserLockWindowStation(HWINSTA hWindowStation)
                                             UserMode,
                                             0,
                                             &Object,
-                                            0);
+                                            NULL);
     if (!NT_SUCCESS(Status))
     {
         TRACE("Validation of window station handle (%p) failed\n",
@@ -1494,7 +1494,7 @@ NtUserUnlockWindowStation(HWINSTA hWindowStation)
                                             UserMode,
                                             0,
                                             &Object,
-                                            0);
+                                            NULL);
     if (!NT_SUCCESS(Status))
     {
         TRACE("Validation of window station handle (%p) failed\n",
@@ -1718,7 +1718,7 @@ BuildDesktopNameList(
                                             UserMode,
                                             0,
                                             &WindowStation,
-                                            0);
+                                            NULL);
     if (! NT_SUCCESS(Status))
     {
         return Status;

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -107,6 +107,19 @@ IntValidateWindowStationHandle(
    PWINSTATION_OBJECT *Object,
    POBJECT_HANDLE_INFORMATION pObjectHandleInfo);
 
+NTSTATUS
+FASTCALL
+IntCreateWindowStation(
+    OUT HWINSTA* phWinSta,
+    IN POBJECT_ATTRIBUTES ObjectAttributes,
+    IN KPROCESSOR_MODE AccessMode,
+    IN ACCESS_MASK dwDesiredAccess,
+    DWORD Unknown2,
+    DWORD Unknown3,
+    DWORD Unknown4,
+    DWORD Unknown5,
+    DWORD Unknown6);
+
 BOOL FASTCALL UserSetProcessWindowStation(HWINSTA hWindowStation);
 
 BOOL FASTCALL co_IntInitializeDesktopGraphics(VOID);

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -15,7 +15,6 @@ typedef struct _WINSTATION_OBJECT
 {
     DWORD dwSessionId;
 
-    UNICODE_STRING Name;
     LIST_ENTRY DesktopListHead;
     PRTL_ATOM_TABLE AtomTable;
     HANDLE ShellWindow;

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -112,6 +112,7 @@ IntCreateWindowStation(
     OUT HWINSTA* phWinSta,
     IN POBJECT_ATTRIBUTES ObjectAttributes,
     IN KPROCESSOR_MODE AccessMode,
+    IN KPROCESSOR_MODE OwnerMode,
     IN ACCESS_MASK dwDesiredAccess,
     DWORD Unknown2,
     DWORD Unknown3,

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.c
@@ -324,7 +324,7 @@ GuiInit(IN PCONSOLE_INIT_INFO ConsoleInitInfo,
 
     hDesk = NtUserResolveDesktop(ConsoleLeaderProcessHandle,
                                  &DesktopPath,
-                                 0,
+                                 FALSE,
                                  &hWinSta);
     DPRINT("NtUserResolveDesktop(DesktopPath = '%wZ') returned hDesk = 0x%p; hWinSta = 0x%p\n",
            &DesktopPath, hDesk, hWinSta);


### PR DESCRIPTION
- Additions to handle calls to CreateWindowStation with a NULL or empty provided window station name.
I expect some fixes in user32:winstation winetests.

- TODO:
- [x] Making NtUserResolveDesktop work as expected for Win2k3.

JIRA issue: [CORE-11933](https://jira.reactos.org/browse/CORE-11933)
Test case is Git-for-Windows' mintty console, which uses Cygwin.
The related code is: [fhandler_console.cc!fhandler_console::create_invisible_console()](https://github.com/cygwin/cygwin/blob/7b9bfb4136f23655e243bab89fb62b04bdbacc7f/winsup/cygwin/fhandler_console.cc#L2494)

Testbot results:
https://reactos.org/testman/compare.php?ids=61114,61120,61123
While both user32:GetUserObjectInformation and user32:winstation show improvements, user32:desktop has regressed. I will investigate.