### PR TITLE
[REGEDIT] Adjustment of column widths

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -389,7 +389,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         if (!g_pChildWnd) return 0;
 
         wcsncpy(g_pChildWnd->szPath, buffer, MAX_PATH);
-        g_pChildWnd->nSplitPos = 250;
+        g_pChildWnd->nSplitPos = 210;
         g_pChildWnd->hWnd = hWnd;
         g_pChildWnd->hAddressBarWnd = CreateWindowExW(WS_EX_CLIENTEDGE, L"Edit", NULL, WS_CHILD | WS_VISIBLE | WS_CHILDWINDOW | WS_TABSTOP,
                                                       CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -49,7 +49,7 @@ typedef struct tagSORT_INFO
 static INT g_iSortedColumn = 0;
 
 #define MAX_LIST_COLUMNS (IDS_LIST_COLUMN_LAST - IDS_LIST_COLUMN_FIRST + 1)
-static const int default_column_widths[MAX_LIST_COLUMNS] = { 200, 175, 400 };
+static const int default_column_widths[MAX_LIST_COLUMNS] = { 130, 95, 150 };
 static const int column_alignment[MAX_LIST_COLUMNS] = { LVCFMT_LEFT, LVCFMT_LEFT, LVCFMT_LEFT };
 
 LPCWSTR GetValueName(HWND hwndLV, int iStartAt)

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -49,7 +49,7 @@ typedef struct tagSORT_INFO
 static INT g_iSortedColumn = 0;
 
 #define MAX_LIST_COLUMNS (IDS_LIST_COLUMN_LAST - IDS_LIST_COLUMN_FIRST + 1)
-static const int default_column_widths[MAX_LIST_COLUMNS] = { 130, 95, 150 };
+static const int default_column_widths[MAX_LIST_COLUMNS] = { 130, 95, 300 };
 static const int column_alignment[MAX_LIST_COLUMNS] = { LVCFMT_LEFT, LVCFMT_LEFT, LVCFMT_LEFT };
 
 LPCWSTR GetValueName(HWND hwndLV, int iStartAt)


### PR DESCRIPTION
## Purpose
Registry Editor's default column widths are improper. This PR will fix them.
JIRA issue: [CORE-15187](https://jira.reactos.org/browse/CORE-15187)