### PR TITLE
[CMAKE] Fix host tools build on x86-64 mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,7 @@ if(NOT CMAKE_CROSSCOMPILING)
             add_definitions(/Dinline=__inline)
         endif()
     endif()
-
-    include_directories(sdk/include/host)
+    add_subdirectory(sdk/include/host)
 
     if(NOT MSVC)
         add_subdirectory(dll/win32/dbghelp)

--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -7,10 +7,6 @@ endif()
 if(NOT CMAKE_CROSSCOMPILING)
     add_definitions(-DDBGHELP_STATIC_LIB)
 
-    if(ARCH STREQUAL "i386")
-        add_definitions(-D_X86_)
-    endif()
-
     include_directories(
         ${REACTOS_SOURCE_DIR}/tools
         ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
@@ -32,6 +28,7 @@ if(NOT CMAKE_CROSSCOMPILING)
     endif()
 
     add_library(dbghelphost ${SOURCE})
+    target_link_libraries(dbghelphost PRIVATE host_includes)
 else()
     add_definitions(
         -D__WINESRC__

--- a/dll/win32/dbghelp/compat.h
+++ b/dll/win32/dbghelp/compat.h
@@ -200,7 +200,7 @@ typedef struct _EXCEPTION_RECORD {
   DWORD NumberParameters;
   ULONG_PTR ExceptionInformation[EXCEPTION_MAXIMUM_PARAMETERS];
 } EXCEPTION_RECORD, *PEXCEPTION_RECORD;
-#if defined(_X86_)
+#if defined(TARGET_i386)
 #define SIZE_OF_80387_REGISTERS	80
 #define CONTEXT_i386	0x10000
 #define CONTEXT_i486	0x10000
@@ -257,7 +257,11 @@ typedef struct _CONTEXT {
   BYTE ExtendedRegisters[MAXIMUM_SUPPORTED_EXTENSION];
 } CONTEXT, *PCONTEXT;
 
-#else /* ARM? */
+#elif defined TARGET_amd64
+
+#error "Please define the CONTEXT structure for amd64 platform"
+
+#elif defined TARGET_arm /* ARM? */
 
 /* The following flags control the contents of the CONTEXT structure. */
 
@@ -356,6 +360,10 @@ typedef struct _CONTEXT {
 BOOLEAN CDECL            RtlAddFunctionTable(RUNTIME_FUNCTION*,DWORD,DWORD);
 BOOLEAN CDECL            RtlDeleteFunctionTable(RUNTIME_FUNCTION*);
 PRUNTIME_FUNCTION WINAPI RtlLookupFunctionEntry(ULONG_PTR,DWORD*,UNWIND_HISTORY_TABLE*);
+#else
+
+#error "Unknown target platform"
+
 #endif
 
 typedef

--- a/sdk/include/host/CMakeLists.txt
+++ b/sdk/include/host/CMakeLists.txt
@@ -1,0 +1,19 @@
+
+include(CheckIncludeFile)
+include(CheckTypeSize)
+
+# check for <sys/types.h>
+CHECK_INCLUDE_FILE("sys/types.h" HAVE_SYS_TYPES_H)
+
+# check for pid_t definition
+if (HAVE_SYS_TYPES_H)
+    set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h")
+    #this sets HAVE_PID_T
+    CHECK_TYPE_SIZE("pid_t" PID_T)
+    unset(CMAKE_EXTRA_INCLUDE_FILES)
+endif()
+
+configure_file(config.h.in config.h @ONLY)
+
+add_library(host_includes INTERFACE)
+target_include_directories(host_includes INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/sdk/include/host/config.h.in
+++ b/sdk/include/host/config.h.in
@@ -3,6 +3,12 @@
 
 #define __WINE_CONFIG_H
 
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H @HAVE_SYS_TYPES_H@
+
+/* Define to 1 if the system has the type `pid_t'. */
+#cmakedefine HAVE_PID_T 1
+
 #define HAVE_SPAWNVP 1
 
 /* Define to 1 if you have the `z' library (-lz). */

--- a/sdk/lib/3rdparty/zlib/CMakeLists.txt
+++ b/sdk/lib/3rdparty/zlib/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(-DNO_VIZ)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
 
 list(APPEND SOLO_SOURCE
     adler32.c
@@ -35,11 +34,15 @@ list(APPEND MINIZIP_SOURCE
 
 if(CMAKE_CROSSCOMPILING)
     add_library(zlib ${SOURCE} ${SOLO_SOURCE})
+    target_include_directories(zlib PRIVATE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
     add_library(zlib_solo ${SOLO_SOURCE})
     add_target_compile_definitions(zlib_solo Z_SOLO)
+    target_include_directories(zlib_solo PRIVATE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
     add_library(minizip ${MINIZIP_SOURCE})
     add_dependencies(minizip psdk)
+    target_include_directories(minizip PRIVATE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
 else()
     add_library(zlibhost ${SOLO_SOURCE})
     add_target_compile_definitions(zlibhost Z_SOLO)
+    target_include_directories(zlibhost PUBLIC ${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
 endif()

--- a/sdk/lib/cmlib/CMakeLists.txt
+++ b/sdk/lib/cmlib/CMakeLists.txt
@@ -26,10 +26,11 @@ else()
         -D__NO_CTYPE_INLINES
         -DCMLIB_HOST)
     add_library(cmlibhost ${SOURCE})
+    target_include_directories(cmlibhost INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
     if(NOT MSVC)
         add_target_compile_flags(cmlibhost "-fshort-wchar -Wno-multichar")
     endif()
 
-    target_link_libraries(cmlibhost unicode)
+    target_link_libraries(cmlibhost PRIVATE host_includes)
 endif()

--- a/sdk/lib/inflib/CMakeLists.txt
+++ b/sdk/lib/inflib/CMakeLists.txt
@@ -23,10 +23,11 @@ else()
 
     add_definitions(-D__NO_CTYPE_INLINES -DINFLIB_HOST -D_CRT_SECURE_NO_WARNINGS)
     add_library(inflibhost ${SOURCE})
+    target_include_directories(inflibhost INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 
     if(NOT MSVC)
         add_target_compile_flags(inflibhost "-fshort-wchar -Wpointer-arith -Wwrite-strings")
     endif()
 
-    target_link_libraries(inflibhost unicode)
+    target_link_libraries(inflibhost PRIVATE host_includes)
 endif()

--- a/sdk/tools/CMakeLists.txt
+++ b/sdk/tools/CMakeLists.txt
@@ -19,6 +19,8 @@ add_host_tool(gendib gendib/gendib.c)
 add_host_tool(geninc geninc/geninc.c)
 add_host_tool(mkshelllink mkshelllink/mkshelllink.c)
 add_host_tool(obj2bin obj2bin/obj2bin.c)
+target_link_libraries(obj2bin PRIVATE host_includes)
+
 add_host_tool(spec2def spec2def/spec2def.c)
 add_host_tool(utf16le utf16le/utf16le.cpp)
 

--- a/sdk/tools/cabman/CMakeLists.txt
+++ b/sdk/tools/cabman/CMakeLists.txt
@@ -7,6 +7,5 @@ list(APPEND SOURCE
     raw.cxx
     CCFDATAStorage.cxx)
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/libs/zlib)
 add_host_tool(cabman ${SOURCE})
-target_link_libraries(cabman zlibhost)
+target_link_libraries(cabman PRIVATE host_includes zlibhost)

--- a/sdk/tools/fatten/CMakeLists.txt
+++ b/sdk/tools/fatten/CMakeLists.txt
@@ -4,3 +4,4 @@ add_host_tool(fatten
     fatfs/diskio.c
     fatfs/ff.c
     fatfs/option/ccsbcs.c)
+target_link_libraries(fatten PRIVATE host_includes)

--- a/sdk/tools/kbdtool/CMakeLists.txt
+++ b/sdk/tools/kbdtool/CMakeLists.txt
@@ -1,2 +1,3 @@
 
 add_host_tool(kbdtool data.c main.c output.c parser.c)
+target_link_libraries(kbdtool PRIVATE host_includes)

--- a/sdk/tools/log2lines/CMakeLists.txt
+++ b/sdk/tools/log2lines/CMakeLists.txt
@@ -14,4 +14,4 @@ list(APPEND SOURCE
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/tools/rsym)
 add_host_tool(log2lines ${SOURCE})
-target_link_libraries(log2lines rsym_common)
+target_link_libraries(log2lines PRIVATE host_includes rsym_common)

--- a/sdk/tools/mkhive/CMakeLists.txt
+++ b/sdk/tools/mkhive/CMakeLists.txt
@@ -1,11 +1,4 @@
 
-add_definitions(-DMKHIVE_HOST)
-
-include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/lib/inflib
-    ${REACTOS_SOURCE_DIR}/sdk/lib/cmlib
-    ${REACTOS_SOURCE_DIR}/sdk/lib/rtl)
-
 list(APPEND SOURCE
     binhive.c
     cmi.c
@@ -15,9 +8,10 @@ list(APPEND SOURCE
     rtl.c)
 
 add_host_tool(mkhive ${SOURCE})
-
+target_include_directories(mkhive PRIVATE ${REACTOS_SOURCE_DIR}/sdk/lib/rtl)
+target_compile_definitions(mkhive PRIVATE -DMKHIVE_HOST)
 if(NOT MSVC)
     add_target_compile_flags(mkhive "-fshort-wchar")
 endif()
 
-target_link_libraries(mkhive unicode cmlibhost inflibhost)
+target_link_libraries(mkhive PRIVATE host_includes unicode cmlibhost inflibhost)

--- a/sdk/tools/rsym/CMakeLists.txt
+++ b/sdk/tools/rsym/CMakeLists.txt
@@ -1,9 +1,9 @@
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/tools)
-add_library(rsym_common rsym_common.c)
+add_library(rsym_common STATIC rsym_common.c)
+target_link_libraries(rsym_common PRIVATE host_includes)
 
 if(ARCH STREQUAL "i386")
-    add_definitions(-D_X86_)
     add_host_tool(rsym rsym.c)
 elseif(ARCH STREQUAL "amd64")
     add_host_tool(rsym rsym64.c)
@@ -11,5 +11,6 @@ elseif(ARCH STREQUAL "arm")
     add_executable(rsym rsym64.c)
 endif()
 
-target_link_libraries(rsym rsym_common dbghelphost zlibhost unicode)
-add_host_tool(raddr2line rsym_common.c raddr2line.c)
+target_link_libraries(rsym PRIVATE host_includes rsym_common dbghelphost zlibhost unicode)
+add_host_tool(raddr2line raddr2line.c)
+target_link_libraries(raddr2line PRIVATE host_includes rsym_common)

--- a/sdk/tools/unicode/CMakeLists.txt
+++ b/sdk/tools/unicode/CMakeLists.txt
@@ -83,7 +83,8 @@ list(APPEND SOURCE
     wctomb.c
     wctype.c)
 
-add_library(unicode ${SOURCE})
+add_library(unicode STATIC ${SOURCE})
+target_link_libraries(unicode PRIVATE host_includes)
 
 if(MSVC)
     # Disable warning "'<': signed/unsigned mismatch"

--- a/sdk/tools/widl/CMakeLists.txt
+++ b/sdk/tools/widl/CMakeLists.txt
@@ -34,7 +34,7 @@ list(APPEND SOURCE
 # Taken from widl.rbuild
 add_definitions(-DINT16=SHORT)
 add_host_tool(widl ${SOURCE})
-target_link_libraries(widl wpphost)
+target_link_libraries(widl PRIVATE host_includes wpphost)
 
 if(MSVC)
     # Disable warning "'>': signed/unsigned mismatch"

--- a/sdk/tools/wpp/CMakeLists.txt
+++ b/sdk/tools/wpp/CMakeLists.txt
@@ -28,7 +28,6 @@ if(CMAKE_CROSSCOMPILING)
         -Dstrtoll=_strtoi64
         -Dopen=_open
         -Dclose=_close)
-
     include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 endif()
 
@@ -42,4 +41,5 @@ if(CMAKE_CROSSCOMPILING)
     add_library(wpp ${SOURCE})
 else()
     add_library(wpphost ${SOURCE})
+    target_link_libraries(wpphost PRIVATE host_includes)
 endif()

--- a/sdk/tools/xml2sdb/CMakeLists.txt
+++ b/sdk/tools/xml2sdb/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(
     ${REACTOS_SOURCE_DIR}/dll/appcompat/apphelp
     ${REACTOS_SOURCE_DIR}/sdk/include/reactos/appcompat)
 add_host_tool(xml2sdb ${SOURCE})
+target_link_libraries(xml2sdb PRIVATE host_includes)
 
 if(MSVC)
     # Disable warning "'=': conversion from 'a' to 'b', possible loss of data"


### PR DESCRIPTION
Dynamically check for sys/types.h and pid_t in wine config.h
Use TARGET_xxx defines instead of _X86_ as this is undefined by GCC
Add some sense in include directories management by using interface
libraries. 
