### PR TITLE
[KS] KsQueryInformationFile(): Fallback to IRP if FastIO failed. CORE-16618

### DIFF
--- a/drivers/ksfilter/ks/irp.c
+++ b/drivers/ksfilter/ks/irp.c
@@ -367,17 +367,31 @@ KsQueryInformationFile(
         if (FileInformationClass == FileBasicInformation)
         {
             /* use FastIoQueryBasicInfo routine */
-            if (FastIoDispatch->FastIoQueryBasicInfo)
+            if (FastIoDispatch->FastIoQueryBasicInfo != NULL &&
+                FastIoDispatch->FastIoQueryBasicInfo(
+                  FileObject,
+                  TRUE,
+                  (PFILE_BASIC_INFORMATION)FileInformation,
+                  &IoStatusBlock,
+                  DeviceObject))
             {
-                return FastIoDispatch->FastIoQueryBasicInfo(FileObject, TRUE, (PFILE_BASIC_INFORMATION)FileInformation, &IoStatusBlock, DeviceObject);
+                /* request was handled */
+                return IoStatusBlock.Status;
             }
         }
         else if (FileInformationClass == FileStandardInformation)
         {
             /* use FastIoQueryStandardInfo routine */
-            if (FastIoDispatch->FastIoQueryStandardInfo)
+            if (FastIoDispatch->FastIoQueryStandardInfo != NULL &&
+                FastIoDispatch->FastIoQueryStandardInfo(
+                  FileObject,
+                  TRUE,
+                  (PFILE_STANDARD_INFORMATION)FileInformation,
+                  &IoStatusBlock,
+                  DeviceObject))
             {
-                return FastIoDispatch->FastIoQueryStandardInfo(FileObject, TRUE, (PFILE_STANDARD_INFORMATION)FileInformation, &IoStatusBlock, DeviceObject);
+                /* request was handled */
+                return IoStatusBlock.Status;
             }
         }
     }


### PR DESCRIPTION
## Purpose

Or, if it succeeded, return the actual NTSTATUS, not an unrelated BOOLEAN.

JIRA issue: [CORE-16618](https://jira.reactos.org/browse/CORE-16618)

## Proposed changes

I adapted code from Read/Write functions.

## TODO

- [X] Is `NT_SUCCESS(IoStatusBlock->Status)` actually wanted, for all 3 functions?
Some similar codes have it, some others do not...
