### PR TITLE
[SETUPAPI] Use ClassInstallReserved field instead of Reserved to store a pointer.

### DIFF
--- a/dll/win32/setupapi/devinst.c
+++ b/dll/win32/setupapi/devinst.c
@@ -5233,7 +5233,7 @@ SetupDiRegisterCoDeviceInstallers(
         if (!Result)
             goto cleanup;
 
-        SelectedDriver = (struct DriverInfoElement *)InstallParams.Reserved;
+        SelectedDriver = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
         if (SelectedDriver == NULL)
         {
             SetLastError(ERROR_NO_DRIVER_SELECTED);
@@ -5436,7 +5436,7 @@ SetupDiInstallDevice(
         goto cleanup;
     }
 
-    SelectedDriver = (struct DriverInfoElement *)InstallParams.Reserved;
+    SelectedDriver = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
     if (SelectedDriver == NULL)
     {
         SetLastError(ERROR_NO_DRIVER_SELECTED);

--- a/dll/win32/setupapi/driver.c
+++ b/dll/win32/setupapi/driver.c
@@ -1247,7 +1247,7 @@ SetupDiDestroyDriverInfoList(
                  driverInfo = CONTAINING_RECORD(ListEntry, struct DriverInfoElement, ListEntry);
                  DestroyDriverInfoElement(driverInfo);
             }
-            InstallParams.Reserved = 0;
+            InstallParams.ClassInstallReserved = 0;
             InstallParams.Flags &= ~(DI_DIDCLASS | DI_MULTMFGS);
             InstallParams.FlagsEx &= ~DI_FLAGSEX_DIDINFOLIST;
             ret = SetupDiSetDeviceInstallParamsW(DeviceInfoSet, NULL, &InstallParams);
@@ -1265,14 +1265,14 @@ SetupDiDestroyDriverInfoList(
             {
                  ListEntry = RemoveHeadList(&deviceInfo->DriverListHead);
                  driverInfo = CONTAINING_RECORD(ListEntry, struct DriverInfoElement, ListEntry);
-                 if ((PVOID)InstallParamsSet.Reserved == driverInfo)
+                 if ((PVOID)InstallParamsSet.ClassInstallReserved == driverInfo)
                  {
-                     InstallParamsSet.Reserved = 0;
+                     InstallParamsSet.ClassInstallReserved = 0;
                      SetupDiSetDeviceInstallParamsW(DeviceInfoSet, NULL, &InstallParamsSet);
                  }
                  DestroyDriverInfoElement(driverInfo);
             }
-            InstallParams.Reserved = 0;
+            InstallParams.ClassInstallReserved = 0;
             InstallParams.Flags &= ~DI_DIDCOMPAT;
             InstallParams.FlagsEx &= ~DI_FLAGSEX_DIDCOMPATINFO;
             ret = SetupDiSetDeviceInstallParamsW(DeviceInfoSet, DeviceInfoData, &InstallParams);
@@ -1503,7 +1503,7 @@ SetupDiGetSelectedDriverW(
         if (SetupDiGetDeviceInstallParamsW(DeviceInfoSet, DeviceInfoData, &InstallParams))
         {
             struct DriverInfoElement *driverInfo;
-            driverInfo = (struct DriverInfoElement *)InstallParams.Reserved;
+            driverInfo = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
             if (driverInfo == NULL)
                 SetLastError(ERROR_NO_DRIVER_SELECTED);
             else
@@ -1613,12 +1613,12 @@ SetupDiSetSelectedDriverW(
 
         if (DeviceInfoData)
         {
-            pDriverInfo = (struct DriverInfoElement **)&((struct DeviceInfo *)DeviceInfoData->Reserved)->InstallParams.Reserved;
+            pDriverInfo = (struct DriverInfoElement **)&((struct DeviceInfo *)DeviceInfoData->Reserved)->InstallParams.ClassInstallReserved;
             ListHead = &((struct DeviceInfo *)DeviceInfoData->Reserved)->DriverListHead;
         }
         else
         {
-            pDriverInfo = (struct DriverInfoElement **)&((struct DeviceInfoSet *)DeviceInfoSet)->InstallParams.Reserved;
+            pDriverInfo = (struct DriverInfoElement **)&((struct DeviceInfoSet *)DeviceInfoSet)->InstallParams.ClassInstallReserved;
             ListHead = &((struct DeviceInfoSet *)DeviceInfoSet)->DriverListHead;
         }
 
@@ -2032,7 +2032,7 @@ SetupDiGetDriverInstallParamsW(
         if (SetupDiGetDeviceInstallParamsW(DeviceInfoSet, DeviceInfoData, &InstallParams))
         {
             struct DriverInfoElement *driverInfo;
-            driverInfo = (struct DriverInfoElement *)InstallParams.Reserved;
+            driverInfo = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
             if (driverInfo == NULL)
                 SetLastError(ERROR_NO_DRIVER_SELECTED);
             else
@@ -2106,9 +2106,9 @@ SetupDiInstallDriverFiles(
         SetLastError(ERROR_INVALID_HANDLE);
     else if (DeviceInfoData && DeviceInfoData->cbSize != sizeof(SP_DEVINFO_DATA))
         SetLastError(ERROR_INVALID_USER_BUFFER);
-    else if (DeviceInfoData && ((struct DeviceInfo *)DeviceInfoData->Reserved)->InstallParams.Reserved == 0)
+    else if (DeviceInfoData && ((struct DeviceInfo *)DeviceInfoData->Reserved)->InstallParams.ClassInstallReserved == 0)
         SetLastError(ERROR_NO_DRIVER_SELECTED);
-    else if (!DeviceInfoData && ((struct DeviceInfoSet *)DeviceInfoSet)->InstallParams.Reserved == 0)
+    else if (!DeviceInfoData && ((struct DeviceInfoSet *)DeviceInfoSet)->InstallParams.ClassInstallReserved == 0)
         SetLastError(ERROR_NO_DRIVER_SELECTED);
     else
     {
@@ -2125,7 +2125,7 @@ SetupDiInstallDriverFiles(
         if (!ret)
             goto done;
 
-        SelectedDriver = (struct DriverInfoElement *)InstallParams.Reserved;
+        SelectedDriver = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
         if (!SelectedDriver)
         {
             SetLastError(ERROR_NO_DRIVER_SELECTED);

--- a/dll/win32/setupapi/interface.c
+++ b/dll/win32/setupapi/interface.c
@@ -454,7 +454,7 @@ SetupDiInstallDeviceInterfaces(
         if (!Result)
             goto cleanup;
 
-        SelectedDriver = (struct DriverInfoElement *)InstallParams.Reserved;
+        SelectedDriver = (struct DriverInfoElement *)InstallParams.ClassInstallReserved;
         if (SelectedDriver == NULL)
         {
             SetLastError(ERROR_NO_DRIVER_SELECTED);


### PR DESCRIPTION
The Reserved field is ULONG and we need ULONG_PTR. ClassInstallReserved was unused so far. I have no idea whether this is correct, but it cannot be more incorrect than what we had.