### PR TITLE
Improvements for MM.

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -245,12 +245,6 @@ MiPxeToAddress(PMMPTE PointerPxe)
 
 //
 // Decodes a Prototype PTE into the underlying PTE
-//
-#define MiProtoPteToPte(x)                  \
-    (PMMPTE)(((LONG64)(x)->u.Long) >> 16) /* Sign extend 48 bits */
-
-//
-// Decodes a Prototype PTE into the underlying PTE
 // The 48 bit signed value gets sign-extended to 64 bits.
 //
 #define MiSubsectionPteToSubsection(x)                              \
@@ -268,20 +262,6 @@ MI_MAKE_SUBSECTION_PTE(
 
     /* Store the lower 48 bits of the Segment address */
     NewPte->u.Subsect.SubsectionAddress = ((ULONG_PTR)Segment & 0x0000FFFFFFFFFFFF);
-}
-
-FORCEINLINE
-VOID
-MI_MAKE_PROTOTYPE_PTE(IN PMMPTE NewPte,
-                      IN PMMPTE PointerPte)
-{
-    /* Store the Address */
-    NewPte->u.Long = (ULONG64)PointerPte << 16;
-
-    /* Mark this as a prototype PTE */
-    NewPte->u.Proto.Prototype = 1;
-
-    ASSERT(MiProtoPteToPte(NewPte) == PointerPte);
 }
 
 INIT_FUNCTION

--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -185,7 +185,6 @@ MiAddressToPdi(PVOID Address)
     return ((((ULONG64)Address) >> PDI_SHIFT) & 0x1FF);
 }
 #define MiAddressToPdeOffset(x) MiAddressToPdi(x)
-#define MiGetPdeOffset(x) MiAddressToPdi(x)
 
 /* Convert an address to a corresponding PXE offset/index */
 FORCEINLINE

--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -284,15 +284,6 @@ MI_MAKE_PROTOTYPE_PTE(IN PMMPTE NewPte,
     ASSERT(MiProtoPteToPte(NewPte) == PointerPte);
 }
 
-FORCEINLINE
-BOOLEAN
-MI_IS_MAPPED_PTE(PMMPTE PointerPte)
-{
-    /// FIXME
-    __debugbreak();
-    return ((PointerPte->u.Long & 0xFFFFFC01) != 0);
-}
-
 INIT_FUNCTION
 FORCEINLINE
 VOID

--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -243,27 +243,6 @@ MiPxeToAddress(PMMPTE PointerPxe)
 #define MiIsPteOnPxeBoundary(PointerPte) \
     ((((ULONG_PTR)PointerPte) & (PPE_PER_PAGE * PDE_PER_PAGE * PAGE_SIZE - 1)) == 0)
 
-//
-// Decodes a Prototype PTE into the underlying PTE
-// The 48 bit signed value gets sign-extended to 64 bits.
-//
-#define MiSubsectionPteToSubsection(x)                              \
-        (PMMPTE)((LONG64)(x)->u.Subsect.SubsectionAddress)
-
-FORCEINLINE
-VOID
-MI_MAKE_SUBSECTION_PTE(
-    _Out_ PMMPTE NewPte,
-    _In_ PVOID Segment)
-{
-    /* Mark this as a prototype */
-    NewPte->u.Long = 0;
-    NewPte->u.Subsect.Prototype = 1;
-
-    /* Store the lower 48 bits of the Segment address */
-    NewPte->u.Subsect.SubsectionAddress = ((ULONG_PTR)Segment & 0x0000FFFFFFFFFFFF);
-}
-
 INIT_FUNCTION
 FORCEINLINE
 VOID

--- a/ntoskrnl/include/internal/arm/mm.h
+++ b/ntoskrnl/include/internal/arm/mm.h
@@ -110,7 +110,6 @@
 /* Convert an address to a corresponding PDE offset/index */
 #define MiAddressToPdeOffset(x) \
     (((ULONG)(x)) >> 20)
-#define MiGetPdeOffset MiAddressToPdeOffset
 
 /* Convert a PTE/PDE into a corresponding address */
 #define MiPteToAddress(_Pte) ((PVOID)((ULONG)(_Pte) << 10))

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -197,14 +197,4 @@ C_ASSERT(PD_COUNT == 1);
 /* Return TRUE if the PTE is at the beginning of the PT */
 #define MiIsPteOnPdeBoundary(_Pte) ((((ULONG_PTR)_Pte) & (PAGE_SIZE - 1)) == 0)
 
-//
-// Decodes a Prototype PTE into the underlying PTE
-//
-#define MiSubsectionPteToSubsection(x)                              \
-    ((x)->u.Subsect.WhichPool == PagedPool) ?                       \
-        (PMMPTE)((ULONG_PTR)MmSubsectionBase +                      \
-                 (((x)->u.Subsect.SubsectionAddressHigh << 7) |     \
-                   (x)->u.Subsect.SubsectionAddressLow << 3)) :     \
-        (PMMPTE)((ULONG_PTR)MmNonPagedPoolEnd -                     \
-                (((x)->u.Subsect.SubsectionAddressHigh << 7) |      \
-                  (x)->u.Subsect.SubsectionAddressLow << 3))
+/* EOF */

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -143,9 +143,6 @@ C_ASSERT(PD_COUNT == 1);
 /* Maximum number of PDEs */
 #define PDE_PER_SYSTEM (PD_COUNT * PDE_PER_PAGE)
 
-/* TODO: It seems this constant is not needed for x86 */
-#define PPE_PER_PAGE 1
-
 /* Maximum number of pages for 4 GB of virtual space */
 #define MI_MAX_PAGES ((1ull << 32) / PAGE_SIZE)
 

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -3,11 +3,11 @@
  */
 #pragma once
 
+#define _MI_PAGING_LEVELS 2
+
 #ifdef _X86PAE_
-#define _MI_PAGING_LEVELS 3
 #define _MI_HAS_NO_EXECUTE 1
 #else
-#define _MI_PAGING_LEVELS 2
 #define _MI_HAS_NO_EXECUTE 0
 #endif
 

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -77,7 +77,6 @@
 #define MM_EMPTY_PTE_LIST  ((ULONG)0xFFFFF)
 #define MM_EMPTY_LIST  ((ULONG_PTR)-1)
 
-
 /* Easy accessing PFN in PTE */
 #define PFN_FROM_PTE(v) ((v)->u.Hard.PageFrameNumber)
 
@@ -175,9 +174,6 @@ C_ASSERT(PD_COUNT == 1);
 
 /* Takes the PDE offset (within all PDs pages) from the virtual address */
 #define MiAddressToPdeOffset(Va) (((ULONG_PTR)(Va)) / PDE_MAPPED_VA)
-
-/* TODO: Free this variable (for offset from the pointer to the PDE) */
-#define MiGetPdeOffset MiAddressToPdeOffset
 
 /* Convert a PTE/PDE into a corresponding address */
 #define MiPteToAddress(_Pte) ((PVOID)((ULONG)(_Pte) << 10))

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -108,9 +108,6 @@
 #define MI_IS_WRITE_ACCESS(FaultCode) BooleanFlagOn(FaultCode, 0x2)
 #define MI_IS_INSTRUCTION_FETCH(FaultCode) BooleanFlagOn(FaultCode, 0x10)
 
-/* On x86, these two are the same */
-#define MI_WRITE_VALID_PPE MI_WRITE_VALID_PTE
-
 /*  Translating virtual addresses to physical addresses
         (See: "Intel® 64 and IA-32 Architectures Software Developer’s Manual
               Volume 3A: System Programming Guide, Part 1, CHAPTER 4 PAGING")

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -200,13 +200,6 @@ C_ASSERT(PD_COUNT == 1);
 //
 // Decodes a Prototype PTE into the underlying PTE
 //
-#define MiProtoPteToPte(x)                  \
-    (PMMPTE)((ULONG_PTR)MmPagedPoolStart +  \
-             (((x)->u.Proto.ProtoAddressHigh << 9) | (x)->u.Proto.ProtoAddressLow << 2))
-
-//
-// Decodes a Prototype PTE into the underlying PTE
-//
 #define MiSubsectionPteToSubsection(x)                              \
     ((x)->u.Subsect.WhichPool == PagedPool) ?                       \
         (PMMPTE)((ULONG_PTR)MmSubsectionBase +                      \

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -178,11 +178,11 @@ C_ASSERT(PD_COUNT == 1);
 
 /* Index of PD in which the PDE is located */
 #ifndef _X86PAE_
-/* Maximum 4 pages of memory (0 ... 3) */
-#define MiGetPdIndex(_Pde) ((MiGetPdeOffset(_Pde)) / PDE_PER_PAGE)
-#else
 /* Only 1 page of memory */
 #define MiGetPdIndex(_Pde) (0)
+#else
+/* Maximum 4 pages of memory (0 ... 3) */
+#define MiGetPdIndex(_Pde) ((MiGetPdeOffset(_Pde)) / PDE_PER_PAGE)
 #endif
 
 /* Determines a virtual address mapped to a this PTE */

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -1660,7 +1660,7 @@ MiIncrementPageTableReferences(IN PVOID Address)
 {
     PUSHORT RefCount;
 
-    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)];
+    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)];
 
     *RefCount += 1;
     ASSERT(*RefCount <= PTE_PER_PAGE);
@@ -1672,7 +1672,7 @@ MiDecrementPageTableReferences(IN PVOID Address)
 {
     PUSHORT RefCount;
 
-    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)];
+    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)];
 
     *RefCount -= 1;
     ASSERT(*RefCount < PTE_PER_PAGE);
@@ -1684,7 +1684,7 @@ MiQueryPageTableReferences(IN PVOID Address)
 {
     PUSHORT RefCount;
 
-    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)];
+    RefCount = &MmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)];
 
     return *RefCount;
 }

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -655,7 +655,7 @@ extern LARGE_INTEGER MmCriticalSectionTimeout;
 extern LIST_ENTRY MmWorkingSetExpansionHead;
 extern KSPIN_LOCK MmExpansionLock;
 extern PETHREAD MiExpansionLockOwner;
-#if (_MI_PAGING_LEVELS <= 3)
+#if (_MI_PAGING_LEVELS == 2)
 extern PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
 extern PMMPDE MmSystemPagePtes;
 #endif

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -25,7 +25,7 @@
 #define PD_SIZE  (PDE_PER_PAGE * sizeof(MMPDE))
 
 /* Size of all page directories for a process */
-#define SYSTEM_PD_SIZE (PPE_PER_PAGE * PD_SIZE)
+#define SYSTEM_PD_SIZE (PD_COUNT * PD_SIZE)
 #ifdef _M_IX86
 C_ASSERT(SYSTEM_PD_SIZE == PAGE_SIZE);
 #endif
@@ -585,7 +585,6 @@ extern PMMPTE MiSessionImagePteStart;
 extern PMMPTE MiSessionImagePteEnd;
 extern PMMPTE MiSessionBasePte;
 extern PMMPTE MiSessionLastPte;
-extern PMMPDE MmSystemPagePtes;
 extern PVOID MmSystemCacheStart;
 extern PVOID MmSystemCacheEnd;
 extern MMSUPPORT MmSystemCacheWs;
@@ -631,7 +630,6 @@ extern PVOID MiSessionImageStart;
 extern PVOID MiSessionImageEnd;
 extern PMMPTE MiHighestUserPte;
 extern PMMPDE MiHighestUserPde;
-extern PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
 extern PMMPTE MmSharedUserDataPte;
 extern LIST_ENTRY MmProcessList;
 extern KEVENT MmZeroingPageEvent;
@@ -657,6 +655,10 @@ extern LARGE_INTEGER MmCriticalSectionTimeout;
 extern LIST_ENTRY MmWorkingSetExpansionHead;
 extern KSPIN_LOCK MmExpansionLock;
 extern PETHREAD MiExpansionLockOwner;
+#if (_MI_PAGING_LEVELS <= 3)
+extern PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
+extern PMMPDE MmSystemPagePtes;
+#endif
 
 FORCEINLINE
 BOOLEAN

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -578,18 +578,13 @@ extern MM_PAGED_POOL_INFO MmPagedPoolInfo;
 extern RTL_BITMAP MiPfnBitMap;
 extern KGUARDED_MUTEX MmPagedPoolMutex;
 extern KGUARDED_MUTEX MmSectionCommitMutex;
-extern PVOID MmPagedPoolStart;
-extern PVOID MmPagedPoolEnd;
-extern PVOID MmNonPagedSystemStart;
 extern PVOID MiSystemViewStart;
 extern SIZE_T MmSystemViewSize;
-extern PVOID MmSessionBase;
 extern PVOID MiSessionSpaceEnd;
 extern PMMPTE MiSessionImagePteStart;
 extern PMMPTE MiSessionImagePteEnd;
 extern PMMPTE MiSessionBasePte;
 extern PMMPTE MiSessionLastPte;
-extern SIZE_T MmSizeOfPagedPoolInBytes;
 extern PMMPDE MmSystemPagePtes;
 extern PVOID MmSystemCacheStart;
 extern PVOID MmSystemCacheEnd;
@@ -647,7 +642,6 @@ extern PFN_NUMBER MiNumberOfFreePages;
 extern SIZE_T MmSessionViewSize;
 extern SIZE_T MmSessionPoolSize;
 extern SIZE_T MmSessionImageSize;
-extern PVOID MiSystemViewStart;
 extern PVOID MiSessionPoolEnd;     // 0xBE000000
 extern PVOID MiSessionPoolStart;   // 0xBD000000
 extern PVOID MiSessionViewStart;   // 0xBE000000

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -827,7 +827,7 @@ MI_MAKE_HARDWARE_PTE_USER(IN PMMPTE NewPte,
 /* Decodes a Prototype PTE into the poiner to proto structure */
 FORCEINLINE
 PMMPTE
-MiProtoPteToPte(IN PMMPTE ProtoPte)
+MiProtoPteToPte(_In_ PMMPTE ProtoPte)
 {
     /* Do MI_MAKE_PROTOTYPE_PTE() in the opposite direction */
 
@@ -846,8 +846,8 @@ MiProtoPteToPte(IN PMMPTE ProtoPte)
 /* Builds a Prototype PTE from the poiner to proto structure */
 FORCEINLINE
 VOID
-MI_MAKE_PROTOTYPE_PTE(OUT PMMPTE ProtoPte,
-                      IN PMMPTE PointerToProto)
+MI_MAKE_PROTOTYPE_PTE(_Out_ PMMPTE ProtoPte,
+                      _In_ PMMPTE PointerToProto)
 {
 #if !defined(_M_AMD64) && !defined(_X86PAE_)
     ULONG_PTR Offset;
@@ -882,7 +882,7 @@ MI_MAKE_PROTOTYPE_PTE(OUT PMMPTE ProtoPte,
 /* Decodes a pointer to a Subsection from the Subsection PTE */
 FORCEINLINE
 PVOID
-MiSubsectionPteToSubsection(IN PMMPTE SubsectionPte)
+MiSubsectionPteToSubsection(_In_ PMMPTE SubsectionPte)
 {
     /* Do MI_MAKE_SUBSECTION_PTE() in the opposite direction. */
 
@@ -910,8 +910,8 @@ MiSubsectionPteToSubsection(IN PMMPTE SubsectionPte)
 /* Builds a Subsection PTE for the address of the Subsection */
 FORCEINLINE
 VOID
-MI_MAKE_SUBSECTION_PTE(OUT PMMPTE NewPte,
-                       IN PVOID Subsection)
+MI_MAKE_SUBSECTION_PTE(_Out_ PMMPTE NewPte,
+                       _In_ PVOID Subsection)
 {
 #if !defined(_M_AMD64) && !defined(_X86PAE_)
     ULONG_PTR Offset;
@@ -953,7 +953,7 @@ MI_MAKE_SUBSECTION_PTE(OUT PMMPTE NewPte,
 
 FORCEINLINE
 BOOLEAN
-MI_IS_MAPPED_PTE(PMMPTE PointerPte)
+MI_IS_MAPPED_PTE(_In_ PMMPTE PointerPte)
 {
     if (PointerPte->u.Soft.Valid ||
         PointerPte->u.Soft.Prototype ||

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -893,15 +893,31 @@ MI_MAKE_SUBSECTION_PTE(IN PMMPTE NewPte,
     NewPte->u.Subsect.SubsectionAddressHigh = (Offset & 0xFFFFF80) >> 7;
 }
 
+#endif
+
 FORCEINLINE
 BOOLEAN
 MI_IS_MAPPED_PTE(PMMPTE PointerPte)
 {
-    /// \todo Make this reasonable code, this is UGLY!
-    return ((PointerPte->u.Long & 0xFFFFFC01) != 0);
-}
-
+    if (PointerPte->u.Soft.Valid ||
+        PointerPte->u.Soft.Prototype ||
+        PointerPte->u.Soft.Transition ||
+#if defined(_X86PAE_)
+        PointerPte->u.Soft.Unused ||
+#elif(_M_AMD64)
+        PointerPte->u.Soft.UsedPageTableEntries ||
+        PointerPte->u.Soft.Reserved ||
 #endif
+        PointerPte->u.Soft.PageFileHigh)
+    {
+        return TRUE;
+    }
+    else
+    {
+        /* Demand zero PTE */
+        return FALSE;
+    }
+}
 
 FORCEINLINE
 VOID

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -2055,6 +2055,7 @@ MmArmInitSystem(IN ULONG Phase,
     ULONG j;
     PMMPTE PointerPte, TestPte;
     MMPTE TempPte;
+    PSUBSECTION Subsection;
 #endif
 
     /* Dump memory descriptors */
@@ -2324,10 +2325,9 @@ MmArmInitSystem(IN ULONG Phase,
         }
 
         /* Subsection PTEs are always in nonpaged pool, pick a random address to try */
-        PointerPte = (PMMPTE)((ULONG_PTR)MmNonPagedPoolStart + (MmSizeOfNonPagedPoolInBytes / 2));
-        MI_MAKE_SUBSECTION_PTE(&TempPte, PointerPte);
-        TestPte = MiSubsectionPteToSubsection(&TempPte);
-        ASSERT(PointerPte == TestPte);
+        Subsection = (PSUBSECTION)((ULONG_PTR)MI_NONPAGED_POOL_END - _1MB);
+        MI_MAKE_SUBSECTION_PTE(&TempPte, Subsection);
+        ASSERT(Subsection == MiSubsectionPteToSubsection(&TempPte));
 #endif
 
         //

--- a/ntoskrnl/mm/ARM3/mminit.c
+++ b/ntoskrnl/mm/ARM3/mminit.c
@@ -161,7 +161,7 @@ SIZE_T MmSystemViewSize;
 // map paged pool PDEs into external processes when they fault on a paged pool
 // address.
 //
-PFN_NUMBER MmSystemPageDirectory[PPE_PER_PAGE];
+PFN_NUMBER MmSystemPageDirectory[PD_COUNT];
 PMMPDE MmSystemPagePtes;
 #endif
 
@@ -779,7 +779,7 @@ MiBuildPfnDatabaseFromPages(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 
     /* Start with the first PDE and scan them all */
     PointerPde = MiAddressToPde(NULL);
-    Count = PPE_PER_PAGE * PDE_PER_PAGE;
+    Count = PD_COUNT * PDE_PER_PAGE;
     for (i = 0; i < Count; i++)
     {
         /* Check for valid PDE */
@@ -1767,7 +1767,7 @@ MiBuildPagedPool(VOID)
     // Get the page frame number for the system page directory
     //
     PointerPte = MiAddressToPte(PDE_BASE);
-    ASSERT(PPE_PER_PAGE == 1);
+    ASSERT(PD_COUNT == 1);
     MmSystemPageDirectory[0] = PFN_FROM_PTE(PointerPte);
 
     //
@@ -1785,7 +1785,7 @@ MiBuildPagedPool(VOID)
     // way).
     //
     TempPte = ValidKernelPte;
-    ASSERT(PPE_PER_PAGE == 1);
+    ASSERT(PD_COUNT == 1);
     TempPte.u.Hard.PageFrameNumber = MmSystemPageDirectory[0];
     MI_WRITE_VALID_PTE(PointerPte, TempPte);
 #endif

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1201,7 +1201,7 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     SystemTable = MiPteToAddress(PointerPte);
 
     /* Copy all the kernel mappings */
-    PdeOffset = MiGetPdeOffset(MmSystemRangeStart);
+    PdeOffset = MiAddressToPdeOffset(MmSystemRangeStart);
     RtlCopyMemory(&SystemTable[PdeOffset],
                   MiAddressToPde(MmSystemRangeStart),
                   PAGE_SIZE - PdeOffset * sizeof(MMPTE));
@@ -1209,15 +1209,15 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     /* Now write the PTE/PDE entry for hyperspace itself */
     TempPte = ValidKernelPteLocal;
     TempPte.u.Hard.PageFrameNumber = HyperIndex;
-    PdeOffset = MiGetPdeOffset(HYPER_SPACE);
+    PdeOffset = MiAddressToPdeOffset(HYPER_SPACE);
     SystemTable[PdeOffset] = TempPte;
 
     /* Sanity check */
     PdeOffset++;
-    ASSERT(MiGetPdeOffset(MmHyperSpaceEnd) >= PdeOffset);
+    ASSERT(MiAddressToPdeOffset(MmHyperSpaceEnd) >= PdeOffset);
 
     /* Now do the x86 trick of making the PDE a page table itself */
-    PdeOffset = MiGetPdeOffset(PTE_BASE);
+    PdeOffset = MiAddressToPdeOffset(PTE_BASE);
     TempPte.u.Hard.PageFrameNumber = PdeIndex;
     SystemTable[PdeOffset] = TempPte;
 

--- a/ntoskrnl/mm/arm/page.c
+++ b/ntoskrnl/mm/arm/page.c
@@ -280,11 +280,11 @@ MmInitGlobalKernelPageDirectory(VOID)
     PULONG CurrentPageDirectory = (PULONG)PDE_BASE;
 
     /* Loop the 2GB of address space which belong to the kernel */
-    for (i = MiGetPdeOffset(MmSystemRangeStart); i < 2048; i++)
+    for (i = MiAddressToPdeOffset(MmSystemRangeStart); i < 2048; i++)
     {
         /* Check if we have an entry for this already */
-        if ((i != MiGetPdeOffset(PTE_BASE)) &&
-            (i != MiGetPdeOffset(HYPER_SPACE)) &&
+        if ((i != MiAddressToPdeOffset(PTE_BASE)) &&
+            (i != MiAddressToPdeOffset(HYPER_SPACE)) &&
             (!MmGlobalKernelPageDirectory[i]) &&
             (CurrentPageDirectory[i]))
         {

--- a/ntoskrnl/mm/arm/stubs.c
+++ b/ntoskrnl/mm/arm/stubs.c
@@ -108,7 +108,7 @@ MiGetPageTableForProcess(IN PEPROCESS Process,
             //
             // Does it exist in the kernel page directory?
             //
-            //PdeOffset = MiGetPdeOffset(Address);
+            //PdeOffset = MiAddressToPdeOffset(Address);
             //if (MmGlobalKernelPageDirectory[PdeOffset] == 0)
             {
                 //
@@ -274,9 +274,9 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     //
     // Copy the PDEs for kernel-mode
     //
-    RtlCopyMemory(PageDirectory + MiGetPdeOffset(MmSystemRangeStart),
-                  MmGlobalKernelPageDirectory + MiGetPdeOffset(MmSystemRangeStart),
-                  (1024 - MiGetPdeOffset(MmSystemRangeStart)) * sizeof(ULONG));
+    RtlCopyMemory(PageDirectory + MiAddressToPdeOffset(MmSystemRangeStart),
+                  MmGlobalKernelPageDirectory + MiAddressToPdeOffset(MmSystemRangeStart),
+                  (1024 - MiAddressToPdeOffset(MmSystemRangeStart)) * sizeof(ULONG));
 
 
     //
@@ -284,7 +284,7 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     //
     TempPde = MiArmTemplatePde;
     TempPde.u.Hard.Coarse.PageFrameNumber = (Pfn[0] << PAGE_SHIFT) >> CPT_SHIFT;
-    PointerPde = &PageDirectory[MiGetPdeOffset(PTE_BASE)];
+    PointerPde = &PageDirectory[MiAddressToPdeOffset(PTE_BASE)];
 
     //
     // Write the PDE
@@ -297,7 +297,7 @@ MmCreateProcessAddressSpace(IN ULONG MinWs,
     // Setup the PDE for the hyperspace
     //
     TempPde.u.Hard.Coarse.PageFrameNumber = (Pfn[1] << PAGE_SHIFT) >> CPT_SHIFT;
-    PointerPde = &PageDirectory[MiGetPdeOffset(HYPER_SPACE)];
+    PointerPde = &PageDirectory[MiAddressToPdeOffset(HYPER_SPACE)];
 
     //
     // Write the PDE
@@ -343,13 +343,13 @@ MmCreateVirtualMappingInternal(IN PEPROCESS Process,
     // Loop every page
     //
     Addr = Address;
-    OldPdeOffset = MiGetPdeOffset(Addr) + 1;
+    OldPdeOffset = MiAddressToPdeOffset(Addr) + 1;
     for (i = 0; i < PageCount; i++)
     {
         //
         // Get the next PDE offset and check if it's a new one
         //
-        PdeOffset = MiGetPdeOffset(Addr);
+        PdeOffset = MiAddressToPdeOffset(Addr);
         if (OldPdeOffset != PdeOffset)
         {
             //
@@ -656,13 +656,13 @@ MmInitGlobalKernelPageDirectory(VOID)
     //
     // Loop the 2GB of address space which belong to the kernel
     //
-    for (i = MiGetPdeOffset(MmSystemRangeStart); i < 1024; i++)
+    for (i = MiAddressToPdeOffset(MmSystemRangeStart); i < 1024; i++)
     {
         //
         // Check if we have an entry for this already
         //
-        if ((i != MiGetPdeOffset(PTE_BASE)) &&
-            (i != MiGetPdeOffset(HYPER_SPACE)) &&
+        if ((i != MiAddressToPdeOffset(PTE_BASE)) &&
+            (i != MiAddressToPdeOffset(HYPER_SPACE)) &&
             (!MmGlobalKernelPageDirectory[i]) &&
             (CurrentPageDirectory[i]))
         {

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -221,7 +221,7 @@ MmGetPageTableForProcess(PEPROCESS Process, PVOID Address, BOOLEAN Create)
         if(Process != PsGetCurrentProcess())
         {
             PMMPDE PdeBase;
-            ULONG PdeOffset = MiGetPdeOffset(Address);
+            ULONG PdeOffset = MiAddressToPdeOffset(Address);
 
             /* Nobody but page fault should ask for creating the PDE,
              * Which imples that Process is the current one */
@@ -389,8 +389,8 @@ MmDeleteVirtualMapping(PEPROCESS Process, PVOID Address,
 		if (Address < MmSystemRangeStart)
 		{
 			/* Remove PDE reference */
-			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]--;
-			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_PER_PAGE);
+			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)]--;
+			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)] < PTE_PER_PAGE);
 		}
 
         Pfn = PTE_TO_PFN(Pte);
@@ -453,8 +453,8 @@ MmDeletePageFileMapping(PEPROCESS Process, PVOID Address,
 	if (Address < MmSystemRangeStart)
 	{
 		/* Remove PDE reference */
-		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]--;
-		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] < PTE_PER_PAGE);
+		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)]--;
+		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)] < PTE_PER_PAGE);
 	}
 
     /* We don't need to flush here because page file entries
@@ -638,8 +638,8 @@ MmCreatePageFileMapping(PEPROCESS Process,
 	if (Address < MmSystemRangeStart)
 	{
 		/* Add PDE reference */
-		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)]++;
-		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Address)] <= PTE_PER_PAGE);
+		Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)]++;
+		ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Address)] <= PTE_PER_PAGE);
 	}
 
     /* We don't need to flush the TLB here because it
@@ -755,8 +755,8 @@ MmCreateVirtualMappingUnsafe(PEPROCESS Process,
 		if (Addr < MmSystemRangeStart)
 		{
 			/* Add PDE reference */
-			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Addr)]++;
-			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiGetPdeOffset(Addr)] <= PTE_PER_PAGE);
+			Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Addr)]++;
+			ASSERT(Process->Vm.VmWorkingSetList->UsedPageTableEntries[MiAddressToPdeOffset(Addr)] <= PTE_PER_PAGE);
 		}
     }
 


### PR DESCRIPTION
Purpose:

1) Removing duplicates:
    extern PVOID MmPagedPoolStart;
    extern PVOID MmPagedPoolEnd;
    extern PVOID MmNonPagedSystemStart;
    extern PVOID MmSessionBase;
    extern SIZE_T MmSizeOfPagedPoolInBytes;
    extern PVOID MiSystemViewStart;

2) For X86:
    using PD_COUNT instead PPE_PER_PAGE;
    using MmSystemPageDirectory and MmSystemPagePtes only if _MI_PAGING_LEVELS <= 3

3) Using MiAddressToPdeOffset() instead of MiGetPdeOffset() for redefine MiGetPdeOffset().

4) Making translation macros for x86 versatility for systems with PAE;
    make also the definitions and macros more human-readable;
    add MiGetPteOffset(), MiGetPdeOffset() and MiGetPdIndex() macros;
    using naiming "Pte" instead "PointerPte".
