### PR TITLE
[SPEC2DEF] Omit skipped exports from ordinal numbering.

### DIFF
--- a/sdk/tools/spec2def/spec2def.c
+++ b/sdk/tools/spec2def/spec2def.c
@@ -1332,7 +1332,7 @@ ApplyOrdinals(EXPORT* pexports, unsigned cExports)
     /* Pass 2: apply available ordinals */
     for (i = 0, j = 1; i < cExports; i++)
     {
-        if ((pexports[i].uFlags & FL_ORDINAL) == 0)
+        if ((pexports[i].uFlags & FL_ORDINAL) == 0 && pexports[i].bVersionIncluded)
         {
             while (used[j] != 0)
                 j++;


### PR DESCRIPTION

JIRA issue: [CORE-16769](https://jira.reactos.org/browse/CORE-16769)
