### PR TITLE
[MSXML3|OLE32|RSAENH] Make some COM Exports private. 

### DIFF
--- a/dll/win32/msxml3/msxml3.spec
+++ b/dll/win32/msxml3/msxml3.spec
@@ -7,6 +7,6 @@
 12 stub MSXML3_12
 
 @ stdcall -private DllCanUnloadNow()
-@ stdcall DllGetClassObject(ptr ptr ptr)
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
 @ stdcall -private DllRegisterServer()
 @ stdcall -private DllUnregisterServer()

--- a/dll/win32/ole32/ole32.spec
+++ b/dll/win32/ole32/ole32.spec
@@ -134,7 +134,7 @@
 @ stdcall CreateStreamOnHGlobal(ptr long ptr)
 # DcomChannelSetHResult
 @ stdcall DllDebugObjectRPCHook(long ptr)
-@ stdcall DllGetClassObject(ptr ptr ptr)
+@ stdcall -private DllGetClassObject(ptr ptr ptr)
 @ stub DllGetClassObjectWOW
 @ stdcall -private DllRegisterServer()
 @ stdcall DoDragDrop(ptr ptr long ptr)

--- a/dll/win32/rsaenh/rsaenh.spec
+++ b/dll/win32/rsaenh/rsaenh.spec
@@ -23,5 +23,5 @@
 @ stdcall CPSetProvParam(long long ptr long) RSAENH_CPSetProvParam
 @ stdcall CPSignHash(long long long wstr long ptr ptr) RSAENH_CPSignHash
 @ stdcall CPVerifySignature(long long ptr long long wstr long) RSAENH_CPVerifySignature
-@ stdcall DllRegisterServer()
-@ stdcall DllUnregisterServer()
+@ stdcall -private DllRegisterServer()
+@ stdcall -private DllUnregisterServer()


### PR DESCRIPTION
This fixes some compiler warnings on GCC.

## Purpose

Building with RosBE 2.1.6 on Win 10 throws me the following compiler warnings:

> WARNING: C:/Users/gonzo/Projekte/reactos/dll/win32/rsaenh/rsaenh.spec line 26: Exported symbol 'DllRegisterServer' should be PRIVATE
> WARNING: C:/Users/gonzo/Projekte/reactos/dll/win32/rsaenh/rsaenh.spec line 27: Exported symbol 'DllUnregisterServer' should be PRIVATE
> 
> WARNING: C:/Users/gonzo/Projekte/reactos/dll/win32/msxml3/msxml3.spec line 10: Exported symbol 'DllGetClassObject' should be PRIVATE
> 
> WARNING: C:/Users/gonzo/Projekte/reactos/dll/win32/ole32/ole32.spec line 137: Exported symbol 'DllGetClassObject' should be PRIVATE

Because I do not know if there is a reason, why those exports are not private, I send this PR.
