### PR TITLE
[WIN32SS][NTGDI][NTUSER] Make gusLanguageID USHORT

### DIFF
--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -21,9 +21,9 @@ extern BOOL APIENTRY IntEngEnter(PINTENG_ENTER_LEAVE EnterLeave,
 extern BOOL APIENTRY IntEngLeave(PINTENG_ENTER_LEAVE EnterLeave);
 
 extern HGDIOBJ StockObjects[];
-extern SHORT gusLanguageID;
+extern USHORT gusLanguageID;
 
-SHORT FASTCALL UserGetLanguageID(VOID);
+USHORT FASTCALL UserGetLanguageID(VOID);
 PVOID APIENTRY HackSecureVirtualMemory(IN PVOID,IN SIZE_T,IN ULONG,OUT PVOID *);
 VOID APIENTRY HackUnsecureVirtualMemory(IN PVOID);
 

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -26,7 +26,7 @@ NTSTATUS GdiThreadDestroy(PETHREAD Thread);
 
 PSERVERINFO gpsi = NULL; // Global User Server Information.
 
-SHORT gusLanguageID;
+USHORT gusLanguageID;
 PPROCESSINFO ppiScrnSaver;
 PPROCESSINFO gppiList = NULL;
 

--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -91,7 +91,7 @@ UserGetLanguageToggle(VOID)
     return dwValue;
 }
 
-SHORT
+USHORT
 FASTCALL
 UserGetLanguageID(VOID)
 {
@@ -137,7 +137,7 @@ UserGetLanguageID(VOID)
     ZwClose(KeyHandle);
   }
   TRACE("Language ID = %x\n",Ret);
-  return (SHORT) Ret;
+  return (USHORT) Ret;
 }
 
 HBRUSH


### PR DESCRIPTION
## Purpose
I think every language ID is an unsigned integer.
JIRA issue: N/A

## Proposed changes
- Make `gusLanguageID` unsigned.
- Make the return value type of `UserGetLanguageID` unsigned.
