### PR TITLE
Fix caret and scroll position in edit controls

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -1046,7 +1046,11 @@ static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap)
 			x -= es->x_offset;
 		}
 		else
+#ifdef __REACTOS__ /* CORE-15780 */
+			x = (lw > 0 ? es->x_offset : x - es->x_offset);
+#else
 			x = es->x_offset;
+#endif
 
 		if (es->style & ES_RIGHT)
 			x = w - (lw - x);

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -1131,7 +1131,11 @@ static LRESULT EDIT_EM_PosFromChar(EDITSTATE *es, INT index, BOOL after_wrap)
 			x -= es->x_offset;
 		}
 		else
+#ifdef __REACTOS__ /* CORE-15780 */
+			x = (lw > 0 ? es->x_offset : x - es->x_offset);
+#else
 			x = es->x_offset;
+#endif
 
 		if (es->style & ES_RIGHT)
 			x = w - (lw - x);


### PR DESCRIPTION
Fix caret and scroll position in edit controls in `comctl32` and `user32`. This PR is based on patch by JIRA contributor 'I_Kill_Bugs'.

JIRA issue: [CORE-15780](https://jira.reactos.org/browse/CORE-15780)