### PR TITLE
[NTUSER] Fix caret display mistake

### DIFF
--- a/win32ss/user/ntuser/caret.c
+++ b/win32ss/user/ntuser/caret.c
@@ -217,10 +217,13 @@ co_IntSetCaretPos(int X, int Y)
       if(ThreadQueue->CaretInfo.Pos.x != X || ThreadQueue->CaretInfo.Pos.y != Y)
       {
          co_IntHideCaret(&ThreadQueue->CaretInfo);
-         ThreadQueue->CaretInfo.Showing = 1;
          ThreadQueue->CaretInfo.Pos.x = X;
          ThreadQueue->CaretInfo.Pos.y = Y;
-         co_IntDrawCaret(pWnd, &ThreadQueue->CaretInfo);
+         if (ThreadQueue->CaretInfo.Visible)
+         {
+            ThreadQueue->CaretInfo.Showing = 1;
+            co_IntDrawCaret(pWnd, &ThreadQueue->CaretInfo);
+         }
 
          IntSetTimer(pWnd, IDCARETTIMER, gpsi->dtCaretBlink, CaretSystemTimerProc, TMRF_SYSTEM);
          IntNotifyWinEvent(EVENT_OBJECT_LOCATIONCHANGE, pWnd, OBJID_CARET, CHILDID_SELF, 0);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15661](https://jira.reactos.org/browse/CORE-15661)
`co_IntSetCaretPos` function wrongly drawn the caret upon invisible timing. Take care of caret visibility. @Doug-Lyons did test this patch.