### PR TITLE
Removed excessive allocation

### DIFF
--- a/dll/win32/advapi32/token/token.c
+++ b/dll/win32/advapi32/token/token.c
@@ -100,7 +100,7 @@ CheckTokenMembership(IN HANDLE ExistingTokenHandle,
                                          0,
                                          sizeof(SECURITY_DESCRIPTOR) +
                                              sizeof(ACL) + SidLen +
-                                             sizeof(ACCESS_ALLOWED_ACE));
+                                             FIELD_OFFSET(ACCESS_ALLOWED_ACE, SidStart));
     if (SecurityDescriptor == NULL)
     {
         Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -134,7 +134,7 @@ CheckTokenMembership(IN HANDLE ExistingTokenHandle,
     /* create the DACL */
     Dacl = (PACL)(SecurityDescriptor + 1);
     Status = RtlCreateAcl(Dacl,
-                          sizeof(ACL) + SidLen + sizeof(ACCESS_ALLOWED_ACE),
+                          sizeof(ACL) + SidLen + FIELD_OFFSET(ACCESS_ALLOWED_ACE, SidStart),
                           ACL_REVISION);
     if (!NT_SUCCESS(Status))
     {


### PR DESCRIPTION
## Purpose

A minor fix to reduce an excessive allocation.

## Proposed changes

According to [the documentation](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/content/ntifs/nf-ntifs-rtlcreateacl) and the `ACCESS_ALLOWED_ACE` structure.

I saw that there are [other places](https://github.com/reactos/reactos/search?q=sizeof%28ACCESS_ALLOWED_ACE%29&unscoped_q=sizeof%28ACCESS_ALLOWED_ACE%29) where `sizeof(ACCESS_ALLOWED_ACE)` is used without subtracting the `sizeof(ULONG)`, you guys who are more familiar with the code might want to look at it.