### PR TITLE
[APPWIZ][GECKO] Display a message box in case of failure

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -351,6 +351,7 @@ static IBindStatusCallback InstallCallback = { &InstallCallbackVtbl };
 
 static DWORD WINAPI download_proc(PVOID arg)
 {
+    WCHAR message[256];
     WCHAR tmp_dir[MAX_PATH], tmp_file[MAX_PATH];
     HRESULT hres;
 
@@ -362,12 +363,13 @@ static DWORD WINAPI download_proc(PVOID arg)
     hres = URLDownloadToFileW(NULL, GeckoUrl, tmp_file, 0, &InstallCallback);
     if(FAILED(hres)) {
         ERR("URLDownloadToFile failed: %08x\n", hres);
+        if (LoadStringW(hApplet, IDS_DWL_FAILED, message, sizeof(message) / sizeof(WCHAR))) {
+            MessageBoxW(NULL, message, NULL, MB_ICONERROR);
+        }
     } else {
         if(sha_check(tmp_file)) {
             install_file(tmp_file);
         }else {
-            WCHAR message[256];
-
             if(LoadStringW(hApplet, IDS_INVALID_SHA, message, sizeof(message)/sizeof(WCHAR))) {
                 MessageBoxW(NULL, message, NULL, MB_ICONERROR);
             }

--- a/dll/cpl/appwiz/lang/bg-BG.rc
+++ b/dll/cpl/appwiz/lang/bg-BG.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/cs-CZ.rc
+++ b/dll/cpl/appwiz/lang/cs-CZ.rc
@@ -84,6 +84,7 @@ BEGIN
     IDS_INSTALLING "Instalace..."
     IDS_INVALID_SHA "Stažený soubor má neplatný kontrolní součet. Instalace poškozeného souboru bude přerušena."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/de-DE.rc
+++ b/dll/cpl/appwiz/lang/de-DE.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installiere..."
     IDS_INVALID_SHA "Die heruntergeladene Datei hat eine unerwartete Prüfsumme. Abbruch der Installation aufgrund beschädigter Datei."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/el-GR.rc
+++ b/dll/cpl/appwiz/lang/el-GR.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/en-US.rc
+++ b/dll/cpl/appwiz/lang/en-US.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/es-ES.rc
+++ b/dll/cpl/appwiz/lang/es-ES.rc
@@ -85,6 +85,7 @@ BEGIN
     IDS_INSTALLING "Instalando..."
     IDS_INVALID_SHA "La suma de verificación del archivo descargado no coincide. Se ha cancelado la instalación del archivo corrupto."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/et-EE.rc
+++ b/dll/cpl/appwiz/lang/et-EE.rc
@@ -86,6 +86,7 @@ BEGIN
     IDS_INSTALLING "Paigaldamine..."
     IDS_INVALID_SHA "Kontrollsumma ei kattu. Paigaldamine katkestatud korrupteerinud faili tõttu."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/fr-FR.rc
+++ b/dll/cpl/appwiz/lang/fr-FR.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installation..."
     IDS_INVALID_SHA "La somme de contrôle du fichier téléchargé est erronée. Abandon de l'installation du fichier corrompu."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/he-IL.rc
+++ b/dll/cpl/appwiz/lang/he-IL.rc
@@ -80,6 +80,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/it-IT.rc
+++ b/dll/cpl/appwiz/lang/it-IT.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installando..."
     IDS_INVALID_SHA "Checksum imprevisto del file scaricato. Interruzione installazione del file danneggiato."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/ja-JP.rc
+++ b/dll/cpl/appwiz/lang/ja-JP.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "インストール中..."
     IDS_INVALID_SHA "ダウンロードしたファイルのチェックサムが合致しません。壊れたファイルのインストールを中止しています。"
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/no-NO.rc
+++ b/dll/cpl/appwiz/lang/no-NO.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/pl-PL.rc
+++ b/dll/cpl/appwiz/lang/pl-PL.rc
@@ -88,6 +88,7 @@ BEGIN
     IDS_INSTALLING "Instalowanie..."
     IDS_INVALID_SHA "Nieoczekiwana suma kontrolna ściągniętego pliku. Przerwanie instalacji uszkodzonego pliku."
     IDS_NEW_INTERNET_SHORTCUT "Nowy skrót internetowy"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Nie można utworzyć skrótu internetowego."
     IDS_CANTMAKESHORTCUT "Nie można utworzyć skrótu."
 END

--- a/dll/cpl/appwiz/lang/pt-BR.rc
+++ b/dll/cpl/appwiz/lang/pt-BR.rc
@@ -81,6 +81,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/ro-RO.rc
+++ b/dll/cpl/appwiz/lang/ro-RO.rc
@@ -85,6 +85,7 @@ BEGIN
     IDS_INSTALLING "În curs de instalare…"
     IDS_INVALID_SHA "Suma de control a fișierului descărcat nu corespunde. Deoarece fișierul a fost corupt, instalarea trebuie abandonată."
     IDS_NEW_INTERNET_SHORTCUT "Creare scurtătură la Internet"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Eșec în crearea scurtăturii la Internet."
     IDS_CANTMAKESHORTCUT "Eșec în crearea scurtăturii."
 END

--- a/dll/cpl/appwiz/lang/ru-RU.rc
+++ b/dll/cpl/appwiz/lang/ru-RU.rc
@@ -79,6 +79,7 @@ BEGIN
     IDS_INSTALLING "Установка..."
     IDS_INVALID_SHA "Ошибка контрольной суммы загруженного файла. Прерывание установки поврежденного файла."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/sk-SK.rc
+++ b/dll/cpl/appwiz/lang/sk-SK.rc
@@ -83,6 +83,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/sq-AL.rc
+++ b/dll/cpl/appwiz/lang/sq-AL.rc
@@ -83,6 +83,7 @@ BEGIN
     IDS_INSTALLING "Instalim..."
     IDS_INVALID_SHA "Kontroll i papritur ne shkarkimin e skedarit. Duke lënë instalimin e dokumentave të korruptuar."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/tr-TR.rc
+++ b/dll/cpl/appwiz/lang/tr-TR.rc
@@ -81,6 +81,7 @@ BEGIN
     IDS_INSTALLING "Kuruluyor..."
     IDS_INVALID_SHA "İndirilen kütüğün sağlama toplamı beklenmeyen. Bozuk kütüğün kurulumu iptal ediliyor."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/uk-UA.rc
+++ b/dll/cpl/appwiz/lang/uk-UA.rc
@@ -87,6 +87,7 @@ BEGIN
     IDS_INSTALLING "Installing..."
     IDS_INVALID_SHA "Unexpected checksum of downloaded file. Aborting installation of corrupted file."
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/zh-CN.rc
+++ b/dll/cpl/appwiz/lang/zh-CN.rc
@@ -88,6 +88,7 @@ BEGIN
     IDS_INSTALLING "正在安装..."
     IDS_INVALID_SHA "下载的文件校验和错误。中止安装已损坏的文件。"
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/lang/zh-TW.rc
+++ b/dll/cpl/appwiz/lang/zh-TW.rc
@@ -86,6 +86,7 @@ BEGIN
     IDS_INSTALLING "安裝中..."
     IDS_INVALID_SHA "意外的下載了的檔案的校驗和。中止安裝已損壞的檔案。"
     IDS_NEW_INTERNET_SHORTCUT "New Internet Shortcut"
+    IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
 END

--- a/dll/cpl/appwiz/resource.h
+++ b/dll/cpl/appwiz/resource.h
@@ -29,6 +29,7 @@
 #define IDS_DOWNLOADING        14
 #define IDS_INSTALLING         15
 #define IDS_INVALID_SHA        16
+#define IDS_DWL_FAILED         17
 
 /* Controls */
 #define IDC_SHORTCUT_LOCATION	107


### PR DESCRIPTION
## Purpose
If `hres` is failing, like due to lack of Internet connection, the Gecko installer directly quits and goes to the last setup page without providing a reason for such action to the user whatsoever. A message box explaining what happened should be enough.
## Proposed Changes
- Move `message` wide character variable at the top of `download_proc()`
- Display a message box with `MessageBoxW()`
- Add `IDS_DWL_FAILED` to resource files and header