### PR TITLE
Add Xbox video miniport driver and fix a bug

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -282,11 +282,13 @@ vbe_1600x1200x8  = "VESA Display (1600x1200x8)",,VBE,1600,1200,8
 vbe_1600x1200x16 = "VESA Display (1600x1200x16)",,VBE,1600,1200,16
 vbe_1600x1200x24 = "VESA Display (1600x1200x24)",,VBE,1600,1200,24
 vbe_1600x1200x32 = "VESA Display (1600x1200x32)",,VBE,1600,1200,32
+xbox             = "Original Xbox NV2A Framebuffer (640x480x32)",,XboxVmp,640,480,32
 
 [Map.Display]
 ;<id> = <pnp id string>
 vga = "VGA Display"
 vbe = "VBE Display"
+xboxvmp = "NV2A Framebuffer"
 
 [Keyboard]
 Default = "XT-, AT- or extended keyboard (83-105 keys)"

--- a/media/inf/display.inf
+++ b/media/inf/display.inf
@@ -40,6 +40,7 @@ CopyFiles = VGA.Miniport_CopyFiles.NT, VGA.Display_CopyFiles.NT
 [VGA.Miniport_CopyFiles.NT]
 vgamp.sys
 vbemp.sys
+xboxvmp.sys
 
 [VGA.Display_CopyFiles.NT]
 vgaddi.dll
@@ -49,6 +50,7 @@ framebuf.dll
 AddService = , 0x00000002
 ;AddService = VGA, , VGA_Service_Inst
 ;AddService = VBE, 0x00000003, VBE_Service_Inst ; SPSVCINST_TAGTOFRONT + SPSVCINST_ASSOCSERVICE
+;AddService = XboxVmp, 0x00000003, XBOX_Service_Inst
 
 [VGA_Service_Inst]
 ServiceType   = 1
@@ -62,6 +64,13 @@ ServiceType   = 1
 StartType     = 1
 ErrorControl  = 0
 ServiceBinary = %12%\vbemp.sys
+LoadOrderGroup = Video Save
+
+[XBOX_Service_Inst]
+ServiceType   = 1
+StartType     = 1
+ErrorControl  = 0
+ServiceBinary = %12%\xboxvmp.sys
 LoadOrderGroup = Video Save
 
 ;-------------------------------- STRINGS -------------------------------

--- a/win32ss/drivers/miniport/xboxvmp/CMakeLists.txt
+++ b/win32ss/drivers/miniport/xboxvmp/CMakeLists.txt
@@ -2,3 +2,5 @@
 add_library(xboxvmp MODULE xboxvmp.c xboxvmp.rc)
 set_module_type(xboxvmp kernelmodedriver)
 add_importlibs(xboxvmp ntoskrnl videoprt)
+add_cd_file(TARGET xboxvmp DESTINATION reactos/system32/drivers FOR all)
+add_registry_inf(xboxvmp_reg.inf)

--- a/win32ss/drivers/miniport/xboxvmp/xboxvmp.c
+++ b/win32ss/drivers/miniport/xboxvmp/xboxvmp.c
@@ -71,19 +71,21 @@ XboxVmpFindAdapter(
   PXBOXVMP_DEVICE_EXTENSION XboxVmpDeviceExtension;
   VIDEO_ACCESS_RANGE AccessRanges[3];
   VP_STATUS Status;
+  USHORT VendorId = 0x10DE; /* NVIDIA Corporation */
+  USHORT DeviceId = 0x02A0; /* NV2A XGPU */
 
   VideoPortDebugPrint(Trace, "XboxVmpFindAdapter\n");
 
   XboxVmpDeviceExtension = (PXBOXVMP_DEVICE_EXTENSION) HwDeviceExtension;
   Status = VideoPortGetAccessRanges(HwDeviceExtension, 0, NULL, 3, AccessRanges,
-                                    NULL, NULL, NULL);
+                                    &VendorId, &DeviceId, NULL);
 
-  if (NO_ERROR == Status)
-    {
+  if (Status == NO_ERROR)
+  {
       XboxVmpDeviceExtension->PhysControlStart = AccessRanges[0].RangeStart;
       XboxVmpDeviceExtension->ControlLength = AccessRanges[0].RangeLength;
       XboxVmpDeviceExtension->PhysFrameBufferStart = AccessRanges[1].RangeStart;
-    }
+  }
 
   return Status;
 }

--- a/win32ss/drivers/miniport/xboxvmp/xboxvmp_reg.inf
+++ b/win32ss/drivers/miniport/xboxvmp/xboxvmp_reg.inf
@@ -1,0 +1,13 @@
+; Xbox Nvidia driver
+[AddReg]
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","ErrorControl",0x00010001,0x00000000
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Group",0x00000000,"Video Save"
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","ImagePath",0x00020000,"system32\drivers\xboxvmp.sys"
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Start",0x00010001,0x00000004
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Type",0x00010001,0x00000001
+HKLM,"SYSTEM\CurrentControlSet\Enum\PCI\VEN_10DE&DEV_02A0&SUBSYS_00000000&REV_A1\0000","Service",0x00000000,"XboxVmp"
+
+HKLM,"SYSTEM\CurrentControlSet\Hardware Profiles\Current\System\CurrentControlSet\Services\XboxVmp\Device0","InstalledDisplayDrivers",0x00010000,"framebuf"
+
+; This is not true but it allows to use 3rd party drivers while having the XboxVmp driver installed
+HKLM,"SYSTEM\CurrentControlSet\Hardware Profiles\Current\System\CurrentControlSet\Services\XboxVmp\Device0","VgaCompatible",0x00010001,1

--- a/win32ss/drivers/videoprt/resource.c
+++ b/win32ss/drivers/videoprt/resource.c
@@ -629,6 +629,7 @@ VideoPortGetAccessRanges(
                 /*
                  * Search for the device id and vendor id on this bus.
                  */
+                PciSlotNumber.u.bits.Reserved = 0;
                 for (DeviceNumber = 0; DeviceNumber < PCI_MAX_DEVICES; DeviceNumber++)
                 {
                     PciSlotNumber.u.bits.DeviceNumber = DeviceNumber;


### PR DESCRIPTION
- Added XboxVmp driver to system32/drivers directory
- Added required registry entries for it
- Made it compatible with current videoprt driver, specified vendor id and device id explicitly in `VideoPortGetAccessRanges()` call
- Fixed a bug in videoprt driver - `Reserved` bit field was uninitialized in `PciSlotNumber` variable, so `HalGetBusData()` call failed in this case (**important:** this might fix some other video driver issues!)

Tested and confirmed that driver doesn't interfere with VGA/VBE on normal PC installations.

JIRA issue: [CORE-16317](https://jira.reactos.org/browse/CORE-16317)

Please add to XBOX Boot milestone. :wink: 

![image](https://user-images.githubusercontent.com/578406/64049710-69089a00-cb7e-11e9-9bbc-d72cafc4a8ba.png)
