### PR TITLE
[COMCTL32] Hide status bar size grip when window is maximized

### DIFF
--- a/dll/win32/comctl32/status.c
+++ b/dll/win32/comctl32/status.c
@@ -1018,10 +1018,7 @@ STATUSBAR_WMNCHitTest (const STATUS_INFO *infoPtr, INT x, INT y)
 	pt.y = y;
 	ScreenToClient (infoPtr->Self, &pt);
 
-	rect.left = rect.right - 13;
-	rect.top += 2;
-
-	if (PtInRect (&rect, pt))
+	if (pt.x >= rect.right - GetSystemMetrics(SM_CXVSCROLL))
         {
             if (GetWindowLongW( infoPtr->Self, GWL_EXSTYLE ) & WS_EX_LAYOUTRTL) return HTBOTTOMLEFT;
 	    else return HTBOTTOMRIGHT;

--- a/dll/win32/comctl32/status.c
+++ b/dll/win32/comctl32/status.c
@@ -293,7 +293,8 @@ STATUSBAR_Refresh (STATUS_INFO *infoPtr, HDC hdc)
 
     SelectObject (hdc, hOldFont);
 
-    if (GetWindowLongW (infoPtr->Self, GWL_STYLE) & SBARS_SIZEGRIP)
+    if ((GetWindowLongW (infoPtr->Self, GWL_STYLE) & SBARS_SIZEGRIP)
+            && !(GetWindowLongW (infoPtr->Notify, GWL_STYLE) & WS_MAXIMIZE))
 	    STATUSBAR_DrawSizeGrip (theme, hdc, &rect);
 
     return 0;
@@ -1006,7 +1007,8 @@ STATUSBAR_WMGetText (const STATUS_INFO *infoPtr, INT size, LPWSTR buf)
 static BOOL
 STATUSBAR_WMNCHitTest (const STATUS_INFO *infoPtr, INT x, INT y)
 {
-    if (GetWindowLongW (infoPtr->Self, GWL_STYLE) & SBARS_SIZEGRIP) {
+    if ((GetWindowLongW (infoPtr->Self, GWL_STYLE) & SBARS_SIZEGRIP)
+            && !(GetWindowLongW (infoPtr->Notify, GWL_STYLE) & WS_MAXIMIZE)) {
 	RECT  rect;
 	POINT pt;
 


### PR DESCRIPTION
## Purpose

Hide status bar size grip when window is maximized.

JIRA issue: [CORE-15240](https://jira.reactos.org/browse/CORE-15240)

## Proposed changes

- Hide size grip of status bar when `SW_MAXIMIZE` is set on the parent window.