### PR TITLE
[WIN32K:NTGDI] REGION_bXformRgn(): Restore check of last rectangle. CORE-15992

### DIFF
--- a/win32ss/gdi/ntgdi/region.c
+++ b/win32ss/gdi/ntgdi/region.c
@@ -2135,6 +2135,7 @@ REGION_bXformRgn(
             {
                 /* Make sure the rect is well-ordered after the xform */
                 RECTL_vMakeWellOrdered(&prgn->Buffer[i]);
+                NT_ASSERT(prgn->Buffer[i].top <= prgn->Buffer[i].bottom);
 
                 /* Update bounds */
                 if (!RECTL_bUnionRect(&prgn->rdh.rcBound,
@@ -2149,7 +2150,6 @@ REGION_bXformRgn(
             /* Loop all rects in the region */
             for (i = 0; i < prgn->rdh.nCount - 1; i++)
             {
-                NT_ASSERT(prgn->Buffer[i].top <= prgn->Buffer[i].bottom);
                 NT_ASSERT(prgn->Buffer[i + 1].top >= prgn->Buffer[i].top);
             }
 


### PR DESCRIPTION
## Purpose

"Do not fix no regression"...
See #1798.

Addendum to c1ec0d92e24c9a27eb5ed2eae78268dda06626ad.

JIRA issue: [CORE-15992](https://jira.reactos.org/browse/CORE-15992)
