### PR TITLE
[KERNEL32] Stub GetSystemTimePreciseAsFileTime

### DIFF
--- a/dll/apisets/api-ms-win-core-sysinfo-l1-2-0.spec
+++ b/dll/apisets/api-ms-win-core-sysinfo-l1-2-0.spec
@@ -17,7 +17,7 @@
 @ stdcall GetSystemTime() kernel32.GetSystemTime
 @ stdcall GetSystemTimeAdjustment() kernel32.GetSystemTimeAdjustment
 @ stdcall GetSystemTimeAsFileTime() kernel32.GetSystemTimeAsFileTime
-@ stub GetSystemTimePreciseAsFileTime
+@ stdcall -version=0x602+ GetSystemTimePreciseAsFileTime() kernel32.GetSystemTimePreciseAsFileTime
 @ stdcall GetSystemWindowsDirectoryA() kernel32.GetSystemWindowsDirectoryA
 @ stdcall GetSystemWindowsDirectoryW() kernel32.GetSystemWindowsDirectoryW
 @ stdcall GetTickCount() kernel32.GetTickCount

--- a/dll/apisets/api-ms-win-core-sysinfo-l1-2-1.spec
+++ b/dll/apisets/api-ms-win-core-sysinfo-l1-2-1.spec
@@ -19,7 +19,7 @@
 @ stdcall GetSystemTime() kernel32.GetSystemTime
 @ stdcall GetSystemTimeAdjustment() kernel32.GetSystemTimeAdjustment
 @ stdcall GetSystemTimeAsFileTime() kernel32.GetSystemTimeAsFileTime
-@ stub GetSystemTimePreciseAsFileTime
+@ stdcall -version=0x602+ GetSystemTimePreciseAsFileTime() kernel32.GetSystemTimePreciseAsFileTime
 @ stdcall GetSystemWindowsDirectoryA() kernel32.GetSystemWindowsDirectoryA
 @ stdcall GetSystemWindowsDirectoryW() kernel32.GetSystemWindowsDirectoryW
 @ stdcall -version=0x600+ GetTickCount64() kernel32.GetTickCount64

--- a/dll/win32/kernel32/client/time.c
+++ b/dll/win32/kernel32/client/time.c
@@ -141,6 +141,16 @@ GetSystemTimeAsFileTime(OUT PFILETIME lpFileTime)
 }
 
 /*
+ * @unimplemented
+ */
+VOID
+WINAPI
+GetSystemTimePreciseAsFileTime(OUT PFILETIME lpFileTime)
+{
+    STUB;
+}
+
+/*
  * @implemented
  */
 BOOL

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -604,6 +604,7 @@
 @ stdcall GetSystemTime(ptr)
 @ stdcall GetSystemTimeAdjustment(ptr ptr ptr)
 @ stdcall GetSystemTimeAsFileTime(ptr)
+@ stdcall -version=0x602+ GetSystemTimePreciseAsFileTime(ptr)
 @ stdcall GetSystemTimes(ptr ptr ptr)
 @ stdcall GetSystemWindowsDirectoryA(ptr long)
 @ stdcall GetSystemWindowsDirectoryW(ptr long)


### PR DESCRIPTION
## Purpose

Add a stub for Windows 8/Server 2012+ `GetSystemTimePreciseAsFileTime` function into kernel32, according to https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsystemtimepreciseasfiletime (but with ROS-specific diffs in the syntax). Required by 360 Extreme Explorer 11.0.2216.0 installer.

JIRA issue: [CORE-16420](https://jira.reactos.org/browse/CORE-16420)

## Proposed changes

- Add a stub for the function in `dll/win32/kernel32/client/time.c`;
- Properly call it in `dll/apisets/api-ms-win-core-sysinfo-l1-2-0.spec` and `dll/apisets/api-ms-win-core-sysinfo-l1-2-1.spec` apisets and in `dll/win32/kernel32/kernel32.spec` itself.

## Result

Before:
![360browser_ROS_before](https://user-images.githubusercontent.com/26385117/66504983-14d4cc00-ead3-11e9-8404-806a60965894.png)

After:
![360browser_ROS_after](https://user-images.githubusercontent.com/26385117/66505002-1f8f6100-ead3-11e9-926b-f099eaddc38a.png)

It also works in Win2k3 (and officially supports XP/2003):
![360browser_Win2k3](https://user-images.githubusercontent.com/26385117/66505087-45b50100-ead3-11e9-8585-1c3c8cbbe665.png)