### PR TITLE
"/c" option not working for findstr command

### DIFF
--- a/base/applications/findstr/findstr.c
+++ b/base/applications/findstr/findstr.c
@@ -169,10 +169,10 @@ main (int argc, char **argv)
 	        at_start = 1;
 	        break;
 			
-	      //case 'c':
-	      //case 'C':		/* Literal? */
-	      //  literal_search = 1;
-	      //  break;
+	        case 'c':
+	        case 'C':		/* Count the number of lines that contain string */
+	         count_lines = 1;
+	         break;
 
 	      case 'e':
 	      case 'E':		/* matches pattern if at end of line */


### PR DESCRIPTION
"/C or /c" was  not working for the findstr command in command prompt.

## Purpose

So i just removed the comment made to switch case for option "c"

JIRA issue: [CORE-15767](https://jira.reactos.org/browse/CORE-15767)

## Proposed changes

Now /C option is working for the findstr program.


- 
- 

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] 
- [ ] 
