### PR TITLE
[NDIS] Enforce '#if DBG' around MiniDisplayPacket[2]()

### DIFF
--- a/drivers/network/ndis/ndis/miniport.c
+++ b/drivers/network/ndis/ndis/miniport.c
@@ -57,12 +57,12 @@ KSPIN_LOCK MiniportListLock;
 LIST_ENTRY AdapterListHead;
 KSPIN_LOCK AdapterListLock;
 
+#if DBG
 VOID
 MiniDisplayPacket(
     PNDIS_PACKET Packet,
     PCSTR Reason)
 {
-#if DBG
     ULONG i, Length;
     UCHAR Buffer[64];
     if ((DebugTraceLevel & DEBUG_PACKET) > 0) {
@@ -82,9 +82,9 @@ MiniDisplayPacket(
 
         DbgPrint("\n*** %s PACKET STOP ***\n", Reason);
     }
-#endif /* DBG */
 }
 
+static
 VOID
 MiniDisplayPacket2(
     PVOID  HeaderBuffer,
@@ -92,7 +92,6 @@ MiniDisplayPacket2(
     PVOID  LookaheadBuffer,
     UINT   LookaheadBufferSize)
 {
-#if DBG
     if ((DebugTraceLevel & DEBUG_PACKET) > 0) {
         ULONG i, Length;
         PUCHAR p;
@@ -118,8 +117,8 @@ MiniDisplayPacket2(
 
         DbgPrint("\n*** RECEIVE PACKET STOP ***\n");
     }
-#endif /* DBG */
 }
+#endif /* DBG */
 
 PNDIS_MINIPORT_WORK_ITEM
 MiniGetFirstWorkItem(
@@ -201,7 +200,9 @@ MiniIndicateData(
       "HeaderBufferSize (0x%X)  LookaheadBuffer (0x%X)  LookaheadBufferSize (0x%X).\n",
       Adapter, HeaderBuffer, HeaderBufferSize, LookaheadBuffer, LookaheadBufferSize));
 
+#if DBG
   MiniDisplayPacket2(HeaderBuffer, HeaderBufferSize, LookaheadBuffer, LookaheadBufferSize);
+#endif
 
   NDIS_DbgPrint(MAX_TRACE, ("acquiring miniport block lock\n"));
   KeAcquireSpinLock(&Adapter->NdisMiniportBlock.Lock, &OldIrql);

--- a/drivers/network/ndis/ndis/protocol.c
+++ b/drivers/network/ndis/ndis/protocol.c
@@ -404,7 +404,9 @@ proSendPacketToMiniport(PLOGICAL_ADAPTER Adapter, PNDIS_PACKET Packet)
       return NDIS_STATUS_PENDING;
    }
 
+#if DBG
    MiniDisplayPacket(Packet, "SEND");
+#endif
 
    if(Adapter->NdisMiniportBlock.DriverHandle->MiniportCharacteristics.SendPacketsHandler)
    {


### PR DESCRIPTION
## Purpose

Full consistency, for real: fix building with `DBG=0`, broken by newest change.

[r1318](https://git.reactos.org/?p=reactos.git;a=commit;h=33252ab449df0b203a901b15a90ab26377b438f6): Add `MiniDisplayPacket()`, within `#ifdef DBG`. (1 miniport.h, 2 miniport.c, 1 protocol.c)
[r6295](https://git.reactos.org/?p=reactos.git;a=commit;h=74be14122f2c1169df97a9ba2c6b7b4ce3e5b35b): Always compile `MiniDisplayPacket()` itself/only, but with `#if 0` code. Add `MiniDisplayPacket2()`, with `#if 0` code.
[r10307](https://git.reactos.org/?p=reactos.git;a=commit;h=bc0ec8c03d9143c489be2d82817e067d62ddc15b): Enable `#ifdef DBG` in `MiniDisplayPacket2()`.
Between r11789 and r11883: Enable `#ifdef DBG` in `MiniDisplayPacket()`.
[r37559](https://git.reactos.org/?p=reactos.git;a=commit;h=438ac1d7da3218b28ff4e0df4c1aa309c0e8c930): Remove `MiniDisplayPacket()` call in miniport.c.
[r41436](https://git.reactos.org/?p=reactos.git;a=commit;h=88e9b2a5131c74ff8c323caa181088cb117e5c84): Global change to `#if DBG`.
[1b2ca28](https://git.reactos.org/?p=reactos.git;a=commit;h=1b2ca2810782464458687cbd70b2feaee10d6279): Add 2nd `MiniDisplayPacket()` call in protocol.c, but without `#if DBG`.

## Proposed changes

- Enforce '#if DBG' around MiniDisplayPacket\[2\](), as initially intended.
- Add 'static' on MiniDisplayPacket2().
