### PR TITLE
[TXTSETUP] Copy usbport.sys

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -112,6 +112,7 @@ hidusb.sys   = 1,,,,,,,4,,,,1,4
 usbccgp.sys  = 1,,,,,,x,4,,,,1,4
 usbd.sys     = 1,,,,,,x,4,,,,1,4
 usbhub.sys   = 1,,,,,,x,4,,,,1,4
+usbport.sys  = 1,,,,,,x,4,,,,1,4
 usbuhci.sys  = 1,,,,,,x,4,,,,1,4
 usbohci.sys  = 1,,,,,,x,4,,,,1,4
 usbehci.sys  = 1,,,,,,x,4,,,,1,4


### PR DESCRIPTION
We generate usbport.sys, add it to the ISO, and then never copy the driver into reactos.
It's needed by our new USB drivers as well as MS's drivers, so let's copy it over. 