### PR TITLE
CORE-12729. [NTOS:MM] s/MmFreeMemoryAreaByNode/MmFreeMemoryArea/ in a DPRINT()

### DIFF
--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -375,7 +375,7 @@ MmFreeMemoryArea(
 #endif
     ExFreePoolWithTag(MemoryArea, TAG_MAREA);
 
-    DPRINT("MmFreeMemoryAreaByNode() succeeded\n");
+    DPRINT("MmFreeMemoryArea() succeeded\n");
 
     return STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Purpose

Revert unwanted part of r12728.

JIRA issue: [CORE-12729](https://jira.reactos.org/browse/CORE-12729)
