### PR TITLE
WIP. [KERNEL32] GetSystemPowerStatus(): Fix and improve

### DIFF
--- a/dll/win32/kernel32/client/power.c
+++ b/dll/win32/kernel32/client/power.c
@@ -81,7 +81,15 @@ GetSystemPowerStatus(IN LPSYSTEM_POWER_STATUS PowerStatus)
         PowerStatus->ACLineStatus = AC_LINE_OFFLINE;
 
     if (BattState.EstimatedTime)
+    {
         PowerStatus->BatteryLifeTime = BattState.EstimatedTime;
+
+        if (PowerStatus->BatteryLifePercent != BATTERY_PERCENTAGE_UNKNOWN &&
+            PowerStatus->BatteryLifePercent != 0)
+        {
+            PowerStatus->BatteryFullLifeTime = 100 * PowerStatus->BatteryLifeTime / PowerStatus->BatteryLifePercent;
+        }
+    }
 
     return TRUE;
 }

--- a/dll/win32/kernel32/client/power.c
+++ b/dll/win32/kernel32/client/power.c
@@ -52,9 +52,9 @@ GetSystemPowerStatus(IN LPSYSTEM_POWER_STATUS PowerStatus)
     Current = BattState.RemainingCapacity;
     if (Max)
     {
-        if (Current <= Max)
+        if (Current < Max)
         {
-            PowerStatus->BatteryLifePercent = (UCHAR)((100 * Current + Max / 2) / Max);
+            PowerStatus->BatteryLifePercent = (UCHAR)(100 * Current / Max);
         }
         else
         {


### PR DESCRIPTION
## Purpose

Contribution to current work by @EricKohl.

Documentation: [(MS) SYSTEM_POWER_STATUS structure](https://docs.microsoft.com/en-us/windows/desktop/api/winbase/ns-winbase-_system_power_status)

## Proposed changes

- Fix BatteryLifePercent calculation.
This mostly reverts formula used since [r52841](https://git.reactos.org/?p=reactos.git;a=commit;h=078cdde168c7bb34135ebd99fc2d5173cbbecbaf), which looks rather wrong.
- Calculate BatteryFullLifeTime too.

## TODO

- [ ] Is the "restored" formula better/correct?
- [ ] Could we "early return" when in `if (!BattState.BatteryPresent)` case?
Calculating/Setting most of other values seems rather odd in this case...
- [ ] Someone else needs to test it, as I have no computer with battery.
