### PR TITLE
[WIN32SS][NTUSER] Fix menu drawing after style change

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -2605,7 +2605,8 @@ static void FASTCALL MENU_DrawPopupMenu(PWND wnd, HDC hdc, PMENU menu )
     {
         HPEN hPrevPen;
 
-        NtGdiRectangle( hdc, rect.left, rect.top, rect.right, rect.bottom );
+        /* FIXME: Maybe we don't have to fill the background manually */
+        FillRect(hdc, &rect, brush);
 
         hPrevPen = NtGdiSelectPen( hdc, NtGdiGetStockObject( NULL_PEN ) );
         if ( hPrevPen )


### PR DESCRIPTION
## Purpose
There were menu drawing regression after https://github.com/reactos/reactos/commit/03adec81414abb53e589ecd9061042b9ca2104c1.
This PR will fix it.
JIRA issue: [CORE-16244](https://jira.reactos.org/browse/CORE-16244)

- We don't have to draw the frame manually because of `WS_EX_DLGMODALFRAME` extended style.
- We don't need the margins (`MENU_TOP_MARGIN` and `MENU_BOTTOM_MARGIN`) in the client area any more because the client area doesn't contain the frame width.
- Use `GetSystemMetrics(SM_CXDLGFRAME)` and `GetSystemMetrics(SM_CYDLGFRAME)` for frame width.