### PR TITLE
[DSOUND_NEW] Add CMakeLists.txt + fix gcc compilation

### DIFF
--- a/dll/directx/dsound_new/CMakeLists.txt
+++ b/dll/directx/dsound_new/CMakeLists.txt
@@ -1,0 +1,30 @@
+
+spec2def(dsound.dll dsound.spec ADD_IMPORTLIB)
+
+list(APPEND SOURCE
+    capture.c
+    capturebuffer.c
+    classfactory.c
+    devicelist.c
+    directsound.c
+    dsound.c
+    enum.c
+    misc.c
+    notify.c
+    primary.c
+    property.c
+    regsvr.c
+    secondary.c
+    stubs.c
+    precomp.h
+    resource.h)
+
+add_library(dsound MODULE
+    ${SOURCE}
+    version.rc)
+
+set_module_type(dsound win32dll)
+target_link_libraries(dsound dxguid uuid)
+add_importlibs(dsound winmm advapi32 msvcrt kernel32 ntdll)
+add_pch(dsound precomp.h SOURCE)
+add_cd_file(TARGET dsound DESTINATION reactos/system32 FOR all)

--- a/dll/directx/dsound_new/capturebuffer.c
+++ b/dll/directx/dsound_new/capturebuffer.c
@@ -641,7 +641,7 @@ IDirectSoundCaptureBufferImpl_GetObjectInPath(
     REFGUID rguidInterface,
     LPVOID* ppObject )
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -652,7 +652,7 @@ IDirectSoundCaptureBufferImpl_GetFXStatus(
     DWORD dwFXCount,
     LPDWORD pdwFXStatus )
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 

--- a/dll/directx/dsound_new/misc.c
+++ b/dll/directx/dsound_new/misc.c
@@ -26,15 +26,12 @@ PerformChannelConversion(
     ULONG ResultLength,
     PULONG BytesWritten)
 {
-    DWORD Samples;
     DWORD NewIndex, OldIndex;
     DWORD NewLength, Skip;
 
-    Samples = BufferLength / (BitsPerSample / 8) / OldChannels;
-
     if (NewChannels > OldChannels)
     {
-        UNIMPLEMENTED
+        UNIMPLEMENTED;
         ASSERT(0);
     }
 
@@ -546,7 +543,7 @@ CreateCompatiblePin(
     {
         if (AudioRange->DataRange.FormatSize != sizeof(KSDATARANGE_AUDIO))
         {
-            UNIMPLEMENTED
+            UNIMPLEMENTED;
             AudioRange = (PKSDATARANGE_AUDIO)((PUCHAR)AudioRange + AudioRange->DataRange.FormatSize);
             continue;
         }

--- a/dll/directx/dsound_new/precomp.h
+++ b/dll/directx/dsound_new/precomp.h
@@ -1,4 +1,5 @@
-#pragma once
+#ifndef PRECOMP_H
+#define PRECOMP_H
 
 #define COBJMACROS
 #define NONAMELESSUNION
@@ -266,3 +267,5 @@ NewDirectSoundNotify(
     BOOL bMix,
     HANDLE hPin,
     DWORD BufferSize);
+
+#endif

--- a/dll/directx/dsound_new/primary.c
+++ b/dll/directx/dsound_new/primary.c
@@ -312,7 +312,7 @@ PrimaryDirectSoundBuffer8Impl_fnLock(
     LPDWORD pdwAudioBytes2,
     DWORD dwFlags)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -500,7 +500,7 @@ PrimaryDirectSoundBuffer8Impl_fnUnlock(
     LPVOID pvAudioPtr2,
     DWORD dwAudioBytes2)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -510,7 +510,7 @@ WINAPI
 PrimaryDirectSoundBuffer8Impl_fnRestore(
     LPDIRECTSOUNDBUFFER8 iface)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -523,7 +523,7 @@ PrimaryDirectSoundBuffer8Impl_fnSetFX(
     LPDSEFFECTDESC pDSFXDesc,
     LPDWORD pdwResultCodes)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -535,7 +535,7 @@ PrimaryDirectSoundBuffer8Impl_fnAcquireResources(
     DWORD dwEffectsCount, 
     LPDWORD pdwResultCodes)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -548,7 +548,7 @@ PrimaryDirectSoundBuffer8Impl_fnGetObjectInPath(
     REFGUID rguidInterface,
     LPVOID *ppObject)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 

--- a/dll/directx/dsound_new/property.c
+++ b/dll/directx/dsound_new/property.c
@@ -196,7 +196,7 @@ KSPropertySetImpl_Get(
     }
 
 
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return E_PROP_ID_UNSUPPORTED;
 }
 
@@ -211,7 +211,7 @@ KSPropertySetImpl_Set(
     LPVOID pPropData,
     ULONG cbPropData )
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return E_PROP_ID_UNSUPPORTED;
 }
 
@@ -223,7 +223,7 @@ KSPropertySetImpl_QuerySupport(
     ULONG dwPropID,
     PULONG pTypeSupport )
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return E_PROP_ID_UNSUPPORTED;
 }
 

--- a/dll/directx/dsound_new/resource.h
+++ b/dll/directx/dsound_new/resource.h
@@ -1,4 +1,7 @@
-#pragma once
+#ifndef RESOURCE_H
+#define RESOURCE_H
 
 #define IDS_PRIMARY_PLAYBACK_DEVICE        100
 #define IDS_PRIMARY_RECORD_DEVICE          101
+
+#endif

--- a/dll/directx/dsound_new/secondary.c
+++ b/dll/directx/dsound_new/secondary.c
@@ -316,7 +316,7 @@ SecondaryDirectSoundBuffer8Impl_fnLock(
     }
     else if (dwFlags == DSBLOCK_FROMWRITECURSOR)
     {
-        UNIMPLEMENTED
+        UNIMPLEMENTED;
         return DSERR_UNSUPPORTED;
     }
     else
@@ -534,7 +534,7 @@ WINAPI
 SecondaryDirectSoundBuffer8Impl_fnRestore(
     LPDIRECTSOUNDBUFFER8 iface)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -547,7 +547,7 @@ SecondaryDirectSoundBuffer8Impl_fnSetFX(
     LPDSEFFECTDESC pDSFXDesc,
     LPDWORD pdwResultCodes)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -559,7 +559,7 @@ SecondaryDirectSoundBuffer8Impl_fnAcquireResources(
     DWORD dwEffectsCount, 
     LPDWORD pdwResultCodes)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 
@@ -572,7 +572,7 @@ SecondaryDirectSoundBuffer8Impl_fnGetObjectInPath(
     REFGUID rguidInterface,
     LPVOID *ppObject)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 

--- a/dll/directx/dsound_new/stubs.c
+++ b/dll/directx/dsound_new/stubs.c
@@ -23,7 +23,7 @@ DirectSoundFullDuplexCreate(
     LPDIRECTSOUNDBUFFER8 *ppDSBuffer8,
     LPUNKNOWN pUnkOuter)
 {
-    UNIMPLEMENTED
+    UNIMPLEMENTED;
     return DSERR_INVALIDPARAM;
 }
 


### PR DESCRIPTION
## Purpose
Add CMakeLists.txt and mostly fix gcc compilation of dsound_new. Although it is still not compilable, my PR fixes at least part of compilation issues.
If you want to test it, you need to comment out `add_subdirectory(dsound)` in dll/directx/wine/CMakeLists.txt and uncomment `#add_subdirectory(dsound_new) # disabled in trunk` in dll/directx/CMakeLists.txt.

JIRA issue: [CORE-16128](https://jira.reactos.org/browse/CORE-16128)