### PR TITLE
[ROSAUTOTEST] Use https for testman webservice

### DIFF
--- a/modules/rostests/rosautotest/CWebService.cpp
+++ b/modules/rostests/rosautotest/CWebService.cpp
@@ -26,7 +26,7 @@ CWebService::CWebService()
     if(!m_hInet)
         FATAL("InternetOpenW failed\n");
 
-    m_hHTTP = InternetConnectW(m_hInet, szHostname, INTERNET_DEFAULT_HTTP_PORT, NULL, NULL, INTERNET_SERVICE_HTTP, 0, 0);
+    m_hHTTP = InternetConnectW(m_hInet, szHostname, INTERNET_DEFAULT_HTTPS_PORT, NULL, NULL, INTERNET_SERVICE_HTTP, 0, 0);
 
     if(!m_hHTTP)
         FATAL("InternetConnectW failed\n");


### PR DESCRIPTION
## Purpose

Guess fix for our WHS testbot

JIRA issue: [ONLINE-855](https://jira.reactos.org/browse/ONLINE-855)

## Proposed changes

Use HTTPS connection when sending results to testman