### PR TITLE
[RAPPS] Proxy fields default state fix (CORE-16853)

### DIFF
--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -71,13 +71,13 @@ namespace
 
         if (Info->Proxy == 0)
         {
-        	EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
-        	EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
+            EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
+            EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
         }
         else
         {
-        	EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
-        	EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
         }
 
         SetWindowTextW(GetDlgItem(hDlg, IDC_PROXY_SERVER), Info->szProxyServer);

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -74,11 +74,11 @@ namespace
             EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
             EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
         }
-		else
-		{
+        else
+        {
             EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
             EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
-		}
+        }
 
         SetWindowTextW(GetDlgItem(hDlg, IDC_PROXY_SERVER), Info->szProxyServer);
         SetWindowTextW(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), Info->szNoProxyFor);

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -69,15 +69,15 @@ namespace
 
         CheckRadioButton(hDlg, IDC_PROXY_DEFAULT, IDC_USE_PROXY, IDC_PROXY_DEFAULT + Info->Proxy);
 
-		if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
+        if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
         {
             EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
             EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
         }
 		else
 		{
-			EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
-			EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
+            EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
 		}
 
         SetWindowTextW(GetDlgItem(hDlg, IDC_PROXY_SERVER), Info->szProxyServer);

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -69,7 +69,7 @@ namespace
 
         CheckRadioButton(hDlg, IDC_PROXY_DEFAULT, IDC_USE_PROXY, IDC_PROXY_DEFAULT + Info->Proxy);
 
-        if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
+        if (Info->Proxy == 0)
         {
         	EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
         	EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -69,11 +69,16 @@ namespace
 
         CheckRadioButton(hDlg, IDC_PROXY_DEFAULT, IDC_USE_PROXY, IDC_PROXY_DEFAULT + Info->Proxy);
 
-        if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
+		if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
         {
             EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
             EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
         }
+		else
+		{
+			EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
+			EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
+		}
 
         SetWindowTextW(GetDlgItem(hDlg, IDC_PROXY_SERVER), Info->szProxyServer);
         SetWindowTextW(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), Info->szNoProxyFor);

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -71,13 +71,13 @@ namespace
 
         if (IDC_PROXY_DEFAULT + Info->Proxy == IDC_USE_PROXY)
         {
-            EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
-            EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
+        	EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), TRUE);
+        	EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), TRUE);
         }
         else
         {
-            EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
-            EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
+        	EnableWindow(GetDlgItem(hDlg, IDC_PROXY_SERVER), FALSE);
+        	EnableWindow(GetDlgItem(hDlg, IDC_NO_PROXY_FOR), FALSE);
         }
 
         SetWindowTextW(GetDlgItem(hDlg, IDC_PROXY_SERVER), Info->szProxyServer);


### PR DESCRIPTION
## Purpose

_ When a proxy was selected then "default settings" is applied, the state of the proxy text fields is unduly kept enabled because the test code in the dialog initialization section is only able to "re-enable" these fields with the wrong assumption that they have been disabled beforehand

JIRA issue: [CORE-16853](https://jira.reactos.org/browse/CORE-16853)

## Proposed changes

_  Change in InitSettingsControls in order to Disable these 2 text fields when not necessary.