### PR TITLE
[KERNEL32_APITEST] More power to ConsoleCP testcase

### DIFF
--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -483,7 +483,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, csbi.dwSize.X * 2);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -529,7 +529,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -675,7 +675,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -728,7 +728,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -800,7 +800,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, csbi.dwSize.X * 2);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -844,7 +844,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -976,7 +976,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));
@@ -1030,7 +1030,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_long(len, 1);
 
-        /* clear buff */
+        /* reset buff */
         buffSize.X = ARRAYSIZE(buff);
         buffSize.Y = 1;
         memset(buff, 0x7F, sizeof(buff));

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -481,12 +481,9 @@ static void test_cp932(HANDLE hConOut)
         okCURSOR(hConOut, c);
 
         /* fill by space */
-        for (n = 0; n < csbi.dwSize.X * 2; ++n)
-        {
-            ret = WriteConsoleW(hConOut, space, 1, &len, NULL);
-            ok_int(ret, 1);
-            ok_long(len, 1);
-        }
+        ret = FillConsoleOutputCharacterW(hConOut, L'A', csbi.dwSize.X * 2, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, csbi.dwSize.X * 2);
 
         /* clear buff */
         buffSize.X = ARRAYSIZE(buff);
@@ -505,7 +502,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(sr.Bottom, 0);
 
         /* check buff */
-        ok_int(buff[0].Char.UnicodeChar, L' ');
+        ok_int(buff[0].Char.UnicodeChar, L'A');
         ok_int(buff[0].Attributes, ATTR);
 
         /* read attr */
@@ -552,12 +549,12 @@ static void test_cp932(HANDLE hConOut)
         else
         {
             ok_int(buff[0].Attributes, ATTR);
-            ok_int(buff[1].Char.UnicodeChar, L' ');
+            ok_int(buff[1].Char.UnicodeChar, L'A');
             ok_int(buff[1].Attributes, ATTR);
         }
-        ok_int(buff[2].Char.UnicodeChar, L' ');
+        ok_int(buff[2].Char.UnicodeChar, L'A');
         ok_int(buff[2].Attributes, ATTR);
-        ok_int(buff[3].Char.UnicodeChar, L' ');
+        ok_int(buff[3].Char.UnicodeChar, L'A');
         ok_int(buff[3].Attributes, ATTR);
 
         /* read attr */
@@ -609,10 +606,10 @@ static void test_cp932(HANDLE hConOut)
             ok_int(buff[0].Attributes, ATTR);
             ok_int(buff[1].Char.UnicodeChar, 0x0414);
             ok_int(buff[1].Attributes, ATTR);
-            ok_int(buff[2].Char.UnicodeChar, L' ');
+            ok_int(buff[2].Char.UnicodeChar, L'A');
             ok_int(buff[2].Attributes, ATTR);
         }
-        ok_int(buff[3].Char.UnicodeChar, L' ');
+        ok_int(buff[3].Char.UnicodeChar, L'A');
         ok_int(buff[3].Attributes, ATTR);
 
         /* read attr */
@@ -660,9 +657,9 @@ static void test_cp932(HANDLE hConOut)
         ok_int(sr.Bottom, 0);
 
         /* check buff */
-        ok_int(buff[0].Char.UnicodeChar, ' ');
+        ok_int(buff[0].Char.UnicodeChar, L'A');
         ok_int(buff[0].Attributes, ATTR);
-        ok_int(buff[1].Char.UnicodeChar, ' ');
+        ok_int(buff[1].Char.UnicodeChar, L'A');
         ok_int(buff[1].Attributes, ATTR);
 
         /* read attr */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -813,7 +813,6 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         if (s_bIs8Plus)
@@ -868,7 +867,6 @@ static void test_cp932(HANDLE hConOut)
         c.Y = 0;
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         ok_int(attrs[0], ATTR);

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -75,7 +75,6 @@ static void test_cp855(HANDLE hConOut)
     ok(ret, "GetConsoleScreenBufferInfo failed\n");
     trace("csbi.dwSize.X:%d, csbi.dwSize.Y:%d\n", csbi.dwSize.X, csbi.dwSize.Y);
     count = 200;
-    trace("count: %d\n", count);
 
     /* "\u0414" */
     {
@@ -293,7 +292,6 @@ static void test_cp932(HANDLE hConOut)
     ok(ret, "GetConsoleScreenBufferInfo failed\n");
     trace("csbi.dwSize.X:%d, csbi.dwSize.Y:%d\n", csbi.dwSize.X, csbi.dwSize.Y);
     count = 200;
-    trace("count: %d\n", count);
 
     /* "\u0414" */
     {

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -74,7 +74,7 @@ static void test_cp855(HANDLE hConOut)
     ret = GetConsoleScreenBufferInfo(hConOut, &csbi);
     ok(ret, "GetConsoleScreenBufferInfo failed\n");
     trace("csbi.dwSize.X:%d, csbi.dwSize.Y:%d\n", csbi.dwSize.X, csbi.dwSize.Y);
-    count = csbi.dwSize.X * 3 / 2;
+    count = 200;
     trace("count: %d\n", count);
 
     /* "\u0414" */
@@ -292,7 +292,7 @@ static void test_cp932(HANDLE hConOut)
     ret = GetConsoleScreenBufferInfo(hConOut, &csbi);
     ok(ret, "GetConsoleScreenBufferInfo failed\n");
     trace("csbi.dwSize.X:%d, csbi.dwSize.Y:%d\n", csbi.dwSize.X, csbi.dwSize.Y);
-    count = csbi.dwSize.X * 3 / 2;
+    count = 200;
     trace("count: %d\n", count);
 
     /* "\u0414" */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -18,10 +18,10 @@
 #define ATTR \
     (FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED)
 
-static const WCHAR u0414[] = {0x0414, 0};             /* Д */
-static const WCHAR u9580[] = {0x9580, 0};             /* 門 */
+static const WCHAR u0414[] = {0x0414, 0}; /* Д */
+static const WCHAR u9580[] = {0x9580, 0}; /* 門 */
 static const WCHAR space[] = {L' ', 0};
-static const WCHAR ideograph_space = (WCHAR)0x3000;     /* fullwidth space */
+static const WCHAR ideograph_space = (WCHAR)0x3000; /* fullwidth space */
 static LCID lcidJapanese = MAKELCID(MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), SORT_DEFAULT);
 static LCID lcidRussian  = MAKELCID(MAKELANGID(LANG_RUSSIAN , SUBLANG_DEFAULT), SORT_DEFAULT);
 static BOOL s_bIs8Plus;

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -478,7 +478,7 @@ static void test_cp932(HANDLE hConOut)
         SetConsoleCursorPosition(hConOut, c);
         okCURSOR(hConOut, c);
 
-        /* fill by space */
+        /* fill by 'A' */
         ret = FillConsoleOutputCharacterW(hConOut, L'A', csbi.dwSize.X * 2, c, &len);
         ok_int(ret, 1);
         ok_long(len, csbi.dwSize.X * 2);
@@ -713,6 +713,65 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_int(str[0], L'A');
         ok_int(str[1], L'A');
+
+        /* fill by space */
+        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, 10);
+
+        /* fill by 'A' */
+        c.X = c.Y = 0;
+        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, 10);
+
+        /* fill by u0414 */
+        c.X = 1;
+        c.Y = 0;
+        ret = FillConsoleOutputCharacterW(hConOut, 0x0414, 1, c, &len);
+        c.X = c.Y = 0;
+        ok_int(ret, 1);
+        ok_long(len, 1);
+
+        /* clear buff */
+        buffSize.X = ARRAYSIZE(buff);
+        buffSize.Y = 1;
+        memset(buff, 0x7F, sizeof(buff));
+
+        /* read output */
+        c.X = c.Y = 0;
+        sr.Left = 0;
+        sr.Top = 0;
+        sr.Right = 4;
+        sr.Bottom = 0;
+        ret = ReadConsoleOutputW(hConOut, buff, buffSize, c, &sr);
+        ok_int(ret, 1);
+        ok_int(sr.Left, 0);
+        ok_int(sr.Top, 0);
+        ok_int(sr.Right, 4);
+        ok_int(sr.Bottom, 0);
+
+        /* check buff */
+        ok_int(buff[0].Char.UnicodeChar, 'A');
+        ok_int(buff[0].Attributes, ATTR);
+        if (s_bIs8Plus)
+        {
+            ok_int(buff[1].Char.UnicodeChar, 0x0414);
+            ok_int(buff[1].Attributes, ATTR | COMMON_LVB_LEADING_BYTE);
+            ok_int(buff[2].Char.UnicodeChar, 0x0414);
+            ok_int(buff[2].Attributes, ATTR | COMMON_LVB_TRAILING_BYTE);
+        }
+        else
+        {
+            ok_int(buff[1].Char.UnicodeChar, L' ');
+            ok_int(buff[1].Attributes, ATTR);
+            ok_int(buff[2].Char.UnicodeChar, 'A');
+            ok_int(buff[2].Attributes, ATTR);
+        }
+        ok_int(buff[3].Char.UnicodeChar, 'A');
+        ok_int(buff[3].Attributes, ATTR);
+        ok_int(buff[4].Char.UnicodeChar, 'A');
+        ok_int(buff[4].Attributes, ATTR);
     }
 
     /* COMMON_LVB_LEADING_BYTE and COMMON_LVB_TRAILING_BYTE for u9580 */
@@ -722,7 +781,7 @@ static void test_cp932(HANDLE hConOut)
         SetConsoleCursorPosition(hConOut, c);
         okCURSOR(hConOut, c);
 
-        /* fill by space */
+        /* fill by 'A' */
         ret = FillConsoleOutputCharacterW(hConOut, L'A', csbi.dwSize.X * 2, c, &len);
         ok_int(ret, 1);
         ok_long(len, csbi.dwSize.X * 2);
@@ -942,6 +1001,65 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_int(str[0], L'A');
         ok_int(str[1], L'A');
+
+        /* fill by space */
+        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, 10);
+
+        /* fill by 'A' */
+        c.X = c.Y = 0;
+        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, 10);
+
+        /* fill by u9580 */
+        c.X = 1;
+        c.Y = 0;
+        ret = FillConsoleOutputCharacterW(hConOut, 0x9580, 1, c, &len);
+        c.X = c.Y = 0;
+        ok_int(ret, 1);
+        ok_long(len, 1);
+
+        /* clear buff */
+        buffSize.X = ARRAYSIZE(buff);
+        buffSize.Y = 1;
+        memset(buff, 0x7F, sizeof(buff));
+
+        /* read output */
+        c.X = c.Y = 0;
+        sr.Left = 0;
+        sr.Top = 0;
+        sr.Right = 4;
+        sr.Bottom = 0;
+        ret = ReadConsoleOutputW(hConOut, buff, buffSize, c, &sr);
+        ok_int(ret, 1);
+        ok_int(sr.Left, 0);
+        ok_int(sr.Top, 0);
+        ok_int(sr.Right, 4);
+        ok_int(sr.Bottom, 0);
+
+        /* check buff */
+        ok_int(buff[0].Char.UnicodeChar, 'A');
+        ok_int(buff[0].Attributes, ATTR);
+        if (s_bIs8Plus)
+        {
+            ok_int(buff[1].Char.UnicodeChar, 0x9580);
+            ok_int(buff[1].Attributes, ATTR | COMMON_LVB_LEADING_BYTE);
+            ok_int(buff[2].Char.UnicodeChar, 0x9580);
+            ok_int(buff[2].Attributes, ATTR | COMMON_LVB_TRAILING_BYTE);
+        }
+        else
+        {
+            ok_int(buff[1].Char.UnicodeChar, L' ');
+            ok_int(buff[1].Attributes, ATTR);
+            ok_int(buff[2].Char.UnicodeChar, 'A');
+            ok_int(buff[2].Attributes, ATTR);
+        }
+        ok_int(buff[3].Char.UnicodeChar, 'A');
+        ok_int(buff[3].Attributes, ATTR);
+        ok_int(buff[4].Char.UnicodeChar, 'A');
+        ok_int(buff[4].Attributes, ATTR);
     }
 
     /* Restore code page */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -509,6 +509,11 @@ static void test_cp932(HANDLE hConOut)
         ok_int(attr, ATTR);
         ok_long(len, 1);
 
+        /* read char */
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], L'A');
+
         /* set cursor */
         c.X = 0;
         c.Y = 0;
@@ -560,11 +565,23 @@ static void test_cp932(HANDLE hConOut)
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
         ok_long(len, ARRAYSIZE(attrs));
-
         ok_int(attrs[0], ATTR | COMMON_LVB_LEADING_BYTE);
         ok_int(attrs[1], ATTR | COMMON_LVB_TRAILING_BYTE);
         ok_int(attrs[2], ATTR);
         ok_int(attrs[3], ATTR);
+
+        /* read char */
+        c.X = c.Y = 0;
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 4, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], 0x0414);
+        ok_int(str[1], L'A');
+        ok_int(str[2], L'A');
+        if (s_bIs8Plus)
+            ok_int(str[3], 0);
+        else
+            ok_int(str[3], 0x7F7F);
 
         /* set cursor */
         c.X = 1;
@@ -615,7 +632,6 @@ static void test_cp932(HANDLE hConOut)
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
         ok_long(len, ARRAYSIZE(attrs));
-
         if (s_bIs8Plus)
             ok_int(attrs[0], ATTR | COMMON_LVB_LEADING_BYTE);
         else
@@ -623,6 +639,11 @@ static void test_cp932(HANDLE hConOut)
         ok_int(attrs[1], ATTR | COMMON_LVB_LEADING_BYTE);
         ok_int(attrs[2], ATTR | COMMON_LVB_TRAILING_BYTE);
         ok_int(attrs[3], ATTR);
+
+        /* read char */
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], L' ');
 
         /* set cursor */
         c.X = csbi.dwSize.X - 1;
@@ -665,9 +686,14 @@ static void test_cp932(HANDLE hConOut)
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
         ok_long(len, ARRAYSIZE(attrs));
-
         ok_int(attrs[0], ATTR);
         ok_int(attrs[1], ATTR);
+
+        /* read char */
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 2, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], L'A');
+        ok_int(str[1], L'A');
     }
 
     /* COMMON_LVB_LEADING_BYTE and COMMON_LVB_TRAILING_BYTE for u9580 */
@@ -707,6 +733,12 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_int(attr, ATTR);
         ok_long(len, 1);
+
+        /* read char */
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], L'A');
 
         /* set cursor */
         c.X = 0;
@@ -764,6 +796,19 @@ static void test_cp932(HANDLE hConOut)
         ok_int(attrs[1], ATTR | COMMON_LVB_TRAILING_BYTE);
         ok_int(attrs[2], ATTR);
         ok_int(attrs[3], ATTR);
+
+        /* read char */
+        c.X = c.Y = 0;
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 4, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], 0x9580);
+        ok_int(str[1], L'A');
+        ok_int(str[2], L'A');
+        if (s_bIs8Plus)
+            ok_int(str[3], 0);
+        else
+            ok_int(str[3], 0x7F7F);
 
         /* set cursor */
         c.X = 1;
@@ -868,9 +913,15 @@ static void test_cp932(HANDLE hConOut)
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
         ok_long(len, ARRAYSIZE(attrs));
-
         ok_int(attrs[0], ATTR);
         ok_int(attrs[1], ATTR);
+
+        /* read char */
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 2, c, &len);
+        ok_int(ret, 1);
+        ok_int(str[0], L'A');
+        ok_int(str[1], L'A');
     }
 
     /* Restore code page */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -510,13 +510,13 @@ static void test_cp932(HANDLE hConOut)
         ok_long(len, 1);
 
         /* read char */
+        c.X = c.Y = 0;
         ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
         ok_int(ret, 1);
         ok_int(str[0], L'A');
 
         /* set cursor */
-        c.X = 0;
-        c.Y = 0;
+        c.X = c.Y = 0;
         SetConsoleCursorPosition(hConOut, c);
         okCURSOR(hConOut, c);
 
@@ -641,6 +641,7 @@ static void test_cp932(HANDLE hConOut)
         ok_int(attrs[3], ATTR);
 
         /* read char */
+        c.X = c.Y = 0;
         ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
         ok_int(ret, 1);
         ok_int(str[0], L' ');

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -758,7 +758,6 @@ static void test_cp932(HANDLE hConOut)
         /* read attr */
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         ok_int(attrs[0], ATTR | COMMON_LVB_LEADING_BYTE);

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -511,9 +511,13 @@ static void test_cp932(HANDLE hConOut)
 
         /* read char */
         c.X = c.Y = 0;
-        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 4, c, &len);
         ok_int(ret, 1);
         ok_int(str[0], L'A');
+        ok_int(str[1], L'A');
+        ok_int(str[2], L'A');
+        ok_int(str[3], L'A');
 
         /* set cursor */
         c.X = c.Y = 0;
@@ -642,9 +646,23 @@ static void test_cp932(HANDLE hConOut)
 
         /* read char */
         c.X = c.Y = 0;
-        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        memset(str, 0x7F, sizeof(str));
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 4, c, &len);
         ok_int(ret, 1);
-        ok_int(str[0], L' ');
+        if (s_bIs8Plus)
+        {
+            ok_int(str[0], 0x0414);
+            ok_int(str[1], 0x0414);
+            ok_int(str[2], L'A');
+            ok_int(str[3], 0);
+        }
+        else
+        {
+            ok_int(str[0], L' ');
+            ok_int(str[1], 0x0414);
+            ok_int(str[2], L'A');
+            ok_int(str[3], 0x7F7F);
+        }
 
         /* set cursor */
         c.X = csbi.dwSize.X - 1;
@@ -737,9 +755,10 @@ static void test_cp932(HANDLE hConOut)
 
         /* read char */
         memset(str, 0x7F, sizeof(str));
-        ret = ReadConsoleOutputCharacterW(hConOut, str, 1, c, &len);
+        ret = ReadConsoleOutputCharacterW(hConOut, str, 2, c, &len);
         ok_int(ret, 1);
         ok_int(str[0], L'A');
+        ok_int(str[1], L'A');
 
         /* set cursor */
         c.X = 0;

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -714,11 +714,6 @@ static void test_cp932(HANDLE hConOut)
         ok_int(str[0], L'A');
         ok_int(str[1], L'A');
 
-        /* fill by space */
-        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
-        ok_int(ret, 1);
-        ok_long(len, 10);
-
         /* fill by 'A' */
         c.X = c.Y = 0;
         ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
@@ -1020,11 +1015,6 @@ static void test_cp932(HANDLE hConOut)
         ok_int(ret, 1);
         ok_int(str[0], L'A');
         ok_int(str[1], L'A');
-
-        /* fill by space */
-        ret = FillConsoleOutputCharacterW(hConOut, L'A', 10, c, &len);
-        ok_int(ret, 1);
-        ok_long(len, 10);
 
         /* fill by 'A' */
         c.X = c.Y = 0;

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -772,6 +772,25 @@ static void test_cp932(HANDLE hConOut)
         ok_int(buff[3].Attributes, ATTR);
         ok_int(buff[4].Char.UnicodeChar, 'A');
         ok_int(buff[4].Attributes, ATTR);
+
+        /* read attrs */
+        c.X = 0;
+        c.Y = 0;
+        ret = ReadConsoleOutputAttribute(hConOut, attrs, 4, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, ARRAYSIZE(attrs));
+        ok_int(attrs[0], ATTR);
+        if (s_bIs8Plus)
+        {
+            ok_int(attrs[1], ATTR | COMMON_LVB_LEADING_BYTE);
+            ok_int(attrs[2], ATTR | COMMON_LVB_TRAILING_BYTE);
+        }
+        else
+        {
+            ok_int(attrs[1], ATTR);
+            ok_int(attrs[2], ATTR);
+        }
+        ok_int(attrs[3], ATTR);
     }
 
     /* COMMON_LVB_LEADING_BYTE and COMMON_LVB_TRAILING_BYTE for u9580 */
@@ -1060,6 +1079,25 @@ static void test_cp932(HANDLE hConOut)
         ok_int(buff[3].Attributes, ATTR);
         ok_int(buff[4].Char.UnicodeChar, 'A');
         ok_int(buff[4].Attributes, ATTR);
+
+        /* read attrs */
+        c.X = 0;
+        c.Y = 0;
+        ret = ReadConsoleOutputAttribute(hConOut, attrs, 4, c, &len);
+        ok_int(ret, 1);
+        ok_long(len, ARRAYSIZE(attrs));
+        ok_int(attrs[0], ATTR);
+        if (s_bIs8Plus)
+        {
+            ok_int(attrs[1], ATTR | COMMON_LVB_LEADING_BYTE);
+            ok_int(attrs[2], ATTR | COMMON_LVB_TRAILING_BYTE);
+        }
+        else
+        {
+            ok_int(attrs[1], ATTR);
+            ok_int(attrs[2], ATTR);
+        }
+        ok_int(attrs[3], ATTR);
     }
 
     /* Restore code page */

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -18,9 +18,9 @@
 #define ATTR \
     (FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED)
 
-static const WCHAR u0414[] = { 0x0414, 0 };             /* Д */
-static const WCHAR u9580[] = { 0x9580, 0 };             /* 門 */
-static const WCHAR space[] = { L' ', 0 };
+static const WCHAR u0414[] = {0x0414, 0};             /* Д */
+static const WCHAR u9580[] = {0x9580, 0};             /* 門 */
+static const WCHAR space[] = {L' ', 0};
 static const WCHAR ideograph_space = (WCHAR)0x3000;     /* fullwidth space */
 static LCID lcidJapanese = MAKELCID(MAKELANGID(LANG_JAPANESE, SUBLANG_DEFAULT), SORT_DEFAULT);
 static LCID lcidRussian  = MAKELCID(MAKELANGID(LANG_RUSSIAN , SUBLANG_DEFAULT), SORT_DEFAULT);

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -537,15 +537,16 @@ static void test_cp932(HANDLE hConOut)
         ok_int(sr.Bottom, 0);
 
         /* check buff */
-        ok_int(buff[0].Char.UnicodeChar, 0x0414);
         if (s_bIs8Plus)
         {
+            ok_int(buff[0].Char.UnicodeChar, 0x0414);
             ok_int(buff[0].Attributes, ATTR | COMMON_LVB_LEADING_BYTE);
             ok_int(buff[1].Char.UnicodeChar, 0x0414);
             ok_int(buff[1].Attributes, ATTR | COMMON_LVB_TRAILING_BYTE);
         }
         else
         {
+            ok_int(buff[0].Char.UnicodeChar, 0x0414);
             ok_int(buff[0].Attributes, ATTR);
             ok_int(buff[1].Char.UnicodeChar, L'A');
             ok_int(buff[1].Attributes, ATTR);

--- a/modules/rostests/apitests/kernel32/ConsoleCP.c
+++ b/modules/rostests/apitests/kernel32/ConsoleCP.c
@@ -559,7 +559,6 @@ static void test_cp932(HANDLE hConOut)
         /* read attr */
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         ok_int(attrs[0], ATTR | COMMON_LVB_LEADING_BYTE);
@@ -615,7 +614,6 @@ static void test_cp932(HANDLE hConOut)
         c.X = c.Y = 0;
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         if (s_bIs8Plus)
@@ -661,12 +659,11 @@ static void test_cp932(HANDLE hConOut)
         ok_int(buff[1].Char.UnicodeChar, L'A');
         ok_int(buff[1].Attributes, ATTR);
 
-        /* read attr */
+        /* read attrs */
         c.X = csbi.dwSize.X - 2;
         c.Y = 0;
         ret = ReadConsoleOutputAttribute(hConOut, attrs, ARRAYSIZE(attrs), c, &len);
         ok_int(ret, 1);
-        ok_long(attr, ATTR);
         ok_long(len, ARRAYSIZE(attrs));
 
         ok_int(attrs[0], ATTR);


### PR DESCRIPTION
## Purpose
Strengthen `kernel32_apitest` `ConsoleCP` testcase for `COMMON_LVB_LEADING_BYTE` and `COMMON_LVB_TRAILING_BYTE` attributes.
JIRA issue: [CORE-12451](https://jira.reactos.org/browse/CORE-12451)

AFTER (WinXP Japanese):
![ConsoleCP-WinXP-Japanese](https://user-images.githubusercontent.com/2107452/71540755-2de27000-2992-11ea-948e-5c18be06aedb.png)
Successful.

AFTER (Win10 Japanese):
![ConsoleCP-Win10-Japanese](https://user-images.githubusercontent.com/2107452/71540756-2e7b0680-2992-11ea-9e5c-b905dcac573a.png)
Successful.

AFTER (Win2k3 English):
![ConsoleCP-Win2k3-English](https://user-images.githubusercontent.com/2107452/71540754-2de27000-2992-11ea-9d50-023522ba9780.png)
Successful.