### PR TITLE
[SHELL32] Set read-only for some shell folders and delete Desktop.ini of Desktop and Program Files

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2393,9 +2393,9 @@ end:
         WCHAR szIconLocation[MAX_PATH];
         DWORD dwAttributes;
 
-        /* make the directory a system folder */
+        /* make the directory a read-only folder */
         dwAttributes = GetFileAttributesW(szBuildPath);
-        dwAttributes |= FILE_ATTRIBUTE_SYSTEM;
+        dwAttributes |= FILE_ATTRIBUTE_READONLY;
         SetFileAttributesW(szBuildPath, dwAttributes);
 
         /* build the desktop.ini file path */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -734,7 +734,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         DesktopW,
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_DESKTOP
+#endif
     },
     { /* 0x01 - CSIDL_INTERNET */
         &FOLDERID_InternetFolder,
@@ -747,7 +751,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         ProgramsW,
         MAKEINTRESOURCEW(IDS_PROGRAMS),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_PROGRAMS_FOLDER
+#endif
     },
     { /* 0x03 - CSIDL_CONTROLS (.CPL files) */
         &FOLDERID_ControlPanelFolder,
@@ -849,7 +857,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_User,
         DesktopW,
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_DESKTOP
+#endif
     },
     { /* 0x11 - CSIDL_DRIVES */
         &FOLDERID_ComputerFolder,
@@ -897,7 +909,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_AllUsers,
         Common_ProgramsW,
         MAKEINTRESOURCEW(IDS_PROGRAMS),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_PROGRAMS_FOLDER
+#endif
     },
     { /* 0x18 - CSIDL_COMMON_STARTUP */
         &FOLDERID_CommonStartup,
@@ -910,7 +926,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_AllUsers,
         Common_DesktopW,
         MAKEINTRESOURCEW(IDS_DESKTOPDIRECTORY),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_DESKTOP
+#endif
     },
     { /* 0x1a - CSIDL_APPDATA */
         &FOLDERID_RoamingAppData,

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1013,7 +1013,11 @@ static const CSIDL_DATA CSIDL_Data[] =
         CSIDL_Type_CurrVer,
         ProgramFilesDirW,
         MAKEINTRESOURCEW(IDS_PROGRAM_FILES),
+#ifdef __REACTOS__
+        0
+#else
         -IDI_SHELL_PROGRAMS_FOLDER
+#endif
     },
     { /* 0x27 - CSIDL_MYPICTURES */
         &FOLDERID_Pictures,


### PR DESCRIPTION
## Purpose

- Set read-only attribute instead of system attribute for some shell folders that has a folder icon.
- Delete `desktop.ini` files in Desktop and Program Files.

JIRA issue: [CORE-16711](https://jira.reactos.org/browse/CORE-16711)
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/75202064-7c9f6100-57ad-11ea-99ea-3449c0486b5b.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/75202065-7c9f6100-57ad-11ea-91ed-6ecad86c73fc.png)
WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/75202061-7b6e3400-57ad-11ea-9906-c3fec2bb7611.png)
Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/75202067-7d37f780-57ad-11ea-9d4a-07169ddb6b78.png)