### PR TITLE
Inconsistent git clone depth in CI - version B - AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
 
 version: reactos.appveyor.{build}
 skip_branch_with_pr: true
-clone_depth: 5
+clone_depth: 1
 clone_folder: c:\reactos-cov
 matrix:
   fast_finish: true


### PR DESCRIPTION
## Purpose

Inconsistent git clone depth in CI.
For Travis = 1
For AppVeyor = 5

## Proposed changes

Version B - update AppVeyor to depth 1

Please see Version A: https://github.com/reactos/reactos/pull/2532