### PR TITLE
[DSOUND_NEW][DDRAW] CMake fixes

### DIFF
--- a/dll/directx/ddraw/CMakeLists.txt
+++ b/dll/directx/ddraw/CMakeLists.txt
@@ -39,7 +39,11 @@ list(APPEND SOURCE
     Vtable/DirectDrawSurface4_Vtable.c
     Vtable/DirectDrawSurface7_Vtable.c)
 
-add_library(ddraw MODULE ${SOURCE})
+add_library(ddraw MODULE 
+    ${SOURCE}
+    ddraw.rc
+    ${CMAKE_CURRENT_BINARY_DIR}/ddraw.def)
+
 set_module_type(ddraw win32dll)
 target_link_libraries(ddraw uuid dxguid ${PSEH_LIB})
 add_importlibs(ddraw advapi32 gdi32 user32 msvcrt kernel32 ntdll)

--- a/dll/directx/dsound_new/CMakeLists.txt
+++ b/dll/directx/dsound_new/CMakeLists.txt
@@ -21,7 +21,8 @@ list(APPEND SOURCE
 
 add_library(dsound MODULE
     ${SOURCE}
-    version.rc)
+    version.rc
+    ${CMAKE_CURRENT_BINARY_DIR}/dsound.def)
 
 set_module_type(dsound win32dll)
 target_link_libraries(dsound dxguid uuid)


### PR DESCRIPTION
## Purpose

* Create export tables for native ddraw and dsound_new
* Include native ddraw version resource in build process

JIRA issue: [CORE-16228](https://jira.reactos.org/browse/CORE-16228)