### PR TITLE
[FREELDR] Add Serial ports detection in DetectIsaBios()

### DIFF
--- a/boot/freeldr/freeldr/include/arch/i386/machxbox.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machxbox.h
@@ -22,6 +22,21 @@
 #include "mm.h"
 #endif
 
+#define MAX_XBOX_COM_PORTS    2
+
+#define LPC_IO_BASE             0x2E
+#define LPC_ENTER_CONFIG_KEY    0x55
+#define LPC_EXIT_CONFIG_KEY     0xAA
+
+#define LPC_DEVICE_SERIAL_PORT_1    0x4
+#define LPC_DEVICE_SERIAL_PORT_2    0x5
+
+#define LPC_CONFIG_DEVICE_NUMBER                0x07
+#define LPC_CONFIG_DEVICE_ACTIVATE              0x30
+#define LPC_CONFIG_DEVICE_BASE_ADDRESS_HIGH     0x60
+#define LPC_CONFIG_DEVICE_BASE_ADDRESS_LOW      0x61
+#define LPC_CONFIG_DEVICE_INTERRUPT             0x70
+
 extern UCHAR XboxFont8x16[256 * 16];
 
 VOID XboxMachInit(const char *CmdLine);

--- a/boot/freeldr/freeldr/include/arch/pc/hardware.h
+++ b/boot/freeldr/freeldr/include/arch/pc/hardware.h
@@ -44,6 +44,10 @@ BOOLEAN
 
 extern FIND_PCI_BIOS FindPciBios;
 
+typedef
+ULONG
+(*GET_SERIAL_PORT)(ULONG Index, PULONG Irq);
+
 VOID
 DetectBiosDisks(PCONFIGURATION_COMPONENT_DATA SystemKey,
                 PCONFIGURATION_COMPONENT_DATA BusKey);


### PR DESCRIPTION
Add Serial ports detection in `DetectIsaBios()`. This is based on PC serial port detection code.

Please add to XBOX Boot milestone. :wink: 