### PR TITLE
[WIN32SS] Revert text drawing

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5,7 +5,7 @@
  * PURPOSE:         FreeType font engine interface
  * PROGRAMMERS:     Copyright 2001 Huw D M Davies for CodeWeavers.
  *                  Copyright 2006 Dmitry Timoshkov for CodeWeavers.
- *                  Copyright 2016-2019 Katayama Hirofumi MZ.
+ *                  Copyright 2016-2020 Katayama Hirofumi MZ.
  */
 
 /** Includes ******************************************************************/
@@ -4231,7 +4231,6 @@ TextIntGetTextExtentPoint(PDC dc,
     PMATRIX pmxWorldToDevice;
     LOGFONTW *plf;
     BOOL EmuBold, EmuItalic;
-    LONG ascender, descender;
 
     FontGDI = ObjToGDI(TextObj->Font, FONT);
 
@@ -4339,12 +4338,13 @@ TextIntGetTextExtentPoint(PDC dc,
         String++;
     }
     ASSERT(FontGDI->Magic == FONTGDI_MAGIC);
-    ascender = FontGDI->tmAscent; /* Units above baseline */
-    descender = FontGDI->tmDescent; /* Units below baseline */
     IntUnLockFreeType();
 
     Size->cx = (TotalWidth64 + 32) >> 6;
-    Size->cy = ascender + descender;
+    Size->cy = (plf->lfHeight == 0 ?
+                dc->ppdev->devinfo.lfDefaultFont.lfHeight :
+                abs(plf->lfHeight));
+    Size->cy = EngMulDiv(Size->cy, dc->ppdev->gdiinfo.ulLogPixelsY, 72);
 
     return TRUE;
 }

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -1262,17 +1262,26 @@ INT WINAPI DrawTextExWorker( HDC hdc,
 
 	if (flags & DT_SINGLELINE)
 	{
+            if (flags & DT_VCENTER)
 #ifdef __REACTOS__
-        if (flags & DT_VCENTER) y = rect->top +
-            (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
-        else if (flags & DT_BOTTOM)
-            y = rect->bottom + (invert_y ? 0 : -size.cy);
+            {
+                if (((rect->bottom - rect->top) < (invert_y ? -size.cy : size.cy)) && (flags & DT_CALCRECT))
+                {
+                    y = rect->top + (invert_y ? -size.cy : size.cy);
+                }
+                else
+                {
+                    y = rect->top + (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
 #else
-	    if (flags & DT_VCENTER) y = rect->top +
-	    	(rect->bottom - rect->top) / 2 - size.cy / 2;
-	    else if (flags & DT_BOTTOM) y = rect->bottom - size.cy;
+                    y = rect->top + (rect->bottom - rect->top) / 2 + (invert_y ? (size.cy / 2) : (-size.cy / 2));
 #endif
-    }
+#ifdef __REACTOS__
+                }
+            }
+#endif
+            else if (flags & DT_BOTTOM)
+                y = rect->bottom + (invert_y ? 0 : -size.cy);
+        }
 
 	if (!(flags & DT_CALCRECT))
 	{


### PR DESCRIPTION
## Purpose
Revert drawing text code by using the patch combination of CORE-16742 revert-freetype.patch and revert-PR745.patch.

JIRA issue: [CORE-16747](https://jira.reactos.org/browse/CORE-16747), [CORE-16742](https://jira.reactos.org/browse/CORE-16742), [CORE-15478](https://jira.reactos.org/browse/CORE-15478), [CORE-14896](https://jira.reactos.org/browse/CORE-14896), [CORE-16552](https://jira.reactos.org/browse/CORE-16552)