### PR TITLE
[WINETESTS] */generated.c: Remove forced 0x0501 API versions

### DIFF
--- a/modules/rostests/winetests/gdi32/generated.c
+++ b/modules/rostests/winetests/gdi32/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include "windows.h"

--- a/modules/rostests/winetests/kernel32/generated.c
+++ b/modules/rostests/winetests/kernel32/generated.c
@@ -5,10 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-
 #define WINE_NOWINSOCK
 
 #include "windows.h"

--- a/modules/rostests/winetests/ntdll/generated.c
+++ b/modules/rostests/winetests/ntdll/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include "ntdll_test.h"

--- a/modules/rostests/winetests/rpcrt4/generated.c
+++ b/modules/rostests/winetests/rpcrt4/generated.c
@@ -5,10 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-
 #define WINE_NOWINSOCK
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/shell32/generated.c
+++ b/modules/rostests/winetests/shell32/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/shlwapi/generated.c
+++ b/modules/rostests/winetests/shlwapi/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/urlmon/generated.c
+++ b/modules/rostests/winetests/urlmon/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/user32/generated.c
+++ b/modules/rostests/winetests/user32/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include "windows.h"

--- a/modules/rostests/winetests/wininet/generated.c
+++ b/modules/rostests/winetests/wininet/generated.c
@@ -5,12 +5,6 @@
  * Unit tests for data structure packing
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
-#endif
-
 #define WINE_NOWINSOCK
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/winmm/generated.c
+++ b/modules/rostests/winetests/winmm/generated.c
@@ -7,10 +7,6 @@
 
 #ifdef __REACTOS__
 #define _WINE
-#else
-#define WINVER 0x0501
-#define _WIN32_IE 0x0501
-#define _WIN32_WINNT 0x0501
 #endif
 
 #define WINE_NOWINSOCK


### PR DESCRIPTION
This actually affects 2 modules only:
* kernel32: this file is still commented out, these defines were going to be deactivated anyway.
* rpcrt4: I don't know why it had these defines (still) activated. Anyway.

Import
https://source.winehq.org/git/wine.git/commit/aa384d36429110970aa72acbc5043158de6aff03
