### PR TITLE
[WINSTA] Export WinStationRedirectErrorMessage

### DIFF
--- a/dll/win32/winsta/winsta.spec
+++ b/dll/win32/winsta/winsta.spec
@@ -69,6 +69,7 @@
 @ stdcall WinStationQueryLicense(ptr ptr ptr)
 @ stdcall WinStationQueryLogonCredentialsW(ptr)
 @ stdcall WinStationQueryUpdateRequired(ptr ptr)
+@ stdcall WinStationRedirectErrorMessage(ptr ptr)
 @ stdcall WinStationRegisterConsoleNotification(ptr ptr ptr)
 @ stdcall WinStationRegisterConsoleNotificationEx(ptr ptr ptr ptr)
 @ stdcall WinStationRegisterNotificationEvent(ptr ptr ptr ptr)


### PR DESCRIPTION
## Purpose

Add export for WinStationRedirectErrorMessage function in Winsta. We already have a stub for this function in `dll/win32/winsta/logon.c`, but for some reason it is not exported.
Required by MS Winlogon with Win32SS and some other needed dlls replaced. Now it fails due to missing WinStationCanLogonProceed, for which we currently haven't a stub.
PR #2042 is also needed to be applied, in order to reproduce the problem (or just replacing rpcrt4.dll may be as an option too).

JIRA issue: [CORE-16458](https://jira.reactos.org/browse/CORE-16458)