### PR TITLE
[GDI32_WINETEST][USER32_WINETEST] Remove forced WINVER defines

### DIFF
--- a/modules/rostests/winetests/gdi32/dc.c
+++ b/modules/rostests/winetests/gdi32/dc.c
@@ -19,9 +19,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0501 /* request latest DEVMODE */
-#endif
 #define NONAMELESSSTRUCT
 #define NONAMELESSUNION
 

--- a/modules/rostests/winetests/user32/dialog.c
+++ b/modules/rostests/winetests/user32/dialog.c
@@ -29,10 +29,6 @@
  * normally be met.
  */
 
-#ifndef __REACTOS__
-#define WINVER 0x0600 /* For NONCLIENTMETRICS with padding */
-#endif
-
 #include <assert.h>
 #include <stdio.h>
 #include <stdarg.h>

--- a/modules/rostests/winetests/user32/msg.c
+++ b/modules/rostests/winetests/user32/msg.c
@@ -20,11 +20,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0600 /* For WM_CHANGEUISTATE,QS_RAWINPUT,WM_DWMxxxx */
-#define WINVER 0x0600 /* for WM_GETTITLEBARINFOEX */
-#endif
-
 #include <assert.h>
 #include <limits.h>
 #include <stdarg.h>

--- a/modules/rostests/winetests/user32/sysparams.c
+++ b/modules/rostests/winetests/user32/sysparams.c
@@ -17,12 +17,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0600 /* For SPI_GETMOUSEHOVERWIDTH and more */
-#define _WIN32_IE 0x0700
-#define WINVER 0x0600 /* For COLOR_MENUBAR, NONCLIENTMETRICS with padding */
-#endif
-
 #include <assert.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
No impact, as already deactivated.

Import
https://source.winehq.org/git/wine.git/commit/d0fd12b90946865a92f3fd016ccac13e5c4fdf54
