### PR TITLE
[HAL][FREELDR] Fix system timer oscillator frequency on a Xbox

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hardware.c
+++ b/boot/freeldr/freeldr/arch/i386/hardware.c
@@ -27,8 +27,13 @@ DBG_DEFAULT_CHANNEL(HWDETECT);
 #define MILLISEC     (10)
 #define PRECISION    (8)
 
+#if defined(SARCH_XBOX)
+#define CLOCK_TICK_RATE 1125000
+#else
+#define CLOCK_TICK_RATE 1193182
+#endif
+
 #define HZ (100)
-#define CLOCK_TICK_RATE (1193182)
 #define LATCH (CLOCK_TICK_RATE / HZ)
 
 static unsigned int delay_count = 1;

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -86,6 +86,9 @@ VOID
 //
 #define GRAPHICS_MODE_12 0x12           /* 80x30	 8x16  640x480	 16/256K */
 
+#if defined(SARCH_XBOX)
+#define PIT_FREQUENCY 1125000
+#else
 //
 // Commonly stated as being 1.19318MHz
 //
@@ -104,6 +107,7 @@ VOID
 // number is quite long.
 //
 #define PIT_FREQUENCY 1193182
+#endif
 
 //
 // These ports are controlled by the i8254 Programmable Interrupt Timer (PIT)

--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -87,13 +87,17 @@ VOID
 #define GRAPHICS_MODE_12 0x12           /* 80x30	 8x16  640x480	 16/256K */
 
 #if defined(SARCH_XBOX)
+//
+// For some unknown reason the PIT of the Xbox is fixed at 1.125000 MHz,
+// which is ~5.7% lower than on the PC.
+//
 #define PIT_FREQUENCY 1125000
 #else
 //
 // Commonly stated as being 1.19318MHz
 //
 // See ISA System Architecture 3rd Edition (Tom Shanley, Don Anderson, John Swindle)
-// P. 471
+// p. 471
 //
 // However, the true value is closer to 1.19318181[...]81MHz since this is 1/3rd
 // of the NTSC color subcarrier frequency which runs at 3.57954545[...]45MHz.


### PR DESCRIPTION
## Purpose

See https://xboxdevwiki.net/Porting_an_Operating_System_to_the_Xbox_HOWTO#Timer_Frequency
Xbox PIT tick rate - 1.125000 MHz. 