### PR TITLE
[ZIPFLDR] CORE-14934: Extraction is now in its own thread

### DIFF
--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -491,9 +491,6 @@ public:
                         case eNo:
                             break;
                         case eCancel:
-                            WaitForSingleObject(hExtractionMutex, INFINITE);
-                            *bCancel = true;
-                            ReleaseMutex(hExtractionMutex);
                             unzCloseCurrentFile(uf);
                             Close();
                             return false;

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -132,13 +132,10 @@ public:
 
             m_pExtract->AddRef();
 
-            m_hExtractionThread = CreateThread(
-                NULL, 0,
-                &CExtractSettingsPage::ExtractEntry,
-                this,
-                0,
-                NULL);
-
+            m_hExtractionThread = CreateThread(NULL, 0,
+                                               &CExtractSettingsPage::ExtractEntry,
+                                               this,
+                                               0, NULL);
             if (!m_hExtractionThread)
             {
                 /* Extraction thread creation failed, do not go to the next page */
@@ -541,7 +538,7 @@ public:
             LocalFileTimeToFileTime(&LocalFileTime, &FileTime);
             SetFileTime(hFile, &FileTime, &LastAccessTime, &FileTime);
 
-            /* Done.. */
+            /* Done */
             CloseHandle(hFile);
 
             if (err)

--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -108,7 +108,9 @@ public:
                 m_hExtractionThread = NULL;
                 m_pExtract->Release();
                 if (!m_bExtractionThreadCancel)
+                {
                     return 0;
+                }
                 else
                 {
                     SetWindowLongPtr(DWLP_MSGRESULT, -1);
@@ -116,7 +118,7 @@ public:
                 }
             }
 
-            /* We end up here if the user manually clicks Next: start extraction*/
+            /* We end up here if the user manually clicks Next: start extraction */
             m_bExtractionThreadCancel = false;
 
             /* Grey out every control during extraction to prevent user interaction */
@@ -168,7 +170,6 @@ public:
                 ::EnableWindow(pPage->GetDlgItem(IDC_BROWSE), TRUE);
                 ::EnableWindow(pPage->GetDlgItem(IDC_DIRECTORY), TRUE);
                 ::EnableWindow(pPage->GetDlgItem(IDC_PASSWORD), TRUE);
-                pPage->SetWizardButtons(PSWIZB_NEXT);
 
                 /* Reset the progress bar's appearance */
                 CWindow Progress(pPage->GetDlgItem(IDC_PROGRESS));
@@ -341,7 +342,7 @@ public:
         PropertySheetW(&psh);
     }
 
-    bool Extract(HWND hDlg, HWND hProgress, bool* bCancel)
+    bool Extract(HWND hDlg, HWND hProgress, const bool* bCancel)
     {
         unz_global_info64 gi;
         uf = unzOpen2_64(m_Filename.GetString(), &g_FFunc);
@@ -501,8 +502,8 @@ public:
                 {
                     CloseHandle(hFile);
                     BOOL deleteResult = DeleteFileA(FullPath);
-                    if(deleteResult != 0)
-                        DPRINT1("ERROR, DeleteFile: %d\n", deleteResult);
+                    if (deleteResult == 0)
+                        DPRINT1("ERROR, DeleteFileA: 0x%x\n", GetLastError());
                     Close();
                     return false;
                 }


### PR DESCRIPTION
## Extraction was previously happening in the main thread, freezing the whole window until the end.

Now when the user clicks "Next", a new thread is created and the extraction starts from there, allowing to move the window during the extraction, or to cancel the extraction in the middle. (Note: after clicking "Cancel", extraction continues until the current file is extracted).

JIRA issue: [CORE-14934](https://jira.reactos.org/browse/CORE-14934)

