### PR TITLE
[TRAVIS] Fix inconsistent git clone depth in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       clang-format-9
 
 git:
-  depth: 1
+  depth: 5
 
 env:
   global:


### PR DESCRIPTION
## Purpose

Inconsistent git clone depth in CI.
For Travis = 1
For AppVeyor = 5

## Proposed changes

Version A - update Travis to depth 5

Please see Version B: https://github.com/reactos/reactos/pull/2533