### PR TITLE
[KERNEL32] FlsAlloc - fiber local storage list was not initialized before using.

### DIFF
--- a/dll/win32/kernel32/client/fiber.c
+++ b/dll/win32/kernel32/client/fiber.c
@@ -372,6 +372,7 @@ FlsAlloc(PFLS_CALLBACK_FUNCTION lpCallback)
                 if (!NtCurrentTeb()->FlsData)
                 {
                     NtCurrentTeb()->FlsData = pFlsData;
+                    InitializeListHead(&Peb->FlsListHead);
                     InsertTailList(&Peb->FlsListHead, &pFlsData->ListEntry);
                 }
 


### PR DESCRIPTION
FlsAlloc - fiber local storage list was not initialized before using

This bug was found while installing .net 4.5