### PR TITLE
[CHARMAP] Updates to behaviour and UI

### DIFF
--- a/base/applications/charmap/charmap.c
+++ b/base/applications/charmap/charmap.c
@@ -276,6 +276,8 @@ ChangeView(HWND hWnd)
     RECT rcCharmap;
 #ifndef REMOVE_ADVANCED
     RECT rcAdvanced;
+#else
+    RECT rcCopy;
 #endif
     RECT rcPanelExt;
     RECT rcPanelInt;
@@ -284,10 +286,16 @@ ChangeView(HWND hWnd)
     UINT xPos, yPos;
     UINT Width, Height;
     UINT DeskTopWidth, DeskTopHeight;
+#ifdef REMOVE_ADVANCED
+    HWND hCopy;
+#endif
 
     GetClientRect(hCharmapDlg, &rcCharmap);
 #ifndef REMOVE_ADVANCED
     GetClientRect(hAdvancedDlg, &rcAdvanced);
+#else
+    hCopy = GetDlgItem(hCharmapDlg, IDC_COPY);
+    GetClientRect(hCopy, &rcCopy);
 #endif
     GetWindowRect(hWnd, &rcPanelExt);
     GetClientRect(hWnd, &rcPanelInt);
@@ -312,6 +320,10 @@ ChangeView(HWND hWnd)
 #ifndef REMOVE_ADVANCED
     if (Settings.IsAdvancedView)
         Height += rcAdvanced.bottom;
+#else
+    /* The lack of advanced button leaves an empty gap at the bottom of the window.
+       Shrink the window height a bit here to accomodate for that lost control. */
+    Height = rcCharmap.bottom + rcCopy.bottom + 10;
 #endif
     if ((xPos + Width) > DeskTopWidth)
         xPos += DeskTopWidth - (xPos + Width);

--- a/base/applications/charmap/map.c
+++ b/base/applications/charmap/map.c
@@ -256,7 +256,7 @@ SetFont(PMAP infoPtr,
                          GGI_MARK_NONEXISTING_GLYPHS) != GDI_ERROR)
     {
         j = 0;
-        for (i = 0; i < MAX_GLYPHS; i++)
+        for (i = ' ' + 1; i < MAX_GLYPHS; i++)
         {
             if (out[i] != 0xffff)
             {

--- a/base/applications/charmap/map.c
+++ b/base/applications/charmap/map.c
@@ -324,12 +324,12 @@ OnClick(PMAP infoPtr,
         if (infoPtr->pActiveCell)
         {
             /* invalidate normal cells, required when
-                * moving a small active cell via keyboard */
+             * moving a small active cell via keyboard */
             if (!infoPtr->pActiveCell->bLarge)
             {
                 InvalidateRect(infoPtr->hMapWnd,
-                                &infoPtr->pActiveCell->CellInt,
-                                TRUE);
+                               &infoPtr->pActiveCell->CellInt,
+                               TRUE);
             }
 
             infoPtr->pActiveCell->bActive = FALSE;
@@ -556,8 +556,8 @@ MapWndProc(HWND hwnd,
             if (wParam & MK_LBUTTON)
             {
                 OnClick(infoPtr,
-                    LOWORD(lParam),
-                    HIWORD(lParam));
+                        LOWORD(lParam),
+                        HIWORD(lParam));
             }
             break;
         }

--- a/base/applications/charmap/map.c
+++ b/base/applications/charmap/map.c
@@ -312,64 +312,38 @@ OnClick(PMAP infoPtr,
         WORD ptx,
         WORD pty)
 {
-    POINT pt;
     INT x, y;
 
-    pt.x = ptx;
-    pt.y = pty;
+    x = ptx / max(1, infoPtr->CellSize.cx);
+    y = pty / max(1, infoPtr->CellSize.cy);
 
-    for (x = 0; x < XCELLS; x++)
-    for (y = 0; y < YCELLS; y++)
+    /* if the cell is not already active */
+    if (!infoPtr->Cells[y][x].bActive)
     {
-        if (PtInRect(&infoPtr->Cells[y][x].CellInt,
-                     pt))
+        /* set previous active cell to inactive */
+        if (infoPtr->pActiveCell)
         {
-            /* if the cell is not already active */
-            if (!infoPtr->Cells[y][x].bActive)
+            /* invalidate normal cells, required when
+                * moving a small active cell via keyboard */
+            if (!infoPtr->pActiveCell->bLarge)
             {
-                /* set previous active cell to inactive */
-                if (infoPtr->pActiveCell)
-                {
-                    /* invalidate normal cells, required when
-                     * moving a small active cell via keyboard */
-                    if (!infoPtr->pActiveCell->bLarge)
-                    {
-                        InvalidateRect(infoPtr->hMapWnd,
-                                       &infoPtr->pActiveCell->CellInt,
-                                       TRUE);
-                    }
-
-                    infoPtr->pActiveCell->bActive = FALSE;
-                    infoPtr->pActiveCell->bLarge = FALSE;
-                }
-
-                /* set new cell to active */
-                infoPtr->pActiveCell = &infoPtr->Cells[y][x];
-                infoPtr->pActiveCell->bActive = TRUE;
-                infoPtr->pActiveCell->bLarge = TRUE;
-                if (infoPtr->hLrgWnd)
-                    MoveLargeCell(infoPtr);
-                else
-                    CreateLargeCell(infoPtr);
-            }
-            else
-            {
-                /* flick between large and small */
-                if (infoPtr->pActiveCell->bLarge)
-                {
-                    DestroyWindow(infoPtr->hLrgWnd);
-                    infoPtr->hLrgWnd = NULL;
-                }
-                else
-                {
-                    CreateLargeCell(infoPtr);
-                }
-
-                infoPtr->pActiveCell->bLarge = (infoPtr->pActiveCell->bLarge) ? FALSE : TRUE;
+                InvalidateRect(infoPtr->hMapWnd,
+                                &infoPtr->pActiveCell->CellInt,
+                                TRUE);
             }
 
-            break;
+            infoPtr->pActiveCell->bActive = FALSE;
+            infoPtr->pActiveCell->bLarge = FALSE;
         }
+
+        /* set new cell to active */
+        infoPtr->pActiveCell = &infoPtr->Cells[y][x];
+        infoPtr->pActiveCell->bActive = TRUE;
+        infoPtr->pActiveCell->bLarge = TRUE;
+        if (infoPtr->hLrgWnd)
+            MoveLargeCell(infoPtr);
+        else
+            CreateLargeCell(infoPtr);
     }
 }
 
@@ -577,12 +551,30 @@ MapWndProc(HWND hwnd,
             break;
         }
 
+        case WM_MOUSEMOVE:
+        {
+            if (wParam & MK_LBUTTON)
+            {
+                OnClick(infoPtr,
+                    LOWORD(lParam),
+                    HIWORD(lParam));
+            }
+            break;
+        }
+
         case WM_LBUTTONDBLCLK:
         {
             NotifyParentOfSelection(infoPtr,
                                     FM_SETCHAR,
                                     infoPtr->pActiveCell->ch);
 
+            if (infoPtr->pActiveCell->bLarge)
+            {
+                DestroyWindow(infoPtr->hLrgWnd);
+                infoPtr->hLrgWnd = NULL;
+            }
+
+            infoPtr->pActiveCell->bLarge = FALSE;
 
             break;
         }


### PR DESCRIPTION
## Purpose

This pull request updates charmap to look a bit better (removes gap at bottom of the window), removes the blank space character (0x0020) from the charmap, and also modifies the behaviour of when a larger glyph is rendered (allowing the user to select a new glyph by holding down the mouse button).  This better mimics the charmap.exe that is bundled by Microsoft.

## Proposed changes

- Remove gap where the advanced button is normally rendered when compiled with REMOVE_ADVANCED (which is the default behaviour)
- Skip over the blank space character
- Change behaviour of rendering large glyphs to allow mouse move, and to hide on double click
- Optimize search for glyph under the mouse by using the cellSize instead of PtInRect

## Before

![before](https://user-images.githubusercontent.com/3923687/79079313-3fdaeb00-7cc3-11ea-8fd9-cfe59a422c6e.png)

## After

![after](https://user-images.githubusercontent.com/3923687/79079318-44070880-7cc3-11ea-97a5-273de079f51b.png)
