### PR TITLE
[CMAKE][BOOTDATA] Properly load Xbox video miniport driver in LiveCD

### DIFF
--- a/boot/bootdata/hiveinst_xbox.inf
+++ b/boot/bootdata/hiveinst_xbox.inf
@@ -1,0 +1,19 @@
+[Version]
+Signature = "$Windows NT$"
+
+[AddReg]
+; Enable _one_ driver per section by removing the leading semicolon.
+
+;
+; Display driver section
+;
+
+; Xbox Nvidia driver
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","ErrorControl",0x00010001,0x00000000
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Group",0x00000000,"Video Save"
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","ImagePath",0x00020000,"system32\drivers\xboxvmp.sys"
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Start",0x00010001,0x00000001
+HKLM,"SYSTEM\CurrentControlSet\Services\XboxVmp","Type",0x00010001,0x00000001
+HKLM,"SYSTEM\CurrentControlSet\Enum\PCI\VEN_10DE&DEV_02A0&SUBSYS_00000000&REV_A1\0000","Service",0x00000000,"XboxVmp"
+HKLM,"SYSTEM\CurrentControlSet\Hardware Profiles\Current\System\CurrentControlSet\Services\XboxVmp\Device0","InstalledDisplayDrivers",0x00010000,"framebuf"
+HKLM,"SYSTEM\CurrentControlSet\Hardware Profiles\Current\System\CurrentControlSet\Services\XboxVmp\Device0","VgaCompatible",0x00010001,1

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -853,8 +853,14 @@ function(create_registry_hives)
     # LiveCD hives
     list(APPEND _livecd_inf_files
         ${_registry_inf}
-        ${CMAKE_SOURCE_DIR}/boot/bootdata/livecd.inf
-        ${CMAKE_SOURCE_DIR}/boot/bootdata/hiveinst.inf)
+        ${CMAKE_SOURCE_DIR}/boot/bootdata/livecd.inf)
+    if(SARCH STREQUAL "xbox")
+        list(APPEND _livecd_inf_files
+            ${CMAKE_SOURCE_DIR}/boot/bootdata/hiveinst_xbox.inf)
+    else()
+        list(APPEND _livecd_inf_files
+            ${CMAKE_SOURCE_DIR}/boot/bootdata/hiveinst.inf)
+    endif()
 
     add_custom_command(
         OUTPUT ${CMAKE_BINARY_DIR}/boot/bootdata/system


### PR DESCRIPTION
This also surprisingly fixes random "Invalid Opcode" exceptions in XQEMU.

JIRA issue: [CORE-16627](https://jira.reactos.org/browse/CORE-16627)