### PR TITLE
[NSLOOKUP] Fix crash in case of no network connectivity

### DIFF
--- a/base/applications/network/nslookup/nslookup.c
+++ b/base/applications/network/nslookup/nslookup.c
@@ -792,36 +792,40 @@ int main( int argc, char* argv[] )
     /* We don't know how long of a buffer it will want to return. So we'll
        pass an empty one now and let it fail only once, instead of guessing. */
     Status = GetNetworkParams( pNetInfo, &NetBufLen );
-    if( Status == ERROR_BUFFER_OVERFLOW )
+
+    if( Status != ERROR_BUFFER_OVERFLOW )
     {
-        pNetInfo = (PFIXED_INFO)HeapAlloc( ProcessHeap, 0, NetBufLen );
-        if( pNetInfo == NULL )
-        {
-            _tprintf( _T("ERROR: Out of memory\n") );
+        _tprintf( _T("Error in GetNetworkParams call\n") );
 
-            return -1;
-        }
-
-        /* For real this time. */
-        Status = GetNetworkParams( pNetInfo, &NetBufLen );
-        if( Status != NO_ERROR )
-        {
-            _tprintf( _T("Error in GetNetworkParams call\n") );
-
-            HeapFree( ProcessHeap, 0, pNetInfo );
-
-            return -2;
-        }
-
-        strncpy( State.domain, pNetInfo->DomainName, 255 );
-        strncpy( State.srchlist[0], pNetInfo->DomainName, 255 );
-        strncpy( State.DefaultServerAddress,
-                 pNetInfo->DnsServerList.IpAddress.String,
-                 15 );
-
-        HeapFree( ProcessHeap, 0, pNetInfo );
+        return -2;
     }
 
+    pNetInfo = (PFIXED_INFO)HeapAlloc( ProcessHeap, 0, NetBufLen );
+    if( pNetInfo == NULL )
+    {
+        _tprintf( _T("ERROR: Out of memory\n") );
+
+        return -1;
+    }
+
+    /* For real this time. */
+    Status = GetNetworkParams( pNetInfo, &NetBufLen );
+    if( Status != NO_ERROR )
+    {
+        _tprintf( _T("Error in GetNetworkParams call\n") );
+
+        HeapFree( ProcessHeap, 0, pNetInfo );
+
+        return -2;
+    }
+
+    strncpy( State.domain, pNetInfo->DomainName, 255 );
+    strncpy( State.srchlist[0], pNetInfo->DomainName, 255 );
+    strncpy( State.DefaultServerAddress,
+             pNetInfo->DnsServerList.IpAddress.String,
+             15 );
+
+    HeapFree( ProcessHeap, 0, pNetInfo );
 
     WSAStartup( MAKEWORD(2,2), &wsaData );
 

--- a/base/applications/network/nslookup/nslookup.c
+++ b/base/applications/network/nslookup/nslookup.c
@@ -812,15 +812,16 @@ int main( int argc, char* argv[] )
 
             return -2;
         }
+
+        strncpy( State.domain, pNetInfo->DomainName, 255 );
+        strncpy( State.srchlist[0], pNetInfo->DomainName, 255 );
+        strncpy( State.DefaultServerAddress,
+                 pNetInfo->DnsServerList.IpAddress.String,
+                 15 );
+
+        HeapFree( ProcessHeap, 0, pNetInfo );
     }
 
-    strncpy( State.domain, pNetInfo->DomainName, 255 );
-    strncpy( State.srchlist[0], pNetInfo->DomainName, 255 );
-    strncpy( State.DefaultServerAddress,
-             pNetInfo->DnsServerList.IpAddress.String,
-             15 );
-
-    HeapFree( ProcessHeap, 0, pNetInfo );
 
     WSAStartup( MAKEWORD(2,2), &wsaData );
 


### PR DESCRIPTION
Prevent nslookup.exe from crashing when executed in a ROS VM with no network
interfaces. This is due to a NULL pointer dereference occurring if
`GetNetworkParams` in `main` fails with an error other than
`ERROR_BUFFER_OVERFLOW`. In this case, `pNetInfo` remains initialized to
NULL, causing `strncpy` to crash.

## Purpose

Fixes a bug in nslookup.exe causing it to crash with a NULL pointer dereference in situations with no network connectivity.

JIRA issue: *none*

## Proposed changes

Move the entire logic that copies the results obtained from `GetNetworkParams` to the global `State` struct into the branch where the first `GetNetworkParams` call was successful but reported the desired size for `pNetInfo`. This additionally is a bit more consistent with regard to `pNetInfo` being allocated and freed within the same code path.