### PR TITLE
CORE-12596. Partially fix dll/win32/kernel32/client/vista.c compilation as NT6

### DIFF
--- a/dll/win32/kernel32/client/vista.c
+++ b/dll/win32/kernel32/client/vista.c
@@ -40,6 +40,7 @@ SleepConditionVariableCS(IN OUT PCONDITION_VARIABLE ConditionVariable,
                          IN DWORD dwMilliseconds)
 {
     NTSTATUS Status = STATUS_SUCCESS;
+#if 0
     LARGE_INTEGER TimeOut;
     PLARGE_INTEGER TimeOutPtr = NULL;
 
@@ -49,7 +50,6 @@ SleepConditionVariableCS(IN OUT PCONDITION_VARIABLE ConditionVariable,
         TimeOutPtr = &TimeOut;
     }
 
-#if 0
     Status = RtlSleepConditionVariableCS((PRTL_CONDITION_VARIABLE)ConditionVariable,
                                          (PRTL_CRITICAL_SECTION)CriticalSection,
                                          TimeOutPtr);
@@ -75,6 +75,7 @@ SleepConditionVariableSRW(IN OUT PCONDITION_VARIABLE ConditionVariable,
                           IN ULONG Flags)
 {
     NTSTATUS Status = STATUS_SUCCESS;
+#if 0
     LARGE_INTEGER TimeOut;
     PLARGE_INTEGER TimeOutPtr = NULL;
 
@@ -84,7 +85,6 @@ SleepConditionVariableSRW(IN OUT PCONDITION_VARIABLE ConditionVariable,
         TimeOutPtr = &TimeOut;
     }
 
-#if 0
     Status = RtlSleepConditionVariableSRW((PRTL_CONDITION_VARIABLE)ConditionVariable,
                                           (PRTL_SRWLOCK)SRWLock,
                                           TimeOutPtr,

--- a/dll/win32/kernel32/client/vista.c
+++ b/dll/win32/kernel32/client/vista.c
@@ -39,7 +39,7 @@ SleepConditionVariableCS(IN OUT PCONDITION_VARIABLE ConditionVariable,
                          IN OUT PCRITICAL_SECTION CriticalSection,
                          IN DWORD dwMilliseconds)
 {
-    NTSTATUS Status = 0;
+    NTSTATUS Status = STATUS_SUCCESS;
     LARGE_INTEGER TimeOut;
     PLARGE_INTEGER TimeOutPtr = NULL;
 
@@ -74,7 +74,7 @@ SleepConditionVariableSRW(IN OUT PCONDITION_VARIABLE ConditionVariable,
                           IN DWORD dwMilliseconds,
                           IN ULONG Flags)
 {
-    NTSTATUS Status = 0;
+    NTSTATUS Status = STATUS_SUCCESS;
     LARGE_INTEGER TimeOut;
     PLARGE_INTEGER TimeOutPtr = NULL;
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12596](https://jira.reactos.org/browse/CORE-12596)

## Proposed changes

- 1 trivial code improvement.
- 1 compilation fix, at least with GCC.
