### PR TITLE
[NTOS:KE] Rename some locking functions to reflect the IRQL changes

### DIFF
--- a/ntoskrnl/ke/gate.c
+++ b/ntoskrnl/ke/gate.c
@@ -44,7 +44,7 @@ KeWaitForGate(IN PKGATE Gate,
     do
     {
         /* Acquire the APC lock */
-        KiAcquireApcLock(Thread, &ApcLock);
+        KiAcquireApcLockRaiseToSynch(Thread, &ApcLock);
 
         /* Check if a kernel APC is pending and we're below APC_LEVEL */
         if ((Thread->ApcState.KernelApcPending) &&
@@ -58,7 +58,7 @@ KeWaitForGate(IN PKGATE Gate,
         {
             /* Check if we have a queue and lock the dispatcher if so */
             Queue = Thread->Queue;
-            if (Queue) KiAcquireDispatcherLockAtDpcLevel();
+            if (Queue) KiAcquireDispatcherLockAtSynchLevel();
 
             /* Lock the thread */
             KiAcquireThreadLock(Thread);
@@ -77,7 +77,7 @@ KeWaitForGate(IN PKGATE Gate,
                 KiReleaseThreadLock(Thread);
 
                 /* Release the gate lock */
-                if (Queue) KiReleaseDispatcherLockFromDpcLevel();
+                if (Queue) KiReleaseDispatcherLockFromSynchLevel();
 
                 /* Release the APC lock and return */
                 KiReleaseApcLock(&ApcLock);
@@ -116,11 +116,11 @@ KeWaitForGate(IN PKGATE Gate,
                 KiActivateWaiterQueue(Queue);
 
                 /* Release the dispatcher lock */
-                KiReleaseDispatcherLockFromDpcLevel();
+                KiReleaseDispatcherLockFromSynchLevel();
             }
 
             /* Release the APC lock but stay at DPC level */
-            KiReleaseApcLockFromDpcLevel(&ApcLock);
+            KiReleaseApcLockFromSynchLevel(&ApcLock);
 
             /* Find a new thread to run */
             Status = KiSwapThread(Thread, KeGetCurrentPrcb());
@@ -203,7 +203,7 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
             if (WaitThread->Queue)
             {
                 /* Acquire the dispatcher lock */
-                KiAcquireDispatcherLockAtDpcLevel();
+                KiAcquireDispatcherLockAtSynchLevel();
 
                 /* Check if we still have one */
                 if (WaitThread->Queue)
@@ -213,7 +213,7 @@ KeSignalGateBoostPriority(IN PKGATE Gate)
                 }
 
                 /* Release lock */
-                KiReleaseDispatcherLockFromDpcLevel();
+                KiReleaseDispatcherLockFromSynchLevel();
             }
 
             /* Make the thread ready */

--- a/ntoskrnl/ke/queue.c
+++ b/ntoskrnl/ke/queue.c
@@ -265,7 +265,7 @@ KeRemoveQueue(IN PKQUEUE Queue,
         /* Raise IRQL to synch, prepare the wait, then lock the database */
         Thread->WaitIrql = KeRaiseIrqlToSynchLevel();
         KxQueueThreadWait();
-        KiAcquireDispatcherLockAtDpcLevel();
+        KiAcquireDispatcherLockAtSynchLevel();
     }
 
     /*
@@ -339,7 +339,7 @@ KeRemoveQueue(IN PKQUEUE Queue,
             {
                 /* Increment the count and unlock the dispatcher */
                 Queue->CurrentCount++;
-                KiReleaseDispatcherLockFromDpcLevel();
+                KiReleaseDispatcherLockFromSynchLevel();
                 KiExitDispatcher(Thread->WaitIrql);
             }
             else
@@ -394,7 +394,7 @@ KeRemoveQueue(IN PKQUEUE Queue,
                 else
                 {
                     /* Otherwise, unlock the dispatcher */
-                    KiReleaseDispatcherLockFromDpcLevel();
+                    KiReleaseDispatcherLockFromSynchLevel();
                 }
 
                 /* Do the actual swap */
@@ -419,13 +419,13 @@ KeRemoveQueue(IN PKQUEUE Queue,
             /* Start another wait */
             Thread->WaitIrql = KeRaiseIrqlToSynchLevel();
             KxQueueThreadWait();
-            KiAcquireDispatcherLockAtDpcLevel();
+            KiAcquireDispatcherLockAtSynchLevel();
             Queue->CurrentCount--;
         }
     }
 
     /* Unlock Database and return */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
     KiExitDispatcher(Thread->WaitIrql);
     return QueueEntry;
 }
@@ -477,7 +477,7 @@ KeRundownQueue(IN PKQUEUE Queue)
     }
 
     /* Release the dispatcher lock */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
  
     /* Exit the dispatcher and return the first entry (if any) */
     KiExitDispatcher(OldIrql);

--- a/ntoskrnl/ke/timerobj.c
+++ b/ntoskrnl/ke/timerobj.c
@@ -184,13 +184,13 @@ KiCompleteTimer(IN PKTIMER Timer,
     KiReleaseTimerLock(LockQueue);
 
     /* Acquire dispatcher lock */
-    KiAcquireDispatcherLockAtDpcLevel();
+    KiAcquireDispatcherLockAtSynchLevel();
 
     /* Signal the timer if it's still on our list */
     if (!IsListEmpty(&ListHead)) RequestInterrupt = KiSignalTimer(Timer);
 
     /* Release the dispatcher lock */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
 
     /* Request a DPC if needed */
     if (RequestInterrupt) HalRequestSoftwareInterrupt(DISPATCH_LEVEL);
@@ -321,7 +321,7 @@ KeSetTimerEx(IN OUT PKTIMER Timer,
         RequestInterrupt = KiSignalTimer(Timer);
         
         /* Release the dispatcher lock */
-        KiReleaseDispatcherLockFromDpcLevel();
+        KiReleaseDispatcherLockFromSynchLevel();
         
         /* Check if we need to do an interrupt */
         if (RequestInterrupt) HalRequestSoftwareInterrupt(DISPATCH_LEVEL);        

--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -386,7 +386,7 @@ WaitStart:
         /* Setup a new wait */
         Thread->WaitIrql = KeRaiseIrqlToSynchLevel();
         KxDelayThreadWait();
-        KiAcquireDispatcherLockAtDpcLevel();
+        KiAcquireDispatcherLockAtSynchLevel();
     }
 
     /* We're done! */
@@ -403,7 +403,7 @@ NoWait:
     }
 
     /* Unlock the dispatcher and adjust the quantum for a no-wait */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
     KiAdjustQuantumThread(Thread);
     return STATUS_SUCCESS;
 }
@@ -540,7 +540,7 @@ KeWaitForSingleObject(IN PVOID Object,
             else
             {
                 /* Otherwise, unlock the dispatcher */
-                KiReleaseDispatcherLockFromDpcLevel();
+                KiReleaseDispatcherLockFromSynchLevel();
             }
 
             /* Do the actual swap */
@@ -562,7 +562,7 @@ WaitStart:
         /* Setup a new wait */
         Thread->WaitIrql = KeRaiseIrqlToSynchLevel();
         KxSingleThreadWait();
-        KiAcquireDispatcherLockAtDpcLevel();
+        KiAcquireDispatcherLockAtSynchLevel();
     }
 
     /* Wait complete */
@@ -571,7 +571,7 @@ WaitStart:
 
 DontWait:
     /* Release dispatcher lock but maintain high IRQL */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
 
     /* Adjust the Quantum and return the wait status */
     KiAdjustQuantumThread(Thread);
@@ -835,7 +835,7 @@ KeWaitForMultipleObjects(IN ULONG Count,
             else
             {
                 /* Otherwise, unlock the dispatcher */
-                KiReleaseDispatcherLockFromDpcLevel();
+                KiReleaseDispatcherLockFromSynchLevel();
             }
 
             /* Swap the thread */
@@ -858,7 +858,7 @@ WaitStart:
         /* Setup a new wait */
         Thread->WaitIrql = KeRaiseIrqlToSynchLevel();
         KxMultiThreadWait();
-        KiAcquireDispatcherLockAtDpcLevel();
+        KiAcquireDispatcherLockAtSynchLevel();
     }
 
     /* We are done */
@@ -867,7 +867,7 @@ WaitStart:
 
 DontWait:
     /* Release dispatcher lock but maintain high IRQL */
-    KiReleaseDispatcherLockFromDpcLevel();
+    KiReleaseDispatcherLockFromSynchLevel();
 
     /* Adjust the Quantum and return the wait status */
     KiAdjustQuantumThread(Thread);

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -2576,7 +2576,7 @@ MmSetExecuteOptions(IN ULONG ExecuteOptions)
     }
 
     /* Change the NX state in the process lock */
-    KiAcquireProcessLock(CurrentProcess, &ProcessLock);
+    KiAcquireProcessLockRaiseToSynch(CurrentProcess, &ProcessLock);
 
     /* Don't change anything if the permanent flag was set */
     if (!CurrentProcess->Flags.Permanent)


### PR DESCRIPTION
* KiAcquireApcLock -> KiAcquireApcLockRaiseToSynch
* KiAcquireApcLockAtDpcLevel -> KiAcquireApcLockAtSynchLevel
* KiReleaseApcLockFromDpcLevel -> KiReleaseApcLockFromSynchLevel
* KiAcquireApcLockAtApcLevel -> KiAcquireApcLockRaiseToDpc
* KiAcquireProcessLock -> KiAcquireProcessLockRaiseToSynch
* KiReleaseProcessLockFromDpcLevel -> KiReleaseProcessLockFromSynchLevel
* KiAcquireDispatcherLockAtDpcLevel -> KiAcquireDispatcherLockAtSynchLevel
* KiReleaseDispatcherLockFromDpcLevel -> KiReleaseDispatcherLockFromSynchLevel
* Add some ASSERTs
