### PR TITLE
[MSV1_0] improve LogonUserEx2

### DIFF
--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1244,9 +1244,6 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
         /* Fix-up pointers in the authentication info */
         PtrOffset = (ULONG_PTR)ProtocolSubmitBuffer - (ULONG_PTR)ClientBufferBase;
 
-        Status = RtlValidateUnicodeString(0, &LogonInfo->LogonDomainName);
-        if (!NT_SUCCESS(Status))
-            return STATUS_INVALID_PARAMETER;
         /* LogonDomainName is optional and can be an empty string */
         if (LogonInfo->LogonDomainName.Length)
         {
@@ -1259,16 +1256,16 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             LogonInfo->LogonDomainName.Buffer = NULL;
             LogonInfo->LogonDomainName.MaximumLength = 0;
         }
-
-        Status = RtlValidateUnicodeString(0, &LogonInfo->UserName);
+        Status = RtlValidateUnicodeString(0, &LogonInfo->LogonDomainName);
         if (!NT_SUCCESS(Status))
             return STATUS_INVALID_PARAMETER;
+
         /* UserName is mandatory and cannot be an empty string */
         // TODO: Check for Buffer limits wrt. ClientBufferBase and alignment.
         LogonInfo->UserName.Buffer = FIXUP_POINTER(LogonInfo->UserName.Buffer, PtrOffset);
         LogonInfo->UserName.MaximumLength = LogonInfo->UserName.Length;
 
-        Status = RtlValidateUnicodeString(0, &LogonInfo->Password);
+        Status = RtlValidateUnicodeString(0, &LogonInfo->UserName);
         if (!NT_SUCCESS(Status))
             return STATUS_INVALID_PARAMETER;
         /* Password is optional and can be an empty string */
@@ -1283,6 +1280,10 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             LogonInfo->Password.Buffer = NULL;
             LogonInfo->Password.MaximumLength = 0;
         }
+
+        Status = RtlValidateUnicodeString(0, &LogonInfo->Password);
+        if (!NT_SUCCESS(Status))
+            return STATUS_INVALID_PARAMETER;
 
         TRACE("Domain: %wZ\n", &LogonInfo->LogonDomainName);
         TRACE("User: %wZ\n", &LogonInfo->UserName);

--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -1284,9 +1284,9 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             LogonInfo->Password.MaximumLength = 0;
         }
 
-        TRACE("Domain: %S\n", LogonInfo->LogonDomainName.Buffer);
-        TRACE("User: %S\n", LogonInfo->UserName.Buffer);
-        TRACE("Password: %S\n", LogonInfo->Password.Buffer);
+        TRACE("Domain: %wZ\n", &LogonInfo->LogonDomainName);
+        TRACE("User: %wZ\n", &LogonInfo->UserName);
+        TRACE("Password: %wZ\n", &LogonInfo->Password);
 
         // TODO: If LogonType == Service, do some extra work using LogonInfo->Password.
     }
@@ -1442,7 +1442,7 @@ LsaApLogonUserEx2(IN PLSA_CLIENT_REQUEST ClientRequest,
             goto done;
         }
 
-        TRACE("UserName: %S\n", UserInfo->All.UserName.Buffer);
+        TRACE("UserName: %wZ\n", &UserInfo->All.UserName);
 
         /* Check the password */
         if ((UserInfo->All.UserAccountControl & USER_PASSWORD_NOT_REQUIRED) == 0)


### PR DESCRIPTION
- improves traces: use %wZ for UNICODE_STRING
- move validation of UNICODE_STRINGS after pointer fixup
- use RtlRunDecodeUnicodeString if needed