### PR TITLE
[APPWIZ] Do not hardcode the strings

### DIFF
--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -408,12 +408,14 @@ ShowCreateShortcutWizard(HWND hwndCPl, LPWSTR szPath)
     UINT nLength;
     DWORD attrs;
     PCREATE_LINK_CONTEXT pContext;
+    WCHAR szMessage[128];
 
     pContext = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*pContext));
     if (!pContext)
     {
         /* no memory */
-        MessageBoxA(hwndCPl, "Out of memory!", NULL, MB_ICONERROR);
+        LoadStringW(hApplet, IDS_NO_MEMORY, szMessage, _countof(szMessage));
+        MessageBoxW(hwndCPl, szMessage, NULL, MB_ICONERROR);
         return FALSE;
     }
 
@@ -423,7 +425,8 @@ ShowCreateShortcutWizard(HWND hwndCPl, LPWSTR szPath)
         HeapFree(GetProcessHeap(), 0, pContext);
 
         /* no directory given */
-        MessageBoxA(hwndCPl, "No directory given!", NULL, MB_ICONERROR);
+        LoadStringW(hApplet, IDS_NO_DIRECTORY, szMessage, _countof(szMessage));
+        MessageBoxW(hwndCPl, szMessage, NULL, MB_ICONERROR);
         return FALSE;
     }
 
@@ -433,7 +436,8 @@ ShowCreateShortcutWizard(HWND hwndCPl, LPWSTR szPath)
         HeapFree(GetProcessHeap(), 0, pContext);
 
         /* invalid path */
-        MessageBoxA(hwndCPl, "Invalid path!", NULL, MB_ICONERROR);
+        LoadStringW(hApplet, IDS_INVALID_PATH, szMessage, _countof(szMessage));
+        MessageBoxW(hwndCPl, szMessage, NULL, MB_ICONERROR);
         return FALSE;
     }
 

--- a/dll/cpl/appwiz/lang/bg-BG.rc
+++ b/dll/cpl/appwiz/lang/bg-BG.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/cs-CZ.rc
+++ b/dll/cpl/appwiz/lang/cs-CZ.rc
@@ -87,4 +87,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/de-DE.rc
+++ b/dll/cpl/appwiz/lang/de-DE.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/el-GR.rc
+++ b/dll/cpl/appwiz/lang/el-GR.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/en-US.rc
+++ b/dll/cpl/appwiz/lang/en-US.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/es-ES.rc
+++ b/dll/cpl/appwiz/lang/es-ES.rc
@@ -88,4 +88,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/et-EE.rc
+++ b/dll/cpl/appwiz/lang/et-EE.rc
@@ -89,4 +89,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/fr-FR.rc
+++ b/dll/cpl/appwiz/lang/fr-FR.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Échec lors du téléchargement du paquet Gecko. Assurez-vous d'avoir une connexion Internet pour pouvoir le télécharger. L'installation va continuer sans installer Gecko."
     IDS_CANTMAKEINETSHORTCUT "Échec lors de la création du raccourci Internet."
     IDS_CANTMAKESHORTCUT "Échec lors de la création du raccourci."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/he-IL.rc
+++ b/dll/cpl/appwiz/lang/he-IL.rc
@@ -83,4 +83,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/it-IT.rc
+++ b/dll/cpl/appwiz/lang/it-IT.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Lo scaricamento del pacchetto Gecko è fallito. Assicurati che hai una connessione internet per scaricarlo. Il setup procederà senza l'installazione del pacchetto Gecko."
     IDS_CANTMAKEINETSHORTCUT "La creazione di un collegamento internet è fallita."
     IDS_CANTMAKESHORTCUT "La creazione di un collegamento è fallita."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/ja-JP.rc
+++ b/dll/cpl/appwiz/lang/ja-JP.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/no-NO.rc
+++ b/dll/cpl/appwiz/lang/no-NO.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/pl-PL.rc
+++ b/dll/cpl/appwiz/lang/pl-PL.rc
@@ -92,4 +92,7 @@ BEGIN
     IDS_DWL_FAILED "Nie udało się pobrać pakietu Gecko. Upewnij się, że masz połączenie z internetem, aby pobrać pakiet. Instalacja będzie kontynuowana bez pakietu Gecko."
     IDS_CANTMAKEINETSHORTCUT "Nie można utworzyć skrótu internetowego."
     IDS_CANTMAKESHORTCUT "Nie można utworzyć skrótu."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/pt-BR.rc
+++ b/dll/cpl/appwiz/lang/pt-BR.rc
@@ -84,4 +84,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/ro-RO.rc
+++ b/dll/cpl/appwiz/lang/ro-RO.rc
@@ -88,4 +88,7 @@ BEGIN
     IDS_DWL_FAILED "Descărcarea pachetului Gecko a eșuat. Asigurați-vă că aveți conexiune la internet pentru a putea descărca. Asistentul va continua fără a instala pachetul Gecko."
     IDS_CANTMAKEINETSHORTCUT "Eșec în crearea scurtăturii la Internet."
     IDS_CANTMAKESHORTCUT "Eșec în crearea scurtăturii."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/ru-RU.rc
+++ b/dll/cpl/appwiz/lang/ru-RU.rc
@@ -82,4 +82,7 @@ BEGIN
     IDS_DWL_FAILED "Не удалось скачать пакет установки Gecko, проверьте ваше подключение к сети интернет. Установка будет продолжена без включения пакета Gecko."
     IDS_CANTMAKEINETSHORTCUT "Не удалось создать ярлык интернета."
     IDS_CANTMAKESHORTCUT "Не удалось создать ярлык."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/sk-SK.rc
+++ b/dll/cpl/appwiz/lang/sk-SK.rc
@@ -86,4 +86,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/sq-AL.rc
+++ b/dll/cpl/appwiz/lang/sq-AL.rc
@@ -86,4 +86,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/tr-TR.rc
+++ b/dll/cpl/appwiz/lang/tr-TR.rc
@@ -84,4 +84,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/uk-UA.rc
+++ b/dll/cpl/appwiz/lang/uk-UA.rc
@@ -90,4 +90,7 @@ BEGIN
     IDS_DWL_FAILED "Не вдалося завантажити пакет встановки Gecko. Перевірте ваше підключення до мережі інтернет. Встановка буде продовжена без включення пакета Gecko."
     IDS_CANTMAKEINETSHORTCUT "Не вдалося створити ярлик інтернету."
     IDS_CANTMAKESHORTCUT "Не вдалося створити ярлик."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/zh-CN.rc
+++ b/dll/cpl/appwiz/lang/zh-CN.rc
@@ -91,4 +91,7 @@ BEGIN
     IDS_DWL_FAILED "无法下载 Gecko 安装包。请确保您有互联网连接才能进行下载。安装程序将在不安装 Gecko 的情况下继续。"
     IDS_CANTMAKEINETSHORTCUT "无法创建 Internet 快捷方式"
     IDS_CANTMAKESHORTCUT "无法创建快捷方式。"
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/lang/zh-TW.rc
+++ b/dll/cpl/appwiz/lang/zh-TW.rc
@@ -89,4 +89,7 @@ BEGIN
     IDS_DWL_FAILED "Failed to download the Gecko package. Make sure you have an internet connection in order to download it. The setup will proceed without installing Gecko."
     IDS_CANTMAKEINETSHORTCUT "Failed to create internet shortcut."
     IDS_CANTMAKESHORTCUT "Failed to create shortcut."
+    IDS_NO_MEMORY "No memory could be allocated!"
+    IDS_NO_DIRECTORY "No directory given!"
+    IDS_INVALID_PATH "The given path is invalid!"
 END

--- a/dll/cpl/appwiz/resource.h
+++ b/dll/cpl/appwiz/resource.h
@@ -25,6 +25,9 @@
 #define IDS_NEW_INTERNET_SHORTCUT   2023
 #define IDS_CANTMAKEINETSHORTCUT    2024
 #define IDS_CANTMAKESHORTCUT        2025
+#define IDS_NO_MEMORY               2026
+#define IDS_NO_DIRECTORY            2027
+#define IDS_INVALID_PATH            2028
 
 #define IDS_DOWNLOADING        14
 #define IDS_INSTALLING         15


### PR DESCRIPTION
## Purpose
In the recent commit ([`c5f89b8`](https://github.com/reactos/reactos/commit/c5f89b815921d41fe97ce645c72cdbb9e4ef8683)) in APPWIZ control panel module, the last implemented strings were hardcoded in the code whereas most of the strings are translatable through resources. In other words, let's make those strings translatable too!
## Proposed Changes
- Make the strings translatable
- Use the UNICODE variation of MessageBox() service instead of the ANSI one
