### PR TITLE
[COMCTL32 and SHELL32] Add basic snap-to-grid

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -8992,6 +8992,12 @@ static BOOL LISTVIEW_SetItemPosition(LISTVIEW_INFO *infoPtr, INT nItem, const PO
     if (!pt || nItem < 0 || nItem >= infoPtr->nItemCount ||
 	!(infoPtr->uView == LV_VIEW_ICON || infoPtr->uView == LV_VIEW_SMALLICON)) return FALSE;
 
+#ifdef __REACTOS__
+    /* FIXME:  This should really call snap to grid if auto-arrange is enabled
+       and limit the size of the grid to nItemCount elements */
+    if (is_autoarrange(infoPtr)) return FALSE;
+#endif
+
     Pt = *pt;
     LISTVIEW_GetOrigin(infoPtr, &Origin);
 

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -2723,11 +2723,16 @@ static DWORD LISTVIEW_MapIndexToId(const LISTVIEW_INFO *infoPtr, INT iItem)
  * PARAMETER(S):
  * [I] infoPtr : valid pointer to the listview structure
  * [O] lpPos : will get the current icon position
+ * [I] nItem : item id to get position for
  *
  * RETURN:
  * None
  */
+#ifdef __REACTOS__
+static void LISTVIEW_NextIconPosTop(LISTVIEW_INFO *infoPtr, LPPOINT lpPos, INT nItem)
+#else
 static void LISTVIEW_NextIconPosTop(LISTVIEW_INFO *infoPtr, LPPOINT lpPos)
+#endif
 {
     INT nListWidth = infoPtr->rcList.right - infoPtr->rcList.left;
     
@@ -2749,11 +2754,16 @@ static void LISTVIEW_NextIconPosTop(LISTVIEW_INFO *infoPtr, LPPOINT lpPos)
  * PARAMETER(S):
  * [I] infoPtr : valid pointer to the listview structure
  * [O] lpPos : will get the current icon position
+ * [I] nItem : item id to get position for
  *
  * RETURN:
  * None
  */
+#ifdef __REACTOS__
+static void LISTVIEW_NextIconPosLeft(LISTVIEW_INFO *infoPtr, LPPOINT lpPos, INT nItem)
+#else
 static void LISTVIEW_NextIconPosLeft(LISTVIEW_INFO *infoPtr, LPPOINT lpPos)
+#endif
 {
     INT nListHeight = infoPtr->rcList.bottom - infoPtr->rcList.top;
     
@@ -2766,7 +2776,45 @@ static void LISTVIEW_NextIconPosLeft(LISTVIEW_INFO *infoPtr, LPPOINT lpPos)
     infoPtr->currIconPos.y  = 0;
 }
 
-    
+
+#ifdef __REACTOS__
+/***
+ * DESCRIPTION:
+ * Returns the grid position closest to the already placed icon.
+ * The returned position is not offset by Origin.
+ *
+ * PARAMETER(S):
+ * [I] infoPtr : valid pointer to the listview structure
+ * [O] lpPos : will get the current icon position
+ * [I] nItem : item id to get position for
+ *
+ * RETURN:
+ * None
+ */
+static void LISTVIEW_NextIconPosSnap(LISTVIEW_INFO *infoPtr, LPPOINT lpPos, INT nItem)
+{
+    INT nListHeight = infoPtr->rcList.bottom - infoPtr->rcList.top;
+    INT nListWidth = infoPtr->rcList.right - infoPtr->rcList.left;
+    INT nMaxColumns = nListWidth / infoPtr->nItemWidth;
+    INT nMaxRows = nListHeight / infoPtr->nItemHeight;
+    POINT oldPosition;
+
+    // get the existing x and y position and then snap to the closest grid square
+    oldPosition.x = (LONG_PTR)DPA_GetPtr(infoPtr->hdpaPosX, nItem);
+    oldPosition.y = (LONG_PTR)DPA_GetPtr(infoPtr->hdpaPosY, nItem);
+
+    // FIXME: This could should deal with multiple icons in the same grid square
+    // equivalent of max(0, round(oldPosition / itemSize) * itemSize), but without need for 'round' function
+    (*lpPos).x = max(0, oldPosition.x + (infoPtr->nItemWidth >> 1) - (oldPosition.x + (infoPtr->nItemWidth >> 1)) % infoPtr->nItemWidth);
+    (*lpPos).y = max(0, oldPosition.y + (infoPtr->nItemHeight >> 1) - (oldPosition.y + (infoPtr->nItemHeight >> 1)) % infoPtr->nItemHeight);
+
+    // deal with any icons that have gone out of range
+    if ((*lpPos).x > nListWidth) (*lpPos).x = nMaxColumns * infoPtr->nItemWidth;
+    if ((*lpPos).y > nListHeight) (*lpPos).y = nMaxRows * infoPtr->nItemHeight;
+}
+#endif
+
+
 /***
  * DESCRIPTION:
  * Moves an icon to the specified position.
@@ -2819,7 +2867,11 @@ static BOOL LISTVIEW_MoveIconTo(const LISTVIEW_INFO *infoPtr, INT nItem, const P
  */
 static BOOL LISTVIEW_Arrange(LISTVIEW_INFO *infoPtr, INT nAlignCode)
 {
+#ifdef __REACTOS__
+    void (*next_pos)(LISTVIEW_INFO *, LPPOINT, INT);
+#else
     void (*next_pos)(LISTVIEW_INFO *, LPPOINT);
+#endif
     POINT pos;
     INT i;
 
@@ -2837,14 +2889,22 @@ static BOOL LISTVIEW_Arrange(LISTVIEW_INFO *infoPtr, INT nAlignCode)
     {
     case LVA_ALIGNLEFT:  next_pos = LISTVIEW_NextIconPosLeft; break;
     case LVA_ALIGNTOP:   next_pos = LISTVIEW_NextIconPosTop;  break;
+#ifdef __REACTOS__
+    case LVA_SNAPTOGRID: next_pos = LISTVIEW_NextIconPosSnap; break;
+#else
     case LVA_SNAPTOGRID: next_pos = LISTVIEW_NextIconPosTop;  break; /* FIXME */
+#endif
     default: return FALSE;
     }
     
     infoPtr->currIconPos.x = infoPtr->currIconPos.y = 0;
     for (i = 0; i < infoPtr->nItemCount; i++)
     {
-	next_pos(infoPtr, &pos);
+#ifdef __REACTOS__
+    next_pos(infoPtr, &pos, i);
+#else
+    next_pos(infoPtr, &pos);
+#endif
 	LISTVIEW_MoveIconTo(infoPtr, i, &pos, FALSE);
     }
 
@@ -7978,10 +8038,17 @@ static INT LISTVIEW_InsertItemT(LISTVIEW_INFO *infoPtr, const LVITEMW *lpLVItem,
     {
 	POINT pt;
 
+#ifdef __REACTOS__
 	if (infoPtr->dwStyle & LVS_ALIGNLEFT)
+	    LISTVIEW_NextIconPosLeft(infoPtr, &pt, nItem);
+        else
+	    LISTVIEW_NextIconPosTop(infoPtr, &pt, nItem);
+#else
+    if (infoPtr->dwStyle & LVS_ALIGNLEFT)
 	    LISTVIEW_NextIconPosLeft(infoPtr, &pt);
         else
 	    LISTVIEW_NextIconPosTop(infoPtr, &pt);
+#endif
 
 	LISTVIEW_MoveIconTo(infoPtr, nItem, &pt, TRUE);
     }

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1768,7 +1768,7 @@ LRESULT CDefView::OnCommand(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHand
             break;
 
         case FCIDM_SHVIEW_SNAPTOGRID:
-            //FIXME
+            m_ListView.Arrange(LVA_SNAPTOGRID);
             break;
         case FCIDM_SHVIEW_AUTOARRANGE:
             if (GetAutoArrange() == S_OK)


### PR DESCRIPTION
## Purpose

This pull request improves the behaviour of the listview used by the shell32 file explorer to more closely mimic what a user would expect (do not allow icons to be moved when auto-arrange is enabled).  This pull request also provides a (dumb) version of snap-to-grid for the listview control and hooks up the 'line up icons' context menu item in shell32.

## Proposed changes

- [COMCTL32 listview] Do not allow user to move icons when auto-arrange is enabled.
- [COMCTL32 listview] Implement a basic snap to grid layout scheme (moves icon to closest grid location, does not deal with stacked icons for now).
- [SHELL32] Hook up 'Line up Icons' context menu item and have it fire Arrange(LVA_SNAPTOGRID).

## TODO

I think the pull request as-is (after review and any fixes) takes a good step in the right direction, and I would like to continue to improve snap-to-grid and shell32 icon layout in general with future pull requests.  Here is what I am thinking, and would love feedback on:

- Discuss possibility of saving auto-arrange state to registry somewhere.  Where?
- Improve snap-to-grid functionality to deal with multiple icons on the same grid location.
- To perfectly mimic Windows the user should be able to move icons even when auto-arrange is enabled, they should just automatically snap to grid and the grid should be the minimum size.
- Actually auto-arrange based on different sort criteria.

## Before 'Line Up Icons'
![before](https://user-images.githubusercontent.com/3923687/79363778-33da6d80-7efd-11ea-997b-b9b8dd49dc48.png)

## After 'Line Up Icons'
![after](https://user-images.githubusercontent.com/3923687/79363789-38068b00-7efd-11ea-82d2-5aebb908116a.png)
