### PR TITLE
Add support for latest MSVC toolchain

### DIFF
--- a/configure.cmd
+++ b/configure.cmd
@@ -64,6 +64,7 @@ if defined ROS_ARCH (
     cl 2>&1 | find "19.20." > NUL && set VS_VERSION=16
     cl 2>&1 | find "19.21." > NUL && set VS_VERSION=16
     cl 2>&1 | find "19.22." > NUL && set VS_VERSION=16
+    cl 2>&1 | find "19.23." > NUL && set VS_VERSION=16
     if not defined VS_VERSION (
         echo Error: Visual Studio version too old ^(before 10 ^(2010^)^) or version detection failed.
         goto quit


### PR DESCRIPTION
## Purpose

Does what the title says. Visual Studio 2019 16.3 bumps the CL.EXE version number to 16.23.*.

## Proposed changes

Detect CL 16.23.* as Visual Studio 2019.