### PR TITLE
[HAL] Fix debug prints in ShowSize() and its caller

### DIFF
--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -792,7 +792,7 @@ ShowSize(ULONG x)
     {
         DbgPrint("%d", x);
     }
-    DbgPrint("]\n");
+    DbgPrint("]");
 }
 
 /*
@@ -980,6 +980,7 @@ HalpDebugPciDumpBus(IN ULONG i,
                          (Mem & PCI_ADDRESS_MEMORY_PREFETCHABLE) ? "" : "non-");
                 ShowSize(Size);
             }
+            DbgPrint("\n");
         }
     }
 }


### PR DESCRIPTION
Noticed the problem in Daniel's debug logs from Xbox with some missing linebreaks.
```
	I/O ports at 0000	I/O ports at 0000
00:09.0 IDE interface [0101]: NVIDIA Corporation nForce IDE [10de:01bc] (rev d4)
```
```
	Memory at f0000000 (32-bit, prefetchable) [size=256M]
	Memory at 00000000 (32-bit, prefetchable)	Device is using IRQ 3! ISA Cards using that IRQ may fail!
```