### PR TITLE
[WINESYNC] Partial sync with mshtml

### DIFF
--- a/dll/win32/mshtml/binding.h
+++ b/dll/win32/mshtml/binding.h
@@ -57,6 +57,8 @@ typedef struct {
     REQUEST_METHOD request_method;
     struct list response_headers;
     struct list request_headers;
+
+    nsChannelBSC *binding;
 } nsChannel;
 
 typedef struct {

--- a/dll/win32/mshtml/htmlattr.c
+++ b/dll/win32/mshtml/htmlattr.c
@@ -281,8 +281,13 @@ static HRESULT WINAPI HTMLDOMAttribute2_get_name(IHTMLDOMAttribute2 *iface, BSTR
 static HRESULT WINAPI HTMLDOMAttribute2_put_value(IHTMLDOMAttribute2 *iface, BSTR v)
 {
     HTMLDOMAttribute *This = impl_from_IHTMLDOMAttribute2(iface);
-    FIXME("(%p)->(%s)\n", This, debugstr_w(v));
-    return E_NOTIMPL;
+    VARIANT var;
+
+    TRACE("(%p)->(%s)\n", This, debugstr_w(v));
+
+    V_VT(&var) = VT_BSTR;
+    V_BSTR(&var) = v;
+    return IHTMLDOMAttribute_put_nodeValue(&This->IHTMLDOMAttribute_iface, var);
 }
 
 static HRESULT WINAPI HTMLDOMAttribute2_get_value(IHTMLDOMAttribute2 *iface, BSTR *p)

--- a/dll/win32/mshtml/htmldoc.c
+++ b/dll/win32/mshtml/htmldoc.c
@@ -2529,8 +2529,21 @@ static HRESULT WINAPI HTMLDocument4_focus(IHTMLDocument4 *iface)
 static HRESULT WINAPI HTMLDocument4_hasFocus(IHTMLDocument4 *iface, VARIANT_BOOL *pfFocus)
 {
     HTMLDocument *This = impl_from_IHTMLDocument4(iface);
-    FIXME("(%p)->(%p)\n", This, pfFocus);
-    return E_NOTIMPL;
+    cpp_bool has_focus;
+    nsresult nsres;
+
+    TRACE("(%p)->(%p)\n", This, pfFocus);
+
+    if(!This->doc_node->nsdoc) {
+        FIXME("Unimplemented for fragments.\n");
+        return E_NOTIMPL;
+    }
+
+    nsres = nsIDOMHTMLDocument_HasFocus(This->doc_node->nsdoc, &has_focus);
+    assert(nsres == NS_OK);
+
+    *pfFocus = has_focus ? VARIANT_TRUE : VARIANT_FALSE;
+    return S_OK;
 }
 
 static HRESULT WINAPI HTMLDocument4_put_onselectionchange(IHTMLDocument4 *iface, VARIANT v)

--- a/dll/win32/mshtml/htmldoc.c
+++ b/dll/win32/mshtml/htmldoc.c
@@ -2351,18 +2351,44 @@ static HRESULT WINAPI HTMLDocument3_getElementsByTagName(IHTMLDocument3 *iface, 
 
     TRACE("(%p)->(%s %p)\n", This, debugstr_w(v), pelColl);
 
-    if(!This->doc_node->nsdoc) {
-        WARN("NULL nsdoc\n");
-        return E_UNEXPECTED;
+    if(This->doc_node->nsdoc) {
+        nsAString_InitDepend(&id_str, v);
+        nsres = nsIDOMHTMLDocument_GetElementsByTagName(This->doc_node->nsdoc, &id_str, &nslist);
+        nsAString_Finish(&id_str);
+        if(FAILED(nsres)) {
+            ERR("GetElementByName failed: %08x\n", nsres);
+            return E_FAIL;
+        }
+    }else {
+        nsIDOMDocumentFragment *docfrag;
+        nsAString nsstr;
+
+        if(v) {
+            const WCHAR *ptr;
+            for(ptr=v; *ptr; ptr++) {
+                if(!isalnumW(*ptr)) {
+                    FIXME("Unsupported invalid tag %s\n", debugstr_w(v));
+                    return E_NOTIMPL;
+                }
+            }
+        }
+
+        nsres = nsIDOMNode_QueryInterface(This->doc_node->node.nsnode, &IID_nsIDOMDocumentFragment, (void**)&docfrag);
+        if(NS_FAILED(nsres)) {
+            ERR("Could not get nsIDOMDocumentFragment iface: %08x\n", nsres);
+            return E_UNEXPECTED;
+        }
+
+        nsAString_InitDepend(&nsstr, v);
+        nsres = nsIDOMDocumentFragment_QuerySelectorAll(docfrag, &nsstr, &nslist);
+        nsAString_Finish(&nsstr);
+        nsIDOMDocumentFragment_Release(docfrag);
+        if(NS_FAILED(nsres)) {
+            ERR("QuerySelectorAll failed: %08x\n", nsres);
+            return E_FAIL;
+        }
     }
 
-    nsAString_InitDepend(&id_str, v);
-    nsres = nsIDOMHTMLDocument_GetElementsByTagName(This->doc_node->nsdoc, &id_str, &nslist);
-    nsAString_Finish(&id_str);
-    if(FAILED(nsres)) {
-        ERR("GetElementByName failed: %08x\n", nsres);
-        return E_FAIL;
-    }
 
     *pelColl = create_collection_from_nodelist(This->doc_node, nslist);
     nsIDOMNodeList_Release(nslist);

--- a/dll/win32/mshtml/htmlelem.c
+++ b/dll/win32/mshtml/htmlelem.c
@@ -828,6 +828,11 @@ static HRESULT WINAPI HTMLElement_get_parentElement(IHTMLElement *iface, IHTMLEl
     if(FAILED(hres))
         return hres;
 
+    if(!node) {
+        *p = NULL;
+        return S_OK;
+    }
+
     hres = IHTMLDOMNode_QueryInterface(node, &IID_IHTMLElement, (void**)p);
     IHTMLDOMNode_Release(node);
     if(FAILED(hres))

--- a/dll/win32/mshtml/htmlelem.c
+++ b/dll/win32/mshtml/htmlelem.c
@@ -624,6 +624,8 @@ HRESULT get_elem_attr_value_by_dispid(HTMLElement *elem, DISPID dispid, DWORD fl
     EXCEPINFO excep;
     HRESULT hres;
 
+    static const WCHAR nullW[] = {'n','u','l','l',0};
+
     hres = IDispatchEx_InvokeEx(&elem->node.event_target.dispex.IDispatchEx_iface, dispid, LOCALE_SYSTEM_DEFAULT,
             DISPATCH_PROPERTYGET, &dispParams, ret, &excep, NULL);
     if(FAILED(hres))
@@ -632,6 +634,12 @@ HRESULT get_elem_attr_value_by_dispid(HTMLElement *elem, DISPID dispid, DWORD fl
     if(flags & ATTRFLAG_ASSTRING) {
         switch(V_VT(ret)) {
         case VT_BSTR:
+            break;
+        case VT_NULL:
+            V_BSTR(ret) = SysAllocString(nullW);
+            if(!V_BSTR(ret))
+                return E_OUTOFMEMORY;
+            V_VT(ret) = VT_BSTR;
             break;
         case VT_DISPATCH:
             IDispatch_Release(V_DISPATCH(ret));

--- a/dll/win32/mshtml/htmlelem.c
+++ b/dll/win32/mshtml/htmlelem.c
@@ -1245,15 +1245,43 @@ static HRESULT WINAPI HTMLElement_get_recordNumber(IHTMLElement *iface, VARIANT 
 static HRESULT WINAPI HTMLElement_put_lang(IHTMLElement *iface, BSTR v)
 {
     HTMLElement *This = impl_from_IHTMLElement(iface);
-    FIXME("(%p)->(%s)\n", This, debugstr_w(v));
-    return E_NOTIMPL;
+    nsAString nsstr;
+    nsresult nsres;
+
+    TRACE("(%p)->(%s)\n", This, debugstr_w(v));
+
+    if(!This->nselem) {
+        FIXME("NULL nselem\n");
+        return E_NOTIMPL;
+    }
+
+    nsAString_InitDepend(&nsstr, v);
+    nsres = nsIDOMHTMLElement_SetLang(This->nselem, &nsstr);
+    nsAString_Finish(&nsstr);
+    if(NS_FAILED(nsres)) {
+        ERR("SetLang failed: %08x\n", nsres);
+        return E_FAIL;
+    }
+
+    return S_OK;
 }
 
 static HRESULT WINAPI HTMLElement_get_lang(IHTMLElement *iface, BSTR *p)
 {
     HTMLElement *This = impl_from_IHTMLElement(iface);
-    FIXME("(%p)->(%p)\n", This, p);
-    return E_NOTIMPL;
+    nsAString nsstr;
+    nsresult nsres;
+
+    TRACE("(%p)->(%p)\n", This, p);
+
+    if(!This->nselem) {
+        FIXME("NULL nselem\n");
+        return E_NOTIMPL;
+    }
+
+    nsAString_Init(&nsstr, NULL);
+    nsres = nsIDOMHTMLElement_GetLang(This->nselem, &nsstr);
+    return return_nsstr(nsres, &nsstr, p);
 }
 
 static HRESULT WINAPI HTMLElement_get_offsetLeft(IHTMLElement *iface, LONG *p)

--- a/dll/win32/mshtml/htmlwindow.c
+++ b/dll/win32/mshtml/htmlwindow.c
@@ -2629,7 +2629,7 @@ static HRESULT WINAPI WindowDispEx_InvokeEx(IDispatchEx *iface, DISPID id, LCID 
         DISPPARAMS dp = {args, NULL, 2, 0};
 
         /*
-         * setTimeout calls shoud use default value 0 for the second argument if only one is provided,
+         * setTimeout calls should use default value 0 for the second argument if only one is provided,
          * but IDL file does not reflect that. We fixup arguments here instead.
          */
         if(!(wFlags & DISPATCH_METHOD) || pdp->cArgs != 1 || pdp->cNamedArgs)

--- a/dll/win32/mshtml/htmlwindow.c
+++ b/dll/win32/mshtml/htmlwindow.c
@@ -1325,8 +1325,10 @@ static HRESULT WINAPI HTMLWindow2_scroll(IHTMLWindow2 *iface, LONG x, LONG y)
 static HRESULT WINAPI HTMLWindow2_get_clientInformation(IHTMLWindow2 *iface, IOmNavigator **p)
 {
     HTMLWindow *This = impl_from_IHTMLWindow2(iface);
-    FIXME("(%p)->(%p)\n", This, p);
-    return E_NOTIMPL;
+
+    TRACE("(%p)->(%p)\n", This, p);
+
+    return IHTMLWindow2_get_navigator(&This->IHTMLWindow2_iface, p);
 }
 
 static HRESULT WINAPI HTMLWindow2_setInterval(IHTMLWindow2 *iface, BSTR expression,

--- a/dll/win32/mshtml/navigate.c
+++ b/dll/win32/mshtml/navigate.c
@@ -904,6 +904,8 @@ static HRESULT on_start_nsrequest(nsChannelBSC *This)
 {
     nsresult nsres;
 
+    This->nschannel->binding = This;
+
     /* FIXME: it's needed for http connections from BindToObject. */
     if(!This->nschannel->response_status)
         This->nschannel->response_status = 200;
@@ -949,11 +951,15 @@ static void on_stop_nsrequest(nsChannelBSC *This, HRESULT result)
             WARN("OnStopRequest failed: %08x\n", nsres);
     }
 
-    if(This->nschannel && This->nschannel->load_group) {
-        nsres = nsILoadGroup_RemoveRequest(This->nschannel->load_group,
-                (nsIRequest*)&This->nschannel->nsIHttpChannel_iface, NULL, request_result);
-        if(NS_FAILED(nsres))
-            ERR("RemoveRequest failed: %08x\n", nsres);
+    if(This->nschannel) {
+        if(This->nschannel->load_group) {
+            nsres = nsILoadGroup_RemoveRequest(This->nschannel->load_group,
+                    (nsIRequest*)&This->nschannel->nsIHttpChannel_iface, NULL, request_result);
+            if(NS_FAILED(nsres))
+                ERR("RemoveRequest failed: %08x\n", nsres);
+        }
+        if(This->nschannel->binding == This)
+            This->nschannel->binding = NULL;
     }
 }
 
@@ -1194,8 +1200,11 @@ static void nsChannelBSC_destroy(BSCallback *bsc)
 {
     nsChannelBSC *This = nsChannelBSC_from_BSCallback(bsc);
 
-    if(This->nschannel)
+    if(This->nschannel) {
+        if(This->nschannel->binding == This)
+            This->nschannel->binding = NULL;
         nsIHttpChannel_Release(&This->nschannel->nsIHttpChannel_iface);
+    }
     if(This->nslistener)
         nsIStreamListener_Release(This->nslistener);
     if(This->nscontext)

--- a/dll/win32/mshtml/nsiface.idl
+++ b/dll/win32/mshtml/nsiface.idl
@@ -2961,7 +2961,7 @@ interface nsIDOMWindowUtils : nsISupports
     nsresult SetDisplayPortForElement(float aXPx, float aYPx, float aWidthPx, float aHeightPx,
             nsIDOMElement *aElement, uint32_t aPriority);
     nsresult SetDisplayPortMarginsForElement(float aLeftMargin, float aTopMargin, float aRightMargin, float aBottomMargin,
-            uint32_t aAlignmentX, uint32_t aAlignmentY, nsIDOMElement *aElement, uint32_t aPriority);
+            nsIDOMElement *aElement, uint32_t aPriority);
     nsresult SetDisplayPortBaseForElement(int32_t aX, int32_t aY, int32_t aWidth, int32_t aHeight, nsIDOMElement *aElement);
     nsresult SetResolution(float aResolution);
     nsresult GetResolution(float *aResolution);
@@ -3893,8 +3893,8 @@ interface nsIDocShell : nsIDocShellTreeItem
     nsresult GatherCharsetMenuTelemetry();
     nsresult GetForcedCharset(nsIAtom **aForcedCharset);
     nsresult SetForcedCharset(nsIAtom *aForcedCharset);
-    void SetParentCharset(const nsACString *parentCharset, int32_t parentCharsetSource, nsIPrincipal *parentCharsetPrincipal);
-    void GetParentCharset(nsACString *parentCharset, int32_t *parentCharsetSource, nsIPrincipal **parentCharsetPrincipal);
+    void /* thiscall */ SetParentCharset(const nsACString *parentCharset, int32_t parentCharsetSource, nsIPrincipal *parentCharsetPrincipal);
+    void /* thiscall */ GetParentCharset(nsACString *parentCharset, int32_t *parentCharsetSource, nsIPrincipal **parentCharsetPrincipal);
     nsresult GetRecordProfileTimelineMarkers(bool *aRecordProfileTimelineMarkers);
     nsresult SetRecordProfileTimelineMarkers(bool aRecordProfileTimelineMarkers);
     nsresult Now(int /* DOMHighResTimeStamp */ *_retval);
@@ -3921,7 +3921,7 @@ interface nsIDocShell : nsIDocShellTreeItem
     nsresult SetSandboxFlags(uint32_t aSandboxFlags);
     nsresult GetOnePermittedSandboxedNavigator(nsIDocShell **aOnePermittedSandboxedNavigator);
     nsresult SetOnePermittedSandboxedNavigator(nsIDocShell *aOnePermittedSandboxedNavigator);
-    bool IsSandboxedFrom(nsIDocShell *aTargetDocShell);
+    bool /* thiscall */ IsSandboxedFrom(nsIDocShell *aTargetDocShell);
     nsresult GetMixedContentChannel(nsIChannel **aMixedContentChannel);
     nsresult SetMixedContentChannel(nsIChannel *aMixedContentChannel);
     nsresult GetAllowMixedContentAndConnectionData(bool *rootHasSecureConnection, bool *allowMixedContent, bool *isRootDocShell);

--- a/dll/win32/mshtml/nsiface.idl
+++ b/dll/win32/mshtml/nsiface.idl
@@ -652,9 +652,11 @@ interface nsIHttpChannelInternal : nsISupports
     nsresult SetDocumentURI(nsIURI *aDocumentURI);
     nsresult GetRequestVersion(uint32_t *major, uint32_t *minor);
     nsresult GetResponseVersion(uint32_t *major, uint32_t *minor);
-    nsresult TakeAllSecurityMessages(void /*securityMessagesArray*/ *aMessages);
+    nsresult TakeAllSecurityMessages(void /*nsCOMArray<nsISecurityConsoleMessage>*/ *aMessages);
     nsresult SetCookie(const char *aCookieHeader);
     nsresult SetupFallbackChannel(const char *aFallbackKey);
+    nsresult GetThirdPartyFlags(uint32_t *aThirdPartyFlags);
+    nsresult SetThirdPartyFlags(uint32_t aThirdPartyFlags);
     nsresult GetForceAllowThirdPartyCookie(bool *aForceAllowThirdPartyCookie);
     nsresult SetForceAllowThirdPartyCookie(bool aForceAllowThirdPartyCookie);
     nsresult GetCanceled(bool *aCanceled);

--- a/dll/win32/mshtml/nsio.c
+++ b/dll/win32/mshtml/nsio.c
@@ -596,9 +596,13 @@ static nsresult NSAPI nsChannel_Cancel(nsIHttpChannel *iface, nsresult aStatus)
 {
     nsChannel *This = impl_from_nsIHttpChannel(iface);
 
-    FIXME("(%p)->(%08x)\n", This, aStatus);
+    TRACE("(%p)->(%08x)\n", This, aStatus);
 
-    return NS_ERROR_NOT_IMPLEMENTED;
+    if(This->binding && This->binding->bsc.binding)
+        IBinding_Abort(This->binding->bsc.binding);
+    else
+        WARN("No binding to cancel\n");
+    return NS_OK;
 }
 
 static nsresult NSAPI nsChannel_Suspend(nsIHttpChannel *iface)

--- a/dll/win32/mshtml/nsio.c
+++ b/dll/win32/mshtml/nsio.c
@@ -1705,6 +1705,20 @@ static nsresult NSAPI nsHttpChannelInternal_SetupFallbackChannel(nsIHttpChannelI
     return NS_ERROR_NOT_IMPLEMENTED;
 }
 
+static nsresult NSAPI nsHttpChannelInternal_GetThirdPartyFlags(nsIHttpChannelInternal *iface, UINT32 *aThirdPartyFlags)
+{
+    nsChannel *This = impl_from_nsIHttpChannelInternal(iface);
+    FIXME("(%p)->(%p)\n", This, aThirdPartyFlags);
+    return NS_ERROR_NOT_IMPLEMENTED;
+}
+
+static nsresult NSAPI nsHttpChannelInternal_SetThirdPartyFlags(nsIHttpChannelInternal *iface, UINT32 aThirdPartyFlags)
+{
+    nsChannel *This = impl_from_nsIHttpChannelInternal(iface);
+    FIXME("(%p)->(%x)\n", This, aThirdPartyFlags);
+    return NS_ERROR_NOT_IMPLEMENTED;
+}
+
 static nsresult NSAPI nsHttpChannelInternal_GetForceAllowThirdPartyCookie(nsIHttpChannelInternal *iface, cpp_bool *aForceThirdPartyCookie)
 {
     nsChannel *This = impl_from_nsIHttpChannelInternal(iface);
@@ -1953,6 +1967,8 @@ static const nsIHttpChannelInternalVtbl nsHttpChannelInternalVtbl = {
     nsHttpChannelInternal_TakeAllSecurityMessages,
     nsHttpChannelInternal_SetCookie,
     nsHttpChannelInternal_SetupFallbackChannel,
+    nsHttpChannelInternal_GetThirdPartyFlags,
+    nsHttpChannelInternal_SetThirdPartyFlags,
     nsHttpChannelInternal_GetForceAllowThirdPartyCookie,
     nsHttpChannelInternal_SetForceAllowThirdPartyCookie,
     nsHttpChannelInternal_GetCanceled,

--- a/dll/win32/mshtml/nsio.c
+++ b/dll/win32/mshtml/nsio.c
@@ -1901,8 +1901,8 @@ static nsresult NSAPI nsHttpChannelInternal_SetCorsIncludeCredentials(nsIHttpCha
         cpp_bool aCorsIncludeCredentials)
 {
     nsChannel *This = impl_from_nsIHttpChannelInternal(iface);
-    FIXME("(%p)->(%x)\n", This, aCorsIncludeCredentials);
-    return NS_ERROR_NOT_IMPLEMENTED;
+    TRACE("(%p)->(%x)\n", This, aCorsIncludeCredentials);
+    return NS_OK;
 }
 
 static nsresult NSAPI nsHttpChannelInternal_GetCorsMode(nsIHttpChannelInternal *iface, UINT32 *aCorsMode)
@@ -1915,8 +1915,8 @@ static nsresult NSAPI nsHttpChannelInternal_GetCorsMode(nsIHttpChannelInternal *
 static nsresult NSAPI nsHttpChannelInternal_SetCorsMode(nsIHttpChannelInternal *iface, UINT32 aCorsMode)
 {
     nsChannel *This = impl_from_nsIHttpChannelInternal(iface);
-    FIXME("(%p)->(%d)\n", This, aCorsMode);
-    return NS_ERROR_NOT_IMPLEMENTED;
+    TRACE("(%p)->(%d)\n", This, aCorsMode);
+    return NS_OK;
 }
 
 static nsresult NSAPI nsHttpChannelInternal_GetTopWindowURI(nsIHttpChannelInternal *iface, nsIURI **aTopWindowURI)

--- a/dll/win32/mshtml/xmlhttprequest.c
+++ b/dll/win32/mshtml/xmlhttprequest.c
@@ -17,6 +17,9 @@
  */
 
 #include "mshtml_private.h"
+#include "initguid.h"
+#include "msxml6.h"
+#include "objsafe.h"
 
 static HRESULT bstr_to_nsacstr(BSTR bstr, nsACString *str)
 {
@@ -319,8 +322,42 @@ static HRESULT WINAPI HTMLXMLHttpRequest_get_responseText(IHTMLXMLHttpRequest *i
 static HRESULT WINAPI HTMLXMLHttpRequest_get_responseXML(IHTMLXMLHttpRequest *iface, IDispatch **p)
 {
     HTMLXMLHttpRequest *This = impl_from_IHTMLXMLHttpRequest(iface);
-    FIXME("(%p)->(%p)\n", This, p);
-    return E_NOTIMPL;
+    IXMLDOMDocument *xmldoc = NULL;
+    BSTR str;
+    HRESULT hres;
+    VARIANT_BOOL vbool;
+    IObjectSafety *safety;
+
+    TRACE("(%p)->(%p)\n", This, p);
+
+    hres = CoCreateInstance(&CLSID_DOMDocument, NULL, CLSCTX_INPROC_SERVER, &IID_IXMLDOMDocument, (void**)&xmldoc);
+    if(FAILED(hres)) {
+        ERR("CoCreateInstance failed: %08x\n", hres);
+        return hres;
+    }
+
+    hres = IHTMLXMLHttpRequest_get_responseText(iface, &str);
+    if(FAILED(hres)) {
+        IXMLDOMDocument_Release(xmldoc);
+        ERR("get_responseText failed: %08x\n", hres);
+        return hres;
+    }
+
+    hres = IXMLDOMDocument_loadXML(xmldoc, str, &vbool);
+    SysFreeString(str);
+    if(hres != S_OK || vbool != VARIANT_TRUE)
+        WARN("loadXML failed: %08x, returning an empty xmldoc\n", hres);
+
+    hres = IXMLDOMDocument_QueryInterface(xmldoc, &IID_IObjectSafety, (void**)&safety);
+    assert(SUCCEEDED(hres));
+    hres = IObjectSafety_SetInterfaceSafetyOptions(safety, NULL,
+        INTERFACESAFE_FOR_UNTRUSTED_CALLER | INTERFACESAFE_FOR_UNTRUSTED_DATA | INTERFACE_USES_SECURITY_MANAGER,
+        INTERFACESAFE_FOR_UNTRUSTED_CALLER | INTERFACESAFE_FOR_UNTRUSTED_DATA | INTERFACE_USES_SECURITY_MANAGER);
+    assert(SUCCEEDED(hres));
+    IObjectSafety_Release(safety);
+
+    *p = (IDispatch*)xmldoc;
+    return S_OK;
 }
 
 static HRESULT WINAPI HTMLXMLHttpRequest_get_status(IHTMLXMLHttpRequest *iface, LONG *p)

--- a/sdk/tools/winesync/mshtml.cfg
+++ b/sdk/tools/winesync/mshtml.cfg
@@ -1,0 +1,6 @@
+directories:
+  dlls/mshtml: dll/win32/mshtml
+files:
+  dummy: dummy
+tags:
+  wine: wine-1.7.55

--- a/sdk/tools/winesync/mshtml.cfg
+++ b/sdk/tools/winesync/mshtml.cfg
@@ -3,4 +3,4 @@ directories:
 files:
   dummy: dummy
 tags:
-  wine: wine-1.7.55
+  wine: fedfe2ea2eaa67aaa9bcd6d6973cf0501d9123d5

--- a/sdk/tools/winesync/winesync.py
+++ b/sdk/tools/winesync/winesync.py
@@ -218,7 +218,7 @@ class wine_sync:
             [self.reactos_repo.head.target])
 
         if (warning_message != ''):
-            warning_message += 'If needed, amend the current commit in your reactos tree and start this script again'
+            warning_message += 'If needed, amend the current commit in your reactos tree and start this script again\n'
 
             if not in_staging:
                 warning_message += f'You can see the details of the wine commit here: https://source.winehq.org/git/wine.git/commit/{str(wine_commit.id)}'


### PR DESCRIPTION
While trying the winesync.py script from @zefklop (Thanks for that script!) I hit a bug on this commit:
https://source.winehq.org/git/wine.git/commit/d22303703428842106f09432111785af7f5b1ad0

It has a deleted file (dlls/mshtml/htmlstyle2.c), but the `delta.new_file.path` is `dlls/mshtml/htmlstyle2.c` instead of `/dev/null`

Due to that, it bombs out trying to find this in the target:
```
mark@DEV2:/mnt/r/src/dev/sdk/tools/winesync/.vscode$ python3 ../winesync.py mshtml wine-4.2 v4.2
Checking patch dll/win32/mshtml/htmlstyle.c...
Hunk #1 succeeded at 3125 (offset -17 lines).
Hunk #2 succeeded at 3801 (offset -17 lines).
Applied patch dll/win32/mshtml/htmlstyle.c cleanly.
Checking patch dll/win32/mshtml/htmlstyle.h...
Hunk #1 succeeded at 124 (offset 2 lines).
Applied patch dll/win32/mshtml/htmlstyle.h cleanly.
Traceback (most recent call last):
  File "../winesync.py", line 354, in <module>
    main()
  File "../winesync.py", line 350, in main
    return syncator.sync_to_wine(args.wine_tag, args.wine_staging_tag)
  File "../winesync.py", line 304, in sync_to_wine
    applied_patch, warning_message = self.sync_wine_commit(wine_commit, in_staging, staging_patch_index)
  File "../winesync.py", line 155, in sync_wine_commit
    new_blob = self.wine_repo.get(wine_commit.tree[delta.new_file.path].id)
KeyError: 'dlls/mshtml/htmlstyle2.c'
```

Environment:
```
WSL

uname -a
Linux DEV2 4.4.0-18362-Microsoft #476-Microsoft Fri Nov 01 16:53:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux

python3 --version
Python 3.6.9

pip3 show pygit2
Name: pygit2
Version: 1.2.0
Summary: Python bindings for libgit2.
Home-page: http://github.com/libgit2/pygit2
Author: None
Author-email: None
License: GPLv2 with linking exception
Location: /home/mark/.local/lib/python3.6/site-packages
Requires: cached-property, cffi
```

The last commit updates `mshtml.cfg` to where the script left off.