### PR TITLE
[KERNEL32] lpNumberOfCharsWritten is optional for WriteConsole

### DIFF
--- a/dll/win32/kernel32/client/console/readwrite.c
+++ b/dll/win32/kernel32/client/console/readwrite.c
@@ -682,7 +682,7 @@ IntWriteConsole(IN HANDLE hConsoleOutput,
     /* Release the capture buffer if needed */
     if (CaptureBuffer) CsrFreeCaptureBuffer(CaptureBuffer);
 
-    /* Retrieve the results */
+    /* Retrieve the results. NOTE: lpNumberOfCharsWritten optional since Vista+ */
     if (Success && lpNumberOfCharsWritten)
     {
         _SEH2_TRY

--- a/dll/win32/kernel32/client/console/readwrite.c
+++ b/dll/win32/kernel32/client/console/readwrite.c
@@ -683,7 +683,7 @@ IntWriteConsole(IN HANDLE hConsoleOutput,
     if (CaptureBuffer) CsrFreeCaptureBuffer(CaptureBuffer);
 
     /* Retrieve the results */
-    if (Success)
+    if (Success && lpNumberOfCharsWritten)
     {
         _SEH2_TRY
         {
@@ -696,7 +696,7 @@ IntWriteConsole(IN HANDLE hConsoleOutput,
         }
         _SEH2_END;
     }
-    else
+    else if (!Success)
     {
         BaseSetLastNTError(ApiMessage.Status);
     }


### PR DESCRIPTION
## Purpose

Some applications (and libraries, like [replxx](https://github.com/AmokHuginnsson/replxx/blob/master/src/windows.cxx)) rely on this undocumented behavior and throw internally an memory access violation exception.

JIRA issue: None