### PR TITLE
[SHLWAPI] Improve SHEvaluateSystemCommandTemplate export CORE-14742

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -549,7 +549,7 @@
 549 stdcall -noname SHCoCreateInstanceAC(ptr ptr long ptr ptr)
 550 stub -noname GetTemplateInfoFromHandle
 551 stub -noname IShellFolder_CompareIDs
-552 stdcall -stub -noname SHEvaluateSystemCommandTemplate(wstr ptr ptr ptr)
+552 stdcall -stub -noname -version=0x501-0x502 SHEvaluateSystemCommandTemplate(wstr ptr ptr ptr)
 553 stdcall IsInternetESCEnabled()
 554 stdcall -noname -stub SHGetAllAccessSA()
 555 stdcall AssocQueryStringByKeyA(long long ptr str ptr ptr)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -549,7 +549,7 @@
 549 stdcall -noname SHCoCreateInstanceAC(ptr ptr long ptr ptr)
 550 stub -noname GetTemplateInfoFromHandle
 551 stub -noname IShellFolder_CompareIDs
-552 stub -noname SHEvaluateSystemCommandTemplate
+552 stdcall -stub -noname SHEvaluateSystemCommandTemplate(wstr ptr ptr ptr)
 553 stdcall IsInternetESCEnabled()
 554 stdcall -noname -stub SHGetAllAccessSA()
 555 stdcall AssocQueryStringByKeyA(long long ptr str ptr ptr)


### PR DESCRIPTION
## Purpose

Improve export for SHEvaluateSystemCommandTemplate funtion in shlwapi by using `stdcall -stub` instead of `stub`.
Required by TuneUP service from TuneUP Utilites 2014. After my changes, it does no longer crash, and main app now works correctly. Since this stub it enough to avoid that crash, I guess it is not necessarily to add a full code stub.

JIRA issue: [CORE-14742](https://jira.reactos.org/browse/CORE-14742)

## Proposed changes

- Replace `stub` by `stdcall -stub`;
- Add function arguments according to MSDN, since using them is required by `stdcall -stub` unlike `stub`.

## Result

Before:
![0 4 14-dev-1531-ga2f5283](https://user-images.githubusercontent.com/26385117/80313575-58372380-87f4-11ea-998e-085ada7b7765.png)

After:
![MS_shlwapi](https://user-images.githubusercontent.com/26385117/80313591-743ac500-87f4-11ea-9d36-e589ad3f75f9.png)