### PR TITLE
[LPK][GDI32] Implement LpkGetTextExtentExPoint

### DIFF
--- a/dll/win32/lpk/lpk.spec
+++ b/dll/win32/lpk/lpk.spec
@@ -5,7 +5,7 @@
 @ extern LpkEditControl
 @ stdcall LpkExtTextOut(long long long long ptr wstr long ptr long)
 @ stdcall LpkGetCharacterPlacement(long wstr long long ptr long long)
-@ stdcall LpkGetTextExtentExPoint(long long long long long long long long long)
+@ stdcall LpkGetTextExtentExPoint(long wstr long long ptr ptr ptr long long)
 @ stdcall LpkPSMTextOut(long long long wstr long long)
 @ stdcall LpkUseGDIWidthCache(long long long long long)
 @ stdcall ftsWordBreak(long long long long long)

--- a/dll/win32/lpk/ros_lpk.h
+++ b/dll/win32/lpk/ros_lpk.h
@@ -18,6 +18,7 @@
 #include <winnls.h>
 #include <usp10.h>
 #include <strsafe.h>
+#include "undocgdi.h"
 #include "wine/unicode.h"
 #include "wine/debug.h"
 
@@ -67,7 +68,6 @@ DWORD WINAPI LpkInitialize(DWORD x1);
 DWORD WINAPI LpkTabbedTextOut(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5,DWORD x6,DWORD x7,DWORD x8,DWORD x9,DWORD x10,DWORD x11,DWORD x12);
 BOOL WINAPI LpkDllInitialize (HANDLE  hDll, DWORD dwReason, LPVOID lpReserved);
 DWORD WINAPI LpkDrawTextEx(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5,DWORD x6,DWORD x7,DWORD x8,DWORD x9, DWORD x10);
-DWORD WINAPI LpkGetTextExtentExPoint(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5,DWORD x6,DWORD x7,DWORD x8,DWORD x9);
 DWORD WINAPI LpkUseGDIWidthCache(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5);
 DWORD WINAPI ftsWordBreak(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5);
 
@@ -80,6 +80,10 @@ DWORD WINAPI LpkGetCharacterPlacement(HDC hdc, LPCWSTR lpString, INT uCount, INT
                                       GCP_RESULTSW *lpResults, DWORD dwFlags, DWORD dwUnused);
 
 INT WINAPI LpkPSMTextOut(HDC hdc, int x, int y, LPCWSTR lpString, int cString, DWORD dwFlags);
+
+BOOL WINAPI LpkGetTextExtentExPoint(HDC hdc, LPCWSTR lpString, INT cString, INT nMaxExtent,
+                                    LPINT lpnFit, LPINT lpnDx, LPSIZE lpSize, DWORD dwUnused,
+                                    int unknown);
 /* bidi.c */
 
 #define WINE_GCPW_FORCE_LTR 0

--- a/dll/win32/lpk/stub.c
+++ b/dll/win32/lpk/stub.c
@@ -43,15 +43,6 @@ DWORD WINAPI LpkDrawTextEx(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5,DWORD x6
 /*
  * @unimplemented
  */
-DWORD WINAPI LpkGetTextExtentExPoint(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5,DWORD x6,DWORD x7,DWORD x8,DWORD x9)
-{
-    UNIMPLEMENTED
-    return 0;
-}
-
-/*
- * @unimplemented
- */
 DWORD WINAPI LpkUseGDIWidthCache(DWORD x1,DWORD x2,DWORD x3,DWORD x4,DWORD x5)
 {
     UNIMPLEMENTED

--- a/sdk/include/reactos/undocgdi.h
+++ b/sdk/include/reactos/undocgdi.h
@@ -30,4 +30,15 @@ BOOL
 WINAPI
 GdiDrawStream(HDC dc, ULONG l, PGDI_DRAW_STREAM pDS);
 
+BOOL
+WINAPI
+GetTextExtentExPointWPri(
+    HDC hdc,
+    LPCWSTR lpwsz, 
+    INT cwc,
+    INT dxMax, 
+    LPINT pcCh, 
+    LPINT pdxOut, 
+    LPSIZE psize);
+
 #endif

--- a/win32ss/gdi/gdi32/include/gdi32p.h
+++ b/win32ss/gdi/gdi32/include/gdi32p.h
@@ -51,9 +51,23 @@ typedef DWORD
     DWORD dwUnused
 );
 
+typedef BOOL
+(WINAPI* LPKGTEP)(
+    HDC hdc,
+    LPCWSTR lpString,
+    INT cString,
+    INT nMaxExtent,
+    LPINT lpnFit,
+    LPINT lpnDx,
+    LPSIZE lpSize,
+    DWORD dwUnused,
+    int unknown
+);
+
 extern HINSTANCE hLpk;
 extern LPKETO LpkExtTextOut;
 extern LPKGCP LpkGetCharacterPlacement;
+extern LPKGTEP LpkGetTextExtentExPoint;
 
 /* DEFINES *******************************************************************/
 
@@ -67,6 +81,7 @@ extern LPKGCP LpkGetCharacterPlacement;
 #define LPK_INIT 1
 #define LPK_ETO  2
 #define LPK_GCP  3
+#define LPK_GTEP 4
 
 /* MACRO ********************************************************************/
 

--- a/win32ss/gdi/gdi32/objects/text.c
+++ b/win32ss/gdi/gdi32/objects/text.c
@@ -296,6 +296,9 @@ GetTextExtentExPointW(
         DPRINT("nMaxExtent is invalid: %d\n", nMaxExtent);
     }
 
+    if (LoadLPK(LPK_GTEP))
+        return LpkGetTextExtentExPoint(hdc, lpszString, cchString, nMaxExtent, lpnFit, lpnDx, lpSize, 0, 0);
+
     return NtGdiGetTextExtentExW (
                hdc, (LPWSTR)lpszString, cchString, nMaxExtent, (PULONG)lpnFit, (PULONG)lpnDx, lpSize, 0 );
 }
@@ -308,14 +311,14 @@ BOOL
 WINAPI
 GetTextExtentExPointWPri(
     _In_ HDC hdc,
-    _In_reads_(cwc) LPWSTR lpwsz,
-    _In_ ULONG cwc,
-    _In_ ULONG dxMax,
-    _Out_opt_ ULONG *pcCh,
-    _Out_writes_to_opt_(cwc, *pcCh) PULONG pdxOut,
+    _In_reads_(cwc) LPCWSTR lpwsz,
+    _In_ INT cwc,
+    _In_ INT dxMax,
+    _Out_opt_ LPINT pcCh,
+    _Out_writes_to_opt_(cwc, *pcCh) LPINT pdxOut,
     _In_ LPSIZE psize)
 {
-    return NtGdiGetTextExtentExW(hdc, lpwsz, cwc, dxMax, pcCh, pdxOut, psize, 0);
+    return NtGdiGetTextExtentExW(hdc, (LPWSTR)lpwsz, cwc, dxMax, (PULONG)pcCh, (PULONG)pdxOut, psize, 0);
 }
 
 /*

--- a/win32ss/gdi/gdi32/objects/utils.c
+++ b/win32ss/gdi/gdi32/objects/utils.c
@@ -4,6 +4,7 @@
 HINSTANCE hLpk = NULL;
 LPKETO LpkExtTextOut = NULL;
 LPKGCP LpkGetCharacterPlacement = NULL;
+LPKGTEP LpkGetTextExtentExPoint = NULL;
 
 /**
  * @name CalculateColorTableSize
@@ -417,7 +418,7 @@ EnumLogFontExW2A( LPENUMLOGFONTEXA fontA, CONST ENUMLOGFONTEXW *fontW )
 * LPK.DLL loader function
 * 
 * Returns TRUE if a valid parameter was passed and loading was successful,
-* retruns FALSE otherwise.
+* returns FALSE otherwise.
 */
 BOOL WINAPI LoadLPK(INT LpkFunctionID)
 {   
@@ -448,6 +449,18 @@ BOOL WINAPI LoadLPK(INT LpkFunctionID)
                     LpkGetCharacterPlacement = (LPKGCP) GetProcAddress(hLpk, "LpkGetCharacterPlacement");
 
                 if (!LpkGetCharacterPlacement)
+                {
+                    FreeLibrary(hLpk);
+                    return FALSE;
+                }
+
+                return TRUE;
+
+            case LPK_GTEP:
+                if (!LpkGetTextExtentExPoint) // Check if the function is already loaded
+                    LpkGetTextExtentExPoint = (LPKGTEP) GetProcAddress(hLpk, "LpkGetTextExtentExPoint");
+
+                if (!LpkGetTextExtentExPoint)
                 {
                     FreeLibrary(hLpk);
                     return FALSE;


### PR DESCRIPTION
Implement and integrate LpkGetTextExtentExPoint into GDI32.
The main improvement will be that for certain texts written in complex scripts there would more correct size calculations, using data generated from USP10.
This is most noticeable with scripts that undergo ligation before being displayed such as Arabic.

Use GetTextExtentExPointWPri to forward non-complex text back to the gdi.

![ros_lpkgetextents](https://user-images.githubusercontent.com/3612577/52951620-fb87df80-338a-11e9-8b94-cbcc7b3fb34f.png)
