### PR TITLE
[SHELL32] Fix extra fixme

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1807,7 +1807,11 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
 
     if (sei_tmp.fMask & unsupportedFlags)
     {
-        FIXME("flags ignored: 0x%08x\n", sei_tmp.fMask & unsupportedFlags);
+        // SEE_MASK_IDLIST is not in unsupportedFlags, but the check above passes because SEE_MASK_INVOKEIDLIST is in it
+        if ((sei_tmp.fMask & unsupportedFlags) != SEE_MASK_IDLIST)
+        {
+            FIXME("flags ignored: 0x%08x\n", sei_tmp.fMask & unsupportedFlags);
+        }
     }
 
     /* process the IDList */


### PR DESCRIPTION
## Purpose
This patch removes this line from the log:  
`fixme:(dll\win32\shell32\shlexec.cpp:1810) flags ignored: 0x00000004`
