### PR TITLE
[SHELL32] Add missing desktop.ini files

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1015,21 +1015,21 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_AllUsers,
         CommonMusicW,
         MAKEINTRESOURCEW(IDS_COMMON_MUSIC),
-        -237
+        -IDI_SHELL_MY_MUSIC
     },
     { /* 0x36 - CSIDL_COMMON_PICTURES */
         &FOLDERID_PublicPictures,
         CSIDL_Type_AllUsers,
         CommonPicturesW,
         MAKEINTRESOURCEW(IDS_COMMON_PICTURES),
-        -236
+        -IDI_SHELL_MY_PICTURES
     },
     { /* 0x37 - CSIDL_COMMON_VIDEO */
         &FOLDERID_PublicVideos,
         CSIDL_Type_AllUsers,
         CommonVideoW,
         MAKEINTRESOURCEW(IDS_COMMON_VIDEO),
-        -238
+        -IDI_SHELL_MY_MOVIES
     },
     { /* 0x38 - CSIDL_RESOURCES */
         &FOLDERID_ResourceDir,

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2158,6 +2158,7 @@ HRESULT WINAPI SHGetFolderPathAndSubDirW(
         hr = E_FAIL;
         goto end;
     }
+
     TRACE("Created missing system directory %s\n", debugstr_w(szBuildPath));
 
     /* create desktop.ini for custom icon */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2170,10 +2170,7 @@ HRESULT WINAPI SHGetFolderPathAndSubDirW(
     /* create desktop.ini for custom icon */
     if (CSIDL_Data[folder].nShell32IconIndex)
     {
-        static const WCHAR s_szDesktopIni[] = L"desktop.ini";
         static const WCHAR s_szFormat[] = L"%%SystemRoot%%\\system32\\shell32.dll,%d";
-        static const WCHAR s_szIconResource[] = L"IconResource";
-        static const WCHAR s_shellClassInfo[] = L".ShellClassInfo";
         WCHAR szIconLocation[MAX_PATH];
         DWORD dwAttributes;
 
@@ -2183,14 +2180,14 @@ HRESULT WINAPI SHGetFolderPathAndSubDirW(
         SetFileAttributesW(szBuildPath, dwAttributes);
 
         /* build the desktop.ini file path */
-        PathAppendW(szBuildPath, s_szDesktopIni);
+        PathAppendW(szBuildPath, L"desktop.ini");
 
         /* build the icon location */
         StringCchPrintfW(szIconLocation, _countof(szIconLocation), s_szFormat,
                          CSIDL_Data[folder].nShell32IconIndex);
 
         /* write desktop.ini */
-        WritePrivateProfileStringW(s_shellClassInfo, s_szIconResource, szIconLocation, szBuildPath);
+        WritePrivateProfileStringW(L".ShellClassInfo", L"IconResource", szIconLocation, szBuildPath);
 
         /* flush! */
         WritePrivateProfileStringW(NULL, NULL, NULL, szBuildPath);

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2164,16 +2164,10 @@ HRESULT WINAPI SHGetFolderPathAndSubDirW(
     /* create desktop.ini for custom icon */
     if (CSIDL_Data[folder].nShell32IconIndex)
     {
-        /* desktop.ini */
-        static const WCHAR s_szDesktopIni[] = { 'd','e','s','k','t','o','p','.','i','n','i',0 };
-        /* %%SystemRoot%%\system32\shell32.dll,%d */
-        static const WCHAR s_szFormat[] = { '%','%','S','y','s','t','e','m','R','o','o','t','%','%','\\',
-            's','y','s','t','e','m','3','2','\\','s','h','e','l','l','3','2','.','d','l','l',',','%','d',0 };
-        /* IconResource */
-        static const WCHAR s_szIconResource[] = { 'I','c','o','n','R','e','s','o','u','r','c','e',0 };
-        /* .ShellClassInfo  */
-        static const WCHAR s_shellClassInfo[] = { '.', 'S', 'h', 'e', 'l', 'l', 'C', 'l', 'a', 's', 's', 'I', 'n', 'f', 'o', 0 };
-
+        static const WCHAR s_szDesktopIni[] = L"desktop.ini";
+        static const WCHAR s_szFormat[] = L"%%SystemRoot%%\\system32\\shell32.dll,%d";
+        static const WCHAR s_szIconResource[] = L"IconResource";
+        static const WCHAR s_shellClassInfo[] = L".ShellClassInfo";
         WCHAR szIconLocation[MAX_PATH];
         DWORD dwAttributes;
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -686,7 +686,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         ProgramsW,
         MAKEINTRESOURCEW(IDS_PROGRAMS),
-        -IDI_SHELL_PRINTERS_FOLDER
+        -IDI_SHELL_PROGRAMS_FOLDER
     },
     { /* 0x03 - CSIDL_CONTROLS (.CPL files) */
         &FOLDERID_ControlPanelFolder,
@@ -700,7 +700,7 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_SystemPath,
         NULL,
         NULL,
-        -IDI_SHELL_PRINTER
+        -IDI_SHELL_PRINTERS_FOLDER
     },
     { /* 0x05 - CSIDL_PERSONAL */
         &FOLDERID_Documents,
@@ -787,12 +787,14 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_Disallowed,
         NULL,
         NULL,
+        -IDI_SHELL_COMPUTER_FOLDER
     },
     { /* 0x12 - CSIDL_NETWORK */
         &FOLDERID_NetworkFolder,
         CSIDL_Type_Disallowed,
         NULL,
         NULL,
+        -IDI_SHELL_NETWORK_FOLDER
     },
     { /* 0x13 - CSIDL_NETHOOD */
         &FOLDERID_NetHood,
@@ -907,7 +909,8 @@ static const CSIDL_DATA CSIDL_Data[] =
         &FOLDERID_Windows,
         CSIDL_Type_WindowsPath,
         NULL,
-        NULL
+        NULL,
+        -IDI_SHELL_SYSTEM_GEAR
     },
     { /* 0x25 - CSIDL_SYSTEM */
         &FOLDERID_System,
@@ -940,19 +943,22 @@ static const CSIDL_DATA CSIDL_Data[] =
         &FOLDERID_SystemX86,
         CSIDL_Type_SystemX86Path,
         NULL,
-        NULL
+        NULL,
+        -IDI_SHELL_SYSTEM_GEAR
     },
     { /* 0x2a - CSIDL_PROGRAM_FILESX86 */
         &FOLDERID_ProgramFilesX86,
         CSIDL_Type_CurrVer,
         ProgramFilesDirX86W,
-        Program_Files_x86W
+        Program_Files_x86W,
+        -IDI_SHELL_PROGRAMS_FOLDER
     },
     { /* 0x2b - CSIDL_PROGRAM_FILES_COMMON */
         &FOLDERID_ProgramFilesCommon,
         CSIDL_Type_CurrVer,
         CommonFilesDirW,
-        MAKEINTRESOURCEW(IDS_PROGRAM_FILES_COMMON)
+        MAKEINTRESOURCEW(IDS_PROGRAM_FILES_COMMON),
+        -IDI_SHELL_PROGRAMS_FOLDER
     },
     { /* 0x2c - CSIDL_PROGRAM_FILES_COMMONX86 */
         &FOLDERID_ProgramFilesCommonX86,

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2190,6 +2190,8 @@ HRESULT WINAPI SHGetFolderPathAndSubDirW(
 
         /* write desktop.ini */
         WritePrivateProfileStringW(s_shellClassInfo, s_szIconResource, szIconLocation, szBuildPath);
+
+        /* flush! */
         WritePrivateProfileStringW(NULL, NULL, NULL, szBuildPath);
 
         /* make the desktop.ini a system and hidden file */


### PR DESCRIPTION
## Purpose
Add the "desktop.ini" files to the special folders to realize the custom icons of them.
JIRA issue: [CORE-10045](https://jira.reactos.org/browse/CORE-10045)