### PR TITLE
[NETID] fr-fr translation fix and component size

### DIFF
--- a/dll/win32/netid/lang/fr-FR.rc
+++ b/dll/win32/netid/lang/fr-FR.rc
@@ -15,7 +15,7 @@ BEGIN
     EDITTEXT IDC_WORKGROUPDOMAIN_NAME, 103, 84, 144, 12, ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP
     LTEXT "Pour utiliser l'Assistant Réseau, afin de rejoindre un domaine ou créer un utilisateur local, cliquez sur Identification Réseau.", IDC_STATIC, 6, 108, 160, 24
     PUSHBUTTON "ID &réseau...", IDC_NETWORK_ID, 170, 114, 78, 15
-    LTEXT "Pour changer le nom de cet ordinateur ou rejoindre un domaine, cliquez sur Changer.", IDC_STATIC, 6, 149, 160, 17
+    LTEXT "Pour changer le nom de cet ordinateur ou rejoindre un domaine, cliquez sur Modifier.", IDC_STATIC, 6, 149, 160, 17
     PUSHBUTTON "Modifier...", IDC_NETWORK_PROPERTY, 170, 149, 78, 15
     LTEXT "Note : Seuls les administrateurs peuvent modifier l'identification de cet ordinateur.", IDC_STATIC, 6, 179, 244, 18
 END


### PR DESCRIPTION
## Purpose

_ Correct fr-fr translation in order to better match with component size and standard wording.

![image](https://user-images.githubusercontent.com/24843587/79833553-db4b1a80-83ab-11ea-8f78-26dc1d7f6ae6.png)
