### PR TITLE
[TASKMGR] Implement proper process tree ending

### DIFF
--- a/base/applications/taskmgr/endproc.c
+++ b/base/applications/taskmgr/endproc.c
@@ -122,6 +122,14 @@ BOOL ShutdownProcessTreeHelper(HANDLE hSnapshot, HANDLE hParentProcess, DWORD dw
                 hChildHandle = OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_INFORMATION,
                                            FALSE,
                                            ProcessEntry.th32ProcessID);
+                if (!hChildHandle || (hChildHandle && IsCriticalProcess(hChildHandle)))
+                {
+                    if (hChildHandle)
+                    {
+                        CloseHandle(hChildHandle);
+                    }
+                    continue;
+                }
                 if (!ShutdownProcessTreeHelper(hSnapshot, hChildHandle, ProcessEntry.th32ProcessID))
                 {
                     return FALSE;

--- a/base/applications/taskmgr/endproc.c
+++ b/base/applications/taskmgr/endproc.c
@@ -122,7 +122,7 @@ BOOL ShutdownProcessTreeHelper(HANDLE hSnapshot, HANDLE hParentProcess, DWORD dw
                 hChildHandle = OpenProcess(PROCESS_TERMINATE | PROCESS_QUERY_INFORMATION,
                                            FALSE,
                                            ProcessEntry.th32ProcessID);
-                if (!hChildHandle || (hChildHandle && IsCriticalProcess(hChildHandle)))
+                if (!hChildHandle || IsCriticalProcess(hChildHandle))
                 {
                     if (hChildHandle)
                     {
@@ -132,6 +132,7 @@ BOOL ShutdownProcessTreeHelper(HANDLE hSnapshot, HANDLE hParentProcess, DWORD dw
                 }
                 if (!ShutdownProcessTreeHelper(hSnapshot, hChildHandle, ProcessEntry.th32ProcessID))
                 {
+                    CloseHandle(hChildHandle);
                     return FALSE;
                 }
                 CloseHandle(hChildHandle);

--- a/base/applications/taskmgr/precomp.h
+++ b/base/applications/taskmgr/precomp.h
@@ -18,6 +18,7 @@
 #include <winreg.h>
 #include <commctrl.h>
 #include <shellapi.h>
+#include <tlhelp32.h>
 
 #include "column.h"
 #include "taskmgr.h"


### PR DESCRIPTION
## Purpose
_ReactOS Task Manager has an option to shut down process trees, but it's not implemented properly (just the parent is terminated instead of the whole tree). This PR implements the missing functionality._

## Proposed changes
- Implement ShutdownProcessTree (and its helper, ShutdownProcessTreeHelper) in endproc.c and use it in ProcessPage_OnEndProcessTree.
