### PR TITLE
[USETUP] Don't print "found EXT2 partition" when it's actually a different FS type

### DIFF
--- a/base/setup/lib/fsutil.c
+++ b/base/setup/lib/fsutil.c
@@ -221,7 +221,7 @@ GetFileSystem(
         else
             FileSystemName = NULL;
     }
-    else if (PartEntry->PartitionType == PARTITION_EXT2)
+    else if (PartEntry->PartitionType == PARTITION_LINUX)
     {
         if (CheckExt2Format())
             FileSystemName = L"EXT2";
@@ -386,7 +386,7 @@ PreparePartitionForFormatting(
 #if 0
     else if (wcscmp(FileSystem->FileSystemName, L"EXT2") == 0)
     {
-        SetPartitionType(PartEntry, PARTITION_EXT2);
+        SetPartitionType(PartEntry, PARTITION_LINUX);
     }
     else if (wcscmp(FileSystem->FileSystemName, L"NTFS") == 0)
     {

--- a/base/setup/lib/utils/partlist.c
+++ b/base/setup/lib/utils/partlist.c
@@ -2710,8 +2710,7 @@ CheckActiveSystemPartition(
     }
     // HACK: WARNING: We cannot write on this FS yet!
     // See fsutil.c:GetFileSystem()
-    if (List->OriginalSystemPartition->PartitionType == PARTITION_EXT2 ||
-        List->OriginalSystemPartition->PartitionType == PARTITION_IFS)
+    if (List->OriginalSystemPartition->PartitionType == PARTITION_IFS)
     {
         DPRINT1("Recognized file system %S that doesn't support write support yet!\n",
                 FileSystem->FileSystemName);

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -4405,10 +4405,10 @@ BootLoaderPage(PINPUT_RECORD Ir)
         DPRINT("Found OS/2 boot manager partition\n");
         InstallOnFloppy = TRUE;
     }
-    else if (PartitionType == PARTITION_EXT2)
+    else if (PartitionType == PARTITION_LINUX)
     {
-        /* Linux EXT2 partition */
-        DPRINT("Found Linux EXT2 partition\n");
+        /* Linux partition */
+        DPRINT("Found Linux native partition (ext2/ext3/ReiserFS/BTRFS/etc)\n");
         InstallOnFloppy = FALSE;
     }
     else if (PartitionType == PARTITION_IFS)

--- a/base/system/diskpart/partlist.c
+++ b/base/system/diskpart/partlist.c
@@ -33,7 +33,7 @@
 }
 
 /* We have to define it there, because it is not in the MS DDK */
-#define PARTITION_EXT2 0x83
+#define PARTITION_LINUX 0x83
 
 #define PARTITION_TBL_SIZE 4
 
@@ -451,7 +451,7 @@ AddPartitionToDisk(
 #endif
         PartEntry->FormatState = Preformatted;
     }
-    else if (PartEntry->PartitionType == PARTITION_EXT2)
+    else if (PartEntry->PartitionType == PARTITION_LINUX)
     {
 #if 0
         if (CheckExt2Format())

--- a/sdk/include/reactos/rosioctl.h
+++ b/sdk/include/reactos/rosioctl.h
@@ -14,7 +14,7 @@
 #define PARTITION_OS2BOOTMGR          0x0A // OS/2 Boot Manager/OPUS/Coherent swap
 #define PARTITION_LINUX_SWAP          0x82 // Linux Swap Partition
 #define PARTITION_LINUX               0x83 // Linux Partition Ext2/Ext3/Ext4
-#define PARTITION_EXT2                PARTITION_LINUX // some apps use this identifier
+#define PARTITION_LINUX_EXT           0x85 // Linux Extended Partition
 #define PARTITION_LINUX_LVM           0x8E
 
 #endif /* __ROSIOCTL_H */


### PR DESCRIPTION
## Purpose
When BTRFS is chosen as the filesystem for the partition, we think of it as being Ext2 partly because of the partition type ID being the same, `0x83`. However there are other Linux filesystems which use this ID as well therefore it doesn't make sense to print `Found Linux EXT2 partition`.
## Proposed Changes
- Display the correct debug message in the console and not `Found Linux EXT2 partition` when there can be other filesystems which have the same ID type too