### PR TITLE
[HAL] Return correct bus handler in HaliFindBusAddressTranslation

### DIFF
--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -1319,7 +1319,7 @@ HaliFindBusAddressTranslation(IN PHYSICAL_ADDRESS BusAddress,
         }
 
         /* If we made it, we're done */
-        *Context = (ULONG_PTR)Handler;
+        *Context = (ULONG_PTR)&BusHandler->Handler;
         return TRUE;
     }
 


### PR DESCRIPTION
This fixes the bug when `VidInitialize` asks for different translated addresses and `VgaIsPresent` always returns FALSE either because the machine does not have VGA controller at all (e.g. 86Duino Zero), or it does have video hardware that is not compatible with VGA standard (e.g. Original Xbox).

The problem investigated by @binarymaster. Suggested fix by @ThFabba.

JIRA issues: [CORE-14625](https://jira.reactos.org/browse/CORE-14625), [CORE-16222](https://jira.reactos.org/browse/CORE-16222)