### PR TITLE
CORE-7538. [ACGENRAL] Fix a C4090 warning

### DIFF
--- a/dll/appcompat/shims/genral/ignorefreelib.c
+++ b/dll/appcompat/shims/genral/ignorefreelib.c
@@ -122,7 +122,7 @@ fail:
 
         --n;
     }
-    ShimLib_ShimFree(names);
+    ShimLib_ShimFree((PVOID)names);
 }
 
 BOOL WINAPI SHIM_OBJ_NAME(Notify)(DWORD fdwReason, PVOID ptr)


### PR DESCRIPTION
## Purpose

Addendum to 007cc5cd8a4ede70516bf2bf15dd62af01dfc8f0, by @HeisSpiter.

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)

## Proposed changes

- Fix a MSVC warning about a ShimLib_ShimFree() call.
"...\ignorefreelib.c(125): error C4090: 'function': different 'const' qualifiers"
