### PR TITLE
[SYSSETUP] Improve SetupQueryRegisteredOsComponent export CORE-16784

### DIFF
--- a/dll/win32/syssetup/syssetup.spec
+++ b/dll/win32/syssetup/syssetup.spec
@@ -62,7 +62,7 @@
 @ stub SetupOobeInitPostServices
 @ stub SetupOobeInitPreServices
 @ stub SetupPidGen3
-@ stdcall -stub SetupQueryRegisteredOsComponent()
+@ stdcall -stub SetupQueryRegisteredOsComponent(ptr ptr ptr)
 @ stub SetupQueryRegisteredOsComponentsOrder
 @ stub SetupReadPhoneList
 @ stub SetupSetAdminPassword

--- a/dll/win32/syssetup/syssetup.spec
+++ b/dll/win32/syssetup/syssetup.spec
@@ -62,7 +62,7 @@
 @ stub SetupOobeInitPostServices
 @ stub SetupOobeInitPreServices
 @ stub SetupPidGen3
-@ stub SetupQueryRegisteredOsComponent
+@ stdcall -stub SetupQueryRegisteredOsComponent()
 @ stub SetupQueryRegisteredOsComponentsOrder
 @ stub SetupReadPhoneList
 @ stub SetupSetAdminPassword


### PR DESCRIPTION
## Purpose

Improve an export for SetupQueryRegisteredOsComponent function in syssetup by using `stdcall -stub` instead of `stub`. Also, since this function is completely undocumented from MS side and there is no even any unofficial prototype, we don't know the function's arguments at all, so just use `()` without arguments then.
Required by Windows Media Encoder 9 installer from Rapps. This fix avoids the rundll32 crashes during WME9 installation. So now it installs without any errors.
Please note that it will install successfully only without VirtualBox Guest Additions installed. If they are installed, then installer will hang at the start of the installation due to another unrelated problem in netapi32. See the ticket description for details.

JIRA issue: [CORE-16784](https://jira.reactos.org/browse/CORE-16784)

## Result

Before:
![wme9_no-GA_1](https://user-images.githubusercontent.com/26385117/80713400-0ba55e00-8afc-11ea-929b-4b322a7beaca.png)
After:
![wme9_no-GA_3_success](https://user-images.githubusercontent.com/26385117/80713786-af8f0980-8afc-11ea-983a-41934912e771.png)