### PR TITLE
[SYSDM] User Profiles fix of OnDestroy (CORE-16921)

### DIFF
--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -828,10 +828,8 @@ OnDestroy(
         Item.iSubItem = 0;
         if (ListView_GetItem(hwndListView, &Item))
         {
-            if (Item.lParam != 0)
-            {
+            if (Item.lParam != 0)            
                 HeapFree(GetProcessHeap(), 0, (LPVOID)Item.lParam);
-            }
         }
     }
 }

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -820,7 +820,6 @@ OnDestroy(
         return;
     
     nItems = ListView_GetItemCount(hwndListView);
-
     for (i = 0; i < nItems; i++)
     {
         ZeroMemory(&Item, sizeof(LVITEM));    

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -828,7 +828,7 @@ OnDestroy(
         Item.iSubItem = 0;
         if (ListView_GetItem(hwndListView, &Item))
         {
-            if (Item.lParam != 0)            
+            if (Item.lParam != 0)
                 HeapFree(GetProcessHeap(), 0, (LPVOID)Item.lParam);
         }
     }

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -645,6 +645,7 @@ UpdateButtonState(
         iSelected = ListView_GetNextItem(hwndListView, -1, LVNI_SELECTED);
         if (iSelected != -1)
         {
+            ZeroMemory(&Item, sizeof(LVITEM));
             Item.mask = LVIF_PARAM;
             Item.iItem = iSelected;
             Item.iSubItem = 0;
@@ -810,21 +811,30 @@ VOID
 OnDestroy(
     _In_ HWND hwndDlg)
 {
-    HWND hwndList;
+    HWND hwndListView;
     INT nItems, i;
     LVITEM Item;
+    //PPROFILEDATA pProfileData;
 
-    hwndList = GetDlgItem(hwndDlg, IDC_USERPROFILE_LIST);
+    hwndListView = GetDlgItem(hwndDlg, IDC_USERPROFILE_LIST);
+    if (hwndListView == NULL)
+        return;
+    
+    nItems = ListView_GetItemCount(hwndListView);
 
-    nItems = ListView_GetItemCount(hwndList);
     for (i = 0; i < nItems; i++)
     {
+        ZeroMemory(&Item, sizeof(LVITEM));    
+        Item.mask = LVIF_PARAM;
         Item.iItem = i;
-        Item.iSubItem = 0;
-        if (ListView_GetItem(hwndList, &Item))
+        Item.iSubItem = 0;    
+        if (ListView_GetItem(hwndListView, &Item))
         {
             if (Item.lParam != 0)
-                HeapFree(GetProcessHeap(), 0, (PVOID)Item.lParam);
+            {
+                //pProfileData = (PPROFILEDATA)Item.lParam;
+                HeapFree(GetProcessHeap(), 0, (LPVOID)Item.lParam);
+            }
         }
     }
 }
@@ -858,12 +868,12 @@ UserProfileDlgProc(HWND hwndDlg,
                    LPARAM lParam)
 {
     switch (uMsg)
-    {
+    {        
         case WM_INITDIALOG:
             OnInitUserProfileDialog(hwndDlg);
             return TRUE;
 
-        case WM_DESTROY:
+        case WM_DESTROY:     
             OnDestroy(hwndDlg);
             break;
 

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -813,7 +813,7 @@ OnDestroy(
 {
     HWND hwndListView;
     INT nItems, i;
-    LVITEM Item;    
+    LVITEM Item;
 
     hwndListView = GetDlgItem(hwndDlg, IDC_USERPROFILE_LIST);
     if (hwndListView == NULL)

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -813,8 +813,7 @@ OnDestroy(
 {
     HWND hwndListView;
     INT nItems, i;
-    LVITEM Item;
-    //PPROFILEDATA pProfileData;
+    LVITEM Item;    
 
     hwndListView = GetDlgItem(hwndDlg, IDC_USERPROFILE_LIST);
     if (hwndListView == NULL)
@@ -827,12 +826,11 @@ OnDestroy(
         ZeroMemory(&Item, sizeof(LVITEM));    
         Item.mask = LVIF_PARAM;
         Item.iItem = i;
-        Item.iSubItem = 0;    
+        Item.iSubItem = 0;
         if (ListView_GetItem(hwndListView, &Item))
         {
             if (Item.lParam != 0)
             {
-                //pProfileData = (PPROFILEDATA)Item.lParam;
                 HeapFree(GetProcessHeap(), 0, (LPVOID)Item.lParam);
             }
         }
@@ -868,12 +866,12 @@ UserProfileDlgProc(HWND hwndDlg,
                    LPARAM lParam)
 {
     switch (uMsg)
-    {        
+    {
         case WM_INITDIALOG:
             OnInitUserProfileDialog(hwndDlg);
             return TRUE;
 
-        case WM_DESTROY:     
+        case WM_DESTROY:
             OnDestroy(hwndDlg);
             break;
 

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -125,7 +125,6 @@ ChangeUserProfileType(
     ZeroMemory(&Item, sizeof(LVITEM));
     Item.mask = LVIF_PARAM;
     Item.iItem = iSelected;
-    Item.iSubItem = 0;
     if (!ListView_GetItem(hwndListView, &Item))
         return FALSE;
 
@@ -170,7 +169,6 @@ DeleteUserProfile(
     ZeroMemory(&Item, sizeof(LVITEM));
     Item.mask = LVIF_PARAM;
     Item.iItem = iSelected;
-    Item.iSubItem = 0;
     if (!ListView_GetItem(hwndListView, &Item))
         return FALSE;
 
@@ -253,7 +251,6 @@ CopyUserProfile(
     ZeroMemory(&Item, sizeof(LVITEM));
     Item.mask = LVIF_PARAM;
     Item.iItem = iSelected;
-    Item.iSubItem = 0;
     if (!ListView_GetItem(hwndListView, &Item))
         return FALSE;
 
@@ -648,7 +645,6 @@ UpdateButtonState(
             ZeroMemory(&Item, sizeof(LVITEM));
             Item.mask = LVIF_PARAM;
             Item.iItem = iSelected;
-            Item.iSubItem = 0;
             if (ListView_GetItem(hwndListView, &Item))
             {
                 if (Item.lParam != 0)
@@ -825,7 +821,6 @@ OnDestroy(
         ZeroMemory(&Item, sizeof(LVITEM));    
         Item.mask = LVIF_PARAM;
         Item.iItem = i;
-        Item.iSubItem = 0;
         if (ListView_GetItem(hwndListView, &Item))
         {
             if (Item.lParam != 0)

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -645,6 +645,7 @@ UpdateButtonState(
             ZeroMemory(&Item, sizeof(LVITEM));
             Item.mask = LVIF_PARAM;
             Item.iItem = iSelected;
+
             if (ListView_GetItem(hwndListView, &Item))
             {
                 if (Item.lParam != 0)


### PR DESCRIPTION
## Purpose

_ User Profiles window incorrectly release Heap zone in its OnDestroy() function, leading to undue closure of its parent Window

JIRA issue: [CORE-16921](https://jira.reactos.org/browse/CORE-16921)

## Proposed changes

_ Correct initialization of "Item" variable before using it
_ Protection against invalid Handle usage
_ Consistency of variable naming accross the window
