### PR TITLE
[NTDLL] Implement RtlGetUnloadEventTrace

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -679,7 +679,7 @@
 @ stdcall RtlGetSecurityDescriptorRMControl(ptr ptr)
 @ stdcall RtlGetSetBootStatusData(ptr long long ptr long long)
 @ stdcall RtlGetThreadErrorMode()
-@ stdcall -stub RtlGetUnloadEventTrace()
+@ stdcall RtlGetUnloadEventTrace()
 @ stdcall RtlGetUserInfoHeap(ptr long ptr ptr ptr)
 @ stdcall RtlGetVersion(ptr)
 @ stdcall RtlHashUnicodeString(ptr long long ptr)

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -1224,6 +1224,8 @@ typedef struct _RTL_FLS_DATA
 //
 // Unload Event Trace Structure for RtlGetUnloadEventTrace
 //
+#define RTL_UNLOAD_EVENT_TRACE_NUMBER 64
+
 typedef struct _RTL_UNLOAD_EVENT_TRACE
 {
     PVOID BaseAddress;

--- a/sdk/lib/rtl/trace.c
+++ b/sdk/lib/rtl/trace.c
@@ -10,7 +10,17 @@
 #define NDEBUG
 #include <debug.h>
 
+static RTL_UNLOAD_EVENT_TRACE RtlpUnloadEventTrace[RTL_UNLOAD_EVENT_TRACE_NUMBER];
+
 /* FUNCTIONS ******************************************************************/
+
+PRTL_UNLOAD_EVENT_TRACE
+NTAPI
+RtlGetUnloadEventTrace(VOID)
+{
+    /* Just return a pointer to an array, according to MSDN */
+    return RtlpUnloadEventTrace;
+}
 
 BOOLEAN
 NTAPI


### PR DESCRIPTION
## Purpose

Implement RtlGetUnloadEventTrace function in ntdll, according to https://docs.microsoft.com/en-us/windows/win32/devnotes/rtlgetunloadeventtrace. As said there, it has no parameters and returns a pointer to an RtlpUnloadEventTrace array, which I added too.
It allows to generate a minidump files from the running processes via MS ProcDump 9.0 (and probably other software, which has the same feature and uses this function) with replaced verifier.dll. Without replacing that dll, now it fails due to VerifierEnumerateResource() stub.

JIRA issue: [CORE-16671](https://jira.reactos.org/browse/CORE-16671)

## Proposed changes

- Add missing `RTL_UNLOAD_EVENT_TRACE_NUMBER` definition in sdk/include/ndk/rtltypes.h,  near the `_RTL_UNLOAD_EVENT_TRACE` structure, same as in MSDN example, and static `RtlpUnloadEventTrace` array in sdk/lib/rtl/trace.c.
- Implement the function itself in sdk/lib/rtl/trace.c and properly call it in dll/ntdll/def/ntdll.spec.

## Result

Before:
![procdump](https://user-images.githubusercontent.com/26385117/73552074-3d048400-4450-11ea-9767-72430e960baf.png)

After (with replaced verifier.dll):
![MS_verifier](https://user-images.githubusercontent.com/26385117/73552131-586f8f00-4450-11ea-9c39-c146940d1f28.png)