### PR TITLE
[SMSS] Use RTL string-safe functions in critical places. Add validity checks for returned NtQueryValueKey() data.

### DIFF
--- a/base/system/smss/smsbapi.c
+++ b/base/system/smss/smsbapi.c
@@ -94,7 +94,7 @@ SmpSbCreateSession(IN PVOID Reserved,
                 NtClose(ProcessInformation->ProcessHandle);
                 NtClose(ProcessInformation->ThreadHandle);
                 SmpDereferenceSubsystem(KnownSubsys);
-                DbgPrint("SmpSbCreateSession: NtDuplicateObject (Thread) Failed %lx\n", Status);
+                DPRINT1("SmpSbCreateSession: NtDuplicateObject (Thread) Failed %lx\n", Status);
                 return Status;
             }
 

--- a/base/system/smss/smss.h
+++ b/base/system/smss/smss.h
@@ -31,6 +31,8 @@
 #include <ndk/umfuncs.h>
 #include <ndk/kefuncs.h>
 
+#include <ntstrsafe.h>
+
 /* SM Protocol Header */
 #include <sm/smmsg.h>
 

--- a/base/system/smss/smsubsys.c
+++ b/base/system/smss/smsubsys.c
@@ -656,8 +656,8 @@ SmpLoadSubSystemsForMuSession(IN PULONG MuSessionId,
         if ((NT_SUCCESS(Status2)) && (InitialCommandBuffer[0]))
         {
             /* Put the debugger string with the Winlogon string */
-            wcscat(InitialCommandBuffer, L" ");
-            wcscat(InitialCommandBuffer, InitialCommand->Buffer);
+            RtlStringCbCatW(InitialCommandBuffer, sizeof(InitialCommandBuffer), L" ");
+            RtlStringCbCatW(InitialCommandBuffer, sizeof(InitialCommandBuffer), InitialCommand->Buffer);
             RtlInitUnicodeString(InitialCommand, InitialCommandBuffer);
         }
     }


### PR DESCRIPTION
- Not all the wcscpy() / swprintf() calls have been converted to their
  string-safe equivalents. Instead I used the string-safe functions only
  for places where strings of unknown length were copied into fixed-size
  internal buffers. On the contrary, for known-fixed-length strings being
  copied or numbers being converted to string representations in large
  enough buffers, I kept the original function calls.

- Verify the registry data that has been returned by NtQueryValueKey():
  * When expecting (not multi) strings, check whether the data type is
    either REG_SZ or REG_EXPAND_SZ.
  * When expecting DWORD values, check whether the data type is
    REG_DWORD and whether the data length is (greater or) equal to
    sizeof(ULONG).
