### PR TITLE
[GDI32][NTGDI] Avoid integer overflow (follow-up of #1492)

### DIFF
--- a/win32ss/gdi/gdi32/include/precomp.h
+++ b/win32ss/gdi/gdi32/include/precomp.h
@@ -58,5 +58,6 @@
 #include <ntgdibad.h>
 
 #include <undocgdi.h>
+#include <ntintsafe.h>
 
 #endif /* _GDI32_PCH_ */

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -295,6 +295,7 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     ENUMLOGFONTEXA EnumLogFontExA;
     NEWTEXTMETRICEXA NewTextMetricExA;
     LOGFONTW lfW;
+    ULONGLONG DataSize64;
     LONG DataSize, InfoCount;
 
     DataSize = INITIAL_FAMILY_COUNT * sizeof(FONTFAMILYINFO);
@@ -330,7 +331,12 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     if (INITIAL_FAMILY_COUNT < InfoCount)
     {
         RtlFreeHeap(GetProcessHeap(), 0, Info);
-        DataSize = InfoCount * sizeof(FONTFAMILYINFO);
+        DataSize64 = UInt32x32To64(InfoCount, sizeof(FONTFAMILYINFO));
+        DataSize = (LONG)DataSize64;
+        if (DataSize <= 0 || DataSize64 > LONG_MAX)
+        {
+            return 1;
+        }
         Info = RtlAllocateHeap(GetProcessHeap(), 0, DataSize);
         if (Info == NULL)
         {

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -295,8 +295,8 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     ENUMLOGFONTEXA EnumLogFontExA;
     NEWTEXTMETRICEXA NewTextMetricExA;
     LOGFONTW lfW;
-    ULONGLONG DataSize64;
     LONG DataSize, InfoCount;
+    NTSTATUS Status;
 
     DataSize = INITIAL_FAMILY_COUNT * sizeof(FONTFAMILYINFO);
     Info = RtlAllocateHeap(GetProcessHeap(), 0, DataSize);
@@ -331,9 +331,9 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     if (INITIAL_FAMILY_COUNT < InfoCount)
     {
         RtlFreeHeap(GetProcessHeap(), 0, Info);
-        DataSize64 = UInt32x32To64(InfoCount, sizeof(FONTFAMILYINFO));
-        DataSize = (LONG)DataSize64;
-        if (DataSize <= 0 || DataSize64 > LONG_MAX)
+
+        Status = RtlULongMult(InfoCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
+        if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
         {
             DPRINT1("Overflowed.\n");
             return 1;

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -335,6 +335,7 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
         DataSize = (LONG)DataSize64;
         if (DataSize <= 0 || DataSize64 > LONG_MAX)
         {
+            DPRINT1("Overflowed.\n");
             return 1;
         }
         Info = RtlAllocateHeap(GetProcessHeap(), 0, DataSize);

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -295,7 +295,8 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     ENUMLOGFONTEXA EnumLogFontExA;
     NEWTEXTMETRICEXA NewTextMetricExA;
     LOGFONTW lfW;
-    LONG DataSize, InfoCount;
+    LONG InfoCount;
+    ULONG DataSize;
     NTSTATUS Status;
 
     DataSize = INITIAL_FAMILY_COUNT * sizeof(FONTFAMILYINFO);
@@ -332,8 +333,8 @@ IntEnumFontFamilies(HDC Dc, const LOGFONTW *LogFont, PVOID EnumProc, LPARAM lPar
     {
         RtlFreeHeap(GetProcessHeap(), 0, Info);
 
-        Status = RtlULongMult(InfoCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
-        if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
+        Status = RtlULongMult(InfoCount, sizeof(FONTFAMILYINFO), &DataSize);
+        if (!NT_SUCCESS(Status) || DataSize > LONG_MAX)
         {
             DPRINT1("Overflowed.\n");
             return 1;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5495,6 +5495,7 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     DataSize = (LONG)DataSize64;
     if (DataSize <= 0 || DataSize64 > LONG_MAX)
     {
+        DPRINT1("Overflowed.\n");
         EngSetLastError(ERROR_INVALID_PARAMETER);
         return -1;
     }
@@ -5517,6 +5518,7 @@ NtGdiGetFontFamilyInfo(HDC Dc,
         DataSize = (LONG)DataSize64;
         if (DataSize <= 0 || DataSize64 > LONG_MAX)
         {
+            DPRINT1("Overflowed.\n");
             ExFreePoolWithTag(Info, GDITAG_TEXT);
             EngSetLastError(ERROR_INVALID_PARAMETER);
             return -1;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5456,7 +5456,8 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     NTSTATUS Status;
     LOGFONTW LogFont;
     PFONTFAMILYINFO Info;
-    LONG GotCount, AvailCount, DataSize, SafeInfoCount;
+    LONG GotCount, AvailCount, SafeInfoCount;
+    ULONG DataSize;
 
     if (UnsafeLogFont == NULL || UnsafeInfo == NULL || UnsafeInfoCount == NULL)
     {
@@ -5490,7 +5491,7 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     }
 
     /* Allocate space for a safe copy */
-    Status = RtlULongMult(SafeInfoCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
+    Status = RtlULongMult(SafeInfoCount, sizeof(FONTFAMILYINFO), &DataSize);
     if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
     {
         DPRINT1("Overflowed.\n");
@@ -5512,8 +5513,8 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     /* Return data to caller */
     if (GotCount > 0)
     {
-        Status = RtlULongMult(GotCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
-        if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
+        Status = RtlULongMult(GotCount, sizeof(FONTFAMILYINFO), &DataSize);
+        if (!NT_SUCCESS(Status) || DataSize > LONG_MAX)
         {
             DPRINT1("Overflowed.\n");
             ExFreePoolWithTag(Info, GDITAG_TEXT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5457,7 +5457,6 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     LOGFONTW LogFont;
     PFONTFAMILYINFO Info;
     LONG GotCount, AvailCount, DataSize, SafeInfoCount;
-    ULONGLONG DataSize64;
 
     if (UnsafeLogFont == NULL || UnsafeInfo == NULL || UnsafeInfoCount == NULL)
     {
@@ -5491,9 +5490,8 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     }
 
     /* Allocate space for a safe copy */
-    DataSize64 = UInt32x32To64(SafeInfoCount, sizeof(FONTFAMILYINFO));
-    DataSize = (LONG)DataSize64;
-    if (DataSize <= 0 || DataSize64 > LONG_MAX)
+    Status = RtlULongMult(SafeInfoCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
+    if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
     {
         DPRINT1("Overflowed.\n");
         EngSetLastError(ERROR_INVALID_PARAMETER);
@@ -5514,9 +5512,8 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     /* Return data to caller */
     if (GotCount > 0)
     {
-        DataSize64 = UInt32x32To64(GotCount, sizeof(FONTFAMILYINFO));
-        DataSize = (LONG)DataSize64;
-        if (DataSize <= 0 || DataSize64 > LONG_MAX)
+        Status = RtlULongMult(GotCount, sizeof(FONTFAMILYINFO), (ULONG *)&DataSize);
+        if (!NT_SUCCESS(Status) || (ULONG)DataSize > LONG_MAX)
         {
             DPRINT1("Overflowed.\n");
             ExFreePoolWithTag(Info, GDITAG_TEXT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5457,6 +5457,7 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     LOGFONTW LogFont;
     PFONTFAMILYINFO Info;
     LONG GotCount, AvailCount, DataSize, SafeInfoCount;
+    ULONGLONG DataSize64;
 
     if (UnsafeLogFont == NULL || UnsafeInfo == NULL || UnsafeInfoCount == NULL)
     {
@@ -5490,8 +5491,9 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     }
 
     /* Allocate space for a safe copy */
-    DataSize = SafeInfoCount * sizeof(FONTFAMILYINFO);
-    if (DataSize <= 0)
+    DataSize64 = UInt32x32To64(SafeInfoCount, sizeof(FONTFAMILYINFO));
+    DataSize = (LONG)DataSize64;
+    if (DataSize <= 0 || DataSize64 > LONG_MAX)
     {
         EngSetLastError(ERROR_INVALID_PARAMETER);
         return -1;
@@ -5511,8 +5513,9 @@ NtGdiGetFontFamilyInfo(HDC Dc,
     /* Return data to caller */
     if (GotCount > 0)
     {
-        DataSize = GotCount * sizeof(FONTFAMILYINFO);
-        if (DataSize <= 0)
+        DataSize64 = UInt32x32To64(GotCount, sizeof(FONTFAMILYINFO));
+        DataSize = (LONG)DataSize64;
+        if (DataSize <= 0 || DataSize64 > LONG_MAX)
         {
             ExFreePoolWithTag(Info, GDITAG_TEXT);
             EngSetLastError(ERROR_INVALID_PARAMETER);


### PR DESCRIPTION
## Purpose
Follow up of #1492.
JIRA issue: [CORE-15755](https://jira.reactos.org/browse/CORE-15755)
- Use `RtlULongMult` function to check integer overflows.
Cc @ThFabba 