### PR TITLE
[SETUPAPI] Improve SetupRemoveFromSourceListA/W exports CORE-16968

### DIFF
--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -503,7 +503,7 @@
 @ stub SetupRemoveFromDiskSpaceListA
 @ stub SetupRemoveFromDiskSpaceListW
 @ stdcall -stub SetupRemoveFromSourceListA(long ptr)
-@ stub SetupRemoveFromSourceListW
+@ stdcall -stub SetupRemoveFromSourceListW(long ptr)
 @ stub SetupRemoveInstallSectionFromDiskSpaceListA
 @ stub SetupRemoveInstallSectionFromDiskSpaceListW
 @ stub SetupRemoveSectionFromDiskSpaceListA

--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -502,8 +502,8 @@
 @ stub SetupRemoveFileLogEntryW
 @ stub SetupRemoveFromDiskSpaceListA
 @ stub SetupRemoveFromDiskSpaceListW
-@ stdcall -stub SetupRemoveFromSourceListA(long ptr)
-@ stdcall -stub SetupRemoveFromSourceListW(long ptr)
+@ stdcall -stub SetupRemoveFromSourceListA(long str)
+@ stdcall -stub SetupRemoveFromSourceListW(long wstr)
 @ stub SetupRemoveInstallSectionFromDiskSpaceListA
 @ stub SetupRemoveInstallSectionFromDiskSpaceListW
 @ stub SetupRemoveSectionFromDiskSpaceListA

--- a/dll/win32/setupapi/setupapi.spec
+++ b/dll/win32/setupapi/setupapi.spec
@@ -502,7 +502,7 @@
 @ stub SetupRemoveFileLogEntryW
 @ stub SetupRemoveFromDiskSpaceListA
 @ stub SetupRemoveFromDiskSpaceListW
-@ stub SetupRemoveFromSourceListA
+@ stdcall -stub SetupRemoveFromSourceListA(long ptr)
 @ stub SetupRemoveFromSourceListW
 @ stub SetupRemoveInstallSectionFromDiskSpaceListA
 @ stub SetupRemoveInstallSectionFromDiskSpaceListW


### PR DESCRIPTION
## Purpose

Improve exports for SetupRemoveFromSourceListA and SetupRemoveFromSourceListW functions in setupapi.dll by replacing `stub` with `stdcall -stub`. Also add functions arguments according to MSDN: https://docs.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupremovefromsourcelista, https://docs.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupremovefromsourcelistw, they are required by `stdcall -stub`.
It fixes EXCEPTION_WINE_STUB during installation the manufacturer's supplied software of USB wireless dongle D-LINK DWA-123, so now it does no longer fail (as confirmed by reporter).

JIRA issue: [CORE-16968](https://jira.reactos.org/browse/CORE-16968)