### PR TITLE
[CMD_APITEST] Add more regression tests for attrib.

### DIFF
--- a/modules/rostests/apitests/cmd/cmd.c
+++ b/modules/rostests/apitests/cmd/cmd.c
@@ -162,6 +162,10 @@ static const TEST_ENTRY s_attrib_entries[] =
     { __LINE__, 0,      "attrib /S attr-te*.txt", TRUE, FALSE, " H " },
     { __LINE__, 0,      "attrib /S -H attr-te*.txt", FALSE, FALSE },
     { __LINE__, 0,      "attrib /S attr-te*.txt", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "attrib /S +H", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, " H " },
+    { __LINE__, 0,      "attrib /S -H", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, NULL, NULL, " H " },
     { __LINE__, 0,      "cmd /c if exist attr-test.txt attrib -H attr-test.txt" },
     { __LINE__, 0,      "cmd /c if exist attr-test.txt del /Q attr-test.txt" },
 
@@ -285,6 +289,34 @@ static const TEST_ENTRY s_attrib_entries[] =
     { __LINE__, 0,      "attrib /S /D -H attr-dir\\dir1", FALSE, FALSE },
     { __LINE__, 0,      "attrib /S /D -H attr-dir", FALSE, FALSE },
     { __LINE__, 0,      "cmd /c if exist attr-dir rmdir /s /q attr-dir" },
+
+    /* /S attr-dir, attr-dir\\dir1\\file.txt */
+    { __LINE__, 0,      "cmd /c if exist attr-dir rmdir /s /q attr-dir" },
+    { __LINE__, 0,      "cmd /c mkdir attr-dir", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S /D attr-dir", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "cmd /c if exist attr-dir echo OK", TRUE, FALSE, "OK" },
+    { __LINE__, 0,      "cmd /c mkdir attr-dir\\dir1", FALSE, FALSE },
+    { __LINE__, 0,      "cmd /c if exist attr-dir\\dir1 echo OK", TRUE, FALSE, "OK" },
+    { __LINE__, 0,      "cmd /c copy NUL attr-dir\\dir1\\attr-test.txt ", TRUE, FALSE },
+    { __LINE__, 0,      "attrib attr-dir\\dir1\\attr-test.txt", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "attrib /S +H attr-dir\\dir1\\attr-test.txt", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, " H " },
+    { __LINE__, 0,      "attrib /S -H attr-dir\\dir1\\attr-test.txt", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "attrib /S +H attr-test.txt", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, " H " },
+    { __LINE__, 0,      "attrib /S -H attr-test.txt", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "attrib /S +H", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, " H " },
+    { __LINE__, 0,      "attrib /S attr-tes*.*", TRUE, FALSE, " H " },
+    { __LINE__, 0,      "attrib /S -H", FALSE, FALSE },
+    { __LINE__, 0,      "attrib /S attr-test.txt", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "attrib /S attr-tes*.*", TRUE, FALSE, NULL, NULL, " H " },
+    { __LINE__, 0,      "cmd /c if exist attr-dir/dir1/test.txt attrib -H attr-dir/dir1/test.txt" },
+    { __LINE__, 0,      "cmd /c if exist attr-dir/dir1/test.txt del /Q attr-dir/dir1/test.txt" },
+    { __LINE__, 0,      "cmd /c if exist attr-dir rmdir /s /q attr-dir" },
+
 };
 
 static BOOL MyDuplicateHandle(HANDLE hFile, PHANDLE phFile, BOOL bInherit)


### PR DESCRIPTION
Additional Regression Tests for Attrib

JIRA issue: [CORE-16284](https://jira.reactos.org/browse/CORE-16284)

_The intent is to test the remaining unimplemented functionality of the attrib command._

Windows Server 2003:
![W2K3_attrib_test](https://user-images.githubusercontent.com/32620577/70391007-e0c43d00-1995-11ea-8bff-0e6e628eecd6.png)

ReactOS:
![ReactOS_attrib_test](https://user-images.githubusercontent.com/32620577/70391084-e2dacb80-1996-11ea-9e99-b5ca3f28b09f.png)
