### PR TITLE
[NTUSER] NtUserxSwitchToThisWindow 2nd argument is fAltTab

### DIFF
--- a/win32ss/user/user32/include/ntwrapper.h
+++ b/win32ss/user/user32/include/ntwrapper.h
@@ -688,9 +688,9 @@ EXTINLINE BOOL NtUserxUpdateUiState(HWND hWnd, DWORD Param)
     return (BOOL)NtUserCallTwoParam((DWORD_PTR)hWnd, (DWORD_PTR)Param, TWOPARAM_ROUTINE_ROS_UPDATEUISTATE);
 }
 
-EXTINLINE VOID NtUserxSwitchToThisWindow(HWND hWnd, BOOL bUnknown)
+EXTINLINE VOID NtUserxSwitchToThisWindow(HWND hWnd, BOOL fAltTab)
 {
-    NtUserCallTwoParam((DWORD_PTR)hWnd, (DWORD_PTR)bUnknown, TWOPARAM_ROUTINE_SWITCHTOTHISWINDOW);
+    NtUserCallTwoParam((DWORD_PTR)hWnd, (DWORD_PTR)fAltTab, TWOPARAM_ROUTINE_SWITCHTOTHISWINDOW);
 }
 
 EXTINLINE BOOL NtUserxShowOwnedPopups(HWND hWnd, BOOL fShow)


### PR DESCRIPTION
## Purpose
Fix the 2nd parameter name of NtUserxSwitchToThisWindow.
JIRA issue: [CORE-15165](https://jira.reactos.org/browse/CORE-15165)
