### PR TITLE
[NTOS:KDBG] Fixed variable declaration to make buildable the project

### DIFF
--- a/ntoskrnl/kdbg/kdb.c
+++ b/ntoskrnl/kdbg/kdb.c
@@ -1606,7 +1606,9 @@ KdbEnterDebuggerException(
         {
             /* FIXME: Add noexec memory stuff */
             ULONG_PTR TrapCr2;
+#ifndef _M_AMD64
             ULONG Err;
+#endif
 
             TrapCr2 = __readcr2();
 #ifndef _M_AMD64


### PR DESCRIPTION
Moved a declaration inside the #ifndef