### PR TITLE
[OPENGLCFG] general.c: Fix overruns and warnings, improve code consistency

### DIFF
--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -55,7 +55,7 @@ static VOID InitSettings(HWND hWndDlg)
 
         ret = RegQueryInfoKeyW(hKeyDrivers, NULL, NULL, NULL, &dwNumDrivers, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
-        if (ret != ERROR_SUCCESS || dwNumDrivers <= 0)
+        if (ret != ERROR_SUCCESS || dwNumDrivers == 0)
         {
             RegCloseKey(hKeyDrivers);
             RegCloseKey(hKeyRenderer);
@@ -148,7 +148,7 @@ static VOID SaveSettings(HWND hWndDlg)
             /* Adjustment for DEFAULT and RSWR renderers */
             iSel -= 2;
 
-            if (iSel >= 0 && iSel <= dwNumDrivers)
+            if (iSel >= 0 && iSel < dwNumDrivers)
                 RegSetValueExW(hKeyRenderer, L"", 0, REG_SZ, (PBYTE)pOglDrivers[iSel], (wcslen(pOglDrivers[iSel]) + 1) * sizeof(WCHAR));
 
             break;
@@ -193,7 +193,7 @@ INT_PTR CALLBACK GeneralPageProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM 
             if (pOglDrivers != NULL)
             {
                 INT iKey;
-                for (iKey = 0; iKey <= dwNumDrivers; iKey++)
+                for (iKey = 0; iKey < dwNumDrivers; ++iKey)
                     HeapFree(GetProcessHeap(), 0, pOglDrivers[iKey]);
 
                 HeapFree(GetProcessHeap(), 0, pOglDrivers);

--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -139,7 +139,7 @@ static VOID SaveSettings(HWND hWndDlg)
         {
             WCHAR szBuffer[MAX_KEY_LENGTH];
             LoadString(hApplet, IDS_RENDERER_RSWR, (LPTSTR)szBuffer, 127);
-            RegSetValueExW(hKeyRenderer, L"", 0, REG_SZ, (PBYTE)szBuffer, (wcslen(szBuffer) + 1) * sizeof(WCHAR));
+            RegSetValueExW(hKeyRenderer, L"", 0, REG_SZ, (PBYTE)szBuffer, (DWORD)((wcslen(szBuffer) + 1) * sizeof(WCHAR)));
             break;
         }
 
@@ -149,7 +149,7 @@ static VOID SaveSettings(HWND hWndDlg)
             iSel -= 2;
 
             if (iSel >= 0 && iSel < dwNumDrivers)
-                RegSetValueExW(hKeyRenderer, L"", 0, REG_SZ, (PBYTE)pOglDrivers[iSel], (wcslen(pOglDrivers[iSel]) + 1) * sizeof(WCHAR));
+                RegSetValueExW(hKeyRenderer, L"", 0, REG_SZ, (PBYTE)pOglDrivers[iSel], (DWORD)((wcslen(pOglDrivers[iSel]) + 1) * sizeof(WCHAR)));
 
             break;
         }

--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -48,7 +48,7 @@ static VOID InitSettings(HWND hWndDlg)
     if (dwType == REG_SZ)
     {
         DWORD ret;
-        INT iKey;
+        DWORD iKey;
 
         if (wcsncmp(szBultin, szDriver, MAX_KEY_LENGTH) == 0)
             SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_RSWR, 0);
@@ -192,7 +192,8 @@ INT_PTR CALLBACK GeneralPageProc(HWND hWndDlg, UINT uMsg, WPARAM wParam, LPARAM 
         case WM_DESTROY:
             if (pOglDrivers != NULL)
             {
-                INT iKey;
+                DWORD iKey;
+
                 for (iKey = 0; iKey < dwNumDrivers; ++iKey)
                     HeapFree(GetProcessHeap(), 0, pOglDrivers[iKey]);
 


### PR DESCRIPTION
Follow-up to e7b8f273094c9402ff1df3baa5841bf3518a3f02.

```
...\dll\cpl\openglcfg\general.c(142): warning C4267: 'function': conversion from 'size_t' to 'DWORD', possible loss of data
...\dll\cpl\openglcfg\general.c(152): warning C4267: 'function': conversion from 'size_t' to 'DWORD', possible loss of data
```