### PR TITLE
[WINNLS] Fix of GetCurrencyFormatW to handle "32" grouping format

### DIFF
--- a/dll/win32/kernel32/winnls/string/lcformat.c
+++ b/dll/win32/kernel32/winnls/string/lcformat.c
@@ -1762,7 +1762,7 @@ INT WINAPI GetCurrencyFormatW(LCID lcid, DWORD dwFlags,
       *szOut-- = *lpszDec--; /* Write decimal separator */
   }
 
-  dwGroupCount = lpFormat->Grouping;
+  dwGroupCount = lpFormat->Grouping == 32 ? 3 : lpFormat->Grouping;
 
   /* Write the remaining whole number digits, including grouping chars */
   while (szSrc >= lpszValue && *szSrc >= '0' && *szSrc <= '9')
@@ -1791,6 +1791,8 @@ INT WINAPI GetCurrencyFormatW(LCID lcid, DWORD dwFlags,
         *szOut-- = *lpszGrp--; /* Write grouping char */
 
       dwCurrentGroupCount = 0;
+      if (lpFormat->Grouping == 32)
+        dwGroupCount = 2; /* Indic grouping: 3 then 2 */
     }
   }
   if (dwState & NF_ROUND)


### PR DESCRIPTION
## Purpose

- Current implementation of GetCurrencyFormatW only supports "single digit" grouping format ("0", "3", ...) while ReactOs use it with "double digits" in Regional Settings ("32" in order to propose format la 12 34 567)
- Problem is located in GetCurrencyFormatW implementation where lpFormat->Grouping is only considered as a "constant" numeric grouping value (2, 3, ...) but does not support "multidigits" like 32 in order to respect lpDecimalSep definition in MSDN ( https://docs.microsoft.com/fr-fr/windows/win32/api/winnls/ns-winnls-currencyfmta ) and use case of currency grouping with parameter set to 32. This should be implemented in a similar way to GetNumberFormatW which supports format "32" in a specific way

JIRA issue: [CORE-17009](https://jira.reactos.org/browse/CORE-17009)

![image](https://user-images.githubusercontent.com/24843587/80868483-35e15200-8c9b-11ea-921b-d9a56155677e.png)

## Proposed changes

- Provide a specific support for "32" format in a similar way at the way it is already implemented in GetNumberFormatW, as per MSDN specification (since "32" is the only "complex" format used) 

![image](https://user-images.githubusercontent.com/24843587/80868476-26620900-8c9b-11ea-843f-916da91f1eac.png)
