### PR TITLE
[MSI] Allow to pass product key validation check

### DIFF
--- a/dll/win32/msi/action.c
+++ b/dll/win32/msi/action.c
@@ -7448,7 +7448,11 @@ UINT msi_validate_product_id( MSIPACKAGE *package )
     if (key && template)
     {
         FIXME( "partial stub: template %s key %s\n", debugstr_w(template), debugstr_w(key) );
+#ifdef __REACTOS__
+        WARN("Product key validation HACK, see CORE-14710\n");
+#else
         r = msi_set_property( package->db, szProductID, key, -1 );
+#endif
     }
     msi_free( template );
     msi_free( key );


### PR DESCRIPTION
## Purpose

Allow to pass product key validation check. This is actually a hackfix, but I'm not sure Wine will implement this function properly any time soon.

JIRA issue: [CORE-14710](https://jira.reactos.org/browse/CORE-14710)