### PR TITLE
[COMDLG32] Add some more places to the places bar

### DIFF
--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -305,9 +305,17 @@ static void filedlg_collect_places_pidls(FileOpenDlgInfos *fodInfos)
 {
     static const int default_places[] =
     {
+#ifdef __REACTOS__
+        CSIDL_RECENT,
         CSIDL_DESKTOP,
         CSIDL_MYDOCUMENTS,
         CSIDL_DRIVES,
+        CSIDL_NETWORK,
+#else        
+        CSIDL_DESKTOP,
+        CSIDL_MYDOCUMENTS,
+        CSIDL_DRIVES,
+#endif
     };
     unsigned int i;
     HKEY hkey;


### PR DESCRIPTION
Add Recent Documents and My Network Places to the places bar in the open file dialog. There is an issue with label wrapping, I've looked at it, appears to be a bug deeper in comctl32 I think.

![comdlg32](https://user-images.githubusercontent.com/15203817/80988157-af428700-8df8-11ea-96fe-db2f1ae18b9e.png)
