### PR TITLE
[ATL][ATLTEST] Adapt to RATL and improvements

### DIFF
--- a/modules/rostests/CMakeLists.txt
+++ b/modules/rostests/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 start_module_group(rostests)
 
+add_definitions(-DHAVE_APITEST)
+
 if(MSVC_IDE)
     add_definitions(-DWINETEST_MSVC_IDE_FORMATTING)
 endif()

--- a/modules/rostests/apitests/atl/CAtlFileMapping.cpp
+++ b/modules/rostests/apitests/atl/CAtlFileMapping.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <atlfile.h>
+#include <cstddef>
 
 #ifdef HAVE_APITEST
     #include <apitest.h>

--- a/modules/rostests/apitests/atl/CAtlFileMapping.cpp
+++ b/modules/rostests/apitests/atl/CAtlFileMapping.cpp
@@ -6,7 +6,9 @@
  */
 
 #include <atlfile.h>
-#include <cstddef>
+#ifndef __REACTOS__
+    #include <cstddef>
+#endif
 
 #ifdef HAVE_APITEST
     #include <apitest.h>

--- a/modules/rostests/apitests/atl/CAtlFileMapping.cpp
+++ b/modules/rostests/apitests/atl/CAtlFileMapping.cpp
@@ -7,7 +7,7 @@
 
 #include <atlfile.h>
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -247,7 +247,7 @@ START_TEST(CAtlFileMapping)
     test_SharedMem();
     test_FileMapping();
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CAtlFile: %i tests executed (0 marked as todo, %i failures), %i skipped.\n", g_tests_executed, g_tests_failed, g_tests_skipped);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CAtlFileMapping.cpp
+++ b/modules/rostests/apitests/atl/CAtlFileMapping.cpp
@@ -6,9 +6,6 @@
  */
 
 #include <atlfile.h>
-#ifndef __REACTOS__
-    #include <cstddef>
-#endif
 
 #ifdef HAVE_APITEST
     #include <apitest.h>

--- a/modules/rostests/apitests/atl/CComObject.cpp
+++ b/modules/rostests/apitests/atl/CComObject.cpp
@@ -9,7 +9,7 @@
 #include <atlbase.h>
 #include <atlcom.h>
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -142,7 +142,7 @@ START_TEST(CComObject)
         ok(g_BLIND == 1, "Expected 1, got %lu\n", g_BLIND);
     }
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CComObject: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CComQIPtr.cpp
+++ b/modules/rostests/apitests/atl/CComQIPtr.cpp
@@ -8,7 +8,7 @@
 #include <atlbase.h>
 #include <atlcom.h>
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -98,6 +98,8 @@ public:
 // Yes this sucks, but we have to support GCC. (CORE-12710)
 #ifdef __REACTOS__
 #define DECLARE_QIPTR(type)     CComQIIDPtr<I_ID(type)>
+#elif defined(__GNUC__)
+#define DECLARE_QIPTR(type)     CComQIIDPtr<I_ID(type)>
 #else
 #define DECLARE_QIPTR(type)     CComQIPtr<type>
 #endif
@@ -153,7 +155,7 @@ START_TEST(CComQIPtr)
         ok(g_QI == 5, "Expected g_QI 5, got %lu\n", g_QI);
     }
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CComQIPtr: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CImage.cpp
+++ b/modules/rostests/apitests/atl/CImage.cpp
@@ -8,7 +8,7 @@
 #include <atlimage.h>
 #include "resource.h"
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -332,7 +332,7 @@ START_TEST(CImage)
        "The exporter filter string is bad, was: %s\n", psz);
 #endif
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CImage: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CSimpleArray.cpp
+++ b/modules/rostests/apitests/atl/CSimpleArray.cpp
@@ -5,7 +5,7 @@
  * PROGRAMMER:      Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -179,7 +179,7 @@ START_TEST(CSimpleArray)
     ok(!!array1.RemoveAt(0), "Expected RemoveAt(0) to succeed\n");
     ok(array1.GetSize() == 0, "Expected array1.GetSize() is 0, was: %d\n", array1.GetSize());
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CSimpleArray: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CSimpleMap.cpp
+++ b/modules/rostests/apitests/atl/CSimpleMap.cpp
@@ -5,7 +5,7 @@
  * PROGRAMMER:      Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -199,7 +199,7 @@ START_TEST(CSimpleMap)
     ok(!!map1.RemoveAt(0), "Expected RemoveAt(0) to succeed\n");
     ok(map1.GetSize() == 0, "Expected map1's size is 0, was %d\n", map1.GetSize());
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CSimpleMap: %i tests executed (0 marked as todo, %i failures), 0 skipped.\n", g_tests_executed, g_tests_failed);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/CString.cpp
+++ b/modules/rostests/apitests/atl/CString.cpp
@@ -171,7 +171,7 @@ static void test_basetypes()
 
 // Allocation strategy seems to differ a bit between us and MS's atl.
 // if someone cares enough to find out why, feel free to change the macro below.
-#ifdef __REACTOS__
+#ifdef __GNUC__
 #define ALLOC_EXPECT(a, b)  b
 #else
 #define ALLOC_EXPECT(a, b)  a

--- a/modules/rostests/apitests/atl/CString.cpp
+++ b/modules/rostests/apitests/atl/CString.cpp
@@ -9,7 +9,7 @@
 #include <atlstr.h>
 #include "resource.h"
 
-#ifdef __REACTOS__
+#ifdef HAVE_APITEST
     #include <apitest.h>
 #else
     #include <stdlib.h>
@@ -257,7 +257,7 @@ START_TEST(CString)
     test_bstrW();
     test_bstrA();
 
-#ifndef __REACTOS__
+#ifndef HAVE_APITEST
     printf("CString: %i tests executed (0 marked as todo, %i failures), %i skipped.\n", g_tests_executed, g_tests_failed, g_tests_skipped);
     return g_tests_failed;
 #endif

--- a/modules/rostests/apitests/atl/devenv/CComObject.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CComObject.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/modules/rostests/apitests/atl/devenv/CComQIPtr.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CComQIPtr.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/modules/rostests/apitests/atl/devenv/CImage.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CImage.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/modules/rostests/apitests/atl/devenv/CSimpleArray.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CSimpleArray.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/modules/rostests/apitests/atl/devenv/CSimpleMap.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CSimpleMap.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/modules/rostests/apitests/atl/devenv/CString.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/CString.vcxproj
@@ -27,25 +27,25 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1074,11 +1074,11 @@ public:
         ATLASSERT(lpszKeyName);
 
         HKEY hKey = NULL;
-        LONG lRes = ::RegOpenKeyEx(hKeyParent, lpszKeyName, NULL, samDesired, &hKey);
+        LONG lRes = ::RegOpenKeyEx(hKeyParent, lpszKeyName, 0, samDesired, &hKey);
         if (lRes != ERROR_SUCCESS)
         {
             samDesired |= KEY_WOW64_64KEY;
-            lRes = ::RegOpenKeyEx(hKeyParent, lpszKeyName, NULL, samDesired, &hKey);
+            lRes = ::RegOpenKeyEx(hKeyParent, lpszKeyName, 0, samDesired, &hKey);
         }
         if (lRes == ERROR_SUCCESS)
         {
@@ -1099,13 +1099,13 @@ public:
         ATLASSERT(lpszKeyName);
 
         HKEY hKey = NULL;
-        LONG lRes = ::RegCreateKeyEx(hKeyParent, lpszKeyName, NULL, lpszClass,
+        LONG lRes = ::RegCreateKeyEx(hKeyParent, lpszKeyName, 0, lpszClass,
                                      dwOptions, samDesired, lpSecAttr, &hKey,
                                      lpdwDisposition);
         if (lRes != ERROR_SUCCESS)
         {
             samDesired |= KEY_WOW64_64KEY;
-            lRes = ::RegCreateKeyEx(hKeyParent, lpszKeyName, NULL, lpszClass,
+            lRes = ::RegCreateKeyEx(hKeyParent, lpszKeyName, 0, lpszClass,
                                     dwOptions, samDesired, lpSecAttr, &hKey,
                                     lpdwDisposition);
         }
@@ -1213,7 +1213,7 @@ public:
     LONG SetValue(LPCTSTR pszValueName, DWORD dwType, const void* pValue, ULONG nBytes) throw()
     {
         ATLASSERT(m_hKey);
-        return ::RegSetValueEx(m_hKey, pszValueName, NULL, dwType, (const BYTE*)pValue, nBytes);
+        return ::RegSetValueEx(m_hKey, pszValueName, 0, dwType, (const BYTE*)pValue, nBytes);
     }
 
     LONG SetDWORDValue(LPCTSTR pszValueName, DWORD dwValue) throw()

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -7,6 +7,14 @@
 
 #pragma once
 
+#ifndef __REACTOS__
+    #ifdef __cplusplus
+        #include <cstddef>
+    #else
+        #include <stddef.h>
+    #endif
+    #include <pseh/pseh2.h>
+#endif
 
 #define _ATL_PACKING 8
 

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #ifndef __REACTOS__
+    #include <cstddef>
     #include <pseh/pseh2.h>
 #endif
 

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -8,11 +8,6 @@
 #pragma once
 
 #ifndef __REACTOS__
-    #ifdef __cplusplus
-        #include <cstddef>
-    #else
-        #include <stddef.h>
-    #endif
     #include <pseh/pseh2.h>
 #endif
 

--- a/sdk/lib/atl/atlfile.h
+++ b/sdk/lib/atl/atlfile.h
@@ -89,7 +89,7 @@ public:
         m_nOffset.QuadPart = orig.m_nOffset.QuadPart;
         m_dwViewDesiredAccess = orig.m_dwViewDesiredAccess;
 
-        if (::DuplicateHandle(GetCurrentProcess(), orig.m_hMapping, GetCurrentProcess(), &m_hMapping, NULL, TRUE, DUPLICATE_SAME_ACCESS))
+        if (::DuplicateHandle(GetCurrentProcess(), orig.m_hMapping, GetCurrentProcess(), &m_hMapping, 0, TRUE, DUPLICATE_SAME_ACCESS))
         {
             m_pData = ::MapViewOfFile(m_hMapping, m_dwViewDesiredAccess, m_nOffset.HighPart, m_nOffset.LowPart, m_nMappingSize);
             if (!m_pData)


### PR DESCRIPTION
## Purpose
Adapt ReactOS ATL for RATL.
JIRA issue: N/A
Independent ReactOS ATL (RATL): https://github.com/katahiromz/RATL
## Proposed changes
- Modify `atldef.h` for non-ReactOS environments.
- Update ATL testcase project files (from `v120_xp` to `v140_xp`).
- `#define HAVE_APITEST` and use it.
- `s/NULL/0/`