### PR TITLE
[NTOS:MM] Get rid of unnecessary MmZeroingPageThreadActive

### DIFF
--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -639,7 +639,6 @@ extern PMMPDE MiHighestUserPde;
 extern PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
 extern PMMPTE MmSharedUserDataPte;
 extern LIST_ENTRY MmProcessList;
-extern BOOLEAN MmZeroingPageThreadActive;
 extern KEVENT MmZeroingPageEvent;
 extern ULONG MmSystemPageColor;
 extern ULONG MmProcessColorSeed;

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -2181,9 +2181,8 @@ MmArmInitSystem(IN ULONG Phase,
         /* Initialize the Loader Lock */
         KeInitializeMutant(&MmSystemLoadLock, FALSE);
 
-        /* Set the zero page event */
-        KeInitializeEvent(&MmZeroingPageEvent, SynchronizationEvent, FALSE);
-        MmZeroingPageThreadActive = FALSE;
+        /* Set up the zero page event */
+        KeInitializeEvent(&MmZeroingPageEvent, NotificationEvent, FALSE);
 
         /* Initialize the dead stack S-LIST */
         InitializeSListHead(&MmDeadStackSListHead);

--- a/ntoskrnl/mm/ARM3/pfnlist.c
+++ b/ntoskrnl/mm/ARM3/pfnlist.c
@@ -704,6 +704,7 @@ MiInsertPageInFreeList(IN PFN_NUMBER PageFrameIndex)
     if ((ListHead->Total >= 8) && !(MmZeroingPageThreadActive))
     {
         /* Set the event */
+        MmZeroingPageThreadActive = TRUE;
         KeSetEvent(&MmZeroingPageEvent, IO_NO_INCREMENT, FALSE);
     }
 

--- a/ntoskrnl/mm/ARM3/pfnlist.c
+++ b/ntoskrnl/mm/ARM3/pfnlist.c
@@ -701,10 +701,9 @@ MiInsertPageInFreeList(IN PFN_NUMBER PageFrameIndex)
     ColorTable->Count++;
 
     /* Notify zero page thread if enough pages are on the free list now */
-    if ((ListHead->Total >= 8) && !(MmZeroingPageThreadActive))
+    if (ListHead->Total >= 8)
     {
         /* Set the event */
-        MmZeroingPageThreadActive = TRUE;
         KeSetEvent(&MmZeroingPageEvent, IO_NO_INCREMENT, FALSE);
     }
 

--- a/ntoskrnl/mm/ARM3/zeropage.c
+++ b/ntoskrnl/mm/ARM3/zeropage.c
@@ -17,7 +17,6 @@
 
 /* GLOBALS ********************************************************************/
 
-BOOLEAN MmZeroingPageThreadActive;
 KEVENT MmZeroingPageEvent;
 
 /* PRIVATE FUNCTIONS **********************************************************/
@@ -73,7 +72,7 @@ MmZeroPageThread(VOID)
         {
             if (!MmFreePageListHead.Total)
             {
-                MmZeroingPageThreadActive = FALSE;
+                KeClearEvent(&MmZeroingPageEvent);
                 MiReleasePfnLock(OldIrql);
                 break;
             }

--- a/ntoskrnl/mm/ARM3/zeropage.c
+++ b/ntoskrnl/mm/ARM3/zeropage.c
@@ -68,7 +68,6 @@ MmZeroPageThread(VOID)
                                  NULL,
                                  NULL);
         OldIrql = MiAcquirePfnLock();
-        MmZeroingPageThreadActive = TRUE;
 
         while (TRUE)
         {


### PR DESCRIPTION
Note the first commit -- I was fixing a race condition with the current code. Then I noticed that the boolean is totally unnecessary as far as I can tell. A `NotificationEvent` can store this same information.
Feel free to prove me wrong ;)