### PR TITLE
[USBHID] Do not assert if the device was unplugged during an operation.

### DIFF
--- a/drivers/hid/hidusb/hidusb.c
+++ b/drivers/hid/hidusb/hidusb.c
@@ -453,7 +453,7 @@ HidUsb_ReadReportCompletion(
         //
         // FIXME handle error
         //
-        ASSERT(Urb->UrbHeader.Status == USBD_STATUS_SUCCESS);
+        ASSERT(Urb->UrbHeader.Status == USBD_STATUS_SUCCESS || Urb->UrbHeader.Status == USBD_STATUS_DEVICE_GONE);
 
         //
         // free the urb


### PR DESCRIPTION
Now when unplugging the mouse while moving it, the driver does not assert