### PR TITLE
Fix unneeded error Popup with Git for Windows.

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1045,14 +1045,18 @@ static unsigned dde_connect(const WCHAR* key, const WCHAR* start, WCHAR* ddeexec
         /* if ddeexec is NULL, then we just need to exit here */
         if (ddeexec == NULL)
         {
-            TRACE("Exiting because ddeexec is NULL. ret=33.\n");
-            return 33; /* FIXME see SHELL_FindExecutable() */
+            TRACE("Exiting because ddeexec is NULL. ret=42.\n");
+            /* See https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew */
+            /* for reason why we use 42 here and also "Shell32_apitest ShellExecuteW" regression test */
+            return 42;
         }
         /* if ddeexec is 'empty string', then we just need to exit here */
         if (wcscmp(ddeexec, L"") == 0)
         {
-            TRACE("Exiting because ddeexec is 'empty string'. ret=33.\n");
-            return 33; /* FIXME see SHELL_FindExecutable() */
+            TRACE("Exiting because ddeexec is 'empty string'. ret=42.\n");
+            /* See https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shellexecutew */
+            /* for reason why we use 42 here and also "Shell32_apitest ShellExecuteW" regression test */
+            return 42;
         }
         hConv = DdeConnect(ddeInst, hszApp, hszTopic, NULL);
         if (!hConv)

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1042,6 +1042,18 @@ static unsigned dde_connect(const WCHAR* key, const WCHAR* start, WCHAR* ddeexec
             TRACE("Couldn't launch\n");
             goto error;
         }
+        /* if ddeexec is NULL, then we just need to exit here */
+        if (ddeexec == NULL)
+        {
+            TRACE("Exiting because ddeexec is NULL. ret=33.\n");
+            return 33; /* FIXME see SHELL_FindExecutable() */
+        }
+        /* if ddeexec is 'empty string', then we just need to exit here */
+        if (wcscmp(ddeexec, L"") == 0)
+        {
+            TRACE("Exiting because ddeexec is 'empty string'. ret=33.\n");
+            return 33; /* FIXME see SHELL_FindExecutable() */
+        }
         hConv = DdeConnect(ddeInst, hszApp, hszTopic, NULL);
         if (!hConv)
         {


### PR DESCRIPTION
Fixes unneeded popup when installing Git for Windows 2.10.0

_Exit from ddeexec if parameter is NULL or empty string._


JIRA issue: [CORE-12266](https://jira.reactos.org/browse/CORE-12266)

## Revise shlexec.cpp

_Fixes unneeded popup when ddeexec is NULL or empty string._
