### PR TITLE
[WIN32SS][NTGDI] Avoid allocation of zero size in NtGdiGetGlyphIndicesW

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6958,7 +6958,7 @@ NtGdiGetGlyphIndicesW(
                 cwc = GDI_ERROR;
                 goto ErrorRet;
             }
-            Size = IntGetOutlineTextMetrics(FontGDI, DataSize, potm);
+            Size = IntGetOutlineTextMetrics(FontGDI, Size, potm);
             if (Size)
                 DefChar = potm->otmTextMetrics.tmDefaultChar;
             ExFreePoolWithTag(potm, GDITAG_TEXT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6990,18 +6990,21 @@ NtGdiGetGlyphIndicesW(
 
     if (!NT_SUCCESS(Status)) goto ErrorRet;
 
-    IntLockFreeType();
-
-    for (i = 0; i < cwc; i++)
+    if (cwc)
     {
-        Buffer[i] = get_glyph_index(FontGDI->SharedFace->Face, Safepwc[i]);
-        if (Buffer[i] == 0)
-        {
-            Buffer[i] = DefChar;
-        }
-    }
+        IntLockFreeType();
 
-    IntUnLockFreeType();
+        for (i = 0; i < cwc; i++)
+        {
+            Buffer[i] = get_glyph_index(FontGDI->SharedFace->Face, Safepwc[i]);
+            if (Buffer[i] == 0)
+            {
+                Buffer[i] = DefChar;
+            }
+        }
+
+        IntUnLockFreeType();
+    }
 
     _SEH2_TRY
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6899,10 +6899,13 @@ NtGdiGetGlyphIndicesW(
         return GDI_ERROR;
     }
 
-    if (!UnSafepwc && !UnSafepgi)
-        return cwc;
+    if (!UnSafepwc && !UnSafepgi && cwc > 0)
+    {
+        DPRINT1("!UnSafepwc && !UnSafepgi && cwc > 0\n");
+        return GDI_ERROR;
+    }
 
-    if (!UnSafepwc || !UnSafepgi)
+    if (!UnSafepwc != !UnSafepgi)
     {
         DPRINT1("UnSafepwc == %p, UnSafepgi = %p\n", UnSafepwc, UnSafepgi);
         return GDI_ERROR;
@@ -6929,8 +6932,16 @@ NtGdiGetGlyphIndicesW(
 
     if (cwc == 0)
     {
-        Status = STATUS_UNSUCCESSFUL;
-        goto ErrorRet;
+        if (!UnSafepwc && !UnSafepgi)
+        {
+            Face = FontGDI->SharedFace->Face;
+            return Face->num_glyphs;
+        }
+        else
+        {
+            Status = STATUS_UNSUCCESSFUL;
+            goto ErrorRet;
+        }
     }
 
     Buffer = ExAllocatePoolWithTag(PagedPool, cwc * sizeof(WORD), GDITAG_TEXT);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6886,7 +6886,7 @@ NtGdiGetGlyphIndicesW(
     INT i;
     WCHAR DefChar = 0xffff;
     PWSTR Buffer = NULL, Safepwc = NULL;
-    DWORD Size, pwcSize;
+    ULONG Size, pwcSize;
     LPCWSTR UnSafepwc = pwc;
     LPWORD UnSafepgi = pgi;
     FT_Face Face;


### PR DESCRIPTION
## Purpose
In `NtGdiGetGlyphIndicesW` function, allocation of zero size had caused fatal failures.
JIRA issue: [CORE-12825](https://jira.reactos.org/browse/CORE-12825)
- Avoid allocation of zero size in `ExAllocatePoolWithTag` calls.
- Optimize for `cwc == 0`.