### PR TITLE
Add support for latest VS2017 (15.0) compiler

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -72,6 +72,7 @@ if defined ROS_ARCH (
     cl 2>&1 | find "19.13." > NUL && set VS_VERSION=15
     cl 2>&1 | find "19.14." > NUL && set VS_VERSION=15
     cl 2>&1 | find "19.15." > NUL && set VS_VERSION=15
+    cl 2>&1 | find "19.16." > NUL && set VS_VERSION=15
     if not defined VS_VERSION (
         echo Error: Visual Studio version too old ^(before 10 ^(2010^)^) or version detection failed.
         goto quit


### PR DESCRIPTION
## Purpose

Latest VS 2017 CL.EXE compiler wasn't being correctly detected by the configure.cmd script.

## Proposed changes

- Adds support for CL.EXE compiler versions starting with 19.16 to the configure.cmd script.