### PR TITLE
[ROSTESTS] Skip flaky tests

### DIFF
--- a/modules/rostests/apitests/kernel32/TunnelCache.c
+++ b/modules/rostests/apitests/kernel32/TunnelCache.c
@@ -176,6 +176,7 @@ Test_LongTests(void)
     ok(GetFileTime(hFile, &File1Time, NULL, NULL) != FALSE, "GetFileTime() failed\n");
     CloseHandle(hFile);
 
+    ros_skip_flaky
     ok(RtlCompareMemory(&FileTime, &File1Time, sizeof(FILETIME)) == sizeof(FILETIME), "Tunnel cache failed\n");
 
     DeleteFile("file2");

--- a/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
@@ -119,6 +119,7 @@ Test_ProcessTimes(void)
                                        sizeof(KERNEL_USER_TIMES),
                                        NULL);
     ok_hex(Status, STATUS_SUCCESS);
+    ros_skip_flaky
     ok(Times1.CreateTime.QuadPart < TestStartTime.QuadPart,
        "CreateTime is %I64u, expected < %I64u\n", Times1.CreateTime.QuadPart, TestStartTime.QuadPart);
     ok(Times1.CreateTime.QuadPart > TestStartTime.QuadPart - 100000000LL,
@@ -126,6 +127,7 @@ Test_ProcessTimes(void)
     ok(Times1.ExitTime.QuadPart == 0,
        "ExitTime is %I64u, expected 0\n", Times1.ExitTime.QuadPart);
     ok(Times1.KernelTime.QuadPart != 0, "KernelTime is 0\n");
+    ros_skip_flaky
     ok(Times1.UserTime.QuadPart != 0, "UserTime is 0\n");
 
     /* Do some busy waiting to increase UserTime */
@@ -162,9 +164,11 @@ Test_ProcessTimes(void)
     /* Time values must have increased */
     ok(Times2.KernelTime.QuadPart > Times1.KernelTime.QuadPart,
        "KernelTime values inconsistent. Expected %I64u > %I64u\n", Times2.KernelTime.QuadPart, Times1.KernelTime.QuadPart);
+    ros_skip_flaky
     ok(Times2.UserTime.QuadPart > Times1.UserTime.QuadPart,
        "UserTime values inconsistent. Expected %I64u > %I64u\n", Times2.UserTime.QuadPart, Times1.UserTime.QuadPart);
     /* They can't have increased by more than wall clock time difference (we only have one thread) */
+    ros_skip_flaky
     ok(Times2.KernelTime.QuadPart - Times1.KernelTime.QuadPart < Time2.QuadPart - Time1.QuadPart,
        "KernelTime values inconsistent. Expected %I64u - %I64u < %I64u\n",
        Times2.KernelTime.QuadPart, Times1.KernelTime.QuadPart, Time2.QuadPart - Time1.QuadPart);

--- a/modules/rostests/apitests/user32/RedrawWindow.c
+++ b/modules/rostests/apitests/user32/RedrawWindow.c
@@ -19,6 +19,7 @@ WndProc(
     _In_ WPARAM wParam,
     _In_ LPARAM lParam)
 {
+    disable_success_count
     ok(GetCurrentThreadId() == dwThreadId, "Thread 0x%lx instead of 0x%lx\n", GetCurrentThreadId(), dwThreadId);
     if (message == WM_PAINT)
     {

--- a/modules/rostests/apitests/user32/SetProp.c
+++ b/modules/rostests/apitests/user32/SetProp.c
@@ -158,6 +158,7 @@ START_TEST(SetProp)
     /* In particular we shouldn't see these from WM_SETICON */
     SysICAtom = RegisterWindowMessageW(L"SysIC");
     Prop = GetPropW(hWnd, (PCWSTR)MAKEINTATOM(SysICAtom));
+    ros_skip_flaky
     ok(Prop == NULL, "SysIC prop (0x%04x) is %p\n", SysICAtom, Prop);
 
     SysICSAtom = RegisterWindowMessageW(L"SysICS");

--- a/modules/rostests/winetests/gdi32/bitmap.c
+++ b/modules/rostests/winetests/gdi32/bitmap.c
@@ -5586,8 +5586,8 @@ static void test_SetDIBitsToDevice_RLE8(void)
     for (i = 0; i < 24; i++) ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
     for (i = 24; i < 64; i++)
         if (i == 52) ok( dib_bits[i] == 0x00808080, "%d: got %08x\n", i, dib_bits[i] );
-        else if (i & 4) ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
-        else ok( dib_bits[i] == bottom_up[i - 20], "%d: got %08x\n", i, dib_bits[i] );
+        else if (i & 4) ros_skip_flaky ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
+        else ros_skip_flaky ok(dib_bits[i] == bottom_up[i - 20], "%d: got %08x\n", i, dib_bits[i]);
     memset( dib_bits, 0xaa, 64 * 4 );
 
     /* top-down compressed dibs are invalid */
@@ -5653,8 +5653,8 @@ static void test_SetDIBitsToDevice_RLE8(void)
     ok( ret == 37, "got %d\n", ret );
     for (i = 0; i < 40; i++)
         if (i == 12) ok( dib_bits[i] == 0x00808080, "%d: got %08x\n", i, dib_bits[i] );
-        else if (i & 4) ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
-        else ok( dib_bits[i] == top_down[i + 28], "%d: got %08x\n", i, dib_bits[i] );
+        else if (i & 4) ros_skip_flaky ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
+        else ros_skip_flaky ok( dib_bits[i] == top_down[i + 28], "%d: got %08x\n", i, dib_bits[i] );
     for (i = 40; i < 64; i++) ok( dib_bits[i] == 0xaaaaaaaa, "%d: got %08x\n", i, dib_bits[i] );
     memset( dib_bits, 0xaa, 64 * 4 );
 

--- a/modules/rostests/winetests/gdi32/path.c
+++ b/modules/rostests/winetests/gdi32/path.c
@@ -420,6 +420,7 @@ static void ok_path(HDC hdc, const char *path_name, const path_test_t *expected,
     size = GetPath(hdc, pnt, types, size);
     assert(size > 0);
 
+    ros_skip_flaky
     ok( size == expected_size, "%s: Path size %d does not match expected size %d\n",
         path_name, size, expected_size);
 
@@ -429,11 +430,13 @@ static void ok_path(HDC hdc, const char *path_name, const path_test_t *expected,
          * floating point to integer conversion */
         static const int fudge = 2;
 
+        ros_skip_flaky
         ok( types[idx] == expected[idx].type, "%s: Expected #%d: %s (%d,%d) but got %s (%d,%d)\n",
             path_name, idx, type_string[expected[idx].type], expected[idx].x, expected[idx].y,
             type_string[types[idx]], pnt[idx].x, pnt[idx].y);
 
         if (types[idx] == expected[idx].type)
+            ros_skip_flaky
             ok( (pnt[idx].x >= expected[idx].x - fudge && pnt[idx].x <= expected[idx].x + fudge) &&
                 (pnt[idx].y >= expected[idx].y - fudge && pnt[idx].y <= expected[idx].y + fudge),
                 "%s: Expected #%d: %s  position (%d,%d) but got (%d,%d)\n", path_name, idx,

--- a/modules/rostests/winetests/kernel32/mailslot.c
+++ b/modules/rostests/winetests/kernel32/mailslot.c
@@ -324,6 +324,7 @@ todo_wine
     ok( !ReadFile( hSlot, buffer, sizeof buffer, &count, NULL), "slot read\n");
     ok( GetLastError() == ERROR_SEM_TIMEOUT, "wrong error %u\n", GetLastError() );
     dwTimeout = GetTickCount() - dwTimeout;
+    ros_skip_flaky
     ok( dwTimeout >= 990, "timeout too short %u\n", dwTimeout );
     ok( CloseHandle( hSlot ), "closing the mailslot\n");
 

--- a/modules/rostests/winetests/kernel32/pipe.c
+++ b/modules/rostests/winetests/kernel32/pipe.c
@@ -117,6 +117,7 @@ static BOOL RpcReadFile(HANDLE hFile, LPVOID buffer, DWORD bytesToRead, LPDWORD 
 static void _test_not_signaled(unsigned line, HANDLE handle)
 {
     DWORD res = WaitForSingleObject(handle, 0);
+    disable_success_count
     ok_(__FILE__,line)(res == WAIT_TIMEOUT, "WaitForSingleObject returned %u (%u)\n", res, GetLastError());
 }
 
@@ -2784,7 +2785,9 @@ static void _overlapped_write_async(unsigned line, HANDLE writer, void *buf, DWO
     memset(overlapped, 0, sizeof(*overlapped));
     overlapped->hEvent = CreateEventW(NULL, TRUE, FALSE, NULL);
     res = WriteFile(writer, buf, size, &written_bytes, overlapped);
+    disable_success_count
     ok_(__FILE__,line)(!res && GetLastError() == ERROR_IO_PENDING, "WriteFile returned %x(%u)\n", res, GetLastError());
+    disable_success_count
     ok_(__FILE__,line)(!written_bytes, "written_bytes = %u\n", written_bytes);
 
     _test_not_signaled(line, overlapped->hEvent);

--- a/modules/rostests/winetests/kernel32/process.c
+++ b/modules/rostests/winetests/kernel32/process.c
@@ -2572,7 +2572,7 @@ static void test_TerminateJobObject(void)
 
     ret = GetExitCodeProcess(pi.hProcess, &dwret);
     ok(ret, "GetExitCodeProcess error %u\n", GetLastError());
-    ok(dwret == 123 || broken(dwret == 0) /* randomly fails on Win 2000 / XP */,
+    ok(dwret == 123 || broken(dwret == 0) || broken(dwret == 259) /* randomly fails on Win 2000 / XP */,
        "wrong exitcode %u\n", dwret);
 
     CloseHandle(pi.hProcess);
@@ -3419,7 +3419,9 @@ static void test_SuspendProcessState(void)
 #endif
 
     ret = ReadProcessMemory( pi.hProcess, peb_ptr, &child_peb, sizeof(child_peb), NULL );
+    ros_skip_flaky
     ok( ret, "Failed to read PEB (%u)\n", GetLastError() );
+    ros_skip_flaky
     ok( child_peb.ImageBaseAddress == exe_base, "wrong base %p/%p\n",
         child_peb.ImageBaseAddress, exe_base );
     ok( entry_ptr == (char *)exe_base + nt_header.OptionalHeader.AddressOfEntryPoint,

--- a/modules/rostests/winetests/kernel32/sync.c
+++ b/modules/rostests/winetests/kernel32/sync.c
@@ -778,6 +778,7 @@ static void test_iocp_callback(void)
 static void CALLBACK timer_queue_cb1(PVOID p, BOOLEAN timedOut)
 {
     int *pn = p;
+    disable_success_count
     ok(timedOut, "Timer callbacks should always time out\n");
     ++*pn;
 }
@@ -2571,12 +2572,14 @@ static DWORD WINAPI apc_deadlock_thread(void *param)
         size = 0x1000;
         status = pNtAllocateVirtualMemory(pi->hProcess, &base, 0, &size,
                                           MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        disable_success_count
         ok(!status, "expected STATUS_SUCCESS, got %08x\n", status);
         ok(base != NULL, "expected base != NULL, got %p\n", base);
         SetEvent(info->event);
 
         size = 0;
         status = pNtFreeVirtualMemory(pi->hProcess, &base, &size, MEM_RELEASE);
+        disable_success_count
         ok(!status, "expected STATUS_SUCCESS, got %08x\n", status);
         SetEvent(info->event);
     }
@@ -2613,6 +2616,7 @@ static void test_apc_deadlock(void)
     result = WaitForSingleObject(event, 1000);
     ok(result == WAIT_OBJECT_0, "expected WAIT_OBJECT_0, got %u\n", result);
 
+    disable_success_count
     for (i = 0; i < 1000; i++)
     {
         result = SuspendThread(pi.hThread);

--- a/modules/rostests/winetests/mshtml/xmlhttprequest.c
+++ b/modules/rostests/winetests/mshtml/xmlhttprequest.c
@@ -231,9 +231,11 @@ static HRESULT WINAPI xmlhttprequest_onreadystatechange(IDispatchEx *iface, DISP
     LONG val;
     HRESULT hres;
 
+    if (!expect_xmlhttprequest_onreadystatechange_loading)
     test_event_args(&DIID_DispHTMLXMLHttpRequest, id, wFlags, pdp, pvarRes, pei, pspCaller);
 
     hres = IHTMLXMLHttpRequest_get_readyState(xhr, &val);
+    disable_success_count
     ok(hres == S_OK, "get_readyState failed: %08x\n", hres);
     readystatechange_cnt++;
 
@@ -246,6 +248,7 @@ static HRESULT WINAPI xmlhttprequest_onreadystatechange(IDispatchEx *iface, DISP
             break;
         case 3:
             loading_cnt++;
+            disable_success_count
             CHECK_EXPECT2(xmlhttprequest_onreadystatechange_loading);
             break;
         case 4:

--- a/modules/rostests/winetests/msi/msi.c
+++ b/modules/rostests/winetests/msi/msi.c
@@ -13505,6 +13505,7 @@ static void test_MsiEnumProducts(void)
     ok(r == ERROR_NO_MORE_ITEMS, "Expected ERROR_NO_MORE_ITEMS, got %u\n", r);
     ok(found1, "product1 not found\n");
     ok(found2, "product2 not found\n");
+    ros_skip_flaky
     ok(found3, "product3 not found\n");
 
     delete_key(key1, "", access & KEY_WOW64_64KEY);
@@ -13693,17 +13694,24 @@ static void test_MsiEnumProductsEx(void)
             ok( !sid[0], "got \"%s\"\n", sid );
             ok( !len, "unexpected length %u\n", len );
         }
-        if (!strcmp( product2, guid ))
+        else if (!strcmp( product2, guid ))
         {
             ok( context == MSIINSTALLCONTEXT_USERMANAGED, "got %u\n", context );
             ok( sid[0], "empty sid\n" );
             ok( len == strlen(sid), "unexpected length %u\n", len );
         }
-        if (!strcmp( product3, guid ))
+        else if (!strcmp( product3, guid ))
         {
             ok( context == MSIINSTALLCONTEXT_USERUNMANAGED, "got %u\n", context );
             ok( sid[0], "empty sid\n" );
             ok( len == strlen(sid), "unexpected length %u\n", len );
+        }
+        else
+        {
+            trace("Unexpected guid: %s (have %s | %s | %s)\n", guid, product1, product2, product3);
+            ok(context != MSIINSTALLCONTEXT_NONE, "got %u\n", context);
+            ok(sid[0], "empty sid\n");
+            ok(len == strlen(sid), "unexpected length %u\n", len);
         }
         index++;
         guid[0] = 0;

--- a/modules/rostests/winetests/msxml3/domdoc.c
+++ b/modules/rostests/winetests/msxml3/domdoc.c
@@ -8027,7 +8027,7 @@ static void test_get_ownerDocument(void)
     IXMLDOMDocument_Release(doc2);
     IXMLDOMDocument_Release(doc3);
     IXMLDOMDocument2_Release(doc);
-    IXMLDOMDocument2_Release(doc_owner);
+    //IXMLDOMDocument2_Release(doc_owner); FIXME: double-free!
     free_bstrs();
 }
 

--- a/modules/rostests/winetests/ntdll/exception.c
+++ b/modules/rostests/winetests/ntdll/exception.c
@@ -782,6 +782,7 @@ static DWORD bpx_handler( EXCEPTION_RECORD *rec, EXCEPTION_REGISTRATION_RECORD *
         ok( context->Eip == (DWORD)code_mem, "eip is wrong:  %x instead of %x\n",
                                              context->Eip, (DWORD)code_mem);
         ok( (context->Dr6 & 0xf) == 1, "B0 flag is not set in Dr6\n");
+        ros_skip_flaky
         ok( !(context->Dr6 & 0x4000), "BS flag is set in Dr6\n");
         context->Dr0 = context->Dr0 + 1;  /* set hw bp again on next instruction */
         context->EFlags |= 0x100;       /* enable single stepping */

--- a/modules/rostests/winetests/ntdll/info.c
+++ b/modules/rostests/winetests/ntdll/info.c
@@ -353,6 +353,7 @@ static void test_query_process(void)
 
         last_pid = (DWORD_PTR)spi->UniqueProcessId;
 
+        disable_success_count
         ok( spi->dwThreadCount > 0, "Expected some threads for this process, got 0\n");
 
         /* Loop through the threads, skip NT4 for now */
@@ -363,6 +364,7 @@ static void test_query_process(void)
             for ( j = 0; j < spi->dwThreadCount; j++) 
             {
                 k++;
+                disable_success_count
                 ok ( spi->ti[j].ClientId.UniqueProcess == spi->UniqueProcessId,
                      "The owning pid of the thread (%p) doesn't equal the pid (%p) of the process\n",
                      spi->ti[j].ClientId.UniqueProcess, spi->UniqueProcessId);
@@ -1691,12 +1693,14 @@ static void test_query_process_debug_flags(int argc, char **argv)
             for (;;)
             {
                 ret = WaitForDebugEvent(&ev, 1000);
+                disable_success_count
                 ok(ret, "WaitForDebugEvent failed, last error %#x.\n", GetLastError());
                 if (!ret) break;
 
                 if (ev.dwDebugEventCode == LOAD_DLL_DEBUG_EVENT) break;
 
                 ret = ContinueDebugEvent(ev.dwProcessId, ev.dwThreadId, DBG_CONTINUE);
+                disable_success_count
                 ok(ret, "ContinueDebugEvent failed, last error %#x.\n", GetLastError());
                 if (!ret) break;
             }
@@ -1733,6 +1737,7 @@ static void test_query_process_debug_flags(int argc, char **argv)
         for (j = 0; j < 100; j++)
         {
             ret = WaitForDebugEvent(&ev, 1000);
+            disable_success_count
             ok(ret || broken(GetLastError() == ERROR_SEM_TIMEOUT),
                 "WaitForDebugEvent failed, last error %#x.\n", GetLastError());
             if (!ret) break;
@@ -1740,6 +1745,7 @@ static void test_query_process_debug_flags(int argc, char **argv)
             if (ev.dwDebugEventCode == EXIT_PROCESS_DEBUG_EVENT) break;
 
             ret = ContinueDebugEvent(ev.dwProcessId, ev.dwThreadId, DBG_CONTINUE);
+            disable_success_count
             ok(ret, "ContinueDebugEvent failed, last error %#x.\n", GetLastError());
             if (!ret) break;
         }
@@ -2248,11 +2254,11 @@ START_TEST(info)
     char **argv;
     int argc;
 
-    if(!InitFunctionPtrs())
-        return;
-
     argc = winetest_get_mainargs(&argv);
     if (argc >= 3) return; /* Child */
+
+    if (!InitFunctionPtrs())
+        return;
 
     /* NtQuerySystemInformation */
 

--- a/modules/rostests/winetests/ntdll/process.c
+++ b/modules/rostests/winetests/ntdll/process.c
@@ -123,6 +123,7 @@ static void test_NtSuspendProcess(char *process_name)
     ret = WaitForSingleObject(event, 200);
     ok(ret == WAIT_TIMEOUT, "Expected timeout, got: %d\n", ret);
 
+    disable_success_count
     for (;;)
     {
         ret = WaitForDebugEvent(&ev, INFINITE);
@@ -158,6 +159,7 @@ static void test_NtSuspendProcess(char *process_name)
     ok(ret, "ContinueDebugEvent failed, last error %#x.\n", GetLastError());
 
     ret = WaitForSingleObject(event, 200);
+    ros_skip_flaky
     ok(ret == WAIT_OBJECT_0, "Event was not signaled: %d\n", ret);
 
     TerminateProcess(info.hProcess, 0);

--- a/modules/rostests/winetests/ole32/compobj.c
+++ b/modules/rostests/winetests/ole32/compobj.c
@@ -841,6 +841,7 @@ static DWORD WINAPI MessageFilter_MessagePending(
   DWORD dwPendingType)
 {
     trace("MessagePending\n");
+    ros_skip_flaky
     todo_wine ok(0, "unexpected call\n");
     return PENDINGMSG_WAITNOPROCESS;
 }

--- a/modules/rostests/winetests/qmgr/job.c
+++ b/modules/rostests/winetests/qmgr/job.c
@@ -359,6 +359,7 @@ static void test_CompleteLocal(void)
     hres = IBackgroundCopyJob_Resume(test_job);
     ok(hres == S_OK, "IBackgroundCopyJob_Resume\n");
 
+    disable_success_count
     for (i = 0; i < timeout_sec; ++i)
     {
         hres = IBackgroundCopyJob_GetState(test_job, &state);
@@ -428,6 +429,7 @@ static void test_CompleteLocalURL(void)
     hres = IBackgroundCopyJob_Resume(test_job);
     ok(hres == S_OK, "IBackgroundCopyJob_Resume\n");
 
+    disable_success_count
     for (i = 0; i < timeout_sec; ++i)
     {
         hres = IBackgroundCopyJob_GetState(test_job, &state);
@@ -570,6 +572,7 @@ static void test_HttpOptions(void)
     hr = IBackgroundCopyJob_Resume(test_job);
     ok(hr == S_OK, "got 0x%08x\n", hr);
 
+    disable_success_count
     for (i = 0; i < timeout; i++)
     {
         hr = IBackgroundCopyJob_GetState(test_job, &state);

--- a/modules/rostests/winetests/quartz/filtermapper.c
+++ b/modules/rostests/winetests/quartz/filtermapper.c
@@ -39,6 +39,7 @@ static BOOL enum_find_filter(const WCHAR *wszFilterName, IEnumMoniker *pEnum)
     HRESULT hr;
     static const WCHAR wszFriendlyName[] = {'F','r','i','e','n','d','l','y','N','a','m','e',0};
 
+    disable_success_count
     while(!found && IEnumMoniker_Next(pEnum, 1, &pMoniker, &nb) == S_OK)
     {
         IPropertyBag * pPropBagCat = NULL;

--- a/modules/rostests/winetests/quartz/referenceclock.c
+++ b/modules/rostests/winetests/quartz/referenceclock.c
@@ -86,6 +86,7 @@ static void test_IReferenceClock_methods(const char * clockdesc, IReferenceClock
     /* FIXME: How much deviation should be allowed after a sleep? */
     /* 0.3% is common, and 0.4% is sometimes observed. */
     diff = time2 - time1;
+    ros_skip_flaky
     ok (9940000 <= diff && diff <= 10240000, "%s - Expected difference around 10000000, got %u\n", clockdesc, diff);
 
 }

--- a/modules/rostests/winetests/riched20/editor.c
+++ b/modules/rostests/winetests/riched20/editor.c
@@ -657,6 +657,7 @@ static void test_EM_POSFROMCHAR(void)
     }
     else
     {
+      ros_skip_flaky
       ok(HIWORD(result) == i * height, "EM_POSFROMCHAR reports y=%d, expected %d\n", HIWORD(result), i * height);
       ok(LOWORD(result) == xpos, "EM_POSFROMCHAR reports x=%d, expected 1\n", LOWORD(result));
     }

--- a/modules/rostests/winetests/rpcrt4/server.c
+++ b/modules/rostests/winetests/rpcrt4/server.c
@@ -1553,7 +1553,9 @@ pointer_tests(void)
       names = NULL;
       get_names(&n, &names);
       ok(n == 2, "expected 2, got %d\n", n);
+      ros_skip_flaky
       ok(!strcmp(names[0], "Hello"), "expected Hello, got %s\n", names[0]);
+      ros_skip_flaky
       ok(!strcmp(names[1], "World!"), "expected World!, got %s\n", names[1]);
       MIDL_user_free(names[0]);
       MIDL_user_free(names[1]);
@@ -1563,7 +1565,9 @@ pointer_tests(void)
       namesw = NULL;
       get_namesw(&n, &namesw);
       ok(n == 2, "expected 2, got %d\n", n);
+      ros_skip_flaky
       ok(!lstrcmpW(namesw[0], helloW), "expected Hello, got %s\n", wine_dbgstr_w(namesw[0]));
+      ros_skip_flaky
       ok(!lstrcmpW(namesw[1], worldW), "expected World!, got %s\n", wine_dbgstr_w(namesw[1]));
       MIDL_user_free(namesw[0]);
       MIDL_user_free(namesw[1]);
@@ -1573,6 +1577,7 @@ pointer_tests(void)
 
   if (!is_interp) { /* broken in widl */
   pa2 = a;
+  ros_skip_flaky
   ok(sum_pcarr2(4, &pa2) == 10, "RPC sum_pcarr2\n");
   }
 

--- a/modules/rostests/winetests/user32/listbox.c
+++ b/modules/rostests/winetests/user32/listbox.c
@@ -1439,6 +1439,7 @@ static void test_listbox_dlgdir(void)
         memset(tempBuffer, 0, MAX_PATH);
         driveletter = '\0';
         SendMessageA(g_listBox, LB_GETTEXT, i, (LPARAM)itemBuffer);
+        if (!strstr(itemBuffer, ".exe")) continue; // skip downloaded/generated files from other tests
         res = SendMessageA(g_listBox, LB_SETCURSEL, i, 0);
         ok (res == i, "SendMessageA(LB_SETCURSEL, %d) failed\n", i);
         if (sscanf(itemBuffer, "[-%c-]", &driveletter) == 1) {

--- a/modules/rostests/winetests/user32/msg.c
+++ b/modules/rostests/winetests/user32/msg.c
@@ -10070,6 +10070,7 @@ static void test_timers(void)
     start = GetTickCount();
     while (GetTickCount()-start < 1001 && GetMessageA(&msg, info.hWnd, 0, 0))
         DispatchMessageA(&msg);
+ros_skip_flaky
 todo_wine
     ok(abs(count-TIMER_COUNT_EXPECTED) < TIMER_COUNT_TOLERANCE /* xp */
        || broken(abs(count-64) < TIMER_COUNT_TOLERANCE) /* most common */
@@ -16546,6 +16547,7 @@ static void test_hotkey(void)
     keybd_event(VK_LWIN, 0, KEYEVENTF_KEYUP, 0);
     while (PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE))
     {
+        ros_skip_flaky
         ok(msg.hwnd != NULL, "unexpected thread message %x\n", msg.message);
         DispatchMessageA(&msg);
     }

--- a/modules/rostests/winetests/user32/win.c
+++ b/modules/rostests/winetests/user32/win.c
@@ -149,6 +149,7 @@ static void check_wnd_state_(const char *file, int line,
     /* foreground can be moved to a different app pretty much at any time */
     if (foreground && GetForegroundWindow() &&
         GetWindowThreadProcessId(GetForegroundWindow(), NULL) == GetCurrentThreadId())
+        disable_success_count
         ok_(file, line)(foreground == GetForegroundWindow(), "GetForegroundWindow() = %p\n", GetForegroundWindow());
     ok_(file, line)(focus == GetFocus(), "GetFocus() = %p\n", GetFocus());
     ok_(file, line)(capture == GetCapture(), "GetCapture() = %p\n", GetCapture());
@@ -164,6 +165,7 @@ static void check_active_state_(const char *file, int line,
     /* foreground can be moved to a different app pretty much at any time */
     if (foreground && GetForegroundWindow() &&
         GetWindowThreadProcessId(GetForegroundWindow(), NULL) == GetCurrentThreadId())
+        disable_success_count
         ok_(file, line)(foreground == GetForegroundWindow(), "GetForegroundWindow() = %p\n", GetForegroundWindow());
     ok_(file, line)(focus == GetFocus(), "GetFocus() = %p\n", GetFocus());
 }
@@ -774,6 +776,7 @@ static LRESULT WINAPI main_window_procA(HWND hwnd, UINT msg, WPARAM wparam, LPAR
 	    break;
 	}
 	case WM_WINDOWPOSCHANGED:
+    disable_success_count
 	{
             RECT rc1, rc2;
 	    WINDOWPOS *winpos = (WINDOWPOS *)lparam;
@@ -966,6 +969,8 @@ static void verify_window_info(const char *hook, HWND hwnd, const WINDOWINFO *in
     if (GetForegroundWindow())
         ok(info->dwWindowStatus == status, "wrong dwWindowStatus: %04x != %04x active %p fg %p in hook %s\n",
            info->dwWindowStatus, status, GetActiveWindow(), GetForegroundWindow(), hook);
+    else
+        ok(1, "Just counting");
 
     /* win2k and XP return broken border info in GetWindowInfo most of
      * the time, so there is no point in testing it.
@@ -981,6 +986,7 @@ if (0)
 }
     ok(info->atomWindowType == GetClassLongA(hwnd, GCW_ATOM), "wrong atomWindowType for %p in hook %s\n",
        hwnd, hook);
+    todo_ros
     ok(info->wCreatorVersion == 0x0400 /* NT4, Win2000, XP, Win2003 */ ||
        info->wCreatorVersion == 0x0500 /* Vista */,
        "wrong wCreatorVersion %04x for %p in hook %s\n", info->wCreatorVersion, hwnd, hook);
@@ -3091,8 +3097,10 @@ static void test_SetActiveWindow(HWND hwnd)
     ok(hwnd2 == hwnd, "SetActiveWindow returned %p instead of %p\n", hwnd2, hwnd);
     if (!GetActiveWindow())  /* doesn't always work on vista */
     {
+        ros_skip_flaky
         check_wnd_state(0, 0, 0, 0);
         hwnd2 = SetActiveWindow(hwnd);
+        ros_skip_flaky
         ok(hwnd2 == 0, "SetActiveWindow returned %p instead of 0\n", hwnd2);
     }
     check_wnd_state(hwnd, hwnd, hwnd, 0);

--- a/modules/rostests/winetests/usp10/usp10.c
+++ b/modules/rostests/winetests/usp10/usp10.c
@@ -1713,6 +1713,8 @@ static void test_ScriptShapeOpenType(HDC hdc)
         DeleteObject(hfont);
     }
 
+    hfont = NULL;
+    ros_skip_flaky
     test_valid = find_font_for_range(hdc, "Estrangelo Edessa", 71, test_syriac[0], &hfont, &hfont_orig, &fingerprint_estrangelo);
     if (hfont != NULL)
     {

--- a/modules/rostests/winetests/wininet/ftp.c
+++ b/modules/rostests/winetests/wininet/ftp.c
@@ -74,10 +74,12 @@ static void test_connect(HINTERNET hInternet)
     hFtp = InternetConnectA(hInternet, "ftp.winehq.org", INTERNET_DEFAULT_FTP_PORT, "anonymous", NULL, INTERNET_SERVICE_FTP, INTERNET_FLAG_PASSIVE, 0);
     if (hFtp)  /* some servers accept an empty password */
     {
+        ros_skip_flaky
         ok ( GetLastError() == ERROR_SUCCESS, "ERROR_SUCCESS, got %d\n", GetLastError());
         InternetCloseHandle(hFtp);
     }
     else
+        ros_skip_flaky
         ok ( GetLastError() == ERROR_INTERNET_LOGIN_FAILURE,
              "Expected ERROR_INTERNET_LOGIN_FAILURE, got %d\n", GetLastError());
 
@@ -109,7 +111,9 @@ static void test_connect(HINTERNET hInternet)
         SetLastError(0xdeadbeef);
         hFtp = InternetConnectA(hInternet, "ftp.winehq.org", INTERNET_DEFAULT_FTP_PORT, "anonymous", "IEUser@", INTERNET_SERVICE_FTP, INTERNET_FLAG_PASSIVE, 0);
     }
+    ros_skip_flaky
     ok ( hFtp != NULL, "InternetConnect failed : %d\n", GetLastError());
+    ros_skip_flaky
     ok ( GetLastError() == ERROR_SUCCESS,
         "ERROR_SUCCESS, got %d\n", GetLastError());
     InternetCloseHandle(hFtp);
@@ -119,11 +123,13 @@ static void test_connect(HINTERNET hInternet)
             INTERNET_SERVICE_FTP, INTERNET_FLAG_PASSIVE, 0);
     if (!hFtp)
     {
+        ros_skip_flaky
         ok(GetLastError() == ERROR_INTERNET_LOGIN_FAILURE,
                 "Expected ERROR_INTERNET_LOGIN_FAILURE, got %d\n", GetLastError());
     }
     else
     {
+        ros_skip_flaky
         ok(GetLastError() == ERROR_SUCCESS,
                 "Expected ERROR_SUCCESS, got %d\n", GetLastError());
         InternetCloseHandle(hFtp);

--- a/modules/rostests/winetests/wininet/http.c
+++ b/modules/rostests/winetests/wininet/http.c
@@ -351,6 +351,7 @@ static VOID WINAPI callback(
      DWORD dwStatusInformationLength
 )
 {
+    ros_skip_flaky
     CHECK_EXPECT(dwInternetStatus);
     switch (dwInternetStatus)
     {
@@ -4800,9 +4801,11 @@ static void test_async_read(int port)
         ret = InternetReadFileExA( req, &ib, 0, 0xdeadbeef );
         if (!count) /* the first part should arrive immediately */
             ok( ret, "InternetReadFileExA failed %u\n", GetLastError() );
+        ros_skip_flaky
         if (!ret)
         {
             ok( GetLastError() == ERROR_IO_PENDING, "expected ERROR_IO_PENDING, got %u\n", GetLastError() );
+            ros_skip_flaky
             CHECK_NOTIFIED( INTERNET_STATUS_RECEIVING_RESPONSE );
             SET_EXPECT( INTERNET_STATUS_REQUEST_COMPLETE );
             if (!pending_reads++)
@@ -4891,6 +4894,7 @@ static void test_async_read(int port)
         {
             ok( GetLastError() == ERROR_IO_PENDING, "expected ERROR_IO_PENDING, got %u\n", GetLastError() );
             ok( bytes == 0, "expected 0, got %u\n", bytes );
+            ros_skip_flaky
             CHECK_NOTIFIED( INTERNET_STATUS_RECEIVING_RESPONSE );
             SET_EXPECT( INTERNET_STATUS_REQUEST_COMPLETE );
             if (!pending_reads++)
@@ -4902,9 +4906,13 @@ static void test_async_read(int port)
             res = WaitForSingleObject( complete_event, INFINITE );
             ok( res == WAIT_OBJECT_0, "expected WAIT_OBJECT_0, got %u\n", res );
             ok( req_error == ERROR_SUCCESS, "expected ERROR_SUCCESS, got %u\n", req_error );
+            ros_skip_flaky {
             todo_wine_if( pending_reads > 1 )
             ok( bytes != 0, "expected bytes != 0\n" );
+            }
+            ros_skip_flaky
             CHECK_NOTIFIED( INTERNET_STATUS_RESPONSE_RECEIVED );
+            ros_skip_flaky
             CHECK_NOTIFIED( INTERNET_STATUS_REQUEST_COMPLETE );
         }
 
@@ -4913,6 +4921,7 @@ static void test_async_read(int port)
         if (!bytes) break;
     }
 
+    ros_skip_flaky
     ok( pending_reads == 1, "expected 1 pending read, got %u\n", pending_reads );
     ok( !strcmp(buffer, page1), "unexpected buffer content\n" );
     close_async_handle( ses, 2 );
@@ -6160,6 +6169,7 @@ static void test_security_flags(void)
     }
     HeapFree(GetProcessHeap(), 0, cert);
 
+    ros_skip_flaky
     CHECK_NOTIFIED2(INTERNET_STATUS_CONNECTING_TO_SERVER, 2);
     CHECK_NOTIFIED2(INTERNET_STATUS_CONNECTED_TO_SERVER, 2);
     CHECK_NOTIFIED2(INTERNET_STATUS_CLOSING_CONNECTION, 2);


### PR DESCRIPTION
# Purpose
Make the results in testman consistent through multiple runs (at least on the same VM).

# Proposed changes
- Skip (disable) 47 oks in 19 tests that randomly fail
- Disable counting successes in non-deterministic loops / asynchonous callbacks
- user32:listbox - Skip files in the current dir that have not a .exe extension to avoid downloaded/generated files
- msxml3:domdoc - Comment out cleanup code that causes a double-free and can crash the test
- kernel32:process - Fix a test failing on Windows
- ntdll:info - Don't call InitFunctionPtrs(), when the child process runs
