### PR TITLE
[DEVMGR] m_DisplayName: Some functions need bytes, not chars

### DIFF
--- a/dll/win32/devmgr/devmgmt/ClassNode.cpp
+++ b/dll/win32/devmgr/devmgmt/ClassNode.cpp
@@ -42,10 +42,10 @@ CClassNode::SetupNode()
                                      0);
     if (hKey != INVALID_HANDLE_VALUE)
     {
-        Size = DISPLAY_NAME_LEN;
         Type = REG_SZ;
 
         // Lookup the class description (win7+)
+        Size = sizeof(m_DisplayName);
         Success = RegQueryValueExW(hKey,
                                    L"ClassDesc",
                                    NULL,
@@ -58,12 +58,13 @@ CClassNode::SetupNode()
             if (m_DisplayName[0] == L'@')
             {
                 // The description is located in a module resource
-                Success = ConvertResourceDescriptorToString(m_DisplayName, DISPLAY_NAME_LEN);
+                Success = ConvertResourceDescriptorToString(m_DisplayName, sizeof(m_DisplayName));
             }
         }
         else if (Success == ERROR_FILE_NOT_FOUND)
         {
             // WinXP stores the description in the default value
+            Size = sizeof(m_DisplayName);
             Success = RegQueryValueExW(hKey,
                                        NULL,
                                        NULL,
@@ -84,7 +85,7 @@ CClassNode::SetupNode()
     if (Success != ERROR_SUCCESS)
     {
         // Use the class name as the description
-        RequiredSize = DISPLAY_NAME_LEN;
+        RequiredSize = _countof(m_DisplayName);
         (VOID)SetupDiClassNameFromGuidW(&m_ClassGuid,
                                         m_DisplayName,
                                         RequiredSize,

--- a/dll/win32/devmgr/devmgmt/DeviceNode.cpp
+++ b/dll/win32/devmgr/devmgmt/DeviceNode.cpp
@@ -131,7 +131,7 @@ CDeviceNode::SetupNode()
                               &m_ClassImage);
 
     // Get the description for the device
-    ulLength = DISPLAY_NAME_LEN * sizeof(WCHAR);
+    ulLength = sizeof(m_DisplayName);
     cr = CM_Get_DevNode_Registry_PropertyW(m_DevInst,
                                            CM_DRP_FRIENDLYNAME,
                                            NULL,
@@ -140,7 +140,7 @@ CDeviceNode::SetupNode()
                                            0);
     if (cr != CR_SUCCESS)
     {
-        ulLength = DISPLAY_NAME_LEN * sizeof(WCHAR);
+        ulLength = sizeof(m_DisplayName);
         cr = CM_Get_DevNode_Registry_PropertyW(m_DevInst,
                                                CM_DRP_DEVICEDESC,
                                                NULL,

--- a/dll/win32/devmgr/devmgmt/Node.cpp
+++ b/dll/win32/devmgr/devmgmt/Node.cpp
@@ -32,7 +32,7 @@ CNode::CNode(const CNode &Node)
     m_DeviceId = Node.m_DeviceId;
     m_ClassImage = Node.m_ClassImage;
 
-    StringCbCopyW(m_DisplayName, DISPLAY_NAME_LEN, Node.m_DisplayName);
+    StringCbCopyW(m_DisplayName, sizeof(m_DisplayName), Node.m_DisplayName);
     CopyMemory(&m_ClassGuid, &Node.m_ClassGuid, sizeof(GUID));
 }
 

--- a/dll/win32/devmgr/devmgmt/RootNode.cpp
+++ b/dll/win32/devmgr/devmgmt/RootNode.cpp
@@ -52,7 +52,7 @@ CRootNode::SetupNode()
     }
 
     // The root name is the computer name 
-    DWORD Size = DISPLAY_NAME_LEN;
+    DWORD Size = _countof(m_DisplayName);
     GetComputerNameW(m_DisplayName, &Size);
 
     return true;


### PR DESCRIPTION
Also:
Always use explicit _countof() and sizeof().
Add a missing 'Size' re-init.
