### PR TITLE
[COMDLG32] Fix Treeview undue handling of WM_SYSKEYDOWN

### DIFF
--- a/dll/win32/comctl32/treeview.c
+++ b/dll/win32/comctl32/treeview.c
@@ -5825,7 +5825,9 @@ TREEVIEW_WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	return TREEVIEW_HScroll(infoPtr, wParam);
 
     case WM_KEYDOWN:
+#ifndef __REACTOS__
     case WM_SYSKEYDOWN:
+#endif
 	return TREEVIEW_KeyDown(infoPtr, wParam);
 
     case WM_KILLFOCUS:


### PR DESCRIPTION
## Purpose

- Current implementation from Wine comDlg32 Treeview component handles WM_SYSKEYDOWN at its level, therefore preventing management at upper level.
- As consequence, when focus is on a treeview (Regedit, EventViewer,....), ALT-F4 has no effect.
- Other components are not affected as they are not managing WM_SYSKEYDOWN in their "KeyDown" processing

JIRA issue: [CORE-17020](https://jira.reactos.org/browse/CORE-17020)

## Proposed changes

- Remove WM_SYSKEYDOWN handling at component level, in consistency with other components (ListView,...)
- Early embodiement of the fix proposed to WineHQ : https://bugs.winehq.org/show_bug.cgi?id=49097 in order to remove functionnal limitation in ReactOS.