### PR TITLE
[SCSIPORT] Add an explicit IOCTL_ATA_PASS_THROUGH* case

### DIFF
--- a/drivers/storage/port/scsiport/ioctl.c
+++ b/drivers/storage/port/scsiport/ioctl.c
@@ -538,6 +538,14 @@ ScsiPortDeviceControl(
             status = STATUS_NOT_IMPLEMENTED;
             break;
 
+        case IOCTL_ATA_PASS_THROUGH:
+        case IOCTL_ATA_PASS_THROUGH_DIRECT:
+            /* ATA passthrough IOCTLs not supported by MS scsiport */
+            DPRINT1("ATA passthrough IOCTLs not supported: 0x%lX\n",
+                    Stack->Parameters.DeviceIoControl.IoControlCode);
+            status = STATUS_NOT_IMPLEMENTED;
+            break;
+
         default:
             DPRINT1("unknown ioctl code: 0x%lX\n", Stack->Parameters.DeviceIoControl.IoControlCode);
             status = STATUS_NOT_SUPPORTED;

--- a/drivers/storage/port/scsiport/ioctl.c
+++ b/drivers/storage/port/scsiport/ioctl.c
@@ -543,7 +543,7 @@ ScsiPortDeviceControl(
             /* ATA passthrough IOCTLs not supported by MS scsiport */
             DPRINT1("ATA passthrough IOCTLs not supported: 0x%lX\n",
                     Stack->Parameters.DeviceIoControl.IoControlCode);
-            status = STATUS_NOT_IMPLEMENTED;
+            status = STATUS_NOT_SUPPORTED;
             break;
 
         default:


### PR DESCRIPTION
## Purpose

If I understand correctly, this (ATA) ioctl code is valid, but implementation is optional (especially in SCSI).

JIRA issue: [CORE-16422](https://jira.reactos.org/browse/CORE-16422)

Please, double-check the message text.

Note:
`IOCTL_SCSI_PASS_THROUGH` is a stub (only), but that would be a separate issue.