### PR TITLE
[LIBXML2] Use '||', instead of '|', on a '#if'

### DIFF
--- a/sdk/lib/3rdparty/libxml2/globals.c
+++ b/sdk/lib/3rdparty/libxml2/globals.c
@@ -537,7 +537,7 @@ xmlInitializeGlobalState(xmlGlobalStatePtr gs)
     gs->xmlDefaultSAXLocator.getColumnNumber = xmlSAX2GetColumnNumber;
     gs->xmlDoValidityCheckingDefaultValue =
          xmlDoValidityCheckingDefaultValueThrDef;
-#if defined(DEBUG_MEMORY_LOCATION) | defined(DEBUG_MEMORY)
+#if defined(DEBUG_MEMORY_LOCATION) || defined(DEBUG_MEMORY)  /* __REACTOS__: Use logical '||'. */
     gs->xmlFree = (xmlFreeFunc) xmlMemFree;
     gs->xmlMalloc = (xmlMallocFunc) xmlMemMalloc;
     gs->xmlMallocAtomic = (xmlMallocFunc) xmlMemMalloc;


### PR DESCRIPTION
## Purpose

Thomas, feel free to upstream this on my behalf,
as it seems upstream is on GitLab, which I don't have an account/use for.