### PR TITLE
[MSAFD] Do workaround against Async connection hung-up

### DIFF
--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -1974,6 +1974,7 @@ WSPConnect(SOCKET Handle,
     if (Socket->SharedData->NonBlocking)
     {
         ERR("Async Connect UNIMPLEMENTED!\n");
+        return WSAECONNREFUSED; /* workaround */
     }
 
     /* Send IOCTL */


### PR DESCRIPTION
## Purpose
Async connection is not supported yet. So I provide safe failure.
JIRA issue: [CORE-11537](https://jira.reactos.org/browse/CORE-11537)

AFTER:
![workaround-by-katahiromz](https://user-images.githubusercontent.com/2107452/73535739-a3e16780-4467-11ea-8fd5-5937f5f350f8.png)