### PR TITLE
[REGEDIT] Adjust ListView column widths

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -385,6 +385,7 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     BOOL Result;
+    RECT rc;
 
     switch (message)
     {
@@ -401,7 +402,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         if (!g_pChildWnd) return 0;
 
         wcsncpy(g_pChildWnd->szPath, buffer, MAX_PATH);
-        g_pChildWnd->nSplitPos = 250;
+        g_pChildWnd->nSplitPos = 190;
         g_pChildWnd->hWnd = hWnd;
         g_pChildWnd->hAddressBarWnd = CreateWindowExW(WS_EX_CLIENTEDGE, L"Edit", NULL, WS_CHILD | WS_VISIBLE | WS_CHILDWINDOW | WS_TABSTOP,
                                                       CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
@@ -409,8 +410,9 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         g_pChildWnd->hAddressBtnWnd = CreateWindowExW(0, L"Button", L"\x00BB", WS_CHILD | WS_VISIBLE | WS_CHILDWINDOW | WS_TABSTOP | BS_TEXT | BS_CENTER | BS_VCENTER | BS_FLAT | BS_DEFPUSHBUTTON,
                                                       CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                                                       hWnd, (HMENU)0, hInst, 0);
+        GetClientRect(hWnd, &rc);
         g_pChildWnd->hTreeWnd = CreateTreeView(hWnd, g_pChildWnd->szPath, (HMENU) TREE_WINDOW);
-        g_pChildWnd->hListWnd = CreateListView(hWnd, (HMENU) LIST_WINDOW/*, g_pChildWnd->szPath*/);
+        g_pChildWnd->hListWnd = CreateListView(hWnd, (HMENU) LIST_WINDOW, rc.right - g_pChildWnd->nSplitPos);
         SetFocus(g_pChildWnd->hTreeWnd);
 
         /* set the address bar and button font */

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1311,8 +1311,8 @@ LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         EnableMenuItem(GetMenu(hWnd), ID_HELP_HELPTOPICS, MF_BYCOMMAND | MF_GRAYED);
         GetClientRect(hWnd, &rc);
         CreateWindowExW(0, szChildClass, NULL, WS_CHILD | WS_VISIBLE,
-                       rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
-                       hWnd, (HMENU)0, hInst, 0);
+                        rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
+                        hWnd, (HMENU)0, hInst, 0);
         break;
     case WM_COMMAND:
         if (!_CmdWndProc(hWnd, message, wParam, lParam))

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1303,13 +1303,15 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
 LRESULT CALLBACK FrameWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
+    RECT rc;
     switch (message)
     {
     case WM_CREATE:
         // For now, the Help dialog item is disabled because of lacking of HTML Help support
         EnableMenuItem(GetMenu(hWnd), ID_HELP_HELPTOPICS, MF_BYCOMMAND | MF_GRAYED);
+        GetClientRect(hWnd, &rc);
         CreateWindowExW(0, szChildClass, NULL, WS_CHILD | WS_VISIBLE,
-                       CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                       rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top,
                        hWnd, (HMENU)0, hInst, 0);
         break;
     case WM_COMMAND:

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -255,7 +255,7 @@ static void AddEntryToList(HWND hwndLV, LPWSTR Name, DWORD dwValType, void* ValB
     }
 }
 
-static BOOL CreateListColumns(HWND hWndListView, INT cx)
+static BOOL CreateListColumns(HWND hWndListView, INT cxTotal)
 {
     WCHAR szText[50];
     int index;
@@ -269,7 +269,7 @@ static BOOL CreateListColumns(HWND hWndListView, INT cx)
     for (index = 0; index < MAX_LIST_COLUMNS; index++)
     {
         lvC.iSubItem = index;
-        lvC.cx = (default_column_widths[index] * cx) / 100;
+        lvC.cx = (cxTotal * default_column_widths[index]) / 100;
         lvC.fmt = column_alignment[index];
         LoadStringW(hInst, IDS_LIST_COLUMN_FIRST + index, szText, COUNT_OF(szText));
         if (ListView_InsertColumn(hWndListView, index, &lvC) == -1) return FALSE;

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -49,7 +49,7 @@ typedef struct tagSORT_INFO
 static INT g_iSortedColumn = 0;
 
 #define MAX_LIST_COLUMNS (IDS_LIST_COLUMN_LAST - IDS_LIST_COLUMN_FIRST + 1)
-static const int default_column_widths[MAX_LIST_COLUMNS] = { 200, 175, 400 };
+static const int default_column_widths[MAX_LIST_COLUMNS] = { 35, 25, 40 };
 static const int column_alignment[MAX_LIST_COLUMNS] = { LVCFMT_LEFT, LVCFMT_LEFT, LVCFMT_LEFT };
 
 LPCWSTR GetValueName(HWND hwndLV, int iStartAt)
@@ -255,7 +255,7 @@ static void AddEntryToList(HWND hwndLV, LPWSTR Name, DWORD dwValType, void* ValB
     }
 }
 
-static BOOL CreateListColumns(HWND hWndListView)
+static BOOL CreateListColumns(HWND hWndListView, INT cx)
 {
     WCHAR szText[50];
     int index;
@@ -269,7 +269,7 @@ static BOOL CreateListColumns(HWND hWndListView)
     for (index = 0; index < MAX_LIST_COLUMNS; index++)
     {
         lvC.iSubItem = index;
-        lvC.cx = default_column_widths[index];
+        lvC.cx = (default_column_widths[index] * cx) / 100;
         lvC.fmt = column_alignment[index];
         LoadStringW(hInst, IDS_LIST_COLUMN_FIRST + index, szText, COUNT_OF(szText));
         if (ListView_InsertColumn(hWndListView, index, &lvC) == -1) return FALSE;
@@ -627,7 +627,7 @@ BOOL ListWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
     return FALSE;
 }
 
-HWND CreateListView(HWND hwndParent, HMENU id)
+HWND CreateListView(HWND hwndParent, HMENU id, INT cx)
 {
     RECT rcClient;
     HWND hwndLV;
@@ -641,7 +641,7 @@ HWND CreateListView(HWND hwndParent, HMENU id)
     if (!hwndLV) return NULL;
 
     /* Initialize the image list, and add items to the control. */
-    if (!CreateListColumns(hwndLV)) goto fail;
+    if (!CreateListColumns(hwndLV, cx)) goto fail;
     if (!InitListViewImageLists(hwndLV)) goto fail;
 
     return hwndLV;

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -49,7 +49,7 @@ typedef struct tagSORT_INFO
 static INT g_iSortedColumn = 0;
 
 #define MAX_LIST_COLUMNS (IDS_LIST_COLUMN_LAST - IDS_LIST_COLUMN_FIRST + 1)
-static const int default_column_widths[MAX_LIST_COLUMNS] = { 35, 25, 40 };
+static const int default_column_widths[MAX_LIST_COLUMNS] = { 35, 25, 40 };  /* in percents */
 static const int column_alignment[MAX_LIST_COLUMNS] = { LVCFMT_LEFT, LVCFMT_LEFT, LVCFMT_LEFT };
 
 LPCWSTR GetValueName(HWND hwndLV, int iStartAt)

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -109,7 +109,7 @@ extern BOOL CopyKeyName(HWND hWnd, HKEY hRootKey, LPCWSTR keyName);
 extern BOOL ExportRegistryFile(HWND hWnd);
 
 /* listview.c */
-extern HWND CreateListView(HWND hwndParent, HMENU id);
+extern HWND CreateListView(HWND hwndParent, HMENU id, INT cx);
 extern BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath);
 extern LPCWSTR GetValueName(HWND hwndLV, int iStartAt);
 extern BOOL ListWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15187](https://jira.reactos.org/browse/CORE-15187)

BEFORE:
![regedit-before](https://user-images.githubusercontent.com/2107452/59561937-cea9b780-9060-11e9-9f19-40eda5d8678e.png)
AFTER:
![regedit-after](https://user-images.githubusercontent.com/2107452/59561936-cea9b780-9060-11e9-8897-580f594c936b.png)

- Adjust the splitter position to shrink it.
- Add a `cx` parameter to `CreateListView` function.
- Fix the ListView column widths by the percent values.
- Pass the valid rectangle upon `ChildWnd` creation.
