### PR TITLE
Revert "[USER32] App Switcher should use the non-owned window's icon"

### DIFF
--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -165,24 +165,20 @@ void CompleteSwitch(BOOL doSwitch)
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
    HICON hIcon;
-   HWND hwndIcon, hwndOwner;
 
    UNREFERENCED_PARAMETER(lParam);
 
-   hwndOwner = GetWindow(window, GW_OWNER);
-   hwndIcon = (hwndOwner ? hwndOwner : window);
-
    // First try to get the big icon assigned to the window
-   hIcon = (HICON)SendMessageW(hwndIcon, WM_GETICON, ICON_BIG, 0);
+   hIcon = (HICON)SendMessageW(window, WM_GETICON, ICON_BIG, 0);
    if (!hIcon)
    {
       // If no icon is assigned, try to get the icon assigned to the windows' class
-      hIcon = (HICON)GetClassLongPtrW(hwndIcon, GCL_HICON);
+      hIcon = (HICON)GetClassLongPtrW(window, GCL_HICON);
       if (!hIcon)
       {
          // If we still don't have an icon, see if we can do with the small icon,
          // or a default application icon
-         hIcon = (HICON)SendMessageW(hwndIcon, WM_GETICON, ICON_SMALL2, 0);
+         hIcon = (HICON)SendMessageW(window, WM_GETICON, ICON_SMALL2, 0);
          if (!hIcon)
          {
             // using windows logo icon as default


### PR DESCRIPTION
Reverts reactos/reactos#1299 (484943d). [CORE-15672](https://jira.reactos.org/browse/CORE-15672) was wrong.