### PR TITLE
Add Regression test for "find" using BAT with Conditionals "&&" and "||"

### DIFF
--- a/modules/rostests/win32/cmd/test_builtins.cmd
+++ b/modules/rostests/win32/cmd/test_builtins.cmd
@@ -26,5 +26,17 @@ for %%i in (M,
 N,
 O
 ) do echo %%j
+echo ------------ Testing Amp-Amp ---------
+echo --- test for something that is TRUE
+ver | find "Ver" > NUL && Echo TRUE Amp-Amp
+echo ------------ Testing Amp-Amp ---------
+echo --- test for something that is FALSE
+ver | find "1234" > NUL && Echo FALSE Amp-Amp
+echo ------------ Testing Pipe-Pipe -------
+echo --- test for something that is TRUE
+ver | find "Ver" > NUL || Echo TRUE Pipe-Pipe
+echo ------------ Testing Pipe-Pipe -------
+echo --- test for something that is FALSE
+ver | find "1234" > NUL || Echo FALSE Pipe-Pipe
 echo ------------ End of Testing ------------
 echo --- Testing ends here

--- a/modules/rostests/win32/cmd/test_builtins.cmd.exp
+++ b/modules/rostests/win32/cmd/test_builtins.cmd.exp
@@ -23,5 +23,15 @@ I
 %j
 %j
 %j
+------------ Testing Amp-Amp ---------
+--- test for something that is TRUE
+TRUE Amp-Amp
+------------ Testing Amp-Amp ---------
+--- test for something that is FALSE
+------------ Testing Pipe-Pipe -------
+--- test for something that is TRUE
+------------ Testing Pipe-Pipe -------
+--- test for something that is FALSE
+FALSE Pipe-Pipe
 ------------ End of Testing ------------
 --- Testing ends here


### PR DESCRIPTION
CORE-16356 Test

Check for BAT Conditionals working using find.exe.

JIRA issue: [CORE-16356](https://jira.reactos.org/browse/CORE-16356)

_Add additional testing to cmd_rostest to test find using conditional logic._

![find_new_test_fails](https://user-images.githubusercontent.com/32620577/64072496-f8807c80-cc54-11e9-922f-8a10bda974ea.png)
