### PR TITLE
[LPK] Make GetCharacterPlacement caret position calculation to respect bidi text

### DIFF
--- a/dll/win32/lpk/bidi.c
+++ b/dll/win32/lpk/bidi.c
@@ -460,7 +460,12 @@ BOOL BIDI_Reorder(
 
     if (lpGlyphs)
     {
+#ifdef __REACTOS__
+        /* ReactOS r57677 and r57679 */
+        cMaxGlyphs = 3 * uCount / 2 + 16;
+#else
         cMaxGlyphs = 1.5 * uCount + 16;
+#endif
         run_glyphs = HeapAlloc(GetProcessHeap(),0,sizeof(WORD) * cMaxGlyphs);
         if (!run_glyphs)
         {

--- a/dll/win32/lpk/lpk.c
+++ b/dll/win32/lpk/lpk.c
@@ -134,9 +134,11 @@ LpkGetCharacterPlacement(
     DWORD dwFlags,
     DWORD dwUnused)
 {
+    DWORD ret = 0;
+    HRESULT hr;
+    SCRIPT_STRING_ANALYSIS ssa;
     LPWORD lpGlyphs = NULL;
     SIZE size;
-    DWORD ret = 0;
     UINT nSet, i;
     INT cGlyphs;
 
@@ -190,16 +192,36 @@ LpkGetCharacterPlacement(
         }
     }
 
-    /* FIXME: Currently not bidi compliant! */
     if (lpResults->lpCaretPos)
     {
         int pos = 0;
 
-        lpResults->lpCaretPos[0] = 0;
-        for (i = 1; i < nSet; i++)
+        hr = ScriptStringAnalyse(hdc, lpString, nSet,
+#ifdef __REACTOS__
+                                 /* ReactOS r57677 and r57679 */
+                                 (3 * nSet / 2 + 16),
+#else
+                                 (1.5 * nSet + 16),
+#endif
+                                 -1, SSA_GLYPHS, -1,
+                                 NULL, NULL, NULL, NULL, NULL, &ssa);
+        if (hr == S_OK)
         {
-            if (GetTextExtentPoint32W(hdc, &(lpString[i - 1]), 1, &size))
-                lpResults->lpCaretPos[i] = (pos += size.cx);
+            for (i = 0; i < nSet; i++)
+            {
+                if (ScriptStringCPtoX(ssa, i, FALSE, &pos) == S_OK)
+                    lpResults->lpCaretPos[i] = pos;
+            }
+            ScriptStringFree(&ssa);
+        }
+        else
+        {
+            lpResults->lpCaretPos[0] = 0;
+            for (i = 1; i < nSet; i++)
+            {
+                if (GetTextExtentPoint32W(hdc, &(lpString[i - 1]), 1, &size))
+                    lpResults->lpCaretPos[i] = (pos += size.cx);
+            }
         }
     }
 

--- a/modules/rostests/win32/user32/biditext/biditext.c
+++ b/modules/rostests/win32/user32/biditext/biditext.c
@@ -60,7 +60,7 @@ wWinMain(HINSTANCE hInstance,
   hAccelerators = LoadAccelerators(hInstance, MAKEINTRESOURCE(IDR_ACCELERATOR));
 
   /* Show main window and force a paint */
-  ShowWindow(hWnd, nCmdShow);
+  ShowWindow(hWnd, nCmdShow | SW_MAXIMIZE);
   UpdateWindow(hWnd);
 
   /* Main message loop */
@@ -171,24 +171,47 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
     case WM_PAINT:
         {
             PAINTSTRUCT ps;
-            
-            HDC hdc = BeginPaint(hWnd, &ps);
-            
-            LPWSTR szString = L"אבגדהABCDוזחטי";
-            int Len = (int)wcslen(szString);
 
+            HDC hdc = BeginPaint(hWnd, &ps);
+
+            enum
+            {
+                ALEF = 0x5D0,
+                BET,
+                GIMEL,
+                DALET,
+                HEY,
+                VAV,
+                ZAYIN,
+                HET,
+                TET,
+                YUD
+            };
+
+            const WCHAR szString[] = {ALEF, BET, GIMEL, DALET, HEY, 'A', 'B', 'C', 'D', VAV, ZAYIN, HET, TET, YUD, 0};
+            const WCHAR szReversedString[] = {HEY, DALET, GIMEL, BET, ALEF, 'A', 'B', 'C', 'D', YUD, TET, HET, ZAYIN, VAV, 0};
+            int Len = wcslen(szString);
+            int i, xpos, tempLength;
+            WCHAR tempString[20] = { 0 };
             WCHAR Glyphs[100] = { 0 };
             WCHAR OutString[100] = { 0 };
+            INT lpCaretPos[100] = { 0 };
+            UINT lpOrder[100] = { 0 };
             GCP_RESULTSW Results = { 0 };
+
             Results.lStructSize = sizeof(Results);
             Results.lpOutString = OutString;
             Results.lpGlyphs = Glyphs;
             Results.nGlyphs = 100;
+            Results.lpCaretPos = lpCaretPos;
+            Results.lpOrder = lpOrder;
+
+            SetBkMode(hdc, TRANSPARENT);
 
             TextOutW(hdc, 10, 10, L"Proper (string being used):", 27);
             TextOutW(hdc, 200, 10, szString, 14);
             TextOutW(hdc, 10, 30, L"Reversed (example):", 19);
-            TextOutW(hdc, 200, 30, L"הדגבאABCDיטחזו", 14);
+            TextOutW(hdc, 200, 30, szReversedString, 14);
 
             TextOutW(hdc, 10, 50, L"String with NULL LpkETO call (not reversed):", 44);
             LpkExtTextOut(hdc, 10, 70, 0, NULL, szString, Len, NULL, 0);
@@ -216,6 +239,55 @@ LRESULT CALLBACK MainWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
             TextOutW(hdc, 10, 370, L"String with ETO_RTLREADING ETO call (slight order change)", 57);
             ExtTextOutW(hdc, 10, 390, ETO_RTLREADING, NULL, szString, Len, NULL);
+
+            GetCharacterPlacementW(hdc, szString, Len, 0, &Results, GCP_REORDER);
+            TextOutW(hdc, 10, 410, L"Glyph positions with GCP_REORDER flag", 37);
+
+            /* Prints per column the location of the character in the string, reordered location, its position and the character itself */
+            for (i = 0, xpos = 10; i < Len; i++, xpos += 30)
+            {
+                StringCchPrintfW(tempString, 20, L"%d", i);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 430, tempString, tempLength);
+
+                StringCchPrintfW(tempString, 20, L"%d", lpOrder[i]);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 450, tempString, tempLength);
+
+                StringCchPrintfW(tempString, 20, L"%d", lpCaretPos[i]);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 470, tempString, tempLength);
+
+                TextOutW(hdc, xpos, 490, &szString[i], 1);
+            }
+            TextOutW(hdc, xpos, 430, L"Character location", 18);
+            TextOutW(hdc, xpos, 450, L"lpOrder[i]", 10);
+            TextOutW(hdc, xpos, 470, L"lpCaretPos[i]", 13);
+            TextOutW(hdc, xpos, 490, L"String[i]", 9);
+
+            GetCharacterPlacementW(hdc, szString, Len, 0, &Results, 0);
+            TextOutW(hdc, 10, 510, L"Glyph positions without GCP_REORDER flag", 40);
+
+            for (i = 0, xpos = 10; i < Len; i++, xpos += 30)
+            {
+                StringCchPrintfW(tempString, 20, L"%d", i);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 530, tempString, tempLength);
+
+                StringCchPrintfW(tempString, 20, L"%d", lpOrder[i]);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 550, tempString, tempLength);
+
+                StringCchPrintfW(tempString, 20, L"%d", lpCaretPos[i]);
+                tempLength = wcslen(tempString);
+                TextOutW(hdc, xpos, 570, tempString, tempLength);
+
+                TextOutW(hdc, xpos, 590, &szString[i], 1);
+            }
+            TextOutW(hdc, xpos, 530, L"Character location", 18);
+            TextOutW(hdc, xpos, 550, L"lpOrder[i]", 10);
+            TextOutW(hdc, xpos, 570, L"lpCaretPos[i]", 13);
+            TextOutW(hdc, xpos, 590, L"String[i]", 9);
 
             EndPaint(hWnd, &ps);
             break;

--- a/modules/rostests/win32/user32/biditext/biditext.h
+++ b/modules/rostests/win32/user32/biditext/biditext.h
@@ -2,6 +2,7 @@
 
 #include <windows.h>
 #include <commctrl.h>
+#include <strsafe.h>
 
 /* Global instance handle */
 extern HINSTANCE g_hInstance;

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -450,8 +450,6 @@ GetCharacterPlacementW(
 
     if (dwFlags&(~GCP_REORDER)) DPRINT("flags 0x%08lx ignored\n", dwFlags);
     if (lpResults->lpClass) DPRINT("classes not implemented\n");
-    if (lpResults->lpCaretPos && (dwFlags & GCP_REORDER))
-        DPRINT("Caret positions for complex scripts not implemented\n");
 
     nSet = (UINT)uCount;
     if (nSet > lpResults->nGlyphs)


### PR DESCRIPTION
## Purpose

Use ScriptStringCPtoX to calculate caret positions when the GCP_REORDER flag is used.
Now the lpCaretPos array will contain value equivalent to the Windows results.
Added test code to the demo program to show the values, includes the changes in #825

JIRA issue: N/A

![caretpos](https://user-images.githubusercontent.com/3612577/45243107-450fd100-b2fb-11e8-9ebb-ed379d1a63d5.PNG)

[(Filed a report to wine about the incorrect lpOrder values)](https://bugs.winehq.org/show_bug.cgi?id=45793)