### PR TITLE
[KERNEL32] Fix multibyte conversion in default char

### DIFF
--- a/dll/win32/kernel32/winnls/string/nls.c
+++ b/dll/win32/kernel32/winnls/string/nls.c
@@ -654,14 +654,9 @@ IntMultiByteToWideCharCP(UINT CodePage,
                 continue;
             }
 
-            if (MultiByteString == MbsEnd)
+            if (MultiByteString == MbsEnd || *MultiByteString == 0)
             {
                 *WideCharString++ = CodePageTable->UniDefaultChar;
-            }
-            else if (*MultiByteString == 0)
-            {
-                *WideCharString++ = CodePageTable->UniDefaultChar;
-                MultiByteString++;
             }
             else
             {

--- a/dll/win32/kernel32/winnls/string/nls.c
+++ b/dll/win32/kernel32/winnls/string/nls.c
@@ -656,11 +656,11 @@ IntMultiByteToWideCharCP(UINT CodePage,
 
             if (MultiByteString == MbsEnd)
             {
-                *WideCharString++ = MultiByteTable[Char];
+                *WideCharString++ = CodePageTable->UniDefaultChar;
             }
             else if (*MultiByteString == 0)
             {
-                *WideCharString++ = UNICODE_NULL;
+                *WideCharString++ = CodePageTable->UniDefaultChar;
                 MultiByteString++;
             }
             else


### PR DESCRIPTION
## Purpose
Fix `kernel32!MultiByteToWideChar` function. The default character was wrong.
JIRA issue: [CORE-16468](https://jira.reactos.org/browse/CORE-16468)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/69895434-b14c7980-1372-11ea-9920-c03bd0962fd4.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/69895433-b14c7980-1372-11ea-9fbd-58c302d1eb9e.png)