### PR TITLE
[BROWSEUI_APITEST] SHEnumClassesOfCategories: Hack for ReactOS. CORE-11711

### DIFF
--- a/modules/rostests/apitests/browseui/SHEnumClassesOfCategories.cpp
+++ b/modules/rostests/apitests/browseui/SHEnumClassesOfCategories.cpp
@@ -19,26 +19,25 @@ TODO, if they make sense:
 
 typedef HRESULT (WINAPI *SHENUMCLASSESOFCATEGORIES)(ULONG cImplemented, CATID *pImplemented, ULONG cRequired, CATID *pRequired, IEnumGUID **out);
 
-static SHENUMCLASSESOFCATEGORIES pSHEnumClassesOfCategories;
-
 START_TEST(SHEnumClassesOfCategories)
 {
+    HMODULE hBrowseUI;
+    SHENUMCLASSESOFCATEGORIES pSHEnumClassesOfCategories;
     HRESULT hr;
-    HMODULE hbrowseui;
     CATID CategoryImplemented, CategoryRequired;
     CComPtr<IEnumGUID> pEnumGUID;
 
     // Set up.
 
-    hbrowseui = LoadLibraryA("browseui.dll");
-    ok(hbrowseui != NULL, "LoadLibraryA() failed\n");
-    if (!hbrowseui)
+    hBrowseUI = LoadLibraryA("browseui.dll");
+    ok(hBrowseUI != NULL, "LoadLibraryA() failed\n");
+    if (!hBrowseUI)
     {
         skip("No dll\n");
         return;
     }
 
-    pSHEnumClassesOfCategories = (SHENUMCLASSESOFCATEGORIES)GetProcAddress(hbrowseui, MAKEINTRESOURCEA(136));
+    pSHEnumClassesOfCategories = (SHENUMCLASSESOFCATEGORIES)GetProcAddress(hBrowseUI, MAKEINTRESOURCEA(136));
     ok(pSHEnumClassesOfCategories != NULL, "GetProcAddress() failed\n");
     if (!pSHEnumClassesOfCategories)
     {
@@ -52,29 +51,29 @@ START_TEST(SHEnumClassesOfCategories)
     // Keep this odd case, as ReactOS used to "implement" it.
 
     // hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 0, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 0, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     CategoryRequired = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 1, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories((ULONG)-1, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     // Implemented, '0, NULL'.
 
     // hr = pSHEnumClassesOfCategories(0, NULL, 0, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(0, NULL, 0, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     // CategoryRequired = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     // The following case duplicates a later one.
     // hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    // ok_long(hr, S_OK);
+    // ok_hex(hr, S_OK);
     // ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     // pEnumGUID = NULL;
 
@@ -82,24 +81,24 @@ START_TEST(SHEnumClassesOfCategories)
 
     CategoryImplemented = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 0, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     CategoryRequired = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
     ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryRequired = CATID_InfoBand;
     // hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(0, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
     ok(CategoryRequired == CATID_InfoBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
@@ -107,15 +106,15 @@ START_TEST(SHEnumClassesOfCategories)
     // Implemented, '1, NULL'.
 
     // hr = pSHEnumClassesOfCategories(1, NULL, 0, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(1, NULL, 0, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     CategoryRequired = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(1, NULL, 1, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(1, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     // Required, '0, &CategoryRequired'.
 
@@ -123,18 +122,18 @@ START_TEST(SHEnumClassesOfCategories)
 
     CategoryImplemented = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
     ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryImplemented = CATID_InfoBand;
     // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_InfoBand, "CategoryImplemented was modified\n");
     ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
@@ -142,26 +141,26 @@ START_TEST(SHEnumClassesOfCategories)
     // Required, '1, NULL'.
 
     // hr = pSHEnumClassesOfCategories(0, NULL, 1, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(0, NULL, 1, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     CategoryImplemented = CATID_DeskBand;
     // hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, NULL, NULL);
-    // ok_long(hr, E_INVALIDARG);
+    // ok_hex(hr, E_INVALIDARG);
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, NULL, &pEnumGUID);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     // Out, 'NULL'.
     // Previous similar checks are commented out, for usual use.
 
     CategoryImplemented = CATID_DeskBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, NULL);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     CategoryRequired = CATID_DeskBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, &CategoryRequired, NULL);
-    ok_long(hr, E_INVALIDARG);
+    ok_hex(hr, E_INVALIDARG);
 
     // Test success.
     // CATID_* from sdk/include/psdk/shlguid.h.
@@ -171,31 +170,31 @@ START_TEST(SHEnumClassesOfCategories)
 
     CategoryImplemented = CATID_BrowsableShellExt;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_BrowsableShellExt, "CategoryImplemented was modified\n");
     pEnumGUID = NULL;
 
     CategoryImplemented = CATID_BrowseInPlace;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_BrowseInPlace, "CategoryImplemented was modified\n");
     pEnumGUID = NULL;
 
     CategoryImplemented = CATID_DeskBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
     pEnumGUID = NULL;
 
     CategoryImplemented = CATID_InfoBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_InfoBand, "CategoryImplemented was modified\n");
     pEnumGUID = NULL;
 
     CategoryImplemented = CATID_CommBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 0, NULL, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_CommBand, "CategoryImplemented was modified\n");
     pEnumGUID = NULL;
 
@@ -203,31 +202,31 @@ START_TEST(SHEnumClassesOfCategories)
 
     CategoryRequired = CATID_BrowsableShellExt;
     hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryRequired == CATID_BrowsableShellExt, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryRequired = CATID_BrowseInPlace;
     hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryRequired == CATID_BrowseInPlace, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryRequired = CATID_DeskBand;
     hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryRequired = CATID_InfoBand;
     hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryRequired == CATID_InfoBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     CategoryRequired = CATID_CommBand;
     hr = pSHEnumClassesOfCategories(0, NULL, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryRequired == CATID_CommBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
@@ -236,12 +235,12 @@ START_TEST(SHEnumClassesOfCategories)
     CategoryImplemented = CATID_DeskBand;
     CategoryRequired = CATID_DeskBand;
     hr = pSHEnumClassesOfCategories(1, &CategoryImplemented, 1, &CategoryRequired, &pEnumGUID);
-    ok_long(hr, S_OK);
+    ok_hex(hr, S_OK);
     ok(CategoryImplemented == CATID_DeskBand, "CategoryImplemented was modified\n");
     ok(CategoryRequired == CATID_DeskBand, "CategoryRequired was modified\n");
     pEnumGUID = NULL;
 
     // Clean up.
 
-    ok(FreeLibrary(hbrowseui) != 0, "FreeLibrary() failed\n");
+    ok(FreeLibrary(hBrowseUI) != 0, "FreeLibrary() failed\n");
 }


### PR DESCRIPTION
## Purpose

Fix `CO_E_NOTINITIALIZED` on ReactOS:
VBox: [Jun 10 20:38 	33604e014768... 	success 	#11213](https://build.reactos.org/builders/Test%20VBox/builds/11213)
```
Running Wine Test, Module: browseui, Test: SHEnumClassesOfCategories
...
err:(dll/win32/ole32/compobj.c:3326) apartment not initialised
CSHEnumClassesOfCategories.cpp:178: Unexpected failure 800401f0.
CSHEnumClassesOfCategories.cpp:72: Unexpected failure 800401f0.
CSHEnumClassesOfCategories.cpp:271: Unexpected failure 800401f0.
CSHEnumClassesOfCategories.cpp:345: Unexpected failure 800401f0.
SHEnumClassesOfCategories.cpp:239: Test failed: Wrong value for 'hr', expected: ((HRESULT)0L) (0x0), got: 0x800401f0

SHEnumClassesOfCategories: 48 tests executed (0 marked as todo, 15 failures), 0 skipped.
```

JIRA issue: [CORE-11711](https://jira.reactos.org/browse/CORE-11711)

Cc @HBelusca

## Proposed changes

- Trivial improvements.
- ROS hack: Call CoInitializeEx(), with FIXME.

## TODO

`// FIXME: On Windows, CoInitializeEx() call is not needed. Why is it on ReactOS?`
Does anyone know the answer? (I found no Jira issue about that "misbehavior"...)
