### PR TITLE
[FONT][WIN32SS] Fix GetTextFace function and related

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4799,7 +4799,8 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
             {
                 /* truncated copy */
                 Name.Length = (USHORT)min(Name.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
-                RtlStringCbCopyNW(TextObj->TextFace, Name.Length + sizeof(WCHAR), Name.Buffer, Name.Length);
+                RtlCopyMemory(TextObj->TextFace, Name.Buffer, Name.Length);
+                TextObj->TextFace[Name.Length / sizeof(WCHAR)] = UNICODE_NULL;
 
                 RtlFreeUnicodeString(&Name);
             }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4667,6 +4667,31 @@ IntFontType(PFONTGDI Font)
     }
 }
 
+static BOOL
+MatchFontName(PSHARED_FACE SharedFace, LPCWSTR lfFaceName, FT_UShort NameID, FT_UShort LangID)
+{
+    NTSTATUS Status;
+    UNICODE_STRING Name;
+
+    if (lfFaceName[0] == UNICODE_NULL)
+        return FALSE;
+
+    RtlInitUnicodeString(&Name, NULL);
+    Status = IntGetFontLocalizedName(&Name, SharedFace, NameID, LangID);
+    if (NT_SUCCESS(Status))
+    {
+        if (_wcsicmp(Name.Buffer, lfFaceName) == 0)
+        {
+            RtlFreeUnicodeString(&Name);
+            return TRUE;
+        }
+
+        RtlFreeUnicodeString(&Name);
+    }
+
+    return FALSE;
+}
+
 NTSTATUS
 FASTCALL
 TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
@@ -4731,22 +4756,36 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
     }
     else
     {
-        UNICODE_STRING FaceName;
+        UNICODE_STRING Name;
         PFONTGDI FontGdi = ObjToGDI(TextObj->Font, FONT);
+        PSHARED_FACE SharedFace = FontGdi->SharedFace;
 
         IntLockFreeType();
         IntRequestFontSize(NULL, FontGdi, pLogFont->lfWidth, pLogFont->lfHeight);
         IntUnLockFreeType();
 
-        RtlInitUnicodeString(&FaceName, NULL);
-        IntGetFontLocalizedName(&FaceName, FontGdi->SharedFace, TT_NAME_ID_FONT_FAMILY, gusLanguageID);
+        TextObj->TextFace[0] = UNICODE_NULL;
+        if (MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FONT_FAMILY, LANG_ENGLISH) ||
+            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FULL_NAME, LANG_ENGLISH) ||
+            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FONT_FAMILY, gusLanguageID) ||
+            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FULL_NAME, gusLanguageID))
+        {
+            RtlStringCchCopyW(TextObj->TextFace, _countof(TextObj->TextFace), pLogFont->lfFaceName);
+        }
+        else
+        {
+            RtlInitUnicodeString(&Name, NULL);
+            Status = IntGetFontLocalizedName(&Name, SharedFace, TT_NAME_ID_FONT_FAMILY, gusLanguageID);
+            if (NT_SUCCESS(Status))
+            {
+                /* truncated copy */
+                Name.Length = (USHORT)min(Name.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
+                Name.MaximumLength = (USHORT)(Name.Length + sizeof(UNICODE_NULL));
+                RtlCopyMemory(TextObj->TextFace, Name.Buffer, Name.MaximumLength);
 
-        /* truncated copy */
-        FaceName.Length = (USHORT)min(FaceName.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
-        FaceName.MaximumLength = (USHORT)(FaceName.Length + sizeof(UNICODE_NULL));
-        RtlCopyMemory(TextObj->FaceName, FaceName.Buffer, FaceName.MaximumLength);
-
-        RtlFreeUnicodeString(&FaceName);
+                RtlFreeUnicodeString(&Name);
+            }
+        }
 
         // Need hdev, when freetype is loaded need to create DEVOBJ for
         // Consumer and Producer.

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4671,22 +4671,25 @@ static BOOL
 MatchFontName(PSHARED_FACE SharedFace, LPCWSTR lfFaceName, FT_UShort NameID, FT_UShort LangID)
 {
     NTSTATUS Status;
-    UNICODE_STRING Name;
+    UNICODE_STRING Name1, Name2;
 
     if (lfFaceName[0] == UNICODE_NULL)
         return FALSE;
 
-    RtlInitUnicodeString(&Name, NULL);
-    Status = IntGetFontLocalizedName(&Name, SharedFace, NameID, LangID);
+    RtlInitUnicodeString(&Name1, lfFaceName);
+
+    RtlInitUnicodeString(&Name2, NULL);
+    Status = IntGetFontLocalizedName(&Name2, SharedFace, NameID, LangID);
+
     if (NT_SUCCESS(Status))
     {
-        if (_wcsicmp(Name.Buffer, lfFaceName) == 0)
+        if (RtlCompareUnicodeString(&Name1, &Name2, TRUE) == 0)
         {
-            RtlFreeUnicodeString(&Name);
+            RtlFreeUnicodeString(&Name2);
             return TRUE;
         }
 
-        RtlFreeUnicodeString(&Name);
+        RtlFreeUnicodeString(&Name2);
     }
 
     return FALSE;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4796,8 +4796,8 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
             {
                 /* truncated copy */
                 Name.Length = (USHORT)min(Name.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
-                Name.MaximumLength = (USHORT)(Name.Length + sizeof(UNICODE_NULL));
-                RtlCopyMemory(TextObj->TextFace, Name.Buffer, Name.MaximumLength);
+                RtlCopyMemory(TextObj->TextFace, Name.Buffer, Name.Length);
+                TextObj->TextFace[Name.Length / sizeof(WCHAR)] = UNICODE_NULL;
 
                 RtlFreeUnicodeString(&Name);
             }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4799,8 +4799,7 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
             {
                 /* truncated copy */
                 Name.Length = (USHORT)min(Name.Length, (LF_FACESIZE - 1) * sizeof(WCHAR));
-                RtlCopyMemory(TextObj->TextFace, Name.Buffer, Name.Length);
-                TextObj->TextFace[Name.Length / sizeof(WCHAR)] = UNICODE_NULL;
+                RtlStringCbCopyNW(TextObj->TextFace, Name.Length + sizeof(WCHAR), Name.Buffer, Name.Length);
 
                 RtlFreeUnicodeString(&Name);
             }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4692,6 +4692,25 @@ MatchFontName(PSHARED_FACE SharedFace, LPCWSTR lfFaceName, FT_UShort NameID, FT_
     return FALSE;
 }
 
+static BOOL
+MatchFontNames(PSHARED_FACE SharedFace, LPCWSTR lfFaceName)
+{
+    if (MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FONT_FAMILY, LANG_ENGLISH) ||
+        MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FULL_NAME, LANG_ENGLISH))
+    {
+        return TRUE;
+    }
+    if (PRIMARYLANGID(gusLanguageID) != LANG_ENGLISH)
+    {
+        if (MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FONT_FAMILY, gusLanguageID) ||
+            MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FULL_NAME, gusLanguageID))
+        {
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
 NTSTATUS
 FASTCALL
 TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
@@ -4765,10 +4784,7 @@ TextIntRealizeFont(HFONT FontHandle, PTEXTOBJ pTextObj)
         IntUnLockFreeType();
 
         TextObj->TextFace[0] = UNICODE_NULL;
-        if (MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FONT_FAMILY, LANG_ENGLISH) ||
-            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FULL_NAME, LANG_ENGLISH) ||
-            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FONT_FAMILY, gusLanguageID) ||
-            MatchFontName(SharedFace, SubstitutedLogFont.lfFaceName, TT_NAME_ID_FULL_NAME, gusLanguageID))
+        if (MatchFontNames(SharedFace, SubstitutedLogFont.lfFaceName))
         {
             RtlStringCchCopyW(TextObj->TextFace, _countof(TextObj->TextFace), pLogFont->lfFaceName);
         }

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -513,12 +513,12 @@ NtGdiGetTextFaceW(
 
     TextObj = RealizeFontInit(hFont);
     ASSERT(TextObj != NULL);
-    fLen = wcslen(TextObj->FaceName) + 1;
+    fLen = wcslen(TextObj->TextFace) + 1;
 
     if (FaceName != NULL)
     {
         Count = min(Count, fLen);
-        Status = MmCopyToCaller(FaceName, TextObj->FaceName, Count * sizeof(WCHAR));
+        Status = MmCopyToCaller(FaceName, TextObj->TextFace, Count * sizeof(WCHAR));
         if (!NT_SUCCESS(Status))
         {
             TEXTOBJ_UnlockText(TextObj);

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -64,9 +64,7 @@ typedef struct _LFONT
    LFTYPE        lft;
    FLONG         fl;
    FONTOBJ      *Font;
-   WCHAR         FullName[LF_FULLFACESIZE];
-   WCHAR         Style[LF_FACESIZE];
-   WCHAR         FaceName[LF_FACESIZE];
+   WCHAR         TextFace[LF_FACESIZE];
    DWORD         dwOffsetEndArray;
 // Fixed:
    ENUMLOGFONTEXDVW logfont;


### PR DESCRIPTION
## Purpose
Google Chrome with -no-sandbox parameter in ReactOS wouldn't display the web page because first-chance exception raised. This PR will fix it (CORE-14926). 
JIRA issue: [CORE-14926](https://jira.reactos.org/browse/CORE-14926)

## Changes
- Remove FullName, Style, and FaceName members from TEXTOBJ structure.
- Add TextFace member into TEXTOBJ structure.
- Add MatchFontName and MatchFontNames functions.
- Fix GetTextFace and related.