### PR TITLE
[RPCRT4] Export NdrCreateServerInterfaceFromStub as `stub`

### DIFF
--- a/dll/win32/rpcrt4/rpcrt4.spec
+++ b/dll/win32/rpcrt4/rpcrt4.spec
@@ -179,7 +179,7 @@
 179 stdcall NdrCorrelationFree(ptr)
 180 stdcall NdrCorrelationInitialize(ptr ptr long long)
 181 stdcall NdrCorrelationPass(ptr)
-# NdrCreateServerInterfaceFromStub
+182 stub NdrCreateServerInterfaceFromStub
 183 stub NdrDcomAsyncClientCall
 184 stub NdrDcomAsyncStubCall
 185 stdcall NdrDllCanUnloadNow(ptr)


### PR DESCRIPTION
## Purpose

Add export for NdrCreateServerInterfaceFromStub function in our rpcrt4.
Required by MS ole32.dll. Since this function is undocumented, and we don't know its exact arguments, use just `stub` for an export. Moreover, it's enough to allow MS ole32 no longer fail.

JIRA issue: [CORE-15395](https://jira.reactos.org/browse/CORE-15395), [CORE-17004](https://jira.reactos.org/browse/CORE-17004).

## Result

Before:
![MS_ole32_before](https://user-images.githubusercontent.com/26385117/80860717-4e894200-8c72-11ea-9799-da28136bc7b3.png)

After:
![MS_ole32_after](https://user-images.githubusercontent.com/26385117/80860724-5648e680-8c72-11ea-940a-ea38d9c18e8d.png)