### PR TITLE
[SYSDM][DESK] Fix GetDC/ReleaseDC error management

### DIFF
--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -72,7 +72,7 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
                 g = GetGValue(Color) * alpha / 255;
                 b = GetBValue(Color) * alpha / 255;
 
-                *pBits++ = b | g << 8 | r << 16 | alpha << 24;
+                *pBits++ = b | (g << 8) | (r << 16) | (alpha << 24);
             }
         }
 

--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -20,12 +20,15 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     BITMAP logoBitmap;
     BITMAP maskBitmap;
     BITMAPINFO bmpi;
-    HDC hDC;
+    HDC hDC = GetDC(hwndDlg);
     HDC hDCLogo = CreateCompatibleDC(NULL);
     HDC hDCMask = CreateCompatibleDC(NULL);
     HBITMAP hMask, hLogo, hAlphaLogo = NULL;
     COLORREF *pBits;
     INT line, column;
+
+    if (hDC == NULL)
+        goto Cleanup;
 
     ZeroMemory(pImgInfo, sizeof(*pImgInfo));
     ZeroMemory(&bmpi, sizeof(bmpi));
@@ -35,15 +38,11 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
 
     if (hLogo != NULL && hMask != NULL && hDCLogo != NULL && hDCMask != NULL)
     {
-        GetObject(hLogo, sizeof(BITMAP), &logoBitmap);
-        GetObject(hMask, sizeof(BITMAP), &maskBitmap);
-        hDC = GetDC(hwndDlg);
-		
-        if (logoBitmap.bmHeight != maskBitmap.bmHeight || logoBitmap.bmWidth != maskBitmap.bmWidth || hDC == NULL)
-            goto Cleanup;
+        GetObject(hLogo, sizeof(logoBitmap), &logoBitmap);
+        GetObject(hMask, sizeof(maskBitmap), &maskBitmap);
 
-        pImgInfo->cxSource = logoBitmap.bmWidth;
-        pImgInfo->cySource = logoBitmap.bmHeight;
+        if (logoBitmap.bmHeight != maskBitmap.bmHeight || logoBitmap.bmWidth != maskBitmap.bmWidth)
+            goto Cleanup;
 
         bmpi.bmiHeader.biSize = sizeof(BITMAPINFO);
         bmpi.bmiHeader.biWidth = logoBitmap.bmWidth;

--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -27,7 +27,7 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     COLORREF *pBits;
     INT line, column;
 
-    if (hDC == NULL)
+    if (hDC == NULL || hDCLogo == NULL || hDCMask == NULL)
         goto Cleanup;
 
     ZeroMemory(pImgInfo, sizeof(*pImgInfo));
@@ -36,7 +36,7 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     hLogo = (HBITMAP)LoadImageW(hInstance, MAKEINTRESOURCEW(IDB_ROSLOGO), IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
     hMask = (HBITMAP)LoadImageW(hInstance, MAKEINTRESOURCEW(IDB_ROSMASK), IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
 
-    if (hLogo != NULL && hMask != NULL && hDCLogo != NULL && hDCMask != NULL)
+    if (hLogo != NULL && hMask != NULL)
     {
         GetObject(hLogo, sizeof(logoBitmap), &logoBitmap);
         GetObject(hMask, sizeof(maskBitmap), &maskBitmap);
@@ -84,10 +84,10 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     }
 
 Cleanup:
-    if (hLogo != NULL) DeleteObject(hLogo);
     if (hMask != NULL) DeleteObject(hMask);
-    if (hDCLogo != NULL) DeleteDC(hDCLogo);
+    if (hLogo != NULL) DeleteObject(hLogo);  
     if (hDCMask != NULL) DeleteDC(hDCMask);
+    if (hDCLogo != NULL) DeleteDC(hDCLogo);    
     if (hDC != NULL) ReleaseDC(hwndDlg, hDC);
 }
 

--- a/base/system/userinit/livecd.c
+++ b/base/system/userinit/livecd.c
@@ -20,7 +20,7 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     BITMAP logoBitmap;
     BITMAP maskBitmap;
     BITMAPINFO bmpi;
-    HDC hDC = GetDC(hwndDlg);
+    HDC hDC;
     HDC hDCLogo = CreateCompatibleDC(NULL);
     HDC hDCMask = CreateCompatibleDC(NULL);
     HBITMAP hMask, hLogo, hAlphaLogo = NULL;
@@ -33,13 +33,17 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     hLogo = (HBITMAP)LoadImageW(hInstance, MAKEINTRESOURCEW(IDB_ROSLOGO), IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
     hMask = (HBITMAP)LoadImageW(hInstance, MAKEINTRESOURCEW(IDB_ROSMASK), IMAGE_BITMAP, 0, 0, LR_DEFAULTCOLOR);
 
-    if (hLogo != NULL && hMask != NULL)
+    if (hLogo != NULL && hMask != NULL && hDCLogo != NULL && hDCMask != NULL)
     {
-        GetObject(hLogo, sizeof(logoBitmap), &logoBitmap);
-        GetObject(hMask, sizeof(maskBitmap), &maskBitmap);
-
-        if (logoBitmap.bmHeight != maskBitmap.bmHeight || logoBitmap.bmWidth != maskBitmap.bmWidth)
+        GetObject(hLogo, sizeof(BITMAP), &logoBitmap);
+        GetObject(hMask, sizeof(BITMAP), &maskBitmap);
+        hDC = GetDC(hwndDlg);
+		
+        if (logoBitmap.bmHeight != maskBitmap.bmHeight || logoBitmap.bmWidth != maskBitmap.bmWidth || hDC == NULL)
             goto Cleanup;
+
+        pImgInfo->cxSource = logoBitmap.bmWidth;
+        pImgInfo->cySource = logoBitmap.bmHeight;
 
         bmpi.bmiHeader.biSize = sizeof(BITMAPINFO);
         bmpi.bmiHeader.biWidth = logoBitmap.bmWidth;
@@ -81,10 +85,11 @@ InitLogo(PIMGINFO pImgInfo, HWND hwndDlg)
     }
 
 Cleanup:
-    DeleteObject(hMask);
-    DeleteObject(hLogo);
-    DeleteDC(hDCMask);
-    DeleteDC(hDCLogo);
+    if (hLogo != NULL) DeleteObject(hLogo);
+    if (hMask != NULL) DeleteObject(hMask);
+    if (hDCLogo != NULL) DeleteDC(hDCLogo);
+    if (hDCMask != NULL) DeleteDC(hDCMask);
+    if (hDC != NULL) ReleaseDC(hwndDlg, hDC);
 }
 
 

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -5,7 +5,7 @@
  * PURPOSE:         Settings property page
  *
  * PROGRAMMERS:     Trevor McCort (lycan359@gmail.com)
- *                  Hervé Poussineau (hpoussin@reactos.org)
+ *                  HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "desk.h"
@@ -474,6 +474,7 @@ OnBPPChanged(IN HWND hwndDlg, IN PSETTINGS_DATA pData)
     hSpectrumDC = GetDC(hSpectrumControl);
     if (hSpectrumDC == NULL)
         return;
+
     GetClientRect(hSpectrumControl, &client);
     ShowColorSpectrum(hSpectrumDC, &client, dmNewBitsPerPel, pData);
     ReleaseDC(hSpectrumControl, hSpectrumDC);

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -472,6 +472,8 @@ OnBPPChanged(IN HWND hwndDlg, IN PSETTINGS_DATA pData)
     /* Show a new spectrum bitmap */
     hSpectrumControl = GetDlgItem(hwndDlg, IDC_SETTINGS_SPECTRUM);
     hSpectrumDC = GetDC(hSpectrumControl);
+    if (hSpectrumDC == NULL)
+        return;
     GetClientRect(hSpectrumControl, &client);
     ShowColorSpectrum(hSpectrumDC, &client, dmNewBitsPerPel, pData);
     ReleaseDC(hSpectrumControl, hSpectrumDC);

--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -474,6 +474,7 @@ OnBPPChanged(IN HWND hwndDlg, IN PSETTINGS_DATA pData)
     hSpectrumDC = GetDC(hSpectrumControl);
     GetClientRect(hSpectrumControl, &client);
     ShowColorSpectrum(hSpectrumDC, &client, dmNewBitsPerPel, pData);
+    ReleaseDC(hSpectrumControl, hSpectrumDC);
 
     /* Find if new parameters are valid */
     Current = pData->CurrentDisplayDevice->CurrentSettings;

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -62,7 +62,7 @@ static VOID InitLogo(HWND hwndDlg)
     BITMAP logoBitmap;
     BITMAP maskBitmap;
     BITMAPINFO bmpi;
-    HDC hDC;
+    HDC hDC = GetDC(hwndDlg);
     HDC hDCLogo = CreateCompatibleDC(NULL);
     HDC hDCMask = CreateCompatibleDC(NULL);
     HBITMAP hMask, hLogo, hAlphaLogo = NULL;
@@ -114,7 +114,7 @@ static VOID InitLogo(HWND hwndDlg)
                 g = GetGValue(Color) * alpha / 255;
                 b = GetBValue(Color) * alpha / 255;
 
-                *pBits++ = b | g << 8 | r << 16 | alpha << 24;
+                *pBits++ = b | (g << 8) | (r << 16) | (alpha << 24);
             }
         }
 

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -170,7 +170,7 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0);
 
                     hFont = CreateFontIndirect(&ncm.lfMessageFont);
-                    if(!hFont)
+                    if (!hFont)
                         goto Cleanup;
                     SelectObject(hCreditsDC, hFont);
 
@@ -181,7 +181,7 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 
                     hCreditsBitmap = CreateBitmap(pImgInfo->cxSource, (2 * pImgInfo->cySource) + iDevsHeight + 1, pImgInfo->iPlanes, pImgInfo->iBits, NULL);
 
-                    if(!hCreditsBitmap)
+                    if (!hCreditsBitmap)
                         goto Cleanup;
 
                     SelectObject(hLogoDC, pImgInfo->hBitmap);
@@ -231,7 +231,8 @@ Cleanup:
                     ReleaseDC(hwnd, hDC);
                 }
                 KillTimer(hwnd, timerid);
-                if (hCreditsBitmap != NULL) DeleteObject(hCreditsBitmap);
+                if (hCreditsBitmap != NULL)
+                    DeleteObject(hCreditsBitmap);
 
                 top = 0;
                 timerid = 0;
@@ -248,14 +249,14 @@ Cleanup:
                 HDC hDC = GetDC(hwnd);
                 if (hDC != NULL)
                 {
-                
                     GetClientRect(hwnd, &rcCredits);
                     SetRect(&rcCredits, 0, 0, rcCredits.right, pImgInfo->cySource);
                     FillRect(hDC, &rcCredits, GetSysColorBrush(COLOR_3DFACE));
                     ReleaseDC(hwnd, hDC);
                 }
                 KillTimer(hwnd, timerid);
-                if (hCreditsBitmap != NULL) DeleteObject(hCreditsBitmap);
+                if (hCreditsBitmap != NULL)
+                    DeleteObject(hCreditsBitmap);
 
                 top = 0;
                 timerid = 0;

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -69,6 +69,9 @@ static VOID InitLogo(HWND hwndDlg)
     COLORREF *pBits;
     INT line, column;
 
+    if (hDC == NULL)
+        goto Cleanup;
+
     ZeroMemory(pImgInfo, sizeof(*pImgInfo));
     ZeroMemory(&bmpi, sizeof(bmpi));
 
@@ -77,15 +80,11 @@ static VOID InitLogo(HWND hwndDlg)
 
     if (hLogo != NULL && hMask != NULL && hDCLogo != NULL && hDCMask != NULL)
     {
-        GetObject(hLogo, sizeof(BITMAP), &logoBitmap);
-        GetObject(hMask, sizeof(BITMAP), &maskBitmap);
-        hDC = GetDC(hwndDlg);
+        GetObject(hLogo, sizeof(logoBitmap), &logoBitmap);
+        GetObject(hMask, sizeof(maskBitmap), &maskBitmap);
 
         if (logoBitmap.bmHeight != maskBitmap.bmHeight || logoBitmap.bmWidth != maskBitmap.bmWidth || hDC == NULL)
             goto Cleanup;
-
-        pImgInfo->cxSource = logoBitmap.bmWidth;
-        pImgInfo->cySource = logoBitmap.bmHeight;
 
         bmpi.bmiHeader.biSize = sizeof(BITMAPINFO);
         bmpi.bmiHeader.biWidth = logoBitmap.bmWidth;
@@ -96,7 +95,7 @@ static VOID InitLogo(HWND hwndDlg)
         bmpi.bmiHeader.biSizeImage = 4 * logoBitmap.bmWidth * logoBitmap.bmHeight;
 
         /* Create a premultiplied bitmap */
-		hAlphaLogo = CreateDIBSection(hDC, &bmpi, DIB_RGB_COLORS, (PVOID*)&pBits, 0, 0);
+        hAlphaLogo = CreateDIBSection(hDC, &bmpi, DIB_RGB_COLORS, (PVOID*)&pBits, 0, 0);
         if (!hAlphaLogo)
             goto Cleanup;
 
@@ -118,13 +117,13 @@ static VOID InitLogo(HWND hwndDlg)
                 *pBits++ = b | g << 8 | r << 16 | alpha << 24;
             }
         }
-    
-		pImgInfo->hBitmap = hAlphaLogo;
-		pImgInfo->cxSource = logoBitmap.bmWidth;
-		pImgInfo->cySource = logoBitmap.bmHeight;
-		pImgInfo->iBits = logoBitmap.bmBitsPixel;
-		pImgInfo->iPlanes = logoBitmap.bmPlanes;	
-	}
+
+        pImgInfo->hBitmap = hAlphaLogo;
+        pImgInfo->cxSource = logoBitmap.bmWidth;
+        pImgInfo->cySource = logoBitmap.bmHeight;
+        pImgInfo->iBits = logoBitmap.bmBitsPixel;
+        pImgInfo->iPlanes = logoBitmap.bmPlanes;
+    }
 
 Cleanup:
     if (hLogo != NULL) DeleteObject(hLogo);

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -153,12 +153,15 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     TCHAR szCredits[2048];
                     INT iDevsHeight;
 
-                    top = 0;
+                    if (hDC == NULL)
+                        goto Cleanup;
+
+					top = 0;
                     offset = 0;
                     hCreditsDC = CreateCompatibleDC(hDC);
                     hLogoDC = CreateCompatibleDC(hCreditsDC);
 
-                    if (hCreditsDC == NULL || hLogoDC == NULL || hDC == NULL)
+                    if (hCreditsDC == NULL || hLogoDC == NULL)
                         goto Cleanup;
 
                     SetRect(&rcCredits, 0, 0, 0, 0);
@@ -205,7 +208,7 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
 
                     timerid = SetTimer(hwnd, 1, ANIM_TIME, NULL);
 
-                Cleanup:
+Cleanup:
                     if (hLogoDC != NULL) DeleteDC(hLogoDC);
                     if (hCreditsDC != NULL) DeleteDC(hCreditsDC);
                     if (hDC != NULL) ReleaseDC(NULL, hDC);
@@ -230,7 +233,8 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                 top = 0;
                 timerid = 0;
             }
-            InvalidateRect(hwnd, NULL, FALSE);
+            
+			InvalidateRect(hwnd, NULL, FALSE);
             break;
         case WM_TIMER:
             top += ANIM_STEP;

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -147,7 +147,7 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                 {
                     HDC hCreditsDC, hLogoDC;
                     HDC hDC = GetDC(NULL);
-                    HFONT hFont;
+                    HFONT hFont = NULL;
                     NONCLIENTMETRICS ncm;
                     RECT rcCredits;
                     TCHAR szCredits[2048];
@@ -170,6 +170,8 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &ncm, 0);
 
                     hFont = CreateFontIndirect(&ncm.lfMessageFont);
+                    if(!hFont)
+                        goto Cleanup;
                     SelectObject(hCreditsDC, hFont);
 
                     LoadString(hApplet, IDS_DEVS, szCredits, sizeof(szCredits) / sizeof(TCHAR));
@@ -209,6 +211,7 @@ LRESULT CALLBACK RosImageProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam
                     timerid = SetTimer(hwnd, 1, ANIM_TIME, NULL);
 
 Cleanup:
+                    if (hFont != NULL) DeleteObject(hFont);
                     if (hLogoDC != NULL) DeleteDC(hLogoDC);
                     if (hCreditsDC != NULL) DeleteDC(hCreditsDC);
                     if (hDC != NULL) ReleaseDC(NULL, hDC);
@@ -228,13 +231,13 @@ Cleanup:
                     ReleaseDC(hwnd, hDC);
                 }
                 KillTimer(hwnd, timerid);
-                DeleteObject(hCreditsBitmap);
+                if (hCreditsBitmap != NULL) DeleteObject(hCreditsBitmap);
 
                 top = 0;
                 timerid = 0;
             }
             
-			InvalidateRect(hwnd, NULL, FALSE);
+            InvalidateRect(hwnd, NULL, FALSE);
             break;
         case WM_TIMER:
             top += ANIM_STEP;
@@ -252,7 +255,7 @@ Cleanup:
                     ReleaseDC(hwnd, hDC);
                 }
                 KillTimer(hwnd, timerid);
-                DeleteObject(hCreditsBitmap);
+                if (hCreditsBitmap != NULL) DeleteObject(hCreditsBitmap);
 
                 top = 0;
                 timerid = 0;


### PR DESCRIPTION
## Purpose
[SYSDM]
- When closing System Properties page, log show
(win32ss/user/ntuser/windc.c:749) err: [00060138] GetDC() without ReleaseDC()!
because GetDC() is called (multiple times) without properly calling ReleaseDC() as required in order to releases a device context.
- This module also lacks some error management in case null DC are provided (on error)
- LiveCD Userinit, based on SYSDM is affected too

[DESK]
- Fix missing ReleaseDC related to the spectrum (color depth)

## Proposed changes

- ReleaseDC() added
- Error management in case of null DC
- Overall alignement of LiveCD Userinit and SYSDM