### PR TITLE
CORE-12716. [CONFIGURE] configure.sh: Add an ending "cd .." to old style build

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -76,4 +76,8 @@ rm -f CMakeCache.txt host-tools/CMakeCache.txt
 
 cmake -G "$CMAKE_GENERATOR" -DENABLE_CCACHE:BOOL=0 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-gcc.cmake -DARCH:STRING=$ARCH -DNEW_STYLE_BUILD:BOOL=$USE_NEW_STYLE $EXTRA_ARGS $ROS_CMAKEOPTS "$REACTOS_SOURCE_DIR"
 
+if [ $USE_NEW_STYLE -eq 0 ]; then
+	cd ..
+fi
+
 echo Configure script complete! Enter directories and execute appropriate build commands \(ex: ninja, make, makex, etc...\).


### PR DESCRIPTION
## Purpose

This makes configure.sh consistent with configure.cmd.

Addendum to 53ce7d4370d2dbcce0217b12d8a93d556a36a55b.

On behalf of "Tim".
JIRA issue: [CORE-12716](https://jira.reactos.org/browse/CORE-12716)

Builds successfully with `.../configure.sh with-host-tools && cd host-tools && ninja -k0 && cd ../reactos && ninja -k0 && ninja bootcd'`.