### PR TITLE
[MKISOFS] Fix a MSVC C4101 warning

### DIFF
--- a/sdk/tools/mkisofs/CMakeLists.txt
+++ b/sdk/tools/mkisofs/CMakeLists.txt
@@ -96,9 +96,6 @@ if(MSVC)
     # Disable warning "'<': signed/unsigned mismatch"
     add_target_compile_flags(mkisofs "/wd4018")
 
-    # Disable warning "'nchar': unreferenced local variable"
-    add_target_compile_flags(mkisofs "/wd4101")
-
     # Disable warning "'+=': conversion from 'x' to 'y', possible loss of data"
     add_target_compile_flags(libschily "/wd4244")
     add_target_compile_flags(mkisofs "/wd4244")

--- a/sdk/tools/mkisofs/schilytools/mkisofs/tree.c
+++ b/sdk/tools/mkisofs/schilytools/mkisofs/tree.c
@@ -2117,7 +2117,9 @@ insert_file_entry(this_dir, whole_path, short_name, statp, have_rsrc)
 	    strcmp(s_entry->name, "..") != 0) {
 
 		char	buffer[SECTOR_SIZE];
+#if !defined(__REACTOS__) || defined(S_IFLNK)
 		int	nchar;
+#endif
 
 		switch (lstatbuf.st_mode & S_IFMT) {
 		case S_IFDIR:


### PR DESCRIPTION
"...\schilytools\mkisofs\tree.c(2120): warning C4101: 'nchar': unreferenced local variable"