### PR TITLE
CORE-7538. [CMAKE] msvc.cmake: Remove now redundant '/we4028' special case

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -99,10 +99,6 @@ add_compile_flags("/wd4018")
 # - C4700: uninitialized variable usage
 # - C4716: function must return a value
 add_compile_flags("/we4013 /we4020 /we4022 /we4028 /we4047 /we4098 /we4113 /we4129 /we4133 /we4163 /we4229 /we4311 /we4312 /we4603 /we4700 /we4716")
-# TODO: Check and fix other architectures.
-if(ARCH STREQUAL "i386")
-    add_compile_flags("/we4028")
-endif()
 
 # - C4189: local variable initialized but not referenced
 # Not in Release mode and not with MSVC 2010


### PR DESCRIPTION
## Purpose

Addendum to 545a2c79367e1457e4bc7ac14d3c0f840c7e063c.

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

@tkreuzer