### PR TITLE
[DESK] Multi-monitor support improvement

### DIFF
--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -381,16 +381,12 @@ SettingsOnInitDialog(IN HWND hwndDlg)
             DWORD offset = 0;
             for (i = 0; i < Result; i++)
             {
-                if (i > 1)
-                {
-                    offset += pMonitors[i - 1].Size.cx;
-                }
-                
                 pMonitors[i].Position.x = offset;
                 pMonitors[i].Position.y = 0;
                 pMonitors[i].Size.cx = pData->DisplayDeviceList->CurrentSettings->dmPelsWidth;
                 pMonitors[i].Size.cy = pData->DisplayDeviceList->CurrentSettings->dmPelsHeight;
                 pMonitors[i].Flags = 0;
+				offset += pMonitors[i].Size.cx;
             }
 
             SendDlgItemMessage(hwndDlg,

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -386,7 +386,7 @@ SettingsOnInitDialog(IN HWND hwndDlg)
                 pMonitors[i].Size.cx = pData->DisplayDeviceList->CurrentSettings->dmPelsWidth;
                 pMonitors[i].Size.cy = pData->DisplayDeviceList->CurrentSettings->dmPelsHeight;
                 pMonitors[i].Flags = 0;
-				offset += pMonitors[i].Size.cx;
+                offset += pMonitors[i].Size.cx;
             }
 
             SendDlgItemMessage(hwndDlg,

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -382,7 +382,8 @@ SettingsOnInitDialog(IN HWND hwndDlg)
             for (i = 0; i < Result; i++)
             {
                 if (i>1) offset = offset + pMonitors[i-1].Size.cx;
-				pMonitors[i].Position.x = offset;
+				
+                pMonitors[i].Position.x = offset;
                 pMonitors[i].Position.y = 0;
                 pMonitors[i].Size.cx = pData->DisplayDeviceList->CurrentSettings->dmPelsWidth;
                 pMonitors[i].Size.cy = pData->DisplayDeviceList->CurrentSettings->dmPelsHeight;

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -385,7 +385,7 @@ SettingsOnInitDialog(IN HWND hwndDlg)
                 {
                     offset += pMonitors[i - 1].Size.cx;
                 }
-				
+                
                 pMonitors[i].Position.x = offset;
                 pMonitors[i].Position.y = 0;
                 pMonitors[i].Size.cx = pData->DisplayDeviceList->CurrentSettings->dmPelsWidth;

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -378,10 +378,11 @@ SettingsOnInitDialog(IN HWND hwndDlg)
         pMonitors = (PMONSL_MONINFO)HeapAlloc(GetProcessHeap(), 0, sizeof(MONSL_MONINFO) * Result);
         if (pMonitors)
         {
-            DWORD hack = 1280;
+            DWORD offset = 0;
             for (i = 0; i < Result; i++)
             {
-                pMonitors[i].Position.x = hack * i;
+                if (i>1) offset = offset + pMonitors[i-1].Size.cx;
+				pMonitors[i].Position.x = offset;
                 pMonitors[i].Position.y = 0;
                 pMonitors[i].Size.cx = pData->DisplayDeviceList->CurrentSettings->dmPelsWidth;
                 pMonitors[i].Size.cy = pData->DisplayDeviceList->CurrentSettings->dmPelsHeight;

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -5,7 +5,7 @@
  * PURPOSE:         Settings property page
  *
  * PROGRAMMERS:     Trevor McCort (lycan359@gmail.com)
- *                  Hervé Poussineau (hpoussin@reactos.org)
+ *                  HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "desk.h"
@@ -381,7 +381,10 @@ SettingsOnInitDialog(IN HWND hwndDlg)
             DWORD offset = 0;
             for (i = 0; i < Result; i++)
             {
-                if (i>1) offset = offset + pMonitors[i-1].Size.cx;
+                if (i > 1)
+                {
+                    offset += pMonitors[i - 1].Size.cx;
+                }
 				
                 pMonitors[i].Position.x = offset;
                 pMonitors[i].Position.y = 0;


### PR DESCRIPTION
## Purpose

_ This PR will attempt to improve support of multi-monitor configurations in display properties .cpl as the current implementation (maked as "incomplete") assume a givent X-resolution (1280) for all screen, regardless of the real x-resolution.
Current code is a "dummy" code. The purpose of this proposal is to move one step further without inducing regressions.

## Proposed changes

_ Use of the "actual" resolution of all "previous" screen when enumerating all displays monitors in order to compute the correct offset.

Post change (non-regression)
![image](https://user-images.githubusercontent.com/24843587/79768256-d2663480-832a-11ea-89c6-b83ef2746c1b.png)
