### PR TITLE
Shell Folders: Reject invalid characters

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1989,9 +1989,13 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
             m_pSFParent->GetAttributesOf(1, &pidl, &dwAttr);
             if (SFGAO_CANRENAME & dwAttr)
             {
+                HWND hEdit = reinterpret_cast<HWND>(m_ListView.SendMessage(LVM_GETEDITCONTROL));
+                SHLimitInputEdit(hEdit, m_pSFParent);
+
                 m_isEditing = TRUE;
                 return FALSE;
             }
+
             return TRUE;
         }
 

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -28,7 +28,8 @@ class CDesktopFolder :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
     public IPersistFolder2,
-    public IContextMenuCB
+    public IContextMenuCB,
+    public IItemNameLimits
 {
     private:
         /* both paths are parsible from the desktop */
@@ -79,6 +80,26 @@ class CDesktopFolder :
         // IContextMenuCB
         virtual HRESULT WINAPI CallBack(IShellFolder *psf, HWND hwndOwner, IDataObject *pdtobj, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+        /*** IItemNameLimits methods ***/
+
+        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        {
+            return E_NOTIMPL;
+        }
+
+        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        {
+            if (ppwszValidChars)
+            {
+                *ppwszValidChars = NULL;
+            }
+            if (ppwszInvalidChars)
+            {
+                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+            }
+            return S_OK;
+        }
+
         DECLARE_REGISTRY_RESOURCEID(IDR_SHELLDESKTOP)
         DECLARE_CENTRAL_INSTANCE_NOT_AGGREGATABLE(CDesktopFolder)
 
@@ -90,6 +111,7 @@ class CDesktopFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder, IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
+        COM_INTERFACE_ENTRY_IID(IID_IItemNameLimits, IItemNameLimits)
         END_COM_MAP()
 };
 

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -82,12 +82,14 @@ class CDesktopFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CDesktopFolder.h
+++ b/dll/win32/shell32/folders/CDesktopFolder.h
@@ -95,7 +95,7 @@ class CDesktopFolder :
             }
             if (ppwszInvalidChars)
             {
-                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+                SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
             }
             return S_OK;
         }

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -104,7 +104,7 @@ class CFSFolder :
             }
             if (ppwszInvalidChars)
             {
-                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+                SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
             }
             return S_OK;
         }

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -91,12 +91,14 @@ class CFSFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CFSFolder.h
+++ b/dll/win32/shell32/folders/CFSFolder.h
@@ -29,7 +29,8 @@ class CFSFolder :
     public IShellFolder2,
     public IPersistFolder3,
     public IContextMenuCB,
-    public IShellFolderViewCB
+    public IShellFolderViewCB,
+    public IItemNameLimits
 {
     private:
         const CLSID *m_pclsid;
@@ -88,6 +89,26 @@ class CFSFolder :
         // IShellFolderViewCB
         virtual HRESULT WINAPI MessageSFVCB(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+        /*** IItemNameLimits methods ***/
+
+        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        {
+            return E_NOTIMPL;
+        }
+
+        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        {
+            if (ppwszValidChars)
+            {
+                *ppwszValidChars = NULL;
+            }
+            if (ppwszInvalidChars)
+            {
+                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+            }
+            return S_OK;
+        }
+
         DECLARE_REGISTRY_RESOURCEID(IDR_SHELLFSFOLDER)
         DECLARE_NOT_AGGREGATABLE(CFSFolder)
 
@@ -101,6 +122,7 @@ class CFSFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder3, IPersistFolder3)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
         COM_INTERFACE_ENTRY_IID(IID_IShellFolderViewCB, IShellFolderViewCB)
+        COM_INTERFACE_ENTRY_IID(IID_IItemNameLimits, IItemNameLimits)
         END_COM_MAP()
 
     protected:

--- a/dll/win32/shell32/folders/CMyDocsFolder.h
+++ b/dll/win32/shell32/folders/CMyDocsFolder.h
@@ -68,12 +68,14 @@ class CMyDocsFolder :
 
         /*** IItemNameLimits methods ***/
 
-        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        STDMETHODIMP
+        GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
         {
             return E_NOTIMPL;
         }
 
-        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        STDMETHODIMP
+        GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
         {
             if (ppwszValidChars)
             {

--- a/dll/win32/shell32/folders/CMyDocsFolder.h
+++ b/dll/win32/shell32/folders/CMyDocsFolder.h
@@ -81,7 +81,7 @@ class CMyDocsFolder :
             }
             if (ppwszInvalidChars)
             {
-                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+                SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
             }
             return S_OK;
         }

--- a/dll/win32/shell32/folders/CMyDocsFolder.h
+++ b/dll/win32/shell32/folders/CMyDocsFolder.h
@@ -26,7 +26,8 @@ class CMyDocsFolder :
     public CComCoClass<CMyDocsFolder, &CLSID_MyDocuments>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
-    public IPersistFolder2
+    public IPersistFolder2,
+    public IItemNameLimits
 {
     private:
         CComPtr<IShellFolder2> m_pisfInner;
@@ -65,6 +66,26 @@ class CMyDocsFolder :
         // IPersistFolder2
         virtual HRESULT WINAPI GetCurFolder(PIDLIST_ABSOLUTE * pidl);
 
+        /*** IItemNameLimits methods ***/
+
+        STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+        {
+            return E_NOTIMPL;
+        }
+
+        STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+        {
+            if (ppwszValidChars)
+            {
+                *ppwszValidChars = NULL;
+            }
+            if (ppwszInvalidChars)
+            {
+                SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+            }
+            return S_OK;
+        }
+
         DECLARE_REGISTRY_RESOURCEID(IDR_MYDOCUMENTS)
         DECLARE_NOT_AGGREGATABLE(CMyDocsFolder)
 
@@ -76,6 +97,7 @@ class CMyDocsFolder :
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder, IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IPersist, IPersist)
+        COM_INTERFACE_ENTRY_IID(IID_IItemNameLimits, IItemNameLimits)
         END_COM_MAP()
 };
 

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -213,7 +213,7 @@ public:
         }
         if (ppwszInvalidChars)
         {
-            SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+            SHStrDupW(INVALID_FILETITLE_CHARACTERSW, ppwszInvalidChars);
         }
         return S_OK;
     }

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -200,12 +200,14 @@ public:
 
     /*** IItemNameLimits methods ***/
 
-    STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+    STDMETHODIMP
+    GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
     {
         return E_NOTIMPL;
     }
 
-    STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+    STDMETHODIMP
+    GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
     {
         if (ppwszValidChars)
         {

--- a/dll/win32/shell32/shellmenu/CMergedFolder.h
+++ b/dll/win32/shell32/shellmenu/CMergedFolder.h
@@ -50,6 +50,7 @@ class CMergedFolder :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IShellFolder2,
     public IPersistFolder2,
+    public IItemNameLimits,
     public IAugmentedShellFolder3     // -- undocumented
     //public IShellService,              // DEPRECATED IE4 interface: https://msdn.microsoft.com/en-us/library/windows/desktop/bb774870%28v=vs.85%29.aspx
     //public ITranslateShellChangeNotify,// -- undocumented
@@ -84,6 +85,7 @@ public:
         COM_INTERFACE_ENTRY_IID(IID_IPersist,        IPersist)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder,  IPersistFolder)
         COM_INTERFACE_ENTRY_IID(IID_IPersistFolder2, IPersistFolder2)
+        COM_INTERFACE_ENTRY_IID(IID_IItemNameLimits, IItemNameLimits)
         COM_INTERFACE_ENTRY_IID(IID_IAugmentedShellFolder,  IAugmentedShellFolder)
         COM_INTERFACE_ENTRY_IID(IID_IAugmentedShellFolder2, IAugmentedShellFolder2)
         COM_INTERFACE_ENTRY_IID(IID_IAugmentedShellFolder3, IAugmentedShellFolder3)
@@ -195,6 +197,26 @@ public:
 
     // IPersistFolder2
     virtual HRESULT STDMETHODCALLTYPE GetCurFolder(PIDLIST_ABSOLUTE * pidl);
+
+    /*** IItemNameLimits methods ***/
+
+    STDMETHODIMP GetMaxLength(LPCWSTR pszName, int *piMaxNameLen)
+    {
+        return E_NOTIMPL;
+    }
+
+    STDMETHODIMP GetValidCharacters(LPWSTR *ppwszValidChars, LPWSTR *ppwszInvalidChars)
+    {
+        if (ppwszValidChars)
+        {
+            *ppwszValidChars = NULL;
+        }
+        if (ppwszInvalidChars)
+        {
+            SHStrDupW(L"\\/:*?\"<>|", ppwszInvalidChars);
+        }
+        return S_OK;
+    }
 
     // IAugmentedShellFolder2
     virtual HRESULT STDMETHODCALLTYPE AddNameSpace(LPGUID lpGuid, IShellFolder * psf, LPCITEMIDLIST pcidl, ULONG dwUnknown);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2231,7 +2231,6 @@ DoSanitizeClipboard(HWND hwnd, UxSubclassInfo *pInfo)
         CloseClipboard();
         return;
     }
-
     SHStrDupW(pszText, &pszSanitized);
     GlobalUnlock(hData);
 
@@ -2261,6 +2260,7 @@ static LRESULT CALLBACK
 LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     WNDPROC fnWndProc;
+    WCHAR wch;
     UxSubclassInfo *pInfo = GetPropW(hwnd, L"UxSubclassInfo");
     if (!pInfo)
         return DefWindowProcW(hwnd, uMsg, wParam, lParam);
@@ -2271,13 +2271,10 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         case WM_KEYDOWN:
             if (GetKeyState(VK_SHIFT) < 0 && wParam == VK_INSERT)
-            {
                 DoSanitizeClipboard(hwnd, pInfo);
-            }
             else if (GetKeyState(VK_CONTROL) < 0 && wParam == L'V')
-            {
                 DoSanitizeClipboard(hwnd, pInfo);
-            }
+
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
 
         case WM_PASTE:
@@ -2285,7 +2282,6 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
 
         case WM_CHAR:
-        {
             if (GetKeyState(VK_CONTROL) < 0 && wParam == L'V')
                 break;
 
@@ -2306,7 +2302,6 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
             }
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
-        }
 
         case WM_UNICHAR:
             if (wParam == UNICODE_NOCHAR)
@@ -2315,8 +2310,7 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             /* FALL THROUGH */
 
         case WM_IME_CHAR:
-        {
-            WCHAR wch = (WCHAR)wParam;
+            wch = (WCHAR)wParam;
             if (GetKeyState(VK_CONTROL) < 0 && wch == L'V')
                 break;
 
@@ -2343,13 +2337,10 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 }
             }
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
-        }
 
         case WM_NCDESTROY:
-        {
             UxSubclassInfo_Destroy(pInfo);
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
-        }
 
         default:
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2254,7 +2254,6 @@ DoSanitizeClipboard(HWND hwnd, UxSubclassInfo *pInfo)
     }
 
     CoTaskMemFree(pszSanitized);
-
     CloseClipboard();
 }
 
@@ -2288,9 +2287,8 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         case WM_CHAR:
         {
             if (GetKeyState(VK_CONTROL) < 0 && wParam == L'V')
-            {
                 break;
-            }
+
             if (pInfo->pwszInvalidChars)
             {
                 if (wcschr(pInfo->pwszInvalidChars, (WCHAR)wParam) != NULL)
@@ -2320,9 +2318,8 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             WCHAR wch = (WCHAR)wParam;
             if (GetKeyState(VK_CONTROL) < 0 && wch == L'V')
-            {
                 break;
-            }
+
             if (!IsWindowUnicode(hwnd) && HIBYTE(wch) != 0)
             {
                 CHAR data[] = {HIBYTE(wch), LOBYTE(wch)};

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2285,6 +2285,10 @@ LimitEditWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
             return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
 
+        case WM_PASTE:
+            DoSanitizeClipboard(hwnd, pInfo);
+            return CallWindowProcW(fnWndProc, hwnd, uMsg, wParam, lParam);
+
         case WM_CHAR:
         {
             if (GetKeyState(VK_CONTROL) < 0 && wParam == L'V')

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2185,15 +2185,13 @@ DoSanitizeText(LPWSTR pszSanitized, LPCWSTR pszInvalidChars, LPCWSTR pszValidCha
     LPWSTR pch1, pch2;
     BOOL bFound = FALSE;
 
-    pch1 = pch2 = pszSanitized;
-    while (*pch1)
+    for (pch1 = pch2 = pszSanitized; *pch1; ++pch1)
     {
         if (pszInvalidChars)
         {
             if (wcschr(pszInvalidChars, *pch1) != NULL)
             {
                 bFound = TRUE;
-                ++pch1;
                 continue;
             }
         }
@@ -2202,13 +2200,11 @@ DoSanitizeText(LPWSTR pszSanitized, LPCWSTR pszInvalidChars, LPCWSTR pszValidCha
             if (wcschr(pszValidChars, *pch1) == NULL)
             {
                 bFound = TRUE;
-                ++pch1;
                 continue;
             }
         }
 
         *pch2 = *pch1;
-        ++pch1;
         ++pch2;
     }
     *pch2 = 0;

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -698,6 +698,19 @@ IStream* WINAPI SHGetViewStream(LPCITEMIDLIST, DWORD, LPCTSTR, LPCTSTR, LPCTSTR)
 EXTERN_C HRESULT WINAPI SHCreateSessionKey(REGSAM samDesired, PHKEY phKey);
 
 /*****************************************************************************
+ * INVALID_FILETITLE_CHARACTERS
+ */
+
+#define INVALID_FILETITLE_CHARACTERSA "\\/:*?\"<>|"
+#define INVALID_FILETITLE_CHARACTERSW L"\\/:*?\"<>|"
+
+#ifdef UNICODE
+    #define INVALID_FILETITLE_CHARACTERS INVALID_FILETITLE_CHARACTERSW
+#else
+    #define INVALID_FILETITLE_CHARACTERS INVALID_FILETITLE_CHARACTERSA
+#endif
+
+/*****************************************************************************
  * Shell Link
  */
 #include <pshpack1.h>


### PR DESCRIPTION
## Purpose
Reject invalid input filename characters by using `shell32!SHLimitInputEdit` function and `IItemNameLimits` interface.
JIRA issue: [CORE-11701](https://jira.reactos.org/browse/CORE-11701)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/74214023-0c89d900-4cdf-11ea-8c70-d726c150eca1.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/74214022-0bf14280-4cdf-11ea-88eb-9609946f585a.png)