### PR TITLE
[NTOS:MM] Fix MmSizeOfSystemCacheInPages value on AMD64. CORE-14259

### DIFF
--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -2521,11 +2521,16 @@ MmArmInitSystem(IN ULONG Phase,
 
         /* Define limits for system cache */
 #ifdef _M_AMD64
-        MmSizeOfSystemCacheInPages = (MI_SYSTEM_CACHE_END - MI_SYSTEM_CACHE_START) / PAGE_SIZE;
+        MmSizeOfSystemCacheInPages = ((MI_SYSTEM_CACHE_END + 1) - MI_SYSTEM_CACHE_START) / PAGE_SIZE;
 #else
         MmSizeOfSystemCacheInPages = ((ULONG_PTR)MI_PAGED_POOL_START - (ULONG_PTR)MI_SYSTEM_CACHE_START) / PAGE_SIZE;
 #endif
         MmSystemCacheEnd = (PVOID)((ULONG_PTR)MmSystemCacheStart + (MmSizeOfSystemCacheInPages * PAGE_SIZE) - 1);
+#ifdef _M_AMD64
+        ASSERT(MmSystemCacheEnd == (PVOID)MI_SYSTEM_CACHE_END);
+#else
+        ASSERT(MmSystemCacheEnd == (PVOID)((ULONG_PTR)MI_PAGED_POOL_START - 1));
+#endif
 
         /* Initialize the system cache */
         //MiInitializeSystemCache(MmSystemCacheWsMinimum, MmAvailablePages);


### PR DESCRIPTION
## Purpose

Fix MmSizeOfSystemCacheInPages value on AMD64.

Addendum to d56a24908908b574852091af0b8bd9dca7bc1165.
JIRA issue: [CORE-14259](https://jira.reactos.org/browse/CORE-14259)

Cc @HeisSpiter

## Proposed changes

And add 'ASSERT(MmSystemCacheEnd == ...);'.

## TODO

- [ ] I can't test it on AMD64.
