### PR TITLE
[SHELL32] Enable background image of folder view

### DIFF
--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -3590,8 +3590,8 @@ DrawTileBitmap(HDC hDC, LPCRECT prc, HBITMAP hbm, INT nWidth, INT nHeight)
     INT x, y, x0, y0, x1, y1;
     x0 = prc->left;
     y0 = prc->top;
-    x1 = prc->right + nWidth - 1;
-    y1 = prc->bottom + nHeight - 1;
+    x1 = prc->right;
+    y1 = prc->bottom;
 
     HDC hMemDC = CreateCompatibleDC(hDC);
     HGDIOBJ hbmOld = SelectObject(hMemDC, hbm);

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2,7 +2,6 @@
  * ReactOS Explorer
  *
  * Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
- * Copyright 2018 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -3686,7 +3685,6 @@ LRESULT CShellBrowser::OnRefresh(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL 
 {
     if (fCurrentShellView)
         fCurrentShellView->Refresh();
-
     return 0;
 }
 

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -2,6 +2,7 @@
  * ReactOS Explorer
  *
  * Copyright 2009 Andrew Hill <ash77 at domain reactos.org>
+ * Copyright 2018 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -24,6 +24,7 @@
 #include <htiframe.h>
 #include <strsafe.h>
 #include <undocshell.h>
+#include <olectl.h>
 
 extern HRESULT IUnknown_ShowDW(IUnknown * punk, BOOL fShow);
 
@@ -167,6 +168,8 @@ HRESULT WINAPI SHBindToFolder(LPCITEMIDLIST path, IShellFolder **newFolder)
     return desktop->BindToObject (path, NULL, IID_PPV_ARG(IShellFolder, newFolder));
 }
 
+HBITMAP DoLoadPicture(LPCWSTR pszFileName);
+
 static const TCHAR szCabinetWndClass[] = TEXT("CabinetWClass");
 //static const TCHAR szExploreWndClass[] = TEXT("ExploreWClass");
 
@@ -306,6 +309,7 @@ private:
     IBindCtx                                *fHistoryBindContext;
     HDSA menuDsa;
     HACCEL m_hAccel;
+    HBITMAP m_hBackImage;
 public:
 #if 0
     ULONG InternalAddRef()
@@ -324,6 +328,7 @@ public:
     ~CShellBrowser();
     HRESULT Initialize(LPITEMIDLIST pidl, DWORD dwFlags);
 public:
+    BOOL CheckBackImage(LPCITEMIDLIST pidl);
     HRESULT BrowseToPIDL(LPCITEMIDLIST pidl, long flags);
     HRESULT BrowseToPath(IShellFolder *newShellFolder, LPCITEMIDLIST absolutePIDL,
         FOLDERSETTINGS *folderSettings, long flags);
@@ -600,6 +605,7 @@ public:
     LRESULT OnInitMenuPopup(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnSetFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT RelayMsgToShellView(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnPrintClient(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnClose(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &bHandled);
     LRESULT OnFolderOptions(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL &bHandled);
@@ -647,6 +653,7 @@ public:
         MESSAGE_HANDLER(WM_DRAWITEM, RelayMsgToShellView)
         MESSAGE_HANDLER(WM_MENUSELECT, RelayMsgToShellView)
         MESSAGE_HANDLER(WM_SETTINGCHANGE, OnSettingChange)
+        MESSAGE_HANDLER(WM_PRINTCLIENT, OnPrintClient)
         COMMAND_ID_HANDLER(IDM_FILE_CLOSE, OnClose)
         COMMAND_ID_HANDLER(IDM_TOOLS_FOLDEROPTIONS, OnFolderOptions)
         COMMAND_ID_HANDLER(IDM_TOOLS_MAPNETWORKDRIVE, OnMapNetworkDrive)
@@ -714,10 +721,13 @@ CShellBrowser::CShellBrowser()
     fHistoryObject = NULL;
     fHistoryStream = NULL;
     fHistoryBindContext = NULL;
+    m_hBackImage = NULL;
 }
 
 CShellBrowser::~CShellBrowser()
 {
+    if (m_hBackImage)
+        DeleteObject(m_hBackImage);
     if (menuDsa)
         DSA_Destroy(menuDsa);
 }
@@ -917,6 +927,65 @@ long IEGetNameAndFlags(LPITEMIDLIST pidl, SHGDNF uFlags, LPWSTR pszBuf, UINT cch
     return IEGetNameAndFlagsEx(pidl, uFlags, 0, pszBuf, cchBuf, rgfInOut);
 }
 
+BOOL CShellBrowser::CheckBackImage(LPCITEMIDLIST pidl)
+{
+    if (m_hBackImage)
+    {
+        DeleteObject(m_hBackImage);
+        m_hBackImage = NULL;
+    }
+
+    COLORREF clrText = GetSysColor(COLOR_WINDOWTEXT);
+
+    WCHAR szPath[MAX_PATH], szIniFile[MAX_PATH];
+    SHGetPathFromIDListW(pidl, szPath);
+
+    // does the folder exists?
+    DWORD attrs = GetFileAttributesW(szPath);
+    if (attrs == INVALID_FILE_ATTRIBUTES)
+    {
+        return FALSE;
+    }
+
+    // build the ini file path
+    StringCchCopyW(szIniFile, _countof(szIniFile), szPath);
+    PathAddBackslashW(szIniFile);
+    StringCchCatW(szIniFile, _countof(szIniFile), L"desktop.ini");
+
+    static LPCWSTR TheGUID = L"{BE098140-A513-11D0-A3A4-00C04FD706EC}";
+    static LPCWSTR Space = L" \t\n\r\f\v";
+
+    // get info from ini file
+    WCHAR szImage[MAX_PATH], szText[64];
+    GetPrivateProfileStringW(TheGUID, L"IconArea_Image", L"", szImage, _countof(szImage), szIniFile);
+    GetPrivateProfileStringW(TheGUID, L"IconArea_Text", L"", szText, _countof(szText), szIniFile);
+
+    // load the image
+    if (szImage[0])
+    {
+        StrTrimW(szImage, Space);
+
+        if (PathIsRelativeW(szImage))
+        {
+            PathAppendW(szPath, szImage);
+            StringCchCopyW(szImage, _countof(szImage), szPath);
+        }
+
+        m_hBackImage = DoLoadPicture(szImage);
+    }
+
+    // load the text color
+    if (szText[0])
+    {
+        StrTrimW(szText, Space);
+        clrText = (wcstol(szText, NULL, 0) & 0xFFFFFF);
+
+        // TODO: clrText
+    }
+
+    return TRUE;
+}
+
 HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
     LPCITEMIDLIST absolutePIDL, FOLDERSETTINGS *folderSettings, long flags)
 {
@@ -1002,6 +1071,7 @@ HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
     // update current pidl
     ILFree(fCurrentDirectoryPIDL);
     fCurrentDirectoryPIDL = ILClone(absolutePIDL);
+    CheckBackImage(fCurrentDirectoryPIDL);
 
     // update view window
     if (saveCurrentShellView != NULL)
@@ -3513,6 +3583,53 @@ LRESULT CShellBrowser::RelayMsgToShellView(UINT uMsg, WPARAM wParam, LPARAM lPar
     return 0;
 }
 
+static VOID
+DrawTileBitmap(HDC hDC, LPCRECT prc, HBITMAP hbm, INT nWidth, INT nHeight)
+{
+    INT x, y, x0, y0, x1, y1;
+    x0 = prc->left;
+    y0 = prc->top;
+    x1 = prc->right + nWidth - 1;
+    y1 = prc->bottom + nHeight - 1;
+
+    HDC hMemDC = CreateCompatibleDC(hDC);
+    HGDIOBJ hbmOld = SelectObject(hMemDC, hbm);
+    for (y = y0; y < y1; y += nHeight)
+    {
+        for (x = x0; x < x1; x += nWidth)
+        {
+            BitBlt(hDC, x, y, nWidth, nHeight, hMemDC, 0, 0, SRCCOPY);
+        }
+    }
+    SelectObject(hMemDC, hbmOld);
+    DeleteDC(hMemDC);
+}
+
+LRESULT CShellBrowser::OnPrintClient(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
+{
+    HDC hDC = (HDC)wParam;
+    HWND hwndCtrl = ::WindowFromDC(hDC);
+
+    RECT rc;
+    ::GetClientRect(hwndCtrl, &rc);
+
+    if (m_hBackImage)
+    {
+        BITMAP bm;
+        if (GetObject(m_hBackImage, sizeof(BITMAP), &bm))
+        {
+            DrawTileBitmap(hDC, &rc, m_hBackImage, bm.bmWidth, bm.bmHeight);
+        }
+    }
+    else
+    {
+        FillRect(hDC, &rc, GetSysColorBrush(COLOR_WINDOW));
+    }
+
+    bHandled = TRUE;
+    return TRUE;
+}
+
 LRESULT CShellBrowser::OnSettingChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
 {
     LPVOID lpEnvironment;
@@ -3685,6 +3802,9 @@ LRESULT CShellBrowser::OnRefresh(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL 
 {
     if (fCurrentShellView)
         fCurrentShellView->Refresh();
+
+    CheckBackImage(fCurrentDirectoryPIDL);
+
     return 0;
 }
 
@@ -3737,4 +3857,70 @@ LRESULT CShellBrowser::RelayCommands(UINT uMsg, WPARAM wParam, LPARAM lParam, BO
 HRESULT CShellBrowser_CreateInstance(LPITEMIDLIST pidl, DWORD dwFlags, REFIID riid, void **ppv)
 {
     return ShellObjectCreatorInit<CShellBrowser>(pidl, dwFlags, riid, ppv);
+}
+
+HBITMAP DoLoadPicture(LPCWSTR pszFileName)
+{
+    // open the picture file
+    HANDLE hFile;
+    hFile = CreateFileW(pszFileName, GENERIC_READ, FILE_SHARE_READ,
+                        NULL, OPEN_EXISTING, 0, NULL);
+    if (hFile == INVALID_HANDLE_VALUE)
+        return NULL;
+
+    // get the file size
+    DWORD cbGlobal = GetFileSize(hFile, NULL);
+    if (cbGlobal == INVALID_FILE_SIZE)
+    {
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    // allocate
+    HGLOBAL hGlobal = GlobalAlloc(GMEM_MOVEABLE, cbGlobal);
+    if (hGlobal == NULL)
+    {
+        CloseHandle(hFile);
+        return NULL;
+    }
+
+    // read it
+    LPVOID pvGlobal = GlobalLock(hGlobal);
+    DWORD cbRead;
+    if (!pvGlobal || !ReadFile(hFile, pvGlobal, cbGlobal, &cbRead, NULL) ||
+        cbRead != cbGlobal)
+    {
+        GlobalUnlock(hGlobal);
+        GlobalFree(hGlobal);
+        CloseHandle(hFile);
+        return NULL;
+    }
+    GlobalUnlock(hGlobal);
+
+    // close the file
+    CloseHandle(hFile);
+
+    // load the picture
+    HBITMAP hbm = NULL;
+    IPicture *pPicture = NULL;
+    IStream *pStream = NULL;
+    if (CreateStreamOnHGlobal(hGlobal, TRUE, &pStream) == S_OK)
+    {
+        OleLoadPicture(pStream, cbGlobal, FALSE, IID_IPicture, (LPVOID *)&pPicture);
+
+        // get the bitmap handle
+        if (pPicture)
+        {
+            pPicture->get_Handle((OLE_HANDLE *)&hbm);
+
+            // copy the bitmap handle
+            hbm = (HBITMAP)CopyImage(hbm, IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION);
+
+            pPicture->Release();
+        }
+        pStream->Release();
+    }
+    GlobalFree(hGlobal);
+
+    return hbm;
 }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3428,7 +3428,7 @@ HRESULT WINAPI SHCreateShellFolderView(const SFV_CREATE *pcsfv,
     return hRes;
 }
 
-    HBITMAP DoLoadPicture(LPCWSTR pszFileName)
+HBITMAP DoLoadPicture(LPCWSTR pszFileName)
 {
     // open the picture file
     HANDLE hFile;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1067,17 +1067,13 @@ LRESULT CDefView::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
 static VOID
 DrawTileBitmap(HDC hDC, LPCRECT prc, HBITMAP hbm, INT nWidth, INT nHeight)
 {
-    INT x, y, x0, y0, x1, y1;
-    x0 = prc->left;
-    y0 = prc->top;
-    x1 = prc->right;
-    y1 = prc->bottom;
+    INT x0 = prc->left, y0 = prc->top, x1 = prc->right, y1 = prc->bottom;
 
     HDC hMemDC = CreateCompatibleDC(hDC);
     HGDIOBJ hbmOld = SelectObject(hMemDC, hbm);
-    for (y = y0; y < y1; y += nHeight)
+    for (INT y = y0; y < y1; y += nHeight)
     {
-        for (x = x0; x < x1; x += nWidth)
+        for (INT x = x0; x < x1; x += nWidth)
         {
             BitBlt(hDC, x, y, nWidth, nHeight, hMemDC, 0, 0, SRCCOPY);
         }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -257,6 +257,7 @@ class CDefView :
         LRESULT OnGetDlgCode(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
         LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
         LRESULT OnEraseBackground(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnPrintClient(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
         LRESULT OnSysColorChange(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
         LRESULT OnGetShellBrowser(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
         LRESULT OnNCCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
@@ -323,6 +324,7 @@ class CDefView :
         MESSAGE_HANDLER(WM_GETDLGCODE, OnGetDlgCode)
         MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
         MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBackground)
+        MESSAGE_HANDLER(WM_PRINTCLIENT, OnPrintClient)
         MESSAGE_HANDLER(WM_SYSCOLORCHANGE, OnSysColorChange)
         MESSAGE_HANDLER(CWM_GETISHELLBROWSER, OnGetShellBrowser)
         MESSAGE_HANDLER(WM_SETTINGCHANGE, OnSettingChange)
@@ -573,6 +575,12 @@ BOOL CDefView::CreateList()
 
     if (!m_ListView)
         return FALSE;
+
+    if (!(m_FolderSettings.fFlags & FWF_DESKTOP))
+    {
+        const DWORD dwLBExStyle = LVS_EX_TRANSPARENTBKGND;
+        ::SendMessage(m_ListView, LVM_SETEXTENDEDLISTVIEWSTYLE, dwLBExStyle, dwLBExStyle);
+    }
 
     m_sortInfo.bIsAscending = TRUE;
     m_sortInfo.nHeaderID = -1;
@@ -988,6 +996,12 @@ LRESULT CDefView::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
     }
     bHandled = FALSE;
     return 0;
+}
+
+LRESULT CDefView::OnPrintClient(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)
+{
+    bHandled = TRUE;
+    return SendMessageW(GetParent(), WM_PRINTCLIENT, wParam, lParam);
 }
 
 LRESULT CDefView::OnEraseBackground(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled)

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1087,9 +1087,12 @@ LRESULT CDefView::OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
 }
 
 static VOID
-DrawTileBitmap(HDC hDC, LPCRECT prc, HBITMAP hbm, INT nWidth, INT nHeight)
+DrawTileBitmap(HDC hDC, LPCRECT prc, HBITMAP hbm, INT nWidth, INT nHeight, INT dx, INT dy)
 {
     INT x0 = prc->left, y0 = prc->top, x1 = prc->right, y1 = prc->bottom;
+
+    x0 += dx;
+    y0 += dy;
 
     HDC hMemDC = CreateCompatibleDC(hDC);
     HGDIOBJ hbmOld = SelectObject(hMemDC, hbm);
@@ -1116,7 +1119,9 @@ LRESULT CDefView::OnPrintClient(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
         BITMAP bm;
         if (::GetObject(m_hBackImage, sizeof(BITMAP), &bm))
         {
-            DrawTileBitmap(hDC, &rc, m_hBackImage, bm.bmWidth, bm.bmHeight);
+            INT dx = -(::GetScrollPos(m_ListView, SB_HORZ) % bm.bmWidth);
+            INT dy = -(::GetScrollPos(m_ListView, SB_VERT) % bm.bmHeight);
+            DrawTileBitmap(hDC, &rc, m_hBackImage, bm.bmWidth, bm.bmHeight, dx, dy);
         }
     }
     else

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -644,14 +644,9 @@ void CDefView::UpdateListColors()
     {
         if (m_crCustomTextColor != CLR_INVALID)
         {
+            m_ListView.SetTextBkColor(CLR_NONE);
             m_ListView.SetTextColor(m_crCustomTextColor);
-
-            if (GetRValue(m_crCustomTextColor) + GetGValue(m_crCustomTextColor) + GetBValue(m_crCustomTextColor) > 128 * 3)
-                m_ListView.SetTextBkColor(RGB(0, 0, 0));
-            else
-                m_ListView.SetTextBkColor(RGB(255, 255, 255));
-
-            m_ListView.SetExtendedListViewStyle(0, LVS_EX_TRANSPARENTSHADOWTEXT);
+            m_ListView.SetExtendedListViewStyle(LVS_EX_TRANSPARENTSHADOWTEXT, LVS_EX_TRANSPARENTSHADOWTEXT);
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR enables the user to set the background image of the folder view, by the desktop.ini file.
JIRA issue: [CORE-5516](https://jira.reactos.org/browse/CORE-5516)

## Todo
- [x] Refresh the background on navigation.
- [x] Refresh the background on view refresh.
- [x] Text Color.
- [x] Scroll.
