### PR TITLE
[FREELDR] Update ACPI Extended Attributes support, to 6.3

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pcmem.c
+++ b/boot/freeldr/freeldr/arch/i386/pcmem.c
@@ -302,7 +302,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
 
         if (Regs.x.ecx == 0)
         {
-            TRACE("Discard empty entry. (would-be-PcBiosMapCount = %lu)\n",
+            TRACE("Discarding empty entry. (would-be-PcBiosMapCount = %lu)\n",
                   PcBiosMapCount);
             goto nextRange;
         }
@@ -332,13 +332,18 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
 
         if (((PBIOS_MEMORY_MAP)BIOSCALLBUFFER)->ExtendedAttributes.Enabled_Reserved == 0)
         {
-            WARN("Discard disabled/invalid entry. (would-be-PcBiosMapCount = %lu)\n",
+            WARN("Discarding disabled/invalid entry. (would-be-PcBiosMapCount = %lu)\n",
                  PcBiosMapCount);
             /* This unlikely case was correct between ACPI 3.0 and 4.0, so assume all is fine.
              * Unless we would be ready to drop ACPI 3.0 compatibility.
              */
             goto nextRange;
         }
+
+        /*
+         * Other deprecated ExtendedAttributes flags such as NonVolatile_Deprecated_Reserved
+         * or SlowAccess_Deprecated_Reserved are simply ignored.
+         */
 
         /* Copy data to global buffer */
         RtlCopyMemory(&PcBiosMemoryMap[PcBiosMapCount], (PVOID)BIOSCALLBUFFER, sizeof(BIOS_MEMORY_MAP));
@@ -362,7 +367,7 @@ PcMemGetBiosMemoryMap(PFREELDR_MEMORY_DESCRIPTOR MemoryMap, ULONG MaxMemoryMapSi
 
         if (PcBiosMemoryMap[PcBiosMapCount].Length == 0)
         {
-            TRACE("Discard empty range. (would-be-PcBiosMapCount = %lu, BaseAddress = 0x%llx, Length = 0)\n",
+            TRACE("Discarding empty range. (would-be-PcBiosMapCount = %lu, BaseAddress = 0x%llx, Length = 0)\n",
                   PcBiosMapCount, PcBiosMemoryMap[PcBiosMapCount].BaseAddress);
             goto nextRange;
         }

--- a/boot/freeldr/freeldr/include/arch/pc/pcbios.h
+++ b/boot/freeldr/freeldr/include/arch/pc/pcbios.h
@@ -46,13 +46,19 @@ typedef struct
 
         struct
         {
-            // Bit 0. ACPI 3.0. As of ACPI 4.0, became "Reserved -> must be 1".
+            // Bit 0. ACPI 3.0.
+            // As of ACPI 4.0, became "Reserved -> must be 1".
             ULONG Enabled_Reserved : 1;
-            // Bit 1. ACPI 3.0. As of ACPI 6.1, became "Unimplemented -> Deprecated".
-            ULONG NonVolatile_Deprecated : 1;
-            // Bit 2. ACPI 4.0. As of ACPI 6.1, became "Unimplemented -> Deprecated".
-            ULONG SlowAccess_Deprecated : 1;
-            // Bit 3. ACPI 4.0. ACPI 5.0-A added "Used only on PC-AT BIOS" (not UEFI).
+            // Bit 1. ACPI 3.0.
+            // As of ACPI 6.1, became "Unimplemented -> Deprecated".
+            // As of ACPI 6.3, became "Reserved -> must be 0".
+            ULONG NonVolatile_Deprecated_Reserved : 1;
+            // Bit 2. ACPI 4.0.
+            // As of ACPI 6.1, became "Unimplemented -> Deprecated".
+            // As of ACPI 6.3, became "Reserved -> must be 0".
+            ULONG SlowAccess_Deprecated_Reserved : 1;
+            // Bit 3. ACPI 4.0.
+            // ACPI 5.0-A added "Used only on PC-AT BIOS" (not UEFI).
             ULONG ErrorLog : 1;
             // Bits 4-31. ACPI 3.0.
             ULONG Reserved : 28;


### PR DESCRIPTION
## Purpose

Update BIOS_MEMORY_MAP and PcMemGetBiosMemoryMap(), to ACPI 6.3 from 6.2-A.

