### PR TITLE
[HAL] Add Xbox Hardware Abstraction Layer

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -224,6 +224,7 @@ pci_up = "Standard PC Uniprocessor"
 ;pci_mp = "Standard PC Multiprocessor"
 acpi_up = "ACPI PC Uniprocessor"
 ;acpi_mp = "ACPI PC Multiprocessor"
+xbox = "Original Xbox"
 
 [Map.Computer]
 ;<id> = <pnp id string>
@@ -231,6 +232,7 @@ pci_up = "PC UP"
 ;pci_mp = "PC MP"
 acpi_up = "ACPI UP"
 ;acpi_mp = "ACPI MP"
+xbox = "Xbox"
 
 [Files.pci_up]
 ntoskrnl.exe = 1,,,,,,,2,,,,1,2
@@ -247,6 +249,10 @@ halacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
 ;[Files.acpi_mp]
 ;ntkrnlmp.exe = 1,,,,,,,2,,,ntoskrnl.exe,1,2
 ;halacpi.dll  = 1,,,,,,,2,,,hal.dll,1,2
+
+[Files.xbox]
+ntoskrnl.exe = 1,,,,,,,2,,,,1,2
+halxbox.dll  = 1,,,,,,,2,,,hal.dll,1,2
 
 [Display]
 ;<id> = <user friendly name>,<spare>,<service key name>,<height>,<width>,<bpp>

--- a/hal/halx86/CMakeLists.txt
+++ b/hal/halx86/CMakeLists.txt
@@ -54,6 +54,7 @@ if(ARCH STREQUAL "i386")
     include(legacy.cmake)
     include(up.cmake)
     include(pic.cmake)
+    include(xbox.cmake)
     add_subdirectory(minihal)
 
     # hal
@@ -61,6 +62,7 @@ if(ARCH STREQUAL "i386")
     add_hal(halacpi SOURCES acpi/halacpi.rc COMPONENTS generic acpi up pic)
     add_hal(halapic SOURCES acpi/halacpi.rc COMPONENTS generic legacy up apic)
     add_hal(halaacpi SOURCES acpi/halacpi.rc COMPONENTS generic acpi up apic)
+    add_hal(halxbox SOURCES xbox/halxbox.rc COMPONENTS generic up xbox)
 
     #add_hal(halmps SOURCES up/halup.rc COMPONENTS generic legacy smp pic)
     #add_hal(halmacpi SOURCES acpi/halacpi.rc COMPONENTS generic acpi smp pic)

--- a/hal/halx86/legacy/bus/pcibus.c
+++ b/hal/halx86/legacy/bus/pcibus.c
@@ -368,12 +368,12 @@ HalpGetPCIData(IN PBUS_HANDLER BusHandler,
      * video card, so it appears to be present on 1:0:0 - 1:31:0.
      * We hack around these problems by indicating "device not present" for devices
      * 0:0:1, 0:0:2, 1:1:0, 1:2:0, 1:3:0, ...., 1:31:0 */
-    if ((0 == BusHandler->BusNumber && 0 == Slot.u.bits.DeviceNumber &&
-         (1 == Slot.u.bits.FunctionNumber || 2 == Slot.u.bits.FunctionNumber)) ||
-        (1 == BusHandler->BusNumber && 0 != Slot.u.bits.DeviceNumber))
+    if ((BusHandler->BusNumber == 0 && Slot.u.bits.DeviceNumber == 0 &&
+        (Slot.u.bits.FunctionNumber == 1 || Slot.u.bits.FunctionNumber == 2)) ||
+        (BusHandler->BusNumber == 1 && Slot.u.bits.DeviceNumber != 0))
     {
-        DPRINT("Blacklisted PCI slot\n");
-        if (0 == Offset && sizeof(USHORT) <= Length)
+        DPRINT("Blacklisted PCI slot (%d:%d:%d)\n", BusHandler->BusNumber, Slot.u.bits.DeviceNumber, Slot.u.bits.FunctionNumber);
+        if (Offset == 0 && Length >= sizeof(USHORT))
         {
             *(PUSHORT)Buffer = PCI_INVALID_VENDORID;
             return sizeof(USHORT);
@@ -460,11 +460,11 @@ HalpSetPCIData(IN PBUS_HANDLER BusHandler,
      * video card, so it appears to be present on 1:0:0 - 1:31:0.
      * We hack around these problems by indicating "device not present" for devices
      * 0:0:1, 0:0:2, 1:1:0, 1:2:0, 1:3:0, ...., 1:31:0 */
-    if ((0 == BusHandler->BusNumber && 0 == Slot.u.bits.DeviceNumber &&
-         (1 == Slot.u.bits.FunctionNumber || 2 == Slot.u.bits.FunctionNumber)) ||
-        (1 == BusHandler->BusNumber && 0 != Slot.u.bits.DeviceNumber))
+    if ((BusHandler->BusNumber == 0 && Slot.u.bits.DeviceNumber == 0 &&
+        (Slot.u.bits.FunctionNumber == 1 || Slot.u.bits.FunctionNumber == 2)) ||
+        (BusHandler->BusNumber == 1 && Slot.u.bits.DeviceNumber != 0))
     {
-        DPRINT1("Trying to set data on blacklisted PCI slot\n");
+        DPRINT1("Trying to set data on blacklisted PCI slot (%d:%d:%d)\n", BusHandler->BusNumber, Slot.u.bits.DeviceNumber, Slot.u.bits.FunctionNumber);
         return 0;
     }
 #endif

--- a/hal/halx86/xbox.cmake
+++ b/hal/halx86/xbox.cmake
@@ -1,0 +1,34 @@
+
+list(APPEND HAL_XBOX_ASM_SOURCE
+    generic/systimer.S
+    generic/trap.S
+    up/pic.S)
+
+list(APPEND HAL_XBOX_SOURCE
+    legacy/bus/bushndlr.c
+    legacy/bus/cmosbus.c
+    legacy/bus/isabus.c
+    legacy/bus/pcibus.c
+    ${CMAKE_CURRENT_BINARY_DIR}/pci_classes.c
+    ${CMAKE_CURRENT_BINARY_DIR}/pci_vendors.c
+    legacy/bus/sysbus.c
+    legacy/bussupp.c
+    legacy/halpnpdd.c
+    legacy/halpcat.c
+    generic/profil.c
+    generic/timer.c
+    xbox/part_xbox.c
+    xbox/halinit_xbox.c
+    up/pic.c)
+
+add_asm_files(lib_hal_xbox_asm ${HAL_XBOX_ASM_SOURCE})
+add_object_library(lib_hal_xbox ${HAL_XBOX_SOURCE} ${lib_hal_xbox_asm})
+if(NOT SARCH STREQUAL "xbox")
+    add_target_compile_definitions(lib_hal_xbox SARCH_XBOX)
+endif()
+add_dependencies(lib_hal_xbox bugcodes xdk asm)
+#add_pch(lib_hal_xbox xbox/halxbox.h)
+
+if(MSVC)
+    target_link_libraries(lib_hal_xbox lib_hal_generic)
+endif()

--- a/hal/halx86/xbox/halinit_xbox.c
+++ b/hal/halx86/xbox/halinit_xbox.c
@@ -15,9 +15,11 @@
 #define NDEBUG
 #include <debug.h>
 
+/* GLOBALS ******************************************************************/
+
 const USHORT HalpBuildType = HAL_BUILD_TYPE;
 
-/* FUNCTIONS ***************************************************************/
+/* FUNCTIONS ****************************************************************/
 
 VOID
 NTAPI
@@ -30,14 +32,33 @@ HalpInitProcessor(
 }
 
 VOID
-HalpInitPhase0(PLOADER_PARAMETER_BLOCK LoaderBlock)
+HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
+    /* Initialize Xbox-specific disk hacks */
     HalpXboxInitPartIo();
 }
 
 VOID
 HalpInitPhase1(VOID)
 {
+    /* Enable IRQ 0 */
+    HalpEnableInterruptHandler(IDT_DEVICE,
+                               0,
+                               PRIMARY_VECTOR_BASE,
+                               CLOCK2_LEVEL,
+                               HalpClockInterrupt,
+                               Latched);
+
+    /* Enable IRQ 8 */
+    HalpEnableInterruptHandler(IDT_DEVICE,
+                               0,
+                               PRIMARY_VECTOR_BASE + 8,
+                               PROFILE_LEVEL,
+                               HalpProfileInterrupt,
+                               Latched);
+
+    /* Initialize DMA. NT does this in Phase 0 */
+    HalpInitDma();
 }
 
 /* EOF */


### PR DESCRIPTION
- Create `xbox.cmake` based on `legacy.cmake` and `pic.cmake`
- Revive Xbox HAL files and add them to the build
- Fix boot with Xbox HAL, add missing parts from `halinit_up.c`
- Code style and debug logging improvements in `pcibus.c`
- Allow to choose Xbox HAL in usetup

Please add to XBOX Boot milestone. :wink: 