### PR TITLE
[MOUNTMGR] QueryPointsFromMemory(): Do not leak DeviceName.Buffer

### DIFF
--- a/drivers/filters/mountmgr/point.c
+++ b/drivers/filters/mountmgr/point.c
@@ -344,6 +344,11 @@ QueryPointsFromMemory(IN PDEVICE_EXTENSION DeviceExtension,
     {
         Irp->IoStatus.Information = sizeof(MOUNTMGR_MOUNT_POINTS);
 
+        if (SymbolicName)
+        {
+            FreePool(DeviceName.Buffer);
+        }
+
         return STATUS_BUFFER_OVERFLOW;
     }
 
@@ -417,6 +422,11 @@ QueryPointsFromMemory(IN PDEVICE_EXTENSION DeviceExtension,
         {
             break;
         }
+    }
+
+    if (SymbolicName)
+    {
+        FreePool(DeviceName.Buffer);
     }
 
     return STATUS_SUCCESS;


### PR DESCRIPTION
Follow-up to 7601011f4ed578ae4a15a55298ebbe96fe3a1129.
