### PR TITLE
Enable support for HTMLHELP

### DIFF
--- a/base/applications/calc/CMakeLists.txt
+++ b/base/applications/calc/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-DDISABLE_HTMLHELP_SUPPORT=1)
-
 list(APPEND SOURCE
     convert.c
     fun_ieee.c

--- a/base/applications/calc/htmlhelp.c
+++ b/base/applications/calc/htmlhelp.c
@@ -49,7 +49,7 @@ dummy_HtmlHelpW(HWND hWnd, LPCWSTR pszFile, UINT uCommand, DWORD dwData)
 
 void HtmlHelp_Start(HINSTANCE hInstance)
 {
-    hHtmlHelp = LoadLibrary(_T("HTMLHELP"));
+    hHtmlHelp = LoadLibrary(_T("HHCTRL.OCX"));
     if (hHtmlHelp == NULL)
         return;
 

--- a/base/applications/calc/winmain.c
+++ b/base/applications/calc/winmain.c
@@ -894,7 +894,7 @@ static void delete_stat_item(int n)
 
 static char *ReadConversion(const char *formula)
 {
-    intptr_t len = strlen(formula);
+    size_t len = strlen(formula);
     char *str = (char *)malloc(len+3);
 
     if (str == NULL)


### PR DESCRIPTION
Some years are passed since 2005 and nowadays ReactOS includes support for htmlhelp.h and a working implementation of HHCTRL.OCX. Although current imported HHCTRL.OCX suffers of this issue:

https://bugs.winehq.org/show_bug.cgi?id=47379

and the help files of ReactOS Calc are not included in the master, I think it is not a bad idea to activate its support by default.