### PR TITLE
[CMAKE] Use modules instead of shared libraries

### DIFF
--- a/base/services/w32time/CMakeLists.txt
+++ b/base/services/w32time/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 spec2def(w32time.dll w32time.spec ADD_IMPORTLIB)
 
-add_library(w32time SHARED
+add_library(w32time MODULE
     w32time.c
     ntpclient.c
     ${CMAKE_CURRENT_BINARY_DIR}/w32time.def)

--- a/dll/apisets/CMakeLists.txt.in
+++ b/dll/apisets/CMakeLists.txt.in
@@ -17,7 +17,7 @@ function (add_apiset apiset_name baseaddress)
         -D_WCTYPE_DEFINED
         -D_CRT_ERRNO_DEFINED)
 
-    add_library(${apiset_name} SHARED
+    add_library(${apiset_name} MODULE
         ${CMAKE_CURRENT_BINARY_DIR}/${apiset_name}_stubs.c
         ${CMAKE_CURRENT_BINARY_DIR}/${apiset_name}.def)
 

--- a/dll/shellext/netplwiz/CMakeLists.txt
+++ b/dll/shellext/netplwiz/CMakeLists.txt
@@ -5,7 +5,7 @@ list(APPEND SOURCE
     netplwiz.c
     SHDisconnectNetDrives.c)
 
-add_library(netplwiz SHARED
+add_library(netplwiz MODULE
     ${SOURCE}
     netplwiz.rc
     ${CMAKE_CURRENT_BINARY_DIR}/netplwiz_stubs.c

--- a/dll/win32/msxml3r/CMakeLists.txt
+++ b/dll/win32/msxml3r/CMakeLists.txt
@@ -1,4 +1,4 @@
 
-add_library(msxml3r SHARED msxml3r.rc)
+add_library(msxml3r MODULE msxml3r.rc)
 set_module_type(msxml3r win32dll ENTRYPOINT 0)
 add_cd_file(TARGET msxml3r DESTINATION reactos/system32 FOR all)

--- a/media/themes/Lunar/lunar.msstyles/CMakeLists.txt
+++ b/media/themes/Lunar/lunar.msstyles/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(_file ${TEXTFILES})
 endforeach()
 
 set_source_files_properties(lunar.rc PROPERTIES OBJECT_DEPENDS "${_converted_files}")
-add_library(lunar.msstyles SHARED lunar.rc)
+add_library(lunar.msstyles MODULE lunar.rc)
 set_module_type(lunar.msstyles module)
 set_target_properties(lunar.msstyles PROPERTIES SUFFIX "")
 add_cd_file(TARGET lunar.msstyles DESTINATION reactos/Resources/Themes/Lunar FOR all)

--- a/media/themes/Mizu/mizu.msstyles/CMakeLists.txt
+++ b/media/themes/Mizu/mizu.msstyles/CMakeLists.txt
@@ -18,7 +18,7 @@ foreach(_file ${TEXTFILES})
 endforeach()
 
 set_source_files_properties(mizu.rc PROPERTIES OBJECT_DEPENDS "${_converted_files}")
-add_library(mizu.msstyles SHARED mizu.rc)
+add_library(mizu.msstyles MODULE mizu.rc)
 set_module_type(mizu.msstyles module)
 set_target_properties(mizu.msstyles PROPERTIES SUFFIX "")
 add_cd_file(TARGET mizu.msstyles DESTINATION reactos/Resources/Themes/Mizu FOR all)


### PR DESCRIPTION
## Purpose

Follow-up to 23373acbb9b5356422657fa8448d2a18270847e2.
2 missed cases: apisets, lunar.msstyles.
4 new cases: w32time, netplwiz, msxml3r, mizu.msstyles.

## TODO

- [X] @learn-more, is this correct for `apisets`? Thanks.
If it is not, could you suggest a comment to add instead?
- [X] @milawynsrealm, does `msxml3r` miss a `.spec` file, or is it fine as is? Thanks.
