### PR TITLE
[NTOS] Fix a bug in the PE loader, which caused images to be loaded u…

### DIFF
--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4579,11 +4579,11 @@ MmMapViewOfSection(IN PVOID SectionObject,
         ImageSectionObject->ImageInformation.ImageFileSize = (ULONG)ImageSize;
 
         /* Check for an illegal base address */
-        if (((ImageBase + ImageSize) > (ULONG_PTR)MmHighestUserAddress) ||
+        if (((ImageBase + ImageSize) > (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS) ||
                 ((ImageBase + ImageSize) < ImageSize))
         {
             ASSERT(*BaseAddress == NULL);
-            ImageBase = ALIGN_DOWN_BY((ULONG_PTR)MmHighestUserAddress - ImageSize,
+            ImageBase = ALIGN_DOWN_BY((ULONG_PTR)MM_HIGHEST_VAD_ADDRESS - ImageSize,
                                       MM_VIRTMEM_GRANULARITY);
             NotAtBase = TRUE;
         }


### PR DESCRIPTION
[NTOS] Fix a bug in the PE loader, which caused images to be loaded up to MmHighestUserAddress, thus overwriting the shared user page.

This is now fixed by using MM_HIGHEST_VAD_ADDRESS as the margin instead.
Should fix [CORE-11717](https://jira.reactos.org/browse/CORE-11717)
