### PR TITLE
[RAPPS] 64bit compatibility fix

### DIFF
--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -404,7 +404,7 @@ INT_PTR CALLBACK CDownloadManager::DownloadDlgProc(HWND Dlg, UINT uMsg, WPARAM w
             SendMessageW(Dlg, WM_SETICON, ICON_SMALL, (LPARAM) hIconSm);
         }
 
-        SetWindowLongW(Dlg, GWLP_USERDATA, 0);
+        SetWindowLongPtrW(Dlg, GWLP_USERDATA, 0);
         HWND Item = GetDlgItem(Dlg, IDC_DOWNLOAD_PROGRESS);
         if (Item)
         {


### PR DESCRIPTION
## Purpose

change ```SetWindowLongW``` to ```SetWindowLongPtrW```

it's the same (because the value is 0) but I think it's better


