### PR TITLE
[WIN32SS][NTGDI] Alignment probe change in NtGdiSetBitmapBits

### DIFF
--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -611,7 +611,8 @@ NtGdiSetBitmapBits(
 
     _SEH2_TRY
     {
-        ProbeForRead(pUnsafeBits, Bytes, sizeof(WORD));
+        /* NOTE: Win2k3 doesn't check WORD alignment here. */
+        ProbeForRead(pUnsafeBits, Bytes, 1);
         ret = UnsafeSetBitmapBits(psurf, Bytes, pUnsafeBits);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)


### PR DESCRIPTION
## Purpose
Don't check `WORD` alignment in `NtGdiSetBitmapBits`.
JIRA issue: [CORE-15657](https://jira.reactos.org/browse/CORE-15657)
Splitted from #1305.