### PR TITLE
[FREETYPE] Improve font rendering with font hinting workaround

### DIFF
--- a/sdk/lib/3rdparty/freetype/include/freetype/config/ftoption.h
+++ b/sdk/lib/3rdparty/freetype/include/freetype/config/ftoption.h
@@ -118,7 +118,7 @@ FT_BEGIN_HEADER
   /* rendering technology that produces excellent output without LCD       */
   /* filtering.                                                            */
   /*                                                                       */
-/* #define FT_CONFIG_OPTION_SUBPIXEL_RENDERING */
+#define FT_CONFIG_OPTION_SUBPIXEL_RENDERING
 
 
   /*************************************************************************/
@@ -654,7 +654,7 @@ FT_BEGIN_HEADER
   /* [1] https://www.microsoft.com/typography/cleartype/truetypecleartype.aspx */
   /*                                                                       */
 /* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  1         */
-#define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2
+/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2 */
 /* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  ( 1 | 2 ) */
 
 


### PR DESCRIPTION
## Purpose
This is a workaround of Font Hinting of FreeType.

JIRA issue: [CORE-15762](https://jira.reactos.org/browse/CORE-15762), [CORE-16232](https://jira.reactos.org/browse/CORE-16232)

It seems some fonts are blurry or in bad rendering because of FreeType Font Hinting implementation.
This PR is `subpixel2.patch` from CORE-16232, based on the following comment:
https://bugs.launchpad.net/ubuntu/+source/freetype/+bug/1722508/comments/29
