### PR TITLE
[UTILMAN] Add Russian translation

### DIFF
--- a/base/applications/utilman/lang/ru-RU.rc
+++ b/base/applications/utilman/lang/ru-RU.rc
@@ -1,0 +1,55 @@
+﻿/*
+ * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         Russian (Russia) translation resource
+ * COPYRIGHT:       Copyright 2019 Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
+ */
+
+LANGUAGE LANG_RUSSIAN, SUBLANG_RUSSIAN_RUSSIA
+
+IDD_MAIN_DIALOG DIALOGEX 0, 0, 284, 183
+STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_CONTEXTHELP
+CAPTION "Диспетчер служебных программ"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LISTBOX IDC_LISTBOX, 4, 4, 273, 56, LBS_STANDARD | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER
+    CONTROL "", IDC_GROUPBOX, "Button", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 3, 62, 275, 92
+    CONTROL "Запустить", IDC_START, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 14, 76, 45, 16
+    CONTROL "Остановить", IDC_STOP, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 69, 76, 45, 16
+    CONTROL "Запускать автоматически при моем входе в систему", IDC_START_LOG_IN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 101, 206, 14 
+    CONTROL "Запускать автоматически при блокировке рабочего стола", IDC_START_DESKTOP, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 118, 212, 14 
+    CONTROL "Запускать автоматически при запуске диспетчера", IDC_START_UTILMAN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 134, 212, 13 
+    CONTROL "&OK", IDC_OK, "Button", BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 160, 161, 50, 14 
+    CONTROL "&Отмена", IDC_CANCEL, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 221, 161, 50, 14 
+    CONTROL "&Справка", IDC_HELP_TOPICS, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 98, 161, 50, 14 
+END
+
+IDD_ABOUT_DIALOG DIALOGEX 22, 16, 210, 65
+CAPTION "О программе"
+FONT 8, "MS Shell Dlg", 0, 0
+STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
+BEGIN
+    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
+    LTEXT "Диспетчер служебных программ\nCopyright 2019 Джордж Бисок (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
+    LTEXT "Copyright 2019 Гермес Белуска-Маито", IDC_STATIC, 48, 33, 150, 36
+    PUSHBUTTON "OK", IDOK, 75, 47, 44, 15
+END
+
+STRINGTABLE
+BEGIN
+    IDS_OSK "Экранная клавиатура"
+    IDS_MAGNIFIER "Экранная лупа"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_NOTRUNNING "%s не выполняется"
+    IDS_RUNNING "%s работает"
+    IDS_GROUPBOX_OPTIONS_TITLE "Параметры для программы %s"
+END
+
+STRINGTABLE
+BEGIN
+    IDM_ABOUT "О программе"
+END

--- a/base/applications/utilman/utilman.rc
+++ b/base/applications/utilman/utilman.rc
@@ -43,5 +43,8 @@ IDI_ICON_UTILMAN ICON "res/utilman.ico"
 #ifdef LANGUAGE_RO_RO
     #include "lang/ro-RO.rc"
 #endif
+#ifdef LANGUAGE_RU_RU
+    #include "lang/ru-RU.rc"
+#endif
 
 /* EOF */

--- a/media/inf/shortcuts.inf
+++ b/media/inf/shortcuts.inf
@@ -1282,6 +1282,8 @@ WINMINE_TITLE=Сапер
 WINMINE_DESC=Сапер
 SPIDER_TITLE=Пасьянс Паук
 SPIDER_DESC=Пасьянс Паук
+UTILMAN_TITLE=Диспетчер служебных программ
+UTILMAN_DESC=Обеспечивает запуск и настройку программ поддержки специальных возможностей.
 
 ; Slovak
 [Strings.041B]


### PR DESCRIPTION
## Purpose

Add Russian translation for Accessibility Utility Manager (utilman).

JIRA issue: None

## Proposed changes

- Add the translation;
- Include it in the .rc file;
- Translate the shortcut in the Start menu.

## Result

![utilman_ros_after](https://user-images.githubusercontent.com/26385117/65426874-c90afd00-de19-11e9-951d-7329e766eae7.png)

Win2k3 (for comparison):
![utilman_win2k3](https://user-images.githubusercontent.com/26385117/65426907-daeca000-de19-11e9-8809-b5b0a5cbc3ba.png)