### PR TITLE
[CMD] Fix Coverity #715934 "Copy-paste error"

### DIFF
--- a/base/shell/cmd/history.c
+++ b/base/shell/cmd/history.c
@@ -309,7 +309,7 @@ LPCTSTR PeekHistory(INT dir)
     else
     {
         /* key down */
-        if (entry->next == Bottom || entry == Bottom)
+        if (entry->prev == Bottom || entry == Bottom)
         {
 #ifdef WRAP_HISTORY
             entry = Top;


### PR DESCRIPTION
### [CMD] Copy-paste error -> Incorrect expression

### Code causing the error https://github.com/reactos/reactos/blob/9491979ac3fd9f4e3ec3898a43960e940ec2f198/base/shell/cmd/history.c#L312-L319

### Reason
https://github.com/reactos/reactos/blob/9491979ac3fd9f4e3ec3898a43960e940ec2f198/base/shell/cmd/history.c#L312 is incorrect expression to compare with `Bottom`.

### CID715934