### PR TITLE
[KERNEL32_APITEST] Add SetComputerNameExW testcase

### DIFF
--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SOURCE
     Mailslot.c
     MultiByteToWideChar.c
     PrivMoveFileIdentityW.c
+    SetComputerNameExW.c
     SetConsoleWindowInfo.c
     SetCurrentDirectory.c
     SetUnhandledExceptionFilter.c

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -74,28 +74,9 @@ START_TEST(SetComputerNameExW)
     ok_long(Error, ERROR_SUCCESS);
     ok(szComputerNameOld[0], "szHostNameOld is %S", szComputerNameOld);
 
-    /* Close keys */
-    Error = RegCloseKey(hKeyHN);
-    ok_long(Error, ERROR_SUCCESS);
-    Error = RegCloseKey(hKeyCN);
-    ok_long(Error, ERROR_SUCCESS);
-
     /* Change the value */
     ret = SetComputerNameExW(ComputerNamePhysicalDnsHostname, szNewName);
     ok_int(ret, TRUE);
-
-    /* Open keys */
-    hKeyHN = OpenHostNameKey();
-    hKeyCN = OpenComputerNameKey();
-    if (!hKeyHN || !hKeyCN)
-    {
-        if (hKeyHN)
-            RegCloseKey(hKeyHN);
-        if (hKeyCN)
-            RegCloseKey(hKeyCN);
-        skip("Unable to open keys (%p, %p).\n", hKeyHN, hKeyCN);
-        return;
-    }
 
     /* Get New Hostname */
     szHostNameNew[0] = UNICODE_NULL;

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -1,0 +1,128 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for the SetComputerNameExW API
+ * COPYRIGHT:   Victor Martinez Calvo (victor.martinez@reactos.org)
+ *              Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+#include <apitest.h>
+
+#define WIN32_NO_STATUS
+#include <stdio.h>
+#include <ndk/rtltypes.h>
+
+#undef _WIN32_WINNT
+#define _WIN32_WINNT 0x0600
+#include <winreg.h>
+
+static HKEY OpenHostNameKey(void)
+{
+    static const WCHAR
+        RegHostNameKey[] = L"System\\CurrentControlSet\\Services\\Tcpip\\Parameters";
+    HKEY hKey = NULL;
+    LONG Error = RegOpenKeyExW(HKEY_LOCAL_MACHINE, RegHostNameKey, 0, KEY_ALL_ACCESS, &hKey);
+    if (!Error)
+        return hKey;
+    return NULL;
+}
+
+static HKEY OpenComputerNameKey(void)
+{
+    static const WCHAR
+        RegComputerNameKey[] = L"System\\CurrentControlSet\\Control\\ComputerName\\ComputerName";
+    HKEY hKey = NULL;
+    LONG Error = RegOpenKeyExW(HKEY_LOCAL_MACHINE, RegComputerNameKey, 0, KEY_ALL_ACCESS, &hKey);
+    if (!Error)
+        return hKey;
+    return NULL;
+}
+
+START_TEST(SetComputerNameExW)
+{
+    LONG Error;
+    BOOL ret;
+    HKEY hKeyHN, hKeyCN;
+    DWORD cbData;
+    WCHAR szHostNameOld[MAX_PATH], szHostNameNew[MAX_PATH];
+    WCHAR szComputerNameOld[MAX_PATH], szComputerNameNew[MAX_PATH];
+    static const WCHAR szNewName[] = L"SRVROSTEST";
+
+    /* Open keys */
+    hKeyHN = OpenHostNameKey();
+    hKeyCN = OpenComputerNameKey();
+    if (!hKeyHN || !hKeyCN)
+    {
+        RegCloseKey(hKeyHN);
+        RegCloseKey(hKeyCN);
+        skip("Unable to open keys (%p, %p).\n", hKeyHN, hKeyCN);
+        return;
+    }
+
+    /* Get Old Hostname */
+    szHostNameOld[0] = UNICODE_NULL;
+    cbData = sizeof(szHostNameOld);
+    Error = RegQueryValueExW(hKeyHN, L"Hostname", NULL, NULL, (LPBYTE)szHostNameOld, &cbData);
+    ok_long(Error, ERROR_SUCCESS);
+    ok(szHostNameOld[0], "szHostNameOld is %S", szHostNameOld);
+
+    /* Get Old Computer Name */
+    szComputerNameOld[0] = UNICODE_NULL;
+    cbData = sizeof(szComputerNameOld);
+    Error = RegQueryValueExW(hKeyCN, L"ComputerName", NULL, NULL, (LPBYTE)szComputerNameOld, &cbData);
+    ok_long(Error, ERROR_SUCCESS);
+    ok(szComputerNameOld[0], "szHostNameOld is %S", szComputerNameOld);
+
+    /* Close keys */
+    Error = RegCloseKey(hKeyHN);
+    ok_long(Error, ERROR_SUCCESS);
+    Error = RegCloseKey(hKeyCN);
+    ok_long(Error, ERROR_SUCCESS);
+
+    /* Change the value */
+    ret = SetComputerNameExW(ComputerNamePhysicalDnsHostname, szNewName);
+    ok_int(ret, TRUE);
+
+    /* Open keys */
+    hKeyHN = OpenHostNameKey();
+    hKeyCN = OpenComputerNameKey();
+    if (!hKeyHN || !hKeyCN)
+    {
+        RegCloseKey(hKeyHN);
+        RegCloseKey(hKeyCN);
+        skip("Unable to open keys (%p, %p).\n", hKeyHN, hKeyCN);
+        return;
+    }
+
+    /* Get New Hostname */
+    szHostNameNew[0] = UNICODE_NULL;
+    cbData = sizeof(szHostNameNew);
+    Error = RegQueryValueExW(hKeyHN, L"Hostname", NULL, NULL, (LPBYTE)szHostNameNew, &cbData);
+    ok_long(Error, ERROR_SUCCESS);
+    ok(szHostNameNew[0], "szHostNameNew was empty.\n");
+    ok(lstrcmpW(szHostNameNew, szHostNameOld) == 0,
+       "szHostNameNew '%S' should be szHostNameOld '%S'.\n", szHostNameNew, szHostNameOld);
+
+    /* Get New Computer Name */
+    szComputerNameNew[0] = UNICODE_NULL;
+    cbData = sizeof(szComputerNameNew);
+    Error = RegQueryValueExW(hKeyCN, L"ComputerName", NULL, NULL, (LPBYTE)szComputerNameNew, &cbData);
+    ok_long(Error, ERROR_SUCCESS);
+    ok(szComputerNameNew[0], "szComputerNameNew was empty.\n");
+    ok(lstrcmpW(szComputerNameNew, szNewName) == 0,
+       "szComputerNameNew '%S' should be szNewName '%S'.\n", szComputerNameNew, szNewName);
+
+    /* Restore the registry values */
+    cbData = (lstrlenW(szHostNameOld) + 1) * sizeof(WCHAR);
+    Error = RegSetValueExW(hKeyHN, L"Hostname", 0, REG_SZ, (LPBYTE)szHostNameOld, cbData);
+    ok_long(Error, ERROR_SUCCESS);
+
+    cbData = (lstrlenW(szComputerNameOld) + 1) * sizeof(WCHAR);
+    Error = RegSetValueExW(hKeyCN, L"ComputerName", 0, REG_SZ, (LPBYTE)szComputerNameOld, cbData);
+    ok_long(Error, ERROR_SUCCESS);
+
+    /* Close keys */
+    Error = RegCloseKey(hKeyHN);
+    ok_long(Error, ERROR_SUCCESS);
+    Error = RegCloseKey(hKeyCN);
+    ok_long(Error, ERROR_SUCCESS);
+}

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -52,8 +52,10 @@ START_TEST(SetComputerNameExW)
     hKeyCN = OpenComputerNameKey();
     if (!hKeyHN || !hKeyCN)
     {
-        RegCloseKey(hKeyHN);
-        RegCloseKey(hKeyCN);
+        if (hKeyHN)
+            RegCloseKey(hKeyHN);
+        if (hKeyCN)
+            RegCloseKey(hKeyCN);
         skip("Unable to open keys (%p, %p).\n", hKeyHN, hKeyCN);
         return;
     }
@@ -87,8 +89,10 @@ START_TEST(SetComputerNameExW)
     hKeyCN = OpenComputerNameKey();
     if (!hKeyHN || !hKeyCN)
     {
-        RegCloseKey(hKeyHN);
-        RegCloseKey(hKeyCN);
+        if (hKeyHN)
+            RegCloseKey(hKeyHN);
+        if (hKeyCN)
+            RegCloseKey(hKeyCN);
         skip("Unable to open keys (%p, %p).\n", hKeyHN, hKeyCN);
         return;
     }

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -26,6 +26,7 @@ extern void func_lstrlen(void);
 extern void func_Mailslot(void);
 extern void func_MultiByteToWideChar(void);
 extern void func_PrivMoveFileIdentityW(void);
+extern void func_SetComputerNameExW(void);
 extern void func_SetConsoleWindowInfo(void);
 extern void func_SetCurrentDirectory(void);
 extern void func_SetUnhandledExceptionFilter(void);
@@ -59,6 +60,7 @@ const struct test winetest_testlist[] =
     { "MailslotRead",                func_Mailslot },
     { "MultiByteToWideChar",         func_MultiByteToWideChar },
     { "PrivMoveFileIdentityW",       func_PrivMoveFileIdentityW },
+    { "SetComputerNameExW",          func_SetComputerNameExW },
     { "SetConsoleWindowInfo",        func_SetConsoleWindowInfo },
     { "SetCurrentDirectory",         func_SetCurrentDirectory },
     { "SetUnhandledExceptionFilter", func_SetUnhandledExceptionFilter },
@@ -68,4 +70,3 @@ const struct test winetest_testlist[] =
     { "WideCharToMultiByte",         func_WideCharToMultiByte },
     { 0, 0 }
 };
-


### PR DESCRIPTION
## Purpose
Add testcase of `kernel32!SetComputerNameExW` function.
JIRA issue: [ROSTESTS-227](https://jira.reactos.org/browse/ROSTESTS-227)

Win2k3 (with Admin Rights):
![SetComputerNameExW-Win2k3](https://user-images.githubusercontent.com/2107452/58368155-f99e6100-7f23-11e9-9ffe-52c8f63b2a71.png)

Win10 (with Admin Rights):
![SetComputerNameExW-Win10](https://user-images.githubusercontent.com/2107452/58368156-fa36f780-7f23-11e9-969c-099e012936f9.png)
Successful.