### PR TITLE
[ROSTESTS] Add missing '\n' to a few skip()

### DIFF
--- a/modules/rostests/apitests/kernel32/MultiByteToWideChar.c
+++ b/modules/rostests/apitests/kernel32/MultiByteToWideChar.c
@@ -254,7 +254,7 @@ START_TEST(MultiByteToWideChar)
         trace("This test is designed for Windows 10+ and ReactOS.\n"
               "It is expected to report some failures on older Windows versions.\n");
 #if 0
-        skip("");
+        skip("\n");
         return;
 #endif
     }

--- a/modules/rostests/apitests/kernel32/TunnelCache.c
+++ b/modules/rostests/apitests/kernel32/TunnelCache.c
@@ -17,7 +17,7 @@ Test_VeryLongTests(void)
     CHAR OldDir[MAX_PATH];
     FILETIME FileTime, File1Time;
 
-    win_skip("Too long, see: ROSTESTS-177");
+    win_skip("Too long, see: ROSTESTS-177\n");
     return;
 
     /* Create a blank test directory */

--- a/modules/rostests/apitests/ntdll/NtContinue.c
+++ b/modules/rostests/apitests/ntdll/NtContinue.c
@@ -123,7 +123,7 @@ void check(CONTEXT * pContext)
 START_TEST(NtContinue)
 {
 #ifdef __RUNTIME_CHECKS__
-    skip("This test breaks MSVC runtime checks!");
+    skip("This test breaks MSVC runtime checks!\n");
     return;
 #endif /* __RUNTIME_CHECKS__ */
     initrand();

--- a/modules/rostests/apitests/shell32/CUserNotification.cpp
+++ b/modules/rostests/apitests/shell32/CUserNotification.cpp
@@ -196,7 +196,7 @@ START_TEST(CUserNotification)
     ok(hThread != NULL, "CreateThread failed with error 0x%lu\n", GetLastError());
     if (!hThread)
     {
-        skip("Could not create the CUserNotification test thread!");
+        skip("Could not create the CUserNotification test thread!\n");
         return;
     }
 

--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiEnumFontOpen.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiEnumFontOpen.c
@@ -22,7 +22,7 @@ START_TEST(NtGdiEnumFontOpen)
     ok(idEnum != 0, "idEnum was 0.\n");
     if (idEnum == 0)
     {
-        skip("idEnum == 0");
+        skip("idEnum == 0\n");
         return;
     }
 

--- a/modules/rostests/kmtests/ntos_ke/KeEvent.c
+++ b/modules/rostests/kmtests/ntos_ke/KeEvent.c
@@ -214,7 +214,7 @@ TestEventConcurrent(
         Priority = KeQueryPriorityThread(Threads[i].Thread);
         ok_eq_long(Priority, max(min(8L + PriorityIncrement + i, 15L), 8L));
         /* replace the thread with the current thread - which will never signal */
-        if (!skip((Status & 0x3F) < ThreadCount, "Index out of bounds"))
+        if (!skip((Status & 0x3F) < ThreadCount, "Index out of bounds\n"))
             ThreadObjects[Status & 0x3F] = Thread;
         Status = KeWaitForMultipleObjects(ThreadCount, ThreadObjects, WaitAny, Executive, KernelMode, FALSE, &ShortTimeout, WaitBlock);
         ok_eq_hex(Status, STATUS_TIMEOUT);

--- a/modules/rostests/kmtests/ntos_ob/ObReference.c
+++ b/modules/rostests/kmtests/ntos_ob/ObReference.c
@@ -212,7 +212,7 @@ START_TEST(ObReference)
         ok_eq_hex(Status, STATUS_SUCCESS);
         ok(DirectoryHandle != NULL, "DirectoryHandle = NULL\n");
 
-        if (!skip(Status == STATUS_SUCCESS && DirectoryHandle, "Cannot proceed without an object"))
+        if (!skip(Status == STATUS_SUCCESS && DirectoryHandle, "Cannot proceed without an object\n"))
         {
             TestReference(DirectoryHandle, pName, pNameUpper, FALSE, Tests[i].AdditionalReferences, (Tests[i].Flags & OBJ_PERMANENT) != 0);
             /* try again for good measure */


### PR DESCRIPTION
A tiny part of the task,
until I find a better way to reliably find similar cases. (Helpwanted on that.)