### PR TITLE
[COMCTL32] Show All Characters in CD-Key Edit Box

### DIFF
--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -2953,8 +2953,14 @@ static void EDIT_EM_SetMargins(EDITSTATE *es, INT action,
             /* The default margins are only non zero for TrueType or Vector fonts */
             if (tm.tmPitchAndFamily & ( TMPF_VECTOR | TMPF_TRUETYPE )) {
                 if (!is_cjk(tm.tmCharSet)) {
+#ifdef __REACTOS__
+                    /* ReactOS CORE-1091 */
+                    default_left_margin = width / 4;
+                    default_right_margin = width / 4;
+#else
                     default_left_margin = width / 2;
                     default_right_margin = width / 2;
+#endif
 
                     GetClientRect(es->hwndSelf, &rc);
                     if (rc.right - rc.left < (width / 2 + width) * 2 &&


### PR DESCRIPTION
## Fix for Starcraft and MS Visual Basic 5/6 CD-Key Edit Box not Showing all Characters

_Shorten user control edit box margins to allow more room for characters to show._

JIRA issue: [CORE-1091](https://jira.reactos.org/browse/CORE-1091)

If this is accepted, it will fix an almost 15 year old bug.

The difference in the VB5 Setup screen is from a margin of 3 to 1, so it is only 2 pixels on each side.
I changed the TRACE at the end of this function to an ERR so that I could see these results:

Previous: err:(win32ss/user/user32/controls/edit.c:2998) left=3, right=3
Present: err:(win32ss/user/user32/controls/edit.c:2998) left=1, right=1