### PR TITLE
[RTL] Introduce RtlpImageNtHeader

### DIFF
--- a/boot/environ/CMakeLists.txt
+++ b/boot/environ/CMakeLists.txt
@@ -20,6 +20,7 @@ list(APPEND BOOTLIB_SOURCE
      lib/misc/resource.c
      lib/misc/font.c
      lib/misc/rtlcompat.c
+     lib/rtl/libsupp.c
      lib/firmware/fwutil.c
      lib/firmware/efi/firmware.c
      lib/mm/mm.c

--- a/boot/environ/lib/rtl/libsupp.c
+++ b/boot/environ/lib/rtl/libsupp.c
@@ -1,0 +1,39 @@
+/*
+ * COPYRIGHT:       See COPYING.ARM in the top level directory
+ * PROJECT:         ReactOS UEFI Boot Library
+ * FILE:            boot/environ/lib/rtl/libsupp.c
+ * PURPOSE:         RTL Support Routines
+ * PROGRAMMER:      Mark Jansen (mark.jansen@reactos.org)
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include "bl.h"
+
+/* FUNCTIONS *****************************************************************/
+
+/* Ldr access to IMAGE_NT_HEADERS without SEH */
+
+/* Rtl SEH-Free version of this */
+NTSTATUS
+NTAPI
+RtlpImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders);
+
+
+/*
+ * @implemented
+ */
+NTSTATUS
+NTAPI
+RtlImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders)
+{
+    return RtlpImageNtHeaderEx(Flags, Base, Size, OutHeaders);
+}

--- a/boot/freeldr/freeldr/lib/rtl/libsupp.c
+++ b/boot/freeldr/freeldr/lib/rtl/libsupp.c
@@ -57,3 +57,30 @@ RtlpSafeCopyMemory(
     RtlCopyMemory(Destination, Source, Length);
     return STATUS_SUCCESS;
 }
+
+/* Ldr access to IMAGE_NT_HEADERS without SEH */
+
+/* Rtl SEH-Free version of this */
+NTSTATUS
+NTAPI
+RtlpImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders);
+
+
+/*
+ * @implemented
+ */
+NTSTATUS
+NTAPI
+RtlImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders)
+{
+    return RtlpImageNtHeaderEx(Flags, Base, Size, OutHeaders);
+}
+

--- a/dll/ntdll/rtl/libsupp.c
+++ b/dll/ntdll/rtl/libsupp.c
@@ -505,6 +505,49 @@ RtlpGetAtomEntry(PRTL_ATOM_TABLE AtomTable, ULONG Index)
    return NULL;
 }
 
+/* Ldr SEH-Protected access to IMAGE_NT_HEADERS */
+
+/* Rtl SEH-Free version of this */
+NTSTATUS
+NTAPI
+RtlpImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders);
+
+
+/*
+ * @implemented
+ * @note: This is here, so that we do not drag SEH into rosload, freeldr and bootmgfw
+ */
+NTSTATUS
+NTAPI
+RtlImageNtHeaderEx(
+    _In_ ULONG Flags,
+    _In_ PVOID Base,
+    _In_ ULONG64 Size,
+    _Out_ PIMAGE_NT_HEADERS *OutHeaders)
+{
+    NTSTATUS Status;
+
+    /* Assume failure. This is also done in RtlpImageNtHeaderEx, but this is guarded by SEH. */
+    if (OutHeaders != NULL)
+        *OutHeaders = NULL;
+
+    _SEH2_TRY
+    {
+        Status = RtlpImageNtHeaderEx(Flags, Base, Size, OutHeaders);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        /* Fail with the SEH error */
+        Status = _SEH2_GetExceptionCode();
+    }
+    _SEH2_END;
+
+    return Status;
+}
 
 /*
  * Ldr Resource support code

--- a/dll/win32/kernel32/client/loader.c
+++ b/dll/win32/kernel32/client/loader.c
@@ -464,17 +464,8 @@ FreeLibrary(HINSTANCE hLibModule)
 
     if (LDR_IS_DATAFILE(hLibModule))
     {
-        // FIXME: This SEH should go inside RtlImageNtHeader instead
-        // See https://jira.reactos.org/browse/CORE-14857
-        _SEH2_TRY
-        {
-            /* This is a LOAD_LIBRARY_AS_DATAFILE module, check if it's a valid one */
-            NtHeaders = RtlImageNtHeader((PVOID)((ULONG_PTR)hLibModule & ~1));
-        }
-        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-        {
-            NtHeaders = NULL;
-        } _SEH2_END
+        /* This is a LOAD_LIBRARY_AS_DATAFILE module, check if it's a valid one */
+        NtHeaders = RtlImageNtHeader((PVOID)((ULONG_PTR)hLibModule & ~1));
 
         if (NtHeaders)
         {

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -291,11 +291,6 @@ C_ASSERT(HEAP_CREATE_VALID_MASK == 0x0007F0FF);
 #define RTL_FIND_CHAR_IN_UNICODE_STRING_CASE_INSENSITIVE    4
 
 //
-// RtlImageNtHeaderEx Flags
-//
-#define RTL_IMAGE_NT_HEADER_EX_FLAG_NO_RANGE_CHECK          0x00000001
-
-//
 // RtlDosApplyFileIsolationRedirection_Ustr Flags
 //
 #define RTL_DOS_APPLY_FILE_REDIRECTION_USTR_FLAG_RESPECT_DOT_LOCAL  0x01
@@ -354,6 +349,13 @@ C_ASSERT(HEAP_CREATE_VALID_MASK == 0x0007F0FF);
 #define MESSAGE_RESOURCE_UNICODE                            0x0001
 
 #endif /* !NTOS_MODE_USER */
+
+//
+// RtlImageNtHeaderEx Flags
+//
+#define RTL_IMAGE_NT_HEADER_EX_FLAG_NO_RANGE_CHECK          0x00000001
+
+
 #define MAXIMUM_LEADBYTES                                   12
 
 //

--- a/sdk/lib/rtl/image.c
+++ b/sdk/lib/rtl/image.c
@@ -134,11 +134,10 @@ LdrVerifyMappedImageMatchesChecksum(
 
 /*
  * @implemented
- * @note This needs SEH (See https://jira.reactos.org/browse/CORE-14857)
  */
 NTSTATUS
 NTAPI
-RtlImageNtHeaderEx(
+RtlpImageNtHeaderEx(
     _In_ ULONG Flags,
     _In_ PVOID Base,
     _In_ ULONG64 Size,


### PR DESCRIPTION
which implements the required functionality.
ntdll and ntoskrnl now have a wrapper for this, with SEH.
This protects the function against malformed / bad images,
whilst still being able to use the code in freeldr et al.
Idea from Thomas.
CORE-14857

JIRA issue: [CORE-14857](https://jira.reactos.org/browse/CORE-14857)
