### PR TITLE
[RAPPS] Add error messages on all download failure cases (CORE-16851)

### DIFF
--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -113,6 +113,8 @@
 #define IDS_UNABLE_TO_INSTALL    128
 #define IDS_SELECTEDFORINST      129
 #define IDS_MISMATCH_CERT_INFO   130
+#define IDS_UNABLE_PATH          131
+
 
 /* Tooltips */
 #define IDS_TOOLTIP_INSTALL      200

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -218,6 +218,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Ausgewählte Installieren"
     IDS_SELECTEDFORINST "Zur Installation ausgewählt"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -216,6 +216,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Instalar selección"
     IDS_SELECTEDFORINST "Seleccionados para instalar"
     IDS_MISMATCH_CERT_INFO "El certificado que usa es desconocido:\nSujeto: %s\nEmisor: %s\n¿Quiere continuar a pesar de ello?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -221,6 +221,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Installi valitud"
     IDS_SELECTEDFORINST "Installimiseks valitud"
     IDS_MISMATCH_CERT_INFO "Kasutatud sertifikaat on tundmatu:\nSubject: %s\nIssuer: %s\nKas soovid siiski jätkata?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -212,7 +212,8 @@ BEGIN
     IDS_SELECT_ALL "Sélectionner/Désélectionner tout"
     IDS_INSTALL_SELECTED "Installer la sélection"
     IDS_SELECTEDFORINST "Sélectionnées pour installation"
-    IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_MISMATCH_CERT_INFO "Certificat inconnu:\nSujet: %s\nEmetteur: %s\nVoulez-vous continuer ?"
+    IDS_UNABLE_PATH "Format de chemin invalide."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -220,6 +220,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Pasang terpilih"
     IDS_SELECTEDFORINST "dipilih untuk pemasangan"
     IDS_MISMATCH_CERT_INFO "Sertifikat yang dipakai tidak dikenal:\nSubyek: %s\nIssuer: %s\nYakin ingin lanjut?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Installa le selezionate"
     IDS_SELECTEDFORINST "Selezionate per l'installazione"
     IDS_MISMATCH_CERT_INFO "Il certificato in uso è sconosciuto:\nSoggetto: %s\nEmittente: %s\nVuoi continuare comunque?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "選択をインストール"
     IDS_SELECTEDFORINST "インストールを選択済み"
     IDS_MISMATCH_CERT_INFO "証明書は未知のものです:\nSubject: %s\nIssuer: %s\nそれでも続けますか？"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -221,6 +221,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Instaluj Zaznaczone"
     IDS_SELECTEDFORINST "Wybrane do instalacji"
     IDS_MISMATCH_CERT_INFO "Użyty certyfikat jest nieznany:\nSubject: %s\nIssuer: %s\nCzy chcesz mimo to kontynuować?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Instalar selecção"
     IDS_SELECTEDFORINST "Seleccionados para instalação"
     IDS_MISMATCH_CERT_INFO "O certificado usado é desconhecido:\nAssunto: %s\nIssuer: %s\nDeseja continuar mesmo assim?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -222,6 +222,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Instalează selecționate"
     IDS_SELECTEDFORINST "Selectate pentru instalare"
     IDS_MISMATCH_CERT_INFO "Certificatul în uz este necunoscut:\nSubiect: %s\nEmitent: %s\nVreți să continuați oricum?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -213,6 +213,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Установить выбранное"
     IDS_SELECTEDFORINST "Выбрано для установки"
     IDS_MISMATCH_CERT_INFO "Используемый сертификат не опознан:\nНазначение: %s\nВыдан: %s\nВы хотите продолжить в любом случае?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -218,6 +218,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -220,6 +220,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Seçileni Kur"
     IDS_SELECTEDFORINST "Kurulum için seçildi"
     IDS_MISMATCH_CERT_INFO "Kullanılan sertifika bilimmiyor:\nAçıklama: %s\nSertifikayı Veren: %s\nYine de sürdürmek istiyor musunuz?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -221,6 +221,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Встановити обране"
     IDS_SELECTEDFORINST "Обрані для встановлення"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_INSTALL_SELECTED "安装已选中的"
     IDS_SELECTEDFORINST "选中以安装"
     IDS_MISMATCH_CERT_INFO "所使用的证书未知:\n主题: %s\n发行方: %s\n您是否仍然想继续？"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Install Selected"
     IDS_SELECTEDFORINST "Selected for installation"
     IDS_MISMATCH_CERT_INFO "The certificate used is unknown:\nSubject: %s\nIssuer: %s\nDo you want to continue anyway?"
+    IDS_UNABLE_PATH "Incorrect path format."
 END
 
 STRINGTABLE

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -514,21 +514,21 @@ VOID ShowLastError(
     HWND hWndOwner,
     DWORD dwLastError)
 {
-    LPTSTR lpMsg;
+    LPWSTR lpMsg;
     
-    if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
-                       FORMAT_MESSAGE_FROM_SYSTEM |
-                       FORMAT_MESSAGE_IGNORE_INSERTS,
-                       NULL,
-                       dwLastError,
-                       LANG_USER_DEFAULT,
-                       (LPTSTR)&lpMsg,
-                       0, NULL))
+    if (!FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                        FORMAT_MESSAGE_FROM_SYSTEM |
+                        FORMAT_MESSAGE_IGNORE_INSERTS,
+                        NULL,
+                        dwLastError,
+                        LANG_USER_DEFAULT,
+                        (LPWSTR)&lpMsg,
+                        0, NULL))
     {
         return;
     }
 
-    MessageBox(hWndOwner, lpMsg, NULL, MB_OK | MB_ICONERROR);
+    MessageBoxW(hWndOwner, lpMsg, NULL, MB_OK | MB_ICONERROR);
     LocalFree(lpMsg);
 }
 

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -39,6 +39,8 @@
 #include <wininet.h>
 #include <shellutils.h>
 
+#include <debug.h>
+
 #include <rosctrls.h>
 #include <windowsx.h>
 #include <process.h>
@@ -508,6 +510,28 @@ VOID CDownloadManager::UpdateProgress(
     }
 }
 
+VOID ShowLastError(
+    HWND hWndOwner,
+    DWORD dwLastError)
+{
+    LPTSTR lpMsg;
+    
+    if (!FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                       FORMAT_MESSAGE_FROM_SYSTEM |
+                       FORMAT_MESSAGE_IGNORE_INSERTS,
+                       NULL,
+                       dwLastError,
+                       LANG_USER_DEFAULT,
+                       (LPTSTR)&lpMsg,
+                       0, NULL))
+    {
+        return;
+    }
+
+    MessageBox(hWndOwner, lpMsg, NULL, MB_OK | MB_ICONERROR);
+    LocalFree(lpMsg);
+}
+
 unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
 {
     ATL::CStringW Path;
@@ -561,7 +585,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         {
             bCab = TRUE;
             if (!GetStorageDirectory(Path))
+            {
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
+            }
         }
         else
         {
@@ -587,7 +614,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
 
         // do we have a final slash separator?
         if (!p)
+        {
+            MessageBox_LoadString(hMainWnd, IDS_UNABLE_PATH);            
             goto end;
+        }
 
         // prepare the tentative length of the filename, maybe we've to remove part of it later on
         filenameLength = wcslen(p) * sizeof(WCHAR);
@@ -601,7 +631,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         if (GetFileAttributesW(Path.GetString()) == INVALID_FILE_ATTRIBUTES)
         {
             if (!CreateDirectoryW(Path.GetString(), NULL))
+            {
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
+            }
         }
 
         // append a \ to the provided file system path, and the filename portion from the URL after that
@@ -640,7 +673,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         }
 
         if (!hOpen)
+        {
+            ShowLastError(hMainWnd, GetLastError());
             goto end;
+        }
 
         dwStatusLen = sizeof(dwStatus);
 
@@ -654,7 +690,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         urlComponents.lpszHostName = (LPWSTR) malloc(urlComponents.dwHostNameLength * sizeof(WCHAR));
 
         if (!InternetCrackUrlW(InfoArray[iAppId].szUrl, urlLength + 1, ICU_DECODE | ICU_ESCAPE, &urlComponents))
+        {
+            ShowLastError(hMainWnd, GetLastError());
             goto end;
+        }
 
         dwContentLen = 0;
 
@@ -665,13 +704,16 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
                                      0);
             if (!hFile)
             {
-                MessageBox_LoadString(hMainWnd, IDS_UNABLE_TO_DOWNLOAD2);
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
             }
 
             // query connection
             if (!HttpQueryInfoW(hFile, HTTP_QUERY_STATUS_CODE | HTTP_QUERY_FLAG_NUMBER, &dwStatus, &dwStatusLen, NULL))
+            {
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
+            }
 
             if (dwStatus != HTTP_STATUS_OK)
             {
@@ -690,7 +732,7 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
                                      0);
             if (!hFile)
             {
-                MessageBox_LoadString(hMainWnd, IDS_UNABLE_TO_DOWNLOAD2);
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
             }
 
@@ -750,20 +792,23 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         hOut = CreateFileW(Path.GetString(), GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, 0, NULL);
 
         if (hOut == INVALID_HANDLE_VALUE)
+        {
+            ShowLastError(hMainWnd, GetLastError());
             goto end;
+        }
 
         dwCurrentBytesRead = 0;
         do
         {
             if (!InternetReadFile(hFile, lpBuffer, _countof(lpBuffer), &dwBytesRead))
             {
-                MessageBox_LoadString(hMainWnd, IDS_INTERRUPTED_DOWNLOAD);
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
             }
 
             if (!WriteFile(hOut, &lpBuffer[0], dwBytesRead, &dwBytesWritten, NULL))
             {
-                MessageBox_LoadString(hMainWnd, IDS_UNABLE_TO_WRITE);
+                ShowLastError(hMainWnd, GetLastError());
                 goto end;
             }
 
@@ -775,7 +820,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
         hOut = INVALID_HANDLE_VALUE;
 
         if (bCancelled)
+        {
+            DPRINT1("Operation cancelled\n");
             goto end;
+        }
 
         if (!dwContentLen)
         {
@@ -794,7 +842,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
 
             // change a few strings in the download dialog to reflect the verification process
             if (!szMsgText.LoadStringW(IDS_INTEG_CHECK_TITLE))
+            {
+                DPRINT1("Unable to load string\n");
                 goto end;
+            }
 
             SetWindowTextW(hDlg, szMsgText.GetString());
             SendMessageW(GetDlgItem(hDlg, IDC_DOWNLOAD_STATUS), WM_SETTEXT, 0, (LPARAM) Path.GetString());
@@ -803,7 +854,10 @@ unsigned int WINAPI CDownloadManager::ThreadFunc(LPVOID param)
             if (!VerifyInteg(InfoArray[iAppId].szSHA1.GetString(), Path.GetString()))
             {
                 if (!szMsgText.LoadStringW(IDS_INTEG_CHECK_FAIL))
+                {
+                    DPRINT1("Unable to load string\n");
                     goto end;
+                }
 
                 MessageBoxW(hDlg, szMsgText.GetString(), NULL, MB_OK | MB_ICONERROR);
                 goto end;
@@ -839,7 +893,7 @@ run:
             }
             else
             {
-                MessageBox_LoadString(hMainWnd, IDS_UNABLE_TO_INSTALL);
+                ShowLastError(hMainWnd, GetLastError());
             }
         }
 


### PR DESCRIPTION
## Purpose

- Current RAPPS has many failure conditions during download process where process stops without user awareness nor logging, making root cause analysis difficult / impossible

JIRA issue: [CORE-16851](https://jira.reactos.org/browse/CORE-16851)

## Proposed changes

- Systematic error messages presented to the users when user awareness is required
- Additionnal logging when no additionnal user awareness is required (cancellation,...)
- All messages added to localization files

![image](https://user-images.githubusercontent.com/24843587/80508481-6615b180-8978-11ea-8555-84d61b5f728b.png)

