### PR TITLE
CORE-15766. [NTOS:IO] PnpRegSzToString(): RegSzLength is bytes, not wchars

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnputil.c
+++ b/ntoskrnl/io/pnpmgr/pnputil.c
@@ -175,7 +175,7 @@ PnpRegSzToString(IN PWCHAR RegSzData,
     PWCHAR p, pp;
 
     /* Find the end */
-    pp = RegSzData + RegSzLength;
+    pp = RegSzData + (RegSzLength / sizeof(WCHAR));
     for (p = RegSzData; p < pp; p++) if (!*p) break;
 
     /* Return it */


### PR DESCRIPTION
## Purpose

On behalf of Vadim Galyant.

JIRA issue: [CORE-15766](https://jira.reactos.org/browse/CORE-15766)
