### PR TITLE
[HDWWIZ] ProbeListPageDlgProc(): Top 'Item' variable is enough

### DIFF
--- a/dll/cpl/hdwwiz/hdwwiz.c
+++ b/dll/cpl/hdwwiz/hdwwiz.c
@@ -434,7 +434,6 @@ ProbeListPageDlgProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     }
                     else
                     {
-                        LVITEM Item;
                         PWSTR pts;
 
                         ZeroMemory(&Item, sizeof(LV_ITEM));


### PR DESCRIPTION
## Purpose

Addendum to ce498aa5714a42c449b244feaa70c7df6d59e0af.
