### PR TITLE
[APITESTS] Tested function must be called before GetLastError() log

### DIFF
--- a/modules/rostests/apitests/apphelp/layerapi.c
+++ b/modules/rostests/apitests/apphelp/layerapi.c
@@ -688,7 +688,8 @@ static void test_Sign_Media(void)
             ok(ret, "Expected redirect_iat to succeed\n");
         if(ret)
         {
-            ok(create_file(workdir, "test.exe", 'a', 4), "create_file error: %d\n", GetLastError());
+            ret = create_file(workdir, "test.exe", 'a', 4);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             ok(wrapSdbSetPermLayerKeys2(drive, "test.exe", "TEST", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             /* 4 */
@@ -696,7 +697,8 @@ static void test_Sign_Media(void)
             expect_LayerValue(0, "SIGN.MEDIA=4 test.exe", "TEST");
             ok(wrapSdbSetPermLayerKeys2(drive, "test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
 
-            ok(create_file(workdir, "test.txt", 'a', 1), "create_file error: %d\n", GetLastError());
+            ret = create_file(workdir, "test.txt", 'a', 1);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(workdir, 2, "test.exe", "test.txt"))
             {
@@ -711,7 +713,8 @@ static void test_Sign_Media(void)
                 ok(wrapSdbSetPermLayerKeys2(drive, "test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             }
 
-            ok(create_file(workdir, "test.zz", 'a', 0x1000), "create_file error: %d\n", GetLastError());
+            ret = create_file(workdir, "test.zz", 'a', 0x1000);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(workdir, 3, "test.exe", "test.txt", "test.zz"))
             {
@@ -726,7 +729,8 @@ static void test_Sign_Media(void)
                 ok(wrapSdbSetPermLayerKeys2(drive, "test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             }
 
-            ok(create_file(subdir, "test.exe", 'a', 0x10203), "create_file error: %d\n", GetLastError());
+            ret = create_file(subdir, "test.exe", 'a', 0x10203);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(subdir, 1, "test.exe"))
             {
@@ -741,7 +745,8 @@ static void test_Sign_Media(void)
                 ok(wrapSdbSetPermLayerKeys2(drive, "sub\\test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             }
 
-            ok(create_file(subdir, "test.bbb", 'a', 0), "create_file error: %d\n", GetLastError());
+            ret = create_file(subdir, "test.bbb", 'a', 0);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(subdir, 2, "test.bbb", "test.exe"))
             {
@@ -756,7 +761,8 @@ static void test_Sign_Media(void)
                 ok(wrapSdbSetPermLayerKeys2(drive, "sub\\test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             }
 
-            ok(create_file(subdir, "TEST.txt", 'a', 0x30201), "create_file error: %d\n", GetLastError());
+            ret = create_file(subdir, "TEST.txt", 'a', 0x30201);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(subdir, 3, "test.bbb", "test.exe", "TEST.txt"))
             {
@@ -771,7 +777,8 @@ static void test_Sign_Media(void)
                 ok(wrapSdbSetPermLayerKeys2(drive, "sub\\test.exe", "", 0), "Expected wrapSdbSetPermLayerKeys2 to succeed\n");
             }
 
-            ok(create_file(subdir, "TEST.aaa", 'a', 0x3a2a1), "create_file error: %d\n", GetLastError());
+            ret = create_file(subdir, "TEST.aaa", 'a', 0x3a2a1);
+            ok(ret, "create_file error: %d\n", GetLastError());
 
             if (!expect_files(subdir, 4, "TEST.aaa", "test.bbb", "test.exe", "TEST.txt"))
             {
@@ -789,13 +796,20 @@ static void test_Sign_Media(void)
             ret = RestoreIat(GetModuleHandleA("apphelp.dll"), "kernel32.dll", "GetDriveTypeW", (ULONG_PTR)pGetDriveTypeW);
             ok(ret, "Expected restore_iat to succeed\n");
 
-            ok(delete_file(subdir, "test.bbb"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(subdir, "TEST.aaa"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(subdir, "TEST.txt"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(subdir, "test.exe"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(workdir, "test.zz"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(workdir, "test.txt"), "delete_file error: %d\n", GetLastError());
-            ok(delete_file(workdir, "test.exe"), "delete_file error: %d\n", GetLastError());
+            ret = delete_file(subdir, "test.bbb");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(subdir, "TEST.aaa");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(subdir, "TEST.txt");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(subdir, "test.exe");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(workdir, "test.zz");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(workdir, "test.txt");
+            ok(ret, "delete_file error: %d\n", GetLastError());
+            ret = delete_file(workdir, "test.exe");
+            ok(ret, "delete_file error: %d\n", GetLastError());
         }
         ret = DefineDosDeviceA(DDD_REMOVE_DEFINITION | DDD_NO_BROADCAST_SYSTEM, drive, NULL);
         ok(ret, "DefineDosDeviceA error: %d\n", GetLastError());

--- a/modules/rostests/apitests/kernel32/GetComputerNameEx.c
+++ b/modules/rostests/apitests/kernel32/GetComputerNameEx.c
@@ -49,8 +49,8 @@ TestGetComputerNameEx(
     StartSeh()
         Ret = GetComputerNameExA(NameType, NULL, NULL);
         Error = GetLastError();
-        ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
-        ok(Error == ERROR_INVALID_PARAMETER, "[%d] GetComputerNameExW returned error %lu\n", NameType, Error);
+        ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
+        ok(Error == ERROR_INVALID_PARAMETER, "[%d] GetComputerNameExA returned error %lu\n", NameType, Error);
     EndSeh(STATUS_SUCCESS);
 
     /* NULL buffer, nonzero size */
@@ -328,6 +328,7 @@ TestReturnValues()
     CHAR ComputerName[128];
     DWORD ComputerNameSize = 0;
     INT ErrorCode;
+    BOOL Ret;
 
     memset(OrigNetBIOS, 0, sizeof(OrigNetBIOS));
     memset(OrigHostname, 0, sizeof(OrigHostname));
@@ -363,9 +364,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalNetBIOS) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalNetBIOS) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigNetBIOS) == 0, "ComputerNamePhysicalNetBIOS doesn't match registry value '%s' != '%s'\n", ComputerName, OrigNetBIOS);
     EndSeh(STATUS_SUCCESS);
 
@@ -374,9 +380,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalDnsHostname) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalDnsHostname) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigHostname) == 0, "ComputerNamePhysicalDnsHostname doesn't match registry value '%s' != '%s'\n", ComputerName, OrigHostname);
     EndSeh(STATUS_SUCCESS);
 
@@ -385,9 +396,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalDnsDomain) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalDnsDomain) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigDomainName) == 0, "ComputerNamePhysicalDnsDomain doesn't match registry value '%s' != '%s'\n", ComputerName, OrigDomainName);
     EndSeh(STATUS_SUCCESS);
     ComputerNameSize = 0;
@@ -396,9 +412,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameNetBIOS) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameNetBIOS) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigNetBIOS) == 0, "ComputerNameNetBIOS doesn't match registry value '%s' != '%s'\n", ComputerName, OrigNetBIOS);
     EndSeh(STATUS_SUCCESS);
 
@@ -407,9 +428,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameDnsHostname) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameDnsHostname) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigHostname) == 0, "ComputerNameDnsHostname doesn't match registry value '%s' != '%s'\n", ComputerName, OrigHostname);
     EndSeh(STATUS_SUCCESS);
 
@@ -418,9 +444,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-           ok(GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameDnsDomain) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameDnsDomain) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigDomainName) == 0, "ComputerNameDnsDomain doesn't match registry value '%s' != '%s'\n", ComputerName, OrigDomainName);
     EndSeh(STATUS_SUCCESS);
 
@@ -434,9 +465,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalNetBIOS) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalNetBIOS, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalNetBIOS) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigNetBIOS) == 0, "ComputerNamePhysicalNetBIOS doesn't match registry value '%s' != '%s'\n", ComputerName, OrigNetBIOS);
     EndSeh(STATUS_SUCCESS);
 
@@ -445,9 +481,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalDnsHostname) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalDnsHostname, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalDnsHostname) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigHostname) == 0, "ComputerNamePhysicalDnsHostname doesn't match registry value '%s' != '%s'\n", ComputerName, OrigHostname);
     EndSeh(STATUS_SUCCESS);
 
@@ -456,9 +497,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNamePhysicalDnsDomain) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNamePhysicalDnsDomain, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNamePhysicalDnsDomain) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigDomainName) == 0, "ComputerNamePhysicalDnsDomain doesn't match registry value '%s' != '%s'\n", ComputerName, OrigDomainName);
     EndSeh(STATUS_SUCCESS);
     ComputerNameSize = 0;
@@ -467,9 +513,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameNetBIOS) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameNetBIOS, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameNetBIOS) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigNetBIOS) == 0, "ComputerNameNetBIOS doesn't match registry value '%s' != '%s'\n", ComputerName, OrigNetBIOS);
     EndSeh(STATUS_SUCCESS);
 
@@ -478,9 +529,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameDnsHostname) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameDnsHostname, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameDnsHostname) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigHostname) == 0, "ComputerNameDnsHostname doesn't match registry value '%s' != '%s'\n", ComputerName, OrigHostname);
     EndSeh(STATUS_SUCCESS);
 
@@ -489,9 +545,14 @@ TestReturnValues()
     StartSeh()
         GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize);
         if (ComputerNameSize)
-            ok(GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize), "GetComputerNameExA(ComputerNameDnsDomain) failed with %ld\n", GetLastError());
+        {
+            Ret = GetComputerNameExA(ComputerNameDnsDomain, ComputerName, &ComputerNameSize);
+            ok(Ret, "GetComputerNameExA(ComputerNameDnsDomain) failed with %ld\n", GetLastError());
+        }
         else
+        {
             memset(ComputerName, 0, sizeof(ComputerName));
+        }
         ok(strcmp(ComputerName, OrigDomainName) == 0, "ComputerNameDnsDomain doesn't match registry value '%s' != '%s'\n", ComputerName, OrigDomainName);
     EndSeh(STATUS_SUCCESS);
 

--- a/modules/rostests/apitests/kernel32/PrivMoveFileIdentityW.c
+++ b/modules/rostests/apitests/kernel32/PrivMoveFileIdentityW.c
@@ -60,6 +60,7 @@ TestPrivMoveFileIdentityW(VOID)
     HANDLE hDest;
     WCHAR Self[MAX_PATH];
     OFSTRUCT ReOpen;
+    BOOL Ret;
 
     DeleteFileW(FileName);
     DeleteFileW(FileName2);
@@ -97,13 +98,15 @@ TestPrivMoveFileIdentityW(VOID)
     ok(FileBasicInfo.CreationTime.QuadPart != CreationTime.QuadPart, "Equal creation times\n");
     ok(FileStandardInfo.EndOfFile.QuadPart == 0LL, "File wasn't created empty: %I64d\n", FileStandardInfo.EndOfFile.QuadPart);
     SetLastError(0xdeadbeef);
-    ok(pPrivMoveFileIdentityW(Self, FileName, 0) == FALSE, "PrivMoveFileIdentityW succeed\n");
+    Ret = pPrivMoveFileIdentityW(Self, FileName, 0);
+    ok(Ret == FALSE, "PrivMoveFileIdentityW succeeded unexpectedly\n");
     ok(GetLastError() == ERROR_SHARING_VIOLATION, "Last error: %#lx\n", GetLastError());
     ok(QueryFileInfo(FileName, &FileBasicInfo, &FileStandardInfo) == TRUE, "QueryFileInfo returned FALSE\n");
     ok(FileBasicInfo.CreationTime.QuadPart != CreationTime.QuadPart, "Equal creation times\n");
     ok(FileStandardInfo.EndOfFile.QuadPart == 0LL, "File wasn't created empty: %I64d\n", FileStandardInfo.EndOfFile.QuadPart);
     SetLastError(0xdeadbeef);
-    ok(pPrivMoveFileIdentityW(Self, FileName, 2) == TRUE, "PrivMoveFileIdentityW failed with %#lx\n", GetLastError());
+    Ret = pPrivMoveFileIdentityW(Self, FileName, 2);
+    ok(Ret == TRUE, "PrivMoveFileIdentityW failed with %#lx\n", GetLastError());
     ok(QueryFileInfo(FileName, &FileBasicInfo, &FileStandardInfo) == TRUE, "QueryFileInfo returned FALSE\n");
     ok(FileBasicInfo.CreationTime.QuadPart == CreationTime.QuadPart, "Creation time didn't change\n");
     ok(FileStandardInfo.EndOfFile.QuadPart == 0LL, "File not empty anymore: %I64d\n", FileStandardInfo.EndOfFile.QuadPart);
@@ -126,7 +129,8 @@ TestPrivMoveFileIdentityW(VOID)
     ok(QueryFileInfo(FileName2, &FileBasicInfo, &FileStandardInfo) == TRUE, "QueryFileInfo returned FALSE\n");
     ok(FileBasicInfo.CreationTime.QuadPart != CreationTime.QuadPart, "Equal creation times\n");
     SetLastError(0xdeadbeef);
-    ok(pPrivMoveFileIdentityW(FileName, FileName2, 3) == TRUE, "PrivMoveFileIdentityW failed with %#lx\n", GetLastError());
+    Ret = pPrivMoveFileIdentityW(FileName, FileName2, 3);
+    ok(Ret == TRUE, "PrivMoveFileIdentityW failed with %#lx\n", GetLastError());
     ok(QueryFileInfo(FileName2, &FileBasicInfo, &FileStandardInfo) == TRUE, "QueryFileInfo returned FALSE\n");
     ok(FileBasicInfo.CreationTime.QuadPart == CreationTime.QuadPart, "Creation time didn't change\n");
     ok(OpenFile(FileNameA, &ReOpen, OF_EXIST) == HFILE_ERROR, "Source file still exists\n");

--- a/modules/rostests/apitests/ws2_32/WSARecv.c
+++ b/modules/rostests/apitests/ws2_32/WSARecv.c
@@ -47,6 +47,7 @@ void Test_WSARecv()
     WSAOVERLAPPED overlapped;
     char szGetRequest[] = "GET / HTTP/1.0\r\n\r\n";
     struct fd_set readable;
+    BOOL ret;
 
     /* Start up Winsock */
     iResult = WSAStartup(MAKEWORD(2, 2), &wdata);
@@ -104,7 +105,8 @@ void Test_WSARecv()
     {
         iResult = WSAWaitForMultipleEvents(1, &overlapped.hEvent, TRUE, WSARecv_TIMEOUT, TRUE);
         ok(iResult == WSA_WAIT_EVENT_0, "WSAWaitForMultipleEvents failed %d\n", iResult);
-        ok(WSAGetOverlappedResult(sck, &overlapped, &dwSent, TRUE, &dwFlags), "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
+        ret = WSAGetOverlappedResult(sck, &overlapped, &dwSent, TRUE, &dwFlags);
+        ok(ret, "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
     }
     ok(dwSent == strlen(szGetRequest), "dwSent %ld != %d\n", dwSent, strlen(szGetRequest));
 #if 0 /* break windows too */
@@ -139,7 +141,8 @@ void Test_WSARecv()
     {
         iResult = WSAWaitForMultipleEvents(1, &overlapped.hEvent, TRUE, WSARecv_TIMEOUT, TRUE);
         ok(iResult == WSA_WAIT_EVENT_0, "WSAWaitForMultipleEvents failed %d\n", iResult);
-        ok(WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags), "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
+        ret = WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags);
+        ok(ret, "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
     }
     ok(dwRecv == sizeof(szRecvBuf), "dwRecv %ld != %d\n", dwRecv, sizeof(szRecvBuf));
     /* normal overlapped, no completion */
@@ -155,7 +158,8 @@ void Test_WSARecv()
     {
         iResult = WSAWaitForMultipleEvents(1, &overlapped.hEvent, TRUE, WSARecv_TIMEOUT, TRUE);
         ok(iResult == WSA_WAIT_EVENT_0, "WSAWaitForMultipleEvents failed %d\n", iResult);
-        ok(WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags), "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
+        ret = WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags);
+        ok(ret, "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
     }
     ok(dwRecv == sizeof(szBuf), "dwRecv %ld != %d\n", dwRecv, sizeof(szBuf));
     ok(memcmp(szRecvBuf, szBuf, sizeof(szBuf)) == 0, "MSG_PEEK shouldn't have moved the pointer\n");
@@ -170,9 +174,11 @@ void Test_WSARecv()
     {
         iResult = WSAWaitForMultipleEvents(1, &overlapped.hEvent, TRUE, WSARecv_TIMEOUT, TRUE);
         ok(iResult == WSA_WAIT_EVENT_0, "WSAWaitForMultipleEvents failed %d\n", iResult);
-        ok(WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags), "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
+        ret = WSAGetOverlappedResult(sck, &overlapped, &dwRecv, TRUE, &dwFlags);
+        ok(ret, "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
     }
-    ok(WSACloseEvent(overlapped.hEvent), "WSAGetOverlappedResult failed %d\n", WSAGetLastError());
+    ret = WSACloseEvent(overlapped.hEvent);
+    ok(ret, "WSACloseEvent failed %d\n", WSAGetLastError());
     ok(dwRecv == sizeof(szBuf), "dwRecv %ld != %d\n", dwRecv, sizeof(szBuf));
     /* no overlapped with completion */
     dwFlags = 0;
@@ -181,7 +187,7 @@ void Test_WSARecv()
     iResult = WSARecv(sck, &buffers, 1, &dwRecv, &dwFlags, NULL, &completion);
     err = WSAGetLastError();
     ok(iResult == 0 || (iResult == SOCKET_ERROR && err == WSA_IO_PENDING), "iResult = %d, %d\n", iResult, err);
-    ok(WSAGetLastError() == 0, "WSAGetLastError failed %d\n", WSAGetLastError());
+    ok(err == 0, "WSARecv failed %d\n", err);
     ok(dwRecv == sizeof(szBuf), "dwRecv %ld != %d and 0\n", dwRecv, sizeof(szBuf));
 
     closesocket(sck);


### PR DESCRIPTION
To get the relevant `LastError` value.