### PR TITLE
[WIN32SS][WINSRV] Improve Asian font choice

### DIFF
--- a/win32ss/user/winsrv/concfg/font.c
+++ b/win32ss/user/winsrv/concfg/font.c
@@ -69,7 +69,13 @@ CreateConsoleFontEx(
                                  ~(VARIABLE_PITCH | FF_DECORATIVE | FF_ROMAN | FF_SCRIPT | FF_SWISS));
 
     if (!IsValidConsoleFont(FaceName, CodePage))
+    {
         StringCchCopyW(FaceName, LF_FACESIZE, L"Terminal");
+        if (IsCJKCodePage(CodePage))
+        {
+            lf.lfCharSet = ANSI_CHARSET;
+        }
+    }
 
     StringCchCopyNW(lf.lfFaceName, ARRAYSIZE(lf.lfFaceName),
                     FaceName, LF_FACESIZE);


### PR DESCRIPTION
## Purpose
Don't choose Asian charset font if there is no preferred font for CJK.
JIRA issue: [CORE-12451](https://jira.reactos.org/browse/CORE-12451)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/70286510-c6ac2280-180e-11ea-9825-c90df967c135.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/70286508-c6ac2280-180e-11ea-929a-9de024ecd69f.png)