### PR TITLE
[SPEC2DEF] Fix compilation of generated stub C files with int64 parameters

### DIFF
--- a/sdk/include/reactos/stubs.h
+++ b/sdk/include/reactos/stubs.h
@@ -1,6 +1,10 @@
 #define WIN32_NO_STATUS
 #include <windef.h>
 
+#ifndef PRIx64
+#define PRIx64 "I64x"
+#endif
+
 #define EXCEPTION_WINE_STUB     0x80000100
 #define EH_NONCONTINUABLE       0x01
 


### PR DESCRIPTION
## Purpose

It appears noone tested `-stub` with `int64` parameters - gives compilation error. Fix by defining the constant in common stub header.

JIRA issue: None