### PR TITLE
[WINETESTS] Remove forced _WIN32_WINNT defines

### DIFF
--- a/modules/rostests/winetests/comctl32/subclass.c
+++ b/modules/rostests/winetests/comctl32/subclass.c
@@ -17,8 +17,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#define _WIN32_WINNT 0x0501 /* For SetWindowSubclass/etc */
-
 #include <assert.h>
 #include <stdarg.h>
 

--- a/modules/rostests/winetests/kernel32/sync.c
+++ b/modules/rostests/winetests/kernel32/sync.c
@@ -18,9 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x500
-#endif
 #include <stdarg.h>
 #include <stdlib.h>
 #include <stdio.h>

--- a/modules/rostests/winetests/kernel32/thread.c
+++ b/modules/rostests/winetests/kernel32/thread.c
@@ -18,11 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* Define _WIN32_WINNT to get SetThreadIdealProcessor on Windows */
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0600
-#endif
-
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/modules/rostests/winetests/kernel32/timer.c
+++ b/modules/rostests/winetests/kernel32/timer.c
@@ -18,10 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include "wine/test.h"
 #include "winbase.h"
 

--- a/modules/rostests/winetests/kernel32/version.c
+++ b/modules/rostests/winetests/kernel32/version.c
@@ -18,11 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* Needed for PRODUCT_* defines and GetProductInfo() */
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0600
-#endif
-
 #include "wine/test.h"
 #include "winbase.h"
 #include "winternl.h"

--- a/modules/rostests/winetests/psapi/psapi_main.c
+++ b/modules/rostests/winetests/psapi/psapi_main.c
@@ -19,11 +19,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* 0x0600 makes PROCESS_ALL_ACCESS not compatible with pre-Vista versions */
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0500
-#endif
-
 #include <stdarg.h>
 
 #include "ntstatus.h"

--- a/modules/rostests/winetests/user32/broadcast.c
+++ b/modules/rostests/winetests/user32/broadcast.c
@@ -18,10 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include <stdarg.h>
 #include <stdio.h>
 

--- a/modules/rostests/winetests/user32/class.c
+++ b/modules/rostests/winetests/user32/class.c
@@ -18,11 +18,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* To get CS_DROPSHADOW with the MSVC headers */
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/modules/rostests/winetests/user32/menu.c
+++ b/modules/rostests/winetests/user32/menu.c
@@ -19,10 +19,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x0501
-#endif
-
 #include <stdarg.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Only comctl32 is affected.

Import
https://source.winehq.org/git/wine.git/commit/be3cda6ec0856d143d4737ee9306844569b76e15