### PR TITLE
[SDK][STDLIB][STRING] Wine-sync wcsrtombs_l and _mbstowcs_l

### DIFF
--- a/sdk/lib/crt/stdlib/mbstowcs.c
+++ b/sdk/lib/crt/stdlib/mbstowcs.c
@@ -1,7 +1,7 @@
 #include <precomp.h>
 
 /*********************************************************************
- * _mbstowcs_l
+ *		_mbstowcs_l (MSVCRT.@)
  */
 size_t CDECL _mbstowcs_l(wchar_t *wcstr, const char *mbstr,
         size_t count, _locale_t locale)
@@ -9,10 +9,26 @@ size_t CDECL _mbstowcs_l(wchar_t *wcstr, const char *mbstr,
     MSVCRT_pthreadlocinfo locinfo;
     size_t i, size;
 
+    if(!mbstr) {
+        _set_errno(EINVAL);
+        return -1;
+    }
+
     if(!locale)
         locinfo = get_locinfo();
     else
         locinfo = ((MSVCRT__locale_t)locale)->locinfo;
+
+    if(!locinfo->lc_codepage) {
+        if(!wcstr)
+            return strlen(mbstr);
+
+        for(i=0; i<count; i++) {
+            wcstr[i] = (unsigned char)mbstr[i];
+            if(!wcstr[i]) break;
+        }
+        return i;
+    }
 
     /* Ignore count parameter */
     if(!wcstr)
@@ -25,10 +41,17 @@ size_t CDECL _mbstowcs_l(wchar_t *wcstr, const char *mbstr,
         size += (_isleadbyte_l((unsigned char)mbstr[size], locale) ? 2 : 1);
     }
 
-    size = MultiByteToWideChar(locinfo->lc_codepage, 0,
-            mbstr, size, wcstr, count);
+    if(size) {
+        size = MultiByteToWideChar(locinfo->lc_codepage, 0,
+                                   mbstr, size, wcstr, count);
+        if(!size) {
+            if(count) wcstr[0] = '\0';
+            _set_errno(EILSEQ);
+            return -1;
+        }
+    }
 
-    if(size<count && wcstr)
+    if(size<count)
         wcstr[size] = '\0';
 
     return size;


### PR DESCRIPTION
`wctomb` is not addressed in this commit, it crashes our current testcase unit we have for that function.
Here are the test results for `mbstowcs` and `wcstombs`.
![Capture](https://user-images.githubusercontent.com/34916900/80825895-8e541900-8be1-11ea-87d5-3a21acab9547.PNG)
![Capture2](https://user-images.githubusercontent.com/34916900/80825896-8eecaf80-8be1-11ea-8d20-f63c52e2c0f0.PNG)
