### PR TITLE
[USER32]  Fix wrong return from LB_GETLISTBOXINFO

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -3419,7 +3419,7 @@ NtUserGetListBoxInfo(
       LB_DESCR *descr = ((PWND2LB)Wnd)->pLBiv;
       // See Controls ListBox.c:LB_GETLISTBOXINFO must match...
       if (descr->style & LBS_MULTICOLUMN) //// ReactOS
-         Ret = descr->page_size * descr->column_width;
+         Ret = descr->page_size * (descr->width / descr->column_width);
       else
          Ret = descr->page_size;
    }

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -3418,10 +3418,7 @@ NtUserGetListBoxInfo(
    {
       LB_DESCR *descr = ((PWND2LB)Wnd)->pLBiv;
       // See Controls ListBox.c:LB_GETLISTBOXINFO must match...
-      if (descr->style & LBS_MULTICOLUMN) //// ReactOS
-         Ret = descr->page_size * (descr->width / descr->column_width);
-      else
-         Ret = descr->page_size;
+      Ret = descr->page_size;
    }
    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
    {

--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -3042,7 +3042,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
 
     case LB_GETLISTBOXINFO:
         if (descr->style & LBS_MULTICOLUMN) //// ReactOS
-           return descr->page_size * descr->column_width;
+           return descr->page_size * (descr->width / descr->column_width);
         else
            return descr->page_size;
 

--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -3041,10 +3041,7 @@ LRESULT WINAPI ListBoxWndProc_common( HWND hwnd, UINT msg,
         return LB_OKAY;
 
     case LB_GETLISTBOXINFO:
-        if (descr->style & LBS_MULTICOLUMN) //// ReactOS
-           return descr->page_size * (descr->width / descr->column_width);
-        else
-           return descr->page_size;
+        return descr->page_size;
 
     case WM_DESTROY:
         return LISTBOX_Destroy( descr );


### PR DESCRIPTION
## Purpose

 win32ss/user/user32/controls/listbox.c   
      Fixed wrong return from LB_GETLISTBOXINFO in case LBS_MULTICOLUMN
  According to Microsoft the message LB_GETLISTBOXINFO should return the number of visible items in the column. In case of a list style LBS_MULTICOLUMN the returned value(line 3045), has no meaning since the calculation multiplies the number of items in a column by its width in pixels.

win32ss/user/ntuser/window.c Line _3422   must match listbox.c L_3045 
 (see window.c line 3420)
