### PR TITLE
[ACLAYERS] Implement the ForceDXSetupSuccess shim

### DIFF
--- a/dll/appcompat/shims/genral/CMakeLists.txt
+++ b/dll/appcompat/shims/genral/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(acgenral SHARED
     ${SOURCE}
     ${CMAKE_CURRENT_BINARY_DIR}/acgenral.def)
 
-set_module_type(acgenral win32dll)
+set_module_type(acgenral win32dll ENTRYPOINT DllMain 12)
 target_link_libraries(acgenral shimlib)
-add_importlibs(acgenral uxtheme msvcrt kernel32 ntdll)
+add_importlibs(acgenral uxtheme kernel32 ntdll)
 add_cd_file(TARGET acgenral DESTINATION reactos/AppPatch FOR all)

--- a/dll/appcompat/shims/layer/CMakeLists.txt
+++ b/dll/appcompat/shims/layer/CMakeLists.txt
@@ -14,7 +14,7 @@ add_library(aclayers SHARED
     ${SOURCE}
     ${CMAKE_CURRENT_BINARY_DIR}/aclayers.def)
 
-set_module_type(aclayers win32dll)
+set_module_type(aclayers win32dll ENTRYPOINT DllMain 12)
 target_link_libraries(aclayers shimlib)
-add_importlibs(aclayers user32 msvcrt kernel32 ntdll)
+add_importlibs(aclayers user32 kernel32 ntdll)
 add_cd_file(TARGET aclayers DESTINATION reactos/AppPatch FOR all)

--- a/dll/appcompat/shims/layer/CMakeLists.txt
+++ b/dll/appcompat/shims/layer/CMakeLists.txt
@@ -5,6 +5,7 @@ spec2def(aclayers.dll layer.spec)
 
 list(APPEND SOURCE
     dispmode.c
+    forcedxsetupsuccess.c
     versionlie.c
     vmhorizon.c
     main.c

--- a/dll/appcompat/shims/layer/forcedxsetupsuccess.c
+++ b/dll/appcompat/shims/layer/forcedxsetupsuccess.c
@@ -1,0 +1,268 @@
+/*
+ * PROJECT:     ReactOS 'Layers' Shim library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     ForceDxSetupSuccess shim
+ * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <shimlib.h>
+#include "ntndk.h"
+
+typedef HMODULE(WINAPI* LOADLIBRARYAPROC)(LPCSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYWPROC)(LPCWSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYEXAPROC)(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+typedef HMODULE(WINAPI* LOADLIBRARYEXWPROC)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+typedef FARPROC(WINAPI* GETPROCADDRESSPROC)(HMODULE hModule, LPCSTR lpProcName);
+typedef BOOL   (WINAPI* FREELIBRARYPROC)(HINSTANCE hLibModule);
+
+
+#define SHIM_NS         ForceDxSetupSuccess
+#include <setup_shim.inl>
+
+
+#define DSETUPERR_SUCCESS 0
+
+INT WINAPI DirectXSetup(HWND hWnd, LPSTR lpszRootPath, DWORD dwFlags)
+{
+    SHIM_MSG("Returning DSETUPERR_SUCCESS\n");
+    return DSETUPERR_SUCCESS;
+}
+
+INT WINAPI DirectXSetupA(HWND hWnd, LPSTR lpszRootPath, DWORD dwFlags)
+{
+    SHIM_MSG("Returning DSETUPERR_SUCCESS\n");
+    return DSETUPERR_SUCCESS;
+}
+
+INT WINAPI DirectXSetupW(HWND hWnd, LPWSTR lpszRootPath, DWORD dwFlags)
+{
+    SHIM_MSG("Returning DSETUPERR_SUCCESS\n");
+    return DSETUPERR_SUCCESS;
+}
+
+INT WINAPI DirectXSetupGetVersion(DWORD *lpdwVersion, DWORD *lpdwMinorVersion)
+{
+    if (lpdwVersion)
+        *lpdwVersion = MAKELONG(7, 4);     // DirectX 7.0
+    if (lpdwMinorVersion)
+        *lpdwMinorVersion = MAKELONG(1792, 0);
+
+    return TRUE;
+}
+
+
+static
+BOOLEAN
+IsCharInAnsiString(
+    IN CHAR Char,
+    IN const STRING* MatchString)
+{
+    USHORT i;
+
+    for (i = 0; i < MatchString->Length; i++)
+    {
+        if (Char == MatchString->Buffer[i])
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+
+NTSTATUS
+NTAPI
+FindCharInAnsiString(
+    IN const STRING* SearchString,
+    IN const STRING* MatchString,
+    OUT PUSHORT Position)
+{
+    BOOLEAN Found;
+    ULONG i, Length;
+
+    *Position = 0;
+
+    /* Search */
+    Length = SearchString->Length;
+    for (i = Length - 1; (LONG)i >= 0; i--)
+    {
+        Found = IsCharInAnsiString(SearchString->Buffer[i], MatchString);
+        if (Found)
+        {
+            *Position = i;
+            return STATUS_SUCCESS;
+        }
+    }
+
+    return STATUS_NOT_FOUND;
+}
+
+
+static BOOL IsDxSetupA(const PSTRING LibraryPath)
+{
+    static const STRING DxSetupDlls[] = {
+        RTL_CONSTANT_STRING("dsetup.dll"),
+        RTL_CONSTANT_STRING("dsetup32.dll"),
+        RTL_CONSTANT_STRING("dsetup"),
+        RTL_CONSTANT_STRING("dsetup32"),
+    };
+    static const STRING PathDividerFind = RTL_CONSTANT_STRING("\\/");
+    STRING LibraryName;
+    USHORT PathDivider;
+    DWORD n;
+
+    if (!NT_SUCCESS(FindCharInAnsiString(LibraryPath, &PathDividerFind, &PathDivider)))
+        PathDivider = 0;
+
+    if (PathDivider)
+        PathDivider += sizeof(CHAR);
+
+    LibraryName.Buffer = LibraryPath->Buffer + PathDivider;
+    LibraryName.Length = LibraryPath->Length - PathDivider;
+    LibraryName.MaximumLength = LibraryPath->MaximumLength - PathDivider;
+
+    for (n = 0; n < ARRAYSIZE(DxSetupDlls); ++n)
+    {
+        if (RtlEqualString(&LibraryName, DxSetupDlls + n, TRUE))
+        {
+            SHIM_MSG("Found %Z\n", DxSetupDlls + n);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+static BOOL IsDxSetupW(PCUNICODE_STRING LibraryPath)
+{
+    static const UNICODE_STRING DxSetupDlls[] = {
+        RTL_CONSTANT_STRING(L"dsetup.dll"),
+        RTL_CONSTANT_STRING(L"dsetup32.dll"),
+        RTL_CONSTANT_STRING(L"dsetup"),
+        RTL_CONSTANT_STRING(L"dsetup32"),
+    };
+    static const UNICODE_STRING PathDividerFind = RTL_CONSTANT_STRING(L"\\/");
+    UNICODE_STRING LibraryName;
+    USHORT PathDivider;
+    DWORD n;
+
+    if (!NT_SUCCESS(RtlFindCharInUnicodeString(RTL_FIND_CHAR_IN_UNICODE_STRING_START_AT_END, LibraryPath, &PathDividerFind, &PathDivider)))
+        PathDivider = 0;
+
+    if (PathDivider)
+        PathDivider += sizeof(WCHAR);
+
+    LibraryName.Buffer = LibraryPath->Buffer + PathDivider / sizeof(WCHAR);
+    LibraryName.Length = LibraryPath->Length - PathDivider;
+    LibraryName.MaximumLength = LibraryPath->MaximumLength - PathDivider;
+
+    for (n = 0; n < ARRAYSIZE(DxSetupDlls); ++n)
+    {
+        if (RtlEqualUnicodeString(&LibraryName, DxSetupDlls + n, TRUE))
+        {
+            SHIM_MSG("Found %wZ\n", DxSetupDlls + n);
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryA)(LPCSTR lpLibFileName)
+{
+    STRING Library;
+
+    RtlInitAnsiString(&Library, lpLibFileName);
+    if (IsDxSetupA(&Library))
+        return ShimLib_Instance();
+
+    return CALL_SHIM(0, LOADLIBRARYAPROC)(lpLibFileName);
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryW)(LPCWSTR lpLibFileName)
+{
+    UNICODE_STRING Library;
+
+    RtlInitUnicodeString(&Library, lpLibFileName);
+    if (IsDxSetupW(&Library))
+        return ShimLib_Instance();
+
+    return CALL_SHIM(1, LOADLIBRARYWPROC)(lpLibFileName);
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryExA)(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    STRING Library;
+
+    RtlInitAnsiString(&Library, lpLibFileName);
+    if (IsDxSetupA(&Library))
+        return ShimLib_Instance();
+
+    return CALL_SHIM(2, LOADLIBRARYEXAPROC)(lpLibFileName, hFile, dwFlags);
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryExW)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    UNICODE_STRING Library;
+
+    RtlInitUnicodeString(&Library, lpLibFileName);
+    if (IsDxSetupW(&Library))
+        return ShimLib_Instance();
+
+    return CALL_SHIM(3, LOADLIBRARYEXWPROC)(lpLibFileName, hFile, dwFlags);
+}
+
+FARPROC WINAPI SHIM_OBJ_NAME(APIHook_GetProcAddress)(HMODULE hModule, LPCSTR lpProcName)
+{
+    static const STRING DxSetupFunctions[] = {
+        RTL_CONSTANT_STRING("DirectXSetup"),
+        RTL_CONSTANT_STRING("DirectXSetupA"),
+        RTL_CONSTANT_STRING("DirectXSetupW"),
+        RTL_CONSTANT_STRING("DirectXSetupGetVersion"),
+    };
+    static const FARPROC DxSetupRedirections[] = {
+        DirectXSetup,
+        DirectXSetupA,
+        DirectXSetupW,
+        DirectXSetupGetVersion,
+    };
+    DWORD n;
+
+    if (hModule == ShimLib_Instance() && ((ULONG_PTR)lpProcName > MAXUSHORT))
+    {
+        STRING ProcName;
+        RtlInitAnsiString(&ProcName, lpProcName);
+        for (n = 0; n < ARRAYSIZE(DxSetupFunctions); ++n)
+        {
+            if (RtlEqualString(&ProcName, DxSetupFunctions + n, TRUE))
+            {
+                SHIM_MSG("Intercepted %Z\n", DxSetupFunctions + n);
+                return DxSetupRedirections[n];
+            }
+        }
+    }
+    return CALL_SHIM(4, GETPROCADDRESSPROC)(hModule, lpProcName);
+}
+
+BOOL WINAPI SHIM_OBJ_NAME(APIHook_FreeLibrary)(HINSTANCE hLibModule)
+{
+    if (hLibModule == ShimLib_Instance())
+    {
+        SHIM_MSG("Intercepted\n");
+        return TRUE;
+    }
+
+    return CALL_SHIM(5, FREELIBRARYPROC)(hLibModule);
+}
+
+
+#define SHIM_NUM_HOOKS  6
+#define SHIM_SETUP_HOOKS \
+    SHIM_HOOK(0, "KERNEL32.DLL", "LoadLibraryA", SHIM_OBJ_NAME(APIHook_LoadLibraryA)) \
+    SHIM_HOOK(1, "KERNEL32.DLL", "LoadLibraryW", SHIM_OBJ_NAME(APIHook_LoadLibraryW)) \
+    SHIM_HOOK(2, "KERNEL32.DLL", "LoadLibraryExA", SHIM_OBJ_NAME(APIHook_LoadLibraryExA)) \
+    SHIM_HOOK(3, "KERNEL32.DLL", "LoadLibraryExW", SHIM_OBJ_NAME(APIHook_LoadLibraryExW)) \
+    SHIM_HOOK(4, "KERNEL32.DLL", "GetProcAddress", SHIM_OBJ_NAME(APIHook_GetProcAddress)) \
+    SHIM_HOOK(5, "KERNEL32.DLL", "FreeLibrary", SHIM_OBJ_NAME(APIHook_FreeLibrary))
+
+#include <implement_shim.inl>

--- a/dll/appcompat/shims/shimlib/shimlib.c
+++ b/dll/appcompat/shims/shimlib/shimlib.c
@@ -23,18 +23,20 @@ typedef struct UsedShim
 
 
 ULONG g_ShimEngDebugLevel = 0xffffffff;
+static HINSTANCE g_ShimLib_hInstance;
 static HANDLE g_ShimLib_Heap;
 static PSLIST_HEADER g_UsedShims;
 
 void ShimLib_Init(HINSTANCE hInstance)
 {
+    g_ShimLib_hInstance = hInstance;
     g_ShimLib_Heap = HeapCreate(0, 0x10000, 0);
 
     g_UsedShims = (PSLIST_HEADER)ShimLib_ShimMalloc(sizeof(SLIST_HEADER));
     RtlInitializeSListHead(g_UsedShims);
 }
 
-void ShimLib_Deinit()
+void ShimLib_Deinit(VOID)
 {
     // Is this a good idea?
     HeapDestroy(g_ShimLib_Heap);
@@ -48,6 +50,11 @@ PVOID ShimLib_ShimMalloc(SIZE_T dwSize)
 void ShimLib_ShimFree(PVOID pData)
 {
     HeapFree(g_ShimLib_Heap, 0, pData);
+}
+
+HINSTANCE ShimLib_Instance(VOID)
+{
+    return g_ShimLib_hInstance;
 }
 
 PCSTR ShimLib_StringNDuplicateA(PCSTR szString, SIZE_T stringLengthIncludingNullTerm)

--- a/dll/appcompat/shims/shimlib/shimlib.h
+++ b/dll/appcompat/shims/shimlib/shimlib.h
@@ -28,7 +28,7 @@ VOID ShimLib_ShimFree(PVOID pData);
 PCSTR ShimLib_StringDuplicateA(PCSTR szString);
 PCSTR ShimLib_StringNDuplicateA(PCSTR szString, SIZE_T stringLength);
 BOOL ShimLib_StrAEqualsW(PCSTR szString, PCWSTR wszString);
-
+HINSTANCE ShimLib_Instance(VOID);
 
 /* Forward events to generic handlers */
 VOID ShimLib_Init(HINSTANCE hInstance);

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -215,6 +215,10 @@
             <SHIM NAME="DisableThemes">
                 <DLLFILE>acgenral.dll</DLLFILE>
             </SHIM>
+            <SHIM NAME="ForceDXSetupSuccess">
+                <DLLFILE>aclayers.dll</DLLFILE>
+                <DESCRIPTION>Some application using an older version of DirectX may encounter problems when calling LoadLibrary or GetProcAddress to use DSETUP.DLL or DSETUP32.DLL</DESCRIPTION>
+            </SHIM>
             <SHIM NAME="IgnoreFreeLibrary">
                 <DLLFILE>acgenral.dll</DLLFILE>
             </SHIM>
@@ -239,10 +243,12 @@
 
         <LAYER NAME="WIN95">
             <SHIM_REF NAME="Win95VersionLie" />
+            <SHIM_REF NAME="ForceDXSetupSuccess" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN98">
             <SHIM_REF NAME="Win98VersionLie" />
+            <SHIM_REF NAME="ForceDXSetupSuccess" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="NT4SP5">
@@ -362,6 +368,9 @@
 
         <LAYER NAME="DisableThemes">
             <SHIM_REF NAME="DisableThemes" />
+        </LAYER>
+        <LAYER NAME="ForceDXSetupSuccess">
+            <SHIM_REF NAME="ForceDXSetupSuccess" />
         </LAYER>
         <LAYER NAME="VMHorizonSetup">
             <!-- ProductId: {7051C96D-AA61-4D83-AF37-646E82D616ED} -->

--- a/modules/rostests/apitests/appshim/CMakeLists.txt
+++ b/modules/rostests/apitests/appshim/CMakeLists.txt
@@ -3,6 +3,7 @@ add_definitions(-D__ROS_LONG64__)
 
 list(APPEND SOURCE
     dispmode.c
+    forcedxsetup.c
     genral_hooks.c
     ignorefreelib.c
     layer_hooks.c

--- a/modules/rostests/apitests/appshim/forcedxsetup.c
+++ b/modules/rostests/apitests/appshim/forcedxsetup.c
@@ -1,0 +1,226 @@
+/*
+ * PROJECT:     appshim_apitest
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for ForceDxSetupSuccess shim
+ * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
+#include <windows.h>
+#include "wine/test.h"
+
+#include "appshim_apitest.h"
+
+static HMODULE g_hShimDll;
+static HMODULE g_hSentinelModule = (HMODULE)&g_hShimDll;  /* Not a valid hmodule, so a nice sentinel */
+static tGETHOOKAPIS pGetHookAPIs;
+
+static INT (WINAPI *DirectXSetupGetVersion)(DWORD *lpdwVersion, DWORD *lpdwMinorVersion);
+
+
+typedef HMODULE(WINAPI* LOADLIBRARYAPROC)(PCSTR);
+typedef HMODULE(WINAPI* LOADLIBRARYWPROC)(PCWSTR);
+typedef FARPROC(WINAPI* GETPROCADDRESSPROC)(HMODULE, PCSTR);
+typedef BOOL(WINAPI* FREELIBRARYPROC)(HMODULE);
+
+
+static HMODULE WINAPI my_LoadLibraryA(PCSTR Name)
+{
+    return g_hSentinelModule;
+}
+
+static void test_LoadLibraryA(PHOOKAPI hook)
+{
+    LOADLIBRARYAPROC proc;
+
+    ok_str(hook->LibraryName, "KERNEL32.DLL");
+    hook->OriginalFunction = my_LoadLibraryA;
+    proc = hook->ReplacementFunction;
+
+    /* Original function is not called */
+    ok_ptr(proc("dsetup"), g_hShimDll);
+    ok_ptr(proc("dsetup.dll"), g_hShimDll);
+    ok_ptr(proc("DSETUP.DLL"), g_hShimDll);
+    ok_ptr(proc("DSeTuP.DlL"), g_hShimDll);
+
+    ok_ptr(proc("dsetup32"), g_hShimDll);
+    ok_ptr(proc("dsetup32.dll"), g_hShimDll);
+    ok_ptr(proc("DSETUP32.DLL"), g_hShimDll);
+    ok_ptr(proc("DSeTuP32.DlL"), g_hShimDll);
+
+    ok_ptr(proc("c:\\bogus/dsetup"), g_hShimDll);
+    ok_ptr(proc("c:\\bogus\\dsetup.dll"), g_hShimDll);
+    ok_ptr(proc("c:/bogus/DSETUP.DLL"), g_hShimDll);
+    ok_ptr(proc("c:\\bogus\\DSeTuP.DlL"), g_hShimDll);
+
+    ok_ptr(proc("////////////////////dsetup32"), g_hShimDll);
+    ok_ptr(proc("\\\\\\\\\\\\\\dsetup32.dll"), g_hShimDll);
+    ok_ptr(proc("xxxxxxxxxxx\\DSETUP32.DLL"), g_hShimDll);
+    ok_ptr(proc("xxxxxxxxxxx//DSeTuP32.DlL"), g_hShimDll);
+
+    /* Original function is called */
+    ok_ptr(proc(NULL), g_hSentinelModule);
+    ok_ptr(proc("dsetup\\something"), g_hSentinelModule);
+    ok_ptr(proc("dsetup.dl"), g_hSentinelModule);
+    ok_ptr(proc("c:\\DSETUP.DLL."), g_hSentinelModule);
+    ok_ptr(proc("DSeTuP.D"), g_hSentinelModule);
+}
+
+static HMODULE WINAPI my_LoadLibraryW(PCWSTR Name)
+{
+    return g_hSentinelModule;
+}
+
+static void test_LoadLibraryW(PHOOKAPI hook)
+{
+    LOADLIBRARYWPROC proc;
+
+    ok_str(hook->LibraryName, "KERNEL32.DLL");
+
+    hook->OriginalFunction = my_LoadLibraryW;
+    proc = hook->ReplacementFunction;
+
+    /* Original function is not called */
+    ok_ptr(proc(L"dsetup"), g_hShimDll);
+    ok_ptr(proc(L"dsetup.dll"), g_hShimDll);
+    ok_ptr(proc(L"DSETUP.DLL"), g_hShimDll);
+    ok_ptr(proc(L"DSeTuP.DlL"), g_hShimDll);
+
+    ok_ptr(proc(L"dsetup32"), g_hShimDll);
+    ok_ptr(proc(L"dsetup32.dll"), g_hShimDll);
+    ok_ptr(proc(L"DSETUP32.DLL"), g_hShimDll);
+    ok_ptr(proc(L"DSeTuP32.DlL"), g_hShimDll);
+
+    ok_ptr(proc(L"c:\\bogus/dsetup"), g_hShimDll);
+    ok_ptr(proc(L"c:\\bogus\\dsetup.dll"), g_hShimDll);
+    ok_ptr(proc(L"c:/bogus/DSETUP.DLL"), g_hShimDll);
+    ok_ptr(proc(L"c:\\bogus\\DSeTuP.DlL"), g_hShimDll);
+
+    ok_ptr(proc(L"////////////////////dsetup32"), g_hShimDll);
+    ok_ptr(proc(L"\\\\\\\\\\\\\\dsetup32.dll"), g_hShimDll);
+    ok_ptr(proc(L"xxxxxxxxxxx\\DSETUP32.DLL"), g_hShimDll);
+    ok_ptr(proc(L"xxxxxxxxxxx//DSeTuP32.DlL"), g_hShimDll);
+
+    /* Original function is called */
+    ok_ptr(proc(NULL), g_hSentinelModule);
+    ok_ptr(proc(L"dsetup\\something"), g_hSentinelModule);
+    ok_ptr(proc(L"dsetup.dl"), g_hSentinelModule);
+    ok_ptr(proc(L"c:\\DSETUP.DLL."), g_hSentinelModule);
+    ok_ptr(proc(L"DSeTuP.D"), g_hSentinelModule);
+}
+
+static void test_GetProcAddress(PHOOKAPI hook)
+{
+    GETPROCADDRESSPROC proc;
+    DWORD n;
+    PCSTR Functions[] = {
+        "DirectXSetup",
+        "DirectXSetupA",
+        "DirectXSetupW",
+        "DirectXSetupGetVersion",
+        /* And not case sensitive? */
+        "directxsetup",
+        "DIRECTXSETUPA",
+        "DiReCtXsEtUpW",
+        NULL
+    };
+    HMODULE mod = GetModuleHandleA("kernel32.dll");
+
+    ok_str(hook->LibraryName, "KERNEL32.DLL");
+    hook->OriginalFunction = GetProcAddress;    /* Some versions seem to call GetProcAddress regardless of what is put here.. */
+    proc = hook->ReplacementFunction;
+
+    ok_ptr(proc(mod, "CreateFileA"), GetProcAddress(mod, "CreateFileA"));
+    ok_ptr(proc(g_hShimDll, "CreateFileA"), NULL);
+
+    for (n = 0; Functions[n]; ++n)
+    {
+        FARPROC fn = proc(g_hShimDll, Functions[n]);
+        ok(fn != NULL, "Got NULL for %s\n", Functions[n]);
+        /* And yet, no export! */
+        ok_ptr(GetProcAddress(g_hShimDll, Functions[n]), NULL);
+    }
+
+    /* Not every function is shimmed */
+    ok_ptr(proc(g_hShimDll, "DirectXSetupShowEULA"), NULL);
+    /* Retrieve a pointer for our next test */
+    DirectXSetupGetVersion = (PVOID)proc(g_hShimDll, "DirectXSetupGetVersion");
+}
+
+static int g_NumShim = 0;
+static int g_NumSentinel = 0;
+static int g_NumCalls = 0;
+BOOL WINAPI my_FreeLibrary(HMODULE module)
+{
+    if (module == g_hSentinelModule)
+        ++g_NumSentinel;
+    else if (module == g_hShimDll)
+        ++g_NumShim;
+    ++g_NumCalls;
+    return 33;
+}
+
+static void test_FreeLibrary(PHOOKAPI hook)
+{
+    FREELIBRARYPROC proc;
+
+    ok_str(hook->LibraryName, "KERNEL32.DLL");
+    hook->OriginalFunction = my_FreeLibrary;
+    proc = hook->ReplacementFunction;
+
+    ok_int(proc(NULL), 33);
+    ok_int(proc(NULL), 33);
+    ok_int(proc(g_hSentinelModule), 33);
+    ok_int(proc(g_hSentinelModule), 33);
+    ok_int(proc(g_hShimDll), TRUE);
+    ok_int(proc(g_hShimDll), TRUE);
+
+    ok_int(g_NumShim, 0);
+    ok_int(g_NumSentinel, 2);
+    ok_int(g_NumCalls, 4);
+}
+
+
+START_TEST(forcedxsetup)
+{
+    DWORD num_shims = 0, n;
+    PHOOKAPI hook;
+
+    if (!LoadShimDLL(L"aclayers.dll", &g_hShimDll, &pGetHookAPIs))
+        return;
+
+    hook = pGetHookAPIs("", L"ForceDxSetupSuccess", &num_shims);
+
+    ok(hook != NULL, "Expected hook to be a valid pointer\n");
+    ok(num_shims == 6, "Expected num_shims to be 6, was: %u\n", num_shims);
+
+    if (!hook || !num_shims)
+        return;
+
+    for (n = 0; n < num_shims; ++n)
+    {
+        if (!_stricmp(hook[n].FunctionName, "LoadLibraryA"))
+            test_LoadLibraryA(hook + n);
+        else if (!_stricmp(hook[n].FunctionName, "LoadLibraryW"))
+            test_LoadLibraryW(hook + n);
+        else if (!_stricmp(hook[n].FunctionName, "GetProcAddress"))
+            test_GetProcAddress(hook + n);
+        else if (!_stricmp(hook[n].FunctionName, "FreeLibrary"))
+            test_FreeLibrary(hook + n);
+    }
+
+    ok(DirectXSetupGetVersion != NULL, "No DirectXSetupGetVersion\n");
+    if (DirectXSetupGetVersion)
+    {
+        DWORD dwVersion = 0xdeadbeef;
+        DWORD dwMinorVersion = 0xbeefdead;
+        INT Res = DirectXSetupGetVersion(&dwVersion, &dwMinorVersion);
+        ok_int(Res, 1);
+        ok_hex(dwVersion, MAKELONG(7, 4));     // DirectX 7.0
+        ok_hex(dwMinorVersion, MAKELONG(1792, 0));
+
+        Res = DirectXSetupGetVersion(NULL, NULL);
+        ok_int(Res, 1);
+    }
+}

--- a/modules/rostests/apitests/appshim/layer_hooks.c
+++ b/modules/rostests/apitests/appshim/layer_hooks.c
@@ -27,12 +27,24 @@ typedef struct expect_shim_data
 {
     const WCHAR* ShimName;
     DWORD MinVersion;
-    expect_shim_hook hooks[4];
+    expect_shim_hook hooks[6];
 } expect_shim_data;
 
 
 static expect_shim_data data[] =
 {
+    {
+        L"ForceDXSetupSuccess",
+        0,
+        {
+            { "KERNEL32.DLL", "LoadLibraryA" },
+            { "KERNEL32.DLL", "LoadLibraryW" },
+            { "KERNEL32.DLL", "LoadLibraryExA" },
+            { "KERNEL32.DLL", "LoadLibraryExW" },
+            { "KERNEL32.DLL", "GetProcAddress" },
+            { "KERNEL32.DLL", "FreeLibrary" },
+        }
+    },
     {
         L"VerifyVersionInfoLite",
         0,

--- a/modules/rostests/apitests/appshim/testlist.c
+++ b/modules/rostests/apitests/appshim/testlist.c
@@ -4,6 +4,7 @@
 #include <wine/test.h>
 
 extern void func_dispmode(void);
+extern void func_forcedxsetup(void);
 extern void func_genral_hooks(void);
 extern void func_ignorefreelib(void);
 extern void func_layer_hooks(void);
@@ -12,6 +13,7 @@ extern void func_versionlie(void);
 const struct test winetest_testlist[] =
 {
     { "dispmode", func_dispmode },
+    { "forcedxsetup", func_forcedxsetup },
     { "genral_hooks", func_genral_hooks },
     { "ignorefreelib", func_ignorefreelib },
     { "layer_hooks", func_layer_hooks },


### PR DESCRIPTION
## Purpose

This shim is used on older installers that try to install DirectX,
but encounter errors doing so with the bundled setup.

JIRA issue: [CORE-15814](https://jira.reactos.org/browse/CORE-15814)
