### PR TITLE
[NETSTAT] ShowUdpTable(): Fix "tcp" copypasta

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -508,7 +508,7 @@ BOOL ShowUdpTable(VOID)
 
         /* I've split this up so it's easier to follow */
         GetIpHostName(TRUE, udpTable->table[i].dwLocalAddr, HostIp, sizeof(HostIp));
-        GetPortName(udpTable->table[i].dwLocalPort, "tcp", HostPort, sizeof(HostPort));
+        GetPortName(udpTable->table[i].dwLocalPort, "udp", HostPort, sizeof(HostPort));
 
         sprintf(Host, "%s:%s", HostIp, HostPort);
 


### PR DESCRIPTION
On WXP,
`netstat -a -p UDP`

Before:
```
  UDP    xyz:500        *:*
  UDP    xyz:123        *:*
  UDP    nnn:123       *:*
  UDP    nnn:138       *:*
```

After:
```
  UDP    xyz:isakmp     *:*
  UDP    xyz:ntp        *:*
  UDP    nnn:ntp       *:*
  UDP    nnn:netbios-dgm *:*
```
