### PR TITLE
[KERNEL32_APITEST] Add QueryUserAPC testcase

### DIFF
--- a/modules/rostests/apitests/kernel32/CMakeLists.txt
+++ b/modules/rostests/apitests/kernel32/CMakeLists.txt
@@ -27,6 +27,7 @@ list(APPEND SOURCE
     Mailslot.c
     MultiByteToWideChar.c
     PrivMoveFileIdentityW.c
+    QueryUserAPC.c
     SetComputerNameExW.c
     SetConsoleWindowInfo.c
     SetCurrentDirectory.c

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -20,7 +20,7 @@ static const DWORD s_expected[] =
     6, 2, 3, 14, 15,
     16
 };
-static const SIZE_T s_expected_count = sizeof(s_expected) / sizeof(s_expected[0]);
+static const SIZE_T s_expected_count = _countof(s_expected);
 
 static void AddValueToRecord(DWORD dwValue)
 {

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -1,0 +1,120 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Tests for QueryUserAPC
+ * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "precomp.h"
+
+#define MAX_RECORD 256
+
+static DWORD s_record_count = 0;
+static DWORD s_record[MAX_RECORD + 1] = { 0 };
+static BOOL s_terminate_all = FALSE;
+
+static const DWORD s_expected[] =
+{
+    0, 1, 7, 8, 4,
+    2, 1, 9, 10, 5,
+    2, 1, 11, 12, 13,
+    6, 2, 3, 14, 15,
+    16
+};
+static const SIZE_T s_expected_count = sizeof(s_expected) / sizeof(s_expected[0]);
+
+static void AddValueToRecord(DWORD dwValue)
+{
+    s_record[s_record_count] = dwValue;
+    if (s_record_count < MAX_RECORD)
+        s_record_count++;
+}
+
+static VOID CheckRecord(void)
+{
+    SIZE_T i, count = min(s_record_count, s_expected_count);
+
+    for (i = 0; i < count; ++i)
+    {
+        ok(s_record[i] == s_expected[i], "s_record[%u]: got %lu vs expected %lu\n",
+           (INT)i, s_record[i], s_expected[i]);
+    }
+
+    count = abs((int)s_record_count - (int)s_expected_count);
+    for (i = 0; i < count; ++i)
+    {
+        ok(s_record_count == s_expected_count, "s_record_count != s_expected_count\n");
+    }
+}
+
+static DWORD WINAPI ThreadFunc(LPVOID arg)
+{
+    AddValueToRecord(0);
+    while (!s_terminate_all)
+    {
+        AddValueToRecord(1);
+        SleepEx(INFINITE, TRUE);
+        AddValueToRecord(2);
+    }
+    AddValueToRecord(3);
+    return 0;
+}
+
+static VOID NTAPI DoUserAPC1(ULONG_PTR Parameter)
+{
+    ok_int((int)Parameter, 1);
+    AddValueToRecord(4);
+}
+
+static VOID NTAPI DoUserAPC2(ULONG_PTR Parameter)
+{
+    ok_int((int)Parameter, 2);
+    AddValueToRecord(5);
+}
+
+static VOID NTAPI DoUserAPC3(ULONG_PTR Parameter)
+{
+    ok_int((int)Parameter, 3);
+    AddValueToRecord(6);
+    s_terminate_all = TRUE;
+}
+
+START_TEST(QueryUserAPC)
+{
+    DWORD dwThreadId;
+    HANDLE hThread;
+
+    s_record_count = 0;
+    ZeroMemory(s_record, sizeof(s_record));
+
+    hThread = CreateThread(NULL, 0, ThreadFunc, NULL, 0, &dwThreadId);
+    ok(hThread != NULL, "hThread was NULL\n");
+
+    Sleep(300);
+
+    AddValueToRecord(7);
+    ok_long(QueueUserAPC(DoUserAPC1, hThread, 1), 1);
+    AddValueToRecord(8);
+
+    Sleep(300);
+
+    AddValueToRecord(9);
+    ok_long(QueueUserAPC(DoUserAPC2, hThread, 2), 1);
+    AddValueToRecord(10);
+
+    Sleep(300);
+
+    AddValueToRecord(11);
+    ok_long(QueueUserAPC(DoUserAPC3, hThread, 3), 1);
+    AddValueToRecord(12);
+
+    AddValueToRecord(13);
+    ok_long(WaitForSingleObject(hThread, 5 * 1000), WAIT_OBJECT_0);
+    AddValueToRecord(14);
+
+    AddValueToRecord(15);
+    ok_int(CloseHandle(hThread), TRUE);
+    AddValueToRecord(16);
+
+    CheckRecord();
+}

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -43,7 +43,9 @@ static VOID CheckRecord(void)
     count = abs((int)s_record_count - (int)s_expected_count);
     for (i = 0; i < count; ++i)
     {
-        ok(s_record_count == s_expected_count, "s_record_count != s_expected_count\n");
+        ok(s_record_count == s_expected_count,
+           "s_record_count: got %u vs expected %u\n",
+           (int)s_record_count, (int)s_expected_count);
     }
 }
 

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -93,7 +93,7 @@ static VOID NTAPI DoUserAPC3(ULONG_PTR Parameter)
     s_terminate_all = TRUE;
 }
 
-static void TestForSleepEx(void)
+static void JustDoIt(LPTHREAD_START_ROUTINE fn)
 {
     HANDLE hThread;
     DWORD dwThreadId;
@@ -102,7 +102,7 @@ static void TestForSleepEx(void)
     s_record_count = 0;
     ZeroMemory(s_record, sizeof(s_record));
 
-    hThread = CreateThread(NULL, 0, ThreadFunc1, NULL, 0, &dwThreadId);
+    hThread = CreateThread(NULL, 0, fn, NULL, 0, &dwThreadId);
     ok(hThread != NULL, "hThread was NULL\n");
 
     Sleep(100);
@@ -135,46 +135,14 @@ static void TestForSleepEx(void)
     CheckRecord();
 }
 
+static void TestForSleepEx(void)
+{
+    JustDoIt(ThreadFunc1);
+}
+
 static void TestForWaitForSingleObjectEx(void)
 {
-    HANDLE hThread;
-    DWORD dwThreadId;
-
-    s_terminate_all = FALSE;
-    s_record_count = 0;
-    ZeroMemory(s_record, sizeof(s_record));
-
-    hThread = CreateThread(NULL, 0, ThreadFunc2, NULL, 0, &dwThreadId);
-    ok(hThread != NULL, "hThread was NULL\n");
-
-    Sleep(100);
-
-    AddValueToRecord(7);
-    ok_long(QueueUserAPC(DoUserAPC1, hThread, 1), 1);
-    AddValueToRecord(8);
-
-    Sleep(100);
-
-    AddValueToRecord(9);
-    ok_long(QueueUserAPC(DoUserAPC2, hThread, 2), 1);
-    AddValueToRecord(10);
-
-    Sleep(100);
-
-    AddValueToRecord(11);
-    ok_long(QueueUserAPC(DoUserAPC3, hThread, 3), 1);
-    AddValueToRecord(12);
-
-    AddValueToRecord(13);
-    ok_long(WaitForSingleObject(hThread, 5 * 1000), WAIT_OBJECT_0);
-    AddValueToRecord(14);
-
-    AddValueToRecord(15);
-    ok_int(CloseHandle(hThread), TRUE);
-    hThread = NULL;
-    AddValueToRecord(16);
-
-    CheckRecord();
+    JustDoIt(ThreadFunc2);
 }
 
 START_TEST(QueryUserAPC)

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -7,7 +7,7 @@
 
 #include "precomp.h"
 
-#define MAX_RECORD 256
+#define MAX_RECORD 30
 
 static DWORD s_record_count = 0;
 static DWORD s_record[MAX_RECORD + 1] = { 0 };

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -1,10 +1,9 @@
 /*
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
- * PURPOSE:     Tests for QueryUserAPC and threads
+ * PURPOSE:     Tests for QueryUserAPC, SleepEx and threads
  * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
-
 #include "precomp.h"
 
 #define MAX_RECORD 30

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -90,19 +90,19 @@ START_TEST(QueryUserAPC)
     hThread = CreateThread(NULL, 0, ThreadFunc, NULL, 0, &dwThreadId);
     ok(hThread != NULL, "hThread was NULL\n");
 
-    Sleep(300);
+    Sleep(200);
 
     AddValueToRecord(7);
     ok_long(QueueUserAPC(DoUserAPC1, hThread, 1), 1);
     AddValueToRecord(8);
 
-    Sleep(300);
+    Sleep(200);
 
     AddValueToRecord(9);
     ok_long(QueueUserAPC(DoUserAPC2, hThread, 2), 1);
     AddValueToRecord(10);
 
-    Sleep(300);
+    Sleep(200);
 
     AddValueToRecord(11);
     ok_long(QueueUserAPC(DoUserAPC3, hThread, 3), 1);

--- a/modules/rostests/apitests/kernel32/QueryUserAPC.c
+++ b/modules/rostests/apitests/kernel32/QueryUserAPC.c
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
- * PURPOSE:     Tests for QueryUserAPC
+ * PURPOSE:     Tests for QueryUserAPC and threads
  * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 

--- a/modules/rostests/apitests/kernel32/testlist.c
+++ b/modules/rostests/apitests/kernel32/testlist.c
@@ -26,6 +26,7 @@ extern void func_lstrlen(void);
 extern void func_Mailslot(void);
 extern void func_MultiByteToWideChar(void);
 extern void func_PrivMoveFileIdentityW(void);
+extern void func_QueryUserAPC(void);
 extern void func_SetComputerNameExW(void);
 extern void func_SetConsoleWindowInfo(void);
 extern void func_SetCurrentDirectory(void);
@@ -60,6 +61,7 @@ const struct test winetest_testlist[] =
     { "MailslotRead",                func_Mailslot },
     { "MultiByteToWideChar",         func_MultiByteToWideChar },
     { "PrivMoveFileIdentityW",       func_PrivMoveFileIdentityW },
+    { "QueryUserAPC",                func_QueryUserAPC },
     { "SetComputerNameExW",          func_SetComputerNameExW },
     { "SetConsoleWindowInfo",        func_SetConsoleWindowInfo },
     { "SetCurrentDirectory",         func_SetCurrentDirectory },


### PR DESCRIPTION
## Purpose

Add a testcase for `kernel32!QueryUserAPC`, `SleepEx` and `WaitForSingleObjectEx` functions.

JIRA issue: [CORE-13950](https://jira.reactos.org/browse/CORE-13950)

WinXP:
![winxp](https://user-images.githubusercontent.com/2107452/80457951-154b8c00-896b-11ea-9969-546389a15790.png)
Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/80457953-154b8c00-896b-11ea-8966-45416bffe82a.png)
Win10:
![win10](https://user-images.githubusercontent.com/2107452/80457947-14b2f580-896b-11ea-8dfa-cd69558532e5.png)
ReactOS:
![reactos](https://user-images.githubusercontent.com/2107452/80457945-141a5f00-896b-11ea-9306-5521cd406516.png)