### PR TITLE
[WIN32SS][NTUSER] Don't freeze Task Bar in switching the app

### DIFF
--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -511,8 +511,13 @@ NtUserCallTwoParam(
             BOOL fAltTab = (BOOL)Param2;
             Ret = 0;
             Window = UserGetWindowObject(hwnd);
-            if (!Window || MsqIsHung(Window->head.pti))
+            if (!Window)
             {
+                break;
+            }
+            if (MsqIsHung(Window->head.pti))
+            {
+                // TODO: Create a Ghost window and activate.
                 break;
             }
             if (fAltTab)

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -511,7 +511,7 @@ NtUserCallTwoParam(
             BOOL fAltTab = (BOOL)Param2;
             Ret = 0;
             Window = UserGetWindowObject(hwnd);
-            if (!Window)
+            if (!Window || MsqIsHung(Window->head.pti))
             {
                 break;
             }

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -517,7 +517,7 @@ NtUserCallTwoParam(
             }
             if (MsqIsHung(Window->head.pti))
             {
-                // TODO: Create a Ghost window and activate.
+                // TODO: Make the window ghosted and activate.
                 break;
             }
             if (fAltTab)


### PR DESCRIPTION
## Purpose
JIRA issue: N/A
Check if the window is not hung when switching to the window. This avoids taskbar hung up.