### PR TITLE
[COMCTL32] Unchange the property sheet page after WM_INITDIALOG

### DIFF
--- a/dll/win32/comctl32/propsheet.c
+++ b/dll/win32/comctl32/propsheet.c
@@ -1333,6 +1333,9 @@ static UINT GetTemplateSize(const DLGTEMPLATE* pTemplate)
   return ret;
 }
 
+#ifdef __REACTOS__
+static void PROPSHEET_UnChanged(HWND hwndDlg, HWND hwndCleanPage);
+#endif
 /******************************************************************************
  *            PROPSHEET_CreatePage
  *
@@ -1473,6 +1476,9 @@ static BOOL PROPSHEET_CreatePage(HWND hwndParent,
   if (!(psInfo->ppshheader.dwFlags & INTRNL_ANY_WIZARD))
       EnableThemeDialogTexture (hwndPage, ETDT_ENABLETAB);
 
+#ifdef __REACTOS__
+  PROPSHEET_UnChanged(hwndParent, hwndPage);
+#endif
   return TRUE;
 }
 


### PR DESCRIPTION
## Purpose
Sorry, my mistakes continued. #1840 and #1841 are incorrect.

JIRA issue: [CORE-16280](https://jira.reactos.org/browse/CORE-16280)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/63167298-d6d7a080-c06b-11e9-8bf0-601c28c3ac2d.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/63167296-d63f0a00-c06b-11e9-96e3-f546e9be4acf.png)

In my testing on Win2k3, `EN_CHANGE` is generated in `OnInitDialog`, that is correct. The target is property sheet. The property sheet does unchange the page after `WM_INITDIALOG` generation.
![EN_CHANGE-generated](https://user-images.githubusercontent.com/2107452/63167319-e8b94380-c06b-11e9-8cbf-0c9a8fcf0871.png)