### PR TITLE
[SHELL32] Add CDefView::DefMessageSFVCB (Retrial of #1145)

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3268,6 +3268,7 @@ HRESULT CDefView::_MergeToolbar()
 HRESULT CDefView::DefMessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     // TODO: SFVM_GET_CUSTOMVIEWINFO, SFVM_WINDOWCREATED
+    TRACE("CDefView::DefMessageSFVCB uMsg=%u\n", uMsg);
     return E_NOTIMPL;
 }
 

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -128,6 +128,7 @@ class CDefView :
         BOOL CreateList();
         void UpdateListColors();
         BOOL InitList();
+        HRESULT DefMessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam);
         static INT CALLBACK ListViewCompareItems(LPARAM lParam1, LPARAM lParam2, LPARAM lpData);
 
         PCUITEMID_CHILD _PidlByItem(int i);
@@ -3263,13 +3264,28 @@ HRESULT CDefView::_MergeToolbar()
     return S_OK;
 }
 
+// The default processing of IShellFolderView callbacks
+HRESULT CDefView::DefMessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    // TODO: SFVM_GET_CUSTOMVIEWINFO, SFVM_WINDOWCREATED
+    return E_NOTIMPL;
+}
+
 HRESULT CDefView::_DoFolderViewCB(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
+    HRESULT hr = E_NOTIMPL;
+
     if (m_pShellFolderViewCB)
     {
-        return m_pShellFolderViewCB->MessageSFVCB(uMsg, wParam, lParam);
+        hr = m_pShellFolderViewCB->MessageSFVCB(uMsg, wParam, lParam);
     }
-    return E_NOINTERFACE;
+
+    if (hr == E_NOTIMPL)
+    {
+        hr = DefMessageSFVCB(uMsg, wParam, lParam);
+    }
+
+    return hr;
 }
 
 HRESULT CDefView_CreateInstance(IShellFolder *pFolder, REFIID riid, LPVOID * ppvOut)


### PR DESCRIPTION
## Purpose
Add CDefView::DefMessageSFVCB method for default processing of IShellFolderView callbacks.

JIRA issue: [CORE-14976](https://jira.reactos.org/browse/CORE-14976)