### PR TITLE
[MSCONFIG] Make it possible to enable or disable AUTOCHK (auto check)

### DIFF
--- a/base/applications/msconfig/CMakeLists.txt
+++ b/base/applications/msconfig/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 list(APPEND SOURCE
+    autochkpage.c
     toolspage.c
     srvpage.c
     systempage.c

--- a/base/applications/msconfig/autochkpage.c
+++ b/base/applications/msconfig/autochkpage.c
@@ -1,0 +1,288 @@
+/*
+ * PROJECT:     ReactOS Applications
+ * LICENSE:     LGPL - See COPYING in the top level directory
+ * PURPOSE:     Auto Check (autochk) page handler
+ * COPYRIGHT:   Copyright 2018 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "precomp.h"
+#include "resource.h"
+#include "autochkpage.h"
+
+/* VARIABLES *******************************************************************/
+
+HWND hAutoChkPage;
+HWND hAutoChkDialog;
+WCHAR SubKey[] = L"SYSTEM\\CurrentControlSet\\Control\\Session Manager";
+WCHAR ValueName[] = L"BootExecute";
+WCHAR EnableValue[] = L"autocheck autochk *\0";
+
+/* FUNCTIONS *******************************************************************/
+
+INT_PTR CALLBACK
+AutoChkPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    HKEY hKey;
+    LONG lResult;
+    WCHAR szValueData[255];
+    DWORD dwcbData = sizeof(szValueData);
+    DWORD dwBufferSize = 0;
+    LPWSTR lpszzMultiString = NULL;
+    size_t size;
+    LPWSTR ptr;
+    DWORD dwType;
+    PWCHAR pszOldValue;
+    DWORD cbData;
+
+    UNREFERENCED_PARAMETER(lParam);
+  
+    switch (message)
+    {
+        case WM_INITDIALOG:
+        {
+            SetWindowPos(hDlg, NULL, 10, 32, 0, 0, SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE | SWP_NOZORDER);
+
+            // Open the key so we can query it
+            lResult = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                                   SubKey,
+                                   0,
+                                   KEY_READ,
+                                   &hKey);
+
+            if (lResult != ERROR_SUCCESS)
+            {
+                // We failed
+                return FALSE;
+            }
+
+            lResult = RegQueryValueExW(hKey,
+                                       ValueName,
+                                       NULL,
+                                       NULL,
+                                       (LPBYTE)szValueData,
+                                       &dwcbData);
+
+            RegCloseKey(hKey);
+
+            if (lResult != ERROR_SUCCESS)
+            {
+                // We failed
+                return FALSE;
+            }
+
+            // Check the array if it's empty
+            if (szValueData[0] == L'\0')
+            {
+                // If the array is empty, always set the Disable radio button
+                SendDlgItemMessage(hDlg, IDC_AUTOCHK_DISABLE, BM_SETCHECK, BST_CHECKED, 0);
+            }
+            else
+            {
+                // Otherwise, always set the Enable radio button
+                SendDlgItemMessage(hDlg, IDC_AUTOCHK_ENABLE, BM_SETCHECK, BST_CHECKED, 0);
+            }
+
+            return TRUE;
+        }
+
+        case WM_COMMAND:
+        {
+            switch ( LOWORD(wParam) )
+            {
+                case IDC_AUTOCHK_ENABLE:
+                {
+
+                    // Open the key so we can enable autochk
+                    lResult = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                                           SubKey,
+                                           0,
+                                           KEY_SET_VALUE,
+                                           &hKey);
+
+                    if (lResult != ERROR_SUCCESS)
+                    {
+                        // We failed (but return 0 since we're processing the message anyways)
+                        return 0;
+                    }
+
+                    lResult = RegQueryValueExW(hKey,
+                                               ValueName,
+                                               NULL,
+                                               NULL,
+                                               (LPBYTE)szValueData,
+                                               &dwcbData);
+
+                    RegCloseKey(hKey);
+
+                    if (lResult != ERROR_SUCCESS)
+                    {
+                        // We failed (but return 0 since we're processing the message anyways)
+                        return 0;
+                    }
+
+                    // Check if the array is empty
+                    if (szValueData[0] == L'\0')
+                    {
+                        // If it is, add the data contents directly
+                        lResult = RegSetValueEx(hKey,
+                                                ValueName,
+                                                0,
+                                                REG_MULTI_SZ,
+                                                (const BYTE *)EnableValue,
+                                                sizeof(EnableValue));
+
+                        RegCloseKey(hKey);
+
+                        if (lResult != ERROR_SUCCESS)
+                        {
+                            // We failed
+                            return 1;
+                        }
+                    }
+                    else
+                    {
+                        // Otherwise add the value to the existing data
+                        StringCbCopy(szValueData, sizeof(szValueData), EnableValue);
+                        pszOldValue = szValueData + wcslen(EnableValue) + 1;
+
+                        lResult = RegQueryValueExW(hKey,
+                                                  ValueName,
+                                                  NULL,
+                                                  NULL,
+                                                  (LPBYTE)pszOldValue,
+                                                  &dwcbData);
+
+                        RegCloseKey(hKey);
+
+                        if (lResult != ERROR_SUCCESS)
+                        {
+                            // Bail out
+                            return 1;
+                        }
+
+                        cbData = dwcbData + (wcslen(EnableValue) + 1) * sizeof(WCHAR);
+
+                        lResult = RegSetValueEx(hKey,
+                                                ValueName,
+                                                0,
+                                                REG_MULTI_SZ,
+                                                (const BYTE *)pszOldValue,
+                                                cbData);
+
+                        RegCloseKey(hKey);
+
+                        if (lResult != ERROR_SUCCESS)
+                        {
+                            // Bail out
+                            return 1;
+                        }
+                    }
+
+                    break;
+                }
+
+                case IDC_AUTOCHK_DISABLE:
+                {
+                    // Open the key so we can query it
+                    lResult = RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                                           SubKey,
+                                           0,
+                                           KEY_ALL_ACCESS,
+                                           &hKey);
+
+                    if (lResult != ERROR_SUCCESS)
+                    {
+                        // We failed (but return 0 since we're processing the message anyways)
+                        return 0;
+                    }
+
+                    lResult = RegQueryValueExW(hKey,
+                                               ValueName,
+                                               NULL,
+                                               &dwType,
+                                               NULL,
+                                               &dwcbData);
+
+                    if (lResult != ERROR_SUCCESS || dwType != REG_MULTI_SZ)
+                    {
+                        // Error, bail out
+                        RegCloseKey(hKey);
+                        return 1;
+                    }
+
+                    // Allocate from the heap for the variable
+                    lpszzMultiString = HeapAlloc(GetProcessHeap(), 0, dwcbData);
+
+                    if (!lpszzMultiString)
+                    {
+                        // Allocation failed, bail out.
+                        RegCloseKey(hKey);
+                        return 1;
+                    }
+
+                    lResult = RegQueryValueExW(hKey,
+                                               ValueName,
+                                               NULL,
+                                               NULL,
+                                               (LPBYTE)lpszzMultiString,
+                                               &dwcbData);
+
+                    if (lResult != ERROR_SUCCESS)
+                    {
+                        // An error happened... free memory & close the key & bail out
+                        HeapFree(GetProcessHeap(), 0, lpszzMultiString);
+                        RegCloseKey(hKey);
+                        return 1;
+                    }
+
+                    dwBufferSize = dwcbData;
+                    ptr = lpszzMultiString;
+
+                    while (*ptr)
+                    {
+                        size = wcslen(ptr) + 1;
+                        if (_wcsnicmp(ptr, L"autocheck ", 10) == 0)
+                        {
+                            /*
+                             * Found a string to remove. To do that, we just
+                             * move everything that is after it backwards.
+                            */
+                            DWORD sizeToCopy;
+                            dwBufferSize -= size * sizeof(WCHAR); // Size that remains after the string to be removed.
+                            sizeToCopy = dwBufferSize - (ptr - lpszzMultiString) * sizeof(WCHAR);
+                            memmove(ptr, ptr + size, sizeToCopy);
+                            continue;
+                        }
+ 
+                        /* Otherwise, continue with the next string */
+                        ptr += size;
+                    }
+
+                    // If all went good from previous points, disable autochk
+                    lResult = RegSetValueEx(hKey,
+                                            ValueName,
+                                            0,
+                                            REG_MULTI_SZ,
+                                            (const BYTE *)lpszzMultiString,
+                                            dwBufferSize);
+
+                    RegCloseKey(hKey);
+
+                    if (lResult != ERROR_SUCCESS)
+                    {
+                        // We failed
+                        return 1;
+                    }
+
+                    break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+    }
+    return 0;
+}

--- a/base/applications/msconfig/autochkpage.h
+++ b/base/applications/msconfig/autochkpage.h
@@ -1,0 +1,15 @@
+/*
+ * PROJECT:     ReactOS Applications
+ * LICENSE:     LGPL - See COPYING in the top level directory
+ * PURPOSE:     Auto Check (autochk) page handler
+ * COPYRIGHT:   Copyright 2018 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+#ifndef _AUTOCHKPAGE_H_
+#define _AUTOCHKPAGE_H_
+
+extern HWND hAutoChkPage;
+
+INT_PTR CALLBACK AutoChkPageWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam);
+
+#endif /* _AUTOCHKPAGE_H_ */

--- a/base/applications/msconfig/lang/bg-BG.rc
+++ b/base/applications/msconfig/lang/bg-BG.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Отказ", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Приложение за настройка на системата"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Услуги"
     IDS_TAB_STARTUP "Запуск"
     IDS_TAB_TOOLS "Средства"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/ca-ES.rc
+++ b/base/applications/msconfig/lang/ca-ES.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Cancel·lar", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Programa de configuracio de sistema"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Serveis"
     IDS_TAB_STARTUP "Arrencada"
     IDS_TAB_TOOLS "Eines"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/cs-CZ.rc
+++ b/base/applications/msconfig/lang/cs-CZ.rc
@@ -127,6 +127,16 @@ BEGIN
     PUSHBUTTON "Storno", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Nástroj pro konfiguraci systému"
@@ -136,6 +146,7 @@ BEGIN
     IDS_TAB_SERVICES "Služby"
     IDS_TAB_STARTUP "Po spuštění"
     IDS_TAB_TOOLS "Nástroje"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/de-DE.rc
+++ b/base/applications/msconfig/lang/de-DE.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Abbrechen", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Systemkonfiguration"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Dienste"
     IDS_TAB_STARTUP "Systemstart"
     IDS_TAB_TOOLS "Tools"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/el-GR.rc
+++ b/base/applications/msconfig/lang/el-GR.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Ακύρωση", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Πρόγραμμα παραμετροποίησης συστήματος"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Υπηρεσίες"
     IDS_TAB_STARTUP "Εκκίνηση"
     IDS_TAB_TOOLS "Εργαλεία"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/en-US.rc
+++ b/base/applications/msconfig/lang/en-US.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Cancel", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "System configuration program"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Services"
     IDS_TAB_STARTUP "Startup"
     IDS_TAB_TOOLS "Tools"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/es-ES.rc
+++ b/base/applications/msconfig/lang/es-ES.rc
@@ -124,6 +124,16 @@ BEGIN
     PUSHBUTTON "Cancelar", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Utilidad de configuración del sistema"
@@ -133,6 +143,7 @@ BEGIN
     IDS_TAB_SERVICES "Servicios"
     IDS_TAB_STARTUP "Inicio"
     IDS_TAB_TOOLS "Herramientas"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/fr-FR.rc
+++ b/base/applications/msconfig/lang/fr-FR.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Annuler", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Utilitaire de configuration système"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Services"
     IDS_TAB_STARTUP "Démarrage"
     IDS_TAB_TOOLS "Outils"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/he-IL.rc
+++ b/base/applications/msconfig/lang/he-IL.rc
@@ -131,6 +131,16 @@ BEGIN
     PUSHBUTTON "ביטול", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "כלי שירות לקביעת תצורת המערכת"
@@ -140,6 +150,7 @@ BEGIN
     IDS_TAB_SERVICES "שירותים"
     IDS_TAB_STARTUP "אתחול"
     IDS_TAB_TOOLS "כלים"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/hu-HU.rc
+++ b/base/applications/msconfig/lang/hu-HU.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "Cancel", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Rendszerkonfiguráciüs segédprogram"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Szolgáltatások"
     IDS_TAB_STARTUP "Automatikus indítás"
     IDS_TAB_TOOLS "Segédprogramok"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/id-ID.rc
+++ b/base/applications/msconfig/lang/id-ID.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Batal", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Program konfigurasi sistem"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Layanan"
     IDS_TAB_STARTUP "Startup"
     IDS_TAB_TOOLS "Piranti"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/it-IT.rc
+++ b/base/applications/msconfig/lang/it-IT.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Annulla", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Utilità di configurazione del sistema"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Servizi"
     IDS_TAB_STARTUP "Avvio"
     IDS_TAB_TOOLS "Strumenti"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/ko-KR.rc
+++ b/base/applications/msconfig/lang/ko-KR.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "취소", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "System 설정 프로그램"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "서비스"
     IDS_TAB_STARTUP "시작프로그램"
     IDS_TAB_TOOLS "도구"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/nl-NL.rc
+++ b/base/applications/msconfig/lang/nl-NL.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "Cancel", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Hulpprogramma voor systeemconfiguratie"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Services"
     IDS_TAB_STARTUP "Opstarten"
     IDS_TAB_TOOLS "Hulpmiddelen"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/no-NO.rc
+++ b/base/applications/msconfig/lang/no-NO.rc
@@ -121,6 +121,16 @@ BEGIN
     PUSHBUTTON "Avbryt", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Systemkonfigurasjon"
@@ -130,6 +140,7 @@ BEGIN
     IDS_TAB_SERVICES "Tjenester"
     IDS_TAB_STARTUP "Oppstart"
     IDS_TAB_TOOLS "Verktøy"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/pl-PL.rc
+++ b/base/applications/msconfig/lang/pl-PL.rc
@@ -129,6 +129,16 @@ BEGIN
     PUSHBUTTON "Anuluj", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Program konfiguracji systemu"
@@ -138,6 +148,7 @@ BEGIN
     IDS_TAB_SERVICES "Usługi"
     IDS_TAB_STARTUP "Uruchamianie"
     IDS_TAB_TOOLS "Narzędzia"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/pt-BR.rc
+++ b/base/applications/msconfig/lang/pt-BR.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "Cancelar", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Programa de configuração do sistema"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Serviços"
     IDS_TAB_STARTUP "Inicializar"
     IDS_TAB_TOOLS "Ferramentas"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/ro-RO.rc
+++ b/base/applications/msconfig/lang/ro-RO.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "A&nulează", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Configuratorul de sistem"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Servicii"
     IDS_TAB_STARTUP "Autolansate"
     IDS_TAB_TOOLS "Instrumente"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/ru-RU.rc
+++ b/base/applications/msconfig/lang/ru-RU.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "Отмена", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Параметры системы"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Службы"
     IDS_TAB_STARTUP "Автозагрузка"
     IDS_TAB_TOOLS "Утилиты"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/sk-SK.rc
+++ b/base/applications/msconfig/lang/sk-SK.rc
@@ -125,6 +125,16 @@ BEGIN
     PUSHBUTTON "Zrušiť", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Program na konfiguráciu systému"
@@ -134,6 +144,7 @@ BEGIN
     IDS_TAB_SERVICES "Služby"
     IDS_TAB_STARTUP "Po spustení"
     IDS_TAB_TOOLS "Nástroje"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/sq-AL.rc
+++ b/base/applications/msconfig/lang/sq-AL.rc
@@ -125,6 +125,16 @@ BEGIN
     PUSHBUTTON "Cancel", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Programi i konfigurimit te sistemit"
@@ -134,6 +144,7 @@ BEGIN
     IDS_TAB_SERVICES "Shërbimet"
     IDS_TAB_STARTUP "Startupi"
     IDS_TAB_TOOLS "Veglat"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/sv-SE.rc
+++ b/base/applications/msconfig/lang/sv-SE.rc
@@ -128,6 +128,16 @@ BEGIN
     PUSHBUTTON "Avbryt", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Systemkonfiguration"
@@ -137,6 +147,7 @@ BEGIN
     IDS_TAB_SERVICES "Tjänster"
     IDS_TAB_STARTUP "Uppstart"
     IDS_TAB_TOOLS "Verktyg"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/th-TH.rc
+++ b/base/applications/msconfig/lang/th-TH.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "ยกเลิก", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "โปรแกรมโครงแบบระบบ"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "บริการ"
     IDS_TAB_STARTUP "เริ่มงานเครื่อง"
     IDS_TAB_TOOLS "เครื่องมือ"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/tr-TR.rc
+++ b/base/applications/msconfig/lang/tr-TR.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "İptal", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Dizge Yapılandırma İzlencesi"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "Hizmetler"
     IDS_TAB_STARTUP "Başlangıç"
     IDS_TAB_TOOLS "Araçlar"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/uk-UA.rc
+++ b/base/applications/msconfig/lang/uk-UA.rc
@@ -129,6 +129,16 @@ BEGIN
     PUSHBUTTON "Скасувати", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "Програма налаштування системи"
@@ -138,6 +148,7 @@ BEGIN
     IDS_TAB_SERVICES "Служби"
     IDS_TAB_STARTUP "Автозавантаження"
     IDS_TAB_TOOLS "Утиліти"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/zh-CN.rc
+++ b/base/applications/msconfig/lang/zh-CN.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "取消", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "系统配置程序"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "服务"
     IDS_TAB_STARTUP "启动"
     IDS_TAB_TOOLS "工具"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/lang/zh-TW.rc
+++ b/base/applications/msconfig/lang/zh-TW.rc
@@ -123,6 +123,16 @@ BEGIN
     PUSHBUTTON "取消", IDC_CANCEL, 100, 160, 50, 12
 END
 
+IDD_AUTOCHK_PAGE DIALOGEX 0, 0, 362, 175
+STYLE DS_SHELLFONT | DS_CONTROL | WS_CHILD | WS_CLIPCHILDREN
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT           "Auto Check is a tool which repairs dirty volumes on startup. You can either enable or disable this check on this dialog.", -1, 14, 17, 339, 300
+    CONTROL         "&Enable", IDC_AUTOCHK_ENABLE, "Button", BS_AUTORADIOBUTTON, 15, 46, 332, 10
+    CONTROL         "&Disable", IDC_AUTOCHK_DISABLE, "Button", BS_AUTORADIOBUTTON, 15, 73, 332, 10
+    GROUPBOX        "Enable/Disable Auto Check", -1, 5, 5, 350, 140, 0, WS_EX_TRANSPARENT
+END
+
 STRINGTABLE
 BEGIN
     IDS_MSCONFIG "系統設定"
@@ -132,6 +142,7 @@ BEGIN
     IDS_TAB_SERVICES "服務"
     IDS_TAB_STARTUP "啟動"
     IDS_TAB_TOOLS "工具"
+    IDS_TAB_AUTOCHK "Auto Check"
 END
 
 STRINGTABLE

--- a/base/applications/msconfig/msconfig.c
+++ b/base/applications/msconfig/msconfig.c
@@ -15,6 +15,7 @@
 #include "freeldrpage.h"
 #include "systempage.h"
 #include "generalpage.h"
+#include "autochkpage.h"
 
 HINSTANCE hInst = 0;
 
@@ -91,6 +92,7 @@ BOOL OnCreate(HWND hWnd)
     hServicesPage = CreateDialog(hInst, MAKEINTRESOURCE(IDD_SERVICES_PAGE), hWnd,  ServicesPageWndProc); EnableDialogTheme(hServicesPage);
     hStartupPage = CreateDialog(hInst, MAKEINTRESOURCE(IDD_STARTUP_PAGE), hWnd,  StartupPageWndProc); EnableDialogTheme(hStartupPage);
     hToolsPage = CreateDialog(hInst, MAKEINTRESOURCE(IDD_TOOLS_PAGE), hWnd,  ToolsPageWndProc); EnableDialogTheme(hToolsPage);
+    hAutoChkPage = CreateDialog(hInst, MAKEINTRESOURCE(IDD_AUTOCHK_PAGE), hWnd,  AutoChkPageWndProc); EnableDialogTheme(hAutoChkPage);
 
     LoadString(hInst, IDS_MSCONFIG, szTemp, 256);
     SetWindowText(hWnd, szTemp);
@@ -132,6 +134,12 @@ BOOL OnCreate(HWND hWnd)
     item.pszText = szTemp;
     (void)TabCtrl_InsertItem(hTabWnd, 5, &item);
 
+    LoadString(hInst, IDS_TAB_AUTOCHK, szTemp, 256);
+    memset(&item, 0, sizeof(TCITEM));
+    item.mask = TCIF_TEXT;
+    item.pszText = szTemp;
+    (void)TabCtrl_InsertItem(hTabWnd, 6, &item);
+
     MsConfig_OnTabWndSelChange();
 
     return TRUE;
@@ -148,6 +156,7 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hServicesPage, SW_HIDE);
         ShowWindow(hStartupPage, SW_HIDE);
         ShowWindow(hToolsPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hGeneralPage);
         break;
     case 1: //SYSTEM.INI
@@ -157,6 +166,7 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hStartupPage, SW_HIDE);
         ShowWindow(hFreeLdrPage, SW_HIDE);
         ShowWindow(hServicesPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hSystemPage);
         break;
     case 2: //Freeldr
@@ -166,6 +176,7 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hServicesPage, SW_HIDE);
         ShowWindow(hStartupPage, SW_HIDE);
         ShowWindow(hToolsPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hFreeLdrPage);
         break;
     case 3: //Services
@@ -175,6 +186,7 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hServicesPage, SW_SHOW);
         ShowWindow(hStartupPage, SW_HIDE);
         ShowWindow(hToolsPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hServicesPage);
         break;
     case 4: //startup
@@ -184,6 +196,7 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hServicesPage, SW_HIDE);
         ShowWindow(hStartupPage, SW_SHOW);
         ShowWindow(hToolsPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hStartupPage);
         break;
     case 5: //Tools
@@ -193,7 +206,18 @@ void MsConfig_OnTabWndSelChange(void)
         ShowWindow(hServicesPage, SW_HIDE);
         ShowWindow(hStartupPage, SW_HIDE);
         ShowWindow(hToolsPage, SW_SHOW);
+        ShowWindow(hAutoChkPage, SW_HIDE);
         BringWindowToTop(hToolsPage);
+        break;
+    case 6: //Auto Check
+        ShowWindow(hGeneralPage, SW_HIDE);
+        ShowWindow(hSystemPage, SW_HIDE);
+        ShowWindow(hFreeLdrPage, SW_HIDE);
+        ShowWindow(hServicesPage, SW_HIDE);
+        ShowWindow(hStartupPage, SW_HIDE);
+        ShowWindow(hToolsPage, SW_HIDE);
+        ShowWindow(hAutoChkPage, SW_SHOW);
+        BringWindowToTop(hAutoChkPage);
         break;
     }
 }
@@ -280,6 +304,8 @@ MsConfigWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             break;
 
         case WM_DESTROY:
+            if (hAutoChkPage)
+                DestroyWindow(hAutoChkPage);
             if (hToolsPage)
                 DestroyWindow(hToolsPage);
             if (hGeneralPage)

--- a/base/applications/msconfig/resource.h
+++ b/base/applications/msconfig/resource.h
@@ -8,6 +8,7 @@
 #define IDD_FREELDR_PAGE          106
 #define IDD_SYSTEM_PAGE           107
 #define IDD_FREELDR_ADVANCED_PAGE 108
+#define IDD_AUTOCHK_PAGE          109
 
 #define IDC_TAB                       1001
 #define IDC_BTN_APPLY                 1002
@@ -68,6 +69,8 @@
 #define IDC_SYSTEM_TREE               1057
 #define IDC_BTN_SYSTEM_ACTIVATE       1058
 #define IDC_BTN_SYSTEM_DEACTIVATE     1059
+#define IDC_AUTOCHK_ENABLE            1060
+#define IDC_AUTOCHK_DISABLE           1061
 
 #define IDS_TAB_TOOLS    2001
 #define IDS_TAB_SYSTEM   2002
@@ -75,6 +78,7 @@
 #define IDS_TAB_STARTUP  2004
 #define IDS_TAB_SERVICES 2005
 #define IDS_TAB_GENERAL  2006
+#define IDS_TAB_AUTOCHK  2007
 
 #define IDS_TOOLS_COLUMN_NAME       2010
 #define IDS_TOOLS_COLUMN_DESCR      2011


### PR DESCRIPTION
## Purpose
I've witnessed many people were complaining about autochk performing the repair of dirty volumes in an incorrect matter such as the duplication of files after an autochk repair or even rendering ReactOS un-bootable.

Judging all the complaints, I decided to implement a small Autochk dialog utility on System Configuration program (msconfig.exe) with the ability to disable or enable the feature. With this, users can disable easily.
## Proposed Changes
- Implement a dialog box with two radio buttons
- Implement the core base engine, using the Windows registry functions to manipulate the autochk registry key
- Helper function (can be seen on `WM_INITDIALOG` case): it checks for autochk state, in any case it's enabled then the "Enable" button will be always checked, and vice versa.