### PR TITLE
[NTGDI][FREETYPE] Return non-zero gm.gmBlackBoxX/Y

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4203,6 +4203,12 @@ ftGdiGetGlyphOutline(
     }
 
     DPRINT("ftGdiGetGlyphOutline END and needed %lu\n", needed);
+
+    if (gm.gmBlackBoxX == 0)
+        gm.gmBlackBoxX = 1;
+    if (gm.gmBlackBoxY == 0)
+        gm.gmBlackBoxY = 1;
+
     *pgm = gm;
     return needed;
 }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15949](https://jira.reactos.org/browse/CORE-15949)

In return of `GetGlyphOutline` function call, `gm.gmBlackBoxX` and `gm.gmBlackBoxY` must be non-zero to avoid Division by Zero. At epilogue of `ftGdiGetGlyphOutline`, we adjust the values.