### PR TITLE
[CPL][DESK] Don't enable 'Apply' button initially

### DIFF
--- a/dll/cpl/desk/screensaver.c
+++ b/dll/cpl/desk/screensaver.c
@@ -741,7 +741,7 @@ ScreenSaverPageProc(HWND hwndDlg,
             {
                 case IDC_SCREENS_LIST:
                 {
-                    if (HIWORD(wParam) == CBN_SELCHANGE)
+                    if (HIWORD(wParam) == CBN_SELCHANGE && !pData->InChangingUI)
                     {
                         SelectionChanged(hwndDlg, pData);
                         SetScreenSaverPreviewBox(hwndDlg, pData);

--- a/dll/cpl/desk/screensaver.c
+++ b/dll/cpl/desk/screensaver.c
@@ -26,6 +26,7 @@ typedef struct _DATA
     PROCESS_INFORMATION PrevWindowPi;
     int                 Selection;
     UINT                ScreenSaverCount;
+    BOOL                InChangingUI;
 } DATA, *PDATA;
 
 
@@ -594,6 +595,8 @@ OnInitDialog(HWND hwndDlg, PDATA pData)
         return FALSE;
     }
 
+    pData->InChangingUI = TRUE;
+
     SetWindowLongPtr(hwndDlg,
                      DWLP_USER,
                      (LONG_PTR)pData);
@@ -684,6 +687,8 @@ OnInitDialog(HWND hwndDlg, PDATA pData)
     SelectionChanged(hwndDlg,
                      pData);
 
+    pData->InChangingUI = FALSE;
+
     return TRUE;
 }
 
@@ -747,7 +752,10 @@ ScreenSaverPageProc(HWND hwndDlg,
 
                 case IDC_SCREENS_TIMEDELAY:
                 {
-                    PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
+                    if (HIWORD(wParam) == EN_CHANGE && !pData->InChangingUI)
+                    {
+                        PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
+                    }
                     break;
                 }
 


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16280](https://jira.reactos.org/browse/CORE-16280)
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/63160139-041a5380-c058-11e9-809f-e6eab4665b68.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/63160138-0381bd00-c058-11e9-865e-68f275b1b67c.png)

- Add `BOOL InChangingUI` member to `DATA` structure.
- Set `pData->InChangingUI` to `TRUE` and `FALSE` in `OnInitDialog`.
- In case of `IDC_SCREENS_TIMEDELAY` and `IDC_SCREENS_LIST`, check notification code and `InChangingUI` member.