### PR TITLE
[INETCPL] Add icon codes for trusted and restricted zones

### DIFF
--- a/dll/cpl/inetcpl/inetcpl.h
+++ b/dll/cpl/inetcpl/inetcpl.h
@@ -41,6 +41,8 @@ INT_PTR CALLBACK security_dlgproc(HWND, UINT, WPARAM, LPARAM) DECLSPEC_HIDDEN;
 #define ICO_CERTIFICATES    1314
 #define ICO_HISTORY         1315
 #define ICO_HOME            1316
+#define ICO_TRUSTED         4480
+#define ICO_RESTRICTED      4481
 #endif
 
 /* strings */


### PR DESCRIPTION
## Purpose

Added icon codes for trusted and restricted zones.

I've placed the definitions inside `#ifdef __REACTOS__` block.

## Proposed changes

- Before:

![image](https://user-images.githubusercontent.com/578406/47394150-8b45b600-d72a-11e8-94e6-8ee9e745af1c.png)

- After:

![image](https://user-images.githubusercontent.com/578406/47394178-afa19280-d72a-11e8-974d-57e128ce4b19.png)
