### PR TITLE
[USERENV] sq-AL: Fix '%SistemDrive%' typo. CORE-16762

### DIFF
--- a/dll/win32/userenv/lang/sq-AL.rc
+++ b/dll/win32/userenv/lang/sq-AL.rc
@@ -8,7 +8,7 @@ LANGUAGE LANG_ALBANIAN, SUBLANG_NEUTRAL
 /* See also: dll/win32/shell32/lang */
 STRINGTABLE
 BEGIN
-    IDS_PROFILEPATH "%SistemDrive%\\Dokumente dhe Cilësime"
+    IDS_PROFILEPATH "%SystemDrive%\\Dokumente dhe Cilësime"
     IDS_APPDATA "Aplikation Data"
     IDS_DESKTOP "Desktop"
     IDS_FAVORITES "Preferuara"


### PR DESCRIPTION
Not to translate!

JIRA issue: [CORE-16762](https://jira.reactos.org/browse/CORE-16762)
