### PR TITLE
[CMAKE] MSVC cmake settings improvements.

### DIFF
--- a/sdk/cmake/config-amd64.cmake
+++ b/sdk/cmake/config-amd64.cmake
@@ -6,7 +6,7 @@ set(OARCH "athlon64" CACHE STRING
 "Generate instructions for this CPU type. Specify one of:
  k8 opteron athlon64 athlon-fx")
 
-set (OPTIMIZE "1" CACHE STRING
+set(OPTIMIZE "1" CACHE STRING
 "What level of optimization to use.
  0 = off
  1 = Default option, optimize for size (-Os) with some additional options

--- a/sdk/cmake/config-arm.cmake
+++ b/sdk/cmake/config-arm.cmake
@@ -7,7 +7,7 @@ set(OARCH "armv7-a" CACHE STRING
 "Generate instructions for this CPU type. Specify one of:
  armv5te armv7-a")
 
-set (OPTIMIZE "1" CACHE STRING
+set(OPTIMIZE "1" CACHE STRING
 "What level of optimization to use.
  0 = off
  1 = Default option, optimize for size (-Os) with some additional options


### PR DESCRIPTION
- Always use string pooling when building: this helps reducing the
  size of the binaries due to string redundancy coming from the usage
  of __FILE__ / __RELFILE__ in the debugging helper macros. Note also
  that GCC builds use string pooling by default.

- Use suitable add_compile_flags() command.
- Add some explanative comments for some settings.

Some numbers (obtained with my local builds):

Before / After => Reduction
===========================

freeldr.sys  :  443 KB (  453.632 bytes) /  364 KB (  372.736 bytes) => ~ 18%
win32k.sys   : 1877 KB (1.922.048 bytes) / 1562 KB (1.599.488 bytes) => ~ 17%
ntoskrnl.exe : 2253 KB (2.307.072 bytes) / 1902 KB (1.947.136 bytes) => ~ 15.6%
kernel32.dll : 3008 KB (3.080.192 bytes) / 2906 KB (2.975.744 bytes) => ~ 3.4%
