### PR TITLE
[MSPAINT] Set default extension .bmp

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -355,6 +355,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     ofn.lpstrFileTitle = ofnFiletitle;
     ofn.nMaxFileTitle  = SIZEOF(ofnFiletitle);
     ofn.Flags          = OFN_HIDEREADONLY;
+    ofn.lpstrDefExt    = L"bmp";
 
     CopyMemory(sfnFilename, filepathname, sizeof(filepathname));
     CString strExporters;
@@ -371,6 +372,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     sfn.nMaxFileTitle  = SIZEOF(sfnFiletitle);
     sfn.Flags          = OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLEHOOK;
     sfn.lpfnHook       = OFNHookProc;
+    sfn.lpstrDefExt    = L"bmp";
 
     /* creating the size boxes */
     RECT sizeboxPos = {0, 0, 0 + 3, 0 + 3};


### PR DESCRIPTION
## Purpose
The filename extension is important information to choose the initial directory. This PR will set the default extension of `mspaint` to `.bmp`.
JIRA issue: [CORE-7114](https://jira.reactos.org/browse/CORE-7114)
Related to #1514.