### PR TITLE
[SHELL32] Format Dialog Warning

### DIFF
--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -411,8 +411,6 @@ InitializeFormatDriveDlg(HWND hwndDlg, PFORMAT_DRIVE_CONTEXT pContext)
     SendMessageW(hwndFileSystems, CB_SETCURSEL, dwDefault, 0);
     /* setup cluster combo */
     InsertDefaultClusterSizeForFs(hwndDlg, pContext);
-    /* hide progress control */
-    ShowWindow(GetDlgItem(hwndDlg, 28678), SW_HIDE);
 }
 
 static HWND FormatDrvDialog = NULL;
@@ -435,6 +433,8 @@ FormatExCB(
         case DONE:
             pSuccess = (PBOOLEAN)ActionInfo;
             bSuccess = (*pSuccess);
+            ShellMessageBoxW(shell32_hInstance, FormatDrvDialog, MAKEINTRESOURCEW(IDS_FORMAT_COMPLETE), MAKEINTRESOURCEW(IDS_FORMAT_TITLE), MB_OK | MB_ICONINFORMATION);
+            SendDlgItemMessageW(FormatDrvDialog, 28678, PBM_SETPOS, 0, 0);
             break;
 
         case VOLUMEINUSE:
@@ -521,7 +521,6 @@ FormatDrive(HWND hwndDlg, PFORMAT_DRIVE_CONTEXT pContext)
     }
 
     hDlgCtrl = GetDlgItem(hwndDlg, 28680);
-    ShowWindow(hDlgCtrl, SW_SHOW);
     SendMessageW(hDlgCtrl, PBM_SETRANGE, 0, MAKELPARAM(0, 100));
     bSuccess = FALSE;
 
@@ -563,7 +562,6 @@ FormatDrive(HWND hwndDlg, PFORMAT_DRIVE_CONTEXT pContext)
              ClusterSize,
              FormatExCB);
 
-    ShowWindow(hDlgCtrl, SW_HIDE);
     FormatDrvDialog = NULL;
     if (!bSuccess)
     {
@@ -594,8 +592,11 @@ FormatDriveDlg(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
             switch(LOWORD(wParam))
             {
                 case IDOK:
-                    pContext = (PFORMAT_DRIVE_CONTEXT)GetWindowLongPtr(hwndDlg, DWLP_USER);
-                    FormatDrive(hwndDlg, pContext);
+                    if (ShellMessageBoxW(shell32_hInstance, hwndDlg, MAKEINTRESOURCEW(IDS_FORMAT_WARNING), MAKEINTRESOURCEW(IDS_FORMAT_TITLE), MB_OKCANCEL | MB_ICONWARNING) == IDOK)
+                    {
+                        pContext = (PFORMAT_DRIVE_CONTEXT)GetWindowLongPtr(hwndDlg, DWLP_USER);
+                        FormatDrive(hwndDlg, pContext);
+                    }
                     break;
                 case IDCANCEL:
                     pContext = (PFORMAT_DRIVE_CONTEXT)GetWindowLongPtr(hwndDlg, DWLP_USER);

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -797,6 +797,11 @@ BEGIN
     IDS_RESTART_PROMPT "Искате ли да презапуснете системата?"
     IDS_SHUTDOWN_TITLE "Изключване"
     IDS_SHUTDOWN_PROMPT "Искате ли да изключите компютъра?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -802,6 +802,11 @@ BEGIN
     IDS_RESTART_PROMPT "Opravdu chcete restartovat systém?"
     IDS_SHUTDOWN_TITLE "Vypnout"
     IDS_SHUTDOWN_PROMPT "Opravdu chcete vypnout počítač?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Nelze zobrazit dialog Spustit soubor (interní chyba)"

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -802,6 +802,11 @@ BEGIN
     IDS_RESTART_PROMPT "Ønsker du at Genstarte Systemet?"
     IDS_SHUTDOWN_TITLE "Luk Ned"
     IDS_SHUTDOWN_PROMPT "Ønsker du at Lukke Ned?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -797,6 +797,11 @@ BEGIN
     IDS_RESTART_PROMPT "Möchten Sie das System neu starten?"
     IDS_SHUTDOWN_TITLE "Herunterfahren"
     IDS_SHUTDOWN_PROMPT "Möchten Sie das System herunterfahren?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Anzeigen der Datei Ausführen Dialogbox nicht möglich (interner Fehler)"

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Είστε σίγουροι ότι θέλετε να επανεκκινήσετε τον υπολογιστή σας;"
     IDS_SHUTDOWN_TITLE "Απενεργοποίηση"
     IDS_SHUTDOWN_PROMPT "Είστε σίγουροι ότι θέλετε να απενεργοποιήσετε τον υπολογιστή σας;"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -797,6 +797,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -804,6 +804,11 @@ BEGIN
     IDS_RESTART_PROMPT "¿Desea reiniciar el equipo?"
     IDS_SHUTDOWN_TITLE "Apagar"
     IDS_SHUTDOWN_PROMPT "¿Desea apagar el equipo?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "No se pudo mostrar el diálogo Ejecutar (error interno)"

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -804,6 +804,11 @@ BEGIN
     IDS_RESTART_PROMPT "Kas soovid taaskäivitada süsteemi?"
     IDS_SHUTDOWN_TITLE "Lülita välja"
     IDS_SHUTDOWN_PROMPT "Kas soovid arvuti välja lülitada?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Ei saanud kuvada Run faili dialoogiboksi (sisemine viga)"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Haluatko simuloida ReactOS:n uudelleenkäynnistämistä?"
     IDS_SHUTDOWN_TITLE "Sammuta"
     IDS_SHUTDOWN_PROMPT "Haluatko lopettaa ReactOS:n istunnon?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Voulez-vous redémarrer votre ordinateur ?"
     IDS_SHUTDOWN_TITLE "Arrêter"
     IDS_SHUTDOWN_PROMPT "Voulez-vous fermer la session ReactOS ?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Impossible d'afficher la boîte de dialogue pour l'exécution d'un fichier (erreur interne)"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "האם ברצונך להפעיל מחדש את המערכת?"
     IDS_SHUTDOWN_TITLE "כיבוי"
     IDS_SHUTDOWN_PROMPT "האם ברצונך לכבות את המחשב?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Újra szeretnéd indítani a rendszert?"
     IDS_SHUTDOWN_TITLE "Kikapcsolás"
     IDS_SHUTDOWN_PROMPT "Kiakarod kapcsolni számítógépét?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Volete riavviare il sistema?"
     IDS_SHUTDOWN_TITLE "Arresta sistema"
     IDS_SHUTDOWN_PROMPT "Volete arrestare il sistema?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Impossibile mostrare il dialogo Eseguire (errore interno)"

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -793,6 +793,11 @@ BEGIN
     IDS_RESTART_PROMPT "システムを再起動しますか?"
     IDS_SHUTDOWN_TITLE "シャットダウン"
     IDS_SHUTDOWN_PROMPT "シャットダウンしますか?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Vil du starte datamaskinen på nytt?"
     IDS_SHUTDOWN_TITLE "Avslutt"
     IDS_SHUTDOWN_PROMPT "Vil du slå av datamaskinen?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -802,6 +802,11 @@ BEGIN
     IDS_RESTART_PROMPT "Czy chcesz zrestartować system?"
     IDS_SHUTDOWN_TITLE "Wyłącz"
     IDS_SHUTDOWN_PROMPT "Czy chcesz wyłączyć system?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Nie mogę wyświetlić okna Uruchom (błąd wewnętrzny)"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Você quer simular a reinicialização do ReactOS?"
     IDS_SHUTDOWN_TITLE "Desligar"
     IDS_SHUTDOWN_PROMPT "Você quer finalizar a sessão?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Deseja simular a reinicialização do ReactOS?"
     IDS_SHUTDOWN_TITLE "Desligar"
     IDS_SHUTDOWN_PROMPT "Deseja finalizar esta sessão do ReactOS?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -798,6 +798,11 @@ BEGIN
     IDS_RESTART_PROMPT "Doriți să reporniți sistemul?"
     IDS_SHUTDOWN_TITLE "Închidere"
     IDS_SHUTDOWN_PROMPT "Doriți să închideți calculatorul?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "„Executare fișier” nu a putut fi deschis (eroare internă)"

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -803,6 +803,11 @@ BEGIN
     IDS_RESTART_PROMPT "Вы действительно хотите перезагрузить ReactOS?"
     IDS_SHUTDOWN_TITLE "Завершение работы"
     IDS_SHUTDOWN_PROMPT "Вы действительно хотите завершить работу ReactOS?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Невозможно отобразить диалоговое окно Выполнить (внутренняя ошибка)"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Naozaj chcete reštartovať systém?"
     IDS_SHUTDOWN_TITLE "Vypnúť"
     IDS_SHUTDOWN_PROMPT "Naozaj chcete vypnúť počítač?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Nemožno zobraziť dialogové okno Spustiť súbor (vnútorná chyba)"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "Shutdown"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -800,6 +800,11 @@ BEGIN
     IDS_RESTART_PROMPT "Doni të rifilloni sistemin?"
     IDS_SHUTDOWN_TITLE "Fike"
     IDS_SHUTDOWN_PROMPT "Doni ta filkni sistemin?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Në pamundësi për të shfaqur kutinë dialogut ekzekuto (gabim i brendshëm)"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Vill du starta om systemet?"
     IDS_SHUTDOWN_TITLE "Stäng av"
     IDS_SHUTDOWN_PROMPT "Vill du stänga av?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Kunde inte visa dialogen Kör fil (internt fel)"

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -798,6 +798,11 @@ BEGIN
     IDS_RESTART_PROMPT "Dizgeyi yeniden başlatmak ister misiniz?"
     IDS_SHUTDOWN_TITLE "Bilgisayarı Kapat"
     IDS_SHUTDOWN_PROMPT "Bilgisayarı kapatmak ister misiniz?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Kütük Çalıştır iletişim kutusu görüntülenemiyor (iç yanlışlık)."

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -796,6 +796,11 @@ BEGIN
     IDS_RESTART_PROMPT "Ви хочете перезавантажити систему?"
     IDS_SHUTDOWN_TITLE "Вимкнути"
     IDS_SHUTDOWN_PROMPT "Ви хочете вимкнути комп'ютер?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Неможливо відобразити Діалог Запуску Файлу (внутрішня помилка)"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -804,6 +804,11 @@ BEGIN
     IDS_RESTART_PROMPT "请问需要重启系统吗?"
     IDS_SHUTDOWN_TITLE "关机"
     IDS_SHUTDOWN_PROMPT "请问需要关闭系统吗?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "无法显示运行文件对话框 (内部错误)"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -804,6 +804,11 @@ BEGIN
     IDS_RESTART_PROMPT "Do you want to restart the system?"
     IDS_SHUTDOWN_TITLE "關機"
     IDS_SHUTDOWN_PROMPT "Do you want to shutdown?"
+    
+    /* Format Dialog Strings */
+    IDS_FORMAT_TITLE "Format Local Disk"
+    IDS_FORMAT_WARNING "WARNING: Formatting will erase ALL data on this disk.\nTo format the disk, click OK. To quit, click CANCEL."
+    IDS_FORMAT_COMPLETE "Format Complete."
 
     /* Run File dialog */
     IDS_RUNDLG_ERROR "Unable to display Run File dialog box (internal error)"

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -184,6 +184,11 @@
 #define IDS_RUNDLG_BROWSE_CAPTION 182
 #define IDS_RUNDLG_BROWSE_FILTER  183
 
+/* Format Dialog strings */
+#define IDS_FORMAT_TITLE          184
+#define IDS_FORMAT_WARNING        185
+#define IDS_FORMAT_COMPLETE       186
+
 #define IDS_UNKNOWN_APP     190
 #define IDS_EXE_DESCRIPTION 191
 


### PR DESCRIPTION
## Purpose

This patch adds a warning dialog before starting a format. It also adds a dialog that the format completed. Also fixes the progress bar not working during a format operation as well as the Allocation unit size combo box disappearing after a format is complete.

I know there are many more dialogs that need to be added but this implements what I consider the most important dialogs. More can follow later.

There is a bug with ShellMessageBoxW where it truncates any string over 100 characters and not an issue with my code. JIRA issue to follow.

JIRA issue: [CORE-13221](https://jira.reactos.org/browse/CORE-13221)

![virtualbox_reactos_14_12_2018_21_40_19](https://user-images.githubusercontent.com/15203817/50038686-04ee7780-ffe9-11e8-8052-d866b56e3e21.png)
