### PR TITLE
[WIN32KNT_APITEST] NtGdiSetBitmapBits: Add tests for maximum buffer size

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiSetBitmapBits.c
@@ -83,6 +83,26 @@ START_TEST(NtGdiSetBitmapBits)
     ok_long(GetLastError(), 0xDEADFACE);
 
     SetLastError(0xDEADFACE);
+    ok_long(NtGdiSetBitmapBits(hBitmap, 0x100, Bits), 0xC);
+    ok_long(GetLastError(), 0xDEADFACE);
+
+    SetLastError(0xDEADFACE);
+    ok_long(NtGdiSetBitmapBits(hBitmap, 564, Bits), 0xC);
+    ok_long(GetLastError(), 0xDEADFACE);
+
+    SetLastError(0xDEADFACE);
+    ok_long(NtGdiSetBitmapBits(hBitmap, 565, Bits), 0);
+    ok_long(GetLastError(), 0xDEADFACE);
+
+    SetLastError(0xDEADFACE);
+    ok_long(NtGdiSetBitmapBits(hBitmap, 0x7FFF, Bits), 0);
+    ok_long(GetLastError(), 0xDEADFACE);
+
+    SetLastError(0xDEADFACE);
+    ok_long(NtGdiSetBitmapBits(hBitmap, 0x8000, Bits), 0);
+    ok_long(GetLastError(), 0xDEADFACE);
+
+    SetLastError(0xDEADFACE);
     ok_long(NtGdiSetBitmapBits(hBitmap, 0xFFFF, Bits), 0);
     ok_long(GetLastError(), 0xDEADFACE);
 


### PR DESCRIPTION
## Purpose
Improve `NtGdiSetBitmapBits` testcase by adding tests for maximum buffer size.
JIRA issue: [CORE-15657](https://jira.reactos.org/browse/CORE-15657)
