### PR TITLE
[SFC][SFC_OS] Improve exports for sfc_1-7() and sfc_os_1-7()

### DIFF
--- a/dll/win32/sfc/sfc.spec
+++ b/dll/win32/sfc/sfc.spec
@@ -1,17 +1,17 @@
-@ stub sfc_1
-@ stub sfc_2
-@ stub sfc_3
-@ stub sfc_4
-@ stub sfc_5
-@ stub sfc_6
-@ stub sfc_7
-@ stdcall sfc_8 ()
-@ stdcall sfc_9 ()
-@ stdcall SRSetRestorePoint (ptr ptr)  SRSetRestorePointA
-@ stdcall SRSetRestorePointA (ptr ptr)
-@ stdcall SRSetRestorePointW (ptr ptr)
-@ stdcall SfcGetNextProtectedFile (ptr ptr) sfc_os.SfcGetNextProtectedFile
-@ stdcall SfcIsFileProtected (ptr wstr) sfc_os.SfcIsFileProtected
-@ stdcall SfcWLEventLogoff (ptr) sfc_os.SfcWLEventLogoff
-@ stdcall SfcWLEventLogon (ptr) sfc_os.SfcWLEventLogon
-@ stdcall SfpVerifyFile (str str long)
+@ stdcall -stub sfc_1()
+@ stdcall -stub sfc_2()
+@ stdcall -stub sfc_3()
+@ stdcall -stub sfc_4()
+@ stdcall -stub sfc_5()
+@ stdcall -stub sfc_6()
+@ stdcall -stub sfc_7()
+@ stdcall sfc_8()
+@ stdcall sfc_9()
+@ stdcall SRSetRestorePoint(ptr ptr) SRSetRestorePointA
+@ stdcall SRSetRestorePointA(ptr ptr)
+@ stdcall SRSetRestorePointW(ptr ptr)
+@ stdcall SfcGetNextProtectedFile(ptr ptr) sfc_os.SfcGetNextProtectedFile
+@ stdcall SfcIsFileProtected(ptr wstr) sfc_os.SfcIsFileProtected
+@ stdcall SfcWLEventLogoff(ptr) sfc_os.SfcWLEventLogoff
+@ stdcall SfcWLEventLogon(ptr) sfc_os.SfcWLEventLogon
+@ stdcall SfpVerifyFile(str str long)

--- a/dll/win32/sfc_os/sfc_os.spec
+++ b/dll/win32/sfc_os/sfc_os.spec
@@ -1,10 +1,10 @@
-@ stub sfc_os_1
-@ stub sfc_os_2
-@ stub sfc_os_3
-@ stub sfc_os_4
+@ stdcall -stub sfc_os_1()
+@ stdcall -stub sfc_os_2()
+@ stdcall -stub sfc_os_3()
+@ stdcall -stub sfc_os_4()
 @ stdcall SfcFileException(long ptr long)
-@ stub sfc_os_6
-@ stub sfc_os_7
+@ stdcall -stub sfc_os_6()
+@ stdcall -stub sfc_os_7()
 @ stdcall SfcGetNextProtectedFile(ptr ptr)
 @ stdcall SfcIsFileProtected(ptr wstr)
 @ stdcall SfcIsKeyProtected(long wstr long)


### PR DESCRIPTION
## Purpose

Improve exports for undocumented sfc_1-7() and sfc_os_1-7() functions in our sfc.dll and sfc_os.dll accordingly. Also remove extra whitespaces between all function names and their arguments in sfc.
Required by userenv.dll from Win2k3 together with MS win32k.sys & others replaced, in Frankensteined ReactOS and also by some MS installers, like Windows Media Encoder 7.1 installer. Now they should not fail due to that functions.

JIRA issue: [CORE-16458](https://jira.reactos.org/browse/CORE-16458)

## Proposed changes

Improve exports for the following functions:

- in sfc.dll
    - sfc_1();
    - sfc_2();
    - sfc_3();
    - sfc_4();
    - sfc_5();
    - sfc_6();
    - sfc_7();
- in sfc_os.dll
    - sfc_os_1();
    - sfc_os_2();
    - sfc_os_3();
    - sfc_os_4();
    - sfc_os_6();
    - sfc_os_7().

Also remove unnecessary whitespaces in dll/win32/sfc/sfc.spec.