### PR TITLE
[HOST] Do not pack structures

### DIFF
--- a/sdk/include/host/typedefs.h
+++ b/sdk/include/host/typedefs.h
@@ -82,7 +82,7 @@ typedef WORD LANGID;
 #define MAXUSHORT USHRT_MAX
 
 /* Widely used structures */
-#include <pshpack4.h>
+
 #ifndef _HAVE_RTL_BITMAP
 typedef struct _RTL_BITMAP
 {
@@ -138,7 +138,6 @@ typedef struct _UNICODE_STRING
 } UNICODE_STRING, *PUNICODE_STRING;
 #endif
 
-#include <poppack.h>
 
 #ifndef _HAVE_LIST_ENTRY
 /* List Functions */


### PR DESCRIPTION
Most of them are unaffected by packing, the ones that are affected have pointers, and packing them will only misalign them, but not making the structures 32 bit compatible.
