### PR TITLE
[SERVMAN] UI update and Error Management

### DIFF
--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -42,7 +42,7 @@ DoControlService(LPWSTR ServiceName,
         default:
             /* Unhandled control code */
             DPRINT1("Unknown control command: 0x%X\n", Control);
-            return ERROR_EXCEPTION_IN_SERVICE;
+            return ERROR_INVALID_SERVICE_CONTROL;
     }
 
     hSCManager = OpenSCManagerW(NULL,

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -8,6 +8,8 @@
  */
 
 #include "precomp.h"
+
+#define NDEBUG
 #include <debug.h>
 
 #define MAX_WAIT_TIME   30000

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -133,7 +133,7 @@ DoControlService(LPWSTR ServiceName,
                     /* It's not, make sure we haven't exceeded our wait time */
                     if (GetTickCount() >= StartTickCount + MaxWait)
                     {
-                        /* We have, give up */                        
+                        /* We have, give up */
                         DPRINT1("Timeout\n");
                         dwResult = ERROR_SERVICE_REQUEST_TIMEOUT;
                         break;
@@ -144,7 +144,7 @@ DoControlService(LPWSTR ServiceName,
         else
         {
             dwResult = GetLastError();
-        }    
+        }
 
         if (ServiceStatus.dwCurrentState == ReqState)
         {

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -8,10 +8,11 @@
  */
 
 #include "precomp.h"
+#include <debug.h>
 
 #define MAX_WAIT_TIME   30000
 
-BOOL
+DWORD
 DoControlService(LPWSTR ServiceName,
                  HWND hProgress,
                  DWORD Control)
@@ -27,6 +28,7 @@ DoControlService(LPWSTR ServiceName,
     DWORD MaxWait;
     DWORD ReqState, i;
     BOOL Result;
+    DWORD dwResult = SC_MANAGER_SUCCESS;	
 
     /* Set the state we're interested in */
     switch (Control)
@@ -39,21 +41,23 @@ DoControlService(LPWSTR ServiceName,
             break;
         default:
             /* Unhandled control code */
-            return FALSE;
+            DPRINT1("Unknown control command: 0x%X\n", Control);
+            return ERROR_EXCEPTION_IN_SERVICE;
     }
 
     hSCManager = OpenSCManagerW(NULL,
                                 NULL,
                                 SC_MANAGER_CONNECT);
-    if (!hSCManager) return FALSE;
+    if (!hSCManager) return GetLastError();
 
     hService = OpenServiceW(hSCManager,
                             ServiceName,
                             SERVICE_PAUSE_CONTINUE | SERVICE_INTERROGATE | SERVICE_QUERY_STATUS);
     if (!hService)
     {
-        CloseServiceHandle(hSCManager);
-        return FALSE;
+        dwResult = GetLastError();
+		CloseServiceHandle(hSCManager);
+        return dwResult;
     }
 
         /* Send the control message to the service */
@@ -109,6 +113,8 @@ DoControlService(LPWSTR ServiceName,
                                             &BytesNeeded))
                 {
                     /* Something went wrong... */
+                    DPRINT1("QueryServiceStatusEx failed: %d\n", GetLastError());
+                    dwResult = GetLastError();
                     break;
                 }
 
@@ -123,23 +129,33 @@ DoControlService(LPWSTR ServiceName,
                 else
                 {
                     /* It's not, make sure we haven't exceeded our wait time */
-                    if(GetTickCount() >= StartTickCount + MaxWait)
+                    if (GetTickCount() >= StartTickCount + MaxWait)
                     {
-                        /* We have, give up */
+                        /* We have, give up */                        
+                        DPRINT1("Timeout\n");
+                        dwResult = ERROR_SERVICE_REQUEST_TIMEOUT;
                         break;
                     }
                 }
             }
         }
+		else
+		{
+			dwResult = GetLastError();
+		}	
 
         if (ServiceStatus.dwCurrentState == ReqState)
         {
-            Result = TRUE;
+            dwResult = SC_MANAGER_SUCCESS;
         }
     }
+	else
+	{
+        dwResult = GetLastError();
+	}
 
     CloseServiceHandle(hService);
     CloseServiceHandle(hSCManager);
 
-    return Result;
+    return dwResult;
 }

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -113,8 +113,8 @@ DoControlService(LPWSTR ServiceName,
                                             &BytesNeeded))
                 {
                     /* Something went wrong... */
-                    DPRINT1("QueryServiceStatusEx failed: %d\n", GetLastError());
                     dwResult = GetLastError();
+                    DPRINT1("QueryServiceStatusEx failed: %d\n", dwResult);
                     break;
                 }
 

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -28,7 +28,7 @@ DoControlService(LPWSTR ServiceName,
     DWORD MaxWait;
     DWORD ReqState, i;
     BOOL Result;
-    DWORD dwResult = SC_MANAGER_SUCCESS;
+    DWORD dwResult = ERROR_SUCCESS;
 
     /* Set the state we're interested in */
     switch (Control)
@@ -146,7 +146,7 @@ DoControlService(LPWSTR ServiceName,
 
         if (ServiceStatus.dwCurrentState == ReqState)
         {
-            dwResult = SC_MANAGER_SUCCESS;
+            dwResult = ERROR_SUCCESS;
         }
     }
     else

--- a/base/applications/mscutils/servman/control.c
+++ b/base/applications/mscutils/servman/control.c
@@ -28,7 +28,7 @@ DoControlService(LPWSTR ServiceName,
     DWORD MaxWait;
     DWORD ReqState, i;
     BOOL Result;
-    DWORD dwResult = SC_MANAGER_SUCCESS;	
+    DWORD dwResult = SC_MANAGER_SUCCESS;
 
     /* Set the state we're interested in */
     switch (Control)
@@ -56,7 +56,7 @@ DoControlService(LPWSTR ServiceName,
     if (!hService)
     {
         dwResult = GetLastError();
-		CloseServiceHandle(hSCManager);
+        CloseServiceHandle(hSCManager);
         return dwResult;
     }
 
@@ -139,20 +139,20 @@ DoControlService(LPWSTR ServiceName,
                 }
             }
         }
-		else
-		{
-			dwResult = GetLastError();
-		}	
+        else
+        {
+            dwResult = GetLastError();
+        }    
 
         if (ServiceStatus.dwCurrentState == ReqState)
         {
             dwResult = SC_MANAGER_SUCCESS;
         }
     }
-	else
-	{
+    else
+    {
         dwResult = GetLastError();
-	}
+    }
 
     CloseServiceHandle(hService);
     CloseServiceHandle(hSCManager);

--- a/base/applications/mscutils/servman/lang/bg-BG.rc
+++ b/base/applications/mscutils/servman/lang/bg-BG.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Управление на услугите"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Управление на услугите на РеактОС"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/bg-BG.rc
+++ b/base/applications/mscutils/servman/lang/bg-BG.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Управление на услугите на РеактОС"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/cs-CZ.rc
+++ b/base/applications/mscutils/servman/lang/cs-CZ.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Správce služeb"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/cs-CZ.rc
+++ b/base/applications/mscutils/servman/lang/cs-CZ.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Ovldání služeb"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Správce služeb"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/de-DE.rc
+++ b/base/applications/mscutils/servman/lang/de-DE.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Dienst-Manager"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/de-DE.rc
+++ b/base/applications/mscutils/servman/lang/de-DE.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Dienststeuerung"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Dienst-Manager"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/el-GR.rc
+++ b/base/applications/mscutils/servman/lang/el-GR.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Service Control"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Διαχειριστής Υπηρεσιών του ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/el-GR.rc
+++ b/base/applications/mscutils/servman/lang/el-GR.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Διαχειριστής Υπηρεσιών του ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/en-US.rc
+++ b/base/applications/mscutils/servman/lang/en-US.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/en-US.rc
+++ b/base/applications/mscutils/servman/lang/en-US.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Service Control"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/es-ES.rc
+++ b/base/applications/mscutils/servman/lang/es-ES.rc
@@ -235,7 +235,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Control de servicios"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -335,6 +334,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Administrador de servicios de ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/es-ES.rc
+++ b/base/applications/mscutils/servman/lang/es-ES.rc
@@ -334,13 +334,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Administrador de servicios de ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/fr-FR.rc
+++ b/base/applications/mscutils/servman/lang/fr-FR.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Contrôle du Service"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestionnaire de Services ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Erreur du Service: Commande inconnue"
+    IDS_MANAGER_ERR_SRVMGROPN "Erreur du Service: Impossible d'ouvrir le gestionnaire de service"
+    IDS_MANAGER_ERR_SRVOPN "Erreur du Service: Impossible d'ouvrir le service"
+    IDS_MANAGER_ERR_ALLOC "Erreur du Service: Défaut d'allocation de mémoire"
+    IDS_MANAGER_ERR_QSS "Erreur du Service: Impossible de récupérer l'état du service"
+    IDS_MANAGER_ERR_TIMEOUT "Erreur du Service: Délai dépassé"
+    IDS_MANAGER_ERR_UNKNOWN "Erreur du Service: Erreur inconnue"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/fr-FR.rc
+++ b/base/applications/mscutils/servman/lang/fr-FR.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestionnaire de Services ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Erreur du Service: Commande inconnue"
-    IDS_MANAGER_ERR_SRVMGROPN "Erreur du Service: Impossible d'ouvrir le gestionnaire de service"
-    IDS_MANAGER_ERR_SRVOPN "Erreur du Service: Impossible d'ouvrir le service"
-    IDS_MANAGER_ERR_ALLOC "Erreur du Service: Défaut d'allocation de mémoire"
-    IDS_MANAGER_ERR_QSS "Erreur du Service: Impossible de récupérer l'état du service"
-    IDS_MANAGER_ERR_TIMEOUT "Erreur du Service: Délai dépassé"
-    IDS_MANAGER_ERR_UNKNOWN "Erreur du Service: Erreur inconnue"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/he-IL.rc
+++ b/base/applications/mscutils/servman/lang/he-IL.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "בקרת שירות"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "מנהל השירותים של ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/he-IL.rc
+++ b/base/applications/mscutils/servman/lang/he-IL.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "מנהל השירותים של ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/id-ID.rc
+++ b/base/applications/mscutils/servman/lang/id-ID.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Kontrol Layanan"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/id-ID.rc
+++ b/base/applications/mscutils/servman/lang/id-ID.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/it-IT.rc
+++ b/base/applications/mscutils/servman/lang/it-IT.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestione dei servizi di ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/it-IT.rc
+++ b/base/applications/mscutils/servman/lang/it-IT.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Controllo dei servizi"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestione dei servizi di ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ja-JP.rc
+++ b/base/applications/mscutils/servman/lang/ja-JP.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS サービス マネージャ"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ja-JP.rc
+++ b/base/applications/mscutils/servman/lang/ja-JP.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "サービス コントロール"
 FONT 9, "MS UI Gothic", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS サービス マネージャ"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ko-KR.rc
+++ b/base/applications/mscutils/servman/lang/ko-KR.rc
@@ -234,7 +234,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "서비스 컨트롤"
 FONT 9, "굴림", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -334,6 +333,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 서비스 관리자"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ko-KR.rc
+++ b/base/applications/mscutils/servman/lang/ko-KR.rc
@@ -333,13 +333,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 서비스 관리자"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/no-NO.rc
+++ b/base/applications/mscutils/servman/lang/no-NO.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Tjenestebehandler"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/no-NO.rc
+++ b/base/applications/mscutils/servman/lang/no-NO.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Tjeneste kontroll"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Tjenestebehandler"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/pl-PL.rc
+++ b/base/applications/mscutils/servman/lang/pl-PL.rc
@@ -242,7 +242,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Usługa kontrolna"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -342,6 +341,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Menedżer usług ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/pl-PL.rc
+++ b/base/applications/mscutils/servman/lang/pl-PL.rc
@@ -341,13 +341,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Menedżer usług ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ro-RO.rc
+++ b/base/applications/mscutils/servman/lang/ro-RO.rc
@@ -336,13 +336,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestionar de servicii"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ro-RO.rc
+++ b/base/applications/mscutils/servman/lang/ro-RO.rc
@@ -237,7 +237,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Control servicii"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -337,6 +336,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Gestionar de servicii"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ru-RU.rc
+++ b/base/applications/mscutils/servman/lang/ru-RU.rc
@@ -232,7 +232,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Управление службами"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -332,6 +331,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Диспетчер служб ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/ru-RU.rc
+++ b/base/applications/mscutils/servman/lang/ru-RU.rc
@@ -331,13 +331,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Диспетчер служб ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sk-SK.rc
+++ b/base/applications/mscutils/servman/lang/sk-SK.rc
@@ -336,13 +336,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Manažér služieb systému ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sk-SK.rc
+++ b/base/applications/mscutils/servman/lang/sk-SK.rc
@@ -237,7 +237,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Service Control"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -337,6 +336,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Manažér služieb systému ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sq-AL.rc
+++ b/base/applications/mscutils/servman/lang/sq-AL.rc
@@ -237,7 +237,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Kontrolli i shërbimeve"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -337,6 +336,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Menaxhues i shërbimeve të ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sq-AL.rc
+++ b/base/applications/mscutils/servman/lang/sq-AL.rc
@@ -336,13 +336,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Menaxhues i shërbimeve të ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sv-SE.rc
+++ b/base/applications/mscutils/servman/lang/sv-SE.rc
@@ -239,7 +239,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Tjänst kontroll"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -339,6 +338,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS tjänster"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/sv-SE.rc
+++ b/base/applications/mscutils/servman/lang/sv-SE.rc
@@ -338,13 +338,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS tjänster"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/th-TH.rc
+++ b/base/applications/mscutils/servman/lang/th-TH.rc
@@ -240,7 +240,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "ตัวควบคุมบริการ"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -340,6 +339,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/th-TH.rc
+++ b/base/applications/mscutils/servman/lang/th-TH.rc
@@ -339,13 +339,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS Service Manager"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/tr-TR.rc
+++ b/base/applications/mscutils/servman/lang/tr-TR.rc
@@ -234,7 +234,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Hizmet Denetimi"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -334,6 +333,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Hizmet Yöneticisi"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/tr-TR.rc
+++ b/base/applications/mscutils/servman/lang/tr-TR.rc
@@ -333,13 +333,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Hizmet Yöneticisi"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/uk-UA.rc
+++ b/base/applications/mscutils/servman/lang/uk-UA.rc
@@ -240,7 +240,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "Управління службами"
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -340,6 +339,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Диспетчер керування службами ReactOS"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/uk-UA.rc
+++ b/base/applications/mscutils/servman/lang/uk-UA.rc
@@ -339,13 +339,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "Диспетчер керування службами ReactOS"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/zh-CN.rc
+++ b/base/applications/mscutils/servman/lang/zh-CN.rc
@@ -234,7 +234,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "服务控制"
 FONT 9, "宋体", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -334,6 +333,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 服务管理器"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/zh-CN.rc
+++ b/base/applications/mscutils/servman/lang/zh-CN.rc
@@ -333,13 +333,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 服务管理器"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/zh-TW.rc
+++ b/base/applications/mscutils/servman/lang/zh-TW.rc
@@ -333,13 +333,6 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 服務管理員"
-    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
-    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
-    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
-    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
-    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
-    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
-    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/lang/zh-TW.rc
+++ b/base/applications/mscutils/servman/lang/zh-TW.rc
@@ -234,7 +234,6 @@ IDD_DLG_PROGRESS DIALOGEX 6, 6, 255, 89
 CAPTION "服務控制"
 FONT 9, "新細明體", 0, 0
 STYLE DS_SHELLFONT | WS_BORDER | WS_DLGFRAME | WS_SYSMENU | WS_VISIBLE | DS_MODALFRAME
-EXSTYLE WS_EX_TOOLWINDOW
 BEGIN
     CONTROL "", IDC_SERVCON_PROGRESS, "msctls_progress32", 0x50000000, 8, 46, 238, 13
     LTEXT "", IDC_SERVCON_INFO, 8, 5, 236, 11
@@ -334,6 +333,13 @@ END
 STRINGTABLE
 BEGIN
     IDS_APPNAME "ReactOS 服務管理員"
+    IDS_MANAGER_ERR_UNKCMD "Service Error: Unknown command"
+    IDS_MANAGER_ERR_SRVMGROPN "Service Error: Unable to open service manager"
+    IDS_MANAGER_ERR_SRVOPN "Service Error: Unable to open service"
+    IDS_MANAGER_ERR_ALLOC "Service Error: Memory allocation failed"
+    IDS_MANAGER_ERR_QSS "Service Error: Unable to query service status"
+    IDS_MANAGER_ERR_TIMEOUT "Service Error: Timeout"
+    IDS_MANAGER_ERR_UNKNOWN "Service Error: Unknown error"
 END
 
 STRINGTABLE

--- a/base/applications/mscutils/servman/precomp.h
+++ b/base/applications/mscutils/servman/precomp.h
@@ -44,8 +44,6 @@
 #define ORD_ASCENDING   1
 #define ORD_DESCENDING  -1
 
-#define SC_MANAGER_SUCCESS    0
-
 typedef struct _MAIN_WND_INFO
 {
     HWND  hMainWnd;

--- a/base/applications/mscutils/servman/precomp.h
+++ b/base/applications/mscutils/servman/precomp.h
@@ -43,6 +43,11 @@
 #define ORD_ASCENDING   1
 #define ORD_DESCENDING  -1
 
+#define SC_MANAGER_SUCCESS    0
+//https://docs.microsoft.com/fr-fr/windows/win32/debug/system-error-codes--1000-1299-
+#define ERROR_SERVICE_REQUEST_TIMEOUT          1053
+#define ERROR_EXCEPTION_IN_SERVICE             1064 
+
 typedef struct _MAIN_WND_INFO
 {
     HWND  hMainWnd;
@@ -100,9 +105,9 @@ VOID ListViewSelectionChanged(PMAIN_WND_INFO Info, LPNMLISTVIEW pnmv);
 BOOL CreateListView(PMAIN_WND_INFO Info);
 
 /* start / stop / control */
-BOOL DoStartService(LPWSTR ServiceName, HANDLE hProgress, LPWSTR lpStartParams);
-BOOL DoStopService(LPWSTR ServiceName, HANDLE hProgress);
-BOOL DoControlService(LPWSTR ServiceName, HWND hProgress, DWORD Control);
+DWORD DoStartService(LPWSTR ServiceName, HANDLE hProgress, LPWSTR lpStartParams);
+DWORD DoStopService(LPWSTR ServiceName, HANDLE hProgress);
+DWORD DoControlService(LPWSTR ServiceName, HWND hProgress, DWORD Control);
 
 /* progress.c */
 #define DEFAULT_STEP 0
@@ -121,7 +126,6 @@ VOID FreeServiceList(PMAIN_WND_INFO Info);
 BOOL RefreshServiceList(PMAIN_WND_INFO Info);
 BOOL UpdateServiceStatus(ENUM_SERVICE_STATUS_PROCESS* pService);
 BOOL GetServiceList(PMAIN_WND_INFO Info);
-
 
 /* propsheet.c */
 typedef struct _SERVICEPROPSHEET

--- a/base/applications/mscutils/servman/precomp.h
+++ b/base/applications/mscutils/servman/precomp.h
@@ -7,14 +7,15 @@
 
 #include <windef.h>
 #include <winbase.h>
+#include <winerror.h>
 #include <wingdi.h>
 #include <winsvc.h>
 #include <wincon.h>
+
 #include <shlobj.h>
 #include <commdlg.h>
 #include <strsafe.h>
 #include <process.h>
-#include <winerror.h>
 
 #include "resource.h"
 

--- a/base/applications/mscutils/servman/precomp.h
+++ b/base/applications/mscutils/servman/precomp.h
@@ -14,6 +14,7 @@
 #include <commdlg.h>
 #include <strsafe.h>
 #include <process.h>
+#include <winerror.h>
 
 #include "resource.h"
 
@@ -44,9 +45,6 @@
 #define ORD_DESCENDING  -1
 
 #define SC_MANAGER_SUCCESS    0
-//https://docs.microsoft.com/fr-fr/windows/win32/debug/system-error-codes--1000-1299-
-#define ERROR_SERVICE_REQUEST_TIMEOUT          1053
-#define ERROR_EXCEPTION_IN_SERVICE             1064 
 
 typedef struct _MAIN_WND_INFO
 {

--- a/base/applications/mscutils/servman/progress.c
+++ b/base/applications/mscutils/servman/progress.c
@@ -28,21 +28,21 @@ typedef struct _PROGRESS_DATA
 
 VOID ShowError(DWORD dwLastError)
 {
-    LPTSTR lpMsg;
+    LPWSTR lpMsg;
 
-    if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                       FORMAT_MESSAGE_FROM_SYSTEM |
-                       FORMAT_MESSAGE_IGNORE_INSERTS,
-                       NULL,
-                       dwLastError,
-                       LANG_USER_DEFAULT,
-                       (LPTSTR)&lpMsg,
-                       0, NULL))
+    if (!FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                        NULL,
+                        dwLastError,
+                        LANG_USER_DEFAULT,
+                        (LPWSTR)&lpMsg,
+                        0, NULL))
     {
         return;
     }
 
-    MessageBox(NULL, lpMsg, NULL, MB_OK | MB_ICONERROR);
+    MessageBoxW(NULL, lpMsg, NULL, MB_OK | MB_ICONERROR);
     LocalFree(lpMsg);
 }
 

--- a/base/applications/mscutils/servman/progress.c
+++ b/base/applications/mscutils/servman/progress.c
@@ -85,7 +85,7 @@ ResetProgressDialog(HWND hDlg,
 
 unsigned int __stdcall ActionThread(void* Param)
 {
-    PPROGRESS_DATA ProgressData = (PPROGRESS_DATA)Param;   
+    PPROGRESS_DATA ProgressData = (PPROGRESS_DATA)Param;
     DWORD dwResult;
 
     if (ProgressData->Action == ACTION_START)

--- a/base/applications/mscutils/servman/progress.c
+++ b/base/applications/mscutils/servman/progress.c
@@ -97,9 +97,9 @@ unsigned int __stdcall ActionThread(void* Param)
 
         /* Start the service */
         dwResult = DoStartService(ProgressData->ServiceName,
-                           ProgressData->hProgress,
-                           ProgressData->Param);
-        if (dwResult==ERROR_SUCCESS)
+                                  ProgressData->hProgress,
+                                  ProgressData->Param);
+        if (dwResult == ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
@@ -134,8 +134,8 @@ unsigned int __stdcall ActionThread(void* Param)
 
                 /* Stop the requested service */
                 dwResult = DoStopService(ProgressData->ServiceName,
-                                  ProgressData->hProgress);
-                if (dwResult==ERROR_SUCCESS)
+                                         ProgressData->hProgress);
+                if (dwResult == ERROR_SUCCESS)
                 {
                     CompleteProgressBar(ProgressData->hProgress);
                 }
@@ -155,8 +155,8 @@ unsigned int __stdcall ActionThread(void* Param)
                             IDS_PROGRESS_INFO_STOP);
 
         dwResult = DoStopService(ProgressData->ServiceName,
-                          ProgressData->hProgress);
-        if (dwResult==ERROR_SUCCESS)
+                                 ProgressData->hProgress);
+        if (dwResult == ERROR_SUCCESS)
         {
             CompleteProgressBar(ProgressData->hProgress);
         }
@@ -176,9 +176,9 @@ unsigned int __stdcall ActionThread(void* Param)
 
             /* Start the service */
             dwResult = DoStartService(ProgressData->ServiceName,
-                               ProgressData->hProgress,
-                               NULL);
-            if (dwResult==ERROR_SUCCESS)
+                                      ProgressData->hProgress,
+                                      NULL);
+            if (dwResult == ERROR_SUCCESS)
             {
                 /* We're done, slide the progress bar up to the top */
                 CompleteProgressBar(ProgressData->hProgress);
@@ -198,9 +198,9 @@ unsigned int __stdcall ActionThread(void* Param)
 
         /* Pause the service */
         dwResult = DoControlService(ProgressData->ServiceName,
-                             ProgressData->hProgress,
-                             SERVICE_CONTROL_PAUSE);
-        if (dwResult==ERROR_SUCCESS)
+                                    ProgressData->hProgress,
+                                    SERVICE_CONTROL_PAUSE);
+        if (dwResult == ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
@@ -219,9 +219,9 @@ unsigned int __stdcall ActionThread(void* Param)
 
         /* resume the service */
         dwResult = DoControlService(ProgressData->ServiceName,
-                             ProgressData->hProgress,
-                             SERVICE_CONTROL_CONTINUE);
-        if (dwResult==ERROR_SUCCESS)
+                                    ProgressData->hProgress,
+                                    SERVICE_CONTROL_CONTINUE);
+        if (dwResult == ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);

--- a/base/applications/mscutils/servman/progress.c
+++ b/base/applications/mscutils/servman/progress.c
@@ -26,6 +26,25 @@ typedef struct _PROGRESS_DATA
 
 } PROGRESS_DATA, *PPROGRESS_DATA;
 
+VOID ShowError(DWORD dwLastError)
+{
+    LPTSTR lpMsg;
+
+    if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                       FORMAT_MESSAGE_FROM_SYSTEM |
+                       FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL,
+                       dwLastError,
+                       LANG_USER_DEFAULT,
+                       (LPTSTR)&lpMsg,
+                       0, NULL))
+    {
+        return;
+    }
+
+    MessageBox(NULL, lpMsg, NULL, MB_OK | MB_ICONERROR);
+    LocalFree(lpMsg);
+}
 
 static VOID
 ResetProgressDialog(HWND hDlg,
@@ -66,7 +85,8 @@ ResetProgressDialog(HWND hDlg,
 
 unsigned int __stdcall ActionThread(void* Param)
 {
-    PPROGRESS_DATA ProgressData = (PPROGRESS_DATA)Param;
+    PPROGRESS_DATA ProgressData = (PPROGRESS_DATA)Param;   
+    DWORD dwResult;
 
     if (ProgressData->Action == ACTION_START)
     {
@@ -76,12 +96,17 @@ unsigned int __stdcall ActionThread(void* Param)
                             IDS_PROGRESS_INFO_START);
 
         /* Start the service */
-        if (DoStartService(ProgressData->ServiceName,
+        dwResult = DoStartService(ProgressData->ServiceName,
                            ProgressData->hProgress,
-                           ProgressData->Param))
+                           ProgressData->Param);
+        if (dwResult==SC_MANAGER_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
+        }
+        else
+        {
+            ShowError(dwResult);
         }
     }
     else if (ProgressData->Action == ACTION_STOP || ProgressData->Action == ACTION_RESTART)
@@ -108,10 +133,15 @@ unsigned int __stdcall ActionThread(void* Param)
                                     IDS_PROGRESS_INFO_STOP);
 
                 /* Stop the requested service */
-                if (DoStopService(ProgressData->ServiceName,
-                                  ProgressData->hProgress))
+                dwResult = DoStopService(ProgressData->ServiceName,
+                                  ProgressData->hProgress);
+                if (dwResult==SC_MANAGER_SUCCESS)
                 {
                     CompleteProgressBar(ProgressData->hProgress);
+                }
+                else
+                {
+                    ShowError(dwResult);
                 }
 
                 /* Move onto the next string */
@@ -124,10 +154,15 @@ unsigned int __stdcall ActionThread(void* Param)
                             ProgressData->ServiceName,
                             IDS_PROGRESS_INFO_STOP);
 
-        if (DoStopService(ProgressData->ServiceName,
-                          ProgressData->hProgress))
+        dwResult = DoStopService(ProgressData->ServiceName,
+                          ProgressData->hProgress);
+        if (dwResult==SC_MANAGER_SUCCESS)
         {
             CompleteProgressBar(ProgressData->hProgress);
+        }
+        else
+        {
+            ShowError(dwResult);
         }
 
 
@@ -140,12 +175,17 @@ unsigned int __stdcall ActionThread(void* Param)
                                 IDS_PROGRESS_INFO_START);
 
             /* Start the service */
-            if (DoStartService(ProgressData->ServiceName,
+            dwResult = DoStartService(ProgressData->ServiceName,
                                ProgressData->hProgress,
-                               NULL))
+                               NULL);
+            if (dwResult==SC_MANAGER_SUCCESS)
             {
                 /* We're done, slide the progress bar up to the top */
                 CompleteProgressBar(ProgressData->hProgress);
+            }
+            else
+            {
+                ShowError(dwResult);
             }
         }
     }
@@ -157,12 +197,17 @@ unsigned int __stdcall ActionThread(void* Param)
                             IDS_PROGRESS_INFO_PAUSE);
 
         /* Pause the service */
-        if (DoControlService(ProgressData->ServiceName,
+        dwResult = DoControlService(ProgressData->ServiceName,
                              ProgressData->hProgress,
-                             SERVICE_CONTROL_PAUSE))
+                             SERVICE_CONTROL_PAUSE);
+        if (dwResult==SC_MANAGER_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
+        }
+        else
+        {
+            ShowError(dwResult);
         }
     }
     else if (ProgressData->Action == ACTION_RESUME)
@@ -173,12 +218,17 @@ unsigned int __stdcall ActionThread(void* Param)
                             IDS_PROGRESS_INFO_RESUME);
 
         /* resume the service */
-        if (DoControlService(ProgressData->ServiceName,
+        dwResult = DoControlService(ProgressData->ServiceName,
                              ProgressData->hProgress,
-                             SERVICE_CONTROL_CONTINUE))
+                             SERVICE_CONTROL_CONTINUE);
+        if (dwResult==SC_MANAGER_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
+        }
+        else
+        {
+            ShowError(dwResult);
         }
     }
 

--- a/base/applications/mscutils/servman/progress.c
+++ b/base/applications/mscutils/servman/progress.c
@@ -99,7 +99,7 @@ unsigned int __stdcall ActionThread(void* Param)
         dwResult = DoStartService(ProgressData->ServiceName,
                            ProgressData->hProgress,
                            ProgressData->Param);
-        if (dwResult==SC_MANAGER_SUCCESS)
+        if (dwResult==ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
@@ -135,7 +135,7 @@ unsigned int __stdcall ActionThread(void* Param)
                 /* Stop the requested service */
                 dwResult = DoStopService(ProgressData->ServiceName,
                                   ProgressData->hProgress);
-                if (dwResult==SC_MANAGER_SUCCESS)
+                if (dwResult==ERROR_SUCCESS)
                 {
                     CompleteProgressBar(ProgressData->hProgress);
                 }
@@ -156,7 +156,7 @@ unsigned int __stdcall ActionThread(void* Param)
 
         dwResult = DoStopService(ProgressData->ServiceName,
                           ProgressData->hProgress);
-        if (dwResult==SC_MANAGER_SUCCESS)
+        if (dwResult==ERROR_SUCCESS)
         {
             CompleteProgressBar(ProgressData->hProgress);
         }
@@ -178,7 +178,7 @@ unsigned int __stdcall ActionThread(void* Param)
             dwResult = DoStartService(ProgressData->ServiceName,
                                ProgressData->hProgress,
                                NULL);
-            if (dwResult==SC_MANAGER_SUCCESS)
+            if (dwResult==ERROR_SUCCESS)
             {
                 /* We're done, slide the progress bar up to the top */
                 CompleteProgressBar(ProgressData->hProgress);
@@ -200,7 +200,7 @@ unsigned int __stdcall ActionThread(void* Param)
         dwResult = DoControlService(ProgressData->ServiceName,
                              ProgressData->hProgress,
                              SERVICE_CONTROL_PAUSE);
-        if (dwResult==SC_MANAGER_SUCCESS)
+        if (dwResult==ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);
@@ -221,7 +221,7 @@ unsigned int __stdcall ActionThread(void* Param)
         dwResult = DoControlService(ProgressData->ServiceName,
                              ProgressData->hProgress,
                              SERVICE_CONTROL_CONTINUE);
-        if (dwResult==SC_MANAGER_SUCCESS)
+        if (dwResult==ERROR_SUCCESS)
         {
             /* We're done, slide the progress bar up to the top */
             CompleteProgressBar(ProgressData->hProgress);

--- a/base/applications/mscutils/servman/resource.h
+++ b/base/applications/mscutils/servman/resource.h
@@ -5,18 +5,10 @@
 #define IDA_SERVMAN 20
 
 /* about box info */
-#define IDD_ABOUTBOX                  200
-#define IDC_LICENSE_EDIT              201
-#define IDS_APPNAME                   202
-#define IDS_LICENSE                   203
-#define IDS_ERROROCCURED              204
-#define IDS_MANAGER_ERR_UNKCMD        205
-#define IDS_MANAGER_ERR_SRVMGROPN     206
-#define IDS_MANAGER_ERR_SRVOPN        207
-#define IDS_MANAGER_ERR_ALLOC         208
-#define IDS_MANAGER_ERR_QSS           209
-#define IDS_MANAGER_ERR_TIMEOUT       210
-#define IDS_MANAGER_ERR_UNKNOWN       211
+#define IDD_ABOUTBOX     200
+#define IDC_LICENSE_EDIT 201
+#define IDS_APPNAME      202
+#define IDS_LICENSE      203
 
 #define IDC_SERVLIST    1000
 #define IDC_STATUSBAR   1001

--- a/base/applications/mscutils/servman/resource.h
+++ b/base/applications/mscutils/servman/resource.h
@@ -5,10 +5,18 @@
 #define IDA_SERVMAN 20
 
 /* about box info */
-#define IDD_ABOUTBOX     200
-#define IDC_LICENSE_EDIT 201
-#define IDS_APPNAME      202
-#define IDS_LICENSE      203
+#define IDD_ABOUTBOX                  200
+#define IDC_LICENSE_EDIT              201
+#define IDS_APPNAME                   202
+#define IDS_LICENSE                   203
+#define IDS_ERROROCCURED              204
+#define IDS_MANAGER_ERR_UNKCMD        205
+#define IDS_MANAGER_ERR_SRVMGROPN     206
+#define IDS_MANAGER_ERR_SRVOPN        207
+#define IDS_MANAGER_ERR_ALLOC         208
+#define IDS_MANAGER_ERR_QSS           209
+#define IDS_MANAGER_ERR_TIMEOUT       210
+#define IDS_MANAGER_ERR_UNKNOWN       211
 
 #define IDC_SERVLIST    1000
 #define IDC_STATUSBAR   1001

--- a/base/applications/mscutils/servman/start.c
+++ b/base/applications/mscutils/servman/start.c
@@ -171,8 +171,8 @@ DoStartService(LPWSTR ServiceName,
                                             &BytesNeeded))
                 {
                     /* Something went wrong... */
-                    DPRINT1("QueryServiceStatusEx failed: %d\n", GetLastError());
                     dwResult = GetLastError();
+                    DPRINT1("QueryServiceStatusEx failed: %d\n", dwResult);
                     break;
                 }
 

--- a/base/applications/mscutils/servman/start.c
+++ b/base/applications/mscutils/servman/start.c
@@ -8,6 +8,8 @@
  */
 
 #include "precomp.h"
+
+#define NDEBUG
 #include <debug.h>
 
 #define MAX_WAIT_TIME   30000

--- a/base/applications/mscutils/servman/start.c
+++ b/base/applications/mscutils/servman/start.c
@@ -30,7 +30,7 @@ DoStartService(LPWSTR ServiceName,
     BOOL bWhiteSpace = TRUE;
     LPWSTR lpChar;
     DWORD dwArgsCount = 0;
-    DWORD dwResult = SC_MANAGER_SUCCESS;
+    DWORD dwResult = ERROR_SUCCESS;
     LPCWSTR *lpArgsVector = NULL;
 
     if (lpStartParams != NULL)
@@ -203,7 +203,7 @@ DoStartService(LPWSTR ServiceName,
 
         if (ServiceStatus.dwCurrentState == SERVICE_RUNNING)
         {
-            dwResult = SC_MANAGER_SUCCESS;
+            dwResult = ERROR_SUCCESS;
         }
     }
 

--- a/base/applications/mscutils/servman/start.c
+++ b/base/applications/mscutils/servman/start.c
@@ -25,13 +25,13 @@ DoStartService(LPWSTR ServiceName,
     DWORD OldCheckPoint;
     DWORD WaitTime;
     DWORD MaxWait;
-    BOOL Result = FALSE;    
+    BOOL Result = FALSE;
 
     BOOL bWhiteSpace = TRUE;
     LPWSTR lpChar;
     DWORD dwArgsCount = 0;
-	DWORD dwResult = SC_MANAGER_SUCCESS;
-	LPCWSTR *lpArgsVector = NULL;
+    DWORD dwResult = SC_MANAGER_SUCCESS;
+    LPCWSTR *lpArgsVector = NULL;
 
     if (lpStartParams != NULL)
     {
@@ -93,7 +93,7 @@ DoStartService(LPWSTR ServiceName,
                                 SC_MANAGER_CONNECT);
     if (!hSCManager)
     {
-		dwResult = GetLastError();
+        dwResult = GetLastError();
         if (lpArgsVector)
             LocalFree((LPVOID)lpArgsVector);
         return dwResult;
@@ -105,7 +105,7 @@ DoStartService(LPWSTR ServiceName,
     if (!hService)
     {
         dwResult = GetLastError();
-		CloseServiceHandle(hSCManager);
+        CloseServiceHandle(hSCManager);
         if (lpArgsVector)
             LocalFree((LPVOID)lpArgsVector);
         return dwResult;
@@ -133,8 +133,8 @@ DoStartService(LPWSTR ServiceName,
                                         SC_STATUS_PROCESS_INFO,
                                         (LPBYTE)&ServiceStatus,
                                         sizeof(SERVICE_STATUS_PROCESS),
-                                        &BytesNeeded);        
-		if (Result)
+                                        &BytesNeeded);
+        if (Result)
         {
             Result = FALSE;
             MaxWait = MAX_WAIT_TIME;

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -36,7 +36,7 @@ DoStopService(_In_z_ LPWSTR ServiceName,
     if (!hService)
     {
         dwResult = GetLastError();
-		CloseServiceHandle(hSCManager);
+        CloseServiceHandle(hSCManager);
         return dwResult;
     }
 
@@ -109,10 +109,10 @@ DoStopService(_In_z_ LPWSTR ServiceName,
             dwResult = SC_MANAGER_SUCCESS;
         }
     }
-	else
-	{
-        dwResult = GetLastError();	
-	}
+    else
+    {
+        dwResult = GetLastError();    
+    }
 
     CloseServiceHandle(hService);
     CloseServiceHandle(hSCManager);

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -8,6 +8,8 @@
  */
 
 #include "precomp.h"
+
+#define NDEBUG
 #include <debug.h>
 
 #define MAX_WAIT_TIME   30000

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -8,10 +8,11 @@
  */
 
 #include "precomp.h"
+#include <debug.h>
 
 #define MAX_WAIT_TIME   30000
 
-BOOL
+DWORD
 DoStopService(_In_z_ LPWSTR ServiceName,
               _In_opt_ HANDLE hProgress)
 {
@@ -21,22 +22,22 @@ DoStopService(_In_z_ LPWSTR ServiceName,
     DWORD BytesNeeded;
     DWORD StartTime;
     DWORD WaitTime;
-    DWORD Timeout;
-    BOOL bRet = FALSE;
-
-
+    DWORD Timeout;    
+    DWORD dwResult = SC_MANAGER_SUCCESS;
+    
     hSCManager = OpenSCManagerW(NULL,
                                 NULL,
                                 SC_MANAGER_CONNECT);
-    if (!hSCManager) return FALSE;
+    if (!hSCManager) return GetLastError();
 
     hService = OpenServiceW(hSCManager,
                             ServiceName,
                             SERVICE_STOP | SERVICE_QUERY_STATUS);
     if (!hService)
     {
-        CloseServiceHandle(hSCManager);
-        return FALSE;
+        dwResult = GetLastError();
+		CloseServiceHandle(hSCManager);
+        return dwResult;
     }
 
     if (hProgress)
@@ -90,21 +91,31 @@ DoStopService(_In_z_ LPWSTR ServiceName,
                 if (GetTickCount() - StartTime > Timeout)
                 {
                     /* Yep, give up */
+                    DPRINT1("Timeout\n");
+                    dwResult = ERROR_SERVICE_REQUEST_TIMEOUT;
                     break;
                 }
+            }
+            else
+            {
+                DPRINT1("QueryServiceStatusEx failed: %d\n", GetLastError());
+                dwResult = GetLastError();
             }
         }
 
         /* If the service is stopped, return TRUE */
         if (ServiceStatus.dwCurrentState == SERVICE_STOPPED)
         {
-            bRet = TRUE;
+            dwResult = SC_MANAGER_SUCCESS;
         }
     }
+	else
+	{
+        dwResult = GetLastError();	
+	}
 
     CloseServiceHandle(hService);
-
     CloseServiceHandle(hSCManager);
 
-    return bRet;
+    return dwResult;
 }

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -98,8 +98,8 @@ DoStopService(_In_z_ LPWSTR ServiceName,
             }
             else
             {
-                DPRINT1("QueryServiceStatusEx failed: %d\n", GetLastError());
                 dwResult = GetLastError();
+                DPRINT1("QueryServiceStatusEx failed: %d\n", dwResult);
             }
         }
 

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -23,7 +23,7 @@ DoStopService(_In_z_ LPWSTR ServiceName,
     DWORD StartTime;
     DWORD WaitTime;
     DWORD Timeout;    
-    DWORD dwResult = SC_MANAGER_SUCCESS;
+    DWORD dwResult = ERROR_SUCCESS;
     
     hSCManager = OpenSCManagerW(NULL,
                                 NULL,
@@ -106,7 +106,7 @@ DoStopService(_In_z_ LPWSTR ServiceName,
         /* If the service is stopped, return TRUE */
         if (ServiceStatus.dwCurrentState == SERVICE_STOPPED)
         {
-            dwResult = SC_MANAGER_SUCCESS;
+            dwResult = ERROR_SUCCESS;
         }
     }
     else

--- a/base/applications/mscutils/servman/stop.c
+++ b/base/applications/mscutils/servman/stop.c
@@ -24,7 +24,7 @@ DoStopService(_In_z_ LPWSTR ServiceName,
     DWORD BytesNeeded;
     DWORD StartTime;
     DWORD WaitTime;
-    DWORD Timeout;    
+    DWORD Timeout;
     DWORD dwResult = ERROR_SUCCESS;
     
     hSCManager = OpenSCManagerW(NULL,


### PR DESCRIPTION
## Purpose

_ Current design does not warn user nor logs DEBUG traces when Service Start/Stop command fails or reach timeout
_ Current Service Start/Stop progress window are WS_EX_TOOLWINDOW which reduce lisibility, is a ReactOS specificity without good reason

This is to be considered as a pre-requisite for https://jira.reactos.org/browse/CORE-16950 resolution, which will imply message pump to be added + interaction with running threads

## Proposed changes

_ DPRINT1 traces added on failure cases
_ Error Message box presented to user upon failure with explicit root cause identification
_ Change Dialog definition to standard Windows

![image](https://user-images.githubusercontent.com/24843587/80522720-4fc62080-898d-11ea-9984-26bc03fdbe80.png)


