### PR TITLE
[SHELLTEXT][COVERITY] Fix a suspecting buffer overflow

### DIFF
--- a/dll/shellext/shellbtrfs/devices.cpp
+++ b/dll/shellext/shellbtrfs/devices.cpp
@@ -907,7 +907,11 @@ static INT_PTR CALLBACK stub_DeviceResizeDlgProc(HWND hwndDlg, UINT uMsg, WPARAM
 
 void BtrfsDeviceResize::ShowDialog(HWND hwnd, WCHAR* fn, UINT64 dev_id) {
     this->dev_id = dev_id;
+#ifdef __REACTOS__
+    wcscpy_s(this->fn, _countof(this->fn), fn);
+#else
     wcscpy(this->fn, fn);
+#endif
 
     DialogBoxParamW(module, MAKEINTRESOURCEW(IDD_RESIZE), hwnd, stub_DeviceResizeDlgProc, (LPARAM)this);
 }


### PR DESCRIPTION
## Purpose
Originally from [PR ~97](https://github.com/maharmstone/btrfs/pull/97). The owner did not seem to accept the commit because from his viewpoint, `wcscpy_s` is a kind of hack. Seriously this does not make any sense and I had no choice but moving the patch here.
## Proposed Changes
Copying the data from the source to the destination without doing any sanity check of the data size is not recommended and that could lead to the classic buffer overflow. The patch should fix Coverity issue, **CID 1419452**.