### PR TITLE
[FREELDR] Don't accidentally overwrite the page directory mapping

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pcmem.c
+++ b/boot/freeldr/freeldr/arch/i386/pcmem.c
@@ -554,6 +554,12 @@ PcMemFinalizeMemoryMap(
     ReserveMemory(MemoryMap, STACKLOW, STACKADDR - STACKLOW, LoaderOsloaderStack, "FreeLdr stack");
     ReserveMemory(MemoryMap, FREELDR_BASE, FrLdrImageSize, LoaderLoadedProgram, "FreeLdr image");
 
+    /* We need to make sure that we don't allocate the 4 MB chunk of physical memory starting at
+     * 0x40000000. The logic used in MempAllocatePTE means that the kernel mapping would be at
+     * 0xc0000000, which is where Windows needs the page directory to be mapped to (see
+     * MempAllocatePageTables). */
+    ReserveMemory(MemoryMap, 0x40000000, 0x400000, LoaderReserve, "Reserved");
+
     /* Default to 1 page above freeldr for the disk read buffer */
     DiskReadBuffer = (PUCHAR)ALIGN_UP_BY(FREELDR_BASE + FrLdrImageSize, PAGE_SIZE);
     DiskReadBufferSize = PAGE_SIZE;


### PR DESCRIPTION
Fix for a bug I encountered while getting Freeldr to work on Windows 7, where if anything gets loaded into 0x40000000 it'd refuse to boot.