### PR TITLE
[NTOS:INBV] Don't touch VGA I/O ports when /NOGUIBOOT specified

### DIFF
--- a/ntoskrnl/inbv/inbv.c
+++ b/ntoskrnl/inbv/inbv.c
@@ -415,6 +415,10 @@ InbvDriverInitialize(IN PLOADER_PARAMETER_BLOCK LoaderBlock,
         CommandLine = (LoaderBlock->LoadOptions ? _strupr(LoaderBlock->LoadOptions) : NULL);
         ResetMode   = (CommandLine == NULL) || (strstr(CommandLine, "BOOTLOGO") == NULL);
     }
+    else if (InbvDisplayState == INBV_DISPLAY_STATE_DISABLED)
+    {
+        return FALSE;
+    }
 
     /* Initialize the video */
     InbvBootDriverInstalled = VidInitialize(ResetMode);


### PR DESCRIPTION
Don't touch VGA I/O ports when /NOGUIBOOT specified.

JIRA issue: [CORE-14625](https://jira.reactos.org/browse/CORE-14625), [CORE-16222](https://jira.reactos.org/browse/CORE-16222)