### PR TITLE
[NTOS:CC] CcWriteVirtualAddress(): Do not round 'Size'. CORE-16018

### DIFF
--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -178,7 +178,6 @@ CcWriteVirtualAddress (
         } while (++i < (Size >> PAGE_SHIFT));
     }
 
-    Size = ROUND_TO_PAGES(Size);
     ASSERT(Size <= VACB_MAPPING_GRANULARITY);
     ASSERT(Size > 0);
 


### PR DESCRIPTION
## Purpose

Revert 'Properly align VACB writes' part of 2a80ae2bb6fdb4135d41244335caa2dadb6c8fa9.

JIRA issue: [CORE-15384](https://jira.reactos.org/browse/CORE-15384) and [CORE-16018](https://jira.reactos.org/browse/CORE-16018)

Cc @HeisSpiter

## Proposed changes

With regard to CORE-15067, kmtest:CcCopyRead result is unchanged :-)