### PR TITLE
[CMD] Correctly parse drive-decorated pathname

### DIFF
--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1762,10 +1762,9 @@ ResolvePattern(
         pNextDir = pszPattern;
     }
 
-    if (_istalpha(pNextDir[0]) && pNextDir[1] == _T(':') && pNextDir[2] == _T('\0'))
+    if (_istalpha(pNextDir[0]) && pNextDir[1] == _T(':') && pNextDir[2] != _T('\\'))
     {
         /*
-         * Drive name only. Nothing to do.
          * The syntax "<drive_letter>:" without any trailing backslash actually
          * means: "current directory on this drive".
          */

--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1762,16 +1762,24 @@ ResolvePattern(
         pNextDir = pszPattern;
     }
 
-    /*
-     * When pszPatternPart == NULL this means that pszFullPath should be a
-     * directory; however it might have happened that the original pattern
-     * was specifying a dots-only directory, that has been stripped off by
-     * GetFullPathName(). In both these cases we need to restore these as
-     * they are part of the actual directory path; the exception being if
-     * these are the special "." or ".." directories.
-     */
-    if (pszPatternPart == NULL)
+    if (_istalpha(pNextDir[0]) && pNextDir[1] == _T(':') && pNextDir[2] == _T('\0'))
     {
+        /*
+         * Drive name only. Nothing to do.
+         * The syntax "<drive_letter>:" without any trailing backslash actually
+         * means: "current directory on this drive".
+         */
+    }
+    else if (pszPatternPart == NULL)
+    {
+        /*
+         * When pszPatternPart == NULL this means that pszFullPath should be a
+         * directory; however it might have happened that the original pattern
+         * was specifying a dots-only directory, that has been stripped off by
+         * GetFullPathName(). In both these cases we need to restore these as
+         * they are part of the actual directory path; the exception being if
+         * these are the special "." or ".." directories.
+         */
         ASSERT(pszFullPath[_tcslen(pszFullPath)-1] == _T('\\'));
 
         /* Anything NOT being "." or ".." (the special directories) must be fully restored */
@@ -1781,10 +1789,6 @@ ResolvePattern(
             _tcscpy(pszPatternPart, pNextDir);
             pszPatternPart = NULL;
         }
-    }
-    else if (_istalpha(pNextDir[0]) && pNextDir[1] == TEXT(':') && pNextDir[2] == TEXT('\0'))
-    {
-        /* Drive name only. Nothing to do. */
     }
     else if (_tcscmp(pNextDir, pszPatternPart) != 0)
     {

--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1782,9 +1782,9 @@ ResolvePattern(
             pszPatternPart = NULL;
         }
     }
-    else if (_istalpha(pNextDir[0]) && pNextDir[1] == TEXT(':') && pNextDir[2] == 0)
+    else if (_istalpha(pNextDir[0]) && pNextDir[1] == TEXT(':') && pNextDir[2] == TEXT('\0'))
     {
-        /* Drive name only */
+        /* Drive name only. Nothing to do. */
     }
     else if (_tcscmp(pNextDir, pszPatternPart) != 0)
     {

--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1782,6 +1782,10 @@ ResolvePattern(
             pszPatternPart = NULL;
         }
     }
+    else if (_istalpha(pNextDir[0]) && pNextDir[1] == TEXT(':') && pNextDir[2] == 0)
+    {
+        /* Drive name only */
+    }
     else if (_tcscmp(pNextDir, pszPatternPart) != 0)
     {
         /*

--- a/base/shell/cmd/dir.c
+++ b/base/shell/cmd/dir.c
@@ -1762,6 +1762,14 @@ ResolvePattern(
         pNextDir = pszPattern;
     }
 
+    /*
+     * When pszPatternPart == NULL this means that pszFullPath should be a
+     * directory; however it might have happened that the original pattern
+     * was specifying a dots-only directory, that has been stripped off by
+     * GetFullPathName(). In both these cases we need to restore these as
+     * they are part of the actual directory path; the exception being if
+     * these are the special "." or ".." directories.
+     */
     if (_istalpha(pNextDir[0]) && pNextDir[1] == _T(':') && pNextDir[2] != _T('\\'))
     {
         /*
@@ -1771,14 +1779,6 @@ ResolvePattern(
     }
     else if (pszPatternPart == NULL)
     {
-        /*
-         * When pszPatternPart == NULL this means that pszFullPath should be a
-         * directory; however it might have happened that the original pattern
-         * was specifying a dots-only directory, that has been stripped off by
-         * GetFullPathName(). In both these cases we need to restore these as
-         * they are part of the actual directory path; the exception being if
-         * these are the special "." or ".." directories.
-         */
         ASSERT(pszFullPath[_tcslen(pszFullPath)-1] == _T('\\'));
 
         /* Anything NOT being "." or ".." (the special directories) must be fully restored */


### PR DESCRIPTION
## Purpose
Correctly interpret the drive-decorated pathnames (`C:` or `D:dir1` etc).
JIRA issue: [CORE-15871](https://jira.reactos.org/browse/CORE-15871)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/75154767-d96d2e00-5751-11ea-9865-3bef05fff7ab.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/75154768-da9e5b00-5751-11ea-9187-30385f4c8012.png)