### PR TITLE
[NTOS::Mm] Fix inverted check in MiWriteProtectSystemImage

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2389,7 +2389,7 @@ MiWriteProtectSystemImage(
     PMMPTE FirstPte, LastPte;
 
     /* Check if the registry setting is on or not */
-    if (MmEnforceWriteProtection)
+    if (MmEnforceWriteProtection == FALSE)
     {
         /* Ignore section protection */
         return;


### PR DESCRIPTION
This will reenable write protection for system images, which got accidentally disabled earlier.