### PR TITLE
[NTUSER] Support MK_SHIFT/MK_CONTROL of mouse messages

### DIFF
--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -332,8 +332,13 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
     /* Mouse wheel */
     if (dwFlags & MOUSEEVENTF_WHEEL)
     {
+        WORD fwKeys = (WORD)pCurInfo->ButtonsDown;
+        if (IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
+            fwKeys |= MK_SHIFT;
+        if (IS_KEY_DOWN(gafAsyncKeyState, VK_CONTROL))
+            fwKeys |= MK_CONTROL;
         Msg.message = WM_MOUSEWHEEL;
-        Msg.wParam = MAKEWPARAM(pCurInfo->ButtonsDown, pmi->mouseData);
+        Msg.wParam = MAKEWPARAM(fwKeys, pmi->mouseData);
         co_MsqInsertMouseMessage(&Msg, bInjected, pmi->dwExtraInfo, TRUE);
     }
 

--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -229,9 +229,13 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
 
     if (IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
         pCurInfo->ButtonsDown |= MK_SHIFT;
+    else
+        pCurInfo->ButtonsDown &= ~MK_SHIFT;
 
     if (IS_KEY_DOWN(gafAsyncKeyState, VK_CONTROL))
         pCurInfo->ButtonsDown |= MK_CONTROL;
+    else
+        pCurInfo->ButtonsDown &= ~MK_CONTROL;
 
     /* Left button */
     if (dwFlags & MOUSEEVENTF_LEFTDOWN)

--- a/win32ss/user/ntuser/mouse.c
+++ b/win32ss/user/ntuser/mouse.c
@@ -227,6 +227,12 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
         UserSetCursorPos(ptCursor.x, ptCursor.y, bInjected, pmi->dwExtraInfo, TRUE);
     }
 
+    if (IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
+        pCurInfo->ButtonsDown |= MK_SHIFT;
+
+    if (IS_KEY_DOWN(gafAsyncKeyState, VK_CONTROL))
+        pCurInfo->ButtonsDown |= MK_CONTROL;
+
     /* Left button */
     if (dwFlags & MOUSEEVENTF_LEFTDOWN)
     {
@@ -332,13 +338,8 @@ UserSendMouseInput(MOUSEINPUT *pmi, BOOL bInjected)
     /* Mouse wheel */
     if (dwFlags & MOUSEEVENTF_WHEEL)
     {
-        WORD fwKeys = (WORD)pCurInfo->ButtonsDown;
-        if (IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
-            fwKeys |= MK_SHIFT;
-        if (IS_KEY_DOWN(gafAsyncKeyState, VK_CONTROL))
-            fwKeys |= MK_CONTROL;
         Msg.message = WM_MOUSEWHEEL;
-        Msg.wParam = MAKEWPARAM(fwKeys, pmi->mouseData);
+        Msg.wParam = MAKEWPARAM(pCurInfo->ButtonsDown, pmi->mouseData);
         co_MsqInsertMouseMessage(&Msg, bInjected, pmi->dwExtraInfo, TRUE);
     }
 


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16279](https://jira.reactos.org/browse/CORE-16279)
Upon mouse message generation, The states of `Shift` key and/or `Ctrl` key must be used. If `Shift` key is pressed, it enables `MK_SHIFT` flag of the mouse message. If `Ctrl` key is pressed, it enables `MK_CONTROL` flag of the mouse message.