### PR TITLE
[ACPICA] Fix MSVC x64 build

### DIFF
--- a/drivers/bus/acpi/acpica/include/platform/acmsvc.h
+++ b/drivers/bus/acpi/acpica/include/platform/acmsvc.h
@@ -149,7 +149,7 @@
 #endif
 
 #ifdef __REACTOS__
-
+#ifdef _M_IX86
 /* Flush CPU cache - used when going to sleep. Wbinvd or similar. */
 
 #ifdef ACPI_APPLICATION
@@ -208,7 +208,7 @@
         __asm exit_rel:                             \
         __asm mov           Pnd, al                 \
 }
-
+#endif /* _M_IX86 */
 #endif /* __REACTOS__ */
 
 /* warn C4100: unreferenced formal parameter */

--- a/drivers/bus/acpi/acpica/namespace/nsnames.c
+++ b/drivers/bus/acpi/acpica/namespace/nsnames.c
@@ -434,7 +434,7 @@ AcpiNsBuildPrefixedPathname (
     char                    *FullPath = NULL;
     char                    *ExternalPath = NULL;
     char                    *PrefixPath = NULL;
-    UINT32                  PrefixPathLength = 0;
+    SIZE_T                  PrefixPathLength = 0;
 
 
     /* If there is a prefix, get the pathname to it */


### PR DESCRIPTION
This adds missing x64 locking code to ACPICA. Instead of replicating the x86 assembly, the code is written in C.
https://jira.reactos.org/browse/CORE-16082
