### PR TITLE
Introduce configuration for gitpod

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,23 @@
+FROM gitpod/workspace-full-vnc
+                    
+USER gitpod
+
+# Install custom tools, runtime, etc. using apt-get
+# For example, the command below would install "bastet" - a command line tetris clone:
+#
+# RUN sudo apt-get -q update && #     sudo apt-get install -yq bastet && #     sudo rm -rf /var/lib/apt/lists/*
+#
+# More information: https://www.gitpod.io/docs/config-docker/
+RUN sudo apt-get -q update && \
+    sudo apt-get -yq upgrade && \
+    sudo apt-get -yq install qemu-system-x86 qemu-utils gdb-mingw-w64 && \
+    sudo rm -rf /var/lib/apt/lists/*
+
+RUN wget https://svn.reactos.org/amine/RosBEBinFull.tar.gz && \
+    sudo tar -xzf RosBEBinFull.tar.gz -C /usr/local && \
+    sudo mv /usr/local/RosBEBinFull /usr/local/RosBE && \
+    rm -f RosBEBinFull.tar.gz
+
+RUN echo 'export PATH=/usr/local/RosBE/i386/bin:$PATH' >> /home/gitpod/.profile
+
+RUN qemu-img create -f qcow2 reactos_hdd.qcow 10G

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,18 @@
+tasks:
+  - before: > 
+      brew install cmake ninja
+    init: >
+      mkdir -p /workspace/reactos/build &&
+      cd /workspace/reactos/build &&
+      cmake .. -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DGDB:BOOL=TRUE -DSEPARATE_DBG:BOOL=TRUE -D_WINKD_:BOOL=TRUE -DKDBG:BOOL=FALSE -DENABLE_ROSTESTS:BOOL=TRUE -DCMAKE_TOOLCHAIN_FILE=toolchain-gcc.cmake -G "Ninja" &&
+      ninja xdk psdk 
+    command: >
+      cd /workspace/reactos/build &&
+      ninja all
+
+image:
+  file: .gitpod.Dockerfile
+
+vscode:
+  extensions:
+    - ms-vscode.cpptools@0.27.0-insiders3:Djj3Csw0GXjmueWAPWvTsg==

--- a/.theia/launch.json
+++ b/.theia/launch.json
@@ -1,0 +1,29 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "cppdbg",
+      "request": "launch",
+      "name": "livecd (qemu)",
+      "preLaunchTask": "launch livecd",
+      "miDebuggerServerAddress": "localhost:9091",
+      "miDebuggerArgs": "-l 15 -ex 'set sysroot ${workspaceRoot}/build/symbols'",
+      "program": "${workspaceRoot}/build/ntoskrnl/ntoskrnl.exe",
+      "cwd": "${workspaceRoot}/build",
+      "miDebuggerPath": "i686-w64-mingw32-gdb"
+    },
+    {
+      "type": "cppdbg",
+      "request": "launch",
+      "name": "bootcd (qemu)",
+      "preLaunchTask": "launch bootcd",
+      "miDebuggerServerAddress": "localhost:9091",
+      "miDebuggerArgs": "-l 15 -ex 'set sysroot ${workspaceRoot}/build/symbols'",
+      "program": "${workspaceRoot}/build/ntoskrnl/ntoskrnl.exe",
+      "cwd": "${workspaceRoot}/build",
+      "miDebuggerPath": "i686-w64-mingw32-gdb"
+    }
+  ]
+}

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,10 @@
+{
+    "cpp.buildConfigurations": [
+        {
+            "name": "build",
+            "directory": "${workspaceFolder}/build"
+        }
+    ],
+    "cpp.clangdArgs": "--background-index",
+    "C_Cpp.intelliSenseEngine": "Disabled",
+}

--- a/.theia/tasks.json
+++ b/.theia/tasks.json
@@ -1,0 +1,91 @@
+{
+	// See https://go.microsoft.com/fwlink/?LinkId=733558
+	// for the documentation about the tasks.json format
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "label": "build livecd",
+            "type": "shell",
+            "command": "ninja livecd",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "group": "build",
+            "problemMatcher": [
+                {
+                    "owner": "cpp",
+                    "fileLocation": ["relative", "${workspaceFolder}/build"],
+                    "pattern": {
+                        "regexp": "^(.*):(\\d+):(\\d+):\\s+(warning|error):\\s+(.*)$",
+                        "file": 1,
+                        "line": 2,
+                        "column": 3,
+                        "severity": 4,
+                        "message": 5
+                    }
+                }
+            ]
+        },
+        {
+            "label": "build bootcd",
+            "type": "shell",
+            "command": "ninja bootcd",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "group": "build",
+            "problemMatcher": [
+                {
+                    "base": "$gcc",
+                    "fileLocation": ["relative", "${workspaceFolder}/build"],
+                },
+            ]
+        },
+        {
+            "label": "launch livecd",
+            "type": "process",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "dependsOn": [
+                "build livecd"
+            ],
+            "dependsOrder": "sequence",
+            "command": "qemu-system-i386",
+            "args": [
+                "-cdrom", "livecd.iso",
+                "-chardev", "socket,port=9091,host=localhost,server,nowait,id=char0",
+                "-serial", "chardev:char0",
+                "-nic", "user,model=e1000",
+                "-boot", "d",
+                "-chardev", "socket,path=/tmp/livecd_dbg,server,nowait,id=char1", "-serial", "chardev:char1",
+                "-daemonize"
+            ],
+            "problemMatcher": []
+        },
+        {
+            "label": "launch bootcd",
+            "type": "process",
+            "options": {
+                "cwd": "${workspaceFolder}/build"
+            },
+            "dependsOn": [
+                "build bootcd"
+            ],
+            "dependsOrder": "sequence",
+            "command": "qemu-system-i386",
+            "args": [
+                "-cdrom", "bootcd.iso",
+                "-hda", "${env:HOME}/reactos_hdd.qcow",
+                "-boot", "d",
+                "-m", "1024",
+                "-chardev", "socket,port=9091,host=localhost,server,nowait,id=char0",
+                "-serial", "chardev:char0",
+                "-nic", "user,model=e1000",
+                "-chardev", "socket,path=/tmp/bootcd_dbg,server,nowait,id=char1", "-serial", "chardev:char1",
+                "-daemonize"
+            ],
+            "problemMatcher": []
+        },
+    ],
+}

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@
 [ReactOS Git mirror](https://git.reactos.org) &bull; 
 [Testman](https://reactos.org/testman/)
 
-
 ## What is ReactOS?
 
 ReactOS™ is an Open Source effort to develop a quality operating system that is compatible with applications and drivers written for the Microsoft® Windows™ NT family of operating systems (NT4, 2000, XP, 2003, Vista, Seven).
@@ -91,7 +90,7 @@ See ["File Bugs"](https://www.reactos.org/wiki/File_Bugs) for a guide.
 
 __NOTE:__ The bug tracker is _not_ for discussions. Please use `#reactos` Freenode IRC channel or our [forum](https://reactos.org/forum).
 
-## Contributing  ![prwelcome.badge]
+## Contributing [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/reactos/reactos) &bull; ![prwelcome.badge]
 
 We are always looking for developers! Check [how to contribute](CONTRIBUTING.md) if you are willing to participate.
 


### PR DESCRIPTION
## Purpose

I played a bit with gitpod and their online IDE (theia) and I have been pleased by the experience. The PR is about having the possibility to develop and debug ReactOS (in qemu) with a one-click solution.

The proposed configuration creates a custom docker image, and has the tasks configured to build, launch & debug both bootcd & livecd (using GDB).

I fixed a few hitches while I were at it, mostly in the build system and in KDGDB.

## Proposed changes

Nothing much, those are a bunch of config files, but you can have a look there :
https://gitpod.io#snapshot/4b28a6aa-3a64-4a6e-8bdb-5a7c190b2e10
If you want to have nice C/C++ integration, you have to choose the build configuration in the "C/C++ build config" button at the bottom right of the screen.
NB : in the "open ports" tab, you can open the browser for port 6080. There you will have a VNC display pointing to an openbox desktop. This is where qemu will show the instance being debugged.
