### PR TITLE
[GDI32_APITEST] Add Tahoma font to GetTextMetrics apitest set

### DIFF
--- a/modules/rostests/apitests/gdi32/GetTextMetrics.c
+++ b/modules/rostests/apitests/gdi32/GetTextMetrics.c
@@ -373,6 +373,57 @@ static const TEST_ENTRY g_MSMINCHO[] =
     { __LINE__, -400, 0, 3000, 400, 400, 344, 56, 0, 0 },
 };
 #define g_MSMINCHO_count _countof(g_MSMINCHO)
+
+static const TEST_ENTRY g_TAHOMA[] =
+{
+    { __LINE__, 400, 0, 1953, 400, 400, 332, 68, 0, 0 },
+    { __LINE__, 300, 0, 1466, 300, 300, 249, 51, 0, 0 },
+    { __LINE__, 200, 0, 980, 200, 200, 166, 34, 0, 0 },
+    { __LINE__, 100, 0, 490, 100, 100, 83, 17, 0, 0 },
+    { __LINE__, 64, 0, 316, 64, 64, 53, 11, 0, 0 },
+    { __LINE__, 32, 0, 156, 32, 32, 27, 5, 6, 0 },
+    { __LINE__, 16, 0, 77, 16, 16, 13, 3, 0, 0 },
+    { __LINE__, 15, 0, 73, 15, 15, 12, 3, 0, 0 },
+    { __LINE__, 14, 0, 73, 14, 14, 12, 2, 0, 0 },
+    { __LINE__, 13, 0, 64, 13, 13, 11, 2, 0, 0 },
+    { __LINE__, 12, 0, 56, 12, 12, 10, 2, 0, 0 },
+    { __LINE__, 11, 0, 55, 11, 11, 9, 2, 0, 0 },
+    { __LINE__, 10, 0, 50, 10, 10, 8, 2, 0, 0 },
+    { __LINE__, 9, 0, 41, 9, 9, 7, 2, 0, 0 },
+    { __LINE__, 8, 0, 41, 8, 8, 7, 1, 0, 0 },
+    { __LINE__, 7, 0, 36, 7, 7, 6, 1, 0, 0 },
+    { __LINE__, 6, 0, 32, 6, 6, 5, 1, 0, 0 },
+    { __LINE__, 5, 0, 22, 5, 5, 4, 1, 0, 0 },
+    { __LINE__, 4, 0, 19, 4, 4, 3, 1, 0, 0 },
+    { __LINE__, 3, 0, 13, 4, 4, 3, 0, 0, 0 },
+    { __LINE__, 2, 0, 13, 2, 2, 2, 0, 0, 0 },
+    { __LINE__, 1, 0, 13, 2, 2, 2, 0, 0, 0 },
+    { __LINE__, 0, 0, -135, -18, -18, -15, -3, 0, 0 },
+    { __LINE__, -1, 0, 13, 2, 2, 2, 0, 0, 0 },
+    { __LINE__, -2, 0, 13, 2, 2, 2, 0, 0, 0 },
+    { __LINE__, -3, 0, 19, 4, 4, 3, 0, 0, 0 },
+    { __LINE__, -4, 0, 22, 5, 5, 4, 1, 0, 0 },
+    { __LINE__, -5, 0, 32, 6, 6, 5, 1, 0, 0 },
+    { __LINE__, -6, 0, 36, 7, 7, 6, 1, 0, 0 },
+    { __LINE__, -7, 0, 41, 8, 8, 7, 1, 0, 0 },
+    { __LINE__, -8, 0, 50, 10, 10, 8, 2, 0, 0 },
+    { __LINE__, -9, 0, 55, 11, 11, 9, 2, 0, 0 },
+    { __LINE__, -10, 0, 56, 12, 12, 10, 2, 0, 0 },
+    { __LINE__, -11, 0, 64, 13, 13, 11, 2, 0, 0 },
+    { __LINE__, -12, 0, 73, 14, 14, 12, 2, 0, 0 },
+    { __LINE__, -13, 0, 77, 16, 16, 13, 3, 0, 0 },
+    { __LINE__, -14, 0, 78, 17, 17, 14, 3, 0, 0 },
+    { __LINE__, -15, 0, 89, 18, 18, 15, 3, 0, 0 },
+    { __LINE__, -16, 0, 94, 19, 19, 16, 3, 0, 0 },
+    { __LINE__, -32, 0, 189, 39, 39, 32, 7, 7, 0 },
+    { __LINE__, -64, 0, 379, 77, 77, 64, 13, 0, 0 },
+    { __LINE__, -100, 0, 589, 121, 121, 100, 21, 0, 0 },
+    { __LINE__, -200, 0, 1182, 241, 241, 200, 41, 0, 0 },
+    { __LINE__, -300, 0, 1770, 362, 362, 300, 62, 0, 0 },
+    { __LINE__, -400, 0, 2361, 483, 483, 400, 83, 0, 0 },
+};
+#define g_TAHOMA_count _countof(g_TAHOMA)
+
 #endif
 
 typedef struct FONT_ENTRY
@@ -393,6 +444,7 @@ static FONT_ENTRY g_font_entries[] =
     { "UBUNTUMONO", "Ubuntu Mono", "UbuntuMono-R.ttf" },
     { "MSGOTHIC", "MS Gothic", "msgothic.ttc" },
     { "MSMINCHO", "MS Mincho", "msmincho.ttc" },
+    { "TAHOMA", "Tahoma", "tahoma.ttf" },
 #else
     { "FREEMONO", "FreeMono", "FreeMono.ttf", g_FREEMONO_count, g_FREEMONO },
     { "DEJAVUSERIF", "DejaVu Serif", "DejaVuSerif.ttf", g_DEJAVUSERIF_count, g_DEJAVUSERIF },
@@ -400,6 +452,7 @@ static FONT_ENTRY g_font_entries[] =
     { "UBUNTUMONO", "Ubuntu Mono", "UbuntuMono-R.ttf", g_UBUNTUMONO_count, g_UBUNTUMONO },
     { "MSGOTHIC", "MS Gothic", "msgothic.ttc", g_MSGOTHIC_count, g_MSGOTHIC },
     { "MSMINCHO", "MS Mincho", "msmincho.ttc", g_MSMINCHO_count, g_MSMINCHO },
+    { "TAHOMA", "Tahoma", "Tahoma.ttf", g_TAHOMA_count, g_TAHOMA },
 #endif
 };
 static size_t g_font_entry_count = _countof(g_font_entries);
@@ -463,6 +516,8 @@ START_TEST(GetTextMetrics)
         for (k = 0; k < font->test_count; ++k)
         {
             const TEST_ENTRY *test = &font->tests[k];
+
+            printf("Testing '%s'.\n", font->entry_name);
 
             lf.lfHeight = test->lfHeight;
             lf.lfWidth = test->lfWidth;

--- a/modules/rostests/apitests/gdi32/GetTextMetrics.c
+++ b/modules/rostests/apitests/gdi32/GetTextMetrics.c
@@ -486,6 +486,8 @@ START_TEST(GetTextMetrics)
             continue;
         }
 
+        trace("Testing '%s'.\n", font->font_file);
+
 #ifdef EMIT_TESTCASES
         printf("static const TEST_ENTRY g_%s[] =\n", font->entry_name);
         printf("{\n");
@@ -516,8 +518,6 @@ START_TEST(GetTextMetrics)
         for (k = 0; k < font->test_count; ++k)
         {
             const TEST_ENTRY *test = &font->tests[k];
-
-            printf("Testing '%s'.\n", font->entry_name);
 
             lf.lfHeight = test->lfHeight;
             lf.lfWidth = test->lfWidth;


### PR DESCRIPTION
## Add Tahoma font to GetTextMetrics apitest set.

_Tahoma is available in Windows and ReactOS both, so this allows us to compare these fonts in both systems._


