### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiBitBlt testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiBitBlt.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiBitBlt.c
@@ -18,77 +18,77 @@ START_TEST(NtGdiBitBlt)
 	/* Test NULL dc */
 	SetLastError(ERROR_SUCCESS);
 	bRet = NtGdiBitBlt((HDC)0, 0, 0, 10, 10, (HDC)0, 10, 10, SRCCOPY, 0, 0);
-	TEST(bRet == FALSE);
-	TEST(GetLastError() == ERROR_SUCCESS);
+	ok_int(bRet, FALSE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	/* Test invalid dc */
 	SetLastError(ERROR_SUCCESS);
 	bRet = NtGdiBitBlt((HDC)0x123456, 0, 0, 10, 10, (HDC)0x123456, 10, 10, SRCCOPY, 0, 0);
-	TEST(bRet == FALSE);
-	TEST(GetLastError() == ERROR_SUCCESS);
+	ok_int(bRet, FALSE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	hdc1 = NtGdiCreateCompatibleDC(0);
-	TEST(hdc1 != NULL);
+	ok_ptr(hdc1, NULL);
 
 	hdc2 = NtGdiCreateCompatibleDC(0);
-	TEST(hdc2 != NULL);
+	ok(hdc2 != NULL, "hdc2 was NULL.\n");
 
 	hbmp1 = NtGdiCreateBitmap(2, 2, 1, 32, (LPBYTE)bytes1 );
-	TEST(hbmp1 != NULL);
+	ok(hbmp1 != NULL, "hbmp1 was NULL.\n");
 	hOldBmp1 = SelectObject(hdc1, hbmp1);
 
-	TESTX(NtGdiGetPixel(hdc1, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc1, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc1, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc1, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok(NtGdiGetPixel(hdc1, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc1, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc1, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc1, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	hbmp2 = NtGdiCreateBitmap(2, 2, 1, 32, (LPBYTE)bytes2 );
-	TEST(hbmp2 != NULL);
+	ok(hbmp2 != NULL, "hbmp2 was NULL.\n");
 	hOldBmp2 = SelectObject(hdc2, hbmp2);
 
 	bRet = NtGdiBitBlt(hdc2, 1, 1, -2, -2, hdc1, 0, 0, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x00000000, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x00000000, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	bRet = NtGdiBitBlt(hdc2, 1, 1, -2, -2, hdc1, 1, 1, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	NtGdiSetPixel(hdc2, 0, 0, 0x00000000);
 
 	bRet = NtGdiBitBlt(hdc2, 1, 1, -2, -2, hdc1, 0, 0, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x00000000, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x00000000, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	bRet = NtGdiBitBlt(hdc2, 1, 1, -2, -2, hdc1, 2, 2, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x00ffffff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x00ffffff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00000000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x00000000, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00000000, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	NtGdiSetPixel(hdc2, 0, 0, 0x00000000);
 
 	bRet = NtGdiBitBlt(hdc2, 2, 2, -2, -2, hdc1, 2, 2, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	NtGdiSetPixel(hdc2, 0, 0, 0x00000000);
 	NtGdiSetPixel(hdc2, 1, 0, 0x00000000);
@@ -96,12 +96,12 @@ START_TEST(NtGdiBitBlt)
 	NtGdiSetPixel(hdc2, 1, 1, 0x00000000);
 
 	bRet = NtGdiBitBlt(hdc2, 0, 0, 2, 2, hdc1, 0, 0, SRCCOPY, 0, 0);
-	TEST(bRet == TRUE);
-	TEST(GetLastError() == ERROR_SUCCESS);
-	TESTX(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
-	TESTX(NtGdiGetPixel(hdc2, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
-	TESTX(NtGdiGetPixel(hdc2, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
-	TESTX(NtGdiGetPixel(hdc2, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
+	ok_int(bRet, TRUE);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok(NtGdiGetPixel(hdc2, 0, 0) == 0x000000ff, "Pixel[0][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 0));
+	ok(NtGdiGetPixel(hdc2, 0, 1) == 0x00ff0000, "Pixel[0][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 0, 1));
+	ok(NtGdiGetPixel(hdc2, 1, 0) == 0x0000ff00, "Pixel[1][0] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 0));
+	ok(NtGdiGetPixel(hdc2, 1, 1) == 0x00ffffff, "Pixel[1][1] 0x%08x\n", (UINT)NtGdiGetPixel(hdc2, 1, 1));
 
 	SelectObject(hdc2, hOldBmp2);
 	SelectObject(hdc1, hOldBmp1);

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiBitBlt.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiBitBlt.c
@@ -28,7 +28,7 @@ START_TEST(NtGdiBitBlt)
 	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	hdc1 = NtGdiCreateCompatibleDC(0);
-	ok_ptr(hdc1, NULL);
+	ok(hdc1 != NULL, "hdc1 was NULL.\n");
 
 	hdc2 = NtGdiCreateCompatibleDC(0);
 	ok(hdc2 != NULL, "hdc2 was NULL.\n");


### PR DESCRIPTION
## Purpose
Improve the testcase for `NtGdiBitBlt` function.
JIRA issue: N/A

## Proposed changes
- Use `ok_int`, `ok_long` and `ok` macros instead of obsolete `TEST` and `TESTX` macros.