### PR TITLE
[OSK] Use the previous coordinate data of the dialog when launching

### DIFF
--- a/base/applications/osk/main.h
+++ b/base/applications/osk/main.h
@@ -1,9 +1,9 @@
 /*
  * PROJECT:         ReactOS On-Screen Keyboard
  * LICENSE:         GPL - See COPYING in the top level directory
- * FILE:            base/applications/osk/main.h
  * PURPOSE:         On screen keyboard.
- * PROGRAMMERS:     Denis ROBERT
+ * COPYRIGHT:       Denis ROBERT
+ *                  Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 #ifndef _OSKMAIN_H
@@ -26,6 +26,8 @@ typedef struct
     BOOL       bShowWarning;
     BOOL       bIsEnhancedKeyboard;
     BOOL       bSoundClick;
+    INT        PosX;
+    INT        PosY;
 } OSK_GLOBALS;
 
 /* DEFINES ********************************************************************/


### PR DESCRIPTION
## Purpose
This PR implements a feature which lets On-Screen Keyboard launching its own dialog with previous coordinate values (this can be also seen with the Windows XP's counterpart of On-Screen Keyboard).
## Presentation
**Video URL**: https://www.youtube.com/watch?v=ONQjKg6I3jo