### PR TITLE
[CMD] Do not overwrite input string on Ctrl+C

### DIFF
--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -458,6 +458,13 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
                         break;
 
                     /*
+                     * Fully print the entered string
+                     * so the command prompt would not overwrite it.
+                     */
+                    SetCursorXY(orgx, orgy);
+                    ConOutPrintf(_T("%s"), str);
+
+                    /*
                      * A Ctrl-C. Do not clear the command line,
                      * but return an empty string in str.
                      */


### PR DESCRIPTION
## Purpose

Avoid overwriting the input string with command prompt on Ctrl+C event.

JIRA issue: [CORE-15029](https://jira.reactos.org/browse/CORE-15029)

## Proposed changes

Fully print the entered string so the command prompt would not overwrite it.

Cc @HBelusca 