### PR TITLE
[WIN32SS] Fix NtUserGetClipboardData for text paste

### DIFF
--- a/win32ss/user/ntuser/clipboard.c
+++ b/win32ss/user/ntuser/clipboard.c
@@ -294,8 +294,8 @@ IntAddSynthesizedFormats(PWINSTATION_OBJECT pWinStaObj)
     bHaveBm = IntIsFormatAvailable(pWinStaObj, CF_BITMAP);
     bHaveDib = IntIsFormatAvailable(pWinStaObj, CF_DIB);
 
-    /* Add CF_LOCALE format if we have CF_TEXT */
-    if (!bHaveLocale && bHaveText)
+    /* Add CF_LOCALE format if we have CF_TEXT, CF_OEMTEXT or CF_UNICODETEXT */
+    if (!bHaveLocale && (bHaveText || bHaveOemText || bHaveUniText))
     {
         PCLIPBOARDDATA pMemObj;
         HANDLE hMem;

--- a/win32ss/user/user32/windows/clipboard.c
+++ b/win32ss/user/user32/windows/clipboard.c
@@ -200,7 +200,26 @@ GetClipboardData(UINT uFormat)
 
     hData = NtUserGetClipboardData(uFormat, &gcd);
     if (!hData)
-        return NULL;
+    {
+        UINT uSourceFormat;
+        switch (uFormat)
+        {
+            case CF_TEXT:
+                uSourceFormat = CF_UNICODETEXT;
+                break;
+            case CF_OEMTEXT:
+                uSourceFormat = CF_UNICODETEXT;
+                break;
+            case CF_UNICODETEXT:
+                uSourceFormat = CF_TEXT;
+                break;
+            default:
+                return NULL;
+        }
+        hData = NtUserGetClipboardData(uSourceFormat, &gcd);
+        if (!hData)
+            return NULL;
+    }
 
     if (gcd.fGlobalHandle)
     {

--- a/win32ss/user/user32/windows/clipboard.c
+++ b/win32ss/user/user32/windows/clipboard.c
@@ -200,24 +200,7 @@ GetClipboardData(UINT uFormat)
 
     hData = NtUserGetClipboardData(uFormat, &gcd);
     if (!hData)
-    {
-        UINT uSourceFormat;
-        switch (uFormat)
-        {
-            case CF_TEXT:
-            case CF_OEMTEXT:
-                uSourceFormat = CF_UNICODETEXT;
-                break;
-            case CF_UNICODETEXT:
-                uSourceFormat = CF_TEXT;
-                break;
-            default:
-                return NULL;
-        }
-        hData = NtUserGetClipboardData(uSourceFormat, &gcd);
-        if (!hData)
-            return NULL;
-    }
+        return NULL;
 
     if (gcd.fGlobalHandle)
     {

--- a/win32ss/user/user32/windows/clipboard.c
+++ b/win32ss/user/user32/windows/clipboard.c
@@ -205,8 +205,6 @@ GetClipboardData(UINT uFormat)
         switch (uFormat)
         {
             case CF_TEXT:
-                uSourceFormat = CF_UNICODETEXT;
-                break;
             case CF_OEMTEXT:
                 uSourceFormat = CF_UNICODETEXT;
                 break;


### PR DESCRIPTION
## Purpose
This PR will fix the GetClipboardData function for the synthesized text formats (CF_TEXT, CF_OEMTEXT and CF_UNICODETEXT).

JIRA issue: [CORE-11471](https://jira.reactos.org/browse/CORE-11471)