### PR TITLE
Add .vscode folder to .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ modules/3rdparty
 .project
 .settings
 build
+.vscode


### PR DESCRIPTION
## Purpose

Matching the existence of Eclipse CDT ignore rules, .vscode should also be added to .gitignore
Visual Studio Code is always eager to create settings.json file there.

JIRA issue: None