### PR TITLE
[ROSSYM] Fix "seeking to" typo

### DIFF
--- a/boot/freeldr/freeldr/lib/fs/ntfs.c
+++ b/boot/freeldr/freeldr/lib/fs/ntfs.c
@@ -946,7 +946,7 @@ const DEVVTBL* NtfsMount(ULONG DeviceId)
     Status = ArcSeek(DeviceId, &Position, SeekAbsolute);
     if (Status != ESUCCESS)
     {
-        FileSystemError("Failed to seek to Master File Table record.");
+        FileSystemError("Failed to seek Master File Table record.");
         FrLdrTempFree(Volume->MasterFileTable, TAG_NTFS_MFT);
         FrLdrTempFree(Volume, TAG_NTFS_VOLUME);
         return NULL;

--- a/sdk/lib/rossym/fromfile.c
+++ b/sdk/lib/rossym/fromfile.c
@@ -41,7 +41,7 @@ RosSymCreateFromFile(PVOID FileContext, PROSSYM_INFO *RosSymInfo)
   /* Load NT headers */
   if (! RosSymSeekFile(FileContext, DosHeader.e_lfanew))
     {
-      DPRINT1("Failed seeking to NT headers\n");
+      DPRINT1("Failed seeking NT headers\n");
       return FALSE;
     }
   if (! RosSymReadFile(FileContext, &NtHeaders, sizeof(IMAGE_NT_HEADERS)))
@@ -59,7 +59,7 @@ RosSymCreateFromFile(PVOID FileContext, PROSSYM_INFO *RosSymInfo)
   if (! RosSymSeekFile(FileContext, (char *) IMAGE_FIRST_SECTION(&NtHeaders) -
                                     (char *) &NtHeaders + DosHeader.e_lfanew))
     {
-      DPRINT1("Failed seeking to section headers\n");
+      DPRINT1("Failed seeking section headers\n");
       return FALSE;
     }
   SectionHeaders = RosSymAllocMem(NtHeaders.FileHeader.NumberOfSections
@@ -101,7 +101,7 @@ RosSymCreateFromFile(PVOID FileContext, PROSSYM_INFO *RosSymInfo)
   if (! RosSymSeekFile(FileContext, SectionHeader->PointerToRawData))
     {
       RosSymFreeMem(SectionHeaders);
-      DPRINT1("Failed seeking to section data\n");
+      DPRINT1("Failed seeking section data\n");
       return FALSE;
     }
   RosSymFreeMem(SectionHeaders);

--- a/sdk/lib/rossym_new/fromfile.c
+++ b/sdk/lib/rossym_new/fromfile.c
@@ -45,7 +45,7 @@ RosSymCreateFromFile(PVOID FileContext, PROSSYM_INFO *RosSymInfo)
     /* Load NT headers */
     if (! RosSymSeekFile(FileContext, DosHeader.e_lfanew))
     {
-        werrstr("Failed seeking to NT headers\n");
+        werrstr("Failed seeking NT headers\n");
         return FALSE;
     }
     if (! RosSymReadFile(FileContext, &NtHeaders, sizeof(IMAGE_NT_HEADERS)))
@@ -74,7 +74,7 @@ RosSymCreateFromFile(PVOID FileContext, PROSSYM_INFO *RosSymInfo)
     if (! RosSymSeekFile(FileContext, (char *) IMAGE_FIRST_SECTION(&NtHeaders) -
                          (char *) &NtHeaders + DosHeader.e_lfanew))
     {
-        werrstr("Failed seeking to section headers\n");
+        werrstr("Failed seeking section headers\n");
         return FALSE;
     }
     DPRINT("Alloc section headers\n");


### PR DESCRIPTION
## Purpose

Follow-up to PR 1767.

NB:
['seek to'](https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=seek+to) cases would be for another time...