### PR TITLE
[NTOS:PNP] When traversing the device tree, keep a reference to the current device

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -1518,33 +1518,50 @@ IopTraverseDeviceTreeNode(PDEVICETREE_TRAVERSE_CONTEXT Context)
 {
     PDEVICE_NODE ParentDeviceNode;
     PDEVICE_NODE ChildDeviceNode;
+    PDEVICE_NODE NextDeviceNode;
     NTSTATUS Status;
 
     /* Copy context data so we don't overwrite it in subsequent calls to this function */
     ParentDeviceNode = Context->DeviceNode;
 
+    /* HACK: Keep a reference to the PDO so we can keep traversing the tree
+     * if the device is deleted. In a perfect world, children would have to be
+     * deleted before their parents, and we'd restart the traversal after
+     * deleting a device node. */
+    ObReferenceObject(ParentDeviceNode->PhysicalDeviceObject);
+
     /* Call the action routine */
     Status = (Context->Action)(ParentDeviceNode, Context->Context);
     if (!NT_SUCCESS(Status))
     {
+        ObDereferenceObject(ParentDeviceNode->PhysicalDeviceObject);
         return Status;
     }
 
     /* Traversal of all children nodes */
     for (ChildDeviceNode = ParentDeviceNode->Child;
          ChildDeviceNode != NULL;
-         ChildDeviceNode = ChildDeviceNode->Sibling)
+         ChildDeviceNode = NextDeviceNode)
     {
+        /* HACK: We need this reference to ensure we can get Sibling below. */
+        ObReferenceObject(ChildDeviceNode->PhysicalDeviceObject);
+
         /* Pass the current device node to the action routine */
         Context->DeviceNode = ChildDeviceNode;
 
         Status = IopTraverseDeviceTreeNode(Context);
         if (!NT_SUCCESS(Status))
         {
+            ObDereferenceObject(ChildDeviceNode->PhysicalDeviceObject);
+            ObDereferenceObject(ParentDeviceNode->PhysicalDeviceObject);
             return Status;
         }
+
+        NextDeviceNode = ChildDeviceNode->Sibling;
+        ObDereferenceObject(ChildDeviceNode->PhysicalDeviceObject);
     }
 
+    ObDereferenceObject(ParentDeviceNode->PhysicalDeviceObject);
     return Status;
 }
 


### PR DESCRIPTION
Devices can be deleted during the traversal, so in order to keep the tree walk intact without use-after-free situations, this just keeps the PDO around until we no longer need the device node.

It could be argued that this is a hack, however implementing it the "correct way" (I haven't actually researched how Windows does this) is unlikely to be possible with our current PNP manager -- so this should keep us going for a while.

JIRA issue: [CORE-15874](https://jira.reactos.org/browse/CORE-15874)