### PR TITLE
[GITIGNORE] Ignore [boot|live|hybrid]cd_extras

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 output-*
 modules/optional
+modules/bootcd_extras
+modules/livecd_extras
+modules/hybridcd_extras


### PR DESCRIPTION
## Purpose

Exclude [boot|live|hybrid]cd_extras from git as well since they are not part of the source code itself.