### PR TITLE
[WIN32SS] Create pathdraw.c

### DIFF
--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -77,6 +77,7 @@ list(APPEND SOURCE
     gdi/eng/mouse.c
     gdi/eng/paint.c
     gdi/eng/pathobj.c
+    gdi/eng/pathdraw.c
     gdi/eng/pdevobj.c
     gdi/eng/perfcnt.c
     gdi/eng/rlecomp.c

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -76,8 +76,8 @@ list(APPEND SOURCE
     gdi/eng/engmisc.c
     gdi/eng/mouse.c
     gdi/eng/paint.c
-    gdi/eng/pathobj.c
     gdi/eng/pathdraw.c
+    gdi/eng/pathobj.c
     gdi/eng/pdevobj.c
     gdi/eng/perfcnt.c
     gdi/eng/rlecomp.c

--- a/win32ss/gdi/eng/pathdraw.c
+++ b/win32ss/gdi/eng/pathdraw.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS kernel
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Path drawing API.
- * COPYRIGHT:   Copyright 2019 Katayama Hirofumi MZ
+ * COPYRIGHT:   Copyright 2019 Katayama Hirofumi MZ.
  */
 
 #include <win32k.h>
@@ -10,6 +10,61 @@
 
 #define NDEBUG
 #include <debug.h>
+
+BOOL
+APIENTRY
+EngStrokePath(
+    IN SURFOBJ  *pso,
+    IN PATHOBJ  *ppo,
+    IN CLIPOBJ  *pco,
+    IN XFORMOBJ  *pxo,
+    IN BRUSHOBJ  *pbo,
+    IN POINTL  *pptlBrushOrg,
+    IN LINEATTRS  *plineattrs,
+    IN MIX  mix)
+{
+    // www.osr.com/ddk/graphics/gdifncs_4yaw.htm
+    UNIMPLEMENTED;
+    return FALSE;
+}
+
+/*
+ * @unimplemented
+ */
+BOOL
+APIENTRY
+EngFillPath(
+    IN SURFOBJ   *pso,
+    IN PATHOBJ   *ppo,
+    IN CLIPOBJ   *pco,
+    IN BRUSHOBJ  *pbo,
+    IN POINTL    *pptlBrushOrg,
+    IN MIX        mix,
+    IN FLONG      flOptions)
+{
+    // www.osr.com/ddk/graphics/gdifncs_9pyf.htm
+    UNIMPLEMENTED;
+    return FALSE;
+}
+
+BOOL
+APIENTRY
+EngStrokeAndFillPath(
+    IN SURFOBJ  *pso,
+    IN PATHOBJ  *ppo,
+    IN CLIPOBJ  *pco,
+    IN XFORMOBJ  *pxo,
+    IN BRUSHOBJ  *pboStroke,
+    IN LINEATTRS  *plineattrs,
+    IN BRUSHOBJ  *pboFill,
+    IN POINTL  *pptlBrushOrg,
+    IN MIX  mixFill,
+    IN FLONG  flOptions)
+{
+    // www.osr.com/ddk/graphics/gdifncs_2xwn.htm
+    UNIMPLEMENTED;
+    return FALSE;
+}
 
 __kernel_entry
 W32KAPI

--- a/win32ss/gdi/eng/pathdraw.c
+++ b/win32ss/gdi/eng/pathdraw.c
@@ -1,0 +1,123 @@
+/*
+ * PROJECT:     ReactOS kernel
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Path drawing API.
+ * COPYRIGHT:   Copyright 2019 Katayama Hirofumi MZ
+ */
+
+#include <win32k.h>
+#undef XFORMOBJ
+
+#define NDEBUG
+#include <debug.h>
+
+__kernel_entry
+W32KAPI
+BOOL
+APIENTRY
+NtGdiEngStrokePath(
+    _In_ SURFOBJ *pso,
+    _In_ PATHOBJ *ppo,
+    _In_ CLIPOBJ *pco,
+    _In_ XFORMOBJ *pxo,
+    _In_ BRUSHOBJ *pbo,
+    _In_ POINTL *pptlBrushOrg,
+    _In_ LINEATTRS *plineattrs,
+    _In_ MIX mix)
+{
+    BOOL ret = FALSE;
+    POINT ptlBrushOrg;
+    LINEATTRS lineattrs;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pptlBrushOrg, sizeof(*pptlBrushOrg), 1);
+        ptlBrushOrg = *pptlBrushOrg;
+
+        ProbeForRead(plineattrs, sizeof(*plineattrs), 1);
+        lineattrs = *plineattrs;
+
+        ret = EngStrokePath(pso, ppo, pco, pxo, pbo, &ptlBrushOrg, &lineattrs, mix);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+    }
+    _SEH2_END;
+
+    return ret;
+}
+
+__kernel_entry
+W32KAPI
+BOOL
+APIENTRY
+NtGdiEngFillPath(
+    _In_ SURFOBJ *pso,
+    _In_ PATHOBJ *ppo,
+    _In_ CLIPOBJ *pco,
+    _In_ BRUSHOBJ *pbo,
+    _In_ POINTL *pptlBrushOrg,
+    _In_ MIX mix,
+    _In_ FLONG flOptions)
+{
+    BOOL ret = FALSE;
+    POINT ptlBrushOrg;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pptlBrushOrg, sizeof(*pptlBrushOrg), 1);
+        ptlBrushOrg = *pptlBrushOrg;
+
+        ret = EngFillPath(pso, ppo, pco, pbo, &ptlBrushOrg, mix, flOptions);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+    }
+    _SEH2_END;
+
+    return ret;
+}
+
+__kernel_entry
+W32KAPI
+BOOL
+APIENTRY
+NtGdiEngStrokeAndFillPath(
+    _In_ SURFOBJ *pso,
+    _In_ PATHOBJ *ppo,
+    _In_ CLIPOBJ *pco,
+    _In_ XFORMOBJ *pxo,
+    _In_ BRUSHOBJ *pboStroke,
+    _In_ LINEATTRS *plineattrs,
+    _In_ BRUSHOBJ *pboFill,
+    _In_ POINTL *pptlBrushOrg,
+    _In_ MIX mix,
+    _In_ FLONG flOptions)
+{
+    BOOL ret = FALSE;
+    POINT ptlBrushOrg;
+    LINEATTRS lineattrs;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pptlBrushOrg, sizeof(*pptlBrushOrg), 1);
+        ptlBrushOrg = *pptlBrushOrg;
+
+        ProbeForRead(plineattrs, sizeof(*plineattrs), 1);
+        lineattrs = *plineattrs;
+
+        ret = EngStrokeAndFillPath(pso, ppo, pco, pxo, pboStroke, &lineattrs, pboFill,
+                                   &ptlBrushOrg, mix, flOptions);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+    }
+    _SEH2_END;
+
+    return ret;
+}
+
+/* EOF */

--- a/win32ss/gdi/eng/stubs.c
+++ b/win32ss/gdi/eng/stubs.c
@@ -90,25 +90,6 @@ EngEnumForms(
 /*
  * @unimplemented
  */
-BOOL
-APIENTRY
-EngFillPath(
-    IN SURFOBJ   *pso,
-    IN PATHOBJ   *ppo,
-    IN CLIPOBJ   *pco,
-    IN BRUSHOBJ  *pbo,
-    IN POINTL    *pptlBrushOrg,
-    IN MIX        mix,
-    IN FLONG      flOptions)
-{
-    // www.osr.com/ddk/graphics/gdifncs_9pyf.htm
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-/*
- * @unimplemented
- */
 PVOID
 APIENTRY
 EngFindResource(
@@ -303,42 +284,6 @@ EngSetPrinterData(
     // www.osr.com/ddk/graphics/gdifncs_8drb.htm
     UNIMPLEMENTED;
     return 0;
-}
-
-BOOL
-APIENTRY
-EngStrokeAndFillPath(
-    IN SURFOBJ  *pso,
-    IN PATHOBJ  *ppo,
-    IN CLIPOBJ  *pco,
-    IN XFORMOBJ  *pxo,
-    IN BRUSHOBJ  *pboStroke,
-    IN LINEATTRS  *plineattrs,
-    IN BRUSHOBJ  *pboFill,
-    IN POINTL  *pptlBrushOrg,
-    IN MIX  mixFill,
-    IN FLONG  flOptions)
-{
-    // www.osr.com/ddk/graphics/gdifncs_2xwn.htm
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-BOOL
-APIENTRY
-EngStrokePath(
-    IN SURFOBJ  *pso,
-    IN PATHOBJ  *ppo,
-    IN CLIPOBJ  *pco,
-    IN XFORMOBJ  *pxo,
-    IN BRUSHOBJ  *pbo,
-    IN POINTL  *pptlBrushOrg,
-    IN LINEATTRS  *plineattrs,
-    IN MIX  mix)
-{
-    // www.osr.com/ddk/graphics/gdifncs_4yaw.htm
-    UNIMPLEMENTED;
-    return FALSE;
 }
 
 INT

--- a/win32ss/gdi/eng/umpdstubs.c
+++ b/win32ss/gdi/eng/umpdstubs.c
@@ -281,22 +281,6 @@ NtGdiEngEraseSurface(
 __kernel_entry
 BOOL
 APIENTRY
-NtGdiEngFillPath(
-    _In_ SURFOBJ *pso,
-    _In_ PATHOBJ *ppo,
-    _In_ CLIPOBJ *pco,
-    _In_ BRUSHOBJ *pbo,
-    _In_ POINTL *pptlBrushOrg,
-    _In_ MIX mix,
-    _In_ FLONG flOptions)
-{
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-__kernel_entry
-BOOL
-APIENTRY
 NtGdiEngGradientFill(
     _In_ SURFOBJ *psoDest,
     _In_ CLIPOBJ *pco,
@@ -392,41 +376,6 @@ NtGdiEngStretchBltROP(
     _In_ ULONG iMode,
     _In_ BRUSHOBJ *pbo,
     _In_ ROP4 rop4)
-{
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-__kernel_entry
-BOOL
-APIENTRY
-NtGdiEngStrokePath(
-    _In_ SURFOBJ *pso,
-    _In_ PATHOBJ *ppo,
-    _In_ CLIPOBJ *pco,
-    _In_ XFORMOBJ *pxo,
-    _In_ BRUSHOBJ *pbo,
-    _In_ POINTL *pptlBrushOrg,
-    _In_ LINEATTRS *plineattrs,
-    _In_ MIX mix)
-{
-    UNIMPLEMENTED;
-    return FALSE;
-}
-
-__kernel_entry
-BOOL
-APIENTRY
-NtGdiEngStrokeAndFillPath(
-    _In_ SURFOBJ *pso,
-    _In_ PATHOBJ *ppo,
-    _In_ CLIPOBJ *pco,IN XFORMOBJ *pxo,
-    _In_ BRUSHOBJ *pboStroke,
-    _In_ LINEATTRS *plineattrs,
-    _In_ BRUSHOBJ *pboFill,
-    _In_ POINTL *pptlBrushOrg,
-    _In_ MIX mix,
-    _In_ FLONG flOptions)
 {
     UNIMPLEMENTED;
     return FALSE;


### PR DESCRIPTION
## Purpose
Create `win32ss/gdi/eng/pathdraw.c` and move `NtGdiEngStrokePath`, `NtGdiEngFillPath`, `NtGdiEngStrokeAndFillPath`, `EngStrokePath`, `EngFillPath` and `EngStrokeAndFillPath` functions to this file.
JIRA issue: [CORE-16243](https://jira.reactos.org/browse/CORE-16243)