### PR TITLE
[DESK] Change the property "Screensaver" page on text change

### DIFF
--- a/dll/cpl/desk/screensaver.c
+++ b/dll/cpl/desk/screensaver.c
@@ -747,7 +747,8 @@ ScreenSaverPageProc(HWND hwndDlg,
 
                 case IDC_SCREENS_TIMEDELAY:
                 {
-                    PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
+                    if (command == EN_CHANGE)
+                        PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
                     break;
                 }
 


### PR DESCRIPTION
## Purpose
Currently the EDITTEXT control receives EN_CHANGE/EN_UPDATE notification codes in a bad manner. These notifications must be sent only when the user takes action to the control although the notifications are always sent even without the user's prompt!

This is merely a temporary fix for **desk.cpl**. When James Tabor (or whoever else) will provide a fix for the regression, the final patch for **desk.cpl** is to check properly for EN_CHANGE.

**JIRA Issue:** [CORE-16280](https://jira.reactos.org/browse/CORE-16280)

**EDIT 1 -** [`344d559`](https://github.com/reactos/reactos/commit/344d5599351c5abae618dae9693a655cdc34dab0) has been finally merged. Here it's the final proper fix.