### PR TITLE
[mvdm] Fix missing pointer dereference

### DIFF
--- a/subsystems/mvdm/ntvdm/console/console.c
+++ b/subsystems/mvdm/ntvdm/console/console.c
@@ -169,7 +169,7 @@ UpdateVdmMenuDisks(VOID)
 
         if (GlobalSettings.FloppyDisks[i].Length != 0 &&
             GlobalSettings.FloppyDisks[i].Buffer      &&
-            GlobalSettings.FloppyDisks[i].Buffer != L'\0')
+           *GlobalSettings.FloppyDisks[i].Buffer != L'\0')
         {
             /* Update item text */
             _snwprintf(szMenuString2, ARRAYSIZE(szMenuString2), szMenuString1, i, GlobalSettings.FloppyDisks[i].Buffer);

--- a/subsystems/mvdm/ntvdm/emulator.c
+++ b/subsystems/mvdm/ntvdm/emulator.c
@@ -592,7 +592,7 @@ BOOLEAN EmulatorInitialize(HANDLE ConsoleInput, HANDLE ConsoleOutput)
     {
         if (GlobalSettings.FloppyDisks[i].Length != 0 &&
             GlobalSettings.FloppyDisks[i].Buffer      &&
-            GlobalSettings.FloppyDisks[i].Buffer != '\0')
+           *GlobalSettings.FloppyDisks[i].Buffer != L'\0')
         {
             if (!MountDisk(FLOPPY_DISK, i, GlobalSettings.FloppyDisks[i].Buffer, FALSE))
             {
@@ -611,7 +611,7 @@ BOOLEAN EmulatorInitialize(HANDLE ConsoleInput, HANDLE ConsoleOutput)
     {
         if (GlobalSettings.HardDisks[i].Length != 0 &&
             GlobalSettings.HardDisks[i].Buffer      &&
-            GlobalSettings.HardDisks[i].Buffer != L'\0')
+           *GlobalSettings.HardDisks[i].Buffer != L'\0')
         {
             if (!MountDisk(HARD_DISK, i, GlobalSettings.HardDisks[i].Buffer, FALSE))
             {


### PR DESCRIPTION
Original code compared against the pointer value rather
than the first byte

Found while building with gcc 7.3,  oddly gcc 4.7 does not emit a warning for this