### PR TITLE
[REGEDIT] Fix HeapFree() on the wrong variable causing memory leak and "HEAP: Trying to free an invalid address"

### DIFF
--- a/base/applications/regedit/regproc.c
+++ b/base/applications/regedit/regproc.c
@@ -1392,7 +1392,7 @@ BOOL export_registry_key(WCHAR *file_name, WCHAR *reg_key_name, DWORD format)
     if (file) {
         fclose(file);
     }
-    HeapFree(GetProcessHeap(), 0, reg_key_name);
+    HeapFree(GetProcessHeap(), 0, reg_key_name_buf);
     HeapFree(GetProcessHeap(), 0, val_name_buf);
     HeapFree(GetProcessHeap(), 0, val_buf);
     HeapFree(GetProcessHeap(), 0, line_buf);


### PR DESCRIPTION
## Purpose

- When exporting registry keys (to.reg files) some variables from the heap are not free'd while log indicates "HEAP: Trying to free an invalid address"
- This is due to the export_registry_key() function which includes call to 
HeapFree(GetProcessHeap(), 0, reg_key_name);
while reg_key_name. is an argument provided by the caller, which is always a statically defined array of WCHAR.
Menwhile reg_key_name_buf is never free'd and cause a memory leak each time the function gets called.

## Proposed changes

- Replace reg_key_name by reg_key_name_buf in the HeapFree instruction.