### PR TITLE
[CPL][APPWIZ] Set description

### DIFF
--- a/dll/cpl/appwiz/createlink.c
+++ b/dll/cpl/appwiz/createlink.c
@@ -450,7 +450,14 @@ ShowCreateShortcutWizard(HWND hwndCPl, LPWSTR szPath)
         StringCchCopyW(pContext->szOldFile, _countof(pContext->szOldFile), szPath);
         pch = PathFindFileNameW(pContext->szOrigin);
         if (pch && *pch)
+        {
+            /* build szDescription */
+            StringCchCopyW(pContext->szDescription, _countof(pContext->szDescription), pch);
             *pch = 0;
+
+            pch = PathFindExtensionW(pContext->szDescription);
+            *pch = 0;
+        }
     }
     PathAddBackslashW(pContext->szOrigin);
 


### PR DESCRIPTION
## Purpose
When creating a shortcut file by appwiz.cpl, set description as filename for shortcut name.
JIRA issue: N/A
Movie: https://jira.reactos.org/secure/attachment/52383/SetDescription.webm