### PR TITLE
[CMAKE] Use configured include files to define the __RELFILE__ hack

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,6 @@ endif()
 include(sdk/cmake/compilerflags.cmake)
 
 add_definitions(-D__REACTOS__)
-add_definitions(-DREACTOS_SOURCE_DIR="\\"${REACTOS_SOURCE_DIR}\\"")
-add_definitions(-DREACTOS_BINARY_DIR="\\"${REACTOS_BINARY_DIR}\\"")
-add_compile_flags(-D__RELFILE__="&__FILE__[sizeof REACTOS_SOURCE_DIR]")
 
 if(MSVC_IDE)
     add_compile_flags("/MP")

--- a/sdk/include/reactos/builddir.h.cmake
+++ b/sdk/include/reactos/builddir.h.cmake
@@ -1,0 +1,7 @@
+/* Do not edit - Machine generated */
+#pragma once
+
+#define REACTOS_SOURCE_DIR        "@REACTOS_SOURCE_DIR@"
+#define REACTOS_BINARY_DIR        "@REACTOS_BINARY_DIR@"
+
+/* EOF */

--- a/sdk/include/reactos/debug.h
+++ b/sdk/include/reactos/debug.h
@@ -15,12 +15,12 @@
 #pragma once
 
 #ifndef __RELFILE__
-#	ifdef __REACTOS__
-#		include <reactos/builddir.h>
-#		define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
-#	else
-#		define __RELFILE__ __FILE__
-#	endif
+#   ifdef __REACTOS__
+#       include <reactos/builddir.h>
+#       define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
+#   else
+#       define __RELFILE__ __FILE__
+#   endif
 #endif
 
 /* Define DbgPrint/DbgPrintEx/RtlAssert unless the NDK is used */

--- a/sdk/include/reactos/debug.h
+++ b/sdk/include/reactos/debug.h
@@ -15,7 +15,12 @@
 #pragma once
 
 #ifndef __RELFILE__
-#define __RELFILE__ __FILE__
+#	ifdef __REACTOS__
+#		include <reactos/builddir.h>
+#		define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
+#	else
+#		define __RELFILE__ __FILE__
+#	endif
 #endif
 
 /* Define DbgPrint/DbgPrintEx/RtlAssert unless the NDK is used */

--- a/sdk/include/reactos/version.cmake
+++ b/sdk/include/reactos/version.cmake
@@ -53,3 +53,4 @@ endif()
 
 configure_file(sdk/include/reactos/version.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/version.h)
 configure_file(sdk/include/reactos/buildno.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/buildno.h)
+configure_file(sdk/include/reactos/builddir.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/builddir.h)

--- a/sdk/include/reactos/wine/debug.h
+++ b/sdk/include/reactos/wine/debug.h
@@ -28,7 +28,12 @@
 #endif
 
 #ifndef __RELFILE__
-#define __RELFILE__ __FILE__
+#	ifdef __REACTOS__
+#		include <reactos/builddir.h>
+#		define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
+#	else
+#		define __RELFILE__ __FILE__
+#	endif
 #endif
 
 #ifdef __WINE_WINE_TEST_H


### PR DESCRIPTION
It's easier on the command line and the eyes looking at it