### PR TITLE
[REGTEST] Add regtest.cmd to the Run key inside regtest.cmd, so we're also started on the next reboot in case ReactOS crashed *and* the registry has been saved.

### DIFF
--- a/boot/bootdata/bootcdregtest/regtest.cmd
+++ b/boot/bootdata/bootcdregtest/regtest.cmd
@@ -2,6 +2,15 @@
 set WINETEST_DEBUG=0
 set WINETEST_PLATFORM=reactos
 
+:: On the first boot, we're started through RunOnce.
+:: Add us to the Run key, so we're also started on the next reboot in case ReactOS crashed *and* the registry has been saved.
+:: Exit right after that, because Explorer processes the Run key right after RunOnce and therefore picks up regtest.cmd a second time during the first boot.
+reg query HKLM\Software\Microsoft\Windows\CurrentVersion\Run /v regtest
+if "%errorlevel%"=="1" (
+    reg add HKLM\Software\Microsoft\Windows\CurrentVersion\Run /v regtest /t REG_SZ /d "%SystemRoot%\system32\cmd.exe /c regtest.cmd"
+    exit 0
+)
+
 move C:\ReactOS\bin\redirtest1.dll C:\ReactOS\bin\kernel32test_versioned.dll
 move C:\ReactOS\bin\testdata\redirtest2.dll C:\ReactOS\bin\testdata\kernel32test_versioned.dll
 if exist "C:\ReactOS\bin\AHKAppTests.cmd" (


### PR DESCRIPTION
unattend.inf only allows to add RunOnce entries, which are in theory only executed on the first boot after installation.
For almost a decade, this worked anyway to start regtest.cmd again after a ReactOS crash, because the registry and thus the deletion of the RunOnce entry wasn't stored on disk in case of a crash.
Thanks to @spetreolle for the hint!

As Explorer processes the Run key right after RunOnce and therefore picks up regtest.cmd a second time during the first boot, exit the script just after adding the Run key.
Otherwise, rosautotest.exe would be started twice, with catastrophic results.