### PR TITLE
CORE-7538. [NOTEPAD] Fix a MSVC warning about Globals.encFile

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -362,7 +362,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
         goto done;
     }
 
-    if (!ReadText(hFile, (LPWSTR *)&pszText, &dwTextLen, &Globals.encFile, &Globals.iEoln))
+    if (!ReadText(hFile, (LPWSTR *)&pszText, &dwTextLen, (int *)&Globals.encFile, &Globals.iEoln))
     {
         ShowLastError();
         goto done;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- "...\dialog.c(365) : error C4133: 'function' : incompatible types - from 'ENCODING *' to 'int *'"

* See https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=ReadText
* `ENCODING` is an `enum`.