### PR TITLE
[SHELL32] Rewrite SHAddToRecentDocs

### DIFF
--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -4,13 +4,15 @@
  * FILE:        base/applications/mspaint/registry.cpp
  * PURPOSE:     Offering functions dealing with registry values
  * PROGRAMMERS: Benedikt Freisen
+ *              Katayama Hirofumi MZ
  */
 
 /* INCLUDES *********************************************************/
 
 #include "precomp.h"
-
 #include <winreg.h>
+#include <wincon.h>
+#include <shlobj.h>
 
 /* FUNCTIONS ********************************************************/
 static DWORD ReadDWORD(CRegKey &key, LPCTSTR lpName, DWORD &dwValue, BOOL bCheckForDef)
@@ -143,6 +145,9 @@ void RegistrySettings::Store()
 
 void RegistrySettings::SetMostRecentFile(LPCTSTR szPathName)
 {
+    if (szPathName && szPathName[0])
+        SHAddToRecentDocs(SHARD_PATHW, szPathName);
+
     if (strFile1 == szPathName)
     {
         // do nothing

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -5,6 +5,7 @@
  *  Copyright 1997,98 Marcel Baur <mbaur@g26.ethz.ch>
  *  Copyright 2002 Sylvain Petreolle <spetreolle@yahoo.fr>
  *  Copyright 2002 Andriy Palamarchuk
+ *  Copyright 2020 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -24,6 +25,7 @@
 
 #include "notepad.h"
 
+#include <shlobj.h>
 #include <strsafe.h>
 
 NOTEPAD_GLOBALS Globals;
@@ -48,6 +50,9 @@ VOID SetFileName(LPCTSTR szFileName)
     StringCchCopy(Globals.szFileName, ARRAY_SIZE(Globals.szFileName), szFileName);
     Globals.szFileTitle[0] = 0;
     GetFileTitle(szFileName, Globals.szFileTitle, ARRAY_SIZE(Globals.szFileTitle));
+
+    if (szFileName && szFileName[0])
+        SHAddToRecentDocs(SHARD_PATHW, szFileName);
 }
 
 /***********************************************************************

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -3,6 +3,7 @@
  *
  * Copyright 2004 by Krzysztof Foltman
  * Copyright 2007-2008 by Alexander N. Sørnes <alex@thehandofagony.com>
+ * Copyright 2020 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -32,6 +33,7 @@
 #include <commctrl.h>
 #include <commdlg.h>
 #include <shellapi.h>
+#include <shlobj.h>
 #include <wine/unicode.h>
 
 #include "wordpad.h"
@@ -811,6 +813,8 @@ static void DoOpenFile(LPCWSTR szOpenFileName)
     SetFocus(hEditorWnd);
 
     set_caption(szOpenFileName);
+    if (szOpenFileName[0])
+        SHAddToRecentDocs(SHARD_PATHW, szOpenFileName);
 
     lstrcpyW(wszFileName, szOpenFileName);
     SendMessageW(hEditorWnd, EM_SETMODIFY, FALSE, 0);
@@ -883,6 +887,9 @@ static BOOL DoSaveFile(LPCWSTR wszSaveFileName, WPARAM format)
 
     lstrcpyW(wszFileName, wszSaveFileName);
     set_caption(wszFileName);
+    if (wszFileName[0])
+        SHAddToRecentDocs(SHARD_PATHW, wszFileName);
+
     SendMessageW(hEditorWnd, EM_SETMODIFY, FALSE, 0);
     set_fileformat(format);
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -751,13 +751,15 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     switch (uFlags)
     {
         case SHARD_PATHA:
-            MultiByteToWideChar(CP_ACP, 0, pv, -1, szTargetPath, ARRAYSIZE(szTargetPath));
+            MultiByteToWideChar(CP_ACP, 0, pv, -1, szLinkDir, ARRAYSIZE(szLinkDir));
+            GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
             break;
         case SHARD_PATHW:
-            lstrcpynW(szTargetPath, pv, ARRAYSIZE(szTargetPath));
+            GetFullPathNameW(pv, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
             break;
         case SHARD_PIDL:
-            SHGetPathFromIDListW(pv, szTargetPath);
+            SHGetPathFromIDListW(pv, szLinkDir);
+            GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
             break;
         default:
             FIXME("Unsupported flags: %u\n", uFlags);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -626,25 +626,25 @@ DoStoreMRUData(LPBYTE pbBuffer, LPDWORD pcbBuffer,
 
     cb = (cchTargetTitle + 1 + cchTargetPath + 1 + cchLinkTitle + 2) * sizeof(WCHAR);
     if (cb > *pcbBuffer)
-       return FALSE;
+        return FALSE;
 
     ZeroMemory(pbBuffer, *pcbBuffer);
 
     cb = (cchTargetTitle + 1) * sizeof(WCHAR);
     if (ib + cb > *pcbBuffer)
-       return FALSE;
+        return FALSE;
     CopyMemory(&pbBuffer[ib], pszTargetTitle, cb);
     ib += cb;
 
     cb = (cchTargetPath + 1) * sizeof(WCHAR);
     if (ib + cb > *pcbBuffer)
-       return FALSE;
+        return FALSE;
     CopyMemory(&pbBuffer[ib], pszTargetPath, cb);
     ib += cb;
 
     cb = (cchLinkTitle + 1) * sizeof(WCHAR);
     if (ib + cb > *pcbBuffer)
-       return FALSE;
+        return FALSE;
     CopyMemory(&pbBuffer[ib], pszLinkTitle, cb);
     ib += cb;
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -877,7 +877,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     /* ***  JOB 1: Update registry for ...\Explorer\RecentDocs list  *** */
 
     mru.uMax = 64;
-    mru.fFlags = MRU_BINARY;
+    mru.fFlags = MRU_BINARY | MRU_CACHEWRITE;
     mru.hKey = hExplorerKey;
     mru.lpszSubKey = L"RecentDocs";
     mru.lpfnCompare = (MRUCMPPROCW)SHADD_compare_mru;

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -620,13 +620,13 @@ SHADD_add_mru_item(HANDLE hMRU, LPCWSTR pszTargetTitle, LPCWSTR pszLinkTitle,
 
     cb = (cchTargetTitle + 1) * sizeof(WCHAR);
     if (ib + cb > *pcbBuffer)
-        return -1;
+        return -2;
     CopyMemory(&pbBuffer[ib], pszTargetTitle, cb);
     ib += cb;
 
     cb = (cchLinkTitle + 1) * sizeof(WCHAR);
     if (ib + cb > *pcbBuffer)
-        return -1;
+        return -3;
     CopyMemory(&pbBuffer[ib], pszLinkTitle, cb);
     ib += cb;
 
@@ -892,9 +892,9 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     cbBuffer = sizeof(Buffer);
     ret = SHADD_add_mru_item(hMRUList, pchTargetTitle, pchLinkTitle,
                              Buffer, &cbBuffer);
-    if (ret == -1)
+    if (ret < 0)
     {
-        ERR("SHADD_add_mru_item failed\n");
+        ERR("SHADD_add_mru_item failed: %d\n", ret);
     }
     FreeMRUList(hMRUList);
     RegCloseKey(hExplorerKey);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -742,9 +742,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
         TRACE("policy value for NoRecentDocsHistory = %08x\n", data[0]);
         /* now test the actual policy value */
         if (data[0] != 0)
-        {
             return;
-        }
     }
 
     /* store to szTargetPath */
@@ -894,15 +892,12 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     cbBuffer = sizeof(Buffer);
     ret = SHADD_add_mru_item(hMRUList, pchTargetTitle, pchLinkTitle,
                              Buffer, &cbBuffer);
-
-    FreeMRUList(hMRUList);
-    RegCloseKey(hExplorerKey);
-
     if (ret == -1)
     {
         ERR("SHADD_add_mru_item failed\n");
-        goto Quit;
     }
+    FreeMRUList(hMRUList);
+    RegCloseKey(hExplorerKey);
 
     /* ***  JOB 2: Create shortcut in user's "Recent" directory  *** */
 

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -706,7 +706,7 @@ static INT SHADD_create_add_mru_data(HANDLE mruhandle, LPCSTR doc_name, LPCSTR n
 void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
 {
 #ifdef __REACTOS__
-    static const WCHAR szExplorerKey[] = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer";
+    static const WCHAR szExplorerKey[] = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer";
     INT ret;
     WCHAR szTargetPath[MAX_PATH], szLinkDir[MAX_PATH], szLinkFile[MAX_PATH], szDescription[128], szData[1280];
     DWORD data[64], datalen, type;

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -725,7 +725,8 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
 #ifdef __REACTOS__
     static const WCHAR szExplorerKey[] = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Explorer";
     INT ret;
-    WCHAR szTargetPath[MAX_PATH], szLinkDir[MAX_PATH], szLinkFile[MAX_PATH], szDescription[128];
+    WCHAR szTargetPath[MAX_PATH], szLinkDir[MAX_PATH], szLinkFile[MAX_PATH], szDescription[80];
+    WCHAR szPath[MAX_PATH];
     DWORD cbBuffer, data[64], datalen, type;
     HANDLE hFind;
     WIN32_FIND_DATAW find;
@@ -847,10 +848,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     pchDotExt = PathFindExtensionW(szTargetPath);
     while (lstrcmpiW(pchDotExt, L".lnk") == 0)
     {
-        WCHAR szPath[MAX_PATH];
-        IShellLinkW *pShellLink = NULL;
-
-        hr = IShellLink_ConstructFromPath(szTargetPath, &IID_IShellLinkW, (LPVOID*)&pShellLink);
+        hr = IShellLink_ConstructFromPath(szTargetPath, &IID_IShellLinkW, (LPVOID*)&psl);
         if (FAILED(hr))
         {
             ERR("IShellLink_ConstructFromPath: 0x%08X\n", hr);
@@ -858,8 +856,8 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
             return;
         }
 
-        IShellLinkW_GetPath(pShellLink, szPath, ARRAYSIZE(szPath), NULL, 0);
-        IShellLinkW_Release(pShellLink);
+        IShellLinkW_GetPath(psl, szPath, ARRAYSIZE(szPath), NULL, 0);
+        IShellLinkW_Release(psl);
 
         lstrcpynW(szTargetPath, szPath, ARRAYSIZE(szTargetPath));
         pchDotExt = PathFindExtensionW(szTargetPath);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -733,11 +733,11 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     HKEY hExplorerKey;
     LONG error;
     LPWSTR pchDotExt, pchTargetTitle, pchLinkTitle;
-    MRUINFOW mru = {sizeof(mru)};
+    MRUINFOW mru;
     HANDLE hMRUList;
-    IShellLinkW *psl = NULL;
+    IShellLinkW *psl;
+    IPersistFile *pPf;
     HRESULT hr;
-    IPersistFile *pPf = NULL;
     BYTE Buffer[(MAX_PATH + 64) * sizeof(WCHAR)];
 
     TRACE("%04x %p\n", uFlags, pv);
@@ -904,6 +904,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     }
 
     /* create MRU list */
+    mru.cbSize = sizeof(mru);
     mru.uMax = 16;
     mru.fFlags = MRU_BINARY | MRU_CACHEWRITE;
     mru.hKey = hExplorerKey;
@@ -949,6 +950,9 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     RegCloseKey(hExplorerKey);
 
     /* ***  JOB 2: Create shortcut in user's "Recent" directory  *** */
+
+    psl = NULL;
+    pPf = NULL;
 
     hr = CoCreateInstance(&CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER,
                           &IID_IShellLinkW, (LPVOID *)&psl);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -925,8 +925,9 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
                             FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
         if (hFile != INVALID_HANDLE_VALUE)
         {
+            TRACE("Just touch file '%S'.\n", szLinkFile);
             CloseHandle(hFile);
-            TRACE("File '%S' already exists.\n", szLinkFile);
+            FreeMRUList(hMRUList);
             RegCloseKey(hExplorerKey);
             return;
         }

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -882,11 +882,11 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     pchTargetTitle = PathFindFileNameW(szTargetPath);
 
     lstrcpyW(szDescription, L"Shortcut to ");
-    lstrcatW(szDescription, pchTargetTitle);
+    StrCatBuffW(szDescription, pchTargetTitle, ARRAYSIZE(szDescription));
 
     lstrcpynW(szLinkFile, szLinkDir, ARRAYSIZE(szLinkFile));
     PathAppendW(szLinkFile, pchTargetTitle);
-    lstrcatW(szLinkFile, L".lnk");
+    StrCatBuffW(szLinkFile, L".lnk", ARRAYSIZE(szLinkFile));
     pchLinkTitle = PathFindFileNameW(szLinkFile);
 
     /* ***  JOB 1: Update registry for ...\Explorer\RecentDocs list  *** */

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -619,7 +619,6 @@ static BOOL
 DoStoreMRUData(LPBYTE pbBuffer, LPDWORD pcbBuffer,
                LPCWSTR pszTargetTitle, LPCWSTR pszTargetPath, LPCWSTR pszLinkTitle)
 {
-    /* FIXME: Make me compatible */
     DWORD ib = 0, cb;
     INT cchTargetTitle = lstrlenW(pszTargetTitle);
     INT cchTargetPath = lstrlenW(pszTargetPath);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -737,9 +737,8 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     if (ret > 0 && ret != ERROR_FILE_NOT_FOUND)
     {
         ERR("Error %d getting policy \"NoRecentDocsHistory\"\n", ret);
-        return;
     }
-    if (ret == ERROR_SUCCESS)
+    else if (ret == ERROR_SUCCESS)
     {
         if (!(type == REG_DWORD || (type == REG_BINARY && datalen == 4)))
         {
@@ -751,7 +750,9 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
         TRACE("policy value for NoRecentDocsHistory = %08x\n", data[0]);
         /* now test the actual policy value */
         if (data[0] != 0)
+        {
             return;
+        }
     }
 
     /* store to szTargetPath */
@@ -820,6 +821,14 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
         return;
     }
 
+    hr = CoInitialize(NULL);
+    if (FAILED(hr))
+    {
+        ERR("CoInitialize: %08X\n", hr);
+        RegCloseKey(hExplorerKey);
+        return;
+    }
+
     /* check if file is a shortcut */
     pchDotExt = PathFindExtensionW(szTargetPath);
     while (lstrcmpiW(pchDotExt, L".lnk") == 0)
@@ -873,13 +882,6 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     RegCloseKey(hExplorerKey);
 
     /* ***  JOB 2: Create shortcut in user's "Recent" directory  *** */
-
-    hr = CoInitialize(NULL);
-    if (FAILED(hr))
-    {
-        ERR("CoInitialize: %08X\n", hr);
-        goto Quit;
-    }
 
     hr = CoCreateInstance(&CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER,
                           &IID_IShellLinkW, (LPVOID *)&psl);

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -748,22 +748,25 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
     }
 
     /* store to szTargetPath */
-    switch (uFlags)
+    if (pv)
     {
-        case SHARD_PATHA:
-            MultiByteToWideChar(CP_ACP, 0, pv, -1, szLinkDir, ARRAYSIZE(szLinkDir));
-            GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
-            break;
-        case SHARD_PATHW:
-            GetFullPathNameW(pv, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
-            break;
-        case SHARD_PIDL:
-            SHGetPathFromIDListW(pv, szLinkDir);
-            GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
-            break;
-        default:
-            FIXME("Unsupported flags: %u\n", uFlags);
-            return;
+        switch (uFlags)
+        {
+            case SHARD_PATHA:
+                MultiByteToWideChar(CP_ACP, 0, pv, -1, szLinkDir, ARRAYSIZE(szLinkDir));
+                GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
+                break;
+            case SHARD_PATHW:
+                GetFullPathNameW(pv, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
+                break;
+            case SHARD_PIDL:
+                SHGetPathFromIDListW(pv, szLinkDir);
+                GetFullPathNameW(szLinkDir, ARRAYSIZE(szTargetPath), szTargetPath, NULL);
+                break;
+            default:
+                FIXME("Unsupported flags: %u\n", uFlags);
+                return;
+        }
     }
 
     /* get recent folder */
@@ -803,7 +806,7 @@ void WINAPI SHAddToRecentDocs (UINT uFlags,LPCVOID pv)
             FindClose(hFind);
         }
 
-        RegDeleteKeyW(hExplorerKey, L"RecentDocs");
+        SHDeleteKeyW(hExplorerKey, L"RecentDocs");
         RegCloseKey(hExplorerKey);
         return;
     }

--- a/dll/win32/shimgvw/CMakeLists.txt
+++ b/dll/win32/shimgvw/CMakeLists.txt
@@ -11,5 +11,5 @@ list(APPEND SOURCE
 add_library(shimgvw MODULE ${SOURCE})
 set_module_type(shimgvw win32dll)
 target_link_libraries(shimgvw wine)
-add_importlibs(shimgvw advapi32 comctl32 user32 gdi32 gdiplus comdlg32 shlwapi msvcrt kernel32 ntdll)
+add_importlibs(shimgvw advapi32 comctl32 user32 gdi32 shell32 gdiplus comdlg32 shlwapi msvcrt kernel32 ntdll)
 add_cd_file(TARGET shimgvw DESTINATION reactos/system32 FOR all)

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -18,12 +18,14 @@
 #include <winnls.h>
 #include <winreg.h>
 #include <wingdi.h>
+#include <wincon.h>
 #include <windowsx.h>
 #include <objbase.h>
 #include <commctrl.h>
 #include <commdlg.h>
 #include <gdiplus.h>
 #include <tchar.h>
+#include <shlobj.h>
 #include <strsafe.h>
 #include <shlwapi.h>
 
@@ -303,6 +305,9 @@ static void pLoadImage(LPWSTR szOpenFileName)
         return;
     }
     Anime_LoadInfo();
+
+    if (szOpenFileName && szOpenFileName[0])
+        SHAddToRecentDocs(SHARD_PATHW, szOpenFileName);
 
     /* reset zoom */
     ResetZoom();


### PR DESCRIPTION
## Purpose
Rewrite `shell32!SHAddToRecentDocs` and use it in some applications.
JIRA issue: [CORE-3588](https://jira.reactos.org/browse/CORE-3588)
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/74308521-ca7a9900-4dab-11ea-8c16-410aa5485b97.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/74308519-c9496c00-4dab-11ea-8147-3eb58fb0d8e6.png)

Wine's `SHAddToRecentDocs` was not Unicode supported and unusable. I will dare to rewrite.