### PR TITLE
[OPENGLCFG] Empty list boxes if registry key is missing

### DIFF
--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -10,11 +10,11 @@ static VOID InitSettings(HWND hWndDlg)
 {
     HKEY hKeyRenderer;
     HKEY hKeyDrivers;
+    DWORD dwType = 0;
+    DWORD dwSize = MAX_KEY_LENGTH;
     WCHAR szBuffer[MAX_KEY_LENGTH];
     WCHAR szBultin[MAX_KEY_LENGTH];
     WCHAR szDriver[MAX_KEY_LENGTH];
-    DWORD dwType = 0;
-    DWORD dwSize = MAX_KEY_LENGTH; 
 
     LoadString(hApplet, IDS_DEBUG_DNM, (LPTSTR)szBultin, 127);
     SendDlgItemMessageW(hWndDlg, IDC_DEBUG_OUTPUT, CB_ADDSTRING, 0, (LPARAM)szBultin);
@@ -39,6 +39,8 @@ static VOID InitSettings(HWND hWndDlg)
     if (RegQueryValueExW(hKeyRenderer, NULL, NULL, &dwType, (LPBYTE)szDriver, &dwSize) != ERROR_SUCCESS || dwSize == sizeof(WCHAR))
         SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_DEFAULT, 0);
 
+    RegCloseKey(hKeyRenderer);
+
     if (dwType == REG_SZ)
     {
         DWORD ret;
@@ -48,17 +50,13 @@ static VOID InitSettings(HWND hWndDlg)
             SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_RSWR, 0);
 
         if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, KEY_DRIVERS, 0, KEY_READ, &hKeyDrivers) != ERROR_SUCCESS)
-        {
-            RegCloseKey(hKeyRenderer);
             return;
-        }
 
         ret = RegQueryInfoKeyW(hKeyDrivers, NULL, NULL, NULL, &dwNumDrivers, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
         if (ret != ERROR_SUCCESS || dwNumDrivers == 0)
         {
             RegCloseKey(hKeyDrivers);
-            RegCloseKey(hKeyRenderer);
             return;
         }
 
@@ -93,8 +91,6 @@ static VOID InitSettings(HWND hWndDlg)
 
         RegCloseKey(hKeyDrivers);
     }
-
-    RegCloseKey(hKeyRenderer);
 
     return;
 }

--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -16,15 +16,6 @@ static VOID InitSettings(HWND hWndDlg)
     DWORD dwType = 0;
     DWORD dwSize = MAX_KEY_LENGTH; 
 
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, KEY_DRIVERS, 0, KEY_READ, &hKeyDrivers) != ERROR_SUCCESS)
-        return;
-
-    if (RegCreateKeyExW(HKEY_CURRENT_USER, KEY_RENDERER, 0, NULL, 0, MAXIMUM_ALLOWED, NULL, &hKeyRenderer, NULL) != ERROR_SUCCESS)
-    {
-        RegCloseKey(hKeyDrivers);
-        return;
-    }
-
     LoadString(hApplet, IDS_DEBUG_DNM, (LPTSTR)szBultin, 127);
     SendDlgItemMessageW(hWndDlg, IDC_DEBUG_OUTPUT, CB_ADDSTRING, 0, (LPARAM)szBultin);
 
@@ -42,6 +33,12 @@ static VOID InitSettings(HWND hWndDlg)
     LoadString(hApplet, IDS_RENDERER_RSWR, (LPTSTR)szBultin, 127);
     SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_ADDSTRING, 0, (LPARAM)szBultin);
 
+    if (RegCreateKeyExW(HKEY_CURRENT_USER, KEY_RENDERER, 0, NULL, 0, MAXIMUM_ALLOWED, NULL, &hKeyRenderer, NULL) != ERROR_SUCCESS)
+    {
+        RegCloseKey(hKeyDrivers);
+        return;
+    }
+
     if (RegQueryValueExW(hKeyRenderer, NULL, NULL, &dwType, (LPBYTE)szDriver, &dwSize) != ERROR_SUCCESS || dwSize == sizeof(WCHAR))
         SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_DEFAULT, 0);
 
@@ -52,6 +49,12 @@ static VOID InitSettings(HWND hWndDlg)
 
         if (wcsncmp(szBultin, szDriver, MAX_KEY_LENGTH) == 0)
             SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_RSWR, 0);
+
+        if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, KEY_DRIVERS, 0, KEY_READ, &hKeyDrivers) != ERROR_SUCCESS)
+        {
+            RegCloseKey(hKeyRenderer);
+            return;
+        }
 
         ret = RegQueryInfoKeyW(hKeyDrivers, NULL, NULL, NULL, &dwNumDrivers, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
 
@@ -90,9 +93,10 @@ static VOID InitSettings(HWND hWndDlg)
             if (wcsncmp(szBuffer, szDriver, MAX_KEY_LENGTH) == 0)
                 SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, iKey + 2, 0);
         }
+
+        RegCloseKey(hKeyDrivers);
     }
 
-    RegCloseKey(hKeyDrivers);
     RegCloseKey(hKeyRenderer);
 
     return;

--- a/dll/cpl/openglcfg/general.c
+++ b/dll/cpl/openglcfg/general.c
@@ -34,10 +34,7 @@ static VOID InitSettings(HWND hWndDlg)
     SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_ADDSTRING, 0, (LPARAM)szBultin);
 
     if (RegCreateKeyExW(HKEY_CURRENT_USER, KEY_RENDERER, 0, NULL, 0, MAXIMUM_ALLOWED, NULL, &hKeyRenderer, NULL) != ERROR_SUCCESS)
-    {
-        RegCloseKey(hKeyDrivers);
         return;
-    }
 
     if (RegQueryValueExW(hKeyRenderer, NULL, NULL, &dwType, (LPBYTE)szDriver, &dwSize) != ERROR_SUCCESS || dwSize == sizeof(WCHAR))
         SendDlgItemMessageW(hWndDlg, IDC_RENDERER, CB_SETCURSEL, RENDERER_DEFAULT, 0);


### PR DESCRIPTION
 ## Purpose
If the registry key that holds the names of installed
opengl drivers is missing, all list boxes in openglcfg
are empty. This is a minor code rearrangement to fix
this behavior.
