### PR TITLE
[FREELDR] Fix memory initialization on Xbox

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/xboxmem.c
+++ b/boot/freeldr/freeldr/arch/i386/xboxmem.c
@@ -15,8 +15,8 @@
  *  with this program; if not, write to the Free Software Foundation, Inc.,
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  *
- * Note: much of this code was based on knowledge and/or code developed
- * by the Xbox Linux group: http://www.xbox-linux.org
+ *  Note: much of this code was based on knowledge and/or code developed
+ *  by the Xbox Linux group: http://www.xbox-linux.org
  */
 
 #include <freeldr.h>
@@ -25,53 +25,53 @@ static ULONG InstalledMemoryMb = 0;
 static ULONG AvailableMemoryMb = 0;
 
 #define TEST_SIZE     0x200
-#define TEST_PATTERN1 0xaa
+#define TEST_PATTERN1 0xAA
 #define TEST_PATTERN2 0x55
 
 VOID
 XboxMemInit(VOID)
 {
-  UCHAR ControlRegion[TEST_SIZE];
-  PVOID MembaseTop = (PVOID)(64 * 1024 * 1024);
-  PVOID MembaseLow = (PVOID)0;
+    UCHAR ControlRegion[TEST_SIZE];
+    PVOID MembaseTop = (PVOID)(64 * 1024 * 1024);
+    PVOID MembaseLow = (PVOID)0;
 
-  (*(PULONG)(0xfd000000 + 0x100200)) = 0x03070103 ;
-  (*(PULONG)(0xfd000000 + 0x100204)) = 0x11448000 ;
+    (*(PULONG)(0xfd000000 + 0x100200)) = 0x03070103;
+    (*(PULONG)(0xfd000000 + 0x100204)) = 0x11448000;
 
-  WRITE_PORT_ULONG((ULONG*) 0xcf8, CONFIG_CMD(0, 0, 0x84));
-  WRITE_PORT_ULONG((ULONG*) 0xcfc, 0x7ffffff);             /* Prep hardware for 128 Mb */
+    WRITE_PORT_ULONG((ULONG*) 0xcf8, CONFIG_CMD(0, 0, 0x84));
+    WRITE_PORT_ULONG((ULONG*) 0xcfc, 0x7ffffff);             /* Prep hardware for 128 Mb */
 
-  InstalledMemoryMb = 64;
-  memset(ControlRegion, TEST_PATTERN1, TEST_SIZE);
-  memset(MembaseTop, TEST_PATTERN1, TEST_SIZE);
-  __wbinvd();
+    InstalledMemoryMb = 64;
+    memset(ControlRegion, TEST_PATTERN1, TEST_SIZE);
+    memset(MembaseTop, TEST_PATTERN1, TEST_SIZE);
+    __wbinvd();
 
-  if (0 == memcmp(MembaseTop, ControlRegion, TEST_SIZE))
+    if (memcmp(MembaseTop, ControlRegion, TEST_SIZE) == 0)
     {
-      /* Looks like there is memory .. maybe a 128MB box */
-      memset(ControlRegion, TEST_PATTERN2, TEST_SIZE);
-      memset(MembaseTop, TEST_PATTERN2, TEST_SIZE);
-      __wbinvd();
-      if (0 == memcmp(MembaseTop, ControlRegion, TEST_SIZE))
+        /* Looks like there is memory .. maybe a 128MB box */
+        memset(ControlRegion, TEST_PATTERN2, TEST_SIZE);
+        memset(MembaseTop, TEST_PATTERN2, TEST_SIZE);
+        __wbinvd();
+        if (memcmp(MembaseTop, ControlRegion, TEST_SIZE) == 0)
         {
-          /* Definitely looks like there is memory */
-          if (0 == memcmp(MembaseLow, ControlRegion, TEST_SIZE))
+            /* Definitely looks like there is memory */
+            if (memcmp(MembaseLow, ControlRegion, TEST_SIZE) == 0)
             {
-              /* Hell, we find the Test-string at 0x0 too ! */
-              InstalledMemoryMb = 64;
+                /* Hell, we find the Test-string at 0x0 too! */
+                InstalledMemoryMb = 64;
             }
-          else
+            else
             {
-              InstalledMemoryMb = 128;
+                InstalledMemoryMb = 128;
             }
         }
     }
 
-  /* Set hardware for amount of memory detected */
-  WRITE_PORT_ULONG((ULONG*) 0xcf8, CONFIG_CMD(0, 0, 0x84));
-  WRITE_PORT_ULONG((ULONG*) 0xcfc, InstalledMemoryMb * 1024 * 1024 - 1);
+    /* Set hardware for amount of memory detected */
+    WRITE_PORT_ULONG((ULONG*) 0xcf8, CONFIG_CMD(0, 0, 0x84));
+    WRITE_PORT_ULONG((ULONG*) 0xcfc, InstalledMemoryMb * 1024 * 1024 - 1);
 
-  AvailableMemoryMb = InstalledMemoryMb;
+    AvailableMemoryMb = InstalledMemoryMb;
 }
 
 FREELDR_MEMORY_DESCRIPTOR XboxMemoryMap[2];
@@ -79,40 +79,41 @@ FREELDR_MEMORY_DESCRIPTOR XboxMemoryMap[2];
 PFREELDR_MEMORY_DESCRIPTOR
 XboxMemGetMemoryMap(ULONG *MemoryMapSize)
 {
-  /* Synthesize memory map */
-      /* Available RAM block */
-      XboxMemoryMap[0].BasePage = 0;
-      XboxMemoryMap[0].PageCount = AvailableMemoryMb * 1024 * 1024 / MM_PAGE_SIZE;
-      XboxMemoryMap[0].MemoryType = LoaderFree;
+    /* Synthesize memory map */
 
-      /* Video memory */
-      XboxMemoryMap[1].BasePage = AvailableMemoryMb * 1024 * 1024 / MM_PAGE_SIZE;
-      XboxMemoryMap[1].PageCount = (InstalledMemoryMb - AvailableMemoryMb) * 1024 * 1024 / MM_PAGE_SIZE;
-      XboxMemoryMap[1].MemoryType = LoaderFirmwarePermanent;
+    /* Available RAM block */
+    XboxMemoryMap[0].BasePage = 0;
+    XboxMemoryMap[0].PageCount = AvailableMemoryMb * 1024 * 1024 / MM_PAGE_SIZE;
+    XboxMemoryMap[0].MemoryType = LoaderFree;
 
-  *MemoryMapSize = 2;
-  return XboxMemoryMap;
+    /* Video memory */
+    XboxMemoryMap[1].BasePage = AvailableMemoryMb * 1024 * 1024 / MM_PAGE_SIZE;
+    XboxMemoryMap[1].PageCount = (InstalledMemoryMb - AvailableMemoryMb) * 1024 * 1024 / MM_PAGE_SIZE;
+    XboxMemoryMap[1].MemoryType = LoaderFirmwarePermanent;
+
+    *MemoryMapSize = 2;
+    return XboxMemoryMap;
 }
 
 PVOID
 XboxMemReserveMemory(ULONG MbToReserve)
 {
-  if (0 == InstalledMemoryMb)
+    if (InstalledMemoryMb == 0)
     {
-      /* Hmm, seems we're not initialized yet */
-      XboxMemInit();
+        /* Hmm, seems we're not initialized yet */
+        XboxMemInit();
     }
 
-  if (AvailableMemoryMb < MbToReserve)
+    if (MbToReserve > AvailableMemoryMb)
     {
-      /* Can't satisfy the request */
-      return NULL;
+        /* Can't satisfy the request */
+        return NULL;
     }
 
-  AvailableMemoryMb -= MbToReserve;
+    AvailableMemoryMb -= MbToReserve;
 
-  /* Top of available memory points to the space just reserved */
-  return (PVOID) (AvailableMemoryMb * 1024 * 1024);
+    /* Top of available memory points to the space just reserved */
+    return (PVOID)(AvailableMemoryMb * 1024 * 1024);
 }
 
 /* EOF */


### PR DESCRIPTION
## Purpose

Fix memory initialization on Xbox.  This PR is based on @mborgerson's misc hacks patch https://github.com/mborgerson/reactos/commit/0015a2e2b66c5b189f2802f29b871c55bc43661c.

No hacks here! :wink: 

JIRA issue: [CORE-16206](https://jira.reactos.org/browse/CORE-16206)

## Proposed changes

- Whitespace improvements (in a separate commit)
- Refactor and use PC memory map init functions
- This fixes filesystem detection and probably some other problems