### PR TITLE
[NTOS:IO] Fix result length for DevicePropertyRemovalPolicy request

### DIFF
--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -4240,6 +4240,7 @@ IoGetDeviceProperty(IN PDEVICE_OBJECT DeviceObject,
     GUID BusTypeGuid;
     POBJECT_NAME_INFORMATION ObjectNameInfo = NULL;
     BOOLEAN NullTerminate = FALSE;
+    DEVICE_REMOVAL_POLICY Policy;
 
     DPRINT("IoGetDeviceProperty(0x%p %d)\n", DeviceObject, DeviceProperty);
 
@@ -4357,7 +4358,9 @@ IoGetDeviceProperty(IN PDEVICE_OBJECT DeviceObject,
             break;
 
         case DevicePropertyRemovalPolicy:
-            PIP_RETURN_DATA(sizeof(UCHAR), &DeviceNode->RemovalPolicy);
+
+            Policy = DeviceNode->RemovalPolicy;
+            PIP_RETURN_DATA(sizeof(Policy), &Policy);
 
         /* Handle the registry-based properties */
         case DevicePropertyUINumber:


### PR DESCRIPTION
Now disk_new.sys is able to start (checked with usbstor.sys as a port driver). This makes us a bit closer to its adoption :) 

JIRA issue: [CORE-6264](https://jira.reactos.org/browse/CORE-6264)
