### PR TITLE
[APITESTS][WIN32KNT_APITEST] Use ok_long for NtGdiGetBitmapBits/NtGdiSetBitmapBits

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetBitmapBits.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetBitmapBits.c
@@ -13,56 +13,56 @@ START_TEST(NtGdiGetBitmapBits)
 	HBITMAP hBitmap;
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetBitmapBits(0, 0, 0) == 0);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_long(NtGdiGetBitmapBits(0, 0, 0), 0);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	/* Test NULL bitmap handle */
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetBitmapBits(0, 5, Bits) == 0);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_long(NtGdiGetBitmapBits(0, 5, Bits), 0);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	/* Test invalid bitmap handle */
 	hBitmap = (HBITMAP)CreatePen(PS_SOLID, 1, RGB(1,2,3));
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetBitmapBits(hBitmap, 5, Bits) == 0);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 5, Bits), 0);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 	DeleteObject(hBitmap);
 
 	hBitmap = CreateBitmap(3, 3, 1, 8, NULL);
 	SetLastError(ERROR_SUCCESS);
 
 	/* test NULL pointer and count buffer size != 0 */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 5, NULL) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 5, NULL), 12);
 
 	/* test NULL pointer and buffer size == 0*/
-	RTEST(NtGdiGetBitmapBits(hBitmap, 0, NULL) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 0, NULL), 12);
 
 	/* test bad pointer */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 5, (PBYTE)0x500) == 0);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 5, (PBYTE)0x500), 0);
 
 	/* Test if we can set a number of bytes between lines */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 5, Bits) == 5);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 5, Bits), 5);
 
 	/* Test alignment */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 4, Bits+1) == 4);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 4, Bits+1), 4);
 
 	/* Test 1 byte too much */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 10, Bits) == 10);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 10, Bits), 10);
 
 	/* Test one row too much */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 12, Bits) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 12, Bits), 12);
 
-	RTEST(NtGdiGetBitmapBits(hBitmap, 13, Bits) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 13, Bits), 12);
 
-	RTEST(NtGdiGetBitmapBits(hBitmap, 100, Bits) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 100, Bits), 12);
 
 	/* Test huge bytes count */
-	RTEST(NtGdiGetBitmapBits(hBitmap, 12345678, Bits) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, 12345678, Bits), 12);
 
 	/* Test negative bytes count */
-	RTEST(NtGdiGetBitmapBits(hBitmap, -5, Bits) == 12);
+	ok_long(NtGdiGetBitmapBits(hBitmap, -5, Bits), 12);
 
-	RTEST(GetLastError() == ERROR_SUCCESS);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	DeleteObject(hBitmap);
 }

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
@@ -13,7 +13,7 @@ START_TEST(NtGdiSetBitmapBits)
 	HBITMAP hBitmap;
 
 	SetLastError(ERROR_SUCCESS);
-    ok_long(NtGdiSetBitmapBits(0, 0, 0), 0);
+	ok_long(NtGdiSetBitmapBits(0, 0, 0), 0);
 	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	/* Test NULL bitnap handle */

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
@@ -13,56 +13,56 @@ START_TEST(NtGdiSetBitmapBits)
 	HBITMAP hBitmap;
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiSetBitmapBits(0, 0, 0) == 0);
-	RTEST(GetLastError() == ERROR_SUCCESS);
+    ok_long(NtGdiSetBitmapBits(0, 0, 0), 0);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	/* Test NULL bitnap handle */
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiSetBitmapBits(0, 5, Bits) == 0);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_long(NtGdiSetBitmapBits(0, 5, Bits), 0);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	/* Test invalid bitmap handle */
 	hBitmap = (HBITMAP)CreatePen(PS_SOLID, 1, RGB(1,2,3));
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiSetBitmapBits(hBitmap, 5, Bits) == 0);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 5, Bits), 0);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 	DeleteObject(hBitmap);
 
 	hBitmap = CreateBitmap(3, 3, 1, 8, NULL);
 	SetLastError(ERROR_SUCCESS);
 
 	/* test NULL pointer and count buffer size != 0 */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 5, NULL) == 0);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 5, NULL), 0);
 
 	/* test NULL pointer and buffer size == 0*/
-	RTEST(NtGdiSetBitmapBits(hBitmap, 0, NULL) == 0);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 0, NULL), 0);
 
 	/* test bad pointer */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 5, (PBYTE)0x500) == 0);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 5, (PBYTE)0x500), 0);
 
 	/* Test if we can set a number of bytes between lines */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 5, Bits) == 5);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 5, Bits), 5);
 
 	/* Test alignment */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 4, Bits+1) == 4);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 4, Bits+1), 4);
 
 	/* Test 1 byte too much */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 10, Bits) == 10);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 10, Bits), 10);
 
 	/* Test one row too much */
-	RTEST(NtGdiSetBitmapBits(hBitmap, 12, Bits) == 12);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 12, Bits), 12);
 
-	RTEST(NtGdiSetBitmapBits(hBitmap, 13, Bits) == 12);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 13, Bits), 12);
 
-	RTEST(NtGdiSetBitmapBits(hBitmap, 100, Bits) == 12);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 100, Bits), 12);
 
 	/* Test huge bytes count */
-	TEST(NtGdiSetBitmapBits(hBitmap, 12345678, Bits) == 0);
+	ok_long(NtGdiSetBitmapBits(hBitmap, 12345678, Bits), 0);
 
 	/* Test negative bytes count */
-	RTEST(NtGdiSetBitmapBits(hBitmap, -5, Bits) == 0);
+	ok_long(NtGdiSetBitmapBits(hBitmap, -5, Bits), 0);
 
-	RTEST(GetLastError() == ERROR_SUCCESS);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	DeleteObject(hBitmap);
 }


### PR DESCRIPTION
## Purpose
Improve the testcases of `NtGdiGetBitmapBits` and `NtGdiSetBitmapBits`.
JIRA issue: N/A
## Proposed changes
- Use `ok_long` macro instead of obsolete `RTEST` macro.