### PR TITLE
[SYSSETUP] Caption of 2nd stage ReactOS Setup is too heavy

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -82,7 +82,7 @@ CreateTitleFont(VOID)
     HDC hdc;
     HFONT hFont;
 
-    LogFont.lfWeight = FW_HEAVY;
+    LogFont.lfWeight = FW_BOLD;
     wcscpy(LogFont.lfFaceName, L"MS Shell Dlg");
 
     hdc = GetDC(NULL);


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16295](https://jira.reactos.org/browse/CORE-16295)
BEFORE:
![too-heavy](https://user-images.githubusercontent.com/2107452/62506147-66927900-b83a-11e9-9153-be5361a8378a.png)
AFTER:
![after-2](https://user-images.githubusercontent.com/2107452/62506146-66927900-b83a-11e9-9352-e194801a02a6.png)