### PR TITLE
[SHELL32] Don't show taskbar button of file property sheet

### DIFF
--- a/dll/win32/shell32/dialogs/fprop.cpp
+++ b/dll/win32/shell32/dialogs/fprop.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright 2005 Johannes Anderwald
  * Copyright 2012 Rafal Harabien
- * Copyright 2017 Katayama Hirofumi MZ
+ * Copyright 2017-2018 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -67,6 +67,17 @@ LoadPropSheetHandlers(LPCWSTR pwszPath, PROPSHEETHEADERW *pHeader, UINT cMaxPage
     return cPages;
 }
 
+// CStubWindow32 --- The owner window of file property sheets.
+// This window hides taskbar button of property sheet.
+class CStubWindow32 : public CWindowImpl<CStubWindow32>
+{
+public:
+    DECLARE_WND_CLASS_EX(_T("StubWindow32"), 0, COLOR_WINDOWTEXT)
+
+    BEGIN_MSG_MAP(CPaletteWindow)
+    END_MSG_MAP()
+};
+
 /*************************************************************************
  *
  * SH_ShowPropertiesDialog
@@ -104,10 +115,17 @@ SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CH
     if (PathIsRootW(wszPath))
         return SUCCEEDED(SH_ShowDriveProperties(wszPath, pidlFolder, apidl));
 
+    DWORD style = WS_DISABLED | WS_CLIPSIBLINGS | WS_CAPTION;
+    DWORD exstyle = WS_EX_WINDOWEDGE | WS_EX_APPWINDOW;
+    CStubWindow32 stub;
+    if (!stub.Create(NULL, NULL, NULL, style, exstyle))
+        return E_FAIL;
+
     /* Handle files and folders */
     PROPSHEETHEADERW Header;
     memset(&Header, 0x0, sizeof(PROPSHEETHEADERW));
     Header.dwSize = sizeof(PROPSHEETHEADERW);
+    Header.hwndParent = stub;
     Header.dwFlags = PSH_NOCONTEXTHELP | PSH_PROPTITLE;
     Header.phpage = hppages;
     Header.pszCaption = PathFindFileNameW(wszPath);
@@ -141,6 +159,8 @@ SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CH
             SHDestroyPropSheetExtArray(hpsxa[i]);
     if (pFileDefExt)
         pFileDefExt->Release();
+
+    stub.DestroyWindow();
 
     return (Result != -1);
 }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-10481](https://jira.reactos.org/browse/CORE-10481)

## Proposed changes
- Create a "StubWindow32" window.
- Make it an owner window of property sheet.
