### PR TITLE
[SHELL32] Command 'start C:' should open 'C:\'

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1824,6 +1824,14 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
         if(l > dwApplicationNameLen) dwApplicationNameLen = l + 1;
         wszApplicationName = (LPWSTR)HeapAlloc(GetProcessHeap(), 0, dwApplicationNameLen * sizeof(WCHAR));
         memcpy(wszApplicationName, sei_tmp.lpFile, l * sizeof(WCHAR));
+
+        if (wszApplicationName[2] == 0 && wszApplicationName[1] == L':' &&
+            ((L'A' <= wszApplicationName[0] && wszApplicationName[0] <= L'Z') ||
+             (L'a' <= wszApplicationName[0] && wszApplicationName[0] <= L'z')))
+        {
+            // 'C:' --> 'C:\'
+            PathAddBackslashW(wszApplicationName);
+        }
     }
 
     wszParameters = parametersBuffer;


### PR DESCRIPTION
## Purpose

Based on JIRA user `amaneureka`'s idea.
JIRA issue: [CORE-16384](https://jira.reactos.org/browse/CORE-16384)

- In `SHELL_execute` function, add a backslash for Drive `"C:"`, `"D:"` or `"E:"` etc.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/80094342-08145300-85a1-11ea-911f-62578be8889c.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/80094341-06e32600-85a1-11ea-9988-0fff7a378397.png)
