### PR TITLE
[FASTFAT] Improvements for volume dismount + minor bugfixing.

### DIFF
--- a/drivers/filesystems/fastfat/cleanup.c
+++ b/drivers/filesystems/fastfat/cleanup.c
@@ -161,7 +161,7 @@ VfatCleanupFile(
 #ifdef ENABLE_SWAPOUT
     if (IsVolume && BooleanFlagOn(DeviceExt->Flags, VCB_DISMOUNT_PENDING))
     {
-        VfatCheckForDismount(DeviceExt, FALSE);
+        VfatCheckForDismount(DeviceExt, TRUE);
     }
 #endif
 

--- a/drivers/filesystems/fastfat/close.c
+++ b/drivers/filesystems/fastfat/close.c
@@ -21,8 +21,8 @@ VfatCommonCloseFile(
     PDEVICE_EXTENSION DeviceExt,
     PVFATFCB pFcb)
 {
-    /* Nothing to do for volumes */
-    if (BooleanFlagOn(pFcb->Flags, FCB_IS_VOLUME))
+    /* Nothing to do for volumes or for the FAT file object */
+    if (BooleanFlagOn(pFcb->Flags, FCB_IS_FAT | FCB_IS_VOLUME))
     {
         return;
     }

--- a/drivers/filesystems/fastfat/fat.c
+++ b/drivers/filesystems/fastfat/fat.c
@@ -20,12 +20,6 @@
 #define  CACHEPAGESIZE(pDeviceExt) ((pDeviceExt)->FatInfo.BytesPerCluster > PAGE_SIZE ? \
 		   (pDeviceExt)->FatInfo.BytesPerCluster : PAGE_SIZE)
 
-/* FIXME: because volume is not cached, we have to perform direct IOs
- * The day this is fixed, just comment out that line, and check
- * it still works (and delete old code ;-))
- */
-#define VOLUME_IS_NOT_CACHED_WORK_AROUND_IT
-
 /* FUNCTIONS ****************************************************************/
 
 /*

--- a/drivers/filesystems/fastfat/flush.c
+++ b/drivers/filesystems/fastfat/flush.c
@@ -59,7 +59,9 @@ VfatFlushVolume(
     KEVENT Event;
     IO_STATUS_BLOCK IoStatusBlock;
 
-    DPRINT("VfatFlushVolume(DeviceExt %p, FatFcb %p)\n", DeviceExt, VolumeFcb);
+    DPRINT("VfatFlushVolume(DeviceExt %p, VolumeFcb %p)\n", DeviceExt, VolumeFcb);
+
+    ASSERT(VolumeFcb == DeviceExt->VolumeFcb);
 
     ListEntry = DeviceExt->FcbListHead.Flink;
     while (ListEntry != &DeviceExt->FcbListHead)

--- a/drivers/filesystems/fastfat/vfat.h
+++ b/drivers/filesystems/fastfat/vfat.h
@@ -16,12 +16,16 @@
 #define INIT_SECTION /* Done via alloc_text for MSC */
 #endif
 
+
 #define USE_ROS_CC_AND_FS
-#if 0
-#ifndef _MSC_VER
 #define ENABLE_SWAPOUT
-#endif
-#endif
+
+/* FIXME: because volume is not cached, we have to perform direct IOs
+ * The day this is fixed, just comment out that line, and check
+ * it still works (and delete old code ;-))
+ */
+#define VOLUME_IS_NOT_CACHED_WORK_AROUND_IT
+
 
 #define ROUND_DOWN(n, align) \
     (((ULONG)n) & ~((align) - 1l))
@@ -244,6 +248,8 @@ typedef union _DIR_ENTRY DIR_ENTRY, *PDIR_ENTRY;
 #define VCB_IS_SYS_OR_HAS_PAGE  0x0008
 #define VCB_IS_DIRTY            0x4000 /* Volume is dirty */
 #define VCB_CLEAR_DIRTY         0x8000 /* Clean dirty flag at shutdown */
+/* VCB condition state */
+#define VCB_GOOD                0x0010 /* If not set, the VCB is improper for usage */
 
 typedef struct
 {
@@ -326,6 +332,7 @@ typedef struct DEVICE_EXTENSION
     BOOLEAN AvailableClustersValid;
     ULONG Flags;
     struct _VFATFCB *VolumeFcb;
+    struct _VFATFCB *RootFcb;
     PSTATISTICS Statistics;
 
     /* Pointers to functions for manipulating FAT. */

--- a/ntoskrnl/io/iomgr/file.c
+++ b/ntoskrnl/io/iomgr/file.c
@@ -582,29 +582,6 @@ IopParseDevice(IN PVOID ParseObject,
         /* Check if we can simply use a dummy file */
         UseDummyFile = ((OpenPacket->QueryOnly) || (OpenPacket->DeleteOnly));
 
-#if 1
-        /* FIXME: Small hack still exists, have to check why...
-         * This is triggered multiple times by usetup and then once per boot.
-         */
-        if (ExpInTextModeSetup &&
-            !(DirectOpen) &&
-            !(RemainingName->Length) &&
-            !(OpenPacket->RelatedFileObject) &&
-            ((wcsstr(CompleteName->Buffer, L"Harddisk")) ||
-            (wcsstr(CompleteName->Buffer, L"Floppy"))) &&
-            !(UseDummyFile))
-        {
-            DPRINT1("Using IopParseDevice() hack. Requested invalid attributes: %lx\n",
-            DesiredAccess & ~(SYNCHRONIZE |
-                              FILE_READ_ATTRIBUTES |
-                              READ_CONTROL |
-                              ACCESS_SYSTEM_SECURITY |
-                              WRITE_OWNER |
-                              WRITE_DAC));
-            DirectOpen = TRUE;
-        }
-#endif
-
         /* Check if this is a direct open */
         if (!(RemainingName->Length) &&
             !(OpenPacket->RelatedFileObject) &&


### PR DESCRIPTION
- Cache the RootFcb so that its cleanup can be handled separately
  during dismounting.

- Force volume dismount at cleanup if the VCB_DISMOUNT_PENDING flag
  is set.

- Actually dismount a volume if its VCB has been flagged as not good,
  or if we force dismounting.

NOTE: In their *CheckForDismount() function, our 3rd-party FS drivers
as well as MS' fastfat, perform a comparison check of the current VCB's
VPB ReferenceCount with some sort of "dangling"/"residual" open count.
It seems to be related to the fact that the volume root directory as
well as auxiliary data stream(s) are still opened, and only these are
allowed to be opened at that moment. After analysis it appears that for
the ReactOS' fastfat, this number is equal to "3". But this should be
investigated more closely...

- On dismounting, cleanup and destroy the RootFcb, VolumeFcb and the
  FATFileObject. Then cleanup the SpareVPB or the IoVPB members, and
  finish by removing the dismounted volume from the VolumeListEntry
  and cleaning up the notify synchronization object and the resources.

- During dismounting, and on shutdown, flush the volume before
  resetting its dirty bit.

- On shutdown, after volume flushing, try to unmount it without forcing.

- Release the VCB resources only when we actually dismount the volume
  in VfatCheckForDismount().

- Initialize first the notify list and the synchronization object,
  before sending the FSRTL_VOLUME_MOUNT notification.

- If we failed at mounting a volume but its VCB's FATFileObject was
  already initialized, first call CcUninitializeCacheMap() on it
  before dereferencing it.

- Send FSRTL_VOLUME_LOCK, FSRTL_VOLUME_LOCK_FAILED and
  FSRTL_VOLUME_UNLOCK notifications during volume locking (and failure)
  and volume unlocking.

- Flush the volume before locking it, and clean its dirty bit if needed.

NOTE: In addition to checking for VCB_CLEAR_DIRTY, we also check for the
presence of the VCB_IS_DIRTY flag before cleaning up the dirty bit: this
allows us to not re-clean the bit if it has been previously cleaned.
This is needed for instance in this scenario:
- The volume is locked (it gets flushed and the dirty bit is possibly cleared);
- The volume then gets formatted with a completely different FS, that
  possibly clears up the first sector (e.g. BTRFS ignores 1st sector);
- The volume is then dismounted: if we didn't check whether VCB_IS_DIRTY
  was set prior to resetting it, we could attempt clearing it again! But
  now that the volume's filesystem has been completely changed, we would
  then try to modify the dirty bit on an erroneous position on disk!
  That's why it should not be touched in this case during dismounting.
- The volume is unlocked (same comment as above), and later can be
  detected as being BTRFS.

[NTOS:IO] Finally remove the dreadful IopParseDevice() hack?!
