### PR TITLE
[FONT][WIN32SS] Define ftFreePoolWithSize and use it once

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -251,6 +251,18 @@ SharedFace_AddRef(PSHARED_FACE Ptr)
     ++Ptr->RefCount;
 }
 
+static inline VOID FASTCALL
+ftFreePoolWithTagAndSize(
+    _Pre_notnull_ __drv_freesMem(Mem) PVOID P,
+    _In_ ULONG Tag,
+    _In_ SIZE_T Size)
+{
+#ifndef NDEBUG
+    RtlFillMemoryUlong(P, Size, 0xDEADFACE);
+#endif
+    ExFreePoolWithTag(P, Tag);
+}
+
 static void
 RemoveCachedEntry(PFONT_CACHE_ENTRY Entry)
 {
@@ -258,7 +270,7 @@ RemoveCachedEntry(PFONT_CACHE_ENTRY Entry)
 
     FT_Done_Glyph((FT_Glyph)Entry->BitmapGlyph);
     RemoveEntryList(&Entry->ListEntry);
-    ExFreePoolWithTag(Entry, TAG_FONT);
+    ftFreePoolWithTagAndSize(Entry, TAG_FONT, sizeof(*Entry));
     g_FontCacheNumEntries--;
     ASSERT(g_FontCacheNumEntries <= MAX_FONT_CACHE);
 }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -256,7 +256,7 @@ ftFreePoolWithSize(
     _Pre_notnull_ __drv_freesMem(Mem) PVOID P,
     _In_ SIZE_T Size)
 {
-#ifdef DBG
+#if DBG
     RtlFillMemoryUlong(P, Size, 0xDEADFACE);
 #endif
     ExFreePoolWithTag(P, TAG_FONT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -252,15 +252,14 @@ SharedFace_AddRef(PSHARED_FACE Ptr)
 }
 
 static inline VOID FASTCALL
-ftFreePoolWithTagAndSize(
+ftFreePoolWithSize(
     _Pre_notnull_ __drv_freesMem(Mem) PVOID P,
-    _In_ ULONG Tag,
     _In_ SIZE_T Size)
 {
-#ifndef NDEBUG
+#ifdef DBG
     RtlFillMemoryUlong(P, Size, 0xDEADFACE);
 #endif
-    ExFreePoolWithTag(P, Tag);
+    ExFreePoolWithTag(P, TAG_FONT);
 }
 
 static void
@@ -270,7 +269,7 @@ RemoveCachedEntry(PFONT_CACHE_ENTRY Entry)
 
     FT_Done_Glyph((FT_Glyph)Entry->BitmapGlyph);
     RemoveEntryList(&Entry->ListEntry);
-    ftFreePoolWithTagAndSize(Entry, TAG_FONT, sizeof(*Entry));
+    ftFreePoolWithSize(Entry, sizeof(*Entry));
     g_FontCacheNumEntries--;
     ASSERT(g_FontCacheNumEntries <= MAX_FONT_CACHE);
 }


### PR DESCRIPTION
## Purpose

Define ftFreePoolWithSize function as replacement of ExFreePoolWithTag, and use it in RemoveCachedEntry function. ftFreePoolWithSize fills a memory block by 0xDEADFACE values and releases the memory block by using ExFreePoolWithTag.

JIRA issue: [CORE-14935](https://jira.reactos.org/browse/CORE-14935)