### PR TITLE
[NTOSKRNL][PS] Implement NtQueueApcThreadEx and use it in NtQueueApcThread

### DIFF
--- a/sdk/include/ndk/kefuncs.h
+++ b/sdk/include/ndk/kefuncs.h
@@ -467,6 +467,18 @@ NtQueueApcThread(
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
+NtQueueApcThreadEx(
+    _In_ HANDLE ThreadHandle,
+    _In_opt_ HANDLE UserApcReserveHandle,
+    _In_ PKNORMAL_ROUTINE ApcRoutine,
+    _In_opt_ PVOID NormalContext,
+    _In_opt_ PVOID SystemArgument1,
+    _In_opt_ PVOID SystemArgument2
+);
+
+NTSYSCALLAPI
+NTSTATUS
+NTAPI
 NtRaiseException(
     _In_ PEXCEPTION_RECORD ExceptionRecord,
     _In_ PCONTEXT Context,


### PR DESCRIPTION
## Purpose

Actually rename NtQueueApcThread to NtQueueApcThreadEx and ignore one additional parameter for now.
The ignored parameter is for careful memory allocation in critical codepaths ([ref](https://wj32.org/wp/2010/07/18/the-nt-reserve-object/)). ReactOS doesn't care much about these things in pre-beta stage.
It's not exported for now, but will be in the future in Vista+ version of the NTDLL.

JIRA issue: None