### PR TITLE
[USETUP] Fix a broken character in Italian resource

### DIFF
--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -561,7 +561,7 @@ static MUI_ENTRY itITFlushPageEntries[] =
     {
         0,
         0,
-        "Svuotamento della cache in corso",
+        "   Svuotamento della cache in corso",
         TEXT_TYPE_STATUS
     },
     {
@@ -1785,7 +1785,7 @@ MUI_STRING itITStrings[] =
     {STRING_REBOOTCOMPUTER2,
     "   INVIO = Riavvia il computer"},
     {STRING_REBOOTPROGRESSBAR,
-    " Il computer si riavvierà in %li secondi... "},
+    " Il computer si riavvier\x85 in %li secondi... "},
     {STRING_CONSOLEFAIL1,
     "Impossibile aprire la console\r\n\r\n"},
     {STRING_CONSOLEFAIL2,


### PR DESCRIPTION
- Fix a broken character encoding in the Italian translation file
- And since we're here, add two spaces at the beginning of the "deleting cache" string