### PR TITLE
[KERNEL32_APITEST][WS2_32_APITEST] Call SetLastError() before checking LastError

### DIFF
--- a/modules/rostests/apitests/kernel32/GetComputerNameEx.c
+++ b/modules/rostests/apitests/kernel32/GetComputerNameEx.c
@@ -41,12 +41,14 @@ TestGetComputerNameEx(
 
     /* NULL buffer, NULL size */
     StartSeh()
+        SetLastError(0xdeadbeef);
         Ret = GetComputerNameExW(NameType, NULL, NULL);
         Error = GetLastError();
         ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
         ok(Error == ERROR_INVALID_PARAMETER, "[%d] GetComputerNameExW returned error %lu\n", NameType, Error);
     EndSeh(STATUS_SUCCESS);
     StartSeh()
+        SetLastError(0xdeadbeef);
         Ret = GetComputerNameExA(NameType, NULL, NULL);
         Error = GetLastError();
         ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
@@ -55,6 +57,7 @@ TestGetComputerNameEx(
 
     /* NULL buffer, nonzero size */
     Size = 0x55555555;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExW(NameType, NULL, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
@@ -62,6 +65,7 @@ TestGetComputerNameEx(
     ok(Size == 0x55555555, "[%d] Got Size %lu\n", NameType, Size);
 
     Size = 0x55555555;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExA(NameType, NULL, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
@@ -70,6 +74,7 @@ TestGetComputerNameEx(
 
     /* non-NULL buffer, NULL size */
     RtlFillMemory(BufferW, sizeof(BufferW), 0x55);
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExW(NameType, BufferW, NULL);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
@@ -77,6 +82,7 @@ TestGetComputerNameEx(
     ok(BufferW[0] == 0x5555, "[%d] BufferW[0] = 0x%x\n", NameType, BufferW[0]);
 
     RtlFillMemory(BufferA, sizeof(BufferA), 0x55);
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExA(NameType, BufferA, NULL);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
@@ -85,6 +91,7 @@ TestGetComputerNameEx(
 
     /* NULL buffer, zero size */
     Size = 0;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExW(NameType, NULL, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
@@ -92,6 +99,7 @@ TestGetComputerNameEx(
     ok(Size == ReferenceLen + 1, "[%d] Got Size %lu, expected %lu\n", NameType, Size, ReferenceLen + 1);
 
     Size = 0;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExA(NameType, NULL, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
@@ -101,6 +109,7 @@ TestGetComputerNameEx(
     /* non-NULL buffer, zero size */
     RtlFillMemory(BufferW, sizeof(BufferW), 0x55);
     Size = 0;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExW(NameType, BufferW, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
@@ -110,6 +119,7 @@ TestGetComputerNameEx(
 
     RtlFillMemory(BufferA, sizeof(BufferA), 0x55);
     Size = 0;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExA(NameType, BufferA, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);
@@ -120,6 +130,7 @@ TestGetComputerNameEx(
     /* non-NULL buffer, too small size */
     RtlFillMemory(BufferW, sizeof(BufferW), 0x55);
     Size = ReferenceLen;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExW(NameType, BufferW, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExW returned %d\n", NameType, Ret);
@@ -142,6 +153,7 @@ TestGetComputerNameEx(
 
     RtlFillMemory(BufferA, sizeof(BufferA), 0x55);
     Size = ReferenceLen;
+    SetLastError(0xdeadbeef);
     Ret = GetComputerNameExA(NameType, BufferA, &Size);
     Error = GetLastError();
     ok(Ret == FALSE, "[%d] GetComputerNameExA returned %d\n", NameType, Ret);

--- a/modules/rostests/apitests/ws2_32/WSARecv.c
+++ b/modules/rostests/apitests/ws2_32/WSARecv.c
@@ -98,6 +98,7 @@ void Test_WSARecv()
     buffers.buf = szGetRequest;
     buffers.len = lstrlenA(szGetRequest);
     dwSent = 0;
+    WSASetLastError(0xdeadbeef);
     iResult = WSASend(sck, &buffers, 1, &dwSent, 0, &overlapped, NULL);
     err = WSAGetLastError();
     ok(iResult == 0 || (iResult == SOCKET_ERROR && err == WSA_IO_PENDING), "iResult = %d, %d\n", iResult, err);
@@ -134,6 +135,7 @@ void Test_WSARecv()
     dwFlags = MSG_PEEK;
     dwRecv = sizeof(szRecvBuf);
     ok(overlapped.hEvent != NULL, "WSACreateEvent failed %d\n", WSAGetLastError());
+    WSASetLastError(0xdeadbeef);
     iResult = WSARecv(sck, &buffers, 1, &dwRecv, &dwFlags, &overlapped, NULL);
     err = WSAGetLastError();
     ok(iResult == 0 || (iResult == SOCKET_ERROR && err == WSA_IO_PENDING), "iResult = %d, %d\n", iResult, err);
@@ -151,6 +153,7 @@ void Test_WSARecv()
     dwFlags = 0;
     dwRecv = sizeof(szBuf);
     WSAResetEvent(overlapped.hEvent);
+    WSASetLastError(0xdeadbeef);
     iResult = WSARecv(sck, &buffers, 1, &dwRecv, &dwFlags, &overlapped, NULL);
     err = WSAGetLastError();
     ok(iResult == 0 || (iResult == SOCKET_ERROR && err == WSA_IO_PENDING), "iResult = %d, %d\n", iResult, err);
@@ -167,6 +170,7 @@ void Test_WSARecv()
     dwFlags = 0;
     dwRecv = sizeof(szBuf);
     WSAResetEvent(overlapped.hEvent);
+    WSASetLastError(0xdeadbeef);
     iResult = WSARecv(sck, &buffers, 1, &dwRecv, &dwFlags, &overlapped, &completion);
     err = WSAGetLastError();
     ok(iResult == 0 || (iResult == SOCKET_ERROR && err == WSA_IO_PENDING), "iResult = %d, %d\n", iResult, err);
@@ -183,6 +187,7 @@ void Test_WSARecv()
     /* no overlapped with completion */
     dwFlags = 0;
     dwRecv = sizeof(szBuf);
+    WSASetLastError(0xdeadbeef);
     /* call doesn't fail, but completion is not called */
     iResult = WSARecv(sck, &buffers, 1, &dwRecv, &dwFlags, NULL, &completion);
     err = WSAGetLastError();


### PR DESCRIPTION
Follow-up to cb5aa7bee44f57306d6c093bd5c93395ab7db7b7.
