### PR TITLE
Fix two ASSERTS in win32ss\gdi\ntgdi\region.c

### DIFF
--- a/win32ss/gdi/ntgdi/region.c
+++ b/win32ss/gdi/ntgdi/region.c
@@ -2084,7 +2084,7 @@ REGION_bXformRgn(
     _In_ PMATRIX pmx)
 {
     XFORMOBJ xo;
-    ULONG i, j, cjSize;
+    ULONG i, cjSize;
     PPOINT ppt;
     PULONG pcPoints;
     RECT rect;
@@ -2149,11 +2149,8 @@ REGION_bXformRgn(
             /* Loop all rects in the region */
             for (i = 0; i < prgn->rdh.nCount - 1; i++)
             {
-                for (j = i; i < prgn->rdh.nCount; i++)
-                {
-                    NT_ASSERT(prgn->Buffer[i].top < prgn->Buffer[i].bottom);
-                    NT_ASSERT(prgn->Buffer[j].top >= prgn->Buffer[i].top);
-                }
+                NT_ASSERT(prgn->Buffer[i].top <= prgn->Buffer[i].bottom);
+                NT_ASSERT(prgn->Buffer[i + 1].top >= prgn->Buffer[i].top);
             }
 
             return TRUE;


### PR DESCRIPTION
CORE-15992

## Fix two Region.c Asserts

_Correct code for nested loops and comparison operator_

JIRA issue: [CORE-15992](https://jira.reactos.org/browse/CORE-15992)

Testbot runs:
https://reactos.org/testman/compare.php?ids=68618,68620
https://reactos.org/testman/compare.php?ids=68619,68621
