### PR TITLE
[COMDLG32] Fix ico3 not shown in Print dialog

### DIFF
--- a/dll/win32/comdlg32/lang/cdlg_Bg.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Bg.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Копия",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Брой &копия:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Под&реждане",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Ca.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ca.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copies",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Nombre de &copies:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "C&ompagina",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Cs.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Cs.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopie",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Počet &kopií:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "K&ompletovat",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Da.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Da.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopier",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Antal &kopier:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&hold sammen",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_De.rc
+++ b/dll/win32/comdlg32/lang/cdlg_De.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopien",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Anzahl &Kopien:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "S&ortieren",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_El.rc
+++ b/dll/win32/comdlg32/lang/cdlg_El.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Αντίγραφα",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Αριθμός &Αντιγράφων:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "C&ollate",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_En.rc
+++ b/dll/win32/comdlg32/lang/cdlg_En.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copies",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Number of &copies:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "C&ollate",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Eo.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Eo.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Ekzempleroj",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Nombro da &ekzempleroj:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Laŭ&kajere",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Es.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Es.rc
@@ -375,7 +375,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copias",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Número de &copias:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Intercalar",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Et.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Et.rc
@@ -370,7 +370,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Koopiad",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "&Koopiate arv:",  stc5,168,105,68,8
-    ICON            "",                ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",                ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "V&õrdle",         chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                           edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Fi.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Fi.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopioita",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Kopioiden &määrä:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Kokoa",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Fr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Fr.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copies",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Nombre de copies :",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Copies assemblées",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_He.rc
+++ b/dll/win32/comdlg32/lang/cdlg_He.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "עותקים",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "מספר ה&עותקים:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&איסוף",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Hi.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Hi.rc
@@ -355,7 +355,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "प्रतियां",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "&प्रतियों की संख्या:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&कोलेट",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Hu.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Hu.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Másolatok",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Másola&tok száma:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Le&válogatás",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Id.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Id.rc
@@ -370,7 +370,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX "Salinan", grp2, 160, 92, 120, 64, WS_GROUP
     LTEXT "Jumlah &Salinan:", stc5, 168, 105, 68, 8
-    ICON "", ico3, 170, 131, 76, 24, WS_GROUP | SS_CENTERIMAGE
+    ICON "", ico3, 210, 131, 76, 24, WS_GROUP
     CONTROL "&Tersusun", chx2, "Button", BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP, 168, 118, 100, 12
     EDITTEXT edt3, 240, 103, 32, 12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_It.rc
+++ b/dll/win32/comdlg32/lang/cdlg_It.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copie",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Numero di &copie:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Fascicola",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Ja.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ja.rc
@@ -369,7 +369,7 @@ FONT 9, "MS UI Gothic"
 
     GROUPBOX        "印刷部数",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "部数(&C):",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "部単位で印刷(&O)",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Ko.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ko.rc
@@ -369,7 +369,7 @@ FONT 9, "MS Shell Dlg"
 
     GROUPBOX        "복사본",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "복사본 갯수(&C):",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "정렬(&O)",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Lt.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Lt.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopijos",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "&Kopijų skaičius:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Su&dėst.",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Nl.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Nl.rc
@@ -368,7 +368,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Aantal",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Aantal e&xemplaren:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Sorteren",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_No.rc
+++ b/dll/win32/comdlg32/lang/cdlg_No.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopier",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Antall &kopier:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "S&orter",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Pl.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Pl.rc
@@ -366,7 +366,7 @@ FONT 8, "MS Shell Dlg"
     LTEXT           "",               stc13, 55, 72, 153,10, SS_NOPREFIX | SS_LEFTNOWORDWRAP
     GROUPBOX        "Kopie",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Lczba &kopii:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Sortuj",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
     GROUPBOX        "Zakres wydruku",    grp1,   8,92,  144,64, WS_GROUP

--- a/dll/win32/comdlg32/lang/cdlg_Pt.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Pt.rc
@@ -353,7 +353,7 @@ FONT 8, "MS Shell Dlg"
     LTEXT "", stc13, 65, 72, 212, 10, SS_NOPREFIX | SS_LEFTNOWORDWRAP
     GROUPBOX "Cópias", grp2, 160, 92, 120, 64, WS_GROUP
     LTEXT "Número de &cópias:", stc5, 168, 105, 68, 8
-    ICON "", ico3, 170, 131, 76, 24, WS_GROUP | SS_CENTERIMAGE
+    ICON "", ico3, 210, 131, 76, 24, WS_GROUP
     CONTROL "&Agrupar", chx2, "Button", BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP, 168, 118, 100, 12
     EDITTEXT edt3, 240, 103, 32, 12, WS_GROUP | ES_NUMBER
     GROUPBOX "Faixa de impressão", grp1, 8, 92, 144, 64, WS_GROUP

--- a/dll/win32/comdlg32/lang/cdlg_Ro.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ro.rc
@@ -371,7 +371,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Cópii",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Numă&r de cópii:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Colaționate",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Ru.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Ru.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Копии",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Число &копий:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Разобрать по копиям",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Si.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Si.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopije",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Število &kopij:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Z&biranje",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Sk.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sk.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kópie",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Počet &kópií:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "C&ollate",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Sq.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sq.rc
@@ -373,7 +373,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopjon",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Numri i kopjeve:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Mbledh",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Sr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sr.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Copies",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Number of &copies:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "C&ollate",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Sv.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Sv.rc
@@ -368,7 +368,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopior",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Antal k&opior:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Sortera",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Th.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Th.rc
@@ -368,7 +368,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "สําเนา",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "กี่สําเนา:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "จัดเรียงตามลําดับ",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Tr.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Tr.rc
@@ -368,7 +368,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Kopyalar",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "K&opya Sayısı:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "Ha&rmanla",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Uk.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Uk.rc
@@ -369,7 +369,7 @@ FONT 8, "MS Shell Dlg"
 
     GROUPBOX        "Копії",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "Кількість &копій:",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "&Розбити",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/lang/cdlg_Zh.rc
+++ b/dll/win32/comdlg32/lang/cdlg_Zh.rc
@@ -371,7 +371,7 @@ FONT 9, "宋体"
 
     GROUPBOX        "份数",         grp2, 160, 92, 120,64, WS_GROUP
     LTEXT           "份数(&C)：",stc5,168,105,68,8
-    ICON            "",               ico3, 170,131,  76,24, WS_GROUP | SS_CENTERIMAGE
+    ICON            "",               ico3, 210,131,  76,24, WS_GROUP
     CONTROL         "逐份打印(&O)",       chx2,"Button",BS_AUTOCHECKBOX | WS_GROUP | WS_TABSTOP,168,118,100,12
     EDITTEXT                          edt3, 240,103,  32,12, WS_GROUP | ES_NUMBER
 

--- a/dll/win32/comdlg32/printdlg.c
+++ b/dll/win32/comdlg32/printdlg.c
@@ -1171,10 +1171,7 @@ static BOOL PRINTDLG_ChangePrinterA(HWND hDlg, char *name, PRINT_PTRA *PrintStru
 	        CheckRadioButton(hDlg, rad1, rad3, rad3);
 	}
 
-	/* Collate pages
-	 *
-	 * FIXME: The ico3 is not displayed for some reason. I don't know why.
-	 */
+	/* Collate pages */
 	if (lppd->Flags & PD_COLLATE) {
             SendDlgItemMessageA(hDlg, ico3, STM_SETIMAGE, IMAGE_ICON,
 				(LPARAM)PrintStructures->hCollateIcon);
@@ -1378,10 +1375,7 @@ static BOOL PRINTDLG_ChangePrinterW(HWND hDlg, WCHAR *name,
 	        CheckRadioButton(hDlg, rad1, rad3, rad3);
 	}
 
-	/* Collate pages
-	 *
-	 * FIXME: The ico3 is not displayed for some reason. I don't know why.
-	 */
+	/* Collate pages */
 	if (lppd->Flags & PD_COLLATE) {
             SendDlgItemMessageW(hDlg, ico3, STM_SETIMAGE, IMAGE_ICON,
 				(LPARAM)PrintStructures->hCollateIcon);


### PR DESCRIPTION
[COMDLG32] Fix ico3 not shown

We need to update the window by calling SetWindowPos () in the STATIC_SetIcon (...) function in <dll / win32 / comctl32 / static.c>

Small adjustment in the position of the icon