### PR TITLE
[WIN32SS] Fix DrawTextExWorker extent for Spotify

### DIFF
--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -1266,7 +1266,7 @@ INT WINAPI DrawTextExWorker( HDC hdc,
         if (flags & DT_VCENTER) y = rect->top +
             (rect->bottom - rect->top + (invert_y ? size.cy : -size.cy)) / 2;
         else if (flags & DT_BOTTOM)
-            y = rect->bottom + (invert_y ? 0 : -size.cy);
+            y = rect->bottom + (invert_y ? size.cy : -size.cy);
 #else
 	    if (flags & DT_VCENTER) y = rect->top +
 	    	(rect->bottom - rect->top) / 2 - size.cy / 2;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16747](https://jira.reactos.org/browse/CORE-16747)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/81467684-5d916680-9215-11ea-9fa9-a96d0333710f.png)
Spotify won't start up.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/81466281-611ff000-920b-11ea-9d20-c42f5e13f9f9.png)
Spotify starts up.

Double checked.