### PR TITLE
[SHELL32] Distinguish floppy and removable drives

### DIFF
--- a/dll/win32/shell32/dialogs/drvdefext.cpp
+++ b/dll/win32/shell32/dialogs/drvdefext.cpp
@@ -283,32 +283,17 @@ CDrvDefExt::PaintStaticControls(HWND hwndDlg, LPDRAWITEMSTRUCT pDrawItem)
     }
 }
 
-typedef NTSTATUS (NTAPI *FN_NtQueryVolumeInformationFile)(HANDLE, PIO_STATUS_BLOCK,
-                                                          PVOID, ULONG, FS_INFORMATION_CLASS);
-
 // https://stackoverflow.com/questions/3098696/get-information-about-disk-drives-result-on-windows7-32-bit-system/3100268#3100268
 static BOOL
 GetDriveTypeAndCharacteristics(HANDLE hDevice, DEVICE_TYPE *pDeviceType, ULONG *pCharacteristics)
 {
-    HMODULE ntdll;
-    FN_NtQueryVolumeInformationFile pNtQueryVolumeInformationFile;
     NTSTATUS Status;
     IO_STATUS_BLOCK IoStatusBlock;
     FILE_FS_DEVICE_INFORMATION DeviceInfo;
 
-    ntdll = GetModuleHandleA("ntdll");
-    if (ntdll == NULL)
-        return FALSE;
-
-    pNtQueryVolumeInformationFile =
-        (FN_NtQueryVolumeInformationFile)
-            GetProcAddress(ntdll, "NtQueryVolumeInformationFile");
-    if (pNtQueryVolumeInformationFile == NULL)
-        return FALSE;
-
-    Status = pNtQueryVolumeInformationFile(hDevice, &IoStatusBlock,
-                                           &DeviceInfo, sizeof(DeviceInfo),
-                                           FileFsDeviceInformation);
+    Status = NtQueryVolumeInformationFile(hDevice, &IoStatusBlock,
+                                          &DeviceInfo, sizeof(DeviceInfo),
+                                          FileFsDeviceInformation);
     if (Status == NO_ERROR)
     {
         *pDeviceType = DeviceInfo.DeviceType;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -449,6 +449,8 @@ getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
     return E_FAIL;
 }
 
+BOOL IsDriveFloppyA(LPCSTR pszDriveRoot);
+
 HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl, REFIID riid, LPVOID * ppvOut)
 {
     CComPtr<IDefaultExtractIconInit> initIcon;
@@ -476,7 +478,14 @@ HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl
     }
     else
     {
-        icon_idx = iDriveIconIds[DriveType];
+        if (DriveType == DRIVE_REMOVABLE && !IsDriveFloppyA(pszDrive))
+        {
+            icon_idx = IDI_SHELL_REMOVEABLE;
+        }
+        else
+        {
+            icon_idx = iDriveIconIds[DriveType];
+        }
         initIcon->SetNormalIcon(swShell32Name, -icon_idx);
     }
 
@@ -1117,7 +1126,10 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
                 hr = SHSetStrRet(&psd->str, "");
                 break;
             case 2:        /* type */
-                hr = SHSetStrRet(&psd->str, iDriveTypeIds[DriveType]);
+                if (DriveType == DRIVE_REMOVABLE && !IsDriveFloppyA(pszDrive))
+                    hr = SHSetStrRet(&psd->str, IDS_DRIVE_REMOVABLE);
+                else
+                    hr = SHSetStrRet(&psd->str, iDriveTypeIds[DriveType]);
                 break;
             case 3:        /* total size */
             case 4:        /* free size */


### PR DESCRIPTION
## Purpose

Distinguish floppy drive and non-floppy removable drive in icon and description.

JIRA issue: [CORE-10221](https://jira.reactos.org/browse/CORE-10221)

![after](https://user-images.githubusercontent.com/2107452/80166618-59602900-8619-11ea-8d8a-82760d7339bc.png)
