### PR TITLE
[NTOS:MM] Stop using PD_COUNT, PDE_COUNT and PTE_COUNT

### DIFF
--- a/ntoskrnl/mm/ARM3/arm/init.c
+++ b/ntoskrnl/mm/ARM3/arm/init.c
@@ -37,7 +37,7 @@ ULONG MmSessionPoolSize;
 ULONG MmSessionImageSize;
 PVOID MiSystemViewStart;
 ULONG MmSystemViewSize;
-PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
+PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
 PMMPDE MmSystemPagePtes;
 ULONG MmNumberOfSystemPtes;
 ULONG MxPfnAllocation;

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -19,10 +19,10 @@
 #define _64K (64 * _1KB)
 
 /* Area mapped by a PDE */
-#define PDE_MAPPED_VA  (PTE_COUNT * PAGE_SIZE)
+#define PDE_MAPPED_VA  (PTE_PER_PAGE * PAGE_SIZE)
 
 /* Size of a page table */
-#define PT_SIZE  (PTE_COUNT * sizeof(MMPTE))
+#define PT_SIZE  (PTE_PER_PAGE * sizeof(MMPTE))
 
 /* Size of a page directory */
 #define PD_SIZE  (PDE_COUNT * sizeof(MMPDE))
@@ -30,7 +30,6 @@
 /* Stop using these! */
 #define PD_COUNT  PPE_PER_PAGE
 #define PDE_COUNT PDE_PER_PAGE
-#define PTE_COUNT PTE_PER_PAGE
 
 /* Size of all page directories for a process */
 #define SYSTEM_PD_SIZE (PD_COUNT * PD_SIZE)

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -25,11 +25,10 @@
 #define PT_SIZE  (PTE_PER_PAGE * sizeof(MMPTE))
 
 /* Size of a page directory */
-#define PD_SIZE  (PDE_COUNT * sizeof(MMPDE))
+#define PD_SIZE  (PDE_PER_PAGE * sizeof(MMPDE))
 
 /* Stop using these! */
 #define PD_COUNT  PPE_PER_PAGE
-#define PDE_COUNT PDE_PER_PAGE
 
 /* Size of all page directories for a process */
 #define SYSTEM_PD_SIZE (PD_COUNT * PD_SIZE)

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -27,11 +27,8 @@
 /* Size of a page directory */
 #define PD_SIZE  (PDE_PER_PAGE * sizeof(MMPDE))
 
-/* Stop using these! */
-#define PD_COUNT  PPE_PER_PAGE
-
 /* Size of all page directories for a process */
-#define SYSTEM_PD_SIZE (PD_COUNT * PD_SIZE)
+#define SYSTEM_PD_SIZE (PPE_PER_PAGE * PD_SIZE)
 #ifdef _M_IX86
 C_ASSERT(SYSTEM_PD_SIZE == PAGE_SIZE);
 #endif
@@ -642,7 +639,7 @@ extern PVOID MiSessionImageStart;
 extern PVOID MiSessionImageEnd;
 extern PMMPTE MiHighestUserPte;
 extern PMMPDE MiHighestUserPde;
-extern PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
+extern PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
 extern PMMPTE MmSharedUserDataPte;
 extern LIST_ENTRY MmProcessList;
 extern BOOLEAN MmZeroingPageThreadActive;

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -161,7 +161,7 @@ SIZE_T MmSystemViewSize;
 // map paged pool PDEs into external processes when they fault on a paged pool
 // address.
 //
-PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
+PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
 PMMPDE MmSystemPagePtes;
 #endif
 
@@ -779,7 +779,7 @@ MiBuildPfnDatabaseFromPages(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     /* Start with the first PDE and scan them all */
     PointerPde = MiAddressToPde(NULL);
-    Count = PD_COUNT * PDE_PER_PAGE;
+    Count = PPE_PER_PAGE * PDE_PER_PAGE;
     for (i = 0; i < Count; i++)
     {
         /* Check for valid PDE */
@@ -1767,7 +1767,7 @@ MiBuildPagedPool(VOID)
     // Get the page frame number for the system page directory
     //
     PointerPte = MiAddressToPte(PDE_BASE);
-    ASSERT(PD_COUNT == 1);
+    ASSERT(PPE_PER_PAGE == 1);
     MmSystemPageDirectory[0] = PFN_FROM_PTE(PointerPte);
 
     //
@@ -1785,7 +1785,7 @@ MiBuildPagedPool(VOID)
     // way).
     //
     TempPte = ValidKernelPte;
-    ASSERT(PD_COUNT == 1);
+    ASSERT(PPE_PER_PAGE == 1);
     TempPte.u.Hard.PageFrameNumber = MmSystemPageDirectory[0];
     MI_WRITE_VALID_PTE(PointerPte, TempPte);
 #endif

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -779,7 +779,7 @@ MiBuildPfnDatabaseFromPages(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     /* Start with the first PDE and scan them all */
     PointerPde = MiAddressToPde(NULL);
-    Count = PD_COUNT * PDE_COUNT;
+    Count = PD_COUNT * PDE_PER_PAGE;
     for (i = 0; i < Count; i++)
     {
         /* Check for valid PDE */
@@ -1894,12 +1894,12 @@ MiBuildPagedPool(VOID)
                                    PFN_FROM_PTE(MiAddressToPpe(MmPagedPoolStart)));
 #else
     /* Do it this way */
-//    Bla = MmSystemPageDirectory[(PointerPde - (PMMPTE)PDE_BASE) / PDE_COUNT]
+//    Bla = MmSystemPageDirectory[(PointerPde - (PMMPTE)PDE_BASE) / PDE_PER_PAGE]
 
     /* Initialize the PFN entry for it */
     MiInitializePfnForOtherProcess(PageFrameIndex,
                                    (PMMPTE)PointerPde,
-                                   MmSystemPageDirectory[(PointerPde - (PMMPDE)PDE_BASE) / PDE_COUNT]);
+                                   MmSystemPageDirectory[(PointerPde - (PMMPDE)PDE_BASE) / PDE_PER_PAGE]);
 #endif
 
     //

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -812,7 +812,7 @@ MiBuildPfnDatabaseFromPages(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
             /* Now get the PTE and scan the pages */
             PointerPte = MiAddressToPte(BaseAddress);
-            for (j = 0; j < PTE_COUNT; j++)
+            for (j = 0; j < PTE_PER_PAGE; j++)
             {
                 /* Check for a valid PTE */
                 if (PointerPte->u.Hard.Valid == 1)
@@ -1439,7 +1439,7 @@ MiAddHalIoMappings(VOID)
         {
             /* Get the PTE for it and scan each page */
             PointerPte = MiAddressToPte(BaseAddress);
-            for (j = 0 ; j < PTE_COUNT; j++)
+            for (j = 0; j < PTE_PER_PAGE; j++)
             {
                 /* Does the HAL own this page? */
                 if (PointerPte->u.Hard.Valid == 1)

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -566,7 +566,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
                 /* Initialize the PFN */
                 MiInitializePfnForOtherProcess(PageFrameNumber,
                                                (PMMPTE)PointerPde,
-                                               MmSystemPageDirectory[(PointerPde - MiAddressToPde(NULL)) / PDE_COUNT]);
+                                               MmSystemPageDirectory[(PointerPde - MiAddressToPde(NULL)) / PDE_PER_PAGE]);
 #endif
 
                 //

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -480,7 +480,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
             //
             // Get the page bit count
             //
-            i = ((SizeInPages - 1) / PTE_COUNT) + 1;
+            i = ((SizeInPages - 1) / PTE_PER_PAGE) + 1;
             DPRINT("Paged pool expansion: %lu %x\n", i, SizeInPages);
 
             //
@@ -586,11 +586,11 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
             // These pages are now available, clear their availablity bits
             //
             EndAllocation = (ULONG)(MmPagedPoolInfo.NextPdeForPagedPoolExpansion -
-                             (PMMPDE)MiAddressToPte(MmPagedPoolInfo.FirstPteForPagedPool)) *
-                             PTE_COUNT;
+                                    (PMMPDE)MiAddressToPte(MmPagedPoolInfo.FirstPteForPagedPool)) *
+                            PTE_PER_PAGE;
             RtlClearBits(MmPagedPoolInfo.PagedPoolAllocationMap,
                          EndAllocation,
-                         PageTableCount * PTE_COUNT);
+                         PageTableCount * PTE_PER_PAGE);
 
             //
             // Update the next expansion location

--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -512,7 +512,7 @@ MiFillSystemPageDirectory(IN PVOID Base,
             TempPde.u.Hard.PageFrameNumber = PageFrameIndex;
 
 #if (_MI_PAGING_LEVELS == 2)
-            ParentPage = MmSystemPageDirectory[(PointerPde - MiAddressToPde(NULL)) / PDE_COUNT];
+            ParentPage = MmSystemPageDirectory[(PointerPde - MiAddressToPde(NULL)) / PDE_PER_PAGE];
 #else
             ParentPage = MiPdeToPpe(PointerPde)->u.Hard.PageFrameNumber;
 #endif

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -360,8 +360,8 @@ MiBalancerThread(PVOID Unused)
                 KIRQL OldIrql = MiAcquirePfnLock();
                 PMMPDE pointerPde;
                 for (Address = (ULONG_PTR)MI_LOWEST_VAD_ADDRESS;
-                        Address < (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS;
-                        Address += (PAGE_SIZE * PTE_COUNT))
+                     Address < (ULONG_PTR)MM_HIGHEST_VAD_ADDRESS;
+                     Address += PTE_PER_PAGE * PAGE_SIZE)
                 {
                     if (MiQueryPageTableReferences((PVOID)Address) == 0)
                     {

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -12,6 +12,7 @@
 #include <ntoskrnl.h>
 #define NDEBUG
 #include <debug.h>
+
 #include <mm/ARM3/miarm.h>
 
 #if defined (ALLOC_PRAGMA)
@@ -389,7 +390,7 @@ MmDeleteVirtualMapping(PEPROCESS Process, PVOID Address,
 		{
 			/* Remove PDE reference */
 			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]--;
-			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_COUNT);
+			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_PER_PAGE);
 		}
 
         Pfn = PTE_TO_PFN(Pte);
@@ -453,7 +454,7 @@ MmDeletePageFileMapping(PEPROCESS Process, PVOID Address,
 	{
 		/* Remove PDE reference */
 		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]--;
-		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_COUNT);
+		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_PER_PAGE);
 	}
 
     /* We don't need to flush here because page file entries
@@ -638,7 +639,7 @@ MmCreatePageFileMapping(PEPROCESS Process,
 	{
 		/* Add PDE reference */
 		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]++;
-		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] <= PTE_COUNT);
+		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] <= PTE_PER_PAGE);
 	}
 
     /* We don't need to flush the TLB here because it
@@ -755,7 +756,7 @@ MmCreateVirtualMappingUnsafe(PEPROCESS Process,
 		{
 			/* Add PDE reference */
 			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Addr)]++;
-			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Addr)] <= PTE_COUNT);
+			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Addr)] <= PTE_PER_PAGE);
 		}
     }
 

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -599,8 +599,8 @@ MmDeleteProcessAddressSpace(PEPROCESS Process)
         OldIrql = MiAcquirePfnLock();
 
         for (Address = MI_LOWEST_VAD_ADDRESS;
-                Address < MM_HIGHEST_VAD_ADDRESS;
-                Address =(PVOID)((ULONG_PTR)Address + (PAGE_SIZE * PTE_COUNT)))
+             Address < MM_HIGHEST_VAD_ADDRESS;
+             Address = (PVOID)((ULONG_PTR)Address + (PTE_PER_PAGE * PAGE_SIZE)))
         {
             /* At this point all references should be dead */
             if (MiQueryPageTableReferences(Address) != 0)


### PR DESCRIPTION
@tkreuzer added `/* Stop using these! */` on 066c89edc704dc46945798c2d7f9d44fca3c1f43 (r67568).