### PR TITLE
[WIN32SS][GDI] Improve stub for EngQueryDeviceAttribute

### DIFF
--- a/win32ss/gdi/eng/stubs.c
+++ b/win32ss/gdi/eng/stubs.c
@@ -583,14 +583,25 @@ EngPlgBlt(
 BOOL
 APIENTRY
 EngQueryDeviceAttribute(
-    IN HDEV Device,
-    IN ENG_DEVICE_ATTRIBUTE Attribute,
-    IN VOID *In,
-    IN ULONG InSize,
-    OUT VOID *Out,
-    OUT ULONG OutSize)
+    _In_ HDEV hdev,
+    _In_ ENG_DEVICE_ATTRIBUTE devAttr,
+    _In_reads_bytes_(cjInSize) PVOID pvIn,
+    _In_ ULONG cjInSize,
+    _Out_writes_bytes_(cjOutSize) PVOID pvOut,
+    _In_ ULONG cjOutSize)
 {
+    if (devAttr != QDA_ACCELERATION_LEVEL)
+        return FALSE;
+
     UNIMPLEMENTED;
+
+    if (cjOutSize >= sizeof(DWORD))
+    {
+        /* Set all accelerations to enabled */
+        *(DWORD*)pvOut = 0;
+        return TRUE;
+    }
+
     return FALSE;
 }
 


### PR DESCRIPTION
## Purpose

Make EngQueryDeviceAttribute return max acceleration level allowed.

## Proposed changes

This improves the stub to return 0 when queried for QDA_ACCELERATION_LEVEL and makes the call succeed.


I used this to check if the driver just thinks it is not allowed to operate the card at full speed, but it had no effect, however other drivers might act different and disable acceleration on failure.
Also updated the function description, suggested by hbelusca, as it is [here](https://git.reactos.org/?p=reactos.git;a=blob;f=sdk/include/psdk/winddi.h;hb=2e1f594d5e3f25b3aaf2bd6a9ee76a03f5279f0b#l2237).