### PR TITLE
[HAL:HALX86] Remove a now useless ASSERT()

### DIFF
--- a/hal/halx86/generic/bios.c
+++ b/hal/halx86/generic/bios.c
@@ -400,7 +400,6 @@ HalpStoreAndClearIopm(VOID)
             //
             // Save it
             //
-            ASSERT(j < IOPM_SIZE / sizeof(USHORT));
             HalpSavedIoMapData[j][0] = i;
             HalpSavedIoMapData[j][1] = *Entry;
             j++;


### PR DESCRIPTION
## Purpose

As `j <= i < IOPM_SIZE / sizeof(USHORT`.

Addendum to 5887b170052db6af1ee86dc68f053d0c79d15028.
Cc @HBelusca

NB:
Unless we remove the whole "optimization" even...