### PR TITLE
[NTOS] Add pool debugging code

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2024,6 +2024,9 @@ ExAllocatePoolWithTag(
             Tag = ' GIB';
         }
         ExpInsertPoolTracker(Tag, ROUND_TO_PAGES(NumberOfBytes), OriginalType);
+#if DBG
+        RtlFillMemory(Allocation, NumberOfBytes, 0xCD);
+#endif
         return Allocation;
     }
 

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -22,6 +22,10 @@
 
 #define POOL_BIG_TABLE_ENTRY_FREE 0x1
 
+/* DEBUGGING ******************************************************************/
+
+//#define DBG_NUMBER_OF_FRAMES_TO_CAPTURE 5
+
 typedef struct _POOL_DPC_CONTEXT
 {
     PPOOL_TRACKER_TABLE PoolTrackTable;
@@ -1855,9 +1859,14 @@ ExReturnPoolQuota(IN PVOID P)
  */
 PVOID
 NTAPI
-ExAllocatePoolWithTag(IN POOL_TYPE PoolType,
-                      IN SIZE_T NumberOfBytes,
-                      IN ULONG Tag)
+#ifdef DBG_NUMBER_OF_FRAMES_TO_CAPTURE
+ExAllocatePoolWithTagInternal(
+#else
+ExAllocatePoolWithTag(
+#endif
+    _In_ POOL_TYPE PoolType,
+    _In_ SIZE_T NumberOfBytes,
+    _In_ ULONG Tag)
 {
     PPOOL_DESCRIPTOR PoolDesc;
     PLIST_ENTRY ListHead;
@@ -2424,6 +2433,33 @@ ExAllocatePoolWithTag(IN POOL_TYPE PoolType,
 
     return Allocation;
 }
+
+#ifdef DBG_NUMBER_OF_FRAMES_TO_CAPTURE
+PVOID
+NTAPI
+ExAllocatePoolWithTag(
+    _In_ POOL_TYPE PoolType,
+    _In_ SIZE_T NumberOfBytes,
+    _In_ ULONG Tag)
+{
+    SIZE_T FullSize;
+    PVOID Allocation, *DbgData;
+
+    /* Allocate a larger chunk to add the debug data */
+    FullSize = NumberOfBytes + (DBG_NUMBER_OF_FRAMES_TO_CAPTURE + 2) * sizeof(PVOID);
+    Allocation = ExAllocatePoolWithTagInternal(PoolType, FullSize, Tag);
+    if (Allocation == NULL)
+    {
+        return NULL;
+    }
+
+    /* Append the debug data, separated by a '####' */
+    DbgData = ALIGN_UP_POINTER_BY((PUCHAR)Allocation + NumberOfBytes, sizeof(PVOID));
+    DbgData[0] = (PVOID)(ULONG_PTR)'####';
+    RtlWalkFrameChain(&DbgData[1], DBG_NUMBER_OF_FRAMES_TO_CAPTURE, 0);
+    return Allocation;
+}
+#endif
 
 /*
  * @implemented

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -665,6 +665,9 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
         //
         // Return the allocation address to the caller
         //
+#if DBG
+        RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+#endif
         return BaseVa;
     }
 
@@ -674,7 +677,13 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     if ((SizeInPages == 1) && (ExQueryDepthSList(&MiNonPagedPoolSListHead)))
     {
         BaseVa = InterlockedPopEntrySList(&MiNonPagedPoolSListHead);
-        if (BaseVa) return BaseVa;
+        if (BaseVa)
+        {
+#if DBG
+            RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+#endif
+            return BaseVa;
+        }
     }
 
     //
@@ -802,6 +811,9 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
                 // Release the nonpaged pool lock, and return the allocation
                 //
                 KeReleaseQueuedSpinLock(LockQueueMmNonPagedPoolLock, OldIrql);
+#if DBG
+                RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+#endif
                 return BaseVa;
             }
 
@@ -897,7 +909,11 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     //
     // Return the address
     //
-    return MiPteToAddress(StartPte);
+    BaseVa = MiPteToAddress(StartPte);
+#if DBG
+            RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+#endif
+    return BaseVa;
 }
 
 ULONG

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -666,7 +666,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
         // Return the allocation address to the caller
         //
 #if DBG
-        RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+        RtlFillMemoryUlong(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xABABABAB);
 #endif
         return BaseVa;
     }
@@ -680,7 +680,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
         if (BaseVa)
         {
 #if DBG
-            RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+            RtlFillMemoryUlong(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xABABABAB);
 #endif
             return BaseVa;
         }
@@ -812,7 +812,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
                 //
                 KeReleaseQueuedSpinLock(LockQueueMmNonPagedPoolLock, OldIrql);
 #if DBG
-                RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+                RtlFillMemoryUlong(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xABABABAB);
 #endif
                 return BaseVa;
             }
@@ -911,7 +911,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
     //
     BaseVa = MiPteToAddress(StartPte);
 #if DBG
-            RtlFillMemory(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xCD);
+    RtlFillMemoryUlong(BaseVa, ROUND_TO_PAGES(SizeInBytes), 0xABABABAB);
 #endif
     return BaseVa;
 }


### PR DESCRIPTION
This PR adds code for pool debugging and fixes a use after free case that it triggers.

Looks good on VBox: https://reactos.org/testman/compare.php?ids=68839,68840,68841
Has issues on KVM: https://build.reactos.org/#/builders/6/builds/24033/steps/1/logs/stdio

Update: new runs
KVM: https://reactos.org/testman/compare.php?ids=68947,68949,68952,68953
VBox: https://build.reactos.org/#/builders/3/builds/11684 (Testman is a bitch and has eaten it)

Any help looking into these issues is highly appreceated, since these are most likely all nasty bugs that were hidden so far and should really be fixed.
