### PR TITLE
CORE-7538. [CYLFRAC] Fix 3 MSVC-x64 warnings about TimeProc()

### DIFF
--- a/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
+++ b/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
@@ -112,7 +112,7 @@ void DrawScene(HWND hwnd, HDC dc, int ticks)
     EndPaint(hwnd, &ps);
 }
 
-void CALLBACK TimeProc(UINT uID, UINT uMsg, DWORD dwUser, DWORD dw1, DWORD dw2)
+void CALLBACK TimeProc(UINT uID, UINT uMsg, DWORD_PTR dwUser, DWORD_PTR dw1, DWORD_PTR dw2)
 {
     InvalidateRect((HWND)dwUser, NULL, 0);
 }


### PR DESCRIPTION
## Purpose

- "...\cylfrac.c(160): warning C4028: formal parameter 3 different from declaration"
- "...\cylfrac.c(160): warning C4028: formal parameter 4 different from declaration"
- "...\cylfrac.c(160): warning C4028: formal parameter 5 different from declaration"

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)
