### PR TITLE
[AUDIOSRV] logmsg(): Skip it on non-debug builds. CORE-16912

### DIFF
--- a/base/services/audiosrv/CMakeLists.txt
+++ b/base/services/audiosrv/CMakeLists.txt
@@ -5,8 +5,11 @@ list(APPEND SOURCE
     pnp_list_lock.c
     pnp.c
     services.c
-    debug.c
     audiosrv.h)
+
+if(DBG)
+    list(APPEND SOURCE debug.c)
+endif()
 
 add_executable(audiosrv ${SOURCE} audiosrv.rc)
 set_module_type(audiosrv win32cui UNICODE)

--- a/base/services/audiosrv/audiosrv.h
+++ b/base/services/audiosrv/audiosrv.h
@@ -64,8 +64,12 @@ StartSystemAudioServices(VOID);
 
 /* Debugging */
 
+#if DBG
 void logmsg(char* string, ...);
-
+#else
+#define logmsg(...) ((void)0)
 #endif
+
+#endif // AUDIOSRV_PRIVATE_H
 
 #endif /* _AUDIOSRV_PCH_ */


### PR DESCRIPTION
Near mininal workaround for
JIRA issue: [CORE-16912](https://jira.reactos.org/browse/CORE-16912)

Co-authored-by: Hermès BÉLUSCA - MAÏTO <hermes.belusca-maito@reactos.org>