### PR TITLE
[DSOUND_NEW] Completely fix gcc compilation (addendum to #1672)

### DIFF
--- a/dll/directx/dsound_new/CMakeLists.txt
+++ b/dll/directx/dsound_new/CMakeLists.txt
@@ -25,6 +25,6 @@ add_library(dsound MODULE
 
 set_module_type(dsound win32dll)
 target_link_libraries(dsound dxguid uuid)
-add_importlibs(dsound winmm advapi32 msvcrt kernel32 ntdll)
+add_importlibs(dsound winmm ole32 advapi32 setupapi ksuser user32 msvcrt kernel32 ntdll)
 add_pch(dsound precomp.h SOURCE)
 add_cd_file(TARGET dsound DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
## Purpose

Completely fix gcc compilation of `dsound_new` by linking some more needed libraries. Spotted by @feel-the-dz3n.
If you want to test it, you need to comment out `add_subdirectory(dsound)` in `dll/directx/wine/CMakeLists.txt` and uncomment `#add_subdirectory(dsound_new) # disabled in trunk` in `dll/directx/CMakeLists.txt`.

JIRA issue: [CORE-16128](https://jira.reactos.org/browse/CORE-16128)

## Proposed changes

- Add `ksuser`, `ole32`, `setupapi` and `user32` libs in `add_importlibs()` section of `dll/directx/dsound_new/CMakeLists.txt`.

## Result

![dsound_new](https://user-images.githubusercontent.com/26385117/61541178-d685be80-aa47-11e9-8008-757c1bf0b1cd.png)