### PR TITLE
[UMPNPMGR] Re-enable the usage of Interlocked Singly-Linked lists.

### DIFF
--- a/base/services/umpnpmgr/umpnpmgr.c
+++ b/base/services/umpnpmgr/umpnpmgr.c
@@ -3554,7 +3554,7 @@ PnpEventThread(LPVOID lpParameter)
             DeviceIdLength = lstrlenW(PnpEvent->TargetDevice.DeviceIds);
             if (DeviceIdLength)
             {
-                /* Queue device install (will be dequeued by DeviceInstallThread */
+                /* Queue device install (will be dequeued by DeviceInstallThread) */
                 len = FIELD_OFFSET(DeviceInstallParams, DeviceIds) + (DeviceIdLength + 1) * sizeof(WCHAR);
                 Params = HeapAlloc(GetProcessHeap(), 0, len);
                 if (Params)

--- a/sdk/include/c++/stlport/stl/config/_reactos.h
+++ b/sdk/include/c++/stlport/stl/config/_reactos.h
@@ -302,6 +302,8 @@
 // Calling convention
 #define _STLP_CALL __cdecl
 
+#if 0
+
 #ifdef _M_AMD64
 #ifdef __cplusplus
 extern "C" {
@@ -322,6 +324,8 @@ extern "C" {
 #undef __cdecl__
 #define __cdecl__
 #endif /* _M_AMD64 */
+
+#endif
 
 // Include stlport windows specifics
 #include "_windows.h"

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -3883,11 +3883,41 @@ InitOnceExecuteOnce(
   _Inout_opt_ PVOID Parameter,
   _Outptr_opt_result_maybenull_ LPVOID *Context);
 
+
+#if defined(_SLIST_HEADER_) && !defined(_NTOS_) && !defined(_NTOSP_)
+
 WINBASEAPI
 VOID
 WINAPI
 InitializeSListHead(
-    _Out_ PSLIST_HEADER ListHead);
+  _Out_ PSLIST_HEADER ListHead);
+
+WINBASEAPI
+PSLIST_ENTRY
+WINAPI
+InterlockedPopEntrySList(
+  _Inout_ PSLIST_HEADER ListHead);
+
+WINBASEAPI
+PSLIST_ENTRY
+WINAPI
+InterlockedPushEntrySList(
+  _Inout_ PSLIST_HEADER ListHead,
+  _Inout_ PSLIST_ENTRY ListEntry);
+
+WINBASEAPI
+PSLIST_ENTRY
+WINAPI
+InterlockedFlushSList(
+  _Inout_ PSLIST_HEADER ListHead);
+
+WINBASEAPI
+USHORT
+WINAPI
+QueryDepthSList(
+  _In_ PSLIST_HEADER ListHead);
+
+#endif /* _SLIST_HEADER_ */
 
 #ifdef _MSC_VER
 #pragma warning(pop)


### PR DESCRIPTION
[UMPNPMGR] Re-enable the usage of Interlocked Singly-Linked lists.

Using locked operations (insertion & removal) on the list of queued
devices installations is necessary, because these operations are done
concurrently by two different threads: PnpEventThread() and
DeviceInstallThread().

Addendum to commit b2aeafca (r24365).
