### PR TITLE
[OPENGL32] Fix use of registers

### DIFF
--- a/dll/opengl/opengl32/icdload.c
+++ b/dll/opengl/opengl32/icdload.c
@@ -287,10 +287,11 @@ custom_end:
     DrvSetCallbackProcs = (void*)GetProcAddress(data->hModule, "DrvSetCallbackProcs");
     if(DrvSetCallbackProcs)
     {
-        PROC callbacks[] = {(PROC)wglGetCurrentValue,
+        PROC callbacks[] = {
             (PROC)wglSetCurrentValue,
+            (PROC)wglGetCurrentValue,
             (PROC)wglGetDHGLRC};
-        DrvSetCallbackProcs(3, callbacks);
+        DrvSetCallbackProcs(ARRAYSIZE(callbacks), callbacks);
     }
     
     /* Get the DLL exports */

--- a/dll/opengl/opengl32/opengl32.h
+++ b/dll/opengl/opengl32/opengl32.h
@@ -134,7 +134,7 @@ IntMakeCurrent(HGLRC hglrc, HDC hdc, struct wgl_dc_data* dc_data)
 
     CurrentTeb->glCurrentRC = hglrc;
     CurrentTeb->glReserved2 = hdc;
-    CurrentTeb->glContext = dc_data;
+    CurrentTeb->glSectionInfo = dc_data;
 }
 
 FORCEINLINE
@@ -155,21 +155,21 @@ static inline
 struct wgl_dc_data*
 IntGetCurrentDcData(void)
 {
-    return NtCurrentTeb()->glContext;
+    return NtCurrentTeb()->glSectionInfo;
 }
 
 FORCEINLINE
 void
 IntSetCurrentICDPrivate(void* value)
 {
-    NtCurrentTeb()->glReserved1[0] = (ULONG_PTR)value;
+    NtCurrentTeb()->glContext = value;
 }
 
 FORCEINLINE
 void*
 IntGetCurrentICDPrivate(void)
 {
-    return (void*)NtCurrentTeb()->glReserved1[0];
+    return (void*)NtCurrentTeb()->glContext;
 }
 
 FORCEINLINE

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -1368,7 +1368,7 @@ KeSaveFloatingPointState(OUT PKFLOATING_SAVE Save)
 {
     PFNSAVE_FORMAT FpState;
     ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
-    DPRINT1("%s is not really implemented\n", __FUNCTION__);
+    UNIMPLEMENTED_ONCE;
 
     /* check if we are doing software emulation */
     if (!KeI386NpxPresent) return STATUS_ILLEGAL_FLOAT_CONTEXT;
@@ -1400,7 +1400,7 @@ KeRestoreFloatingPointState(IN PKFLOATING_SAVE Save)
 {
     PFNSAVE_FORMAT FpState = *((PVOID *) Save);
     ASSERT(KeGetCurrentThread()->Header.NpxIrql == KeGetCurrentIrql());
-    DPRINT1("%s is not really implemented\n", __FUNCTION__);
+    UNIMPLEMENTED_ONCE;
 
 #ifdef __GNUC__
     asm volatile("fnclex\n\t");

--- a/ntoskrnl/mm/ARM3/vadnode.c
+++ b/ntoskrnl/mm/ARM3/vadnode.c
@@ -285,7 +285,7 @@ MiInsertVadEx(
                                            &Parent);
         if (Result == TableFoundNode)
         {
-            DPRINT1("Given address conflicts with existing node\n");
+            DPRINT("Given address conflicts with existing node\n");
             KeReleaseGuardedMutex(&CurrentProcess->AddressCreationLock);
             return STATUS_CONFLICTING_ADDRESSES;
         }

--- a/win32ss/user/winsrv/usersrv/init.c
+++ b/win32ss/user/winsrv/usersrv/init.c
@@ -140,7 +140,7 @@ CSR_API(SrvGetThreadConsoleDesktop)
 {
     PUSER_GET_THREAD_CONSOLE_DESKTOP GetThreadConsoleDesktopRequest = &((PUSER_API_MESSAGE)ApiMessage)->Data.GetThreadConsoleDesktopRequest;
 
-    DPRINT1("%s not yet implemented\n", __FUNCTION__);
+    UNIMPLEMENTED_ONCE;
 
     /* Return nothing for the moment... */
     GetThreadConsoleDesktopRequest->ConsoleDesktop = NULL;


### PR DESCRIPTION
## Purpose

Make the Nvidia Driver <181.22 working. With Success.

The first commit contains the actual fix.
The second one is to silence some very noisy FIXMEs which hit performance hard and it is very much desired to silence them.

## What works
Applications:
- A random "wglinfo.exe" i grabbed off the internet months ago
- ReactOS 3D-Text Screensaver
- A random "cube.exe" someone sent me.

Drivers:
- 175.19
- 181.22

Confirmed working Cards:
- 7300GS 175.19,181.22
- 8800GTS 181.22
- FX5900 175.19
- FX5500 175.19
- 6600 181.22

Everyone with a card supported by 181.22, please test and have some fun.

## What doesn't work
- FurMark keeps a blank window
- wined3d applications crash the driver
But these cause issues in a completely different area which i will now take a look into.


Lessons learned:
I was assuming the driver does messed up things and i was wrong, costing me months. Don't do that.