### PR TITLE
CORE-7538. [JSCRIPT] Fix a MSVC-x64 warning about to_uint32()

### DIFF
--- a/dll/win32/jscript/jsutils.c
+++ b/dll/win32/jscript/jsutils.c
@@ -675,7 +675,7 @@ HRESULT to_int32(script_ctx_t *ctx, jsval_t v, INT *ret)
 }
 
 /* ECMA-262 3rd Edition    9.6 */
-HRESULT to_uint32(script_ctx_t *ctx, jsval_t val, DWORD *ret)
+HRESULT to_uint32(script_ctx_t *ctx, jsval_t val, UINT32 *ret)
 {
     INT32 n;
     HRESULT hres;


### PR DESCRIPTION
"...\jsutils.c(679) : warning C4028: formal parameter 3 different from declaration"

Cherry-pick https://source.winehq.org/git/wine.git/commit/961d5c8ed05eeccbe216ff24faa0e3d6a0c2b332

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)
