### PR TITLE
[REACTOS] Introduce a "DEBUGFORMAT" environment variable that allows to select different debug trace formats. - CORE-12671

### DIFF
--- a/sdk/include/reactos/wine/debug.h
+++ b/sdk/include/reactos/wine/debug.h
@@ -141,7 +141,7 @@ struct __wine_debug_channel
 
 #define __WINE_DPRINTF(dbcl,dbch) \
     (!__WINE_GET_DEBUGGING(dbcl,(dbch)) || \
-     (ros_dbg_log(__WINE_DBCL##dbcl,(dbch),__FILE__,"",__LINE__,"") == -1)) ? \
+     (ros_dbg_log(__WINE_DBCL##dbcl,(dbch),__RELFILE__,__FUNCTION__,__LINE__,"") == -1)) ? \
      (void)0 : (void)wine_dbg_printf
 
 #define __WINE_PRINTF_ATTR(fmt, args)


### PR DESCRIPTION
**Supersedes PR #112.**

JIRA issue: [CORE-12671](https://jira.reactos.org/browse/CORE-12671)

- The default format is used when no format name is specified: this is
  the one we use so far in ReactOS:

    `<debug_class>:(<file>:<line>) <message>`

  with "debug_class" being "trace", "warn", "err".

- The "wine" format is the one used by Wine. It can be used when trying
  to diff-compare traces for a module with the corresponding one
  obtained from a Wine run. It can also be useful because the logging of
  Wine-synced code assumes that the function names are automatically
  added by the helper macros "FIXME()", "TRACE()", "WARN()" or "ERR()",
  and not manually inside the logging string given to these macros:
  for example:

    `FIXME("(%params) message\n", params);`

  displays:

    `fixme:<module>:SomeFunc(params) message`

- The "extended" (or "ext") format is very noisy and tries to output a
  lot of information; it is a hybrid of the previous two formats:

    `<debug_class>:(<file>:<line>):<channel>:SomeFunc <message>`

Support for displaying the current process ID is added in
addition to the already existing support for thread ID.