### PR TITLE
Stub GetCurrentPackageId()

### DIFF
--- a/dll/apisets/CMakeLists.txt
+++ b/dll/apisets/CMakeLists.txt
@@ -40,7 +40,7 @@ add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/x86_reactos.apisets_6595b64144ccf1d
 # Apisets will be appended
 
 add_apiset(api-ms-win-appmodel-identity-l1-1-0 0x60000000 )
-add_apiset(api-ms-win-appmodel-runtime-l1-1-1 0x60020000 )
+add_apiset(api-ms-win-appmodel-runtime-l1-1-1 0x60020000 kernel32)
 add_apiset(api-ms-win-appmodel-runtime-l1-1-2 0x60040000 )
 add_apiset(api-ms-win-core-apiquery-l1-1-0 0x60060000 )
 add_apiset(api-ms-win-core-appcompat-l1-1-1 0x60070000 kernel32)

--- a/dll/apisets/api-ms-win-appmodel-runtime-l1-1-1.spec
+++ b/dll/apisets/api-ms-win-appmodel-runtime-l1-1-1.spec
@@ -8,7 +8,7 @@
 @ stub GetCurrentApplicationUserModelId
 @ stub GetCurrentPackageFamilyName
 @ stub GetCurrentPackageFullName
-@ stub GetCurrentPackageId
+@ stdcall GetCurrentPackageId(ptr ptr) kernel32.GetCurrentPackageId
 @ stub GetCurrentPackageInfo
 @ stub GetCurrentPackagePath
 @ stub GetPackageApplicationIds

--- a/dll/apisets/api-ms-win-appmodel-runtime-l1-1-1.spec
+++ b/dll/apisets/api-ms-win-appmodel-runtime-l1-1-1.spec
@@ -8,7 +8,7 @@
 @ stub GetCurrentApplicationUserModelId
 @ stub GetCurrentPackageFamilyName
 @ stub GetCurrentPackageFullName
-@ stdcall GetCurrentPackageId(ptr ptr) kernel32.GetCurrentPackageId
+@ stdcall -version=0x602+ GetCurrentPackageId(ptr ptr) kernel32.GetCurrentPackageId
 @ stub GetCurrentPackageInfo
 @ stub GetCurrentPackagePath
 @ stub GetPackageApplicationIds

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -584,3 +584,15 @@ SetSystemFileCacheSize(IN SIZE_T MinimumFileCacheSize,
     STUB;
     return FALSE;
 }
+
+/*
+ * @unimplemented
+ */
+LONG
+WINAPI
+GetCurrentPackageId(UINT32 *BufferLength,
+                    BYTE *Buffer)
+{
+    STUB;
+    return APPMODEL_ERROR_NO_PACKAGE;
+}

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -430,10 +430,10 @@
 @ stub -version=0x600+ GetCurrentConsoleFontEx
 @ stdcall GetCurrentDirectoryA(long ptr)
 @ stdcall GetCurrentDirectoryW(long ptr)
+@ stdcall -version=0x602+ GetCurrentPackageId(ptr ptr)
 @ stdcall -norelay GetCurrentProcess()
 @ stdcall -norelay GetCurrentProcessId()
 @ stdcall GetCurrentProcessorNumber() ntdll.RtlGetCurrentProcessorNumber
-@ stdcall GetCurrentPackageId(ptr ptr)
 @ stdcall -norelay GetCurrentThread()
 @ stdcall -norelay GetCurrentThreadId()
 @ stdcall GetDateFormatA(long long ptr str ptr long)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -433,6 +433,7 @@
 @ stdcall -norelay GetCurrentProcess()
 @ stdcall -norelay GetCurrentProcessId()
 @ stdcall GetCurrentProcessorNumber() ntdll.RtlGetCurrentProcessorNumber
+@ stdcall GetCurrentPackageId(ptr ptr)
 @ stdcall -norelay GetCurrentThread()
 @ stdcall -norelay GetCurrentThreadId()
 @ stdcall GetDateFormatA(long long ptr str ptr long)


### PR DESCRIPTION
## Purpose

Some WiX-based installers (I have reproduced this issue with the 32-bit .NET Core 3.0 installers, which I am currently trying to get working on a different branch) call the Windows 8+ `GetCurrentPackageId()` function. Since that function is marked as a stub in the spec file, this will crash the process.

JIRA issue: (none)

## Proposed changes

I added a stub implementation of `GetCurrentPackageId()` that always returns `APPMODEL_ERROR_NO_PACKAGE`. This is the error code that Microsoft documents Windows as returning when the current process is not within an AppX package. Since that condition is never true on ReactOS, I chose this error over `ERROR_NOT_IMPLEMENTED`, as it is more accurate.