### PR TITLE
[NTOS:KE] fix stub for KeAcquireInStackQueuedSpinLockForDpc

### DIFF
--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -415,13 +415,13 @@ KeReleaseSpinLockForDpc(IN PKSPIN_LOCK SpinLock,
 /*
  * @unimplemented
  */
-KIRQL
+VOID
 FASTCALL
 KeAcquireInStackQueuedSpinLockForDpc(IN PKSPIN_LOCK SpinLock,
                                      IN PKLOCK_QUEUE_HANDLE LockHandle)
 {
     UNIMPLEMENTED;
-    return 0;
+    return;
 }
 
 /*


### PR DESCRIPTION
Error was found when building as 0x600+

CORE-12596