### PR TITLE
CORE-7538. [OLEAUT32] Fix an MSVC warning about VarCyMul()

### DIFF
--- a/dll/win32/oleaut32/vartype.c
+++ b/dll/win32/oleaut32/vartype.c
@@ -3804,7 +3804,7 @@ HRESULT WINAPI VarCyAdd(const CY cyLeft, const CY cyRight, CY* pCyOut)
  *  Success: S_OK.
  *  Failure: DISP_E_OVERFLOW, if the value will not fit in the destination
  */
-HRESULT WINAPI VarCyMul(const CY cyLeft, const CY cyRight, CY* pCyOut)
+HRESULT WINAPI VarCyMul(const CY cyLeft, CY cyRight, CY* pCyOut)
 {
   double l,r;
   _VarR8FromCy(cyLeft, &l);


### PR DESCRIPTION
## Purpose

Mininal cherry-pick Alexandre Julliard https://source.winehq.org/git/wine.git/commit/18f7ec3670375f6389b36527fbfe1216fe795e53

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- "...\vartype.c(3808) : warning C4028: formal parameter 2 different from declaration"
