### PR TITLE
[SHELL32] Disable all controls during format

### DIFF
--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -591,17 +591,27 @@ static unsigned __stdcall DoFormatDrive(void *args)
     HWND hwndDlg = pParams->hwndDlg;
     PFORMAT_DRIVE_CONTEXT pContext = pParams->pContext;
 
+	/* Disable controls during format */
     HMENU hSysMenu = GetSystemMenu(hwndDlg, FALSE);
     EnableMenuItem(hSysMenu, SC_CLOSE, MF_BYCOMMAND | MF_GRAYED);
     EnableWindow(GetDlgItem(hwndDlg, IDOK), FALSE);
     EnableWindow(GetDlgItem(hwndDlg, IDCANCEL), FALSE);
+    EnableWindow(GetDlgItem(hwndDlg, 28673), FALSE);
     EnableWindow(GetDlgItem(hwndDlg, 28677), FALSE);
+    EnableWindow(GetDlgItem(hwndDlg, 28680), FALSE);
+    EnableWindow(GetDlgItem(hwndDlg, 28679), FALSE);
+    EnableWindow(GetDlgItem(hwndDlg, 28674), FALSE);
 
     FormatDrive(hwndDlg, pContext);
 
+	/* Re-enable controls after format */
     EnableWindow(GetDlgItem(hwndDlg, IDOK), TRUE);
     EnableWindow(GetDlgItem(hwndDlg, IDCANCEL), TRUE);
+    EnableWindow(GetDlgItem(hwndDlg, 28673), TRUE);
     EnableWindow(GetDlgItem(hwndDlg, 28677), TRUE);
+    EnableWindow(GetDlgItem(hwndDlg, 28680), TRUE);
+    EnableWindow(GetDlgItem(hwndDlg, 28679), TRUE);
+    EnableWindow(GetDlgItem(hwndDlg, 28674), TRUE);
     EnableMenuItem(hSysMenu, SC_CLOSE, MF_BYCOMMAND | MF_ENABLED);
     pContext->bFormattingNow = FALSE;
 


### PR DESCRIPTION
This patch disables all the controls after a format is started and re-enables them after the format is complete. Doesn't make much sense to add a volume label after the format is started. :D 

I guess it could be considered a continuation of [CORE-13221](https://jira.reactos.org/browse/CORE-13221)

![compare](https://user-images.githubusercontent.com/15203817/69699506-b5944080-10ad-11ea-90bc-07008d8ce05a.png)
