### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiArcInternal testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiArcInternal.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiArcInternal.c
@@ -12,28 +12,28 @@ START_TEST(NtGdiArcInternal)
 	HDC hDC = CreateDCW(L"Display",NULL,NULL,NULL);
 
 	SetLastError(ERROR_SUCCESS);
-	TEST(NtGdiArcInternal(0, 0, 0, 0, 0, 0, 0, 0, 0, 0) == FALSE);
-	TEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiArcInternal(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), FALSE);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	TEST(NtGdiArcInternal(0, hDC, 0, 0, 0, 0, 0, 0, 0, 0) == TRUE);
-	TEST(NtGdiArcInternal(1, hDC, 0, 0, 0, 0, 0, 0, 0, 0) == TRUE);
-	TEST(NtGdiArcInternal(2, hDC, 0, 0, 0, 0, 0, 0, 0, 0) == TRUE);
-	TEST(NtGdiArcInternal(3, hDC, 0, 0, 0, 0, 0, 0, 0, 0) == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
+	ok_int(NtGdiArcInternal(0, hDC, 0, 0, 0, 0, 0, 0, 0, 0), TRUE);
+	ok_int(NtGdiArcInternal(1, hDC, 0, 0, 0, 0, 0, 0, 0, 0), TRUE);
+	ok_int(NtGdiArcInternal(2, hDC, 0, 0, 0, 0, 0, 0, 0, 0), TRUE);
+	ok_int(NtGdiArcInternal(3, hDC, 0, 0, 0, 0, 0, 0, 0, 0), TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	SetLastError(ERROR_SUCCESS);
-	TEST(NtGdiArcInternal(4, hDC, 0, 0, 0, 0, 0, 0, 0, 0) == FALSE);
-	TEST(GetLastError() == ERROR_INVALID_PARAMETER);
+	ok_int(NtGdiArcInternal(4, hDC, 0, 0, 0, 0, 0, 0, 0, 0), FALSE);
+	ok_long(GetLastError(), ERROR_INVALID_PARAMETER);
 
 	SetLastError(ERROR_SUCCESS);
-	TEST(NtGdiArcInternal(4, (HDC)10, 0, 0, 0, 0, 0, 0, 0, 0) == FALSE);
-	TEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiArcInternal(4, (HDC)10, 0, 0, 0, 0, 0, 0, 0, 0), FALSE);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	TEST(NtGdiArcInternal(0, hDC, 10, 10, 0, 0, 0, 0, 0, 0) == TRUE);
-	TEST(NtGdiArcInternal(0, hDC, 10, 10, -10, -10, 0, 0, 0, 0) == TRUE);
-	TEST(NtGdiArcInternal(0, hDC, 0, 0, 0, 0, 10, 0, -10, 0) == TRUE);
+	ok_int(NtGdiArcInternal(0, hDC, 10, 10, 0, 0, 0, 0, 0, 0), TRUE);
+	ok_int(NtGdiArcInternal(0, hDC, 10, 10, -10, -10, 0, 0, 0, 0), TRUE);
+	ok_int(NtGdiArcInternal(0, hDC, 0, 0, 0, 0, 10, 0, -10, 0), TRUE);
 
 // was passiert, wenn left > right ? einfach tauschen?
 


### PR DESCRIPTION
## Purpose
Improve `NtGdiArcInternal` testcase.
JIRA issue: N/A

## Proposed changes
- Use `ok_int` and `ok_long` macros instead of obsolete `TEST` macro.