### PR TITLE
Improve buffer size handling / avoid MAX_PATH

### DIFF
--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1191,7 +1191,7 @@ VOID
 NTAPI
 CmpLoadHiveThread(IN PVOID StartContext)
 {
-    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH];
+    WCHAR FileBuffer[64], RegBuffer[64];
     PCWSTR ConfigPath;
     UNICODE_STRING TempName, FileName, RegName;
     ULONG i, ErrorResponse, WorkerCount, Length;
@@ -1357,7 +1357,7 @@ VOID
 NTAPI
 CmpInitializeHiveList(VOID)
 {
-    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH];
+    WCHAR FileBuffer[64], RegBuffer[64];
     PCWSTR ConfigPath;
     UNICODE_STRING TempName, FileName, RegName;
     HANDLE Thread;

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1166,32 +1166,24 @@ CmpCreateRegistryRoot(VOID)
     return TRUE;
 }
 
-static NTSTATUS
-CmpGetRegistryPath(OUT PWCHAR ConfigPath)
+static PCWSTR
+CmpGetRegistryPath(VOID)
 {
-    /* Just use default path */
-    wcscpy(ConfigPath, L"\\SystemRoot");
+    PCWSTR ConfigPath;
 
     /* Check if we are booted in setup */
     if (!ExpInTextModeSetup)
     {
-        /* Add registry path */
-#if 0
-        ResultSize = wcslen(ConfigPath);
-        if (ResultSize && ConfigPath[ResultSize - 1] == L'\\')
-            ConfigPath[ResultSize - 1] = UNICODE_NULL;
-#endif
-        wcscat(ConfigPath, L"\\System32\\Config\\");
+        ConfigPath = L"\\SystemRoot\\System32\\Config\\";
     }
     else
     {
-        wcscat(ConfigPath, L"\\");
+        ConfigPath = L"\\SystemRoot\\";
     }
 
     DPRINT1("CmpGetRegistryPath: ConfigPath = '%S'\n", ConfigPath);
 
-    /* Done */
-    return STATUS_SUCCESS;
+    return ConfigPath;
 }
 
 _Function_class_(KSTART_ROUTINE)
@@ -1199,7 +1191,8 @@ VOID
 NTAPI
 CmpLoadHiveThread(IN PVOID StartContext)
 {
-    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH], ConfigPath[MAX_PATH];
+    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH];
+    PCWSTR ConfigPath;
     UNICODE_STRING TempName, FileName, RegName;
     ULONG i, ErrorResponse, WorkerCount, Length;
     USHORT FileStart;
@@ -1222,7 +1215,7 @@ CmpLoadHiveThread(IN PVOID StartContext)
     RtlInitEmptyUnicodeString(&RegName, RegBuffer, sizeof(RegBuffer));
 
     /* Now build the system root path */
-    CmpGetRegistryPath(ConfigPath);
+    ConfigPath = CmpGetRegistryPath();
     RtlInitUnicodeString(&TempName, ConfigPath);
     RtlAppendUnicodeStringToString(&FileName, &TempName);
     FileStart = FileName.Length;
@@ -1364,7 +1357,8 @@ VOID
 NTAPI
 CmpInitializeHiveList(VOID)
 {
-    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH], ConfigPath[MAX_PATH];
+    WCHAR FileBuffer[MAX_PATH], RegBuffer[MAX_PATH];
+    PCWSTR ConfigPath;
     UNICODE_STRING TempName, FileName, RegName;
     HANDLE Thread;
     NTSTATUS Status;
@@ -1381,7 +1375,7 @@ CmpInitializeHiveList(VOID)
     RtlInitEmptyUnicodeString(&RegName, RegBuffer, sizeof(RegBuffer));
 
     /* Now build the system root path */
-    CmpGetRegistryPath(ConfigPath);
+    ConfigPath = CmpGetRegistryPath();
     RtlInitUnicodeString(&TempName, ConfigPath);
     RtlAppendUnicodeStringToString(&FileName, &TempName);
 

--- a/ntoskrnl/ex/handle.c
+++ b/ntoskrnl/ex/handle.c
@@ -1292,7 +1292,7 @@ BOOLEAN ExpKdbgExtHandle(ULONG Argc, PCHAR Argv[])
     EXHANDLE ExHandle;
     PLIST_ENTRY Entry;
     PEPROCESS Process;
-    WCHAR KeyPath[MAX_PATH];
+    WCHAR KeyPath[256];
     PFILE_OBJECT FileObject;
     PHANDLE_TABLE HandleTable;
     POBJECT_HEADER ObjectHeader;
@@ -1418,7 +1418,7 @@ BOOLEAN ExpKdbgExtHandle(ULONG Argc, PCHAR Argv[])
                             CurrentKcb = CurrentKcb->ParentKcb;
                         }
 
-                        if (NeededLength < MAX_PATH * sizeof(WCHAR))
+                        if (NeededLength < sizeof(KeyPath))
                         {
                             CurrentKcb = Kcb;
 

--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -735,7 +735,9 @@ LdrProcessDriverModule(PLDR_DATA_TABLE_ENTRY LdrEntry,
     PVOID DriverBase = LdrEntry->DllBase;
 
     /* Allocate a buffer we'll use for names */
-    Buffer = ExAllocatePoolWithTag(NonPagedPool, MAX_PATH, TAG_LDR_WSTR);
+    Buffer = ExAllocatePoolWithTag(NonPagedPool,
+                                   MAXIMUM_FILENAME_LENGTH,
+                                   TAG_LDR_WSTR);
     if (!Buffer)
     {
         /* Fail */

--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -1853,7 +1853,7 @@ IopGetParentIdPrefix(PDEVICE_NODE DeviceNode,
     }
 
     /* 1. Try to retrieve ParentIdPrefix from registry */
-    KeyNameBufferLength = FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION, Data[0]) + MAX_PATH * sizeof(WCHAR);
+    KeyNameBufferLength = FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION, Data) + sizeof(L"12345678&12345678");
     ParentIdPrefixInformation = ExAllocatePoolWithTag(PagedPool,
                                                       KeyNameBufferLength + sizeof(UNICODE_NULL),
                                                       TAG_IO);

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2793,7 +2793,9 @@ MmLoadSystemImage(IN PUNICODE_STRING FileName,
     }
 
     /* Allocate a buffer we'll use for names */
-    Buffer = ExAllocatePoolWithTag(NonPagedPool, MAX_PATH, TAG_LDR_WSTR);
+    Buffer = ExAllocatePoolWithTag(NonPagedPool,
+                                   MAXIMUM_FILENAME_LENGTH,
+                                   TAG_LDR_WSTR);
     if (!Buffer) return STATUS_INSUFFICIENT_RESOURCES;
 
     /* Check for a separator */


### PR DESCRIPTION
MAX_PATH is a Win32 concept that makes no sense in the kernel (unless specifically interacting with a Win32 process). Plus, fixed size buffers should be avoided anyway where possible.