### PR TITLE
[MC] Fix build of message text files for latest VS version

### DIFF
--- a/sdk/include/reactos/mc/errcodes.mc
+++ b/sdk/include/reactos/mc/errcodes.mc
@@ -1,3 +1,12 @@
+
+;
+; IMPORTANT: When a new language is added, all messages in this file need to be
+; either translated or at least duplicated for the new language.
+; This is a new requirement by MS mc.exe
+; To do this, start with a regex replace:
+; - In VS IDE: "Language=English\r\n(?<String>(?:[^\.].*\r\n)*\.\r\n)" -> "Language=English\r\n${String}Language=MyLanguage\r\n${String}"
+;
+
 MessageIdTypedef=ULONG
 
 SeverityNames=(Success=0x0:STATUS_SEVERITY_SUCCESS
@@ -1848,12 +1857,18 @@ SymbolicName=ERROR_EXE_MACHINE_TYPE_MISMATCH
 Language=English
 ERROR_EXE_MACHINE_TYPE_MISMATCH - The image file %1 is valid, but is for a machine type other than the current machine.
 .
+Language=Russian
+ERROR_EXE_MACHINE_TYPE_MISMATCH - The image file %1 is valid, but is for a machine type other than the current machine.
+.
 
 MessageId=217
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EXE_CANNOT_MODIFY_SIGNED_BINARY
 Language=English
+ERROR_EXE_CANNOT_MODIFY_SIGNED_BINARY - The image file %1 is signed, unable to modify.
+.
+Language=Russian
 ERROR_EXE_CANNOT_MODIFY_SIGNED_BINARY - The image file %1 is signed, unable to modify.
 .
 
@@ -1864,12 +1879,18 @@ SymbolicName=ERRO_EXE_CANNOT_MODIFY_STRONG_SIGNED_BINARY
 Language=English
 ERRO_EXE_CANNOT_MODIFY_STRONG_SIGNED_BINARY - The image file %1 is strong signed, unable to modify.
 .
+Language=Russian
+ERRO_EXE_CANNOT_MODIFY_STRONG_SIGNED_BINARY - The image file %1 is strong signed, unable to modify.
+.
 
 MessageId=230
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_PIPE
 Language=English
+ERROR_BAD_PIPE - The pipe state is invalid.
+.
+Language=Russian
 ERROR_BAD_PIPE - The pipe state is invalid.
 .
 
@@ -1880,12 +1901,18 @@ SymbolicName=ERROR_PIPE_BUSY
 Language=English
 ERROR_PIPE_BUSY - All pipe instances are busy.
 .
+Language=Russian
+ERROR_PIPE_BUSY - All pipe instances are busy.
+.
 
 MessageId=232
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_DATA
 Language=English
+ERROR_NO_DATA - The pipe is being closed.
+.
+Language=Russian
 ERROR_NO_DATA - The pipe is being closed.
 .
 
@@ -1896,12 +1923,18 @@ SymbolicName=ERROR_PIPE_NOT_CONNECTED
 Language=English
 ERROR_PIPE_NOT_CONNECTED - No process is on the other end of the pipe.
 .
+Language=Russian
+ERROR_PIPE_NOT_CONNECTED - No process is on the other end of the pipe.
+.
 
 MessageId=234
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MORE_DATA
 Language=English
+ERROR_MORE_DATA - More data is available.
+.
+Language=Russian
 ERROR_MORE_DATA - More data is available.
 .
 
@@ -1912,12 +1945,18 @@ SymbolicName=ERROR_VC_DISCONNECTED
 Language=English
 ERROR_VC_DISCONNECTED - The session was canceled.
 .
+Language=Russian
+ERROR_VC_DISCONNECTED - The session was canceled.
+.
 
 MessageId=254
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_EA_NAME
 Language=English
+ERROR_INVALID_EA_NAME - The specified extended attribute name was invalid.
+.
+Language=Russian
 ERROR_INVALID_EA_NAME - The specified extended attribute name was invalid.
 .
 
@@ -1928,12 +1967,18 @@ SymbolicName=ERROR_EA_LIST_INCONSISTENT
 Language=English
 ERROR_EA_LIST_INCONSISTENT - The extended attributes are inconsistent.
 .
+Language=Russian
+ERROR_EA_LIST_INCONSISTENT - The extended attributes are inconsistent.
+.
 
 MessageId=258
 Severity=Success
 Facility=System
 SymbolicName=WAIT_TIMEOUT
 Language=English
+WAIT_TIMEOUT - The wait operation timed out.
+.
+Language=Russian
 WAIT_TIMEOUT - The wait operation timed out.
 .
 
@@ -1944,12 +1989,18 @@ SymbolicName=ERROR_NO_MORE_ITEMS
 Language=English
 ERROR_NO_MORE_ITEMS - No more data is available.
 .
+Language=Russian
+ERROR_NO_MORE_ITEMS - No more data is available.
+.
 
 MessageId=266
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANNOT_COPY
 Language=English
+ERROR_CANNOT_COPY - The copy functions cannot be used.
+.
+Language=Russian
 ERROR_CANNOT_COPY - The copy functions cannot be used.
 .
 
@@ -1960,12 +2011,18 @@ SymbolicName=ERROR_DIRECTORY
 Language=English
 ERROR_DIRECTORY - The directory name is invalid.
 .
+Language=Russian
+ERROR_DIRECTORY - The directory name is invalid.
+.
 
 MessageId=275
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EAS_DIDNT_FIT
 Language=English
+ERROR_EAS_DIDNT_FIT - The extended attributes did not fit in the buffer.
+.
+Language=Russian
 ERROR_EAS_DIDNT_FIT - The extended attributes did not fit in the buffer.
 .
 
@@ -1976,12 +2033,18 @@ SymbolicName=ERROR_EA_FILE_CORRUPT
 Language=English
 ERROR_EA_FILE_CORRUPT - The extended attribute file on the mounted file system is corrupt.
 .
+Language=Russian
+ERROR_EA_FILE_CORRUPT - The extended attribute file on the mounted file system is corrupt.
+.
 
 MessageId=277
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EA_TABLE_FULL
 Language=English
+ERROR_EA_TABLE_FULL - The extended attribute table file is full.
+.
+Language=Russian
 ERROR_EA_TABLE_FULL - The extended attribute table file is full.
 .
 
@@ -1992,12 +2055,18 @@ SymbolicName=ERROR_INVALID_EA_HANDLE
 Language=English
 ERROR_INVALID_EA_HANDLE - The specified extended attribute handle is invalid.
 .
+Language=Russian
+ERROR_INVALID_EA_HANDLE - The specified extended attribute handle is invalid.
+.
 
 MessageId=282
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EAS_NOT_SUPPORTED
 Language=English
+ERROR_EAS_NOT_SUPPORTED - The mounted file system does not support extended attributes.
+.
+Language=Russian
 ERROR_EAS_NOT_SUPPORTED - The mounted file system does not support extended attributes.
 .
 
@@ -2008,12 +2077,18 @@ SymbolicName=ERROR_NOT_OWNER
 Language=English
 ERROR_NOT_OWNER - Attempt to release mutex not owned by caller.
 .
+Language=Russian
+ERROR_NOT_OWNER - Attempt to release mutex not owned by caller.
+.
 
 MessageId=298
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TOO_MANY_POSTS
 Language=English
+ERROR_TOO_MANY_POSTS - Too many posts were made to a semaphore.
+.
+Language=Russian
 ERROR_TOO_MANY_POSTS - Too many posts were made to a semaphore.
 .
 
@@ -2024,12 +2099,18 @@ SymbolicName=ERROR_PARTIAL_COPY
 Language=English
 ERROR_PARTIAL_COPY - Only part of a ReadProcessMemory or WriteProcessMemory request was completed.
 .
+Language=Russian
+ERROR_PARTIAL_COPY - Only part of a ReadProcessMemory or WriteProcessMemory request was completed.
+.
 
 MessageId=300
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OPLOCK_NOT_GRANTED
 Language=English
+ERROR_OPLOCK_NOT_GRANTED - The oplock request is denied.
+.
+Language=Russian
 ERROR_OPLOCK_NOT_GRANTED - The oplock request is denied.
 .
 
@@ -2040,12 +2121,18 @@ SymbolicName=ERROR_INVALID_OPLOCK_PROTOCOL
 Language=English
 ERROR_INVALID_OPLOCK_PROTOCOL - An invalid oplock acknowledgment was received by the system.
 .
+Language=Russian
+ERROR_INVALID_OPLOCK_PROTOCOL - An invalid oplock acknowledgment was received by the system.
+.
 
 MessageId=302
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DISK_TOO_FRAGMENTED
 Language=English
+ERROR_DISK_TOO_FRAGMENTED - The volume is too fragmented to complete this operation.
+.
+Language=Russian
 ERROR_DISK_TOO_FRAGMENTED - The volume is too fragmented to complete this operation.
 .
 
@@ -2056,12 +2143,18 @@ SymbolicName=ERROR_DELETE_PENDING
 Language=English
 ERROR_DELETE_PENDING - The file cannot be opened because it is in the process of being deleted.
 .
+Language=Russian
+ERROR_DELETE_PENDING - The file cannot be opened because it is in the process of being deleted.
+.
 
 MessageId=317
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MR_MID_NOT_FOUND
 Language=English
+ERROR_MR_MID_NOT_FOUND - The system cannot find message text for message number 0x%1 in the message file for %2.
+.
+Language=Russian
 ERROR_MR_MID_NOT_FOUND - The system cannot find message text for message number 0x%1 in the message file for %2.
 .
 
@@ -2072,12 +2165,18 @@ SymbolicName=ERROR_SCOPE_NOT_FOUND
 Language=English
 ERROR_SCOPE_NOT_FOUND - The scope specified was not found.
 .
+Language=Russian
+ERROR_SCOPE_NOT_FOUND - The scope specified was not found.
+.
 
 MessageId=487
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_ADDRESS
 Language=English
+ERROR_INVALID_ADDRESS - Attempt to access invalid address.
+.
+Language=Russian
 ERROR_INVALID_ADDRESS - Attempt to access invalid address.
 .
 
@@ -2088,12 +2187,18 @@ SymbolicName=ERROR_ARITHMETIC_OVERFLOW
 Language=English
 ERROR_ARITHMETIC_OVERFLOW - Arithmetic result exceeded 32 bits.
 .
+Language=Russian
+ERROR_ARITHMETIC_OVERFLOW - Arithmetic result exceeded 32 bits.
+.
 
 MessageId=535
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PIPE_CONNECTED
 Language=English
+ERROR_PIPE_CONNECTED - There is a process on other end of the pipe.
+.
+Language=Russian
 ERROR_PIPE_CONNECTED - There is a process on other end of the pipe.
 .
 
@@ -2104,12 +2209,18 @@ SymbolicName=ERROR_PIPE_LISTENING
 Language=English
 ERROR_PIPE_LISTENING - Waiting for a process to open the other end of the pipe.
 .
+Language=Russian
+ERROR_PIPE_LISTENING - Waiting for a process to open the other end of the pipe.
+.
 
 MessageId=537
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ACPI_ERROR
 Language=English
+ERROR_ACPI_ERROR - An error occurred in the ACPI subsystem.
+.
+Language=Russian
 ERROR_ACPI_ERROR - An error occurred in the ACPI subsystem.
 .
 
@@ -2120,12 +2231,18 @@ SymbolicName=ERROR_ABIOS_ERROR
 Language=English
 ERROR_ABIOS_ERROR - An error occurred in the ABIOS subsystem
 .
+Language=Russian
+ERROR_ABIOS_ERROR - An error occurred in the ABIOS subsystem
+.
 
 MessageId=539
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WX86_WARNING
 Language=English
+ERROR_WX86_WARNING - A warning occurred in the WX86 subsystem.
+.
+Language=Russian
 ERROR_WX86_WARNING - A warning occurred in the WX86 subsystem.
 .
 
@@ -2136,12 +2253,18 @@ SymbolicName=ERROR_WX86_ERROR
 Language=English
 ERROR_WX86_ERROR - An error occurred in the WX86 subsystem.
 .
+Language=Russian
+ERROR_WX86_ERROR - An error occurred in the WX86 subsystem.
+.
 
 MessageId=541
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TIMER_NOT_CANCELED
 Language=English
+ERROR_TIMER_NOT_CANCELED - An attempt was made to cancel or set a timer that has an associated APC and the subject thread is not the thread that originally set the timer with an associated APC routine.
+.
+Language=Russian
 ERROR_TIMER_NOT_CANCELED - An attempt was made to cancel or set a timer that has an associated APC and the subject thread is not the thread that originally set the timer with an associated APC routine.
 .
 
@@ -2152,12 +2275,18 @@ SymbolicName=ERROR_UNWIND
 Language=English
 ERROR_UNWIND - Unwind exception code.
 .
+Language=Russian
+ERROR_UNWIND - Unwind exception code.
+.
 
 MessageId=543
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_STACK
 Language=English
+ERROR_BAD_STACK - An invalid or unaligned stack was encountered during an unwind operation.
+.
+Language=Russian
 ERROR_BAD_STACK - An invalid or unaligned stack was encountered during an unwind operation.
 .
 
@@ -2168,12 +2297,18 @@ SymbolicName=ERROR_INVALID_UNWIND_TARGET
 Language=English
 ERROR_INVALID_UNWIND_TARGET - An invalid unwind target was encountered during an unwind operation.
 .
+Language=Russian
+ERROR_INVALID_UNWIND_TARGET - An invalid unwind target was encountered during an unwind operation.
+.
 
 MessageId=545
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_PORT_ATTRIBUTES
 Language=English
+ERROR_INVALID_PORT_ATTRIBUTES - Invalid Object Attributes specified to NtCreatePort or invalid Port Attributes specified to NtConnectPort
+.
+Language=Russian
 ERROR_INVALID_PORT_ATTRIBUTES - Invalid Object Attributes specified to NtCreatePort or invalid Port Attributes specified to NtConnectPort
 .
 
@@ -2184,12 +2319,18 @@ SymbolicName=ERROR_PORT_MESSAGE_TOO_LONG
 Language=English
 ERROR_PORT_MESSAGE_TOO_LONG - Length of message passed to NtRequestPort or NtRequestWaitReplyPort was longer than the maximum message allowed by the port.
 .
+Language=Russian
+ERROR_PORT_MESSAGE_TOO_LONG - Length of message passed to NtRequestPort or NtRequestWaitReplyPort was longer than the maximum message allowed by the port.
+.
 
 MessageId=547
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_QUOTA_LOWER
 Language=English
+ERROR_INVALID_QUOTA_LOWER - An attempt was made to lower a quota limit below the current usage.
+.
+Language=Russian
 ERROR_INVALID_QUOTA_LOWER - An attempt was made to lower a quota limit below the current usage.
 .
 
@@ -2200,12 +2341,18 @@ SymbolicName=ERROR_DEVICE_ALREADY_ATTACHED
 Language=English
 ERROR_DEVICE_ALREADY_ATTACHED - An attempt was made to attach to a device that was already attached to another device.
 .
+Language=Russian
+ERROR_DEVICE_ALREADY_ATTACHED - An attempt was made to attach to a device that was already attached to another device.
+.
 
 MessageId=549
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTRUCTION_MISALIGNMENT
 Language=English
+ERROR_INSTRUCTION_MISALIGNMENT - An attempt was made to execute an instruction at an unaligned address and the host system does not support unaligned instruction references.
+.
+Language=Russian
 ERROR_INSTRUCTION_MISALIGNMENT - An attempt was made to execute an instruction at an unaligned address and the host system does not support unaligned instruction references.
 .
 
@@ -2216,12 +2363,18 @@ SymbolicName=ERROR_PROFILING_NOT_STARTED
 Language=English
 ERROR_PROFILING_NOT_STARTED - Profiling not started.
 .
+Language=Russian
+ERROR_PROFILING_NOT_STARTED - Profiling not started.
+.
 
 MessageId=551
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PROFILING_NOT_STOPPED
 Language=English
+ERROR_PROFILING_NOT_STOPPED - Profiling not stopped.
+.
+Language=Russian
 ERROR_PROFILING_NOT_STOPPED - Profiling not stopped.
 .
 
@@ -2232,12 +2385,18 @@ SymbolicName=ERROR_COULD_NOT_INTERPRET
 Language=English
 ERROR_COULD_NOT_INTERPRET - The passed ACL did not contain the minimum required information.
 .
+Language=Russian
+ERROR_COULD_NOT_INTERPRET - The passed ACL did not contain the minimum required information.
+.
 
 MessageId=553
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PROFILING_AT_LIMIT
 Language=English
+ERROR_PROFILING_AT_LIMIT - The number of active profiling objects is at the maximum and no more may be started.
+.
+Language=Russian
 ERROR_PROFILING_AT_LIMIT - The number of active profiling objects is at the maximum and no more may be started.
 .
 
@@ -2248,12 +2407,18 @@ SymbolicName=ERROR_CANT_WAIT
 Language=English
 ERROR_CANT_WAIT - Used to indicate that an operation cannot continue without blocking for I/O.
 .
+Language=Russian
+ERROR_CANT_WAIT - Used to indicate that an operation cannot continue without blocking for I/O.
+.
 
 MessageId=555
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANT_TERMINATE_SELF
 Language=English
+ERROR_CANT_TERMINATE_SELF - Indicates that a thread attempted to terminate itself by default (called NtTerminateThread with NULL) and it was the last thread in the current process.
+.
+Language=Russian
 ERROR_CANT_TERMINATE_SELF - Indicates that a thread attempted to terminate itself by default (called NtTerminateThread with NULL) and it was the last thread in the current process.
 .
 
@@ -2264,12 +2429,18 @@ SymbolicName=ERROR_UNEXPECTED_MM_CREATE_ERR
 Language=English
 ERROR_UNEXPECTED_MM_CREATE_ERR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
 .
+Language=Russian
+ERROR_UNEXPECTED_MM_CREATE_ERR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
+.
 
 MessageId=557
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNEXPECTED_MM_MAP_ERROR
 Language=English
+ERROR_UNEXPECTED_MM_MAP_ERROR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
+.
+Language=Russian
 ERROR_UNEXPECTED_MM_MAP_ERROR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
 .
 
@@ -2280,12 +2451,18 @@ SymbolicName=ERROR_UNEXPECTED_MM_EXTEND_ERR
 Language=English
 ERROR_UNEXPECTED_MM_EXTEND_ERR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
 .
+Language=Russian
+ERROR_UNEXPECTED_MM_EXTEND_ERR - If an MM error is returned which is not defined in the standard FsRtl filter, it is converted to one of the following errors which is guaranteed to be in the filter. In this case information is lost, however, the filter correctly handles the exception.
+.
 
 MessageId=559
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_FUNCTION_TABLE
 Language=English
+ERROR_BAD_FUNCTION_TABLE - A malformed function table was encountered during an unwind operation.
+.
+Language=Russian
 ERROR_BAD_FUNCTION_TABLE - A malformed function table was encountered during an unwind operation.
 .
 
@@ -2296,12 +2473,18 @@ SymbolicName=ERROR_NO_GUID_TRANSLATION
 Language=English
 ERROR_NO_GUID_TRANSLATION - Indicates that an attempt was made to assign protection to a file system file or directory and one of the SIDs in the security descriptor could not be translated into a GUID that could be stored by the file system. This causes the protection attempt to fail, which may cause a file creation attempt to fail.
 .
+Language=Russian
+ERROR_NO_GUID_TRANSLATION - Indicates that an attempt was made to assign protection to a file system file or directory and one of the SIDs in the security descriptor could not be translated into a GUID that could be stored by the file system. This causes the protection attempt to fail, which may cause a file creation attempt to fail.
+.
 
 MessageId=561
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_LDT_SIZE
 Language=English
+ERROR_INVALID_LDT_SIZE - Indicates that an attempt was made to grow an LDT by setting its size, or that the size was not an even number of selectors.
+.
+Language=Russian
 ERROR_INVALID_LDT_SIZE - Indicates that an attempt was made to grow an LDT by setting its size, or that the size was not an even number of selectors.
 .
 
@@ -2312,12 +2495,18 @@ SymbolicName=ERROR_INVALID_LDT_OFFSET
 Language=English
 ERROR_INVALID_LDT_OFFSET - Indicates that the starting value for the LDT information was not an integral multiple of the selector size.
 .
+Language=Russian
+ERROR_INVALID_LDT_OFFSET - Indicates that the starting value for the LDT information was not an integral multiple of the selector size.
+.
 
 MessageId=564
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_LDT_DESCRIPTOR
 Language=English
+ERROR_INVALID_LDT_DESCRIPTOR - Indicates that the user supplied an invalid descriptor when trying to set up Ldt descriptors.
+.
+Language=Russian
 ERROR_INVALID_LDT_DESCRIPTOR - Indicates that the user supplied an invalid descriptor when trying to set up Ldt descriptors.
 .
 
@@ -2328,12 +2517,18 @@ SymbolicName=ERROR_TOO_MANY_THREADS
 Language=English
 ERROR_TOO_MANY_THREADS - Indicates a process has too many threads to perform the requested action. For example, assignment of a primary token may only be performed when a process has zero or one threads.
 .
+Language=Russian
+ERROR_TOO_MANY_THREADS - Indicates a process has too many threads to perform the requested action. For example, assignment of a primary token may only be performed when a process has zero or one threads.
+.
 
 MessageId=566
 Severity=Success
 Facility=System
 SymbolicName=ERROR_THREAD_NOT_IN_PROCESS
 Language=English
+ERROR_THREAD_NOT_IN_PROCESS - An attempt was made to operate on a thread within a specific process, but the thread specified is not in the process specified.
+.
+Language=Russian
 ERROR_THREAD_NOT_IN_PROCESS - An attempt was made to operate on a thread within a specific process, but the thread specified is not in the process specified.
 .
 
@@ -2344,12 +2539,18 @@ SymbolicName=ERROR_PAGEFILE_QUOTA_EXCEEDED
 Language=English
 ERROR_PAGEFILE_QUOTA_EXCEEDED - Page file quota was exceeded.
 .
+Language=Russian
+ERROR_PAGEFILE_QUOTA_EXCEEDED - Page file quota was exceeded.
+.
 
 MessageId=568
 Severity=Success
 Facility=System
 SymbolicName=ERROR_LOGON_SERVER_CONFLICT
 Language=English
+ERROR_LOGON_SERVER_CONFLICT - The Netlogon service cannot start because another Netlogon service running in the domain conflicts with the specified role.
+.
+Language=Russian
 ERROR_LOGON_SERVER_CONFLICT - The Netlogon service cannot start because another Netlogon service running in the domain conflicts with the specified role.
 .
 
@@ -2360,12 +2561,18 @@ SymbolicName=ERROR_SYNCHRONIZATION_REQUIRED
 Language=English
 ERROR_SYNCHRONIZATION_REQUIRED - The SAM database on a Windows Server is significantly out of synchronization with the copy on the Domain Controller. A complete synchronization is required.
 .
+Language=Russian
+ERROR_SYNCHRONIZATION_REQUIRED - The SAM database on a Windows Server is significantly out of synchronization with the copy on the Domain Controller. A complete synchronization is required.
+.
 
 MessageId=570
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NET_OPEN_FAILED
 Language=English
+ERROR_NET_OPEN_FAILED - The NtCreateFile API failed. This error should never be returned to an application, it is a place holder for the Windows Lan Manager Redirector to use in its internal error mapping routines.
+.
+Language=Russian
 ERROR_NET_OPEN_FAILED - The NtCreateFile API failed. This error should never be returned to an application, it is a place holder for the Windows Lan Manager Redirector to use in its internal error mapping routines.
 .
 
@@ -2376,12 +2583,18 @@ SymbolicName=ERROR_IO_PRIVILEGE_FAILED
 Language=English
 ERROR_IO_PRIVILEGE_FAILED - The I/O permissions for the process could not be changed.
 .
+Language=Russian
+ERROR_IO_PRIVILEGE_FAILED - The I/O permissions for the process could not be changed.
+.
 
 MessageId=572
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CONTROL_C_EXIT
 Language=English
+ERROR_CONTROL_C_EXIT - The application terminated as a result of a CTRL+C.
+.
+Language=Russian
 ERROR_CONTROL_C_EXIT - The application terminated as a result of a CTRL+C.
 .
 
@@ -2392,12 +2605,18 @@ SymbolicName=ERROR_MISSING_SYSTEMFILE
 Language=English
 ERROR_MISSING_SYSTEMFILE - The required system file %hs is bad or missing.
 .
+Language=Russian
+ERROR_MISSING_SYSTEMFILE - The required system file %hs is bad or missing.
+.
 
 MessageId=574
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNHANDLED_EXCEPTION
 Language=English
+ERROR_UNHANDLED_EXCEPTION - The exception %s (0x%08lx) occurred in the application at location 0x%08lx.
+.
+Language=Russian
 ERROR_UNHANDLED_EXCEPTION - The exception %s (0x%08lx) occurred in the application at location 0x%08lx.
 .
 
@@ -2408,12 +2627,18 @@ SymbolicName=ERROR_APP_INIT_FAILURE
 Language=English
 ERROR_APP_INIT_FAILURE - The application failed to initialize properly (0x%lx). Click on OK to terminate the application.
 .
+Language=Russian
+ERROR_APP_INIT_FAILURE - The application failed to initialize properly (0x%lx). Click on OK to terminate the application.
+.
 
 MessageId=576
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PAGEFILE_CREATE_FAILED
 Language=English
+ERROR_PAGEFILE_CREATE_FAILED - The creation of the paging file %hs failed (%lx). The requested size was %ld.
+.
+Language=Russian
 ERROR_PAGEFILE_CREATE_FAILED - The creation of the paging file %hs failed (%lx). The requested size was %ld.
 .
 
@@ -2424,12 +2649,18 @@ SymbolicName=ERROR_NO_PAGEFILE
 Language=English
 ERROR_NO_PAGEFILE - No paging file was specified in the system configuration.
 .
+Language=Russian
+ERROR_NO_PAGEFILE - No paging file was specified in the system configuration.
+.
 
 MessageId=579
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ILLEGAL_FLOAT_CONTEXT
 Language=English
+ERROR_ILLEGAL_FLOAT_CONTEXT - A real-mode application issued a floating-point instruction and floating-point hardware is not present.
+.
+Language=Russian
 ERROR_ILLEGAL_FLOAT_CONTEXT - A real-mode application issued a floating-point instruction and floating-point hardware is not present.
 .
 
@@ -2440,12 +2671,18 @@ SymbolicName=ERROR_NO_EVENT_PAIR
 Language=English
 ERROR_NO_EVENT_PAIR - An event pair synchronization operation was performed using the thread specific client/server event pair object, but no event pair object was associated with the thread.
 .
+Language=Russian
+ERROR_NO_EVENT_PAIR - An event pair synchronization operation was performed using the thread specific client/server event pair object, but no event pair object was associated with the thread.
+.
 
 MessageId=581
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DOMAIN_CTRLR_CONFIG_ERROR
 Language=English
+ERROR_DOMAIN_CTRLR_CONFIG_ERROR - A Windows Server has an incorrect configuration.
+.
+Language=Russian
 ERROR_DOMAIN_CTRLR_CONFIG_ERROR - A Windows Server has an incorrect configuration.
 .
 
@@ -2456,12 +2693,18 @@ SymbolicName=ERROR_ILLEGAL_CHARACTER
 Language=English
 ERROR_ILLEGAL_CHARACTER - An illegal character was encountered. For a multi-byte character set this includes a lead byte without a succeeding trail byte. For the Unicode character set this includes the characters 0xFFFF and 0xFFFE.
 .
+Language=Russian
+ERROR_ILLEGAL_CHARACTER - An illegal character was encountered. For a multi-byte character set this includes a lead byte without a succeeding trail byte. For the Unicode character set this includes the characters 0xFFFF and 0xFFFE.
+.
 
 MessageId=583
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNDEFINED_CHARACTER
 Language=English
+ERROR_UNDEFINED_CHARACTER - The Unicode character is not defined in the Unicode character set installed on the system.
+.
+Language=Russian
 ERROR_UNDEFINED_CHARACTER - The Unicode character is not defined in the Unicode character set installed on the system.
 .
 
@@ -2472,12 +2715,18 @@ SymbolicName=ERROR_FLOPPY_VOLUME
 Language=English
 ERROR_FLOPPY_VOLUME - The paging file cannot be created on a floppy diskette.
 .
+Language=Russian
+ERROR_FLOPPY_VOLUME - The paging file cannot be created on a floppy diskette.
+.
 
 MessageId=585
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BIOS_FAILED_TO_CONNECT_INTERRUPT
 Language=English
+ERROR_BIOS_FAILED_TO_CONNECT_INTERRUPT - The system bios failed to connect a system interrupt to the device or bus for which the device is connected.
+.
+Language=Russian
 ERROR_BIOS_FAILED_TO_CONNECT_INTERRUPT - The system bios failed to connect a system interrupt to the device or bus for which the device is connected.
 .
 
@@ -2488,12 +2737,18 @@ SymbolicName=ERROR_BACKUP_CONTROLLER
 Language=English
 ERROR_BACKUP_CONTROLLER - This operation is only allowed for the Primary Domain Controller of the domain.
 .
+Language=Russian
+ERROR_BACKUP_CONTROLLER - This operation is only allowed for the Primary Domain Controller of the domain.
+.
 
 MessageId=587
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MUTANT_LIMIT_EXCEEDED
 Language=English
+ERROR_MUTANT_LIMIT_EXCEEDED - An attempt was made to acquire a mutant such that its maximum count would have been exceeded.
+.
+Language=Russian
 ERROR_MUTANT_LIMIT_EXCEEDED - An attempt was made to acquire a mutant such that its maximum count would have been exceeded.
 .
 
@@ -2504,12 +2759,18 @@ SymbolicName=ERROR_FS_DRIVER_REQUIRED
 Language=English
 ERROR_FS_DRIVER_REQUIRED - A volume has been accessed for which a file system driver is required that has not yet been loaded.
 .
+Language=Russian
+ERROR_FS_DRIVER_REQUIRED - A volume has been accessed for which a file system driver is required that has not yet been loaded.
+.
 
 MessageId=589
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANNOT_LOAD_REGISTRY_FILE
 Language=English
+ERROR_CANNOT_LOAD_REGISTRY_FILE - The registry cannot load the hive (file): %hs or its log or alternate. It is corrupt, absent, or not writable.
+.
+Language=Russian
 ERROR_CANNOT_LOAD_REGISTRY_FILE - The registry cannot load the hive (file): %hs or its log or alternate. It is corrupt, absent, or not writable.
 .
 
@@ -2520,12 +2781,18 @@ SymbolicName=ERROR_DEBUG_ATTACH_FAILED
 Language=English
 ERROR_DEBUG_ATTACH_FAILED - An unexpected failure occurred while processing a DebugActiveProcess API request. You may choose OK to terminate the process, or Cancel to ignore the error.
 .
+Language=Russian
+ERROR_DEBUG_ATTACH_FAILED - An unexpected failure occurred while processing a DebugActiveProcess API request. You may choose OK to terminate the process, or Cancel to ignore the error.
+.
 
 MessageId=591
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SYSTEM_PROCESS_TERMINATED
 Language=English
+ERROR_SYSTEM_PROCESS_TERMINATED - The %hs system process terminated unexpectedly with a status of 0x%08x (0x%08x 0x%08x). The system has been shut down.
+.
+Language=Russian
 ERROR_SYSTEM_PROCESS_TERMINATED - The %hs system process terminated unexpectedly with a status of 0x%08x (0x%08x 0x%08x). The system has been shut down.
 .
 
@@ -2536,12 +2803,18 @@ SymbolicName=ERROR_DATA_NOT_ACCEPTED
 Language=English
 ERROR_DATA_NOT_ACCEPTED - The TDI client could not handle the data received during an indication.
 .
+Language=Russian
+ERROR_DATA_NOT_ACCEPTED - The TDI client could not handle the data received during an indication.
+.
 
 MessageId=593
 Severity=Success
 Facility=System
 SymbolicName=ERROR_VDM_HARD_ERROR
 Language=English
+ERROR_VDM_HARD_ERROR - NTVDM encountered a hard error.
+.
+Language=Russian
 ERROR_VDM_HARD_ERROR - NTVDM encountered a hard error.
 .
 
@@ -2552,12 +2825,18 @@ SymbolicName=ERROR_DRIVER_CANCEL_TIMEOUT
 Language=English
 ERROR_DRIVER_CANCEL_TIMEOUT - The driver %hs failed to complete a cancelled I/O request in the allotted time.
 .
+Language=Russian
+ERROR_DRIVER_CANCEL_TIMEOUT - The driver %hs failed to complete a cancelled I/O request in the allotted time.
+.
 
 MessageId=595
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REPLY_MESSAGE_MISMATCH
 Language=English
+ERROR_REPLY_MESSAGE_MISMATCH - An attempt was made to reply to an LPC message, but the thread specified by the client ID in the message was not waiting on that message.
+.
+Language=Russian
 ERROR_REPLY_MESSAGE_MISMATCH - An attempt was made to reply to an LPC message, but the thread specified by the client ID in the message was not waiting on that message.
 .
 
@@ -2568,12 +2847,18 @@ SymbolicName=ERROR_LOST_WRITEBEHIND_DATA
 Language=English
 ERROR_LOST_WRITEBEHIND_DATA - Windows was unable to save all the data for the file %hs. The data has been lost. This error may be caused by a failure of your computer hardware or network connection. Please try to save this file elsewhere.
 .
+Language=Russian
+ERROR_LOST_WRITEBEHIND_DATA - Windows was unable to save all the data for the file %hs. The data has been lost. This error may be caused by a failure of your computer hardware or network connection. Please try to save this file elsewhere.
+.
 
 MessageId=597
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLIENT_SERVER_PARAMETERS_INVALID
 Language=English
+ERROR_CLIENT_SERVER_PARAMETERS_INVALID - The parameter(s) passed to the server in the client/server shared memory window were invalid. Too much data may have been put in the shared memory window.
+.
+Language=Russian
 ERROR_CLIENT_SERVER_PARAMETERS_INVALID - The parameter(s) passed to the server in the client/server shared memory window were invalid. Too much data may have been put in the shared memory window.
 .
 
@@ -2584,12 +2869,18 @@ SymbolicName=ERROR_NOT_TINY_STREAM
 Language=English
 ERROR_NOT_TINY_STREAM - The stream is not a tiny stream.
 .
+Language=Russian
+ERROR_NOT_TINY_STREAM - The stream is not a tiny stream.
+.
 
 MessageId=599
 Severity=Success
 Facility=System
 SymbolicName=ERROR_STACK_OVERFLOW_READ
 Language=English
+ERROR_STACK_OVERFLOW_READ - The request must be handled by the stack overflow code.
+.
+Language=Russian
 ERROR_STACK_OVERFLOW_READ - The request must be handled by the stack overflow code.
 .
 
@@ -2600,12 +2891,18 @@ SymbolicName=ERROR_CONVERT_TO_LARGE
 Language=English
 ERROR_CONVERT_TO_LARGE - Internal OFS status codes indicating how an allocation operation is handled. Either it is retried after the containing onode is moved or the extent stream is converted to a large stream.
 .
+Language=Russian
+ERROR_CONVERT_TO_LARGE - Internal OFS status codes indicating how an allocation operation is handled. Either it is retried after the containing onode is moved or the extent stream is converted to a large stream.
+.
 
 MessageId=601
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FOUND_OUT_OF_SCOPE
 Language=English
+ERROR_FOUND_OUT_OF_SCOPE - The attempt to find the object found an object matching by ID on the volume but it is out of the scope of the handle used for the operation.
+.
+Language=Russian
 ERROR_FOUND_OUT_OF_SCOPE - The attempt to find the object found an object matching by ID on the volume but it is out of the scope of the handle used for the operation.
 .
 
@@ -2616,12 +2913,18 @@ SymbolicName=ERROR_ALLOCATE_BUCKET
 Language=English
 ERROR_ALLOCATE_BUCKET - The bucket array must be grown. Retry transaction after doing so.
 .
+Language=Russian
+ERROR_ALLOCATE_BUCKET - The bucket array must be grown. Retry transaction after doing so.
+.
 
 MessageId=603
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MARSHALL_OVERFLOW
 Language=English
+ERROR_MARSHALL_OVERFLOW - The user/kernel marshalling buffer has overflowed.
+.
+Language=Russian
 ERROR_MARSHALL_OVERFLOW - The user/kernel marshalling buffer has overflowed.
 .
 
@@ -2632,12 +2935,18 @@ SymbolicName=ERROR_INVALID_VARIANT
 Language=English
 ERROR_INVALID_VARIANT - The supplied variant structure contains invalid data.
 .
+Language=Russian
+ERROR_INVALID_VARIANT - The supplied variant structure contains invalid data.
+.
 
 MessageId=605
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_COMPRESSION_BUFFER
 Language=English
+ERROR_BAD_COMPRESSION_BUFFER - The specified buffer contains ill-formed data.
+.
+Language=Russian
 ERROR_BAD_COMPRESSION_BUFFER - The specified buffer contains ill-formed data.
 .
 
@@ -2648,12 +2957,18 @@ SymbolicName=ERROR_AUDIT_FAILED
 Language=English
 ERROR_AUDIT_FAILED - An attempt to generate a security audit failed.
 .
+Language=Russian
+ERROR_AUDIT_FAILED - An attempt to generate a security audit failed.
+.
 
 MessageId=607
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TIMER_RESOLUTION_NOT_SET
 Language=English
+ERROR_TIMER_RESOLUTION_NOT_SET - The timer resolution was not previously set by the current process.
+.
+Language=Russian
 ERROR_TIMER_RESOLUTION_NOT_SET - The timer resolution was not previously set by the current process.
 .
 
@@ -2664,12 +2979,18 @@ SymbolicName=ERROR_INSUFFICIENT_LOGON_INFO
 Language=English
 ERROR_INSUFFICIENT_LOGON_INFO - There is insufficient account information to log you on.
 .
+Language=Russian
+ERROR_INSUFFICIENT_LOGON_INFO - There is insufficient account information to log you on.
+.
 
 MessageId=609
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_DLL_ENTRYPOINT
 Language=English
+ERROR_BAD_DLL_ENTRYPOINT - The dynamic link library %hs is not written correctly. The stack pointer has been left in an inconsistent state. The entrypoint should be declared as WINAPI or STDCALL. Select YES to fail the DLL load. Select NO to continue execution. Selecting NO may cause the application to operate incorrectly.
+.
+Language=Russian
 ERROR_BAD_DLL_ENTRYPOINT - The dynamic link library %hs is not written correctly. The stack pointer has been left in an inconsistent state. The entrypoint should be declared as WINAPI or STDCALL. Select YES to fail the DLL load. Select NO to continue execution. Selecting NO may cause the application to operate incorrectly.
 .
 
@@ -2680,12 +3001,18 @@ SymbolicName=ERROR_BAD_SERVICE_ENTRYPOINT
 Language=English
 ERROR_BAD_SERVICE_ENTRYPOINT - The %hs service is not written correctly. The stack pointer has been left in an inconsistent state. The callback entrypoint should be declared as WINAPI or STDCALL. Selecting OK will cause the service to continue operation. However, the service process may operate incorrectly.
 .
+Language=Russian
+ERROR_BAD_SERVICE_ENTRYPOINT - The %hs service is not written correctly. The stack pointer has been left in an inconsistent state. The callback entrypoint should be declared as WINAPI or STDCALL. Selecting OK will cause the service to continue operation. However, the service process may operate incorrectly.
+.
 
 MessageId=611
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IP_ADDRESS_CONFLICT1
 Language=English
+ERROR_IP_ADDRESS_CONFLICT1 - There is an IP address conflict with another system on the network
+.
+Language=Russian
 ERROR_IP_ADDRESS_CONFLICT1 - There is an IP address conflict with another system on the network
 .
 
@@ -2696,12 +3023,18 @@ SymbolicName=ERROR_IP_ADDRESS_CONFLICT2
 Language=English
 ERROR_IP_ADDRESS_CONFLICT2 - There is an IP address conflict with another system on the network
 .
+Language=Russian
+ERROR_IP_ADDRESS_CONFLICT2 - There is an IP address conflict with another system on the network
+.
 
 MessageId=613
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REGISTRY_QUOTA_LIMIT
 Language=English
+ERROR_REGISTRY_QUOTA_LIMIT - The system has reached the maximum size allowed for the system part of the registry. Additional storage requests will be ignored.
+.
+Language=Russian
 ERROR_REGISTRY_QUOTA_LIMIT - The system has reached the maximum size allowed for the system part of the registry. Additional storage requests will be ignored.
 .
 
@@ -2712,12 +3045,18 @@ SymbolicName=ERROR_NO_CALLBACK_ACTIVE
 Language=English
 ERROR_NO_CALLBACK_ACTIVE - A callback return system service cannot be executed when no callback is active.
 .
+Language=Russian
+ERROR_NO_CALLBACK_ACTIVE - A callback return system service cannot be executed when no callback is active.
+.
 
 MessageId=615
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PWD_TOO_SHORT
 Language=English
+ERROR_PWD_TOO_SHORT - The password provided is too short to meet the policy of your user account. Please choose a longer password.
+.
+Language=Russian
 ERROR_PWD_TOO_SHORT - The password provided is too short to meet the policy of your user account. Please choose a longer password.
 .
 
@@ -2728,12 +3067,18 @@ SymbolicName=ERROR_PWD_TOO_RECENT
 Language=English
 ERROR_PWD_TOO_RECENT - The policy of your user account does not allow you to change passwords too frequently. This is done to prevent users from changing back to a familiar, but potentially discovered, password. If you feel your password has been compromised then please contact your administrator immediately to have a new one assigned.
 .
+Language=Russian
+ERROR_PWD_TOO_RECENT - The policy of your user account does not allow you to change passwords too frequently. This is done to prevent users from changing back to a familiar, but potentially discovered, password. If you feel your password has been compromised then please contact your administrator immediately to have a new one assigned.
+.
 
 MessageId=617
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PWD_HISTORY_CONFLICT
 Language=English
+ERROR_PWD_HISTORY_CONFLICT - You have attempted to change your password to one that you have used in the past. The policy of your user account does not allow this. Please select a password that you have not previously used.
+.
+Language=Russian
 ERROR_PWD_HISTORY_CONFLICT - You have attempted to change your password to one that you have used in the past. The policy of your user account does not allow this. Please select a password that you have not previously used.
 .
 
@@ -2744,12 +3089,18 @@ SymbolicName=ERROR_UNSUPPORTED_COMPRESSION
 Language=English
 ERROR_UNSUPPORTED_COMPRESSION - The specified compression format is unsupported.
 .
+Language=Russian
+ERROR_UNSUPPORTED_COMPRESSION - The specified compression format is unsupported.
+.
 
 MessageId=619
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_HW_PROFILE
 Language=English
+ERROR_INVALID_HW_PROFILE - The specified hardware profile configuration is invalid.
+.
+Language=Russian
 ERROR_INVALID_HW_PROFILE - The specified hardware profile configuration is invalid.
 .
 
@@ -2760,12 +3111,18 @@ SymbolicName=ERROR_INVALID_PLUGPLAY_DEVICE_PATH
 Language=English
 ERROR_INVALID_PLUGPLAY_DEVICE_PATH - The specified Plug and Play registry device path is invalid.
 .
+Language=Russian
+ERROR_INVALID_PLUGPLAY_DEVICE_PATH - The specified Plug and Play registry device path is invalid.
+.
 
 MessageId=621
 Severity=Success
 Facility=System
 SymbolicName=ERROR_QUOTA_LIST_INCONSISTENT
 Language=English
+ERROR_QUOTA_LIST_INCONSISTENT - The specified quota list is internally inconsistent with its descriptor.
+.
+Language=Russian
 ERROR_QUOTA_LIST_INCONSISTENT - The specified quota list is internally inconsistent with its descriptor.
 .
 
@@ -2776,12 +3133,18 @@ SymbolicName=ERROR_EVALUATION_EXPIRATION
 Language=English
 ERROR_EVALUATION_EXPIRATION - The evaluation period for this installation of Windows has expired. This system will shutdown in 1 hour. To restore access to this installation of Windows, please upgrade this installation using a licensed distribution of this product.
 .
+Language=Russian
+ERROR_EVALUATION_EXPIRATION - The evaluation period for this installation of Windows has expired. This system will shutdown in 1 hour. To restore access to this installation of Windows, please upgrade this installation using a licensed distribution of this product.
+.
 
 MessageId=623
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ILLEGAL_DLL_RELOCATION
 Language=English
+ERROR_ILLEGAL_DLL_RELOCATION - The system DLL %hs was relocated in memory. The application will not run properly. The relocation occurred because the DLL %hs occupied an address range reserved for Windows system DLLs. The vendor supplying the DLL should be contacted for a new DLL.
+.
+Language=Russian
 ERROR_ILLEGAL_DLL_RELOCATION - The system DLL %hs was relocated in memory. The application will not run properly. The relocation occurred because the DLL %hs occupied an address range reserved for Windows system DLLs. The vendor supplying the DLL should be contacted for a new DLL.
 .
 
@@ -2792,12 +3155,18 @@ SymbolicName=ERROR_DLL_INIT_FAILED_LOGOFF
 Language=English
 ERROR_DLL_INIT_FAILED_LOGOFF - The application failed to initialize because the window station is shutting down.
 .
+Language=Russian
+ERROR_DLL_INIT_FAILED_LOGOFF - The application failed to initialize because the window station is shutting down.
+.
 
 MessageId=625
 Severity=Success
 Facility=System
 SymbolicName=ERROR_VALIDATE_CONTINUE
 Language=English
+ERROR_VALIDATE_CONTINUE - The validation process needs to continue on to the next step.
+.
+Language=Russian
 ERROR_VALIDATE_CONTINUE - The validation process needs to continue on to the next step.
 .
 
@@ -2808,12 +3177,18 @@ SymbolicName=ERROR_NO_MORE_MATCHES
 Language=English
 ERROR_NO_MORE_MATCHES - There are no more matches for the current index enumeration.
 .
+Language=Russian
+ERROR_NO_MORE_MATCHES - There are no more matches for the current index enumeration.
+.
 
 MessageId=627
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RANGE_LIST_CONFLICT
 Language=English
+ERROR_RANGE_LIST_CONFLICT - The range could not be added to the range list because of a conflict.
+.
+Language=Russian
 ERROR_RANGE_LIST_CONFLICT - The range could not be added to the range list because of a conflict.
 .
 
@@ -2824,12 +3199,18 @@ SymbolicName=ERROR_SERVER_SID_MISMATCH
 Language=English
 ERROR_SERVER_SID_MISMATCH - The server process is running under a SID different than that required by client.
 .
+Language=Russian
+ERROR_SERVER_SID_MISMATCH - The server process is running under a SID different than that required by client.
+.
 
 MessageId=629
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANT_ENABLE_DENY_ONLY
 Language=English
+ERROR_CANT_ENABLE_DENY_ONLY - A group marked use for deny only cannot be enabled.
+.
+Language=Russian
 ERROR_CANT_ENABLE_DENY_ONLY - A group marked use for deny only cannot be enabled.
 .
 
@@ -2840,12 +3221,18 @@ SymbolicName=ERROR_FLOAT_MULTIPLE_FAULTS
 Language=English
 ERROR_FLOAT_MULTIPLE_FAULTS - Multiple floating point faults.
 .
+Language=Russian
+ERROR_FLOAT_MULTIPLE_FAULTS - Multiple floating point faults.
+.
 
 MessageId=631
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLOAT_MULTIPLE_TRAPS
 Language=English
+ERROR_FLOAT_MULTIPLE_TRAPS - Multiple floating point traps.
+.
+Language=Russian
 ERROR_FLOAT_MULTIPLE_TRAPS - Multiple floating point traps.
 .
 
@@ -2856,12 +3243,18 @@ SymbolicName=ERROR_NOINTERFACE
 Language=English
 ERROR_NOINTERFACE - The requested interface is not supported.
 .
+Language=Russian
+ERROR_NOINTERFACE - The requested interface is not supported.
+.
 
 MessageId=633
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DRIVER_FAILED_SLEEP
 Language=English
+ERROR_DRIVER_FAILED_SLEEP - The driver %hs does not support standby mode. Updating this driver may allow the system to go to standby mode.
+.
+Language=Russian
 ERROR_DRIVER_FAILED_SLEEP - The driver %hs does not support standby mode. Updating this driver may allow the system to go to standby mode.
 .
 
@@ -2872,12 +3265,18 @@ SymbolicName=ERROR_CORRUPT_SYSTEM_FILE
 Language=English
 ERROR_CORRUPT_SYSTEM_FILE - The system file %1 has become corrupt and has been replaced.
 .
+Language=Russian
+ERROR_CORRUPT_SYSTEM_FILE - The system file %1 has become corrupt and has been replaced.
+.
 
 MessageId=635
 Severity=Success
 Facility=System
 SymbolicName=ERROR_COMMITMENT_MINIMUM
 Language=English
+ERROR_COMMITMENT_MINIMUM - Your system is low on virtual memory. Windows is increasing the size of your virtual memory paging file. During this process, memory requests for some applications may be denied. For more information, see Help.
+.
+Language=Russian
 ERROR_COMMITMENT_MINIMUM - Your system is low on virtual memory. Windows is increasing the size of your virtual memory paging file. During this process, memory requests for some applications may be denied. For more information, see Help.
 .
 
@@ -2888,12 +3287,18 @@ SymbolicName=ERROR_PNP_RESTART_ENUMERATION
 Language=English
 ERROR_PNP_RESTART_ENUMERATION - A device was removed so enumeration must be restarted.
 .
+Language=Russian
+ERROR_PNP_RESTART_ENUMERATION - A device was removed so enumeration must be restarted.
+.
 
 MessageId=637
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SYSTEM_IMAGE_BAD_SIGNATURE
 Language=English
+ERROR_SYSTEM_IMAGE_BAD_SIGNATURE - The system image %s is not properly signed. The file has been replaced with the signed file. The system has been shut down.
+.
+Language=Russian
 ERROR_SYSTEM_IMAGE_BAD_SIGNATURE - The system image %s is not properly signed. The file has been replaced with the signed file. The system has been shut down.
 .
 
@@ -2904,12 +3309,18 @@ SymbolicName=ERROR_PNP_REBOOT_REQUIRED
 Language=English
 ERROR_PNP_REBOOT_REQUIRED - Device will not start without a reboot.
 .
+Language=Russian
+ERROR_PNP_REBOOT_REQUIRED - Device will not start without a reboot.
+.
 
 MessageId=639
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSUFFICIENT_POWER
 Language=English
+ERROR_INSUFFICIENT_POWER - There is not enough power to complete the requested operation.
+.
+Language=Russian
 ERROR_INSUFFICIENT_POWER - There is not enough power to complete the requested operation.
 .
 
@@ -2920,12 +3331,18 @@ SymbolicName=ERROR_SYSTEM_SHUTDOWN
 Language=English
 ERROR_SYSTEM_SHUTDOWN - The system is in the process of shutting down.
 .
+Language=Russian
+ERROR_SYSTEM_SHUTDOWN - The system is in the process of shutting down.
+.
 
 MessageId=642
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PORT_NOT_SET
 Language=English
+ERROR_PORT_NOT_SET - An attempt to remove a processes DebugPort was made, but a port was not already associated with the process.
+.
+Language=Russian
 ERROR_PORT_NOT_SET - An attempt to remove a processes DebugPort was made, but a port was not already associated with the process.
 .
 
@@ -2936,12 +3353,18 @@ SymbolicName=ERROR_DS_VERSION_CHECK_FAILURE
 Language=English
 ERROR_DS_VERSION_CHECK_FAILURE - This version of Windows is not compatible with the behavior version of directory forest, domain or domain controller.
 .
+Language=Russian
+ERROR_DS_VERSION_CHECK_FAILURE - This version of Windows is not compatible with the behavior version of directory forest, domain or domain controller.
+.
 
 MessageId=644
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RANGE_NOT_FOUND
 Language=English
+ERROR_RANGE_NOT_FOUND - The specified range could not be found in the range list.
+.
+Language=Russian
 ERROR_RANGE_NOT_FOUND - The specified range could not be found in the range list.
 .
 
@@ -2952,12 +3375,18 @@ SymbolicName=ERROR_NOT_SAFE_MODE_DRIVER
 Language=English
 ERROR_NOT_SAFE_MODE_DRIVER - The driver was not loaded because the system is booting into safe mode.
 .
+Language=Russian
+ERROR_NOT_SAFE_MODE_DRIVER - The driver was not loaded because the system is booting into safe mode.
+.
 
 MessageId=647
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FAILED_DRIVER_ENTRY
 Language=English
+ERROR_FAILED_DRIVER_ENTRY - The driver was not loaded because it failed it's initialization call.
+.
+Language=Russian
 ERROR_FAILED_DRIVER_ENTRY - The driver was not loaded because it failed it's initialization call.
 .
 
@@ -2968,12 +3397,18 @@ SymbolicName=ERROR_DEVICE_ENUMERATION_ERROR
 Language=English
 ERROR_DEVICE_ENUMERATION_ERROR - The \"%hs\" encountered an error while applying power or reading the device configuration. This may be caused by a failure of your hardware or by a poor connection.
 .
+Language=Russian
+ERROR_DEVICE_ENUMERATION_ERROR - The \"%hs\" encountered an error while applying power or reading the device configuration. This may be caused by a failure of your hardware or by a poor connection.
+.
 
 MessageId=649
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MOUNT_POINT_NOT_RESOLVED
 Language=English
+ERROR_MOUNT_POINT_NOT_RESOLVED - The create operation failed because the name contained at least one mount point which resolves to a volume to which the specified device object is not attached.
+.
+Language=Russian
 ERROR_MOUNT_POINT_NOT_RESOLVED - The create operation failed because the name contained at least one mount point which resolves to a volume to which the specified device object is not attached.
 .
 
@@ -2984,12 +3419,18 @@ SymbolicName=ERROR_INVALID_DEVICE_OBJECT_PARAMETER
 Language=English
 ERROR_INVALID_DEVICE_OBJECT_PARAMETER - The device object parameter is either not a valid device object or is not attached to the volume specified by the file name.
 .
+Language=Russian
+ERROR_INVALID_DEVICE_OBJECT_PARAMETER - The device object parameter is either not a valid device object or is not attached to the volume specified by the file name.
+.
 
 MessageId=651
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MCA_OCCURED
 Language=English
+ERROR_MCA_OCCURED - A Machine Check Error has occurred. Please check the system eventlog for additional information.
+.
+Language=Russian
 ERROR_MCA_OCCURED - A Machine Check Error has occurred. Please check the system eventlog for additional information.
 .
 
@@ -3000,12 +3441,18 @@ SymbolicName=ERROR_DRIVER_DATABASE_ERROR
 Language=English
 ERROR_DRIVER_DATABASE_ERROR - There was error [%2] processing the driver database.
 .
+Language=Russian
+ERROR_DRIVER_DATABASE_ERROR - There was error [%2] processing the driver database.
+.
 
 MessageId=653
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SYSTEM_HIVE_TOO_LARGE
 Language=English
+ERROR_SYSTEM_HIVE_TOO_LARGE - System hive size has exceeded its limit.
+.
+Language=Russian
 ERROR_SYSTEM_HIVE_TOO_LARGE - System hive size has exceeded its limit.
 .
 
@@ -3016,12 +3463,18 @@ SymbolicName=ERROR_DRIVER_FAILED_PRIOR_UNLOAD
 Language=English
 ERROR_DRIVER_FAILED_PRIOR_UNLOAD - The driver could not be loaded because a previous version of the driver is still in memory.
 .
+Language=Russian
+ERROR_DRIVER_FAILED_PRIOR_UNLOAD - The driver could not be loaded because a previous version of the driver is still in memory.
+.
 
 MessageId=655
 Severity=Success
 Facility=System
 SymbolicName=ERROR_VOLSNAP_PREPARE_HIBERNATE
 Language=English
+ERROR_VOLSNAP_PREPARE_HIBERNATE - Please wait while the Volume Shadow Copy Service prepares volume %hs for hibernation.
+.
+Language=Russian
 ERROR_VOLSNAP_PREPARE_HIBERNATE - Please wait while the Volume Shadow Copy Service prepares volume %hs for hibernation.
 .
 
@@ -3032,12 +3485,18 @@ SymbolicName=ERROR_HIBERNATION_FAILURE
 Language=English
 ERROR_HIBERNATION_FAILURE - The system has failed to hibernate (The error code is %hs). Hibernation will be disabled until the system is restarted.
 .
+Language=Russian
+ERROR_HIBERNATION_FAILURE - The system has failed to hibernate (The error code is %hs). Hibernation will be disabled until the system is restarted.
+.
 
 MessageId=657
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HUNG_DISPLAY_DRIVER_THREAD
 Language=English
+ERROR_HUNG_DISPLAY_DRIVER_THREAD - The %hs display driver has stopped working normally. Save your work and reboot the system to restore full display functionality. The next time you reboot the machine a dialog will be displayed giving you a chance to report this failure to Microsoft.
+.
+Language=Russian
 ERROR_HUNG_DISPLAY_DRIVER_THREAD - The %hs display driver has stopped working normally. Save your work and reboot the system to restore full display functionality. The next time you reboot the machine a dialog will be displayed giving you a chance to report this failure to Microsoft.
 .
 
@@ -3048,12 +3507,18 @@ SymbolicName=ERROR_FILE_SYSTEM_LIMITATION
 Language=English
 ERROR_FILE_SYSTEM_LIMITATION - The requested operation could not be completed due to a file system limitation.
 .
+Language=Russian
+ERROR_FILE_SYSTEM_LIMITATION - The requested operation could not be completed due to a file system limitation.
+.
 
 MessageId=668
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ASSERTION_FAILURE
 Language=English
+ERROR_ASSERTION_FAILURE - An assertion failure has occurred.
+.
+Language=Russian
 ERROR_ASSERTION_FAILURE - An assertion failure has occurred.
 .
 
@@ -3064,12 +3529,18 @@ SymbolicName=ERROR_VERIFIER_STOP
 Language=English
 ERROR_VERIFIER_STOP - Application verifier has found an error in the current process.
 .
+Language=Russian
+ERROR_VERIFIER_STOP - Application verifier has found an error in the current process.
+.
 
 MessageId=670
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WOW_ASSERTION
 Language=English
+ERROR_WOW_ASSERTION - WOW Assertion Error.
+.
+Language=Russian
 ERROR_WOW_ASSERTION - WOW Assertion Error.
 .
 
@@ -3080,12 +3551,18 @@ SymbolicName=ERROR_PNP_BAD_MPS_TABLE
 Language=English
 ERROR_PNP_BAD_MPS_TABLE - A device is missing in the system BIOS MPS table. This device will not be used. Please contact your system vendor for system BIOS update.
 .
+Language=Russian
+ERROR_PNP_BAD_MPS_TABLE - A device is missing in the system BIOS MPS table. This device will not be used. Please contact your system vendor for system BIOS update.
+.
 
 MessageId=672
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PNP_TRANSLATION_FAILED
 Language=English
+ERROR_PNP_TRANSLATION_FAILED - A translator failed to translate resources.
+.
+Language=Russian
 ERROR_PNP_TRANSLATION_FAILED - A translator failed to translate resources.
 .
 
@@ -3096,12 +3573,18 @@ SymbolicName=ERROR_PNP_IRQ_TRANSLATION_FAILED
 Language=English
 ERROR_PNP_IRQ_TRANSLATION_FAILED - A IRQ translator failed to translate resources.
 .
+Language=Russian
+ERROR_PNP_IRQ_TRANSLATION_FAILED - A IRQ translator failed to translate resources.
+.
 
 MessageId=674
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PNP_INVALID_ID
 Language=English
+ERROR_PNP_INVALID_ID - Driver %2 returned invalid ID for a child device (%3).
+.
+Language=Russian
 ERROR_PNP_INVALID_ID - Driver %2 returned invalid ID for a child device (%3).
 .
 
@@ -3112,12 +3595,18 @@ SymbolicName=ERROR_WAKE_SYSTEM_DEBUGGER
 Language=English
 ERROR_WAKE_SYSTEM_DEBUGGER - The system debugger was awakened by an interrupt.
 .
+Language=Russian
+ERROR_WAKE_SYSTEM_DEBUGGER - The system debugger was awakened by an interrupt.
+.
 
 MessageId=676
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HANDLES_CLOSED
 Language=English
+ERROR_HANDLES_CLOSED - Handles to objects have been automatically closed as a result of the requested operation.
+.
+Language=Russian
 ERROR_HANDLES_CLOSED - Handles to objects have been automatically closed as a result of the requested operation.
 .
 
@@ -3128,12 +3617,18 @@ SymbolicName=ERROR_EXTRANEOUS_INFORMATION
 Language=English
 ERROR_EXTRANEOUS_INFORMATION - he specified access control list (ACL) contained more information than was expected.
 .
+Language=Russian
+ERROR_EXTRANEOUS_INFORMATION - he specified access control list (ACL) contained more information than was expected.
+.
 
 MessageId=678
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RXACT_COMMIT_NECESSARY
 Language=English
+ERROR_RXACT_COMMIT_NECESSARY - This warning level status indicates that the transaction state already exists for the registry sub-tree, but that a transaction commit was previously aborted. The commit has NOT been completed, but has not been rolled back either (so it may still be committed if desired).
+.
+Language=Russian
 ERROR_RXACT_COMMIT_NECESSARY - This warning level status indicates that the transaction state already exists for the registry sub-tree, but that a transaction commit was previously aborted. The commit has NOT been completed, but has not been rolled back either (so it may still be committed if desired).
 .
 
@@ -3144,12 +3639,18 @@ SymbolicName=ERROR_MEDIA_CHECK
 Language=English
 ERROR_MEDIA_CHECK - The media may have changed.
 .
+Language=Russian
+ERROR_MEDIA_CHECK - The media may have changed.
+.
 
 MessageId=680
 Severity=Success
 Facility=System
 SymbolicName=ERROR_GUID_SUBSTITUTION_MADE
 Language=English
+ERROR_GUID_SUBSTITUTION_MADE - During the translation of a global identifier (GUID) to a Windows security ID (SID), no administratively-defined GUID prefix was found. A substitute prefix was used, which will not compromise system security. However, this may provide a more restrictive access than intended.
+.
+Language=Russian
 ERROR_GUID_SUBSTITUTION_MADE - During the translation of a global identifier (GUID) to a Windows security ID (SID), no administratively-defined GUID prefix was found. A substitute prefix was used, which will not compromise system security. However, this may provide a more restrictive access than intended.
 .
 
@@ -3160,12 +3661,18 @@ SymbolicName=ERROR_STOPPED_ON_SYMLINK
 Language=English
 ERROR_STOPPED_ON_SYMLINK - The create operation stopped after reaching a symbolic link.
 .
+Language=Russian
+ERROR_STOPPED_ON_SYMLINK - The create operation stopped after reaching a symbolic link.
+.
 
 MessageId=682
 Severity=Success
 Facility=System
 SymbolicName=ERROR_LONGJUMP
 Language=English
+ERROR_LONGJUMP - A long jump has been executed.
+.
+Language=Russian
 ERROR_LONGJUMP - A long jump has been executed.
 .
 
@@ -3176,12 +3683,18 @@ SymbolicName=ERROR_PLUGPLAY_QUERY_VETOED
 Language=English
 ERROR_PLUGPLAY_QUERY_VETOED - The Plug and Play query operation was not successful.
 .
+Language=Russian
+ERROR_PLUGPLAY_QUERY_VETOED - The Plug and Play query operation was not successful.
+.
 
 MessageId=684
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNWIND_CONSOLIDATE
 Language=English
+ERROR_UNWIND_CONSOLIDATE - A frame consolidation has been executed.
+.
+Language=Russian
 ERROR_UNWIND_CONSOLIDATE - A frame consolidation has been executed.
 .
 
@@ -3192,12 +3705,18 @@ SymbolicName=ERROR_REGISTRY_HIVE_RECOVERED
 Language=English
 ERROR_REGISTRY_HIVE_RECOVERED - Registry hive (file): %hs was corrupted and it has been recovered. Some data might have been lost.
 .
+Language=Russian
+ERROR_REGISTRY_HIVE_RECOVERED - Registry hive (file): %hs was corrupted and it has been recovered. Some data might have been lost.
+.
 
 MessageId=686
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DLL_MIGHT_BE_INSECURE
 Language=English
+ERROR_DLL_MIGHT_BE_INSECURE - The application is attempting to run executable code from the module %hs. This may be insecure. An alternative, %hs, is available. Should the application use the secure module %hs?
+.
+Language=Russian
 ERROR_DLL_MIGHT_BE_INSECURE - The application is attempting to run executable code from the module %hs. This may be insecure. An alternative, %hs, is available. Should the application use the secure module %hs?
 .
 
@@ -3208,12 +3727,18 @@ SymbolicName=ERROR_DLL_MIGHT_BE_INCOMPATIBLE
 Language=English
 ERROR_DLL_MIGHT_BE_INCOMPATIBLE - The application is loading executable code from the module %hs. This is secure, but may be incompatible with previous releases of the operating system. An alternative, %hs, is available. Should the application use the secure module %hs?
 .
+Language=Russian
+ERROR_DLL_MIGHT_BE_INCOMPATIBLE - The application is loading executable code from the module %hs. This is secure, but may be incompatible with previous releases of the operating system. An alternative, %hs, is available. Should the application use the secure module %hs?
+.
 
 MessageId=688
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_EXCEPTION_NOT_HANDLED
 Language=English
+ERROR_DBG_EXCEPTION_NOT_HANDLED - Debugger did not handle the exception.
+.
+Language=Russian
 ERROR_DBG_EXCEPTION_NOT_HANDLED - Debugger did not handle the exception.
 .
 
@@ -3224,12 +3749,18 @@ SymbolicName=ERROR_DBG_REPLY_LATER
 Language=English
 ERROR_DBG_REPLY_LATER - Debugger will reply later.
 .
+Language=Russian
+ERROR_DBG_REPLY_LATER - Debugger will reply later.
+.
 
 MessageId=690
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_UNABLE_TO_PROVIDE_HANDLE
 Language=English
+ERROR_DBG_UNABLE_TO_PROVIDE_HANDLE - Debugger can not provide handle.
+.
+Language=Russian
 ERROR_DBG_UNABLE_TO_PROVIDE_HANDLE - Debugger can not provide handle.
 .
 
@@ -3240,12 +3771,18 @@ SymbolicName=ERROR_DBG_TERMINATE_THREAD
 Language=English
 ERROR_DBG_TERMINATE_THREAD - Debugger terminated thread.
 .
+Language=Russian
+ERROR_DBG_TERMINATE_THREAD - Debugger terminated thread.
+.
 
 MessageId=692
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_TERMINATE_PROCESS
 Language=English
+ERROR_DBG_TERMINATE_PROCESS - Debugger terminated process.
+.
+Language=Russian
 ERROR_DBG_TERMINATE_PROCESS - Debugger terminated process.
 .
 
@@ -3256,12 +3793,18 @@ SymbolicName=ERROR_DBG_CONTROL_C
 Language=English
 ERROR_DBG_CONTROL_C - Debugger got control C.
 .
+Language=Russian
+ERROR_DBG_CONTROL_C - Debugger got control C.
+.
 
 MessageId=694
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_PRINTEXCEPTION_C
 Language=English
+ERROR_DBG_PRINTEXCEPTION_C - Debugger printed exception on control C.
+.
+Language=Russian
 ERROR_DBG_PRINTEXCEPTION_C - Debugger printed exception on control C.
 .
 
@@ -3272,12 +3815,18 @@ SymbolicName=ERROR_DBG_RIPEXCEPTION
 Language=English
 ERROR_DBG_RIPEXCEPTION - Debugger received RIP exception.
 .
+Language=Russian
+ERROR_DBG_RIPEXCEPTION - Debugger received RIP exception.
+.
 
 MessageId=696
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_CONTROL_BREAK
 Language=English
+ERROR_DBG_CONTROL_BREAK - Debugger received control break.
+.
+Language=Russian
 ERROR_DBG_CONTROL_BREAK - Debugger received control break.
 .
 
@@ -3288,12 +3837,18 @@ SymbolicName=ERROR_DBG_COMMAND_EXCEPTION
 Language=English
 ERROR_DBG_COMMAND_EXCEPTION - Debugger command communication exception.
 .
+Language=Russian
+ERROR_DBG_COMMAND_EXCEPTION - Debugger command communication exception.
+.
 
 MessageId=698
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OBJECT_NAME_EXISTS
 Language=English
+ERROR_OBJECT_NAME_EXISTS - An attempt was made to create an object and the object name already existed.
+.
+Language=Russian
 ERROR_OBJECT_NAME_EXISTS - An attempt was made to create an object and the object name already existed.
 .
 
@@ -3304,12 +3859,18 @@ SymbolicName=ERROR_THREAD_WAS_SUSPENDED
 Language=English
 ERROR_THREAD_WAS_SUSPENDED - A thread termination occurred while the thread was suspended. The thread was resumed, and termination proceeded.
 .
+Language=Russian
+ERROR_THREAD_WAS_SUSPENDED - A thread termination occurred while the thread was suspended. The thread was resumed, and termination proceeded.
+.
 
 MessageId=700
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IMAGE_NOT_AT_BASE
 Language=English
+ERROR_IMAGE_NOT_AT_BASE - An image file could not be mapped at the address specified in the image file. Local fixups must be performed on this image.
+.
+Language=Russian
 ERROR_IMAGE_NOT_AT_BASE - An image file could not be mapped at the address specified in the image file. Local fixups must be performed on this image.
 .
 
@@ -3320,12 +3881,18 @@ SymbolicName=ERROR_RXACT_STATE_CREATED
 Language=English
 ERROR_RXACT_STATE_CREATED - This informational level status indicates that a specified registry sub-tree transaction state did not yet exist and had to be created.
 .
+Language=Russian
+ERROR_RXACT_STATE_CREATED - This informational level status indicates that a specified registry sub-tree transaction state did not yet exist and had to be created.
+.
 
 MessageId=702
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SEGMENT_NOTIFICATION
 Language=English
+ERROR_SEGMENT_NOTIFICATION - A virtual DOS machine (VDM) is loading, unloading, or moving an MS-DOS or Win16 program segment image. An exception is raised so a debugger can load, unload or track symbols and breakpoints within these 16-bit segments.
+.
+Language=Russian
 ERROR_SEGMENT_NOTIFICATION - A virtual DOS machine (VDM) is loading, unloading, or moving an MS-DOS or Win16 program segment image. An exception is raised so a debugger can load, unload or track symbols and breakpoints within these 16-bit segments.
 .
 
@@ -3336,12 +3903,18 @@ SymbolicName=ERROR_BAD_CURRENT_DIRECTORY
 Language=English
 ERROR_BAD_CURRENT_DIRECTORY - The process cannot switch to the startup current directory %hs. Select OK to set current directory to %hs, or select CANCEL to exit.
 .
+Language=Russian
+ERROR_BAD_CURRENT_DIRECTORY - The process cannot switch to the startup current directory %hs. Select OK to set current directory to %hs, or select CANCEL to exit.
+.
 
 MessageId=704
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FT_READ_RECOVERY_FROM_BACKUP
 Language=English
+ERROR_FT_READ_RECOVERY_FROM_BACKUP - To satisfy a read request, the NT fault-tolerant file system successfully read the requested data from a redundant copy. This was done because the file system encountered a failure on a member of the fault-tolerant volume, but was unable to reassign the failing area of the device.
+.
+Language=Russian
 ERROR_FT_READ_RECOVERY_FROM_BACKUP - To satisfy a read request, the NT fault-tolerant file system successfully read the requested data from a redundant copy. This was done because the file system encountered a failure on a member of the fault-tolerant volume, but was unable to reassign the failing area of the device.
 .
 
@@ -3352,12 +3925,18 @@ SymbolicName=ERROR_FT_WRITE_RECOVERY
 Language=English
 ERROR_FT_WRITE_RECOVERY - To satisfy a write request, the NT fault-tolerant file system successfully wrote a redundant copy of the information. This was done because the file system encountered a failure on a member of the fault-tolerant volume, but was not able to reassign the failing area of the device.
 .
+Language=Russian
+ERROR_FT_WRITE_RECOVERY - To satisfy a write request, the NT fault-tolerant file system successfully wrote a redundant copy of the information. This was done because the file system encountered a failure on a member of the fault-tolerant volume, but was not able to reassign the failing area of the device.
+.
 
 MessageId=706
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IMAGE_MACHINE_TYPE_MISMATCH
 Language=English
+ERROR_IMAGE_MACHINE_TYPE_MISMATCH - The image file %hs is valid, but is for a machine type other than the current machine. Select OK to continue, or CANCEL to fail the DLL load.
+.
+Language=Russian
 ERROR_IMAGE_MACHINE_TYPE_MISMATCH - The image file %hs is valid, but is for a machine type other than the current machine. Select OK to continue, or CANCEL to fail the DLL load.
 .
 
@@ -3368,12 +3947,18 @@ SymbolicName=ERROR_RECEIVE_PARTIAL
 Language=English
 ERROR_RECEIVE_PARTIAL - The network transport returned partial data to its client. The remaining data will be sent later.
 .
+Language=Russian
+ERROR_RECEIVE_PARTIAL - The network transport returned partial data to its client. The remaining data will be sent later.
+.
 
 MessageId=708
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RECEIVE_EXPEDITED
 Language=English
+ERROR_RECEIVE_EXPEDITED - The network transport returned data to its client that was marked as expedited by the remote system.
+.
+Language=Russian
 ERROR_RECEIVE_EXPEDITED - The network transport returned data to its client that was marked as expedited by the remote system.
 .
 
@@ -3384,12 +3969,18 @@ SymbolicName=ERROR_RECEIVE_PARTIAL_EXPEDITED
 Language=English
 ERROR_RECEIVE_PARTIAL_EXPEDITED - The network transport returned partial data to its client and this data was marked as expedited by the remote system. The remaining data will be sent later.
 .
+Language=Russian
+ERROR_RECEIVE_PARTIAL_EXPEDITED - The network transport returned partial data to its client and this data was marked as expedited by the remote system. The remaining data will be sent later.
+.
 
 MessageId=710
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVENT_DONE
 Language=English
+ERROR_EVENT_DONE - The TDI indication has completed successfully.
+.
+Language=Russian
 ERROR_EVENT_DONE - The TDI indication has completed successfully.
 .
 
@@ -3400,12 +3991,18 @@ SymbolicName=ERROR_EVENT_PENDING
 Language=English
 ERROR_EVENT_PENDING - The TDI indication has entered the pending state.
 .
+Language=Russian
+ERROR_EVENT_PENDING - The TDI indication has entered the pending state.
+.
 
 MessageId=712
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CHECKING_FILE_SYSTEM
 Language=English
+ERROR_CHECKING_FILE_SYSTEM - Checking file system on %wZ.
+.
+Language=Russian
 ERROR_CHECKING_FILE_SYSTEM - Checking file system on %wZ.
 .
 
@@ -3416,12 +4013,18 @@ SymbolicName=ERROR_PREDEFINED_HANDLE
 Language=English
 ERROR_PREDEFINED_HANDLE - The specified registry key is referenced by a predefined handle.
 .
+Language=Russian
+ERROR_PREDEFINED_HANDLE - The specified registry key is referenced by a predefined handle.
+.
 
 MessageId=715
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WAS_UNLOCKED
 Language=English
+ERROR_WAS_UNLOCKED - The page protection of a locked page was changed to 'No Access' and the page was unlocked from memory and from the process.
+.
+Language=Russian
 ERROR_WAS_UNLOCKED - The page protection of a locked page was changed to 'No Access' and the page was unlocked from memory and from the process.
 .
 
@@ -3432,12 +4035,18 @@ SymbolicName=ERROR_WAS_LOCKED
 Language=English
 ERROR_WAS_LOCKED - One of the pages to lock was already locked.
 .
+Language=Russian
+ERROR_WAS_LOCKED - One of the pages to lock was already locked.
+.
 
 MessageId=720
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IMAGE_MACHINE_TYPE_MISMATCH_EXE
 Language=English
+ERROR_IMAGE_MACHINE_TYPE_MISMATCH_EXE - The image file %hs is valid, but is for a machine type other than the current machine.
+.
+Language=Russian
 ERROR_IMAGE_MACHINE_TYPE_MISMATCH_EXE - The image file %hs is valid, but is for a machine type other than the current machine.
 .
 
@@ -3448,12 +4057,18 @@ SymbolicName=ERROR_NO_YIELD_PERFORMED
 Language=English
 ERROR_NO_YIELD_PERFORMED - A yield execution was performed and no thread was available to run.
 .
+Language=Russian
+ERROR_NO_YIELD_PERFORMED - A yield execution was performed and no thread was available to run.
+.
 
 MessageId=722
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TIMER_RESUME_IGNORED
 Language=English
+ERROR_TIMER_RESUME_IGNORED - The resumable flag to a timer API was ignored.
+.
+Language=Russian
 ERROR_TIMER_RESUME_IGNORED - The resumable flag to a timer API was ignored.
 .
 
@@ -3464,12 +4079,18 @@ SymbolicName=ERROR_ARBITRATION_UNHANDLED
 Language=English
 ERROR_ARBITRATION_UNHANDLED - The arbiter has deferred arbitration of these resources to its parent.
 .
+Language=Russian
+ERROR_ARBITRATION_UNHANDLED - The arbiter has deferred arbitration of these resources to its parent.
+.
 
 MessageId=724
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CARDBUS_NOT_SUPPORTED
 Language=English
+ERROR_CARDBUS_NOT_SUPPORTED - The device \"%hs\" has detected a CardBus card in its slot, but the firmware on this system is not configured to allow the CardBus controller to be run in CardBus mode. The operating system will currently accept only 16-bit (R2) pc-cards on this controller.
+.
+Language=Russian
 ERROR_CARDBUS_NOT_SUPPORTED - The device \"%hs\" has detected a CardBus card in its slot, but the firmware on this system is not configured to allow the CardBus controller to be run in CardBus mode. The operating system will currently accept only 16-bit (R2) pc-cards on this controller.
 .
 
@@ -3480,12 +4101,18 @@ SymbolicName=ERROR_MP_PROCESSOR_MISMATCH
 Language=English
 ERROR_MP_PROCESSOR_MISMATCH - The CPUs in this multiprocessor system are not all the same revision level. To use all processors the operating system restricts itself to the features of the least capable processor in the system. Should problems occur with this system, contact the CPU manufacturer to see if this mix of processors is supported.
 .
+Language=Russian
+ERROR_MP_PROCESSOR_MISMATCH - The CPUs in this multiprocessor system are not all the same revision level. To use all processors the operating system restricts itself to the features of the least capable processor in the system. Should problems occur with this system, contact the CPU manufacturer to see if this mix of processors is supported.
+.
 
 MessageId=726
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HIBERNATED
 Language=English
+ERROR_HIBERNATED - The system was put into hibernation.
+.
+Language=Russian
 ERROR_HIBERNATED - The system was put into hibernation.
 .
 
@@ -3496,12 +4123,18 @@ SymbolicName=ERROR_RESUME_HIBERNATION
 Language=English
 ERROR_RESUME_HIBERNATION - The system was resumed from hibernation.
 .
+Language=Russian
+ERROR_RESUME_HIBERNATION - The system was resumed from hibernation.
+.
 
 MessageId=728
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FIRMWARE_UPDATED
 Language=English
+ERROR_FIRMWARE_UPDATED - Windows has detected that the system firmware (BIOS) was updated [previous firmware date = %2, current firmware date %3].
+.
+Language=Russian
 ERROR_FIRMWARE_UPDATED - Windows has detected that the system firmware (BIOS) was updated [previous firmware date = %2, current firmware date %3].
 .
 
@@ -3512,12 +4145,18 @@ SymbolicName=ERROR_DRIVERS_LEAKING_LOCKED_PAGES
 Language=English
 ERROR_DRIVERS_LEAKING_LOCKED_PAGES - A device driver is leaking locked I/O pages causing system degradation. The system has automatically enabled tracking code in order to try and catch the culprit.
 .
+Language=Russian
+ERROR_DRIVERS_LEAKING_LOCKED_PAGES - A device driver is leaking locked I/O pages causing system degradation. The system has automatically enabled tracking code in order to try and catch the culprit.
+.
 
 MessageId=730
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WAKE_SYSTEM
 Language=English
+ERROR_WAKE_SYSTEM - The system has awoken
+.
+Language=Russian
 ERROR_WAKE_SYSTEM - The system has awoken
 .
 
@@ -3528,12 +4167,18 @@ SymbolicName=ERROR_REPARSE
 Language=English
 ERROR_REPARSE - A reparse should be performed by the Object Manager since the name of the file resulted in a symbolic link.
 .
+Language=Russian
+ERROR_REPARSE - A reparse should be performed by the Object Manager since the name of the file resulted in a symbolic link.
+.
 
 MessageId=742
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OPLOCK_BREAK_IN_PROGRESS
 Language=English
+ERROR_OPLOCK_BREAK_IN_PROGRESS - An open/create operation completed while an oplock break is underway.
+.
+Language=Russian
 ERROR_OPLOCK_BREAK_IN_PROGRESS - An open/create operation completed while an oplock break is underway.
 .
 
@@ -3544,12 +4189,18 @@ SymbolicName=ERROR_VOLUME_MOUNTED
 Language=English
 ERROR_VOLUME_MOUNTED - A new volume has been mounted by a file system.
 .
+Language=Russian
+ERROR_VOLUME_MOUNTED - A new volume has been mounted by a file system.
+.
 
 MessageId=744
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RXACT_COMMITTED
 Language=English
+ERROR_RXACT_COMMITTED - This success level status indicates that the transaction state already exists for the registry sub-tree, but that a transaction commit was previously aborted. The commit has now been completed.
+.
+Language=Russian
 ERROR_RXACT_COMMITTED - This success level status indicates that the transaction state already exists for the registry sub-tree, but that a transaction commit was previously aborted. The commit has now been completed.
 .
 
@@ -3560,12 +4211,18 @@ SymbolicName=ERROR_NOTIFY_CLEANUP
 Language=English
 ERROR_NOTIFY_CLEANUP - This indicates that a notify change request has been completed due to closing the handle which made the notify change request.
 .
+Language=Russian
+ERROR_NOTIFY_CLEANUP - This indicates that a notify change request has been completed due to closing the handle which made the notify change request.
+.
 
 MessageId=746
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRIMARY_TRANSPORT_CONNECT_FAILED
 Language=English
+ERROR_PRIMARY_TRANSPORT_CONNECT_FAILED - An attempt was made to connect to the remote server %hs on the primary transport, but the connection failed. The computer WAS able to connect on a secondary transport.
+.
+Language=Russian
 ERROR_PRIMARY_TRANSPORT_CONNECT_FAILED - An attempt was made to connect to the remote server %hs on the primary transport, but the connection failed. The computer WAS able to connect on a secondary transport.
 .
 
@@ -3576,12 +4233,18 @@ SymbolicName=ERROR_PAGE_FAULT_TRANSITION
 Language=English
 ERROR_PAGE_FAULT_TRANSITION - Page fault was a transition fault.
 .
+Language=Russian
+ERROR_PAGE_FAULT_TRANSITION - Page fault was a transition fault.
+.
 
 MessageId=748
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PAGE_FAULT_DEMAND_ZERO
 Language=English
+ERROR_PAGE_FAULT_DEMAND_ZERO - Page fault was a demand zero fault.
+.
+Language=Russian
 ERROR_PAGE_FAULT_DEMAND_ZERO - Page fault was a demand zero fault.
 .
 
@@ -3592,12 +4255,18 @@ SymbolicName=ERROR_PAGE_FAULT_COPY_ON_WRITE
 Language=English
 ERROR_PAGE_FAULT_COPY_ON_WRITE - Page fault was a demand zero fault.
 .
+Language=Russian
+ERROR_PAGE_FAULT_COPY_ON_WRITE - Page fault was a demand zero fault.
+.
 
 MessageId=750
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PAGE_FAULT_GUARD_PAGE
 Language=English
+ERROR_PAGE_FAULT_GUARD_PAGE - Page fault was a demand zero fault.
+.
+Language=Russian
 ERROR_PAGE_FAULT_GUARD_PAGE - Page fault was a demand zero fault.
 .
 
@@ -3608,12 +4277,18 @@ SymbolicName=ERROR_PAGE_FAULT_PAGING_FILE
 Language=English
 ERROR_PAGE_FAULT_PAGING_FILE - Page fault was satisfied by reading from a secondary storage device.
 .
+Language=Russian
+ERROR_PAGE_FAULT_PAGING_FILE - Page fault was satisfied by reading from a secondary storage device.
+.
 
 MessageId=752
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CACHE_PAGE_LOCKED
 Language=English
+ERROR_CACHE_PAGE_LOCKED - Cached page was locked during operation.
+.
+Language=Russian
 ERROR_CACHE_PAGE_LOCKED - Cached page was locked during operation.
 .
 
@@ -3624,12 +4299,18 @@ SymbolicName=ERROR_CRASH_DUMP
 Language=English
 ERROR_CRASH_DUMP - Crash dump exists in paging file.
 .
+Language=Russian
+ERROR_CRASH_DUMP - Crash dump exists in paging file.
+.
 
 MessageId=754
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BUFFER_ALL_ZEROS
 Language=English
+ERROR_BUFFER_ALL_ZEROS - Specified buffer contains all zeros.
+.
+Language=Russian
 ERROR_BUFFER_ALL_ZEROS - Specified buffer contains all zeros.
 .
 
@@ -3640,12 +4321,18 @@ SymbolicName=ERROR_REPARSE_OBJECT
 Language=English
 ERROR_REPARSE_OBJECT - A reparse should be performed by the Object Manager since the name of the file resulted in a symbolic link.
 .
+Language=Russian
+ERROR_REPARSE_OBJECT - A reparse should be performed by the Object Manager since the name of the file resulted in a symbolic link.
+.
 
 MessageId=756
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_REQUIREMENTS_CHANGED
 Language=English
+ERROR_RESOURCE_REQUIREMENTS_CHANGED - The device has succeeded a query-stop and its resource requirements have changed.
+.
+Language=Russian
 ERROR_RESOURCE_REQUIREMENTS_CHANGED - The device has succeeded a query-stop and its resource requirements have changed.
 .
 
@@ -3656,12 +4343,18 @@ SymbolicName=ERROR_TRANSLATION_COMPLETE
 Language=English
 ERROR_TRANSLATION_COMPLETE - The translator has translated these resources into the global space and no further translations should be performed.
 .
+Language=Russian
+ERROR_TRANSLATION_COMPLETE - The translator has translated these resources into the global space and no further translations should be performed.
+.
 
 MessageId=758
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOTHING_TO_TERMINATE
 Language=English
+ERROR_NOTHING_TO_TERMINATE - A process being terminated has no threads to terminate.
+.
+Language=Russian
 ERROR_NOTHING_TO_TERMINATE - A process being terminated has no threads to terminate.
 .
 
@@ -3672,12 +4365,18 @@ SymbolicName=ERROR_PROCESS_NOT_IN_JOB
 Language=English
 ERROR_PROCESS_NOT_IN_JOB - The specified process is not part of a job.
 .
+Language=Russian
+ERROR_PROCESS_NOT_IN_JOB - The specified process is not part of a job.
+.
 
 MessageId=760
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PROCESS_IN_JOB
 Language=English
+ERROR_PROCESS_IN_JOB - The specified process is part of a job.
+.
+Language=Russian
 ERROR_PROCESS_IN_JOB - The specified process is part of a job.
 .
 
@@ -3688,12 +4387,18 @@ SymbolicName=ERROR_VOLSNAP_HIBERNATE_READY
 Language=English
 ERROR_VOLSNAP_HIBERNATE_READY - The system is now ready for hibernation.
 .
+Language=Russian
+ERROR_VOLSNAP_HIBERNATE_READY - The system is now ready for hibernation.
+.
 
 MessageId=762
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FSFILTER_OP_COMPLETED_SUCCESSFULLY
 Language=English
+ERROR_FSFILTER_OP_COMPLETED_SUCCESSFULLY - A file system or file system filter driver has successfully completed an FsFilter operation.
+.
+Language=Russian
 ERROR_FSFILTER_OP_COMPLETED_SUCCESSFULLY - A file system or file system filter driver has successfully completed an FsFilter operation.
 .
 
@@ -3704,12 +4409,18 @@ SymbolicName=ERROR_INTERRUPT_VECTOR_ALREADY_CONNECTED
 Language=English
 ERROR_INTERRUPT_VECTOR_ALREADY_CONNECTED - The specified interrupt vector was already connected.
 .
+Language=Russian
+ERROR_INTERRUPT_VECTOR_ALREADY_CONNECTED - The specified interrupt vector was already connected.
+.
 
 MessageId=764
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INTERRUPT_STILL_CONNECTED
 Language=English
+ERROR_INTERRUPT_STILL_CONNECTED - The specified interrupt vector is still connected.
+.
+Language=Russian
 ERROR_INTERRUPT_STILL_CONNECTED - The specified interrupt vector is still connected.
 .
 
@@ -3720,12 +4431,18 @@ SymbolicName=ERROR_WAIT_FOR_OPLOCK
 Language=English
 ERROR_WAIT_FOR_OPLOCK - An operation is blocked waiting for an oplock.
 .
+Language=Russian
+ERROR_WAIT_FOR_OPLOCK - An operation is blocked waiting for an oplock.
+.
 
 MessageId=766
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DBG_EXCEPTION_HANDLED
 Language=English
+ERROR_DBG_EXCEPTION_HANDLED - Debugger handled exception.
+.
+Language=Russian
 ERROR_DBG_EXCEPTION_HANDLED - Debugger handled exception.
 .
 
@@ -3736,12 +4453,18 @@ SymbolicName=ERROR_DBG_CONTINUE
 Language=English
 ERROR_DBG_CONTINUE - Debugger continued
 .
+Language=Russian
+ERROR_DBG_CONTINUE - Debugger continued
+.
 
 MessageId=768
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CALLBACK_POP_STACK
 Language=English
+ERROR_CALLBACK_POP_STACK - An exception occurred in a user mode callback and the kernel callback frame should be removed.
+.
+Language=Russian
 ERROR_CALLBACK_POP_STACK - An exception occurred in a user mode callback and the kernel callback frame should be removed.
 .
 
@@ -3752,12 +4475,18 @@ SymbolicName=ERROR_COMPRESSION_DISABLED
 Language=English
 ERROR_COMPRESSION_DISABLED - Compression is disabled for this volume.
 .
+Language=Russian
+ERROR_COMPRESSION_DISABLED - Compression is disabled for this volume.
+.
 
 MessageId=770
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANTFETCHBACKWARDS
 Language=English
+ERROR_CANTFETCHBACKWARDS - The data provider cannot fetch backwards through a result set.
+.
+Language=Russian
 ERROR_CANTFETCHBACKWARDS - The data provider cannot fetch backwards through a result set.
 .
 
@@ -3768,12 +4497,18 @@ SymbolicName=ERROR_CANTSCROLLBACKWARDS
 Language=English
 ERROR_CANTSCROLLBACKWARDS - The data provider cannot scroll backwards through a result set.
 .
+Language=Russian
+ERROR_CANTSCROLLBACKWARDS - The data provider cannot scroll backwards through a result set.
+.
 
 MessageId=772
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ROWSNOTRELEASED
 Language=English
+ERROR_ROWSNOTRELEASED - The data provider requires that previously fetched data is released before asking for more data.
+.
+Language=Russian
 ERROR_ROWSNOTRELEASED - The data provider requires that previously fetched data is released before asking for more data.
 .
 
@@ -3784,12 +4519,18 @@ SymbolicName=ERROR_BAD_ACCESSOR_FLAGS
 Language=English
 ERROR_BAD_ACCESSOR_FLAGS - The data provider was not able to interpret the flags set for a column binding in an accessor.
 .
+Language=Russian
+ERROR_BAD_ACCESSOR_FLAGS - The data provider was not able to interpret the flags set for a column binding in an accessor.
+.
 
 MessageId=774
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ERRORS_ENCOUNTERED
 Language=English
+ERROR_ERRORS_ENCOUNTERED - One or more errors occurred while processing the request.
+.
+Language=Russian
 ERROR_ERRORS_ENCOUNTERED - One or more errors occurred while processing the request.
 .
 
@@ -3800,12 +4541,18 @@ SymbolicName=ERROR_NOT_CAPABLE
 Language=English
 ERROR_NOT_CAPABLE - The implementation is not capable of performing the request.
 .
+Language=Russian
+ERROR_NOT_CAPABLE - The implementation is not capable of performing the request.
+.
 
 MessageId=776
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REQUEST_OUT_OF_SEQUENCE
 Language=English
+ERROR_REQUEST_OUT_OF_SEQUENCE - The client of a component requested an operation which is not valid given the state of the component instance.
+.
+Language=Russian
 ERROR_REQUEST_OUT_OF_SEQUENCE - The client of a component requested an operation which is not valid given the state of the component instance.
 .
 
@@ -3816,12 +4563,18 @@ SymbolicName=ERROR_VERSION_PARSE_ERROR
 Language=English
 ERROR_VERSION_PARSE_ERROR - A version number could not be parsed.
 .
+Language=Russian
+ERROR_VERSION_PARSE_ERROR - A version number could not be parsed.
+.
 
 MessageId=778
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BADSTARTPOSITION
 Language=English
+ERROR_BADSTARTPOSITION - The iterator's start position is invalid.
+.
+Language=Russian
 ERROR_BADSTARTPOSITION - The iterator's start position is invalid.
 .
 
@@ -3832,12 +4585,18 @@ SymbolicName=ERROR_EA_ACCESS_DENIED
 Language=English
 ERROR_EA_ACCESS_DENIED - Access to the extended attribute was denied.
 .
+Language=Russian
+ERROR_EA_ACCESS_DENIED - Access to the extended attribute was denied.
+.
 
 MessageId=995
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OPERATION_ABORTED
 Language=English
+ERROR_OPERATION_ABORTED - The I/O operation has been aborted because of either a thread exit or an application request.
+.
+Language=Russian
 ERROR_OPERATION_ABORTED - The I/O operation has been aborted because of either a thread exit or an application request.
 .
 
@@ -3848,12 +4607,18 @@ SymbolicName=ERROR_IO_INCOMPLETE
 Language=English
 ERROR_IO_INCOMPLETE - Overlapped I/O event is not in a signaled state.
 .
+Language=Russian
+ERROR_IO_INCOMPLETE - Overlapped I/O event is not in a signaled state.
+.
 
 MessageId=997
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IO_PENDING
 Language=English
+ERROR_IO_PENDING - Overlapped I/O operation is in progress.
+.
+Language=Russian
 ERROR_IO_PENDING - Overlapped I/O operation is in progress.
 .
 
@@ -3864,12 +4629,18 @@ SymbolicName=ERROR_NOACCESS
 Language=English
 ERROR_NOACCESS - Invalid access to memory location.
 .
+Language=Russian
+ERROR_NOACCESS - Invalid access to memory location.
+.
 
 MessageId=999
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SWAPERROR
 Language=English
+ERROR_SWAPERROR - Error performing inpage operation.
+.
+Language=Russian
 ERROR_SWAPERROR - Error performing inpage operation.
 .
 
@@ -3880,12 +4651,18 @@ SymbolicName=ERROR_STACK_OVERFLOW
 Language=English
 ERROR_STACK_OVERFLOW - Recursion too deep; the stack overflowed.
 .
+Language=Russian
+ERROR_STACK_OVERFLOW - Recursion too deep; the stack overflowed.
+.
 
 MessageId=1002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_MESSAGE
 Language=English
+ERROR_INVALID_MESSAGE - The window cannot act on the sent message.
+.
+Language=Russian
 ERROR_INVALID_MESSAGE - The window cannot act on the sent message.
 .
 
@@ -3896,12 +4673,18 @@ SymbolicName=ERROR_CAN_NOT_COMPLETE
 Language=English
 ERROR_CAN_NOT_COMPLETE - Cannot complete this function.
 .
+Language=Russian
+ERROR_CAN_NOT_COMPLETE - Cannot complete this function.
+.
 
 MessageId=1004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_FLAGS
 Language=English
+ERROR_INVALID_FLAGS - Invalid flags.
+.
+Language=Russian
 ERROR_INVALID_FLAGS - Invalid flags.
 .
 
@@ -3912,12 +4695,18 @@ SymbolicName=ERROR_UNRECOGNIZED_VOLUME
 Language=English
 ERROR_UNRECOGNIZED_VOLUME - The volume does not contain a recognized file system. Please make sure that all required file system drivers are loaded and that the volume is not corrupted.
 .
+Language=Russian
+ERROR_UNRECOGNIZED_VOLUME - The volume does not contain a recognized file system. Please make sure that all required file system drivers are loaded and that the volume is not corrupted.
+.
 
 MessageId=1006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FILE_INVALID
 Language=English
+ERROR_FILE_INVALID - The volume for a file has been externally altered so that the opened file is no longer valid.
+.
+Language=Russian
 ERROR_FILE_INVALID - The volume for a file has been externally altered so that the opened file is no longer valid.
 .
 
@@ -3928,12 +4717,18 @@ SymbolicName=ERROR_FULLSCREEN_MODE
 Language=English
 ERROR_FULLSCREEN_MODE - The requested operation cannot be performed in full-screen mode.
 .
+Language=Russian
+ERROR_FULLSCREEN_MODE - The requested operation cannot be performed in full-screen mode.
+.
 
 MessageId=1008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_TOKEN
 Language=English
+ERROR_NO_TOKEN - An attempt was made to reference a token that does not exist.
+.
+Language=Russian
 ERROR_NO_TOKEN - An attempt was made to reference a token that does not exist.
 .
 
@@ -3944,12 +4739,18 @@ SymbolicName=ERROR_BADDB
 Language=English
 ERROR_BADDB - The configuration registry database is corrupt.
 .
+Language=Russian
+ERROR_BADDB - The configuration registry database is corrupt.
+.
 
 MessageId=1010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BADKEY
 Language=English
+ERROR_BADKEY - The configuration registry key is invalid.
+.
+Language=Russian
 ERROR_BADKEY - The configuration registry key is invalid.
 .
 
@@ -3960,12 +4761,18 @@ SymbolicName=ERROR_CANTOPEN
 Language=English
 ERROR_CANTOPEN - The configuration registry key could not be opened.
 .
+Language=Russian
+ERROR_CANTOPEN - The configuration registry key could not be opened.
+.
 
 MessageId=1012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANTREAD
 Language=English
+ERROR_CANTREAD - The configuration registry key could not be read.
+.
+Language=Russian
 ERROR_CANTREAD - The configuration registry key could not be read.
 .
 
@@ -3976,12 +4783,18 @@ SymbolicName=ERROR_CANTWRITE
 Language=English
 ERROR_CANTWRITE - The configuration registry key could not be written.
 .
+Language=Russian
+ERROR_CANTWRITE - The configuration registry key could not be written.
+.
 
 MessageId=1014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REGISTRY_RECOVERED
 Language=English
+ERROR_REGISTRY_RECOVERED - One of the files in the registry database had to be recovered by use of a log or alternate copy. The recovery was successful.
+.
+Language=Russian
 ERROR_REGISTRY_RECOVERED - One of the files in the registry database had to be recovered by use of a log or alternate copy. The recovery was successful.
 .
 
@@ -3992,12 +4805,18 @@ SymbolicName=ERROR_REGISTRY_CORRUPT
 Language=English
 ERROR_REGISTRY_CORRUPT - The registry is corrupted. The structure of one of the files containing registry data is corrupted, or the system's memory image of the file is corrupted, or the file could not be recovered because the alternate copy or log was absent or corrupted.
 .
+Language=Russian
+ERROR_REGISTRY_CORRUPT - The registry is corrupted. The structure of one of the files containing registry data is corrupted, or the system's memory image of the file is corrupted, or the file could not be recovered because the alternate copy or log was absent or corrupted.
+.
 
 MessageId=1016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REGISTRY_IO_FAILED
 Language=English
+ERROR_REGISTRY_IO_FAILED - An I/O operation initiated by the registry failed unrecoverably. The registry could not read in, or write out, or flush, one of the files that contain the system's image of the registry.
+.
+Language=Russian
 ERROR_REGISTRY_IO_FAILED - An I/O operation initiated by the registry failed unrecoverably. The registry could not read in, or write out, or flush, one of the files that contain the system's image of the registry.
 .
 
@@ -4008,12 +4827,18 @@ SymbolicName=ERROR_NOT_REGISTRY_FILE
 Language=English
 ERROR_NOT_REGISTRY_FILE - The system has attempted to load or restore a file into the registry, but the specified file is not in a registry file format.
 .
+Language=Russian
+ERROR_NOT_REGISTRY_FILE - The system has attempted to load or restore a file into the registry, but the specified file is not in a registry file format.
+.
 
 MessageId=1018
 Severity=Success
 Facility=System
 SymbolicName=ERROR_KEY_DELETED
 Language=English
+ERROR_KEY_DELETED - Illegal operation attempted on a registry key that has been marked for deletion.
+.
+Language=Russian
 ERROR_KEY_DELETED - Illegal operation attempted on a registry key that has been marked for deletion.
 .
 
@@ -4024,12 +4849,18 @@ SymbolicName=ERROR_NO_LOG_SPACE
 Language=English
 ERROR_NO_LOG_SPACE - System could not allocate the required space in a registry log.
 .
+Language=Russian
+ERROR_NO_LOG_SPACE - System could not allocate the required space in a registry log.
+.
 
 MessageId=1020
 Severity=Success
 Facility=System
 SymbolicName=ERROR_KEY_HAS_CHILDREN
 Language=English
+ERROR_KEY_HAS_CHILDREN - Cannot create a symbolic link in a registry key that already has subkeys or values.
+.
+Language=Russian
 ERROR_KEY_HAS_CHILDREN - Cannot create a symbolic link in a registry key that already has subkeys or values.
 .
 
@@ -4040,12 +4871,18 @@ SymbolicName=ERROR_CHILD_MUST_BE_VOLATILE
 Language=English
 ERROR_CHILD_MUST_BE_VOLATILE - Cannot create a stable subkey under a volatile parent key.
 .
+Language=Russian
+ERROR_CHILD_MUST_BE_VOLATILE - Cannot create a stable subkey under a volatile parent key.
+.
 
 MessageId=1022
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOTIFY_ENUM_DIR
 Language=English
+ERROR_NOTIFY_ENUM_DIR - A notify change request is being completed and the information is not being returned in the caller's buffer. The caller now needs to enumerate the files to find the changes.
+.
+Language=Russian
 ERROR_NOTIFY_ENUM_DIR - A notify change request is being completed and the information is not being returned in the caller's buffer. The caller now needs to enumerate the files to find the changes.
 .
 
@@ -4056,12 +4893,18 @@ SymbolicName=ERROR_DEPENDENT_SERVICES_RUNNING
 Language=English
 ERROR_DEPENDENT_SERVICES_RUNNING - A stop control has been sent to a service that other running services are dependent on.
 .
+Language=Russian
+ERROR_DEPENDENT_SERVICES_RUNNING - A stop control has been sent to a service that other running services are dependent on.
+.
 
 MessageId=1052
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_SERVICE_CONTROL
 Language=English
+ERROR_INVALID_SERVICE_CONTROL - The requested control is not valid for this service.
+.
+Language=Russian
 ERROR_INVALID_SERVICE_CONTROL - The requested control is not valid for this service.
 .
 
@@ -4072,12 +4915,18 @@ SymbolicName=ERROR_SERVICE_REQUEST_TIMEOUT
 Language=English
 ERROR_SERVICE_REQUEST_TIMEOUT - The service did not respond to the start or control request in a timely fashion.
 .
+Language=Russian
+ERROR_SERVICE_REQUEST_TIMEOUT - The service did not respond to the start or control request in a timely fashion.
+.
 
 MessageId=1054
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_NO_THREAD
 Language=English
+ERROR_SERVICE_NO_THREAD - A thread could not be created for the service.
+.
+Language=Russian
 ERROR_SERVICE_NO_THREAD - A thread could not be created for the service.
 .
 
@@ -4088,12 +4937,18 @@ SymbolicName=ERROR_SERVICE_DATABASE_LOCKED
 Language=English
 ERROR_SERVICE_DATABASE_LOCKED - The service database is locked.
 .
+Language=Russian
+ERROR_SERVICE_DATABASE_LOCKED - The service database is locked.
+.
 
 MessageId=1056
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_ALREADY_RUNNING
 Language=English
+ERROR_SERVICE_ALREADY_RUNNING - An instance of the service is already running.
+.
+Language=Russian
 ERROR_SERVICE_ALREADY_RUNNING - An instance of the service is already running.
 .
 
@@ -4104,12 +4959,18 @@ SymbolicName=ERROR_INVALID_SERVICE_ACCOUNT
 Language=English
 ERROR_INVALID_SERVICE_ACCOUNT - The account name is invalid or does not exist, or the password is invalid for the account name specified.
 .
+Language=Russian
+ERROR_INVALID_SERVICE_ACCOUNT - The account name is invalid or does not exist, or the password is invalid for the account name specified.
+.
 
 MessageId=1058
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_DISABLED
 Language=English
+ERROR_SERVICE_DISABLED - The service cannot be started, either because it is disabled or because it has no enabled devices associated with it.
+.
+Language=Russian
 ERROR_SERVICE_DISABLED - The service cannot be started, either because it is disabled or because it has no enabled devices associated with it.
 .
 
@@ -4120,12 +4981,18 @@ SymbolicName=ERROR_CIRCULAR_DEPENDENCY
 Language=English
 ERROR_CIRCULAR_DEPENDENCY - Circular service dependency was specified.
 .
+Language=Russian
+ERROR_CIRCULAR_DEPENDENCY - Circular service dependency was specified.
+.
 
 MessageId=1060
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_DOES_NOT_EXIST
 Language=English
+ERROR_SERVICE_DOES_NOT_EXIST - The specified service does not exist as an installed service.
+.
+Language=Russian
 ERROR_SERVICE_DOES_NOT_EXIST - The specified service does not exist as an installed service.
 .
 
@@ -4136,12 +5003,18 @@ SymbolicName=ERROR_SERVICE_CANNOT_ACCEPT_CTRL
 Language=English
 ERROR_SERVICE_CANNOT_ACCEPT_CTRL - The service cannot accept control messages at this time.
 .
+Language=Russian
+ERROR_SERVICE_CANNOT_ACCEPT_CTRL - The service cannot accept control messages at this time.
+.
 
 MessageId=1062
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_NOT_ACTIVE
 Language=English
+ERROR_SERVICE_NOT_ACTIVE - The service has not been started.
+.
+Language=Russian
 ERROR_SERVICE_NOT_ACTIVE - The service has not been started.
 .
 
@@ -4152,12 +5025,18 @@ SymbolicName=ERROR_FAILED_SERVICE_CONTROLLER_CONNECT
 Language=English
 ERROR_FAILED_SERVICE_CONTROLLER_CONNECT - The service process could not connect to the service controller.
 .
+Language=Russian
+ERROR_FAILED_SERVICE_CONTROLLER_CONNECT - The service process could not connect to the service controller.
+.
 
 MessageId=1064
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EXCEPTION_IN_SERVICE
 Language=English
+ERROR_EXCEPTION_IN_SERVICE - An exception occurred in the service when handling the control request.
+.
+Language=Russian
 ERROR_EXCEPTION_IN_SERVICE - An exception occurred in the service when handling the control request.
 .
 
@@ -4168,12 +5047,18 @@ SymbolicName=ERROR_DATABASE_DOES_NOT_EXIST
 Language=English
 ERROR_DATABASE_DOES_NOT_EXIST - The database specified does not exist.
 .
+Language=Russian
+ERROR_DATABASE_DOES_NOT_EXIST - The database specified does not exist.
+.
 
 MessageId=1066
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_SPECIFIC_ERROR
 Language=English
+ERROR_SERVICE_SPECIFIC_ERROR - The service has returned a service-specific error code.
+.
+Language=Russian
 ERROR_SERVICE_SPECIFIC_ERROR - The service has returned a service-specific error code.
 .
 
@@ -4184,12 +5069,18 @@ SymbolicName=ERROR_PROCESS_ABORTED
 Language=English
 ERROR_PROCESS_ABORTED - The process terminated unexpectedly.
 .
+Language=Russian
+ERROR_PROCESS_ABORTED - The process terminated unexpectedly.
+.
 
 MessageId=1068
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_DEPENDENCY_FAIL
 Language=English
+ERROR_SERVICE_DEPENDENCY_FAIL - The dependency service or group failed to start.
+.
+Language=Russian
 ERROR_SERVICE_DEPENDENCY_FAIL - The dependency service or group failed to start.
 .
 
@@ -4200,12 +5091,18 @@ SymbolicName=ERROR_SERVICE_LOGON_FAILED
 Language=English
 ERROR_SERVICE_LOGON_FAILED - The service did not start due to a logon failure.
 .
+Language=Russian
+ERROR_SERVICE_LOGON_FAILED - The service did not start due to a logon failure.
+.
 
 MessageId=1070
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_START_HANG
 Language=English
+ERROR_SERVICE_START_HANG - After starting, the service hung in a start-pending state.
+.
+Language=Russian
 ERROR_SERVICE_START_HANG - After starting, the service hung in a start-pending state.
 .
 
@@ -4216,12 +5113,18 @@ SymbolicName=ERROR_INVALID_SERVICE_LOCK
 Language=English
 ERROR_INVALID_SERVICE_LOCK - The specified service database lock is invalid.
 .
+Language=Russian
+ERROR_INVALID_SERVICE_LOCK - The specified service database lock is invalid.
+.
 
 MessageId=1072
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SERVICE_MARKED_FOR_DELETE
 Language=English
+ERROR_SERVICE_MARKED_FOR_DELETE - The specified service has been marked for deletion.
+.
+Language=Russian
 ERROR_SERVICE_MARKED_FOR_DELETE - The specified service has been marked for deletion.
 .
 
@@ -4232,12 +5135,18 @@ SymbolicName=ERROR_SERVICE_EXISTS
 Language=English
 ERROR_SERVICE_EXISTS - The specified service already exists.
 .
+Language=Russian
+ERROR_SERVICE_EXISTS - The specified service already exists.
+.
 
 MessageId=1074
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ALREADY_RUNNING_LKG
 Language=English
+ERROR_ALREADY_RUNNING_LKG - The system is currently running with the last-known-good configuration.
+.
+Language=Russian
 ERROR_ALREADY_RUNNING_LKG - The system is currently running with the last-known-good configuration.
 .
 
@@ -4248,12 +5157,18 @@ SymbolicName=ERROR_SERVICE_DEPENDENCY_DELETED
 Language=English
 ERROR_SERVICE_DEPENDENCY_DELETED - The dependency service does not exist or has been marked for deletion.
 .
+Language=Russian
+ERROR_SERVICE_DEPENDENCY_DELETED - The dependency service does not exist or has been marked for deletion.
+.
 
 MessageId=1076
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BOOT_ALREADY_ACCEPTED
 Language=English
+ERROR_BOOT_ALREADY_ACCEPTED - The current boot has already been accepted for use as the last-known-good control set.
+.
+Language=Russian
 ERROR_BOOT_ALREADY_ACCEPTED - The current boot has already been accepted for use as the last-known-good control set.
 .
 
@@ -4264,12 +5179,18 @@ SymbolicName=ERROR_SERVICE_NEVER_STARTED
 Language=English
 ERROR_SERVICE_NEVER_STARTED - No attempts to start the service have been made since the last boot.
 .
+Language=Russian
+ERROR_SERVICE_NEVER_STARTED - No attempts to start the service have been made since the last boot.
+.
 
 MessageId=1078
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DUPLICATE_SERVICE_NAME
 Language=English
+ERROR_DUPLICATE_SERVICE_NAME - The name is already in use as either a service name or a service display name.
+.
+Language=Russian
 ERROR_DUPLICATE_SERVICE_NAME - The name is already in use as either a service name or a service display name.
 .
 
@@ -4280,12 +5201,18 @@ SymbolicName=ERROR_DIFFERENT_SERVICE_ACCOUNT
 Language=English
 ERROR_DIFFERENT_SERVICE_ACCOUNT - The account specified for this service is different from the account specified for other services running in the same process.
 .
+Language=Russian
+ERROR_DIFFERENT_SERVICE_ACCOUNT - The account specified for this service is different from the account specified for other services running in the same process.
+.
 
 MessageId=1080
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANNOT_DETECT_DRIVER_FAILURE
 Language=English
+ERROR_CANNOT_DETECT_DRIVER_FAILURE - Failure actions can only be set for Win32 services, not for drivers.
+.
+Language=Russian
 ERROR_CANNOT_DETECT_DRIVER_FAILURE - Failure actions can only be set for Win32 services, not for drivers.
 .
 
@@ -4296,12 +5223,18 @@ SymbolicName=ERROR_CANNOT_DETECT_PROCESS_ABORT
 Language=English
 ERROR_CANNOT_DETECT_PROCESS_ABORT - This service runs in the same process as the service control manager. Therefore, the service control manager cannot take action if this service's process terminates unexpectedly.
 .
+Language=Russian
+ERROR_CANNOT_DETECT_PROCESS_ABORT - This service runs in the same process as the service control manager. Therefore, the service control manager cannot take action if this service's process terminates unexpectedly.
+.
 
 MessageId=1082
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_RECOVERY_PROGRAM
 Language=English
+ERROR_NO_RECOVERY_PROGRAM - No recovery program has been configured for this service.
+.
+Language=Russian
 ERROR_NO_RECOVERY_PROGRAM - No recovery program has been configured for this service.
 .
 
@@ -4312,12 +5245,18 @@ SymbolicName=ERROR_SERVICE_NOT_IN_EXE
 Language=English
 ERROR_SERVICE_NOT_IN_EXE - The executable program that this service is configured to run in does not implement the service.
 .
+Language=Russian
+ERROR_SERVICE_NOT_IN_EXE - The executable program that this service is configured to run in does not implement the service.
+.
 
 MessageId=1084
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_SAFEBOOT_SERVICE
 Language=English
+ERROR_NOT_SAFEBOOT_SERVICE - This service cannot be started in Safe Mode.
+.
+Language=Russian
 ERROR_NOT_SAFEBOOT_SERVICE - This service cannot be started in Safe Mode.
 .
 
@@ -4328,12 +5267,18 @@ SymbolicName=ERROR_END_OF_MEDIA
 Language=English
 ERROR_END_OF_MEDIA - The physical end of the tape has been reached.
 .
+Language=Russian
+ERROR_END_OF_MEDIA - The physical end of the tape has been reached.
+.
 
 MessageId=1101
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FILEMARK_DETECTED
 Language=English
+ERROR_FILEMARK_DETECTED - A tape access reached a filemark.
+.
+Language=Russian
 ERROR_FILEMARK_DETECTED - A tape access reached a filemark.
 .
 
@@ -4344,12 +5289,18 @@ SymbolicName=ERROR_BEGINNING_OF_MEDIA
 Language=English
 ERROR_BEGINNING_OF_MEDIA - The beginning of the tape or a partition was encountered.
 .
+Language=Russian
+ERROR_BEGINNING_OF_MEDIA - The beginning of the tape or a partition was encountered.
+.
 
 MessageId=1103
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SETMARK_DETECTED
 Language=English
+ERROR_SETMARK_DETECTED - A tape access reached the end of a set of files.
+.
+Language=Russian
 ERROR_SETMARK_DETECTED - A tape access reached the end of a set of files.
 .
 
@@ -4360,12 +5311,18 @@ SymbolicName=ERROR_NO_DATA_DETECTED
 Language=English
 ERROR_NO_DATA_DETECTED - No more data is on the tape.
 .
+Language=Russian
+ERROR_NO_DATA_DETECTED - No more data is on the tape.
+.
 
 MessageId=1105
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PARTITION_FAILURE
 Language=English
+ERROR_PARTITION_FAILURE - Tape could not be partitioned.
+.
+Language=Russian
 ERROR_PARTITION_FAILURE - Tape could not be partitioned.
 .
 
@@ -4376,12 +5333,18 @@ SymbolicName=ERROR_INVALID_BLOCK_LENGTH
 Language=English
 ERROR_INVALID_BLOCK_LENGTH - When accessing a new tape of a multivolume partition, the current block size is incorrect.
 .
+Language=Russian
+ERROR_INVALID_BLOCK_LENGTH - When accessing a new tape of a multivolume partition, the current block size is incorrect.
+.
 
 MessageId=1107
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DEVICE_NOT_PARTITIONED
 Language=English
+ERROR_DEVICE_NOT_PARTITIONED - Tape partition information could not be found when loading a tape.
+.
+Language=Russian
 ERROR_DEVICE_NOT_PARTITIONED - Tape partition information could not be found when loading a tape.
 .
 
@@ -4392,12 +5355,18 @@ SymbolicName=ERROR_UNABLE_TO_LOCK_MEDIA
 Language=English
 ERROR_UNABLE_TO_LOCK_MEDIA - Unable to lock the media eject mechanism.
 .
+Language=Russian
+ERROR_UNABLE_TO_LOCK_MEDIA - Unable to lock the media eject mechanism.
+.
 
 MessageId=1109
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNABLE_TO_UNLOAD_MEDIA
 Language=English
+ERROR_UNABLE_TO_UNLOAD_MEDIA - Unable to unload the media.
+.
+Language=Russian
 ERROR_UNABLE_TO_UNLOAD_MEDIA - Unable to unload the media.
 .
 
@@ -4408,12 +5377,18 @@ SymbolicName=ERROR_MEDIA_CHANGED
 Language=English
 ERROR_MEDIA_CHANGED - The media in the drive may have changed.
 .
+Language=Russian
+ERROR_MEDIA_CHANGED - The media in the drive may have changed.
+.
 
 MessageId=1111
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BUS_RESET
 Language=English
+ERROR_BUS_RESET - The I/O bus was reset.
+.
+Language=Russian
 ERROR_BUS_RESET - The I/O bus was reset.
 .
 
@@ -4424,12 +5399,18 @@ SymbolicName=ERROR_NO_MEDIA_IN_DRIVE
 Language=English
 ERROR_NO_MEDIA_IN_DRIVE - No media in drive.
 .
+Language=Russian
+ERROR_NO_MEDIA_IN_DRIVE - No media in drive.
+.
 
 MessageId=1113
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_UNICODE_TRANSLATION
 Language=English
+ERROR_NO_UNICODE_TRANSLATION - No mapping for the Unicode character exists in the target multi-byte code page.
+.
+Language=Russian
 ERROR_NO_UNICODE_TRANSLATION - No mapping for the Unicode character exists in the target multi-byte code page.
 .
 
@@ -4440,12 +5421,18 @@ SymbolicName=ERROR_DLL_INIT_FAILED
 Language=English
 ERROR_DLL_INIT_FAILED - A dynamic link library (DLL) initialization routine failed.
 .
+Language=Russian
+ERROR_DLL_INIT_FAILED - A dynamic link library (DLL) initialization routine failed.
+.
 
 MessageId=1115
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SHUTDOWN_IN_PROGRESS
 Language=English
+ERROR_SHUTDOWN_IN_PROGRESS - A system shutdown is in progress.
+.
+Language=Russian
 ERROR_SHUTDOWN_IN_PROGRESS - A system shutdown is in progress.
 .
 
@@ -4456,12 +5443,18 @@ SymbolicName=ERROR_NO_SHUTDOWN_IN_PROGRESS
 Language=English
 ERROR_NO_SHUTDOWN_IN_PROGRESS - Unable to abort the system shutdown because no shutdown was in progress.
 .
+Language=Russian
+ERROR_NO_SHUTDOWN_IN_PROGRESS - Unable to abort the system shutdown because no shutdown was in progress.
+.
 
 MessageId=1117
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IO_DEVICE
 Language=English
+ERROR_IO_DEVICE - The request could not be performed because of an I/O device error.
+.
+Language=Russian
 ERROR_IO_DEVICE - The request could not be performed because of an I/O device error.
 .
 
@@ -4472,12 +5465,18 @@ SymbolicName=ERROR_SERIAL_NO_DEVICE
 Language=English
 ERROR_SERIAL_NO_DEVICE - No serial device was successfully initialized. The serial driver will unload.
 .
+Language=Russian
+ERROR_SERIAL_NO_DEVICE - No serial device was successfully initialized. The serial driver will unload.
+.
 
 MessageId=1119
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IRQ_BUSY
 Language=English
+ERROR_IRQ_BUSY - Unable to open a device that was sharing an interrupt request (IRQ) with other devices. At least one other device that uses that IRQ was already opened.
+.
+Language=Russian
 ERROR_IRQ_BUSY - Unable to open a device that was sharing an interrupt request (IRQ) with other devices. At least one other device that uses that IRQ was already opened.
 .
 
@@ -4488,12 +5487,18 @@ SymbolicName=ERROR_MORE_WRITES
 Language=English
 ERROR_MORE_WRITES - A serial I/O operation was completed by another write to the serial port. (The IOCTL_SERIAL_XOFF_COUNTER reached zero.)
 .
+Language=Russian
+ERROR_MORE_WRITES - A serial I/O operation was completed by another write to the serial port. (The IOCTL_SERIAL_XOFF_COUNTER reached zero.)
+.
 
 MessageId=1121
 Severity=Success
 Facility=System
 SymbolicName=ERROR_COUNTER_TIMEOUT
 Language=English
+ERROR_COUNTER_TIMEOUT - A serial I/O operation completed because the timeout period expired. (The IOCTL_SERIAL_XOFF_COUNTER did not reach zero.)
+.
+Language=Russian
 ERROR_COUNTER_TIMEOUT - A serial I/O operation completed because the timeout period expired. (The IOCTL_SERIAL_XOFF_COUNTER did not reach zero.)
 .
 
@@ -4504,12 +5509,18 @@ SymbolicName=ERROR_FLOPPY_ID_MARK_NOT_FOUND
 Language=English
 ERROR_FLOPPY_ID_MARK_NOT_FOUND - No ID address mark was found on the floppy disk.
 .
+Language=Russian
+ERROR_FLOPPY_ID_MARK_NOT_FOUND - No ID address mark was found on the floppy disk.
+.
 
 MessageId=1123
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLOPPY_WRONG_CYLINDER
 Language=English
+ERROR_FLOPPY_WRONG_CYLINDER - Mismatch between the floppy disk sector ID field and the floppy disk controller track address.
+.
+Language=Russian
 ERROR_FLOPPY_WRONG_CYLINDER - Mismatch between the floppy disk sector ID field and the floppy disk controller track address.
 .
 
@@ -4520,12 +5531,18 @@ SymbolicName=ERROR_FLOPPY_UNKNOWN_ERROR
 Language=English
 ERROR_FLOPPY_UNKNOWN_ERROR - The floppy disk controller reported an error that is not recognized by the floppy disk driver.
 .
+Language=Russian
+ERROR_FLOPPY_UNKNOWN_ERROR - The floppy disk controller reported an error that is not recognized by the floppy disk driver.
+.
 
 MessageId=1125
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLOPPY_BAD_REGISTERS
 Language=English
+ERROR_FLOPPY_BAD_REGISTERS - The floppy disk controller returned inconsistent results in its registers.
+.
+Language=Russian
 ERROR_FLOPPY_BAD_REGISTERS - The floppy disk controller returned inconsistent results in its registers.
 .
 
@@ -4536,12 +5553,18 @@ SymbolicName=ERROR_DISK_RECALIBRATE_FAILED
 Language=English
 ERROR_DISK_RECALIBRATE_FAILED - While accessing the hard disk, a recalibrate operation failed, even after retries.
 .
+Language=Russian
+ERROR_DISK_RECALIBRATE_FAILED - While accessing the hard disk, a recalibrate operation failed, even after retries.
+.
 
 MessageId=1127
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DISK_OPERATION_FAILED
 Language=English
+ERROR_DISK_OPERATION_FAILED - While accessing the hard disk, a disk operation failed even after retries.
+.
+Language=Russian
 ERROR_DISK_OPERATION_FAILED - While accessing the hard disk, a disk operation failed even after retries.
 .
 
@@ -4552,12 +5575,18 @@ SymbolicName=ERROR_DISK_RESET_FAILED
 Language=English
 ERROR_DISK_RESET_FAILED - While accessing the hard disk, a disk controller reset was needed, but even that failed.
 .
+Language=Russian
+ERROR_DISK_RESET_FAILED - While accessing the hard disk, a disk controller reset was needed, but even that failed.
+.
 
 MessageId=1129
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EOM_OVERFLOW
 Language=English
+ERROR_EOM_OVERFLOW - Physical end of tape encountered.
+.
+Language=Russian
 ERROR_EOM_OVERFLOW - Physical end of tape encountered.
 .
 
@@ -4568,12 +5597,18 @@ SymbolicName=ERROR_NOT_ENOUGH_SERVER_MEMORY
 Language=English
 ERROR_NOT_ENOUGH_SERVER_MEMORY - Not enough server storage is available to process this command.
 .
+Language=Russian
+ERROR_NOT_ENOUGH_SERVER_MEMORY - Not enough server storage is available to process this command.
+.
 
 MessageId=1131
 Severity=Success
 Facility=System
 SymbolicName=ERROR_POSSIBLE_DEADLOCK
 Language=English
+ERROR_POSSIBLE_DEADLOCK - A potential deadlock condition has been detected.
+.
+Language=Russian
 ERROR_POSSIBLE_DEADLOCK - A potential deadlock condition has been detected.
 .
 
@@ -4584,12 +5619,18 @@ SymbolicName=ERROR_MAPPED_ALIGNMENT
 Language=English
 ERROR_MAPPED_ALIGNMENT - The base address or the file offset specified does not have the proper alignment.
 .
+Language=Russian
+ERROR_MAPPED_ALIGNMENT - The base address or the file offset specified does not have the proper alignment.
+.
 
 MessageId=1140
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SET_POWER_STATE_VETOED
 Language=English
+ERROR_SET_POWER_STATE_VETOED - An attempt to change the system power state was vetoed by another application or driver.
+.
+Language=Russian
 ERROR_SET_POWER_STATE_VETOED - An attempt to change the system power state was vetoed by another application or driver.
 .
 
@@ -4600,12 +5641,18 @@ SymbolicName=ERROR_SET_POWER_STATE_FAILED
 Language=English
 ERROR_SET_POWER_STATE_FAILED - The system BIOS failed an attempt to change the system power state.
 .
+Language=Russian
+ERROR_SET_POWER_STATE_FAILED - The system BIOS failed an attempt to change the system power state.
+.
 
 MessageId=1142
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TOO_MANY_LINKS
 Language=English
+ERROR_TOO_MANY_LINKS - An attempt was made to create more links on a file than the file system supports.
+.
+Language=Russian
 ERROR_TOO_MANY_LINKS - An attempt was made to create more links on a file than the file system supports.
 .
 
@@ -4616,12 +5663,18 @@ SymbolicName=ERROR_OLD_WIN_VERSION
 Language=English
 ERROR_OLD_WIN_VERSION - The specified program requires a newer version of Windows.
 .
+Language=Russian
+ERROR_OLD_WIN_VERSION - The specified program requires a newer version of Windows.
+.
 
 MessageId=1151
 Severity=Success
 Facility=System
 SymbolicName=ERROR_APP_WRONG_OS
 Language=English
+ERROR_APP_WRONG_OS - The specified program is not a Windows or MS-DOS program.
+.
+Language=Russian
 ERROR_APP_WRONG_OS - The specified program is not a Windows or MS-DOS program.
 .
 
@@ -4632,12 +5685,18 @@ SymbolicName=ERROR_SINGLE_INSTANCE_APP
 Language=English
 ERROR_SINGLE_INSTANCE_APP - Cannot start more than one instance of the specified program.
 .
+Language=Russian
+ERROR_SINGLE_INSTANCE_APP - Cannot start more than one instance of the specified program.
+.
 
 MessageId=1153
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RMODE_APP
 Language=English
+ERROR_RMODE_APP - The specified program was written for an earlier version of Windows.
+.
+Language=Russian
 ERROR_RMODE_APP - The specified program was written for an earlier version of Windows.
 .
 
@@ -4648,12 +5707,18 @@ SymbolicName=ERROR_INVALID_DLL
 Language=English
 ERROR_INVALID_DLL - One of the library files needed to run this application is damaged.
 .
+Language=Russian
+ERROR_INVALID_DLL - One of the library files needed to run this application is damaged.
+.
 
 MessageId=1155
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_ASSOCIATION
 Language=English
+ERROR_NO_ASSOCIATION - No application is associated with the specified file for this operation.
+.
+Language=Russian
 ERROR_NO_ASSOCIATION - No application is associated with the specified file for this operation.
 .
 
@@ -5665,12 +6730,18 @@ SymbolicName=SEC_E_SMARTCARD_CERT_REVOKED
 Language=English
 SEC_E_SMARTCARD_CERT_REVOKED - The smartcard certificate used for authentication has been revoked. Please contact your system administrator. There may be additional information in the event log.
 .
+Language=Russian
+SEC_E_SMARTCARD_CERT_REVOKED - The smartcard certificate used for authentication has been revoked. Please contact your system administrator. There may be additional information in the event log.
+.
 
 MessageId=1267
 Severity=Success
 Facility=System
 SymbolicName=SEC_E_ISSUING_CA_UNTRUSTED
 Language=English
+SEC_E_ISSUING_CA_UNTRUSTED - An untrusted certificate authority was detected while processing the smartcard certificate used for authentication. Please contact your system administrator.
+.
+Language=Russian
 SEC_E_ISSUING_CA_UNTRUSTED - An untrusted certificate authority was detected while processing the smartcard certificate used for authentication. Please contact your system administrator.
 .
 
@@ -5681,6 +6752,9 @@ SymbolicName=SEC_E_REVOCATION_OFFLINE_C
 Language=English
 SEC_E_REVOCATION_OFFLINE_C - The revocation status of the smartcard certificate used for authentication could not be determined. Please contact your system administrator.
 .
+Language=Russian
+SEC_E_REVOCATION_OFFLINE_C - The revocation status of the smartcard certificate used for authentication could not be determined. Please contact your system administrator.
+.
 
 MessageId=1269
 Severity=Success
@@ -5689,12 +6763,18 @@ SymbolicName=SEC_E_PKINIT_CLIENT_FAILUR
 Language=English
 SEC_E_PKINIT_CLIENT_FAILUR - The smartcard certificate used for authentication was not trusted. Please contact your system administrator.
 .
+Language=Russian
+SEC_E_PKINIT_CLIENT_FAILUR - The smartcard certificate used for authentication was not trusted. Please contact your system administrator.
+.
 
 MessageId=1270
 Severity=Success
 Facility=System
 SymbolicName=SEC_E_SMARTCARD_CERT_EXPIRED
 Language=English
+SEC_E_SMARTCARD_CERT_EXPIRED - The smartcard certificate used for authentication has expired. Please contact your system administrator.
+.
+Language=Russian
 SEC_E_SMARTCARD_CERT_EXPIRED - The smartcard certificate used for authentication has expired. Please contact your system administrator.
 .
 
@@ -7223,12 +8303,18 @@ SymbolicName=ERROR_CLASS_HAS_WINDOWS
 Language=English
 ERROR_CLASS_HAS_WINDOWS - Class still has open windows.
 .
+Language=Russian
+ERROR_CLASS_HAS_WINDOWS - Class still has open windows.
+.
 
 MessageId=1413
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_INDEX
 Language=English
+ERROR_INVALID_INDEX - Invalid index.
+.
+Language=Russian
 ERROR_INVALID_INDEX - Invalid index.
 .
 
@@ -7239,12 +8325,18 @@ SymbolicName=ERROR_INVALID_ICON_HANDLE
 Language=English
 ERROR_INVALID_ICON_HANDLE - Invalid icon handle.
 .
+Language=Russian
+ERROR_INVALID_ICON_HANDLE - Invalid icon handle.
+.
 
 MessageId=1415
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRIVATE_DIALOG_INDEX
 Language=English
+ERROR_PRIVATE_DIALOG_INDEX - Using private DIALOG window words.
+.
+Language=Russian
 ERROR_PRIVATE_DIALOG_INDEX - Using private DIALOG window words.
 .
 
@@ -7255,12 +8347,18 @@ SymbolicName=ERROR_LISTBOX_ID_NOT_FOUND
 Language=English
 ERROR_LISTBOX_ID_NOT_FOUND - The list box identifier was not found.
 .
+Language=Russian
+ERROR_LISTBOX_ID_NOT_FOUND - The list box identifier was not found.
+.
 
 MessageId=1417
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_WILDCARD_CHARACTERS
 Language=English
+ERROR_NO_WILDCARD_CHARACTERS - No wildcards were found.
+.
+Language=Russian
 ERROR_NO_WILDCARD_CHARACTERS - No wildcards were found.
 .
 
@@ -7271,12 +8369,18 @@ SymbolicName=ERROR_CLIPBOARD_NOT_OPEN
 Language=English
 ERROR_CLIPBOARD_NOT_OPEN - Thread does not have a clipboard open.
 .
+Language=Russian
+ERROR_CLIPBOARD_NOT_OPEN - Thread does not have a clipboard open.
+.
 
 MessageId=1419
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HOTKEY_NOT_REGISTERED
 Language=English
+ERROR_HOTKEY_NOT_REGISTERED - Hot key is not registered.
+.
+Language=Russian
 ERROR_HOTKEY_NOT_REGISTERED - Hot key is not registered.
 .
 
@@ -7287,12 +8391,18 @@ SymbolicName=ERROR_WINDOW_NOT_DIALOG
 Language=English
 ERROR_WINDOW_NOT_DIALOG - The window is not a valid dialog window.
 .
+Language=Russian
+ERROR_WINDOW_NOT_DIALOG - The window is not a valid dialog window.
+.
 
 MessageId=1421
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CONTROL_ID_NOT_FOUND
 Language=English
+ERROR_CONTROL_ID_NOT_FOUND - Control ID not found.
+.
+Language=Russian
 ERROR_CONTROL_ID_NOT_FOUND - Control ID not found.
 .
 
@@ -7303,12 +8413,18 @@ SymbolicName=ERROR_INVALID_COMBOBOX_MESSAGE
 Language=English
 ERROR_INVALID_COMBOBOX_MESSAGE - Invalid message for a combo box because it does not have an edit control.
 .
+Language=Russian
+ERROR_INVALID_COMBOBOX_MESSAGE - Invalid message for a combo box because it does not have an edit control.
+.
 
 MessageId=1423
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WINDOW_NOT_COMBOBOX
 Language=English
+ERROR_WINDOW_NOT_COMBOBOX - The window is not a combo box.
+.
+Language=Russian
 ERROR_WINDOW_NOT_COMBOBOX - The window is not a combo box.
 .
 
@@ -7319,12 +8435,18 @@ SymbolicName=ERROR_INVALID_EDIT_HEIGHT
 Language=English
 ERROR_INVALID_EDIT_HEIGHT - Height must be less than 256.
 .
+Language=Russian
+ERROR_INVALID_EDIT_HEIGHT - Height must be less than 256.
+.
 
 MessageId=1425
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DC_NOT_FOUND
 Language=English
+ERROR_DC_NOT_FOUND - Invalid device context (DC) handle.
+.
+Language=Russian
 ERROR_DC_NOT_FOUND - Invalid device context (DC) handle.
 .
 
@@ -7335,12 +8457,18 @@ SymbolicName=ERROR_INVALID_HOOK_FILTER
 Language=English
 ERROR_INVALID_HOOK_FILTER - Invalid hook procedure type.
 .
+Language=Russian
+ERROR_INVALID_HOOK_FILTER - Invalid hook procedure type.
+.
 
 MessageId=1427
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_FILTER_PROC
 Language=English
+ERROR_INVALID_FILTER_PROC - Invalid hook procedure.
+.
+Language=Russian
 ERROR_INVALID_FILTER_PROC - Invalid hook procedure.
 .
 
@@ -7351,12 +8479,18 @@ SymbolicName=ERROR_HOOK_NEEDS_HMOD
 Language=English
 ERROR_HOOK_NEEDS_HMOD - Cannot set nonlocal hook without a module handle.
 .
+Language=Russian
+ERROR_HOOK_NEEDS_HMOD - Cannot set nonlocal hook without a module handle.
+.
 
 MessageId=1429
 Severity=Success
 Facility=System
 SymbolicName=ERROR_GLOBAL_ONLY_HOOK
 Language=English
+ERROR_GLOBAL_ONLY_HOOK - This hook procedure can only be set globally.
+.
+Language=Russian
 ERROR_GLOBAL_ONLY_HOOK - This hook procedure can only be set globally.
 .
 
@@ -7367,12 +8501,18 @@ SymbolicName=ERROR_JOURNAL_HOOK_SET
 Language=English
 ERROR_JOURNAL_HOOK_SET - The journal hook procedure is already installed.
 .
+Language=Russian
+ERROR_JOURNAL_HOOK_SET - The journal hook procedure is already installed.
+.
 
 MessageId=1431
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HOOK_NOT_INSTALLED
 Language=English
+ERROR_HOOK_NOT_INSTALLED - The hook procedure is not installed.
+.
+Language=Russian
 ERROR_HOOK_NOT_INSTALLED - The hook procedure is not installed.
 .
 
@@ -7383,12 +8523,18 @@ SymbolicName=ERROR_INVALID_LB_MESSAGE
 Language=English
 ERROR_INVALID_LB_MESSAGE - Invalid message for single-selection list box.
 .
+Language=Russian
+ERROR_INVALID_LB_MESSAGE - Invalid message for single-selection list box.
+.
 
 MessageId=1433
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SETCOUNT_ON_BAD_LB
 Language=English
+ERROR_SETCOUNT_ON_BAD_LB - LB_SETCOUNT sent to non-lazy list box.
+.
+Language=Russian
 ERROR_SETCOUNT_ON_BAD_LB - LB_SETCOUNT sent to non-lazy list box.
 .
 
@@ -7399,12 +8545,18 @@ SymbolicName=ERROR_LB_WITHOUT_TABSTOPS
 Language=English
 ERROR_LB_WITHOUT_TABSTOPS - This list box does not support tab stops.
 .
+Language=Russian
+ERROR_LB_WITHOUT_TABSTOPS - This list box does not support tab stops.
+.
 
 MessageId=1435
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DESTROY_OBJECT_OF_OTHER_THREAD
 Language=English
+ERROR_DESTROY_OBJECT_OF_OTHER_THREAD - Cannot destroy object created by another thread.
+.
+Language=Russian
 ERROR_DESTROY_OBJECT_OF_OTHER_THREAD - Cannot destroy object created by another thread.
 .
 
@@ -7415,12 +8567,18 @@ SymbolicName=ERROR_CHILD_WINDOW_MENU
 Language=English
 ERROR_CHILD_WINDOW_MENU - Child windows cannot have menus.
 .
+Language=Russian
+ERROR_CHILD_WINDOW_MENU - Child windows cannot have menus.
+.
 
 MessageId=1437
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_SYSTEM_MENU
 Language=English
+ERROR_NO_SYSTEM_MENU - The window does not have a system menu.
+.
+Language=Russian
 ERROR_NO_SYSTEM_MENU - The window does not have a system menu.
 .
 
@@ -7431,12 +8589,18 @@ SymbolicName=ERROR_INVALID_MSGBOX_STYLE
 Language=English
 ERROR_INVALID_MSGBOX_STYLE - Invalid message box style.
 .
+Language=Russian
+ERROR_INVALID_MSGBOX_STYLE - Invalid message box style.
+.
 
 MessageId=1439
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_SPI_VALUE
 Language=English
+ERROR_INVALID_SPI_VALUE - Invalid system-wide (SPI_*) parameter.
+.
+Language=Russian
 ERROR_INVALID_SPI_VALUE - Invalid system-wide (SPI_*) parameter.
 .
 
@@ -7447,12 +8611,18 @@ SymbolicName=ERROR_SCREEN_ALREADY_LOCKED
 Language=English
 ERROR_SCREEN_ALREADY_LOCKED - Screen already locked.
 .
+Language=Russian
+ERROR_SCREEN_ALREADY_LOCKED - Screen already locked.
+.
 
 MessageId=1441
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HWNDS_HAVE_DIFF_PARENT
 Language=English
+ERROR_HWNDS_HAVE_DIFF_PARENT - All handles to windows in a multiple-window position structure must have the same parent.
+.
+Language=Russian
 ERROR_HWNDS_HAVE_DIFF_PARENT - All handles to windows in a multiple-window position structure must have the same parent.
 .
 
@@ -7463,12 +8633,18 @@ SymbolicName=ERROR_NOT_CHILD_WINDOW
 Language=English
 ERROR_NOT_CHILD_WINDOW - The window is not a child window.
 .
+Language=Russian
+ERROR_NOT_CHILD_WINDOW - The window is not a child window.
+.
 
 MessageId=1443
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_GW_COMMAND
 Language=English
+ERROR_INVALID_GW_COMMAND - Invalid GW_* command.
+.
+Language=Russian
 ERROR_INVALID_GW_COMMAND - Invalid GW_* command.
 .
 
@@ -7479,12 +8655,18 @@ SymbolicName=ERROR_INVALID_THREAD_ID
 Language=English
 ERROR_INVALID_THREAD_ID - Invalid thread identifier.
 .
+Language=Russian
+ERROR_INVALID_THREAD_ID - Invalid thread identifier.
+.
 
 MessageId=1445
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NON_MDICHILD_WINDOW
 Language=English
+ERROR_NON_MDICHILD_WINDOW - Cannot process a message from a window that is not a multiple document interface (MDI) window.
+.
+Language=Russian
 ERROR_NON_MDICHILD_WINDOW - Cannot process a message from a window that is not a multiple document interface (MDI) window.
 .
 
@@ -7495,12 +8677,18 @@ SymbolicName=ERROR_POPUP_ALREADY_ACTIVE
 Language=English
 ERROR_POPUP_ALREADY_ACTIVE - Popup menu already active.
 .
+Language=Russian
+ERROR_POPUP_ALREADY_ACTIVE - Popup menu already active.
+.
 
 MessageId=1447
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_SCROLLBARS
 Language=English
+ERROR_NO_SCROLLBARS - The window does not have scroll bars.
+.
+Language=Russian
 ERROR_NO_SCROLLBARS - The window does not have scroll bars.
 .
 
@@ -7511,12 +8699,18 @@ SymbolicName=ERROR_INVALID_SCROLLBAR_RANGE
 Language=English
 ERROR_INVALID_SCROLLBAR_RANGE - Scroll bar range cannot be greater than MAXLONG.
 .
+Language=Russian
+ERROR_INVALID_SCROLLBAR_RANGE - Scroll bar range cannot be greater than MAXLONG.
+.
 
 MessageId=1449
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_SHOWWIN_COMMAND
 Language=English
+ERROR_INVALID_SHOWWIN_COMMAND - Cannot show or remove the window in the way specified.
+.
+Language=Russian
 ERROR_INVALID_SHOWWIN_COMMAND - Cannot show or remove the window in the way specified.
 .
 
@@ -7527,12 +8721,18 @@ SymbolicName=ERROR_NO_SYSTEM_RESOURCES
 Language=English
 ERROR_NO_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
 .
+Language=Russian
+ERROR_NO_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
+.
 
 MessageId=1451
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NONPAGED_SYSTEM_RESOURCES
 Language=English
+ERROR_NONPAGED_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
+.
+Language=Russian
 ERROR_NONPAGED_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
 .
 
@@ -7543,12 +8743,18 @@ SymbolicName=ERROR_PAGED_SYSTEM_RESOURCES
 Language=English
 ERROR_PAGED_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
 .
+Language=Russian
+ERROR_PAGED_SYSTEM_RESOURCES - Insufficient system resources exist to complete the requested service.
+.
 
 MessageId=1453
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WORKING_SET_QUOTA
 Language=English
+ERROR_WORKING_SET_QUOTA - Insufficient quota to complete the requested service.
+.
+Language=Russian
 ERROR_WORKING_SET_QUOTA - Insufficient quota to complete the requested service.
 .
 
@@ -7559,12 +8765,18 @@ SymbolicName=ERROR_PAGEFILE_QUOTA
 Language=English
 ERROR_PAGEFILE_QUOTA - Insufficient quota to complete the requested service.
 .
+Language=Russian
+ERROR_PAGEFILE_QUOTA - Insufficient quota to complete the requested service.
+.
 
 MessageId=1455
 Severity=Success
 Facility=System
 SymbolicName=ERROR_COMMITMENT_LIMIT
 Language=English
+ERROR_COMMITMENT_LIMIT - The paging file is too small for this operation to complete.
+.
+Language=Russian
 ERROR_COMMITMENT_LIMIT - The paging file is too small for this operation to complete.
 .
 
@@ -7575,12 +8787,18 @@ SymbolicName=ERROR_MENU_ITEM_NOT_FOUND
 Language=English
 ERROR_MENU_ITEM_NOT_FOUND - A menu item was not found.
 .
+Language=Russian
+ERROR_MENU_ITEM_NOT_FOUND - A menu item was not found.
+.
 
 MessageId=1457
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_KEYBOARD_HANDLE
 Language=English
+ERROR_INVALID_KEYBOARD_HANDLE - Invalid keyboard layout handle.
+.
+Language=Russian
 ERROR_INVALID_KEYBOARD_HANDLE - Invalid keyboard layout handle.
 .
 
@@ -7591,12 +8809,18 @@ SymbolicName=ERROR_HOOK_TYPE_NOT_ALLOWED
 Language=English
 ERROR_HOOK_TYPE_NOT_ALLOWED - Hook type not allowed.
 .
+Language=Russian
+ERROR_HOOK_TYPE_NOT_ALLOWED - Hook type not allowed.
+.
 
 MessageId=1459
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REQUIRES_INTERACTIVE_WINDOWSTATION
 Language=English
+ERROR_REQUIRES_INTERACTIVE_WINDOWSTATION - This operation requires an interactive window station.
+.
+Language=Russian
 ERROR_REQUIRES_INTERACTIVE_WINDOWSTATION - This operation requires an interactive window station.
 .
 
@@ -7607,12 +8831,18 @@ SymbolicName=ERROR_TIMEOUT
 Language=English
 ERROR_TIMEOUT - This operation returned because the timeout period expired.
 .
+Language=Russian
+ERROR_TIMEOUT - This operation returned because the timeout period expired.
+.
 
 MessageId=1461
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_MONITOR_HANDLE
 Language=English
+ERROR_INVALID_MONITOR_HANDLE - Invalid monitor handle.
+.
+Language=Russian
 ERROR_INVALID_MONITOR_HANDLE - Invalid monitor handle.
 .
 
@@ -7623,12 +8853,18 @@ SymbolicName=ERROR_EVENTLOG_FILE_CORRUPT
 Language=English
 ERROR_EVENTLOG_FILE_CORRUPT - The event log file is corrupted.
 .
+Language=Russian
+ERROR_EVENTLOG_FILE_CORRUPT - The event log file is corrupted.
+.
 
 MessageId=1501
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVENTLOG_CANT_START
 Language=English
+ERROR_EVENTLOG_CANT_START - No event log file could be opened, so the event logging service did not start.
+.
+Language=Russian
 ERROR_EVENTLOG_CANT_START - No event log file could be opened, so the event logging service did not start.
 .
 
@@ -7639,12 +8875,18 @@ SymbolicName=ERROR_LOG_FILE_FULL
 Language=English
 ERROR_LOG_FILE_FULL - The event log file is full.
 .
+Language=Russian
+ERROR_LOG_FILE_FULL - The event log file is full.
+.
 
 MessageId=1503
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVENTLOG_FILE_CHANGED
 Language=English
+ERROR_EVENTLOG_FILE_CHANGED - The event log file has changed between read operations.
+.
+Language=Russian
 ERROR_EVENTLOG_FILE_CHANGED - The event log file has changed between read operations.
 .
 
@@ -7655,12 +8897,18 @@ SymbolicName=ERROR_INSTALL_SERVICE_FAILURE
 Language=English
 ERROR_INSTALL_SERVICE_FAILURE - The Windows Installer service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.
 .
+Language=Russian
+ERROR_INSTALL_SERVICE_FAILURE - The Windows Installer service could not be accessed. This can occur if you are running Windows in safe mode, or if the Windows Installer is not correctly installed. Contact your support personnel for assistance.
+.
 
 MessageId=1602
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_USEREXIT
 Language=English
+ERROR_INSTALL_USEREXIT - User cancelled installation.
+.
+Language=Russian
 ERROR_INSTALL_USEREXIT - User cancelled installation.
 .
 
@@ -7671,12 +8919,18 @@ SymbolicName=ERROR_INSTALL_FAILURE
 Language=English
 ERROR_INSTALL_FAILURE - Fatal error during installation.
 .
+Language=Russian
+ERROR_INSTALL_FAILURE - Fatal error during installation.
+.
 
 MessageId=1604
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_SUSPEND
 Language=English
+ERROR_INSTALL_SUSPEND - Installation suspended, incomplete.
+.
+Language=Russian
 ERROR_INSTALL_SUSPEND - Installation suspended, incomplete.
 .
 
@@ -7687,12 +8941,18 @@ SymbolicName=ERROR_UNKNOWN_PRODUCT
 Language=English
 ERROR_UNKNOWN_PRODUCT - This action is only valid for products that are currently installed.
 .
+Language=Russian
+ERROR_UNKNOWN_PRODUCT - This action is only valid for products that are currently installed.
+.
 
 MessageId=1606
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNKNOWN_FEATURE
 Language=English
+ERROR_UNKNOWN_FEATURE - Feature ID not registered.
+.
+Language=Russian
 ERROR_UNKNOWN_FEATURE - Feature ID not registered.
 .
 
@@ -7703,12 +8963,18 @@ SymbolicName=ERROR_UNKNOWN_COMPONENT
 Language=English
 ERROR_UNKNOWN_COMPONENT - Component ID not registered.
 .
+Language=Russian
+ERROR_UNKNOWN_COMPONENT - Component ID not registered.
+.
 
 MessageId=1608
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNKNOWN_PROPERTY
 Language=English
+ERROR_UNKNOWN_PROPERTY - Unknown property.
+.
+Language=Russian
 ERROR_UNKNOWN_PROPERTY - Unknown property.
 .
 
@@ -7719,12 +8985,18 @@ SymbolicName=ERROR_INVALID_HANDLE_STATE
 Language=English
 ERROR_INVALID_HANDLE_STATE - Handle is in an invalid state.
 .
+Language=Russian
+ERROR_INVALID_HANDLE_STATE - Handle is in an invalid state.
+.
 
 MessageId=1610
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_CONFIGURATION
 Language=English
+ERROR_BAD_CONFIGURATION - The configuration data for this product is corrupt. Contact your support personnel.
+.
+Language=Russian
 ERROR_BAD_CONFIGURATION - The configuration data for this product is corrupt. Contact your support personnel.
 .
 
@@ -7735,12 +9007,18 @@ SymbolicName=ERROR_INDEX_ABSENT
 Language=English
 ERROR_INDEX_ABSENT - Component qualifier not present.
 .
+Language=Russian
+ERROR_INDEX_ABSENT - Component qualifier not present.
+.
 
 MessageId=1612
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_SOURCE_ABSENT
 Language=English
+ERROR_INSTALL_SOURCE_ABSENT - The installation source for this product is not available. Verify that the source exists and that you can access it.
+.
+Language=Russian
 ERROR_INSTALL_SOURCE_ABSENT - The installation source for this product is not available. Verify that the source exists and that you can access it.
 .
 
@@ -7751,12 +9029,18 @@ SymbolicName=ERROR_INSTALL_PACKAGE_VERSION
 Language=English
 ERROR_INSTALL_PACKAGE_VERSION - This installation package cannot be installed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.
 .
+Language=Russian
+ERROR_INSTALL_PACKAGE_VERSION - This installation package cannot be installed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.
+.
 
 MessageId=1614
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRODUCT_UNINSTALLED
 Language=English
+ERROR_PRODUCT_UNINSTALLED - Product is uninstalled.
+.
+Language=Russian
 ERROR_PRODUCT_UNINSTALLED - Product is uninstalled.
 .
 
@@ -7767,12 +9051,18 @@ SymbolicName=ERROR_BAD_QUERY_SYNTAX
 Language=English
 ERROR_BAD_QUERY_SYNTAX - SQL query syntax invalid or unsupported.
 .
+Language=Russian
+ERROR_BAD_QUERY_SYNTAX - SQL query syntax invalid or unsupported.
+.
 
 MessageId=1616
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_FIELD
 Language=English
+ERROR_INVALID_FIELD - Record field does not exist.
+.
+Language=Russian
 ERROR_INVALID_FIELD - Record field does not exist.
 .
 
@@ -7783,12 +9073,18 @@ SymbolicName=ERROR_DEVICE_REMOVED
 Language=English
 ERROR_DEVICE_REMOVED - The device has been removed.
 .
+Language=Russian
+ERROR_DEVICE_REMOVED - The device has been removed.
+.
 
 MessageId=1618
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_ALREADY_RUNNING
 Language=English
+ERROR_INSTALL_ALREADY_RUNNING - Another installation is already in progress. Complete that installation before proceeding with this install.
+.
+Language=Russian
 ERROR_INSTALL_ALREADY_RUNNING - Another installation is already in progress. Complete that installation before proceeding with this install.
 .
 
@@ -7799,12 +9095,18 @@ SymbolicName=ERROR_INSTALL_PACKAGE_OPEN_FAILED
 Language=English
 ERROR_INSTALL_PACKAGE_OPEN_FAILED - This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package.
 .
+Language=Russian
+ERROR_INSTALL_PACKAGE_OPEN_FAILED - This installation package could not be opened. Verify that the package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer package.
+.
 
 MessageId=1620
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_PACKAGE_INVALID
 Language=English
+ERROR_INSTALL_PACKAGE_INVALID - This installation package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer package.
+.
+Language=Russian
 ERROR_INSTALL_PACKAGE_INVALID - This installation package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer package.
 .
 
@@ -7815,12 +9117,18 @@ SymbolicName=ERROR_INSTALL_UI_FAILURE
 Language=English
 ERROR_INSTALL_UI_FAILURE - There was an error starting the Windows Installer service user interface. Contact your support personnel.
 .
+Language=Russian
+ERROR_INSTALL_UI_FAILURE - There was an error starting the Windows Installer service user interface. Contact your support personnel.
+.
 
 MessageId=1622
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_LOG_FAILURE
 Language=English
+ERROR_INSTALL_LOG_FAILURE - Error opening installation log file. Verify that the specified log file location exists and that you can write to it.
+.
+Language=Russian
 ERROR_INSTALL_LOG_FAILURE - Error opening installation log file. Verify that the specified log file location exists and that you can write to it.
 .
 
@@ -7831,12 +9139,18 @@ SymbolicName=ERROR_INSTALL_LANGUAGE_UNSUPPORTED
 Language=English
 ERROR_INSTALL_LANGUAGE_UNSUPPORTED - The language of this installation package is not supported by your system.
 .
+Language=Russian
+ERROR_INSTALL_LANGUAGE_UNSUPPORTED - The language of this installation package is not supported by your system.
+.
 
 MessageId=1624
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_TRANSFORM_FAILURE
 Language=English
+ERROR_INSTALL_TRANSFORM_FAILURE - Error applying transforms. Verify that the specified transform paths are valid.
+.
+Language=Russian
 ERROR_INSTALL_TRANSFORM_FAILURE - Error applying transforms. Verify that the specified transform paths are valid.
 .
 
@@ -7847,12 +9161,18 @@ SymbolicName=ERROR_INSTALL_PACKAGE_REJECTED
 Language=English
 ERROR_INSTALL_PACKAGE_REJECTED - This installation is forbidden by system policy. Contact your system administrator.
 .
+Language=Russian
+ERROR_INSTALL_PACKAGE_REJECTED - This installation is forbidden by system policy. Contact your system administrator.
+.
 
 MessageId=1626
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FUNCTION_NOT_CALLED
 Language=English
+ERROR_FUNCTION_NOT_CALLED - Function could not be executed.
+.
+Language=Russian
 ERROR_FUNCTION_NOT_CALLED - Function could not be executed.
 .
 
@@ -7863,12 +9183,18 @@ SymbolicName=ERROR_FUNCTION_FAILED
 Language=English
 ERROR_FUNCTION_FAILED - Function failed during execution.
 .
+Language=Russian
+ERROR_FUNCTION_FAILED - Function failed during execution.
+.
 
 MessageId=1628
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_TABLE
 Language=English
+ERROR_INVALID_TABLE - Invalid or unknown table specified.
+.
+Language=Russian
 ERROR_INVALID_TABLE - Invalid or unknown table specified.
 .
 
@@ -7879,12 +9205,18 @@ SymbolicName=ERROR_DATATYPE_MISMATCH
 Language=English
 ERROR_DATATYPE_MISMATCH - Data supplied is of wrong type.
 .
+Language=Russian
+ERROR_DATATYPE_MISMATCH - Data supplied is of wrong type.
+.
 
 MessageId=1630
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNSUPPORTED_TYPE
 Language=English
+ERROR_UNSUPPORTED_TYPE - Data of this type is not supported.
+.
+Language=Russian
 ERROR_UNSUPPORTED_TYPE - Data of this type is not supported.
 .
 
@@ -7895,12 +9227,18 @@ SymbolicName=ERROR_CREATE_FAILED
 Language=English
 ERROR_CREATE_FAILED - The Windows Installer service failed to start. Contact your support personnel.
 .
+Language=Russian
+ERROR_CREATE_FAILED - The Windows Installer service failed to start. Contact your support personnel.
+.
 
 MessageId=1632
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_TEMP_UNWRITABLE
 Language=English
+ERROR_INSTALL_TEMP_UNWRITABLE - The Temp folder is on a drive that is full or inaccessible. Free up space on the drive or verify that you have write permission on the Temp folder.
+.
+Language=Russian
 ERROR_INSTALL_TEMP_UNWRITABLE - The Temp folder is on a drive that is full or inaccessible. Free up space on the drive or verify that you have write permission on the Temp folder.
 .
 
@@ -7911,12 +9249,18 @@ SymbolicName=ERROR_INSTALL_PLATFORM_UNSUPPORTED
 Language=English
 ERROR_INSTALL_PLATFORM_UNSUPPORTED - This installation package is not supported by this processor type. Contact your product vendor.
 .
+Language=Russian
+ERROR_INSTALL_PLATFORM_UNSUPPORTED - This installation package is not supported by this processor type. Contact your product vendor.
+.
 
 MessageId=1634
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_NOTUSED
 Language=English
+ERROR_INSTALL_NOTUSED - Component not used on this computer.
+.
+Language=Russian
 ERROR_INSTALL_NOTUSED - Component not used on this computer.
 .
 
@@ -7927,12 +9271,18 @@ SymbolicName=ERROR_PATCH_PACKAGE_OPEN_FAILED
 Language=English
 ERROR_PATCH_PACKAGE_OPEN_FAILED - This patch package could not be opened. Verify that the patch package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer patch package.
 .
+Language=Russian
+ERROR_PATCH_PACKAGE_OPEN_FAILED - This patch package could not be opened. Verify that the patch package exists and that you can access it, or contact the application vendor to verify that this is a valid Windows Installer patch package.
+.
 
 MessageId=1636
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PATCH_PACKAGE_INVALID
 Language=English
+ERROR_PATCH_PACKAGE_INVALID - This patch package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer patch package.
+.
+Language=Russian
 ERROR_PATCH_PACKAGE_INVALID - This patch package could not be opened. Contact the application vendor to verify that this is a valid Windows Installer patch package.
 .
 
@@ -7943,12 +9293,18 @@ SymbolicName=ERROR_PATCH_PACKAGE_UNSUPPORTED
 Language=English
 ERROR_PATCH_PACKAGE_UNSUPPORTED - This patch package cannot be processed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.
 .
+Language=Russian
+ERROR_PATCH_PACKAGE_UNSUPPORTED - This patch package cannot be processed by the Windows Installer service. You must install a Windows service pack that contains a newer version of the Windows Installer service.
+.
 
 MessageId=1638
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRODUCT_VERSION
 Language=English
+ERROR_PRODUCT_VERSION - Another version of this product is already installed. Installation of this version cannot continue. To configure or remove the existing version of this product, use Add/Remove Programs on the Control Panel.
+.
+Language=Russian
 ERROR_PRODUCT_VERSION - Another version of this product is already installed. Installation of this version cannot continue. To configure or remove the existing version of this product, use Add/Remove Programs on the Control Panel.
 .
 
@@ -7959,12 +9315,18 @@ SymbolicName=ERROR_INVALID_COMMAND_LINE
 Language=English
 ERROR_INVALID_COMMAND_LINE - Invalid command line argument. Consult the Windows Installer SDK for detailed command line help.
 .
+Language=Russian
+ERROR_INVALID_COMMAND_LINE - Invalid command line argument. Consult the Windows Installer SDK for detailed command line help.
+.
 
 MessageId=1640
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_REMOTE_DISALLOWED
 Language=English
+ERROR_INSTALL_REMOTE_DISALLOWED - Only administrators have permission to add, remove, or configure server software during a Terminal Services remote session. If you want to install or configure software on the server, contact your network administrator.
+.
+Language=Russian
 ERROR_INSTALL_REMOTE_DISALLOWED - Only administrators have permission to add, remove, or configure server software during a Terminal Services remote session. If you want to install or configure software on the server, contact your network administrator.
 .
 
@@ -7975,12 +9337,18 @@ SymbolicName=ERROR_SUCCESS_REBOOT_INITIATED
 Language=English
 ERROR_SUCCESS_REBOOT_INITIATED - The requested operation completed successfully. The system will be restarted so the changes can take effect.
 .
+Language=Russian
+ERROR_SUCCESS_REBOOT_INITIATED - The requested operation completed successfully. The system will be restarted so the changes can take effect.
+.
 
 MessageId=1642
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PATCH_TARGET_NOT_FOUND
 Language=English
+ERROR_PATCH_TARGET_NOT_FOUND - The upgrade patch cannot be installed by the Windows Installer service because the program to be upgraded may be missing, or the upgrade patch may update a different version of the program. Verify that the program to be upgraded exists on your computer and that you have the correct upgrade patch.
+.
+Language=Russian
 ERROR_PATCH_TARGET_NOT_FOUND - The upgrade patch cannot be installed by the Windows Installer service because the program to be upgraded may be missing, or the upgrade patch may update a different version of the program. Verify that the program to be upgraded exists on your computer and that you have the correct upgrade patch.
 .
 
@@ -7991,12 +9359,18 @@ SymbolicName=ERROR_PATCH_PACKAGE_REJECTED
 Language=English
 ERROR_PATCH_PACKAGE_REJECTED - The patch package is not permitted by software restriction policy.
 .
+Language=Russian
+ERROR_PATCH_PACKAGE_REJECTED - The patch package is not permitted by software restriction policy.
+.
 
 MessageId=1644
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INSTALL_TRANSFORM_REJECTED
 Language=English
+ERROR_INSTALL_TRANSFORM_REJECTED - One or more customizations are not permitted by software restriction policy.
+.
+Language=Russian
 ERROR_INSTALL_TRANSFORM_REJECTED - One or more customizations are not permitted by software restriction policy.
 .
 
@@ -8007,12 +9381,18 @@ SymbolicName=ERROR_INSTALL_REMOTE_PROHIBITED
 Language=English
 ERROR_INSTALL_REMOTE_PROHIBITED - The Windows Installer does not permit installation from a Remote Desktop Connection.
 .
+Language=Russian
+ERROR_INSTALL_REMOTE_PROHIBITED - The Windows Installer does not permit installation from a Remote Desktop Connection.
+.
 
 MessageId=1700
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_STRING_BINDING
 Language=English
+RPC_S_INVALID_STRING_BINDING - The string binding is invalid.
+.
+Language=Russian
 RPC_S_INVALID_STRING_BINDING - The string binding is invalid.
 .
 
@@ -8023,12 +9403,18 @@ SymbolicName=RPC_S_WRONG_KIND_OF_BINDING
 Language=English
 RPC_S_WRONG_KIND_OF_BINDING - The binding handle is not the correct type.
 .
+Language=Russian
+RPC_S_WRONG_KIND_OF_BINDING - The binding handle is not the correct type.
+.
 
 MessageId=1702
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_BINDING
 Language=English
+RPC_S_INVALID_BINDING - The binding handle is invalid.
+.
+Language=Russian
 RPC_S_INVALID_BINDING - The binding handle is invalid.
 .
 
@@ -8039,12 +9425,18 @@ SymbolicName=RPC_S_PROTSEQ_NOT_SUPPORTED
 Language=English
 RPC_S_PROTSEQ_NOT_SUPPORTED - The RPC protocol sequence is not supported.
 .
+Language=Russian
+RPC_S_PROTSEQ_NOT_SUPPORTED - The RPC protocol sequence is not supported.
+.
 
 MessageId=1704
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_RPC_PROTSEQ
 Language=English
+RPC_S_INVALID_RPC_PROTSEQ - The RPC protocol sequence is invalid.
+.
+Language=Russian
 RPC_S_INVALID_RPC_PROTSEQ - The RPC protocol sequence is invalid.
 .
 
@@ -8055,12 +9447,18 @@ SymbolicName=RPC_S_INVALID_STRING_UUID
 Language=English
 RPC_S_INVALID_STRING_UUID - The string universal unique identifier (UUID) is invalid.
 .
+Language=Russian
+RPC_S_INVALID_STRING_UUID - The string universal unique identifier (UUID) is invalid.
+.
 
 MessageId=1706
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_ENDPOINT_FORMAT
 Language=English
+RPC_S_INVALID_ENDPOINT_FORMAT - The endpoint format is invalid.
+.
+Language=Russian
 RPC_S_INVALID_ENDPOINT_FORMAT - The endpoint format is invalid.
 .
 
@@ -8071,12 +9469,18 @@ SymbolicName=RPC_S_INVALID_NET_ADDR
 Language=English
 RPC_S_INVALID_NET_ADDR - The network address is invalid.
 .
+Language=Russian
+RPC_S_INVALID_NET_ADDR - The network address is invalid.
+.
 
 MessageId=1708
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_ENDPOINT_FOUND
 Language=English
+RPC_S_NO_ENDPOINT_FOUND - No endpoint was found.
+.
+Language=Russian
 RPC_S_NO_ENDPOINT_FOUND - No endpoint was found.
 .
 
@@ -8087,12 +9491,18 @@ SymbolicName=RPC_S_INVALID_TIMEOUT
 Language=English
 RPC_S_INVALID_TIMEOUT - The timeout value is invalid.
 .
+Language=Russian
+RPC_S_INVALID_TIMEOUT - The timeout value is invalid.
+.
 
 MessageId=1710
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_OBJECT_NOT_FOUND
 Language=English
+RPC_S_OBJECT_NOT_FOUND - The object universal unique identifier (UUID) was not found.
+.
+Language=Russian
 RPC_S_OBJECT_NOT_FOUND - The object universal unique identifier (UUID) was not found.
 .
 
@@ -8103,12 +9513,18 @@ SymbolicName=RPC_S_ALREADY_REGISTERED
 Language=English
 RPC_S_ALREADY_REGISTERED - The object universal unique identifier (UUID) has already been registered.
 .
+Language=Russian
+RPC_S_ALREADY_REGISTERED - The object universal unique identifier (UUID) has already been registered.
+.
 
 MessageId=1712
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_TYPE_ALREADY_REGISTERED
 Language=English
+RPC_S_TYPE_ALREADY_REGISTERED - The type universal unique identifier (UUID) has already been registered.
+.
+Language=Russian
 RPC_S_TYPE_ALREADY_REGISTERED - The type universal unique identifier (UUID) has already been registered.
 .
 
@@ -8119,12 +9535,18 @@ SymbolicName=RPC_S_ALREADY_LISTENING
 Language=English
 RPC_S_ALREADY_LISTENING - The RPC server is already listening.
 .
+Language=Russian
+RPC_S_ALREADY_LISTENING - The RPC server is already listening.
+.
 
 MessageId=1714
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_PROTSEQS_REGISTERED
 Language=English
+RPC_S_NO_PROTSEQS_REGISTERED - No protocol sequences have been registered.
+.
+Language=Russian
 RPC_S_NO_PROTSEQS_REGISTERED - No protocol sequences have been registered.
 .
 
@@ -8135,12 +9557,18 @@ SymbolicName=RPC_S_NOT_LISTENING
 Language=English
 RPC_S_NOT_LISTENING - The RPC server is not listening.
 .
+Language=Russian
+RPC_S_NOT_LISTENING - The RPC server is not listening.
+.
 
 MessageId=1716
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UNKNOWN_MGR_TYPE
 Language=English
+RPC_S_UNKNOWN_MGR_TYPE - The manager type is unknown.
+.
+Language=Russian
 RPC_S_UNKNOWN_MGR_TYPE - The manager type is unknown.
 .
 
@@ -8151,12 +9579,18 @@ SymbolicName=RPC_S_UNKNOWN_IF
 Language=English
 RPC_S_UNKNOWN_IF - The interface is unknown.
 .
+Language=Russian
+RPC_S_UNKNOWN_IF - The interface is unknown.
+.
 
 MessageId=1718
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_BINDINGS
 Language=English
+RPC_S_NO_BINDINGS - There are no bindings.
+.
+Language=Russian
 RPC_S_NO_BINDINGS - There are no bindings.
 .
 
@@ -8167,12 +9601,18 @@ SymbolicName=RPC_S_NO_PROTSEQS
 Language=English
 RPC_S_NO_PROTSEQS - There are no protocol sequences.
 .
+Language=Russian
+RPC_S_NO_PROTSEQS - There are no protocol sequences.
+.
 
 MessageId=1720
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_CANT_CREATE_ENDPOINT
 Language=English
+RPC_S_CANT_CREATE_ENDPOINT - The endpoint cannot be created.
+.
+Language=Russian
 RPC_S_CANT_CREATE_ENDPOINT - The endpoint cannot be created.
 .
 
@@ -8183,12 +9623,18 @@ SymbolicName=RPC_S_OUT_OF_RESOURCES
 Language=English
 RPC_S_OUT_OF_RESOURCES - Not enough resources are available to complete this operation.
 .
+Language=Russian
+RPC_S_OUT_OF_RESOURCES - Not enough resources are available to complete this operation.
+.
 
 MessageId=1722
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_SERVER_UNAVAILABLE
 Language=English
+RPC_S_SERVER_UNAVAILABLE - The RPC server is unavailable.
+.
+Language=Russian
 RPC_S_SERVER_UNAVAILABLE - The RPC server is unavailable.
 .
 
@@ -8199,12 +9645,18 @@ SymbolicName=RPC_S_SERVER_TOO_BUSY
 Language=English
 RPC_S_SERVER_TOO_BUSY - The RPC server is too busy to complete this operation.
 .
+Language=Russian
+RPC_S_SERVER_TOO_BUSY - The RPC server is too busy to complete this operation.
+.
 
 MessageId=1724
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_NETWORK_OPTIONS
 Language=English
+RPC_S_INVALID_NETWORK_OPTIONS - The network options are invalid.
+.
+Language=Russian
 RPC_S_INVALID_NETWORK_OPTIONS - The network options are invalid.
 .
 
@@ -8215,12 +9667,18 @@ SymbolicName=RPC_S_NO_CALL_ACTIVE
 Language=English
 RPC_S_NO_CALL_ACTIVE - There are no remote procedure calls active on this thread.
 .
+Language=Russian
+RPC_S_NO_CALL_ACTIVE - There are no remote procedure calls active on this thread.
+.
 
 MessageId=1726
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_CALL_FAILED
 Language=English
+RPC_S_CALL_FAILED - The remote procedure call failed.
+.
+Language=Russian
 RPC_S_CALL_FAILED - The remote procedure call failed.
 .
 
@@ -8231,12 +9689,18 @@ SymbolicName=RPC_S_CALL_FAILED_DNE
 Language=English
 RPC_S_CALL_FAILED_DNE - The remote procedure call failed and did not execute.
 .
+Language=Russian
+RPC_S_CALL_FAILED_DNE - The remote procedure call failed and did not execute.
+.
 
 MessageId=1728
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_PROTOCOL_ERROR
 Language=English
+RPC_S_PROTOCOL_ERROR - A remote procedure call (RPC) protocol error occurred.
+.
+Language=Russian
 RPC_S_PROTOCOL_ERROR - A remote procedure call (RPC) protocol error occurred.
 .
 
@@ -8247,12 +9711,18 @@ SymbolicName=RPC_S_UNSUPPORTED_TRANS_SYN
 Language=English
 RPC_S_UNSUPPORTED_TRANS_SYN - The transfer syntax is not supported by the RPC server.
 .
+Language=Russian
+RPC_S_UNSUPPORTED_TRANS_SYN - The transfer syntax is not supported by the RPC server.
+.
 
 MessageId=1732
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UNSUPPORTED_TYPE
 Language=English
+RPC_S_UNSUPPORTED_TYPE - The universal unique identifier (UUID) type is not supported.
+.
+Language=Russian
 RPC_S_UNSUPPORTED_TYPE - The universal unique identifier (UUID) type is not supported.
 .
 
@@ -8263,12 +9733,18 @@ SymbolicName=RPC_S_INVALID_TAG
 Language=English
 RPC_S_INVALID_TAG - The tag is invalid.
 .
+Language=Russian
+RPC_S_INVALID_TAG - The tag is invalid.
+.
 
 MessageId=1734
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_BOUND
 Language=English
+RPC_S_INVALID_BOUND - The array bounds are invalid.
+.
+Language=Russian
 RPC_S_INVALID_BOUND - The array bounds are invalid.
 .
 
@@ -8279,12 +9755,18 @@ SymbolicName=RPC_S_NO_ENTRY_NAME
 Language=English
 RPC_S_NO_ENTRY_NAME - The binding does not contain an entry name.
 .
+Language=Russian
+RPC_S_NO_ENTRY_NAME - The binding does not contain an entry name.
+.
 
 MessageId=1736
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_NAME_SYNTAX
 Language=English
+RPC_S_INVALID_NAME_SYNTAX - The name syntax is invalid.
+.
+Language=Russian
 RPC_S_INVALID_NAME_SYNTAX - The name syntax is invalid.
 .
 
@@ -8295,12 +9777,18 @@ SymbolicName=RPC_S_UNSUPPORTED_NAME_SYNTAX
 Language=English
 RPC_S_UNSUPPORTED_NAME_SYNTAX - The name syntax is not supported.
 .
+Language=Russian
+RPC_S_UNSUPPORTED_NAME_SYNTAX - The name syntax is not supported.
+.
 
 MessageId=1739
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UUID_NO_ADDRESS
 Language=English
+RPC_S_UUID_NO_ADDRESS - No network address is available to use to construct a universal unique identifier (UUID).
+.
+Language=Russian
 RPC_S_UUID_NO_ADDRESS - No network address is available to use to construct a universal unique identifier (UUID).
 .
 
@@ -8311,12 +9799,18 @@ SymbolicName=RPC_S_DUPLICATE_ENDPOINT
 Language=English
 RPC_S_DUPLICATE_ENDPOINT - The endpoint is a duplicate.
 .
+Language=Russian
+RPC_S_DUPLICATE_ENDPOINT - The endpoint is a duplicate.
+.
 
 MessageId=1741
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UNKNOWN_AUTHN_TYPE
 Language=English
+RPC_S_UNKNOWN_AUTHN_TYPE - The authentication type is unknown.
+.
+Language=Russian
 RPC_S_UNKNOWN_AUTHN_TYPE - The authentication type is unknown.
 .
 
@@ -8327,12 +9821,18 @@ SymbolicName=RPC_S_MAX_CALLS_TOO_SMALL
 Language=English
 RPC_S_MAX_CALLS_TOO_SMALL - The maximum number of calls is too small.
 .
+Language=Russian
+RPC_S_MAX_CALLS_TOO_SMALL - The maximum number of calls is too small.
+.
 
 MessageId=1743
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_STRING_TOO_LONG
 Language=English
+RPC_S_STRING_TOO_LONG - The string is too long.
+.
+Language=Russian
 RPC_S_STRING_TOO_LONG - The string is too long.
 .
 
@@ -8343,12 +9843,18 @@ SymbolicName=RPC_S_PROTSEQ_NOT_FOUND
 Language=English
 RPC_S_PROTSEQ_NOT_FOUND - The RPC protocol sequence was not found.
 .
+Language=Russian
+RPC_S_PROTSEQ_NOT_FOUND - The RPC protocol sequence was not found.
+.
 
 MessageId=1745
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_PROCNUM_OUT_OF_RANGE
 Language=English
+RPC_S_PROCNUM_OUT_OF_RANGE - The procedure number is out of range.
+.
+Language=Russian
 RPC_S_PROCNUM_OUT_OF_RANGE - The procedure number is out of range.
 .
 
@@ -8359,12 +9865,18 @@ SymbolicName=RPC_S_BINDING_HAS_NO_AUTH
 Language=English
 RPC_S_BINDING_HAS_NO_AUTH - The binding does not contain any authentication information.
 .
+Language=Russian
+RPC_S_BINDING_HAS_NO_AUTH - The binding does not contain any authentication information.
+.
 
 MessageId=1747
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UNKNOWN_AUTHN_SERVICE
 Language=English
+RPC_S_UNKNOWN_AUTHN_SERVICE - The authentication service is unknown.
+.
+Language=Russian
 RPC_S_UNKNOWN_AUTHN_SERVICE - The authentication service is unknown.
 .
 
@@ -8375,12 +9887,18 @@ SymbolicName=RPC_S_UNKNOWN_AUTHN_LEVEL
 Language=English
 RPC_S_UNKNOWN_AUTHN_LEVEL - The authentication level is unknown.
 .
+Language=Russian
+RPC_S_UNKNOWN_AUTHN_LEVEL - The authentication level is unknown.
+.
 
 MessageId=1749
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_AUTH_IDENTITY
 Language=English
+RPC_S_INVALID_AUTH_IDENTITY - The security context is invalid.
+.
+Language=Russian
 RPC_S_INVALID_AUTH_IDENTITY - The security context is invalid.
 .
 
@@ -8391,12 +9909,18 @@ SymbolicName=RPC_S_UNKNOWN_AUTHZ_SERVICE
 Language=English
 RPC_S_UNKNOWN_AUTHZ_SERVICE - The authorization service is unknown.
 .
+Language=Russian
+RPC_S_UNKNOWN_AUTHZ_SERVICE - The authorization service is unknown.
+.
 
 MessageId=1751
 Severity=Success
 Facility=System
 SymbolicName=EPT_S_INVALID_ENTRY
 Language=English
+EPT_S_INVALID_ENTRY - The entry is invalid.
+.
+Language=Russian
 EPT_S_INVALID_ENTRY - The entry is invalid.
 .
 
@@ -8407,12 +9931,18 @@ SymbolicName=EPT_S_CANT_PERFORM_OP
 Language=English
 EPT_S_CANT_PERFORM_OP - The server endpoint cannot perform the operation.
 .
+Language=Russian
+EPT_S_CANT_PERFORM_OP - The server endpoint cannot perform the operation.
+.
 
 MessageId=1753
 Severity=Success
 Facility=System
 SymbolicName=EPT_S_NOT_REGISTERED
 Language=English
+EPT_S_NOT_REGISTERED - There are no more endpoints available from the endpoint mapper.
+.
+Language=Russian
 EPT_S_NOT_REGISTERED - There are no more endpoints available from the endpoint mapper.
 .
 
@@ -8423,12 +9953,18 @@ SymbolicName=RPC_S_NOTHING_TO_EXPORT
 Language=English
 RPC_S_NOTHING_TO_EXPORT - No interfaces have been exported.
 .
+Language=Russian
+RPC_S_NOTHING_TO_EXPORT - No interfaces have been exported.
+.
 
 MessageId=1755
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INCOMPLETE_NAME
 Language=English
+RPC_S_INCOMPLETE_NAME - The entry name is incomplete.
+.
+Language=Russian
 RPC_S_INCOMPLETE_NAME - The entry name is incomplete.
 .
 
@@ -8439,12 +9975,18 @@ SymbolicName=RPC_S_INVALID_VERS_OPTION
 Language=English
 RPC_S_INVALID_VERS_OPTION - The version option is invalid.
 .
+Language=Russian
+RPC_S_INVALID_VERS_OPTION - The version option is invalid.
+.
 
 MessageId=1757
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_MORE_MEMBERS
 Language=English
+RPC_S_NO_MORE_MEMBERS - There are no more members.
+.
+Language=Russian
 RPC_S_NO_MORE_MEMBERS - There are no more members.
 .
 
@@ -8455,12 +9997,18 @@ SymbolicName=RPC_S_NOT_ALL_OBJS_UNEXPORTED
 Language=English
 RPC_S_NOT_ALL_OBJS_UNEXPORTED - There is nothing to unexport.
 .
+Language=Russian
+RPC_S_NOT_ALL_OBJS_UNEXPORTED - There is nothing to unexport.
+.
 
 MessageId=1759
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INTERFACE_NOT_FOUND
 Language=English
+RPC_S_INTERFACE_NOT_FOUND - The interface was not found.
+.
+Language=Russian
 RPC_S_INTERFACE_NOT_FOUND - The interface was not found.
 .
 
@@ -8471,12 +10019,18 @@ SymbolicName=RPC_S_ENTRY_ALREADY_EXISTS
 Language=English
 RPC_S_ENTRY_ALREADY_EXISTS - The entry already exists.
 .
+Language=Russian
+RPC_S_ENTRY_ALREADY_EXISTS - The entry already exists.
+.
 
 MessageId=1761
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_ENTRY_NOT_FOUND
 Language=English
+RPC_S_ENTRY_NOT_FOUND - The entry is not found.
+.
+Language=Russian
 RPC_S_ENTRY_NOT_FOUND - The entry is not found.
 .
 
@@ -8487,12 +10041,18 @@ SymbolicName=RPC_S_NAME_SERVICE_UNAVAILABLE
 Language=English
 RPC_S_NAME_SERVICE_UNAVAILABLE - The name service is unavailable.
 .
+Language=Russian
+RPC_S_NAME_SERVICE_UNAVAILABLE - The name service is unavailable.
+.
 
 MessageId=1763
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_NAF_ID
 Language=English
+RPC_S_INVALID_NAF_ID - The network address family is invalid.
+.
+Language=Russian
 RPC_S_INVALID_NAF_ID - The network address family is invalid.
 .
 
@@ -8503,12 +10063,18 @@ SymbolicName=RPC_S_CANNOT_SUPPORT
 Language=English
 RPC_S_CANNOT_SUPPORT - The requested operation is not supported.
 .
+Language=Russian
+RPC_S_CANNOT_SUPPORT - The requested operation is not supported.
+.
 
 MessageId=1765
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_CONTEXT_AVAILABLE
 Language=English
+RPC_S_NO_CONTEXT_AVAILABLE - No security context is available to allow impersonation.
+.
+Language=Russian
 RPC_S_NO_CONTEXT_AVAILABLE - No security context is available to allow impersonation.
 .
 
@@ -8519,12 +10085,18 @@ SymbolicName=RPC_S_INTERNAL_ERROR
 Language=English
 RPC_S_INTERNAL_ERROR - An internal error occurred in a remote procedure call (RPC).
 .
+Language=Russian
+RPC_S_INTERNAL_ERROR - An internal error occurred in a remote procedure call (RPC).
+.
 
 MessageId=1767
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_ZERO_DIVIDE
 Language=English
+RPC_S_ZERO_DIVIDE - The RPC server attempted an integer division by zero.
+.
+Language=Russian
 RPC_S_ZERO_DIVIDE - The RPC server attempted an integer division by zero.
 .
 
@@ -8535,12 +10107,18 @@ SymbolicName=RPC_S_ADDRESS_ERROR
 Language=English
 RPC_S_ADDRESS_ERROR - An addressing error occurred in the RPC server.
 .
+Language=Russian
+RPC_S_ADDRESS_ERROR - An addressing error occurred in the RPC server.
+.
 
 MessageId=1769
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_FP_DIV_ZERO
 Language=English
+RPC_S_FP_DIV_ZERO - A floating-point operation at the RPC server caused a division by zero.
+.
+Language=Russian
 RPC_S_FP_DIV_ZERO - A floating-point operation at the RPC server caused a division by zero.
 .
 
@@ -8551,12 +10129,18 @@ SymbolicName=RPC_S_FP_UNDERFLOW
 Language=English
 RPC_S_FP_UNDERFLOW - A floating-point underflow occurred at the RPC server.
 .
+Language=Russian
+RPC_S_FP_UNDERFLOW - A floating-point underflow occurred at the RPC server.
+.
 
 MessageId=1771
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_FP_OVERFLOW
 Language=English
+RPC_S_FP_OVERFLOW - A floating-point overflow occurred at the RPC server.
+.
+Language=Russian
 RPC_S_FP_OVERFLOW - A floating-point overflow occurred at the RPC server.
 .
 
@@ -8567,12 +10151,18 @@ SymbolicName=RPC_X_NO_MORE_ENTRIES
 Language=English
 RPC_X_NO_MORE_ENTRIES - The list of RPC servers available for the binding of auto handles has been exhausted.
 .
+Language=Russian
+RPC_X_NO_MORE_ENTRIES - The list of RPC servers available for the binding of auto handles has been exhausted.
+.
 
 MessageId=1773
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_SS_CHAR_TRANS_OPEN_FAIL
 Language=English
+RPC_X_SS_CHAR_TRANS_OPEN_FAIL - Unable to open the character translation table file.
+.
+Language=Russian
 RPC_X_SS_CHAR_TRANS_OPEN_FAIL - Unable to open the character translation table file.
 .
 
@@ -8583,12 +10173,18 @@ SymbolicName=RPC_X_SS_CHAR_TRANS_SHORT_FILE
 Language=English
 RPC_X_SS_CHAR_TRANS_SHORT_FILE - The file containing the character translation table has fewer than 512 bytes.
 .
+Language=Russian
+RPC_X_SS_CHAR_TRANS_SHORT_FILE - The file containing the character translation table has fewer than 512 bytes.
+.
 
 MessageId=1775
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_SS_IN_NULL_CONTEXT
 Language=English
+RPC_X_SS_IN_NULL_CONTEXT - A null context handle was passed from the client to the host during a remote procedure call.
+.
+Language=Russian
 RPC_X_SS_IN_NULL_CONTEXT - A null context handle was passed from the client to the host during a remote procedure call.
 .
 
@@ -8599,12 +10195,18 @@ SymbolicName=RPC_X_SS_CONTEXT_DAMAGED
 Language=English
 RPC_X_SS_CONTEXT_DAMAGED - The context handle changed during a remote procedure call.
 .
+Language=Russian
+RPC_X_SS_CONTEXT_DAMAGED - The context handle changed during a remote procedure call.
+.
 
 MessageId=1778
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_SS_HANDLES_MISMATCH
 Language=English
+RPC_X_SS_HANDLES_MISMATCH - The binding handles passed to a remote procedure call do not match.
+.
+Language=Russian
 RPC_X_SS_HANDLES_MISMATCH - The binding handles passed to a remote procedure call do not match.
 .
 
@@ -8615,12 +10217,18 @@ SymbolicName=RPC_X_SS_CANNOT_GET_CALL_HANDLE
 Language=English
 RPC_X_SS_CANNOT_GET_CALL_HANDLE - The stub is unable to get the remote procedure call handle.
 .
+Language=Russian
+RPC_X_SS_CANNOT_GET_CALL_HANDLE - The stub is unable to get the remote procedure call handle.
+.
 
 MessageId=1780
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_NULL_REF_POINTER
 Language=English
+RPC_X_NULL_REF_POINTER - A null reference pointer was passed to the stub.
+.
+Language=Russian
 RPC_X_NULL_REF_POINTER - A null reference pointer was passed to the stub.
 .
 
@@ -8631,12 +10239,18 @@ SymbolicName=RPC_X_ENUM_VALUE_OUT_OF_RANGE
 Language=English
 RPC_X_ENUM_VALUE_OUT_OF_RANGE - The enumeration value is out of range.
 .
+Language=Russian
+RPC_X_ENUM_VALUE_OUT_OF_RANGE - The enumeration value is out of range.
+.
 
 MessageId=1782
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_BYTE_COUNT_TOO_SMALL
 Language=English
+RPC_X_BYTE_COUNT_TOO_SMALL - The byte count is too small.
+.
+Language=Russian
 RPC_X_BYTE_COUNT_TOO_SMALL - The byte count is too small.
 .
 
@@ -8647,12 +10261,18 @@ SymbolicName=RPC_X_BAD_STUB_DATA
 Language=English
 RPC_X_BAD_STUB_DATA - The stub received bad data.
 .
+Language=Russian
+RPC_X_BAD_STUB_DATA - The stub received bad data.
+.
 
 MessageId=1784
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_USER_BUFFER
 Language=English
+ERROR_INVALID_USER_BUFFER - The supplied user buffer is not valid for the requested operation.
+.
+Language=Russian
 ERROR_INVALID_USER_BUFFER - The supplied user buffer is not valid for the requested operation.
 .
 
@@ -8663,12 +10283,18 @@ SymbolicName=ERROR_UNRECOGNIZED_MEDIA
 Language=English
 ERROR_UNRECOGNIZED_MEDIA - The disk media is not recognized. It may not be formatted.
 .
+Language=Russian
+ERROR_UNRECOGNIZED_MEDIA - The disk media is not recognized. It may not be formatted.
+.
 
 MessageId=1786
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_TRUST_LSA_SECRET
 Language=English
+ERROR_NO_TRUST_LSA_SECRET - The workstation does not have a trust secret.
+.
+Language=Russian
 ERROR_NO_TRUST_LSA_SECRET - The workstation does not have a trust secret.
 .
 
@@ -8679,12 +10305,18 @@ SymbolicName=ERROR_NO_TRUST_SAM_ACCOUNT
 Language=English
 ERROR_NO_TRUST_SAM_ACCOUNT - The security database on the server does not have a computer account for this workstation trust relationship.
 .
+Language=Russian
+ERROR_NO_TRUST_SAM_ACCOUNT - The security database on the server does not have a computer account for this workstation trust relationship.
+.
 
 MessageId=1788
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TRUSTED_DOMAIN_FAILURE
 Language=English
+ERROR_TRUSTED_DOMAIN_FAILURE - The trust relationship between the primary domain and the trusted domain failed.
+.
+Language=Russian
 ERROR_TRUSTED_DOMAIN_FAILURE - The trust relationship between the primary domain and the trusted domain failed.
 .
 
@@ -8695,12 +10327,18 @@ SymbolicName=ERROR_TRUSTED_RELATIONSHIP_FAILURE
 Language=English
 ERROR_TRUSTED_RELATIONSHIP_FAILURE - The trust relationship between this workstation and the primary domain failed.
 .
+Language=Russian
+ERROR_TRUSTED_RELATIONSHIP_FAILURE - The trust relationship between this workstation and the primary domain failed.
+.
 
 MessageId=1790
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TRUST_FAILURE
 Language=English
+ERROR_TRUST_FAILURE - The network logon failed.
+.
+Language=Russian
 ERROR_TRUST_FAILURE - The network logon failed.
 .
 
@@ -8711,12 +10349,18 @@ SymbolicName=RPC_S_CALL_IN_PROGRESS
 Language=English
 RPC_S_CALL_IN_PROGRESS - A remote procedure call is already in progress for this thread.
 .
+Language=Russian
+RPC_S_CALL_IN_PROGRESS - A remote procedure call is already in progress for this thread.
+.
 
 MessageId=1792
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NETLOGON_NOT_STARTED
 Language=English
+ERROR_NETLOGON_NOT_STARTED - An attempt was made to logon, but the network logon service was not started.
+.
+Language=Russian
 ERROR_NETLOGON_NOT_STARTED - An attempt was made to logon, but the network logon service was not started.
 .
 
@@ -8727,12 +10371,18 @@ SymbolicName=ERROR_ACCOUNT_EXPIRED
 Language=English
 ERROR_ACCOUNT_EXPIRED - The user's account has expired.
 .
+Language=Russian
+ERROR_ACCOUNT_EXPIRED - The user's account has expired.
+.
 
 MessageId=1794
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REDIRECTOR_HAS_OPEN_HANDLES
 Language=English
+ERROR_REDIRECTOR_HAS_OPEN_HANDLES - The redirector is in use and cannot be unloaded.
+.
+Language=Russian
 ERROR_REDIRECTOR_HAS_OPEN_HANDLES - The redirector is in use and cannot be unloaded.
 .
 
@@ -8743,12 +10393,18 @@ SymbolicName=ERROR_PRINTER_DRIVER_ALREADY_INSTALLED
 Language=English
 ERROR_PRINTER_DRIVER_ALREADY_INSTALLED - The specified printer driver is already installed.
 .
+Language=Russian
+ERROR_PRINTER_DRIVER_ALREADY_INSTALLED - The specified printer driver is already installed.
+.
 
 MessageId=1796
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNKNOWN_PORT
 Language=English
+ERROR_UNKNOWN_PORT - The specified port is unknown.
+.
+Language=Russian
 ERROR_UNKNOWN_PORT - The specified port is unknown.
 .
 
@@ -8759,12 +10415,18 @@ SymbolicName=ERROR_UNKNOWN_PRINTER_DRIVER
 Language=English
 ERROR_UNKNOWN_PRINTER_DRIVER - The printer driver is unknown.
 .
+Language=Russian
+ERROR_UNKNOWN_PRINTER_DRIVER - The printer driver is unknown.
+.
 
 MessageId=1798
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNKNOWN_PRINTPROCESSOR
 Language=English
+ERROR_UNKNOWN_PRINTPROCESSOR - The print processor is unknown.
+.
+Language=Russian
 ERROR_UNKNOWN_PRINTPROCESSOR - The print processor is unknown.
 .
 
@@ -8775,12 +10437,18 @@ SymbolicName=ERROR_INVALID_SEPARATOR_FILE
 Language=English
 ERROR_INVALID_SEPARATOR_FILE - The specified separator file is invalid.
 .
+Language=Russian
+ERROR_INVALID_SEPARATOR_FILE - The specified separator file is invalid.
+.
 
 MessageId=1800
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_PRIORITY
 Language=English
+ERROR_INVALID_PRIORITY - The specified priority is invalid.
+.
+Language=Russian
 ERROR_INVALID_PRIORITY - The specified priority is invalid.
 .
 
@@ -8791,12 +10459,18 @@ SymbolicName=ERROR_INVALID_PRINTER_NAME
 Language=English
 ERROR_INVALID_PRINTER_NAME - The printer name is invalid.
 .
+Language=Russian
+ERROR_INVALID_PRINTER_NAME - The printer name is invalid.
+.
 
 MessageId=1802
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINTER_ALREADY_EXISTS
 Language=English
+ERROR_PRINTER_ALREADY_EXISTS - The printer already exists.
+.
+Language=Russian
 ERROR_PRINTER_ALREADY_EXISTS - The printer already exists.
 .
 
@@ -8807,12 +10481,18 @@ SymbolicName=ERROR_INVALID_PRINTER_COMMAND
 Language=English
 ERROR_INVALID_PRINTER_COMMAND - The printer command is invalid.
 .
+Language=Russian
+ERROR_INVALID_PRINTER_COMMAND - The printer command is invalid.
+.
 
 MessageId=1804
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_DATATYPE
 Language=English
+ERROR_INVALID_DATATYPE - The specified datatype is invalid.
+.
+Language=Russian
 ERROR_INVALID_DATATYPE - The specified datatype is invalid.
 .
 
@@ -8823,12 +10503,18 @@ SymbolicName=ERROR_INVALID_ENVIRONMENT
 Language=English
 ERROR_INVALID_ENVIRONMENT - The environment specified is invalid.
 .
+Language=Russian
+ERROR_INVALID_ENVIRONMENT - The environment specified is invalid.
+.
 
 MessageId=1806
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_MORE_BINDINGS
 Language=English
+RPC_S_NO_MORE_BINDINGS - There are no more bindings.
+.
+Language=Russian
 RPC_S_NO_MORE_BINDINGS - There are no more bindings.
 .
 
@@ -8839,12 +10525,18 @@ SymbolicName=ERROR_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT
 Language=English
 ERROR_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT - The account used is an interdomain trust account. Use your global user account or local user account to access this server.
 .
+Language=Russian
+ERROR_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT - The account used is an interdomain trust account. Use your global user account or local user account to access this server.
+.
 
 MessageId=1808
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOLOGON_WORKSTATION_TRUST_ACCOUNT
 Language=English
+ERROR_NOLOGON_WORKSTATION_TRUST_ACCOUNT - The account used is a computer account. Use your global user account or local user account to access this server.
+.
+Language=Russian
 ERROR_NOLOGON_WORKSTATION_TRUST_ACCOUNT - The account used is a computer account. Use your global user account or local user account to access this server.
 .
 
@@ -8855,12 +10547,18 @@ SymbolicName=ERROR_NOLOGON_SERVER_TRUST_ACCOUNT
 Language=English
 ERROR_NOLOGON_SERVER_TRUST_ACCOUNT - The account used is a server trust account. Use your global user account or local user account to access this server.
 .
+Language=Russian
+ERROR_NOLOGON_SERVER_TRUST_ACCOUNT - The account used is a server trust account. Use your global user account or local user account to access this server.
+.
 
 MessageId=1810
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DOMAIN_TRUST_INCONSISTENT
 Language=English
+ERROR_DOMAIN_TRUST_INCONSISTENT - The name or security ID (SID) of the domain specified is inconsistent with the trust information for that domain.
+.
+Language=Russian
 ERROR_DOMAIN_TRUST_INCONSISTENT - The name or security ID (SID) of the domain specified is inconsistent with the trust information for that domain.
 .
 
@@ -8871,12 +10569,18 @@ SymbolicName=ERROR_SERVER_HAS_OPEN_HANDLES
 Language=English
 ERROR_SERVER_HAS_OPEN_HANDLES - The server is in use and cannot be unloaded.
 .
+Language=Russian
+ERROR_SERVER_HAS_OPEN_HANDLES - The server is in use and cannot be unloaded.
+.
 
 MessageId=1812
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_DATA_NOT_FOUND
 Language=English
+ERROR_RESOURCE_DATA_NOT_FOUND - The specified image file did not contain a resource section.
+.
+Language=Russian
 ERROR_RESOURCE_DATA_NOT_FOUND - The specified image file did not contain a resource section.
 .
 
@@ -8887,12 +10591,18 @@ SymbolicName=ERROR_RESOURCE_TYPE_NOT_FOUND
 Language=English
 ERROR_RESOURCE_TYPE_NOT_FOUND - The specified resource type cannot be found in the image file.
 .
+Language=Russian
+ERROR_RESOURCE_TYPE_NOT_FOUND - The specified resource type cannot be found in the image file.
+.
 
 MessageId=1814
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_NAME_NOT_FOUND
 Language=English
+ERROR_RESOURCE_NAME_NOT_FOUND - The specified resource name cannot be found in the image file.
+.
+Language=Russian
 ERROR_RESOURCE_NAME_NOT_FOUND - The specified resource name cannot be found in the image file.
 .
 
@@ -8903,12 +10613,18 @@ SymbolicName=ERROR_RESOURCE_LANG_NOT_FOUND
 Language=English
 ERROR_RESOURCE_LANG_NOT_FOUND - The specified resource language ID cannot be found in the image file.
 .
+Language=Russian
+ERROR_RESOURCE_LANG_NOT_FOUND - The specified resource language ID cannot be found in the image file.
+.
 
 MessageId=1816
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_ENOUGH_QUOTA
 Language=English
+ERROR_NOT_ENOUGH_QUOTA - Not enough quota is available to process this command.
+.
+Language=Russian
 ERROR_NOT_ENOUGH_QUOTA - Not enough quota is available to process this command.
 .
 
@@ -8919,12 +10635,18 @@ SymbolicName=RPC_S_NO_INTERFACES
 Language=English
 RPC_S_NO_INTERFACES - No interfaces have been registered.
 .
+Language=Russian
+RPC_S_NO_INTERFACES - No interfaces have been registered.
+.
 
 MessageId=1818
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_CALL_CANCELLED
 Language=English
+RPC_S_CALL_CANCELLED - The remote procedure call was cancelled.
+.
+Language=Russian
 RPC_S_CALL_CANCELLED - The remote procedure call was cancelled.
 .
 
@@ -8935,12 +10657,18 @@ SymbolicName=RPC_S_BINDING_INCOMPLETE
 Language=English
 RPC_S_BINDING_INCOMPLETE - The binding handle does not contain all required information.
 .
+Language=Russian
+RPC_S_BINDING_INCOMPLETE - The binding handle does not contain all required information.
+.
 
 MessageId=1820
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_COMM_FAILURE
 Language=English
+RPC_S_COMM_FAILURE - A communications failure occurred during a remote procedure call.
+.
+Language=Russian
 RPC_S_COMM_FAILURE - A communications failure occurred during a remote procedure call.
 .
 
@@ -8951,12 +10679,18 @@ SymbolicName=RPC_S_UNSUPPORTED_AUTHN_LEVEL
 Language=English
 RPC_S_UNSUPPORTED_AUTHN_LEVEL - The requested authentication level is not supported.
 .
+Language=Russian
+RPC_S_UNSUPPORTED_AUTHN_LEVEL - The requested authentication level is not supported.
+.
 
 MessageId=1822
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NO_PRINC_NAME
 Language=English
+RPC_S_NO_PRINC_NAME - No principal name registered.
+.
+Language=Russian
 RPC_S_NO_PRINC_NAME - No principal name registered.
 .
 
@@ -8967,12 +10701,18 @@ SymbolicName=RPC_S_NOT_RPC_ERROR
 Language=English
 RPC_S_NOT_RPC_ERROR - The error specified is not a valid Windows RPC error code.
 .
+Language=Russian
+RPC_S_NOT_RPC_ERROR - The error specified is not a valid Windows RPC error code.
+.
 
 MessageId=1824
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_UUID_LOCAL_ONLY
 Language=English
+RPC_S_UUID_LOCAL_ONLY - A UUID that is valid only on this computer has been allocated.
+.
+Language=Russian
 RPC_S_UUID_LOCAL_ONLY - A UUID that is valid only on this computer has been allocated.
 .
 
@@ -8983,12 +10723,18 @@ SymbolicName=RPC_S_SEC_PKG_ERROR
 Language=English
 RPC_S_SEC_PKG_ERROR - A security package specific error occurred.
 .
+Language=Russian
+RPC_S_SEC_PKG_ERROR - A security package specific error occurred.
+.
 
 MessageId=1826
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NOT_CANCELLED
 Language=English
+RPC_S_NOT_CANCELLED - Thread is not canceled.
+.
+Language=Russian
 RPC_S_NOT_CANCELLED - Thread is not canceled.
 .
 
@@ -8999,12 +10745,18 @@ SymbolicName=RPC_X_INVALID_ES_ACTION
 Language=English
 RPC_X_INVALID_ES_ACTION - Invalid operation on the encoding/decoding handle.
 .
+Language=Russian
+RPC_X_INVALID_ES_ACTION - Invalid operation on the encoding/decoding handle.
+.
 
 MessageId=1828
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_WRONG_ES_VERSION
 Language=English
+RPC_X_WRONG_ES_VERSION - Incompatible version of the serializing package.
+.
+Language=Russian
 RPC_X_WRONG_ES_VERSION - Incompatible version of the serializing package.
 .
 
@@ -9015,12 +10767,18 @@ SymbolicName=RPC_X_WRONG_STUB_VERSION
 Language=English
 RPC_X_WRONG_STUB_VERSION - Incompatible version of the RPC stub.
 .
+Language=Russian
+RPC_X_WRONG_STUB_VERSION - Incompatible version of the RPC stub.
+.
 
 MessageId=1830
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_INVALID_PIPE_OBJECT
 Language=English
+RPC_X_INVALID_PIPE_OBJECT - The RPC pipe object is invalid or corrupted.
+.
+Language=Russian
 RPC_X_INVALID_PIPE_OBJECT - The RPC pipe object is invalid or corrupted.
 .
 
@@ -9031,12 +10789,18 @@ SymbolicName=RPC_X_WRONG_PIPE_ORDER
 Language=English
 RPC_X_WRONG_PIPE_ORDER - An invalid operation was attempted on an RPC pipe object.
 .
+Language=Russian
+RPC_X_WRONG_PIPE_ORDER - An invalid operation was attempted on an RPC pipe object.
+.
 
 MessageId=1832
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_WRONG_PIPE_VERSION
 Language=English
+RPC_X_WRONG_PIPE_VERSION - Unsupported RPC pipe version.
+.
+Language=Russian
 RPC_X_WRONG_PIPE_VERSION - Unsupported RPC pipe version.
 .
 
@@ -9047,12 +10811,18 @@ SymbolicName=RPC_S_GROUP_MEMBER_NOT_FOUND
 Language=English
 RPC_S_GROUP_MEMBER_NOT_FOUND - The group member was not found.
 .
+Language=Russian
+RPC_S_GROUP_MEMBER_NOT_FOUND - The group member was not found.
+.
 
 MessageId=1899
 Severity=Success
 Facility=System
 SymbolicName=EPT_S_CANT_CREATE
 Language=English
+EPT_S_CANT_CREATE - The endpoint mapper database entry could not be created.
+.
+Language=Russian
 EPT_S_CANT_CREATE - The endpoint mapper database entry could not be created.
 .
 
@@ -9063,12 +10833,18 @@ SymbolicName=RPC_S_INVALID_OBJECT
 Language=English
 RPC_S_INVALID_OBJECT - The object universal unique identifier (UUID) is the nil UUID.
 .
+Language=Russian
+RPC_S_INVALID_OBJECT - The object universal unique identifier (UUID) is the nil UUID.
+.
 
 MessageId=1901
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_TIME
 Language=English
+ERROR_INVALID_TIME - The specified time is invalid.
+.
+Language=Russian
 ERROR_INVALID_TIME - The specified time is invalid.
 .
 
@@ -9079,12 +10855,18 @@ SymbolicName=ERROR_INVALID_FORM_NAME
 Language=English
 ERROR_INVALID_FORM_NAME - The specified form name is invalid.
 .
+Language=Russian
+ERROR_INVALID_FORM_NAME - The specified form name is invalid.
+.
 
 MessageId=1903
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_FORM_SIZE
 Language=English
+ERROR_INVALID_FORM_SIZE - The specified form size is invalid.
+.
+Language=Russian
 ERROR_INVALID_FORM_SIZE - The specified form size is invalid.
 .
 
@@ -9095,12 +10877,18 @@ SymbolicName=ERROR_ALREADY_WAITING
 Language=English
 ERROR_ALREADY_WAITING - The specified printer handle is already being waited on
 .
+Language=Russian
+ERROR_ALREADY_WAITING - The specified printer handle is already being waited on
+.
 
 MessageId=1905
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINTER_DELETED
 Language=English
+ERROR_PRINTER_DELETED - The specified printer has been deleted.
+.
+Language=Russian
 ERROR_PRINTER_DELETED - The specified printer has been deleted.
 .
 
@@ -9111,12 +10899,18 @@ SymbolicName=ERROR_INVALID_PRINTER_STATE
 Language=English
 ERROR_INVALID_PRINTER_STATE - The state of the printer is invalid.
 .
+Language=Russian
+ERROR_INVALID_PRINTER_STATE - The state of the printer is invalid.
+.
 
 MessageId=1907
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PASSWORD_MUST_CHANGE
 Language=English
+ERROR_PASSWORD_MUST_CHANGE - The user's password must be changed before logging on the first time.
+.
+Language=Russian
 ERROR_PASSWORD_MUST_CHANGE - The user's password must be changed before logging on the first time.
 .
 
@@ -9127,12 +10921,18 @@ SymbolicName=ERROR_DOMAIN_CONTROLLER_NOT_FOUND
 Language=English
 ERROR_DOMAIN_CONTROLLER_NOT_FOUND - Could not find the domain controller for this domain.
 .
+Language=Russian
+ERROR_DOMAIN_CONTROLLER_NOT_FOUND - Could not find the domain controller for this domain.
+.
 
 MessageId=1909
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ACCOUNT_LOCKED_OUT
 Language=English
+ERROR_ACCOUNT_LOCKED_OUT - The referenced account is currently locked out and may not be used to log on.
+.
+Language=Russian
 ERROR_ACCOUNT_LOCKED_OUT - The referenced account is currently locked out and may not be used to log on.
 .
 
@@ -9143,12 +10943,18 @@ SymbolicName=OR_INVALID_OXID
 Language=English
 OR_INVALID_OXID - The object exporter specified was not found.
 .
+Language=Russian
+OR_INVALID_OXID - The object exporter specified was not found.
+.
 
 MessageId=1911
 Severity=Success
 Facility=System
 SymbolicName=OR_INVALID_OID
 Language=English
+OR_INVALID_OID - The object specified was not found.
+.
+Language=Russian
 OR_INVALID_OID - The object specified was not found.
 .
 
@@ -9159,12 +10965,18 @@ SymbolicName=OR_INVALID_SET
 Language=English
 OR_INVALID_SET - The object resolver set specified was not found.
 .
+Language=Russian
+OR_INVALID_SET - The object resolver set specified was not found.
+.
 
 MessageId=1913
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_SEND_INCOMPLETE
 Language=English
+RPC_S_SEND_INCOMPLETE - Some data remains to be sent in the request buffer.
+.
+Language=Russian
 RPC_S_SEND_INCOMPLETE - Some data remains to be sent in the request buffer.
 .
 
@@ -9175,12 +10987,18 @@ SymbolicName=RPC_S_INVALID_ASYNC_HANDLE
 Language=English
 RPC_S_INVALID_ASYNC_HANDLE - Invalid asynchronous remote procedure call handle.
 .
+Language=Russian
+RPC_S_INVALID_ASYNC_HANDLE - Invalid asynchronous remote procedure call handle.
+.
 
 MessageId=1915
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_INVALID_ASYNC_CALL
 Language=English
+RPC_S_INVALID_ASYNC_CALL - Invalid asynchronous RPC call handle for this operation.
+.
+Language=Russian
 RPC_S_INVALID_ASYNC_CALL - Invalid asynchronous RPC call handle for this operation.
 .
 
@@ -9191,12 +11009,18 @@ SymbolicName=RPC_X_PIPE_CLOSED
 Language=English
 RPC_X_PIPE_CLOSED - The RPC pipe object has already been closed.
 .
+Language=Russian
+RPC_X_PIPE_CLOSED - The RPC pipe object has already been closed.
+.
 
 MessageId=1917
 Severity=Success
 Facility=System
 SymbolicName=RPC_X_PIPE_DISCIPLINE_ERROR
 Language=English
+RPC_X_PIPE_DISCIPLINE_ERROR - The RPC call completed before all pipes were processed.
+.
+Language=Russian
 RPC_X_PIPE_DISCIPLINE_ERROR - The RPC call completed before all pipes were processed.
 .
 
@@ -9207,12 +11031,18 @@ SymbolicName=RPC_X_PIPE_EMPTY
 Language=English
 RPC_X_PIPE_EMPTY - No more data is available from the RPC pipe.
 .
+Language=Russian
+RPC_X_PIPE_EMPTY - No more data is available from the RPC pipe.
+.
 
 MessageId=1919
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_SITENAME
 Language=English
+ERROR_NO_SITENAME - No site name is available for this machine.
+.
+Language=Russian
 ERROR_NO_SITENAME - No site name is available for this machine.
 .
 
@@ -9223,12 +11053,18 @@ SymbolicName=ERROR_CANT_ACCESS_FILE
 Language=English
 ERROR_CANT_ACCESS_FILE - The file cannot be accessed by the system.
 .
+Language=Russian
+ERROR_CANT_ACCESS_FILE - The file cannot be accessed by the system.
+.
 
 MessageId=1921
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANT_RESOLVE_FILENAME
 Language=English
+ERROR_CANT_RESOLVE_FILENAME - The name of the file cannot be resolved by the system.
+.
+Language=Russian
 ERROR_CANT_RESOLVE_FILENAME - The name of the file cannot be resolved by the system.
 .
 
@@ -9239,12 +11075,18 @@ SymbolicName=RPC_S_ENTRY_TYPE_MISMATCH
 Language=English
 RPC_S_ENTRY_TYPE_MISMATCH - The entry is not of the expected type.
 .
+Language=Russian
+RPC_S_ENTRY_TYPE_MISMATCH - The entry is not of the expected type.
+.
 
 MessageId=1923
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_NOT_ALL_OBJS_EXPORTED
 Language=English
+RPC_S_NOT_ALL_OBJS_EXPORTED - Not all object UUIDs could be exported to the specified entry.
+.
+Language=Russian
 RPC_S_NOT_ALL_OBJS_EXPORTED - Not all object UUIDs could be exported to the specified entry.
 .
 
@@ -9255,12 +11097,18 @@ SymbolicName=RPC_S_INTERFACE_NOT_EXPORTED
 Language=English
 RPC_S_INTERFACE_NOT_EXPORTED - Interface could not be exported to the specified entry.
 .
+Language=Russian
+RPC_S_INTERFACE_NOT_EXPORTED - Interface could not be exported to the specified entry.
+.
 
 MessageId=1925
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_PROFILE_NOT_ADDED
 Language=English
+RPC_S_PROFILE_NOT_ADDED - The specified profile entry could not be added.
+.
+Language=Russian
 RPC_S_PROFILE_NOT_ADDED - The specified profile entry could not be added.
 .
 
@@ -9271,12 +11119,18 @@ SymbolicName=RPC_S_PRF_ELT_NOT_ADDED
 Language=English
 RPC_S_PRF_ELT_NOT_ADDED - The specified profile element could not be added.
 .
+Language=Russian
+RPC_S_PRF_ELT_NOT_ADDED - The specified profile element could not be added.
+.
 
 MessageId=1927
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_PRF_ELT_NOT_REMOVED
 Language=English
+RPC_S_PRF_ELT_NOT_REMOVED - The specified profile element could not be removed.
+.
+Language=Russian
 RPC_S_PRF_ELT_NOT_REMOVED - The specified profile element could not be removed.
 .
 
@@ -9287,12 +11141,18 @@ SymbolicName=RPC_S_GRP_ELT_NOT_ADDED
 Language=English
 RPC_S_GRP_ELT_NOT_ADDED - The group element could not be added.
 .
+Language=Russian
+RPC_S_GRP_ELT_NOT_ADDED - The group element could not be added.
+.
 
 MessageId=1929
 Severity=Success
 Facility=System
 SymbolicName=RPC_S_GRP_ELT_NOT_REMOVED
 Language=English
+RPC_S_GRP_ELT_NOT_REMOVED - The group element could not be removed.
+.
+Language=Russian
 RPC_S_GRP_ELT_NOT_REMOVED - The group element could not be removed.
 .
 
@@ -9303,12 +11163,18 @@ SymbolicName=ERROR_KM_DRIVER_BLOCKED
 Language=English
 ERROR_KM_DRIVER_BLOCKED - The printer driver is not compatible with a policy enabled on your computer that blocks NT 4.0 drivers.
 .
+Language=Russian
+ERROR_KM_DRIVER_BLOCKED - The printer driver is not compatible with a policy enabled on your computer that blocks NT 4.0 drivers.
+.
 
 MessageId=1931
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CONTEXT_EXPIRED
 Language=English
+ERROR_CONTEXT_EXPIRED - The context has expired and can no longer be used.
+.
+Language=Russian
 ERROR_CONTEXT_EXPIRED - The context has expired and can no longer be used.
 .
 
@@ -9319,12 +11185,18 @@ SymbolicName=ERROR_PER_USER_TRUST_QUOTA_EXCEEDED
 Language=English
 ERROR_PER_USER_TRUST_QUOTA_EXCEEDED - The current user's delegated trust creation quota has been exceeded.
 .
+Language=Russian
+ERROR_PER_USER_TRUST_QUOTA_EXCEEDED - The current user's delegated trust creation quota has been exceeded.
+.
 
 MessageId=1933
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ALL_USER_TRUST_QUOTA_EXCEEDED
 Language=English
+ERROR_ALL_USER_TRUST_QUOTA_EXCEEDED - The total delegated trust creation quota has been exceeded.
+.
+Language=Russian
 ERROR_ALL_USER_TRUST_QUOTA_EXCEEDED - The total delegated trust creation quota has been exceeded.
 .
 
@@ -9335,12 +11207,18 @@ SymbolicName=ERROR_USER_DELETE_TRUST_QUOTA_EXCEEDED
 Language=English
 ERROR_USER_DELETE_TRUST_QUOTA_EXCEEDED - The current user's delegated trust deletion quota has been exceeded.
 .
+Language=Russian
+ERROR_USER_DELETE_TRUST_QUOTA_EXCEEDED - The current user's delegated trust deletion quota has been exceeded.
+.
 
 MessageId=2000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_PIXEL_FORMAT
 Language=English
+ERROR_INVALID_PIXEL_FORMAT - The pixel format is invalid.
+.
+Language=Russian
 ERROR_INVALID_PIXEL_FORMAT - The pixel format is invalid.
 .
 
@@ -9351,12 +11229,18 @@ SymbolicName=ERROR_BAD_DRIVER
 Language=English
 ERROR_BAD_DRIVER - The specified driver is invalid.
 .
+Language=Russian
+ERROR_BAD_DRIVER - The specified driver is invalid.
+.
 
 MessageId=2002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_WINDOW_STYLE
 Language=English
+ERROR_INVALID_WINDOW_STYLE - The window style or class attribute is invalid for this operation.
+.
+Language=Russian
 ERROR_INVALID_WINDOW_STYLE - The window style or class attribute is invalid for this operation.
 .
 
@@ -9367,12 +11251,18 @@ SymbolicName=ERROR_METAFILE_NOT_SUPPORTED
 Language=English
 ERROR_METAFILE_NOT_SUPPORTED - The requested metafile operation is not supported.
 .
+Language=Russian
+ERROR_METAFILE_NOT_SUPPORTED - The requested metafile operation is not supported.
+.
 
 MessageId=2004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TRANSFORM_NOT_SUPPORTED
 Language=English
+ERROR_TRANSFORM_NOT_SUPPORTED - The requested transformation operation is not supported.
+.
+Language=Russian
 ERROR_TRANSFORM_NOT_SUPPORTED - The requested transformation operation is not supported.
 .
 
@@ -9383,12 +11273,18 @@ SymbolicName=ERROR_CLIPPING_NOT_SUPPORTED
 Language=English
 ERROR_CLIPPING_NOT_SUPPORTED - The requested clipping operation is not supported.
 .
+Language=Russian
+ERROR_CLIPPING_NOT_SUPPORTED - The requested clipping operation is not supported.
+.
 
 MessageId=2010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_CMM
 Language=English
+ERROR_INVALID_CMM - The specified color management module is invalid.
+.
+Language=Russian
 ERROR_INVALID_CMM - The specified color management module is invalid.
 .
 
@@ -9399,12 +11295,18 @@ SymbolicName=ERROR_INVALID_PROFILE
 Language=English
 ERROR_INVALID_PROFILE - The specified color profile is invalid.
 .
+Language=Russian
+ERROR_INVALID_PROFILE - The specified color profile is invalid.
+.
 
 MessageId=2012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TAG_NOT_FOUND
 Language=English
+ERROR_TAG_NOT_FOUND - The specified tag was not found.
+.
+Language=Russian
 ERROR_TAG_NOT_FOUND - The specified tag was not found.
 .
 
@@ -9415,12 +11317,18 @@ SymbolicName=ERROR_TAG_NOT_PRESENT
 Language=English
 ERROR_TAG_NOT_PRESENT - A required tag is not present.
 .
+Language=Russian
+ERROR_TAG_NOT_PRESENT - A required tag is not present.
+.
 
 MessageId=2014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DUPLICATE_TAG
 Language=English
+ERROR_DUPLICATE_TAG - The specified tag is already present.
+.
+Language=Russian
 ERROR_DUPLICATE_TAG - The specified tag is already present.
 .
 
@@ -9431,12 +11339,18 @@ SymbolicName=ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE
 Language=English
 ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE - The specified color profile is not associated with any device.
 .
+Language=Russian
+ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE - The specified color profile is not associated with any device.
+.
 
 MessageId=2016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PROFILE_NOT_FOUND
 Language=English
+ERROR_PROFILE_NOT_FOUND - The specified color profile was not found.
+.
+Language=Russian
 ERROR_PROFILE_NOT_FOUND - The specified color profile was not found.
 .
 
@@ -9447,12 +11361,18 @@ SymbolicName=ERROR_INVALID_COLORSPACE
 Language=English
 ERROR_INVALID_COLORSPACE - The specified color space is invalid.
 .
+Language=Russian
+ERROR_INVALID_COLORSPACE - The specified color space is invalid.
+.
 
 MessageId=2018
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ICM_NOT_ENABLED
 Language=English
+ERROR_ICM_NOT_ENABLED - Image Color Management is not enabled.
+.
+Language=Russian
 ERROR_ICM_NOT_ENABLED - Image Color Management is not enabled.
 .
 
@@ -9463,12 +11383,18 @@ SymbolicName=ERROR_DELETING_ICM_XFORM
 Language=English
 ERROR_DELETING_ICM_XFORM - There was an error while deleting the color transform.
 .
+Language=Russian
+ERROR_DELETING_ICM_XFORM - There was an error while deleting the color transform.
+.
 
 MessageId=2020
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_TRANSFORM
 Language=English
+ERROR_INVALID_TRANSFORM - The specified color transform is invalid.
+.
+Language=Russian
 ERROR_INVALID_TRANSFORM - The specified color transform is invalid.
 .
 
@@ -9479,12 +11405,18 @@ SymbolicName=ERROR_COLORSPACE_MISMATCH
 Language=English
 ERROR_COLORSPACE_MISMATCH - The specified transform does not match the bitmap's color space.
 .
+Language=Russian
+ERROR_COLORSPACE_MISMATCH - The specified transform does not match the bitmap's color space.
+.
 
 MessageId=2022
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_COLORINDEX
 Language=English
+ERROR_INVALID_COLORINDEX - The specified named color index is not present in the profile.
+.
+Language=Russian
 ERROR_INVALID_COLORINDEX - The specified named color index is not present in the profile.
 .
 
@@ -9495,12 +11427,18 @@ SymbolicName=ERROR_CONNECTED_OTHER_PASSWORD
 Language=English
 ERROR_CONNECTED_OTHER_PASSWORD - The network connection was made successfully, but the user had to be prompted for a password other than the one originally specified.
 .
+Language=Russian
+ERROR_CONNECTED_OTHER_PASSWORD - The network connection was made successfully, but the user had to be prompted for a password other than the one originally specified.
+.
 
 MessageId=2109
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CONNECTED_OTHER_PASSWORD_DEFAULT
 Language=English
+ERROR_CONNECTED_OTHER_PASSWORD_DEFAULT - The network connection was made successfully using default credentials.
+.
+Language=Russian
 ERROR_CONNECTED_OTHER_PASSWORD_DEFAULT - The network connection was made successfully using default credentials.
 .
 
@@ -9511,12 +11449,18 @@ SymbolicName=ERROR_BAD_USERNAME
 Language=English
 ERROR_BAD_USERNAME - The specified username is invalid.
 .
+Language=Russian
+ERROR_BAD_USERNAME - The specified username is invalid.
+.
 
 MessageId=2250
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_CONNECTED
 Language=English
+ERROR_NOT_CONNECTED - This network connection does not exist.
+.
+Language=Russian
 ERROR_NOT_CONNECTED - This network connection does not exist.
 .
 
@@ -9527,12 +11471,18 @@ SymbolicName=ERROR_OPEN_FILES
 Language=English
 ERROR_OPEN_FILES - This network connection has files open or requests pending.
 .
+Language=Russian
+ERROR_OPEN_FILES - This network connection has files open or requests pending.
+.
 
 MessageId=2402
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ACTIVE_CONNECTIONS
 Language=English
+ERROR_ACTIVE_CONNECTIONS - Active connections still exist.
+.
+Language=Russian
 ERROR_ACTIVE_CONNECTIONS - Active connections still exist.
 .
 
@@ -9543,12 +11493,18 @@ SymbolicName=ERROR_DEVICE_IN_USE
 Language=English
 ERROR_DEVICE_IN_USE - The device is in use by an active process and cannot be disconnected.
 .
+Language=Russian
+ERROR_DEVICE_IN_USE - The device is in use by an active process and cannot be disconnected.
+.
 
 MessageId=3000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNKNOWN_PRINT_MONITOR
 Language=English
+ERROR_UNKNOWN_PRINT_MONITOR - The specified print monitor is unknown.
+.
+Language=Russian
 ERROR_UNKNOWN_PRINT_MONITOR - The specified print monitor is unknown.
 .
 
@@ -9559,12 +11515,18 @@ SymbolicName=ERROR_PRINTER_DRIVER_IN_USE
 Language=English
 ERROR_PRINTER_DRIVER_IN_USE - The specified printer driver is currently in use.
 .
+Language=Russian
+ERROR_PRINTER_DRIVER_IN_USE - The specified printer driver is currently in use.
+.
 
 MessageId=3002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SPOOL_FILE_NOT_FOUND
 Language=English
+ERROR_SPOOL_FILE_NOT_FOUND - The spool file was not found.
+.
+Language=Russian
 ERROR_SPOOL_FILE_NOT_FOUND - The spool file was not found.
 .
 
@@ -9575,12 +11537,18 @@ SymbolicName=ERROR_SPL_NO_STARTDOC
 Language=English
 ERROR_SPL_NO_STARTDOC - A StartDocPrinter call was not issued.
 .
+Language=Russian
+ERROR_SPL_NO_STARTDOC - A StartDocPrinter call was not issued.
+.
 
 MessageId=3004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SPL_NO_ADDJOB
 Language=English
+ERROR_SPL_NO_ADDJOB - An AddJob call was not issued.
+.
+Language=Russian
 ERROR_SPL_NO_ADDJOB - An AddJob call was not issued.
 .
 
@@ -9591,12 +11559,18 @@ SymbolicName=ERROR_PRINT_PROCESSOR_ALREADY_INSTALLED
 Language=English
 ERROR_PRINT_PROCESSOR_ALREADY_INSTALLED - The specified print processor has already been installed.
 .
+Language=Russian
+ERROR_PRINT_PROCESSOR_ALREADY_INSTALLED - The specified print processor has already been installed.
+.
 
 MessageId=3006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINT_MONITOR_ALREADY_INSTALLED
 Language=English
+ERROR_PRINT_MONITOR_ALREADY_INSTALLED - The specified print monitor has already been installed.
+.
+Language=Russian
 ERROR_PRINT_MONITOR_ALREADY_INSTALLED - The specified print monitor has already been installed.
 .
 
@@ -9607,12 +11581,18 @@ SymbolicName=ERROR_INVALID_PRINT_MONITOR
 Language=English
 ERROR_INVALID_PRINT_MONITOR - The specified print monitor does not have the required functions.
 .
+Language=Russian
+ERROR_INVALID_PRINT_MONITOR - The specified print monitor does not have the required functions.
+.
 
 MessageId=3008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINT_MONITOR_IN_USE
 Language=English
+ERROR_PRINT_MONITOR_IN_USE - The specified print monitor is currently in use.
+.
+Language=Russian
 ERROR_PRINT_MONITOR_IN_USE - The specified print monitor is currently in use.
 .
 
@@ -9623,12 +11603,18 @@ SymbolicName=ERROR_PRINTER_HAS_JOBS_QUEUED
 Language=English
 ERROR_PRINTER_HAS_JOBS_QUEUED - The requested operation is not allowed when there are jobs queued to the printer.
 .
+Language=Russian
+ERROR_PRINTER_HAS_JOBS_QUEUED - The requested operation is not allowed when there are jobs queued to the printer.
+.
 
 MessageId=3010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SUCCESS_REBOOT_REQUIRED
 Language=English
+ERROR_SUCCESS_REBOOT_REQUIRED - The requested operation is successful. Changes will not be effective until the system is rebooted.
+.
+Language=Russian
 ERROR_SUCCESS_REBOOT_REQUIRED - The requested operation is successful. Changes will not be effective until the system is rebooted.
 .
 
@@ -9639,12 +11625,18 @@ SymbolicName=ERROR_SUCCESS_RESTART_REQUIRED
 Language=English
 ERROR_SUCCESS_RESTART_REQUIRED - The requested operation is successful. Changes will not be effective until the service is restarted.
 .
+Language=Russian
+ERROR_SUCCESS_RESTART_REQUIRED - The requested operation is successful. Changes will not be effective until the service is restarted.
+.
 
 MessageId=3012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINTER_NOT_FOUND
 Language=English
+ERROR_PRINTER_NOT_FOUND - No printers were found.
+.
+Language=Russian
 ERROR_PRINTER_NOT_FOUND - No printers were found.
 .
 
@@ -9655,12 +11647,18 @@ SymbolicName=ERROR_PRINTER_DRIVER_WARNED
 Language=English
 ERROR_PRINTER_DRIVER_WARNED - The printer driver is known to be unreliable.
 .
+Language=Russian
+ERROR_PRINTER_DRIVER_WARNED - The printer driver is known to be unreliable.
+.
 
 MessageId=3014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PRINTER_DRIVER_BLOCKED
 Language=English
+ERROR_PRINTER_DRIVER_BLOCKED - The printer driver is known to harm the system.
+.
+Language=Russian
 ERROR_PRINTER_DRIVER_BLOCKED - The printer driver is known to harm the system.
 .
 
@@ -9671,12 +11669,18 @@ SymbolicName=ERROR_XML_UNDEFINED_ENTITY
 Language=English
 ERROR_XML_UNDEFINED_ENTITY - The XML contains an entity reference to an undefined entity.
 .
+Language=Russian
+ERROR_XML_UNDEFINED_ENTITY - The XML contains an entity reference to an undefined entity.
+.
 
 MessageId=3101
 Severity=Success
 Facility=System
 SymbolicName=ERROR_XML_MALFORMED_ENTITY
 Language=English
+ERROR_XML_MALFORMED_ENTITY - The XML contains a malformed entity reference.
+.
+Language=Russian
 ERROR_XML_MALFORMED_ENTITY - The XML contains a malformed entity reference.
 .
 
@@ -9687,12 +11691,18 @@ SymbolicName=ERROR_XML_CHAR_NOT_IN_RANGE
 Language=English
 ERROR_XML_CHAR_NOT_IN_RANGE - The XML contains a character which is not permitted in XML.
 .
+Language=Russian
+ERROR_XML_CHAR_NOT_IN_RANGE - The XML contains a character which is not permitted in XML.
+.
 
 MessageId=3200
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_EXTERNAL_PROXY
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_EXTERNAL_PROXY - The manifest contained a duplicate definition for external proxy stub %1 at (%1:%2,%3)
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_EXTERNAL_PROXY - The manifest contained a duplicate definition for external proxy stub %1 at (%1:%2,%3)
 .
 
@@ -9703,12 +11713,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_ASSEMBLY_REFERENCE
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_ASSEMBLY_REFERENCE - The manifest already contains a reference to %4 - a second reference was found at (%1:%2,%3)
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_ASSEMBLY_REFERENCE - The manifest already contains a reference to %4 - a second reference was found at (%1:%2,%3)
+.
 
 MessageId=3202
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_INVALID_ASSEMBLY_REFERENCE
 Language=English
+ERROR_PCM_COMPILER_INVALID_ASSEMBLY_REFERENCE - The assembly reference at (%1:%2,%3) is invalid.
+.
+Language=Russian
 ERROR_PCM_COMPILER_INVALID_ASSEMBLY_REFERENCE - The assembly reference at (%1:%2,%3) is invalid.
 .
 
@@ -9719,12 +11735,18 @@ SymbolicName=ERROR_PCM_COMPILER_INVALID_ASSEMBLY_DEFINITION
 Language=English
 ERROR_PCM_COMPILER_INVALID_ASSEMBLY_DEFINITION - The assembly definition at (%1:%2,%3) is invalid.
 .
+Language=Russian
+ERROR_PCM_COMPILER_INVALID_ASSEMBLY_DEFINITION - The assembly definition at (%1:%2,%3) is invalid.
+.
 
 MessageId=3204
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_WINDOW_CLASS
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_WINDOW_CLASS - The manifest already contained the window class %4, found a second declaration at (%1:%2,%3)
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_WINDOW_CLASS - The manifest already contained the window class %4, found a second declaration at (%1:%2,%3)
 .
 
@@ -9735,12 +11757,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_PROGID
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_PROGID - The manifest already declared the progId %4, found a second declaration at (%1:%2,%3)
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_PROGID - The manifest already declared the progId %4, found a second declaration at (%1:%2,%3)
+.
 
 MessageId=3206
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_NOINHERIT
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_NOINHERIT - Only one noInherit tag may be present in a manifest, found a second tag at (%1:%2,%3)
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_NOINHERIT - Only one noInherit tag may be present in a manifest, found a second tag at (%1:%2,%3)
 .
 
@@ -9751,12 +11779,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_NOINHERITABLE
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_NOINHERITABLE - Only one noInheritable tag may be present in a manifest, found a second tag at (%1:%2,%3)
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_NOINHERITABLE - Only one noInheritable tag may be present in a manifest, found a second tag at (%1:%2,%3)
+.
 
 MessageId=3208
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_COM_CLASS
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_COM_CLASS - The manifest contained a duplicate declaration of COM class %4 at (%1:%2,%3)
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_COM_CLASS - The manifest contained a duplicate declaration of COM class %4 at (%1:%2,%3)
 .
 
@@ -9767,12 +11801,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_FILE_NAME
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_FILE_NAME - The manifest already declared the file %4, a second definition was found at (%1:%2,%3)
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_FILE_NAME - The manifest already declared the file %4, a second definition was found at (%1:%2,%3)
+.
 
 MessageId=3210
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_CLR_SURROGATE
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_CLR_SURROGATE - CLR surrogate %1 was already defined, second definition at (%1:%2,%3) is invalid.
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_CLR_SURROGATE - CLR surrogate %1 was already defined, second definition at (%1:%2,%3) is invalid.
 .
 
@@ -9783,12 +11823,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_TYPE_LIBRARY
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_TYPE_LIBRARY - Type library %1 was already defined, second definition at (%1:%2,%3) is invalid.
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_TYPE_LIBRARY - Type library %1 was already defined, second definition at (%1:%2,%3) is invalid.
+.
 
 MessageId=3212
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_PROXY_STUB
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_PROXY_STUB - Proxy stub definition %1 was already defined, second definition at (%1:%2,%3) is invalid.
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_PROXY_STUB - Proxy stub definition %1 was already defined, second definition at (%1:%2,%3) is invalid.
 .
 
@@ -9799,12 +11845,18 @@ SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_CATEGORY_NAME
 Language=English
 ERROR_PCM_COMPILER_DUPLICATE_CATEGORY_NAME - Category friendly name %4 was already used, second definition was found at (%1:%2,%3) is invalid.
 .
+Language=Russian
+ERROR_PCM_COMPILER_DUPLICATE_CATEGORY_NAME - Category friendly name %4 was already used, second definition was found at (%1:%2,%3) is invalid.
+.
 
 MessageId=3214
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_DUPLICATE_TOP_LEVEL_IDENTITY_FOUND
 Language=English
+ERROR_PCM_COMPILER_DUPLICATE_TOP_LEVEL_IDENTITY_FOUND - Only one top-level assemblyIdentity tag may be present in a manifest. A second tag with identity %4 was found at (%1:%2,%3)
+.
+Language=Russian
 ERROR_PCM_COMPILER_DUPLICATE_TOP_LEVEL_IDENTITY_FOUND - Only one top-level assemblyIdentity tag may be present in a manifest. A second tag with identity %4 was found at (%1:%2,%3)
 .
 
@@ -9815,12 +11867,18 @@ SymbolicName=ERROR_PCM_COMPILER_UNKNOWN_ROOT_ELEMENT
 Language=English
 ERROR_PCM_COMPILER_UNKNOWN_ROOT_ELEMENT - The root element for a manifest found at (%1:%2,%3) was not expected or was of the wrong version.
 .
+Language=Russian
+ERROR_PCM_COMPILER_UNKNOWN_ROOT_ELEMENT - The root element for a manifest found at (%1:%2,%3) was not expected or was of the wrong version.
+.
 
 MessageId=3216
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_INVALID_ELEMENT
 Language=English
+ERROR_PCM_COMPILER_INVALID_ELEMENT - The element found at (%1:%2,%3) was not expected according to the manifest schema.
+.
+Language=Russian
 ERROR_PCM_COMPILER_INVALID_ELEMENT - The element found at (%1:%2,%3) was not expected according to the manifest schema.
 .
 
@@ -9831,12 +11889,18 @@ SymbolicName=ERROR_PCM_COMPILER_MISSING_REQUIRED_ATTRIBUTE
 Language=English
 ERROR_PCM_COMPILER_MISSING_REQUIRED_ATTRIBUTE - The element found at (%1:%2,%3) was missing the required attribute '%4'. See the manifest schema for more information
 .
+Language=Russian
+ERROR_PCM_COMPILER_MISSING_REQUIRED_ATTRIBUTE - The element found at (%1:%2,%3) was missing the required attribute '%4'. See the manifest schema for more information
+.
 
 MessageId=3218
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_COMPILER_INVALID_ATTRIBUTE_VALUE
 Language=English
+ERROR_PCM_COMPILER_INVALID_ATTRIBUTE_VALUE - The attribute value %4 at (%1:%2,%3) was invalid according to the schema.
+.
+Language=Russian
 ERROR_PCM_COMPILER_INVALID_ATTRIBUTE_VALUE - The attribute value %4 at (%1:%2,%3) was invalid according to the schema.
 .
 
@@ -9847,12 +11911,18 @@ SymbolicName=ERROR_PCM_COMPILER_UNEXPECTED_PCDATA
 Language=English
 ERROR_PCM_COMPILER_UNEXPECTED_PCDATA - PCDATA or CDATA found at (%1:%2,%3) in the source document was not expected in the parent element %4.
 .
+Language=Russian
+ERROR_PCM_COMPILER_UNEXPECTED_PCDATA - PCDATA or CDATA found at (%1:%2,%3) in the source document was not expected in the parent element %4.
+.
 
 MessageId=3220
 Severity=Success
 Facility=System
 SymbolicName=ERROR_PCM_DUPLICATE_STRING_TABLE_ENT
 Language=English
+ERROR_PCM_DUPLICATE_STRING_TABLE_ENT - The string table entry with culture %4, name %5, and value '%6' at (%1:%2,%3) duplicated a previous entry.
+.
+Language=Russian
 ERROR_PCM_DUPLICATE_STRING_TABLE_ENT - The string table entry with culture %4, name %5, and value '%6' at (%1:%2,%3) duplicated a previous entry.
 .
 
@@ -9863,12 +11933,18 @@ SymbolicName=ERROR_WINS_INTERNAL
 Language=English
 ERROR_WINS_INTERNAL - WINS encountered an error while processing the command.
 .
+Language=Russian
+ERROR_WINS_INTERNAL - WINS encountered an error while processing the command.
+.
 
 MessageId=4001
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CAN_NOT_DEL_LOCAL_WINS
 Language=English
+ERROR_CAN_NOT_DEL_LOCAL_WINS - The local WINS cannot be deleted.
+.
+Language=Russian
 ERROR_CAN_NOT_DEL_LOCAL_WINS - The local WINS cannot be deleted.
 .
 
@@ -9879,12 +11955,18 @@ SymbolicName=ERROR_STATIC_INIT
 Language=English
 ERROR_STATIC_INIT - The importation from the file failed.
 .
+Language=Russian
+ERROR_STATIC_INIT - The importation from the file failed.
+.
 
 MessageId=4003
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INC_BACKUP
 Language=English
+ERROR_INC_BACKUP - The backup failed. Was a full backup done before?
+.
+Language=Russian
 ERROR_INC_BACKUP - The backup failed. Was a full backup done before?
 .
 
@@ -9895,12 +11977,18 @@ SymbolicName=ERROR_FULL_BACKUP
 Language=English
 ERROR_FULL_BACKUP - The backup failed. Check the directory to which you are backing the database.
 .
+Language=Russian
+ERROR_FULL_BACKUP - The backup failed. Check the directory to which you are backing the database.
+.
 
 MessageId=4005
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REC_NON_EXISTENT
 Language=English
+ERROR_REC_NON_EXISTENT - The name does not exist in the WINS database.
+.
+Language=Russian
 ERROR_REC_NON_EXISTENT - The name does not exist in the WINS database.
 .
 
@@ -9911,12 +11999,18 @@ SymbolicName=ERROR_RPL_NOT_ALLOWED
 Language=English
 ERROR_RPL_NOT_ALLOWED - Replication with a nonconfigured partner is not allowed.
 .
+Language=Russian
+ERROR_RPL_NOT_ALLOWED - Replication with a nonconfigured partner is not allowed.
+.
 
 MessageId=4100
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DHCP_ADDRESS_CONFLICT
 Language=English
+ERROR_DHCP_ADDRESS_CONFLICT - The DHCP client has obtained an IP address that is already in use on the network. The local interface will be disabled until the DHCP client can obtain a new address.
+.
+Language=Russian
 ERROR_DHCP_ADDRESS_CONFLICT - The DHCP client has obtained an IP address that is already in use on the network. The local interface will be disabled until the DHCP client can obtain a new address.
 .
 
@@ -9927,12 +12021,18 @@ SymbolicName=ERROR_WMI_GUID_NOT_FOUND
 Language=English
 ERROR_WMI_GUID_NOT_FOUND - The GUID passed was not recognized as valid by a WMI data provider.
 .
+Language=Russian
+ERROR_WMI_GUID_NOT_FOUND - The GUID passed was not recognized as valid by a WMI data provider.
+.
 
 MessageId=4201
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_INSTANCE_NOT_FOUND
 Language=English
+ERROR_WMI_INSTANCE_NOT_FOUND - The instance name passed was not recognized as valid by a WMI data provider.
+.
+Language=Russian
 ERROR_WMI_INSTANCE_NOT_FOUND - The instance name passed was not recognized as valid by a WMI data provider.
 .
 
@@ -9943,12 +12043,18 @@ SymbolicName=ERROR_WMI_ITEMID_NOT_FOUND
 Language=English
 ERROR_WMI_ITEMID_NOT_FOUND - The data item ID passed was not recognized as valid by a WMI data provider.
 .
+Language=Russian
+ERROR_WMI_ITEMID_NOT_FOUND - The data item ID passed was not recognized as valid by a WMI data provider.
+.
 
 MessageId=4203
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_TRY_AGAIN
 Language=English
+ERROR_WMI_TRY_AGAIN - The WMI request could not be completed and should be retried.
+.
+Language=Russian
 ERROR_WMI_TRY_AGAIN - The WMI request could not be completed and should be retried.
 .
 
@@ -9959,12 +12065,18 @@ SymbolicName=ERROR_WMI_DP_NOT_FOUND
 Language=English
 ERROR_WMI_DP_NOT_FOUND - The WMI data provider could not be located.
 .
+Language=Russian
+ERROR_WMI_DP_NOT_FOUND - The WMI data provider could not be located.
+.
 
 MessageId=4205
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_UNRESOLVED_INSTANCE_REF
 Language=English
+ERROR_WMI_UNRESOLVED_INSTANCE_REF - The WMI data provider references an instance set that has not been registered.
+.
+Language=Russian
 ERROR_WMI_UNRESOLVED_INSTANCE_REF - The WMI data provider references an instance set that has not been registered.
 .
 
@@ -9975,12 +12087,18 @@ SymbolicName=ERROR_WMI_ALREADY_ENABLED
 Language=English
 ERROR_WMI_ALREADY_ENABLED - The WMI data block or event notification has already been enabled.
 .
+Language=Russian
+ERROR_WMI_ALREADY_ENABLED - The WMI data block or event notification has already been enabled.
+.
 
 MessageId=4207
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_GUID_DISCONNECTED
 Language=English
+ERROR_WMI_GUID_DISCONNECTED - The WMI data block is no longer available.
+.
+Language=Russian
 ERROR_WMI_GUID_DISCONNECTED - The WMI data block is no longer available.
 .
 
@@ -9991,12 +12109,18 @@ SymbolicName=ERROR_WMI_SERVER_UNAVAILABLE
 Language=English
 ERROR_WMI_SERVER_UNAVAILABLE - The WMI data service is not available.
 .
+Language=Russian
+ERROR_WMI_SERVER_UNAVAILABLE - The WMI data service is not available.
+.
 
 MessageId=4209
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_DP_FAILED
 Language=English
+ERROR_WMI_DP_FAILED - The WMI data provider failed to carry out the request.
+.
+Language=Russian
 ERROR_WMI_DP_FAILED - The WMI data provider failed to carry out the request.
 .
 
@@ -10007,12 +12131,18 @@ SymbolicName=ERROR_WMI_INVALID_MOF
 Language=English
 ERROR_WMI_INVALID_MOF - The WMI MOF information is not valid.
 .
+Language=Russian
+ERROR_WMI_INVALID_MOF - The WMI MOF information is not valid.
+.
 
 MessageId=4211
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_INVALID_REGINFO
 Language=English
+ERROR_WMI_INVALID_REGINFO - The WMI registration information is not valid.
+.
+Language=Russian
 ERROR_WMI_INVALID_REGINFO - The WMI registration information is not valid.
 .
 
@@ -10023,12 +12153,18 @@ SymbolicName=ERROR_WMI_ALREADY_DISABLED
 Language=English
 ERROR_WMI_ALREADY_DISABLED - The WMI data block or event notification has already been disabled.
 .
+Language=Russian
+ERROR_WMI_ALREADY_DISABLED - The WMI data block or event notification has already been disabled.
+.
 
 MessageId=4213
 Severity=Success
 Facility=System
 SymbolicName=ERROR_WMI_READ_ONLY
 Language=English
+ERROR_WMI_READ_ONLY - The WMI data item or data block is read only.
+.
+Language=Russian
 ERROR_WMI_READ_ONLY - The WMI data item or data block is read only.
 .
 
@@ -10039,12 +12175,18 @@ SymbolicName=ERROR_WMI_SET_FAILURE
 Language=English
 ERROR_WMI_SET_FAILURE - The WMI data item or data block could not be changed.
 .
+Language=Russian
+ERROR_WMI_SET_FAILURE - The WMI data item or data block could not be changed.
+.
 
 MessageId=4300
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_MEDIA
 Language=English
+ERROR_INVALID_MEDIA - The media identifier does not represent a valid medium.
+.
+Language=Russian
 ERROR_INVALID_MEDIA - The media identifier does not represent a valid medium.
 .
 
@@ -10055,12 +12197,18 @@ SymbolicName=ERROR_INVALID_LIBRARY
 Language=English
 ERROR_INVALID_LIBRARY - The library identifier does not represent a valid library.
 .
+Language=Russian
+ERROR_INVALID_LIBRARY - The library identifier does not represent a valid library.
+.
 
 MessageId=4302
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_MEDIA_POOL
 Language=English
+ERROR_INVALID_MEDIA_POOL - The media pool identifier does not represent a valid media pool.
+.
+Language=Russian
 ERROR_INVALID_MEDIA_POOL - The media pool identifier does not represent a valid media pool.
 .
 
@@ -10071,12 +12219,18 @@ SymbolicName=ERROR_DRIVE_MEDIA_MISMATCH
 Language=English
 ERROR_DRIVE_MEDIA_MISMATCH - The drive and medium are not compatible or exist in different libraries.
 .
+Language=Russian
+ERROR_DRIVE_MEDIA_MISMATCH - The drive and medium are not compatible or exist in different libraries.
+.
 
 MessageId=4304
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MEDIA_OFFLINE
 Language=English
+ERROR_MEDIA_OFFLINE - The medium currently exists in an offline library and must be online to perform this operation.
+.
+Language=Russian
 ERROR_MEDIA_OFFLINE - The medium currently exists in an offline library and must be online to perform this operation.
 .
 
@@ -10087,12 +12241,18 @@ SymbolicName=ERROR_LIBRARY_OFFLINE
 Language=English
 ERROR_LIBRARY_OFFLINE - The operation cannot be performed on an offline library.
 .
+Language=Russian
+ERROR_LIBRARY_OFFLINE - The operation cannot be performed on an offline library.
+.
 
 MessageId=4306
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EMPTY
 Language=English
+ERROR_EMPTY - The library, drive, or media pool is empty.
+.
+Language=Russian
 ERROR_EMPTY - The library, drive, or media pool is empty.
 .
 
@@ -10103,12 +12263,18 @@ SymbolicName=ERROR_NOT_EMPTY
 Language=English
 ERROR_NOT_EMPTY - The library, drive, or media pool must be empty to perform this operation.
 .
+Language=Russian
+ERROR_NOT_EMPTY - The library, drive, or media pool must be empty to perform this operation.
+.
 
 MessageId=4308
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MEDIA_UNAVAILABLE
 Language=English
+ERROR_MEDIA_UNAVAILABLE - No media is currently available in this media pool or library.
+.
+Language=Russian
 ERROR_MEDIA_UNAVAILABLE - No media is currently available in this media pool or library.
 .
 
@@ -10119,12 +12285,18 @@ SymbolicName=ERROR_RESOURCE_DISABLED
 Language=English
 ERROR_RESOURCE_DISABLED - A resource required for this operation is disabled.
 .
+Language=Russian
+ERROR_RESOURCE_DISABLED - A resource required for this operation is disabled.
+.
 
 MessageId=4310
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_CLEANER
 Language=English
+ERROR_INVALID_CLEANER - The media identifier does not represent a valid cleaner.
+.
+Language=Russian
 ERROR_INVALID_CLEANER - The media identifier does not represent a valid cleaner.
 .
 
@@ -10135,12 +12307,18 @@ SymbolicName=ERROR_UNABLE_TO_CLEAN
 Language=English
 ERROR_UNABLE_TO_CLEAN - The drive cannot be cleaned or does not support cleaning.
 .
+Language=Russian
+ERROR_UNABLE_TO_CLEAN - The drive cannot be cleaned or does not support cleaning.
+.
 
 MessageId=4312
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OBJECT_NOT_FOUND
 Language=English
+ERROR_OBJECT_NOT_FOUND - The object identifier does not represent a valid object.
+.
+Language=Russian
 ERROR_OBJECT_NOT_FOUND - The object identifier does not represent a valid object.
 .
 
@@ -10151,12 +12329,18 @@ SymbolicName=ERROR_DATABASE_FAILURE
 Language=English
 ERROR_DATABASE_FAILURE - Unable to read from or write to the database.
 .
+Language=Russian
+ERROR_DATABASE_FAILURE - Unable to read from or write to the database.
+.
 
 MessageId=4314
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DATABASE_FULL
 Language=English
+ERROR_DATABASE_FULL - The database is full.
+.
+Language=Russian
 ERROR_DATABASE_FULL - The database is full.
 .
 
@@ -10167,12 +12351,18 @@ SymbolicName=ERROR_MEDIA_INCOMPATIBLE
 Language=English
 ERROR_MEDIA_INCOMPATIBLE - The medium is not compatible with the device or media pool.
 .
+Language=Russian
+ERROR_MEDIA_INCOMPATIBLE - The medium is not compatible with the device or media pool.
+.
 
 MessageId=4316
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_NOT_PRESENT
 Language=English
+ERROR_RESOURCE_NOT_PRESENT - The resource required for this operation does not exist.
+.
+Language=Russian
 ERROR_RESOURCE_NOT_PRESENT - The resource required for this operation does not exist.
 .
 
@@ -10183,12 +12373,18 @@ SymbolicName=ERROR_INVALID_OPERATION
 Language=English
 ERROR_INVALID_OPERATION - The operation identifier is not valid.
 .
+Language=Russian
+ERROR_INVALID_OPERATION - The operation identifier is not valid.
+.
 
 MessageId=4318
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MEDIA_NOT_AVAILABLE
 Language=English
+ERROR_MEDIA_NOT_AVAILABLE - The media is not mounted or ready for use.
+.
+Language=Russian
 ERROR_MEDIA_NOT_AVAILABLE - The media is not mounted or ready for use.
 .
 
@@ -10199,12 +12395,18 @@ SymbolicName=ERROR_DEVICE_NOT_AVAILABLE
 Language=English
 ERROR_DEVICE_NOT_AVAILABLE - The device is not ready for use.
 .
+Language=Russian
+ERROR_DEVICE_NOT_AVAILABLE - The device is not ready for use.
+.
 
 MessageId=4320
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REQUEST_REFUSED
 Language=English
+ERROR_REQUEST_REFUSED - The operator or administrator has refused the request.
+.
+Language=Russian
 ERROR_REQUEST_REFUSED - The operator or administrator has refused the request.
 .
 
@@ -10215,12 +12417,18 @@ SymbolicName=ERROR_INVALID_DRIVE_OBJECT
 Language=English
 ERROR_INVALID_DRIVE_OBJECT - The drive identifier does not represent a valid drive.
 .
+Language=Russian
+ERROR_INVALID_DRIVE_OBJECT - The drive identifier does not represent a valid drive.
+.
 
 MessageId=4322
 Severity=Success
 Facility=System
 SymbolicName=ERROR_LIBRARY_FULL
 Language=English
+ERROR_LIBRARY_FULL - Library is full. No slot is available for use.
+.
+Language=Russian
 ERROR_LIBRARY_FULL - Library is full. No slot is available for use.
 .
 
@@ -10231,12 +12439,18 @@ SymbolicName=ERROR_MEDIUM_NOT_ACCESSIBLE
 Language=English
 ERROR_MEDIUM_NOT_ACCESSIBLE - The transport cannot access the medium.
 .
+Language=Russian
+ERROR_MEDIUM_NOT_ACCESSIBLE - The transport cannot access the medium.
+.
 
 MessageId=4324
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNABLE_TO_LOAD_MEDIUM
 Language=English
+ERROR_UNABLE_TO_LOAD_MEDIUM - Unable to load the medium into the drive.
+.
+Language=Russian
 ERROR_UNABLE_TO_LOAD_MEDIUM - Unable to load the medium into the drive.
 .
 
@@ -10247,12 +12461,18 @@ SymbolicName=ERROR_UNABLE_TO_INVENTORY_DRIVE
 Language=English
 ERROR_UNABLE_TO_INVENTORY_DRIVE - Unable to retrieve status about the drive.
 .
+Language=Russian
+ERROR_UNABLE_TO_INVENTORY_DRIVE - Unable to retrieve status about the drive.
+.
 
 MessageId=4326
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNABLE_TO_INVENTORY_SLOT
 Language=English
+ERROR_UNABLE_TO_INVENTORY_SLOT - Unable to retrieve status about the slot.
+.
+Language=Russian
 ERROR_UNABLE_TO_INVENTORY_SLOT - Unable to retrieve status about the slot.
 .
 
@@ -10263,12 +12483,18 @@ SymbolicName=ERROR_UNABLE_TO_INVENTORY_TRANSPORT
 Language=English
 ERROR_UNABLE_TO_INVENTORY_TRANSPORT - Unable to retrieve status about the transport.
 .
+Language=Russian
+ERROR_UNABLE_TO_INVENTORY_TRANSPORT - Unable to retrieve status about the transport.
+.
 
 MessageId=4328
 Severity=Success
 Facility=System
 SymbolicName=ERROR_TRANSPORT_FULL
 Language=English
+ERROR_TRANSPORT_FULL - Cannot use the transport because it is already in use.
+.
+Language=Russian
 ERROR_TRANSPORT_FULL - Cannot use the transport because it is already in use.
 .
 
@@ -10279,12 +12505,18 @@ SymbolicName=ERROR_CONTROLLING_IEPORT
 Language=English
 ERROR_CONTROLLING_IEPORT - Unable to open or close the inject/eject port.
 .
+Language=Russian
+ERROR_CONTROLLING_IEPORT - Unable to open or close the inject/eject port.
+.
 
 MessageId=4330
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNABLE_TO_EJECT_MOUNTED_MEDIA
 Language=English
+ERROR_UNABLE_TO_EJECT_MOUNTED_MEDIA - Unable to eject the media because it is in a drive.
+.
+Language=Russian
 ERROR_UNABLE_TO_EJECT_MOUNTED_MEDIA - Unable to eject the media because it is in a drive.
 .
 
@@ -10295,12 +12527,18 @@ SymbolicName=ERROR_CLEANER_SLOT_SET
 Language=English
 ERROR_CLEANER_SLOT_SET - A cleaner slot is already reserved.
 .
+Language=Russian
+ERROR_CLEANER_SLOT_SET - A cleaner slot is already reserved.
+.
 
 MessageId=4332
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLEANER_SLOT_NOT_SET
 Language=English
+ERROR_CLEANER_SLOT_NOT_SET - A cleaner slot is not reserved.
+.
+Language=Russian
 ERROR_CLEANER_SLOT_NOT_SET - A cleaner slot is not reserved.
 .
 
@@ -10311,12 +12549,18 @@ SymbolicName=ERROR_CLEANER_CARTRIDGE_SPENT
 Language=English
 ERROR_CLEANER_CARTRIDGE_SPENT - The cleaner cartridge has performed the maximum number of drive cleanings.
 .
+Language=Russian
+ERROR_CLEANER_CARTRIDGE_SPENT - The cleaner cartridge has performed the maximum number of drive cleanings.
+.
 
 MessageId=4334
 Severity=Success
 Facility=System
 SymbolicName=ERROR_UNEXPECTED_OMID
 Language=English
+ERROR_UNEXPECTED_OMID - Unexpected on-medium identifier.
+.
+Language=Russian
 ERROR_UNEXPECTED_OMID - Unexpected on-medium identifier.
 .
 
@@ -10327,12 +12571,18 @@ SymbolicName=ERROR_CANT_DELETE_LAST_ITEM
 Language=English
 ERROR_CANT_DELETE_LAST_ITEM - The last remaining item in this group or resource cannot be deleted.
 .
+Language=Russian
+ERROR_CANT_DELETE_LAST_ITEM - The last remaining item in this group or resource cannot be deleted.
+.
 
 MessageId=4336
 Severity=Success
 Facility=System
 SymbolicName=ERROR_MESSAGE_EXCEEDS_MAX_SIZE
 Language=English
+ERROR_MESSAGE_EXCEEDS_MAX_SIZE - The message provided exceeds the maximum size allowed for this parameter.
+.
+Language=Russian
 ERROR_MESSAGE_EXCEEDS_MAX_SIZE - The message provided exceeds the maximum size allowed for this parameter.
 .
 
@@ -10343,12 +12593,18 @@ SymbolicName=ERROR_VOLUME_CONTAINS_SYS_FILES
 Language=English
 ERROR_VOLUME_CONTAINS_SYS_FILES - The volume contains system or paging files.
 .
+Language=Russian
+ERROR_VOLUME_CONTAINS_SYS_FILES - The volume contains system or paging files.
+.
 
 MessageId=4338
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INDIGENOUS_TYPE
 Language=English
+ERROR_INDIGENOUS_TYPE - The media type cannot be removed from this library since at least one drive in the library reports it can support this media type.
+.
+Language=Russian
 ERROR_INDIGENOUS_TYPE - The media type cannot be removed from this library since at least one drive in the library reports it can support this media type.
 .
 
@@ -10359,12 +12615,18 @@ SymbolicName=ERROR_NO_SUPPORTING_DRIVES
 Language=English
 ERROR_NO_SUPPORTING_DRIVES - This offline media cannot be mounted on this system since no enabled drives are present which can be used.
 .
+Language=Russian
+ERROR_NO_SUPPORTING_DRIVES - This offline media cannot be mounted on this system since no enabled drives are present which can be used.
+.
 
 MessageId=4340
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLEANER_CARTRIDGE_INSTALLED
 Language=English
+ERROR_CLEANER_CARTRIDGE_INSTALLED - A cleaner cartridge is present in the tape library.
+.
+Language=Russian
 ERROR_CLEANER_CARTRIDGE_INSTALLED - A cleaner cartridge is present in the tape library.
 .
 
@@ -10375,12 +12637,18 @@ SymbolicName=ERROR_FILE_OFFLINE
 Language=English
 ERROR_FILE_OFFLINE - The remote storage service was not able to recall the file.
 .
+Language=Russian
+ERROR_FILE_OFFLINE - The remote storage service was not able to recall the file.
+.
 
 MessageId=4351
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REMOTE_STORAGE_NOT_ACTIVE
 Language=English
+ERROR_REMOTE_STORAGE_NOT_ACTIVE - The remote storage service is not operational at this time.
+.
+Language=Russian
 ERROR_REMOTE_STORAGE_NOT_ACTIVE - The remote storage service is not operational at this time.
 .
 
@@ -10391,12 +12659,18 @@ SymbolicName=ERROR_REMOTE_STORAGE_MEDIA_ERROR
 Language=English
 ERROR_REMOTE_STORAGE_MEDIA_ERROR - The remote storage service encountered a media error.
 .
+Language=Russian
+ERROR_REMOTE_STORAGE_MEDIA_ERROR - The remote storage service encountered a media error.
+.
 
 MessageId=4390
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_A_REPARSE_POINT
 Language=English
+ERROR_NOT_A_REPARSE_POINT - The file or directory is not a reparse point.
+.
+Language=Russian
 ERROR_NOT_A_REPARSE_POINT - The file or directory is not a reparse point.
 .
 
@@ -10407,12 +12681,18 @@ SymbolicName=ERROR_REPARSE_ATTRIBUTE_CONFLICT
 Language=English
 ERROR_REPARSE_ATTRIBUTE_CONFLICT - The reparse point attribute cannot be set because it conflicts with an existing attribute.
 .
+Language=Russian
+ERROR_REPARSE_ATTRIBUTE_CONFLICT - The reparse point attribute cannot be set because it conflicts with an existing attribute.
+.
 
 MessageId=4392
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_REPARSE_DATA
 Language=English
+ERROR_INVALID_REPARSE_DATA - The data present in the reparse point buffer is invalid.
+.
+Language=Russian
 ERROR_INVALID_REPARSE_DATA - The data present in the reparse point buffer is invalid.
 .
 
@@ -10423,12 +12703,18 @@ SymbolicName=ERROR_REPARSE_TAG_INVALID
 Language=English
 ERROR_REPARSE_TAG_INVALID - The tag present in the reparse point buffer is invalid.
 .
+Language=Russian
+ERROR_REPARSE_TAG_INVALID - The tag present in the reparse point buffer is invalid.
+.
 
 MessageId=4394
 Severity=Success
 Facility=System
 SymbolicName=ERROR_REPARSE_TAG_MISMATCH
 Language=English
+ERROR_REPARSE_TAG_MISMATCH - There is a mismatch between the tag specified in the request and the tag present in the reparse point.
+.
+Language=Russian
 ERROR_REPARSE_TAG_MISMATCH - There is a mismatch between the tag specified in the request and the tag present in the reparse point.
 .
 
@@ -10439,12 +12725,18 @@ SymbolicName=ERROR_VOLUME_NOT_SIS_ENABLED
 Language=English
 ERROR_VOLUME_NOT_SIS_ENABLED - Single Instance Storage is not available on this volume.
 .
+Language=Russian
+ERROR_VOLUME_NOT_SIS_ENABLED - Single Instance Storage is not available on this volume.
+.
 
 MessageId=5001
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DEPENDENT_RESOURCE_EXISTS
 Language=English
+ERROR_DEPENDENT_RESOURCE_EXISTS - The cluster resource cannot be moved to another group because other resources are dependent on it.
+.
+Language=Russian
 ERROR_DEPENDENT_RESOURCE_EXISTS - The cluster resource cannot be moved to another group because other resources are dependent on it.
 .
 
@@ -10455,12 +12747,18 @@ SymbolicName=ERROR_DEPENDENCY_NOT_FOUND
 Language=English
 ERROR_DEPENDENCY_NOT_FOUND - The cluster resource dependency cannot be found.
 .
+Language=Russian
+ERROR_DEPENDENCY_NOT_FOUND - The cluster resource dependency cannot be found.
+.
 
 MessageId=5003
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DEPENDENCY_ALREADY_EXISTS
 Language=English
+ERROR_DEPENDENCY_ALREADY_EXISTS - The cluster resource cannot be made dependent on the specified resource because it is already dependent.
+.
+Language=Russian
 ERROR_DEPENDENCY_ALREADY_EXISTS - The cluster resource cannot be made dependent on the specified resource because it is already dependent.
 .
 
@@ -10471,12 +12769,18 @@ SymbolicName=ERROR_RESOURCE_NOT_ONLINE
 Language=English
 ERROR_RESOURCE_NOT_ONLINE - The cluster resource is not online.
 .
+Language=Russian
+ERROR_RESOURCE_NOT_ONLINE - The cluster resource is not online.
+.
 
 MessageId=5005
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HOST_NODE_NOT_AVAILABLE
 Language=English
+ERROR_HOST_NODE_NOT_AVAILABLE - A cluster node is not available for this operation.
+.
+Language=Russian
 ERROR_HOST_NODE_NOT_AVAILABLE - A cluster node is not available for this operation.
 .
 
@@ -10487,12 +12791,18 @@ SymbolicName=ERROR_RESOURCE_NOT_AVAILABLE
 Language=English
 ERROR_RESOURCE_NOT_AVAILABLE - The cluster resource is not available.
 .
+Language=Russian
+ERROR_RESOURCE_NOT_AVAILABLE - The cluster resource is not available.
+.
 
 MessageId=5007
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_NOT_FOUND
 Language=English
+ERROR_RESOURCE_NOT_FOUND - The cluster resource could not be found.
+.
+Language=Russian
 ERROR_RESOURCE_NOT_FOUND - The cluster resource could not be found.
 .
 
@@ -10503,12 +12813,18 @@ SymbolicName=ERROR_SHUTDOWN_CLUSTER
 Language=English
 ERROR_SHUTDOWN_CLUSTER - The cluster is being shut down.
 .
+Language=Russian
+ERROR_SHUTDOWN_CLUSTER - The cluster is being shut down.
+.
 
 MessageId=5009
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CANT_EVICT_ACTIVE_NODE
 Language=English
+ERROR_CANT_EVICT_ACTIVE_NODE - A cluster node cannot be evicted from the cluster unless the node is down.
+.
+Language=Russian
 ERROR_CANT_EVICT_ACTIVE_NODE - A cluster node cannot be evicted from the cluster unless the node is down.
 .
 
@@ -10519,12 +12835,18 @@ SymbolicName=ERROR_OBJECT_ALREADY_EXISTS
 Language=English
 ERROR_OBJECT_ALREADY_EXISTS - The object already exists.
 .
+Language=Russian
+ERROR_OBJECT_ALREADY_EXISTS - The object already exists.
+.
 
 MessageId=5011
 Severity=Success
 Facility=System
 SymbolicName=ERROR_OBJECT_IN_LIST
 Language=English
+ERROR_OBJECT_IN_LIST - The object is already in the list.
+.
+Language=Russian
 ERROR_OBJECT_IN_LIST - The object is already in the list.
 .
 
@@ -10535,12 +12857,18 @@ SymbolicName=ERROR_GROUP_NOT_AVAILABLE
 Language=English
 ERROR_GROUP_NOT_AVAILABLE - The cluster group is not available for any new requests.
 .
+Language=Russian
+ERROR_GROUP_NOT_AVAILABLE - The cluster group is not available for any new requests.
+.
 
 MessageId=5013
 Severity=Success
 Facility=System
 SymbolicName=ERROR_GROUP_NOT_FOUND
 Language=English
+ERROR_GROUP_NOT_FOUND - The cluster group could not be found.
+.
+Language=Russian
 ERROR_GROUP_NOT_FOUND - The cluster group could not be found.
 .
 
@@ -10551,12 +12879,18 @@ SymbolicName=ERROR_GROUP_NOT_ONLINE
 Language=English
 ERROR_GROUP_NOT_ONLINE - The operation could not be completed because the cluster group is not online.
 .
+Language=Russian
+ERROR_GROUP_NOT_ONLINE - The operation could not be completed because the cluster group is not online.
+.
 
 MessageId=5015
 Severity=Success
 Facility=System
 SymbolicName=ERROR_HOST_NODE_NOT_RESOURCE_OWNER
 Language=English
+ERROR_HOST_NODE_NOT_RESOURCE_OWNER - The cluster node is not the owner of the resource.
+.
+Language=Russian
 ERROR_HOST_NODE_NOT_RESOURCE_OWNER - The cluster node is not the owner of the resource.
 .
 
@@ -10567,12 +12901,18 @@ SymbolicName=ERROR_HOST_NODE_NOT_GROUP_OWNER
 Language=English
 ERROR_HOST_NODE_NOT_GROUP_OWNER - The cluster node is not the owner of the group.
 .
+Language=Russian
+ERROR_HOST_NODE_NOT_GROUP_OWNER - The cluster node is not the owner of the group.
+.
 
 MessageId=5017
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESMON_CREATE_FAILED
 Language=English
+ERROR_RESMON_CREATE_FAILED - The cluster resource could not be created in the specified resource monitor.
+.
+Language=Russian
 ERROR_RESMON_CREATE_FAILED - The cluster resource could not be created in the specified resource monitor.
 .
 
@@ -10583,12 +12923,18 @@ SymbolicName=ERROR_RESMON_ONLINE_FAILED
 Language=English
 ERROR_RESMON_ONLINE_FAILED - The cluster resource could not be brought online by the resource monitor.
 .
+Language=Russian
+ERROR_RESMON_ONLINE_FAILED - The cluster resource could not be brought online by the resource monitor.
+.
 
 MessageId=5019
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESOURCE_ONLINE
 Language=English
+ERROR_RESOURCE_ONLINE - The operation could not be completed because the cluster resource is online.
+.
+Language=Russian
 ERROR_RESOURCE_ONLINE - The operation could not be completed because the cluster resource is online.
 .
 
@@ -10599,12 +12945,18 @@ SymbolicName=ERROR_QUORUM_RESOURCE
 Language=English
 ERROR_QUORUM_RESOURCE - The cluster resource could not be deleted or brought offline because it is the quorum resource.
 .
+Language=Russian
+ERROR_QUORUM_RESOURCE - The cluster resource could not be deleted or brought offline because it is the quorum resource.
+.
 
 MessageId=5021
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_QUORUM_CAPABLE
 Language=English
+ERROR_NOT_QUORUM_CAPABLE - The cluster could not make the specified resource a quorum resource because it is not capable of being a quorum resource.
+.
+Language=Russian
 ERROR_NOT_QUORUM_CAPABLE - The cluster could not make the specified resource a quorum resource because it is not capable of being a quorum resource.
 .
 
@@ -10615,12 +12967,18 @@ SymbolicName=ERROR_CLUSTER_SHUTTING_DOWN
 Language=English
 ERROR_CLUSTER_SHUTTING_DOWN - The cluster software is shutting down.
 .
+Language=Russian
+ERROR_CLUSTER_SHUTTING_DOWN - The cluster software is shutting down.
+.
 
 MessageId=5023
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_STATE
 Language=English
+ERROR_INVALID_STATE - The group or resource is not in the correct state to perform the requested operation.
+.
+Language=Russian
 ERROR_INVALID_STATE - The group or resource is not in the correct state to perform the requested operation.
 .
 
@@ -10631,12 +12989,18 @@ SymbolicName=ERROR_RESOURCE_PROPERTIES_STORED
 Language=English
 ERROR_RESOURCE_PROPERTIES_STORED - The properties were stored but not all changes will take effect until the next time the resource is brought online.
 .
+Language=Russian
+ERROR_RESOURCE_PROPERTIES_STORED - The properties were stored but not all changes will take effect until the next time the resource is brought online.
+.
 
 MessageId=5025
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_QUORUM_CLASS
 Language=English
+ERROR_NOT_QUORUM_CLASS - The cluster could not make the specified resource a quorum resource because it does not belong to a shared storage class.
+.
+Language=Russian
 ERROR_NOT_QUORUM_CLASS - The cluster could not make the specified resource a quorum resource because it does not belong to a shared storage class.
 .
 
@@ -10647,12 +13011,18 @@ SymbolicName=ERROR_CORE_RESOURCE
 Language=English
 ERROR_CORE_RESOURCE - The cluster resource could not be deleted since it is a core resource.
 .
+Language=Russian
+ERROR_CORE_RESOURCE - The cluster resource could not be deleted since it is a core resource.
+.
 
 MessageId=5027
 Severity=Success
 Facility=System
 SymbolicName=ERROR_QUORUM_RESOURCE_ONLINE_FAILED
 Language=English
+ERROR_QUORUM_RESOURCE_ONLINE_FAILED - The quorum resource failed to come online.
+.
+Language=Russian
 ERROR_QUORUM_RESOURCE_ONLINE_FAILED - The quorum resource failed to come online.
 .
 
@@ -10663,12 +13033,18 @@ SymbolicName=ERROR_QUORUMLOG_OPEN_FAILED
 Language=English
 ERROR_QUORUMLOG_OPEN_FAILED - The quorum log could not be created or mounted successfully.
 .
+Language=Russian
+ERROR_QUORUMLOG_OPEN_FAILED - The quorum log could not be created or mounted successfully.
+.
 
 MessageId=5029
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTERLOG_CORRUPT
 Language=English
+ERROR_CLUSTERLOG_CORRUPT - The cluster log is corrupt.
+.
+Language=Russian
 ERROR_CLUSTERLOG_CORRUPT - The cluster log is corrupt.
 .
 
@@ -10679,12 +13055,18 @@ SymbolicName=ERROR_CLUSTERLOG_RECORD_EXCEEDS_MAXSIZE
 Language=English
 ERROR_CLUSTERLOG_RECORD_EXCEEDS_MAXSIZE - The record could not be written to the cluster log since it exceeds the maximum size.
 .
+Language=Russian
+ERROR_CLUSTERLOG_RECORD_EXCEEDS_MAXSIZE - The record could not be written to the cluster log since it exceeds the maximum size.
+.
 
 MessageId=5031
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTERLOG_EXCEEDS_MAXSIZE
 Language=English
+ERROR_CLUSTERLOG_EXCEEDS_MAXSIZE - The cluster log exceeds its maximum size.
+.
+Language=Russian
 ERROR_CLUSTERLOG_EXCEEDS_MAXSIZE - The cluster log exceeds its maximum size.
 .
 
@@ -10695,12 +13077,18 @@ SymbolicName=ERROR_CLUSTERLOG_CHKPOINT_NOT_FOUND
 Language=English
 ERROR_CLUSTERLOG_CHKPOINT_NOT_FOUND - No checkpoint record was found in the cluster log.
 .
+Language=Russian
+ERROR_CLUSTERLOG_CHKPOINT_NOT_FOUND - No checkpoint record was found in the cluster log.
+.
 
 MessageId=5033
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTERLOG_NOT_ENOUGH_SPACE
 Language=English
+ERROR_CLUSTERLOG_NOT_ENOUGH_SPACE - The minimum required disk space needed for logging is not available.
+.
+Language=Russian
 ERROR_CLUSTERLOG_NOT_ENOUGH_SPACE - The minimum required disk space needed for logging is not available.
 .
 
@@ -10711,12 +13099,18 @@ SymbolicName=ERROR_QUORUM_OWNER_ALIVE
 Language=English
 ERROR_QUORUM_OWNER_ALIVE - The cluster node failed to take control of the quorum resource because the resource is owned by another active node.
 .
+Language=Russian
+ERROR_QUORUM_OWNER_ALIVE - The cluster node failed to take control of the quorum resource because the resource is owned by another active node.
+.
 
 MessageId=5035
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NETWORK_NOT_AVAILABLE
 Language=English
+ERROR_NETWORK_NOT_AVAILABLE - A cluster network is not available for this operation.
+.
+Language=Russian
 ERROR_NETWORK_NOT_AVAILABLE - A cluster network is not available for this operation.
 .
 
@@ -10727,12 +13121,18 @@ SymbolicName=ERROR_NODE_NOT_AVAILABLE
 Language=English
 ERROR_NODE_NOT_AVAILABLE - A cluster node is not available for this operation.
 .
+Language=Russian
+ERROR_NODE_NOT_AVAILABLE - A cluster node is not available for this operation.
+.
 
 MessageId=5037
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ALL_NODES_NOT_AVAILABLE
 Language=English
+ERROR_ALL_NODES_NOT_AVAILABLE - All cluster nodes must be running to perform this operation.
+.
+Language=Russian
 ERROR_ALL_NODES_NOT_AVAILABLE - All cluster nodes must be running to perform this operation.
 .
 
@@ -10743,12 +13143,18 @@ SymbolicName=ERROR_RESOURCE_FAILED
 Language=English
 ERROR_RESOURCE_FAILED - A cluster resource failed.
 .
+Language=Russian
+ERROR_RESOURCE_FAILED - A cluster resource failed.
+.
 
 MessageId=5039
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_INVALID_NODE
 Language=English
+ERROR_CLUSTER_INVALID_NODE - The cluster node is not valid.
+.
+Language=Russian
 ERROR_CLUSTER_INVALID_NODE - The cluster node is not valid.
 .
 
@@ -10759,12 +13165,18 @@ SymbolicName=ERROR_CLUSTER_NODE_EXISTS
 Language=English
 ERROR_CLUSTER_NODE_EXISTS - The cluster node already exists.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_EXISTS - The cluster node already exists.
+.
 
 MessageId=5041
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_JOIN_IN_PROGRESS
 Language=English
+ERROR_CLUSTER_JOIN_IN_PROGRESS - A node is in the process of joining the cluster.
+.
+Language=Russian
 ERROR_CLUSTER_JOIN_IN_PROGRESS - A node is in the process of joining the cluster.
 .
 
@@ -10775,12 +13187,18 @@ SymbolicName=ERROR_CLUSTER_NODE_NOT_FOUND
 Language=English
 ERROR_CLUSTER_NODE_NOT_FOUND - The cluster node was not found.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_NOT_FOUND - The cluster node was not found.
+.
 
 MessageId=5043
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_LOCAL_NODE_NOT_FOUND
 Language=English
+ERROR_CLUSTER_LOCAL_NODE_NOT_FOUND - The cluster local node information was not found.
+.
+Language=Russian
 ERROR_CLUSTER_LOCAL_NODE_NOT_FOUND - The cluster local node information was not found.
 .
 
@@ -10791,12 +13209,18 @@ SymbolicName=ERROR_CLUSTER_NETWORK_EXISTS
 Language=English
 ERROR_CLUSTER_NETWORK_EXISTS - The cluster network already exists.
 .
+Language=Russian
+ERROR_CLUSTER_NETWORK_EXISTS - The cluster network already exists.
+.
 
 MessageId=5045
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NETWORK_NOT_FOUND
 Language=English
+ERROR_CLUSTER_NETWORK_NOT_FOUND - The cluster network was not found.
+.
+Language=Russian
 ERROR_CLUSTER_NETWORK_NOT_FOUND - The cluster network was not found.
 .
 
@@ -10807,12 +13231,18 @@ SymbolicName=ERROR_CLUSTER_NETINTERFACE_EXISTS
 Language=English
 ERROR_CLUSTER_NETINTERFACE_EXISTS - The cluster network interface already exists.
 .
+Language=Russian
+ERROR_CLUSTER_NETINTERFACE_EXISTS - The cluster network interface already exists.
+.
 
 MessageId=5047
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NETINTERFACE_NOT_FOUND
 Language=English
+ERROR_CLUSTER_NETINTERFACE_NOT_FOUND - The cluster network interface was not found.
+.
+Language=Russian
 ERROR_CLUSTER_NETINTERFACE_NOT_FOUND - The cluster network interface was not found.
 .
 
@@ -10823,12 +13253,18 @@ SymbolicName=ERROR_CLUSTER_INVALID_REQUEST
 Language=English
 ERROR_CLUSTER_INVALID_REQUEST - The cluster request is not valid for this object.
 .
+Language=Russian
+ERROR_CLUSTER_INVALID_REQUEST - The cluster request is not valid for this object.
+.
 
 MessageId=5049
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_INVALID_NETWORK_PROVIDER
 Language=English
+ERROR_CLUSTER_INVALID_NETWORK_PROVIDER - The cluster network provider is not valid.
+.
+Language=Russian
 ERROR_CLUSTER_INVALID_NETWORK_PROVIDER - The cluster network provider is not valid.
 .
 
@@ -10839,12 +13275,18 @@ SymbolicName=ERROR_CLUSTER_NODE_DOWN
 Language=English
 ERROR_CLUSTER_NODE_DOWN - The cluster node is down.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_DOWN - The cluster node is down.
+.
 
 MessageId=5051
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_UNREACHABLE
 Language=English
+ERROR_CLUSTER_NODE_UNREACHABLE - The cluster node is not reachable.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_UNREACHABLE - The cluster node is not reachable.
 .
 
@@ -10855,12 +13297,18 @@ SymbolicName=ERROR_CLUSTER_NODE_NOT_MEMBER
 Language=English
 ERROR_CLUSTER_NODE_NOT_MEMBER - The cluster node is not a member of the cluster.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_NOT_MEMBER - The cluster node is not a member of the cluster.
+.
 
 MessageId=5053
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_JOIN_NOT_IN_PROGRESS
 Language=English
+ERROR_CLUSTER_JOIN_NOT_IN_PROGRESS - A cluster join operation is not in progress.
+.
+Language=Russian
 ERROR_CLUSTER_JOIN_NOT_IN_PROGRESS - A cluster join operation is not in progress.
 .
 
@@ -10871,12 +13319,18 @@ SymbolicName=ERROR_CLUSTER_INVALID_NETWORK
 Language=English
 ERROR_CLUSTER_INVALID_NETWORK - The cluster network is not valid.
 .
+Language=Russian
+ERROR_CLUSTER_INVALID_NETWORK - The cluster network is not valid.
+.
 
 MessageId=5056
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_UP
 Language=English
+ERROR_CLUSTER_NODE_UP - The cluster node is up.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_UP - The cluster node is up.
 .
 
@@ -10887,12 +13341,18 @@ SymbolicName=ERROR_CLUSTER_IPADDR_IN_USE
 Language=English
 ERROR_CLUSTER_IPADDR_IN_USE - The cluster IP address is already in use.
 .
+Language=Russian
+ERROR_CLUSTER_IPADDR_IN_USE - The cluster IP address is already in use.
+.
 
 MessageId=5058
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_NOT_PAUSED
 Language=English
+ERROR_CLUSTER_NODE_NOT_PAUSED - The cluster node is not paused.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_NOT_PAUSED - The cluster node is not paused.
 .
 
@@ -10903,12 +13363,18 @@ SymbolicName=ERROR_CLUSTER_NO_SECURITY_CONTEXT
 Language=English
 ERROR_CLUSTER_NO_SECURITY_CONTEXT - No cluster security context is available.
 .
+Language=Russian
+ERROR_CLUSTER_NO_SECURITY_CONTEXT - No cluster security context is available.
+.
 
 MessageId=5060
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NETWORK_NOT_INTERNAL
 Language=English
+ERROR_CLUSTER_NETWORK_NOT_INTERNAL - The cluster network is not configured for internal cluster communication.
+.
+Language=Russian
 ERROR_CLUSTER_NETWORK_NOT_INTERNAL - The cluster network is not configured for internal cluster communication.
 .
 
@@ -10919,12 +13385,18 @@ SymbolicName=ERROR_CLUSTER_NODE_ALREADY_UP
 Language=English
 ERROR_CLUSTER_NODE_ALREADY_UP - The cluster node is already up.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_ALREADY_UP - The cluster node is already up.
+.
 
 MessageId=5062
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_ALREADY_DOWN
 Language=English
+ERROR_CLUSTER_NODE_ALREADY_DOWN - The cluster node is already down.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_ALREADY_DOWN - The cluster node is already down.
 .
 
@@ -10935,12 +13407,18 @@ SymbolicName=ERROR_CLUSTER_NETWORK_ALREADY_ONLINE
 Language=English
 ERROR_CLUSTER_NETWORK_ALREADY_ONLINE - The cluster network is already online.
 .
+Language=Russian
+ERROR_CLUSTER_NETWORK_ALREADY_ONLINE - The cluster network is already online.
+.
 
 MessageId=5064
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NETWORK_ALREADY_OFFLINE
 Language=English
+ERROR_CLUSTER_NETWORK_ALREADY_OFFLINE - The cluster network is already offline.
+.
+Language=Russian
 ERROR_CLUSTER_NETWORK_ALREADY_OFFLINE - The cluster network is already offline.
 .
 
@@ -10951,12 +13429,18 @@ SymbolicName=ERROR_CLUSTER_NODE_ALREADY_MEMBER
 Language=English
 ERROR_CLUSTER_NODE_ALREADY_MEMBER - The cluster node is already a member of the cluster.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_ALREADY_MEMBER - The cluster node is already a member of the cluster.
+.
 
 MessageId=5066
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_LAST_INTERNAL_NETWORK
 Language=English
+ERROR_CLUSTER_LAST_INTERNAL_NETWORK - The cluster network is the only one configured for internal cluster communication between two or more active cluster nodes. The internal communication capability cannot be removed from the network.
+.
+Language=Russian
 ERROR_CLUSTER_LAST_INTERNAL_NETWORK - The cluster network is the only one configured for internal cluster communication between two or more active cluster nodes. The internal communication capability cannot be removed from the network.
 .
 
@@ -10967,12 +13451,18 @@ SymbolicName=ERROR_CLUSTER_NETWORK_HAS_DEPENDENTS
 Language=English
 ERROR_CLUSTER_NETWORK_HAS_DEPENDENTS - One or more cluster resources depend on the network to provide service to clients. The client access capability cannot be removed from the network.
 .
+Language=Russian
+ERROR_CLUSTER_NETWORK_HAS_DEPENDENTS - One or more cluster resources depend on the network to provide service to clients. The client access capability cannot be removed from the network.
+.
 
 MessageId=5068
 Severity=Success
 Facility=System
 SymbolicName=ERROR_INVALID_OPERATION_ON_QUORUM
 Language=English
+ERROR_INVALID_OPERATION_ON_QUORUM - This operation cannot be performed on the cluster resource as it the quorum resource. You may not bring the quorum resource offline or modify its possible owners list.
+.
+Language=Russian
 ERROR_INVALID_OPERATION_ON_QUORUM - This operation cannot be performed on the cluster resource as it the quorum resource. You may not bring the quorum resource offline or modify its possible owners list.
 .
 
@@ -10983,12 +13473,18 @@ SymbolicName=ERROR_DEPENDENCY_NOT_ALLOWED
 Language=English
 ERROR_DEPENDENCY_NOT_ALLOWED - The cluster quorum resource is not allowed to have any dependencies.
 .
+Language=Russian
+ERROR_DEPENDENCY_NOT_ALLOWED - The cluster quorum resource is not allowed to have any dependencies.
+.
 
 MessageId=5070
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_PAUSED
 Language=English
+ERROR_CLUSTER_NODE_PAUSED - The cluster node is paused.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_PAUSED - The cluster node is paused.
 .
 
@@ -10999,12 +13495,18 @@ SymbolicName=ERROR_NODE_CANT_HOST_RESOURCE
 Language=English
 ERROR_NODE_CANT_HOST_RESOURCE - The cluster resource cannot be brought online. The owner node cannot run this resource.
 .
+Language=Russian
+ERROR_NODE_CANT_HOST_RESOURCE - The cluster resource cannot be brought online. The owner node cannot run this resource.
+.
 
 MessageId=5072
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_NOT_READY
 Language=English
+ERROR_CLUSTER_NODE_NOT_READY - The cluster node is not ready to perform the requested operation.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_NOT_READY - The cluster node is not ready to perform the requested operation.
 .
 
@@ -11015,12 +13517,18 @@ SymbolicName=ERROR_CLUSTER_NODE_SHUTTING_DOWN
 Language=English
 ERROR_CLUSTER_NODE_SHUTTING_DOWN - The cluster node is shutting down.
 .
+Language=Russian
+ERROR_CLUSTER_NODE_SHUTTING_DOWN - The cluster node is shutting down.
+.
 
 MessageId=5074
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_JOIN_ABORTED
 Language=English
+ERROR_CLUSTER_JOIN_ABORTED - The cluster join operation was aborted.
+.
+Language=Russian
 ERROR_CLUSTER_JOIN_ABORTED - The cluster join operation was aborted.
 .
 
@@ -11031,12 +13539,18 @@ SymbolicName=ERROR_CLUSTER_INCOMPATIBLE_VERSIONS
 Language=English
 ERROR_CLUSTER_INCOMPATIBLE_VERSIONS - The cluster join operation failed due to incompatible software versions between the joining node and its sponsor.
 .
+Language=Russian
+ERROR_CLUSTER_INCOMPATIBLE_VERSIONS - The cluster join operation failed due to incompatible software versions between the joining node and its sponsor.
+.
 
 MessageId=5076
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_MAXNUM_OF_RESOURCES_EXCEEDED
 Language=English
+ERROR_CLUSTER_MAXNUM_OF_RESOURCES_EXCEEDED - This resource cannot be created because the cluster has reached the limit on the number of resources it can monitor.
+.
+Language=Russian
 ERROR_CLUSTER_MAXNUM_OF_RESOURCES_EXCEEDED - This resource cannot be created because the cluster has reached the limit on the number of resources it can monitor.
 .
 
@@ -11047,12 +13561,18 @@ SymbolicName=ERROR_CLUSTER_SYSTEM_CONFIG_CHANGED
 Language=English
 ERROR_CLUSTER_SYSTEM_CONFIG_CHANGED - The system configuration changed during the cluster join or form operation. The join or form operation was aborted.
 .
+Language=Russian
+ERROR_CLUSTER_SYSTEM_CONFIG_CHANGED - The system configuration changed during the cluster join or form operation. The join or form operation was aborted.
+.
 
 MessageId=5078
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_RESOURCE_TYPE_NOT_FOUND
 Language=English
+ERROR_CLUSTER_RESOURCE_TYPE_NOT_FOUND - The specified resource type was not found.
+.
+Language=Russian
 ERROR_CLUSTER_RESOURCE_TYPE_NOT_FOUND - The specified resource type was not found.
 .
 
@@ -11063,12 +13583,18 @@ SymbolicName=ERROR_CLUSTER_RESTYPE_NOT_SUPPORTED
 Language=English
 ERROR_CLUSTER_RESTYPE_NOT_SUPPORTED - The specified node does not support a resource of this type. This may be due to version inconsistencies or due to the absence of the resource DLL on this node.
 .
+Language=Russian
+ERROR_CLUSTER_RESTYPE_NOT_SUPPORTED - The specified node does not support a resource of this type. This may be due to version inconsistencies or due to the absence of the resource DLL on this node.
+.
 
 MessageId=5080
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_RESNAME_NOT_FOUND
 Language=English
+ERROR_CLUSTER_RESNAME_NOT_FOUND - The specified resource name is supported by this resource DLL. This may be due to a bad (or changed) name supplied to the resource DLL.
+.
+Language=Russian
 ERROR_CLUSTER_RESNAME_NOT_FOUND - The specified resource name is supported by this resource DLL. This may be due to a bad (or changed) name supplied to the resource DLL.
 .
 
@@ -11079,12 +13605,18 @@ SymbolicName=ERROR_CLUSTER_NO_RPC_PACKAGES_REGISTERED
 Language=English
 ERROR_CLUSTER_NO_RPC_PACKAGES_REGISTERED - No authentication package could be registered with the RPC server.
 .
+Language=Russian
+ERROR_CLUSTER_NO_RPC_PACKAGES_REGISTERED - No authentication package could be registered with the RPC server.
+.
 
 MessageId=5082
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_OWNER_NOT_IN_PREFLIST
 Language=English
+ERROR_CLUSTER_OWNER_NOT_IN_PREFLIST - You cannot bring the group online because the owner of the group is not in the preferred list for the group. To change the owner node for the group, move the group.
+.
+Language=Russian
 ERROR_CLUSTER_OWNER_NOT_IN_PREFLIST - You cannot bring the group online because the owner of the group is not in the preferred list for the group. To change the owner node for the group, move the group.
 .
 
@@ -11095,12 +13627,18 @@ SymbolicName=ERROR_CLUSTER_DATABASE_SEQMISMATCH
 Language=English
 ERROR_CLUSTER_DATABASE_SEQMISMATCH - The join operation failed because the cluster database sequence number has changed or is incompatible with the locker node. This may happen during a join operation if the cluster database was changing during the join.
 .
+Language=Russian
+ERROR_CLUSTER_DATABASE_SEQMISMATCH - The join operation failed because the cluster database sequence number has changed or is incompatible with the locker node. This may happen during a join operation if the cluster database was changing during the join.
+.
 
 MessageId=5084
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RESMON_INVALID_STATE
 Language=English
+ERROR_RESMON_INVALID_STATE - The resource monitor will not allow the fail operation to be performed while the resource is in its current state. This may happen if the resource is in a pending state.
+.
+Language=Russian
 ERROR_RESMON_INVALID_STATE - The resource monitor will not allow the fail operation to be performed while the resource is in its current state. This may happen if the resource is in a pending state.
 .
 
@@ -11111,12 +13649,18 @@ SymbolicName=ERROR_CLUSTER_GUM_NOT_LOCKER
 Language=English
 ERROR_CLUSTER_GUM_NOT_LOCKER - A non locker code got a request to reserve the lock for making global updates.
 .
+Language=Russian
+ERROR_CLUSTER_GUM_NOT_LOCKER - A non locker code got a request to reserve the lock for making global updates.
+.
 
 MessageId=5086
 Severity=Success
 Facility=System
 SymbolicName=ERROR_QUORUM_DISK_NOT_FOUND
 Language=English
+ERROR_QUORUM_DISK_NOT_FOUND - The quorum disk could not be located by the cluster service.
+.
+Language=Russian
 ERROR_QUORUM_DISK_NOT_FOUND - The quorum disk could not be located by the cluster service.
 .
 
@@ -11127,12 +13671,18 @@ SymbolicName=ERROR_DATABASE_BACKUP_CORRUPT
 Language=English
 ERROR_DATABASE_BACKUP_CORRUPT - The backup up cluster database is possibly corrupt.
 .
+Language=Russian
+ERROR_DATABASE_BACKUP_CORRUPT - The backup up cluster database is possibly corrupt.
+.
 
 MessageId=5088
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NODE_ALREADY_HAS_DFS_ROOT
 Language=English
+ERROR_CLUSTER_NODE_ALREADY_HAS_DFS_ROOT - A DFS root already exists in this cluster node.
+.
+Language=Russian
 ERROR_CLUSTER_NODE_ALREADY_HAS_DFS_ROOT - A DFS root already exists in this cluster node.
 .
 
@@ -11143,12 +13693,18 @@ SymbolicName=ERROR_RESOURCE_PROPERTY_UNCHANGEABLE
 Language=English
 ERROR_RESOURCE_PROPERTY_UNCHANGEABLE - An attempt to modify a resource property failed because it conflicts with another existing property.
 .
+Language=Russian
+ERROR_RESOURCE_PROPERTY_UNCHANGEABLE - An attempt to modify a resource property failed because it conflicts with another existing property.
+.
 
 MessageId=5890
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_MEMBERSHIP_INVALID_STATE
 Language=English
+ERROR_CLUSTER_MEMBERSHIP_INVALID_STATE - An operation was attempted that is incompatible with the current membership state of the node.
+.
+Language=Russian
 ERROR_CLUSTER_MEMBERSHIP_INVALID_STATE - An operation was attempted that is incompatible with the current membership state of the node.
 .
 
@@ -11159,12 +13715,18 @@ SymbolicName=ERROR_CLUSTER_QUORUMLOG_NOT_FOUND
 Language=English
 ERROR_CLUSTER_QUORUMLOG_NOT_FOUND - The quorum resource does not contain the quorum log.
 .
+Language=Russian
+ERROR_CLUSTER_QUORUMLOG_NOT_FOUND - The quorum resource does not contain the quorum log.
+.
 
 MessageId=5892
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_MEMBERSHIP_HALT
 Language=English
+ERROR_CLUSTER_MEMBERSHIP_HALT - The membership engine requested shutdown of the cluster service on this node.
+.
+Language=Russian
 ERROR_CLUSTER_MEMBERSHIP_HALT - The membership engine requested shutdown of the cluster service on this node.
 .
 
@@ -11175,12 +13737,18 @@ SymbolicName=ERROR_CLUSTER_INSTANCE_ID_MISMATCH
 Language=English
 ERROR_CLUSTER_INSTANCE_ID_MISMATCH - The join operation failed because the cluster instance ID of the joining node does not match the cluster instance ID of the sponsor node.
 .
+Language=Russian
+ERROR_CLUSTER_INSTANCE_ID_MISMATCH - The join operation failed because the cluster instance ID of the joining node does not match the cluster instance ID of the sponsor node.
+.
 
 MessageId=5894
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NETWORK_NOT_FOUND_FOR_IP
 Language=English
+ERROR_CLUSTER_NETWORK_NOT_FOUND_FOR_IP - A matching network for the specified IP address could not be found. Please also specify a subnet mask and a cluster network.
+.
+Language=Russian
 ERROR_CLUSTER_NETWORK_NOT_FOUND_FOR_IP - A matching network for the specified IP address could not be found. Please also specify a subnet mask and a cluster network.
 .
 
@@ -11191,12 +13759,18 @@ SymbolicName=ERROR_CLUSTER_PROPERTY_DATA_TYPE_MISMATCH
 Language=English
 ERROR_CLUSTER_PROPERTY_DATA_TYPE_MISMATCH - The actual data type of the property did not match the expected data type of the property.
 .
+Language=Russian
+ERROR_CLUSTER_PROPERTY_DATA_TYPE_MISMATCH - The actual data type of the property did not match the expected data type of the property.
+.
 
 MessageId=5896
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_EVICT_WITHOUT_CLEANUP
 Language=English
+ERROR_CLUSTER_EVICT_WITHOUT_CLEANUP - The cluster node was evicted from the cluster successfully, but the node was not cleaned up. Extended status information explaining why the node was not cleaned up is available.
+.
+Language=Russian
 ERROR_CLUSTER_EVICT_WITHOUT_CLEANUP - The cluster node was evicted from the cluster successfully, but the node was not cleaned up. Extended status information explaining why the node was not cleaned up is available.
 .
 
@@ -11207,12 +13781,18 @@ SymbolicName=ERROR_CLUSTER_PARAMETER_MISMATCH
 Language=English
 ERROR_CLUSTER_PARAMETER_MISMATCH - Two or more parameter values specified for a resource's properties are in conflict.
 .
+Language=Russian
+ERROR_CLUSTER_PARAMETER_MISMATCH - Two or more parameter values specified for a resource's properties are in conflict.
+.
 
 MessageId=5898
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NODE_CANNOT_BE_CLUSTERED
 Language=English
+ERROR_NODE_CANNOT_BE_CLUSTERED - This computer cannot be made a member of a cluster.
+.
+Language=Russian
 ERROR_NODE_CANNOT_BE_CLUSTERED - This computer cannot be made a member of a cluster.
 .
 
@@ -11223,12 +13803,18 @@ SymbolicName=ERROR_CLUSTER_WRONG_OS_VERSION
 Language=English
 ERROR_CLUSTER_WRONG_OS_VERSION - This computer cannot be made a member of a cluster because it does not have the correct version of Windows installed.
 .
+Language=Russian
+ERROR_CLUSTER_WRONG_OS_VERSION - This computer cannot be made a member of a cluster because it does not have the correct version of Windows installed.
+.
 
 MessageId=5900
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_CANT_CREATE_DUP_CLUSTER_NAME
 Language=English
+ERROR_CLUSTER_CANT_CREATE_DUP_CLUSTER_NAME - A cluster cannot be created with the specified cluster name because that cluster name is already in use. Specify a different name for the cluster.
+.
+Language=Russian
 ERROR_CLUSTER_CANT_CREATE_DUP_CLUSTER_NAME - A cluster cannot be created with the specified cluster name because that cluster name is already in use. Specify a different name for the cluster.
 .
 
@@ -11239,12 +13825,18 @@ SymbolicName=ERROR_CLUSCFG_ALREADY_COMMITTED
 Language=English
 ERROR_CLUSCFG_ALREADY_COMMITTED - The cluster configuration action has already been committed.
 .
+Language=Russian
+ERROR_CLUSCFG_ALREADY_COMMITTED - The cluster configuration action has already been committed.
+.
 
 MessageId=5902
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSCFG_ROLLBACK_FAILED
 Language=English
+ERROR_CLUSCFG_ROLLBACK_FAILED - The cluster configuration action could not be rolled back.
+.
+Language=Russian
 ERROR_CLUSCFG_ROLLBACK_FAILED - The cluster configuration action could not be rolled back.
 .
 
@@ -11255,12 +13847,18 @@ SymbolicName=ERROR_CLUSCFG_SYSTEM_DISK_DRIVE_LETTER_CONFLICT
 Language=English
 ERROR_CLUSCFG_SYSTEM_DISK_DRIVE_LETTER_CONFLICT - The drive letter assigned to a system disk on one node conflicted with the driver letter assigned to a disk on another node.
 .
+Language=Russian
+ERROR_CLUSCFG_SYSTEM_DISK_DRIVE_LETTER_CONFLICT - The drive letter assigned to a system disk on one node conflicted with the driver letter assigned to a disk on another node.
+.
 
 MessageId=5904
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_OLD_VERSION
 Language=English
+ERROR_CLUSTER_OLD_VERSION - One or more nodes in the cluster are running a version of Windows that does not support this operation.
+.
+Language=Russian
 ERROR_CLUSTER_OLD_VERSION - One or more nodes in the cluster are running a version of Windows that does not support this operation.
 .
 
@@ -11271,12 +13869,18 @@ SymbolicName=ERROR_CLUSTER_MISMATCHED_COMPUTER_ACCT_NAME
 Language=English
 ERROR_CLUSTER_MISMATCHED_COMPUTER_ACCT_NAME - The name of the corresponding computer account doesn't match the Network Name for this resource.
 .
+Language=Russian
+ERROR_CLUSTER_MISMATCHED_COMPUTER_ACCT_NAME - The name of the corresponding computer account doesn't match the Network Name for this resource.
+.
 
 MessageId=5906
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CLUSTER_NO_NET_ADAPTERS
 Language=English
+ERROR_CLUSTER_NO_NET_ADAPTERS - No network adapters are available.
+.
+Language=Russian
 ERROR_CLUSTER_NO_NET_ADAPTERS - No network adapters are available.
 .
 
@@ -11287,12 +13891,18 @@ SymbolicName=ERROR_CLUSTER_POISONED
 Language=English
 ERROR_CLUSTER_POISONED - The cluster node has been poisoned.
 .
+Language=Russian
+ERROR_CLUSTER_POISONED - The cluster node has been poisoned.
+.
 
 MessageId=6000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ENCRYPTION_FAILED
 Language=English
+ERROR_ENCRYPTION_FAILED - The specified file could not be encrypted.
+.
+Language=Russian
 ERROR_ENCRYPTION_FAILED - The specified file could not be encrypted.
 .
 
@@ -11303,12 +13913,18 @@ SymbolicName=ERROR_DECRYPTION_FAILED
 Language=English
 ERROR_DECRYPTION_FAILED - The specified file could not be decrypted.
 .
+Language=Russian
+ERROR_DECRYPTION_FAILED - The specified file could not be decrypted.
+.
 
 MessageId=6002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FILE_ENCRYPTED
 Language=English
+ERROR_FILE_ENCRYPTED - The specified file is encrypted and the user does not have the ability to decrypt it.
+.
+Language=Russian
 ERROR_FILE_ENCRYPTED - The specified file is encrypted and the user does not have the ability to decrypt it.
 .
 
@@ -11319,12 +13935,18 @@ SymbolicName=ERROR_NO_RECOVERY_POLICY
 Language=English
 ERROR_NO_RECOVERY_POLICY - There is no valid encryption recovery policy configured for this system.
 .
+Language=Russian
+ERROR_NO_RECOVERY_POLICY - There is no valid encryption recovery policy configured for this system.
+.
 
 MessageId=6004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_EFS
 Language=English
+ERROR_NO_EFS - The required encryption driver is not loaded for this system.
+.
+Language=Russian
 ERROR_NO_EFS - The required encryption driver is not loaded for this system.
 .
 
@@ -11335,12 +13957,18 @@ SymbolicName=ERROR_WRONG_EFS
 Language=English
 ERROR_WRONG_EFS - The file was encrypted with a different encryption driver than is currently loaded.
 .
+Language=Russian
+ERROR_WRONG_EFS - The file was encrypted with a different encryption driver than is currently loaded.
+.
 
 MessageId=6006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_USER_KEYS
 Language=English
+ERROR_NO_USER_KEYS - There are no EFS keys defined for the user.
+.
+Language=Russian
 ERROR_NO_USER_KEYS - There are no EFS keys defined for the user.
 .
 
@@ -11351,12 +13979,18 @@ SymbolicName=ERROR_FILE_NOT_ENCRYPTED
 Language=English
 ERROR_FILE_NOT_ENCRYPTED - The specified file is not encrypted.
 .
+Language=Russian
+ERROR_FILE_NOT_ENCRYPTED - The specified file is not encrypted.
+.
 
 MessageId=6008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NOT_EXPORT_FORMAT
 Language=English
+ERROR_NOT_EXPORT_FORMAT - The specified file is not in the defined EFS export format.
+.
+Language=Russian
 ERROR_NOT_EXPORT_FORMAT - The specified file is not in the defined EFS export format.
 .
 
@@ -11367,12 +14001,18 @@ SymbolicName=ERROR_FILE_READ_ONLY
 Language=English
 ERROR_FILE_READ_ONLY - The specified file is read only.
 .
+Language=Russian
+ERROR_FILE_READ_ONLY - The specified file is read only.
+.
 
 MessageId=6010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DIR_EFS_DISALLOWED
 Language=English
+ERROR_DIR_EFS_DISALLOWED - The directory has been disabled for encryption.
+.
+Language=Russian
 ERROR_DIR_EFS_DISALLOWED - The directory has been disabled for encryption.
 .
 
@@ -11383,12 +14023,18 @@ SymbolicName=ERROR_EFS_SERVER_NOT_TRUSTED
 Language=English
 ERROR_EFS_SERVER_NOT_TRUSTED - The server is not trusted for remote encryption operation.
 .
+Language=Russian
+ERROR_EFS_SERVER_NOT_TRUSTED - The server is not trusted for remote encryption operation.
+.
 
 MessageId=6012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_BAD_RECOVERY_POLICY
 Language=English
+ERROR_BAD_RECOVERY_POLICY - Recovery policy configured for this system contains invalid recovery certificate.
+.
+Language=Russian
 ERROR_BAD_RECOVERY_POLICY - Recovery policy configured for this system contains invalid recovery certificate.
 .
 
@@ -11399,12 +14045,18 @@ SymbolicName=ERROR_EFS_ALG_BLOB_TOO_BIG
 Language=English
 ERROR_EFS_ALG_BLOB_TOO_BIG - The encryption algorithm used on the source file needs a bigger key buffer than the one on the destination file.
 .
+Language=Russian
+ERROR_EFS_ALG_BLOB_TOO_BIG - The encryption algorithm used on the source file needs a bigger key buffer than the one on the destination file.
+.
 
 MessageId=6014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_VOLUME_NOT_SUPPORT_EFS
 Language=English
+ERROR_VOLUME_NOT_SUPPORT_EFS - The disk partition does not support file encryption.
+.
+Language=Russian
 ERROR_VOLUME_NOT_SUPPORT_EFS - The disk partition does not support file encryption.
 .
 
@@ -11415,12 +14067,18 @@ SymbolicName=ERROR_EFS_DISABLED
 Language=English
 ERROR_EFS_DISABLED - This machine is disabled for file encryption.
 .
+Language=Russian
+ERROR_EFS_DISABLED - This machine is disabled for file encryption.
+.
 
 MessageId=6016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EFS_VERSION_NOT_SUPPORT
 Language=English
+ERROR_EFS_VERSION_NOT_SUPPORT - A newer system is required to decrypt this encrypted file.
+.
+Language=Russian
 ERROR_EFS_VERSION_NOT_SUPPORT - A newer system is required to decrypt this encrypted file.
 .
 
@@ -11431,12 +14089,18 @@ SymbolicName=ERROR_NO_BROWSER_SERVERS_FOUND
 Language=English
 ERROR_NO_BROWSER_SERVERS_FOUND - The list of servers for this workgroup is not currently available.
 .
+Language=Russian
+ERROR_NO_BROWSER_SERVERS_FOUND - The list of servers for this workgroup is not currently available.
+.
 
 MessageId=6200
 Severity=Success
 Facility=System
 SymbolicName=SCHED_E_SERVICE_NOT_LOCALSYSTEM
 Language=English
+SCHED_E_SERVICE_NOT_LOCALSYSTEM - The Task Scheduler service must be configured to run in the System account to function properly. Individual tasks may be configured to run in other accounts.
+.
+Language=Russian
 SCHED_E_SERVICE_NOT_LOCALSYSTEM - The Task Scheduler service must be configured to run in the System account to function properly. Individual tasks may be configured to run in other accounts.
 .
 
@@ -11447,12 +14111,18 @@ SymbolicName=ERROR_CTX_WINSTATION_NAME_INVALID
 Language=English
 ERROR_CTX_WINSTATION_NAME_INVALID - The specified session name is invalid.
 .
+Language=Russian
+ERROR_CTX_WINSTATION_NAME_INVALID - The specified session name is invalid.
+.
 
 MessageId=7002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_INVALID_PD
 Language=English
+ERROR_CTX_INVALID_PD - The specified protocol driver is invalid.
+.
+Language=Russian
 ERROR_CTX_INVALID_PD - The specified protocol driver is invalid.
 .
 
@@ -11463,12 +14133,18 @@ SymbolicName=ERROR_CTX_PD_NOT_FOUND
 Language=English
 ERROR_CTX_PD_NOT_FOUND - The specified protocol driver was not found in the system path.
 .
+Language=Russian
+ERROR_CTX_PD_NOT_FOUND - The specified protocol driver was not found in the system path.
+.
 
 MessageId=7004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_WD_NOT_FOUND
 Language=English
+ERROR_CTX_WD_NOT_FOUND - The specified terminal connection driver was not found in the system path.
+.
+Language=Russian
 ERROR_CTX_WD_NOT_FOUND - The specified terminal connection driver was not found in the system path.
 .
 
@@ -11479,12 +14155,18 @@ SymbolicName=ERROR_CTX_CANNOT_MAKE_EVENTLOG_ENTRY
 Language=English
 ERROR_CTX_CANNOT_MAKE_EVENTLOG_ENTRY - A registry key for event logging could not be created for this session.
 .
+Language=Russian
+ERROR_CTX_CANNOT_MAKE_EVENTLOG_ENTRY - A registry key for event logging could not be created for this session.
+.
 
 MessageId=7006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_SERVICE_NAME_COLLISION
 Language=English
+ERROR_CTX_SERVICE_NAME_COLLISION - A service with the same name already exists on the system.
+.
+Language=Russian
 ERROR_CTX_SERVICE_NAME_COLLISION - A service with the same name already exists on the system.
 .
 
@@ -11495,12 +14177,18 @@ SymbolicName=ERROR_CTX_CLOSE_PENDING
 Language=English
 ERROR_CTX_CLOSE_PENDING - A close operation is pending on the session.
 .
+Language=Russian
+ERROR_CTX_CLOSE_PENDING - A close operation is pending on the session.
+.
 
 MessageId=7008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_NO_OUTBUF
 Language=English
+ERROR_CTX_NO_OUTBUF - There are no free output buffers available.
+.
+Language=Russian
 ERROR_CTX_NO_OUTBUF - There are no free output buffers available.
 .
 
@@ -11511,12 +14199,18 @@ SymbolicName=ERROR_CTX_MODEM_INF_NOT_FOUND
 Language=English
 ERROR_CTX_MODEM_INF_NOT_FOUND - The MODEM.INF file was not found.
 .
+Language=Russian
+ERROR_CTX_MODEM_INF_NOT_FOUND - The MODEM.INF file was not found.
+.
 
 MessageId=7010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_INVALID_MODEMNAME
 Language=English
+ERROR_CTX_INVALID_MODEMNAME - The modem name was not found in MODEM.INF.
+.
+Language=Russian
 ERROR_CTX_INVALID_MODEMNAME - The modem name was not found in MODEM.INF.
 .
 
@@ -11527,12 +14221,18 @@ SymbolicName=ERROR_CTX_MODEM_RESPONSE_ERROR
 Language=English
 ERROR_CTX_MODEM_RESPONSE_ERROR - The modem did not accept the command sent to it. Verify that the configured modem name matches the attached modem.
 .
+Language=Russian
+ERROR_CTX_MODEM_RESPONSE_ERROR - The modem did not accept the command sent to it. Verify that the configured modem name matches the attached modem.
+.
 
 MessageId=7012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_MODEM_RESPONSE_TIMEOUT
 Language=English
+ERROR_CTX_MODEM_RESPONSE_TIMEOUT - The modem did not respond to the command sent to it. Verify that the modem is properly cabled and powered on.
+.
+Language=Russian
 ERROR_CTX_MODEM_RESPONSE_TIMEOUT - The modem did not respond to the command sent to it. Verify that the modem is properly cabled and powered on.
 .
 
@@ -11543,12 +14243,18 @@ SymbolicName=ERROR_CTX_MODEM_RESPONSE_NO_CARRIER
 Language=English
 ERROR_CTX_MODEM_RESPONSE_NO_CARRIER - Carrier detect has failed or carrier has been dropped due to disconnect.
 .
+Language=Russian
+ERROR_CTX_MODEM_RESPONSE_NO_CARRIER - Carrier detect has failed or carrier has been dropped due to disconnect.
+.
 
 MessageId=7014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_MODEM_RESPONSE_NO_DIALTONE
 Language=English
+ERROR_CTX_MODEM_RESPONSE_NO_DIALTONE - Dial tone not detected within the required time. Verify that the phone cable is properly attached and functional.
+.
+Language=Russian
 ERROR_CTX_MODEM_RESPONSE_NO_DIALTONE - Dial tone not detected within the required time. Verify that the phone cable is properly attached and functional.
 .
 
@@ -11559,12 +14265,18 @@ SymbolicName=ERROR_CTX_MODEM_RESPONSE_BUSY
 Language=English
 ERROR_CTX_MODEM_RESPONSE_BUSY - Busy signal detected at remote site on callback.
 .
+Language=Russian
+ERROR_CTX_MODEM_RESPONSE_BUSY - Busy signal detected at remote site on callback.
+.
 
 MessageId=7016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_MODEM_RESPONSE_VOICE
 Language=English
+ERROR_CTX_MODEM_RESPONSE_VOICE - Voice detected at remote site on callback.
+.
+Language=Russian
 ERROR_CTX_MODEM_RESPONSE_VOICE - Voice detected at remote site on callback.
 .
 
@@ -11575,12 +14287,18 @@ SymbolicName=ERROR_CTX_TD_ERROR
 Language=English
 ERROR_CTX_TD_ERROR - Transport driver error
 .
+Language=Russian
+ERROR_CTX_TD_ERROR - Transport driver error
+.
 
 MessageId=7022
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_WINSTATION_NOT_FOUND
 Language=English
+ERROR_CTX_WINSTATION_NOT_FOUND - The specified session cannot be found.
+.
+Language=Russian
 ERROR_CTX_WINSTATION_NOT_FOUND - The specified session cannot be found.
 .
 
@@ -11591,12 +14309,18 @@ SymbolicName=ERROR_CTX_WINSTATION_ALREADY_EXISTS
 Language=English
 ERROR_CTX_WINSTATION_ALREADY_EXISTS - The specified session name is already in use.
 .
+Language=Russian
+ERROR_CTX_WINSTATION_ALREADY_EXISTS - The specified session name is already in use.
+.
 
 MessageId=7024
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_WINSTATION_BUSY
 Language=English
+ERROR_CTX_WINSTATION_BUSY - The requested operation cannot be completed because the terminal connection is currently busy processing a connect, disconnect, reset, or delete operation.
+.
+Language=Russian
 ERROR_CTX_WINSTATION_BUSY - The requested operation cannot be completed because the terminal connection is currently busy processing a connect, disconnect, reset, or delete operation.
 .
 
@@ -11607,12 +14331,18 @@ SymbolicName=ERROR_CTX_BAD_VIDEO_MODE
 Language=English
 ERROR_CTX_BAD_VIDEO_MODE - An attempt has been made to connect to a session whose video mode is not supported by the current client.
 .
+Language=Russian
+ERROR_CTX_BAD_VIDEO_MODE - An attempt has been made to connect to a session whose video mode is not supported by the current client.
+.
 
 MessageId=7035
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_GRAPHICS_INVALID
 Language=English
+ERROR_CTX_GRAPHICS_INVALID - The application attempted to enable DOS graphics mode. DOS graphics mode is not supported.
+.
+Language=Russian
 ERROR_CTX_GRAPHICS_INVALID - The application attempted to enable DOS graphics mode. DOS graphics mode is not supported.
 .
 
@@ -11623,12 +14353,18 @@ SymbolicName=ERROR_CTX_LOGON_DISABLED
 Language=English
 ERROR_CTX_LOGON_DISABLED - Your interactive logon privilege has been disabled. Please contact your administrator.
 .
+Language=Russian
+ERROR_CTX_LOGON_DISABLED - Your interactive logon privilege has been disabled. Please contact your administrator.
+.
 
 MessageId=7038
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_NOT_CONSOLE
 Language=English
+ERROR_CTX_NOT_CONSOLE - The requested operation can be performed only on the system console. This is most often the result of a driver or system DLL requiring direct console access.
+.
+Language=Russian
 ERROR_CTX_NOT_CONSOLE - The requested operation can be performed only on the system console. This is most often the result of a driver or system DLL requiring direct console access.
 .
 
@@ -11639,12 +14375,18 @@ SymbolicName=ERROR_CTX_CLIENT_QUERY_TIMEOUT
 Language=English
 ERROR_CTX_CLIENT_QUERY_TIMEOUT - The client failed to respond to the server connect message.
 .
+Language=Russian
+ERROR_CTX_CLIENT_QUERY_TIMEOUT - The client failed to respond to the server connect message.
+.
 
 MessageId=7041
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_CONSOLE_DISCONNECT
 Language=English
+ERROR_CTX_CONSOLE_DISCONNECT - Disconnecting the console session is not supported.
+.
+Language=Russian
 ERROR_CTX_CONSOLE_DISCONNECT - Disconnecting the console session is not supported.
 .
 
@@ -11655,12 +14397,18 @@ SymbolicName=ERROR_CTX_CONSOLE_CONNECT
 Language=English
 ERROR_CTX_CONSOLE_CONNECT - Reconnecting a disconnected session to the console is not supported.
 .
+Language=Russian
+ERROR_CTX_CONSOLE_CONNECT - Reconnecting a disconnected session to the console is not supported.
+.
 
 MessageId=7044
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_SHADOW_DENIED
 Language=English
+ERROR_CTX_SHADOW_DENIED - The request to control another session remotely was denied.
+.
+Language=Russian
 ERROR_CTX_SHADOW_DENIED - The request to control another session remotely was denied.
 .
 
@@ -11671,12 +14419,18 @@ SymbolicName=ERROR_CTX_WINSTATION_ACCESS_DENIED
 Language=English
 ERROR_CTX_WINSTATION_ACCESS_DENIED - The requested session access is denied.
 .
+Language=Russian
+ERROR_CTX_WINSTATION_ACCESS_DENIED - The requested session access is denied.
+.
 
 MessageId=7049
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_INVALID_WD
 Language=English
+ERROR_CTX_INVALID_WD - The specified terminal connection driver is invalid.
+.
+Language=Russian
 ERROR_CTX_INVALID_WD - The specified terminal connection driver is invalid.
 .
 
@@ -11687,12 +14441,18 @@ SymbolicName=ERROR_CTX_SHADOW_INVALID
 Language=English
 ERROR_CTX_SHADOW_INVALID - The requested session cannot be controlled remotely. This may be because the session is disconnected or does not currently have a user logged on.
 .
+Language=Russian
+ERROR_CTX_SHADOW_INVALID - The requested session cannot be controlled remotely. This may be because the session is disconnected or does not currently have a user logged on.
+.
 
 MessageId=7051
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_SHADOW_DISABLED
 Language=English
+ERROR_CTX_SHADOW_DISABLED - The requested session is not configured to allow remote control.
+.
+Language=Russian
 ERROR_CTX_SHADOW_DISABLED - The requested session is not configured to allow remote control.
 .
 
@@ -11703,12 +14463,18 @@ SymbolicName=ERROR_CTX_CLIENT_LICENSE_IN_USE
 Language=English
 ERROR_CTX_CLIENT_LICENSE_IN_USE - Your request to connect to this Terminal Server has been rejected. Your Terminal Server client license number is currently being used by another user. Please call your system administrator to obtain a unique license number.
 .
+Language=Russian
+ERROR_CTX_CLIENT_LICENSE_IN_USE - Your request to connect to this Terminal Server has been rejected. Your Terminal Server client license number is currently being used by another user. Please call your system administrator to obtain a unique license number.
+.
 
 MessageId=7053
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_CLIENT_LICENSE_NOT_SET
 Language=English
+ERROR_CTX_CLIENT_LICENSE_NOT_SET - Your request to connect to this Terminal Server has been rejected. Your Terminal Server client license number has not been entered for this copy of the Terminal Server client. Please contact your system administrator.
+.
+Language=Russian
 ERROR_CTX_CLIENT_LICENSE_NOT_SET - Your request to connect to this Terminal Server has been rejected. Your Terminal Server client license number has not been entered for this copy of the Terminal Server client. Please contact your system administrator.
 .
 
@@ -11719,12 +14485,18 @@ SymbolicName=ERROR_CTX_LICENSE_NOT_AVAILABLE
 Language=English
 ERROR_CTX_LICENSE_NOT_AVAILABLE - The system has reached its licensed logon limit. Please try again later.
 .
+Language=Russian
+ERROR_CTX_LICENSE_NOT_AVAILABLE - The system has reached its licensed logon limit. Please try again later.
+.
 
 MessageId=7055
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_LICENSE_CLIENT_INVALID
 Language=English
+ERROR_CTX_LICENSE_CLIENT_INVALID - The client you are using is not licensed to use this system. Your logon request is denied.
+.
+Language=Russian
 ERROR_CTX_LICENSE_CLIENT_INVALID - The client you are using is not licensed to use this system. Your logon request is denied.
 .
 
@@ -11735,12 +14507,18 @@ SymbolicName=ERROR_CTX_LICENSE_EXPIRED
 Language=English
 ERROR_CTX_LICENSE_EXPIRED - The system license has expired. Your logon request is denied.
 .
+Language=Russian
+ERROR_CTX_LICENSE_EXPIRED - The system license has expired. Your logon request is denied.
+.
 
 MessageId=7057
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_SHADOW_NOT_RUNNING
 Language=English
+ERROR_CTX_SHADOW_NOT_RUNNING - Remote control could not be terminated because the specified session is not currently being remotely controlled.
+.
+Language=Russian
 ERROR_CTX_SHADOW_NOT_RUNNING - Remote control could not be terminated because the specified session is not currently being remotely controlled.
 .
 
@@ -11751,12 +14529,18 @@ SymbolicName=ERROR_CTX_SHADOW_ENDED_BY_MODE_CHANGE
 Language=English
 ERROR_CTX_SHADOW_ENDED_BY_MODE_CHANGE - The remote control of the console was terminated because the display mode was changed. Changing the display mode in a remote control session is not supported.
 .
+Language=Russian
+ERROR_CTX_SHADOW_ENDED_BY_MODE_CHANGE - The remote control of the console was terminated because the display mode was changed. Changing the display mode in a remote control session is not supported.
+.
 
 MessageId=7059
 Severity=Success
 Facility=System
 SymbolicName=ERROR_ACTIVATION_COUNT_EXCEEDED
 Language=English
+ERROR_ACTIVATION_COUNT_EXCEEDED - Activation has already been reset the maximum number of times for this installation. Your activation timer will not be cleared.
+.
+Language=Russian
 ERROR_ACTIVATION_COUNT_EXCEEDED - Activation has already been reset the maximum number of times for this installation. Your activation timer will not be cleared.
 .
 
@@ -11767,12 +14551,18 @@ SymbolicName=ERROR_CTX_WINSTATIONS_DISABLED
 Language=English
 ERROR_CTX_WINSTATIONS_DISABLED - Remote logins are currently disabled.
 .
+Language=Russian
+ERROR_CTX_WINSTATIONS_DISABLED - Remote logins are currently disabled.
+.
 
 MessageId=7061
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_ENCRYPTION_LEVEL_REQUIRED
 Language=English
+ERROR_CTX_ENCRYPTION_LEVEL_REQUIRED - You do not have the proper encryption level to access this Session.
+.
+Language=Russian
 ERROR_CTX_ENCRYPTION_LEVEL_REQUIRED - You do not have the proper encryption level to access this Session.
 .
 
@@ -11783,12 +14573,18 @@ SymbolicName=ERROR_CTX_SESSION_IN_USE
 Language=English
 ERROR_CTX_SESSION_IN_USE - The user %s\\%s is currently logged on to this computer. Only the current user or an administrator can log on to this computer.
 .
+Language=Russian
+ERROR_CTX_SESSION_IN_USE - The user %s\\%s is currently logged on to this computer. Only the current user or an administrator can log on to this computer.
+.
 
 MessageId=7063
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_NO_FORCE_LOGOFF
 Language=English
+ERROR_CTX_NO_FORCE_LOGOFF - The user %s\\%s is already logged on to the console of this computer. You do not have permission to log in at this time. To resolve this issue, contact %s\\%s and have them log off.
+.
+Language=Russian
 ERROR_CTX_NO_FORCE_LOGOFF - The user %s\\%s is already logged on to the console of this computer. You do not have permission to log in at this time. To resolve this issue, contact %s\\%s and have them log off.
 .
 
@@ -11799,12 +14595,18 @@ SymbolicName=ERROR_CTX_ACCOUNT_RESTRICTION
 Language=English
 ERROR_CTX_ACCOUNT_RESTRICTION - Unable to log you on because of an account restriction.
 .
+Language=Russian
+ERROR_CTX_ACCOUNT_RESTRICTION - Unable to log you on because of an account restriction.
+.
 
 MessageId=7065
 Severity=Success
 Facility=System
 SymbolicName=ERROR_RDP_PROTOCOL_ERROR
 Language=English
+ERROR_RDP_PROTOCOL_ERROR - The RDP protocol component %2 detected an error in the protocol stream and has disconnected the client.
+.
+Language=Russian
 ERROR_RDP_PROTOCOL_ERROR - The RDP protocol component %2 detected an error in the protocol stream and has disconnected the client.
 .
 
@@ -11815,12 +14617,18 @@ SymbolicName=ERROR_CTX_CDM_CONNECT
 Language=English
 ERROR_CTX_CDM_CONNECT - The Client Drive Mapping Service Has Connected on Terminal Connection.
 .
+Language=Russian
+ERROR_CTX_CDM_CONNECT - The Client Drive Mapping Service Has Connected on Terminal Connection.
+.
 
 MessageId=7067
 Severity=Success
 Facility=System
 SymbolicName=ERROR_CTX_CDM_DISCONNECT
 Language=English
+ERROR_CTX_CDM_DISCONNECT - The Client Drive Mapping Service Has Disconnected on Terminal Connection.
+.
+Language=Russian
 ERROR_CTX_CDM_DISCONNECT - The Client Drive Mapping Service Has Disconnected on Terminal Connection.
 .
 
@@ -11831,12 +14639,18 @@ SymbolicName=FRS_ERR_INVALID_API_SEQUENCE
 Language=English
 FRS_ERR_INVALID_API_SEQUENCE - The file replication service API was called incorrectly.
 .
+Language=Russian
+FRS_ERR_INVALID_API_SEQUENCE - The file replication service API was called incorrectly.
+.
 
 MessageId=8002
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_STARTING_SERVICE
 Language=English
+FRS_ERR_STARTING_SERVICE - The file replication service cannot be started.
+.
+Language=Russian
 FRS_ERR_STARTING_SERVICE - The file replication service cannot be started.
 .
 
@@ -11847,12 +14661,18 @@ SymbolicName=FRS_ERR_STOPPING_SERVICE
 Language=English
 FRS_ERR_STOPPING_SERVICE - The file replication service cannot be stopped.
 .
+Language=Russian
+FRS_ERR_STOPPING_SERVICE - The file replication service cannot be stopped.
+.
 
 MessageId=8004
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_INTERNAL_API
 Language=English
+FRS_ERR_INTERNAL_API - The file replication service API terminated the request. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_INTERNAL_API - The file replication service API terminated the request. The event log may have more information.
 .
 
@@ -11863,12 +14683,18 @@ SymbolicName=FRS_ERR_INTERNAL
 Language=English
 FRS_ERR_INTERNAL - The file replication service terminated the request. The event log may have more information.
 .
+Language=Russian
+FRS_ERR_INTERNAL - The file replication service terminated the request. The event log may have more information.
+.
 
 MessageId=8006
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_SERVICE_COMM
 Language=English
+FRS_ERR_SERVICE_COMM - The file replication service cannot be contacted. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_SERVICE_COMM - The file replication service cannot be contacted. The event log may have more information.
 .
 
@@ -11879,12 +14705,18 @@ SymbolicName=FRS_ERR_INSUFFICIENT_PRIV
 Language=English
 FRS_ERR_INSUFFICIENT_PRIV - The file replication service cannot satisfy the request because the user has insufficient privileges. The event log may have more information.
 .
+Language=Russian
+FRS_ERR_INSUFFICIENT_PRIV - The file replication service cannot satisfy the request because the user has insufficient privileges. The event log may have more information.
+.
 
 MessageId=8008
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_AUTHENTICATION
 Language=English
+FRS_ERR_AUTHENTICATION - The file replication service cannot satisfy the request because authenticated RPC is not available. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_AUTHENTICATION - The file replication service cannot satisfy the request because authenticated RPC is not available. The event log may have more information.
 .
 
@@ -11895,12 +14727,18 @@ SymbolicName=FRS_ERR_PARENT_INSUFFICIENT_PRIV
 Language=English
 FRS_ERR_PARENT_INSUFFICIENT_PRIV - The file replication service cannot satisfy the request because the user has insufficient privileges on the domain controller. The event log may have more information.
 .
+Language=Russian
+FRS_ERR_PARENT_INSUFFICIENT_PRIV - The file replication service cannot satisfy the request because the user has insufficient privileges on the domain controller. The event log may have more information.
+.
 
 MessageId=8010
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_PARENT_AUTHENTICATION
 Language=English
+FRS_ERR_PARENT_AUTHENTICATION - The file replication service cannot satisfy the request because authenticated RPC is not available on the domain controller. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_PARENT_AUTHENTICATION - The file replication service cannot satisfy the request because authenticated RPC is not available on the domain controller. The event log may have more information.
 .
 
@@ -11911,12 +14749,18 @@ SymbolicName=FRS_ERR_CHILD_TO_PARENT_COMM
 Language=English
 FRS_ERR_CHILD_TO_PARENT_COMM - The file replication service cannot communicate with the file replication service on the domain controller. The event log may have more information.
 .
+Language=Russian
+FRS_ERR_CHILD_TO_PARENT_COMM - The file replication service cannot communicate with the file replication service on the domain controller. The event log may have more information.
+.
 
 MessageId=8012
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_PARENT_TO_CHILD_COMM
 Language=English
+FRS_ERR_PARENT_TO_CHILD_COMM - The file replication service on the domain controller cannot communicate with the file replication service on this computer. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_PARENT_TO_CHILD_COMM - The file replication service on the domain controller cannot communicate with the file replication service on this computer. The event log may have more information.
 .
 
@@ -11927,12 +14771,18 @@ SymbolicName=FRS_ERR_SYSVOL_POPULATE
 Language=English
 FRS_ERR_SYSVOL_POPULATE - The file replication service cannot populate the system volume because of an internal error. The event log may have more information.
 .
+Language=Russian
+FRS_ERR_SYSVOL_POPULATE - The file replication service cannot populate the system volume because of an internal error. The event log may have more information.
+.
 
 MessageId=8014
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_SYSVOL_POPULATE_TIMEOUT
 Language=English
+FRS_ERR_SYSVOL_POPULATE_TIMEOUT - The file replication service cannot populate the system volume because of an internal timeout. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_SYSVOL_POPULATE_TIMEOUT - The file replication service cannot populate the system volume because of an internal timeout. The event log may have more information.
 .
 
@@ -11943,12 +14793,18 @@ SymbolicName=FRS_ERR_SYSVOL_IS_BUSY
 Language=English
 FRS_ERR_SYSVOL_IS_BUSY - The file replication service cannot process the request. The system volume is busy with a previous request.
 .
+Language=Russian
+FRS_ERR_SYSVOL_IS_BUSY - The file replication service cannot process the request. The system volume is busy with a previous request.
+.
 
 MessageId=8016
 Severity=Success
 Facility=System
 SymbolicName=FRS_ERR_SYSVOL_DEMOTE
 Language=English
+FRS_ERR_SYSVOL_DEMOTE - The file replication service cannot stop replicating the system volume because of an internal error. The event log may have more information.
+.
+Language=Russian
 FRS_ERR_SYSVOL_DEMOTE - The file replication service cannot stop replicating the system volume because of an internal error. The event log may have more information.
 .
 
@@ -11959,12 +14815,18 @@ SymbolicName=FRS_ERR_INVALID_SERVICE_PARAMETER
 Language=English
 FRS_ERR_INVALID_SERVICE_PARAMETER - The file replication service detected an invalid parameter.
 .
+Language=Russian
+FRS_ERR_INVALID_SERVICE_PARAMETER - The file replication service detected an invalid parameter.
+.
 
 MessageId=8200
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NOT_INSTALLED
 Language=English
+ERROR_DS_NOT_INSTALLED - An error occurred while installing the directory service. For more information, see the event log.
+.
+Language=Russian
 ERROR_DS_NOT_INSTALLED - An error occurred while installing the directory service. For more information, see the event log.
 .
 
@@ -11975,12 +14837,18 @@ SymbolicName=ERROR_DS_MEMBERSHIP_EVALUATED_LOCALLY
 Language=English
 ERROR_DS_MEMBERSHIP_EVALUATED_LOCALLY - The directory service evaluated group memberships locally.
 .
+Language=Russian
+ERROR_DS_MEMBERSHIP_EVALUATED_LOCALLY - The directory service evaluated group memberships locally.
+.
 
 MessageId=8202
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_ATTRIBUTE_OR_VALUE
 Language=English
+ERROR_DS_NO_ATTRIBUTE_OR_VALUE - The specified directory service attribute or value does not exist.
+.
+Language=Russian
 ERROR_DS_NO_ATTRIBUTE_OR_VALUE - The specified directory service attribute or value does not exist.
 .
 
@@ -11991,12 +14859,18 @@ SymbolicName=ERROR_DS_INVALID_ATTRIBUTE_SYNTAX
 Language=English
 ERROR_DS_INVALID_ATTRIBUTE_SYNTAX - The attribute syntax specified to the directory service is invalid.
 .
+Language=Russian
+ERROR_DS_INVALID_ATTRIBUTE_SYNTAX - The attribute syntax specified to the directory service is invalid.
+.
 
 MessageId=8204
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ATTRIBUTE_TYPE_UNDEFINED
 Language=English
+ERROR_DS_ATTRIBUTE_TYPE_UNDEFINED - The attribute type specified to the directory service is not defined.
+.
+Language=Russian
 ERROR_DS_ATTRIBUTE_TYPE_UNDEFINED - The attribute type specified to the directory service is not defined.
 .
 
@@ -12007,12 +14881,18 @@ SymbolicName=ERROR_DS_ATTRIBUTE_OR_VALUE_EXISTS
 Language=English
 ERROR_DS_ATTRIBUTE_OR_VALUE_EXISTS - The specified directory service attribute or value already exists.
 .
+Language=Russian
+ERROR_DS_ATTRIBUTE_OR_VALUE_EXISTS - The specified directory service attribute or value already exists.
+.
 
 MessageId=8206
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BUSY
 Language=English
+ERROR_DS_BUSY - The directory service is busy.
+.
+Language=Russian
 ERROR_DS_BUSY - The directory service is busy.
 .
 
@@ -12023,12 +14903,18 @@ SymbolicName=ERROR_DS_UNAVAILABLE
 Language=English
 ERROR_DS_UNAVAILABLE - The directory service is unavailable.
 .
+Language=Russian
+ERROR_DS_UNAVAILABLE - The directory service is unavailable.
+.
 
 MessageId=8208
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_RIDS_ALLOCATED
 Language=English
+ERROR_DS_NO_RIDS_ALLOCATED - The directory service was unable to allocate a relative identifier.
+.
+Language=Russian
 ERROR_DS_NO_RIDS_ALLOCATED - The directory service was unable to allocate a relative identifier.
 .
 
@@ -12039,12 +14925,18 @@ SymbolicName=ERROR_DS_NO_MORE_RIDS
 Language=English
 ERROR_DS_NO_MORE_RIDS - The directory service has exhausted the pool of relative identifiers.
 .
+Language=Russian
+ERROR_DS_NO_MORE_RIDS - The directory service has exhausted the pool of relative identifiers.
+.
 
 MessageId=8210
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INCORRECT_ROLE_OWNER
 Language=English
+ERROR_DS_INCORRECT_ROLE_OWNER - The requested operation could not be performed because the directory service is not the master for that type of operation.
+.
+Language=Russian
 ERROR_DS_INCORRECT_ROLE_OWNER - The requested operation could not be performed because the directory service is not the master for that type of operation.
 .
 
@@ -12055,12 +14947,18 @@ SymbolicName=ERROR_DS_RIDMGR_INIT_ERROR
 Language=English
 ERROR_DS_RIDMGR_INIT_ERROR - The directory service was unable to initialize the subsystem that allocates relative identifiers.
 .
+Language=Russian
+ERROR_DS_RIDMGR_INIT_ERROR - The directory service was unable to initialize the subsystem that allocates relative identifiers.
+.
 
 MessageId=8212
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OBJ_CLASS_VIOLATION
 Language=English
+ERROR_DS_OBJ_CLASS_VIOLATION - The requested operation did not satisfy one or more constraints associated with the class of the object.
+.
+Language=Russian
 ERROR_DS_OBJ_CLASS_VIOLATION - The requested operation did not satisfy one or more constraints associated with the class of the object.
 .
 
@@ -12071,12 +14969,18 @@ SymbolicName=ERROR_DS_CANT_ON_NON_LEAF
 Language=English
 ERROR_DS_CANT_ON_NON_LEAF - The directory service can perform the requested operation only on a leaf object.
 .
+Language=Russian
+ERROR_DS_CANT_ON_NON_LEAF - The directory service can perform the requested operation only on a leaf object.
+.
 
 MessageId=8214
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_ON_RDN
 Language=English
+ERROR_DS_CANT_ON_RDN - The directory service cannot perform the requested operation on the RDN attribute of an object.
+.
+Language=Russian
 ERROR_DS_CANT_ON_RDN - The directory service cannot perform the requested operation on the RDN attribute of an object.
 .
 
@@ -12087,12 +14991,18 @@ SymbolicName=ERROR_DS_CANT_MOD_OBJ_CLASS
 Language=English
 ERROR_DS_CANT_MOD_OBJ_CLASS - The directory service detected an attempt to modify the object class of an object.
 .
+Language=Russian
+ERROR_DS_CANT_MOD_OBJ_CLASS - The directory service detected an attempt to modify the object class of an object.
+.
 
 MessageId=8216
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CROSS_DOM_MOVE_ERROR
 Language=English
+ERROR_DS_CROSS_DOM_MOVE_ERROR - The requested cross-domain move operation could not be performed.
+.
+Language=Russian
 ERROR_DS_CROSS_DOM_MOVE_ERROR - The requested cross-domain move operation could not be performed.
 .
 
@@ -12103,12 +15013,18 @@ SymbolicName=ERROR_DS_GC_NOT_AVAILABLE
 Language=English
 ERROR_DS_GC_NOT_AVAILABLE - Unable to contact the global catalog server.
 .
+Language=Russian
+ERROR_DS_GC_NOT_AVAILABLE - Unable to contact the global catalog server.
+.
 
 MessageId=8218
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SHARED_POLICY
 Language=English
+ERROR_SHARED_POLICY - The policy object is shared and can only be modified at the root.
+.
+Language=Russian
 ERROR_SHARED_POLICY - The policy object is shared and can only be modified at the root.
 .
 
@@ -12119,12 +15035,18 @@ SymbolicName=ERROR_POLICY_OBJECT_NOT_FOUND
 Language=English
 ERROR_POLICY_OBJECT_NOT_FOUND - The policy object does not exist.
 .
+Language=Russian
+ERROR_POLICY_OBJECT_NOT_FOUND - The policy object does not exist.
+.
 
 MessageId=8220
 Severity=Success
 Facility=System
 SymbolicName=ERROR_POLICY_ONLY_IN_DS
 Language=English
+ERROR_POLICY_ONLY_IN_DS - The requested policy information is only in the directory service.
+.
+Language=Russian
 ERROR_POLICY_ONLY_IN_DS - The requested policy information is only in the directory service.
 .
 
@@ -12135,12 +15057,18 @@ SymbolicName=ERROR_PROMOTION_ACTIVE
 Language=English
 ERROR_PROMOTION_ACTIVE - A domain controller promotion is currently active.
 .
+Language=Russian
+ERROR_PROMOTION_ACTIVE - A domain controller promotion is currently active.
+.
 
 MessageId=8222
 Severity=Success
 Facility=System
 SymbolicName=ERROR_NO_PROMOTION_ACTIVE
 Language=English
+ERROR_NO_PROMOTION_ACTIVE - A domain controller promotion is not currently active
+.
+Language=Russian
 ERROR_NO_PROMOTION_ACTIVE - A domain controller promotion is not currently active
 .
 
@@ -12151,12 +15079,18 @@ SymbolicName=ERROR_DS_OPERATIONS_ERROR
 Language=English
 ERROR_DS_OPERATIONS_ERROR - An operations error occurred.
 .
+Language=Russian
+ERROR_DS_OPERATIONS_ERROR - An operations error occurred.
+.
 
 MessageId=8225
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_PROTOCOL_ERROR
 Language=English
+ERROR_DS_PROTOCOL_ERROR - A protocol error occurred.
+.
+Language=Russian
 ERROR_DS_PROTOCOL_ERROR - A protocol error occurred.
 .
 
@@ -12167,12 +15101,18 @@ SymbolicName=ERROR_DS_TIMELIMIT_EXCEEDED
 Language=English
 ERROR_DS_TIMELIMIT_EXCEEDED - The time limit for this request was exceeded.
 .
+Language=Russian
+ERROR_DS_TIMELIMIT_EXCEEDED - The time limit for this request was exceeded.
+.
 
 MessageId=8227
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SIZELIMIT_EXCEEDED
 Language=English
+ERROR_DS_SIZELIMIT_EXCEEDED - The size limit for this request was exceeded.
+.
+Language=Russian
 ERROR_DS_SIZELIMIT_EXCEEDED - The size limit for this request was exceeded.
 .
 
@@ -12183,12 +15123,18 @@ SymbolicName=ERROR_DS_ADMIN_LIMIT_EXCEEDED
 Language=English
 ERROR_DS_ADMIN_LIMIT_EXCEEDED - The administrative limit for this request was exceeded.
 .
+Language=Russian
+ERROR_DS_ADMIN_LIMIT_EXCEEDED - The administrative limit for this request was exceeded.
+.
 
 MessageId=8229
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_COMPARE_FALSE
 Language=English
+ERROR_DS_COMPARE_FALSE - The compare response was false.
+.
+Language=Russian
 ERROR_DS_COMPARE_FALSE - The compare response was false.
 .
 
@@ -12199,12 +15145,18 @@ SymbolicName=ERROR_DS_COMPARE_TRUE
 Language=English
 ERROR_DS_COMPARE_TRUE - The compare response was true.
 .
+Language=Russian
+ERROR_DS_COMPARE_TRUE - The compare response was true.
+.
 
 MessageId=8231
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_AUTH_METHOD_NOT_SUPPORTED
 Language=English
+ERROR_DS_AUTH_METHOD_NOT_SUPPORTED - The requested authentication method is not supported by the server.
+.
+Language=Russian
 ERROR_DS_AUTH_METHOD_NOT_SUPPORTED - The requested authentication method is not supported by the server.
 .
 
@@ -12215,12 +15167,18 @@ SymbolicName=ERROR_DS_STRONG_AUTH_REQUIRED
 Language=English
 ERROR_DS_STRONG_AUTH_REQUIRED - A more secure authentication method is required for this server.
 .
+Language=Russian
+ERROR_DS_STRONG_AUTH_REQUIRED - A more secure authentication method is required for this server.
+.
 
 MessageId=8233
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INAPPROPRIATE_AUTH
 Language=English
+ERROR_DS_INAPPROPRIATE_AUTH - Inappropriate authentication.
+.
+Language=Russian
 ERROR_DS_INAPPROPRIATE_AUTH - Inappropriate authentication.
 .
 
@@ -12231,12 +15189,18 @@ SymbolicName=ERROR_DS_AUTH_UNKNOWN
 Language=English
 ERROR_DS_AUTH_UNKNOWN - The authentication mechanism is unknown.
 .
+Language=Russian
+ERROR_DS_AUTH_UNKNOWN - The authentication mechanism is unknown.
+.
 
 MessageId=8235
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_REFERRAL
 Language=English
+ERROR_DS_REFERRAL - A referral was returned from the server.
+.
+Language=Russian
 ERROR_DS_REFERRAL - A referral was returned from the server.
 .
 
@@ -12247,12 +15211,18 @@ SymbolicName=ERROR_DS_UNAVAILABLE_CRIT_EXTENSION
 Language=English
 ERROR_DS_UNAVAILABLE_CRIT_EXTENSION - The server does not support the requested critical extension.
 .
+Language=Russian
+ERROR_DS_UNAVAILABLE_CRIT_EXTENSION - The server does not support the requested critical extension.
+.
 
 MessageId=8237
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CONFIDENTIALITY_REQUIRED
 Language=English
+ERROR_DS_CONFIDENTIALITY_REQUIRED - This request requires a secure connection.
+.
+Language=Russian
 ERROR_DS_CONFIDENTIALITY_REQUIRED - This request requires a secure connection.
 .
 
@@ -12263,12 +15233,18 @@ SymbolicName=ERROR_DS_INAPPROPRIATE_MATCHING
 Language=English
 ERROR_DS_INAPPROPRIATE_MATCHING - Inappropriate matching.
 .
+Language=Russian
+ERROR_DS_INAPPROPRIATE_MATCHING - Inappropriate matching.
+.
 
 MessageId=8239
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CONSTRAINT_VIOLATION
 Language=English
+ERROR_DS_CONSTRAINT_VIOLATION - A constraint violation occurred.
+.
+Language=Russian
 ERROR_DS_CONSTRAINT_VIOLATION - A constraint violation occurred.
 .
 
@@ -12279,12 +15255,18 @@ SymbolicName=ERROR_DS_NO_SUCH_OBJECT
 Language=English
 ERROR_DS_NO_SUCH_OBJECT - There is no such object on the server.
 .
+Language=Russian
+ERROR_DS_NO_SUCH_OBJECT - There is no such object on the server.
+.
 
 MessageId=8241
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ALIAS_PROBLEM
 Language=English
+ERROR_DS_ALIAS_PROBLEM - There is an alias problem.
+.
+Language=Russian
 ERROR_DS_ALIAS_PROBLEM - There is an alias problem.
 .
 
@@ -12295,12 +15277,18 @@ SymbolicName=ERROR_DS_INVALID_DN_SYNTAX
 Language=English
 ERROR_DS_INVALID_DN_SYNTAX - An invalid dn syntax has been specified.
 .
+Language=Russian
+ERROR_DS_INVALID_DN_SYNTAX - An invalid dn syntax has been specified.
+.
 
 MessageId=8243
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_IS_LEAF
 Language=English
+ERROR_DS_IS_LEAF - The object is a leaf object.
+.
+Language=Russian
 ERROR_DS_IS_LEAF - The object is a leaf object.
 .
 
@@ -12311,12 +15299,18 @@ SymbolicName=ERROR_DS_ALIAS_DEREF_PROBLEM
 Language=English
 ERROR_DS_ALIAS_DEREF_PROBLEM - There is an alias dereferencing problem.
 .
+Language=Russian
+ERROR_DS_ALIAS_DEREF_PROBLEM - There is an alias dereferencing problem.
+.
 
 MessageId=8245
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_UNWILLING_TO_PERFORM
 Language=English
+ERROR_DS_UNWILLING_TO_PERFORM - The server is unwilling to process the request.
+.
+Language=Russian
 ERROR_DS_UNWILLING_TO_PERFORM - The server is unwilling to process the request.
 .
 
@@ -12327,12 +15321,18 @@ SymbolicName=ERROR_DS_LOOP_DETECT
 Language=English
 ERROR_DS_LOOP_DETECT - A loop has been detected.
 .
+Language=Russian
+ERROR_DS_LOOP_DETECT - A loop has been detected.
+.
 
 MessageId=8247
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAMING_VIOLATION
 Language=English
+ERROR_DS_NAMING_VIOLATION - There is a naming violation.
+.
+Language=Russian
 ERROR_DS_NAMING_VIOLATION - There is a naming violation.
 .
 
@@ -12343,12 +15343,18 @@ SymbolicName=ERROR_DS_OBJECT_RESULTS_TOO_LARGE
 Language=English
 ERROR_DS_OBJECT_RESULTS_TOO_LARGE - The result set is too large.
 .
+Language=Russian
+ERROR_DS_OBJECT_RESULTS_TOO_LARGE - The result set is too large.
+.
 
 MessageId=8249
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_AFFECTS_MULTIPLE_DSAS
 Language=English
+ERROR_DS_AFFECTS_MULTIPLE_DSAS - The operation affects multiple DSAs
+.
+Language=Russian
 ERROR_DS_AFFECTS_MULTIPLE_DSAS - The operation affects multiple DSAs
 .
 
@@ -12359,12 +15365,18 @@ SymbolicName=ERROR_DS_SERVER_DOWN
 Language=English
 ERROR_DS_SERVER_DOWN - The server is not operational.
 .
+Language=Russian
+ERROR_DS_SERVER_DOWN - The server is not operational.
+.
 
 MessageId=8251
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_LOCAL_ERROR
 Language=English
+ERROR_DS_LOCAL_ERROR - A local error has occurred.
+.
+Language=Russian
 ERROR_DS_LOCAL_ERROR - A local error has occurred.
 .
 
@@ -12375,12 +15387,18 @@ SymbolicName=ERROR_DS_ENCODING_ERROR
 Language=English
 ERROR_DS_ENCODING_ERROR - An encoding error has occurred.
 .
+Language=Russian
+ERROR_DS_ENCODING_ERROR - An encoding error has occurred.
+.
 
 MessageId=8253
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DECODING_ERROR
 Language=English
+ERROR_DS_DECODING_ERROR - A decoding error has occurred.
+.
+Language=Russian
 ERROR_DS_DECODING_ERROR - A decoding error has occurred.
 .
 
@@ -12391,12 +15409,18 @@ SymbolicName=ERROR_DS_FILTER_UNKNOWN
 Language=English
 ERROR_DS_FILTER_UNKNOWN - The search filter cannot be recognized.
 .
+Language=Russian
+ERROR_DS_FILTER_UNKNOWN - The search filter cannot be recognized.
+.
 
 MessageId=8255
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_PARAM_ERROR
 Language=English
+ERROR_DS_PARAM_ERROR - One or more parameters are illegal.
+.
+Language=Russian
 ERROR_DS_PARAM_ERROR - One or more parameters are illegal.
 .
 
@@ -12407,12 +15431,18 @@ SymbolicName=ERROR_DS_NOT_SUPPORTED
 Language=English
 ERROR_DS_NOT_SUPPORTED - The specified method is not supported.
 .
+Language=Russian
+ERROR_DS_NOT_SUPPORTED - The specified method is not supported.
+.
 
 MessageId=8257
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_RESULTS_RETURNED
 Language=English
+ERROR_DS_NO_RESULTS_RETURNED - No results were returned.
+.
+Language=Russian
 ERROR_DS_NO_RESULTS_RETURNED - No results were returned.
 .
 
@@ -12423,12 +15453,18 @@ SymbolicName=ERROR_DS_CONTROL_NOT_FOUND
 Language=English
 ERROR_DS_CONTROL_NOT_FOUND - The specified control is not supported by the server.
 .
+Language=Russian
+ERROR_DS_CONTROL_NOT_FOUND - The specified control is not supported by the server.
+.
 
 MessageId=8259
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CLIENT_LOOP
 Language=English
+ERROR_DS_CLIENT_LOOP - A referral loop was detected by the client.
+.
+Language=Russian
 ERROR_DS_CLIENT_LOOP - A referral loop was detected by the client.
 .
 
@@ -12439,12 +15475,18 @@ SymbolicName=ERROR_DS_REFERRAL_LIMIT_EXCEEDED
 Language=English
 ERROR_DS_REFERRAL_LIMIT_EXCEEDED - The preset referral limit was exceeded.
 .
+Language=Russian
+ERROR_DS_REFERRAL_LIMIT_EXCEEDED - The preset referral limit was exceeded.
+.
 
 MessageId=8261
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SORT_CONTROL_MISSING
 Language=English
+ERROR_DS_SORT_CONTROL_MISSING - The search requires a SORT control.
+.
+Language=Russian
 ERROR_DS_SORT_CONTROL_MISSING - The search requires a SORT control.
 .
 
@@ -12455,12 +15497,18 @@ SymbolicName=ERROR_DS_OFFSET_RANGE_ERROR
 Language=English
 ERROR_DS_OFFSET_RANGE_ERROR - The search results exceed the offset range specified.
 .
+Language=Russian
+ERROR_DS_OFFSET_RANGE_ERROR - The search results exceed the offset range specified.
+.
 
 MessageId=8301
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ROOT_MUST_BE_NC
 Language=English
+ERROR_DS_ROOT_MUST_BE_NC - The root object must be the head of a naming context. The root object cannot have an instantiated parent.
+.
+Language=Russian
 ERROR_DS_ROOT_MUST_BE_NC - The root object must be the head of a naming context. The root object cannot have an instantiated parent.
 .
 
@@ -12471,12 +15519,18 @@ SymbolicName=ERROR_DS_ADD_REPLICA_INHIBITED
 Language=English
 ERROR_DS_ADD_REPLICA_INHIBITED - The add replica operation cannot be performed. The naming context must be writeable in order to create the replica.
 .
+Language=Russian
+ERROR_DS_ADD_REPLICA_INHIBITED - The add replica operation cannot be performed. The naming context must be writeable in order to create the replica.
+.
 
 MessageId=8303
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ATT_NOT_DEF_IN_SCHEMA
 Language=English
+ERROR_DS_ATT_NOT_DEF_IN_SCHEMA - A reference to an attribute that is not defined in the schema occurred.
+.
+Language=Russian
 ERROR_DS_ATT_NOT_DEF_IN_SCHEMA - A reference to an attribute that is not defined in the schema occurred.
 .
 
@@ -12487,12 +15541,18 @@ SymbolicName=ERROR_DS_MAX_OBJ_SIZE_EXCEEDED
 Language=English
 ERROR_DS_MAX_OBJ_SIZE_EXCEEDED - The maximum size of an object has been exceeded.
 .
+Language=Russian
+ERROR_DS_MAX_OBJ_SIZE_EXCEEDED - The maximum size of an object has been exceeded.
+.
 
 MessageId=8305
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OBJ_STRING_NAME_EXISTS
 Language=English
+ERROR_DS_OBJ_STRING_NAME_EXISTS - An attempt was made to add an object to the directory with a name that is already in use.
+.
+Language=Russian
 ERROR_DS_OBJ_STRING_NAME_EXISTS - An attempt was made to add an object to the directory with a name that is already in use.
 .
 
@@ -12503,12 +15563,18 @@ SymbolicName=ERROR_DS_NO_RDN_DEFINED_IN_SCHEMA
 Language=English
 ERROR_DS_NO_RDN_DEFINED_IN_SCHEMA - An attempt was made to add an object of a class that does not have an RDN defined in the schema.
 .
+Language=Russian
+ERROR_DS_NO_RDN_DEFINED_IN_SCHEMA - An attempt was made to add an object of a class that does not have an RDN defined in the schema.
+.
 
 MessageId=8307
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_RDN_DOESNT_MATCH_SCHEMA
 Language=English
+ERROR_DS_RDN_DOESNT_MATCH_SCHEMA - An attempt was made to add an object using an RDN that is not the RDN defined in the schema.
+.
+Language=Russian
 ERROR_DS_RDN_DOESNT_MATCH_SCHEMA - An attempt was made to add an object using an RDN that is not the RDN defined in the schema.
 .
 
@@ -12519,12 +15585,18 @@ SymbolicName=ERROR_DS_NO_REQUESTED_ATTS_FOUND
 Language=English
 ERROR_DS_NO_REQUESTED_ATTS_FOUND - None of the requested attributes were found on the objects.
 .
+Language=Russian
+ERROR_DS_NO_REQUESTED_ATTS_FOUND - None of the requested attributes were found on the objects.
+.
 
 MessageId=8309
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_USER_BUFFER_TO_SMALL
 Language=English
+ERROR_DS_USER_BUFFER_TO_SMALL - The user buffer is too small.
+.
+Language=Russian
 ERROR_DS_USER_BUFFER_TO_SMALL - The user buffer is too small.
 .
 
@@ -12535,12 +15607,18 @@ SymbolicName=ERROR_DS_ATT_IS_NOT_ON_OBJ
 Language=English
 ERROR_DS_ATT_IS_NOT_ON_OBJ - The attribute specified in the operation is not present on the object.
 .
+Language=Russian
+ERROR_DS_ATT_IS_NOT_ON_OBJ - The attribute specified in the operation is not present on the object.
+.
 
 MessageId=8311
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ILLEGAL_MOD_OPERATION
 Language=English
+ERROR_DS_ILLEGAL_MOD_OPERATION - Illegal modify operation. Some aspect of the modification is not permitted.
+.
+Language=Russian
 ERROR_DS_ILLEGAL_MOD_OPERATION - Illegal modify operation. Some aspect of the modification is not permitted.
 .
 
@@ -12551,12 +15629,18 @@ SymbolicName=ERROR_DS_OBJ_TOO_LARGE
 Language=English
 ERROR_DS_OBJ_TOO_LARGE - The specified object is too large.
 .
+Language=Russian
+ERROR_DS_OBJ_TOO_LARGE - The specified object is too large.
+.
 
 MessageId=8313
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BAD_INSTANCE_TYPE
 Language=English
+ERROR_DS_BAD_INSTANCE_TYPE - The specified instance type is not valid.
+.
+Language=Russian
 ERROR_DS_BAD_INSTANCE_TYPE - The specified instance type is not valid.
 .
 
@@ -12567,12 +15651,18 @@ SymbolicName=ERROR_DS_MASTERDSA_REQUIRED
 Language=English
 ERROR_DS_MASTERDSA_REQUIRED - The operation must be performed at a master DSA.
 .
+Language=Russian
+ERROR_DS_MASTERDSA_REQUIRED - The operation must be performed at a master DSA.
+.
 
 MessageId=8315
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OBJECT_CLASS_REQUIRED
 Language=English
+ERROR_DS_OBJECT_CLASS_REQUIRED - The object class attribute must be specified.
+.
+Language=Russian
 ERROR_DS_OBJECT_CLASS_REQUIRED - The object class attribute must be specified.
 .
 
@@ -12583,12 +15673,18 @@ SymbolicName=ERROR_DS_MISSING_REQUIRED_ATT
 Language=English
 ERROR_DS_MISSING_REQUIRED_ATT - A required attribute is missing.
 .
+Language=Russian
+ERROR_DS_MISSING_REQUIRED_ATT - A required attribute is missing.
+.
 
 MessageId=8317
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ATT_NOT_DEF_FOR_CLASS
 Language=English
+ERROR_DS_ATT_NOT_DEF_FOR_CLASS - An attempt was made to modify an object to include an attribute that is not legal for its class
+.
+Language=Russian
 ERROR_DS_ATT_NOT_DEF_FOR_CLASS - An attempt was made to modify an object to include an attribute that is not legal for its class
 .
 
@@ -12599,12 +15695,18 @@ SymbolicName=ERROR_DS_ATT_ALREADY_EXISTS
 Language=English
 ERROR_DS_ATT_ALREADY_EXISTS - The specified attribute is already present on the object.
 .
+Language=Russian
+ERROR_DS_ATT_ALREADY_EXISTS - The specified attribute is already present on the object.
+.
 
 MessageId=8320
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_ADD_ATT_VALUES
 Language=English
+ERROR_DS_CANT_ADD_ATT_VALUES - The specified attribute is not present, or has no values.
+.
+Language=Russian
 ERROR_DS_CANT_ADD_ATT_VALUES - The specified attribute is not present, or has no values.
 .
 
@@ -12615,12 +15717,18 @@ SymbolicName=ERROR_DS_SINGLE_VALUE_CONSTRAINT
 Language=English
 ERROR_DS_SINGLE_VALUE_CONSTRAINT - Multiple values were specified for an attribute that can have only one value.
 .
+Language=Russian
+ERROR_DS_SINGLE_VALUE_CONSTRAINT - Multiple values were specified for an attribute that can have only one value.
+.
 
 MessageId=8322
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_RANGE_CONSTRAINT
 Language=English
+ERROR_DS_RANGE_CONSTRAINT - A value for the attribute was not in the acceptable range of values.
+.
+Language=Russian
 ERROR_DS_RANGE_CONSTRAINT - A value for the attribute was not in the acceptable range of values.
 .
 
@@ -12631,12 +15739,18 @@ SymbolicName=ERROR_DS_ATT_VAL_ALREADY_EXISTS
 Language=English
 ERROR_DS_ATT_VAL_ALREADY_EXISTS - The specified value already exists.
 .
+Language=Russian
+ERROR_DS_ATT_VAL_ALREADY_EXISTS - The specified value already exists.
+.
 
 MessageId=8324
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_REM_MISSING_ATT
 Language=English
+ERROR_DS_CANT_REM_MISSING_ATT - The attribute cannot be removed because it is not present on the object.
+.
+Language=Russian
 ERROR_DS_CANT_REM_MISSING_ATT - The attribute cannot be removed because it is not present on the object.
 .
 
@@ -12647,12 +15761,18 @@ SymbolicName=ERROR_DS_CANT_REM_MISSING_ATT_VAL
 Language=English
 ERROR_DS_CANT_REM_MISSING_ATT_VAL - The attribute value cannot be removed because it is not present on the object.
 .
+Language=Russian
+ERROR_DS_CANT_REM_MISSING_ATT_VAL - The attribute value cannot be removed because it is not present on the object.
+.
 
 MessageId=8326
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ROOT_CANT_BE_SUBREF
 Language=English
+ERROR_DS_ROOT_CANT_BE_SUBREF - The specified root object cannot be a subref.
+.
+Language=Russian
 ERROR_DS_ROOT_CANT_BE_SUBREF - The specified root object cannot be a subref.
 .
 
@@ -12663,12 +15783,18 @@ SymbolicName=ERROR_DS_NO_CHAINING
 Language=English
 ERROR_DS_NO_CHAINING - Chaining is not permitted.
 .
+Language=Russian
+ERROR_DS_NO_CHAINING - Chaining is not permitted.
+.
 
 MessageId=8328
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_CHAINED_EVAL
 Language=English
+ERROR_DS_NO_CHAINED_EVAL - Chained evaluation is not permitted.
+.
+Language=Russian
 ERROR_DS_NO_CHAINED_EVAL - Chained evaluation is not permitted.
 .
 
@@ -12679,12 +15805,18 @@ SymbolicName=ERROR_DS_NO_PARENT_OBJECT
 Language=English
 ERROR_DS_NO_PARENT_OBJECT - The operation could not be performed because the object's parent is either uninstantiated or deleted.
 .
+Language=Russian
+ERROR_DS_NO_PARENT_OBJECT - The operation could not be performed because the object's parent is either uninstantiated or deleted.
+.
 
 MessageId=8330
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_PARENT_IS_AN_ALIAS
 Language=English
+ERROR_DS_PARENT_IS_AN_ALIAS - Having a parent that is an alias is not permitted. Aliases are leaf objects.
+.
+Language=Russian
 ERROR_DS_PARENT_IS_AN_ALIAS - Having a parent that is an alias is not permitted. Aliases are leaf objects.
 .
 
@@ -12695,12 +15827,18 @@ SymbolicName=ERROR_DS_CANT_MIX_MASTER_AND_REPS
 Language=English
 ERROR_DS_CANT_MIX_MASTER_AND_REPS - The object and parent must be of the same type, either both masters or both replicas.
 .
+Language=Russian
+ERROR_DS_CANT_MIX_MASTER_AND_REPS - The object and parent must be of the same type, either both masters or both replicas.
+.
 
 MessageId=8332
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CHILDREN_EXIST
 Language=English
+ERROR_DS_CHILDREN_EXIST - The operation cannot be performed because child objects exist. This operation can only be performed on a leaf object.
+.
+Language=Russian
 ERROR_DS_CHILDREN_EXIST - The operation cannot be performed because child objects exist. This operation can only be performed on a leaf object.
 .
 
@@ -12711,12 +15849,18 @@ SymbolicName=ERROR_DS_OBJ_NOT_FOUND
 Language=English
 ERROR_DS_OBJ_NOT_FOUND - Directory object not found.
 .
+Language=Russian
+ERROR_DS_OBJ_NOT_FOUND - Directory object not found.
+.
 
 MessageId=8334
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ALIASED_OBJ_MISSING
 Language=English
+ERROR_DS_ALIASED_OBJ_MISSING - The aliased object is missing.
+.
+Language=Russian
 ERROR_DS_ALIASED_OBJ_MISSING - The aliased object is missing.
 .
 
@@ -12727,12 +15871,18 @@ SymbolicName=ERROR_DS_BAD_NAME_SYNTAX
 Language=English
 ERROR_DS_BAD_NAME_SYNTAX - The object name has bad syntax.
 .
+Language=Russian
+ERROR_DS_BAD_NAME_SYNTAX - The object name has bad syntax.
+.
 
 MessageId=8336
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ALIAS_POINTS_TO_ALIAS
 Language=English
+ERROR_DS_ALIAS_POINTS_TO_ALIAS - It is not permitted for an alias to refer to another alias.
+.
+Language=Russian
 ERROR_DS_ALIAS_POINTS_TO_ALIAS - It is not permitted for an alias to refer to another alias.
 .
 
@@ -12743,12 +15893,18 @@ SymbolicName=ERROR_DS_CANT_DEREF_ALIAS
 Language=English
 ERROR_DS_CANT_DEREF_ALIAS - The alias cannot be dereferenced.
 .
+Language=Russian
+ERROR_DS_CANT_DEREF_ALIAS - The alias cannot be dereferenced.
+.
 
 MessageId=8338
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OUT_OF_SCOPE
 Language=English
+ERROR_DS_OUT_OF_SCOPE - The operation is out of scope.
+.
+Language=Russian
 ERROR_DS_OUT_OF_SCOPE - The operation is out of scope.
 .
 
@@ -12759,12 +15915,18 @@ SymbolicName=ERROR_DS_OBJECT_BEING_REMOVED
 Language=English
 ERROR_DS_OBJECT_BEING_REMOVED - The operation cannot continue because the object is in the process of being removed.
 .
+Language=Russian
+ERROR_DS_OBJECT_BEING_REMOVED - The operation cannot continue because the object is in the process of being removed.
+.
 
 MessageId=8340
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_DELETE_DSA_OBJ
 Language=English
+ERROR_DS_CANT_DELETE_DSA_OBJ - The DSA object cannot be deleted.
+.
+Language=Russian
 ERROR_DS_CANT_DELETE_DSA_OBJ - The DSA object cannot be deleted.
 .
 
@@ -12775,12 +15937,18 @@ SymbolicName=ERROR_DS_GENERIC_ERROR
 Language=English
 ERROR_DS_GENERIC_ERROR - A directory service error has occurred.
 .
+Language=Russian
+ERROR_DS_GENERIC_ERROR - A directory service error has occurred.
+.
 
 MessageId=8342
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DSA_MUST_BE_INT_MASTER
 Language=English
+ERROR_DS_DSA_MUST_BE_INT_MASTER - The operation can only be performed on an internal master DSA object.
+.
+Language=Russian
 ERROR_DS_DSA_MUST_BE_INT_MASTER - The operation can only be performed on an internal master DSA object.
 .
 
@@ -12791,12 +15959,18 @@ SymbolicName=ERROR_DS_CLASS_NOT_DSA
 Language=English
 ERROR_DS_CLASS_NOT_DSA - The object must be of class DSA.
 .
+Language=Russian
+ERROR_DS_CLASS_NOT_DSA - The object must be of class DSA.
+.
 
 MessageId=8344
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INSUFF_ACCESS_RIGHTS
 Language=English
+ERROR_DS_INSUFF_ACCESS_RIGHTS - Insufficient access rights to perform the operation.
+.
+Language=Russian
 ERROR_DS_INSUFF_ACCESS_RIGHTS - Insufficient access rights to perform the operation.
 .
 
@@ -12807,12 +15981,18 @@ SymbolicName=ERROR_DS_ILLEGAL_SUPERIOR
 Language=English
 ERROR_DS_ILLEGAL_SUPERIOR - The object cannot be added because the parent is not on the list of possible superiors.
 .
+Language=Russian
+ERROR_DS_ILLEGAL_SUPERIOR - The object cannot be added because the parent is not on the list of possible superiors.
+.
 
 MessageId=8346
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ATTRIBUTE_OWNED_BY_SAM
 Language=English
+ERROR_DS_ATTRIBUTE_OWNED_BY_SAM - Access to the attribute is not permitted because the attribute is owned by the Security Accounts Manager (SAM).
+.
+Language=Russian
 ERROR_DS_ATTRIBUTE_OWNED_BY_SAM - Access to the attribute is not permitted because the attribute is owned by the Security Accounts Manager (SAM).
 .
 
@@ -12823,12 +16003,18 @@ SymbolicName=ERROR_DS_NAME_TOO_MANY_PARTS
 Language=English
 ERROR_DS_NAME_TOO_MANY_PARTS - The name has too many parts.
 .
+Language=Russian
+ERROR_DS_NAME_TOO_MANY_PARTS - The name has too many parts.
+.
 
 MessageId=8348
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_TOO_LONG
 Language=English
+ERROR_DS_NAME_TOO_LONG - The name is too long.
+.
+Language=Russian
 ERROR_DS_NAME_TOO_LONG - The name is too long.
 .
 
@@ -12839,12 +16025,18 @@ SymbolicName=ERROR_DS_NAME_VALUE_TOO_LONG
 Language=English
 ERROR_DS_NAME_VALUE_TOO_LONG - The name value is too long.
 .
+Language=Russian
+ERROR_DS_NAME_VALUE_TOO_LONG - The name value is too long.
+.
 
 MessageId=8350
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_UNPARSEABLE
 Language=English
+ERROR_DS_NAME_UNPARSEABLE - The directory service encountered an error parsing a name.
+.
+Language=Russian
 ERROR_DS_NAME_UNPARSEABLE - The directory service encountered an error parsing a name.
 .
 
@@ -12855,12 +16047,18 @@ SymbolicName=ERROR_DS_NAME_TYPE_UNKNOWN
 Language=English
 ERROR_DS_NAME_TYPE_UNKNOWN - The directory service cannot get the attribute type for a name.
 .
+Language=Russian
+ERROR_DS_NAME_TYPE_UNKNOWN - The directory service cannot get the attribute type for a name.
+.
 
 MessageId=8352
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NOT_AN_OBJECT
 Language=English
+ERROR_DS_NOT_AN_OBJECT - The name does not identify an object; the name identifies a phantom.
+.
+Language=Russian
 ERROR_DS_NOT_AN_OBJECT - The name does not identify an object; the name identifies a phantom.
 .
 
@@ -12871,12 +16069,18 @@ SymbolicName=ERROR_DS_SEC_DESC_TOO_SHORT
 Language=English
 ERROR_DS_SEC_DESC_TOO_SHORT - The security descriptor is too short.
 .
+Language=Russian
+ERROR_DS_SEC_DESC_TOO_SHORT - The security descriptor is too short.
+.
 
 MessageId=8354
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SEC_DESC_INVALID
 Language=English
+ERROR_DS_SEC_DESC_INVALID - The security descriptor is invalid.
+.
+Language=Russian
 ERROR_DS_SEC_DESC_INVALID - The security descriptor is invalid.
 .
 
@@ -12887,12 +16091,18 @@ SymbolicName=ERROR_DS_NO_DELETED_NAME
 Language=English
 ERROR_DS_NO_DELETED_NAME - Failed to create name for deleted object.
 .
+Language=Russian
+ERROR_DS_NO_DELETED_NAME - Failed to create name for deleted object.
+.
 
 MessageId=8356
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SUBREF_MUST_HAVE_PARENT
 Language=English
+ERROR_DS_SUBREF_MUST_HAVE_PARENT - The parent of a new subref must exist.
+.
+Language=Russian
 ERROR_DS_SUBREF_MUST_HAVE_PARENT - The parent of a new subref must exist.
 .
 
@@ -12903,12 +16113,18 @@ SymbolicName=ERROR_DS_NCNAME_MUST_BE_NC
 Language=English
 ERROR_DS_NCNAME_MUST_BE_NC - The object must be a naming context.
 .
+Language=Russian
+ERROR_DS_NCNAME_MUST_BE_NC - The object must be a naming context.
+.
 
 MessageId=8358
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_ADD_SYSTEM_ONLY
 Language=English
+ERROR_DS_CANT_ADD_SYSTEM_ONLY - It is not permitted to add an attribute which is owned by the system.
+.
+Language=Russian
 ERROR_DS_CANT_ADD_SYSTEM_ONLY - It is not permitted to add an attribute which is owned by the system.
 .
 
@@ -12919,12 +16135,18 @@ SymbolicName=ERROR_DS_CLASS_MUST_BE_CONCRETE
 Language=English
 ERROR_DS_CLASS_MUST_BE_CONCRETE - The class of the object must be structural; you cannot instantiate an abstract class.
 .
+Language=Russian
+ERROR_DS_CLASS_MUST_BE_CONCRETE - The class of the object must be structural; you cannot instantiate an abstract class.
+.
 
 MessageId=8360
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INVALID_DMD
 Language=English
+ERROR_DS_INVALID_DMD - The schema object could not be found.
+.
+Language=Russian
 ERROR_DS_INVALID_DMD - The schema object could not be found.
 .
 
@@ -12935,12 +16157,18 @@ SymbolicName=ERROR_DS_OBJ_GUID_EXISTS
 Language=English
 ERROR_DS_OBJ_GUID_EXISTS - A local object with this GUID (dead or alive) already exists.
 .
+Language=Russian
+ERROR_DS_OBJ_GUID_EXISTS - A local object with this GUID (dead or alive) already exists.
+.
 
 MessageId=8362
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NOT_ON_BACKLINK
 Language=English
+ERROR_DS_NOT_ON_BACKLINK - The operation cannot be performed on a back link.
+.
+Language=Russian
 ERROR_DS_NOT_ON_BACKLINK - The operation cannot be performed on a back link.
 .
 
@@ -12951,12 +16179,18 @@ SymbolicName=ERROR_DS_NO_CROSSREF_FOR_NC
 Language=English
 ERROR_DS_NO_CROSSREF_FOR_NC - The cross reference for the specified naming context could not be found.
 .
+Language=Russian
+ERROR_DS_NO_CROSSREF_FOR_NC - The cross reference for the specified naming context could not be found.
+.
 
 MessageId=8364
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SHUTTING_DOWN
 Language=English
+ERROR_DS_SHUTTING_DOWN - The operation could not be performed because the directory service is shutting down.
+.
+Language=Russian
 ERROR_DS_SHUTTING_DOWN - The operation could not be performed because the directory service is shutting down.
 .
 
@@ -12967,12 +16201,18 @@ SymbolicName=ERROR_DS_UNKNOWN_OPERATION
 Language=English
 ERROR_DS_UNKNOWN_OPERATION - The directory service request is invalid.
 .
+Language=Russian
+ERROR_DS_UNKNOWN_OPERATION - The directory service request is invalid.
+.
 
 MessageId=8366
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INVALID_ROLE_OWNER
 Language=English
+ERROR_DS_INVALID_ROLE_OWNER - The role owner attribute could not be read.
+.
+Language=Russian
 ERROR_DS_INVALID_ROLE_OWNER - The role owner attribute could not be read.
 .
 
@@ -12983,12 +16223,18 @@ SymbolicName=ERROR_DS_COULDNT_CONTACT_FSMO
 Language=English
 ERROR_DS_COULDNT_CONTACT_FSMO - The requested FSMO operation failed. The current FSMO holder could not be reached.
 .
+Language=Russian
+ERROR_DS_COULDNT_CONTACT_FSMO - The requested FSMO operation failed. The current FSMO holder could not be reached.
+.
 
 MessageId=8368
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CROSS_NC_DN_RENAME
 Language=English
+ERROR_DS_CROSS_NC_DN_RENAME - Modification of a DN across a naming context is not permitted.
+.
+Language=Russian
 ERROR_DS_CROSS_NC_DN_RENAME - Modification of a DN across a naming context is not permitted.
 .
 
@@ -12999,12 +16245,18 @@ SymbolicName=ERROR_DS_CANT_MOD_SYSTEM_ONLY
 Language=English
 ERROR_DS_CANT_MOD_SYSTEM_ONLY - The attribute cannot be modified because it is owned by the system.
 .
+Language=Russian
+ERROR_DS_CANT_MOD_SYSTEM_ONLY - The attribute cannot be modified because it is owned by the system.
+.
 
 MessageId=8370
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_REPLICATOR_ONLY
 Language=English
+ERROR_DS_REPLICATOR_ONLY - Only the replicator can perform this function.
+.
+Language=Russian
 ERROR_DS_REPLICATOR_ONLY - Only the replicator can perform this function.
 .
 
@@ -13015,12 +16267,18 @@ SymbolicName=ERROR_DS_OBJ_CLASS_NOT_DEFINED
 Language=English
 ERROR_DS_OBJ_CLASS_NOT_DEFINED - The specified class is not defined.
 .
+Language=Russian
+ERROR_DS_OBJ_CLASS_NOT_DEFINED - The specified class is not defined.
+.
 
 MessageId=8372
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OBJ_CLASS_NOT_SUBCLASS
 Language=English
+ERROR_DS_OBJ_CLASS_NOT_SUBCLASS - The specified class is not a subclass.
+.
+Language=Russian
 ERROR_DS_OBJ_CLASS_NOT_SUBCLASS - The specified class is not a subclass.
 .
 
@@ -13031,12 +16289,18 @@ SymbolicName=ERROR_DS_NAME_REFERENCE_INVALID
 Language=English
 ERROR_DS_NAME_REFERENCE_INVALID - The name reference is invalid.
 .
+Language=Russian
+ERROR_DS_NAME_REFERENCE_INVALID - The name reference is invalid.
+.
 
 MessageId=8374
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CROSS_REF_EXISTS
 Language=English
+ERROR_DS_CROSS_REF_EXISTS - A cross reference already exists.
+.
+Language=Russian
 ERROR_DS_CROSS_REF_EXISTS - A cross reference already exists.
 .
 
@@ -13047,12 +16311,18 @@ SymbolicName=ERROR_DS_CANT_DEL_MASTER_CROSSREF
 Language=English
 ERROR_DS_CANT_DEL_MASTER_CROSSREF - It is not permitted to delete a master cross reference.
 .
+Language=Russian
+ERROR_DS_CANT_DEL_MASTER_CROSSREF - It is not permitted to delete a master cross reference.
+.
 
 MessageId=8376
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SUBTREE_NOTIFY_NOT_NC_HEAD
 Language=English
+ERROR_DS_SUBTREE_NOTIFY_NOT_NC_HEAD - Subtree notifications are only supported on NC heads.
+.
+Language=Russian
 ERROR_DS_SUBTREE_NOTIFY_NOT_NC_HEAD - Subtree notifications are only supported on NC heads.
 .
 
@@ -13063,12 +16333,18 @@ SymbolicName=ERROR_DS_NOTIFY_FILTER_TOO_COMPLEX
 Language=English
 ERROR_DS_NOTIFY_FILTER_TOO_COMPLEX - Notification filter is too complex.
 .
+Language=Russian
+ERROR_DS_NOTIFY_FILTER_TOO_COMPLEX - Notification filter is too complex.
+.
 
 MessageId=8378
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUP_RDN
 Language=English
+ERROR_DS_DUP_RDN - Schema update failed: duplicate RDN.
+.
+Language=Russian
 ERROR_DS_DUP_RDN - Schema update failed: duplicate RDN.
 .
 
@@ -13079,12 +16355,18 @@ SymbolicName=ERROR_DS_DUP_OID
 Language=English
 ERROR_DS_DUP_OID - Schema update failed: duplicate OID
 .
+Language=Russian
+ERROR_DS_DUP_OID - Schema update failed: duplicate OID
+.
 
 MessageId=8380
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUP_MAPI_ID
 Language=English
+ERROR_DS_DUP_MAPI_ID - Schema update failed: duplicate MAPI identifier.
+.
+Language=Russian
 ERROR_DS_DUP_MAPI_ID - Schema update failed: duplicate MAPI identifier.
 .
 
@@ -13095,12 +16377,18 @@ SymbolicName=ERROR_DS_DUP_SCHEMA_ID_GUID
 Language=English
 ERROR_DS_DUP_SCHEMA_ID_GUID - Schema update failed: duplicate schema-id GUID.
 .
+Language=Russian
+ERROR_DS_DUP_SCHEMA_ID_GUID - Schema update failed: duplicate schema-id GUID.
+.
 
 MessageId=8382
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUP_LDAP_DISPLAY_NAME
 Language=English
+ERROR_DS_DUP_LDAP_DISPLAY_NAME - Schema update failed: duplicate LDAP display name.
+.
+Language=Russian
 ERROR_DS_DUP_LDAP_DISPLAY_NAME - Schema update failed: duplicate LDAP display name.
 .
 
@@ -13111,12 +16399,18 @@ SymbolicName=ERROR_DS_SEMANTIC_ATT_TEST
 Language=English
 ERROR_DS_SEMANTIC_ATT_TEST - Schema update failed: range-lower less than range upper
 .
+Language=Russian
+ERROR_DS_SEMANTIC_ATT_TEST - Schema update failed: range-lower less than range upper
+.
 
 MessageId=8384
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SYNTAX_MISMATCH
 Language=English
+ERROR_DS_SYNTAX_MISMATCH - Schema update failed: syntax mismatch
+.
+Language=Russian
 ERROR_DS_SYNTAX_MISMATCH - Schema update failed: syntax mismatch
 .
 
@@ -13127,12 +16421,18 @@ SymbolicName=ERROR_DS_EXISTS_IN_MUST_HAVE
 Language=English
 ERROR_DS_EXISTS_IN_MUST_HAVE - Schema deletion failed: attribute is used in must-contain
 .
+Language=Russian
+ERROR_DS_EXISTS_IN_MUST_HAVE - Schema deletion failed: attribute is used in must-contain
+.
 
 MessageId=8386
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_EXISTS_IN_MAY_HAVE
 Language=English
+ERROR_DS_EXISTS_IN_MAY_HAVE - Schema deletion failed: attribute is used in may-contain
+.
+Language=Russian
 ERROR_DS_EXISTS_IN_MAY_HAVE - Schema deletion failed: attribute is used in may-contain
 .
 
@@ -13143,12 +16443,18 @@ SymbolicName=ERROR_DS_NONEXISTENT_MAY_HAVE
 Language=English
 ERROR_DS_NONEXISTENT_MAY_HAVE - Schema update failed: attribute in may-contain does not exist
 .
+Language=Russian
+ERROR_DS_NONEXISTENT_MAY_HAVE - Schema update failed: attribute in may-contain does not exist
+.
 
 MessageId=8388
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NONEXISTENT_MUST_HAVE
 Language=English
+ERROR_DS_NONEXISTENT_MUST_HAVE - Schema update failed: attribute in must-contain does not exist
+.
+Language=Russian
 ERROR_DS_NONEXISTENT_MUST_HAVE - Schema update failed: attribute in must-contain does not exist
 .
 
@@ -13159,12 +16465,18 @@ SymbolicName=ERROR_DS_AUX_CLS_TEST_FAIL
 Language=English
 ERROR_DS_AUX_CLS_TEST_FAIL - Schema update failed: class in aux-class list does not exist or is not an auxiliary class
 .
+Language=Russian
+ERROR_DS_AUX_CLS_TEST_FAIL - Schema update failed: class in aux-class list does not exist or is not an auxiliary class
+.
 
 MessageId=8390
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NONEXISTENT_POSS_SUP
 Language=English
+ERROR_DS_NONEXISTENT_POSS_SUP - Schema update failed: class in poss-superiors does not exist
+.
+Language=Russian
 ERROR_DS_NONEXISTENT_POSS_SUP - Schema update failed: class in poss-superiors does not exist
 .
 
@@ -13175,12 +16487,18 @@ SymbolicName=ERROR_DS_SUB_CLS_TEST_FAIL
 Language=English
 ERROR_DS_SUB_CLS_TEST_FAIL - Schema update failed: class in subclassof list does not exist or does not satisfy hierarchy rules
 .
+Language=Russian
+ERROR_DS_SUB_CLS_TEST_FAIL - Schema update failed: class in subclassof list does not exist or does not satisfy hierarchy rules
+.
 
 MessageId=8392
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BAD_RDN_ATT_ID_SYNTAX
 Language=English
+ERROR_DS_BAD_RDN_ATT_ID_SYNTAX - Schema update failed: Rdn-Att-Id has wrong syntax
+.
+Language=Russian
 ERROR_DS_BAD_RDN_ATT_ID_SYNTAX - Schema update failed: Rdn-Att-Id has wrong syntax
 .
 
@@ -13191,12 +16509,18 @@ SymbolicName=ERROR_DS_EXISTS_IN_AUX_CLS
 Language=English
 ERROR_DS_EXISTS_IN_AUX_CLS - Schema deletion failed: class is used as auxiliary class
 .
+Language=Russian
+ERROR_DS_EXISTS_IN_AUX_CLS - Schema deletion failed: class is used as auxiliary class
+.
 
 MessageId=8394
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_EXISTS_IN_SUB_CLS
 Language=English
+ERROR_DS_EXISTS_IN_SUB_CLS - Schema deletion failed: class is used as sub class
+.
+Language=Russian
 ERROR_DS_EXISTS_IN_SUB_CLS - Schema deletion failed: class is used as sub class
 .
 
@@ -13207,12 +16531,18 @@ SymbolicName=ERROR_DS_EXISTS_IN_POSS_SUP
 Language=English
 ERROR_DS_EXISTS_IN_POSS_SUP - Schema deletion failed: class is used as poss superior
 .
+Language=Russian
+ERROR_DS_EXISTS_IN_POSS_SUP - Schema deletion failed: class is used as poss superior
+.
 
 MessageId=8396
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_RECALCSCHEMA_FAILED
 Language=English
+ERROR_DS_RECALCSCHEMA_FAILED - Schema update failed in recalculating validation cache.
+.
+Language=Russian
 ERROR_DS_RECALCSCHEMA_FAILED - Schema update failed in recalculating validation cache.
 .
 
@@ -13223,12 +16553,18 @@ SymbolicName=ERROR_DS_TREE_DELETE_NOT_FINISHED
 Language=English
 ERROR_DS_TREE_DELETE_NOT_FINISHED - The tree deletion is not finished.
 .
+Language=Russian
+ERROR_DS_TREE_DELETE_NOT_FINISHED - The tree deletion is not finished.
+.
 
 MessageId=8398
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_DELETE
 Language=English
+ERROR_DS_CANT_DELETE - The requested delete operation could not be performed.
+.
+Language=Russian
 ERROR_DS_CANT_DELETE - The requested delete operation could not be performed.
 .
 
@@ -13239,12 +16575,18 @@ SymbolicName=ERROR_DS_ATT_SCHEMA_REQ_ID
 Language=English
 ERROR_DS_ATT_SCHEMA_REQ_ID - Cannot read the governs class identifier for the schema record.
 .
+Language=Russian
+ERROR_DS_ATT_SCHEMA_REQ_ID - Cannot read the governs class identifier for the schema record.
+.
 
 MessageId=8400
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BAD_ATT_SCHEMA_SYNTAX
 Language=English
+ERROR_DS_BAD_ATT_SCHEMA_SYNTAX - The attribute schema has bad syntax.
+.
+Language=Russian
 ERROR_DS_BAD_ATT_SCHEMA_SYNTAX - The attribute schema has bad syntax.
 .
 
@@ -13255,12 +16597,18 @@ SymbolicName=ERROR_DS_CANT_CACHE_ATT
 Language=English
 ERROR_DS_CANT_CACHE_ATT - The attribute could not be cached.
 .
+Language=Russian
+ERROR_DS_CANT_CACHE_ATT - The attribute could not be cached.
+.
 
 MessageId=8402
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_CACHE_CLASS
 Language=English
+ERROR_DS_CANT_CACHE_CLASS - The class could not be cached.
+.
+Language=Russian
 ERROR_DS_CANT_CACHE_CLASS - The class could not be cached.
 .
 
@@ -13271,12 +16619,18 @@ SymbolicName=ERROR_DS_CANT_REMOVE_ATT_CACHE
 Language=English
 ERROR_DS_CANT_REMOVE_ATT_CACHE - The attribute could not be removed from the cache.
 .
+Language=Russian
+ERROR_DS_CANT_REMOVE_ATT_CACHE - The attribute could not be removed from the cache.
+.
 
 MessageId=8404
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_REMOVE_CLASS_CACHE
 Language=English
+ERROR_DS_CANT_REMOVE_CLASS_CACHE - The class could not be removed from the cache.
+.
+Language=Russian
 ERROR_DS_CANT_REMOVE_CLASS_CACHE - The class could not be removed from the cache.
 .
 
@@ -13287,12 +16641,18 @@ SymbolicName=ERROR_DS_CANT_RETRIEVE_DN
 Language=English
 ERROR_DS_CANT_RETRIEVE_DN - The distinguished name attribute could not be read.
 .
+Language=Russian
+ERROR_DS_CANT_RETRIEVE_DN - The distinguished name attribute could not be read.
+.
 
 MessageId=8406
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_MISSING_SUPREF
 Language=English
+ERROR_DS_MISSING_SUPREF - No superior reference has been configured for the directory service. The directory service is therefore unable to issue referrals to objects outside this forest.
+.
+Language=Russian
 ERROR_DS_MISSING_SUPREF - No superior reference has been configured for the directory service. The directory service is therefore unable to issue referrals to objects outside this forest.
 .
 
@@ -13303,12 +16663,18 @@ SymbolicName=ERROR_DS_CANT_RETRIEVE_INSTANCE
 Language=English
 ERROR_DS_CANT_RETRIEVE_INSTANCE - The instance type attribute could not be retrieved.
 .
+Language=Russian
+ERROR_DS_CANT_RETRIEVE_INSTANCE - The instance type attribute could not be retrieved.
+.
 
 MessageId=8408
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CODE_INCONSISTENCY
 Language=English
+ERROR_DS_CODE_INCONSISTENCY - An internal error has occurred.
+.
+Language=Russian
 ERROR_DS_CODE_INCONSISTENCY - An internal error has occurred.
 .
 
@@ -13319,12 +16685,18 @@ SymbolicName=ERROR_DS_DATABASE_ERROR
 Language=English
 ERROR_DS_DATABASE_ERROR - A database error has occurred.
 .
+Language=Russian
+ERROR_DS_DATABASE_ERROR - A database error has occurred.
+.
 
 MessageId=8410
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_GOVERNSID_MISSING
 Language=English
+ERROR_DS_GOVERNSID_MISSING - The attribute GOVERNSID is missing.
+.
+Language=Russian
 ERROR_DS_GOVERNSID_MISSING - The attribute GOVERNSID is missing.
 .
 
@@ -13335,12 +16707,18 @@ SymbolicName=ERROR_DS_MISSING_EXPECTED_ATT
 Language=English
 ERROR_DS_MISSING_EXPECTED_ATT - An expected attribute is missing.
 .
+Language=Russian
+ERROR_DS_MISSING_EXPECTED_ATT - An expected attribute is missing.
+.
 
 MessageId=8412
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NCNAME_MISSING_CR_REF
 Language=English
+ERROR_DS_NCNAME_MISSING_CR_REF - The specified naming context is missing a cross reference.
+.
+Language=Russian
 ERROR_DS_NCNAME_MISSING_CR_REF - The specified naming context is missing a cross reference.
 .
 
@@ -13351,12 +16729,18 @@ SymbolicName=ERROR_DS_SECURITY_CHECKING_ERROR
 Language=English
 ERROR_DS_SECURITY_CHECKING_ERROR - A security checking error has occurred.
 .
+Language=Russian
+ERROR_DS_SECURITY_CHECKING_ERROR - A security checking error has occurred.
+.
 
 MessageId=8414
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SCHEMA_NOT_LOADED
 Language=English
+ERROR_DS_SCHEMA_NOT_LOADED - The schema is not loaded.
+.
+Language=Russian
 ERROR_DS_SCHEMA_NOT_LOADED - The schema is not loaded.
 .
 
@@ -13367,12 +16751,18 @@ SymbolicName=ERROR_DS_SCHEMA_ALLOC_FAILED
 Language=English
 ERROR_DS_SCHEMA_ALLOC_FAILED - Schema allocation failed. Please check if the machine is running low on memory.
 .
+Language=Russian
+ERROR_DS_SCHEMA_ALLOC_FAILED - Schema allocation failed. Please check if the machine is running low on memory.
+.
 
 MessageId=8416
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ATT_SCHEMA_REQ_SYNTAX
 Language=English
+ERROR_DS_ATT_SCHEMA_REQ_SYNTAX - Failed to obtain the required syntax for the attribute schema.
+.
+Language=Russian
 ERROR_DS_ATT_SCHEMA_REQ_SYNTAX - Failed to obtain the required syntax for the attribute schema.
 .
 
@@ -13383,12 +16773,18 @@ SymbolicName=ERROR_DS_GCVERIFY_ERROR
 Language=English
 ERROR_DS_GCVERIFY_ERROR - The global catalog verification failed. The global catalog is not available or does not support the operation. Some part of the directory is currently not available.
 .
+Language=Russian
+ERROR_DS_GCVERIFY_ERROR - The global catalog verification failed. The global catalog is not available or does not support the operation. Some part of the directory is currently not available.
+.
 
 MessageId=8418
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_SCHEMA_MISMATCH
 Language=English
+ERROR_DS_DRA_SCHEMA_MISMATCH - The replication operation failed because of a schema mismatch between the servers involved.
+.
+Language=Russian
 ERROR_DS_DRA_SCHEMA_MISMATCH - The replication operation failed because of a schema mismatch between the servers involved.
 .
 
@@ -13399,12 +16795,18 @@ SymbolicName=ERROR_DS_CANT_FIND_DSA_OBJ
 Language=English
 ERROR_DS_CANT_FIND_DSA_OBJ - The DSA object could not be found.
 .
+Language=Russian
+ERROR_DS_CANT_FIND_DSA_OBJ - The DSA object could not be found.
+.
 
 MessageId=8420
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_FIND_EXPECTED_NC
 Language=English
+ERROR_DS_CANT_FIND_EXPECTED_NC - The naming context could not be found.
+.
+Language=Russian
 ERROR_DS_CANT_FIND_EXPECTED_NC - The naming context could not be found.
 .
 
@@ -13415,12 +16817,18 @@ SymbolicName=ERROR_DS_CANT_FIND_NC_IN_CACHE
 Language=English
 ERROR_DS_CANT_FIND_NC_IN_CACHE - The naming context could not be found in the cache.
 .
+Language=Russian
+ERROR_DS_CANT_FIND_NC_IN_CACHE - The naming context could not be found in the cache.
+.
 
 MessageId=8422
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_RETRIEVE_CHILD
 Language=English
+ERROR_DS_CANT_RETRIEVE_CHILD - The child object could not be retrieved.
+.
+Language=Russian
 ERROR_DS_CANT_RETRIEVE_CHILD - The child object could not be retrieved.
 .
 
@@ -13431,12 +16839,18 @@ SymbolicName=ERROR_DS_SECURITY_ILLEGAL_MODIFY
 Language=English
 ERROR_DS_SECURITY_ILLEGAL_MODIFY - The modification was not permitted for security reasons.
 .
+Language=Russian
+ERROR_DS_SECURITY_ILLEGAL_MODIFY - The modification was not permitted for security reasons.
+.
 
 MessageId=8424
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_REPLACE_HIDDEN_REC
 Language=English
+ERROR_DS_CANT_REPLACE_HIDDEN_REC - The operation cannot replace the hidden record.
+.
+Language=Russian
 ERROR_DS_CANT_REPLACE_HIDDEN_REC - The operation cannot replace the hidden record.
 .
 
@@ -13447,12 +16861,18 @@ SymbolicName=ERROR_DS_BAD_HIERARCHY_FILE
 Language=English
 ERROR_DS_BAD_HIERARCHY_FILE - The hierarchy file is invalid.
 .
+Language=Russian
+ERROR_DS_BAD_HIERARCHY_FILE - The hierarchy file is invalid.
+.
 
 MessageId=8426
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BUILD_HIERARCHY_TABLE_FAILED
 Language=English
+ERROR_DS_BUILD_HIERARCHY_TABLE_FAILED - The attempt to build the hierarchy table failed.
+.
+Language=Russian
 ERROR_DS_BUILD_HIERARCHY_TABLE_FAILED - The attempt to build the hierarchy table failed.
 .
 
@@ -13463,12 +16883,18 @@ SymbolicName=ERROR_DS_CONFIG_PARAM_MISSING
 Language=English
 ERROR_DS_CONFIG_PARAM_MISSING - The directory configuration parameter is missing from the registry.
 .
+Language=Russian
+ERROR_DS_CONFIG_PARAM_MISSING - The directory configuration parameter is missing from the registry.
+.
 
 MessageId=8428
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_COUNTING_AB_INDICES_FAILED
 Language=English
+ERROR_DS_COUNTING_AB_INDICES_FAILED - The attempt to count the address book indices failed.
+.
+Language=Russian
 ERROR_DS_COUNTING_AB_INDICES_FAILED - The attempt to count the address book indices failed.
 .
 
@@ -13479,12 +16905,18 @@ SymbolicName=ERROR_DS_HIERARCHY_TABLE_MALLOC_FAILED
 Language=English
 ERROR_DS_HIERARCHY_TABLE_MALLOC_FAILED - The allocation of the hierarchy table failed.
 .
+Language=Russian
+ERROR_DS_HIERARCHY_TABLE_MALLOC_FAILED - The allocation of the hierarchy table failed.
+.
 
 MessageId=8430
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INTERNAL_FAILURE
 Language=English
+ERROR_DS_INTERNAL_FAILURE - The directory service encountered an internal failure.
+.
+Language=Russian
 ERROR_DS_INTERNAL_FAILURE - The directory service encountered an internal failure.
 .
 
@@ -13495,12 +16927,18 @@ SymbolicName=ERROR_DS_UNKNOWN_ERROR
 Language=English
 ERROR_DS_UNKNOWN_ERROR - The directory service encountered an unknown failure.
 .
+Language=Russian
+ERROR_DS_UNKNOWN_ERROR - The directory service encountered an unknown failure.
+.
 
 MessageId=8432
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ROOT_REQUIRES_CLASS_TOP
 Language=English
+ERROR_DS_ROOT_REQUIRES_CLASS_TOP - A root object requires a class of 'top'.
+.
+Language=Russian
 ERROR_DS_ROOT_REQUIRES_CLASS_TOP - A root object requires a class of 'top'.
 .
 
@@ -13511,12 +16949,18 @@ SymbolicName=ERROR_DS_REFUSING_FSMO_ROLES
 Language=English
 ERROR_DS_REFUSING_FSMO_ROLES - This directory server is shutting down, and cannot take ownership of new floating single-master operation roles.
 .
+Language=Russian
+ERROR_DS_REFUSING_FSMO_ROLES - This directory server is shutting down, and cannot take ownership of new floating single-master operation roles.
+.
 
 MessageId=8434
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_MISSING_FSMO_SETTINGS
 Language=English
+ERROR_DS_MISSING_FSMO_SETTINGS - The directory service is missing mandatory configuration information, and is unable to determine the ownership of floating single-master operation roles.
+.
+Language=Russian
 ERROR_DS_MISSING_FSMO_SETTINGS - The directory service is missing mandatory configuration information, and is unable to determine the ownership of floating single-master operation roles.
 .
 
@@ -13527,12 +16971,18 @@ SymbolicName=ERROR_DS_UNABLE_TO_SURRENDER_ROLES
 Language=English
 ERROR_DS_UNABLE_TO_SURRENDER_ROLES - The directory service was unable to transfer ownership of one or more floating single-master operation roles to other servers.
 .
+Language=Russian
+ERROR_DS_UNABLE_TO_SURRENDER_ROLES - The directory service was unable to transfer ownership of one or more floating single-master operation roles to other servers.
+.
 
 MessageId=8436
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_GENERIC
 Language=English
+ERROR_DS_DRA_GENERIC - The replication operation failed.
+.
+Language=Russian
 ERROR_DS_DRA_GENERIC - The replication operation failed.
 .
 
@@ -13543,12 +16993,18 @@ SymbolicName=ERROR_DS_DRA_INVALID_PARAMETER
 Language=English
 ERROR_DS_DRA_INVALID_PARAMETER - An invalid parameter was specified for this replication operation.
 .
+Language=Russian
+ERROR_DS_DRA_INVALID_PARAMETER - An invalid parameter was specified for this replication operation.
+.
 
 MessageId=8438
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_BUSY
 Language=English
+ERROR_DS_DRA_BUSY - The directory service is too busy to complete the replication operation at this time.
+.
+Language=Russian
 ERROR_DS_DRA_BUSY - The directory service is too busy to complete the replication operation at this time.
 .
 
@@ -13559,12 +17015,18 @@ SymbolicName=ERROR_DS_DRA_BAD_DN
 Language=English
 ERROR_DS_DRA_BAD_DN - The distinguished name specified for this replication operation is invalid.
 .
+Language=Russian
+ERROR_DS_DRA_BAD_DN - The distinguished name specified for this replication operation is invalid.
+.
 
 MessageId=8440
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_BAD_NC
 Language=English
+ERROR_DS_DRA_BAD_NC - The naming context specified for this replication operation is invalid.
+.
+Language=Russian
 ERROR_DS_DRA_BAD_NC - The naming context specified for this replication operation is invalid.
 .
 
@@ -13575,12 +17037,18 @@ SymbolicName=ERROR_DS_DRA_DN_EXISTS
 Language=English
 ERROR_DS_DRA_DN_EXISTS - The distinguished name specified for this replication operation already exists.
 .
+Language=Russian
+ERROR_DS_DRA_DN_EXISTS - The distinguished name specified for this replication operation already exists.
+.
 
 MessageId=8442
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_INTERNAL_ERROR
 Language=English
+ERROR_DS_DRA_INTERNAL_ERROR - The replication system encountered an internal error.
+.
+Language=Russian
 ERROR_DS_DRA_INTERNAL_ERROR - The replication system encountered an internal error.
 .
 
@@ -13591,12 +17059,18 @@ SymbolicName=ERROR_DS_DRA_INCONSISTENT_DIT
 Language=English
 ERROR_DS_DRA_INCONSISTENT_DIT - The replication operation encountered a database inconsistency.
 .
+Language=Russian
+ERROR_DS_DRA_INCONSISTENT_DIT - The replication operation encountered a database inconsistency.
+.
 
 MessageId=8444
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_CONNECTION_FAILED
 Language=English
+ERROR_DS_DRA_CONNECTION_FAILED - The server specified for this replication operation could not be contacted.
+.
+Language=Russian
 ERROR_DS_DRA_CONNECTION_FAILED - The server specified for this replication operation could not be contacted.
 .
 
@@ -13607,12 +17081,18 @@ SymbolicName=ERROR_DS_DRA_BAD_INSTANCE_TYPE
 Language=English
 ERROR_DS_DRA_BAD_INSTANCE_TYPE - The replication operation encountered an object with an invalid instance type.
 .
+Language=Russian
+ERROR_DS_DRA_BAD_INSTANCE_TYPE - The replication operation encountered an object with an invalid instance type.
+.
 
 MessageId=8446
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_OUT_OF_MEM
 Language=English
+ERROR_DS_DRA_OUT_OF_MEM - The replication operation failed to allocate memory.
+.
+Language=Russian
 ERROR_DS_DRA_OUT_OF_MEM - The replication operation failed to allocate memory.
 .
 
@@ -13623,12 +17103,18 @@ SymbolicName=ERROR_DS_DRA_MAIL_PROBLEM
 Language=English
 ERROR_DS_DRA_MAIL_PROBLEM - The replication operation encountered an error with the mail system.
 .
+Language=Russian
+ERROR_DS_DRA_MAIL_PROBLEM - The replication operation encountered an error with the mail system.
+.
 
 MessageId=8448
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_REF_ALREADY_EXISTS
 Language=English
+ERROR_DS_DRA_REF_ALREADY_EXISTS - The replication reference information for the target server already exists.
+.
+Language=Russian
 ERROR_DS_DRA_REF_ALREADY_EXISTS - The replication reference information for the target server already exists.
 .
 
@@ -13639,12 +17125,18 @@ SymbolicName=ERROR_DS_DRA_REF_NOT_FOUND
 Language=English
 ERROR_DS_DRA_REF_NOT_FOUND - The replication reference information for the target server does not exist.
 .
+Language=Russian
+ERROR_DS_DRA_REF_NOT_FOUND - The replication reference information for the target server does not exist.
+.
 
 MessageId=8450
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_OBJ_IS_REP_SOURCE
 Language=English
+ERROR_DS_DRA_OBJ_IS_REP_SOURCE - The naming context cannot be removed because it is replicated to another server.
+.
+Language=Russian
 ERROR_DS_DRA_OBJ_IS_REP_SOURCE - The naming context cannot be removed because it is replicated to another server.
 .
 
@@ -13655,12 +17147,18 @@ SymbolicName=ERROR_DS_DRA_DB_ERROR
 Language=English
 ERROR_DS_DRA_DB_ERROR - The replication operation encountered a database error.
 .
+Language=Russian
+ERROR_DS_DRA_DB_ERROR - The replication operation encountered a database error.
+.
 
 MessageId=8452
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_NO_REPLICA
 Language=English
+ERROR_DS_DRA_NO_REPLICA - The naming context is in the process of being removed or is not replicated from the specified server.
+.
+Language=Russian
 ERROR_DS_DRA_NO_REPLICA - The naming context is in the process of being removed or is not replicated from the specified server.
 .
 
@@ -13671,12 +17169,18 @@ SymbolicName=ERROR_DS_DRA_ACCESS_DENIED
 Language=English
 ERROR_DS_DRA_ACCESS_DENIED - Replication access was denied.
 .
+Language=Russian
+ERROR_DS_DRA_ACCESS_DENIED - Replication access was denied.
+.
 
 MessageId=8454
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_NOT_SUPPORTED
 Language=English
+ERROR_DS_DRA_NOT_SUPPORTED - The requested operation is not supported by this version of the directory service.
+.
+Language=Russian
 ERROR_DS_DRA_NOT_SUPPORTED - The requested operation is not supported by this version of the directory service.
 .
 
@@ -13687,12 +17191,18 @@ SymbolicName=ERROR_DS_DRA_RPC_CANCELLED
 Language=English
 ERROR_DS_DRA_RPC_CANCELLED - The replication remote procedure call was cancelled.
 .
+Language=Russian
+ERROR_DS_DRA_RPC_CANCELLED - The replication remote procedure call was cancelled.
+.
 
 MessageId=8456
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_SOURCE_DISABLED
 Language=English
+ERROR_DS_DRA_SOURCE_DISABLED - The source server is currently rejecting replication requests.
+.
+Language=Russian
 ERROR_DS_DRA_SOURCE_DISABLED - The source server is currently rejecting replication requests.
 .
 
@@ -13703,12 +17213,18 @@ SymbolicName=ERROR_DS_DRA_SINK_DISABLED
 Language=English
 ERROR_DS_DRA_SINK_DISABLED - The destination server is currently rejecting replication requests.
 .
+Language=Russian
+ERROR_DS_DRA_SINK_DISABLED - The destination server is currently rejecting replication requests.
+.
 
 MessageId=8458
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_NAME_COLLISION
 Language=English
+ERROR_DS_DRA_NAME_COLLISION - The replication operation failed due to a collision of object names.
+.
+Language=Russian
 ERROR_DS_DRA_NAME_COLLISION - The replication operation failed due to a collision of object names.
 .
 
@@ -13719,12 +17235,18 @@ SymbolicName=ERROR_DS_DRA_SOURCE_REINSTALLED
 Language=English
 ERROR_DS_DRA_SOURCE_REINSTALLED - The replication source has been reinstalled.
 .
+Language=Russian
+ERROR_DS_DRA_SOURCE_REINSTALLED - The replication source has been reinstalled.
+.
 
 MessageId=8460
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_MISSING_PARENT
 Language=English
+ERROR_DS_DRA_MISSING_PARENT - The replication operation failed because a required parent object is missing.
+.
+Language=Russian
 ERROR_DS_DRA_MISSING_PARENT - The replication operation failed because a required parent object is missing.
 .
 
@@ -13735,12 +17257,18 @@ SymbolicName=ERROR_DS_DRA_PREEMPTED
 Language=English
 ERROR_DS_DRA_PREEMPTED - The replication operation was preempted.
 .
+Language=Russian
+ERROR_DS_DRA_PREEMPTED - The replication operation was preempted.
+.
 
 MessageId=8462
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_ABANDON_SYNC
 Language=English
+ERROR_DS_DRA_ABANDON_SYNC - The replication synchronization attempt was abandoned because of a lack of updates.
+.
+Language=Russian
 ERROR_DS_DRA_ABANDON_SYNC - The replication synchronization attempt was abandoned because of a lack of updates.
 .
 
@@ -13751,12 +17279,18 @@ SymbolicName=ERROR_DS_DRA_SHUTDOWN
 Language=English
 ERROR_DS_DRA_SHUTDOWN - The replication operation was terminated because the system is shutting down.
 .
+Language=Russian
+ERROR_DS_DRA_SHUTDOWN - The replication operation was terminated because the system is shutting down.
+.
 
 MessageId=8464
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_INCOMPATIBLE_PARTIAL_SET
 Language=English
+ERROR_DS_DRA_INCOMPATIBLE_PARTIAL_SET - Synchronization attempt failed because the destination DC is currently waiting to synchronize new partial attributes from source. This condition is normal if a recent schema change modified the partial attribute set. The destination partial attribute set is not a subset of the source partial attribute set.
+.
+Language=Russian
 ERROR_DS_DRA_INCOMPATIBLE_PARTIAL_SET - Synchronization attempt failed because the destination DC is currently waiting to synchronize new partial attributes from source. This condition is normal if a recent schema change modified the partial attribute set. The destination partial attribute set is not a subset of the source partial attribute set.
 .
 
@@ -13767,12 +17301,18 @@ SymbolicName=ERROR_DS_DRA_SOURCE_IS_PARTIAL_REPLICA
 Language=English
 ERROR_DS_DRA_SOURCE_IS_PARTIAL_REPLICA - The replication synchronization attempt failed because a master replica attempted to sync from a partial replica.
 .
+Language=Russian
+ERROR_DS_DRA_SOURCE_IS_PARTIAL_REPLICA - The replication synchronization attempt failed because a master replica attempted to sync from a partial replica.
+.
 
 MessageId=8466
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_EXTN_CONNECTION_FAILED
 Language=English
+ERROR_DS_DRA_EXTN_CONNECTION_FAILED - The server specified for this replication operation was contacted, but that server was unable to contact an additional server needed to complete the operation.
+.
+Language=Russian
 ERROR_DS_DRA_EXTN_CONNECTION_FAILED - The server specified for this replication operation was contacted, but that server was unable to contact an additional server needed to complete the operation.
 .
 
@@ -13783,12 +17323,18 @@ SymbolicName=ERROR_DS_INSTALL_SCHEMA_MISMATCH
 Language=English
 ERROR_DS_INSTALL_SCHEMA_MISMATCH - The version of the Active Directory schema of the source forest is not compatible with the version of Active Directory on this computer.
 .
+Language=Russian
+ERROR_DS_INSTALL_SCHEMA_MISMATCH - The version of the Active Directory schema of the source forest is not compatible with the version of Active Directory on this computer.
+.
 
 MessageId=8468
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUP_LINK_ID
 Language=English
+ERROR_DS_DUP_LINK_ID - Schema update failed: An attribute with the same link identifier already exists.
+.
+Language=Russian
 ERROR_DS_DUP_LINK_ID - Schema update failed: An attribute with the same link identifier already exists.
 .
 
@@ -13799,12 +17345,18 @@ SymbolicName=ERROR_DS_NAME_ERROR_RESOLVING
 Language=English
 ERROR_DS_NAME_ERROR_RESOLVING - Name translation: Generic processing error.
 .
+Language=Russian
+ERROR_DS_NAME_ERROR_RESOLVING - Name translation: Generic processing error.
+.
 
 MessageId=8470
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_ERROR_NOT_FOUND
 Language=English
+ERROR_DS_NAME_ERROR_NOT_FOUND - Name translation: Could not find the name or insufficient right to see name.
+.
+Language=Russian
 ERROR_DS_NAME_ERROR_NOT_FOUND - Name translation: Could not find the name or insufficient right to see name.
 .
 
@@ -13815,12 +17367,18 @@ SymbolicName=ERROR_DS_NAME_ERROR_NOT_UNIQUE
 Language=English
 ERROR_DS_NAME_ERROR_NOT_UNIQUE - Name translation: Input name mapped to more than one output name.
 .
+Language=Russian
+ERROR_DS_NAME_ERROR_NOT_UNIQUE - Name translation: Input name mapped to more than one output name.
+.
 
 MessageId=8472
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_ERROR_NO_MAPPING
 Language=English
+ERROR_DS_NAME_ERROR_NO_MAPPING - Name translation: Input name found, but not the associated output format.
+.
+Language=Russian
 ERROR_DS_NAME_ERROR_NO_MAPPING - Name translation: Input name found, but not the associated output format.
 .
 
@@ -13831,12 +17389,18 @@ SymbolicName=ERROR_DS_NAME_ERROR_DOMAIN_ONLY
 Language=English
 ERROR_DS_NAME_ERROR_DOMAIN_ONLY - Name translation: Unable to resolve completely, only the domain was found.
 .
+Language=Russian
+ERROR_DS_NAME_ERROR_DOMAIN_ONLY - Name translation: Unable to resolve completely, only the domain was found.
+.
 
 MessageId=8474
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_ERROR_NO_SYNTACTICAL_MAPPING
 Language=English
+ERROR_DS_NAME_ERROR_NO_SYNTACTICAL_MAPPING - Name translation: Unable to perform purely syntactical mapping at the client without going out to the wire.
+.
+Language=Russian
 ERROR_DS_NAME_ERROR_NO_SYNTACTICAL_MAPPING - Name translation: Unable to perform purely syntactical mapping at the client without going out to the wire.
 .
 
@@ -13847,12 +17411,18 @@ SymbolicName=ERROR_DS_CONSTRUCTED_ATT_MOD
 Language=English
 ERROR_DS_CONSTRUCTED_ATT_MOD - Modification of a constructed attribute is not allowed.
 .
+Language=Russian
+ERROR_DS_CONSTRUCTED_ATT_MOD - Modification of a constructed attribute is not allowed.
+.
 
 MessageId=8476
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_WRONG_OM_OBJ_CLASS
 Language=English
+ERROR_DS_WRONG_OM_OBJ_CLASS - The OM-Object-Class specified is incorrect for an attribute with the specified syntax.
+.
+Language=Russian
 ERROR_DS_WRONG_OM_OBJ_CLASS - The OM-Object-Class specified is incorrect for an attribute with the specified syntax.
 .
 
@@ -13863,12 +17433,18 @@ SymbolicName=ERROR_DS_DRA_REPL_PENDING
 Language=English
 ERROR_DS_DRA_REPL_PENDING - The replication request has been posted; waiting for reply.
 .
+Language=Russian
+ERROR_DS_DRA_REPL_PENDING - The replication request has been posted; waiting for reply.
+.
 
 MessageId=8478
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DS_REQUIRED
 Language=English
+ERROR_DS_DS_REQUIRED - The requested operation requires a directory service, and none was available.
+.
+Language=Russian
 ERROR_DS_DS_REQUIRED - The requested operation requires a directory service, and none was available.
 .
 
@@ -13879,12 +17455,18 @@ SymbolicName=ERROR_DS_INVALID_LDAP_DISPLAY_NAME
 Language=English
 ERROR_DS_INVALID_LDAP_DISPLAY_NAME - The LDAP display name of the class or attribute contains non-ASCII characters.
 .
+Language=Russian
+ERROR_DS_INVALID_LDAP_DISPLAY_NAME - The LDAP display name of the class or attribute contains non-ASCII characters.
+.
 
 MessageId=8480
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NON_BASE_SEARCH
 Language=English
+ERROR_DS_NON_BASE_SEARCH - The requested search operation is only supported for base searches.
+.
+Language=Russian
 ERROR_DS_NON_BASE_SEARCH - The requested search operation is only supported for base searches.
 .
 
@@ -13895,12 +17477,18 @@ SymbolicName=ERROR_DS_CANT_RETRIEVE_ATTS
 Language=English
 ERROR_DS_CANT_RETRIEVE_ATTS - The search failed to retrieve attributes from the database.
 .
+Language=Russian
+ERROR_DS_CANT_RETRIEVE_ATTS - The search failed to retrieve attributes from the database.
+.
 
 MessageId=8482
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_BACKLINK_WITHOUT_LINK
 Language=English
+ERROR_DS_BACKLINK_WITHOUT_LINK - The schema update operation tried to add a backward link attribute that has no corresponding forward link.
+.
+Language=Russian
 ERROR_DS_BACKLINK_WITHOUT_LINK - The schema update operation tried to add a backward link attribute that has no corresponding forward link.
 .
 
@@ -13911,12 +17499,18 @@ SymbolicName=ERROR_DS_EPOCH_MISMATCH
 Language=English
 ERROR_DS_EPOCH_MISMATCH - Source and destination of a cross domain move do not agree on the object's epoch number. Either source or destination does not have the latest version of the object.
 .
+Language=Russian
+ERROR_DS_EPOCH_MISMATCH - Source and destination of a cross domain move do not agree on the object's epoch number. Either source or destination does not have the latest version of the object.
+.
 
 MessageId=8484
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SRC_NAME_MISMATCH
 Language=English
+ERROR_DS_SRC_NAME_MISMATCH - Source and destination of a cross domain move do not agree on the object's current name. Either source or destination does not have the latest version of the object.
+.
+Language=Russian
 ERROR_DS_SRC_NAME_MISMATCH - Source and destination of a cross domain move do not agree on the object's current name. Either source or destination does not have the latest version of the object.
 .
 
@@ -13927,12 +17521,18 @@ SymbolicName=ERROR_DS_SRC_AND_DST_NC_IDENTICAL
 Language=English
 ERROR_DS_SRC_AND_DST_NC_IDENTICAL - Source and destination of a cross domain move operation are identical. Caller should use local move operation instead of cross domain move operation.
 .
+Language=Russian
+ERROR_DS_SRC_AND_DST_NC_IDENTICAL - Source and destination of a cross domain move operation are identical. Caller should use local move operation instead of cross domain move operation.
+.
 
 MessageId=8486
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DST_NC_MISMATCH
 Language=English
+ERROR_DS_DST_NC_MISMATCH - Source and destination for a cross domain move are not in agreement on the naming contexts in the forest. Either source or destination does not have the latest version of the Partitions container.
+.
+Language=Russian
 ERROR_DS_DST_NC_MISMATCH - Source and destination for a cross domain move are not in agreement on the naming contexts in the forest. Either source or destination does not have the latest version of the Partitions container.
 .
 
@@ -13943,12 +17543,18 @@ SymbolicName=ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC
 Language=English
 ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC - Destination of a cross domain move is not authoritative for the destination naming context.
 .
+Language=Russian
+ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC - Destination of a cross domain move is not authoritative for the destination naming context.
+.
 
 MessageId=8488
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SRC_GUID_MISMATCH
 Language=English
+ERROR_DS_SRC_GUID_MISMATCH - Source and destination of a cross domain move do not agree on the identity of the source object. Either source or destination does not have the latest version of the source object.
+.
+Language=Russian
 ERROR_DS_SRC_GUID_MISMATCH - Source and destination of a cross domain move do not agree on the identity of the source object. Either source or destination does not have the latest version of the source object.
 .
 
@@ -13959,12 +17565,18 @@ SymbolicName=ERROR_DS_CANT_MOVE_DELETED_OBJECT
 Language=English
 ERROR_DS_CANT_MOVE_DELETED_OBJECT - Object being moved across domains is already known to be deleted by the destination server. The source server does not have the latest version of the source object.
 .
+Language=Russian
+ERROR_DS_CANT_MOVE_DELETED_OBJECT - Object being moved across domains is already known to be deleted by the destination server. The source server does not have the latest version of the source object.
+.
 
 MessageId=8490
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_PDC_OPERATION_IN_PROGRESS
 Language=English
+ERROR_DS_PDC_OPERATION_IN_PROGRESS - Another operation, which requires exclusive access to the PDC PSMO, is already in progress.
+.
+Language=Russian
 ERROR_DS_PDC_OPERATION_IN_PROGRESS - Another operation, which requires exclusive access to the PDC PSMO, is already in progress.
 .
 
@@ -13975,12 +17587,18 @@ SymbolicName=ERROR_DS_CROSS_DOMAIN_CLEANUP_REQD
 Language=English
 ERROR_DS_CROSS_DOMAIN_CLEANUP_REQD - A cross domain move operation failed such that the two versions of the moved object exist - one each in the source and destination domains. The destination object needs to be removed to restore the system to a consistent state.
 .
+Language=Russian
+ERROR_DS_CROSS_DOMAIN_CLEANUP_REQD - A cross domain move operation failed such that the two versions of the moved object exist - one each in the source and destination domains. The destination object needs to be removed to restore the system to a consistent state.
+.
 
 MessageId=8492
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ILLEGAL_XDOM_MOVE_OPERATION
 Language=English
+ERROR_DS_ILLEGAL_XDOM_MOVE_OPERATION - This object may not be moved across domain boundaries either because cross domain moves for this class are disallowed, or the object has some special characteristics, e.g.: trust account or restricted RID, which prevent its move.
+.
+Language=Russian
 ERROR_DS_ILLEGAL_XDOM_MOVE_OPERATION - This object may not be moved across domain boundaries either because cross domain moves for this class are disallowed, or the object has some special characteristics, e.g.: trust account or restricted RID, which prevent its move.
 .
 
@@ -13991,12 +17609,18 @@ SymbolicName=ERROR_DS_CANT_WITH_ACCT_GROUP_MEMBERSHPS
 Language=English
 ERROR_DS_CANT_WITH_ACCT_GROUP_MEMBERSHPS - Can't move objects with memberships across domain boundaries as once moved, this would violate the membership conditions of the account group. Remove the object from any account group memberships and retry.
 .
+Language=Russian
+ERROR_DS_CANT_WITH_ACCT_GROUP_MEMBERSHPS - Can't move objects with memberships across domain boundaries as once moved, this would violate the membership conditions of the account group. Remove the object from any account group memberships and retry.
+.
 
 MessageId=8494
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NC_MUST_HAVE_NC_PARENT
 Language=English
+ERROR_DS_NC_MUST_HAVE_NC_PARENT - A naming context head must be the immediate child of another naming context head, not of an interior node.
+.
+Language=Russian
 ERROR_DS_NC_MUST_HAVE_NC_PARENT - A naming context head must be the immediate child of another naming context head, not of an interior node.
 .
 
@@ -14007,12 +17631,18 @@ SymbolicName=ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE
 Language=English
 ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE - The directory cannot validate the proposed naming context name because it does not hold a replica of the naming context above the proposed naming context. Please ensure that the domain naming master role is held by a server that is configured as a global catalog server, and that the server is up to date with its replication partners. (Applies only to Windows 2000 Domain Naming masters)
 .
+Language=Russian
+ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE - The directory cannot validate the proposed naming context name because it does not hold a replica of the naming context above the proposed naming context. Please ensure that the domain naming master role is held by a server that is configured as a global catalog server, and that the server is up to date with its replication partners. (Applies only to Windows 2000 Domain Naming masters)
+.
 
 MessageId=8496
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DST_DOMAIN_NOT_NATIVE
 Language=English
+ERROR_DS_DST_DOMAIN_NOT_NATIVE - Destination domain must be in native mode.
+.
+Language=Russian
 ERROR_DS_DST_DOMAIN_NOT_NATIVE - Destination domain must be in native mode.
 .
 
@@ -14023,12 +17653,18 @@ SymbolicName=ERROR_DS_MISSING_INFRASTRUCTURE_CONTAINER
 Language=English
 ERROR_DS_MISSING_INFRASTRUCTURE_CONTAINER - The operation cannot be performed because the server does not have an infrastructure container in the domain of interest.
 .
+Language=Russian
+ERROR_DS_MISSING_INFRASTRUCTURE_CONTAINER - The operation cannot be performed because the server does not have an infrastructure container in the domain of interest.
+.
 
 MessageId=8498
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_MOVE_ACCOUNT_GROUP
 Language=English
+ERROR_DS_CANT_MOVE_ACCOUNT_GROUP - Cross-domain move of non-empty account groups is not allowed.
+.
+Language=Russian
 ERROR_DS_CANT_MOVE_ACCOUNT_GROUP - Cross-domain move of non-empty account groups is not allowed.
 .
 
@@ -14039,12 +17675,18 @@ SymbolicName=ERROR_DS_CANT_MOVE_RESOURCE_GROUP
 Language=English
 ERROR_DS_CANT_MOVE_RESOURCE_GROUP - Cross-domain move of non-empty resource groups is not allowed.
 .
+Language=Russian
+ERROR_DS_CANT_MOVE_RESOURCE_GROUP - Cross-domain move of non-empty resource groups is not allowed.
+.
 
 MessageId=8500
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INVALID_SEARCH_FLAG
 Language=English
+ERROR_DS_INVALID_SEARCH_FLAG - The search flags for the attribute are invalid. The ANR bit is valid only on attributes of Unicode or Teletex strings.
+.
+Language=Russian
 ERROR_DS_INVALID_SEARCH_FLAG - The search flags for the attribute are invalid. The ANR bit is valid only on attributes of Unicode or Teletex strings.
 .
 
@@ -14055,6 +17697,9 @@ SymbolicName=ERROR_DS_NO_TREE_DELETE_ABOVE_NC
 Language=English
 ERROR_DS_NO_TREE_DELETE_ABOVE_NC - Tree deletions starting at an object which has an NC head as a descendant are not allowed.
 .
+Language=Russian
+ERROR_DS_NO_TREE_DELETE_ABOVE_NC - Tree deletions starting at an object which has an NC head as a descendant are not allowed.
+.
 
 MessageId=8502
 Severity=Success
@@ -14063,12 +17708,18 @@ SymbolicName=ERROR_DS_COULDNT_LOCK_TREE_FOR_DELETE
 Language=English
 ERROR_DS_COULDNT_LOCK_TREE_FOR_DELETE - The directory service failed to lock a tree in preparation for a tree deletion because the tree was in use.
 .
+Language=Russian
+ERROR_DS_COULDNT_LOCK_TREE_FOR_DELETE - The directory service failed to lock a tree in preparation for a tree deletion because the tree was in use.
+.
 
 MessageId=8503
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_COULDNT_IDENTIFY_OBJECTS_FOR_TREE_DELETE
 Language=English
+ERROR_DS_COULDNT_IDENTIFY_OBJECTS_FOR_TREE_DELETE - The directory service failed to identify the list of objects to delete while attempting a tree deletion.
+.
+Language=Russian
 ERROR_DS_COULDNT_IDENTIFY_OBJECTS_FOR_TREE_DELETE - The directory service failed to identify the list of objects to delete while attempting a tree deletion.
 .
 
@@ -14080,12 +17731,19 @@ Language=English
 ERROR_DS_SAM_INIT_FAILURE - Security Accounts Manager initialization failed because of the following error: %1.
 Error Status: 0x%2. Click OK to shut down the system and reboot into Directory Services Restore Mode. Check the event log for detailed information.
 .
+Language=Russian
+ERROR_DS_SAM_INIT_FAILURE - Security Accounts Manager initialization failed because of the following error: %1.
+Error Status: 0x%2. Click OK to shut down the system and reboot into Directory Services Restore Mode. Check the event log for detailed information.
+.
 
 MessageId=8505
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SENSITIVE_GROUP_VIOLATION
 Language=English
+ERROR_DS_SENSITIVE_GROUP_VIOLATION - Only an administrator can modify the membership list of an administrative group.
+.
+Language=Russian
 ERROR_DS_SENSITIVE_GROUP_VIOLATION - Only an administrator can modify the membership list of an administrative group.
 .
 
@@ -14096,12 +17754,18 @@ SymbolicName=ERROR_DS_CANT_MOD_PRIMARYGROUPID
 Language=English
 ERROR_DS_CANT_MOD_PRIMARYGROUPID - Cannot change the primary group ID of a domain controller account.
 .
+Language=Russian
+ERROR_DS_CANT_MOD_PRIMARYGROUPID - Cannot change the primary group ID of a domain controller account.
+.
 
 MessageId=8507
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_ILLEGAL_BASE_SCHEMA_MOD
 Language=English
+ERROR_DS_ILLEGAL_BASE_SCHEMA_MOD - An attempt is made to modify the base schema.
+.
+Language=Russian
 ERROR_DS_ILLEGAL_BASE_SCHEMA_MOD - An attempt is made to modify the base schema.
 .
 
@@ -14112,12 +17776,18 @@ SymbolicName=ERROR_DS_NONSAFE_SCHEMA_CHANGE
 Language=English
 ERROR_DS_NONSAFE_SCHEMA_CHANGE - Adding a new mandatory attribute to an existing class, deleting a mandatory attribute from an existing class, or adding an optional attribute to the special class Top that is not a backlink attribute (directly or through inheritance, for example, by adding or deleting an auxiliary class) is not allowed.
 .
+Language=Russian
+ERROR_DS_NONSAFE_SCHEMA_CHANGE - Adding a new mandatory attribute to an existing class, deleting a mandatory attribute from an existing class, or adding an optional attribute to the special class Top that is not a backlink attribute (directly or through inheritance, for example, by adding or deleting an auxiliary class) is not allowed.
+.
 
 MessageId=8509
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SCHEMA_UPDATE_DISALLOWED
 Language=English
+ERROR_DS_SCHEMA_UPDATE_DISALLOWED - Schema update is not allowed on this DC because the DC is not the schema FSMO Role Owner.
+.
+Language=Russian
 ERROR_DS_SCHEMA_UPDATE_DISALLOWED - Schema update is not allowed on this DC because the DC is not the schema FSMO Role Owner.
 .
 
@@ -14128,12 +17798,18 @@ SymbolicName=ERROR_DS_CANT_CREATE_UNDER_SCHEMA
 Language=English
 ERROR_DS_CANT_CREATE_UNDER_SCHEMA - An object of this class cannot be created under the schema container. You can only create attribute-schema and class-schema objects under the schema container.
 .
+Language=Russian
+ERROR_DS_CANT_CREATE_UNDER_SCHEMA - An object of this class cannot be created under the schema container. You can only create attribute-schema and class-schema objects under the schema container.
+.
 
 MessageId=8511
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INSTALL_NO_SRC_SCH_VERSION
 Language=English
+ERROR_DS_INSTALL_NO_SRC_SCH_VERSION - The replica/child install failed to get the objectVersion attribute on the schema container on the source DC. Either the attribute is missing on the schema container or the credentials supplied do not have permission to read it.
+.
+Language=Russian
 ERROR_DS_INSTALL_NO_SRC_SCH_VERSION - The replica/child install failed to get the objectVersion attribute on the schema container on the source DC. Either the attribute is missing on the schema container or the credentials supplied do not have permission to read it.
 .
 
@@ -14144,12 +17820,18 @@ SymbolicName=ERROR_DS_INSTALL_NO_SCH_VERSION_IN_INIFILE
 Language=English
 ERROR_DS_INSTALL_NO_SCH_VERSION_IN_INIFILE - The replica/child install failed to read the objectVersion attribute in the SCHEMA section of the file schema.ini in the system32 directory.
 .
+Language=Russian
+ERROR_DS_INSTALL_NO_SCH_VERSION_IN_INIFILE - The replica/child install failed to read the objectVersion attribute in the SCHEMA section of the file schema.ini in the system32 directory.
+.
 
 MessageId=8513
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INVALID_GROUP_TYPE
 Language=English
+ERROR_DS_INVALID_GROUP_TYPE - The specified group type is invalid.
+.
+Language=Russian
 ERROR_DS_INVALID_GROUP_TYPE - The specified group type is invalid.
 .
 
@@ -14160,12 +17842,18 @@ SymbolicName=ERROR_DS_NO_NEST_GLOBALGROUP_IN_MIXEDDOMAIN
 Language=English
 ERROR_DS_NO_NEST_GLOBALGROUP_IN_MIXEDDOMAIN - Cannot nest global groups in a mixed domain if the group is security-enabled.
 .
+Language=Russian
+ERROR_DS_NO_NEST_GLOBALGROUP_IN_MIXEDDOMAIN - Cannot nest global groups in a mixed domain if the group is security-enabled.
+.
 
 MessageId=8515
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_NEST_LOCALGROUP_IN_MIXEDDOMAIN
 Language=English
+ERROR_DS_NO_NEST_LOCALGROUP_IN_MIXEDDOMAIN - Cannot nest local groups in a mixed domain if the group is security-enabled.
+.
+Language=Russian
 ERROR_DS_NO_NEST_LOCALGROUP_IN_MIXEDDOMAIN - Cannot nest local groups in a mixed domain if the group is security-enabled.
 .
 
@@ -14176,12 +17864,18 @@ SymbolicName=ERROR_DS_GLOBAL_CANT_HAVE_LOCAL_MEMBER
 Language=English
 ERROR_DS_GLOBAL_CANT_HAVE_LOCAL_MEMBER - A global group cannot have a local group as a member.
 .
+Language=Russian
+ERROR_DS_GLOBAL_CANT_HAVE_LOCAL_MEMBER - A global group cannot have a local group as a member.
+.
 
 MessageId=8517
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_GLOBAL_CANT_HAVE_UNIVERSAL_MEMBER
 Language=English
+ERROR_DS_GLOBAL_CANT_HAVE_UNIVERSAL_MEMBER - A global group cannot have a universal group as a member.
+.
+Language=Russian
 ERROR_DS_GLOBAL_CANT_HAVE_UNIVERSAL_MEMBER - A global group cannot have a universal group as a member.
 .
 
@@ -14192,12 +17886,18 @@ SymbolicName=ERROR_DS_UNIVERSAL_CANT_HAVE_LOCAL_MEMBER
 Language=English
 ERROR_DS_UNIVERSAL_CANT_HAVE_LOCAL_MEMBER - A universal group cannot have a local group as a member.
 .
+Language=Russian
+ERROR_DS_UNIVERSAL_CANT_HAVE_LOCAL_MEMBER - A universal group cannot have a local group as a member.
+.
 
 MessageId=8519
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_GLOBAL_CANT_HAVE_CROSSDOMAIN_MEMBER
 Language=English
+ERROR_DS_GLOBAL_CANT_HAVE_CROSSDOMAIN_MEMBER - A global group cannot have a cross-domain member.
+.
+Language=Russian
 ERROR_DS_GLOBAL_CANT_HAVE_CROSSDOMAIN_MEMBER - A global group cannot have a cross-domain member.
 .
 
@@ -14208,12 +17908,18 @@ SymbolicName=ERROR_DS_LOCAL_CANT_HAVE_CROSSDOMAIN_LOCAL_MEMBER
 Language=English
 ERROR_DS_LOCAL_CANT_HAVE_CROSSDOMAIN_LOCAL_MEMBER - A local group cannot have another cross-domain local group as a member.
 .
+Language=Russian
+ERROR_DS_LOCAL_CANT_HAVE_CROSSDOMAIN_LOCAL_MEMBER - A local group cannot have another cross-domain local group as a member.
+.
 
 MessageId=8521
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_HAVE_PRIMARY_MEMBERS
 Language=English
+ERROR_DS_HAVE_PRIMARY_MEMBERS - A group with primary members cannot change to a security-disabled group.
+.
+Language=Russian
 ERROR_DS_HAVE_PRIMARY_MEMBERS - A group with primary members cannot change to a security-disabled group.
 .
 
@@ -14224,12 +17930,18 @@ SymbolicName=ERROR_DS_STRING_SD_CONVERSION_FAILED
 Language=English
 ERROR_DS_STRING_SD_CONVERSION_FAILED - The schema cache load failed to convert the string default SD on a class-schema object.
 .
+Language=Russian
+ERROR_DS_STRING_SD_CONVERSION_FAILED - The schema cache load failed to convert the string default SD on a class-schema object.
+.
 
 MessageId=8523
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAMING_MASTER_GC
 Language=English
+ERROR_DS_NAMING_MASTER_GC - Only DSAs configured to be Global Catalog servers should be allowed to hold the Domain Naming Master FSMO role. (Applies only to Windows 2000 servers)
+.
+Language=Russian
 ERROR_DS_NAMING_MASTER_GC - Only DSAs configured to be Global Catalog servers should be allowed to hold the Domain Naming Master FSMO role. (Applies only to Windows 2000 servers)
 .
 
@@ -14240,12 +17952,18 @@ SymbolicName=ERROR_DS_LOOKUP_FAILURE
 Language=English
 ERROR_DS_LOOKUP_FAILURE - The DSA operation is unable to proceed because of a DNS lookup failure.
 .
+Language=Russian
+ERROR_DS_LOOKUP_FAILURE - The DSA operation is unable to proceed because of a DNS lookup failure.
+.
 
 MessageId=8525
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_COULDNT_UPDATE_SPNS
 Language=English
+ERROR_DS_COULDNT_UPDATE_SPNS - While processing a change to the DNS Host Name for an object, the Service Principal Name values could not be kept in sync.
+.
+Language=Russian
 ERROR_DS_COULDNT_UPDATE_SPNS - While processing a change to the DNS Host Name for an object, the Service Principal Name values could not be kept in sync.
 .
 
@@ -14256,12 +17974,18 @@ SymbolicName=ERROR_DS_CANT_RETRIEVE_SD
 Language=English
 ERROR_DS_CANT_RETRIEVE_SD - The Security Descriptor attribute could not be read.
 .
+Language=Russian
+ERROR_DS_CANT_RETRIEVE_SD - The Security Descriptor attribute could not be read.
+.
 
 MessageId=8527
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_KEY_NOT_UNIQUE
 Language=English
+ERROR_DS_KEY_NOT_UNIQUE - The object requested was not found, but an object with that key was found.
+.
+Language=Russian
 ERROR_DS_KEY_NOT_UNIQUE - The object requested was not found, but an object with that key was found.
 .
 
@@ -14272,12 +17996,18 @@ SymbolicName=ERROR_DS_WRONG_LINKED_ATT_SYNTAX
 Language=English
 ERROR_DS_WRONG_LINKED_ATT_SYNTAX - The syntax of the linked attributed being added is incorrect. Forward links can only have syntax 2.5.5.1, 2.5.5.7, and 2.5.5.14, and backlinks can only have syntax 2.5.5.1.
 .
+Language=Russian
+ERROR_DS_WRONG_LINKED_ATT_SYNTAX - The syntax of the linked attributed being added is incorrect. Forward links can only have syntax 2.5.5.1, 2.5.5.7, and 2.5.5.14, and backlinks can only have syntax 2.5.5.1.
+.
 
 MessageId=8529
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SAM_NEED_BOOTKEY_PASSWORD
 Language=English
+ERROR_DS_SAM_NEED_BOOTKEY_PASSWORD - Security Account Manager needs to get the boot password.
+.
+Language=Russian
 ERROR_DS_SAM_NEED_BOOTKEY_PASSWORD - Security Account Manager needs to get the boot password.
 .
 
@@ -14288,12 +18018,18 @@ SymbolicName=ERROR_DS_SAM_NEED_BOOTKEY_FLOPPY
 Language=English
 ERROR_DS_SAM_NEED_BOOTKEY_FLOPPY - Security Account Manager needs to get the boot key from floppy disk.
 .
+Language=Russian
+ERROR_DS_SAM_NEED_BOOTKEY_FLOPPY - Security Account Manager needs to get the boot key from floppy disk.
+.
 
 MessageId=8531
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_START
 Language=English
+ERROR_DS_CANT_START - Directory Service cannot start.
+.
+Language=Russian
 ERROR_DS_CANT_START - Directory Service cannot start.
 .
 
@@ -14304,12 +18040,18 @@ SymbolicName=ERROR_DS_INIT_FAILURE
 Language=English
 ERROR_DS_INIT_FAILURE - Directory Services could not start.
 .
+Language=Russian
+ERROR_DS_INIT_FAILURE - Directory Services could not start.
+.
 
 MessageId=8533
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_PKT_PRIVACY_ON_CONNECTION
 Language=English
+ERROR_DS_NO_PKT_PRIVACY_ON_CONNECTION - The connection between client and server requires packet privacy or better.
+.
+Language=Russian
 ERROR_DS_NO_PKT_PRIVACY_ON_CONNECTION - The connection between client and server requires packet privacy or better.
 .
 
@@ -14320,12 +18062,18 @@ SymbolicName=ERROR_DS_SOURCE_DOMAIN_IN_FOREST
 Language=English
 ERROR_DS_SOURCE_DOMAIN_IN_FOREST - The source domain may not be in the same forest as destination.
 .
+Language=Russian
+ERROR_DS_SOURCE_DOMAIN_IN_FOREST - The source domain may not be in the same forest as destination.
+.
 
 MessageId=8535
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DESTINATION_DOMAIN_NOT_IN_FOREST
 Language=English
+ERROR_DS_DESTINATION_DOMAIN_NOT_IN_FOREST - The destination domain must be in the forest.
+.
+Language=Russian
 ERROR_DS_DESTINATION_DOMAIN_NOT_IN_FOREST - The destination domain must be in the forest.
 .
 
@@ -14336,12 +18084,18 @@ SymbolicName=ERROR_DS_DESTINATION_AUDITING_NOT_ENABLED
 Language=English
 ERROR_DS_DESTINATION_AUDITING_NOT_ENABLED - The operation requires that destination domain auditing be enabled.
 .
+Language=Russian
+ERROR_DS_DESTINATION_AUDITING_NOT_ENABLED - The operation requires that destination domain auditing be enabled.
+.
 
 MessageId=8537
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_FIND_DC_FOR_SRC_DOMAIN
 Language=English
+ERROR_DS_CANT_FIND_DC_FOR_SRC_DOMAIN - The operation couldn't locate a DC for the source domain.
+.
+Language=Russian
 ERROR_DS_CANT_FIND_DC_FOR_SRC_DOMAIN - The operation couldn't locate a DC for the source domain.
 .
 
@@ -14352,6 +18106,9 @@ SymbolicName=ERROR_DS_SRC_OBJ_NOT_GROUP_OR_USER
 Language=English
 ERROR_DS_SRC_OBJ_NOT_GROUP_OR_USER - The source object must be a group or user.
 .
+Language=Russian
+ERROR_DS_SRC_OBJ_NOT_GROUP_OR_USER - The source object must be a group or user.
+.
 
 MessageId=8539
 Severity=Success
@@ -14360,12 +18117,18 @@ SymbolicName=ERROR_DS_SRC_SID_EXISTS_IN_FOREST
 Language=English
 ERROR_DS_SRC_SID_EXISTS_IN_FOREST - The source object's SID already exists in destination forest.
 .
+Language=Russian
+ERROR_DS_SRC_SID_EXISTS_IN_FOREST - The source object's SID already exists in destination forest.
+.
 
 MessageId=8540
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SRC_AND_DST_OBJECT_CLASS_MISMATCH
 Language=English
+ERROR_DS_SRC_AND_DST_OBJECT_CLASS_MISMATCH - The source and destination object must be of the same type.
+.
+Language=Russian
 ERROR_DS_SRC_AND_DST_OBJECT_CLASS_MISMATCH - The source and destination object must be of the same type.
 .
 
@@ -14377,12 +18140,19 @@ Language=English
 ERROR_SAM_INIT_FAILURE - Security Accounts Manager initialization failed because of the following error: %1.
 Error Status: 0x%2. Click OK to shut down the system and reboot into Safe Mode. Check the event log for detailed information.
 .
+Language=Russian
+ERROR_SAM_INIT_FAILURE - Security Accounts Manager initialization failed because of the following error: %1.
+Error Status: 0x%2. Click OK to shut down the system and reboot into Safe Mode. Check the event log for detailed information.
+.
 
 MessageId=8542
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_SCHEMA_INFO_SHIP
 Language=English
+ERROR_DS_DRA_SCHEMA_INFO_SHIP - Schema information could not be included in the replication request.
+.
+Language=Russian
 ERROR_DS_DRA_SCHEMA_INFO_SHIP - Schema information could not be included in the replication request.
 .
 
@@ -14393,12 +18163,18 @@ SymbolicName=ERROR_DS_DRA_SCHEMA_CONFLICT
 Language=English
 ERROR_DS_DRA_SCHEMA_CONFLICT - The replication operation could not be completed due to a schema incompatibility.
 .
+Language=Russian
+ERROR_DS_DRA_SCHEMA_CONFLICT - The replication operation could not be completed due to a schema incompatibility.
+.
 
 MessageId=8544
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_EARLIER_SCHEMA_CONLICT
 Language=English
+ERROR_DS_DRA_EARLIER_SCHEMA_CONLICT - The replication operation could not be completed due to a previous schema incompatibility.
+.
+Language=Russian
 ERROR_DS_DRA_EARLIER_SCHEMA_CONLICT - The replication operation could not be completed due to a previous schema incompatibility.
 .
 
@@ -14409,12 +18185,18 @@ SymbolicName=ERROR_DS_DRA_OBJ_NC_MISMATCH
 Language=English
 ERROR_DS_DRA_OBJ_NC_MISMATCH - The replication update could not be applied because either the source or the destination has not yet received information regarding a recent cross-domain move operation.
 .
+Language=Russian
+ERROR_DS_DRA_OBJ_NC_MISMATCH - The replication update could not be applied because either the source or the destination has not yet received information regarding a recent cross-domain move operation.
+.
 
 MessageId=8546
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NC_STILL_HAS_DSAS
 Language=English
+ERROR_DS_NC_STILL_HAS_DSAS - The requested domain could not be deleted because there exist domain controllers that still host this domain.
+.
+Language=Russian
 ERROR_DS_NC_STILL_HAS_DSAS - The requested domain could not be deleted because there exist domain controllers that still host this domain.
 .
 
@@ -14425,12 +18207,18 @@ SymbolicName=ERROR_DS_GC_REQUIRED
 Language=English
 ERROR_DS_GC_REQUIRED - The requested operation can be performed only on a global catalog server.
 .
+Language=Russian
+ERROR_DS_GC_REQUIRED - The requested operation can be performed only on a global catalog server.
+.
 
 MessageId=8548
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_LOCAL_MEMBER_OF_LOCAL_ONLY
 Language=English
+ERROR_DS_LOCAL_MEMBER_OF_LOCAL_ONLY - A local group can only be a member of other local groups in the same domain.
+.
+Language=Russian
 ERROR_DS_LOCAL_MEMBER_OF_LOCAL_ONLY - A local group can only be a member of other local groups in the same domain.
 .
 
@@ -14441,12 +18229,18 @@ SymbolicName=ERROR_DS_NO_FPO_IN_UNIVERSAL_GROUPS
 Language=English
 ERROR_DS_NO_FPO_IN_UNIVERSAL_GROUPS - Foreign security principals cannot be members of universal groups.
 .
+Language=Russian
+ERROR_DS_NO_FPO_IN_UNIVERSAL_GROUPS - Foreign security principals cannot be members of universal groups.
+.
 
 MessageId=8550
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_ADD_TO_GC
 Language=English
+ERROR_DS_CANT_ADD_TO_GC - The attribute is not allowed to be replicated to the GC because of security reasons.
+.
+Language=Russian
 ERROR_DS_CANT_ADD_TO_GC - The attribute is not allowed to be replicated to the GC because of security reasons.
 .
 
@@ -14457,12 +18251,18 @@ SymbolicName=ERROR_DS_NO_CHECKPOINT_WITH_PDC
 Language=English
 ERROR_DS_NO_CHECKPOINT_WITH_PDC - The checkpoint with the PDC could not be taken because there are too many modifications being processed currently.
 .
+Language=Russian
+ERROR_DS_NO_CHECKPOINT_WITH_PDC - The checkpoint with the PDC could not be taken because there are too many modifications being processed currently.
+.
 
 MessageId=8552
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_SOURCE_AUDITING_NOT_ENABLED
 Language=English
+ERROR_DS_SOURCE_AUDITING_NOT_ENABLED - The operation requires that source domain auditing be enabled.
+.
+Language=Russian
 ERROR_DS_SOURCE_AUDITING_NOT_ENABLED - The operation requires that source domain auditing be enabled.
 .
 
@@ -14473,12 +18273,18 @@ SymbolicName=ERROR_DS_CANT_CREATE_IN_NONDOMAIN_NC
 Language=English
 ERROR_DS_CANT_CREATE_IN_NONDOMAIN_NC - Security principal objects can only be created inside domain naming contexts.
 .
+Language=Russian
+ERROR_DS_CANT_CREATE_IN_NONDOMAIN_NC - Security principal objects can only be created inside domain naming contexts.
+.
 
 MessageId=8554
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INVALID_NAME_FOR_SPN
 Language=English
+ERROR_DS_INVALID_NAME_FOR_SPN - A Service Principal Name (SPN) could not be constructed because the provided hostname is not in the necessary format.
+.
+Language=Russian
 ERROR_DS_INVALID_NAME_FOR_SPN - A Service Principal Name (SPN) could not be constructed because the provided hostname is not in the necessary format.
 .
 
@@ -14489,12 +18295,18 @@ SymbolicName=ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS
 Language=English
 ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS - A Filter was passed that uses constructed attributes.
 .
+Language=Russian
+ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS - A Filter was passed that uses constructed attributes.
+.
 
 MessageId=8556
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_UNICODEPWD_NOT_IN_QUOTES
 Language=English
+ERROR_DS_UNICODEPWD_NOT_IN_QUOTES - The unicodePwd attribute value must be enclosed in double quotes.
+.
+Language=Russian
 ERROR_DS_UNICODEPWD_NOT_IN_QUOTES - The unicodePwd attribute value must be enclosed in double quotes.
 .
 
@@ -14505,12 +18317,18 @@ SymbolicName=ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED
 Language=English
 ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED - Your computer could not be joined to the domain. You have exceeded the maximum number of computer accounts you are allowed to create in this domain. Contact your system administrator to have this limit reset or increased.
 .
+Language=Russian
+ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED - Your computer could not be joined to the domain. You have exceeded the maximum number of computer accounts you are allowed to create in this domain. Contact your system administrator to have this limit reset or increased.
+.
 
 MessageId=8558
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_MUST_BE_RUN_ON_DST_DC
 Language=English
+ERROR_DS_MUST_BE_RUN_ON_DST_DC - For security reasons, the operation must be run on the destination DC.
+.
+Language=Russian
 ERROR_DS_MUST_BE_RUN_ON_DST_DC - For security reasons, the operation must be run on the destination DC.
 .
 
@@ -14521,6 +18339,9 @@ SymbolicName=ERROR_DS_SRC_DC_MUST_BE_SP4_OR_GREATER
 Language=English
 ERROR_DS_SRC_DC_MUST_BE_SP4_OR_GREATER - For security reasons, the source DC must be NT4SP4 or greater.
 .
+Language=Russian
+ERROR_DS_SRC_DC_MUST_BE_SP4_OR_GREATER - For security reasons, the source DC must be NT4SP4 or greater.
+.
 
 MessageId=8560
 Severity=Success
@@ -14529,12 +18350,19 @@ SymbolicName=ERROR_DS_CANT_TREE_DELETE_CRITICAL_OBJ
 Language=English
 ERROR_DS_CANT_TREE_DELETE_CRITICAL_OBJ - Critical Directory Service System objects cannot be deleted during tree delete operations. The tree delete may have been partially performed.
 .
+Language=Russian
+ERROR_DS_CANT_TREE_DELETE_CRITICAL_OBJ - Critical Directory Service System objects cannot be deleted during tree delete operations. The tree delete may have been partially performed.
+.
 
 MessageId=8561
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INIT_FAILURE_CONSOLE
 Language=English
+ERROR_DS_INIT_FAILURE_CONSOLE - Directory Services could not start because of the following error: %1.
+Error Status: 0x%2. Please click OK to shutdown the system. You can use the recovery console to diagnose the system further.
+.
+Language=Russian
 ERROR_DS_INIT_FAILURE_CONSOLE - Directory Services could not start because of the following error: %1.
 Error Status: 0x%2. Please click OK to shutdown the system. You can use the recovery console to diagnose the system further.
 .
@@ -14547,12 +18375,19 @@ Language=English
 ERROR_DS_SAM_INIT_FAILURE_CONSOLE - Security Accounts Manager initialization failed because of the following error: %1.
 Error Status: 0x%2. Please click OK to shutdown the system. You can use the recovery console to diagnose the system further.
 .
+Language=Russian
+ERROR_DS_SAM_INIT_FAILURE_CONSOLE - Security Accounts Manager initialization failed because of the following error: %1.
+Error Status: 0x%2. Please click OK to shutdown the system. You can use the recovery console to diagnose the system further.
+.
 
 MessageId=8563
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_FOREST_VERSION_TOO_HIGH
 Language=English
+ERROR_DS_FOREST_VERSION_TOO_HIGH - The version of the operating system installed is incompatible with the current forest functional level. You must upgrade to a new version of the operating system before this server can become a domain controller in this forest.
+.
+Language=Russian
 ERROR_DS_FOREST_VERSION_TOO_HIGH - The version of the operating system installed is incompatible with the current forest functional level. You must upgrade to a new version of the operating system before this server can become a domain controller in this forest.
 .
 
@@ -14563,12 +18398,18 @@ SymbolicName=ERROR_DS_DOMAIN_VERSION_TOO_HIGH
 Language=English
 ERROR_DS_DOMAIN_VERSION_TOO_HIGH - The version of the operating system installed is incompatible with the current domain functional level. You must upgrade to a new version of the operating system before this server can become a domain controller in this domain.
 .
+Language=Russian
+ERROR_DS_DOMAIN_VERSION_TOO_HIGH - The version of the operating system installed is incompatible with the current domain functional level. You must upgrade to a new version of the operating system before this server can become a domain controller in this domain.
+.
 
 MessageId=8565
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_FOREST_VERSION_TOO_LOW
 Language=English
+ERROR_DS_FOREST_VERSION_TOO_LOW - This version of the operating system installed on this server no longer supports the current forest functional level. You must raise the forest functional level before this server can become a domain controller in this forest.
+.
+Language=Russian
 ERROR_DS_FOREST_VERSION_TOO_LOW - This version of the operating system installed on this server no longer supports the current forest functional level. You must raise the forest functional level before this server can become a domain controller in this forest.
 .
 
@@ -14579,12 +18420,18 @@ SymbolicName=ERROR_DS_DOMAIN_VERSION_TOO_LOW
 Language=English
 ERROR_DS_DOMAIN_VERSION_TOO_LOW - This version of the operating system installed on this server no longer supports the current domain functional level. You must raise the domain functional level before this server can become a domain controller in this domain.
 .
+Language=Russian
+ERROR_DS_DOMAIN_VERSION_TOO_LOW - This version of the operating system installed on this server no longer supports the current domain functional level. You must raise the domain functional level before this server can become a domain controller in this domain.
+.
 
 MessageId=8567
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_INCOMPATIBLE_VERSION
 Language=English
+ERROR_DS_INCOMPATIBLE_VERSION - The version of the operating system installed on this server is incompatible with the functional level of the domain or forest.
+.
+Language=Russian
 ERROR_DS_INCOMPATIBLE_VERSION - The version of the operating system installed on this server is incompatible with the functional level of the domain or forest.
 .
 
@@ -14595,12 +18442,18 @@ SymbolicName=ERROR_DS_LOW_DSA_VERSION
 Language=English
 ERROR_DS_LOW_DSA_VERSION - The functional level of the domain (or forest) cannot be raised to the requested value, because there exist one or more domain controllers in the domain (or forest) that are at a lower incompatible functional level.
 .
+Language=Russian
+ERROR_DS_LOW_DSA_VERSION - The functional level of the domain (or forest) cannot be raised to the requested value, because there exist one or more domain controllers in the domain (or forest) that are at a lower incompatible functional level.
+.
 
 MessageId=8569
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_BEHAVIOR_VERSION_IN_MIXEDDOMAIN
 Language=English
+ERROR_DS_NO_BEHAVIOR_VERSION_IN_MIXEDDOMAIN - The forest functional level cannot be raised to the requested level since one or more domains are still in mixed domain mode. All domains in the forest must be in native mode before you can raise the forest functional level.
+.
+Language=Russian
 ERROR_DS_NO_BEHAVIOR_VERSION_IN_MIXEDDOMAIN - The forest functional level cannot be raised to the requested level since one or more domains are still in mixed domain mode. All domains in the forest must be in native mode before you can raise the forest functional level.
 .
 
@@ -14611,12 +18464,18 @@ SymbolicName=ERROR_DS_NOT_SUPPORTED_SORT_ORDER
 Language=English
 ERROR_DS_NOT_SUPPORTED_SORT_ORDER - The sort order requested is not supported.
 .
+Language=Russian
+ERROR_DS_NOT_SUPPORTED_SORT_ORDER - The sort order requested is not supported.
+.
 
 MessageId=8571
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_NOT_UNIQUE
 Language=English
+ERROR_DS_NAME_NOT_UNIQUE - The requested name already exists as a unique identifier.
+.
+Language=Russian
 ERROR_DS_NAME_NOT_UNIQUE - The requested name already exists as a unique identifier.
 .
 
@@ -14627,12 +18486,18 @@ SymbolicName=ERROR_DS_MACHINE_ACCOUNT_CREATED_PRENT4
 Language=English
 ERROR_DS_MACHINE_ACCOUNT_CREATED_PRENT4 - The machine account was created pre-NT4. The account needs to be recreated.
 .
+Language=Russian
+ERROR_DS_MACHINE_ACCOUNT_CREATED_PRENT4 - The machine account was created pre-NT4. The account needs to be recreated.
+.
 
 MessageId=8573
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_OUT_OF_VERSION_STORE
 Language=English
+ERROR_DS_OUT_OF_VERSION_STORE - The database is out of version store.
+.
+Language=Russian
 ERROR_DS_OUT_OF_VERSION_STORE - The database is out of version store.
 .
 
@@ -14643,12 +18508,18 @@ SymbolicName=ERROR_DS_INCOMPATIBLE_CONTROLS_USED
 Language=English
 ERROR_DS_INCOMPATIBLE_CONTROLS_USED - Unable to continue operation because multiple conflicting controls were used.
 .
+Language=Russian
+ERROR_DS_INCOMPATIBLE_CONTROLS_USED - Unable to continue operation because multiple conflicting controls were used.
+.
 
 MessageId=8575
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NO_REF_DOMAIN
 Language=English
+ERROR_DS_NO_REF_DOMAIN - Unable to find a valid security descriptor reference domain for this partition.
+.
+Language=Russian
 ERROR_DS_NO_REF_DOMAIN - Unable to find a valid security descriptor reference domain for this partition.
 .
 
@@ -14659,12 +18530,18 @@ SymbolicName=ERROR_DS_RESERVED_LINK_ID
 Language=English
 ERROR_DS_RESERVED_LINK_ID - Schema update failed: The link identifier is reserved.
 .
+Language=Russian
+ERROR_DS_RESERVED_LINK_ID - Schema update failed: The link identifier is reserved.
+.
 
 MessageId=8577
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_LINK_ID_NOT_AVAILABLE
 Language=English
+ERROR_DS_LINK_ID_NOT_AVAILABLE - Schema update failed: There are no link identifiers available.
+.
+Language=Russian
 ERROR_DS_LINK_ID_NOT_AVAILABLE - Schema update failed: There are no link identifiers available.
 .
 
@@ -14675,12 +18552,18 @@ SymbolicName=ERROR_DS_AG_CANT_HAVE_UNIVERSAL_MEMBER
 Language=English
 ERROR_DS_AG_CANT_HAVE_UNIVERSAL_MEMBER - An account group cannot have a universal group as a member.
 .
+Language=Russian
+ERROR_DS_AG_CANT_HAVE_UNIVERSAL_MEMBER - An account group cannot have a universal group as a member.
+.
 
 MessageId=8579
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_MODIFYDN_DISALLOWED_BY_INSTANCE_TYPE
 Language=English
+ERROR_DS_MODIFYDN_DISALLOWED_BY_INSTANCE_TYPE - Rename or move operations on naming context heads or read-only objects are not allowed.
+.
+Language=Russian
 ERROR_DS_MODIFYDN_DISALLOWED_BY_INSTANCE_TYPE - Rename or move operations on naming context heads or read-only objects are not allowed.
 .
 
@@ -14691,12 +18574,18 @@ SymbolicName=ERROR_DS_NO_OBJECT_MOVE_IN_SCHEMA_NC
 Language=English
 ERROR_DS_NO_OBJECT_MOVE_IN_SCHEMA_NC - Move operations on objects in the schema naming context are not allowed.
 .
+Language=Russian
+ERROR_DS_NO_OBJECT_MOVE_IN_SCHEMA_NC - Move operations on objects in the schema naming context are not allowed.
+.
 
 MessageId=8581
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_MODIFYDN_DISALLOWED_BY_FLAG
 Language=English
+ERROR_DS_MODIFYDN_DISALLOWED_BY_FLAG - A system flag has been set on the object and does not allow the object to be moved or renamed.
+.
+Language=Russian
 ERROR_DS_MODIFYDN_DISALLOWED_BY_FLAG - A system flag has been set on the object and does not allow the object to be moved or renamed.
 .
 
@@ -14707,12 +18596,18 @@ SymbolicName=ERROR_DS_MODIFYDN_WRONG_GRANDPARENT
 Language=English
 ERROR_DS_MODIFYDN_WRONG_GRANDPARENT - This object is not allowed to change its grandparent container. Moves are not forbidden on this object, but are restricted to sibling containers.
 .
+Language=Russian
+ERROR_DS_MODIFYDN_WRONG_GRANDPARENT - This object is not allowed to change its grandparent container. Moves are not forbidden on this object, but are restricted to sibling containers.
+.
 
 MessageId=8583
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NAME_ERROR_TRUST_REFERRAL
 Language=English
+ERROR_DS_NAME_ERROR_TRUST_REFERRAL - Unable to resolve completely, a referral to another forest is generated.
+.
+Language=Russian
 ERROR_DS_NAME_ERROR_TRUST_REFERRAL - Unable to resolve completely, a referral to another forest is generated.
 .
 
@@ -14723,12 +18618,18 @@ SymbolicName=ERROR_NOT_SUPPORTED_ON_STANDARD_SERVER
 Language=English
 ERROR_NOT_SUPPORTED_ON_STANDARD_SERVER - The requested action is not supported on standard server.
 .
+Language=Russian
+ERROR_NOT_SUPPORTED_ON_STANDARD_SERVER - The requested action is not supported on standard server.
+.
 
 MessageId=8585
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_ACCESS_REMOTE_PART_OF_AD
 Language=English
+ERROR_DS_CANT_ACCESS_REMOTE_PART_OF_AD - Could not access a partition of the Active Directory located on a remote server. Make sure at least one server is running for the partition in question.
+.
+Language=Russian
 ERROR_DS_CANT_ACCESS_REMOTE_PART_OF_AD - Could not access a partition of the Active Directory located on a remote server. Make sure at least one server is running for the partition in question.
 .
 
@@ -14739,12 +18640,18 @@ SymbolicName=ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE_V2
 Language=English
 ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE_V2 - The directory cannot validate the proposed naming context (or partition) name because it does not hold a replica nor can it contact a replica of the naming context above the proposed naming context. Please ensure that the parent naming context is properly registered in DNS, and at least one replica of this naming context is reachable by the Domain Naming master.
 .
+Language=Russian
+ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE_V2 - The directory cannot validate the proposed naming context (or partition) name because it does not hold a replica nor can it contact a replica of the naming context above the proposed naming context. Please ensure that the parent naming context is properly registered in DNS, and at least one replica of this naming context is reachable by the Domain Naming master.
+.
 
 MessageId=8587
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_THREAD_LIMIT_EXCEEDED
 Language=English
+ERROR_DS_THREAD_LIMIT_EXCEEDED - The thread limit for this request was exceeded.
+.
+Language=Russian
 ERROR_DS_THREAD_LIMIT_EXCEEDED - The thread limit for this request was exceeded.
 .
 
@@ -14755,12 +18662,18 @@ SymbolicName=ERROR_DS_NOT_CLOSEST
 Language=English
 ERROR_DS_NOT_CLOSEST - The Global catalog server is not in the closet site.
 .
+Language=Russian
+ERROR_DS_NOT_CLOSEST - The Global catalog server is not in the closet site.
+.
 
 MessageId=8589
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_DERIVE_SPN_WITHOUT_SERVER_REF
 Language=English
+ERROR_DS_CANT_DERIVE_SPN_WITHOUT_SERVER_REF - The DS cannot derive a service principal name (SPN) with which to mutually authenticate the target server because the corresponding server object in the local DS database has no serverReference attribute.
+.
+Language=Russian
 ERROR_DS_CANT_DERIVE_SPN_WITHOUT_SERVER_REF - The DS cannot derive a service principal name (SPN) with which to mutually authenticate the target server because the corresponding server object in the local DS database has no serverReference attribute.
 .
 
@@ -14771,12 +18684,18 @@ SymbolicName=ERROR_DS_SINGLE_USER_MODE_FAILED
 Language=English
 ERROR_DS_SINGLE_USER_MODE_FAILED - The Directory Service failed to enter single user mode.
 .
+Language=Russian
+ERROR_DS_SINGLE_USER_MODE_FAILED - The Directory Service failed to enter single user mode.
+.
 
 MessageId=8591
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_NTDSCRIPT_SYNTAX_ERROR
 Language=English
+ERROR_DS_NTDSCRIPT_SYNTAX_ERROR - The Directory Service cannot parse the script because of a syntax error.
+.
+Language=Russian
 ERROR_DS_NTDSCRIPT_SYNTAX_ERROR - The Directory Service cannot parse the script because of a syntax error.
 .
 
@@ -14787,12 +18706,18 @@ SymbolicName=ERROR_DS_NTDSCRIPT_PROCESS_ERROR
 Language=English
 ERROR_DS_NTDSCRIPT_PROCESS_ERROR - The Directory Service cannot process the script because of an error.
 .
+Language=Russian
+ERROR_DS_NTDSCRIPT_PROCESS_ERROR - The Directory Service cannot process the script because of an error.
+.
 
 MessageId=8593
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DIFFERENT_REPL_EPOCHS
 Language=English
+ERROR_DS_DIFFERENT_REPL_EPOCHS - The directory service cannot perform the requested operation because the servers involved are of different replication epochs (which is usually related to a domain rename that is in progress).
+.
+Language=Russian
 ERROR_DS_DIFFERENT_REPL_EPOCHS - The directory service cannot perform the requested operation because the servers involved are of different replication epochs (which is usually related to a domain rename that is in progress).
 .
 
@@ -14803,12 +18728,18 @@ SymbolicName=ERROR_DS_DRS_EXTENSIONS_CHANGED
 Language=English
 ERROR_DS_DRS_EXTENSIONS_CHANGED - The directory service binding must be renegotiated due to a change in the server extensions information.
 .
+Language=Russian
+ERROR_DS_DRS_EXTENSIONS_CHANGED - The directory service binding must be renegotiated due to a change in the server extensions information.
+.
 
 MessageId=8595
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_REPLICA_SET_CHANGE_NOT_ALLOWED_ON_DISABLED_CR
 Language=English
+ERROR_DS_REPLICA_SET_CHANGE_NOT_ALLOWED_ON_DISABLED_CR - Operation not allowed on a disabled cross ref.
+.
+Language=Russian
 ERROR_DS_REPLICA_SET_CHANGE_NOT_ALLOWED_ON_DISABLED_CR - Operation not allowed on a disabled cross ref.
 .
 
@@ -14819,12 +18750,18 @@ SymbolicName=ERROR_DS_NO_MSDS_INTID
 Language=English
 ERROR_DS_NO_MSDS_INTID - Schema update failed: No values for msDS-IntId are available.
 .
+Language=Russian
+ERROR_DS_NO_MSDS_INTID - Schema update failed: No values for msDS-IntId are available.
+.
 
 MessageId=8597
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUP_MSDS_INTID
 Language=English
+ERROR_DS_DUP_MSDS_INTID - Schema update failed: Duplicate msDS-IntId. Retry the operation.
+.
+Language=Russian
 ERROR_DS_DUP_MSDS_INTID - Schema update failed: Duplicate msDS-IntId. Retry the operation.
 .
 
@@ -14835,12 +18772,18 @@ SymbolicName=ERROR_DS_EXISTS_IN_RDNATTID
 Language=English
 ERROR_DS_EXISTS_IN_RDNATTID - Schema deletion failed: attribute is used in rDNAttID.
 .
+Language=Russian
+ERROR_DS_EXISTS_IN_RDNATTID - Schema deletion failed: attribute is used in rDNAttID.
+.
 
 MessageId=8599
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_AUTHORIZATION_FAILED
 Language=English
+ERROR_DS_AUTHORIZATION_FAILED - The directory service failed to authorize the request.
+.
+Language=Russian
 ERROR_DS_AUTHORIZATION_FAILED - The directory service failed to authorize the request.
 .
 
@@ -14851,12 +18794,18 @@ SymbolicName=ERROR_DS_INVALID_SCRIPT
 Language=English
 ERROR_DS_INVALID_SCRIPT - The Directory Service cannot process the script because it is invalid.
 .
+Language=Russian
+ERROR_DS_INVALID_SCRIPT - The Directory Service cannot process the script because it is invalid.
+.
 
 MessageId=8601
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_REMOTE_CROSSREF_OP_FAILED
 Language=English
+ERROR_DS_REMOTE_CROSSREF_OP_FAILED - The remote create cross reference operation failed on the Domain Naming Master FSMO. The operation's error is in the extended data.
+.
+Language=Russian
 ERROR_DS_REMOTE_CROSSREF_OP_FAILED - The remote create cross reference operation failed on the Domain Naming Master FSMO. The operation's error is in the extended data.
 .
 
@@ -14867,12 +18816,18 @@ SymbolicName=ERROR_DS_CROSS_REF_BUSY
 Language=English
 ERROR_DS_CROSS_REF_BUSY - A cross reference is in use locally with the same name.
 .
+Language=Russian
+ERROR_DS_CROSS_REF_BUSY - A cross reference is in use locally with the same name.
+.
 
 MessageId=8603
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_DERIVE_SPN_FOR_DELETED_DOMAIN
 Language=English
+ERROR_DS_CANT_DERIVE_SPN_FOR_DELETED_DOMAIN - The DS cannot derive a service principal name (SPN) with which to mutually authenticate the target server because the server's domain has been deleted from the forest.
+.
+Language=Russian
 ERROR_DS_CANT_DERIVE_SPN_FOR_DELETED_DOMAIN - The DS cannot derive a service principal name (SPN) with which to mutually authenticate the target server because the server's domain has been deleted from the forest.
 .
 
@@ -14883,12 +18838,18 @@ SymbolicName=ERROR_DS_CANT_DEMOTE_WITH_WRITEABLE_NC
 Language=English
 ERROR_DS_CANT_DEMOTE_WITH_WRITEABLE_NC - Writeable NCs prevent this DC from demoting.
 .
+Language=Russian
+ERROR_DS_CANT_DEMOTE_WITH_WRITEABLE_NC - Writeable NCs prevent this DC from demoting.
+.
 
 MessageId=8605
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DUPLICATE_ID_FOUND
 Language=English
+ERROR_DS_DUPLICATE_ID_FOUND - The requested object has a non-unique identifier and cannot be retrieved.
+.
+Language=Russian
 ERROR_DS_DUPLICATE_ID_FOUND - The requested object has a non-unique identifier and cannot be retrieved.
 .
 
@@ -14899,12 +18860,18 @@ SymbolicName=ERROR_DS_INSUFFICIENT_ATTR_TO_CREATE_OBJECT
 Language=English
 ERROR_DS_INSUFFICIENT_ATTR_TO_CREATE_OBJECT - Insufficient attributes were given to create an object. This object may not exist because it may have been deleted and already garbage collected.
 .
+Language=Russian
+ERROR_DS_INSUFFICIENT_ATTR_TO_CREATE_OBJECT - Insufficient attributes were given to create an object. This object may not exist because it may have been deleted and already garbage collected.
+.
 
 MessageId=8607
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_GROUP_CONVERSION_ERROR
 Language=English
+ERROR_DS_GROUP_CONVERSION_ERROR - The group cannot be converted due to attribute restrictions on the requested group type.
+.
+Language=Russian
 ERROR_DS_GROUP_CONVERSION_ERROR - The group cannot be converted due to attribute restrictions on the requested group type.
 .
 
@@ -14915,12 +18882,18 @@ SymbolicName=ERROR_DS_CANT_MOVE_APP_BASIC_GROUP
 Language=English
 ERROR_DS_CANT_MOVE_APP_BASIC_GROUP - Cross-domain move of non-empty basic application groups is not allowed.
 .
+Language=Russian
+ERROR_DS_CANT_MOVE_APP_BASIC_GROUP - Cross-domain move of non-empty basic application groups is not allowed.
+.
 
 MessageId=8609
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_CANT_MOVE_APP_QUERY_GROUP
 Language=English
+ERROR_DS_CANT_MOVE_APP_QUERY_GROUP - Cross-domain move on non-empty query based application groups is not allowed.
+.
+Language=Russian
 ERROR_DS_CANT_MOVE_APP_QUERY_GROUP - Cross-domain move on non-empty query based application groups is not allowed.
 .
 
@@ -14931,12 +18904,18 @@ SymbolicName=ERROR_DS_ROLE_NOT_VERIFIED
 Language=English
 ERROR_DS_ROLE_NOT_VERIFIED - The role owner could not be verified because replication of its partition has not occurred recently.
 .
+Language=Russian
+ERROR_DS_ROLE_NOT_VERIFIED - The role owner could not be verified because replication of its partition has not occurred recently.
+.
 
 MessageId=8611
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_WKO_CONTAINER_CANNOT_BE_SPECIAL
 Language=English
+ERROR_DS_WKO_CONTAINER_CANNOT_BE_SPECIAL - The target container for a redirection of a well-known object container cannot already be a special container.
+.
+Language=Russian
 ERROR_DS_WKO_CONTAINER_CANNOT_BE_SPECIAL - The target container for a redirection of a well-known object container cannot already be a special container.
 .
 
@@ -14947,12 +18926,18 @@ SymbolicName=ERROR_DS_DOMAIN_RENAME_IN_PROGRESS
 Language=English
 ERROR_DS_DOMAIN_RENAME_IN_PROGRESS - The Directory Service cannot perform the requested operation because a domain rename operation is in progress.
 .
+Language=Russian
+ERROR_DS_DOMAIN_RENAME_IN_PROGRESS - The Directory Service cannot perform the requested operation because a domain rename operation is in progress.
+.
 
 MessageId=8613
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_EXISTING_AD_CHILD_NC
 Language=English
+ERROR_DS_EXISTING_AD_CHILD_NC - The Active Directory detected an Active Directory child partition below the requested new partition name. The Active Directory's partition hierarchy must be created in a top-down method.
+.
+Language=Russian
 ERROR_DS_EXISTING_AD_CHILD_NC - The Active Directory detected an Active Directory child partition below the requested new partition name. The Active Directory's partition hierarchy must be created in a top-down method.
 .
 
@@ -14963,12 +18948,18 @@ SymbolicName=ERROR_DS_REPL_LIFETIME_EXCEEDED
 Language=English
 ERROR_DS_REPL_LIFETIME_EXCEEDED - The Active Directory cannot replicate with this server because the time since the last replication with this server has exceeded the tombstone lifetime.
 .
+Language=Russian
+ERROR_DS_REPL_LIFETIME_EXCEEDED - The Active Directory cannot replicate with this server because the time since the last replication with this server has exceeded the tombstone lifetime.
+.
 
 MessageId=8615
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DISALLOWED_IN_SYSTEM_CONTAINER
 Language=English
+ERROR_DS_DISALLOWED_IN_SYSTEM_CONTAINER - The requested operation is not allowed on an object under the system container.
+.
+Language=Russian
 ERROR_DS_DISALLOWED_IN_SYSTEM_CONTAINER - The requested operation is not allowed on an object under the system container.
 .
 
@@ -14979,12 +18970,18 @@ SymbolicName=ERROR_DS_LDAP_SEND_QUEUE_FULL
 Language=English
 ERROR_DS_LDAP_SEND_QUEUE_FULL - The LDAP servers network send queue has filled up because the client is not processing the results of it's requests fast enough. No more requests will be processed until the client catches up. If the client does not catch up then it will be disconnected.
 .
+Language=Russian
+ERROR_DS_LDAP_SEND_QUEUE_FULL - The LDAP servers network send queue has filled up because the client is not processing the results of it's requests fast enough. No more requests will be processed until the client catches up. If the client does not catch up then it will be disconnected.
+.
 
 MessageId=8617
 Severity=Success
 Facility=System
 SymbolicName=ERROR_DS_DRA_OUT_SCHEDULE_WINDOW
 Language=English
+ERROR_DS_DRA_OUT_SCHEDULE_WINDOW - The scheduled replication did not take place because the system was too busy to execute the request within the schedule window. The replication queue is overloaded. Consider reducing the number of partners or decreasing the scheduled replication frequency.
+.
+Language=Russian
 ERROR_DS_DRA_OUT_SCHEDULE_WINDOW - The scheduled replication did not take place because the system was too busy to execute the request within the schedule window. The replication queue is overloaded. Consider reducing the number of partners or decreasing the scheduled replication frequency.
 .
 
@@ -14995,12 +18992,18 @@ SymbolicName=DNS_ERROR_RCODE_FORMAT_ERROR
 Language=English
 DNS_ERROR_RCODE_FORMAT_ERROR - DNS server unable to interpret format.
 .
+Language=Russian
+DNS_ERROR_RCODE_FORMAT_ERROR - DNS server unable to interpret format.
+.
 
 MessageId=9002
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_SERVER_FAILURE
 Language=English
+DNS_ERROR_RCODE_SERVER_FAILURE - DNS server failure.
+.
+Language=Russian
 DNS_ERROR_RCODE_SERVER_FAILURE - DNS server failure.
 .
 
@@ -15011,12 +19014,18 @@ SymbolicName=DNS_ERROR_RCODE_NAME_ERROR
 Language=English
 DNS_ERROR_RCODE_NAME_ERROR - DNS name does not exist.
 .
+Language=Russian
+DNS_ERROR_RCODE_NAME_ERROR - DNS name does not exist.
+.
 
 MessageId=9004
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_NOT_IMPLEMENTED
 Language=English
+DNS_ERROR_RCODE_NOT_IMPLEMENTED - DNS request not supported by name server.
+.
+Language=Russian
 DNS_ERROR_RCODE_NOT_IMPLEMENTED - DNS request not supported by name server.
 .
 
@@ -15027,12 +19036,18 @@ SymbolicName=DNS_ERROR_RCODE_REFUSED
 Language=English
 DNS_ERROR_RCODE_REFUSED - DNS operation refused.
 .
+Language=Russian
+DNS_ERROR_RCODE_REFUSED - DNS operation refused.
+.
 
 MessageId=9006
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_YXDOMAIN
 Language=English
+DNS_ERROR_RCODE_YXDOMAIN - DNS name that ought not exist, does exist.
+.
+Language=Russian
 DNS_ERROR_RCODE_YXDOMAIN - DNS name that ought not exist, does exist.
 .
 
@@ -15043,12 +19058,18 @@ SymbolicName=DNS_ERROR_RCODE_YXRRSET
 Language=English
 DNS_ERROR_RCODE_YXRRSET - DNS RR set that ought not exist, does exist.
 .
+Language=Russian
+DNS_ERROR_RCODE_YXRRSET - DNS RR set that ought not exist, does exist.
+.
 
 MessageId=9008
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_NXRRSET
 Language=English
+DNS_ERROR_RCODE_NXRRSET - DNS RR set that ought to exist, does not exist.
+.
+Language=Russian
 DNS_ERROR_RCODE_NXRRSET - DNS RR set that ought to exist, does not exist.
 .
 
@@ -15059,12 +19080,18 @@ SymbolicName=DNS_ERROR_RCODE_NOTAUTH
 Language=English
 DNS_ERROR_RCODE_NOTAUTH - DNS server not authoritative for zone.
 .
+Language=Russian
+DNS_ERROR_RCODE_NOTAUTH - DNS server not authoritative for zone.
+.
 
 MessageId=9010
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_NOTZONE
 Language=English
+DNS_ERROR_RCODE_NOTZONE - DNS name in update or prereq is not in zone.
+.
+Language=Russian
 DNS_ERROR_RCODE_NOTZONE - DNS name in update or prereq is not in zone.
 .
 
@@ -15075,12 +19102,18 @@ SymbolicName=DNS_ERROR_RCODE_BADSIG
 Language=English
 DNS_ERROR_RCODE_BADSIG - DNS signature failed to verify.
 .
+Language=Russian
+DNS_ERROR_RCODE_BADSIG - DNS signature failed to verify.
+.
 
 MessageId=9017
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RCODE_BADKEY
 Language=English
+DNS_ERROR_RCODE_BADKEY - DNS bad key.
+.
+Language=Russian
 DNS_ERROR_RCODE_BADKEY - DNS bad key.
 .
 
@@ -15091,12 +19124,18 @@ SymbolicName=DNS_ERROR_RCODE_BADTIME
 Language=English
 DNS_ERROR_RCODE_BADTIME - DNS signature validity expired.
 .
+Language=Russian
+DNS_ERROR_RCODE_BADTIME - DNS signature validity expired.
+.
 
 MessageId=9501
 Severity=Success
 Facility=System
 SymbolicName=DNS_INFO_NO_RECORDS
 Language=English
+DNS_INFO_NO_RECORDS - No records found for given DNS query.
+.
+Language=Russian
 DNS_INFO_NO_RECORDS - No records found for given DNS query.
 .
 
@@ -15107,12 +19146,18 @@ SymbolicName=DNS_ERROR_BAD_PACKET
 Language=English
 DNS_ERROR_BAD_PACKET - Bad DNS packet.
 .
+Language=Russian
+DNS_ERROR_BAD_PACKET - Bad DNS packet.
+.
 
 MessageId=9503
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NO_PACKET
 Language=English
+DNS_ERROR_NO_PACKET - No DNS packet.
+.
+Language=Russian
 DNS_ERROR_NO_PACKET - No DNS packet.
 .
 
@@ -15123,12 +19168,18 @@ SymbolicName=DNS_ERROR_RCODE
 Language=English
 DNS_ERROR_RCODE - DNS error, check rcode.
 .
+Language=Russian
+DNS_ERROR_RCODE - DNS error, check rcode.
+.
 
 MessageId=9505
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_UNSECURE_PACKET
 Language=English
+DNS_ERROR_UNSECURE_PACKET - Unsecured DNS packet.
+.
+Language=Russian
 DNS_ERROR_UNSECURE_PACKET - Unsecured DNS packet.
 .
 
@@ -15139,12 +19190,18 @@ SymbolicName=DNS_ERROR_INVALID_TYPE
 Language=English
 DNS_ERROR_INVALID_TYPE - Invalid DNS type.
 .
+Language=Russian
+DNS_ERROR_INVALID_TYPE - Invalid DNS type.
+.
 
 MessageId=9552
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_INVALID_IP_ADDRESS
 Language=English
+DNS_ERROR_INVALID_IP_ADDRESS - Invalid IP address.
+.
+Language=Russian
 DNS_ERROR_INVALID_IP_ADDRESS - Invalid IP address.
 .
 
@@ -15155,12 +19212,18 @@ SymbolicName=DNS_ERROR_INVALID_PROPERTY
 Language=English
 DNS_ERROR_INVALID_PROPERTY - Invalid property.
 .
+Language=Russian
+DNS_ERROR_INVALID_PROPERTY - Invalid property.
+.
 
 MessageId=9554
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_TRY_AGAIN_LATER
 Language=English
+DNS_ERROR_TRY_AGAIN_LATER - Try DNS operation again later.
+.
+Language=Russian
 DNS_ERROR_TRY_AGAIN_LATER - Try DNS operation again later.
 .
 
@@ -15171,12 +19234,18 @@ SymbolicName=DNS_ERROR_NOT_UNIQUE
 Language=English
 DNS_ERROR_NOT_UNIQUE - Record for given name and type is not unique.
 .
+Language=Russian
+DNS_ERROR_NOT_UNIQUE - Record for given name and type is not unique.
+.
 
 MessageId=9556
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NON_RFC_NAME
 Language=English
+DNS_ERROR_NON_RFC_NAME - DNS name does not comply with RFC specifications.
+.
+Language=Russian
 DNS_ERROR_NON_RFC_NAME - DNS name does not comply with RFC specifications.
 .
 
@@ -15187,12 +19256,18 @@ SymbolicName=DNS_STATUS_FQDN
 Language=English
 DNS_STATUS_FQDN - DNS name is a fully-qualified DNS name.
 .
+Language=Russian
+DNS_STATUS_FQDN - DNS name is a fully-qualified DNS name.
+.
 
 MessageId=9558
 Severity=Success
 Facility=System
 SymbolicName=DNS_STATUS_DOTTED_NAME
 Language=English
+DNS_STATUS_DOTTED_NAME - DNS name is dotted (multi-label).
+.
+Language=Russian
 DNS_STATUS_DOTTED_NAME - DNS name is dotted (multi-label).
 .
 
@@ -15203,12 +19278,18 @@ SymbolicName=DNS_STATUS_SINGLE_PART_NAME
 Language=English
 DNS_STATUS_SINGLE_PART_NAME - DNS name is a single-part name.
 .
+Language=Russian
+DNS_STATUS_SINGLE_PART_NAME - DNS name is a single-part name.
+.
 
 MessageId=9560
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_INVALID_NAME_CHAR
 Language=English
+DNS_ERROR_INVALID_NAME_CHAR - DSN name contains an invalid character.
+.
+Language=Russian
 DNS_ERROR_INVALID_NAME_CHAR - DSN name contains an invalid character.
 .
 
@@ -15219,12 +19300,18 @@ SymbolicName=DNS_ERROR_NUMERIC_NAME
 Language=English
 DNS_ERROR_NUMERIC_NAME - DNS name is entirely numeric.
 .
+Language=Russian
+DNS_ERROR_NUMERIC_NAME - DNS name is entirely numeric.
+.
 
 MessageId=9562
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NOT_ALLOWED_ON_ROOT_SERVER
 Language=English
+DNS_ERROR_NOT_ALLOWED_ON_ROOT_SERVER - The operation requested is not permitted on a DNS root server.
+.
+Language=Russian
 DNS_ERROR_NOT_ALLOWED_ON_ROOT_SERVER - The operation requested is not permitted on a DNS root server.
 .
 
@@ -15235,12 +19322,18 @@ SymbolicName=DNS_ERROR_NOT_ALLOWED_UNDER_DELEGATION
 Language=English
 DNS_ERROR_NOT_ALLOWED_UNDER_DELEGATION - The record could not be created because this part of the DNS namespace has been delegated to another server.
 .
+Language=Russian
+DNS_ERROR_NOT_ALLOWED_UNDER_DELEGATION - The record could not be created because this part of the DNS namespace has been delegated to another server.
+.
 
 MessageId=9564
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_CANNOT_FIND_ROOT_HINTS
 Language=English
+DNS_ERROR_CANNOT_FIND_ROOT_HINTS - The DNS server could not find a set of root hints.
+.
+Language=Russian
 DNS_ERROR_CANNOT_FIND_ROOT_HINTS - The DNS server could not find a set of root hints.
 .
 
@@ -15251,12 +19344,18 @@ SymbolicName=DNS_ERROR_INCONSISTENT_ROOT_HINTS
 Language=English
 DNS_ERROR_INCONSISTENT_ROOT_HINTS - The DNS server found root hints but they were not consistent across all adapters.
 .
+Language=Russian
+DNS_ERROR_INCONSISTENT_ROOT_HINTS - The DNS server found root hints but they were not consistent across all adapters.
+.
 
 MessageId=9601
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_DOES_NOT_EXIST
 Language=English
+DNS_ERROR_ZONE_DOES_NOT_EXIST - DNS zone does not exist.
+.
+Language=Russian
 DNS_ERROR_ZONE_DOES_NOT_EXIST - DNS zone does not exist.
 .
 
@@ -15267,12 +19366,18 @@ SymbolicName=DNS_ERROR_NO_ZONE_INFO
 Language=English
 DNS_ERROR_NO_ZONE_INFO - DNS zone information not available.
 .
+Language=Russian
+DNS_ERROR_NO_ZONE_INFO - DNS zone information not available.
+.
 
 MessageId=9603
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_INVALID_ZONE_OPERATION
 Language=English
+DNS_ERROR_INVALID_ZONE_OPERATION - Invalid operation for DNS zone.
+.
+Language=Russian
 DNS_ERROR_INVALID_ZONE_OPERATION - Invalid operation for DNS zone.
 .
 
@@ -15283,12 +19388,18 @@ SymbolicName=DNS_ERROR_ZONE_CONFIGURATION_ERROR
 Language=English
 DNS_ERROR_ZONE_CONFIGURATION_ERROR - Invalid DNS zone configuration.
 .
+Language=Russian
+DNS_ERROR_ZONE_CONFIGURATION_ERROR - Invalid DNS zone configuration.
+.
 
 MessageId=9605
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_HAS_NO_SOA_RECORD
 Language=English
+DNS_ERROR_ZONE_HAS_NO_SOA_RECORD - DNS zone has no start of authority (SOA) record.
+.
+Language=Russian
 DNS_ERROR_ZONE_HAS_NO_SOA_RECORD - DNS zone has no start of authority (SOA) record.
 .
 
@@ -15299,12 +19410,18 @@ SymbolicName=DNS_ERROR_ZONE_HAS_NO_NS_RECORDS
 Language=English
 DNS_ERROR_ZONE_HAS_NO_NS_RECORDS - DNS zone has no name server (NS) record.
 .
+Language=Russian
+DNS_ERROR_ZONE_HAS_NO_NS_RECORDS - DNS zone has no name server (NS) record.
+.
 
 MessageId=9607
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_LOCKED
 Language=English
+DNS_ERROR_ZONE_LOCKED - DNS zone is locked.
+.
+Language=Russian
 DNS_ERROR_ZONE_LOCKED - DNS zone is locked.
 .
 
@@ -15315,12 +19432,18 @@ SymbolicName=DNS_ERROR_ZONE_CREATION_FAILED
 Language=English
 DNS_ERROR_ZONE_CREATION_FAILED - DNS zone creation failed.
 .
+Language=Russian
+DNS_ERROR_ZONE_CREATION_FAILED - DNS zone creation failed.
+.
 
 MessageId=9609
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_ALREADY_EXISTS
 Language=English
+DNS_ERROR_ZONE_ALREADY_EXISTS - DNS zone already exists.
+.
+Language=Russian
 DNS_ERROR_ZONE_ALREADY_EXISTS - DNS zone already exists.
 .
 
@@ -15331,12 +19454,18 @@ SymbolicName=DNS_ERROR_AUTOZONE_ALREADY_EXISTS
 Language=English
 DNS_ERROR_AUTOZONE_ALREADY_EXISTS - DNS automatic zone already exists.
 .
+Language=Russian
+DNS_ERROR_AUTOZONE_ALREADY_EXISTS - DNS automatic zone already exists.
+.
 
 MessageId=9611
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_INVALID_ZONE_TYPE
 Language=English
+DNS_ERROR_INVALID_ZONE_TYPE - Invalid DNS zone type.
+.
+Language=Russian
 DNS_ERROR_INVALID_ZONE_TYPE - Invalid DNS zone type.
 .
 
@@ -15347,12 +19476,18 @@ SymbolicName=DNS_ERROR_SECONDARY_REQUIRES_MASTER_IP
 Language=English
 DNS_ERROR_SECONDARY_REQUIRES_MASTER_IP - Secondary DNS zone requires master IP address.
 .
+Language=Russian
+DNS_ERROR_SECONDARY_REQUIRES_MASTER_IP - Secondary DNS zone requires master IP address.
+.
 
 MessageId=9613
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_NOT_SECONDARY
 Language=English
+DNS_ERROR_ZONE_NOT_SECONDARY - DNS zone not secondary.
+.
+Language=Russian
 DNS_ERROR_ZONE_NOT_SECONDARY - DNS zone not secondary.
 .
 
@@ -15363,12 +19498,18 @@ SymbolicName=DNS_ERROR_NEED_SECONDARY_ADDRESSES
 Language=English
 DNS_ERROR_NEED_SECONDARY_ADDRESSES - Need secondary IP address.
 .
+Language=Russian
+DNS_ERROR_NEED_SECONDARY_ADDRESSES - Need secondary IP address.
+.
 
 MessageId=9615
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_WINS_INIT_FAILED
 Language=English
+DNS_ERROR_WINS_INIT_FAILED - WINS initialization failed.
+.
+Language=Russian
 DNS_ERROR_WINS_INIT_FAILED - WINS initialization failed.
 .
 
@@ -15379,12 +19520,18 @@ SymbolicName=DNS_ERROR_NEED_WINS_SERVERS
 Language=English
 DNS_ERROR_NEED_WINS_SERVERS - Need WINS servers.
 .
+Language=Russian
+DNS_ERROR_NEED_WINS_SERVERS - Need WINS servers.
+.
 
 MessageId=9617
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NBSTAT_INIT_FAILED
 Language=English
+DNS_ERROR_NBSTAT_INIT_FAILED - NBTSTAT initialization call failed.
+.
+Language=Russian
 DNS_ERROR_NBSTAT_INIT_FAILED - NBTSTAT initialization call failed.
 .
 
@@ -15395,12 +19542,18 @@ SymbolicName=DNS_ERROR_SOA_DELETE_INVALID
 Language=English
 DNS_ERROR_SOA_DELETE_INVALID - Invalid delete of start of authority (SOA)
 .
+Language=Russian
+DNS_ERROR_SOA_DELETE_INVALID - Invalid delete of start of authority (SOA)
+.
 
 MessageId=9619
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_FORWARDER_ALREADY_EXISTS
 Language=English
+DNS_ERROR_FORWARDER_ALREADY_EXISTS - A conditional forwarding zone already exists for that name.
+.
+Language=Russian
 DNS_ERROR_FORWARDER_ALREADY_EXISTS - A conditional forwarding zone already exists for that name.
 .
 
@@ -15411,12 +19564,18 @@ SymbolicName=DNS_ERROR_ZONE_REQUIRES_MASTER_IP
 Language=English
 DNS_ERROR_ZONE_REQUIRES_MASTER_IP - This zone must be configured with one or more master DNS server IP addresses.
 .
+Language=Russian
+DNS_ERROR_ZONE_REQUIRES_MASTER_IP - This zone must be configured with one or more master DNS server IP addresses.
+.
 
 MessageId=9621
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_ZONE_IS_SHUTDOWN
 Language=English
+DNS_ERROR_ZONE_IS_SHUTDOWN - The operation cannot be performed because this zone is shutdown.
+.
+Language=Russian
 DNS_ERROR_ZONE_IS_SHUTDOWN - The operation cannot be performed because this zone is shutdown.
 .
 
@@ -15427,12 +19586,18 @@ SymbolicName=DNS_ERROR_PRIMARY_REQUIRES_DATAFILE
 Language=English
 DNS_ERROR_PRIMARY_REQUIRES_DATAFILE - Primary DNS zone requires datafile.
 .
+Language=Russian
+DNS_ERROR_PRIMARY_REQUIRES_DATAFILE - Primary DNS zone requires datafile.
+.
 
 MessageId=9652
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_INVALID_DATAFILE_NAME
 Language=English
+DNS_ERROR_INVALID_DATAFILE_NAME - Invalid datafile name for DNS zone.
+.
+Language=Russian
 DNS_ERROR_INVALID_DATAFILE_NAME - Invalid datafile name for DNS zone.
 .
 
@@ -15443,12 +19608,18 @@ SymbolicName=DNS_ERROR_DATAFILE_OPEN_FAILURE
 Language=English
 DNS_ERROR_DATAFILE_OPEN_FAILURE - Failed to open datafile for DNS zone.
 .
+Language=Russian
+DNS_ERROR_DATAFILE_OPEN_FAILURE - Failed to open datafile for DNS zone.
+.
 
 MessageId=9654
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_FILE_WRITEBACK_FAILED
 Language=English
+DNS_ERROR_FILE_WRITEBACK_FAILED - Failed to write datafile for DNS zone.
+.
+Language=Russian
 DNS_ERROR_FILE_WRITEBACK_FAILED - Failed to write datafile for DNS zone.
 .
 
@@ -15459,12 +19630,18 @@ SymbolicName=DNS_ERROR_DATAFILE_PARSING
 Language=English
 DNS_ERROR_DATAFILE_PARSING - Failure while reading datafile for DNS zone.
 .
+Language=Russian
+DNS_ERROR_DATAFILE_PARSING - Failure while reading datafile for DNS zone.
+.
 
 MessageId=9701
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RECORD_DOES_NOT_EXIST
 Language=English
+DNS_ERROR_RECORD_DOES_NOT_EXIST - DNS record does not exist.
+.
+Language=Russian
 DNS_ERROR_RECORD_DOES_NOT_EXIST - DNS record does not exist.
 .
 
@@ -15475,12 +19652,18 @@ SymbolicName=DNS_ERROR_RECORD_FORMAT
 Language=English
 DNS_ERROR_RECORD_FORMAT - DNS record format error.
 .
+Language=Russian
+DNS_ERROR_RECORD_FORMAT - DNS record format error.
+.
 
 MessageId=9703
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NODE_CREATION_FAILED
 Language=English
+DNS_ERROR_NODE_CREATION_FAILED - Node creation failure in DNS.
+.
+Language=Russian
 DNS_ERROR_NODE_CREATION_FAILED - Node creation failure in DNS.
 .
 
@@ -15491,12 +19674,18 @@ SymbolicName=DNS_ERROR_UNKNOWN_RECORD_TYPE
 Language=English
 DNS_ERROR_UNKNOWN_RECORD_TYPE - Unknown DNS record type.
 .
+Language=Russian
+DNS_ERROR_UNKNOWN_RECORD_TYPE - Unknown DNS record type.
+.
 
 MessageId=9705
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RECORD_TIMED_OUT
 Language=English
+DNS_ERROR_RECORD_TIMED_OUT - DNS record timed out.
+.
+Language=Russian
 DNS_ERROR_RECORD_TIMED_OUT - DNS record timed out.
 .
 
@@ -15507,12 +19696,18 @@ SymbolicName=DNS_ERROR_NAME_NOT_IN_ZONE
 Language=English
 DNS_ERROR_NAME_NOT_IN_ZONE - Name not in DNS zone.
 .
+Language=Russian
+DNS_ERROR_NAME_NOT_IN_ZONE - Name not in DNS zone.
+.
 
 MessageId=9707
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_CNAME_LOOP
 Language=English
+DNS_ERROR_CNAME_LOOP - CNAME loop detected.
+.
+Language=Russian
 DNS_ERROR_CNAME_LOOP - CNAME loop detected.
 .
 
@@ -15523,12 +19718,18 @@ SymbolicName=DNS_ERROR_NODE_IS_CNAME
 Language=English
 DNS_ERROR_NODE_IS_CNAME - Node is a CNAME DNS record.
 .
+Language=Russian
+DNS_ERROR_NODE_IS_CNAME - Node is a CNAME DNS record.
+.
 
 MessageId=9709
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_CNAME_COLLISION
 Language=English
+DNS_ERROR_CNAME_COLLISION - A CNAME record already exists for given name.
+.
+Language=Russian
 DNS_ERROR_CNAME_COLLISION - A CNAME record already exists for given name.
 .
 
@@ -15539,12 +19740,18 @@ SymbolicName=DNS_ERROR_RECORD_ONLY_AT_ZONE_ROOT
 Language=English
 DNS_ERROR_RECORD_ONLY_AT_ZONE_ROOT - Record only at DNS zone root.
 .
+Language=Russian
+DNS_ERROR_RECORD_ONLY_AT_ZONE_ROOT - Record only at DNS zone root.
+.
 
 MessageId=9711
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_RECORD_ALREADY_EXISTS
 Language=English
+DNS_ERROR_RECORD_ALREADY_EXISTS - DNS record already exists.
+.
+Language=Russian
 DNS_ERROR_RECORD_ALREADY_EXISTS - DNS record already exists.
 .
 
@@ -15555,12 +19762,18 @@ SymbolicName=DNS_ERROR_SECONDARY_DATA
 Language=English
 DNS_ERROR_SECONDARY_DATA - Secondary DNS zone data error.
 .
+Language=Russian
+DNS_ERROR_SECONDARY_DATA - Secondary DNS zone data error.
+.
 
 MessageId=9713
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NO_CREATE_CACHE_DATA
 Language=English
+DNS_ERROR_NO_CREATE_CACHE_DATA - Could not create DNS cache data.
+.
+Language=Russian
 DNS_ERROR_NO_CREATE_CACHE_DATA - Could not create DNS cache data.
 .
 
@@ -15571,12 +19784,18 @@ SymbolicName=DNS_ERROR_NAME_DOES_NOT_EXIST
 Language=English
 DNS_ERROR_NAME_DOES_NOT_EXIST - DNS name does not exist.
 .
+Language=Russian
+DNS_ERROR_NAME_DOES_NOT_EXIST - DNS name does not exist.
+.
 
 MessageId=9715
 Severity=Success
 Facility=System
 SymbolicName=DNS_WARNING_PTR_CREATE_FAILED
 Language=English
+DNS_WARNING_PTR_CREATE_FAILED - Could not create pointer (PTR) record.
+.
+Language=Russian
 DNS_WARNING_PTR_CREATE_FAILED - Could not create pointer (PTR) record.
 .
 
@@ -15587,12 +19806,18 @@ SymbolicName=DNS_WARNING_DOMAIN_UNDELETED
 Language=English
 DNS_WARNING_DOMAIN_UNDELETED - DNS domain was undeleted.
 .
+Language=Russian
+DNS_WARNING_DOMAIN_UNDELETED - DNS domain was undeleted.
+.
 
 MessageId=9717
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_DS_UNAVAILABLE
 Language=English
+DNS_ERROR_DS_UNAVAILABLE - The directory service is unavailable.
+.
+Language=Russian
 DNS_ERROR_DS_UNAVAILABLE - The directory service is unavailable.
 .
 
@@ -15603,12 +19828,18 @@ SymbolicName=DNS_ERROR_DS_ZONE_ALREADY_EXISTS
 Language=English
 DNS_ERROR_DS_ZONE_ALREADY_EXISTS - DNS zone already exists in the directory service.
 .
+Language=Russian
+DNS_ERROR_DS_ZONE_ALREADY_EXISTS - DNS zone already exists in the directory service.
+.
 
 MessageId=9719
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NO_BOOTFILE_IF_DS_ZONE
 Language=English
+DNS_ERROR_NO_BOOTFILE_IF_DS_ZONE - DNS server not creating or reading the boot file for the directory service integrated DNS zone.
+.
+Language=Russian
 DNS_ERROR_NO_BOOTFILE_IF_DS_ZONE - DNS server not creating or reading the boot file for the directory service integrated DNS zone.
 .
 
@@ -15619,12 +19850,18 @@ SymbolicName=DNS_INFO_AXFR_COMPLETE
 Language=English
 DNS_INFO_AXFR_COMPLETE - DNS AXFR (zone transfer) complete.
 .
+Language=Russian
+DNS_INFO_AXFR_COMPLETE - DNS AXFR (zone transfer) complete.
+.
 
 MessageId=9752
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_AXFR
 Language=English
+DNS_ERROR_AXFR - DNS zone transfer failed.
+.
+Language=Russian
 DNS_ERROR_AXFR - DNS zone transfer failed.
 .
 
@@ -15635,12 +19872,18 @@ SymbolicName=DNS_INFO_ADDED_LOCAL_WINS
 Language=English
 DNS_INFO_ADDED_LOCAL_WINS - Added local WINS server.
 .
+Language=Russian
+DNS_INFO_ADDED_LOCAL_WINS - Added local WINS server.
+.
 
 MessageId=9801
 Severity=Success
 Facility=System
 SymbolicName=DNS_STATUS_CONTINUE_NEEDED
 Language=English
+DNS_STATUS_CONTINUE_NEEDED - Secure update call needs to continue update request.
+.
+Language=Russian
 DNS_STATUS_CONTINUE_NEEDED - Secure update call needs to continue update request.
 .
 
@@ -15651,12 +19894,18 @@ SymbolicName=DNS_ERROR_NO_TCPIP
 Language=English
 DNS_ERROR_NO_TCPIP - TCP/IP network protocol not installed.
 .
+Language=Russian
+DNS_ERROR_NO_TCPIP - TCP/IP network protocol not installed.
+.
 
 MessageId=9852
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_NO_DNS_SERVERS
 Language=English
+DNS_ERROR_NO_DNS_SERVERS - No DNS servers configured for local system.
+.
+Language=Russian
 DNS_ERROR_NO_DNS_SERVERS - No DNS servers configured for local system.
 .
 
@@ -15667,12 +19916,18 @@ SymbolicName=DNS_ERROR_DP_DOES_NOT_EXIST
 Language=English
 DNS_ERROR_DP_DOES_NOT_EXIST - The specified directory partition does not exist.
 .
+Language=Russian
+DNS_ERROR_DP_DOES_NOT_EXIST - The specified directory partition does not exist.
+.
 
 MessageId=9902
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_DP_ALREADY_EXISTS
 Language=English
+DNS_ERROR_DP_ALREADY_EXISTS - The specified directory partition already exists.
+.
+Language=Russian
 DNS_ERROR_DP_ALREADY_EXISTS - The specified directory partition already exists.
 .
 
@@ -15683,12 +19938,18 @@ SymbolicName=DNS_ERROR_DP_NOT_ENLISTED
 Language=English
 DNS_ERROR_DP_NOT_ENLISTED - The DNS server is not enlisted in the specified directory partition.
 .
+Language=Russian
+DNS_ERROR_DP_NOT_ENLISTED - The DNS server is not enlisted in the specified directory partition.
+.
 
 MessageId=9904
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_DP_ALREADY_ENLISTED
 Language=English
+DNS_ERROR_DP_ALREADY_ENLISTED - The DNS server is already enlisted in the specified directory partition.
+.
+Language=Russian
 DNS_ERROR_DP_ALREADY_ENLISTED - The DNS server is already enlisted in the specified directory partition.
 .
 
@@ -15699,12 +19960,18 @@ SymbolicName=DNS_ERROR_DP_NOT_AVAILABLE
 Language=English
 DNS_ERROR_DP_NOT_AVAILABLE - The directory partition is not available at this time. Please wait a few minutes and try again.
 .
+Language=Russian
+DNS_ERROR_DP_NOT_AVAILABLE - The directory partition is not available at this time. Please wait a few minutes and try again.
+.
 
 MessageId=9906
 Severity=Success
 Facility=System
 SymbolicName=DNS_ERROR_DP_FSMO_ERROR
 Language=English
+DNS_ERROR_DP_FSMO_ERROR - The application directory partition operation failed. The domain controller holding the domain naming master role is down or unable to service the request or is not running Windows Server 2003.
+.
+Language=Russian
 DNS_ERROR_DP_FSMO_ERROR - The application directory partition operation failed. The domain controller holding the domain naming master role is down or unable to service the request or is not running Windows Server 2003.
 .
 
@@ -15715,12 +19982,18 @@ SymbolicName=WSAEINTR
 Language=English
 WSAEINTR - A blocking operation was interrupted by a call to WSACancelBlockingCall.
 .
+Language=Russian
+WSAEINTR - A blocking operation was interrupted by a call to WSACancelBlockingCall.
+.
 
 MessageId=10009
 Severity=Success
 Facility=System
 SymbolicName=WSAEBADF
 Language=English
+WSAEBADF - The file handle supplied is not valid.
+.
+Language=Russian
 WSAEBADF - The file handle supplied is not valid.
 .
 
@@ -15731,12 +20004,18 @@ SymbolicName=WSAEACCES
 Language=English
 WSAEACCES - An attempt was made to access a socket in a way forbidden by its access permissions.
 .
+Language=Russian
+WSAEACCES - An attempt was made to access a socket in a way forbidden by its access permissions.
+.
 
 MessageId=10014
 Severity=Success
 Facility=System
 SymbolicName=WSAEFAULT
 Language=English
+WSAEFAULT - The system detected an invalid pointer address in attempting to use a pointer argument in a call.
+.
+Language=Russian
 WSAEFAULT - The system detected an invalid pointer address in attempting to use a pointer argument in a call.
 .
 
@@ -15747,12 +20026,18 @@ SymbolicName=WSAEINVAL
 Language=English
 WSAEINVAL - An invalid argument was supplied.
 .
+Language=Russian
+WSAEINVAL - An invalid argument was supplied.
+.
 
 MessageId=10024
 Severity=Success
 Facility=System
 SymbolicName=WSAEMFILE
 Language=English
+WSAEMFILE - Too many open sockets.
+.
+Language=Russian
 WSAEMFILE - Too many open sockets.
 .
 
@@ -15763,12 +20048,18 @@ SymbolicName=WSAEWOULDBLOCK
 Language=English
 WSAEWOULDBLOCK - A non-blocking socket operation could not be completed immediately.
 .
+Language=Russian
+WSAEWOULDBLOCK - A non-blocking socket operation could not be completed immediately.
+.
 
 MessageId=10036
 Severity=Success
 Facility=System
 SymbolicName=WSAEINPROGRESS
 Language=English
+WSAEINPROGRESS - A blocking operation is currently executing.
+.
+Language=Russian
 WSAEINPROGRESS - A blocking operation is currently executing.
 .
 
@@ -15779,12 +20070,18 @@ SymbolicName=WSAEALREADY
 Language=English
 WSAEALREADY - An operation was attempted on a non-blocking socket that already had an operation in progress.
 .
+Language=Russian
+WSAEALREADY - An operation was attempted on a non-blocking socket that already had an operation in progress.
+.
 
 MessageId=10038
 Severity=Success
 Facility=System
 SymbolicName=WSAENOTSOCK
 Language=English
+WSAENOTSOCK - An operation was attempted on something that is not a socket.
+.
+Language=Russian
 WSAENOTSOCK - An operation was attempted on something that is not a socket.
 .
 
@@ -15795,12 +20092,18 @@ SymbolicName=WSAEDESTADDRREQ
 Language=English
 WSAEDESTADDRREQ - A required address was omitted from an operation on a socket.
 .
+Language=Russian
+WSAEDESTADDRREQ - A required address was omitted from an operation on a socket.
+.
 
 MessageId=10040
 Severity=Success
 Facility=System
 SymbolicName=WSAEMSGSIZE
 Language=English
+WSAEMSGSIZE - A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself.
+.
+Language=Russian
 WSAEMSGSIZE - A message sent on a datagram socket was larger than the internal message buffer or some other network limit, or the buffer used to receive a datagram into was smaller than the datagram itself.
 .
 
@@ -15811,12 +20114,18 @@ SymbolicName=WSAEPROTOTYPE
 Language=English
 WSAEPROTOTYPE - A protocol was specified in the socket function call that does not support the semantics of the socket type requested.
 .
+Language=Russian
+WSAEPROTOTYPE - A protocol was specified in the socket function call that does not support the semantics of the socket type requested.
+.
 
 MessageId=10042
 Severity=Success
 Facility=System
 SymbolicName=WSAENOPROTOOPT
 Language=English
+WSAENOPROTOOPT - An unknown, invalid, or unsupported option or level was specified in a getsockopt or setsockopt call.
+.
+Language=Russian
 WSAENOPROTOOPT - An unknown, invalid, or unsupported option or level was specified in a getsockopt or setsockopt call.
 .
 
@@ -15827,12 +20136,18 @@ SymbolicName=WSAEPROTONOSUPPORT
 Language=English
 WSAEPROTONOSUPPORT - The requested protocol has not been configured into the system, or no implementation for it exists.
 .
+Language=Russian
+WSAEPROTONOSUPPORT - The requested protocol has not been configured into the system, or no implementation for it exists.
+.
 
 MessageId=10044
 Severity=Success
 Facility=System
 SymbolicName=WSAESOCKTNOSUPPORT
 Language=English
+WSAESOCKTNOSUPPORT - The support for the specified socket type does not exist in this address family.
+.
+Language=Russian
 WSAESOCKTNOSUPPORT - The support for the specified socket type does not exist in this address family.
 .
 
@@ -15843,12 +20158,18 @@ SymbolicName=WSAEOPNOTSUPP
 Language=English
 WSAEOPNOTSUPP - The attempted operation is not supported for the type of object referenced.
 .
+Language=Russian
+WSAEOPNOTSUPP - The attempted operation is not supported for the type of object referenced.
+.
 
 MessageId=10046
 Severity=Success
 Facility=System
 SymbolicName=WSAEPFNOSUPPORT
 Language=English
+WSAEPFNOSUPPORT - The protocol family has not been configured into the system or no implementation for it exists.
+.
+Language=Russian
 WSAEPFNOSUPPORT - The protocol family has not been configured into the system or no implementation for it exists.
 .
 
@@ -15859,12 +20180,18 @@ SymbolicName=WSAEAFNOSUPPORT
 Language=English
 WSAEAFNOSUPPORT - An address incompatible with the requested protocol was used.
 .
+Language=Russian
+WSAEAFNOSUPPORT - An address incompatible with the requested protocol was used.
+.
 
 MessageId=10048
 Severity=Success
 Facility=System
 SymbolicName=WSAEADDRINUSE
 Language=English
+WSAEADDRINUSE - Only one usage of each socket address (protocol/network address/port) is normally permitted.
+.
+Language=Russian
 WSAEADDRINUSE - Only one usage of each socket address (protocol/network address/port) is normally permitted.
 .
 
@@ -15875,12 +20202,18 @@ SymbolicName=WSAEADDRNOTAVAIL
 Language=English
 WSAEADDRNOTAVAIL - The requested address is not valid in its context.
 .
+Language=Russian
+WSAEADDRNOTAVAIL - The requested address is not valid in its context.
+.
 
 MessageId=10050
 Severity=Success
 Facility=System
 SymbolicName=WSAENETDOWN
 Language=English
+WSAENETDOWN - A socket operation encountered a dead network.
+.
+Language=Russian
 WSAENETDOWN - A socket operation encountered a dead network.
 .
 
@@ -15891,12 +20224,18 @@ SymbolicName=WSAENETUNREACH
 Language=English
 WSAENETUNREACH - A socket operation was attempted to an unreachable network.
 .
+Language=Russian
+WSAENETUNREACH - A socket operation was attempted to an unreachable network.
+.
 
 MessageId=10052
 Severity=Success
 Facility=System
 SymbolicName=WSAENETRESET
 Language=English
+WSAENETRESET - The connection has been broken due to keep-alive activity detecting a failure while the operation was in progress.
+.
+Language=Russian
 WSAENETRESET - The connection has been broken due to keep-alive activity detecting a failure while the operation was in progress.
 .
 
@@ -15907,12 +20246,18 @@ SymbolicName=WSAECONNABORTED
 Language=English
 WSAECONNABORTED - An established connection was aborted by the software in your host machine.
 .
+Language=Russian
+WSAECONNABORTED - An established connection was aborted by the software in your host machine.
+.
 
 MessageId=10054
 Severity=Success
 Facility=System
 SymbolicName=WSAECONNRESET
 Language=English
+WSAECONNRESET - An existing connection was forcibly closed by the remote host.
+.
+Language=Russian
 WSAECONNRESET - An existing connection was forcibly closed by the remote host.
 .
 
@@ -15923,12 +20268,18 @@ SymbolicName=WSAENOBUFS
 Language=English
 WSAENOBUFS - An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full.
 .
+Language=Russian
+WSAENOBUFS - An operation on a socket could not be performed because the system lacked sufficient buffer space or because a queue was full.
+.
 
 MessageId=10056
 Severity=Success
 Facility=System
 SymbolicName=WSAEISCONN
 Language=English
+WSAEISCONN - A connect request was made on an already connected socket.
+.
+Language=Russian
 WSAEISCONN - A connect request was made on an already connected socket.
 .
 
@@ -15939,12 +20290,18 @@ SymbolicName=WSAENOTCONN
 Language=English
 WSAENOTCONN - A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.
 .
+Language=Russian
+WSAENOTCONN - A request to send or receive data was disallowed because the socket is not connected and (when sending on a datagram socket using a sendto call) no address was supplied.
+.
 
 MessageId=10058
 Severity=Success
 Facility=System
 SymbolicName=WSAESHUTDOWN
 Language=English
+WSAESHUTDOWN - A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call.
+.
+Language=Russian
 WSAESHUTDOWN - A request to send or receive data was disallowed because the socket had already been shut down in that direction with a previous shutdown call.
 .
 
@@ -15955,12 +20312,18 @@ SymbolicName=WSAETOOMANYREFS
 Language=English
 WSAETOOMANYREFS - Too many references to some kernel object.
 .
+Language=Russian
+WSAETOOMANYREFS - Too many references to some kernel object.
+.
 
 MessageId=10060
 Severity=Success
 Facility=System
 SymbolicName=WSAETIMEDOUT
 Language=English
+WSAETIMEDOUT - A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
+.
+Language=Russian
 WSAETIMEDOUT - A connection attempt failed because the connected party did not properly respond after a period of time, or established connection failed because connected host has failed to respond.
 .
 
@@ -15971,12 +20334,18 @@ SymbolicName=WSAECONNREFUSED
 Language=English
 WSAECONNREFUSED - No connection could be made because the target machine actively refused it.
 .
+Language=Russian
+WSAECONNREFUSED - No connection could be made because the target machine actively refused it.
+.
 
 MessageId=10062
 Severity=Success
 Facility=System
 SymbolicName=WSAELOOP
 Language=English
+WSAELOOP - Cannot translate name.
+.
+Language=Russian
 WSAELOOP - Cannot translate name.
 .
 
@@ -15987,12 +20356,18 @@ SymbolicName=WSAENAMETOOLONG
 Language=English
 WSAENAMETOOLONG - Name component or name was too long.
 .
+Language=Russian
+WSAENAMETOOLONG - Name component or name was too long.
+.
 
 MessageId=10064
 Severity=Success
 Facility=System
 SymbolicName=WSAEHOSTDOWN
 Language=English
+WSAEHOSTDOWN - A socket operation failed because the destination host was down.
+.
+Language=Russian
 WSAEHOSTDOWN - A socket operation failed because the destination host was down.
 .
 
@@ -16003,12 +20378,18 @@ SymbolicName=WSAEHOSTUNREACH
 Language=English
 WSAEHOSTUNREACH - A socket operation was attempted to an unreachable host.
 .
+Language=Russian
+WSAEHOSTUNREACH - A socket operation was attempted to an unreachable host.
+.
 
 MessageId=10066
 Severity=Success
 Facility=System
 SymbolicName=WSAENOTEMPTY
 Language=English
+WSAENOTEMPTY - Cannot remove a directory that is not empty.
+.
+Language=Russian
 WSAENOTEMPTY - Cannot remove a directory that is not empty.
 .
 
@@ -16019,12 +20400,18 @@ SymbolicName=WSAEPROCLIM
 Language=English
 WSAEPROCLIM - A Windows Sockets implementation may have a limit on the number of applications that may use it simultaneously.
 .
+Language=Russian
+WSAEPROCLIM - A Windows Sockets implementation may have a limit on the number of applications that may use it simultaneously.
+.
 
 MessageId=10068
 Severity=Success
 Facility=System
 SymbolicName=WSAEUSERS
 Language=English
+WSAEUSERS - Ran out of quota.
+.
+Language=Russian
 WSAEUSERS - Ran out of quota.
 .
 
@@ -16035,12 +20422,18 @@ SymbolicName=WSAEDQUOT
 Language=English
 WSAEDQUOT - Ran out of disk quota.
 .
+Language=Russian
+WSAEDQUOT - Ran out of disk quota.
+.
 
 MessageId=10070
 Severity=Success
 Facility=System
 SymbolicName=WSAESTALE
 Language=English
+WSAESTALE - File handle reference is no longer available.
+.
+Language=Russian
 WSAESTALE - File handle reference is no longer available.
 .
 
@@ -16051,12 +20444,18 @@ SymbolicName=WSAEREMOTE
 Language=English
 WSAEREMOTE - Item is not available locally.
 .
+Language=Russian
+WSAEREMOTE - Item is not available locally.
+.
 
 MessageId=10091
 Severity=Success
 Facility=System
 SymbolicName=WSASYSNOTREADY
 Language=English
+WSASYSNOTREADY - WSAStartup cannot function at this time because the underlying system it uses to provide network services is currently unavailable.
+.
+Language=Russian
 WSASYSNOTREADY - WSAStartup cannot function at this time because the underlying system it uses to provide network services is currently unavailable.
 .
 
@@ -16067,12 +20466,18 @@ SymbolicName=WSAVERNOTSUPPORTED
 Language=English
 WSAVERNOTSUPPORTED - The Windows Sockets version requested is not supported.
 .
+Language=Russian
+WSAVERNOTSUPPORTED - The Windows Sockets version requested is not supported.
+.
 
 MessageId=10093
 Severity=Success
 Facility=System
 SymbolicName=WSANOTINITIALISED
 Language=English
+WSANOTINITIALISED - Either the application has not called WSAStartup, or WSAStartup failed.
+.
+Language=Russian
 WSANOTINITIALISED - Either the application has not called WSAStartup, or WSAStartup failed.
 .
 
@@ -16083,12 +20488,18 @@ SymbolicName=WSAEDISCON
 Language=English
 WSAEDISCON - Returned by WSARecv or WSARecvFrom to indicate the remote party has initiated a graceful shutdown sequence.
 .
+Language=Russian
+WSAEDISCON - Returned by WSARecv or WSARecvFrom to indicate the remote party has initiated a graceful shutdown sequence.
+.
 
 MessageId=10102
 Severity=Success
 Facility=System
 SymbolicName=WSAENOMORE
 Language=English
+WSAENOMORE - No more results can be returned by WSALookupServiceNext.
+.
+Language=Russian
 WSAENOMORE - No more results can be returned by WSALookupServiceNext.
 .
 
@@ -16099,12 +20510,18 @@ SymbolicName=WSAECANCELLED
 Language=English
 WSAECANCELLED - A call to WSALookupServiceEnd was made while this call was still processing. The call has been canceled.
 .
+Language=Russian
+WSAECANCELLED - A call to WSALookupServiceEnd was made while this call was still processing. The call has been canceled.
+.
 
 MessageId=10104
 Severity=Success
 Facility=System
 SymbolicName=WSAEINVALIDPROCTABLE
 Language=English
+WSAEINVALIDPROCTABLE - The procedure call table is invalid.
+.
+Language=Russian
 WSAEINVALIDPROCTABLE - The procedure call table is invalid.
 .
 
@@ -16115,12 +20532,18 @@ SymbolicName=WSAEINVALIDPROVIDER
 Language=English
 WSAEINVALIDPROVIDER - The requested service provider is invalid.
 .
+Language=Russian
+WSAEINVALIDPROVIDER - The requested service provider is invalid.
+.
 
 MessageId=10106
 Severity=Success
 Facility=System
 SymbolicName=WSAEPROVIDERFAILEDINIT
 Language=English
+WSAEPROVIDERFAILEDINIT - The requested service provider could not be loaded or initialized.
+.
+Language=Russian
 WSAEPROVIDERFAILEDINIT - The requested service provider could not be loaded or initialized.
 .
 
@@ -16131,12 +20554,18 @@ SymbolicName=WSASYSCALLFAILURE
 Language=English
 WSASYSCALLFAILURE - A system call that should never fail has failed.
 .
+Language=Russian
+WSASYSCALLFAILURE - A system call that should never fail has failed.
+.
 
 MessageId=10108
 Severity=Success
 Facility=System
 SymbolicName=WSASERVICE_NOT_FOUND
 Language=English
+WSASERVICE_NOT_FOUND - No such service is known. The service cannot be found in the specified name space.
+.
+Language=Russian
 WSASERVICE_NOT_FOUND - No such service is known. The service cannot be found in the specified name space.
 .
 
@@ -16147,12 +20576,18 @@ SymbolicName=WSATYPE_NOT_FOUND
 Language=English
 WSATYPE_NOT_FOUND - The specified class was not found.
 .
+Language=Russian
+WSATYPE_NOT_FOUND - The specified class was not found.
+.
 
 MessageId=10110
 Severity=Success
 Facility=System
 SymbolicName=WSA_E_NO_MORE
 Language=English
+WSA_E_NO_MORE - No more results can be returned by WSALookupServiceNext.
+.
+Language=Russian
 WSA_E_NO_MORE - No more results can be returned by WSALookupServiceNext.
 .
 
@@ -16163,12 +20598,18 @@ SymbolicName=WSA_E_CANCELLED
 Language=English
 WSA_E_CANCELLED - A call to WSALookupServiceEnd was made while this call was still processing. The call has been canceled.
 .
+Language=Russian
+WSA_E_CANCELLED - A call to WSALookupServiceEnd was made while this call was still processing. The call has been canceled.
+.
 
 MessageId=10112
 Severity=Success
 Facility=System
 SymbolicName=WSAEREFUSED
 Language=English
+WSAEREFUSED - A database query failed because it was actively refused.
+.
+Language=Russian
 WSAEREFUSED - A database query failed because it was actively refused.
 .
 
@@ -16179,12 +20620,18 @@ SymbolicName=WSAHOST_NOT_FOUND
 Language=English
 WSAHOST_NOT_FOUND - No such host is known.
 .
+Language=Russian
+WSAHOST_NOT_FOUND - No such host is known.
+.
 
 MessageId=11002
 Severity=Success
 Facility=System
 SymbolicName=WSATRY_AGAIN
 Language=English
+WSATRY_AGAIN - This is usually a temporary error during hostname resolution and means that the local server did not receive a response from an authoritative server.
+.
+Language=Russian
 WSATRY_AGAIN - This is usually a temporary error during hostname resolution and means that the local server did not receive a response from an authoritative server.
 .
 
@@ -16195,12 +20642,18 @@ SymbolicName=WSANO_RECOVERY
 Language=English
 WSANO_RECOVERY - A non-recoverable error occurred during a database lookup.
 .
+Language=Russian
+WSANO_RECOVERY - A non-recoverable error occurred during a database lookup.
+.
 
 MessageId=11004
 Severity=Success
 Facility=System
 SymbolicName=WSANO_DATA
 Language=English
+WSANO_DATA - The requested name is valid, but no data of the requested type was found.
+.
+Language=Russian
 WSANO_DATA - The requested name is valid, but no data of the requested type was found.
 .
 
@@ -16211,12 +20664,18 @@ SymbolicName=WSA_QOS_RECEIVERS
 Language=English
 WSA_QOS_RECEIVERS - At least one reserve has arrived.
 .
+Language=Russian
+WSA_QOS_RECEIVERS - At least one reserve has arrived.
+.
 
 MessageId=11006
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_SENDERS
 Language=English
+WSA_QOS_SENDERS - At least one path has arrived.
+.
+Language=Russian
 WSA_QOS_SENDERS - At least one path has arrived.
 .
 
@@ -16227,12 +20686,18 @@ SymbolicName=WSA_QOS_NO_SENDERS
 Language=English
 WSA_QOS_NO_SENDERS - There are no senders.
 .
+Language=Russian
+WSA_QOS_NO_SENDERS - There are no senders.
+.
 
 MessageId=11008
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_NO_RECEIVERS
 Language=English
+WSA_QOS_NO_RECEIVERS - There are no receivers.
+.
+Language=Russian
 WSA_QOS_NO_RECEIVERS - There are no receivers.
 .
 
@@ -16243,12 +20708,18 @@ SymbolicName=WSA_QOS_REQUEST_CONFIRMED
 Language=English
 WSA_QOS_REQUEST_CONFIRMED - Reserve has been confirmed.
 .
+Language=Russian
+WSA_QOS_REQUEST_CONFIRMED - Reserve has been confirmed.
+.
 
 MessageId=11010
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_ADMISSION_FAILURE
 Language=English
+WSA_QOS_ADMISSION_FAILURE - Error due to lack of resources.
+.
+Language=Russian
 WSA_QOS_ADMISSION_FAILURE - Error due to lack of resources.
 .
 
@@ -16259,12 +20730,18 @@ SymbolicName=WSA_QOS_POLICY_FAILURE
 Language=English
 WSA_QOS_POLICY_FAILURE - Rejected for administrative reasons - bad credentials.
 .
+Language=Russian
+WSA_QOS_POLICY_FAILURE - Rejected for administrative reasons - bad credentials.
+.
 
 MessageId=11012
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_BAD_STYLE
 Language=English
+WSA_QOS_BAD_STYLE - Unknown or conflicting style.
+.
+Language=Russian
 WSA_QOS_BAD_STYLE - Unknown or conflicting style.
 .
 
@@ -16275,12 +20752,18 @@ SymbolicName=WSA_QOS_BAD_OBJECT
 Language=English
 WSA_QOS_BAD_OBJECT - Problem with some part of the filterspec or providerspecific buffer in general.
 .
+Language=Russian
+WSA_QOS_BAD_OBJECT - Problem with some part of the filterspec or providerspecific buffer in general.
+.
 
 MessageId=11014
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_TRAFFIC_CTRL_ERROR
 Language=English
+WSA_QOS_TRAFFIC_CTRL_ERROR - Problem with some part of the flowspec.
+.
+Language=Russian
 WSA_QOS_TRAFFIC_CTRL_ERROR - Problem with some part of the flowspec.
 .
 
@@ -16291,12 +20774,18 @@ SymbolicName=WSA_QOS_GENERIC_ERROR
 Language=English
 WSA_QOS_GENERIC_ERROR - General QOS error.
 .
+Language=Russian
+WSA_QOS_GENERIC_ERROR - General QOS error.
+.
 
 MessageId=11016
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_ESERVICETYPE
 Language=English
+WSA_QOS_ESERVICETYPE - An invalid or unrecognized service type was found in the flowspec.
+.
+Language=Russian
 WSA_QOS_ESERVICETYPE - An invalid or unrecognized service type was found in the flowspec.
 .
 
@@ -16307,12 +20796,18 @@ SymbolicName=WSA_QOS_EFLOWSPEC
 Language=English
 WSA_QOS_EFLOWSPEC - An invalid or inconsistent flowspec was found in the QOS structure.
 .
+Language=Russian
+WSA_QOS_EFLOWSPEC - An invalid or inconsistent flowspec was found in the QOS structure.
+.
 
 MessageId=11018
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EPROVSPECBUF
 Language=English
+WSA_QOS_EPROVSPECBUF - Invalid QOS provider-specific buffer.
+.
+Language=Russian
 WSA_QOS_EPROVSPECBUF - Invalid QOS provider-specific buffer.
 .
 
@@ -16323,12 +20818,18 @@ SymbolicName=WSA_QOS_EFILTERSTYLE
 Language=English
 WSA_QOS_EFILTERSTYLE - An invalid QOS filter style was used.
 .
+Language=Russian
+WSA_QOS_EFILTERSTYLE - An invalid QOS filter style was used.
+.
 
 MessageId=11020
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EFILTERTYPE
 Language=English
+WSA_QOS_EFILTERTYPE - An invalid QOS filter type was used.
+.
+Language=Russian
 WSA_QOS_EFILTERTYPE - An invalid QOS filter type was used.
 .
 
@@ -16339,12 +20840,18 @@ SymbolicName=WSA_QOS_EFILTERCOUNT
 Language=English
 WSA_QOS_EFILTERCOUNT - An incorrect number of QOS FILTERSPECs were specified in the FLOWDESCRIPTOR.
 .
+Language=Russian
+WSA_QOS_EFILTERCOUNT - An incorrect number of QOS FILTERSPECs were specified in the FLOWDESCRIPTOR.
+.
 
 MessageId=11022
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EOBJLENGTH
 Language=English
+WSA_QOS_EOBJLENGTH - An object with an invalid ObjectLength field was specified in the QOS provider-specific buffer.
+.
+Language=Russian
 WSA_QOS_EOBJLENGTH - An object with an invalid ObjectLength field was specified in the QOS provider-specific buffer.
 .
 
@@ -16355,12 +20862,18 @@ SymbolicName=WSA_QOS_EFLOWCOUNT
 Language=English
 WSA_QOS_EFLOWCOUNT - An incorrect number of flow descriptors was specified in the QOS structure.
 .
+Language=Russian
+WSA_QOS_EFLOWCOUNT - An incorrect number of flow descriptors was specified in the QOS structure.
+.
 
 MessageId=11024
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EUNKNOWNPSOBJ
 Language=English
+WSA_QOS_EUNKNOWNPSOBJ - An unrecognized object was found in the QOS provider-specific buffer.
+.
+Language=Russian
 WSA_QOS_EUNKNOWNPSOBJ - An unrecognized object was found in the QOS provider-specific buffer.
 .
 
@@ -16371,12 +20884,18 @@ SymbolicName=WSA_QOS_EPOLICYOBJ
 Language=English
 WSA_QOS_EPOLICYOBJ - An invalid policy object was found in the QOS provider-specific buffer.
 .
+Language=Russian
+WSA_QOS_EPOLICYOBJ - An invalid policy object was found in the QOS provider-specific buffer.
+.
 
 MessageId=11026
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EFLOWDESC
 Language=English
+WSA_QOS_EFLOWDESC - An invalid QOS flow descriptor was found in the flow descriptor list.
+.
+Language=Russian
 WSA_QOS_EFLOWDESC - An invalid QOS flow descriptor was found in the flow descriptor list.
 .
 
@@ -16387,12 +20906,18 @@ SymbolicName=WSA_QOS_EPSFLOWSPEC
 Language=English
 WSA_QOS_EPSFLOWSPEC - An invalid or inconsistent flowspec was found in the QOS provider-specific buffer.
 .
+Language=Russian
+WSA_QOS_EPSFLOWSPEC - An invalid or inconsistent flowspec was found in the QOS provider-specific buffer.
+.
 
 MessageId=11028
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_EPSFILTERSPEC
 Language=English
+WSA_QOS_EPSFILTERSPEC - An invalid FILTERSPEC was found in the QOS provider-specific buffer.
+.
+Language=Russian
 WSA_QOS_EPSFILTERSPEC - An invalid FILTERSPEC was found in the QOS provider-specific buffer.
 .
 
@@ -16403,12 +20928,18 @@ SymbolicName=WSA_QOS_ESDMODEOBJ
 Language=English
 WSA_QOS_ESDMODEOBJ - An invalid shape discard mode object was found in the QOS provider-specific buffer.
 .
+Language=Russian
+WSA_QOS_ESDMODEOBJ - An invalid shape discard mode object was found in the QOS provider-specific buffer.
+.
 
 MessageId=11030
 Severity=Success
 Facility=System
 SymbolicName=WSA_QOS_ESHAPERATEOBJ
 Language=English
+WSA_QOS_ESHAPERATEOBJ - An invalid shaping rate object was found in the QOS provider-specific buffer.
+.
+Language=Russian
 WSA_QOS_ESHAPERATEOBJ - An invalid shaping rate object was found in the QOS provider-specific buffer.
 .
 
@@ -16419,12 +20950,18 @@ SymbolicName=WSA_QOS_RESERVED_PETYPE
 Language=English
 WSA_QOS_RESERVED_PETYPE - A reserved policy element was found in the QOS provider-specific buffer.
 .
+Language=Russian
+WSA_QOS_RESERVED_PETYPE - A reserved policy element was found in the QOS provider-specific buffer.
+.
 
 MessageId=12000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_IO_COMPLETE
 Language=English
+ERROR_FLT_IO_COMPLETE - The IO was completed by a filter.
+.
+Language=Russian
 ERROR_FLT_IO_COMPLETE - The IO was completed by a filter.
 .
 
@@ -16435,12 +20972,18 @@ SymbolicName=ERROR_FLT_BUFFER_TOO_SMALL
 Language=English
 ERROR_FLT_BUFFER_TOO_SMALL - The buffer is too small to contain the entry. No information has been written to the buffer.
 .
+Language=Russian
+ERROR_FLT_BUFFER_TOO_SMALL - The buffer is too small to contain the entry. No information has been written to the buffer.
+.
 
 MessageId=12002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_NO_HANDLER_DEFINED
 Language=English
+ERROR_FLT_NO_HANDLER_DEFINED - A handler was not defined by the filter for this operation.
+.
+Language=Russian
 ERROR_FLT_NO_HANDLER_DEFINED - A handler was not defined by the filter for this operation.
 .
 
@@ -16451,12 +20994,18 @@ SymbolicName=ERROR_FLT_CONTEXT_ALREADY_DEFINED
 Language=English
 ERROR_FLT_CONTEXT_ALREADY_DEFINED - A context is already defined for this object.
 .
+Language=Russian
+ERROR_FLT_CONTEXT_ALREADY_DEFINED - A context is already defined for this object.
+.
 
 MessageId=12004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_INVALID_ASYNCHRONOUS_REQUEST
 Language=English
+ERROR_FLT_INVALID_ASYNCHRONOUS_REQUEST - Asynchronous requests are not valid for this operation.
+.
+Language=Russian
 ERROR_FLT_INVALID_ASYNCHRONOUS_REQUEST - Asynchronous requests are not valid for this operation.
 .
 
@@ -16467,12 +21016,18 @@ SymbolicName=ERROR_FLT_DISALLOW_FAST_IO
 Language=English
 ERROR_FLT_DISALLOW_FAST_IO - Disallow the Fast IO path for this operation.
 .
+Language=Russian
+ERROR_FLT_DISALLOW_FAST_IO - Disallow the Fast IO path for this operation.
+.
 
 MessageId=12006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_INVALID_NAME_REQUEST
 Language=English
+ERROR_FLT_INVALID_NAME_REQUEST - An invalid name request was made. The name requested cannot be retrieved at this time.
+.
+Language=Russian
 ERROR_FLT_INVALID_NAME_REQUEST - An invalid name request was made. The name requested cannot be retrieved at this time.
 .
 
@@ -16483,12 +21038,18 @@ SymbolicName=ERROR_FLT_NOT_SAFE_TO_POST_OPERATION
 Language=English
 ERROR_FLT_NOT_SAFE_TO_POST_OPERATION - Posting this operation to a worker thread for further processing is not safe at this time because it could lead to a system deadlock.
 .
+Language=Russian
+ERROR_FLT_NOT_SAFE_TO_POST_OPERATION - Posting this operation to a worker thread for further processing is not safe at this time because it could lead to a system deadlock.
+.
 
 MessageId=12008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_NOT_INITIALIZED
 Language=English
+ERROR_FLT_NOT_INITIALIZED - The Filter Manager was not initialized when a filter tried to register. Make sure that the Filter Manager is getting loaded as a driver.
+.
+Language=Russian
 ERROR_FLT_NOT_INITIALIZED - The Filter Manager was not initialized when a filter tried to register. Make sure that the Filter Manager is getting loaded as a driver.
 .
 
@@ -16499,12 +21060,18 @@ SymbolicName=ERROR_FLT_FILTER_NOT_READY
 Language=English
 ERROR_FLT_FILTER_NOT_READY - The filter is not ready for attachment to volumes because it has not finished initializing (FltStartFiltering has not been called).
 .
+Language=Russian
+ERROR_FLT_FILTER_NOT_READY - The filter is not ready for attachment to volumes because it has not finished initializing (FltStartFiltering has not been called).
+.
 
 MessageId=12010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_POST_OPERATION_CLEANUP
 Language=English
+ERROR_FLT_POST_OPERATION_CLEANUP - The filter must cleanup any operation specific context at this time because it is being removed from the system before the operation is completed by the lower drivers.
+.
+Language=Russian
 ERROR_FLT_POST_OPERATION_CLEANUP - The filter must cleanup any operation specific context at this time because it is being removed from the system before the operation is completed by the lower drivers.
 .
 
@@ -16515,12 +21082,18 @@ SymbolicName=ERROR_FLT_INTERNAL_ERROR
 Language=English
 ERROR_FLT_INTERNAL_ERROR - The Filter Manager had an internal error from which it cannot recover, therefore the operation has been failed. This is usually the result of a filter returning an invalid value from a pre-operation callback.
 .
+Language=Russian
+ERROR_FLT_INTERNAL_ERROR - The Filter Manager had an internal error from which it cannot recover, therefore the operation has been failed. This is usually the result of a filter returning an invalid value from a pre-operation callback.
+.
 
 MessageId=12012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_DELETING_OBJECT
 Language=English
+ERROR_FLT_DELETING_OBJECT - The object specified for this action is in the process of being deleted, therefore the action requested cannot be completed at this time.
+.
+Language=Russian
 ERROR_FLT_DELETING_OBJECT - The object specified for this action is in the process of being deleted, therefore the action requested cannot be completed at this time.
 .
 
@@ -16531,12 +21104,18 @@ SymbolicName=ERROR_FLT_MUST_BE_NONPAGED_POOL
 Language=English
 ERROR_FLT_MUST_BE_NONPAGED_POOL - Non-paged pool must be used for this type of context.
 .
+Language=Russian
+ERROR_FLT_MUST_BE_NONPAGED_POOL - Non-paged pool must be used for this type of context.
+.
 
 MessageId=12014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_DUPLICATE_ENTRY
 Language=English
+ERROR_FLT_DUPLICATE_ENTRY - A duplicate handler definition has been provided for an operation.
+.
+Language=Russian
 ERROR_FLT_DUPLICATE_ENTRY - A duplicate handler definition has been provided for an operation.
 .
 
@@ -16547,12 +21126,18 @@ SymbolicName=ERROR_FLT_CBDQ_DISABLED
 Language=English
 ERROR_FLT_CBDQ_DISABLED - The callback data queue has been disabled.
 .
+Language=Russian
+ERROR_FLT_CBDQ_DISABLED - The callback data queue has been disabled.
+.
 
 MessageId=12016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_DO_NOT_ATTACH
 Language=English
+ERROR_FLT_DO_NOT_ATTACH - Do not attach the filter to the volume at this time.
+.
+Language=Russian
 ERROR_FLT_DO_NOT_ATTACH - Do not attach the filter to the volume at this time.
 .
 
@@ -16563,12 +21148,18 @@ SymbolicName=ERROR_FLT_DO_NOT_DETACH
 Language=English
 ERROR_FLT_DO_NOT_DETACH - Do not detach the filter from the volume at this time.
 .
+Language=Russian
+ERROR_FLT_DO_NOT_DETACH - Do not detach the filter from the volume at this time.
+.
 
 MessageId=12018
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_INSTANCE_ALTITUDE_COLLISION
 Language=English
+ERROR_FLT_INSTANCE_ALTITUDE_COLLISION - An instance already exists at this altitude on the volume specified.
+.
+Language=Russian
 ERROR_FLT_INSTANCE_ALTITUDE_COLLISION - An instance already exists at this altitude on the volume specified.
 .
 
@@ -16579,12 +21170,18 @@ SymbolicName=ERROR_FLT_INSTANCE_NAME_COLLISION
 Language=English
 ERROR_FLT_INSTANCE_NAME_COLLISION - An instance already exists with this name on the volume specified.
 .
+Language=Russian
+ERROR_FLT_INSTANCE_NAME_COLLISION - An instance already exists with this name on the volume specified.
+.
 
 MessageId=12020
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_FILTER_NOT_FOUND
 Language=English
+ERROR_FLT_FILTER_NOT_FOUND - The system could not find the filter specified.
+.
+Language=Russian
 ERROR_FLT_FILTER_NOT_FOUND - The system could not find the filter specified.
 .
 
@@ -16595,12 +21192,18 @@ SymbolicName=ERROR_FLT_VOLUME_NOT_FOUND
 Language=English
 ERROR_FLT_VOLUME_NOT_FOUND - The system could not find the volume specified.
 .
+Language=Russian
+ERROR_FLT_VOLUME_NOT_FOUND - The system could not find the volume specified.
+.
 
 MessageId=12022
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_INSTANCE_NOT_FOUND
 Language=English
+ERROR_FLT_INSTANCE_NOT_FOUND - The system could not find the instance specified.
+.
+Language=Russian
 ERROR_FLT_INSTANCE_NOT_FOUND - The system could not find the instance specified.
 .
 
@@ -16611,12 +21214,18 @@ SymbolicName=ERROR_FLT_CONTEXT_ALLOCATION_NOT_FOUND
 Language=English
 ERROR_FLT_CONTEXT_ALLOCATION_NOT_FOUND - No registered context allocation definition was found for the given request.
 .
+Language=Russian
+ERROR_FLT_CONTEXT_ALLOCATION_NOT_FOUND - No registered context allocation definition was found for the given request.
+.
 
 MessageId=12024
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_INVALID_CONTEXT_REGISTRATION
 Language=English
+ERROR_FLT_INVALID_CONTEXT_REGISTRATION - An invalid parameter was specified during context registration.
+.
+Language=Russian
 ERROR_FLT_INVALID_CONTEXT_REGISTRATION - An invalid parameter was specified during context registration.
 .
 
@@ -16627,12 +21236,18 @@ SymbolicName=ERROR_FLT_NAME_CACHE_MISS
 Language=English
 ERROR_FLT_NAME_CACHE_MISS - The name requested was not found in Filter Manager's name cache and could not be retrieved from the file system.
 .
+Language=Russian
+ERROR_FLT_NAME_CACHE_MISS - The name requested was not found in Filter Manager's name cache and could not be retrieved from the file system.
+.
 
 MessageId=12026
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_NO_DEVICE_OBJECT
 Language=English
+ERROR_FLT_NO_DEVICE_OBJECT - The requested device object does not exist for the given volume.
+.
+Language=Russian
 ERROR_FLT_NO_DEVICE_OBJECT - The requested device object does not exist for the given volume.
 .
 
@@ -16643,12 +21258,18 @@ SymbolicName=ERROR_FLT_VOLUME_ALREADY_MOUNTED
 Language=English
 ERROR_FLT_VOLUME_ALREADY_MOUNTED - The specified volume is already mounted.
 .
+Language=Russian
+ERROR_FLT_VOLUME_ALREADY_MOUNTED - The specified volume is already mounted.
+.
 
 MessageId=12028
 Severity=Success
 Facility=System
 SymbolicName=ERROR_FLT_NO_WAITER_FOR_REPLY
 Language=English
+ERROR_FLT_NO_WAITER_FOR_REPLY - No waiter is present for the filter's reply to this message.
+.
+Language=Russian
 ERROR_FLT_NO_WAITER_FOR_REPLY - No waiter is present for the filter's reply to this message.
 .
 
@@ -16659,12 +21280,18 @@ SymbolicName=ERROR_IPSEC_QM_POLICY_EXISTS
 Language=English
 ERROR_IPSEC_QM_POLICY_EXISTS - The specified quick mode policy already exists.
 .
+Language=Russian
+ERROR_IPSEC_QM_POLICY_EXISTS - The specified quick mode policy already exists.
+.
 
 MessageId=13001
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_QM_POLICY_NOT_FOUND
 Language=English
+ERROR_IPSEC_QM_POLICY_NOT_FOUND - The specified quick mode policy was not found.
+.
+Language=Russian
 ERROR_IPSEC_QM_POLICY_NOT_FOUND - The specified quick mode policy was not found.
 .
 
@@ -16675,12 +21302,18 @@ SymbolicName=ERROR_IPSEC_QM_POLICY_IN_USE
 Language=English
 ERROR_IPSEC_QM_POLICY_IN_USE - The specified quick mode policy is being used.
 .
+Language=Russian
+ERROR_IPSEC_QM_POLICY_IN_USE - The specified quick mode policy is being used.
+.
 
 MessageId=13003
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_MM_POLICY_EXISTS
 Language=English
+ERROR_IPSEC_MM_POLICY_EXISTS - The specified main mode policy already exists.
+.
+Language=Russian
 ERROR_IPSEC_MM_POLICY_EXISTS - The specified main mode policy already exists.
 .
 
@@ -16691,12 +21324,18 @@ SymbolicName=ERROR_IPSEC_MM_POLICY_NOT_FOUND
 Language=English
 ERROR_IPSEC_MM_POLICY_NOT_FOUND - The specified main mode policy was not found.
 .
+Language=Russian
+ERROR_IPSEC_MM_POLICY_NOT_FOUND - The specified main mode policy was not found.
+.
 
 MessageId=13005
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_MM_POLICY_IN_USE
 Language=English
+ERROR_IPSEC_MM_POLICY_IN_USE - The specified main mode policy is being used.
+.
+Language=Russian
 ERROR_IPSEC_MM_POLICY_IN_USE - The specified main mode policy is being used.
 .
 
@@ -16707,12 +21346,18 @@ SymbolicName=ERROR_IPSEC_MM_FILTER_EXISTS
 Language=English
 ERROR_IPSEC_MM_FILTER_EXISTS - The specified main mode filter already exists.
 .
+Language=Russian
+ERROR_IPSEC_MM_FILTER_EXISTS - The specified main mode filter already exists.
+.
 
 MessageId=13007
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_MM_FILTER_NOT_FOUND
 Language=English
+ERROR_IPSEC_MM_FILTER_NOT_FOUND - The specified main mode filter was not found.
+.
+Language=Russian
 ERROR_IPSEC_MM_FILTER_NOT_FOUND - The specified main mode filter was not found.
 .
 
@@ -16723,12 +21368,18 @@ SymbolicName=ERROR_IPSEC_TRANSPORT_FILTER_EXISTS
 Language=English
 ERROR_IPSEC_TRANSPORT_FILTER_EXISTS - The specified transport mode filter already exists.
 .
+Language=Russian
+ERROR_IPSEC_TRANSPORT_FILTER_EXISTS - The specified transport mode filter already exists.
+.
 
 MessageId=13009
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_TRANSPORT_FILTER_NOT_FOUND
 Language=English
+ERROR_IPSEC_TRANSPORT_FILTER_NOT_FOUND - The specified transport mode filter does not exist.
+.
+Language=Russian
 ERROR_IPSEC_TRANSPORT_FILTER_NOT_FOUND - The specified transport mode filter does not exist.
 .
 
@@ -16739,12 +21390,18 @@ SymbolicName=ERROR_IPSEC_MM_AUTH_EXISTS
 Language=English
 ERROR_IPSEC_MM_AUTH_EXISTS - The specified main mode authentication list exists.
 .
+Language=Russian
+ERROR_IPSEC_MM_AUTH_EXISTS - The specified main mode authentication list exists.
+.
 
 MessageId=13011
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_MM_AUTH_NOT_FOUND
 Language=English
+ERROR_IPSEC_MM_AUTH_NOT_FOUND - The specified main mode authentication list was not found.
+.
+Language=Russian
 ERROR_IPSEC_MM_AUTH_NOT_FOUND - The specified main mode authentication list was not found.
 .
 
@@ -16755,12 +21412,18 @@ SymbolicName=ERROR_IPSEC_MM_AUTH_IN_USE
 Language=English
 ERROR_IPSEC_MM_AUTH_IN_USE - The specified quick mode policy is being used.
 .
+Language=Russian
+ERROR_IPSEC_MM_AUTH_IN_USE - The specified quick mode policy is being used.
+.
 
 MessageId=13013
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_DEFAULT_MM_POLICY_NOT_FOUND
 Language=English
+ERROR_IPSEC_DEFAULT_MM_POLICY_NOT_FOUND - The specified main mode policy was not found.
+.
+Language=Russian
 ERROR_IPSEC_DEFAULT_MM_POLICY_NOT_FOUND - The specified main mode policy was not found.
 .
 
@@ -16771,12 +21434,18 @@ SymbolicName=ERROR_IPSEC_DEFAULT_MM_AUTH_NOT_FOUND
 Language=English
 ERROR_IPSEC_DEFAULT_MM_AUTH_NOT_FOUND - The specified quick mode policy was not found.
 .
+Language=Russian
+ERROR_IPSEC_DEFAULT_MM_AUTH_NOT_FOUND - The specified quick mode policy was not found.
+.
 
 MessageId=13015
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_DEFAULT_QM_POLICY_NOT_FOUND
 Language=English
+ERROR_IPSEC_DEFAULT_QM_POLICY_NOT_FOUND - The manifest file contains one or more syntax errors.
+.
+Language=Russian
 ERROR_IPSEC_DEFAULT_QM_POLICY_NOT_FOUND - The manifest file contains one or more syntax errors.
 .
 
@@ -16787,12 +21456,18 @@ SymbolicName=ERROR_IPSEC_TUNNEL_FILTER_EXISTS
 Language=English
 ERROR_IPSEC_TUNNEL_FILTER_EXISTS - The application attempted to activate a disabled activation context.
 .
+Language=Russian
+ERROR_IPSEC_TUNNEL_FILTER_EXISTS - The application attempted to activate a disabled activation context.
+.
 
 MessageId=13017
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_TUNNEL_FILTER_NOT_FOUND
 Language=English
+ERROR_IPSEC_TUNNEL_FILTER_NOT_FOUND - The requested lookup key was not found in any active activation context.
+.
+Language=Russian
 ERROR_IPSEC_TUNNEL_FILTER_NOT_FOUND - The requested lookup key was not found in any active activation context.
 .
 
@@ -16803,12 +21478,18 @@ SymbolicName=ERROR_IPSEC_MM_FILTER_PENDING_DELETION
 Language=English
 ERROR_IPSEC_MM_FILTER_PENDING_DELETION - The Main Mode filter is pending deletion.
 .
+Language=Russian
+ERROR_IPSEC_MM_FILTER_PENDING_DELETION - The Main Mode filter is pending deletion.
+.
 
 MessageId=13019
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_TRANSPORT_FILTER_PENDING_DELETION
 Language=English
+ERROR_IPSEC_TRANSPORT_FILTER_PENDING_DELETION - The transport filter is pending deletion.
+.
+Language=Russian
 ERROR_IPSEC_TRANSPORT_FILTER_PENDING_DELETION - The transport filter is pending deletion.
 .
 
@@ -16819,12 +21500,18 @@ SymbolicName=ERROR_IPSEC_TUNNEL_FILTER_PENDING_DELETION
 Language=English
 ERROR_IPSEC_TUNNEL_FILTER_PENDING_DELETION - The tunnel filter is pending deletion.
 .
+Language=Russian
+ERROR_IPSEC_TUNNEL_FILTER_PENDING_DELETION - The tunnel filter is pending deletion.
+.
 
 MessageId=13021
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_MM_POLICY_PENDING_DELETION
 Language=English
+ERROR_IPSEC_MM_POLICY_PENDING_DELETION - The Main Mode policy is pending deletion.
+.
+Language=Russian
 ERROR_IPSEC_MM_POLICY_PENDING_DELETION - The Main Mode policy is pending deletion.
 .
 
@@ -16835,12 +21522,18 @@ SymbolicName=ERROR_IPSEC_MM_AUTH_PENDING_DELETION
 Language=English
 ERROR_IPSEC_MM_AUTH_PENDING_DELETION - The Main Mode authentication bundle is pending deletion.
 .
+Language=Russian
+ERROR_IPSEC_MM_AUTH_PENDING_DELETION - The Main Mode authentication bundle is pending deletion.
+.
 
 MessageId=13023
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_QM_POLICY_PENDING_DELETION
 Language=English
+ERROR_IPSEC_QM_POLICY_PENDING_DELETION - The Quick Mode policy is pending deletion.
+.
+Language=Russian
 ERROR_IPSEC_QM_POLICY_PENDING_DELETION - The Quick Mode policy is pending deletion.
 .
 
@@ -16851,12 +21544,18 @@ SymbolicName=WARNING_IPSEC_MM_POLICY_PRUNED
 Language=English
 WARNING_IPSEC_MM_POLICY_PRUNED - The Main Mode policy was successfully added, but some of the requested offers are not supported.
 .
+Language=Russian
+WARNING_IPSEC_MM_POLICY_PRUNED - The Main Mode policy was successfully added, but some of the requested offers are not supported.
+.
 
 MessageId=13025
 Severity=Success
 Facility=System
 SymbolicName=WARNING_IPSEC_QM_POLICY_PRUNED
 Language=English
+WARNING_IPSEC_QM_POLICY_PRUNED - The Quick Mode policy was successfully added, but some of the requested offers are not supported.
+.
+Language=Russian
 WARNING_IPSEC_QM_POLICY_PRUNED - The Quick Mode policy was successfully added, but some of the requested offers are not supported.
 .
 
@@ -16867,12 +21566,18 @@ SymbolicName=ERROR_IPSEC_IKE_AUTH_FAIL
 Language=English
 ERROR_IPSEC_IKE_AUTH_FAIL - IKE authentication credentials are unacceptable.
 .
+Language=Russian
+ERROR_IPSEC_IKE_AUTH_FAIL - IKE authentication credentials are unacceptable.
+.
 
 MessageId=13802
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_ATTRIB_FAIL
 Language=English
+ERROR_IPSEC_IKE_ATTRIB_FAIL - IKE security attributes are unacceptable.
+.
+Language=Russian
 ERROR_IPSEC_IKE_ATTRIB_FAIL - IKE security attributes are unacceptable.
 .
 
@@ -16883,12 +21588,18 @@ SymbolicName=ERROR_IPSEC_IKE_NEGOTIATION_PENDING
 Language=English
 ERROR_IPSEC_IKE_NEGOTIATION_PENDING - IKE Negotiation in progress.
 .
+Language=Russian
+ERROR_IPSEC_IKE_NEGOTIATION_PENDING - IKE Negotiation in progress.
+.
 
 MessageId=13804
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_GENERAL_PROCESSING_ERROR
 Language=English
+ERROR_IPSEC_IKE_GENERAL_PROCESSING_ERROR - General processing error.
+.
+Language=Russian
 ERROR_IPSEC_IKE_GENERAL_PROCESSING_ERROR - General processing error.
 .
 
@@ -16899,12 +21610,18 @@ SymbolicName=ERROR_IPSEC_IKE_TIMED_OUT
 Language=English
 ERROR_IPSEC_IKE_TIMED_OUT - Negotiation timed out.
 .
+Language=Russian
+ERROR_IPSEC_IKE_TIMED_OUT - Negotiation timed out.
+.
 
 MessageId=13806
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_NO_CERT
 Language=English
+ERROR_IPSEC_IKE_NO_CERT - IKE failed to find valid machine certificate.
+.
+Language=Russian
 ERROR_IPSEC_IKE_NO_CERT - IKE failed to find valid machine certificate.
 .
 
@@ -16915,12 +21632,18 @@ SymbolicName=ERROR_IPSEC_IKE_SA_DELETED
 Language=English
 ERROR_IPSEC_IKE_SA_DELETED - IKE SA deleted by peer before establishment completed.
 .
+Language=Russian
+ERROR_IPSEC_IKE_SA_DELETED - IKE SA deleted by peer before establishment completed.
+.
 
 MessageId=13808
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_SA_REAPED
 Language=English
+ERROR_IPSEC_IKE_SA_REAPED - IKE SA deleted before establishment completed.
+.
+Language=Russian
 ERROR_IPSEC_IKE_SA_REAPED - IKE SA deleted before establishment completed.
 .
 
@@ -16931,12 +21654,18 @@ SymbolicName=ERROR_IPSEC_IKE_MM_ACQUIRE_DROP
 Language=English
 ERROR_IPSEC_IKE_MM_ACQUIRE_DROP - Negotiation request sat in Queue too long.
 .
+Language=Russian
+ERROR_IPSEC_IKE_MM_ACQUIRE_DROP - Negotiation request sat in Queue too long.
+.
 
 MessageId=13810
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_QM_ACQUIRE_DROP
 Language=English
+ERROR_IPSEC_IKE_QM_ACQUIRE_DROP - Negotiation request sat in Queue too long.
+.
+Language=Russian
 ERROR_IPSEC_IKE_QM_ACQUIRE_DROP - Negotiation request sat in Queue too long.
 .
 
@@ -16947,12 +21676,18 @@ SymbolicName=ERROR_IPSEC_IKE_QUEUE_DROP_MM
 Language=English
 ERROR_IPSEC_IKE_QUEUE_DROP_MM - Negotiation request sat in Queue too long.
 .
+Language=Russian
+ERROR_IPSEC_IKE_QUEUE_DROP_MM - Negotiation request sat in Queue too long.
+.
 
 MessageId=13812
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_QUEUE_DROP_NO_MM
 Language=English
+ERROR_IPSEC_IKE_QUEUE_DROP_NO_MM - Negotiation request sat in Queue too long.
+.
+Language=Russian
 ERROR_IPSEC_IKE_QUEUE_DROP_NO_MM - Negotiation request sat in Queue too long.
 .
 
@@ -16963,12 +21698,18 @@ SymbolicName=ERROR_IPSEC_IKE_DROP_NO_RESPONSE
 Language=English
 ERROR_IPSEC_IKE_DROP_NO_RESPONSE - No response from peer.
 .
+Language=Russian
+ERROR_IPSEC_IKE_DROP_NO_RESPONSE - No response from peer.
+.
 
 MessageId=13814
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_MM_DELAY_DROP
 Language=English
+ERROR_IPSEC_IKE_MM_DELAY_DROP - Negotiation took too long.
+.
+Language=Russian
 ERROR_IPSEC_IKE_MM_DELAY_DROP - Negotiation took too long.
 .
 
@@ -16979,12 +21720,18 @@ SymbolicName=ERROR_IPSEC_IKE_QM_DELAY_DROP
 Language=English
 ERROR_IPSEC_IKE_QM_DELAY_DROP - Negotiation took too long.
 .
+Language=Russian
+ERROR_IPSEC_IKE_QM_DELAY_DROP - Negotiation took too long.
+.
 
 MessageId=13816
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_ERROR
 Language=English
+ERROR_IPSEC_IKE_ERROR - Unknown error occurred.
+.
+Language=Russian
 ERROR_IPSEC_IKE_ERROR - Unknown error occurred.
 .
 
@@ -16995,12 +21742,18 @@ SymbolicName=ERROR_IPSEC_IKE_CRL_FAILED
 Language=English
 ERROR_IPSEC_IKE_CRL_FAILED - Certificate Revocation Check failed.
 .
+Language=Russian
+ERROR_IPSEC_IKE_CRL_FAILED - Certificate Revocation Check failed.
+.
 
 MessageId=13818
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_KEY_USAGE
 Language=English
+ERROR_IPSEC_IKE_INVALID_KEY_USAGE - Invalid certificate key usage.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_KEY_USAGE - Invalid certificate key usage.
 .
 
@@ -17011,12 +21764,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_CERT_TYPE
 Language=English
 ERROR_IPSEC_IKE_INVALID_CERT_TYPE - Invalid certificate type.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_CERT_TYPE - Invalid certificate type.
+.
 
 MessageId=13820
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_NO_PRIVATE_KEY
 Language=English
+ERROR_IPSEC_IKE_NO_PRIVATE_KEY - No private key associated with machine certificate.
+.
+Language=Russian
 ERROR_IPSEC_IKE_NO_PRIVATE_KEY - No private key associated with machine certificate.
 .
 
@@ -17027,12 +21786,18 @@ SymbolicName=ERROR_IPSEC_IKE_DH_FAIL
 Language=English
 ERROR_IPSEC_IKE_DH_FAIL - Failure in Diffie-Hellman computation.
 .
+Language=Russian
+ERROR_IPSEC_IKE_DH_FAIL - Failure in Diffie-Hellman computation.
+.
 
 MessageId=13824
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_HEADER
 Language=English
+ERROR_IPSEC_IKE_INVALID_HEADER - Invalid header.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_HEADER - Invalid header.
 .
 
@@ -17043,12 +21808,18 @@ SymbolicName=ERROR_IPSEC_IKE_NO_POLICY
 Language=English
 ERROR_IPSEC_IKE_NO_POLICY - No policy configured.
 .
+Language=Russian
+ERROR_IPSEC_IKE_NO_POLICY - No policy configured.
+.
 
 MessageId=13826
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_SIGNATURE
 Language=English
+ERROR_IPSEC_IKE_INVALID_SIGNATURE - Failed to verify signature.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_SIGNATURE - Failed to verify signature.
 .
 
@@ -17059,12 +21830,18 @@ SymbolicName=ERROR_IPSEC_IKE_KERBEROS_ERROR
 Language=English
 ERROR_IPSEC_IKE_KERBEROS_ERROR - Failed to authenticate using Kerberos.
 .
+Language=Russian
+ERROR_IPSEC_IKE_KERBEROS_ERROR - Failed to authenticate using Kerberos.
+.
 
 MessageId=13828
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_NO_PUBLIC_KEY
 Language=English
+ERROR_IPSEC_IKE_NO_PUBLIC_KEY - Peer's certificate did not have a public key.
+.
+Language=Russian
 ERROR_IPSEC_IKE_NO_PUBLIC_KEY - Peer's certificate did not have a public key.
 .
 
@@ -17075,12 +21852,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR - Error processing error payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR - Error processing error payload.
+.
 
 MessageId=13830
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_SA
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_SA - Error processing SA payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_SA - Error processing SA payload.
 .
 
@@ -17091,12 +21874,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_PROP
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_PROP - Error processing Proposal payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_PROP - Error processing Proposal payload.
+.
 
 MessageId=13832
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_TRANS
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_TRANS - Error processing Transform payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_TRANS - Error processing Transform payload.
 .
 
@@ -17107,12 +21896,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_KE
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_KE - Error processing KE payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_KE - Error processing KE payload.
+.
 
 MessageId=13834
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_ID
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_ID - Error processing ID payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_ID - Error processing ID payload.
 .
 
@@ -17123,12 +21918,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_CERT
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_CERT - Error processing Cert payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_CERT - Error processing Cert payload.
+.
 
 MessageId=13836
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_CERT_REQ
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_CERT_REQ - Error processing Certificate Request payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_CERT_REQ - Error processing Certificate Request payload.
 .
 
@@ -17139,12 +21940,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_HASH
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_HASH - Error processing Hash payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_HASH - Error processing Hash payload.
+.
 
 MessageId=13838
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_SIG
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_SIG - Error processing Signature payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_SIG - Error processing Signature payload.
 .
 
@@ -17155,12 +21962,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_NONCE
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_NONCE - Error processing Nonce payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_NONCE - Error processing Nonce payload.
+.
 
 MessageId=13840
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_NOTIFY
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_NOTIFY - Error processing Notify payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_NOTIFY - Error processing Notify payload.
 .
 
@@ -17171,12 +21984,18 @@ SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_DELETE
 Language=English
 ERROR_IPSEC_IKE_PROCESS_ERR_DELETE - Error processing Delete Payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_PROCESS_ERR_DELETE - Error processing Delete Payload.
+.
 
 MessageId=13842
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PROCESS_ERR_VENDOR
 Language=English
+ERROR_IPSEC_IKE_PROCESS_ERR_VENDOR - Error processing VendorId payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PROCESS_ERR_VENDOR - Error processing VendorId payload.
 .
 
@@ -17187,12 +22006,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_PAYLOAD
 Language=English
 ERROR_IPSEC_IKE_INVALID_PAYLOAD - Invalid payload received.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_PAYLOAD - Invalid payload received.
+.
 
 MessageId=13844
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_LOAD_SOFT_SA
 Language=English
+ERROR_IPSEC_IKE_LOAD_SOFT_SA - Soft SA loaded.
+.
+Language=Russian
 ERROR_IPSEC_IKE_LOAD_SOFT_SA - Soft SA loaded.
 .
 
@@ -17203,12 +22028,18 @@ SymbolicName=ERROR_IPSEC_IKE_SOFT_SA_TORN_DOWN
 Language=English
 ERROR_IPSEC_IKE_SOFT_SA_TORN_DOWN - Soft SA torn down.
 .
+Language=Russian
+ERROR_IPSEC_IKE_SOFT_SA_TORN_DOWN - Soft SA torn down.
+.
 
 MessageId=13846
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_COOKIE
 Language=English
+ERROR_IPSEC_IKE_INVALID_COOKIE - Invalid cookie received..
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_COOKIE - Invalid cookie received..
 .
 
@@ -17219,12 +22050,18 @@ SymbolicName=ERROR_IPSEC_IKE_NO_PEER_CERT
 Language=English
 ERROR_IPSEC_IKE_NO_PEER_CERT - Peer failed to send valid machine certificate.
 .
+Language=Russian
+ERROR_IPSEC_IKE_NO_PEER_CERT - Peer failed to send valid machine certificate.
+.
 
 MessageId=13848
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_PEER_CRL_FAILED
 Language=English
+ERROR_IPSEC_IKE_PEER_CRL_FAILED - Certification Revocation check of peer's certificate failed.
+.
+Language=Russian
 ERROR_IPSEC_IKE_PEER_CRL_FAILED - Certification Revocation check of peer's certificate failed.
 .
 
@@ -17235,12 +22072,18 @@ SymbolicName=ERROR_IPSEC_IKE_POLICY_CHANGE
 Language=English
 ERROR_IPSEC_IKE_POLICY_CHANGE - New policy invalidated SAs formed with old policy.
 .
+Language=Russian
+ERROR_IPSEC_IKE_POLICY_CHANGE - New policy invalidated SAs formed with old policy.
+.
 
 MessageId=13850
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_NO_MM_POLICY
 Language=English
+ERROR_IPSEC_IKE_NO_MM_POLICY - There is no available Main Mode IKE policy.
+.
+Language=Russian
 ERROR_IPSEC_IKE_NO_MM_POLICY - There is no available Main Mode IKE policy.
 .
 
@@ -17251,12 +22094,18 @@ SymbolicName=ERROR_IPSEC_IKE_NOTCBPRIV
 Language=English
 ERROR_IPSEC_IKE_NOTCBPRIV - Failed to enabled TCB privilege.
 .
+Language=Russian
+ERROR_IPSEC_IKE_NOTCBPRIV - Failed to enabled TCB privilege.
+.
 
 MessageId=13852
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_SECLOADFAIL
 Language=English
+ERROR_IPSEC_IKE_SECLOADFAIL - Failed to load SECURITY.DLL.
+.
+Language=Russian
 ERROR_IPSEC_IKE_SECLOADFAIL - Failed to load SECURITY.DLL.
 .
 
@@ -17267,12 +22116,18 @@ SymbolicName=ERROR_IPSEC_IKE_FAILSSPINIT
 Language=English
 ERROR_IPSEC_IKE_FAILSSPINIT - Failed to obtain security function table dispatch address from SSPI.
 .
+Language=Russian
+ERROR_IPSEC_IKE_FAILSSPINIT - Failed to obtain security function table dispatch address from SSPI.
+.
 
 MessageId=13854
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_FAILQUERYSSP
 Language=English
+ERROR_IPSEC_IKE_FAILQUERYSSP - Failed to query Kerberos package to obtain max token size.
+.
+Language=Russian
 ERROR_IPSEC_IKE_FAILQUERYSSP - Failed to query Kerberos package to obtain max token size.
 .
 
@@ -17283,12 +22138,18 @@ SymbolicName=ERROR_IPSEC_IKE_SRVACQFAIL
 Language=English
 ERROR_IPSEC_IKE_SRVACQFAIL - Failed to obtain Kerberos server credentials for ISAKMP/ERROR_IPSEC_IKE service. Kerberos authentication will not function. The most likely reason for this is lack of domain membership. This is normal if your computer is a member of a workgroup.
 .
+Language=Russian
+ERROR_IPSEC_IKE_SRVACQFAIL - Failed to obtain Kerberos server credentials for ISAKMP/ERROR_IPSEC_IKE service. Kerberos authentication will not function. The most likely reason for this is lack of domain membership. This is normal if your computer is a member of a workgroup.
+.
 
 MessageId=13856
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_SRVQUERYCRED
 Language=English
+ERROR_IPSEC_IKE_SRVQUERYCRED - Failed to determine SSPI principal name for ISAKMP/ERROR_IPSEC_IKE service (QueryCredentialsAttributes).
+.
+Language=Russian
 ERROR_IPSEC_IKE_SRVQUERYCRED - Failed to determine SSPI principal name for ISAKMP/ERROR_IPSEC_IKE service (QueryCredentialsAttributes).
 .
 
@@ -17299,12 +22160,18 @@ SymbolicName=ERROR_IPSEC_IKE_GETSPIFAIL
 Language=English
 ERROR_IPSEC_IKE_GETSPIFAIL - Failed to obtain new SPI for the inbound SA from IPSec driver. The most common cause for this is that the driver does not have the correct filter. Check your policy to verify the filters.
 .
+Language=Russian
+ERROR_IPSEC_IKE_GETSPIFAIL - Failed to obtain new SPI for the inbound SA from IPSec driver. The most common cause for this is that the driver does not have the correct filter. Check your policy to verify the filters.
+.
 
 MessageId=13858
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_FILTER
 Language=English
+ERROR_IPSEC_IKE_INVALID_FILTER - Given filter is invalid.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_FILTER - Given filter is invalid.
 .
 
@@ -17315,12 +22182,18 @@ SymbolicName=ERROR_IPSEC_IKE_OUT_OF_MEMORY
 Language=English
 ERROR_IPSEC_IKE_OUT_OF_MEMORY - Memory allocation failed.
 .
+Language=Russian
+ERROR_IPSEC_IKE_OUT_OF_MEMORY - Memory allocation failed.
+.
 
 MessageId=13860
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_ADD_UPDATE_KEY_FAILED
 Language=English
+ERROR_IPSEC_IKE_ADD_UPDATE_KEY_FAILED - Failed to add Security Association to IPSec Driver. The most common cause for this is if the IKE negotiation took too long to complete. If the problem persists, reduce the load on the faulting machine.
+.
+Language=Russian
 ERROR_IPSEC_IKE_ADD_UPDATE_KEY_FAILED - Failed to add Security Association to IPSec Driver. The most common cause for this is if the IKE negotiation took too long to complete. If the problem persists, reduce the load on the faulting machine.
 .
 
@@ -17331,12 +22204,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_POLICY
 Language=English
 ERROR_IPSEC_IKE_INVALID_POLICY - Invalid policy.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_POLICY - Invalid policy.
+.
 
 MessageId=13862
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_UNKNOWN_DOI
 Language=English
+ERROR_IPSEC_IKE_UNKNOWN_DOI - Invalid DOI.
+.
+Language=Russian
 ERROR_IPSEC_IKE_UNKNOWN_DOI - Invalid DOI.
 .
 
@@ -17347,12 +22226,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_SITUATION
 Language=English
 ERROR_IPSEC_IKE_INVALID_SITUATION - Invalid situation.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_SITUATION - Invalid situation.
+.
 
 MessageId=13864
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_DH_FAILURE
 Language=English
+ERROR_IPSEC_IKE_DH_FAILURE - Diffie-Hellman failure.
+.
+Language=Russian
 ERROR_IPSEC_IKE_DH_FAILURE - Diffie-Hellman failure.
 .
 
@@ -17363,12 +22248,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_GROUP
 Language=English
 ERROR_IPSEC_IKE_INVALID_GROUP - Invalid Diffie-Hellman group.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_GROUP - Invalid Diffie-Hellman group.
+.
 
 MessageId=13866
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_ENCRYPT
 Language=English
+ERROR_IPSEC_IKE_ENCRYPT - Error encrypting payload.
+.
+Language=Russian
 ERROR_IPSEC_IKE_ENCRYPT - Error encrypting payload.
 .
 
@@ -17379,12 +22270,18 @@ SymbolicName=ERROR_IPSEC_IKE_DECRYPT
 Language=English
 ERROR_IPSEC_IKE_DECRYPT - Error decrypting payload.
 .
+Language=Russian
+ERROR_IPSEC_IKE_DECRYPT - Error decrypting payload.
+.
 
 MessageId=13868
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_POLICY_MATCH
 Language=English
+ERROR_IPSEC_IKE_POLICY_MATCH - Policy match error.
+.
+Language=Russian
 ERROR_IPSEC_IKE_POLICY_MATCH - Policy match error.
 .
 
@@ -17395,12 +22292,18 @@ SymbolicName=ERROR_IPSEC_IKE_UNSUPPORTED_ID
 Language=English
 ERROR_IPSEC_IKE_UNSUPPORTED_ID - Unsupported ID.
 .
+Language=Russian
+ERROR_IPSEC_IKE_UNSUPPORTED_ID - Unsupported ID.
+.
 
 MessageId=13870
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_HASH
 Language=English
+ERROR_IPSEC_IKE_INVALID_HASH - Hash verification failed.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_HASH - Hash verification failed.
 .
 
@@ -17411,12 +22314,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_HASH_ALG
 Language=English
 ERROR_IPSEC_IKE_INVALID_HASH_ALG - Invalid hash algorithm.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_HASH_ALG - Invalid hash algorithm.
+.
 
 MessageId=13872
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_HASH_SIZE
 Language=English
+ERROR_IPSEC_IKE_INVALID_HASH_SIZE - Invalid hash size.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_HASH_SIZE - Invalid hash size.
 .
 
@@ -17427,12 +22336,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_ENCRYPT_ALG
 Language=English
 ERROR_IPSEC_IKE_INVALID_ENCRYPT_ALG - Invalid encryption algorithm.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_ENCRYPT_ALG - Invalid encryption algorithm.
+.
 
 MessageId=13874
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_AUTH_ALG
 Language=English
+ERROR_IPSEC_IKE_INVALID_AUTH_ALG - Invalid authentication algorithm.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_AUTH_ALG - Invalid authentication algorithm.
 .
 
@@ -17443,12 +22358,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_SIG
 Language=English
 ERROR_IPSEC_IKE_INVALID_SIG - Invalid certificate signature.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_SIG - Invalid certificate signature.
+.
 
 MessageId=13876
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_LOAD_FAILED
 Language=English
+ERROR_IPSEC_IKE_LOAD_FAILED - Load failed.
+.
+Language=Russian
 ERROR_IPSEC_IKE_LOAD_FAILED - Load failed.
 .
 
@@ -17459,12 +22380,18 @@ SymbolicName=ERROR_IPSEC_IKE_RPC_DELETE
 Language=English
 ERROR_IPSEC_IKE_RPC_DELETE - Deleted via RPC call.
 .
+Language=Russian
+ERROR_IPSEC_IKE_RPC_DELETE - Deleted via RPC call.
+.
 
 MessageId=13878
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_BENIGN_REINIT
 Language=English
+ERROR_IPSEC_IKE_BENIGN_REINIT - Temporary state created to perform reinit. This is not a real failure.
+.
+Language=Russian
 ERROR_IPSEC_IKE_BENIGN_REINIT - Temporary state created to perform reinit. This is not a real failure.
 .
 
@@ -17475,12 +22402,18 @@ SymbolicName=ERROR_IPSEC_IKE_INVALID_RESPONDER_LIFETIME_NOTIFY
 Language=English
 ERROR_IPSEC_IKE_INVALID_RESPONDER_LIFETIME_NOTIFY - The lifetime value received in the Responder Lifetime Notify is below the Windows 2000 configured minimum value. Please fix the policy on the peer machine.
 .
+Language=Russian
+ERROR_IPSEC_IKE_INVALID_RESPONDER_LIFETIME_NOTIFY - The lifetime value received in the Responder Lifetime Notify is below the Windows 2000 configured minimum value. Please fix the policy on the peer machine.
+.
 
 MessageId=13881
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_INVALID_CERT_KEYLEN
 Language=English
+ERROR_IPSEC_IKE_INVALID_CERT_KEYLEN - Key length in certificate is too small for configured security requirements.
+.
+Language=Russian
 ERROR_IPSEC_IKE_INVALID_CERT_KEYLEN - Key length in certificate is too small for configured security requirements.
 .
 
@@ -17491,12 +22424,18 @@ SymbolicName=ERROR_IPSEC_IKE_MM_LIMIT
 Language=English
 ERROR_IPSEC_IKE_MM_LIMIT - Max number of established MM SAs to peer exceeded.
 .
+Language=Russian
+ERROR_IPSEC_IKE_MM_LIMIT - Max number of established MM SAs to peer exceeded.
+.
 
 MessageId=13883
 Severity=Success
 Facility=System
 SymbolicName=ERROR_IPSEC_IKE_NEGOTIATION_DISABLED
 Language=English
+ERROR_IPSEC_IKE_NEGOTIATION_DISABLED - IKE received a policy that disables negotiation.
+.
+Language=Russian
 ERROR_IPSEC_IKE_NEGOTIATION_DISABLED - IKE received a policy that disables negotiation.
 .
 
@@ -17507,12 +22446,18 @@ SymbolicName=ERROR_IPSEC_IKE_NEG_STATUS_END
 Language=English
 ERROR_IPSEC_IKE_NEG_STATUS_END - ERROR_IPSEC_IKE_NEG_STATUS_END
 .
+Language=Russian
+ERROR_IPSEC_IKE_NEG_STATUS_END - ERROR_IPSEC_IKE_NEG_STATUS_END
+.
 
 MessageId=14000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_SECTION_NOT_FOUND
 Language=English
+ERROR_SXS_SECTION_NOT_FOUND - The requested section was not present in the activation context.
+.
+Language=Russian
 ERROR_SXS_SECTION_NOT_FOUND - The requested section was not present in the activation context.
 .
 
@@ -17523,12 +22468,18 @@ SymbolicName=ERROR_SXS_CANT_GEN_ACTCTX
 Language=English
 ERROR_SXS_CANT_GEN_ACTCTX - This application has failed to start because the application configuration is incorrect. Reinstalling the application may fix this problem.
 .
+Language=Russian
+ERROR_SXS_CANT_GEN_ACTCTX - This application has failed to start because the application configuration is incorrect. Reinstalling the application may fix this problem.
+.
 
 MessageId=14002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_INVALID_ACTCTXDATA_FORMAT
 Language=English
+ERROR_SXS_INVALID_ACTCTXDATA_FORMAT - The application binding data format is invalid.
+.
+Language=Russian
 ERROR_SXS_INVALID_ACTCTXDATA_FORMAT - The application binding data format is invalid.
 .
 
@@ -17539,12 +22490,18 @@ SymbolicName=ERROR_SXS_ASSEMBLY_NOT_FOUND
 Language=English
 ERROR_SXS_ASSEMBLY_NOT_FOUND - The referenced assembly is not installed on your system.
 .
+Language=Russian
+ERROR_SXS_ASSEMBLY_NOT_FOUND - The referenced assembly is not installed on your system.
+.
 
 MessageId=14004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_MANIFEST_FORMAT_ERROR
 Language=English
+ERROR_SXS_MANIFEST_FORMAT_ERROR - The manifest file does not begin with the required tag and format information.
+.
+Language=Russian
 ERROR_SXS_MANIFEST_FORMAT_ERROR - The manifest file does not begin with the required tag and format information.
 .
 
@@ -17555,12 +22512,18 @@ SymbolicName=ERROR_SXS_MANIFEST_PARSE_ERROR
 Language=English
 ERROR_SXS_MANIFEST_PARSE_ERROR - The manifest file contains one or more syntax errors.
 .
+Language=Russian
+ERROR_SXS_MANIFEST_PARSE_ERROR - The manifest file contains one or more syntax errors.
+.
 
 MessageId=14006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_ACTIVATION_CONTEXT_DISABLED
 Language=English
+ERROR_SXS_ACTIVATION_CONTEXT_DISABLED - The application attempted to activate a disabled activation context.
+.
+Language=Russian
 ERROR_SXS_ACTIVATION_CONTEXT_DISABLED - The application attempted to activate a disabled activation context.
 .
 
@@ -17571,12 +22534,18 @@ SymbolicName=ERROR_SXS_KEY_NOT_FOUND
 Language=English
 ERROR_SXS_KEY_NOT_FOUND - The requested lookup key was not found in any active activation context.
 .
+Language=Russian
+ERROR_SXS_KEY_NOT_FOUND - The requested lookup key was not found in any active activation context.
+.
 
 MessageId=14008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_VERSION_CONFLICT
 Language=English
+ERROR_SXS_VERSION_CONFLICT - A component version required by the application conflicts with another component version already active.
+.
+Language=Russian
 ERROR_SXS_VERSION_CONFLICT - A component version required by the application conflicts with another component version already active.
 .
 
@@ -17587,12 +22556,18 @@ SymbolicName=ERROR_SXS_WRONG_SECTION_TYPE
 Language=English
 ERROR_SXS_WRONG_SECTION_TYPE - The type requested activation context section does not match the query API used.
 .
+Language=Russian
+ERROR_SXS_WRONG_SECTION_TYPE - The type requested activation context section does not match the query API used.
+.
 
 MessageId=14010
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_THREAD_QUERIES_DISABLED
 Language=English
+ERROR_SXS_THREAD_QUERIES_DISABLED - Lack of system resources has required isolated activation to be disabled for the current thread of execution.
+.
+Language=Russian
 ERROR_SXS_THREAD_QUERIES_DISABLED - Lack of system resources has required isolated activation to be disabled for the current thread of execution.
 .
 
@@ -17603,12 +22578,18 @@ SymbolicName=ERROR_SXS_PROCESS_DEFAULT_ALREADY_SET
 Language=English
 ERROR_SXS_PROCESS_DEFAULT_ALREADY_SET - An attempt to set the process default activation context failed because the process default activation context was already set.
 .
+Language=Russian
+ERROR_SXS_PROCESS_DEFAULT_ALREADY_SET - An attempt to set the process default activation context failed because the process default activation context was already set.
+.
 
 MessageId=14012
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_UNKNOWN_ENCODING_GROUP
 Language=English
+ERROR_SXS_UNKNOWN_ENCODING_GROUP - The encoding group identifier specified is not recognized.
+.
+Language=Russian
 ERROR_SXS_UNKNOWN_ENCODING_GROUP - The encoding group identifier specified is not recognized.
 .
 
@@ -17619,12 +22600,18 @@ SymbolicName=ERROR_SXS_UNKNOWN_ENCODING
 Language=English
 ERROR_SXS_UNKNOWN_ENCODING - The encoding requested is not recognized.
 .
+Language=Russian
+ERROR_SXS_UNKNOWN_ENCODING - The encoding requested is not recognized.
+.
 
 MessageId=14014
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_INVALID_XML_NAMESPACE_URI
 Language=English
+ERROR_SXS_INVALID_XML_NAMESPACE_URI - The manifest contains a reference to an invalid URI.
+.
+Language=Russian
 ERROR_SXS_INVALID_XML_NAMESPACE_URI - The manifest contains a reference to an invalid URI.
 .
 
@@ -17635,12 +22622,18 @@ SymbolicName=ERROR_SXS_ROOT_MANIFEST_DEPENDENCY_NOT_INSTALLED
 Language=English
 ERROR_SXS_ROOT_MANIFEST_DEPENDENCY_NOT_INSTALLED - The application manifest contains a reference to a dependent assembly which is not installed.
 .
+Language=Russian
+ERROR_SXS_ROOT_MANIFEST_DEPENDENCY_NOT_INSTALLED - The application manifest contains a reference to a dependent assembly which is not installed.
+.
 
 MessageId=14016
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_LEAF_MANIFEST_DEPENDENCY_NOT_INSTALLED
 Language=English
+ERROR_SXS_LEAF_MANIFEST_DEPENDENCY_NOT_INSTALLED - The manifest for an assembly used by the application has a reference to a dependent assembly which is not installed.
+.
+Language=Russian
 ERROR_SXS_LEAF_MANIFEST_DEPENDENCY_NOT_INSTALLED - The manifest for an assembly used by the application has a reference to a dependent assembly which is not installed.
 .
 
@@ -17651,12 +22644,18 @@ SymbolicName=ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE
 Language=English
 ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE - The manifest contains an attribute for the assembly identity which is not valid.
 .
+Language=Russian
+ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE - The manifest contains an attribute for the assembly identity which is not valid.
+.
 
 MessageId=14018
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_MANIFEST_MISSING_REQUIRED_DEFAULT_NAMESPACE
 Language=English
+ERROR_SXS_MANIFEST_MISSING_REQUIRED_DEFAULT_NAMESPACE - The manifest is missing the required default namespace specification on the assembly element.
+.
+Language=Russian
 ERROR_SXS_MANIFEST_MISSING_REQUIRED_DEFAULT_NAMESPACE - The manifest is missing the required default namespace specification on the assembly element.
 .
 
@@ -17667,12 +22666,18 @@ SymbolicName=ERROR_SXS_MANIFEST_INVALID_REQUIRED_DEFAULT_NAMESPACE
 Language=English
 ERROR_SXS_MANIFEST_INVALID_REQUIRED_DEFAULT_NAMESPACE - The manifest has a default namespace specified on the assembly element but its value is not \"urn:schemas-microsoft-com:asm.v1\".
 .
+Language=Russian
+ERROR_SXS_MANIFEST_INVALID_REQUIRED_DEFAULT_NAMESPACE - The manifest has a default namespace specified on the assembly element but its value is not \"urn:schemas-microsoft-com:asm.v1\".
+.
 
 MessageId=14020
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_PRIVATE_MANIFEST_CROSS_PATH_WITH_REPARSE_POINT
 Language=English
+ERROR_SXS_PRIVATE_MANIFEST_CROSS_PATH_WITH_REPARSE_POINT - The private manifest probe has crossed the reparse-point-associated path.
+.
+Language=Russian
 ERROR_SXS_PRIVATE_MANIFEST_CROSS_PATH_WITH_REPARSE_POINT - The private manifest probe has crossed the reparse-point-associated path.
 .
 
@@ -17683,12 +22688,18 @@ SymbolicName=ERROR_SXS_DUPLICATE_DLL_NAME
 Language=English
 ERROR_SXS_DUPLICATE_DLL_NAME - Two or more components referenced directly or indirectly by the application manifest have files by the same name.
 .
+Language=Russian
+ERROR_SXS_DUPLICATE_DLL_NAME - Two or more components referenced directly or indirectly by the application manifest have files by the same name.
+.
 
 MessageId=14022
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_DUPLICATE_WINDOWCLASS_NAME
 Language=English
+ERROR_SXS_DUPLICATE_WINDOWCLASS_NAME - Two or more components referenced directly or indirectly by the application manifest have window classes with the same name.
+.
+Language=Russian
 ERROR_SXS_DUPLICATE_WINDOWCLASS_NAME - Two or more components referenced directly or indirectly by the application manifest have window classes with the same name.
 .
 
@@ -17699,12 +22710,18 @@ SymbolicName=ERROR_SXS_DUPLICATE_CLSID
 Language=English
 ERROR_SXS_DUPLICATE_CLSID - Two or more components referenced directly or indirectly by the application manifest have the same COM server CLSIDs.
 .
+Language=Russian
+ERROR_SXS_DUPLICATE_CLSID - Two or more components referenced directly or indirectly by the application manifest have the same COM server CLSIDs.
+.
 
 MessageId=14024
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_DUPLICATE_IID
 Language=English
+ERROR_SXS_DUPLICATE_IID - Two or more components referenced directly or indirectly by the application manifest have proxies for the same COM interface IIDs.
+.
+Language=Russian
 ERROR_SXS_DUPLICATE_IID - Two or more components referenced directly or indirectly by the application manifest have proxies for the same COM interface IIDs.
 .
 
@@ -17715,12 +22732,18 @@ SymbolicName=ERROR_SXS_DUPLICATE_TLBID
 Language=English
 ERROR_SXS_DUPLICATE_TLBID - Two or more components referenced directly or indirectly by the application manifest have the same COM type library TLBIDs.
 .
+Language=Russian
+ERROR_SXS_DUPLICATE_TLBID - Two or more components referenced directly or indirectly by the application manifest have the same COM type library TLBIDs.
+.
 
 MessageId=14026
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_DUPLICATE_PROGID
 Language=English
+ERROR_SXS_DUPLICATE_PROGID - Two or more components referenced directly or indirectly by the application manifest have the same COM ProgIDs.
+.
+Language=Russian
 ERROR_SXS_DUPLICATE_PROGID - Two or more components referenced directly or indirectly by the application manifest have the same COM ProgIDs.
 .
 
@@ -17731,12 +22754,18 @@ SymbolicName=ERROR_SXS_DUPLICATE_ASSEMBLY_NAME
 Language=English
 ERROR_SXS_DUPLICATE_ASSEMBLY_NAME - Two or more components referenced directly or indirectly by the application manifest are different versions of the same component which is not permitted.
 .
+Language=Russian
+ERROR_SXS_DUPLICATE_ASSEMBLY_NAME - Two or more components referenced directly or indirectly by the application manifest are different versions of the same component which is not permitted.
+.
 
 MessageId=14028
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_FILE_HASH_MISMATCH
 Language=English
+ERROR_SXS_FILE_HASH_MISMATCH - A component's file does not match the verification information present in the component manifest.
+.
+Language=Russian
 ERROR_SXS_FILE_HASH_MISMATCH - A component's file does not match the verification information present in the component manifest.
 .
 
@@ -17747,12 +22776,18 @@ SymbolicName=ERROR_SXS_POLICY_PARSE_ERROR
 Language=English
 ERROR_SXS_POLICY_PARSE_ERROR - The policy manifest contains one or more syntax errors.
 .
+Language=Russian
+ERROR_SXS_POLICY_PARSE_ERROR - The policy manifest contains one or more syntax errors.
+.
 
 MessageId=14030
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_MISSINGQUOTE
 Language=English
+ERROR_SXS_XML_E_MISSINGQUOTE - Manifest Parse Error : A string literal was expected, but no opening quote character was found.
+.
+Language=Russian
 ERROR_SXS_XML_E_MISSINGQUOTE - Manifest Parse Error : A string literal was expected, but no opening quote character was found.
 .
 
@@ -17763,12 +22798,18 @@ SymbolicName=ERROR_SXS_XML_E_COMMENTSYNTAX
 Language=English
 ERROR_SXS_XML_E_COMMENTSYNTAX - Manifest Parse Error : Incorrect syntax was used in a comment.
 .
+Language=Russian
+ERROR_SXS_XML_E_COMMENTSYNTAX - Manifest Parse Error : Incorrect syntax was used in a comment.
+.
 
 MessageId=14032
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_BADSTARTNAMECHAR
 Language=English
+ERROR_SXS_XML_E_BADSTARTNAMECHAR - Manifest Parse Error : A name was started with an invalid character.
+.
+Language=Russian
 ERROR_SXS_XML_E_BADSTARTNAMECHAR - Manifest Parse Error : A name was started with an invalid character.
 .
 
@@ -17779,12 +22820,18 @@ SymbolicName=ERROR_SXS_XML_E_BADNAMECHAR
 Language=English
 ERROR_SXS_XML_E_BADNAMECHAR - Manifest Parse Error : A name contained an invalid character.
 .
+Language=Russian
+ERROR_SXS_XML_E_BADNAMECHAR - Manifest Parse Error : A name contained an invalid character.
+.
 
 MessageId=14034
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_BADCHARINSTRING
 Language=English
+ERROR_SXS_XML_E_BADCHARINSTRING - Manifest Parse Error : A string literal contained an invalid character.
+.
+Language=Russian
 ERROR_SXS_XML_E_BADCHARINSTRING - Manifest Parse Error : A string literal contained an invalid character.
 .
 
@@ -17795,12 +22842,18 @@ SymbolicName=ERROR_SXS_XML_E_XMLDECLSYNTAX
 Language=English
 ERROR_SXS_XML_E_XMLDECLSYNTAX - Manifest Parse Error : Invalid syntax for an XML declaration.
 .
+Language=Russian
+ERROR_SXS_XML_E_XMLDECLSYNTAX - Manifest Parse Error : Invalid syntax for an XML declaration.
+.
 
 MessageId=14036
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_BADCHARDATA
 Language=English
+ERROR_SXS_XML_E_BADCHARDATA - Manifest Parse Error : An invalid character was found in text content.
+.
+Language=Russian
 ERROR_SXS_XML_E_BADCHARDATA - Manifest Parse Error : An invalid character was found in text content.
 .
 
@@ -17811,12 +22864,18 @@ SymbolicName=ERROR_SXS_XML_E_MISSINGWHITESPACE
 Language=English
 ERROR_SXS_XML_E_MISSINGWHITESPACE - Manifest Parse Error : Required white space was missing.
 .
+Language=Russian
+ERROR_SXS_XML_E_MISSINGWHITESPACE - Manifest Parse Error : Required white space was missing.
+.
 
 MessageId=14038
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_EXPECTINGTAGEND
 Language=English
+ERROR_SXS_XML_E_EXPECTINGTAGEND - Manifest Parse Error : The character '>' was expected.
+.
+Language=Russian
 ERROR_SXS_XML_E_EXPECTINGTAGEND - Manifest Parse Error : The character '>' was expected.
 .
 
@@ -17827,12 +22886,18 @@ SymbolicName=ERROR_SXS_XML_E_MISSINGSEMICOLON
 Language=English
 ERROR_SXS_XML_E_MISSINGSEMICOLON - Manifest Parse Error : A semi colon character was expected.
 .
+Language=Russian
+ERROR_SXS_XML_E_MISSINGSEMICOLON - Manifest Parse Error : A semi colon character was expected.
+.
 
 MessageId=14040
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNBALANCEDPAREN
 Language=English
+ERROR_SXS_XML_E_UNBALANCEDPAREN - Manifest Parse Error : Unbalanced parentheses.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNBALANCEDPAREN - Manifest Parse Error : Unbalanced parentheses.
 .
 
@@ -17843,12 +22908,18 @@ SymbolicName=ERROR_SXS_XML_E_INTERNALERROR
 Language=English
 ERROR_SXS_XML_E_INTERNALERROR - Manifest Parse Error : Internal error.
 .
+Language=Russian
+ERROR_SXS_XML_E_INTERNALERROR - Manifest Parse Error : Internal error.
+.
 
 MessageId=14042
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNEXPECTED_WHITESPACE
 Language=English
+ERROR_SXS_XML_E_UNEXPECTED_WHITESPACE - Manifest Parse Error : White space is not allowed at this location.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNEXPECTED_WHITESPACE - Manifest Parse Error : White space is not allowed at this location.
 .
 
@@ -17859,12 +22930,18 @@ SymbolicName=ERROR_SXS_XML_E_INCOMPLETE_ENCODING
 Language=English
 ERROR_SXS_XML_E_INCOMPLETE_ENCODING - Manifest Parse Error : End of file reached in invalid state for current encoding.
 .
+Language=Russian
+ERROR_SXS_XML_E_INCOMPLETE_ENCODING - Manifest Parse Error : End of file reached in invalid state for current encoding.
+.
 
 MessageId=14044
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_MISSING_PAREN
 Language=English
+ERROR_SXS_XML_E_MISSING_PAREN - Manifest Parse Error : Missing parenthesis.
+.
+Language=Russian
 ERROR_SXS_XML_E_MISSING_PAREN - Manifest Parse Error : Missing parenthesis.
 .
 
@@ -17875,12 +22952,18 @@ SymbolicName=ERROR_SXS_XML_E_EXPECTINGCLOSEQUOTE
 Language=English
 ERROR_SXS_XML_E_EXPECTINGCLOSEQUOTE - Manifest Parse Error : A single or double closing quote character (\' or \") is missing.
 .
+Language=Russian
+ERROR_SXS_XML_E_EXPECTINGCLOSEQUOTE - Manifest Parse Error : A single or double closing quote character (\' or \") is missing.
+.
 
 MessageId=14046
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_MULTIPLE_COLONS
 Language=English
+ERROR_SXS_XML_E_MULTIPLE_COLONS - Manifest Parse Error : Multiple colons are not allowed in a name.
+.
+Language=Russian
 ERROR_SXS_XML_E_MULTIPLE_COLONS - Manifest Parse Error : Multiple colons are not allowed in a name.
 .
 
@@ -17891,12 +22974,18 @@ SymbolicName=ERROR_SXS_XML_E_INVALID_DECIMAL
 Language=English
 ERROR_SXS_XML_E_INVALID_DECIMAL - Manifest Parse Error : Invalid character for decimal digit.
 .
+Language=Russian
+ERROR_SXS_XML_E_INVALID_DECIMAL - Manifest Parse Error : Invalid character for decimal digit.
+.
 
 MessageId=14048
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_INVALID_HEXIDECIMAL
 Language=English
+ERROR_SXS_XML_E_INVALID_HEXIDECIMAL - Manifest Parse Error : Invalid character for hexadecimal digit.
+.
+Language=Russian
 ERROR_SXS_XML_E_INVALID_HEXIDECIMAL - Manifest Parse Error : Invalid character for hexadecimal digit.
 .
 
@@ -17907,12 +22996,18 @@ SymbolicName=ERROR_SXS_XML_E_INVALID_UNICODE
 Language=English
 ERROR_SXS_XML_E_INVALID_UNICODE - Manifest Parse Error : Invalid Unicode character value for this platform.
 .
+Language=Russian
+ERROR_SXS_XML_E_INVALID_UNICODE - Manifest Parse Error : Invalid Unicode character value for this platform.
+.
 
 MessageId=14050
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_WHITESPACEORQUESTIONMARK
 Language=English
+ERROR_SXS_XML_E_WHITESPACEORQUESTIONMARK - Manifest Parse Error : Expecting white space or '?'.
+.
+Language=Russian
 ERROR_SXS_XML_E_WHITESPACEORQUESTIONMARK - Manifest Parse Error : Expecting white space or '?'.
 .
 
@@ -17923,12 +23018,18 @@ SymbolicName=ERROR_SXS_XML_E_UNEXPECTEDENDTAG
 Language=English
 ERROR_SXS_XML_E_UNEXPECTEDENDTAG - Manifest Parse Error : End tag was not expected at this location.
 .
+Language=Russian
+ERROR_SXS_XML_E_UNEXPECTEDENDTAG - Manifest Parse Error : End tag was not expected at this location.
+.
 
 MessageId=14052
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNCLOSEDTAG
 Language=English
+ERROR_SXS_XML_E_UNCLOSEDTAG - Manifest Parse Error : The following tags were not closed: %1.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNCLOSEDTAG - Manifest Parse Error : The following tags were not closed: %1.
 .
 
@@ -17939,12 +23040,18 @@ SymbolicName=ERROR_SXS_XML_E_DUPLICATEATTRIBUTE
 Language=English
 ERROR_SXS_XML_E_DUPLICATEATTRIBUTE - Manifest Parse Error : Duplicate attribute.
 .
+Language=Russian
+ERROR_SXS_XML_E_DUPLICATEATTRIBUTE - Manifest Parse Error : Duplicate attribute.
+.
 
 MessageId=14054
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_MULTIPLEROOTS
 Language=English
+ERROR_SXS_XML_E_MULTIPLEROOTS - Manifest Parse Error : Only one top level element is allowed in an XML document.
+.
+Language=Russian
 ERROR_SXS_XML_E_MULTIPLEROOTS - Manifest Parse Error : Only one top level element is allowed in an XML document.
 .
 
@@ -17955,12 +23062,18 @@ SymbolicName=ERROR_SXS_XML_E_INVALIDATROOTLEVEL
 Language=English
 ERROR_SXS_XML_E_INVALIDATROOTLEVEL - Manifest Parse Error : Invalid at the top level of the document.
 .
+Language=Russian
+ERROR_SXS_XML_E_INVALIDATROOTLEVEL - Manifest Parse Error : Invalid at the top level of the document.
+.
 
 MessageId=14056
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_BADXMLDECL
 Language=English
+ERROR_SXS_XML_E_BADXMLDECL - Manifest Parse Error : Invalid XML declaration.
+.
+Language=Russian
 ERROR_SXS_XML_E_BADXMLDECL - Manifest Parse Error : Invalid XML declaration.
 .
 
@@ -17971,12 +23084,18 @@ SymbolicName=ERROR_SXS_XML_E_MISSINGROOT
 Language=English
 ERROR_SXS_XML_E_MISSINGROOT - Manifest Parse Error : XML document must have a top level element.
 .
+Language=Russian
+ERROR_SXS_XML_E_MISSINGROOT - Manifest Parse Error : XML document must have a top level element.
+.
 
 MessageId=14058
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNEXPECTEDEOF
 Language=English
+ERROR_SXS_XML_E_UNEXPECTEDEOF - Manifest Parse Error : Unexpected end of file.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNEXPECTEDEOF - Manifest Parse Error : Unexpected end of file.
 .
 
@@ -17987,12 +23106,18 @@ SymbolicName=ERROR_SXS_XML_E_BADPEREFINSUBSET
 Language=English
 ERROR_SXS_XML_E_BADPEREFINSUBSET - Manifest Parse Error : Parameter entities cannot be used inside markup declarations in an internal subset.
 .
+Language=Russian
+ERROR_SXS_XML_E_BADPEREFINSUBSET - Manifest Parse Error : Parameter entities cannot be used inside markup declarations in an internal subset.
+.
 
 MessageId=14060
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNCLOSEDSTARTTAG
 Language=English
+ERROR_SXS_XML_E_UNCLOSEDSTARTTAG - Manifest Parse Error : Element was not closed.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNCLOSEDSTARTTAG - Manifest Parse Error : Element was not closed.
 .
 
@@ -18003,12 +23128,18 @@ SymbolicName=ERROR_SXS_XML_E_UNCLOSEDENDTAG
 Language=English
 ERROR_SXS_XML_E_UNCLOSEDENDTAG - Manifest Parse Error : End element was missing the character '>'.
 .
+Language=Russian
+ERROR_SXS_XML_E_UNCLOSEDENDTAG - Manifest Parse Error : End element was missing the character '>'.
+.
 
 MessageId=14062
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNCLOSEDSTRING
 Language=English
+ERROR_SXS_XML_E_UNCLOSEDSTRING - Manifest Parse Error : A string literal was not closed.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNCLOSEDSTRING - Manifest Parse Error : A string literal was not closed.
 .
 
@@ -18019,12 +23150,18 @@ SymbolicName=ERROR_SXS_XML_E_UNCLOSEDCOMMENT
 Language=English
 ERROR_SXS_XML_E_UNCLOSEDCOMMENT - Manifest Parse Error : A comment was not closed.
 .
+Language=Russian
+ERROR_SXS_XML_E_UNCLOSEDCOMMENT - Manifest Parse Error : A comment was not closed.
+.
 
 MessageId=14064
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_UNCLOSEDDECL
 Language=English
+ERROR_SXS_XML_E_UNCLOSEDDECL - Manifest Parse Error : A declaration was not closed.
+.
+Language=Russian
 ERROR_SXS_XML_E_UNCLOSEDDECL - Manifest Parse Error : A declaration was not closed.
 .
 
@@ -18035,12 +23172,18 @@ SymbolicName=ERROR_SXS_XML_E_UNCLOSEDCDATA
 Language=English
 ERROR_SXS_XML_E_UNCLOSEDCDATA - Manifest Parse Error : A CDATA section was not closed.
 .
+Language=Russian
+ERROR_SXS_XML_E_UNCLOSEDCDATA - Manifest Parse Error : A CDATA section was not closed.
+.
 
 MessageId=14066
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_RESERVEDNAMESPACE
 Language=English
+ERROR_SXS_XML_E_RESERVEDNAMESPACE - Manifest Parse Error : The namespace prefix is not allowed to start with the reserved string \"xml\".
+.
+Language=Russian
 ERROR_SXS_XML_E_RESERVEDNAMESPACE - Manifest Parse Error : The namespace prefix is not allowed to start with the reserved string \"xml\".
 .
 
@@ -18051,12 +23194,18 @@ SymbolicName=ERROR_SXS_XML_E_INVALIDENCODING
 Language=English
 ERROR_SXS_XML_E_INVALIDENCODING - Manifest Parse Error : System does not support the specified encoding.
 .
+Language=Russian
+ERROR_SXS_XML_E_INVALIDENCODING - Manifest Parse Error : System does not support the specified encoding.
+.
 
 MessageId=14068
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_INVALIDSWITCH
 Language=English
+ERROR_SXS_XML_E_INVALIDSWITCH - Manifest Parse Error : Switch from current encoding to specified encoding not supported.
+.
+Language=Russian
 ERROR_SXS_XML_E_INVALIDSWITCH - Manifest Parse Error : Switch from current encoding to specified encoding not supported.
 .
 
@@ -18067,12 +23216,18 @@ SymbolicName=ERROR_SXS_XML_E_BADXMLCASE
 Language=English
 ERROR_SXS_XML_E_BADXMLCASE - Manifest Parse Error : The name 'xml' is reserved and must be lower case.
 .
+Language=Russian
+ERROR_SXS_XML_E_BADXMLCASE - Manifest Parse Error : The name 'xml' is reserved and must be lower case.
+.
 
 MessageId=14070
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_INVALID_STANDALONE
 Language=English
+ERROR_SXS_XML_E_INVALID_STANDALONE - Manifest Parse Error : The standalone attribute must have the value 'yes' or 'no'.
+.
+Language=Russian
 ERROR_SXS_XML_E_INVALID_STANDALONE - Manifest Parse Error : The standalone attribute must have the value 'yes' or 'no'.
 .
 
@@ -18083,12 +23238,18 @@ SymbolicName=ERROR_SXS_XML_E_UNEXPECTED_STANDALONE
 Language=English
 ERROR_SXS_XML_E_UNEXPECTED_STANDALONE - Manifest Parse Error : The standalone attribute cannot be used in external entities.
 .
+Language=Russian
+ERROR_SXS_XML_E_UNEXPECTED_STANDALONE - Manifest Parse Error : The standalone attribute cannot be used in external entities.
+.
 
 MessageId=14072
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_XML_E_INVALID_VERSION
 Language=English
+ERROR_SXS_XML_E_INVALID_VERSION - Manifest Parse Error : Invalid version number.
+.
+Language=Russian
 ERROR_SXS_XML_E_INVALID_VERSION - Manifest Parse Error : Invalid version number.
 .
 
@@ -18099,12 +23260,18 @@ SymbolicName=ERROR_SXS_XML_E_MISSINGEQUALS
 Language=English
 ERROR_SXS_XML_E_MISSINGEQUALS - Manifest Parse Error : Missing equals sign between attribute and attribute value.
 .
+Language=Russian
+ERROR_SXS_XML_E_MISSINGEQUALS - Manifest Parse Error : Missing equals sign between attribute and attribute value.
+.
 
 MessageId=14074
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_PROTECTION_RECOVERY_FAILED
 Language=English
+ERROR_SXS_PROTECTION_RECOVERY_FAILED - Assembly Protection Error: Unable to recover the specified assembly.
+.
+Language=Russian
 ERROR_SXS_PROTECTION_RECOVERY_FAILED - Assembly Protection Error: Unable to recover the specified assembly.
 .
 
@@ -18115,12 +23282,18 @@ SymbolicName=ERROR_SXS_PROTECTION_PUBLIC_KEY_TOO_SHORT
 Language=English
 ERROR_SXS_PROTECTION_PUBLIC_KEY_TOO_SHORT - Assembly Protection Error: The public key for an assembly was too short to be allowed.
 .
+Language=Russian
+ERROR_SXS_PROTECTION_PUBLIC_KEY_TOO_SHORT - Assembly Protection Error: The public key for an assembly was too short to be allowed.
+.
 
 MessageId=14076
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_PROTECTION_CATALOG_NOT_VALID
 Language=English
+ERROR_SXS_PROTECTION_CATALOG_NOT_VALID - Assembly Protection Error: The catalog for an assembly is not valid, or does not match the assembly's manifest.
+.
+Language=Russian
 ERROR_SXS_PROTECTION_CATALOG_NOT_VALID - Assembly Protection Error: The catalog for an assembly is not valid, or does not match the assembly's manifest.
 .
 
@@ -18131,12 +23304,18 @@ SymbolicName=ERROR_SXS_UNTRANSLATABLE_HRESULT
 Language=English
 ERROR_SXS_UNTRANSLATABLE_HRESULT - An HRESULT could not be translated to a corresponding Win32 error code.
 .
+Language=Russian
+ERROR_SXS_UNTRANSLATABLE_HRESULT - An HRESULT could not be translated to a corresponding Win32 error code.
+.
 
 MessageId=14078
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_PROTECTION_CATALOG_FILE_MISSING
 Language=English
+ERROR_SXS_PROTECTION_CATALOG_FILE_MISSING - Assembly Protection Error: The catalog for an assembly is missing.
+.
+Language=Russian
 ERROR_SXS_PROTECTION_CATALOG_FILE_MISSING - Assembly Protection Error: The catalog for an assembly is missing.
 .
 
@@ -18147,12 +23326,18 @@ SymbolicName=ERROR_SXS_MISSING_ASSEMBLY_IDENTITY_ATTRIBUTE
 Language=English
 ERROR_SXS_MISSING_ASSEMBLY_IDENTITY_ATTRIBUTE - The supplied assembly identity is missing one or more attributes which must be present in this context.
 .
+Language=Russian
+ERROR_SXS_MISSING_ASSEMBLY_IDENTITY_ATTRIBUTE - The supplied assembly identity is missing one or more attributes which must be present in this context.
+.
 
 MessageId=14080
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE_NAME
 Language=English
+ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE_NAME - The supplied assembly identity has one or more attribute names that contain characters not permitted in XML names.
+.
+Language=Russian
 ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE_NAME - The supplied assembly identity has one or more attribute names that contain characters not permitted in XML names.
 .
 
@@ -18163,12 +23348,18 @@ SymbolicName=ERROR_SXS_ASSEMBLY_MISSING
 Language=English
 ERROR_SXS_ASSEMBLY_MISSING - The referenced assembly could not be found.
 .
+Language=Russian
+ERROR_SXS_ASSEMBLY_MISSING - The referenced assembly could not be found.
+.
 
 MessageId=14082
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_CORRUPT_ACTIVATION_STACK
 Language=English
+ERROR_SXS_CORRUPT_ACTIVATION_STACK - The activation context activation stack for the running thread of execution is corrupt.
+.
+Language=Russian
 ERROR_SXS_CORRUPT_ACTIVATION_STACK - The activation context activation stack for the running thread of execution is corrupt.
 .
 
@@ -18179,12 +23370,18 @@ SymbolicName=ERROR_SXS_CORRUPTION
 Language=English
 ERROR_SXS_CORRUPTION - The application isolation metadata for this process or thread has become corrupt.
 .
+Language=Russian
+ERROR_SXS_CORRUPTION - The application isolation metadata for this process or thread has become corrupt.
+.
 
 MessageId=14084
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_EARLY_DEACTIVATION
 Language=English
+ERROR_SXS_EARLY_DEACTIVATION - The activation context being deactivated is not the most recently activated one.
+.
+Language=Russian
 ERROR_SXS_EARLY_DEACTIVATION - The activation context being deactivated is not the most recently activated one.
 .
 
@@ -18195,12 +23392,18 @@ SymbolicName=ERROR_SXS_INVALID_DEACTIVATION
 Language=English
 ERROR_SXS_INVALID_DEACTIVATION - The activation context being deactivated is not active for the current thread of execution.
 .
+Language=Russian
+ERROR_SXS_INVALID_DEACTIVATION - The activation context being deactivated is not active for the current thread of execution.
+.
 
 MessageId=14086
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_MULTIPLE_DEACTIVATION
 Language=English
+ERROR_SXS_MULTIPLE_DEACTIVATION - The activation context being deactivated has already been deactivated.
+.
+Language=Russian
 ERROR_SXS_MULTIPLE_DEACTIVATION - The activation context being deactivated has already been deactivated.
 .
 
@@ -18211,12 +23414,18 @@ SymbolicName=ERROR_SXS_PROCESS_TERMINATION_REQUESTED
 Language=English
 ERROR_SXS_PROCESS_TERMINATION_REQUESTED - A component used by the isolation facility has requested to terminate the process.
 .
+Language=Russian
+ERROR_SXS_PROCESS_TERMINATION_REQUESTED - A component used by the isolation facility has requested to terminate the process.
+.
 
 MessageId=14088
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_RELEASE_ACTIVATION_CONTEXT
 Language=English
+ERROR_SXS_RELEASE_ACTIVATION_CONTEXT - A kernel mode component is releasing a reference on an activation context.
+.
+Language=Russian
 ERROR_SXS_RELEASE_ACTIVATION_CONTEXT - A kernel mode component is releasing a reference on an activation context.
 .
 
@@ -18227,12 +23436,18 @@ SymbolicName=ERROR_SXS_SYSTEM_DEFAULT_ACTIVATION_CONTEXT_EMPTY
 Language=English
 ERROR_SXS_SYSTEM_DEFAULT_ACTIVATION_CONTEXT_EMPTY - The activation context of system default assembly could not be generated.
 .
+Language=Russian
+ERROR_SXS_SYSTEM_DEFAULT_ACTIVATION_CONTEXT_EMPTY - The activation context of system default assembly could not be generated.
+.
 
 MessageId=14090
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_VALUE
 Language=English
+ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_VALUE - The value of an attribute in an identity is not within the legal range.
+.
+Language=Russian
 ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_VALUE - The value of an attribute in an identity is not within the legal range.
 .
 
@@ -18243,12 +23458,18 @@ SymbolicName=ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_NAME
 Language=English
 ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_NAME - The name of an attribute in an identity is not within the legal range.
 .
+Language=Russian
+ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_NAME - The name of an attribute in an identity is not within the legal range.
+.
 
 MessageId=14092
 Severity=Success
 Facility=System
 SymbolicName=ERROR_SXS_IDENTITY_DUPLICATE_ATTRIBUTE
 Language=English
+ERROR_SXS_IDENTITY_DUPLICATE_ATTRIBUTE - An identity contains two definitions for the same attribute.
+.
+Language=Russian
 ERROR_SXS_IDENTITY_DUPLICATE_ATTRIBUTE - An identity contains two definitions for the same attribute.
 .
 
@@ -18259,12 +23480,18 @@ SymbolicName=ERROR_SXS_IDENTITY_PARSE_ERROR
 Language=English
 ERROR_SXS_IDENTITY_PARSE_ERROR - The identity string is malformed. This may be due to a trailing comma, more than two unnamed attributes, missing attribute name or missing attribute value.
 .
+Language=Russian
+ERROR_SXS_IDENTITY_PARSE_ERROR - The identity string is malformed. This may be due to a trailing comma, more than two unnamed attributes, missing attribute name or missing attribute value.
+.
 
 MessageId=15000
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVT_INVALID_CHANNEL_PATH
 Language=English
+ERROR_EVT_INVALID_CHANNEL_PATH - The specified channel path is invalid. See extended error info for more details.
+.
+Language=Russian
 ERROR_EVT_INVALID_CHANNEL_PATH - The specified channel path is invalid. See extended error info for more details.
 .
 
@@ -18275,12 +23502,18 @@ SymbolicName=ERROR_EVT_INVALID_QUERY
 Language=English
 ERROR_EVT_INVALID_QUERY - The specified query is invalid. See extended error info for more details.
 .
+Language=Russian
+ERROR_EVT_INVALID_QUERY - The specified query is invalid. See extended error info for more details.
+.
 
 MessageId=15002
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVT_PUBLISHER_MANIFEST_NOT_FOUND
 Language=English
+ERROR_EVT_PUBLISHER_MANIFEST_NOT_FOUND - The publisher did indicate they have a manifest/resource but a manifest/resource could not be found.
+.
+Language=Russian
 ERROR_EVT_PUBLISHER_MANIFEST_NOT_FOUND - The publisher did indicate they have a manifest/resource but a manifest/resource could not be found.
 .
 
@@ -18291,12 +23524,18 @@ SymbolicName=ERROR_EVT_PUBLISHER_MANIFEST_NOT_SPECIFIED
 Language=English
 ERROR_EVT_PUBLISHER_MANIFEST_NOT_SPECIFIED - The publisher does not have a manifest and is performing an operation which requires they have a manifest.
 .
+Language=Russian
+ERROR_EVT_PUBLISHER_MANIFEST_NOT_SPECIFIED - The publisher does not have a manifest and is performing an operation which requires they have a manifest.
+.
 
 MessageId=15004
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVT_NO_REGISTERED_TEMPLATE
 Language=English
+ERROR_EVT_NO_REGISTERED_TEMPLATE - There is no registered template for specified event id.
+.
+Language=Russian
 ERROR_EVT_NO_REGISTERED_TEMPLATE - There is no registered template for specified event id.
 .
 
@@ -18307,12 +23546,18 @@ SymbolicName=ERROR_EVT_EVENT_CHANNEL_MISMATCH
 Language=English
 ERROR_EVT_EVENT_CHANNEL_MISMATCH - The specified event was declared in the manifest to go a different channel than the one this publisher handle is bound to.
 .
+Language=Russian
+ERROR_EVT_EVENT_CHANNEL_MISMATCH - The specified event was declared in the manifest to go a different channel than the one this publisher handle is bound to.
+.
 
 MessageId=15006
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVT_UNEXPECTED_VALUE_TYPE
 Language=English
+ERROR_EVT_UNEXPECTED_VALUE_TYPE - The type of a specified substitution value does not match the type expected from the template definition.
+.
+Language=Russian
 ERROR_EVT_UNEXPECTED_VALUE_TYPE - The type of a specified substitution value does not match the type expected from the template definition.
 .
 
@@ -18323,12 +23568,18 @@ SymbolicName=ERROR_EVT_UNEXPECTED_NUM_VALUES
 Language=English
 ERROR_EVT_UNEXPECTED_NUM_VALUES - The number of specified substitution values does not match the number expected from the template definition.
 .
+Language=Russian
+ERROR_EVT_UNEXPECTED_NUM_VALUES - The number of specified substitution values does not match the number expected from the template definition.
+.
 
 MessageId=15008
 Severity=Success
 Facility=System
 SymbolicName=ERROR_EVT_CHANNEL_NOT_FOUND
 Language=English
+ERROR_EVT_CHANNEL_NOT_FOUND - The specified channel could not be found. Check channel configuration.
+.
+Language=Russian
 ERROR_EVT_CHANNEL_NOT_FOUND - The specified channel could not be found. Check channel configuration.
 .
 
@@ -18339,6 +23590,9 @@ SymbolicName=ERROR_EVT_MALFORMED_XML_TEXT
 Language=English
 ERROR_EVT_MALFORMED_XML_TEXT - The specified xml text was not well-formed. See Extended Error for more details.
 .
+Language=Russian
+ERROR_EVT_MALFORMED_XML_TEXT - The specified xml text was not well-formed. See Extended Error for more details.
+.
 
 MessageId=15010
 Severity=Success
@@ -18347,13 +23601,18 @@ SymbolicName=ERROR_EVT_CHANNEL_PATH_TOO_GENERAL
 Language=English
 ERROR_EVT_CHANNEL_PATH_TOO_GENERAL - The specified channel path selects more than one instance of a channel. The operation requires that only one channel be selected. It may be necessary to scope channel path to version / publicKeyToken to select only one instance.
 .
-
+Language=Russian
+ERROR_EVT_CHANNEL_PATH_TOO_GENERAL - The specified channel path selects more than one instance of a channel. The operation requires that only one channel be selected. It may be necessary to scope channel path to version / publicKeyToken to select only one instance.
+.
 
 MessageId=0x000E
 Severity=Warning
 Facility=WIN32
 SymbolicName=E_OUTOFMEMORY
 Language=English
+E_OUTOFMEMORY - Out of memory
+.
+Language=Russian
 E_OUTOFMEMORY - Out of memory
 .
 
@@ -18364,6 +23623,9 @@ SymbolicName=E_INVALIDARG
 Language=English
 E_INVALIDARG - One or more arguments are invalid
 .
+Language=Russian
+E_INVALIDARG - One or more arguments are invalid
+.
 
 MessageId=0x0006
 Severity=Warning
@@ -18372,12 +23634,18 @@ SymbolicName=E_HANDLE
 Language=English
 E_POINTER - Invalid handle
 .
+Language=Russian
+E_POINTER - Invalid handle
+.
 
 MessageId=0x0005
 Severity=Warning
 Facility=WIN32
 SymbolicName=E_ACCESSDENIED
 Language=English
+E_ACCESSDENIED - WIN32 access denied error
+.
+Language=Russian
 E_ACCESSDENIED - WIN32 access denied error
 .
 
@@ -18389,12 +23657,18 @@ SymbolicName=OLE_E_OLEVERB
 Language=English
 OLE_E_OLEVERB - Invalid OLEVERB structure
 .
+Language=Russian
+OLE_E_OLEVERB - Invalid OLEVERB structure
+.
 
 MessageId=0x0001
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_ADVF
 Language=English
+OLE_E_ADVF - Invalid advise flags
+.
+Language=Russian
 OLE_E_ADVF - Invalid advise flags
 .
 
@@ -18405,12 +23679,18 @@ SymbolicName=OLE_E_ENUM_NOMORE
 Language=English
 OLE_E_ENUM_NOMORE - Can't enumerate any more, because the associated data is missing
 .
+Language=Russian
+OLE_E_ENUM_NOMORE - Can't enumerate any more, because the associated data is missing
+.
 
 MessageId=0x0003
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_ADVISENOTSUPPORTED
 Language=English
+OLE_E_ADVISENOTSUPPORTED - This implementation doesn't take advises
+.
+Language=Russian
 OLE_E_ADVISENOTSUPPORTED - This implementation doesn't take advises
 .
 
@@ -18421,12 +23701,18 @@ SymbolicName=OLE_E_NOCONNECTION
 Language=English
 OLE_E_NOCONNECTION - There is no connection for this connection ID
 .
+Language=Russian
+OLE_E_NOCONNECTION - There is no connection for this connection ID
+.
 
 MessageId=0x0005
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_NOTRUNNING
 Language=English
+OLE_E_NOTRUNNING - Need to run the object to perform this operation
+.
+Language=Russian
 OLE_E_NOTRUNNING - Need to run the object to perform this operation
 .
 
@@ -18437,12 +23723,18 @@ SymbolicName=OLE_E_NOCACHE
 Language=English
 OLE_E_NOCACHE - There is no cache to operate on
 .
+Language=Russian
+OLE_E_NOCACHE - There is no cache to operate on
+.
 
 MessageId=0x0007
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_BLANK
 Language=English
+OLE_E_BLANK - Uninitialized object
+.
+Language=Russian
 OLE_E_BLANK - Uninitialized object
 .
 
@@ -18453,12 +23745,18 @@ SymbolicName=OLE_E_CLASSDIFF
 Language=English
 OLE_E_CLASSDIFF - Linked object's source class has changed
 .
+Language=Russian
+OLE_E_CLASSDIFF - Linked object's source class has changed
+.
 
 MessageId=0x0009
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_CANT_GETMONIKER
 Language=English
+OLE_E_CANT_GETMONIKER - Not able to get the moniker of the object
+.
+Language=Russian
 OLE_E_CANT_GETMONIKER - Not able to get the moniker of the object
 .
 
@@ -18469,12 +23767,18 @@ SymbolicName=OLE_E_CANT_BINDTOSOURCE
 Language=English
 OLE_E_CANT_BINDTOSOURCE - Not able to bind to the source
 .
+Language=Russian
+OLE_E_CANT_BINDTOSOURCE - Not able to bind to the source
+.
 
 MessageId=0x000B
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_STATIC
 Language=English
+OLE_E_STATIC - Object is static; operation not allowed
+.
+Language=Russian
 OLE_E_STATIC - Object is static; operation not allowed
 .
 
@@ -18485,12 +23789,18 @@ SymbolicName=OLE_E_PROMPTSAVECANCELLED
 Language=English
 OLE_E_PROMPTSAVECANCELLED - User canceled out of save dialog
 .
+Language=Russian
+OLE_E_PROMPTSAVECANCELLED - User canceled out of save dialog
+.
 
 MessageId=0x000D
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_INVALIDRECT
 Language=English
+OLE_E_INVALIDRECT - Invalid rectangle
+.
+Language=Russian
 OLE_E_INVALIDRECT - Invalid rectangle
 .
 
@@ -18501,12 +23811,18 @@ SymbolicName=OLE_E_WRONGCOMPOBJ
 Language=English
 OLE_E_WRONGCOMPOBJ - compobj.dll is too old for the ole2.dll initialized
 .
+Language=Russian
+OLE_E_WRONGCOMPOBJ - compobj.dll is too old for the ole2.dll initialized
+.
 
 MessageId=0x000F
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_INVALIDHWND
 Language=English
+OLE_E_INVALIDHWND - Invalid window handle
+.
+Language=Russian
 OLE_E_INVALIDHWND - Invalid window handle
 .
 
@@ -18517,12 +23833,18 @@ SymbolicName=OLE_E_NOT_INPLACEACTIVE
 Language=English
 OLE_E_NOT_INPLACEACTIVE - Object is not in any of the inplace active states
 .
+Language=Russian
+OLE_E_NOT_INPLACEACTIVE - Object is not in any of the inplace active states
+.
 
 MessageId=0x0011
 Severity=Warning
 Facility=ITF
 SymbolicName=OLE_E_CANTCONVERT
 Language=English
+OLE_E_CANTCONVERT - Not able to convert object
+.
+Language=Russian
 OLE_E_CANTCONVERT - Not able to convert object
 .
 
@@ -18533,12 +23855,18 @@ SymbolicName=OLE_E_NOSTORAGE
 Language=English
 OLE_E_NOSTORAGE - Not able to perform the operation because object is not given storage yet
 .
+Language=Russian
+OLE_E_NOSTORAGE - Not able to perform the operation because object is not given storage yet
+.
 
 MessageId=0x0064
 Severity=Warning
 Facility=ITF
 SymbolicName=DV_E_FORMATETC
 Language=English
+DV_E_FORMATETC - Invalid FORMATETC structure
+.
+Language=Russian
 DV_E_FORMATETC - Invalid FORMATETC structure
 .
 
@@ -18549,12 +23877,18 @@ SymbolicName=DV_E_DVTARGETDEVICE
 Language=English
 DV_E_DVTARGETDEVICE - Invalid DVTARGETDEVICE structure
 .
+Language=Russian
+DV_E_DVTARGETDEVICE - Invalid DVTARGETDEVICE structure
+.
 
 MessageId=0x0066
 Severity=Warning
 Facility=ITF
 SymbolicName=DV_E_STGMEDIUM
 Language=English
+DV_E_STGMEDIUM - Invalid STDGMEDIUM structure
+.
+Language=Russian
 DV_E_STGMEDIUM - Invalid STDGMEDIUM structure
 .
 
@@ -18565,12 +23899,18 @@ SymbolicName=DV_E_STATDATA
 Language=English
 DV_E_STATDATA - Invalid STATDATA structure
 .
+Language=Russian
+DV_E_STATDATA - Invalid STATDATA structure
+.
 
 MessageId=0x0068
 Severity=Warning
 Facility=ITF
 SymbolicName=DV_E_LINDEX
 Language=English
+DV_E_LINDEX - Invalid lindex
+.
+Language=Russian
 DV_E_LINDEX - Invalid lindex
 .
 
@@ -18581,12 +23921,18 @@ SymbolicName=DV_E_TYMED
 Language=English
 DV_E_TYMED - Invalid tymed
 .
+Language=Russian
+DV_E_TYMED - Invalid tymed
+.
 
 MessageId=0x006A
 Severity=Warning
 Facility=ITF
 SymbolicName=DV_E_CLIPFORMAT
 Language=English
+DV_E_CLIPFORMAT - Invalid clipboard format
+.
+Language=Russian
 DV_E_CLIPFORMAT - Invalid clipboard format
 .
 
@@ -18597,12 +23943,18 @@ SymbolicName=DV_E_DVASPECT
 Language=English
 DV_E_DVASPECT - Invalid aspect(s)
 .
+Language=Russian
+DV_E_DVASPECT - Invalid aspect(s)
+.
 
 MessageId=0x006C
 Severity=Warning
 Facility=ITF
 SymbolicName=DV_E_DVTARGETDEVICE_SIZE
 Language=English
+DV_E_DVTARGETDEVICE_SIZE - tdSize parameter of the DVTARGETDEVICE structure is invalid
+.
+Language=Russian
 DV_E_DVTARGETDEVICE_SIZE - tdSize parameter of the DVTARGETDEVICE structure is invalid
 .
 
@@ -18613,12 +23965,18 @@ SymbolicName=DV_E_NOIVIEWOBJECT
 Language=English
 DV_E_NOIVIEWOBJECT - Object doesn't support IViewObject interface
 .
+Language=Russian
+DV_E_NOIVIEWOBJECT - Object doesn't support IViewObject interface
+.
 
 MessageId=0x0100
 Severity=Warning
 Facility=ITF
 SymbolicName=DRAGDROP_E_NOTREGISTERED
 Language=English
+DRAGDROP_E_NOTREGISTERED - Trying to revoke a drop target that has not been registered
+.
+Language=Russian
 DRAGDROP_E_NOTREGISTERED - Trying to revoke a drop target that has not been registered
 .
 
@@ -18629,12 +23987,18 @@ SymbolicName=DRAGDROP_E_ALREADYREGISTERED
 Language=English
 DRAGDROP_E_ALREADYREGISTERED - This window has already been registered as a drop target
 .
+Language=Russian
+DRAGDROP_E_ALREADYREGISTERED - This window has already been registered as a drop target
+.
 
 MessageId=0x0102
 Severity=Warning
 Facility=ITF
 SymbolicName=DRAGDROP_E_INVALIDHWND
 Language=English
+DRAGDROP_E_INVALIDHWND - Invalid window handle
+.
+Language=Russian
 DRAGDROP_E_INVALIDHWND - Invalid window handle
 .
 
@@ -18645,6 +24009,9 @@ SymbolicName=CLASS_E_NOAGGREGATION
 Language=English
 CLASS_E_NOAGGREGATION - Class does not support aggregation (or class object is remote)
 .
+Language=Russian
+CLASS_E_NOAGGREGATION - Class does not support aggregation (or class object is remote)
+.
 
 MessageId=0x0111
 Severity=Warning
@@ -18653,11 +24020,17 @@ SymbolicName=CLASS_E_CLASSNOTAVAILABLE
 Language=English
 CLASS_E_CLASSNOTAVAILABLE - ClassFactory cannot supply requested class
 .
+Language=Russian
+CLASS_E_CLASSNOTAVAILABLE - ClassFactory cannot supply requested class
+.
 
 MessageId=0x0112
 Severity=Warning
 Facility=ITF
 SymbolicName=CLASS_E_NOTLICENSED
 Language=English
+CLASS_E_NOTLICENSED - Class is not licensed for use
+.
+Language=Russian
 CLASS_E_NOTLICENSED - Class is not licensed for use
 .

--- a/sdk/include/reactos/mc/neteventmsg.mc
+++ b/sdk/include/reactos/mc/neteventmsg.mc
@@ -1,6 +1,13 @@
 ;
 ; netevent.mc MESSAGE resources for netevent.dll
 ;
+;
+; IMPORTANT: When a new language is added, all messages in this file need to be
+; either translated or at least duplicated for the new language.
+; This is a new requirement by MS mc.exe
+; To do this, start with a regex replace:
+; - In VS IDE: "Language=English\r\n(?<String>(?:[^\.].*\r\n)*\.\r\n)" -> "Language=English\r\n${String}Language=MyLanguage\r\n${String}"
+;
 
 MessageIdTypedef=DWORD
 
@@ -134,6 +141,15 @@ Language=English
 Eventlog Service %0
 .
 Language=Russian
+
+;
+; IMPORTANT: When a new language is added, all messages in this file need to be
+; either translated or at least duplicated for the new language.
+; This is a new requirement by MS mc.exe
+; To do this, start with a regex replace:
+; - In VS IDE: "Language=English\r\n(?<String>(?:[^\.].*\r\n)*\.\r\n)" -> "Language=English\r\n${String}Language=MyLanguage\r\n${String}"
+;
+
 Служба журнала событий %0
 .
 Language=French
@@ -159,6 +175,9 @@ Severity=Warning
 Facility=System
 SymbolicName=EVENT_EventLogProductInfo
 Language=English
+ReactOS %1 %2 %3 %4.
+.
+Language=Russian
 ReactOS %1 %2 %3 %4.
 .
 Language=French
@@ -308,6 +327,9 @@ SymbolicName=EVENT_CALL_TO_FUNCTION_FAILED_II
 Language=English
 The %1 call failed for %2 with the following error: %n%3
 .
+Language=Russian
+The %1 call failed for %2 with the following error: %n%3
+.
 Language=French
 L'appel %1 a échoué pour %2 avec l'erreur suivante : %n%3
 .
@@ -317,6 +339,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_REVERTED_TO_LASTKNOWNGOOD
 Language=English
+The system reverted to its last known good configuration.  The system is restarting....
+.
+Language=Russian
 The system reverted to its last known good configuration.  The system is restarting....
 .
 Language=French
@@ -330,6 +355,9 @@ SymbolicName=EVENT_BAD_ACCOUNT_NAME
 Language=English
 No backslash is in the account name.
 .
+Language=Russian
+No backslash is in the account name.
+.
 Language=French
 Aucun backslash n'est présent dans le nom de compte.
 .
@@ -339,6 +367,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_CONNECTION_TIMEOUT
 Language=English
+Timeout (%1 milliseconds) waiting for the %2 service to connect.
+.
+Language=Russian
 Timeout (%1 milliseconds) waiting for the %2 service to connect.
 .
 Language=French
@@ -352,6 +383,9 @@ SymbolicName=EVENT_READFILE_TIMEOUT
 Language=English
 Timeout (%1 milliseconds) waiting for ReadFile.
 .
+Language=Russian
+Timeout (%1 milliseconds) waiting for ReadFile.
+.
 Language=French
 Expiration du délai (%1 millisecondes) lors de l'attente de ReadFile.
 .
@@ -361,6 +395,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_TRANSACT_TIMEOUT
 Language=English
+Timeout (%1 milliseconds) waiting for a transaction response from the %2 service.
+.
+Language=Russian
 Timeout (%1 milliseconds) waiting for a transaction response from the %2 service.
 .
 Language=French
@@ -374,6 +411,9 @@ SymbolicName=EVENT_TRANSACT_INVALID
 Language=English
 Message returned in transaction has incorrect size.
 .
+Language=Russian
+Message returned in transaction has incorrect size.
+.
 Language=French
 Le message retourné dans la transaction a une taille incorrecte.
 .
@@ -383,6 +423,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_FIRST_LOGON_FAILED
 Language=English
+Logon attempt with current password failed with the following error: %n%1
+.
+Language=Russian
 Logon attempt with current password failed with the following error: %n%1
 .
 Language=French
@@ -396,6 +439,9 @@ SymbolicName=EVENT_SECOND_LOGON_FAILED
 Language=English
 Second logon attempt with old password also failed with the following error: %n%1
 .
+Language=Russian
+Second logon attempt with old password also failed with the following error: %n%1
+.
 Language=French
 La seconde tentative de connexion avec l'ancien mot de passe a également échoué avec l'erreur suivante : %n%1
 .
@@ -405,6 +451,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_INVALID_DRIVER_DEPENDENCY
 Language=English
+Boot-start or system-start driver (%1) must not depend on a service.
+.
+Language=Russian
 Boot-start or system-start driver (%1) must not depend on a service.
 .
 Language=French
@@ -418,6 +467,9 @@ SymbolicName=EVENT_BAD_SERVICE_STATE
 Language=English
 The %1 service has reported an invalid current state %2.
 .
+Language=Russian
+The %1 service has reported an invalid current state %2.
+.
 Language=French
 Le service %1 a reporté un état courant invalide %2.
 .
@@ -427,6 +479,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_CIRCULAR_DEPENDENCY_DEMAND
 Language=English
+Detected circular dependencies demand starting %1.
+.
+Language=Russian
 Detected circular dependencies demand starting %1.
 .
 Language=French
@@ -440,6 +495,9 @@ SymbolicName=EVENT_CIRCULAR_DEPENDENCY_AUTO
 Language=English
 Detected circular dependencies auto-starting services.
 .
+Language=Russian
+Detected circular dependencies auto-starting services.
+.
 Language=French
 Dépendances circulaires détectées lors du démarrage automatique des services.
 .
@@ -449,6 +507,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_DEPEND_ON_LATER_SERVICE
 Language=English
+Circular dependency: The %1 service depends on a service in a group which starts later.
+.
+Language=Russian
 Circular dependency: The %1 service depends on a service in a group which starts later.
 .
 Language=French
@@ -462,6 +523,9 @@ SymbolicName=EVENT_DEPEND_ON_LATER_GROUP
 Language=English
 Circular dependency: The %1 service depends on a group which starts later.
 .
+Language=Russian
+Circular dependency: The %1 service depends on a group which starts later.
+.
 Language=French
 Dépendance circulaire : le service %1 dépend d'un groupe qui démarre plus tard.
 .
@@ -471,6 +535,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_SEVERE_SERVICE_FAILED
 Language=English
+About to revert to the last known good configuration because the %1 service failed to start.
+.
+Language=Russian
 About to revert to the last known good configuration because the %1 service failed to start.
 .
 Language=French
@@ -498,6 +565,9 @@ SymbolicName=EVENT_SERVICE_EXIT_FAILED
 Language=English
 The %1 service terminated with the following error: %n%2
 .
+Language=Russian
+The %1 service terminated with the following error: %n%2
+.
 Language=French
 Le service %1 s'est terminé avec l'erreur suivante : %n%2
 .
@@ -507,6 +577,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_SERVICE_EXIT_FAILED_SPECIFIC
 Language=English
+The %1 service terminated with service-specific error %2.
+.
+Language=Russian
 The %1 service terminated with service-specific error %2.
 .
 Language=French
@@ -520,6 +593,9 @@ SymbolicName=EVENT_SERVICE_START_AT_BOOT_FAILED
 Language=English
 At least one service or driver failed during system startup.  Use Event Viewer to examine the event log for details.
 .
+Language=Russian
+At least one service or driver failed during system startup.  Use Event Viewer to examine the event log for details.
+.
 Language=French
 Au moins un service ou pilote a échoué durant le démarrage du système. Utilisez la visionneuse d'évènements pour examiner les journaux d'évènements pour plus de détails.
 .
@@ -529,6 +605,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_BOOT_SYSTEM_DRIVERS_FAILED
 Language=English
+The following boot-start or system-start driver(s) failed to load: %1
+.
+Language=Russian
 The following boot-start or system-start driver(s) failed to load: %1
 .
 Language=French
@@ -542,6 +621,9 @@ SymbolicName=EVENT_RUNNING_LASTKNOWNGOOD
 Language=English
 ReactOS could not be started as configured.  A previous working configuration was used instead.
 .
+Language=Russian
+ReactOS could not be started as configured.  A previous working configuration was used instead.
+.
 Language=French
 ReactOS n'a pas pu démarrer tel que configuré. Une précédente configuration fonctionnelle a été utilisé à la place.
 .
@@ -551,6 +633,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_TAKE_OWNERSHIP
 Language=English
+The %1 Registry key denied access to SYSTEM account programs so the Service Control Manager took ownership of the Registry key.
+.
+Language=Russian
 The %1 Registry key denied access to SYSTEM account programs so the Service Control Manager took ownership of the Registry key.
 .
 Language=French
@@ -564,6 +649,9 @@ SymbolicName=TITLE_SC_MESSAGE_BOX
 Language=English
 Service Control Manager %0
 .
+Language=Russian
+Service Control Manager %0
+.
 Language=French
 Gestionnaire de contrôle des services %0
 .
@@ -573,6 +661,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_SERVICE_NOT_INTERACTIVE
 Language=English
+The %1 service is marked as an interactive service.  However, the system is configured to not allow interactive services.  This service may not function properly.
+.
+Language=Russian
 The %1 service is marked as an interactive service.  However, the system is configured to not allow interactive services.  This service may not function properly.
 .
 Language=French
@@ -586,6 +677,9 @@ SymbolicName=EVENT_SERVICE_CRASH
 Language=English
 The %1 service terminated unexpectedly.  It has done this %2 time(s).  The following corrective action will be taken in %3 milliseconds: %5.
 .
+Language=Russian
+The %1 service terminated unexpectedly.  It has done this %2 time(s).  The following corrective action will be taken in %3 milliseconds: %5.
+.
 Language=French
 Le service %1 s'est terminée de façon non prévue. Il l'a fait %2 fois. L'action corrective suivante va être prise dans %3 millisecondes : %5.
 .
@@ -597,6 +691,9 @@ SymbolicName=EVENT_SERVICE_RECOVERY_FAILED
 Language=English
 The Service Control Manager tried to take a corrective action (%2) after the unexpected termination of the %3 service, but this action failed with the following error: %n%4
 .
+Language=Russian
+The Service Control Manager tried to take a corrective action (%2) after the unexpected termination of the %3 service, but this action failed with the following error: %n%4
+.
 Language=French
 Le gestionnaire de contrôle des services a tenté de prendre une action corrective (%2) après la fin inattendue du service %3, mais cette action a échoué avec l'erreur suivante : %n%4
 .
@@ -606,6 +703,11 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_SERVICE_SCESRV_FAILED
 Language=English
+The Service Control Manager did not initialize successfully. The security
+configuration server (scesrv.dll) failed to initialize with error %1.  The
+system is restarting...
+.
+Language=Russian
 The Service Control Manager did not initialize successfully. The security
 configuration server (scesrv.dll) failed to initialize with error %1.  The
 system is restarting...
@@ -670,6 +772,14 @@ If you do not correct this configuration, you may not be able to restart the %1
 service or may encounter other errors.  To ensure that the service is configured
 properly, use the Services snap-in in Microsoft Management Console (MMC).
 .
+Language=Russian
+The Service Control Manager encountered an error undoing a configuration change
+to the %1 service.  The service's %2 is currently in an unpredictable state.
+
+If you do not correct this configuration, you may not be able to restart the %1
+service or may encounter other errors.  To ensure that the service is configured
+properly, use the Services snap-in in Microsoft Management Console (MMC).
+.
 Language=French
 Le gestionnaire de contrôle des services a rencontré une erreur lors de l'annulation
 d'un changement de configuration sur le service %1. Le %2 du service est actuellement
@@ -691,6 +801,12 @@ password due to the following error: %n%3%n%nTo ensure that the service is
 configured properly, use the Services snap-in in Microsoft Management
 Console (MMC).
 .
+Language=Russian
+The %1 service was unable to log on as %2 with the currently configured
+password due to the following error: %n%3%n%nTo ensure that the service is
+configured properly, use the Services snap-in in Microsoft Management
+Console (MMC).
+.
 Language=French
 Le service %1 n'a pas réussi à s'identifier en tant que %2 avec le mot de passe
 actuellement configuré en raison de l'erreur suivante : %n%3%n%nPour vous assurer
@@ -703,6 +819,13 @@ Severity=Warning
 Facility=System
 SymbolicName=EVENT_SERVICE_DIFFERENT_PID_CONNECTED
 Language=English
+A service process other than the one launched by the Service Control Manager
+connected when starting the %1 service.  The Service Control Manager launched
+process %2 and process %3 connected instead.%n%n
+
+Note that if this service is configured to start under a debugger, this behavior is expected.
+.
+Language=Russian
 A service process other than the one launched by the Service Control Manager
 connected when starting the %1 service.  The Service Control Manager launched
 process %2 and process %3 connected instead.%n%n
@@ -751,6 +874,22 @@ user right appears to be removed, a Group Policy object associated with this
 node might be removing the right. Check with your domain administrator to find
 out if this is happening.
 .
+Language=Russian
+The %1 service was unable to log on as %2 with the currently configured password due to the following error:%n
+Logon failure: the user has not been granted the requested logon type at this computer.%n%n
+Service: %1%n
+Domain and account: %2%n%n
+This service account does not have the necessary user right "Log on as a service."%n%n
+User Action%n%n
+Assign "Log on as a service" to the service account on this computer. You can
+use Local Security Settings (Secpol.msc) to do this. If this computer is a
+node in a cluster, check that this user right is assigned to the Cluster
+service account on all nodes in the cluster.%n%n
+If you have already assigned this user right to the service account, and the
+user right appears to be removed, a Group Policy object associated with this
+node might be removing the right. Check with your domain administrator to find
+out if this is happening.
+.
 Language=French
 Le service %1 n'a pas réussi à s'identifier en tant que %2 avec le mot de passe
 actuellement configuré en raison de l'erreur suivante : %n
@@ -777,6 +916,11 @@ The %1 service was successfully sent a %2 control.%n%n
 The reason specified was: %3 [%4]%n%n
 Comment: %5
 .
+Language=Russian
+The %1 service was successfully sent a %2 control.%n%n
+The reason specified was: %3 [%4]%n%n
+Comment: %5
+.
 Language=French
 Le contrôle %2 a été envoyé avec succès au service %1.%n%n
 La raison spécifiée était : %3 [%4]%n%n
@@ -788,6 +932,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_SERVICE_SHUTDOWN_FAILED
 Language=English
+The %1 service did not shut down properly after receiving a preshutdown control.
+.
+Language=Russian
 The %1 service did not shut down properly after receiving a preshutdown control.
 .
 Language=French
@@ -804,6 +951,9 @@ Severity=Error
 Facility=System
 SymbolicName=EVENT_TRANSPORT_REGISTER_FAILED
 Language=English
+%2 failed to register itself with the NDIS wrapper.
+.
+Language=Russian
 %2 failed to register itself with the NDIS wrapper.
 .
 Language=French

--- a/sdk/include/reactos/mc/netmsgmsg.mc
+++ b/sdk/include/reactos/mc/netmsgmsg.mc
@@ -1,6 +1,13 @@
 ;
 ; netmsg_msg.mc MESSAGE resources for netmsg.dll
 ;
+;
+; IMPORTANT: When a new language is added, all messages in this file need to be
+; either translated or at least duplicated for the new language.
+; This is a new requirement by MS mc.exe
+; To do this, start with a regex replace:
+; - In VS IDE: "Language=English\r\n(?<String>(?:[^\.].*\r\n)*\.\r\n)" -> "Language=English\r\n${String}Language=MyLanguage\r\n${String}"
+;
 
 MessageIdTypedef=DWORD
 
@@ -13,7 +20,8 @@ SeverityNames=(Success=0x0:STATUS_SEVERITY_SUCCESS
 FacilityNames=(System=0x0:FACILITY_SYSTEM
               )
 
-LanguageNames=(English=0x409:MSG00409)
+LanguageNames=(English=0x409:MSG00409
+               Russian=0x419:MSG00419)
 
 
 ;
@@ -27,12 +35,18 @@ SymbolicName=NERR_NetNotStarted
 Language=English
 The workstation driver is not installed.
 .
+Language=Russian
+The workstation driver is not installed.
+.
 
 MessageId=2103
 Severity=Success
 Facility=System
 SymbolicName=NERR_UnknownServer
 Language=English
+The server could not be located.
+.
+Language=Russian
 The server could not be located.
 .
 
@@ -43,12 +57,18 @@ SymbolicName=NERR_ShareMem
 Language=English
 An internal error occurred. The network cannot access a shared memory segment.
 .
+Language=Russian
+An internal error occurred. The network cannot access a shared memory segment.
+.
 
 MessageId=2105
 Severity=Success
 Facility=System
 SymbolicName=NERR_NoNetworkResource
 Language=English
+A network resource shortage occurred.
+.
+Language=Russian
 A network resource shortage occurred.
 .
 
@@ -59,12 +79,18 @@ SymbolicName=NERR_RemoteOnly
 Language=English
 This operation is not supported on workstations.
 .
+Language=Russian
+This operation is not supported on workstations.
+.
 
 MessageId=2107
 Severity=Success
 Facility=System
 SymbolicName=NERR_DevNotRedirected
 Language=English
+The device is not connected.
+.
+Language=Russian
 The device is not connected.
 .
 
@@ -80,11 +106,17 @@ SymbolicName=OTHER_3000
 Language=English
 The command completed successfully.
 .
+Language=Russian
+The command completed successfully.
+.
 
 MessageId=3515
 Severity=Success
 Facility=System
 SymbolicName=OTHER_3515
 Language=English
+The command can be used only on a Domain Controller.
+.
+Language=Russian
 The command can be used only on a Domain Controller.
 .


### PR DESCRIPTION
* Latest VS does not like half translated files
* errcodes.mc is duplicated in kernel32
* It would probably be better to separate each language into it's own file, but we need a build mechanism for that
