### PR TITLE
[WIN32SS] Replace ASSERT(FALSE); in IntGhostWindowFromHungWindow

### DIFF
--- a/win32ss/user/ntuser/ghost.c
+++ b/win32ss/user/ntuser/ghost.c
@@ -54,7 +54,7 @@ HWND FASTCALL IntGhostWindowFromHungWindow(PWND pHungWnd)
     HWND hwndGhost;
 
     if (!IntGetAtomFromStringOrAtom(&GhostProp, &Atom))
-        ASSERT(FALSE);
+        return NULL;
 
     hwndGhost = UserGetProp(pHungWnd, Atom, TRUE);
     if (hwndGhost)


### PR DESCRIPTION
## Purpose
@HeisSpiter says ASSERT(FALSE); in IntGhostWindowFromHungWindow is incorrect in [f469aca](https://github.com/reactos/reactos/commit/f469acacecfd3d215ebe5dde79517c45b92aa730#commitcomment-31640772).
JIRA issue: [CORE-11944](https://jira.reactos.org/browse/CORE-11944)
