### PR TITLE
Fix desktop context menu + improve it

### DIFF
--- a/base/applications/msconfig_new/comctl32ex/comctl32supp.h
+++ b/base/applications/msconfig_new/comctl32ex/comctl32supp.h
@@ -10,10 +10,6 @@
 #define __COMCTL32SUPP_H__
 
 #include <windowsx.h>
-/*
-#define GET_X_LPARAM(lp)    ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp)    ((int)(short)HIWORD(lp))
-*/
 
 #define Button_IsEnabled(hwndCtl) IsWindowEnabled((hwndCtl))
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -64,9 +64,6 @@ extern HANDLE hProcessHeap;
 extern HKEY hkExplorer;
 extern BOOL bExplorerIsShell;
 
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 /*
  * explorer.c
  */

--- a/dll/shellext/stobject/precomp.h
+++ b/dll/shellext/stobject/precomp.h
@@ -34,9 +34,6 @@ extern HINSTANCE g_hInstance;
 #define ID_ICON_HOTPLUG (WM_APP + 0x4CC)
 #define ID_ICON_POWER   (WM_APP + 0x4CD)
 
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 #include "csystray.h"
 
 typedef HRESULT(STDMETHODCALLTYPE * PFNSTINIT)     (_In_ CSysTray * pSysTray);

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -25,10 +25,6 @@ toolbar, and address band for an explorer window
 
 #include "precomp.h"
 
-/* FIXME, I can't include windowsx because it conflicts with some #defines */
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 #if 1
 
 interface IAugmentedShellFolder : public IShellFolder

--- a/dll/win32/browseui/shellbars/shellbars.h
+++ b/dll/win32/browseui/shellbars/shellbars.h
@@ -31,9 +31,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(browseui);
 #include "CBandSiteMenu.h"
 #include "CISFBand.h"
 
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 #define USE_SYSTEM_ISFBAND 0
 
 #if USE_SYSTEM_ISFBAND

--- a/dll/win32/browseui/toolsband.cpp
+++ b/dll/win32/browseui/toolsband.cpp
@@ -24,10 +24,6 @@ Implements the toolbar band of a cabinet window
 
 #include "precomp.h"
 
-/* FIXME, I can't include windowsx because it conflicts with some #defines */
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 class CToolsBand :
     public CWindowImpl<CToolsBand, CWindow, CControlWinTraits>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -28,9 +28,6 @@
 
 #define IDS_MENU_EMPTY 34561
 
-#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
-#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
-
 WINE_DEFAULT_DEBUG_CHANNEL(CMenuToolbars);
 
 // FIXME: Enable if/when wine comctl supports this flag properly

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -52,6 +52,15 @@ inline LONG_PTR GetWindowLongPtr(HWND hWnd, int nIndex)
 namespace ATL
 {
 
+#ifndef GET_X_LPARAM
+#define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
+#endif
+#ifndef GET_Y_LPARAM
+#define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
+#endif
+
+
+
 struct _ATL_WNDCLASSINFOW;
 typedef _ATL_WNDCLASSINFOW CWndClassInfo;
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2912,8 +2912,9 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
 
         if( x + width > monitor->rcMonitor.right)
         {
-            /* If we would flip around our origin, would we go off screen on the other side? */
-            if (x - width < monitor->rcMonitor.left)
+            /* If we would flip around our origin, would we go off screen on the other side?
+               Or is our origin itself too far to the right already? */
+            if (x - width < monitor->rcMonitor.left || x > monitor->rcMonitor.right)
                 x = monitor->rcMonitor.right - width;
             else
                 x -= width;
@@ -2935,8 +2936,9 @@ static BOOL FASTCALL MENU_ShowPopup(PWND pwndOwner, PMENU menu, UINT id, UINT fl
 
         if( y + height > monitor->rcMonitor.bottom)
         {
-            /* If we would flip around our origin, would we go off screen on the other side? */
-            if (y - height < monitor->rcMonitor.top)
+            /* If we would flip around our origin, would we go off screen on the other side?
+               Or is our origin itself too far to the bottom already? */
+            if (y - height < monitor->rcMonitor.top || y > monitor->rcMonitor.bottom)
                 y = monitor->rcMonitor.bottom - height;
             else
                 y -= height;


### PR DESCRIPTION
The previous context menu fix introduced a small regression,
the menu would be off-screen if it was too far to the right.
The first commit fixes this case.

The second commit makes a macro available for general use, and removes copypasta.

The third commit fixes our `CDefView` context menu behavior when triggered from the keyboard.
Previously, we would send huge coordinates, because we treated the input as unsigned.
Additionally, we now also position the menu over a focused or selected item.