### PR TITLE
CORE-10782 [EXPLORER] Fix creation of shortcuts in the start menu.

### DIFF
--- a/base/shell/explorer/startmnucust.cpp
+++ b/base/shell/explorer/startmnucust.cpp
@@ -26,7 +26,7 @@ VOID OnAddStartMenuItems(HWND hDlg)
 {
     WCHAR szPath[MAX_PATH];
 
-    if (SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_STARTMENU, NULL, 0, szPath)))
+    if (SUCCEEDED(SHGetFolderPathW(NULL, CSIDL_PROGRAMS, NULL, 0, szPath)))
     {
         WCHAR szCommand[MAX_PATH] = L"appwiz.cpl,NewLinkHere ";
         if (SUCCEEDED(StringCchCatW(szCommand, _countof(szCommand), szPath)))


### PR DESCRIPTION
## Purpose

Right now, the create shortcut dialog drops custom shortcuts in the Start Menu folder. This places the shortcuts in the favorites portion of the start menu. This commit fixes it so the shortcut is dropped into the Start Menu\Programs folder like expected.

![virtualbox_reactos_22_07_2018_11_00_26](https://user-images.githubusercontent.com/15203817/43047617-afa24286-8d9f-11e8-8a82-ddfbc5ddd875.png)


JIRA issue: [CORE-10782](https://jira.reactos.org/browse/CORE-10782)
