### PR TITLE
[USER32] Let App Switcher activate even if only one window

### DIFF
--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -424,8 +424,15 @@ BOOL ProcessHotKey(VOID)
       windowCount=0;
       EnumChildWindowsZOrder(NULL, EnumerateCallback, 0);
 
-      if (windowCount < 2)
+      if (windowCount == 0)
          return FALSE;
+
+      if (windowCount == 1)
+      {
+         selectedWindow = 0;
+         CompleteSwitch(TRUE);
+         return TRUE;
+      }
 
       selectedWindow = 1;
 


### PR DESCRIPTION
## Purpose
JIRA issue: N/A
If there is only one top-level window, then let App Switcher (Alt+Tab) activate the window.