### PR TITLE
[DEVMGR] Use the ShellAboutW API routine to display the about dialog and French translation update

### DIFF
--- a/dll/win32/devmgr/CMakeLists.txt
+++ b/dll/win32/devmgr/CMakeLists.txt
@@ -36,6 +36,6 @@ add_library(devmgr MODULE
 
 set_module_type(devmgr win32dll UNICODE)
 target_link_libraries(devmgr uuid wine)
-add_importlibs(devmgr setupapi advapi32 newdev user32 gdi32 comctl32 version msvcrt kernel32 ole32 oleaut32 uxtheme ntdll)
+add_importlibs(devmgr setupapi advapi32 shell32 newdev user32 gdi32 comctl32 version msvcrt kernel32 ole32 oleaut32 uxtheme ntdll)
 add_pch(devmgr precomp.h SOURCE)
 add_cd_file(TARGET devmgr DESTINATION reactos/system32 FOR all)

--- a/dll/win32/devmgr/devmgmt/MainWindow.cpp
+++ b/dll/win32/devmgr/devmgmt/MainWindow.cpp
@@ -654,11 +654,15 @@ CDeviceManager::OnCommand(_In_ WPARAM wParam,
             CAtlStringW szAppName;
             CAtlStringW szAppAuthors;
             HICON hIcon;
-            szAppName.LoadStringW(g_hThisInstance, IDS_APPNAME);
-            szAppAuthors.LoadStringW(g_hThisInstance, IDS_APP_AUTHORS);
+
+            if (!szAppName.LoadStringW(g_hThisInstance, IDS_APPNAME))
+                szAppName = L"ReactOS Device Manager";
+            if (!szAppAuthors.LoadStringW(g_hThisInstance, IDS_APP_AUTHORS))
+                szAppAuthors = L"";
             hIcon = LoadIconW(g_hThisInstance, MAKEINTRESOURCEW(IDI_MAIN_ICON));
             ShellAboutW(m_hMainWnd, szAppName, szAppAuthors, hIcon);
-            DestroyIcon(hIcon);
+            if (hIcon)
+                DestroyIcon(hIcon);
 
             // Set focus back to the treeview
             m_DeviceView->SetFocus();

--- a/dll/win32/devmgr/devmgmt/MainWindow.cpp
+++ b/dll/win32/devmgr/devmgmt/MainWindow.cpp
@@ -11,7 +11,6 @@
 #include "devmgmt.h"
 #include "MainWindow.h"
 
-
 /* DATA *****************************************************/
 
 #define BTN_PROPERTIES      0
@@ -652,11 +651,14 @@ CDeviceManager::OnCommand(_In_ WPARAM wParam,
 
         case IDM_ABOUT:
         {
-            // Apportion blame
-            MessageBoxW(m_hMainWnd,
-                        L"ReactOS Device Manager\r\nCopyright Ged Murphy 2015",
-                        L"About",
-                        MB_OK | MB_APPLMODAL);
+            CAtlStringW szAppName;
+            CAtlStringW szAppAuthors;
+            HICON hIcon;
+            szAppName.LoadStringW(g_hThisInstance, IDS_APPNAME);
+            szAppAuthors.LoadStringW(g_hThisInstance, IDS_APP_AUTHORS);
+            hIcon = LoadIconW(g_hThisInstance, MAKEINTRESOURCEW(IDI_MAIN_ICON));
+            ShellAboutW(m_hMainWnd, szAppName, szAppAuthors, hIcon);
+            DestroyIcon(hIcon);
 
             // Set focus back to the treeview
             m_DeviceView->SetFocus();

--- a/dll/win32/devmgr/lang/bg-BG.rc
+++ b/dll/win32/devmgr/lang/bg-BG.rc
@@ -288,6 +288,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/cs-CZ.rc
+++ b/dll/win32/devmgr/lang/cs-CZ.rc
@@ -292,6 +292,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Správce zařízení ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Zakázáním tohoto zařízení dojde k ukončení jeho činnosti.\r\nOpravdu si jej přejete zakázat?"
   IDS_CONFIRM_UNINSTALL     "Varování: Chystáte se odebrat toto zařízení ze systému.\r\nPřejete si pokračovat?"
 END

--- a/dll/win32/devmgr/lang/de-DE.rc
+++ b/dll/win32/devmgr/lang/de-DE.rc
@@ -288,6 +288,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Geräte-Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Dieses Gerät zu deaktivieren wird dessen Funktion einstellen.\r\nWollen Sie es wirklich deaktivieren?"
   IDS_CONFIRM_UNINSTALL     "Warnung: Sie sind dabei, dieses Gerät deinstallieren\r\nMöchten Sie den Vorgang fortsetzen?"
 END

--- a/dll/win32/devmgr/lang/el-GR.rc
+++ b/dll/win32/devmgr/lang/el-GR.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/en-US.rc
+++ b/dll/win32/devmgr/lang/en-US.rc
@@ -287,6 +287,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/es-ES.rc
+++ b/dll/win32/devmgr/lang/es-ES.rc
@@ -296,6 +296,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Administrador de dispositivos de ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Deshabilitar este dispositivo hará que deje de funcionar.\r\n¿Seguro que quiere deshabilitarlo?"
   IDS_CONFIRM_UNINSTALL     "Advertencia: Está a punto de desinstalar este dispositivo de su equipo.\r\n¿Seguro que quiere continuar?"
 END

--- a/dll/win32/devmgr/lang/et-EE.rc
+++ b/dll/win32/devmgr/lang/et-EE.rc
@@ -294,6 +294,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Seadmehaldur"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Selle seadme keelamine põhjustab selle töötamise lakkamise.\r\nKas soovite kindlasti seda keelata?"
   IDS_CONFIRM_UNINSTALL     "Hoiatus: Hakkate seda seadet süsteemist desinstallima.\r\nKas soovite jätkata?"
 END

--- a/dll/win32/devmgr/lang/fr-FR.rc
+++ b/dll/win32/devmgr/lang/fr-FR.rc
@@ -16,13 +16,13 @@ BEGIN
     IDS_ENABLEDEVICE "Utiliser ce périphérique (activé)"
     IDS_DISABLEDEVICE "Ne pas utiliser ce matériel (désactivé)"
     IDS_UNKNOWNDEVICE "Matériel inconnu"
-    IDS_NODRIVERLOADED "Aucun driver n'est installé pour ce matériel."
+    IDS_NODRIVERLOADED "Aucun pilote n'est installé pour ce matériel."
     IDS_DEVONPARENT "sur %1"
     IDS_TROUBLESHOOTDEV "&Dépannage..."
     IDS_ENABLEDEV "A&ctiver le matériel"
-    IDS_REINSTALLDRV "Ré&installer le Driver"
+    IDS_REINSTALLDRV "Ré&installer le pilote"
     IDS_PROPERTIES "&Propriétés"
-    IDS_UPDATEDRV "Mettre à jour le Driver..."
+    IDS_UPDATEDRV "Mettre à jour le pilote..."
     IDS_REBOOT "&Redémarrer l'ordinateur..."
     IDS_NOTAVAILABLE "Non disponible"
     IDS_NOTDIGITALLYSIGNED "Non signé numériquement"
@@ -40,7 +40,7 @@ BEGIN
     IDS_DEV_NO_PROBLEM "Ce périphérique fonctionne correctement."
     IDS_DEV_NOT_CONFIGURED "Ce périphérique n'est pas configuré correctement."
     IDS_DEV_DEVLOADER_FAILED "ReactOS n'a pas pu charger le pilote de ce périphérique car l'ordinateur signale deux types de bus %1."
-    IDS_DEV_DEVLOADER_FAILED2 "Le(s) chargeur(s) de périphérique %1 pour ce périphérique n'ont pas pu charger le driver."
+    IDS_DEV_DEVLOADER_FAILED2 "Le(s) chargeur(s) de périphérique %1 pour ce périphérique n'ont pas pu charger le pilote."
     IDS_DEV_OUT_OF_MEMORY "Le pilote de ce périphérique peut être mauvais, ou votre système peut être à court de mémoire ou d'autres ressources."
     IDS_DEV_ENTRY_IS_WRONG_TYPE "Ce périphérique ne fonctionne pas correctement parce qu'un des pilotes de ce périphérique peut être mauvais, ou votre base de registres peut être mauvaise."
     IDS_DEV_LACKED_ARBITRATOR "Le pilote de ce périphérique a demandé une ressource que ReactOS ne sait pas prendre en compte."
@@ -64,7 +64,7 @@ BEGIN
     IDS_DEV_WILL_BE_REMOVED "ReactOS est en train de supprimer ce périphérique."
     IDS_DEV_DISABLED "Ce périphérique n'est pas démarré."
     IDS_DEV_DISABLED2 "Ce périphérique est désactivé."
-    IDS_DEV_DEVLOADER_NOT_READY "Les chargeurs de ce périphérique ne peuvent pas charger les drivers requis."
+    IDS_DEV_DEVLOADER_NOT_READY "Les chargeurs de ce périphérique ne peuvent pas charger les pilotes requis."
     IDS_DEV_DEVLOADER_NOT_READY2 "" /* unused */
     IDS_DEV_DEVLOADER_NOT_READY3 "" /* unused */
     IDS_DEV_DEVICE_NOT_THERE "Ce périphérique est soit non présent, soit ne fonctionne pas correctement, ou n'a pas tous les pilotes installés."
@@ -174,13 +174,13 @@ BEGIN
     EDITTEXT IDC_DRVVERSION, 120, 67, 145, 12, NOT WS_TABSTOP | NOT WS_BORDER | ES_AUTOHSCROLL | ES_READONLY
     LTEXT "Signature numérique :", -1, 37, 81, 80, 8, SS_NOPREFIX
     EDITTEXT IDC_DIGITALSIGNER, 120, 81, 126, 12, NOT WS_TABSTOP | NOT WS_BORDER | ES_AUTOHSCROLL | ES_READONLY
-    PUSHBUTTON "&Détails...", IDC_DRIVERDETAILS, 7, 106, 75, 15
+    PUSHBUTTON "&Détails...", IDC_DRIVERDETAILS, 5, 106, 79, 15
     LTEXT "Voir les détails à propos des fichiers du Pilote.", -1, 91, 110, 154, 17, SS_NOPREFIX
-    PUSHBUTTON "&Mettre le pilote à jour...", IDC_UPDATEDRIVER, 7, 134, 75, 15
+    PUSHBUTTON "&Mettre le pilote à jour...", IDC_UPDATEDRIVER, 5, 134, 79, 15
     LTEXT "Mettre à jour le pilote du périphérique.", -1, 91, 138, 154, 17, SS_NOPREFIX
-    PUSHBUTTON "&Restaurer le pilote", IDC_ROLLBACKDRIVER, 7, 162, 75, 15
+    PUSHBUTTON "&Restaurer le pilote", IDC_ROLLBACKDRIVER, 5, 162, 79, 15
     LTEXT "Si le périphérique ne fonctionne plus après la mise à jour du pilote, permet de retourner au pilote précédemment installé.", -1, 91, 162, 154, 25, SS_NOPREFIX
-    PUSHBUTTON "Dé&sinstaller", IDC_UNINSTALLDRIVER, 7, 190, 75, 15
+    PUSHBUTTON "Dé&sinstaller", IDC_UNINSTALLDRIVER, 5, 190, 79, 15
     LTEXT "Désinstaller le pilote (Avancé).", -1, 91, 194, 154, 17, SS_NOPREFIX
 END
 

--- a/dll/win32/devmgr/lang/fr-FR.rc
+++ b/dll/win32/devmgr/lang/fr-FR.rc
@@ -243,14 +243,14 @@ END
 
 IDD_UNINSTALLDRIVER DIALOGEX 0, 0, 224, 121
 STYLE DS_SHELLFONT | DS_MODALFRAME | DS_CONTEXTHELP | WS_POPUPWINDOW | WS_VISIBLE | WS_DLGFRAME
-CAPTION "Confirm Device Removal"
+CAPTION "Confirmer la suppression d'un périphérique"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON "", IDC_DEVICON, 7, 7, 20, 20
     LTEXT "", IDC_DEVNAME, 40, 9, 174, 16, SS_NOPREFIX
-    LTEXT "Warning: You are about to uninstall this device from your system.", -1, 7, 37, 204, 50
+    LTEXT "Attention : vous êtes sur le point de désinstaller ce périphérique de votre système.", -1, 7, 37, 204, 50
     DEFPUSHBUTTON "OK", IDOK, 110, 100, 50, 14
-    PUSHBUTTON "Cancel", IDCANCEL, 166, 100, 50, 14
+    PUSHBUTTON "Annuler", IDCANCEL, 166, 100, 50, 14
 END
 
 
@@ -288,6 +288,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Gestionnaire de périphériques ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Désactiver ce périphérique va le rendre inopérant.\r\nVoulez-vous réellement le désactiver ?"
   IDS_CONFIRM_UNINSTALL     "Attention : vous êtes sur le point de désinstaller ce périphérique de votre système.\r\nVoulez-vous continuer ?"
 END

--- a/dll/win32/devmgr/lang/he-IL.rc
+++ b/dll/win32/devmgr/lang/he-IL.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "מנהל ההתקנים של ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/hu-HU.rc
+++ b/dll/win32/devmgr/lang/hu-HU.rc
@@ -288,6 +288,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/id-ID.rc
+++ b/dll/win32/devmgr/lang/id-ID.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Manajer Perangkat ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Mematikan perangkat ini akan menyebabkan fungsionalitasnya berhenti.\r\nYakin ingin mematikannya?"
   IDS_CONFIRM_UNINSTALL     "Peringatan: Anda akan mencopot perangkat ini dari sistem anda.\r\nIngin melanjutkan?"
 END

--- a/dll/win32/devmgr/lang/it-IT.rc
+++ b/dll/win32/devmgr/lang/it-IT.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/ja-JP.rc
+++ b/dll/win32/devmgr/lang/ja-JP.rc
@@ -287,6 +287,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS デバイス マネージャ"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "このデバイスを無効にすると、機能が止まります。\r\nこれを本当に無効にしたいですか？"
   IDS_CONFIRM_UNINSTALL     "警告: あなたのシステムからこのデバイスをアンインストールしようとしています。\r\n続行したいですか？"
 END

--- a/dll/win32/devmgr/lang/no-NO.rc
+++ b/dll/win32/devmgr/lang/no-NO.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/pl-PL.rc
+++ b/dll/win32/devmgr/lang/pl-PL.rc
@@ -298,6 +298,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Menedźer urządzeń ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Wyłączenie tego urządzenia spowoduje, że przestanie ono funkcjonować. Czy na /npewno chcesz je wyłączyć?"
   IDS_CONFIRM_UNINSTALL     "Ostrzeżenie: Urządzenie to zostanie zaraz odinstalowane z systemu.\r\nCzy chcesz kontynuować?"
 END

--- a/dll/win32/devmgr/lang/pt-BR.rc
+++ b/dll/win32/devmgr/lang/pt-BR.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/pt-PT.rc
+++ b/dll/win32/devmgr/lang/pt-PT.rc
@@ -287,6 +287,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Gestor de dispositivos"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Desactivar este dispositivo fará com que pare de funcionar. \r\nDeseja realmente desactiva-lo?"
   IDS_CONFIRM_UNINSTALL     "Aviso: Está prestes a desinstalar este dispositivo do sistema.\r\nDeseja continuar?"
 END

--- a/dll/win32/devmgr/lang/ro-RO.rc
+++ b/dll/win32/devmgr/lang/ro-RO.rc
@@ -292,6 +292,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Gestionar de dispozitive"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Dezactivarea acestui dispozitiv va cauza oprirea funcționării sale.\r\nSigur doriți dezactivarea sa?"
   IDS_CONFIRM_UNINSTALL     "Avertisment: Urmează să dezinstalați acest dispozitiv din sistem.\r\nContinuați?"
 END

--- a/dll/win32/devmgr/lang/ru-RU.rc
+++ b/dll/win32/devmgr/lang/ru-RU.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "Диспетчер устройств ReactOS"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Отключение устройства означает, что оно перестанет работать. Отключить устройство?"
   IDS_CONFIRM_UNINSTALL     "Предупреждение: Сейчас устройство будет удалено из системы.\r\nВы хотите продолжить?"
 END

--- a/dll/win32/devmgr/lang/sk-SK.rc
+++ b/dll/win32/devmgr/lang/sk-SK.rc
@@ -292,6 +292,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/sq-AL.rc
+++ b/dll/win32/devmgr/lang/sq-AL.rc
@@ -291,6 +291,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/tr-TR.rc
+++ b/dll/win32/devmgr/lang/tr-TR.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Aygıt Yöneticisi"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Bu aygıtı edilginleştirmek işleyiş durmasına neden olacaktır.\r\nOnu edilginleştirmeyi gerçekten istiyor musunuz?"
   IDS_CONFIRM_UNINSTALL     "Uyarı: Bu aygıtı dizgenizden kaldırmak üzeresiniz.\r\nSürdürmek istiyor musunuz?"
 END

--- a/dll/win32/devmgr/lang/uk-UA.rc
+++ b/dll/win32/devmgr/lang/uk-UA.rc
@@ -295,6 +295,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS Device Manager"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "Disabling this device will cause it to stop functioning.\r\nDo you really want to disable it?"
   IDS_CONFIRM_UNINSTALL     "Warning: You are about to uninstall this device from your system.\r\nDo you want to continue?"
 END

--- a/dll/win32/devmgr/lang/zh-CN.rc
+++ b/dll/win32/devmgr/lang/zh-CN.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS 设备管理器"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "禁用此设备会使其停止运行。\r\n你真的想要禁用它吗?"
   IDS_CONFIRM_UNINSTALL     "警告: 您将要从系统中卸载此设备。\r\n你想要继续吗?"
 END

--- a/dll/win32/devmgr/lang/zh-TW.rc
+++ b/dll/win32/devmgr/lang/zh-TW.rc
@@ -289,6 +289,7 @@ END
 STRINGTABLE DISCARDABLE
 BEGIN
   IDS_APPNAME               "ReactOS 裝置管理員"
+  IDS_APP_AUTHORS           "Copyright 2015 Ged Murphy"
   IDS_CONFIRM_DISABLE       "禁用此裝置會使其停止運行。\r\n你真的想要禁用它嗎?"
   IDS_CONFIRM_UNINSTALL     "警告: 您將要從系統中解除安裝此裝置。\r\n你想要繼續嗎?"
 END

--- a/dll/win32/devmgr/precomp.h
+++ b/dll/win32/devmgr/precomp.h
@@ -53,6 +53,7 @@ OUT LPDWORD lpReboot);
 #include <winnls.h>
 #include <wincon.h>
 #include <shlobj.h>
+#include <shellapi.h>
 #include <shlwapi.h>
 #include <strsafe.h>
 #include <process.h>

--- a/dll/win32/devmgr/resource.h
+++ b/dll/win32/devmgr/resource.h
@@ -3,6 +3,7 @@
 #define IDC_STATIC          -1
 
 #define IDS_APPNAME         10
+#define IDS_APP_AUTHORS     11
 
 #define IDI_MAIN_ICON       20
 #define IDB_ROOT_IMAGE      21


### PR DESCRIPTION
## Purpose

As the dialog simply displays the copyright names and nothing particular it makes sense to use ShellAboutW() instead.

![image](https://user-images.githubusercontent.com/24843587/82179223-16266c80-98de-11ea-92a5-e6ed54cd9947.png)

Similar to #2743 by @HBelusca

## Proposed changes

![image](https://user-images.githubusercontent.com/24843587/82179206-0dce3180-98de-11ea-9b0d-6d331900be3f.png)
