### PR TITLE
[WIN32SS][NTGDI] Fix UnsafeSetBitmapBits

### DIFF
--- a/win32ss/gdi/ntgdi/bitmaps.h
+++ b/win32ss/gdi/ntgdi/bitmaps.h
@@ -46,13 +46,6 @@ GreCreateDIBitmapInternal(
 
 BOOL
 NTAPI
-UnsafeSetBitmapBits(
-    _Inout_ PSURFACE psurf,
-    _In_ ULONG cjBits,
-    _In_ const VOID *pvBits);
-
-BOOL
-NTAPI
 GreGetBitmapDimension(
     _In_ HBITMAP hBitmap,
     _Out_ LPSIZE psizDim);


### PR DESCRIPTION
## Purpose
Fix `UnsafeSetBitmapBits` function.
JIRA issue: [CORE-15657](https://jira.reactos.org/browse/CORE-15657)
Splitted from #1305.