### PR TITLE
[UNIATA] fix for uninitialized Lun pointer, CORE-15886

### DIFF
--- a/drivers/storage/ide/uniata/id_init.cpp
+++ b/drivers/storage/ide/uniata/id_init.cpp
@@ -1251,6 +1251,7 @@ for_ugly_chips:
 
             for(c=0; c<deviceExtension->NumberChannels; c++) {
                 chan = &deviceExtension->chan[c];
+                AtapiSetupLunPtrs(chan, deviceExtension, c);
                 IsPata = FALSE;
                 if(ChipFlags & ICH5) {
                     KdPrint2((PRINT_PREFIX "ICH5\n"));


### PR DESCRIPTION
## Purpose

fix for uninitialized Lun pointer, CORE-15886
Fixes crash on Intel AHCI init

JIRA issue: [CORE-15886](https://jira.reactos.org/browse/CORE-15886)

## Proposed changes

AtapiSetupLunPtrs() was not called after UniataAllocateLunExt() in Intel SATA/AHCI detect code. It is necessary to do it at this moment because
we have to setup LUN-specfic flags at this moment.
