### PR TITLE
[WIN32SS][FONT] Add 5 members to FONTGDI structure

### DIFF
--- a/win32ss/gdi/eng/engobjects.h
+++ b/win32ss/gdi/eng/engobjects.h
@@ -153,6 +153,13 @@ typedef struct _FONTGDI {
   BYTE          OriginalItalic;
   LONG          OriginalWeight;
   BYTE          CharSet;
+
+  /* Precomputed font metrics (supplements FreeType metrics) */
+  LONG          tmHeight;
+  LONG          tmAscent;
+  LONG          tmDescent;
+  LONG          tmInternalLeading;
+  LONG          EmHeight;
 } FONTGDI, *PFONTGDI;
 
 typedef struct _PATHGDI {


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-11536](https://jira.reactos.org/browse/CORE-11536)
This PR will add 5 members to FONTGDI structure.
They are the precomputed font metrics (not used yet).
Retrial of #706.