### PR TITLE
[SYSSETUP] Plan A: Also write ReportAsWorkstation value

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -380,11 +380,12 @@ AckPageDlgProc(HWND hwndDlg,
 static BOOL
 DoWriteProductOption(PRODUCT_OPTION nOption)
 {
-    static const WCHAR s_szProductOptions[] = L"System\\CurrentControlSet\\Control\\ProductOptions";
+    static const WCHAR s_szProductOptions[] = L"SYSTEM\\CurrentControlSet\\Control\\ProductOptions";
+    static WCHAR s_szRosVersion[] = L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version";
     HKEY hKey;
     LONG error;
     LPCWSTR pData;
-    DWORD cbData;
+    DWORD cbData, dwValue;
 
     error = RegOpenKeyExW(HKEY_LOCAL_MACHINE, s_szProductOptions, 0, KEY_WRITE, &hKey);
     if (error)
@@ -422,6 +423,18 @@ DoWriteProductOption(PRODUCT_OPTION nOption)
     }
 
     RegCloseKey(hKey);
+
+    error = RegOpenKeyExW(HKEY_LOCAL_MACHINE, s_szRosVersion, 0, KEY_WRITE, &hKey);
+    if (error)
+        return FALSE;
+
+    /* write ReportAsWorkstation value */
+    dwValue = (nOption == PRODUCT_OPTION_WORKSTATION);
+    cbData = sizeof(dwValue);
+    error = RegSetValueExW(hKey, L"ReportAsWorkstation", 0, REG_DWORD, (BYTE *)&dwValue, cbData);
+
+    RegCloseKey(hKey);
+
     return error == ERROR_SUCCESS;
 }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -381,7 +381,7 @@ static BOOL
 DoWriteProductOption(PRODUCT_OPTION nOption)
 {
     static const WCHAR s_szProductOptions[] = L"SYSTEM\\CurrentControlSet\\Control\\ProductOptions";
-    static WCHAR s_szRosVersion[] = L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version";
+    static const WCHAR s_szRosVersion[] = L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version";
     HKEY hKey;
     LONG error;
     LPCWSTR pData;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-13795](https://jira.reactos.org/browse/CORE-13795)

Write the `ReportAsWorkstation` value of the registry key `HKLM\SYSTEM\CurrentControlSet\Control\ReactOS\Settings\Version`.
The reason is shown at [CORE-6611](https://jira.reactos.org/browse/CORE-6611).
![after](https://user-images.githubusercontent.com/2107452/74209063-8ca54400-4cc9-11ea-8b27-1d15d12fa5e9.png)
