### PR TITLE
[USETUP][REACTOS] Check the status return value of InitDestinationPaths()

### DIFF
--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -628,18 +628,24 @@ InitDestinationPaths(
     IN PPARTENTRY PartEntry)    // FIXME: HACK!
 {
     WCHAR PathBuffer[MAX_PATH];
-
-    //
-    // TODO: Check return status values of the functions!
-    //
+    NTSTATUS Status;
 
     /* Create 'pSetupData->DestinationRootPath' string */
     RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
-    RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
-            L"\\Device\\Harddisk%lu\\Partition%lu\\",
-            DiskEntry->DiskNumber,
-            PartEntry->PartitionNumber);
-    RtlCreateUnicodeString(&pSetupData->DestinationRootPath, PathBuffer);
+    Status = RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
+                     L"\\Device\\Harddisk%lu\\Partition%lu\\",
+                     DiskEntry->DiskNumber,
+                     PartEntry->PartitionNumber);
+
+    /* Check the condition status of RtlStringCchPrintfW() */
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
+
+    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
+    Status = RtlCreateUnicodeString(&pSetupData->DestinationRootPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
     DPRINT("DestinationRootPath: %wZ\n", &pSetupData->DestinationRootPath);
 
     // FIXME! Which variable to choose?
@@ -649,23 +655,50 @@ InitDestinationPaths(
 /** Equivalent of 'NTOS_INSTALLATION::SystemArcPath' **/
     /* Create 'pSetupData->DestinationArcPath' */
     RtlFreeUnicodeString(&pSetupData->DestinationArcPath);
-    RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
-            L"multi(0)disk(0)rdisk(%lu)partition(%lu)\\",
-            DiskEntry->BiosDiskNumber,
-            PartEntry->OnDiskPartitionNumber);
-    ConcatPaths(PathBuffer, ARRAYSIZE(PathBuffer), 1, InstallationDir);
-    RtlCreateUnicodeString(&pSetupData->DestinationArcPath, PathBuffer);
+    Status = RtlStringCchPrintfW(PathBuffer, ARRAYSIZE(PathBuffer),
+                     L"multi(0)disk(0)rdisk(%lu)partition(%lu)\\",
+                     DiskEntry->BiosDiskNumber,
+                     PartEntry->OnDiskPartitionNumber);
+
+    /* Check the condition status of RtlStringCchPrintfW() */
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
+
+    Status = ConcatPaths(PathBuffer, ARRAYSIZE(PathBuffer), 1, InstallationDir);
+
+    /* Check the condition status of ConcatPaths() */
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT("ConcatPaths() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
+
+    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
+    Status = RtlCreateUnicodeString(&pSetupData->DestinationArcPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
 
 /** Equivalent of 'NTOS_INSTALLATION::SystemNtPath' **/
     /* Create 'pSetupData->DestinationPath' string */
     RtlFreeUnicodeString(&pSetupData->DestinationPath);
-    CombinePaths(PathBuffer, ARRAYSIZE(PathBuffer), 2,
-                 pSetupData->DestinationRootPath.Buffer, InstallationDir);
-    RtlCreateUnicodeString(&pSetupData->DestinationPath, PathBuffer);
+    Status = CombinePaths(PathBuffer, ARRAYSIZE(PathBuffer), 2,
+                          pSetupData->DestinationRootPath.Buffer, InstallationDir);
+
+    /* Check the condition status of CombinePaths() */
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT("CombinePaths() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
+
+    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
+    Status = RtlCreateUnicodeString(&pSetupData->DestinationPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
 
 /** Equivalent of 'NTOS_INSTALLATION::PathComponent' **/
     // FIXME: This is only temporary!! Must be removed later!
-    /***/RtlCreateUnicodeString(&pSetupData->InstallPath, InstallationDir);/***/
+    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
+    /***/Status = RtlCreateUnicodeString(&pSetupData->InstallPath, InstallationDir) ? STATUS_SUCCESS : STATUS_NO_MEMORY;/***/
 
     return STATUS_SUCCESS;
 }

--- a/base/setup/lib/setuplib.c
+++ b/base/setup/lib/setuplib.c
@@ -637,15 +637,20 @@ InitDestinationPaths(
                      DiskEntry->DiskNumber,
                      PartEntry->PartitionNumber);
 
-    /* Check the condition status of RtlStringCchPrintfW() */
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
+        DPRINT1("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
         return Status;
     }
 
-    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
     Status = RtlCreateUnicodeString(&pSetupData->DestinationRootPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("RtlCreateUnicodeString() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
+
     DPRINT("DestinationRootPath: %wZ\n", &pSetupData->DestinationRootPath);
 
     // FIXME! Which variable to choose?
@@ -660,24 +665,30 @@ InitDestinationPaths(
                      DiskEntry->BiosDiskNumber,
                      PartEntry->OnDiskPartitionNumber);
 
-    /* Check the condition status of RtlStringCchPrintfW() */
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
+        DPRINT1("RtlStringCchPrintfW() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
         return Status;
     }
 
     Status = ConcatPaths(PathBuffer, ARRAYSIZE(PathBuffer), 1, InstallationDir);
 
-    /* Check the condition status of ConcatPaths() */
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("ConcatPaths() failed with status 0x%08lx\n", Status);
+        DPRINT1("ConcatPaths() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
         return Status;
     }
 
-    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
     Status = RtlCreateUnicodeString(&pSetupData->DestinationArcPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("RtlCreateUnicodeString() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
+        return Status;
+    }
 
 /** Equivalent of 'NTOS_INSTALLATION::SystemNtPath' **/
     /* Create 'pSetupData->DestinationPath' string */
@@ -685,20 +696,36 @@ InitDestinationPaths(
     Status = CombinePaths(PathBuffer, ARRAYSIZE(PathBuffer), 2,
                           pSetupData->DestinationRootPath.Buffer, InstallationDir);
 
-    /* Check the condition status of CombinePaths() */
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("CombinePaths() failed with status 0x%08lx\n", Status);
+        DPRINT1("CombinePaths() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
+        RtlFreeUnicodeString(&pSetupData->DestinationArcPath);
         return Status;
     }
 
-    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
     Status = RtlCreateUnicodeString(&pSetupData->DestinationPath, PathBuffer) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("RtlCreateUnicodeString() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
+        RtlFreeUnicodeString(&pSetupData->DestinationArcPath);
+        return Status;
+    }
 
 /** Equivalent of 'NTOS_INSTALLATION::PathComponent' **/
     // FIXME: This is only temporary!! Must be removed later!
-    /* Status assignment to Run-Time function returning boolean values (such values are of BOOLEAN type) */
-    /***/Status = RtlCreateUnicodeString(&pSetupData->InstallPath, InstallationDir) ? STATUS_SUCCESS : STATUS_NO_MEMORY;/***/
+    Status = RtlCreateUnicodeString(&pSetupData->InstallPath, InstallationDir) ? STATUS_SUCCESS : STATUS_NO_MEMORY;
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("RtlCreateUnicodeString() failed with status 0x%08lx\n", Status);
+        RtlFreeUnicodeString(&pSetupData->DestinationRootPath);
+        RtlFreeUnicodeString(&pSetupData->DestinationArcPath);
+        RtlFreeUnicodeString(&pSetupData->DestinationPath);
+        return Status;
+    }
 
     return STATUS_SUCCESS;
 }

--- a/base/setup/reactos/drivepage.c
+++ b/base/setup/reactos/drivepage.c
@@ -33,6 +33,9 @@
 
 #include "resource.h"
 
+#define NDEBUG
+#include <debug.h>
+
 /* GLOBALS ******************************************************************/
 
 #define IDS_LIST_COLUMN_FIRST IDS_PARTITION_NAME
@@ -795,8 +798,11 @@ DisableWizNext:
                     Status = InitDestinationPaths(&pSetupData->USetupData,
                                                   NULL, // pSetupData->USetupData.InstallationDirectory,
                                                   &DiskEntry, &PartEntry);
-                    // TODO: Check Status
-                    UNREFERENCED_PARAMETER(Status);
+
+                    if (!NT_SUCCESS(Status))
+                    {
+                        DPRINT1("InitDestinationPaths() failed with status 0x%08lx\n", Status);
+                    }
 
                     break;
                 }

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3238,7 +3238,7 @@ CheckFileSystemPage(PINPUT_RECORD Ir)
 }
 
 
-static VOID
+static NTSTATUS
 BuildInstallPaths(PWSTR InstallDir,
                   PDISKENTRY DiskEntry,
                   PPARTENTRY PartEntry)
@@ -3246,11 +3246,18 @@ BuildInstallPaths(PWSTR InstallDir,
     NTSTATUS Status;
 
     Status = InitDestinationPaths(&USetupData, InstallDir, DiskEntry, PartEntry);
-    // TODO: Check Status
-    UNREFERENCED_PARAMETER(Status);
+
+    /* Check the condition status of InitDestinationPaths() */
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT("InitDestinationPaths() failed with status 0x%08lx\n", Status);
+        return Status;
+    }
 
     /* Initialize DestinationDriveLetter */
     DestinationDriveLetter = PartEntry->DriveLetter;
+
+    return STATUS_SUCCESS;
 }
 
 

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3247,10 +3247,9 @@ BuildInstallPaths(PWSTR InstallDir,
 
     Status = InitDestinationPaths(&USetupData, InstallDir, DiskEntry, PartEntry);
 
-    /* Check the condition status of InitDestinationPaths() */
     if (!NT_SUCCESS(Status))
     {
-        DPRINT("InitDestinationPaths() failed with status 0x%08lx\n", Status);
+        DPRINT1("InitDestinationPaths() failed with status 0x%08lx\n", Status);
         return Status;
     }
 


### PR DESCRIPTION
## Purpose
Currently the `InitDestinationPaths()` doesn't check the used routines inside the code and if one of those functions fail, the user won't know why did it fail.
## Proposed Changes
- Check the status conditions given by the functions inside `InitDestinationPaths()`
- Check the status values of `InitDestinationPaths()`