### PR TITLE
[WIN32SS][NTUSER] Fix hit test position of popup menu

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -1480,11 +1480,16 @@ MENU_AdjustMenuItemRect(PMENU menu, PRECTL rect)
 static ITEM *MENU_FindItemByCoords( MENU *menu, POINT pt, UINT *pos )
 {
     ITEM *item;
-    UINT i;
+    UINT i, cx, cy;
     RECT rect;
     PWND pWnd = ValidateHwndNoErr(menu->hWnd);
 
     if (!IntGetWindowRect(pWnd, &rect)) return NULL;
+
+    cx = UserGetSystemMetrics(SM_CXDLGFRAME);
+    cy = UserGetSystemMetrics(SM_CYDLGFRAME);
+    RECTL_vInflateRect(&rect, -cx, -cy);
+
     if (pWnd->ExStyle & WS_EX_LAYOUTRTL)
        pt.x = rect.right - 1 - pt.x;
     else


### PR DESCRIPTION
## Purpose
The submenu of desktop popup menu was erroneously shown at first right click.
JIRA issue: [CORE-16382](https://jira.reactos.org/browse/CORE-16382)
BEFORE:
![0 4 13-dev-1168-gb9a2eee_submenu](https://user-images.githubusercontent.com/2107452/65367189-c2895380-dc68-11e9-9d63-3d5efc372272.png)
AFTER:
![fixed](https://user-images.githubusercontent.com/2107452/65367184-adacc000-dc68-11e9-83b6-76dec3530174.png)

- Fix the hit test position that was modified by window style change.