### PR TITLE
[ATL] Re-enable MSVC warning C4477

### DIFF
--- a/dll/win32/atl/CMakeLists.txt
+++ b/dll/win32/atl/CMakeLists.txt
@@ -9,11 +9,6 @@ add_definitions(
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(atl.dll atl.spec ADD_IMPORTLIB)
 
-if(MSVC)
-    # Disable warning C4477 (printf format warnings)
-    add_compile_flags("/wd4477")
-endif()
-
 list(APPEND SOURCE
     atl.c
     atl30.c


### PR DESCRIPTION
Follow-up to e410a12242a50e850846058ef5c53652340c1724.