### PR TITLE
[SHELL32] Fix SHChangeNotify for one item events

### DIFF
--- a/dll/win32/shell32/wine/changenotify.c
+++ b/dll/win32/shell32/wine/changenotify.c
@@ -370,7 +370,9 @@ void WINAPI SHChangeNotify(LONG wEventId, UINT uFlags, LPCVOID dwItem1, LPCVOID 
     {
         TRACE("dwItem2 is not zero, but should be\n");
         dwItem2 = 0;
+#ifndef __REACTOS__
         return;
+#endif
     }
 
     if( ( ( wEventId & SHCNE_NOITEMEVENTS ) && 


### PR DESCRIPTION
## Purpose
Windows sends notification even if two parameters are provided for notification of one parameter.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/75203125-a4dc8f00-57b0-11ea-81d1-0f6864c8423b.png)
There were some failures.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/75203126-a5752580-57b0-11ea-824e-5680391498fa.png)
Failures are fixed.