### PR TITLE
Allow Freeloader to boot Vista

### DIFF
--- a/boot/freeldr/freeldr/bootmgr.c
+++ b/boot/freeldr/freeldr/bootmgr.c
@@ -65,6 +65,7 @@ static const struct
 #endif
     {"Windows"     , EditCustomBootNTOS , LoadAndBootWindows},
     {"Windows2003" , EditCustomBootNTOS , LoadAndBootWindows},
+    {"WindowsVista", EditCustomBootNTOS , LoadAndBootWindows},
 };
 
 /* FUNCTIONS ******************************************************************/

--- a/boot/freeldr/freeldr/ntldr/arch/amd64/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/amd64/winldr.c
@@ -345,7 +345,7 @@ Amd64SetupIdt(PVOID IdtBase)
 }
 
 VOID
-WinLdrSetProcessorContext(void)
+WinLdrSetProcessorContext(USHORT OperatingSystemVersion)
 {
     TRACE("WinLdrSetProcessorContext\n");
 

--- a/boot/freeldr/freeldr/ntldr/arch/arm/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/arm/winldr.c
@@ -249,7 +249,7 @@ MempAllocatePageTables(VOID)
 }
 
 VOID
-WinLdrSetProcessorContext(VOID)
+WinLdrSetProcessorContext(USHORT OperatingSystemVersion)
 {
     ARM_CONTROL_REGISTER ControlRegister;
     ARM_TTB_REGISTER TtbRegister;

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -503,7 +503,7 @@ void WinLdrSetupMachineDependent(PLOADER_PARAMETER_BLOCK LoaderBlock)
 
 
 VOID
-WinLdrSetProcessorContext(void)
+WinLdrSetProcessorContext(USHORT OperatingSystemVersion)
 {
     GDTIDT GdtDesc, IdtDesc, OldIdt;
     PKGDTENTRY    pGdt;
@@ -600,15 +600,19 @@ WinLdrSetProcessorContext(void)
      * Longhorn/Vista reports LimitLow == 0x0fff == MM_PAGE_SIZE - 1, whereas
      * Windows 7+ uses larger sizes there (not aligned on a page boundary).
      */
-#if 1
-    /* Server 2003 way */
-    KiSetGdtEntryEx(KiGetGdtEntry(pGdt, KGDT_R0_PCR), (ULONG32)Pcr, 0x1,
-                    TYPE_DATA, DPL_SYSTEM, TRUE, 2);
-#else
-    /* Vista+ way */
-    KiSetGdtEntry(KiGetGdtEntry(pGdt, KGDT_R0_PCR), (ULONG32)Pcr, MM_PAGE_SIZE - 1,
-                  TYPE_DATA, DPL_SYSTEM, 2);
-#endif
+    if (OperatingSystemVersion < _WIN32_WINNT_VISTA)
+    {
+        /* Server 2003 way */
+        KiSetGdtEntryEx(KiGetGdtEntry(pGdt, KGDT_R0_PCR), (ULONG32)Pcr, 0x1,
+                        TYPE_DATA, DPL_SYSTEM, TRUE, 2);
+    }
+    else
+    {
+        /* Vista+ way */
+        KiSetGdtEntry(KiGetGdtEntry(pGdt, KGDT_R0_PCR), (ULONG32)Pcr, MM_PAGE_SIZE - 1,
+                    TYPE_DATA, DPL_SYSTEM, 2);
+    }
+
     // DumpGDTEntry(GdtDesc.Base, KGDT_R0_PCR);
 
     /* KGDT_R3_TEB (0x38) Thread Environment Block Selector (Ring 3) */

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -319,7 +319,7 @@ MempSetupPaging(IN PFN_NUMBER StartPage,
         }
 
         PhysicalPT[Page & 0x3ff].PageFrameNumber = Page;
-        PhysicalPT[Page & 0x3ff].Valid = (Page != 0);
+        PhysicalPT[Page & 0x3ff].Valid = 1;
         PhysicalPT[Page & 0x3ff].Write = (Page != 0);
 
         if (KernelMapping)

--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -160,7 +160,10 @@ SetupLdrScanBootDrivers(PLIST_ENTRY BootDriverListHead, HINF InfHandle, PCSTR Se
                 Success = WinLdrAddDriverToList(BootDriverListHead,
                                                 L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\",
                                                 ImagePathW,
-                                                ServiceName);
+                                                ServiceName,
+                                                NULL,
+                                                1,
+                                                (ULONG)-1);
                 if (!Success)
                 {
                     ERR("Could not add boot driver '%s', '%s'\n", SearchPath, DriverName);

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -991,7 +991,7 @@ LoadAndBootWindowsCommon(
     WinLdrSetupMemoryLayout(LoaderBlock);
 
     /* Set processor context */
-    WinLdrSetProcessorContext();
+    WinLdrSetProcessorContext(OperatingSystemVersion);
 
     /* Save final value of LoaderPagesSpanned */
     LoaderBlock->Extension->LoaderPagesSpanned = LoaderPagesSpanned;

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -204,6 +204,13 @@ WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
         // FIXME: Extension->AcpiTableSize;
     }
 
+    Extension->BootViaWinload = 1;
+
+    InitializeListHead(&Extension->BootApplicationPersistentData);
+    List_PaToVa(&Extension->BootApplicationPersistentData);
+
+    Extension->LoaderPerformanceData = PaToVa(&WinLdrSystemBlock->LoaderPerformanceData);
+
 #ifdef _M_IX86
     /* Set headless block pointer */
     if (WinLdrTerminalConnected)
@@ -752,6 +759,10 @@ LoadAndBootWindows(
     else if (_stricmp(ArgValue, "WindowsNT40") == 0)
     {
         OperatingSystemVersion = _WIN32_WINNT_NT4;
+    }
+    else if (_stricmp(ArgValue, "WindowsVista") == 0)
+    {
+        OperatingSystemVersion = _WIN32_WINNT_VISTA;
     }
     else
     {

--- a/boot/freeldr/freeldr/ntldr/winldr.h
+++ b/boot/freeldr/freeldr/ntldr/winldr.h
@@ -58,6 +58,7 @@ typedef struct _LOADER_SYSTEM_BLOCK
     CHAR NtBootPathName[MAX_PATH+1];
     CHAR NtHalPathName[MAX_PATH+1];
     ARC_DISK_INFORMATION ArcDiskInformation;
+    LOADER_PERFORMANCE_DATA LoaderPerformanceData;
 } LOADER_SYSTEM_BLOCK, *PLOADER_SYSTEM_BLOCK;
 
 extern PLOADER_SYSTEM_BLOCK WinLdrSystemBlock;

--- a/boot/freeldr/freeldr/ntldr/winldr.h
+++ b/boot/freeldr/freeldr/ntldr/winldr.h
@@ -108,7 +108,10 @@ BOOLEAN
 WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
                       PWSTR RegistryPath,
                       PWSTR ImagePath,
-                      PWSTR ServiceName);
+                      PWSTR ServiceName,
+                      PWSTR GroupName,
+                      ULONG ErrorControl,
+                      ULONG Tag);
 
 VOID
 WinLdrpDumpMemoryDescriptors(PLOADER_PARAMETER_BLOCK LoaderBlock);

--- a/boot/freeldr/freeldr/ntldr/winldr.h
+++ b/boot/freeldr/freeldr/ntldr/winldr.h
@@ -134,7 +134,7 @@ VOID
 WinLdrSetupMachineDependent(PLOADER_PARAMETER_BLOCK LoaderBlock);
 
 VOID
-WinLdrSetProcessorContext(VOID);
+WinLdrSetProcessorContext(USHORT OperatingSystemVersion);
 
 // arch/xxx/winldr.c
 BOOLEAN

--- a/boot/freeldr/freeldr/ntldr/wlmemory.c
+++ b/boot/freeldr/freeldr/ntldr/wlmemory.c
@@ -185,7 +185,7 @@ WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock)
     PPAGE_LOOKUP_TABLE_ITEM MemoryMap;
     ULONG LastPageType;
     //PKTSS Tss;
-    //BOOLEAN Status;
+    BOOLEAN Status;
 
     /* Cleanup heap */
     FrLdrHeapCleanupAll();
@@ -229,15 +229,14 @@ WinLdrSetupMemoryLayout(IN OUT PLOADER_PARAMETER_BLOCK LoaderBlock)
     MemoryMapSizeInPages = (NoEntries * sizeof(PAGE_LOOKUP_TABLE_ITEM) + MM_PAGE_SIZE - 1) / MM_PAGE_SIZE;
 
     TRACE("Got memory map with %d entries\n", NoEntries);
-#if 0
-    // Always contiguously map low 1Mb of memory
-    Status = MempSetupPaging(0, 0x100, FALSE);
+
+    // Always map first page of memory
+    Status = MempSetupPaging(0, 1, FALSE);
     if (!Status)
     {
-        ERR("Error during MempSetupPaging of low 1Mb\n");
+        ERR("Error during MempSetupPaging of first page\n");
         return FALSE;
     }
-#endif
 
     /* Before creating the map, we need to map pages to kernel mode */
     LastPageIndex = 1;

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -106,7 +106,10 @@ WinLdrLoadSystemHive(
         Success = WinLdrAddDriverToList(&LoaderBlock->BootDriverListHead,
                                         L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\",
                                         NULL,
-                                        (PWSTR)FsService);
+                                        (PWSTR)FsService,
+                                        L"FileSystem",
+                                        1,
+                                        (ULONG)-1);
         if (!Success)
             TRACE(" Failed to add filesystem service\n");
     }
@@ -495,6 +498,7 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
     ULONG ValueType;
     ULONG StartValue;
     ULONG TagValue;
+    ULONG ErrorControl;
     WCHAR DriverGroup[256];
     ULONG DriverGroupSize;
 
@@ -593,6 +597,11 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
                 rc = RegQueryValue(hDriverKey, L"Group", NULL, (PUCHAR)DriverGroup, &DriverGroupSize);
                 //TRACE_CH(REACTOS, "  Group: '%S'  \n", DriverGroup);
 
+                /* Read the error control value */
+                ValueSize = sizeof(ULONG);
+                rc = RegQueryValue(hDriverKey, L"ErrorControl", &ValueType, (PUCHAR)&ErrorControl, &ValueSize);
+                if (rc != ERROR_SUCCESS) ErrorControl = 0;
+
                 /* Make sure it should be started */
                 if ((StartValue == 0) &&
                     (TagValue == OrderList[TagIndex]) &&
@@ -624,7 +633,10 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
                     Success = WinLdrAddDriverToList(BootDriverListHead,
                                                     L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\",
                                                     TempImagePath,
-                                                    ServiceName);
+                                                    ServiceName,
+                                                    DriverGroup,
+                                                    ErrorControl,
+                                                    TagValue);
                     if (!Success)
                         ERR("Failed to add boot driver\n");
                 }
@@ -672,6 +684,11 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
             rc = RegQueryValue(hDriverKey, L"Group", NULL, (PUCHAR)DriverGroup, &DriverGroupSize);
             //TRACE_CH(REACTOS, "  Group: '%S'  \n", DriverGroup);
 
+            /* Read the error control value */
+            ValueSize = sizeof(ULONG);
+            rc = RegQueryValue(hDriverKey, L"ErrorControl", &ValueType, (PUCHAR)&ErrorControl, &ValueSize);
+            if (rc != ERROR_SUCCESS) ErrorControl = 0;
+
             for (TagIndex = 1; TagIndex <= OrderList[0]; TagIndex++)
             {
                 if (TagValue == OrderList[TagIndex]) break;
@@ -703,7 +720,10 @@ WinLdrScanRegistry(IN OUT PLIST_ENTRY BootDriverListHead,
                 Success = WinLdrAddDriverToList(BootDriverListHead,
                                                 L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\",
                                                 TempImagePath,
-                                                ServiceName);
+                                                ServiceName,
+                                                DriverGroup,
+                                                ErrorControl,
+                                                TagValue);
                 if (!Success)
                     ERR(" Failed to add boot driver\n");
             }
@@ -768,7 +788,10 @@ BOOLEAN
 WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
                       PWSTR RegistryPath,
                       PWSTR ImagePath,
-                      PWSTR ServiceName)
+                      PWSTR ServiceName,
+                      PWSTR GroupName,
+                      ULONG ErrorControl,
+                      ULONG Tag)
 {
     PBOOT_DRIVER_LIST_ENTRY BootDriverEntry;
     NTSTATUS Status;
@@ -861,6 +884,38 @@ WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
     Status = RtlAppendUnicodeToString(&BootDriverEntry->RegistryPath, ServiceName);
     if (!NT_SUCCESS(Status))
         return FALSE;
+
+    BootDriverEntry->ServiceName.Length = wcslen(ServiceName) * sizeof(WCHAR);
+    BootDriverEntry->ServiceName.MaximumLength = BootDriverEntry->ServiceName.Length;
+    BootDriverEntry->ServiceName.Buffer = FrLdrHeapAlloc(BootDriverEntry->ServiceName.Length, TAG_WLDR_NAME);
+    if (!BootDriverEntry->ServiceName.Buffer)
+        return FALSE;
+
+    RtlCopyMemory(BootDriverEntry->ServiceName.Buffer, ServiceName, BootDriverEntry->ServiceName.Length);
+
+    if (GroupName)
+    {
+        BootDriverEntry->GroupName.Length = wcslen(GroupName) * sizeof(WCHAR);
+        BootDriverEntry->GroupName.MaximumLength = BootDriverEntry->GroupName.Length;
+        BootDriverEntry->GroupName.Buffer = FrLdrHeapAlloc(BootDriverEntry->GroupName.Length, TAG_WLDR_NAME);
+        if (!BootDriverEntry->GroupName.Buffer)
+            return FALSE;
+
+        RtlCopyMemory(BootDriverEntry->GroupName.Buffer, GroupName, BootDriverEntry->GroupName.Length);
+    }
+    else
+    {
+        BootDriverEntry->GroupName.Length = 0;
+        BootDriverEntry->GroupName.MaximumLength = 0;
+        BootDriverEntry->GroupName.Buffer = NULL;
+    }
+
+    BootDriverEntry->Status = STATUS_SUCCESS;
+    BootDriverEntry->unk1 = 0;
+    BootDriverEntry->Tag = Tag;
+    BootDriverEntry->ErrorControl = ErrorControl;
+    BootDriverEntry->unk2 = NULL;
+    BootDriverEntry->unk3 = NULL;
 
     // Insert entry into the list
     if (!InsertInBootDriverList(BootDriverListHead, BootDriverEntry))

--- a/sdk/include/reactos/arc/arc.h
+++ b/sdk/include/reactos/arc/arc.h
@@ -201,6 +201,15 @@ typedef struct _BOOT_DRIVER_LIST_ENTRY
     UNICODE_STRING FilePath;
     UNICODE_STRING RegistryPath;
     struct _LDR_DATA_TABLE_ENTRY *LdrEntry;
+    // Vista extensions
+    NTSTATUS Status;
+    ULONG unk1;
+    UNICODE_STRING GroupName;
+    UNICODE_STRING ServiceName;
+    ULONG Tag;
+    ULONG ErrorControl;
+    void* unk2;
+    void* unk3;
 } BOOT_DRIVER_LIST_ENTRY, *PBOOT_DRIVER_LIST_ENTRY;
 
 typedef struct _ARC_DISK_SIGNATURE


### PR DESCRIPTION
This is a series of patches to allow Freeloader to boot Windows Vista.

I couldn't get Freeloader to read the Vista NTFS volume - it complains about not being able to read the MFT. It works well enough with Btrfs though, which was the aim anyway.

If you are testing this, make sure you grab the latest patches at https://github.com/maharmstone/btrfs, otherwise you'll encounter a race condition. You will also need to set your CPU to only have one core, otherwise it'll fail - I'm guessing Vista moved the SMP initialization code from the kernel into the bootloader.

The new fields in BOOT_DRIVER_LIST_ENTRY are an educated guess, as it doesn't seem to be documented anywhere. The most important field is what I've called "Status" - if the high bit is set, the kernel won't load the driver (I'm assuming this is `NT_SUCCESS(Status)`). The Tag field as set by NTLDR doesn't exactly match what's in the Registry, as it changes some values for some reason, but it works for us here.

I've not tested this with ReactOS, but it still works with Windows Server 2003.