### PR TITLE
[APPCOMPAT][ACCPAGE][SDB][ROSTESTS] Implement compatibility modes for Windows 10, Server 2016 and 2019

### DIFF
--- a/dll/appcompat/shims/layer/versionlie.c
+++ b/dll/appcompat/shims/layer/versionlie.c
@@ -52,6 +52,11 @@ VersionLieInfo g_Win7SP1 = { 0x1db10106, 6, 1, 7601, VER_PLATFORM_WIN32_NT, 1, 0
 VersionLieInfo g_Win8RTM = { 0x23f00206, 6, 2, 9200, VER_PLATFORM_WIN32_NT, 0, 0 };
 VersionLieInfo g_Win81RTM = { 0x25800306, 6, 3, 9600, VER_PLATFORM_WIN32_NT, 0, 0 };
 
+VersionLieInfo g_Win10RTM = { 0x47ba000a, 10, 0, 18362, VER_PLATFORM_WIN32_NT, 0, 0 };
+
+VersionLieInfo g_Win2k16RTM = { 0x3fab000a, 10, 0, 16299, VER_PLATFORM_WIN32_NT, 0, 0 };
+VersionLieInfo g_Win2k19RTM = { 0x4563000a, 10, 0, 17763, VER_PLATFORM_WIN32_NT, 0, 0 };
+
 /* Fill the OSVERSIONINFO[EX][W|A] struct with the info from the generic VersionLieInfo */
 
 BOOL FakeVersion(LPOSVERSIONINFOEXA pResult, VersionLieInfo* pFake)
@@ -171,6 +176,7 @@ BOOL WINAPI SHIM_OBJ_NAME(APIHook_GetVersionExW)(LPOSVERSIONINFOEXA lpOsVersionI
 #define VERSION_INFO    g_WinNT4SP5
 #include "versionlie.inl"
 
+
 #define SHIM_NS         Win2000VersionLie
 #define VERSION_INFO    g_Win2000
 #include "versionlie.inl"
@@ -235,6 +241,7 @@ BOOL WINAPI SHIM_OBJ_NAME(APIHook_GetVersionExW)(LPOSVERSIONINFOEXA lpOsVersionI
 #define VERSION_INFO    g_Win7SP1
 #include "versionlie.inl"
 
+
 #define SHIM_NS         Win8RTMVersionLie
 #define VERSION_INFO    g_Win8RTM
 #include "versionlie.inl"
@@ -244,3 +251,16 @@ BOOL WINAPI SHIM_OBJ_NAME(APIHook_GetVersionExW)(LPOSVERSIONINFOEXA lpOsVersionI
 #include "versionlie.inl"
 
 
+#define SHIM_NS         Win10RTMVersionLie
+#define VERSION_INFO    g_Win10RTM
+#include "versionlie.inl"
+
+
+#define SHIM_NS         Win2k16RTMVersionLie
+#define VERSION_INFO    g_Win2k16RTM
+#include "versionlie.inl"
+
+
+#define SHIM_NS         Win2k19RTMVersionLie
+#define VERSION_INFO    g_Win2k19RTM
+#include "versionlie.inl"

--- a/dll/shellext/acppage/CLayerUIPropPage.cpp
+++ b/dll/shellext/acppage/CLayerUIPropPage.cpp
@@ -29,17 +29,16 @@ static struct {
     { L"Windows 98/ME", L"WIN98" },
     { L"Windows NT 4.0 (SP5)", L"NT4SP5" },
     { L"Windows 2000", L"WIN2000" },
-    { L"Windows XP (SP2)", L"WINXPSP2" },
     { L"Windows XP (SP3)", L"WINXPSP3" },
     { L"Windows Server 2003 (SP1)", L"WINSRV03SP1" },
     { L"Windows Server 2008 (SP1)", L"WINSRV08SP1" },
-    { L"Windows Vista", L"VISTARTM" },
-    { L"Windows Vista (SP1)", L"VISTASP1" },
     { L"Windows Vista (SP2)", L"VISTASP2" },
     { L"Windows 7", L"WIN7RTM" },
     { L"Windows 7 (SP1)", L"WIN7SP1" },
-    { L"Windows 8", L"WIN8RTM" },
     { L"Windows 8.1", L"WIN81RTM" },
+    { L"Windows 10", L"WIN10RTM" },
+    { L"Windows Server 2016", L"WINSRV16RTM" },
+    { L"Windows Server 2019", L"WINSRV19RTM" },
     { NULL, NULL }
 };
 
@@ -339,7 +338,7 @@ LRESULT CLayerUIPropPage::OnInitDialog(UINT uMsg, WPARAM wParam, LPARAM lParam, 
     HWND cboMode = GetDlgItem(IDC_COMPATIBILITYMODE);
     for (size_t n = 0; g_CompatModes[n].Display; ++n)
         ComboBox_AddString(cboMode, g_CompatModes[n].Display);
-    ComboBox_SetCurSel(cboMode, 5);
+    ComboBox_SetCurSel(cboMode, 4);
 
     CStringW explanation;
     if (!m_AllowPermLayer)

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -200,6 +200,33 @@
                 <EXCLUDE MODULE="oleaut32.dll" />
                 <DLLFILE>aclayers.dll</DLLFILE>
             </SHIM>
+            <SHIM NAME="Win10RTMVersionLie">
+                <INCLUDE MODULE="shell32.dll" />
+                <INCLUDE MODULE="msi.dll" />
+                <EXCLUDE MODULE="kernel32.dll" />
+                <EXCLUDE MODULE="msvcrt.dll" />
+                <EXCLUDE MODULE="ole32.dll" />
+                <EXCLUDE MODULE="oleaut32.dll" />
+                <DLLFILE>aclayers.dll</DLLFILE>
+            </SHIM>
+            <SHIM NAME="Win2k16RTMVersionLie">
+                <INCLUDE MODULE="shell32.dll" />
+                <INCLUDE MODULE="msi.dll" />
+                <EXCLUDE MODULE="kernel32.dll" />
+                <EXCLUDE MODULE="msvcrt.dll" />
+                <EXCLUDE MODULE="ole32.dll" />
+                <EXCLUDE MODULE="oleaut32.dll" />
+                <DLLFILE>aclayers.dll</DLLFILE>
+            </SHIM>
+            <SHIM NAME="Win2k19RTMVersionLie">
+                <INCLUDE MODULE="shell32.dll" />
+                <INCLUDE MODULE="msi.dll" />
+                <EXCLUDE MODULE="kernel32.dll" />
+                <EXCLUDE MODULE="msvcrt.dll" />
+                <EXCLUDE MODULE="ole32.dll" />
+                <EXCLUDE MODULE="oleaut32.dll" />
+                <DLLFILE>aclayers.dll</DLLFILE>
+            </SHIM>
 
             <!-- Display mode shims -->
 
@@ -361,6 +388,24 @@
         <LAYER NAME="WIN81RTM">
             <SHIM_REF NAME="Win81RTMVersionLie" />
             <DATA NAME="SHIMVERSIONNT" DATA_DWORD="603" />
+            <!-- TODO: Add more fixes! -->
+        </LAYER>
+        <LAYER NAME="WIN10RTM">
+            <!-- ReactOS specific. Windows does not have this version lie -->
+            <SHIM_REF NAME="Win10RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
+            <!-- TODO: Add more fixes! -->
+        </LAYER>
+        <LAYER NAME="WINSRV16RTM">
+            <!-- ReactOS specific. Windows does not have this version lie -->
+            <SHIM_REF NAME="Win2k16RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
+            <!-- TODO: Add more fixes! -->
+        </LAYER>
+        <LAYER NAME="WINSRV19RTM">
+            <!-- ReactOS specific. Windows does not have this version lie -->
+            <SHIM_REF NAME="Win2k19RTMVersionLie" />
+            <DATA NAME="SHIMVERSIONNT" DATA_DWORD="1000" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
 

--- a/modules/rostests/apitests/appshim/versionlie.c
+++ b/modules/rostests/apitests/appshim/versionlie.c
@@ -288,6 +288,10 @@ VersionLieInfo g_Win7SP1 = { 0x1db10106, 6, 1, 7601, VER_PLATFORM_WIN32_NT, 1, 0
 VersionLieInfo g_Win8RTM = { 0x23f00206, 6, 2, 9200, VER_PLATFORM_WIN32_NT, 0, 0 };
 VersionLieInfo g_Win81RTM = { 0x25800306, 6, 3, 9600, VER_PLATFORM_WIN32_NT, 0, 0 };
 
+VersionLieInfo g_Win10RTM = { 0x47ba000a, 10, 0, 18362, VER_PLATFORM_WIN32_NT, 0, 0 };
+
+VersionLieInfo g_Win2k16RTM = { 0x3fab000a, 10, 0, 16299, VER_PLATFORM_WIN32_NT, 0, 0 };
+VersionLieInfo g_Win2k19RTM = { 0x4563000a, 10, 0, 17763, VER_PLATFORM_WIN32_NT, 0, 0 };
 
 DWORD get_host_winver(void)
 {
@@ -406,4 +410,7 @@ START_TEST(versionlie)
     run_test("Win7SP1VersionLie", &g_Win7SP1);    /* ReactOS specific. Windows does not have this version lie */
     run_test("Win8RTMVersionLie", &g_Win8RTM);
     run_test("Win81RTMVersionLie", &g_Win81RTM);
+    run_test("Win10RTMVersionLie", &g_Win10RTM);    /* ReactOS specific. Windows does not have this version lie */
+    run_test("Win2k16RTMVersionLie", &g_Win2k16RTM);    /* ReactOS specific. Windows does not have this version lie */
+    run_test("Win2k19RTMVersionLie", &g_Win2k19RTM);    /* ReactOS specific. Windows does not have this version lie */
 }


### PR DESCRIPTION
## Purpose

Implement ReactOS-specific Windows 10 1903, Server 2016 (1709) and 2019 (1809) compatibility modes. Windows has no these modes. The latest mode which 1903 has, is "Windows 8".
Although after my changes appeared some warnings during ROS compilation, but the system still compiles successfully and the modes work correctly:
`[Err ][fromXml ] Data node (SHIMVERSIONNT) without value!`
I wonder why they appeared. I specified `A00` in `DATA_DWORD` value for each HighVersionLie layer, which is correct for NT 10, according to the `_WIN32_WINNT_*` values (e. g. `0x0600` -> `600`, so `0x0A00` -> `A00`) defined in `sdk/include/psdk/sdkddkver.h`. Propapbly I need `a00` (in lowercase)?

JIRA issue: [CORE-16454](https://jira.reactos.org/browse/CORE-16454)

## Proposed changes

- Declare VersionLieInfos and define shims in appcompat;
- Add relevant dropdown menu entries in the accpage shell extension;
- Implement shims itself and VersionLies in sdb;
- Update appshim rostest accordingly;
- Additionally add a few missing newlines between the groups of different compatibility modes;
- Remove some less common compatibility modes (XP SP2, Vista, Vista SP1 and 8) from accpage.

## Result

After implementing compatibility modes, GetVersion tool: http://www.geocities.ws/jumper/GetVersion.7z, which gets a result of `GetVersion`, `GetVersionExA` and `GetVersionExW` functions, shows correct values, which I got from Microsoft Application Verifier 4.0 HighVersionLie:
![GetVersion_Win10_cm](https://user-images.githubusercontent.com/26385117/67611964-14148900-f7a7-11e9-8eb3-d1d3b5b7ca34.png)
![GetVersion_Win2k16_cm](https://user-images.githubusercontent.com/26385117/67611965-14148900-f7a7-11e9-8c9c-06517baccb65.png)
![GetVersion_Win2k19_cm](https://user-images.githubusercontent.com/26385117/67611966-14ad1f80-f7a7-11e9-8106-60036f4d5acb.png)

Also the menu entries appeared in accpage as well:
![compatibility_modes_ROS_after](https://user-images.githubusercontent.com/26385117/67611996-51791680-f7a7-11e9-81d0-991a50150c31.png)