### PR TITLE
[NETSTAT] '-p UDP' depends on '-a'

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -212,7 +212,7 @@ BOOL DisplayOutput(VOID)
                     ShowUdpStatistics();
                 ConResPuts(StdOut, IDS_ACTIVE_CONNECT);
                 DisplayTableHeader();
-                return ShowUdpTable();
+                return (bDoShowAllCons ? ShowUdpTable() : TRUE);
             default:
                 break;
         }


### PR DESCRIPTION
On WXP,
`netstat -p UDP`

WXP netstat:
```
Active Connections

  Proto  Local Address          Foreign Address        State
```

ROS netstat (before):
```
Active Connections

  Proto  Local Address          Foreign Address        State
  UDP    xyz:500        *:*
  UDP    xyz:123        *:*
  UDP    nnn:123       *:*
  UDP    nnn:138       *:*
```
