### PR TITLE
[REGEDIT] Set background brush to child window

### DIFF
--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -83,6 +83,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
     wcChild.hInstance = hInstance;
     wcChild.hIcon = LoadIconW(hInstance, MAKEINTRESOURCEW(IDI_REGEDIT));
     wcChild.hCursor = LoadCursorW(NULL, IDC_ARROW);
+    wcChild.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1);
     wcChild.lpszClassName = szChildClass;
     wcChild.hIconSm = (HICON)LoadImageW(hInstance, MAKEINTRESOURCEW(IDI_REGEDIT),
                                         IMAGE_ICON, GetSystemMetrics(SM_CXSMICON),


### PR DESCRIPTION
## Purpose
There is a problem with drawing of splitter. 
JIRA issue: [CORE-15442](https://jira.reactos.org/browse/CORE-15442)
We can fix this bug by setting the background brush of the child window.