### PR TITLE
[NTDLL_APITEST] Add NtQueryInformationThread testcase

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND SOURCE
     NtProtectVirtualMemory.c
     NtQueryInformationFile.c
     NtQueryInformationProcess.c
+    NtQueryInformationThread.c
     NtQueryKey.c
     NtQuerySystemEnvironmentValue.c
     NtQuerySystemInformation.c

--- a/modules/rostests/apitests/ntdll/NtQueryInformationThread.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationThread.c
@@ -1,0 +1,106 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtQueryInformationThread API
+ * COPYRIGHT:       Copyright 2020 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+
+static
+void
+Test_ThreadBasicInformationClass(void)
+{
+    NTSTATUS Status;
+    PTHREAD_BASIC_INFORMATION ThreadInfoBasic;
+    ULONG ReturnedLength;
+
+    ThreadInfoBasic = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(THREAD_BASIC_INFORMATION));
+    if (!ThreadInfoBasic)
+    {
+        skip("Failed to allocate memory for THREAD_BASIC_INFORMATION!\n");
+        return;
+    }
+
+    /* Everything is NULL */
+    Status = NtQueryInformationThread(NULL,
+                                      ThreadBasicInformation,
+                                      NULL,
+                                      0,
+                                      NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Don't give a valid thread handle */
+    Status = NtQueryInformationThread(NULL,
+                                      ThreadBasicInformation,
+                                      ThreadInfoBasic,
+                                      sizeof(THREAD_BASIC_INFORMATION),
+                                      NULL);
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* The information length is incorrect */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      ThreadInfoBasic,
+                                      0,
+                                      NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Don't query anything from the function */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      NULL,
+                                      sizeof(THREAD_BASIC_INFORMATION),
+                                      NULL);
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* The buffer is misaligned and length information is wrong */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      (PVOID)1,
+                                      0,
+                                      NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      (PVOID)1,
+                                      sizeof(THREAD_BASIC_INFORMATION),
+                                      NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned, try with an alignment size of 2 */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      (PVOID)2,
+                                      sizeof(THREAD_BASIC_INFORMATION),
+                                      NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Query the basic information we need from the thread */
+    Status = NtQueryInformationThread(GetCurrentThread(),
+                                      ThreadBasicInformation,
+                                      ThreadInfoBasic,
+                                      sizeof(THREAD_BASIC_INFORMATION),
+                                      &ReturnedLength);
+    ok_hex(Status, STATUS_SUCCESS);
+    ok(ReturnedLength != 0, "The size of the buffer pointed by ThreadInformation shouldn't be 0!\n");
+
+    /* Output the thread basic information details */
+    trace("ReturnedLength = %lu\n", ReturnedLength);
+    trace("ThreadInfoBasic->ExitStatus = 0x%08lx\n", ThreadInfoBasic->ExitStatus);
+    trace("ThreadInfoBasic->TebBaseAddress = %p\n", ThreadInfoBasic->TebBaseAddress);
+    trace("ThreadInfoBasic->ClientId.UniqueProcess = %p\n", ThreadInfoBasic->ClientId.UniqueProcess);
+    trace("ThreadInfoBasic->ClientId.UniqueThread = %p\n", ThreadInfoBasic->ClientId.UniqueThread);
+    trace("ThreadInfoBasic->AffinityMask = %lu\n", ThreadInfoBasic->AffinityMask);
+    trace("ThreadInfoBasic->Priority = %li\n", ThreadInfoBasic->Priority);
+    trace("ThreadInfoBasic->BasePriority = %li\n", ThreadInfoBasic->BasePriority);
+
+    HeapFree(GetProcessHeap(), 0, ThreadInfoBasic);
+}
+
+START_TEST(NtQueryInformationThread)
+{
+    Test_ThreadBasicInformationClass();
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -24,6 +24,7 @@ extern void func_NtOpenThreadToken(void);
 extern void func_NtProtectVirtualMemory(void);
 extern void func_NtQueryInformationFile(void);
 extern void func_NtQueryInformationProcess(void);
+extern void func_NtQueryInformationThread(void);
 extern void func_NtQueryKey(void);
 extern void func_NtQuerySystemEnvironmentValue(void);
 extern void func_NtQuerySystemInformation(void);
@@ -96,6 +97,7 @@ const struct test winetest_testlist[] =
     { "NtProtectVirtualMemory",         func_NtProtectVirtualMemory },
     { "NtQueryInformationFile",         func_NtQueryInformationFile },
     { "NtQueryInformationProcess",      func_NtQueryInformationProcess },
+    { "NtQueryInformationThread",       func_NtQueryInformationThread },
     { "NtQueryKey",                     func_NtQueryKey },
     { "NtQuerySystemEnvironmentValue",  func_NtQuerySystemEnvironmentValue },
     { "NtQuerySystemInformation",       func_NtQuerySystemInformation },


### PR DESCRIPTION
This is the initial implementation of a testcase unit for `NtQueryInformationThread`. It can be expanded later on.
**Windows XP**
![Capture](https://user-images.githubusercontent.com/34916900/81847369-cbaa9600-9553-11ea-8aee-0b19970d20ff.PNG)
**Windows Server 2003**
![Capture2](https://user-images.githubusercontent.com/34916900/81847430-df55fc80-9553-11ea-9889-157b04c34511.PNG)
**ReactOS**
![Capture6](https://user-images.githubusercontent.com/34916900/81847438-e41ab080-9553-11ea-84f5-f2eeb41b4742.PNG)