### PR TITLE
[WIN32SS][GDI] Assume pso->sizlBitmap.cy positiveness

### DIFF
--- a/win32ss/gdi/dib/stretchblt.c
+++ b/win32ss/gdi/dib/stretchblt.c
@@ -58,7 +58,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
 
   if (UsesSource)
   {
-    SourceCy = abs(SourceSurf->sizlBitmap.cy);
+    SourceCy = SourceSurf->sizlBitmap.cy;
     fnSource_GetPixel = DibFunctionsForBitmapFormat[SourceSurf->iBitmapFormat].DIB_GetPixel;
     DPRINT("Source BPP: %u, srcRect: (%d,%d)-(%d,%d)\n",
       BitsPerFormat(SourceSurf->iBitmapFormat), SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom);
@@ -67,7 +67,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
   if (MaskSurf)
   {
     fnMask_GetPixel = DibFunctionsForBitmapFormat[MaskSurf->iBitmapFormat].DIB_GetPixel;
-    MaskCy = abs(MaskSurf->sizlBitmap.cy);
+    MaskCy = MaskSurf->sizlBitmap.cy;
   }
 
   DstHeight = DestRect->bottom - DestRect->top;

--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -59,7 +59,7 @@ UnsafeSetBitmapBits(
     NT_ASSERT(psurf->SurfObj.iBitmapFormat <= BMF_32BPP);
 
     nWidth = psurf->SurfObj.sizlBitmap.cx;
-    nHeight = labs(psurf->SurfObj.sizlBitmap.cy);
+    nHeight = psurf->SurfObj.sizlBitmap.cy;
     cBitsPixel = BitsPerFormat(psurf->SurfObj.iBitmapFormat);
 
     pjDst = psurf->SurfObj.pvScan0;
@@ -509,7 +509,7 @@ UnsafeGetBitmapBits(
     ULONG Y, iSrc, iDst, cbSrc, cbDst, nWidth, nHeight, cBitsPixel;
 
     nWidth = psurf->SurfObj.sizlBitmap.cx;
-    nHeight = labs(psurf->SurfObj.sizlBitmap.cy);
+    nHeight = psurf->SurfObj.sizlBitmap.cy;
     cBitsPixel = BitsPerFormat(psurf->SurfObj.iBitmapFormat);
 
     /* Get pointers */
@@ -575,7 +575,7 @@ NtGdiGetBitmapBits(
     /* Calculate the size of the bitmap in bytes */
     cjSize = WIDTH_BYTES_ALIGN16(psurf->SurfObj.sizlBitmap.cx,
                 BitsPerFormat(psurf->SurfObj.iBitmapFormat)) *
-                abs(psurf->SurfObj.sizlBitmap.cy);
+                psurf->SurfObj.sizlBitmap.cy;
 
     /* If the bits vector is null, the function should return the read size */
     if (pUnsafeBits == NULL)


### PR DESCRIPTION
## Purpose
We assume `pso->sizlBitmap.cy` is positive.
JIRA issue: [CORE-15995](https://jira.reactos.org/browse/CORE-15995)
Because `pso->sizlBitmap.cy` is certificated as a positive value after initialization in `SURFACE_AllocSurface`, so we can safely omit `abs` and `labs` (absolute) function calls for it.