### PR TITLE
[BOOTDATA] Change the default open command for HTA files

### DIFF
--- a/boot/bootdata/hivecls.inf
+++ b/boot/bootdata/hivecls.inf
@@ -220,7 +220,9 @@ HKCR,"chm.file\shell\open\command","",0x00020000,"%SystemRoot%\hh.exe %1"
 HKCR,".hta","",0x00000000,"htafile"
 HKCR,"htafile","",0x00000000,"HTML Application"
 HKCR,"htafile\DefaultIcon","",0x00020000,"%SystemRoot%\system32\mshta.exe,-1"
-HKCR,"htafile\shell\open\command","",0x00020000,"%SystemRoot%\system32\mshta.exe ""%1"" %*"
+; HKCR,"htafile\shell\open\command","",0x00020000,"%SystemRoot%\system32\mshta.exe ""%1"" %*"
+HKCR,"htafile\shell\edit\command","",0x00020000,"%SystemRoot%\system32\notepad.exe %1"
+HKCR,"htafile\shell\open\command","",0x00020000,"""%ProgramFiles%\Internet Explorer\iexplore.exe"" %1"
 
 ; set MIME type for .html and .htm because Tiny webserver needs it
 HKCR,".htm","",0x00000000,"htmlfile"


### PR DESCRIPTION
Change the open command for hta files so it opens up in Wine Internet Explorer. It's not the proper way to do it but it works for noww=. Also add an edit option to the right click menu.