### PR TITLE
[SHELL32] Fix default context menu ignoring the default menu item.

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -289,11 +289,11 @@ void CDefaultContextMenu::AddStaticEntry(const HKEY hkeyClass, const WCHAR *szVe
 	
     lres = RegOpenKeyExW(hkeyClass, L"shell", 0, KEY_READ, &hShellKey);
 	
-    if(lres == STATUS_SUCCESS)
+    if(lres == ERROR_SUCCESS)
         lres = RegQueryValueEx(hShellKey, NULL, 0, &dwType, (LPBYTE)wszDefault, &dwSize);
 	
-    if((!wcsicmp(szVerb, wszDefault) && lres == STATUS_SUCCESS) ||
-       (!wcsicmp(szVerb, L"open") && lres != STATUS_SUCCESS))
+    if((!wcsicmp(szVerb, wszDefault) && lres == ERROR_SUCCESS) ||
+       (!wcsicmp(szVerb, L"open") && lres != ERROR_SUCCESS))
     {
         /* open verb is always inserted in front, unless the default value of shell entry is set */
         pEntry->pNext = m_pStaticEntries;
@@ -314,13 +314,13 @@ void CDefaultContextMenu::AddStaticEntriesForKey(HKEY hKey)
     HKEY hShellKey;
     LRESULT lres = RegOpenKeyExW(hKey, L"shell", 0, KEY_READ, &hShellKey);
 	
-    if (lres != STATUS_SUCCESS)
+    if (lres != ERROR_SUCCESS)
         return;
 
     while(TRUE)
     {
         cchName = _countof(wszName);
-        if (RegEnumKeyExW(hShellKey, dwIndex++, wszName, &cchName, NULL, NULL, NULL, NULL) != STATUS_SUCCESS)
+        if (RegEnumKeyExW(hShellKey, dwIndex++, wszName, &cchName, NULL, NULL, NULL, NULL) != ERROR_SUCCESS)
             break;
 
         AddStaticEntry(hKey, wszName);

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -290,8 +290,10 @@ void CDefaultContextMenu::AddStaticEntry(const HKEY hkeyClass, const HKEY hShell
     pEntry->hkClass = hkeyClass;
 
     lres = RegQueryValueExW(hShellKey, NULL, 0, &dwType, (LPBYTE)wszDefault, &dwSize);
+    if ((lres == ERROR_SUCCESS) && (dwType != REG_SZ))
+        lres = ERROR_INVALID_DATA;
 
-    if (((lres == ERROR_SUCCESS && dwType == REG_SZ) && !wcsicmp(szVerb, wszDefault)) ||
+    if (((lres == ERROR_SUCCESS) && !wcsicmp(szVerb, wszDefault)) ||
         ((lres != ERROR_SUCCESS) && !wcsicmp(szVerb, L"open")))
     {
         /* open verb is always inserted in front, unless the default value of shell entry is set */


### PR DESCRIPTION
Make default context menu read the default value of the "shell" key to check which menu entry should be the first (and default) one.

I have installed Bochs on ReactOS, and I have noticed a slight difference in how the .bochsrc files are opened. When I double-clicked the file the configuration menu popped up. I knew it should have just run the emulation instead. Therefore I installed the same version of Bochs on Windows XP machine, and I have confirmed that it shouldn't bring up the configuration menu. I checked the (ReactOS) registry, and I have came to a conclusion that ReactOS is simply ignoring the "(Default)" value in "shell" key.

## Purpose

Make ReactOS read the "(Default)" value of "shell" key, so that the default menu item for context menu and the effect of doubleclick the same as in Windows.


