### PR TITLE
[WIN32SS][NTUSER] Fix ScrollWindowEx SW_SCROLLCHILDREN

### DIFF
--- a/win32ss/user/ntuser/scrollex.c
+++ b/win32ss/user/ntuser/scrollex.c
@@ -385,6 +385,10 @@ IntScrollWindowEx(
          rcChild = Child->rcWindow;
          RECTL_vOffsetRect(&rcChild, -ClientOrigin.x, -ClientOrigin.y);
 
+         /* Adjust window positions */
+         RECTL_vOffsetRect(&Child->rcWindow, dx, dy);
+         RECTL_vOffsetRect(&Child->rcClient, dx, dy);
+
          if (!prcScroll || RECTL_bIntersectRect(&rcDummy, &rcChild, &rcScroll))
          {
             UserRefObjectCo(Child, &WndRef);


### PR DESCRIPTION
## Purpose

Based on the patch of `I_Kill_Bugs` of JIRA user.
JIRA issue: [CORE-16687](https://jira.reactos.org/browse/CORE-16687), [CORE-12114](https://jira.reactos.org/browse/CORE-12114)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/74209927-1a366300-4ccd-11ea-8957-46ab9be8d155.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/74209926-19053600-4ccd-11ea-972b-55043cd76714.png)