### PR TITLE
[GDI32] allow BI_BITFIELDS compression in CreateDIBitmap

### DIFF
--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -486,7 +486,7 @@ CreateDIBitmap(
     }
 
     /* Check if the Compr is incompatible */
-    if ((Compression == BI_JPEG) || (Compression == BI_PNG) || (Compression == BI_BITFIELDS))
+    if ((Compression == BI_JPEG) || (Compression == BI_PNG))
     {
         DPRINT1("Invalid compression: %lu!\n", Compression);
         goto Exit;


### PR DESCRIPTION
## Purpose

allow BI_BITFIELDS compression in CreateDIBitmap

JIRA issue: [CORE-16750](https://jira.reactos.org/browse/CORE-16750)

