### PR TITLE
[WIN32SS][FONT] Fix font metrics (retry)

### DIFF
--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -3,7 +3,6 @@
  *
  * Copyright 2006 - 2007 Thomas Weidenmueller <w3seek@reactos.org>
  * Copyright 2018 Ged Murphy <gedmurphy@reactos.org>
- * Copyright 2018 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -3,6 +3,7 @@
  *
  * Copyright 2006 - 2007 Thomas Weidenmueller <w3seek@reactos.org>
  * Copyright 2018 Ged Murphy <gedmurphy@reactos.org>
+ * Copyright 2018 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -534,7 +535,7 @@ LRESULT CTrayClockWnd::OnPaint(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
 
         hPrevFont = (HFONT) SelectObject(hDC, hFont);
 
-        rcClient.top = (rcClient.bottom / 2) - (CurrentSize.cy / 2);
+        rcClient.top = (rcClient.bottom - CurrentSize.cy) / 2;
         rcClient.bottom = rcClient.top + CurrentSize.cy;
 
         for (i = 0, line = 0;

--- a/win32ss/gdi/eng/engobjects.h
+++ b/win32ss/gdi/eng/engobjects.h
@@ -163,6 +163,9 @@ typedef struct _FONTGDI {
   LONG          Magic;
 } FONTGDI, *PFONTGDI;
 
+/* The initialized 'Magic' value in FONTGDI */
+#define FONTGDI_MAGIC   0x20110311
+
 typedef struct _PATHGDI {
   PATHOBJ PathObj;
 } PATHGDI;

--- a/win32ss/gdi/eng/engobjects.h
+++ b/win32ss/gdi/eng/engobjects.h
@@ -160,6 +160,7 @@ typedef struct _FONTGDI {
   LONG          tmDescent;
   LONG          tmInternalLeading;
   LONG          EmHeight;
+  LONG          Magic;
 } FONTGDI, *PFONTGDI;
 
 typedef struct _PATHGDI {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -41,6 +41,9 @@
     #define _TMPF_VARIABLE_PITCH    TMPF_FIXED_PITCH
 #endif
 
+/* the initialized 'Magic' value in FONTGDI */
+#define FONTGDI_MAGIC   0xBAD3DCAD
+
 extern const MATRIX gmxWorldToDeviceDefault;
 extern const MATRIX gmxWorldToPageDefault;
 
@@ -1572,7 +1575,7 @@ FillTMEx(TEXTMETRICW *TM, PFONTGDI FontGDI,
         Descent = pOS2->usWinDescent;
     }
 
-    if (FontGDI->Magic != 0xDEADBEEF)
+    if (FontGDI->Magic != FONTGDI_MAGIC)
     {
         IntRequestFontSize(NULL, FontGDI, 0, 0);
     }
@@ -3043,7 +3046,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->EmHeight           = FontGDI->tmHeight - FontGDI->tmInternalLeading;
         FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
         FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
-        FontGDI->Magic = 0xDEADBEEF;
+        FontGDI->Magic = FONTGDI_MAGIC;
 
         req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
         req.width          = 0;
@@ -3086,7 +3089,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     FontGDI->EmHeight = FontGDI->tmHeight - FontGDI->tmInternalLeading;
     FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
     FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
-    FontGDI->Magic = 0xDEADBEEF;
+    FontGDI->Magic = FONTGDI_MAGIC;
 
     if (lfHeight > 0)
         EmHeight64 = (FontGDI->EmHeight << 6) + 31;
@@ -3772,7 +3775,7 @@ TextIntGetTextExtentPoint(PDC dc,
         previous = glyph_index;
         String++;
     }
-    ASSERT(FontGDI->Magic == 0xDEADBEEF);
+    ASSERT(FontGDI->Magic == FONTGDI_MAGIC);
     ascender = FontGDI->tmAscent; /* Units above baseline */
     descender = FontGDI->tmDescent; /* Units below baseline */
     IntUnLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3012,6 +3012,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         lfHeight = 13;
     }
 
+    ASSERT_FREETYPE_LOCK_HELD();
     pOS2 = (TT_OS2 *)FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
     pHori = (TT_HoriHeader *)FT_Get_Sfnt_Table(face, FT_SFNT_HHEA);
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3014,7 +3014,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     {
         if (lfWidth == 0)
         {
-            DPRINT1("lfHeight and lfWidth are zero.");
+            DPRINT("lfHeight and lfWidth are zero.\n");
             lfHeight = -16;
         }
         else

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5353,8 +5353,8 @@ GreExtTextOutW(
         pmxWorldToDevice = DC_pmxWorldToDevice(dc);
         FtSetCoordinateTransform(face, pmxWorldToDevice);
 
-        fixAscender = ScaleLong(FontGDI->tmAscent << 6, &pmxWorldToDevice->efM22);
-        fixDescender = ScaleLong(FontGDI->tmDescent << 6, &pmxWorldToDevice->efM22);
+        fixAscender = ScaleLong(FontGDI->tmAscent, &pmxWorldToDevice->efM22) << 6;
+        fixDescender = ScaleLong(FontGDI->tmDescent, &pmxWorldToDevice->efM22) << 6;
     }
     else
     {
@@ -5369,10 +5369,10 @@ GreExtTextOutW(
      * Process the vertical alignment and determine the yoff.
      */
 
-    if (pdcattr->lTextAlign & TA_BASELINE)
+    if ((pdcattr->lTextAlign & TA_MASK) == TA_BASELINE)
         yoff = 0;
-    else if (pdcattr->lTextAlign & TA_BOTTOM)
-        yoff = -(fixDescender >> 6);
+    else if ((pdcattr->lTextAlign & TA_MASK) == TA_BOTTOM)
+        yoff = -fixDescender >> 6;
     else /* TA_TOP */
         yoff = fixAscender >> 6;
 
@@ -5550,8 +5550,8 @@ GreExtTextOutW(
 
             DestRect.left = BackgroundLeft;
             DestRect.right = (TextLeft + (realglyph->root.advance.x >> 10) + 32) >> 6;
-            DestRect.top = TextTop;
-            DestRect.bottom = TextTop + ((fixAscender + fixDescender) >> 6);
+            DestRect.top = TextTop + yoff - ((fixAscender + 32) >> 6);
+            DestRect.bottom = DestRect.top + ((fixAscender + fixDescender) >> 6);
             MouseSafetyOnDrawStart(dc->ppdev, DestRect.left, DestRect.top, DestRect.right, DestRect.bottom);
             if (dc->fs & (DC_ACCUM_APP|DC_ACCUM_WMGR))
             {
@@ -5690,8 +5690,8 @@ GreExtTextOutW(
         {
             DestRect.left = BackgroundLeft;
             DestRect.right = (TextLeft + (realglyph->root.advance.x >> 10) + 32) >> 6;
-            DestRect.top = TextTop;
-            DestRect.bottom = TextTop + ((fixAscender + fixDescender) >> 6);
+            DestRect.top = TextTop + yoff - ((fixAscender + 32) >> 6);;
+            DestRect.bottom = DestRect.top + ((fixAscender + fixDescender) >> 6);
 
             if (dc->dctype == DCTYPE_DIRECT)
                 MouseSafetyOnDrawStart(dc->ppdev, DestRect.left, DestRect.top, DestRect.right, DestRect.bottom);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4456,6 +4456,13 @@ FindBestFontFromList(FONTOBJ **FontObj, ULONG *MatchPenalty,
         ASSERT(FontGDI);
         Face = FontGDI->SharedFace->Face;
 
+        if (FontGDI->Magic != 0xDEADBEEF)
+        {
+            IntLockFreeType();
+            IntRequestFontSize(NULL, FontGDI, LogFont->lfWidth, LogFont->lfHeight);
+            IntUnLockFreeType();
+        }
+
         /* get text metrics */
         OtmSize = IntGetOutlineTextMetrics(FontGDI, 0, NULL);
         if (OtmSize > OldOtmSize)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3023,7 +3023,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->tmAscent           = WinFNT.ascent;
         FontGDI->tmDescent          = FontGDI->tmHeight - FontGDI->tmAscent;
         FontGDI->tmInternalLeading  = WinFNT.internal_leading;
-        FontGDI->EmHeight           = FontGDI->tmAscent - FontGDI->tmInternalLeading;
+        FontGDI->EmHeight           = FontGDI->tmHeight - FontGDI->tmInternalLeading;
         FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
         FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5332,20 +5332,23 @@ GreExtTextOutW(
         goto Cleanup;
     }
 
+    /* NOTE: Don't trust face->size->metrics.ascender and descender values. */
     if (dc->pdcattr->iGraphicsMode == GM_ADVANCED)
     {
         pmxWorldToDevice = DC_pmxWorldToDevice(dc);
         FtSetCoordinateTransform(face, pmxWorldToDevice);
+
+        fixAscender = ScaleLong(FontGDI->tmAscent << 6, &pmxWorldToDevice->efM22); 
+        fixDescender = ScaleLong(FontGDI->tmDescent << 6, &pmxWorldToDevice->efM22);
     }
     else
     {
         pmxWorldToDevice = (PMATRIX)&gmxWorldToDeviceDefault;
         FtSetCoordinateTransform(face, pmxWorldToDevice);
-    }
 
-    /* NOTE: Don't trust face->size->metrics.ascender and descender values. */
-    fixAscender = FontGDI->tmAscent << 6;
-    fixDescender = FontGDI->tmDescent << 6;
+        fixAscender = FontGDI->tmAscent << 6;
+        fixDescender = FontGDI->tmDescent << 6;
+    }
 
     /*
      * Process the vertical alignment and determine the yoff.

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3023,6 +3023,9 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         }
     }
 
+    if (lfHeight == -1)
+        lfHeight = -2;
+
     ASSERT_FREETYPE_LOCK_HELD();
     pOS2 = (TT_OS2 *)FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
     pHori = (TT_HoriHeader *)FT_Get_Sfnt_Table(face, FT_SFNT_HHEA);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5340,7 +5340,7 @@ GreExtTextOutW(
         pmxWorldToDevice = DC_pmxWorldToDevice(dc);
         FtSetCoordinateTransform(face, pmxWorldToDevice);
 
-        fixAscender = ScaleLong(FontGDI->tmAscent << 6, &pmxWorldToDevice->efM22); 
+        fixAscender = ScaleLong(FontGDI->tmAscent << 6, &pmxWorldToDevice->efM22);
         fixDescender = ScaleLong(FontGDI->tmDescent << 6, &pmxWorldToDevice->efM22);
     }
     else

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3002,11 +3002,10 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     lfWidth = abs(lfWidth);
     if (lfHeight == 0)
     {
-        lfHeight = lfWidth;
-    }
-    if (lfHeight == 0)
-    {
-        lfHeight = -16;
+        if (lfWidth != 0)
+            lfHeight = lfWidth;
+        else
+            lfHeight = -16;
     }
 
     ASSERT_FREETYPE_LOCK_HELD();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3006,7 +3006,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     }
     if (lfHeight == 0)
     {
-        lfHeight = 13;
+        lfHeight = -16;
     }
 
     ASSERT_FREETYPE_LOCK_HELD();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2999,10 +2999,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     FT_WinFNT_HeaderRec WinFNT;
     LONG Ascent, Descent, Sum, EmHeight64;
 
-    if (lfWidth < 0)
-    {
-        lfWidth = -lfWidth;
-    }
+    lfWidth = abs(lfWidth);
     if (lfHeight == 0)
     {
         lfHeight = lfWidth;
@@ -3027,10 +3024,8 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->tmDescent          = FontGDI->tmHeight - FontGDI->tmAscent;
         FontGDI->tmInternalLeading  = WinFNT.internal_leading;
         FontGDI->EmHeight           = FontGDI->tmAscent - FontGDI->tmInternalLeading;
-        if (FontGDI->EmHeight <= 0)
-            FontGDI->EmHeight = 1;
-        if (FontGDI->EmHeight > USHORT_MAX)
-            FontGDI->EmHeight = USHORT_MAX;
+        FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
+        FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
 
         req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
         req.width          = 0;
@@ -3072,10 +3067,8 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->EmHeight = FontGDI->tmHeight - FontGDI->tmInternalLeading;
     }
 
-    if (FontGDI->EmHeight <= 0)
-        FontGDI->EmHeight = 1;
-    if (FontGDI->EmHeight > USHORT_MAX)
-        FontGDI->EmHeight = USHORT_MAX;
+    FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
+    FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
 
     if (lfHeight > 0)
         EmHeight64 = (FontGDI->EmHeight << 6) + 31;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3278,7 +3278,7 @@ ftGdiGetGlyphOutline(
 
     IntLockFreeType();
 
-    /* Scaling transform */
+    /* Width scaling transform */
     if (widthRatio != 1.0)
     {
         FT_Matrix scaleMat;
@@ -3291,6 +3291,7 @@ ftGdiGetGlyphOutline(
         needsTransform = TRUE;
     }
 
+    /* World transform */
     {
         FT_Matrix ftmatrix;
         FLOATOBJ efTemp;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5691,7 +5691,7 @@ GreExtTextOutW(
         {
             DestRect.left = BackgroundLeft;
             DestRect.right = (TextLeft + (realglyph->root.advance.x >> 10) + 32) >> 6;
-            DestRect.top = TextTop + yoff - ((fixAscender + 32) >> 6);;
+            DestRect.top = TextTop + yoff - ((fixAscender + 32) >> 6);
             DestRect.bottom = DestRect.top + ((fixAscender + fixDescender) >> 6);
 
             if (dc->dctype == DCTYPE_DIRECT)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1566,6 +1566,7 @@ FillTMEx(TEXTMETRICW *TM, PFONTGDI FontGDI,
         Descent = pOS2->usWinDescent;
     }
 
+    ASSERT(FontGDI->Magic == 0xDEADBEEF);
     TM->tmAscent = FontGDI->tmAscent;
     TM->tmDescent = FontGDI->tmDescent;
     TM->tmHeight = TM->tmAscent + TM->tmDescent;
@@ -3025,6 +3026,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->EmHeight           = FontGDI->tmHeight - FontGDI->tmInternalLeading;
         FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
         FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
+        FontGDI->Magic = 0xDEADBEEF;
 
         req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
         req.width          = 0;
@@ -3054,7 +3056,6 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->tmDescent = FT_MulDiv(lfHeight, Descent, Sum);
         FontGDI->tmHeight = FontGDI->tmAscent + FontGDI->tmDescent;
         FontGDI->tmInternalLeading = FontGDI->tmHeight - FT_MulDiv(lfHeight, face->units_per_EM, Sum);
-        FontGDI->EmHeight = FontGDI->tmHeight - FontGDI->tmInternalLeading;
     }
     else if (lfHeight < 0)
     {
@@ -3063,11 +3064,12 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         FontGDI->tmDescent = FT_MulDiv(-lfHeight, pOS2->usWinDescent, face->units_per_EM);
         FontGDI->tmHeight = FontGDI->tmAscent + FontGDI->tmDescent;
         FontGDI->tmInternalLeading = FontGDI->tmHeight + lfHeight;
-        FontGDI->EmHeight = FontGDI->tmHeight - FontGDI->tmInternalLeading;
     }
 
+    FontGDI->EmHeight = FontGDI->tmHeight - FontGDI->tmInternalLeading;
     FontGDI->EmHeight = max(FontGDI->EmHeight, 1);
     FontGDI->EmHeight = min(FontGDI->EmHeight, USHORT_MAX);
+    FontGDI->Magic = 0xDEADBEEF;
 
     if (lfHeight > 0)
         EmHeight64 = (FontGDI->EmHeight << 6) + 31;
@@ -3752,6 +3754,7 @@ TextIntGetTextExtentPoint(PDC dc,
         previous = glyph_index;
         String++;
     }
+    ASSERT(FontGDI->Magic == 0xDEADBEEF);
     ascender = FontGDI->tmAscent; /* Units above baseline */
     descender = FontGDI->tmDescent; /* Units below baseline */
     IntUnLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4114,7 +4114,6 @@ GetFontPenalty(const LOGFONTW *               LogFont,
     ASSERT(Otm);
     ASSERT(LogFont);
 
-    /* FIXME: Aspect Penalty 30 */
     /* FIXME: IntSizeSynth Penalty 20 */
     /* FIXME: SmallPenalty Penalty 1 */
     /* FIXME: FaceNameSubst Penalty 500 */
@@ -4455,13 +4454,15 @@ GetFontPenalty(const LOGFONTW *               LogFont,
     {
         if (TM->tmAveCharWidth / TM->tmHeight >= 3)
         {
+            /* Aspect Penalty 30 */
             /* The aspect rate is >= 3. It seems like a bad font. */
-            Penalty += ((TM->tmAveCharWidth / TM->tmHeight) - 2) * 100;
+            Penalty += ((TM->tmAveCharWidth / TM->tmHeight) - 2) * 30;
         }
         else if (TM->tmHeight / TM->tmAveCharWidth >= 3)
         {
+            /* Aspect Penalty 30 */
             /* The aspect rate is >= 3. It seems like a bad font. */
-            Penalty += ((TM->tmHeight / TM->tmAveCharWidth) - 2) * 100;
+            Penalty += ((TM->tmHeight / TM->tmAveCharWidth) - 2) * 30;
         }
     }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4646,11 +4646,16 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
     }
     else
     {
+        UNICODE_STRING FaceName;
         PFONTGDI FontGdi = ObjToGDI(TextObj->Font, FONT);
 
         IntLockFreeType();
         IntRequestFontSize(NULL, FontGdi, pLogFont->lfWidth, pLogFont->lfHeight);
         IntUnLockFreeType();
+
+        RtlInitUnicodeString(&FaceName, NULL);
+        IntGetFontLocalizedName(&FaceName, FontGdi->SharedFace, TT_NAME_ID_FONT_FAMILY, gusLanguageID);
+        wcscpy(TextObj->FaceName, FaceName.Buffer);
 
         // Need hdev, when freetype is loaded need to create DEVOBJ for
         // Consumer and Producer.

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5368,13 +5368,14 @@ GreExtTextOutW(
     /*
      * Process the vertical alignment and determine the yoff.
      */
-
-    if ((pdcattr->lTextAlign & TA_MASK) == TA_BASELINE)
+#define VALIGN_MASK  (TA_TOP | TA_BASELINE | TA_BOTTOM)
+    if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BASELINE)
         yoff = 0;
-    else if ((pdcattr->lTextAlign & TA_MASK) == TA_BOTTOM)
+    else if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BOTTOM)
         yoff = -fixDescender >> 6;
     else /* TA_TOP */
         yoff = fixAscender >> 6;
+#undef VALIGN_MASK
 
     use_kerning = FT_HAS_KERNING(face);
     previous = 0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -41,9 +41,6 @@
     #define _TMPF_VARIABLE_PITCH    TMPF_FIXED_PITCH
 #endif
 
-/* the initialized 'Magic' value in FONTGDI */
-#define FONTGDI_MAGIC   0xBAD3DCAD
-
 extern const MATRIX gmxWorldToDeviceDefault;
 extern const MATRIX gmxWorldToPageDefault;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4655,7 +4655,13 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
 
         RtlInitUnicodeString(&FaceName, NULL);
         IntGetFontLocalizedName(&FaceName, FontGdi->SharedFace, TT_NAME_ID_FONT_FAMILY, gusLanguageID);
-        wcscpy(TextObj->FaceName, FaceName.Buffer);
+
+        /* truncated copy */
+        FaceName.Length = (USHORT)min(FaceName.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
+        FaceName.MaximumLength = (USHORT)(FaceName.Length + sizeof(UNICODE_NULL));
+        RtlCopyMemory(TextObj->FaceName, FaceName.Buffer, FaceName.MaximumLength);
+
+        RtlFreeUnicodeString(&FaceName);
 
         // Need hdev, when freetype is loaded need to create DEVOBJ for
         // Consumer and Producer.

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3003,10 +3003,15 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     lfWidth = abs(lfWidth);
     if (lfHeight == 0)
     {
-        if (lfWidth != 0)
-            lfHeight = lfWidth;
-        else
+        if (lfWidth == 0)
+        {
+            DPRINT1("lfHeight and lfWidth are zero.");
             lfHeight = -16;
+        }
+        else
+        {
+            lfHeight = lfWidth;
+        }
     }
 
     ASSERT_FREETYPE_LOCK_HELD();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5439,7 +5439,7 @@ GreExtTextOutW(
     if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BASELINE)
         yoff = 0;
     else if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BOTTOM)
-        yoff = -fixDescender >> 6;
+        yoff = -(fixDescender >> 6);
     else /* TA_TOP */
         yoff = fixAscender >> 6;
 #undef VALIGN_MASK

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -513,12 +513,12 @@ NtGdiGetTextFaceW(
 
     TextObj = RealizeFontInit(hFont);
     ASSERT(TextObj != NULL);
-    fLen = wcslen(TextObj->logfont.elfEnumLogfontEx.elfLogFont.lfFaceName) + 1;
+    fLen = wcslen(TextObj->FaceName) + 1;
 
     if (FaceName != NULL)
     {
         Count = min(Count, fLen);
-        Status = MmCopyToCaller(FaceName, TextObj->logfont.elfEnumLogfontEx.elfLogFont.lfFaceName, Count * sizeof(WCHAR));
+        Status = MmCopyToCaller(FaceName, TextObj->FaceName, Count * sizeof(WCHAR));
         if (!NT_SUCCESS(Status))
         {
             TEXTOBJ_UnlockText(TextObj);

--- a/win32ss/user/ntuser/draw.c
+++ b/win32ss/user/ntuser/draw.c
@@ -814,6 +814,7 @@ BOOL FASTCALL UITOOLS95_DrawFrameCaption(HDC dc, LPRECT r, UINT uFlags)
     lf.lfWidth = 0;
     lf.lfWeight = FW_NORMAL;
     lf.lfCharSet = DEFAULT_CHARSET;
+    lf.lfQuality = NONANTIALIASED_QUALITY;
     RtlCopyMemory(lf.lfFaceName, L"Marlett", sizeof(L"Marlett"));
     hFont = GreCreateFontIndirectW(&lf);
     /* save font and text color */

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -3,10 +3,7 @@
  * PROJECT:          ReactOS Win32k subsystem
  * PURPOSE:          Miscellaneous User functions
  * FILE:             win32ss/user/ntuser/nonclient.c
- * PROGRAMERS:       Colin Finck <colin@reactos.org>
- *                   Thomas Faber <thomas.faber@reactos.org>
- *                   Timo Kreuzer <timo.kreuzer@reactos.org>
- *                   Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * PROGRAMER:
  */
 
 #include <win32k.h>
@@ -708,8 +705,8 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
              TempRect.right -= UserGetSystemMetrics(SM_CXSIZE) - 2;
 
          TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE) + 1;
-         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
-         TempRect.top += 1;
+         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
+         TempRect.top += 2;
          TempRect.right -= 1;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
@@ -727,8 +724,8 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
              TempRect.right -= UserGetSystemMetrics(SM_CXSIZE) + 1;
 
          TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE) + 1;
-         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
-         TempRect.top += 1;
+         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
+         TempRect.top += 2;
          TempRect.right -= 1;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
@@ -746,15 +743,15 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
          if (ExStyle & WS_EX_TOOLWINDOW)
          {
             TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSMSIZE);
-            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSMSIZE) - 1;
+            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSMSIZE) - 2;
          }
          else
          {
             TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE);
-            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
+            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
          }
-         TempRect.top += 1;
-         TempRect.right -= 1;
+         TempRect.top += 2;
+         TempRect.right -= 2;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
                           (DFCS_CAPTIONCLOSE | (bDown ? DFCS_PUSHED : 0) |

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -3,7 +3,10 @@
  * PROJECT:          ReactOS Win32k subsystem
  * PURPOSE:          Miscellaneous User functions
  * FILE:             win32ss/user/ntuser/nonclient.c
- * PROGRAMER:
+ * PROGRAMERS:       Colin Finck <colin@reactos.org>
+ *                   Thomas Faber <thomas.faber@reactos.org>
+ *                   Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                   Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include <win32k.h>
@@ -705,8 +708,8 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
              TempRect.right -= UserGetSystemMetrics(SM_CXSIZE) - 2;
 
          TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE) + 1;
-         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
-         TempRect.top += 2;
+         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
+         TempRect.top += 1;
          TempRect.right -= 1;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
@@ -724,8 +727,8 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
              TempRect.right -= UserGetSystemMetrics(SM_CXSIZE) + 1;
 
          TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE) + 1;
-         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
-         TempRect.top += 2;
+         TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
+         TempRect.top += 1;
          TempRect.right -= 1;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
@@ -743,15 +746,15 @@ UserDrawCaptionButton(PWND pWnd, LPRECT Rect, DWORD Style, DWORD ExStyle, HDC hD
          if (ExStyle & WS_EX_TOOLWINDOW)
          {
             TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSMSIZE);
-            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSMSIZE) - 2;
+            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSMSIZE) - 1;
          }
          else
          {
             TempRect.left = TempRect.right - UserGetSystemMetrics(SM_CXSIZE);
-            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 2;
+            TempRect.bottom = TempRect.top + UserGetSystemMetrics(SM_CYSIZE) - 1;
          }
-         TempRect.top += 2;
-         TempRect.right -= 2;
+         TempRect.top += 1;
+         TempRect.right -= 1;
 
          DrawFrameControl(hDC, &TempRect, DFC_CAPTION,
                           (DFCS_CAPTIONCLOSE | (bDown ? DFCS_PUSHED : 0) |

--- a/win32ss/user/ntuser/painting.c
+++ b/win32ss/user/ntuser/painting.c
@@ -2147,7 +2147,7 @@ UserDrawCaptionText(
    {  // Faster while in setup.
       GreExtTextOutW( hDc,
                       lpRc->left,
-                      lpRc->top + (lpRc->bottom - lpRc->top) / 2 - Size.cy / 2, // DT_SINGLELINE && DT_VCENTER
+                      lpRc->top + (lpRc->bottom - lpRc->top - Size.cy) / 2, // DT_SINGLELINE && DT_VCENTER
                       ETO_CLIPPED,
                      (RECTL *)lpRc,
                       Text->Buffer,

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -20,7 +20,8 @@
  * PROJECT:         ReactOS user32.dll
  * FILE:            win32ss/user/rtl/text.c
  * PURPOSE:         Draw Text
- * PROGRAMMER:      Casper S. Hornstrup (chorns@users.sourceforge.net)
+ * PROGRAMMERS:     Casper S. Hornstrup (chorns@users.sourceforge.net)
+ *                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  * UPDATE HISTORY:
  *      09-05-2001  CSH  Created
  */
@@ -1157,8 +1158,10 @@ INT WINAPI DrawTextExWorker( HDC hdc,
                 }
                 else
                 {
-#endif
+                    y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
+#else
                     y = rect->top + (rect->bottom - rect->top) / 2 + (invert_y ? (size.cy / 2) : (-size.cy / 2));
+#endif
 #ifdef __REACTOS__
                 }
             }

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -20,8 +20,7 @@
  * PROJECT:         ReactOS user32.dll
  * FILE:            win32ss/user/rtl/text.c
  * PURPOSE:         Draw Text
- * PROGRAMMERS:     Casper S. Hornstrup (chorns@users.sourceforge.net)
- *                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * PROGRAMMER:      Casper S. Hornstrup (chorns@users.sourceforge.net)
  * UPDATE HISTORY:
  *      09-05-2001  CSH  Created
  */


### PR DESCRIPTION
## Purpose
This PR aims to fix the font metrics.
JIRA issue: [CORE-11536](https://jira.reactos.org/browse/CORE-11536)
Retrial of #706.

[V] FIXED: Total Commander 8.52 setup: font displayed too large
https://jira.reactos.org/browse/CORE-11620

[V] FIXED: CORE-14378: Effective File Search 6.8.1 german localization text rendering issues
https://jira.reactos.org/browse/CORE-14378

[V] FIXED: CORE-9767: Font garbage in register splash screen in Foxit Reader 7.1.5
https://jira.reactos.org/browse/CORE-9767

[V] FIXED: Calipers-1 is not displayed correctly.
https://jira.reactos.org/browse/CORE-14302

[V] FIXED: some msi-Installers draw their dialogs too large (example: Click-N-Type Virtual Keyboard 3.03.0412)
https://jira.reactos.org/browse/CORE-13161

[V] FIXED: Irfanview 4.50 font in zoom combobox displayed too large
https://jira.reactos.org/browse/CORE-14396

[V] FIXED: rufus - The window and controls are displayed larger than necessary
https://jira.reactos.org/browse/CORE-14461

## TODOs
- [x] Fix the problem that the line is too tall.
- [x] Fix the 1-pixel-lower problem.
- [ ] Fix the small text in Age of Empires.