### PR TITLE
[CRT] Only write to the output buffer when necessary in _strupr

### DIFF
--- a/sdk/lib/crt/string/strupr.c
+++ b/sdk/lib/crt/string/strupr.c
@@ -16,9 +16,13 @@
 char * CDECL _strupr(char *x)
 {
 	char  *y=x;
+	char ch, upper;
 
 	while (*y) {
-		*y=toupper(*y);
+		ch = *y;
+		upper = toupper(ch);
+		if (ch != upper)
+			*y = upper;
 		y++;
 	}
 	return x;


### PR DESCRIPTION
Fixes crash in msvcrt_winetest:string.

This is a hack and is supposed to be specific to the C locale.

JIRA issue: [CORE-16667](https://jira.reactos.org/browse/CORE-16667)