### PR TITLE
CORE-12596. [CMLIB] Fix compiling as NT6+

### DIFF
--- a/sdk/lib/cmlib/hiveinit.c
+++ b/sdk/lib/cmlib/hiveinit.c
@@ -556,7 +556,9 @@ HvInitialize(
     Hive->BaseBlockAlloc = sizeof(HBASE_BLOCK); // == HBLOCK_SIZE
 
     Hive->Version = HSYS_MINOR;
+#if (NTDDI_VERSION < NTDDI_VISTA)
     Hive->Log = (FileType == HFILE_TYPE_LOG);
+#endif
     Hive->HiveFlags = HiveFlags & ~HIVE_NOLAZYFLUSH;
 
     switch (OperationType)


### PR DESCRIPTION
## Purpose

Addendum to r70582.
@HBelusca

JIRA issue: [CORE-12596](https://jira.reactos.org/browse/CORE-12596)

```
.../sdk/lib/cmlib/hiveinit.c: In function 'HvInitialize':
.../sdk/lib/cmlib/hiveinit.c:559:9: error: 'struct _HHIVE' has no member named 'Log'
```