### PR TITLE
[WIN32SS][USER32] CloseWindow does minimize, doesn't close

### DIFF
--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -127,9 +127,9 @@ ChildWindowFromPointEx(HWND hwndParent,
 BOOL WINAPI
 CloseWindow(HWND hWnd)
 {
-    SendMessageA(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
+    PostMessageW(hWnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
 
-    return HandleToUlong(hWnd);
+    return ValidateHwnd(hWndParent) != NULL;
 }
 
 FORCEINLINE


### PR DESCRIPTION
## Purpose
In Windows, user32!CloseWindow minimizes the window. It doesn't close the window actually. This is not a joke. This bad function naming is responsible to MS.

JIRA issue: N/A
