### PR TITLE
[NDK][NTDLL] RtlGetNtProductType(): update it with SAL2 annotations.

### DIFF
--- a/dll/ntdll/rtl/version.c
+++ b/dll/ntdll/rtl/version.c
@@ -93,7 +93,7 @@ SetRosSpecificInfo(IN OUT PRTL_OSVERSIONINFOEXW VersionInformation)
  * @implemented
  */
 BOOLEAN NTAPI
-RtlGetNtProductType(PNT_PRODUCT_TYPE ProductType)
+RtlGetNtProductType(_Out_ PNT_PRODUCT_TYPE ProductType)
 {
     *ProductType = SharedUserData->NtProductType;
     return TRUE;

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -4526,7 +4526,7 @@ RtlGetVersion(
 NTSYSAPI
 BOOLEAN
 NTAPI
-RtlGetNtProductType(OUT PNT_PRODUCT_TYPE ProductType);
+RtlGetNtProductType(_Out_ PNT_PRODUCT_TYPE ProductType);
 
 //
 // Secure Memory Functions


### PR DESCRIPTION
Calling this function with fake `NULL` causes an access violation exception on Windows :->