### PR TITLE
[NTDLL_APITEST] Add NtSetInformationThread testcase

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -35,6 +35,7 @@ list(APPEND SOURCE
     NtSaveKey.c
     NtSetInformationFile.c
     NtSetInformationProcess.c
+    NtSetInformationThread.c
     NtSetValueKey.c
     NtSetVolumeInformationFile.c
     NtUnloadDriver.c

--- a/modules/rostests/apitests/ntdll/NtSetInformationThread.c
+++ b/modules/rostests/apitests/ntdll/NtSetInformationThread.c
@@ -1,0 +1,100 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtSetInformationThread API
+ * COPYRIGHT:       Copyright 2020 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+
+static
+void
+Test_ThreadPriorityClass(void)
+{
+    NTSTATUS Status;
+    KPRIORITY *Priority;
+
+    Priority = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(KPRIORITY));
+    if (Priority == NULL)
+    {
+        skip("Failed to allocate memory for thread priority variable!\n");
+        return;
+    }
+
+    /* Assign a priority */
+    *Priority = 11;
+
+    /* Everything is NULL */
+    Status = NtSetInformationThread(NULL,
+                                    ThreadPriority,
+                                    NULL,
+                                    0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Give an invalid thread handle */
+    Status = NtSetInformationThread(NULL,
+                                    ThreadPriority,
+                                    Priority,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* Don't set any priority to the thread */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    NULL,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+
+    /* The information length is incorrect */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    Priority,
+                                    0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned and information length is incorrect */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    (PVOID)1,
+                                    0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    (PVOID)1,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    (PVOID)2,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* Set the priority to the current thread */
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    Priority,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_SUCCESS);
+
+    /*
+     * Set the priority as LOW_REALTIME_PRIORITY,
+     * we don't have privileges to do so.
+    */
+    *Priority = LOW_REALTIME_PRIORITY;
+    Status = NtSetInformationThread(GetCurrentThread(),
+                                    ThreadPriority,
+                                    Priority,
+                                    sizeof(KPRIORITY));
+    ok_hex(Status, STATUS_PRIVILEGE_NOT_HELD);
+
+    HeapFree(GetProcessHeap(), 0, Priority);
+}
+
+START_TEST(NtSetInformationThread)
+{
+    Test_ThreadPriorityClass();
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -33,6 +33,7 @@ extern void func_NtReadFile(void);
 extern void func_NtSaveKey(void);
 extern void func_NtSetInformationFile(void);
 extern void func_NtSetInformationProcess(void);
+extern void func_NtSetInformationThread(void);
 extern void func_NtSetValueKey(void);
 extern void func_NtSetVolumeInformationFile(void);
 extern void func_NtSystemInformation(void);
@@ -106,6 +107,7 @@ const struct test winetest_testlist[] =
     { "NtSaveKey",                      func_NtSaveKey},
     { "NtSetInformationFile",           func_NtSetInformationFile },
     { "NtSetInformationProcess",        func_NtSetInformationProcess },
+    { "NtSetInformationThread",         func_NtSetInformationThread },
     { "NtSetValueKey",                  func_NtSetValueKey},
     { "NtSetVolumeInformationFile",     func_NtSetVolumeInformationFile },
     { "NtSystemInformation",            func_NtSystemInformation },


### PR DESCRIPTION
It seems like both XP and Server 2003 do privilege probe checks when setting a base priority to a thread whereas ReactOS doesn't. I've to fix that later.
**Windows XP**
![Capture](https://user-images.githubusercontent.com/34916900/82066044-33d1b700-96cf-11ea-99bc-cb7491344cd6.PNG)
**Windows Server 2003**
![Capture4](https://user-images.githubusercontent.com/34916900/82066095-43510000-96cf-11ea-84c9-a28ba20e6e9c.PNG)
**ReactOS**
![Capture2](https://user-images.githubusercontent.com/34916900/82066111-48ae4a80-96cf-11ea-88ea-05760f7b68e0.PNG)