### PR TITLE
[WIN32K:NTUSER] Re-enable the correct original code in IntSendChildNCPaint. Fixes painting hangs under diverse situations.

### DIFF
--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -366,38 +366,16 @@ IntSendNCPaint(PWND pWnd, HRGN hRgn)
 VOID FASTCALL
 IntSendChildNCPaint(PWND pWnd)
 {
-   PWND Child;
-   HWND *List, *phWnd;
-
-   List = IntWinListChildren(UserGetDesktopWindow());
-   if ( List )
-   {
-      for (phWnd = List; *phWnd; ++phWnd)
-      {
-          Child = ValidateHwndNoErr(*phWnd);
-          if ( Child && Child->hrgnUpdate == NULL && Child->state & WNDS_SENDNCPAINT)
-          {
-             USER_REFERENCE_ENTRY Ref;
-             UserRefObjectCo(Child, &Ref);
-             IntSendNCPaint(Child, HRGN_WINDOW);
-             UserDerefObjectCo(Child);
-          }
-      }
-      ExFreePoolWithTag(List, USERTAG_WINDOWLIST);
-   }
-/* FIXME : Use snap shot mode until window death is fixed while surfing menus! Fix CORE-12085 and CORE-12071.
-   pWnd = pWnd->spwndChild;
-   while(pWnd)
-   {
-      if (pWnd->hrgnUpdate == NULL && pWnd->state & WNDS_SENDNCPAINT)
-      {
-         USER_REFERENCE_ENTRY Ref;
-         UserRefObjectCo(pWnd, &Ref);
-         IntSendNCPaint(pWnd, HRGN_WINDOW);
-         UserDerefObjectCo(pWnd);
-      }
-      pWnd = pWnd->spwndNext;
-   }*/
+    for (pWnd = pWnd->spwndChild; pWnd; pWnd = pWnd->spwndNext)
+    {
+        if ((pWnd->hrgnUpdate == NULL) && (pWnd->state & WNDS_SENDNCPAINT))
+        {
+            USER_REFERENCE_ENTRY Ref;
+            UserRefObjectCo(pWnd, &Ref);
+            IntSendNCPaint(pWnd, HRGN_WINDOW);
+            UserDerefObjectCo(pWnd);
+        }
+    }
 }
 
 /*

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -861,19 +861,28 @@ IntLinkWindow(
     PWND WndInsertAfter /* Set to NULL if top sibling */
 )
 {
+    if (Wnd == WndInsertAfter)
+    {
+        ERR("IntLinkWindow -- Trying to link window 0x%p to itself!!\n", Wnd);
+        return;
+    }
+
     Wnd->spwndPrev = WndInsertAfter;
     if (Wnd->spwndPrev)
     {
         /* Link after WndInsertAfter */
+        ASSERT(Wnd != WndInsertAfter->spwndNext);
         Wnd->spwndNext = WndInsertAfter->spwndNext;
         if (Wnd->spwndNext)
             Wnd->spwndNext->spwndPrev = Wnd;
 
+        ASSERT(Wnd != Wnd->spwndPrev);
         Wnd->spwndPrev->spwndNext = Wnd;
     }
     else
     {
         /* Link at the top */
+        ASSERT(Wnd != Wnd->spwndParent->spwndChild);
         Wnd->spwndNext = Wnd->spwndParent->spwndChild;
         if (Wnd->spwndNext)
             Wnd->spwndNext->spwndPrev = Wnd;
@@ -956,6 +965,8 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
             return;
         }
 
+        if (Wnd == WndInsertAfter)
+            ERR("IntLinkHwnd -- Trying to link window 0x%p to itself!!\n", Wnd);
         IntLinkWindow(Wnd, WndInsertAfter);
 
         /* Fix the WS_EX_TOPMOST flag */
@@ -1254,6 +1265,9 @@ co_UserSetParent(HWND hWndChild, HWND hWndNewParent)
 VOID FASTCALL
 IntUnlinkWindow(PWND Wnd)
 {
+    ASSERT(Wnd != Wnd->spwndNext);
+    ASSERT(Wnd != Wnd->spwndPrev);
+
     if (Wnd->spwndNext)
         Wnd->spwndNext->spwndPrev = Wnd->spwndPrev;
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -854,32 +854,32 @@ IntIsChildWindow(PWND Parent, PWND BaseWindow)
 }
 ////
 
-/*
-   Link the window into siblings list
-   children and parent are kept in place.
-*/
+/* Link the window into siblings list. Children and parent are kept in place. */
 VOID FASTCALL
 IntLinkWindow(
-   PWND Wnd,
-   PWND WndInsertAfter /* set to NULL if top sibling */
+    PWND Wnd,
+    PWND WndInsertAfter /* Set to NULL if top sibling */
 )
 {
-  if ((Wnd->spwndPrev = WndInsertAfter))
-   {
-      /* link after WndInsertAfter */
-      if ((Wnd->spwndNext = WndInsertAfter->spwndNext))
-         Wnd->spwndNext->spwndPrev = Wnd;
+    Wnd->spwndPrev = WndInsertAfter;
+    if (Wnd->spwndPrev)
+    {
+        /* Link after WndInsertAfter */
+        Wnd->spwndNext = WndInsertAfter->spwndNext;
+        if (Wnd->spwndNext)
+            Wnd->spwndNext->spwndPrev = Wnd;
 
-      Wnd->spwndPrev->spwndNext = Wnd;
-   }
-   else
-   {
-      /* link at top */
-     if ((Wnd->spwndNext = Wnd->spwndParent->spwndChild))
-         Wnd->spwndNext->spwndPrev = Wnd;
+        Wnd->spwndPrev->spwndNext = Wnd;
+    }
+    else
+    {
+        /* Link at the top */
+        Wnd->spwndNext = Wnd->spwndParent->spwndChild;
+        if (Wnd->spwndNext)
+            Wnd->spwndNext->spwndPrev = Wnd;
 
-     Wnd->spwndParent->spwndChild = Wnd;
-   }
+        Wnd->spwndParent->spwndChild = Wnd;
+    }
 }
 
 /*
@@ -889,8 +889,8 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
 {
     if (hWndPrev == HWND_NOTOPMOST)
     {
-        if (!(Wnd->ExStyle & WS_EX_TOPMOST) &&
-            (Wnd->ExStyle2 & WS_EX2_LINKED)) return;  /* nothing to do */
+        if (!(Wnd->ExStyle & WS_EX_TOPMOST) && (Wnd->ExStyle2 & WS_EX2_LINKED))
+            return;  /* nothing to do */
         Wnd->ExStyle &= ~WS_EX_TOPMOST;
         hWndPrev = HWND_TOP;  /* fallback to the HWND_TOP case */
     }
@@ -903,8 +903,10 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
         PWND WndInsertAfter;
 
         WndInsertAfter = Wnd->spwndParent->spwndChild;
-        while( WndInsertAfter && WndInsertAfter->spwndNext)
+        while (WndInsertAfter && WndInsertAfter->spwndNext)
+        {
             WndInsertAfter = WndInsertAfter->spwndNext;
+        }
 
         IntLinkWindow(Wnd, WndInsertAfter);
         Wnd->ExStyle &= ~WS_EX_TOPMOST;
@@ -913,7 +915,6 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
     {
         /* Link in the top of the list */
         IntLinkWindow(Wnd, NULL);
-
         Wnd->ExStyle |= WS_EX_TOPMOST;
     }
     else if (hWndPrev == HWND_TOP)
@@ -927,7 +928,9 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
         {
             while (WndInsertBefore != NULL && WndInsertBefore->spwndNext != NULL)
             {
-                if (!(WndInsertBefore->ExStyle & WS_EX_TOPMOST)) break;
+                if (!(WndInsertBefore->ExStyle & WS_EX_TOPMOST))
+                    break;
+
                 if (WndInsertBefore == Wnd->spwndOwner)  /* keep it above owner */
                 {
                     Wnd->ExStyle |= WS_EX_TOPMOST;
@@ -946,7 +949,7 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
 
         WndInsertAfter = UserGetWindowObject(hWndPrev);
         /* Are we called with an erroneous handle */
-        if(WndInsertAfter == NULL)
+        if (WndInsertAfter == NULL)
         {
             /* Link in a default position */
             IntLinkHwnd(Wnd, HWND_TOP);
@@ -962,8 +965,8 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
         }
         else
         {
-            if(WndInsertAfter->spwndNext &&
-               WndInsertAfter->spwndNext->ExStyle & WS_EX_TOPMOST)
+            if (WndInsertAfter->spwndNext &&
+                (WndInsertAfter->spwndNext->ExStyle & WS_EX_TOPMOST))
             {
                 Wnd->ExStyle |= WS_EX_TOPMOST;
             }
@@ -1247,20 +1250,20 @@ co_UserSetParent(HWND hWndChild, HWND hWndNewParent)
    return( hWndOldParent);
 }
 
-/* Unlink the window from siblings. children and parent are kept in place. */
+/* Unlink the window from siblings. Children and parent are kept in place. */
 VOID FASTCALL
 IntUnlinkWindow(PWND Wnd)
 {
-   if (Wnd->spwndNext)
-       Wnd->spwndNext->spwndPrev = Wnd->spwndPrev;
+    if (Wnd->spwndNext)
+        Wnd->spwndNext->spwndPrev = Wnd->spwndPrev;
 
-   if (Wnd->spwndPrev)
-       Wnd->spwndPrev->spwndNext = Wnd->spwndNext;
+    if (Wnd->spwndPrev)
+        Wnd->spwndPrev->spwndNext = Wnd->spwndNext;
 
-   if (Wnd->spwndParent && Wnd->spwndParent->spwndChild == Wnd)
-       Wnd->spwndParent->spwndChild = Wnd->spwndNext;
+    if (Wnd->spwndParent && Wnd->spwndParent->spwndChild == Wnd)
+        Wnd->spwndParent->spwndChild = Wnd->spwndNext;
 
-   Wnd->spwndPrev = Wnd->spwndNext = NULL;
+    Wnd->spwndPrev = Wnd->spwndNext = NULL;
 }
 
 /* FUNCTIONS *****************************************************************/

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -30,8 +30,6 @@ DBG_DEFAULT_CHANNEL(UserWinpos);
 #define PLACE_MAX               0x0002
 #define PLACE_RECT              0x0004
 
-VOID FASTCALL IntLinkWindow(PWND Wnd,PWND WndInsertAfter);
-
 /* FUNCTIONS *****************************************************************/
 
 #if DBG


### PR DESCRIPTION
## Purpose

In https://svn.reactos.org/svn/reactos/trunk/reactos/win32ss/user/ntuser/painting.c?r1=73532&r2=73531&pathrev=73532
correct code in IntSendChildNCPaint() has been disabled and been replaced by other one, supposedly to fix [CORE-12085](https://jira.reactos.org/browse/CORE-12085) and [CORE-12071](https://jira.reactos.org/browse/CORE-12071), however this new code introduced subtle painting problems like hangs in some situations (last in date is [CORE-14763](https://jira.reactos.org/browse/CORE-14763)).
This PR aims at re-enabling the original code.

JIRA issue: [CORE-14763](https://jira.reactos.org/browse/CORE-14763)

It fixes the testbots:

(Old tests)
https://build.reactos.org/builders/Test%20KVM/builds/20737
Tests results: https://www.reactos.org/testman/compare.php?ids=61203,61219

(New tests)
https://build.reactos.org/builders/Test%20KVM/builds/20738 and
https://build.reactos.org/builders/Test%20KVM/builds/20739
Tests results: https://www.reactos.org/testman/compare.php?ids=61201,61203,61221,61222