### PR TITLE
[ntuser] fix ShellHook notifications when creating/activating windows

### DIFF
--- a/win32ss/user/ntuser/focus.c
+++ b/win32ss/user/ntuser/focus.c
@@ -52,7 +52,6 @@ VOID FASTCALL
 UpdateShellHook(PWND Window)
 {
    if ( Window->spwndParent == UserGetDesktopWindow() &&
-        Window->spwndOwner == NULL &&
        (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
          (Window->ExStyle & WS_EX_APPWINDOW)))
    {
@@ -511,7 +510,8 @@ co_IntSendActivateMessages(PWND WindowPrev, PWND Window, BOOL MouseActivate, BOO
                          MAKEWPARAM(MouseActivate ? WA_CLICKACTIVE : WA_ACTIVE, (Window->style & WS_MINIMIZE) != 0),
                         (LPARAM)(WindowPrev ? UserHMGetHandle(WindowPrev) : 0));
 
-      UpdateShellHook(Window);
+      if (Window->style & WS_VISIBLE)
+         UpdateShellHook(Window);
 
       Window->state &= ~WNDS_NONCPAINT;
 

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1913,6 +1913,8 @@ co_WinPosSetWindowPos(
               (Window->ExStyle & WS_EX_APPWINDOW)))
          {
             co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
+            if (!(WinPos.flags & SWP_NOACTIVATE))
+               UpdateShellHook(Window);
          }
       }
 


### PR DESCRIPTION
## Purpose

Fix taskbar button states via correct ShellHook notifications when creating/activating/switching windows.

JIRA issues:
[CORE-11324](https://jira.reactos.org/browse/CORE-11324)
[CORE-16703](https://jira.reactos.org/browse/CORE-16703)
[CORE-16705](https://jira.reactos.org/browse/CORE-16705)
[CORE-16706](https://jira.reactos.org/browse/CORE-16706)

This is my first PR here which is actual code and not just translation, so it may not be perfect.