### PR TITLE
[WIN32SS] Fix DrawText wrt DT_CALCRECT | DT_VCENTER

### DIFF
--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -1151,16 +1151,15 @@ INT WINAPI DrawTextExWorker( HDC hdc,
             if (flags & DT_VCENTER)
 #ifdef __REACTOS__
             {
-                if (((rect->bottom - rect->top) < (invert_y ? -size.cy : size.cy)) && (flags & DT_CALCRECT))
+                if (flags & DT_CALCRECT)
                 {
-                    y = rect->top + (invert_y ? -size.cy : size.cy);
+                    if (rect->bottom - rect->top < size.cy / 2)
+                        y = rect->top + (invert_y ? size.cy : -size.cy) / 2;
                 }
                 else
                 {
-                    y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
-#else
-                    y = rect->top + (rect->bottom - rect->top) / 2 + (invert_y ? (size.cy / 2) : (-size.cy / 2));
 #endif
+                    y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
 #ifdef __REACTOS__
                 }
             }

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -1146,27 +1146,31 @@ INT WINAPI DrawTextExWorker( HDC hdc,
 #endif
 	else if (flags & DT_RIGHT) x = rect->right - size.cx;
 
-	if (flags & DT_SINGLELINE)
-	{
-            if (flags & DT_VCENTER)
+    if (flags & DT_SINGLELINE)
+    {
+        if (flags & DT_VCENTER)
 #ifdef __REACTOS__
+        {
+            if (flags & DT_CALCRECT)
             {
-                if (flags & DT_CALCRECT)
-                {
-                    if (rect->bottom - rect->top < size.cy / 2)
-                        y = rect->top + (invert_y ? size.cy : -size.cy) / 2;
-                }
-                else
-                {
-#endif
-                    y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
-#ifdef __REACTOS__
-                }
+                if (rect->bottom - rect->top < size.cy / 2)
+                    y = rect->top + (invert_y ? size.cy : -size.cy) / 2;
             }
-#endif
-            else if (flags & DT_BOTTOM)
-                y = rect->bottom + (invert_y ? 0 : -size.cy);
+            else
+            {
+                y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
+            }
         }
+#else
+            y = rect->top + (rect->bottom - rect->top) / 2 - size.cy / 2;
+#endif
+        else if (flags & DT_BOTTOM)
+#ifdef __REACTOS__
+            y = rect->bottom + (invert_y ? 0 : -size.cy);
+#else
+            y = rect->bottom - size.cy;
+#endif
+    }
 
 	if (!(flags & DT_CALCRECT))
 	{

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -1146,10 +1146,10 @@ INT WINAPI DrawTextExWorker( HDC hdc,
 #endif
 	else if (flags & DT_RIGHT) x = rect->right - size.cx;
 
-    if (flags & DT_SINGLELINE)
-    {
-        if (flags & DT_VCENTER)
+	if (flags & DT_SINGLELINE)
+	{
 #ifdef __REACTOS__
+        if (flags & DT_VCENTER)
         {
             if (flags & DT_CALCRECT)
             {
@@ -1161,14 +1161,12 @@ INT WINAPI DrawTextExWorker( HDC hdc,
                 y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
             }
         }
-#else
-            y = rect->top + (rect->bottom - rect->top) / 2 - size.cy / 2;
-#endif
         else if (flags & DT_BOTTOM)
-#ifdef __REACTOS__
             y = rect->bottom + (invert_y ? 0 : -size.cy);
 #else
-            y = rect->bottom - size.cy;
+	    if (flags & DT_VCENTER) y = rect->top +
+	    	(rect->bottom - rect->top) / 2 - size.cy / 2;
+	    else if (flags & DT_BOTTOM) y = rect->bottom - size.cy;
 #endif
     }
 


### PR DESCRIPTION
## Purpose
This PR will fix DrawText function behaviour wrt DT_CALCRECT | DT_VCENTER.
JIRA issue: [CORE-14896](https://jira.reactos.org/browse/CORE-14896)

The test program: https://jira.reactos.org/secure/attachment/47925/TnB3.zip

BEFORE:
![tnb3-ros-before](https://user-images.githubusercontent.com/2107452/44140304-a3a25da4-a0b4-11e8-80e8-dde57ba5a245.png)

AFTER:
![tnb3-ros-after](https://user-images.githubusercontent.com/2107452/44140302-a3726144-a0b4-11e8-8535-e37d6eb91f9a.png)

WIN2K3:
![tnb3-win2k3](https://user-images.githubusercontent.com/2107452/44140306-a3ce8848-a0b4-11e8-9286-356e6a5b201b.png)

WIN10 JAPANESE:
![tnb3-win10](https://user-images.githubusercontent.com/2107452/44140307-a3f7cb04-a0b4-11e8-812f-d816b6c880d0.png)
