### PR TITLE
[SHELL32] Fix version info in the file dialog

### DIFF
--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -80,7 +80,7 @@ LPCWSTR CFileVersionInfo::GetString(LPCWSTR pwszName)
     if (!VerQueryValueW(m_pInfo, wszBuf, (LPVOID *)&pwszResult, &cBytes))
         pwszResult = NULL;
 
-    if (!m_wLang && !m_wCode)
+    if (!pwszResult)
     {
         /* Try US English */
         swprintf(wszBuf, L"\\StringFileInfo\\%04x%04x\\%s", MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US), 1252, pwszName);


### PR DESCRIPTION
## Purpose

Fix application information in the file dialog

![reshacker](https://user-images.githubusercontent.com/33279413/55436058-fd58db80-55a3-11e9-8f89-2c054b812416.png)

# before:
![before](https://user-images.githubusercontent.com/33279413/55436060-fe8a0880-55a3-11e9-9a90-a3e601db2274.png)

# after
![after](https://user-images.githubusercontent.com/33279413/55436059-fe8a0880-55a3-11e9-9106-88729f17dba8.png)
