### PR TITLE
[MSV1_0] dont change original pointers passed to LogonUserEx2

### DIFF
--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1297,6 +1297,8 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
         TRACE("Domain: %wZ\n", &LogonDom);
         TRACE("User: %wZ\n", &LogonUser);
         TRACE("Password: %wZ\n", &LogonPass);
+
+        // TODO: If LogonType == Service, do some extra work using LogonInfo->Password.
     }
     else
     {

--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1485,17 +1485,14 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             }
 
             /* Check if the account expired */
-            if (!(UserInfo->All.UserAccountControl & USER_DONT_EXPIRE_PASSWORD))
+            AccountExpires.LowPart = UserInfo->All.AccountExpires.LowPart;
+            AccountExpires.HighPart = UserInfo->All.AccountExpires.HighPart;
+            if (LogonTime.QuadPart >= AccountExpires.QuadPart)
             {
-                AccountExpires.LowPart = UserInfo->All.AccountExpires.LowPart;
-                AccountExpires.HighPart = UserInfo->All.AccountExpires.HighPart;
-                if (LogonTime.QuadPart >= AccountExpires.QuadPart)
-                {
-                    ERR("Account expired!\n");
-                    *SubStatus = STATUS_ACCOUNT_EXPIRED;
-                    Status = STATUS_ACCOUNT_RESTRICTION;
-                    goto done;
-                }
+                ERR("Account expired!\n");
+                *SubStatus = STATUS_ACCOUNT_EXPIRED;
+                Status = STATUS_ACCOUNT_RESTRICTION;
+                goto done;
             }
 
             /* Check if the password expired */

--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1294,9 +1294,9 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             LogonPass.MaximumLength = 0;
         }
 
-        TRACE("Domain: %.*S\n", LogonDom.Length / sizeof(WCHAR), LogonDom.Buffer);
-        TRACE("User: %.*S\n", LogonUser.Length / sizeof(WCHAR), LogonUser.Buffer);
-        TRACE("Password: %.*S\n", LogonPass.Length / sizeof(WCHAR), LogonPass.Buffer);
+        TRACE("Domain: %wZ\n", &LogonDom);
+        TRACE("User: %wZ\n", &LogonUser);
+        TRACE("Password: %wZ\n", &LogonPass);
     }
     else
     {

--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1294,12 +1294,9 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             LogonPass.MaximumLength = 0;
         }
 
-        TRACE("Domain: %.*S\n",
-            LogonDom.Length / sizeof(WCHAR), LogonDom.Buffer);
-        TRACE("User: %.*S\n",
-            LogonUser.Length / sizeof(WCHAR), LogonUser.Buffer);
-        TRACE("Password: %.*S\n",
-            LogonPass.Length / sizeof(WCHAR), LogonPass.Buffer);
+        TRACE("Domain: %.*S\n", LogonDom.Length / sizeof(WCHAR), LogonDom.Buffer);
+        TRACE("User: %.*S\n", LogonUser.Length / sizeof(WCHAR), LogonUser.Buffer);
+        TRACE("Password: %.*S\n", LogonPass.Length / sizeof(WCHAR), LogonPass.Buffer);
     }
     else
     {
@@ -1608,12 +1605,10 @@ done:
     *AccountName = DispatchTable.AllocateLsaHeap(sizeof(UNICODE_STRING));
     if (*AccountName != NULL)
     {
-        (*AccountName)->Buffer = DispatchTable.AllocateLsaHeap(LogonUser.Length +
-                                                               sizeof(UNICODE_NULL));
+        (*AccountName)->Buffer = DispatchTable.AllocateLsaHeap(LogonUser.Length + sizeof(UNICODE_NULL));
         if ((*AccountName)->Buffer != NULL)
         {
-            (*AccountName)->MaximumLength = LogonUser.Length +
-                                            sizeof(UNICODE_NULL);
+            (*AccountName)->MaximumLength = LogonUser.Length + sizeof(UNICODE_NULL);
             RtlCopyUnicodeString(*AccountName, &LogonUser);
         }
     }
@@ -1622,12 +1617,10 @@ done:
     *AuthenticatingAuthority = DispatchTable.AllocateLsaHeap(sizeof(UNICODE_STRING));
     if (*AuthenticatingAuthority != NULL)
     {
-        (*AuthenticatingAuthority)->Buffer = DispatchTable.AllocateLsaHeap(LogonDom.Length +
-                                                                           sizeof(UNICODE_NULL));
+        (*AuthenticatingAuthority)->Buffer = DispatchTable.AllocateLsaHeap(LogonDom.Length + sizeof(UNICODE_NULL));
         if ((*AuthenticatingAuthority)->Buffer != NULL)
         {
-            (*AuthenticatingAuthority)->MaximumLength = LogonDom.Length +
-                                                        sizeof(UNICODE_NULL);
+            (*AuthenticatingAuthority)->MaximumLength = LogonDom.Length + sizeof(UNICODE_NULL);
             RtlCopyUnicodeString(*AuthenticatingAuthority, &LogonDom);
         }
     }


### PR DESCRIPTION
Old code makes lsass.exe unstable (tested on windows xp).

I discovered this bug during my work on sspi bringup branch.