### PR TITLE
WIP. [NTOS:CC] CcCanIWrite(): Use BYTES_TO_PAGES(Length)

### DIFF
--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -685,8 +685,7 @@ CcCanIWrite (
         Length = BytesToWrite;
     }
 
-    /* Convert it to pages count */
-    Pages = (Length + PAGE_SIZE - 1) >> PAGE_SHIFT;
+    Pages = BYTES_TO_PAGES(Length);
 
     /* By default, assume limits per file won't be hit */
     PerFileDefer = FALSE;


### PR DESCRIPTION
## Purpose

Addendum to 945ff8ea2ee2abd48f5ecbe707131446546e75a3.
Should not change behavior, especially with regard to overflow, as `Length = MAX_ZERO_LENGTH;` currently...

## TODO

- [ ] Untested.
