### PR TITLE
[NEWDEV] Fix a truncated text

### DIFF
--- a/dll/win32/newdev/lang/ru-RU.rc
+++ b/dll/win32/newdev/lang/ru-RU.rc
@@ -19,7 +19,7 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYS
 CAPTION "Мастер нового оборудования"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Это оборудование установить не удалось", IDC_FINISHTITLE, 120, 8, 195, 16
+    LTEXT "Это оборудование установить не удалось", IDC_FINISHTITLE, 120, 8, 195, 26
     LTEXT "Оборудование не установлено, поскольку мастер не смог найти нужного программного обеспечения.", IDC_STATIC, 120, 32, 195, 16
     LTEXT "Если имеются установочные диски или известно расположение нужного программного обеспечения, нажмите кнопку ""Назад"".", IDC_STATIC, 120, 98, 195, 24
     CONTROL "Больше не напоминать об установке этого драйвера.", IDC_DONOTSHOWDLG, "Button", BS_AUTOCHECKBOX | WS_TABSTOP, 120, 170, 195, 12
@@ -30,7 +30,7 @@ STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYS
 CAPTION "Мастер нового оборудования"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "Это оборудование установить не удалось", IDC_FINISHTITLE, 120, 8, 195, 16
+    LTEXT "Это оборудование установить не удалось", IDC_FINISHTITLE, 120, 8, 195, 26
     LTEXT "Неизвестная ошибка. Не удалось установить устройство.", IDC_STATIC, 120, 32, 195, 16
     LTEXT "Неизвестное устройство", IDC_DEVICE, 148, 53, 147, 12
 END


### PR DESCRIPTION
## Purpose
In Russian locale, a portion of text is truncated in Driver Installation Wizard dialog especially when the driver hasn't been installed properly.
## Presentation
URL Image -- https://imgur.com/a/Q2kewWS
## JIRA
Issue ID -- [CORE-14761](https://jira.reactos.org/browse/CORE-14761)
