### PR TITLE
[HALXBOX] Don't use Xbox partitions if MBR signature found

### DIFF
--- a/hal/halx86/xbox/halxbox.h
+++ b/hal/halx86/xbox/halxbox.h
@@ -3,7 +3,7 @@
  * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:         Xbox specific routines
  * COPYRIGHT:       Copyright 2004 Gé van Geldorp (gvg@reactos.com)
- *                  Copyright 2019 Stanislav Motylkov (x86corez@gmail.com)
+ *                  Copyright 2019-2020 Stanislav Motylkov (x86corez@gmail.com)
  *
  * REFERENCES:      https://xboxdevwiki.net/SMBus
  *                  https://github.com/XboxDev/cromwell/blob/master/drivers/pci/i2cio.c
@@ -16,6 +16,8 @@
 
 #include <hal.h>
 #include <ntdddisk.h>
+
+#define TAG_HAL_XBOX 'XlaH'
 
 #define SMB_IO_BASE 0xC000
 

--- a/hal/halx86/xbox/part_xbox.c
+++ b/hal/halx86/xbox/part_xbox.c
@@ -1,16 +1,15 @@
 /*
- * COPYRIGHT:     See COPYING in the top level directory
- * PROJECT:       ReactOS kernel
- * FILE:          hal/halx86/xbox/part_xbox.c
- * PURPOSE:       Xbox specific handling of partition tables
- * PROGRAMMER:    Ge van Geldorp (gvg@reactos.com)
- * UPDATE HISTORY:
- *             2004/12/04: Created
+ * PROJECT:         Xbox HAL
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Xbox specific handling of partition tables
+ * COPYRIGHT:       Copyright 2004 Ge van Geldorp (gvg@reactos.com)
+ *                  Copyright 2020 Stanislav Motylkov (x86corez@gmail.com)
  */
 
 /* INCLUDES *****************************************************************/
 
 #include "halxbox.h"
+#include <internal/tag.h>
 
 #define NDEBUG
 #include <debug.h>
@@ -106,32 +105,51 @@ HalpXboxDeviceHasXboxPartitioning(IN PDEVICE_OBJECT DeviceObject,
     PVOID SectorData;
     LARGE_INTEGER Offset;
     NTSTATUS Status;
+    BOOLEAN HasMBRPartitioning;
 
     DPRINT("HalpXboxDeviceHasXboxPartitioning(%p %lu %p)\n",
            DeviceObject,
            SectorSize,
            HasXboxPartitioning);
 
-    SectorData = ExAllocatePool(PagedPool, SectorSize);
+    SectorData = ExAllocatePoolWithTag(PagedPool, SectorSize, TAG_HAL_XBOX);
     if (!SectorData)
     {
         return STATUS_NO_MEMORY;
+    }
+
+    Offset.QuadPart = 0;
+    Status = HalpXboxReadSector(DeviceObject, SectorSize, &Offset, SectorData);
+    if (!NT_SUCCESS(Status))
+    {
+        goto Cleanup;
+    }
+
+    HasMBRPartitioning = (*((USHORT *)SectorData + (SectorSize / sizeof(USHORT)) - 1) == PARTITION_SIGNATURE);
+    if (HasMBRPartitioning)
+    {
+        *HasXboxPartitioning = FALSE;
+        goto Cleanup;
     }
 
     Offset.QuadPart = XBOX_SIGNATURE_SECTOR * SectorSize;
     Status = HalpXboxReadSector(DeviceObject, SectorSize, &Offset, SectorData);
     if (!NT_SUCCESS(Status))
     {
-        return Status;
+        goto Cleanup;
     }
 
     DPRINT("Signature 0x%02x 0x%02x 0x%02x 0x%02x\n",
            *((UCHAR *) SectorData), *((UCHAR *) SectorData + 1), *((UCHAR *) SectorData + 2), *((UCHAR *) SectorData + 3));
     *HasXboxPartitioning = (XBOX_SIGNATURE == *((ULONG *) SectorData));
-    ExFreePool(SectorData);
-    DPRINT("%s partitioning found\n", *HasXboxPartitioning ? "Xbox" : "MBR");
+Cleanup:
+    ExFreePoolWithTag(SectorData, TAG_HAL_XBOX);
+    if (NT_SUCCESS(Status))
+    {
+        DPRINT("%s partitioning found\n", *HasXboxPartitioning ? "Xbox" : "MBR");
+    }
 
-    return STATUS_SUCCESS;
+    return Status;
 }
 
 static VOID FASTCALL
@@ -202,7 +220,7 @@ HalpXboxIoReadPartitionTable(IN PDEVICE_OBJECT DeviceObject,
                         PagedPool,
                         sizeof(DRIVE_LAYOUT_INFORMATION) +
                         XBOX_PARTITION_COUNT * sizeof(PARTITION_INFORMATION),
-                        'SYSF');
+                        TAG_FILE_SYSTEM);
     if (*PartitionBuffer == NULL)
     {
         return STATUS_NO_MEMORY;

--- a/hal/halx86/xbox/part_xbox.c
+++ b/hal/halx86/xbox/part_xbox.c
@@ -120,7 +120,7 @@ HalpXboxDeviceHasXboxPartitioning(IN PDEVICE_OBJECT DeviceObject,
 
     Offset.QuadPart = XBOX_SIGNATURE_SECTOR * SectorSize;
     Status = HalpXboxReadSector(DeviceObject, SectorSize, &Offset, SectorData);
-    if (! NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         return Status;
     }
@@ -152,12 +152,12 @@ HalpXboxExamineMBR(IN PDEVICE_OBJECT DeviceObject,
     *Buffer = NULL;
 
     Status = HalpXboxDeviceHasXboxPartitioning(DeviceObject, SectorSize, &HasXboxPartitioning);
-    if (! NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         return;
     }
 
-    if (! HasXboxPartitioning)
+    if (!HasXboxPartitioning)
     {
         DPRINT("Delegating to standard MBR code\n");
         NtoskrnlExamineMBR(DeviceObject, SectorSize, MBRTypeIdentifier, Buffer);
@@ -186,12 +186,12 @@ HalpXboxIoReadPartitionTable(IN PDEVICE_OBJECT DeviceObject,
            PartitionBuffer);
 
     Status = HalpXboxDeviceHasXboxPartitioning(DeviceObject, SectorSize, &HasXboxPartitioning);
-    if (! NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         return Status;
     }
 
-    if (! HasXboxPartitioning)
+    if (!HasXboxPartitioning)
     {
         DPRINT("Delegating to standard MBR code\n");
         return NtoskrnlIoReadPartitionTable(DeviceObject, SectorSize,
@@ -203,7 +203,7 @@ HalpXboxIoReadPartitionTable(IN PDEVICE_OBJECT DeviceObject,
                         sizeof(DRIVE_LAYOUT_INFORMATION) +
                         XBOX_PARTITION_COUNT * sizeof(PARTITION_INFORMATION),
                         'SYSF');
-    if (NULL == *PartitionBuffer)
+    if (*PartitionBuffer == NULL)
     {
         return STATUS_NO_MEMORY;
     }
@@ -251,7 +251,7 @@ HalpXboxIoSetPartitionInformation(IN PDEVICE_OBJECT DeviceObject,
            PartitionType);
 
     Status = HalpXboxDeviceHasXboxPartitioning(DeviceObject, SectorSize, &HasXboxPartitioning);
-    if (! NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         return Status;
     }
@@ -286,7 +286,7 @@ HalpXboxIoWritePartitionTable(IN PDEVICE_OBJECT DeviceObject,
            PartitionBuffer);
 
     Status = HalpXboxDeviceHasXboxPartitioning(DeviceObject, SectorSize, &HasXboxPartitioning);
-    if (! NT_SUCCESS(Status))
+    if (!NT_SUCCESS(Status))
     {
         return Status;
     }


### PR DESCRIPTION
Fixes BSOD 0x7B when booting from a HDD that have both MBR and BRFR signatures.