### PR TITLE
[RICHED20] Address incomplete wine sync

### DIFF
--- a/dll/win32/riched20/editor.h
+++ b/dll/win32/riched20/editor.h
@@ -278,7 +278,7 @@ void ME_InitTableDef(ME_TextEditor *editor, struct RTFTable *tableDef) DECLSPEC_
 
 /* txthost.c */
 ITextHost *ME_CreateTextHost(HWND hwnd, CREATESTRUCTW *cs, BOOL bEmulateVersion10) DECLSPEC_HIDDEN;
-#if defined(__i386__) && !defined(__MINGW32__)  /* Use wrappers to perform thiscall on i386 */
+#ifdef __ASM_USE_THISCALL_WRAPPER
 #define TXTHOST_VTABLE(This) (&itextHostStdcallVtbl)
 #else /* __i386__ */
 #define TXTHOST_VTABLE(This) (This)->lpVtbl

--- a/dll/win32/riched20/editstr.h
+++ b/dll/win32/riched20/editstr.h
@@ -43,11 +43,12 @@
 #include <textserv.h>
 #include "usp10.h"
 
+#include "wine/asm.h"
 #include "wine/debug.h"
 #include "wine/heap.h"
 #include "wine/list.h"
 
-#if defined(__i386__) && !defined(__MINGW32__)
+#ifdef __ASM_USE_THISCALL_WRAPPER
 extern const struct ITextHostVtbl itextHostStdcallVtbl DECLSPEC_HIDDEN;
 #endif /* __i386__ */
 

--- a/dll/win32/riched20/txthost.c
+++ b/dll/win32/riched20/txthost.c
@@ -20,6 +20,9 @@
 
 #define COBJMACROS
 
+#ifndef __REACTOS__
+#include "config.h"
+#endif
 #include "editor.h"
 #include "ole2.h"
 #include "richole.h"
@@ -103,63 +106,73 @@ static ULONG WINAPI ITextHostImpl_Release(ITextHost *iface)
     return ref;
 }
 
-DECLSPEC_HIDDEN HDC WINAPI ITextHostImpl_TxGetDC(ITextHost *iface)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetDC,4)
+DECLSPEC_HIDDEN HDC __thiscall ITextHostImpl_TxGetDC(ITextHost *iface)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return GetDC(This->hWnd);
 }
 
-DECLSPEC_HIDDEN INT WINAPI ITextHostImpl_TxReleaseDC(ITextHost *iface, HDC hdc)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxReleaseDC,8)
+DECLSPEC_HIDDEN INT __thiscall ITextHostImpl_TxReleaseDC(ITextHost *iface, HDC hdc)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return ReleaseDC(This->hWnd, hdc);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxShowScrollBar(ITextHost *iface, INT fnBar, BOOL fShow)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowScrollBar,12)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowScrollBar(ITextHost *iface, INT fnBar, BOOL fShow)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return ShowScrollBar(This->hWnd, fnBar, fShow);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxEnableScrollBar(ITextHost *iface, INT fuSBFlags, INT fuArrowflags)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxEnableScrollBar,12)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxEnableScrollBar(ITextHost *iface, INT fuSBFlags, INT fuArrowflags)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return EnableScrollBar(This->hWnd, fuSBFlags, fuArrowflags);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxSetScrollRange(ITextHost *iface, INT fnBar, LONG nMinPos, INT nMaxPos,
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollRange,20)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollRange(ITextHost *iface, INT fnBar, LONG nMinPos, INT nMaxPos,
                                            BOOL fRedraw)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return SetScrollRange(This->hWnd, fnBar, nMinPos, nMaxPos, fRedraw);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxSetScrollPos(ITextHost *iface, INT fnBar, INT nPos, BOOL fRedraw)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollPos,16)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetScrollPos(ITextHost *iface, INT fnBar, INT nPos, BOOL fRedraw)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return SetScrollPos(This->hWnd, fnBar, nPos, fRedraw) != 0;
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxInvalidateRect(ITextHost *iface, LPCRECT prc, BOOL fMode)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxInvalidateRect,12)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxInvalidateRect(ITextHost *iface, LPCRECT prc, BOOL fMode)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     InvalidateRect(This->hWnd, prc, fMode);
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxViewChange(ITextHost *iface, BOOL fUpdate)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxViewChange,8)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxViewChange(ITextHost *iface, BOOL fUpdate)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     if (fUpdate)
         UpdateWindow(This->hWnd);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxCreateCaret(ITextHost *iface, HBITMAP hbmp, INT xWidth, INT yHeight)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxCreateCaret,16)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxCreateCaret(ITextHost *iface, HBITMAP hbmp, INT xWidth, INT yHeight)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return CreateCaret(This->hWnd, hbmp, xWidth, yHeight);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fShow)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowCaret,8)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fShow)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     if (fShow)
@@ -168,25 +181,29 @@ DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fSh
         return HideCaret(This->hWnd);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxSetCaretPos(ITextHost *iface,
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCaretPos,12)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetCaretPos(ITextHost *iface,
                                         INT x, INT y)
 {
     return SetCaretPos(x, y);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxSetTimer(ITextHost *iface, UINT idTimer, UINT uTimeout)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetTimer,12)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxSetTimer(ITextHost *iface, UINT idTimer, UINT uTimeout)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return SetTimer(This->hWnd, idTimer, uTimeout, NULL) != 0;
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxKillTimer(ITextHost *iface, UINT idTimer)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxKillTimer,8)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxKillTimer(ITextHost *iface, UINT idTimer)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     KillTimer(This->hWnd, idTimer);
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxScrollWindowEx(ITextHost *iface, INT dx, INT dy, LPCRECT lprcScroll,
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScrollWindowEx,32)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxScrollWindowEx(ITextHost *iface, INT dx, INT dy, LPCRECT lprcScroll,
                                            LPCRECT lprcClip, HRGN hRgnUpdate, LPRECT lprcUpdate,
                                            UINT fuScroll)
 {
@@ -195,7 +212,8 @@ DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxScrollWindowEx(ITextHost *iface, INT
                    hRgnUpdate, lprcUpdate, fuScroll);
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxSetCapture(ITextHost *iface, BOOL fCapture)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCapture,8)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCapture(ITextHost *iface, BOOL fCapture)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     if (fCapture)
@@ -204,54 +222,58 @@ DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxSetCapture(ITextHost *iface, BOOL fC
         ReleaseCapture();
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxSetFocus(ITextHost *iface)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetFocus,4)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetFocus(ITextHost *iface)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     SetFocus(This->hWnd);
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxSetCursor(ITextHost *iface,
-                                      HCURSOR hcur,
-                                      BOOL fText)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCursor,12)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxSetCursor(ITextHost *iface, HCURSOR hcur, BOOL fText)
 {
     SetCursor(hcur);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxScreenToClient(ITextHost *iface, LPPOINT lppt)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScreenToClient,8)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxScreenToClient(ITextHost *iface, LPPOINT lppt)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return ScreenToClient(This->hWnd, lppt);
 }
 
-DECLSPEC_HIDDEN BOOL WINAPI ITextHostImpl_TxClientToScreen(ITextHost *iface, LPPOINT lppt)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxClientToScreen,8)
+DECLSPEC_HIDDEN BOOL __thiscall ITextHostImpl_TxClientToScreen(ITextHost *iface, LPPOINT lppt)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return ClientToScreen(This->hWnd, lppt);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxActivate(ITextHost *iface, LONG *plOldState)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxActivate,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxActivate(ITextHost *iface, LONG *plOldState)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     *plOldState = HandleToLong(SetActiveWindow(This->hWnd));
     return (*plOldState ? S_OK : E_FAIL);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxDeactivate(ITextHost *iface,
-                                          LONG lNewState)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxDeactivate,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxDeactivate(ITextHost *iface, LONG lNewState)
 {
     HWND ret = SetActiveWindow(LongToHandle(lNewState));
     return (ret ? S_OK : E_FAIL);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetClientRect(ITextHost *iface, LPRECT prc)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetClientRect,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetClientRect(ITextHost *iface, LPRECT prc)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     int ret = GetClientRect(This->hWnd, prc);
     return (ret ? S_OK : E_FAIL);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetViewInset(ITextHost *iface,
-                                            LPRECT prc)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetViewInset,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetViewInset(ITextHost *iface, LPRECT prc)
 {
     prc->top = 0;
     prc->left = 0;
@@ -260,41 +282,42 @@ DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetViewInset(ITextHost *iface,
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetCharFormat(ITextHost *iface,
-                                             const CHARFORMATW **ppCF)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetCharFormat,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetCharFormat(ITextHost *iface, const CHARFORMATW **ppCF)
 {
     return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetParaFormat(ITextHost *iface,
-                                                             const PARAFORMAT **fmt)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetParaFormat,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetParaFormat(ITextHost *iface, const PARAFORMAT **fmt)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     *fmt = (const PARAFORMAT *)&This->para_fmt;
     return S_OK;
 }
 
-DECLSPEC_HIDDEN COLORREF WINAPI ITextHostImpl_TxGetSysColor(ITextHost *iface,
-                                            int nIndex)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSysColor,8)
+DECLSPEC_HIDDEN COLORREF __thiscall ITextHostImpl_TxGetSysColor(ITextHost *iface, int nIndex)
 {
     return GetSysColor(nIndex);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetBackStyle(ITextHost *iface,
-                                            TXTBACKSTYLE *pStyle)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetBackStyle,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetBackStyle(ITextHost *iface, TXTBACKSTYLE *pStyle)
 {
     *pStyle = TXTBACK_OPAQUE;
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetMaxLength(ITextHost *iface,
-                                            DWORD *pLength)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetMaxLength,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetMaxLength(ITextHost *iface, DWORD *pLength)
 {
     *pLength = INFINITE;
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetScrollBars(ITextHost *iface, DWORD *pdwScrollBar)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetScrollBars,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetScrollBars(ITextHost *iface, DWORD *pdwScrollBar)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     ME_TextEditor *editor = (ME_TextEditor*)GetWindowLongPtrW(This->hWnd, 0);
@@ -317,39 +340,40 @@ DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetScrollBars(ITextHost *iface, D
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetPasswordChar(ITextHost *iface,
-                                               WCHAR *pch)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPasswordChar,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPasswordChar(ITextHost *iface, WCHAR *pch)
 {
     *pch = '*';
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetAcceleratorPos(ITextHost *iface,
-                                                 LONG *pch)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetAcceleratorPos,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetAcceleratorPos(ITextHost *iface, LONG *pch)
 {
     *pch = -1;
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetExtent(ITextHost *iface,
-                                         LPSIZEL lpExtent)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetExtent,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetExtent(ITextHost *iface, LPSIZEL lpExtent)
 {
     return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_OnTxCharFormatChange(ITextHost *iface,
-                                                  const CHARFORMATW *pcf)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxCharFormatChange,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxCharFormatChange(ITextHost *iface, const CHARFORMATW *pcf)
 {
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_OnTxParaFormatChange(ITextHost *iface,
-                                                  const PARAFORMAT *ppf)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxParaFormatChange,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_OnTxParaFormatChange(ITextHost *iface, const PARAFORMAT *ppf)
 {
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetPropertyBits(ITextHost *iface, DWORD dwMask, DWORD *pdwBits)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPropertyBits,12)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetPropertyBits(ITextHost *iface, DWORD dwMask, DWORD *pdwBits)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     ME_TextEditor *editor = (ME_TextEditor *)GetWindowLongPtrW(This->hWnd, 0);
@@ -415,7 +439,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetPropertyBits(ITextHost *iface,
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxNotify(ITextHost *iface, DWORD iNotify, void *pv)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxNotify,12)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxNotify(ITextHost *iface, DWORD iNotify, void *pv)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     ME_TextEditor *editor = (ME_TextEditor*)GetWindowLongPtrW(This->hWnd, 0);
@@ -473,19 +498,22 @@ DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxNotify(ITextHost *iface, DWORD iN
     return S_OK;
 }
 
-DECLSPEC_HIDDEN HIMC WINAPI ITextHostImpl_TxImmGetContext(ITextHost *iface)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmGetContext,4)
+DECLSPEC_HIDDEN HIMC __thiscall ITextHostImpl_TxImmGetContext(ITextHost *iface)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     return ImmGetContext(This->hWnd);
 }
 
-DECLSPEC_HIDDEN void WINAPI ITextHostImpl_TxImmReleaseContext(ITextHost *iface, HIMC himc)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmReleaseContext,8)
+DECLSPEC_HIDDEN void __thiscall ITextHostImpl_TxImmReleaseContext(ITextHost *iface, HIMC himc)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     ImmReleaseContext(This->hWnd, himc);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetSelectionBarWidth(ITextHost *iface, LONG *lSelBarWidth)
+DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSelectionBarWidth,8)
+DECLSPEC_HIDDEN HRESULT __thiscall ITextHostImpl_TxGetSelectionBarWidth(ITextHost *iface, LONG *lSelBarWidth)
 {
     ITextHostImpl *This = impl_from_ITextHost(iface);
     ME_TextEditor *editor = (ME_TextEditor *)GetWindowLongPtrW(This->hWnd, 0);
@@ -495,47 +523,9 @@ DECLSPEC_HIDDEN HRESULT WINAPI ITextHostImpl_TxGetSelectionBarWidth(ITextHost *i
     *lSelBarWidth = (style & ES_SELECTIONBAR) ? 225 : 0; /* in HIMETRIC */
     return S_OK;
 }
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetDC,4)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxReleaseDC,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowScrollBar,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxEnableScrollBar,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollRange,20)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetScrollPos,16)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxInvalidateRect,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxViewChange,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxCreateCaret,16)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxShowCaret,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCaretPos,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetTimer,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxKillTimer,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScrollWindowEx,32)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCapture,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetFocus,4)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxSetCursor,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxScreenToClient,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxClientToScreen,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxActivate,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxDeactivate,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetClientRect,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetViewInset,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetCharFormat,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetParaFormat,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSysColor,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetBackStyle,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetMaxLength,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetScrollBars,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPasswordChar,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetAcceleratorPos,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetExtent,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxCharFormatChange,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_OnTxParaFormatChange,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetPropertyBits,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxNotify,12)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmGetContext,4)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxImmReleaseContext,8)
-DEFINE_THISCALL_WRAPPER(ITextHostImpl_TxGetSelectionBarWidth,8)
 
-#if defined(__i386__) && !defined(__MINGW32__)  /* thiscall functions are i386-specific */
+
+#ifdef __ASM_USE_THISCALL_WRAPPER
 
 #define STDCALL(func) (void *) __stdcall_ ## func
 #ifdef _MSC_VER

--- a/dll/win32/riched20/txtsrv.c
+++ b/dll/win32/riched20/txtsrv.c
@@ -20,6 +20,9 @@
 
 #define COBJMACROS
 
+#ifndef __REACTOS__
+#include "config.h"
+#endif
 #include "editor.h"
 #include "ole2.h"
 #include "oleauto.h"
@@ -132,7 +135,8 @@ static ULONG WINAPI fnTextSrv_Release(ITextServices *iface)
    return IUnknown_Release(This->outer_unk);
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxSendMessage(ITextServices *iface, UINT msg, WPARAM wparam,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSendMessage,20)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSendMessage(ITextServices *iface, UINT msg, WPARAM wparam,
                                        LPARAM lparam, LRESULT *plresult)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
@@ -144,7 +148,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxSendMessage(ITextServices *iface, UIN
    return hresult;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxDraw(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxDraw,52)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxDraw(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
                                 void *pvAspect, DVTARGETDEVICE *ptd, HDC hdcDraw, HDC hdcTargetDev,
                                 LPCRECTL lprcBounds, LPCRECTL lprcWBounds, LPRECT lprcUpdate,
                                 BOOL (CALLBACK * pfnContinue)(DWORD), DWORD dwContinue,
@@ -156,7 +161,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxDraw(ITextServices *iface, DWORD dwDr
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetHScroll(ITextServices *iface, LONG *plMin, LONG *plMax, LONG *plPos,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetHScroll,24)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetHScroll(ITextServices *iface, LONG *plMin, LONG *plMax, LONG *plPos,
                                       LONG *plPage, BOOL *pfEnabled)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
@@ -174,7 +180,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetHScroll(ITextServices *iface, LONG
    return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetVScroll(ITextServices *iface, LONG *plMin, LONG *plMax, LONG *plPos,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetVScroll,24)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetVScroll(ITextServices *iface, LONG *plMin, LONG *plMax, LONG *plPos,
                                       LONG *plPage, BOOL *pfEnabled)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
@@ -192,7 +199,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetVScroll(ITextServices *iface, LONG
    return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxSetCursor(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxSetCursor,40)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxSetCursor(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
                                        void *pvAspect, DVTARGETDEVICE *ptd, HDC hdcDraw,
                                        HDC hicTargetDev, LPCRECT lprcClient, INT x, INT y)
 {
@@ -202,7 +210,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxSetCursor(ITextServices *iface, DWO
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxQueryHitPoint(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxQueryHitPoint,44)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxQueryHitPoint(ITextServices *iface, DWORD dwDrawAspect, LONG lindex,
                                          void *pvAspect, DVTARGETDEVICE *ptd, HDC hdcDraw,
                                          HDC hicTargetDev, LPCRECT lprcClient, INT x, INT y,
                                          DWORD *pHitResult)
@@ -213,7 +222,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxQueryHitPoint(ITextServices *iface, D
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxInplaceActivate(ITextServices *iface, LPCRECT prcClient)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInplaceActivate,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInplaceActivate(ITextServices *iface, LPCRECT prcClient)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -221,7 +231,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxInplaceActivate(ITextServices *ifac
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxInplaceDeactivate(ITextServices *iface)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInplaceDeactivate,4)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxInplaceDeactivate(ITextServices *iface)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -229,7 +240,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxInplaceDeactivate(ITextServices *if
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxUIActivate(ITextServices *iface)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIActivate,4)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIActivate(ITextServices *iface)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -237,7 +249,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxUIActivate(ITextServices *iface)
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxUIDeactivate(ITextServices *iface)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIDeactivate,4)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxUIDeactivate(ITextServices *iface)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -245,7 +258,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxUIDeactivate(ITextServices *iface)
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetText(ITextServices *iface, BSTR *pbstrText)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetText,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetText(ITextServices *iface, BSTR *pbstrText)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
    int length;
@@ -269,7 +283,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetText(ITextServices *iface, BSTR *p
    return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxSetText(ITextServices *iface, LPCWSTR pszText)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSetText,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxSetText(ITextServices *iface, LPCWSTR pszText)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
    ME_Cursor cursor;
@@ -287,7 +302,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxSetText(ITextServices *iface, LPCWSTR
    return S_OK;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetCurTargetX(ITextServices *iface, LONG *x)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetCurTargetX,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCurTargetX(ITextServices *iface, LONG *x)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -295,7 +311,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetCurTargetX(ITextServices *iface, L
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetBaseLinePos(ITextServices *iface, LONG *x)
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetBaseLinePos,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetBaseLinePos(ITextServices *iface, LONG *x)
 {
    ITextServicesImpl *This = impl_from_ITextServices(iface);
 
@@ -303,7 +320,8 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetBaseLinePos(ITextServices *iface, 
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetNaturalSize(ITextServices *iface, DWORD dwAspect, HDC hdcDraw,
+DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetNaturalSize,36)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetNaturalSize(ITextServices *iface, DWORD dwAspect, HDC hdcDraw,
                                           HDC hicTargetDev, DVTARGETDEVICE *ptd, DWORD dwMode,
                                           const SIZEL *psizelExtent, LONG *pwidth, LONG *pheight)
 {
@@ -313,48 +331,33 @@ DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetNaturalSize(ITextServices *iface, 
    return E_NOTIMPL;
 }
 
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetDropTarget(ITextServices *iface, IDropTarget **ppDropTarget)
-{
-   ITextServicesImpl *This = impl_from_ITextServices(iface);
-
-   FIXME("%p: STUB\n", This);
-   return E_NOTIMPL;
-}
-
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_OnTxPropertyBitsChange(ITextServices *iface, DWORD dwMask, DWORD dwBits)
-{
-   ITextServicesImpl *This = impl_from_ITextServices(iface);
-
-   FIXME("%p: STUB\n", This);
-   return E_NOTIMPL;
-}
-
-DECLSPEC_HIDDEN HRESULT WINAPI fnTextSrv_TxGetCachedSize(ITextServices *iface, DWORD *pdwWidth, DWORD *pdwHeight)
-{
-   ITextServicesImpl *This = impl_from_ITextServices(iface);
-
-   FIXME("%p: STUB\n", This);
-   return E_NOTIMPL;
-}
-
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSendMessage,20)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxDraw,52)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetHScroll,24)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetVScroll,24)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxSetCursor,40)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxQueryHitPoint,44)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInplaceActivate,8)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxInplaceDeactivate,4)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIActivate,4)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxUIDeactivate,4)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetText,8)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxSetText,8)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetCurTargetX,8)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetBaseLinePos,8)
-DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetNaturalSize,36)
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetDropTarget,8)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetDropTarget(ITextServices *iface, IDropTarget **ppDropTarget)
+{
+   ITextServicesImpl *This = impl_from_ITextServices(iface);
+
+   FIXME("%p: STUB\n", This);
+   return E_NOTIMPL;
+}
+
 DEFINE_THISCALL_WRAPPER(fnTextSrv_OnTxPropertyBitsChange,12)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_OnTxPropertyBitsChange(ITextServices *iface, DWORD dwMask, DWORD dwBits)
+{
+   ITextServicesImpl *This = impl_from_ITextServices(iface);
+
+   FIXME("%p: STUB\n", This);
+   return E_NOTIMPL;
+}
+
 DEFINE_THISCALL_WRAPPER(fnTextSrv_TxGetCachedSize,12)
+DECLSPEC_HIDDEN HRESULT __thiscall fnTextSrv_TxGetCachedSize(ITextServices *iface, DWORD *pdwWidth, DWORD *pdwHeight)
+{
+   ITextServicesImpl *This = impl_from_ITextServices(iface);
+
+   FIXME("%p: STUB\n", This);
+   return E_NOTIMPL;
+}
+
 
 static const ITextServicesVtbl textservices_vtbl =
 {

--- a/modules/rostests/winetests/riched20/txtsrv.c
+++ b/modules/rostests/winetests/riched20/txtsrv.c
@@ -48,7 +48,7 @@ static PCreateTextServices pCreateTextServices;
 
 /* Use a special table for x86 machines to convert the thiscall
  * calling convention.  This isn't needed on other platforms. */
-#if defined(__i386__) && !defined(__MINGW32__)
+#if  defined(__i386__) && !defined(__MINGW32__) && (!defined(_MSC_VER) || !defined(__clang__))
 static ITextServicesVtbl itextServicesStdcallVtbl;
 #define TXTSERV_VTABLE(This) (&itextServicesStdcallVtbl)
 #else /* __i386__ */
@@ -129,24 +129,21 @@ static ULONG WINAPI ITextHostImpl_Release(ITextHost *iface)
     }
 }
 
-static HDC WINAPI ITextHostImpl_TxGetDC(ITextHost *iface)
+static HDC __thiscall ITextHostImpl_TxGetDC(ITextHost *iface)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetDC(%p)\n", This);
     return NULL;
 }
 
-static INT WINAPI ITextHostImpl_TxReleaseDC(ITextHost *iface,
-                                            HDC hdc)
+static INT __thiscall ITextHostImpl_TxReleaseDC(ITextHost *iface, HDC hdc)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxReleaseDC(%p)\n", This);
     return 0;
 }
 
-static BOOL WINAPI ITextHostImpl_TxShowScrollBar(ITextHost *iface,
-                                                 INT fnBar,
-                                                 BOOL fShow)
+static BOOL __thiscall ITextHostImpl_TxShowScrollBar(ITextHost *iface, INT fnBar, BOOL fShow)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxShowScrollBar(%p, fnBar=%d, fShow=%d)\n",
@@ -154,9 +151,7 @@ static BOOL WINAPI ITextHostImpl_TxShowScrollBar(ITextHost *iface,
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxEnableScrollBar(ITextHost *iface,
-                                                   INT fuSBFlags,
-                                                   INT fuArrowflags)
+static BOOL __thiscall ITextHostImpl_TxEnableScrollBar(ITextHost *iface, INT fuSBFlags, INT fuArrowflags)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxEnableScrollBar(%p, fuSBFlags=%d, fuArrowflags=%d)\n",
@@ -164,11 +159,8 @@ static BOOL WINAPI ITextHostImpl_TxEnableScrollBar(ITextHost *iface,
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxSetScrollRange(ITextHost *iface,
-                                                  INT fnBar,
-                                                  LONG nMinPos,
-                                                  INT nMaxPos,
-                                                  BOOL fRedraw)
+static BOOL __thiscall ITextHostImpl_TxSetScrollRange(ITextHost *iface, INT fnBar, LONG nMinPos,
+                                                      INT nMaxPos, BOOL fRedraw)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetScrollRange(%p, fnBar=%d, nMinPos=%d, nMaxPos=%d, fRedraw=%d)\n",
@@ -176,10 +168,7 @@ static BOOL WINAPI ITextHostImpl_TxSetScrollRange(ITextHost *iface,
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxSetScrollPos(ITextHost *iface,
-                                                INT fnBar,
-                                                INT nPos,
-                                                BOOL fRedraw)
+static BOOL __thiscall ITextHostImpl_TxSetScrollPos(ITextHost *iface, INT fnBar, INT nPos, BOOL fRedraw)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetScrollPos(%p, fnBar=%d, nPos=%d, fRedraw=%d)\n",
@@ -187,25 +176,21 @@ static BOOL WINAPI ITextHostImpl_TxSetScrollPos(ITextHost *iface,
     return FALSE;
 }
 
-static void WINAPI ITextHostImpl_TxInvalidateRect(ITextHost *iface,
-                                                  LPCRECT prc,
-                                                  BOOL fMode)
+static void __thiscall ITextHostImpl_TxInvalidateRect(ITextHost *iface, LPCRECT prc, BOOL fMode)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxInvalidateRect(%p, prc=%p, fMode=%d)\n",
                This, prc, fMode);
 }
 
-static void WINAPI ITextHostImpl_TxViewChange(ITextHost *iface, BOOL fUpdate)
+static void __thiscall ITextHostImpl_TxViewChange(ITextHost *iface, BOOL fUpdate)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxViewChange(%p, fUpdate=%d)\n",
                This, fUpdate);
 }
 
-static BOOL WINAPI ITextHostImpl_TxCreateCaret(ITextHost *iface,
-                                               HBITMAP hbmp,
-                                               INT xWidth, INT yHeight)
+static BOOL __thiscall ITextHostImpl_TxCreateCaret(ITextHost *iface, HBITMAP hbmp, INT xWidth, INT yHeight)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxCreateCaret(%p, nbmp=%p, xWidth=%d, yHeight=%d)\n",
@@ -213,7 +198,7 @@ static BOOL WINAPI ITextHostImpl_TxCreateCaret(ITextHost *iface,
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fShow)
+static BOOL __thiscall ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fShow)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxShowCaret(%p, fShow=%d)\n",
@@ -221,16 +206,14 @@ static BOOL WINAPI ITextHostImpl_TxShowCaret(ITextHost *iface, BOOL fShow)
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxSetCaretPos(ITextHost *iface,
-                                               INT x, INT y)
+static BOOL __thiscall ITextHostImpl_TxSetCaretPos(ITextHost *iface, INT x, INT y)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetCaretPos(%p, x=%d, y=%d)\n", This, x, y);
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxSetTimer(ITextHost *iface,
-                                            UINT idTimer, UINT uTimeout)
+static BOOL __thiscall ITextHostImpl_TxSetTimer(ITextHost *iface, UINT idTimer, UINT uTimeout)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetTimer(%p, idTimer=%u, uTimeout=%u)\n",
@@ -238,136 +221,119 @@ static BOOL WINAPI ITextHostImpl_TxSetTimer(ITextHost *iface,
     return FALSE;
 }
 
-static void WINAPI ITextHostImpl_TxKillTimer(ITextHost *iface, UINT idTimer)
+static void __thiscall ITextHostImpl_TxKillTimer(ITextHost *iface, UINT idTimer)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxKillTimer(%p, idTimer=%u)\n", This, idTimer);
 }
 
-static void WINAPI ITextHostImpl_TxScrollWindowEx(ITextHost *iface,
-                                                  INT dx, INT dy,
-                                                  LPCRECT lprcScroll,
-                                                  LPCRECT lprcClip,
-                                                  HRGN hRgnUpdate,
-                                                  LPRECT lprcUpdate,
-                                                  UINT fuScroll)
+static void __thiscall ITextHostImpl_TxScrollWindowEx(ITextHost *iface, INT dx, INT dy, LPCRECT lprcScroll,
+                                                      LPCRECT lprcClip, HRGN hRgnUpdate, LPRECT lprcUpdate,
+                                                      UINT fuScroll)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxScrollWindowEx(%p, %d, %d, %p, %p, %p, %p, %d)\n",
               This, dx, dy, lprcScroll, lprcClip, hRgnUpdate, lprcUpdate, fuScroll);
 }
 
-static void WINAPI ITextHostImpl_TxSetCapture(ITextHost *iface, BOOL fCapture)
+static void __thiscall ITextHostImpl_TxSetCapture(ITextHost *iface, BOOL fCapture)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetCapture(%p, fCapture=%d)\n", This, fCapture);
 }
 
-static void WINAPI ITextHostImpl_TxSetFocus(ITextHost *iface)
+static void __thiscall ITextHostImpl_TxSetFocus(ITextHost *iface)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetFocus(%p)\n", This);
 }
 
-static void WINAPI ITextHostImpl_TxSetCursor(ITextHost *iface,
-                                             HCURSOR hcur,
-                                             BOOL fText)
+static void __thiscall ITextHostImpl_TxSetCursor(ITextHost *iface, HCURSOR hcur, BOOL fText)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxSetCursor(%p, hcur=%p, fText=%d)\n",
               This, hcur, fText);
 }
 
-static BOOL WINAPI ITextHostImpl_TxScreenToClient(ITextHost *iface,
-                                                  LPPOINT lppt)
+static BOOL __thiscall ITextHostImpl_TxScreenToClient(ITextHost *iface, LPPOINT lppt)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxScreenToClient(%p, lppt=%p)\n", This, lppt);
     return FALSE;
 }
 
-static BOOL WINAPI ITextHostImpl_TxClientToScreen(ITextHost *iface,
-                                                  LPPOINT lppt)
+static BOOL __thiscall ITextHostImpl_TxClientToScreen(ITextHost *iface, LPPOINT lppt)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxClientToScreen(%p, lppt=%p)\n", This, lppt);
     return FALSE;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxActivate(ITextHost *iface,
-                                               LONG *plOldState)
+static HRESULT __thiscall ITextHostImpl_TxActivate(ITextHost *iface, LONG *plOldState)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxActivate(%p, plOldState=%p)\n", This, plOldState);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxDeactivate(ITextHost *iface,
-                                                 LONG lNewState)
+static HRESULT __thiscall ITextHostImpl_TxDeactivate(ITextHost *iface, LONG lNewState)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxDeactivate(%p, lNewState=%d)\n", This, lNewState);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetClientRect(ITextHost *iface,
-                                                    LPRECT prc)
+static HRESULT __thiscall ITextHostImpl_TxGetClientRect(ITextHost *iface, LPRECT prc)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetClientRect(%p, prc=%p)\n", This, prc);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetViewInset(ITextHost *iface,
-                                                   LPRECT prc)
+static HRESULT __thiscall ITextHostImpl_TxGetViewInset(ITextHost *iface, LPRECT prc)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetViewInset(%p, prc=%p)\n", This, prc);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetCharFormat(ITextHost *iface,
-                                                    const CHARFORMATW **ppCF)
+static HRESULT __thiscall ITextHostImpl_TxGetCharFormat(ITextHost *iface, const CHARFORMATW **ppCF)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetCharFormat(%p, ppCF=%p)\n", This, ppCF);
-    return E_NOTIMPL;
+    *ppCF = (CHARFORMATW *)&This->char_format;
+    return S_OK;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetParaFormat(ITextHost *iface,
-                                                    const PARAFORMAT **ppPF)
+static HRESULT __thiscall ITextHostImpl_TxGetParaFormat(ITextHost *iface, const PARAFORMAT **ppPF)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetParaFormat(%p, ppPF=%p)\n", This, ppPF);
     return E_NOTIMPL;
 }
 
-static COLORREF WINAPI ITextHostImpl_TxGetSysColor(ITextHost *iface,
-                                                   int nIndex)
+static COLORREF __thiscall ITextHostImpl_TxGetSysColor(ITextHost *iface, int nIndex)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetSysColor(%p, nIndex=%d)\n", This, nIndex);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetBackStyle(ITextHost *iface,
-                                                   TXTBACKSTYLE *pStyle)
+static HRESULT __thiscall ITextHostImpl_TxGetBackStyle(ITextHost *iface, TXTBACKSTYLE *pStyle)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetBackStyle(%p, pStyle=%p)\n", This, pStyle);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetMaxLength(ITextHost *iface,
-                                                   DWORD *pLength)
+static HRESULT __thiscall ITextHostImpl_TxGetMaxLength(ITextHost *iface, DWORD *pLength)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetMaxLength(%p, pLength=%p)\n", This, pLength);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetScrollBars(ITextHost *iface,
-                                                    DWORD *pdwScrollBar)
+static HRESULT __thiscall ITextHostImpl_TxGetScrollBars(ITextHost *iface, DWORD *pdwScrollBar)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetScrollBars(%p, pdwScrollBar=%p)\n",
@@ -375,40 +341,35 @@ static HRESULT WINAPI ITextHostImpl_TxGetScrollBars(ITextHost *iface,
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetPasswordChar(ITextHost *iface,
-                                                      WCHAR *pch)
+static HRESULT __thiscall ITextHostImpl_TxGetPasswordChar(ITextHost *iface, WCHAR *pch)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetPasswordChar(%p, pch=%p)\n", This, pch);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetAcceleratorPos(ITextHost *iface,
-                                                        LONG *pch)
+static HRESULT __thiscall ITextHostImpl_TxGetAcceleratorPos(ITextHost *iface, LONG *pch)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetAcceleratorPos(%p, pch=%p)\n", This, pch);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxGetExtent(ITextHost *iface,
-                                                LPSIZEL lpExtent)
+static HRESULT __thiscall ITextHostImpl_TxGetExtent(ITextHost *iface, LPSIZEL lpExtent)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetExtent(%p, lpExtent=%p)\n", This, lpExtent);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_OnTxCharFormatChange(ITextHost *iface,
-                                                         const CHARFORMATW *pcf)
+static HRESULT __thiscall ITextHostImpl_OnTxCharFormatChange(ITextHost *iface, const CHARFORMATW *pcf)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to OnTxCharFormatChange(%p, pcf=%p)\n", This, pcf);
     return E_NOTIMPL;
 }
 
-static HRESULT WINAPI ITextHostImpl_OnTxParaFormatChange(ITextHost *iface,
-                                                         const PARAFORMAT *ppf)
+static HRESULT __thiscall ITextHostImpl_OnTxParaFormatChange(ITextHost *iface, const PARAFORMAT *ppf)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to OnTxParaFormatChange(%p, ppf=%p)\n", This, ppf);
@@ -417,9 +378,7 @@ static HRESULT WINAPI ITextHostImpl_OnTxParaFormatChange(ITextHost *iface,
 
 /* This must return S_OK for the native ITextServices object to
    initialize. */
-static HRESULT WINAPI ITextHostImpl_TxGetPropertyBits(ITextHost *iface,
-                                                      DWORD dwMask,
-                                                      DWORD *pdwBits)
+static HRESULT __thiscall ITextHostImpl_TxGetPropertyBits(ITextHost *iface, DWORD dwMask, DWORD *pdwBits)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetPropertyBits(%p, dwMask=0x%08x, pdwBits=%p)\n",
@@ -428,22 +387,21 @@ static HRESULT WINAPI ITextHostImpl_TxGetPropertyBits(ITextHost *iface,
     return S_OK;
 }
 
-static HRESULT WINAPI ITextHostImpl_TxNotify(ITextHost *iface, DWORD iNotify,
-                                             void *pv)
+static HRESULT __thiscall ITextHostImpl_TxNotify(ITextHost *iface, DWORD iNotify, void *pv)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxNotify(%p, iNotify=%d, pv=%p)\n", This, iNotify, pv);
     return E_NOTIMPL;
 }
 
-static HIMC WINAPI ITextHostImpl_TxImmGetContext(ITextHost *iface)
+static HIMC __thiscall ITextHostImpl_TxImmGetContext(ITextHost *iface)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxImmGetContext(%p)\n", This);
     return 0;
 }
 
-static void WINAPI ITextHostImpl_TxImmReleaseContext(ITextHost *iface, HIMC himc)
+static void __thiscall ITextHostImpl_TxImmReleaseContext(ITextHost *iface, HIMC himc)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxImmReleaseContext(%p, himc=%p)\n", This, himc);
@@ -452,8 +410,7 @@ static void WINAPI ITextHostImpl_TxImmReleaseContext(ITextHost *iface, HIMC himc
 /* This function must set the variable pointed to by *lSelBarWidth.
    Otherwise an uninitialized value will be used to calculate
    positions and sizes even if E_NOTIMPL is returned. */
-static HRESULT WINAPI ITextHostImpl_TxGetSelectionBarWidth(ITextHost *iface,
-                                                           LONG *lSelBarWidth)
+static HRESULT __thiscall ITextHostImpl_TxGetSelectionBarWidth(ITextHost *iface, LONG *lSelBarWidth)
 {
     ITextHostTestImpl *This = impl_from_ITextHost(iface);
     TRACECALL("Call to TxGetSelectionBarWidth(%p, lSelBarWidth=%p)\n",
@@ -535,7 +492,7 @@ typedef struct
 
 static void setup_thiscall_wrappers(void)
 {
-#if defined(__i386__) && !defined(__MINGW32__)
+#if defined(__i386__) && !defined(__MINGW32__) && (!defined(_MSC_VER) || !defined(__clang__))
     void** pVtable;
     void** pVtableEnd;
     THISCALL_TO_STDCALL_THUNK *thunk;
@@ -1035,10 +992,10 @@ static void test_TxGetScroll(void)
         return;
 
     ret = ITextServices_TxGetHScroll(txtserv, NULL, NULL, NULL, NULL, NULL);
-    ok(ret == S_OK, "ITextSerHices_GetVScroll failed: 0x%08x.\n", ret);
+    ok(ret == S_OK, "ITextServices_TxGetHScroll failed: 0x%08x.\n", ret);
 
     ret = ITextServices_TxGetVScroll(txtserv, NULL, NULL, NULL, NULL, NULL);
-    ok(ret == S_OK, "ITextServices_GetVScroll failed: 0x%08x.\n", ret);
+    ok(ret == S_OK, "ITextServices_TxGetVScroll failed: 0x%08x.\n", ret);
 
     ITextServices_Release(txtserv);
     ITextHost_Release(host);

--- a/sdk/include/psdk/textserv.h
+++ b/sdk/include/psdk/textserv.h
@@ -23,6 +23,12 @@
 extern "C" {
 #endif
 
+#ifdef __REACTOS__
+#ifdef _MSC_VER
+#define __thiscall __stdcall
+#endif
+#endif
+
 #ifdef __cplusplus
 #define THISCALLMETHOD_(type,method)  virtual type __thiscall method
 #else

--- a/sdk/include/psdk/textserv.h
+++ b/sdk/include/psdk/textserv.h
@@ -23,9 +23,14 @@
 extern "C" {
 #endif
 
-DEFINE_GUID(IID_ITextServices,0x8d33f740,0xcf58,0x11ce,0xa8,0x9d,0x00,0xaa,0x00,0x6c,0xad,0xc5);
-DEFINE_GUID(IID_ITextHost,    0xc5bdd8d0,0xd26e,0x11ce,0xa8,0x9e,0x00,0xaa,0x00,0x6c,0xad,0xc5);
-DEFINE_GUID(IID_ITextHost2,   0xc5bdd8d0,0xd26e,0x11ce,0xa8,0x9e,0x00,0xaa,0x00,0x6c,0xad,0xc5);
+#ifdef __cplusplus
+#define THISCALLMETHOD_(type,method)  virtual type __thiscall method
+#else
+#define THISCALLMETHOD_(type,method)  type (__thiscall *method)
+#endif
+
+EXTERN_C const IID IID_ITextServices;
+EXTERN_C const IID IID_ITextHost;
 
 /*****************************************************************************
  * ITextServices interface
@@ -44,10 +49,10 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
 
     /*** ITextServices methods ***/
 
-    STDMETHOD(TxSendMessage)( THIS_
+    THISCALLMETHOD_(HRESULT,TxSendMessage)( THIS_
         UINT msg, WPARAM wparam, LPARAM lparam, LRESULT* plresult) PURE;
 
-    STDMETHOD(TxDraw)( THIS_
+    THISCALLMETHOD_(HRESULT,TxDraw)( THIS_
         DWORD dwDrawAspect,
         LONG lindex,
         void* pvAspect,
@@ -61,21 +66,21 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
         DWORD dwContinue,
         LONG lViewId) PURE;
 
-    STDMETHOD(TxGetHScroll)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetHScroll)( THIS_
         LONG* plMin,
         LONG* plMax,
         LONG* plPos,
         LONG* plPage,
         BOOL* pfEnabled) PURE;
 
-    STDMETHOD(TxGetVScroll)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetVScroll)( THIS_
         LONG* plMin,
         LONG* plMax,
         LONG* plPos,
         LONG* plPage,
         BOOL* pfEnabled) PURE;
 
-    STDMETHOD(OnTxSetCursor)( THIS_
+    THISCALLMETHOD_(HRESULT,OnTxSetCursor)( THIS_
         DWORD dwDrawAspect,
         LONG lindex,
         void* pvAspect,
@@ -86,7 +91,7 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
         INT x,
         INT y) PURE;
 
-    STDMETHOD(TxQueryHitPoint)( THIS_
+    THISCALLMETHOD_(HRESULT,TxQueryHitPoint)( THIS_
         DWORD dwDrawAspect,
         LONG lindex,
         void* pvAspect,
@@ -98,28 +103,28 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
         INT y,
         DWORD* pHitResult) PURE;
 
-    STDMETHOD(OnTxInplaceActivate)( THIS_
+    THISCALLMETHOD_(HRESULT,OnTxInplaceActivate)( THIS_
         LPCRECT prcClient) PURE;
 
-    STDMETHOD(OnTxInplaceDeactivate)( THIS ) PURE;
+    THISCALLMETHOD_(HRESULT,OnTxInplaceDeactivate)( THIS ) PURE;
 
-    STDMETHOD(OnTxUIActivate)( THIS ) PURE;
+    THISCALLMETHOD_(HRESULT,OnTxUIActivate)( THIS ) PURE;
 
-    STDMETHOD(OnTxUIDeactivate)( THIS ) PURE;
+    THISCALLMETHOD_(HRESULT,OnTxUIDeactivate)( THIS ) PURE;
 
-    STDMETHOD(TxGetText)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetText)( THIS_
         BSTR* pbstrText) PURE;
 
-    STDMETHOD(TxSetText)( THIS_
+    THISCALLMETHOD_(HRESULT,TxSetText)( THIS_
         LPCWSTR pszText) PURE;
 
-    STDMETHOD(TxGetCurrentTargetX)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetCurTargetX)( THIS_
         LONG* x) PURE;
 
-    STDMETHOD(TxGetBaseLinePos)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetBaseLinePos)( THIS_
         LONG* x) PURE;
 
-    STDMETHOD(TxGetNaturalSize)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetNaturalSize)( THIS_
         DWORD dwAspect,
         HDC hdcDraw,
         HDC hicTargetDev,
@@ -129,18 +134,19 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
         LONG* pwidth,
         LONG* pheight) PURE;
 
-    STDMETHOD(TxGetDropTarget)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetDropTarget)( THIS_
         IDropTarget** ppDropTarget) PURE;
 
-    STDMETHOD(OnTxPropertyBitsChange)( THIS_
+    THISCALLMETHOD_(HRESULT,OnTxPropertyBitsChange)( THIS_
         DWORD dwMask,
         DWORD dwBits) PURE;
 
-    STDMETHOD(TxGetCachedSize)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetCachedSize)( THIS_
         DWORD* pdwWidth,
         DWORD* pdwHeight) PURE;
 
 };
+#undef INTERFACE
 
 #ifdef COBJMACROS
 /*** IUnknown methods ***/
@@ -148,8 +154,6 @@ DECLARE_INTERFACE_(ITextServices,IUnknown)
 #define ITextServices_AddRef(p) (p)->lpVtbl->AddRef(p)
 #define ITextServices_Release(p) (p)->lpVtbl->Release(p)
 #endif
-
-#undef INTERFACE
 
 typedef enum _TXTBACKSTYLE {
     TXTBACK_TRANSPARENT = 0,
@@ -212,58 +216,58 @@ DECLARE_INTERFACE_(ITextHost,IUnknown)
     STDMETHOD_(ULONG,Release)(THIS) PURE;
 
     /*** ITextHost methods ***/
-    STDMETHOD_(HDC,TxGetDC)( THIS
+    THISCALLMETHOD_(HDC,TxGetDC)( THIS
         ) PURE;
 
-    STDMETHOD_(INT,TxReleaseDC)( THIS_
+    THISCALLMETHOD_(INT,TxReleaseDC)( THIS_
         HDC hdc) PURE;
 
-    STDMETHOD_(BOOL,TxShowScrollBar)( THIS_
+    THISCALLMETHOD_(BOOL,TxShowScrollBar)( THIS_
         INT fnBar,
         BOOL fShow) PURE;
 
-    STDMETHOD_(BOOL,TxEnableScrollBar)( THIS_
+    THISCALLMETHOD_(BOOL,TxEnableScrollBar)( THIS_
         INT fuSBFlags,
         INT fuArrowflags) PURE;
 
-    STDMETHOD_(BOOL,TxSetScrollRange)( THIS_
+    THISCALLMETHOD_(BOOL,TxSetScrollRange)( THIS_
         INT fnBar,
         LONG nMinPos,
         INT nMaxPos,
         BOOL fRedraw) PURE;
 
-    STDMETHOD_(BOOL,TxSetScrollPos)( THIS_
+    THISCALLMETHOD_(BOOL,TxSetScrollPos)( THIS_
         INT fnBar,
         INT nPos,
         BOOL fRedraw) PURE;
 
-    STDMETHOD_(void,TxInvalidateRect)( THIS_
+    THISCALLMETHOD_(void,TxInvalidateRect)( THIS_
         LPCRECT prc,
         BOOL fMode) PURE;
 
-    STDMETHOD_(void,TxViewChange)( THIS_
+    THISCALLMETHOD_(void,TxViewChange)( THIS_
         BOOL fUpdate) PURE;
 
-    STDMETHOD_(BOOL,TxCreateCaret)( THIS_
+    THISCALLMETHOD_(BOOL,TxCreateCaret)( THIS_
         HBITMAP hbmp,
         INT xWidth,
         INT yHeight) PURE;
 
-    STDMETHOD_(BOOL,TxShowCaret)( THIS_
+    THISCALLMETHOD_(BOOL,TxShowCaret)( THIS_
         BOOL fShow) PURE;
 
-    STDMETHOD_(BOOL,TxSetCaretPos)( THIS_
+    THISCALLMETHOD_(BOOL,TxSetCaretPos)( THIS_
         INT x,
         INT y) PURE;
 
-    STDMETHOD_(BOOL,TxSetTimer)( THIS_
+    THISCALLMETHOD_(BOOL,TxSetTimer)( THIS_
         UINT idTimer,
         UINT uTimeout) PURE;
 
-    STDMETHOD_(void,TxKillTimer)( THIS_
+    THISCALLMETHOD_(void,TxKillTimer)( THIS_
         UINT idTimer) PURE;
 
-    STDMETHOD_(void,TxScrollWindowEx)( THIS_
+    THISCALLMETHOD_(void,TxScrollWindowEx)( THIS_
         INT dx,
         INT dy,
         LPCRECT lprcScroll,
@@ -272,85 +276,86 @@ DECLARE_INTERFACE_(ITextHost,IUnknown)
         LPRECT lprcUpdate,
         UINT fuScroll) PURE;
 
-    STDMETHOD_(void,TxSetCapture)( THIS_
+    THISCALLMETHOD_(void,TxSetCapture)( THIS_
         BOOL fCapture) PURE;
 
-    STDMETHOD_(void,TxSetFocus)( THIS
+    THISCALLMETHOD_(void,TxSetFocus)( THIS
         ) PURE;
 
-    STDMETHOD_(void,TxSetCursor)( THIS_
+    THISCALLMETHOD_(void,TxSetCursor)( THIS_
         HCURSOR hcur,
         BOOL fText) PURE;
 
-    STDMETHOD_(BOOL,TxScreenToClient)( THIS_
+    THISCALLMETHOD_(BOOL,TxScreenToClient)( THIS_
         LPPOINT lppt) PURE;
 
-    STDMETHOD_(BOOL,TxClientToScreen)( THIS_
+    THISCALLMETHOD_(BOOL,TxClientToScreen)( THIS_
         LPPOINT lppt) PURE;
 
-    STDMETHOD(TxActivate)( THIS_
+    THISCALLMETHOD_(HRESULT,TxActivate)( THIS_
         LONG* plOldState) PURE;
 
-    STDMETHOD(TxDeactivate)( THIS_
+    THISCALLMETHOD_(HRESULT,TxDeactivate)( THIS_
         LONG lNewState) PURE;
 
-    STDMETHOD(TxGetClientRect)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetClientRect)( THIS_
         LPRECT prc) PURE;
 
-    STDMETHOD(TxGetViewInset)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetViewInset)( THIS_
         LPRECT prc) PURE;
 
-    STDMETHOD(TxGetCharFormat)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetCharFormat)( THIS_
         const CHARFORMATW** ppCF) PURE;
 
-    STDMETHOD(TxGetParaFormat)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetParaFormat)( THIS_
         const PARAFORMAT** ppPF) PURE;
 
-    STDMETHOD_(COLORREF,TxGetSysColor)( THIS_
+    THISCALLMETHOD_(COLORREF,TxGetSysColor)( THIS_
         int nIndex) PURE;
 
-    STDMETHOD(TxGetBackStyle)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetBackStyle)( THIS_
         TXTBACKSTYLE* pStyle) PURE;
 
-    STDMETHOD(TxGetMaxLength)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetMaxLength)( THIS_
         DWORD* plength) PURE;
 
-    STDMETHOD(TxGetScrollBars)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetScrollBars)( THIS_
         DWORD* pdwScrollBar) PURE;
 
-    STDMETHOD(TxGetPasswordChar)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetPasswordChar)( THIS_
         WCHAR* pch) PURE;
 
-    STDMETHOD(TxGetAcceleratorPos)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetAcceleratorPos)( THIS_
         LONG* pch) PURE;
 
-    STDMETHOD(TxGetExtent)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetExtent)( THIS_
         LPSIZEL lpExtent) PURE;
 
-    STDMETHOD(OnTxCharFormatChange)( THIS_
+    THISCALLMETHOD_(HRESULT,OnTxCharFormatChange)( THIS_
         const CHARFORMATW* pcf) PURE;
 
-    STDMETHOD(OnTxParaFormatChange)( THIS_
+    THISCALLMETHOD_(HRESULT,OnTxParaFormatChange)( THIS_
         const PARAFORMAT* ppf) PURE;
 
-    STDMETHOD(TxGetPropertyBits)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetPropertyBits)( THIS_
         DWORD dwMask,
         DWORD* pdwBits) PURE;
 
-    STDMETHOD(TxNotify)( THIS_
+    THISCALLMETHOD_(HRESULT,TxNotify)( THIS_
         DWORD iNotify,
         void* pv) PURE;
 
-    STDMETHOD_(HIMC,TxImmGetContext)( THIS
+    THISCALLMETHOD_(HIMC,TxImmGetContext)( THIS
         ) PURE;
 
-    STDMETHOD_(void,TxImmReleaseContext)( THIS_
+    THISCALLMETHOD_(void,TxImmReleaseContext)( THIS_
         HIMC himc) PURE;
 
-    STDMETHOD(TxGetSelectionBarWidth)( THIS_
+    THISCALLMETHOD_(HRESULT,TxGetSelectionBarWidth)( THIS_
         LONG* lSelBarWidth) PURE;
 
 };
+#undef INTERFACE
 
 #ifdef COBJMACROS
 /*** IUnknown methods ***/
@@ -358,8 +363,6 @@ DECLARE_INTERFACE_(ITextHost,IUnknown)
 #define ITextHost_AddRef(p) (p)->lpVtbl->AddRef(p)
 #define ITextHost_Release(p) (p)->lpVtbl->Release(p)
 #endif
-
-#undef INTERFACE
 
 HRESULT WINAPI CreateTextServices(IUnknown*,ITextHost*,IUnknown**);
 


### PR DESCRIPTION
## Purpose

Note:  See TODO below!  This PR is not ready to merge as it does not compile in MSVC!

This PR fixes an issue introduced with a [wine sync of riched20](https://github.com/reactos/reactos/commit/661b8a2a05f70f5d2eddc0fdf089f003e84c79bc).  This wine sync caused a regression in mail.ru as outlined in the below Jira ticket.  Currently, the code will throw an unhandled exception due to inconsistent calling conventions.  The Jira ticket has plenty of extra information as I traced down this issue with the help of ThFabba.

JIRA issue: [CORE-17021](https://jira.reactos.org/browse/CORE-17021)

## Proposed changes

Add the missing wine sync patch while retaining special REACTOS flags.  After this patch is applied then mail.ru starts working again!

![mailru_working](https://user-images.githubusercontent.com/3923687/81641262-7183c680-93d5-11ea-96e1-7c749ed3829f.png)

## TODO

This code does not currently compile is MSVC, and I do not know enough about that build system at this time to fix the issue.  I'm hoping this PR will encourage someone else to either point me in the correct direction, or to address the issue.