### PR TITLE
[IPCONFIG] Do not free NULL pPerAdapterInfo

### DIFF
--- a/base/applications/network/ipconfig/ipconfig.c
+++ b/base/applications/network/ipconfig/ipconfig.c
@@ -586,8 +586,11 @@ VOID ShowInfo(BOOL bAll)
         }
         _tprintf(_T("\n"));
 
-        HeapFree(ProcessHeap, 0, pPerAdapterInfo);
-        pPerAdapterInfo = NULL;
+        if (pPerAdapterInfo)
+        {
+            HeapFree(ProcessHeap, 0, pPerAdapterInfo);
+            pPerAdapterInfo = NULL;
+        }
 
         pAdapter = pAdapter->Next;
     }


### PR DESCRIPTION
Addendum to 5539ca8d7e7d7f7cf7f52bd4d108a26495c20f0c.
