### PR TITLE
[BOOTLIB] Remove a useless 'FontDirectory' check. CORE-11590

### DIFF
--- a/boot/environ/lib/io/display/display.c
+++ b/boot/environ/lib/io/display/display.c
@@ -157,7 +157,7 @@ Quickie:
     }
 
     /* Check if we had a custom font directory allocated and free it */
-    if ((FontDirectory) && (CustomDirectory))
+    if (CustomDirectory) // FontDirectory is != NULL.
     {
         BlMmFreeHeap(FontDirectory);
     }


### PR DESCRIPTION
## Purpose

Reduce confusion.

Author = Victor Martinez.

JIRA issue: [CORE-11590](https://jira.reactos.org/browse/CORE-11590)
