### PR TITLE
[BOOTDATA] Add AppliedDPI registry value

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -83,6 +83,7 @@ HKCU,"Control Panel\Desktop","MenuShowDelay",2,"400"
 HKCU,"Control Panel\Desktop","WheelScrollLines",2,"3"
 HKCU,"Control Panel\Desktop","WheelScrollChars",2,"3"
 
+HKCU,"Control Panel\Desktop\WindowMetrics","AppliedDPI",0x00010003,0x00000060
 HKCU,"Control Panel\Desktop\WindowMetrics","ScrollWidth",2,"16"
 HKCU,"Control Panel\Desktop\WindowMetrics","ScrollHeight",2,"16"
 HKCU,"Control Panel\Desktop\WindowMetrics","CaptionWidth",2,"18"


### PR DESCRIPTION
## Purpose

Add `AppliedDPI` DWORD registry value 0x00000060 (96 DPI) into `HKCU\Control Panel\Desktop\WindowMetrics` registry key. For now it does nothing, since saving DPI registry settings is not implemented yet. It's required only for ViStart 8 to be started successfully (with MS VB6 Runtime installed and wshom.ocx replaced).

JIRA issue: [CORE-13877](https://jira.reactos.org/browse/CORE-13877)

## Result

Before:
![MS_wshom ocx_before](https://user-images.githubusercontent.com/26385117/66715677-b65b6680-edce-11e9-978f-9800ca00664a.png)
![WindowMetrics_before](https://user-images.githubusercontent.com/26385117/66715678-bce9de00-edce-11e9-9db7-2266f9d48f4e.png)

After:
![MS_wshom ocx_after](https://user-images.githubusercontent.com/26385117/66715698-fc182f00-edce-11e9-897e-301203de90de.png)
![WindowMetrics_after](https://user-images.githubusercontent.com/26385117/66715699-01757980-edcf-11e9-9879-552f77ec3d7d.png)

This value is also present in Win2k3 (96 DPI is default value):
![WindowMetrics_Win2k3](https://user-images.githubusercontent.com/26385117/66715716-3386db80-edcf-11e9-9ceb-58ef918983f0.png)