### PR TITLE
[CRT_APITEST] Add testcase for wctomb()

### DIFF
--- a/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/crtdll_crt_apitest.cmake
@@ -519,7 +519,7 @@ list(APPEND SOURCE_CRTDLL
     wcstombs.c
     wcstoul.c
 #    wcsxfrm.c
-#    wctomb.c
+    wctomb.c
 #    wprintf.c
 #    wscanf.c
 )

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1255,7 +1255,7 @@ list(APPEND SOURCE_MSVCRT
     wcstoul.c
 #    wcsxfrm.c
 #    wctob
-#    wctomb.c
+    wctomb.c
 #    wctomb_s
 #    wprintf.c
 #    wprintf_s.c

--- a/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/ntdll_crt_apitest.cmake
@@ -123,6 +123,7 @@ list(APPEND SOURCE_NTDLL
 #    wcstol.c
     wcstombs.c
     wcstoul.c
+    wctomb.c
 )
 
 if(ARCH STREQUAL "i386")

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -26,6 +26,7 @@ extern void func_strtoul(void);
 extern void func_wcsnlen(void);
 extern void func_wcstombs(void);
 extern void func_wcstoul(void);
+extern void func_wctomb(void);
 extern void func___getmainargs(void);
 
 extern void func_static_construct(void);
@@ -44,6 +45,7 @@ const struct test winetest_testlist[] =
     { "strlen", func_strlen },
     { "strtoul", func_strtoul },
     { "wcstoul", func_wcstoul },
+    { "wctomb", func_wctomb },
     { "wcstombs", func_wcstombs },
 #if defined(TEST_CRTDLL) || defined(TEST_MSVCRT) || defined(TEST_STATIC_CRT)
     // ...

--- a/modules/rostests/apitests/crt/wctomb.c
+++ b/modules/rostests/apitests/crt/wctomb.c
@@ -1,0 +1,67 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for wctomb
+ * COPYRIGHT:       Copyright 2020 Bișoc George <george.bisoc@reactos.org>
+ */
+
+#include <apitest.h>
+#include <apitest_guard.h>
+
+#define WIN32_NO_STATUS
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <locale.h>
+
+unsigned int cdecl ___lc_codepage_func(void);
+
+START_TEST(wctomb)
+{
+    int Length;
+    char *chDest;
+    char *loc;
+    unsigned int codepage = ___lc_codepage_func();
+    wchar_t wchSrc[2] = {L'R', 0414}; // 0414 corresponds to a Russian character in Windows-1251
+
+    chDest = AllocateGuarded(sizeof(*chDest));
+    if (!chDest)
+    {
+        skip("Buffer allocation failed!\n");
+        return;
+    }
+
+    /* Output the current locale of the system and codepage for comparison between ReactOS and Windows */
+    loc = setlocale(LC_ALL, NULL);
+    printf("The current codepage of your system tested is (%u) and locale (%s).\n\n", codepage, loc);
+
+    /* Do not give output to the caller */
+    Length = wctomb(NULL, 0);
+    ok(Length == 0, "Expected no characters to be converted (because the output argument is refused) but got %d\n.", Length);
+
+    /* Do the same but expect a valid wide character argument this time */
+    Length = wctomb(NULL, wchSrc[0]);
+    ok(Length == 0, "Expected no characters to be converted (because the output argument is refused) but got %d\n.", Length);
+
+    /* Don't return anything to the output even if conversion is impossible */
+    Length = wctomb(NULL, wchSrc[1]);
+    ok(errno == 0, "The error number (errno) should be 0 even though an invalid character in current locale is given but got %d.\n", errno);
+    ok(Length == 0, "Expected no characters to be converted (because the output argument is refused) but got %d\n.", Length);
+
+    /* Attempt to convert a character not possible in current locale */
+    Length = wctomb(chDest, wchSrc[1]);
+    ok(Length == -1, "The conversion is not possible in current locale but got %d as returned value.\n", Length);
+    ok(errno == EILSEQ, "EILSEQ is expected in an illegal sequence conversion but got %d.\n", errno);
+
+    /* Return a null wide character to the destination argument */
+    Length = wctomb(chDest, 0);
+    ok(Length == 1, "Expected one character to be converted (the null character) but got %d.\n", Length);
+    ok_int(chDest[0], '\0');
+
+    /* Get the converted output and validate what we should get */
+    Length = wctomb(chDest, wchSrc[0]);
+    ok(Length == 1, "Expected one character to be converted but got %d.\n", Length);
+    ok_int(chDest[0], 'R');
+
+    FreeGuarded(chDest);
+}


### PR DESCRIPTION
CRT, NTDLL and MSVCRT testcase work flawlessly in Windows Server 2003, ReactOS and Windows XP (with the exception of NTDLL testcase in Windows XP as usual).
**Windows Server 2003**
![Capture](https://user-images.githubusercontent.com/34916900/80713118-3c34ca00-8af3-11ea-92b4-22cb5d67f230.PNG)
**Windows XP**
![Capture2](https://user-images.githubusercontent.com/34916900/80713132-40f97e00-8af3-11ea-84f0-881cd8c80ddc.PNG)
**ReactOS**
![Capture4](https://user-images.githubusercontent.com/34916900/80713183-54a4e480-8af3-11ea-834e-173c0474146f.PNG)

The implementation of `wctomb` in ReactOS is not that all gold and roses...