### PR TITLE
[FREELDR][XBOXVMP] Check only low 28 bits for framebuffer address

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/xboxvideo.c
+++ b/boot/freeldr/freeldr/arch/i386/xboxvideo.c
@@ -158,7 +158,10 @@ XboxGetFramebufferSize(PVOID Offset)
     {
         TRACE("i = %d, base_addr_low = 0x%p, MemoryMap->length_low = 0x%p\n", i, MemoryMap->base_addr_low, MemoryMap->length_low);
 
-        if (MemoryMap->base_addr_low == (ULONG)Offset && MemoryMap->base_addr_high == 0)
+        /* Framebuffer address offset value is coming from the GPU within
+         * memory mapped I/O address space, so we're comparing only low
+         * 28 bits of the address within actual RAM address space */
+        if (MemoryMap->base_addr_low == ((ULONG)Offset & 0x0FFFFFFF) && MemoryMap->base_addr_high == 0)
         {
             TRACE("Video memory found\n");
             return MemoryMap->length_low;

--- a/win32ss/drivers/miniport/xboxvmp/xboxvmp.c
+++ b/win32ss/drivers/miniport/xboxvmp/xboxvmp.c
@@ -394,6 +394,10 @@ XboxVmpMapVideoMemory(
 
     /* Reuse framebuffer that was set up by firmware */
     FrameBuffer.QuadPart = *((PULONG)((ULONG_PTR)DeviceExtension->VirtControlStart + NV2A_CONTROL_FRAMEBUFFER_ADDRESS_OFFSET));
+    /* Framebuffer address offset value is coming from the GPU within
+     * memory mapped I/O address space, so we're comparing only low
+     * 28 bits of the address within actual RAM address space */
+    FrameBuffer.QuadPart &= 0x0FFFFFFF;
     if (FrameBuffer.QuadPart != 0x3C00000 && FrameBuffer.QuadPart != 0x7C00000)
     {
         /* Check framebuffer address (high 4 MB of either 64 or 128 MB RAM) */
@@ -402,6 +406,7 @@ XboxVmpMapVideoMemory(
     /* Verify that framebuffer address is page-aligned */
     ASSERT(FrameBuffer.QuadPart % PAGE_SIZE == 0);
 
+    /* Return the address back to GPU memory mapped I/O */
     FrameBuffer.QuadPart += DeviceExtension->PhysFrameBufferStart.QuadPart;
     MapInformation->VideoRamBase = RequestedAddress->RequestedVirtualAddress;
     /* FIXME: obtain fb size from firmware somehow (Cromwell reserves high 4 MB of RAM) */


### PR DESCRIPTION
Fixes framebuffer detection on real hardware Xbox.