### PR TITLE
[WIN32SS][NTGDI] Fix ExtTextOut upon TA_UPDATECP

### DIFF
--- a/win32ss/gdi/ntgdi/coord.c
+++ b/win32ss/gdi/ntgdi/coord.c
@@ -600,7 +600,7 @@ NtGdiOffsetViewportOrgEx(
     }
     pdcattr->ptlViewportOrg.x += XOffset;
     pdcattr->ptlViewportOrg.y += YOffset;
-    pdcattr->flXform |= PAGE_XLATE_CHANGED | DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     DC_UnlockDc(dc);
 
@@ -652,7 +652,7 @@ NtGdiOffsetWindowOrgEx(
 
     pdcattr->ptlWindowOrg.x += XOffset;
     pdcattr->ptlWindowOrg.y += YOffset;
-    pdcattr->flXform |= PAGE_XLATE_CHANGED|DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     DC_UnlockDc(dc);
 
@@ -701,6 +701,7 @@ NtGdiScaleViewportExtEx(
 
                     pdcattr->flXform |= (PAGE_EXTENTS_CHANGED |
                                          INVALIDATE_ATTRIBUTES |
+                                         WORLD_XFORM_CHANGED |
                                          DEVICE_TO_WORLD_INVALID);
 
                     if (pdcattr->iMapMode == MM_ISOTROPIC)
@@ -802,7 +803,10 @@ NtGdiScaleWindowExtEx(
 
                     IntMirrorWindowOrg(pDC);
 
-                    pdcattr->flXform |= (PAGE_EXTENTS_CHANGED|INVALIDATE_ATTRIBUTES|DEVICE_TO_WORLD_INVALID);
+                    pdcattr->flXform |= (PAGE_EXTENTS_CHANGED |
+                                         INVALIDATE_ATTRIBUTES |
+                                         WORLD_XFORM_CHANGED |
+                                         DEVICE_TO_WORLD_INVALID);
 
                     Ret = TRUE;
                 }
@@ -896,8 +900,9 @@ IntGdiSetMapMode(
     pdcattr->iMapMode = MapMode;
 
     /* Update xform flags */
-    pdcattr->flXform = flXform | (PAGE_XLATE_CHANGED|PAGE_EXTENTS_CHANGED|
-        INVALIDATE_ATTRIBUTES|DEVICE_TO_PAGE_INVALID|DEVICE_TO_WORLD_INVALID);
+    pdcattr->flXform = flXform | (PAGE_XLATE_CHANGED | PAGE_EXTENTS_CHANGED |
+                                  INVALIDATE_ATTRIBUTES | DEVICE_TO_PAGE_INVALID |
+                                  WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID);
 
     return iPrevMapMode;
 }
@@ -929,7 +934,7 @@ GreSetViewportOrgEx(
 
     pdcattr->ptlViewportOrg.x = X;
     pdcattr->ptlViewportOrg.y = Y;
-    pdcattr->flXform |= PAGE_XLATE_CHANGED | DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     DC_UnlockDc(dc);
     return TRUE;
@@ -980,7 +985,7 @@ NtGdiSetViewportOrgEx(
 
     pdcattr->ptlViewportOrg.x = X;
     pdcattr->ptlViewportOrg.y = Y;
-    pdcattr->flXform |= PAGE_XLATE_CHANGED | DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     DC_UnlockDc(dc);
 
@@ -1032,7 +1037,7 @@ NtGdiSetWindowOrgEx(
 
     pdcattr->ptlWindowOrg.x = X;
     pdcattr->ptlWindowOrg.y = Y;
-    pdcattr->flXform |= PAGE_XLATE_CHANGED | DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     DC_UnlockDc(dc);
 
@@ -1068,7 +1073,7 @@ IntMirrorWindowOrg(PDC dc)
     X = (X * pdcattr->szlWindowExt.cx) / cx;
 
     pdcattr->ptlWindowOrg.x = pdcattr->lWindowOrgx - X; // Now set the inverted win origion.
-    pdcattr->flXform |= PAGE_XLATE_CHANGED | DEVICE_TO_WORLD_INVALID;
+    pdcattr->flXform |= PAGE_XLATE_CHANGED | WORLD_XFORM_CHANGED | DEVICE_TO_WORLD_INVALID;
 
     return;
 }
@@ -1108,6 +1113,7 @@ DC_vSetLayout(
 
     pdcattr->flXform |= (PAGE_EXTENTS_CHANGED |
                          INVALIDATE_ATTRIBUTES |
+                         WORLD_XFORM_CHANGED |
                          DEVICE_TO_WORLD_INVALID);
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6306,8 +6306,11 @@ IntExtTextOutW(
             MouseSafetyOnDrawEnd(dc->ppdev);
     }
 
-    if (pdcattr->flTextAlign & TA_UPDATECP) {
-        pdcattr->ptlCurrent.x = DestRect.right - dc->ptlDCOrig.x;
+    if (pdcattr->flTextAlign & TA_UPDATECP)
+    {
+        pdcattr->ptlCurrent.x = vecs[2].x - dc->ptlDCOrig.x;
+        pdcattr->ptlCurrent.y = vecs[2].y - dc->ptlDCOrig.y;
+        IntDPtoLP(dc, &pdcattr->ptlCurrent, 1);
     }
 
     IntUnLockFreeType();


### PR DESCRIPTION
## Purpose
The `ExtTextOut` function didn't correctly update the current position when the text alignment was `TA_UPDATECP`.
JIRA issue: [CORE-14994](https://jira.reactos.org/browse/CORE-14994)
- Add `WORLD_XFORM_CHANGED` flag to some positioning functions.
- Fix `IntExtTextOutW` function for `TA_UPDATECP` alignment, so that it can correctly update the current position.
