### PR TITLE
[WIN32SS][NTGDI] Keep FontSubstitutes enumeration CORE-15785

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2821,7 +2821,9 @@ GetFontFamilyInfoForSubstitutes(const LOGFONTW *LogFont,
         GetFontFamilyInfoForList(&lf, Info, pFromW->Buffer, pCount, MaxCount,
                                  &Win32Process->PrivateFontListHead);
         IntUnLockProcessPrivateFonts(Win32Process);
-        break;
+
+        if (LogFont->lfFaceName[0])
+            break;
     }
 
     return TRUE;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -2823,7 +2823,11 @@ GetFontFamilyInfoForSubstitutes(const LOGFONTW *LogFont,
         IntUnLockProcessPrivateFonts(Win32Process);
 
         if (LogFont->lfFaceName[0])
+        {
+            /* it's already matched to the exact name and charset if the name
+               was specified at here, then so don't scan more for another name */
             break;
+        }
     }
 
     return TRUE;


### PR DESCRIPTION
## Purpose
Fix CORE-15785. When `LOGFONT.lfFaceName[0] == 0`, then enumeration of font substitutes had failed.
JIRA issue: [CORE-15785](https://jira.reactos.org/browse/CORE-15785)
BEFORE:
![not-fixed-yet-g983cd57](https://user-images.githubusercontent.com/2107452/56785178-e9189f00-682e-11e9-93ab-d45d99bdfac2.png)
AFTER:
![ok2](https://user-images.githubusercontent.com/2107452/56785169-dc944680-682e-11e9-8133-04ca605a1933.png)