### PR TITLE
Fixes for upstream cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ if(POLICY CMP0058)
     cmake_policy(SET CMP0058 OLD)
 endif()
 
+if(POLICY CMP0065)
+    # Do not add flags to export symbols from executables without the ENABLE_EXPORTS target property
+    cmake_policy(SET CMP0065 NEW)
+endif()
+
 project(REACTOS)
 
 # Versioning

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -300,6 +300,9 @@ endif()
 add_executable(freeldr_pe ${FREELDR_BASE_SOURCE})
 add_executable(freeldr_pe_dbg EXCLUDE_FROM_ALL ${FREELDR_BASE_SOURCE})
 
+set_property(TARGET freeldr_pe PROPERTY ENABLE_EXPORTS TRUE)
+set_property(TARGET freeldr_pe_dbg PROPERTY ENABLE_EXPORTS TRUE)
+
 if(NOT MSVC AND SEPARATE_DBG)
     set_target_properties(freeldr_pe PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)
     set_target_properties(freeldr_pe_dbg PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)

--- a/dll/3rdparty/libtirpc/CMakeLists.txt
+++ b/dll/3rdparty/libtirpc/CMakeLists.txt
@@ -39,7 +39,6 @@ list(APPEND SOURCE
     src/gettimeofday.c
     src/key_call.c
     src/key_prot_xdr.c
-    src/libtirpc.def
     #src/makefile
     #src/Makefile.am
     src/mt_misc.c

--- a/ntoskrnl/CMakeLists.txt
+++ b/ntoskrnl/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(ntoskrnl
     guid.c
     ntoskrnl.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntoskrnl.def)
+set_property(TARGET ntoskrnl PROPERTY ENABLE_EXPORTS TRUE)
 
 if(ARCH STREQUAL "i386")
     set_entrypoint(ntoskrnl KiSystemStartup 4)

--- a/ntoskrnl/ntkrnlmp/CMakeLists.txt
+++ b/ntoskrnl/ntkrnlmp/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(ntkrnlmp
     ${REACTOS_SOURCE_DIR}/ntoskrnl/guid.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/ntoskrnl.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntkrnlmp.def)
+set_property(TARGET ntkrnlmp PROPERTY ENABLE_EXPORTS TRUE)
 
 add_target_compile_definitions(ntkrnlmp CONFIG_SMP)
 


### PR DESCRIPTION
Adds the ENABLE_EXPORTS property where needed. newer versions of cmake require this

Fixes a def file being listed twice, this triggers an issue in some unix versions of cmake where it attempts to merge two def files using a cmake command only available on windows

Related JIRA issue: [CORE-15406](https://jira.reactos.org/browse/CORE-15406)
Previous PR: https://github.com/reactos/reactos/pull/808