### PR TITLE
[NTOSKRNL] Fix a nullptr dereference in IopStartDevice

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -786,7 +786,7 @@ IopStartDevice(
 {
    NTSTATUS Status;
    HANDLE InstanceHandle = NULL, ControlHandle = NULL;
-   UNICODE_STRING KeyName;
+   UNICODE_STRING KeyName, ValueString;
    OBJECT_ATTRIBUTES ObjectAttributes;
 
    if (DeviceNode->Flags & DNF_DISABLED)
@@ -817,7 +817,10 @@ IopStartDevice(
        goto ByeBye;
 
    RtlInitUnicodeString(&KeyName, L"ActiveService");
-   Status = ZwSetValueKey(ControlHandle, &KeyName, 0, REG_SZ, DeviceNode->ServiceName.Buffer, DeviceNode->ServiceName.Length + sizeof(UNICODE_NULL));
+   ValueString = DeviceNode->ServiceName;
+   if (!ValueString.Buffer)
+       RtlInitUnicodeString(&ValueString, L"");
+   Status = ZwSetValueKey(ControlHandle, &KeyName, 0, REG_SZ, ValueString.Buffer, ValueString.Length + sizeof(UNICODE_NULL));
    // }
 
 ByeBye:


### PR DESCRIPTION
```
kd> kp
ChildEBP RetAddr  
f7923354 80412f7a nt!memmove+0x48
f792342c 80428bc6 nt!CmSetValueKey(struct _CM_KEY_CONTROL_BLOCK * Kcb = 0xe105c890, struct _UNICODE_STRING * ValueName = 0xf7923464 "ActiveService", unsigned long Type = 1, void * Data = 0x00000000, unsigned long DataLength = 2)+0x46a [r:\src\master\ntoskrnl\config\cmapi.c @ 812]
f79234e8 8054a95b nt!NtSetValueKey(void * KeyHandle = 0x800007d4, struct _UNICODE_STRING * ValueName = 0xf7923618 "ActiveService", unsigned long TitleIndex = 0, unsigned long Type = 1, void * Data = 0x00000000, unsigned long DataSize = 2)+0x266 [r:\src\master\ntoskrnl\config\ntapi.c @ 721]
f7923510 805487d4 nt!KiSystemCallTrampoline(void * Handler = 0x80428960, void * Arguments = 0xf79235d8, unsigned long StackBytes = 0x18)+0x1b [r:\src\master\ntoskrnl\include\internal\i386\ke.h @ 748]
f7923558 80403d96 nt!KiSystemServiceHandler(struct _KTRAP_FRAME * TrapFrame = 0xf7923560, void * Arguments = 0xf79235d8)+0x254 [r:\src\master\ntoskrnl\ke\i386\traphdlr.c @ 1813]
f7923558 8040241d nt!KiSystemService+0x60
f79235d0 80497cf0 nt!ZwSetValueKey+0x11
f7923640 8049164f nt!IopStartDevice(struct _DEVICE_NODE * DeviceNode = 0xb25a8970)+0x110 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 820]
f79236a0 8049825b nt!IopActionInitChildServices(struct _DEVICE_NODE * DeviceNode = 0xb25a8970, void * Context = 0xb269ea00)+0x10f [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2813]
f79236c0 8049829d nt!IopTraverseDeviceTreeNode(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf79236fc)+0x3b [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1374]
f79236dc 804981f1 nt!IopTraverseDeviceTreeNode(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf79236fc)+0x7d [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1388]
f79236ec 8049568b nt!IopTraverseDeviceTree(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf79236fc)+0x21 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1413]
f7923710 80494ae2 nt!IopInitializePnpServices(struct _DEVICE_NODE * DeviceNode = 0xb269ea00)+0x3b [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2911]
f792379c 80491190 nt!IopEnumerateDevice(struct _DEVICE_OBJECT * DeviceObject = 0xb269eb68)+0x262 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2601]
f79237ac 80497bac nt!IoSynchronousInvalidateDeviceRelations(struct _DEVICE_OBJECT * DeviceObject = 0xb269eb68, _DEVICE_RELATION_TYPE Type = BusRelations (0n0))+0x30 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 4937]
f79237d4 80497c3e nt!IopStartAndEnumerateDevice(struct _DEVICE_NODE * DeviceNode = 0xb269ea00)+0xdc [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 749]
f7923830 8048f5e5 nt!IopStartDevice(struct _DEVICE_NODE * DeviceNode = 0xb269ea00)+0x5e [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 803]
f79238d0 80491922 nt!PipCallDriverAddDevice(struct _DEVICE_NODE * DeviceNode = 0xb269ea00, unsigned char LoadDriver = 0x00 '', struct _DRIVER_OBJECT * DriverObject = 0xb2682e10)+0x375 [r:\src\master\ntoskrnl\io\pnpmgr\pnpinit.c @ 376]
f7923938 8049825b nt!IopActionInitChildServices(struct _DEVICE_NODE * DeviceNode = 0xb269ea00, void * Context = 0xb26b8ba8)+0x3e2 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2866]
f7923958 8049829d nt!IopTraverseDeviceTreeNode(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf7923994)+0x3b [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1374]
f7923974 804981f1 nt!IopTraverseDeviceTreeNode(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf7923994)+0x7d [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1388]
f7923984 8049568b nt!IopTraverseDeviceTree(struct _DEVICETREE_TRAVERSE_CONTEXT * Context = 0xf7923994)+0x21 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 1413]
f79239a8 80494ae2 nt!IopInitializePnpServices(struct _DEVICE_NODE * DeviceNode = 0xb26b8ba8)+0x3b [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2911]
f7923a34 80491190 nt!IopEnumerateDevice(struct _DEVICE_OBJECT * DeviceObject = 0xb26b8e18)+0x262 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 2601]
f7923a44 8025ed7f nt!IoSynchronousInvalidateDeviceRelations(struct _DEVICE_OBJECT * DeviceObject = 0xb26b8e18, _DEVICE_RELATION_TYPE Type = BusRelations (0n0))+0x30 [r:\src\master\ntoskrnl\io\pnpmgr\pnpmgr.c @ 4937]
f7923a74 804728ee hal!HalpReportDetectedDevices(struct _DRIVER_OBJECT * DriverObject = 0xb26b8f38, void * Context = 0xb26b8db0, unsigned long Count = 1)+0x15f [r:\src\master\hal\halx86\acpi\halpnpdd.c @ 104]
f7923a94 8058be15 nt!IopReinitializeBootDrivers(void)+0x8e [r:\src\master\ntoskrnl\io\iomgr\driver.c @ 1404]
f7923be0 8043819c nt!IoInitSystem(struct _LOADER_PARAMETER_BLOCK * LoaderBlock = 0x80088000)+0x2e5 [r:\src\master\ntoskrnl\io\iomgr\iomgr.c @ 560]
f7923d7c 804376de nt!Phase1InitializationDiscard(void * Context = 0x80088000)+0xa9c [r:\src\master\ntoskrnl\ex\init.c @ 1802]
f7923d88 80526516 nt!Phase1Initialization(void * Context = 0x80088000)+0xe [r:\src\master\ntoskrnl\ex\init.c @ 2019]
f7923dbc 80547c43 nt!PspSystemThreadStartup(<function> * StartRoutine = 0x804376d0, void * StartContext = 0x80088000)+0x76 [r:\src\master\ntoskrnl\ps\thread.c @ 156]
f7923ddc 8052649f nt!KiThreadStartup(void)+0x63 [r:\src\master\ntoskrnl\ke\i386\thrdini.c @ 78]
f7923de0 804376cf nt!PspCreateThread+0xedf
f7923de4 80088000 nt!ExpLoadInitialProcess+0x55f
WARNING: Frame IP not in any known module. Following frames may be wrong.
f7923de8 00000000 0x80088000
kd> dt nt!_DEVICE_NODE 0xb25a8970
   +0x000 Sibling          : 0xb25a8838 _DEVICE_NODE
   +0x004 Child            : (null) 
   +0x008 Parent           : 0xb269ea00 _DEVICE_NODE
   +0x00c LastChild        : (null) 
   +0x010 Level            : 3
   +0x014 Notify           : (null) 
   +0x018 PoIrpManager     : _PO_IRP_MANAGER
   +0x028 State            : 0 (No matching name)
   +0x02c PreviousState    : 0 (No matching name)
   +0x030 StateHistory     : [20] 0 (No matching name)
   +0x080 StateHistoryEntry : 0
   +0x084 CompletionStatus : 0n0
   +0x088 PendingIrp       : (null) 
   +0x08c Flags            : 0x108b
   +0x090 UserFlags        : 0
   +0x094 Problem          : 0
   +0x098 PhysicalDeviceObject : 0xb25aaee0 _DEVICE_OBJECT
   +0x09c ResourceList     : (null) 
   +0x0a0 ResourceListTranslated : (null) 
   +0x0a4 InstancePath     : _UNICODE_STRING "ACPI\FixedButton\2&ccb86d17&0"
   +0x0ac ServiceName      : _UNICODE_STRING ""
   +0x0b4 DuplicatePDO     : (null) 
   +0x0b8 ResourceRequirements : (null) 
   +0x0bc InterfaceType    : 0 ( Internal )
   +0x0c0 BusNumber        : 0
   +0x0c4 ChildInterfaceType : d ( InternalPowerBus )
   +0x0c8 ChildBusNumber   : 0
   +0x0cc ChildBusTypeIndex : 0
   +0x0ce RemovalPolicy    : 0 ''
   +0x0cf HardwareRemovalPolicy : 0 ''
   +0x0d0 TargetDeviceNotify : _LIST_ENTRY [ 0x0 - 0x0 ]
   +0x0d8 DeviceArbiterList : _LIST_ENTRY [ 0x0 - 0x0 ]
   +0x0e0 DeviceTranslatorList : _LIST_ENTRY [ 0x0 - 0x0 ]
   +0x0e8 NoTranslatorMask : 0
   +0x0ea QueryTranslatorMask : 0
   +0x0ec NoArbiterMask    : 0
   +0x0ee QueryArbiterMask : 0
   +0x0f0 OverUsed1        : <unnamed-tag>
   +0x0f4 OverUsed2        : <unnamed-tag>
   +0x0f8 BootResources    : (null) 
   +0x0fc CapabilityFlags  : 0x900
   +0x100 DockInfo         : <unnamed-tag>
   +0x110 DisableableDepends : 0
   +0x114 PendedSetInterfaceState : _LIST_ENTRY [ 0x0 - 0x0 ]
   +0x11c LegacyBusListEntry : _LIST_ENTRY [ 0x0 - 0x0 ]
   +0x124 DriverUnloadRetryCount : 0
   +0x128 PreviousParent   : (null) 
   +0x12c DeletedChidren   : 0

```