### PR TITLE
[SHLWAPI] Some functions are NT5.2 only. CORE-9708

### DIFF
--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -559,11 +559,11 @@
 559 stub -noname SHGetSignatureInfo
 560 stdcall -stub -noname SHWindowsPolicyGetValue(ptr ptr ptr)
 561 stub -noname AssocGetUrlAction
-562 stub -noname SHGetPrivateProfileInt
-563 stdcall -stub -noname SHGetPrivateProfileSection(wstr ptr long ptr)
-564 stub -noname SHGetPrivateProfileSectionNames
-565 stub -noname SHGetPrivateProfileString
-566 stub -noname SHGetPrivateProfileStruct
+562 stub -noname -version=0x502 SHGetPrivateProfileInt
+563 stdcall -stub -noname -version=0x502 SHGetPrivateProfileSection(wstr ptr long ptr)
+564 stub -noname -version=0x502 SHGetPrivateProfileSectionNames
+565 stub -noname -version=0x502 SHGetPrivateProfileString
+566 stub -noname -version=0x502 SHGetPrivateProfileStruct
 567 stdcall AssocQueryStringByKeyW(long long ptr wstr ptr ptr)
 568 stdcall AssocQueryStringW(long long wstr wstr ptr ptr)
 569 stdcall ChrCmpIA(long long)

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -551,11 +551,11 @@
 551 stub -noname IShellFolder_CompareIDs
 552 stdcall -stub -noname -version=0x501-0x502 SHEvaluateSystemCommandTemplate(wstr ptr ptr ptr)
 553 stdcall IsInternetESCEnabled()
-554 stdcall -noname -stub SHGetAllAccessSA()
+554 stdcall -stub -noname -version=0x502 SHGetAllAccessSA()
 555 stdcall AssocQueryStringByKeyA(long long ptr str ptr ptr)
-556 stub -noname SHCoExtensionAllowed
-557 stub -noname SHCoCreateExtension
-558 stub -noname SHCoExtensionCollectStats
+556 stub -noname -version=0x502 SHCoExtensionAllowed
+557 stub -noname -version=0x502 SHCoCreateExtension
+558 stub -noname -version=0x501-0x502 SHCoExtensionCollectStats
 559 stub -noname SHGetSignatureInfo
 560 stdcall -stub -noname SHWindowsPolicyGetValue(ptr ptr ptr)
 561 stub -noname AssocGetUrlAction


### PR DESCRIPTION
http://www.geoffchappell.com/studies/windows/shell/shlwapi/history/ords600.htm
I checked 552-566 range only.

JIRA issue: [CORE-9708](https://jira.reactos.org/browse/CORE-9708)
