### PR TITLE
[WINETESTS] Remove forced 0x050n API versions, with regard to NTDDI_VERSION

### DIFF
--- a/modules/rostests/winetests/rpcrt4/ndr_marshall.c
+++ b/modules/rostests/winetests/rpcrt4/ndr_marshall.c
@@ -18,9 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#define _WIN32_WINNT  0x0500
-#define NTDDI_WIN2K   0x05000000
-#define NTDDI_VERSION NTDDI_WIN2K /* for some MIDL_STUB_MESSAGE fields */
 #define COBJMACROS
 
 #include <stdarg.h>

--- a/modules/rostests/winetests/shell32/shlexec.c
+++ b/modules/rostests/winetests/shell32/shlexec.c
@@ -30,13 +30,6 @@
  *   we could check
  */
 
-/* Needed to get SEE_MASK_NOZONECHECKS with the PSDK */
-#ifndef __REACTOS__
-#define NTDDI_WINXPSP1 0x05010100
-#define NTDDI_VERSION NTDDI_WINXPSP1
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include <stdio.h>
 #include <assert.h>
 


### PR DESCRIPTION
Affects rpcrt4 only.

Import
https://source.winehq.org/git/wine.git/commit/57f08ba5259e56ae681bab1e61f86d6e8ab96f37
https://source.winehq.org/git/wine.git/commit/8fc0b7d525ae5e85b5a796eaf6572d22591e02c6