### PR TITLE
[WINLOGON] Fix fallback keyboard layout flags

### DIFF
--- a/base/system/winlogon/winlogon.c
+++ b/base/system/winlogon/winlogon.c
@@ -204,7 +204,7 @@ InitKeyboardLayouts(VOID)
     if (!bRet)
     {
         /* If we failed, load US keyboard layout */
-        if (LoadKeyboardLayoutW(L"00000409", 0x04090409))
+        if (LoadKeyboardLayoutW(L"00000409", KLF_ACTIVATE | KLF_SUBSTITUTE_OK | KLF_REPLACELANG | KLF_SETFORPROCESS))
             bRet = TRUE;
     }
 


### PR DESCRIPTION
## Purpose

Fixes winlogon keyboard layout fallback flags. Previously the flags were made up from the locale identifier (409) and the result was an invalid combination of flags. This causes `NtUserLoadKeyboardLayoutEx` to fail [when checking the flags](https://github.com/reactos/reactos/blob/893a3c9d030fd8b078cbd747eeefd3f6ce57e560/win32ss/user/ntuser/kbdlayout.c#L610), resulting in an eventual boot failure.