### PR TITLE
[DRWTSN32] Recognize EXCEPTION_WINE_STUB

### DIFF
--- a/base/applications/drwtsn32/sysinfo.cpp
+++ b/base/applications/drwtsn32/sysinfo.cpp
@@ -9,6 +9,7 @@
 #include <udmihelp.h>
 #include <winreg.h>
 #include <reactos/buildno.h>
+#include <reactos/stubs.h>
 
 static const char* Exception2Str(DWORD code)
 {
@@ -36,6 +37,7 @@ static const char* Exception2Str(DWORD code)
     case EXCEPTION_INVALID_DISPOSITION: return "EXCEPTION_INVALID_DISPOSITION";
     case EXCEPTION_GUARD_PAGE: return "EXCEPTION_GUARD_PAGE";
     case EXCEPTION_INVALID_HANDLE: return "EXCEPTION_INVALID_HANDLE";
+    case EXCEPTION_WINE_STUB: return "EXCEPTION_WINE_STUB";
     }
 
     return "--";


### PR DESCRIPTION
## Purpose

drwtsn32.exe recognizes several standard exception codes, and prints their names in the crash log. However, EXCEPTION_WINE_STUB is not in this list, and as such it is treated as an unknown error and printed as "--". Having this error code given a name at the start of the crash dump is useful, as it allows me to identify calls to unimplemented issues more readily.

JIRA issue: (none)