### PR TITLE
[RAPPS] Deselect apps after installing

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -1467,6 +1467,7 @@ private:
                 {
                     CDownloadManager::DownloadListOfApplications(m_AvailableApps.GetSelected());
                     UpdateApplicationsList(-1);
+                    m_ListView->SetSelected(-1, FALSE);
                 }
                 else if (CDownloadManager::DownloadApplication(m_ListView->GetSelectedData()))
                 {


### PR DESCRIPTION
## Purpose

I found it unintuitive that each time I selected some software for installation, it wasn't automatically deselected after installation. I kept re-triggering the same installation a few times before I realized I had to manually uncheck the checked packages.

## Proposed changes

Deselect installed apps after installation.