### PR TITLE
[BTRFS] Create system threads with OBJ_KERNEL_HANDLE. CORE-16375

### DIFF
--- a/drivers/filesystems/btrfs/balance.c
+++ b/drivers/filesystems/btrfs/balance.c
@@ -3599,7 +3599,11 @@ NTSTATUS start_balance(device_extension* Vcb, void* data, ULONG length, KPROCESS
     Vcb->balance.status = STATUS_SUCCESS;
     KeInitializeEvent(&Vcb->balance.event, NotificationEvent, !Vcb->balance.paused);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+    Status = PsCreateSystemThread(&Vcb->balance.thread, 0, &system_thread_attributes, NULL, NULL, balance_thread, Vcb);
+#else
     Status = PsCreateSystemThread(&Vcb->balance.thread, 0, NULL, NULL, NULL, balance_thread, Vcb);
+#endif
     if (!NT_SUCCESS(Status)) {
         ERR("PsCreateSystemThread returned %08x\n", Status);
         return Status;
@@ -3679,7 +3683,11 @@ NTSTATUS look_for_balance_item(_Requires_lock_held_(_Curr_->tree_lock) device_ex
     Vcb->balance.status = STATUS_SUCCESS;
     KeInitializeEvent(&Vcb->balance.event, NotificationEvent, !Vcb->balance.paused);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+    Status = PsCreateSystemThread(&Vcb->balance.thread, 0, &system_thread_attributes, NULL, NULL, balance_thread, Vcb);
+#else
     Status = PsCreateSystemThread(&Vcb->balance.thread, 0, NULL, NULL, NULL, balance_thread, Vcb);
+#endif
     if (!NT_SUCCESS(Status)) {
         ERR("PsCreateSystemThread returned %08x\n", Status);
         return Status;
@@ -3876,7 +3884,11 @@ NTSTATUS remove_device(device_extension* Vcb, void* data, ULONG length, KPROCESS
     Vcb->balance.status = STATUS_SUCCESS;
     KeInitializeEvent(&Vcb->balance.event, NotificationEvent, !Vcb->balance.paused);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+    Status = PsCreateSystemThread(&Vcb->balance.thread, 0, &system_thread_attributes, NULL, NULL, balance_thread, Vcb);
+#else
     Status = PsCreateSystemThread(&Vcb->balance.thread, 0, NULL, NULL, NULL, balance_thread, Vcb);
+#endif
     if (!NT_SUCCESS(Status)) {
         ERR("PsCreateSystemThread returned %08x\n", Status);
         dev->reloc = false;

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -1756,6 +1756,8 @@ typedef BOOLEAN (*tCcCopyReadEx)(PFILE_OBJECT FileObject, PLARGE_INTEGER FileOff
 #if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
 typedef struct _ECP_LIST ECP_LIST;
 typedef struct _ECP_LIST *PECP_LIST;
+
+extern OBJECT_ATTRIBUTES system_thread_attributes;
 #endif
 
 typedef VOID (*tCcSetAdditionalCacheAttributesEx)(PFILE_OBJECT FileObject, ULONG Flags);

--- a/drivers/filesystems/btrfs/fsctl.c
+++ b/drivers/filesystems/btrfs/fsctl.c
@@ -4751,7 +4751,11 @@ static NTSTATUS resize_device(device_extension* Vcb, void* data, ULONG len, PIRP
 
             space_list_subtract2(&dev->space, NULL, br->size, delta, NULL, NULL);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+            Status = PsCreateSystemThread(&Vcb->balance.thread, 0, &system_thread_attributes, NULL, NULL, balance_thread, Vcb);
+#else
             Status = PsCreateSystemThread(&Vcb->balance.thread, 0, NULL, NULL, NULL, balance_thread, Vcb);
+#endif
             if (!NT_SUCCESS(Status)) {
                 ERR("PsCreateSystemThread returned %08x\n", Status);
                 goto end;

--- a/drivers/filesystems/btrfs/scrub.c
+++ b/drivers/filesystems/btrfs/scrub.c
@@ -3292,7 +3292,11 @@ NTSTATUS start_scrub(device_extension* Vcb, KPROCESSOR_MODE processor_mode) {
     Vcb->scrub.error = STATUS_SUCCESS;
     KeInitializeEvent(&Vcb->scrub.event, NotificationEvent, !Vcb->scrub.paused);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+    Status = PsCreateSystemThread(&Vcb->scrub.thread, 0, &system_thread_attributes, NULL, NULL, scrub_thread, Vcb);
+#else
     Status = PsCreateSystemThread(&Vcb->scrub.thread, 0, NULL, NULL, NULL, scrub_thread, Vcb);
+#endif
     if (!NT_SUCCESS(Status)) {
         ERR("PsCreateSystemThread returned %08x\n", Status);
         return Status;

--- a/drivers/filesystems/btrfs/send.c
+++ b/drivers/filesystems/btrfs/send.c
@@ -3810,7 +3810,11 @@ NTSTATUS send_subvol(device_extension* Vcb, void* data, ULONG datalen, PFILE_OBJ
 
     InterlockedIncrement(&Vcb->running_sends);
 
+#if defined(__REACTOS__) && (NTDDI_VERSION < NTDDI_VISTA)
+    Status = PsCreateSystemThread(&send->thread, 0, &system_thread_attributes, NULL, NULL, send_thread, context);
+#else
     Status = PsCreateSystemThread(&send->thread, 0, NULL, NULL, NULL, send_thread, context);
+#endif
     if (!NT_SUCCESS(Status)) {
         ERR("PsCreateSystemThread returned %08x\n", Status);
         ccb->send = NULL;


### PR DESCRIPTION
Windows Vista and later automatically return a kernel handle from
PsCreateSystemThread, but earlier versions require that OBJ_KERNEL_HANDLE
be specified explicitly.

JIRA issue: [CORE-16375](https://jira.reactos.org/browse/CORE-16375)


Upstream PR: https://github.com/maharmstone/btrfs/pull/193