### PR TITLE
[CORE-16385] Support STRICT_TYPED_ITEMIDS

### DIFF
--- a/dll/win32/shell32/CShellItem.cpp
+++ b/dll/win32/shell32/CShellItem.cpp
@@ -24,8 +24,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-EXTERN_C HRESULT WINAPI SHCreateShellItem(LPCITEMIDLIST pidlParent,
-    IShellFolder *psfParent, LPCITEMIDLIST pidl, IShellItem **ppsi);
+EXTERN_C HRESULT WINAPI SHCreateShellItem(PCIDLIST_ABSOLUTE pidlParent,
+    IShellFolder *psfParent, PCUITEMID_CHILD pidl, IShellItem **ppsi);
 
 CShellItem::CShellItem() :
     m_pidl(NULL)
@@ -261,8 +261,8 @@ HRESULT WINAPI CShellItem::GetIDList(PIDLIST_ABSOLUTE *ppidl)
         return E_OUTOFMEMORY;
 }
 
-HRESULT WINAPI SHCreateShellItem(LPCITEMIDLIST pidlParent,
-    IShellFolder *psfParent, LPCITEMIDLIST pidl, IShellItem **ppsi)
+HRESULT WINAPI SHCreateShellItem(PCIDLIST_ABSOLUTE pidlParent,
+    IShellFolder *psfParent, PCUITEMID_CHILD pidl, IShellItem **ppsi)
 {
     HRESULT hr;
     CComPtr<IShellItem> newShellItem;

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -638,7 +638,7 @@ BOOL WINAPI ILIsParent(LPCITEMIDLIST pidlParent, LPCITEMIDLIST pidlChild, BOOL b
  * NOTES
  *  exported by ordinal.
  */
-LPITEMIDLIST WINAPI ILFindChild(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
+PUIDLIST_RELATIVE WINAPI ILFindChild(PIDLIST_ABSOLUTE pidl1, PCIDLIST_ABSOLUTE pidl2)
 {
     LPCITEMIDLIST pidltemp1 = pidl1;
     LPCITEMIDLIST pidltemp2 = pidl2;
@@ -674,7 +674,7 @@ LPITEMIDLIST WINAPI ILFindChild(LPCITEMIDLIST pidl1, LPCITEMIDLIST pidl2)
             ret = NULL; /* elements of pidl1 left*/
     }
     TRACE_(shell)("--- %p\n", ret);
-    return (LPITEMIDLIST)ret; /* pidl 1 is shorter */
+    return (PUIDLIST_RELATIVE)ret; /* pidl 1 is shorter */
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -743,7 +743,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
 	if (SUCCEEDED(SHGetSpecialFolderLocation(hwnd, CSIDL_RECENT,
 						 &pidl))) {
 	    SHGetPathFromIDListA(pidl, link_dir);
-	    IMalloc_Free(ppM, pidl);
+	    IMalloc_Free(ppM,pidl);
 	}
 	else {
 	    /* serious issues */
@@ -1824,7 +1824,7 @@ HRESULT WINAPI SHCreateStdEnumFmtEtc(
 /*************************************************************************
  *		SHFindFiles (SHELL32.90)
  */
-BOOL WINAPI SHFindFiles( LPCITEMIDLIST pidlFolder, LPCITEMIDLIST pidlSaveFile )
+BOOL WINAPI SHFindFiles( PCIDLIST_ABSOLUTE pidlFolder, PCIDLIST_ABSOLUTE pidlSaveFile )
 {
     FIXME("params ignored: %p %p\n", pidlFolder, pidlSaveFile);
     if (SHRestricted(REST_NOFIND))
@@ -1870,7 +1870,7 @@ VOID WINAPI SHUpdateImageA(LPCSTR pszHashItem, INT iIndex, UINT uFlags, INT iIma
     FIXME("%s, %d, 0x%x, %d - stub\n", debugstr_a(pszHashItem), iIndex, uFlags, iImageIndex);
 }
 
-INT WINAPI SHHandleUpdateImage(LPCITEMIDLIST pidlExtra)
+INT WINAPI SHHandleUpdateImage(PCIDLIST_ABSOLUTE pidlExtra)
 {
     FIXME("%p - stub\n", pidlExtra);
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -743,7 +743,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
 	if (SUCCEEDED(SHGetSpecialFolderLocation(hwnd, CSIDL_RECENT,
 						 &pidl))) {
 	    SHGetPathFromIDListA(pidl, link_dir);
-	    IMalloc_Free(ppM,pidl);
+	    IMalloc_Free(ppM, pidl);
 	}
 	else {
 	    /* serious issues */

--- a/sdk/include/psdk/shdeprecated.idl
+++ b/sdk/include/psdk/shdeprecated.idl
@@ -50,7 +50,7 @@ interface ITravelEntry : IUnknown
         [in] BOOL fIsLocalAnchor);
 
     HRESULT GetPidl(
-        [out] LPITEMIDLIST *ppidl);
+        [out] PIDLIST_ABSOLUTE *ppidl);
 };
 
 [
@@ -84,7 +84,7 @@ interface ITravelLog : IUnknown
 
     HRESULT FindTravelEntry(
         [in]  IUnknown *punk,
-        [in]  LPCITEMIDLIST pidl,
+        [in]  PCIDLIST_ABSOLUTE pidl,
         [out] ITravelEntry **ppte);
 
     HRESULT GetToolTipText(
@@ -343,17 +343,17 @@ typedef struct basebrowserdataxp
     DWORD               _fCreatingViewWindow;
     UINT                _uActivateState;
 
-    LPCITEMIDLIST       _pidlNewShellView;
+    PCIDLIST_ABSOLUTE   _pidlNewShellView;
 
     IOleCommandTarget   *_pctView;
 
-    LPITEMIDLIST        _pidlCur;
+    PIDLIST_ABSOLUTE    _pidlCur;
     IShellView          *_psv;
     IShellFolder        *_psf;
     HWND                _hwndView;
     LPWSTR              _pszTitleCur;
 
-    LPITEMIDLIST        _pidlPending;
+    PIDLIST_ABSOLUTE    _pidlPending;
     IShellView          *_psvPending;
     IShellFolder        *_psfPending;
     HWND                _hwndViewPending;
@@ -378,17 +378,17 @@ typedef struct basebrowserdatalh
     DWORD               _fCreatingViewWindow;
     UINT                _uActivateState;
 
-    LPCITEMIDLIST       _pidlNewShellView;
+    PCIDLIST_ABSOLUTE   _pidlNewShellView;
 
     IOleCommandTarget   *_pctView;
 
-    LPITEMIDLIST        _pidlCur;
+    PIDLIST_ABSOLUTE    _pidlCur;
     IShellView          *_psv;
     IShellFolder        *_psf;
     HWND                _hwndView;
     LPWSTR              _pszTitleCur;
 
-    LPITEMIDLIST        _pidlPending;
+    PIDLIST_ABSOLUTE    _pidlPending;
     IShellView          *_psvPending;
     IShellFolder        *_psfPending;
     HWND                _hwndViewPending;
@@ -535,13 +535,13 @@ interface IBrowserService2 : IBrowserService
     HRESULT _DisableModeless();
 
     HRESULT _NavigateToPidl(
-        [in] LPCITEMIDLIST pidl,
+        [in] PCIDLIST_ABSOLUTE pidl,
         [in] DWORD grfHLNF,
         [in] DWORD dwFlags);
 
     HRESULT _TryShell2Rename(
         [in] IShellView *psv,
-        [in] LPCITEMIDLIST pidlNew);
+        [in] PCIDLIST_ABSOLUTE pidlNew);
 
     HRESULT _SwitchActivationNow();
 
@@ -593,7 +593,7 @@ interface IBrowserService2 : IBrowserService
         [in] HMONITOR hmon);
 
     IStream* v_GetViewStream(
-        [in] LPCITEMIDLIST pidl,
+        [in] PCIDLIST_ABSOLUTE pidl,
         [in] DWORD grfMode,
         [in] LPCWSTR pwszName);
 
@@ -647,7 +647,7 @@ interface IBrowserService2 : IBrowserService
         [in] BOOL bUseHmonitor);
 
     HRESULT v_CheckZoneCrossing(
-        [in, out] LPCITEMIDLIST pidl);
+        [in, out] PCIDLIST_ABSOLUTE pidl);
 };
 
 [
@@ -666,7 +666,7 @@ interface IBrowserService3 : IBrowserService2
         [in] UINT uiCP,
         [in] LPCWSTR pwszPath,
         [in] DWORD dwFlags,
-        [out] LPITEMIDLIST *ppidlOut);
+        [out] PIDLIST_ABSOLUTE *ppidlOut);
 };
 
 [

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -135,9 +135,9 @@ HRESULT      WINAPI SHCreateQueryCancelAutoPlayMoniker(IMoniker**);
 HRESULT
 WINAPI
 SHCreateShellItem(
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCIDLIST_ABSOLUTE,
   _In_opt_ IShellFolder*,
-  _In_ LPCITEMIDLIST,
+  _In_ PCUITEMID_CHILD,
   _Outptr_ IShellItem**);
 
 DWORD        WINAPI SHCLSIDFromStringA(_In_ LPCSTR, _Out_ CLSID*);
@@ -152,7 +152,7 @@ SHCreateStdEnumFmtEtc(
   _Outptr_ IEnumFORMATETC**);
 
 void         WINAPI SHDestroyPropSheetExtArray(_In_ HPSXA);
-BOOL         WINAPI SHFindFiles(_In_opt_ LPCITEMIDLIST, _In_opt_ LPCITEMIDLIST);
+BOOL         WINAPI SHFindFiles(_In_opt_ PCIDLIST_ABSOLUTE, _In_opt_ PCIDLIST_ABSOLUTE);
 DWORD        WINAPI SHFormatDrive(_In_ HWND, UINT, UINT, UINT);
 void         WINAPI SHFree(_In_opt_ LPVOID);
 
@@ -196,25 +196,25 @@ _Success_(return != 0)
 BOOL
 WINAPI
 SHGetPathFromIDListA(
-  _In_ LPCITEMIDLIST,
+  _In_ PCIDLIST_ABSOLUTE,
   _Out_writes_(MAX_PATH) LPSTR);
 
 _Success_(return != 0)
 BOOL
 WINAPI
 SHGetPathFromIDListW(
-  _In_ LPCITEMIDLIST,
+  _In_ PCIDLIST_ABSOLUTE,
   _Out_writes_(MAX_PATH) LPWSTR);
 
 #define SHGetPathFromIDList WINELIB_NAME_AW(SHGetPathFromIDList)
 
-INT          WINAPI SHHandleUpdateImage(_In_ LPCITEMIDLIST);
+INT          WINAPI SHHandleUpdateImage(_In_ PCIDLIST_ABSOLUTE);
 
 HRESULT
 WINAPI
 SHILCreateFromPath(
-  _In_ LPCWSTR,
-  _Outptr_ LPITEMIDLIST*,
+  _In_ PCWSTR,
+  _Outptr_ PIDLIST_ABSOLUTE*,
   _Inout_opt_ DWORD*);
 
 HRESULT      WINAPI SHLoadOLE(LPARAM);
@@ -222,9 +222,9 @@ HRESULT      WINAPI SHLoadOLE(LPARAM);
 HRESULT
 WINAPI
 SHParseDisplayName(
-  _In_ LPCWSTR,
+  _In_ PCWSTR,
   _In_opt_ IBindCtx*,
-  _Outptr_ LPITEMIDLIST*,
+  _Outptr_ PIDLIST_ABSOLUTE*,
   _In_ SFGAOF,
   _Out_opt_ SFGAOF*);
 
@@ -252,13 +252,13 @@ SHReplaceFromPropSheetExtArray(
   _In_ LPFNADDPROPSHEETPAGE,
   LPARAM);
 
-LPITEMIDLIST WINAPI SHSimpleIDListFromPath(LPCWSTR);
+PIDLIST_ABSOLUTE WINAPI SHSimpleIDListFromPath(PCWSTR);
 
 int
 WINAPI
 SHMapPIDLToSystemImageListIndex(
   _In_ IShellFolder*,
-  _In_ LPCITEMIDLIST,
+  _In_ PCUITEMID_CHILD,
   _Out_opt_ int*);
 
 HRESULT      WINAPI SHStartNetConnectionDialog(HWND,LPCSTR,DWORD);
@@ -1104,25 +1104,25 @@ typedef INT (CALLBACK *BFFCALLBACK)(HWND,UINT,LPARAM,LPARAM);
 #include <pshpack8.h>
 
 typedef struct tagBROWSEINFOA {
-    HWND        hwndOwner;
-    LPCITEMIDLIST pidlRoot;
-    LPSTR         pszDisplayName;
-    LPCSTR        lpszTitle;
-    UINT        ulFlags;
-    BFFCALLBACK   lpfn;
-    LPARAM        lParam;
-    INT         iImage;
+    HWND                hwndOwner;
+    PCIDLIST_ABSOLUTE   pidlRoot;
+    LPSTR               pszDisplayName;
+    LPCSTR              lpszTitle;
+    UINT                ulFlags;
+    BFFCALLBACK         lpfn;
+    LPARAM              lParam;
+    INT                 iImage;
 } BROWSEINFOA, *PBROWSEINFOA, *LPBROWSEINFOA;
 
 typedef struct tagBROWSEINFOW {
-    HWND        hwndOwner;
-    LPCITEMIDLIST pidlRoot;
-    LPWSTR        pszDisplayName;
-    LPCWSTR       lpszTitle;
-    UINT        ulFlags;
-    BFFCALLBACK   lpfn;
-    LPARAM        lParam;
-    INT         iImage;
+    HWND                hwndOwner;
+    PCIDLIST_ABSOLUTE   pidlRoot;
+    LPWSTR              pszDisplayName;
+    LPCWSTR             lpszTitle;
+    UINT                ulFlags;
+    BFFCALLBACK         lpfn;
+    LPARAM              lParam;
+    INT                 iImage;
 } BROWSEINFOW, *PBROWSEINFOW, *LPBROWSEINFOW;
 
 #define BROWSEINFO   WINELIB_NAME_AW(BROWSEINFO)
@@ -1166,8 +1166,8 @@ typedef struct tagBROWSEINFOW {
 #define BFFM_SETOKTEXT          (WM_USER+105)
 #define BFFM_SETEXPANDED        (WM_USER+106)
 
-LPITEMIDLIST WINAPI SHBrowseForFolderA(_In_ LPBROWSEINFOA lpbi);
-LPITEMIDLIST WINAPI SHBrowseForFolderW(_In_ LPBROWSEINFOW lpbi);
+PIDLIST_ABSOLUTE WINAPI SHBrowseForFolderA(_In_ LPBROWSEINFOA lpbi);
+PIDLIST_ABSOLUTE WINAPI SHBrowseForFolderW(_In_ LPBROWSEINFOW lpbi);
 #define SHBrowseForFolder WINELIB_NAME_AW(SHBrowseForFolder)
 
 #define BFFM_SETSTATUSTEXT  WINELIB_NAME_AW(BFFM_SETSTATUSTEXT)
@@ -1191,13 +1191,13 @@ typedef HRESULT
 
 typedef struct _CSFV
 {
-  UINT             cbSize;
-  IShellFolder*    pshf;
-  IShellView*      psvOuter;
-  LPCITEMIDLIST    pidl;
-  LONG             lEvents;
-  LPFNVIEWCALLBACK pfnCallback;
-  FOLDERVIEWMODE   fvm;
+  UINT                 cbSize;
+  IShellFolder*        pshf;
+  IShellView*          psvOuter;
+  PCIDLIST_ABSOLUTE    pidl;
+  LONG                 lEvents;
+  LPFNVIEWCALLBACK     pfnCallback;
+  FOLDERVIEWMODE       fvm;
 } CSFV, *LPCSFV;
 
 #include <poppack.h>
@@ -1403,7 +1403,7 @@ HRESULT
 WINAPI
 SHGetDataFromIDListA(
   _In_ LPSHELLFOLDER psf,
-  _In_ LPCITEMIDLIST pidl,
+  _In_ PCUITEMID_CHILD pidl,
   int nFormat,
   _Out_writes_bytes_(cb) LPVOID pv,
   int cb);
@@ -1412,14 +1412,14 @@ HRESULT
 WINAPI
 SHGetDataFromIDListW(
   _In_ LPSHELLFOLDER psf,
-  _In_ LPCITEMIDLIST pidl,
+  _In_ PCUITEMID_CHILD pidl,
   int nFormat,
   _Out_writes_bytes_(cb) LPVOID pv,
   int cb);
 
 #define SHGetDataFromIDList WINELIB_NAME_AW(SHGetDataFromIDList)
 
-LPITEMIDLIST
+PIDLIST_ABSOLUTE
 WINAPI
 SHCloneSpecialIDList(
   _Reserved_ HWND hwnd,
@@ -1454,37 +1454,37 @@ _Check_return_ HRESULT WINAPI SHGetMalloc(_Outptr_ LPMALLOC *lpmal);
 
 typedef struct
 {
-    BOOL fShowAllObjects : 1;
-    BOOL fShowExtensions : 1;
-    BOOL fNoConfirmRecycle : 1;
+    BOOL  fShowAllObjects : 1;
+    BOOL  fShowExtensions : 1;
+    BOOL  fNoConfirmRecycle : 1;
 
-    BOOL fShowSysFiles : 1;
-    BOOL fShowCompColor : 1;
-    BOOL fDoubleClickInWebView : 1;
-    BOOL fDesktopHTML : 1;
-    BOOL fWin95Classic : 1;
-    BOOL fDontPrettyPath : 1;
-    BOOL fShowAttribCol : 1;
-    BOOL fMapNetDrvBtn : 1;
-    BOOL fShowInfoTip : 1;
-    BOOL fHideIcons : 1;
-    BOOL fWebView : 1;
-    BOOL fFilter : 1;
-    BOOL fShowSuperHidden : 1;
-    BOOL fNoNetCrawling : 1;
+    BOOL  fShowSysFiles : 1;
+    BOOL  fShowCompColor : 1;
+    BOOL  fDoubleClickInWebView : 1;
+    BOOL  fDesktopHTML : 1;
+    BOOL  fWin95Classic : 1;
+    BOOL  fDontPrettyPath : 1;
+    BOOL  fShowAttribCol : 1;
+    BOOL  fMapNetDrvBtn : 1;
+    BOOL  fShowInfoTip : 1;
+    BOOL  fHideIcons : 1;
+    BOOL  fWebView : 1;
+    BOOL  fFilter : 1;
+    BOOL  fShowSuperHidden : 1;
+    BOOL  fNoNetCrawling : 1;
 
-    UINT :15; /* Required for proper binary layout with gcc */
+    UINT  :15; /* Required for proper binary layout with gcc */
     DWORD dwWin95Unused;
     UINT  uWin95Unused;
-    LONG   lParamSort;
-    int    iSortDirection;
-    UINT   version;
-    UINT uNotUsed;
-    BOOL fSepProcess: 1;
-    BOOL fStartPanelOn: 1;
-    BOOL fShowStartPage: 1;
-    UINT fSpareFlags : 13;
-    UINT :15; /* Required for proper binary layout with gcc */
+    LONG  lParamSort;
+    int   iSortDirection;
+    UINT  version;
+    UINT  uNotUsed;
+    BOOL  fSepProcess: 1;
+    BOOL  fStartPanelOn: 1;
+    BOOL  fShowStartPage: 1;
+    UINT  fSpareFlags : 13;
+    UINT  :15; /* Required for proper binary layout with gcc */
 } SHELLSTATE, *LPSHELLSTATE;
 
 VOID WINAPI SHGetSetSettings(LPSHELLSTATE lpss, DWORD dwMask, BOOL bSet);
@@ -1713,7 +1713,7 @@ DWORD WINAPI SHRestricted(RESTRICTIONS rest);
 */
 typedef struct _SHChangeNotifyEntry
 {
-    LPCITEMIDLIST pidl;
+    PCIDLIST_ABSOLUTE pidl;
     BOOL   fRecursive;
 } SHChangeNotifyEntry;
 
@@ -1824,25 +1824,25 @@ typedef struct tagDATABLOCKHEADER
 #ifdef LF_FACESIZE
 typedef struct {
     DATABLOCK_HEADER dbh;
-    WORD wFillAttribute;
-    WORD wPopupFillAttribute;
+    WORD  wFillAttribute;
+    WORD  wPopupFillAttribute;
     COORD dwScreenBufferSize;
     COORD dwWindowSize;
     COORD dwWindowOrigin;
     DWORD nFont;
     DWORD nInputBufferSize;
     COORD dwFontSize;
-    UINT uFontFamily;
-    UINT uFontWeight;
+    UINT  uFontFamily;
+    UINT  uFontWeight;
     WCHAR FaceName[LF_FACESIZE];
-    UINT uCursorSize;
-    BOOL bFullScreen;
-    BOOL bQuickEdit;
-    BOOL bInsertMode;
-    BOOL bAutoPosition;
-    UINT uHistoryBufferSize;
-    UINT uNumberOfHistoryBuffers;
-    BOOL bHistoryNoDup;
+    UINT  uCursorSize;
+    BOOL  bFullScreen;
+    BOOL  bQuickEdit;
+    BOOL  bInsertMode;
+    BOOL  bAutoPosition;
+    UINT  uHistoryBufferSize;
+    UINT  uNumberOfHistoryBuffers;
+    BOOL  bHistoryNoDup;
     COLORREF ColorTable[16];
 } NT_CONSOLE_PROPS, *LPNT_CONSOLE_PROPS;
 #endif
@@ -1875,7 +1875,7 @@ typedef struct {
 typedef struct {
     DWORD cbSize;
     DWORD dwSignature;
-    BYTE abPropertyStorage[1];
+    BYTE  abPropertyStorage[1];
 } EXP_PROPERTYSTORAGE;
 
 #define EXP_SZ_LINK_SIG         0xA0000001 /* EXP_SZ_LINK */
@@ -1919,7 +1919,7 @@ WINAPI
 SHChangeNotification_Lock(
   _In_ HANDLE hChangeNotification,
   DWORD dwProcessId,
-  _Outptr_opt_result_buffer_(2)_Outptr_opt_result_buffer_(2) LPITEMIDLIST **pppidl,
+  _Outptr_opt_result_buffer_(2)_Outptr_opt_result_buffer_(2) PIDLIST_ABSOLUTE **pppidl,
   _Out_opt_ LONG *plEvent);
 
 BOOL WINAPI SHChangeNotification_Unlock(_In_ HANDLE hLock);
@@ -1928,8 +1928,8 @@ HRESULT
 WINAPI
 SHGetRealIDL(
   _In_ IShellFolder *psf,
-  _In_ LPCITEMIDLIST pidlSimple,
-  _Outptr_ LPITEMIDLIST * ppidlReal);
+  _In_ PCUITEMID_CHILD pidlSimple,
+  _Outptr_ PITEMID_CHILD * ppidlReal);
 
 /****************************************************************************
 * SHCreateDirectory API
@@ -1961,7 +1961,7 @@ WINAPI
 SHGetSpecialFolderLocation(
   _Reserved_ HWND hwndOwner,
   _In_ int nFolder,
-  _Outptr_ LPITEMIDLIST *ppidl);
+  _Outptr_ PIDLIST_ABSOLUTE *ppidl);
 
 HRESULT
 WINAPI
@@ -1970,7 +1970,7 @@ SHGetFolderLocation(
   _In_ int nFolder,
   _In_opt_ HANDLE hToken,
   _In_ DWORD dwReserved,
-  _Outptr_ LPITEMIDLIST *ppidl);
+  _Outptr_ PIDLIST_ABSOLUTE *ppidl);
 
 /****************************************************************************
 * SHGetFolderPath API
@@ -2077,10 +2077,10 @@ _Check_return_ HRESULT WINAPI SHGetDesktopFolder(_Outptr_ IShellFolder * *);
 HRESULT
 WINAPI
 SHBindToParent(
-  _In_ LPCITEMIDLIST pidl,
+  _In_ PCIDLIST_ABSOLUTE pidl,
   _In_ REFIID riid,
   _Outptr_ LPVOID *ppv,
-  _Outptr_opt_ LPCITEMIDLIST *ppidlLast);
+  _Outptr_opt_ PCUITEMID_CHILD *ppidlLast);
 
 /****************************************************************************
 * SHDefExtractIcon API
@@ -2289,25 +2289,25 @@ SHDoDragDrop(
 #define PID_IS_COMMENT     13
 
 
-LPITEMIDLIST WINAPI ILAppendID(_In_opt_ LPITEMIDLIST, _In_ LPCSHITEMID, BOOL);
-LPITEMIDLIST WINAPI ILClone(_In_ LPCITEMIDLIST);
-LPITEMIDLIST WINAPI ILCloneFirst(_In_ LPCITEMIDLIST);
-LPITEMIDLIST WINAPI ILCreateFromPathA(_In_ LPCSTR);
-LPITEMIDLIST WINAPI ILCreateFromPathW(_In_ LPCWSTR);
+PIDLIST_RELATIVE WINAPI ILAppendID(_In_opt_ PIDLIST_RELATIVE, _In_ LPCSHITEMID, BOOL);
+PIDLIST_RELATIVE WINAPI ILClone(_In_ PCUIDLIST_RELATIVE);
+PITEMID_CHILD WINAPI ILCloneFirst(_In_ PCUIDLIST_RELATIVE);
+PIDLIST_ABSOLUTE WINAPI ILCreateFromPathA(_In_ PCSTR);
+PIDLIST_ABSOLUTE WINAPI ILCreateFromPathW(_In_ PCWSTR);
 #define             ILCreateFromPath WINELIB_NAME_AW(ILCreateFromPath)
-LPITEMIDLIST WINAPI ILCombine(_In_opt_ LPCITEMIDLIST, _In_opt_ LPCITEMIDLIST);
-LPITEMIDLIST WINAPI ILFindChild(_In_ LPCITEMIDLIST, _In_ LPCITEMIDLIST);
-LPITEMIDLIST WINAPI ILFindLastID(_In_ LPCITEMIDLIST);
-void         WINAPI ILFree(_In_opt_ LPITEMIDLIST);
-LPITEMIDLIST WINAPI ILGetNext(_In_opt_ LPCITEMIDLIST);
-UINT         WINAPI ILGetSize(_In_opt_ LPCITEMIDLIST);
-BOOL         WINAPI ILIsEqual(_In_ LPCITEMIDLIST, _In_ LPCITEMIDLIST);
-BOOL         WINAPI ILIsParent(_In_ LPCITEMIDLIST, _In_ LPCITEMIDLIST, BOOL);
-HRESULT      WINAPI ILLoadFromStream(_In_ LPSTREAM, _Inout_ LPITEMIDLIST*);
-BOOL         WINAPI ILRemoveLastID(_Inout_opt_ LPITEMIDLIST);
-HRESULT      WINAPI ILSaveToStream(_In_ LPSTREAM, _In_ LPCITEMIDLIST);
+PIDLIST_ABSOLUTE WINAPI ILCombine(_In_opt_ PCIDLIST_ABSOLUTE, _In_opt_ PCUIDLIST_RELATIVE);
+PUIDLIST_RELATIVE WINAPI ILFindChild(_In_ PIDLIST_ABSOLUTE, _In_ PCIDLIST_ABSOLUTE);
+PUITEMID_CHILD WINAPI ILFindLastID(_In_ PCUIDLIST_RELATIVE);
+void         WINAPI ILFree(_In_opt_ PIDLIST_RELATIVE);
+PUIDLIST_RELATIVE WINAPI ILGetNext(_In_opt_ PCUIDLIST_RELATIVE);
+UINT         WINAPI ILGetSize(_In_opt_ PCUIDLIST_RELATIVE);
+BOOL         WINAPI ILIsEqual(_In_ PCIDLIST_ABSOLUTE, _In_ PCIDLIST_ABSOLUTE);
+BOOL         WINAPI ILIsParent(_In_ PCIDLIST_ABSOLUTE, _In_ PCIDLIST_ABSOLUTE, BOOL);
+HRESULT      WINAPI ILLoadFromStream(_In_ LPSTREAM, _Inout_ PIDLIST_RELATIVE*);
+BOOL         WINAPI ILRemoveLastID(_Inout_opt_ PUIDLIST_RELATIVE);
+HRESULT      WINAPI ILSaveToStream(_In_ LPSTREAM, _In_ PCUIDLIST_RELATIVE);
 
-static inline BOOL ILIsEmpty(_In_opt_ LPCITEMIDLIST pidl)
+static inline BOOL ILIsEmpty(_In_opt_ PCUIDLIST_RELATIVE pidl)
 {
     return !(pidl && pidl->mkid.cb);
 }

--- a/sdk/include/psdk/shlwapi.h
+++ b/sdk/include/psdk/shlwapi.h
@@ -1738,14 +1738,14 @@ HRESULT
 WINAPI
 StrRetToStrA(
   _Inout_ STRRET*,
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCUITEMID_CHILD,
   _Outptr_ LPSTR*);
 
 HRESULT
 WINAPI
 StrRetToStrW(
   _Inout_ STRRET*,
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCUITEMID_CHILD,
   _Outptr_ LPWSTR*);
 
 #define StrRetToStr WINELIB_NAME_AW(StrRetToStr)
@@ -1754,7 +1754,7 @@ HRESULT
 WINAPI
 StrRetToBufA(
   _Inout_ STRRET*,
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCUITEMID_CHILD,
   _Out_writes_(cchBuf) LPSTR,
   UINT cchBuf);
 
@@ -1762,7 +1762,7 @@ HRESULT
 WINAPI
 StrRetToBufW(
   _Inout_ STRRET*,
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCUITEMID_CHILD,
   _Out_writes_(cchBuf) LPWSTR,
   UINT cchBuf);
 
@@ -1772,7 +1772,7 @@ HRESULT
 WINAPI
 StrRetToBSTR(
   _Inout_ STRRET*,
-  _In_opt_ LPCITEMIDLIST,
+  _In_opt_ PCUITEMID_CHILD,
   _Outptr_ BSTR*);
 
 BOOL WINAPI IsCharSpaceA(CHAR);
@@ -2002,7 +2002,7 @@ HRESULT WINAPI DllInstall(BOOL, _In_opt_ LPCWSTR) DECLSPEC_HIDDEN;
 HRESULT
 WINAPI
 SHGetViewStatePropertyBag(
-  _In_opt_ LPCITEMIDLIST pidl,
+  _In_opt_ PCIDLIST_ABSOLUTE pidl,
   _In_opt_ LPWSTR bag_name,
   DWORD flags,
   _In_ REFIID riid,

--- a/sdk/include/psdk/shobjidl.idl
+++ b/sdk/include/psdk/shobjidl.idl
@@ -102,7 +102,7 @@ interface IEnumIDList : IUnknown
 
     HRESULT Next(
         [in] ULONG celt,
-        [out, size_is(celt), length_is(*pceltFetched)] LPITEMIDLIST *rgelt,
+        [out, size_is(celt), length_is(*pceltFetched)] PITEMID_CHILD *rgelt,
         [out] ULONG *pceltFetched);
 
     HRESULT Skip( [in] ULONG celt );
@@ -764,7 +764,7 @@ interface IShellView : IOleWindow
 
     HRESULT SaveViewState();
     HRESULT SelectItem(
-        [in] LPCITEMIDLIST pidlItem,
+        [in] PCUITEMID_CHILD pidlItem,
         [in] SVSIF uFlags);
     HRESULT GetItemObject(
         [in] UINT uItem,
@@ -801,10 +801,10 @@ cpp_quote("#include <poppack.h>")
         [in] LPSV2CVW2_PARAMS view_params
     );
     HRESULT HandleRename(
-        [in] LPCITEMIDLIST new_pidl
+        [in] PCUITEMID_CHILD new_pidl
     );
     HRESULT SelectAndPositionItem(
-        [in] LPCITEMIDLIST item,
+        [in] PCUITEMID_CHILD item,
         [in] UINT flags,
         [in] POINT *point
     );
@@ -1079,7 +1079,7 @@ cpp_quote("#endif")
     HRESULT TranslateAcceleratorSB( [in] MSG *pmsg, [in] WORD wID );
 
     HRESULT BrowseObject(
-        [in] LPCITEMIDLIST pidl,
+        [in] PCUIDLIST_RELATIVE pidl,
         [in] UINT wFlags);
 
     HRESULT GetViewStateStream(
@@ -1307,7 +1307,7 @@ interface IPersistFolder3 : IPersistFolder2
 {
     typedef struct
     {
-        LPITEMIDLIST	pidlTargetFolder;
+    PIDLIST_ABSOLUTE	pidlTargetFolder;
 	WCHAR		szTargetParsingName[MAX_PATH];
 	WCHAR		szNetworkProvider[MAX_PATH];
 	DWORD		dwAttributes;
@@ -1316,7 +1316,7 @@ interface IPersistFolder3 : IPersistFolder2
 
     HRESULT InitializeEx(
         [in] IBindCtx *pbc,
-        [in] LPCITEMIDLIST pidlRoot,
+        [in] PCIDLIST_ABSOLUTE pidlRoot,
         [in] const PERSIST_FOLDER_TARGET_INFO *ppfti);
 
     HRESULT GetFolderTargetInfo( [out] PERSIST_FOLDER_TARGET_INFO *ppfti );
@@ -1416,7 +1416,7 @@ cpp_quote("#define CDBOSC_STATECHANGE  0x00000004")
 
     HRESULT OnDefaultCommand( [in] IShellView *shv );
     HRESULT OnStateChange( [in] IShellView *shv, [in] ULONG uChange );
-    HRESULT IncludeObject( [in] IShellView *shv, [in] LPCITEMIDLIST pidl );
+    HRESULT IncludeObject( [in] IShellView *shv, [in] PCUITEMID_CHILD pidl );
 }
 
 
@@ -1988,8 +1988,8 @@ interface IShellChangeNotify : IUnknown
 {
     HRESULT OnChange(
                 [in] LONG lEvent,
-                [in] LPCITEMIDLIST pidl1,
-                [in] LPCITEMIDLIST pidl2);
+                [in] PCIDLIST_ABSOLUTE pidl1,
+                [in] PCIDLIST_ABSOLUTE pidl2);
 }
 
 cpp_quote("#define STR_FILE_SYS_BIND_DATA  L\"File System Bind Data\"")
@@ -2625,8 +2625,8 @@ typedef struct tagSMDATA
 	UINT			uIdParent;
 	UINT			uIdAncestor;
 	IUnknown		*punk;
-	LPITEMIDLIST	pidlFolder;
-	LPITEMIDLIST	pidlItem;
+	PIDLIST_ABSOLUTE	pidlFolder;
+	PUITEMID_CHILD	pidlItem;
 	IShellFolder	*psf;
 	void			*pvUserData;
 } SMDATA, *LPSMDATA;
@@ -2646,8 +2646,8 @@ typedef struct tagSMINFO
 typedef struct tagSHCSCHANGENOTIFYSTRUCT
 {
 	LONG			lEvent;
-	LPCITEMIDLIST	pidl1;
-	LPCITEMIDLIST	pidl2;
+	PCIDLIST_ABSOLUTE	pidl1;
+	PCIDLIST_ABSOLUTE	pidl2;
 } SMCSHCHANGENOTIFYSTRUCT, *PSMCSHCHANGENOTIFYSTRUCT;
 
 cpp_quote("#include <poppack.h>")
@@ -2762,13 +2762,13 @@ interface IShellMenu : IUnknown
 
 	HRESULT SetShellFolder(
         [in] IShellFolder *psf,
-		[in] LPCITEMIDLIST pidlFolder,
+		[in] PCIDLIST_ABSOLUTE pidlFolder,
         [in] HKEY hKey,
         [in] DWORD dwFlags);
 
 	HRESULT GetShellFolder(
 		[out] DWORD *pdwFlags,
-		[out] LPITEMIDLIST *ppidl,
+		[out] PIDLIST_ABSOLUTE *ppidl,
 		[in] REFIID riid,
 		[out] void **ppv);
 


### PR DESCRIPTION
## Support STRICT_TYPED_ITEMIDS

In this pull request, I've updated the file shlobj.h with the strictly typed version of ITEMIDLIST from MSDN.

JIRA issue: [CORE-16385](https://jira.reactos.org/browse/CORE-16385)

## TODO
- [x] shlwapi.h
- [x] shdeprecated.idl
- [x] shobjidl.idl

