### PR TITLE
[FREELDR] Add missing VideoSetTextCursorPosition handler for Xbox

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/machxbox.c
@@ -224,6 +224,7 @@ XboxMachInit(const char *CmdLine)
     MachVtbl.VideoGetDisplaySize = XboxVideoGetDisplaySize;
     MachVtbl.VideoGetBufferSize = XboxVideoGetBufferSize;
     MachVtbl.VideoGetFontsFromFirmware = XboxVideoGetFontsFromFirmware;
+    MachVtbl.VideoSetTextCursorPosition = XboxVideoSetTextCursorPosition;
     MachVtbl.VideoHideShowTextCursor = XboxVideoHideShowTextCursor;
     MachVtbl.VideoPutChar = XboxVideoPutChar;
     MachVtbl.VideoCopyOffScreenBufferToVRAM = XboxVideoCopyOffScreenBufferToVRAM;


### PR DESCRIPTION
This fixes null pointer call bug, which was revealed in 85d44fc by @HBelusca. Bug spotted by Mark Jansen.

Please add to XBOX Boot milestone. :wink: 