### PR TITLE
[WIN32SS][WINSRV] Fullwidth character handling Part 2

### DIFF
--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -934,12 +934,13 @@ ConDrvReadConsoleOutputString(IN PCONSOLE Console,
 }
 
 static NTSTATUS FASTCALL
-IntWriteConsoleOutputStringAscii(IN PCONSOLE Console,
-                                 IN PTEXTMODE_SCREEN_BUFFER Buffer,
-                                 IN PVOID StringBuffer,
-                                 IN ULONG NumCodesToWrite,
-                                 IN PCOORD WriteCoord,
-                                 OUT PULONG NumCodesWritten OPTIONAL)
+IntWriteConsoleOutputStringAscii(
+    IN PCONSOLE Console,
+    IN PTEXTMODE_SCREEN_BUFFER Buffer,
+    IN PVOID StringBuffer,
+    IN ULONG NumCodesToWrite,
+    IN PCOORD WriteCoord,
+    OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     LPBYTE WriteBuffer;
@@ -952,18 +953,13 @@ IntWriteConsoleOutputStringAscii(IN PCONSOLE Console,
         goto Cleanup;
 
     /* Convert the ASCII string into Unicode before writing it to the console */
-    Length = MultiByteToWideChar(Console->OutputCodePage, 0,
-                                 (PCHAR)StringBuffer,
-                                 NumCodesToWrite,
-                                 NULL, 0);
+    Length = MultiByteToWideChar(Console->OutputCodePage, 0, (PCHAR)StringBuffer, NumCodesToWrite, NULL, 0);
     tmpString = RtlAllocateHeap(RtlGetProcessHeap(), 0, Length * sizeof(WCHAR));
     if (tmpString)
     {
         WriteBuffer = (LPBYTE)tmpString;
-        MultiByteToWideChar(Console->OutputCodePage, 0,
-                            (PCHAR)StringBuffer,
-                            NumCodesToWrite,
-                            (PWCHAR)WriteBuffer, Length);
+        MultiByteToWideChar(
+            Console->OutputCodePage, 0, (PCHAR)StringBuffer, NumCodesToWrite, (PWCHAR)WriteBuffer, Length);
     }
     else
     {
@@ -993,8 +989,7 @@ IntWriteConsoleOutputStringAscii(IN PCONSOLE Console,
         }
 
         /* For Chinese, Japanese and Korean */
-        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
-            mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
+        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 && mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
             /* the leading byte */
             Ptr->Attributes = Buffer->ScreenDefaultAttrib;
@@ -1028,12 +1023,13 @@ Cleanup:
 }
 
 static NTSTATUS FASTCALL
-IntWriteConsoleOutputStringUnicode(IN PCONSOLE Console,
-                                   IN PTEXTMODE_SCREEN_BUFFER Buffer,
-                                   IN PVOID StringBuffer,
-                                   IN ULONG NumCodesToWrite,
-                                   IN PCOORD WriteCoord,
-                                   OUT PULONG NumCodesWritten OPTIONAL)
+IntWriteConsoleOutputStringUnicode(
+    IN PCONSOLE Console,
+    IN PTEXTMODE_SCREEN_BUFFER Buffer,
+    IN PVOID StringBuffer,
+    IN ULONG NumCodesToWrite,
+    IN PCOORD WriteCoord,
+    OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     LPBYTE WriteBuffer = (LPBYTE)StringBuffer;
@@ -1067,8 +1063,7 @@ IntWriteConsoleOutputStringUnicode(IN PCONSOLE Console,
         }
 
         /* For Chinese, Japanese and Korean */
-        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
-            mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
+        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 && mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
             /* the leading byte */
             Ptr->Attributes = Buffer->ScreenDefaultAttrib;
@@ -1100,12 +1095,13 @@ Cleanup:
 }
 
 static NTSTATUS FASTCALL
-IntWriteConsoleOutputStringAttribute(IN PCONSOLE Console,
-                                     IN PTEXTMODE_SCREEN_BUFFER Buffer,
-                                     IN PVOID StringBuffer,
-                                     IN ULONG NumCodesToWrite,
-                                     IN PCOORD WriteCoord,
-                                     OUT PULONG NumCodesWritten OPTIONAL)
+IntWriteConsoleOutputStringAttribute(
+    IN PCONSOLE Console,
+    IN PTEXTMODE_SCREEN_BUFFER Buffer,
+    IN PVOID StringBuffer,
+    IN ULONG NumCodesToWrite,
+    IN PCOORD WriteCoord,
+    OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     LPBYTE WriteBuffer = (LPBYTE)StringBuffer;
@@ -1145,14 +1141,14 @@ Cleanup:
 }
 
 NTSTATUS NTAPI
-ConDrvWriteConsoleOutputString(IN PCONSOLE Console,
-                               IN PTEXTMODE_SCREEN_BUFFER Buffer,
-                               IN CODE_TYPE CodeType,
-                               IN PVOID StringBuffer,
-                               IN ULONG NumCodesToWrite,
-                               IN PCOORD WriteCoord,
-                               // OUT PCOORD EndCoord,
-                               OUT PULONG NumCodesWritten OPTIONAL)
+ConDrvWriteConsoleOutputString(
+    IN PCONSOLE Console,
+    IN PTEXTMODE_SCREEN_BUFFER Buffer,
+    IN CODE_TYPE CodeType,
+    IN PVOID StringBuffer,
+    IN ULONG NumCodesToWrite,
+    IN PCOORD WriteCoord,
+    OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status;
     SMALL_RECT UpdateRect;
@@ -1172,18 +1168,18 @@ ConDrvWriteConsoleOutputString(IN PCONSOLE Console,
     switch (CodeType)
     {
         case CODE_ASCII:
-            Status = IntWriteConsoleOutputStringAscii(Console, Buffer, StringBuffer,
-                NumCodesToWrite, WriteCoord, NumCodesWritten);
+            Status = IntWriteConsoleOutputStringAscii(
+                Console, Buffer, StringBuffer, NumCodesToWrite, WriteCoord, NumCodesWritten);
             break;
 
         case CODE_UNICODE:
-            Status = IntWriteConsoleOutputStringUnicode(Console, Buffer, StringBuffer,
-                NumCodesToWrite, WriteCoord, NumCodesWritten);
+            Status = IntWriteConsoleOutputStringUnicode(
+                Console, Buffer, StringBuffer, NumCodesToWrite, WriteCoord, NumCodesWritten);
             break;
 
         case CODE_ATTRIBUTE:
-            Status = IntWriteConsoleOutputStringAttribute(Console, Buffer, StringBuffer,
-                NumCodesToWrite, WriteCoord, NumCodesWritten);
+            Status = IntWriteConsoleOutputStringAttribute(
+                Console, Buffer, StringBuffer, NumCodesToWrite, WriteCoord, NumCodesWritten);
             break;
 
         default:

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -953,13 +953,18 @@ IntWriteConsoleOutputStringAscii(
         goto Cleanup;
 
     /* Convert the ASCII string into Unicode before writing it to the console */
-    Length = MultiByteToWideChar(Console->OutputCodePage, 0, (PCHAR)StringBuffer, NumCodesToWrite, NULL, 0);
+    Length = MultiByteToWideChar(Console->OutputCodePage, 0,
+                                 (PCHAR)StringBuffer,
+                                 NumCodesToWrite,
+                                 NULL, 0);
     tmpString = RtlAllocateHeap(RtlGetProcessHeap(), 0, Length * sizeof(WCHAR));
     if (tmpString)
     {
         WriteBuffer = (LPBYTE)tmpString;
-        MultiByteToWideChar(
-            Console->OutputCodePage, 0, (PCHAR)StringBuffer, NumCodesToWrite, (PWCHAR)WriteBuffer, Length);
+        MultiByteToWideChar(Console->OutputCodePage, 0,
+                            (PCHAR)StringBuffer,
+                            NumCodesToWrite,
+                            (PWCHAR)WriteBuffer, Length);
     }
     else
     {
@@ -989,7 +994,8 @@ IntWriteConsoleOutputStringAscii(
         }
 
         /* For Chinese, Japanese and Korean */
-        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 && mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
+        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
+            mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
             /* the leading byte */
             Ptr->Attributes = Buffer->ScreenDefaultAttrib;
@@ -1063,7 +1069,8 @@ IntWriteConsoleOutputStringUnicode(
         }
 
         /* For Chinese, Japanese and Korean */
-        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 && mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
+        if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
+            mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
             /* the leading byte */
             Ptr->Attributes = Buffer->ScreenDefaultAttrib;

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -1037,9 +1037,9 @@ IntWriteConsoleOutputStringAscii(
         return STATUS_NO_MEMORY;
 
     MultiByteToWideChar(Console->OutputCodePage, 0,
-                        (PCHAR)StringBuffer,
+                        StringBuffer,
                         NumCodesToWrite,
-                        (PWCHAR)tmpString, Length);
+                        tmpString, Length);
 
     Status = IntWriteConsoleOutputStringUnicode(Console,
                                                 Buffer,

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -1032,7 +1032,7 @@ IntWriteConsoleOutputStringAscii(
                                  StringBuffer,
                                  NumCodesToWrite,
                                  NULL, 0);
-    tmpString = RtlAllocateHeap(RtlGetProcessHeap(), 0, Length * sizeof(WCHAR));
+    tmpString = ConsoleAllocHeap(0, Length * sizeof(WCHAR));
     if (!tmpString)
         return STATUS_NO_MEMORY;
 
@@ -1047,8 +1047,7 @@ IntWriteConsoleOutputStringAscii(
                                                 Length,
                                                 WriteCoord,
                                                 NumCodesWritten);
-
-    RtlFreeHeap(RtlGetProcessHeap(), 0, tmpString);
+    ConsoleFreeHeap(tmpString);
     return Status;
 }
 

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -943,7 +943,7 @@ IntWriteConsoleOutputStringUnicode(
     OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    LPWSTR WriteBuffer = StringBuffer;
+    PWCHAR WriteBuffer = StringBuffer;
     ULONG i, X, Y, Length;
     PCHAR_INFO Ptr;
     BOOL bCJK = Console->IsCJK;
@@ -1016,7 +1016,7 @@ IntWriteConsoleOutputStringAscii(
     OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status;
-    LPWSTR tmpString;
+    PWCHAR tmpString;
     ULONG Length;
 
     if (!StringBuffer)

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -1043,7 +1043,7 @@ IntWriteConsoleOutputStringUnicode(
     PCHAR_INFO Ptr;
     BOOL bCJK = Console->IsCJK;
 
-    if (!WriteBuffer)
+    if (!StringBuffer)
         goto Cleanup;
 
     X = WriteCoord->X;
@@ -1115,7 +1115,7 @@ IntWriteConsoleOutputStringAttribute(
     ULONG i, X, Y, Length;
     PCHAR_INFO Ptr;
 
-    if (!WriteBuffer)
+    if (!StringBuffer)
         goto Cleanup;
 
     X = WriteCoord->X;

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -933,7 +933,7 @@ ConDrvReadConsoleOutputString(IN PCONSOLE Console,
     }
 }
 
-static NTSTATUS FASTCALL
+static NTSTATUS
 IntWriteConsoleOutputStringAscii(
     IN PCONSOLE Console,
     IN PTEXTMODE_SCREEN_BUFFER Buffer,
@@ -1028,7 +1028,7 @@ Cleanup:
     return Status;
 }
 
-static NTSTATUS FASTCALL
+static NTSTATUS
 IntWriteConsoleOutputStringUnicode(
     IN PCONSOLE Console,
     IN PTEXTMODE_SCREEN_BUFFER Buffer,
@@ -1101,7 +1101,7 @@ Cleanup:
     return Status;
 }
 
-static NTSTATUS FASTCALL
+static NTSTATUS
 IntWriteConsoleOutputStringAttribute(
     IN PCONSOLE Console,
     IN PTEXTMODE_SCREEN_BUFFER Buffer,

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -977,9 +977,10 @@ IntWriteConsoleOutputStringUnicode(
         if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
             mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
+            /* A full-width character cannot cross a line boundary */
             if (X == Buffer->ScreenBufferSize.X - 1)
             {
-                /* new line */
+                /* go to next line */
                 X = 0;
                 ++Y;
                 if (Y == Buffer->ScreenBufferSize.Y)

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -1061,7 +1061,7 @@ IntWriteConsoleOutputStringAttribute(
     OUT PULONG NumCodesWritten OPTIONAL)
 {
     NTSTATUS Status = STATUS_SUCCESS;
-    WORD *WriteBuffer = StringBuffer;
+    PWORD WriteBuffer = StringBuffer;
     ULONG i, X, Y, Length;
     PCHAR_INFO Ptr;
 

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -977,6 +977,18 @@ IntWriteConsoleOutputStringUnicode(
         if (bCJK && Ptr->Char.UnicodeChar >= 0x80 &&
             mk_wcwidth_cjk(Ptr->Char.UnicodeChar) == 2)
         {
+            if (X == Buffer->ScreenBufferSize.X - 1)
+            {
+                /* new line */
+                X = 0;
+                ++Y;
+                if (Y == Buffer->ScreenBufferSize.Y)
+                {
+                    Y = 0;
+                }
+                Ptr = ConioCoordToPointer(Buffer, X, Y);
+            }
+
             /* the leading byte */
             Ptr->Attributes = Buffer->ScreenDefaultAttrib;
             Ptr->Attributes |= COMMON_LVB_LEADING_BYTE;

--- a/win32ss/user/winsrv/consrv/condrv/text.c
+++ b/win32ss/user/winsrv/consrv/condrv/text.c
@@ -735,7 +735,7 @@ IntReadConsoleOutputStringAscii(IN PCONSOLE Console,
     SHORT Ypos = (ReadCoord->Y + Buffer->VirtualY) % Buffer->ScreenBufferSize.Y;
     ULONG i;
     PCHAR_INFO Ptr;
-    BOOL bCJK = Console->IsCJK;
+    BOOLEAN bCJK = Console->IsCJK;
 
     for (i = 0; i < NumCodesToRead; ++i)
     {
@@ -792,7 +792,7 @@ IntReadConsoleOutputStringUnicode(IN PCONSOLE Console,
     SHORT Ypos = (ReadCoord->Y + Buffer->VirtualY) % Buffer->ScreenBufferSize.Y;
     ULONG i, nNumChars = 0;
     PCHAR_INFO Ptr;
-    BOOL bCJK = Console->IsCJK;
+    BOOLEAN bCJK = Console->IsCJK;
 
     for (i = 0; i < NumCodesToRead; ++i, ++nNumChars)
     {
@@ -946,7 +946,7 @@ IntWriteConsoleOutputStringUnicode(
     PWCHAR WriteBuffer = StringBuffer;
     ULONG i, X, Y, Length;
     PCHAR_INFO Ptr;
-    BOOL bCJK = Console->IsCJK;
+    BOOLEAN bCJK = Console->IsCJK;
 
     if (!StringBuffer)
         goto Cleanup;
@@ -1165,7 +1165,7 @@ ConDrvFillConsoleOutput(IN PCONSOLE Console,
 {
     ULONG X, Y, i;
     PCHAR_INFO Ptr;
-    BOOL bLead, bFullwidth;
+    BOOLEAN bLead, bFullwidth;
 
     if (Console == NULL || Buffer == NULL || WriteCoord == NULL)
     {

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -991,17 +991,8 @@ OnPaint(PGUI_CONSOLE_DATA GuiData)
         /* Compose the current screen-buffer on-memory */
         if (GetType(ActiveBuffer) == TEXTMODE_BUFFER)
         {
-            if (IsCJKCodePage(ActiveBuffer->Header.Console->OutputCodePage))
-            {
-                /* For Chinese, Japanese and Korean */
-                GuiPaintTextModeBufferCJK((PTEXTMODE_SCREEN_BUFFER)ActiveBuffer,
-                                          GuiData, &ps.rcPaint, &rcPaint);
-            }
-            else
-            {
-                GuiPaintTextModeBuffer((PTEXTMODE_SCREEN_BUFFER)ActiveBuffer,
-                                       GuiData, &ps.rcPaint, &rcPaint);
-            }
+            GuiPaintTextModeBuffer((PTEXTMODE_SCREEN_BUFFER)ActiveBuffer,
+                                   GuiData, &ps.rcPaint, &rcPaint);
         }
         else /* if (GetType(ActiveBuffer) == GRAPHICS_BUFFER) */
         {

--- a/win32ss/user/winsrv/consrv/frontends/gui/guiterm.h
+++ b/win32ss/user/winsrv/consrv/frontends/gui/guiterm.h
@@ -121,11 +121,4 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
                        PRECT rcView,
                        PRECT rcFramebuffer);
 
-/* For Chinese, Japanese and Korean */
-VOID
-GuiPaintTextModeBufferCJK(PTEXTMODE_SCREEN_BUFFER Buffer,
-                          PGUI_CONSOLE_DATA GuiData,
-                          PRECT rcView,
-                          PRECT rcFramebuffer);
-
 /* EOF */

--- a/win32ss/user/winsrv/consrv/frontends/gui/text.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/text.c
@@ -473,7 +473,7 @@ GuiPaintTextModeBuffer(PTEXTMODE_SCREEN_BUFFER Buffer,
                             IsUnderline = !!(LastAttribute & COMMON_LVB_UNDERSCORE);
                             /* Select the new font */
                             NewFont = GuiData->Font[IsUnderline ? FONT_BOLD : FONT_NORMAL];
-                            /* OldFont = */ SelectObject(GuiData->hMemDC, NewFont);
+                            SelectObject(GuiData->hMemDC, NewFont);
                         }
                     }
                 }

--- a/win32ss/user/winsrv/consrv/frontends/terminal.c
+++ b/win32ss/user/winsrv/consrv/frontends/terminal.c
@@ -558,6 +558,17 @@ ConioWriteConsole(PFRONTEND FrontEnd,
                     }
                     Ptr = ConioCoordToPointer(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y);
                     Ptr->Char.UnicodeChar = L' ';
+
+                    if (Ptr->Attributes & COMMON_LVB_TRAILING_BYTE)
+                    {
+                        /* Delete a full-width character */
+                        Ptr->Attributes  = Buff->ScreenDefaultAttrib;
+                        if (Buff->CursorPosition.X > 0)
+                            Buff->CursorPosition.X--;
+                        Ptr = ConioCoordToPointer(Buff, Buff->CursorPosition.X, Buff->CursorPosition.Y);
+                        Ptr->Char.UnicodeChar = L' ';
+                    }
+
                     Ptr->Attributes  = Buff->ScreenDefaultAttrib;
                     UpdateRect.Left  = min(UpdateRect.Left, Buff->CursorPosition.X);
                     UpdateRect.Right = max(UpdateRect.Right, Buff->CursorPosition.X);


### PR DESCRIPTION
## Purpose

Follow-up of #2231. Also fix `FillConsoleOutputAttribute`, `WriteConsoleOutputCharacterW` and `WriteConsoleOutputAttribute` functions.
JIRA issue: [CORE-12451](https://jira.reactos.org/browse/CORE-12451)

BEFORE (Japanese):
![before](https://user-images.githubusercontent.com/2107452/72152293-e5916c00-33ed-11ea-8a37-396764a372ee.png)
AFTER (Japanese):
![after](https://user-images.githubusercontent.com/2107452/72152292-e5916c00-33ed-11ea-832c-cad2ec0dba4a.png)
It's successful.

BEFORE (Japanese with ReactOS JPN Package from Rapps):
![before-2](https://user-images.githubusercontent.com/2107452/72152309-f215c480-33ed-11ea-8448-3b4bcd943ff1.png)
AFTER (Japanese with ReactOS JPN Package from Rapps):
![after-2](https://user-images.githubusercontent.com/2107452/72152310-f2ae5b00-33ed-11ea-8f9c-ad8955f663dc.png)
It correctly handles Shift_JIS encoding.