### PR TITLE
Fix CJK font problems in the Official theme

### DIFF
--- a/base/setup/lib/muifonts.h
+++ b/base/setup/lib/muifonts.h
@@ -140,6 +140,7 @@ MUI_SUBFONT ChineseSimplifiedFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { CSF_LocalName0,            L"Droid Sans Fallback" },
     { CSF_LocalName1,            L"Droid Sans Fallback" },
@@ -181,6 +182,7 @@ MUI_SUBFONT ChineseTraditionalFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { CTF_LocalName0,     L"Droid Sans Fallback" },
     { CTF_LocalName1,     L"Droid Sans Fallback" },
@@ -220,6 +222,7 @@ MUI_SUBFONT JapaneseFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { JF_LocalName0,      L"Droid Sans Fallback" },
     { JF_LocalName1,      L"Droid Sans Fallback" },
@@ -263,6 +266,7 @@ MUI_SUBFONT KoreanFonts[] =
     { L"Comic Sans MS",          L"Ubuntu" },
     { L"Georgia",                L"FreeSerif" },
     { L"Palatino Linotype",      L"DejaVu Serif" },
+    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { KF_LocalName0,      L"Droid Sans Fallback" },
     { KF_LocalName1,      L"Droid Sans Fallback" },

--- a/media/inf/font.inf
+++ b/media/inf/font.inf
@@ -110,6 +110,7 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Terminal",0
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Times",0x00000000,"Liberation Serif"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Times New Roman",0x00000000,"Liberation Serif"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Tms Rmn",0x00000000,"Liberation Serif"
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Ubuntu",0x00000000,"Droid Sans Fallback"
 
 [Font.Unicode.Reg]
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Arial",0x00000000,"DejaVu Sans"


### PR DESCRIPTION
I have solved this problem by mapping Ubuntu to Droid Sans Fallback via Font Substitutes. 
I know this is not a way to completely solve the problem, but I think this is the best way before improve the ReactOS font mechanism in the future.

JIRA: [CORE-15179](https://jira.reactos.org/browse/CORE-15179)

