### PR TITLE
[NTOSKRNL][IO] Tiny improvement to debug message

### DIFF
--- a/ntoskrnl/io/iomgr/error.c
+++ b/ntoskrnl/io/iomgr/error.c
@@ -695,7 +695,7 @@ IoRaiseInformationalHardError(IN NTSTATUS ErrorStatus,
                               IN PUNICODE_STRING String,
                               IN PKTHREAD Thread)
 {
-    DPRINT1("IoRaiseInformationalHardError: %lx, %wZ\n", ErrorStatus, String);
+    DPRINT1("IoRaiseInformationalHardError: %lx, '%wZ'\n", ErrorStatus, String);
     return FALSE;
 }
 


### PR DESCRIPTION
## Purpose

Add quotes around string, since it is often empty, thus confusing in log.

JIRA issue: None