### PR TITLE
[UTILMAN] Implement UManDlg library and move most of the code there

### DIFF
--- a/base/applications/utilman/CMakeLists.txt
+++ b/base/applications/utilman/CMakeLists.txt
@@ -1,14 +1,12 @@
 
 list(APPEND SOURCE
-    dialog.c
-    process.c
-    about.c
-    registry.c
+    utilman.c
     precomp.h)
 
 add_rc_deps(utilman.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/utilman.ico)
 add_executable(utilman ${SOURCE} utilman.rc)
 set_module_type(utilman win32gui UNICODE)
-add_importlibs(utilman comdlg32 user32 gdi32 advapi32 shell32 comctl32 msvcrt kernel32 ntdll)
+add_importlibs(utilman user32 msvcrt kernel32 ntdll)
 add_pch(utilman precomp.h SOURCE)
 add_cd_file(TARGET utilman DESTINATION reactos/system32 FOR all)
+add_subdirectory(umandlg)

--- a/base/applications/utilman/NOTES.txt
+++ b/base/applications/utilman/NOTES.txt
@@ -7,5 +7,4 @@ Currently the application can manage the state of the accessibility tools howeve
 - The program can only control the launch/stopping states of accessibility tools, the code which manages the options for each utility is not implemented YET
 - Function helper which catches the Windows logo + U keys is not implemented YET
 - Registry configuration saver/loader is not implemented YET (XP's Utility Manager creates a key on HKEY_CURRENT_USER\Software\Microsoft with the name "Utility Manager" although the rest of other configuration values for utility options are stored elsewhere and I don't know exactly where are those)
-- XP's and Server 2003's main Utility Manager implementation is compiled in a DLL (+ an executable which loads the DLL in question) whereas our Utility Manager is compiled as a whole executable
 - On Windows Vista and later, it complains for required elevation to open a process. We need to improve our process creation code and discard ShellExecuteW()

--- a/base/applications/utilman/lang/en-US.rc
+++ b/base/applications/utilman/lang/en-US.rc
@@ -1,55 +1,14 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         English (United States of America) translation resource
- * COPYRIGHT:       Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
 
-IDD_MAIN_DIALOG DIALOGEX 0, 0, 284, 183
-STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
-EXSTYLE WS_EX_CONTEXTHELP
-CAPTION "Accessibility Utility Manager"
-FONT 8, "MS Shell Dlg"
-BEGIN
-    LISTBOX IDC_LISTBOX, 4, 4, 273, 56, LBS_STANDARD | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER
-    CONTROL "", IDC_GROUPBOX, "Button", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 3, 62, 275, 92
-    CONTROL "Start", IDC_START, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 14, 76, 45, 16
-    CONTROL "Stop", IDC_STOP, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 69, 76, 45, 16
-    CONTROL "Start automatically when I log in", IDC_START_LOG_IN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 101, 206, 14 
-    CONTROL "Start automatically when I lock my desktop", IDC_START_DESKTOP, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 118, 212, 14 
-    CONTROL "Start automatically when Utility Manager starts", IDC_START_UTILMAN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 134, 212, 13 
-    CONTROL "&OK", IDC_OK, "Button", BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 160, 161, 50, 14 
-    CONTROL "&Cancel", IDC_CANCEL, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 221, 161, 50, 14 
-    CONTROL "&Help", IDC_HELP_TOPICS, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 98, 161, 50, 14 
-END
-
-IDD_ABOUT_DIALOG DIALOGEX 22, 16, 210, 65
-CAPTION "About Accessibility Utility Manager"
-FONT 8, "MS Shell Dlg", 0, 0
-STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
-BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
-    PUSHBUTTON "Close", IDOK, 75, 47, 44, 15
-END
-
 STRINGTABLE
 BEGIN
-    IDS_OSK "On-Screen Keyboard"
-    IDS_MAGNIFIER "Magnifier"
-END
-
-STRINGTABLE
-BEGIN
-    IDS_NOTRUNNING "%s is not running"
-    IDS_RUNNING "%s is running"
-    IDS_GROUPBOX_OPTIONS_TITLE "Options for %s"
-END
-
-STRINGTABLE
-BEGIN
-    IDM_ABOUT "About Accessibility Utility Manager..."
+    IDS_FAIL_INIT "Failed to initialize the Utility Manager library! The error code is %lu."
+    IDS_FAIL_INIT_TITLE "Initialization failure"
 END

--- a/base/applications/utilman/precomp.h
+++ b/base/applications/utilman/precomp.h
@@ -10,13 +10,7 @@
 
 /* INCLUDES ******************************************************************/
 
-#include <stdlib.h>
 #include <windows.h>
-#include <commctrl.h>
-#include <tlhelp32.h>
-#include <windowsx.h>
-#include <debug.h>
-#include <wchar.h>
 #include <strsafe.h>
 
 #include "resource.h"
@@ -27,93 +21,7 @@
 
 /* TYPES **********************************************************************/
 
-typedef struct
-{
-    HINSTANCE hInstance;
-    HICON     hIcon;
-    UINT_PTR  iTimer;
-    INT       iSelectedIndex;
-    HWND      hDlgCtlStart;
-    HWND      hDlgCtlStop;
-    HWND      hListDlg;
-    HWND      hMainDlg;
-    WCHAR     szRunning[MAX_BUFFER];
-    WCHAR     szNotRunning[MAX_BUFFER];
-    WCHAR     szGrpBoxTitle[MAX_BUFFER];
-} UTILMAN_GLOBALS;
-
-typedef struct _UTILMAN_STATE
-{
-    LPCWSTR lpProgram;
-    UINT    uNameId;
-    WCHAR   szResource[MAX_BUFFER];
-    BOOL    bState;
-} UTILMAN_STATE, *PUTILMAN_STATE;
-
-typedef struct _REGISTRY_SETTINGS
-{
-    /* Accessibility Registry settings */
-    LPCWSTR wszAppPath;
-    DWORD dwAppType;
-    DWORD dwClientControlCode;
-    LPCWSTR wszAppName;
-    LPCWSTR wszErrorOnLaunch;
-    BOOL bHideClient;
-    BOOL bStartWithUtilman;
-    BOOL bStartWithROS;
-    LPCWSTR wszHungRespondAction;
-    DWORD dwHungTimeOut;
-
-    /* Utility Manager Registry settings */
-    BOOL bShowWarning;
-} REGISTRY_SETTINGS, *PREGISTRY_SETTINGS;
-
-typedef struct _REGISTRY_DATA
-{
-    /* On-Screen Keyboard Registry data */
-    LPCWSTR lpwsOskPath;
-    LPCWSTR lpwszOskDisplayName;
-
-    /* Magnify Registry data */
-    LPCWSTR lpwszMagnifyPath;
-    LPCWSTR lpwszMagnifyDisplayName;
-} REGISTRY_DATA, *PREGISTRY_DATA;
-
-/* ENUMERATIONS ***************************************************************/
-
-typedef enum _WRITE_REGISTRY
-{
-    REGISTRY_ACCESSIBILITY,
-    REGISTRY_UTILMAN
-} WRITE_REGISTRY, *PWRITE_REGISTRY;
-
-/* DECLARATIONS ***************************************************************/
-
-/* dialog.c */
-BOOL DlgInitHandler(HWND hDlg);
-INT_PTR APIENTRY DlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
-INT ListBoxRefreshContents(VOID);
-VOID CheckUtilityState(BOOL bUtilState);
-
-/* process.c */
-DWORD GetProcessID(IN LPCWSTR lpProcessName);
-BOOL IsProcessRunning(IN LPCWSTR lpProcessName);
-BOOL LaunchProcess(LPCWSTR lpProcessName);
-BOOL CloseProcess(IN LPCWSTR lpProcessName);
-
-/* about.c */
-VOID ShowAboutDlg(HWND hDlgParent);
-INT_PTR CALLBACK AboutDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
-
-/* registry.c */
-BOOL InitAppRegKey(IN HKEY hPredefinedKey, IN LPCWSTR lpwszSubKey, OUT PHKEY phKey, OUT LPDWORD lpdwDisposition);
-BOOL QueryAppSettings(IN HKEY hKey, IN LPCWSTR lpwszSubKey, IN LPCWSTR lpwszRegValue, OUT PVOID ReturnedData, IN OUT LPDWORD lpdwSizeData);
-BOOL SaveAppSettings(IN HKEY hKey, IN LPCWSTR lpwszRegValue, IN DWORD dwRegType, IN PVOID Data, IN DWORD cbSize);
-
-/* Struct variable declaration */
-extern UTILMAN_GLOBALS Globals;
-extern REGISTRY_SETTINGS Settings;
-extern REGISTRY_DATA RegData;
+typedef BOOL (WINAPI *EXECDLGROUTINE)(VOID);
 
 #endif /* _UTILMAN_H */
 

--- a/base/applications/utilman/resource.h
+++ b/base/applications/utilman/resource.h
@@ -2,7 +2,7 @@
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Resource header file
- * COPYRIGHT:       Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 #pragma once
@@ -10,38 +10,8 @@
 #define IDC_STATIC                     -1
 
 /* Icon resource */
-#define IDI_ICON_UTILMAN               50
+#define IDI_ICON_UTILMAN               30
 
-/* List box resource */
-#define IDC_LISTBOX                    60
-
-/* Utility tools name strings */
-#define IDS_OSK                        100
-#define IDS_MAGNIFIER                  101
-
-/* Utility state strings */
-#define IDS_NOTRUNNING                 150
-#define IDS_RUNNING                    151
-
-/* Groupbox option title */
-#define IDC_GROUPBOX                   200
-#define IDS_GROUPBOX_OPTIONS_TITLE     201
-
-/* Button resources */
-#define IDC_START                      300
-#define IDC_STOP                       301
-#define IDC_OK                         302
-#define IDC_CANCEL                     303
-#define IDC_HELP_TOPICS                304
-
-/* Checkbox resources */
-#define IDC_START_LOG_IN               400
-#define IDC_START_DESKTOP              401
-#define IDC_START_UTILMAN              402
-
-/* System menu (About) resource */
-#define IDM_ABOUT                      600
-
-/* Main dialog resource */
-#define IDD_MAIN_DIALOG                1000
-#define IDD_ABOUT_DIALOG               1050
+/* Strings */
+#define IDS_FAIL_INIT                  40
+#define IDS_FAIL_INIT_TITLE            41

--- a/base/applications/utilman/umandlg/CMakeLists.txt
+++ b/base/applications/utilman/umandlg/CMakeLists.txt
@@ -1,0 +1,15 @@
+
+spec2def(umandlg.dll umandlg.spec)
+
+add_library(umandlg MODULE
+    about.c
+    process.c
+    registry.c
+    umandlg.c
+    umandlg.h
+    umandlg.rc
+    ${CMAKE_CURRENT_BINARY_DIR}/umandlg.def)
+
+set_module_type(umandlg win32dll UNICODE)
+add_importlibs(umandlg comdlg32 user32 gdi32 advapi32 shell32 comctl32 msvcrt kernel32 ntdll)
+add_cd_file(TARGET umandlg DESTINATION reactos/system32 FOR all)

--- a/base/applications/utilman/umandlg/about.c
+++ b/base/applications/utilman/umandlg/about.c
@@ -1,13 +1,13 @@
 /*
- * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         About dialog file
- * COPYRIGHT:       Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 /* INCLUDES *******************************************************************/
 
-#include "precomp.h"
+#include "umandlg.h"
 
 /* GLOBALS ********************************************************************/
 
@@ -43,12 +43,11 @@ INT_PTR CALLBACK AboutDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
     {
         case WM_INITDIALOG:
         {
-            Globals.hIcon = LoadImageW(Globals.hInstance,
-                                       MAKEINTRESOURCEW(IDI_ICON_UTILMAN),
-                                       IMAGE_ICON,
-                                       0,
-                                       0,
-                                       LR_DEFAULTSIZE);
+            WCHAR wszAppPath[MAX_BUFFER];
+
+            /* Extract the icon resource from the executable process */
+            GetModuleFileNameW(NULL, wszAppPath, _countof(wszAppPath));
+            Globals.hIcon = ExtractIconW(Globals.hInstance, wszAppPath, 0);
 
             /* Set the icon within the dialog's title bar */
             if (Globals.hIcon)

--- a/base/applications/utilman/umandlg/lang/en-US.rc
+++ b/base/applications/utilman/umandlg/lang/en-US.rc
@@ -1,0 +1,54 @@
+/*
+ * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         English (United States of America) translation resource
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_US
+
+IDD_MAIN_DIALOG DIALOGEX 0, 0, 284, 183
+STYLE DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+EXSTYLE WS_EX_CONTEXTHELP
+CAPTION "Accessibility Utility Manager"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LISTBOX IDC_LISTBOX, 4, 4, 273, 56, LBS_STANDARD | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER
+    CONTROL "", IDC_GROUPBOX, "Button", BS_GROUPBOX | WS_CHILD | WS_VISIBLE, 3, 62, 275, 92
+    CONTROL "Start", IDC_START, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 14, 76, 45, 16
+    CONTROL "Stop", IDC_STOP, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 69, 76, 45, 16
+    CONTROL "Start automatically when I log in", IDC_START_LOG_IN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 101, 206, 14 
+    CONTROL "Start automatically when I lock my desktop", IDC_START_DESKTOP, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 118, 212, 14 
+    CONTROL "Start automatically when Utility Manager starts", IDC_START_UTILMAN, "Button", BS_CHECKBOX | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 12, 134, 212, 13 
+    CONTROL "&OK", IDC_OK, "Button", BS_DEFPUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 160, 161, 50, 14 
+    CONTROL "&Cancel", IDC_CANCEL, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 221, 161, 50, 14 
+    CONTROL "&Help", IDC_HELP_TOPICS, "Button", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | WS_DISABLED | WS_TABSTOP, 98, 161, 50, 14 
+END
+
+IDD_ABOUT_DIALOG DIALOGEX 22, 16, 210, 65
+CAPTION "About Accessibility Utility Manager"
+FONT 8, "MS Shell Dlg", 0, 0
+STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
+BEGIN
+    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
+    PUSHBUTTON "Close", IDOK, 75, 47, 44, 15
+END
+
+STRINGTABLE
+BEGIN
+    IDS_OSK "On-Screen Keyboard"
+    IDS_MAGNIFIER "Magnifier"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_NOTRUNNING "%s is not running"
+    IDS_RUNNING "%s is running"
+    IDS_GROUPBOX_OPTIONS_TITLE "Options for %s"
+END
+
+STRINGTABLE
+BEGIN
+    IDM_ABOUT "About Accessibility Utility Manager..."
+END

--- a/base/applications/utilman/umandlg/lang/es-ES.rc
+++ b/base/applications/utilman/umandlg/lang/es-ES.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Spanish (Neutral) translation resource
@@ -31,9 +31,8 @@ CAPTION "Acerca de las Herramientas de Accesibilidad"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "Cerrar", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/fr-FR.rc
+++ b/base/applications/utilman/umandlg/lang/fr-FR.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         French (France) translation resource
@@ -30,9 +30,8 @@ CAPTION "A propos du gestionnaire d'utilitaires d'accessibilité"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Accessibility Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "Close", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/he-IL.rc
+++ b/base/applications/utilman/umandlg/lang/he-IL.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Hebrew (Israel) translation resource
@@ -30,9 +30,8 @@ CAPTION "אודות מנהל כלי הנגישות"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "מנהל כלי הנגישות\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "מנהל כלי הנגישות\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "סגור", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/it-IT.rc
+++ b/base/applications/utilman/umandlg/lang/it-IT.rc
@@ -30,9 +30,8 @@ CAPTION "Informazioni su Accessibilità Utility Manager"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Accessibilità Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Accessibilità Utility Manager\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "Chiudi", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/pl-PL.rc
+++ b/base/applications/utilman/umandlg/lang/pl-PL.rc
@@ -29,9 +29,8 @@ CAPTION "Menedżer narzędzi ułatwienia dostępu - informacje"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Menedżer narzędzi ułatwienia dostępu\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Menedżer narzędzi ułatwienia dostępu\nCopyright 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Copyright 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "Close", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/ro-RO.rc
+++ b/base/applications/utilman/umandlg/lang/ro-RO.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Romanian (Romania) translation resource
@@ -30,9 +30,8 @@ CAPTION "Despre Managerul utilitare"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Manager utilitare\nDrept de autor 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "Drept de autor 2019 Hermes Belusca-Maito", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Manager utilitare\nDrept de autor 2019 George Bișoc (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "Drept de autor 2019 Hermes Belusca-Maito", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "Închide", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/ru-RU.rc
+++ b/base/applications/utilman/umandlg/lang/ru-RU.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Russian (Russia) translation resource
@@ -30,9 +30,8 @@ CAPTION "О программе"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Диспетчер служебных программ\n© 2019 Джордж Бисок (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "© 2019 Гермес Белуска-Майто", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Диспетчер служебных программ\n© 2019 Джордж Бисок (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "© 2019 Гермес Белуска-Майто", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "OK", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/lang/uk-UA.rc
+++ b/base/applications/utilman/umandlg/lang/uk-UA.rc
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Ukrainian (Ukraine) translation resource
@@ -30,9 +30,8 @@ CAPTION "Про программу"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | DS_MODALFRAME
 BEGIN
-    ICON IDI_ICON_UTILMAN, IDC_STATIC, 10, 10, 7, 30
-    LTEXT "Диспетчер службових програм\n© 2019 Джордж Бісок (fraizeraust99 at gmail dot com)", IDC_STATIC, 48, 7, 150, 36
-    LTEXT "© 2019 Гермес Белуска-Майто", IDC_STATIC, 48, 33, 150, 36
+    LTEXT "Диспетчер службових програм\n© 2019 Джордж Бісок (fraizeraust99 at gmail dot com)", IDC_STATIC, 10, 7, 150, 36
+    LTEXT "© 2019 Гермес Белуска-Майто", IDC_STATIC, 10, 33, 150, 36
     PUSHBUTTON "OK", IDOK, 75, 47, 44, 15
 END
 

--- a/base/applications/utilman/umandlg/process.c
+++ b/base/applications/utilman/umandlg/process.c
@@ -1,13 +1,13 @@
 /*
- * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Process handling functions
- * COPYRIGHT:       Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 /* INCLUDES *******************************************************************/
 
-#include "precomp.h"
+#include "umandlg.h"
 
 /* FUNCTIONS ******************************************************************/
 

--- a/base/applications/utilman/umandlg/registry.c
+++ b/base/applications/utilman/umandlg/registry.c
@@ -1,5 +1,5 @@
 /*
- * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Registry functions for Utility Manager settings management
  * COPYRIGHT:       Copyright 2020 Bișoc George (fraizeraust99 at gmail dot com)
@@ -7,7 +7,7 @@
 
 /* INCLUDES *******************************************************************/
 
-#include "precomp.h"
+#include "umandlg.h"
 
 /* GLOBALS ********************************************************************/
 

--- a/base/applications/utilman/umandlg/resource.h
+++ b/base/applications/utilman/umandlg/resource.h
@@ -1,0 +1,44 @@
+/*
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         Resource header file
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+#pragma once
+
+#define IDC_STATIC                     -1
+
+/* List box resource */
+#define IDC_LISTBOX                    60
+
+/* Utility tools name strings */
+#define IDS_OSK                        100
+#define IDS_MAGNIFIER                  101
+
+/* Utility state strings */
+#define IDS_NOTRUNNING                 150
+#define IDS_RUNNING                    151
+
+/* Groupbox option title */
+#define IDC_GROUPBOX                   200
+#define IDS_GROUPBOX_OPTIONS_TITLE     201
+
+/* Button resources */
+#define IDC_START                      300
+#define IDC_STOP                       301
+#define IDC_OK                         302
+#define IDC_CANCEL                     303
+#define IDC_HELP_TOPICS                304
+
+/* Checkbox resources */
+#define IDC_START_LOG_IN               400
+#define IDC_START_DESKTOP              401
+#define IDC_START_UTILMAN              402
+
+/* System menu (About) resource */
+#define IDM_ABOUT                      600
+
+/* Main dialog resource */
+#define IDD_MAIN_DIALOG                1000
+#define IDD_ABOUT_DIALOG               1050

--- a/base/applications/utilman/umandlg/umandlg.h
+++ b/base/applications/utilman/umandlg/umandlg.h
@@ -1,0 +1,121 @@
+/*
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         DLL header file
+ * COPYRIGHT:       Copyright 2020 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+#ifndef _UMANDLG_H
+#define _UMANDLG_H
+
+/* INCLUDES ******************************************************************/
+
+#include <stdlib.h>
+#include <windows.h>
+#include <commctrl.h>
+#include <tlhelp32.h>
+#include <windowsx.h>
+#include <debug.h>
+#include <wchar.h>
+#include <strsafe.h>
+
+#include "resource.h"
+
+/* DEFINES ********************************************************************/
+
+#define MAX_BUFFER 256
+
+/* TYPES **********************************************************************/
+
+typedef struct
+{
+    HINSTANCE hInstance;
+    HICON     hIcon;
+    UINT_PTR  iTimer;
+    INT       iSelectedIndex;
+    HWND      hDlgCtlStart;
+    HWND      hDlgCtlStop;
+    HWND      hListDlg;
+    HWND      hMainDlg;
+    WCHAR     szRunning[MAX_BUFFER];
+    WCHAR     szNotRunning[MAX_BUFFER];
+    WCHAR     szGrpBoxTitle[MAX_BUFFER];
+} UTILMAN_GLOBALS;
+
+typedef struct _UTILMAN_STATE
+{
+    LPCWSTR lpProgram;
+    UINT    uNameId;
+    WCHAR   szResource[MAX_BUFFER];
+    BOOL    bState;
+} UTILMAN_STATE, *PUTILMAN_STATE;
+
+typedef struct _REGISTRY_SETTINGS
+{
+    /* Accessibility Registry settings */
+    LPCWSTR wszAppPath;
+    DWORD dwAppType;
+    DWORD dwClientControlCode;
+    LPCWSTR wszAppName;
+    LPCWSTR wszErrorOnLaunch;
+    BOOL bHideClient;
+    BOOL bStartWithUtilman;
+    BOOL bStartWithROS;
+    LPCWSTR wszHungRespondAction;
+    DWORD dwHungTimeOut;
+
+    /* Utility Manager Registry settings */
+    BOOL bShowWarning;
+} REGISTRY_SETTINGS, *PREGISTRY_SETTINGS;
+
+typedef struct _REGISTRY_DATA
+{
+    /* On-Screen Keyboard Registry data */
+    LPCWSTR lpwsOskPath;
+    LPCWSTR lpwszOskDisplayName;
+
+    /* Magnify Registry data */
+    LPCWSTR lpwszMagnifyPath;
+    LPCWSTR lpwszMagnifyDisplayName;
+} REGISTRY_DATA, *PREGISTRY_DATA;
+
+/* ENUMERATIONS ***************************************************************/
+
+typedef enum _WRITE_REGISTRY
+{
+    REGISTRY_ACCESSIBILITY,
+    REGISTRY_UTILMAN
+} WRITE_REGISTRY, *PWRITE_REGISTRY;
+
+/* DECLARATIONS ***************************************************************/
+
+/* umandlg.c */
+BOOL DlgInitHandler(HWND hDlg);
+INT_PTR APIENTRY DlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
+INT ListBoxRefreshContents(VOID);
+VOID CheckUtilityState(BOOL bUtilState);
+BOOL WINAPI UManStartDlg(VOID);
+
+/* process.c */
+DWORD GetProcessID(IN LPCWSTR lpProcessName);
+BOOL IsProcessRunning(IN LPCWSTR lpProcessName);
+BOOL LaunchProcess(LPCWSTR lpProcessName);
+BOOL CloseProcess(IN LPCWSTR lpProcessName);
+
+/* about.c */
+VOID ShowAboutDlg(HWND hDlgParent);
+INT_PTR CALLBACK AboutDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam);
+
+/* registry.c */
+BOOL InitAppRegKey(IN HKEY hPredefinedKey, IN LPCWSTR lpwszSubKey, OUT PHKEY phKey, OUT LPDWORD lpdwDisposition);
+BOOL QueryAppSettings(IN HKEY hKey, IN LPCWSTR lpwszSubKey, IN LPCWSTR lpwszRegValue, OUT PVOID ReturnedData, IN OUT LPDWORD lpdwSizeData);
+BOOL SaveAppSettings(IN HKEY hKey, IN LPCWSTR lpwszRegValue, IN DWORD dwRegType, IN PVOID Data, IN DWORD cbSize);
+
+/* Struct variable declaration */
+extern UTILMAN_GLOBALS Globals;
+extern REGISTRY_SETTINGS Settings;
+extern REGISTRY_DATA RegData;
+
+#endif /* UMANDLG_H_ */
+
+/* EOF */

--- a/base/applications/utilman/umandlg/umandlg.rc
+++ b/base/applications/utilman/umandlg/umandlg.rc
@@ -1,0 +1,54 @@
+/*
+ * PROJECT:         ReactOS Utility Manager Resources DLL (UManDlg.dll)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         Main DLL resource file
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <windef.h>
+#include <winuser.h>
+#include "resource.h"
+
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
+#define REACTOS_STR_FILE_DESCRIPTION    "ReactOS Accessibility Utility Manager Resources DLL"
+#define REACTOS_STR_INTERNAL_NAME       "UManDlg"
+#define REACTOS_STR_ORIGINAL_FILENAME   "UManDlg.dll"
+#include <reactos/version.rc>
+
+#include <reactos/manifest_exe.rc>
+
+/* UTF-8 */
+#pragma code_page(65001)
+
+#ifdef LANGUAGE_EN_US
+    #include "lang/en-US.rc"
+#endif
+#ifdef LANGUAGE_ES_ES
+    #include "lang/es-ES.rc"
+#endif
+#ifdef LANGUAGE_FR_FR
+    #include "lang/fr-FR.rc"
+#endif
+#ifdef LANGUAGE_HE_IL
+    #include "lang/he-IL.rc"
+#endif
+#ifdef LANGUAGE_IT_IT
+    #include "lang/it-IT.rc"
+#endif
+#ifdef LANGUAGE_PL_PL
+    #include "lang/pl-PL.rc"
+#endif
+#ifdef LANGUAGE_RO_RO
+    #include "lang/ro-RO.rc"
+#endif
+#ifdef LANGUAGE_RU_RU
+    #include "lang/ru-RU.rc"
+#endif
+#ifdef LANGUAGE_UK_UA
+    #include "lang/uk-UA.rc"
+#endif
+
+/* EOF */

--- a/base/applications/utilman/umandlg/umandlg.spec
+++ b/base/applications/utilman/umandlg/umandlg.spec
@@ -1,0 +1,1 @@
+1 stdcall UManStartDlg()

--- a/base/applications/utilman/utilman.c
+++ b/base/applications/utilman/utilman.c
@@ -1,0 +1,68 @@
+/*
+ * PROJECT:         ReactOS Utility Manager (Accessibility)
+ * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:         Main dialog code file
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include "precomp.h"
+
+/* FUNCTIONS ******************************************************************/
+
+/**
+ * @wWinMain
+ *
+ * Application entry point.
+ *
+ * @param[in]   hInstance
+ *     Application instance.
+ *
+ * @param[in]   hPrevInstance
+ *     The previous instance of the application (not used).
+ *
+ * @param[in]   pCmdLine
+ *     Pointer to a command line argument (in wide string -- not used).
+ *
+ * @param[in]   nCmdShow
+ *     An integer served as a flag to note how the application will be shown (not used).
+ *
+ * @return
+ *     Returns 0 to let the function terminating before it enters in the message loop.
+ *
+ */
+INT WINAPI wWinMain(IN HINSTANCE hInstance,
+                    IN HINSTANCE hPrevInstance,
+                    IN LPWSTR pCmdLine,
+                    IN INT nCmdShow)
+{
+    HMODULE hModule;
+    WCHAR wszFormat[MAX_BUFFER];
+    WCHAR wszFailLoad[MAX_BUFFER];
+    WCHAR wszTitle[MAX_BUFFER];
+    EXECDLGROUTINE UManStartDlg;
+
+    UNREFERENCED_PARAMETER(hPrevInstance);
+    UNREFERENCED_PARAMETER(pCmdLine);
+    UNREFERENCED_PARAMETER(nCmdShow);
+
+    /* Load the main resources module of Utility Manager */
+    hModule = LoadLibraryW(L"UManDlg.dll");
+    if (!hModule)
+    {
+        LoadStringW(hInstance, IDS_FAIL_INIT, wszFormat, _countof(wszFormat));
+        LoadStringW(hInstance, IDS_FAIL_INIT_TITLE, wszTitle, _countof(wszTitle));
+
+        StringCchPrintfW(wszFailLoad, _countof(wszFailLoad), wszFormat, GetLastError());
+        MessageBoxW(GetDesktopWindow(), wszFailLoad, wszTitle, MB_ICONERROR | MB_OK);
+        return -1;
+    }
+
+    /* Get the function address and launch Utility Manager */
+    UManStartDlg = (EXECDLGROUTINE)GetProcAddress(hModule, "UManStartDlg");
+    UManStartDlg();
+
+    FreeLibrary(hModule);
+    return 0;
+}

--- a/base/applications/utilman/utilman.rc
+++ b/base/applications/utilman/utilman.rc
@@ -2,7 +2,7 @@
  * PROJECT:         ReactOS Utility Manager (Accessibility)
  * LICENSE:         GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:         Main resource file
- * COPYRIGHT:       Copyright 2019 Bișoc George (fraizeraust99 at gmail dot com)
+ * COPYRIGHT:       Copyright 2019-2020 Bișoc George (fraizeraust99 at gmail dot com)
  */
 
 /* INCLUDES ******************************************************************/
@@ -27,30 +27,6 @@ IDI_ICON_UTILMAN ICON "res/utilman.ico"
 
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
-#endif
-#ifdef LANGUAGE_ES_ES
-    #include "lang/es-ES.rc"
-#endif
-#ifdef LANGUAGE_FR_FR
-    #include "lang/fr-FR.rc"
-#endif
-#ifdef LANGUAGE_HE_IL
-    #include "lang/he-IL.rc"
-#endif
-#ifdef LANGUAGE_IT_IT
-    #include "lang/it-IT.rc"
-#endif
-#ifdef LANGUAGE_PL_PL
-    #include "lang/pl-PL.rc"
-#endif
-#ifdef LANGUAGE_RO_RO
-    #include "lang/ro-RO.rc"
-#endif
-#ifdef LANGUAGE_RU_RU
-    #include "lang/ru-RU.rc"
-#endif
-#ifdef LANGUAGE_UK_UA
-    #include "lang/uk-UA.rc"
 #endif
 
 /* EOF */


### PR DESCRIPTION
## Purpose
Utility Manager has its own library which contains all the needed resources and stuff. The PR implements that library and move the dialog management and other chunks of code there.