### PR TITLE
[COMCTL32][USER32] Fix radio button regression

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1211,7 +1211,11 @@ static UINT BUTTON_CalcLabelRect(const BUTTON_INFO *infoPtr, HDC hdc, RECT *rc)
           }
 
           if ((hFont = infoPtr->font)) hPrevFont = SelectObject( hdc, hFont );
+#ifdef __REACTOS__
           DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
+#else
+          DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
+#endif
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           heap_free( text );
 #ifdef __REACTOS__

--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1211,7 +1211,7 @@ static UINT BUTTON_CalcLabelRect(const BUTTON_INFO *infoPtr, HDC hdc, RECT *rc)
           }
 
           if ((hFont = infoPtr->font)) hPrevFont = SelectObject( hdc, hFont );
-          DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
+          DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           heap_free( text );
 #ifdef __REACTOS__

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -773,7 +773,7 @@ static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
           }
 
           if ((hFont = get_button_font( hwnd ))) hPrevFont = SelectObject( hdc, hFont );
-          DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
+          DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           HeapFree( GetProcessHeap(), 0, text );
 #ifdef __REACTOS__

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -773,7 +773,11 @@ static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
           }
 
           if ((hFont = get_button_font( hwnd ))) hPrevFont = SelectObject( hdc, hFont );
+#ifdef __REACTOS__
           DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
+#else
+          DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
+#endif
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           HeapFree( GetProcessHeap(), 0, text );
 #ifdef __REACTOS__


### PR DESCRIPTION
## Purpose
PR #2135 (https://github.com/reactos/reactos/commit/e329e83857db0db67c6798c538ad658be044057e) caused radiobutton regression. This PR will fix it.
JIRA issue: [CORE-16552](https://jira.reactos.org/browse/CORE-16552)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/70484105-169c2980-1b2e-11ea-92aa-b216e628762f.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/70483962-a68da380-1b2d-11ea-95dc-c978e89263b0.png)

- Clear `DT_BOTTOM | DT_VCENTER` flags upon calculating the button text height.