### PR TITLE
[WTSAPI32] Implement WTSConnectState and WTSClientProtocolType in WTSQuerySessionInformation

### DIFF
--- a/sdk/include/psdk/wtsapi32.h
+++ b/sdk/include/psdk/wtsapi32.h
@@ -59,6 +59,19 @@ typedef enum tagWTS_INFO_CLASS
     WTSClientAddress,
     WTSClientDisplay,
     WTSClientProtocolType,
+    WTSIdleTime,
+    WTSLogonTime,
+    WTSIncomingBytes,
+    WTSOutgoingBytes,
+    WTSIncomingFrames,
+    WTSOutgoingFrames,
+    WTSClientInfo,
+    WTSSessionInfo,
+    WTSSessionInfoEx,
+    WTSConfigInfo,
+    WTSValidationInfo,
+    WTSSessionAddressV4,
+    WTSIsRemoteSession
 } WTS_INFO_CLASS;
 
 typedef enum _WTS_CONNECTSTATE_CLASS


### PR DESCRIPTION
## Purpose

Since ReactOS doesn't actually support non-local WinSTA/WTS capabilities, this seems to be a good way to reduce spam in the log while providing correct behaviour.
Also call Unicode version from ANSI one to reduce code duplication.

JIRA issue: None

## Origin of changes
I have a [collection of patches](https://github.com/andrew-boyarshin/reactos/tree/a11y) to ReactOS for quite some time (regularly rebased upon upstream). Finally I've decided to send PRs upstream. These PRs (a lot more to come) are generated automatically based on latest `a11y` branch in my repo.

## Wine
I am looking for a good guide related ReactOS changes to Winesynced code. What are my next steps?