### PR TITLE
[CMAKE] Fix LINK_DEPENDS usage

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -479,8 +479,5 @@ endmacro()
 function(add_linker_script _target _linker_script_file)
     get_filename_component(_file_full_path ${_linker_script_file} ABSOLUTE)
     add_target_link_flags(${_target} "-Wl,-T,${_file_full_path}")
-
-    # Unfortunately LINK_DEPENDS is ignored in non-Makefile generators (for now...)
-    # See also http://www.cmake.org/pipermail/cmake/2010-May/037206.html
     add_target_property(${_target} LINK_DEPENDS ${_file_full_path})
 endfunction()

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -616,9 +616,6 @@ function(add_linker_script _target _linker_script_file)
         # add_custom_target("${_target}_${_file_name}" ALL DEPENDS ${_generated_file})
         # add_dependencies(${_target} "${_target}_${_file_name}")
         add_target_link_flags(${_target} "@${_generated_file}")
-
-        # Unfortunately LINK_DEPENDS is ignored in non-Makefile generators (for now...)
-        # See also http://www.cmake.org/pipermail/cmake/2010-May/037206.html
-        add_target_property(${_target} LINK_DEPENDS ${_generated_file})
+        add_target_property(${_target} LINK_DEPENDS ${_file_full_path})
     endif()
 endfunction()


### PR DESCRIPTION
Up to CMake 3.3 LINK_DEPENDS was ignored in non-Makefile generators. See also http://www.cmake.org/pipermail/cmake/2010-May/037206.html. 

Since CMake 3.4 it is no longer ignored, but requires CMP0005 policy to be set to NEW and it requires a full path which was already correctly used on GCC, but not on MSVC builds.

This fixes
> ninja: error: FindFirstFileExA( d:/testproject/src): The filename, directory name, or volume label syntax is incorrect.

When building ReactOS with latest CMake (3.14.3)
