### PR TITLE
[USETUP] Implement CreateProgressBarEx()

### DIFF
--- a/base/setup/usetup/progress.c
+++ b/base/setup/usetup/progress.c
@@ -219,7 +219,7 @@ DrawProgressBar(
     for (coPos.Y = Bar->Top + 2; coPos.Y <= Bar->Bottom - 1; coPos.Y++)
     {
         FillConsoleOutputAttribute(StdOutput,
-                                   Bar.ProgressColour,
+                                   Bar->ProgressColour,
                                    Bar->Width - 2,
                                    coPos,
                                    &Written);
@@ -242,7 +242,7 @@ CreateProgressBarEx(
     SHORT TextTop,
     SHORT TextRight,
     IN BOOLEAN DoubleEdge,
-    WORD ProgressColour,
+    SHORT ProgressColour,
     CHAR *Text)
 {
     PPROGRESSBAR Bar;
@@ -288,10 +288,13 @@ CreateProgressBar(
     CHAR *Text)
 {
 
-    // Call the Ex variant of the function, without invoking ProgressColour parameter...
-    CreateProgressBarEx(SHORT Left, SHORT Top, SHORT Right, SHORT Bottom, SHORT TextTop, SHORT TextRight, IN BOOLEAN DoubleEdge, CHAR *Text);
+    /* Call the Ex variant of the function */
+    return CreateProgressBarEx(Left, Top, Right, Bottom,
+                               TextTop, TextRight,
+                               DoubleEdge,
+                               FOREGROUND_YELLOW | BACKGROUND_BLUE,
+                               Text);
 }
-
 
 VOID
 DestroyProgressBar(

--- a/base/setup/usetup/progress.c
+++ b/base/setup/usetup/progress.c
@@ -219,7 +219,7 @@ DrawProgressBar(
     for (coPos.Y = Bar->Top + 2; coPos.Y <= Bar->Bottom - 1; coPos.Y++)
     {
         FillConsoleOutputAttribute(StdOutput,
-                                   FOREGROUND_YELLOW | BACKGROUND_BLUE,
+                                   Bar.ProgressColour,
                                    Bar->Width - 2,
                                    coPos,
                                    &Written);
@@ -234,7 +234,7 @@ DrawProgressBar(
 
 
 PPROGRESSBAR
-CreateProgressBar(
+CreateProgressBarEx(
     SHORT Left,
     SHORT Top,
     SHORT Right,
@@ -242,6 +242,7 @@ CreateProgressBar(
     SHORT TextTop,
     SHORT TextRight,
     IN BOOLEAN DoubleEdge,
+    WORD ProgressColour,
     CHAR *Text)
 {
     PPROGRESSBAR Bar;
@@ -259,6 +260,7 @@ CreateProgressBar(
     Bar->TextTop = TextTop;
     Bar->TextRight = TextRight;
     Bar->Double = DoubleEdge;
+    Bar->ProgressColour = ProgressColour;
     Bar->Text = Text;
 
     Bar->Width = Bar->Right - Bar->Left + 1;
@@ -272,6 +274,22 @@ CreateProgressBar(
     DrawProgressBar(Bar);
 
     return Bar;
+}
+
+PPROGRESSBAR
+CreateProgressBar(
+    SHORT Left,
+    SHORT Top,
+    SHORT Right,
+    SHORT Bottom,
+    SHORT TextTop,
+    SHORT TextRight,
+    IN BOOLEAN DoubleEdge,
+    CHAR *Text)
+{
+
+    // Call the Ex variant of the function, without invoking ProgressColour parameter...
+    CreateProgressBarEx(SHORT Left, SHORT Top, SHORT Right, SHORT Bottom, SHORT TextTop, SHORT TextRight, IN BOOLEAN DoubleEdge, CHAR *Text);
 }
 
 

--- a/base/setup/usetup/progress.h
+++ b/base/setup/usetup/progress.h
@@ -44,7 +44,7 @@ typedef struct _PROGRESS
     ULONG CurrentStep;
 
     BOOLEAN Double;
-    WORD ProgressColour;
+    SHORT ProgressColour;
     CHAR *Text;
 } PROGRESSBAR, *PPROGRESSBAR;
 
@@ -59,7 +59,7 @@ CreateProgressBarEx(
     SHORT TextTop,
     SHORT TextRight,
     IN BOOLEAN DoubleEdge,
-    WORD ProgressColour,
+    SHORT ProgressColour,
     CHAR *Text);
 
 PPROGRESSBAR

--- a/base/setup/usetup/progress.h
+++ b/base/setup/usetup/progress.h
@@ -44,10 +44,23 @@ typedef struct _PROGRESS
     ULONG CurrentStep;
 
     BOOLEAN Double;
+    WORD ProgressColour;
     CHAR *Text;
 } PROGRESSBAR, *PPROGRESSBAR;
 
 /* FUNCTIONS ****************************************************************/
+
+PPROGRESSBAR
+CreateProgressBarEx(
+    SHORT Left,
+    SHORT Top,
+    SHORT Right,
+    SHORT Bottom,
+    SHORT TextTop,
+    SHORT TextRight,
+    IN BOOLEAN DoubleEdge,
+    WORD ProgressColour,
+    CHAR *Text);
 
 PPROGRESSBAR
 CreateProgressBar(


### PR DESCRIPTION
## Purpose
Currently our USETUP lacks the option to choose a different colour from yellow, which is the default colour for the most of progress bars in the setup. This patch implements the required code to solve this. This allows me to begin the implementation of a reboot progress bar similar on 2000/XP USETUPs - you know what I mean.
## Proposed Changes
- Add a new member to the struct, ``ProgressColour``
- Implement ``CreateProgressBarEx()`` and recreate ``CreateProgressBar()`` which will invoke the extended function
- Remove the hard-coded parameter on 222 line
## Presentation
**Video URL:** https://youtu.be/4s5tGsUhx1k