### PR TITLE
Make MmSection KMtest FS-Agnostic

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -174,6 +174,7 @@ add_dependencies(kmtest_drivers
     ioreadwrite_drv
     kernel32_drv
     mmmaplockedpagesspecifycache_drv
+    mmsection_drv
     ntcreatesection_drv
     poirp_drv
     tcpip_drv

--- a/modules/rostests/kmtests/include/kmt_platform.h
+++ b/modules/rostests/kmtests/include/kmt_platform.h
@@ -26,6 +26,7 @@
 #include <ndk/obfuncs.h>
 #include <ndk/sefuncs.h>
 #include <ntstrsafe.h>
+#include <strsafe.h>
 #if defined KMT_FILTER_DRIVER
 #include <fltkernel.h>
 #endif

--- a/modules/rostests/kmtests/kmtest/support.c
+++ b/modules/rostests/kmtests/kmtest/support.c
@@ -52,6 +52,23 @@ KmtUserCallbackThread(
 
         switch (RequestPacket.OperationClass)
         {
+        	case FlushLogBuffer:
+        	{
+        		LONG Offset = 0;
+    			LONG OldLength;
+        		do
+        		{
+        			DWORD BytesWritten;
+
+        			OldLength = ResultBuffer->LogBufferLength;
+
+        			if (!WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), ResultBuffer->LogBuffer + Offset, OldLength - Offset, &BytesWritten, NULL))
+        				break;
+        			Offset = OldLength;
+        		} while (InterlockedCompareExchange(&ResultBuffer->LogBufferLength, 0, OldLength) != OldLength);
+
+        		break;
+        	}
             case QueryVirtualMemory:
             {
                 SIZE_T InfoBufferSize = VirtualQuery(RequestPacket.BaseAddress, &Response.MemInfo, sizeof(Response.MemInfo));

--- a/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
+++ b/modules/rostests/kmtests/kmtest_drv/kmtest_drv.c
@@ -549,8 +549,7 @@ DriverIoControl(
  */
 PKMT_RESPONSE
 KmtUserModeCallback(
-    IN KMT_CALLBACK_INFORMATION_CLASS Operation,
-    IN PVOID Parameters)
+    _In_ PKMT_CALLBACK_REQUEST_PACKET Request)
 {
     PKMT_RESPONSE Result;
     NTSTATUS Status;
@@ -564,9 +563,8 @@ KmtUserModeCallback(
         return NULL;
 
     KeInitializeEvent(&WorkEntry->WorkDoneEvent, NotificationEvent, FALSE);
+    RtlCopyMemory(&WorkEntry->Request, Request, sizeof(*Request));
     WorkEntry->Request.RequestId = RequestId++;
-    WorkEntry->Request.OperationClass = Operation;
-    WorkEntry->Request.Parameters = Parameters;
     WorkEntry->Response = NULL;
 
     ExAcquireFastMutex(&WorkList.Lock);

--- a/modules/rostests/kmtests/ntos_mm/CMakeLists.txt
+++ b/modules/rostests/kmtests/ntos_mm/CMakeLists.txt
@@ -30,3 +30,19 @@ add_importlibs(mmmaplockedpagesspecifycache_drv ntoskrnl hal)
 add_target_compile_definitions(mmmaplockedpagesspecifycache_drv KMT_STANDALONE_DRIVER)
 #add_pch(mmmaplockedpagesspecifycache_drv ../include/kmt_test.h)
 add_rostests_file(TARGET mmmaplockedpagesspecifycache_drv)
+
+#
+# MmSection
+#
+list(APPEND MMSECTION_DRV_SOURCE
+    ../kmtest_drv/kmtest_standalone.c
+    MmSection_drv.c)
+
+add_library(mmsection_drv SHARED ${MMSECTION_DRV_SOURCE})
+set_module_type(mmsection_drv kernelmodedriver)
+target_link_libraries(mmsection_drv kmtest_printf ${PSEH_LIB})
+add_importlibs(mmsection_drv ntoskrnl hal)
+add_target_compile_definitions(mmsection_drv KMT_STANDALONE_DRIVER)
+#add_pch(mmsection_drv ../include/kmt_test.h)
+add_rostests_file(TARGET mmsection_drv)
+

--- a/modules/rostests/kmtests/ntos_mm/MmSection.c
+++ b/modules/rostests/kmtests/ntos_mm/MmSection.c
@@ -820,15 +820,15 @@ START_TEST(MmSection)
     PFILE_OBJECT FileObject1 = NULL, FileObject2 = NULL;
     OBJECT_ATTRIBUTES ObjectAttributes;
     IO_STATUS_BLOCK IoStatusBlock;
-    UNICODE_STRING FileName1 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-NtCreateSection\\MmSection.txt");
-    UNICODE_STRING FileName2 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-NtCreateSection\\MmSection.dll");
+    UNICODE_STRING FileName1 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-MmSection\\MmSection.txt");
+    UNICODE_STRING FileName2 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-MmSection\\MmSection.dll");
     LARGE_INTEGER FileOffset;
     UCHAR FileData = 0;
 
     ok(ExGetPreviousMode() == UserMode, "Previous mode is kernel mode\n");
 
     /* Start our special-purpose driver */
-    Status = KmtStartDriver(L"NtCreateSection");
+    Status = KmtStartDriver(L"MmSection");
     ok_eq_hex(Status, STATUS_SUCCESS);
 
     /* create a one-byte file that we can use */
@@ -891,7 +891,7 @@ START_TEST(MmSection)
     if (FileHandle1)
         ZwClose(FileHandle1);
 
-    Status = KmtStopDriver(L"NtCreateSection");
+    Status = KmtStopDriver(L"MmSection");
     ok_eq_hex(Status, STATUS_SUCCESS);
 
     TestPhysicalMemorySection();

--- a/modules/rostests/kmtests/ntos_mm/MmSection.c
+++ b/modules/rostests/kmtests/ntos_mm/MmSection.c
@@ -820,12 +820,17 @@ START_TEST(MmSection)
     PFILE_OBJECT FileObject1 = NULL, FileObject2 = NULL;
     OBJECT_ATTRIBUTES ObjectAttributes;
     IO_STATUS_BLOCK IoStatusBlock;
-    UNICODE_STRING FileName1 = RTL_CONSTANT_STRING(L"\\SystemRoot\\kmtest-MmSection.txt");
-    UNICODE_STRING FileName2 = RTL_CONSTANT_STRING(L"\\SystemRoot\\system32\\ntdll.dll");
+    UNICODE_STRING FileName1 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-NtCreateSection\\MmSection.txt");
+    UNICODE_STRING FileName2 = RTL_CONSTANT_STRING(L"\\Device\\Kmtest-NtCreateSection\\MmSection.dll");
     LARGE_INTEGER FileOffset;
     UCHAR FileData = 0;
 
     ok(ExGetPreviousMode() == UserMode, "Previous mode is kernel mode\n");
+
+    /* Start our special-purpose driver */
+    Status = KmtStartDriver(L"NtCreateSection");
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
     /* create a one-byte file that we can use */
     InitializeObjectAttributes(&ObjectAttributes, &FileName1, OBJ_CASE_INSENSITIVE, NULL, NULL);
     Status = ZwCreateFile(&FileHandle1, GENERIC_WRITE | SYNCHRONIZE, &ObjectAttributes, &IoStatusBlock, NULL, FILE_ATTRIBUTE_NORMAL, FILE_SHARE_READ, FILE_SUPERSEDE, FILE_NON_DIRECTORY_FILE, NULL, 0);
@@ -885,6 +890,9 @@ START_TEST(MmSection)
         ZwClose(FileHandle2);
     if (FileHandle1)
         ZwClose(FileHandle1);
+
+    Status = KmtStopDriver(L"NtCreateSection");
+    ok_eq_hex(Status, STATUS_SUCCESS);
 
     TestPhysicalMemorySection();
 }

--- a/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
+++ b/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
@@ -25,6 +25,11 @@ static FAST_IO_DISPATCH TestFastIoDispatch;
 static UNICODE_STRING InitOnCreate = RTL_CONSTANT_STRING(L"\\InitOnCreate");
 static UNICODE_STRING InitOnRW = RTL_CONSTANT_STRING(L"\\InitOnRW");
 static UNICODE_STRING InvalidInit = RTL_CONSTANT_STRING(L"\\InvalidInit");
+/*
+static UNICODE_STRING MmSection_txt = RTL_CONSTANT_STRING(L"\\MmSection.txt");
+static UNICODE_STRING MmSection_dll = RTL_CONSTANT_STRING(L"\\MmSection.dll");
+*/
+
 
 static
 BOOLEAN


### PR DESCRIPTION
## Purpose

The results of the test are dependent on the underlying filesystem.

Furthermore, I want to better test the behaviour of the kernel with regards to sections and filesystems, and this looks like the right place to start :-)

JIRA issue: [ROSTESTS-267](https://jira.reactos.org/browse/ROSTESTS-267)

## Proposed changes

Use NtCreateSection-drv as "file system" to allow better grained behaviour checks.

## TODO

Actually tune the test for actual values returned by WHS testbot.