### PR TITLE
Add "Setup in RAM" option to the HybridCD

### DIFF
--- a/boot/bootdata/hybridcd.ini
+++ b/boot/bootdata/hybridcd.ini
@@ -26,6 +26,7 @@ TimeText=Seconds until highlighted choice will be started automatically:
 
 [Operating Systems]
 Setup="Setup"
+Setup_RamDisk="Setup in RAM"
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
 LiveCD_Screen="LiveCD (Screen)"
@@ -37,6 +38,11 @@ LiveCD_RamDisk_Screen="LiveCD in RAM (Screen)"
 [Setup]
 BootType=ReactOSSetup
 SystemPath=\bootcd
+
+[Setup_RamDisk]
+BootType=ReactOSSetup
+SystemPath=ramdisk(0)
+Options=/MININT /RDPATH=bootcd\bootcd.iso /RDEXPORTASCD
 
 [LiveCD]
 BootType=Windows2003

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -472,6 +472,11 @@ function(create_iso_lists)
         FILE ${CMAKE_CURRENT_BINARY_DIR}/livecd.iso
         DESTINATION livecd
         FOR hybridcd)
+		
+    add_cd_file(
+        FILE ${CMAKE_CURRENT_BINARY_DIR}/bootcd.iso
+        DESTINATION bootcd
+        FOR hybridcd)
 
     get_property(_filelist GLOBAL PROPERTY BOOTCD_FILE_LIST)
     string(REPLACE ";" "\n" _filelist "${_filelist}")


### PR DESCRIPTION
Allow to boot setup from RAM disk in HybridCD.