### PR TITLE
[FREELDR] Xbox memory management improvements

### DIFF
--- a/boot/freeldr/freeldr/include/arch/i386/machxbox.h
+++ b/boot/freeldr/freeldr/include/arch/i386/machxbox.h
@@ -63,7 +63,6 @@ VOID XboxVideoPrepareForReactOS(VOID);
 VOID XboxPrepareForReactOS(VOID);
 
 VOID XboxMemInit(VOID);
-PVOID XboxMemReserveMemory(ULONG MbToReserve);
 PFREELDR_MEMORY_DESCRIPTOR XboxMemGetMemoryMap(ULONG *MemoryMapSize);
 
 BOOLEAN XboxDiskReadLogicalSectors(UCHAR DriveNumber, ULONGLONG SectorNumber, ULONG SectorCount, PVOID Buffer);


### PR DESCRIPTION
- Reuse framebuffer address that was set up by firmware
- Get rid of XboxMemReserveMemory and use ReserveMemory instead