### PR TITLE
[CPL][SHELL32] Add icons to input, joy, sysdm, folder options

### DIFF
--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -47,7 +47,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
+            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_KEY_SHORT_ICO));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }
@@ -71,7 +71,7 @@ SystemApplet(VOID)
     header.dwFlags     = PSH_PROPSHEETPAGE | PSH_USEICONID | PSH_USECALLBACK;
     header.hwndParent  = hCPLWindow;
     header.hInstance   = hApplet;
-    header.pszIcon     = MAKEINTRESOURCEW(IDI_CPLSYSTEM);
+    header.pszIcon     = MAKEINTRESOURCEW(IDI_KEY_SHORT_ICO);
     header.pszCaption  = szCaption;
     header.nPages      = ARRAYSIZE(page);
     header.nStartPage  = 0;

--- a/dll/cpl/joy/joy.c
+++ b/dll/cpl/joy/joy.c
@@ -198,12 +198,20 @@ AddPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 INT_PTR CALLBACK
 MainPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    static HICON s_hIcon = NULL, s_hIconSm = NULL;
     UNREFERENCED_PARAMETER(lParam);
 
     switch (uMsg)
     {
         case WM_INITDIALOG:
             AddColumns(GetDlgItem(hwndDlg,IDC_CONTROLLER_LIST));
+            s_hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
+            s_hIconSm = (HICON)LoadImageW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM),
+                                          IMAGE_ICON,
+                                          GetSystemMetrics(SM_CXSMICON),
+                                          GetSystemMetrics(SM_CYSMICON), 0);
+            SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)s_hIcon);
+            SendMessageW(hwndDlg, WM_SETICON, ICON_SMALL, (LPARAM)s_hIconSm);
             break;
 
         case WM_COMMAND:
@@ -224,6 +232,8 @@ MainPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     break;
 
                 case IDOK:
+                    DestroyIcon(s_hIcon);
+                    DestroyIcon(s_hIconSm);
                     EndDialog(hwndDlg,LOWORD(wParam));
                     break;
             }
@@ -236,6 +246,8 @@ MainPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
             switch (LOWORD(wParam))
             {
                 case SC_CLOSE:
+                    DestroyIcon(s_hIcon);
+                    DestroyIcon(s_hIconSm);
                     EndDialog(hwndDlg,LOWORD(wParam));
                     break;
 

--- a/dll/cpl/sysdm/hardprof.c
+++ b/dll/cpl/sysdm/hardprof.c
@@ -407,6 +407,22 @@ HardwareProfilePropertiesDlgProc(
     return FALSE;
 }
 
+static int CALLBACK
+PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
+{
+    // NOTE: This callback is needed to set large icon correctly.
+    HICON hIcon;
+    switch (uMsg)
+    {
+        case PSCB_INITIALIZED:
+        {
+            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_HARDPROF));
+            SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+            break;
+        }
+    }
+    return 0;
+}
 
 static
 VOID
@@ -433,15 +449,15 @@ HardwareProfileProperties(
 
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
-    psh.dwFlags = PSH_PROPTITLE;
+    psh.dwFlags = PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwndDlg;
     psh.hInstance = hApplet;
-    psh.hIcon = NULL;
+    psh.pszIcon = MAKEINTRESOURCEW(IDI_HARDPROF);
     psh.pszCaption = pProfileData->pProfiles[pProfileData->dwSelectedProfileIndex].szFriendlyName;
     psh.nPages = 1;
     psh.nStartPage = 0;
     psh.phpage = &hpsp;
-    psh.pfnCallback = NULL;
+    psh.pfnCallback = PropSheetProc;
 
     PropertySheet(&psh);
 }

--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -130,7 +130,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
+            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_USERPROF));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }
@@ -157,7 +157,7 @@ SystemApplet(VOID)
     psh.dwFlags =  PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hCPLWindow;
     psh.hInstance = hApplet;
-    psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLSYSTEM);
+    psh.pszIcon = MAKEINTRESOURCEW(IDI_USERPROF);
     psh.pszCaption = MAKEINTRESOURCE(IDS_CPLSYSTEMNAME);
     psh.nPages = 0;
     psh.nStartPage = 0;

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -214,7 +214,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS));
+            hIcon = LoadIconW(shell32_hInstance, MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }

--- a/dll/win32/shell32/dialogs/folder_options.cpp
+++ b/dll/win32/shell32/dialogs/folder_options.cpp
@@ -205,6 +205,23 @@ public:
 
 EXTERN_C HPSXA WINAPI SHCreatePropSheetExtArrayEx(HKEY hKey, LPCWSTR pszSubKey, UINT max_iface, IDataObject *pDataObj);
 
+static int CALLBACK
+PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
+{
+    // NOTE: This callback is needed to set large icon correctly.
+    HICON hIcon;
+    switch (uMsg)
+    {
+        case PSCB_INITIALIZED:
+        {
+            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS));
+            SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+            break;
+        }
+    }
+    return 0;
+}
+
 static VOID
 ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
 {
@@ -242,11 +259,13 @@ ShowFolderOptionsDialog(HWND hWnd, HINSTANCE hInst)
 
     memset(&pinfo, 0x0, sizeof(PROPSHEETHEADERW));
     pinfo.dwSize = sizeof(PROPSHEETHEADERW);
-    pinfo.dwFlags = PSH_NOCONTEXTHELP;
+    pinfo.dwFlags = PSH_NOCONTEXTHELP | PSH_USEICONID | PSH_USECALLBACK;
     pinfo.hwndParent = stub;
     pinfo.nPages = num_pages;
     pinfo.phpage = hppages;
+    pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_FOLDER_OPTIONS);
     pinfo.pszCaption = szOptions;
+    pinfo.pfnCallback = PropSheetProc;
 
     PropertySheetW(&pinfo);
 


### PR DESCRIPTION
## Purpose
Set more small and large icons to Control Panel applets.
JIRA issue: [CORE-15445](https://jira.reactos.org/browse/CORE-15445)
