### PR TITLE
[SYSTEMINFO] Fix various bugs and add SMBIOS support

### DIFF
--- a/modules/rosapps/applications/sysutils/systeminfo/CMakeLists.txt
+++ b/modules/rosapps/applications/sysutils/systeminfo/CMakeLists.txt
@@ -1,5 +1,10 @@
 
+include_directories(
+    ${REACTOS_SOURCE_DIR}/sdk/lib/udmihelp
+    ${REACTOS_SOURCE_DIR}/sdk/lib/dmilib)
+
 add_executable(systeminfo systeminfo.c systeminfo.rc)
 set_module_type(systeminfo win32cui)
+target_link_libraries(systeminfo udmihelp)
 add_importlibs(systeminfo user32 advapi32 netapi32 shlwapi iphlpapi ws2_32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET systeminfo DESTINATION reactos/system32 FOR all)

--- a/modules/rosapps/applications/sysutils/systeminfo/systeminfo.c
+++ b/modules/rosapps/applications/sysutils/systeminfo/systeminfo.c
@@ -27,6 +27,8 @@
 #include <shlwapi.h>
 #include <iphlpapi.h>
 #include <winsock2.h>
+#include <udmihelp.h>
+#include <dmilib.h>
 
 #include "resource.h"
 
@@ -62,7 +64,7 @@ RegGetSZ(HKEY hKey, LPCWSTR lpSubKey, LPCWSTR lpValueName, LPWSTR lpBuf, DWORD c
         wprintf(L"Warning! Cannot query %s. Last error: %lu, type: %lu.\n", lpValueName, GetLastError(), dwType);
         dwBytes = 0;
     }
-    else
+    else if (dwBytes == 0)
     {
         wcscpy(lpBuf, L"N/A");
         dwBytes = 6;
@@ -173,7 +175,7 @@ FormatDateTime(time_t Time, LPWSTR lpBuf)
 
     /* Copy time now */
     i += swprintf(lpBuf + i, L", ");
-    i += 2;
+
     GetTimeFormatW(LOCALE_SYSTEM_DEFAULT, 0, &SysTime, NULL, lpBuf + i, BUFFER_SIZE - i);
 }
 
@@ -236,6 +238,8 @@ AllSysInfo(VOID)
     HKEY hKey;
     PIP_ADAPTER_ADDRESSES pAdapters;
     ULONG cbAdapters;
+    PVOID SMBiosBuf;
+    PCHAR DmiStrings[ID_STRINGS_MAX] = { 0 };
 
     if (!GetSystemDirectoryW(szSystemDir, sizeof(szSystemDir)/sizeof(szSystemDir[0])))
     {
@@ -319,23 +323,34 @@ AllSysInfo(VOID)
     swprintf(Buf, Tmp, cSeconds / (60*60*24), (cSeconds / (60*60)) % 24, (cSeconds / 60) % 60, cSeconds % 60);
     PrintRow(IDS_UP_TIME, FALSE, L"%s", Buf);
 
+    // prepare SMBIOS data
+    SMBiosBuf = LoadSMBiosData(DmiStrings);
+
     //getting System Manufacturer; HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OEMInformation\Manufacturer for Win >= 6.0
     swprintf(Tmp, L"%s\\oeminfo.ini", szSystemDir);
     GetPrivateProfileStringW(L"General",
                              L"Manufacturer",
-                             L"To Be Filled By O.E.M.",
+                             L"",
                              Buf,
                              sizeof(Buf)/sizeof(Buf[0]),
                              Tmp);
+    if (wcslen(Buf) == 0 && SMBiosBuf)
+    {
+        GetSMBiosStringW(DmiStrings[SYS_VENDOR], Buf, _countof(Buf), FALSE);
+    }
     PrintRow(IDS_SYS_MANUFACTURER, FALSE, L"%s", Buf);
 
     //getting System Model; HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\OEMInformation\Model for Win >= 6.0
     GetPrivateProfileStringW(L"General",
                              L"Model",
-                             L"To Be Filled By O.E.M.",
+                             L"",
                              Buf,
                              sizeof(Buf)/sizeof(Buf[0]),
                              Tmp);
+    if (wcslen(Buf) == 0 && SMBiosBuf)
+    {
+        GetSMBiosStringW(DmiStrings[SYS_PRODUCT], Buf, _countof(Buf), FALSE);
+    }
     PrintRow(IDS_SYS_MODEL, FALSE, L"%s", Buf);
 
     //getting System type
@@ -375,20 +390,43 @@ AllSysInfo(VOID)
     }
 
     //getting BIOS Version
-    RegGetSZ(HKEY_LOCAL_MACHINE,
-             L"HARDWARE\\DESCRIPTION\\System",
-             L"SystemBiosVersion",
-             Buf,
-             BUFFER_SIZE);
+    if (SMBiosBuf)
+    {
+        j = GetSMBiosStringW(DmiStrings[BIOS_VENDOR], Buf, BUFFER_SIZE, TRUE);
+        if (j + 1 < BUFFER_SIZE)
+        {
+            Buf[j++] = L' ';
+            Buf[j] = L'\0';
+        }
+        GetSMBiosStringW(DmiStrings[BIOS_VERSION], Buf + j, BUFFER_SIZE - j, TRUE);
+    }
+    else
+    {
+        RegGetSZ(HKEY_LOCAL_MACHINE,
+                 L"HARDWARE\\DESCRIPTION\\System",
+                 L"SystemBiosVersion",
+                 Buf,
+                 BUFFER_SIZE);
+    }
     PrintRow(IDS_BIOS_VERSION, FALSE, L"%s", Buf);
 
     //gettings BIOS date
-    RegGetSZ(HKEY_LOCAL_MACHINE,
-             L"HARDWARE\\DESCRIPTION\\System",
-             L"SystemBiosDate",
-             Buf,
-             BUFFER_SIZE);
+    if (SMBiosBuf)
+    {
+        GetSMBiosStringW(DmiStrings[BIOS_DATE], Buf, BUFFER_SIZE, TRUE);
+    }
+    else
+    {
+        RegGetSZ(HKEY_LOCAL_MACHINE,
+                 L"HARDWARE\\DESCRIPTION\\System",
+                 L"SystemBiosDate",
+                 Buf,
+                 BUFFER_SIZE);
+    }
     PrintRow(IDS_BIOS_DATE, FALSE, L"%s", Buf);
+
+    // clean SMBIOS data
+    FreeSMBiosData(SMBiosBuf);
 
     //getting ReactOS Directory
     if (!GetWindowsDirectoryW(Buf, BUFFER_SIZE))


### PR DESCRIPTION
## Purpose

Fix various bugs in `systeminfo` utility and add SMBIOS support.

JIRA issue: None

## Proposed changes

- Fix output of registry strings
- Fix output of install date
- Remove hardcoded `To Be Filled By O.E.M.` strings (these are known and reserved values in some motherboards)
- Print actual strings from SMBIOS

![image](https://user-images.githubusercontent.com/578406/44004724-aec9e2a2-9e6f-11e8-9ff3-971003e47e22.png)
