### PR TITLE
[NTDLL_APITEST] Expand the NtSetInformationProcess testcase with some tests

### DIFF
--- a/modules/rostests/apitests/ntdll/NtSetInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtSetInformationProcess.c
@@ -9,6 +9,147 @@
 
 static
 void
+Test_ProcBasePriorityClass(void)
+{
+    NTSTATUS Status;
+
+    /*
+     * Assign a priority of HIGH_PRIORITY (see pstypes.h).
+     * The function will fail with a status of STATUS_PRIVILEGE_NOT_HELD
+     * as the process who executed the caller doesn't have the requested
+     * privileges to perform the operation.
+    */
+    KPRIORITY BasePriority = HIGH_PRIORITY;
+
+    /* Everything is NULL */
+    Status = NtSetInformationProcess(NULL,
+                                     ProcessBasePriority,
+                                     NULL,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Set the base priority to an invalid process handle */
+    Status = NtSetInformationProcess(NULL,
+                                     ProcessBasePriority,
+                                     &BasePriority,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* Don't input anything to the caller but the length information is valid */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     NULL,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* Give the base priority input to the caller but length is invalid */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     &BasePriority,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The input buffer is misaligned and length information invalid */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The input buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     (PVOID)1,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The input buffer is misaligned (try with an alignment of 2) */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     (PVOID)2,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Set the base priority but we have lack privileges to do so */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     &BasePriority,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_PRIVILEGE_NOT_HELD);
+
+    /*
+     * Assign a random priority value this time and
+     * set the base priority to the current process.
+    */
+    BasePriority = 8;
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBasePriority,
+                                     &BasePriority,
+                                     sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_SUCCESS);
+}
+
+static
+void
+Test_ProcRaisePriorityClass(void)
+{
+    NTSTATUS Status;
+
+    /* Raise the priority as much as possible */
+    ULONG RaisePriority = MAXIMUM_PRIORITY;
+
+    /* Everything is NULL */
+    Status = NtSetInformationProcess(NULL,
+                                     ProcessRaisePriority,
+                                     NULL,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* A invalid handle to process is given */
+    Status = NtSetInformationProcess(NULL,
+                                     ProcessRaisePriority,
+                                     &RaisePriority,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* The input buffer is misaligned and length information invalid */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessRaisePriority,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* A NULL buffer has been accessed */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessRaisePriority,
+                                     NULL,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* The input buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessRaisePriority,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The input buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessRaisePriority,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Raise the priority of the given current process */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessRaisePriority,
+                                     &RaisePriority,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_SUCCESS);
+}
+
+static
+void
 Test_ProcForegroundBackgroundClass(void)
 {
     NTSTATUS Status;
@@ -77,4 +218,6 @@ Test_ProcForegroundBackgroundClass(void)
 START_TEST(NtSetInformationProcess)
 {
     Test_ProcForegroundBackgroundClass();
+    Test_ProcBasePriorityClass();
+    Test_ProcRaisePriorityClass();
 }


### PR DESCRIPTION
`ProcessRaisePriority` class expects a buffer information of **KPRIORITY** type.
**Windows Server 2003**
![Capture2](https://user-images.githubusercontent.com/34916900/81092117-6c6bd680-8f00-11ea-8796-7eef3dee5043.PNG)
**Windows XP**
![Capture4](https://user-images.githubusercontent.com/34916900/81092126-71c92100-8f00-11ea-8b8e-fdfb9cf1b46b.PNG)
**Windows 10 Home 1909**
![Capture](https://user-images.githubusercontent.com/34916900/81092392-d08e9a80-8f00-11ea-83fb-a37781b886b6.PNG)
**ReactOS**
![Capture6](https://user-images.githubusercontent.com/34916900/81092236-9cb37500-8f00-11ea-9531-de7375270250.PNG)