### PR TITLE
[FREELDR] Implement proper partition type detection and handling

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwdisk.c
+++ b/boot/freeldr/freeldr/arch/i386/hwdisk.c
@@ -231,6 +231,9 @@ GetHarddiskInformation(UCHAR DriveNumber)
     PARTITION_TABLE_ENTRY PartitionTableEntry;
     PCHAR Identifier = PcDiskIdentifier[DriveNumber - 0x80];
 
+    /* Detect disk partition type */
+    DiskDetectPartitionType(DriveNumber);
+
     /* Read the MBR */
     if (!MachDiskReadLogicalSectors(DriveNumber, 0ULL, 1, DiskReadBuffer))
     {

--- a/boot/freeldr/freeldr/arch/i386/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/machpc.c
@@ -1422,8 +1422,6 @@ PcMachInit(const char *CmdLine)
     MachVtbl.InitializeBootDevices = PcInitializeBootDevices;
     MachVtbl.HwDetect = PcHwDetect;
     MachVtbl.HwIdle = PcHwIdle;
-
-    // DiskGetPartitionEntry = DiskGetMbrPartitionEntry; // Default
 }
 
 VOID

--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -231,8 +231,6 @@ XboxMachInit(const char *CmdLine)
     MachVtbl.HwDetect = XboxHwDetect;
     MachVtbl.HwIdle = XboxHwIdle;
 
-    DiskGetPartitionEntry = XboxDiskGetPartitionEntry;
-
     /* Set LEDs to orange after init */
     XboxSetLED("oooo");
 }

--- a/boot/freeldr/freeldr/disk/disk.c
+++ b/boot/freeldr/freeldr/disk/disk.c
@@ -130,9 +130,9 @@ BOOLEAN DiskGetBootPath(OUT PCHAR BootPath, IN ULONG Size)
         PARTITION_TABLE_ENTRY PartitionEntry;
 
         /* This is a hard disk */
-        if (!DiskGetActivePartitionEntry(FrldrBootDrive, &PartitionEntry, &BootPartition))
+        if (!DiskGetBootPartitionEntry(FrldrBootDrive, &PartitionEntry, &BootPartition))
         {
-            ERR("Invalid active partition information\n");
+            ERR("Failed to get boot partition entry\n");
             return FALSE;
         }
 

--- a/boot/freeldr/freeldr/include/arch/i386/machxbox.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machxbox.h
@@ -52,7 +52,6 @@ PVOID XboxMemReserveMemory(ULONG MbToReserve);
 PFREELDR_MEMORY_DESCRIPTOR XboxMemGetMemoryMap(ULONG *MemoryMapSize);
 
 BOOLEAN XboxDiskReadLogicalSectors(UCHAR DriveNumber, ULONGLONG SectorNumber, ULONG SectorCount, PVOID Buffer);
-BOOLEAN XboxDiskGetPartitionEntry(UCHAR DriveNumber, ULONG PartitionNumber, PPARTITION_TABLE_ENTRY PartitionTableEntry);
 BOOLEAN XboxDiskGetDriveGeometry(UCHAR DriveNumber, PGEOMETRY DriveGeometry);
 ULONG XboxDiskGetCacheableBlockCount(UCHAR DriveNumber);
 

--- a/boot/freeldr/freeldr/include/disk.h
+++ b/boot/freeldr/freeldr/include/disk.h
@@ -102,6 +102,7 @@ typedef struct _MASTER_BOOT_RECORD
 #define PARTITION_UNIX                  0x63      // Unix
 #define VALID_NTFT                      0xC0      // NTFT uses high order bits
 #define PARTITION_NTFT                  0x80      // NTFT partition
+#define PARTITION_GPT                   0xEE      // GPT protective partition
 #ifdef __REACTOS__
 #define PARTITION_OLD_LINUX             0x43
 #define PARTITION_LINUX                 0x83
@@ -144,18 +145,9 @@ extern SIZE_T DiskReadBufferSize;
 //
 ///////////////////////////////////////////////////////////////////////////////////////
 
-/* Signature of DiskGetPartitionEntry(...) */
-typedef
-BOOLEAN
-(*DISK_GET_PARTITION_ENTRY)(UCHAR DriveNumber,
-                            ULONG PartitionNumber,
-                            PPARTITION_TABLE_ENTRY PartitionTableEntry);
-
-/* This function serves to retrieve a partition entry for devices that handle partitions differently */
-extern DISK_GET_PARTITION_ENTRY DiskGetPartitionEntry;
-
-BOOLEAN DiskGetActivePartitionEntry(UCHAR DriveNumber, PPARTITION_TABLE_ENTRY PartitionTableEntry, ULONG *ActivePartition);
-BOOLEAN DiskGetMbrPartitionEntry(UCHAR DriveNumber, ULONG PartitionNumber, PPARTITION_TABLE_ENTRY PartitionTableEntry);
+VOID DiskDetectPartitionType(UCHAR DriveNumber);
+BOOLEAN DiskGetBootPartitionEntry(UCHAR DriveNumber, PPARTITION_TABLE_ENTRY PartitionTableEntry, ULONG *BootPartition);
+BOOLEAN DiskGetPartitionEntry(UCHAR DriveNumber, ULONG PartitionNumber, PPARTITION_TABLE_ENTRY PartitionTableEntry);
 BOOLEAN DiskGetFirstPartitionEntry(PMASTER_BOOT_RECORD MasterBootRecord, PPARTITION_TABLE_ENTRY PartitionTableEntry);
 BOOLEAN DiskGetFirstExtendedPartitionEntry(PMASTER_BOOT_RECORD MasterBootRecord, PPARTITION_TABLE_ENTRY PartitionTableEntry);
 BOOLEAN DiskReadBootRecord(UCHAR DriveNumber, ULONGLONG LogicalSectorNumber, PMASTER_BOOT_RECORD BootRecord);

--- a/sdk/include/psdk/ntdddisk.h
+++ b/sdk/include/psdk/ntdddisk.h
@@ -410,7 +410,11 @@ typedef struct _PARTITION_INFORMATION_GPT {
 typedef enum _PARTITION_STYLE {
   PARTITION_STYLE_MBR,
   PARTITION_STYLE_GPT,
-  PARTITION_STYLE_RAW
+  PARTITION_STYLE_RAW,
+#ifdef __REACTOS__
+  /* ReactOS custom partition handlers */
+  PARTITION_STYLE_BRFR = 128 /* Xbox-BRFR partitioning scheme */
+#endif
 } PARTITION_STYLE;
 
 typedef struct _DISK_PARTITION_INFO {


### PR DESCRIPTION
- This allows to detect and dynamically handle different partitioning schemes.
- Implemented detection of MBR, GPT, Xbox-BRFR, and partitionless disks.
- Currently only MBR and Xbox-BRFR partitions are handled and tested.