### PR TITLE
[MKISOFS] #undef HAVE_WCTYPE_H

### DIFF
--- a/sdk/tools/mkisofs/reactos/xconfig.h
+++ b/sdk/tools/mkisofs/reactos/xconfig.h
@@ -59,7 +59,7 @@
 
 #define HAVE_LOCALE_H 1
 #define HAVE_CTYPE_H 1
-#define HAVE_WCTYPE_H 1
+/* #define HAVE_WCTYPE_H 1 */   /* LNK2001 */
 #define HAVE_WCHAR_H 1
 
 /*


### PR DESCRIPTION
## Purpose
Some environments got "external symbol `__imp__wctype` is not resolved" errors.
Modify `xconfig.h` file of `mkisofs`.
JIRA issue: N/A
