### PR TITLE
ROSTESTS-299. [KMTESTS:FLTMGR] Hide FltMgrLoad and FltMgrReg

### DIFF
--- a/modules/rostests/kmtests/kmtest/testlist.c
+++ b/modules/rostests/kmtests/kmtest/testlist.c
@@ -42,8 +42,8 @@ const KMT_TEST TestList[] =
     { "-Example",                     Test_Example },
     { "FileAttributes",               Test_FileAttributes },
     { "FindFile",                     Test_FindFile },
-    { "FltMgrLoad",                   Test_FltMgrLoad },
-    { "FltMgrReg",                    Test_FltMgrReg },
+    { "-FltMgrLoad",                  Test_FltMgrLoad }, // TODO: WIP/untested/crashes.
+    { "-FltMgrReg",                   Test_FltMgrReg }, // TODO: WIP/untested/crashes.
     { "HidPDescription",              Test_HidPDescription },
     { "IoCreateFile",                 Test_IoCreateFile },
     { "IoDeviceObject",               Test_IoDeviceObject },


### PR DESCRIPTION
## Purpose

Not worth investigating in current state.

JIRA issue: [ROSTESTS-299](https://jira.reactos.org/browse/ROSTESTS-299)

For what it's worth, it crashes [without](https://testbot.winehq.org/JobDetails.pl?Key=41482) or [with](https://testbot.winehq.org/JobDetails.pl?Key=41476) PR502.

## Proposed changes

And add "// TODO: WIP/untested/crashes."
