### PR TITLE
[FREELDR] Abstract VGA BIOS specific code

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/machpc.c
@@ -77,6 +77,27 @@ DBG_DEFAULT_CHANNEL(HWDETECT);
 #define CONTROLLER_TIMEOUT                              250
 
 
+VOID
+PcGetExtendedBIOSData(PULONG ExtendedBIOSDataArea, PULONG ExtendedBIOSDataSize)
+{
+    REGS BiosRegs;
+
+    /* Get address and size of the extended BIOS data area */
+    BiosRegs.d.eax = 0xC100;
+    Int386(0x15, &BiosRegs, &BiosRegs);
+    if (INT386_SUCCESS(BiosRegs))
+    {
+        *ExtendedBIOSDataArea = BiosRegs.w.es << 4;
+        *ExtendedBIOSDataSize = 1024;
+    }
+    else
+    {
+        WARN("Int 15h AH=C1h call failed\n");
+        *ExtendedBIOSDataArea = 0;
+        *ExtendedBIOSDataSize = 0;
+    }
+}
+
 // NOTE: Similar to machxbox.c!XboxGetHarddiskConfigurationData(),
 // but with extended geometry support.
 static
@@ -1391,6 +1412,7 @@ PcMachInit(const char *CmdLine)
     MachVtbl.Beep = PcBeep;
     MachVtbl.PrepareForReactOS = PcPrepareForReactOS;
     MachVtbl.GetMemoryMap = PcMemGetMemoryMap;
+    MachVtbl.GetExtendedBIOSData = PcGetExtendedBIOSData;
     MachVtbl.GetFloppyCount = PcGetFloppyCount;
     MachVtbl.DiskGetBootPath = PcDiskGetBootPath;
     MachVtbl.DiskReadLogicalSectors = PcDiskReadLogicalSectors;

--- a/boot/freeldr/freeldr/arch/i386/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/machpc.c
@@ -1379,6 +1379,7 @@ PcMachInit(const char *CmdLine)
     MachVtbl.VideoSetDisplayMode = PcVideoSetDisplayMode;
     MachVtbl.VideoGetDisplaySize = PcVideoGetDisplaySize;
     MachVtbl.VideoGetBufferSize = PcVideoGetBufferSize;
+    MachVtbl.VideoGetFontsFromFirmware = PcVideoGetFontsFromFirmware;
     MachVtbl.VideoSetTextCursorPosition = PcVideoSetTextCursorPosition;
     MachVtbl.VideoHideShowTextCursor = PcVideoHideShowTextCursor;
     MachVtbl.VideoPutChar = PcVideoPutChar;

--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -201,6 +201,7 @@ XboxMachInit(const char *CmdLine)
     MachVtbl.VideoSetDisplayMode = XboxVideoSetDisplayMode;
     MachVtbl.VideoGetDisplaySize = XboxVideoGetDisplaySize;
     MachVtbl.VideoGetBufferSize = XboxVideoGetBufferSize;
+    MachVtbl.VideoGetFontsFromFirmware = XboxVideoGetFontsFromFirmware;
     MachVtbl.VideoHideShowTextCursor = XboxVideoHideShowTextCursor;
     MachVtbl.VideoPutChar = XboxVideoPutChar;
     MachVtbl.VideoCopyOffScreenBufferToVRAM = XboxVideoCopyOffScreenBufferToVRAM;

--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -23,6 +23,14 @@
 DBG_DEFAULT_CHANNEL(HWDETECT);
 
 
+VOID
+XboxGetExtendedBIOSData(PULONG ExtendedBIOSDataArea, PULONG ExtendedBIOSDataSize)
+{
+    TRACE("XboxGetExtendedBIOSData(): UNIMPLEMENTED\n");
+    *ExtendedBIOSDataArea = 0;
+    *ExtendedBIOSDataSize = 0;
+}
+
 // NOTE: Similar to machpc.c!PcGetHarddiskConfigurationData(),
 // but without extended geometry support.
 static
@@ -212,6 +220,7 @@ XboxMachInit(const char *CmdLine)
     MachVtbl.Beep = PcBeep;
     MachVtbl.PrepareForReactOS = XboxPrepareForReactOS;
     MachVtbl.GetMemoryMap = XboxMemGetMemoryMap;
+    MachVtbl.GetExtendedBIOSData = XboxGetExtendedBIOSData;
     MachVtbl.GetFloppyCount = XboxGetFloppyCount;
     MachVtbl.DiskGetBootPath = DiskGetBootPath;
     MachVtbl.DiskReadLogicalSectors = XboxDiskReadLogicalSectors;

--- a/boot/freeldr/freeldr/arch/i386/pcvideo.c
+++ b/boot/freeldr/freeldr/arch/i386/pcvideo.c
@@ -118,6 +118,20 @@ static BOOLEAN VesaVideoMode = FALSE;                     /* Are we using a VESA
 static SVGA_MODE_INFORMATION VesaVideoModeInformation; /* Only valid when in VESA mode */
 static ULONG CurrentMemoryBank = 0;                      /* Currently selected VESA bank */
 
+enum
+{
+    INT1FhFont = 0x00,
+    INT43hFont = 0x01,
+    ROM_8x14CharacterFont = 0x02,
+    ROM_8x8DoubleDotFontLo = 0x03,
+    ROM_8x8DoubleDotFontHi = 0x04,
+    ROM_AlphaAlternate = 0x05,
+    ROM_8x16Font = 0x06,
+    ROM_Alternate9x16Font = 0x07,
+    UltraVision_8x20Font = 0x11,
+    UltraVision_8x10Font = 0x12,
+};
+
 static ULONG
 PcVideoDetectVideoCard(VOID)
 {
@@ -955,6 +969,40 @@ ULONG
 PcVideoGetBufferSize(VOID)
 {
   return ScreenHeight * BytesPerScanLine;
+}
+
+VOID
+PcVideoGetFontsFromFirmware(PULONG RomFontPointers)
+{
+    REGS BiosRegs;
+
+    /* Get the address of the BIOS ROM fonts.
+       Int 10h, AX=1130h, BH = pointer specifier
+       returns: es:bp = address */
+    BiosRegs.d.eax = 0x1130;
+    BiosRegs.b.bh = ROM_8x14CharacterFont;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[0] = BiosRegs.w.es << 4 | BiosRegs.w.bp;
+
+    BiosRegs.b.bh = ROM_8x8DoubleDotFontLo;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[1] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
+
+    BiosRegs.b.bh = ROM_8x8DoubleDotFontHi;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[2] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
+
+    BiosRegs.b.bh = ROM_AlphaAlternate;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[3] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
+
+    BiosRegs.b.bh = ROM_8x16Font;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[4] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
+
+    BiosRegs.b.bh = ROM_Alternate9x16Font;
+    Int386(0x10, &BiosRegs, &BiosRegs);
+    RomFontPointers[5] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
 }
 
 VOID

--- a/boot/freeldr/freeldr/arch/i386/xboxvideo.c
+++ b/boot/freeldr/freeldr/arch/i386/xboxvideo.c
@@ -20,6 +20,9 @@
  */
 
 #include <freeldr.h>
+#include <debug.h>
+
+DBG_DEFAULT_CHANNEL(UI);
 
 static PVOID FrameBuffer;
 static ULONG ScreenWidth;
@@ -178,6 +181,12 @@ ULONG
 XboxVideoGetBufferSize(VOID)
 {
   return (ScreenHeight - 2 * TOP_BOTTOM_LINES) / CHAR_HEIGHT * (ScreenWidth / CHAR_WIDTH) * 2;
+}
+
+VOID
+XboxVideoGetFontsFromFirmware(PULONG RomFontPointers)
+{
+    TRACE("XboxVideoGetFontsFromFirmware(): UNIMPLEMENTED\n");
 }
 
 VOID

--- a/boot/freeldr/freeldr/include/arch/i386/machxbox.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machxbox.h
@@ -35,6 +35,7 @@ VOID XboxVideoClearScreen(UCHAR Attr);
 VIDEODISPLAYMODE XboxVideoSetDisplayMode(char *DisplayModem, BOOLEAN Init);
 VOID XboxVideoGetDisplaySize(PULONG Width, PULONG Height, PULONG Depth);
 ULONG XboxVideoGetBufferSize(VOID);
+VOID XboxVideoGetFontsFromFirmware(PULONG RomFontPointers);
 VOID XboxVideoSetTextCursorPosition(UCHAR X, UCHAR Y);
 VOID XboxVideoHideShowTextCursor(BOOLEAN Show);
 VOID XboxVideoPutChar(int Ch, UCHAR Attr, unsigned X, unsigned Y);

--- a/boot/freeldr/freeldr/include/arch/pc/machpc.h
+++ b/boot/freeldr/freeldr/include/arch/pc/machpc.h
@@ -36,6 +36,7 @@ VOID PcVideoClearScreen(UCHAR Attr);
 VIDEODISPLAYMODE PcVideoSetDisplayMode(char *DisplayMode, BOOLEAN Init);
 VOID PcVideoGetDisplaySize(PULONG Width, PULONG Height, PULONG Depth);
 ULONG PcVideoGetBufferSize(VOID);
+VOID PcVideoGetFontsFromFirmware(PULONG RomFontPointers);
 VOID PcVideoSetTextCursorPosition(UCHAR X, UCHAR Y);
 VOID PcVideoHideShowTextCursor(BOOLEAN Show);
 VOID PcVideoPutChar(int Ch, UCHAR Attr, unsigned X, unsigned Y);

--- a/boot/freeldr/freeldr/include/machine.h
+++ b/boot/freeldr/freeldr/include/machine.h
@@ -46,6 +46,7 @@ typedef struct tagMACHVTBL
     VIDEODISPLAYMODE (*VideoSetDisplayMode)(char *DisplayMode, BOOLEAN Init);
     VOID (*VideoGetDisplaySize)(PULONG Width, PULONG Height, PULONG Depth);
     ULONG (*VideoGetBufferSize)(VOID);
+    VOID (*VideoGetFontsFromFirmware)(PULONG RomFontPointers);
     VOID (*VideoSetTextCursorPosition)(UCHAR X, UCHAR Y);
     VOID (*VideoHideShowTextCursor)(BOOLEAN Show);
     VOID (*VideoPutChar)(int Ch, UCHAR Attr, unsigned X, unsigned Y);
@@ -96,6 +97,8 @@ VOID MachInit(const char *CmdLine);
     MachVtbl.VideoGetDisplaySize((W), (H), (D))
 #define MachVideoGetBufferSize()    \
     MachVtbl.VideoGetBufferSize()
+#define MachVideoGetFontsFromFirmware(RomFontPointers) \
+    MachVtbl.VideoGetFontsFromFirmware((RomFontPointers))
 #define MachVideoSetTextCursorPosition(X, Y)    \
     MachVtbl.VideoSetTextCursorPosition((X), (Y))
 #define MachVideoHideShowTextCursor(Show)   \

--- a/boot/freeldr/freeldr/include/machine.h
+++ b/boot/freeldr/freeldr/include/machine.h
@@ -61,6 +61,7 @@ typedef struct tagMACHVTBL
     // NOTE: Not in the machine.c ...
     FREELDR_MEMORY_DESCRIPTOR* (*GetMemoryDescriptor)(FREELDR_MEMORY_DESCRIPTOR* Current);
     PFREELDR_MEMORY_DESCRIPTOR (*GetMemoryMap)(PULONG MaxMemoryMapSize);
+    VOID (*GetExtendedBIOSData)(PULONG ExtendedBIOSDataArea, PULONG ExtendedBIOSDataSize);
 
     UCHAR (*GetFloppyCount)(VOID);
     BOOLEAN (*DiskGetBootPath)(PCHAR BootPath, ULONG Size);
@@ -119,6 +120,8 @@ VOID MachInit(const char *CmdLine);
     MachVtbl.Beep()
 #define MachPrepareForReactOS() \
     MachVtbl.PrepareForReactOS()
+#define MachGetExtendedBIOSData(ExtendedBIOSDataArea, ExtendedBIOSDataSize) \
+    MachVtbl.GetExtendedBIOSData((ExtendedBIOSDataArea), (ExtendedBIOSDataSize))
 #define MachGetFloppyCount() \
     MachVtbl.GetFloppyCount()
 #define MachDiskGetBootPath(Path, Size) \

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -290,27 +290,21 @@ WinLdrMapSpecialPages(void)
 static
 void WinLdrSetupSpecialDataPointers(VOID)
 {
-    REGS BiosRegs;
-
     /* Get the address of the BIOS ROM fonts. Win 2003 videoprt reads these
        values from address 0x700 .. 0x718 and store them in the registry
        in HKLM\System\CurrentControlSet\Control\Wow\RomFontPointers */
     MachVideoGetFontsFromFirmware(RomFontPointers);
 
-    /* Store address of the extended bios data area in 0x740 */
-    BiosRegs.d.eax = 0xC100;
-    Int386(0x15, &BiosRegs, &BiosRegs);
-    if (INT386_SUCCESS(BiosRegs))
+    /* Store address of the extended BIOS data area in 0x740 */
+    MachGetExtendedBIOSData(ExtendedBIOSDataArea, ExtendedBIOSDataSize);
+
+    if (*ExtendedBIOSDataArea == 0 && *ExtendedBIOSDataSize == 0)
     {
-        *ExtendedBIOSDataArea = BiosRegs.w.es << 4;
-        *ExtendedBIOSDataSize = 1024;
-        TRACE("*ExtendedBIOSDataArea = 0x%lx\n", *ExtendedBIOSDataArea);
+        WARN("Couldn't get address of extended BIOS data area\n");
     }
     else
     {
-        WARN("Couldn't get address of extended BIOS data area\n");
-        *ExtendedBIOSDataArea = 0;
-        *ExtendedBIOSDataSize = 0;
+        TRACE("*ExtendedBIOSDataArea = 0x%lx\n", *ExtendedBIOSDataArea);
     }
 }
 

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -287,54 +287,15 @@ WinLdrMapSpecialPages(void)
 #define ExtendedBIOSDataSize ((PULONG)0x744)
 #define RomFontPointers ((PULONG)0x700)
 
-enum
-{
-    INT1FhFont = 0x00,
-    INT43hFont = 0x01,
-    ROM_8x14CharacterFont = 0x02,
-    ROM_8x8DoubleDotFontLo = 0x03,
-    ROM_8x8DoubleDotFontHi = 0x04,
-    ROM_AlphaAlternate = 0x05,
-    ROM_8x16Font = 0x06,
-    ROM_Alternate9x16Font = 0x07,
-    UltraVision_8x20Font = 0x11,
-    UltraVision_8x10Font = 0x12,
-};
-
 static
 void WinLdrSetupSpecialDataPointers(VOID)
 {
     REGS BiosRegs;
 
-    /* Get the address of the bios rom fonts. Win 2003 videoprt reads these
+    /* Get the address of the BIOS ROM fonts. Win 2003 videoprt reads these
        values from address 0x700 .. 0x718 and store them in the registry
-       in HKLM\System\CurrentControlSet\Control\Wow\RomFontPointers
-       Int 10h, AX=1130h, BH = pointer specifier
-       returns: es:bp = address */
-    BiosRegs.d.eax = 0x1130;
-    BiosRegs.b.bh = ROM_8x14CharacterFont;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[0] = BiosRegs.w.es << 4 | BiosRegs.w.bp;
-
-    BiosRegs.b.bh = ROM_8x8DoubleDotFontLo;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[1] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
-
-    BiosRegs.b.bh = ROM_8x8DoubleDotFontHi;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[2] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
-
-    BiosRegs.b.bh = ROM_AlphaAlternate;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[3] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
-
-    BiosRegs.b.bh = ROM_8x16Font;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[4] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
-
-    BiosRegs.b.bh = ROM_Alternate9x16Font;
-    Int386(0x10, &BiosRegs, &BiosRegs);
-    RomFontPointers[5] = BiosRegs.w.es << 16 | BiosRegs.w.bp;
+       in HKLM\System\CurrentControlSet\Control\Wow\RomFontPointers */
+    MachVideoGetFontsFromFirmware(RomFontPointers);
 
     /* Store address of the extended bios data area in 0x740 */
     BiosRegs.d.eax = 0xC100;


### PR DESCRIPTION
## Purpose

Abstract VGA BIOS specific code.

JIRA issue: [CORE-16210](https://jira.reactos.org/browse/CORE-16210)

## Proposed changes

- `WinLdrSetupSpecialDataPointers()` uses INT 10h video interrupts, but they are not available on Xbox, so make them machine-specific
- Next it also uses INT 15h AH=C1h to get extended BIOS data area, but it doesn't exist on Xbox either, so make it machine-specific too
- This fixes freeloader hanging after "Loading boot devices..."