### PR TITLE
[EVENTVWR] Implementation of Properties page functionnal code.

### DIFF
--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -2749,7 +2749,10 @@ GetDisplayNameFileAndID(IN LPCWSTR lpLogName,
     Result = RegOpenKeyExW(hkMachine, KeyPath, 0, KEY_QUERY_VALUE, &hLogKey);
     HeapFree(GetProcessHeap(), 0, KeyPath);
     if (Result != ERROR_SUCCESS)
+    {
+        ShowWin32Error(Result);
         return FALSE;
+    }
 
     cbData = sizeof(szModuleName);
     Result = RegQueryValueExW(hLogKey,

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -4019,8 +4019,8 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
     WCHAR *KeyPath;    
     SIZE_T cbKeyPath;
 
-    if (EventLog->Permanent)
-    {
+    if (!EventLog->Permanent)
+        return;
 
     cbKeyPath = (wcslen(EVENTLOG_BASE_KEY) + wcslen(lpLogName) + 1) * sizeof(WCHAR);
     KeyPath = HeapAlloc(GetProcessHeap(), 0, cbKeyPath);
@@ -4045,9 +4045,9 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
                         NULL) != ERROR_SUCCESS)
     {
         ShowWin32Error(GetLastError());
-		return;
+        return;
     }
-   
+
     HeapFree(GetProcessHeap(), 0, KeyPath);
 
     dwMaxSize = GetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, NULL, FALSE)*1024;
@@ -4069,7 +4069,6 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
                    sizeof(dwRetention));
     
     RegCloseKey(hLogKey);
-    }
 }
 
 /* Message handler for EventLog Properties dialog */
@@ -4164,8 +4163,8 @@ EventLogPropProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 
                 case IDC_RESTOREDEFAULTS:
                 {
-                    LoadStringW(hInst, IDS_APP_TITLE, szTitle, 128);
-                    LoadStringW(hInst, IDS_RESTOREDEFAULTS, szText, 256);
+                    LoadStringW(hInst, IDS_APP_TITLE, szTitle, _countof(szTitle));
+                    LoadStringW(hInst, IDS_RESTOREDEFAULTS, szText, _countof(szText));
 
                     if (MessageBox(hDlg, szText, szTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
                     {
@@ -4249,7 +4248,7 @@ EventLogProperties(HINSTANCE hInstance, HWND hWndParent, PEVENTLOGFILTER EventLo
 
     /* Create the property sheet */
     ret = PropertySheetW(&psh);
-    
+
 Quit:
     EventLogFilter_Release(EventLogFilter);
     return ret;

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -3874,8 +3874,8 @@ InitPropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
     if ((Result != ERROR_SUCCESS) || (dwType != REG_DWORD))
     {
         // dwMaxSize = 512 * 1024; /* 512 kBytes */
-        // x10 while ReactOS is Alpha
-        dwMaxSize = 512*10*1024;
+        /* Workstation: 512 KB; Server: 16384 KB */
+        dwMaxSize = 16384 * 1024;
     }
     /* Convert in KB */
     dwMaxSize /= 1024;
@@ -3889,12 +3889,12 @@ InitPropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
                               &cbData);
     if ((Result != ERROR_SUCCESS) || (dwType != REG_DWORD))
     {
-        /* On Windows 2003 it is 604800 (secs) == 7 days */
-        // No delete while ReactOS is Alpha        
+        /* By default, it is 604800 (secs) == 7 days. On Server, the retention is zeroed out. */
         dwRetention = 0;
     }
-    /* Convert in days */    
-    if(dwRetention != INFINITE) dwRetention = (dwRetention + 24*3600 - 1) / (24*3600);
+    /* Convert in days, rounded up */    
+    if (dwRetention != INFINITE)
+        dwRetention = (dwRetention + 24*3600 - 1) / (24*3600);
 
     RegCloseKey(hLogKey);
 
@@ -3984,7 +3984,7 @@ Quit:
         SendDlgItemMessageW(hDlg, IDC_UPDOWN_EVENTS_AGE, UDM_SETRANGE, 0, (LPARAM)MAKELONG(365, 1));
 
         SetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, dwMaxSize, FALSE);
-        SetDlgItemInt(hDlg, IDC_EDIT_EVENTS_AGE, (dwRetention == 0)?7:dwRetention, FALSE);
+        SetDlgItemInt(hDlg, IDC_EDIT_EVENTS_AGE, (dwRetention == 0) ? 7 : dwRetention, FALSE);
 
         if (dwRetention == 0)
         {
@@ -4017,7 +4017,6 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
 {
     LPWSTR lpLogName = EventLog->LogName;
 
-    DWORD dwType;
     DWORD dwMaxSize = 0, dwRetention = 0;
     HKEY hLogKey;
     WCHAR *KeyPath;    
@@ -4054,22 +4053,25 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
 
     HeapFree(GetProcessHeap(), 0, KeyPath);
 
-    dwMaxSize = GetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, NULL, FALSE)*1024;
-    dwType = REG_DWORD;
+    dwMaxSize = GetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, NULL, FALSE) * 1024;
     RegSetValueExW(hLogKey,
                    L"MaxSize",
                    0,
-                   dwType,
+                   REG_DWORD,
                    (LPBYTE)&dwMaxSize,
                    sizeof(dwMaxSize));    
 
-    dwRetention = GetDlgItemInt(hDlg, IDC_EDIT_EVENTS_AGE, NULL, FALSE)*(24*3600);
-    if (IsDlgButtonChecked(hDlg, IDC_OVERWRITE_AS_NEEDED) == BST_CHECKED) dwRetention = 0;
-    if (IsDlgButtonChecked(hDlg, IDC_NO_OVERWRITE) == BST_CHECKED) dwRetention = INFINITE;
+    if (IsDlgButtonChecked(hDlg, IDC_OVERWRITE_AS_NEEDED) == BST_CHECKED)
+        dwRetention = 0;
+    else if (IsDlgButtonChecked(hDlg, IDC_NO_OVERWRITE) == BST_CHECKED)
+        dwRetention = INFINITE;
+    else // if (IsDlgButtonChecked(hDlg, IDC_OVERWRITE_OLDER_THAN) == BST_CHECKED)
+        dwRetention = GetDlgItemInt(hDlg, IDC_EDIT_EVENTS_AGE, NULL, FALSE) * (24*3600);
+
     RegSetValueExW(hLogKey,
                    L"Retention",
                    0,
-                   dwType,
+                   REG_DWORD,
                    (LPBYTE)&dwRetention,
                    sizeof(dwRetention));
     
@@ -4081,9 +4083,7 @@ INT_PTR CALLBACK
 EventLogPropProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     PEVENTLOG EventLog;
-    WCHAR szTitle[128];
-    WCHAR szText[256];
-    PEVENTLOGFILTER EventLogFilter;
+    WCHAR szText[MAX_LOADSTRING];
 
     EventLog = (PEVENTLOG)GetWindowLongPtrW(hDlg, DWLP_USER);
 
@@ -4122,18 +4122,19 @@ EventLogPropProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                     return (INT_PTR)TRUE;
 
                 case ID_CLEARLOG:
-                    
-                    EventLogFilter = GetSelectedFilter(NULL);
+                {
+                    PEVENTLOGFILTER EventLogFilter = GetSelectedFilter(NULL);
                     if (EventLogFilter && ClearEvents(EventLogFilter))
                     {
                         Refresh(EventLogFilter);
                         InitPropertiesDlg(hDlg, EventLog);
                     }
                     return (INT_PTR)TRUE;
+                }
                 
                 case IDC_EDIT_EVENTS_AGE:
                 case IDC_EDIT_MAXLOGSIZE:
-                    if( HIWORD( wParam ) == EN_CHANGE )
+                    if (HIWORD(wParam) == EN_CHANGE)
                     {
                         PropSheet_Changed(GetParent(hDlg), hDlg);
                     }
@@ -4168,12 +4169,12 @@ EventLogPropProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 
                 case IDC_RESTOREDEFAULTS:
                 {
-                    LoadStringW(hInst, IDS_APP_TITLE, szTitle, _countof(szTitle));
                     LoadStringW(hInst, IDS_RESTOREDEFAULTS, szText, _countof(szText));
 
-                    if (MessageBox(hDlg, szText, szTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
+                    if (MessageBoxW(hDlg, szText, szTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
                     {
                         CheckRadioButton(hDlg, IDC_OVERWRITE_AS_NEEDED, IDC_NO_OVERWRITE, IDC_OVERWRITE_AS_NEEDED);
+                        /* Workstation: 512 KB; Server: 16384 KB */
                         SetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, 5120, FALSE);
                         SetDlgItemInt(hDlg, IDC_EDIT_EVENTS_AGE, 7, FALSE);
                         EnableDlgItem(hDlg, IDC_EDIT_EVENTS_AGE, FALSE);

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -3855,13 +3855,13 @@ InitPropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
     StringCbCopyW(KeyPath, cbKeyPath, EVENTLOG_BASE_KEY);
     StringCbCatW(KeyPath, cbKeyPath, lpLogName);
 
-    if (RegOpenKeyExW(hkMachine, KeyPath, 0, KEY_QUERY_VALUE, &hLogKey) != ERROR_SUCCESS)
+    Result = RegOpenKeyExW(hkMachine, KeyPath, 0, KEY_QUERY_VALUE, &hLogKey);
+    HeapFree(GetProcessHeap(), 0, KeyPath);
+    if (Result != ERROR_SUCCESS)
     {
-        HeapFree(GetProcessHeap(), 0, KeyPath);
-        ShowWin32Error(GetLastError());
+        ShowWin32Error(Result);
         goto Quit;
     }
-    HeapFree(GetProcessHeap(), 0, KeyPath);
 
 
     cbData = sizeof(dwMaxSize);
@@ -4017,6 +4017,7 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
 {
     LPWSTR lpLogName = EventLog->LogName;
 
+    LONG Result;
     DWORD dwMaxSize = 0, dwRetention = 0;
     HKEY hLogKey;
     WCHAR *KeyPath;    
@@ -4036,22 +4037,13 @@ SavePropertiesDlg(HWND hDlg, PEVENTLOG EventLog)
     StringCbCopyW(KeyPath, cbKeyPath, EVENTLOG_BASE_KEY);
     StringCbCatW(KeyPath, cbKeyPath, lpLogName);
 
-    /* Try to create/open the Event Viewer user key */
-    if (RegCreateKeyExW(HKEY_LOCAL_MACHINE,
-                        KeyPath,
-                        0,
-                        NULL,
-                        REG_OPTION_NON_VOLATILE,
-                        KEY_READ | KEY_WRITE,
-                        NULL,
-                        &hLogKey,
-                        NULL) != ERROR_SUCCESS)
+    Result = RegOpenKeyExW(hkMachine, KeyPath, 0, KEY_SET_VALUE, &hLogKey);
+    HeapFree(GetProcessHeap(), 0, KeyPath);
+    if (Result != ERROR_SUCCESS)
     {
-        ShowWin32Error(GetLastError());
+        ShowWin32Error(Result);
         return;
     }
-
-    HeapFree(GetProcessHeap(), 0, KeyPath);
 
     dwMaxSize = GetDlgItemInt(hDlg, IDC_EDIT_MAXLOGSIZE, NULL, FALSE) * 1024;
     RegSetValueExW(hLogKey,

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -142,6 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/bg-BG.rc
+++ b/base/applications/mscutils/eventvwr/lang/bg-BG.rc
@@ -142,7 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Не е намерено описанието на събитие ( %lu ) в източник ( %s ). Възможно е местият компютър да няма нужните сведения в регистъра или DLL файловет, нужни за показване на съобщения от отдалечен компютър.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -142,7 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "Uživatelské protokoly"
     IDS_SAVE_FILTER "Protokol událostí (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Chcete tento protokol před odstraněním uložit?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
+++ b/base/applications/mscutils/eventvwr/lang/cs-CZ.rc
@@ -142,6 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "Uživatelské protokoly"
     IDS_SAVE_FILTER "Protokol událostí (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Chcete tento protokol před odstraněním uložit?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis ID události ( %lu ) zdroj ( %s ) nebyl nalezen. Místní počítač neobsahuje potřebné informace v registru nebo chybí DLL soubory pro zobrazení zpráv ze vzdáleného počítače.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Ereignisprotokoll (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Möchten Sie dieses Protokoll vor dem Löschen speichern?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der Lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten von Remoten Computern anzuzeigen, nicht besitzt.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/de-DE.rc
+++ b/base/applications/mscutils/eventvwr/lang/de-DE.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Ereignisprotokoll (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Möchten Sie dieses Protokoll vor dem Löschen speichern?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Die Bezeichnung für die Ereignis-ID ( %lu ) in der Quelle ( %s ) kann nicht gefunden werden. Es könnte sein, dass der Lokale Computer die notwendigen Registry Einträge oder Nachrichten DLLs, um Nachrichten von Remoten Computern anzuzeigen, nicht besitzt.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/el-GR.rc
+++ b/base/applications/mscutils/eventvwr/lang/el-GR.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -150,7 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/en-US.rc
+++ b/base/applications/mscutils/eventvwr/lang/en-US.rc
@@ -150,6 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "Registros de Usuario"
     IDS_SAVE_FILTER "Registro de Eventos (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "¿Desea guardar este registro de eventos antes de borrarlo?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/es-ES.rc
+++ b/base/applications/mscutils/eventvwr/lang/es-ES.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "Registros de Usuario"
     IDS_SAVE_FILTER "Registro de Eventos (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "¿Desea guardar este registro de eventos antes de borrarlo?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "No se pudo recuperar la descripción para el evento con ID ( %lu ) y origen ( %s ). El equipo local puede no tener la información necesaria en el registro o las DLLs necesarias para mostrar los mensajes de un equipo remoto.\n\nLa siguiente información es parte del evento:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/fr-FR.rc
+++ b/base/applications/mscutils/eventvwr/lang/fr-FR.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "Journaux de l'utilisateur"
     IDS_SAVE_FILTER "Journal d'événements (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Voulez-vous enregistrer ce journal d'événements avant de l'effacer ?"
+    IDS_RESTOREDEFAULTS "Voulez-vous vraiment réinitialiser tous les paramètres pour ce journal aux valeurs par défaut ?"
     IDS_EVENTSTRINGIDNOTFOUND "La description pour l'événement d'ID ( %lu ) dans la source ( %s ) ne peut être trouvée. L'ordinateur local pourrait ne pas avoir les informations registres nécessaires ou les fichiers DLL de message pour afficher les messages depuis un ordinateur distant.\n\nLes informations suivantes font partie de l'événement :\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/he-IL.rc
+++ b/base/applications/mscutils/eventvwr/lang/he-IL.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "The description for Event ID ( %lu ) in Source ( %s ) cannot be found. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/it-IT.rc
+++ b/base/applications/mscutils/eventvwr/lang/it-IT.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "La descrizione per l'ID evento ( %lu ) proveniente da ( %s ) non può essere trovata. Il computer locale potrebbe non avere le informazioni sul registry necessarie o i file DLL con i messaggi necessari per la visualizzazione da un computer remoto.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ja-JP.rc
+++ b/base/applications/mscutils/eventvwr/lang/ja-JP.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "イベント ID (%lu) (ソース %s 内) に関する説明が見つかりませんでした。 リモート コンピュータからメッセージを表示するために必要なレジストリ情報またはメッセージ DLL ファイルがローカル コンピュータにない可能性があります。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ja-JP.rc
+++ b/base/applications/mscutils/eventvwr/lang/ja-JP.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "イベント ID (%lu) (ソース %s 内) に関する説明が見つかりませんでした。 リモート コンピュータからメッセージを表示するために必要なレジストリ情報またはメッセージ DLL ファイルがローカル コンピュータにない可能性があります。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ko-KR.rc
+++ b/base/applications/mscutils/eventvwr/lang/ko-KR.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) 의 이벤트ID ( %lu ) 에 대한 설명을 찾을 수 없습니다. 로컬 컴퓨터가 원격 컴퓨터의 메세지를 표시하는데 필요한 레지스트리나 DLL 파일을 가지지 않고 있을수 있습니다.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -142,6 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/no-NO.rc
+++ b/base/applications/mscutils/eventvwr/lang/no-NO.rc
@@ -142,7 +142,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivelsen for Hendelse ID ( %lu ) i kilden ( %s ) kan ikke bli finnet. Lokale datamaskinen har ikke nødvendige register informasjon eller melding DLL filer for å vise melding fra en fjern datamaskin.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -146,6 +146,7 @@ BEGIN
     IDS_EVENTLOG_USER "Dzienniki użytkownika"
     IDS_SAVE_FILTER "Dziennik zdarzeń (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Czy chcesz zapisać dziennik zdarzeń przed czyszczeniem?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/pl-PL.rc
+++ b/base/applications/mscutils/eventvwr/lang/pl-PL.rc
@@ -146,7 +146,7 @@ BEGIN
     IDS_EVENTLOG_USER "Dzienniki użytkownika"
     IDS_SAVE_FILTER "Dziennik zdarzeń (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Czy chcesz zapisać dziennik zdarzeń przed czyszczeniem?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Opis zdarzenia dla danego numeru ID ( %lu ) nie został odnaleziony w źródle ( %s ). Ten komputer może nie miec wystarczających informacji w rejestrze, albo bibliotek DLL, aby wyświetlić wiadomości z komputera zdalnego.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/pt-BR.rc
+++ b/base/applications/mscutils/eventvwr/lang/pt-BR.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "A descrição para Event ID ( %lu ) em Fonte ( %s ) não foi encontrado. O computador local talvez não possua a informação de registro necessária ou mensagem de arquivos DLL para exibir mensagens de um computador remoto.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_EVENTLOG_USER "Jurnale de utilizator"
     IDS_SAVE_FILTER "Jurnal de evenimente (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Doriți păstrarea acestui jurnal de evenimente înainte de a-l închide?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ) nu a fost găsită. Este posibil ca în calculatorul local să nu existe informațiile de registru necesare sau fișierele dll de mesaje să afișeze mesaje de la un calculator din rețea.\n\nInformații aferente evenimentului:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ro-RO.rc
+++ b/base/applications/mscutils/eventvwr/lang/ro-RO.rc
@@ -147,6 +147,7 @@ BEGIN
     IDS_EVENTLOG_USER "Jurnale de utilizator"
     IDS_SAVE_FILTER "Jurnal de evenimente (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Doriți păstrarea acestui jurnal de evenimente înainte de a-l închide?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Descrierea evenimentului cu ID-ul ( %lu ) în sursa ( %s ) nu a fost găsită. Este posibil ca în calculatorul local să nu existe informațiile de registru necesare sau fișierele dll de mesaje să afișeze mesaje de la un calculator din rețea.\n\nInformații aferente evenimentului:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "Пользовательский журнал"
     IDS_SAVE_FILTER "Журнал событий (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Вы хотите сохранить журнал событий перед очисткой?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/ru-RU.rc
+++ b/base/applications/mscutils/eventvwr/lang/ru-RU.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "Пользовательский журнал"
     IDS_SAVE_FILTER "Журнал событий (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Вы хотите сохранить журнал событий перед очисткой?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Не найдено описание для события с кодом ( %lu ) в источнике ( %s ). Возможно, на локальном компьютере нет нужных данных в реестре или файлов DLL сообщений для отображения сообщений удаленного компьютера.\n\nСледующая информация часть события:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -147,7 +147,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sk-SK.rc
+++ b/base/applications/mscutils/eventvwr/lang/sk-SK.rc
@@ -147,6 +147,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Popis pre udalosť ID ( %lu ) zo zdroja ( %s ) nebol nájdený. The local computer may not have the necessary registry information or message DLL files to display messages from a remote computer.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -150,6 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sq-AL.rc
+++ b/base/applications/mscutils/eventvwr/lang/sq-AL.rc
@@ -150,7 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Përshkrimi për ngjarjet ID ( %lu ) në burim ( %s ) nuk gjindet. Kompjuter vendas mund të mos ketë informacionin e regjistrit te nevojshem ose mesazhin për dokumentat DLL për të shfaqur nga një kompjuter në distancë.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/sv-SE.rc
+++ b/base/applications/mscutils/eventvwr/lang/sv-SE.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Beskrivning av Händelse ID ( %lu ) i källan ( %s ) kan inte hittas. Lokal dator har inte nödvendig registerinformation eller meddelander DLL filer for å vise meddelander från en fjärr dator.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -150,7 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "Kullanıcı Kayıtları"
     IDS_SAVE_FILTER "Olay Kaydı (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Silmeden önce bu olay kaydını saklamak ister misiniz?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerli bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Değer Defteri bilgisi veyâ ileti DLL kütükleri olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/tr-TR.rc
+++ b/base/applications/mscutils/eventvwr/lang/tr-TR.rc
@@ -150,6 +150,7 @@ BEGIN
     IDS_EVENTLOG_USER "Kullanıcı Kayıtları"
     IDS_SAVE_FILTER "Olay Kaydı (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Silmeden önce bu olay kaydını saklamak ister misiniz?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "( %s ) kaynağındaki ( %lu ) olay kimliği için açıklama bulunamıyor. Yerli bilgisayarda, uzak bilgisayardan iletileri görüntülemesi için gerekli Değer Defteri bilgisi veyâ ileti DLL kütükleri olmayabilir.\n\nAşağıdaki bilgi olayın parçasıdır:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/uk-UA.rc
+++ b/base/applications/mscutils/eventvwr/lang/uk-UA.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "Event Log (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "Do you want to save this event log before clearing it?"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "Опис для Ідентифікатора події ( %lu ) за джерелом ( %s ) не знайдено. Локальний комп'ютер може не мати необхідної інформації в реєстрі чи DLL файлів повідомлень для відображення повідомлень, що надходять від віддаленого комп'ютера.\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "用户日志"
     IDS_SAVE_FILTER "事件日志 (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "你想要在清除之前保存此事件日志吗？"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "来源 ( %s ) 中的事件 ID ( %lu ) 的描述无法找到。本地计算机可能没有显示来自远程计算机消息所必需的注册表信息或消息 DLL 文件。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/zh-CN.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-CN.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "用户日志"
     IDS_SAVE_FILTER "事件日志 (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "你想要在清除之前保存此事件日志吗？"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "来源 ( %s ) 中的事件 ID ( %lu ) 的描述无法找到。本地计算机可能没有显示来自远程计算机消息所必需的注册表信息或消息 DLL 文件。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -144,7 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "事件日誌 (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "你想要在清除之前保存此事件日誌嗎？"
-    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
+    IDS_RESTOREDEFAULTS "Do you want to restore all settings for this log to their default values?"
     IDS_EVENTSTRINGIDNOTFOUND "來源 ( %s ) 中的事件 ID ( %lu ) 的描述無法找到。 本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/lang/zh-TW.rc
+++ b/base/applications/mscutils/eventvwr/lang/zh-TW.rc
@@ -144,6 +144,7 @@ BEGIN
     IDS_EVENTLOG_USER "User Logs"
     IDS_SAVE_FILTER "事件日誌 (*.evt)\0*.evt\0"
     IDS_CLEAREVENTS_MSG "你想要在清除之前保存此事件日誌嗎？"
+    IDS_RESTOREDEFAULTS "Do you want to restore all parameters to default value for this log ?"
     IDS_EVENTSTRINGIDNOTFOUND "來源 ( %s ) 中的事件 ID ( %lu ) 的描述無法找到。 本地電腦可能沒有顯示來自遠端電腦消息所必需的註冊表資訊或消息 DLL 檔。\n\nThe following information is part of the event:\n\n"
 END
 

--- a/base/applications/mscutils/eventvwr/resource.h
+++ b/base/applications/mscutils/eventvwr/resource.h
@@ -94,6 +94,7 @@
 #define IDS_SAVE_FILTER                 109
 #define IDS_CLEAREVENTS_MSG             110
 #define IDS_EVENTSTRINGIDNOTFOUND       111
+#define IDS_RESTOREDEFAULTS             112
 
 #define IDS_USAGE                       120
 #define IDS_EVENTLOGFILE                121

--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -1576,18 +1576,18 @@ HKLM,"SYSTEM\CurrentControlSet\Services\EventLog","Type",0x00010001,0x00000010
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","File",0x00020000,"%SystemRoot%\system32\config\AppEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","MaxSize",0x00010003,524288
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","Retention",0x00010003,604800
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","MaxSize",0x00010003,5242880
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","Retention",0x00010003,0
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","File",0x00020000,"%SystemRoot%\system32\config\SecEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","MaxSize",0x00010003,524288
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","Retention",0x00010003,604800
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","MaxSize",0x00010003,5242880
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","Retention",0x00010003,0
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","File",0x00020000,"%SystemRoot%\system32\config\SysEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","MaxSize",0x00010003,524288
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","Retention",0x00010003,604800
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","MaxSize",0x00010003,5242880
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","Retention",0x00010003,0
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\Application Popup","EventMessageFile",0x00020000,"%SystemRoot%\system32\ntdll.dll"
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\Application Popup","TypesSupported",0x00010003,0x00000007
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\EventLog","EventMessageFile",0x00020000,"%SystemRoot%\system32\netevent.dll"

--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -1576,18 +1576,18 @@ HKLM,"SYSTEM\CurrentControlSet\Services\EventLog","Type",0x00010001,0x00000010
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","File",0x00020000,"%SystemRoot%\system32\config\AppEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","MaxSize",0x00010003,5242880
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","Retention",0x00010003,0
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","MaxSize",0x00010003,524288
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Application","Retention",0x00010003,604800
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","File",0x00020000,"%SystemRoot%\system32\config\SecEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","MaxSize",0x00010003,5242880
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","Retention",0x00010003,0
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","MaxSize",0x00010003,524288
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\Security","Retention",0x00010003,604800
 
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System",,0x00000010
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","File",0x00020000,"%SystemRoot%\system32\config\SysEvent.Evt"
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","MaxSize",0x00010003,5242880
-HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","Retention",0x00010003,0
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","MaxSize",0x00010003,524288
+HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System","Retention",0x00010003,604800
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\Application Popup","EventMessageFile",0x00020000,"%SystemRoot%\system32\ntdll.dll"
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\Application Popup","TypesSupported",0x00010003,0x00000007
 HKLM,"SYSTEM\CurrentControlSet\Services\EventLog\System\EventLog","EventMessageFile",0x00020000,"%SystemRoot%\system32\netevent.dll"


### PR DESCRIPTION
## Purpose

Implementation of functional code for log properties page  (currently "set default", "Delete log" does nothing, apply systematically greyed, changes not saved nor taken into account...)

## Proposed changes

Implementation of functional code for log properties page in order to allow user to :
- Make modification and have them saved in registry when properties page is closed / apply is used and taken into account at the next session
- Set defaults (including correction of default max size)
- Delete content of log
- Make "Apply" button functional based on user inputs
- Keep current specific default values (no time based log pruning, extended size) as per discussion with @HBelusca : https://github.com/reactos/reactos/pull/2744#discussion_r420819152