### PR TITLE
Implement LdrpRecordUnloadEvent

### DIFF
--- a/dll/ntdll/include/ntdllp.h
+++ b/dll/ntdll/include/ntdllp.h
@@ -159,6 +159,9 @@ VOID NTAPI
 LdrpFreeUnicodeString(PUNICODE_STRING String);
 
 VOID NTAPI
+LdrpRecordUnloadEvent(_In_ PLDR_DATA_TABLE_ENTRY LdrEntry);
+
+VOID NTAPI
 LdrpGetShimEngineInterface(VOID);
 
 VOID

--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -1449,8 +1449,7 @@ LdrUnloadDll(IN PVOID BaseAddress)
         /* Get the current entry */
         LdrEntry = CONTAINING_RECORD(NextEntry, LDR_DATA_TABLE_ENTRY, HashLinks);
 
-        /* FIXME: Log the Unload Event */
-        //LdrpRecordUnloadEvent(LdrEntry);
+        LdrpRecordUnloadEvent(LdrEntry);
 
         /* Set the entry and clear it from the list */
         CurrentEntry = LdrEntry;

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -58,6 +58,7 @@ list(APPEND SOURCE
     RtlGetLengthWithoutTrailingPathSeperators.c
     RtlGetLongestNtPathLength.c
     RtlGetNtProductType.c
+    RtlGetUnloadEventTrace.c
     RtlHandle.c
     RtlImageRvaToVa.c
     RtlIsNameLegalDOS8Dot3.c

--- a/modules/rostests/apitests/ntdll/RtlGetUnloadEventTrace.c
+++ b/modules/rostests/apitests/ntdll/RtlGetUnloadEventTrace.c
@@ -1,0 +1,83 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for RtlGetUnloadEventTrace
+ * COPYRIGHT:   Copyright 2020 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#include "precomp.h"
+
+PRTL_UNLOAD_EVENT_TRACE
+NTAPI
+RtlGetUnloadEventTrace(VOID);
+
+#ifndef _WIN64
+C_ASSERT(sizeof(RTL_UNLOAD_EVENT_TRACE) == 84);
+C_ASSERT(sizeof(RTL_UNLOAD_EVENT_TRACE) * RTL_UNLOAD_EVENT_TRACE_NUMBER == 0x540);
+#endif
+
+static void Test_Dump()
+{
+    PRTL_UNLOAD_EVENT_TRACE TraceHead, Trace;
+    UINT n;
+
+    TraceHead = RtlGetUnloadEventTrace();
+    for (n = 0; n < RTL_UNLOAD_EVENT_TRACE_NUMBER; ++n)
+    {
+        ULONG ExpectSequence = n ? n : RTL_UNLOAD_EVENT_TRACE_NUMBER;
+
+        Trace = TraceHead + n;
+
+        ok(Trace->BaseAddress != NULL, "Got no BaseAddress for %u\n", n);
+        ok(Trace->SizeOfImage != 0, "Got no SizeOfImage for %u\n", n);
+        ok(Trace->Sequence == ExpectSequence,
+           "Wrong Sequence: %lu instead of %lu for %u\n", Trace->Sequence, ExpectSequence, n);
+        ok(Trace->TimeDateStamp != 0, "Got no TimeDateStamp for %u\n", n);
+        ok(Trace->CheckSum != 0, "Got no CheckSum for %u\n", n);
+        ok(!wcscmp(Trace->ImageName, L"GetUName.dLl"), "Wrong ImageName for %u: %S\n", n, Trace->ImageName);
+    }
+}
+
+#define TESTDLL "GetUName.dLl"
+static void Test_LoadUnload()
+{
+    HMODULE mod;
+    static char Buffer[MAX_PATH] = {0};
+
+    mod = GetModuleHandleA(TESTDLL);
+    ok(mod == NULL, "ERROR, %s already loaded\n", TESTDLL);
+
+    mod = LoadLibraryA(Buffer[0] ? Buffer :TESTDLL);
+    ok(mod != NULL, "ERROR, %s not loaded\n", TESTDLL);
+
+    if (!Buffer[0])
+    {
+        GetModuleFileNameA(mod, Buffer, _countof(Buffer));
+    }
+    else
+    {
+        Buffer[0] = '\0';
+    }
+
+    FreeLibrary(mod);
+
+    mod = GetModuleHandleA(TESTDLL);
+    ok(mod == NULL, "ERROR, %s still loaded\n", TESTDLL);
+}
+
+START_TEST(RtlGetUnloadEventTrace)
+{
+    int n;
+    HMODULE Ignore;
+
+    Ignore = LoadLibrary("user32.dll");
+
+    for (n = 0; n <= RTL_UNLOAD_EVENT_TRACE_NUMBER; ++n)
+    {
+        trace("Num: %u\n", n);
+        Test_LoadUnload();
+    }
+    Test_Dump();
+
+    FreeLibrary(Ignore);
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -57,6 +57,7 @@ extern void func_RtlGetFullPathName_UstrEx(void);
 extern void func_RtlGetLengthWithoutTrailingPathSeperators(void);
 extern void func_RtlGetLongestNtPathLength(void);
 extern void func_RtlGetNtProductType(void);
+extern void func_RtlGetUnloadEventTrace(void);
 extern void func_RtlHandle(void);
 extern void func_RtlImageRvaToVa(void);
 extern void func_RtlIsNameLegalDOS8Dot3(void);
@@ -128,6 +129,7 @@ const struct test winetest_testlist[] =
     { "RtlGetLengthWithoutTrailingPathSeperators", func_RtlGetLengthWithoutTrailingPathSeperators },
     { "RtlGetLongestNtPathLength",      func_RtlGetLongestNtPathLength },
     { "RtlGetNtProductType",            func_RtlGetNtProductType },
+    { "RtlGetUnloadEventTrace",         func_RtlGetUnloadEventTrace },
     { "RtlHandle",                      func_RtlHandle },
     { "RtlImageRvaToVa",                func_RtlImageRvaToVa },
     { "RtlIsNameLegalDOS8Dot3",         func_RtlIsNameLegalDOS8Dot3 },

--- a/sdk/include/ndk/rtltypes.h
+++ b/sdk/include/ndk/rtltypes.h
@@ -1226,7 +1226,7 @@ typedef struct _RTL_FLS_DATA
 //
 // Unload Event Trace Structure for RtlGetUnloadEventTrace
 //
-#define RTL_UNLOAD_EVENT_TRACE_NUMBER 64
+#define RTL_UNLOAD_EVENT_TRACE_NUMBER 16
 
 typedef struct _RTL_UNLOAD_EVENT_TRACE
 {

--- a/sdk/lib/rtl/trace.c
+++ b/sdk/lib/rtl/trace.c
@@ -11,6 +11,7 @@
 #include <debug.h>
 
 static RTL_UNLOAD_EVENT_TRACE RtlpUnloadEventTrace[RTL_UNLOAD_EVENT_TRACE_NUMBER];
+static UINT RtlpUnloadEventTraceIndex = 0;
 
 /* FUNCTIONS ******************************************************************/
 
@@ -22,10 +23,45 @@ RtlGetUnloadEventTrace(VOID)
     return RtlpUnloadEventTrace;
 }
 
+VOID
+NTAPI
+LdrpRecordUnloadEvent(_In_ PLDR_DATA_TABLE_ENTRY LdrEntry)
+{
+    PIMAGE_NT_HEADERS NtHeaders;
+    UINT Sequence = RtlpUnloadEventTraceIndex++;
+    UINT Index = Sequence % RTL_UNLOAD_EVENT_TRACE_NUMBER;
+    USHORT StringLen;
+
+    DPRINT("LdrpRecordUnloadEvent(%wZ, %p - %p)\n", &LdrEntry->BaseDllName, LdrEntry->DllBase,
+        (ULONG_PTR)LdrEntry->DllBase + LdrEntry->SizeOfImage);
+
+    RtlpUnloadEventTrace[Index].BaseAddress = LdrEntry->DllBase;
+    RtlpUnloadEventTrace[Index].SizeOfImage = LdrEntry->SizeOfImage;
+    RtlpUnloadEventTrace[Index].Sequence = Sequence;
+
+    NtHeaders = RtlImageNtHeader(LdrEntry->DllBase);
+
+    if (NtHeaders)
+    {
+        RtlpUnloadEventTrace[Index].TimeDateStamp = NtHeaders->FileHeader.TimeDateStamp;
+        RtlpUnloadEventTrace[Index].CheckSum = NtHeaders->OptionalHeader.CheckSum;
+    }
+    else
+    {
+        RtlpUnloadEventTrace[Index].TimeDateStamp = 0;
+        RtlpUnloadEventTrace[Index].CheckSum = 0;
+    }
+
+    StringLen = min(LdrEntry->BaseDllName.Length / sizeof(WCHAR), RTL_NUMBER_OF(RtlpUnloadEventTrace[Index].ImageName));
+    RtlCopyMemory(RtlpUnloadEventTrace[Index].ImageName, LdrEntry->BaseDllName.Buffer, StringLen * sizeof(WCHAR));
+    if (StringLen < RTL_NUMBER_OF(RtlpUnloadEventTrace[Index].ImageName))
+        RtlpUnloadEventTrace[Index].ImageName[StringLen] = 0;
+}
+
 BOOLEAN
 NTAPI
-RtlTraceDatabaseAdd(IN PRTL_TRACE_DATABASE Database, 
-                    IN ULONG Count, 
+RtlTraceDatabaseAdd(IN PRTL_TRACE_DATABASE Database,
+                    IN ULONG Count,
                     IN PVOID *Trace,
                     OUT OPTIONAL PRTL_TRACE_BLOCK *TraceBlock)
 {
@@ -35,10 +71,10 @@ RtlTraceDatabaseAdd(IN PRTL_TRACE_DATABASE Database,
 
 PRTL_TRACE_DATABASE
 NTAPI
-RtlTraceDatabaseCreate(IN ULONG Buckets, 
-                       IN OPTIONAL SIZE_T MaximumSize, 
-                       IN ULONG Flags, 
-                       IN ULONG Tag, 
+RtlTraceDatabaseCreate(IN ULONG Buckets,
+                       IN OPTIONAL SIZE_T MaximumSize,
+                       IN ULONG Flags,
+                       IN ULONG Tag,
                        IN OPTIONAL RTL_TRACE_HASH_FUNCTION HashFunction)
 {
     UNIMPLEMENTED;
@@ -55,7 +91,7 @@ RtlTraceDatabaseDestroy(IN PRTL_TRACE_DATABASE Database)
 
 BOOLEAN
 NTAPI
-RtlTraceDatabaseEnumerate(IN PRTL_TRACE_DATABASE Database, 
+RtlTraceDatabaseEnumerate(IN PRTL_TRACE_DATABASE Database,
                           IN PRTL_TRACE_ENUMERATE TraceEnumerate,
                           IN OUT PRTL_TRACE_BLOCK *TraceBlock)
 {
@@ -66,7 +102,7 @@ RtlTraceDatabaseEnumerate(IN PRTL_TRACE_DATABASE Database,
 
 BOOLEAN
 NTAPI
-RtlTraceDatabaseFind(IN PRTL_TRACE_DATABASE Database, 
+RtlTraceDatabaseFind(IN PRTL_TRACE_DATABASE Database,
                      IN ULONG Count,
                      IN PVOID *Trace,
                      OUT OPTIONAL PRTL_TRACE_BLOCK *TraceBlock)


### PR DESCRIPTION
This allows viewing unloaded modules in f.e. windbg:

```
kd> !lm
No export lm found
kd> lm
start    end        module name
00400000 004e0000   mshtml_winetest   (private pdb symbols)  C:\ProgramData\dbg\sym\mshtml_winetest.pdb\5542EB3B9C9E440B95C224B107D54EB830\mshtml_winetest.pdb
<!-- snip -->
77190000 77308000   mshtml     (private pdb symbols)  C:\ProgramData\dbg\sym\mshtml.pdb\D0A7F49CFC0845E4A3E5353C4E6358AF43\mshtml.pdb
<!-- snip -->
7c620000 7c908000   kernel32 M (private pdb symbols)  C:\ProgramData\dbg\sym\kernel32.pdb\375CDA8E2B794AD6BC5F5BD69116B3FC45\kernel32.pdb
7c920000 7c9d1000   ntdll      (private pdb symbols)  C:\ProgramData\dbg\sym\ntdll.pdb\88B32AD594B4402F8A52E9D04ED37C0A51\ntdll.pdb
80081000 80088000   kdcom      (deferred)             
80088000 80090000   bootvid    (deferred)             
8028f000 802b6000   hal        (private pdb symbols)  C:\ProgramData\dbg\sym\halacpi.pdb\811A5DB5FF1A4AF58C26AB35327F2EA03c\halacpi.pdb
80400000 80627000   nt         (private pdb symbols)  C:\ProgramData\dbg\sym\ntoskrnl.pdb\889E63DB144441B486E0FEB289274A824c\ntoskrnl.pdb
<!-- snip -->
f7b96000 f7bbc000   fastfat    (deferred)             

Unloaded modules:
7a760000 7a797000   rsaenh.DLL
7a760000 7a797000   rsaenh.DLL
75c20000 75c35000   schannel.dll
7a760000 7a797000   rsaenh.DLL

```