### PR TITLE
[AUDIOSRV][BOOTDATA][INCLUDE][MMSYS] Rename RosAudioSrv to AudioSrv

### DIFF
--- a/base/services/audiosrv/audiosrv.txt
+++ b/base/services/audiosrv/audiosrv.txt
@@ -19,18 +19,18 @@ subsequently passes to wdmaud.drv
 It is not necessary to duplicate the exact structure of this mapped 
 file, since it appears to only be used internally by Windows components.
 
-The ROS Audio Service (RosAudioSrv) is intended to be able to run 
+The ROS Audio Service (AudioSrv) is intended to be able to run 
 alongside the Windows Audio Service on XP/Vista, so it should be 
 possible to test in a "known working environment" ;)
 
 It will create a mutex, to:
 1) Allow synchronization when accessing the device list
-2) Provide a simple method of identifying if RosAudioSrv is running
+2) Provide a simple method of identifying if AudioSrv is running
 
 (It might be worth using an event to notify WinMM when things are 
 happening?)
 
-The intention is to make RosAudioSrv receive PnP notifications for 
+The intention is to make AudioSrv receive PnP notifications for 
 relevant audio devices, and also let AudioSrv in Windows do this. Then 
 it should be possible to create a small application that imitates 
 WinMM's actions :)
@@ -54,12 +54,12 @@ Testing the Service
 ===================
 
 The service can be installed on Windows XP (possibly also Vista) like so:
-sc create RosAudioSrv <path to audiosrv.exe>
-net start RosAudioSrv
+sc create AudioSrv <path to audiosrv.exe>
+net start AudioSrv
 
 ...and can be removed like so:
-net stop RosAudioSrv
-sc delete RosAudioSrv
+net stop AudioSrv
+sc delete AudioSrv
 
 You can view a list of the currently available devices (device list is
 identical to the one offered by Windows' own AudioSrv) by running

--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -1521,14 +1521,14 @@ HKLM,"SYSTEM\CurrentControlSet\Services\swenum","Start",0x00010001,0x00000000
 HKLM,"SYSTEM\CurrentControlSet\Services\swenum","Type",0x00010001,0x00000001
 
 ; Audio Service
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","DisplayName",0x00000000,%AUDIO_SERVICE%
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","Description",0x00000000,%AUDIO_SERVICE_DESCRIPTION%
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","ErrorControl",0x00010001,0x00000000
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","Group",0x00000000,"Audio"
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","ImagePath",0x00020000,"%SystemRoot%\system32\audiosrv.exe"
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","ObjectName",0x00000000,"LocalSystem"
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","Start",0x00010001,0x00000003
-HKLM,"SYSTEM\CurrentControlSet\Services\RosAudioSrv","Type",0x00010001,0x00000010
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","DisplayName",0x00000000,%AUDIO_SERVICE%
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","Description",0x00000000,%AUDIO_SERVICE_DESCRIPTION%
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","ErrorControl",0x00010001,0x00000000
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","Group",0x00000000,"Audio"
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","ImagePath",0x00020000,"%SystemRoot%\system32\audiosrv.exe"
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","ObjectName",0x00000000,"LocalSystem"
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","Start",0x00010001,0x00000003
+HKLM,"SYSTEM\CurrentControlSet\Services\AudioSrv","Type",0x00010001,0x00000010
 
 ; Background Intelligent Transfer Service (BITS)
 HKLM,"SYSTEM\CurrentControlSet\Services\BITS","DisplayName",0x00000000,%BITS_SERVICE%

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -553,10 +553,10 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
         return ERROR_DI_DO_DEFAULT;
     }
 
-    hService = OpenService(hSCManager, L"RosAudioSrv", SERVICE_ALL_ACCESS);
+    hService = OpenService(hSCManager, L"AudioSrv", SERVICE_ALL_ACCESS);
     if (hService)
     {
-        /* Make RosAudioSrv start automatically */
+        /* Make AudioSrv start automatically */
         ChangeServiceConfig(hService, SERVICE_NO_CHANGE, SERVICE_AUTO_START, SERVICE_NO_CHANGE, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
         StartService(hService, 0, NULL);

--- a/sdk/include/reactos/libs/audiosrv/audiosrv.h
+++ b/sdk/include/reactos/libs/audiosrv/audiosrv.h
@@ -11,7 +11,7 @@
 #ifndef AUDIOSRV_H
 #define AUDIOSRV_H
 
-/* This is currently set to avoid conflicting service names in Windows! */
+/* The service name */
 #define SERVICE_NAME                L"AudioSrv"
 
 /* A named mutex is used for synchronizing access to the device list.

--- a/sdk/include/reactos/libs/audiosrv/audiosrv.h
+++ b/sdk/include/reactos/libs/audiosrv/audiosrv.h
@@ -12,7 +12,7 @@
 #define AUDIOSRV_H
 
 /* This is currently set to avoid conflicting service names in Windows! */
-#define SERVICE_NAME                L"RosAudioSrv"
+#define SERVICE_NAME                L"AudioSrv"
 
 /* A named mutex is used for synchronizing access to the device list.
    If this mutex doesn't exist, it means the audio service isn't running. */


### PR DESCRIPTION
## Purpose

Rename RosAudioSrv to AudioSrv in audio service itself and in all system components which are related to this, same as it done in Win2k3.
It allows MS DxDiag to detect the system audio service correctly, so it becomes possible to run DirectSound test properly with MS dsound.dll, although it works with some minor errors and only in older VirtualBox versions, ~ up to 5.1.38 (and in other emulators as well).

JIRA issue: [CORE-16307](https://jira.reactos.org/browse/CORE-16307)

## Proposed changes

Rename RosAudioSrv to AudioSrv in the following source files:

- `base/services/audiosrv/audiosrv.txt` (just description of audio service, it doesn't make any changes in the system);
- `boot/bootdata/hivesys.inf` (registry values of the audio service);
- `dll/cpl/mmsys/mmsys.c` (audio properties cpl part, which calls it also, when changing audio settings);
- `sdk/include/reactos/libs/audiosrv/audiosrv.h` (service name itself, as it named in the system and visible to other system components and to user).

## Result

Before:
![before](https://user-images.githubusercontent.com/26385117/62887134-5819f500-bd45-11e9-8d12-6ad53015e385.png)
![dxdiag_before](https://user-images.githubusercontent.com/26385117/62887145-5f410300-bd45-11e9-90e1-c173fc2b16ba.png)

After:
![after](https://user-images.githubusercontent.com/26385117/62887170-6f58e280-bd45-11e9-9f8a-6246fc730e46.png)
![dxdiag_after](https://user-images.githubusercontent.com/26385117/62887201-7aac0e00-bd45-11e9-8e34-849a786dc052.png)