### PR TITLE
[SHELL32] Improve ShellExecCmdLine in path resolving

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2457,12 +2457,26 @@ HRESULT WINAPI ShellExecCmdLine(
         {
             PathAddBackslashW(szFile);
         }
-        if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
+
+        WCHAR szCurDir[MAX_PATH];
+        GetCurrentDirectoryW(_countof(szCurDir), szCurDir);
+        if (pwszStartDir)
+        {
+            SetCurrentDirectoryW(pwszStartDir);
+        }
+
+        if (PathIsRelativeW(szFile) &&
+            GetFullPathNameW(szFile, _countof(szFile2), szFile2, NULL) &&
+            PathFileExistsW(szFile2))
+        {
+            StringCchCopyW(szFile, _countof(szFile), szFile2);
+        }
+        else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
@@ -2475,6 +2489,11 @@ HRESULT WINAPI ShellExecCmdLine(
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
             pchParams = NULL;
+        }
+
+        if (pwszStartDir)
+        {
+            SetCurrentDirectoryW(szCurDir);
         }
 
         if (!(dwSeclFlags & SECL_ALLOW_NONEXE))

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -153,11 +153,11 @@ HRESULT WINAPI ShellExecCmdLine(
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
         else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
-            SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
+                 SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -133,7 +133,26 @@ HRESULT WINAPI ShellExecCmdLine(
     else
     {
         pchParams = SplitParams(lpCommand, szFile, _countof(szFile));
-        if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
+        if (szFile[0] != UNICODE_NULL && szFile[1] == L':' &&
+            szFile[2] == UNICODE_NULL)
+        {
+            PathAddBackslashW(szFile);
+        }
+
+        WCHAR szCurDir[MAX_PATH];
+        GetCurrentDirectoryW(_countof(szCurDir), szCurDir);
+        if (pwszStartDir)
+        {
+            SetCurrentDirectoryW(pwszStartDir);
+        }
+
+        if (PathIsRelativeW(szFile) &&
+            GetFullPathNameW(szFile, _countof(szFile2), szFile2, NULL) &&
+            PathFileExistsW(szFile2))
+        {
+            StringCchCopyW(szFile, _countof(szFile), szFile2);
+        }
+        else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
             SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
             SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
             SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
@@ -151,6 +170,11 @@ HRESULT WINAPI ShellExecCmdLine(
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
             pchParams = NULL;
+        }
+
+        if (pwszStartDir)
+        {
+            SetCurrentDirectoryW(szCurDir);
         }
 
         if (!(dwSeclFlags & SECL_ALLOW_NONEXE))


### PR DESCRIPTION
## Purpose
Fix and improve private function `shell32!ShellExecCmdLine` to improve `Run` Dialog behavior.

JIRA issue: [CORE-14409](https://jira.reactos.org/browse/CORE-14409)

Dot:
![dot](https://user-images.githubusercontent.com/2107452/75505748-76182000-5a1f-11ea-82d7-52a294616b03.png)
Dot dot:
![dotdot](https://user-images.githubusercontent.com/2107452/75505750-76182000-5a1f-11ea-805d-592dc394eb6e.png)
C drive:
![c-drive](https://user-images.githubusercontent.com/2107452/75505745-74e6f300-5a1f-11ea-84b8-cd68c90a33f3.png)