### PR TITLE
[APISETS] Forward _seh_filter_{dll,exe}

### DIFF
--- a/dll/apisets/api-ms-win-crt-runtime-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-runtime-l1-1-0.spec
@@ -66,8 +66,8 @@
 @ stub _register_onexit_function
 @ stub _register_thread_local_exe_atexit_callback
 @ stdcall _resetstkoflw() msvcrt._resetstkoflw
-@ stub _seh_filter_dll
-@ stub _seh_filter_exe
+@ cdecl _seh_filter_dll(long ptr) msvcrt.__CppXcptFilter
+@ cdecl _seh_filter_exe(long ptr) msvcrt._XcptFilter
 @ stub _set_abort_behavior
 @ stub _set_app_type
 @ stub _set_controlfp


### PR DESCRIPTION
## Purpose

Since these functions are forwarded to a different function name, update.py misses them. The choice of target [comes from Wine](https://github.com/wine-mirror/wine/blob/a98ca88dd1139ad8e16e63fbb349c2fc5e9ad332/dlls/ucrtbase/ucrtbase.spec#L1877-L1878).

With this change applied, calls to other stub functions from certain binaries (namely, dotnet.exe from .NET Core) now "correctly" crash, invoking drwtsn32, instead of simply exiting.