### PR TITLE
Update CODEOWNERS - translation section

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -327,7 +327,22 @@ amd64/                                      @tkreuzer
 # Translations
 # This is the list of translation teams in ReactOS GitHub organization.
 # If you want to be part of one - hit us at https://chat.reactos.org/
-de-DE.rc    @reactos/lang-german
-fr-FR.rc    @reactos/lang-french
-nl-NL.rc    @reactos/lang-dutch
-ru-RU.rc    @reactos/lang-russian
+de-DE.*    @reactos/lang-german
+es-ES.*    @reactos/lang-spanish
+et-EE.*    @reactos/lang-estonian
+fr-FR.*    @reactos/lang-french
+he-IL.*    @reactos/lang-hebrew
+hi-IN.*    @reactos/lang-hindi
+hu-HU.*    @reactos/lang-hungarian
+id-ID.*    @reactos/lang-indonesian
+it-IT.*    @reactos/lang-italian
+nl-NL.*    @reactos/lang-dutch
+pl-PL.*    @reactos/lang-polish
+pt-BR.*    @reactos/lang-portuguese
+pt-PT.*    @reactos/lang-portuguese
+ro-RO.*    @reactos/lang-romanian
+ru-RU.*    @reactos/lang-russian
+tr-TR.*    @reactos/lang-turkish
+uk-UA.*    @reactos/lang-ukrainian
+zh-CN.*    @reactos/lang-chinese
+zh-TW.*    @reactos/lang-chinese


### PR DESCRIPTION
Add missing translation teams

`*` is, because we have other file extension for translation somewhere like here: https://github.com/reactos/reactos/tree/master/base/setup/usetup/lang

Some language teams appears here more than one, like lang-chinese or portuguese, but I belive this list is not finished yet.

Lang codes: http://www.lingoes.net/en/translator/langcode.htm