### PR TITLE
[NTDLL_VISTA] Check _DEBUG with #ifdef, not #if

### DIFF
--- a/dll/win32/ntdll_vista/condvar.c
+++ b/dll/win32/ntdll_vista/condvar.c
@@ -429,7 +429,7 @@ InternalSleep(IN OUT PRTL_CONDITION_VARIABLE ConditionVariable,
         }
     }
 
-#if _DEBUG
+#ifdef _DEBUG
     /* Clear OwnEntry to aid in detecting bugs. */
     RtlZeroMemory(&OwnEntry, sizeof(OwnEntry));
 #endif


### PR DESCRIPTION
As far as I can see, `_DEBUG` is defined/tested as value-less everywhere else.
If this case is an intended exception, then I would suggest to add a comment instead...