### PR TITLE
[SHELL32_APITEST] Support multi-process of SHChangeNotify testcase

### DIFF
--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -46,3 +46,9 @@ set_module_type(shell32_apitest win32cui)
 add_importlibs(shell32_apitest user32 gdi32 shell32 ole32 oleaut32 advapi32 shlwapi msvcrt kernel32 ntdll)
 add_pch(shell32_apitest shelltest.h SOURCE)
 add_rostests_file(TARGET shell32_apitest)
+
+# shell-notify.exe
+add_executable(shell-notify shell-notify.cpp)
+set_module_type(shell-notify win32gui UNICODE)
+add_importlibs(shell-notify msvcrt kernel32 user32 shell32 shlwapi ole32)
+add_rostests_file(TARGET shell-notify SUBDIR testdata)

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -21,7 +21,6 @@ static WCHAR s_file2[MAX_PATH]; // "%TEMP%\\WatchDir1\\File2.txt"
 
 static HWND s_hwnd = NULL;
 static const WCHAR s_szName[] = L"SHChangeNotify testcase";
-static LPITEMIDLIST s_pidl = NULL;
 
 typedef enum TYPE
 {
@@ -157,7 +156,7 @@ static const size_t s_nTestEntries = _countof(s_TestEntries);
 
 LPCSTR PatternFromFlags(DWORD flags)
 {
-    static char s_buf[32];
+    static char s_buf[TYPE_FREESPACE + 1 + 1];
     DWORD i;
     for (i = 0; i <= TYPE_FREESPACE; ++i)
     {
@@ -209,14 +208,12 @@ DoStart(HWND hwnd)
     lstrcpyW(s_file2, s_dir1);
     PathAppendW(s_file2, L"File2.txt");
 
-    s_pidl = ILCreateFromPathW(s_dir1);
     return TRUE;
 }
 
 static void
 DoEnd(HWND hwnd)
 {
-    CoTaskMemFree(s_pidl);
     DeleteFileW(s_file1);
     DeleteFileW(s_file2);
     RemoveDirectoryW(s_dir3);

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -268,7 +268,7 @@ START_TEST(SHChangeNotify)
 
     if (!DoStart(s_hwnd))
     {
-        skip("Unable to register the notification client.\n");
+        skip("Unable to initialize.\n");
         return;
     }
 

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -152,7 +152,6 @@ static const TEST_ENTRY s_TestEntries[] = {
     {__LINE__, SHCNE_RMDIR, s_dir1, NULL, "000010000", NULL},
     {__LINE__, SHCNE_RMDIR, s_dir1, NULL, "000010000", DoAction8},
 };
-static const size_t s_nTestEntries = _countof(s_TestEntries);
 
 LPCSTR PatternFromFlags(DWORD flags)
 {
@@ -272,7 +271,7 @@ START_TEST(SHChangeNotify)
         return;
     }
 
-    for (size_t i = 0; i < s_nTestEntries; ++i)
+    for (size_t i = 0; i < _countof(s_TestEntries); ++i)
     {
         DoTestEntry(&s_TestEntries[i]);
     }

--- a/modules/rostests/apitests/shell32/SHChangeNotify.cpp
+++ b/modules/rostests/apitests/shell32/SHChangeNotify.cpp
@@ -184,7 +184,7 @@ DoTestEntry(const TEST_ENTRY *entry)
 }
 
 static BOOL
-DoStart(HWND hwnd)
+DoInit(HWND hwnd)
 {
     WCHAR szTemp[MAX_PATH], szPath[MAX_PATH];
 
@@ -265,7 +265,7 @@ START_TEST(SHChangeNotify)
         return;
     }
 
-    if (!DoStart(s_hwnd))
+    if (!DoInit(s_hwnd))
     {
         skip("Unable to initialize.\n");
         return;

--- a/modules/rostests/apitests/shell32/shell-notify.cpp
+++ b/modules/rostests/apitests/shell32/shell-notify.cpp
@@ -1,0 +1,256 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Test for SHChangeNotify
+ * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "shelltest.h"
+#include <shlwapi.h>
+#include <stdio.h>
+
+#define WM_SHELL_NOTIFY (WM_USER + 100)
+#define WM_GET_NOTIFY_FLAGS (WM_USER + 101)
+#define WM_CLEAR_FLAGS (WM_USER + 102)
+
+static HWND s_hwnd = NULL;
+static const WCHAR s_szName[] = L"SHChangeNotify testcase";
+
+typedef enum TYPE
+{
+    TYPE_RENAMEITEM,
+    TYPE_CREATE,
+    TYPE_DELETE,
+    TYPE_MKDIR,
+    TYPE_RMDIR,
+    TYPE_UPDATEDIR,
+    TYPE_UPDATEITEM,
+    TYPE_RENAMEFOLDER,
+    TYPE_FREESPACE
+} TYPE;
+
+static BYTE s_counters[TYPE_FREESPACE + 1];
+static UINT s_uRegID = 0;
+static WCHAR s_dir1[MAX_PATH];  // "%TEMP%\\WatchDir1"
+static LPITEMIDLIST s_pidl = NULL;
+static SHChangeNotifyEntry s_entry;
+
+static BOOL
+OnCreate(HWND hwnd)
+{
+    s_hwnd = hwnd;
+
+    WCHAR szTemp[MAX_PATH], szPath[MAX_PATH];
+
+    GetTempPathW(_countof(szTemp), szTemp);
+    GetLongPathNameW(szTemp, szPath, _countof(szPath));
+
+    lstrcpyW(s_dir1, szPath);
+    PathAppendW(s_dir1, L"WatchDir1");
+
+    s_pidl = ILCreateFromPathW(s_dir1);
+
+    s_entry.pidl = s_pidl;
+    s_entry.fRecursive = TRUE;
+    LONG fEvents = SHCNE_ALLEVENTS;
+    s_uRegID = SHChangeNotifyRegister(hwnd, SHCNRF_ShellLevel, fEvents, WM_SHELL_NOTIFY,
+                                      1, &s_entry);
+    return s_uRegID != 0;
+}
+
+static void
+OnCommand(HWND hwnd, UINT id)
+{
+    switch (id)
+    {
+        case IDOK:
+        case IDCANCEL:
+            DestroyWindow(hwnd);
+            break;
+    }
+}
+
+static void
+OnDestroy(HWND hwnd)
+{
+    SHChangeNotifyDeregister(s_uRegID);
+    s_uRegID = 0;
+
+    CoTaskMemFree(s_pidl);
+    s_pidl = NULL;
+
+    PostQuitMessage(0);
+    s_hwnd = NULL;
+}
+
+static void
+DoShellNotify(HWND hwnd, PIDLIST_ABSOLUTE pidl1, PIDLIST_ABSOLUTE pidl2, LONG lEvent)
+{
+    CHAR path1[MAX_PATH], path2[MAX_PATH];
+
+    if (pidl1)
+        SHGetPathFromIDListA(pidl1, path1);
+    else
+        path1[0] = 0;
+
+    if (pidl2)
+        SHGetPathFromIDListA(pidl2, path2);
+    else
+        path2[0] = 0;
+
+    switch (lEvent)
+    {
+        case SHCNE_RENAMEITEM:
+            s_counters[TYPE_RENAMEITEM] = 1;
+            break;
+        case SHCNE_CREATE:
+            s_counters[TYPE_CREATE] = 1;
+            break;
+        case SHCNE_DELETE:
+            s_counters[TYPE_DELETE] = 1;
+            break;
+        case SHCNE_MKDIR:
+            s_counters[TYPE_MKDIR] = 1;
+            break;
+        case SHCNE_RMDIR:
+            s_counters[TYPE_RMDIR] = 1;
+            break;
+        case SHCNE_MEDIAINSERTED:
+            break;
+        case SHCNE_MEDIAREMOVED:
+            break;
+        case SHCNE_DRIVEREMOVED:
+            break;
+        case SHCNE_DRIVEADD:
+            break;
+        case SHCNE_NETSHARE:
+            break;
+        case SHCNE_NETUNSHARE:
+            break;
+        case SHCNE_ATTRIBUTES:
+            break;
+        case SHCNE_UPDATEDIR:
+            s_counters[TYPE_UPDATEDIR] = 1;
+            break;
+        case SHCNE_UPDATEITEM:
+            s_counters[TYPE_UPDATEITEM] = 1;
+            break;
+        case SHCNE_SERVERDISCONNECT:
+            break;
+        case SHCNE_UPDATEIMAGE:
+            break;
+        case SHCNE_DRIVEADDGUI:
+            break;
+        case SHCNE_RENAMEFOLDER:
+            s_counters[TYPE_RENAMEFOLDER] = 1;
+            break;
+        case SHCNE_FREESPACE:
+            s_counters[TYPE_FREESPACE] = 1;
+            break;
+        case SHCNE_EXTENDED_EVENT:
+            break;
+        case SHCNE_ASSOCCHANGED:
+            break;
+        default:
+            break;
+    }
+}
+
+static INT_PTR
+OnShellNotify(HWND hwnd, WPARAM wParam, LPARAM lParam)
+{
+    LONG lEvent;
+    PIDLIST_ABSOLUTE *pidlAbsolute;
+    HANDLE hLock = SHChangeNotification_Lock((HANDLE)wParam, (DWORD)lParam, &pidlAbsolute, &lEvent);
+    if (hLock)
+    {
+        DoShellNotify(hwnd, pidlAbsolute[0], pidlAbsolute[1], lEvent);
+        SHChangeNotification_Unlock(hLock);
+    }
+    else
+    {
+        pidlAbsolute = (PIDLIST_ABSOLUTE *)wParam;
+        DoShellNotify(hwnd, pidlAbsolute[0], pidlAbsolute[1], lParam);
+    }
+    return TRUE;
+}
+
+static LRESULT
+OnGetNotifyFlags(HWND hwnd)
+{
+    DWORD dwFlags = 0;
+    for (size_t i = 0; i < _countof(s_counters); ++i)
+    {
+        if (s_counters[i])
+            dwFlags |= (1 << i);
+    }
+    return dwFlags;
+}
+
+static LRESULT CALLBACK
+WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
+{
+    switch (uMsg)
+    {
+        case WM_CREATE:
+            return (OnCreate(hwnd) ? 0 : -1);
+
+        case WM_COMMAND:
+            OnCommand(hwnd, LOWORD(wParam));
+            break;
+
+        case WM_SHELL_NOTIFY:
+            return OnShellNotify(hwnd, wParam, lParam);
+
+        case WM_DESTROY:
+            OnDestroy(hwnd);
+            break;
+
+        case WM_GET_NOTIFY_FLAGS:
+            return OnGetNotifyFlags(hwnd);
+
+        case WM_CLEAR_FLAGS:
+            ZeroMemory(&s_counters, sizeof(s_counters));
+            break;
+
+        default:
+            return DefWindowProcW(hwnd, uMsg, wParam, lParam);
+    }
+    return 0;
+}
+
+INT APIENTRY
+wWinMain(HINSTANCE hInstance,
+         HINSTANCE hPrevInstance,
+         LPWSTR    lpCmdLine,
+         INT       nCmdShow)
+{
+    WNDCLASSW wc;
+    ZeroMemory(&wc, sizeof(wc));
+    wc.lpfnWndProc = WindowProc;
+    wc.hInstance = GetModuleHandleW(NULL);
+    wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
+    wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+    wc.hbrBackground = (HBRUSH)(COLOR_3DFACE + 1);
+    wc.lpszClassName = s_szName;
+    if (!RegisterClassW(&wc))
+        return -1;
+
+    HWND hwnd = CreateWindowW(s_szName, s_szName, WS_OVERLAPPEDWINDOW,
+                              CW_USEDEFAULT, CW_USEDEFAULT, 100, 100,
+                              NULL, NULL, GetModuleHandleW(NULL), NULL);
+    if (!hwnd)
+        return -1;
+
+    ShowWindow(hwnd, SW_SHOWNORMAL);
+    UpdateWindow(hwnd);
+
+    MSG msg;
+    while (GetMessageW(&msg, NULL, 0, 0))
+    {
+        TranslateMessage(&msg);
+        DispatchMessageW(&msg);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Purpose
The `shell32!SHChangeNotify` function must be tested on multiple processes.

JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)
WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/75518645-c3f34f00-5a44-11ea-859b-30b556cf5a9f.png)
Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/75518646-c3f34f00-5a44-11ea-9307-d42331fd6675.png)
Win10:
![Win10](https://user-images.githubusercontent.com/2107452/75518644-c35ab880-5a44-11ea-8e9e-7ebec36ef251.png)
ReactOS:
![ReactOS](https://user-images.githubusercontent.com/2107452/75518643-c2c22200-5a44-11ea-9533-396b5eaed8a5.png)