### PR TITLE
[WIN32SS] Properly handle an invalid image passed to RtlGetExpWinVer

### DIFF
--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -160,15 +160,22 @@ RtlGetExpWinVer( HMODULE hModule )
     {
         pinth = RtlImageNtHeader( hModule );
 
-        dwMajorVersion = pinth->OptionalHeader.MajorSubsystemVersion;
-
-        if ( dwMajorVersion == 1 )
+        if (pinth)
         {
-            dwMajorVersion = 3;
+            dwMajorVersion = pinth->OptionalHeader.MajorSubsystemVersion;
+
+            if ( dwMajorVersion == 1 )
+            {
+                dwMajorVersion = 3;
+            }
+            else
+            {
+                dwMinorVersion = pinth->OptionalHeader.MinorSubsystemVersion;
+            }
         }
         else
         {
-            dwMinorVersion = pinth->OptionalHeader.MinorSubsystemVersion;
+            ERR("Invalid hModule: %p\n", hModule);
         }
     }
     return MAKELONG(MAKEWORD(dwMinorVersion, dwMajorVersion), 0);


### PR DESCRIPTION
JIRA issue: [CORE-16769](https://jira.reactos.org/browse/CORE-16769)

To be used together with #2476 