### PR TITLE
[WIN32SS][NTDDRAW] Get complexity of visible region in DxEngGetDCState CORE-7733

### DIFF
--- a/win32ss/reactx/ntddraw/dxeng.c
+++ b/win32ss/reactx/ntddraw/dxeng.c
@@ -4,6 +4,7 @@
  * FILE:             win32ss/reactx/ntddraw/dxeng.c
  * PURPOSE:          Implementation of DxEng functions
  * PROGRAMMERS:      Magnus Olsen (magnus@greatlord.com)
+ *                   Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
  */
 
 #include <win32k.h>
@@ -442,7 +443,7 @@ DxEngSetHdevData(HDEV hDev,
 * Return one of the type values
 *
 * @remarks.
-* We do not have type 2 implemented yet
+* none
 *
 *--*/
 DWORD_PTR
@@ -463,7 +464,8 @@ DxEngGetDCState(HDC hDC,
                 retVal = (DWORD_PTR) pDC->fs & DC_FLAG_FULLSCREEN;
                 break;
             case 2:
-                UNIMPLEMENTED;
+                /* Return the number of rectangles in the visible region. */
+                retVal = (DWORD_PTR) pDC->prgnRao ? pDC->prgnRao->rdh.nCount : pDC->prgnVis->rdh.nCount;
                 break;
             case 3:
             {


### PR DESCRIPTION
## Purpose

Get complexity of visible region in DxEngGetDCState function, according to its remarks.
My implementation of that returns a number of rectangles that make up the region, similarly to as it done in `REGION_Complexity` function: https://git.reactos.org/?p=reactos.git;a=blob;f=win32ss/gdi/ntgdi/region.c;h=38bf3d377fa805e9db8768774c4fc473590252d0;hb=HEAD#l573.
Required by MS ddraw.dll when calling win32k/dxg functions during launching DirectDraw test or any DirectX 1 - 7 apps/games.

JIRA issue: [CORE-7733](https://jira.reactos.org/browse/CORE-7733)

## Proposed changes

- Implement type 2 of DxEngGetDCState;
- Add a comment;
- Update function remarks;
- Update copyright.