### PR TITLE
[WINMM][MIDIMAP] Support Windows XP compatible MIDIMap registry setting

### DIFF
--- a/dll/win32/winmm/midimap/midimap.c
+++ b/dll/win32/winmm/midimap/midimap.c
@@ -239,6 +239,11 @@ static BOOL	MIDIMAP_LoadSettings(MIDIMAPDATA* mom)
 	    {
 		ret = MIDIMAP_LoadSettingsDefault(mom, buffer);
 	    }
+	    else if (!RegQueryValueExW(hKey, L"szPname", 0, &type, (void*)buffer, &size) && *buffer)
+	    {
+		/* Windows XP and higher setting */
+		ret = MIDIMAP_LoadSettingsDefault(mom, buffer);
+	    }
 	    else
 	    {
 		ret = MIDIMAP_LoadSettingsDefault(mom, NULL);


### PR DESCRIPTION
## Purpose

Support Windows XP compatible MIDIMap registry setting.

JIRA issue: [CORE-15602](https://jira.reactos.org/browse/CORE-15602)

**Note:** midimap is not synced with Wine (it's forked), so I did not used `__REACTOS__` ifdefs.