### PR TITLE
[APPWIZ][GECKO] Do not display the message box if the user aborts the download

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -362,10 +362,15 @@ static DWORD WINAPI download_proc(PVOID arg)
 
     hres = URLDownloadToFileW(NULL, GeckoUrl, tmp_file, 0, &InstallCallback);
     if(FAILED(hres)) {
-        ERR("URLDownloadToFile failed: %08x\n", hres);
         if (LoadStringW(hApplet, IDS_DWL_FAILED, message, sizeof(message) / sizeof(WCHAR))) {
-            MessageBoxW(NULL, message, NULL, MB_ICONERROR);
+            /* If the user aborted the download, DO NOT display the message box */
+            if (hres == E_ABORT) {
+                TRACE("Downloading of Gecko package aborted!\n");
+            } else {
+                MessageBoxW(NULL, message, NULL, MB_ICONERROR);
+            }
         }
+        ERR("URLDownloadToFile failed: %08x\n", hres);
     } else {
         if(sha_check(tmp_file)) {
             install_file(tmp_file);


### PR DESCRIPTION
## Purpose
With the merge of #913, the message box will always be displayed even when the user attempts to abort the download of the Gecko package which confuses the user.

**JIRA Issue:** [CORE-15183](https://jira.reactos.org/browse/CORE-15183)
## Proposed Changes
If `hres` returns **E_ABORT**, do not display the message box.