### PR TITLE
[USER32] Relax conditions for creating MDI windows

### DIFF
--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -411,7 +411,7 @@ CreateWindowExA(DWORD dwExStyle,
         if (pWndParent->fnid != FNID_MDICLIENT) // wine uses WIN_ISMDICLIENT
         {
            WARN("WS_EX_MDICHILD, but parent %p is not MDIClient\n", hWndParent);
-           return NULL;
+           goto skip_mdi;
         }
 
         /* lpParams of WM_[NC]CREATE is different for MDI children.
@@ -477,6 +477,7 @@ CreateWindowExA(DWORD dwExStyle,
         }
     }
 
+skip_mdi:
     hwnd = User32CreateWindowEx(dwExStyle,
                                 lpClassName,
                                 lpWindowName,
@@ -536,7 +537,7 @@ CreateWindowExW(DWORD dwExStyle,
         if (pWndParent->fnid != FNID_MDICLIENT)
         {
            WARN("WS_EX_MDICHILD, but parent %p is not MDIClient\n", hWndParent);
-           return NULL;
+           goto skip_mdi;
         }
 
         /* lpParams of WM_[NC]CREATE is different for MDI children.
@@ -602,6 +603,7 @@ CreateWindowExW(DWORD dwExStyle,
         }
     }
 
+skip_mdi:
     hwnd = User32CreateWindowEx(dwExStyle,
                                 (LPCSTR)lpClassName,
                                 (LPCSTR)lpWindowName,


### PR DESCRIPTION
## Purpose
The creation conditions of MDI window was too strict.
JIRA issue: [CORE-15633](https://jira.reactos.org/browse/CORE-15633)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/77120960-68cdde80-6a7d-11ea-850d-7b6712bfa348.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/77120958-68354800-6a7d-11ea-9442-d3f7ba445751.png)