### PR TITLE
Get rid of MM_SECTION_OBJECT

### DIFF
--- a/ntoskrnl/cache/cachesub.c
+++ b/ntoskrnl/cache/cachesub.c
@@ -312,7 +312,7 @@ CcShutdownSystem(VOID)
                     i,
                     Bcb->FileOffset.u.HighPart,
                     Bcb->FileOffset.u.LowPart,
-                    &MmGetFileObjectForSection((PROS_SECTION_OBJECT)Bcb->SectionObject)->FileName);
+                    &MmGetFileObjectForSection(Bcb->SectionObject)->FileName);
 
             CcpFlushCache(Bcb->Map, NULL, 0, NULL, TRUE);
             Bcb->Dirty = FALSE;

--- a/ntoskrnl/cache/fssup.c
+++ b/ntoskrnl/cache/fssup.c
@@ -612,7 +612,7 @@ CcGetFileObjectFromSectionPtrs(IN PSECTION_OBJECT_POINTERS SectionObjectPointer)
                                           NOCC_BCB,
                                           ThisFileList);
 
-        Result = MmGetFileObjectForSection((PROS_SECTION_OBJECT)Bcb->SectionObject);
+        Result = MmGetFileObjectForSection(Bcb->SectionObject);
     }
     CcpUnlock();
     return Result;
@@ -624,7 +624,7 @@ CcGetFileObjectFromBcb(PVOID Bcb)
 {
     PNOCC_BCB RealBcb = (PNOCC_BCB)Bcb;
     DPRINT("BCB #%x\n", RealBcb - CcCacheSections);
-    return MmGetFileObjectForSection((PROS_SECTION_OBJECT)RealBcb->SectionObject);
+    return MmGetFileObjectForSection(RealBcb->SectionObject);
 }
 
 /* EOF */

--- a/ntoskrnl/cache/newcc.h
+++ b/ntoskrnl/cache/newcc.h
@@ -6,7 +6,7 @@ typedef struct _NOCC_BCB
     PUBLIC_BCB Bcb;
 
     struct _NOCC_CACHE_MAP *Map;
-    PROS_SECTION_OBJECT SectionObject;
+    PSECTION SectionObject;
     LARGE_INTEGER FileOffset;
     ULONG Length;
     PVOID BaseAddress;

--- a/ntoskrnl/cache/pinsup.c
+++ b/ntoskrnl/cache/pinsup.c
@@ -245,7 +245,7 @@ CcpDereferenceCache(ULONG Start,
 
     if (Immediate)
     {
-    	PSECTION ToDeref = Bcb->SectionObject;
+        PSECTION ToDeref = Bcb->SectionObject;
         Bcb->Map = NULL;
         Bcb->SectionObject = NULL;
         Bcb->BaseAddress = NULL;
@@ -308,7 +308,7 @@ on failure.
 /* Needs mutex */
 ULONG
 CcpAllocateCacheSections(PFILE_OBJECT FileObject,
-						 PSECTION SectionObject)
+                         PSECTION SectionObject)
 {
     ULONG i = INVALID_CACHE;
     PNOCC_CACHE_MAP Map;

--- a/ntoskrnl/cache/pinsup.c
+++ b/ntoskrnl/cache/pinsup.c
@@ -140,7 +140,7 @@ NTSTATUS
 CcpAllocateSection(PFILE_OBJECT FileObject,
                    ULONG Length,
                    ULONG Protect,
-                   PROS_SECTION_OBJECT *Result)
+                   PSECTION *Result)
 {
     NTSTATUS Status;
     LARGE_INTEGER MaxSize;
@@ -168,7 +168,7 @@ typedef struct _WORK_QUEUE_WITH_CONTEXT
     PVOID ToUnmap;
     LARGE_INTEGER FileOffset;
     LARGE_INTEGER MapSize;
-    PROS_SECTION_OBJECT ToDeref;
+    PSECTION ToDeref;
     PACQUIRE_FOR_LAZY_WRITE AcquireForLazyWrite;
     PRELEASE_FROM_LAZY_WRITE ReleaseFromLazyWrite;
     PVOID LazyContext;
@@ -245,7 +245,7 @@ CcpDereferenceCache(ULONG Start,
 
     if (Immediate)
     {
-        PROS_SECTION_OBJECT ToDeref = Bcb->SectionObject;
+    	PSECTION ToDeref = Bcb->SectionObject;
         Bcb->Map = NULL;
         Bcb->SectionObject = NULL;
         Bcb->BaseAddress = NULL;
@@ -308,7 +308,7 @@ on failure.
 /* Needs mutex */
 ULONG
 CcpAllocateCacheSections(PFILE_OBJECT FileObject,
-                         PROS_SECTION_OBJECT SectionObject)
+						 PSECTION SectionObject)
 {
     ULONG i = INVALID_CACHE;
     PNOCC_CACHE_MAP Map;
@@ -475,7 +475,7 @@ CcpMapData(IN PFILE_OBJECT FileObject,
     LARGE_INTEGER Target, EndInterval;
     ULONG BcbHead, SectionSize, ViewSize;
     PNOCC_BCB Bcb = NULL;
-    PROS_SECTION_OBJECT SectionObject = NULL;
+    PSECTION SectionObject = NULL;
     NTSTATUS Status;
     PNOCC_CACHE_MAP Map = (PNOCC_CACHE_MAP)FileObject->SectionObjectPointer->SharedCacheMap;
     ViewSize = CACHE_STRIPE;

--- a/ntoskrnl/cache/pinsup.c
+++ b/ntoskrnl/cache/pinsup.c
@@ -245,7 +245,7 @@ CcpDereferenceCache(ULONG Start,
 
     if (Immediate)
     {
-        PSECTION ToDeref = Bcb->SectionObject;
+    	PSECTION ToDeref = Bcb->SectionObject;
         Bcb->Map = NULL;
         Bcb->SectionObject = NULL;
         Bcb->BaseAddress = NULL;
@@ -308,7 +308,7 @@ on failure.
 /* Needs mutex */
 ULONG
 CcpAllocateCacheSections(PFILE_OBJECT FileObject,
-                         PSECTION SectionObject)
+						 PSECTION SectionObject)
 {
     ULONG i = INVALID_CACHE;
     PNOCC_CACHE_MAP Map;

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -350,10 +350,7 @@ MmCreateCacheSection(PSECTION *SectionObject,
 
     /* Initialize it */
     RtlZeroMemory(Section, sizeof(*Section));
-
-    /* Mark it as a "ROS" Section */
-    Section->u.Flags.filler0 = 1
-
+    Section->u.Flags.filler0 = 1;
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
     Section->Segment = NULL;

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -348,7 +348,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
     RtlZeroMemory(Section, sizeof(ROS_SECTION_OBJECT));
     Section->u.Flags.filler0 = 1;
     Section->InitialPageProtection = SectionPageProtection;
-    Section->AllocationAttributes = AllocationAttributes;
+    Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
     Section->Segment = NULL;
 
     DPRINT("Getting original file size\n");

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -350,7 +350,10 @@ MmCreateCacheSection(PSECTION *SectionObject,
 
     /* Initialize it */
     RtlZeroMemory(Section, sizeof(*Section));
-    Section->u.Flags.filler0 = 1;
+
+    /* Mark it as a "ROS" Section */
+    Section->u.Flags.filler0 = 1
+
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
     Section->Segment = NULL;

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -277,6 +277,10 @@ MmFinalizeSegment(PMM_SECTION_SEGMENT Segment)
     MmLockSectionSegment(Segment);
     RemoveEntryList(&Segment->ListOfSegments);
     if (Segment->Flags & MM_DATAFILE_SEGMENT) {
+#ifndef NEWCC
+        ASSERT(FALSE);
+#endif
+
         KeAcquireSpinLock(&Segment->FileObject->IrpListLock, &OldIrql);
         if (Segment->Flags & MM_SEGMENT_FINALIZE) {
             KeReleaseSpinLock(&Segment->FileObject->IrpListLock, OldIrql);

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -501,7 +501,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
 
     MmUnlockSectionSegment(Segment);
 
-    Section->MaximumSize.QuadPart = MaximumSize.QuadPart;
+    Section->SizeOfSection.QuadPart = MaximumSize.QuadPart;
 
     /* Extend file if section is longer */
     DPRINT("MaximumSize %I64x ValidDataLength %I64x\n",

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -346,9 +346,8 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
 
     /* Initialize it */
     RtlZeroMemory(Section, sizeof(ROS_SECTION_OBJECT));
-    Section->Type = 'SC';
-    Section->Size = 'TN';
-    Section->SectionPageProtection = SectionPageProtection;
+    Section->u.Flags.filler0 = 1;
+    Section->InitialPageProtection = SectionPageProtection;
     Section->AllocationAttributes = AllocationAttributes;
     Section->Segment = NULL;
 
@@ -437,7 +436,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
     Segment->ReferenceCount = 1;
     Segment->Locked = TRUE;
     RtlZeroMemory(&Segment->Image, sizeof(Segment->Image));
-    Section->Segment = Segment;
+    Section->Segment = (PSEGMENT)Segment;
 
     KeAcquireSpinLock(&FileObject->IrpListLock, &OldIrql);
     /*
@@ -487,7 +486,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
         * to extend it
         */
         Segment = (PMM_SECTION_SEGMENT)FileObject->SectionObjectPointer->DataSectionObject;
-        Section->Segment = Segment;
+        Section->Segment = (PSEGMENT)Segment;
         (void)InterlockedIncrementUL(&Segment->ReferenceCount);
 
         MmLockSectionSegment(Segment);
@@ -760,7 +759,7 @@ MmExtendCacheSection(PROS_SECTION_OBJECT Section,
                      BOOLEAN ExtendFile)
 {
     LARGE_INTEGER OldSize;
-    PMM_SECTION_SEGMENT Segment = Section->Segment;
+    PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
     DPRINT("Extend Segment %p\n", Segment);
 
     MmLockSectionSegment(Segment);

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -305,7 +305,7 @@ MmFinalizeSegment(PMM_SECTION_SEGMENT Segment)
 
 NTSTATUS
 NTAPI
-MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
+MmCreateCacheSection(PSECTION *SectionObject,
                      ACCESS_MASK DesiredAccess,
                      POBJECT_ATTRIBUTES ObjectAttributes,
                      PLARGE_INTEGER UMaximumSize,
@@ -316,7 +316,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
  * Create a section backed by a data file.
  */
 {
-    PROS_SECTION_OBJECT Section;
+    PSECTION Section;
     NTSTATUS Status;
     LARGE_INTEGER MaximumSize;
     PMM_SECTION_SEGMENT Segment;
@@ -333,10 +333,10 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
                             ObjectAttributes,
                             ExGetPreviousMode(),
                             NULL,
-                            sizeof(ROS_SECTION_OBJECT),
+                            sizeof(*Section),
                             0,
                             0,
-                            (PVOID*)(PVOID)&Section);
+                            (PVOID*)&Section);
     if (!NT_SUCCESS(Status))
     {
         DPRINT("Failed: %x\n", Status);
@@ -345,7 +345,7 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
     }
 
     /* Initialize it */
-    RtlZeroMemory(Section, sizeof(ROS_SECTION_OBJECT));
+    RtlZeroMemory(Section, sizeof(*Section));
     Section->u.Flags.filler0 = 1;
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
@@ -752,7 +752,7 @@ MmUnmapViewOfCacheSegment(PMMSUPPORT AddressSpace,
 
 NTSTATUS
 NTAPI
-MmExtendCacheSection(PROS_SECTION_OBJECT Section,
+MmExtendCacheSection(PSECTION Section,
                      PLARGE_INTEGER NewSize,
                      BOOLEAN ExtendFile)
 {

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -352,7 +352,7 @@ MmCreateCacheSection(PSECTION *SectionObject,
     RtlZeroMemory(Section, sizeof(*Section));
 
     /* Mark it as a "ROS" Section */
-    Section->u.Flags.filler0 = 1
+    Section->u.Flags.filler0 = 1;
 
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -351,8 +351,6 @@ MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
     Section->AllocationAttributes = AllocationAttributes;
     Section->Segment = NULL;
 
-    Section->FileObject = FileObject;
-
     DPRINT("Getting original file size\n");
     /* A hack: If we're cached, we can overcome deadlocking with the upper
     * layer filesystem call by retriving the object sizes from the cache

--- a/ntoskrnl/cache/section/newmm.h
+++ b/ntoskrnl/cache/section/newmm.h
@@ -96,7 +96,7 @@ typedef struct _MM_REQUIRED_RESOURCES
 
 NTSTATUS
 NTAPI
-MmCreateCacheSection(PROS_SECTION_OBJECT *SectionObject,
+MmCreateCacheSection(PSECTION *SectionObject,
                      ACCESS_MASK DesiredAccess,
                      POBJECT_ATTRIBUTES ObjectAttributes,
                      PLARGE_INTEGER UMaximumSize,
@@ -386,7 +386,7 @@ MiSwapInSectionPage(PMMSUPPORT AddressSpace,
 
 NTSTATUS
 NTAPI
-MmExtendCacheSection(PROS_SECTION_OBJECT Section,
+MmExtendCacheSection(PSECTION Section,
                      PLARGE_INTEGER NewSize,
                      BOOLEAN ExtendFile);
 

--- a/ntoskrnl/cache/section/newmm.h
+++ b/ntoskrnl/cache/section/newmm.h
@@ -173,7 +173,7 @@ MmpPageOutPhysicalAddress(PFN_NUMBER Page);
 
 /* io.c **********************************************************************/
 
-NTSTATUS
+VOID
 MmspWaitForFileLock(PFILE_OBJECT File);
 
 NTSTATUS
@@ -305,10 +305,6 @@ _MiFlushMappedSection(PVOID BaseAddress,
 VOID
 NTAPI
 MmFinalizeSegment(PMM_SECTION_SEGMENT Segment);
-
-VOID
-NTAPI
-MmFreeSectionSegments(PFILE_OBJECT FileObject);
 
 NTSTATUS
 NTAPI

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -1316,14 +1316,7 @@ CcRosDereferenceCache (
         SharedCacheMap->OpenCount--;
         if (SharedCacheMap->OpenCount == 0)
         {
-            KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
-            MmFreeSectionSegments(SharedCacheMap->FileObject);
-
-            OldIrql = KeAcquireQueuedSpinLock(LockQueueMasterLock);
             CcRosDeleteFileCache(FileObject, SharedCacheMap, &OldIrql);
-            KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
-
-            return;
         }
     }
     KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
@@ -1378,14 +1371,7 @@ CcRosReleaseFileCache (
                 SharedCacheMap->OpenCount--;
                 if (SharedCacheMap->OpenCount == 0)
                 {
-                    KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
-                    MmFreeSectionSegments(SharedCacheMap->FileObject);
-
-                    OldIrql = KeAcquireQueuedSpinLock(LockQueueMasterLock);
                     CcRosDeleteFileCache(FileObject, SharedCacheMap, &OldIrql);
-                    KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
-
-                    return STATUS_SUCCESS;
                 }
             }
         }

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -185,6 +185,7 @@ typedef struct _MM_IMAGE_SECTION_OBJECT
 {
     SECTION_IMAGE_INFORMATION ImageInformation;
     PFILE_OBJECT FileObject;
+    ULONG ReferenceCount;
     PVOID BasedAddress;
     ULONG NrSegments;
     PMM_SECTION_SEGMENT Segments;
@@ -1350,10 +1351,6 @@ MmAccessFaultSectionView(
     MEMORY_AREA* MemoryArea,
     PVOID Address
 );
-
-VOID
-NTAPI
-MmFreeSectionSegments(PFILE_OBJECT FileObject);
 
 /* sysldr.c ******************************************************************/
 

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -159,26 +159,26 @@ typedef ULONG_PTR SWAPENTRY;
 
 typedef struct _MM_SECTION_SEGMENT
 {
-    FAST_MUTEX Lock;		/* lock which protects the page directory */
-	PFILE_OBJECT FileObject;
-    LARGE_INTEGER RawLength;		/* length of the segment which is part of the mapped file */
-    LARGE_INTEGER Length;			/* absolute length of the segment */
+    FAST_MUTEX Lock;      /* lock which protects the page directory */
+    PFILE_OBJECT FileObject;
+    LARGE_INTEGER RawLength;      /* length of the segment which is part of the mapped file */
+    LARGE_INTEGER Length;         /* absolute length of the segment */
     ULONG ReferenceCount;
-	ULONG CacheCount;
+    ULONG CacheCount;
     ULONG Protection;
     ULONG Flags;
     BOOLEAN WriteCopy;
-	BOOLEAN Locked;
+    BOOLEAN Locked;
 
-	struct
-	{
-		ULONGLONG FileOffset;		/* start offset into the file for image sections */
-		ULONG_PTR VirtualAddress;	/* start offset into the address range for image sections */
-		ULONG Characteristics;
-	} Image;
+    struct
+    {
+        ULONGLONG FileOffset;      /* start offset into the file for image sections */
+        ULONG_PTR VirtualAddress;   /* start offset into the address range for image sections */
+        ULONG Characteristics;
+    } Image;
 
-	LIST_ENTRY ListOfSegments;
-	RTL_GENERIC_TABLE PageTable;
+    LIST_ENTRY ListOfSegments;
+    RTL_GENERIC_TABLE PageTable;
 } MM_SECTION_SEGMENT, *PMM_SECTION_SEGMENT;
 
 typedef struct _MM_IMAGE_SECTION_OBJECT
@@ -195,15 +195,15 @@ FORCEINLINE
 PFILE_OBJECT
 FILE_OBJECT_FROM_SECTION(PSECTION Section)
 {
-	ASSERT(Section->u.Flags.filler0 == 1);
+   ASSERT(Section->u.Flags.filler0 == 1);
 
-	if (!Section->Segment)
-		return NULL;
+    if (!Section->Segment)
+        return NULL;
 
-	if (Section->u.Flags.Image)
-		return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
+    if (Section->u.Flags.Image)
+        return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
 
-	return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
+    return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
 }
 
 #define MA_GetStartingAddress(_MemoryArea) ((_MemoryArea)->VadNode.StartingVpn << PAGE_SHIFT)
@@ -1093,9 +1093,9 @@ MmInitGlobalKernelPageDirectory(VOID);
 VOID
 NTAPI
 MmGetPageFileMapping(
-	struct _EPROCESS *Process,
-	PVOID Address,
-	SWAPENTRY* SwapEntry);
+    struct _EPROCESS *Process,
+    PVOID Address,
+    SWAPENTRY* SwapEntry);
 
 VOID
 NTAPI

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -160,25 +160,25 @@ typedef ULONG_PTR SWAPENTRY;
 typedef struct _MM_SECTION_SEGMENT
 {
     FAST_MUTEX Lock;		/* lock which protects the page directory */
-    PFILE_OBJECT FileObject;
+	PFILE_OBJECT FileObject;
     LARGE_INTEGER RawLength;		/* length of the segment which is part of the mapped file */
     LARGE_INTEGER Length;			/* absolute length of the segment */
     ULONG ReferenceCount;
-    ULONG CacheCount;
+	ULONG CacheCount;
     ULONG Protection;
     ULONG Flags;
     BOOLEAN WriteCopy;
-    BOOLEAN Locked;
+	BOOLEAN Locked;
 
-    struct
-    {
-        ULONGLONG FileOffset;		/* start offset into the file for image sections */
-        ULONG_PTR VirtualAddress;	/* start offset into the address range for image sections */
-        ULONG Characteristics;
-    } Image;
+	struct
+	{
+		ULONGLONG FileOffset;		/* start offset into the file for image sections */
+		ULONG_PTR VirtualAddress;	/* start offset into the address range for image sections */
+		ULONG Characteristics;
+	} Image;
 
-    LIST_ENTRY ListOfSegments;
-    RTL_GENERIC_TABLE PageTable;
+	LIST_ENTRY ListOfSegments;
+	RTL_GENERIC_TABLE PageTable;
 } MM_SECTION_SEGMENT, *PMM_SECTION_SEGMENT;
 
 typedef struct _MM_IMAGE_SECTION_OBJECT
@@ -195,15 +195,15 @@ FORCEINLINE
 PFILE_OBJECT
 FILE_OBJECT_FROM_SECTION(PSECTION Section)
 {
-    ASSERT(Section->u.Flags.filler0 == 1);
+	ASSERT(Section->u.Flags.filler0 == 1);
 
-    if (!Section->Segment)
-        return NULL;
+	if (!Section->Segment)
+		return NULL;
 
-    if (Section->u.Flags.Image)
-        return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
+	if (Section->u.Flags.Image)
+		return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
 
-    return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
+	return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
 }
 
 #define MA_GetStartingAddress(_MemoryArea) ((_MemoryArea)->VadNode.StartingVpn << PAGE_SHIFT)

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -192,7 +192,6 @@ typedef struct _MM_IMAGE_SECTION_OBJECT
 typedef struct _ROS_SECTION_OBJECT
 {
 	SECTION;
-    LARGE_INTEGER MaximumSize;
     ULONG AllocationAttributes;
     PFILE_OBJECT FileObject;
     union

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -160,25 +160,25 @@ typedef ULONG_PTR SWAPENTRY;
 typedef struct _MM_SECTION_SEGMENT
 {
     FAST_MUTEX Lock;		/* lock which protects the page directory */
-	PFILE_OBJECT FileObject;
+    PFILE_OBJECT FileObject;
     LARGE_INTEGER RawLength;		/* length of the segment which is part of the mapped file */
     LARGE_INTEGER Length;			/* absolute length of the segment */
     ULONG ReferenceCount;
-	ULONG CacheCount;
+    ULONG CacheCount;
     ULONG Protection;
     ULONG Flags;
     BOOLEAN WriteCopy;
-	BOOLEAN Locked;
+    BOOLEAN Locked;
 
-	struct
-	{
-		ULONGLONG FileOffset;		/* start offset into the file for image sections */
-		ULONG_PTR VirtualAddress;	/* start offset into the address range for image sections */
-		ULONG Characteristics;
-	} Image;
+    struct
+    {
+        ULONGLONG FileOffset;		/* start offset into the file for image sections */
+        ULONG_PTR VirtualAddress;	/* start offset into the address range for image sections */
+        ULONG Characteristics;
+    } Image;
 
-	LIST_ENTRY ListOfSegments;
-	RTL_GENERIC_TABLE PageTable;
+    LIST_ENTRY ListOfSegments;
+    RTL_GENERIC_TABLE PageTable;
 } MM_SECTION_SEGMENT, *PMM_SECTION_SEGMENT;
 
 typedef struct _MM_IMAGE_SECTION_OBJECT
@@ -195,15 +195,15 @@ FORCEINLINE
 PFILE_OBJECT
 FILE_OBJECT_FROM_SECTION(PSECTION Section)
 {
-	ASSERT(Section->u.Flags.filler0 == 1);
+    ASSERT(Section->u.Flags.filler0 == 1);
 
-	if (!Section->Segment)
-		return NULL;
+    if (!Section->Segment)
+        return NULL;
 
-	if (Section->u.Flags.Image)
-		return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
+    if (Section->u.Flags.Image)
+        return ((PMM_IMAGE_SECTION_OBJECT)Section->Segment)->FileObject;
 
-	return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
+    return ((PMM_SECTION_SEGMENT)Section->Segment)->FileObject;
 }
 
 #define MA_GetStartingAddress(_MemoryArea) ((_MemoryArea)->VadNode.StartingVpn << PAGE_SHIFT)

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -194,10 +194,6 @@ typedef struct _ROS_SECTION_OBJECT
 	SECTION;
     ULONG AllocationAttributes;
     PFILE_OBJECT FileObject;
-    union
-    {
-        PMM_IMAGE_SECTION_OBJECT ImageSection;
-    };
 } ROS_SECTION_OBJECT, *PROS_SECTION_OBJECT;
 
 #define MA_GetStartingAddress(_MemoryArea) ((_MemoryArea)->VadNode.StartingVpn << PAGE_SHIFT)

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -192,7 +192,6 @@ typedef struct _MM_IMAGE_SECTION_OBJECT
 typedef struct _ROS_SECTION_OBJECT
 {
 	SECTION;
-    ULONG AllocationAttributes;
     PFILE_OBJECT FileObject;
 } ROS_SECTION_OBJECT, *PROS_SECTION_OBJECT;
 

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -191,16 +191,13 @@ typedef struct _MM_IMAGE_SECTION_OBJECT
 
 typedef struct _ROS_SECTION_OBJECT
 {
-    CSHORT Type;
-    CSHORT Size;
+	SECTION;
     LARGE_INTEGER MaximumSize;
-    ULONG SectionPageProtection;
     ULONG AllocationAttributes;
     PFILE_OBJECT FileObject;
     union
     {
         PMM_IMAGE_SECTION_OBJECT ImageSection;
-        PMM_SECTION_SEGMENT Segment;
     };
 } ROS_SECTION_OBJECT, *PROS_SECTION_OBJECT;
 

--- a/ntoskrnl/kdbg/kdb_symbols.cmake.c
+++ b/ntoskrnl/kdbg/kdb_symbols.cmake.c
@@ -256,7 +256,7 @@ KdbSymPrintAddress(
 		}
 
 		SectionObject = MemoryArea->Data.SectionData.Section;
-		if (!(SectionObject->AllocationAttributes & SEC_IMAGE)) goto end;
+		if (!SectionObject->u.Flags.Image) goto end;
 #if 0
 		if (MemoryArea->StartingAddress != (PVOID)KdbpImageBase)
 		{

--- a/ntoskrnl/kdbg/kdb_symbols.cmake.c
+++ b/ntoskrnl/kdbg/kdb_symbols.cmake.c
@@ -176,7 +176,7 @@ KdbSymPrintAddress(
 {
     int i;
 	PMEMORY_AREA MemoryArea = NULL;
-	PROS_SECTION_OBJECT SectionObject;
+	PSECTION SectionObject;
     PLDR_DATA_TABLE_ENTRY LdrEntry;
 #if 0
     PROSSYM_KM_OWN_CONTEXT FileContext;

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2304,27 +2304,27 @@ FORCEINLINE
 ULONG
 MiSectionFlagsFromAllocationAttributes(ULONG Attributes)
 {
-    union
-    {
-        ULONG LongFlags;
-        MMSECTION_FLAGS Flags;
-    } u;
+	union
+	{
+		ULONG LongFlags;
+		MMSECTION_FLAGS Flags;
+	} u;
 
-    u.LongFlags = 0;
+	u.LongFlags = 0;
 
 #define ATTRIBUTE_TO_FLAG(__a, __f) if (Attributes & __a) u.Flags.__f = 1
-    ATTRIBUTE_TO_FLAG(SEC_IMAGE, Image);
-    ATTRIBUTE_TO_FLAG(SEC_PHYSICALMEMORY, PhysicalMemory);
-    ATTRIBUTE_TO_FLAG(SEC_FILE, File);
-    ATTRIBUTE_TO_FLAG(SEC_NO_CHANGE, NoChange);
-    ATTRIBUTE_TO_FLAG(SEC_BASED, Based);
-    ATTRIBUTE_TO_FLAG(SEC_RESERVE, Reserve);
-    ATTRIBUTE_TO_FLAG(SEC_COMMIT, Commit);
-    ATTRIBUTE_TO_FLAG(SEC_NOCACHE, NoCache);
-    ATTRIBUTE_TO_FLAG(SEC_WRITECOMBINE, WriteCombined);
+	ATTRIBUTE_TO_FLAG(SEC_IMAGE, Image);
+	ATTRIBUTE_TO_FLAG(SEC_PHYSICALMEMORY, PhysicalMemory);
+	ATTRIBUTE_TO_FLAG(SEC_FILE, File);
+	ATTRIBUTE_TO_FLAG(SEC_NO_CHANGE, NoChange);
+	ATTRIBUTE_TO_FLAG(SEC_BASED, Based);
+	ATTRIBUTE_TO_FLAG(SEC_RESERVE, Reserve);
+	ATTRIBUTE_TO_FLAG(SEC_COMMIT, Commit);
+	ATTRIBUTE_TO_FLAG(SEC_NOCACHE, NoCache);
+	ATTRIBUTE_TO_FLAG(SEC_WRITECOMBINE, WriteCombined);
 #undef ATTRIBUTE_TO_FLAG
 
-    return u.LongFlags;
+	return u.LongFlags;
 }
 
 /* EOF */

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2300,4 +2300,31 @@ MiSynchronizeSystemPde(PMMPDE PointerPde)
 }
 #endif
 
+FORCEINLINE
+ULONG
+MiSectionFlagsFromAllocationAttributes(ULONG Attributes)
+{
+	union
+	{
+		ULONG LongFlags;
+		MMSECTION_FLAGS Flags;
+	} u;
+
+	u.LongFlags = 0;
+
+#define ATTRIBUTE_TO_FLAG(__a, __f) if (Attributes & __a) u.Flags.__f = 1
+	ATTRIBUTE_TO_FLAG(SEC_IMAGE, Image);
+	ATTRIBUTE_TO_FLAG(SEC_PHYSICALMEMORY, PhysicalMemory);
+	ATTRIBUTE_TO_FLAG(SEC_FILE, File);
+	ATTRIBUTE_TO_FLAG(SEC_NO_CHANGE, NoChange);
+	ATTRIBUTE_TO_FLAG(SEC_BASED, Based);
+	ATTRIBUTE_TO_FLAG(SEC_RESERVE, Reserve);
+	ATTRIBUTE_TO_FLAG(SEC_COMMIT, Commit);
+	ATTRIBUTE_TO_FLAG(SEC_NOCACHE, NoCache);
+	ATTRIBUTE_TO_FLAG(SEC_WRITECOMBINE, WriteCombined);
+#undef ATTRIBUTE_TO_FLAG
+
+	return u.LongFlags;
+}
+
 /* EOF */

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2304,27 +2304,27 @@ FORCEINLINE
 ULONG
 MiSectionFlagsFromAllocationAttributes(ULONG Attributes)
 {
-	union
-	{
-		ULONG LongFlags;
-		MMSECTION_FLAGS Flags;
-	} u;
+    union
+    {
+        ULONG LongFlags;
+        MMSECTION_FLAGS Flags;
+    } u;
 
-	u.LongFlags = 0;
+    u.LongFlags = 0;
 
 #define ATTRIBUTE_TO_FLAG(__a, __f) if (Attributes & __a) u.Flags.__f = 1
-	ATTRIBUTE_TO_FLAG(SEC_IMAGE, Image);
-	ATTRIBUTE_TO_FLAG(SEC_PHYSICALMEMORY, PhysicalMemory);
-	ATTRIBUTE_TO_FLAG(SEC_FILE, File);
-	ATTRIBUTE_TO_FLAG(SEC_NO_CHANGE, NoChange);
-	ATTRIBUTE_TO_FLAG(SEC_BASED, Based);
-	ATTRIBUTE_TO_FLAG(SEC_RESERVE, Reserve);
-	ATTRIBUTE_TO_FLAG(SEC_COMMIT, Commit);
-	ATTRIBUTE_TO_FLAG(SEC_NOCACHE, NoCache);
-	ATTRIBUTE_TO_FLAG(SEC_WRITECOMBINE, WriteCombined);
+    ATTRIBUTE_TO_FLAG(SEC_IMAGE, Image);
+    ATTRIBUTE_TO_FLAG(SEC_PHYSICALMEMORY, PhysicalMemory);
+    ATTRIBUTE_TO_FLAG(SEC_FILE, File);
+    ATTRIBUTE_TO_FLAG(SEC_NO_CHANGE, NoChange);
+    ATTRIBUTE_TO_FLAG(SEC_BASED, Based);
+    ATTRIBUTE_TO_FLAG(SEC_RESERVE, Reserve);
+    ATTRIBUTE_TO_FLAG(SEC_COMMIT, Commit);
+    ATTRIBUTE_TO_FLAG(SEC_NOCACHE, NoCache);
+    ATTRIBUTE_TO_FLAG(SEC_WRITECOMBINE, WriteCombined);
 #undef ATTRIBUTE_TO_FLAG
 
-	return u.LongFlags;
+    return u.LongFlags;
 }
 
 /* EOF */

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -1035,9 +1035,8 @@ FORCEINLINE
 BOOLEAN
 MiIsRosSectionObject(IN PVOID Section)
 {
-    PROS_SECTION_OBJECT RosSection = Section;
-    if ((RosSection->Type == 'SC') && (RosSection->Size == 'TN')) return TRUE;
-    return FALSE;
+    PSECTION RosSection = Section;
+    return RosSection->u.Flags.filler0 == 1;
 }
 
 #define MI_IS_ROS_PFN(x)     ((x)->u4.AweAllocation == TRUE)

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -886,7 +886,7 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
     NTSTATUS Status = STATUS_SUCCESS;
     SIZE_T ViewSize = 0;
     PVOID ImageBase = 0;
-    PROS_SECTION_OBJECT SectionObject = Section;
+    PSECTION SectionObject = Section;
     PMMPTE PointerPte;
     KIRQL OldIrql;
     PMMPDE PointerPde;
@@ -962,7 +962,7 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
     if (SectionObject)
     {
         /* Determine the image file name and save it to EPROCESS */
-        FileName = SectionObject->FileObject->FileName;
+        FileName = FILE_OBJECT_FROM_SECTION(SectionObject)->FileName;
         Source = (PWCHAR)((PCHAR)FileName.Buffer + FileName.Length);
         if (FileName.Buffer)
         {
@@ -994,7 +994,7 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
         if (AuditName)
         {
             /* Setup the audit name */
-            Status = SeInitializeProcessAuditName(SectionObject->FileObject,
+            Status = SeInitializeProcessAuditName(FILE_OBJECT_FROM_SECTION(SectionObject),
                                                   FALSE,
                                                   AuditName);
             if (!NT_SUCCESS(Status))

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1636,14 +1636,14 @@ MiGetFileObjectForSectionAddress(
     if (Vad->u.VadFlags.Spare != 0)
     {
         PMEMORY_AREA MemoryArea = (PMEMORY_AREA)Vad;
-        PROS_SECTION_OBJECT Section;
+        PSECTION Section;
 
         /* Check if it's a section view (RosMm section) */
         if (MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
         {
             /* Get the section pointer to the SECTION_OBJECT */
             Section = MemoryArea->Data.SectionData.Section;
-            *FileObject = Section->FileObject;
+            *FileObject = FILE_OBJECT_FROM_SECTION(Section);
         }
         else
         {
@@ -1694,7 +1694,7 @@ MmGetFileObjectForSection(IN PVOID SectionObject)
     }
 
     /* Return the file object */
-    return ((PROS_SECTION_OBJECT)SectionObject)->FileObject;
+    return FILE_OBJECT_FROM_SECTION(SectionObject);
 }
 
 static
@@ -1709,14 +1709,14 @@ MiGetFileObjectForVad(
     if (Vad->u.VadFlags.Spare != 0)
     {
         PMEMORY_AREA MemoryArea = (PMEMORY_AREA)Vad;
-        PROS_SECTION_OBJECT Section;
+        PSECTION Section;
 
         /* Check if it's a section view (RosMm section) */
         if (MemoryArea->Type == MEMORY_AREA_SECTION_VIEW)
         {
             /* Get the section pointer to the SECTION_OBJECT */
             Section = MemoryArea->Data.SectionData.Section;
-            FileObject = Section->FileObject;
+            FileObject = FILE_OBJECT_FROM_SECTION(Section);
         }
         else
         {

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1805,12 +1805,12 @@ MmGetFileNameForSection(IN PVOID Section,
     PFILE_OBJECT FileObject;
 
     /* Make sure it's an image section */
-   if (((PSECTION)Section)->u.Flags.Image == 0)
-   {
-      /* It's not, fail */
-      DPRINT1("Not an image section\n");
-      return STATUS_SECTION_NOT_IMAGE;
-   }
+	if (((PSECTION)Section)->u.Flags.Image == 0)
+	{
+		/* It's not, fail */
+		DPRINT1("Not an image section\n");
+		return STATUS_SECTION_NOT_IMAGE;
+	}
 
     /* Get the file object */
     FileObject = MmGetFileObjectForSection(Section);

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1754,7 +1754,7 @@ VOID
 NTAPI
 MmGetImageInformation (OUT PSECTION_IMAGE_INFORMATION ImageInformation)
 {
-    PSECTION_OBJECT SectionObject;
+    PSECTION SectionObject;
 
     /* Get the section object of this process*/
     SectionObject = PsGetCurrentProcess()->SectionObject;
@@ -1762,7 +1762,7 @@ MmGetImageInformation (OUT PSECTION_IMAGE_INFORMATION ImageInformation)
     ASSERT(MiIsRosSectionObject(SectionObject) == TRUE);
 
     /* Return the image information */
-    *ImageInformation = ((PROS_SECTION_OBJECT)SectionObject)->ImageSection->ImageInformation;
+    *ImageInformation = ((PMM_IMAGE_SECTION_OBJECT)SectionObject->Segment)->ImageInformation;
 }
 
 NTSTATUS

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1805,12 +1805,12 @@ MmGetFileNameForSection(IN PVOID Section,
     PFILE_OBJECT FileObject;
 
     /* Make sure it's an image section */
-	if (((PSECTION)Section)->u.Flags.Image == 0)
-	{
-		/* It's not, fail */
-		DPRINT1("Not an image section\n");
-		return STATUS_SECTION_NOT_IMAGE;
-	}
+   if (((PSECTION)Section)->u.Flags.Image == 0)
+   {
+      /* It's not, fail */
+      DPRINT1("Not an image section\n");
+      return STATUS_SECTION_NOT_IMAGE;
+   }
 
     /* Get the file object */
     FileObject = MmGetFileObjectForSection(Section);

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -2435,6 +2435,9 @@ MmCreateArm3Section(OUT PVOID *SectionObject,
              (SectionPageProtection & PAGE_GUARD) ||
              (SectionPageProtection & PAGE_NOACCESS)));
 
+    /* Start from scratch */
+    RtlZeroMemory(&Section, sizeof(Section));
+
     /* Convert section flag to page flag */
     if (AllocationAttributes & SEC_NOCACHE) SectionPageProtection |= PAGE_NOCACHE;
 

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1805,12 +1805,12 @@ MmGetFileNameForSection(IN PVOID Section,
     PFILE_OBJECT FileObject;
 
     /* Make sure it's an image section */
-	if (((PSECTION)Section)->u.Flags.Image == 0)
-	{
-		/* It's not, fail */
-		DPRINT1("Not an image section\n");
-		return STATUS_SECTION_NOT_IMAGE;
-	}
+    if (((PSECTION)Section)->u.Flags.Image == 0)
+    {
+        /* It's not, fail */
+        DPRINT1("Not an image section\n");
+        return STATUS_SECTION_NOT_IMAGE;
+    }
 
     /* Get the file object */
     FileObject = MmGetFileObjectForSection(Section);

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -87,7 +87,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
                    IN BOOLEAN SessionLoad,
                    IN PLDR_DATA_TABLE_ENTRY LdrEntry)
 {
-    PROS_SECTION_OBJECT Section = *SectionPtr;
+	PSECTION Section = *SectionPtr;
     NTSTATUS Status;
     PEPROCESS Process;
     PVOID Base = NULL;

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -87,7 +87,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
                    IN BOOLEAN SessionLoad,
                    IN PLDR_DATA_TABLE_ENTRY LdrEntry)
 {
-   PSECTION Section = *SectionPtr;
+	PSECTION Section = *SectionPtr;
     NTSTATUS Status;
     PEPROCESS Process;
     PVOID Base = NULL;

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -87,7 +87,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
                    IN BOOLEAN SessionLoad,
                    IN PLDR_DATA_TABLE_ENTRY LdrEntry)
 {
-	PSECTION Section = *SectionPtr;
+    PSECTION Section = *SectionPtr;
     NTSTATUS Status;
     PEPROCESS Process;
     PVOID Base = NULL;

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -87,7 +87,7 @@ MiLoadImageSection(IN OUT PVOID *SectionPtr,
                    IN BOOLEAN SessionLoad,
                    IN PLDR_DATA_TABLE_ENTRY LdrEntry)
 {
-	PSECTION Section = *SectionPtr;
+   PSECTION Section = *SectionPtr;
     NTSTATUS Status;
     PEPROCESS Process;
     PVOID Base = NULL;

--- a/ntoskrnl/mm/mminit.c
+++ b/ntoskrnl/mm/mminit.c
@@ -210,9 +210,11 @@ MmInitSystem(IN ULONG Phase,
     InitializeListHead(&MiSegmentList);
     ExInitializeFastMutex(&MiGlobalPageOperation);
     KeInitializeEvent(&MmWaitPageEvent, SynchronizationEvent, FALSE);
+#ifdef NEWCC
     // Until we're fully demand paged, we can do things the old way through
     // the balance manager
     MmInitializeMemoryConsumer(MC_CACHE, MiRosTrimCache);
+#endif
 
     MmKernelAddressSpace = &PsIdleProcess->Vm;
 

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2656,6 +2656,7 @@ MmpDeleteSection(PVOID ObjectBody)
         ULONG NrSegments;
         ULONG RefCount;
         PMM_SECTION_SEGMENT SectionSegments;
+        PMM_IMAGE_SECTION_OBJECT ImageSection = (PMM_IMAGE_SECTION_OBJECT)Section->Segment;
 
         /*
          * NOTE: Section->ImageSection can be NULL for short time
@@ -2663,11 +2664,11 @@ MmpDeleteSection(PVOID ObjectBody)
          * until the image section is properly initialized we shouldn't
          * process further here.
          */
-        if (Section->ImageSection == NULL)
+        if (ImageSection == NULL)
             return;
 
-        SectionSegments = Section->ImageSection->Segments;
-        NrSegments = Section->ImageSection->NrSegments;
+        SectionSegments = ImageSection->Segments;
+        NrSegments = ImageSection->NrSegments;
 
         for (i = 0; i < NrSegments; i++)
         {
@@ -3815,7 +3816,7 @@ MmCreateImageSection(PROS_SECTION_OBJECT *SectionObject,
             return(Status);
         }
 
-        Section->ImageSection = ImageSectionObject;
+        Section->Segment = (PSEGMENT)ImageSectionObject;
         ASSERT(ImageSectionObject->Segments);
 
         /*
@@ -3840,7 +3841,7 @@ MmCreateImageSection(PROS_SECTION_OBJECT *SectionObject,
             ExFreePool(ImageSectionObject->Segments);
             ExFreePool(ImageSectionObject);
             ImageSectionObject = FileObject->SectionObjectPointer->ImageSectionObject;
-            Section->ImageSection = ImageSectionObject;
+            Section->Segment = (PSEGMENT)ImageSectionObject;
             SectionSegments = ImageSectionObject->Segments;
 
             for (i = 0; i < ImageSectionObject->NrSegments; i++)
@@ -3865,7 +3866,7 @@ MmCreateImageSection(PROS_SECTION_OBJECT *SectionObject,
         }
 
         ImageSectionObject = FileObject->SectionObjectPointer->ImageSectionObject;
-        Section->ImageSection = ImageSectionObject;
+        Section->Segment = (PSEGMENT)ImageSectionObject;
         SectionSegments = ImageSectionObject->Segments;
 
         /*
@@ -4175,7 +4176,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         PMM_SECTION_SEGMENT Segment;
 
         Segment = MemoryArea->Data.SectionData.Segment;
-        ImageSectionObject = Section->ImageSection;
+        ImageSectionObject = (PMM_IMAGE_SECTION_OBJECT)Section->Segment;
         SectionSegments = ImageSectionObject->Segments;
         NrSegments = ImageSectionObject->NrSegments;
 
@@ -4370,8 +4371,7 @@ NtQuerySection(
                 {
                     if (RosSection->AllocationAttributes & SEC_IMAGE)
                     {
-                        PMM_IMAGE_SECTION_OBJECT ImageSectionObject;
-                        ImageSectionObject = RosSection->ImageSection;
+                        PMM_IMAGE_SECTION_OBJECT ImageSectionObject = (PMM_IMAGE_SECTION_OBJECT)Section->Segment;
 
                         *Sii = ImageSectionObject->ImageInformation;
                     }
@@ -4559,7 +4559,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
         PMM_IMAGE_SECTION_OBJECT ImageSectionObject;
         PMM_SECTION_SEGMENT SectionSegments;
 
-        ImageSectionObject = Section->ImageSection;
+        ImageSectionObject = (PMM_IMAGE_SECTION_OBJECT)Section->Segment;
         SectionSegments = ImageSectionObject->Segments;
         NrSegments = ImageSectionObject->NrSegments;
 

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2883,10 +2883,12 @@ MmCreatePageFileSection(PSECTION *SectionObject,
      * Initialize it
      */
     RtlZeroMemory(Section, sizeof(*Section));
-    /* Mark it as a "ROS" Section */
-    Section->u.Flags.filler0 = 1;
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
+
+    /* Mark it as a "ROS" Section */
+    Section->u.Flags.filler0 = 1;
+
     Section->SizeOfSection = MaximumSize;
     Segment = ExAllocatePoolWithTag(NonPagedPool, sizeof(MM_SECTION_SEGMENT),
                                     TAG_MM_SECTION_SEGMENT);
@@ -2953,11 +2955,12 @@ MmCreateDataFileSection(PSECTION *SectionObject,
      * Initialize it
      */
     RtlZeroMemory(Section, sizeof(*Section));
-    /* Mark it as a ROS Section */
-    Section->u.Flags.filler0 = 1;
 
     Section->InitialPageProtection = SectionPageProtection;
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
+
+    /* Mark it as a ROS Section */
+    Section->u.Flags.filler0 = 1;
 
     /*
      * FIXME: This is propably not entirely correct. We can't look into
@@ -3776,13 +3779,13 @@ MmCreateImageSection(PSECTION *SectionObject,
      * Initialize it
      */
     RtlZeroMemory(Section, sizeof(*Section));
-    /* Mark it as a "ROS" section */
-    Section->u.Flags.filler0 = 1;
-
     Section->InitialPageProtection = SectionPageProtection;
 
     /* Initialize flags */
     Section->u.LongFlags = MiSectionFlagsFromAllocationAttributes(AllocationAttributes);
+
+    /* Mark it as a "ROS" section */
+    Section->u.Flags.filler0 = 1;
 
     if (FileObject->SectionObjectPointer->ImageSectionObject == NULL)
     {

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -62,7 +62,7 @@
 #define MmSetPageEntrySectionSegment(S,O,E) do { \
         DPRINT("SetPageEntrySectionSegment(old,%p,%x,%x)\n",(S),(O)->LowPart,E); \
         _MmSetPageEntrySectionSegment((S),(O),(E),__FILE__,__LINE__);   \
-   } while (0)
+	} while (0)
 
 extern MMSESSION MmSession;
 
@@ -121,7 +121,7 @@ C_ASSERT(PEFMT_FIELDS_EQUAL(IMAGE_OPTIONAL_HEADER32, IMAGE_OPTIONAL_HEADER64, Si
 
 typedef struct
 {
-   PSECTION Section;
+	PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     LARGE_INTEGER Offset;
     BOOLEAN WasDirty;
@@ -2766,7 +2766,7 @@ INIT_FUNCTION
 NTAPI
 MmCreatePhysicalMemorySection(VOID)
 {
-   PSECTION PhysSection;
+	PSECTION PhysSection;
     NTSTATUS Status;
     OBJECT_ATTRIBUTES Obj;
     UNICODE_STRING Name = RTL_CONSTANT_STRING(L"\\Device\\PhysicalMemory");
@@ -4356,7 +4356,7 @@ NtQuerySection(
 
                 if (Section->u.Flags.Image == 0)
                 {
-                   PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+                	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
                     Sbi.BaseAddress = (PVOID)Segment->Image.VirtualAddress;
                     Sbi.Size.QuadPart = Segment->Length.QuadPart;
@@ -4364,7 +4364,7 @@ NtQuerySection(
 
                 _SEH2_TRY
                 {
-                   RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
+                	RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
 
                     if (ResultLength != NULL)
                     {
@@ -4530,7 +4530,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
                    IN ULONG AllocationType,
                    IN ULONG Protect)
 {
-   PSECTION Section;
+	PSECTION Section;
     PMMSUPPORT AddressSpace;
     ULONG ViewOffset;
     NTSTATUS Status = STATUS_SUCCESS;
@@ -4565,7 +4565,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     AddressSpace = &Process->Vm;
 
     if (Section->u.Flags.NoChange)
-       AllocationType |= SEC_NO_CHANGE;
+    	AllocationType |= SEC_NO_CHANGE;
 
     MmLockAddressSpace(AddressSpace);
 
@@ -4662,7 +4662,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     }
     else
     {
-       PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+    	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
         /* check for write access */
         if ((Protect & (PAGE_READWRITE|PAGE_EXECUTE_READWRITE)) &&
@@ -4871,7 +4871,7 @@ MmMapViewInSystemSpace (IN PVOID SectionObject,
                         OUT PVOID * MappedBase,
                         IN OUT PSIZE_T ViewSize)
 {
-   PSECTION Section;
+	PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     PMMSUPPORT AddressSpace;
     NTSTATUS Status;

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -62,7 +62,7 @@
 #define MmSetPageEntrySectionSegment(S,O,E) do { \
         DPRINT("SetPageEntrySectionSegment(old,%p,%x,%x)\n",(S),(O)->LowPart,E); \
         _MmSetPageEntrySectionSegment((S),(O),(E),__FILE__,__LINE__);   \
-	} while (0)
+    } while (0)
 
 extern MMSESSION MmSession;
 
@@ -121,7 +121,7 @@ C_ASSERT(PEFMT_FIELDS_EQUAL(IMAGE_OPTIONAL_HEADER32, IMAGE_OPTIONAL_HEADER64, Si
 
 typedef struct
 {
-	PSECTION Section;
+    PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     LARGE_INTEGER Offset;
     BOOLEAN WasDirty;
@@ -2766,7 +2766,7 @@ INIT_FUNCTION
 NTAPI
 MmCreatePhysicalMemorySection(VOID)
 {
-	PSECTION PhysSection;
+    PSECTION PhysSection;
     NTSTATUS Status;
     OBJECT_ATTRIBUTES Obj;
     UNICODE_STRING Name = RTL_CONSTANT_STRING(L"\\Device\\PhysicalMemory");
@@ -4356,7 +4356,7 @@ NtQuerySection(
 
                 if (Section->u.Flags.Image == 0)
                 {
-                	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+                    PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
                     Sbi.BaseAddress = (PVOID)Segment->Image.VirtualAddress;
                     Sbi.Size.QuadPart = Segment->Length.QuadPart;
@@ -4364,7 +4364,7 @@ NtQuerySection(
 
                 _SEH2_TRY
                 {
-                	RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
+                    RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
 
                     if (ResultLength != NULL)
                     {
@@ -4530,7 +4530,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
                    IN ULONG AllocationType,
                    IN ULONG Protect)
 {
-	PSECTION Section;
+    PSECTION Section;
     PMMSUPPORT AddressSpace;
     ULONG ViewOffset;
     NTSTATUS Status = STATUS_SUCCESS;
@@ -4565,7 +4565,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     AddressSpace = &Process->Vm;
 
     if (Section->u.Flags.NoChange)
-    	AllocationType |= SEC_NO_CHANGE;
+        AllocationType |= SEC_NO_CHANGE;
 
     MmLockAddressSpace(AddressSpace);
 
@@ -4662,7 +4662,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     }
     else
     {
-    	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+        PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
         /* check for write access */
         if ((Protect & (PAGE_READWRITE|PAGE_EXECUTE_READWRITE)) &&
@@ -4871,7 +4871,7 @@ MmMapViewInSystemSpace (IN PVOID SectionObject,
                         OUT PVOID * MappedBase,
                         IN OUT PSIZE_T ViewSize)
 {
-	PSECTION Section;
+    PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     PMMSUPPORT AddressSpace;
     NTSTATUS Status;

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2884,7 +2884,7 @@ MmCreatePageFileSection(PROS_SECTION_OBJECT *SectionObject,
     Section->u.Flags.filler0 = 1;
     Section->InitialPageProtection = SectionPageProtection;
     Section->AllocationAttributes = AllocationAttributes;
-    Section->MaximumSize = MaximumSize;
+    Section->SizeOfSection = MaximumSize;
     Segment = ExAllocatePoolWithTag(NonPagedPool, sizeof(MM_SECTION_SEGMENT),
                                     TAG_MM_SECTION_SEGMENT);
     if (Segment == NULL)
@@ -3091,7 +3091,7 @@ MmCreateDataFileSection(PROS_SECTION_OBJECT *SectionObject,
     }
     MmUnlockSectionSegment(Segment);
     Section->FileObject = FileObject;
-    Section->MaximumSize = MaximumSize;
+    Section->SizeOfSection = MaximumSize;
 #ifndef NEWCC
     CcRosReferenceCache(FileObject);
 #endif
@@ -4684,11 +4684,11 @@ MmMapViewOfSection(IN PVOID SectionObject,
 
         if ((*ViewSize) == 0)
         {
-            (*ViewSize) = Section->MaximumSize.u.LowPart - ViewOffset;
+            (*ViewSize) = Section->SizeOfSection.u.LowPart - ViewOffset;
         }
-        else if (((*ViewSize)+ViewOffset) > Section->MaximumSize.u.LowPart)
+        else if (((*ViewSize)+ViewOffset) > Section->SizeOfSection.u.LowPart)
         {
-            (*ViewSize) = Section->MaximumSize.u.LowPart - ViewOffset;
+            (*ViewSize) = Section->SizeOfSection.u.LowPart - ViewOffset;
         }
 
         *ViewSize = PAGE_ROUND_UP(*ViewSize);
@@ -4877,11 +4877,11 @@ MmMapViewInSystemSpace (IN PVOID SectionObject,
 
     if ((*ViewSize) == 0)
     {
-        (*ViewSize) = Section->MaximumSize.u.LowPart;
+        (*ViewSize) = Section->SizeOfSection.u.LowPart;
     }
-    else if ((*ViewSize) > Section->MaximumSize.u.LowPart)
+    else if ((*ViewSize) > Section->SizeOfSection.u.LowPart)
     {
-        (*ViewSize) = Section->MaximumSize.u.LowPart;
+        (*ViewSize) = Section->SizeOfSection.u.LowPart;
     }
 
     MmLockSectionSegment(Segment);
@@ -5151,6 +5151,9 @@ MmCreateSection (OUT PVOID  * Section,
         if ((AllocationAttributes & SEC_PHYSICALMEMORY) == 0)
         {
             DPRINT1("Invalid path: %lx %p %p\n", AllocationAttributes, FileObject, FileHandle);
+
+            /* We should have called the ARM3 implementation. */
+            ASSERT(FALSE);
         }
 //        ASSERT(AllocationAttributes & SEC_PHYSICALMEMORY);
         Status = MmCreatePageFileSection(SectionObject,

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -62,7 +62,7 @@
 #define MmSetPageEntrySectionSegment(S,O,E) do { \
         DPRINT("SetPageEntrySectionSegment(old,%p,%x,%x)\n",(S),(O)->LowPart,E); \
         _MmSetPageEntrySectionSegment((S),(O),(E),__FILE__,__LINE__);   \
-	} while (0)
+   } while (0)
 
 extern MMSESSION MmSession;
 
@@ -121,7 +121,7 @@ C_ASSERT(PEFMT_FIELDS_EQUAL(IMAGE_OPTIONAL_HEADER32, IMAGE_OPTIONAL_HEADER64, Si
 
 typedef struct
 {
-	PSECTION Section;
+   PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     LARGE_INTEGER Offset;
     BOOLEAN WasDirty;
@@ -2766,7 +2766,7 @@ INIT_FUNCTION
 NTAPI
 MmCreatePhysicalMemorySection(VOID)
 {
-	PSECTION PhysSection;
+   PSECTION PhysSection;
     NTSTATUS Status;
     OBJECT_ATTRIBUTES Obj;
     UNICODE_STRING Name = RTL_CONSTANT_STRING(L"\\Device\\PhysicalMemory");
@@ -4356,7 +4356,7 @@ NtQuerySection(
 
                 if (Section->u.Flags.Image == 0)
                 {
-                	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+                   PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
                     Sbi.BaseAddress = (PVOID)Segment->Image.VirtualAddress;
                     Sbi.Size.QuadPart = Segment->Length.QuadPart;
@@ -4364,7 +4364,7 @@ NtQuerySection(
 
                 _SEH2_TRY
                 {
-                	RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
+                   RtlCopyMemory(SectionInformation, &Sbi, sizeof(Sbi));
 
                     if (ResultLength != NULL)
                     {
@@ -4530,7 +4530,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
                    IN ULONG AllocationType,
                    IN ULONG Protect)
 {
-	PSECTION Section;
+   PSECTION Section;
     PMMSUPPORT AddressSpace;
     ULONG ViewOffset;
     NTSTATUS Status = STATUS_SUCCESS;
@@ -4565,7 +4565,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     AddressSpace = &Process->Vm;
 
     if (Section->u.Flags.NoChange)
-    	AllocationType |= SEC_NO_CHANGE;
+       AllocationType |= SEC_NO_CHANGE;
 
     MmLockAddressSpace(AddressSpace);
 
@@ -4662,7 +4662,7 @@ MmMapViewOfSection(IN PVOID SectionObject,
     }
     else
     {
-    	PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
+       PMM_SECTION_SEGMENT Segment = (PMM_SECTION_SEGMENT)Section->Segment;
 
         /* check for write access */
         if ((Protect & (PAGE_READWRITE|PAGE_EXECUTE_READWRITE)) &&
@@ -4871,7 +4871,7 @@ MmMapViewInSystemSpace (IN PVOID SectionObject,
                         OUT PVOID * MappedBase,
                         IN OUT PSIZE_T ViewSize)
 {
-	PSECTION Section;
+   PSECTION Section;
     PMM_SECTION_SEGMENT Segment;
     PMMSUPPORT AddressSpace;
     NTSTATUS Status;

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -5143,7 +5143,7 @@ MmCreateSection (OUT PVOID  * Section,
                                       FileObject);
     }
 #ifndef NEWCC
-    else if (FileHandle != NULL)
+    else if ((FileHandle != NULL) || (FileObject != NULL))
     {
         Status =  MmCreateDataFileSection(SectionObject,
                                           DesiredAccess,


### PR DESCRIPTION
## Purpose
Get rid of MM_SECTION_OBJECT in favor of the SECTION structure.

## Proposed changes
To make the ROS <-> ARM3 hack a bit cleaner. More to come.