### PR TITLE
[FREELDR] Fix remaining hwdisk and FATX bugs

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwdisk.c
+++ b/boot/freeldr/freeldr/arch/i386/hwdisk.c
@@ -65,8 +65,8 @@ DiskGetFileInformation(ULONG FileId, FILEINFORMATION* Information)
     DISKCONTEXT* Context = FsGetDeviceSpecific(FileId);
 
     RtlZeroMemory(Information, sizeof(FILEINFORMATION));
-    Information->EndingAddress.QuadPart = (Context->SectorOffset + Context->SectorCount) * Context->SectorSize;
-    Information->CurrentAddress.QuadPart = (Context->SectorOffset + Context->SectorNumber) * Context->SectorSize;
+    Information->EndingAddress.QuadPart = Context->SectorCount * Context->SectorSize;
+    Information->CurrentAddress.QuadPart = Context->SectorNumber * Context->SectorSize;
 
     return ESUCCESS;
 }

--- a/boot/freeldr/freeldr/lib/fs/fat.c
+++ b/boot/freeldr/freeldr/lib/fs/fat.c
@@ -266,12 +266,12 @@ BOOLEAN FatOpenVolume(PFAT_VOLUME_INFO Volume, PFAT_BOOTSECTOR BootSector, ULONG
     {
         Volume->BytesPerSector = 512;
         Volume->SectorsPerCluster = SWAPD(FatXVolumeBootSector->SectorsPerCluster);
-        Volume->FatSectorStart = (4096 / Volume->BytesPerSector);
+        Volume->FatSectorStart = (0x1000 / Volume->BytesPerSector);
         Volume->ActiveFatSectorStart = Volume->FatSectorStart;
         Volume->NumberOfFats = 1;
         FatSize = (ULONG)(PartitionSectorCount / Volume->SectorsPerCluster *
                   (Volume->FatType == FATX16 ? 2 : 4));
-        Volume->SectorsPerFat = (((FatSize + 4095) / 4096) * 4096) / Volume->BytesPerSector;
+        Volume->SectorsPerFat = ROUND_UP(FatSize, 0x1000) / Volume->BytesPerSector;
 
         Volume->RootDirSectorStart = Volume->FatSectorStart + Volume->NumberOfFats * Volume->SectorsPerFat;
         Volume->RootDirSectors = FatXVolumeBootSector->SectorsPerCluster;
@@ -720,6 +720,7 @@ static BOOLEAN FatXSearchDirectoryBufferForFile(PFAT_VOLUME_INFO Volume, PVOID D
             /*
              * We found the entry, now fill in the FAT_FILE_INFO struct
              */
+            FatFileInfoPointer->Attributes = DirEntry->Attr;
             FatFileInfoPointer->FileSize = DirEntry->Size;
             FatFileInfoPointer->FilePointer = 0;
 


### PR DESCRIPTION
- DiskGetFileInformation() should return relative addresses
- FatXSearchDirectoryBufferForFile() should assign file attributes
- Minor code style improvements in FatOpenVolume()

Many thanks to @Extravert-ir who helped to debug and spot all these hidden bugs. :beetle: 

JIRA issue: [CORE-16248](https://jira.reactos.org/browse/CORE-16248)
