### PR TITLE
[APITESTS] Add UTF-8 BOM to RtlGenerate8dot3Name.c

### DIFF
--- a/modules/rostests/apitests/ntdll/RtlGenerate8dot3Name.c
+++ b/modules/rostests/apitests/ntdll/RtlGenerate8dot3Name.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:         ReactOS api tests
  * LICENSE:         GPLv2+ - See COPYING in the top level directory
  * PURPOSE:         Test for RtlGenerate8dot3Name


### PR DESCRIPTION
## Purpose
Add UTF-8 BOM to RtlGenerate8dot3Name.c. This will fix CORE-14972.
JIRA issue: [CORE-14972](https://jira.reactos.org/browse/CORE-14972)
