### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiFlushUserBatch testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiFlushUserBatch.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiFlushUserBatch.c
@@ -25,7 +25,7 @@ START_TEST(NtGdiFlushUserBatch)
 
 	pRet = (PVOID)pNtGdiFlushUserBatch();
 
-	ok_ptr(pRet != NULL, "pRet was NULL.\n");
+	ok(pRet != NULL, "pRet was NULL.\n");
 	ok_ptr(pRet, &pTeb->RealClientId);
 
 	ok_long(pTeb->GdiBatchCount, 0);

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiFlushUserBatch.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiFlushUserBatch.c
@@ -21,16 +21,16 @@ START_TEST(NtGdiFlushUserBatch)
         return APISTATUS_NOT_FOUND;
 
 	pTeb = NtCurrentTeb();
-	ASSERT(pTeb);
+	ok(pTeb != NULL, "pTeb was NULL.\n");
 
 	pRet = (PVOID)pNtGdiFlushUserBatch();
 
-	TEST(pRet != 0);
-	TEST(pRet == &pTeb->RealClientId);
+	ok_ptr(pRet != NULL, "pRet was NULL.\n");
+	ok_ptr(pRet, &pTeb->RealClientId);
 
-	TEST(pTeb->GdiBatchCount == 0);
-	TEST(pTeb->GdiTebBatch.Offset == 0);
-	TEST(pTeb->GdiTebBatch.HDC == 0);
+	ok_long(pTeb->GdiBatchCount, 0);
+	ok_long(pTeb->GdiTebBatch.Offset, 0);
+	ok_ptr(pTeb->GdiTebBatch.HDC, NULL);
 
 	/* Set up some bullshit */
 	pTeb->InDbgPrint = 1;
@@ -39,11 +39,10 @@ START_TEST(NtGdiFlushUserBatch)
 	pTeb->GdiTebBatch.HDC = (HDC)123;
 
 	pRet = (PVOID)pNtGdiFlushUserBatch();
-	TEST(pRet == &pTeb->RealClientId);
+	ok_ptr(pRet, &pTeb->RealClientId);
 
-	TEST(pTeb->InDbgPrint == 0);
-	TEST(pTeb->GdiBatchCount == 12);
-	TEST(pTeb->GdiTebBatch.Offset == 0);
-	TEST(pTeb->GdiTebBatch.HDC == 0);
-
+	ok_int(pTeb->InDbgPrint, 0);
+	ok_long(pTeb->GdiBatchCount, 12);
+	ok_long(pTeb->GdiTebBatch.Offset, 0);
+	ok_ptr(pTeb->GdiTebBatch.HDC, NULL);
 }


### PR DESCRIPTION
## Purpose
Improve the testcase of `NtGdiFlushUserBatch` function.
JIRA issue: N/A

## Proposed changes

- Use `ok`, `ok_int`, `ok_long`, and `ok_ptr` macros instead of `TEST` and `ASSERT` macros.
