### PR TITLE
[FREELDR] Verbose error output for FS errors

### DIFF
--- a/boot/freeldr/freeldr/lib/inifile/ini_init.c
+++ b/boot/freeldr/freeldr/lib/inifile/ini_init.c
@@ -51,6 +51,7 @@ BOOLEAN IniFileInitialize(VOID)
     Status = IniOpenIniFile(&FileId);
     if (Status != ESUCCESS)
     {
+        ERR("Error while opening freeldr.ini, Status: %d\n", Status);
         UiMessageBoxCritical("Error opening freeldr.ini or file not found.\nYou need to re-install FreeLoader.");
         return FALSE;
     }
@@ -83,6 +84,7 @@ BOOLEAN IniFileInitialize(VOID)
     Status = ArcRead(FileId, FreeLoaderIniFileData, FreeLoaderIniFileSize, &Count);
     if (Status != ESUCCESS || Count != FreeLoaderIniFileSize)
     {
+        ERR("Error while reading freeldr.ini, Status: %d\n", Status);
         UiMessageBoxCritical("Error while reading freeldr.ini.");
         ArcClose(FileId);
         FrLdrTempFree(FreeLoaderIniFileData, TAG_INI_FILE);

--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -287,7 +287,7 @@ WinLdrLoadImage(IN PCHAR FileName,
     Status = ArcOpen(FileName, OpenReadOnly, &FileId);
     if (Status != ESUCCESS)
     {
-        // UiMessageBox("Can not open the file.");
+        WARN("Error while opening '%s', Status: %u\n", FileName, Status);
         return FALSE;
     }
 
@@ -295,6 +295,7 @@ WinLdrLoadImage(IN PCHAR FileName,
     Status = ArcRead(FileId, HeadersBuffer, SECTOR_SIZE * 2, &BytesRead);
     if (Status != ESUCCESS)
     {
+        WARN("Error while reading '%s', Status: %u\n", FileName, Status);
         UiMessageBox("Error reading from file.");
         ArcClose(FileId);
         return FALSE;
@@ -348,11 +349,12 @@ WinLdrLoadImage(IN PCHAR FileName,
     TRACE("Base PA: 0x%X, VA: 0x%X\n", PhysicalBase, VirtualBase);
 
     /* Set to 0 position and fully load the file image */
-    Position.HighPart = Position.LowPart = 0;
+    Position.QuadPart = 0;
     Status = ArcSeek(FileId, &Position, SeekAbsolute);
     if (Status != ESUCCESS)
     {
-        UiMessageBox("Error seeking to start of file.");
+        WARN("Error while seeking '%s', Status: %u\n", FileName, Status);
+        UiMessageBox("Error seeking the start of a file.");
         ArcClose(FileId);
         return FALSE;
     }
@@ -360,7 +362,7 @@ WinLdrLoadImage(IN PCHAR FileName,
     Status = ArcRead(FileId, PhysicalBase, NtHeaders->OptionalHeader.SizeOfHeaders, &BytesRead);
     if (Status != ESUCCESS)
     {
-        // Print(L"Error reading headers %s\n", FileName);
+        WARN("Error while reading '%s', Status: %u\n", FileName, Status);
         UiMessageBox("Error reading headers.");
         ArcClose(FileId);
         return FALSE;

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -370,6 +370,7 @@ WinLdrLoadModule(PCSTR ModuleName,
     if (Status != ESUCCESS)
     {
         /* In case of errors, we just return, without complaining to the user */
+        WARN("Error while opening '%s', Status: %u\n", ModuleName, Status);
         return NULL;
     }
 
@@ -396,6 +397,7 @@ WinLdrLoadModule(PCSTR ModuleName,
     ArcClose(FileId);
     if (Status != ESUCCESS)
     {
+        WARN("Error while reading '%s', Status: %u\n", ModuleName, Status);
         return NULL;
     }
 

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -49,10 +49,11 @@ WinLdrLoadSystemHive(
     /* Concatenate path and filename to get the full name */
     strcpy(FullHiveName, DirectoryPath);
     strcat(FullHiveName, HiveName);
-    //Print(L"Loading %s...\n", FullHiveName);
+
     Status = ArcOpen(FullHiveName, OpenReadOnly, &FileId);
     if (Status != ESUCCESS)
     {
+        WARN("Error while opening '%s', Status: %u\n", FullHiveName, Status);
         UiMessageBox("Opening hive file failed!");
         return FALSE;
     }
@@ -91,6 +92,7 @@ WinLdrLoadSystemHive(
     if (Status != ESUCCESS)
     {
         ArcClose(FileId);
+        WARN("Error while reading '%s', Status: %u\n", FullHiveName, Status);
         UiMessageBox("Unable to read from hive file!");
         return FALSE;
     }
@@ -320,12 +322,14 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
         AnsiEqualsOem = TRUE;
 
     /* Open file with ANSI and store its size */
-    //Print(L"Loading %s...\n", Filename);
     strcpy(FileName, DirectoryPath);
     strcat(FileName, AnsiFileName);
     Status = ArcOpen(FileName, OpenReadOnly, &AnsiFileId);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while opening '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     Status = ArcGetFileInformation(AnsiFileId, &FileInfo);
     if (Status != ESUCCESS)
@@ -346,7 +350,10 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
         strcat(FileName, OemFileName);
         Status = ArcOpen(FileName, OpenReadOnly, &OemFileId);
         if (Status != ESUCCESS)
+        {
+            WARN("Error while opening '%s', Status: %u\n", FileName, Status);
             goto Failure;
+        }
 
         Status = ArcGetFileInformation(OemFileId, &FileInfo);
         if (Status != ESUCCESS)
@@ -362,7 +369,10 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     strcat(FileName, LanguageFileName);
     Status = ArcOpen(FileName, OpenReadOnly, &LanguageFileId);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while opening '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     Status = ArcGetFileInformation(LanguageFileId, &FileInfo);
     if (Status != ESUCCESS)
@@ -403,11 +413,17 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     strcat(FileName, AnsiFileName);
     Status = ArcOpen(FileName, OpenReadOnly, &AnsiFileId);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while opening '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     Status = ArcRead(AnsiFileId, VaToPa(LoaderBlock->NlsData->AnsiCodePageData), AnsiFileSize, &BytesRead);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while reading '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     ArcClose(AnsiFileId);
 
@@ -418,11 +434,17 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
         strcat(FileName, OemFileName);
         Status = ArcOpen(FileName, OpenReadOnly, &OemFileId);
         if (Status != ESUCCESS)
+        {
+            WARN("Error while opening '%s', Status: %u\n", FileName, Status);
             goto Failure;
+        }
 
         Status = ArcRead(OemFileId, VaToPa(LoaderBlock->NlsData->OemCodePageData), OemFileSize, &BytesRead);
         if (Status != ESUCCESS)
+        {
+            WARN("Error while reading '%s', Status: %u\n", FileName, Status);
             goto Failure;
+        }
 
         ArcClose(OemFileId);
     }
@@ -432,11 +454,17 @@ WinLdrLoadNLSData(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock,
     strcat(FileName, LanguageFileName);
     Status = ArcOpen(FileName, OpenReadOnly, &LanguageFileId);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while opening '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     Status = ArcRead(LanguageFileId, VaToPa(LoaderBlock->NlsData->UnicodeCodePageData), LanguageFileSize, &BytesRead);
     if (Status != ESUCCESS)
+    {
+        WARN("Error while reading '%s', Status: %u\n", FileName, Status);
         goto Failure;
+    }
 
     ArcClose(LanguageFileId);
 
@@ -841,7 +869,7 @@ WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
     if (!NT_SUCCESS(Status))
         return FALSE;
 
-    // Insert entry into the list 
+    // Insert entry into the list
     if (!InsertInBootDriverList(BootDriverListHead, BootDriverEntry))
     {
         // It was already there, so delete our entry


### PR DESCRIPTION
At the moment, Freeloader is silent about the status, returned by Arc* functions, which makes FS debugging much harder. Fixing this
