### PR TITLE
[FREELDR] xboxmem: Fix array out-of-bounds access

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pcmem.c
+++ b/boot/freeldr/freeldr/arch/i386/pcmem.c
@@ -35,8 +35,6 @@ DBG_DEFAULT_CHANNEL(MEMORY);
 #define ULONGLONG_ALIGN_UP_BY(size, align) \
     (ULONGLONG_ALIGN_DOWN_BY(((ULONGLONG)(size) + align - 1), align))
 
-#define MAX_BIOS_DESCRIPTORS 80ul
-
 BIOS_MEMORY_MAP PcBiosMemoryMap[MAX_BIOS_DESCRIPTORS];
 ULONG PcBiosMapCount;
 

--- a/boot/freeldr/freeldr/arch/i386/xboxmem.c
+++ b/boot/freeldr/freeldr/arch/i386/xboxmem.c
@@ -89,12 +89,13 @@ XboxMemInit(VOID)
     AvailableMemoryMb = InstalledMemoryMb;
 }
 
-FREELDR_MEMORY_DESCRIPTOR XboxMemoryMap[2];
+FREELDR_MEMORY_DESCRIPTOR XboxMemoryMap[MAX_BIOS_DESCRIPTORS + 1];
 
 PFREELDR_MEMORY_DESCRIPTOR
 XboxMemGetMemoryMap(ULONG *MemoryMapSize)
 {
     TRACE("XboxMemGetMemoryMap()\n");
+    /* FIXME: Obtain memory map via multiboot spec */
 
     /* Synthesize memory map */
 

--- a/boot/freeldr/freeldr/include/arch/pc/pcbios.h
+++ b/boot/freeldr/freeldr/include/arch/pc/pcbios.h
@@ -3,6 +3,8 @@
 
 #ifndef __ASM__
 
+#define MAX_BIOS_DESCRIPTORS 80
+
 typedef enum
 {
     // ACPI 1.0.


### PR DESCRIPTION
Memory map array should be large enough to fit additional descriptors.

JIRA issue: [CORE-16267](https://jira.reactos.org/browse/CORE-16267)