### PR TITLE
[FREELDR] Use text video mode for compatibility with /NOGUIBOOT

### DIFF
--- a/boot/freeldr/freeldr/arch/arm/macharm.c
+++ b/boot/freeldr/freeldr/arch/arm/macharm.c
@@ -90,7 +90,7 @@ ArmInit(IN PARM_BOARD_CONFIGURATION_BLOCK BootContext)
 }
 
 VOID
-ArmPrepareForReactOS(IN BOOLEAN Setup)
+ArmPrepareForReactOS(VOID)
 {
     return;
 }

--- a/boot/freeldr/freeldr/arch/i386/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/machpc.c
@@ -1391,10 +1391,10 @@ PcMachInit(const char *CmdLine)
 }
 
 VOID
-PcPrepareForReactOS(IN BOOLEAN Setup)
+PcPrepareForReactOS(VOID)
 {
     /* On PC, prepare video and turn off the floppy motor */
-    PcVideoPrepareForReactOS(Setup);
+    PcVideoPrepareForReactOS();
     DiskStopFloppyMotor();
 }
 

--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -211,10 +211,10 @@ XboxMachInit(const char *CmdLine)
 }
 
 VOID
-XboxPrepareForReactOS(IN BOOLEAN Setup)
+XboxPrepareForReactOS(VOID)
 {
     /* On XBOX, prepare video and turn off the floppy motor */
-    XboxVideoPrepareForReactOS(Setup);
+    XboxVideoPrepareForReactOS();
     DiskStopFloppyMotor();
 }
 

--- a/boot/freeldr/freeldr/arch/i386/pcvideo.c
+++ b/boot/freeldr/freeldr/arch/i386/pcvideo.c
@@ -1109,16 +1109,10 @@ PcVideoSync(VOID)
 }
 
 VOID
-PcVideoPrepareForReactOS(IN BOOLEAN Setup)
+PcVideoPrepareForReactOS(VOID)
 {
-    if (Setup)
-    {
-        PcVideoSetMode80x50_80x43();
-    }
-    else
-    {
-        PcVideoSetBiosMode(0x12);
-    }
+    // PcVideoSetMode80x50_80x43();
+    PcVideoSetMode80x25();
     PcVideoHideShowTextCursor(FALSE);
 }
 

--- a/boot/freeldr/freeldr/arch/i386/xboxvideo.c
+++ b/boot/freeldr/freeldr/arch/i386/xboxvideo.c
@@ -240,9 +240,10 @@ XboxBeep(VOID)
 }
 
 VOID
-XboxVideoPrepareForReactOS(IN BOOLEAN Setup)
+XboxVideoPrepareForReactOS(VOID)
 {
-  XboxVideoClearScreenColor(MAKE_COLOR(0, 0, 0), TRUE);
+    XboxVideoClearScreenColor(MAKE_COLOR(0, 0, 0), TRUE);
+    XboxVideoHideShowTextCursor(FALSE);
 }
 
 /* EOF */

--- a/boot/freeldr/freeldr/include/arch/i386/machxbox.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machxbox.h
@@ -43,8 +43,8 @@ BOOLEAN XboxVideoIsPaletteFixed(VOID);
 VOID XboxVideoSetPaletteColor(UCHAR Color, UCHAR Red, UCHAR Green, UCHAR Blue);
 VOID XboxVideoGetPaletteColor(UCHAR Color, UCHAR* Red, UCHAR* Green, UCHAR* Blue);
 VOID XboxVideoSync(VOID);
-VOID XboxVideoPrepareForReactOS(IN BOOLEAN Setup);
-VOID XboxPrepareForReactOS(IN BOOLEAN Setup);
+VOID XboxVideoPrepareForReactOS(VOID);
+VOID XboxPrepareForReactOS(VOID);
 
 VOID XboxMemInit(VOID);
 PVOID XboxMemReserveMemory(ULONG MbToReserve);

--- a/boot/freeldr/freeldr/include/arch/pc/machpc.h
+++ b/boot/freeldr/freeldr/include/arch/pc/machpc.h
@@ -44,8 +44,8 @@ BOOLEAN PcVideoIsPaletteFixed(VOID);
 VOID PcVideoSetPaletteColor(UCHAR Color, UCHAR Red, UCHAR Green, UCHAR Blue);
 VOID PcVideoGetPaletteColor(UCHAR Color, UCHAR* Red, UCHAR* Green, UCHAR* Blue);
 VOID PcVideoSync(VOID);
-VOID PcVideoPrepareForReactOS(IN BOOLEAN Setup);
-VOID PcPrepareForReactOS(IN BOOLEAN Setup);
+VOID PcVideoPrepareForReactOS(VOID);
+VOID PcPrepareForReactOS(VOID);
 
 PFREELDR_MEMORY_DESCRIPTOR PcMemGetMemoryMap(ULONG *MemoryMapSize);
 

--- a/boot/freeldr/freeldr/include/machine.h
+++ b/boot/freeldr/freeldr/include/machine.h
@@ -55,7 +55,7 @@ typedef struct tagMACHVTBL
     VOID (*VideoGetPaletteColor)(UCHAR Color, UCHAR* Red, UCHAR* Green, UCHAR* Blue);
     VOID (*VideoSync)(VOID);
     VOID (*Beep)(VOID);
-    VOID (*PrepareForReactOS)(IN BOOLEAN Setup);
+    VOID (*PrepareForReactOS)(VOID);
 
     // NOTE: Not in the machine.c ...
     FREELDR_MEMORY_DESCRIPTOR* (*GetMemoryDescriptor)(FREELDR_MEMORY_DESCRIPTOR* Current);
@@ -113,8 +113,8 @@ VOID MachInit(const char *CmdLine);
     MachVtbl.VideoSync()
 #define MachBeep()  \
     MachVtbl.Beep()
-#define MachPrepareForReactOS(Setup)    \
-    MachVtbl.PrepareForReactOS(Setup)
+#define MachPrepareForReactOS() \
+    MachVtbl.PrepareForReactOS()
 #define MachDiskGetBootPath(Path, Size) \
     MachVtbl.DiskGetBootPath((Path), (Size))
 #define MachDiskReadLogicalSectors(Drive, Start, Count, Buf)    \

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -832,7 +832,7 @@ LoadAndBootWindowsCommon(
     LoaderBlockVA = PaToVa(LoaderBlock);
 
     /* "Stop all motors", change videomode */
-    MachPrepareForReactOS(Setup);
+    MachPrepareForReactOS();
 
     /* Cleanup ini file */
     IniCleanup();

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -211,6 +211,9 @@ ScrAcquireOwnership(PDEVICE_EXTENSION DeviceExtension)
     DeviceExtension->Rows = 30;
 #endif
 
+    /* Upload a default font for the default codepage 437 */
+    ScrLoadFontTable(437);
+
     DPRINT ("%d Columns  %d Rows %d Scanlines\n",
             DeviceExtension->Columns,
             DeviceExtension->Rows,
@@ -864,7 +867,7 @@ ScrIoControl(PDEVICE_OBJECT DeviceObject,
 
               if (!InbvCheckDisplayOwnership())
               {
-                // Upload a font for the codepage if needed
+                /* Upload a font for the codepage if needed */
                 ScrLoadFontTable(CodePage);
               }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16116](https://jira.reactos.org/browse/CORE-16116)

## Proposed changes

- always set video mode to 80x50.
  it's used for usetup & kernel boot screen will change video mode to VGA if required
- a~~dd text "Setup is starting ReactOS"
  the same thing was since Windows NT setup, but in ReactOS it just shows black screen. Now everything is ok.~~

## Preview

(outdated)
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/25367511/59462059-7d64b280-8e2b-11e9-9969-7b1235f73894.gif)

