### PR TITLE
CORE-8773. [KMTEST:RTL] RtlException: Remove '#if CORE_6640_IS_FIXED'

### DIFF
--- a/modules/rostests/kmtests/rtl/RtlException.c
+++ b/modules/rostests/kmtests/rtl/RtlException.c
@@ -158,7 +158,6 @@ START_TEST(RtlException)
 
     /* We cannot test this in kernel mode easily - the stack is just "somewhere"
      * in system space, and there's no guard page below it */
-#if CORE_6640_IS_FIXED
 #ifdef KMT_USER_MODE
     /* Overflow the stack - must cause a special exception */
     KmtStartSeh()
@@ -171,5 +170,4 @@ START_TEST(RtlException)
         }
     KmtEndSeh(STATUS_STACK_OVERFLOW);
 #endif
-#endif /* CORE_6640_IS_FIXED */
 }


### PR DESCRIPTION
## Purpose

On behalf of Victor Martinez.
JIRA issue: [CORE-8773](https://jira.reactos.org/browse/CORE-8773)

## TODO

- [X] To be tried on testbots. // KVM and VBox succeed. WHS not run.
