### PR TITLE
[CRT_APITEST] Add testcase for mbtowc()

### DIFF
--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -425,7 +425,7 @@ list(APPEND SOURCE_CRTDLL
 #    malloc.c
 #    mblen.c
     mbstowcs.c
-#    mbtowc.c
+    mbtowc.c
 #    memchr.c
 #    memcmp.c
 #    memcpy.c

--- a/modules/rostests/apitests/crt/mbtowc.c
+++ b/modules/rostests/apitests/crt/mbtowc.c
@@ -1,0 +1,61 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for mbtowc
+ * COPYRIGHT:       Copyright 2020 Bișoc George <fraizeraust99 at gmail dot com>
+ */
+
+#include <apitest.h>
+#include <apitest_guard.h>
+
+#define WIN32_NO_STATUS
+#include <stdio.h>
+#include <stdlib.h>
+
+START_TEST(mbtowc)
+{
+    int Length;
+    wchar_t BufferDest[3];
+    char *ch;
+
+    ch = AllocateGuarded(sizeof(ch));
+    if (!ch)
+    {
+        skip("Buffer allocation failed!\n");
+        return;
+    }
+
+    /* Assign a character for tests */
+    *ch = 'A';
+
+    /* Everything is NULL */
+    Length = mbtowc(NULL, NULL, 0);
+    ok(Length == 0, "Expected 0 characters to be converted as everything is NULL but got %u.\n", Length);
+
+    /* Don't examine the number of bytes pointed by multibyte parameter */
+    Length = mbtowc(BufferDest, ch, 0);
+    ok(Length == 0, "Expected 0 characters to be converted but got %u.\n", Length);
+
+    /* Wide character argument is invalid */
+    Length = mbtowc(NULL, ch, 0);
+    ok(Length == 0, "Expected 0 characters to be converted but got %u.\n", Length);
+
+    /* The multibyte argument is invalid */
+    Length = mbtowc(BufferDest, NULL, 0);
+    ok(Length == 0, "Expected 0 characters to be converted but got %u.\n", Length);
+
+    /* The multibyte argument is invalid but count number for examination is correct */
+    Length = mbtowc(BufferDest, NULL, MB_CUR_MAX);
+    ok(Length == 0, "Expected 0 characters to be converted but got %u.\n", Length);
+
+    /* Don't give the output but the count character inspection argument is valid */
+    Length = mbtowc(NULL, ch, MB_CUR_MAX);
+    ok(Length == 1, "The number of bytes to check should be 1 but got %u.\n", Length);
+
+    /* Convert the character and validate the output that we should get */
+    Length = mbtowc(BufferDest, ch, MB_CUR_MAX);
+    ok(Length == 1, "Expected 1 character to be converted but got %u.\n", Length);
+    ok_int(BufferDest[0], L'A');
+
+    FreeGuarded(ch);
+}

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1119,7 +1119,7 @@ list(APPEND SOURCE_MSVCRT
 #    mbsrtowcs_s
     mbstowcs.c
 #    mbstowcs_s Not exported in 2k3 Sp1
-#    mbtowc.c
+    mbtowc.c
 #    memchr.c
 #    memcmp.c
 #    memcpy.c

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -72,6 +72,7 @@ list(APPEND SOURCE_NTDLL
 #    labs.c
 #    log.c
     mbstowcs.c
+    mbtowc.c
 #    memchr.c
 #    memcmp.c
     # memcpy == memmove

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -17,6 +17,7 @@ extern void func__snwprintf(void);
 extern void func__vsnprintf(void);
 extern void func__vsnwprintf(void);
 extern void func_mbstowcs(void);
+extern void func_mbtowc(void);
 extern void func_sprintf(void);
 extern void func_strcpy(void);
 extern void func_strlen(void);
@@ -35,6 +36,7 @@ const struct test winetest_testlist[] =
     { "_vsnprintf", func__vsnprintf },
     { "_vsnwprintf", func__vsnwprintf },
     { "mbstowcs", func_mbstowcs },
+    { "mbtowc", func_mbtowc },
     { "_snprintf", func__snprintf },
     { "_snwprintf", func__snwprintf },
     { "sprintf", func_sprintf },


### PR DESCRIPTION
**Windows XP**
![Capture2](https://user-images.githubusercontent.com/34916900/80192472-83b0e700-8617-11ea-8239-3d5c012f7d35.PNG)
**Windows Server 2003**
![4](https://user-images.githubusercontent.com/34916900/80192499-94f9f380-8617-11ea-835c-140974d1ce1f.PNG)
**ReactOS (with #2563 applied to build)**
![Capture](https://user-images.githubusercontent.com/34916900/80192588-b22ec200-8617-11ea-9a29-672a29790e7a.PNG)