### PR TITLE
[SHELL32] Fix "Open With..." spamming registry MRU keys.

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -534,8 +534,6 @@ VOID COpenWithList::LoadFromProgIdKey(HKEY hKey, LPCWSTR pwszExt)
         {
             StringCbCopyW(pApp->wszCmd, sizeof(pApp->wszCmd), wszCmd);
             SetRecommended(pApp);
-            if (!pApp->bMRUList)
-                AddAppToMRUList(pApp, pwszExt);
         }
     }
 }
@@ -652,6 +650,9 @@ BOOL COpenWithList::AddAppToMRUList(SApp *pApp, LPCWSTR pwszFilename)
     {
         /* Insert the entry */
         AddMRUStringW(hList, pApp->wszFilename);
+
+        /* Set MRU pressence */
+        pApp->bMRUList = TRUE;
 
         /* Close MRU list */
         FreeMRUList(hList);

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -651,7 +651,7 @@ BOOL COpenWithList::AddAppToMRUList(SApp *pApp, LPCWSTR pwszFilename)
         /* Insert the entry */
         AddMRUStringW(hList, pApp->wszFilename);
 
-        /* Set MRU pressence */
+        /* Set MRU presence */
         pApp->bMRUList = TRUE;
 
         /* Close MRU list */


### PR DESCRIPTION
## Purpose

- When opening "Open With..." dialog for a given file format, multiple MRU items are appended to registry : 2 items written, even if dialog is closed "cancel".
- Expected behavior : 1 MRU item if execute is selected and 0 MRU if cancel is selected

JIRA issue: [CORE-16981](https://jira.reactos.org/browse/CORE-16981)

## Proposed changes

- MRU item write in registry only if "Execute" if selected (no MRU if "cancel")
- MRU item presence flag corectly set after writing MRU item to avoid multiple write action