### PR TITLE
[WIN32SS][NTGDI] Use ProbeForWrite in NtGdiSetBitmapBits

### DIFF
--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -645,7 +645,7 @@ NtGdiSetBitmapBits(
     _SEH2_TRY
     {
         /* NOTE: Win2k3 doesn't check WORD alignment here. */
-        ProbeForRead(pUnsafeBits, Bytes, 1);
+        ProbeForWrite(pUnsafeBits, Bytes, 1);
         ret = UnsafeSetBitmapBits(psurf, Bytes, pUnsafeBits);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15657](https://jira.reactos.org/browse/CORE-15657) and [CORE-15695](https://jira.reactos.org/browse/CORE-15695).

## Proposed changes

- Use `ProbeForWrite` instead of `ProbeForRead`.