### PR TITLE
[ADVAPI32] Fix undue debug print in nominal case

### DIFF
--- a/dll/win32/advapi32/reg/hkcr.c
+++ b/dll/win32/advapi32/reg/hkcr.c
@@ -961,7 +961,8 @@ EnumHKCRValue(
         if (ErrorCode != ERROR_SUCCESS)
         {
             /* Most likely ERROR_NO_MORE_ITEMS */
-            ERR("Returning %d.\n", ErrorCode);
+            if (ErrorCode != ERROR_NO_MORE_ITEMS)
+                ERR("Returning %d.\n", ErrorCode);
             goto Exit;
         }
         FallbackValueName[FallbackValueNameLen] = L'\0';


### PR DESCRIPTION
## Purpose

- In current implementation, when Regedit opens HKCR root key, an error is logged
err:(dll/win32/advapi32/reg/hkcr.c:964) Returning 259.
This is not correct as code 259 is for ERROR_NO_MORE_ITEMS which is the nominal return value when end of enumeration is reached.

## Proposed changes

Err is not displayed when ERROR_NO_MORE_ITEMS is returned.