### PR TITLE
Fix crash that occurs if nul is typed in cmd.exe

### DIFF
--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3735,11 +3735,11 @@ MmCreateImageSection(PROS_SECTION_OBJECT *SectionObject,
     PMM_IMAGE_SECTION_OBJECT ImageSectionObject;
     ULONG i;
 
-    if (FileObject == NULL || FileObject->SectionObjectPointer == NULL)
+    if (FileObject == NULL)
         return STATUS_INVALID_FILE_FOR_SECTION;
 
 #ifndef NEWCC
-    if (FileObject->SectionObjectPointer->SharedCacheMap == NULL)
+    if (!CcIsFileCached(FileObject))
     {
         DPRINT1("Denying section creation due to missing cache initialization\n");
         return STATUS_INVALID_FILE_FOR_SECTION;

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3735,7 +3735,7 @@ MmCreateImageSection(PROS_SECTION_OBJECT *SectionObject,
     PMM_IMAGE_SECTION_OBJECT ImageSectionObject;
     ULONG i;
 
-    if (FileObject == NULL)
+    if (FileObject == NULL || FileObject->SectionObjectPointer == NULL)
         return STATUS_INVALID_FILE_FOR_SECTION;
 
 #ifndef NEWCC


### PR DESCRIPTION
## Purpose

If you open cmd.exe, enter "nul" and press enter, it will crash.
This PR fixes this crash.

Possibly related JIRA issue: [CORE-15589](https://jira.reactos.org/browse/CORE-15589)

## TODO

@ThFabba said in the chat that this is the wrong way to solve the crash issue.
Maybe the problem is elsewhere.

Check FileObject->SectionObjectPointer value received by ObReferenceObjectByHandle for HANDLE of nul file in win.