### PR TITLE
[VIDEOPRT] VideoPortEnableInterrupt(): Demote an ASSERT(). CORE-16002

### DIFF
--- a/win32ss/drivers/videoprt/interrupt.c
+++ b/win32ss/drivers/videoprt/interrupt.c
@@ -135,7 +135,11 @@ VideoPortEnableInterrupt(IN PVOID HwDeviceExtension)
                                               DeviceExtension->InterruptLevel);
 
     /* Make sure the interrupt was valid */
-    ASSERT(InterruptValid == TRUE);
+    if (!InterruptValid)
+    {
+        ERR_(VIDEOPRT, "HalEnableSystemInterrupt failed. Ignored\n");
+        /* FIXME: Should we (WARN_() only and) "return ERROR_INVALID_FUNCTION;"? */
+    }
 
     /* Return to caller */
     return NO_ERROR;


### PR DESCRIPTION
## Purpose

@ThFabba wrote
> It looks like Windows ignores HalEnableSystemInterrupt's return value, so I suppose we could just remove the assert.

[HalEnableSystemInterrupt grep](https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=HalEnableSystemInterrupt)

Part of
JIRA issue: [CORE-16002](https://jira.reactos.org/browse/CORE-16002) and CORE-13036 too

## Proposed changes

- Demote `ASSERT()` to `ERR_()`, as a minimal step.
- Add a FIXME comment.

## TODO

- [ ] Optionally answer the FIXME.
`Should we (WARN_() only and) "return ERROR_INVALID_FUNCTION;"?`

[(MS) VideoPortEnableInterrupt()](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/video/nf-video-videoportenableinterrupt)
> If VideoPortEnableInterrupt succeeds, it returns NO_ERROR. Otherwise, it returns ERROR_INVALID_FUNCTION.