### PR TITLE
[SHIMLIB] Fix gcc8 build crashing when using shims

### DIFF
--- a/dll/appcompat/shims/shimlib/shimlib.c
+++ b/dll/appcompat/shims/shimlib/shimlib.c
@@ -100,7 +100,7 @@ BOOL ShimLib_StrAEqualsWNC(PCSTR szString, PCWSTR wszString)
 #endif
 
 
-_SHMALLOC(".shm") SHIMREG _shim_start = { 0 };
+_SHMALLOC(".shm$AAA") SHIMREG _shim_start = { 0 };
 _SHMALLOC(".shm$ZZZ") SHIMREG _shim_end = { 0 };
 
 
@@ -112,7 +112,7 @@ PHOOKAPI WINAPI ShimLib_GetHookAPIs(IN LPCSTR szCommandLine, IN LPCWSTR wszShimN
 {
     PSHIMREG ps = &_shim_start;
     ps++;
-    for (; ps != &_shim_end; ps++)
+    for (; ps < &_shim_end; ps++)
     {
         if (ps->GetHookAPIs != NULL && ps->ShimName != NULL)
         {


### PR DESCRIPTION
JIRA issue: [CORE-16514](https://jira.reactos.org/browse/CORE-16514)
There seems to be some padding before `_shim_end`, causing the loop to continue forever.