### PR TITLE
[LOG2LINES] Improve malloc() and free() uses

### DIFF
--- a/sdk/tools/log2lines/cache.c
+++ b/sdk/tools/log2lines/cache.c
@@ -18,8 +18,10 @@
 
 #include "log2lines.h"
 
-static char *cache_name;
-static char *tmp_name;
+static char CacheName[PATH_MAX];
+static char *cache_name = CacheName;
+static char TmpName[PATH_MAX];
+static char *tmp_name = TmpName;
 
 static int
 unpack_iso(char *dir, char *iso)
@@ -141,8 +143,6 @@ check_directory(int force)
             return 1;
         }
     }
-    cache_name = malloc(PATH_MAX);
-    tmp_name = malloc(PATH_MAX);
     strcpy(cache_name, opt_dir);
     if (cleanable(opt_dir))
         strcat(cache_name, ALT_PATH_STR CACHEFILE);
@@ -158,22 +158,15 @@ read_cache(void)
 {
     FILE *fr;
     LIST_MEMBER *pentry;
-    char *Line = NULL;
+    char Line[LINESIZE + 1];
     int result = 0;
 
-    Line = malloc(LINESIZE + 1);
-    if (!Line)
-    {
-        l2l_dbg(1, "Alloc Line failed\n");
-        return 1;
-    }
     Line[LINESIZE] = '\0';
 
     fr = fopen(cache_name, "r");
     if (!fr)
     {
         l2l_dbg(1, "Open %s failed\n", cache_name);
-        free(Line);
         return 2;
     }
     cache.phead = cache.ptail = NULL;
@@ -190,7 +183,6 @@ read_cache(void)
     }
 
     fclose(fr);
-    free(Line);
     return result;
 }
 
@@ -198,7 +190,7 @@ int
 create_cache(int force, int skipImageBase)
 {
     FILE *fr, *fw;
-    char *Line = NULL, *Fname = NULL;
+    char Line[LINESIZE + 1], *Fname = NULL;
     int len, err;
     size_t ImageBase;
 
@@ -229,9 +221,6 @@ create_cache(int force, int skipImageBase)
         }
     }
 
-    Line = malloc(LINESIZE + 1);
-    if (!Line)
-        return 1;
     Line[LINESIZE] = '\0';
 
     remove(tmp_name);
@@ -243,7 +232,6 @@ create_cache(int force, int skipImageBase)
         l2l_dbg(0, "Cannot list directory %s\n", opt_dir);
         l2l_dbg(1, "Failed to execute: '%s'\n", Line);
         remove(tmp_name);
-        free(Line);
         return 2;
     }
     l2l_dbg(0, "Creating cache ...");
@@ -280,7 +268,6 @@ create_cache(int force, int skipImageBase)
         fclose(fr);
     }
     remove(tmp_name);
-    free(Line);
     return 0;
 }
 

--- a/sdk/tools/log2lines/log2lines.c
+++ b/sdk/tools/log2lines/log2lines.c
@@ -410,9 +410,9 @@ translate_line(FILE *outFile, char *Line, char *path, char *LineOut)
 static int
 translate_files(FILE *inFile, FILE *outFile)
 {
-    char *Line = malloc(LINESIZE + 1);
-    char *path = malloc(LINESIZE + 1);
-    char *LineOut = malloc(LINESIZE + 1);
+    char Line[LINESIZE + 1];
+    char path[LINESIZE + 1];
+    char LineOut[LINESIZE + 1];
     int c;
     unsigned char ch;
     int i = 0;
@@ -420,8 +420,6 @@ translate_files(FILE *inFile, FILE *outFile)
     const char *p     = kdbg_prompt;
     const char *p_eos = p + sizeof(KDBG_PROMPT) - 1; //end of string pos
 
-    if (Line && path && LineOut)
-    {
         memset(Line, '\0', LINESIZE + 1);
         if (opt_console)
         {
@@ -536,7 +534,6 @@ translate_files(FILE *inFile, FILE *outFile)
                     log(outFile, "%s", Line);
             }
         }
-    }
 
     if (opt_Revision && (strstr(opt_Revision, "regscan") == opt_Revision))
     {
@@ -555,9 +552,6 @@ translate_files(FILE *inFile, FILE *outFile)
         if (logFile)
             stat_print(logFile, &summ);
     }
-    free(LineOut);
-    free(Line);
-    free(path);
     return 0;
 }
 

--- a/sdk/tools/log2lines/options.c
+++ b/sdk/tools/log2lines/options.c
@@ -96,8 +96,8 @@ int optionInit(int argc, const char **argv)
                 strcpy(opt_logFile, argv[i+1]);
                 break;
             case 'P':
-                free(opt_Pipe);
-                opt_Pipe = malloc(LINESIZE);
+                if (!opt_Pipe)
+                    opt_Pipe = malloc(LINESIZE);
                 strcpy(opt_Pipe, argv[i+1]);
                 break;
             case 'z':
@@ -166,8 +166,8 @@ int optionParse(int argc, const char **argv)
             break;
         case 'R':
             optCount++;
-            free(opt_Revision);
-            opt_Revision = malloc(LINESIZE);
+            if (!opt_Revision)
+                opt_Revision = malloc(LINESIZE);
             sscanf(optarg, "%s", opt_Revision);
             if (strcmp(opt_Revision, "check") == 0)
                 opt_Revision_check ++;


### PR DESCRIPTION
## Purpose

`Log2Lines` uses a mix of `malloc()` and no `malloc()`. I don't know why.
Simpler and safer code.

## Proposed changes

- Replace overkill malloc() uses
- Optimize malloc() uses
- Free all memory on exit
