### PR TITLE
[WIN32K] Allocate a buffer for a classname that is too long

### DIFF
--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -301,7 +301,7 @@ FontGetObject(PTEXTOBJ plfont, ULONG cjBuffer, PVOID pvBuffer)
     if (!(plfont->fl & TEXTOBJECT_INIT))
     {
         NTSTATUS Status;
-        DPRINT1("FontGetObject font not initialized!\n");
+        DPRINT("FontGetObject font not initialized!\n");
 
         Status = TextIntRealizeFont(plfont->BaseObject.hHmgr, plfont);
         if (!NT_SUCCESS(Status))


### PR DESCRIPTION

JIRA issue: [CORE-15811](https://jira.reactos.org/browse/CORE-15811)
