### PR TITLE
[BROWSEUI_APITEST] Add a test for SHEnumClassesOfCategories. CORE-11711

### DIFF
--- a/dll/win32/browseui/browseui.spec
+++ b/dll/win32/browseui/browseui.spec
@@ -26,6 +26,6 @@
 133 stdcall -noname Channel_QuickLaunch()
 134 stdcall -noname SHGetNavigateTarget(long long long long)
 135 stdcall -noname GetInfoTip(ptr long wstr long)
-136 stdcall -noname SHEnumClassesOfCategories(long long long long long)
+136 stdcall -noname SHEnumClassesOfCategories(long ptr long ptr ptr)
 137 stdcall -noname SHWriteClassesOfCategories(long long long long long long long)
 138 stdcall -noname SHIsExplorerBrowser()

--- a/dll/win32/browseui/shellbars/CSHEnumClassesOfCategories.cpp
+++ b/dll/win32/browseui/shellbars/CSHEnumClassesOfCategories.cpp
@@ -254,17 +254,16 @@ HRESULT CSHEnumClassesOfCategories::Initialize(ULONG cImplemented, CATID *pImple
     if (!fDsa)
         return E_FAIL;
 
-    if (cRequired > 0 || cImplemented == (ULONG)-1)
-    {
-        FIXME("Implement required categories class enumeration\n");
-        return E_NOTIMPL;
-    }
+    // Parameter validation:
+    // - We must have at least one category to manage.
+    // - The array pointers must not be NULL if there is a non-zero
+    //   element count specified for them.
+    if (cImplemented == 0 && cRequired == 0)
+        return E_INVALIDARG;
+    if ((cImplemented && !pImplemented) || (cRequired && !pRequired))
+        return E_INVALIDARG;
 
-    // Don't do anything if we have nothing
-    if (cRequired == 0 && cImplemented == (ULONG)-1)
-        return E_FAIL;
-
-    // For each implemented category, create a cache and add it to our local DSA
+    // For each implemented category, create a cache and add it to our local DSA.
     for (i = 0; i < cImplemented; i++)
     {
         CComCatCachedCategory cachedCat;
@@ -273,6 +272,17 @@ HRESULT CSHEnumClassesOfCategories::Initialize(ULONG cImplemented, CATID *pImple
             return hr;
         cachedCat.WriteCacheToDSA(fDsa);
     }
+
+    // TODO: Implement caching of the required categories.
+    if (cRequired > 0)
+    {
+        FIXME("Implement required categories class enumeration\n");
+
+        // Only fail in case we didn't look at the implemented categories.
+        if (cImplemented == 0)
+            return E_NOTIMPL;
+    }
+
     return S_OK;
 }
 

--- a/modules/rostests/apitests/browseui/CMakeLists.txt
+++ b/modules/rostests/apitests/browseui/CMakeLists.txt
@@ -12,6 +12,7 @@ include_directories(
 list(APPEND SOURCE
     ACListISF.cpp
     IACLCustomMRU.cpp
+    SHEnumClassesOfCategories.cpp
     SHExplorerParseCmdLine.c
     testlist.c)
 

--- a/modules/rostests/apitests/browseui/SHEnumClassesOfCategories.cpp
+++ b/modules/rostests/apitests/browseui/SHEnumClassesOfCategories.cpp
@@ -1,0 +1,247 @@
+/*
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Test for SHEnumClassesOfCategories
+ * COPYRIGHT:   Copyright 2019 Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
+ */
+
+/*
+TODO, if they make sense:
+* Test more than 1 Implemented/Required.
+  And maybe not "matching" ones.
+* Check pEnumGUID after S_OK cases.
+*/
+
+#include <apitest.h>
+
+#include <shlobj.h>
+#include <atlbase.h>
+
+typedef HRESULT (WINAPI *SHENUMCLASSESOFCATEGORIES)(ULONG cImplemented, CATID *pImplemented, ULONG cRequired, CATID *pRequired, IEnumGUID **out);
+
+static SHENUMCLASSESOFCATEGORIES pSHEnumClassesOfCategories;
+
+START_TEST(SHEnumClassesOfCategories)
+{
+    HRESULT hr;
+    HMODULE hbrowseui;
+    CATID CategoryImplemented, CategoryRequired;
+    CComPtr<IEnumGUID> pEnumGUID;
+
+    // Set up.
+
+    hbrowseui = LoadLibraryA("browseui.dll");
+    ok(hbrowseui != NULL, "LoadLibraryA() failed\n");
+    if (!hbrowseui)
+    {
+        skip("No dll\n");
+        return;
+    }
+
+    pSHEnumClassesOfCategories = (SHENUMCLASSESOFCATEGORIES)GetProcAddress(hbrowseui, MAKEINTRESOURCEA(136));
+    ok(pSHEnumClassesOfCategories != NULL, "GetProcAddress() failed\n");
+    if (!pSHEnumClassesOfCategories)
+    {
+        skip("No function, as on NT 6.1+\n");
+        return;
+    }
+
+    // Test (mostly) invalid arguments.
+
+    // Implemented, '(ULONG)-1, NULL'.
+    // Keep this odd case, as ReactOS used to "implement" it.
+
+    // hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 0, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 0, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    CategoryRequired = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 1, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    // Implemented, '0, NULL'.
+
+    // hr = pSHEnumClassesOfCategories(0, NULL, 0, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(0, NULL, 0, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    // CategoryRequired = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    // The following case duplicates a later one.
+    // hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    // ok_long(hr, S_OK);
+    // ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    // pEnumGUID = NULL;
+
+    // Implemented, '0, &CategoryImplemented'.
+
+    CategoryImplemented = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 0, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    CategoryRequired = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
+    ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryRequired = CATID_InfoBand;
+    // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
+    ok(CategoryRequired == CATID_InfoBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    // Implemented, '1, NULL'.
+
+    // hr = pSHEnumClassesOfCategories(1, NULL, 0, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(1, NULL, 0, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    CategoryRequired = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(1, NULL, 1, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(1, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    // Required, '0, &CategoryRequired'.
+
+    CategoryRequired = CATID_DeskBand;
+
+    CategoryImplemented = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
+    ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryImplemented = CATID_InfoBand;
+    // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_InfoBand, "CategoryImplemented was modified\n");
+    ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    // Required, '1, NULL'.
+
+    // hr = pSHEnumClassesOfCategories(0, NULL, 1, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    CategoryImplemented = CATID_DeskBand;
+    // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, NULL, NULL);
+    // ok_long(hr, E_INVALIDARG);
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, NULL, &pEnumGUID);
+    ok_long(hr, E_INVALIDARG);
+
+    // Out, 'NULL'.
+    // Previous similar checks are commented out, for usual use.
+
+    CategoryImplemented = CATID_DeskBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, NULL);
+    ok_long(hr, E_INVALIDARG);
+
+    CategoryRequired = CATID_DeskBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, &CategoryRequired, NULL);
+    ok_long(hr, E_INVALIDARG);
+
+    // Test success.
+    // CATID_* from sdk/include/psdk/shlguid.h.
+    // See also modules/rostests/winetests/shlwapi/clsid.c.
+
+    // Each CATID, as Implemented.
+
+    CategoryImplemented = CATID_BrowsableShellExt;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_BrowsableShellExt, "CategoryImplemented was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryImplemented = CATID_BrowseInPlace;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_BrowseInPlace, "CategoryImplemented was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryImplemented = CATID_DeskBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryImplemented = CATID_InfoBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_InfoBand, "CategoryImplemented was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryImplemented = CATID_CommBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_CommBand, "CategoryImplemented was modified\n");
+    pEnumGUID = NULL;
+
+    // Each CATID, as Required.
+
+    CategoryRequired = CATID_BrowsableShellExt;
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryRequired == CATID_BrowsableShellExt, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryRequired = CATID_BrowseInPlace;
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryRequired == CATID_BrowseInPlace, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryRequired = CATID_DeskBand;
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryRequired = CATID_InfoBand;
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryRequired == CATID_InfoBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    CategoryRequired = CATID_CommBand;
+    hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryRequired == CATID_CommBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    // Same CATID, as Implemented and Required.
+
+    CategoryImplemented = CATID_DeskBand;
+    CategoryRequired = CATID_DeskBand;
+    hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
+    ok_long(hr, S_OK);
+    ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
+    ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
+    pEnumGUID = NULL;
+
+    // Clean up.
+
+    ok(FreeLibrary(hbrowseui) != 0, "FreeLibrary() failed\n");
+}

--- a/modules/rostests/apitests/browseui/testlist.c
+++ b/modules/rostests/apitests/browseui/testlist.c
@@ -5,14 +5,14 @@
 
 extern void func_ACListISF(void);
 extern void func_IACLCustomMRU(void);
+extern void func_SHEnumClassesOfCategories(void);
 extern void func_SHExplorerParseCmdLine(void);
 
 const struct test winetest_testlist[] =
 {
     { "ACListISF", func_ACListISF },
     { "IACLCustomMRU", func_IACLCustomMRU },
+    { "SHEnumClassesOfCategories", func_SHEnumClassesOfCategories },
     { "SHExplorerParseCmdLine", func_SHExplorerParseCmdLine },
-
     { 0, 0 }
 };
-


### PR DESCRIPTION
## Purpose

Mark wrote
> Can we prove this is correct with an apitest?

JIRA issue: [CORE-11711](https://jira.reactos.org/browse/CORE-11711)

[WTB 52076](https://testbot.winehq.org/JobDetails.pl?Key=52076)
On ReactOS, test crashes with an 'Unhandled exception', on first `1, NULL` case, as the function does not/poorly validate arguments.

## Proposed changes

- [BROWSEUI] browseui.spec: Fix SHEnumClassesOfCategories() parameters
- [BROWSEUI_APITEST] Add a test for SHEnumClassesOfCategories
