### PR TITLE
[W32Time] Use a reasonable fallback of 9 hours

### DIFF
--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -129,16 +129,18 @@ GetIntervalSetting(VOID)
     LONG lRet;
 
     dwData = 0;
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                      L"SYSTEM\\CurrentControlSet\\Services\\W32Time\\TimeProviders\\NtpClient",
-                      0,
-                      KEY_QUERY_VALUE,
-                      &hKey) == ERROR_SUCCESS)
+    lRet = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                         L"SYSTEM\\CurrentControlSet\\Services\\W32Time\\TimeProviders\\NtpClient",
+                         0,
+                         KEY_QUERY_VALUE,
+                         &hKey);
+    if (lRet == ERROR_SUCCESS)
     {
-        /* This key holds the update interval in seconds
-         * It is useful for testing to set it to a value of 10 (Decimal)
-         * This will cause the clock to try and update every 10 seconds
-         * So you can change the time and expect it to be set back correctly in 10-20 seconds
+        /*
+         * This key holds the update interval in seconds.
+         * It is useful for testing to set it to a value of 10 (Decimal).
+         * This will cause the clock to try and update every 10 seconds.
+         * So you can change the time and expect it to be set back correctly in 10-20 seconds.
          */
         lRet = RegQueryValueExW(hKey,
                                 L"SpecialPollInterval",
@@ -149,8 +151,8 @@ GetIntervalSetting(VOID)
         RegCloseKey(hKey);
     }
 
-    if (lRet != ERROR_SUCCESS)
-        return 0;
+    if (lRet != ERROR_SUCCESS || dwData < 120)
+        return 9 * 60 * 60; // 9 hours, because Windows uses 9 hrs, 6 mins and 8 seconds by default.
     else
         return dwData;
 }


### PR DESCRIPTION
## Purpose

Use `32400` as a fallback setting for `GetIntervalSetting`, which is equal to 9 hour rather than `0` which prevents spamming the time servers if the registry entry becomes corrupted or missing.
Also, disallow a setting of less than 2 minutes and instead use the fallback of 9 hour. 
JIRA issue: [CORE-16181](https://jira.reactos.org/browse/CORE-16181)
