### PR TITLE
[WIN32SS][NTGDI] Fix and improve font dumping

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1361,9 +1361,8 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
             Entry->NotEnum = (Characteristics & FR_NOT_ENUM);
             InsertTailList(&LoadedFontList, &Entry->ListEntry);
 
-            DPRINT("Font loaded: %s (%s), CharSet %u\n", Face->family_name, Face->style_name,
-                   FontGDI->CharSet);
-            DPRINT("Num glyphs: %d\n", Face->num_glyphs);
+            DPRINT("Font loaded: %s (%s), CharSet %u, Num glyphs %d\n",
+                   Face->family_name, Face->style_name, FontGDI->CharSet, Face->num_glyphs);
         }
 
         IntLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -387,7 +387,7 @@ VOID DumpFontEntry(PFONT_ENTRY FontEntry)
     const char *family_name;
     const char *style_name;
     FT_Face Face;
-    FONTGDI *FontGDI = FontEntry->Font;
+    PFONTGDI FontGDI = FontEntry->Font;
 
     if (!FontGDI)
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -409,17 +409,17 @@ VOID DumpFontEntry(PFONT_ENTRY FontEntry)
 
     DPRINT("family_name '%s', style_name '%s', FaceName '%wZ', StyleName '%wZ', FontGDI %p, "
            "FontObj %p, iUnique %lu, SharedFace %p, Face %p, CharSet %u, Filename '%S'\n",
-        family_name,
-        style_name,
-        &FontEntry->FaceName,
-        &FontEntry->StyleName,
-        FontGDI,
-        &FontGDI->FontObj,
-        FontGDI->iUnique,
-        FontGDI->SharedFace,
-        Face,
-        FontGDI->CharSet,
-        FontGDI->Filename);
+           family_name,
+           style_name,
+           &FontEntry->FaceName,
+           &FontEntry->StyleName,
+           FontGDI,
+           &FontGDI->FontObj,
+           FontGDI->iUnique,
+           FontGDI->SharedFace,
+           Face,
+           FontGDI->CharSet,
+           FontGDI->Filename);
 }
 
 VOID DumpFontList(PLIST_ENTRY Head)


### PR DESCRIPTION
## Purpose
Fix and improve font dumping.
JIRA issue: [CORE-16245](https://jira.reactos.org/browse/CORE-16245)

- `FontGDI->FontObj` is not a pointer.
- `"%s"` does null check, so we remove redundant null checks.
- Add `FaceName` and `StyleName` dumping.