### PR TITLE
[FONT][WIN32SS] Partially implement font/text rotation

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -715,7 +715,7 @@ FtMatrixFromMx(FT_Matrix *pmat, PMATRIX pmx)
     pmat->yy = FLOATOBJ_GetLong(&ef);
 }
 
-static __inline VOID FASTCALL
+FORCEINLINE VOID FASTCALL
 FtSetCoordinateTransform(
     FT_Face face,
     PMATRIX pmx)
@@ -5603,7 +5603,8 @@ ScaleLong(LONG lValue, PFLOATOBJ pef)
     return lValue;
 }
 
-LONG IntNormalizeAngle(LONG nTenthAngle)
+FORCEINLINE LONG FASTCALL
+IntNormalizeAngle(LONG nTenthAngle)
 {
     const LONG nFullAngle = 360 * 10;
     nTenthAngle %= nFullAngle;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -662,6 +662,7 @@ VOID FASTCALL IntWidthMatrix(FT_Face face, FT_Matrix *pmat, LONG lfWidth)
     if (lfWidth == 0)
         return;
 
+    ASSERT_FREETYPE_LOCK_HELD();
     pOS2 = (TT_OS2 *)FT_Get_Sfnt_Table(face, FT_SFNT_OS2);
     if (!pOS2)
         return;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5581,6 +5581,13 @@ ScaleLong(LONG lValue, PFLOATOBJ pef)
     return lValue;
 }
 
+LONG IntNormalizeAngle(LONG nTenthAngle)
+{
+    const LONG nFullAngle = 360 * 10;
+    nTenthAngle %= nFullAngle;
+    return (nTenthAngle + nFullAngle) % nFullAngle;
+}
+
 BOOL
 APIENTRY
 GreExtTextOutW(
@@ -5775,7 +5782,7 @@ GreExtTextOutW(
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     EmuBold = (plf->lfWeight >= FW_BOLD && FontGDI->OriginalWeight <= FW_NORMAL);
     EmuItalic = (plf->lfItalic && !FontGDI->OriginalItalic);
-    lfEscapement = plf->lfEscapement % 3600;
+    lfEscapement = IntNormalizeAngle(plf->lfEscapement);
 
     if (Render)
         RenderMode = IntGetFontRenderMode(plf);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6318,10 +6318,10 @@ GreExtTextOutW(
 
     if (plf->lfUnderline)
     {
-        INT i, Escape = lfEscapement % 180 * 10;
+        INT i, nEscape = lfEscapement % (180 * 10);
         for (i = -thickness / 2; i < -thickness / 2 + thickness; ++i)
         {
-            if (Escape < 45 * 10 || Escape > (180 - 45) * 10)
+            if (nEscape < 45 * 10 || nEscape > (180 - 45) * 10)
             {
                 // move vertical
                 EngLineTo(SurfObj, (CLIPOBJ *)&dc->co,
@@ -6344,10 +6344,10 @@ GreExtTextOutW(
 
     if (plf->lfStrikeOut)
     {
-        INT i, Escape = lfEscapement % 180 * 10;
+        INT i, nEscape = lfEscapement % (180 * 10);
         for (i = -thickness / 2; i < -thickness / 2 + thickness; ++i)
         {
-            if (Escape < 45 * 10 || Escape > (180 - 45) * 10)
+            if (nEscape < 45 * 10 || nEscape > (180 - 45) * 10)
             {
                 // move vertical
                 EngLineTo(SurfObj, (CLIPOBJ *)&dc->co,

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6155,9 +6155,9 @@ GreExtTextOutW(
             FT_Get_Kerning(face, previous, glyph_index, 0, &delta);
             TextLeft64 += delta.x;
         }
-        //DPRINT("TextLeft64: %I64d\n", TextLeft64);
-        //DPRINT("TextTop64: %I64d\n", TextTop64);
-        //DPRINT("Advance: %d\n", realglyph->root.advance.x);
+        DPRINT("TextLeft64: %I64d\n", TextLeft64);
+        DPRINT("TextTop64: %I64d\n", TextTop64);
+        DPRINT("Advance: %d\n", realglyph->root.advance.x);
 
         DestRect.left = ((TextLeft64 + 32) >> 6) + realglyph->left;
         DestRect.right = DestRect.left + realglyph->bitmap.width;
@@ -6262,7 +6262,7 @@ GreExtTextOutW(
         {
             TextLeft64 += realglyph->root.advance.x >> 10;
             TextTop64 -= realglyph->root.advance.y >> 10;
-            //DPRINT("New TextLeft64: %I64d\n", TextLeft64);
+            DPRINT("New TextLeft64: %I64d\n", TextLeft64);
         }
         else
         {
@@ -6274,7 +6274,7 @@ GreExtTextOutW(
             /* do the shift before multiplying to preserve precision */
             FLOATOBJ_MulLong(&Scale, Dx[i<<DxShift] << 6); 
             TextLeft64 += FLOATOBJ_GetLong(&Scale);
-            //DPRINT("New TextLeft64 2: %I64d\n", TextLeft64);
+            DPRINT("New TextLeft64 2: %I64d\n", TextLeft64);
         }
 
         if (DxShift)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5804,8 +5804,15 @@ GreExtTextOutW(
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     EmuBold = (plf->lfWeight >= FW_BOLD && FontGDI->OriginalWeight <= FW_NORMAL);
     EmuItalic = (plf->lfItalic && !FontGDI->OriginalItalic);
-    lfEscapement = IntNormalizeAngle(plf->lfEscapement);
-    lfWidth = FT_IS_SCALABLE(face) ? labs(plf->lfWidth) : 0;
+    if (FT_IS_SCALABLE(face))
+    {
+        lfEscapement = IntNormalizeAngle(plf->lfEscapement);
+        lfWidth = labs(plf->lfWidth);
+    }
+    else
+    {
+        lfEscapement = lfWidth = 0;
+    }
 
     if (Render)
         RenderMode = IntGetFontRenderMode(plf);
@@ -6051,6 +6058,7 @@ GreExtTextOutW(
         default:
             DPRINT1("FIXME: Not implemented lfEscapement\n");
             RtlZeroMemory(&Rect, sizeof(Rect));
+            // FIXME: Use pts[0] ... pts[3] and EngFillPath
         }
 
         if (dc->fs & (DC_ACCUM_APP | DC_ACCUM_WMGR))

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -689,8 +689,8 @@ VOID FASTCALL IntEscapeMatrix(FT_Matrix *pmat, LONG lfEscapement)
 
     pmat->xx = (FT_Fixed)(cos(radian) * (1 << 16));
     pmat->xy = (FT_Fixed)(-sin(radian) * (1 << 16));
-    pmat->yx = (FT_Fixed)(sin(radian) * (1 << 16));
-    pmat->yy = (FT_Fixed)(cos(radian) * (1 << 16));
+    pmat->yx = -pmat->xy;
+    pmat->yy = pmat->xx;
 }
 
 VOID FASTCALL

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5616,7 +5616,6 @@ GreExtTextOutW(
     HBITMAP HSourceGlyph;
     SURFOBJ *SourceGlyphSurf;
     SIZEL bitSize;
-    INT yoff;
     FONTOBJ *FontObj;
     PFONTGDI FontGDI;
     PTEXTOBJ TextObj = NULL;
@@ -5627,7 +5626,7 @@ GreExtTextOutW(
     BOOL DoBreak = FALSE;
     USHORT DxShift;
     PMATRIX pmxWorldToDevice;
-    LONG fixAscender, fixDescender, lfEscapement;
+    LONG fixAscender, lfEscapement;
     FLOATOBJ Scale;
     LOGFONTW *plf;
     BOOL EmuBold, EmuItalic;
@@ -5797,7 +5796,7 @@ GreExtTextOutW(
         FtSetCoordinateTransform(face, pmxWorldToDevice);
 
         fixAscender = ScaleLong(FontGDI->tmAscent, &pmxWorldToDevice->efM22) << 6;
-        fixDescender = ScaleLong(FontGDI->tmDescent, &pmxWorldToDevice->efM22) << 6;
+        //fixDescender = ScaleLong(FontGDI->tmDescent, &pmxWorldToDevice->efM22) << 6;
     }
     else
     {
@@ -5805,28 +5804,25 @@ GreExtTextOutW(
         FtSetCoordinateTransform(face, pmxWorldToDevice);
 
         fixAscender = FontGDI->tmAscent << 6;
-        fixDescender = FontGDI->tmDescent << 6;
+        //fixDescender = FontGDI->tmDescent << 6;
     }
 
     /*
-     * Process the vertical alignment and determine the yoff.
+     * Process the vertical alignment and determine DY1 and DY2.
      */
 #define VALIGN_MASK  (TA_TOP | TA_BASELINE | TA_BOTTOM)
     if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BASELINE)
     {
-        yoff = 0;
         DY1 = FontGDI->tmAscent;
         DY2 = FontGDI->tmDescent;
     }
     else if ((pdcattr->lTextAlign & VALIGN_MASK) == TA_BOTTOM)
     {
-        yoff = -(fixDescender >> 6);
         DY1 = FontGDI->tmHeight;
         DY2 = 0;
     }
     else /* TA_TOP */
     {
-        yoff = fixAscender >> 6;
         DY1 = 0;
         DY2 = FontGDI->tmHeight;
     }
@@ -6103,7 +6099,6 @@ GreExtTextOutW(
 
         DestRect.left = ((TextLeft + 32) >> 6) + realglyph->left;
         DestRect.right = DestRect.left + realglyph->bitmap.width;
-        //DestRect.top = TextTop + yoff - realglyph->top;
         DestRect.top = TextTop - realglyph->top;
         DestRect.bottom = DestRect.top + realglyph->bitmap.rows;
 
@@ -6219,9 +6214,9 @@ GreExtTextOutW(
                           (CLIPOBJ *)&dc->co,
                           &dc->eboText.BrushObject,
                           (TextLeft >> 6),
-                          TextTop + yoff - position + i - (realglyph->root.advance.y >> 16),
+                          TextTop - position + i,
                           ((TextLeft + (realglyph->root.advance.x >> 10)) >> 6),
-                          TextTop + yoff - position + i,
+                          TextTop - position + i - (realglyph->root.advance.y >> 16),
                           NULL,
                           ROP2_TO_MIX(R2_COPYPEN));
             }
@@ -6235,9 +6230,9 @@ GreExtTextOutW(
                           (CLIPOBJ *)&dc->co,
                           &dc->eboText.BrushObject,
                           (TextLeft >> 6),
-                          TextTop + yoff - (fixAscender >> 6) / 3 + i - (realglyph->root.advance.y >> 16),
+                          TextTop - (fixAscender >> 6) / 3 + i,
                           ((TextLeft + (realglyph->root.advance.x >> 10)) >> 6),
-                          TextTop + yoff - (fixAscender >> 6) / 3 + i,
+                          TextTop - (fixAscender >> 6) / 3 + i - (realglyph->root.advance.y >> 16),
                           NULL,
                           ROP2_TO_MIX(R2_COPYPEN));
             }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11848](https://jira.reactos.org/browse/CORE-11848), [CORE-15319](https://jira.reactos.org/browse/CORE-15319)

This PR will partially implement font/text rotation by LOGFONT.lfEscapement and improve the rendering image. If (angle % 90) was non-zero, then the background won't be drawn. The case of (angle % 90) will be later work.