### PR TITLE
[SHELLBTRFS] Fix Coverity #1441388 "Resource leak"

### DIFF
--- a/dll/shellext/shellbtrfs/send.cpp
+++ b/dll/shellext/shellbtrfs/send.cpp
@@ -729,15 +729,19 @@ void CALLBACK SendSubvolW(HWND hwnd, HINSTANCE hinst, LPWSTR lpszCmdLine, int nC
         if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &token))
             goto end;
 
-        if (!LookupPrivilegeValueW(NULL, L"SeManageVolumePrivilege", &luid))
+        if (!LookupPrivilegeValueW(NULL, L"SeManageVolumePrivilege", &luid)) {
+            CloseHandle(token);
             goto end;
+        }
 
         tp.PrivilegeCount = 1;
         tp.Privileges[0].Luid = luid;
         tp.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
 
-        if (!AdjustTokenPrivileges(token, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), NULL, NULL))
+        if (!AdjustTokenPrivileges(token, FALSE, &tp, sizeof(TOKEN_PRIVILEGES), NULL, NULL)) {
+            CloseHandle(token);
             goto end;
+        }
 
         CloseHandle(token);
 


### PR DESCRIPTION
### [SHELLBTRFS] Memory leak

### Code causing the error 
https://github.com/reactos/reactos/blob/9491979ac3fd9f4e3ec3898a43960e940ec2f198/dll/shellext/shellbtrfs/send.cpp#L732-L733 https://github.com/reactos/reactos/blob/9491979ac3fd9f4e3ec3898a43960e940ec2f198/dll/shellext/shellbtrfs/send.cpp#L739-L740

### Reason
Variable `token` going out of scope leaks the storage it points to. https://github.com/reactos/reactos/blob/9491979ac3fd9f4e3ec3898a43960e940ec2f198/dll/shellext/shellbtrfs/send.cpp#L712-L769

### CID1441388