### PR TITLE
[CMAKE] Remove a remnant comment related to 'dll/cpl/console'

### DIFF
--- a/dll/cpl/CMakeLists.txt
+++ b/dll/cpl/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_subdirectory(access)
 add_subdirectory(appwiz)
-add_subdirectory(console)#Warning: console\\/lang/cs-CZ.rc:143: unrecognized escape sequence
+add_subdirectory(console)
 add_subdirectory(desk)
 add_subdirectory(hdwwiz)
 add_subdirectory(inetcpl)


### PR DESCRIPTION
'#Warning: console\\/lang/cs-CZ.rc:143: unrecognized escape sequence'

Created on r51783.
Assumed fixed by d132a09e69c201092e21818568cfd4844f1a5eab (r58770), which removed `IDS_SCREEN_TEXT`.