### PR TITLE
[SNDVOL32] Fix GetDC/ReleaseDC error management

### DIFF
--- a/base/applications/sndvol32/dialog.c
+++ b/base/applications/sndvol32/dialog.c
@@ -408,6 +408,7 @@ LoadDialog(
             MixerWindow->baseUnit.cx = charSize.cx;
             MixerWindow->baseUnit.cy = charSize.cy;
         }
+
         ReleaseDC(NULL, hDC);
     }
 

--- a/base/applications/sndvol32/dialog.c
+++ b/base/applications/sndvol32/dialog.c
@@ -408,6 +408,7 @@ LoadDialog(
             MixerWindow->baseUnit.cx = charSize.cx;
             MixerWindow->baseUnit.cy = charSize.cy;
         }
+        ReleaseDC(NULL, hDC);
     }
 
 //    assert(MixerWindow->hFont);


### PR DESCRIPTION
## Purpose

- GetDC() is called without properly calling ReleaseDC() as required in order to releases a device context.
Similar to https://github.com/reactos/reactos/pull/2707

## Proposed changes

- Add missing ReleaseDC