### PR TITLE
[AUDIOSRV] logmsg(): Disable its file part. CORE-16814

### DIFF
--- a/base/services/audiosrv/debug.c
+++ b/base/services/audiosrv/debug.c
@@ -4,10 +4,14 @@
 
 #include <stdio.h>
 
+// FIXME: Disabled to work around CORE-16814 (and CORE-16912).
+// #define ENABLE_LOGMSG_FILE
+
 void logmsg(char* string, ...)
 {
     va_list args;
 
+#ifdef ENABLE_LOGMSG_FILE
     FILE* debug_file = fopen("c:\\audiosrv-debug.txt", "a");
 
     if (debug_file)
@@ -18,6 +22,7 @@ void logmsg(char* string, ...)
         fclose(debug_file);
     }
     else
+#endif
     {
         char buf[256];
         va_start(args, string);


### PR DESCRIPTION
Mininal workaround for
JIRA issue: [CORE-16814](https://jira.reactos.org/browse/CORE-16814)
