### PR TITLE
[KDCOM][NTOS:INBV][FREELDR] Decrease default baud rate for PC-98

### DIFF
--- a/boot/bootdata/floppy_pc98.ini
+++ b/boot/bootdata/floppy_pc98.ini
@@ -39,7 +39,7 @@ Options=/MININT
 [LiveCD_Debug]
 BootType=Windows2003
 SystemPath=multi(0)disk(0)cdrom(0)\reactos
-Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=9600 /SOS /MININT
 
 [LiveCD_Screen]
 BootType=Windows2003

--- a/boot/freeldr/freeldr/lib/comm/rs232.c
+++ b/boot/freeldr/freeldr/lib/comm/rs232.c
@@ -30,7 +30,11 @@
 
 /* STATIC VARIABLES ***********************************************************/
 
+#if defined(SARCH_PC98)
+#define DEFAULT_BAUD_RATE   9600
+#else
 #define DEFAULT_BAUD_RATE   19200
+#endif
 
 #if defined(_M_IX86) || defined(_M_AMD64)
 #if defined(SARCH_PC98)

--- a/boot/freeldr/freeldr/lib/debug.c
+++ b/boot/freeldr/freeldr/lib/debug.c
@@ -43,8 +43,14 @@ static UCHAR DbgChannels[DBG_CHANNELS_COUNT];
 ULONG DebugPort = RS232;
 
 /* Serial debug connection */
-ULONG ComPort  = 0; // The COM port initializer chooses the first available port starting from COM4 down to COM1.
+
+#if defined(SARCH_PC98)
+ULONG BaudRate = 9600;
+#else
 ULONG BaudRate = 115200;
+#endif
+
+ULONG ComPort  = 0; // The COM port initializer chooses the first available port starting from COM4 down to COM1.
 ULONG PortIrq  = 0; // Not used at the moment.
 
 BOOLEAN DebugStartOfLine = TRUE;

--- a/boot/freeldr/freeldr/lib/debug.c
+++ b/boot/freeldr/freeldr/lib/debug.c
@@ -43,7 +43,6 @@ static UCHAR DbgChannels[DBG_CHANNELS_COUNT];
 ULONG DebugPort = RS232;
 
 /* Serial debug connection */
-
 #if defined(SARCH_PC98)
 ULONG BaudRate = 9600;
 #else

--- a/boot/freeldr/freeldr/ntldr/headless.c
+++ b/boot/freeldr/freeldr/ntldr/headless.c
@@ -67,10 +67,10 @@ WinLdrPortInitialize(IN ULONG BaudRate,
                      IN BOOLEAN TerminalConnected,
                      OUT PULONG PortId)
 {
-    /* Set default baud rate */
-    if (BaudRate == 0) BaudRate = 19200;
-
 #if defined(SARCH_PC98)
+    /* Set default baud rate */
+    if (BaudRate == 0) BaudRate = 9600;
+
     /* Check if port or address given */
     if (PortNumber)
     {
@@ -106,6 +106,9 @@ WinLdrPortInitialize(IN ULONG BaudRate,
         }
     }
 #else
+    /* Set default baud rate */
+    if (BaudRate == 0) BaudRate = 19200;
+
     /* Check if port or address given */
     if (PortNumber)
     {

--- a/drivers/base/kdcom/kdcom.c
+++ b/drivers/base/kdcom/kdcom.c
@@ -15,12 +15,19 @@
 #include <ndk/halfuncs.h>
 
 /* Serial debug connection */
+#if defined(SARCH_PC98)
 #define DEFAULT_DEBUG_PORT      2 /* COM2 */
-#define DEFAULT_DEBUG_COM1_IRQ  4 /* COM1 IRQ */
-#define DEFAULT_DEBUG_COM2_IRQ  3 /* COM2 IRQ */
-#define DEFAULT_DEBUG_BAUD_RATE 115200 /* 115200 Baud */
-
-#define DEFAULT_BAUD_RATE   19200
+#define DEFAULT_DEBUG_COM1_IRQ  4
+#define DEFAULT_DEBUG_COM2_IRQ  5
+#define DEFAULT_DEBUG_BAUD_RATE 9600
+#define DEFAULT_BAUD_RATE       9600
+#else
+#define DEFAULT_DEBUG_PORT      2 /* COM2 */
+#define DEFAULT_DEBUG_COM1_IRQ  4
+#define DEFAULT_DEBUG_COM2_IRQ  3
+#define DEFAULT_DEBUG_BAUD_RATE 115200
+#define DEFAULT_BAUD_RATE       19200
+#endif
 
 #if defined(_M_IX86) || defined(_M_AMD64)
 #if defined(SARCH_PC98)

--- a/drivers/base/kdgdb/kdcom.c
+++ b/drivers/base/kdgdb/kdcom.c
@@ -13,12 +13,19 @@
 #include <ndk/halfuncs.h>
 
 /* Serial debug connection */
+#if defined(SARCH_PC98)
 #define DEFAULT_DEBUG_PORT      2 /* COM2 */
-#define DEFAULT_DEBUG_COM1_IRQ  4 /* COM1 IRQ */
-#define DEFAULT_DEBUG_COM2_IRQ  3 /* COM2 IRQ */
-#define DEFAULT_DEBUG_BAUD_RATE 115200 /* 115200 Baud */
-
-#define DEFAULT_BAUD_RATE   19200
+#define DEFAULT_DEBUG_COM1_IRQ  4
+#define DEFAULT_DEBUG_COM2_IRQ  5
+#define DEFAULT_DEBUG_BAUD_RATE 9600
+#define DEFAULT_BAUD_RATE       9600
+#else
+#define DEFAULT_DEBUG_PORT      2 /* COM2 */
+#define DEFAULT_DEBUG_COM1_IRQ  4
+#define DEFAULT_DEBUG_COM2_IRQ  3
+#define DEFAULT_DEBUG_BAUD_RATE 115200
+#define DEFAULT_BAUD_RATE       19200
+#endif
 
 #if defined(_M_IX86) || defined(_M_AMD64)
 #if defined(SARCH_PC98)
@@ -299,12 +306,12 @@ NTAPI
 KdpReceiveByte(_Out_ PUCHAR OutByte)
 {
     USHORT CpStatus;
-    
+
     do
     {
         CpStatus = CpGetByte(&KdComPort, OutByte, TRUE, FALSE);
     } while (CpStatus == CP_GET_NODATA);
-    
+
     /* Get the byte */
     if (CpStatus == CP_GET_SUCCESS)
     {

--- a/ntoskrnl/inbv/inbvport.c
+++ b/ntoskrnl/inbv/inbvport.c
@@ -79,10 +79,10 @@ InbvPortInitialize(IN  ULONG   BaudRate,
     /* Not yet supported */
     ASSERT(IsMMIODevice == FALSE);
 
-    /* Set default baud rate */
-    if (BaudRate == 0) BaudRate = 19200;
-
 #if defined(SARCH_PC98)
+    /* Set default baud rate */
+    if (BaudRate == 0) BaudRate = 9600;
+
     /* Check if port or address given */
     if (PortNumber)
     {
@@ -118,6 +118,9 @@ InbvPortInitialize(IN  ULONG   BaudRate,
         }
     }
 #else
+    /* Set default baud rate */
+    if (BaudRate == 0) BaudRate = 19200;
+
     /* Check if port or address given */
     if (PortNumber)
     {

--- a/ntoskrnl/kd/i386/kdbg.c
+++ b/ntoskrnl/kd/i386/kdbg.c
@@ -13,8 +13,11 @@
 #define NDEBUG
 #include <debug.h>
 
-
+#if defined(SARCH_PC98)
+#define DEFAULT_BAUD_RATE   9600
+#else
 #define DEFAULT_BAUD_RATE   19200
+#endif
 
 #if defined(_M_IX86) || defined(_M_AMD64)
 #if defined(SARCH_PC98)


### PR DESCRIPTION
## Purpose

Attempt to fix bug described in that Twitter post: https://twitter.com/simk98l/status/1251340347491282945.

## Proposed changes

According to PC-9801 Bible p. 50, divisor for PIT will become unsupported in some cases after having removed the fractional part. 
- Replace 19200 value with 9600 which is supported by both 10 MHz and 8 MHz machines.

## TODO

- [x] Make a real hardware test (with screen debug enabled) to confirm that patch works.