### PR TITLE
[SHELL32] Watch for common desktop and SHCNE_CREATE for IShellLink::Save

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1166,17 +1166,17 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
         SHGetSpecialFolderLocation(m_hWnd, CSIDL_DESKTOPDIRECTORY, &pidls[0]);
         SHGetSpecialFolderLocation(m_hWnd, CSIDL_COMMON_DESKTOPDIRECTORY, &pidls[1]);
         SHGetSpecialFolderLocation(m_hWnd, CSIDL_BITBUCKET, &pidls[2]);
-        ntreg[0].fRecursive = TRUE;
+        ntreg[0].fRecursive = FALSE;
         ntreg[0].pidl = pidls[0];
-        ntreg[1].fRecursive = TRUE;
+        ntreg[1].fRecursive = FALSE;
         ntreg[1].pidl = pidls[1];
-        ntreg[2].fRecursive = TRUE;
+        ntreg[2].fRecursive = FALSE;
         ntreg[2].pidl = pidls[2];
     }
     else
     {
         nRegCount = 1;
-        ntreg[0].fRecursive = TRUE;
+        ntreg[0].fRecursive = FALSE;
         ntreg[0].pidl = m_pidlParent;
     }
     m_hNotify = SHChangeNotifyRegister(m_hWnd, SHCNRF_NewDelivery | SHCNRF_ShellLevel,

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1160,7 +1160,7 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
     INT nRegCount;
     SHChangeNotifyEntry ntreg[3];
     PIDLIST_ABSOLUTE pidls[3];
-    if ((m_FolderSettings.fFlags & FWF_DESKTOP) || _ILIsDesktop(m_pidlParent))
+    if (_ILIsDesktop(m_pidlParent))
     {
         nRegCount = 3;
         SHGetSpecialFolderLocation(m_hWnd, CSIDL_DESKTOPDIRECTORY, &pidls[0]);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1157,11 +1157,36 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
         SetShellWindowEx(hwndSB, m_ListView);
     }
 
-    SHChangeNotifyEntry ntreg;
-    ntreg.fRecursive = TRUE;
-    ntreg.pidl = m_pidlParent;
+    INT nRegCount;
+    SHChangeNotifyEntry ntreg[3];
+    PIDLIST_ABSOLUTE pidls[3];
+    if ((m_FolderSettings.fFlags & FWF_DESKTOP) || _ILIsDesktop(m_pidlParent))
+    {
+        nRegCount = 3;
+        SHGetSpecialFolderLocation(m_hWnd, CSIDL_DESKTOPDIRECTORY, &pidls[0]);
+        SHGetSpecialFolderLocation(m_hWnd, CSIDL_COMMON_DESKTOPDIRECTORY, &pidls[1]);
+        SHGetSpecialFolderLocation(m_hWnd, CSIDL_BITBUCKET, &pidls[2]);
+        ntreg[0].fRecursive = TRUE;
+        ntreg[0].pidl = pidls[0];
+        ntreg[1].fRecursive = TRUE;
+        ntreg[1].pidl = pidls[1];
+        ntreg[2].fRecursive = TRUE;
+        ntreg[2].pidl = pidls[2];
+    }
+    else
+    {
+        nRegCount = 1;
+        ntreg[0].fRecursive = TRUE;
+        ntreg[0].pidl = m_pidlParent;
+    }
     m_hNotify = SHChangeNotifyRegister(m_hWnd, SHCNRF_NewDelivery | SHCNRF_ShellLevel,
-                                       SHCNE_ALLEVENTS, SHV_CHANGE_NOTIFY, 1, &ntreg);
+                                       SHCNE_ALLEVENTS, SHV_CHANGE_NOTIFY, nRegCount, ntreg);
+    if (nRegCount == 3)
+    {
+        ILFree(pidls[0]);
+        ILFree(pidls[1]);
+        ILFree(pidls[2]);
+    }
 
     /* _DoFolderViewCB(SFVM_GETNOTIFY, ??  ??) */
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -344,10 +344,15 @@ HRESULT STDMETHODCALLTYPE CShellLink::Load(LPCOLESTR pszFileName, DWORD dwMode)
 
 HRESULT STDMETHODCALLTYPE CShellLink::Save(LPCOLESTR pszFileName, BOOL fRemember)
 {
+    BOOL bAlreadyExists;
+    WCHAR szFullPath[MAX_PATH];
+
     TRACE("(%p)->(%s)\n", this, debugstr_w(pszFileName));
 
     if (!pszFileName)
         return E_FAIL;
+
+    bAlreadyExists = PathFileExistsW(pszFileName);
 
     CComPtr<IStream> stm;
     HRESULT hr = SHCreateStreamOnFileW(pszFileName, STGM_READWRITE | STGM_CREATE | STGM_SHARE_EXCLUSIVE, &stm);
@@ -357,6 +362,12 @@ HRESULT STDMETHODCALLTYPE CShellLink::Save(LPCOLESTR pszFileName, BOOL fRemember
 
         if (SUCCEEDED(hr))
         {
+            if (!bAlreadyExists)
+            {
+                GetFullPathNameW(pszFileName, _countof(szFullPath), szFullPath, NULL);
+                SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, szFullPath, NULL);
+            }
+
             if (m_sLinkPath)
                 HeapFree(GetProcessHeap(), 0, m_sLinkPath);
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -362,11 +362,11 @@ HRESULT STDMETHODCALLTYPE CShellLink::Save(LPCOLESTR pszFileName, BOOL fRemember
 
         if (SUCCEEDED(hr))
         {
-            if (!bAlreadyExists)
-            {
-                GetFullPathNameW(pszFileName, _countof(szFullPath), szFullPath, NULL);
+            GetFullPathNameW(pszFileName, _countof(szFullPath), szFullPath, NULL);
+            if (bAlreadyExists)
+                SHChangeNotify(SHCNE_UPDATEITEM, SHCNF_PATHW, szFullPath, NULL);
+            else
                 SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, szFullPath, NULL);
-            }
 
             if (m_sLinkPath)
                 HeapFree(GetProcessHeap(), 0, m_sLinkPath);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-10391](https://jira.reactos.org/browse/CORE-10391)

On desktop view, we have to watch both the common desktop and the private desktop.
In Windows, `IShellLink::Save` (shortcut creation) sends `SHCNE_CREATE` or `SHCNE_UPDATEITEM` notification.
Simplify `CChangeNotify::ShouldNotify`.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/78847441-bff61c00-7a49-11ea-9240-83aa8d230bf5.png)