### PR TITLE
Fixes for cmake 3.11

### DIFF
--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -223,6 +223,9 @@ endif()
 add_executable(freeldr_pe ${FREELDR_BASE_SOURCE})
 add_executable(freeldr_pe_dbg EXCLUDE_FROM_ALL ${FREELDR_BASE_SOURCE})
 
+set_property(TARGET freeldr_pe PROPERTY ENABLE_EXPORTS TRUE)
+set_property(TARGET freeldr_pe_dbg PROPERTY ENABLE_EXPORTS TRUE)
+
 if(NOT MSVC AND SEPARATE_DBG)
     set_target_properties(freeldr_pe PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)
     set_target_properties(freeldr_pe_dbg PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)

--- a/dll/3rdparty/libtirpc/CMakeLists.txt
+++ b/dll/3rdparty/libtirpc/CMakeLists.txt
@@ -39,7 +39,6 @@ list(APPEND SOURCE
     src/gettimeofday.c
     src/key_call.c
     src/key_prot_xdr.c
-    src/libtirpc.def
     #src/makefile
     #src/Makefile.am
     src/mt_misc.c

--- a/ntoskrnl/CMakeLists.txt
+++ b/ntoskrnl/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(ntoskrnl
     guid.c
     ntoskrnl.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntoskrnl.def)
+set_property(TARGET ntoskrnl PROPERTY ENABLE_EXPORTS TRUE)
 
 if(ARCH STREQUAL "i386")
     set_entrypoint(ntoskrnl KiSystemStartup 4)

--- a/ntoskrnl/ntkrnlmp/CMakeLists.txt
+++ b/ntoskrnl/ntkrnlmp/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(ntkrnlmp
     ${REACTOS_SOURCE_DIR}/ntoskrnl/guid.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ntoskrnl.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntkrnlmp.def)
+set_property(TARGET ntkrnlmp PROPERTY ENABLE_EXPORTS TRUE)
 
 add_target_compile_definitions(ntkrnlmp CONFIG_SMP)
 


### PR DESCRIPTION
With these two commits cmake 3.11 successfully builds reactos

VSSolution doesn't work, presumably depending on rosbe's patched cmake; ninja+msvc should but has not been tested