### PR TITLE
[NTOS:IO] iomgr.c: Add a missing '#if defined(KDBG)'

### DIFF
--- a/ntoskrnl/io/iomgr/iomgr.c
+++ b/ntoskrnl/io/iomgr/iomgr.c
@@ -584,7 +584,7 @@ IoInitSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     /* Initialize PnP root relations */
     IopEnumerateDevice(IopRootDeviceNode->PhysicalDeviceObject);
 
-#ifndef _WINKD_
+#if !defined(_WINKD_) && defined(KDBG)
     /* Read KDB Data */
     KdbInit();
 


### PR DESCRIPTION
## Purpose

Fix building with `-DCMAKE_BUILD_TYPE=Release`.

Initial code added on [r25987](https://git.reactos.org/?p=reactos.git;a=commit;h=be2645ad8a5492bfc124b0d98f4ab81c03b27f0c).

## Proposed changes

Is it the right check to add?
Are both checks needed, or would `#ifdef KDBG` be enough?
