### PR TITLE
[USER32] Implement DM_REPOSITION message

### DIFF
--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -1179,7 +1179,49 @@ static BOOL DEFDLG_SetDefButton( HWND hwndDlg, DIALOGINFO *dlgInfo, HWND hwndNew
     return TRUE;
 }
 
+#ifdef __REACTOS__
+static void DEFDLG_Reposition(HWND hwnd)
+{
+    HMONITOR hMon;
+    MONITORINFO mi = { sizeof(mi) };
+    RECT rc;
+    SIZE siz;
 
+    hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
+
+    if (!GetMonitorInfoW(hMon, &mi) || !GetWindowRect(hwnd, &rc))
+        return;
+
+    siz.cx = rc.right - rc.left;
+    siz.cy = rc.bottom - rc.top;
+
+    if (rc.right > mi.rcWork.right)
+    {
+        rc.right = mi.rcWork.right;
+        rc.left = rc.right - siz.cx;
+    }
+    if (rc.bottom > mi.rcWork.bottom)
+    {
+        rc.bottom = mi.rcWork.bottom;
+        rc.top = rc.bottom - siz.cy;
+    }
+
+    if (rc.left < mi.rcWork.left)
+    {
+        rc.left = mi.rcWork.left;
+        rc.right = rc.left + siz.cx;
+    }
+    if (rc.top < mi.rcWork.top)
+    {
+        rc.top = mi.rcWork.top;
+        rc.bottom = rc.top + siz.cy;
+    }
+
+    SetWindowPos(hwnd, NULL, rc.left, rc.top, 0, 0,
+                 SWP_NOACTIVATE | SWP_NOOWNERZORDER | SWP_NOSIZE |
+                 SWP_NOZORDER);
+}
+#endif
 /***********************************************************************
  *           DEFDLG_Proc
  *
@@ -1253,6 +1295,11 @@ static LRESULT DEFDLG_Proc( HWND hwnd, UINT msg, WPARAM wParam,
             }
             return 0;
 
+#ifdef __REACTOS__
+        case DM_REPOSITION:
+            DEFDLG_Reposition(hwnd);
+            return 0;
+#endif
         case WM_NEXTDLGCTL:
             if (dlgInfo)
             {
@@ -1692,6 +1739,9 @@ DefDlgProcA(
             case WM_SETFOCUS:
             case DM_SETDEFID:
             case DM_GETDEFID:
+#ifdef __REACTOS__
+            case DM_REPOSITION:
+#endif
             case WM_NEXTDLGCTL:
             case WM_GETFONT:
             case WM_CLOSE:
@@ -1752,6 +1802,9 @@ DefDlgProcW(
             case WM_SETFOCUS:
             case DM_SETDEFID:
             case DM_GETDEFID:
+#ifdef __REACTOS__
+            case DM_REPOSITION:
+#endif
             case WM_NEXTDLGCTL:
             case WM_GETFONT:
             case WM_CLOSE:

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -1187,6 +1187,9 @@ static void DEFDLG_Reposition(HWND hwnd)
     RECT rc;
     SIZE siz;
 
+    if (GetWindowLong(hwnd, GWL_STYLE) & WS_CHILD)
+        return;
+
     hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);
 
     if (!GetMonitorInfoW(hMon, &mi) || !GetWindowRect(hwnd, &rc))

--- a/win32ss/user/user32/windows/dialog.c
+++ b/win32ss/user/user32/windows/dialog.c
@@ -1187,7 +1187,7 @@ static void DEFDLG_Reposition(HWND hwnd)
     RECT rc;
     SIZE siz;
 
-    if (GetWindowLong(hwnd, GWL_STYLE) & WS_CHILD)
+    if (GetWindowLongW(hwnd, GWL_STYLE) & WS_CHILD)
         return;
 
     hMon = MonitorFromWindow(hwnd, MONITOR_DEFAULTTOPRIMARY);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16490](https://jira.reactos.org/browse/CORE-16490)

`DM_REPOSITION` is dialog message that can reposition the dialog to the workarea when the dialog is partially/entirely in outside of the workarea.

I know it's Wine sync though. This PR is for review.