### PR TITLE
[SHELL32] Disable the Hardware tab in the properties dialog for Network drives

### DIFF
--- a/dll/win32/shell32/dialogs/drvdefext.cpp
+++ b/dll/win32/shell32/dialogs/drvdefext.cpp
@@ -648,12 +648,15 @@ CDrvDefExt::AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
             pfnAddPage(hPage, lParam);
     }
 
-    hPage = SH_CreatePropertySheetPage(IDD_DRIVE_HARDWARE,
-                                       HardwarePageProc,
-                                       (LPARAM)this,
-                                       NULL);
-    if (hPage)
-        pfnAddPage(hPage, lParam);
+    if (GetDriveTypeW(m_wszDrive) != DRIVE_REMOTE)
+    {
+        hPage = SH_CreatePropertySheetPage(IDD_DRIVE_HARDWARE,
+                                            HardwarePageProc,
+                                            (LPARAM)this,
+                                            NULL);
+        if (hPage)
+            pfnAddPage(hPage, lParam);
+    }
 
     return S_OK;
 }

--- a/dll/win32/shell32/dialogs/drvdefext.cpp
+++ b/dll/win32/shell32/dialogs/drvdefext.cpp
@@ -651,9 +651,9 @@ CDrvDefExt::AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam)
     if (GetDriveTypeW(m_wszDrive) != DRIVE_REMOTE)
     {
         hPage = SH_CreatePropertySheetPage(IDD_DRIVE_HARDWARE,
-                                            HardwarePageProc,
-                                            (LPARAM)this,
-                                            NULL);
+                                           HardwarePageProc,
+                                           (LPARAM)this,
+                                           NULL);
         if (hPage)
             pfnAddPage(hPage, lParam);
     }


### PR DESCRIPTION
Disable the Hardware tab in the properties dialog for Network drives. This matches what Windows does. 

I've tested this and it didn't appear to break this tab for hard drives, cd drives and floppy drives but I can't test every scenario.