### PR TITLE
[TRANSLATION] Updated Polish translation in USETUP

### DIFF
--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -1789,7 +1789,7 @@ MUI_STRING plPLStrings[] =
     {STRING_REBOOTCOMPUTER2,
     "   ENTER = Restart komputera"},
     {STRING_REBOOTPROGRESSBAR,
-    " Your computer will reboot in %li second(s)... "},
+    " Komputer zostanie uruchomiony ponownie za %li sekund(y)... "},
     {STRING_CONSOLEFAIL1,
     "Otwarcie konsoli nieudane\r\n\r\n"},
     {STRING_CONSOLEFAIL2,


### PR DESCRIPTION
## Purpose

_As recently reboot progress bar was implemented in usetup (https://github.com/reactos/reactos/commit/e5c0bfacf1374abf34abbaf75047149a6252ca5e), this PR translates the "Your computer will reboot in X second(s)..." string to Polish._