### PR TITLE
[USETUP] Remove redundant TEXT_STYLE_NORMAL flag on empty MUI entry f…

### DIFF
--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -1335,7 +1335,7 @@ static MUI_ENTRY bgBGFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -1325,7 +1325,7 @@ static MUI_ENTRY bnBDFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -1333,7 +1333,7 @@ static MUI_ENTRY csCZFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -1327,7 +1327,7 @@ static MUI_ENTRY daDKFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -1320,7 +1320,7 @@ static MUI_ENTRY deDEFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -1342,7 +1342,7 @@ static MUI_ENTRY elGRFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -1325,7 +1325,7 @@ static MUI_ENTRY enUSFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -1330,7 +1330,7 @@ static MUI_ENTRY esESFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -1328,7 +1328,7 @@ static MUI_ENTRY etEEFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -1348,7 +1348,7 @@ static MUI_ENTRY frFRFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -1329,7 +1329,7 @@ static MUI_ENTRY heILFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/hu-HU.h
+++ b/base/setup/usetup/lang/hu-HU.h
@@ -1219,7 +1219,7 @@ static MUI_ENTRY huHUFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -1331,7 +1331,7 @@ static MUI_ENTRY itITFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -1328,7 +1328,7 @@ static MUI_ENTRY jaJPFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -1336,7 +1336,7 @@ static MUI_ENTRY ltLTFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -1317,7 +1317,7 @@ static MUI_ENTRY msMYFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -1340,7 +1340,7 @@ static MUI_ENTRY nlNLFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -1330,7 +1330,7 @@ static MUI_ENTRY plPLFormatPartitionEntries[] =
         0,
         "ENTER = Kontynuacja   F3 = Wyj\230cie",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
-        TEXT_ID_STATIC
+        0
     },
     {
         0,

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -1336,7 +1336,7 @@ static MUI_ENTRY ptBRFormatPartitionEntries[] =
         0,
         "ENTER=Continuar  F3=Sair",
         TEXT_TYPE_STATUS,
-        TEXT_ID_STATIC
+        0
     },
     {
         0,

--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -1342,7 +1342,7 @@ static MUI_ENTRY ptPTFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -1357,7 +1357,7 @@ static MUI_ENTRY roROFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/ru-RU.h
+++ b/base/setup/usetup/lang/ru-RU.h
@@ -1348,7 +1348,7 @@ static MUI_ENTRY ruRUFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -1334,7 +1334,7 @@ static MUI_ENTRY skSKFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -1332,7 +1332,7 @@ static MUI_ENTRY sqALFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -1334,7 +1334,7 @@ static MUI_ENTRY svSEFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -1309,7 +1309,7 @@ static MUI_ENTRY trTRFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 

--- a/base/setup/usetup/lang/uk-UA.h
+++ b/base/setup/usetup/lang/uk-UA.h
@@ -1333,7 +1333,7 @@ static MUI_ENTRY ukUAFormatPartitionEntries[] =
         0,
         0,
         NULL,
-        TEXT_STYLE_NORMAL
+        0
     }
 };
 


### PR DESCRIPTION
…ield
## Purpose
Remove a redundant flag on format partition page as the last field entry is empty therefor it shouldn't have any text flags. I just discovered that while I was working on #2193.