### PR TITLE
[WIN32SS][USER32] Make IsHungAppWindow check FNID

### DIFF
--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -1841,13 +1841,16 @@ InternalGetWindowText(HWND hWnd, LPWSTR lpString, int nMaxCount)
 BOOL WINAPI
 IsHungAppWindow(HWND hwnd)
 {
+    PWND Window;
     UNICODE_STRING ClassName;
     WCHAR szClass[16];
     static const UNICODE_STRING GhostClass = RTL_CONSTANT_STRING(L"Ghost");
 
     /* Ghost is a hung window */
     RtlInitEmptyUnicodeString(&ClassName, szClass, sizeof(szClass));
-    if (NtUserGetClassName(hwnd, FALSE, &ClassName) &&
+    Window = ValidateHwnd(hwnd);
+    if (Window && Window->fnid == FNID_GHOST &&
+        NtUserGetClassName(hwnd, FALSE, &ClassName) &&
         RtlEqualUnicodeString(&ClassName, &GhostClass, TRUE))
     {
         return TRUE;


### PR DESCRIPTION
## Purpose
Check `Window->fnid == FNID_GHOST` in `IsHungAppWindow` function.
JIRA issue: [CORE-11944](https://jira.reactos.org/browse/CORE-11944)
