### PR TITLE
[COMCTL32] Fix Properties dialog position

### DIFF
--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -269,149 +269,6 @@ public:
         return PSNRET_NOERROR;
     }
 };
- 
- /**
-*    Autor:      Jose Carlos Jesus 
-*    email:      zecarlos1957@hotmail.com
-*    Project:    ReactOS  
-*    date:       12-08-2019   
-*    input - 
-*               LPARAM lParam : Pointer to Resource Dialog TEMPLATE 
-*               DWORD id :       Resource ID from object to be extracted
-*                                  id = 0 -> Dialog rectangle
-*                                  id = # -> Object rectangle
-*               LPVOID data:    Pointer to buffer that receive data
-*
-*    Output    return pointer to RECT object or NULL if ID not found
-*                     If object not found, show a Dialog with Title, ClassName, ResourceID,
-*                     and Rectangle structure from all objects inside this Resource
-*
-*      (NOTE) For now, just work with DLGTEMPLATEEX resource type
-*/
-
-WORD *TEMPLATE_ExtractRect(LPARAM lParam, DWORD id, LPVOID data)
-{
-    WCHAR buf[1024];
-    WCHAR *aux = buf;
-    WORD _id;
-    WORD len;
-    RECT rc;
-    WORD *ptr = reinterpret_cast<WORD*>(lParam);
-    DWORD signature = *((DWORD*)ptr);
-
-    if(signature != 0xffff0001)
-        return NULL;
-
-    ((*ptr == 1) && (*(ptr + 1) == 0xffff)) ? ptr += 7 : ptr += 4;
-    BOOL font = ((*ptr++ & DS_SETFONT) != 0) ;
-    WORD nItems = *ptr++;
-
-    rc.left = *ptr;
-    rc.top = *(ptr + 1);
-    rc.right = *(ptr + 2);
-    rc.bottom = *(ptr + 3);
-
-    if(id == 0)
-    {
-        ((RECT *)data)->left = *ptr;
-        ((RECT *)data)->top = *(ptr + 1);
-        ((RECT *)data)->right = *(ptr + 2);
-        ((RECT *)data)->bottom = *(ptr + 3);
-        return ptr;
-    }
-
-    ptr += 4;
-
-    if (*ptr == 0)               /// No menu id
-        ptr++;           
-    else if (*ptr == 0xffff)     /// menu # id
-        ptr += 2;        
-    else 
-        ptr += (lstrlenW((WCHAR*)ptr) + 1);
-
-    if (*ptr == 0)               /// Default Dialog ClassName id
-        ptr++;  
-    else if(*ptr == 0xffff)      /// ClassName # id
-        ptr += 2;   
-    else                         /// Unicode ClassName
-        ptr += (lstrlenW((WCHAR*)ptr) + 1);
-
-    if (*ptr == 0)               /// No WindowTitle
-        ptr++;
-    else                         /// Unicode WindowTitle
-    {
-        lstrcpyW(aux, (WCHAR*)ptr);
-        int n = lstrlenW((WCHAR*)ptr);
-        wsprintfW(aux + n,L" Rect(%d, %d, %d, %d)\n", rc.left, rc.top, rc.right, rc.bottom);
-        aux += lstrlenW(aux);
-        ptr += (n + 1);
-    }
-
-    if (font)
-    {
-        ptr += 3;
-        wsprintfW(aux, L"%s\n", (WCHAR*)ptr);
-        len = lstrlenW((WCHAR*)ptr);
-        aux += (len + 1);
-        ptr += (len + 1);
-    }
-
-    for (WORD i = 0; i < nItems; i++)
-    {
-        if ((DWORD)ptr % 4) ptr++;  /// aligned DWORD
-
-        ptr += 6;
-
-        rc.left = *ptr;
-        rc.top = *(ptr + 1);
-        rc.right = *(ptr + 2);
-        rc.bottom = *(ptr + 3);
-
-        _id = *(ptr + 4);
-        if (id == _id)
-        {
-            ((RECT*)data)->left = rc.left;
-            ((RECT*)data)->top = rc.top;
-            ((RECT*)data)->right = rc.right;
-            ((RECT*)data)->bottom = rc.bottom;
-            return ptr;
-        }
-        ptr += 6;
-        if (*ptr == 0xffff)
-        {
-            wsprintfW(aux, L" Class #0x%x ", *(ptr + 1));
-            aux += lstrlenW(aux);
-            ptr += 2;
-        }
-        else
-        {
-            wsprintfW(aux, L" Class %s ",  ptr);
-            aux += lstrlenW(aux);
-            ptr += (lstrlenW((WCHAR*)ptr) + 1);
-        }
-
-        if(*ptr == 0xffff)
-        {
-            wsprintfW(aux, L" #0x%x _ID %d Rect(%d, %d, %d, %d)\n", *(ptr+1), _id,rc.left,rc.top, rc.right, rc.bottom);
-            aux += lstrlenW(aux);
-            ptr += 2;
-        }
-        else
-        {
-            wsprintfW(aux,L" %s ID. %d Rect(%d, %d, %d, %d)\n",(WCHAR*)ptr, _id,rc.left,rc.top, rc.right, rc.bottom);
-            aux += lstrlenW(aux);
-            ptr += (lstrlenW((WCHAR*)ptr )+ 1);
-        }
-        if (*ptr)
-            ptr += *ptr;
-        else
-            ptr++;
-   }
-   MessageBoxW(0, buf, L"ID not found", MB_OK|MB_ICONEXCLAMATION);
-   return NULL;
-}
-
-#define IDC_TABCONTROL 12320
 
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
@@ -420,43 +277,20 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     HICON hIcon;
     switch (uMsg)
     {
-        case PSCB_PRECREATE:
-        {
-            RECT rc, aux;
-            HRSRC hRes;
-            LPVOID Template;
-            APPBARDATA tbData;
-
-            if ((hRes = FindResourceW(NULL, MAKEINTRESOURCE(IDD_TASKBARPROP_TASKBAR),
-                                     (LPWSTR)RT_DIALOG)) != NULL)
-                Template = LoadResource(NULL, hRes);
-            else
-                return 0;
-
-            WORD *rcObject = TEMPLATE_ExtractRect(lParam, 0, &rc);
-            if (rcObject == NULL) return FALSE;
-
-            WORD oldH = rc.bottom;
-            TEMPLATE_ExtractRect((LPARAM)Template, 0, &rc);
-            TEMPLATE_ExtractRect(lParam, IDC_TABCONTROL, &aux);
-            AdjustWindowRect(&rc, WS_POPUPWINDOW, 0); 
-            
-            tbData.cbSize = sizeof(APPBARDATA);
-            tbData.hWnd = FindWindowW(L"Shell_TrayWnd", NULL);
-            SHAppBarMessage(ABM_GETTASKBARPOS, &tbData);
-
-            WORD tbHeight = tbData.rc.bottom - tbData.rc.top;
-            tbHeight = (tbHeight * 8) / HIWORD(GetDialogBaseUnits());
-
-            *(rcObject + 2) = rc.right;
-            *(rcObject + 3) = rc.bottom + (oldH - aux.bottom) + tbHeight;
-
-            return 0;
-        }
         case PSCB_INITIALIZED:
         {
+            RECT pos;
+            RECT rcWork;
             hIcon = LoadIconW(hExplorerInstance, MAKEINTRESOURCEW(IDI_STARTMENU));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
+ 
+            GetWindowRect(hwndDlg,&pos);
+            SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
+            if (pos.bottom > rcWork.bottom) 
+                pos.top -= (pos.bottom - rcWork.bottom + 2);
+            if (pos.right > rcWork.right)
+                pos.left -= (pos.right - rcWork.right + 2);
+            SetWindowPos(hwndDlg, 0, pos.left, pos.top, 0, 0, SWP_NOSIZE);
             break;
         }
     }

--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -269,19 +269,149 @@ public:
         return PSNRET_NOERROR;
     }
 };
+ 
+ /**
+*    Autor:      Jose Carlos Jesus 
+*    email:      zecarlos1957@hotmail.com
+*    Project:    ReactOS  
+*    date:       12-08-2019   
+*    input - 
+*               LPARAM lParam : Pointer to Resource Dialog TEMPLATE 
+*               DWORD id :       Resource ID from object to be extracted
+*                                  id = 0 -> Dialog rectangle
+*                                  id = # -> Object rectangle
+*               LPVOID data:    Pointer to buffer that receive data
+*
+*    Output    return pointer to RECT object or NULL if ID not found
+*                     If object not found, show a Dialog with Title, ClassName, ResourceID,
+*                     and Rectangle structure from all objects inside this Resource
+*
+*      (NOTE) For now, just work with DLGTEMPLATEEX resource type
+*/
 
-WORD *TEMPLATE_ExtractRect(LPARAM lParam, RECT &rc)
+WORD *TEMPLATE_ExtractRect(LPARAM lParam, DWORD id, LPVOID data)
 {
+    WCHAR buf[1024];
+    WCHAR *aux = buf;
+    WORD _id;
+    WORD len;
+    RECT rc;
     WORD *ptr = reinterpret_cast<WORD*>(lParam);
-    ((*ptr == 1) && (*(ptr + 1) == 0xffff)) ? ptr += 9 : ptr += 5;
+    DWORD signature = *((DWORD*)ptr);
+
+    if(signature != 0xffff0001)
+        return NULL;
+
+    ((*ptr == 1) && (*(ptr + 1) == 0xffff)) ? ptr += 7 : ptr += 4;
+    BOOL font = ((*ptr++ & DS_SETFONT) != 0) ;
+    WORD nItems = *ptr++;
+
     rc.left = *ptr;
     rc.top = *(ptr + 1);
     rc.right = *(ptr + 2);
     rc.bottom = *(ptr + 3);
-    return ptr;
+
+    if(id == 0)
+    {
+        ((RECT *)data)->left = *ptr;
+        ((RECT *)data)->top = *(ptr + 1);
+        ((RECT *)data)->right = *(ptr + 2);
+        ((RECT *)data)->bottom = *(ptr + 3);
+        return ptr;
+    }
+
+    ptr += 4;
+
+    if (*ptr == 0)               /// No menu id
+        ptr++;           
+    else if (*ptr == 0xffff)     /// menu # id
+        ptr += 2;        
+    else 
+        ptr += (lstrlenW((WCHAR*)ptr) + 1);
+
+    if (*ptr == 0)               /// Default Dialog ClassName id
+        ptr++;  
+    else if(*ptr == 0xffff)      /// ClassName # id
+        ptr += 2;   
+    else                         /// Unicode ClassName
+        ptr += (lstrlenW((WCHAR*)ptr) + 1);
+
+    if (*ptr == 0)               /// No WindowTitle
+        ptr++;
+    else                         /// Unicode WindowTitle
+    {
+        lstrcpyW(aux, (WCHAR*)ptr);
+        int n = lstrlenW((WCHAR*)ptr);
+        wsprintfW(aux + n,L" Rect(%d, %d, %d, %d)\n", rc.left, rc.top, rc.right, rc.bottom);
+        aux += lstrlenW(aux);
+        ptr += (n + 1);
+    }
+
+    if (font)
+    {
+        ptr += 3;
+        wsprintfW(aux, L"%s\n", (WCHAR*)ptr);
+        len = lstrlenW((WCHAR*)ptr);
+        aux += (len + 1);
+        ptr += (len + 1);
+    }
+
+    for (WORD i = 0; i < nItems; i++)
+    {
+        if ((DWORD)ptr % 4) ptr++;  /// aligned DWORD
+
+        ptr += 6;
+
+        rc.left = *ptr;
+        rc.top = *(ptr + 1);
+        rc.right = *(ptr + 2);
+        rc.bottom = *(ptr + 3);
+
+        _id = *(ptr + 4);
+        if (id == _id)
+        {
+            ((RECT*)data)->left = rc.left;
+            ((RECT*)data)->top = rc.top;
+            ((RECT*)data)->right = rc.right;
+            ((RECT*)data)->bottom = rc.bottom;
+            return ptr;
+        }
+        ptr += 6;
+        if (*ptr == 0xffff)
+        {
+            wsprintfW(aux, L" Class #0x%x ", *(ptr + 1));
+            aux += lstrlenW(aux);
+            ptr += 2;
+        }
+        else
+        {
+            wsprintfW(aux, L" Class %s ",  ptr);
+            aux += lstrlenW(aux);
+            ptr += (lstrlenW((WCHAR*)ptr) + 1);
+        }
+
+        if(*ptr == 0xffff)
+        {
+            wsprintfW(aux, L" #0x%x _ID %d Rect(%d, %d, %d, %d)\n", *(ptr+1), _id,rc.left,rc.top, rc.right, rc.bottom);
+            aux += lstrlenW(aux);
+            ptr += 2;
+        }
+        else
+        {
+            wsprintfW(aux,L" %s ID. %d Rect(%d, %d, %d, %d)\n",(WCHAR*)ptr, _id,rc.left,rc.top, rc.right, rc.bottom);
+            aux += lstrlenW(aux);
+            ptr += (lstrlenW((WCHAR*)ptr )+ 1);
+        }
+        if (*ptr)
+            ptr += *ptr;
+        else
+            ptr++;
+   }
+   MessageBoxW(0, buf, L"ID not found", MB_OK|MB_ICONEXCLAMATION);
+   return NULL;
 }
 
-#define EXTRA_BUTTON_SPACE 20
+#define IDC_TABCONTROL 12320
 
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
@@ -292,22 +422,34 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_PRECREATE:
         {
-            RECT rc;
+            RECT rc, aux;
             HRSRC hRes;
             LPVOID Template;
+            APPBARDATA tbData;
 
-            if ((hRes = FindResource(NULL, MAKEINTRESOURCE(IDD_TASKBARPROP_TASKBAR),
+            if ((hRes = FindResourceW(NULL, MAKEINTRESOURCE(IDD_TASKBARPROP_TASKBAR),
                                      (LPWSTR)RT_DIALOG)) != NULL)
                 Template = LoadResource(NULL, hRes);
-            else 
+            else
                 return 0;
 
-            WORD *temple = TEMPLATE_ExtractRect(lParam, rc);
-            TEMPLATE_ExtractRect((LPARAM)Template, rc);
-            AdjustWindowRectEx(&rc, WS_CAPTION, 0, WS_EX_PALETTEWINDOW);
+            WORD *rcObject = TEMPLATE_ExtractRect(lParam, 0, &rc);
+            if (rcObject == NULL) return FALSE;
 
-            *(temple + 2) = rc.right;
-            *(temple + 3) = rc.bottom + 20 + EXTRA_BUTTON_SPACE;
+            WORD oldH = rc.bottom;
+            TEMPLATE_ExtractRect((LPARAM)Template, 0, &rc);
+            TEMPLATE_ExtractRect(lParam, IDC_TABCONTROL, &aux);
+            AdjustWindowRect(&rc, WS_POPUPWINDOW, 0); 
+            
+            tbData.cbSize = sizeof(APPBARDATA);
+            tbData.hWnd = FindWindowW(L"Shell_TrayWnd", NULL);
+            SHAppBarMessage(ABM_GETTASKBARPOS, &tbData);
+
+            WORD tbHeight = tbData.rc.bottom - tbData.rc.top;
+            tbHeight = (tbHeight * 8) / HIWORD(GetDialogBaseUnits());
+
+            *(rcObject + 2) = rc.right;
+            *(rcObject + 3) = rc.bottom + (oldH - aux.bottom) + tbHeight;
 
             return 0;
         }
@@ -329,9 +471,9 @@ DisplayTrayProperties(IN HWND hwndOwner, IN HWND hwndTaskbar)
     CTaskBarSettingsPage tbSettingsPage(hwndTaskbar);
     CStartMenuSettingsPage smSettingsPage;
     CStringW caption;
-    
+
     caption.LoadStringW(IDS_TASKBAR_STARTMENU_PROP_CAPTION);
-    
+
     hpsp[0] = tbSettingsPage.Create();
     hpsp[1] = smSettingsPage.Create();
 

--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -46,7 +46,7 @@ static void SetBitmap(HWND hwnd, HBITMAP* hbmp, UINT uImageId)
 
 class CTaskBarSettingsPage : public CPropertyPageImpl<CTaskBarSettingsPage>
 {
-private:
+private: 
     HBITMAP m_hbmpTaskbar;
     HBITMAP m_hbmpTray;
     HWND m_hwndTaskbar;
@@ -85,7 +85,7 @@ private:
             uImageId = IDB_TASKBARPROP_NOLOCK_NOGROUP_QL;
         else if (!bLock && bGroup  && bShowQL)
             uImageId = IDB_TASKBARPROP_NOLOCK_GROUP_QL;
-        else
+        else 
             ASSERT(FALSE);
 
         SetBitmap(hwndTaskbarBitmap, &m_hbmpTaskbar, uImageId);
@@ -107,7 +107,7 @@ private:
             uImageId = IDB_SYSTRAYPROP_SHOW_CLOCK;
         else if (!bHideInactive && !bShowClock)
             uImageId = IDB_SYSTRAYPROP_SHOW_NOCLOCK;
-        else
+        else 
             ASSERT(FALSE);
 
         SetBitmap(hwndTrayBitmap, &m_hbmpTray, uImageId);
@@ -279,18 +279,8 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            RECT pos;
-            RECT rcWork;
             hIcon = LoadIconW(hExplorerInstance, MAKEINTRESOURCEW(IDI_STARTMENU));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
-
-            GetWindowRect(hwndDlg, &pos);
-            SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
-            if (pos.bottom > rcWork.bottom)
-                pos.top -= (pos.bottom - rcWork.bottom);
-            if (pos.right > rcWork.right)
-                pos.left -= (pos.right - rcWork.right);
-            SetWindowPos(hwndDlg, 0, pos.left, pos.top, 0, 0, SWP_NOSIZE);
             break;
         }
     }
@@ -305,9 +295,9 @@ DisplayTrayProperties(IN HWND hwndOwner, IN HWND hwndTaskbar)
     CTaskBarSettingsPage tbSettingsPage(hwndTaskbar);
     CStartMenuSettingsPage smSettingsPage;
     CStringW caption;
-
+    
     caption.LoadStringW(IDS_TASKBAR_STARTMENU_PROP_CAPTION);
-
+    
     hpsp[0] = tbSettingsPage.Create();
     hpsp[1] = smSettingsPage.Create();
 

--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -46,7 +46,7 @@ static void SetBitmap(HWND hwnd, HBITMAP* hbmp, UINT uImageId)
 
 class CTaskBarSettingsPage : public CPropertyPageImpl<CTaskBarSettingsPage>
 {
-private: 
+private:
     HBITMAP m_hbmpTaskbar;
     HBITMAP m_hbmpTray;
     HWND m_hwndTaskbar;
@@ -85,7 +85,7 @@ private:
             uImageId = IDB_TASKBARPROP_NOLOCK_NOGROUP_QL;
         else if (!bLock && bGroup  && bShowQL)
             uImageId = IDB_TASKBARPROP_NOLOCK_GROUP_QL;
-        else 
+        else
             ASSERT(FALSE);
 
         SetBitmap(hwndTaskbarBitmap, &m_hbmpTaskbar, uImageId);
@@ -107,7 +107,7 @@ private:
             uImageId = IDB_SYSTRAYPROP_SHOW_CLOCK;
         else if (!bHideInactive && !bShowClock)
             uImageId = IDB_SYSTRAYPROP_SHOW_NOCLOCK;
-        else 
+        else
             ASSERT(FALSE);
 
         SetBitmap(hwndTrayBitmap, &m_hbmpTray, uImageId);
@@ -283,13 +283,13 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
             RECT rcWork;
             hIcon = LoadIconW(hExplorerInstance, MAKEINTRESOURCEW(IDI_STARTMENU));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
- 
-            GetWindowRect(hwndDlg,&pos);
+
+            GetWindowRect(hwndDlg, &pos);
             SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
-            if (pos.bottom > rcWork.bottom) 
-                pos.top -= (pos.bottom - rcWork.bottom + 2);
+            if (pos.bottom > rcWork.bottom)
+                pos.top -= (pos.bottom - rcWork.bottom);
             if (pos.right > rcWork.right)
-                pos.left -= (pos.right - rcWork.right + 2);
+                pos.left -= (pos.right - rcWork.right);
             SetWindowPos(hwndDlg, 0, pos.left, pos.top, 0, 0, SWP_NOSIZE);
             break;
         }

--- a/base/shell/explorer/trayprop.cpp
+++ b/base/shell/explorer/trayprop.cpp
@@ -270,6 +270,19 @@ public:
     }
 };
 
+WORD *TEMPLATE_ExtractRect(LPARAM lParam, RECT &rc)
+{
+    WORD *ptr = reinterpret_cast<WORD*>(lParam);
+    ((*ptr == 1) && (*(ptr + 1) == 0xffff)) ? ptr += 9 : ptr += 5;
+    rc.left = *ptr;
+    rc.top = *(ptr + 1);
+    rc.right = *(ptr + 2);
+    rc.bottom = *(ptr + 3);
+    return ptr;
+}
+
+#define EXTRA_BUTTON_SPACE 20
+
 static int CALLBACK
 PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
 {
@@ -277,6 +290,27 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     HICON hIcon;
     switch (uMsg)
     {
+        case PSCB_PRECREATE:
+        {
+            RECT rc;
+            HRSRC hRes;
+            LPVOID Template;
+
+            if ((hRes = FindResource(NULL, MAKEINTRESOURCE(IDD_TASKBARPROP_TASKBAR),
+                                     (LPWSTR)RT_DIALOG)) != NULL)
+                Template = LoadResource(NULL, hRes);
+            else 
+                return 0;
+
+            WORD *temple = TEMPLATE_ExtractRect(lParam, rc);
+            TEMPLATE_ExtractRect((LPARAM)Template, rc);
+            AdjustWindowRectEx(&rc, WS_CAPTION, 0, WS_EX_PALETTEWINDOW);
+
+            *(temple + 2) = rc.right;
+            *(temple + 3) = rc.bottom + 20 + EXTRA_BUTTON_SPACE;
+
+            return 0;
+        }
         case PSCB_INITIALIZED:
         {
             hIcon = LoadIconW(hExplorerInstance, MAKEINTRESOURCEW(IDI_STARTMENU));

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3580,6 +3580,27 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         SetFocus(GetDlgItem(hwnd, IDOK));
       }
+#ifdef __REACTOS__
+      { /* try to fit it into the desktop */
+          RECT rcWork;
+          RECT rcDlg;
+          int dx, dy;
+          int cx, cy;
+
+          GetWindowRect(hwnd, &rcDlg);
+          SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
+          dx = rcDlg.right - rcWork.right;
+          dy = rcDlg.bottom - rcWork.bottom;
+          cx = rcDlg.right - rcDlg.left;
+          cy = rcDlg.bottom - rcDlg.top;
+          if (dx > 0)
+              rcDlg.left -= dx;
+          if (dy > 0)
+              rcDlg.top -= dy;
+
+          MoveWindow(hwnd, rcDlg.left, rcDlg.top, cx, cy, FALSE);
+      }
+#endif
 
       if (IS_INTRESOURCE(psInfo->ppshheader.pszCaption) &&
               psInfo->ppshheader.hInstance)

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3581,7 +3581,11 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetFocus(GetDlgItem(hwnd, IDOK));
       }
 #ifdef __REACTOS__
-      { /* try to fit it into the desktop */
+      { /* 
+           try to fit it into the desktop  
+           user32 positions the dialog based on the IDD_PROPSHEET template, 
+           but we've since made it larger by adding controls
+        */
           RECT rcWork;
           RECT rcDlg;
           int dx, dy;

--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -3585,20 +3585,19 @@ PROPSHEET_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
           RECT rcWork;
           RECT rcDlg;
           int dx, dy;
-          int cx, cy;
 
-          GetWindowRect(hwnd, &rcDlg);
-          SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
-          dx = rcDlg.right - rcWork.right;
-          dy = rcDlg.bottom - rcWork.bottom;
-          cx = rcDlg.right - rcDlg.left;
-          cy = rcDlg.bottom - rcDlg.top;
-          if (dx > 0)
-              rcDlg.left -= dx;
-          if (dy > 0)
-              rcDlg.top -= dy;
+          if (GetWindowRect(hwnd, &rcDlg) && SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0))
+          {
+              dx = rcDlg.right - rcWork.right;
+              dy = rcDlg.bottom - rcWork.bottom;
 
-          MoveWindow(hwnd, rcDlg.left, rcDlg.top, cx, cy, FALSE);
+              if (rcDlg.right > rcWork.right)
+                  rcDlg.left -= dx;
+              if (rcDlg.bottom > rcWork.bottom)
+                  rcDlg.top -= dy;
+
+              SetWindowPos(hwnd, HWND_TOPMOST, rcDlg.left, rcDlg.top, 0, 0, SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREDRAW | SWP_NOSIZE);
+          }
       }
 #endif
 


### PR DESCRIPTION
In the file "win32ss / user / user32 / windows / dialog.c"
In the DIALOG_CreateIndirect (...) function, before calling CreateWindowEx (...) the code attempts to adjust the position of the window within the screen area if possible.
For this calculates:
      dY = pos.y + size.cy - rcWork.bottom
     if (dY> 0) pos.y - = dY;
this size.cy was read from IDD_PROPSHEET TEMPLATE structure
and has a value of 140.
Here we need the correct window height value which is that of the IDD_TASKBARPROP_TASKBAR TEMPLATE and is equal to (218 + Title_height + ExtraButtons_height) to subtract from the current position which is the position of the top left corner of the start button.

## Proposed changes

JIRA issue: [CORE 9008](https://jira.reactos.org/browse/CORE-9008)
(and will also improve [CORE 9602](https://jira.reactos.org/browse/CORE-9602))