### PR TITLE
[RPCRT4] Stub RpcGetAuthorizationContextForClient

### DIFF
--- a/dll/win32/rpcrt4/rpc_async.c
+++ b/dll/win32/rpcrt4/rpc_async.c
@@ -159,22 +159,23 @@ RPC_STATUS WINAPI RpcAsyncCancelCall(PRPC_ASYNC_STATE pAsync, BOOL fAbortCall)
     return RPC_S_INVALID_ASYNC_HANDLE;
 }
 
+#ifdef __REACTOS__
 /***********************************************************************
  *           RpcGetAuthorizationContextForClient [RPCRT4.@]
  * 
- * Returns the Authz context for an RPC client.
+ * Called by RpcFreeAuthorizationContext to return the Authz context.
  * 
  * PARAMS
- *  ClientBinding       [I] Binding handle on the server that represents
- *                          a binding to a client.
- *  ImpersonateOnReturn [I] Directs the function to impersonate the client on return.
- *  Reserved1           [I] Reserved. Must be null.
- *  pExpirationTime     [I] Pointer to the expiration date and time of the token.
- *  Reserved2           [I] Reserved. Must be a LUID structure with each member set to zero.
- *  Reserved3           [I] Reserved. Must be zero.
- *  Reserved4           [I] Reserved. Must be null.
- *  pAuthzClientContext [I] Pointer to an AUTHZ_CLIENT_CONTEXT_HANDLE structure
- *                          that can be passed directly to Authz functions.
+ *  ClientBinding        [I] Binding handle, represents a binding to a client on the server.
+ *  ImpersonateOnReturn  [I] Directs this function to be represented the client on return.
+ *  Reserved1            [I] Reserved, equal to null.
+ *  expiration_time      [I] Points to the exact date and time when the token expires.
+ *  Reserved2            [I] Reserved, equal to a LUID structure which has a members,
+ *                           each of them is set to zero.
+ *  Reserved3            [I] Reserved, equal to zero.
+ *  Reserved4            [I] Reserved, equal to null.
+ *  authz_client_context [I] Points to an AUTHZ_CLIENT_CONTEXT_HANDLE structure
+ *                           that has direct pass to Authz functions.
  * 
  * RETURNS
  *  Success: RPC_S_OK.
@@ -185,20 +186,22 @@ WINAPI
 RpcGetAuthorizationContextForClient(RPC_BINDING_HANDLE ClientBinding,
                                     BOOL ImpersonateOnReturn,
                                     void * Reserved1,
-                                    PLARGE_INTEGER pExpirationTime,
+                                    PLARGE_INTEGER expiration_time,
                                     LUID Reserved2,
                                     DWORD Reserved3,
                                     PVOID Reserved4,
                                     PVOID *authz_client_context)
 {
-    FIXME("(%p, %s, %p, %p, %p, %d, %p, %p): stub\n",
+    FIXME("(%p, %s, %p, %p, (%u, %d), %u, %p, %p): stub\n",
           ClientBinding,
           ImpersonateOnReturn,
           Reserved1,
-          pExpirationTime,
-          Reserved2,
+          expiration_time,
+          Reserved2.HighPart,
+          Reserved2.LowPart,
           Reserved3,
           Reserved4,
           authz_client_context);
     return RPC_S_NO_CONTEXT_AVAILABLE;
 }
+#endif

--- a/dll/win32/rpcrt4/rpc_async.c
+++ b/dll/win32/rpcrt4/rpc_async.c
@@ -158,3 +158,47 @@ RPC_STATUS WINAPI RpcAsyncCancelCall(PRPC_ASYNC_STATE pAsync, BOOL fAbortCall)
     FIXME("(%p, %s): stub\n", pAsync, fAbortCall ? "TRUE" : "FALSE");
     return RPC_S_INVALID_ASYNC_HANDLE;
 }
+
+/***********************************************************************
+ *           RpcGetAuthorizationContextForClient [RPCRT4.@]
+ * 
+ * Returns the Authz context for an RPC client.
+ * 
+ * PARAMS
+ *  ClientBinding       [I] Binding handle on the server that represents
+ *                          a binding to a client.
+ *  ImpersonateOnReturn [I] Directs the function to impersonate the client on return.
+ *  Reserved1           [I] Reserved. Must be null.
+ *  pExpirationTime     [I] Pointer to the expiration date and time of the token.
+ *  Reserved2           [I] Reserved. Must be a LUID structure with each member set to zero.
+ *  Reserved3           [I] Reserved. Must be zero.
+ *  Reserved4           [I] Reserved. Must be null.
+ *  pAuthzClientContext [I] Pointer to an AUTHZ_CLIENT_CONTEXT_HANDLE structure
+ *                          that can be passed directly to Authz functions.
+ * 
+ * RETURNS
+ *  Success: RPC_S_OK.
+ *  Failure: Any error code.
+ */
+RPC_STATUS
+WINAPI
+RpcGetAuthorizationContextForClient(RPC_BINDING_HANDLE ClientBinding,
+                                    BOOL ImpersonateOnReturn,
+                                    void * Reserved1,
+                                    PLARGE_INTEGER pExpirationTime,
+                                    LUID Reserved2,
+                                    DWORD Reserved3,
+                                    PVOID Reserved4,
+                                    PVOID *authz_client_context)
+{
+    FIXME("(%p, %s, %p, %p, %p, %d, %p, %p): stub\n",
+          ClientBinding,
+          ImpersonateOnReturn,
+          Reserved1,
+          pExpirationTime,
+          Reserved2,
+          Reserved3,
+          Reserved4,
+          authz_client_context);
+    return RPC_S_NO_CONTEXT_AVAILABLE;
+}

--- a/dll/win32/rpcrt4/rpc_async.c
+++ b/dll/win32/rpcrt4/rpc_async.c
@@ -192,7 +192,7 @@ RpcGetAuthorizationContextForClient(RPC_BINDING_HANDLE ClientBinding,
                                     PVOID Reserved4,
                                     PVOID *authz_client_context)
 {
-    FIXME("(%p, %s, %p, %p, (%u, %d), %u, %p, %p): stub\n",
+    FIXME("(%p, %d, %p, %p, (%d, %u), %u, %p, %p): stub\n",
           ClientBinding,
           ImpersonateOnReturn,
           Reserved1,

--- a/dll/win32/rpcrt4/rpcrt4.spec
+++ b/dll/win32/rpcrt4/rpcrt4.spec
@@ -378,7 +378,7 @@
 378 stdcall RpcErrorStartEnumeration(ptr)
 379 stub RpcFreeAuthorizationContext
 380 stdcall RpcGetAsyncCallStatus(ptr) RpcAsyncGetCallStatus
-381 stdcall RpcGetAuthorizationContextForClient(ptr long ptr ptr long long ptr ptr ptr)
+381 stdcall RpcGetAuthorizationContextForClient(ptr long ptr ptr int64 long ptr ptr)
 382 stub RpcIfIdVectorFree
 383 stub RpcIfInqId
 384 stdcall RpcImpersonateClient(ptr)

--- a/dll/win32/rpcrt4/rpcrt4.spec
+++ b/dll/win32/rpcrt4/rpcrt4.spec
@@ -378,7 +378,7 @@
 378 stdcall RpcErrorStartEnumeration(ptr)
 379 stub RpcFreeAuthorizationContext
 380 stdcall RpcGetAsyncCallStatus(ptr) RpcAsyncGetCallStatus
-# RpcGetAuthorizationContextForClient
+381 stdcall RpcGetAuthorizationContextForClient(ptr long ptr ptr long long ptr ptr ptr)
 382 stub RpcIfIdVectorFree
 383 stub RpcIfInqId
 384 stdcall RpcImpersonateClient(ptr)


### PR DESCRIPTION
## Purpose

Add a stub for RpcGetAuthorizationContextForClient function into rpcrt4, according to https://docs.microsoft.com/en-us/windows/win32/api/rpcasync/nf-rpcasync-rpcgetauthorizationcontextforclient (but with Wine-specific diffs in the syntax, according to the code guidelines: https://wiki.winehq.org/Submitting_Patches#Code_guidelines, since we're syncing rpcrt4 with Wine). Required by MS Winlogon with also Win32 subsystem and some other dlls replaced (aka ROS-Frankenstein), so after my changes it doesn't fail with our rpcrt4.dll at the system startup.
I think I also need to submit a patch in Wine, but it is a bit problematically to reproduce this error there, since Wine has no even winlogon.exe, and launching MS Winlogon in pair with profmap.dll, causes the crash due to unimplemented RtlSetProcessIsCritical function in ntdll (which is completely different than our). Ftr, our ntdll already has it implemented: https://git.reactos.org/?p=reactos.git;a=blob;f=sdk/lib/rtl/process.c;hb=67c78d88c885ca92c72e2bcf59ddcf1d429096b1#l453 But with MS ntdll.dll, as far as I know, Wine will not work.

JIRA issue: [CORE-16458](https://jira.reactos.org/browse/CORE-16458)

Although this PR doesn't fix that shutdown issue, it at least improves the situation with replaced system files and allows to investigate it more.

## Proposed changes

- Add a stub for the function in `dll/win32/rpcrt4/rpc_async.c`;
- Properly call it in `dll/win32/rpcrt4/rpcrt4.spec`.