### PR TITLE
[WS2_32_APITEST] Add some tests for GetAddrInfoW

### DIFF
--- a/modules/rostests/apitests/ws2_32/getaddrinfo.c
+++ b/modules/rostests/apitests/ws2_32/getaddrinfo.c
@@ -199,7 +199,9 @@ START_TEST(getaddrinfo)
     WSADATA WsaData;
     int Error;
     PADDRINFOA AddrInfo;
+    PADDRINFOW AddrInfoW;
     ADDRINFOA Hints;
+    ADDRINFOW HintsW;
     CHAR LocalHostName[128];
     struct hostent *Hostent;
 
@@ -216,6 +218,9 @@ START_TEST(getaddrinfo)
     EndSeh(STATUS_SUCCESS);
 
     Error = getaddrinfo("127.0.0.1", "80", NULL, &AddrInfo);
+    ok_dec(Error, WSANOTINITIALISED);
+
+    Error = GetAddrInfoW(L"127.0.0.1", L"80", NULL, &AddrInfoW);
     ok_dec(Error, WSANOTINITIALISED);
 
     Error = WSAStartup(MAKEWORD(2, 2), &WsaData);
@@ -239,7 +244,7 @@ START_TEST(getaddrinfo)
        "Could not determine local address. Following test results may be wrong.\n");
 
     ZeroMemory(&Hints, sizeof(Hints));
-    /* parameter tests */
+    /* parameter tests for getaddrinfo */
     StartSeh() getaddrinfo(NULL, NULL, NULL, NULL); EndSeh(STATUS_ACCESS_VIOLATION);
     StartSeh() getaddrinfo("", "", &Hints, NULL);   EndSeh(STATUS_ACCESS_VIOLATION);
     StartSeh()
@@ -248,6 +253,17 @@ START_TEST(getaddrinfo)
         ok_dec(Error, WSAHOST_NOT_FOUND);
         ok_dec(WSAGetLastError(), WSAHOST_NOT_FOUND);
         ok_ptr(AddrInfo, NULL);
+    EndSeh(STATUS_SUCCESS);
+
+    /* parameter tests for GetAddrInfoW */
+    StartSeh() GetAddrInfoW(NULL, NULL, NULL, NULL);  EndSeh(STATUS_ACCESS_VIOLATION);
+    StartSeh() GetAddrInfoW(L"", L"", &HintsW, NULL); EndSeh(STATUS_ACCESS_VIOLATION);
+    StartSeh()
+        AddrInfo = InvalidPointer;
+        Error = GetAddrInfoW(NULL, NULL, NULL, &AddrInfoW);
+        ok_dec(Error, WSAHOST_NOT_FOUND);
+        ok_dec(WSAGetLastError(), WSAHOST_NOT_FOUND);
+        ok_ptr(AddrInfo, InvalidPointer); /* differs from getaddrinfo */
     EndSeh(STATUS_SUCCESS);
 
     TestNodeName();
@@ -261,5 +277,8 @@ START_TEST(getaddrinfo)
 
     /* not initialized anymore */
     Error = getaddrinfo("127.0.0.1", "80", NULL, &AddrInfo);
+    ok_dec(Error, WSANOTINITIALISED);
+
+    Error = GetAddrInfoW(L"127.0.0.1", L"80", NULL, &AddrInfoW);
     ok_dec(Error, WSANOTINITIALISED);
 }


### PR DESCRIPTION
Test results proves `WSAStartup` call should precede `GetAddrInfoW` calls.

JIRA issue: N/A

## Results

BEFORE:
```
Windows XP SP3
getaddrinfo: 890 tests executed (0 marked as todo, 1 failure), 0 skipped.

Windows 7 SP1
getaddrinfo: 839 tests executed (0 marked as todo, 10 failures), 0 skipped.
```
AFTER:
```
Windows XP SP3
getaddrinfo: 898 tests executed (0 marked as todo, 1 failure), 0 skipped.

Windows 7 SP1
getaddrinfo: 847 tests executed (0 marked as todo, 10 failures), 0 skipped.
```
**_Note:_** I don't have Windows 2003 virtual machine at the moment, so I didn't fixed existing test failures.