### PR TITLE
CORE-15336. [WINMM] Use "joystick.drv" instead of "winejoystick.drv"

### DIFF
--- a/dll/win32/winmm/joystick.c
+++ b/dll/win32/winmm/joystick.c
@@ -60,7 +60,11 @@ static	BOOL JOY_LoadDriver(DWORD dwJoyID)
     if (JOY_Sticks[dwJoyID].hDriver)
 	return TRUE;
 
+#ifdef __REACTOS__
+    JOY_Sticks[dwJoyID].hDriver = OpenDriverA("joystick.drv", 0, dwJoyID);
+#else
     JOY_Sticks[dwJoyID].hDriver = OpenDriverA("winejoystick.drv", 0, dwJoyID);
+#endif
     return (JOY_Sticks[dwJoyID].hDriver != 0);
 }
 


### PR DESCRIPTION
## Purpose

As suggested by Hermès Bélusca-Maïto.

NB: No driver is actually present.

JIRA issue: [CORE-15336](https://jira.reactos.org/browse/CORE-15336)
