### PR TITLE
[NETAPI32] Fix NetUserEnum to work on x64

### DIFF
--- a/dll/win32/netapi32/netapi32.c
+++ b/dll/win32/netapi32/netapi32.c
@@ -26,6 +26,8 @@ BOOL WINAPI DllMain (HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 
     switch (fdwReason) {
         case DLL_PROCESS_ATTACH:
+            InitializeListHead(&g_EnumContextListHead);
+            InitializeCriticalSection(&g_EnumContextListLock);
             DisableThreadLibraryCalls(hinstDLL);
             NetBIOSInit();
             NetBTInit();

--- a/dll/win32/netapi32/netapi32.h
+++ b/dll/win32/netapi32/netapi32.h
@@ -29,6 +29,9 @@
 #include "nbnamecache.h"
 #include "netbios.h"
 
+extern LIST_ENTRY g_EnumContextListHead;
+extern CRITICAL_SECTION g_EnumContextListLock;
+
 NET_API_STATUS
 WINAPI
 NetpNtStatusToApiStatus(NTSTATUS Status);


### PR DESCRIPTION
The previous implementation used the resume_handle parameter to return a pointer to the active enumeration context, but resume_handle is a DWORD. To support 64 bit pointers, the enumeration context is inserted into a global linked list and given a unique 32 bit value as identifier for later lookup.
The way the function is implemented, leaking a data structure while the MSDN description does not indicate that, seems a little questionable in general, but that is something that I leave to the original author to investigate.
