### PR TITLE
[SHPOLICY] Fix the missing backslash in SHRestricted

### DIFF
--- a/dll/win32/shell32/wine/shpolicy.c
+++ b/dll/win32/shell32/wine/shpolicy.c
@@ -856,6 +856,9 @@ DWORD WINAPI SHRestricted (RESTRICTIONS policy)
 	}
 
 	lstrcpyA(regstr, strRegistryPolicyA);
+#ifdef __REACTOS__
+    lstrcatA(regstr, "\\");
+#endif
 	lstrcatA(regstr, p->appstr);
 
 	/* return 0 and don't set the cache if any registry errors occur */

--- a/dll/win32/shell32/wine/shpolicy.c
+++ b/dll/win32/shell32/wine/shpolicy.c
@@ -856,9 +856,7 @@ DWORD WINAPI SHRestricted (RESTRICTIONS policy)
 	}
 
 	lstrcpyA(regstr, strRegistryPolicyA);
-#ifdef __REACTOS__
     lstrcatA(regstr, "\\");
-#endif
 	lstrcatA(regstr, p->appstr);
 
 	/* return 0 and don't set the cache if any registry errors occur */

--- a/dll/win32/shell32/wine/shpolicy.c
+++ b/dll/win32/shell32/wine/shpolicy.c
@@ -856,7 +856,7 @@ DWORD WINAPI SHRestricted (RESTRICTIONS policy)
 	}
 
 	lstrcpyA(regstr, strRegistryPolicyA);
-    lstrcatA(regstr, "\\");
+	lstrcatA(regstr, "\\");
 	lstrcatA(regstr, p->appstr);
 
 	/* return 0 and don't set the cache if any registry errors occur */


### PR DESCRIPTION
## Purpose

I ran into a problem when I tried to [implement NoSimpleStartMenu](https://github.com/reactos/reactos/pull/1258) policy for explorer.

![image](https://user-images.githubusercontent.com/25367511/51428257-222aed00-1c0a-11e9-88dd-c281b063ea0f.png)
[_(message link)_](https://github.com/reactos/reactos/pull/1258#discussion_r249244170)

There are no backslash between ``Policies`` and ``Explorer``, we need to add one.

[CORE-15666](https://jira.reactos.org/browse/CORE-15666)

## Proposed changes

- ``strcat`` backslash before ``strcat`` ``p->appstr``
