### PR TITLE
[SHELL32] Don't hardcode explorer.exe

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2619,11 +2619,14 @@ HRESULT STDMETHODCALLTYPE CShellLink::QueryContextMenu(HMENU hMenu, UINT indexMe
 
 HRESULT CShellLink::DoOpenFileLocation()
 {
+    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
     WCHAR szParams[MAX_PATH + 64];
     StringCbPrintfW(szParams, sizeof(szParams), L"/select,%s", m_sPath);
 
     INT_PTR ret;
-    ret = reinterpret_cast<INT_PTR>(ShellExecuteW(NULL, NULL, L"explorer.exe", szParams,
+    ret = reinterpret_cast<INT_PTR>(ShellExecuteW(NULL, NULL, szExplorer, szParams,
                                                   NULL, m_Header.nShowCommand));
     if (ret <= 32)
     {

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2619,7 +2619,7 @@ HRESULT STDMETHODCALLTYPE CShellLink::QueryContextMenu(HMENU hMenu, UINT indexMe
 
 HRESULT CShellLink::DoOpenFileLocation()
 {
-    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    WCHAR szExplorer[MAX_PATH];
     Shell_GetShellProgram(szExplorer, _countof(szExplorer));
 
     WCHAR szParams[MAX_PATH + 64];

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -65,7 +65,7 @@ HRESULT CALLBACK RegFolderContextMenuCallback(IShellFolder *psf,
     }
     else if (_ILIsNetHood(apidl[0]))
     {
-        WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+        WCHAR szExplorer[MAX_PATH];
         Shell_GetShellProgram(szExplorer, _countof(szExplorer));
 
         // FIXME path!

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -65,10 +65,13 @@ HRESULT CALLBACK RegFolderContextMenuCallback(IShellFolder *psf,
     }
     else if (_ILIsNetHood(apidl[0]))
     {
+        WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+        Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
         // FIXME path!
         if (32 >= (UINT_PTR)ShellExecuteW(NULL,
                                           L"open",
-                                          L"explorer.exe",
+                                          szExplorer,
                                           L"::{7007ACC7-3202-11D1-AAD2-00805FC1270E}",
                                           NULL,
                                           SW_SHOWDEFAULT))

--- a/dll/win32/shell32/shellmenu/CMakeLists.txt
+++ b/dll/win32/shell32/shellmenu/CMakeLists.txt
@@ -16,7 +16,8 @@ list(APPEND SOURCE
     CMenuSite.cpp
     CMenuToolbars.cpp
     CMergedFolder.cpp
-    CStartMenu.cpp)
+    CStartMenu.cpp
+    ShellProgram.cpp)
 
 add_library(shellmenu ${SOURCE})
 add_dependencies(shellmenu xdk psdk)

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -240,15 +240,18 @@ private:
 
     HRESULT OnExec(LPSMDATA psmd)
     {
+        WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+        Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
         // HACK: Because our ShellExecute can't handle CLSID components in paths, we can't launch the paths using the "open" verb.
         // FIXME: Change this back to using the path as the filename and the "open" verb, once ShellExecute can handle CLSID path components.
 
         if (psmd->uId == IDM_CONTROLPANEL)
-            ShellExecuteW(NULL, NULL, L"explorer.exe", L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}", NULL, SW_SHOWNORMAL);
+            ShellExecuteW(NULL, NULL, szExplorer, L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}", NULL, SW_SHOWNORMAL);
         else if (psmd->uId == IDM_NETWORKCONNECTIONS)
-            ShellExecuteW(NULL, NULL, L"explorer.exe", L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}", NULL, SW_SHOWNORMAL);
+            ShellExecuteW(NULL, NULL, szExplorer, L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{7007ACC7-3202-11D1-AAD2-00805FC1270E}", NULL, SW_SHOWNORMAL);
         else if (psmd->uId == IDM_PRINTERSANDFAXES)
-            ShellExecuteW(NULL, NULL, L"explorer.exe", L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{2227A280-3AEA-1069-A2DE-08002B30309D}", NULL, SW_SHOWNORMAL);
+            ShellExecuteW(NULL, NULL, szExplorer, L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}\\::{2227A280-3AEA-1069-A2DE-08002B30309D}", NULL, SW_SHOWNORMAL);
         else
             PostMessageW(m_hwndTray, WM_COMMAND, psmd->uId, 0);
 

--- a/dll/win32/shell32/shellmenu/CStartMenu.cpp
+++ b/dll/win32/shell32/shellmenu/CStartMenu.cpp
@@ -240,7 +240,7 @@ private:
 
     HRESULT OnExec(LPSMDATA psmd)
     {
-        WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+        WCHAR szExplorer[MAX_PATH];
         Shell_GetShellProgram(szExplorer, _countof(szExplorer));
 
         // HACK: Because our ShellExecute can't handle CLSID components in paths, we can't launch the paths using the "open" verb.

--- a/dll/win32/shell32/shellmenu/ShellProgram.cpp
+++ b/dll/win32/shell32/shellmenu/ShellProgram.cpp
@@ -1,0 +1,34 @@
+#include "shellmenu.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(shell);
+
+extern "C"
+BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
+{
+    if (!cchProgramMax)
+        return FALSE;
+
+    LONG err;
+    HKEY hKey;
+    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                        L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
+                        0, KEY_READ, &hKey);
+    if (err)
+    {
+        ERR("err: %ld\n", err);
+        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
+        return FALSE;
+    }
+
+    DWORD cbData = cchProgramMax * sizeof(WCHAR);
+    err = RegQueryValueExW(hKey, L"Shell", NULL, NULL, (LPBYTE)pszProgram, &cbData);
+    if (err)
+    {
+        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
+        ERR("err: %ld\n", err);
+    }
+
+    RegCloseKey(hKey);
+
+    return !err;
+}

--- a/dll/win32/shell32/shellmenu/ShellProgram.cpp
+++ b/dll/win32/shell32/shellmenu/ShellProgram.cpp
@@ -1,3 +1,22 @@
+/*
+ * ShellProgram.cpp
+ *
+ * Copyright 2019 Katayama Hirofumi MZ.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
 #include "shellmenu.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);

--- a/dll/win32/shell32/shellmenu/shellmenu.h
+++ b/dll/win32/shell32/shellmenu/shellmenu.h
@@ -103,4 +103,5 @@ HRESULT WINAPI RSHELL_CMenuDeskBar_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMenuSite_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMenuBand_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMergedFolder_CreateInstance(REFIID riid, LPVOID *ppv);
+
 }

--- a/dll/win32/shell32/shellmenu/shellmenu.h
+++ b/dll/win32/shell32/shellmenu/shellmenu.h
@@ -54,6 +54,7 @@
 #include <shellutils.h>
 #include <rosctrls.h>
 #include "../shresdef.h"
+#include "../wine/shell32_main.h"
 
 #include <wine/debug.h>
 
@@ -102,5 +103,4 @@ HRESULT WINAPI RSHELL_CMenuDeskBar_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMenuSite_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMenuBand_CreateInstance(REFIID riid, LPVOID *ppv);
 HRESULT WINAPI RSHELL_CMergedFolder_CreateInstance(REFIID riid, LPVOID *ppv);
-
 }

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1549,11 +1549,11 @@ static UINT_PTR SHELL_execute_class(LPCWSTR wszApplicationName, LPSHELLEXECUTEIN
 
 static BOOL SHELL_translate_idlist(LPSHELLEXECUTEINFOW sei, LPWSTR wszParameters, DWORD parametersLen, LPWSTR wszApplicationName, DWORD dwApplicationNameLen)
 {
-    WCHAR wExplorer[] = L"explorer.exe";
+    WCHAR wExplorer[MAX_PATH];
+    Shell_GetShellProgram(wExplorer, _countof(wExplorer));
+
     WCHAR buffer[MAX_PATH];
     BOOL appKnownSingular = FALSE;
-
-    Shell_GetShellProgram(wExplorer, _countof(wExplorer));
 
     /* last chance to translate IDList: now also allow CLSID paths */
     if (SUCCEEDED(SHELL_GetPathFromIDListForExecuteW((LPCITEMIDLIST)sei->lpIDList, buffer, sizeof(buffer)/sizeof(WCHAR)))) {
@@ -2487,8 +2487,6 @@ BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
     if (!cchProgramMax)
         return FALSE;
 
-    StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
-
     LONG err;
     HKEY hKey;
     err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
@@ -2497,6 +2495,7 @@ BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
     if (err)
     {
         ERR("err: %ld\n", err);
+        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
         return FALSE;
     }
 
@@ -2504,6 +2503,7 @@ BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
     err = RegQueryValueExW(hKey, L"Shell", NULL, NULL, (LPBYTE)pszProgram, &cbData);
     if (err)
     {
+        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
         ERR("err: %ld\n", err);
     }
 

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2045,9 +2045,12 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         WCHAR wExec[MAX_PATH];
         WCHAR * lpQuotedFile = (LPWSTR)HeapAlloc(GetProcessHeap(), 0, sizeof(WCHAR) * (strlenW(lpFile) + 3));
 
+        WCHAR szExplorer[MAX_PATH];
+        Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
         if (lpQuotedFile)
         {
-            retval = SHELL_FindExecutable(sei_tmp.lpDirectory, L"explorer",
+            retval = SHELL_FindExecutable(sei_tmp.lpDirectory, szExplorer,
                                           wszOpen, wExec, MAX_PATH,
                                           NULL, &env, NULL, NULL);
             if (retval > 32)

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2487,7 +2487,7 @@ BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
     if (!cchProgramMax)
         return FALSE;
 
-    StringCbCopyW(pszProgram, cchProgramMax, L"explorer.exe");
+    StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
 
     LONG err;
     HKEY hKey;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2480,34 +2480,3 @@ HRESULT WINAPI ShellExecCmdLine(
 
     return HRESULT_FROM_WIN32(dwError);
 }
-
-extern "C"
-BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax)
-{
-    if (!cchProgramMax)
-        return FALSE;
-
-    LONG err;
-    HKEY hKey;
-    err = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                        L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon",
-                        0, KEY_READ, &hKey);
-    if (err)
-    {
-        ERR("err: %ld\n", err);
-        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
-        return FALSE;
-    }
-
-    DWORD cbData = cchProgramMax * sizeof(WCHAR);
-    err = RegQueryValueExW(hKey, L"Shell", NULL, NULL, (LPBYTE)pszProgram, &cbData);
-    if (err)
-    {
-        StringCchCopyW(pszProgram, cchProgramMax, L"explorer.exe");
-        ERR("err: %ld\n", err);
-    }
-
-    RegCloseKey(hKey);
-
-    return !err;
-}

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -426,6 +426,9 @@ SHOpenFolderAndSelectItems(LPITEMIDLIST pidlFolder,
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
+    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
     WCHAR wszParams[MAX_PATH];
     wcscpy(wszParams, L"/select,");
     wcscat(wszParams, wszBuf);
@@ -434,7 +437,7 @@ SHOpenFolderAndSelectItems(LPITEMIDLIST pidlFolder,
     memset(&sei, 0, sizeof sei);
     sei.cbSize = sizeof sei;
     sei.fMask = SEE_MASK_WAITFORINPUTIDLE;
-    sei.lpFile = L"explorer.exe";
+    sei.lpFile = szExplorer;
     sei.lpParameters = wszParams;
 
     if (ShellExecuteExW(&sei))

--- a/dll/win32/shell32/shlfolder.cpp
+++ b/dll/win32/shell32/shlfolder.cpp
@@ -426,7 +426,7 @@ SHOpenFolderAndSelectItems(LPITEMIDLIST pidlFolder,
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    WCHAR szExplorer[MAX_PATH];
     Shell_GetShellProgram(szExplorer, _countof(szExplorer));
 
     WCHAR wszParams[MAX_PATH];

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -34,6 +34,9 @@
 
 #include "cpanel.h"
 #include "wine/unicode.h"
+#ifdef __REACTOS__
+BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax);
+#endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(shlctrl);
 
@@ -730,9 +733,12 @@ static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 #else
 static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 {
+    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
     ShellExecuteW(NULL,
                   L"open",
-                  L"explorer.exe",
+                  szExplorer,
                   L"::{20D04FE0-3AEA-1069-A2D8-08002B30309D}\\::{21EC2020-3AEA-1069-A2DD-08002B30309D}",
                   NULL,
                   SW_SHOWDEFAULT);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -733,7 +733,7 @@ static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 #else
 static	void	Control_DoWindow(CPanel* panel, HWND hWnd, HINSTANCE hInst)
 {
-    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    WCHAR szExplorer[MAX_PATH];
     Shell_GetShellProgram(szExplorer, _countof(szExplorer));
 
     ShellExecuteW(NULL,

--- a/dll/win32/shell32/wine/shell32_main.h
+++ b/dll/win32/shell32/wine/shell32_main.h
@@ -194,6 +194,8 @@ LPWSTR SH_FormatFileSizeWithBytes(PULARGE_INTEGER lpQwSize, LPWSTR pszBuf, UINT 
 HRESULT WINAPI DoRegisterServer(void);
 HRESULT WINAPI DoUnregisterServer(void);
 
+BOOL Shell_GetShellProgram(LPWSTR pszProgram, SIZE_T cchProgramMax);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1826,14 +1826,19 @@ HRESULT WINAPI SHCreateStdEnumFmtEtc(
  */
 BOOL WINAPI SHFindFiles( LPCITEMIDLIST pidlFolder, LPCITEMIDLIST pidlSaveFile )
 {
+    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+
     FIXME("params ignored: %p %p\n", pidlFolder, pidlSaveFile);
     if (SHRestricted(REST_NOFIND))
     {
         return FALSE;
     }
+
+    Shell_GetShellProgram(szExplorer, _countof(szExplorer));
+
     /* Open the search results folder */
     /* FIXME: CSearchBar should be opened as well */
-    return ShellExecuteW(NULL, NULL, L"explorer.exe", L"::{E17D4FC0-5564-11D1-83F2-00A0C90DC849}", NULL, SW_SHOWNORMAL) > (HINSTANCE)32;
+    return ShellExecuteW(NULL, NULL, szExplorer, L"::{E17D4FC0-5564-11D1-83F2-00A0C90DC849}", NULL, SW_SHOWNORMAL) > (HINSTANCE)32;
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -1826,7 +1826,7 @@ HRESULT WINAPI SHCreateStdEnumFmtEtc(
  */
 BOOL WINAPI SHFindFiles( LPCITEMIDLIST pidlFolder, LPCITEMIDLIST pidlSaveFile )
 {
-    WCHAR szExplorer[MAX_PATH] = L"explorer.exe";
+    WCHAR szExplorer[MAX_PATH];
 
     FIXME("params ignored: %p %p\n", pidlFolder, pidlSaveFile);
     if (SHRestricted(REST_NOFIND))


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16500](https://jira.reactos.org/browse/CORE-16500)

- Add `Shell_GetShellProgram` function into `shellmenu/ShellProgram.cpp`.
- Use it at some places for softcoding `"explorer.exe"`.

Thanks to @ale5000.