### PR TITLE
[WIN32K][NTUSER] Specify constant name explicitly

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3326,7 +3326,7 @@ NtUserSetWindowPos(
       RETURN(FALSE);
    }
 
-   if ( hWndInsertAfter &&
+   if ( hWndInsertAfter != HWND_TOP &&
         hWndInsertAfter != HWND_BOTTOM &&
         hWndInsertAfter != HWND_TOPMOST &&
         hWndInsertAfter != HWND_NOTOPMOST )


### PR DESCRIPTION
## Purpose

Reduce confusion by specifying the omitted constant HWND_TOP == 0.

JIRA issue: None