### PR TITLE
[WIN32SS][NTUSER] Fix message time

### DIFF
--- a/win32ss/gdi/eng/eng.h
+++ b/win32ss/gdi/eng/eng.h
@@ -40,6 +40,8 @@ APIENTRY
 EngGetTickCount(
     VOID);
 
+#define EngGetTickCount32() (ULONG)EngGetTickCount()
+
 HANDLE
 APIENTRY
 EngSecureMemForRead(

--- a/win32ss/user/ntuser/event.c
+++ b/win32ss/user/ntuser/event.c
@@ -165,7 +165,7 @@ co_EVENT_CallEvents( DWORD event,
                                  pEP->idObject,
                                  pEP->idChild,
                                  pEP->idThread,
-                                (DWORD)EngGetTickCount(),
+                                 EngGetTickCount32(),
                                  pEH->Proc,
                                  pEH->ihmod,
                                  pEH->offPfn);
@@ -229,7 +229,7 @@ IntNotifyWinEvent(
                                    idObject,
                                    idChild,
                                    PtrToUint(NtCurrentTeb()->ClientId.UniqueThread),
-                                  (DWORD)EngGetTickCount(),
+                                   EngGetTickCount32(),
                                    pEH->Proc,
                                    pEH->ihmod,
                                    pEH->offPfn);

--- a/win32ss/user/ntuser/input.c
+++ b/win32ss/user/ntuser/input.c
@@ -33,7 +33,7 @@ IntLastInputTick(BOOL bUpdate)
 {
     if (bUpdate)
     {
-        LastInputTick = (DWORD)EngGetTickCount();
+        LastInputTick = EngGetTickCount32();
         if (gpsi) gpsi->dwLastRITEventTickCount = LastInputTick;
     }
     return LastInputTick;
@@ -51,7 +51,7 @@ DoTheScreenSaver(VOID)
 
     if (gspv.iScrSaverTimeout > 0) // Zero means Off.
     {
-        Test = (DWORD)EngGetTickCount();
+        Test = EngGetTickCount32();
         Test = Test - LastInputTick;
         TO = 1000 * gspv.iScrSaverTimeout;
         if (Test > TO)

--- a/win32ss/user/ntuser/input.c
+++ b/win32ss/user/ntuser/input.c
@@ -33,9 +33,7 @@ IntLastInputTick(BOOL bUpdate)
 {
     if (bUpdate)
     {
-        LARGE_INTEGER TickCount;
-        KeQueryTickCount(&TickCount);
-        LastInputTick = MsqCalculateMessageTime(&TickCount);
+        LastInputTick = (DWORD)EngGetTickCount();
         if (gpsi) gpsi->dwLastRITEventTickCount = LastInputTick;
     }
     return LastInputTick;
@@ -49,13 +47,11 @@ IntLastInputTick(BOOL bUpdate)
 VOID FASTCALL
 DoTheScreenSaver(VOID)
 {
-    LARGE_INTEGER TickCount;
     DWORD Test, TO;
 
     if (gspv.iScrSaverTimeout > 0) // Zero means Off.
     {
-        KeQueryTickCount(&TickCount);
-        Test = MsqCalculateMessageTime(&TickCount);
+        Test = (DWORD)EngGetTickCount();
         Test = Test - LastInputTick;
         TO = 1000 * gspv.iScrSaverTimeout;
         if (Test > TO)

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1029,7 +1029,7 @@ UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected)
         dwTime = pKbdInput->time;
     else
     {
-        dwTime = (DWORD)EngGetTickCount();
+        dwTime = EngGetTickCount32();
     }
 
     if (wVk == VK_RMENU && (pKbdTbl->fLocaleFlags & KLLF_ALTGR))
@@ -1173,7 +1173,7 @@ IntTranslateKbdMessage(LPMSG lpMsg,
     /* Init pt, hwnd and time msg fields */
     NewMsg.pt = gpsi->ptCursor;
     NewMsg.hwnd = lpMsg->hwnd;
-    NewMsg.time = (DWORD)EngGetTickCount();
+    NewMsg.time = EngGetTickCount32();
 
     TRACE("Enter IntTranslateKbdMessage msg %s, vk %x\n",
         lpMsg->message == WM_SYSKEYDOWN ? "WM_SYSKEYDOWN" : "WM_KEYDOWN", lpMsg->wParam);

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -976,7 +976,6 @@ UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected)
     PKL pKl = NULL;
     PKBDTABLES pKbdTbl;
     PUSER_MESSAGE_QUEUE pFocusQueue;
-    LARGE_INTEGER LargeTickCount;
     DWORD dwTime;
     BOOL bExt = (pKbdInput->dwFlags & KEYEVENTF_EXTENDEDKEY) ? TRUE : FALSE;
 
@@ -1030,8 +1029,7 @@ UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected)
         dwTime = pKbdInput->time;
     else
     {
-        KeQueryTickCount(&LargeTickCount);
-        dwTime = MsqCalculateMessageTime(&LargeTickCount);
+        dwTime = (DWORD)EngGetTickCount();
     }
 
     if (wVk == VK_RMENU && (pKbdTbl->fLocaleFlags & KLLF_ALTGR))
@@ -1143,7 +1141,6 @@ IntTranslateKbdMessage(LPMSG lpMsg,
     WCHAR wch[3] = { 0 };
     MSG NewMsg = { 0 };
     PKBDTABLES pKbdTbl;
-    LARGE_INTEGER LargeTickCount;
     BOOL bResult = FALSE;
 
     switch(lpMsg->message)
@@ -1176,8 +1173,7 @@ IntTranslateKbdMessage(LPMSG lpMsg,
     /* Init pt, hwnd and time msg fields */
     NewMsg.pt = gpsi->ptCursor;
     NewMsg.hwnd = lpMsg->hwnd;
-    KeQueryTickCount(&LargeTickCount);
-    NewMsg.time = MsqCalculateMessageTime(&LargeTickCount);
+    NewMsg.time = (DWORD)EngGetTickCount();
 
     TRACE("Enter IntTranslateKbdMessage msg %s, vk %x\n",
         lpMsg->message == WM_SYSKEYDOWN ? "WM_SYSKEYDOWN" : "WM_KEYDOWN", lpMsg->wParam);

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -503,7 +503,7 @@ InitThreadCallback(PETHREAD Thread)
         goto error;
     }
 
-    ptiCurrent->timeLast = (DWORD)EngGetTickCount();
+    ptiCurrent->timeLast = EngGetTickCount32();
     ptiCurrent->MessageQueue = MsqCreateMessageQueue(ptiCurrent);
     if (ptiCurrent->MessageQueue == NULL)
     {

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -505,7 +505,7 @@ InitThreadCallback(PETHREAD Thread)
     }
 
     KeQueryTickCount(&LargeTickCount);
-    ptiCurrent->timeLast = LargeTickCount.u.LowPart;
+    ptiCurrent->timeLast = MsqCalculateMessageTime(&LargeTickCount);
 
     ptiCurrent->MessageQueue = MsqCreateMessageQueue(ptiCurrent);
     if (ptiCurrent->MessageQueue == NULL)

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -443,7 +443,6 @@ InitThreadCallback(PETHREAD Thread)
     int i;
     NTSTATUS Status = STATUS_SUCCESS;
     PTEB pTeb;
-    LARGE_INTEGER LargeTickCount;
     PRTL_USER_PROCESS_PARAMETERS ProcessParams;
 
     Process = Thread->ThreadsProcess;
@@ -504,9 +503,7 @@ InitThreadCallback(PETHREAD Thread)
         goto error;
     }
 
-    KeQueryTickCount(&LargeTickCount);
-    ptiCurrent->timeLast = MsqCalculateMessageTime(&LargeTickCount);
-
+    ptiCurrent->timeLast = (DWORD)EngGetTickCount();
     ptiCurrent->MessageQueue = MsqCreateMessageQueue(ptiCurrent);
     if (ptiCurrent->MessageQueue == NULL)
     {

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -709,7 +709,7 @@ IntDispatchMessage(PMSG pMsg)
         {
             if (ValidateTimerCallback(pti,pMsg->lParam))
             {
-                Time = (DWORD)EngGetTickCount();
+                Time = EngGetTickCount32();
                 retval = co_IntCallWindowProc((WNDPROC)pMsg->lParam,
                                               TRUE,
                                               pMsg->hwnd,
@@ -725,7 +725,7 @@ IntDispatchMessage(PMSG pMsg)
             PTIMER pTimer = FindSystemTimer(pMsg);
             if (pTimer && pTimer->pfn)
             {
-                Time = (DWORD)EngGetTickCount();
+                Time = EngGetTickCount32();
                 pTimer->pfn(pMsg->hwnd, WM_SYSTIMER, (UINT)pMsg->wParam, Time);
             }
             return 0;
@@ -829,7 +829,7 @@ co_IntPeekMessage( PMSG Msg,
 
     do
     {
-        pti->timeLast = (DWORD)EngGetTickCount();
+        pti->timeLast = EngGetTickCount32();
         pti->pcti->tickLastMsgChecked = pti->timeLast;
 
         // Post mouse moves while looping through peek messages.
@@ -1158,7 +1158,7 @@ UserPostThreadMessage( PTHREADINFO pti,
     Message.wParam = wParam;
     Message.lParam = lParam;
     Message.pt = gpsi->ptCursor;
-    Message.time = (DWORD)EngGetTickCount();
+    Message.time = EngGetTickCount32();
     MsqPostMessage(pti, &Message, FALSE, QS_POSTMESSAGE, 0, 0);
     return TRUE;
 }
@@ -1192,7 +1192,7 @@ UserPostMessage( HWND Wnd,
     Message.wParam = wParam;
     Message.lParam = lParam;
     Message.pt = gpsi->ptCursor;
-    Message.time = (DWORD)EngGetTickCount();
+    Message.time = EngGetTickCount32();
 
     if (is_pointer_message(Message.message))
     {

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -1458,7 +1458,7 @@ co_IntSendMessageTimeoutSingle( HWND hWnd,
 
     if (Status == STATUS_TIMEOUT)
     {
-        if (MsqIsHung(ptiSendTo))
+        if (0 && MsqIsHung(ptiSendTo))
         {
             TRACE("Let's go Ghost!\n");
             IntMakeHungWindowGhosted(hWnd);

--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -834,8 +834,8 @@ co_IntPeekMessage( PMSG Msg,
     do
     {
         KeQueryTickCount(&LargeTickCount);
-        pti->timeLast = LargeTickCount.u.LowPart;
-        pti->pcti->tickLastMsgChecked = LargeTickCount.u.LowPart;
+        pti->timeLast = MsqCalculateMessageTime(&LargeTickCount);
+        pti->pcti->tickLastMsgChecked = pti->timeLast;
 
         // Post mouse moves while looping through peek messages.
         if (pti->MessageQueue->QF_flags & QF_MOUSEMOVED)

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -296,7 +296,7 @@ NtUserGetThreadState(
          {
            PTHREADINFO pti;
            pti = PsGetCurrentThreadWin32Thread();
-           pti->timeLast = (DWORD)EngGetTickCount();
+           pti->timeLast = EngGetTickCount32();
            pti->pcti->tickLastMsgChecked = pti->timeLast;
          }
          break;

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -298,8 +298,8 @@ NtUserGetThreadState(
            LARGE_INTEGER LargeTickCount;
            pti = PsGetCurrentThreadWin32Thread();
            KeQueryTickCount(&LargeTickCount);
-           pti->timeLast = LargeTickCount.u.LowPart;
-           pti->pcti->tickLastMsgChecked = LargeTickCount.u.LowPart;
+           pti->timeLast = MsqCalculateMessageTime(&LargeTickCount);
+           pti->pcti->tickLastMsgChecked = pti->timeLast;
          }
          break;
 

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -295,10 +295,8 @@ NtUserGetThreadState(
       case THREADSTATE_UPTIMELASTREAD:
          {
            PTHREADINFO pti;
-           LARGE_INTEGER LargeTickCount;
            pti = PsGetCurrentThreadWin32Thread();
-           KeQueryTickCount(&LargeTickCount);
-           pti->timeLast = MsqCalculateMessageTime(&LargeTickCount);
+           pti->timeLast = (DWORD)EngGetTickCount();
            pti->pcti->tickLastMsgChecked = pti->timeLast;
          }
          break;

--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -210,9 +210,7 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
     Msg.time = pmi->time;
     if (!Msg.time)
     {
-        LARGE_INTEGER LargeTickCount;
-        KeQueryTickCount(&LargeTickCount);
-        Msg.time = MsqCalculateMessageTime(&LargeTickCount);
+        Msg.time = (DWORD)EngGetTickCount();
     }
 
     /* Do GetMouseMovePointsEx FIFO. */

--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -210,7 +210,7 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
     Msg.time = pmi->time;
     if (!Msg.time)
     {
-        Msg.time = (DWORD)EngGetTickCount();
+        Msg.time = EngGetTickCount32();
     }
 
     /* Do GetMouseMovePointsEx FIFO. */

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -555,7 +555,7 @@ IntCoalesceMouseMove(PTHREADINFO pti)
     // Force time stamp to update, keeping message time in sync.
     if (gdwMouseMoveTimeStamp == 0)
     {
-        gdwMouseMoveTimeStamp = (DWORD)EngGetTickCount();
+        gdwMouseMoveTimeStamp = EngGetTickCount32();
     }
 
     // Build mouse move message.
@@ -587,7 +587,7 @@ co_MsqInsertMouseMessage(MSG* Msg, DWORD flags, ULONG_PTR dwExtraInfo, BOOL Hook
    PUSER_MESSAGE_QUEUE MessageQueue;
    PSYSTEM_CURSORINFO CurInfo;
 
-   Msg->time = (DWORD)EngGetTickCount();
+   Msg->time = EngGetTickCount32();
 
    MouseHookData.pt.x = LOWORD(Msg->lParam);
    MouseHookData.pt.y = HIWORD(Msg->lParam);
@@ -2193,7 +2193,7 @@ co_MsqWaitForNewMessages(PTHREADINFO pti, PWND WndFilter,
 BOOL FASTCALL
 MsqIsHung(PTHREADINFO pti)
 {
-    if ((DWORD)EngGetTickCount() - pti->timeLast > MSQ_HUNG &&
+    if (EngGetTickCount32() - pti->timeLast > MSQ_HUNG &&
        !(pti->pcti->fsWakeMask & QS_INPUT) &&
        !PsGetThreadFreezeCount(pti->pEThread) &&
        !(pti->ppi->W32PF_flags & W32PF_APPSTARTING))

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -551,13 +551,11 @@ VOID FASTCALL
 IntCoalesceMouseMove(PTHREADINFO pti)
 {
     MSG Msg;
-    LARGE_INTEGER LargeTickCount;
 
     // Force time stamp to update, keeping message time in sync.
     if (gdwMouseMoveTimeStamp == 0)
     {
-       KeQueryTickCount(&LargeTickCount);
-       gdwMouseMoveTimeStamp = MsqCalculateMessageTime(&LargeTickCount);
+        gdwMouseMoveTimeStamp = (DWORD)EngGetTickCount();
     }
 
     // Build mouse move message.
@@ -581,7 +579,6 @@ IntCoalesceMouseMove(PTHREADINFO pti)
 VOID FASTCALL
 co_MsqInsertMouseMessage(MSG* Msg, DWORD flags, ULONG_PTR dwExtraInfo, BOOL Hook)
 {
-   LARGE_INTEGER LargeTickCount;
    MSLLHOOKSTRUCT MouseHookData;
 //   PDESKTOP pDesk;
    PWND pwnd, pwndDesktop;
@@ -590,8 +587,7 @@ co_MsqInsertMouseMessage(MSG* Msg, DWORD flags, ULONG_PTR dwExtraInfo, BOOL Hook
    PUSER_MESSAGE_QUEUE MessageQueue;
    PSYSTEM_CURSORINFO CurInfo;
 
-   KeQueryTickCount(&LargeTickCount);
-   Msg->time = MsqCalculateMessageTime(&LargeTickCount);
+   Msg->time = (DWORD)EngGetTickCount();
 
    MouseHookData.pt.x = LOWORD(Msg->lParam);
    MouseHookData.pt.y = HIWORD(Msg->lParam);
@@ -2197,11 +2193,7 @@ co_MsqWaitForNewMessages(PTHREADINFO pti, PWND WndFilter,
 BOOL FASTCALL
 MsqIsHung(PTHREADINFO pti)
 {
-   LARGE_INTEGER LargeTickCount;
-
-   KeQueryTickCount(&LargeTickCount);
-
-   if ((MsqCalculateMessageTime(&LargeTickCount) - pti->timeLast) > MSQ_HUNG &&
+    if ((DWORD)EngGetTickCount() - pti->timeLast > MSQ_HUNG &&
        !(pti->pcti->fsWakeMask & QS_INPUT) &&
        !PsGetThreadFreezeCount(pti->pEThread) &&
        !(pti->ppi->W32PF_flags & W32PF_APPSTARTING))

--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -2201,7 +2201,7 @@ MsqIsHung(PTHREADINFO pti)
 
    KeQueryTickCount(&LargeTickCount);
 
-   if ((LargeTickCount.u.LowPart - pti->timeLast) > MSQ_HUNG &&
+   if ((MsqCalculateMessageTime(&LargeTickCount) - pti->timeLast) > MSQ_HUNG &&
        !(pti->pcti->fsWakeMask & QS_INPUT) &&
        !PsGetThreadFreezeCount(pti->pEThread) &&
        !(pti->ppi->W32PF_flags & W32PF_APPSTARTING))

--- a/win32ss/user/ntuser/msgqueue.h
+++ b/win32ss/user/ntuser/msgqueue.h
@@ -249,12 +249,6 @@ VOID APIENTRY MsqRemoveWindowMessagesFromQueue(PWND pWindow);
 HANDLE FASTCALL IntMsqSetWakeMask(DWORD WakeMask);
 BOOL FASTCALL IntMsqClearWakeMask(VOID);
 
-static __inline LONG
-MsqCalculateMessageTime(IN PLARGE_INTEGER TickCount)
-{
-    return (LONG)(TickCount->QuadPart * (KeQueryTimeIncrement() / 10000));
-}
-
 VOID FASTCALL IdlePing(VOID);
 VOID FASTCALL IdlePong(VOID);
 BOOL FASTCALL co_MsqReplyMessage(LRESULT);

--- a/win32ss/user/ntuser/msgqueue.h
+++ b/win32ss/user/ntuser/msgqueue.h
@@ -252,7 +252,7 @@ BOOL FASTCALL IntMsqClearWakeMask(VOID);
 static __inline LONG
 MsqCalculateMessageTime(IN PLARGE_INTEGER TickCount)
 {
-    return TickCount->LowPart;
+    return (LONG)(TickCount->QuadPart * (KeQueryTimeIncrement() / 10000));
 }
 
 VOID FASTCALL IdlePing(VOID);

--- a/win32ss/user/ntuser/msgqueue.h
+++ b/win32ss/user/ntuser/msgqueue.h
@@ -252,7 +252,7 @@ BOOL FASTCALL IntMsqClearWakeMask(VOID);
 static __inline LONG
 MsqCalculateMessageTime(IN PLARGE_INTEGER TickCount)
 {
-    return (LONG)(TickCount->QuadPart * (KeQueryTimeIncrement() / 10000));
+    return TickCount->LowPart;
 }
 
 VOID FASTCALL IdlePing(VOID);

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -415,7 +415,7 @@ PostTimerMessages(PWND Window)
            Msg.message = (pTmr->flags & TMRF_SYSTEM) ? WM_SYSTIMER : WM_TIMER;
            Msg.wParam  = (WPARAM) pTmr->nID;
            Msg.lParam  = (LPARAM) pTmr->pfn;
-           Msg.time    = (DWORD)EngGetTickCount();
+           Msg.time    = EngGetTickCount32();
            // Fix all wine win:test_GetMessagePos WM_TIMER tests. See CORE-10867.
            Msg.pt      = gpsi->ptCursor;
 
@@ -453,7 +453,7 @@ ProcessTimers(VOID)
 
   TimerEnterExclusive();
   pLE = TimersListHead.Flink;
-  Time = (DWORD)EngGetTickCount();
+  Time = EngGetTickCount32();
 
   DueTime.QuadPart = (LONGLONG)(-97656); // 1024hz .9765625 ms set to 10.0 ms
 

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -399,7 +399,6 @@ PostTimerMessages(PWND Window)
   PTHREADINFO pti;
   BOOL Hit = FALSE;
   PTIMER pTmr;
-  LARGE_INTEGER TickCount;
 
   pti = PsGetCurrentThreadWin32Thread();
 
@@ -412,13 +411,11 @@ PostTimerMessages(PWND Window)
           (pTmr->pti == pti) &&
           ((pTmr->pWnd == Window) || (Window == NULL)) )
         {
-           KeQueryTickCount(&TickCount);
-
            Msg.hwnd    = (pTmr->pWnd) ? pTmr->pWnd->head.h : 0;
            Msg.message = (pTmr->flags & TMRF_SYSTEM) ? WM_SYSTIMER : WM_TIMER;
            Msg.wParam  = (WPARAM) pTmr->nID;
            Msg.lParam  = (LPARAM) pTmr->pfn;
-           Msg.time    = MsqCalculateMessageTime(&TickCount);
+           Msg.time    = (DWORD)EngGetTickCount();
            // Fix all wine win:test_GetMessagePos WM_TIMER tests. See CORE-10867.
            Msg.pt      = gpsi->ptCursor;
 
@@ -448,7 +445,7 @@ VOID
 FASTCALL
 ProcessTimers(VOID)
 {
-  LARGE_INTEGER TickCount, DueTime;
+  LARGE_INTEGER DueTime;
   LONG Time;
   PLIST_ENTRY pLE;
   PTIMER pTmr;
@@ -456,8 +453,7 @@ ProcessTimers(VOID)
 
   TimerEnterExclusive();
   pLE = TimersListHead.Flink;
-  KeQueryTickCount(&TickCount);
-  Time = MsqCalculateMessageTime(&TickCount);
+  Time = (DWORD)EngGetTickCount();
 
   DueTime.QuadPart = (LONGLONG)(-97656); // 1024hz .9765625 ms set to 10.0 ms
 


### PR DESCRIPTION
## Purpose
This PR will fix CORE-15565 and make #1245 GetMessageTime testcase successful.
JIRA issue: [CORE-15565](https://jira.reactos.org/browse/CORE-15565)

## Proposed Changes
- Erase `MsqCalculateMessageTime` function.
- Use `(DWORD)EngGetTickCount()` instead.
- Ghosting is temporarily disabled.