### PR TITLE
Shell Find Improvements to make Search Item general and Show Sub-directories

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -260,6 +260,12 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
         if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             CStringW status;
+            if ((pSearchData->szFileName.IsEmpty() || PathMatchSpecW(FindData.cFileName, pSearchData->szFileName))
+                && (pSearchData->szQueryA.IsEmpty() || SearchFile(szPath, pSearchData)))
+                {
+                PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM) StrDupW(szPath));
+                uTotalFound++;
+                }
             status.Format(IDS_SEARCH_FOLDER, FindData.cFileName);
             PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM) StrDupW(status.GetBuffer()));
 

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -262,10 +262,10 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
             CStringW status;
             if ((pSearchData->szFileName.IsEmpty() || PathMatchSpecW(FindData.cFileName, pSearchData->szFileName))
                 && (pSearchData->szQueryA.IsEmpty() || SearchFile(szPath, pSearchData)))
-                {
+            {
                 PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM) StrDupW(szPath));
                 uTotalFound++;
-                }
+            }
             status.Format(IDS_SEARCH_FOLDER, FindData.cFileName);
             PostMessageW(pSearchData->hwnd, WM_SEARCH_UPDATE_STATUS, 0, (LPARAM) StrDupW(status.GetBuffer()));
 

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -147,7 +147,7 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
             endchar = ptrchar;
             ptrchar = pSearchStart->szFileName[0];
             startchar = ptrchar;
-            if ((len < MAX_PATH) && (startchar != L'*'))
+            if ((len < MAX_PATH - 1) && (startchar != L'*'))
             {
                 memmove(&pSearchStart->szFileName[1], &pSearchStart->szFileName[0],
                        len * sizeof(WCHAR) + sizeof(WCHAR));
@@ -157,7 +157,7 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
         }
 
         // See if our last character is an asterisk and if not and we have room then add one
-        if ((len < MAX_PATH) && (endchar != L'*'))
+        if ((len < MAX_PATH - 1) && (endchar != L'*'))
             wcscat(pSearchStart->szFileName, L"*");
     }
 

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -135,8 +135,9 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
         return 0;
     }
 
-    // See if we have a szFileName, our first character is not an asterisk,
-    // and we have room in MAX_PATH to add an asterisk at the beginning of szFileName then add it
+    // See if we have an szFileName by testing for its entry lenth > 0 and our searched FileName does not contain
+    // an asterisk or a question mark. If so, then prepend and append an asterisk to the searched FileName.
+    // (i.e. it's equivalent to searching for *<the_file_name>* )
     StringCchLength(pSearchStart->szFileName, MAX_PATH, &len);
     if ((len > 0) && !StrStrW(pSearchStart->szFileName, L"*") && !StrStrW(pSearchStart->szFileName, L"?"))
     {

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -124,9 +124,8 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
 {
     INT len = 0;
     WCHAR ptrchar;
-    WCHAR endchar[2] = { 0 };
-    WCHAR startchar[2] = { 0 };
-    WCHAR asterisk[2] = L"*";
+    WCHAR endchar;
+    WCHAR startchar;
 
     CComHeapPtr<SearchStart> pSearchStart(static_cast<SearchStart *>(CoTaskMemAlloc(sizeof(SearchStart))));
     GetDlgItemText(IDC_SEARCH_FILENAME, pSearchStart->szFileName, _countof(pSearchStart->szFileName));
@@ -139,28 +138,28 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
 
     // See if we have a szFileName, our first character is not an asterisk,
     // and we have room in MAX_PATH to add an asterisk at the beginning of szFileName then add it
-    if(wcscmp(pSearchStart->szFileName, L"") != 0)
-        {
+    if (wcscmp(pSearchStart->szFileName, L"") != 0)
+    {
         len = wcslen(pSearchStart->szFileName);
         if(len > 0)
-            {
+        {
             ptrchar = pSearchStart->szFileName[len - 1];
-            memcpy(endchar, &ptrchar, 2);
+            endchar = ptrchar;
             ptrchar = pSearchStart->szFileName[0];
-            memcpy(startchar, &ptrchar, 2);
-            if ((len < MAX_PATH) && (wcscmp(startchar, L"*") != 0))
-                {
-                    memmove(&pSearchStart->szFileName[1], &pSearchStart->szFileName[0],
-                            len * sizeof(WCHAR) + sizeof(WCHAR));
-                    len = len + 1;
-                    pSearchStart->szFileName[0] = asterisk[0];
-                }
+            startchar = ptrchar;
+            if ((len < MAX_PATH) && (startchar != L'*'))
+            {
+                memmove(&pSearchStart->szFileName[1], &pSearchStart->szFileName[0],
+                       len * sizeof(WCHAR) + sizeof(WCHAR));
+                len = len + 1;
+                pSearchStart->szFileName[0] = L'*';
             }
+        }
 
         // See if our last character is an asterisk and if not and we have room then add one
-        if((wcscmp(endchar, L"*") != 0) && (len < MAX_PATH))
+        if ((len < MAX_PATH) && (endchar != L'*'))
             wcscat(pSearchStart->szFileName, L"*");
-        }
+    }
 
     // Print our final search string for szFileName
     TRACE("Searched szFileName is '%S'.\n", pSearchStart->szFileName);

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -138,8 +138,8 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
     // See if we have an szFileName by testing for its entry lenth > 0 and our searched FileName does not contain
     // an asterisk or a question mark. If so, then prepend and append an asterisk to the searched FileName.
     // (i.e. it's equivalent to searching for *<the_file_name>* )
-    StringCchLength(pSearchStart->szFileName, MAX_PATH, &len);
-    if ((len > 0) && !StrStrW(pSearchStart->szFileName, L"*") && !StrStrW(pSearchStart->szFileName, L"?"))
+    if (FAILED (StringCchLengthW (pSearchStart->szFileName, MAX_PATH, &len))) return 0;
+    if ((len > 0) && !wcspbrk(pSearchStart->szFileName, L"*?"))
     {
         endchar = pSearchStart->szFileName[len - 1];
         startchar = pSearchStart->szFileName[0];

--- a/dll/win32/browseui/shellfind/CSearchBar.cpp
+++ b/dll/win32/browseui/shellfind/CSearchBar.cpp
@@ -122,8 +122,7 @@ HRESULT CSearchBar::GetSearchResultsFolder(IShellBrowser **ppShellBrowser, HWND 
 
 LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    INT len = 0;
-    WCHAR ptrchar;
+    size_t len = 0;
     WCHAR endchar;
     WCHAR startchar;
 
@@ -138,27 +137,22 @@ LRESULT CSearchBar::OnSearchButtonClicked(WORD wNotifyCode, WORD wID, HWND hWndC
 
     // See if we have a szFileName, our first character is not an asterisk,
     // and we have room in MAX_PATH to add an asterisk at the beginning of szFileName then add it
-    if (wcscmp(pSearchStart->szFileName, L"") != 0)
+    StringCchLength(pSearchStart->szFileName, MAX_PATH, &len);
+    if ((len > 0) && !StrStrW(pSearchStart->szFileName, L"*") && !StrStrW(pSearchStart->szFileName, L"?"))
     {
-        len = wcslen(pSearchStart->szFileName);
-        if(len > 0)
+        endchar = pSearchStart->szFileName[len - 1];
+        startchar = pSearchStart->szFileName[0];
+        if ((len < MAX_PATH - 1) && (startchar != L'*'))
         {
-            ptrchar = pSearchStart->szFileName[len - 1];
-            endchar = ptrchar;
-            ptrchar = pSearchStart->szFileName[0];
-            startchar = ptrchar;
-            if ((len < MAX_PATH - 1) && (startchar != L'*'))
-            {
-                memmove(&pSearchStart->szFileName[1], &pSearchStart->szFileName[0],
-                       len * sizeof(WCHAR) + sizeof(WCHAR));
-                len = len + 1;
-                pSearchStart->szFileName[0] = L'*';
-            }
+            memmove(&pSearchStart->szFileName[1], &pSearchStart->szFileName[0],
+                   len * sizeof(WCHAR) + sizeof(WCHAR));
+            len = len + 1;
+            pSearchStart->szFileName[0] = L'*';
         }
 
         // See if our last character is an asterisk and if not and we have room then add one
         if ((len < MAX_PATH - 1) && (endchar != L'*'))
-            wcscat(pSearchStart->szFileName, L"*");
+            StringCchCatW(pSearchStart->szFileName, MAX_PATH, L"*");
     }
 
     // Print our final search string for szFileName


### PR DESCRIPTION
Improve Find Function of ReactOS Explorer

_Add ability to show sub-directories and generalize search item before searching._

JIRA issue: CORE-16152

Example on Windows 2003 Server:
![W2K3_test](https://user-images.githubusercontent.com/32620577/65390243-d98c7c00-dd22-11e9-91bc-a3fdc81ce2e1.png)

ReactOS - Before:
![ROS_Old_test](https://user-images.githubusercontent.com/32620577/65390251-ea3cf200-dd22-11e9-8e28-bf03be9f2e95.png)

ReactOS - After
![ROS_New_test](https://user-images.githubusercontent.com/32620577/65390258-f45ef080-dd22-11e9-9f20-df3092902b76.png)

Example Windows 2003 Server:
![W2K3_oracle](https://user-images.githubusercontent.com/32620577/65390267-050f6680-dd23-11e9-9ee2-a73bd454c6f5.png)

ReactOS - Before
![ROS_Old_oracle](https://user-images.githubusercontent.com/32620577/65390272-122c5580-dd23-11e9-919a-ed07dd7f2b36.png)

ReactOS - After
![ROS_New_oracle](https://user-images.githubusercontent.com/32620577/65390276-1eb0ae00-dd23-11e9-801c-80656e281ce0.png)

Example Windows 2003 Server
![W2K3_Blank](https://user-images.githubusercontent.com/32620577/65390280-2ec88d80-dd23-11e9-895e-63fb9610f3bc.png)

ReactOS - Before:
![ROS_Old_Blank](https://user-images.githubusercontent.com/32620577/65390285-3851f580-dd23-11e9-9933-621d43d5f118.png)

ReactOS - After:
![ROS_New_Blank](https://user-images.githubusercontent.com/32620577/65390289-44d64e00-dd23-11e9-9899-8068e4d6a322.png)

