### PR TITLE
[KERNEL32_APITEST] Adjust ConsoleCP testcase for Win10 JPN

### DIFF
--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -410,7 +410,8 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = FillConsoleOutputCharacterW(hConOut, ideograph_space, csbi.dwSize.X * csbi.dwSize.Y, c, &len);
         ok(ret, "FillConsoleOutputCharacterW failed\n");
-        ok(len == csbi.dwSize.X * csbi.dwSize.Y, "len was: %ld\n", len);
+        ok(len == csbi.dwSize.X * csbi.dwSize.Y ||
+           len == csbi.dwSize.X * csbi.dwSize.Y / 2, "len was: %ld\n", len);
 
         /* Read characters at (0,0) */
         c.X = c.Y = 0;
@@ -450,10 +451,10 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = ReadConsoleOutputCharacterW(hConOut, str, 3 * sizeof(WCHAR), c, &len);
         ok(ret, "ReadConsoleOutputCharacterW failed\n");
-        ok(len == 4, "len was: %ld\n", len);
-        ok(str[0] == L' ', "str[0] was: 0x%04X\n", str[0]);
+        ok(len == 3 || len == 4, "len was: %ld\n", len);
+        ok(str[0] == L' ' || str[0] == 0x3000, "str[0] was: 0x%04X\n", str[0]);
         ok(str[1] == 0x9580, "str[1] was: 0x%04X\n", str[1]);
-        ok(str[2] == L' ', "str[2] was: 0x%04X\n", str[2]);
+        ok(str[2] == L' ' || str[2] == 0x3000, "str[2] was: 0x%04X\n", str[2]);
     }
 
     /* Restore code page */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -21,8 +21,9 @@
 static const WCHAR u0414[] = { 0x0414, 0 };             /* Д */
 static const WCHAR u9580[] = { 0x9580, 0 };             /* 門 */
 static const WCHAR ideograph_space = (WCHAR)0x3000;     /* fullwidth space */
-LCID lcidJapanese = MAKELCID(MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), SORT_DEFAULT);
-LCID lcidRussian  = MAKELCID(MAKELANGID(LANG_RUSSIAN , SUBLANG_DEFAULT), SORT_DEFAULT);
+static LCID lcidJapanese = MAKELCID(MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), SORT_DEFAULT);
+static LCID lcidRussian  = MAKELCID(MAKELANGID(LANG_RUSSIAN , SUBLANG_DEFAULT), SORT_DEFAULT);
+static BOOL s_bIsVistaPlus;
 
 static BOOL IsCJKCodePage(void)
 {
@@ -410,8 +411,10 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = FillConsoleOutputCharacterW(hConOut, ideograph_space, csbi.dwSize.X * csbi.dwSize.Y, c, &len);
         ok(ret, "FillConsoleOutputCharacterW failed\n");
-        ok(len == csbi.dwSize.X * csbi.dwSize.Y ||
-           len == csbi.dwSize.X * csbi.dwSize.Y / 2, "len was: %ld\n", len);
+        if (s_bIsVistaPlus)
+            ok(len == csbi.dwSize.X * csbi.dwSize.Y / 2, "len was: %ld\n", len);
+        else
+            ok(len == csbi.dwSize.X * csbi.dwSize.Y, "len was: %ld\n", len);
 
         /* Read characters at (0,0) */
         c.X = c.Y = 0;
@@ -451,10 +454,20 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = ReadConsoleOutputCharacterW(hConOut, str, 3 * sizeof(WCHAR), c, &len);
         ok(ret, "ReadConsoleOutputCharacterW failed\n");
-        ok(len == 3 || len == 4, "len was: %ld\n", len);
-        ok(str[0] == L' ' || str[0] == 0x3000, "str[0] was: 0x%04X\n", str[0]);
-        ok(str[1] == 0x9580, "str[1] was: 0x%04X\n", str[1]);
-        ok(str[2] == L' ' || str[2] == 0x3000, "str[2] was: 0x%04X\n", str[2]);
+        if (s_bIsVistaPlus)
+        {
+            ok(len == 3, "len was: %ld\n", len);
+            ok(str[0] == 0x3000, "str[0] was: 0x%04X\n", str[0]);
+            ok(str[1] == 0x9580, "str[1] was: 0x%04X\n", str[1]);
+            ok(str[2] == 0x3000, "str[2] was: 0x%04X\n", str[2]);
+        }
+        else
+        {
+            ok(len == 4, "len was: %ld\n", len);
+            ok(str[0] == L' ', "str[0] was: 0x%04X\n", str[0]);
+            ok(str[1] == 0x9580, "str[1] was: 0x%04X\n", str[1]);
+            ok(str[2] == L' ', "str[2] was: 0x%04X\n", str[2]);
+        }
     }
 
     /* Restore code page */
@@ -464,6 +477,11 @@ static void test_cp932(HANDLE hConOut)
 START_TEST(ConsoleCP)
 {
     HANDLE hConIn, hConOut;
+    OSVERSIONINFOA osver = { sizeof(osver) };
+
+    GetVersionExA(&osver);
+    s_bIsVistaPlus = (osver.dwMajorVersion >= 6);
+
     FreeConsole();
     ok(AllocConsole(), "Couldn't alloc console\n");
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12451](https://jira.reactos.org/browse/CORE-12451)

BEFORE (WinXP Japanese):
![ConsoleCP-WinXPja-before](https://user-images.githubusercontent.com/2107452/70190068-529f4b00-1738-11ea-8c84-11b46b443ac7.png)
AFTER (WinXP Japanese):
![ConsoleCP-WinXPja-after](https://user-images.githubusercontent.com/2107452/70190070-529f4b00-1738-11ea-87a6-40ff6c56e0e9.png)
No change.

BEFORE (Win10 Japanese):
![ConsoleCP-Win10ja-before](https://user-images.githubusercontent.com/2107452/70190071-529f4b00-1738-11ea-950e-53d159be790f.png)
AFTER (Win10 Japanese):
![ConsoleCP-Win10ja-after](https://user-images.githubusercontent.com/2107452/70190069-529f4b00-1738-11ea-8df9-416c38628473.png)
Reduced 4 failures.