### PR TITLE
[SDK] Define some constants for use with _mm_prefetch

### DIFF
--- a/sdk/include/crt/intrin.h
+++ b/sdk/include/crt/intrin.h
@@ -11,6 +11,7 @@
 #if defined(_M_IX86) || defined(_M_X64)
 //#include <immintrin.h>
 //#include <ammintrin.h>
+#include <xmmintrin.h>
 #endif /* _M_IX86 || _M_X64 */
 
 #if defined(_M_IX86)

--- a/sdk/include/crt/xmmintrin.h
+++ b/sdk/include/crt/xmmintrin.h
@@ -55,4 +55,12 @@ __INTRIN_INLINE void _mm_setcsr(unsigned int val)
 #define _mm_cvtss_si32 _mm_cvt_ss2si
 
 
+/* _mm_prefetch constants */
+#define _MM_HINT_T0 1
+#define _MM_HINT_T1 2
+#define _MM_HINT_T2 3
+#define _MM_HINT_NTA 0
+#define _MM_HINT_ET1 6
+
+
 #endif /* _INCLUDED_MM2 */


### PR DESCRIPTION
This should fix the build for x64

