### PR TITLE
[COMCTL32] Export LoadIconMetric and LoadIconWithScaleDown

### DIFF
--- a/dll/win32/comctl32/comctl32.spec
+++ b/dll/win32/comctl32/comctl32.spec
@@ -181,3 +181,5 @@
 
 ; Exported in v6 but not v5
 @ stdcall DrawShadowText(long wstr long ptr long long long long long)
+@ stdcall -version=0x600+ LoadIconWithScaleDown(long wstr long long long)
+@ stdcall -version=0x600+ LoadIconMetric(long wstr long long)


### PR DESCRIPTION
## Purpose

They are already implemented and there is little sense for them to be hidden.
Required for ProcessHacker 3.0+.

JIRA issue: None

## Origin of changes
I have a [collection of patches](https://github.com/andrew-boyarshin/reactos/tree/a11y) to ReactOS for quite some time (regularly rebased upon upstream). Finally I've decided to send PRs upstream. These PRs (a lot more to come) are generated automatically based on latest `a11y` branch in my repo.

## Wine