### PR TITLE
[NTOS:MM] Make the definitions and macros for x86 more human-readable.

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -35,6 +35,9 @@
 #define MM_HIGHEST_USER_ADDRESS_WOW64   0x7FFEFFFF
 #define MM_SYSTEM_RANGE_START_WOW64     0x80000000
 
+/* The size of the virtual memory area that is mapped using a single PDE */
+#define PDE_MAPPED_VA (PTE_PER_PAGE * PAGE_SIZE)
+
 /* Misc address definitions */
 //#define MI_NON_PAGED_SYSTEM_START_MIN   MM_SYSTEM_SPACE_START // FIXME
 //#define MI_SYSTEM_PTE_START             MM_SYSTEM_SPACE_START

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -140,7 +140,7 @@
 /* Maximum number of PDEs */
 #define PDE_PER_SYSTEM (PD_COUNT * PDE_PER_PAGE)
 
-/* TODO: It seems this variable is not needed for x86 */
+/* TODO: It seems this constant is not needed for x86 */
 #define PPE_PER_PAGE 1
 
 /* Maximum number of pages for 4 GB of virtual space */
@@ -154,13 +154,13 @@
 #define MI_SYSTEM_PTE_BASE (PVOID)MiAddressToPte(NULL)
 
 /* Base addreses for page directories */
-#define PDE_BASE (ULONG_PTR)MiAddressToPte(PTE_BASE)
+#define PDE_BASE (ULONG_PTR)MiPteToPde(PTE_BASE)
 #define PDE_TOP  (ULONG_PTR)(PDE_BASE + (PDE_PER_SYSTEM * sizeof(MMPDE)) - 1)
 #define PDE_MASK (PDE_TOP - PDE_BASE)
 
 /* The size of the virtual memory area that is mapped using a single PDE */
 #ifndef PDE_MAPPED_VA
-#define PDE_MAPPED_VA  (PTE_PER_PAGE * PAGE_SIZE)
+#define PDE_MAPPED_VA (PTE_PER_PAGE * PAGE_SIZE)
 #endif
 
 /* Maps the virtual address to the corresponding PTE */
@@ -169,7 +169,7 @@
 
 /* Maps the virtual address to the corresponding PDE */
 #define MiAddressToPde(Va) \
-    ((PMMPDE)(PDE_BASE + ((MiAddressToPdeOffset(Va)) * sizeof(MMPTE))))
+    ((PMMPDE)(PDE_BASE + ((MiAddressToPdeOffset(Va)) * sizeof(MMPDE))))
 
 /* Takes the PTE index (for one PD page) from the virtual address */
 #define MiAddressToPteOffset(Va) \

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -131,6 +131,9 @@
 #define PD_COUNT (1 << 2) /* The two most significant bits in the VA */
 #endif
 
+/* PAE not yet implemented. */
+C_ASSERT(PD_COUNT == 1);
+
 /* The number of PTEs on one page of the PT */
 #define PTE_PER_PAGE (PAGE_SIZE / sizeof(MMPTE))
 
@@ -159,9 +162,7 @@
 #define PDE_MASK (PDE_TOP - PDE_BASE)
 
 /* The size of the virtual memory area that is mapped using a single PDE */
-#ifndef PDE_MAPPED_VA
 #define PDE_MAPPED_VA (PTE_PER_PAGE * PAGE_SIZE)
-#endif
 
 /* Maps the virtual address to the corresponding PTE */
 #define MiAddressToPte(Va) \

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -18,9 +18,6 @@
 /* Everyone loves 64K */
 #define _64K (64 * _1KB)
 
-/* Area mapped by a PDE */
-#define PDE_MAPPED_VA  (PTE_PER_PAGE * PAGE_SIZE)
-
 /* Size of a page table */
 #define PT_SIZE  (PTE_PER_PAGE * sizeof(MMPTE))
 


### PR DESCRIPTION
Purpose: make the definitions and macros for x86 MM more human-readable.
Now definitions have become more universal for PAE mode.
