### PR TITLE
Small CShellLink fixes

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -349,14 +349,10 @@ HRESULT STDMETHODCALLTYPE CShellLink::Save(LPCOLESTR pszFileName, BOOL fRemember
 
         if (SUCCEEDED(hr))
         {
-            if (pszFileName != m_sLinkPath)
-            {
-                if (m_sLinkPath)
-                    HeapFree(GetProcessHeap(), 0, m_sLinkPath);
+            if (m_sLinkPath)
+                HeapFree(GetProcessHeap(), 0, m_sLinkPath);
 
-                m_sLinkPath = strdupW(pszFileName);
-            }
-
+            m_sLinkPath = strdupW(pszFileName);
             m_bDirty = FALSE;
         }
         else
@@ -1416,12 +1412,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::Resolve(HWND hwnd, DWORD fFlags)
         bSuccess = SHGetPathFromIDListW(m_pPidl, buffer);
         if (bSuccess && *buffer)
         {
-            if (buffer != m_sPath)
-            {
-                m_sPath = strdupW(buffer);
-                if (!m_sPath)
-                    return E_OUTOFMEMORY;
-            }
+            m_sPath = strdupW(buffer);
+            if (!m_sPath)
+                return E_OUTOFMEMORY;
 
             m_bDirty = TRUE;
         }
@@ -1434,12 +1427,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::Resolve(HWND hwnd, DWORD fFlags)
     // FIXME: Strange to do that here...
     if (!m_sIcoPath && m_sPath)
     {
-        if (m_sIcoPath != m_sPath)
-        {
-            m_sIcoPath = strdupW(m_sPath);
-            if (!m_sIcoPath)
-                return E_OUTOFMEMORY;
-        }
+        m_sIcoPath = strdupW(m_sPath);
+        if (!m_sIcoPath)
+            return E_OUTOFMEMORY;
 
         m_Header.nIconIndex = 0;
 
@@ -1565,12 +1555,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetDescription(LPCWSTR pszName)
     HeapFree(GetProcessHeap(), 0, m_sDescription);
     if (pszName)
     {
-        if (m_sDescription != pszName)
-        {
-            m_sDescription = strdupW(pszName);
-            if (!m_sDescription)
-                return E_OUTOFMEMORY;
-        }
+        m_sDescription = strdupW(pszName);
+        if (!m_sDescription)
+            return E_OUTOFMEMORY;
     }
     else
         m_sDescription = NULL;
@@ -1600,12 +1587,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetWorkingDirectory(LPCWSTR pszDir)
     HeapFree(GetProcessHeap(), 0, m_sWorkDir);
     if (pszDir)
     {
-        if (m_sWorkDir != pszDir)
-        {
-            m_sWorkDir = strdupW(pszDir);
-            if (!m_sWorkDir)
-                return E_OUTOFMEMORY;
-        }
+        m_sWorkDir = strdupW(pszDir);
+        if (!m_sWorkDir)
+            return E_OUTOFMEMORY;
     }
     else
         m_sWorkDir = NULL;
@@ -1635,12 +1619,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetArguments(LPCWSTR pszArgs)
     HeapFree(GetProcessHeap(), 0, m_sArgs);
     if (pszArgs)
     {
-        if (m_sArgs != pszArgs)
-        {
-            m_sArgs = strdupW(pszArgs);
-            if (!m_sArgs)
-                return E_OUTOFMEMORY;
-        }
+        m_sArgs = strdupW(pszArgs);
+        if (!m_sArgs)
+            return E_OUTOFMEMORY;
     }
     else
         m_sArgs = NULL;
@@ -1675,12 +1656,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::GetIconLocation(LPWSTR pszIconPath, INT cc
 
             SHExpandEnvironmentStringsW(pInfo->szwTarget, szPath, _countof(szPath));
 
-            if (m_sIcoPath != szPath)
-            {
-                m_sIcoPath = strdupW(szPath);
-                if (!m_sIcoPath)
-                    return E_OUTOFMEMORY;
-            }
+            m_sIcoPath = strdupW(szPath);
+            if (!m_sIcoPath)
+                return E_OUTOFMEMORY;
 
             m_Header.dwFlags |= SLDF_HAS_ICONLOCATION;
 
@@ -1954,12 +1932,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetIconLocation(LPCWSTR pszIconPath, INT i
         HeapFree(GetProcessHeap(), 0, m_sIcoPath);
         m_sIcoPath = NULL;
 
-        if (m_sIcoPath != pszIconPath)
-        {
-            m_sIcoPath = strdupW(pszIconPath);
-            if (!m_sIcoPath)
-                return E_OUTOFMEMORY;
-        }
+        m_sIcoPath = strdupW(pszIconPath);
+        if (!m_sIcoPath)
+            return E_OUTOFMEMORY;
 
         m_Header.dwFlags |= SLDF_HAS_ICONLOCATION;
     }
@@ -1979,12 +1954,9 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetRelativePath(LPCWSTR pszPathRel, DWORD 
     HeapFree(GetProcessHeap(), 0, m_sPathRel);
     if (pszPathRel)
     {
-        if (m_sPathRel != pszPathRel)
-        {
-            m_sPathRel = strdupW(pszPathRel);
-            if (!m_sPathRel)
-                return E_OUTOFMEMORY;
-        }
+        m_sPathRel = strdupW(pszPathRel);
+        if (!m_sPathRel)
+            return E_OUTOFMEMORY;
     }
     else
         m_sPathRel = NULL;
@@ -2327,12 +2299,12 @@ HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
     /* Update the cached path (for link info) */
     ShellLink_GetVolumeInfo(pszFile, &volume);
 
-    if (m_sPath != pszFile)
-    {
-        m_sPath = strdupW(pszFile);
-        if (!m_sPath)
-            return E_OUTOFMEMORY;
-    }
+    if (m_sPath)
+        HeapFree(GetProcessHeap(), 0, m_sPath);
+
+    m_sPath = strdupW(pszFile);
+    if (!m_sPath)
+        return E_OUTOFMEMORY;
 
     m_bDirty = TRUE;
     return hr;

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -1856,6 +1856,7 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetIconLocation(LPCWSTR pszIconPath, INT i
 {
     HRESULT hr = E_FAIL;
     WCHAR szUnExpIconPath[MAX_PATH];
+    BOOL bSuccess;
 
     TRACE("(%p)->(path=%s iicon=%u)\n", this, debugstr_w(pszIconPath), iIcon);
 
@@ -1875,8 +1876,8 @@ HRESULT STDMETHODCALLTYPE CShellLink::SetIconLocation(LPCWSTR pszIconPath, INT i
          */
         // FIXME: http://stackoverflow.com/questions/2976489/ishelllinkseticonlocation-translates-my-icon-path-into-program-files-which-i
         // if (PathFullyUnExpandEnvStringsW(pszIconPath, szUnExpIconPath, _countof(szUnExpIconPath)))
-        PathUnExpandEnvStringsW(pszIconPath, szUnExpIconPath, _countof(szUnExpIconPath));
-        if (wcscmp(pszIconPath, szUnExpIconPath) != 0)
+        bSuccess = PathUnExpandEnvStringsW(pszIconPath, szUnExpIconPath, _countof(szUnExpIconPath));
+        if (bSuccess && wcscmp(pszIconPath, szUnExpIconPath) != 0)
         {
             /* Unexpansion succeeded, so we need an icon environment block */
             EXP_SZ_LINK buffer;


### PR DESCRIPTION
remove some dead code + check PathUnExpandEnvStringsW for success (don't try to use un-initialized crap)