### PR TITLE
[ROSAUTOTEST] Implement a process activity timeout of 2 minutes

### DIFF
--- a/modules/rostests/rosautotest/CPipe.cpp
+++ b/modules/rostests/rosautotest/CPipe.cpp
@@ -169,7 +169,9 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
         // The asynchronous read request could be satisfied immediately.
         return ERROR_SUCCESS;
     }
-    else if (GetLastError() == ERROR_IO_PENDING)
+
+    DWORD dwLastError = GetLastError();
+    if (dwLastError == ERROR_IO_PENDING)
     {
         // The asynchronous read request could not be satisfied immediately, so wait for it with the given timeout.
         DWORD dwWaitResult = WaitForSingleObject(m_ReadOverlapped.hEvent, TimeoutMilliseconds);
@@ -181,7 +183,9 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
                 // We successfully read NumberOfBytesRead bytes.
                 return ERROR_SUCCESS;
             }
-            else if (GetLastError() == ERROR_BROKEN_PIPE)
+
+            dwLastError = GetLastError();
+            if (dwLastError == ERROR_BROKEN_PIPE)
             {
                 // The other end of the pipe has been closed.
                 return ERROR_BROKEN_PIPE;
@@ -201,7 +205,7 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
     else
     {
         // This may be ERROR_BROKEN_PIPE or an unexpected error.
-        return GetLastError();
+        return dwLastError;
     }
 }
 

--- a/modules/rostests/rosautotest/CPipe.h
+++ b/modules/rostests/rosautotest/CPipe.h
@@ -3,11 +3,15 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Class that manages an unidirectional anonymous byte stream pipe
  * COPYRIGHT:   Copyright 2015 Thomas Faber (thomas.faber@reactos.org)
+ *              Copyright 2019 Colin Finck (colin@reactos.org)
  */
 
 class CPipe
 {
 private:
+    static LONG m_lPipeCount;
+
+    OVERLAPPED m_ReadOverlapped;
     HANDLE m_hReadPipe;
     HANDLE m_hWritePipe;
 
@@ -19,7 +23,7 @@ public:
     void CloseWritePipe();
 
     bool Peek(PVOID Buffer, DWORD BufferSize, PDWORD BytesRead, PDWORD TotalBytesAvailable);
-    bool Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead);
+    DWORD Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, DWORD TimeoutMilliseconds);
     bool Write(LPCVOID Buffer, DWORD NumberOfBytesToWrite, PDWORD NumberOfBytesWritten);
 
     friend class CPipedProcess;

--- a/modules/rostests/rosautotest/CProcess.cpp
+++ b/modules/rostests/rosautotest/CProcess.cpp
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Automatic Testing Utility
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Class able to create a new process and closing its handles on destruction (exception-safe)
- * COPYRIGHT:   Copyright 2009 Colin Finck (colin@reactos.org)
+ * COPYRIGHT:   Copyright 2009-2019 Colin Finck (colin@reactos.org)
  */
 
 #include "precomp.h"
@@ -27,10 +27,11 @@ CProcess::CProcess(const wstring& CommandLine, LPSTARTUPINFOW StartupInfo)
 }
 
 /**
- * Destructs a CProcess object and closes all handles belonging to the process.
+ * Destructs a CProcess object, terminates the process if running, and closes all handles belonging to the process.
  */
 CProcess::~CProcess()
 {
+    TerminateProcess(m_ProcessInfo.hProcess, 255);
     CloseHandle(m_ProcessInfo.hThread);
     CloseHandle(m_ProcessInfo.hProcess);
 }


### PR DESCRIPTION
If there is no log output within 2 minutes, the test process is killed, and we continue with the next test.

This is a rather graceful approach compared to sysreg2's 3 minute timeout before killing and restarting the entire VM.
Since we added autochk for FAT filesystems, the filesystem is often "fixed" after a reset with the consequence that ReactOS doesn't boot up anymore.
The sysreg2 restart code still remains for handling tests causing BSODs.

This should fix our testbots, which currently randomly hang in winhttp:winhttp, then let sysreg2 kill the VM, and don't boot up anymore.