### PR TITLE
Add a maintainers file

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -9,6 +9,7 @@ area of ReactOS. Being a maintainer means the following:
 	- that person has good knownledge in the area
 	- that person is able to enforce consistency in the area
 	- that person may be available for giving help in the area
+	- that person has push access on the repository
 Being a maintainer does not mean the following:
 	- that person is dedicated to the area
 	- that person is working full-time on the area/on ReactOS
@@ -25,7 +26,8 @@ from all the listed reviewers.
 Also, when submitted a pull request on GitHub, rules defined in
 CONTRIBUTING.md apply. And if the maintainer is not available and
 reviewers approved the pull request, developers feeling confident
-can merge the pull request.
+can merge the pull request. Note that reviewers do not necessarily
+have push access to the repository.
 When submitting a bug report on Jira, if you want to be sure to have
 a developer with skills in that area, write @nick from M people.
 
@@ -36,6 +38,10 @@ is responsible of updating periodically the source code and of
 managing local patches. He is not here to upstream code on your behalf.
 As responsible, he may refuse a local patch if you did not try to
 upstream your changes.
+
+If you want to get listed in that file, either put yourself in the
+file and push it, or open a pull request. You can also ask a person
+who has push access to add yourself.
 
 This file uses a similar format to the Linux kernel MAINTAINERS file.
 Descriptions of section entries used here:

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -63,6 +63,18 @@ ACPICA Library
 	S: Upstream
 	F: drivers/bus/acpi/acpica/
 
+Apisets
+	M: learn-more, learn_more, Mark Jansen
+	S: Maintained
+	F: dll/apisets
+
+Application Compatibility subystem
+	M: learn-more, learn_more, Mark Jansen
+	S: Maintained
+	F: dll/appcompat
+	F: dll/shellext/acppage
+	F: ntoskrnl/ps/apphelp.c
+
 Cache Manager
 	M: HeisSpiter, Pierre Schweitzer
 	S: Maintained
@@ -74,6 +86,7 @@ Cache Manager Rewrite
 
 CMake Build Scripts
 	M:
+	R: learn-more, learn_more, Mark Jansen
 	R: ThFabba, Thomas Faber
 	S: Maintained
 	F: sdk/cmake/
@@ -120,12 +133,15 @@ Network File Systems kernel libraries
 
 NTDLL
 	M:
+	R: HeisSpiter, Pierre Schweitzer
+	R: learn-more, learn_more, Mark Jansen
 	R: ThFabba, Thomas Faber
 	S: Maintained
 	F: dll/ntdll/
 
 ReactOS API Tests
 	M:
+	R: learn-more, learn_more, Mark Jansen
 	R: ThFabba, Thomas Faber
 	S: Maintained
 	F: modules/rostests/apitests/
@@ -142,9 +158,16 @@ ROS internals tools
 
 Run-Time Library (RTL)
 	M:
+	R: learn-more, learn_more, Mark Jansen
 	R: ThFabba, Thomas Faber
 	S: Maintained
 	F: sdk/lib/rtl/
+
+Shell Extensions
+	M:
+	R: learn-more, learn_more, Mark Jansen
+	S: Maintained
+	F: dll/shellext
 
 Upstream File Systems
 	M: HeisSpiter, Pierre Schweitzer

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,131 @@
+	List of maintainers for the ReactOS project
+
+This file purpose is to give newcomers to the projet the responsible
+developers when submitting a pull request on GitHub, or opening a bug
+report on Jira.
+
+This file will notably establish who is responsible for a specific
+area of ReactOS. Being a maintainer means the following:
+	- that person has good knownledge in the area
+	- that person is able to enforce consistency in the area
+	- that person may be available for giving help in the area
+Being a maintainer does not mean the following:
+	- that person is dedicated to the area
+	- that person is working full-time on the area/on ReactOS
+	- that person is paid
+	- that person is always available
+
+We have no supported (paid) areas in ReactOS.
+
+When submitting a pull request on GitHub and looking for reviewers,
+look at that file and ask for a review from some of the people (M, R
+- the most recently active in the area) listed in the matching area,
+also, assign the pull request to the M person. Don't ask for a review
+from all the listed reviewers.
+Also, when submitted a pull request on GitHub, rules defined in
+CONTRIBUTING.md apply. And if the maintainer is not available and
+reviewers approved the pull request, developers feeling confident
+can merge the pull request.
+When submitting a bug report on Jira, if you want to be sure to have
+a developer with skills in that area, write @nick from M people.
+
+There should be one and only one primary maintainer per area.
+
+In case of 3rd party code (also refered as upstream), the maintainer
+is responsible of updating periodically the source code and of
+managing local patches. He is not here to upstream code on your behalf.
+As responsible, he may refuse a local patch if you did not try to
+upstream your changes.
+
+This file uses a similar format to the Linux kernel MAINTAINERS file.
+Descriptions of section entries used here:
+	M: Primary maintainer. Assign them pull requests
+	   Use the GitHub, Jira, Real Name format for entry, squash if
+	   some are overlapping
+	R: Reviewers. Ask them for review on pull requests
+	S: Status, one of the following:
+	   Maintained:  Someone is handling that area
+	   Upstream: This is 3rd party code, synced in our tree
+	   Abandoned:  No one is handling that code anymore
+	F: Files. Directories, files (wildcards allowed) covered in
+	   this area
+	C: Comments
+
+Cache Manager
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: ntoskrnl/cc/
+
+Cache Manager Rewrite
+	S: Abandonned
+	F: ntoskrnl/cache/
+
+File Systems
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: drivers/filesystems/
+	F: sdk/lib/fslib/
+	C: Also see "Upstream File Systems"
+
+File Systems Run Time Library
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: ntoskrnl/fsrtl/
+	F: sdk/lib/drivers/ntoskrnl_vista/fsrtl.c
+
+IO Manager
+	M:
+	R: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: ntoskrnl/io/iomgr/
+
+Network File Systems kernel libraries
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: sdk/lib/drivers/rdbsslib/
+	F: sdk/lib/drivers/rxce/
+
+ROS internals tools
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: modules/rosapps/applications/rosinternals/
+
+Upstream File Systems
+	M: HeisSpiter, Pierre Schweitzer
+	S: Upstream
+	F: base/services/nfsd/
+	F: dll/np/nfs/
+	F: dll/shellext/shellbtrfs/
+	F: drivers/filesystems/btrfs/
+	F: drivers/filesystems/cdfs/
+	F: drivers/filesystems/ext2/
+	F: drivers/filesystems/fastfat_new/
+	F: drivers/filesystems/ffs/
+	F: drivers/filesystems/nfs/
+	F: drivers/filesystems/reiserfs/
+	F: media/doc/README.FSD
+	F: sdk/lib/fslib/btrfslib/
+	F: sdk/lib/fslib/ext2lib/
+	F: sdk/lib/fslib/vfatlib/check/
+
+Virtual CD-ROM
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: modules/rosapps/applications/cmdutils/vcdcli/
+	F: modules/rosapps/drivers/vcdrom/
+
+Virtual Floppy Disk
+	M: HeisSpiter, Pierre Schweitzer
+	S: Upstream
+	F: modules/rosapps/applications/cmdutils/vfdcmd/
+	F: modules/rosapps/drivers/vfd/
+
+Win32 file functions
+	M: HeisSpiter, Pierre Schweitzer
+	S: Maintained
+	F: dll/win32/kernel32/client/file/
+
+Windows Network File Systems functions
+	M: HeisSpiter, Pierre Schweitzer
+	S: Upstream
+	F: dll/win32/mpr/wnet.c

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -51,14 +51,34 @@ Descriptions of section entries used here:
 	   this area
 	C: Comments
 
+ACPI
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: drivers/bus/acpi/
+	F: hal/halx86/acpi/
+
+ACPICA Library
+	M: ThFabba, Thomas Faber
+	S: Upstream
+	F: drivers/bus/acpi/acpica/
+
 Cache Manager
 	M: HeisSpiter, Pierre Schweitzer
 	S: Maintained
 	F: ntoskrnl/cc/
 
 Cache Manager Rewrite
-	S: Abandonned
+	S: Abandoned
 	F: ntoskrnl/cache/
+
+CMake Build Scripts
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: sdk/cmake/
+	F: */CMakeLists.txt
+	F: */*.cmake
 
 File Systems
 	M: HeisSpiter, Pierre Schweitzer
@@ -73,11 +93,24 @@ File Systems Run Time Library
 	F: ntoskrnl/fsrtl/
 	F: sdk/lib/drivers/ntoskrnl_vista/fsrtl.c
 
-IO Manager
+HID Drivers
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: drivers/hid/
+
+Kernel
 	M:
 	R: HeisSpiter, Pierre Schweitzer
+	R: ThFabba, Thomas Faber
 	S: Maintained
-	F: ntoskrnl/io/iomgr/
+	F: ntoskrnl/
+
+Network Drivers
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: drivers/network/
 
 Network File Systems kernel libraries
 	M: HeisSpiter, Pierre Schweitzer
@@ -85,10 +118,33 @@ Network File Systems kernel libraries
 	F: sdk/lib/drivers/rdbsslib/
 	F: sdk/lib/drivers/rxce/
 
+NTDLL
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: dll/ntdll/
+
+ReactOS API Tests
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: modules/rostests/apitests/
+
+ReactOS Kernel-Mode Tests
+	M: ThFabba, Thomas Faber
+	S: Maintained
+	F: modules/rostests/kmtests/
+
 ROS internals tools
 	M: HeisSpiter, Pierre Schweitzer
 	S: Maintained
 	F: modules/rosapps/applications/rosinternals/
+
+Run-Time Library (RTL)
+	M:
+	R: ThFabba, Thomas Faber
+	S: Maintained
+	F: sdk/lib/rtl/
 
 Upstream File Systems
 	M: HeisSpiter, Pierre Schweitzer
@@ -107,6 +163,13 @@ Upstream File Systems
 	F: sdk/lib/fslib/btrfslib/
 	F: sdk/lib/fslib/ext2lib/
 	F: sdk/lib/fslib/vfatlib/check/
+
+USB Drivers
+	M: ThFabba, Thomas Faber
+	S: Maintained
+	F: drivers/usb/
+	F: sdk/lib/drivers/libusb/
+	F: sdk/include/reactos/drivers/usbport/
 
 Virtual CD-ROM
 	M: HeisSpiter, Pierre Schweitzer
@@ -129,3 +192,9 @@ Windows Network File Systems functions
 	M: HeisSpiter, Pierre Schweitzer
 	S: Upstream
 	F: dll/win32/mpr/wnet.c
+
+Wine Tests
+	M:
+	R: ThFabba, Thomas Faber
+	S: Upstream
+	F: modules/rostests/winetests/

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -84,6 +84,7 @@ Application Compatibility subystem
 Cache Manager
 	M: HeisSpiter, Pierre Schweitzer
 	S: Maintained
+	F: modules/rostests/kmtests/ntos_cc/
 	F: ntoskrnl/cc/
 
 Cache Manager Rewrite
@@ -109,6 +110,8 @@ File Systems
 File Systems Run Time Library
 	M: HeisSpiter, Pierre Schweitzer
 	S: Maintained
+	F: modules/rostests/kmtests/ntos_fsrtl/
+	F: modules/rostests/kmtests/novp_fsrtl/
 	F: ntoskrnl/fsrtl/
 	F: sdk/lib/drivers/ntoskrnl_vista/fsrtl.c
 
@@ -164,6 +167,7 @@ ROS internals tools
 
 Run-Time Library (RTL)
 	M:
+	R: HeisSpiter, Pierre Schweitzer
 	R: learn-more, learn_more, Mark Jansen
 	R: ThFabba, Thomas Faber
 	S: Maintained


### PR DESCRIPTION
This is a proposal so that ReactOS also gets a MAINTAINERS file.
The purpose of this file is to allow newcomers to know at a glance who's responsible of what in the project. It also puts some limits on what a maintainer is (and isn't).
It also helps newcomers knowing that some code is 3rd party and shouldn't directly be handled in ReactOS.
This is a pull request for comments, and approval.
Feel free to directly push to the branch what areas you want to be maintainer of.

Some examples:
- https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/MAINTAINERS
- https://source.winehq.org/git/wine.git/blob/HEAD:/MAINTAINERS