### PR TITLE
[SHELL32] Implement 'New Link' (Retrial of #1510)

### DIFF
--- a/dll/win32/shell32/CNewMenu.h
+++ b/dll/win32/shell32/CNewMenu.h
@@ -56,7 +56,7 @@ private:
     LPITEMIDLIST m_pidlFolder;
     LPWSTR m_wszPath;
     SHELLNEW_ITEM *m_pItems;
-    SHELLNEW_ITEM *m_pLinkItem;
+    SHELLNEW_ITEM *m_pLinkItem; // Points to the link handler item in the m_pItems list.
     CComPtr<IUnknown> m_pSite;
     HMENU m_hSubMenu;
     HICON m_hiconFolder, m_hiconLink;
@@ -71,7 +71,10 @@ private:
     SHELLNEW_ITEM *FindItemFromIdOffset(UINT IdOffset);
     HRESULT CreateNewFolder(LPCMINVOKECOMMANDINFO lpici);
     HRESULT CreateNewItem(SHELLNEW_ITEM *pItem, LPCMINVOKECOMMANDINFO lpcmi);
-    HRESULT SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName);
+    HRESULT SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL bRename);
+    HRESULT NewItemByCommand(SHELLNEW_ITEM *pItem, LPCWSTR wszPath);
+    HRESULT NewItemByNonCommand(SHELLNEW_ITEM *pItem, LPWSTR wszName,
+                                DWORD cchNameMax, LPCWSTR wszPath);
 
 public:
     CNewMenu();


### PR DESCRIPTION
## Purpose
This PR is retrial of #1510.
Right-Click Desktop, and Choose [New] --> [New Link]. Wizard will start up.
JIRA issue: [CORE-15511](https://jira.reactos.org/browse/CORE-15511)
Movie: https://jira.reactos.org/secure/attachment/52382/Shortcut2ndTrial.webm
## Proposed changes
- Set `NULL` to m_pItems in `CNewMenu::UnloadAllItems()`.
- Add `bIsShortcut` member into `SHELLNEW_ITEM` structure.
- Correctly create cache about `".lnk"`.
- Add special handling for the item of `bIsShortcut == TRUE`.
- Add `bRename` parameter to `CNewMenu::SelectNewItem`.
- Add and use `CNewMenu::NewItemByCommand` and `CNewMenu::NewItemByNonCommand` methods.