### PR TITLE
[FREETYPE] Handle allocation failures in our stack-saving hacks.

### DIFF
--- a/sdk/lib/3rdparty/freetype/src/autofit/afcjk.c
+++ b/sdk/lib/3rdparty/freetype/src/autofit/afcjk.c
@@ -73,6 +73,7 @@
     /* scan the array of segments in each direction */
 #ifdef __REACTOS__
     AF_GlyphHintsRec *hints = malloc(sizeof(AF_GlyphHintsRec));
+    if (!hints) return;
 #else
     AF_GlyphHintsRec  hints[1];
 #endif
@@ -95,6 +96,9 @@
       int               dim;
 #ifdef __REACTOS__
       AF_CJKMetricsRec *dummy = malloc(sizeof(AF_CJKMetricsRec));
+      if (!dummy)
+        goto Exit;
+      {
 #else
       AF_CJKMetricsRec  dummy[1];
 #endif
@@ -274,6 +278,7 @@
       }
 #ifdef __REACTOS__
       free(dummy);
+      }
 #endif
     }
 

--- a/sdk/lib/3rdparty/freetype/src/autofit/aflatin.c
+++ b/sdk/lib/3rdparty/freetype/src/autofit/aflatin.c
@@ -64,6 +64,7 @@
     /* scan the array of segments in each direction */
 #ifdef __REACTOS__
     AF_GlyphHintsRec *hints = malloc(sizeof(AF_GlyphHintsRec));
+    if (!hints) return;
 #else
     AF_GlyphHintsRec  hints[1];
 #endif
@@ -86,6 +87,9 @@
       int                 dim;
 #ifdef __REACTOS__
       AF_LatinMetricsRec *dummy = malloc(sizeof(AF_LatinMetricsRec));
+      if (!dummy)
+        goto Exit;
+      {
 #else
       AF_LatinMetricsRec  dummy[1];
 #endif
@@ -267,6 +271,7 @@
       }
 #ifdef __REACTOS__
       free(dummy);
+      }
 #endif
     }
 

--- a/sdk/lib/3rdparty/freetype/src/autofit/afmodule.c
+++ b/sdk/lib/3rdparty/freetype/src/autofit/afmodule.c
@@ -552,6 +552,11 @@
 #ifdef __REACTOS__
     AF_GlyphHintsRec *hints = malloc(sizeof(AF_GlyphHintsRec));
     AF_LoaderRec *loader = malloc(sizeof(AF_LoaderRec));
+    if (!hints || !loader)
+    {
+        error =  FT_Err_Out_Of_Memory;
+        goto Exit;
+    }
 #else
     AF_GlyphHintsRec  hints[1];
     AF_LoaderRec      loader[1];
@@ -570,6 +575,7 @@
     af_glyph_hints_done( hints );
 
 #ifdef __REACTOS__
+Exit:
     free(hints);
     free(loader);
 #endif

--- a/sdk/lib/3rdparty/freetype/src/cid/cidgload.c
+++ b/sdk/lib/3rdparty/freetype/src/cid/cidgload.c
@@ -343,8 +343,10 @@
     FT_Error       error;
 #ifdef __REACTOS__
     T1_DecoderRec *decoder = malloc(sizeof(T1_DecoderRec));
+    if (!decoder) return FT_Err_Out_Of_Memory;
 /* Ugly but it allows us to reduce the diff */
 #define decoder (*decoder)
+    {
 #else
     T1_DecoderRec  decoder;
 #endif
@@ -533,6 +535,7 @@
 #ifdef __REACTOS__
     free(&decoder);
 #undef decoder
+    }
 #endif
     return error;
   }

--- a/sdk/lib/3rdparty/freetype/src/psaux/psintrp.c
+++ b/sdk/lib/3rdparty/freetype/src/psaux/psintrp.c
@@ -527,6 +527,7 @@
     CF2_HintMaskRec   hintMask;
 #ifdef __REACTOS__
     CF2_GlyphPathRec *glyphPath = malloc(sizeof(CF2_GlyphPathRec));
+    if (!glyphPath) return;
 /* Ugly but it allows us to reduce the diff */
 #define glyphPath (*glyphPath)
 #else
@@ -2613,12 +2614,18 @@
            */
 #ifdef __REACTOS__
           CF2_HintMapRec *counterHintMap = malloc(sizeof(CF2_HintMapRec));
+          CF2_HintMaskRec  counterMask;
+          if (!counterHintMap)
+          {
+            lastError = FT_Err_Out_Of_Memory;
+            goto exit;
+          }
 /* Ugly but it allows us to reduce the diff */
 #define counterHintMap (*counterHintMap)
 #else
           CF2_HintMapRec   counterHintMap;
-#endif
           CF2_HintMaskRec  counterMask;
+#endif
 
 
           cf2_hintmap_init( &counterHintMap,

--- a/sdk/lib/3rdparty/freetype/src/raster/ftraster.c
+++ b/sdk/lib/3rdparty/freetype/src/raster/ftraster.c
@@ -3208,6 +3208,12 @@
 #ifdef __REACTOS__
     worker = malloc(sizeof(black_TWorker));
     buffer = malloc(FT_MAX(FT_RENDER_POOL_SIZE, 2048));
+    if (!worker || !buffer)
+    {
+      free(worker);
+      free(buffer);
+      return FT_THROW( Out_Of_Memory );
+    }
 #endif
 
     ras.outline = *outline;

--- a/sdk/lib/3rdparty/freetype/src/smooth/ftgrays.c
+++ b/sdk/lib/3rdparty/freetype/src/smooth/ftgrays.c
@@ -1757,6 +1757,10 @@ typedef ptrdiff_t  FT_PtrDist;
 
 #ifdef __REACTOS__
     buffer = malloc(FT_MAX(FT_RENDER_POOL_SIZE, 2048));
+    if (!buffer)
+    {
+      return 1;
+    }
 #endif
 
     /* set up vertical bands */

--- a/sdk/lib/3rdparty/freetype/src/type1/t1gload.c
+++ b/sdk/lib/3rdparty/freetype/src/type1/t1gload.c
@@ -215,6 +215,9 @@
     FT_Error       error;
 #ifdef __REACTOS__
     T1_DecoderRec *decoder = malloc(sizeof(T1_DecoderRec));
+    if (!decoder)
+      return FT_THROW( Out_Of_Memory );
+    {
 /* Ugly but it allows us to reduce the diff */
 #define decoder (*decoder)
 #else
@@ -279,6 +282,7 @@
 #ifdef __REACTOS__
     free(&decoder);
 #undef decoder
+    }
 #endif
     return FT_Err_Ok;
   }
@@ -294,8 +298,11 @@
     T1_Face        face  = (T1_Face)t1face;
 #ifdef __REACTOS__
     T1_DecoderRec *decoder = malloc(sizeof(T1_DecoderRec));
+    if (!decoder)
+      return FT_THROW( Out_Of_Memory );
 /* Ugly but it allows us to reduce the diff */
 #define decoder (*decoder)
+    {
 #else
     T1_DecoderRec  decoder;
 #endif
@@ -358,6 +365,7 @@
 #ifdef __REACTOS__
     free(&decoder);
 #undef decoder
+    }
 #endif
     return FT_Err_Ok;
   }
@@ -373,8 +381,11 @@
     FT_Error                error;
 #ifdef __REACTOS__
     T1_DecoderRec *decoder = malloc(sizeof(T1_DecoderRec));
+    if (!decoder)
+      return FT_THROW( Out_Of_Memory );
 /* Ugly but it allows us to reduce the diff */
 #define decoder (*decoder)
+    {
 #else
     T1_DecoderRec           decoder;
 #endif
@@ -629,6 +640,7 @@
 #ifdef __REACTOS__
     free(&decoder);
 #undef decoder
+    }
 #endif
     return error;
   }


### PR DESCRIPTION
Running out of pool is likely at least during kmtest:ExPools.
There is a chance of crashing when dereferencing these null pointers -- but
worse, there's also a chance of overwriting the IVT or BDA if a VDM BIOS
call is in progress, which can lead to crashes in non-obvious places later.

JIRA issue: [CORE-15642](https://jira.reactos.org/browse/CORE-15642)