### PR TITLE
[ROSAUTOTEST] "Enforce" ending '\n' on C___Exception messages

### DIFF
--- a/modules/rostests/rosautotest/CConfiguration.cpp
+++ b/modules/rostests/rosautotest/CConfiguration.cpp
@@ -27,7 +27,7 @@ CConfiguration::CConfiguration()
 
     /* Check if we are running under ReactOS from the SystemRoot directory */
     if(!GetWindowsDirectoryW(WindowsDirectory, MAX_PATH))
-        FATAL("GetWindowsDirectoryW failed");
+        FATAL("GetWindowsDirectoryW failed\n");
 
     m_IsReactOS = !_wcsnicmp(&WindowsDirectory[3], L"reactos", 7);
 

--- a/modules/rostests/rosautotest/CPipe.cpp
+++ b/modules/rostests/rosautotest/CPipe.cpp
@@ -86,7 +86,7 @@ void
 CPipe::CloseReadPipe()
 {
     if (!m_hReadPipe)
-        FATAL("Trying to close already closed read pipe");
+        FATAL("Trying to close already closed read pipe\n");
     CloseHandle(m_hReadPipe);
     m_hReadPipe = NULL;
 }
@@ -98,7 +98,7 @@ void
 CPipe::CloseWritePipe()
 {
     if (!m_hWritePipe)
-        FATAL("Trying to close already closed write pipe");
+        FATAL("Trying to close already closed write pipe\n");
     CloseHandle(m_hWritePipe);
     m_hWritePipe = NULL;
 }
@@ -129,7 +129,7 @@ bool
 CPipe::Peek(PVOID Buffer, DWORD BufferSize, PDWORD BytesRead, PDWORD TotalBytesAvailable)
 {
     if (!m_hReadPipe)
-        FATAL("Trying to peek from a closed read pipe");
+        FATAL("Trying to peek from a closed read pipe\n");
 
     return PeekNamedPipe(m_hReadPipe, Buffer, BufferSize, BytesRead, TotalBytesAvailable, NULL);
 }
@@ -161,7 +161,7 @@ CPipe::Read(PVOID Buffer, DWORD NumberOfBytesToRead, PDWORD NumberOfBytesRead, D
 {
     if (!m_hReadPipe)
     {
-        FATAL("Trying to read from a closed read pipe");
+        FATAL("Trying to read from a closed read pipe\n");
     }
 
     if (ReadFile(m_hReadPipe, Buffer, NumberOfBytesToRead, NumberOfBytesRead, &m_ReadOverlapped))
@@ -232,7 +232,7 @@ bool
 CPipe::Write(LPCVOID Buffer, DWORD NumberOfBytesToWrite, PDWORD NumberOfBytesWritten)
 {
     if (!m_hWritePipe)
-        FATAL("Trying to write to a closed write pipe");
+        FATAL("Trying to write to a closed write pipe\n");
 
     return WriteFile(m_hWritePipe, Buffer, NumberOfBytesToWrite, NumberOfBytesWritten, NULL);
 }

--- a/modules/rostests/rosautotest/CWebService.cpp
+++ b/modules/rostests/rosautotest/CWebService.cpp
@@ -108,7 +108,7 @@ CWebService::Finish(const char* TestType)
     stringstream ss;
 
     if (!m_TestID)
-        EXCEPTION("CWebService::Finish was called, but not a single result had been submitted!");
+        EXCEPTION("CWebService::Finish was called, but not a single result had been submitted!\n");
 
     Data = "action=finish";
     Data += Configuration.GetAuthenticationRequestString();

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -32,7 +32,7 @@ CWineTest::CWineTest()
     else
     {
         if (!GetWindowsDirectoryW(wszDirectory, MAX_PATH))
-            FATAL("GetWindowsDirectoryW failed");
+            FATAL("GetWindowsDirectoryW failed\n");
 
         m_TestPath = wszDirectory;
         m_TestPath += L"\\bin\\";

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -89,6 +89,7 @@ wmain(int argc, wchar_t* argv[])
     }
     catch(CSimpleException& e)
     {
+        // e.GetMessage() must include ending '\n'.
         StringOut(e.GetMessage());
     }
     catch(CFatalException& e)

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -96,8 +96,9 @@ wmain(int argc, wchar_t* argv[])
     {
         stringstream ss;
 
+        // e.GetMessage() must include ending '\n'.
         ss << "An exception occured in rosautotest." << endl
-           << "Message: " << e.GetMessage() << endl
+           << "Message: " << e.GetMessage()
            << "File: " << e.GetFile() << endl
            << "Line: " << e.GetLine() << endl
            << "Last Win32 Error: " << GetLastError() << endl;


### PR DESCRIPTION
## Purpose

Add missing ones in strings, Remove duplication on output..

Split off from #1531.