### PR TITLE
[WIN32SS][NTGDI] Delete mapping hacks

### DIFF
--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -19,18 +19,18 @@ PBRUSH pbrDefaultBrush = NULL;
 
 const MATRIX gmxWorldToDeviceDefault =
 {
-    FLOATOBJ_16, FLOATOBJ_0,
-    FLOATOBJ_0, FLOATOBJ_16,
+    FLOATOBJ_1, FLOATOBJ_0,
+    FLOATOBJ_0, FLOATOBJ_1,
     FLOATOBJ_0, FLOATOBJ_0,
-    0, 0, 0x4b
+    0, 0, 0x63
 };
 
 const MATRIX gmxDeviceToWorldDefault =
 {
-    FLOATOBJ_1_16, FLOATOBJ_0,
-    FLOATOBJ_0, FLOATOBJ_1_16,
+    FLOATOBJ_1, FLOATOBJ_0,
+    FLOATOBJ_0, FLOATOBJ_1,
     FLOATOBJ_0, FLOATOBJ_0,
-    0, 0, 0x53
+    0, 0, 0x63
 };
 
 const MATRIX gmxWorldToPageDefault =
@@ -40,10 +40,6 @@ const MATRIX gmxWorldToPageDefault =
     FLOATOBJ_0, FLOATOBJ_0,
     0, 0, 0x63
 };
-
-// HACK!! Fix XFORMOBJ then use 1:16 / 16:1
-#define gmxWorldToDeviceDefault gmxWorldToPageDefault
-#define gmxDeviceToWorldDefault gmxWorldToPageDefault
 
 /** Internal functions ********************************************************/
 
@@ -203,8 +199,8 @@ DC_vInitDc(
 	pdc->dclevel.mxWorldToDevice = gmxWorldToDeviceDefault;
 	pdc->dclevel.mxDeviceToWorld = gmxDeviceToWorldDefault;
 	pdc->dclevel.mxWorldToPage = gmxWorldToPageDefault;
-	pdc->dclevel.efM11PtoD = gef16;
-	pdc->dclevel.efM22PtoD = gef16;
+	pdc->dclevel.efM11PtoD = gef1;
+	pdc->dclevel.efM22PtoD = gef1;
 	pdc->dclevel.efDxPtoD = gef0;
 	pdc->dclevel.efDyPtoD = gef0;
 	pdc->dclevel.efM11_TWIPS = gef0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -45,9 +45,6 @@ extern const MATRIX gmxWorldToDeviceDefault;
 extern const MATRIX gmxWorldToPageDefault;
 static const FT_Matrix identityMat = {(1 << 16), 0, 0, (1 << 16)};
 
-/* HACK!! Fix XFORMOBJ then use 1:16 / 16:1 */
-#define gmxWorldToDeviceDefault gmxWorldToPageDefault
-
 FT_Library  g_FreeTypeLibrary;
 
 /* special font names */


### PR DESCRIPTION
## Purpose
Fix the hack of the world-to-page and device-to-world mappings.
JIRA issue: [CORE-16047](https://jira.reactos.org/browse/CORE-16047)
![nothing-changed](https://user-images.githubusercontent.com/2107452/58423922-39567b80-80d1-11e9-9f6c-26ab90986390.png)
It looks like nothing changed.
