### PR TITLE
Fix rectangle overflow when inserting characters

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -720,7 +720,11 @@ static void EDIT_BuildLineDefs_ML(EDITSTATE *es, INT istart, INT iend, INT delta
 		if ((es->style & ES_CENTER) || (es->style & ES_RIGHT))
 			rc.left = es->format_rect.left;
 		else
+#ifdef __REACTOS__ /* CORE-11475 */
+			rc.left = (short)LOWORD(EDIT_EM_PosFromChar(es, nstart_index, FALSE));
+#else
                         rc.left = LOWORD(EDIT_EM_PosFromChar(es, nstart_index, FALSE));
+#endif
 		rc.right = es->format_rect.right;
 		SetRectRgn(hrgn, rc.left, rc.top, rc.right, rc.bottom);
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -805,7 +805,11 @@ static void EDIT_BuildLineDefs_ML(EDITSTATE *es, INT istart, INT iend, INT delta
 		if ((es->style & ES_CENTER) || (es->style & ES_RIGHT))
 			rc.left = es->format_rect.left;
 		else
+#ifdef __REACTOS__ /* CORE-11475 */
+			rc.left = (short)LOWORD(EDIT_EM_PosFromChar(es, nstart_index, FALSE));
+#else
                         rc.left = LOWORD(EDIT_EM_PosFromChar(es, nstart_index, FALSE));
+#endif
 		rc.right = es->format_rect.right;
 		SetRectRgn(hrgn, rc.left, rc.top, rc.right, rc.bottom);
 


### PR DESCRIPTION
Fix rectangle overflow when inserting characters in edit controls in `comctl32` and `user32`. This PR is based on patch by JIRA contributor 'I_Kill_Bugs'.

JIRA issue: [CORE-11475](https://jira.reactos.org/browse/CORE-11475)