### PR TITLE
[NTUSER] Fix condition of HSHELL_WINDOWCREATED

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2351,13 +2351,17 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    IntSendParentNotify(Window, WM_CREATE);
 
    /* Notify the shell that a new window was created */
-   if (UserIsDesktopWindow(Window->spwndParent) &&
-       Window->spwndOwner == NULL &&
-       (Window->style & WS_VISIBLE) &&
-       (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
-        (Window->ExStyle & WS_EX_APPWINDOW)))
+   if (Window->spwndOwner == NULL ||
+       !(Window->spwndOwner->style & WS_VISIBLE) ||
+       (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
    {
-      co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
+      if (UserIsDesktopWindow(Window->spwndParent) &&
+          (Window->style & WS_VISIBLE) &&
+          (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
+           (Window->ExStyle & WS_EX_APPWINDOW)))
+      {
+         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
+      }
    }
 
    /* Initialize and show the window's scrollbars */

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1904,11 +1904,17 @@ co_WinPosSetWindowPos(
    }
    else if (WinPos.flags & SWP_SHOWWINDOW)
    {
-       if (UserIsDesktopWindow(Window->spwndParent) &&
-           Window->spwndOwner == NULL &&
-           (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
-            (Window->ExStyle & WS_EX_APPWINDOW)))
-         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
+      if (Window->spwndOwner == NULL ||
+          !(Window->spwndOwner->style & WS_VISIBLE) ||
+          (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
+      {
+         if (UserIsDesktopWindow(Window->spwndParent) &&
+             (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
+              (Window->ExStyle & WS_EX_APPWINDOW)))
+         {
+            co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
+         }
+      }
 
       Window->style |= WS_VISIBLE; //IntSetStyle( Window, WS_VISIBLE, 0 );
       Window->head.pti->cVisWindows++;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15655](https://jira.reactos.org/browse/CORE-15655)

If the owner window doesn't exist or is invisible or has `WS_EX_TOOLWINDOW` style, `HSHELL_WINDOWCREATED` regards the window a non-owned window.

![Click-N-Type-success](https://user-images.githubusercontent.com/2107452/69003186-236b9a00-0941-11ea-9446-787829732075.png)
Successful.
