### PR TITLE
[CMLIB] Clean volatile registry entries in the same manner as Windows

### DIFF
--- a/sdk/lib/cmlib/cminit.c
+++ b/sdk/lib/cmlib/cminit.c
@@ -121,6 +121,7 @@ CmpPrepareKey(
     ASSERT(KeyCell->Signature == CM_KEY_NODE_SIGNATURE);
 
     KeyCell->SubKeyCounts[Volatile] = 0;
+    // KeyCell->SubKeyLists[Volatile] = HCELL_NIL; // FIXME! Done only on Windows < XP.
 
     /* Enumerate and add subkeys */
     if (KeyCell->SubKeyCounts[Stable] > 0)

--- a/sdk/lib/cmlib/cminit.c
+++ b/sdk/lib/cmlib/cminit.c
@@ -120,7 +120,6 @@ CmpPrepareKey(
 
     ASSERT(KeyCell->Signature == CM_KEY_NODE_SIGNATURE);
 
-    KeyCell->SubKeyLists[Volatile] = HCELL_NIL;
     KeyCell->SubKeyCounts[Volatile] = 0;
 
     /* Enumerate and add subkeys */


### PR DESCRIPTION
This fixes the crashes in HvpGetCellMapped on Windows Server 2003 when booting from Freeloader, as mentioned in https://github.com/maharmstone/btrfs/issues/16.

When the bootloader loads the system hive, it cleans the data pertaining to any volatile keys. The Windows bootloader does this by setting SubKeyCounts[Volatile] to 0. After boot, the kernel marks any cell where this is 0 but SubKeyLists[Volatile] isn't HCELL_NIL as dirty, meaning that the sanitized version will then get flushed to the disk.

Because Freeloader sets SubKeyLists[Volatile] to HCELL_NIL straightaway, Windows thinks the cell is clean, and can unload it without flushing. If it then reads it from the disk, it will crash in HvpGetCellMapped due to the stale volatile pointers.

If you break on nt!CmpInitializeSystemHive on Windows and "gu" to the let the function run, you'll see that DirtyVector of the HHIVE has only the first 8 bits set. If you run it using the official bootloader, it'll have a lot more than that.

Bear in mind that I haven't tested this either on ReactOS, or any other version of Windows - but it's definitely the case for WS2003. You probably want to do your own testing before accepting this patch.