### PR TITLE
[UDFS] UDFCommonCreate uninitialized var use. CORE-16174

### DIFF
--- a/drivers/filesystems/udfs/create.cpp
+++ b/drivers/filesystems/udfs/create.cpp
@@ -1143,6 +1143,7 @@ op_vol_accs_dnd:
                     // Only say ..CK OFF !!!!
                     if(RC == STATUS_OBJECT_NAME_NOT_FOUND)
                         RC = STATUS_OBJECT_PATH_NOT_FOUND;
+                    ReturnedInformation = FILE_DOES_NOT_EXIST;
                     try_return(RC);
                 }
 


### PR DESCRIPTION
## Purpose

The issue was the use of an uninitialized variable **Returnedinformation** in the UDFS driver. The folder traversal method tries to traverse into a file which is not possible. So it returns an error when it tries to do so. But we **haven't initialized Returnedinformation** anywhere. In the next call, we assign a new variable with the value of  **Returnedinformation** which has not been initialized yet. Hence we can initialize the value before returning. The reason I went with setting the value of it as **FILE_DOES_NOT_EXIST** because of the error which closely links to it.

JIRA issue: [CORE-16174](https://jira.reactos.org/browse/CORE-16174)

## Proposed changes
Initialize **Returninformation** with the error value before returning. 

The error value I'm using is **FILE_DOES_NOT_EXIST**
