### PR TITLE
[SYSSETUP] Add spec definition for SetupInfObjectInstallActionW

### DIFF
--- a/dll/win32/syssetup/syssetup.spec
+++ b/dll/win32/syssetup/syssetup.spec
@@ -53,7 +53,7 @@
 @ stub SetupGetProductType
 @ stub SetupGetSetupInfo
 @ stub SetupGetValidEula
-@ stub SetupInfObjectInstallActionW
+@ stdcall SetupInfObjectInstallActionW() SETUPAPI.InstallHinfSectionW
 @ stub SetupInstallCatalog
 @ stub SetupMapTapiToIso
 @ stub SetupOobeBnk


### PR DESCRIPTION
## Purpose

Add spec definition for `SetupInfObjectInstallActionW`.

It just forwards the call to `SETUPAPI.InstallHinfSectionW`.

JIRA issue: [CORE-9897](https://jira.reactos.org/browse/CORE-9897)
