### PR TITLE
[WIN32SS][NTUSER] Fix popup menu window styles

### DIFF
--- a/win32ss/user/ntuser/class.c
+++ b/win32ss/user/ntuser/class.c
@@ -53,7 +53,7 @@ REGISTER_SYSCLASS DefaultServerClasses[] =
     ICLS_SWITCH
   },
   { ((PWSTR)((ULONG_PTR)(WORD)(0x8000))),
-    CS_DBLCLKS|CS_SAVEBITS,
+    CS_DBLCLKS|CS_SAVEBITS|CS_DROPSHADOW,
     NULL, // Use User32 procs
     sizeof(LONG),
     (HICON)OCR_NORMAL,

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2807,7 +2807,7 @@ static BOOL MENU_InitPopup( PWND pWndOwner, PMENU menu, UINT flags )
 
     RtlZeroMemory(&WindowName, sizeof(WindowName));
     RtlZeroMemory(&Cs, sizeof(Cs));
-    Cs.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_BORDER;
+    Cs.style = WS_POPUP | WS_CLIPSIBLINGS | WS_BORDER;
     Cs.dwExStyle = ex_style;
     Cs.hInstance = hModClient; // hModuleWin; // Server side winproc!
     Cs.lpszName = (LPCWSTR) &WindowName;

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2801,7 +2801,7 @@ static BOOL MENU_InitPopup( PWND pWndOwner, PMENU menu, UINT flags )
     menu->spwndNotify = pWndOwner;
 
     if (flags & TPM_LAYOUTRTL || pWndOwner->ExStyle & WS_EX_LAYOUTRTL)
-       ex_style = WS_EX_LAYOUTRTL;
+       ex_style |= WS_EX_LAYOUTRTL;
 
     RtlInitUnicodeString(&ClassName, WC_MENU);
 

--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2794,7 +2794,7 @@ static BOOL MENU_InitPopup( PWND pWndOwner, PMENU menu, UINT flags )
     CREATESTRUCTW Cs;
     LARGE_STRING WindowName;
     UNICODE_STRING ClassName;
-    DWORD ex_style = WS_EX_TOOLWINDOW;
+    DWORD ex_style = WS_EX_PALETTEWINDOW | WS_EX_DLGMODALFRAME;
 
     TRACE("owner=%p hmenu=%p\n", pWndOwner, menu);
 
@@ -2803,12 +2803,11 @@ static BOOL MENU_InitPopup( PWND pWndOwner, PMENU menu, UINT flags )
     if (flags & TPM_LAYOUTRTL || pWndOwner->ExStyle & WS_EX_LAYOUTRTL)
        ex_style = WS_EX_LAYOUTRTL;
 
-    ClassName.Buffer = WC_MENU;
-    ClassName.Length = 0;
+    RtlInitUnicodeString(&ClassName, WC_MENU);
 
     RtlZeroMemory(&WindowName, sizeof(WindowName));
     RtlZeroMemory(&Cs, sizeof(Cs));
-    Cs.style = WS_POPUP;
+    Cs.style = WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_BORDER;
     Cs.dwExStyle = ex_style;
     Cs.hInstance = hModClient; // hModuleWin; // Server side winproc!
     Cs.lpszName = (LPCWSTR) &WindowName;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16244](https://jira.reactos.org/browse/CORE-16244)

- Fix the class style, the window style and the extended style of the popup menu window.

I have investigated and confirmed these style values by WinHier in Win2k3.