### PR TITLE
Fix Coverity #1434273

### DIFF
--- a/base/services/tftpd/tftpd.cpp
+++ b/base/services/tftpd/tftpd.cpp
@@ -38,7 +38,7 @@ char iniFile[_MAX_PATH];
 char logFile[_MAX_PATH];
 char lnkFile[_MAX_PATH];
 char tempbuff[256];
-char extbuff[256];
+char extbuff[_MAX_PATH];
 char logBuff[512];
 char fileSep = '\\';
 char notFileSep = '/';


### PR DESCRIPTION
### [TFTPD] Out-of-Bounds access

### Code causing the error https://github.com/reactos/reactos/blob/95bc44e214cb03fb8184519c8a7ad5a1880a35a2/base/services/tftpd/tftpd.cpp#L1809

### Reason
- The extbuff array is declared as
https://github.com/reactos/reactos/blob/95bc44e214cb03fb8184519c8a7ad5a1880a35a2/base/services/tftpd/tftpd.cpp#L41
- The macro _MAX_PATH is defined as
https://github.com/reactos/reactos/blob/95bc44e214cb03fb8184519c8a7ad5a1880a35a2/sdk/include/crt/stdlib.h#L116

**And if we analyze GetModuleInfoA function**:
https://github.com/reactos/reactos/blob/95bc44e214cb03fb8184519c8a7ad5a1880a35a2/sdk/include/psdk/winbase.h#L3645 https://github.com/reactos/reactos/blob/95bc44e214cb03fb8184519c8a7ad5a1880a35a2/dll/win32/kernel32/client/loader.c#L541-L600

**we will note that out-of-bounds access cases are possible, which is what coverity warns about.**

### CID1434273