### PR TITLE
[WIN32SS] Fix IntSynthesizeDib to synthesize CF_DIB with CF_BITMAP

### DIFF
--- a/win32ss/user/ntuser/clipboard.c
+++ b/win32ss/user/ntuser/clipboard.c
@@ -144,6 +144,7 @@ IntSynthesizeDib(
     ULONG cjInfoSize, cjDataSize;
     PCLIPBOARDDATA pClipboardData;
     HANDLE hMem;
+    BITMAP bm;
     INT iResult;
     struct
     {
@@ -160,7 +161,16 @@ IntSynthesizeDib(
     }
 
     /* Get information about the bitmap format */
+    if (!GreGetObject(hbm, sizeof(BITMAP), &bm))
+        goto cleanup;
+
+    memset(&bmiBuffer, 0, sizeof(bmiBuffer));
     pbmi->bmiHeader.biSize = sizeof(bmiBuffer.bmih);
+    pbmi->bmiHeader.biWidth = bm.bmWidth;
+    pbmi->bmiHeader.biHeight = bm.bmHeight;
+    pbmi->bmiHeader.biPlanes = bm.bmPlanes;
+    pbmi->bmiHeader.biBitCount = bm.bmBitsPixel;
+
     iResult = GreGetDIBitsInternal(hdc,
                                    hbm,
                                    0,


### PR DESCRIPTION
## Purpose
This PR will fix the IntSynthesizeDib function to synthesize CF_DIB with CF_BITMAP clipboard format.

JIRA issue: [CORE-14770](https://jira.reactos.org/browse/CORE-14770)