### PR TITLE
[FONT][WIN32SS] Use ExFreePoolWithTag instead of ExFreePool

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5150,7 +5150,7 @@ IntGdiGetFontResourceInfo(
 
     /* Free the buffers */
     ExFreePoolWithTag(NameInfo1, TAG_FINF);
-    ExFreePool(NameInfo2);
+    ExFreePoolWithTag(NameInfo2, TAG_FINF);
 
     if (Count == 0 && dwType != 5)
     {


### PR DESCRIPTION
## Purpose
We had forgotten the pool tag in freetype.c.