### PR TITLE
[DESK] Set some flags for Browse for Wallpaper dialog

### DIFF
--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -635,7 +635,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     OPENFILENAME ofn;
     TCHAR filename[MAX_PATH];
     TCHAR fileTitle[256];
-	TCHAR initialDir[MAX_PATH];
+    TCHAR initialDir[MAX_PATH];
     LPTSTR filter;
     LPTSTR extensions;
     BackgroundItem *backgroundItem = NULL;
@@ -653,7 +653,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
 
     hwndBackgroundList = GetDlgItem(hwndDlg, IDC_BACKGROUND_LIST);
     himl = ListView_GetImageList(hwndBackgroundList, LVSIL_SMALL);
-	SHGetFolderPathW(NULL, CSIDL_MYPICTURES, NULL, 0, initialDir);
+    SHGetFolderPathW(NULL, CSIDL_MYPICTURES, NULL, 0, initialDir);
 
     ZeroMemory(&ofn, sizeof(OPENFILENAME));
 

--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -706,8 +706,8 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     ofn.nFilterIndex = 0;
     ofn.lpstrFileTitle = fileTitle;
     ofn.nMaxFileTitle = 256;
-    ofn.lpstrInitialDir = NULL;
-    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
+    ofn.lpstrInitialDir = L"%USERPROFILE%\\My Documents\\My Pictures";
+    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_EXPLORER;
 
     success = GetOpenFileName(&ofn);
     HeapFree(GetProcessHeap(), 0, filter);

--- a/dll/cpl/desk/background.c
+++ b/dll/cpl/desk/background.c
@@ -635,6 +635,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     OPENFILENAME ofn;
     TCHAR filename[MAX_PATH];
     TCHAR fileTitle[256];
+	TCHAR initialDir[MAX_PATH];
     LPTSTR filter;
     LPTSTR extensions;
     BackgroundItem *backgroundItem = NULL;
@@ -652,6 +653,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
 
     hwndBackgroundList = GetDlgItem(hwndDlg, IDC_BACKGROUND_LIST);
     himl = ListView_GetImageList(hwndBackgroundList, LVSIL_SMALL);
+	SHGetFolderPathW(NULL, CSIDL_MYPICTURES, NULL, 0, initialDir);
 
     ZeroMemory(&ofn, sizeof(OPENFILENAME));
 
@@ -706,7 +708,7 @@ OnBrowseButton(HWND hwndDlg, PBACKGROUND_DATA pData)
     ofn.nFilterIndex = 0;
     ofn.lpstrFileTitle = fileTitle;
     ofn.nMaxFileTitle = 256;
-    ofn.lpstrInitialDir = L"%USERPROFILE%\\My Documents\\My Pictures";
+    ofn.lpstrInitialDir = initialDir;
     ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_EXPLORER;
 
     success = GetOpenFileName(&ofn);


### PR DESCRIPTION
This patch makes some changes to the browse for wallpaper dialog. It sets and uses the lpstrInitialDir flag and sets it to the My Pictures folder. Please note Server 2003 doesn't have a My Pictures folder and instead sets the default folder to My Documents. This patch also adds the OFN_EXPLORER so the Open file dialog uses the XP/2003 style dialog instead of the old style dialog.

Photos below!
![Before](https://user-images.githubusercontent.com/15203817/80672988-b58cd800-8a73-11ea-90cb-df7e7e0d92d2.png)
![after](https://user-images.githubusercontent.com/15203817/80672999-b9b8f580-8a73-11ea-9e58-d005939e66df.png)

