### PR TITLE
CORE-7538. [MSHTML] Fix 3 MSVC warnings about HTML*Element_handle_event()

### DIFF
--- a/dll/win32/mshtml/htmlanchor.c
+++ b/dll/win32/mshtml/htmlanchor.c
@@ -710,7 +710,7 @@ static HRESULT HTMLAnchorElement_QI(HTMLDOMNode *iface, REFIID riid, void **ppv)
     return HTMLElement_QI(&This->element.node, riid, ppv);
 }
 
-static HRESULT HTMLAnchorElement_handle_event(HTMLDOMNode *iface, eventid_t eid, nsIDOMEvent *event, BOOL *prevent_default)
+static HRESULT HTMLAnchorElement_handle_event(HTMLDOMNode *iface, DWORD eid, nsIDOMEvent *event, BOOL *prevent_default)
 {
     HTMLAnchorElement *This = impl_from_HTMLDOMNode(iface);
     nsAString href_str, target_str;

--- a/dll/win32/mshtml/htmlarea.c
+++ b/dll/win32/mshtml/htmlarea.c
@@ -388,7 +388,7 @@ static HRESULT HTMLAreaElement_QI(HTMLDOMNode *iface, REFIID riid, void **ppv)
     return S_OK;
 }
 
-static HRESULT HTMLAreaElement_handle_event(HTMLDOMNode *iface, eventid_t eid, nsIDOMEvent *event, BOOL *prevent_default)
+static HRESULT HTMLAreaElement_handle_event(HTMLDOMNode *iface, DWORD eid, nsIDOMEvent *event, BOOL *prevent_default)
 {
     HTMLAreaElement *This = impl_from_HTMLDOMNode(iface);
     nsAString href_str, target_str;

--- a/dll/win32/mshtml/htmlform.c
+++ b/dll/win32/mshtml/htmlform.c
@@ -717,7 +717,7 @@ static HRESULT HTMLFormElement_invoke(HTMLDOMNode *iface,
     return S_OK;
 }
 
-static HRESULT HTMLFormElement_handle_event(HTMLDOMNode *iface, eventid_t eid, nsIDOMEvent *event, BOOL *prevent_default)
+static HRESULT HTMLFormElement_handle_event(HTMLDOMNode *iface, DWORD eid, nsIDOMEvent *event, BOOL *prevent_default)
 {
     HTMLFormElement *This = impl_from_HTMLDOMNode(iface);
 


### PR DESCRIPTION
## Purpose

Cherry-pick Jacek Caban https://source.winehq.org/git/wine.git/commit/a660f673cb7d6d04e0f2a9a98cff439b5403365b

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- "...\htmlanchor.c(769) : warning C4028: formal parameter 2 different from declaration"
- "...\htmlarea.c(427) : warning C4028: formal parameter 2 different from declaration"
- "...\htmlform.c(757) : warning C4028: formal parameter 2 different from declaration"
