### PR TITLE
[KMTESTS:TCPIP] Add an "Associate address IRP completed" trace

### DIFF
--- a/modules/rostests/kmtests/tcpip/connect.c
+++ b/modules/rostests/kmtests/tcpip/connect.c
@@ -166,6 +166,7 @@ TestTcpConnect(void)
             FALSE,
             NULL);
         Status = Irp->IoStatus.Status;
+        trace("Associate address IRP completed.\n");
     }
     ok_eq_hex(Status, STATUS_SUCCESS);
     IoFreeIrp(Irp);


### PR DESCRIPTION
## Purpose

Split off of PR868.

> ThFabba: approved.

> HeisSpiter: "What's the purpose of that trace?"

To complete the 3 other traces.