### PR TITLE
[OLEAUT32] Implement call_method for x64 MSVC.

### DIFF
--- a/dll/win32/oleaut32/msvc.S
+++ b/dll/win32/oleaut32/msvc.S
@@ -13,9 +13,42 @@
 .code64
 
 PUBLIC call_method
-call_method:
-    int 2ch
+FUNC call_method
+    push rbp
+    .PUSHREG rbp
+    mov rbp, rsp
+    push rsi
+    .PUSHREG rsi
+    push rdi
+    .PUSHREG rdi
+    .ENDPROLOG
+
+    mov rax, rcx
+    mov rcx, 4
+    cmp rdx, rcx
+    cmovg rcx, rdx
+    lea rdx, [rcx * 8]
+    sub rsp, rdx
+    and rsp, HEX(0FFFFFFFFFFFFFFF0)
+    mov rdi, rsp
+    mov rsi, r8
+    rep movsq
+    mov rcx, qword ptr [rsp + 0]
+    mov rdx, qword ptr [rsp + 8]
+    mov r8, qword ptr [rsp + 16]
+    mov r9, qword ptr [rsp + 24]
+    movq xmm0, qword ptr [rsp + 0]
+    movq xmm1, qword ptr [rsp + 8]
+    movq xmm2, qword ptr [rsp + 16]
+    movq xmm3, qword ptr [rsp + 24]
+    call qword ptr [rax]
+
+    lea rsp, [rbp - 16]
+    pop rdi
+    pop rsi
+    pop rbp
     ret
+ENDFUNC
 
 PUBLIC call_double_method
 call_double_method:


### PR DESCRIPTION
Code should be identical to https://github.com/reactos/reactos/blob/master/dll/win32/oleaut32/typelib.c#L6450-L6488