### PR TITLE
[NETID] Fix incorrect component position and size, complete translation for French language

### DIFF
--- a/dll/win32/netid/lang/fr-FR.rc
+++ b/dll/win32/netid/lang/fr-FR.rc
@@ -48,12 +48,12 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Suffixe DNS &primaire de cet ordinateur :", -1, 7, 5, 253, 8
     EDITTEXT 1011, 7, 17, 252, 14, ES_AUTOHSCROLL
-    AUTOCHECKBOX "&Changer le suffixe DNS primaire lorsque les adhésions au domaine sont changées", 115, 11, 39, 250, 10
+    AUTOCHECKBOX "&Changer le suffixe DNS primaire lorsque les adhésions au domaine sont changées", 115, 7, 32, 250, 19, BS_MULTILINE
     LTEXT "Nom &NetBIOS de l'ordinateur :", -1, 7, 57, 148, 8
     EDITTEXT 1013, 7, 69, 150, 14, ES_UPPERCASE | ES_AUTOHSCROLL | ES_READONLY
     DEFPUSHBUTTON "OK", 1, 153, 104, 50, 14
     PUSHBUTTON "Annuler", 2, 209, 104, 50, 14
-    LTEXT "Ce nom est utilié pour l'interopérabilité avec des ordinateurs et des services plus anciens.", 13, 7, 88, 253, 8
+    LTEXT "Ce nom est utilié pour l'interopérabilité avec des ordinateurs et des services plus anciens.", 13, 7, 86, 253, 18
 END
 
 STRINGTABLE
@@ -64,22 +64,22 @@ BEGIN
     4 "Changement du nom de l'ordinateur"
     5 "Groupe de travail :"
     6 "Domaine :"
-    7 "The domain name ""%1"" does not conform to Internet Domain Name Service specifications, although it is a legal ReactOS name. You must use ReactOS DNS server for non-standard names."
-    8 "The domain name ""%1"" is not properly formatted. Periods (.) are used to separate domains. Each domain is limited to 63 characters. Example: domain-1.reactos.org."
-    10 "The new computer name ""%1"" is too long. The name may not be longer than 63 characters."
-    11 "The new computer name entered is not properly formatted. Standard names may contain letters (a-z, A-Z), numbers (0-9), and hyphens (-), but no spaces or periods (.). The name may not consist entirely of digits."
+    7 "Le nom de domaine ""%1"" n'est pas conforme à l'Internet Domain Name Service Specifications, même si c'est un nom valide pour ReactOS. Vous devez utiliser le serveur DNS de ReactOS pour les noms non-standards."
+    8 "Le nom de domaine ""%1"" n'est pas correctement formatté. Les points (.) sont utilisés pour séparer les domaines. Chaque domaine est limité à 63 caractères. Exemple: domain-1.reactos.org."
+    10 "Le nouveau nom d'ordinateur ""%1"" est trop long. Le nom ne doit pas être plus long que 63 cractères."
+    11 "Le nouveau nom d'ordinateur est mal formatté. Les noms standards ne contiennenent que des caractères alphanumériques (a-z, A-Z,0-9), des tirets (-), mais pas d'espaces ni de points (.) et ne peut être constitué de chiffres seulement."
     22 "Bienvenue dans le groupe de travail %1."
     23 "Bienvenue dans le domaine %1."
     24 "Vous devez redémarrer votre ordinateur pour que les changements soient pris en compte."
-    25 "You can change the name and the membership of this computer. Changes may affect access to network resources."
+    25 "Vous pouvez changer le nom et l'appartenance de cet ordinateur. Les changements peuvent affecter vos accès aux ressources réseau."
     1021 "Note : Seuls les administrateurs peuvent modifier l'identification de cet ordinateur."
     1022 "Note : L'identification de l'ordinateur ne peut pas être modifiée car :"
-    1029 "The new computer name ""%1"" is a number. The name may not be a number."
-    1030 "The new computer name ""%1"" contains characters which are not allowed. Characters which are not allowed include ` ~ ! @ # $ %% ^ & * ( ) = + [ ] { } \\ | ; : ' "" , < > / and ?"
-    1031 "The first domain of the domain name ""%1"" is a number. The first domain may not be a number."
-    1032 "The domain name ""%1"" contains characters which are not allowed. Standard DNS names may contain letters (a-z, A-Z), numbers (0-9), and hyphens, but no spaces. Periods (.) are used to separate domains. Example: domain-1.reactos.org."
+    1029 "Le nouveau nom d'ordinateur ""%1"" est un nombre, ce qui n'est pas valide."
+    1030 "Le nouveau nom d'ordinateur ""%1"" contient des caractères interdits. Les caractères interdits sont ` ~ ! @ # $ %% ^ & * ( ) = + [ ] { } \\ | ; : ' "" , < > / et ?"
+    1031 "Le premier domaine du nom de domaine ""%1"" est un nombre, ce qui n'est pas valide."
+    1032 "Le nom de domaine ""%1"" contient des caractères interdits. Les noms de DNS standards Standard DNS ne contiennenent que des caractères alphanumériques (a-z, A-Z,0-9), des tirets (-), mais pas d'espaces. Les points (.) sont utilisés pour séparer les domaines. Exemple: domain-1.reactos.org."
     3210 "&Détails >>"
     3220 "<< &Détails"
     4000 "Information"
-    4001 "Can't set new a computer name!"
+    4001 "Impossible de définir le nouveau nom de l'ordinateur"
 END

--- a/dll/win32/netid/lang/fr-FR.rc
+++ b/dll/win32/netid/lang/fr-FR.rc
@@ -48,12 +48,12 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Suffixe DNS &primaire de cet ordinateur :", -1, 7, 5, 253, 8
     EDITTEXT 1011, 7, 17, 252, 14, ES_AUTOHSCROLL
-    AUTOCHECKBOX "&Changer le suffixe DNS primaire lorsque les adhésions au domaine sont changées", 115, 7, 32, 250, 19, BS_MULTILINE
+    AUTOCHECKBOX "&Changer le suffixe DNS primaire lorsque les adhésions au domaine sont modifiées.", 115, 7, 32, 250, 19, BS_MULTILINE
     LTEXT "Nom &NetBIOS de l'ordinateur :", -1, 7, 57, 148, 8
     EDITTEXT 1013, 7, 69, 150, 14, ES_UPPERCASE | ES_AUTOHSCROLL | ES_READONLY
     DEFPUSHBUTTON "OK", 1, 153, 104, 50, 14
     PUSHBUTTON "Annuler", 2, 209, 104, 50, 14
-    LTEXT "Ce nom est utilié pour l'interopérabilité avec des ordinateurs et des services plus anciens.", 13, 7, 86, 253, 18
+    LTEXT "Ce nom est utilisé pour l'interopérabilité avec des ordinateurs et des services plus anciens.", 13, 7, 86, 253, 18
 END
 
 STRINGTABLE
@@ -65,9 +65,9 @@ BEGIN
     5 "Groupe de travail :"
     6 "Domaine :"
     7 "Le nom de domaine ""%1"" n'est pas conforme à l'Internet Domain Name Service Specifications, même si c'est un nom valide pour ReactOS. Vous devez utiliser le serveur DNS de ReactOS pour les noms non-standards."
-    8 "Le nom de domaine ""%1"" n'est pas correctement formatté. Les points (.) sont utilisés pour séparer les domaines. Chaque domaine est limité à 63 caractères. Exemple: domain-1.reactos.org."
-    10 "Le nouveau nom d'ordinateur ""%1"" est trop long. Le nom ne doit pas être plus long que 63 cractères."
-    11 "Le nouveau nom d'ordinateur est mal formatté. Les noms standards ne contiennenent que des caractères alphanumériques (a-z, A-Z,0-9), des tirets (-), mais pas d'espaces ni de points (.) et ne peut être constitué de chiffres seulement."
+    8 "Le nom de domaine ""%1"" n'est pas correctement formaté. Les points (.) sont utilisés pour séparer les domaines. Chaque domaine est limité à 63 caractères. Exemple : domain-1.reactos.org."
+    10 "Le nouveau nom d'ordinateur ""%1"" est trop long. Le nom ne doit pas être plus long que 63 caractères."
+    11 "Le nouveau nom d'ordinateur est mal formaté. Les noms standards ne contiennent que des caractères alphanumériques (a-z, A-Z, 0-9), des tirets (-), mais pas d'espaces ni de points (.) et ne peut être constitué de chiffres seulement."
     22 "Bienvenue dans le groupe de travail %1."
     23 "Bienvenue dans le domaine %1."
     24 "Vous devez redémarrer votre ordinateur pour que les changements soient pris en compte."
@@ -77,9 +77,9 @@ BEGIN
     1029 "Le nouveau nom d'ordinateur ""%1"" est un nombre, ce qui n'est pas valide."
     1030 "Le nouveau nom d'ordinateur ""%1"" contient des caractères interdits. Les caractères interdits sont ` ~ ! @ # $ %% ^ & * ( ) = + [ ] { } \\ | ; : ' "" , < > / et ?"
     1031 "Le premier domaine du nom de domaine ""%1"" est un nombre, ce qui n'est pas valide."
-    1032 "Le nom de domaine ""%1"" contient des caractères interdits. Les noms de DNS standards Standard DNS ne contiennenent que des caractères alphanumériques (a-z, A-Z,0-9), des tirets (-), mais pas d'espaces. Les points (.) sont utilisés pour séparer les domaines. Exemple: domain-1.reactos.org."
+    1032 "Le nom de domaine ""%1"" contient des caractères interdits. Les noms de DNS standards ne contiennenent que des caractères alphanumériques (a-z, A-Z, 0-9), des tirets (-), mais pas d'espaces. Les points (.) sont utilisés pour séparer les domaines. Exemple : domain-1.reactos.org."
     3210 "&Détails >>"
     3220 "<< &Détails"
     4000 "Information"
-    4001 "Impossible de définir le nouveau nom de l'ordinateur"
+    4001 "Impossible de définir le nouveau nom de l'ordinateur !"
 END


### PR DESCRIPTION
## Purpose

_ Missing fr-fr translation for some items
_ Wrong components size and/or position to fully display text

JIRA issue: [CORE-16597](https://jira.reactos.org/browse/CORE-16597)

![image](https://user-images.githubusercontent.com/24843587/80337982-88fe7380-885b-11ea-9016-3e0b5ed2cb46.png)

![image](https://user-images.githubusercontent.com/24843587/80337989-8d2a9100-885b-11ea-9ff8-b271f64c35b0.png)

## Proposed changes

_ Complete fr-fr translation of associated .rc file
_ Fix of component design (size, location, BS_MULTILINE).

![image](https://user-images.githubusercontent.com/24843587/80337968-81d76580-885b-11ea-9c43-5ee658eac98c.png)
