### PR TITLE
[INF] Added BTRFS inf to remove unknown device

### DIFF
--- a/media/inf/CMakeLists.txt
+++ b/media/inf/CMakeLists.txt
@@ -5,6 +5,7 @@ list(APPEND INF_FILES
     battery.inf
     bda.inf
     bth.inf
+    btrfs.inf
     c_image.inf
     cdrom.inf
     cpu.inf

--- a/media/inf/btrfs.inf
+++ b/media/inf/btrfs.inf
@@ -1,0 +1,111 @@
+;;;
+;;; WinBtrfs
+;;;
+;;;
+;;; Copyright (c) 2016-19 Mark Harmstone
+;;;
+
+[Version]
+Signature   = "$Windows NT$"
+Class       = Volume
+ClassGuid   = {71a27cdd-812a-11d0-bec7-08002be2092f}
+Provider    = %Me%
+DriverVer   = 06/08/2019,1.3.0.0
+CatalogFile = btrfs.cat
+
+[DestinationDirs]
+DefaultDestDir          = 12
+Btrfs.DriverFiles       = 12            ;%windir%\system32\drivers
+Btrfs.DllFiles          = 11            ;%windir%\system32
+
+;;
+;; Default install sections
+;;
+
+[DefaultInstall]
+OptionDesc  = %ServiceDescription%
+CopyFiles   = Btrfs.DriverFiles,Btrfs.DllFiles
+RegisterDlls = shellbtrfs
+CopyINF     = btrfs.inf
+
+[DefaultInstall.Services]
+AddService  = %ServiceName%,0x802,Btrfs.Service
+
+[Manufacturer]
+%Me%=Standard,NTamd64,NTx86
+
+[Standard.NTamd64]
+%VolumeName% = Btrfs_Install, BtrfsVolume
+%ControllerName% = Btrfs_Install, ROOT\btrfs
+%ControllerName% = Btrfs_Install, ROOT\btrfs
+%ControllerName% = Btrfs_Install, DETECTED\BTRFS
+
+[Standard.NTx86]
+%VolumeName% = Btrfs_Install, BtrfsVolume
+%ControllerName% = Btrfs_Install, ROOT\btrfs
+%ControllerName% = Btrfs_Install, DETECTED\BTRFS
+
+[Btrfs_Install]
+OptionDesc   = %ServiceDescription%
+
+[Btrfs_Install.Services]
+AddService  = %ServiceName%,2,Btrfs.Service
+
+;;
+;; Default uninstall sections
+;;
+
+[DefaultUninstall]
+UnregisterDlls = shellbtrfs
+DelFiles   = Btrfs.DriverFiles,Btrfs.DllFiles
+
+[DefaultUninstall.Services]
+DelService = %ServiceName%,0x200      ;Ensure service is stopped before deleting
+
+;
+; Services Section
+;
+
+[Btrfs.Service]
+DisplayName      = %ServiceName%
+Description      = %ServiceDescription%
+ServiceBinary    = %12%\%DriverName%.sys    ;%windir%\system32\drivers\
+ServiceType      = 1
+StartType        = 1                        ;SERVICE_SYSTEM_START
+ErrorControl     = 1
+LoadOrderGroup   = "File System"
+
+[shellbtrfs]
+11,,shellbtrfs.dll,1
+
+;
+; Copy Files
+;
+
+[Btrfs.DriverFiles]
+%DriverName%.sys
+
+[Btrfs.DllFiles]
+shellbtrfs.dll
+ubtrfs.dll
+mkbtrfs.exe
+
+
+[SourceDisksNames.x86]
+1 = %DiskId1%,,,\x86
+
+[SourceDisksNames.amd64]
+1 = %DiskId1%,,,\x64
+
+;;
+;; String Section
+;;
+
+[Strings]
+Me                      = "Mark Harmstone"
+ServiceDescription      = "Btrfs driver"
+ServiceName             = "btrfs"
+DriverName              = "btrfs"
+DiskId1                 = "Btrfs Device Installation Disk"
+VolumeName              = "Btrfs volume"
+ControllerName          = "Btrfs controller"


### PR DESCRIPTION
## Purpose

Added brtfs.inf 

JIRA issue: [CORE-15928](https://jira.reactos.org/browse/CORE-15928)

## Proposed changes

I added the inf from the btrfs driver's github to our repository so that we no longer have it listed as an unknown device.

Only difference between this and the original is that I removed the copy files (as they are already installed) and I added the compatible device ID of `DETECTED\BTRFS` because this is what ReactOS listed as the compatible ID.

Before:
![image](https://user-images.githubusercontent.com/17304943/62446376-677eba00-b717-11e9-8fc8-223ed4770f35.png)


After:
![image](https://user-images.githubusercontent.com/17304943/62446138-cbed4980-b716-11e9-89a1-ec95822951e7.png)


