### PR TITLE
[FREELDR] Abstract floppy drive detection code

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hardware.c
+++ b/boot/freeldr/freeldr/arch/i386/hardware.c
@@ -167,18 +167,6 @@ HalpCalibrateStallExecution(VOID)
 
 static
 UCHAR
-GetFloppyCount(VOID)
-{
-    UCHAR Data;
-
-    WRITE_PORT_UCHAR((PUCHAR)0x70, 0x10);
-    Data = READ_PORT_UCHAR((PUCHAR)0x71);
-
-    return ((Data & 0xF0) ? 1 : 0) + ((Data & 0x0F) ? 1 : 0);
-}
-
-static
-UCHAR
 GetFloppyType(UCHAR DriveNumber)
 {
     UCHAR Data;
@@ -285,7 +273,7 @@ DetectBiosFloppyController(PCONFIGURATION_COMPONENT_DATA BusKey)
     ULONG Size;
     ULONG FloppyCount;
 
-    FloppyCount = GetFloppyCount();
+    FloppyCount = MachGetFloppyCount();
     TRACE("Floppy count: %u\n", FloppyCount);
 
     /* Always create a BIOS disk controller, no matter if we have floppy drives or not */

--- a/boot/freeldr/freeldr/arch/i386/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/machpc.c
@@ -1301,6 +1301,18 @@ DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
     /* FIXME: Detect more ISA devices */
 }
 
+static
+UCHAR
+PcGetFloppyCount(VOID)
+{
+    UCHAR Data;
+
+    WRITE_PORT_UCHAR((PUCHAR)0x70, 0x10);
+    Data = READ_PORT_UCHAR((PUCHAR)0x71);
+
+    return ((Data & 0xF0) ? 1 : 0) + ((Data & 0x0F) ? 1 : 0);
+}
+
 PCONFIGURATION_COMPONENT_DATA
 PcHwDetect(VOID)
 {
@@ -1378,6 +1390,7 @@ PcMachInit(const char *CmdLine)
     MachVtbl.Beep = PcBeep;
     MachVtbl.PrepareForReactOS = PcPrepareForReactOS;
     MachVtbl.GetMemoryMap = PcMemGetMemoryMap;
+    MachVtbl.GetFloppyCount = PcGetFloppyCount;
     MachVtbl.DiskGetBootPath = PcDiskGetBootPath;
     MachVtbl.DiskReadLogicalSectors = PcDiskReadLogicalSectors;
     MachVtbl.DiskGetDriveGeometry = PcDiskGetDriveGeometry;

--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -139,6 +139,22 @@ DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
     /* FIXME: Detect more ISA devices */
 }
 
+static
+UCHAR
+XboxGetFloppyCount(VOID)
+{
+    /* On a PC we use CMOS/RTC I/O ports 0x70 and 0x71 to detect floppies.
+     * However an Xbox CMOS memory range [0x10, 0x70) and [0x80, 0x100)
+     * is filled with 0x55 0xAA 0x55 0xAA ... byte pattern which is used
+     * to validate the date/time settings by Xbox OS.
+     *
+     * Technically it's possible to connect a floppy drive to Xbox, but
+     * CMOS detection method should not be used here. */
+
+    WARN("XboxGetFloppyCount() is UNIMPLEMENTED, returning 0\n");
+    return 0;
+}
+
 PCONFIGURATION_COMPONENT_DATA
 XboxHwDetect(VOID)
 {
@@ -195,6 +211,7 @@ XboxMachInit(const char *CmdLine)
     MachVtbl.Beep = PcBeep;
     MachVtbl.PrepareForReactOS = XboxPrepareForReactOS;
     MachVtbl.GetMemoryMap = XboxMemGetMemoryMap;
+    MachVtbl.GetFloppyCount = XboxGetFloppyCount;
     MachVtbl.DiskGetBootPath = DiskGetBootPath;
     MachVtbl.DiskReadLogicalSectors = XboxDiskReadLogicalSectors;
     MachVtbl.DiskGetDriveGeometry = XboxDiskGetDriveGeometry;

--- a/boot/freeldr/freeldr/include/machine.h
+++ b/boot/freeldr/freeldr/include/machine.h
@@ -61,6 +61,7 @@ typedef struct tagMACHVTBL
     FREELDR_MEMORY_DESCRIPTOR* (*GetMemoryDescriptor)(FREELDR_MEMORY_DESCRIPTOR* Current);
     PFREELDR_MEMORY_DESCRIPTOR (*GetMemoryMap)(PULONG MaxMemoryMapSize);
 
+    UCHAR (*GetFloppyCount)(VOID);
     BOOLEAN (*DiskGetBootPath)(PCHAR BootPath, ULONG Size);
     BOOLEAN (*DiskReadLogicalSectors)(UCHAR DriveNumber, ULONGLONG SectorNumber, ULONG SectorCount, PVOID Buffer);
     BOOLEAN (*DiskGetDriveGeometry)(UCHAR DriveNumber, PGEOMETRY DriveGeometry);
@@ -115,6 +116,8 @@ VOID MachInit(const char *CmdLine);
     MachVtbl.Beep()
 #define MachPrepareForReactOS() \
     MachVtbl.PrepareForReactOS()
+#define MachGetFloppyCount() \
+    MachVtbl.GetFloppyCount()
 #define MachDiskGetBootPath(Path, Size) \
     MachVtbl.DiskGetBootPath((Path), (Size))
 #define MachDiskReadLogicalSectors(Drive, Start, Count, Buf)    \


### PR DESCRIPTION
## Purpose

Abstract floppy drive detection code.  This PR is based on @mborgerson's misc hacks patch https://github.com/mborgerson/reactos/commit/0015a2e2b66c5b189f2802f29b871c55bc43661c.

No hacks here! :wink: 

JIRA issue: [CORE-16207](https://jira.reactos.org/browse/CORE-16207)

## Proposed changes

- Make floppy detection code machine-specific, because Xbox CMOS cannot be used to detect floppies
- This fixes freeloader hanging at "Detecting hardware..."