### PR TITLE
[USETUP] Update now-redirected 'http' and 'www.reactos.org' URLs

### DIFF
--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -168,7 +168,7 @@ static MUI_ENTRY bgBGWelcomePageEntries[] =
     {
         6,
         25,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -159,7 +159,7 @@ static MUI_ENTRY bnBDWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -167,7 +167,7 @@ static MUI_ENTRY csCZWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -161,7 +161,7 @@ static MUI_ENTRY daDKWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -161,7 +161,7 @@ static MUI_ENTRY deDEWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -161,7 +161,7 @@ static MUI_ENTRY elGRWelcomePageEntries[] =
     {
         5,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -159,7 +159,7 @@ static MUI_ENTRY enUSWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -164,7 +164,7 @@ static MUI_ENTRY esESWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -161,7 +161,7 @@ static MUI_ENTRY etEEWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -161,7 +161,7 @@ static MUI_ENTRY frFRWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -163,7 +163,7 @@ static MUI_ENTRY heILWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/hu-HU.h
+++ b/base/setup/usetup/lang/hu-HU.h
@@ -161,7 +161,7 @@ static MUI_ENTRY huHUWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org weboldalra.",
+        "https://reactos.org/ weboldalra.",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/id-ID.h
+++ b/base/setup/usetup/lang/id-ID.h
@@ -159,7 +159,7 @@ static MUI_ENTRY idIDWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -158,7 +158,7 @@ static MUI_ENTRY itITWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -161,7 +161,7 @@ static MUI_ENTRY jaJPWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -170,7 +170,7 @@ static MUI_ENTRY ltLTWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -158,7 +158,7 @@ static MUI_ENTRY msMYWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -173,7 +173,7 @@ static MUI_ENTRY nlNLWelcomePageEntries[] =
     {
         6,
         25,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -4,7 +4,7 @@
 /*
  *      translated by Caemyr (Jan-Feb, Apr, 2008)
  *      Use ReactOS forum PM or IRC to contact me
- *      http://www.reactos.org
+ *      https://reactos.org/
  *      IRC: irc.freenode.net #reactos-pl;
  *      Updated by Wojo664 (July, 2014)
  *      Updated by Saibamen (July, 2015)
@@ -170,7 +170,7 @@ static MUI_ENTRY plPLWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -161,7 +161,7 @@ static MUI_ENTRY ptBRWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -161,7 +161,7 @@ static MUI_ENTRY ptPTWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -169,7 +169,7 @@ static MUI_ENTRY roROWelcomePageEntries[] =
     {
         6,
         27,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -167,7 +167,7 @@ static MUI_ENTRY skSKWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -165,7 +165,7 @@ static MUI_ENTRY sqALWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -167,7 +167,7 @@ static MUI_ENTRY svSEWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -163,7 +163,7 @@ static MUI_ENTRY trTRWelcomePageEntries[] =
     {
         6,
         24,
-        "http://www.reactos.org",
+        "https://reactos.org/",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },


### PR DESCRIPTION
NB:
http://www.reactos.org/uk/
is not updated, as it returns
`Error 404 - Page not found`.