### PR TITLE
Fix Computer Name Change to update Hostname on reboot.

### DIFF
--- a/dll/win32/netid/netid.c
+++ b/dll/win32/netid/netid.c
@@ -232,7 +232,7 @@ NetworkPropDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
                                     SetFocus(GetDlgItem(hDlg, 1002));
                                     break;
                                 }
-                                else if (!SetComputerName(NewComputerName))
+                                else if (!SetComputerNameExW(ComputerNamePhysicalDnsHostname, NewComputerName))
                                 {
                                     TCHAR szMsgText[MAX_PATH];
 
@@ -308,7 +308,7 @@ NetIDPage_OnInitDialog(
         RegCloseKey(KeyHandle);
     }
 
-    if (GetComputerName(ComputerName,&Size))
+    if (GetComputerName(ComputerName, &Size))
     {
         SetDlgItemText(hwndDlg, IDC_COMPUTERNAME, ComputerName);
     }


### PR DESCRIPTION
## Purpose

Fixes updating Hostname in registry after Computer Name Change and reboot.

JIRA issue: [CORE-16123](https://jira.reactos.org/browse/CORE-16123)

## Proposed changes

Changes to netid.c correct the call when using the Computer Name change in ReactOS.
Changes to winlogon.c add the ability to copy from the "NV Hostname" to the "Hostname"

