### PR TITLE
[ROSAUTOTEST] Don't disallow buffering for journal file

### DIFF
--- a/modules/rostests/rosautotest/CJournaledTestList.cpp
+++ b/modules/rostests/rosautotest/CJournaledTestList.cpp
@@ -70,7 +70,7 @@ CJournaledTestList::OpenJournal(DWORD DesiredAccess, bool CreateNew)
         0,
         NULL,
         (CreateNew ? CREATE_ALWAYS : OPEN_EXISTING),
-        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_NO_BUFFERING | FILE_FLAG_WRITE_THROUGH,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH,
         NULL
     );
 


### PR DESCRIPTION
This fixes back journal in ReactOS "at low costs". Indeed,
because write are improperly aligned right now, journaling
just fails.
With that patch, Cc will take care of aligning writes and
journal will be written again. Because flush operations
happen at each and every write to the journal, we expect
changes to land on disk quickly (not as quickly as if
they were directly written). But that's a good trade off
between over engineering and fixing a broken feature.

JIRA issue: [CORE-15973](https://jira.reactos.org/browse/CORE-15973)