### PR TITLE
[KERNEL32_WINETEST] Enable 'generated.c', at last. ROSTESTS-251

### DIFF
--- a/modules/rostests/winetests/kernel32/CMakeLists.txt
+++ b/modules/rostests/winetests/kernel32/CMakeLists.txt
@@ -22,7 +22,7 @@ list(APPEND SOURCE
     fiber.c
     file.c
     format_msg.c
-    #generated.c
+    generated.c
     heap.c
     loader.c
     locale.c

--- a/modules/rostests/winetests/kernel32/generated.c
+++ b/modules/rostests/winetests/kernel32/generated.c
@@ -985,12 +985,12 @@ static void test_pack_LPEXCEPTION_POINTERS(void)
     TEST_TYPE_ALIGN  (LPEXCEPTION_POINTERS, 8)
 }
 
-//static void test_pack_LPEXCEPTION_RECORD(void)
-//{
-//    /* LPEXCEPTION_RECORD */
-//    TEST_TYPE_SIZE   (LPEXCEPTION_RECORD, 8)
-//    TEST_TYPE_ALIGN  (LPEXCEPTION_RECORD, 8)
-//}
+static void test_pack_LPEXCEPTION_RECORD(void)
+{
+    /* LPEXCEPTION_RECORD */
+    TEST_TYPE_SIZE   (LPEXCEPTION_RECORD, 8)
+    TEST_TYPE_ALIGN  (LPEXCEPTION_RECORD, 8)
+}
 
 static void test_pack_LPFIBER_START_ROUTINE(void)
 {
@@ -2842,12 +2842,12 @@ static void test_pack_LPEXCEPTION_POINTERS(void)
     TEST_TYPE_ALIGN  (LPEXCEPTION_POINTERS, 4)
 }
 
-//static void test_pack_LPEXCEPTION_RECORD(void)
-//{
-//    /* LPEXCEPTION_RECORD */
-//    TEST_TYPE_SIZE   (LPEXCEPTION_RECORD, 4)
-//    TEST_TYPE_ALIGN  (LPEXCEPTION_RECORD, 4)
-//}
+static void test_pack_LPEXCEPTION_RECORD(void)
+{
+    /* LPEXCEPTION_RECORD */
+    TEST_TYPE_SIZE   (LPEXCEPTION_RECORD, 4)
+    TEST_TYPE_ALIGN  (LPEXCEPTION_RECORD, 4)
+}
 
 static void test_pack_LPFIBER_START_ROUTINE(void)
 {


### PR DESCRIPTION
JIRA issue: [ROSTESTS-251](https://jira.reactos.org/browse/ROSTESTS-251)
