### PR TITLE
[CYLFRAC] Fix a MSVC-x64 warning about hwnd

### DIFF
--- a/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
+++ b/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
@@ -157,7 +157,7 @@ LRESULT WINAPI ScreenSaverProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam
             GetCursorPos(&initpoint);
             InitGL(hwnd);
             oldticks = GetTickCount();
-            TimerID = timeSetEvent (timerdelay, 0, TimeProc, (DWORD)hwnd, TIME_PERIODIC);
+            TimerID = timeSetEvent(timerdelay, 0, TimeProc, (DWORD_PTR)hwnd, TIME_PERIODIC);
         }
         break;
         case WM_PAINT:


### PR DESCRIPTION
## Purpose

"...\cylfrac.c(160): warning C4311: 'type cast': pointer truncation from 'HWND' to 'DWORD'"
