### PR TITLE
Cmake/core 14839 fix  relfile  

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,9 @@ endif()
 include(sdk/cmake/compilerflags.cmake)
 
 add_definitions(-D__REACTOS__)
+add_definitions(-DREACTOS_SOURCE_DIR="\\"${REACTOS_SOURCE_DIR}\\"")
+add_definitions(-DREACTOS_BINARY_DIR="\\"${REACTOS_BINARY_DIR}\\"")
+add_compile_flags(-D__RELFILE__="&__FILE__[sizeof REACTOS_SOURCE_DIR]")
 
 if(MSVC_IDE)
     add_compile_flags("/MP")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,9 +57,14 @@ endif()
 include(sdk/cmake/compilerflags.cmake)
 
 add_definitions(-D__REACTOS__)
-add_definitions(-DREACTOS_SOURCE_DIR="\\"${REACTOS_SOURCE_DIR}\\"")
-add_definitions(-DREACTOS_BINARY_DIR="\\"${REACTOS_BINARY_DIR}\\"")
-add_compile_flags(-D__RELFILE__="&__FILE__[sizeof REACTOS_SOURCE_DIR]")
+
+# Double escape, since CMake unescapes before putting it on the command-line, where it's unescaped again by GCC/CL.
+add_definitions(-DREACTOS_SOURCE_DIR="\\\"${REACTOS_SOURCE_DIR}\\\"")
+add_definitions(-DREACTOS_BINARY_DIR="\\\"${REACTOS_BINARY_DIR}\\\"")
+
+# There doesn't seem to be a standard for __FILE__ being relative or absolute, so detect it at runtime.
+file(RELATIVE_PATH _PATH_PREFIX ${REACTOS_BINARY_DIR} ${REACTOS_SOURCE_DIR})
+add_compile_flags(-D__RELFILE__="&__FILE__[__FILE__[0] == '.' ? sizeof \\\"${_PATH_PREFIX}\\\" - 1 : sizeof REACTOS_SOURCE_DIR]")
 
 if(MSVC_IDE)
     add_compile_flags("/MP")

--- a/sdk/include/reactos/builddir.h.cmake
+++ b/sdk/include/reactos/builddir.h.cmake
@@ -1,7 +1,0 @@
-/* Do not edit - Machine generated */
-#pragma once
-
-#define REACTOS_SOURCE_DIR        "@REACTOS_SOURCE_DIR@"
-#define REACTOS_BINARY_DIR        "@REACTOS_BINARY_DIR@"
-
-/* EOF */

--- a/sdk/include/reactos/debug.h
+++ b/sdk/include/reactos/debug.h
@@ -15,12 +15,7 @@
 #pragma once
 
 #ifndef __RELFILE__
-#   ifdef __REACTOS__
-#       include <reactos/builddir.h>
-#       define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
-#   else
-#       define __RELFILE__ __FILE__
-#   endif
+#define __RELFILE__ __FILE__
 #endif
 
 /* Define DbgPrint/DbgPrintEx/RtlAssert unless the NDK is used */

--- a/sdk/include/reactos/version.cmake
+++ b/sdk/include/reactos/version.cmake
@@ -53,4 +53,3 @@ endif()
 
 configure_file(sdk/include/reactos/version.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/version.h)
 configure_file(sdk/include/reactos/buildno.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/buildno.h)
-configure_file(sdk/include/reactos/builddir.h.cmake ${REACTOS_BINARY_DIR}/sdk/include/reactos/builddir.h)

--- a/sdk/include/reactos/wine/debug.h
+++ b/sdk/include/reactos/wine/debug.h
@@ -28,12 +28,7 @@
 #endif
 
 #ifndef __RELFILE__
-#	ifdef __REACTOS__
-#		include <reactos/builddir.h>
-#		define __RELFILE__ &__FILE__[sizeof(REACTOS_SOURCE_DIR)]
-#	else
-#		define __RELFILE__ __FILE__
-#	endif
+#define __RELFILE__ __FILE__
 #endif
 
 #ifdef __WINE_WINE_TEST_H


### PR DESCRIPTION
## Purpose
Fixes missing characters in debuglog after introduction of __RELFILE__.

JIRA issue: [CORE-14839](https://jira.reactos.org/browse/CORE-14839)

## Proposed changes
* Revert commit [07bd6089ec96b068d92f42e764cc7336a7de24a0](https://git.reactos.org/?p=reactos.git;a=commit;h=07bd6089ec96b068d92f42e764cc7336a7de24a0), which reverted my earlier changes and replaced 3 lines in the toplevel CMake file with ~20 lines in 3 different files, adding a new file and auto-generating another file, because "It's easier on the command line and the eyes looking at it".
* Do a runtime-detect relative vs absolute path (based on Thomas' suggestion), using the size of the relative path from the build dir to the source dir as the length of the prefix to skip.
* Fix broken escaping in definition of REACTOS_*_DIR, which worked, but caused problems with sytax highlighting.

## TODO
- [ ] Review and fix remaining instances of __FILE__, e.g. in UNIMPLEMENTED macro.
