### PR TITLE
Improve RtlAssert(..., Message) handling

### DIFF
--- a/base/system/smss/smss.c
+++ b/base/system/smss/smss.c
@@ -70,7 +70,7 @@ SmpExecuteImage(IN PUNICODE_STRING FileName,
     if (!NT_SUCCESS(Status))
     {
         /* This is a pretty bad failure. ASSERT on checked builds and exit */
-        ASSERTMSG("RtlCreateProcessParameters", NT_SUCCESS(Status));
+        ASSERTMSG("RtlCreateProcessParameters failed.\n", NT_SUCCESS(Status));
         DPRINT1("SMSS: RtlCreateProcessParameters failed for %wZ - Status == %lx\n",
                 FileName, Status);
         return Status;

--- a/boot/environ/lib/misc/rtlcompat.c
+++ b/boot/environ/lib/misc/rtlcompat.c
@@ -72,11 +72,24 @@ RtlAssert (
     IN PCHAR Message OPTIONAL
     )
 {
-    EfiPrintf(L"*** ASSERTION %s FAILED AT %d in %s (%s) ***\r\n",
-              FailedAssertion,
-              LineNumber,
-              FileName,
-              Message);
+    if (Message != NULL)
+    {
+        EfiPrintf(L"*** ASSERTION \'%S\' FAILED AT line %lu in %S (%S) ***\r\n",
+                  (PCHAR)FailedAssertion,
+                  LineNumber,
+                  (PCHAR)FileName,
+                  Message);
+    }
+    else
+    {
+        EfiPrintf(L"*** ASSERTION \'%S\' FAILED AT line %lu in %S ***\r\n",
+                  (PCHAR)FailedAssertion,
+                  LineNumber,
+                  (PCHAR)FileName);
+    }
+
+    /* Issue a breakpoint */
+    __debugbreak();
 }
 
 ULONG
@@ -85,7 +98,7 @@ DbgPrint (
     ...
     )
 {
-    EfiPrintf(L"%s\r\n", Format);
+    EfiPrintf(L"%S\r\n", Format);
     return 0;
 }
 

--- a/boot/freeldr/freeldr/arch/i386/pcmem.c
+++ b/boot/freeldr/freeldr/arch/i386/pcmem.c
@@ -322,7 +322,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
             /* Warn user, unless wrong case is "first and not too big entry", which is otherwise harmless. */
             if (PcBiosMapCount > 0 || Regs.x.ecx > sizeof(BIOS_MEMORY_MAP))
             {
-                ASSERTMSG("Int 15h AX=E820h returned an invalid entry length!", FALSE);
+                ASSERTMSG("Int 15h AX=E820h returned an invalid entry length!\n", FALSE);
             }
             /* We keep previous entries (if any), but do not dare trying next entries.
              * We assume these entries are good to use as is. If they are not, we are in trouble...
@@ -360,7 +360,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
                   PcBiosMemoryMap[PcBiosMapCount].Length,
                   PcBiosMemoryMap[PcBiosMapCount].Type,
                   PcBiosMemoryMap[PcBiosMapCount].ExtendedAttributesAsULONG);
-            // NotWantedForPublicBuilds: ASSERTMSG("EA.ErrorLog = 1. Check/Report then CONTinue.", FALSE);
+            // NotWantedForPublicBuilds: ASSERTMSG("EA.ErrorLog = 1. Check/Report then CONTinue.\n", FALSE);
         }
 
         if (PcBiosMemoryMap[PcBiosMapCount].Length == 0)
@@ -433,7 +433,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
         {
             ERR("PcMemoryMap is already full! (PcBiosMapCount = %lu, PcMapCount = %lu (>= %lu))\n",
                 PcBiosMapCount, PcMapCount, MaxMemoryMapSize);
-            // NotWantedForPublicBuilds: ASSERTMSG("PcMemoryMap is already full!", FALSE);
+            // NotWantedForPublicBuilds: ASSERTMSG("PcMemoryMap is already full!\n", FALSE);
             /* We keep previous entries, and half-retrieve current/next entries.
              * We assume all these entries are good to use as is. If they are not, we are in trouble...
              *
@@ -466,7 +466,7 @@ nextRange:
     {
         ERR("PcBiosMemoryMap is already full! (PcBiosMapCount = %lu (>= %lu), PcMapCount = %lu)\n",
             PcBiosMapCount, MAX_BIOS_DESCRIPTORS, PcMapCount);
-        // NotWantedForPublicBuilds: ASSERTMSG("PcBiosMemoryMap is already full!", FALSE);
+        // NotWantedForPublicBuilds: ASSERTMSG("PcBiosMemoryMap is already full!\n", FALSE);
         /* We keep retrieved entries, but ignore next entries.
          * We assume these entries are good to use as is. If they are not, we are in trouble...
          *

--- a/boot/freeldr/freeldr/lib/debug.c
+++ b/boot/freeldr/freeldr/lib/debug.c
@@ -488,7 +488,7 @@ RtlAssert(IN PVOID FailedAssertion,
 {
     if (Message)
     {
-        DbgPrint("Assertion \'%s\' failed at %s line %u: %s\n",
+        DbgPrint("Assertion \'%s\' failed at %s line %lu: %s\n",
                  (PCHAR)FailedAssertion,
                  (PCHAR)FileName,
                  LineNumber,
@@ -496,7 +496,7 @@ RtlAssert(IN PVOID FailedAssertion,
     }
     else
     {
-        DbgPrint("Assertion \'%s\' failed at %s line %u\n",
+        DbgPrint("Assertion \'%s\' failed at %s line %lu\n",
                  (PCHAR)FailedAssertion,
                  (PCHAR)FileName,
                  LineNumber);

--- a/drivers/bus/acpi/buspdo.c
+++ b/drivers/bus/acpi/buspdo.c
@@ -1851,7 +1851,7 @@ Return Value:
             // Only PDO can handle this request. Somebody above
             // is not playing by rule.
             //
-            ASSERTMSG("Someone above is handling TargetDeviceRelation", !deviceRelations);
+            ASSERTMSG("Someone above is handling TargetDeviceRelation\n", !deviceRelations);
         }
 
         deviceRelations = ExAllocatePoolWithTag(PagedPool,

--- a/drivers/bus/pcix/arb/tr_irq.c
+++ b/drivers/bus/pcix/arb/tr_irq.c
@@ -36,7 +36,7 @@ tranirq_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI tranirq_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI tranirq_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/enum.c
+++ b/drivers/bus/pcix/enum.c
@@ -1128,7 +1128,7 @@ PciSkipThisFunction(IN PPCI_COMMON_HEADER PciData,
         else
         {
             /* Logic error in the driver */
-            ASSERTMSG("PCI Skip Function - Operation type unknown.", FALSE);
+            ASSERTMSG("PCI Skip Function - Operation type unknown.\n", FALSE);
         }
 
         /* Check for legacy bridges during resource enumeration */
@@ -2172,7 +2172,7 @@ PciSetResources(IN PPCI_PDO_EXTENSION PdoExtension,
     if (!PcipIsSameDevice(PdoExtension, &PciData))
     {
         /* Fail */
-        ASSERTMSG("PCI Set resources - not same device", FALSE);
+        ASSERTMSG("PCI Set resources - not same device.\n", FALSE);
         return STATUS_DEVICE_DOES_NOT_EXIST;
     }
 

--- a/drivers/bus/pcix/intrface/agpintrf.c
+++ b/drivers/bus/pcix/intrface/agpintrf.c
@@ -38,7 +38,7 @@ agpintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI agpintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI agpintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/busintrf.c
+++ b/drivers/bus/pcix/intrface/busintrf.c
@@ -36,7 +36,7 @@ busintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI busintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI busintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/cardbus.c
+++ b/drivers/bus/pcix/intrface/cardbus.c
@@ -100,7 +100,7 @@ pcicbintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI pcicbintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI pcicbintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/devhere.c
+++ b/drivers/bus/pcix/intrface/devhere.c
@@ -36,7 +36,7 @@ devpresent_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI devpresent_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI devpresent_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/lddintrf.c
+++ b/drivers/bus/pcix/intrface/lddintrf.c
@@ -36,7 +36,7 @@ lddintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI lddintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI lddintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/locintrf.c
+++ b/drivers/bus/pcix/intrface/locintrf.c
@@ -36,7 +36,7 @@ locintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI locintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI locintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/pmeintf.c
+++ b/drivers/bus/pcix/intrface/pmeintf.c
@@ -36,7 +36,7 @@ PciPmeInterfaceInitializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI PciPmeInterfaceInitializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI PciPmeInterfaceInitializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/intrface/routintf.c
+++ b/drivers/bus/pcix/intrface/routintf.c
@@ -38,7 +38,7 @@ routeintrf_Initializer(IN PVOID Instance)
 {
     UNREFERENCED_PARAMETER(Instance);
     /* PnP Interfaces don't get Initialized */
-    ASSERTMSG("PCI routeintrf_Initializer, unexpected call.", FALSE);
+    ASSERTMSG("PCI routeintrf_Initializer, unexpected call.\n", FALSE);
     return STATUS_UNSUCCESSFUL;
 }
 

--- a/drivers/bus/pcix/utils.c
+++ b/drivers/bus/pcix/utils.c
@@ -494,7 +494,7 @@ PciGetDeviceProperty(IN PDEVICE_OBJECT DeviceObject,
                     Status,
                     STATUS_BUFFER_TOO_SMALL);
             *OutputBuffer = NULL;
-            ASSERTMSG("PCI Successfully did the impossible!", FALSE);
+            ASSERTMSG("PCI Successfully did the impossible!\n", FALSE);
             break;
         }
 

--- a/modules/rostests/kmtests/npfs/NpfsHelpers.c
+++ b/modules/rostests/kmtests/npfs/NpfsHelpers.c
@@ -105,7 +105,7 @@ NpCreatePipe(
         ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
     else
     {
-        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!", FALSE);
+        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!\n", FALSE);
         return STATUS_INVALID_PARAMETER_6;
     }
 
@@ -192,7 +192,7 @@ NpOpenPipe(
         ShareAccess = FILE_SHARE_READ | FILE_SHARE_WRITE;
     else
     {
-        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!", FALSE);
+        ASSERTMSG("Invalid NamedPipeConfiguration parameter value!\n", FALSE);
         return STATUS_INVALID_PARAMETER_3;
     }
 

--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -153,7 +153,7 @@ CmpInitializeRegistryNode(IN PCONFIGURATION_COMPONENT_DATA CurrentEntry,
                  FIELD_OFFSET(CM_FULL_RESOURCE_DESCRIPTOR, PartialResourceList);
         if (Length > CmpConfigurationAreaSize)
         {
-            ASSERTMSG("Component too large -- need reallocation!", FALSE);
+            ASSERTMSG("Component too large -- need reallocation!\n", FALSE);
         }
         else
         {

--- a/ntoskrnl/config/cmparse.c
+++ b/ntoskrnl/config/cmparse.c
@@ -1097,7 +1097,8 @@ CmpParseKey(IN PVOID ParseObject,
     ASSERT(ParentKcb != NULL);
 
     /* Check if everything was found cached */
-    if (!TotalRemainingSubkeys) ASSERTMSG("Caching not implemented", FALSE);
+    if (!TotalRemainingSubkeys)
+        ASSERTMSG("Caching not implemented\n", FALSE);
 
     /* Don't do anything if we're being deleted */
     if (Kcb->Delete)

--- a/ntoskrnl/config/cmvalche.c
+++ b/ntoskrnl/config/cmvalche.c
@@ -35,7 +35,7 @@ CmpSetValueCached(IN PHCELL_INDEX CellIndex)
 }
 
 #define ASSERT_VALUE_CACHE() \
-    ASSERTMSG("Cached Values Not Yet Supported!", FALSE);
+    ASSERTMSG("Cached Values Not Yet Supported!\n", FALSE);
 
 /* FUNCTIONS *****************************************************************/
 

--- a/ntoskrnl/ex/callback.c
+++ b/ntoskrnl/ex/callback.c
@@ -183,7 +183,7 @@ ExCompareExchangeCallBack(IN OUT PEX_CALLBACK CallBack,
                                            MAX_FAST_REFS + 1))
         {
             /* This should never happen */
-            ASSERTMSG("Callback block is already undergoing rundown", FALSE);
+            ASSERTMSG("Callback block is already undergoing rundown\n", FALSE);
             return FALSE;
         }
     }

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -40,7 +40,7 @@
 // Hack since bigkeys are not yet supported
 //
 #define ASSERT_VALUE_BIG(h, s)                          \
-    ASSERTMSG("Big keys not supported!", !CmpIsKeyValueBig(h, s));
+    ASSERTMSG("Big keys not supported!\n", !CmpIsKeyValueBig(h, s));
 
 //
 // CM_KEY_CONTROL_BLOCK Signatures

--- a/ntoskrnl/po/power.c
+++ b/ntoskrnl/po/power.c
@@ -991,7 +991,7 @@ NtSetSystemPowerState(IN POWER_ACTION SystemAction,
         }
 
         /* You should not have made it this far */
-        // ASSERTMSG("System is still up and running?!", FALSE);
+        // ASSERTMSG("System is still up and running?!\n", FALSE);
         DPRINT1("System is still up and running, you may not have chosen a yet supported power option: %u\n", PopAction.Action);
         break;
     }

--- a/sdk/lib/cmlib/cmindex.c
+++ b/sdk/lib/cmlib/cmindex.c
@@ -1285,7 +1285,7 @@ CmpSelectLeaf(IN PHHIVE Hive,
     if (!IndexKey)
     {
         /* Should not happen! */
-        ASSERTMSG("IndexKey = NULL!, it should not happen!\n", FALSE);
+        ASSERT(IndexKey != NULL);
         return HCELL_NIL;
     }
 

--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -313,7 +313,7 @@ extern ULONG CmlibTraceLevel;
 // Hack since bigkeys are not yet supported
 //
 #define ASSERT_VALUE_BIG(h, s)                          \
-    ASSERTMSG("Big keys not supported!", !CmpIsKeyValueBig(h, s));
+    ASSERTMSG("Big keys not supported!\n", !CmpIsKeyValueBig(h, s));
 
 //
 // Returns whether or not this is a small valued key

--- a/sdk/lib/rtl/assert.c
+++ b/sdk/lib/rtl/assert.c
@@ -36,7 +36,7 @@ RtlAssert(IN PVOID FailedAssertion,
     {
         /* Print the assertion */
         DbgPrint("\n*** Assertion failed: %s%s\n"
-                 "***   Source File: %s, line %ld\n\n",
+                 "***   Source File: %s, line %lu\n\n",
                  Message != NULL ? Message : "",
                  (PSTR)FailedAssertion,
                  (PSTR)FileName,

--- a/sdk/tools/mkhive/rtl.c
+++ b/sdk/tools/mkhive/rtl.c
@@ -131,28 +131,28 @@ DbgPrint(
 
 VOID
 NTAPI
-RtlAssert(PVOID FailedAssertion,
-          PVOID FileName,
-          ULONG LineNumber,
-          PCHAR Message)
+RtlAssert(IN PVOID FailedAssertion,
+          IN PVOID FileName,
+          IN ULONG LineNumber,
+          IN PCHAR Message OPTIONAL)
 {
-   if (NULL != Message)
-   {
-      DbgPrint("Assertion \'%s\' failed at %s line %d: %s\n",
-               (PCHAR)FailedAssertion,
-               (PCHAR)FileName,
-               LineNumber,
-               Message);
-   }
-   else
-   {
-      DbgPrint("Assertion \'%s\' failed at %s line %d\n",
-               (PCHAR)FailedAssertion,
-               (PCHAR)FileName,
-               LineNumber);
-   }
+    if (Message != NULL)
+    {
+        DbgPrint("Assertion \'%s\' failed at %s line %u: %s\n",
+                 (PCHAR)FailedAssertion,
+                 (PCHAR)FileName,
+                 LineNumber,
+                 Message);
+    }
+    else
+    {
+        DbgPrint("Assertion \'%s\' failed at %s line %u\n",
+                 (PCHAR)FailedAssertion,
+                 (PCHAR)FileName,
+                 LineNumber);
+    }
 
-   //DbgBreakPoint();
+    //DbgBreakPoint();
 }
 
 // DECLSPEC_NORETURN


### PR DESCRIPTION
## Purpose

More consistency with/without message.
Though not using an all-on-one-line format as elsewhere.

## Proposed changes

- [REACTOS] RtlAssert(): use "%lu" as LineNumber format
- [CMLIB] Simplify an ASSERTMSG() as an ASSERT()
- [REACTOS] Improve ASSERTMSG() Message values
