### PR TITLE
[SHELL32] Let the run dialog use the newer style browse dialog

### DIFF
--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -684,7 +684,7 @@ static INT_PTR CALLBACK RunDlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARA
                     ofn.lpstrFile = szFName;
                     ofn.nMaxFile = _countof(szFName) - 1;
                     ofn.lpstrTitle = szCaption;
-                    ofn.Flags = OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+                    ofn.Flags = OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST | OFN_EXPLORER;
                     ofn.lpstrInitialDir = prfdp->lpstrDirectory;
 
                     if (NULL == (hComdlg = LoadLibraryExW(L"comdlg32", NULL, 0)) ||


### PR DESCRIPTION
Apply the OFN_EXPLORER flag to the Run dialog so the dialog uses the newer style browse dialog.

Why? Because it's a whole lot easier and quicker to browse for files with the newer style dialog. :)

![Before](https://user-images.githubusercontent.com/15203817/80931693-1ae90d80-8d81-11ea-8b31-854b1c308406.png)
![after](https://user-images.githubusercontent.com/15203817/80931695-1d4b6780-8d81-11ea-96d0-d81860a4a97e.png)
