### PR TITLE
[DOC] fix typos

### DIFF
--- a/media/doc/DdCreateDirectDrawObject.txt
+++ b/media/doc/DdCreateDirectDrawObject.txt
@@ -11,15 +11,15 @@ When IN HDC is not NULL
  
 When IN HDC is NULL   
 Now we come to if IN HDC is null basic we need create
-   a hdc and cashe some data
+   a hdc and cache some data
 1. if internal cache of directdraw handle is not null (pDirectDrawGlobalInternal->hDD)
    we take it and fill to the public directdraw handler (pDirectDrawGlobal->hDD)
    and return susses.
  
 2.  if no internal cache of directdraw handle is found we need create it
-    by using CreateDC for tempary HDC that will be cache in the win32k later
+    by using CreateDC for temporary HDC that will be cached in the win32k later
  
-3.  we need check see if we got a tempary HDC or not, if we fail getting tempary 
+3.  we need check see if we got a temporary HDC or not, if we fail getting temporary
     HDC return FALSE
  
 4. Now we trying create directdraw handler it being cache to (pDirectDrawGlobalInternal->hDD)

--- a/media/doc/HACKING
+++ b/media/doc/HACKING
@@ -77,7 +77,7 @@ Debugging kernel-mode code is tricky, these are some snippets
     The fault type will usually be either 'General Protection' or
     'Page Fault', see your Intel manual for the more exotic types. The
     'EIP' number is the address of the faulting instruction. If the 'CS'
-    number is 0x20 then the exception occured in kernel mode, if it is 0x11
+    number is 0x20 then the exception occurred in kernel mode, if it is 0x11
     then the exception occurred in user mode. 'cr2' is the address that the
     faulting instruction was trying to access, if the exception was a page 
     fault. The number printed after 'Frames' are any addresses on the stack
@@ -92,7 +92,7 @@ Debugging kernel-mode code is tricky, these are some snippets
 	           ....
 		   
     Again the numbers printed after 'Frames' are any addresses on the stack
-    that look like function addresss. Usually the kernel will also print a
+    that look like function addresses. Usually the kernel will also print a
     message describing the problem in more detail, the bug check code isn't
     very useful at the moment. 
     
@@ -117,8 +117,8 @@ Debugging kernel-mode code is tricky, these are some snippets
     The NT4 ddk license agreement allows its usage for developing nt drivers
     only. Legally therefore it can not be used to develop ReactOS, neither the
     documentation or the sample code. I'm not a lawyer, but I doubt the
-    effiacy of 'shrinkwrap licenses' particularly on freely downloadable 
-    software. The only precendent I know of, in a Scottish court, didn't
+    efficacy of 'shrinkwrap licenses' particularly on freely downloadable
+    software. The only precedent I know of, in a Scottish court, didn't
     upload this type of license.
     
     Also the 'fair use' section of copyright law allows the 'quoting' of small

--- a/media/doc/LPC.txt
+++ b/media/doc/LPC.txt
@@ -9,7 +9,7 @@ Below are some of Alex's notes on the mysterious LPC Subsystem
 1. Sizes, sizes, sizes...
 =========================
 
-There are four imporant LPC Sizes to keep in mind. Try to understand them:
+There are four important LPC Sizes to keep in mind. Try to understand them:
 
 /* 
  * This determines the absolute maximum message size (0x100 bytes). For
@@ -20,7 +20,7 @@ There are four imporant LPC Sizes to keep in mind. Try to understand them:
 /*
  * This determines the maximum length of an LPC request. It is the largest
  * amount of bytes that an LPC request can take. To calculate this, assume
- * that this is a CONNECTION_REQUEST message, which includes the additionnal
+ * that this is a CONNECTION_REQUEST message, which includes the additional
  * LPCP_CONNECTION_MESSAGE structure as well. Therefore, we add the kernel LPC,
  * header, the maximum port size and the size of the connection request 
  * structure. This gives a value of 0x15C. However, one must note that NT

--- a/media/doc/notes
+++ b/media/doc/notes
@@ -11,7 +11,7 @@ From: Emanuele Aliberti <ea@iol.it>
 
 For those working on the boot loader: in WinNt Magazine november 1998
 issue (http://www.winntmag.com/) there is a detailed description, by
-Mark Russinovich, of the rôle the MBR, NTLDR, boot.ini, ntdetect.com...
+Mark Russinovich, of the role the MBR, NTLDR, boot.ini, ntdetect.com...
 play in the boot process ("Inside the Boot Process, Part 1").
 -----
 Yes with DPCs, KeDrainDpcQueue should go to HIGH_LEVEL because 
@@ -85,7 +85,7 @@ makefile for the module to generate a listing file with
 symbol information.  Then, on a boot test, note the
 address that the module is loaded at, and subtract
 this from the EIP value.  add any offset used in the
-module link specification (I dont think there currently
+module link specification (I don't think there currently
 is one), and look for the last symbol with a lower
 address offset.
 
@@ -96,7 +96,7 @@ in memory somewhere.  Perhaps the exception
 dump could check offending addresses to see if
 they lie in the kernel or in a module, and if they
 lie in a module the proper offset could be subtracted
-and this number could be displayed seperately.  If
+and this number could be displayed separately.  If
 I get a chance today, I'll make this change and send
 it to ya.
 
@@ -109,7 +109,7 @@ Organization: Microsoft Corp.
 Newsgroups: microsoft.public.win32.programmer.kernel, comp.os.ms-windows.programmer.nt.kernel-mode
 References: 1
 
-Radu, I post the following information occassionally for questions such as
+Radu, I post the following information occasionally for questions such as
 yours.  I hope it helps.
 
 -Paul
@@ -254,7 +254,7 @@ Device Driver Completion Routine perspective
 standard completion routine operations
 set IoStatus.Status to an approriate NtStatus
 IoStatus.Information is not needed
-completete the request
+complete the request
 
 
 
@@ -333,7 +333,7 @@ return status pending
 Device Driver Completion Routine perspective
 
 standard completion routine operations
-set IoStatus.Status to an approriate NtStatus
+set IoStatus.Status to an appropriate NtStatus
 IoStatus.Information is not needed
 completete the request
 
@@ -413,13 +413,13 @@ Something(
 >
 >The aDataIn buffer will not exist after DeviceIoControl returns (and
 >when the I/O operation terminates). I know that for buffered IO the
->input data buffer is copyed by de IOManager to a nonpaged-pool area
+>input data buffer is copied by de IOManager to a nonpaged-pool area
 >before passing the request to driver dispatch routine (DeviceControl).
 >At the point of calling the dispatch routine (DeviceControl) the driver
 >runs in the context of the calling thread so DeviceIoControl hasn't
 >returned yet (?? or so I think) so aDataI
 n will still be valid at the
->time IOManager copyes it to its buffer. So, this apears to work ok (at
+>time IOManager copies it to its buffer. So, this appears to work ok (at
 >least in my opinion).
 >
 >Does I/O Manager use the Input buffer from the call to the Win32

--- a/media/doc/notes
+++ b/media/doc/notes
@@ -413,12 +413,11 @@ Something(
 >
 >The aDataIn buffer will not exist after DeviceIoControl returns (and
 >when the I/O operation terminates). I know that for buffered IO the
->input data buffer is copied by de IOManager to a nonpaged-pool area
+>input data buffer is copied by IOManager to a nonpaged-pool area
 >before passing the request to driver dispatch routine (DeviceControl).
 >At the point of calling the dispatch routine (DeviceControl) the driver
 >runs in the context of the calling thread so DeviceIoControl hasn't
->returned yet (?? or so I think) so aDataI
-n will still be valid at the
+>returned yet (?? or so I think) so aDataIn will still be valid at the
 >time IOManager copies it to its buffer. So, this appears to work ok (at
 >least in my opinion).
 >

--- a/media/doc/todo
+++ b/media/doc/todo
@@ -12,7 +12,7 @@
        Dma functions (see hal/x86/dma.c)
        Shutdown support (see ex/power.c)
        Zw(Set/Get)SystemInformation (see ex/sysinfo.c)
-       Io cancelation support (see io/cancel, et al)
+       Io cancellation support (see io/cancel, et al)
        Directory change notification (see io/dir.c)
        Error logging (see io/errlog.c)
        Io completion ports (see io/iocomp.c)

--- a/media/doc/win32k_refs.txt
+++ b/media/doc/win32k_refs.txt
@@ -49,7 +49,7 @@ GUI thread conversion.  The Win32 process initialization callback routine
 also creates and initializes the W32PROCESS structure and associates it with
 the process.
 
-Similary for thread the callback routine automatically assigns a desktop
+Similarly for thread the callback routine automatically assigns a desktop
 when the thread is converted to GUI thread. The thread also gets a W32THREAD
 structure, a message queue and a thread input structures.
 

--- a/media/doc/winsta and desktops.txt
+++ b/media/doc/winsta and desktops.txt
@@ -1,6 +1,6 @@
 SAWinSta
 --------
-I write a GUI appication, and the user may run it in task schedule. Since
+I write a GUI application, and the user may run it in task schedule. Since
 windows 2000/XP treat schedule task as a service, the schedule service can
 not be associated with interactive desktop object in the in 2 states
 1) No user log on
@@ -64,7 +64,7 @@ Process closing window station with CloseWindowStation can't be assigned to the 
 
 The reason is that each session has its own CSRSS, as well as instanced
 win32k.sys data.  So in each session, you basically have a complete copy of
-Windows that doesn't know about the existance of any other copy.  You're not
+Windows that doesn't know about the existence of any other copy.  You're not
 just on a different desktop/windowstation when you're in a different
 session.
 
@@ -78,12 +78,12 @@ The CreateDesktop function creates a new desktop on the window station associate
 
 PROCESS:
 -every w32 process is associated with a WindowStation
--can move between window stations (well, with strict limitations i would guess eg. what if
+-can move between window stations (well, with strict limitations i would guess e.g. what if
  windows have been created and is using the winsta heap? or can multiple winsta heaps be mapped into
  one process?? )
 
 THREADS:
--can only enumerate windows on its desktop (but u can easely switch to a different desk)
+-can only enumerate windows on its desktop (but you can easily switch to a different desk)
 -every w32 thread is associated with a Desktop
 -Threads can switch between desktops, and windows are created on the thread's current desktop
  (a thread can have windows on multiple desktops? IS THIS REALLY TRUE?)
@@ -94,7 +94,7 @@ DESKTOP:
 be associated with Winsta0
 -Only one desktop is visible to the user and only one can receives input at any time
 -contain a logical display surface
--contin windows (or a pointer to the desktop window)
+-contain windows (or a pointer to the desktop window)
 -contain menus
 -contain hooks
 -holds UI objects, such as windows, menus, and hooks

--- a/media/doc/winsta and desktops.txt
+++ b/media/doc/winsta and desktops.txt
@@ -93,10 +93,10 @@ DESKTOP:
 -Only one desktop at a time can interact with the user, and that desktop must necessarily 
 be associated with Winsta0
 -Only one desktop is visible to the user and only one can receives input at any time
--contain a logical display surface
--contain windows (or a pointer to the desktop window)
--contain menus
--contain hooks
+-contains a logical display surface
+-contains windows (or a pointer to the desktop window)
+-contains menus
+-contains hooks
 -holds UI objects, such as windows, menus, and hooks
 -Once a window is created it cannot move between desktops
 
@@ -118,7 +118,7 @@ WINDOW STATION:
 -contains a clipboard
 -contains a set of desktop objects
 -contains handle table(s) (handles are valid throughout the whole windowstation, not only the creating process)
--contain heaps (pointer(s) to the section heap(s) shared between user32/gdi32/win32k)
+-contains heaps (pointer(s) to the section heap(s) shared between user32/gdi32/win32k)
 -A Windows 2000 session will have several windows stations, one assigned to the logon session 
  of the interactive user, and others assigned to the Winlogon process, the secure screen saver
  process, and any service that runs in a security context other than that of the interactive user.


### PR DESCRIPTION
## Purpose

fix english typos in the doc files, nothing fancy
