### PR TITLE
[NTOS:WMI] WMIP_GUID_OBJECT must start with an event object, as it is waitable.

### DIFF
--- a/ntoskrnl/wmi/guidobj.c
+++ b/ntoskrnl/wmi/guidobj.c
@@ -204,6 +204,7 @@ WmipCreateGuidObject(
     }
 
     RtlZeroMemory(GuidObject, sizeof(*GuidObject));
+    KeInitializeEvent(&GuidObject->Event, NotificationEvent, FALSE);
     GuidObject->Guid = *Guid;
 
     *OutGuidObject = GuidObject;

--- a/ntoskrnl/wmi/wmip.h
+++ b/ntoskrnl/wmi/wmip.h
@@ -12,6 +12,7 @@ typedef struct _WMIP_IRP_CONTEXT
 
 typedef struct _WMIP_GUID_OBJECT
 {
+    KEVENT Event;
     GUID Guid;
     PIRP Irp;
     LIST_ENTRY IrpLink;


### PR DESCRIPTION
The initializer for `WmipGuidObjectType` does not set `UseDefaultObject`, and it's possible for user mode to obtain a handle to a GUID object with `SYNCHRONIZE` access.
Therefore that handle can be passed to `NtWaitForSingleObject`, which means it must start with a `DISPATCHER_HEADER`.

This is a security issue since such a wait could cause kernel memory corruption.