### PR TITLE
[HAL] Use a spin lock for the DMA adapter list.

### DIFF
--- a/hal/halx86/generic/dma.c
+++ b/hal/halx86/generic/dma.c
@@ -85,6 +85,7 @@
 
 #ifndef _MINIHAL_
 static KEVENT HalpDmaLock;
+static KSPIN_LOCK HalpDmaAdapterListLock;
 static LIST_ENTRY HalpDmaAdapterList;
 static PADAPTER_OBJECT HalpEisaAdapter[8];
 #endif
@@ -165,6 +166,7 @@ HalpInitDma(VOID)
      * first map buffers.
      */
     InitializeListHead(&HalpDmaAdapterList);
+    KeInitializeSpinLock(&HalpDmaAdapterListLock);
     KeInitializeEvent(&HalpDmaLock, NotificationEvent, TRUE);
     HalpMasterAdapter = HalpDmaAllocateMasterAdapter();
 
@@ -621,6 +623,7 @@ HalGetAdapter(IN PDEVICE_DESCRIPTION DeviceDescription,
     BOOLEAN EisaAdapter;
     ULONG MapRegisters;
     ULONG MaximumLength;
+    KIRQL OldIrql;
 
     /* Validate parameters in device description */
     if (DeviceDescription->Version > DEVICE_DESCRIPTION_VERSION2) return NULL;
@@ -688,8 +691,7 @@ HalGetAdapter(IN PDEVICE_DESCRIPTION DeviceDescription,
     }
 
     /*
-     * Acquire the DMA lock that is used to protect adapter lists and
-     * EISA adapter array.
+     * Acquire the DMA lock that is used to protect the EISA adapter array.
      */
     KeWaitForSingleObject(&HalpDmaLock, Executive, KernelMode, FALSE, NULL);
 
@@ -745,13 +747,19 @@ HalGetAdapter(IN PDEVICE_DESCRIPTION DeviceDescription,
         }
     }
 
-    if (!EisaAdapter) InsertTailList(&HalpDmaAdapterList, &AdapterObject->AdapterList);
-
     /*
-     * Release the DMA lock. HalpDmaAdapterList and HalpEisaAdapter will
-     * no longer be touched, so we don't need it.
+     * Release the DMA lock. HalpEisaAdapter will no longer be touched,
+     * so we don't need it.
      */
     KeSetEvent(&HalpDmaLock, 0, 0);
+
+    if (!EisaAdapter)
+    {
+        /* If it's not one of the static adapters, add it to the list */
+        KeAcquireSpinLock(&HalpDmaAdapterListLock, &OldIrql);
+        InsertTailList(&HalpDmaAdapterList, &AdapterObject->AdapterList);
+        KeReleaseSpinLock(&HalpDmaAdapterListLock, OldIrql);
+    }
 
     /*
      * Setup the values in the adapter object that are common for all
@@ -818,11 +826,12 @@ VOID
 NTAPI
 HalPutDmaAdapter(IN PADAPTER_OBJECT AdapterObject)
 {
+    KIRQL OldIrql;
     if (AdapterObject->ChannelNumber == 0xFF)
     {
-        KeWaitForSingleObject(&HalpDmaLock, Executive, KernelMode, FALSE, NULL);
+        KeAcquireSpinLock(&HalpDmaAdapterListLock, &OldIrql);
         RemoveEntryList(&AdapterObject->AdapterList);
-        KeSetEvent(&HalpDmaLock, 0, 0);
+        KeReleaseSpinLock(&HalpDmaAdapterListLock, OldIrql);
     }
 
     ObDereferenceObject(AdapterObject);


### PR DESCRIPTION
JIRA issue: [CORE-16611](https://jira.reactos.org/browse/CORE-16611)

HalPutDmaAdapter can be called at DISPATCH_LEVEL. Windows's portcls apparently does this:

```
*** Assertion failed: KeGetCurrentIrql() < DISPATCH_LEVEL || (KeGetCurrentIrql() == DISPATCH_LEVEL && Timeout && Timeout->QuadPart == 0)
***   Source File: ../ntoskrnl/ke/wait.c, line 436

Break repeatedly, break Once, Ignore, terminate Process or terminate Thread (boipt)?
kdb:> o
Execute '.cxr F74B87D0' to dump context

Entered debugger on embedded INT3 at 0x0008:0x80988afe.
kdb:> bt
Eip:
<ntoskrnl.exe:188aff (sdk/lib/rtl/i386/debug_asm.S:34 (DbgBreakPoint))>
Frames:
<ntoskrnl.exe:9e248 (ntoskrnl/ke/wait.c:436 (KeWaitForSingleObject))>
<hal.dll:17af (hal/halx86/generic/dma.c:823 (HalPutDmaAdapter))>
<portcls.sys:2f8a>
<portcls.sys:11ef>
<portcls.sys:175f>
<portcls.sys:1711c>
<VirtualAudio.sys:758a>
<VirtualAudio.sys:76e9>
<portcls.sys:169e3>
<VirtualAudio.sys:38db>
<VirtualAudio.sys:3b0d>
<portcls.sys:1565e>
<portcls.sys:1495b>
<ntoskrnl.exe:77345 (ntoskrnl/io/iomgr/iowork.c:24 (IopWorkItemCallback))>
<ntoskrnl.exe:43c4d (ntoskrnl/ex/work.c:162 (ExpWorkerThreadEntryPoint))>
<ntoskrnl.exe:12e6f7 (ntoskrnl/ps/thread.c:156 (PspSystemThreadStartup))>
<ntoskrnl.exe:149665 (ntoskrnl/ke/i386/thrdini.c:78 (KiThreadStartup))>
<ntoskrnl.exe:12e6ca (ntoskrnl/ps/thread.c:63 (PspUserThreadStartup))>
<ec835356>
```