### PR TITLE
[SHELL32] Wait for DDE communication

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -465,7 +465,7 @@ static HHOOK s_hCBTHook = NULL;
 static BOOL s_bDidWake = FALSE;
 static DWORD s_dwProcessId = 0;
 
-/* CBT procedure for waiting process. See below. */
+/* CBT procedure for waiting process. See SHELL_ExecuteW. */
 static LRESULT CALLBACK
 CBTProc(int nCode, WPARAM wParam, LPARAM lParam)
 {


### PR DESCRIPTION
## Purpose
The system has to wait for the process establishment with using CBT hook, for a process with DDE, when `WaitForInputIdle` failed.
JIRA issue: [CORE-12266](https://jira.reactos.org/browse/CORE-12266)

STEP1: Install Mozilla Firefox by using Rapps.
![Step1](https://user-images.githubusercontent.com/2107452/73329964-b78fa100-42a2-11ea-82e9-83999e0d885f.png)
STEP2: Win+R and execute `https://google.com`.
![Step2](https://user-images.githubusercontent.com/2107452/73329965-b78fa100-42a2-11ea-8c32-0929ad019e78.png)
STEP3: Browser will be shown without error message.
![Step3](https://user-images.githubusercontent.com/2107452/73329963-b6f70a80-42a2-11ea-89c5-eea1c110f518.png)

See also: https://stackoverflow.com/questions/33405201/waitforinputidle-doesnt-work-for-starting-mspaint-programmatically