### PR TITLE
[SHELL32] ShellExecCmdLine: Add backslash if path was like C:

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2422,6 +2422,11 @@ HRESULT WINAPI ShellExecCmdLine(
     else
     {
         pchParams = SplitParams(lpCommand, szFile, _countof(szFile));
+        if (szFile[0] != UNICODE_NULL && szFile[1] == L':' &&
+            szFile[2] == UNICODE_NULL)
+        {
+            PathAddBackslashW(szFile);
+        }
         if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
             SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
             SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||


### PR DESCRIPTION
## Purpose
This PR will fix 'Run' dialog box's behaivour after entering `"C:"`.
JIRA issue: [CORE-15434](https://jira.reactos.org/browse/CORE-15434)

In CORE-15434, amber has detected that `ShellExecCmdLine` call for `"C:"` will append a backslash to the path by replacing `explorer.exe` in Windows.