### PR TITLE
Fix APC_INDEX_MISMATCH bugcheck

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -426,6 +426,9 @@ VOID DumpPrivateFontList(BOOL bDoLock)
 {
     PPROCESSINFO Win32Process = PsGetCurrentProcessWin32Process();
 
+    if (!Win32Process)
+        return;
+
     if (bDoLock)
         IntLockProcessPrivateFonts(Win32Process);
 


### PR DESCRIPTION
## Purpose

Fix APC_INDEX_MISMATCH bugcheck.

JIRA issue: [CORE-15031](https://jira.reactos.org/browse/CORE-15031)

## Proposed changes

Check whether Win32Process is NULL.