### PR TITLE
Implement IgnoreLoadLibrary & shimeng fixes

### DIFF
--- a/dll/appcompat/apphelp/shimeng.c
+++ b/dll/appcompat/apphelp/shimeng.c
@@ -1142,10 +1142,13 @@ VOID SeiInit(PUNICODE_STRING ProcessImage, HSDB hsdb, SDBQUERYRESULT* pQuery)
             SHIMENG_INFO("Using SHIM \"%S!%S\"\n", DllName, ShimName);
 
             /* Ask this shim what hooks it needs (and pass along the commandline) */
+            dwHookCount = 0;
             pHookApi = pShimModuleInfo->pGetHookAPIs(AnsiCommandLine.Buffer, ShimName, &dwHookCount);
             SHIMENG_INFO("GetHookAPIs returns %d hooks for DLL \"%wZ\" SHIM \"%S\"\n", dwHookCount, &UnicodeDllName, ShimName);
-            if (dwHookCount)
+            if (dwHookCount && pHookApi)
                 pShimInfo = SeiAppendHookInfo(pShimModuleInfo, pHookApi, dwHookCount, ShimName);
+            else
+                dwHookCount = 0;
 
             /* If this shim has hooks, create the include / exclude lists */
             if (pShimInfo)

--- a/dll/appcompat/apphelp/shimeng.h
+++ b/dll/appcompat/apphelp/shimeng.h
@@ -23,6 +23,8 @@ typedef struct _ARRAY
 typedef struct _SHIMINFO *PSHIMINFO;
 typedef struct _SHIMMODULE *PSHIMMODULE;
 
+typedef struct tagHOOKAPIEX *PHOOKAPIEX;
+
 /* Shims know this structure as HOOKAPI, with 2 reserved members (the last 2). */
 typedef struct tagHOOKAPIEX
 {
@@ -31,8 +33,8 @@ typedef struct tagHOOKAPIEX
     PVOID ReplacementFunction;
     PVOID OriginalFunction;
     PSHIMINFO pShimInfo;
-    PVOID Unused;
-} HOOKAPIEX, *PHOOKAPIEX;
+    PHOOKAPIEX ApiLink;
+} HOOKAPIEX;
 
 C_ASSERT(sizeof(HOOKAPIEX) == sizeof(HOOKAPI));
 C_ASSERT(offsetof(HOOKAPIEX, pShimInfo) == offsetof(HOOKAPI, Reserved));

--- a/dll/appcompat/shims/layer/CMakeLists.txt
+++ b/dll/appcompat/shims/layer/CMakeLists.txt
@@ -6,6 +6,7 @@ spec2def(aclayers.dll layer.spec)
 list(APPEND SOURCE
     dispmode.c
     forcedxsetupsuccess.c
+    ignoreloadlibrary.c
     versionlie.c
     vmhorizon.c
     main.c

--- a/dll/appcompat/shims/layer/forcedxsetupsuccess.c
+++ b/dll/appcompat/shims/layer/forcedxsetupsuccess.c
@@ -19,7 +19,7 @@ typedef FARPROC(WINAPI* GETPROCADDRESSPROC)(HMODULE hModule, LPCSTR lpProcName);
 typedef BOOL   (WINAPI* FREELIBRARYPROC)(HINSTANCE hLibModule);
 
 
-#define SHIM_NS         ForceDxSetupSuccess
+#define SHIM_NS         ForceDXSetupSuccess
 #include <setup_shim.inl>
 
 

--- a/dll/appcompat/shims/layer/ignoreloadlibrary.c
+++ b/dll/appcompat/shims/layer/ignoreloadlibrary.c
@@ -1,0 +1,80 @@
+/*
+ * PROJECT:     ReactOS 'Layers' Shim library
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     IgnoreLoadLibrary shim
+ * COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <shimlib.h>
+#include "ntndk.h"
+
+typedef HMODULE(WINAPI* LOADLIBRARYAPROC)(LPCSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYEXAPROC)(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+typedef HMODULE(WINAPI* LOADLIBRARYWPROC)(LPCWSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYEXWPROC)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+
+
+#define SHIM_NS         IgnoreLoadLibrary
+#include <setup_shim.inl>
+
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryA)(LPCSTR lpLibFileName)
+{
+    HMODULE Module;
+    DWORD dwOldErrorMode;
+
+    dwOldErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    Module = CALL_SHIM(0, LOADLIBRARYAPROC)(lpLibFileName);
+    SetErrorMode(dwOldErrorMode);
+
+    return Module;
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryExA)(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    HMODULE Module;
+    DWORD dwOldErrorMode;
+
+    dwOldErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    Module = CALL_SHIM(1, LOADLIBRARYEXAPROC)(lpLibFileName, hFile, dwFlags);
+    SetErrorMode(dwOldErrorMode);
+
+    return Module;
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryW)(LPCWSTR lpLibFileName)
+{
+    HMODULE Module;
+    DWORD dwOldErrorMode;
+
+    dwOldErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    Module = CALL_SHIM(2, LOADLIBRARYWPROC)(lpLibFileName);
+    SetErrorMode(dwOldErrorMode);
+
+    return Module;
+}
+
+HMODULE WINAPI SHIM_OBJ_NAME(APIHook_LoadLibraryExW)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags)
+{
+    HMODULE Module;
+    DWORD dwOldErrorMode;
+
+    dwOldErrorMode = SetErrorMode(SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX);
+    Module = CALL_SHIM(3, LOADLIBRARYEXWPROC)(lpLibFileName, hFile, dwFlags);
+    SetErrorMode(dwOldErrorMode);
+
+    return Module;
+}
+
+
+#define SHIM_NUM_HOOKS  4
+#define SHIM_SETUP_HOOKS \
+    SHIM_HOOK(0, "KERNEL32.DLL", "LoadLibraryA", SHIM_OBJ_NAME(APIHook_LoadLibraryA)) \
+    SHIM_HOOK(1, "KERNEL32.DLL", "LoadLibraryExA", SHIM_OBJ_NAME(APIHook_LoadLibraryExA)) \
+    SHIM_HOOK(2, "KERNEL32.DLL", "LoadLibraryW", SHIM_OBJ_NAME(APIHook_LoadLibraryW)) \
+    SHIM_HOOK(3, "KERNEL32.DLL", "LoadLibraryExW", SHIM_OBJ_NAME(APIHook_LoadLibraryExW))
+
+#include <implement_shim.inl>

--- a/dll/appcompat/shims/shimlib/shimlib.c
+++ b/dll/appcompat/shims/shimlib/shimlib.c
@@ -69,9 +69,9 @@ PCSTR ShimLib_StringDuplicateA(PCSTR szString)
     return ShimLib_StringNDuplicateA(szString, lstrlenA(szString) + 1);
 }
 
-BOOL ShimLib_StrAEqualsW(PCSTR szString, PCWSTR wszString)
+BOOL ShimLib_StrAEqualsWNC(PCSTR szString, PCWSTR wszString)
 {
-    while (*szString == *wszString)
+    while (toupper(*szString) == towupper(*wszString))
     {
         if (!*szString)
             return TRUE;
@@ -116,7 +116,7 @@ PHOOKAPI WINAPI ShimLib_GetHookAPIs(IN LPCSTR szCommandLine, IN LPCWSTR wszShimN
     {
         if (ps->GetHookAPIs != NULL && ps->ShimName != NULL)
         {
-            if (ShimLib_StrAEqualsW(ps->ShimName, wszShimName))
+            if (ShimLib_StrAEqualsWNC(ps->ShimName, wszShimName))
             {
                 pUsedShim shim = (pUsedShim)ShimLib_ShimMalloc(sizeof(UsedShim));
                 shim->pShim = ps;

--- a/dll/appcompat/shims/shimlib/shimlib.h
+++ b/dll/appcompat/shims/shimlib/shimlib.h
@@ -27,7 +27,7 @@ PVOID ShimLib_ShimMalloc(SIZE_T dwSize);
 VOID ShimLib_ShimFree(PVOID pData);
 PCSTR ShimLib_StringDuplicateA(PCSTR szString);
 PCSTR ShimLib_StringNDuplicateA(PCSTR szString, SIZE_T stringLength);
-BOOL ShimLib_StrAEqualsW(PCSTR szString, PCWSTR wszString);
+BOOL ShimLib_StrAEqualsWNC(PCSTR szString, PCWSTR wszString);
 HINSTANCE ShimLib_Instance(VOID);
 
 /* Forward events to generic handlers */

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -222,6 +222,9 @@
             <SHIM NAME="IgnoreFreeLibrary">
                 <DLLFILE>acgenral.dll</DLLFILE>
             </SHIM>
+            <SHIM NAME="IgnoreLoadLibrary">
+                <DLLFILE>aclayers.dll</DLLFILE>
+            </SHIM>
             <SHIM NAME="VMHorizonSetup">
                 <DLLFILE>aclayers.dll</DLLFILE>
             </SHIM>
@@ -244,11 +247,13 @@
         <LAYER NAME="WIN95">
             <SHIM_REF NAME="Win95VersionLie" />
             <SHIM_REF NAME="ForceDXSetupSuccess" />
+            <SHIM_REF NAME="IgnoreLoadLibrary" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN98">
             <SHIM_REF NAME="Win98VersionLie" />
             <SHIM_REF NAME="ForceDXSetupSuccess" />
+            <SHIM_REF NAME="IgnoreLoadLibrary" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="NT4SP5">

--- a/modules/rostests/apitests/appshim/CMakeLists.txt
+++ b/modules/rostests/apitests/appshim/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND SOURCE
     forcedxsetup.c
     genral_hooks.c
     ignorefreelib.c
+    ignoreloadlib.c
     layer_hooks.c
     versionlie.c
     testlist.c

--- a/modules/rostests/apitests/appshim/ignoreloadlib.c
+++ b/modules/rostests/apitests/appshim/ignoreloadlib.c
@@ -1,0 +1,301 @@
+/*
+* PROJECT:     appshim_apitest
+* LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+* PURPOSE:     Tests for IgnoreLoadLibrary shim
+* COPYRIGHT:   Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+*/
+
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
+#include <windows.h>
+#include <ntndk.h>
+#include "wine/test.h"
+
+#include "appshim_apitest.h"
+
+static DWORD g_WinVersion;
+static tGETHOOKAPIS pGetHookAPIs;
+static HMODULE g_hSentinelModule = (HMODULE)&pGetHookAPIs;  /* Not a valid hmodule, so a nice sentinel */
+static HMODULE g_h123 = (HMODULE)123;
+static HMODULE g_h111 = (HMODULE)111;
+static HMODULE g_h0 = (HMODULE)0;
+
+typedef HMODULE(WINAPI* LOADLIBRARYAPROC)(LPCSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYWPROC)(LPCWSTR lpLibFileName);
+typedef HMODULE(WINAPI* LOADLIBRARYEXAPROC)(LPCSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+typedef HMODULE(WINAPI* LOADLIBRARYEXWPROC)(LPCWSTR lpLibFileName, HANDLE hFile, DWORD dwFlags);
+
+
+UINT
+WINAPI
+GetErrorMode(VOID)
+{
+    NTSTATUS Status;
+    UINT ErrMode;
+
+    /* Query the current setting */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDefaultHardErrorMode,
+                                       &ErrMode,
+                                       sizeof(ErrMode),
+                                       NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        /* Fail if we couldn't query */
+        return 0;
+    }
+
+    /* Check if NOT failing critical errors was requested */
+    if (ErrMode & SEM_FAILCRITICALERRORS)
+    {
+        /* Mask it out, since the native API works differently */
+        ErrMode &= ~SEM_FAILCRITICALERRORS;
+    }
+    else
+    {
+        /* OR it if the caller didn't, due to different native semantics */
+        ErrMode |= SEM_FAILCRITICALERRORS;
+    }
+
+    /* Return the mode */
+    return ErrMode;
+}
+
+static HMODULE WINAPI my_LoadLibraryA(PCSTR Name)
+{
+    DWORD dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == (SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX),
+       "Unexpected error mode: 0x%x\n", dwErrorMode);
+    return g_hSentinelModule;
+}
+
+static HMODULE WINAPI my_LoadLibraryExA(PCSTR Name, HANDLE hFile, DWORD dwFlags)
+{
+    DWORD dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == (SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX),
+       "Unexpected error mode: 0x%x\n", dwErrorMode);
+    return g_hSentinelModule;
+}
+
+static HMODULE WINAPI my_LoadLibraryW(PCWSTR Name)
+{
+    DWORD dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == (SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX),
+       "Unexpected error mode: 0x%x\n", dwErrorMode);
+    return g_hSentinelModule;
+}
+
+static HMODULE WINAPI my_LoadLibraryExW(PCWSTR Name, HANDLE hFile, DWORD dwFlags)
+{
+    DWORD dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == (SEM_FAILCRITICALERRORS | SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX),
+       "Unexpected error mode: 0x%x\n", dwErrorMode);
+    return g_hSentinelModule;
+}
+
+
+static void test_LoadLibraryA(PHOOKAPI hook)
+{
+    LOADLIBRARYAPROC proc;
+    DWORD dwErrorMode, dwOldErrorMode;
+
+    hook->OriginalFunction = my_LoadLibraryA;
+    proc = hook->ReplacementFunction;
+
+    dwOldErrorMode = GetErrorMode();
+
+    /* Exact names return what is specified */
+    ok_ptr(proc("test123.dll"), g_h123);
+    ok_ptr(proc("test111"), g_h111);
+    /* Extension is not added */
+    ok_ptr(proc("test111.dll"), g_hSentinelModule);
+    /* Zero can be specified */
+    ok_ptr(proc("Something.mark"), g_h0);
+    /* Or default returned */
+    ok_ptr(proc("empty"), g_h0);
+
+    /* Paths, do not have to be valid */
+    ok_ptr(proc("\\test123.dll"), g_h123);
+    ok_ptr(proc("/test123.dll"), g_h123);
+    ok_ptr(proc("\\\\\\\\test123.dll"), g_h123);
+    ok_ptr(proc("////test123.dll"), g_h123);
+    ok_ptr(proc("mypath:something\\does\\not\\matter\\test123.dll"), g_h123);
+    ok_ptr(proc("/put/whatever/you/want/here/test123.dll"), g_h123);
+
+    /* path separator is checked, not just any point in the path */
+    ok_ptr(proc("-test123.dll"), g_hSentinelModule);
+    ok_ptr(proc("test123.dll-"), g_hSentinelModule);
+
+    dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == dwOldErrorMode, "ErrorMode changed, was 0x%x, is 0x%x\n", dwOldErrorMode, dwErrorMode);
+}
+
+static void test_LoadLibraryW(PHOOKAPI hook)
+{
+    LOADLIBRARYWPROC proc;
+    DWORD dwErrorMode, dwOldErrorMode;
+
+    hook->OriginalFunction = my_LoadLibraryW;
+    proc = hook->ReplacementFunction;
+
+    dwOldErrorMode = GetErrorMode();
+
+    /* Exact names return what is specified */
+    ok_ptr(proc(L"test123.dll"), g_h123);
+    ok_ptr(proc(L"test111"), g_h111);
+    /* Extension is not added */
+    ok_ptr(proc(L"test111.dll"), g_hSentinelModule);
+    /* Zero can be specified */
+    ok_ptr(proc(L"Something.mark"), g_h0);
+    /* Or default returned */
+    ok_ptr(proc(L"empty"), g_h0);
+
+    /* Paths, do not have to be valid */
+    ok_ptr(proc(L"\\test123.dll"), g_h123);
+    ok_ptr(proc(L"/test123.dll"), g_h123);
+    ok_ptr(proc(L"\\\\\\\\test123.dll"), g_h123);
+    ok_ptr(proc(L"////test123.dll"), g_h123);
+    ok_ptr(proc(L"mypath:something\\does\\not\\matter\\test123.dll"), g_h123);
+    ok_ptr(proc(L"/put/whatever/you/want/here/test123.dll"), g_h123);
+
+    /* path separator is checked, not just any point in the path */
+    ok_ptr(proc(L"-test123.dll"), g_hSentinelModule);
+    ok_ptr(proc(L"test123.dll-"), g_hSentinelModule);
+
+    dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == dwOldErrorMode, "ErrorMode changed, was 0x%x, is 0x%x\n", dwOldErrorMode, dwErrorMode);
+}
+
+static void test_LoadLibraryExA(PHOOKAPI hook)
+{
+    LOADLIBRARYEXAPROC proc;
+    DWORD dwErrorMode, dwOldErrorMode;
+
+    hook->OriginalFunction = my_LoadLibraryExA;
+    proc = hook->ReplacementFunction;
+
+    dwOldErrorMode = GetErrorMode();
+
+    /* Exact names return what is specified */
+    ok_ptr(proc("test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("test111", INVALID_HANDLE_VALUE, 0), g_h111);
+    /* Extension is not added */
+    ok_ptr(proc("test111.dll", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+    /* Zero can be specified */
+    ok_ptr(proc("Something.mark", INVALID_HANDLE_VALUE, 0), g_h0);
+    /* Or default returned */
+    ok_ptr(proc("empty", INVALID_HANDLE_VALUE, 0), g_h0);
+
+    /* Paths, do not have to be valid */
+    ok_ptr(proc("\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("/test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("\\\\\\\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("////test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("mypath:something\\does\\not\\matter\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc("/put/whatever/you/want/here/test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+
+    /* path separator is checked, not just any point in the path */
+    ok_ptr(proc("-test123.dll", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+    ok_ptr(proc("test123.dll-", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+
+    dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == dwOldErrorMode, "ErrorMode changed, was 0x%x, is 0x%x\n", dwOldErrorMode, dwErrorMode);
+}
+
+static void test_LoadLibraryExW(PHOOKAPI hook)
+{
+    LOADLIBRARYEXWPROC proc;
+    DWORD dwErrorMode, dwOldErrorMode;
+
+    hook->OriginalFunction = my_LoadLibraryExW;
+    proc = hook->ReplacementFunction;
+
+    dwOldErrorMode = GetErrorMode();
+
+    /* Exact names return what is specified */
+    ok_ptr(proc(L"test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"test111", INVALID_HANDLE_VALUE, 0), g_h111);
+    /* Extension is not added */
+    ok_ptr(proc(L"test111.dll", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+    /* Zero can be specified */
+    ok_ptr(proc(L"Something.mark", INVALID_HANDLE_VALUE, 0), g_h0);
+    /* Or default returned */
+    ok_ptr(proc(L"empty", INVALID_HANDLE_VALUE, 0), g_h0);
+
+    /* Paths, do not have to be valid */
+    ok_ptr(proc(L"\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"/test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"\\\\\\\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"////test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"mypath:something\\does\\not\\matter\\test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+    ok_ptr(proc(L"/put/whatever/you/want/here/test123.dll", INVALID_HANDLE_VALUE, 0), g_h123);
+
+    /* path separator is checked, not just any point in the path */
+    ok_ptr(proc(L"-test123.dll", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+    ok_ptr(proc(L"test123.dll-", INVALID_HANDLE_VALUE, 0), g_hSentinelModule);
+
+    dwErrorMode = GetErrorMode();
+    ok(dwErrorMode == dwOldErrorMode, "ErrorMode changed, was 0x%x, is 0x%x\n", dwOldErrorMode, dwErrorMode);
+}
+
+/* versionlie.c */
+DWORD get_host_winver(void);
+
+START_TEST(ignoreloadlib)
+{
+    DWORD num_shims = 0, n, dwErrorMode;
+    PHOOKAPI hook;
+
+    g_WinVersion = get_host_winver();
+
+    if (g_WinVersion < _WIN32_WINNT_WIN8)
+        pGetHookAPIs = LoadShimDLL2(L"aclayers.dll");
+    else
+        pGetHookAPIs = LoadShimDLL2(L"acgenral.dll");
+
+    if (!pGetHookAPIs)
+    {
+        skip("GetHookAPIs not found\n");
+        return;
+    }
+
+    hook = pGetHookAPIs("test123.dll:123;test111:111;Something.mark:0;empty", L"IgnoreLoadLibrary", &num_shims);
+
+    ok(hook != NULL, "Expected hook to be a valid pointer\n");
+    ok(num_shims == 4, "Expected num_shims to be 0, was: %u\n", num_shims);
+
+    if (!hook || num_shims != 4)
+        return;
+
+    dwErrorMode = GetErrorMode();
+    trace("Error mode: 0x%x\n", dwErrorMode);
+
+    for (n = 0; n < num_shims; ++n)
+    {
+        ok_str(hook[n].LibraryName, "KERNEL32.DLL");
+        if (!_stricmp(hook[n].FunctionName, "LoadLibraryA"))
+        {
+            ok_int(n, 0);
+            test_LoadLibraryA(hook + n);
+        }
+        else if (!_stricmp(hook[n].FunctionName, "LoadLibraryExA"))
+        {
+            ok_int(n, 1);
+            test_LoadLibraryExA(hook + n);
+        }
+        else if (!_stricmp(hook[n].FunctionName, "LoadLibraryW"))
+        {
+            ok_int(n, 2);
+            test_LoadLibraryW(hook + n);
+        }
+        else if (!_stricmp(hook[n].FunctionName, "LoadLibraryExW"))
+        {
+            ok_int(n, 3);
+            test_LoadLibraryExW(hook + n);
+        }
+        else
+        {
+            ok(0, "Unknown function %s\n", hook[n].FunctionName);
+        }
+    }
+}

--- a/modules/rostests/apitests/appshim/layer_hooks.c
+++ b/modules/rostests/apitests/appshim/layer_hooks.c
@@ -53,6 +53,15 @@ static expect_shim_data data[] =
             { "KERNEL32.DLL", "VerifyVersionInfoW" },
         }
     },
+    /* Show that it is not case sensitive */
+    {
+        L"VeRiFyVeRsIoNInFoLiTe",
+        0,
+        {
+            { "KERNEL32.DLL", "VerifyVersionInfoA" },
+            { "KERNEL32.DLL", "VerifyVersionInfoW" },
+        }
+    },
 };
 
 static DWORD count_shims(expect_shim_data* data)

--- a/modules/rostests/apitests/appshim/testlist.c
+++ b/modules/rostests/apitests/appshim/testlist.c
@@ -7,6 +7,7 @@ extern void func_dispmode(void);
 extern void func_forcedxsetup(void);
 extern void func_genral_hooks(void);
 extern void func_ignorefreelib(void);
+extern void func_ignoreloadlib(void);
 extern void func_layer_hooks(void);
 extern void func_versionlie(void);
 
@@ -16,6 +17,7 @@ const struct test winetest_testlist[] =
     { "forcedxsetup", func_forcedxsetup },
     { "genral_hooks", func_genral_hooks },
     { "ignorefreelib", func_ignorefreelib },
+    { "ignoreloadlib", func_ignoreloadlib },
     { "layer_hooks", func_layer_hooks },
     { "versionlie", func_versionlie },
     { 0, 0 }

--- a/sdk/include/ndk/ldrtypes.h
+++ b/sdk/include/ndk/ldrtypes.h
@@ -37,6 +37,7 @@ Author:
 //
 #define LDRP_STATIC_LINK                        0x00000002
 #define LDRP_IMAGE_DLL                          0x00000004
+#define LDRP_SHIMENG_SUPPRESSED_ENTRY           0x00000008
 #define LDRP_LOAD_IN_PROGRESS                   0x00001000
 #define LDRP_UNLOAD_IN_PROGRESS                 0x00002000
 #define LDRP_ENTRY_PROCESSED                    0x00004000


### PR DESCRIPTION
## Purpose

* Simplify ForceDXSetupSuccess
* Add test for IgnoreLoadLibrary
* Add stubplemented IgnoreLoadLibrary shim
* Find shims case-insensitive
* Do not call module entrypoints while loading the shim engine.
* Implement experimental support for multiple hooks on the same function

JIRA issue: [CORE-15845](https://jira.reactos.org/browse/CORE-15845)
JIRA issue: [CORE-15846](https://jira.reactos.org/browse/CORE-15846)
JIRA issue: [CORE-15814](https://jira.reactos.org/browse/CORE-15814)
