### PR TITLE
[CMAKE] Follow-up to PR #2041

### DIFF
--- a/sdk/include/host/CMakeLists.txt
+++ b/sdk/include/host/CMakeLists.txt
@@ -1,19 +1,3 @@
 
-include(CheckIncludeFile)
-include(CheckTypeSize)
-
-# check for <sys/types.h>
-CHECK_INCLUDE_FILE("sys/types.h" HAVE_SYS_TYPES_H)
-
-# check for pid_t definition
-if (HAVE_SYS_TYPES_H)
-    set(CMAKE_EXTRA_INCLUDE_FILES "sys/types.h")
-    #this sets HAVE_PID_T
-    CHECK_TYPE_SIZE("pid_t" PID_T)
-    unset(CMAKE_EXTRA_INCLUDE_FILES)
-endif()
-
-configure_file(config.h.in config.h @ONLY)
-
 add_library(host_includes INTERFACE)
 target_include_directories(host_includes INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})

--- a/sdk/include/host/CMakeLists.txt
+++ b/sdk/include/host/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_library(host_includes INTERFACE)
-target_include_directories(host_includes INTERFACE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(host_includes INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/sdk/include/host/config.h
+++ b/sdk/include/host/config.h
@@ -4,11 +4,12 @@
 #define __WINE_CONFIG_H
 
 /* Define to 1 if you have the <sys/types.h> header file. */
-#cmakedefine HAVE_SYS_TYPES_H @HAVE_SYS_TYPES_H@
+#define HAVE_SYS_TYPES_H 1
 
 /* Define to 1 if the system has the type `pid_t'. */
-#cmakedefine HAVE_PID_T 1
+#define HAVE_PID_T 1
 
+/* Define to 1 if you have the `spawnvp' function. */
 #define HAVE_SPAWNVP 1
 
 /* Define to 1 if you have the `z' library (-lz). */


### PR DESCRIPTION
sys/types.h is guaranteed to be available on all our supported host platforms and always contains a `pid_t` definition (cf. https://pubs.opengroup.org/onlinepubs/009695399/basedefs/sys/types.h.html), so define the corresponding `HAVE_*` constants unconditionally.

If you think that this is just nitpicking, let me explain:
* Defining all `HAVE_*` constants unconditionally tells people that we only support host platforms coming with these headers and type definitions.
* Checking the host platform and defining them conditionally puts an additional burden on our build process. It asks for adding more header checks, slowly turning our CMake into an 80s-style `./configure` script. Moreover, it tells people that we support host platforms with and without these characteristics and accept patches if we fail on platforms lacking these headers.

We clearly want the first thing and this is what this patch is for :)