### PR TITLE
[WINSPOOL] Fix existing Level checks

### DIFF
--- a/sdk/include/reactos/idl/winspool.idl
+++ b/sdk/include/reactos/idl/winspool.idl
@@ -74,6 +74,8 @@ typedef struct _WINSPOOL_DOC_INFO_1 {
 }
 WINSPOOL_DOC_INFO_1;
 
+/* TODO: Add WINSPOOL_DOC_INFO_2 and WINSPOOL_DOC_INFO_3 */
+
 typedef struct _WINSPOOL_DRIVER_INFO_1
 {
     [string] WCHAR* pName;
@@ -124,6 +126,8 @@ typedef struct _WINSPOOL_DRIVER_INFO_4
     [size_is(cchPreviousNames), unique] WCHAR* pszzPreviousNames;
 }
 WINSPOOL_DRIVER_INFO_4;
+
+/* TODO: Add WINSPOOL_DRIVER_INFO_5 */
 
 typedef struct _WINSPOOL_DRIVER_INFO_6
 {
@@ -571,6 +575,7 @@ typedef struct _WINSPOOL_DOC_INFO_CONTAINER
 {
     DWORD Level;
 
+    /* TODO: Add WINSPOOL_DOC_INFO_2 and WINSPOOL_DOC_INFO_3 */
     [switch_is(Level)] union
     {
         [case(1)]
@@ -591,6 +596,7 @@ typedef struct _WINSPOOL_DRIVER_CONTAINER
 {
     DWORD Level;
 
+    /* TODO: Add WINSPOOL_DRIVER_INFO_5 */
     [switch_is(Level)] union
     {
         [case(1)]

--- a/win32ss/printing/base/spoolsv/jobs.c
+++ b/win32ss/printing/base/spoolsv/jobs.c
@@ -59,7 +59,7 @@ _RpcEnumJobs(WINSPOOL_PRINTER_HANDLE hPrinter, DWORD FirstJob, DWORD NoJobs, DWO
         // Replace absolute pointer addresses in the output by relative offsets for JOB_INFO_1W and JOB_INFO_2W.
         if (Level <= 2)
         {
-            ASSERT(Level >= 1);
+            ASSERT(Level >= 1 && Level <= 2);
             MarshallDownStructuresArray(pJobAligned, *pcReturned, pJobInfoMarshalling[Level]->pInfo, pJobInfoMarshalling[Level]->cbStructureSize, TRUE);
         }
     }

--- a/win32ss/printing/base/spoolsv/printerdrivers.c
+++ b/win32ss/printing/base/spoolsv/printerdrivers.c
@@ -63,6 +63,7 @@ _RpcGetPrinterDriver(WINSPOOL_PRINTER_HANDLE hPrinter, WCHAR* pEnvironment, DWOR
     if (GetPrinterDriverW(hPrinter, pEnvironment, Level, pDriverAligned, cbBuf, pcbNeeded))
     {
         // Replace relative offset addresses in the output by absolute pointers.
+        // TODO: Support 6 and 8 too.
         ASSERT(Level >= 1 && Level <= 5);
         MarshallDownStructure(pDriverAligned, pPrinterDriverMarshalling[Level]->pInfo, pPrinterDriverMarshalling[Level]->cbStructureSize, TRUE);
     }

--- a/win32ss/printing/base/winspool/jobs.c
+++ b/win32ss/printing/base/winspool/jobs.c
@@ -75,6 +75,12 @@ EnumJobsW(HANDLE hPrinter, DWORD FirstJob, DWORD NoJobs, DWORD Level, PBYTE pJob
         goto Cleanup;
     }
 
+    if (Level == 0 || Level > 3)
+    {
+        dwErrorCode = ERROR_INVALID_LEVEL;
+        goto Cleanup;
+    }
+
     // Do the RPC call
     RpcTryExcept
     {
@@ -92,7 +98,7 @@ EnumJobsW(HANDLE hPrinter, DWORD FirstJob, DWORD NoJobs, DWORD Level, PBYTE pJob
         // Replace relative offset addresses in the output by absolute pointers for JOB_INFO_1W and JOB_INFO_2W.
         if (Level <= 2)
         {
-            ASSERT(Level >= 1);
+            ASSERT(Level >= 1 && Level <= 2);
             MarshallUpStructuresArray(cbBuf, pJob, *pcReturned, pJobInfoMarshalling[Level]->pInfo, pJobInfoMarshalling[Level]->cbStructureSize, TRUE);
         }
     }
@@ -121,6 +127,12 @@ GetJobW(HANDLE hPrinter, DWORD JobId, DWORD Level, PBYTE pJob, DWORD cbBuf, PDWO
     if (!pHandle)
     {
         dwErrorCode = ERROR_INVALID_HANDLE;
+        goto Cleanup;
+    }
+
+    if (Level == 0 || Level > 2)
+    {
+        dwErrorCode = ERROR_INVALID_LEVEL;
         goto Cleanup;
     }
 

--- a/win32ss/printing/base/winspool/monitors.c
+++ b/win32ss/printing/base/winspool/monitors.c
@@ -55,6 +55,12 @@ EnumMonitorsW(PWSTR pName, DWORD Level, PBYTE pMonitors, DWORD cbBuf, PDWORD pcb
 
     TRACE("EnumMonitorsW(%S, %lu, %p, %lu, %p, %p)\n", pName, Level, pMonitors, cbBuf, pcbNeeded, pcReturned);
 
+    if (Level == 0 || Level > 2)
+    {
+        dwErrorCode = ERROR_INVALID_LEVEL;
+        goto Cleanup;
+    }
+
     // Do the RPC call
     RpcTryExcept
     {
@@ -74,6 +80,7 @@ EnumMonitorsW(PWSTR pName, DWORD Level, PBYTE pMonitors, DWORD cbBuf, PDWORD pcb
         MarshallUpStructuresArray(cbBuf, pMonitors, *pcReturned, pMonitorInfoMarshalling[Level]->pInfo, pMonitorInfoMarshalling[Level]->cbStructureSize, TRUE);
     }
 
+Cleanup:
     SetLastError(dwErrorCode);
     return (dwErrorCode == ERROR_SUCCESS);
 }

--- a/win32ss/printing/base/winspool/ports.c
+++ b/win32ss/printing/base/winspool/ports.c
@@ -87,6 +87,12 @@ EnumPortsW(PWSTR pName, DWORD Level, PBYTE pPorts, DWORD cbBuf, PDWORD pcbNeeded
 
     TRACE("EnumPortsW(%S, %lu, %p, %lu, %p, %p)\n", pName, Level, pPorts, cbBuf, pcbNeeded, pcReturned);
 
+    if (Level == 0 || Level > 2)
+    {
+        dwErrorCode = ERROR_INVALID_LEVEL;
+        goto Cleanup;
+    }
+
     // Do the RPC call
     RpcTryExcept
     {
@@ -106,6 +112,7 @@ EnumPortsW(PWSTR pName, DWORD Level, PBYTE pPorts, DWORD cbBuf, PDWORD pcbNeeded
         MarshallUpStructuresArray(cbBuf, pPorts, *pcReturned, pPortInfoMarshalling[Level]->pInfo, pPortInfoMarshalling[Level]->cbStructureSize, TRUE);
     }
 
+Cleanup:
     SetLastError(dwErrorCode);
     return (dwErrorCode == ERROR_SUCCESS);
 }

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -1935,7 +1935,7 @@ SetPrinterW(HANDLE hPrinter, DWORD Level, PBYTE pPrinter, DWORD Command)
 BOOL WINAPI
 SplDriverUnloadComplete(LPWSTR pDriverFile)
 {
-    TRACE("DriverUnloadComplete(%S)\n", pDriverFile);
+    TRACE("SplDriverUnloadComplete(%S)\n", pDriverFile);
     UNIMPLEMENTED;
     return TRUE; // return true for now.
 }

--- a/win32ss/printing/base/winspool/printers.c
+++ b/win32ss/printing/base/winspool/printers.c
@@ -427,7 +427,6 @@ EnumPrintersA(DWORD Flags, PSTR Name, DWORD Level, PBYTE pPrinterEnum, DWORD cbB
     if (Level !=  1 && Level != 2 && Level != 4 && Level != 5)
     {
         SetLastError(ERROR_INVALID_LEVEL);
-        ERR("Invalid Level!\n");
         goto Cleanup;
     }
 
@@ -850,7 +849,7 @@ EnumPrintersW(DWORD Flags, PWSTR Name, DWORD Level, PBYTE pPrinterEnum, DWORD cb
     TRACE("EnumPrintersW(%lu, %S, %lu, %p, %lu, %p, %p)\n", Flags, Name, Level, pPrinterEnum, cbBuf, pcbNeeded, pcReturned);
 
     // Dismiss invalid levels already at this point.
-    if (Level == 3 || Level > 5)
+    if (Level == 0 || Level == 3 || Level > 5)
     {
         dwErrorCode = ERROR_INVALID_LEVEL;
         goto Cleanup;
@@ -1512,7 +1511,7 @@ GetPrinterDriverW(HANDLE hPrinter, LPWSTR pEnvironment, DWORD Level, LPBYTE pDri
     }
 
     // Dismiss invalid levels already at this point.
-    if (Level > 8 || Level < 1)
+    if (Level == 0 || Level == 7 || Level > 8)
     {
         dwErrorCode = ERROR_INVALID_LEVEL;
         goto Cleanup;
@@ -1536,7 +1535,8 @@ GetPrinterDriverW(HANDLE hPrinter, LPWSTR pEnvironment, DWORD Level, LPBYTE pDri
     if (dwErrorCode == ERROR_SUCCESS)
     {
         // Replace relative offset addresses in the output by absolute pointers.
-        ASSERT(Level <= 5);
+        // TODO: Support 6 and 8 too.
+        ASSERT(Level >= 1 && Level <= 5);
         MarshallUpStructure(cbBuf, pDriverInfo, pPrinterDriverMarshalling[Level]->pInfo, pPrinterDriverMarshalling[Level]->cbStructureSize, TRUE);
     }
 
@@ -1561,7 +1561,7 @@ GetPrinterW(HANDLE hPrinter, DWORD Level, LPBYTE pPrinter, DWORD cbBuf, LPDWORD 
     }
 
     // Dismiss invalid levels already at this point.
-    if (Level > 9)
+    if (Level == 0 || Level > 9)
     {
         dwErrorCode = ERROR_INVALID_LEVEL;
         goto Cleanup;

--- a/win32ss/printing/include/marshalling/printerdrivers.h
+++ b/win32ss/printing/include/marshalling/printerdrivers.h
@@ -70,6 +70,7 @@ static const MARSHALLING PrinterDriver5Marshalling = {
     }
 };
 
+/* TODO: Add PrinterDriver6Marshalling and PrinterDriver8Marshalling */
 
 static const MARSHALLING* pPrinterDriverMarshalling[] = {
     NULL,


### PR DESCRIPTION
Based on MSDN.

Please, double-check `EnumPrintersW` and `GetPrinterDriverW`, where old `ASSERT` did not match.