### PR TITLE
Fix a undeclared side effect in inline assembly

### DIFF
--- a/modules/rosapps/applications/sysutils/utils/pice/module/utils.c
+++ b/modules/rosapps/applications/sysutils/utils/pice/module/utils.c
@@ -803,7 +803,7 @@ ULONG GetLinearAddress(USHORT Segment,ULONG Offset)
 		__asm__("\n\t \
 			sldt %%ax\n\t \
 			mov %%ax,%0"
-			:"=m" (Segment));
+			:"=m" (Segment) : : "ax");
 		if(Segment)
 		{
 			DPRINT((0,"GetLinearAddress(): no LDT\n"));


### PR DESCRIPTION
In file reactos/modules/rosapps/applications/sysutils/utils/pice/module/utils.c:803,
the instruction `sldt` will override register eax, this side effect may
corrupt the normal data flow in certain context. For example, assume
somebody incidently write a assignment expression which assigned from a
function call, the return value of function call will use the register
eax which will override existing value:
```
  int Segment = 0;
  int val = printf("Hello world\n");
  __asm__ volatile("\n\t \
          sldt %%ax\n\t \
          mov %%ax,%0"
          :"=m" (Segment));
  printf("%d\n", val); // should be 12
```
The above code will produce output 0 on my PC when compiled with flag -O2
where it should be 12.
