### PR TITLE
[FREELDR] machpc.c: Increase parallel port length to 8 from 3

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -809,7 +809,7 @@ DetectParallelPorts(PCONFIGURATION_COMPONENT_DATA BusKey)
         PartialDescriptor->Flags = CM_RESOURCE_PORT_IO;
         PartialDescriptor->u.Port.Start.LowPart = Base;
         PartialDescriptor->u.Port.Start.HighPart = 0x0;
-        PartialDescriptor->u.Port.Length = 3;
+        PartialDescriptor->u.Port.Length = 8;
 
         /* Set Interrupt */
         if (Irq[i] != (ULONG) - 1)


### PR DESCRIPTION
I could not find any "explicit" documentation about this change :-|