### PR TITLE
ROSTESTS-268. Fix kmtest:TcpIpConnect on Test WHS

### DIFF
--- a/modules/rostests/kmtests/tcpip/connect.c
+++ b/modules/rostests/kmtests/tcpip/connect.c
@@ -229,11 +229,11 @@ TestTcpConnect(void)
     ok_eq_long(ReturnInfo.UserDataLength, 0);
     ok_eq_pointer(ReturnInfo.UserData, NULL);
 
-    ok_eq_long(ReturnAddress.TAAddressCount, 0);
-    ok_eq_hex(ReturnAddress.Address[0].AddressType, 0);
-    ok_eq_hex(ReturnAddress.Address[0].AddressLength, 0);
-    ok_eq_hex(ReturnAddress.Address[0].Address[0].sin_port, 0);
-    ok_eq_hex(ReturnAddress.Address[0].Address[0].in_addr, 0);
+    ok_eq_long(ReturnAddress.TAAddressCount, 1);
+    ok_eq_hex(ReturnAddress.Address[0].AddressType, TDI_ADDRESS_TYPE_IP);
+    ok_eq_hex(ReturnAddress.Address[0].AddressLength, TDI_ADDRESS_LENGTH_IP);
+    ok_eq_hex(ReturnAddress.Address[0].Address[0].sin_port, htons(TEST_CONNECT_SERVER_PORT));
+    ok_eq_hex(ReturnAddress.Address[0].Address[0].in_addr, InAddr.S_un.S_addr);
 
     ObDereferenceObject(ConnectionFileObject);
 


### PR DESCRIPTION
## Purpose

ReactOS (new) results are out of scope of this PR.

JIRA issue: [ROSTESTS-268](https://jira.reactos.org/browse/ROSTESTS-268)
Windows results: [(WTB) Job 42089](https://testbot.winehq.org/JobDetails.pl?Key=42089)
