### PR TITLE
[SHELL32] improve CShellLink a little

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -271,10 +271,9 @@ CShellLink::CShellLink()
 
     m_sLinkPath = NULL;
     m_iIdOpen = -1;
+    m_bInitializing = FALSE;
 
     /**/sProduct = sComponent = NULL;/**/
-
-    m_bInitializing = FALSE;
 }
 
 CShellLink::~CShellLink()
@@ -2770,7 +2769,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
             pThis = reinterpret_cast<CShellLink *>(ppsp->lParam);
             SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pThis);
 
-            pThis->m_bInitializing = TRUE;
+            pThis->SetInInit(TRUE);
 
             TRACE("m_sArgs: %S sComponent: %S m_sDescription: %S m_sIcoPath: %S m_sPath: %S m_sPathRel: %S sProduct: %S m_sWorkDir: %S\n", pThis->m_sArgs, pThis->sComponent, pThis->m_sDescription,
                   pThis->m_sIcoPath, pThis->m_sPath, pThis->m_sPathRel, pThis->sProduct, pThis->m_sWorkDir);
@@ -2828,7 +2827,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
             if (pThis->m_sDescription)
                 SetDlgItemTextW(hwndDlg, IDC_SHORTCUT_COMMENT_EDIT, pThis->m_sDescription);
 
-            pThis->m_bInitializing = FALSE;
+            pThis->SetInInit(FALSE);
 
             return TRUE;
         }
@@ -2942,7 +2941,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
                     return TRUE;
                 }
             }
-            if (HIWORD(wParam) == EN_CHANGE && !pThis->m_bInitializing)
+            if (HIWORD(wParam) == EN_CHANGE && !pThis->IsInInit())
                 PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
             break;
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -3130,9 +3130,12 @@ HICON CShellLink::CreateShortcutIcon(LPCWSTR wszIconPath, INT IconIndex)
     }
 
 cleanup:
-    DestroyIcon(hIcon);
-    DestroyIcon(hShortcut);
-    ImageList_Destroy(himl);
+    if (hIcon)
+        DestroyIcon(hIcon);
+    if (hShortcut)
+        DestroyIcon(hShortcut);
+    if (himl)
+        ImageList_Destroy(himl);
 
     return hNewIcon;
 }

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -3158,7 +3158,8 @@ HICON CShellLink::CreateShortcutIcon(LPCWSTR wszIconPath, INT IconIndex)
     HDC hDC;
     HIMAGELIST himl = ImageList_Create(cx, cy, ILC_COLOR32 | ILC_MASK, 1, 1);
     HICON hIcon = NULL, hNewIcon = NULL;
-    HICON hShortcut = LoadIconW(shell32_hInstance, MAKEINTRESOURCE(IDI_SHELL_SHORTCUT));
+    HICON hShortcut = (HICON)LoadImageW(shell32_hInstance, MAKEINTRESOURCE(IDI_SHELL_SHORTCUT),
+                                        IMAGE_ICON, cx, cy, 0);
 
     ::ExtractIconExW(wszIconPath, IconIndex, &hIcon, NULL, 1);
     if (!hIcon || !hShortcut || !himl)

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -271,7 +271,6 @@ CShellLink::CShellLink()
 
     m_sLinkPath = NULL;
     m_iIdOpen = -1;
-    m_bInitializing = FALSE;
 
     /**/sProduct = sComponent = NULL;/**/
 }
@@ -2755,6 +2754,7 @@ LPWSTR SH_GetTargetTypeByPath(LPCWSTR lpcwFullPath)
 INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     CShellLink *pThis = reinterpret_cast<CShellLink *>(GetWindowLongPtr(hwndDlg, DWLP_USER));
+    static BOOL s_bInInit = FALSE;
 
     switch(uMsg)
     {
@@ -2769,7 +2769,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
             pThis = reinterpret_cast<CShellLink *>(ppsp->lParam);
             SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pThis);
 
-            pThis->SetInInit(TRUE);
+            s_bInInit = TRUE;
 
             TRACE("m_sArgs: %S sComponent: %S m_sDescription: %S m_sIcoPath: %S m_sPath: %S m_sPathRel: %S sProduct: %S m_sWorkDir: %S\n", pThis->m_sArgs, pThis->sComponent, pThis->m_sDescription,
                   pThis->m_sIcoPath, pThis->m_sPath, pThis->m_sPathRel, pThis->sProduct, pThis->m_sWorkDir);
@@ -2827,7 +2827,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
             if (pThis->m_sDescription)
                 SetDlgItemTextW(hwndDlg, IDC_SHORTCUT_COMMENT_EDIT, pThis->m_sDescription);
 
-            pThis->SetInInit(FALSE);
+            s_bInInit = FALSE;
 
             return TRUE;
         }
@@ -2941,7 +2941,7 @@ INT_PTR CALLBACK CShellLink::SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
                     return TRUE;
                 }
             }
-            if (HIWORD(wParam) == EN_CHANGE && !pThis->IsInInit())
+            if (HIWORD(wParam) == EN_CHANGE && !s_bInInit)
                 PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
             break;
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -1772,8 +1772,42 @@ HRESULT STDMETHODCALLTYPE CShellLink::GetIconLocation(UINT uFlags, PWSTR pszIcon
 HRESULT STDMETHODCALLTYPE
 CShellLink::Extract(PCWSTR pszFile, UINT nIconIndex, HICON *phiconLarge, HICON *phiconSmall, UINT nIconSize)
 {
-    UNIMPLEMENTED;
-    return E_FAIL;
+    HRESULT hr = NOERROR;
+    UINT cxyLarge = LOWORD(nIconSize), cxySmall = HIWORD(nIconSize);
+
+    if (phiconLarge)
+    {
+        *phiconLarge = NULL;
+        PrivateExtractIconsW(pszFile, nIconIndex, cxyLarge, cxyLarge, phiconLarge, NULL, 1, 0);
+
+        if (*phiconLarge == NULL)
+            hr = S_FALSE;
+    }
+
+    if (phiconSmall)
+    {
+        *phiconSmall = NULL;
+        PrivateExtractIconsW(pszFile, nIconIndex, cxySmall, cxySmall, phiconSmall, NULL, 1, 0);
+
+        if (*phiconSmall == NULL)
+            hr = S_FALSE;
+    }
+
+    if (hr == S_FALSE)
+    {
+        if (phiconLarge && *phiconLarge)
+        {
+            DestroyIcon(*phiconLarge);
+            *phiconLarge = NULL;
+        }
+        if (phiconSmall && *phiconSmall)
+        {
+            DestroyIcon(*phiconSmall);
+            *phiconSmall = NULL;
+        }
+    }
+
+    return hr;
 }
 
 #if 0

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -88,6 +88,7 @@ private:
 
     LPWSTR        m_sLinkPath;
     INT           m_iIdOpen;     /* ID of the "Open" entry in the context menu */
+    BOOL          m_bInitializing;
 
     CComPtr<IUnknown>    m_site;
     CComPtr<IDropTarget> m_DropTarget;
@@ -105,7 +106,14 @@ public:
     ~CShellLink();
     static INT_PTR CALLBACK SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    BOOL m_bInitializing;
+    BOOL IsInInit() const
+    {
+        return m_bInitializing;
+    }
+    void SetInInit(BOOL bInInit)
+    {
+        m_bInitializing = bInInit;
+    }
 
     // IPersistFile
     virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -88,7 +88,6 @@ private:
 
     LPWSTR        m_sLinkPath;
     INT           m_iIdOpen;     /* ID of the "Open" entry in the context menu */
-    BOOL          m_bInitializing;
 
     CComPtr<IUnknown>    m_site;
     CComPtr<IDropTarget> m_DropTarget;
@@ -105,15 +104,6 @@ public:
     CShellLink();
     ~CShellLink();
     static INT_PTR CALLBACK SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-
-    BOOL IsInInit() const
-    {
-        return m_bInitializing;
-    }
-    void SetInInit(BOOL bInInit)
-    {
-        m_bInitializing = bInInit;
-    }
 
     // IPersistFile
     virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -81,6 +81,8 @@ private:
     BOOL          m_bRunAs;
     BOOL          m_bDirty;
     LPDBLIST      m_pDBList; /* Optional data block list (in the extra data section) */
+    BOOL          m_bInInit;    // in initialization or not
+    HICON         m_hIcon;
 
     /* Pointers to strings inside Logo3/Darwin info blocks, cached for debug info purposes only */
     LPWSTR sProduct;
@@ -104,6 +106,11 @@ public:
     CShellLink();
     ~CShellLink();
     static INT_PTR CALLBACK SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    BOOL OnInitDialog(HWND hwndDlg, HWND hwndFocus, LPARAM lParam);
+    void OnCommand(HWND hwndDlg, int id, HWND hwndCtl, UINT codeNotify);
+    LRESULT OnNotify(HWND hwndDlg, int idFrom, LPNMHDR pnmhdr);
+    void OnDestroy(HWND hwndDlg);
 
     // IPersistFile
     virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -98,11 +98,14 @@ private:
     HRESULT SetAdvertiseInfo(LPCWSTR str);
     HRESULT WriteAdvertiseInfo(LPCWSTR string, DWORD dwSig);
     HRESULT SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile);
+    HICON CreateShortcutIcon(LPCWSTR wszIconPath, INT IconIndex);
 
 public:
     CShellLink();
     ~CShellLink();
     static INT_PTR CALLBACK SH_ShellLinkDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    BOOL m_bInitializing;
 
     // IPersistFile
     virtual HRESULT STDMETHODCALLTYPE GetClassID(CLSID *pclsid);


### PR DESCRIPTION
## Purpose
This PR will improve display and UI in the shortcut dialog.
JIRA issue: [CORE-11407](https://jira.reactos.org/browse/CORE-11407)

## Proposed changes
- Use strdupW instead of HeapAlloc.
- Unimplement Extract method.
- Add CreateShortcutIcon method to create an arrowed icon.
- Add BOOL m_bInitializing member to determine the moment is in initialization.
- Implement CShellLink::Extract.