### PR TITLE
[WIN32SS][NTGDI] Don't use FLOAT in IntEscapeMatrix

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -719,8 +719,8 @@ VOID FASTCALL IntWidthMatrix(FT_Face face, FT_Matrix *pmat, LONG lfWidth)
 VOID FASTCALL IntEscapeMatrix(FT_Matrix *pmat, LONG lfEscapement)
 {
     FT_Vector vecAngle;
-    /* Convert from angle in tenths of degrees to 'FT_Angle' degrees */
-    FT_Angle angle = FT_FixedFromFloat((FLOAT)lfEscapement / 10);
+    /* Convert the angle in tenths of degrees into degrees as a 16.16 fixed-point value */
+    FT_Angle angle = lfEscapement * (1 << 16) / 10;
     FT_Vector_Unit(&vecAngle, angle);
     pmat->xx = vecAngle.x;
     pmat->xy = -vecAngle.y;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -720,7 +720,7 @@ VOID FASTCALL IntEscapeMatrix(FT_Matrix *pmat, LONG lfEscapement)
 {
     FT_Vector vecAngle;
     /* Convert the angle in tenths of degrees into degrees as a 16.16 fixed-point value */
-    FT_Angle angle = lfEscapement * (1 << 16) / 10;
+    FT_Angle angle = INT_TO_FIXED(lfEscapement) / 10;
     FT_Vector_Unit(&vecAngle, angle);
     pmat->xx = vecAngle.x;
     pmat->xy = -vecAngle.y;


### PR DESCRIPTION
## Purpose
Appendum to 1a402847ed307af7e72fcd9e15bb970b4285690d.
JIRA issue: [CORE-15838](https://jira.reactos.org/browse/CORE-15838)
Use a 16.16 fixed point value instead of `FT_FixedFromFloat` function.

![fixed-point](https://user-images.githubusercontent.com/2107452/58214457-ba5bee80-7d30-11e9-8f52-3c4264dece32.png)
