### PR TITLE
CORE-7538. [WINDOWSCODECS] Fix an MSVC warning about get_decoder_info()

### DIFF
--- a/dll/win32/windowscodecs/info.c
+++ b/dll/win32/windowscodecs/info.c
@@ -2159,7 +2159,7 @@ void ReleaseComponentInfos(void)
         IWICComponentInfo_Release(&info->IWICComponentInfo_iface);
 }
 
-HRESULT get_decoder_info(const CLSID *clsid, IWICBitmapDecoderInfo **info)
+HRESULT get_decoder_info(REFCLSID clsid, IWICBitmapDecoderInfo **info)
 {
     IWICComponentInfo *compinfo;
     HRESULT hr;


### PR DESCRIPTION
## Purpose

Cherry-pick https://source.winehq.org/git/wine.git/commit/90518ebd2ca14568879831a5a87685a8385a21d7

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- "...\info.c(2163) : warning C4028: formal parameter 1 different from declaration"
