### PR TITLE
[MAIN] Fix of Keyboard settings French translation

### DIFF
--- a/dll/cpl/main/lang/fr-FR.rc
+++ b/dll/cpl/main/lang/fr-FR.rc
@@ -7,16 +7,16 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     GROUPBOX "Répétition des caractères", -1, 5, 5, 230, 130
     ICON IDI_REPEAT_DELAY, IDC_ICON_REPEAT_DELAY, 15, 15, 15, 15
-    LTEXT "&Délai de répétition", -1, 40, 15, 50, 10
+    LTEXT "&Délai de répétition", -1, 40, 15, 150, 10
     LTEXT "Long", -1, 40, 30, 20, 10
     LTEXT "Court", -1, 200, 30, 20, 10
     CONTROL "", IDC_SLIDER_REPEAT_DELAY, "msctls_trackbar32", TBS_AUTOTICKS | WS_TABSTOP, 65, 30, 130, 17
     ICON IDI_REPEAT_RATE, IDC_ICON_REPEAT_RATE, 15, 70, 15, 15
-    LTEXT "&Délai de répétition", -1, 40, 70, 50, 10
+    LTEXT "&Fréquence de répétition", -1, 40, 70, 150, 10
     LTEXT "Lent", -1, 40, 85, 20, 10
-    LTEXT "Rapide", -1, 200, 85, 20, 10
+    LTEXT "Rapide", -1, 200, 85, 21, 10
     CONTROL "", IDC_SLIDER_REPEAT_RATE, "msctls_trackbar32", TBS_AUTOTICKS | WS_TABSTOP, 65, 85, 130, 17
-    LTEXT "Cliquer ici et enfoncer une touche pour &tester le délai de répétition :", -1, 15, 105, 150, 10
+    LTEXT "Cliquer ici et enfoncer une touche pour &tester la répétition :", -1, 15, 105, 200, 10
     EDITTEXT IDC_EDIT_REPEAT_RATE, 15, 115, 200, 15, WS_CHILD | WS_VISIBLE | WS_GROUP
     GROUPBOX "Taux de &clignotement du curseur :", -1, 5, 145, 230, 50
     LTEXT "", IDC_TEXT_CURSOR_BLINK, 20, 165, 1, 8


### PR DESCRIPTION
## Purpose

- Some IU elements are incorrectly defined
- Some translation are wrong (copy/paste of other elements)

![clavier1](https://user-images.githubusercontent.com/24843587/82343956-c20dac00-99f3-11ea-98c8-c1ad952097a7.png)

## Proposed changes

![clavier2](https://user-images.githubusercontent.com/24843587/82343965-c4700600-99f3-11ea-9af2-50923c8adc07.png)