### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiExtTextOutW testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiExtTextOutW.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiExtTextOutW.c
@@ -43,18 +43,16 @@ START_TEST(NtGdiExtTextOutW)
     len = wcslen(lpstr);
 
     ret = NtGdiExtTextOutW(hDC, 0, 0, 0, &rect, lpstr, len, Dx, 0);
-    TEST(ret == 1);
+    ok_int(ret, 1);
 
     ret = NtGdiExtTextOutW(hDC, 0, 0, ETO_PDY, &rect, lpstr, len, Dx, 0);
-    TEST(ret == 1);
+    ok_int(ret, 1);
 
     /* Test invalid lpDx */
     ret = NtGdiExtTextOutW(hDC, 0, 0, 0, 0, lpstr, len, (INT*)((ULONG_PTR)-1), 0);
-    TEST(ret == 0);
+    ok_int(ret, 0);
 
     /* Test alignment requirement for lpDx */
     ret = NtGdiExtTextOutW(hDC, 0, 0, 0, 0, lpstr, len, (INT*)((ULONG_PTR)Dx + 1), 0);
-    TEST(ret == 1);
-
+    ok_int(ret, 1);
 }
-


### PR DESCRIPTION
## Purpose
Improve the testcase of `NtGdiExtTextOutW` function.
JIRA issue: N/A
## Proposed changes
- Use `ok_int` macros instead of obsolete `TEST` macros.