### PR TITLE
CORE-7538. [D3DCOMPILER_43] Fix a MSVC-x64 warning about dxbc_init()

### DIFF
--- a/dll/directx/wine/d3dcompiler_43/d3dcompiler_private.h
+++ b/dll/directx/wine/d3dcompiler_43/d3dcompiler_private.h
@@ -1214,7 +1214,7 @@ HRESULT dxbc_write_blob(struct dxbc *dxbc, ID3DBlob **blob) DECLSPEC_HIDDEN;
 void dxbc_destroy(struct dxbc *dxbc) DECLSPEC_HIDDEN;
 HRESULT dxbc_parse(const char *data, SIZE_T data_size, struct dxbc *dxbc) DECLSPEC_HIDDEN;
 HRESULT dxbc_add_section(struct dxbc *dxbc, DWORD tag, const char *data, DWORD data_size) DECLSPEC_HIDDEN;
-HRESULT dxbc_init(struct dxbc *dxbc, DWORD count) DECLSPEC_HIDDEN;
+HRESULT dxbc_init(struct dxbc *dxbc, unsigned int size) DECLSPEC_HIDDEN;
 
 static inline void read_dword(const char **ptr, DWORD *d)
 {

--- a/dll/directx/wine/d3dcompiler_43/utils.c
+++ b/dll/directx/wine/d3dcompiler_43/utils.c
@@ -557,7 +557,7 @@ HRESULT dxbc_add_section(struct dxbc *dxbc, DWORD tag, const char *data, DWORD d
     return S_OK;
 }
 
-HRESULT dxbc_init(struct dxbc *dxbc, UINT size)
+HRESULT dxbc_init(struct dxbc *dxbc, unsigned int size)
 {
     TRACE("dxbc %p, size %u.\n", dxbc, size);
 


### PR DESCRIPTION
"...\utils.c(561) : warning C4028: formal parameter 2 different from declaration"

Cherry-pick https://source.winehq.org/git/wine.git/commit/ffe9346120ca74f193d8a31d0b6a48eb55604d2b

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)
