### PR TITLE
[KERNEL32] Use the default UnhandledExceptionFilter in BaseThreadStartup and BaseProcessStartup .

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -445,33 +445,6 @@ BasepSxsCloseHandles(IN PBASE_MSG_SXS_HANDLES Handles)
     }
 }
 
-static
-LONG BaseExceptionFilter(EXCEPTION_POINTERS *ExceptionInfo)
-{
-    LONG ExceptionDisposition = EXCEPTION_EXECUTE_HANDLER;
-    LPTOP_LEVEL_EXCEPTION_FILTER RealFilter;
-    RealFilter = RtlDecodePointer(GlobalTopLevelExceptionFilter);
-
-    if (RealFilter != NULL)
-    {
-        _SEH2_TRY
-        {
-            ExceptionDisposition = RealFilter(ExceptionInfo);
-        }
-        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-        {
-        }
-        _SEH2_END;
-    }
-    if ((ExceptionDisposition == EXCEPTION_CONTINUE_SEARCH || ExceptionDisposition == EXCEPTION_EXECUTE_HANDLER) &&
-        RealFilter != UnhandledExceptionFilter)
-    {
-       ExceptionDisposition = UnhandledExceptionFilter(ExceptionInfo);
-    }
-
-    return ExceptionDisposition;
-}
-
 VOID
 WINAPI
 BaseProcessStartup(PPROCESS_START_ROUTINE lpStartAddress)
@@ -489,7 +462,7 @@ BaseProcessStartup(PPROCESS_START_ROUTINE lpStartAddress)
         /* Call the Start Routine */
         ExitThread(lpStartAddress());
     }
-    _SEH2_EXCEPT(BaseExceptionFilter(_SEH2_GetExceptionInformation()))
+    _SEH2_EXCEPT(UnhandledExceptionFilter(_SEH2_GetExceptionInformation()))
     {
         /* Get the Exit code from the SEH Handler */
         if (!BaseRunningInServerProcess)

--- a/dll/win32/kernel32/client/thread.c
+++ b/dll/win32/kernel32/client/thread.c
@@ -26,29 +26,6 @@ BasepNotifyCsrOfThread(IN HANDLE ThreadHandle,
 
 /* FUNCTIONS ******************************************************************/
 
-static
-LONG BaseThreadExceptionFilter(EXCEPTION_POINTERS * ExceptionInfo)
-{
-    LONG ExceptionDisposition = EXCEPTION_EXECUTE_HANDLER;
-    LPTOP_LEVEL_EXCEPTION_FILTER RealFilter;
-
-    RealFilter = RtlDecodePointer(GlobalTopLevelExceptionFilter);
-    if (RealFilter != NULL)
-    {
-        _SEH2_TRY
-        {
-            ExceptionDisposition = RealFilter(ExceptionInfo);
-        }
-        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-        {
-            ExceptionDisposition = UnhandledExceptionFilter(ExceptionInfo);
-        }
-        _SEH2_END;
-    }
-
-    return ExceptionDisposition;
-}
-
 __declspec(noreturn)
 VOID
 WINAPI
@@ -68,7 +45,7 @@ BaseThreadStartup(IN LPTHREAD_START_ROUTINE lpStartAddress,
         /* Get the exit code from the Thread Start */
         ExitThread((lpStartAddress)((PVOID)lpParameter));
     }
-    _SEH2_EXCEPT(BaseThreadExceptionFilter(_SEH2_GetExceptionInformation()))
+    _SEH2_EXCEPT(UnhandledExceptionFilter(_SEH2_GetExceptionInformation()))
     {
         /* Get the Exit code from the SEH Handler */
         if (!BaseRunningInServerProcess)


### PR DESCRIPTION

This should allow unhandled exceptions in a thread to trigger our crash reporter,
instead of killing the process directly.

