### PR TITLE
[GDI32] Preserve PitchAndFamily across GetTextMetricsW call

### DIFF
--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2154,6 +2154,8 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
     };
 
 #if 1 /* This is a hack. See CORE-1091. */
+    /* It is needed because ReactOS does not support raster fonts now  */
+    /* After Raster Font support is added, then it can be removed      */
     /* Determine the current font's Pitch and Family to save for later */
     LOGFONT lf;
     HFONT hCurrentFont;
@@ -2170,8 +2172,12 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
         return 0;
 
     /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
+    /* to a Truetype one when we have a Raster Type font as our input         */
     /* we copy our stored value back into this field to restore the old value */
-    tm.tmPitchAndFamily = bPitchAndFamily;
+    if (tm.tmPitchAndFamily & ( TMPF_VECTOR | TMPF_TRUETYPE ))
+    {
+        tm.tmPitchAndFamily = bPitchAndFamily;
+    }
 #else
     if(!GetTextMetricsW(hdc, &tm)) return 0;
 #endif

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2159,11 +2159,9 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
     /* Determine the current font's Pitch and Family to save for later */
     LOGFONT lf;
     HFONT hCurrentFont;
-    BYTE bPitchAndFamily = 0;
 
     hCurrentFont = (HFONT)GetCurrentObject(hdc, OBJ_FONT);
-    if (GetObject(hCurrentFont, sizeof(LOGFONT), &lf))
-        bPitchAndFamily = lf.lfPitchAndFamily;
+    GetObject(hCurrentFont, sizeof(LOGFONT), &lf);
 
     /* This function currently in ReactOS will always return a Truetype font */
     /* because we cannot yet handle raster fonts. So it will return flags    */
@@ -2172,11 +2170,11 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
         return 0;
 
     /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
-    /* to a Truetype one when we have a Raster Type font as our input         */
-    /* we copy our stored value back into this field to restore the old value */
-    if (tm.tmPitchAndFamily & ( TMPF_VECTOR | TMPF_TRUETYPE ))
+    /* to a Truetype one when we have a 'helv' font as our input we and (&)   */
+    /* our current PitchAndFamily with 0xF9 to remove the two problem bits    */
+    if (wcsicmp(lf.lfFaceName, L"helv")==0)
     {
-        tm.tmPitchAndFamily = bPitchAndFamily;
+        tm.tmPitchAndFamily = tm.tmPitchAndFamily & 0xF9;
     }
 #else
     if(!GetTextMetricsW(hdc, &tm)) return 0;

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2172,7 +2172,7 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
     /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
     /* to a Truetype one when we have a 'helv' font as our input we and (&)   */
     /* our current PitchAndFamily with 0xF9 to remove the two problem bits    */
-    /* Out list below checks for Raster Font Facenames                        */
+    /* Our list below checks for Raster Font Facenames                        */
     DPRINT1("Font Facename is '%S'.\n", lf.lfFaceName);
     if ((wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
         (wcsicmp(lf.lfFaceName, L"Courier") == 0) ||

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2156,7 +2156,7 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
 #if 1 /* This is a hack. See CORE-1091. */
     /* It is needed because ReactOS does not support raster fonts now  */
     /* After Raster Font support is added, then it can be removed      */
-    /* Determine the current font's Pitch and Family to save for later */
+    /* Find the current font's logfont for testing its lf.lfFaceName   */
     LOGFONT lf;
     HFONT hCurrentFont;
 
@@ -2172,7 +2172,16 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
     /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
     /* to a Truetype one when we have a 'helv' font as our input we and (&)   */
     /* our current PitchAndFamily with 0xF9 to remove the two problem bits    */
-    if (wcsicmp(lf.lfFaceName, L"helv")==0)
+    /* Out list below checks for Raster Font Facenames                        */
+    DPRINT1("Font Facename is '%S'.\n", lf.lfFaceName);
+    if ((wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Courier") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Sans Serif") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Serif") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Times New Roman") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Shell Dlg") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"System") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Terminal") == 0))
     {
         tm.tmPitchAndFamily = tm.tmPitchAndFamily & 0xF9;
     }

--- a/win32ss/gdi/gdi32/objects/font.c
+++ b/win32ss/gdi/gdi32/objects/font.c
@@ -2153,41 +2153,7 @@ GdiGetCharDimensions(HDC hdc, LPTEXTMETRICW lptm, LONG *height)
         'I','J','K','L','M','N','O','P','Q','R','S','T','U','V','W','X','Y','Z',0
     };
 
-#if 1 /* This is a hack. See CORE-1091. */
-    /* It is needed because ReactOS does not support raster fonts now  */
-    /* After Raster Font support is added, then it can be removed      */
-    /* Find the current font's logfont for testing its lf.lfFaceName   */
-    LOGFONT lf;
-    HFONT hCurrentFont;
-
-    hCurrentFont = (HFONT)GetCurrentObject(hdc, OBJ_FONT);
-    GetObject(hCurrentFont, sizeof(LOGFONT), &lf);
-
-    /* This function currently in ReactOS will always return a Truetype font */
-    /* because we cannot yet handle raster fonts. So it will return flags    */
-    /* TMPF_VECTOR and TMPF_TRUETYPE, which can cause problems in edit boxes */
-    if (!GetTextMetricsW(hdc, &tm))
-        return 0;
-
-    /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
-    /* to a Truetype one when we have a 'helv' font as our input we and (&)   */
-    /* our current PitchAndFamily with 0xF9 to remove the two problem bits    */
-    /* Our list below checks for Raster Font Facenames                        */
-    DPRINT1("Font Facename is '%S'.\n", lf.lfFaceName);
-    if ((wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Courier") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"MS Sans Serif") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"MS Serif") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Times New Roman") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"MS Shell Dlg") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"System") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Terminal") == 0))
-    {
-        tm.tmPitchAndFamily = tm.tmPitchAndFamily & 0xF9;
-    }
-#else
     if(!GetTextMetricsW(hdc, &tm)) return 0;
-#endif
 
     if(!GetTextExtentPointW(hdc, alphabet, 52, &sz)) return 0;
 

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -51,7 +51,7 @@ IntTMWFixUp(
         (wcsicmp(lf.lfFaceName, L"System") == 0) ||
         (wcsicmp(lf.lfFaceName, L"Terminal") == 0))
     {
-        ptm->TextMetric.tmPitchAndFamily = ptm->TextMetric.tmPitchAndFamily & ~(TMPF_TRUETYPE | TMPF_VECTOR);
+        ptm->TextMetric.tmPitchAndFamily &= ~(TMPF_TRUETYPE | TMPF_VECTOR);
     }
 }
 

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -13,6 +13,48 @@
 #define NDEBUG
 #include <debug.h>
 
+
+/*
+   This is a hack. See CORE-1091.
+
+   It is needed because ReactOS does not support raster fonts now
+   After Raster Font support is added, then it can be removed
+   Find the current font's logfont for testing its lf.lfFaceName
+
+   The ftGdiGetTextMetricsW function currently in ReactOS will always return a Truetype font
+   because we cannot yet handle raster fonts. So it will return flags
+   TMPF_VECTOR and TMPF_TRUETYPE, which can cause problems in edit boxes
+ */
+
+VOID FASTCALL
+IntTMWFixUp(
+   HDC hDC,
+   TMW_INTERNAL *ptm )
+{
+    LOGFONTW lf;
+    HFONT hCurrentFont;
+
+    hCurrentFont = NtGdiGetDCObject( hDC, GDI_OBJECT_TYPE_FONT );
+    GreGetObject(hCurrentFont, sizeof(LOGFONTW), &lf );
+
+    /* To compensate for the GetTextMetricsW call changing the PitchAndFamily */
+    /* to a Truetype one when we have a 'helv' font as our input we and (&)   */
+    /* our current PitchAndFamily with 0xF9 to remove the two problem bits    */
+    /* Out list below checks for Raster Font Facenames                        */
+    DPRINT1("Font Facename is '%S'.\n", lf.lfFaceName);
+    if ((wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Courier") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Sans Serif") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Serif") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Times New Roman") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Shell Dlg") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"System") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Terminal") == 0))
+    {
+        ptm->TextMetric.tmPitchAndFamily = ptm->TextMetric.tmPitchAndFamily & 0xF9;
+    }
+}
+
 /** Functions *****************************************************************/
 
 BOOL FASTCALL
@@ -154,6 +196,7 @@ GreGetTextMetricsW(
 {
    TMW_INTERNAL tmwi;
    if (!ftGdiGetTextMetricsW(hdc, &tmwi)) return FALSE;
+   IntTMWFixUp( hdc, &tmwi );
    *lptm = tmwi.TextMetric;
    return TRUE;
 }
@@ -555,6 +598,7 @@ NtGdiGetTextMetricsW(
     {
         if (ftGdiGetTextMetricsW(hDC, &Tmwi))
         {
+            IntTMWFixUp( hDC, &Tmwi );
             _SEH2_TRY
             {
                 ProbeForWrite(pUnsafeTmwi, cj, 1);


### PR DESCRIPTION
## Adjust for User32-Comctl32 Editbox Margins being set wrong when Raster Font is specified

_ReactOS has no Raster fonts today, so compensate for this affecting the editbox margins._

JIRA issue: [CORE-1091](https://jira.reactos.org/browse/CORE-1091)

This patch is from a concept and a rough patch by me that was polished by @katahiromz.
This patch fixes the inability to see all of the characters in the CD-KEY box of Starcraft and Visual Basic 5 and Visual Basic 6 Installs. It supersedes https://github.com/reactos/reactos/pull/2656