### PR TITLE
[WINSTA] Stub WinStationCanLogonProceed and _WinStationOpenSessionDirectory

### DIFF
--- a/dll/win32/winsta/logon.c
+++ b/dll/win32/winsta/logon.c
@@ -119,3 +119,10 @@ WINSTAAPI WinStationCanLogonProceed(PVOID A,
 {
     UNIMPLEMENTED;
 }
+
+VOID
+WINSTAAPI _WinStationOpenSessionDirectory(PVOID A,
+                                          PVOID B)
+{
+    UNIMPLEMENTED;
+}

--- a/dll/win32/winsta/logon.c
+++ b/dll/win32/winsta/logon.c
@@ -111,3 +111,11 @@ WINSTAAPI _WinStationNotifyLogon(PVOID A,
 {
     UNIMPLEMENTED;
 }
+
+VOID
+WINSTAAPI WinStationCanLogonProceed(PVOID A,
+                                    PVOID B,
+                                    PVOID C)
+{
+    UNIMPLEMENTED;
+}

--- a/dll/win32/winsta/winsta.spec
+++ b/dll/win32/winsta/winsta.spec
@@ -21,6 +21,7 @@
 @ stdcall WinStationActivateLicense(ptr ptr ptr ptr)
 @ stdcall WinStationAutoReconnect(ptr)
 @ stdcall WinStationBroadcastSystemMessage(ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr)
+@ stdcall WinStationCanLogonProceed(ptr ptr ptr)
 @ stdcall WinStationCheckAccess(ptr ptr ptr)
 @ stdcall WinStationCheckLoopBack(ptr ptr ptr ptr)
 @ stdcall WinStationCloseServer(ptr ptr ptr ptr)

--- a/dll/win32/winsta/winsta.spec
+++ b/dll/win32/winsta/winsta.spec
@@ -112,6 +112,7 @@
 @ stdcall _WinStationNotifyLogoff()
 @ stdcall _WinStationNotifyLogon(ptr ptr ptr ptr ptr ptr ptr ptr)
 @ stdcall _WinStationNotifyNewSession(ptr ptr)
+@ stdcall _WinStationOpenSessionDirectory(ptr ptr)
 @ stdcall _WinStationReInitializeSecurity(ptr)
 @ stdcall _WinStationReadRegistry(ptr)
 @ stdcall _WinStationSessionInitialized()


### PR DESCRIPTION
## Purpose

Add a stubs for the WinStationCanLogonProceed() and _WinStationOpenSessionDirectory() functions in Winsta. Based on the prototypes by @HBelusca from PR #2072: https://github.com/reactos/reactos/pull/2072#issuecomment-559795653. The only difference are functions types (`VOID WINSTAAPI` instead of `BOOLEAN WINSTAAPI`) and the function arguments (`PVOID A`, `B`, `C` etc, instead of `DWORD dwUnknown1`, `DWORD dwUnknown2`, `LPCWSTR pString1`, `LPCWSTR pString2` etc). I wrote them the same as all other Winsta stubs. If they are not (completely) correct, I think they nevertheless can be a good (temporary) solution for now.
Now MS Winlogon does not fail at all due to our Winsta. :smiley:

JIRA issue: [CORE-16458](https://jira.reactos.org/browse/CORE-16458), [CORE-15392](https://jira.reactos.org/browse/CORE-15392)

## Proposed changes

- Add the stubs for the functions itself in dll/win32/winsta/logon.c;
- Properly call them in dll/win32/winsta/winsta.spec.