### PR TITLE
[WIN32K] Don't trust the BITMAPINFOHEADER size

### DIFF
--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1288,7 +1288,7 @@ NtGdiStretchDIBitsInternal(
                                BitmapFormat(pbmi->bmiHeader.biBitCount,
                                             pbmi->bmiHeader.biCompression),
                                pbmi->bmiHeader.biHeight < 0 ? BMF_TOPDOWN : 0,
-                               pbmi->bmiHeader.biSizeImage,
+                               cjMaxBits,
                                pvBits,
                                0);
 


### PR DESCRIPTION

JIRA issue: [CORE-16621](https://jira.reactos.org/browse/CORE-16621)

I am not sure if this is a fix or a hack :)
