### PR TITLE
[SHELL32] Simply return S_OK if *pdwEffect is none

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3186,6 +3186,9 @@ HRESULT CDefView::drag_notify_subitem(DWORD grfKeyState, POINTL pt, DWORD *pdwEf
 
 HRESULT WINAPI CDefView::DragEnter(IDataObject *pDataObject, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect)
 {
+    if (*pdwEffect == DROPEFFECT_NONE)
+        return S_OK;
+
     /* Get a hold on the data object for later calls to DragEnter on the sub-folders */
     m_pCurDataObject = pDataObject;
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -3107,6 +3107,10 @@ HRESULT STDMETHODCALLTYPE CShellLink::DragEnter(IDataObject *pDataObject,
     DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
 {
     TRACE("(%p)->(DataObject=%p)\n", this, pDataObject);
+
+    if (*pdwEffect == DROPEFFECT_NONE)
+        return S_OK;
+
     LPCITEMIDLIST pidlLast;
     CComPtr<IShellFolder> psf;
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -283,6 +283,10 @@ HRESULT WINAPI CFSDropTarget::DragEnter(IDataObject *pDataObject,
                                         DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
 {
     TRACE("(%p)->(DataObject=%p)\n", this, pDataObject);
+
+    if (*pdwEffect == DROPEFFECT_NONE)
+        return S_OK;
+
     FORMATETC fmt;
     FORMATETC fmt2;
     m_fAcceptFmt = FALSE;

--- a/dll/win32/shell32/droptargets/CexeDropHandler.cpp
+++ b/dll/win32/shell32/droptargets/CexeDropHandler.cpp
@@ -36,6 +36,9 @@ CExeDropHandler::~CExeDropHandler()
 HRESULT WINAPI CExeDropHandler::DragEnter(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
 {
     TRACE ("(%p)\n", this);
+    if (*pdwEffect == DROPEFFECT_NONE)
+        return S_OK;
+
     *pdwEffect = DROPEFFECT_COPY;
     return S_OK;
 }


### PR DESCRIPTION
## Purpose
{{IDropTarget::DragEnter}} must simply return `S_OK` if `*pdwEffect == DROPEFFECT_NONE`.

JIRA issue: [CORE-11238](https://jira.reactos.org/browse/CORE-11238)
