### PR TITLE
[NTOSKRNL] Place INIT_FUNCTION before the return type

### DIFF
--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -1529,8 +1529,8 @@ CcGetFileObjectFromSectionPtrs (
     return NULL;
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 CcInitView (
     VOID)

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -446,8 +446,8 @@ Quit:
     return Status;
 }
 
-INIT_FUNCTION
 static
+INIT_FUNCTION
 NTSTATUS
 CmpCreateHardwareProfile(HANDLE ControlSetHandle)
 {

--- a/ntoskrnl/dbgk/dbgkobj.c
+++ b/ntoskrnl/dbgk/dbgkobj.c
@@ -1492,8 +1492,8 @@ DbgkClearProcessDebugObject(IN PEPROCESS Process,
     return STATUS_SUCCESS;
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 DbgkInitialize(VOID)
 {

--- a/ntoskrnl/ex/callback.c
+++ b/ntoskrnl/ex/callback.c
@@ -250,8 +250,8 @@ ExpDeleteCallback(IN PVOID Object)
  * @remarks None
  *
  *--*/
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeCallbacks(VOID)
 {

--- a/ntoskrnl/ex/event.c
+++ b/ntoskrnl/ex/event.c
@@ -37,8 +37,8 @@ static const INFORMATION_CLASS_INFO ExEventInfoClass[] =
 
 /* FUNCTIONS *****************************************************************/
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeEventImplementation(VOID)
 {

--- a/ntoskrnl/ex/evtpair.c
+++ b/ntoskrnl/ex/evtpair.c
@@ -31,8 +31,8 @@ GENERIC_MAPPING ExEventPairMapping =
 
 /* FUNCTIONS *****************************************************************/
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeEventPairImplementation(VOID)
 {

--- a/ntoskrnl/ex/keyedevt.c
+++ b/ntoskrnl/ex/keyedevt.c
@@ -42,8 +42,8 @@ GENERIC_MAPPING ExpKeyedEventMapping =
 /* FUNCTIONS *****************************************************************/
 
 _IRQL_requires_max_(APC_LEVEL)
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeKeyedEventImplementation(VOID)
 {

--- a/ntoskrnl/ex/mutant.c
+++ b/ntoskrnl/ex/mutant.c
@@ -50,8 +50,8 @@ ExpDeleteMutant(PVOID ObjectBody)
                     FALSE);
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeMutantImplementation(VOID)
 {

--- a/ntoskrnl/ex/profile.c
+++ b/ntoskrnl/ex/profile.c
@@ -62,8 +62,8 @@ ExpDeleteProfile(PVOID ObjectBody)
     if (Profile->Process) ObDereferenceObject(Profile->Process);
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeProfileImplementation(VOID)
 {

--- a/ntoskrnl/ex/sem.c
+++ b/ntoskrnl/ex/sem.c
@@ -37,8 +37,8 @@ static const INFORMATION_CLASS_INFO ExSemaphoreInfoClass[] =
 
 /* FUNCTIONS *****************************************************************/
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeSemaphoreImplementation(VOID)
 {

--- a/ntoskrnl/ex/timer.c
+++ b/ntoskrnl/ex/timer.c
@@ -217,8 +217,8 @@ ExpTimerApcKernelRoutine(IN PKAPC Apc,
     ObDereferenceObjectEx(Timer, DerefsToDo);
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpInitializeTimerImplementation(VOID)
 {

--- a/ntoskrnl/ex/uuid.c
+++ b/ntoskrnl/ex/uuid.c
@@ -52,8 +52,8 @@ LARGE_INTEGER ExpLuid = {{0x3e9, 0x0}};
 /*
  * @implemented
  */
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpUuidInitialization(VOID)
 {
@@ -324,8 +324,8 @@ ExpUuidGetValues(PUUID_CACHED_VALUES_STRUCT CachedValues)
 /*
  * @implemented
  */
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExLuidInitialization(VOID)
 {

--- a/ntoskrnl/ex/win32k.c
+++ b/ntoskrnl/ex/win32k.c
@@ -257,8 +257,8 @@ ExpDesktopClose(IN PEPROCESS Process OPTIONAL,
                            &Parameters);
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ExpWin32kInit(VOID)
 {

--- a/ntoskrnl/ex/work.c
+++ b/ntoskrnl/ex/work.c
@@ -515,8 +515,8 @@ ExpWorkerThreadBalanceManager(IN PVOID Context)
  * @remarks This routine is only called once during system initialization.
  *
  *--*/
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 ExpInitializeWorkerThreads(VOID)
 {

--- a/ntoskrnl/io/iomgr/bootlog.c
+++ b/ntoskrnl/io/iomgr/bootlog.c
@@ -29,8 +29,8 @@ static ERESOURCE IopBootLogResource;
 
 /* FUNCTIONS ****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 IopInitBootLog(BOOLEAN StartBootLog)
 {
     ExInitializeResourceLite(&IopBootLogResource);
@@ -38,8 +38,8 @@ IopInitBootLog(BOOLEAN StartBootLog)
 }
 
 
-VOID
 INIT_FUNCTION
+VOID
 IopStartBootLog(VOID)
 {
     IopBootLogCreate = TRUE;

--- a/ntoskrnl/io/iomgr/iomgr.c
+++ b/ntoskrnl/io/iomgr/iomgr.c
@@ -93,8 +93,8 @@ PLOADER_PARAMETER_BLOCK IopLoaderBlock;
 
 /* INIT FUNCTIONS ************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 IopInitLookasideLists(VOID)
 {
@@ -240,8 +240,8 @@ IopInitLookasideLists(VOID)
     }
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 IopCreateObjectTypes(VOID)
 {
@@ -329,8 +329,8 @@ IopCreateObjectTypes(VOID)
     return TRUE;
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 IopCreateRootDirectories(VOID)
 {
@@ -394,8 +394,8 @@ IopCreateRootDirectories(VOID)
     return TRUE;
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 IopMarkBootPartition(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
@@ -464,8 +464,8 @@ IopMarkBootPartition(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     return TRUE;
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 IoInitSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {

--- a/ntoskrnl/ke/amd64/except.c
+++ b/ntoskrnl/ke/amd64/except.c
@@ -53,8 +53,8 @@ KDESCRIPTOR KiIdtDescriptor = {{0}, sizeof(KiIdt) - 1, KiIdt};
 
 /* FUNCTIONS *****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 KeInitExceptions(VOID)
 {

--- a/ntoskrnl/ke/amd64/kiinit.c
+++ b/ntoskrnl/ke/amd64/kiinit.c
@@ -268,9 +268,9 @@ KiInitializeTss(IN PKTSS64 Tss,
     __ltr(KGDT64_SYS_TSS);
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 KiInitializeKernelMachineDependent(
     IN PKPRCB Prcb,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock)

--- a/ntoskrnl/ke/amd64/krnlinit.c
+++ b/ntoskrnl/ke/amd64/krnlinit.c
@@ -20,9 +20,9 @@ extern BOOLEAN RtlpUse16ByteSLists;
 
 /* FUNCTIONS *****************************************************************/
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 KiInitializeKernel(IN PKPROCESS InitProcess,
                    IN PKTHREAD InitThread,
                    IN PVOID IdleStack,
@@ -51,9 +51,9 @@ KiInitializeHandBuiltThread(
 
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 KiSystemStartupBootStack(VOID)
 {
     PLOADER_PARAMETER_BLOCK LoaderBlock = KeLoaderBlock; // hack
@@ -134,9 +134,9 @@ KiSystemStartupBootStack(VOID)
     KiIdleLoop();
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 KiInitializeKernel(IN PKPROCESS InitProcess,
                    IN PKTHREAD InitThread,
                    IN PVOID IdleStack,

--- a/ntoskrnl/ke/bug.c
+++ b/ntoskrnl/ke/bug.c
@@ -295,8 +295,8 @@ KeRosDumpStackFrames(IN PULONG_PTR Frame OPTIONAL,
     }
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 KiInitializeBugCheck(VOID)
 {

--- a/ntoskrnl/ke/i386/exp.c
+++ b/ntoskrnl/ke/i386/exp.c
@@ -17,8 +17,8 @@
 
 /* FUNCTIONS *****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 KeInitExceptions(VOID)
 {

--- a/ntoskrnl/ke/powerpc/exp.c
+++ b/ntoskrnl/ke/powerpc/exp.c
@@ -17,8 +17,8 @@
 
 /* FUNCTIONS *****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 KeInitExceptions(VOID)
 {

--- a/ntoskrnl/ke/powerpc/ppc_irq.c
+++ b/ntoskrnl/ke/powerpc/ppc_irq.c
@@ -145,8 +145,8 @@ static ISR_TABLE IsrTable[NR_TRAPS][1];
 
 /* FUNCTIONS ****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 KeInitInterrupts (VOID)
 {

--- a/ntoskrnl/mm/ARM3/arm/init.c
+++ b/ntoskrnl/mm/ARM3/arm/init.c
@@ -57,9 +57,9 @@ PVOID MmHyperSpaceEnd;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+INIT_FUNCTION
 NTSTATUS
 NTAPI
-INIT_FUNCTION
 MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
     //

--- a/ntoskrnl/mm/amd64/init.c
+++ b/ntoskrnl/mm/amd64/init.c
@@ -57,9 +57,9 @@ BOOLEAN MiPfnsInitialized = FALSE;
 
 /* FUNCTIONS *****************************************************************/
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiInitializeSessionSpaceLayout(VOID)
 {
     MmSessionSize = MI_SESSION_SIZE;
@@ -180,9 +180,9 @@ MiMapPTEs(
     }
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiInitializePageTable(VOID)
 {
     ULONG64 PxePhysicalAddress;
@@ -266,9 +266,9 @@ MiInitializePageTable(VOID)
     MiMapPTEs((PVOID)MI_VAD_BITMAP, (PVOID)(MI_WORKING_SET_LIST + PAGE_SIZE - 1));
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiBuildNonPagedPool(VOID)
 {
     /* Check if this is a machine with less than 256MB of RAM, and no overide */
@@ -357,9 +357,9 @@ MiBuildNonPagedPool(VOID)
 
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiBuildSystemPteSpace(VOID)
 {
     PMMPTE PointerPte;
@@ -524,9 +524,9 @@ MiBuildPfnDatabaseFromPageTables(VOID)
 #endif
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiAddDescriptorToDatabase(
     PFN_NUMBER BasePage,
     PFN_NUMBER PageCount,
@@ -603,9 +603,9 @@ MiAddDescriptorToDatabase(
     }
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiBuildPfnDatabase(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
     PLIST_ENTRY ListEntry;
@@ -670,9 +670,9 @@ MiBuildPfnDatabase(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     *MxFreeDescriptor = MxOldFreeDescriptor;
 }
 
+INIT_FUNCTION
 NTSTATUS
 NTAPI
-INIT_FUNCTION
 MiInitMachineDependent(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
     ASSERT(MxPfnAllocation != 0);

--- a/ntoskrnl/mm/arm/page.c
+++ b/ntoskrnl/mm/arm/page.c
@@ -312,9 +312,9 @@ MmIsDisabledPage(PEPROCESS Process, PVOID Address)
     return FALSE;
 }
 
+INIT_FUNCTION
 VOID
 NTAPI
-INIT_FUNCTION
 MiInitializeSessionSpaceLayout(VOID)
 {
     ASSERT(FALSE);

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -47,8 +47,8 @@ static KTIMER MiBalancerTimer;
 
 /* FUNCTIONS ****************************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitializeBalancer(ULONG NrAvailablePages, ULONG NrSystemPages)
 {
@@ -76,8 +76,8 @@ MmInitializeBalancer(ULONG NrAvailablePages, ULONG NrSystemPages)
     MiMemoryConsumers[MC_USER].PagesTarget = NrAvailablePages - MiMinimumAvailablePages;
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitializeMemoryConsumer(
     ULONG Consumer,
@@ -443,8 +443,8 @@ BOOLEAN MmRosNotifyAvailablePage(PFN_NUMBER Page)
     return TRUE;
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MiInitBalancerThread(VOID)
 {

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -877,8 +877,8 @@ MmSetPageProtect(PEPROCESS Process, PVOID Address, ULONG flProtect)
         MmUnmapPageTable(Pt);
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitGlobalKernelPageDirectory(VOID)
 {

--- a/ntoskrnl/mm/i386/pagepae.c
+++ b/ntoskrnl/mm/i386/pagepae.c
@@ -1492,8 +1492,8 @@ MmSetPageProtect(PEPROCESS Process, PVOID Address, ULONG flProtect)
    }
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitGlobalKernelPageDirectory(VOID)
 {

--- a/ntoskrnl/mm/pagefile.c
+++ b/ntoskrnl/mm/pagefile.c
@@ -253,8 +253,8 @@ MiReadPageFile(
     return(Status);
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitPagingFile(VOID)
 {

--- a/ntoskrnl/mm/powerpc/page.c
+++ b/ntoskrnl/mm/powerpc/page.c
@@ -445,8 +445,8 @@ MmSetPageProtect(PEPROCESS Process, PVOID Address, ULONG flProtect)
 #endif
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitGlobalKernelPageDirectory(VOID)
 {

--- a/ntoskrnl/mm/rmap.c
+++ b/ntoskrnl/mm/rmap.c
@@ -37,8 +37,8 @@ RmapListFree(
     ExFreePoolWithTag(P, TAG_RMAP);
 }
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 MmInitializeRmapList(VOID)
 {

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -2749,8 +2749,8 @@ MmpCloseSection(IN PEPROCESS Process OPTIONAL,
     DPRINT("MmpCloseSection(OB %p, HC %lu)\n", Object, ProcessHandleCount);
 }
 
-NTSTATUS
 INIT_FUNCTION
+NTSTATUS
 NTAPI
 MmCreatePhysicalMemorySection(VOID)
 {
@@ -2800,8 +2800,8 @@ MmCreatePhysicalMemorySection(VOID)
     return(STATUS_SUCCESS);
 }
 
-NTSTATUS
 INIT_FUNCTION
+NTSTATUS
 NTAPI
 MmInitSectionImplementation(VOID)
 {

--- a/ntoskrnl/ob/obinit.c
+++ b/ntoskrnl/ob/obinit.c
@@ -129,8 +129,8 @@ done:
     return Status;
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ObInit2(VOID)
 {
@@ -196,8 +196,8 @@ ObInit2(VOID)
     return TRUE;
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 ObInitSystem(VOID)
 {

--- a/ntoskrnl/se/acl.c
+++ b/ntoskrnl/se/acl.c
@@ -28,8 +28,8 @@ PACL SeUnrestrictedDacl = NULL;
 
 /* FUNCTIONS ******************************************************************/
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 SepInitDACLs(VOID)
 {

--- a/ntoskrnl/se/priv.c
+++ b/ntoskrnl/se/priv.c
@@ -58,8 +58,8 @@ const LUID SeCreateSymbolicLinkPrivilege = CONST_LUID(SE_CREATE_SYMBOLIC_LINK_PR
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 SepInitPrivileges(VOID)
 {

--- a/ntoskrnl/se/sd.c
+++ b/ntoskrnl/se/sd.c
@@ -28,8 +28,8 @@ PSECURITY_DESCRIPTOR SeUnrestrictedSd = NULL;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 SepInitSDs(VOID)
 {

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -94,8 +94,8 @@ FreeInitializedSids(VOID)
     if (SeAnonymousLogonSid) ExFreePoolWithTag(SeAnonymousLogonSid, TAG_SID);
 }
 
-BOOLEAN
 INIT_FUNCTION
+BOOLEAN
 NTAPI
 SepInitSecurityIDs(VOID)
 {

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -830,8 +830,8 @@ SepDeleteToken(PVOID ObjectBody)
 }
 
 
-VOID
 INIT_FUNCTION
+VOID
 NTAPI
 SepInitializeTokenImplementation(VOID)
 {


### PR DESCRIPTION
Follow-up to 71fefa32db013317842fd9224b63bcf5f72f2e32.