### PR TITLE
[BROWSEUI] Add backslash for directory

### DIFF
--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -382,6 +382,9 @@ SHExplorerParseCmdLine(ExplorerCommandLineParseResults * pInfo)
             {
                 // Or just a plain old string.
 
+                if (PathIsDirectoryW(strField))
+                    PathAddBackslash(strField);
+
                 WCHAR szPath[MAX_PATH];
                 DWORD result = GetFullPathNameW(strField, _countof(szPath), szPath, NULL);
 


### PR DESCRIPTION
## Purpose
Add a backslash to the path if the path is a directory in parsing Explorer command line.
JIRA issue: [CORE-15434](https://jira.reactos.org/browse/CORE-15434)
