### PR TITLE
[SDK][ATL] Implement CStringT::FormatMessage

### DIFF
--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -153,7 +153,7 @@ public:
     static LPWSTR
     FormatMessageV(_In_z_ LPCWSTR pszFormat, _In_opt_ va_list *pArgList)
     {
-        LPWSTR psz = NULL;
+        LPWSTR psz;
         ::FormatMessageW(
             FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING, pszFormat, 0, 0,
             reinterpret_cast<LPWSTR>(&psz), 0, pArgList);
@@ -302,7 +302,7 @@ public:
     static LPSTR
     FormatMessageV(_In_z_ LPCSTR pszFormat, _In_opt_ va_list *pArgList)
     {
-        LPSTR psz = NULL;
+        LPSTR psz;
         ::FormatMessageA(
             FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING, pszFormat, 0, 0, reinterpret_cast<LPSTR>(&psz),
             0, pArgList);

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -150,6 +150,14 @@ public:
         return ::vswprintf(pszDest, pszFormat, args);
     }
 
+    static LPWSTR FormatMessageV(LPWSTR pszFormat, va_list* pArgList)
+    {
+        LPWSTR psz = NULL;
+        ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
+                         pszFormat, 0, 0, reinterpret_cast<LPWSTR>(&psz), 0, pArgList);
+        return psz;
+    }
+
     static BSTR __cdecl AllocSysString(
         _In_z_ LPCWSTR pszSource,
         _In_ int nLength)
@@ -287,6 +295,14 @@ public:
         if (pszDest == NULL)
             return ::_vscprintf(pszFormat, args);
         return ::vsprintf(pszDest, pszFormat, args);
+    }
+
+    static LPSTR FormatMessageV(LPSTR pszFormat, va_list* pArgList)
+    {
+        LPSTR psz = NULL;
+        ::FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
+                         pszFormat, 0, 0, reinterpret_cast<LPSTR>(&psz), 0, pArgList);
+        return psz;
     }
 
     static BSTR __cdecl AllocSysString(
@@ -692,6 +708,35 @@ public:
         CThisSimpleString::ReleaseBufferSetLength(nLength);
     }
 
+    void __cdecl FormatMessage(UINT nFormatID, ...)
+    {
+        va_list va;
+        va_start(va, nFormatID);
+
+        CStringT str;
+        if (str.LoadString(nFormatID))
+            FormatMessageV(str, &va);
+
+        va_end(va);
+    }
+
+    void __cdecl FormatMessage(PCXSTR pszFormat, ...)
+    {
+        va_list va;
+        va_start(va, pszFormat);
+        FormatMessageV(pszFormat, &va);
+        va_end(va);
+    }
+
+    void FormatMessageV(PCXSTR pszFormat, va_list* pArgList)
+    {
+        PXSTR psz = StringTraits::FormatMessageV(pszFormat, pArgList);
+        if (psz)
+        {
+            *this = psz;
+            ::LocalFree(psz);
+        }
+    }
 
     int Replace(PCXSTR pszOld, PCXSTR pszNew)
     {

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -150,7 +150,9 @@ public:
         return ::vswprintf(pszDest, pszFormat, args);
     }
 
-    static LPWSTR FormatMessageV(LPWSTR pszFormat, va_list* pArgList)
+    static LPWSTR FormatMessageV(
+        _In_z_ LPCWSTR pszFormat,
+        _In_ va_list* pArgList)
     {
         LPWSTR psz = NULL;
         ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
@@ -297,7 +299,9 @@ public:
         return ::vsprintf(pszDest, pszFormat, args);
     }
 
-    static LPSTR FormatMessageV(LPSTR pszFormat, va_list* pArgList)
+    static LPSTR FormatMessageV(
+        _In_z_ LPCSTR pszFormat,
+        _In_ va_list* pArgList)
     {
         LPSTR psz = NULL;
         ::FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -150,13 +150,13 @@ public:
         return ::vswprintf(pszDest, pszFormat, args);
     }
 
-    static LPWSTR FormatMessageV(
-        _In_z_ LPCWSTR pszFormat,
-        _In_opt_ va_list* pArgList)
+    static LPWSTR
+    FormatMessageV(_In_z_ LPCWSTR pszFormat, _In_opt_ va_list* pArgList)
     {
         LPWSTR psz = NULL;
-        ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
-                         pszFormat, 0, 0, reinterpret_cast<LPWSTR>(&psz), 0, pArgList);
+        ::FormatMessageW(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING, pszFormat, 0, 0,
+            reinterpret_cast<LPWSTR>(&psz), 0, pArgList);
         return psz;
     }
 
@@ -299,13 +299,13 @@ public:
         return ::vsprintf(pszDest, pszFormat, args);
     }
 
-    static LPSTR FormatMessageV(
-        _In_z_ LPCSTR pszFormat,
-        _In_opt_ va_list* pArgList)
+    static LPSTR
+    FormatMessageV(_In_z_ LPCSTR pszFormat, _In_opt_ va_list* pArgList)
     {
         LPSTR psz = NULL;
-        ::FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
-                         pszFormat, 0, 0, reinterpret_cast<LPSTR>(&psz), 0, pArgList);
+        ::FormatMessageA(
+            FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING, pszFormat, 0, 0, reinterpret_cast<LPSTR>(&psz),
+            0, pArgList);
         return psz;
     }
 
@@ -732,7 +732,8 @@ public:
         va_end(va);
     }
 
-    void FormatMessageV(PCXSTR pszFormat, va_list* pArgList)
+    void
+    FormatMessageV(PCXSTR pszFormat, va_list* pArgList)
     {
         PXSTR psz = StringTraits::FormatMessageV(pszFormat, pArgList);
         if (!psz)

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -151,7 +151,7 @@ public:
     }
 
     static LPWSTR
-    FormatMessageV(_In_z_ LPCWSTR pszFormat, _In_opt_ va_list* pArgList)
+    FormatMessageV(_In_z_ LPCWSTR pszFormat, _In_opt_ va_list *pArgList)
     {
         LPWSTR psz = NULL;
         ::FormatMessageW(
@@ -300,7 +300,7 @@ public:
     }
 
     static LPSTR
-    FormatMessageV(_In_z_ LPCSTR pszFormat, _In_opt_ va_list* pArgList)
+    FormatMessageV(_In_z_ LPCSTR pszFormat, _In_opt_ va_list *pArgList)
     {
         LPSTR psz = NULL;
         ::FormatMessageA(
@@ -733,7 +733,7 @@ public:
     }
 
     void
-    FormatMessageV(PCXSTR pszFormat, va_list* pArgList)
+    FormatMessageV(PCXSTR pszFormat, va_list *pArgList)
     {
         PXSTR psz = StringTraits::FormatMessageV(pszFormat, pArgList);
         if (!psz)

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -735,11 +735,11 @@ public:
     void FormatMessageV(PCXSTR pszFormat, va_list* pArgList)
     {
         PXSTR psz = StringTraits::FormatMessageV(pszFormat, pArgList);
-        if (psz)
-        {
-            *this = psz;
-            ::LocalFree(psz);
-        }
+        if (!psz)
+            CThisSimpleString::ThrowMemoryException();
+
+        *this = psz;
+        ::LocalFree(psz);
     }
 
     int Replace(PCXSTR pszOld, PCXSTR pszNew)

--- a/sdk/lib/atl/cstringt.h
+++ b/sdk/lib/atl/cstringt.h
@@ -152,7 +152,7 @@ public:
 
     static LPWSTR FormatMessageV(
         _In_z_ LPCWSTR pszFormat,
-        _In_ va_list* pArgList)
+        _In_opt_ va_list* pArgList)
     {
         LPWSTR psz = NULL;
         ::FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
@@ -301,7 +301,7 @@ public:
 
     static LPSTR FormatMessageV(
         _In_z_ LPCSTR pszFormat,
-        _In_ va_list* pArgList)
+        _In_opt_ va_list* pArgList)
     {
         LPSTR psz = NULL;
         ::FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,


### PR DESCRIPTION
## Purpose
`CStringT::FormatMessage` in ATL is an important method to build a formatted string.
JIRA issue: [CORE-16666](https://jira.reactos.org/browse/CORE-16666)
