### PR TITLE
[MMSYS] IMGINFO: Add a FIXME about missing iPlanes and iBits

### DIFF
--- a/dll/cpl/mmsys/volume.c
+++ b/dll/cpl/mmsys/volume.c
@@ -17,6 +17,10 @@ typedef struct _IMGINFO
     HBITMAP hBitmap;
     INT cxSource;
     INT cySource;
+    // FIXME: Add iPlanes, though unused here? Use it?
+    // INT iPlanes;
+    // FIXME: Add iBits, though unused here? Use it?
+    // INT iBits;
 } IMGINFO, *PIMGINFO;
 
 


### PR DESCRIPTION
## Purpose

Goal: be consistent or explain why not.
See
https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=struct+_IMGINFO
