### PR TITLE
[SHELL32] Fix SHFileOperation Move operation

### DIFF
--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1640,7 +1640,8 @@ static void move_dir_to_dir(FILE_OPERATION *op, const FILE_ENTRY *feFrom, LPCWST
     destroy_file_list(&flFromNew);
     destroy_file_list(&flToNew);
 
-    Win32RemoveDirectoryW(feFrom->szFullPath);
+    if (PathIsDirectoryEmptyW(feFrom->szFullPath))
+        Win32RemoveDirectoryW(feFrom->szFullPath);
 }
 
 /* moves a file or directory to another directory */

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1792,6 +1792,7 @@ int WINAPI SHFileOperationW(LPSHFILEOPSTRUCTW lpFileOp)
     if (FAILED(ret))
         return ret;
 
+    lpFileOp->fAnyOperationsAborted = FALSE;
     check_flags(lpFileOp->fFlags);
 
     ZeroMemory(&flFrom, sizeof(FILE_LIST));


### PR DESCRIPTION
## Purpose
This PR will reduce the failures of Move operation of `shell32!SHFileOperation` function.
JIRA issue: [CORE-13450](https://jira.reactos.org/browse/CORE-13450), [CORE-13176](https://jira.reactos.org/browse/CORE-13176)