### PR TITLE
[CRT] Implement __chkstk function for ARM

### DIFF
--- a/sdk/lib/crt/except/arm/chkstk_asm.s
+++ b/sdk/lib/crt/except/arm/chkstk_asm.s
@@ -1,9 +1,12 @@
 /*
- * COPYRIGHT:         BSD - See COPYING.ARM in the top level directory
- * PROJECT:           ReactOS CRT librariy
- * PURPOSE:           Implementation of _chkstk and _alloca_probe
- * PROGRAMMER:        Timo Kreuzer (timo.kreuzer@reactos.org)
- *                    Yuntian Zhang (yuntian.zh@gmail.com)
+ * PROJECT:     ReactOS CRT library
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * PURPOSE:     Implementation of _chkstk and _alloca_probe
+ * COPYRIGHT:   Copyright 2014 Timo Kreuzer (timo.kreuzer@reactos.org)
+ *              Copyright 2014 Yuntian Zhang (yuntian.zh@gmail.com)
+ *              Copyright 2019 Mohamed Mediouni (mmediouni@gmx.fr)
+ *
+ * REFERENCES:  https://github.com/wine-mirror/wine/commit/2b095beace7b457586bd33b3b1c81df116215193
  */
 
 /* INCLUDES ******************************************************************/
@@ -14,7 +17,7 @@
     TEXTAREA
 
     LEAF_ENTRY __chkstk
-    __assertfail
+    lsl r4, r4, #2
     bx lr
     LEAF_END __chkstk
 


### PR DESCRIPTION
Incoming r4 contains the number of dwords to allocate, converting to bytes then return.
This makes ReactOS applications compiled for ARM running on true ARM Windows.

Reference: https://github.com/wine-mirror/wine/commit/2b095beace7b457586bd33b3b1c81df116215193