### PR TITLE
[MKHIVE] Fix compilation warnings.

### DIFF
--- a/sdk/tools/mkhive/registry.c
+++ b/sdk/tools/mkhive/registry.c
@@ -488,7 +488,8 @@ RegpCreateOrOpenKey(
 
         if (!NT_SUCCESS(Status))
         {
-            DPRINT("RegpCreateOrOpenKey('%S'): Could not create or open subkey '%wZ', Status 0x%08x\n", KeyName, &KeyString, Status);
+            DPRINT("RegpCreateOrOpenKey('%S'): Could not create or open subkey '%.*S', Status 0x%08x\n",
+                   KeyName, (int)(KeyString.Length / sizeof(WCHAR)), KeyString.Buffer, Status);
             return ERROR_GEN_FAILURE; // STATUS_UNSUCCESSFUL;
         }
 


### PR DESCRIPTION
Fixes the following warnings:
```
/srv/buildbot/Build_GCCLin_x86/build/sdk/tools/mkhive/registry.c:491:13: warning: unknown conversion type character 'w' in format [-Wformat=]
/srv/buildbot/Build_GCCLin_x86/build/sdk/tools/mkhive/registry.c:491:13: warning: format '%x' expects argument of type 'unsigned int', but argument 3 has type 'struct UNICODE_STRING *' [-Wformat=]
/srv/buildbot/Build_GCCLin_x86/build/sdk/tools/mkhive/registry.c:491:13: warning: too many arguments for format [-Wformat-extra-args]
```