### PR TITLE
[KERNEL32_APITEST] Improve one-character Heisei tests

### DIFF
--- a/modules/rostests/apitests/kernel32/JapaneseCalendar.c
+++ b/modules/rostests/apitests/kernel32/JapaneseCalendar.c
@@ -39,7 +39,9 @@ START_TEST(JapaneseCalendar)
     static const WCHAR s_szHeisei31[] = {0x5E73, 0x6210, '3', '1', 0};  // L"\u5E73\u6210" L"31"
     static const WCHAR s_szOneCharHeisei1[] = {0x337B, 0};   // L"\u337B"
     static const WCHAR s_szOneCharHeisei2[] = {0x5E73, 0};   // L"\u5E73"
-    static const WCHAR s_szOneCharReiwa[] = {0x32FF, 0};   // L"\u32FF"
+    static const WCHAR s_szOneCharReiwa1[] = {0x32FF, 0};   // L"\u32FF"
+    static const WCHAR s_szOneCharReiwa2[] = {0x4EE4, 0};   // L"\u4EE4"
+    static const WCHAR s_szOneCharReiwa3[] = {0xF9A8, 0};   // L"\uF9A8"
     static const WCHAR s_szWareki[] = {0x548C, 0x66A6, 0};  // L"\u548C\u66A6"
     static const WCHAR s_szNen[] = {0x5E74, 0};             // L"\u5E74"
 
@@ -196,7 +198,9 @@ START_TEST(JapaneseCalendar)
         ok(/* WinXP */ (szTextW[0] == 0x7F && szTextW[1] == 0) ||
            /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei1) == 0 ||
            /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei2) == 0 ||
-           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharReiwa) == 0,
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharReiwa1) == 0 ||
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharReiwa2) == 0 ||
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharReiwa3) == 0,
            "szTextW: %04X %04X %04X\n", szTextW[0], szTextW[1], szTextW[2]);
 
         szTextW[0] = 0x7F;

--- a/modules/rostests/apitests/kernel32/JapaneseCalendar.c
+++ b/modules/rostests/apitests/kernel32/JapaneseCalendar.c
@@ -37,7 +37,8 @@ START_TEST(JapaneseCalendar)
     static const WCHAR s_szSeireki19[] = {0x897F, 0x66A6, '1', '9', 0}; // L"\u897F\u66A6" L"19"
     static const WCHAR s_szHeisei[] = {0x5E73, 0x6210, 0};  // L"\u5E73\u6210"
     static const WCHAR s_szHeisei31[] = {0x5E73, 0x6210, '3', '1', 0};  // L"\u5E73\u6210" L"31"
-    static const WCHAR s_szOneCharHeisei[] = {0x5E73, 0};   // L"\u5E73"
+    static const WCHAR s_szOneCharHeisei1[] = {0x337B, 0};   // L"\u337B"
+    static const WCHAR s_szOneCharHeisei2[] = {0x5E73, 0};   // L"\u5E73"
     static const WCHAR s_szWareki[] = {0x548C, 0x66A6, 0};  // L"\u548C\u66A6"
     static const WCHAR s_szNen[] = {0x5E74, 0};             // L"\u5E74"
 
@@ -192,7 +193,8 @@ START_TEST(JapaneseCalendar)
         ret = GetCalendarInfoW(lcid, CAL_JAPAN, type, szTextW, ARRAYSIZE(szTextW), NULL);
         ok(/* WinXP */ ret == 0 || /* Win10 */ ret != 0, "ret: %d\n", ret);
         ok(/* WinXP */ (szTextW[0] == 0x7F && szTextW[1] == 0) ||
-           /* Win10 */ lstrcmpiW(szTextW, s_szOneCharHeisei) == 0,
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei1) == 0 ||
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei2) == 0,
            "szTextW: %04X %04X %04X\n", szTextW[0], szTextW[1], szTextW[2]);
 
         szTextW[0] = 0x7F;

--- a/modules/rostests/apitests/kernel32/JapaneseCalendar.c
+++ b/modules/rostests/apitests/kernel32/JapaneseCalendar.c
@@ -39,6 +39,7 @@ START_TEST(JapaneseCalendar)
     static const WCHAR s_szHeisei31[] = {0x5E73, 0x6210, '3', '1', 0};  // L"\u5E73\u6210" L"31"
     static const WCHAR s_szOneCharHeisei1[] = {0x337B, 0};   // L"\u337B"
     static const WCHAR s_szOneCharHeisei2[] = {0x5E73, 0};   // L"\u5E73"
+    static const WCHAR s_szOneCharReiwa[] = {0x32FF, 0};   // L"\u32FF"
     static const WCHAR s_szWareki[] = {0x548C, 0x66A6, 0};  // L"\u548C\u66A6"
     static const WCHAR s_szNen[] = {0x5E74, 0};             // L"\u5E74"
 
@@ -194,7 +195,8 @@ START_TEST(JapaneseCalendar)
         ok(/* WinXP */ ret == 0 || /* Win10 */ ret != 0, "ret: %d\n", ret);
         ok(/* WinXP */ (szTextW[0] == 0x7F && szTextW[1] == 0) ||
            /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei1) == 0 ||
-           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei2) == 0,
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharHeisei2) == 0 ||
+           /* Win10? */ lstrcmpiW(szTextW, s_szOneCharReiwa) == 0,
            "szTextW: %04X %04X %04X\n", szTextW[0], szTextW[1], szTextW[2]);
 
         szTextW[0] = 0x7F;


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-15920](https://jira.reactos.org/browse/CORE-15920)

Reported by @ThFabba in IRC, one-character Heisei for `CAL_SABBREVERASTRING` locale info can be `U+337B` or `U+5E73`. And one-character Reiwa `U+32FF`, `U+4EE4`, and `U+F9A8` are also added. Improve `kernel32_apitest` testcase.