### PR TITLE
[KERNEL32_APITEST] Improve SetComputerNameExW testcase

### DIFF
--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -229,7 +229,7 @@ START_TEST(SetComputerNameExW)
     for (i = 0; i < cchValidSymbols; ++i)
     {
         szName[0] = ValidSymbols[i];
-        szName[1] = 0;
+        szName[1] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, TRUE);
     }
 
@@ -237,7 +237,7 @@ START_TEST(SetComputerNameExW)
     {
         szName[0] = L'a';
         szName[1] = ValidSymbols[i];
-        szName[2] = 0;
+        szName[2] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, TRUE);
     }
 
@@ -245,7 +245,7 @@ START_TEST(SetComputerNameExW)
     {
         szName[0] = L'A';
         szName[1] = ValidSymbols[i];
-        szName[2] = 0;
+        szName[2] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, TRUE);
     }
 
@@ -253,7 +253,7 @@ START_TEST(SetComputerNameExW)
     {
         szName[0] = L'1';
         szName[1] = ValidSymbols[i];
-        szName[2] = 0;
+        szName[2] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, TRUE);
     }
 
@@ -261,7 +261,7 @@ START_TEST(SetComputerNameExW)
     {
         szName[0] = L'A';
         szName[1] = InvalidSymbols[i];
-        szName[2] = 0;
+        szName[2] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, FALSE);
     }
 
@@ -269,7 +269,7 @@ START_TEST(SetComputerNameExW)
     {
         szName[0] = L'1';
         szName[1] = InvalidSymbols[i];
-        szName[2] = 0;
+        szName[2] = UNICODE_NULL;
         DoTestComputerName(hKeyHN, hKeyCN, szName, FALSE);
     }
 

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -176,7 +176,7 @@ START_TEST(SetComputerNameExW)
     DoTestComputerName(hKeyHN, hKeyCN, L"", FALSE);
     DoTestComputerName(hKeyHN, hKeyCN, L"a", TRUE);
     DoTestComputerName(hKeyHN, hKeyCN, L"A", TRUE);
-    DoTestComputerName(hKeyHN, hKeyCN, L"1", FALSE);
+    DoTestComputerName(hKeyHN, hKeyCN, L"1", FALSE);   // numeric-only
     DoTestComputerName(hKeyHN, hKeyCN, L"@", FALSE);
     DoTestComputerName(hKeyHN, hKeyCN, L".", FALSE);
 
@@ -219,7 +219,7 @@ START_TEST(SetComputerNameExW)
     DoTestComputerName(hKeyHN, hKeyCN, ValidSymbols, TRUE);
     DoTestComputerName(hKeyHN, hKeyCN, InvalidSymbols, FALSE);
 
-    DoTestComputerName(hKeyHN, hKeyCN, L"123456", FALSE);
+    DoTestComputerName(hKeyHN, hKeyCN, L"123456", FALSE);   // numeric-only
     DoTestComputerName(hKeyHN, hKeyCN, L"123.456", FALSE);
     DoTestComputerName(hKeyHN, hKeyCN, L"123X456", TRUE);
     DoTestComputerName(hKeyHN, hKeyCN, L"123X.456", FALSE);

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -70,8 +70,14 @@ static void DoTestComputerName(HKEY hKeyHN, HKEY hKeyCN, LPCWSTR pszNewName, BOO
     ok(szComputerNameOld[0], "szComputerNameOld is empty\n");
 
     /* Change the value */
+    SetLastError(0xDEADFACE);
     ret = SetComputerNameExW(ComputerNamePhysicalDnsHostname, pszNewName);
     ok_int(ret, bValid);
+    Error = GetLastError();
+    if (bValid)
+        ok_long(Error, ERROR_SUCCESS);
+    else
+        ok_long(Error, ERROR_INVALID_PARAMETER);
 
     /* Get New NV Hostname */
     szNVHostNameNew[0] = UNICODE_NULL;

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -46,7 +46,7 @@ static void DoTestComputerName(HKEY hKeyHN, HKEY hKeyCN, LPCWSTR pszNewName, BOO
     WCHAR szHostNameOld[MAX_PATH], szHostNameNew[MAX_PATH];
     WCHAR szComputerNameOld[MAX_PATH], szComputerNameNew[MAX_PATH];
 
-    trace("Testing on '%S':\n", pszNewName);
+    trace("Testing '%S':\n", pszNewName);
 
     /* Get Old NV Hostname */
     szNVHostNameOld[0] = UNICODE_NULL;

--- a/modules/rostests/apitests/kernel32/SetComputerNameExW.c
+++ b/modules/rostests/apitests/kernel32/SetComputerNameExW.c
@@ -216,6 +216,7 @@ START_TEST(SetComputerNameExW)
     DoTestComputerName(hKeyHN, hKeyCN, L"123456", FALSE);
     DoTestComputerName(hKeyHN, hKeyCN, L"123.456", FALSE);
     DoTestComputerName(hKeyHN, hKeyCN, L"123X456", TRUE);
+    DoTestComputerName(hKeyHN, hKeyCN, L"123X.456", FALSE);
 
     DoTestComputerName(hKeyHN, hKeyCN, L"ThisIsLongLongComputerName", TRUE);
 


### PR DESCRIPTION
## Purpose
Improve `SetComputerNameExW` testcase to check invalid characters.
JIRA issue: [CORE-16122](https://jira.reactos.org/browse/CORE-16122)

Win2k3:
![successful](https://user-images.githubusercontent.com/2107452/59558693-eff3af00-9032-11e9-9417-e4a3ca2bc6cb.png)
Successful.