### PR TITLE
[SHELL32] Enable custom CD/DVD icons

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -316,9 +316,9 @@ getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
 
     // get path
     if (!ILGetDisplayNameExW(psf, pidl, wszPath, 0))
-        goto Quit;
+        return E_FAIL;
     if (!PathIsDirectoryW(wszPath))
-        goto Quit;
+        return E_FAIL;
 
     // build the full path of autorun.inf
     StringCchCopyW(wszAutoRunInfPath, _countof(wszAutoRunInfPath), wszPath);
@@ -345,7 +345,6 @@ getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
         return S_OK;
     }
 
-Quit:
     return E_FAIL;
 }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -300,7 +300,7 @@ HRESULT CDrivesContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
 static BOOL
 getAutoRunInfo(LPCWSTR Entry, LPWSTR pszValue, DWORD cchValueLen, LPCWSTR InfFile)
 {
-    static const WCHAR s_icon[] = { 'i', 'c', 'o', 'n', 0 };
+    static const WCHAR s_icon[] = L"icon";
     return GetPrivateProfileStringW(Entry, s_icon, NULL, pszValue, cchValueLen, InfFile);
 }
 

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -297,13 +297,6 @@ HRESULT CDrivesContextMenu_CreateInstance(PCIDLIST_ABSOLUTE pidlFolder,
     return CDefFolderMenu_Create2(pidlFolder, hwnd, cidl, apidl, psf, DrivesContextMenuCallback, cKeys, hKeys, ppcm);
 }
 
-static BOOL
-getAutoRunInfo(LPCWSTR Entry, LPWSTR pszValue, DWORD cchValueLen, LPCWSTR InfFile)
-{
-    static const WCHAR s_icon[] = L"icon";
-    return GetPrivateProfileStringW(Entry, s_icon, NULL, pszValue, cchValueLen, InfFile);
-}
-
 static HRESULT
 getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
                         LPWSTR szIconFile, UINT cchMax, int *piIndex, UINT *pwFlags)
@@ -325,7 +318,8 @@ getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
     PathAppendW(wszAutoRunInfPath, wszAutoRunInf);
 
     // autorun.inf --> wszValue
-    if (getAutoRunInfo(wszAutoRun, wszValue, _countof(wszValue), wszAutoRunInfPath))
+    if (GetPrivateProfileStringW(wszAutoRun, L"icon", NULL, wszValue, _countof(wszValue),
+                                 wszAutoRunInfPath) && wszValue[0] != 0)
     {
         // wszValue --> wszTemp
         ExpandEnvironmentStringsW(wszValue, wszTemp, _countof(wszTemp));


### PR DESCRIPTION
## Purpose
This PR will properly show the custom icon for the optical disk with file "autorun.inf".
JIRA issue: [CORE-14766](https://jira.reactos.org/browse/CORE-14766)