### PR TITLE
[EXPLORER] trayclock:Update taskbar clock display when it should (only)

### DIFF
--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -696,7 +696,12 @@ LRESULT CTrayClockWnd::OnTaskbarSettingsChanged(UINT uMsg, WPARAM wParam, LPARAM
     if (newSettings->bShowSeconds != g_TaskbarSettings.bShowSeconds)
     {
         g_TaskbarSettings.bShowSeconds = newSettings->bShowSeconds;
-        bRealign = TRUE;
+        if (!g_TaskbarSettings.sr.HideClock)
+        {
+            bRealign = TRUE;
+
+            ResetTime();
+        }
     }
 
     if (newSettings->sr.HideClock != g_TaskbarSettings.sr.HideClock)

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -424,12 +424,9 @@ UINT CTrayClockWnd::CalculateDueTime()
 {
     UINT uiDueTime;
 
-    /* Calculate the due time */
     GetLocalTime(&LocalTime);
     uiDueTime = 1000 - (UINT) LocalTime.wMilliseconds;
-    if (g_TaskbarSettings.bShowSeconds)
-        uiDueTime += (UINT) LocalTime.wSecond * 100;
-    else
+    if (!g_TaskbarSettings.bShowSeconds)
         uiDueTime += (59 - (UINT) LocalTime.wSecond) * 1000;
 
     if (uiDueTime < USER_TIMER_MINIMUM || uiDueTime > USER_TIMER_MAXIMUM)


### PR DESCRIPTION
1. When shown: correctly calculate 1-second due time.
2. When hidden: stop useless timer(s), skip display update (easy code parts at least).
3. On setting changed: use correct delay (1-second or 1-minute).