### PR TITLE
Fixed 64-bit integer constants declaration in asm.inc

### DIFF
--- a/boot/freeldr/freeldr/arch/amd64/entry.S
+++ b/boot/freeldr/freeldr/arch/amd64/entry.S
@@ -25,7 +25,7 @@ RealEntryPoint:
     jmp qword ptr [ContinueAddress]
 
 ContinueAddress:
-    .double offset FrldrStartup
+    .quad offset FrldrStartup
 
 FrldrStartup:
 
@@ -120,7 +120,7 @@ CallRealMode_return:
 
     /* 64-bit stack pointer */
 stack64:
-    .double STACKADDR
+    .quad STACKADDR
 
 PUBLIC FrldrBootDrive
 FrldrBootDrive:

--- a/sdk/include/asm/asm.inc
+++ b/sdk/include/asm/asm.inc
@@ -136,8 +136,12 @@ ENDM
     dd args
 ENDM
 
-.double MACRO args:VARARG
+.quad MACRO args:VARARG
     dq args
+ENDM
+
+.double MACRO args:VARARG
+    real8 args
 ENDM
 
 .org MACRO value

--- a/sdk/lib/crt/except/amd64/cpp.s
+++ b/sdk/lib/crt/except/amd64/cpp.s
@@ -8,18 +8,18 @@
 MACRO(START_VTABLE, shortname, cxxname)
 EXTERN shortname&_rtti:PROC
 EXTERN MSVCRT_&shortname&_vector_dtor:PROC
-    .double shortname&_rtti
+    .quad shortname&_rtti
 PUBLIC MSVCRT_&shortname&_vtable
 MSVCRT_&shortname&_vtable:
 PUBLIC &cxxname
 &cxxname:
-    .double MSVCRT_&shortname&_vector_dtor
+    .quad MSVCRT_&shortname&_vector_dtor
 ENDM
 
 MACRO(DEFINE_EXCEPTION_VTABLE, shortname, cxxname)
     START_VTABLE shortname, cxxname
     EXTERN MSVCRT_what_exception:ABS
-    .double MSVCRT_what_exception
+    .quad MSVCRT_what_exception
 ENDM
 
 START_VTABLE type_info, __dummyname_type_info


### PR DESCRIPTION
GAS uses ".double" symbol for declaring floating-point constants and
".quad" symbol for declaring 64-bit numbers.
This is not compatible with our macro for MASM and introduces bugs.
Now 64-bit constants are supposed to be declared using ".quad" macro.