### PR TITLE
[ROSAUTOTEST] Output '[ROSAUTOTEST] ' "everywhere"

### DIFF
--- a/modules/rostests/rosautotest/CJournaledTestList.cpp
+++ b/modules/rostests/rosautotest/CJournaledTestList.cpp
@@ -154,7 +154,7 @@ CJournaledTestList::WriteInitialJournalFile()
     CTestInfo* TestInfo;
     DWORD BytesWritten;
 
-    StringOut("Writing initial journal file...\n\n");
+    StringOut("[ROSAUTOTEST] Writing initial journal file...\n\n");
 
     m_ListIterator = 0;
 
@@ -200,7 +200,7 @@ CJournaledTestList::LoadJournalFile()
     DWORD BytesRead;
     DWORD RemainingSize;
 
-    StringOut("Loading journal file...\n\n");
+    StringOut("[ROSAUTOTEST] Loading journal file...\n\n");
 
     OpenJournal(GENERIC_READ);
     RemainingSize = GetFileSize(m_hJournal, NULL);

--- a/modules/rostests/rosautotest/CWebService.cpp
+++ b/modules/rostests/rosautotest/CWebService.cpp
@@ -105,7 +105,6 @@ CWebService::Finish(const char* TestType)
 {
     auto_array_ptr<char> Response;
     string Data;
-    stringstream ss;
 
     if (!m_TestID)
         EXCEPTION("CWebService::Finish was called, but not a single result had been submitted!\n");
@@ -121,7 +120,10 @@ CWebService::Finish(const char* TestType)
 
     if (strcmp(Response, "OK"))
     {
-        ss << "When finishing the test run, the server responded:" << endl << Response << endl;
+        stringstream ss;
+
+        ss << "[ROSAUTOTEST] When finishing the test run, the server responded:" << endl
+           << "[ROSAUTOTEST] " << Response << endl;
         SSEXCEPTION;
     }
 }
@@ -156,7 +158,8 @@ CWebService::GetTestID(const char* TestType)
     {
         stringstream ss;
 
-        ss << "Expected Test ID, but received:" << endl << m_TestID << endl;
+        ss << "[ROSAUTOTEST] Expected Test ID, but received:" << endl
+           << "[ROSAUTOTEST] " << m_TestID << endl;
         SSEXCEPTION;
     }
 }
@@ -196,7 +199,8 @@ CWebService::GetSuiteID(const char* TestType, CTestInfo* TestInfo)
     {
         stringstream ss;
 
-        ss << "Expected Suite ID, but received:" << endl << SuiteID << endl;
+        ss << "[ROSAUTOTEST] Expected Suite ID, but received:" << endl
+           << "[ROSAUTOTEST] " << SuiteID << endl;
         SSEXCEPTION;
     }
 
@@ -240,7 +244,8 @@ CWebService::Submit(const char* TestType, CTestInfo* TestInfo)
 
     if (strcmp(Response, "OK"))
     {
-        ss << "When submitting the result, the server responded:" << endl << Response << endl;
+        ss << "[ROSAUTOTEST] When submitting the result, the server responded:" << endl
+           << "[ROSAUTOTEST] " << Response << endl;
         SSEXCEPTION;
     }
 }

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -327,11 +327,17 @@ CWineTest::RunTest(CTestInfo* TestInfo)
     }
     catch(CTestException& e)
     {
+        /* Print what's left */
         if(!tailString.empty())
+        {
             StringOut(tailString);
-        tailString.clear();
+            tailString.clear();
+        }
+
         StringOut(e.GetMessage());
-        TestInfo->Log += e.GetMessage();
+
+        if (Configuration.DoSubmit())
+            TestInfo->Log += e.GetMessage();
     }
 
     /* Print what's left */
@@ -342,7 +348,9 @@ CWineTest::RunTest(CTestInfo* TestInfo)
     ssFinish << "Test " << TestInfo->Test << " completed in ";
     ssFinish << setprecision(2) << fixed << TotalTime << " seconds." << endl;
     StringOut(ssFinish.str());
-    TestInfo->Log += ssFinish.str();
+
+    if (Configuration.DoSubmit())
+        TestInfo->Log += ssFinish.str();
 }
 
 /**

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -238,7 +238,7 @@ CWineTest::GetNextTestInfo()
                     {
                         stringstream ss;
 
-                        ss << "Invalid test file name: " << UnicodeToAscii(m_CurrentFile) << endl;
+                        ss << "[ROSAUTOTEST] Invalid test file name: " << UnicodeToAscii(m_CurrentFile) << endl;
                         SSEXCEPTION;
                     }
 
@@ -287,7 +287,8 @@ CWineTest::RunTest(CTestInfo* TestInfo)
     CPipe Pipe;
     char Buffer[1024];
 
-    ss << "Running Wine Test, Module: " << TestInfo->Module << ", Test: " << TestInfo->Test << endl;
+    ss << "[ROSAUTOTEST] Running Wine Test, Module: " << TestInfo->Module
+         << ", Test: " << TestInfo->Test << endl;
     StringOut(ss.str());
 
     StartTime = GetTickCount();
@@ -351,8 +352,8 @@ CWineTest::RunTest(CTestInfo* TestInfo)
         StringOut(tailString);
 
     TotalTime = ((float)GetTickCount() - StartTime)/1000;
-    ssFinish << "Test " << TestInfo->Test << " completed in ";
-    ssFinish << setprecision(2) << fixed << TotalTime << " seconds." << endl;
+    ssFinish << "[ROSAUTOTEST] Test " << TestInfo->Test << " completed in "
+               << setprecision(2) << fixed << TotalTime << " seconds." << endl;
     StringOut(ssFinish.str());
 
     if (Configuration.DoSubmit())

--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -255,10 +255,12 @@ CWineTest::GetNextTestInfo()
         {
             stringstream ss;
 
-            ss << "An exception occurred trying to list tests for: " << UnicodeToAscii(m_CurrentFile) << endl;
+            // e.GetMessage() must include ending '\n'.
+            ss << "[ROSAUTOTEST] An exception occurred trying to list tests for: " << UnicodeToAscii(m_CurrentFile) << endl
+               << "[ROSAUTOTEST] " << e.GetMessage()
+               << endl;
             StringOut(ss.str());
-            StringOut(e.GetMessage());
-            StringOut("\n");
+
             m_CurrentFile.clear();
             delete[] m_ListBuffer;
         }
@@ -327,6 +329,8 @@ CWineTest::RunTest(CTestInfo* TestInfo)
     }
     catch(CTestException& e)
     {
+        stringstream ss;
+
         /* Print what's left */
         if(!tailString.empty())
         {
@@ -334,10 +338,12 @@ CWineTest::RunTest(CTestInfo* TestInfo)
             tailString.clear();
         }
 
-        StringOut(e.GetMessage());
+        // e.GetMessage() must include ending '\n'.
+        ss << "[ROSAUTOTEST] " << e.GetMessage();
+        StringOut(ss.str());
 
         if (Configuration.DoSubmit())
-            TestInfo->Log += e.GetMessage();
+            TestInfo->Log += ss.str();
     }
 
     /* Print what's left */

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -61,8 +61,8 @@ wmain(int argc, wchar_t* argv[])
 
         ss << endl
            << endl
-           << "[ROSAUTOTEST] System uptime " << setprecision(2) << fixed;
-        ss << ((float)GetTickCount()/1000) << " seconds" << endl;
+           << "[ROSAUTOTEST] System uptime " << setprecision(2) << fixed
+             << ((float)GetTickCount() / 1000) << " seconds" << endl;
         StringOut(ss.str());
         
         /* Report tests startup */

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -102,11 +102,11 @@ wmain(int argc, wchar_t* argv[])
         stringstream ss;
 
         // e.GetMessage() must include ending '\n'.
-        ss << "An exception occured in rosautotest." << endl
-           << "Message: " << e.GetMessage()
-           << "File: " << e.GetFile() << endl
-           << "Line: " << e.GetLine() << endl
-           << "Last Win32 Error: " << GetLastError() << endl;
+        ss << "[ROSAUTOTEST] An exception occured in rosautotest." << endl
+           << "[ROSAUTOTEST] Message: " << e.GetMessage()
+           << "[ROSAUTOTEST] File: " << e.GetFile() << endl
+           << "[ROSAUTOTEST] Line: " << e.GetLine() << endl
+           << "[ROSAUTOTEST] Last Win32 Error: " << GetLastError() << endl;
         StringOut(ss.str());
     }
 

--- a/modules/rostests/rosautotest/main.cpp
+++ b/modules/rostests/rosautotest/main.cpp
@@ -81,7 +81,7 @@ wmain(int argc, wchar_t* argv[])
         WineTest.Run();
 
         /* For sysreg2 */
-        DbgPrint("SYSREG_CHECKPOINT:THIRDBOOT_COMPLETE\n");
+        DbgPrint("[ROSAUTOTEST] SYSREG_CHECKPOINT:THIRDBOOT_COMPLETE\n");
 
         ReturnValue = 0;
     }
@@ -112,7 +112,7 @@ wmain(int argc, wchar_t* argv[])
 
     /* For sysreg2 to notice if rosautotest itself failed */
     if(ReturnValue == 1)
-        DbgPrint("SYSREG_ROSAUTOTEST_FAILURE\n");
+        DbgPrint("[ROSAUTOTEST] SYSREG_ROSAUTOTEST_FAILURE\n");
 
     /* Report successful end of tests */
     ReportEventW(hLog,

--- a/modules/rostests/rosautotest/shutdown.cpp
+++ b/modules/rostests/rosautotest/shutdown.cpp
@@ -20,14 +20,14 @@ bool ShutdownSystem()
 
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES, &hToken))
     {
-        StringOut("OpenProcessToken failed\n");
+        StringOut("[ROSAUTOTEST] OpenProcessToken failed\n");
         return false;
     }
 
     /* Get the LUID for the Shutdown privilege */
     if (!LookupPrivilegeValueW(NULL, SE_SHUTDOWN_NAME, &Privileges.Privileges[0].Luid))
     {
-        StringOut("LookupPrivilegeValue failed\n");
+        StringOut("[ROSAUTOTEST] LookupPrivilegeValue failed\n");
         return false;
     }
 
@@ -37,14 +37,14 @@ bool ShutdownSystem()
 
     if (!AdjustTokenPrivileges(hToken, FALSE, &Privileges, 0, NULL, NULL))
     {
-        StringOut("AdjustTokenPrivileges failed\n");
+        StringOut("[ROSAUTOTEST] AdjustTokenPrivileges failed\n");
         return false;
     }
 
     /* Finally shut down the system */
     if(!ExitWindowsEx(EWX_POWEROFF, SHTDN_REASON_MAJOR_OTHER | SHTDN_REASON_MINOR_OTHER | SHTDN_REASON_FLAG_PLANNED))
     {
-        StringOut("ExitWindowsEx failed\n");
+        StringOut("[ROSAUTOTEST] ExitWindowsEx failed\n");
         return false;
     }
 


### PR DESCRIPTION
## Purpose

Follow-up to #1531.

Cc @ColinFinck

## Proposed changes

- Output '[ROSAUTOTEST]' "everywhere", except test logs.
Tell me if I missed other ways to output.
- A few minor fixes.

## TODO

- [X] Create TestMan matching PR. // Done: web PR9.
(SysReg2 should be fine as is.)
- [ ] Try them together. (I can't do that.)
