### PR TITLE
[SHELL32] HCR_GetIconA(): Properly use icon_idx. CORE-11713

### DIFF
--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -332,7 +332,12 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 	  ret = HCR_RegGetIconA(hkey, szDest, szName, len, picon_idx);
 	  RegCloseKey(hkey);
 	}
-	TRACE("-- %s %i\n", szDest, *picon_idx);
+
+    if (ret)
+        TRACE("-- %s %i\n", szDest, *picon_idx);
+    else
+        TRACE("-- not found\n");
+
 	return ret;
 }
 


### PR DESCRIPTION
Import
https://source.winehq.org/git/wine.git/commit/7cc2806e0e0d97c0df93e2695351a4d3a3c72254

NB:
Since #2054 is stalled.

JIRA issue: [CORE-11713](https://jira.reactos.org/browse/CORE-11713)
