### PR TITLE
[TRAVIS] Disable code format checker in CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ env:
     - CLFORMAT_BINARY=clang-format-9
   jobs:
     - DO_BUILD=1
-    - DO_CHECK=1
 
 before_install:
   - ln -s /usr/share/clang/clang-format-9/clang-format-diff.py ./sdk/tools/;


### PR DESCRIPTION
The configuration is not final yet and we have a lot of files that don't
follow the suggested file. At this point, having it active in CI means
builds are essentially always red, and we miss actual compilation errors.