### PR TITLE
[KERNEL32_APITEST] dynamic linked RtlIsCriticalSectionLockedByThread

### DIFF
--- a/modules/rostests/apitests/kernel32/FLS.c
+++ b/modules/rostests/apitests/kernel32/FLS.c
@@ -119,14 +119,15 @@ void ok_fls_(DWORD dwIndex, PVOID pValue, PFLS_CALLBACK_FUNCTION lpCallback)
 static VOID init_funcs(void)
 {
     HMODULE hKernel32 = GetModuleHandleA("kernel32.dll");
+    HMODULE hNTDLL = GetModuleHandleA("ntdll.dll");
 
 #define X(f) p##f = (void*)GetProcAddress(hKernel32, #f);
     X(FlsAlloc);
     X(FlsFree);
     X(FlsGetValue);
     X(FlsSetValue);
-    X(RtlIsCriticalSectionLockedByThread);
 #undef X
+    pRtlIsCriticalSectionLockedByThread = (void*)GetProcAddress(hNTDLL, "RtlIsCriticalSectionLockedByThread");
 }
 
 


### PR DESCRIPTION
## Purpose
Statically linked `ntdll.RtlIsCriticalSectionLockedByThread` had made `kernel32_apitest` unable to run in XP.
JIRA issue: [CORE-16077](https://jira.reactos.org/browse/CORE-16077)
