### PR TITLE
__DestructExceptionObject(): Update spec files. CORE-15135

### DIFF
--- a/dll/apisets/api-ms-win-crt-private-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-private-l1-1-0.spec
@@ -27,7 +27,7 @@
 @ stdcall -arch=i386 __CxxQueryExceptionSize() msvcrt.__CxxQueryExceptionSize
 @ stub __CxxRegisterExceptionObject
 @ stub __CxxUnregisterExceptionObject
-@ stub __DestructExceptionObject
+@ cdecl __DestructExceptionObject() msvcrt.__DestructExceptionObject
 @ stub __FrameUnwindFilter
 @ stub __GetPlatformExceptionInfo
 @ stub __NLG_Dispatch2

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -212,7 +212,7 @@
 @ cdecl -i386 __CxxQueryExceptionSize()
 @ cdecl -i386 __CxxRegisterExceptionObject()
 @ cdecl -i386 __CxxUnregisterExceptionObject()
-@ cdecl -version=0x600+ __DestructExceptionObject(ptr)
+@ cdecl __DestructExceptionObject(ptr)
 @ cdecl __RTCastToVoid(ptr) MSVCRT___RTCastToVoid
 @ cdecl __RTDynamicCast(ptr long ptr ptr long) MSVCRT___RTDynamicCast
 @ cdecl __RTtypeid(ptr) MSVCRT___RTtypeid


### PR DESCRIPTION
## Purpose

XP x86 has this function.
`-version=0x600+` was erroneously added on 99fe069ce64f9b079b51e083ebb4e1b4092f71ff.

JIRA issue: [CORE-15135](https://jira.reactos.org/browse/CORE-15135)

## TODO

- [X] @JoachimHenze, can you retest your issue? Thanks. // Works fine.
