### PR TITLE
Improve Stubs for printers.c GetPrinterA and GetPrinterDeviceA

### DIFF
--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -580,6 +580,7 @@ BOOL WINAPI
 GetPrinterA(HANDLE hPrinter, DWORD Level, LPBYTE pPrinter, DWORD cbBuf, LPDWORD pcbNeeded)
 {
     TRACE("GetPrinterA(%p, %lu, %p, %lu, %p)\n", hPrinter, Level, pPrinter, cbBuf, pcbNeeded);
+    *pcbNeeded = 0;
     return FALSE;
 }
 
@@ -587,6 +588,7 @@ BOOL WINAPI
 GetPrinterDriverA(HANDLE hPrinter, LPSTR pEnvironment, DWORD Level, LPBYTE pDriverInfo, DWORD cbBuf, LPDWORD pcbNeeded)
 {
     TRACE("GetPrinterDriverA(%p, %s, %lu, %p, %lu, %p)\n", hPrinter, pEnvironment, Level, pDriverInfo, cbBuf, pcbNeeded);
+    *pcbNeeded = 0;
     return FALSE;
 }
 

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -580,7 +580,7 @@ BOOL WINAPI
 GetPrinterA(HANDLE hPrinter, DWORD Level, LPBYTE pPrinter, DWORD cbBuf, LPDWORD pcbNeeded)
 {
     TRACE("GetPrinterA(%p, %lu, %p, %lu, %p)\n", hPrinter, Level, pPrinter, cbBuf, pcbNeeded);
-    *pcbNeeded = 0;
+    if(pcbNeeded) *pcbNeeded = 0;
     return FALSE;
 }
 
@@ -588,7 +588,7 @@ BOOL WINAPI
 GetPrinterDriverA(HANDLE hPrinter, LPSTR pEnvironment, DWORD Level, LPBYTE pDriverInfo, DWORD cbBuf, LPDWORD pcbNeeded)
 {
     TRACE("GetPrinterDriverA(%p, %s, %lu, %p, %lu, %p)\n", hPrinter, pEnvironment, Level, pDriverInfo, cbBuf, pcbNeeded);
-    *pcbNeeded = 0;
+    if(pcbNeeded) *pcbNeeded = 0;
     return FALSE;
 }
 


### PR DESCRIPTION
## Improve stubs for GetPrinterA and GetPrinterDriverA

JIRA issue: [CORE-16622](https://jira.reactos.org/browse/CORE-16622)

_This improves the return value for pcbNeeded from being an unititialized value and makes it zero._
_The reason for this is that this value is often used afterwards in the code for HeapAlloc._