### PR TITLE
Fix IO_STACK_LOCATION alignment

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND COMMON_SOURCE
 list(APPEND KMTEST_DRV_SOURCE
     kmtest_drv/guid.c
     kmtest_drv/kmtest_drv.c
+    kmtest_drv/structs.c
     kmtest_drv/testlist.c
 
     example/Example.c

--- a/modules/rostests/kmtests/kmtest_drv/structs.c
+++ b/modules/rostests/kmtests/kmtest_drv/structs.c
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
+ * PURPOSE:     Kernel-Mode Test Suite Struct alignment tests
+ * COPYRIGHT:   Copyright 2018 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#include <kmt_test.h>
+
+// When searching for the correct offset,
+// this will generate a compile-time error including the offset:
+// char (*__kaboom1)[FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.EaLength)] = 1;
+// Taken from https://stackoverflow.com/a/35261673
+
+#if !defined(_AMD64_)
+
+C_ASSERT(sizeof(IO_STACK_LOCATION) == 36);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, MajorFunction) == 0);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, MinorFunction) == 1);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Flags) == 2);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Control) == 3);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.SecurityContext) == 4);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.Options) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.FileAttributes) == 12);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.ShareAccess) == 14);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.EaLength) == 16);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.WhichSpace) == 4);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Buffer) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Offset) == 12);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Length) == 16);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.Length) == 4);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.FileInformationClass) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.FileObject) == 12);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.ReplaceIfExists) == 16);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.AdvanceOnly) == 17);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.ClusterCount) == 16);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.DeleteHandle) == 16);
+
+#else
+
+C_ASSERT(sizeof(IO_STACK_LOCATION) == 72);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, MajorFunction) == 0);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, MinorFunction) == 1);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Flags) == 2);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Control) == 3);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.SecurityContext) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.Options) == 16);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.FileAttributes) == 24);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.ShareAccess) == 26);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.Create.EaLength) == 32);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.WhichSpace) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Buffer) == 16);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Offset) == 24);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.ReadWriteConfig.Length) == 32);
+
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.Length) == 8);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.FileInformationClass) == 16);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.FileObject) == 24);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.ReplaceIfExists) == 32);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.AdvanceOnly) == 33);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.ClusterCount) == 32);
+C_ASSERT(FIELD_OFFSET(IO_STACK_LOCATION, Parameters.SetFile.DeleteHandle) == 32);
+
+#endif

--- a/sdk/include/xdk/iotypes.h
+++ b/sdk/include/xdk/iotypes.h
@@ -2746,6 +2746,10 @@ typedef struct _ACPI_INTERFACE_STANDARD2 {
   PUNREGISTER_FOR_DEVICE_NOTIFICATIONS2 UnregisterForDeviceNotifications;
 } ACPI_INTERFACE_STANDARD2, *PACPI_INTERFACE_STANDARD2;
 
+#if !defined(_AMD64_) && !defined(_ARM_)
+#include <pshpack4.h>
+#endif
+
 typedef struct _IO_STACK_LOCATION {
   UCHAR MajorFunction;
   UCHAR MinorFunction;
@@ -2953,6 +2957,11 @@ typedef struct _IO_STACK_LOCATION {
   PIO_COMPLETION_ROUTINE CompletionRoutine;
   PVOID Context;
 } IO_STACK_LOCATION, *PIO_STACK_LOCATION;
+
+#if !defined(_AMD64_) && !defined(_ARM_)
+#include "poppack.h"
+#endif
+
 
 /* IO_STACK_LOCATION.Control */
 


### PR DESCRIPTION
Got broken with #516

Hopefully fixes stuff like:

JIRA issue: [CORE-14782](https://jira.reactos.org/browse/CORE-14782)

C_ASSERTS created in a winddk v 3790.1830 environment.
