### PR TITLE
CORE-14734. [LOG2LINES] Enforce "Iso" type when unpacking the Iso file

### DIFF
--- a/sdk/tools/log2lines/config.h
+++ b/sdk/tools/log2lines/config.h
@@ -21,7 +21,7 @@
 
 #define CMD_7Z          "7z"
 #define UNZIP_FMT_7Z    "%s e -y %s -o%s > " DEV_NULL
-#define UNZIP_FMT       "%s x -y -r %s -o%s > " DEV_NULL
+#define UNZIP_FMT       "%s x -tIso -y -r %s -o%s > " DEV_NULL
 #define UNZIP_FMT_CAB \
 "%s x -y -r %s" PATH_STR "reactos" PATH_STR "reactos.cab -o%s" \
 PATH_STR "reactos" PATH_STR "reactos > " DEV_NULL


### PR DESCRIPTION
## Purpose

Work around some "7z" dealing with files not named "*.iso" as "Cab" type.

JIRA issue: [CORE-14734](https://jira.reactos.org/browse/CORE-14734)

## Proposed changes

- Enforce "Iso" type when unpacking the Iso file
