### PR TITLE
[WIN32SS][NTGDI] Fix NtGdiSetBitmapBits in buffer size

### DIFF
--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -617,6 +617,12 @@ NtGdiSetBitmapBits(
         return 0;
     }
 
+    /* 565 is confirmed value in Win2k3 */
+    if (Bytes >= 565)
+    {
+        return 0;
+    }
+
     if (GDI_HANDLE_IS_STOCKOBJ(hBitmap))
     {
         return 0;


### PR DESCRIPTION
## Purpose
Fix `NtGdiSetBitmapBits` function in buffer size checking.
JIRA issue: [CORE-15657](https://jira.reactos.org/browse/CORE-15657)

## Proposed changes
- Let it fail if buffer size was greater than 564.