### PR TITLE
Revert "[COMCTL32][USER32] Fix radio button regression"

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1211,11 +1211,7 @@ static UINT BUTTON_CalcLabelRect(const BUTTON_INFO *infoPtr, HDC hdc, RECT *rc)
           }
 
           if ((hFont = infoPtr->font)) hPrevFont = SelectObject( hdc, hFont );
-#ifdef __REACTOS__
-          DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
-#else
           DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
-#endif
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           heap_free( text );
 #ifdef __REACTOS__

--- a/win32ss/user/user32/controls/button.c
+++ b/win32ss/user/user32/controls/button.c
@@ -773,11 +773,7 @@ static UINT BUTTON_CalcLabelRect(HWND hwnd, HDC hdc, RECT *rc)
           }
 
           if ((hFont = get_button_font( hwnd ))) hPrevFont = SelectObject( hdc, hFont );
-#ifdef __REACTOS__
-          DrawTextW(hdc, text, -1, &r, ((dtStyle | DT_CALCRECT) & ~(DT_VCENTER | DT_BOTTOM)));
-#else
           DrawTextW(hdc, text, -1, &r, dtStyle | DT_CALCRECT);
-#endif
           if (hPrevFont) SelectObject( hdc, hPrevFont );
           HeapFree( GetProcessHeap(), 0, text );
 #ifdef __REACTOS__


### PR DESCRIPTION
Reverts reactos/reactos#2146.

#2135 (e329e83) and #2146 (2d4d3f5) are my mistakes. I misunderstood the difference with real Microsoft Tahoma font.

JIRA issue: [CORE-16552](https://jira.reactos.org/browse/CORE-16552), [CORE-16747](https://jira.reactos.org/browse/CORE-16747)