### PR TITLE
Add .clang-format and Travis job for checking formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,35 @@
+# full manual is at https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+---
+BasedOnStyle: Microsoft
+
+IndentWidth:     4
+UseTab:          Never
+
+IndentCaseLabels: true
+
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+
+BinPackParameters: false
+BinPackArguments: true
+
+# This applies to () [] <>
+AlignAfterOpenBracket: AlwaysBreak
+
+# Always break before braces
+BreakBeforeBraces: Allman
+
+# return type on it's own line
+AlwaysBreakAfterReturnType: All
+
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,35 @@
-language: bash
+dist: bionic
+language: cpp
+
+addons:
+  apt:
+    sources:
+      - sourceline: 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-9 main'
+        key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+    packages:
+      clang-format-9
 
 git:
-  depth: 5
+  depth: 1
 
-before_script:
+env:
+  global:
+    - DO_BUILD=0
+    - DO_CHECK=0
+    - CLFORMAT_BINARY=clang-format-9
+  jobs:
+    - DO_BUILD=1
+    - DO_CHECK=1
+
+before_install:
+  - ln -s /usr/share/clang/clang-format-9/clang-format-diff.py ./sdk/tools/;
   - wget https://svn.reactos.org/amine/RosBEBinFull.tar.gz -O RosBE.tar.gz
   - tar -xzf RosBE.tar.gz
   - echo 'mkdir ../Build && cd ../Build && $TRAVIS_BUILD_DIR/configure.sh -DENABLE_ROSTESTS=1 && ninja -k 0 && ninja bootcd' > tmp_file
 
 script:
-  - ./RosBEBinFull/RosBE.sh < tmp_file
+  - if [ $DO_BUILD == "1" ]; then
+      ./RosBEBinFull/RosBE.sh < tmp_file;
+    elif [ $DO_CHECK == "1" ]; then
+      ./sdk/tools/check_code_format.sh;
+    fi

--- a/drivers/network/tcpip/.clang-format
+++ b/drivers/network/tcpip/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: false
+...

--- a/sdk/lib/3rdparty/.clang-format
+++ b/sdk/lib/3rdparty/.clang-format
@@ -1,0 +1,4 @@
+---
+DisableFormat: true
+SortIncludes: false
+...

--- a/sdk/tools/check_code_format.sh
+++ b/sdk/tools/check_code_format.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Copyright (c) 2017 Google Inc.
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Script to determine if source code in Pull Request is properly formatted.
+# Exits with non 0 exit code if formatting is needed.
+#
+# This script assumes to be invoked at the project root directory.
+
+BASE_BRANCH=${1:-master}
+
+FILES_TO_CHECK=$(git diff --name-only ${BASE_BRANCH} | grep -E ".*\.(cpp|cc|c\+\+|cxx|c|h|hpp)$")
+
+if [ -z "${FILES_TO_CHECK}" ]; then
+  echo "No source code to check for formatting."
+  exit 0
+fi
+
+FORMAT_DIFF=$(git diff -U0 ${BASE_BRANCH} -- ${FILES_TO_CHECK} | python3 ./sdk/tools/clang-format-diff.py -binary ${CLFORMAT_BINARY} -p1 -style=file)
+
+if [ -z "${FORMAT_DIFF}" ]; then
+  echo "All source code in PR properly formatted."
+  exit 0
+else
+  echo "Found formatting errors!"
+  echo "${FORMAT_DIFF}"
+  exit 1
+fi


### PR DESCRIPTION
No more formatting comments while reviewing PRs!

__TODO__:
- [x] find better place for `check_code_format.sh`
- [x] finish `.clang-format`