### PR TITLE
[CMD] Set ERRORLEVEL upon Move failure

### DIFF
--- a/base/shell/cmd/move.c
+++ b/base/shell/cmd/move.c
@@ -496,9 +496,14 @@ INT cmd_move (LPTSTR param)
             }
         }
         if (MoveStatus)
+        {
             ConOutResPrintf(STRING_MOVE_ERROR1);
+        }
         else
+        {
             ConOutResPrintf(STRING_MOVE_ERROR2);
+            nErrorLevel = 1;
+        }
     }
     while ((!OnlyOneFile || dwMoveStatusFlags & MOVE_SRC_CURRENT_IS_DIR ) &&
             !(dwMoveStatusFlags & MOVE_SOURCE_IS_DIR) &&


### PR DESCRIPTION
## Purpose

Based on a report of JIRA user "Hans Harder".
JIRA issue: [CORE-14261](https://jira.reactos.org/browse/CORE-14261)
