### PR TITLE
[USBAUDIO] Fix compilation issues

### DIFF
--- a/drivers/usb/usbaudio/filter.c
+++ b/drivers/usb/usbaudio/filter.c
@@ -326,7 +326,6 @@ CountTopologyComponents(
     PUSB_AUDIO_CONTROL_INPUT_TERMINAL_DESCRIPTOR InputTerminalDescriptor;
     PUSB_AUDIO_CONTROL_FEATURE_UNIT_DESCRIPTOR FeatureUnitDescriptor;
     PUSB_AUDIO_CONTROL_MIXER_UNIT_DESCRIPTOR MixerUnitDescriptor;
-    PUSB_AUDIO_CONTROL_SELECTOR_UNIT_DESCRIPTOR SelectorUnitDescriptor;
     ULONG NodeCount = 0, Length, Index;
     ULONG DescriptorCount = 0;
     UCHAR Value;
@@ -387,7 +386,6 @@ CountTopologyComponents(
                     }
                     else if (InputTerminalDescriptor->bDescriptorSubtype == 0x05 /* SELECTOR_UNIT */)
                     {
-                        SelectorUnitDescriptor = (PUSB_AUDIO_CONTROL_SELECTOR_UNIT_DESCRIPTOR)InputTerminalDescriptor;
                         DescriptorCount++;
                         NodeCount++;
                     }

--- a/drivers/usb/usbaudio/pin.c
+++ b/drivers/usb/usbaudio/pin.c
@@ -697,7 +697,7 @@ InitStreamPin(
 ULONG
 GetDataRangeIndexForFormat(
     IN PKSDATARANGE ConnectionFormat,
-    IN PKSDATARANGE * DataRanges,
+    IN const PKSDATARANGE * DataRanges,
     IN ULONG DataRangesCount)
 {
     ULONG Index;


### PR DESCRIPTION
## Purpose

Fix gcc compilation issues of usbaudio driver. With this fixes, it's fully compilable.
If you want to test it, you need to add `add_subdirectory(usbaudio)` in `drivers/usb/CMakeLists.txt` and `usbaudio.sys = 1,,,,,,,4,,,,1,4` in `[SourceDiskFiles]` section of `boot/bootdata/txtsetup.sif`.

JIRA issue: None

## Proposed changes

- Remove declaration and value of unused `SelectorUnitDescriptor` variable of `CountTopologyComponents` function in `drivers/usb/usbaudio/filter.c`;
- Add missing `const` to the 2nd argument of `GetDataRangeIndexForFormat` function in `drivers/usb/usbaudio/pin.c`.

## Result
![usbaudio](https://user-images.githubusercontent.com/26385117/62320496-fafe8380-b4a8-11e9-8929-932706dd7fb7.png)