### PR TITLE
[FREELDR] PXE: Fix network packet size

### DIFF
--- a/boot/freeldr/freeldr/lib/fs/pxe.c
+++ b/boot/freeldr/freeldr/lib/fs/pxe.c
@@ -32,7 +32,7 @@ static CHAR _OpenFileName[128];
 static ULONG _FileSize = 0;
 static ULONG _FilePosition = 0;
 static ULONG _PacketPosition = 0;
-static UCHAR _Packet[4096];
+static UCHAR _Packet[1024]; // Should be a value which can be transferred well in one packet over the network
 static UCHAR* _CachedFile = NULL;
 static ULONG _CachedLength = 0;
 


### PR DESCRIPTION
## Purpose

PXE: Fix network packet size. 1024 bytes should fit into a single network packet. Original patch by @mifritscher.

JIRA issue: [CORE-15706](https://jira.reactos.org/browse/CORE-15706)

------
Cc @HBelusca (since the ticket in JIRA is assigned to you)