### PR TITLE
[FREELDR] Fix calculation of page lookup table

### DIFF
--- a/boot/freeldr/freeldr/include/mm.h
+++ b/boot/freeldr/freeldr/include/mm.h
@@ -58,8 +58,7 @@ typedef struct _FREELDR_MEMORY_DESCRIPTOR
 #define MM_PAGE_SIZE    4096
 #define MM_PAGE_MASK    0xFFF
 #define MM_PAGE_SHIFT    12
-// FIXME: freeldr implementation uses ULONG for page numbers
-#define MM_MAX_PAGE        0xFFFFFFFFFFFFF
+#define MM_MAX_PAGE     0x3FFFF /* freeldr only maps 1 GB */
 
 #define MM_SIZE_TO_PAGES(a)  \
     ( ((a) >> MM_PAGE_SHIFT) + ((a) & MM_PAGE_MASK ? 1 : 0) )


### PR DESCRIPTION
On x64 we only map 1GB of pages, so adjust MM_MAX_PAGE accordingly and also respect that value when searching for the best location of the page lookup table.
