### PR TITLE
[CMAKE] When disabling C4101, explicitly remove the error flag.

### DIFF
--- a/dll/3rdparty/libtirpc/CMakeLists.txt
+++ b/dll/3rdparty/libtirpc/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(libtirpc MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/libtirpc.def)
 
 if(MSVC AND (NOT USE_CLANG_CL))
+    replace_compile_flags("/we4101" " ")
     add_target_compile_flags(libtirpc "/wd4101 /wd4133 /wd4473 /wd4477")
 else()
     # FIXME: Tons of warnings.

--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -94,6 +94,7 @@ endif()
 
 if(MSVC AND (NOT USE_CLANG_CL))
     # Disable warnings: "unreferenced local variable", "initialized, but not used variable", "benign include"
+    replace_compile_flags("/we4101" " ")
     replace_compile_flags("/we4189" " ")
     add_target_compile_flags(ext2fs "/wd4189 /wd4142 /wd4101")
 else()

--- a/drivers/filesystems/reiserfs/CMakeLists.txt
+++ b/drivers/filesystems/reiserfs/CMakeLists.txt
@@ -86,6 +86,7 @@ if(USE_CLANG_CL OR (NOT MSVC))
     endif()
 else()
     #disable warnings: "unreferenced local variable", "initialized, but not used variable", "benign include"
+    replace_compile_flags("/we4101" " ")
     replace_compile_flags("/we4189" " ")
     add_target_compile_flags(reiserfs "/wd4189 /wd4142 /wd4101")
 endif()

--- a/sdk/lib/3rdparty/libxml2/CMakeLists.txt
+++ b/sdk/lib/3rdparty/libxml2/CMakeLists.txt
@@ -65,7 +65,8 @@ list(APPEND SOURCE
 add_library(libxml2 ${SOURCE})
 
 if(MSVC AND (NOT USE_CLANG_CL))
-    # Formal parameter different from declaration
+    # Unreferenced local variable
+    replace_compile_flags("/we4101" " ")
     add_target_compile_flags(libxml2 "/wd4101")
     # Local variable initialized but not referenced
     replace_compile_flags("/we4189" " ")


### PR DESCRIPTION
Should fix VC2010 build.
Addendum to 11ecf5c969b.