### PR TITLE
[NTOS:MM] Add debug print to MiAllocateContiguousMemory in out-of-memory case

### DIFF
--- a/ntoskrnl/mm/ARM3/contmem.c
+++ b/ntoskrnl/mm/ARM3/contmem.c
@@ -444,11 +444,16 @@ MiAllocateContiguousMemory(IN SIZE_T NumberOfBytes,
     //
     // Otherwise, we'll go try to find some
     //
-    return MiFindContiguousMemory(LowestAcceptablePfn,
-                                  HighestAcceptablePfn,
-                                  BoundaryPfn,
-                                  SizeInPages,
-                                  CacheType);
+    BaseAddress = MiFindContiguousMemory(LowestAcceptablePfn,
+                                         HighestAcceptablePfn,
+                                         BoundaryPfn,
+                                         SizeInPages,
+                                         CacheType);
+    if (!BaseAddress)
+    {
+        DPRINT1("Unable to allocate contiguous memory for %d bytes (%d pages), out of memory!\n", NumberOfBytes, SizeInPages);
+    }
+    return BaseAddress;
 }
 
 VOID


### PR DESCRIPTION
I'm still investigating random out-of-memory problem with patched xboxvmp (video miniport driver for Xbox, see PR #1896), which [we discussed](https://chat.reactos.org/reactos/pl/5xc4gg63zibgpegasr4uh4y5dh) with @ThFabba on Mattermost.

We came to the conclusion there is no bug in the memory manager, but for some reason the memory is full at this early loading stage. This pull request adds a debug print for the code path I'm hitting, because there are no other debug prints signaling about outage of memory.