### PR TITLE
[portcls] Add in missing IoControlCode switches

### DIFF
--- a/drivers/wdm/audio/backpln/portcls/pin_wavert.cpp
+++ b/drivers/wdm/audio/backpln/portcls/pin_wavert.cpp
@@ -309,7 +309,6 @@ CPortPinWaveRT::DeviceIoControl(
     {
         case IOCTL_KS_PROPERTY:
             return HandleKsProperty(Irp);
-            break;
 		
         case IOCTL_KS_ENABLE_EVENT:
             /* FIXME UNIMPLEMENTED */
@@ -329,7 +328,7 @@ CPortPinWaveRT::DeviceIoControl(
         case IOCTL_KS_METHOD:
             /* FIXME UNIMPLEMENTED */
             UNIMPLEMENTED_ONCE;
-            break;
+            return KsDefaultDeviceIoCompletion(DeviceObject, Irp);
 
         case IOCTL_KS_RESET_STATE:
             /* FIXME UNIMPLEMENTED */
@@ -339,11 +338,9 @@ CPortPinWaveRT::DeviceIoControl(
         case IOCTL_KS_WRITE_STREAM:
         case IOCTL_KS_READ_STREAM:
             return HandleKsStream(Irp);
-            break;
 			
         default:
             return KsDefaultDeviceIoCompletion(DeviceObject, Irp);
-            break;
     }
 
     Irp->IoStatus.Information = 0;

--- a/drivers/wdm/audio/backpln/portcls/pin_wavert.cpp
+++ b/drivers/wdm/audio/backpln/portcls/pin_wavert.cpp
@@ -305,35 +305,46 @@ CPortPinWaveRT::DeviceIoControl(
     IoStack = IoGetCurrentIrpStackLocation(Irp);
 
 
-    if (IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_PROPERTY)
+    switch (IoStack->Parameters.DeviceIoControl.IoControlCode)
     {
-       return HandleKsProperty(Irp);
-    }
-    else if (IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_ENABLE_EVENT)
-    {
-        /// FIXME
-        /// handle enable event
-    }
-    else if (IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_DISABLE_EVENT)
-    {
-        /// FIXME
-        /// handle disable event
-    }
-    else if (IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_RESET_STATE)
-    {
-        /// FIXME
-        /// handle reset state
-    }
-    else if (IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_WRITE_STREAM || IoStack->Parameters.DeviceIoControl.IoControlCode == IOCTL_KS_READ_STREAM)
-    {
-       return HandleKsStream(Irp);
-    }
-    else
-    {
-        return KsDefaultDeviceIoCompletion(DeviceObject, Irp);
-    }
+        case IOCTL_KS_PROPERTY:
+            return HandleKsProperty(Irp);
+            break;
+		
+        case IOCTL_KS_ENABLE_EVENT:
+            /* FIXME UNIMPLEMENTED */
+            UNIMPLEMENTED_ONCE;
+            break;
 
-    UNIMPLEMENTED;
+        case IOCTL_KS_DISABLE_EVENT:
+            /* FIXME UNIMPLEMENTED */
+            UNIMPLEMENTED_ONCE;
+            break;
+
+        case IOCTL_KS_HANDSHAKE:
+            /* FIXME UNIMPLEMENTED */
+            UNIMPLEMENTED_ONCE;
+            break;
+
+        case IOCTL_KS_METHOD:
+            /* FIXME UNIMPLEMENTED */
+            UNIMPLEMENTED_ONCE;
+            break;
+
+        case IOCTL_KS_RESET_STATE:
+            /* FIXME UNIMPLEMENTED */
+            UNIMPLEMENTED_ONCE;
+            break;
+			
+        case IOCTL_KS_WRITE_STREAM:
+        case IOCTL_KS_READ_STREAM:
+            return HandleKsStream(Irp);
+            break;
+			
+        default:
+            return KsDefaultDeviceIoCompletion(DeviceObject, Irp);
+            break;
+    }
 
     Irp->IoStatus.Information = 0;
     Irp->IoStatus.Status = STATUS_UNSUCCESSFUL;


### PR DESCRIPTION
## Purpose
Added in missing switches. (`IOCTL_KS_HANDSHAKE `and `IOCTL_KS_METHOD`)

There are many instances of replacing this driver with MS's fixing a lot of different sound issues, but it's hard to debug such a thing without warnings and errors in the logs, so I've also added unimplemented messages for when these are called. 

I wish I had the knowledge to fix such an issue, but at the least I can do small things like this