### PR TITLE
[CDROM] Replace obsolete POOL_TAGGING uses. CORE-13134

### DIFF
--- a/drivers/storage/class/cdrom/cdrom.c
+++ b/drivers/storage/class/cdrom/cdrom.c
@@ -656,7 +656,8 @@ Return Value:
         }
     }
 
-    ExFreePool(buffer);
+    // Allocated by ScsiClassGetInquiryData(), without a tag.
+    ExFreePoolWithTag(buffer, 'enoN');
 
 
     return foundDevice;
@@ -1167,14 +1168,12 @@ Return Value:
 
                         cddata->MediaChangeSupported = TRUE;
                         cddata->MediaChange = TRUE;
-
                     } else {
-
                         if (McSrb) {
-                            ExFreePool(McSrb);
+                            ExFreePoolWithTag(McSrb, CDROM_ALLOC_TAG);
                         }
                         else if (McSrbBuffer) {
-                            ExFreePool(McSrbBuffer);
+                            ExFreePoolWithTag(McSrbBuffer, CDROM_ALLOC_TAG);
                         }
                         IoFreeIrp(irp);
                     }
@@ -1323,7 +1322,7 @@ Return Value:
         cddata->u1.Header.ModeDataLength = 0;
     }
 
-    ExFreePool(buffer);
+    ExFreePoolWithTag(buffer, CDROM_ALLOC_TAG);
 
     //
     // Start the timer now regardless of if Autorun is enabled.
@@ -1347,11 +1346,11 @@ CreateCdRomDeviceObjectExit:
                          NULL);
 
     if (senseData != NULL) {
-        ExFreePool(senseData);
+        ExFreePoolWithTag(senseData, CDROM_ALLOC_TAG);
     }
 
     if (deviceExtension->DiskGeometry != NULL) {
-        ExFreePool(deviceExtension->DiskGeometry);
+        ExFreePoolWithTag(deviceExtension->DiskGeometry, CDROM_ALLOC_TAG);
     }
 
     if (deviceObject != NULL) {
@@ -1504,7 +1503,7 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(srb);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -1573,8 +1572,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -1591,9 +1590,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -1744,7 +1743,7 @@ ScsiCdRomStartIo(
             Irp->IoStatus.Information = 0;
             Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
             IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-            ExFreePool(srb);
+            ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
             IoFreeIrp(irp2);
             IoStartNextPacket(DeviceObject, FALSE);
             DebugPrint((2, "ScsiCdRomStartIo: [%lx] bailing with status %lx at line %s\n", Irp, Irp->IoStatus.Status, __LINE__));
@@ -1872,8 +1871,8 @@ ScsiCdRomStartIo(
                         Irp->IoStatus.Information = 0;
                         Irp->IoStatus.Status = STATUS_INVALID_PARAMETER;
                         IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                        ExFreePool(senseBuffer);
-                        ExFreePool(srb);
+                        ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                         IoStartNextPacket(DeviceObject, FALSE);
                         return;
 
@@ -1973,8 +1972,8 @@ ScsiCdRomStartIo(
                         Irp->IoStatus.Information = 0;
                         Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                         IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                        ExFreePool(senseBuffer);
-                        ExFreePool(srb);
+                        ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                         IoFreeIrp(irp2);
                         IoStartNextPacket(DeviceObject, FALSE);
                         return;
@@ -1991,9 +1990,9 @@ ScsiCdRomStartIo(
                         Irp->IoStatus.Information = 0;
                         Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                         IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                        ExFreePool(senseBuffer);
-                        ExFreePool(srb);
-                        ExFreePool(dataBuffer);
+                        ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                         IoFreeIrp(irp2);
                         IoStartNextPacket(DeviceObject, FALSE);
                         return;
@@ -2149,8 +2148,8 @@ ScsiCdRomStartIo(
                     Irp->IoStatus.Information = 0;
                     Irp->IoStatus.Status = STATUS_INVALID_PARAMETER;
                     IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                    ExFreePool(senseBuffer);
-                    ExFreePool(srb);
+                    ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                    ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                     IoStartNextPacket(DeviceObject, FALSE);
                     DebugPrint((2, "ScsiCdRomStartIo: [%lx] bailing with status %lx at line %s\n", Irp, Irp->IoStatus.Status, __LINE__));
                     return;
@@ -2223,8 +2222,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 DebugPrint((2, "ScsiCdRomStartIo: [%lx] bailing with status %lx at line %s\n", Irp, Irp->IoStatus.Status, __LINE__));
@@ -2242,9 +2241,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 DebugPrint((2, "ScsiCdRomStartIo: [%lx] bailing with status %lx at line %s\n", Irp, Irp->IoStatus.Status, __LINE__));
@@ -2349,8 +2348,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2367,9 +2366,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2433,8 +2432,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2451,9 +2450,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2589,7 +2588,6 @@ ScsiCdRomStartIo(
 
             srb->CdbLength = 6;
             srb->TimeOutValue = deviceExtension->TimeOutValue;
-
             srb->SrbFlags = deviceExtension->SrbFlags;
             srb->SrbFlags |= (SRB_FLAGS_DISABLE_SYNCH_TRANSFER | SRB_FLAGS_NO_DATA_TRANSFER);
 
@@ -2609,8 +2607,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2627,9 +2625,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2697,8 +2695,8 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2714,9 +2712,9 @@ ScsiCdRomStartIo(
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
                 IoCompleteRequest(Irp, IO_DISK_INCREMENT);
-                ExFreePool(senseBuffer);
-                ExFreePool(srb);
-                ExFreePool(dataBuffer);
+                ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
+                ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp2);
                 IoStartNextPacket(DeviceObject, FALSE);
                 return;
@@ -2783,8 +2781,8 @@ ScsiCdRomStartIo(
             //
 
             IoCompleteRequest(Irp, IO_NO_INCREMENT);
-            ExFreePool(senseBuffer);
-            ExFreePool(srb);
+            ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+            ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
             IoFreeIrp(irp2);
             return;
 
@@ -5091,7 +5089,7 @@ RetryControl:
                 FALSE,
                 NULL);
 
-            ExFreePool(deviceControlEvent);
+            ExFreePoolWithTag(deviceControlEvent, CDROM_ALLOC_TAG);
 
             DebugPrint((2, "CdRomDeviceControl: irp %#08lx synchronized\n", Irp));
 
@@ -5306,7 +5304,7 @@ Return Value:
 
         deviceExtension->ClassError = ToshibaProcessError;
 
-        ExFreePool(buffer);
+        ExFreePoolWithTag(buffer, CDROM_ALLOC_TAG);
 
     }
 
@@ -5673,7 +5671,7 @@ Return Value:
 
         if (!irp->MdlAddress) {
             ExFreePool(srb);
-            ExFreePool(dataBuffer);
+            ExFreePoolWithTag(dataBuffer, CDROM_ALLOC_TAG);
             IoFreeIrp(irp);
             return;
         }
@@ -5828,7 +5826,7 @@ Return Value:
                                         &ioStatus);
 
     if (irp == NULL) {
-        ExFreePool(currentBuffer);
+        ExFreePoolWithTag(currentBuffer, CDROM_ALLOC_TAG);
         return FALSE;
     }
 
@@ -5844,11 +5842,11 @@ Return Value:
     }
 
     if (!NT_SUCCESS(status)) {
-        ExFreePool(currentBuffer);
+        ExFreePoolWithTag(currentBuffer, CDROM_ALLOC_TAG);
         return FALSE;
     }
 
-    ExFreePool(currentBuffer);
+    ExFreePoolWithTag(currentBuffer, CDROM_ALLOC_TAG);
 
     return(PLAY_ACTIVE(deviceExtension));
 
@@ -6380,7 +6378,7 @@ Return Value:
 
     if(!NT_SUCCESS(status)) {
         DebugPrint((1,"CdRomCheckRegAP: couldn't convert paramNum to paramSuffix\n"));
-        ExFreePool(paramPath.Buffer);
+        ExFreePoolWithTag(paramPath.Buffer, CDROM_ALLOC_TAG);
         return FALSE;
     }
 
@@ -6398,7 +6396,7 @@ Return Value:
                                                 CDROM_ALLOC_TAG);
     if(!paramDevPath.Buffer) {
         RtlFreeUnicodeString(&paramSuffix);
-        ExFreePool(paramPath.Buffer);
+        ExFreePoolWithTag(paramPath.Buffer, CDROM_ALLOC_TAG);
         return FALSE;
     }
 
@@ -6474,12 +6472,12 @@ Return Value:
 
         DebugPrint((1, "CdRomCheckRegAP: cdrom/parameters/device%d/autorun flag = %d\n", DeviceNumber, doRun));
 
-        ExFreePool(parameters);
+        ExFreePoolWithTag(parameters, CDROM_ALLOC_TAG);
 
     }
 
-    ExFreePool(paramPath.Buffer);
-    ExFreePool(paramDevPath.Buffer);
+    ExFreePoolWithTag(paramPath.Buffer, CDROM_ALLOC_TAG);
+    ExFreePoolWithTag(paramDevPath.Buffer, CDROM_ALLOC_TAG);
     RtlFreeUnicodeString(&paramSuffix);
 
     DebugPrint((1, "CdRomCheckRegAP: Autoplay for device %d is %s\n",
@@ -6579,7 +6577,7 @@ Return Value:
                 inquiryData = (PVOID) lunInfo->InquiryData;
 
                 if (RtlCompareMemory(inquiryData->VendorId, "TORiSAN CD-ROM CDR-C", 20) == 20) {
-                    ExFreePool(inquiryBuffer);
+                    ExFreePoolWithTag(inquiryBuffer, CDROM_ALLOC_TAG);
                     return TRUE;
                 }
 
@@ -6595,7 +6593,7 @@ Return Value:
     }
 
 ExitIsThisASanyo:
-    ExFreePool(inquiryBuffer);
+    ExFreePoolWithTag(inquiryBuffer, CDROM_ALLOC_TAG);
     return FALSE;
 }
 
@@ -6702,7 +6700,7 @@ Return Value:
             retVal = FALSE;
         }
 
-        ExFreePool(mechanicalStatusBuffer);
+        ExFreePoolWithTag(mechanicalStatusBuffer, CDROM_ALLOC_TAG);
     }
 
     return retVal;
@@ -6778,7 +6776,8 @@ Return Value:
                 //
 
                 if (lunCount++) {
-                    ExFreePool(buffer);
+                    // Allocated by ScsiClassGetInquiryData(), without a tag.
+                    ExFreePoolWithTag(buffer, 'enoN');
                     return TRUE;
                 }
             }
@@ -6795,7 +6794,8 @@ Return Value:
         }
     }
 
-    ExFreePool(buffer);
+    // Allocated by ScsiClassGetInquiryData(), without a tag.
+    ExFreePoolWithTag(buffer, 'enoN');
     return FALSE;
 
 }
@@ -7205,18 +7205,18 @@ Return Value:
                         return STATUS_PENDING;
 
                     } else {
-                        ExFreePool(senseBuffer);
-                        ExFreePool(capacityBuffer);
-                        ExFreePool(srb);
+                        ExFreePoolWithTag(senseBuffer, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(capacityBuffer, CDROM_ALLOC_TAG);
+                        ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                         IoFreeIrp(irp);
                     }
                 } else {
-                    ExFreePool(capacityBuffer);
-                    ExFreePool(srb);
+                    ExFreePoolWithTag(capacityBuffer, CDROM_ALLOC_TAG);
+                    ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                     IoFreeIrp(irp);
                 }
             } else {
-                ExFreePool(srb);
+                ExFreePoolWithTag(srb, CDROM_ALLOC_TAG);
                 IoFreeIrp(irp);
             }
         } else {

--- a/drivers/storage/class/cdrom/cdrom.c
+++ b/drivers/storage/class/cdrom/cdrom.c
@@ -224,13 +224,7 @@ typedef struct _CDROM_DATA {
 #define FORM2_MODE1_SECTOR        4
 #define FORM2_MODE2_SECTOR        5
 
-
-#ifdef POOL_TAGGING
-#ifdef ExAllocatePool
-#undef ExAllocatePool
-#endif
-#define ExAllocatePool(a,b) ExAllocatePoolWithTag(a,b,'CscS')
-#endif
+#define CDROM_ALLOC_TAG 'CscS'
 
 NTSTATUS
 NTAPI
@@ -889,8 +883,9 @@ Return Value:
     // Allocate request sense buffer.
     //
 
-    senseData = ExAllocatePool(NonPagedPoolCacheAligned, SENSE_BUFFER_SIZE);
-
+    senseData = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                      SENSE_BUFFER_SIZE,
+                                      CDROM_ALLOC_TAG);
     if (senseData == NULL) {
 
         //
@@ -956,8 +951,9 @@ Return Value:
     //
 
     deviceExtension->DiskGeometry =
-        ExAllocatePool(NonPagedPool, sizeof(DISK_GEOMETRY_EX));
-
+      ExAllocatePoolWithTag(NonPagedPool,
+                            sizeof(DISK_GEOMETRY_EX),
+                            CDROM_ALLOC_TAG);
     if (deviceExtension->DiskGeometry == NULL) {
 
         status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1113,9 +1109,12 @@ Return Value:
                 if (irp) {
                     PVOID buffer;
 
-                    srb = ExAllocatePool(NonPagedPool, sizeof(SCSI_REQUEST_BLOCK));
-                    buffer = ExAllocatePool(NonPagedPoolCacheAligned, SENSE_BUFFER_SIZE);
-
+                    srb = ExAllocatePoolWithTag(NonPagedPool,
+                                                sizeof(SCSI_REQUEST_BLOCK),
+                                                CDROM_ALLOC_TAG);
+                    buffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                                   SENSE_BUFFER_SIZE,
+                                                   CDROM_ALLOC_TAG);
                     if (srb && buffer) {
                         PCDB cdb;
 
@@ -1221,7 +1220,10 @@ Return Value:
     cdb->MODE_SENSE.PageCode = 0x1;
     cdb->MODE_SENSE.AllocationLength = (UCHAR)length;
 
-    buffer = ExAllocatePool(NonPagedPoolCacheAligned, (sizeof(MODE_READ_RECOVERY_PAGE) + MODE_BLOCK_DESC_LENGTH + MODE_HEADER_LENGTH10));
+    buffer = ExAllocatePoolWithTag(
+      NonPagedPoolCacheAligned,
+      sizeof(MODE_READ_RECOVERY_PAGE) + MODE_BLOCK_DESC_LENGTH + MODE_HEADER_LENGTH10,
+      CDROM_ALLOC_TAG);
     if (!buffer) {
         status = STATUS_INSUFFICIENT_RESOURCES;
         goto CreateCdRomDeviceObjectExit;
@@ -1475,7 +1477,9 @@ ScsiCdRomStartIo(
                 return;
             }
 
-            srb = ExAllocatePool(NonPagedPool, sizeof(SCSI_REQUEST_BLOCK));
+            srb = ExAllocatePoolWithTag(NonPagedPool,
+                                        sizeof(SCSI_REQUEST_BLOCK),
+                                        CDROM_ALLOC_TAG);
             if (!srb) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1493,8 +1497,9 @@ ScsiCdRomStartIo(
             // Allocate sense buffer.
             //
 
-            senseBuffer = ExAllocatePool(NonPagedPoolCacheAligned, SENSE_BUFFER_SIZE);
-
+            senseBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                                SENSE_BUFFER_SIZE,
+                                                CDROM_ALLOC_TAG);
             if (!senseBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1561,7 +1566,9 @@ ScsiCdRomStartIo(
             srb->SenseInfoBuffer = senseBuffer;
 
             transferByteCount = (use6Byte) ? sizeof(ERROR_RECOVERY_DATA) : sizeof(ERROR_RECOVERY_DATA10);
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, transferByteCount );
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               transferByteCount,
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1709,7 +1716,9 @@ ScsiCdRomStartIo(
             return;
         }
 
-        srb = ExAllocatePool(NonPagedPool, sizeof(SCSI_REQUEST_BLOCK));
+        srb = ExAllocatePoolWithTag(NonPagedPool,
+                                    sizeof(SCSI_REQUEST_BLOCK),
+                                    CDROM_ALLOC_TAG);
         if (!srb) {
             Irp->IoStatus.Information = 0;
             Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1728,8 +1737,9 @@ ScsiCdRomStartIo(
         // Allocate sense buffer.
         //
 
-        senseBuffer = ExAllocatePool(NonPagedPoolCacheAligned, SENSE_BUFFER_SIZE);
-
+        senseBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                            SENSE_BUFFER_SIZE,
+                                            CDROM_ALLOC_TAG);
         if (!senseBuffer) {
             Irp->IoStatus.Information = 0;
             Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -1956,7 +1966,9 @@ ScsiCdRomStartIo(
                 } else {
 
                     transferByteCount = (use6Byte) ? sizeof(ERROR_RECOVERY_DATA) : sizeof(ERROR_RECOVERY_DATA10);
-                    dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, transferByteCount );
+                    dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                                       transferByteCount,
+                                                       CDROM_ALLOC_TAG);
                     if (!dataBuffer) {
                         Irp->IoStatus.Information = 0;
                         Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -2204,7 +2216,9 @@ ScsiCdRomStartIo(
             srb->CdbLength = 10;
             srb->TimeOutValue = deviceExtension->TimeOutValue;
 
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, sizeof(READ_CAPACITY_DATA));
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               sizeof(READ_CAPACITY_DATA),
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -2328,7 +2342,9 @@ ScsiCdRomStartIo(
             srb->CdbLength = 10;
             srb->TimeOutValue = deviceExtension->TimeOutValue;
 
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, transferByteCount);
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               transferByteCount,
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -2410,9 +2426,9 @@ ScsiCdRomStartIo(
             // Allocate buffer for subq channel information.
             //
 
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned,
-                                     sizeof(SUB_Q_CHANNEL_DATA));
-
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               sizeof(SUB_Q_CHANNEL_DATA),
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -2586,9 +2602,9 @@ ScsiCdRomStartIo(
             // Allocate buffer for volume control information.
             //
 
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned,
-                                         MODE_DATA_SIZE);
-
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               MODE_DATA_SIZE,
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -2674,9 +2690,9 @@ ScsiCdRomStartIo(
         case IOCTL_CDROM_GET_VOLUME:
         case IOCTL_CDROM_SET_VOLUME: {
 
-            dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned,
-                                         MODE_DATA_SIZE);
-
+            dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                               MODE_DATA_SIZE,
+                                               CDROM_ALLOC_TAG);
             if (!dataBuffer) {
                 Irp->IoStatus.Information = 0;
                 Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -3863,8 +3879,9 @@ CdRomSetVolumeIntermediateCompletion(
         // Allocate a new buffer for the mode select.
         //
 
-        dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, bytesTransferred);
-
+        dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                           bytesTransferred,
+                                           CDROM_ALLOC_TAG);
         if (!dataBuffer) {
             realIrp->IoStatus.Information = 0;
             realIrp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
@@ -5013,8 +5030,9 @@ RetryControl:
         // allocate an event and stuff it into our stack location.
         //
 
-        deviceControlEvent = ExAllocatePool(NonPagedPool, sizeof(KEVENT));
-
+        deviceControlEvent = ExAllocatePoolWithTag(NonPagedPool,
+                                                   sizeof(KEVENT),
+                                                   CDROM_ALLOC_TAG);
         if(!deviceControlEvent) {
 
             status = STATUS_INSUFFICIENT_RESOURCES;
@@ -5236,7 +5254,10 @@ Return Value:
         cdb->MODE_SENSE.PageCode = 0x1;
         cdb->MODE_SENSE.AllocationLength = (UCHAR)length;
 
-        buffer = ExAllocatePool(NonPagedPoolCacheAligned, (sizeof(MODE_READ_RECOVERY_PAGE) + MODE_BLOCK_DESC_LENGTH + MODE_HEADER_LENGTH));
+        buffer = ExAllocatePoolWithTag(
+          NonPagedPoolCacheAligned,
+          sizeof(MODE_READ_RECOVERY_PAGE) + MODE_BLOCK_DESC_LENGTH + MODE_HEADER_LENGTH,
+          CDROM_ALLOC_TAG);
         if (!buffer) {
             return;
         }
@@ -5385,11 +5406,10 @@ Return Value:
         alignment = DeviceObject->AlignmentRequirement ?
             DeviceObject->AlignmentRequirement : 1;
 
-        context = ExAllocatePool(
-            NonPagedPool,
-            sizeof(COMPLETION_CONTEXT) +  HITACHI_MODE_DATA_SIZE + alignment
-            );
-
+        context = ExAllocatePoolWithTag(
+          NonPagedPool,
+          sizeof(COMPLETION_CONTEXT) +  HITACHI_MODE_DATA_SIZE + alignment,
+          CDROM_ALLOC_TAG);
         if (context == NULL) {
 
             //
@@ -5626,7 +5646,9 @@ Return Value:
             return;
         }
 
-        srb = ExAllocatePool(NonPagedPool, sizeof(SCSI_REQUEST_BLOCK));
+        srb = ExAllocatePoolWithTag(NonPagedPool,
+                                    sizeof(SCSI_REQUEST_BLOCK),
+                                    CDROM_ALLOC_TAG);
         if (!srb) {
             IoFreeIrp(irp);
             return;
@@ -5634,7 +5656,9 @@ Return Value:
 
 
         length = sizeof(ERROR_RECOVERY_DATA);
-        dataBuffer = ExAllocatePool(NonPagedPoolCacheAligned, length);
+        dataBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                           length,
+                                           CDROM_ALLOC_TAG);
         if (!dataBuffer) {
             ExFreePool(srb);
             IoFreeIrp(irp);
@@ -5771,8 +5795,9 @@ Return Value:
         return(FALSE);
     }
 
-    currentBuffer = ExAllocatePool(NonPagedPoolCacheAligned, sizeof(SUB_Q_CURRENT_POSITION));
-
+    currentBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                          sizeof(SUB_Q_CURRENT_POSITION),
+                                          CDROM_ALLOC_TAG);
     if (currentBuffer == NULL) {
         return(FALSE);
     }
@@ -6321,8 +6346,9 @@ Return Value:
                               paramStr.Length +
                               sizeof(WCHAR);
 
-    paramPath.Buffer = ExAllocatePool(PagedPool, paramPath.MaximumLength);
-
+    paramPath.Buffer = ExAllocatePoolWithTag(PagedPool,
+                                             paramPath.MaximumLength,
+                                             CDROM_ALLOC_TAG);
     if(!paramPath.Buffer) {
 
         DebugPrint((1,"CdRomCheckRegAP: couldn't allocate paramPath\n"));
@@ -6367,8 +6393,9 @@ Return Value:
     paramDevPath.MaximumLength = paramPath.Length +
                                  paramSuffix.Length +
                                  sizeof(WCHAR);
-    paramDevPath.Buffer = ExAllocatePool(PagedPool, paramDevPath.MaximumLength);
-
+    paramDevPath.Buffer = ExAllocatePoolWithTag(PagedPool,
+                                                paramDevPath.MaximumLength,
+                                                CDROM_ALLOC_TAG);
     if(!paramDevPath.Buffer) {
         RtlFreeUnicodeString(&paramSuffix);
         ExFreePool(paramPath.Buffer);
@@ -6383,9 +6410,10 @@ Return Value:
                 paramPath.Length,
                 paramPath.Buffer));
 
-    parameters = ExAllocatePool(NonPagedPool,
-                                sizeof(RTL_QUERY_REGISTRY_TABLE)*ITEMS_TO_QUERY);
-
+    parameters = ExAllocatePoolWithTag(
+      NonPagedPool,
+      sizeof(RTL_QUERY_REGISTRY_TABLE) * ITEMS_TO_QUERY,
+      CDROM_ALLOC_TAG);
     if (parameters) {
 
         //
@@ -6504,7 +6532,7 @@ Return Value:
     PINQUIRYDATA           inquiryData;
     PSCSI_INQUIRY_DATA     lunInfo;
 
-    inquiryBuffer = ExAllocatePool(NonPagedPool, 2048);
+    inquiryBuffer = ExAllocatePoolWithTag(NonPagedPool, 2048, CDROM_ALLOC_TAG);
     KeInitializeEvent(&event, NotificationEvent, FALSE);
     irp = IoBuildDeviceIoControlRequest(IOCTL_SCSI_GET_INQUIRY_DATA,
                                         DeviceObject,
@@ -6617,9 +6645,10 @@ Return Value:
     // Build and issue the mechanical status command.
     //
 
-    mechanicalStatusBuffer = ExAllocatePool(NonPagedPoolCacheAligned,
-                                            sizeof(MECHANICAL_STATUS_INFORMATION_HEADER));
-
+    mechanicalStatusBuffer = ExAllocatePoolWithTag(
+      NonPagedPoolCacheAligned,
+      sizeof(MECHANICAL_STATUS_INFORMATION_HEADER),
+      CDROM_ALLOC_TAG);
     if (!mechanicalStatusBuffer) {
         retVal = FALSE;
     } else {
@@ -7061,16 +7090,19 @@ Return Value:
 
     if (irp) {
 
-        srb = ExAllocatePool(NonPagedPool, sizeof(SCSI_REQUEST_BLOCK));
+        srb = ExAllocatePoolWithTag(NonPagedPool,
+                                    sizeof(SCSI_REQUEST_BLOCK),
+                                    CDROM_ALLOC_TAG);
         if (srb) {
-            capacityBuffer = ExAllocatePool(NonPagedPoolCacheAligned,
-                                            sizeof(READ_CAPACITY_DATA));
 
+           capacityBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                                  sizeof(READ_CAPACITY_DATA),
+                                                  CDROM_ALLOC_TAG);
             if (capacityBuffer) {
 
-
-                senseBuffer = ExAllocatePool(NonPagedPoolCacheAligned, SENSE_BUFFER_SIZE);
-
+                senseBuffer = ExAllocatePoolWithTag(NonPagedPoolCacheAligned,
+                                                    SENSE_BUFFER_SIZE,
+                                                    CDROM_ALLOC_TAG);
                 if (senseBuffer) {
 
                     irp->MdlAddress = IoAllocateMdl(capacityBuffer,


### PR DESCRIPTION
## Purpose

Pool tagging is permanently enabled on NT5.2+.

JIRA issue: [CORE-13134](https://jira.reactos.org/browse/CORE-13134)

## Proposed changes

- "Always" use `ExAllocatePoolWithTag()` and  `ExFreePoolWithTag()`.

## TODO

- [ ] I left alone some `ExFreePool()`, when `srb = Context` parameter.
Is there a tag to use in these cases, or can it vary?
- [ ] Test it on checked WS03+. (I can't do that.)
