### PR TITLE
[CONFIGURE] Add MSVC compiler 19.22.27905 (VS Community 2019)

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -75,6 +75,7 @@ if defined ROS_ARCH (
     cl 2>&1 | find "19.16." > NUL && set VS_VERSION=15
     cl 2>&1 | find "19.20." > NUL && set VS_VERSION=16
     cl 2>&1 | find "19.21." > NUL && set VS_VERSION=16
+    cl 2>&1 | find "19.22." > NUL && set VS_VERSION=16
     if not defined VS_VERSION (
         echo Error: Visual Studio version too old ^(before 10 ^(2010^)^) or version detection failed.
         goto quit


### PR DESCRIPTION
Add detection for `Microsoft (R) C/C++ compiler 19.22.27905` which comes with VS Community 2019.

Builds ReactOS successfully and runs just fine:

![image](https://user-images.githubusercontent.com/578406/62162882-e2b02c80-b321-11e9-8730-b466cb6bf3cd.png)
