### PR TITLE
[NTOS:KE] In KiExitV86Mode, restore KTSS::Esp0 to its standard value

### DIFF
--- a/ntoskrnl/ke/i386/exp.c
+++ b/ntoskrnl/ke/i386/exp.c
@@ -291,8 +291,8 @@ Ki386AdjustEsp0(IN PKTRAP_FRAME TrapFrame)
     if (!(TrapFrame->EFlags & EFLAGS_V86_MASK))
     {
         /* Bias the stack for the V86 segments */
-        Stack -= (FIELD_OFFSET(KTRAP_FRAME, V86Gs) -
-                  FIELD_OFFSET(KTRAP_FRAME, HardwareSegSs));
+        Stack -= sizeof(KTRAP_FRAME) -
+                 FIELD_OFFSET(KTRAP_FRAME, V86Es);
     }
 
     /* Bias the stack for the FPU area */

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -369,7 +369,7 @@ KiSwapContextExit(IN PKTHREAD OldThread,
     Pcr->TSS->Esp0 = (ULONG_PTR)NewThread->InitialStack;
     if (!((KeGetTrapFrame(NewThread))->EFlags & EFLAGS_V86_MASK))
     {
-        Pcr->TSS->Esp0 -= (FIELD_OFFSET(KTRAP_FRAME, V86Gs) - FIELD_OFFSET(KTRAP_FRAME, HardwareSegSs));
+        Pcr->TSS->Esp0 -= sizeof(KTRAP_FRAME) - FIELD_OFFSET(KTRAP_FRAME, V86Es);
     }
     Pcr->TSS->Esp0 -= NPX_FRAME_LENGTH;
     Pcr->TSS->IoMapBase = NewProcess->IopmOffset;


### PR DESCRIPTION
The trap frame is in a random location on the stack, and setting Esp0 there
wastes significant amounts of space and may lead to unexpected stack overflows.

Also use a more descriptive expression for the V86 members of the KTRAP_FRAME.

JIRA issue: [CORE-16531](https://jira.reactos.org/browse/CORE-16531)