### PR TITLE
[SHELL32] Return ERROR_INVALID_DRIVE

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -573,6 +573,7 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
     HRESULT hr = E_INVALIDARG;
     LPCWSTR szNext = NULL;
     LPITEMIDLIST pidlTemp = NULL;
+    WCHAR volumePathName[MAX_PATH];
 
     TRACE("(%p)->(HWND=%p,%p,%p=%s,%p,pidl=%p,%p)\n", this,
           hwndOwner, pbc, lpszDisplayName, debugstr_w (lpszDisplayName),
@@ -588,6 +589,13 @@ HRESULT WINAPI CDrivesFolder::ParseDisplayName(HWND hwndOwner, LPBC pbc, LPOLEST
 
     if (PathGetDriveNumberW(lpszDisplayName) < 0)
         return E_INVALIDARG;
+
+    /* check if this drive actually exists */
+    if (!GetVolumePathNameW(lpszDisplayName, volumePathName, _countof(volumePathName)) ||
+        GetDriveTypeW(volumePathName) < DRIVE_REMOVABLE)
+    {
+        return HRESULT_FROM_WIN32(ERROR_INVALID_DRIVE);
+    }
 
     pidlTemp = _ILCreateDrive(lpszDisplayName);
     if (!pidlTemp)


### PR DESCRIPTION
## Purpose

Shell32 currently returns S_OK when browsing to a drive that does not exist.  This causes browseui to allow browsing to non-available drive letters.

![beforePatch](https://user-images.githubusercontent.com/3923687/80738357-c23c1b00-8ac9-11ea-891c-7f9a34cca086.png)

The purpose of this PR is to address this issue by returning ERROR_INVALID_DRIVE if the drive is either unknown or unmounted.

## Proposed changes

Check to see if the drive type is unknown or unmounted by making a call to `GetDriveTypeW` while validating arguments in `CDrivesFolder`.  I'm not 100% sure if this is the correct place to do this check, so I'm definitely open to suggestions on changing how/where this is done.

## Working Screenshot

![afterPatch](https://user-images.githubusercontent.com/3923687/80738434-e7308e00-8ac9-11ea-91a6-f0719b6b33a5.png)

## TODO

- Invalid network locations continue to behave incorrectly.  I think network support in general is limited, so modifying this will take some future work.