### PR TITLE
[LPK] Winetest Crash fix + code refactoring/changes

### DIFF
--- a/dll/win32/lpk/lpk.c
+++ b/dll/win32/lpk/lpk.c
@@ -145,7 +145,7 @@ LpkGetCharacterPlacement(
     if (lpResults->lpGlyphs)
     {
         if (lpGlyphs)
-            wcscpy(lpResults->lpGlyphs, lpGlyphs);
+            StringCchCopyW(lpResults->lpGlyphs, cGlyphs, lpGlyphs);
 
         else if (lpResults->lpOutString)
             GetGlyphIndicesW(hdc, lpResults->lpOutString, nSet, lpResults->lpGlyphs, 0);
@@ -154,7 +154,7 @@ LpkGetCharacterPlacement(
     if (lpResults->lpDx)
     {
         /* If glyph shaping was requested */
-        if(dwFlags & GCP_GLYPHSHAPE)
+        if (dwFlags & GCP_GLYPHSHAPE)
         {
             int c;
 
@@ -162,7 +162,7 @@ LpkGetCharacterPlacement(
             {
                 for (i = 0; i < lpResults->nGlyphs; i++)
                 {
-                    if (GetCharWidth32W(hdc, lpResults->lpGlyphs[i], lpResults->lpGlyphs[i], &c))
+                    if (GetCharWidthI(hdc, 0, 1, (WORD *)&lpResults->lpGlyphs[i], &c))
                         lpResults->lpDx[i] = c;
                 }
             }

--- a/dll/win32/lpk/ros_lpk.h
+++ b/dll/win32/lpk/ros_lpk.h
@@ -17,6 +17,7 @@
 #include <wingdi.h>
 #include <winnls.h>
 #include <usp10.h>
+#include <strsafe.h>
 
 /* FIXME USP10 api that does not have prototype in any include file */
 VOID WINAPI LpkPresent(VOID);


### PR DESCRIPTION
## Purpose

Added additional code in case BIDI_reorder doesn't create the lpGlyphs array, fixes CORE-14732.
ExtTextOutW code changes are similar on how wine handles if lyGlyphs array is NULL.
Added memory management in LpkExtTextOut
Refactored some codepaths in LpkGetCharacterPlacement

JIRA issue: [CORE-14732](https://jira.reactos.org/browse/CORE-14732)

No functional changes unless the above mentioned error occurs.

Thanks to @Doug-Lyons for bringing out the issue and finding the cause of it.

