### PR TITLE
[USER32] RegisterClipboardFormatA(): Enable a SetLastError()

### DIFF
--- a/win32ss/user/user32/windows/clipboard.c
+++ b/win32ss/user/user32/windows/clipboard.c
@@ -114,7 +114,7 @@ RegisterClipboardFormatA(LPCSTR lpszFormat)
 
     if (!RtlCreateUnicodeStringFromAsciiz(&usFormat, lpszFormat))
     {
-        // FIXME: Shouldn't we 'SetLastError(ERROR_NOT_ENOUGH_MEMORY);'?
+        SetLastError(ERROR_NOT_ENOUGH_MEMORY);
         return 0;
     }
 


### PR DESCRIPTION
## Purpose

Same pattern as lots of other `RtlCreateUnicodeStringFromAsciiz()` calls.

Follow-up to #1529.