### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiEngCreatePalette testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiEngCreatePalette.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiEngCreatePalette.c
@@ -16,7 +16,7 @@ START_TEST(NtGdiEngCreatePalette)
 	hPal = NtGdiEngCreatePalette(PAL_RGB, 3, Colors, 0xff000000, 0x00ff0000, 0x0000ff00);
 
 	ok(hPal != NULL, "hPal was NULL.\n");
-	ok_ptr((void *)GDI_HANDLE_GET_TYPE(hPal), (void *)GDI_OBJECT_TYPE_PALETTE);
+	ok_int((int)GDI_HANDLE_GET_TYPE(hPal), (int)GDI_OBJECT_TYPE_PALETTE);
 	pEntry = &GdiHandleTable[GDI_HANDLE_GET_INDEX(hPal)];
 	ok(pEntry->einfo.pobj != NULL, "pEntry->einfo.pobj was NULL.\n");
 	ok_long(pEntry->ObjectOwner.ulObj, GetCurrentProcessId());

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiEngCreatePalette.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiEngCreatePalette.c
@@ -15,12 +15,11 @@ START_TEST(NtGdiEngCreatePalette)
 
 	hPal = NtGdiEngCreatePalette(PAL_RGB, 3, Colors, 0xff000000, 0x00ff0000, 0x0000ff00);
 
-	TEST(hPal != 0);
-	TEST(GDI_HANDLE_GET_TYPE(hPal) == GDI_OBJECT_TYPE_PALETTE);
+	ok(hPal != NULL, "hPal was NULL.\n");
+	ok_ptr((void *)GDI_HANDLE_GET_TYPE(hPal), (void *)GDI_OBJECT_TYPE_PALETTE);
 	pEntry = &GdiHandleTable[GDI_HANDLE_GET_INDEX(hPal)];
-	TEST(pEntry->einfo.pobj != NULL);
-	TEST(pEntry->ObjectOwner.ulObj == GetCurrentProcessId());
-	TEST(pEntry->pUser == 0);
+	ok(pEntry->einfo.pobj != NULL, "pEntry->einfo.pobj was NULL.\n");
+	ok_long(pEntry->ObjectOwner.ulObj, GetCurrentProcessId());
+	ok_ptr(pEntry->pUser, NULL);
 	//TEST(pEntry->Type == (((UINT)hPal >> 16) | GDI_OBJECT_TYPE_PALETTE));
-
 }


### PR DESCRIPTION
## Purpose
Improve the testcase of `NtGdiEngCreatePalette` function.
JIRA issue: N/A

## Proposed changes
- Use `ok` and `ok_long` and `ok_ptr` macros instead of obsolete `TEST` macros.