### PR TITLE
[EXPLORER] Fix incorrect component position and size for French language

### DIFF
--- a/base/shell/explorer/lang/fr-FR.rc
+++ b/base/shell/explorer/lang/fr-FR.rc
@@ -77,7 +77,7 @@ BEGIN
     AUTOCHECKBOX "Afficher les secondes", IDC_TASKBARPROP_SECONDS, 120, 153, 80, 10, WS_DISABLED
     LTEXT "Vous pouvez garder la zone de notification épurée en cachant les icônes sur lesquelles vous n'avez pas cliqué récemment.", IDC_STATIC, 13, 169, 223, 16
     AUTOCHECKBOX "&Cacher les icônes inactives", IDC_TASKBARPROP_HIDEICONS, 13, 191, 125, 10
-    PUSHBUTTON "&Personnaliser...", IDC_TASKBARPROP_ICONCUST, 188, 191, 50, 14
+    PUSHBUTTON "&Personnaliser...", IDC_TASKBARPROP_ICONCUST, 185, 191, 53, 14
 END
 
 IDD_TASKBARPROP_STARTMENU DIALOGEX 0, 0, 252, 218
@@ -100,11 +100,11 @@ EXSTYLE WS_EX_CONTEXTHELP
 CAPTION "Personnaliser les notifications"
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT            "ReactOS affiche les icônes pour les notifications actives ou urgentes, et cache les inactives. Vous pouvez changer ce comportement pour les éléments dans la liste ci-dessous.", IDC_STATIC, 6, 6, 220, 30
-    LTEXT            "Sélectionnez un élément, puis choisissez le comportement de ses notifications :", IDC_STATIC, 6, 40, 220, 10
+    LTEXT            "ReactOS affiche les icônes pour les notifications actives ou urgentes, et cache les inactives. Vous pouvez changer ce comportement pour les éléments dans la liste ci-dessous.", IDC_STATIC, 6, 3, 220, 28
+    LTEXT            "Sélectionnez un élément, puis choisissez le comportement de ses notifications :", IDC_STATIC, 6, 30, 220, 19
     CONTROL          "", IDC_NOTIFICATION_LIST, "SysListView32", WS_CLIPSIBLINGS | WS_BORDER | 0x00008005, 6, 50, 220, 128
     COMBOBOX         IDC_NOTIFICATION_BEHAVIOUR, 103, 178, 78, 200, CBS_DROPDOWNLIST | NOT WS_VISIBLE | WS_CLIPSIBLINGS
-    PUSHBUTTON       "&Restaurer les paramètres par défaut", IDC_TASKBARPROP_NOTIREST, 164, 188, 62, 14
+    PUSHBUTTON       "&Paramètres par défaut", IDC_TASKBARPROP_NOTIREST, 147, 188, 79, 14
     DEFPUSHBUTTON    "OK", IDOK, 122, 220, 50, 14
     PUSHBUTTON       "Annuler", IDCANCEL, 176, 220, 50, 14
 END


### PR DESCRIPTION
## Purpose

_ One label is misplaced
_ "default" button is too narrow

JIRA issue: [CORE-16930](https://jira.reactos.org/browse/CORE-16930)

![image](https://user-images.githubusercontent.com/24843587/80335065-73854b80-8853-11ea-8f19-7034b7647799.png)

## Proposed changes

_ By opportunty improve fix of https://jira.reactos.org/browse/CORE-12386 on parent window

![image](https://user-images.githubusercontent.com/24843587/80335072-7da74a00-8853-11ea-9bfb-7f154703825c.png)
