### PR TITLE
[SMSS] Fix PROCESSOR_IDENTIFIER environment variable assignment

### DIFF
--- a/base/system/smss/sminit.c
+++ b/base/system/smss/sminit.c
@@ -1819,9 +1819,9 @@ SmpCreateDynamicEnvironmentVariables(VOID)
     if (NT_SUCCESS(Status))
     {
         /* To combine it into a single string */
-        swprintf((PWCHAR)PartialInfo->Data + wcslen((PWCHAR)PartialInfo->Data),
-                 L", %S",
-                 PartialInfo2->Data);
+        ((PWCHAR)(PartialInfo->Data))[PartialInfo->DataLength / sizeof(WCHAR)] = L'\0';        
+        wcsncat((PWCHAR)PartialInfo->Data, L", ", 2 * sizeof(WCHAR));
+        wcsncat((PWCHAR)PartialInfo->Data, (PWCHAR)PartialInfo2->Data, PartialInfo2->DataLength / sizeof(WCHAR));		
     }
 
     /* So that we can set this as the PROCESSOR_IDENTIFIER variable */


### PR DESCRIPTION
## Purpose

- Current PROCESSOR_IDENTIFIER Environment Variable is "truncated" and does not correctly show the Vendor name. This is due to an incorrect string concatenation.

HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment" is truncated while HKEY_LOCAL_MACHINE\HARDWARE\Description\System\CentralProcessor\0 is correct and contains the full, relevant data (VendorIdentifier)

JIRA issue: [CORE-16986](https://jira.reactos.org/browse/CORE-16986)

![image](https://user-images.githubusercontent.com/24843587/80611652-2bc11880-8a3b-11ea-916b-737bc8457958.png)

## Proposed changes

- Use a correct concatenation to have the full text stored in registry and Environement Variable

![image](https://user-images.githubusercontent.com/24843587/80611618-1ea42980-8a3b-11ea-9c51-0f43126ce7eb.png)
