### PR TITLE
[WIN32SS][NTGDI] Fix wrong IN/OUT

### DIFF
--- a/win32ss/gdi/ntgdi/coord.h
+++ b/win32ss/gdi/ntgdi/coord.h
@@ -124,7 +124,7 @@ VOID
 DC_vXformDeviceToWorld(
     IN PDC pdc,
     IN ULONG cNumPoints,
-    IN PPOINTL pptlDest,
+    OUT PPOINTL pptlDest,
     IN PPOINTL pptlSource)
 {
     XFORMOBJ xo;
@@ -140,7 +140,7 @@ VOID
 DC_vXformWorldToDevice(
     IN PDC pdc,
     IN ULONG cNumPoints,
-    IN PPOINTL pptlDest,
+    OUT PPOINTL pptlDest,
     IN PPOINTL pptlSource)
 {
     XFORMOBJ xo;

--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -1259,7 +1259,7 @@ NTAPI
 GreGetObject(
     IN HGDIOBJ hobj,
     IN INT cbCount,
-    IN PVOID pvBuffer)
+    OUT PVOID pvBuffer)
 {
     PVOID pvObj;
     UCHAR objt;

--- a/win32ss/gdi/ntgdi/gdiobj.h
+++ b/win32ss/gdi/ntgdi/gdiobj.h
@@ -111,7 +111,7 @@ NTAPI
 GreGetObject(
     IN HGDIOBJ hobj,
     IN INT cbCount,
-    IN PVOID pvBuffer);
+    OUT PVOID pvBuffer);
 
 POBJ
 NTAPI

--- a/win32ss/gdi/ntgdi/xformobj.c
+++ b/win32ss/gdi/ntgdi/xformobj.c
@@ -105,7 +105,7 @@ HintFromAccel(ULONG flAccel)
 ULONG
 NTAPI
 XFORMOBJ_UpdateAccel(
-    IN XFORMOBJ *pxo)
+    IN OUT XFORMOBJ *pxo)
 {
     PMATRIX pmx = XFORMOBJ_pmx(pxo);
 
@@ -146,7 +146,7 @@ XFORMOBJ_UpdateAccel(
 ULONG
 NTAPI
 XFORMOBJ_iSetXform(
-    OUT XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN const XFORML *pxform)
 {
     PMATRIX pmx = XFORMOBJ_pmx(pxo);
@@ -189,7 +189,7 @@ XFORMOBJ_iSetXform(
 ULONG
 NTAPI
 XFORMOBJ_iCombine(
-    IN XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN XFORMOBJ *pxo1,
     IN XFORMOBJ *pxo2)
 {
@@ -222,7 +222,7 @@ XFORMOBJ_iCombine(
 ULONG
 NTAPI
 XFORMOBJ_iCombineXform(
-    IN XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN XFORMOBJ *pxo1,
     IN XFORML *pxform,
     IN BOOL bLeftMultiply)

--- a/win32ss/gdi/ntgdi/xformobj.h
+++ b/win32ss/gdi/ntgdi/xformobj.h
@@ -36,20 +36,20 @@ XFORMOBJ_pmx(
 ULONG
 NTAPI
 XFORMOBJ_iSetXform(
-    OUT XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN const XFORML *pxform);
 
 ULONG
 NTAPI
 XFORMOBJ_iCombine(
-    IN XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN XFORMOBJ *pxo1,
     IN XFORMOBJ *pxo2);
 
 ULONG
 NTAPI
 XFORMOBJ_iCombineXform(
-    IN XFORMOBJ *pxo,
+    IN OUT XFORMOBJ *pxo,
     IN XFORMOBJ *pxo1,
     IN XFORML *pxform,
     IN BOOL bLeftMultiply);


### PR DESCRIPTION
## Purpose
There were wrong `IN`/`OUT` about the parameters of some NTGDI functions.
JIRA issue: [CORE-15983](https://jira.reactos.org/browse/CORE-15983)
