### PR TITLE
[RAPPS] Update now-redirected 'http' and 'www.reactos.org' URLs

### DIFF
--- a/base/applications/rapps/README.RUS
+++ b/base/applications/rapps/README.RUS
@@ -1,4 +1,4 @@
-For more information for RAPPS, see: https://www.reactos.org/wiki/RAPPS
+For more information for RAPPS, see: https://reactos.org/wiki/RAPPS
 
 днаюбкемхе гюцпсфюелшу опнцпюлл
 

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -195,7 +195,7 @@ BEGIN
     IDS_APPS_COUNT "Брой приложения: %d; Selected: %d"
     IDS_WELCOME_TITLE "Управителят на приложенията на РеактОС ви приветства"
     IDS_WELCOME_TEXT "Изберете раздел от лявата страна, след което изберете приложение за слагане или премахване.\nСтраницата на РеактОС: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Сложено"
     IDS_AVAILABLEFORINST "Налично за слагане"
     IDS_UPDATES "Обновления"

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -196,7 +196,7 @@ BEGIN
     IDS_APPS_COUNT "Počet aplikací: %d; Selected: %d"
     IDS_WELCOME_TITLE "Vítejte v ReactOS Správci aplikací!\n\n"
     IDS_WELCOME_TEXT "Na levé straně zvolte kategorii, pak vpravo zvolte aplikaci, která bude nainstalována nebo odinstalována.\nWebová stránka ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Nainstalováno"
     IDS_AVAILABLEFORINST "Lze instalovat"
     IDS_UPDATES "Aktualizace"

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Anzahl der Anwendungen: %d, ausgewählt: %d"
     IDS_WELCOME_TITLE "Willkommen im ReactOS-Anwendungsmanager!\n\n"
     IDS_WELCOME_TEXT "Wählen Sie links eine Kategorie und dann eine Anwendung um sie zu installieren oder zu deinstallieren.\nReactOS-Webseite: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installiert"
     IDS_AVAILABLEFORINST "Zur Installation verfügbar"
     IDS_UPDATES "Aktualisierungen"

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Applications count: %d; Selected: %d"
     IDS_WELCOME_TITLE "Welcome to ReactOS Applications Manager!\n\n"
     IDS_WELCOME_TEXT "Choose a category on the left, then choose an application to install or uninstall.\nReactOS Web Site: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installed"
     IDS_AVAILABLEFORINST "Available for installation"
     IDS_UPDATES "Updates"

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -194,7 +194,7 @@ BEGIN
     IDS_APPS_COUNT "Nº de aplicaciones: %d; Selecionadas: %d"
     IDS_WELCOME_TITLE "Bienvenido al Administrador de aplicaciones de ReactOS.\n\n"
     IDS_WELCOME_TEXT "Seleccione una categoría a la izquierda, para más tarde seleccionar la aplicación a instalar o desinstalar.\nWeb de ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Instaladas"
     IDS_AVAILABLEFORINST "Disponible para su instalación"
     IDS_UPDATES "Actualizaciones"

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_APPS_COUNT "Rakenduste arv: %d; Valitud: %d"
     IDS_WELCOME_TITLE "Tere tulemast ReactOS'i Rakenduste Haldurisse!\n\n"
     IDS_WELCOME_TEXT "Vali vasakult teema, siis vali paremalt rakendusi mida soovid installida või desinstallida.\nReactOS'i veebileht: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installitud"
     IDS_AVAILABLEFORINST "Installimiseks saadaval"
     IDS_UPDATES "Uuendused"

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Nombre d'applications : %d ; Sélectionnées : %d"
     IDS_WELCOME_TITLE "Bienvenue dans ReactOS Applications Manager !\n\n"
     IDS_WELCOME_TEXT "Choisissez une catégorie à gauche, ensuite choisissez une application à installer ou désinstaller.\nSite internet de ReactOS : "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installé"
     IDS_AVAILABLEFORINST "Disponible pour installation"
     IDS_UPDATES "Mises à jour"

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_APPS_COUNT "ספירת יישומים: %d; Selected: %d"
     IDS_WELCOME_TITLE "ברוכים הבאים למנהל היישומים של ReactOS!\n\n"
     IDS_WELCOME_TEXT "Choose a category on the left, then choose an application to install or uninstall.\nReactOS Web Site: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "מותקן"
     IDS_AVAILABLEFORINST "זמין להתקנה"
     IDS_UPDATES "עדכונים"

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Jumlah aplikasi: %d; Terpilih: %d"
     IDS_WELCOME_TITLE "Selamat datang di Manajer Aplikasi ReactOS!\n\n"
     IDS_WELCOME_TEXT "pilih kategori di sisi kiri, kemudian pilih aplikasi untuk dipasang atau dibongkar.\nSitus Web ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Terpasang"
     IDS_AVAILABLEFORINST "Tersedia untuk pemasangan"
     IDS_UPDATES "Pembaruan"

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Numero applicazioni: %d; Selezionate: %d"
     IDS_WELCOME_TITLE "Benvenuto!\n\n"
     IDS_WELCOME_TEXT "Scegliere una categoria a sinistra, poi scegliere una applicazione da installare o disinstallare.\nReactOS Web Site: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installato"
     IDS_AVAILABLEFORINST "Disponibile per l'installazione"
     IDS_UPDATES "Aggiornamenti"

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT          "アプリケーション数: %d; Selected: %d"
     IDS_WELCOME_TITLE       "ReactOS アプリケーション マネージャへようこそ!\n\n"
     IDS_WELCOME_TEXT        "左側からカテゴリを選択し、インストール又はアンインストールするアプリケーションを選んでください。\nReactOS ウェブ サイト: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED           "インストール済み"
     IDS_AVAILABLEFORINST    "インストール可能"
     IDS_UPDATES             "アップデート"

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Program oppsummering: %d; Selected: %d"
     IDS_WELCOME_TITLE "Velkommen til ReactOS programbehandler!\n\n"
     IDS_WELCOME_TEXT "Velg en kategori til venstre, og velg et program for installere eller avinstallere programvaren.\nReactOS internettside: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installert"
     IDS_AVAILABLEFORINST "Tilgjengelig for installasjon"
     IDS_UPDATES "Oppdateringer"

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -2,7 +2,7 @@
  *    Translated by Caemyr - Olaf Siejka (Aug, 2009)
  *    Use ReactOS forum PM or IRC to contact me
  *    Updated by Saibamen - Adam Stachowicz (saibamenppl@gmail.com) (Apr, 2011)
- *    http://www.reactos.org
+ *    https://reactos.org/
  *    IRC: irc.freenode.net #reactos-pl;
  */
 
@@ -199,7 +199,7 @@ BEGIN
     IDS_APPS_COUNT "Licznik aplikacji: %d"
     IDS_WELCOME_TITLE "Witamy w Menedżerze aplikacji ReactOS!\n\n"
     IDS_WELCOME_TEXT "Z listy po lewej wybierz kategorię, a następnie aplikację, by ją zainstalować lub odinstalować.\nStrona projektu ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Zainstalowane"
     IDS_AVAILABLEFORINST "Dostępne"
     IDS_UPDATES "Uaktualnienia"

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_APPS_COUNT "Número de aplicativos: %d; Selected: %d"
     IDS_WELCOME_TITLE "Bem-vindo(a) a Central de Aplicativos ReactOS!\n\n"
     IDS_WELCOME_TEXT "Escolha uma categoria à esquerda, então escolha um aplicativo para instalar ou desinstalar.\nWeb Site ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Instalado"
     IDS_AVAILABLEFORINST "Disponível para instalação"
     IDS_UPDATES "Atualizações"

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_APPS_COUNT "Número de aplicativos: %d; Seleccionados: %d"
     IDS_WELCOME_TITLE "Bem-vindo(a) a Central de Aplicativos ReactOS!\n\n"
     IDS_WELCOME_TEXT "Escolha uma categoria à esquerda, então escolha um aplicativo para instalar ou desinstalar.\nWeb Site ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Instalado"
     IDS_AVAILABLEFORINST "Disponível para instalação"
     IDS_UPDATES "Actualizações"

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -200,7 +200,7 @@ BEGIN
     IDS_APPS_COUNT "Numărul de programe: %d; Selectate: %d"
     IDS_WELCOME_TITLE "Bun venit la gestionarul de programe ReactOS!\n\n"
     IDS_WELCOME_TEXT "Alegeți o categorie din stânga, apoi alegeți o aplicație pentru a o instala sau dezinstala.\nArdesa web ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Instalate"
     IDS_AVAILABLEFORINST "Disponibile pentru instalare"
     IDS_UPDATES "Actualizări"

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -191,7 +191,7 @@ BEGIN
     IDS_APPS_COUNT "Количество приложений: %d; Выбрано: %d"
     IDS_WELCOME_TITLE "Добро пожаловать в ""Менеджер приложений ReactOS""!\n\n"
     IDS_WELCOME_TEXT "Выберите категорию слева и приложение для установки или удаления.\nСайт ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Установленные"
     IDS_AVAILABLEFORINST "Доступно для установки"
     IDS_UPDATES "Обновления"

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -196,7 +196,7 @@ BEGIN
     IDS_APPS_COUNT "Počet programov: %d; Selected: %d"
     IDS_WELCOME_TITLE "Víta Vás Manažér aplikácií systému ReactOS!\n\n" // ReactOS Application Manager
     IDS_WELCOME_TEXT "Vyberte si kategóriu na ľavej strane, potom vyberte aplikáciu, ktorú chcete nainštalovať alebo odinštalovať.\nWebstránka projektu ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Nainštalované"
     IDS_AVAILABLEFORINST "Dostupné pre nainštalovanie"
     IDS_UPDATES "Aktualizácie"

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -195,7 +195,7 @@ BEGIN
     IDS_APPS_COUNT "Numrimi Aplicacioneve: %d; Selected: %d"
     IDS_WELCOME_TITLE "Mire Se Erdhe ne ReactOS Applications Manager!\n\n"
     IDS_WELCOME_TEXT "Zgjidh nje kategori ne te majte, pastaj zgjidh nje aplicacion per ta instaluar ose uninstall.\nReactOS Web Site: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Instaluar"
     IDS_AVAILABLEFORINST "Te vlefshem per instalim"
     IDS_UPDATES "Updates"

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_APPS_COUNT "Programantal: %d; Selected: %d"
     IDS_WELCOME_TITLE "Välkommen till ReactOS programhanterare!\n\n"
     IDS_WELCOME_TEXT "Välj en kategori till vänster, och sedan ett program för att installera eller avinstallera.\nReactOS Web sida: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Installerat"
     IDS_AVAILABLEFORINST "Tillgängliga for installation"
     IDS_UPDATES "Uppdateringar"

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_APPS_COUNT "Uygulama Sayısı: %d; Seçili: %d"
     IDS_WELCOME_TITLE "ReactOS Uygulama Yöneticisi'ne hoş geldiniz.\n\n"
     IDS_WELCOME_TEXT "Solda bir kategori seçiniz, ardından kurmak ya da kaldırmak için bir uygulama seçiniz.\nReactOS'un İnternet sitesi: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Kurulanlar"
     IDS_AVAILABLEFORINST "Kurulum İçin Bulunanlar"
     IDS_UPDATES "Güncelleştirmeler"

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_APPS_COUNT "Kількість додатків: %d; Обрано: %d"
     IDS_WELCOME_TITLE "Ласкаво просимо в Менеджер додатків ReactOS!\n\n"
     IDS_WELCOME_TEXT "Виберіть категорію зліва, а потім виберіть програми для встановлення чи видалення.\nСторінка ReactOS: "
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "Встановлені"
     IDS_AVAILABLEFORINST "Доступні для встановлення"
     IDS_UPDATES "Оновлення"

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_APPS_COUNT "程序数量：%d；已选：%d"
     IDS_WELCOME_TITLE "欢迎使用 ReactOS 程序管理器！\n\n"
     IDS_WELCOME_TEXT "从左栏选择一个类别，然后选择要安装或卸载的程序。\nReactOS 网站："
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "已安装"
     IDS_AVAILABLEFORINST "可安装"
     IDS_UPDATES "更新"

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_APPS_COUNT "程式個數:%d; Selected: %d"
     IDS_WELCOME_TITLE "歡迎來到 ReactOS 程式管理員！\n\n"
     IDS_WELCOME_TEXT "從左欄選擇一個類別，然後選擇要安裝或解除安裝的程式。\nReactOS 網站:"
-    IDS_WELCOME_URL "http://www.reactos.org"
+    IDS_WELCOME_URL "https://reactos.org/"
     IDS_INSTALLED "已安裝"
     IDS_AVAILABLEFORINST "可安裝"
     IDS_UPDATES "更新"


### PR DESCRIPTION
NB:
http://www.reactos.org/wiki/Bulgarian_translation
is not updated, as it returns
`Error 404 - Page not found`.