### PR TITLE
[COVERITY][SETUPAPI] Release the blocks of memory when done

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -1075,7 +1075,8 @@ CM_Add_Range(
     }
     else
     {
-
+        HeapFree(GetProcessHeap(), 0, pRange);
+        UNIMPLEMENTED;
     }
 
 done:


### PR DESCRIPTION
## Purpose
`HeapAlloc()` allocates a memory block which is never freed when the function finishes the last operation. Therefore, the resources allocated in the memory from the heap must be released. 

This patch fixes a Coverity issue with 1427056 CID.