### PR TITLE
CORE-10266. [USER32] EDIT_WM_KillFocus(): Restore Wine code, #ifdef'ed out

### DIFF
--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3634,6 +3634,7 @@ static LRESULT EDIT_WM_KeyDown(EDITSTATE *es, INT key)
  */
 static LRESULT EDIT_WM_KillFocus(EDITSTATE *es)
 {
+#ifdef __REACTOS__
 	HWND hCombo;
 	LONG lStyles;
 
@@ -3654,8 +3655,16 @@ static LRESULT EDIT_WM_KillFocus(EDITSTATE *es)
 		if ((lStyles & CBS_DROPDOWN) || (lStyles & CBS_SIMPLE))
 			SendMessage(hCombo, WM_CBLOSTTEXTFOCUS, 0, 0);
 	}
-
-	return 0;
+#else
+        es->flags &= ~EF_FOCUSED;
+        DestroyCaret();
+        if(!(es->style & ES_NOHIDESEL))
+                EDIT_InvalidateText(es, es->selection_start, es->selection_end);
+        EDIT_NOTIFY_PARENT(es, EN_KILLFOCUS);
+        /* throw away left over scroll when we lose focus */
+        es->wheelDeltaRemainder = 0;
+#endif
+        return 0;
 }
 
 


### PR DESCRIPTION
Use `#ifdef __REACTOS__` for WINESYNC'ed code.

Partially reverts 71ab0b5d4cb7fe00e0047308a18ae48c734266b9.
JIRA issue: [CORE-10266](https://jira.reactos.org/browse/CORE-10266)
