### PR TITLE
CORE-7538. [MSHTML] Fix an MSVC warning about HTMLInputElementImpl_fire_event()

### DIFF
--- a/dll/win32/mshtml/htmlinput.c
+++ b/dll/win32/mshtml/htmlinput.c
@@ -1215,7 +1215,11 @@ static HRESULT HTMLInputElement_QI(HTMLDOMNode *iface, REFIID riid, void **ppv)
     return HTMLElement_QI(&This->element.node, riid, ppv);
 }
 
+#ifndef __REACTOS__
 static HRESULT HTMLInputElementImpl_fire_event(HTMLDOMNode *iface, eventid_t eid, BOOL *handled)
+#else
+static HRESULT HTMLInputElementImpl_fire_event(HTMLDOMNode *iface, DWORD eid, BOOL *handled)
+#endif
 {
     HTMLInputElement *This = impl_from_HTMLDOMNode(iface);
 


### PR DESCRIPTION
## Purpose

Temporary fix, until WINESYNC replaces this function.
Similar to #688. See also [CORE-14829](https://jira.reactos.org/browse/CORE-14829).

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- "...\htmlinput.c(1303) : warning C4028: formal parameter 2 different from declaration"
