### PR TITLE
[OPENGLCFG] Capitalize Configuration in applet name

### DIFF
--- a/dll/cpl/openglcfg/lang/en-US.rc
+++ b/dll/cpl/openglcfg/lang/en-US.rc
@@ -20,7 +20,7 @@ STRINGTABLE
 BEGIN
     IDS_RENDERER_DEFAULT "System default"
     IDS_RENDERER_RSWR "ReactOS Software Implementation"
-    IDS_CPLNAME "OpenGL configuration"
+    IDS_CPLNAME "OpenGL Configuration"
     IDS_CPLDESCRIPTION "Configures OpenGL renderer."
     IDS_DEBUG_SET "Set"
     IDS_DEBUG_CLEAR "Clear"

--- a/dll/cpl/openglcfg/lang/tr-TR.rc
+++ b/dll/cpl/openglcfg/lang/tr-TR.rc
@@ -22,7 +22,7 @@ STRINGTABLE
 BEGIN
     IDS_RENDERER_DEFAULT "Dizge Ön Tanımlı"
     IDS_RENDERER_RSWR "ReactOS Yazılım Gerçekleştirmesi"
-    IDS_CPLNAME "OpenGL yapılandırması"
+    IDS_CPLNAME "OpenGL Yapılandırması"
     IDS_CPLDESCRIPTION "OpenGL işleyicisini yapılandırır."
     IDS_DEBUG_SET "Ayarla"
     IDS_DEBUG_CLEAR "Sil"


### PR DESCRIPTION
Capitalize configuration in the applet name for OpenGL configuration so it matches the rest of the Control Panel applets.

![VirtualBox_ReactOS_12_04_2019_18_19_58](https://user-images.githubusercontent.com/15203817/56070821-de024100-5d4f-11e9-8839-db013b7ff05f.png)
