### PR TITLE
[EXPLORER][INCLUDE] Fix wrong title on taskbar about ampersand (&)

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -285,7 +285,9 @@ public:
             TBSTYLE_TOOLTIPS | TBSTYLE_WRAPABLE | TBSTYLE_LIST | TBSTYLE_TRANSPARENT |
             CCS_TOP | CCS_NORESIZE | CCS_NODIVIDER;
 
-        return SubclassWindow(CToolbar::Create(hWndParent, styles));
+        HWND toolbar = CToolbar::Create(hWndParent, styles);
+        SetDrawTextFlags(DT_NOPREFIX, DT_NOPREFIX);
+        return SubclassWindow(toolbar);
     }
 };
 

--- a/sdk/include/reactos/rosctrls.h
+++ b/sdk/include/reactos/rosctrls.h
@@ -306,6 +306,11 @@ public: // Configuration methods
         return SendMessageW(TB_SETHOTITEM, item);
     }
 
+    DWORD SetDrawTextFlags(DWORD useBits, DWORD bitState)
+    {
+        return SendMessageW(TB_SETDRAWTEXTFLAGS, useBits, bitState);
+    }
+
 public: // Button list management methods
     int GetButtonCount()
     {


### PR DESCRIPTION
## Purpose
Based on @learn-more's `CORE-11619.patch`.
JIRA issue: [CORE-11619](https://jira.reactos.org/browse/CORE-11619)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/72856294-707f3a00-3cfd-11ea-9657-841495d724c9.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/72856293-707f3a00-3cfd-11ea-9a46-61af74e4326b.png)