### PR TITLE
[SHELL32] SHCreateShellFolderView(): Fix parameter validation order. CORE-16098

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3449,13 +3449,16 @@ HRESULT WINAPI SHCreateShellFolderView(const SFV_CREATE *pcsfv,
     CComPtr<IShellView> psv;
     HRESULT hRes;
 
-    if (!ppsv || !pcsfv || pcsfv->cbSize != sizeof(*pcsfv))
+    if (!ppsv)
+        return E_INVALIDARG;
+
+    *ppsv = NULL;
+
+    if (!pcsfv || pcsfv->cbSize != sizeof(*pcsfv))
         return E_INVALIDARG;
 
     TRACE("sf=%p outer=%p callback=%p\n",
       pcsfv->pshf, pcsfv->psvOuter, pcsfv->psfvcb);
-
-    *ppsv = NULL;
 
     hRes = CDefView_CreateInstance(pcsfv->pshf, IID_PPV_ARG(IShellView, &psv));
     if (FAILED(hRes))


### PR DESCRIPTION
## Purpose

This partially reverts ae2a85d003da762e4bcb232b15f1180333e5917a.

JIRA issue: [CORE-16098](https://jira.reactos.org/browse/CORE-16098)

Cc @HBelusca
