### PR TITLE
[D3D8][D3D9][DDRAW][WINED3D] Use modules instead of shared libraries

### DIFF
--- a/dll/directx/wine/d3d8/CMakeLists.txt
+++ b/dll/directx/wine/d3d8/CMakeLists.txt
@@ -19,7 +19,7 @@ list(APPEND SOURCE
     volume.c
     precomp.h)
 
-add_library(d3d8 SHARED
+add_library(d3d8 MODULE
     ${SOURCE}
     guid.c
     version.rc

--- a/dll/directx/wine/d3d9/CMakeLists.txt
+++ b/dll/directx/wine/d3d9/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND SOURCE
     volume.c
     precomp.h)
 
-add_library(d3d9 SHARED
+add_library(d3d9 MODULE
     ${SOURCE}
     guid.c
     version.rc

--- a/dll/directx/wine/ddraw/CMakeLists.txt
+++ b/dll/directx/wine/ddraw/CMakeLists.txt
@@ -29,7 +29,7 @@ if(MSVC)
     set_source_files_properties(${SOURCE} PROPERTIES COMPILE_FLAGS "/FIwine/typeof.h")
 endif()
 
-add_library(ddraw SHARED
+add_library(ddraw MODULE
     ${SOURCE}
     ddraw.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ddraw.def)

--- a/dll/directx/wine/wined3d/CMakeLists.txt
+++ b/dll/directx/wine/wined3d/CMakeLists.txt
@@ -41,7 +41,7 @@ list(APPEND SOURCE
     wined3d_main.c
     precomp.h)
 
-add_library(d3dwine SHARED
+add_library(d3dwine MODULE
     ${SOURCE}
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/d3dwine.def)


### PR DESCRIPTION
## Purpose

This reverts part of (revert) commit 81cffd7658765be610e53bcd9489a3d73597e5eb,
so restores 23373acbb9b5356422657fa8448d2a18270847e2.

NB:
`CMakeLists.txt` parts, which were "unexpectedly" reverted:
- error C4133: superseded by additional 36d9e80add6c295ce05a3655eb23b1efd1f3fff7.
- SHARED to MODULE: restored by this PR.
- generated files: eventually restored by dffb99c172d74986c9cbcd2ce42d73b822c5bcd9.
- error C4312: unneeded anymore... (until next `wined3d` re-sync?)

## TODO

- [X] @JoachimHenze, please double-check this was an overkill part of your revert.
