### PR TITLE
[NETSHELL] Use distinct icon for connection status window

### DIFF
--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -685,7 +685,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            hIcon = LoadIconW(netshell_hInstance, MAKEINTRESOURCEW(IDI_SHELL_NETWORK_FOLDER));
+            hIcon = LoadIconW(netshell_hInstance, MAKEINTRESOURCEW(IDI_NET_IDLE));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }
@@ -710,7 +710,7 @@ ShowStatusPropertyDialog(
     pinfo.phpage = hppages;
     pinfo.hwndParent = hwndDlg;
     pinfo.hInstance = netshell_hInstance;
-    pinfo.pszIcon = MAKEINTRESOURCEW(IDI_SHELL_NETWORK_FOLDER);
+    pinfo.pszIcon = MAKEINTRESOURCEW(IDI_NET_IDLE);
     pinfo.pfnCallback = PropSheetProc;
 
     if (pContext->pNet->GetProperties(&pProperties) == S_OK)


### PR DESCRIPTION
## Purpose

Use distinct icon for connection status window.

JIRA issue: [CORE-15445](https://jira.reactos.org/browse/CORE-15445)

## Showcase

AFTER:

![image](https://user-images.githubusercontent.com/578406/50236238-f62e0900-03ca-11e9-9b8f-0c04fca0e34b.png)
