### PR TITLE
[NTDLL_WINETEST] Remove forced 0x500 API versions

### DIFF
--- a/modules/rostests/winetests/ntdll/exception.c
+++ b/modules/rostests/winetests/ntdll/exception.c
@@ -21,10 +21,6 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x500 /* For NTSTATUS */
-#endif
-
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
 #define NONAMELESSUNION

--- a/modules/rostests/winetests/ntdll/ntdll_test.h
+++ b/modules/rostests/winetests/ntdll/ntdll_test.h
@@ -20,10 +20,6 @@
 
 #include <stdarg.h>
 
-#ifndef _WIN32_WINNT
-#define _WIN32_WINNT 0x500 /* For NTSTATUS */
-#endif
-
 #include "ntstatus.h"
 #define WIN32_NO_STATUS
 #include "windef.h"


### PR DESCRIPTION
No impact, as conditional.

Import
https://source.winehq.org/git/wine.git/commit/71d810319059d171df0e40d85752519e50e58056
