### PR TITLE
[WINMM] Add a WARN() when winejoystick.drv is missing

### DIFF
--- a/dll/win32/winmm/joystick.c
+++ b/dll/win32/winmm/joystick.c
@@ -66,6 +66,8 @@ static	BOOL JOY_LoadDriver(DWORD dwJoyID)
 
     if (!JOY_Sticks[dwJoyID].hDriver)
     {
+        WARN("OpenDriverA(\"winejoystick.drv\") failed\n");
+
         /* The default driver is missing, don't attempt to load it again */
         winejoystick_missing = TRUE;
     }


### PR DESCRIPTION
Follow-up to 97150ce9dd96412036e64a1aa74ccfd2ca9c1805.

Import
https://source.winehq.org/git/wine.git/commit/175a2a027637719d1f3c644d97b6df4aacabb296
