### PR TITLE
[SHELL32] Don't show taskbar button of Folder Options

### DIFF
--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -190,6 +190,19 @@ HBITMAP CreateRadioMask(HDC hDC)
 
 /////////////////////////////////////////////////////////////////////////////
 
+// CMSGlobalFolderOptionsStub --- The owner window of Folder Options.
+// This window hides taskbar button of Folder Options.
+class CMSGlobalFolderOptionsStub : public CWindowImpl<CMSGlobalFolderOptionsStub>
+{
+public:
+    DECLARE_WND_CLASS_EX(_T("MSGlobalFolderOptionsStub"), 0, COLOR_WINDOWTEXT)
+
+    BEGIN_MSG_MAP(CMSGlobalFolderOptionsStub)
+    END_MSG_MAP()
+};
+
+/////////////////////////////////////////////////////////////////////////////
+
 EXTERN_C HPSXA WINAPI SHCreatePropSheetExtArrayEx(HKEY hKey, LPCWSTR pszSubKey, UINT max_iface, IDataObject *pDataObj);
 
 static VOID
@@ -217,14 +230,27 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
     LoadStringW(shell32_hInstance, IDS_FOLDER_OPTIONS, szOptions, _countof(szOptions));
     szOptions[_countof(szOptions) - 1] = 0;
 
+    // the stub window to hide taskbar button
+    DWORD style = WS_DISABLED | WS_CLIPSIBLINGS | WS_CAPTION;
+    DWORD exstyle = WS_EX_WINDOWEDGE | WS_EX_TOOLWINDOW;
+    CMSGlobalFolderOptionsStub stub;
+    if (!stub.Create(NULL, NULL, NULL, style, exstyle))
+    {
+        ERR("stub.Create failed\n");
+        return;
+    }
+
     memset(&pinfo, 0x0, sizeof(PROPSHEETHEADERW));
     pinfo.dwSize = sizeof(PROPSHEETHEADERW);
     pinfo.dwFlags = PSH_NOCONTEXTHELP;
+    pinfo.hwndParent = stub;
     pinfo.nPages = num_pages;
     pinfo.phpage = hppages;
     pinfo.pszCaption = szOptions;
 
     PropertySheetW(&pinfo);
+
+    stub.DestroyWindow();
 }
 
 static VOID


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-10481](https://jira.reactos.org/browse/CORE-10481)

## Proposed changes

- Create a stub window "MSGlobalFolderOptionsStub".
- Create Folder Options dialog owned by the stub window.