### PR TITLE
Fix last printf warning and turn it into an error

### DIFF
--- a/modules/rosapps/applications/net/netreg/netreg.cpp
+++ b/modules/rosapps/applications/net/netreg/netreg.cpp
@@ -417,7 +417,7 @@ SOCKET make_listening_socket( int port ) {
 
   fprintf( stderr, "Creating the listener\n" );
   SOCKET l = socket( PF_INET, SOCK_STREAM, 0 );
-  fprintf( stderr, "Socket %x\n", l );
+  fprintf( stderr, "Socket %Ix\n", l );
 
   if( l == INVALID_SOCKET ) return l;
   if( bind( l, (struct sockaddr *)&sa, sizeof( sa ) ) < 0 ) {

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -95,11 +95,13 @@ add_compile_flags("/wd4018")
 # - C4229: modifiers on data are ignored
 # - C4311: pointer truncation from '<pointer>' to '<integer>'
 # - C4312: conversion from '<integer>' to '<pointer>' of greater size
+# - C4313: 'fprintf': '%x' in format string conflicts with argument n of type 'HANDLE'
+# - C4477: '_snprintf' : format string '%ld' requires an argument of type 'long', but variadic argument 1 has type 'DWORD_PTR'
 # - C4603: macro is not defined or definition is different after precompiled header use
 # - C4700: uninitialized variable usage
 # - C4715: 'function': not all control paths return a value
 # - C4716: function must return a value
-add_compile_flags("/we4013 /we4020 /we4022 /we4028 /we4047 /we4098 /we4113 /we4129 /we4133 /we4163 /we4229 /we4311 /we4312 /we4603 /we4700 /we4715 /we4716")
+add_compile_flags("/we4013 /we4020 /we4022 /we4028 /we4047 /we4098 /we4113 /we4129 /we4133 /we4163 /we4229 /we4311 /we4312 /we4313 /we4477 /we4603 /we4700 /we4715 /we4716")
 
 # - C4189: local variable initialized but not referenced
 # Not in Release mode and not with MSVC 2010


### PR DESCRIPTION
## Proposed changes

- [NETREG] Fix a 64bit printf format warning
- [CMAKE] Turn printf format warnings (C4313 and C4477) into errors
