### PR TITLE
[SHELL32] Don't hardcode C: drive again

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -192,7 +192,7 @@ CRecycleBinEnum::~CRecycleBinEnum()
 HRESULT WINAPI CRecycleBinEnum::Initialize(DWORD dwFlags)
 {
     WCHAR szDrive[8];
-    if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive)))
+    if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
         PathAddBackslashW(szDrive);
     else
         StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
@@ -367,7 +367,7 @@ HRESULT WINAPI CRecycleBinItemContextMenu::InvokeCommand(LPCMINVOKECOMMANDINFO l
         Context.pFileDetails = _ILGetRecycleStruct(apidl);
         Context.bFound = FALSE;
 
-        if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive)))
+        if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
             PathAddBackslashW(szDrive);
         else
             StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
@@ -823,14 +823,18 @@ HRESULT WINAPI CRecycleBin::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     HRESULT hr;
     LPSHELLBROWSER lpSB;
     IShellView * lpSV = NULL;
+    WCHAR szDrive[8];
 
     TRACE("%p %p verb %p\n", this, lpcmi, lpcmi->lpVerb);
 
     if (LOWORD(lpcmi->lpVerb) == iIdEmpty)
     {
-        // FIXME
-        // path & flags
-        hr = SHEmptyRecycleBinW(lpcmi->hwnd, L"C:\\", 0);
+        if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+            PathAddBackslashW(szDrive);
+        else
+            StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
+
+        hr = SHEmptyRecycleBinW(lpcmi->hwnd, szDrive, 0);
         TRACE("result %x\n", hr);
         if (hr != S_OK)
             return hr;

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -193,8 +193,10 @@ HRESULT WINAPI CRecycleBinEnum::Initialize(DWORD dwFlags)
 {
     WCHAR szDrive[8];
     if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+    {
+        ERR("GetEnvironmentVariableW failed\n");
         return E_FAIL;
-
+    }
     PathAddBackslashW(szDrive);
 
     if (dwFlags & SHCONTF_NONFOLDERS)
@@ -368,8 +370,10 @@ HRESULT WINAPI CRecycleBinItemContextMenu::InvokeCommand(LPCMINVOKECOMMANDINFO l
         Context.bFound = FALSE;
 
         if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+        {
+            ERR("GetEnvironmentVariableW failed\n");
             return E_FAIL;
-
+        }
         PathAddBackslashW(szDrive);
 
         EnumerateRecycleBinW(szDrive, CBSearchRecycleBin, (PVOID)&Context);
@@ -830,8 +834,10 @@ HRESULT WINAPI CRecycleBin::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     if (LOWORD(lpcmi->lpVerb) == iIdEmpty)
     {
         if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+        {
+            ERR("GetEnvironmentVariableW failed\n");
             return E_FAIL;
-
+        }
         PathAddBackslashW(szDrive);
 
         hr = SHEmptyRecycleBinW(lpcmi->hwnd, szDrive, 0);

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -192,10 +192,10 @@ CRecycleBinEnum::~CRecycleBinEnum()
 HRESULT WINAPI CRecycleBinEnum::Initialize(DWORD dwFlags)
 {
     WCHAR szDrive[8];
-    if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
-        PathAddBackslashW(szDrive);
-    else
-        StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
+    if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+        return E_FAIL;
+
+    PathAddBackslashW(szDrive);
 
     if (dwFlags & SHCONTF_NONFOLDERS)
     {
@@ -367,10 +367,10 @@ HRESULT WINAPI CRecycleBinItemContextMenu::InvokeCommand(LPCMINVOKECOMMANDINFO l
         Context.pFileDetails = _ILGetRecycleStruct(apidl);
         Context.bFound = FALSE;
 
-        if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
-            PathAddBackslashW(szDrive);
-        else
-            StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
+        if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+            return E_FAIL;
+
+        PathAddBackslashW(szDrive);
 
         EnumerateRecycleBinW(szDrive, CBSearchRecycleBin, (PVOID)&Context);
         if (!Context.bFound)
@@ -829,10 +829,10 @@ HRESULT WINAPI CRecycleBin::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
 
     if (LOWORD(lpcmi->lpVerb) == iIdEmpty)
     {
-        if (GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
-            PathAddBackslashW(szDrive);
-        else
-            StringCbCopyW(szDrive, sizeof(szDrive), L"C:\\");
+        if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
+            return E_FAIL;
+
+        PathAddBackslashW(szDrive);
 
         hr = SHEmptyRecycleBinW(lpcmi->hwnd, szDrive, 0);
         TRACE("result %x\n", hr);


### PR DESCRIPTION
## Purpose

- Avoid buffer overrun.
- Don't hardcode C: drive.

JIRA issue: [CORE-13235](https://jira.reactos.org/browse/CORE-13235)
