### PR TITLE
[NTOS:PS] Fix an issue with PROCESS_DEVICEMAP_INFORMATION  size on x64

### DIFF
--- a/base/system/smss/pagefile.c
+++ b/base/system/smss/pagefile.c
@@ -837,8 +837,8 @@ SmpCreateVolumeDescriptors(VOID)
     /* Query the device map so we can get the drive letters */
     Status = NtQueryInformationProcess(NtCurrentProcess(),
                                        ProcessDeviceMap,
-                                       &ProcessInformation,
-                                       sizeof(ProcessInformation),
+                                       &ProcessInformation.Query,
+                                       sizeof(ProcessInformation.Query),
                                        NULL);
     if (!NT_SUCCESS(Status))
     {

--- a/dll/win32/kernel32/client/file/disk.c
+++ b/dll/win32/kernel32/client/file/disk.c
@@ -115,8 +115,8 @@ GetLogicalDrives(VOID)
     /* Get the Device Map for this Process */
     Status = NtQueryInformationProcess(NtCurrentProcess(),
                                        ProcessDeviceMap,
-                                       &ProcessDeviceMapInfo,
-                                       sizeof(ProcessDeviceMapInfo),
+                                       &ProcessDeviceMapInfo.Query,
+                                       sizeof(ProcessDeviceMapInfo.Query),
                                        NULL);
 
     /* Return the Drive Map */
@@ -557,9 +557,10 @@ GetDriveTypeW(IN LPCWSTR lpRootPathName)
         PROCESS_DEVICEMAP_INFORMATION DeviceMap;
 
         /* Query the device map */
-        Status = NtQueryInformationProcess(NtCurrentProcess(), ProcessDeviceMap,
-                                           &DeviceMap,
-                                           sizeof(PROCESS_DEVICEMAP_INFORMATION),
+        Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                           ProcessDeviceMap,
+                                           &DeviceMap.Query,
+                                           sizeof(DeviceMap.Query),
                                            NULL);
         /* Zero output if we failed */
         if (!NT_SUCCESS(Status))

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -564,7 +564,7 @@ NtQueryInformationProcess(IN HANDLE ProcessHandle,
         /* DOS Device Map */
         case ProcessDeviceMap:
 
-            if (ProcessInformationLength != sizeof(PROCESS_DEVICEMAP_INFORMATION))
+            if (ProcessInformationLength != RTL_FIELD_SIZE(PROCESS_DEVICEMAP_INFORMATION, Query))
             {
                 if (ProcessInformationLength == sizeof(PROCESS_DEVICEMAP_INFORMATION_EX))
                 {


### PR DESCRIPTION
The PROCESS_DEVICEMAP_INFORMATION  union has 2 fields, one is a handle, the other one is a structure of 36 bytes (independent of architecture). The handle forces 64 bit alignment on 64 bit builds, making the structure 4 bytes bigger than on 32 bit builds. The site is checked in NtQueryInformationProcess (case ProcessDeviceMap). The expected size on x64 is the size of the Query structure without alignment. autocheck correctly passes the site of the Query union member, while smss passes the full size of PROCESS_DEVICEMAP_INFORMATION. Packing the structure is not an option, since it is defined in public headers without packing. Using the original headers sizeof(PROCESS_DEVICEMAP_INFORMATION) is 0x28, sizeof(PROCESS_DEVICEMAP_INFORMATION::Query) is 0x24.
