### PR TITLE
CORE-7538. [SHELL32_WINETEST] Fix 2 MSVC warnings about flags

### DIFF
--- a/modules/rostests/winetests/shell32/ebrowser.c
+++ b/modules/rostests/winetests/shell32/ebrowser.c
@@ -1102,7 +1102,7 @@ static void test_basics(void)
     IShellBrowser *psb;
     FOLDERSETTINGS fs;
     ULONG lres;
-    DWORD flags;
+    EXPLORER_BROWSER_OPTIONS flags;
     HDWP hdwp;
     RECT rc;
     HRESULT hr;


### PR DESCRIPTION
## Purpose

Cherry-pick https://source.winehq.org/git/wine.git/commit/535f2f9e663b7b3db3147960942d3b4934e1ce07

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- `...\ebrowser.c(1188) : warning C4133: 'function' : incompatible types - from 'DWORD *' to 'EXPLORER_BROWSER_OPTIONS *'`
- `...\ebrowser.c(1198) : warning C4133: 'function' : incompatible types - from 'DWORD *' to 'EXPLORER_BROWSER_OPTIONS *'`
