### PR TITLE
[NTOSKRNL][PS] Implement NtGetNextProcess, stubplement NtGetNextThread

### DIFF
--- a/sdk/include/ndk/psfuncs.h
+++ b/sdk/include/ndk/psfuncs.h
@@ -629,6 +629,29 @@ NtTerminateJobObject(
     _In_ NTSTATUS ExitStatus
 );
 
+NTSYSCALLAPI
+NTSTATUS
+NTAPI
+NtGetNextProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ ULONG HandleAttributes,
+    _In_ ULONG Flags,
+    _Out_ PHANDLE NewProcessHandle
+);
+
+NTSYSCALLAPI
+NTSTATUS
+NTAPI
+NtGetNextThread(
+    _In_ HANDLE ProcessHandle,
+    _In_ HANDLE ThreadHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ ULONG HandleAttributes,
+    _In_ ULONG Flags,
+    _Out_ PHANDLE NewThreadHandle
+);
+
 NTSYSAPI
 NTSTATUS
 NTAPI


### PR DESCRIPTION
## Purpose

NtGetNextProcess is required for ProcessHacker 3.0+ (hidden process search routine, hidden by default, shown after changing advanced options).
NtGetNextThread is a semi-stub, not required for PH, always returns "iteration finished" for now.
PspOpenProcess is there to match Windows Vista+ PROCESS_QUERY_INFORMATION behavior (processes with PROCESS_QUERY_LIMITED_INFORMATION get PROCESS_QUERY_LIMITED_INFORMATION automatically). It's not used in this PR, requires following OB PR changes.
NtGetNextProcess supports at least one flag (added somewhere between Win7 and Win10, change detected by running demo app on VM and my host PC), that is reverse iteration. Hence the PsGetPreviousProcess. Not tested much though.

JIRA issue: None