### PR TITLE
CORE-15446. [NTOS:MM] ExFreePoolWithTag(): Accept tag mismatch, on release build

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2558,7 +2558,9 @@ ExFreePoolWithTag(IN PVOID P,
         if (TagToFree && TagToFree != Tag)
         {
             DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
+#if DBG
             KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
+#endif
         }
 
         //
@@ -2640,7 +2642,9 @@ ExFreePoolWithTag(IN PVOID P,
     if (TagToFree && TagToFree != Tag)
     {
         DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
+#if DBG
         KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
+#endif
     }
 
     //


### PR DESCRIPTION
## Purpose

"Free" build should not BSoD on 'Freeing pool - invalid tag specified' case.

JIRA issue: [CORE-15446](https://jira.reactos.org/browse/CORE-15446)
