### PR TITLE
[TIMEDATE] Do not display a message box when NTP sync fails

### DIFF
--- a/base/services/w32time/w32time.c
+++ b/base/services/w32time/w32time.c
@@ -191,6 +191,13 @@ SetTime(VOID)
 
     DPRINT("Time Server is '%S'.\n", szData);
 
+    /* Is the given string empty? */
+    if (cbName == 0 || szData[0] == '\0')
+    {
+        DPRINT("The time NTP server couldn't be found, the string is empty!\n");
+        return ERROR_INVALID_DATA;
+    }
+
     ulTime = GetServerTime(szData);
 
     if (ulTime != 0)

--- a/dll/cpl/timedate/CMakeLists.txt
+++ b/dll/cpl/timedate/CMakeLists.txt
@@ -19,6 +19,6 @@ add_library(timedate MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/timedate.def)
 
 set_module_type(timedate cpl UNICODE)
-add_importlibs(timedate w32time advapi32 user32 gdi32 comctl32 ws2_32 iphlpapi msvcrt kernel32)
+add_importlibs(timedate w32time advapi32 user32 gdi32 comctl32 ws2_32 iphlpapi msvcrt kernel32 ntdll)
 add_pch(timedate timedate.h SOURCE)
 add_cd_file(TARGET timedate DESTINATION reactos/system32 FOR all)

--- a/dll/cpl/timedate/internettime.c
+++ b/dll/cpl/timedate/internettime.c
@@ -278,7 +278,7 @@ InetTimePageProc(HWND hwndDlg,
                     dwError = W32TimeSyncNow(L"localhost", 0, 0);
                     if (dwError != ERROR_SUCCESS)
                     {
-                        DisplayWin32Error(dwError);
+                        DPRINT("Failed to synchronize the time! Invalid NTP server name has been caught or no server name could be found (Error: %lu).\n", dwError);
                     }
                 }
                 break;

--- a/dll/cpl/timedate/timedate.h
+++ b/dll/cpl/timedate/timedate.h
@@ -16,6 +16,7 @@
 #include <wchar.h>
 #include <commctrl.h>
 #include <cpl.h>
+#include <debug.h>
 
 #include "resource.h"
 


### PR DESCRIPTION
## Purpose
In Windows XP and Server 2003 the Time/Date control applet does not display any message box in case of NTP synchronization failure or no given NTP server name. However, their applet displays a dynamic string resource every time a successful or failed NTP synchronization operation occurs.

For now, this PR merely checks if the string is empty and displaying (only) a debug information to the debugger, at disposal of displaying a message box. I might implement such dynamic resource string to the CPL later in a next PR.

**JIRA Issue:** [CORE-16654](https://jira.reactos.org/browse/CORE-16654)