### PR TITLE
Updated the release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 ---
 
 <p align=center>
-  <a href="https://reactos.org/project-news/reactos-0410-released">
-    <img alt="ReactOS 0.4.10 Release" src="https://img.shields.io/badge/release-0.4.10-0688CB.svg">
+  <a href="https://reactos.org/project-news/reactos-0411-released">
+    <img alt="ReactOS 0.4.11 Release" src="https://img.shields.io/badge/release-0.4.11-0688CB.svg">
   </a>
   <a href="https://reactos.org/download">
     <img alt="Download ReactOS" src="https://img.shields.io/badge/download-latest-0688CB.svg">


### PR DESCRIPTION
## Purpose

This was outdated, pointing to 0.4.10 not 0.4.11

## Proposed changes

- Just updated the link 

Also, should we link the mattermost chat server on the readme?
Taking about https://chat.reactos.org/


edit: this feels like such a waste of the CI's time, building it just for a readme update. 