### PR TITLE
Fix incorrect result of GetFileType for nul file

### DIFF
--- a/drivers/base/null/null.c
+++ b/drivers/base/null/null.c
@@ -33,9 +33,16 @@ NullQueryVolumeInformation(OUT PVOID Buffer,
         return STATUS_INVALID_INFO_CLASS;
     }
 
+    /* Check the buffer length */
+    if (*Length < sizeof(FILE_FS_DEVICE_INFORMATION))
+    {
+        *Length = sizeof(FILE_FS_DEVICE_INFORMATION);
+        return STATUS_INFO_LENGTH_MISMATCH;
+    }
+
     /* Fill out the information */
-    RtlZeroMemory(DeviceInformation, sizeof(FILE_FS_DEVICE_INFORMATION));
     DeviceInformation->DeviceType = FILE_DEVICE_NULL;
+    DeviceInformation->Characteristics = FILE_DEVICE_SECURE_OPEN;
 
     /* Return the length and success */
     *Length = sizeof(FILE_FS_DEVICE_INFORMATION);
@@ -57,6 +64,13 @@ NullQueryFileInformation(OUT PVOID Buffer,
     {
         /* Fail */
         return STATUS_INVALID_INFO_CLASS;
+    }
+
+    /* Check the buffer length */
+    if (*Length < sizeof(FILE_STANDARD_INFORMATION))
+    {
+        *Length = sizeof(FILE_STANDARD_INFORMATION);
+        return STATUS_INFO_LENGTH_MISMATCH;
     }
 
     /* Fill out the information */
@@ -228,7 +242,7 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
                             0,
                             &DeviceName,
                             FILE_DEVICE_NULL,
-                            0,
+                            FILE_DEVICE_SECURE_OPEN,
                             FALSE,
                             &DeviceObject);
     if (!NT_SUCCESS(Status))


### PR DESCRIPTION
## Purpose

The result of GetFileType for the nul file should be 2 (FILE_TYPE_CHAR).
Now it is 0 (FILE_TYPE_UNKNOWN). This PR fixes this.

Also because of this problem, it was impossible to open the nul file in python.
JIRA issue: [CORE-14551](https://jira.reactos.org/browse/CORE-14551) has been fixed with this PR.

Test:
![python_dev_null](https://user-images.githubusercontent.com/33279413/54966752-5ca46380-4f86-11e9-96f2-59305cc66ddd.png)