### PR TITLE
[WIN32K:NTUSER] ntuser.h: Rename NtUserWaitForInputIdle() 3rd parameter

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3499,7 +3499,7 @@ NTAPI
 NtUserWaitForInputIdle(
     IN HANDLE hProcess,
     IN DWORD dwMilliseconds,
-    IN BOOL Unknown2); /* Always FALSE */
+    IN BOOL bSharedWow); /* Always FALSE */
 
 DWORD
 NTAPI


### PR DESCRIPTION
Addendum to 568b6d0558d047df1826d7438448432643d7fe5c.