### PR TITLE
[STDUNK][PORTCLS][CMIDriver] Fix issue with operator new/delete

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ else()
     endif()
 
     # Other
+    add_definitions(-D_NEW_DELETE_OPERATORS_)
     if(ARCH STREQUAL "i386")
         add_definitions(-DUSE_COMPILER_EXCEPTIONS -D_USE_32BIT_TIME_T)
     elseif(ARCH STREQUAL "amd64")

--- a/drivers/wdm/audio/backpln/portcls/dma_slave.cpp
+++ b/drivers/wdm/audio/backpln/portcls/dma_slave.cpp
@@ -17,6 +17,16 @@
 class CDmaChannelInit : public IDmaChannelInit
 {
 public:
+    inline
+    PVOID
+    operator new(
+        size_t Size,
+        POOL_TYPE PoolType,
+        ULONG Tag)
+    {
+        return ExAllocatePoolWithTag(PoolType, Size, Tag);
+    }
+
     STDMETHODIMP QueryInterface( REFIID InterfaceId, PVOID* Interface);
 
     STDMETHODIMP_(ULONG) AddRef()

--- a/drivers/wdm/audio/backpln/portcls/miniport.cpp
+++ b/drivers/wdm/audio/backpln/portcls/miniport.cpp
@@ -14,6 +14,32 @@
 
 #include <debug.h>
 
+PVOID
+__cdecl
+operator new(
+    size_t Size,
+    POOL_TYPE PoolType,
+    ULONG Tag)
+{
+    return ExAllocatePoolWithTag(PoolType, Size, Tag);
+}
+
+void
+__cdecl
+operator delete(
+    PVOID ptr)
+{
+    ExFreePool(ptr);
+}
+
+void
+__cdecl
+operator delete(
+    PVOID ptr, UINT_PTR)
+{
+    ExFreePool(ptr);
+}
+
 NTSTATUS
 NTAPI
 PcNewMiniport(

--- a/drivers/wdm/audio/backpln/portcls/miniport_dmus.cpp
+++ b/drivers/wdm/audio/backpln/portcls/miniport_dmus.cpp
@@ -1708,7 +1708,7 @@ NewStream
         )
     {
         CMiniportDMusUARTStream *pStream =
-            new(PoolType) CMiniportDMusUARTStream();
+            new(PoolType, 'wNcP') CMiniportDMusUARTStream();
 
         if (pStream)
         {

--- a/drivers/wdm/audio/backpln/portcls/pin_wavecyclic.cpp
+++ b/drivers/wdm/audio/backpln/portcls/pin_wavecyclic.cpp
@@ -18,6 +18,16 @@ class CPortPinWaveCyclic : public IPortPinWaveCyclic,
                            public IServiceSink
 {
 public:
+    inline
+    PVOID
+    operator new(
+        size_t Size,
+        POOL_TYPE PoolType,
+        ULONG Tag)
+    {
+        return ExAllocatePoolWithTag(PoolType, Size, Tag);
+    }
+
     STDMETHODIMP QueryInterface( REFIID InterfaceId, PVOID* Interface);
 
     STDMETHODIMP_(ULONG) AddRef()

--- a/drivers/wdm/audio/backpln/portcls/private.hpp
+++ b/drivers/wdm/audio/backpln/portcls/private.hpp
@@ -30,6 +30,13 @@
 #define PC_ASSERT_IRQL(x) PC_ASSERT(KeGetCurrentIrql() <= (x))
 #define PC_ASSERT_IRQL_EQUAL(x) PC_ASSERT(KeGetCurrentIrql()==(x))
 
+PVOID
+__cdecl
+operator new(
+    size_t Size,
+    POOL_TYPE PoolType,
+    ULONG Tag);
+
 extern
 "C"
 NTSTATUS

--- a/drivers/wdm/audio/drivers/CMIDriver/precomp.h
+++ b/drivers/wdm/audio/drivers/CMIDriver/precomp.h
@@ -6,4 +6,11 @@
 
 #include "debug.hpp"
 
+PVOID
+__cdecl
+operator new(
+    size_t size,
+    POOL_TYPE pool_type,
+    ULONG tag);
+
 #endif /* _CMIDRIVER_PCH_ */

--- a/sdk/include/ddk/stdunk.h
+++ b/sdk/include/ddk/stdunk.h
@@ -211,7 +211,7 @@ operator delete(
     ExFreePool(ptr);
 }
 
-#endif  /* ALLOCATION_OPERATORS_DEFINED */
+#endif  /* _NEW_DELETE_OPERATORS_ */
 
 
 #else   /* Being compiled with C */

--- a/sdk/lib/drivers/libusb/libusb.h
+++ b/sdk/lib/drivers/libusb/libusb.h
@@ -22,7 +22,6 @@ extern "C"
 // the following includes are required to get kcom to compile
 //
 #include <portcls.h>
-#define _NEW_DELETE_OPERATORS_
 #include <kcom.h>
 
 PVOID

--- a/sdk/lib/drivers/sound/stdunk/cunknown.cpp
+++ b/sdk/lib/drivers/sound/stdunk/cunknown.cpp
@@ -11,6 +11,58 @@
 
 #include <stdunk.h>
 
+inline
+PVOID
+KCOM_New(
+    size_t size,
+    POOL_TYPE pool_type,
+    ULONG tag)
+{
+    PVOID result;
+
+    result = ExAllocatePoolWithTag(pool_type, size, tag);
+
+    if (result)
+        RtlZeroMemory(result, size);
+
+    return result;
+}
+
+PVOID
+__cdecl
+operator new(
+    size_t size,
+    POOL_TYPE pool_type)
+{
+    return KCOM_New(size, pool_type, 'wNcP');
+}
+
+PVOID
+__cdecl
+operator new(
+    size_t size,
+    POOL_TYPE pool_type,
+    ULONG tag)
+{
+    return KCOM_New(size, pool_type, tag);
+}
+
+void
+__cdecl
+operator delete(
+    PVOID ptr)
+{
+    ExFreePool(ptr);
+}
+
+void
+__cdecl
+operator delete(
+    PVOID ptr, UINT_PTR)
+{
+    ExFreePool(ptr);
+}
+
 CUnknown::CUnknown(PUNKNOWN outer_unknown)
 {
     m_ref_count = 0;


### PR DESCRIPTION
Fix for MSVC warning "C2323: 'operator new': non-member operator new or delete functions may not be declared static or in a namespace other than the global namespace."

See https://docs.microsoft.com/en-us/cpp/porting/visual-cpp-what-s-new-2003-through-2015?view=vs-2019 section "Overloaded operator new and operator delete"
