### PR TITLE
[MSVCRT] Export __acrt_iob_func from MSVC 2015 and higher

### DIFF
--- a/sdk/lib/crt/msvcrtex.cmake
+++ b/sdk/lib/crt/msvcrtex.cmake
@@ -39,7 +39,8 @@ list(APPEND MSVCRTEX_SOURCE
     misc/fltused.c
     misc/isblank.c
     misc/iswblank.c
-    misc/ofmt_stub.c)
+    misc/ofmt_stub.c
+    stdio/acrt_iob_func.c)
 
 if(MSVC)
     list(APPEND MSVCRTEX_SOURCE

--- a/sdk/lib/crt/stdio/acrt_iob_func.c
+++ b/sdk/lib/crt/stdio/acrt_iob_func.c
@@ -14,3 +14,7 @@ FILE * CDECL __acrt_iob_func(int index)
 {
     return &__iob_func()[index];
 }
+
+// Evil hack necessary, because we're linking to the RosBE-provided libstdc++ when using GCC.
+// This can only be solved cleanly by adding a GCC-compatible C++ standard library to our tree.
+const void* _imp____acrt_iob_func = __acrt_iob_func;

--- a/sdk/lib/crt/stdio/acrt_iob_func.c
+++ b/sdk/lib/crt/stdio/acrt_iob_func.c
@@ -5,6 +5,10 @@
  * COPYRIGHT:   Victor Perevertkin <victor.perevertkin@reactos.org>
  */
 
+// Evil hack necessary, because we're linking to the RosBE-provided libstdc++ when using GCC.
+// This can only be solved cleanly by adding a GCC-compatible C++ standard library to our tree.
+#ifdef __GNUC__
+
 #include <precomp.h>
 
 /*********************************************************************
@@ -15,6 +19,6 @@ FILE * CDECL __acrt_iob_func(int index)
     return &__iob_func()[index];
 }
 
-// Evil hack necessary, because we're linking to the RosBE-provided libstdc++ when using GCC.
-// This can only be solved cleanly by adding a GCC-compatible C++ standard library to our tree.
 const void* _imp____acrt_iob_func = __acrt_iob_func;
+
+#endif

--- a/sdk/lib/crt/stdio/acrt_iob_func.c
+++ b/sdk/lib/crt/stdio/acrt_iob_func.c
@@ -1,0 +1,16 @@
+/*
+ * PROJECT:     ReactOS CRT library
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     __acrt_iob_func implementation
+ * COPYRIGHT:   Victor Perevertkin <victor.perevertkin@reactos.org>
+ */
+
+#include <precomp.h>
+
+/*********************************************************************
+ *    __acrt_iob_func(MSVCRT.@)
+ */
+FILE * CDECL __acrt_iob_func(int index)
+{
+    return &__iob_func()[index];
+}


### PR DESCRIPTION
This makes GCC 8.3.0 compiled with mingw-w64 6.0.0 happy.
I'm not sure if we should do anything with "old" export `__iob_func`

See https://stackoverflow.com/questions/30412951/unresolved-external-symbol-imp-fprintf-and-imp-iob-func-sdl2