### PR TITLE
[SHELL32] Notify filesystem changes

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1185,8 +1185,10 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
         ntreg[0].pidl = m_pidlParent;
     }
     m_hNotify = SHChangeNotifyRegister(m_hWnd,
-        SHCNRF_InterruptLevel | SHCNRF_ShellLevel | SHCNRF_NewDelivery,
-        SHCNE_ALLEVENTS, SHV_CHANGE_NOTIFY, nRegCount, ntreg);
+                                       SHCNRF_InterruptLevel | SHCNRF_ShellLevel |
+                                       SHCNRF_NewDelivery,
+                                       SHCNE_ALLEVENTS, SHV_CHANGE_NOTIFY,
+                                       nRegCount, ntreg);
     if (nRegCount == 3)
     {
         ILFree(pidls[0]);

--- a/dll/win32/shell32/changenotify.cpp
+++ b/dll/win32/shell32/changenotify.cpp
@@ -320,6 +320,23 @@ CreateNotificationParamAndSend(LONG wEventId, UINT uFlags, LPITEMIDLIST pidl1, L
         SendNotifyMessageW(hwndServer, CN_DELIVER_NOTIFICATION, (WPARAM)hTicket, pid);
 }
 
+void NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
+{
+    LPITEMIDLIST pidl1 = NULL, pidl2 = NULL;
+    if (path1)
+        pidl1 = SHSimpleIDListFromPathW(path1);
+    if (path2)
+        pidl2 = SHSimpleIDListFromPathW(path1);
+
+    CreateNotificationParamAndSend(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW,
+                                   pidl1, pidl2, GetTickCount());
+
+    if (pidl1)
+        ILFree(pidl1);
+    if (pidl2)
+        ILFree(pidl2);
+}
+
 /*************************************************************************
  * SHChangeNotifyRegister           [SHELL32.2]
  */
@@ -573,7 +590,7 @@ SHChangeNotification_Lock(HANDLE hTicket, DWORD dwOwnerPID, LPITEMIDLIST **lppid
     if (lppidls)
         *lppidls = pHandbag->pidls;
     if (lpwEventId)
-        *lpwEventId = pHandbag->pTicket->wEventId;
+        *lpwEventId = (pHandbag->pTicket->wEventId & ~SHCNE_INTERRUPT);
 
     // return the handbag
     return pHandbag;

--- a/dll/win32/shell32/changenotify.cpp
+++ b/dll/win32/shell32/changenotify.cpp
@@ -320,23 +320,6 @@ CreateNotificationParamAndSend(LONG wEventId, UINT uFlags, LPITEMIDLIST pidl1, L
         SendNotifyMessageW(hwndServer, CN_DELIVER_NOTIFICATION, (WPARAM)hTicket, pid);
 }
 
-void NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
-{
-    LPITEMIDLIST pidl1 = NULL, pidl2 = NULL;
-    if (path1)
-        pidl1 = SHSimpleIDListFromPathW(path1);
-    if (path2)
-        pidl2 = SHSimpleIDListFromPathW(path2);
-
-    CreateNotificationParamAndSend(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW,
-                                   pidl1, pidl2, GetTickCount());
-
-    if (pidl1)
-        ILFree(pidl1);
-    if (pidl2)
-        ILFree(pidl2);
-}
-
 /*************************************************************************
  * SHChangeNotifyRegister           [SHELL32.2]
  */

--- a/dll/win32/shell32/changenotify.cpp
+++ b/dll/win32/shell32/changenotify.cpp
@@ -326,7 +326,7 @@ void NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
     if (path1)
         pidl1 = SHSimpleIDListFromPathW(path1);
     if (path2)
-        pidl2 = SHSimpleIDListFromPathW(path1);
+        pidl2 = SHSimpleIDListFromPathW(path2);
 
     CreateNotificationParamAndSend(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW,
                                    pidl1, pidl2, GetTickCount());

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -356,8 +356,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
         if (pDirWatch->m_fRecursive)
         {
             // then, notify a SHCNE_UPDATEDIR
-            SHChangeNotify(SHCNE_UPDATEDIR | SHCNE_INTERRUPT, SHCNF_PATHW,
-                           pDirWatch->m_szDir, NULL);
+            NotifyFileSystemChange(SHCNE_UPDATEDIR, pDirWatch->m_szDir, NULL);
 
             if (pInfo->NextEntryOffset == 0)
                 break; // there is no next entry
@@ -416,9 +415,9 @@ static void _ProcessNotification(DirWatch *pDirWatch)
         {
             // notify
             if (pInfo->Action == FILE_ACTION_RENAMED_NEW_NAME)
-                SHChangeNotify(dwEvent | SHCNE_INTERRUPT, SHCNF_PATHW, szTempPath, szPath);
+                NotifyFileSystemChange(dwEvent, szTempPath, szPath);
             else
-                SHChangeNotify(dwEvent | SHCNE_INTERRUPT, SHCNF_PATHW, szPath, NULL);
+                NotifyFileSystemChange(dwEvent, szPath, NULL);
         }
         else if (pInfo->Action == FILE_ACTION_RENAMED_OLD_NAME)
         {
@@ -474,8 +473,7 @@ _NotificationCompletion(DWORD dwErrorCode,
     if (dwNumberOfBytesTransfered == 0)
     {
         // do notify a SHCNE_UPDATEDIR
-        SHChangeNotify(SHCNE_UPDATEDIR | SHCNE_INTERRUPT, SHCNF_PATHW,
-                       pDirWatch->m_szDir, NULL);
+        NotifyFileSystemChange(SHCNE_UPDATEDIR, pDirWatch->m_szDir, NULL);
     }
     else
     {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -388,7 +388,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
         // convert SHCNE_DELETE to SHCNE_RMDIR if the path is a directory
         if (!fDir && dwEvent == SHCNE_DELETE)
         {
-            if (pList && pList->Contains(szPath, TRUE))
+            if (pList->Contains(szPath, TRUE))
             {
                 fDir = TRUE;
                 dwEvent = SHCNE_RMDIR;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -334,7 +334,6 @@ static void _ProcessNotification(DirWatch *pDirWatch)
     PFILE_NOTIFY_INFORMATION pInfo = (PFILE_NOTIFY_INFORMATION)s_buffer;
     WCHAR szName[MAX_PATH], szPath[MAX_PATH], szTempPath[MAX_PATH];
     DWORD dwEvent, cbName;
-    LPWSTR psz1, psz2;
     BOOL fDir;
 
     szPath[0] = szTempPath[0] = 0;
@@ -418,19 +417,11 @@ static void _ProcessNotification(DirWatch *pDirWatch)
 
         if (dwEvent != 0)
         {
-            if (pInfo->Action == FILE_ACTION_RENAMED_NEW_NAME)
-            {
-                psz1 = szTempPath;
-                psz2 = szPath;
-            }
-            else
-            {
-                psz1 = szPath;
-                psz2 = NULL;
-            }
-
             // notify
-            SHChangeNotify(dwEvent | SHCNE_INTERRUPT, SHCNF_PATHW, psz1, psz2);
+            if (pInfo->Action == FILE_ACTION_RENAMED_NEW_NAME)
+                SHChangeNotify(dwEvent | SHCNE_INTERRUPT, SHCNF_PATHW, szTempPath, szPath);
+            else
+                SHChangeNotify(dwEvent | SHCNE_INTERRUPT, SHCNF_PATHW, szPath, NULL);
         }
         else
         {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -105,7 +105,7 @@ void DIRLIST::RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir)
     WCHAR szPath[MAX_PATH + 1];
     for (DWORD i = 0; i < m_count; ++i)
     {
-        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem1))
+        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem1) == 0)
         {
             szPath[0] = fDir ? L'|' : L'>';
             lstrcpynW(&szPath[1], pszItem2, _countof(szPath) - 1);
@@ -124,7 +124,7 @@ void DIRLIST::DeleteItem(LPCWSTR pszItem, BOOL fDir)
 
     for (DWORD i = 0; i < m_count; ++i)
     {
-        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem))
+        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem) == 0)
         {
             free(m_items[i]);
             m_items[i] = NULL;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -395,7 +395,8 @@ static void _ProcessNotification(DirWatch *pDirWatch)
                 break;
 
             // then, notify a SHCNE_UPDATEDIR
-            PathRemoveFileSpecW(szChangePath);
+            if (lstrcmpiW(pDirWatch->m_szDir, szChangePath) != 0)
+                PathRemoveFileSpecW(szChangePath);
             NotifyFileSystemChange(SHCNE_UPDATEDIR, szChangePath, NULL);
 
             // update directory list

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -124,7 +124,7 @@ BOOL DIRLIST::GetDirList(LPCWSTR pszDir, BOOL fRecursive)
 {
     // get the full path
     WCHAR szPath[MAX_PATH];
-    GetFullPathNameW(pszDir, _countof(szPath), szPath, NULL);
+    lstrcpynW(szPath, pszDir, _countof(szPath));
 
     // is it a directory?
     if (!PathIsDirectoryW(szPath))
@@ -267,11 +267,11 @@ protected:
 };
 
 DirWatch::DirWatch(LPCWSTR pszDir, BOOL fSubTree)
+    : m_fDeadWatch(FALSE)
+    , m_fRecursive(fSubTree)
+    , m_DirList(pszDir, fSubTree)
 {
     TRACE("DirWatch::DirWatch: %p\n", this);
-
-    m_fDeadWatch = FALSE;
-    m_fRecursive = fSubTree;
 
     lstrcpynW(m_szDir, pszDir, MAX_PATH);
 
@@ -281,14 +281,14 @@ DirWatch::DirWatch(LPCWSTR pszDir, BOOL fSubTree)
                          NULL, OPEN_EXISTING,
                          FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
                          NULL);
-
-    // set a directory list
-    m_DirList.GetDirList(pszDir, fSubTree);
 }
 
 /*static*/ DirWatch *DirWatch::Create(LPCWSTR pszDir, BOOL fSubTree)
 {
-    DirWatch *pDirWatch = new DirWatch(pszDir, fSubTree);
+    WCHAR szFullPath[MAX_PATH];
+    GetFullPathNameW(pszDir, _countof(szFullPath), szFullPath, NULL);
+
+    DirWatch *pDirWatch = new DirWatch(szFullPath, fSubTree);
     if (pDirWatch->m_hDir == INVALID_HANDLE_VALUE)
     {
         ERR("CreateFileW failed\n");

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -220,6 +220,7 @@ static unsigned __stdcall DirWatchThreadFuncAPC(void *)
     return 0;
 }
 
+// the buffer for ReadDirectoryChangesW
 #define BUFFER_SIZE 0x1000
 static BYTE s_buffer[BUFFER_SIZE];
 
@@ -261,12 +262,15 @@ protected:
 
         lstrcpynW(m_szDir, pszDir, MAX_PATH);
 
+        // open the directory to watch changes (for ReadDirectoryChangesW)
         m_hDir = CreateFileW(pszDir, FILE_LIST_DIRECTORY,
                              FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                              NULL, OPEN_EXISTING,
                              FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
                              NULL);
-        m_pDirList = NULL;
+
+        // set a directory list
+        m_pDirList = DIRLIST::GetDirList(NULL, pszDir, FALSE);
     }
 };
 
@@ -448,6 +452,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
     }
 }
 
+// The completion routine of ReadDirectoryChangesW.
 static void CALLBACK
 _NotificationCompletion(DWORD dwErrorCode,
                         DWORD dwNumberOfBytesTransfered,
@@ -560,9 +565,6 @@ CreateDirWatchFromRegEntry(LPREGENTRY pRegEntry)
     DirWatch *pDirWatch = DirWatch::Create(szPath, pRegEntry->fRecursive);
     if (pDirWatch == NULL)
         return NULL;
-
-    // set a directory list
-    pDirWatch->m_pDirList = DIRLIST::GetDirList(NULL, szPath, FALSE);
 
     return pDirWatch;
 }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -125,6 +125,7 @@ BOOL DIRLIST::GetDirList(LPCWSTR pszDir, BOOL fRecursive)
     // get the full path
     WCHAR szPath[MAX_PATH];
     lstrcpynW(szPath, pszDir, _countof(szPath));
+    assert(!PathIsRelativeW(szPath));
 
     // is it a directory?
     if (!PathIsDirectoryW(szPath))

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -77,13 +77,12 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
         if (m_items[i].EqualPath(pszPath))
             return TRUE;
     }
-
     return FALSE;
 }
 
 BOOL DIRLIST::AddItem(LPCWSTR pszPath, DWORD dwFileSize, BOOL fDir)
 {
-    if (dwFileSize == 0xFFFFFFFF)
+    if (dwFileSize == INVALID_FILE_SIZE)
     {
         WIN32_FIND_DATAW find;
         HANDLE hFind = FindFirstFileW(pszPath, &find);
@@ -432,7 +431,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
                 List.AddItem(szPath, 0, TRUE);
                 break;
             case SHCNE_CREATE:
-                List.AddItem(szPath, 0xFFFFFFFF, FALSE);
+                List.AddItem(szPath, INVALID_FILE_SIZE, FALSE);
                 break;
             case SHCNE_RENAMEFOLDER:
                 List.RenameItem(szTempPath, szPath, TRUE);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -247,6 +247,8 @@ public:
 
     ~DirWatch()
     {
+        TRACE("DirWatch::~DirWatch: %p\n", this);
+
         if (m_hDir != INVALID_HANDLE_VALUE && m_hDir != NULL)
             CloseHandle(m_hDir);
 
@@ -256,6 +258,8 @@ public:
 protected:
     DirWatch(LPCWSTR pszDir, BOOL fSubTree)
     {
+        TRACE("DirWatch::DirWatch: %p\n", this);
+
         m_fDeadWatch = FALSE;
         m_fRecursive = fSubTree;
 

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -86,19 +86,16 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 /*static*/ DIRLIST *
 DIRLIST::AddItem(DIRLIST *pList OPTIONAL, LPCWSTR pszPath, BOOL fDir)
 {
-    SIZE_T count = 0, cbDirList = sizeof(DIRLIST);
+    SIZE_T cbDirList = sizeof(DIRLIST);
     if (pList)
-    {
-        count = pList->m_count;
-        cbDirList += count * sizeof(LPWSTR);
-    }
+        cbDirList += pList->m_count * sizeof(LPWSTR);
 
     DIRLIST *pNewList = (DIRLIST *)realloc(pList, cbDirList);
     if (pNewList == NULL)
         return pList;
 
-    if (count == 0)
-        ZeroMemory(pNewList, cbDirList);
+    if (pList == NULL)
+        pNewList->m_count = 0;
 
     WCHAR szPath[MAX_PATH + 1];
     szPath[0] = fDir ? DL_DIR : DL_FILE;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -121,6 +121,7 @@ void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
         if (m_items[i].fDir == fDir && m_items[i].EqualPath(pszPath))
         {
             m_items[i].strPath.Empty();
+            return;
         }
     }
 }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -283,7 +283,7 @@ DirWatch::DirWatch(LPCWSTR pszDir, BOOL fSubTree)
     , m_fRecursive(fSubTree)
     , m_DirList(pszDir, fSubTree)
 {
-    TRACE("DirWatch::DirWatch: %p\n", this);
+    TRACE("DirWatch::DirWatch: %p, '%S'\n", this, pszDir);
 
     lstrcpynW(m_szDir, pszDir, MAX_PATH);
 
@@ -312,7 +312,7 @@ DirWatch::DirWatch(LPCWSTR pszDir, BOOL fSubTree)
 
 DirWatch::~DirWatch()
 {
-    TRACE("DirWatch::~DirWatch: %p\n", this);
+    TRACE("DirWatch::~DirWatch: %p, '%S'\n", this, m_szDir);
 
     if (m_hDir != INVALID_HANDLE_VALUE)
         CloseHandle(m_hDir);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -351,9 +351,10 @@ static void _ProcessNotification(DirWatch *pDirWatch)
         ZeroMemory(szName, sizeof(szName));
         CopyMemory(szName, pInfo->FileName, cbName);
 
-        // if the watch is recursive, them notify a SHCNE_UPDATEDIR
+        // if the watch is recursive
         if (pDirWatch->m_fRecursive)
         {
+            // then, notify a SHCNE_UPDATEDIR
             SHChangeNotify(SHCNE_UPDATEDIR | SHCNE_INTERRUPT, SHCNF_PATHW,
                            pDirWatch->m_szDir, NULL);
 
@@ -473,6 +474,7 @@ _NotificationCompletion(DWORD dwErrorCode,
         return;
     }
 
+    // is this watch dead?
     if (pDirWatch->m_fDeadWatch)
     {
         ERR("m_fDeadWatch\n");
@@ -554,7 +556,7 @@ CreateDirWatchFromRegEntry(LPREGENTRY pRegEntry)
     }
 
     // create a DirWatch
-    DirWatch *pDirWatch = DirWatch::Create(szPath, FALSE);
+    DirWatch *pDirWatch = DirWatch::Create(szPath, pRegEntry->fRecursive);
     if (pDirWatch == NULL)
         return NULL;
 

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -26,17 +26,7 @@ struct DIRLIST
     static DIRLIST *
     GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive);
 
-    ~DIRLIST()
-    {
-        if (this)
-        {
-            for (DWORD i = 0; i < m_count; ++i)
-            {
-                free(m_items[i]);
-            }
-            free(this);
-        }
-    }
+    ~DIRLIST();
 
     BOOL Contains(LPCWSTR pszPath, BOOL fDir) const;
 
@@ -48,6 +38,18 @@ protected:
     {
     }
 };
+
+DIRLIST::~DIRLIST()
+{
+    if (this)
+    {
+        for (DWORD i = 0; i < m_count; ++i)
+        {
+            free(m_items[i]);
+        }
+        free(this);
+    }
+}
 
 BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -221,7 +221,7 @@ static unsigned __stdcall DirWatchThreadFuncAPC(void *)
 }
 
 #define BUFFER_SIZE 0x1000
-static BYTE s_abBuffer[BUFFER_SIZE];
+static BYTE s_buffer[BUFFER_SIZE];
 
 class DirWatch
 {
@@ -330,7 +330,7 @@ ConvertActionToEvent(DWORD Action, BOOL fDir)
 // Notify a filesystem notification using pDirWatch.
 static void _ProcessNotification(DirWatch *pDirWatch)
 {
-    PFILE_NOTIFY_INFORMATION pInfo = (PFILE_NOTIFY_INFORMATION)s_abBuffer;
+    PFILE_NOTIFY_INFORMATION pInfo = (PFILE_NOTIFY_INFORMATION)s_buffer;
     WCHAR szName[MAX_PATH], szPath[MAX_PATH], szTempPath[MAX_PATH];
     DWORD dwEvent, cbName;
     LPWSTR psz1, psz2;
@@ -338,6 +338,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
 
     szPath[0] = szTempPath[0] = 0;
 
+    // for each info in s_buffer
     for (;;)
     {
         // get name (relative from pDirWatch->m_szDir)
@@ -517,13 +518,13 @@ static BOOL _BeginRead(DirWatch *pDirWatch)
         return FALSE; // the watch is dead
 
     // initialize the buffer and the overlapped
-    ZeroMemory(s_abBuffer, sizeof(s_abBuffer));
+    ZeroMemory(s_buffer, sizeof(s_buffer));
     ZeroMemory(&pDirWatch->m_overlapped, sizeof(pDirWatch->m_overlapped));
     pDirWatch->m_overlapped.hEvent = (HANDLE)pDirWatch;
 
     // start the directory watch
     DWORD dwFilter = GetFilterFromEvents(SHCNE_ALLEVENTS);
-    if (!ReadDirectoryChangesW(pDirWatch->m_hDir, s_abBuffer, sizeof(s_abBuffer),
+    if (!ReadDirectoryChangesW(pDirWatch->m_hDir, s_buffer, sizeof(s_buffer),
                                pDirWatch->m_fRecursive, dwFilter, NULL,
                                &pDirWatch->m_overlapped, _NotificationCompletion))
     {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -368,7 +368,8 @@ static void _ProcessNotification(DirWatch *pDirWatch)
     PFILE_NOTIFY_INFORMATION pInfo = (PFILE_NOTIFY_INFORMATION)s_buffer;
     WCHAR szName[MAX_PATH], szPath[MAX_PATH], szTempPath[MAX_PATH];
     DWORD dwEvent, cbName;
-    BOOL fDir;
+    BOOL fDir, fRefreshed = FALSE;
+    WCHAR szChangePath[MAX_PATH];
 
     szPath[0] = szTempPath[0] = 0;
 
@@ -390,7 +391,6 @@ static void _ProcessNotification(DirWatch *pDirWatch)
         if (pDirWatch->m_fRecursive)
         {
             // get the first change
-            WCHAR szChangePath[MAX_PATH];
             if (!pDirWatch->m_DirList.GetFirstChange(szChangePath))
                 break;
 
@@ -399,9 +399,13 @@ static void _ProcessNotification(DirWatch *pDirWatch)
                 PathRemoveFileSpecW(szChangePath);
             NotifyFileSystemChange(SHCNE_UPDATEDIR, szChangePath, NULL);
 
-            // update directory list
-            pDirWatch->m_DirList.RemoveAll();
-            pDirWatch->m_DirList.GetDirList(pDirWatch->m_szDir, TRUE);
+            // refresh directory list
+            if (!fRefreshed)
+            {
+                pDirWatch->m_DirList.RemoveAll();
+                pDirWatch->m_DirList.GetDirList(pDirWatch->m_szDir, TRUE);
+                fRefreshed = TRUE;
+            }
 
             if (pInfo->NextEntryOffset == 0)
                 break; // there is no next entry

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -51,10 +51,6 @@ public:
         GetDirList(pszDir, fRecursive);
     }
 
-    ~DIRLIST()
-    {
-    }
-
     BOOL AddItem(LPCWSTR pszPath, DWORD dwFileSize, BOOL fDir);
     BOOL GetDirList(LPCWSTR pszDir, BOOL fRecursive);
     BOOL Contains(LPCWSTR pszPath, BOOL fDir) const;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -12,6 +12,12 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shcn);
 
+static void
+NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
+{
+    SHChangeNotify(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW, path1, path2);
+}
+
 //////////////////////////////////////////////////////////////////////////////
 // DIRLIST --- directory list
 
@@ -538,7 +544,7 @@ static BOOL _BeginRead(DirWatch *pDirWatch)
 static DirWatch *
 CreateDirWatchFromRegEntry(LPREGENTRY pRegEntry)
 {
-    if (pRegEntry->ibPidl == 0 || pRegEntry->fEvents == 0)
+    if (pRegEntry->ibPidl == 0)
         return NULL;
 
     // it must be interrupt level if pRegEntry is a filesystem watch

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -536,7 +536,10 @@ static BOOL _BeginRead(DirWatch *pDirWatch)
     assert(pDirWatch != NULL);
 
     if (pDirWatch->m_fDeadWatch)
+    {
+        delete pDirWatch;
         return FALSE; // the watch is dead
+    }
 
     // initialize the buffer and the overlapped
     ZeroMemory(s_buffer, sizeof(s_buffer));

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -542,9 +542,11 @@ _NotificationCompletion(DWORD dwErrorCode,
 static DWORD
 GetFilterFromEvents(DWORD fEvents)
 {
+    // FIXME
     return (FILE_NOTIFY_CHANGE_FILE_NAME |
             FILE_NOTIFY_CHANGE_DIR_NAME |
-            FILE_NOTIFY_CHANGE_CREATION);
+            FILE_NOTIFY_CHANGE_CREATION |
+            FILE_NOTIFY_CHANGE_SIZE);
 }
 
 // Restart a watch by using ReadDirectoryChangesW function

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -69,6 +69,8 @@ protected:
 
 BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 {
+    assert(!PathIsRelativeW(pszPath));
+
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
         if (m_items[i].IsEmpty() || fDir != m_items[i].fDir)
@@ -82,6 +84,8 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 
 BOOL DIRLIST::AddItem(LPCWSTR pszPath, DWORD dwFileSize, BOOL fDir)
 {
+    assert(!PathIsRelativeW(pszPath));
+
     if (dwFileSize == INVALID_FILE_SIZE)
     {
         WIN32_FIND_DATAW find;
@@ -98,6 +102,9 @@ BOOL DIRLIST::AddItem(LPCWSTR pszPath, DWORD dwFileSize, BOOL fDir)
 
 void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)
 {
+    assert(!PathIsRelativeW(pszPath1));
+    assert(!PathIsRelativeW(pszPath2));
+
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
         if (m_items[i].fDir == fDir && m_items[i].EqualPath(pszPath1))
@@ -110,6 +117,8 @@ void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)
 
 void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
 {
+    assert(!PathIsRelativeW(pszPath));
+
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
         if (m_items[i].fDir == fDir && m_items[i].EqualPath(pszPath))

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -495,7 +495,7 @@ struct ITEM
     DWORD dwUserPID;    // The user PID; that is the process ID of the target window.
     HANDLE hRegEntry;   // The registration entry.
     HWND hwndBroker;    // Client broker window (if any).
-    DirWatch *pDirWatch; // for filesystem notification (SHCNRF_InterruptLevel)
+    DirWatch *pDirWatch; // for filesystem notification (for SHCNRF_InterruptLevel)
 };
 
 typedef CWinTraits <
@@ -705,12 +705,12 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
             unsigned tid;
             s_fTerminateAll = FALSE;
             s_hThread = (HANDLE)_beginthreadex(NULL, 0, DirWatchThreadFuncAPC, NULL, 0, &tid);
-        }
-        if (s_hThread == NULL)
-        {
-            pRegEntry->nRegID = INVALID_REG_ID;
-            SHUnlockShared(pRegEntry);
-            return FALSE;
+            if (s_hThread == NULL)
+            {
+                pRegEntry->nRegID = INVALID_REG_ID;
+                SHUnlockShared(pRegEntry);
+                return FALSE;
+            }
         }
 
         QueueUserAPC(_AddDirectoryProcAPC, s_hThread, (ULONG_PTR)pDirWatch);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -31,7 +31,7 @@ struct DIRLIST
     void DeleteItem(LPCWSTR pszItem, BOOL fDir);
 
 protected:
-    DWORD m_count;
+    SIZE_T m_count;
     LPWSTR m_items[ANYSIZE_ARRAY];
 
     DIRLIST()
@@ -82,13 +82,19 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 /*static*/ DIRLIST *
 DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir)
 {
-    SIZE_T cbDirList = sizeof(DIRLIST);
+    SIZE_T count = 0, cbDirList = sizeof(DIRLIST);
     if (pList)
-        cbDirList += pList->m_count * sizeof(LPWSTR);
+    {
+        count = pList->m_count;
+        cbDirList += count * sizeof(LPWSTR);
+    }
 
     DIRLIST *pNewList = (DIRLIST *)realloc(pList, cbDirList);
     if (pNewList == NULL)
         return pList;
+
+    if (count == 0)
+        ZeroMemory(pNewList, cbDirList);
 
     WCHAR szPath[MAX_PATH + 1];
     szPath[0] = fDir ? L'|' : L'>';

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -536,11 +536,8 @@ CreateDirWatchFromRegEntry(LPREGENTRY pRegEntry)
     // get the path
     WCHAR szPath[MAX_PATH];
     LPITEMIDLIST pidl = (LPITEMIDLIST)((LPBYTE)pRegEntry + pRegEntry->ibPidl);
-    if (!SHGetPathFromIDListW(pidl, szPath) ||
-        (!PathIsDirectoryW(szPath) && !PathIsRootW(szPath)))
-    {
+    if (!SHGetPathFromIDListW(pidl, szPath) || !PathIsDirectoryW(szPath))
         return NULL;
-    }
 
     // create a DirWatch
     DirWatch *pDirWatch = DirWatch::Create(szPath, pRegEntry->fRecursive);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -928,10 +928,15 @@ BOOL CChangeNotifyServer::ShouldNotify(LPDELITICKET pTicket, LPREGENTRY pRegEntr
     WCHAR szPath[MAX_PATH], szPath1[MAX_PATH], szPath2[MAX_PATH];
     INT cch, cch1, cch2;
 
-    // check SHCNE_INTERRUPT and SHCNRF_InterruptLevel
+    // check fSources
     if (pTicket->uFlags & SHCNE_INTERRUPT)
     {
         if (!(pRegEntry->fSources & SHCNRF_InterruptLevel))
+            return FALSE;
+    }
+    else
+    {
+        if (!(pRegEntry->fSources & SHCNRF_ShellLevel))
             return FALSE;
     }
 

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -26,14 +26,14 @@ struct DIRLIST
     ~DIRLIST();
 
     static DIRLIST *
-    AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir);
+    AddItem(DIRLIST *pList, LPCWSTR pszPath, BOOL fDir);
 
     static DIRLIST *
     GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive);
 
     BOOL Contains(LPCWSTR pszPath, BOOL fDir) const;
-    void RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir);
-    void DeleteItem(LPCWSTR pszItem, BOOL fDir);
+    void RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir);
+    void DeleteItem(LPCWSTR pszPath, BOOL fDir);
 
 protected:
     SIZE_T m_count;
@@ -85,7 +85,7 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 }
 
 /*static*/ DIRLIST *
-DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir)
+DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszPath, BOOL fDir)
 {
     SIZE_T count = 0, cbDirList = sizeof(DIRLIST);
     if (pList)
@@ -103,14 +103,14 @@ DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir)
 
     WCHAR szPath[MAX_PATH + 1];
     szPath[0] = fDir ? DL_DIR : DL_FILE;
-    lstrcpynW(&szPath[1], pszItem, _countof(szPath) - 1);
+    lstrcpynW(&szPath[1], pszPath, _countof(szPath) - 1);
 
     pNewList->m_items[pNewList->m_count] = _wcsdup(szPath);
     pNewList->m_count++;
     return pNewList;
 }
 
-void DIRLIST::RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir)
+void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)
 {
     if (this == NULL)
         return;
@@ -118,10 +118,10 @@ void DIRLIST::RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir)
     WCHAR szPath[MAX_PATH + 1];
     for (DWORD i = 0; i < m_count; ++i)
     {
-        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem1) == 0)
+        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszPath1) == 0)
         {
             szPath[0] = (fDir ? DL_DIR : DL_FILE);
-            lstrcpynW(&szPath[1], pszItem2, _countof(szPath) - 1);
+            lstrcpynW(&szPath[1], pszPath2, _countof(szPath) - 1);
 
             free(m_items[i]);
             m_items[i] = _wcsdup(szPath);
@@ -130,14 +130,14 @@ void DIRLIST::RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir)
     }
 }
 
-void DIRLIST::DeleteItem(LPCWSTR pszItem, BOOL fDir)
+void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
 {
     if (this == NULL)
         return;
 
     for (DWORD i = 0; i < m_count; ++i)
     {
-        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem) == 0)
+        if (m_items[i] && lstrcmpiW(&m_items[i][1], pszPath) == 0)
         {
             free(m_items[i]);
             m_items[i] = NULL;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -510,14 +510,16 @@ _NotificationCompletion(DWORD dwErrorCode,
     // directory), then, don't requeue notification.
     if (dwErrorCode == ERROR_OPERATION_ABORTED)
     {
-        ERR("ERROR_OPERATION_ABORTED\n");
+        TRACE("ERROR_OPERATION_ABORTED\n");
+        if (pDirWatch->m_fDeadWatch)
+            delete pDirWatch;
         return;
     }
 
     // is this watch dead?
     if (pDirWatch->m_fDeadWatch)
     {
-        ERR("m_fDeadWatch\n");
+        TRACE("m_fDeadWatch\n");
         delete pDirWatch;
         return;
     }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -26,10 +26,10 @@ struct DIRLIST
     ~DIRLIST();
 
     static DIRLIST *
-    AddItem(DIRLIST *pList, LPCWSTR pszPath, BOOL fDir);
+    AddItem(DIRLIST *pList OPTIONAL, LPCWSTR pszPath, BOOL fDir);
 
     static DIRLIST *
-    GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive);
+    GetDirList(DIRLIST *pList OPTIONAL, LPCWSTR pszDir, BOOL fRecursive);
 
     BOOL Contains(LPCWSTR pszPath, BOOL fDir) const;
     void RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir);
@@ -85,7 +85,7 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 }
 
 /*static*/ DIRLIST *
-DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszPath, BOOL fDir)
+DIRLIST::AddItem(DIRLIST *pList OPTIONAL, LPCWSTR pszPath, BOOL fDir)
 {
     SIZE_T count = 0, cbDirList = sizeof(DIRLIST);
     if (pList)
@@ -147,7 +147,7 @@ void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
 }
 
 /*static*/ DIRLIST *
-DIRLIST::GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive)
+DIRLIST::GetDirList(DIRLIST *pList OPTIONAL, LPCWSTR pszDir, BOOL fRecursive)
 {
     // get the full path
     WCHAR szPath[MAX_PATH];

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -375,7 +375,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
     {
         // get the first change
         if (!pDirWatch->m_DirList.GetFirstChange(szPath))
-            break;
+            return;
 
         // then, notify a SHCNE_UPDATEDIR
         if (lstrcmpiW(pDirWatch->m_szDir, szPath) != 0)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -934,8 +934,15 @@ BOOL CChangeNotifyServer::ShouldNotify(LPDELITICKET pTicket, LPREGENTRY pRegEntr
     WCHAR szPath[MAX_PATH], szPath1[MAX_PATH], szPath2[MAX_PATH];
     INT cch, cch1, cch2;
 
+    // check SHCNE_INTERRUPT and SHCNRF_InterruptLevel
+    if (pTicket->uFlags & SHCNE_INTERRUPT)
+    {
+        if (!(pRegEntry->fSources & SHCNRF_InterruptLevel))
+            return FALSE;
+    }
+
     if (pRegEntry->ibPidl == 0)
-        return TRUE;
+        return TRUE; // there is no PIDL
 
     // get the stored pidl
     pidl = (LPITEMIDLIST)((LPBYTE)pRegEntry + pRegEntry->ibPidl);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -204,7 +204,7 @@ BOOL DIRLIST::GetFirstChange(LPWSTR pszPath) const
         }
         else
         {
-            if (!PathFileExists(m_items[i].strPath) ||
+            if (!PathFileExistsW(m_items[i].strPath) ||
                 PathIsDirectoryW(m_items[i].strPath))
             {
                 lstrcpynW(pszPath, m_items[i].strPath, MAX_PATH);
@@ -221,7 +221,7 @@ BOOL DIRLIST::GetFirstChange(LPWSTR pszPath) const
         if (m_items[i].IsEmpty() || m_items[i].fDir)
             continue;
 
-        hFind = FindFirstFile(m_items[i].strPath, &find);
+        hFind = FindFirstFileW(m_items[i].strPath, &find);
         FindClose(hFind);
         if (hFind == INVALID_HANDLE_VALUE ||
             find.nFileSizeLow != m_items[i].dwFileSize)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -210,7 +210,7 @@ DIRLIST::GetDirList(DIRLIST *pList OPTIONAL, LPCWSTR pszDir, BOOL fRecursive)
 static HANDLE s_hThread = NULL;
 static BOOL s_fTerminateAll = FALSE;
 
-// NOTE: Regard to Asynchronous procedure call (APC), please see:
+// NOTE: Regard to asynchronous procedure call (APC), please see:
 // https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex
 
 // The APC thread function for directory watch

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -194,19 +194,21 @@ BOOL DIRLIST::GetFirstChange(LPWSTR pszPath) const
         if (m_items[i].IsEmpty())
             continue;
 
-        if (m_items[i].fDir)
+        if (m_items[i].fDir) // item is a directory
         {
             if (!PathIsDirectoryW(m_items[i].strPath))
             {
+                // mismatched
                 lstrcpynW(pszPath, m_items[i].strPath, MAX_PATH);
                 return TRUE;
             }
         }
-        else
+        else // item is a normal file
         {
             if (!PathFileExistsW(m_items[i].strPath) ||
                 PathIsDirectoryW(m_items[i].strPath))
             {
+                // mismatched
                 lstrcpynW(pszPath, m_items[i].strPath, MAX_PATH);
                 return TRUE;
             }
@@ -221,11 +223,14 @@ BOOL DIRLIST::GetFirstChange(LPWSTR pszPath) const
         if (m_items[i].IsEmpty() || m_items[i].fDir)
             continue;
 
+        // get size
         hFind = FindFirstFileW(m_items[i].strPath, &find);
         FindClose(hFind);
+
         if (hFind == INVALID_HANDLE_VALUE ||
             find.nFileSizeLow != m_items[i].dwFileSize)
         {
+            // different size
             lstrcpynW(pszPath, m_items[i].strPath, MAX_PATH);
             return TRUE;
         }
@@ -435,7 +440,7 @@ static void _ProcessNotification(DirWatch *pDirWatch)
             dwEvent = SHCNE_RMDIR;
         }
 
-        // update pList
+        // update List
         switch (dwEvent)
         {
             case SHCNE_MKDIR:

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -210,6 +210,9 @@ DIRLIST::GetDirList(DIRLIST *pList OPTIONAL, LPCWSTR pszDir, BOOL fRecursive)
 static HANDLE s_hThread = NULL;
 static BOOL s_fTerminateAll = FALSE;
 
+// NOTE: Regard to Asynchronous procedure call (APC), please see:
+// https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex
+
 // The APC thread function for directory watch
 static unsigned __stdcall DirWatchThreadFuncAPC(void *)
 {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -75,10 +75,7 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 {
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
-        if (m_items[i].IsEmpty())
-            continue;
-
-        if (fDir != m_items[i].fDir)
+        if (m_items[i].IsEmpty() || fDir != m_items[i].fDir)
             continue;
 
         if (m_items[i].EqualPath(pszPath))
@@ -109,10 +106,9 @@ void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)
 {
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
-        if (!m_items[i].IsEmpty() && m_items[i].EqualPath(pszPath1))
+        if (m_items[i].fDir == fDir && m_items[i].EqualPath(pszPath1))
         {
             m_items[i].strPath = pszPath2;
-            m_items[i].fDir = fDir;
             return;
         }
     }
@@ -122,7 +118,7 @@ void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
 {
     for (INT i = 0; i < m_items.GetSize(); ++i)
     {
-        if (m_items[i].IsEmpty() && m_items[i].EqualPath(pszPath))
+        if (m_items[i].fDir == fDir && m_items[i].EqualPath(pszPath))
         {
             m_items[i].strPath.Empty();
         }
@@ -398,13 +394,13 @@ static void _ProcessNotification(DirWatch *pDirWatch)
             if (!pDirWatch->m_DirList.GetFirstChange(szChangePath))
                 break;
 
-            // update directory list
-            pDirWatch->m_DirList.RemoveAll();
-            pDirWatch->m_DirList.GetDirList(pDirWatch->m_szDir, TRUE);
-
             // then, notify a SHCNE_UPDATEDIR
             PathRemoveFileSpecW(szChangePath);
             NotifyFileSystemChange(SHCNE_UPDATEDIR, szChangePath, NULL);
+
+            // update directory list
+            pDirWatch->m_DirList.RemoveAll();
+            pDirWatch->m_DirList.GetDirList(pDirWatch->m_szDir, TRUE);
 
             if (pInfo->NextEntryOffset == 0)
                 break; // there is no next entry

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -820,6 +820,7 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
             {
                 pRegEntry->nRegID = INVALID_REG_ID;
                 SHUnlockShared(pRegEntry);
+                delete pDirWatch;
                 return FALSE;
             }
         }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -369,19 +369,18 @@ static void _ProcessNotification(DirWatch *pDirWatch)
     WCHAR szName[MAX_PATH], szPath[MAX_PATH], szTempPath[MAX_PATH];
     DWORD dwEvent, cbName;
     BOOL fDir;
-    WCHAR szChangePath[MAX_PATH];
 
     // if the watch is recursive
     if (pDirWatch->m_fRecursive)
     {
         // get the first change
-        if (!pDirWatch->m_DirList.GetFirstChange(szChangePath))
+        if (!pDirWatch->m_DirList.GetFirstChange(szPath))
             break;
 
         // then, notify a SHCNE_UPDATEDIR
-        if (lstrcmpiW(pDirWatch->m_szDir, szChangePath) != 0)
-            PathRemoveFileSpecW(szChangePath);
-        NotifyFileSystemChange(SHCNE_UPDATEDIR, szChangePath, NULL);
+        if (lstrcmpiW(pDirWatch->m_szDir, szPath) != 0)
+            PathRemoveFileSpecW(szPath);
+        NotifyFileSystemChange(SHCNE_UPDATEDIR, szPath, NULL);
 
         // refresh directory list
         pDirWatch->m_DirList.RemoveAll();

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -17,8 +17,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(shcn);
 
 struct DIRLIST
 {
-    DWORD m_count;
-    LPWSTR m_items[ANYSIZE_ARRAY];
+    ~DIRLIST();
 
     static DIRLIST *
     AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir);
@@ -26,14 +25,15 @@ struct DIRLIST
     static DIRLIST *
     GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive);
 
-    ~DIRLIST();
-
     BOOL Contains(LPCWSTR pszPath, BOOL fDir) const;
 
     void RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir);
     void DeleteItem(LPCWSTR pszItem, BOOL fDir);
 
 protected:
+    DWORD m_count;
+    LPWSTR m_items[ANYSIZE_ARRAY];
+
     DIRLIST()
     {
     }

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -766,9 +766,11 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
         return FALSE;
     }
 
+    // create a directory watch if necessary
     DirWatch *pDirWatch = CreateDirWatchFromRegEntry(pRegEntry);
     if (pDirWatch)
     {
+        // create an APC thread for directory watching
         if (s_hThread == NULL)
         {
             unsigned tid;
@@ -782,6 +784,7 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
             }
         }
 
+        // add the watch
         QueueUserAPC(_AddDirectoryProcAPC, s_hThread, (ULONG_PTR)pDirWatch);
     }
 

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -17,6 +17,12 @@ WINE_DEFAULT_DEBUG_CHANNEL(shcn);
 
 struct DIRLIST
 {
+    enum FirstChar // the first character of each item of m_items
+    {
+        DL_DIR = L'|',
+        DL_FILE = L'>'
+    };
+
     ~DIRLIST();
 
     static DIRLIST *
@@ -62,12 +68,12 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
 
         if (fDir)
         {
-            if (m_items[i][0] != L'|')
+            if (m_items[i][0] != DL_DIR)
                 continue;
         }
         else
         {
-            if (m_items[i][0] != L'>')
+            if (m_items[i][0] != DL_FILE)
                 continue;
         }
 
@@ -96,7 +102,7 @@ DIRLIST::AddItem(DIRLIST *pList, LPCWSTR pszItem, BOOL fDir)
         ZeroMemory(pNewList, cbDirList);
 
     WCHAR szPath[MAX_PATH + 1];
-    szPath[0] = fDir ? L'|' : L'>';
+    szPath[0] = fDir ? DL_DIR : DL_FILE;
     lstrcpynW(&szPath[1], pszItem, _countof(szPath) - 1);
 
     pNewList->m_items[pNewList->m_count] = _wcsdup(szPath);
@@ -114,7 +120,7 @@ void DIRLIST::RenameItem(LPCWSTR pszItem1, LPCWSTR pszItem2, BOOL fDir)
     {
         if (m_items[i] && lstrcmpiW(&m_items[i][1], pszItem1) == 0)
         {
-            szPath[0] = (fDir ? L'|' : L'>');
+            szPath[0] = (fDir ? DL_DIR : DL_FILE);
             lstrcpynW(&szPath[1], pszItem2, _countof(szPath) - 1);
 
             free(m_items[i]);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -458,7 +458,7 @@ static BOOL _BeginRead(DirWatch *pDirWatch)
 }
 
 static DirWatch *
-CreateDirWatch(LPREGENTRY pRegEntry)
+CreateDirWatchFromRegEntry(LPREGENTRY pRegEntry)
 {
     if (pRegEntry->ibPidl == 0 || pRegEntry->fEvents == 0)
         return NULL;
@@ -695,7 +695,7 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
         return FALSE;
     }
 
-    DirWatch *pDirWatch = CreateDirWatch(pRegEntry);
+    DirWatch *pDirWatch = CreateDirWatchFromRegEntry(pRegEntry);
     if (pDirWatch)
     {
         if (s_hThread == NULL)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -208,7 +208,7 @@ DIRLIST::GetDirList(DIRLIST *pList OPTIONAL, LPCWSTR pszDir, BOOL fRecursive)
 // DirWatch --- directory watcher using ReadDirectoryChangesW
 
 static HANDLE s_hThreadAPC = NULL;
-static BOOL s_fTerminateAll = FALSE;
+static BOOL s_fTerminateAllWatches = FALSE;
 
 // NOTE: Regard to asynchronous procedure call (APC), please see:
 // https://docs.microsoft.com/en-us/windows/win32/api/synchapi/nf-synchapi-sleepex
@@ -216,7 +216,7 @@ static BOOL s_fTerminateAll = FALSE;
 // The APC thread function for directory watch
 static unsigned __stdcall DirWatchThreadFuncAPC(void *)
 {
-    while (!s_fTerminateAll)
+    while (!s_fTerminateAllWatches)
     {
 #if 1 // FIXME: This is a HACK
         WaitForSingleObjectEx(GetCurrentThread(), INFINITE, TRUE);
@@ -314,7 +314,7 @@ static void NTAPI _RequestTerminationAPC(ULONG_PTR Parameter)
 // The APC procedure to request termination of all the directory watches
 static void NTAPI _RequestAllTerminationAPC(ULONG_PTR Parameter)
 {
-    s_fTerminateAll = TRUE;
+    s_fTerminateAllWatches = TRUE;
     CloseHandle(s_hThreadAPC);
     s_hThreadAPC = NULL;
 }
@@ -779,7 +779,7 @@ LRESULT CChangeNotifyServer::OnRegister(UINT uMsg, WPARAM wParam, LPARAM lParam,
         if (s_hThreadAPC == NULL)
         {
             unsigned tid;
-            s_fTerminateAll = FALSE;
+            s_fTerminateAllWatches = FALSE;
             s_hThreadAPC = (HANDLE)_beginthreadex(NULL, 0, DirWatchThreadFuncAPC, NULL, 0, &tid);
             if (s_hThreadAPC == NULL)
             {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -442,6 +442,9 @@ static void _ProcessNotification(DirWatch *pDirWatch)
             case SHCNE_RMDIR:
                 List.DeleteItem(szPath, TRUE);
                 break;
+            case SHCNE_DELETE:
+                List.DeleteItem(szPath, FALSE);
+                break;
         }
 
         if (dwEvent != 0)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -93,8 +93,7 @@ BOOL DIRLIST::AddItem(LPCWSTR pszPath, DWORD dwFileSize, BOOL fDir)
     }
 
     DIRLISTITEM item = { pszPath, dwFileSize, fDir };
-    m_items.Add(item);
-    return TRUE;
+    return m_items.Add(item);
 }
 
 void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -270,6 +270,8 @@ static void NTAPI _RequestTerminationAPC(ULONG_PTR Parameter)
 static void NTAPI _RequestAllTerminationAPC(ULONG_PTR Parameter)
 {
     s_fTerminateAll = TRUE;
+    CloseHandle(s_hThread);
+    s_hThread = NULL;
 }
 
 static DWORD

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -141,7 +141,7 @@ DIRLIST::GetDirList(DIRLIST *pList, LPCWSTR pszDir, BOOL fRecursive)
     WCHAR szPath[MAX_PATH];
     GetFullPathNameW(pszDir, _countof(szPath), szPath, NULL);
 
-    if (!PathIsDirectoryW(szPath))
+    if (!PathIsDirectoryW(szPath) && !PathIsRootW(szPath))
     {
         delete pList;
         return NULL;

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -12,7 +12,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shcn);
 
-static void
+static inline void
 NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2)
 {
     SHChangeNotify(wEventId | SHCNE_INTERRUPT, SHCNF_PATHW, path1, path2);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.cpp
@@ -47,7 +47,7 @@ DIRLIST::~DIRLIST()
 {
     if (this)
     {
-        for (DWORD i = 0; i < m_count; ++i)
+        for (SIZE_T i = 0; i < m_count; ++i)
         {
             free(m_items[i]);
         }
@@ -60,7 +60,7 @@ BOOL DIRLIST::Contains(LPCWSTR pszPath, BOOL fDir) const
     if (this == NULL)
         return FALSE;
 
-    for (DWORD i = 0; i < m_count; ++i)
+    for (SIZE_T i = 0; i < m_count; ++i)
     {
         if (m_items[i] == NULL)
             continue;
@@ -115,7 +115,7 @@ void DIRLIST::RenameItem(LPCWSTR pszPath1, LPCWSTR pszPath2, BOOL fDir)
         return;
 
     WCHAR szPath[MAX_PATH + 1];
-    for (DWORD i = 0; i < m_count; ++i)
+    for (SIZE_T i = 0; i < m_count; ++i)
     {
         if (m_items[i] && lstrcmpiW(&m_items[i][1], pszPath1) == 0)
         {
@@ -134,7 +134,7 @@ void DIRLIST::DeleteItem(LPCWSTR pszPath, BOOL fDir)
     if (this == NULL)
         return;
 
-    for (DWORD i = 0; i < m_count; ++i)
+    for (SIZE_T i = 0; i < m_count; ++i)
     {
         if (m_items[i] && lstrcmpiW(&m_items[i][1], pszPath) == 0)
         {

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.h
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.h
@@ -89,3 +89,5 @@ typedef struct HANDBAG
 #define HANDBAG_MAGIC 0xFACEB00C
 
 HRESULT CChangeNotifyServer_CreateInstance(REFIID riid, void **ppv);
+
+void NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2);

--- a/dll/win32/shell32/shelldesktop/CChangeNotifyServer.h
+++ b/dll/win32/shell32/shelldesktop/CChangeNotifyServer.h
@@ -89,5 +89,3 @@ typedef struct HANDBAG
 #define HANDBAG_MAGIC 0xFACEB00C
 
 HRESULT CChangeNotifyServer_CreateInstance(REFIID riid, void **ppv);
-
-void NotifyFileSystemChange(LONG wEventId, LPCWSTR path1, LPCWSTR path2);


### PR DESCRIPTION
## Purpose
Notify filesystem change notifications by using `ReadDirectoryChangesW` function. Creating/Deleting files/folders will be responsive in Explorer.

JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

![after](https://user-images.githubusercontent.com/2107452/80273479-4e86c080-870d-11ea-9adb-ad6f72529e37.png)
