### PR TITLE
[SHELL32] Implement 'Open file location' of shortcut files

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2636,9 +2636,6 @@ HRESULT CShellLink::DoOpenFileLocation()
 
 HRESULT STDMETHODCALLTYPE CShellLink::InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
 {
-    LPWSTR args = NULL;
-    LPWSTR path = NULL;
-
     TRACE("%p %p\n", this, lpici);
 
     if (lpici->cbSize < sizeof(CMINVOKECOMMANDINFO))
@@ -2661,14 +2658,19 @@ HRESULT STDMETHODCALLTYPE CShellLink::InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
     switch (idCmd)
     {
     case IDCMD_OPEN:
-        break;
+        return DoOpen(lpici);
     case IDCMD_OPENFILELOCATION:
         return DoOpenFileLocation();
     default:
         return E_NOTIMPL;
     }
+}
 
-    path = strdupW(m_sPath);
+HRESULT CShellLink::DoOpen(LPCMINVOKECOMMANDINFO lpici)
+{
+    HRESULT hr;
+    LPWSTR args = NULL;
+    LPWSTR path = strdupW(m_sPath);
 
     if ( lpici->cbSize == sizeof(CMINVOKECOMMANDINFOEX) &&
         (lpici->fMask & CMIC_MASK_UNICODE) )

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -106,6 +106,7 @@ private:
     HRESULT SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile);
     HICON CreateShortcutIcon(LPCWSTR wszIconPath, INT IconIndex);
 
+    HRESULT DoOpen(LPCMINVOKECOMMANDINFO lpici);
     HRESULT DoOpenFileLocation();
 
 public:

--- a/dll/win32/shell32/CShellLink.h
+++ b/dll/win32/shell32/CShellLink.h
@@ -51,15 +51,19 @@ public:
     /* Link file formats */
 
     #include "pshpack1.h"
-
     struct volume_info
     {
         DWORD type;
         DWORD serial;
         WCHAR label[12];  /* assume 8.3 */
     };
-
     #include "poppack.h"
+
+    enum IDCMD
+    {
+        IDCMD_OPEN = 0,
+        IDCMD_OPENFILELOCATION
+    };
 
 private:
     /* Cached link header */
@@ -83,13 +87,13 @@ private:
     LPDBLIST      m_pDBList; /* Optional data block list (in the extra data section) */
     BOOL          m_bInInit;    // in initialization or not
     HICON         m_hIcon;
+    UINT          m_idCmdFirst;
 
     /* Pointers to strings inside Logo3/Darwin info blocks, cached for debug info purposes only */
     LPWSTR sProduct;
     LPWSTR sComponent;
 
     LPWSTR        m_sLinkPath;
-    INT           m_iIdOpen;     /* ID of the "Open" entry in the context menu */
 
     CComPtr<IUnknown>    m_site;
     CComPtr<IDropTarget> m_DropTarget;
@@ -101,6 +105,8 @@ private:
     HRESULT WriteAdvertiseInfo(LPCWSTR string, DWORD dwSig);
     HRESULT SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile);
     HICON CreateShortcutIcon(LPCWSTR wszIconPath, INT IconIndex);
+
+    HRESULT DoOpenFileLocation();
 
 public:
     CShellLink();

--- a/dll/win32/shell32/lang/bg-BG.rc
+++ b/dll/win32/shell32/lang/bg-BG.rc
@@ -770,6 +770,7 @@ BEGIN
     IDS_PASTE "Вмъкване"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/ca-ES.rc
+++ b/dll/win32/shell32/lang/ca-ES.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/cs-CZ.rc
+++ b/dll/win32/shell32/lang/cs-CZ.rc
@@ -775,6 +775,7 @@ BEGIN
     IDS_PASTE "Vložit"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Složku '%1' nebylo možné vytvořit"
     IDS_CREATEFOLDER_CAPTION "Složku nebylo možné vytvořit"

--- a/dll/win32/shell32/lang/da-DK.rc
+++ b/dll/win32/shell32/lang/da-DK.rc
@@ -775,6 +775,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -770,6 +770,7 @@ BEGIN
     IDS_PASTE "Einfügen"
     IDS_EJECT "Auswerfen"
     IDS_DISCONNECT "Trennen"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED " Der Ordner kann nicht erstellt werden '%1'"
     IDS_CREATEFOLDER_CAPTION " Der Ordner kann nicht erstellt werden."

--- a/dll/win32/shell32/lang/el-GR.rc
+++ b/dll/win32/shell32/lang/el-GR.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/en-GB.rc
+++ b/dll/win32/shell32/lang/en-GB.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/en-US.rc
+++ b/dll/win32/shell32/lang/en-US.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/es-ES.rc
+++ b/dll/win32/shell32/lang/es-ES.rc
@@ -777,6 +777,7 @@ BEGIN
     IDS_PASTE "Insertar"
     IDS_EJECT "Extraer"
     IDS_DISCONNECT "Desconectar"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "No se pudo crear la carpeta '%1'"
     IDS_CREATEFOLDER_CAPTION "No se pudo crear la carpeta"

--- a/dll/win32/shell32/lang/et-EE.rc
+++ b/dll/win32/shell32/lang/et-EE.rc
@@ -776,6 +776,7 @@ BEGIN
     IDS_PASTE "Kleebi"
     IDS_EJECT "Väljuta"
     IDS_DISCONNECT "Katkesta ühendus"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Ei saa luua kausta '%1'"
     IDS_CREATEFOLDER_CAPTION "Ei saa kausta luua"

--- a/dll/win32/shell32/lang/fi-FI.rc
+++ b/dll/win32/shell32/lang/fi-FI.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Insérer"
     IDS_EJECT "Éjecter"
     IDS_DISCONNECT "Déconnecter"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Impossible de créer le dossier '%1'"
     IDS_CREATEFOLDER_CAPTION "Impossible de créer un dossier"

--- a/dll/win32/shell32/lang/he-IL.rc
+++ b/dll/win32/shell32/lang/he-IL.rc
@@ -771,6 +771,7 @@ BEGIN
     IDS_PASTE "הכנס"
     IDS_EJECT "הוצא"
     IDS_DISCONNECT "נתק"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/hi-IN.rc
+++ b/dll/win32/shell32/lang/hi-IN.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "पैस्ट"
     IDS_EJECT "इजेक्ट"
     IDS_DISCONNECT "डिस्कनेक्ट"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "फ़ोल्डर '%1' बनाने में असमर्थ"
     IDS_CREATEFOLDER_CAPTION "फ़ोल्डर बनाने में असमर्थ"

--- a/dll/win32/shell32/lang/hu-HU.rc
+++ b/dll/win32/shell32/lang/hu-HU.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/id-ID.rc
+++ b/dll/win32/shell32/lang/id-ID.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Tempel"
     IDS_EJECT "Keluarkan"
     IDS_DISCONNECT "Putuskan"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Tidak bisa membuat folder folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Tidak bisa membuat folder"

--- a/dll/win32/shell32/lang/it-IT.rc
+++ b/dll/win32/shell32/lang/it-IT.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Inserisci"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/ja-JP.rc
+++ b/dll/win32/shell32/lang/ja-JP.rc
@@ -766,6 +766,7 @@ BEGIN
     IDS_PASTE "挿入"
     IDS_EJECT "取り出し"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "フォルダ '%1' を作成できません"
     IDS_CREATEFOLDER_CAPTION "フォルダを作成できません"

--- a/dll/win32/shell32/lang/ko-KR.rc
+++ b/dll/win32/shell32/lang/ko-KR.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/nl-NL.rc
+++ b/dll/win32/shell32/lang/nl-NL.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/no-NO.rc
+++ b/dll/win32/shell32/lang/no-NO.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Sett inn"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/pl-PL.rc
+++ b/dll/win32/shell32/lang/pl-PL.rc
@@ -774,6 +774,7 @@ BEGIN
     IDS_PASTE "Włóż"
     IDS_EJECT "Wysuń"
     IDS_DISCONNECT "Odłącz"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Nie można utworzyć folderu '%1'"
     IDS_CREATEFOLDER_CAPTION "Nie można utworzyć folderu"

--- a/dll/win32/shell32/lang/pt-BR.rc
+++ b/dll/win32/shell32/lang/pt-BR.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Inserir"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/pt-PT.rc
+++ b/dll/win32/shell32/lang/pt-PT.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Inserir"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Desligar"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Impossivel de criar pasta '%1'"
     IDS_CREATEFOLDER_CAPTION "Impossivel de criar pasta"

--- a/dll/win32/shell32/lang/ro-RO.rc
+++ b/dll/win32/shell32/lang/ro-RO.rc
@@ -771,6 +771,7 @@ BEGIN
     IDS_PASTE "&Lipește"
     IDS_EJECT "S&coate"
     IDS_DISCONNECT "Deconectea&ză"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Nu poate fi creat un dosar cu numele „%1”"
     IDS_CREATEFOLDER_CAPTION "Nu poate fi creat dosar"

--- a/dll/win32/shell32/lang/ru-RU.rc
+++ b/dll/win32/shell32/lang/ru-RU.rc
@@ -776,6 +776,7 @@ BEGIN
     IDS_PASTE "Вставить"
     IDS_EJECT "Извлечь"
     IDS_DISCONNECT "Отсоединить"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Невозможно создать папку '%1'"
     IDS_CREATEFOLDER_CAPTION "Невозможно создать папку"

--- a/dll/win32/shell32/lang/sk-SK.rc
+++ b/dll/win32/shell32/lang/sk-SK.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Vložiť"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/sl-SI.rc
+++ b/dll/win32/shell32/lang/sl-SI.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Paste"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/sq-AL.rc
+++ b/dll/win32/shell32/lang/sq-AL.rc
@@ -773,6 +773,7 @@ BEGIN
     IDS_PASTE "Fut"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Unable to create the folder '%1'"
     IDS_CREATEFOLDER_CAPTION "Unable to create folder"

--- a/dll/win32/shell32/lang/sv-SE.rc
+++ b/dll/win32/shell32/lang/sv-SE.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Klistra in"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Kunde inte skapa mappen '%1'"
     IDS_CREATEFOLDER_CAPTION "Kunde inte skapa mapp"

--- a/dll/win32/shell32/lang/tr-TR.rc
+++ b/dll/win32/shell32/lang/tr-TR.rc
@@ -771,6 +771,7 @@ BEGIN
     IDS_PASTE "Yapıştır"
     IDS_EJECT "Eject"
     IDS_DISCONNECT "Disconnect"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED """%1"" dizini oluşturulamıyor."
     IDS_CREATEFOLDER_CAPTION "Dizin Oluşturulamıyor"

--- a/dll/win32/shell32/lang/uk-UA.rc
+++ b/dll/win32/shell32/lang/uk-UA.rc
@@ -769,6 +769,7 @@ BEGIN
     IDS_PASTE "Вставити"
     IDS_EJECT "Витягнути"
     IDS_DISCONNECT "Відключити"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "Не вдалося створити папку '%1'"
     IDS_CREATEFOLDER_CAPTION "Не вдалося створити папку"

--- a/dll/win32/shell32/lang/zh-CN.rc
+++ b/dll/win32/shell32/lang/zh-CN.rc
@@ -777,6 +777,7 @@ BEGIN
     IDS_PASTE "贴上"
     IDS_EJECT "弹出"
     IDS_DISCONNECT "断开"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "无法创建文件夹 '%1'"
     IDS_CREATEFOLDER_CAPTION "无法创建文件夹"

--- a/dll/win32/shell32/lang/zh-TW.rc
+++ b/dll/win32/shell32/lang/zh-TW.rc
@@ -778,6 +778,7 @@ BEGIN
     IDS_PASTE "插入"
     IDS_EJECT "退出"
     IDS_DISCONNECT "中斷"
+    IDS_OPENFILELOCATION "Open f&ile location"
 
     IDS_CREATEFOLDER_DENIED "無法建立資料夾 '%1'"
     IDS_CREATEFOLDER_CAPTION "無法建立資料夾"

--- a/dll/win32/shell32/shresdef.h
+++ b/dll/win32/shell32/shresdef.h
@@ -227,6 +227,8 @@
 #define IDS_EJECT                339
 #define IDS_DISCONNECT           340
 
+#define IDS_OPENFILELOCATION     341
+
 #define IDS_MENU_EMPTY           34561
 
 /* Note: those strings are referenced from the registry */


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-12770](https://jira.reactos.org/browse/CORE-12770)
"Open file location" is a feature to open the location of the target of a shortcut file.

![open-loc](https://user-images.githubusercontent.com/2107452/68568313-96d35e80-049e-11ea-9628-0cf0ac6e3dff.png)