### PR TITLE
[NTOS:MM] Do not write-protect the first page of a driver image.

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2474,14 +2474,10 @@ MiWriteProtectSystemImage(
     /* Get the base address of the first section */
     SectionBase = Add2Ptr(ImageBase, SectionHeaders[0].VirtualAddress);
 
-    /* Start protecting the image header as R/O */
+    /* Protection starts with the image header as R/W */
     FirstPte = MiAddressToPte(ImageBase);
     LastPte = MiAddressToPte(SectionBase) - 1;
-    Protection = IMAGE_SCN_MEM_READ;
-    if (LastPte >= FirstPte)
-    {
-        MiSetSystemCodeProtection(FirstPte, LastPte, IMAGE_SCN_MEM_READ);
-    }
+    Protection = IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE;
 
     /* Loop the sections */
     for (i = 0; i < NtHeaders->FileHeader.NumberOfSections; i++)


### PR DESCRIPTION
Windows starts out the header page with read+write protection, which then gets merged with any protections for overlapping sections.
Compare our old implementation that was modeled closely after Windows:
https://github.com/reactos/reactos/blob/4b924a8685c8ce9005797b85b7aaa3998b3d472c/ntoskrnl/mm/ARM3/sysldr.c#L2476-L2478

JIRA issue: [CORE-16387](https://jira.reactos.org/browse/CORE-16387)