### PR TITLE
[VIDEOPRT] Remove confusing 'else' after 'return'. CORE-10146

### DIFF
--- a/win32ss/drivers/videoprt/resource.c
+++ b/win32ss/drivers/videoprt/resource.c
@@ -765,7 +765,8 @@ VideoPortGetAccessRanges(
             ERR_(VIDEOPRT, "Too many access ranges found\n");
             return ERROR_NOT_ENOUGH_MEMORY;
         }
-        else if (Descriptor->Type == CmResourceTypeMemory)
+
+        if (Descriptor->Type == CmResourceTypeMemory)
         {
             INFO_(VIDEOPRT, "Memory range starting at 0x%08x length 0x%08x\n",
                   Descriptor->u.Memory.Start.u.LowPart, Descriptor->u.Memory.Length);


### PR DESCRIPTION
## Purpose

Revert a hunk of b82bf8ce167ae96dff2868461e82136b90b8c45f.

JIRA issue: [CORE-10146](https://jira.reactos.org/browse/CORE-10146)
