### PR TITLE
WIP. [ROSAUTOTEST] Fix and improve some log handling

### DIFF
--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -61,7 +61,7 @@ wmain(int argc, wchar_t* argv[])
 
         ss << endl
            << endl
-           << "System uptime " << setprecision(2) << fixed;
+           << "[ROSAUTOTEST] System uptime " << setprecision(2) << fixed;
         ss << ((float)GetTickCount()/1000) << " seconds" << endl;
         StringOut(ss.str());
         
@@ -91,8 +91,11 @@ wmain(int argc, wchar_t* argv[])
     }
     catch(CSimpleException& e)
     {
+        stringstream ss;
+
         // e.GetMessage() must include ending '\n'.
-        StringOut(e.GetMessage());
+        ss << "[ROSAUTOTEST] " << e.GetMessage();
+        StringOut(ss.str());
     }
     catch(CFatalException& e)
     {

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -59,8 +59,10 @@ wmain(int argc, wchar_t* argv[])
         Configuration.GetSystemInformation();
         Configuration.GetConfigurationFromFile();
 
-        ss << "\n\nSystem uptime " << setprecision(2) << fixed ;
-        ss << ((float)GetTickCount()/1000) << " seconds\n";
+        ss << endl
+           << endl
+           << "System uptime " << setprecision(2) << fixed;
+        ss << ((float)GetTickCount()/1000) << " seconds" << endl;
         StringOut(ss.str());
         
         /* Report tests startup */


### PR DESCRIPTION
## Purpose

Let it be a bit more consistent.
Also, differentiate a bit more between tests, RosAutoTest and SysReg.

## Proposed changes

- wmain(): Use endl instead of '\n', for 'System uptime' 
- wmain(): Output "[ROSAUTOTEST] " in two cases:
'System uptime' and all CSimpleException.

## TODO

- [ ] Investigate adding more "[ROSAUTOTEST] ".
