### PR TITLE
WIP. [NTOSKRNL] ntos.cmake: Add 2 missing 'if(KDBG)'

### DIFF
--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -369,11 +369,12 @@ if(NOT _WINKD_)
     if(ARCH STREQUAL "i386")
         list(APPEND SOURCE
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/i386/kdbg.c
-            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/i386/kdmemsup.c
-            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/gdbstub.c)
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/i386/kdmemsup.c)
         if(KDBG)
             list(APPEND ASM_SOURCE ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/i386/kdb_help.S)
-            list(APPEND SOURCE ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/i386/i386-dis.c)
+            list(APPEND SOURCE
+                ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/gdbstub.c
+                ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/i386/i386-dis.c)
         endif()
     elseif(ARCH STREQUAL "amd64")
         list(APPEND SOURCE
@@ -394,6 +395,11 @@ if(NOT _WINKD_)
 
     if(KDBG)
         list(APPEND SOURCE
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/bochs.c
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/kdbg.c
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdinit.c
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdio.c
+            ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdmain.c
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/kdb.c
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/kdb_cli.c
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/kdb_expr.c
@@ -401,13 +407,6 @@ if(NOT _WINKD_)
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/kdb_serial.c
             ${REACTOS_SOURCE_DIR}/ntoskrnl/kdbg/kdb_symbols.c)
     endif()
-
-    list(APPEND SOURCE
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/bochs.c
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/wrappers/kdbg.c
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdinit.c
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdio.c
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/kd/kdmain.c)
 
 else() # _WINKD_
 


### PR DESCRIPTION
## Purpose

Fix building with `-DCMAKE_BUILD_TYPE=Release`.

Code was "added" as is, on [r51783](https://git.reactos.org/?p=reactos.git;a=commit;h=fae2044a23d373a0a217567d751aed87122ebbb6).
Cc @tkreuzer

## Proposed changes

Similar to #1628:
Is it the right check to add?
Are both checks needed, or would `ifdef(KDBG)` be enough?

## TODO

I am building with 'msvc'.

Initially, there were lots of errors like:
```
...\ntoskrnl\kd\wrappers\kdbg.c(15) : error C2146: syntax error : missing ')' before identifier 'DispatchTable'
```

Now, only 2 * 10 errors like:
```
ntoskrnl.def : error LNK2001: unresolved external symbol KdChangeOption

ntkrnlmp.def : error LNK2001: unresolved external symbol KdChangeOption
```

- [ ] Helpwanted: How to fix ntoskrnl.spec? Or differently.
