### PR TITLE
[SHELL32] Fix Desktop Properties menu item action

### DIFF
--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -845,8 +845,11 @@ HRESULT WINAPI CDesktopFolder::CallBack(IShellFolder *psf, HWND hwndOwner, IData
     {
         if (uMsg == DFM_INVOKECOMMAND && wParam == 0)
         {
-            if (32 >= (UINT_PTR)ShellExecuteW(hwndOwner, L"open", L"rundll32.exe shell32.dll,Control_RunDLL desk.cpl", NULL, NULL, SW_SHOWNORMAL))
+            if (32 >= (UINT_PTR)ShellExecuteW(hwndOwner, L"open", L"rundll32.exe",
+                                              L"shell32.dll,Control_RunDLL desk.cpl", NULL, SW_SHOWNORMAL))
+            {
                 return E_FAIL;
+            }
             return S_OK;
         }
         else if (uMsg == DFM_MERGECONTEXTMENU)


### PR DESCRIPTION
## Purpose
1. Right Click the Desktop.
2. Choose "Properties" menu item.
3. "Properties for Display" dialog must be shown.

JIRA issue: [CORE-16299](https://jira.reactos.org/browse/CORE-16299)
