### PR TITLE
[TRANSLATION][MSCONFIG_NEW] Do not assign an access key to a letter with diacritic

### DIFF
--- a/base/applications/msconfig_new/lang/ro-RO.rc
+++ b/base/applications/msconfig_new/lang/ro-RO.rc
@@ -84,7 +84,7 @@ BEGIN
     LTEXT           "secunde", IDC_STATIC, 330, 104, 31, 10
     CONTROL         "&Permanenizează configurația de inițializare", 292,
                     "Button", BS_AUTOCHECKBOX | BS_TOP | BS_MULTILINE | WS_TABSTOP, 295, 121, 66, 49
-    PUSHBUTTON      "&Șterge", IDC_BTN_DELETE, 295, 68, 66, 14
+    PUSHBUTTON      "Ș&terge", IDC_BTN_DELETE, 295, 68, 66, 14
 END
 
 IDD_SERVICES_PAGE DIALOGEX 0, 0, 366, 175


### PR DESCRIPTION
## Purpose
As the title of the PR says, we should not assign an access key to a letter with diacritic in anyway. The patch is for [`29603e7`](https://github.com/reactos/reactos/commit/29603e7291401080a14fde6f327c703b5ce6f640).