### PR TITLE
[WIN32SS][USER32] Ghost is a hung window

### DIFF
--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -1841,6 +1841,18 @@ InternalGetWindowText(HWND hWnd, LPWSTR lpString, int nMaxCount)
 BOOL WINAPI
 IsHungAppWindow(HWND hwnd)
 {
+    UNICODE_STRING ClassName;
+    WCHAR szClass[16];
+    static const UNICODE_STRING GhostClass = RTL_CONSTANT_STRING(L"Ghost");
+
+    /* Ghost is a hung window */
+    RtlInitEmptyUnicodeString(&ClassName, szClass, sizeof(szClass));
+    if (NtUserGetClassName(hwnd, FALSE, &ClassName) &&
+        RtlEqualUnicodeString(&ClassName, &GhostClass, TRUE))
+    {
+        return TRUE;
+    }
+
     return (NtUserQueryWindow(hwnd, QUERY_WINDOW_ISHUNG) != 0);
 }
 


### PR DESCRIPTION
## Purpose
`IsHungAppWindow(a ghost window) == TRUE`.
JIRA issue: [CORE-11944](https://jira.reactos.org/browse/CORE-11944)
