### PR TITLE
E1000: 82573_l bringup

### DIFF
--- a/drivers/network/dd/e1000/e1000hw.h
+++ b/drivers/network/dd/e1000/e1000hw.h
@@ -163,9 +163,11 @@ C_ASSERT(sizeof(E1000_TRANSMIT_DESCRIPTOR) == 16);
 
 
 /* E1000_REG_EERD */
-#define E1000_EERD_START            (1 << 0)    /* Start Read*/
-#define E1000_EERD_DONE             (1 << 4)    /* Read Done */
-#define E1000_EERD_ADDR_SHIFT       8
+#define E1000_EERD_START            (1 << 0)    /* Start Read */
+#define E1000_EERD_DONE_8254x       (1 << 4)    /* Read Done - 8254x */
+#define E1000_EERD_ADDR_SHIFT_8254x 8           /* 8254x */
+#define E1000_EERD_DONE_8257x       (1 << 1)    /* Read Done - 8257x */
+#define E1000_EERD_ADDR_SHIFT_8257x 2           /* 8257x */
 #define E1000_EERD_DATA_SHIFT       16
 
 
@@ -226,6 +228,9 @@ C_ASSERT(sizeof(E1000_TRANSMIT_DESCRIPTOR) == 16);
 /* NVM */
 #define E1000_NVM_REG_CHECKSUM      0x03f
 #define NVM_MAGIC_SUM               0xBABA
+
+#define E1000_NVM_REG_VID           0x00e
+#define NVM_VID                     HW_VENDOR_INTEL
 
 
 

--- a/drivers/network/dd/e1000/nic.h
+++ b/drivers/network/dd/e1000/nic.h
@@ -86,6 +86,11 @@ typedef struct _E1000_ADAPTER
     NDIS_PHYSICAL_ADDRESS ReceiveBufferPa;
     ULONG ReceiveBufferEntrySize;
 
+
+    /* EEPROM/nvm data */
+    ULONG EERDDoneBit;
+    UINT EERDAddrShift;
+
 } E1000_ADAPTER, *PE1000_ADAPTER;
 
 

--- a/media/inf/nete1000.inf
+++ b/media/inf/nete1000.inf
@@ -55,6 +55,7 @@ DefaultDestDir = 12
 %IntelE1000_108A.DeviceDesc% = E1000_Inst.ndi,PCI\VEN_8086&DEV_108A
 %IntelE1000_1099.DeviceDesc% = E1000_Inst.ndi,PCI\VEN_8086&DEV_1099
 %IntelE1000_10B5.DeviceDesc% = E1000_Inst.ndi,PCI\VEN_8086&DEV_10B5
+%IntelE1000_109A.DeviceDesc% = E1000_Inst.ndi,PCI\VEN_8086&DEV_109A
 
 ;----------------------------- E1000 DRIVER -----------------------------
 
@@ -120,3 +121,4 @@ IntelE1000_107C.DeviceDesc = "Intel 82541PI PCI Ethernet Adapter"
 IntelE1000_108A.DeviceDesc = "Intel 82546GB PCI-E Ethernet Adapter"
 IntelE1000_1099.DeviceDesc = "Intel 82546GB Quad Copper PCI Ethernet Adapter"
 IntelE1000_10B5.DeviceDesc = "Intel 82546GB Quad Copper KSP3 PCI-X Ethernet Adapter"
+IntelE1000_109A.DeviceDesc = "Intel 82573L PCI-E Ethernet Adapter"


### PR DESCRIPTION
## Purpose

Intel 82573L bringup (used by Lenovo x60) 


## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- This chip has a changed EERD layout. Guess the layout by try to read the Vendor ID.
- Additionally, try to get the MAC from RAL/RAH as well to support EEPROM-less operation.
