### PR TITLE
[FREELDR] Fix triple fault with debug on screen

### DIFF
--- a/boot/freeldr/freeldr/freeldr.c
+++ b/boot/freeldr/freeldr/freeldr.c
@@ -47,9 +47,9 @@ VOID __cdecl BootMain(IN PCCH CmdLine)
     /* Debugger pre-initialization */
     DebugInit(0);
 
-    TRACE("BootMain() called.\n");
-
     MachInit(CmdLine);
+
+    TRACE("BootMain() called.\n");
 
     /* Check if the CPU is new enough */
     FrLdrCheckCpuCompatibility(); // FIXME: Should be done inside MachInit!


### PR DESCRIPTION



## Purpose

Prevent uninitialized MachVtbl usage

JIRA issue: [CORE-16507](https://jira.reactos.org/browse/CORE-16507)

## Proposed changes

- Move the trace call after the MachInit()
