### PR TITLE
[NCFTP] Check _DEBUG with #ifdef, not #if

### DIFF
--- a/modules/rosapps/applications/net/ncftp/libncftp/glob.c
+++ b/modules/rosapps/applications/net/ncftp/libncftp/glob.c
@@ -1157,9 +1157,15 @@ Traverse(FTPCIPtr cip, char *fullpath, struct Stat *st, char *relpath, FileInfoL
 		}
 
 next:
+#ifndef __REACTOS__
 #if _DEBUG
 		memset(&ffd, 0, sizeof(ffd));
 #endif
+#else //  __REACTOS__
+#ifdef _DEBUG
+		memset(&ffd, 0, sizeof(ffd));
+#endif
+#endif //  __REACTOS__
 		if (!FindNextFile(searchHandle, &ffd)) {
 			dwErr = GetLastError();
 			if (dwErr != ERROR_NO_MORE_FILES) {


### PR DESCRIPTION
As far as I can see, `_DEBUG` is defined/tested as value-less everywhere else.
If this case is an intended exception, then I would suggest to add a comment instead...

--

I add `__REACTOS__`, as this app is not documented as either sync'ed or forked.
Not sure if it should be upgraded or removed (as in made available through RApps)...
https://www.ncftp.com/download/