### PR TITLE
[TRACERT] Fix Coverity #1434258  "Out-of-Bounds access"

### DIFF
--- a/base/applications/network/tracert/tracert.cpp
+++ b/base/applications/network/tracert/tracert.cpp
@@ -252,11 +252,11 @@ PrintHopInfo(_In_ PVOID Buffer)
         }
     }
 
-    WCHAR IpAddress[NI_MAXHOST];
+    WCHAR IpAddress[MAX_IPADDRESS];
     Status = GetNameInfoW(SockAddr,
                           Size,
                           IpAddress,
-                          NI_MAXHOST,
+                          MAX_IPADDRESS,
                           NULL,
                           0,
                           NI_NUMERICHOST);

--- a/base/applications/network/tracert/tracert.cpp
+++ b/base/applications/network/tracert/tracert.cpp
@@ -252,7 +252,7 @@ PrintHopInfo(_In_ PVOID Buffer)
         }
     }
 
-    WCHAR IpAddress[MAX_IPADDRESS];
+    WCHAR IpAddress[NI_MAXHOST];
     Status = GetNameInfoW(SockAddr,
                           Size,
                           IpAddress,


### PR DESCRIPTION
### [TRACERT] Out-of-Bounds access

### Code causing the error https://github.com/reactos/reactos/blob/97150ce9dd96412036e64a1aa74ccfd2ca9c1805/base/applications/network/tracert/tracert.cpp#L256-L262

### Reason
- The IpAddress array is declared as
https://github.com/reactos/reactos/blob/97150ce9dd96412036e64a1aa74ccfd2ca9c1805/base/applications/network/tracert/tracert.cpp#L255 https://github.com/reactos/reactos/blob/97150ce9dd96412036e64a1aa74ccfd2ca9c1805/base/applications/network/tracert/tracert.cpp#L34
- The macro NI_MAXHOST is defined as
https://github.com/reactos/reactos/blob/97150ce9dd96412036e64a1aa74ccfd2ca9c1805/sdk/include/psdk/ws2def.h#L359

'IpAddress' must be of size NI_MAXHOST to comply with its usage in the GetNameInfoW() call made in the code.

### CID1434258