### PR TITLE
[SDK][LIB] Add structures for the arbiter.

### DIFF
--- a/drivers/bus/pcix/CMakeLists.txt
+++ b/drivers/bus/pcix/CMakeLists.txt
@@ -1,3 +1,5 @@
+include_directories(
+    ${REACTOS_SOURCE_DIR}/sdk/lib/drivers/arbiter)
 
 list(APPEND SOURCE
     arb/ar_busno.c
@@ -41,6 +43,7 @@ add_library(pcix MODULE
     pci.rc)
 
 set_module_type(pcix kernelmodedriver)
+target_link_libraries(pcix arbiter)
 add_importlibs(pcix ntoskrnl hal)
 add_pch(pcix pci.h SOURCE)
 add_dependencies(pcix pciclass)

--- a/drivers/bus/pcix/arb/ar_busno.c
+++ b/drivers/bus/pcix/arb/ar_busno.c
@@ -34,11 +34,38 @@ NTSTATUS
 NTAPI
 arbusno_Initializer(IN PVOID Instance)
 {
-    UNREFERENCED_PARAMETER(Instance);
+    PPCI_ARBITER_INSTANCE Arbiter = Instance;
+    PPCI_FDO_EXTENSION FdoExtension;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    RtlZeroMemory(&Arbiter->CommonInstance, sizeof(Arbiter->CommonInstance));
+
+    FdoExtension = Arbiter->BusFdoExtension;
+
     /* Not yet implemented */
     UNIMPLEMENTED;
-    //while (TRUE);
-    return STATUS_SUCCESS;
+
+#if 0
+    Arbiter->CommonInstance.UnpackRequirement = arbusno_UnpackRequirement;
+    Arbiter->CommonInstance.PackResource = arbusno_PackResource;
+    Arbiter->CommonInstance.UnpackResource = arbusno_UnpackResource;
+    Arbiter->CommonInstance.ScoreRequirement = arbusno_ScoreRequirement;
+#endif
+
+    Status = ArbInitializeArbiterInstance(&Arbiter->CommonInstance,
+                                          FdoExtension->FunctionalDeviceObject,
+                                          CmResourceTypeBusNumber,
+                                          Arbiter->InstanceName,
+                                          L"Pci",
+                                          NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("arbusno_Initializer: init arbiter return %X", Status);
+    }
+
+    return Status;
 }
 
 NTSTATUS

--- a/drivers/bus/pcix/pci.h
+++ b/drivers/bus/pcix/pci.h
@@ -18,6 +18,7 @@
 #include <ndk/halfuncs.h>
 #include <ndk/rtlfuncs.h>
 #include <ndk/vffuncs.h>
+#include <arbiter.h>
 
 //
 // Tag used in all pool allocations (Pci Bus)
@@ -402,7 +403,7 @@ typedef struct PCI_ARBITER_INSTANCE
     PPCI_INTERFACE Interface;
     PPCI_FDO_EXTENSION BusFdoExtension;
     WCHAR InstanceName[24];
-    //ARBITER_INSTANCE CommonInstance; FIXME: Need Arbiter Headers
+    ARBITER_INSTANCE CommonInstance;
 } PCI_ARBITER_INSTANCE, *PPCI_ARBITER_INSTANCE;
 
 //

--- a/hal/halx86/CMakeLists.txt
+++ b/hal/halx86/CMakeLists.txt
@@ -32,7 +32,12 @@ function(add_hal _halname)
         target_link_libraries(${_halname} ${_haldata_LIBS})
     endif()
 
-    target_link_libraries(${_halname} libcntpr)
+    if (${_halname} STREQUAL "hal")
+        target_link_libraries(${_halname} libcntpr arbiter)
+    else()
+        target_link_libraries(${_halname} libcntpr)
+    endif()
+
     add_importlibs(${_halname} ntoskrnl)
     #add_pch(${_halname} include/hal.h)
     add_dependencies(${_halname} psdk asm)

--- a/ntoskrnl/CMakeLists.txt
+++ b/ntoskrnl/CMakeLists.txt
@@ -42,7 +42,7 @@ else()
     #add_linker_script(ntoskrnl ${REACTOS_SOURCE_DIR}/sdk/cmake/init-section.lds)
 endif()
 
-target_link_libraries(ntoskrnl cportlib csq ${PSEH_LIB} cmlib ntlsalib rtl ${ROSSYM_LIB} libcntpr wdmguid ioevent)
+target_link_libraries(ntoskrnl cportlib csq ${PSEH_LIB} arbiter cmlib ntlsalib rtl ${ROSSYM_LIB} libcntpr wdmguid ioevent)
 
 if(STACK_PROTECTOR)
     target_link_libraries(ntoskrnl gcc_ssp)

--- a/ntoskrnl/include/internal/ntoskrnl.h
+++ b/ntoskrnl/include/internal/ntoskrnl.h
@@ -79,6 +79,7 @@
 #include "hal.h"
 #include "hdl.h"
 #include "arch/intrin_i.h"
+#include <arbiter.h>
 
 /*
  * generic information class probing code

--- a/ntoskrnl/io/pnpmgr/arbs.c
+++ b/ntoskrnl/io/pnpmgr/arbs.c
@@ -1,0 +1,123 @@
+/*
+ * PROJECT:         ReactOS Kernel
+ * COPYRIGHT:       GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * FILE:            ntoskrnl/io/pnpmgr/arbs.c
+ * PURPOSE:         Root arbiters of the PnP manager
+ * PROGRAMMERS:     Copyright 2020 Vadim Galyant <vgal@rambler.ru>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <ntoskrnl.h>
+
+#define NDEBUG
+#include <debug.h>
+
+/* GLOBALS *******************************************************************/
+
+extern ARBITER_INSTANCE IopRootBusNumberArbiter;
+extern ARBITER_INSTANCE IopRootIrqArbiter;
+extern ARBITER_INSTANCE IopRootDmaArbiter;
+extern ARBITER_INSTANCE IopRootMemArbiter;
+extern ARBITER_INSTANCE IopRootPortArbiter;
+
+/* DATA **********************************************************************/
+
+/* FUNCTIONS *****************************************************************/
+
+/* BusNumber arbiter */
+
+NTSTATUS
+NTAPI
+IopBusNumberInitialize(VOID)
+{
+    NTSTATUS Status;
+
+    DPRINT("IopRootBusNumberArbiter %p\n", &IopRootBusNumberArbiter);
+
+    Status = ArbInitializeArbiterInstance(&IopRootBusNumberArbiter,
+                                          NULL,
+                                          CmResourceTypeBusNumber,
+                                          L"RootBusNumber",
+                                          L"Root",
+                                          NULL);
+    return Status;
+}
+
+/* Irq arbiter */
+
+NTSTATUS
+NTAPI
+IopIrqInitialize(VOID)
+{
+    NTSTATUS Status;
+
+    DPRINT("IopRootIrqArbiter %p\n", &IopRootIrqArbiter);
+
+    Status = ArbInitializeArbiterInstance(&IopRootIrqArbiter,
+                                          NULL,
+                                          CmResourceTypeInterrupt,
+                                          L"RootIRQ",
+                                          L"Root",
+                                          NULL);
+    return Status;
+}
+
+/* Dma arbiter */
+
+NTSTATUS
+NTAPI
+IopDmaInitialize(VOID)
+{
+    NTSTATUS Status;
+
+    DPRINT("IopRootDmaArbiter %p\n", &IopRootDmaArbiter);
+
+    Status = ArbInitializeArbiterInstance(&IopRootDmaArbiter,
+                                          NULL,
+                                          CmResourceTypeDma,
+                                          L"RootDMA",
+                                          L"Root",
+                                          NULL);
+    return Status;
+}
+
+/* Memory arbiter */
+
+NTSTATUS
+NTAPI
+IopMemInitialize(VOID)
+{
+    NTSTATUS Status;
+
+    DPRINT("IopRootMemArbiter %p\n", &IopRootMemArbiter);
+
+    Status = ArbInitializeArbiterInstance(&IopRootMemArbiter,
+                                          NULL,
+                                          CmResourceTypeMemory,
+                                          L"RootMemory",
+                                          L"Root",
+                                          NULL);
+    return Status;
+}
+
+/* Port arbiter */
+
+NTSTATUS
+NTAPI
+IopPortInitialize(VOID)
+{
+    NTSTATUS Status;
+
+    DPRINT("IopRootPortArbiter %p\n", &IopRootPortArbiter);
+
+    Status = ArbInitializeArbiterInstance(&IopRootPortArbiter,
+                                          NULL,
+                                          CmResourceTypePort,
+                                          L"RootPort",
+                                          L"Root",
+                                          NULL);
+    return Status;
+}
+
+/* EOF */

--- a/ntoskrnl/io/pnpmgr/pnpinit.c
+++ b/ntoskrnl/io/pnpmgr/pnpinit.c
@@ -24,6 +24,18 @@ PUNICODE_STRING PiInitGroupOrderTable;
 USHORT PiInitGroupOrderTableCount;
 INTERFACE_TYPE PnpDefaultInterfaceType;
 
+ARBITER_INSTANCE IopRootBusNumberArbiter;
+ARBITER_INSTANCE IopRootIrqArbiter;
+ARBITER_INSTANCE IopRootDmaArbiter;
+ARBITER_INSTANCE IopRootMemArbiter;
+ARBITER_INSTANCE IopRootPortArbiter;
+
+NTSTATUS NTAPI IopPortInitialize(VOID);
+NTSTATUS NTAPI IopMemInitialize(VOID);
+NTSTATUS NTAPI IopDmaInitialize(VOID);
+NTSTATUS NTAPI IopIrqInitialize(VOID);
+NTSTATUS NTAPI IopBusNumberInitialize(VOID);
+
 /* FUNCTIONS ******************************************************************/
 
 INTERFACE_TYPE
@@ -38,9 +50,45 @@ NTSTATUS
 NTAPI
 IopInitializeArbiters(VOID)
 {
-     /* FIXME: TODO */
-    return STATUS_SUCCESS;
+    NTSTATUS Status;
+
+    Status = IopPortInitialize();
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IopPortInitialize() return %X\n", Status);
+        return Status;
+    }
+
+    Status = IopMemInitialize();
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IopMemInitialize() return %X\n", Status);
+        return Status;
+    }
+
+    Status = IopDmaInitialize();
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IopDmaInitialize() return %X\n", Status);
+        return Status;
+    }
+
+    Status = IopIrqInitialize();
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IopIrqInitialize() return %X\n", Status);
+        return Status;
+    }
+
+    Status = IopBusNumberInitialize();
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IopBusNumberInitialize() return %X\n", Status);
+    }
+
+    return Status;
 }
+
 
 INIT_FUNCTION
 NTSTATUS

--- a/ntoskrnl/ntkrnlmp/CMakeLists.txt
+++ b/ntoskrnl/ntkrnlmp/CMakeLists.txt
@@ -40,7 +40,7 @@ elseif(RUNTIME_CHECKS)
     target_link_libraries(ntkrnlmp runtmchk)
 endif()
 
-target_link_libraries(ntkrnlmp cportlib csq ${PSEH_LIB} cmlib ntlsalib rtl ${ROSSYM_LIB} libcntpr wdmguid ioevent)
+target_link_libraries(ntkrnlmp cportlib csq ${PSEH_LIB} arbiter cmlib ntlsalib rtl ${ROSSYM_LIB} libcntpr wdmguid ioevent)
 add_importlibs(ntkrnlmp hal kdcom bootvid)
 add_pch(ntkrnlmp ${REACTOS_SOURCE_DIR}/ntoskrnl/include/ntoskrnl.h NTKRNLMP_SOURCE)
 add_dependencies(ntkrnlmp psdk bugcodes asm)

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -1,6 +1,7 @@
 
 include_directories(
     ${REACTOS_SOURCE_DIR}
+    ${REACTOS_SOURCE_DIR}/sdk/lib/drivers/arbiter
     ${REACTOS_SOURCE_DIR}/sdk/lib/cmlib
     include
     ${CMAKE_CURRENT_BINARY_DIR}/include
@@ -151,6 +152,7 @@ list(APPEND SOURCE
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/iomgr/symlink.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/iomgr/util.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/iomgr/volume.c
+    ${REACTOS_SOURCE_DIR}/ntoskrnl/io/pnpmgr/arbs.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/pnpmgr/plugplay.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/pnpmgr/pnpdma.c
     ${REACTOS_SOURCE_DIR}/ntoskrnl/io/pnpmgr/pnpinit.c

--- a/sdk/lib/drivers/CMakeLists.txt
+++ b/sdk/lib/drivers/CMakeLists.txt
@@ -1,4 +1,5 @@
 
+add_subdirectory(arbiter)
 add_subdirectory(chew)
 add_subdirectory(copysup)
 add_subdirectory(csq)

--- a/sdk/lib/drivers/arbiter/CMakeLists.txt
+++ b/sdk/lib/drivers/arbiter/CMakeLists.txt
@@ -1,0 +1,10 @@
+
+include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/rtl)
+
+list(APPEND SOURCE
+    arbiter.c
+    arbiter.h)
+
+add_library(arbiter ${SOURCE})
+add_dependencies(arbiter bugcodes xdk)
+add_pch(arbiter arbiter.h SOURCE)

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -1,0 +1,41 @@
+/*
+ * PROJECT:         ReactOS Kernel
+ * COPYRIGHT:       GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * FILE:            lib/drivers/arbiter/arbiter.c
+ * PURPOSE:         Hardware Resources Arbiter Library
+ * PROGRAMMERS:     Copyright 2020 Vadim Galyant <vgal@rambler.ru>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#define NDEBUG
+#include <debug.h>
+
+#include "arbiter.h"
+
+/* GLOBALS ********************************************************************/
+
+/* DATA **********************************************************************/
+
+/* FUNCTIONS ******************************************************************/
+
+NTSTATUS
+NTAPI
+ArbInitializeArbiterInstance(
+    _Inout_ PARBITER_INSTANCE Arbiter,
+    _In_ PDEVICE_OBJECT BusDeviceObject,
+    _In_ CM_RESOURCE_TYPE ResourceType,
+    _In_ PCWSTR ArbiterName,
+    _In_ PCWSTR OrderName,
+    _In_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction)
+{
+    NTSTATUS Status;
+
+    DPRINT("ArbInitializeArbiterInstance: Initializing %S Arbiter\n", ArbiterName);
+    UNIMPLEMENTED;
+
+    Status = STATUS_SUCCESS;
+    return Status;
+}
+
+/* EOF */

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -1,0 +1,240 @@
+/*
+ * PROJECT:         ReactOS Kernel
+ * COPYRIGHT:       GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * FILE:            lib/drivers/arbiter/arbiter.h
+ * PURPOSE:         Hardware Resources Arbiter Library
+ * PROGRAMMERS:     Copyright 2020 Vadim Galyant <vgal@rambler.ru>
+ */
+
+#ifndef _ARBITER_H
+#define _ARBITER_H
+
+#ifndef _NTOSKRNL_
+#include <ntifs.h>
+#include <ndk/rtlfuncs.h>
+#endif
+
+typedef struct _ARBITER_ORDERING
+{
+    ULONGLONG Start;
+    ULONGLONG End;
+} ARBITER_ORDERING, *PARBITER_ORDERING;
+
+typedef struct _ARBITER_ORDERING_LIST
+{
+    USHORT Count;
+    USHORT Maximum;
+    PARBITER_ORDERING Orderings;
+} ARBITER_ORDERING_LIST, *PARBITER_ORDERING_LIST;
+
+typedef struct _ARBITER_ALTERNATIVE
+{
+    ULONGLONG Minimum;
+    ULONGLONG Maximum;
+    ULONG Length;
+    ULONG Alignment;
+    LONG Priority;
+    ULONG Flags;
+    PIO_RESOURCE_DESCRIPTOR Descriptor;
+    ULONG Reserved[3];
+} ARBITER_ALTERNATIVE, *PARBITER_ALTERNATIVE;
+
+typedef struct _ARBITER_ALLOCATION_STATE
+{
+    ULONGLONG Start;
+    ULONGLONG End;
+    ULONGLONG CurrentMinimum;
+    ULONGLONG CurrentMaximum;
+    PARBITER_LIST_ENTRY Entry;
+    PARBITER_ALTERNATIVE CurrentAlternative;
+    ULONG AlternativeCount;
+    PARBITER_ALTERNATIVE Alternatives;
+    USHORT Flags;
+    UCHAR RangeAttributes;
+    UCHAR RangeAvailableAttributes;
+    ULONG_PTR WorkSpace;
+} ARBITER_ALLOCATION_STATE, *PARBITER_ALLOCATION_STATE;
+
+typedef struct _ARBITER_INSTANCE *PARBITER_INSTANCE;
+
+typedef NTSTATUS
+(NTAPI * PARB_UNPACK_REQUIREMENT)(
+    _In_ PIO_RESOURCE_DESCRIPTOR IoDescriptor,
+    _Out_ PULONGLONG OutMinimumAddress,
+    _Out_ PULONGLONG OutMaximumAddress,
+    _Out_ PULONG OutLength,
+    _Out_ PULONG OutAlignment
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_PACK_RESOURCE)(
+    _In_ PIO_RESOURCE_DESCRIPTOR IoDescriptor,
+    _In_ ULONGLONG Start,
+    _Out_ PCM_PARTIAL_RESOURCE_DESCRIPTOR CmDescriptor
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_UNPACK_RESOURCE)(
+    _In_ PCM_PARTIAL_RESOURCE_DESCRIPTOR CmDescriptor,
+    _Out_ PULONGLONG Start,
+    _Out_ PULONG OutLength
+);
+
+typedef LONG
+(NTAPI * PARB_SCORE_REQUIREMENT)(
+    _In_ PIO_RESOURCE_DESCRIPTOR IoDescriptor
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_TEST_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ PLIST_ENTRY ArbitrationList
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_RETEST_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ PLIST_ENTRY ArbitrationList
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_COMMIT_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_ROLLBACK_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_BOOT_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _In_ PLIST_ENTRY ArbitrationList
+);
+
+/*  Not correct yet, FIXME! */
+typedef NTSTATUS
+(NTAPI * PARB_QUERY_ARBITRATE)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+/*  Not correct yet, FIXME! */
+typedef NTSTATUS
+(NTAPI * PARB_QUERY_CONFLICT)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+/*  Not correct yet, FIXME! */
+typedef NTSTATUS
+(NTAPI * PARB_ADD_RESERVED)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+/*  Not correct yet, FIXME! */
+typedef NTSTATUS
+(NTAPI * PARB_START_ARBITER)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_PREPROCESS_ENTRY)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+typedef NTSTATUS
+(NTAPI * PARB_ALLOCATE_ENTRY)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+typedef BOOLEAN
+(NTAPI * PARB_GET_NEXT_ALLOCATION_RANGE)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+typedef BOOLEAN
+(NTAPI * PARB_FIND_SUITABLE_RANGE)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+typedef VOID
+(NTAPI * PARB_ADD_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+typedef VOID
+(NTAPI * PARB_BACKTRACK_ALLOCATION)(
+    _In_ PARBITER_INSTANCE Arbiter,
+    _Inout_ PARBITER_ALLOCATION_STATE ArbState
+);
+
+/*  Not correct yet, FIXME! */
+typedef NTSTATUS
+(NTAPI * PARB_OVERRIDE_CONFLICT)(
+    _In_ PARBITER_INSTANCE Arbiter
+);
+
+typedef struct _ARBITER_INSTANCE
+{
+    ULONG Signature;
+    PKEVENT MutexEvent;
+    PCWSTR Name;
+    CM_RESOURCE_TYPE ResourceType;
+    PRTL_RANGE_LIST Allocation;
+    PRTL_RANGE_LIST PossibleAllocation;
+    ARBITER_ORDERING_LIST OrderingList;
+    ARBITER_ORDERING_LIST ReservedList;
+    LONG ReferenceCount;
+    PARBITER_INTERFACE Interface;
+    ULONG AllocationStackMaxSize;
+    PARBITER_ALLOCATION_STATE AllocationStack;
+    PARB_UNPACK_REQUIREMENT UnpackRequirement;
+    PARB_PACK_RESOURCE PackResource;
+    PARB_UNPACK_RESOURCE UnpackResource;
+    PARB_SCORE_REQUIREMENT ScoreRequirement;
+    PARB_TEST_ALLOCATION TestAllocation;
+    PARB_RETEST_ALLOCATION RetestAllocation;
+    PARB_COMMIT_ALLOCATION CommitAllocation;
+    PARB_ROLLBACK_ALLOCATION RollbackAllocation;
+    PARB_BOOT_ALLOCATION BootAllocation;
+    PARB_QUERY_ARBITRATE QueryArbitrate; // Not used yet
+    PARB_QUERY_CONFLICT QueryConflict; // Not used yet
+    PARB_ADD_RESERVED AddReserved; // Not used yet
+    PARB_START_ARBITER StartArbiter; // Not used yet
+    PARB_PREPROCESS_ENTRY PreprocessEntry;
+    PARB_ALLOCATE_ENTRY AllocateEntry;
+    PARB_GET_NEXT_ALLOCATION_RANGE GetNextAllocationRange;
+    PARB_FIND_SUITABLE_RANGE FindSuitableRange;
+    PARB_ADD_ALLOCATION AddAllocation;
+    PARB_BACKTRACK_ALLOCATION BacktrackAllocation;
+    PARB_OVERRIDE_CONFLICT OverrideConflict; // Not used yet
+    BOOLEAN TransactionInProgress;
+    PVOID Extension;
+    PDEVICE_OBJECT BusDeviceObject;
+    PVOID ConflictCallbackContext;
+    PVOID ConflictCallback;
+} ARBITER_INSTANCE, *PARBITER_INSTANCE;
+
+typedef NTSTATUS
+(NTAPI * PARB_TRANSLATE_ORDERING)(
+    _Out_ PIO_RESOURCE_DESCRIPTOR OutIoDescriptor,
+    _In_ PIO_RESOURCE_DESCRIPTOR IoDescriptor
+);
+
+NTSTATUS
+NTAPI
+ArbInitializeArbiterInstance(
+    _Inout_ PARBITER_INSTANCE Arbiter,
+    _In_ PDEVICE_OBJECT BusDeviceObject,
+    _In_ CM_RESOURCE_TYPE ResourceType,
+    _In_ PCWSTR ArbiterName,
+    _In_ PCWSTR OrderName,
+    _In_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction
+);
+
+#endif  /* _ARBITER_H */


### PR DESCRIPTION
The main purpose of this PR is to add a definition of the structures for the HW resource arbiter.

In addition to this, the IopInitializeArbiters() function was implemented in the PNP manager and stub was added for ArbInitializeArbiterInstance().

The directory "XXX" is chosen because the arbiter can be used not only by the kernel, but also by pci and acpi bus drivers, as well as legacy HAL (PIC).
