### PR TITLE
[NTUSER] Fix SetProcessDefaultLayout

### DIFF
--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -342,7 +342,7 @@ NtUserCallOneParam(
         case ONEPARAM_ROUTINE_SETPROCDEFLAYOUT:
         {
             PPROCESSINFO ppi;
-            if (Param & LAYOUT_ORIENTATIONMASK)
+            if (Param & LAYOUT_ORIENTATIONMASK || Param == LAYOUT_LTR)
             {
                 ppi = PsGetCurrentProcessWin32Process();
                 ppi->dwLayout = Param;

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2017,6 +2017,16 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
          EngSetLastError(ERROR_TLW_WITH_WSCHILD);
          goto cleanup;  /* WS_CHILD needs a parent, but WS_POPUP doesn't */
     }
+    else if (Cs->lpszClass != (LPCWSTR)MAKEINTATOM(gpsi->atomSysClass[ICLS_DESKTOP]) &&
+             (IS_INTRESOURCE(Cs->lpszClass) ||
+              Cs->lpszClass != (LPCWSTR)MAKEINTATOM(gpsi->atomSysClass[ICLS_HWNDMESSAGE]) ||
+              _wcsicmp(Cs->lpszClass, L"Message") != 0))
+    {
+        if (pti->ppi->dwLayout & LAYOUT_RTL)
+        {
+            Cs->dwExStyle |= WS_EX_LAYOUTRTL;
+        }
+    }
 
     ParentWindow = hWndParent ? UserGetWindowObject(hWndParent): NULL;
     OwnerWindow = hWndOwner ? UserGetWindowObject(hWndOwner): NULL;


### PR DESCRIPTION
## Purpose
1. Added a check in `co_UserCreateWindowEx` for parentless windows,
that checks the default layout direction, if its `LAYOUT_RTL` add the `WS_EX_LAYOUTRTL` flag to the extended window styles.
2. Made the internal routine to also accept `LAYOUT_LTR` as a value for `SetProcessDefaultLayout`

Now all the reactos applications that have SetProcessDefaultLayout calls to mirror the layout get mirrored.
(albeit to mixed results)

This code is based on this following wine code path->
[How wine checks for default process layout](https://github.com/wine-mirror/wine/blob/da5112c74313b5236183135204cab38a8b0169ed/dlls/user32/win.c#L1437)

Hopefully this will fare better than PR #600 