### PR TITLE
[HOST-TOOLS] Fix the build from IDE for visual studio 2019 CE

### DIFF
--- a/sdk/tools/cabman/cabinet.h
+++ b/sdk/tools/cabman/cabinet.h
@@ -9,6 +9,7 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #include <intrin.h>
     #include <windows.h>
 #else
     #include <typedefs.h>

--- a/sdk/tools/hhpcomp/utils.cpp
+++ b/sdk/tools/hhpcomp/utils.cpp
@@ -23,6 +23,7 @@
 
 #if defined(_WIN32)
     #define WIN32_LEAN_AND_MEAN
+    #include <intrin.h>
     #include <windows.h>  // for GetFullPathNameA 
 #else
     #include <unistd.h>


### PR DESCRIPTION
Without this, I would hit fun errors like:

```
1>C:\Program Files (x86)\Windows Kits\8.1\Include\um\winnt.h(17792,5): error C3861: '__stosb': identifier not found (compiling source file R:\src\wip\sdk\tools\cabman\mszip.cxx) [R:\build\wip\devenv_2019\host-tools\sdk\tools\cabman\cabman.vcxproj]
```