### PR TITLE
[APISETS] Remove RoInitialize stub

### DIFF
--- a/dll/apisets/api-ms-win-core-winrt-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-core-winrt-l1-1-0.spec
@@ -4,7 +4,7 @@
 @ stub RoActivateInstance
 @ stub RoGetActivationFactory
 @ stub RoGetApartmentIdentifier
-@ stub RoInitialize
+# RoInitialize
 @ stub RoRegisterActivationFactories
 @ stub RoRegisterForApartmentShutdown
 @ stub RoRevokeActivationFactories


### PR DESCRIPTION
## Purpose

Remove a stub for RoInitialize function (NT6+) from api-ms-win-core-winrt-l1-1-0 apiset. Add a comment with the function name instead of that.
It fixes a regression with starting Motorbike game. Now it does not crash anymore.
Since we currently even don't have a dll or header that contains this function, it seems to be the best fix for this issue for now.

JIRA issue: [CORE-16707](https://jira.reactos.org/browse/CORE-16707)

## Result

Before:
![0 4 9-dev-626-g3f15a0d](https://user-images.githubusercontent.com/26385117/75114395-44d5d380-565e-11ea-9b5d-9050ac19f5ca.png)

After:
![fixed](https://user-images.githubusercontent.com/26385117/75114411-5ae39400-565e-11ea-8da4-5bd5789df166.png)

XP:
![Motorbike_XP](https://user-images.githubusercontent.com/26385117/75114441-86ff1500-565e-11ea-9819-f01bf1bc9080.png)