### PR TITLE
[UMPNPMGR] Implement registry handler functions for wizard suppression

### DIFF
--- a/base/services/umpnpmgr/install.c
+++ b/base/services/umpnpmgr/install.c
@@ -340,6 +340,15 @@ cleanup:
 }
 
 
+FORCEINLINE
+BOOL
+IsUISuppressionAllowed(VOID)
+{
+    /* Display the newdev.dll wizard UI only if it's allowed */
+    return (g_IsUISuppressed || GetSuppressNewUIValue());
+}
+
+
 /* Loop to install all queued devices installations */
 DWORD
 WINAPI
@@ -368,7 +377,7 @@ DeviceInstallThread(LPVOID lpParameter)
         {
             ResetEvent(hNoPendingInstalls);
             Params = CONTAINING_RECORD(ListEntry, DeviceInstallParams, ListEntry);
-            InstallDevice(Params->DeviceIds, showWizard);
+            InstallDevice(Params->DeviceIds, showWizard && !IsUISuppressionAllowed());
             HeapFree(GetProcessHeap(), 0, Params);
         }
     }

--- a/base/services/umpnpmgr/precomp.h
+++ b/base/services/umpnpmgr/precomp.h
@@ -39,7 +39,6 @@ typedef struct
     WCHAR DeviceIds[1];
 } DeviceInstallParams;
 
-
 /* install.c */
 
 extern HANDLE hUserToken;
@@ -51,6 +50,10 @@ extern HANDLE hDeviceInstallListNotEmpty;
 
 BOOL
 SetupIsActive(VOID);
+
+FORCEINLINE
+BOOL
+IsUISuppressionAllowed(VOID);
 
 DWORD
 WINAPI
@@ -70,6 +73,9 @@ RpcServerThread(
 
 extern HKEY hEnumKey;
 extern HKEY hClassKey;
+extern BOOL g_IsUISuppressed;
 
+BOOL
+GetSuppressNewUIValue(VOID);
 
 #endif /* _UMPNPMGR_PCH_ */


### PR DESCRIPTION
## Purpose
Windows XP and Server 2003 use `SuppressUI` and `SuppressNewHWUI` registry values to allow or not the "New Hardware Wizard" dialog to be displayed of NEWDEV component.

Specifically, Windows XP 32-bit uses `SuppressNewHWUI` whereas Server 2003 and XP 64-bit use `SuppressUI` but for compatibility reasons we'll be going to implement registry functions to handle both of these values.
## JIRA
**JIRA Issue:** [CORE-15897](https://jira.reactos.org/browse/CORE-15897)