### PR TITLE
[SHELL32] Fix a careless mistake of ShellExecCmdLine

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2430,7 +2430,6 @@ HRESULT WINAPI ShellExecCmdLine(
             SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
-            pchParams = NULL;
         }
         else if (SearchPathW(NULL, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(NULL, lpCommand, wszExe, _countof(szFile2), szFile2, NULL) ||

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -140,7 +140,6 @@ HRESULT WINAPI ShellExecCmdLine(
             SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
-            pchParams = NULL;
         }
         else if (SearchPathW(NULL, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(NULL, lpCommand, wszExe, _countof(szFile2), szFile2, NULL) ||
@@ -415,6 +414,7 @@ static void DoEntry(const TEST_ENTRY *pEntry)
             {
                 bFound = TRUE;
                 SendMessage(hwnd, WM_CLOSE, 0, 0);
+                Sleep(RETRY_INTERVAL);
                 break;
             }
             Sleep(RETRY_INTERVAL);


### PR DESCRIPTION
## Purpose

This PR fix my careless mistake of ShellExecCmdLine.
JIRA issue: [CORE-14886](https://jira.reactos.org/browse/CORE-14886)
