### PR TITLE
[FREELDR] machpc.c: Increase serial port length to 8 from 7

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -706,7 +706,7 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
         PartialDescriptor->Flags = CM_RESOURCE_PORT_IO;
         PartialDescriptor->u.Port.Start.LowPart = Base;
         PartialDescriptor->u.Port.Start.HighPart = 0x0;
-        PartialDescriptor->u.Port.Length = 7;
+        PartialDescriptor->u.Port.Length = 8;
 
         /* Set Interrupt */
         PartialDescriptor = &PartialResourceList->PartialDescriptors[1];


### PR DESCRIPTION
See for example:

* [I/O Ports and Devices](https://www.pearsonitcertification.com/articles/article.aspx?p=1681059) Table 3-1.
* https://en.wikipedia.org/wiki/COM_(hardware_interface)#I/O_addresses
`This IC has seven internal 8-bit registers which hold information and configuration data about which data is to be sent or was received, the baud rate, interrupt configuration and more. In the case of COM1, these registers can be accessed by writing to or reading from the I/O addresses 0x3F8 to 0x3FF.`
* https://www.tldp.org/HOWTO/Serial-HOWTO-8.html#ss8.9
`The addresses shown below represent the first address of an 8-byte range. For example 3f8 is really the range 3f8-3ff.`