### PR TITLE
[NET] cmdAccounts(): Set ProductType default value

### DIFF
--- a/base/applications/network/net/cmdAccounts.c
+++ b/base/applications/network/net/cmdAccounts.c
@@ -17,7 +17,7 @@ cmdAccounts(
     PUSER_MODALS_INFO_0 Info0 = NULL;
     PUSER_MODALS_INFO_1 Info1 = NULL;
     PUSER_MODALS_INFO_3 Info3 = NULL;
-    NT_PRODUCT_TYPE ProductType;
+    NT_PRODUCT_TYPE ProductType = NtProductWinNt;
     LPWSTR p;
     LPWSTR endptr;
     DWORD ParamErr;


### PR DESCRIPTION
## Purpose

No uninitialized use, as done at the other `RtlGetNtProductType()` calls.

https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=NT_PRODUCT_TYPE+.*ProductType&sr=1
