### PR TITLE
[TCPIP] Implement InfoTdiQueryGetATInfo

### DIFF
--- a/drivers/network/tcpip/include/tcpip.h
+++ b/drivers/network/tcpip/include/tcpip.h
@@ -170,6 +170,6 @@ extern ULONG EntityCount;
 extern ULONG EntityMax;
 
 extern NTSTATUS TiGetProtocolNumber( PUNICODE_STRING FileName,
-				     PULONG Protocol );
+				     PUSHORT Protocol );
 
 /* EOF */

--- a/drivers/network/tcpip/tcpip/main.c
+++ b/drivers/network/tcpip/tcpip/main.c
@@ -117,7 +117,7 @@ NTSTATUS TiCreateFileObject(
     TDI_REQUEST Request;
     PVOID ClientContext;
     NTSTATUS Status;
-    ULONG Protocol;
+    USHORT Protocol;
     BOOLEAN Shared;
 
     TI_DbgPrint(DEBUG_IRP, ("Called. DeviceObject is at (0x%X), IRP is at (0x%X).\n", DeviceObject, Irp));

--- a/drivers/network/tcpip/tcpip/proto.c
+++ b/drivers/network/tcpip/tcpip/proto.c
@@ -2,7 +2,7 @@
 
 NTSTATUS TiGetProtocolNumber(
   PUNICODE_STRING FileName,
-  PULONG Protocol)
+  PUSHORT Protocol)
 /*
  * FUNCTION: Returns the protocol number from a file name
  * ARGUMENTS:
@@ -33,7 +33,7 @@ NTSTATUS TiGetProtocolNumber(
   if (!NT_SUCCESS(Status) || ((Value > 255)))
     return STATUS_UNSUCCESSFUL;
 
-  *Protocol = Value;
+  *Protocol = (USHORT)Value;
 
   return STATUS_SUCCESS;
 }

--- a/drivers/network/tcpip/tests/tests/tigetprotocolnumber.c
+++ b/drivers/network/tcpip/tests/tests/tigetprotocolnumber.c
@@ -3,9 +3,9 @@
 
 static void RunTest() {
     UNICODE_STRING Str;
-    int Proto;
+    USHORT Proto;
     RtlInitUnicodeString( &Str, L"1" );
-    TiGetProtocolNumber( &Str, (PULONG)&Proto );
+    TiGetProtocolNumber( &Str, &Proto );
     _AssertEqualValue(1, Proto);
 }
 


### PR DESCRIPTION
This implements a case for InfoTdiQueryInformationEx. It's based on wild guesses, but it helps to make Windows 2003 lsass not fail.
- Silence VC warnings
(kernel-fun branch r64175)
