### PR TITLE
[SDK][RTL][NTDLL_APITEST] Add RtlMultipleAllocateHeap and RtlMultipleFreeHeap

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -61,6 +61,7 @@ list(APPEND SOURCE
     RtlImageRvaToVa.c
     RtlIsNameLegalDOS8Dot3.c
     RtlMemoryStream.c
+    RtlMultipleAllocateHeap.c
     RtlNtPathNameToDosPathName.c
     RtlpEnsureBufferSize.c
     RtlQueryTimeZoneInfo.c

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -286,8 +286,15 @@ START_TEST(RtlMultipleAllocateHeap)
     g_alloc = (FN_RtlMultipleAllocateHeap)GetProcAddress(ntdll, "RtlMultipleAllocateHeap");
     g_free = (FN_RtlMultipleFreeHeap)GetProcAddress(ntdll, "RtlMultipleFreeHeap");
 
-    MultiHeapAllocTest();
-    MultiHeapFreeTest();
+    if (!g_alloc || !g_free)
+    {
+        skip("RtlMultipleAllocateHeap or RtlMultipleFreeHeap not found\n");
+    }
+    else
+    {
+        MultiHeapAllocTest();
+        MultiHeapFreeTest();
+    }
 
     FreeLibrary(ntdll);
 }

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -117,14 +117,14 @@ MultiHeapAllocTest()
     set_array(Array, NULL, NULL, NULL);
     TEST_ALLOC(2, -1, 0, HeapHandle, 0, 1, 2, Array);
     ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
-    ok(Array[1] != NULL, "Array[1] is expected as NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as non-NULL\n");
     ok(Array[2] == NULL, "Array[2] is expected as NULL\n");
 
     set_array(Array, NULL, NULL, NULL);
     TEST_ALLOC(3, -1, 0, HeapHandle, 0, 1, 3, Array);
     ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
-    ok(Array[1] != NULL, "Array[1] is expected as NULL\n");
-    ok(Array[2] != NULL, "Array[2] is expected as NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as non-NULL\n");
+    ok(Array[2] != NULL, "Array[2] is expected as non-NULL\n");
 
     // Array is non-NULL and contents are invalid pointers
     set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
@@ -135,7 +135,7 @@ MultiHeapAllocTest()
 
     set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
     TEST_ALLOC(1, -1, 0, HeapHandle, 0, 0, 1, Array);
-    ok(Array[0] != NULL, "Array[0] is expected as 1\n");
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
     ok(Array[1] == (PVOID)2, "Array[1] is expected as 2\n");
     ok(Array[2] == (PVOID)3, "Array[2] is expected as 3\n");
 

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -1,10 +1,9 @@
 /*
- * PROJECT:         ReactOS API tests
- * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
- * PURPOSE:         Test for RtlMultipleAllocateHeap and RtlMultipleFreeHeap
- * PROGRAMMER:      Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ * PROJECT:     ReactOS API Tests
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Test for RtlMultipleAllocateHeap and RtlMultipleFreeHeap
+ * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
-
 #include "precomp.h"
 
 typedef ULONG (NTAPI *FN_RtlMultipleAllocateHeap)(IN PVOID, IN ULONG, IN SIZE_T, IN ULONG, OUT PVOID *);

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -8,18 +8,6 @@
 #include <apitest.h>
 #include <windows.h>
 
-// #define HEAP_NO_SERIALIZE                                   0x00000001
-// #define HEAP_GROWABLE                                       0x00000002
-// #define HEAP_GENERATE_EXCEPTIONS                            0x00000004
-// #define HEAP_ZERO_MEMORY                                    0x00000008
-// #define HEAP_REALLOC_IN_PLACE_ONLY                          0x00000010
-// #define HEAP_TAIL_CHECKING_ENABLED                          0x00000020
-// #define HEAP_FREE_CHECKING_ENABLED                          0x00000040
-// #define HEAP_DISABLE_COALESCE_ON_FREE                       0x00000080
-// #define HEAP_CREATE_ALIGN_16                                0x00010000
-// #define HEAP_CREATE_ENABLE_TRACING                          0x00020000
-// #define HEAP_CREATE_ENABLE_EXECUTE                          0x00040000
-
 typedef ULONG (NTAPI *FN_RtlMultipleAllocateHeap)(IN PVOID, IN ULONG, IN SIZE_T, IN ULONG, OUT PVOID *);
 typedef ULONG (NTAPI *FN_RtlMultipleFreeHeap)(IN PVOID, IN ULONG, IN ULONG, OUT PVOID *);
 

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -1,0 +1,283 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
+ * PURPOSE:         Test for RtlMultipleAllocateHeap and RtlMultipleFreeHeap
+ * PROGRAMMER:      Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
+#include <apitest.h>
+#include <windows.h>
+
+// #define HEAP_NO_SERIALIZE                                   0x00000001
+// #define HEAP_GROWABLE                                       0x00000002
+// #define HEAP_GENERATE_EXCEPTIONS                            0x00000004
+// #define HEAP_ZERO_MEMORY                                    0x00000008
+// #define HEAP_REALLOC_IN_PLACE_ONLY                          0x00000010
+// #define HEAP_TAIL_CHECKING_ENABLED                          0x00000020
+// #define HEAP_FREE_CHECKING_ENABLED                          0x00000040
+// #define HEAP_DISABLE_COALESCE_ON_FREE                       0x00000080
+// #define HEAP_CREATE_ALIGN_16                                0x00010000
+// #define HEAP_CREATE_ENABLE_TRACING                          0x00020000
+// #define HEAP_CREATE_ENABLE_EXECUTE                          0x00040000
+
+#define THE_ALLOC RtlMultipleAllocateHeap
+#define THE_FREE RtlMultipleFreeHeap
+
+#define TEST_ALLOC(ret_expected,err_expected,threw_excepted,HeapHandle,Flags,Size,Count,Array) \
+    threw = 0; \
+    SetLastError(-1); \
+    _SEH2_TRY { \
+        ret = THE_ALLOC((HeapHandle), (Flags), (Size), (Count), (Array)); \
+        err = GetLastError(); \
+    } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) { \
+        threw = _SEH2_GetExceptionCode(); \
+    } \
+    _SEH2_END \
+    ok((ret) == (ret_expected), "ret excepted %d, but %d\n", (ret_expected), (ret)); \
+    ok((err) == (err_expected), "err excepted %d, but %d\n", (err_expected), (err)); \
+    ok((threw) == (threw_excepted), "threw excepted %d, but %d\n", (threw_excepted), (threw));
+
+#define TEST_ALLOC_NO_RET(err_expected,threw_excepted,HeapHandle,Flags,Size,Count,Array) \
+    threw = 0; \
+    SetLastError(-1); \
+    _SEH2_TRY { \
+        ret = THE_ALLOC((HeapHandle), (Flags), (Size), (Count), (Array)); \
+        err = GetLastError(); \
+    } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) { \
+        threw = _SEH2_GetExceptionCode(); \
+    } \
+    _SEH2_END \
+    ok((err) == (err_expected), "err excepted %d, but %d", (err_expected), (err)); \
+    ok((threw) == (threw_excepted), "threw excepted %d, but %d\n", (threw_excepted), (threw));
+
+#define TEST_FREE(ret_expected,err_expected,threw_excepted,HeapHandle,Flags,Count,Array) \
+    threw = 0; \
+    SetLastError(-1); \
+    _SEH2_TRY { \
+        ret = THE_FREE((HeapHandle), (Flags), (Count), (Array)); \
+        err = GetLastError(); \
+    } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) { \
+        threw = _SEH2_GetExceptionCode(); \
+    } \
+    _SEH2_END \
+    ok((ret) == (ret_expected), "ret excepted %d, but %d\n", (ret_expected), (ret)); \
+    ok((err) == (err_expected), "err excepted %d, but %d\n", (err_expected), (err)); \
+    ok((threw) == (threw_excepted), "threw excepted %d, but %d\n", (threw_excepted), (threw));
+
+#define ASSUME_ARRAY_ITEMS_ARE_NULL() \
+    ok(Array[0] == NULL, "Array[0] is expected as NULL\n"); \
+    ok(Array[1] == NULL, "Array[1] is expected as NULL\n"); \
+    ok(Array[2] == NULL, "Array[2] is expected as NULL\n");
+
+#define INT_EXPECTED(var,value) \
+    ok((var) == (value), #var " expected %d, but %d\n", (value), (var))
+
+static void
+set_array(PVOID *array, PVOID p0, PVOID p1, PVOID p2)
+{
+    array[0] = p0;
+    array[1] = p1;
+    array[2] = p2;
+}
+
+static void
+MultiHeapAllocTest()
+{
+    INT ret, threw, err;
+    HANDLE HeapHandle = GetProcessHeap();
+    PVOID Array[3] = {NULL, NULL, NULL};
+
+    // HeapHandle is non-NULL and array is NULL
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 0, 0, NULL);
+    TEST_ALLOC(0, -1, 0xC0000005, HeapHandle, 0, 0, 1, NULL);
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 1, 0, NULL);
+    TEST_ALLOC(0, -1, 0xC0000005, HeapHandle, 0, 1, 1, NULL);
+
+    // Array is non-NULL and contents are NULL
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 0, 0, Array);
+    ASSUME_ARRAY_ITEMS_ARE_NULL();
+
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(1, -1, 0, HeapHandle, 0, 0, 1, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] == NULL, "Array[1] is expected as NULL\n");
+    ok(Array[2] == NULL, "Array[2] is expected as NULL\n");
+
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 1, 0, Array);
+    ASSUME_ARRAY_ITEMS_ARE_NULL();
+
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(1, -1, 0, HeapHandle, 0, 1, 1, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] == NULL, "Array[1] is expected as NULL\n");
+    ok(Array[2] == NULL, "Array[2] is expected as NULL\n");
+
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(2, -1, 0, HeapHandle, 0, 1, 2, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as NULL\n");
+    ok(Array[2] == NULL, "Array[2] is expected as NULL\n");
+
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC(3, -1, 0, HeapHandle, 0, 1, 3, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as NULL\n");
+    ok(Array[2] != NULL, "Array[2] is expected as NULL\n");
+
+    // Array is non-NULL and contents are invalid pointers
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 0, 0, Array);
+    ok(Array[0] == (PVOID)1, "Array[0] is expected as 1\n");
+    ok(Array[1] == (PVOID)2, "Array[1] is expected as 2\n");
+    ok(Array[2] == (PVOID)3, "Array[2] is expected as 3\n");
+
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(1, -1, 0, HeapHandle, 0, 0, 1, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as 1\n");
+    ok(Array[1] == (PVOID)2, "Array[1] is expected as 2\n");
+    ok(Array[2] == (PVOID)3, "Array[2] is expected as 3\n");
+
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(0, -1, 0, HeapHandle, 0, 1, 0, Array);
+    ok(Array[0] == (PVOID)1, "Array[0] is expected as 1\n");
+    ok(Array[1] == (PVOID)2, "Array[1] is expected as 2\n");
+    ok(Array[2] == (PVOID)3, "Array[2] is expected as 3\n");
+
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(1, -1, 0, HeapHandle, 0, 1, 1, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] == (PVOID)2, "Array[1] is expected as non-NULL\n");
+    ok(Array[2] == (PVOID)3, "Array[2] is expected as NULL\n");
+
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(2, -1, 0, HeapHandle, 0, 1, 2, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as non-NULL\n");
+    ok(Array[2] == (PVOID)3, "Array[2] is expected as 3\n");
+
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_ALLOC(3, -1, 0, HeapHandle, 0, 1, 3, Array);
+    ok(Array[0] != NULL, "Array[0] is expected as non-NULL\n");
+    ok(Array[1] != NULL, "Array[1] is expected as non-NULL\n");
+    ok(Array[2] != NULL, "Array[2] is expected as non-NULL\n");
+
+    // Array is non-NULL and too large to allocate
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC_NO_RET(ERROR_NOT_ENOUGH_MEMORY, 0, HeapHandle, 0, 0x5FFFFFFF, 3, Array);
+    ok(ret != 3, "excepted not allocated");
+    set_array(Array, NULL, NULL, NULL);
+    TEST_ALLOC_NO_RET(ERROR_NOT_ENOUGH_MEMORY, 0xC0000017, HeapHandle, HEAP_GENERATE_EXCEPTIONS, 0x5FFFFFFF, 3, Array);
+    ok(ret != 3, "excepted not allocated");
+}
+
+static void
+MultiHeapFreeTest()
+{
+    INT ret, threw, err;
+    HANDLE HeapHandle = GetProcessHeap();
+    PVOID Array[3] = {NULL, NULL, NULL};
+
+    // HeapHandle is non-NULL and array is NULL
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, NULL);
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, NULL);
+    TEST_FREE(0, -1, 0xC0000005, HeapHandle, 0, 1, NULL);
+    TEST_FREE(0, -1, 0xC0000005, HeapHandle, 0, 2, NULL);
+    TEST_FREE(0, -1, 0xC0000005, HeapHandle, 0, 3, NULL);
+
+    // Array is non-NULL and contents are NULL
+    set_array(Array, NULL, NULL, NULL);
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, Array);
+    set_array(Array, NULL, NULL, NULL);
+    TEST_FREE(1, -1, 0, HeapHandle, 0, 1, Array);
+    set_array(Array, NULL, NULL, NULL);
+    TEST_FREE(2, -1, 0, HeapHandle, 0, 2, Array);
+    set_array(Array, NULL, NULL, NULL);
+    TEST_FREE(3, -1, 0, HeapHandle, 0, 3, Array);
+
+    // Array is non-NULL and contents are invalid pointers
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, Array);
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_FREE(0, ERROR_INVALID_PARAMETER, 0, HeapHandle, 0, 1, Array);
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_FREE(0, ERROR_INVALID_PARAMETER, 0, HeapHandle, 0, 2, Array);
+    set_array(Array, (PVOID)1, (PVOID)2, (PVOID)3);
+    TEST_FREE(0, ERROR_INVALID_PARAMETER, 0, HeapHandle, 0, 3, Array);
+
+    // Array is non-NULL and contents are 1 valid pointer and 2 NULLs
+    set_array(Array, NULL, NULL, NULL);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, Array);
+
+    set_array(Array, NULL, NULL, NULL);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, -1, 0, HeapHandle, 0, 1, Array);
+
+    set_array(Array, NULL, NULL, NULL);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(2, -1, 0, HeapHandle, 0, 2, Array);
+
+    set_array(Array, NULL, NULL, NULL);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(3, -1, 0, HeapHandle, 0, 3, Array);
+
+    // Array is non-NULL and contents are 1 valid pointer and 2 invalids
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(0, -1, 0, HeapHandle, 0, 0, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, -1, 0, HeapHandle, 0, 1, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, ERROR_INVALID_PARAMETER, 0, HeapHandle, 0, 2, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, ERROR_INVALID_PARAMETER, 0, HeapHandle, 0, 3, Array);
+
+    // Array is non-NULL and contents are 1 valid pointer and 2 invalids (generate exceptions)
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(0, -1, 0, HeapHandle, HEAP_GENERATE_EXCEPTIONS, 0, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, -1, 0, HeapHandle, HEAP_GENERATE_EXCEPTIONS, 1, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, ERROR_INVALID_PARAMETER, 0, HeapHandle, HEAP_GENERATE_EXCEPTIONS, 2, Array);
+
+    set_array(Array, NULL, (PVOID)2, (PVOID)3);
+    ret = THE_ALLOC(HeapHandle, 0, 1, 1, Array);
+    INT_EXPECTED(ret, 1);
+    TEST_FREE(1, ERROR_INVALID_PARAMETER, 0, HeapHandle, HEAP_GENERATE_EXCEPTIONS, 3, Array);
+
+    // Array is non-NULL and contents are 3 valid pointers
+    set_array(Array, NULL, NULL, NULL);
+    ret = THE_ALLOC(HeapHandle, 0, 3, 3, Array);
+    INT_EXPECTED(ret, 3);
+    TEST_FREE(3, -1, 0, HeapHandle, 0, 3, Array);
+}
+
+START_TEST(RtlMultipleAllocateHeap)
+{
+    MultiHeapAllocTest();
+    MultiHeapFreeTest();
+}

--- a/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
+++ b/modules/rostests/apitests/ntdll/RtlMultipleAllocateHeap.c
@@ -5,8 +5,7 @@
  * PROGRAMMER:      Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
-#include <apitest.h>
-#include <windows.h>
+#include "precomp.h"
 
 typedef ULONG (NTAPI *FN_RtlMultipleAllocateHeap)(IN PVOID, IN ULONG, IN SIZE_T, IN ULONG, OUT PVOID *);
 typedef ULONG (NTAPI *FN_RtlMultipleFreeHeap)(IN PVOID, IN ULONG, IN ULONG, OUT PVOID *);

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -60,6 +60,7 @@ extern void func_RtlHandle(void);
 extern void func_RtlImageRvaToVa(void);
 extern void func_RtlIsNameLegalDOS8Dot3(void);
 extern void func_RtlMemoryStream(void);
+extern void func_RtlMultipleAllocateHeap(void);
 extern void func_RtlNtPathNameToDosPathName(void);
 extern void func_RtlpEnsureBufferSize(void);
 extern void func_RtlQueryTimeZoneInformation(void);
@@ -129,6 +130,7 @@ const struct test winetest_testlist[] =
     { "RtlImageRvaToVa",                func_RtlImageRvaToVa },
     { "RtlIsNameLegalDOS8Dot3",         func_RtlIsNameLegalDOS8Dot3 },
     { "RtlMemoryStream",                func_RtlMemoryStream },
+    { "RtlMultipleAllocateHeap",        func_RtlMultipleAllocateHeap },
     { "RtlNtPathNameToDosPathName",     func_RtlNtPathNameToDosPathName },
     { "RtlpEnsureBufferSize",           func_RtlpEnsureBufferSize },
     { "RtlQueryTimeZoneInformation",    func_RtlQueryTimeZoneInformation },

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -992,27 +992,26 @@ RtlLockHeap(
     _In_ HANDLE Heap
 );
 
-_Must_inspect_result_
 NTSYSAPI
-NTSTATUS
+ULONG
 NTAPI
-RtlMultipleAllocateHeap (
+RtlMultipleAllocateHeap(
     _In_ HANDLE HeapHandle,
     _In_ ULONG Flags,
     _In_ SIZE_T Size,
     _In_ ULONG Count,
     _Out_cap_(Count) _Deref_post_bytecap_(Size) PVOID * Array
-    );
+);
 
 NTSYSAPI
-NTSTATUS
+ULONG
 NTAPI
-RtlMultipleFreeHeap (
+RtlMultipleFreeHeap(
     _In_ HANDLE HeapHandle,
     _In_ ULONG Flags,
     _In_ ULONG Count,
     _In_count_(Count) /* _Deref_ _Post_invalid_ */ PVOID * Array
-    );
+);
 
 NTSYSAPI
 NTSTATUS

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -4019,8 +4019,6 @@ RtlMultipleFreeHeap(IN PVOID HeapHandle,
 {
     ULONG Index;
 
-    Flags &= ~HEAP_GENERATE_EXCEPTIONS; /* ignore the generate-exception flag */
-
     for (Index = 0; Index < Count; ++Index)
     {
         if (Array[Index] == NULL)

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -4018,25 +4018,14 @@ RtlMultipleFreeHeap(IN PVOID HeapHandle,
                     OUT PVOID *Array)
 {
     ULONG Index;
-    EXCEPTION_RECORD ExceptionRecord;
 
-    Flags &= ~HEAP_GENERATE_EXCEPTIONS;
+    Flags &= ~HEAP_GENERATE_EXCEPTIONS; /* ignore the generate-exception flag */
 
     for (Index = 0; Index < Count; ++Index)
     {
-        if (Array == NULL)
-        {
-            ExceptionRecord.ExceptionCode = STATUS_ACCESS_VIOLATION;
-            ExceptionRecord.ExceptionRecord = NULL;
-            ExceptionRecord.NumberParameters = 0;
-            ExceptionRecord.ExceptionFlags = 0;
-
-            RtlRaiseException(&ExceptionRecord);
-        }
         if (Array[Index] == NULL)
-        {
             continue;
-        }
+
         _SEH2_TRY
         {
             if (!RtlFreeHeap(HeapHandle, Flags, Array[Index]))


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12026](https://jira.reactos.org/browse/CORE-12026)

- Add `RtlMultipleAllocateHeap` and `RtlMultipleFreeHeap` functions (`2k3+`).
- Add a testcase for two functions.

WinXP:
![winxp](https://user-images.githubusercontent.com/2107452/80082732-bb744c00-858f-11ea-9bd1-128d5c018935.png)
XP doesn't support two functions.

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/80082760-c333f080-858f-11ea-89e6-672d0d65c3fa.png)

Win10:
![win10](https://user-images.githubusercontent.com/2107452/80082727-ba431f00-858f-11ea-9ba3-f3b1f557bf62.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/80082724-b911f200-858f-11ea-8a88-846c00578a20.png)