### PR TITLE
[SDK][INCLUDE] Add Gdiplus::Image::~Image

### DIFF
--- a/sdk/include/psdk/gdiplusheaders.h
+++ b/sdk/include/psdk/gdiplusheaders.h
@@ -47,6 +47,11 @@ public:
     return newImage;
   }
 
+  virtual ~Image()
+  {
+    DllExports::GdipDisposeImage(image);
+  }
+
   static Image *FromFile(const WCHAR *filename, BOOL useEmbeddedColorManagement = FALSE)
   {
     return new Image(filename, useEmbeddedColorManagement);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16566](https://jira.reactos.org/browse/CORE-16566)
Our `gdiplusheaders.h` has no dtor of `Gdiplus::Image`. Our `Gdiplus::Bitmap` won't be `GdipDisposeImage`'d upon its destruction.
