### PR TITLE
Improve cdrom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,9 +265,6 @@ else()
     # Create the registry hives
     create_registry_hives()
 
-    # Create {bootcd, livecd, bootcdregtest}.lst
-    create_iso_lists()
-
     file(MAKE_DIRECTORY ${REACTOS_BINARY_DIR}/sdk/include/reactos)
 
     add_dependency_footer()

--- a/boot/CMakeLists.txt
+++ b/boot/CMakeLists.txt
@@ -15,11 +15,12 @@ else()
     message(FATAL_ERROR "Unknown ARCH '" ${ARCH} "', cannot generate a valid UEFI boot filename.")
 endif()
 
-add_custom_target(efisys
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/efisys.bin
     COMMAND native-fatten ${CMAKE_CURRENT_BINARY_DIR}/efisys.bin -format 2880 EFIBOOT -boot ${CMAKE_CURRENT_BINARY_DIR}/freeldr/bootsect/fat.bin -mkdir EFI -mkdir EFI/BOOT -add $<TARGET_FILE:bootmgfw> EFI/BOOT/boot${EFI_PLATFORM_ID}.efi
     DEPENDS native-fatten fat bootmgfw
     VERBATIM)
-
+add_custom_target(efisys DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/efisys.bin)
 
 # Create an 'empty' directory (guaranteed to be empty) to be able to add
 # arbitrary empty directories to the ISO image using mkisofs.
@@ -97,7 +98,8 @@ endfunction()
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcd.cmake.lst "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
-add_custom_target(bootcd
+add_custom_command(
+    OUTPUT ${REACTOS_BINARY_DIR}/bootcd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/bootcd.iso -iso-level 4
         -publisher ${ISO_MANUFACTURER} -preparer ${ISO_MANUFACTURER} -volid ${ISO_VOLNAME} -volset ${ISO_VOLNAME}
         -eltorito-boot loader/isoboot.bin -no-emul-boot -boot-load-size 4 -eltorito-alt-boot -eltorito-platform efi -eltorito-boot loader/efisys.bin -no-emul-boot -hide boot.catalog
@@ -106,13 +108,15 @@ add_custom_target(bootcd
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/bootcd.iso
     DEPENDS isombr native-isohybrid native-mkisofs
     VERBATIM)
+add_custom_target(bootcd DEPENDS ${REACTOS_BINARY_DIR}/bootcd.iso)
 
 ## BootCDRegTest
 # Create the file list
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.cmake.lst "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
-add_custom_target(bootcdregtest
+add_custom_command(
+    OUTPUT ${REACTOS_BINARY_DIR}/bootcdregtest.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/bootcdregtest.iso -iso-level 4
         -publisher ${ISO_MANUFACTURER} -preparer ${ISO_MANUFACTURER} -volid ${ISO_VOLNAME} -volset ${ISO_VOLNAME}
         -eltorito-boot loader/isobtrt.bin -no-emul-boot -boot-load-size 4 -eltorito-alt-boot -eltorito-platform efi -eltorito-boot loader/efisys.bin -no-emul-boot -hide boot.catalog
@@ -121,6 +125,7 @@ add_custom_target(bootcdregtest
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/bootcdregtest.iso
     DEPENDS isombr native-isohybrid native-mkisofs
     VERBATIM)
+add_custom_target(bootcdregtest DEPENDS ${REACTOS_BINARY_DIR}/bootcdregtest.iso)
 
 ## LiveCD
 # Create the file list
@@ -131,7 +136,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "${CMAKE_CURRENT_BINARY_
 add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles")
 add_user_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles" "Default User")
 
-add_custom_target(livecd
+add_custom_command(
+    OUTPUT ${REACTOS_BINARY_DIR}/livecd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/livecd.iso -iso-level 4
         -publisher ${ISO_MANUFACTURER} -preparer ${ISO_MANUFACTURER} -volid ${ISO_VOLNAME} -volset ${ISO_VOLNAME}
         -eltorito-boot loader/isoboot.bin -no-emul-boot -boot-load-size 4 -eltorito-alt-boot -eltorito-platform efi -eltorito-boot loader/efisys.bin -no-emul-boot -hide boot.catalog
@@ -140,6 +146,7 @@ add_custom_target(livecd
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/livecd.iso
     DEPENDS isombr native-isohybrid native-mkisofs
     VERBATIM)
+add_custom_target(livecd DEPENDS ${REACTOS_BINARY_DIR}/livecd.iso)
 
 ## HybridCD
 # Create the file list
@@ -150,7 +157,8 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "${CMAKE_CURRENT_BINAR
 add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/Profiles")
 add_user_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/Profiles" "Default User")
 
-add_custom_target(hybridcd
+add_custom_command(
+    OUTPUT ${REACTOS_BINARY_DIR}/hybridcd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/hybridcd.iso -iso-level 4
         -publisher ${ISO_MANUFACTURER} -preparer ${ISO_MANUFACTURER} -volid ${ISO_VOLNAME} -volset ${ISO_VOLNAME}
         -eltorito-boot loader/isoboot.bin -no-emul-boot -boot-load-size 4 -eltorito-alt-boot -eltorito-platform efi -eltorito-boot loader/efisys.bin -no-emul-boot -hide boot.catalog
@@ -159,6 +167,7 @@ add_custom_target(hybridcd
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/hybridcd.iso
     DEPENDS bootcd livecd
     VERBATIM)
+add_custom_target(hybridcd DEPENDS ${REACTOS_BINARY_DIR}/hybridcd.iso)
 
 add_cd_file(TARGET efisys FILE ${CMAKE_CURRENT_BINARY_DIR}/efisys.bin DESTINATION loader NO_CAB NOT_IN_HYBRIDCD FOR bootcd regtest livecd hybridcd)
 

--- a/boot/CMakeLists.txt
+++ b/boot/CMakeLists.txt
@@ -60,44 +60,45 @@ set(ISO_VOLNAME      "ReactOS")             # For both the Volume ID and the Vol
 
 
 # Create user profile directories in the LiveImage
-function(add_allusers_profile_dirs _image_filelist _rootdir)
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Documents/My Music=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Documents/My Pictures=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Documents/My Videos=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Favorites=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/My Documents=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/All Users/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+function(add_allusers_profile_dirs _target _rootdir)
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Documents/My Music=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Documents/My Pictures=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Documents/My Videos=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Favorites=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/My Documents=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/All Users/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty")
 endfunction()
-function(add_user_profile_dirs _image_filelist _rootdir _username)
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Application Data/Microsoft/Internet Explorer/Quick Launch=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Cookies=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Desktop=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Favorites=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Local Settings/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Local Settings/History=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Local Settings/Temporary Internet Files=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/My Music=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/My Pictures=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/My Videos=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/NetHood=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/PrintHood=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Recent=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/SendTo=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-    file(APPEND ${_image_filelist} "${_rootdir}/${_username}/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+function(add_user_profile_dirs _target _rootdir _username)
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Application Data/Microsoft/Internet Explorer/Quick Launch=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Cookies=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Desktop=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Favorites=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Local Settings/Application Data=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Local Settings/History=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Local Settings/Temporary Internet Files=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/My Music=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/My Pictures=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/My Videos=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/NetHood=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/PrintHood=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Recent=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/SendTo=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Start Menu/Programs=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Start Menu/Programs/Administrative Tools=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Start Menu/Programs/StartUp=${CMAKE_CURRENT_BINARY_DIR}/empty")
+    set_property(TARGET ${_target} APPEND PROPERTY FILE_LIST "${_rootdir}/${_username}/Templates=${CMAKE_CURRENT_BINARY_DIR}/empty")
 endfunction()
 
 
 ## BootCD
-# Create the file list
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcd.cmake.lst "")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-
+# create file list on generation phase
+file(GENERATE 
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/bootcd.$<CONFIG>.lst
+    CONTENT $<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:bootcd,FILE_LIST>,\n>>)
+# create target
 add_custom_command(
     OUTPUT ${REACTOS_BINARY_DIR}/bootcd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/bootcd.iso -iso-level 4
@@ -106,15 +107,16 @@ add_custom_command(
         -sort ${CMAKE_CURRENT_BINARY_DIR}/bootfiles.sort
         -no-cache-inodes -graft-points -path-list ${CMAKE_CURRENT_BINARY_DIR}/bootcd.$<CONFIG>.lst
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/bootcd.iso
-    DEPENDS isombr native-isohybrid native-mkisofs
+    DEPENDS isombr native-isohybrid native-mkisofs $<TARGET_PROPERTY:bootcd,ISO_DEPENDENCIES>
     VERBATIM)
 add_custom_target(bootcd DEPENDS ${REACTOS_BINARY_DIR}/bootcd.iso)
 
 ## BootCDRegTest
-# Create the file list
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.cmake.lst "")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-
+# create file list on generation phase
+file(GENERATE 
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.$<CONFIG>.lst
+    CONTENT $<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:bootcdregtest,FILE_LIST>,\n>>)
+# create target
 add_custom_command(
     OUTPUT ${REACTOS_BINARY_DIR}/bootcdregtest.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/bootcdregtest.iso -iso-level 4
@@ -123,19 +125,16 @@ add_custom_command(
         -sort ${CMAKE_CURRENT_BINARY_DIR}/bootfiles.sort
         -no-cache-inodes -graft-points -path-list ${CMAKE_CURRENT_BINARY_DIR}/bootcdregtest.$<CONFIG>.lst
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/bootcdregtest.iso
-    DEPENDS isombr native-isohybrid native-mkisofs
+    DEPENDS isombr native-isohybrid native-mkisofs $<TARGET_PROPERTY:bootcdregtest,ISO_DEPENDENCIES>
     VERBATIM)
 add_custom_target(bootcdregtest DEPENDS ${REACTOS_BINARY_DIR}/bootcdregtest.iso)
 
 ## LiveCD
-# Create the file list
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-
-# Create user profile directories
-add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles")
-add_user_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles" "Default User")
-
+# create file list on generation phase
+file(GENERATE 
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/livecd.$<CONFIG>.lst
+    CONTENT $<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:livecd,FILE_LIST>,\n>>)
+# create target
 add_custom_command(
     OUTPUT ${REACTOS_BINARY_DIR}/livecd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/livecd.iso -iso-level 4
@@ -144,19 +143,19 @@ add_custom_command(
         -sort ${CMAKE_CURRENT_BINARY_DIR}/bootfiles.sort
         -no-cache-inodes -graft-points -path-list ${CMAKE_CURRENT_BINARY_DIR}/livecd.$<CONFIG>.lst
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/livecd.iso
-    DEPENDS isombr native-isohybrid native-mkisofs
+    DEPENDS isombr native-isohybrid native-mkisofs ${CMAKE_CURRENT_BINARY_DIR}/livecd.$<CONFIG>.lst $<TARGET_PROPERTY:livecd,ISO_DEPENDENCIES>
     VERBATIM)
 add_custom_target(livecd DEPENDS ${REACTOS_BINARY_DIR}/livecd.iso)
+# Create user profile directories
+add_allusers_profile_dirs(livecd "Profiles")
+add_user_profile_dirs(livecd "Profiles" "Default User")
 
 ## HybridCD
-# Create the file list
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "")
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
-
-# Create user profile directories
-add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/Profiles")
-add_user_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/Profiles" "Default User")
-
+# create file list on generation phase
+file(GENERATE 
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.$<CONFIG>.lst
+    CONTENT $<GENEX_EVAL:$<JOIN:$<TARGET_PROPERTY:hybridcd,FILE_LIST>,\n>>)
+# create target
 add_custom_command(
     OUTPUT ${REACTOS_BINARY_DIR}/hybridcd.iso
     COMMAND native-mkisofs -quiet -o ${REACTOS_BINARY_DIR}/hybridcd.iso -iso-level 4
@@ -165,11 +164,15 @@ add_custom_command(
         -sort ${CMAKE_CURRENT_BINARY_DIR}/bootfiles.sort
         -duplicates-once -no-cache-inodes -graft-points -path-list ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.$<CONFIG>.lst
     COMMAND native-isohybrid -b ${_isombr_file} -t 0x96 ${REACTOS_BINARY_DIR}/hybridcd.iso
-    DEPENDS bootcd livecd
+    DEPENDS isombr native-isohybrid native-mkisofs ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.$<CONFIG>.lst $<TARGET_PROPERTY:hybridcd,ISO_DEPENDENCIES>
     VERBATIM)
 add_custom_target(hybridcd DEPENDS ${REACTOS_BINARY_DIR}/hybridcd.iso)
+# Create user profile directories
+add_allusers_profile_dirs(hybridcd "livecd/Profiles")
+add_user_profile_dirs(livecd "livecd/Profiles" "Default User")
 
 add_cd_file(TARGET efisys FILE ${CMAKE_CURRENT_BINARY_DIR}/efisys.bin DESTINATION loader NO_CAB NOT_IN_HYBRIDCD FOR bootcd regtest livecd hybridcd)
+add_cd_file(TARGET livecd FILE ${REACTOS_BINARY_DIR}/livecd.iso DESTINATION livecd FOR hybridcd)
 
 add_subdirectory(freeldr)
 add_subdirectory(bootdata)

--- a/boot/bootdata/packages/CMakeLists.txt
+++ b/boot/bootdata/packages/CMakeLists.txt
@@ -31,20 +31,37 @@ add_custom_command(
                              -D SRC2=${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.$<CONFIG>.dyn
                              -D DST=${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.maydiff
                              -P ${CMAKE_CURRENT_BINARY_DIR}/concat.cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
                              ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.maydiff
                              ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/reactos.dff.in
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.$<CONFIG>.dyn)
 
-add_custom_target(
-    reactos_cab_inf
+# reactos.inf. We want this command to be always executed, in case someone added an optional file between two builds.
+# So we pretend it generates another file although it will never do.
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reactos_real.inf ${CMAKE_CURRENT_BINARY_DIR}/__some_non_existent_file
     COMMAND native-cabman -C ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff -L ${CMAKE_CURRENT_BINARY_DIR} -I -P ${REACTOS_SOURCE_DIR}
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf ${CMAKE_CURRENT_BINARY_DIR}/reactos_real.inf
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff native-cabman
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf)
 
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab
+    COMMAND native-cabman -C ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff -RC ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf -N -P ${REACTOS_SOURCE_DIR}
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos_real.inf native-cabman $<TARGET_PROPERTY:reactos_cab,CAB_DEPENDENCIES>)
+
+add_custom_target(reactos_cab DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab)
+
 add_cd_file(
-    TARGET reactos_cab_inf
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf
+    TARGET reactos_cab
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab
+    DESTINATION reactos
+    NO_CAB FOR bootcd regtest)
+
+add_cd_file(
+    TARGET reactos_cab
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/reactos_real.inf
+    NAME_ON_CD reactos.inf
     DESTINATION reactos
     NO_CAB FOR bootcd regtest)

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -309,7 +309,12 @@ macro(dir_to_num dir var)
 endmacro()
 
 function(add_cd_file)
-    cmake_parse_arguments(_CD "NO_CAB;NOT_IN_HYBRIDCD" "DESTINATION;NAME_ON_CD;TARGET" "FILE;FOR" ${ARGN})
+    cmake_parse_arguments(_CD "NO_CAB;NOT_IN_HYBRIDCD" "DESTINATION;NAME_ON_CD;TARGET;FILE" "FOR" ${ARGN})
+
+    if (_CD_UNPARSED_ARGUMENTS)
+        message(FATAL_ERROR "Unexpected arguments to add_cd_file : ${_CD_UNPARSED_ARGUMENTS}")
+    endif()
+
     if(NOT (_CD_TARGET OR _CD_FILE))
         message(FATAL_ERROR "You must provide a target or a file to install!")
     endif()
@@ -332,6 +337,10 @@ function(add_cd_file)
         endif()
     endif()
 
+    if (NOT _CD_NAME_ON_CD)
+        get_filename_component(_CD_NAME_ON_CD ${_CD_FILE} NAME)
+    endif()
+
     # do we add it to all CDs?
     list(FIND _CD_FOR all __cd)
     if(NOT __cd EQUAL -1)
@@ -339,42 +348,38 @@ function(add_cd_file)
         list(INSERT _CD_FOR __cd "bootcd;livecd;regtest")
     endif()
 
+
     # do we add it to bootcd?
     list(FIND _CD_FOR bootcd __cd)
     if(NOT __cd EQUAL -1)
         # whether or not we should put it in reactos.cab or directly on cd
         if(_CD_NO_CAB)
             # directly on cd
-            foreach(item ${_CD_FILE})
-                if(_CD_NAME_ON_CD)
-                    # rename it in the cd tree
-                    set(__file ${_CD_NAME_ON_CD})
-                else()
-                    get_filename_component(__file ${item} NAME)
-                endif()
-                set_property(GLOBAL APPEND PROPERTY BOOTCD_FILE_LIST "${_CD_DESTINATION}/${__file}=${item}")
-                # add it also into the hybridcd if not specified otherwise
-                if(NOT _CD_NOT_IN_HYBRIDCD)
-                    set_property(GLOBAL APPEND PROPERTY HYBRIDCD_FILE_LIST "bootcd/${_CD_DESTINATION}/${__file}=${item}")
-                endif()
-            endforeach()
+            set_property(TARGET bootcd APPEND PROPERTY FILE_LIST "${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
+            # add it also into the hybridcd if not specified otherwise
+            if(NOT _CD_NOT_IN_HYBRIDCD)
+                set_property(GLOBAL APPEND PROPERTY HYBRIDCD_FILE_LIST "bootcd/${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
+            endif()
             # manage dependency
             if(_CD_TARGET)
-                add_dependencies(bootcd ${_CD_TARGET} registry_inf)
+                set_property(TARGET bootcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
+                if(NOT _CD_NOT_IN_HYBRIDCD)
+                    set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
+                endif()
+            else()
+                set_property(TARGET bootcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
+                if(NOT _CD_NOT_IN_HYBRIDCD)
+                    set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
+                endif()
             endif()
         else()
             dir_to_num(${_CD_DESTINATION} _num)
-            foreach(item ${_CD_FILE})
-                # add it in reactos.cab
-                file(APPEND ${REACTOS_BINARY_DIR}/boot/bootdata/packages/reactos.dff.cmake "\"${item}\" ${_num}\n")
-
-                # manage dependency - file level
-                set_property(GLOBAL APPEND PROPERTY REACTOS_CAB_DEPENDS ${item})
-            endforeach()
-
-            # manage dependency - target level
+            file(APPEND ${REACTOS_BINARY_DIR}/boot/bootdata/packages/reactos.dff.cmake "\"${_CD_FILE}\" ${_num}\n")
+            # manage dependencies
             if(_CD_TARGET)
-                add_dependencies(reactos_cab_inf ${_CD_TARGET})
+                set_property(TARGET reactos_cab APPEND PROPERTY CAB_DEPENDENCIES ${_CD_TARGET})
+            else()
+                set_property(TARGET reactos_cab APPEND PROPERTY CAB_DEPENDENCIES ${_CD_FILE})
             endif()
         endif()
     endif() #end bootcd
@@ -384,39 +389,36 @@ function(add_cd_file)
     if(NOT __cd EQUAL -1)
         # manage dependency
         if(_CD_TARGET)
-            add_dependencies(livecd ${_CD_TARGET} registry_inf)
-        endif()
-        foreach(item ${_CD_FILE})
-            if(_CD_NAME_ON_CD)
-                # rename it in the cd tree
-                set(__file ${_CD_NAME_ON_CD})
-            else()
-                get_filename_component(__file ${item} NAME)
-            endif()
-            set_property(GLOBAL APPEND PROPERTY LIVECD_FILE_LIST "${_CD_DESTINATION}/${__file}=${item}")
-            # add it also into the hybridcd if not specified otherwise
+            set_property(TARGET livecd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
             if(NOT _CD_NOT_IN_HYBRIDCD)
-                set_property(GLOBAL APPEND PROPERTY HYBRIDCD_FILE_LIST "livecd/${_CD_DESTINATION}/${__file}=${item}")
+                set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
             endif()
-        endforeach()
+        endif()
+
+        set_property(TARGET livecd APPEND PROPERTY FILE_LIST "${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
+        # manage dependency
+        if (NOT _CD_TARGET)
+            set_property(TARGET livecd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
+        endif()
+        # add it also into the hybridcd if not specified otherwise
+        if(NOT _CD_NOT_IN_HYBRIDCD)
+            set_property(TARGET hybridcd APPEND PROPERTY FILE_LIST "livecd/${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
+            if (NOT _CD_TARGET)
+                set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
+            endif()
+        endif()
     endif() #end livecd
 
     # do we need also to add it to hybridcd?
     list(FIND _CD_FOR hybridcd __cd)
     if(NOT __cd EQUAL -1)
+        set_property(TARGET hybridcd APPEND PROPERTY FILE_LIST "${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
         # manage dependency
         if(_CD_TARGET)
-            add_dependencies(hybridcd ${_CD_TARGET})
+            set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
+        else()
+            set_property(TARGET hybridcd APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
         endif()
-        foreach(item ${_CD_FILE})
-            if(_CD_NAME_ON_CD)
-                # rename it in the cd tree
-                set(__file ${_CD_NAME_ON_CD})
-            else()
-                get_filename_component(__file ${item} NAME)
-            endif()
-            set_property(GLOBAL APPEND PROPERTY HYBRIDCD_FILE_LIST "${_CD_DESTINATION}/${__file}=${item}")
-        endforeach()
     endif() #end hybridcd
 
     # do we add it to regtest?
@@ -424,19 +426,12 @@ function(add_cd_file)
     if(NOT __cd EQUAL -1)
         # whether or not we should put it in reactos.cab or directly on cd
         if(_CD_NO_CAB)
-            # directly on cd
-            foreach(item ${_CD_FILE})
-                if(_CD_NAME_ON_CD)
-                    # rename it in the cd tree
-                    set(__file ${_CD_NAME_ON_CD})
-                else()
-                    get_filename_component(__file ${item} NAME)
-                endif()
-                set_property(GLOBAL APPEND PROPERTY BOOTCDREGTEST_FILE_LIST "${_CD_DESTINATION}/${__file}=${item}")
-            endforeach()
+            set_property(TARGET bootcdregtest APPEND PROPERTY FILE_LIST "${_CD_DESTINATION}/${_CD_NAME_ON_CD}=${_CD_FILE}")
             # manage dependency
             if(_CD_TARGET)
-                add_dependencies(bootcdregtest ${_CD_TARGET} registry_inf)
+                set_property(TARGET bootcdregtest APPEND PROPERTY ISO_DEPENDENCIES ${_CD_TARGET})
+            else()
+                set_property(TARGET bootcdregtest APPEND PROPERTY ISO_DEPENDENCIES ${_CD_FILE})
             endif()
         else()
             #add it in reactos.cab
@@ -448,68 +443,6 @@ function(add_cd_file)
             #endif()
         endif()
     endif() #end bootcd
-endfunction()
-
-function(create_iso_lists)
-    # generate reactos.cab before anything else
-    get_property(_filelist GLOBAL PROPERTY REACTOS_CAB_DEPENDS)
-
-    # begin with reactos.inf. We want this command to be always executed, so we pretend it generates another file although it will never do.
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf ${CMAKE_CURRENT_BINARY_DIR}/__some_non_existent_file
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${REACTOS_BINARY_DIR}/boot/bootdata/packages/reactos.inf ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf
-        DEPENDS ${REACTOS_BINARY_DIR}/boot/bootdata/packages/reactos.inf reactos_cab_inf)
-
-    add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab
-        COMMAND native-cabman -C ${REACTOS_BINARY_DIR}/boot/bootdata/packages/reactos.dff -RC ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf -N -P ${REACTOS_SOURCE_DIR}
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf native-cabman ${_filelist})
-
-    add_custom_target(reactos_cab DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab)
-    add_dependencies(reactos_cab reactos_cab_inf)
-
-    add_cd_file(
-        TARGET reactos_cab
-        FILE ${CMAKE_CURRENT_BINARY_DIR}/reactos.cab
-        DESTINATION reactos
-        NO_CAB FOR bootcd regtest)
-
-    add_cd_file(
-        FILE ${CMAKE_CURRENT_BINARY_DIR}/livecd.iso
-        DESTINATION livecd
-        FOR hybridcd)
-
-    get_property(_filelist GLOBAL PROPERTY BOOTCD_FILE_LIST)
-    string(REPLACE ";" "\n" _filelist "${_filelist}")
-    file(APPEND ${REACTOS_BINARY_DIR}/boot/bootcd.cmake.lst "${_filelist}")
-    unset(_filelist)
-    file(GENERATE
-         OUTPUT ${REACTOS_BINARY_DIR}/boot/bootcd.$<CONFIG>.lst
-         INPUT ${REACTOS_BINARY_DIR}/boot/bootcd.cmake.lst)
-
-    get_property(_filelist GLOBAL PROPERTY LIVECD_FILE_LIST)
-    string(REPLACE ";" "\n" _filelist "${_filelist}")
-    file(APPEND ${REACTOS_BINARY_DIR}/boot/livecd.cmake.lst "${_filelist}")
-    unset(_filelist)
-    file(GENERATE
-         OUTPUT ${REACTOS_BINARY_DIR}/boot/livecd.$<CONFIG>.lst
-         INPUT ${REACTOS_BINARY_DIR}/boot/livecd.cmake.lst)
-
-    get_property(_filelist GLOBAL PROPERTY HYBRIDCD_FILE_LIST)
-    string(REPLACE ";" "\n" _filelist "${_filelist}")
-    file(APPEND ${REACTOS_BINARY_DIR}/boot/hybridcd.cmake.lst "${_filelist}")
-    unset(_filelist)
-    file(GENERATE
-         OUTPUT ${REACTOS_BINARY_DIR}/boot/hybridcd.$<CONFIG>.lst
-         INPUT ${REACTOS_BINARY_DIR}/boot/hybridcd.cmake.lst)
-
-    get_property(_filelist GLOBAL PROPERTY BOOTCDREGTEST_FILE_LIST)
-    string(REPLACE ";" "\n" _filelist "${_filelist}")
-    file(APPEND ${REACTOS_BINARY_DIR}/boot/bootcdregtest.cmake.lst "${_filelist}")
-    unset(_filelist)
-    file(GENERATE
-         OUTPUT ${REACTOS_BINARY_DIR}/boot/bootcdregtest.$<CONFIG>.lst
-         INPUT ${REACTOS_BINARY_DIR}/boot/bootcdregtest.cmake.lst)
 endfunction()
 
 # Create module_clean targets
@@ -887,15 +820,11 @@ function(create_registry_hives)
                 ${CMAKE_BINARY_DIR}/boot/bootdata/sam
                 ${CMAKE_BINARY_DIR}/boot/bootdata/security)
 
-    add_cd_file(
-        FILE ${CMAKE_BINARY_DIR}/boot/bootdata/system
-             ${CMAKE_BINARY_DIR}/boot/bootdata/software
-             ${CMAKE_BINARY_DIR}/boot/bootdata/default
-             ${CMAKE_BINARY_DIR}/boot/bootdata/sam
-             ${CMAKE_BINARY_DIR}/boot/bootdata/security
-        TARGET livecd_hives
-        DESTINATION reactos/system32/config
-        FOR livecd)
+    add_cd_file(FILE ${CMAKE_BINARY_DIR}/boot/bootdata/system TARGET livecd_hives DESTINATION reactos/system32/config FOR livecd)
+    add_cd_file(FILE ${CMAKE_BINARY_DIR}/boot/bootdata/software TARGET livecd_hives DESTINATION reactos/system32/config FOR livecd)
+    add_cd_file(FILE ${CMAKE_BINARY_DIR}/boot/bootdata/default TARGET livecd_hives DESTINATION reactos/system32/config FOR livecd)
+    add_cd_file(FILE ${CMAKE_BINARY_DIR}/boot/bootdata/sam TARGET livecd_hives DESTINATION reactos/system32/config FOR livecd)
+    add_cd_file(FILE ${CMAKE_BINARY_DIR}/boot/bootdata/security TARGET livecd_hives DESTINATION reactos/system32/config FOR livecd)
 
     # BCD Hive
     add_custom_command(
@@ -924,10 +853,13 @@ function(add_driver_inf _module)
                            COMMAND native-utf16le "${_source_item}" "${_converted_item}"
                            DEPENDS native-utf16le "${_source_item}")
         list(APPEND _converted_inf_files ${_converted_item})
+
     endforeach()
 
     add_custom_target(${_module}_inf_files DEPENDS ${_converted_inf_files})
-    add_cd_file(FILE ${_converted_inf_files} TARGET ${_module}_inf_files DESTINATION reactos/inf FOR all)
+    foreach(item ${_converted_inf_files})
+        add_cd_file(FILE ${item} TARGET ${_module}_inf_files DESTINATION reactos/inf FOR all)
+    endforeach()
 endfunction()
 
 if(KDBG)


### PR DESCRIPTION
## Purpose
Rework how our cdrom targets are generated, with proper dependency tracking, thanks to properties maintained at target level and avoiding calling functions at the end of the party.

Maybe we should move the add_cd_file function to boot/CmakeFiles.txt to make it clearer where everything comes from.
