### PR TITLE
[USER32] Adjusted the column width in IDC_PICKICON_LIST

### DIFF
--- a/win32ss/user/user32/controls/listbox.c
+++ b/win32ss/user/user32/controls/listbox.c
@@ -1289,6 +1289,14 @@ static LRESULT LISTBOX_SetColumnWidth( LB_DESCR *descr, INT width)
 {
     if (width == descr->column_width) return LB_OKAY;
     TRACE("[%p]: new column width = %d\n", descr->self, width );
+#ifdef __REACTOS__
+    if (!(descr->style & WS_VSCROLL))
+    {
+        int w = GetSystemMetrics(SM_CXVSCROLL);
+        w /= LOWORD(GetDialogBaseUnits());
+        width += w;
+    }
+#endif
     descr->column_width = width;
     LISTBOX_UpdatePage( descr );
     return LB_OKAY;


### PR DESCRIPTION
Adjusted the width of the columns in  IDC_PICKICON_LIST list

The list of icons in IDC_PICKICON_LIST only shows half an icon in the right hand column on all lines.

Proposal:
Adjust the width of each column to show a full number of icons.