### PR TITLE
[OSK] Implement "Always on Top" feature

### DIFF
--- a/base/applications/osk/lang/ar-DZ.rc
+++ b/base/applications/osk/lang/ar-DZ.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/cs-CZ.rc
+++ b/base/applications/osk/lang/cs-CZ.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/de-DE.rc
+++ b/base/applications/osk/lang/de-DE.rc
@@ -269,7 +269,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/en-GB.rc
+++ b/base/applications/osk/lang/en-GB.rc
@@ -269,7 +269,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/en-US.rc
+++ b/base/applications/osk/lang/en-US.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/es-ES.rc
+++ b/base/applications/osk/lang/es-ES.rc
@@ -270,7 +270,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/et-EE.rc
+++ b/base/applications/osk/lang/et-EE.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/fr-CA.rc
+++ b/base/applications/osk/lang/fr-CA.rc
@@ -269,7 +269,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/fr-FR.rc
+++ b/base/applications/osk/lang/fr-FR.rc
@@ -269,7 +269,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/he-IL.rc
+++ b/base/applications/osk/lang/he-IL.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/id-ID.rc
+++ b/base/applications/osk/lang/id-ID.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "&Pengaturan"
     BEGIN
-        MENUITEM "&Selalu di Atas", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "&Selalu di Atas", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Gunakan Suara", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/it-IT.rc
+++ b/base/applications/osk/lang/it-IT.rc
@@ -270,7 +270,7 @@ BEGIN
 
     POPUP "Impostazioni"
     BEGIN
-        MENUITEM "Sempre in primo piano", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Sempre in primo piano", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Usa suono al click", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/pl-PL.rc
+++ b/base/applications/osk/lang/pl-PL.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Ust&awienia"
     BEGIN
-        MENUITEM "&Zawsze na wierzchu", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "&Zawsze na wierzchu", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Użyj dźwięku kliknięcia", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/ro-RO.rc
+++ b/base/applications/osk/lang/ro-RO.rc
@@ -269,7 +269,7 @@ BEGIN
 
     POPUP "Setări"
     BEGIN
-        MENUITEM "Întotdeauna în sus", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Întotdeauna în sus", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Folosește sunetul de clic", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/ru-RU.rc
+++ b/base/applications/osk/lang/ru-RU.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/tr-TR.rc
+++ b/base/applications/osk/lang/tr-TR.rc
@@ -268,7 +268,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/zh-CN.rc
+++ b/base/applications/osk/lang/zh-CN.rc
@@ -271,7 +271,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/lang/zh-TW.rc
+++ b/base/applications/osk/lang/zh-TW.rc
@@ -270,7 +270,7 @@ BEGIN
 
     POPUP "Settings"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED, GRAYED
+        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
         MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
         MENUITEM SEPARATOR

--- a/base/applications/osk/main.c
+++ b/base/applications/osk/main.c
@@ -213,8 +213,20 @@ int OSK_DlgInitDialog(HWND hDlg)
         }
     }
 
-    /* Move the dialog according to the placement coordination */
-    SetWindowPos(hDlg, HWND_TOP, Globals.PosX, Globals.PosY, 0, 0, SWP_NOSIZE);
+    /*
+        Place the window (with respective placement coordinates) as topmost, above
+        every window which are not on top or are at the bottom of the Z order.
+    */
+    if (Globals.bAlwaysOnTop)
+    {
+        CheckMenuItem(GetMenu(hDlg), IDM_ON_TOP, MF_BYCOMMAND | MF_CHECKED);
+        SetWindowPos(hDlg, HWND_TOPMOST, Globals.PosX, Globals.PosY, 0, 0, SWP_NOSIZE);
+    }
+    else
+    {
+        CheckMenuItem(GetMenu(hDlg), IDM_ON_TOP, MF_BYCOMMAND | MF_UNCHECKED);
+        SetWindowPos(hDlg, HWND_NOTOPMOST, Globals.PosX, Globals.PosY, 0, 0, SWP_NOSIZE);
+    }
 
     /* Set icon on visual buttons */
     OSK_SetImage(SCAN_CODE_15, IDI_BACK);
@@ -632,6 +644,28 @@ INT_PTR APIENTRY OSK_DlgProc(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
                     {
                         Globals.bSoundClick = FALSE;
                         CheckMenuItem(GetMenu(hDlg), IDM_CLICK_SOUND, MF_BYCOMMAND | MF_UNCHECKED);
+                    }
+
+                    break;
+                }
+
+                case IDM_ON_TOP:
+                {
+                    /*
+                        Check the condition state before disabling/enabling the menu
+                        item and change the topmost order.
+                    */
+                    if (!Globals.bAlwaysOnTop)
+                    {
+                        Globals.bAlwaysOnTop = TRUE;
+                        CheckMenuItem(GetMenu(hDlg), IDM_ON_TOP, MF_BYCOMMAND | MF_CHECKED);
+                        SetWindowPos(hDlg, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
+                    }
+                    else
+                    {
+                        Globals.bAlwaysOnTop = FALSE;
+                        CheckMenuItem(GetMenu(hDlg), IDM_ON_TOP, MF_BYCOMMAND | MF_UNCHECKED);
+                        SetWindowPos(hDlg, HWND_NOTOPMOST, 0, 0, 0, 0, SWP_NOSIZE | SWP_NOMOVE);
                     }
 
                     break;

--- a/base/applications/osk/main.h
+++ b/base/applications/osk/main.h
@@ -26,6 +26,7 @@ typedef struct
     BOOL       bShowWarning;
     BOOL       bIsEnhancedKeyboard;
     BOOL       bSoundClick;
+    BOOL       bAlwaysOnTop;
     INT        PosX;
     INT        PosY;
 } OSK_GLOBALS;

--- a/base/applications/osk/settings.c
+++ b/base/applications/osk/settings.c
@@ -16,13 +16,14 @@ BOOL LoadDataFromRegistry()
 {
     HKEY hKey;
     LONG lResult;
-    DWORD dwShowWarningData, dwLayout, dwSoundOnClick, dwPositionLeft, dwPositionTop;
+    DWORD dwShowWarningData, dwLayout, dwSoundOnClick, dwPositionLeft, dwPositionTop, dwAlwaysOnTop;
     DWORD cbData = sizeof(DWORD);
 
-    /* Set the structure members to TRUE (and the bSoundClick member to FALSE) */
+    /* Initialize the registry application settings */
     Globals.bShowWarning = TRUE;
     Globals.bIsEnhancedKeyboard = TRUE;
     Globals.bSoundClick = FALSE;
+    Globals.bAlwaysOnTop = TRUE;
 
     /* Set the coordinate values to default */
     Globals.PosX = CW_USEDEFAULT;
@@ -129,6 +130,23 @@ BOOL LoadDataFromRegistry()
 
     /* Load the Y value data of the dialog's coordinate */
     Globals.PosY = dwPositionTop;
+
+    lResult = RegQueryValueExW(hKey,
+                               L"AlwaysOnTop",
+                               0,
+                               0,
+                               (BYTE *)&dwAlwaysOnTop,
+                               &cbData);
+
+    if (lResult != ERROR_SUCCESS)
+    {
+        /* Bail out and return FALSE if we fail */
+        RegCloseKey(hKey);
+        return FALSE;
+    }
+
+    /* Load the window state value data */
+    Globals.bAlwaysOnTop = (dwAlwaysOnTop != 0);
     
     /* If we're here then we succeed, close the key and return TRUE */
     RegCloseKey(hKey);
@@ -139,7 +157,7 @@ BOOL SaveDataToRegistry()
 {
     HKEY hKey;
     LONG lResult;
-    DWORD dwShowWarningData, dwLayout, dwSoundOnClick, dwPositionLeft, dwPositionTop;
+    DWORD dwShowWarningData, dwLayout, dwSoundOnClick, dwPositionLeft, dwPositionTop, dwAlwaysOnTop;
     WINDOWPLACEMENT wp;
 
     /* Set the structure length and retrieve the dialog's placement */
@@ -245,6 +263,24 @@ BOOL SaveDataToRegistry()
                              REG_DWORD,
                              (BYTE *)&dwPositionTop,
                              sizeof(dwPositionTop));
+
+    if (lResult != ERROR_SUCCESS)
+    {
+        /* Bail out and return FALSE if we fail */
+        RegCloseKey(hKey);
+        return FALSE;
+    }
+
+    /* Window top state value */
+    dwAlwaysOnTop = Globals.bAlwaysOnTop;
+
+    /* "Always on Top" state value key */
+    lResult = RegSetValueExW(hKey,
+                             L"AlwaysOnTop",
+                             0,
+                             REG_DWORD,
+                             (BYTE *)&dwAlwaysOnTop,
+                             sizeof(dwAlwaysOnTop));
 
     if (lResult != ERROR_SUCCESS)
     {


### PR DESCRIPTION
## Purpose
With this implementation, it allows On-Screen Keyboard to be placed at the topmost state in Z order remaining above the non-topmost windows.