### PR TITLE
[USER32] Fix task switcher

### DIFF
--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -125,7 +125,7 @@ void ResizeAndCenter(HWND hwnd, int width, int height)
 void MakeWindowActive(HWND hwnd)
 {
    if (IsIconic(hwnd))
-      ShowWindowAsync(hwnd, SW_RESTORE);
+      PostMessageW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
 
    BringWindowToTop(hwnd);  // same as: SetWindowPos(hwnd,HWND_TOP,0,0,0,0,SWP_NOMOVE|SWP_NOSIZE); ?
    SetForegroundWindow(hwnd);
@@ -170,6 +170,9 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 
    if (!IsWindowVisible(window))
             return TRUE;
+
+   if (GetWindow(window, GW_OWNER) != NULL)
+       return TRUE;
 
    GetClassNameW(window, windowText, _countof(windowText));
    if ((wcscmp(L"Shell_TrayWnd", windowText)==0) ||


### PR DESCRIPTION
## Purpose
This PR will fix Task Switcher in switching tasks and enumeration.
JIRA issue: [CORE-15165](https://jira.reactos.org/browse/CORE-15165)

## Proposed changes
- Don't enumerate the windows whose owner window exists.
- Use PostMessage SC_RESTORE instead of ShowWindowAsync SW_RESTORE.