### PR TITLE
[BOOTDATA] AHKAppTests.cmd: Fix 'media' typo

### DIFF
--- a/boot/bootdata/bootcdregtest/AHKAppTests.cmd
+++ b/boot/bootdata/bootcdregtest/AHKAppTests.cmd
@@ -5,7 +5,7 @@ for %%X in (A B C D E F G H I J K L M N O P Q R S T U V W X Y Z) do (if exist %%
 
 if not defined DRIVE (
     dbgprint "AHK Application testing suite not present, skipping."
-    dbgprint "Insert ReactOS boot media and try again."
+    dbgprint "Insert ReactOS boot medium and try again."
     exit /b 0
 )
 


### PR DESCRIPTION
## Purpose

Addendum to df2a8c40becc5542bf093238826d795cce70a6c7.

@katahiromz