### PR TITLE
[CMAKE] gcc.cmake: '-Wno-unused-const-variable' applies to GCC 6.1+

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -113,7 +113,9 @@ endif()
 
 add_compile_flags("-Wall -Wpointer-arith")
 add_compile_flags("-Wno-char-subscripts -Wno-multichar -Wno-unused-value")
-add_compile_flags("-Wno-unused-const-variable")
+if(NOT GCC_VERSION VERSION_LESS 6.1)
+    add_compile_flags("-Wno-unused-const-variable")
+endif()
 add_compile_flags("-Wno-unused-local-typedefs")
 add_compile_flags("-Wno-deprecated")
 


### PR DESCRIPTION
## Purpose

GCC 4.7.2 logs
'cc1: error: unrecognized command line option "-Wno-unused-const-variable" [-Werror]'

Addendum to 8eb7a1a2f4a9cce5a70a9c48efb30cdfa59bf56f.
