### PR TITLE
[BTRFS] Remove 2 hacks, not needed anymore

### DIFF
--- a/drivers/filesystems/btrfs/btrfs.c
+++ b/drivers/filesystems/btrfs/btrfs.c
@@ -4785,21 +4785,7 @@ static NTSTATUS mount_vol(_In_ PDEVICE_OBJECT DeviceObject, _In_ PIRP Irp) {
         goto exit;
     }
 
-    /* HACK: stream file object seems to get deleted at some point
-     * leading to use after free when installing ReactOS on
-     * BtrFS.
-     * Workaround: leak a handle to the fileobject
-     * XXX: Could be improved by storing it somewhere and releasing it
-     * on dismount. Or even by referencing again the file object.
-     */
-#ifndef __REACTOS__
     Vcb->root_file = IoCreateStreamFileObject(NULL, DeviceToMount);
-#else
-    {
-        HANDLE Dummy;
-        Vcb->root_file = IoCreateStreamFileObjectEx(NULL, DeviceToMount, &Dummy);
-    }
-#endif
     Vcb->root_file->FsContext = root_fcb;
     Vcb->root_file->SectionObjectPointer = &root_fcb->nonpaged->segment_object;
     Vcb->root_file->Vpb = DeviceObject->Vpb;

--- a/drivers/filesystems/btrfs/btrfs.c
+++ b/drivers/filesystems/btrfs/btrfs.c
@@ -5949,19 +5949,12 @@ NTSTATUS __stdcall DriverEntry(_In_ PDRIVER_OBJECT DriverObject, _In_ PUNICODE_S
 
     InitializeObjectAttributes(&oa, RegistryPath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
     Status = ZwCreateKey(&regh, KEY_QUERY_VALUE | KEY_ENUMERATE_SUB_KEYS | KEY_NOTIFY, &oa, 0, NULL, REG_OPTION_NON_VOLATILE, &dispos);
-    /* ReactOS specific hack: allow BtrFS driver to start in 1st stage with no hive */
-#ifndef __REACTOS__
     if (!NT_SUCCESS(Status)) {
         ERR("ZwCreateKey returned %08x\n", Status);
         return Status;
     }
 
     watch_registry(regh);
-#else
-    if (NT_SUCCESS(Status)) {
-        watch_registry(regh);
-    }
-#endif
 
     Status = IoCreateDevice(DriverObject, sizeof(bus_device_extension), NULL, FILE_DEVICE_UNKNOWN,
                             FILE_DEVICE_SECURE_OPEN, false, &busobj);


### PR DESCRIPTION
I tested 3 existing hacks: 1 is still required, 2 seem not needed anymore.
I don't know what fixed these cases.
Please, double-check.

Stages 1-2-3 custom logs:
```
Btrfs ERR : DriverEntry : ReactOS hack removed: ZwCreateKey succeeded
WARNING:  NtNotifyChangeMultipleKeys at ntoskrnl/config/ntapi.c:1450 is UNIMPLEMENTED!
Btrfs ERR : watch_registry : ZwNotifyChangeKey returned c0000002
Btrfs ERR : DriverEntry : ReactOS hack: Do not create mountmgr_thread
...
Btrfs ERR : mount_vol : ReactOS hack removed: Do not leak a dummy handle
```

I tried with system wide DPH too, but install hangs (CPU=100%) on 'Importing registry.inf'', even on FAT32 :-/