### PR TITLE
[WIN32SS][FONT] Fix registry-based management

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1412,7 +1412,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    // FIXME!
+                    break;
                 }
             }
             else
@@ -1430,7 +1430,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    // FIXME!
+                    break;
                 }
             }
         }
@@ -1456,7 +1456,8 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    // FIXME!
+                    RtlFreeUnicodeString(pValueName);
+                    break;
                 }
             }
             else
@@ -1474,7 +1475,8 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    // FIXME!
+                    RtlFreeUnicodeString(pValueName);
+                    break;
                 }
             }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1610,7 +1610,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
     UNICODE_STRING PathName;
     LPWSTR pszBuffer;
     static const UNICODE_STRING TrueTypePostfix = RTL_CONSTANT_STRING(L" (TrueType)");
-    static const UNICODE_STRING DosPathPrefix = RTL_CONSTANT_STRING(L"\\\\?\\");
+    static const UNICODE_STRING DosPathPrefix = RTL_CONSTANT_STRING(L"\\??\\");
 
     /* Build PathName */
     if (dwFlags & AFRX_DOS_DEVICE_PATH)
@@ -1633,7 +1633,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
 
     /* Open the font file */
     InitializeObjectAttributes(&ObjectAttributes, &PathName,
-                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+                               OBJ_CASE_INSENSITIVE, NULL, NULL);
     Status = ZwOpenFile(
                  &FileHandle,
                  FILE_GENERIC_READ | SYNCHRONIZE,
@@ -1649,7 +1649,8 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
     }
 
     SectionSize.QuadPart = 0LL;
-    Status = MmCreateSection(&SectionObject, SECTION_ALL_ACCESS,
+    Status = MmCreateSection(&SectionObject,
+                             STANDARD_RIGHTS_REQUIRED | SECTION_QUERY | SECTION_MAP_READ,
                              NULL, &SectionSize, PAGE_READONLY,
                              SEC_COMMIT, FileHandle, NULL);
     if (!NT_SUCCESS(Status))

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1611,12 +1611,13 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
 
     /* Build PathName */
     Length = wcslen(SharedUserData->NtSystemRoot);
-    FileName->Buffer[FileName->Length / sizeof(WCHAR)] = 0;
-    if (RtlCompareMemory(FileName->Buffer, SharedUserData->NtSystemRoot,
-                         Length * sizeof(WCHAR)) == Length * sizeof(WCHAR))
+    RtlStringCbCopyNW(szPath, sizeof(szPath), FileName->Buffer,
+                      min(Length * sizeof(WCHAR), FileName->Length));
+    if (_wcsnicmp(szPath, SharedUserData->NtSystemRoot, Length) == 0)
     {
         RtlStringCbCopyW(szPath, sizeof(szPath), L"\\SystemRoot");
-        RtlStringCbCatW(szPath, sizeof(szPath), &FileName->Buffer[Length]);
+        RtlStringCbCatNW(szPath, sizeof(szPath), &FileName->Buffer[Length],
+                         FileName->Length - Length * sizeof(WCHAR));
         RtlInitUnicodeString(&PathName, szPath);
     }
     else

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1398,14 +1398,20 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
             if (FT_IS_SFNT(Face))
             {
                 // L"Name StyleName\0"
-                Length = NameLength + sizeof(WCHAR) + Entry->StyleName.Length + sizeof(UNICODE_NULL);
+                Length = NameLength + sizeof(L' ') + Entry->StyleName.Length + sizeof(UNICODE_NULL);
+                if (Entry->StyleName.Length == 0)
+                    Length -= sizeof(L' ');
+
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
                     RtlInitEmptyUnicodeString(pValueName, pszBuffer, (USHORT)Length);
                     RtlCopyUnicodeString(pValueName, &Entry->FaceName);
-                    RtlAppendUnicodeToString(pValueName, L" ");
-                    RtlAppendUnicodeStringToString(pValueName, &Entry->StyleName);
+                    if (Entry->StyleName.Length > 0)
+                    {
+                        RtlAppendUnicodeToString(pValueName, L" ");
+                        RtlAppendUnicodeStringToString(pValueName, &Entry->StyleName);
+                    }
                 }
                 else
                 {
@@ -1437,7 +1443,10 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
             {
                 // L"... & Name StyleName\0"
                 Length = pValueName->Length + 3 * sizeof(WCHAR) + Entry->FaceName.Length +
-                         sizeof(WCHAR) + Entry->StyleName.Length + sizeof(UNICODE_NULL);
+                         sizeof(L' ') + Entry->StyleName.Length + sizeof(UNICODE_NULL);
+                if (Entry->StyleName.Length == 0)
+                    Length -= sizeof(L' ');
+
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
@@ -1445,8 +1454,11 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                     RtlCopyUnicodeString(&NewString, pValueName);
                     RtlAppendUnicodeToString(&NewString, L" & ");
                     RtlAppendUnicodeStringToString(&NewString, &Entry->FaceName);
-                    RtlAppendUnicodeToString(pValueName, L" ");
-                    RtlAppendUnicodeStringToString(&NewString, &Entry->StyleName);
+                    if (Entry->StyleName.Length > 0)
+                    {
+                        RtlAppendUnicodeToString(pValueName, L" ");
+                        RtlAppendUnicodeStringToString(&NewString, &Entry->StyleName);
+                    }
                 }
                 else
                 {
@@ -1459,6 +1471,9 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 _itow(PX2PT(FontGDI->EmHeight), szSize+1, 10);
 
                 Length = pValueName->Length + (wcslen(szSize) + 1) * sizeof(WCHAR);
+                if (Entry->StyleName.Length == 0)
+                    Length -= sizeof(WCHAR);
+
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1412,7 +1412,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    break;
+                    break;  /* failure */
                 }
             }
             else
@@ -1430,7 +1430,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 }
                 else
                 {
-                    break;
+                    break;  /* failure */
                 }
             }
         }
@@ -1457,7 +1457,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 else
                 {
                     RtlFreeUnicodeString(pValueName);
-                    break;
+                    break;  /* failure */
                 }
             }
             else
@@ -1476,7 +1476,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 else
                 {
                     RtlFreeUnicodeString(pValueName);
-                    break;
+                    break;  /* failure */
                 }
             }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1402,7 +1402,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
-                    RtlInitEmptyUnicodeString(pValueName, pszBuffer, (USHORT)Length);
+                    RtlInitEmptyUnicodeString(pValueName, pszBuffer, Length);
                     RtlCopyUnicodeString(pValueName, &Entry->FaceName);
                     if (Entry->StyleName.Length > 0)
                     {
@@ -1424,7 +1424,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
-                    RtlInitEmptyUnicodeString(pValueName, pszBuffer, (USHORT)Length);
+                    RtlInitEmptyUnicodeString(pValueName, pszBuffer, Length);
                     RtlCopyUnicodeString(pValueName, &Entry->FaceName);
                     RtlAppendUnicodeToString(pValueName, szSize);
                 }
@@ -1444,7 +1444,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
-                    RtlInitEmptyUnicodeString(&NewString, pszBuffer, (USHORT)Length);
+                    RtlInitEmptyUnicodeString(&NewString, pszBuffer, Length);
                     RtlCopyUnicodeString(&NewString, pValueName);
                     RtlAppendUnicodeToString(&NewString, L" & ");
                     RtlAppendUnicodeStringToString(&NewString, &Entry->FaceName);
@@ -1469,7 +1469,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
-                    RtlInitEmptyUnicodeString(&NewString, pszBuffer, (USHORT)Length);
+                    RtlInitEmptyUnicodeString(&NewString, pszBuffer, Length);
                     RtlCopyUnicodeString(&NewString, pValueName);
                     RtlAppendUnicodeToString(&NewString, szSize);
                 }
@@ -1694,7 +1694,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
             pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
             if (pszBuffer)
             {
-                RtlInitEmptyUnicodeString(&NewString, pszBuffer, (USHORT)Length);
+                RtlInitEmptyUnicodeString(&NewString, pszBuffer, Length);
                 NewString.Buffer[0] = UNICODE_NULL;
                 RtlAppendUnicodeStringToString(&NewString, &LoadFont.RegValueName);
                 RtlAppendUnicodeStringToString(&NewString, &TrueTypePostfix);
@@ -1717,7 +1717,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
             pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
             if (pszBuffer)
             {
-                RtlInitEmptyUnicodeString(&NewString, pszBuffer, (USHORT)Length);
+                RtlInitEmptyUnicodeString(&NewString, pszBuffer, Length);
                 NewString.Buffer[0] = UNICODE_NULL;
                 RtlAppendUnicodeStringToString(&NewString, &LoadFont.RegValueName);
                 RtlAppendUnicodeToString(&NewString, L" (");

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1450,7 +1450,7 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                     RtlAppendUnicodeStringToString(&NewString, &Entry->FaceName);
                     if (Entry->StyleName.Length > 0)
                     {
-                        RtlAppendUnicodeToString(pValueName, L" ");
+                        RtlAppendUnicodeToString(&NewString, L" ");
                         RtlAppendUnicodeStringToString(&NewString, &Entry->StyleName);
                     }
                 }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1610,7 +1610,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
     UNICODE_STRING PathName;
     LPWSTR pszBuffer;
     static const UNICODE_STRING TrueTypePostfix = RTL_CONSTANT_STRING(L" (TrueType)");
-    static const UNICODE_STRING DosPathPrefix = RTL_CONSTANT_STRING(L"\\\\.\\");
+    static const UNICODE_STRING DosPathPrefix = RTL_CONSTANT_STRING(L"\\\\?\\");
 
     /* Build PathName */
     if (dwFlags & AFRX_DOS_DEVICE_PATH)
@@ -1778,7 +1778,7 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
 INT FASTCALL
 IntGdiAddFontResource(PUNICODE_STRING FileName, DWORD Characteristics)
 {
-    return IntGdiAddFontResourceEx(FileName, Characteristics, AFRX_DOS_DEVICE_PATH);
+    return IntGdiAddFontResourceEx(FileName, Characteristics, 0);
 }
 
 /* Borrowed from shlwapi!PathIsRelativeW */

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1613,7 +1613,8 @@ IntGdiAddFontResourceEx(PUNICODE_STRING FileName, DWORD Characteristics,
     Length = wcslen(SharedUserData->NtSystemRoot);
     RtlStringCbCopyNW(szPath, sizeof(szPath), FileName->Buffer,
                       min(Length * sizeof(WCHAR), FileName->Length));
-    if (_wcsnicmp(szPath, SharedUserData->NtSystemRoot, Length) == 0)
+    if (FileName->Length > Length * sizeof(WCHAR) &&
+        _wcsnicmp(szPath, SharedUserData->NtSystemRoot, Length) == 0)
     {
         RtlStringCbCopyW(szPath, sizeof(szPath), L"\\SystemRoot");
         RtlStringCbCatNW(szPath, sizeof(szPath), &FileName->Buffer[Length],

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1399,9 +1399,6 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
             {
                 // L"Name StyleName\0"
                 Length = NameLength + sizeof(L' ') + Entry->StyleName.Length + sizeof(UNICODE_NULL);
-                if (Entry->StyleName.Length == 0)
-                    Length -= sizeof(L' ');
-
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
@@ -1444,9 +1441,6 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 // L"... & Name StyleName\0"
                 Length = pValueName->Length + 3 * sizeof(WCHAR) + Entry->FaceName.Length +
                          sizeof(L' ') + Entry->StyleName.Length + sizeof(UNICODE_NULL);
-                if (Entry->StyleName.Length == 0)
-                    Length -= sizeof(L' ');
-
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {
@@ -1471,9 +1465,6 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont)
                 _itow(PX2PT(FontGDI->EmHeight), szSize+1, 10);
 
                 Length = pValueName->Length + (wcslen(szSize) + 1) * sizeof(WCHAR);
-                if (Entry->StyleName.Length == 0)
-                    Length -= sizeof(WCHAR);
-
                 pszBuffer = ExAllocatePoolWithTag(PagedPool, Length, TAG_USTR);
                 if (pszBuffer)
                 {

--- a/win32ss/gdi/ntgdi/text.h
+++ b/win32ss/gdi/ntgdi/text.h
@@ -103,6 +103,7 @@ TEXTOBJ_UnlockText(PLFONT plfnt)
 /* dwFlags for IntGdiAddFontResourceEx */
 #define AFRX_WRITE_REGISTRY 0x1
 #define AFRX_ALTERNATIVE_PATH 0x2
+#define AFRX_DOS_DEVICE_PATH 0x4
 
 PTEXTOBJ FASTCALL RealizeFontInit(HFONT);
 NTSTATUS FASTCALL TextIntRealizeFont(HFONT,PTEXTOBJ);


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16269](https://jira.reactos.org/browse/CORE-16269)

- Fix and improve registry-based font entry management.
- Append style name to registry value name.
- Make some `DPRINT` `DPRINT1` (noisy).