### PR TITLE
[FREELDR] Fix VSSolution configuring and build

### DIFF
--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -34,7 +34,7 @@ function(add_linker_script _target _linker_script_file)
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${_file_full_path}" "${_generated_file}"
         DEPENDS ${_file_full_path})
     set_source_files_properties(${_generated_file} PROPERTIES LANGUAGE "ASM" GENERATED TRUE)
-    add_asm_files(freeldr_linker_file ${_generated_file})
+    add_asm_files(${_target}_freeldr_linker_file ${_generated_file})
 
     # Generate the C module containing extra sections specifications and layout,
     # as well as comment-type linker #pragma directives.
@@ -44,10 +44,10 @@ function(add_linker_script _target _linker_script_file)
         COMMAND "${CMAKE_COMMAND}" -E copy_if_different "${_file_full_path}" "${_generated_file}"
         DEPENDS ${_file_full_path})
     set_source_files_properties(${_generated_file} PROPERTIES LANGUAGE "C" GENERATED TRUE)
-    list(APPEND freeldr_linker_file ${_generated_file})
+    list(APPEND ${_target}_freeldr_linker_file ${_generated_file})
 
     # Add both files to the sources of the target.
-    target_sources(${_target} PRIVATE ${freeldr_linker_file})
+    target_sources(${_target} PRIVATE "${${_target}_freeldr_linker_file}")
 
     # Create the additional linker response file.
     set(_generated_file "${_generated_file_path_prefix}.rsp")


### PR DESCRIPTION
`configure.cmd VSSolution` was failing due to `add_asm_files()` macro expansion.
It was using the same `freeldr_linker_file` variable name as a temporary filename base twice.

This patch uses `_target` parameter to make those variable names differ and fixes the configure step.
