### PR TITLE
[SHELL32] Fixed TRASH_CanTrashFile() sending the wrong path string to GetVolumeInformationW()

### DIFF
--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -851,8 +851,14 @@ static void processRegLinesW(FILE *in)
                 if(*s_eol == '\r' && *(s_eol+1) == '\n')
                     NextLine++;
 
-                while(*(NextLine+1) == ' ' || *(NextLine+1) == '\t')
+                while(isspaceW(*NextLine))
                     NextLine++;
+
+                if (!*NextLine)
+                {
+                    s = NextLine;
+                    break;
+                }
 
                 MoveMemory(s_eol - 1, NextLine, (CharsInBuf - (NextLine - s) + 1)*sizeof(WCHAR));
                 CharsInBuf -= NextLine - s_eol + 1;

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -889,13 +889,9 @@ TRASH_CanTrashFile(LPCWSTR wszPath)
         return FALSE;
     }
 
-    // Create a wide character buffer for our path copy
+    // Copy and retrieve the root path from get given string
     WCHAR wszRootPathName[MAX_PATH];
-
-    // Copy the path given so we can modify it (copies at most MAX_PATH)
-    StringCbCopy(wszRootPathName, MAX_PATH, wszPath);
-    
-    // Get just the root path
+    StringCbCopy(wszRootPathName, sizeof(wszRootPathName), wszPath);
     PathStripToRootW(wszRootPathName);
 
     // Test to see if the drive is fixed (non removable)
@@ -907,7 +903,7 @@ TRASH_CanTrashFile(LPCWSTR wszPath)
 
     if (!GetVolumeInformationW(wszRootPathName, NULL, 0, &VolSerialNumber, &MaxComponentLength, &FileSystemFlags, NULL, 0))
     {
-        ERR("GetVolumeInformationW failed with %u wszRootPathName[%s]\n", GetLastError(), debugstr_w(wszRootPathName));
+        ERR("GetVolumeInformationW failed with %u wszRootPathName=%s\n", GetLastError(), debugstr_w(wszRootPathName));
         return FALSE;
     }
 

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -870,7 +870,7 @@ HRESULT WINAPI CRecycleBin::Initialize(LPCITEMIDLIST pidlFolder, IDataObject *pd
 
 /**
  * Tests whether a file can be trashed
- * @param wszPath Path to the file to trash
+ * @param wszPath Path to the file to be trash
  * @returns TRUE if the file can be trashed, FALSE otherwise
  */
 BOOL
@@ -889,14 +889,14 @@ TRASH_CanTrashFile(LPCWSTR wszPath)
         return FALSE;
     }
 
-    // Create a Wide character buffer and copy the given path
+    // Create a wide character buffer and copy the given path
     WCHAR wszRootPathName[MAX_PATH];
     strcpyW(wszRootPathName, wszPath); // warning: possible buffer overflow
     
     // Get just the root path
     PathStripToRootW(wszRootPathName);
 
-    // Test to see if the file is not fixed (non removable)
+    // Test to see if the drive is fixed (non removable)
     if (GetDriveTypeW(wszRootPathName) != DRIVE_FIXED)
     {
         /* no bitbucket on removable media */

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -889,9 +889,11 @@ TRASH_CanTrashFile(LPCWSTR wszPath)
         return FALSE;
     }
 
-    // Create a wide character buffer and copy the given path
+    // Create a wide character buffer for our path copy
     WCHAR wszRootPathName[MAX_PATH];
-    strcpyW(wszRootPathName, wszPath); // warning: possible buffer overflow
+
+    // Copy the path given so we can modify it (copies at most MAX_PATH)
+    StringCbCopy(wszRootPathName, MAX_PATH, wszPath);
     
     // Get just the root path
     PathStripToRootW(wszRootPathName);


### PR DESCRIPTION
## Purpose

Function TRASH_CanTrashFile() would always fail because GetVolumeInformationW() requires only the base root path. The path (stored in buffer wszRootPathName) was not being stripped correctly.

Note this issue [CORE-12340] appears to have regressed and is currently in reactos:master.
JIRA issue: [CORE-12340](https://jira.reactos.org/browse/CORE-12340)

## Proposed changes
- Remove PathRemoveFileSpecW as this did nothing relevant
- PathAddBackslashW is redundant as PathStripToRootW already has a backslash
- Added a function header
- Added my name to file header
- Cleaned up some comments near the change to be more clearer.
- Added some more debug information to the ERR when GetVolumeInformationW fails