### PR TITLE
[SHELL32] Correctly fail if shortcut target not found

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -3162,7 +3162,21 @@ HRESULT STDMETHODCALLTYPE CShellLink::Drop(IDataObject *pDataObject,
     DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
 {
     TRACE("(%p)\n", this);
-    HRESULT hr = S_OK;
+    HRESULT hr;
+
+    WCHAR szPath[MAX_PATH];
+    hr = GetPath(szPath, _countof(szPath), NULL, 0);
+    if (FAILED(hr) || !PathFileExistsW(szPath))
+    {
+        Resolve(NULL, SLR_UPDATE);
+
+        hr = GetPath(szPath, _countof(szPath), NULL, 0);
+        if (FAILED_UNEXPECTEDLY(hr))
+            return hr;
+        if (!PathFileExistsW(szPath))
+            return E_FAIL;
+    }
+
     if (m_DropTarget)
         hr = m_DropTarget->Drop(pDataObject, dwKeyState, pt, pdwEffect);
 


### PR DESCRIPTION
## Purpose
Dereferencing the shell link of invalid target must fail correctly.
JIRA issue: [CORE-16816](https://jira.reactos.org/browse/CORE-16816)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/79977988-25321e80-84da-11ea-9fba-1a85c1367a55.png)
It won't fail and file operation occurs.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/79977993-26fbe200-84da-11ea-9f7a-d0f5797a9722.png)
It fails. File operation won't happen.