### PR TITLE
[MMSYS] Set the initial media folder location

### DIFF
--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -1157,7 +1157,7 @@ SoundsDlgProc(HWND hwndDlg,
                     ofn.nFilterIndex = 0;
                     LoadStringW(hApplet, IDS_BROWSE_FOR_SOUND, szTitle, _countof(szTitle));
                     ofn.lpstrTitle = szTitle;
-                    ofn.lpstrInitialDir = NULL;
+                    ofn.lpstrInitialDir = L"%SystemRoot%\\Media";
                     ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 
                     if (GetOpenFileNameW(&ofn) != FALSE)


### PR DESCRIPTION
Let's try this again. Set the initial media folder location for the Browse button on the Sounds tab to C:\ReactOS\Media using %SystemRoot%.