### PR TITLE
[DIRECTX] Fix typos in readme.txt

### DIFF
--- a/dll/directx/wine/readme.txt
+++ b/dll/directx/wine/readme.txt
@@ -2,7 +2,7 @@ This Is wine DirectX support.
 It works in reactos and windows
 When ReactOS own ReactX are inplace 
 this file will be remove from our SVN
-for now they stay as tempary sovlotions
+for now they stay as temporary solutions
 
 
 People that have help getting this thing 


### PR DESCRIPTION
## Purpose

Fix 3 typos in dll/directx/wine/readme.txt, in words `tempary` and `sovlotions`. Replace them with correct `temporary` and `solutions`.

JIRA issue: None