### PR TITLE
[REACTOS] Remove forced _WIN32_IE defines

### DIFF
--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -21,7 +21,6 @@
  */
 
 #define WIN32_LEAN_AND_MEAN
-#define _WIN32_IE 0x0400
 
 #include <stdio.h>
 #include <assert.h>

--- a/dll/win32/riched20/editstr.h
+++ b/dll/win32/riched20/editstr.h
@@ -21,10 +21,6 @@
 #ifndef __EDITSTR_H
 #define __EDITSTR_H
 
-#ifndef _WIN32_IE
-#define _WIN32_IE 0x0400
-#endif
-
 #include <assert.h>
 #include <stdarg.h>
 #include <stdio.h>

--- a/modules/rostests/winetests/comctl32/rebar.c
+++ b/modules/rostests/winetests/comctl32/rebar.c
@@ -17,12 +17,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* make sure the structures work with a comctl32 v5.x */
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x500
-#define _WIN32_IE 0x500
-#endif
-
 #include <assert.h>
 #include <stdarg.h>
 

--- a/modules/rostests/winetests/shell32/systray.c
+++ b/modules/rostests/winetests/shell32/systray.c
@@ -17,9 +17,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#ifndef __REACTOS__
-#define _WIN32_IE 0x600
-#endif
 #include <stdarg.h>
 
 #include <windows.h>

--- a/modules/rostests/winetests/urlmon/sec_mgr.c
+++ b/modules/rostests/winetests/urlmon/sec_mgr.c
@@ -21,12 +21,6 @@
 #define COBJMACROS
 #define CONST_VTABLE
 
-/* needed for IInternetZoneManagerEx2 */
-#ifdef __REACTOS__
-#undef _WIN32_IE
-#endif
-#define _WIN32_IE 0x0700
-
 #include <wine/test.h>
 #include <stdarg.h>
 #include <stddef.h>

--- a/modules/rostests/winetests/user32/input.c
+++ b/modules/rostests/winetests/user32/input.c
@@ -44,11 +44,6 @@
  *
  */
 
-#ifndef __REACTOS__
-#define _WIN32_WINNT 0x401
-#define _WIN32_IE 0x0500
-#endif
-
 #include <stdarg.h>
 #include <assert.h>
 

--- a/sdk/include/reactos/wine/commctrl.h
+++ b/sdk/include/reactos/wine/commctrl.h
@@ -5,11 +5,6 @@
 #define DPA_GetPtr DPA_GetPtr_wine_hack
 #define FlatSB_SetScrollProp FlatSB_SetScrollProp_wine_hack
 
-#if (_WIN32_IE < 0x501)
-#undef _WIN32_IE
-#define _WIN32_IE 0x0501
-#endif
-
 #include <psdk/commctrl.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
No impact, as already deactivated or superseded or superfluous.

Import
https://source.winehq.org/git/wine.git/commit/7770e26f2d773dcade6f073585b6fac2661e1eb3