### PR TITLE
[REGEDIT] Fix and improvement in TreeView (Null handle check, incorrect display after edit, WM_NOTIFY refactor)

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -261,7 +261,7 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
             if (keyPath[0] != L'\0')
                 swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
             else
-                fullPath = wcscpy(fullPath, rootName);            
+                fullPath = wcscpy(fullPath, rootName);
              
             SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
             SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);
@@ -272,7 +272,7 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
             EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
             /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
             if (_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") != 0 ||
-                _wcsicmp(rootName, L"HKEY_USERS") != 0 )
+                _wcsicmp(rootName, L"HKEY_USERS") != 0)
             {
                 /*
                  * enable the unload menu item if at the root, otherwise

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -228,7 +228,7 @@ LRESULT CALLBACK AddressBarProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     return CallWindowProcW(oldwndproc, hwnd, uMsg, wParam, lParam);
 }
 
-static VOID
+VOID
 UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 {
     LPCWSTR keyPath, rootName;

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -228,7 +228,7 @@ LRESULT CALLBACK AddressBarProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     return CallWindowProcW(oldwndproc, hwnd, uMsg, wParam, lParam);
 }
 
-VOID
+extern VOID
 UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 {
     LPCWSTR keyPath, rootName;

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -430,8 +430,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         else
         {
             if (((LPNMHDR)lParam)->idFrom == LIST_WINDOW)
-            {
-                
+            {               
                 if (!ListWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
                 {
                     goto def;

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -228,6 +228,66 @@ LRESULT CALLBACK AddressBarProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     return CallWindowProcW(oldwndproc, hwnd, uMsg, wParam, lParam);
 }
 
+static VOID
+UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
+{
+    LPCWSTR keyPath, rootName;
+    LPWSTR fullPath;
+    DWORD cbFullPath;
+
+    /* Wipe the listview, the status bar and the address bar if the root key was selected */
+    if (TreeView_GetParent(g_pChildWnd->hTreeWnd, hItem) == NULL)
+    {
+        ListView_DeleteAllItems(g_pChildWnd->hListWnd);
+        SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)NULL);
+        SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)NULL);
+        return;
+    }
+
+    if (pszPath == NULL)
+        keyPath = GetItemPath(g_pChildWnd->hTreeWnd, hItem, &hRootKey);
+    else
+        keyPath = pszPath;
+
+    if (keyPath)
+    {
+        RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath);
+        rootName = get_root_key_name(hRootKey);
+        cbFullPath = (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR);
+        fullPath = HeapAlloc(GetProcessHeap(), 0, cbFullPath);
+        if (fullPath)
+        {
+            /* set (correct) the address bar text */
+            if (keyPath[0] != L'\0')
+                swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
+            else
+                fullPath = wcscpy(fullPath, rootName);            
+             
+            SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
+            SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);
+            HeapFree(GetProcessHeap(), 0, fullPath);
+
+            /* disable hive manipulation items temporarily (enable only if necessary) */
+            EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
+            if (_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") != 0 ||
+                _wcsicmp(rootName, L"HKEY_USERS") != 0 )
+            {
+                /*
+                 * enable the unload menu item if at the root, otherwise
+                 * enable the load menu item if there is no slash in
+                 * keyPath (ie. immediate child selected)
+                 */
+                if (keyPath[0] == UNICODE_NULL)
+                    EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+                else if (!wcschr(keyPath, L'\\'))
+                    EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+            }
+        }
+    }
+}
+
 /*******************************************************************************
  *
  *  FUNCTION: ChildWndProc(HWND, unsigned, WORD, LONG)

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -416,11 +416,11 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         break;
 
     case WM_NOTIFY:
-        if(g_pChildWnd == NULL) break;
+        if (g_pChildWnd == NULL) break;
                 
         if (((LPNMHDR)lParam)->idFrom == TREE_WINDOW)
         {
-            if(!TreeWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
+            if (!TreeWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
             {
                 goto def;
             }
@@ -432,7 +432,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
             if (((LPNMHDR)lParam)->idFrom == LIST_WINDOW)
             {
                 
-                if(!ListWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
+                if (!ListWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
                 {
                     goto def;
                 }
@@ -443,8 +443,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
             {
                 goto def;
             }
-        }
-        
+        }        
         break;
 
     case WM_CONTEXTMENU:

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -430,7 +430,7 @@ LRESULT CALLBACK ChildWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lPa
         else
         {
             if (((LPNMHDR)lParam)->idFrom == LIST_WINDOW)
-            {               
+            {
                 if (!ListWndNotifyProc(g_pChildWnd->hListWnd, wParam, lParam, &Result))
                 {
                     goto def;

--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -228,7 +228,7 @@ LRESULT CALLBACK AddressBarProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
     return CallWindowProcW(oldwndproc, hwnd, uMsg, wParam, lParam);
 }
 
-extern VOID
+VOID
 UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 {
     LPCWSTR keyPath, rootName;

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -563,7 +563,7 @@ BOOL ListWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
     }
     return TRUE;
     case NM_SETFOCUS:
-        g_pChildWnd->nFocusPanel = 0;
+        g_pChildWnd->nFocusPanel = 1;
         break;
     case LVN_BEGINLABELEDIT:
         Info = (NMLVDISPINFO*)lParam;

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -27,7 +27,7 @@
 #define TREE_WINDOW     2002
 #define LIST_WINDOW     2003
 
-#define	SPLIT_WIDTH	5
+#define    SPLIT_WIDTH    5
 #define SPLIT_MIN  30
 
 #define COUNT_OF(a) (sizeof(a)/sizeof(a[0]))
@@ -115,6 +115,7 @@ extern HWND CreateListView(HWND hwndParent, HMENU id, INT cx);
 extern BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath);
 extern LPCWSTR GetValueName(HWND hwndLV, int iStartAt);
 extern BOOL ListWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result);
+extern BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result);
 extern BOOL IsDefaultValue(HWND hwndLV, int i);
 
 /* regedit.c */

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -27,8 +27,8 @@
 #define TREE_WINDOW     2002
 #define LIST_WINDOW     2003
 
-#define    SPLIT_WIDTH    5
-#define SPLIT_MIN  30
+#define SPLIT_WIDTH    5
+#define SPLIT_MIN     30
 
 #define COUNT_OF(a) (sizeof(a)/sizeof(a[0]))
 

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -94,6 +94,7 @@ extern void ShowAboutBox(HWND hWnd);
 extern LRESULT CALLBACK ChildWndProc(HWND, UINT, WPARAM, LPARAM);
 extern void ResizeWnd(int cx, int cy);
 extern LPCWSTR get_root_key_name(HKEY hRootKey);
+extern VOID UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath);
 
 /* error.c */
 extern int ErrorMessageBox(HWND hWnd, LPCWSTR lpTitle, DWORD dwErrorCode, ...);

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -94,7 +94,7 @@ extern void ShowAboutBox(HWND hWnd);
 extern LRESULT CALLBACK ChildWndProc(HWND, UINT, WPARAM, LPARAM);
 extern void ResizeWnd(int cx, int cy);
 extern LPCWSTR get_root_key_name(HKEY hRootKey);
-extern VOID UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath);
+VOID UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath);
 
 /* error.c */
 extern int ErrorMessageBox(HWND hWnd, LPCWSTR lpTitle, DWORD dwErrorCode, ...);

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -625,6 +625,161 @@ done:
     return bSuccess;
 }
 
+static VOID
+UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
+{
+    LPCWSTR keyPath, rootName;
+    LPWSTR fullPath;
+
+    /* Wipe the listview, the status bar and the address bar if the root key was selected */
+    if (TreeView_GetParent(g_pChildWnd->hTreeWnd, hItem) == NULL)
+    {
+        ListView_DeleteAllItems(g_pChildWnd->hListWnd);
+        SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)NULL);
+        SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)NULL);
+        return;
+    }
+
+    if (pszPath == NULL)
+        keyPath = GetItemPath(g_pChildWnd->hTreeWnd, hItem, &hRootKey);
+    else
+        keyPath = pszPath;
+
+    if (keyPath)
+    {
+        RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath);
+        rootName = get_root_key_name(hRootKey);
+        fullPath = HeapAlloc(GetProcessHeap(), 0, (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR));
+        if (fullPath)
+        {
+            /* set (correct) the address bar text */
+            if (keyPath[0] != L'\0')
+               swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
+            else
+                fullPath = wcscpy(fullPath, rootName);
+            SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
+            SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);
+            HeapFree(GetProcessHeap(), 0, fullPath);
+            /* disable hive manipulation items temporarily (enable only if necessary) */
+            EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
+            if (!(_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") &&
+                  _wcsicmp(rootName, L"HKEY_USERS")))
+            {
+                /*
+                 * enable the unload menu item if at the root, otherwise
+                 * enable the load menu item if there is no slash in
+                 * keyPath (ie. immediate child selected)
+                 */
+                if(keyPath[0] == L'\0')
+                    EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+                else if(!wcschr(keyPath, L'\\'))
+                    EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+            }
+        }
+    }
+}
+
+BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
+{    
+    UNREFERENCED_PARAMETER(wParam);
+    *Result = TRUE;
+    
+    switch (((LPNMHDR)lParam)->code)
+            {
+            case TVN_ITEMEXPANDING:
+                *Result = !OnTreeExpanding(g_pChildWnd->hTreeWnd, (NMTREEVIEW*)lParam);
+                return TRUE;
+            case TVN_SELCHANGED:
+            {
+                NMTREEVIEW* pnmtv = (NMTREEVIEW*)lParam;
+                /* Get the parent of the current item */
+                HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
+
+                UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
+
+                /* Disable the Permissions menu item for 'My Computer' */
+                EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | ((hParentItem == NULL) ? MF_GRAYED : MF_ENABLED));
+
+                /*
+                 * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
+                 * and HKEY_* keys (their parent is 'My Computer' and the previous remark applies).
+                 */
+                if (!hParentItem || !TreeView_GetParent(g_pChildWnd->hTreeWnd, hParentItem))
+                {
+                    EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_GRAYED);
+                    EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_GRAYED);
+                    EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_GRAYED);
+                    EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_GRAYED); 
+                }
+                else
+                {
+                    EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_ENABLED);
+                    EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_ENABLED);
+                    EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_ENABLED);
+                    EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_ENABLED);
+                }
+
+                return TRUE;
+            }
+            case NM_SETFOCUS:
+                g_pChildWnd->nFocusPanel = 0;
+                break;
+            case TVN_BEGINLABELEDIT:
+            {
+                LPNMTVDISPINFO ptvdi;
+                /* cancel label edit for rootkeys  */
+                ptvdi = (LPNMTVDISPINFO) lParam;
+                if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
+                    !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
+                    {
+                        *Result = TRUE;
+                    }
+                    else
+                    {
+                        *Result = FALSE;
+                    }
+                return TRUE;
+            }
+            case TVN_ENDLABELEDIT:
+            {
+                LPCWSTR keyPath;
+                HKEY hRootKey;
+                HKEY hKey = NULL;
+                LPNMTVDISPINFO ptvdi;
+                LONG lResult = TRUE;
+                WCHAR szBuffer[MAX_PATH];
+
+                ptvdi = (LPNMTVDISPINFO) lParam;
+                if (ptvdi->item.pszText)
+                {
+                    keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
+                    if(wcslen(keyPath))
+                        _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s\\%s", keyPath, ptvdi->item.pszText);
+                    else
+                        _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s", ptvdi->item.pszText);
+                    keyPath = GetItemPath(g_pChildWnd->hTreeWnd, ptvdi->item.hItem, &hRootKey);
+                    if (RegOpenKeyExW(hRootKey, szBuffer, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+                    {
+                        lResult = FALSE;
+                        RegCloseKey(hKey);
+                        TreeView_EditLabel(g_pChildWnd->hTreeWnd, ptvdi->item.hItem);
+                    }
+                    else
+                    {
+                        if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
+                            lResult = FALSE;
+                        else
+                            UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
+                    }
+                    *Result = lResult;
+                }
+                return TRUE;
+            }           
+    }
+    return FALSE;
+}
 
 /*
  * CreateTreeView - creates a tree view control.
@@ -642,6 +797,8 @@ HWND CreateTreeView(HWND hwndParent, LPWSTR pHostName, HMENU id)
                             WS_VISIBLE | WS_CHILD | WS_TABSTOP | TVS_HASLINES | TVS_HASBUTTONS | TVS_LINESATROOT | TVS_EDITLABELS | TVS_SHOWSELALWAYS,
                             0, 0, rcClient.right, rcClient.bottom,
                             hwndParent, id, hInst, NULL);
+    if (!hwndTV) return NULL;
+    
     /* Initialize the image list, and add items to the control.  */
     if (!InitTreeViewImageLists(hwndTV) || !InitTreeViewItems(hwndTV, pHostName))
     {

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -625,66 +625,6 @@ done:
     return bSuccess;
 }
 
-static VOID
-UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
-{
-    LPCWSTR keyPath, rootName;
-    LPWSTR fullPath;
-    DWORD cbFullPath;
-
-    /* Wipe the listview, the status bar and the address bar if the root key was selected */
-    if (TreeView_GetParent(g_pChildWnd->hTreeWnd, hItem) == NULL)
-    {
-        ListView_DeleteAllItems(g_pChildWnd->hListWnd);
-        SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)NULL);
-        SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)NULL);
-        return;
-    }
-
-    if (pszPath == NULL)
-        keyPath = GetItemPath(g_pChildWnd->hTreeWnd, hItem, &hRootKey);
-    else
-        keyPath = pszPath;
-
-    if (keyPath)
-    {
-        RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath);
-        rootName = get_root_key_name(hRootKey);
-        cbFullPath = (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR);
-        fullPath = HeapAlloc(GetProcessHeap(), 0, cbFullPath);
-        if (fullPath)
-        {
-            /* set (correct) the address bar text */
-            if (keyPath[0] != L'\0')
-                swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
-            else
-                fullPath = wcscpy(fullPath, rootName);            
-             
-            SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
-            SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);
-            HeapFree(GetProcessHeap(), 0, fullPath);
-
-            /* disable hive manipulation items temporarily (enable only if necessary) */
-            EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
-            EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
-            /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
-            if (_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") != 0 ||
-                _wcsicmp(rootName, L"HKEY_USERS") != 0 )
-            {
-                /*
-                 * enable the unload menu item if at the root, otherwise
-                 * enable the load menu item if there is no slash in
-                 * keyPath (ie. immediate child selected)
-                 */
-                if (keyPath[0] == UNICODE_NULL)
-                    EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_ENABLED);
-                else if (!wcschr(keyPath, L'\\'))
-                    EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_ENABLED);
-            }
-        }
-    }
-}
-
 BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
 {    
     UNREFERENCED_PARAMETER(wParam);

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -630,6 +630,7 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 {
     LPCWSTR keyPath, rootName;
     LPWSTR fullPath;
+    DWORD cbFullPath;
 
     /* Wipe the listview, the status bar and the address bar if the root key was selected */
     if (TreeView_GetParent(g_pChildWnd->hTreeWnd, hItem) == NULL)
@@ -649,20 +650,23 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
     {
         RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath);
         rootName = get_root_key_name(hRootKey);
-        fullPath = HeapAlloc(GetProcessHeap(), 0, (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR));
+        cbFullPath = (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR);
+        fullPath = HeapAlloc(GetProcessHeap(), 0, cbFullPath);
         if (fullPath)
         {
             /* set (correct) the address bar text */
             if (keyPath[0] != L'\0')
-               swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
+                swprintf(fullPath, L"%s%s%s", rootName, keyPath[0]==L'\\'?L"":L"\\", keyPath);
             else
-                fullPath = wcscpy(fullPath, rootName);
+                fullPath = wcscpy(fullPath, rootName);            
+             
             SendMessageW(hStatusBar, SB_SETTEXTW, 0, (LPARAM)fullPath);
             SendMessageW(g_pChildWnd->hAddressBarWnd, WM_SETTEXT, 0, (LPARAM)fullPath);
             HeapFree(GetProcessHeap(), 0, fullPath);
+
             /* disable hive manipulation items temporarily (enable only if necessary) */
-            EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
-            EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_GRAYED);
             /* compare the strings to see if we should enable/disable the "Load Hive" menus accordingly */
             if (!(_wcsicmp(rootName, L"HKEY_LOCAL_MACHINE") &&
                   _wcsicmp(rootName, L"HKEY_USERS")))
@@ -672,10 +676,10 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
                  * enable the load menu item if there is no slash in
                  * keyPath (ie. immediate child selected)
                  */
-                if(keyPath[0] == L'\0')
-                    EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_ENABLED);
-                else if(!wcschr(keyPath, L'\\'))
-                    EnableMenuItem(GetSubMenu(hMenuFrame,0), ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+                if (keyPath[0] == UNICODE_NULL)
+                    EnableMenuItem(hMenuFrame, ID_REGISTRY_LOADHIVE, MF_BYCOMMAND | MF_ENABLED);
+                else if (!wcschr(keyPath, L'\\'))
+                    EnableMenuItem(hMenuFrame, ID_REGISTRY_UNLOADHIVE, MF_BYCOMMAND | MF_ENABLED);
             }
         }
     }
@@ -687,96 +691,96 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
     *Result = TRUE;
     
     switch (((LPNMHDR)lParam)->code)
+    {
+    case TVN_ITEMEXPANDING:
+        *Result = !OnTreeExpanding(g_pChildWnd->hTreeWnd, (NMTREEVIEW*)lParam);
+        return TRUE;
+    case TVN_SELCHANGED:    
+        {
+        NMTREEVIEW* pnmtv = (NMTREEVIEW*)lParam;
+        /* Get the parent of the current item */
+        HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
+
+        UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
+
+        /* Disable the Permissions menu item for 'My Computer' */
+        EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | ((hParentItem == NULL) ? MF_GRAYED : MF_ENABLED));
+
+        /*
+         * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
+         * and HKEY_* keys (their parent is 'My Computer' and the previous remark applies).
+         */
+        if (!hParentItem || !TreeView_GetParent(g_pChildWnd->hTreeWnd, hParentItem))
+        {
+            EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_GRAYED);
+            EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_GRAYED); 
+        }
+        else
+        {
+            EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_ENABLED);
+            EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_ENABLED);
+            EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_ENABLED);
+            EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_ENABLED);
+        }
+
+        return TRUE;
+        }
+    case NM_SETFOCUS:
+        g_pChildWnd->nFocusPanel = 0;
+        break;
+    case TVN_BEGINLABELEDIT:
+    {
+        LPNMTVDISPINFO ptvdi;
+        /* cancel label edit for rootkeys  */
+        ptvdi = (LPNMTVDISPINFO) lParam;
+        if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
+            !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
+        {
+            *Result = TRUE;
+        }
+        else
+        {
+            *Result = FALSE;
+        }
+        return TRUE;
+    }
+    case TVN_ENDLABELEDIT:
+        {    
+        LPCWSTR keyPath;
+        HKEY hRootKey;
+        HKEY hKey = NULL;
+        LPNMTVDISPINFO ptvdi;
+        LONG lResult = TRUE;
+        WCHAR szBuffer[MAX_PATH];
+
+        ptvdi = (LPNMTVDISPINFO) lParam;
+        if (ptvdi->item.pszText)
+        {
+            keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
+            if(wcslen(keyPath))
+                _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s\\%s", keyPath, ptvdi->item.pszText);
+            else
+                _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s", ptvdi->item.pszText);
+            keyPath = GetItemPath(g_pChildWnd->hTreeWnd, ptvdi->item.hItem, &hRootKey);
+            if (RegOpenKeyExW(hRootKey, szBuffer, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
             {
-            case TVN_ITEMEXPANDING:
-                *Result = !OnTreeExpanding(g_pChildWnd->hTreeWnd, (NMTREEVIEW*)lParam);
-                return TRUE;
-            case TVN_SELCHANGED:
+                lResult = FALSE;
+                RegCloseKey(hKey);
+                TreeView_EditLabel(g_pChildWnd->hTreeWnd, ptvdi->item.hItem);
+            }
+            else
             {
-                NMTREEVIEW* pnmtv = (NMTREEVIEW*)lParam;
-                /* Get the parent of the current item */
-                HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
-
-                UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
-
-                /* Disable the Permissions menu item for 'My Computer' */
-                EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | ((hParentItem == NULL) ? MF_GRAYED : MF_ENABLED));
-
-                /*
-                 * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
-                 * and HKEY_* keys (their parent is 'My Computer' and the previous remark applies).
-                 */
-                if (!hParentItem || !TreeView_GetParent(g_pChildWnd->hTreeWnd, hParentItem))
-                {
-                    EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_GRAYED);
-                    EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_GRAYED);
-                    EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_GRAYED);
-                    EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_GRAYED); 
-                }
+                if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
+                    lResult = FALSE;
                 else
-                {
-                    EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_ENABLED);
-                    EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_ENABLED);
-                    EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_ENABLED);
-                    EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_ENABLED);
-                }
-
-                return TRUE;
+                    UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
             }
-            case NM_SETFOCUS:
-                g_pChildWnd->nFocusPanel = 0;
-                break;
-            case TVN_BEGINLABELEDIT:
-            {
-                LPNMTVDISPINFO ptvdi;
-                /* cancel label edit for rootkeys  */
-                ptvdi = (LPNMTVDISPINFO) lParam;
-                if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
-                    !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
-                    {
-                        *Result = TRUE;
-                    }
-                    else
-                    {
-                        *Result = FALSE;
-                    }
-                return TRUE;
-            }
-            case TVN_ENDLABELEDIT:
-            {
-                LPCWSTR keyPath;
-                HKEY hRootKey;
-                HKEY hKey = NULL;
-                LPNMTVDISPINFO ptvdi;
-                LONG lResult = TRUE;
-                WCHAR szBuffer[MAX_PATH];
-
-                ptvdi = (LPNMTVDISPINFO) lParam;
-                if (ptvdi->item.pszText)
-                {
-                    keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
-                    if(wcslen(keyPath))
-                        _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s\\%s", keyPath, ptvdi->item.pszText);
-                    else
-                        _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s", ptvdi->item.pszText);
-                    keyPath = GetItemPath(g_pChildWnd->hTreeWnd, ptvdi->item.hItem, &hRootKey);
-                    if (RegOpenKeyExW(hRootKey, szBuffer, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-                    {
-                        lResult = FALSE;
-                        RegCloseKey(hKey);
-                        TreeView_EditLabel(g_pChildWnd->hTreeWnd, ptvdi->item.hItem);
-                    }
-                    else
-                    {
-                        if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
-                            lResult = FALSE;
-                        else
-                            UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
-                    }
-                    *Result = lResult;
-                }
-                return TRUE;
-            }           
+            *Result = lResult;
+        }
+        return TRUE;
+        }
     }
     return FALSE;
 }

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -644,7 +644,7 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
             UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
 
             /* Disable the Permissions menu item for 'My Computer' */
-            EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | (hParentItem ? MF_ENABLED : MF_GRAYED));
+            EnableMenuItem(hMenuFrame, ID_EDIT_PERMISSIONS, MF_BYCOMMAND | (hParentItem ? MF_ENABLED : MF_GRAYED));
 
             /*
              * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
@@ -672,9 +672,8 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
             break;
         case TVN_BEGINLABELEDIT:
         {
-            LPNMTVDISPINFO ptvdi;
-            /* cancel label edit for rootkeys  */
-            ptvdi = (LPNMTVDISPINFO) lParam;
+            LPNMTVDISPINFO ptvdi = (LPNMTVDISPINFO) lParam;
+            /* cancel label edit for rootkeys */
             if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
                 !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
             {
@@ -691,11 +690,12 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
             LPCWSTR keyPath;
             HKEY hRootKey;
             HKEY hKey = NULL;
-            LPNMTVDISPINFO ptvdi;
+            LPNMTVDISPINFO ptvdi = (LPNMTVDISPINFO) lParam;
+            LONG nRenResult;
             LONG lResult = TRUE;
             WCHAR szBuffer[MAX_PATH];
+            WCHAR Caption[128];
 
-            ptvdi = (LPNMTVDISPINFO) lParam;
             if (ptvdi->item.pszText)
             {
                 keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
@@ -712,8 +712,13 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
                 }
                 else
                 {
-                    if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
+                    nRenResult = RenameKey(hRootKey, keyPath, ptvdi->item.pszText);
+                    if (nRenResult != ERROR_SUCCESS)
+                    {
+                        LoadStringW(hInst, IDS_ERROR, Caption, COUNT_OF(Caption));
+                        ErrorMessageBox(hWnd, Caption, nRenResult);
                         lResult = FALSE;
+                    }
                     else
                         UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
                 }

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -692,95 +692,95 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
     
     switch (((LPNMHDR)lParam)->code)
     {
-		case TVN_ITEMEXPANDING:
-			*Result = !OnTreeExpanding(g_pChildWnd->hTreeWnd, (NMTREEVIEW*)lParam);
-			return TRUE;
-		case TVN_SELCHANGED:    
-		{
-			NMTREEVIEW* pnmtv = (NMTREEVIEW*)lParam;
-			/* Get the parent of the current item */
-			HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
+        case TVN_ITEMEXPANDING:
+            *Result = !OnTreeExpanding(g_pChildWnd->hTreeWnd, (NMTREEVIEW*)lParam);
+            return TRUE;
+        case TVN_SELCHANGED:    
+        {
+            NMTREEVIEW* pnmtv = (NMTREEVIEW*)lParam;
+            /* Get the parent of the current item */
+            HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
 
-			UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
+            UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
 
-			/* Disable the Permissions menu item for 'My Computer' */
-			EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | (hParentItem ? MF_ENABLED : MF_GRAYED));
+            /* Disable the Permissions menu item for 'My Computer' */
+            EnableMenuItem(hMenuFrame , ID_EDIT_PERMISSIONS, MF_BYCOMMAND | (hParentItem ? MF_ENABLED : MF_GRAYED));
 
-			/*
-			 * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
-			 * and HKEY_* keys (their parent is 'My Computer' and the previous remark applies).
-			 */
-			if (!hParentItem || !TreeView_GetParent(g_pChildWnd->hTreeWnd, hParentItem))
-			{
-				EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_GRAYED);
-				EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_GRAYED);
-				EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_GRAYED);
-				EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_GRAYED); 
-			}
-			else
-			{
-				EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_ENABLED);
-				EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_ENABLED);
-				EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_ENABLED);
-				EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_ENABLED);
-			}
+            /*
+             * Disable Delete/Rename menu options for 'My Computer' (first item so doesn't have any parent)
+             * and HKEY_* keys (their parent is 'My Computer' and the previous remark applies).
+             */
+            if (!hParentItem || !TreeView_GetParent(g_pChildWnd->hTreeWnd, hParentItem))
+            {
+                EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_GRAYED);
+                EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_GRAYED);
+                EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_GRAYED);
+                EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_GRAYED); 
+            }
+            else
+            {
+                EnableMenuItem(hMenuFrame , ID_EDIT_DELETE, MF_BYCOMMAND | MF_ENABLED);
+                EnableMenuItem(hMenuFrame , ID_EDIT_RENAME, MF_BYCOMMAND | MF_ENABLED);
+                EnableMenuItem(hPopupMenus, ID_TREE_DELETE, MF_BYCOMMAND | MF_ENABLED);
+                EnableMenuItem(hPopupMenus, ID_TREE_RENAME, MF_BYCOMMAND | MF_ENABLED);
+            }
 
-			return TRUE;
-		}
-		case NM_SETFOCUS:
-			g_pChildWnd->nFocusPanel = 0;
-			break;
-		case TVN_BEGINLABELEDIT:
-		{
-			LPNMTVDISPINFO ptvdi;
-			/* cancel label edit for rootkeys  */
-			ptvdi = (LPNMTVDISPINFO) lParam;
-			if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
-				!TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
-			{
-				*Result = TRUE;
-			}
-			else
-			{
-				*Result = FALSE;
-			}
-			return TRUE;
-		}
-		case TVN_ENDLABELEDIT:
-		{    
-			LPCWSTR keyPath;
-			HKEY hRootKey;
-			HKEY hKey = NULL;
-			LPNMTVDISPINFO ptvdi;
-			LONG lResult = TRUE;
-			WCHAR szBuffer[MAX_PATH];
+            return TRUE;
+        }
+        case NM_SETFOCUS:
+            g_pChildWnd->nFocusPanel = 0;
+            break;
+        case TVN_BEGINLABELEDIT:
+        {
+            LPNMTVDISPINFO ptvdi;
+            /* cancel label edit for rootkeys  */
+            ptvdi = (LPNMTVDISPINFO) lParam;
+            if (!TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem) ||
+                !TreeView_GetParent(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem)))
+            {
+                *Result = TRUE;
+            }
+            else
+            {
+                *Result = FALSE;
+            }
+            return TRUE;
+        }
+        case TVN_ENDLABELEDIT:
+        {    
+            LPCWSTR keyPath;
+            HKEY hRootKey;
+            HKEY hKey = NULL;
+            LPNMTVDISPINFO ptvdi;
+            LONG lResult = TRUE;
+            WCHAR szBuffer[MAX_PATH];
 
-			ptvdi = (LPNMTVDISPINFO) lParam;
-			if (ptvdi->item.pszText)
-			{
-				keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
-				if (wcslen(keyPath))
-					_snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s\\%s", keyPath, ptvdi->item.pszText);
-				else
-					_snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s", ptvdi->item.pszText);
-				keyPath = GetItemPath(g_pChildWnd->hTreeWnd, ptvdi->item.hItem, &hRootKey);
-				if (RegOpenKeyExW(hRootKey, szBuffer, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
-				{
-					lResult = FALSE;
-					RegCloseKey(hKey);
-					TreeView_EditLabel(g_pChildWnd->hTreeWnd, ptvdi->item.hItem);
-				}
-				else
-				{
-					if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
-						lResult = FALSE;
-					else
-						UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
-				}
-				*Result = lResult;
-			}
-			return TRUE;
-		}
+            ptvdi = (LPNMTVDISPINFO) lParam;
+            if (ptvdi->item.pszText)
+            {
+                keyPath = GetItemPath(g_pChildWnd->hTreeWnd, TreeView_GetParent(g_pChildWnd->hTreeWnd, ptvdi->item.hItem), &hRootKey);
+                if (wcslen(keyPath))
+                    _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s\\%s", keyPath, ptvdi->item.pszText);
+                else
+                    _snwprintf(szBuffer, COUNT_OF(szBuffer), L"%s", ptvdi->item.pszText);
+                keyPath = GetItemPath(g_pChildWnd->hTreeWnd, ptvdi->item.hItem, &hRootKey);
+                if (RegOpenKeyExW(hRootKey, szBuffer, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
+                {
+                    lResult = FALSE;
+                    RegCloseKey(hKey);
+                    TreeView_EditLabel(g_pChildWnd->hTreeWnd, ptvdi->item.hItem);
+                }
+                else
+                {
+                    if (RenameKey(hRootKey, keyPath, ptvdi->item.pszText) != ERROR_SUCCESS)
+                        lResult = FALSE;
+                    else
+                        UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
+                }
+                *Result = lResult;
+            }
+            return TRUE;
+        }
     }
     return FALSE;
 }


### PR DESCRIPTION
## Purpose

Several fix and improvement identified during investigation for CORE-17020
- Current implementation misses a NULL Handle check in the Treeview creation
- When Editing a key name in treeview, incorrect Address bar and Status indicatation (double trailing slash) - see screenshot 
- Code could be better structured for maintainability by organizing the TreeView management of WM_NOTIFY in a similar way to what has been put in place for ListView (all NOTIFY code resp in listview.c or treeview.c). This will simplify lisibility and maintainability of the code.
- [CORE-17048](https://jira.reactos.org/browse/CORE-17048) shows a lack of error reporting to users when key edit in treeview fails

![image](https://user-images.githubusercontent.com/24843587/81037432-06049b00-8ea3-11ea-8b75-c766320ae853.png)

## Proposed changes

- Addition of NULL handle check
- Do not append a slash if already present in to-be key name
- Refactoring of the WM_NOTIFY code for Treeview and code grouping in treeview.c
- Error message box with formatted message in case of key rename failure.

![image](https://user-images.githubusercontent.com/24843587/81037479-2df3fe80-8ea3-11ea-849d-cf43f4f92e80.png)