### PR TITLE
[HAL] Fix parser bugs in HalpDebugPciDumpBus

### DIFF
--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -809,7 +809,7 @@ HalpDebugPciDumpBus(IN ULONG i,
                     IN ULONG k,
                     IN PPCI_COMMON_CONFIG PciData)
 {
-    PCHAR p, ClassName, SubClassName, VendorName, ProductName, SubVendorName;
+    PCHAR p, ClassName, ClassEnd, SubClassName, VendorName, ProductName, SubVendorName;
     ULONG Length;
     CHAR LookupString[16] = "";
     CHAR bSubClassName[64] = "";
@@ -824,19 +824,28 @@ HalpDebugPciDumpBus(IN ULONG i,
     if (ClassName)
     {
         /* Isolate the subclass name */
-        ClassName += 6;
-        sprintf(LookupString, "\t%02x  ", PciData->SubClass);
+        ClassName += strlen("C 00  ");
+        ClassEnd = strstr(ClassName, "\nC ");
+        sprintf(LookupString, "\n\t%02x  ", PciData->SubClass);
         SubClassName = strstr(ClassName, LookupString);
-        if (SubClassName)
+        if (ClassEnd && SubClassName > ClassEnd)
         {
-            /* Copy the subclass into our buffer */
-            SubClassName += 5;
-            p = strpbrk(SubClassName, "\r\n");
-            Length = p - SubClassName;
-            if (Length >= sizeof(bSubClassName)) Length = sizeof(bSubClassName) - 1;
-            strncpy(bSubClassName, SubClassName, Length);
-            bSubClassName[Length] = '\0';
+            SubClassName = NULL;
         }
+        if (!SubClassName)
+        {
+            SubClassName = ClassName;
+        }
+        else
+        {
+            SubClassName += strlen("\n\t00  ");
+        }
+        /* Copy the subclass into our buffer */
+        p = strpbrk(SubClassName, "\r\n");
+        Length = p - SubClassName;
+        if (Length >= sizeof(bSubClassName)) Length = sizeof(bSubClassName) - 1;
+        strncpy(bSubClassName, SubClassName, Length);
+        bSubClassName[Length] = '\0';
     }
 
     /* Isolate the vendor name */


### PR DESCRIPTION
I noticed one of these bugs when reading debug logs from real hardware Xbox 1.3. :slightly_smiling_face: 

## Proposed changes
- Match subclass properly, don't match third subclass
- Don't match subclass from next class, add ClassEnd boundary
- Use class name if subclass name not available
- Gracefully return "Unknown" if no class name found
### BEFORE
```
00:03.0 16650 [0703]
00:03.0  [0750]
00:03.0 USB controller [0b03]
00:03.0  [4000]
00:03.0  [1403]
```
### AFTER
```
00:03.0 Modem [0703]
00:03.0 Communication controller [0750]
00:03.0 Processor [0b03]
00:03.0 Coprocessor [4000]
00:03.0 Unknown [1403]
```