### PR TITLE
[WIN32SS][NTUSER] Fix default menu item font weight

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -380,7 +380,7 @@ MenuInit(VOID)
       ERR("MenuInit(): CreateFontIndirectW(hMenuFont) failed!\n");
       return FALSE;
     }
-    ncm.lfMenuFont.lfWeight = max(ncm.lfMenuFont.lfWeight + 300, 1000);
+    ncm.lfMenuFont.lfWeight = min(ncm.lfMenuFont.lfWeight + (FW_BOLD - FW_NORMAL), FW_HEAVY);
     ghMenuFontBold = GreCreateFontIndirectW(&ncm.lfMenuFont);
     if (ghMenuFontBold == NULL)
     {


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16294](https://jira.reactos.org/browse/CORE-16294)
We had added "Arial Black" font, so a request for heavy weight font will be realized as it is. This PR will fix font weight (`FW_*`) calculation of default menu items.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/62469244-d3722880-b7d2-11e9-8817-2db0ffa417cf.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/62469243-d3722880-b7d2-11e9-982f-06692396e4ac.png)
