### PR TITLE
[CRT] ARM & ARM64 Windows do not have initenv in their CRTs

### DIFF
--- a/sdk/lib/crt/startup/crtexe.c
+++ b/sdk/lib/crt/startup/crtexe.c
@@ -24,6 +24,10 @@
 #include <mbstring.h>
 #endif
 
+/* Special handling for ARM & ARM64, __winitenv & __initenv aren't present there. */
+
+#if !defined(__arm__) && !defined(__aarch64__)
+
 #ifndef __winitenv
 extern wchar_t *** __MINGW_IMP_SYMBOL(__winitenv);
 #define __winitenv (* __MINGW_IMP_SYMBOL(__winitenv))
@@ -32,6 +36,8 @@ extern wchar_t *** __MINGW_IMP_SYMBOL(__winitenv);
 #ifndef __initenv
 extern char *** __MINGW_IMP_SYMBOL(__initenv);
 #define __initenv (* __MINGW_IMP_SYMBOL(__initenv))
+#endif
+
 #endif
 
 /* Hack, for bug in ld.  Will be removed soon.  */
@@ -306,12 +312,16 @@ __tmainCRTStartup (void)
     duplicate_ppstrings (argc, &argv);
     __main ();
 #ifdef WPRFLAG
+#if !defined(__arm__) && !defined(__aarch64__)
     __winitenv = envp;
+#endif
     /* C++ initialization.
        gcc inserts this call automatically for a function called main, but not for wmain.  */
     mainret = wmain (argc, argv, envp);
 #else
+#if !defined(__arm__) && !defined(__aarch64__)
     __initenv = envp;
+#endif
     mainret = main (argc, argv, envp);
 #endif
     if (!managedapp)


### PR DESCRIPTION
Native CRT on ARM & ARM64 Windows doesn't have these functions.
For compatibility, it's mandatory to not have it at all. Otherwise,
ARM executables built for ReactOS do not run on true ARM Windows.