### PR TITLE
[KERNEL32_WINETEST] Fix a MSVC-x64 C4101 error

### DIFF
--- a/dll/3rdparty/libtirpc/CMakeLists.txt
+++ b/dll/3rdparty/libtirpc/CMakeLists.txt
@@ -102,6 +102,7 @@ add_library(libtirpc MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/libtirpc.def)
 
 if(MSVC AND (NOT USE_CLANG_CL))
+    # Disable warnings: "unreferenced local variable", "incompatible types - from '<x> *' to '<y> *'", "'function' : not enough arguments passed for format string placeholders" and "'_snprintf' : format string '%ld' requires an argument of type 'long'".
     replace_compile_flags("/we4101" " ")
     add_target_compile_flags(libtirpc "/wd4101 /wd4133 /wd4473 /wd4477")
 else()

--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -9,7 +9,6 @@ if (MSVC)
     add_compile_flags("/wd4267") # C4267: '=': conversion from 'size_t' to 'int', possible loss of data
     add_compile_flags("/wd4305") # C4305: '=': truncation from 'double' to 'FLOAT'
     if (ARCH STREQUAL "amd64")
-        add_compile_flags("/wd4101") # C4101: 'x': unreferenced local variable
         add_compile_flags("/wd4312") # C4312: 'type cast': conversion from 'unsigned int' to 'char *' of greater size
         add_compile_flags("/wd4334") # C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
     endif()


### PR DESCRIPTION
"...\kernel32\virtual.c(1112): error C4101: 'is_wow64': unreferenced local variable"

Addendum to 11ecf5c and 80296be.

NB:
Wine moved this code (https://source.winehq.org/git/wine.git/commit/d1b7e01e5e1697e10d3530bdf4124c2e40172cee)
then fixed this issue (https://source.winehq.org/git/wine.git/commit/3cdb5072e8794daaaa302611ab5f9cd999cf798a),
so this PR code is temporary, until next WineSync.