### PR TITLE
[NTFS] Handling of $ATTRIBUTE_LIST

### DIFF
--- a/drivers/filesystems/ntfs/ntfs.h
+++ b/drivers/filesystems/ntfs/ntfs.h
@@ -300,6 +300,17 @@ typedef struct
     };
 } NTFS_ATTR_RECORD, *PNTFS_ATTR_RECORD;
 
+typedef struct
+{
+    ULONG Type;
+    USHORT Length;
+    UCHAR NameLength;
+    UCHAR NameOffset;
+    ULONGLONG StartingVCN;
+    ULONGLONG MFTIndex;
+    USHORT Instance;
+} NTFS_ATTRIBUTE_LIST_ITEM, *PNTFS_ATTRIBUTE_LIST_ITEM;
+
 // The beginning and length of an attribute record are always aligned to an 8-byte boundary,
 // relative to the beginning of the file record.
 #define ATTR_RECORD_ALIGNMENT 8
@@ -486,6 +497,7 @@ typedef struct _NTFS_ATTR_CONTEXT
     ULONGLONG            CacheRunCurrentOffset;
     LARGE_MCB           DataRunsMCB;
     ULONGLONG           FileMFTIndex;
+    ULONGLONG           FileOwnerMFTIndex; /* If attribute list attribute, reference the original file */
     PNTFS_ATTR_RECORD    pRecord;
 } NTFS_ATTR_CONTEXT, *PNTFS_ATTR_CONTEXT;
 
@@ -534,8 +546,9 @@ typedef struct _FIND_ATTR_CONTXT
     PNTFS_ATTR_RECORD FirstAttr;
     PNTFS_ATTR_RECORD CurrAttr;
     PNTFS_ATTR_RECORD LastAttr;
-    PNTFS_ATTR_RECORD NonResidentStart;
-    PNTFS_ATTR_RECORD NonResidentEnd;
+    PNTFS_ATTRIBUTE_LIST_ITEM NonResidentStart;
+    PNTFS_ATTRIBUTE_LIST_ITEM NonResidentEnd;
+    PNTFS_ATTRIBUTE_LIST_ITEM NonResidentCur;
     ULONG Offset;
 } FIND_ATTR_CONTXT, *PFIND_ATTR_CONTXT;
 
@@ -658,6 +671,14 @@ GetLastClusterInDataRun(PDEVICE_EXTENSION Vcb,
 PFILENAME_ATTRIBUTE
 GetBestFileNameFromRecord(PDEVICE_EXTENSION Vcb,
                           PFILE_RECORD_HEADER FileRecord);
+
+NTSTATUS
+FindFirstAttributeListItem(PFIND_ATTR_CONTXT Context,
+                           PNTFS_ATTRIBUTE_LIST_ITEM *Item);
+
+NTSTATUS
+FindNextAttributeListItem(PFIND_ATTR_CONTXT Context,
+                          PNTFS_ATTRIBUTE_LIST_ITEM *Item);
 
 NTSTATUS
 FindFirstAttribute(PFIND_ATTR_CONTXT Context,


### PR DESCRIPTION
## Purpose

Trying to implement proper handling of $ATTRIBUTE_LIST attribute, which references other MFT records containing attributes for the files

JIRA issue: [CORE-13575](https://jira.reactos.org/browse/CORE-13575)

## Proposed changes

- Lookup attributes into $ATTRIBUTE_LIST and referenced into another MFT record when not found.

## TODO

Handle the case where the non-resident attribute is split across several file records (like it happens for test file in image attached in the issue)

There are two records in the $ATTRIBUTE_LIST with same AttributeType and name, but StartingVCN differs. RunLists for the other records need to be parsed too (and first data run is relative to cluster 0 again).
