### PR TITLE
Fix VSSolution build CORE-15991

### DIFF
--- a/base/applications/winhlp32/CMakeLists.txt
+++ b/base/applications/winhlp32/CMakeLists.txt
@@ -14,9 +14,6 @@ list(APPEND SOURCE
     winhelp.c
     precomp.h)
 
-# macro.lex.yy.c has been generated with relative file paths...
-set_source_files_properties(macro.lex.yy.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 add_rc_deps(rsrc.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/winhelp.ico)
 add_executable(winhlp32 ${SOURCE} macro.lex.yy.c string.c rsrc.rc)
 set_module_type(winhlp32 win32gui)

--- a/dll/directx/wine/d3dcompiler_43/CMakeLists.txt
+++ b/dll/directx/wine/d3dcompiler_43/CMakeLists.txt
@@ -31,14 +31,6 @@ add_library(d3dcompiler_43 MODULE
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/d3dcompiler_43.def)
 
-# some files have been generated with relative file paths...
-set_source_files_properties(
-    asmshader.tab.c
-    asmshader.yy.c
-    hlsl.tab.c
-    hlsl.yy.c
-    PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 set_module_type(d3dcompiler_43 win32dll)
 target_link_libraries(d3dcompiler_43 dx10guid uuid wine wpp)
 add_importlibs(d3dcompiler_43 msvcrt kernel32 ntdll)

--- a/dll/win32/jscript/CMakeLists.txt
+++ b/dll/win32/jscript/CMakeLists.txt
@@ -33,9 +33,6 @@ list(APPEND SOURCE
     vbarray.c
     precomp.h)
 
-# cc_parser.tab.c/parser.tab.c have been generated with relative file paths...
-set_source_files_properties(cc_parser.tab.c parser.tab.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 list(APPEND jscript_rc_deps
     ${CMAKE_CURRENT_SOURCE_DIR}/jscript.rgs
     ${CMAKE_CURRENT_SOURCE_DIR}/jscript_classes.rgs

--- a/dll/win32/msi/CMakeLists.txt
+++ b/dll/win32/msi/CMakeLists.txt
@@ -57,9 +57,6 @@ list(APPEND SOURCE
     where.c
     precomp.h)
 
-# cond.tab.c/sql.tab.c have been generated with relative file paths...
-set_source_files_properties(cond.tab.c sql.tab.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 add_library(msi MODULE
     ${SOURCE}
     cond.tab.c

--- a/dll/win32/msxml3/CMakeLists.txt
+++ b/dll/win32/msxml3/CMakeLists.txt
@@ -50,9 +50,6 @@ list(APPEND SOURCE
     precomp.h
     ${CMAKE_CURRENT_BINARY_DIR}/msxml3_stubs.c)
 
-# xslpattern.tab.c/xslpattern.yy.c have been generated with relative file paths...
-set_source_files_properties(xslpattern.tab.c xslpattern.yy.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 list(APPEND msxml3_rc_deps
     ${CMAKE_CURRENT_SOURCE_DIR}/msxml3.manifest
     ${CMAKE_CURRENT_SOURCE_DIR}/msxml3_v1.rgs

--- a/dll/win32/vbscript/CMakeLists.txt
+++ b/dll/win32/vbscript/CMakeLists.txt
@@ -16,9 +16,6 @@ list(APPEND SOURCE
     vbscript_main.c
     precomp.h)
 
-# parser.tab.c has been generated with relative file paths...
-set_source_files_properties(parser.tab.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 list(APPEND vbscript_rc_deps
     ${CMAKE_CURRENT_SOURCE_DIR}/vbscript_classes.rgs
     ${CMAKE_CURRENT_SOURCE_DIR}/vbsglobal.rgs

--- a/dll/win32/wbemprox/CMakeLists.txt
+++ b/dll/win32/wbemprox/CMakeLists.txt
@@ -21,9 +21,6 @@ list(APPEND SOURCE
     wbemlocator.c
     precomp.h)
 
-# wql.tab.c has been generated with relative file paths...
-set_source_files_properties(wql.tab.c PROPERTIES COMPILE_FLAGS "-UREACTOS_SOURCE_DIR -DREACTOS_SOURCE_DIR=\"\\\".\\\"\"")
-
 add_library(wbemprox MODULE
     ${SOURCE}
     wql.tab.c


### PR DESCRIPTION
## Purpose

This reverts commit 09c4d0a74b2362e2c9d29ec87c54ecc3bddd5b79.

After other fixes, that commit is now doing more bad than good, if any.
Fixes VSSolution build.

JIRA issue: [CORE-15991](https://jira.reactos.org/browse/CORE-15991)

This seems to restore builds as they were initially.
Unless there would be an additional fix to apply instead, with regard to VSS and maybe Clang.
Note that I am not sure which case/behavior that commit intended to fix...

Cc @hpoussin
