### PR TITLE
Fix handling of OLE exports

### DIFF
--- a/base/services/shsvcs/shsvcs.spec
+++ b/base/services/shsvcs/shsvcs.spec
@@ -1,16 +1,16 @@
-1 stdcall ThemeWatchForStart()
-2 stdcall ThemeWaitForServiceReady(long)
-#3 stub Stub3
-#4 stub Stub4
-#5 stub Stub5
-#6 stub Stub6
-#7 stub BadApplicationServiceMain
-8 stdcall DllInstall(long wstr)
-9 stdcall DllRegisterServer()
-10 stdcall DllUnregisterServer()
-#11 stub HardwareDetectionServiceMain
-12 stdcall ThemeServiceMain(long ptr)
-#13 stub CreateHardwareEventMoniker
-14 stdcall DllCanUnloadNow()
-15 stdcall DllGetClassObject(ptr ptr ptr)
-#16 stub FUSCompatibilityEntryW
+1 stdcall -noname ThemeWatchForStart()
+2 stdcall -noname ThemeWaitForServiceReady(long)
+3 stdcall -stub -noname ThemeUserLogoff()
+4 stdcall -stub -noname ThemeUserLogon(ptr)
+5 stdcall -stub -noname ThemeUserStartShell()
+6 stdcall -stub -noname ThemeUserTSReconnect()
+@ stdcall -stub BadApplicationServiceMain(long ptr)
+@ stdcall -private DllInstall(long wstr)
+@ stdcall -private DllRegisterServer()
+@ stdcall -private DllUnregisterServer()
+@ stdcall -stub HardwareDetectionServiceMain(long ptr)
+@ stdcall ThemeServiceMain(long ptr)
+@ stdcall -stub CreateHardwareEventMoniker(ptr ptr ptr)
+@ stdcall -private DllCanUnloadNow()
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
+@ stdcall -stub FUSCompatibilityEntryW(long long wstr long)

--- a/dll/directx/bdaplgin/bdaplgin.spec
+++ b/dll/directx/bdaplgin/bdaplgin.spec
@@ -1,4 +1,4 @@
-@ stdcall DllCanUnloadNow()
-@ stdcall DllGetClassObject(ptr ptr ptr)
-@ stdcall DllRegisterServer()
-@ stdcall DllUnregisterServer()
+@ stdcall -private DllCanUnloadNow()
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
+@ stdcall -private DllRegisterServer()
+@ stdcall -private DllUnregisterServer()

--- a/dll/directx/ddraw/ddraw.spec
+++ b/dll/directx/ddraw/ddraw.spec
@@ -13,8 +13,8 @@
 @ stdcall DirectDrawEnumerateW(ptr ptr)
 @ stdcall DirectDrawEnumerateExA(ptr ptr long)
 @ stdcall DirectDrawEnumerateExW(ptr ptr long)
-#@ stdcall DllCanUnloadNow()
-#@ stdcall DllGetClassObject(ptr ptr ptr)
+#@ stdcall -private DllCanUnloadNow()
+#@ stdcall -private DllGetClassObject(ptr ptr ptr)
 #@ stdcall GetDDSurfaceLocal
 #@ stdcall GetOLEThunkData
 #@ stdcall GetSurfaceFromDC

--- a/dll/directx/msdvbnp/msdvbnp.spec
+++ b/dll/directx/msdvbnp/msdvbnp.spec
@@ -1,4 +1,4 @@
-@ stdcall DllCanUnloadNow()
-@ stdcall DllGetClassObject(ptr ptr ptr)
-@ stdcall DllRegisterServer()
-@ stdcall DllUnregisterServer()
+@ stdcall -private DllCanUnloadNow()
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
+@ stdcall -private DllRegisterServer()
+@ stdcall -private DllUnregisterServer()

--- a/dll/directx/msvidctl/msvidctl.spec
+++ b/dll/directx/msvidctl/msvidctl.spec
@@ -1,4 +1,4 @@
-@ stdcall DllCanUnloadNow()
-@ stdcall DllGetClassObject(ptr ptr ptr)
-@ stdcall DllRegisterServer()
-@ stdcall DllUnregisterServer()
+@ stdcall -private DllCanUnloadNow()
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
+@ stdcall -private DllRegisterServer()
+@ stdcall -private DllUnregisterServer()

--- a/dll/shellext/netplwiz/netplwiz.spec
+++ b/dll/shellext/netplwiz/netplwiz.spec
@@ -5,7 +5,7 @@
 5 stub ClearAutoLogon
 @ stdcall -private DllCanUnloadNow()
 @ stdcall -private DllGetClassObject(ptr ptr ptr)
-8 stub -private DllInstall
+@ stub -private DllInstall
 9 stdcall DllMain(ptr long ptr)
 @ stdcall -private DllRegisterServer()
 @ stdcall -private DllUnregisterServer()

--- a/drivers/multimedia/bdasup/bdasup.spec
+++ b/drivers/multimedia/bdasup/bdasup.spec
@@ -1,4 +1,4 @@
-@ stdcall DllInitialize(ptr)
+@ stdcall -private DllInitialize(ptr)
 @ stdcall BdaCheckChanges(ptr)
 @ stdcall BdaCommitChanges(ptr)
 @ stdcall BdaCreateFilterFactory(ptr ptr ptr)


### PR DESCRIPTION
## Purpose

Fix handling of OLE exports: they should be PRIVATE and have no manually-assigned ordinals.

## Proposed changes

```
[SPEC2DEF] Check whether OLE-specific exports do not have assigned ordinals, as they should be.

The check is done at the same time as when we check also that these
exports are marked PRIVATE or not.

This permits us to check for the same conditions as MS' LINK.EXE, but
here on GCC builds as well.

See the following pages for more details:
https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4104
https://docs.microsoft.com/en-us/cpp/error-messages/tool-errors/linker-tools-warning-lnk4222

In this last page (LNK4222), the specified list of exports is incomplete.
Manual tests showed that the very same list as for LNK4104 is checked.
```
```
[DLLs] Fix .spec files regarding OLE-specific exports.

Do not use hardcoded ordinals, add missing '-private'.
Except for MSXML3, OLE32 and RSAENH, see commit bff824b2 for more details.

Co-Authored-By: Timo Kreuzer <timo.kreuzer@reactos.org>
```