### PR TITLE
[REISERFS][EXT2][LIBTIRPC] Fix unreferenced local variable (C4101)

### DIFF
--- a/dll/3rdparty/libtirpc/src/svc_vc.c
+++ b/dll/3rdparty/libtirpc/src/svc_vc.c
@@ -312,7 +312,6 @@ rendezvous_request(xprt, msg)
 	socklen_t len;
 	struct __rpc_sockinfo si;
 	SVCXPRT *newxprt;
-	fd_set cleanfds;
 
 	assert(xprt != NULL);
 	assert(msg != NULL);

--- a/drivers/filesystems/ext2/src/block.c
+++ b/drivers/filesystems/ext2/src/block.c
@@ -250,7 +250,6 @@ Ext2ReadWriteBlocks(
     PMDL                Mdl;
     PEXT2_RW_CONTEXT    pContext = NULL;
     PEXT2_EXTENT        Extent;
-    KEVENT              Wait;
     NTSTATUS            Status = STATUS_SUCCESS;
     BOOLEAN             bMasterCompleted = FALSE;
     BOOLEAN             bBugCheck = FALSE;

--- a/drivers/filesystems/ext2/src/debug.c
+++ b/drivers/filesystems/ext2/src/debug.c
@@ -139,7 +139,6 @@ Ext2Printf(
     LARGE_INTEGER       CurrentTime;
     TIME_FIELDS         TimeFields;
     CHAR                Buffer[DBG_BUF_LEN];
-    ULONG               i;
 
     RtlZeroMemory(Buffer, DBG_BUF_LEN);
     va_start(ap, DebugMessage);

--- a/drivers/filesystems/ext2/src/ext3/generic.c
+++ b/drivers/filesystems/ext2/src/ext3/generic.c
@@ -146,8 +146,6 @@ VOID
 Ext2PutGroup(IN PEXT2_VCB Vcb)
 {
     struct ext3_sb_info *sbi = &Vcb->sbi;
-    unsigned long i;
-
 
     if (NULL == Vcb->sbi.s_gd) {
         return;

--- a/drivers/filesystems/ext2/src/ext3/htree.c
+++ b/drivers/filesystems/ext2/src/ext3/htree.c
@@ -392,7 +392,7 @@ int add_dirent_to_buf(struct ext2_icb *icb, struct dentry *dentry,
     int		namelen = dentry->d_name.len;
     unsigned int	offset = 0;
     unsigned short	reclen;
-    int		nlen, rlen, err;
+    int		nlen, rlen;
     char		*top;
 
     reclen = EXT3_DIR_REC_LEN(namelen);

--- a/drivers/filesystems/ext2/src/ext3/recover.c
+++ b/drivers/filesystems/ext2/src/ext3/recover.c
@@ -106,7 +106,6 @@ Ext2RecoverJournal(
 #endif
     struct inode *          ji = NULL;
     journal_t *             journal = NULL;
-    struct ext3_super_block *esb;
 
     ExAcquireResourceExclusiveLite(&Vcb->MainResource, TRUE);
 

--- a/drivers/filesystems/ext2/src/ext4/ext4_extents.c
+++ b/drivers/filesystems/ext2/src/ext4/ext4_extents.c
@@ -1885,7 +1885,6 @@ static int ext4_remove_blocks(void *icb, handle_t *handle, struct inode *inode,
 		struct ext4_extent *ex,
 		unsigned long from, unsigned long to)
 {
-	struct buffer_head *bh;
 	int i;
 
 	if (from >= le32_to_cpu(ex->ee_block)

--- a/drivers/filesystems/ext2/src/ext4/extents.c
+++ b/drivers/filesystems/ext2/src/ext4/extents.c
@@ -209,7 +209,6 @@ Ext2TruncateExtent(
     ULONG    Extra = 0;
     ULONG    Wanted = 0;
     ULONG    End;
-    ULONG    Removed;
     int      err;
 
     /* translate file size to block */

--- a/drivers/filesystems/ext2/src/fsctl.c
+++ b/drivers/filesystems/ext2/src/fsctl.c
@@ -1387,7 +1387,6 @@ Ext2GetReparsePoint (IN PEXT2_IRP_CONTEXT IrpContext)
 {
     PIRP                        Irp = NULL;
     PIO_STACK_LOCATION          IrpSp;
-    PEXTENDED_IO_STACK_LOCATION EIrpSp;
 
     PDEVICE_OBJECT      DeviceObject;
 

--- a/drivers/filesystems/ext2/src/init.c
+++ b/drivers/filesystems/ext2/src/init.c
@@ -111,7 +111,7 @@ Ext2RegistryQueryCallback(
     )
 {
     ULONG  i = 0;
-    BYTE   *s, *t;
+    BYTE   *t;
 
     if (NULL == ValueName || NULL == ValueData)
         return STATUS_SUCCESS;

--- a/drivers/filesystems/ext2/src/linux.c
+++ b/drivers/filesystems/ext2/src/linux.c
@@ -439,8 +439,6 @@ get_block_bh_mdl(
     PVOID         bcb = NULL;
     PVOID         ptr = NULL;
 
-    struct list_head *entry;
-
     /* allocate buffer_head and initialize it */
     struct buffer_head *bh = NULL, *tbh = NULL;
 

--- a/drivers/filesystems/ext2/src/memory.c
+++ b/drivers/filesystems/ext2/src/memory.c
@@ -3047,7 +3047,7 @@ Ext2McbReaperThread(
     PEXT2_VCB       Vcb = NULL;
     PEXT2_MCB       Mcb  = NULL;
 
-    ULONG           i, NumOfMcbs;
+    ULONG           NumOfMcbs;
 
     BOOLEAN         GlobalAcquired = FALSE;
 

--- a/drivers/filesystems/ext2/src/write.c
+++ b/drivers/filesystems/ext2/src/write.c
@@ -178,7 +178,6 @@ Ext2ZeroData (
     PEXT2_FCB       Fcb;
     PBCB            Bcb;
     PVOID           Ptr;
-    ULONG           Size;
     BOOLEAN         rc = TRUE;
 
     ASSERT (End && Start && End->QuadPart > Start->QuadPart);

--- a/drivers/filesystems/reiserfs/src/dirctl.c
+++ b/drivers/filesystems/reiserfs/src/dirctl.c
@@ -489,8 +489,6 @@ RfsdQueryDirectory (IN PRFSD_IRP_CONTEXT IrpContext)
 		// A callback will be triggered on any direntry span belonging to DirectoryKey.
 		// This callback will fill the requested section of the user buffer.
 		{
-			ULONG CurrentFileIndex;
-
 			RFSD_CALLBACK_CONTEXT  CallbackContext;
 			CallbackContext.Vcb						= Vcb;
 			CallbackContext.Ccb						= Ccb;

--- a/drivers/filesystems/reiserfs/src/rfsd.c
+++ b/drivers/filesystems/reiserfs/src/rfsd.c
@@ -2962,8 +2962,6 @@ _NavigateToLeafNode(
 	// If this block is a leaf, just return it (or invoke the given callback on the leaf block)	
 	if (pBlockHeader->blk_level == RFSD_LEAF_BLOCK_LEVEL)
 	{
-		NTSTATUS	CallbackStatus;
-
 		ExFreePool(pBlockBuffer);
 		
 		*out_NextBlockNumber = StartingBlockNumber;


### PR DESCRIPTION
## Purpose
JIRA issue: N/A
https://github.com/reactos/reactos/commit/11ecf5c969bffb4f245bd84e86e25a6ec70509c9
Fix the following errors:
```txt
c:\reactos-cov\drivers\filesystems\reiserfs\src\dirctl.c(492) : error C4101: 'CurrentFileIndex' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\reiserfs\src\rfsd.c(2965) : error C4101: 'CallbackStatus' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\ext4\ext4_extents.c(1888) : error C4101: 'bh' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\init.c(114) : error C4101: 's' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\ext3\generic.c(149) : error C4101: 'i' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\ext3\htree.c(395) : error C4101: 'err' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\ext3\recover.c(109) : error C4101: 'esb' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\ext4\extents.c(212) : error C4101: 'Removed' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\debug.c(142) : error C4101: 'i' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\block.c(253) : error C4101: 'Wait' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\fsctl.c(1390) : error C4101: 'EIrpSp' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\linux.c(442) : error C4101: 'entry' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\memory.c(3050) : error C4101: 'i' : unreferenced local variable
c:\reactos-cov\drivers\filesystems\ext2\src\write.c(181) : error C4101: 'Size' : unreferenced local variable
c:\reactos-cov\dll\3rdparty\libtirpc\src\svc_vc.c(315) : error C4101: 'cleanfds' : unreferenced local variable
```