### PR TITLE
[WINMM] Sync wine commit ebae298 as a fix for CORE-15336

### DIFF
--- a/dll/win32/winmm/joystick.c
+++ b/dll/win32/winmm/joystick.c
@@ -55,12 +55,21 @@ static	WINE_JOYSTICK	JOY_Sticks[MAXJOYSTICK];
  */
 static	BOOL JOY_LoadDriver(DWORD dwJoyID)
 {
-    if (dwJoyID >= MAXJOYSTICK)
+    static BOOL winejoystick_missing = FALSE;
+
+    if (dwJoyID >= MAXJOYSTICK || winejoystick_missing)
 	return FALSE;
     if (JOY_Sticks[dwJoyID].hDriver)
 	return TRUE;
 
     JOY_Sticks[dwJoyID].hDriver = OpenDriverA("winejoystick.drv", 0, dwJoyID);
+
+    if (!JOY_Sticks[dwJoyID].hDriver)
+    {
+        /* The default driver is missing, don't attempt to load it again */
+        winejoystick_missing = TRUE;
+    }
+
     return (JOY_Sticks[dwJoyID].hDriver != 0);
 }
 


### PR DESCRIPTION
## Purpose

Reduce CPU usage while using certain programs/games by not continuously looking up for the default joystick driver that isn't included in ReactOS.

Imported the following wine commit
https://github.com/wine-mirror/wine/commit/ebae298aa4d2711fef35d4ac60c6012438f36d61

Fix for JIRA issue [CORE-15336](https://jira.reactos.org/browse/CORE-15336)

