### PR TITLE
[APITESTS][WIN32KNT_APITEST] Improve NtGdiGetRandomRgn testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetRandomRgn.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiGetRandomRgn.c
@@ -21,66 +21,66 @@ START_TEST(NtGdiGetRandomRgn)
 //	UpdateWindow(hWnd);
 	hDC = GetDC(hWnd);
 
-	ASSERT(hDC != NULL);
+	ok(hDC != NULL, "hDC was NULL.\n");
 
 	hrgn = CreateRectRgn(0,0,0,0);
 	hrgn2 = CreateRectRgn(3,3,10,10);
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn(0, hrgn, 0) == -1);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiGetRandomRgn(0, hrgn, 0), -1);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn((HDC)2345, hrgn, 1) == -1);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiGetRandomRgn((HDC)2345, hrgn, 1), -1);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn((HDC)2345, hrgn, 10) == -1);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiGetRandomRgn((HDC)2345, hrgn, 10), -1);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn((HDC)2345, (HRGN)10, 10) == -1);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiGetRandomRgn((HDC)2345, (HRGN)10, 10), -1);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn((HDC)2345, 0, 1) == -1);
-	RTEST(GetLastError() == ERROR_INVALID_HANDLE);
+	ok_int(NtGdiGetRandomRgn((HDC)2345, 0, 1), -1);
+	ok_long(GetLastError(), ERROR_INVALID_HANDLE);
 
 	SetLastError(ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn(hDC, 0, 0) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, 0, 1) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, (HRGN)-5, 0) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, (HRGN)-5, 1) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 0) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 1) == 0);
-	TEST(NtGdiGetRandomRgn(hDC, hrgn, 2) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 3) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 4) == 1);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 5) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 10) == 0);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, -10) == 0);
-	RTEST(GetLastError() == ERROR_SUCCESS);
+	ok_int(NtGdiGetRandomRgn(hDC, 0, 0), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, 0, 1), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, (HRGN)-5, 0), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, (HRGN)-5, 1), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 0), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 1), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 2), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 3), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 4), 1);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 5), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 10), 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, -10), 0);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	SelectClipRgn(hDC, hrgn2);
-	RTEST(NtGdiGetRandomRgn(hDC, 0, 1) == -1);
-	RTEST(GetLastError() == ERROR_SUCCESS);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 1) == 1);
-	RTEST(CombineRgn(hrgn, hrgn, hrgn, RGN_OR) == SIMPLEREGION);
-	RTEST(CombineRgn(hrgn, hrgn, hrgn2, RGN_XOR) == NULLREGION);
+	ok_int(NtGdiGetRandomRgn(hDC, 0, 1), -1);
+	ok_long(GetLastError(), ERROR_SUCCESS);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 1), 1);
+	ok_int(CombineRgn(hrgn, hrgn, hrgn, RGN_OR), SIMPLEREGION);
+	ok_int(CombineRgn(hrgn, hrgn, hrgn2, RGN_XOR), NULLREGION);
 
 	SetRectRgn(hrgn2,0,0,0,0);
 	SelectClipRgn(hDC, hrgn2);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 1) == 1);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 1), 1);
 
-	RTEST(CombineRgn(hrgn2, hrgn, hrgn2, RGN_XOR) == NULLREGION);
-	RTEST(CombineRgn(hrgn2, hrgn, hrgn, RGN_OR) == NULLREGION);
+	ok_int(CombineRgn(hrgn2, hrgn, hrgn2, RGN_XOR), NULLREGION);
+	ok_int(CombineRgn(hrgn2, hrgn, hrgn, RGN_OR), NULLREGION);
 
 	SelectClipRgn(hDC, NULL);
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 1) == 0);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 1), 0);
 
 
-	RTEST(NtGdiGetRandomRgn(hDC, hrgn, 4) == 1);
+	ok_int(NtGdiGetRandomRgn(hDC, hrgn, 4), 1);
 
-	RTEST(GetLastError() == ERROR_SUCCESS);
+	ok_long(GetLastError(), ERROR_SUCCESS);
 
 	ReleaseDC(hWnd, hDC);
 	DestroyWindow(hWnd);


### PR DESCRIPTION
## Purpose
Improve the testcase of `NtGdiGetRandomRgn` function.
JIRA issue: N/A
## Proposed changes
- Use `ok_int` and `ok_long` macros instead of obsolete `TEST` and `RTEST` macros.
