### PR TITLE
[WIN32SS][NTGDI] Registry-based font management

### DIFF
--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -62,6 +62,7 @@ typedef struct GDI_LOAD_FONT
     DWORD               Characteristics;
     UNICODE_STRING      RegValueName;
     BOOL                IsTrueType;
+    BYTE                CharSet;
     PFONT_ENTRY_MEM     PrivateEntry;
 } GDI_LOAD_FONT, *PGDI_LOAD_FONT;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1756,8 +1756,8 @@ IntLoadFontsInRegistry(VOID)
         Length = pInfo->DataLength / sizeof(WCHAR);
         pchPath[Length] = UNICODE_NULL; /* truncate */
 
-        /* Load font(s) with writing registry */
-        dwFlags = AFRX_WRITE_REGISTRY;
+        /* Load font(s) without writing registry */
+        dwFlags = 0;
         if (PathIsRelativeW(pchPath))
         {
             Status = RtlStringCbPrintfW(szPath, sizeof(szPath),

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1646,7 +1646,10 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
 
             if (pFileName)
             {
-                pFileName++;
+                if (!(dwFlags & AFRX_ALTERNATIVE_PATH))
+                {
+                    pFileName++;
+                }
                 DataSize = (wcslen(pFileName) + 1) * sizeof(WCHAR);
                 ZwSetValueKey(KeyHandle, &LoadFont.RegValueName, 0, REG_SZ,
                               pFileName, DataSize);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1687,7 +1687,7 @@ IntLoadFontsInRegistry(VOID)
     KEY_FULL_INFORMATION            KeyFullInfo;
     ULONG                           i, Length;
     UNICODE_STRING                  FontTitleW, FileNameW;
-    BYTE                            InfoBuffer[128];
+    BYTE                            InfoBuffer[MAX_PATH + 128];
     PKEY_VALUE_FULL_INFORMATION     pInfo;
     LPWSTR                          pchPath;
     BOOLEAN                         Success;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1532,7 +1532,7 @@ NameFromCharSet(BYTE CharSet)
 {
     switch (CharSet)
     {
-        case ANSI_CHARSET: return L"Ansi";
+        case ANSI_CHARSET: return L"ANSI";
         case DEFAULT_CHARSET: return L"Default";
         case SYMBOL_CHARSET: return L"Symbol";
         case SHIFTJIS_CHARSET: return L"Shift_JIS";

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1537,7 +1537,7 @@ NameFromCharSet(BYTE CharSet)
         case SYMBOL_CHARSET: return L"Symbol";
         case SHIFTJIS_CHARSET: return L"Shift_JIS";
         case HANGUL_CHARSET: return L"Hangul";
-        case GB2312_CHARSET: return L"GB2312";
+        case GB2312_CHARSET: return L"GB 2312";
         case CHINESEBIG5_CHARSET: return L"Chinese Big5";
         case OEM_CHARSET: return L"OEM";
         case JOHAB_CHARSET: return L"Johab";

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -686,7 +686,14 @@ InitFontSupport(VOID)
         return FALSE;
     }
 
-    IntLoadFontsInRegistry();
+    if (!IntLoadFontsInRegistry())
+    {
+        DPRINT1("Fonts registry is empty.\n");
+
+        /* Load font(s) with writing registry */
+        IntLoadSystemFonts();
+    }
+
     IntLoadFontSubstList(&g_FontSubstListHead);
 
 #if DBG
@@ -1885,16 +1892,7 @@ IntLoadFontsInRegistry(VOID)
         ExFreePoolWithTag(InfoBuffer, TAG_FONT);
     }
 
-    if (KeyFullInfo.Values == 0 || nFontCount == 0)
-    {
-        DPRINT1("Fonts registry is empty.\n");
-
-        /* Load font(s) with writing registry */
-        IntLoadSystemFonts();
-        return TRUE;
-    }
-
-    return NT_SUCCESS(Status);
+    return (KeyFullInfo.Values != 0 && nFontCount != 0);
 }
 
 HANDLE FASTCALL

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -100,6 +100,9 @@ TEXTOBJ_UnlockText(PLFONT plfnt)
     LFONT_ShareUnlockFont(plfnt);
 }
 
+/* dwFlags for IntGdiAddFontResourceEx */
+#define AFRX_WRITE_REGISTRY 0x1
+#define AFRX_ALTERNATIVE_PATH 0x2
 
 PTEXTOBJ FASTCALL RealizeFontInit(HFONT);
 NTSTATUS FASTCALL TextIntRealizeFont(HFONT,PTEXTOBJ);
@@ -111,8 +114,11 @@ BOOL FASTCALL IntIsFontRenderingEnabled(VOID);
 VOID FASTCALL IntEnableFontRendering(BOOL Enable);
 ULONG FASTCALL FontGetObject(PTEXTOBJ TextObj, ULONG Count, PVOID Buffer);
 VOID FASTCALL IntLoadSystemFonts(VOID);
+BOOL FASTCALL IntLoadFontsInRegistry(VOID);
 VOID FASTCALL IntGdiCleanupPrivateFontsForProcess(VOID);
 INT FASTCALL IntGdiAddFontResource(PUNICODE_STRING FileName, DWORD Characteristics);
+INT FASTCALL IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
+                                     DWORD dwFlags);
 HANDLE FASTCALL IntGdiAddFontMemResource(PVOID Buffer, DWORD dwSize, PDWORD pNumAdded);
 BOOL FASTCALL IntGdiRemoveFontMemResource(HANDLE hMMFont);
 ULONG FASTCALL ftGdiGetGlyphOutline(PDC,WCHAR,UINT,LPGLYPHMETRICS,ULONG,PVOID,LPMAT2,BOOL);


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16269](https://jira.reactos.org/browse/CORE-16269)

- Add `IntGdiAddFontResourceEx` function that is extended from `IntGdiAddFontResource`, in order to add `dwFlags` parameter.
- Add `IntLoadFontsInRegistry` function that will load the fonts from registry info.
- If loading from registry failed, `IntLoadSystemFonts` will be called.
- Use `IntLoadFontsInRegistry` rather than `IntLoadSystemFonts` in the OS startup.
- Add `NameFromCharSet` function.
- Append `" (CharSetName)"` to registry value name if not TrueType.