### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiGetFontResourceInfoInternal…

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetFontResourceInfoInternalW.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetFontResourceInfoInternalW.c
@@ -31,7 +31,7 @@ START_TEST(NtGdiGetFontResourceInfoInternalW)
 		&logfont,
 		2);
 
-	TEST(bRet != FALSE);
+	ok(bRet != FALSE, "bRet was not FALSE.\n");
 
 	printf("lfHeight = %ld\n", logfont.lfHeight);
 	printf("lfWidth = %ld\n", logfont.lfWidth);
@@ -40,4 +40,3 @@ START_TEST(NtGdiGetFontResourceInfoInternalW)
 //	RemoveFontResourceW(szFullFileName);
 
 }
-


### PR DESCRIPTION
…W testcase

## Purpose
Improve the testcase of `NtGdiGetFontResourceInfoInternalW` function.
JIRA issue: N/A
## Proposed changes
- Use `ok` macro instead of obsolete `TEST` macro.