### PR TITLE
[SHELL32] Rewrite SHChangeNotify and SHChangeNotifyRegister

### DIFF
--- a/dll/win32/shell32/wine/changenotify.c
+++ b/dll/win32/shell32/wine/changenotify.c
@@ -288,7 +288,7 @@ DoAddBlock(DWORD pid, LPBLOCK block)
     pLinkHub = LinkHub_Lock(s_hLinkHub, s_dwLinkOwnerPID);
     if (!pLinkHub)
     {
-        ERR("!hLinkHub\n");
+        ERR("!pLinkHub\n");
         return nRegID;
     }
 

--- a/dll/win32/shell32/wine/changenotify.c
+++ b/dll/win32/shell32/wine/changenotify.c
@@ -40,6 +40,382 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+#ifdef __REACTOS__
+#define SHARE_MUTEX_NAME L"Shell32ShareMutex"
+#define LINKHUB_GROW 5
+
+typedef struct ITEM
+{
+    BOOL fRecursive;
+    WCHAR szPath[MAX_PATH];
+} ITEM, *LPITEM;
+
+typedef struct BLOCK
+{
+    HWND hwnd;
+    INT fSources;
+    LONG fEvents;
+    UINT uMsg;
+    INT cItems;
+    ITEM Items[1];
+} BLOCK, *LPBLOCK;
+
+typedef struct LINK
+{
+    DWORD dwUserPID;
+    DWORD dwOwnerPID;
+    UINT nRegID;
+    HANDLE hBlock;
+} LINK, *LPLINK;
+
+typedef struct LINKHUB
+{
+    INT nCapacity;
+    INT nCount;
+    LINK Links[1];
+} LINKHUB, *LPLINKHUB;
+
+/* shared data section */
+
+#ifdef _MSC_VER
+    #define SHELL32SHARE
+#else
+    #define SHELL32SHARE __attribute__((section(".shared"), shared))
+#endif
+#ifdef _MSC_VER
+    #pragma data_seg(".shared")
+#endif
+static HANDLE s_hLinkHub SHELL32SHARE = NULL;
+static DWORD s_dwLinkOwnerPID SHELL32SHARE = 0;
+static UINT s_nNextRegID SHELL32SHARE = 0;
+#ifdef _MSC_VER
+    #pragma data_seg()
+    #pragma comment(linker, "/SECTION:.shared,RWS")
+#endif
+
+static BOOL
+IsProcessRunning(DWORD pid)
+{
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_INFORMATION, TRUE, pid);
+    if (hProcess)
+        CloseHandle(hProcess);
+    return hProcess != NULL;
+}
+
+static DWORD
+LinkHub_GetSize(INT nCount)
+{
+    return sizeof(LINKHUB) + (nCount - 1) * sizeof(LINK);
+}
+
+static LPLINKHUB
+LinkHub_Lock(HANDLE hLinkHub, DWORD dwOwnerPID)
+{
+    if (!hLinkHub || !dwOwnerPID || !IsProcessRunning(dwOwnerPID))
+        return NULL;
+
+    return (LPLINKHUB)SHLockShared(hLinkHub, dwOwnerPID);
+}
+
+static void
+LinkHub_Unlock(LPLINKHUB pLinkHub)
+{
+    if (!pLinkHub)
+        return;
+
+    SHUnlockShared(pLinkHub);
+}
+
+static DWORD
+Block_GetSize(INT nEntries)
+{
+    return sizeof(BLOCK) + (nEntries - 1) * sizeof(ITEM);
+}
+
+static BLOCK *
+Block_Lock(HANDLE hShare, DWORD pid)
+{
+    if (!hShare || !pid || !IsProcessRunning(pid))
+        return NULL;
+
+    return (LPBLOCK)SHLockShared(hShare, pid);
+}
+
+static void
+Block_Unlock(LPVOID block)
+{
+    if (!block)
+        return;
+
+    SHUnlockShared(block);
+}
+
+static void
+Block_Destroy(HANDLE hShare, DWORD pid)
+{
+    if (!hShare || !pid || !IsProcessRunning(pid))
+        return;
+
+    SHFreeShared(hShare, pid);
+}
+
+static BOOL
+LinkHub_RemoveByRegID(LPLINKHUB pLinkHub, UINT nRegID)
+{
+    BOOL ret = FALSE;
+    INT iLink;
+    LPLINK pLink;
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        pLink = &pLinkHub->Links[iLink];
+        if (!pLink->nRegID)
+            continue;
+
+        if (pLink->nRegID == nRegID)
+        {
+            Block_Destroy(pLink->hBlock, pLink->dwOwnerPID);
+            ZeroMemory(pLink, sizeof(*pLink));
+            pLinkHub->nCount--;
+            ret = TRUE;
+            break;
+        }
+    }
+    return ret;
+}
+
+static BOOL
+DoRemoveBlockByRegID(UINT nRegID)
+{
+    BOOL ret = FALSE;
+    LPLINKHUB pLinkHub = LinkHub_Lock(s_hLinkHub, s_dwLinkOwnerPID);
+    if (pLinkHub)
+    {
+        ret = LinkHub_RemoveByRegID(pLinkHub, nRegID);
+        LinkHub_Unlock(pLinkHub);
+    }
+    return ret;
+}
+
+static UINT
+LinkHub_Add(LPLINKHUB pLinkHub, DWORD pid, LPBLOCK block)
+{
+    INT iLink;
+    LPLINK pLink;
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        pLink = &pLinkHub->Links[iLink];
+        if (pLink->nRegID != 0)
+            continue;
+
+        pLink->hBlock = SHAllocShared(block, Block_GetSize(block->cItems), pid);
+        if (pLink->hBlock)
+        {
+            pLink->dwUserPID = pLink->dwOwnerPID = pid;
+            pLink->nRegID = ++s_nNextRegID;
+            pLinkHub->nCount++;
+            return pLink->nRegID;
+        }
+    }
+    return 0;
+}
+
+static UINT
+LinkHub_GrowAdd(LPLINKHUB pOldLinkHub, INT nNewCapacity, DWORD pid, LPBLOCK block)
+{
+    UINT nRegID = 0;
+    DWORD cbOldLinkHub = LinkHub_GetSize(pOldLinkHub->nCapacity);
+    DWORD cbNewLinkHub = LinkHub_GetSize(nNewCapacity);
+    HANDLE hNewLinkHub;
+    LPLINKHUB pNewLinkHub;
+
+    hNewLinkHub = SHAllocShared(NULL, cbNewLinkHub, pid);
+    if (!hNewLinkHub)
+    {
+        ERR("!hNewLinkHub\n");
+        return nRegID;
+    }
+
+    pNewLinkHub = LinkHub_Lock(hNewLinkHub, pid);
+    if (!pNewLinkHub)
+    {
+        ERR("!pNewLinkHub");
+        return nRegID;
+    }
+
+    CopyMemory(pNewLinkHub, pOldLinkHub, cbOldLinkHub);
+    pNewLinkHub->nCapacity = nNewCapacity;
+
+    if (block)
+        nRegID = LinkHub_Add(pNewLinkHub, pid, block);
+
+    SHUnlockShared(pNewLinkHub);
+
+    s_hLinkHub = hNewLinkHub;
+    s_dwLinkOwnerPID = pid;
+
+    return nRegID;
+}
+
+static HANDLE
+LinkHub_Create(DWORD pid)
+{
+    LINKHUB LinkHub = { 1 };
+    return SHAllocShared(&LinkHub, sizeof(LinkHub), pid);
+}
+
+static UINT
+DoAddBlock(DWORD pid, LPBLOCK block)
+{
+    UINT nRegID = 0;
+    HANDLE hOldLinkHub;
+    DWORD dwOldOwnerPID;
+    HANDLE hLinkHub;
+    LPLINKHUB pLinkHub;
+
+    if (!s_hLinkHub)
+    {
+        hLinkHub = LinkHub_Create(pid);
+        if (!hLinkHub)
+        {
+            ERR("!hLinkHub\n");
+            return nRegID;
+        }
+
+        s_hLinkHub = hLinkHub;
+        s_dwLinkOwnerPID = pid;
+    }
+
+    pLinkHub = LinkHub_Lock(s_hLinkHub, s_dwLinkOwnerPID);
+    if (!pLinkHub)
+    {
+        ERR("!hLinkHub\n");
+        return nRegID;
+    }
+
+    nRegID = LinkHub_Add(pLinkHub, pid, block);
+    if (nRegID)
+    {
+        LinkHub_Unlock(pLinkHub);
+        return nRegID;
+    }
+
+    hOldLinkHub = s_hLinkHub;
+    dwOldOwnerPID = s_dwLinkOwnerPID;
+
+    nRegID = LinkHub_GrowAdd(pLinkHub, pLinkHub->nCapacity + LINKHUB_GROW, pid, block);
+    LinkHub_Unlock(pLinkHub);
+
+    SHFreeShared(hOldLinkHub, dwOldOwnerPID);
+    return nRegID;
+}
+
+static void
+LinkHub_MoveOwnership(LPLINKHUB pLinkHub, DWORD dwFromPID, DWORD dwToPID)
+{
+    INT iLink;
+    LPLINK pLink;
+    LPBLOCK block;
+    DWORD cbBlock;
+    HANDLE hBlock;
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        pLink = &pLinkHub->Links[iLink];
+        if (pLink->nRegID == 0)
+            continue;
+
+        if (pLink->dwOwnerPID != dwFromPID)
+            continue;
+
+        block = Block_Lock(pLink->hBlock, pLink->dwOwnerPID);
+        if (!block)
+            continue;
+
+        cbBlock = Block_GetSize(block->cItems);
+        hBlock = SHAllocShared(block, cbBlock, dwToPID);
+        Block_Unlock(block);
+
+        if (hBlock)
+        {
+            Block_Destroy(pLink->hBlock, pLink->dwOwnerPID);
+
+            pLink->hBlock = hBlock;
+            pLink->dwOwnerPID = dwToPID;
+        }
+    }
+}
+
+static void
+LinkHub_RemoveByProcess(LPLINKHUB pLinkHub, DWORD pid)
+{
+    INT iLink;
+    LPLINK pLink;
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        pLink = &pLinkHub->Links[iLink];
+        if (pLink->nRegID == 0)
+            continue;
+
+        if (pLink->dwUserPID == pid)
+        {
+            Block_Destroy(pLink->hBlock, pLink->dwOwnerPID);
+            ZeroMemory(pLink, sizeof(*pLink));
+            pLinkHub->nCount--;
+        }
+    }
+}
+
+static DWORD
+LinkHub_GetAnotherPID(LPLINKHUB pLinkHub, DWORD pid)
+{
+    INT iLink;
+    LPLINK pLink;
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        pLink = &pLinkHub->Links[iLink];
+        if (pLink->nRegID == 0)
+            continue;
+
+        if (pLink->dwOwnerPID != pid)
+        {
+            return pLink->dwOwnerPID;
+        }
+    }
+    return 0;
+}
+
+static void
+DoRemoveBlockByProcess(DWORD pid)
+{
+    LPLINKHUB pLinkHub = LinkHub_Lock(s_hLinkHub, s_dwLinkOwnerPID);
+    if (pLinkHub)
+    {
+        DWORD dwToPID = LinkHub_GetAnotherPID(pLinkHub, pid);
+        if (!dwToPID)
+        {
+            LinkHub_Unlock(pLinkHub);
+            return;
+        }
+
+        LinkHub_RemoveByProcess(pLinkHub, pid);
+        LinkHub_MoveOwnership(pLinkHub, pid, dwToPID);
+
+        if (pid == s_dwLinkOwnerPID)
+        {
+            HANDLE hOldLinkHub = s_hLinkHub;
+            DWORD dwOldOwnerPID = s_dwLinkOwnerPID;
+
+            LinkHub_GrowAdd(pLinkHub, pLinkHub->nCapacity, dwToPID, NULL);
+            LinkHub_Unlock(pLinkHub);
+
+            SHFreeShared(hOldLinkHub, dwOldOwnerPID);
+        }
+        else
+        {
+            LinkHub_Unlock(pLinkHub);
+        }
+    }
+}
+#else
 static CRITICAL_SECTION SHELL32_ChangenotifyCS;
 static CRITICAL_SECTION_DEBUG critsect_debug =
 {
@@ -49,20 +425,7 @@ static CRITICAL_SECTION_DEBUG critsect_debug =
 };
 static CRITICAL_SECTION SHELL32_ChangenotifyCS = { &critsect_debug, -1, 0, 0, 0, 0 };
 
-#ifdef __REACTOS__
-typedef struct {
-    PCIDLIST_ABSOLUTE pidl;
-    BOOL fRecursive;
-    /* File system notification items */
-    HANDLE hDirectory; /* Directory handle */
-    WCHAR wstrDirectory[MAX_PATH]; /* Directory name */
-    OVERLAPPED overlapped; /* Overlapped structure */
-    BYTE *buffer; /* Async buffer to fill */
-    BYTE *backBuffer; /* Back buffer to swap buffer into */
-} SHChangeNotifyEntryInternal, *LPNOTIFYREGISTER;
-#else
 typedef SHChangeNotifyEntry *LPNOTIFYREGISTER;
-#endif
 
 /* internal list of notification clients (internal) */
 typedef struct _NOTIFICATIONLIST
@@ -77,23 +440,8 @@ typedef struct _NOTIFICATIONLIST
 	ULONG id;
 } NOTIFICATIONLIST, *LPNOTIFICATIONLIST;
 
-#ifdef __REACTOS__
-VOID _ProcessNotification(LPNOTIFYREGISTER item);
-BOOL _OpenDirectory(LPNOTIFYREGISTER item);
-static void CALLBACK _RequestTermination(ULONG_PTR arg);
-static void CALLBACK _RequestAllTermination(ULONG_PTR arg);
-static void CALLBACK _AddDirectoryProc(ULONG_PTR arg);
-static VOID _BeginRead(LPNOTIFYREGISTER item);
-static unsigned int WINAPI _RunAsyncThreadProc(LPVOID arg);
-#endif
-
 static struct list notifications = LIST_INIT( notifications );
 static LONG next_id;
-
-#ifdef __REACTOS__
-HANDLE m_hThread;
-UINT m_dwThreadId;
-BOOL m_bTerminate;
 #endif
 
 #define SHCNE_NOITEMEVENTS ( \
@@ -142,6 +490,7 @@ static const char * DumpEvent( LONG event )
 #undef DUMPEV
 }
 
+#ifndef __REACTOS__
 static const char * NodeName(const NOTIFICATIONLIST *item)
 {
     const char *str;
@@ -165,30 +514,24 @@ static void DeleteNode(LPNOTIFICATIONLIST item)
 
     /* free the item */
     for (i=0; i<item->cidl; i++)
-#ifdef __REACTOS__
-    {
-        QueueUserAPC(_RequestTermination, m_hThread, (ULONG_PTR) &item->apidl[i] );
-        WaitForSingleObjectEx(m_hThread, 100, FALSE);
-#endif
         SHFree((LPITEMIDLIST)item->apidl[i].pidl);
-#ifdef __REACTOS__
-        SHFree(item->apidl[i].buffer);
-        SHFree(item->apidl[i].backBuffer);
-    }
-#endif
     SHFree(item->apidl);
     SHFree(item);
 }
+#endif  /* ndef __REACTOS__ */
 
 void InitChangeNotifications(void)
 {
-#ifdef __REACTOS__
-    m_hThread = NULL;
-#endif
 }
 
 void FreeChangeNotifications(void)
 {
+#ifdef __REACTOS__
+    HANDLE hMutex = CreateMutexW(NULL, TRUE, SHARE_MUTEX_NAME);
+    DoRemoveBlockByProcess(GetCurrentProcessId());
+    ReleaseMutex(hMutex);
+    CloseHandle(hMutex);
+#else
     LPNOTIFICATIONLIST ptr, next;
 
     TRACE("\n");
@@ -200,11 +543,8 @@ void FreeChangeNotifications(void)
 
     LeaveCriticalSection(&SHELL32_ChangenotifyCS);
 
-#ifdef __REACTOS__
-    QueueUserAPC(_RequestAllTermination, m_hThread, (ULONG_PTR) NULL );
-#endif
-
     DeleteCriticalSection(&SHELL32_ChangenotifyCS);
+#endif
 }
 
 /*************************************************************************
@@ -220,6 +560,62 @@ SHChangeNotifyRegister(
     int cItems,
     SHChangeNotifyEntry *lpItems)
 {
+#ifdef __REACTOS__
+    HANDLE hMutex;
+    DWORD pid;
+    UINT nRegID = 0;
+    DWORD cbBlock;
+    LPBLOCK lpBlock;
+    INT iEntries;
+    LPITEM pItem;
+
+    TRACE("(%p,0x%08x,0x%08x,0x%08x,%d,%p) item=%p\n",
+
+    if (cItems <= 0 || !lpItems || !IsWindow(hwnd))
+    {
+        ERR("Sanity check\n");
+        return nRegID;
+    }
+
+    GetWindowThreadProcessId(hwnd, &pid);
+    if (pid != GetCurrentProcessId())
+    {
+        ERR("Sanity check 2\n");
+        return nRegID;
+    }
+
+    hMutex = CreateMutexW(NULL, TRUE, SHARE_MUTEX_NAME);
+    if (cItems == 1)
+    {
+        ITEM item = { lpItems->fRecursive };
+        BLOCK block = { hwnd, fSources, wEventMask, uMsg, 1 };
+
+        SHGetPathFromIDListW(lpItems->pidl, item.szPath);
+        block.Items[0] = item;
+
+        nRegID = DoAddBlock(GetCurrentProcessId(), &block);
+    }
+    else
+    {
+        cbBlock = Block_GetSize(cItems);
+        lpBlock = (LPBLOCK)CoTaskMemAlloc(cbBlock);
+        if (lpBlock)
+        {
+            for (iEntries = 0; iEntries < cItems; ++iEntries)
+            {
+                pItem = &lpBlock->Items[iEntries];
+                pItem->fRecursive = lpItems[iEntries].fRecursive;
+                SHGetPathFromIDListW(lpItems[iEntries].pidl, pItem->szPath);
+            }
+            nRegID = DoAddBlock(GetCurrentProcessId(), lpBlock);
+            CoTaskMemFree(lpBlock);
+        }
+    }
+    ReleaseMutex(hMutex);
+    CloseHandle(hMutex);
+
+    return nRegID;
+#else
     LPNOTIFICATIONLIST item;
     int i;
 
@@ -228,37 +624,12 @@ SHChangeNotifyRegister(
     TRACE("(%p,0x%08x,0x%08x,0x%08x,%d,%p) item=%p\n",
 	hwnd, fSources, wEventMask, uMsg, cItems, lpItems, item);
 
-#ifdef __REACTOS__
-    if (!m_hThread)
-        m_hThread = (HANDLE) _beginthreadex(NULL, 0, _RunAsyncThreadProc, NULL, 0, &m_dwThreadId);
-#endif
-
     item->cidl = cItems;
-#ifdef __REACTOS__
-    item->apidl = SHAlloc(sizeof(SHChangeNotifyEntryInternal) * cItems);
-#else
     item->apidl = SHAlloc(sizeof(SHChangeNotifyEntry) * cItems);
-#endif
     for(i=0;i<cItems;i++)
     {
-#ifdef __REACTOS__
-        ZeroMemory(&item->apidl[i], sizeof(SHChangeNotifyEntryInternal));
-#endif
         item->apidl[i].pidl = ILClone(lpItems[i].pidl);
         item->apidl[i].fRecursive = lpItems[i].fRecursive;
-#ifdef __REACTOS__
-        item->apidl[i].buffer = SHAlloc(BUFFER_SIZE);
-        item->apidl[i].backBuffer = SHAlloc(BUFFER_SIZE);
-        item->apidl[i].overlapped.hEvent = &item->apidl[i];
-
-        if (fSources & SHCNRF_InterruptLevel)
-        {
-            if (_OpenDirectory( &item->apidl[i] ))
-            {
-                QueueUserAPC( _AddDirectoryProc, m_hThread, (ULONG_PTR) &item->apidl[i] );
-            }
-        }
-#endif
     }
     item->hwnd = hwnd;
     item->uMsg = uMsg;
@@ -275,6 +646,7 @@ SHChangeNotifyRegister(
     LeaveCriticalSection(&SHELL32_ChangenotifyCS);
 
     return item->id;
+#endif
 }
 
 /*************************************************************************
@@ -282,6 +654,13 @@ SHChangeNotifyRegister(
  */
 BOOL WINAPI SHChangeNotifyDeregister(ULONG hNotify)
 {
+#ifdef __REACTOS__
+    HANDLE hMutex = CreateMutexW(NULL, TRUE, SHARE_MUTEX_NAME);
+    BOOL ret = DoRemoveBlockByRegID(hNotify);
+    ReleaseMutex(hMutex);
+    CloseHandle(hMutex);
+    return ret;
+#else
     LPNOTIFICATIONLIST node;
 
     TRACE("(0x%08x)\n", hNotify);
@@ -299,6 +678,7 @@ BOOL WINAPI SHChangeNotifyDeregister(ULONG hNotify)
     }
     LeaveCriticalSection(&SHELL32_ChangenotifyCS);
     return FALSE;
+#endif
 }
 
 /*************************************************************************
@@ -322,6 +702,147 @@ struct new_delivery_notification
     BYTE data[1];
 };
 
+#ifdef __REACTOS__
+typedef struct DELIVERY
+{
+    LONG event;
+    WCHAR szPath1[MAX_PATH];
+    WCHAR szPath2[MAX_PATH];
+} DELIVERY, *LPDELIVERY;
+
+static BOOL
+should_notify(LPCWSTR changed, LPCWSTR watched, BOOL sub)
+{
+    WCHAR szChanged[MAX_PATH], szWatched[MAX_PATH];
+    INT cchChanged;
+
+    if (!watched)
+        return FALSE;
+
+    lstrcpynW(szChanged, changed, MAX_PATH);
+    if (PathIsDirectoryW(szChanged))
+        PathAddBackslashW(szChanged);
+    if (PathIsDirectoryW(szWatched))
+        PathAddBackslashW(szWatched);
+
+    if (lstrcmpiW(szChanged, szWatched) == 0)
+        return TRUE;
+
+    if (sub)
+    {
+        cchChanged = lstrlenW(szChanged);
+        szWatched[cchChanged] = 0;
+        if (lstrcmpiW(szChanged, szWatched) == 0)
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+static void
+DoDelivery(LPDELIVERY delivery, LONG wEventId, ULONG uFlags)
+{
+    LPLINKHUB pLinkHub;
+    INT iLink, iItem;
+    struct new_delivery_notification *shared_data = NULL;
+    LPITEMIDLIST Pidls[2];
+
+    pLinkHub = LinkHub_Lock(s_hLinkHub, s_dwLinkOwnerPID);
+    if (!pLinkHub)
+        return;
+
+    if (!pLinkHub->nCount)
+    {
+        LinkHub_Unlock(pLinkHub);
+        return;
+    }
+
+    Pidls[0] = (delivery->szPath1[0] ? ILCreateFromPathW(delivery->szPath1) : NULL);
+    Pidls[1] = (delivery->szPath2[0] ? ILCreateFromPathW(delivery->szPath2) : NULL);
+
+    /* Create shared_data */
+    {
+        struct new_delivery_notification *notification;
+        UINT size1 = ILGetSize(Pidls[0]), size2 = ILGetSize(Pidls[1]);
+        UINT offset = (size1 + sizeof(int) - 1) / sizeof(int) * sizeof(int);
+
+        notification = SHAlloc(sizeof(struct new_delivery_notification) + offset + size2);
+        if (!notification) {
+            ERR("out of memory\n");
+        } else {
+            notification->event = wEventId;
+            notification->pidl1_size = size1;
+            notification->pidl2_size = size2;
+            if (size1)
+                memcpy(notification->data, Pidls[0], size1);
+            if (size2)
+                memcpy(notification->data+offset, Pidls[1], size2);
+
+            shared_data = SHAllocShared(notification,
+                sizeof(struct new_delivery_notification) + size1 + size2,
+                GetCurrentProcessId());
+            SHFree(notification);
+        }
+    }
+
+    for (iLink = 0; iLink < pLinkHub->nCapacity; ++iLink)
+    {
+        LPBLOCK block;
+        LPLINK pLink = &pLinkHub->Links[iLink];
+        if (pLink->nRegID == 0)
+            continue;
+
+        block = Block_Lock(pLink->hBlock, pLink->dwOwnerPID);
+        if (!block)
+            continue;
+
+        TRACE("notifying %p, event %s(%x)\n", block->hwnd, DumpEvent(block->fEvents), wEventId);
+
+        for (iItem = 0; iItem < block->cItems; ++iItem)
+        {
+            LPITEM pItem = &block->Items[iItem];
+            LPCWSTR pszPath = pItem->szPath;
+            BOOL subtree = pItem->fRecursive;
+            BOOL notify = FALSE;
+
+            if (wEventId & block->fEvents)
+            {
+                if (!pszPath[0])
+                    notify = TRUE;
+                else if (wEventId & SHCNE_NOITEMEVENTS)
+                    notify = TRUE;
+                else if (wEventId & (SHCNE_ONEITEMEVENTS | SHCNE_TWOITEMEVENTS))
+                    notify = should_notify(delivery->szPath1, pszPath, subtree);
+                else if( wEventId & SHCNE_TWOITEMEVENTS )
+                    notify = should_notify(delivery->szPath2, pszPath, subtree);
+            }
+
+            if (!notify)
+                continue;
+
+            if ((block->fSources & SHCNRF_NewDelivery))
+            {
+                if (shared_data)
+                    SendMessageA(block->hwnd, block->uMsg, (WPARAM)shared_data, GetCurrentProcessId());
+                else
+                    ERR("out of memory\n");
+            }
+            else
+            {
+                SendMessageA(block->hwnd, block->uMsg, (WPARAM)Pidls, wEventId);
+            }
+        }
+
+        Block_Unlock(block);
+    }
+
+    SHFreeShared(shared_data, GetCurrentProcessId());
+    SHFree(Pidls[0]);
+    SHFree(Pidls[1]);
+
+    LinkHub_Unlock(pLinkHub);
+}
+#else
 static BOOL should_notify( LPCITEMIDLIST changed, LPCITEMIDLIST watched, BOOL sub )
 {
     TRACE("%p %p %d\n", changed, watched, sub );
@@ -333,12 +854,81 @@ static BOOL should_notify( LPCITEMIDLIST changed, LPCITEMIDLIST watched, BOOL su
         return TRUE;
     return FALSE;
 }
+#endif
 
 /*************************************************************************
  * SHChangeNotify				[SHELL32.@]
  */
 void WINAPI SHChangeNotify(LONG wEventId, UINT uFlags, LPCVOID dwItem1, LPCVOID dwItem2)
 {
+#ifdef __REACTOS__
+    DELIVERY delivery;
+    HANDLE hMutex;
+
+    TRACE("(0x%08x,0x%08x,%p,%p)\n", wEventId, uFlags, dwItem1, dwItem2);
+
+    if (uFlags & ~(SHCNF_TYPE | SHCNF_FLUSH))
+        FIXME("ignoring unsupported flags: %x\n", uFlags);
+
+    if ((wEventId & SHCNE_NOITEMEVENTS) && (dwItem1 || dwItem2))
+    {
+        TRACE("dwItem1 and dwItem2 are not zero, but should be\n");
+        dwItem1 = 0;
+        dwItem2 = 0;
+    }
+    else if ((wEventId & SHCNE_ONEITEMEVENTS) && dwItem2)
+    {
+        TRACE("dwItem2 is not zero, but should be\n");
+        dwItem2 = 0;
+    }
+
+    if (((wEventId & SHCNE_NOITEMEVENTS) && 
+         (wEventId & ~(SHCNE_NOITEMEVENTS | SHCNE_INTERRUPT))) ||
+        ((wEventId & SHCNE_ONEITEMEVENTS) && 
+         (wEventId & ~(SHCNE_ONEITEMEVENTS | SHCNE_INTERRUPT))) ||
+        ((wEventId & SHCNE_TWOITEMEVENTS) && 
+         (wEventId & ~(SHCNE_TWOITEMEVENTS | SHCNE_INTERRUPT))))
+    {
+        WARN("mutually incompatible events listed\n");
+        return;
+    }
+
+    delivery.szPath1[0] = delivery.szPath2[0] = 0;
+    switch (uFlags & SHCNF_TYPE)
+    {
+        case SHCNF_PATHA:
+            if (dwItem1)
+                MultiByteToWideChar(CP_ACP, 0, dwItem1, -1, delivery.szPath1, MAX_PATH);
+            if (dwItem2)
+                MultiByteToWideChar(CP_ACP, 0, dwItem2, -1, delivery.szPath2, MAX_PATH);
+            break;
+        case SHCNF_PATHW:
+            if (dwItem1)
+                lstrcpynW(delivery.szPath1, dwItem1, MAX_PATH);
+            if (dwItem2)
+                lstrcpynW(delivery.szPath2, dwItem2, MAX_PATH);
+            break;
+        case SHCNF_IDLIST:
+            if (dwItem1)
+                SHGetPathFromIDListW(dwItem1, delivery.szPath1);
+            if (dwItem2)
+                SHGetPathFromIDListW(dwItem2, delivery.szPath2);
+            break;
+        case SHCNF_PRINTERA:
+        case SHCNF_PRINTERW:
+            FIXME("SHChangeNotify with (uFlags & SHCNF_PRINTER)\n");
+            return;
+        case SHCNF_DWORD:
+        default:
+            FIXME("unknown type %08x\n", uFlags & SHCNF_TYPE);
+            return;
+    }
+
+    hMutex = CreateMutexW(NULL, TRUE, SHARE_MUTEX_NAME);
+    DoDelivery(&delivery, wEventId, uFlags);
+    ReleaseMutex(hMutex);
+    CloseHandle(hMutex);
+#else   /* ndef __REACTOS__ */
     struct notification_recipients {
         struct list entry;
         HWND hwnd;
@@ -370,9 +960,7 @@ void WINAPI SHChangeNotify(LONG wEventId, UINT uFlags, LPCVOID dwItem1, LPCVOID 
     {
         TRACE("dwItem2 is not zero, but should be\n");
         dwItem2 = 0;
-#ifndef __REACTOS__
         return;
-#endif
     }
 
     if( ( ( wEventId & SHCNE_NOITEMEVENTS ) && 
@@ -390,49 +978,12 @@ void WINAPI SHChangeNotify(LONG wEventId, UINT uFlags, LPCVOID dwItem1, LPCVOID 
     switch (uFlags & SHCNF_TYPE)
     {
     case SHCNF_PATHA:
-        if (dwItem1) Pidls[0] = SHSimpleIDListFromPathA(dwItem1); //FIXME
-        if (dwItem2) Pidls[1] = SHSimpleIDListFromPathA(dwItem2); //FIXME
+        if (dwItem1) Pidls[0] = SHSimpleIDListFromPathA(dwItem1);
+        if (dwItem2) Pidls[1] = SHSimpleIDListFromPathA(dwItem2);
         break;
     case SHCNF_PATHW:
         if (dwItem1) Pidls[0] = SHSimpleIDListFromPathW(dwItem1);
         if (dwItem2) Pidls[1] = SHSimpleIDListFromPathW(dwItem2);
-#ifdef __REACTOS__
-        if (wEventId & (SHCNE_MKDIR | SHCNE_RMDIR | SHCNE_UPDATEDIR | SHCNE_RENAMEFOLDER))
-        {
-            /*
-             * The last items in the ID are currently files. So we chop off the last
-             * entry, and create a new one using a find data struct.
-             */
-            if (dwItem1 && Pidls[0]){
-                WIN32_FIND_DATAW wfd;
-                LPITEMIDLIST oldpidl, newpidl;
-                LPWSTR p = PathFindFileNameW((LPCWSTR)dwItem1);
-                ILRemoveLastID(Pidls[0]);
-                lstrcpynW(&wfd.cFileName[0], p, MAX_PATH);
-                wfd.dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
-                newpidl = _ILCreateFromFindDataW(&wfd);
-                oldpidl = ILClone(Pidls[0]);
-                ILFree(Pidls[0]);
-                Pidls[0] = ILCombine(oldpidl, newpidl);
-                ILFree(newpidl);
-                ILFree(oldpidl);
-            }
-            if (dwItem2 && Pidls[1]){
-                WIN32_FIND_DATAW wfd;
-                LPITEMIDLIST oldpidl, newpidl;
-                LPWSTR p = PathFindFileNameW((LPCWSTR)dwItem2);
-                ILRemoveLastID(Pidls[1]);
-                lstrcpynW(&wfd.cFileName[0], p, MAX_PATH);
-                wfd.dwFileAttributes = FILE_ATTRIBUTE_DIRECTORY;
-                newpidl = _ILCreateFromFindDataW(&wfd);
-                oldpidl = ILClone(Pidls[0]);
-                ILFree(Pidls[1]);
-                Pidls[1] = ILCombine(oldpidl, newpidl);
-                ILFree(newpidl);
-                ILFree(oldpidl);
-            }
-        }
-#endif
         break;
     case SHCNF_IDLIST:
         Pidls[0] = ILClone(dwItem1);
@@ -534,33 +1085,31 @@ void WINAPI SHChangeNotify(LONG wEventId, UINT uFlags, LPCVOID dwItem1, LPCVOID 
     SHFree(Pidls[0]);
     SHFree(Pidls[1]);
 
-#ifndef __REACTOS__
     if (wEventId & SHCNE_ASSOCCHANGED)
     {
         static const WCHAR args[] = {' ','-','a',0 };
         TRACE("refreshing file type associations\n");
         run_winemenubuilder( args );
     }
-#endif
+#endif  /* ndef __REACTOS__ */
 }
 
 /*************************************************************************
- * NTSHChangeNotifyRegister            [SHELL32.640]
+ * NTSHChangeNotifyRegister			[SHELL32.640]
  * NOTES
- *   Idlist is an array of structures and Count specifies how many items in the array.
- *   count should always be one when calling SHChangeNotifyRegister, or
- *   SHChangeNotifyDeregister will not work properly.
+ *   Idlist is an array of structures and Count specifies how many items in the array
+ *   (usually just one I think).
  */
-EXTERN_C ULONG WINAPI NTSHChangeNotifyRegister(
+ULONG WINAPI NTSHChangeNotifyRegister(
     HWND hwnd,
     int fSources,
-    LONG fEvents,
-    UINT msg,
-    int count,
-    SHChangeNotifyEntry *idlist)
+    LONG wEventMask,
+    UINT uMsg,
+    int cItems,
+    SHChangeNotifyEntry *lpItems)
 {
     return SHChangeNotifyRegister(hwnd, fSources | SHCNRF_NewDelivery,
-                                  fEvents, msg, count, idlist);
+                                  wEventMask, uMsg, cItems, lpItems);
 }
 
 /*************************************************************************
@@ -614,255 +1163,3 @@ DWORD WINAPI NTSHChangeNotifyDeregister(ULONG x1)
 
     return SHChangeNotifyDeregister( x1 );
 }
-
-#ifdef __REACTOS__
-
-static
-void
-CALLBACK
-_AddDirectoryProc(ULONG_PTR arg)
-{
-    LPNOTIFYREGISTER item = (LPNOTIFYREGISTER)arg;
-    _BeginRead(item);
-}
-
-BOOL _OpenDirectory(LPNOTIFYREGISTER item)
-{
-    STRRET strFile;
-    IShellFolder *psf;
-    HRESULT hr;
-    LPCITEMIDLIST child;
-    ULONG ulAttrs;
-
-    // Makes function idempotent
-    if (item->hDirectory && !(item->hDirectory == INVALID_HANDLE_VALUE))
-        return TRUE;
-
-    hr = SHBindToParent(item->pidl, &IID_IShellFolder, (LPVOID*)&psf, &child);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    ulAttrs = SFGAO_FILESYSTEM | SFGAO_FOLDER;
-    hr = IShellFolder_GetAttributesOf(psf, 1, (LPCITEMIDLIST*)&child, &ulAttrs);
-    if (SUCCEEDED(hr))
-        hr = IShellFolder_GetDisplayNameOf(psf, child, SHGDN_FORPARSING, &strFile);
-
-    IShellFolder_Release(psf);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return FALSE;
-
-    hr = StrRetToBufW(&strFile, NULL, item->wstrDirectory, _countof(item->wstrDirectory));
-    if (FAILED_UNEXPECTEDLY(hr))
-        return FALSE;
-
-    if ((ulAttrs & (SFGAO_FILESYSTEM | SFGAO_FOLDER)) != (SFGAO_FILESYSTEM | SFGAO_FOLDER))
-    {
-        TRACE("_OpenDirectory ignoring %s\n", debugstr_w(item->wstrDirectory));
-        item->hDirectory = INVALID_HANDLE_VALUE;
-        return FALSE;
-    }
-
-    TRACE("_OpenDirectory %s\n", debugstr_w(item->wstrDirectory));
-
-    item->hDirectory = CreateFileW(item->wstrDirectory, // pointer to the file name
-                                   GENERIC_READ | FILE_LIST_DIRECTORY, // access (read/write) mode
-                                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, // share mode
-                                   NULL, // security descriptor
-                                   OPEN_EXISTING, // how to create
-                                   FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED, // file attributes
-                                   NULL); // file with attributes to copy
-
-    if (item->hDirectory == INVALID_HANDLE_VALUE)
-    {
-        ERR("_OpenDirectory failed for %s\n", debugstr_w(item->wstrDirectory));
-        return FALSE;
-    }
-    return TRUE;
-}
-
-static void CALLBACK _RequestTermination(ULONG_PTR arg)
-{
-    LPNOTIFYREGISTER item = (LPNOTIFYREGISTER) arg;
-    TRACE("_RequestTermination %p %p \n", item, item->hDirectory);
-    if (!item->hDirectory || item->hDirectory == INVALID_HANDLE_VALUE) return;
-
-    CancelIo(item->hDirectory);
-    CloseHandle(item->hDirectory);
-    item->hDirectory = NULL;
-}
-
-static
-void
-CALLBACK
-_NotificationCompletion(DWORD dwErrorCode, // completion code
-                        DWORD dwNumberOfBytesTransfered, // number of bytes transferred
-                        LPOVERLAPPED lpOverlapped) // I/O information buffer
-{
-    /* MSDN: The hEvent member of the OVERLAPPED structure is not used by the
-       system, so you can use it yourself. We do just this, storing a pointer
-       to the working struct in the overlapped structure. */
-    LPNOTIFYREGISTER item = (LPNOTIFYREGISTER) lpOverlapped->hEvent;
-    TRACE("_NotificationCompletion\n");
-
-#if 0
-    if (dwErrorCode == ERROR_OPERATION_ABORTED)
-    {
-        /* Command was induced by CancelIo in the shutdown procedure. */
-        TRACE("_NotificationCompletion ended.\n");
-        return;
-    }
-#endif
-
-#ifdef __REACTOS__
-    /* If the FSD doesn't support directory change notifications, there's no
-     * no need to retry and requeue notification
-     */
-    if (dwErrorCode == ERROR_INVALID_FUNCTION)
-    {
-        WARN("Directory watching not supported\n");
-        return;
-    }
-
-    /* Also, if the notify operation was canceled (like, user moved to another
-     * directory), then, don't requeue notification
-     */
-    if (dwErrorCode == ERROR_OPERATION_ABORTED)
-    {
-        TRACE("Notification aborted\n");
-        return;
-    }
-
-    if (!item)
-    {
-        ERR("item == NULL\n");
-        return;
-    }
-
-#endif
-
-    /* This likely means overflow, so force whole directory refresh. */
-    if (!dwNumberOfBytesTransfered)
-    {
-        ERR("_NotificationCompletion overflow\n");
-
-        ZeroMemory(item->buffer, BUFFER_SIZE);
-        _BeginRead(item);
-
-        SHChangeNotify(SHCNE_UPDATEITEM | SHCNE_INTERRUPT,
-                       SHCNF_IDLIST,
-                       item->pidl,
-                       NULL);
-
-        return;
-    }
-
-    /*
-     * Get the new read issued as fast as possible (before we do the
-     * processing and message posting). All of the file notification
-     * occur on one thread so the buffers should not collide with one another.
-     * The extra zero mems are because the FNI size isn't written correctly.
-     */
-
-    ZeroMemory(item->backBuffer, BUFFER_SIZE);
-    memcpy(item->backBuffer, item->buffer, dwNumberOfBytesTransfered);
-    ZeroMemory(item->buffer, BUFFER_SIZE);
-
-    _BeginRead(item);
-
-    _ProcessNotification(item);
-}
-
-static VOID _BeginRead(LPNOTIFYREGISTER item )
-{
-    TRACE("_BeginRead %p \n", item->hDirectory);
-
-    /* This call needs to be reissued after every APC. */
-    if (!ReadDirectoryChangesW(item->hDirectory, // handle to directory
-                               item->buffer, // read results buffer
-                               BUFFER_SIZE, // length of buffer
-                               FALSE, // monitoring option (recursion)
-                               FILE_NOTIFY_CHANGE_DIR_NAME | FILE_NOTIFY_CHANGE_FILE_NAME, // filter conditions
-                               NULL, // bytes returned
-                               &item->overlapped, // overlapped buffer
-                               _NotificationCompletion)) // completion routine
-        ERR("ReadDirectoryChangesW failed. (%p, %p, %p, %p, %p) Code: %u \n",
-            item,
-            item->hDirectory,
-            item->buffer,
-            &item->overlapped,
-            _NotificationCompletion,
-            GetLastError());
-}
-
-DWORD _MapAction(DWORD dwAction, BOOL isDir)
-{
-    switch (dwAction)
-    {
-       case FILE_ACTION_ADDED : return isDir ? SHCNE_MKDIR : SHCNE_CREATE;
-       case FILE_ACTION_REMOVED : return isDir ? SHCNE_RMDIR : SHCNE_DELETE;
-       case FILE_ACTION_MODIFIED : return isDir ? SHCNE_UPDATEDIR : SHCNE_UPDATEITEM;
-       case FILE_ACTION_RENAMED_OLD_NAME : return isDir ? SHCNE_UPDATEDIR : SHCNE_UPDATEITEM;
-       case FILE_ACTION_RENAMED_NEW_NAME : return isDir ? SHCNE_UPDATEDIR : SHCNE_UPDATEITEM;
-       default: return SHCNE_UPDATEITEM;
-    }
-}
-
-VOID _ProcessNotification(LPNOTIFYREGISTER item)
-{
-    BYTE* pBase = item->backBuffer;
-    TRACE("_ProcessNotification\n");
-
-    for (;;)
-    {
-        FILE_NOTIFY_INFORMATION* fni = (FILE_NOTIFY_INFORMATION*)pBase;
-        LPWSTR wszFilename;
-        INT len = 0;
-        WCHAR wstrFilename[MAX_PATH];
-        WCHAR tmp[MAX_PATH];
-        StringCchCopy(tmp, fni->FileNameLength, fni->FileName);
-
-        PathCombine(wstrFilename, item->wstrDirectory, tmp);
-
-        /* If it could be a short filename, expand it. */
-        wszFilename = PathFindFileNameW(wstrFilename);
-
-        len = lstrlenW(wszFilename);
-        /* The maximum length of an 8.3 filename is twelve, including the dot. */
-        if (len <= 12 && wcschr(wszFilename, L'~'))
-        {
-            /* Convert to the long filename form. Unfortunately, this
-               does not work for deletions, so it's an imperfect fix. */
-            wchar_t wbuf[MAX_PATH];
-            if (GetLongPathName(wstrFilename, wbuf, _countof (wbuf)) > 0)
-                StringCchCopyW(wstrFilename, MAX_PATH, wbuf);
-        }
-
-        /* On deletion of a folder PathIsDirectory will return false even if
-           it *was* a directory, so, again, imperfect. */
-        SHChangeNotify(_MapAction(fni->Action, PathIsDirectory(wstrFilename)) | SHCNE_INTERRUPT,
-                       SHCNF_PATHW,
-                       wstrFilename,
-                       NULL);
-
-        if (!fni->NextEntryOffset)
-            break;
-        pBase += fni->NextEntryOffset;
-    }
-}
-
-static void CALLBACK _RequestAllTermination(ULONG_PTR arg)
-{
-    m_bTerminate = TRUE;
-}
-
-static unsigned int WINAPI _RunAsyncThreadProc(LPVOID arg)
-{
-    m_bTerminate = FALSE;
-    while (!m_bTerminate)
-    {
-        SleepEx(INFINITE, TRUE);
-    }
-    return 0;
-}
-
-#endif /* __REACTOS__ */


### PR DESCRIPTION
## Purpose
Fix `shell32!SHChangeNotify` and `shell32!SHChangeNotifyRegister` for shell notification mechanism.
JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/75833299-f95cbb80-5dfb-11ea-9bd5-6b1ad789d287.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/75833302-f9f55200-5dfb-11ea-8ff7-88cdf31fb554.png)

## TODOs
- [x] Use process memory.
- [x] Use PIDL. 