### PR TITLE
[REACTOS] Fix '\NLS\' typos

### DIFF
--- a/base/setup/lib/mui.c
+++ b/base/setup/lib/mui.c
@@ -403,7 +403,7 @@ AddCodepageToRegistry(
 
     // Open the nls codepage key
     RtlInitUnicodeString(&KeyName,
-                         L"SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage");
+                         L"SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage");
     InitializeObjectAttributes(&ObjectAttributes,
                                &KeyName,
                                OBJ_CASE_INSENSITIVE,

--- a/base/setup/lib/settings.c
+++ b/base/setup/lib/settings.c
@@ -1018,7 +1018,7 @@ ProcessLocaleRegistry(
 
     /* Open the NLS language key */
     RtlInitUnicodeString(&KeyName,
-                         L"SYSTEM\\CurrentControlSet\\Control\\NLS\\Language");
+                         L"SYSTEM\\CurrentControlSet\\Control\\Nls\\Language");
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &KeyName,

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -220,7 +220,7 @@ WinLdrGetNLSNames(PSTR AnsiName,
 
     /* Open the CodePage key */
     rc = RegOpenKey(NULL,
-        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage",
+        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage",
         &hKey);
     if (rc != ERROR_SUCCESS)
     {
@@ -268,7 +268,7 @@ WinLdrGetNLSNames(PSTR AnsiName,
 
     /* Open the Language key */
     rc = RegOpenKey(NULL,
-        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language",
+        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language",
         &hKey);
     if (rc != ERROR_SUCCESS)
     {

--- a/dll/cpl/intl/advanced.c
+++ b/dll/cpl/intl/advanced.c
@@ -361,7 +361,7 @@ SaveSystemSettings(
     }
 
     /* Set codepages */
-    ret = RegOpenKeyW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage", &langKey);
+    ret = RegOpenKeyW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage", &langKey);
     if (ret != ERROR_SUCCESS)
     {
         PrintErrorMsgBox(IDS_ERROR_NLS_CODE_REG);
@@ -378,7 +378,7 @@ SaveSystemSettings(
     valuesize = (wcslen(value) + 1) * sizeof(WCHAR);
 
     /* Set language */
-    ret = RegOpenKeyW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\NLS\\Language", &langKey);
+    ret = RegOpenKeyW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Nls\\Language", &langKey);
     if (ret != ERROR_SUCCESS)
     {
         PrintErrorMsgBox(IDS_ERROR_NLS_KEY_REG);

--- a/dll/cpl/intl/lang/bg-BG.rc
+++ b/dll/cpl/intl/lang/bg-BG.rc
@@ -210,8 +210,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/cs-CZ.rc
+++ b/dll/cpl/intl/lang/cs-CZ.rc
@@ -215,7 +215,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Vyskytl se problém při načítání znakové sady ANSI"
     IDS_ERROR_INT_KEY_REG "Problém při otevírání klíče: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problém při otevírání klíče: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problém při otevírání klíče: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problém při otevírání klíče: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problém při otevírání klíče: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problém při otevírání klíče: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Nebylo možné spustit input.dll"
 END

--- a/dll/cpl/intl/lang/de-DE.rc
+++ b/dll/cpl/intl/lang/de-DE.rc
@@ -211,7 +211,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Die ANSI-Codepage konnte nicht gelesen werden."
     IDS_ERROR_INT_KEY_REG "Der Schlüssel HKCU\\Control Panel\\International konnte nicht geöffnet werden."
     IDS_ERROR_DEF_INT_KEY_REG "Der Schlüssel HKU\\.DEFAULT\\Control Panel\\International konnte nicht geöffnet werden."
-    IDS_ERROR_NLS_KEY_REG "Der Schlüssel HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language konnte nicht geöffnet werden."
-    IDS_ERROR_NLS_CODE_REG "Der Schlüssel HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage konnte nicht geöffnet werden."
+    IDS_ERROR_NLS_KEY_REG "Der Schlüssel HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language konnte nicht geöffnet werden."
+    IDS_ERROR_NLS_CODE_REG "Der Schlüssel HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage konnte nicht geöffnet werden."
     IDS_ERROR_INPUT_DLL "Die Datei input.dll konnte nicht geladen werden."
 END

--- a/dll/cpl/intl/lang/en-US.rc
+++ b/dll/cpl/intl/lang/en-US.rc
@@ -210,7 +210,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END

--- a/dll/cpl/intl/lang/es-ES.rc
+++ b/dll/cpl/intl/lang/es-ES.rc
@@ -212,8 +212,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Hubo un problema al leer la página de caracteres regional ANSI"
     IDS_ERROR_INT_KEY_REG "Hubo un problema al abrir la clave del Registro: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Hubo un problema al abrir la clave del Registro: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Hubo un problema al abrir la clave del Registro: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Hubo un problema al abrir la clave del Registro: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Hubo un problema al abrir la clave del Registro: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Hubo un problema al abrir la clave del Registro: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "No se pudo iniciar input.dll"
 END
 

--- a/dll/cpl/intl/lang/fr-FR.rc
+++ b/dll/cpl/intl/lang/fr-FR.rc
@@ -212,8 +212,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/he-IL.rc
+++ b/dll/cpl/intl/lang/he-IL.rc
@@ -212,8 +212,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/it-IT.rc
+++ b/dll/cpl/intl/lang/it-IT.rc
@@ -213,8 +213,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/ja-JP.rc
+++ b/dll/cpl/intl/lang/ja-JP.rc
@@ -210,7 +210,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "ANSIコードページの読み込みに問題がありました"
     IDS_ERROR_INT_KEY_REG "問題の開いているキー: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "問題の開いているキー: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "問題の開いているキー: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "問題の開いているキー: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "問題の開いているキー: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "問題の開いているキー: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "input.dllを開始できません"
 END

--- a/dll/cpl/intl/lang/no-NO.rc
+++ b/dll/cpl/intl/lang/no-NO.rc
@@ -210,8 +210,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/pl-PL.rc
+++ b/dll/cpl/intl/lang/pl-PL.rc
@@ -218,7 +218,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Wystąpił problem podczas czytania strony kodowej ANSI"
     IDS_ERROR_INT_KEY_REG "Problem z otwarciem klucza: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem z otwarciem klucza: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem z otwarciem klucza: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem z otwarciem klucza: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem z otwarciem klucza: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem z otwarciem klucza: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Nie można uruchomić input.dll"
 END

--- a/dll/cpl/intl/lang/pt-BR.rc
+++ b/dll/cpl/intl/lang/pt-BR.rc
@@ -207,7 +207,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Erro ao ler a tabela de conversão de página de código ANSI"
     IDS_ERROR_INT_KEY_REG "Erro ao abrir a chave: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Erro ao abrir a chave: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Não foi possível iniciar input.dll"
 END

--- a/dll/cpl/intl/lang/pt-PT.rc
+++ b/dll/cpl/intl/lang/pt-PT.rc
@@ -207,8 +207,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Erro ao ler a tabela de conversão de página de código ANSI"
     IDS_ERROR_INT_KEY_REG "Erro ao abrir a chave: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Erro ao abrir a chave: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Erro ao abrir a chave: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Não foi possível iniciar input.dll"
 END
 

--- a/dll/cpl/intl/lang/ru-RU.rc
+++ b/dll/cpl/intl/lang/ru-RU.rc
@@ -211,7 +211,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "Возникла проблема при чтении кодовой страницы ANSI"
     IDS_ERROR_INT_KEY_REG "Проблема открытия ключа: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Проблема открытия ключа: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Проблема открытия ключа: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Проблема открытия ключа: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Проблема открытия ключа: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Проблема открытия ключа: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Не удается запустить input.dll"
 END

--- a/dll/cpl/intl/lang/sk-SK.rc
+++ b/dll/cpl/intl/lang/sk-SK.rc
@@ -216,8 +216,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END
 

--- a/dll/cpl/intl/lang/sq-AL.rc
+++ b/dll/cpl/intl/lang/sq-AL.rc
@@ -214,7 +214,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END

--- a/dll/cpl/intl/lang/uk-UA.rc
+++ b/dll/cpl/intl/lang/uk-UA.rc
@@ -218,7 +218,7 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "There was a problem reading the ANSI code page"
     IDS_ERROR_INT_KEY_REG "Problem opening key: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "Problem opening key: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "Problem opening key: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "Unable to start input.dll"
 END

--- a/dll/cpl/intl/lang/zh-CN.rc
+++ b/dll/cpl/intl/lang/zh-CN.rc
@@ -215,8 +215,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "阅读 ANSI 代码页时有个问题。"
     IDS_ERROR_INT_KEY_REG "问题打开项: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "问题打开项: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "问题打开项: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "问题打开项: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "问题打开项: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "问题打开项: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "无法启动 input.dll"
 END
 

--- a/dll/cpl/intl/lang/zh-TW.rc
+++ b/dll/cpl/intl/lang/zh-TW.rc
@@ -215,8 +215,8 @@ BEGIN
     IDS_ERROR_ANSI_CODE_PAGE "閱讀 ANSI 內碼表時有個問題。"
     IDS_ERROR_INT_KEY_REG "問題開啟項: HKCU\\Control Panel\\International"
     IDS_ERROR_DEF_INT_KEY_REG "問題開啟項: HKU\\.DEFAULT\\Control Panel\\International"
-    IDS_ERROR_NLS_KEY_REG "問題開啟項: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\Language"
-    IDS_ERROR_NLS_CODE_REG "問題開啟項: HKLM\\SYSTEM\\CurrentControlSet\\Control\\NLS\\CodePage"
+    IDS_ERROR_NLS_KEY_REG "問題開啟項: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\Language"
+    IDS_ERROR_NLS_CODE_REG "問題開啟項: HKLM\\SYSTEM\\CurrentControlSet\\Control\\Nls\\CodePage"
     IDS_ERROR_INPUT_DLL "無法啟動 input.dll"
 END
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -1020,7 +1020,7 @@ SetKeyboardLayoutName(HWND hwnd)
     HKEY hKey;
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
-                     _T("SYSTEM\\CurrentControlSet\\Control\\NLS\\Locale"),
+                     _T("SYSTEM\\CurrentControlSet\\Control\\Nls\\Locale"),
                      0,
                      KEY_ALL_ACCESS,
                      &hKey))
@@ -1436,7 +1436,7 @@ GetTimeZoneListIndex(LPDWORD lpIndex)
         *lpIndex = 85; /* fallback to GMT time zone */
 
         if (RegOpenKeyExW(HKEY_LOCAL_MACHINE,
-                          L"SYSTEM\\CurrentControlSet\\Control\\NLS\\Language",
+                          L"SYSTEM\\CurrentControlSet\\Control\\Nls\\Language",
                           0,
                           KEY_ALL_ACCESS,
                           &hKey))


### PR DESCRIPTION
Use `\Nls\`, as everywhere else.

NB:
1 case remains in `dll/win32/kernel32/winnls/string/lang.c`: to be WineSync'ed...