### PR TITLE
[WIN32KNT_APITEST] Split win32knt_apitest to 3 modules

### DIFF
--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -66,6 +66,7 @@ list(APPEND SOURCE
 
 add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
 add_dependencies(win32knt_static xdk)
+add_pch(win32knt_static win32nt.h SOURCE)
 
 add_executable(win32knt_apitest testlist.c)
 add_executable(win32knt_xpsp2_apitest testlist.c)
@@ -106,7 +107,5 @@ if (0)  # vista
         win32u_vista
         gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 endif()
-
-add_pch(win32knt_static win32nt.h SOURCE)
 
 add_rostests_file(TARGET win32knt_apitest)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -68,38 +68,44 @@ add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
 add_dependencies(win32knt_static xdk)
 
 add_executable(win32knt_apitest testlist.c)
-#add_executable(win32knt_2ksp4_apitest testlist.c)
 add_executable(win32knt_xpsp2_apitest testlist.c)
 add_executable(win32knt_2k3sp2_apitest testlist.c)
-#add_executable(win32knt_vista_apitest testlist.c)
 
 target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
-#target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
 target_link_libraries(win32knt_xpsp2_apitest ${PSEH_LIB} win32knt_static gditools)
 target_link_libraries(win32knt_2k3sp2_apitest ${PSEH_LIB} win32knt_static gditools)
-#target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
 
 set_module_type(win32knt_apitest win32cui)
-#set_module_type(win32knt_2ksp4_apitest win32cui)
 set_module_type(win32knt_xpsp2_apitest win32cui)
 set_module_type(win32knt_2k3sp2_apitest win32cui)
-#set_module_type(win32knt_vista_apitest win32cui)
 
 add_importlibs(win32knt_apitest
     win32u
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
-#add_importlibs(win32knt_2ksp4_apitest
-#    win32u_2ksp4
-#    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 add_importlibs(win32knt_xpsp2_apitest
     win32u_xpsp2
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 add_importlibs(win32knt_2k3sp2_apitest
     win32u_2k3sp2
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
-#add_importlibs(win32knt_vista_apitest
-#    win32u_vista
-#    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+
+if (0)  # 2ksp4
+    add_executable(win32knt_2ksp4_apitest testlist.c)
+    target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
+    set_module_type(win32knt_2ksp4_apitest win32cui)
+    add_importlibs(win32knt_2ksp4_apitest
+        win32u_2ksp4
+        gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+endif()
+
+if (0)  # vista
+    add_executable(win32knt_vista_apitest testlist.c)
+    target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
+    set_module_type(win32knt_vista_apitest win32cui)
+    add_importlibs(win32knt_vista_apitest
+        win32u_vista
+        gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+endif()
 
 add_pch(win32knt_static win32nt.h SOURCE)
 

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -78,6 +78,7 @@ if(1)  # ros
 endif()
 
 if(0)  # Specify 1 if you want 2ksp4 version
+    # See also ../win32u/CMakeLists.txt
     add_executable(win32knt_2ksp4_apitest testlist.c)
     target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_2ksp4_apitest win32cui)
@@ -99,6 +100,7 @@ if(1) # 2k3sp2
 endif()
 
 if(0)  # Specify 1 if you want vista version
+    # See also ../win32u/CMakeLists.txt
     add_executable(win32knt_vista_apitest testlist.c)
     target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_vista_apitest win32cui)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -65,6 +65,7 @@ list(APPEND SOURCE
     win32nt.h)
 
 add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
+add_dependencies(win32knt_static psdk)
 
 add_executable(win32knt_apitest testlist.c)
 #add_executable(win32knt_2ksp4_apitest testlist.c)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND SOURCE
     win32nt.h)
 
 add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
-add_dependencies(win32knt_static psdk)
+add_dependencies(win32knt_static xdk)
 
 add_executable(win32knt_apitest testlist.c)
 #add_executable(win32knt_2ksp4_apitest testlist.c)
@@ -100,12 +100,6 @@ add_importlibs(win32knt_2k3sp2_apitest
 #add_importlibs(win32knt_vista_apitest
 #    win32u_vista
 #    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
-
-add_dependencies(win32knt_apitest xdk)
-#add_dependencies(win32knt_2ksp4_apitest xdk)
-add_dependencies(win32knt_xpsp2_apitest xdk)
-add_dependencies(win32knt_2k3sp2_apitest xdk)
-#add_dependencies(win32knt_vista_apitest xdk)
 
 add_pch(win32knt_static win32nt.h SOURCE)
 

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -68,40 +68,41 @@ add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
 add_dependencies(win32knt_static xdk)
 add_pch(win32knt_static win32nt.h SOURCE)
 
-add_executable(win32knt_apitest testlist.c)
-add_executable(win32knt_xpsp2_apitest testlist.c)
-add_executable(win32knt_2k3sp2_apitest testlist.c)
-
-target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
-target_link_libraries(win32knt_xpsp2_apitest ${PSEH_LIB} win32knt_static gditools)
-target_link_libraries(win32knt_2k3sp2_apitest ${PSEH_LIB} win32knt_static gditools)
-
-set_module_type(win32knt_apitest win32cui)
-set_module_type(win32knt_xpsp2_apitest win32cui)
-set_module_type(win32knt_2k3sp2_apitest win32cui)
-
 set(WIN32KNT_IMPORTLIBS gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 
-add_importlibs(win32knt_apitest win32u ${WIN32KNT_IMPORTLIBS})
-add_importlibs(win32knt_xpsp2_apitest win32u_xpsp2 ${WIN32KNT_IMPORTLIBS})
-add_importlibs(win32knt_2k3sp2_apitest win32u_2k3sp2 ${WIN32KNT_IMPORTLIBS})
+if(1)  # ros
+    add_executable(win32knt_apitest testlist.c)
+    target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
+    set_module_type(win32knt_apitest win32cui)
+    add_importlibs(win32knt_apitest win32u ${WIN32KNT_IMPORTLIBS})
+endif()
 
 if(0)  # Specify 1 if you want 2ksp4 version
     add_executable(win32knt_2ksp4_apitest testlist.c)
     target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_2ksp4_apitest win32cui)
-    add_importlibs(win32knt_2ksp4_apitest
-        win32u_2ksp4
-        gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+    add_importlibs(win32knt_2ksp4_apitest win32u_2ksp4 ${WIN32KNT_IMPORTLIBS})
+endif()
+
+if(1) # xpsp2
+    add_executable(win32knt_xpsp2_apitest testlist.c)
+    target_link_libraries(win32knt_xpsp2_apitest ${PSEH_LIB} win32knt_static gditools)
+    set_module_type(win32knt_xpsp2_apitest win32cui)
+    add_importlibs(win32knt_xpsp2_apitest win32u_xpsp2 ${WIN32KNT_IMPORTLIBS})
+endif()
+
+if(1) # 2k3sp2
+    add_executable(win32knt_2k3sp2_apitest testlist.c)
+    target_link_libraries(win32knt_2k3sp2_apitest ${PSEH_LIB} win32knt_static gditools)
+    set_module_type(win32knt_2k3sp2_apitest win32cui)
+    add_importlibs(win32knt_2k3sp2_apitest win32u_2k3sp2 ${WIN32KNT_IMPORTLIBS})
 endif()
 
 if(0)  # Specify 1 if you want vista version
     add_executable(win32knt_vista_apitest testlist.c)
     target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_vista_apitest win32cui)
-    add_importlibs(win32knt_vista_apitest
-        win32u_vista
-        gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+    add_importlibs(win32knt_vista_apitest win32u_vista ${WIN32KNT_IMPORTLIBS})
 endif()
 
 add_rostests_file(TARGET win32knt_apitest)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -75,6 +75,8 @@ if(1)  # ros
     target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_apitest win32cui)
     add_importlibs(win32knt_apitest win32u ${WIN32KNT_IMPORTLIBS})
+
+    add_rostests_file(TARGET win32knt_apitest)
 endif()
 
 if(0)  # Specify 1 if you want 2ksp4 version
@@ -106,5 +108,3 @@ if(0)  # Specify 1 if you want vista version
     set_module_type(win32knt_vista_apitest win32cui)
     add_importlibs(win32knt_vista_apitest win32u_vista ${WIN32KNT_IMPORTLIBS})
 endif()
-
-add_rostests_file(TARGET win32knt_apitest)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -64,23 +64,34 @@ list(APPEND SOURCE
     #osver.c
     win32nt.h)
 
-add_executable(win32knt_apitest
-    ${SOURCE}
-    testlist.c
-    w32knapi.rc)
+add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
 
-target_link_libraries(win32knt_apitest ${PSEH_LIB} gditools)
+add_executable(win32knt_apitest testlist.c)
+add_executable(win32knt_xpsp2_apitest testlist.c)
+add_executable(win32knt_2k3sp2_apitest testlist.c)
+
+target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
+target_link_libraries(win32knt_xpsp2_apitest ${PSEH_LIB} win32knt_static gditools)
+target_link_libraries(win32knt_2k3sp2_apitest ${PSEH_LIB} win32knt_static gditools)
+
 set_module_type(win32knt_apitest win32cui)
+set_module_type(win32knt_xpsp2_apitest win32cui)
+set_module_type(win32knt_2k3sp2_apitest win32cui)
+
 add_importlibs(win32knt_apitest
-    win32u # win32u_2ksp4 win32u_xpsp2 win32u_2k3sp2 win32u_vista
-    gdi32
-    user32
-    shell32
-    advapi32
-    msvcrt
-    kernel32
-    ntdll)
+    win32u
+    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+add_importlibs(win32knt_xpsp2_apitest
+    win32u_xpsp2
+    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+add_importlibs(win32knt_2k3sp2_apitest
+    win32u_2k3sp2
+    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 
 add_dependencies(win32knt_apitest xdk)
-add_pch(win32knt_apitest win32nt.h SOURCE)
+add_dependencies(win32knt_xpsp2_apitest xdk)
+add_dependencies(win32knt_2k3sp2_apitest xdk)
+
+add_pch(win32knt_static win32nt.h SOURCE)
+
 add_rostests_file(TARGET win32knt_apitest)

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -67,30 +67,44 @@ list(APPEND SOURCE
 add_library(win32knt_static STATIC ${SOURCE} w32knapi.rc)
 
 add_executable(win32knt_apitest testlist.c)
+#add_executable(win32knt_2ksp4_apitest testlist.c)
 add_executable(win32knt_xpsp2_apitest testlist.c)
 add_executable(win32knt_2k3sp2_apitest testlist.c)
+#add_executable(win32knt_vista_apitest testlist.c)
 
 target_link_libraries(win32knt_apitest ${PSEH_LIB} win32knt_static gditools)
+#target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
 target_link_libraries(win32knt_xpsp2_apitest ${PSEH_LIB} win32knt_static gditools)
 target_link_libraries(win32knt_2k3sp2_apitest ${PSEH_LIB} win32knt_static gditools)
+#target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
 
 set_module_type(win32knt_apitest win32cui)
+#set_module_type(win32knt_2ksp4_apitest win32cui)
 set_module_type(win32knt_xpsp2_apitest win32cui)
 set_module_type(win32knt_2k3sp2_apitest win32cui)
+#set_module_type(win32knt_vista_apitest win32cui)
 
 add_importlibs(win32knt_apitest
     win32u
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+#add_importlibs(win32knt_2ksp4_apitest
+#    win32u_2ksp4
+#    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 add_importlibs(win32knt_xpsp2_apitest
     win32u_xpsp2
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 add_importlibs(win32knt_2k3sp2_apitest
     win32u_2k3sp2
     gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+#add_importlibs(win32knt_vista_apitest
+#    win32u_vista
+#    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 
 add_dependencies(win32knt_apitest xdk)
+#add_dependencies(win32knt_2ksp4_apitest xdk)
 add_dependencies(win32knt_xpsp2_apitest xdk)
 add_dependencies(win32knt_2k3sp2_apitest xdk)
+#add_dependencies(win32knt_vista_apitest xdk)
 
 add_pch(win32knt_static win32nt.h SOURCE)
 

--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -80,17 +80,13 @@ set_module_type(win32knt_apitest win32cui)
 set_module_type(win32knt_xpsp2_apitest win32cui)
 set_module_type(win32knt_2k3sp2_apitest win32cui)
 
-add_importlibs(win32knt_apitest
-    win32u
-    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
-add_importlibs(win32knt_xpsp2_apitest
-    win32u_xpsp2
-    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
-add_importlibs(win32knt_2k3sp2_apitest
-    win32u_2k3sp2
-    gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
+set(WIN32KNT_IMPORTLIBS gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 
-if (0)  # 2ksp4
+add_importlibs(win32knt_apitest win32u ${WIN32KNT_IMPORTLIBS})
+add_importlibs(win32knt_xpsp2_apitest win32u_xpsp2 ${WIN32KNT_IMPORTLIBS})
+add_importlibs(win32knt_2k3sp2_apitest win32u_2k3sp2 ${WIN32KNT_IMPORTLIBS})
+
+if(0)  # Specify 1 if you want 2ksp4 version
     add_executable(win32knt_2ksp4_apitest testlist.c)
     target_link_libraries(win32knt_2ksp4_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_2ksp4_apitest win32cui)
@@ -99,7 +95,7 @@ if (0)  # 2ksp4
         gdi32 user32 shell32 advapi32 msvcrt kernel32 ntdll)
 endif()
 
-if (0)  # vista
+if(0)  # Specify 1 if you want vista version
     add_executable(win32knt_vista_apitest testlist.c)
     target_link_libraries(win32knt_vista_apitest ${PSEH_LIB} win32knt_static gditools)
     set_module_type(win32knt_vista_apitest win32cui)


### PR DESCRIPTION
## Purpose
Split `win32knt_apitest` to 3 modules (`win32knt_apitest`, `win32knt_xpsp2_apitest` and `win32knt_2k3sp2_apitest`) for usability.
JIRA issue: N/A