### PR TITLE
Make configure.sh behave like configure.cmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ git:
 before_script:
   - wget https://svn.reactos.org/amine/RosBEBinFull.tar.gz -O RosBE.tar.gz
   - tar -xzf RosBE.tar.gz
-  - echo 'mkdir ../Build && cd ../Build && $TRAVIS_BUILD_DIR/configure.sh -DENABLE_ROSTESTS=1 && cd reactos && ninja -k 0 && ninja bootcd' > tmp_file
+  - echo 'mkdir ../Build && cd ../Build && $TRAVIS_BUILD_DIR/configure.sh -DENABLE_ROSTESTS=1 && ninja -k 0 && ninja bootcd' > tmp_file
 
 script:
   - ./RosBEBinFull/RosBE.sh < tmp_file

--- a/configure.sh
+++ b/configure.sh
@@ -50,11 +50,10 @@ if [ "$REACTOS_SOURCE_DIR" = "$PWD" ]; then
 	cd "$REACTOS_OUTPUT_PATH"
 fi
 
-mkdir -p reactos
-
 #EXTRA_ARGS=""
 if [ $USE_NEW_STYLE -eq 0 ]; then
 	mkdir -p host-tools
+	mkdir -p reactos
 	echo Preparing host tools...
 	cd host-tools
 	rm -f CMakeCache.txt
@@ -68,7 +67,11 @@ if [ $USE_NEW_STYLE -eq 0 ]; then
 fi
 
 echo Preparing reactos...
-cd reactos
+
+if [ $USE_NEW_STYLE -eq 0 ]; then
+	cd reactos
+fi
+
 rm -f CMakeCache.txt host-tools/CMakeCache.txt
 
 cmake -G "$CMAKE_GENERATOR" -DENABLE_CCACHE:BOOL=0 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-gcc.cmake -DARCH:STRING=$ARCH -DNEW_STYLE_BUILD:BOOL=$USE_NEW_STYLE $EXTRA_ARGS $ROS_CMAKEOPTS "$REACTOS_SOURCE_DIR"


### PR DESCRIPTION
Right now configure.sh creates a folder in build directory but configure.cmd does not.
This PR makes configure.sh consistent with configure.cmd