### PR TITLE
[WIN32K:NTUSER] Find a better position for a menu that is off-screen

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2911,9 +2911,22 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
             x -= width - xanchor;
 
         if( x + width > monitor->rcMonitor.right)
-            x = monitor->rcMonitor.right - width;
+        {
+            /* If we would flip around our origin, would we go off screen on the other side? */
+            if (x - width < monitor->rcMonitor.left)
+                x = monitor->rcMonitor.right - width;
+            else
+                x -= width;
+        }
     }
-    if( x < monitor->rcMonitor.left ) x = monitor->rcMonitor.left;
+    if( x < monitor->rcMonitor.left )
+    {
+        /* If we would flip around our origin, would we go off screen on the other side? */
+        if (x + width > monitor->rcMonitor.right)
+            x = monitor->rcMonitor.left;
+        else
+            x += width;
+    }
 
     if( y + height > monitor->rcMonitor.bottom)
     {
@@ -2921,9 +2934,22 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
             y -= height + yanchor;
 
         if( y + height > monitor->rcMonitor.bottom)
-            y = monitor->rcMonitor.bottom - height;
+        {
+            /* If we would flip around our origin, would we go off screen on the other side? */
+            if (y - height < monitor->rcMonitor.top)
+                y = monitor->rcMonitor.bottom - height;
+            else
+                y -= height;
+        }
     }
-    if( y < monitor->rcMonitor.top ) y = monitor->rcMonitor.top;
+    if( y < monitor->rcMonitor.top )
+    {
+        /* If we would flip around our origin, would we go off screen on the other side? */
+        if (y + height > monitor->rcMonitor.bottom)
+            y = monitor->rcMonitor.top;
+        else
+            y += height;
+    }
 
     pWnd = ValidateHwndNoErr( menu->hWnd );
 


### PR DESCRIPTION
Previously, we would just stick the menu on the edge of the screen.
We should actually try to flip the menu around the point of origin,
and only when that fails move it to the edge of the screen.
CORE-15001
CORE-9037

JIRA issue: [CORE-15001](https://jira.reactos.org/browse/CORE-15001)
JIRA issue: [CORE-9037](https://jira.reactos.org/browse/CORE-9037)
