### PR TITLE
[NTDLL] Improve EtwRegisterTraceGuidsW() stub and related, based on Wine

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -71,7 +71,7 @@
 @ stdcall -stub EtwTraceEventInstance(double ptr ptr ptr)
 @ varargs EtwTraceMessage(ptr long ptr long)
 @ stdcall -stub EtwTraceMessageVa(double long ptr long ptr)
-@ stdcall EtwUnregisterTraceGuids(double)
+@ stdcall EtwUnregisterTraceGuids(int64)
 @ stdcall EtwUpdateTraceA(double str ptr)
 @ stdcall EtwUpdateTraceW(double wstr ptr)
 @ stdcall -stub EtwpGetTraceBuffer(long long long long)

--- a/dll/ntdll/etw/trace.c
+++ b/dll/ntdll/etw/trace.c
@@ -15,14 +15,14 @@
 ULONG
 NTAPI
 EtwRegisterTraceGuidsW(
-    WMIDPREQUEST RequestAddress,
-    PVOID RequestContext,
-    LPCGUID ControlGuid,
-    ULONG GuidCount,
-    PTRACE_GUID_REGISTRATION TraceGuidReg,
-    LPCWSTR MofImagePath,
-    LPCWSTR MofResourceName,
-    PTRACEHANDLE RegistrationHandle
+    _In_ WMIDPREQUEST RequestAddress,
+    _In_opt_ PVOID RequestContext,
+    _In_ LPCGUID ControlGuid,
+    _In_ ULONG GuidCount,
+    _In_reads_opt_(GuidCount) PTRACE_GUID_REGISTRATION TraceGuidReg,
+    _In_opt_ LPCWSTR MofImagePath,
+    _In_opt_ LPCWSTR MofResourceName,
+    _Out_ PTRACEHANDLE RegistrationHandle
 );
 
 /*
@@ -151,20 +151,64 @@ EtwRegisterTraceGuidsA(
                                   RegistrationHandle);
 }
 
+/******************************************************************************
+ * EtwRegisterTraceGuidsW (NTDLL.@)
+ *
+ * Register an event trace provider and the event trace classes that it uses
+ * to generate events.
+ *
+ * PARAMS
+ *  RequestAddress     [I]   ControlCallback function
+ *  RequestContext     [I]   Optional provider-defined context
+ *  ControlGuid        [I]   GUID of the registering provider
+ *  GuidCount          [I]   Number of elements in the TraceGuidReg array
+ *  TraceGuidReg       [I/O] Array of TRACE_GUID_REGISTRATION structures
+ *  MofImagePath       [I]   not supported, set to NULL
+ *  MofResourceName    [I]   not supported, set to NULL
+ *  RegistrationHandle [O]   Provider's registration handle
+ *
+ * RETURNS
+ *  Success: ERROR_SUCCESS
+ *  Failure: System error code
+ */
 ULONG
 NTAPI
 EtwRegisterTraceGuidsW(
-    WMIDPREQUEST RequestAddress,
-    PVOID RequestContext,
-    LPCGUID ControlGuid,
-    ULONG GuidCount,
-    PTRACE_GUID_REGISTRATION TraceGuidReg,
-    LPCWSTR MofImagePath,
-    LPCWSTR MofResourceName,
-    PTRACEHANDLE RegistrationHandle
+    _In_ WMIDPREQUEST RequestAddress,
+    _In_opt_ PVOID RequestContext,
+    _In_ LPCGUID ControlGuid,
+    _In_ ULONG GuidCount,
+    _In_reads_opt_(GuidCount) PTRACE_GUID_REGISTRATION TraceGuidReg,
+    _In_opt_ LPCWSTR MofImagePath,
+    _In_opt_ LPCWSTR MofResourceName,
+    _Out_ PTRACEHANDLE RegistrationHandle
 )
 {
-    FIXME("EtwRegisterTraceGuidsW stub()\n");
+    if (!RequestContext || !ControlGuid || !RegistrationHandle)
+        return ERROR_INVALID_PARAMETER;
+
+#if 0
+    // TODO: Should be NULL on XPsp2+... Test if error or simply ignored.
+    if (MofImagePath || MofResourceName)
+        return ERROR_INVALID_PARAMETER;
+#endif
+
+    FIXME("EtwRegisterTraceGuidsW(%p, %p, %p, %lu, %p, %p, %p, %p) stub\n",
+          RequestAddress, RequestContext, ControlGuid, GuidCount, TraceGuidReg,
+          MofImagePath, MofResourceName, RegistrationHandle);
+
+    if (TraceGuidReg)
+    {
+        ULONG i;
+        for (i = 0; i < GuidCount; i++)
+        {
+            FIXME("  register trace class %p\n", TraceGuidReg[i].Guid);
+            TraceGuidReg[i].RegHandle = UlongToPtr(0xdeadbeef);
+        }
+    }
+
+    *RegistrationHandle = (TRACEHANDLE)0xdeadbeef;
+
     return ERROR_SUCCESS;
 }
 

--- a/dll/ntdll/etw/trace.c
+++ b/dll/ntdll/etw/trace.c
@@ -82,13 +82,20 @@ EtwGetTraceEnableLevel(
     return 0xFF;
 }
 
+/******************************************************************************
+ * EtwUnregisterTraceGuids (NTDLL.@)
+ */
 ULONG
 NTAPI
 EtwUnregisterTraceGuids(
-    TRACEHANDLE RegistrationHandle
+    _In_ TRACEHANDLE RegistrationHandle
 )
 {
-    FIXME("EtwUnregisterTraceGuids stub()\n");
+    if (!RegistrationHandle)
+        return ERROR_INVALID_PARAMETER;
+
+    FIXME("EtwUnregisterTraceGuids(%I64x) stub\n", RegistrationHandle);
+
     return ERROR_SUCCESS;
 }
 

--- a/dll/ntdll/etw/trace.c
+++ b/dll/ntdll/etw/trace.c
@@ -12,6 +12,19 @@
 
 #define FIXME DPRINT1
 
+ULONG
+NTAPI
+EtwRegisterTraceGuidsW(
+    WMIDPREQUEST RequestAddress,
+    PVOID RequestContext,
+    LPCGUID ControlGuid,
+    ULONG GuidCount,
+    PTRACE_GUID_REGISTRATION TraceGuidReg,
+    LPCWSTR MofImagePath,
+    LPCWSTR MofResourceName,
+    PTRACEHANDLE RegistrationHandle
+);
+
 /*
  * @unimplemented
  */
@@ -99,21 +112,43 @@ EtwUnregisterTraceGuids(
     return ERROR_SUCCESS;
 }
 
+/******************************************************************************
+ * EtwRegisterTraceGuidsA (NTDLL.@)
+ */
 ULONG
 NTAPI
 EtwRegisterTraceGuidsA(
-    WMIDPREQUEST RequestAddress,
-    PVOID RequestContext,
-    LPCGUID ControlGuid,
-    ULONG GuidCount,
-    PTRACE_GUID_REGISTRATION TraceGuidReg,
-    LPCSTR MofImagePath,
-    LPCSTR MofResourceName,
-    PTRACEHANDLE RegistrationHandle
+    _In_ WMIDPREQUEST RequestAddress,
+    _In_opt_ PVOID RequestContext,
+    _In_ LPCGUID ControlGuid,
+    _In_ ULONG GuidCount,
+    _In_reads_opt_(GuidCount) PTRACE_GUID_REGISTRATION TraceGuidReg,
+    _In_opt_ LPCSTR MofImagePath,
+    _In_opt_ LPCSTR MofResourceName,
+    _Out_ PTRACEHANDLE RegistrationHandle
 )
 {
-    FIXME("EtwRegisterTraceGuidsA stub()\n");
-    return ERROR_SUCCESS;
+    if (!RequestContext || !ControlGuid || !RegistrationHandle)
+        return ERROR_INVALID_PARAMETER;
+
+#if 0
+    // TODO: Should be NULL on XPsp2+... Test if error or simply ignored.
+    if (MofImagePath || MofResourceName)
+        return ERROR_INVALID_PARAMETER;
+#endif
+
+    FIXME("EtwRegisterTraceGuidsA(%p, %p, %p, %lu, %p, %p, %p, %p) stub\n",
+          RequestAddress, RequestContext, ControlGuid, GuidCount, TraceGuidReg,
+          MofImagePath, MofResourceName, RegistrationHandle);
+
+    return EtwRegisterTraceGuidsW(RequestAddress,
+                                  RequestContext,
+                                  ControlGuid,
+                                  GuidCount,
+                                  TraceGuidReg,
+                                  NULL,
+                                  NULL,
+                                  RegistrationHandle);
 }
 
 ULONG

--- a/dll/win32/advapi32/advapi32.spec
+++ b/dll/win32/advapi32/advapi32.spec
@@ -640,7 +640,7 @@
 640 stub UninstallApplication
 641 stdcall UnlockServiceDatabase(ptr)
 642 stub UnregisterIdleTask
-643 stdcall UnregisterTraceGuids(double) ntdll.EtwUnregisterTraceGuids
+643 stdcall UnregisterTraceGuids() ntdll.EtwUnregisterTraceGuids
 644 stdcall UpdateTraceA(double str ptr) ntdll.EtwUpdateTraceA
 645 stdcall UpdateTraceW(double wstr ptr) ntdll.EtwUpdateTraceW
 646 stub WdmWmiServiceMain

--- a/dll/win32/advapi32/advapi32.spec
+++ b/dll/win32/advapi32/advapi32.spec
@@ -527,7 +527,7 @@
 527 stdcall RegisterServiceCtrlHandlerExW(wstr ptr ptr)
 528 stdcall RegisterServiceCtrlHandlerW(wstr ptr)
 529 stdcall RegisterTraceGuidsA() ntdll.EtwRegisterTraceGuidsA
-530 stdcall RegisterTraceGuidsW(ptr ptr ptr long ptr wstr wstr ptr) ntdll.EtwRegisterTraceGuidsW
+530 stdcall RegisterTraceGuidsW() ntdll.EtwRegisterTraceGuidsW
 531 stub RemoveTraceCallback
 532 stdcall RemoveUsersFromEncryptedFile(wstr ptr)
 533 stdcall ReportEventA(long long long long ptr long long str ptr)

--- a/dll/win32/advapi32/advapi32.spec
+++ b/dll/win32/advapi32/advapi32.spec
@@ -526,7 +526,7 @@
 526 stdcall RegisterServiceCtrlHandlerExA(str ptr ptr)
 527 stdcall RegisterServiceCtrlHandlerExW(wstr ptr ptr)
 528 stdcall RegisterServiceCtrlHandlerW(wstr ptr)
-529 stdcall RegisterTraceGuidsA(ptr ptr ptr long ptr str str ptr) ntdll.EtwRegisterTraceGuidsA
+529 stdcall RegisterTraceGuidsA() ntdll.EtwRegisterTraceGuidsA
 530 stdcall RegisterTraceGuidsW(ptr ptr ptr long ptr wstr wstr ptr) ntdll.EtwRegisterTraceGuidsW
 531 stub RemoveTraceCallback
 532 stdcall RemoveUsersFromEncryptedFile(wstr ptr)

--- a/dll/win32/wmi/wmi.spec
+++ b/dll/win32/wmi/wmi.spec
@@ -12,7 +12,7 @@
 @ stdcall QueryAllTracesA(ptr long ptr) advapi32.QueryAllTracesA
 @ stdcall QueryAllTracesW(ptr long ptr) advapi32.QueryAllTracesW
 @ stdcall RegisterTraceGuidsA() advapi32.RegisterTraceGuidsA
-@ stdcall RegisterTraceGuidsW(ptr ptr ptr long ptr wstr wstr ptr) advapi32.RegisterTraceGuidsW
+@ stdcall RegisterTraceGuidsW() advapi32.RegisterTraceGuidsW
 @ stdcall RemoveTraceCallback(ptr) advapi32.RemoveTraceCallback
 @ stdcall SetTraceCallback(ptr ptr) advapi32.SetTraceCallback
 @ stdcall StartTraceA(ptr str ptr) advapi32.StartTraceA

--- a/dll/win32/wmi/wmi.spec
+++ b/dll/win32/wmi/wmi.spec
@@ -11,7 +11,7 @@
 @ stdcall ProcessTrace(ptr long ptr ptr) advapi32.ProcessTrace
 @ stdcall QueryAllTracesA(ptr long ptr) advapi32.QueryAllTracesA
 @ stdcall QueryAllTracesW(ptr long ptr) advapi32.QueryAllTracesW
-@ stdcall RegisterTraceGuidsA(ptr ptr ptr long ptr str str ptr) advapi32.RegisterTraceGuidsA
+@ stdcall RegisterTraceGuidsA() advapi32.RegisterTraceGuidsA
 @ stdcall RegisterTraceGuidsW(ptr ptr ptr long ptr wstr wstr ptr) advapi32.RegisterTraceGuidsW
 @ stdcall RemoveTraceCallback(ptr) advapi32.RemoveTraceCallback
 @ stdcall SetTraceCallback(ptr ptr) advapi32.SetTraceCallback

--- a/dll/win32/wmi/wmi.spec
+++ b/dll/win32/wmi/wmi.spec
@@ -19,7 +19,7 @@
 @ stdcall StartTraceW(ptr wstr ptr) advapi32.StartTraceW
 @ stdcall TraceEvent(int64 ptr) advapi32.TraceEvent
 @ stdcall TraceEventInstance(int64 ptr ptr ptr) advapi32.TraceEventInstance
-@ stdcall UnregisterTraceGuids(int64) advapi32.UnregisterTraceGuids
+@ stdcall UnregisterTraceGuids() advapi32.UnregisterTraceGuids
 @ stdcall WmiCloseBlock() advapi32.WmiCloseBlock
 @ stdcall WmiDevInstToInstanceNameA() advapi32.WmiDevInstToInstanceNameA
 @ stdcall WmiDevInstToInstanceNameW() advapi32.WmiDevInstToInstanceNameW


### PR DESCRIPTION
`(dll/ntdll/etw/trace.c:125) EtwRegisterTraceGuidsW stub()`
is actually called:
see logs on CORE-13878 and CORE-16996, for example.

Then, improve it somewhat:
* Adapt Wine stub code.
* Additions based on MS docs.
