### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiCreateCompatibleDC testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiCreateCompatibleDC.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiCreateCompatibleDC.c
@@ -29,5 +29,5 @@ START_TEST(NtGdiCreateCompatibleDC)
 	hObj = SelectObject(hDC, GetStockObject(WHITE_PEN));
 	ok_ptr(hObj, GetStockObject(BLACK_PEN));
 
-	ok_int(NtGdiDeleteObjectApp(hDC) != 0, "NtGdiDeleteObjectApp(hDC) was zero.\n");
+	ok(NtGdiDeleteObjectApp(hDC) != 0, "NtGdiDeleteObjectApp(hDC) was zero.\n");
 }

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiCreateCompatibleDC.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiCreateCompatibleDC.c
@@ -14,21 +14,20 @@ START_TEST(NtGdiCreateCompatibleDC)
 
 	/* Test if aa NULL DC is accepted */
 	hDC = NtGdiCreateCompatibleDC(NULL);
-	TEST(hDC != NULL);
+	ok(hDC != NULL, "hDC was NULL.\n");
 
 	/* We select a nwe palette. Note: SelectObject doesn't work with palettes! */
 	hObj = SelectPalette(hDC, GetStockObject(DEFAULT_PALETTE), 0);
 	/* The old palette should be GetStockObject(DEFAULT_PALETTE) */
-	TEST(hObj == GetStockObject(DEFAULT_PALETTE));
+	ok_ptr(hObj, GetStockObject(DEFAULT_PALETTE));
 
 	/* The default bitmap should be GetStockObject(21) */
 	hObj = SelectObject(hDC, GetStockObject(21));
-	TEST(hObj == GetStockObject(21));
+	ok_ptr(hObj, GetStockObject(21));
 
 	/* The default pen should be GetStockObject(BLACK_PEN) */
 	hObj = SelectObject(hDC, GetStockObject(WHITE_PEN));
-	TEST(hObj == GetStockObject(BLACK_PEN));
+	ok_ptr(hObj, GetStockObject(BLACK_PEN));
 
-	TEST(NtGdiDeleteObjectApp(hDC) != 0);
+	ok_int(NtGdiDeleteObjectApp(hDC) != 0, "NtGdiDeleteObjectApp(hDC) was zero.\n");
 }
-


### PR DESCRIPTION
## Purpose
Improve the testcase of `NtGdiCreateCompatibleDC` function.
JIRA issue: N/A

## Proposed changes
- Use `ok`, `ok_int` and `ok_ptr` macros instead of obsolete `TEST` macros.