### PR TITLE
[SETUPAPI] Revert "Fix a typo in CM_Query_Resource_Conflict_List."

### DIFF
--- a/dll/win32/setupapi/cfgmgr.c
+++ b/dll/win32/setupapi/cfgmgr.c
@@ -6761,7 +6761,7 @@ CM_Query_Resource_Conflict_List(
     if (lpDevInst == NULL)
         return CR_INVALID_DEVNODE;
 
-    pConflictData = MyMalloc(sizeof(PCONFLICT_DATA));
+    pConflictData = MyMalloc(sizeof(CONFLICT_DATA));
     if (pConflictData == NULL)
     {
         ret = CR_OUT_OF_MEMORY;


### PR DESCRIPTION
## Purpose

Previous code was correct.

This reverts commit c47ad98ff79ad98042ff2043d739be58770c2fbc.

@EricKohl doesn't answer email/mailinglist on this issue and has no account on mattermost...