### PR TITLE
[SHIMGVW] Consider failure case of loading file

### DIFF
--- a/dll/win32/shimgvw/lang/bg-BG.rc
+++ b/dll/win32/shimgvw/lang/bg-BG.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Прегледът за снимки и факсове на РеактОС"
     IDS_SETASDESKBG "Слагане като подкраска"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Преглед"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Следващо изображение"

--- a/dll/win32/shimgvw/lang/cs-CZ.rc
+++ b/dll/win32/shimgvw/lang/cs-CZ.rc
@@ -9,6 +9,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS prohlížeč obrázků a faxů"
     IDS_SETASDESKBG "Nastavit jako pozadí plochy"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Náhled"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Další obrázek"

--- a/dll/win32/shimgvw/lang/de-DE.rc
+++ b/dll/win32/shimgvw/lang/de-DE.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS-Bild- und Faxansicht"
     IDS_SETASDESKBG "Als Desktophintergrund setzen"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Vorschau"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Nächstes Bild"

--- a/dll/win32/shimgvw/lang/en-US.rc
+++ b/dll/win32/shimgvw/lang/en-US.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS Picture and Fax Viewer"
     IDS_SETASDESKBG "Set as Desktop Background"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Preview"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Next Picture"

--- a/dll/win32/shimgvw/lang/es-ES.rc
+++ b/dll/win32/shimgvw/lang/es-ES.rc
@@ -6,6 +6,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Visor de imágenes y fax de ReactOS"
     IDS_SETASDESKBG "Establecer como fondo de escritorio"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Vista previa"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Siguiente imagen"

--- a/dll/win32/shimgvw/lang/fr-FR.rc
+++ b/dll/win32/shimgvw/lang/fr-FR.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Visionneuse d'Images et Fax de ReactOS"
     IDS_SETASDESKBG "Définir comme Arrière-plan du Bureau"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Aperçu"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Image Suivante"

--- a/dll/win32/shimgvw/lang/he-IL.rc
+++ b/dll/win32/shimgvw/lang/he-IL.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "מציג התמונות והפקסים של ReactOS"
     IDS_SETASDESKBG "קבע כרקע שולחן עבודה"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "תצוגה מקדימה"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "התמונה הבאה"

--- a/dll/win32/shimgvw/lang/it-IT.rc
+++ b/dll/win32/shimgvw/lang/it-IT.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Visualizzatore immagini e fax di ReactOS"
     IDS_SETASDESKBG "Imposta come sfondo del desktop"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Anteprima"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Immagine successiva"

--- a/dll/win32/shimgvw/lang/ja-JP.rc
+++ b/dll/win32/shimgvw/lang/ja-JP.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS画像とFAXビュアー"
     IDS_SETASDESKBG "デスクトップの背景に設定する"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "プレビュー"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "次の画像"

--- a/dll/win32/shimgvw/lang/lt-LT.rc
+++ b/dll/win32/shimgvw/lang/lt-LT.rc
@@ -6,6 +6,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS paveikslėlių ir faksogramų peržiūros programa"
     IDS_SETASDESKBG "Nustatyti kaip darbalaukio foną"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Preview"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Tolesnis paveikslėlis"

--- a/dll/win32/shimgvw/lang/no-NO.rc
+++ b/dll/win32/shimgvw/lang/no-NO.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS bilde og Faks Viser"
     IDS_SETASDESKBG "Sett som skrivebord bakgrunn"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Skriv ut"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Neste bilde"

--- a/dll/win32/shimgvw/lang/pl-PL.rc
+++ b/dll/win32/shimgvw/lang/pl-PL.rc
@@ -9,6 +9,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Przeglądarka obrazów i faksów ReactOS"
     IDS_SETASDESKBG "Ustaw jako tło pulpitu"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Podgląd"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Następny obraz"

--- a/dll/win32/shimgvw/lang/pt-PT.rc
+++ b/dll/win32/shimgvw/lang/pt-PT.rc
@@ -9,6 +9,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Visualizador de imagens e faxes do ReactOS"
     IDS_SETASDESKBG "Definir como plano de fundo da área de trabalho"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Pre-visualizar"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Próxima imagem"

--- a/dll/win32/shimgvw/lang/ro-RO.rc
+++ b/dll/win32/shimgvw/lang/ro-RO.rc
@@ -11,6 +11,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Vizualizare fax și imagini"
     IDS_SETASDESKBG "Plasează ca decor de fundal"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Previzionare"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Imaginea următare"

--- a/dll/win32/shimgvw/lang/ru-RU.rc
+++ b/dll/win32/shimgvw/lang/ru-RU.rc
@@ -4,6 +4,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Программа просмотра изображений и факсов"
     IDS_SETASDESKBG "Установить как фон рабочего стола"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Предпросмотр"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Следующее изображение"

--- a/dll/win32/shimgvw/lang/sk-SK.rc
+++ b/dll/win32/shimgvw/lang/sk-SK.rc
@@ -8,6 +8,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Zobrazovač obrázkov a faxov systému ReactOS"
     IDS_SETASDESKBG "Nastaviť ako pozadie pracovnej plochy"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Preview" // Náhľad, Ukážka, Prezrieť ???
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Nasledujúci obrázok"

--- a/dll/win32/shimgvw/lang/sq-AL.rc
+++ b/dll/win32/shimgvw/lang/sq-AL.rc
@@ -8,6 +8,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS Vëzhguesi i Fotove dhe Faxit"
     IDS_SETASDESKBG "Vendos si Sfond Desktopi"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Shikim Paraprak"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Fotoja Tjetër"

--- a/dll/win32/shimgvw/lang/tr-TR.rc
+++ b/dll/win32/shimgvw/lang/tr-TR.rc
@@ -6,6 +6,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS Resim ve Belgegeçer Görüntüleyicisi"
     IDS_SETASDESKBG "Masaüstü Arka Planı Olarak Ayarla"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Ön İzleme"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Sonraki Resim"

--- a/dll/win32/shimgvw/lang/uk-UA.rc
+++ b/dll/win32/shimgvw/lang/uk-UA.rc
@@ -12,6 +12,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "Програма перегляду зображень і факсів ReactOS"
     IDS_SETASDESKBG "Встановити як фон робочого столу"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "Перегляд"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "Наступне зображення"

--- a/dll/win32/shimgvw/lang/zh-CN.rc
+++ b/dll/win32/shimgvw/lang/zh-CN.rc
@@ -7,6 +7,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS 图片和传真查看器"
     IDS_SETASDESKBG "设置为桌面背景"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "预览"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "下一张图片"

--- a/dll/win32/shimgvw/lang/zh-TW.rc
+++ b/dll/win32/shimgvw/lang/zh-TW.rc
@@ -6,6 +6,7 @@ STRINGTABLE
 BEGIN
     IDS_APPTITLE "ReactOS 圖片和傳真檢視器"
     IDS_SETASDESKBG "設定為桌面背景"
+    IDS_NOPREVIEW "No preview available."
     IDS_PREVIEW "預覽"
     /* Tooltips */
     IDS_TOOLTIP_NEXT_PIC "下一張圖片"

--- a/dll/win32/shimgvw/resource.h
+++ b/dll/win32/shimgvw/resource.h
@@ -38,6 +38,7 @@
 /* Strings */
 #define IDS_APPTITLE    100
 #define IDS_SETASDESKBG 101
+#define IDS_NOPREVIEW   102
 #define IDS_PREVIEW     550
 
 /* Friendly File Type Names */

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -240,6 +240,9 @@ static void ResetZoom(void)
     RECT Rect;
     UINT ImageWidth, ImageHeight;
 
+    if (image == NULL)
+        return;
+
     /* get disp window size and image size */
     GetClientRect(hDispWnd, &Rect);
     GdipGetImageWidth(image, &ImageWidth);
@@ -434,35 +437,52 @@ pPrintImage(HWND hwnd)
 }
 
 static VOID
+EnableToolBarButtons(BOOL bEnable)
+{
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMP, bEnable);
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMM, bEnable);
+
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT1, bEnable);
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT2, bEnable);
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_SAVE, bEnable);
+    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_PRINT, bEnable);
+}
+
+static VOID
 pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
 {
     WCHAR szTitleBuf[800];
     WCHAR szResStr[512];
     LPWSTR pchFileTitle;
 
-    if (node)
+    if (image)
     {
-        if (image)
-        {
-            GdipDisposeImage(image);
-            image = NULL;
-        }
-
-        pLoadImage(node->FileName);
-
-        LoadStringW(hInstance, IDS_APPTITLE, szResStr, ARRAYSIZE(szResStr));
-        if (image != NULL)
-        {
-            pchFileTitle = PathFindFileNameW(node->FileName);
-            StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
-                            L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);
-            SetWindowTextW(hwnd, szTitleBuf);
-        }
-        else
-        {
-            SetWindowTextW(hwnd, szResStr);
-        }
+        GdipDisposeImage(image);
+        image = NULL;
     }
+
+    if (node == NULL)
+    {
+        EnableToolBarButtons(FALSE);
+        return;
+    }
+
+    pLoadImage(node->FileName);
+
+    LoadStringW(hInstance, IDS_APPTITLE, szResStr, ARRAYSIZE(szResStr));
+    if (image != NULL)
+    {
+        pchFileTitle = PathFindFileNameW(node->FileName);
+        StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
+                        L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);
+        SetWindowTextW(hwnd, szTitleBuf);
+    }
+    else
+    {
+        SetWindowTextW(hwnd, szResStr);
+    }
+
+    EnableToolBarButtons(image != NULL);
 }
 
 static SHIMGVW_FILENODE*
@@ -893,16 +913,6 @@ ImageView_InitControls(HWND hwnd)
     PrevProc = (WNDPROC) SetWindowLongPtr(hDispWnd, GWLP_WNDPROC, (LPARAM) ImageView_DispWndProc);
 
     ImageView_CreateToolBar(hwnd);
-
-    if (image == NULL)
-    {
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMP, FALSE);
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMM, FALSE);
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT1, FALSE);
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT2, FALSE);
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_SAVE, FALSE);
-        SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_PRINT, FALSE);
-    }
 }
 
 static VOID

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -438,20 +438,10 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
 {
     WCHAR szTitleBuf[800];
     WCHAR szResStr[512];
-    WCHAR *c;
+    LPWSTR pchFileTitle;
 
     if (node)
     {
-        c = wcsrchr(node->FileName, '\\');
-        if (c)
-        {
-            c++;
-        }
-
-        LoadStringW(hInstance, IDS_APPTITLE, szResStr, ARRAYSIZE(szResStr));
-        StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf), L"%ls%ls%ls", szResStr, L" - ", c);
-        SetWindowTextW(hwnd, szTitleBuf);
-
         if (image)
         {
             GdipDisposeImage(image);
@@ -459,6 +449,19 @@ pLoadImageFromNode(SHIMGVW_FILENODE *node, HWND hwnd)
         }
 
         pLoadImage(node->FileName);
+
+        LoadStringW(hInstance, IDS_APPTITLE, szResStr, ARRAYSIZE(szResStr));
+        if (image != NULL)
+        {
+            pchFileTitle = PathFindFileNameW(node->FileName);
+            StringCbPrintfW(szTitleBuf, sizeof(szTitleBuf),
+                            L"%ls%ls%ls", szResStr, L" - ", pchFileTitle);
+            SetWindowTextW(hwnd, szTitleBuf);
+        }
+        else
+        {
+            SetWindowTextW(hwnd, szResStr);
+        }
     }
 }
 

--- a/dll/win32/shimgvw/shimgvw.c
+++ b/dll/win32/shimgvw/shimgvw.c
@@ -439,11 +439,6 @@ pPrintImage(HWND hwnd)
 static VOID
 EnableToolBarButtons(BOOL bEnable)
 {
-    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMP, bEnable);
-    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ZOOMM, bEnable);
-
-    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT1, bEnable);
-    SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_ROT2, bEnable);
     SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_SAVE, bEnable);
     SendMessage(hToolBar, TB_ENABLEBUTTON, IDC_PRINT, bEnable);
 }


### PR DESCRIPTION
## Purpose
If loading an image file failed, then properly handle it.
JIRA issue: [CORE-16911](https://jira.reactos.org/browse/CORE-16911)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/79744664-b6ba5880-8341-11ea-9029-24b2bf1f4e28.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/79749372-0e5cc200-834a-11ea-9874-445147dd1a1c.png)

The command line is `rundll32 shimgvw.dll,ImageView_Fullscreen`.