### PR TITLE
[LOG2LINES] handle_escape_cmd(): Remove 2 unused parameters

### DIFF
--- a/sdk/tools/log2lines/cmd.c
+++ b/sdk/tools/log2lines/cmd.c
@@ -177,7 +177,7 @@ handle_address_cmd(FILE *outFile, char *arg)
 }
 
 char
-handle_escape_cmd(FILE *outFile, char *Line, char *path, char *LineOut)
+handle_escape_cmd(FILE *outFile, char *Line)
 {
     char cmd;
     char sep = '\n';

--- a/sdk/tools/log2lines/cmd.h
+++ b/sdk/tools/log2lines/cmd.h
@@ -18,6 +18,6 @@
 #define KDBG_CONT       "---"                       //Also after this pattern (prompt with no line ending)
 #define KDBG_DISCARD    "Command '" KDBG_ESC_STR    //Discard responses at l2l escape commands
 
-char handle_escape_cmd(FILE *outFile, char *Line, char *path, char *LineOut);
+char handle_escape_cmd(FILE *outFile, char *Line);
 
 /* EOF */

--- a/sdk/tools/log2lines/log2lines.c
+++ b/sdk/tools/log2lines/log2lines.c
@@ -439,7 +439,7 @@ translate_files(FILE *inFile, FILE *outFile)
                     }
                     else
                     {
-                        Line[1] = handle_escape_cmd(outFile, Line, path, LineOut);
+                        Line[1] = handle_escape_cmd(outFile, Line);
                         if (Line[1] != KDBG_ESC_CHAR)
                         {
                             if (p == p_eos)


### PR DESCRIPTION
## Purpose

Trivial code cleanup.