### PR TITLE
[MSPAINT] Fix scrollbar presence on canvas/view fitting

### DIFF
--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -9,31 +9,90 @@
 /* INCLUDES *********************************************************/
 
 #include "precomp.h"
+#include <atltypes.h>
+
+/*
+ * Scrollbar functional modes:
+ * 0  view < canvas
+ * 1  view < canvas + scroll
+ * 2  view >= canvas + scroll
+ *
+ * Matrix of scrollbar presence (VERTICAL,HORIZONTAL) given by
+ * vertical x horizontal scrollbar modes (view:whole report):
+ *
+ *           horizontal mode
+ *             |      0      |      1      |      2
+ * vertical ---+-------------+-------------+------------
+ *   mode    0 |  TRUE,TRUE  |  TRUE,TRUE  |  TRUE,FALSE
+ *          ---+-------------+-------------+------------
+ *           1 |  TRUE,TRUE  | FALSE,FALSE | FALSE,FALSE
+ *          ---+-------------+-------------+------------
+ *           2 | FALSE,TRUE  | FALSE,FALSE | FALSE,FALSE
+ */
+
+struct ScrollbarPresence
+{
+    BOOL bVert;
+    BOOL bHoriz;
+};
+
+CONST ScrollbarPresence sp_mx[3][3] =
+{
+    { {  TRUE,TRUE  }, {  TRUE,TRUE  }, {  TRUE,FALSE } },
+    { {  TRUE,TRUE  }, { FALSE,FALSE }, { FALSE,FALSE } },
+    { { FALSE,TRUE  }, { FALSE,FALSE }, { FALSE,FALSE } }
+};
+
 
 /* FUNCTIONS ********************************************************/
 
 void
 UpdateScrollbox()
 {
-    RECT clientRectScrollbox;
-    RECT clientRectImageArea;
+    CONST INT EXTRASIZE = 5; /* 3 px of selection markers + 2 px of border */
+
+    CRect tempRect;
+    CSize sizeImageArea;
+    CSize sizeScrollBox;
+    INT vmode, hmode;
     SCROLLINFO si;
-    scrollboxWindow.GetClientRect(&clientRectScrollbox);
-    imageArea.GetClientRect(&clientRectImageArea);
+
+    scrollboxWindow.GetWindowRect(&tempRect);
+    sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
+
+    imageArea.GetClientRect(&tempRect);
+    sizeImageArea = CSize(tempRect.Width(), tempRect.Height());
+    sizeImageArea += CSize(EXTRASIZE * 2, EXTRASIZE * 2);
+
+    /* show/hide the scrollbars */
+    vmode = (sizeScrollBox.cy < sizeImageArea.cy? 0 :
+                (sizeScrollBox.cy < sizeImageArea.cy +
+                    ::GetSystemMetrics(SM_CYHSCROLL) ? 1 : 2));
+    hmode = (sizeScrollBox.cx < sizeImageArea.cx ? 0 :
+                (sizeScrollBox.cx < sizeImageArea.cx +
+                    ::GetSystemMetrics(SM_CXVSCROLL) ? 1 : 2));
+    scrollboxWindow.ShowScrollBar(SB_VERT, sp_mx[vmode][hmode].bVert);
+    scrollboxWindow.ShowScrollBar(SB_HORZ, sp_mx[vmode][hmode].bHoriz);
+
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask  = SIF_PAGE | SIF_RANGE;
-    si.nMax   = clientRectImageArea.right + 6 - 1;
     si.nMin   = 0;
-    si.nPage  = clientRectScrollbox.right;
+
+    si.nMax   = sizeImageArea.cx +
+                    (sp_mx[vmode][hmode].bVert == TRUE ?
+                        ::GetSystemMetrics(SM_CYHSCROLL) : 0);
+    si.nPage  = sizeScrollBox.cx;
     scrollboxWindow.SetScrollInfo(SB_HORZ, &si);
-    scrollboxWindow.GetClientRect(&clientRectScrollbox);
-    si.nMax   = clientRectImageArea.bottom + 6 - 1;
-    si.nPage  = clientRectScrollbox.bottom;
+
+    si.nMax   = sizeImageArea.cy +
+                    (sp_mx[vmode][hmode].bHoriz == TRUE ?
+                        ::GetSystemMetrics(SM_CXHSCROLL) : 0);
+    si.nPage  = sizeScrollBox.cy;
     scrollboxWindow.SetScrollInfo(SB_VERT, &si);
-    scrlClientWindow.MoveWindow(
-        -scrollboxWindow.GetScrollPos(SB_HORZ), -scrollboxWindow.GetScrollPos(SB_VERT),
-        max(clientRectImageArea.right + 6, clientRectScrollbox.right),
-        max(clientRectImageArea.bottom + 6, clientRectScrollbox.bottom), TRUE);
+
+    scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
+                                -scrollboxWindow.GetScrollPos(SB_VERT),
+                                sizeImageArea.cx, sizeImageArea.cy, TRUE);
 }
 
 LRESULT CScrollboxWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -14,11 +14,11 @@
 /*
  * Scrollbar functional modes:
  * 0  view < canvas
- * 1  view < canvas + scroll
- * 2  view >= canvas + scroll
+ * 1  view < canvas + scroll width
+ * 2  view >= canvas + scroll width
  *
  * Matrix of scrollbar presence (VERTICAL,HORIZONTAL) given by
- * vertical x horizontal scrollbar modes (view:whole report):
+ * vertical & horizontal scrollbar modes (view:canvas ratio):
  *
  *           horizontal mode
  *             |      0      |      1      |      2
@@ -43,6 +43,9 @@ CONST ScrollbarPresence sp_mx[3][3] =
     { { FALSE,TRUE  }, { FALSE,FALSE }, { FALSE,FALSE } }
 };
 
+CONST INT HSCROLL_WIDTH = ::GetSystemMetrics(SM_CYHSCROLL);
+CONST INT VSCROLL_WIDTH = ::GetSystemMetrics(SM_CXVSCROLL);
+
 
 /* FUNCTIONS ********************************************************/
 
@@ -65,12 +68,10 @@ UpdateScrollbox()
     sizeImageArea += CSize(EXTRASIZE * 2, EXTRASIZE * 2);
 
     /* show/hide the scrollbars */
-    vmode = (sizeScrollBox.cy < sizeImageArea.cy? 0 :
-                (sizeScrollBox.cy < sizeImageArea.cy +
-                    ::GetSystemMetrics(SM_CYHSCROLL) ? 1 : 2));
+    vmode = (sizeScrollBox.cy < sizeImageArea.cy ? 0 :
+                (sizeScrollBox.cy < sizeImageArea.cy + HSCROLL_WIDTH ? 1 : 2));
     hmode = (sizeScrollBox.cx < sizeImageArea.cx ? 0 :
-                (sizeScrollBox.cx < sizeImageArea.cx +
-                    ::GetSystemMetrics(SM_CXVSCROLL) ? 1 : 2));
+                (sizeScrollBox.cx < sizeImageArea.cx + VSCROLL_WIDTH ? 1 : 2));
     scrollboxWindow.ShowScrollBar(SB_VERT, sp_mx[vmode][hmode].bVert);
     scrollboxWindow.ShowScrollBar(SB_HORZ, sp_mx[vmode][hmode].bHoriz);
 
@@ -79,14 +80,12 @@ UpdateScrollbox()
     si.nMin   = 0;
 
     si.nMax   = sizeImageArea.cx +
-                    (sp_mx[vmode][hmode].bVert == TRUE ?
-                        ::GetSystemMetrics(SM_CYHSCROLL) : 0);
+                    (sp_mx[vmode][hmode].bVert == TRUE ? HSCROLL_WIDTH : 0);
     si.nPage  = sizeScrollBox.cx;
     scrollboxWindow.SetScrollInfo(SB_HORZ, &si);
 
     si.nMax   = sizeImageArea.cy +
-                    (sp_mx[vmode][hmode].bHoriz == TRUE ?
-                        ::GetSystemMetrics(SM_CXHSCROLL) : 0);
+                    (sp_mx[vmode][hmode].bHoriz == TRUE ? VSCROLL_WIDTH : 0);
     si.nPage  = sizeScrollBox.cy;
     scrollboxWindow.SetScrollInfo(SB_VERT, &si);
 


### PR DESCRIPTION
This is a small fix for a scrollbar related edge case functionality exhibited in mspaint (and in a lesser degree also elsewhere in instances of) scrollbar controlled content. As known, the scrollbars presence is given by the size ratio between the accommodating outer frame and the scroll-controlled contents inside it, and it works for the most part. There is, however, a case where the presence of both toolbars is kept even when the contents would fit the frame (if not for the scrollbars themselves that increase the size of the contents' area). Please take the current commit as a demo fix and a provisional correction for mspaint (as I think that the proper fix should reside in common controls).

JIRA issue: [CORE-15096](https://jira.reactos.org/browse/CORE-15096)

The commit exposes the modes defined by canvas/view ratio and improves the UpdateScrollbox() function by taking into account the need for scrollbars in the edge case of 2nd canvas/view mode.