### PR TITLE
[BROWSEUI] Attempt absolute path on relative path fail

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -146,11 +146,11 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
 
     hr = pbs->GetPidl(&pidlCurrent);
     if (FAILED_UNEXPECTEDLY(hr))
-        goto cleanup;
+        goto parseabsolute;
 
     hr = psfDesktop->BindToObject(pidlCurrent, NULL, IID_PPV_ARG(IShellFolder, &psfCurrent));
     if (FAILED_UNEXPECTEDLY(hr))
-        goto cleanup;
+        goto parseabsolute;
 
     hr = psfCurrent->ParseDisplayName(topLevelWindow, NULL, address, &eaten,  &pidlRelative, &attributes);
     if (SUCCEEDED(hr))
@@ -160,6 +160,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
         goto cleanup;
     }
 
+parseabsolute:
     /* We couldn't parse a relative path, attempt to parse an absolute path */
     hr = psfDesktop->ParseDisplayName(topLevelWindow, NULL, address, &eaten, &pidlLastParsed, &attributes);
 


### PR DESCRIPTION
## Purpose

This PR will attempt to parse an absolute path even in the case of an unexpected failure while computing the relative path of a directory entered into the address bar of the file explorer.  An unexpected error could occur when `BindToObject` is unimplemented, or when `BindToObject` was attempted on the Desktop.

## Proposed changes

- Attempt to parse an absolute path as long as `psfDesktop` is valid.

## More Information

To reproduce this issue:

1.  Boot up a copy of ReactOS and navigate the file explorer to the desktop.
2.  Try to enter a valid path and navigate to it using the address bar.
3.  You will be unable to navigate using the address bar.  The error being returned is E_INVALIDARG by `BindToObject` because the Desktop is the current path.

![stuckondesktop](https://user-images.githubusercontent.com/3923687/79680482-ff003c00-81c4-11ea-89d6-c24c889a3258.png)
