### PR TITLE
[KERNEL32_WINETEST] Fix COMMCONFIG.wcProviderData values. ROSTESTS-251

### DIFF
--- a/modules/rostests/winetests/kernel32/generated.c
+++ b/modules/rostests/winetests/kernel32/generated.c
@@ -546,8 +546,8 @@ static void test_pack_COMMCONFIG(void)
     TEST_FIELD_SIZE  (COMMCONFIG, dwProviderSize, 4)
     TEST_FIELD_ALIGN (COMMCONFIG, dwProviderSize, 4)
     TEST_FIELD_OFFSET(COMMCONFIG, dwProviderSize, 44)
-    TEST_FIELD_SIZE  (COMMCONFIG, wcProviderData, 4)
-    TEST_FIELD_ALIGN (COMMCONFIG, wcProviderData, 4)
+    TEST_FIELD_SIZE  (COMMCONFIG, wcProviderData, 2)
+    TEST_FIELD_ALIGN (COMMCONFIG, wcProviderData, 2)
     TEST_FIELD_OFFSET(COMMCONFIG, wcProviderData, 48)
 }
 
@@ -2403,8 +2403,8 @@ static void test_pack_COMMCONFIG(void)
     TEST_FIELD_SIZE  (COMMCONFIG, dwProviderSize, 4)
     TEST_FIELD_ALIGN (COMMCONFIG, dwProviderSize, 4)
     TEST_FIELD_OFFSET(COMMCONFIG, dwProviderSize, 44)
-    TEST_FIELD_SIZE  (COMMCONFIG, wcProviderData, 4)
-    TEST_FIELD_ALIGN (COMMCONFIG, wcProviderData, 4)
+    TEST_FIELD_SIZE  (COMMCONFIG, wcProviderData, 2)
+    TEST_FIELD_ALIGN (COMMCONFIG, wcProviderData, 2)
     TEST_FIELD_OFFSET(COMMCONFIG, wcProviderData, 48)
 }
 


### PR DESCRIPTION
Import test part of
https://source.winehq.org/git/wine.git/commit/a59d6387b6734cf0acb187e9c178d7c540751cae

JIRA issue: [ROSTESTS-251](https://jira.reactos.org/browse/ROSTESTS-251)
