### PR TITLE
[SHELL32] Add FOF_RENAMEONCOLLISION upon bCopy

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -86,6 +86,8 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     op.hwnd = m_hwndSite;
     op.wFunc = bCopy ? FO_COPY : FO_MOVE;
     op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMMKDIR;
+    if (bCopy)
+        op.fFlags |= FOF_RENAMEONCOLLISION;
 
     int res = SHFileOperationW(&op);
 


### PR DESCRIPTION
## Purpose
Enable rename-on-collision (`FOF_RENAMEONCOLLISION`) for copying files and/or folders.
JIRA issue: N/A

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/71452082-574da100-27c4-11ea-9611-8a6e4d6698be.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/71452081-56b50a80-27c4-11ea-9ee5-486e4dde1fdc.png)