### PR TITLE
[COMCTL32] Fix issue on scrolling icon list by mouse wheel and thumb CORE-16162

### DIFF
--- a/dll/win32/comctl32/listbox.c
+++ b/dll/win32/comctl32/listbox.c
@@ -1951,7 +1951,11 @@ static LRESULT LISTBOX_HandleHScroll( LB_DESCR *descr, WORD scrollReq, WORD pos 
         case SB_THUMBTRACK:
             info.cbSize = sizeof(info);
             info.fMask  = SIF_TRACKPOS;
+#ifdef __REACTOS__
+            GetScrollInfo( descr->self, SB_HORZ, &info );
+#else
             GetScrollInfo( descr->self, SB_VERT, &info );
+#endif
             LISTBOX_SetTopItem( descr, info.nTrackPos*descr->page_size,
                                 TRUE );
             break;

--- a/dll/win32/comctl32/listbox.c
+++ b/dll/win32/comctl32/listbox.c
@@ -296,6 +296,12 @@ static LRESULT LISTBOX_SetTopItem( LB_DESCR *descr, INT index, BOOL scroll )
         else
             diff = (descr->top_item - index) * descr->item_height;
 
+#ifdef __REACTOS__
+        if (descr->style & LBS_MULTICOLUMN)
+            ScrollWindowEx(descr->self, diff, 0, NULL, NULL, 0, NULL,
+                           SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN);
+        else
+#endif
         ScrollWindowEx( descr->self, 0, diff, NULL, NULL, 0, NULL,
                         SW_INVALIDATE | SW_ERASE | SW_SCROLLCHILDREN );
     }
@@ -2015,6 +2021,10 @@ static LRESULT LISTBOX_HandleMouseWheel(LB_DESCR *descr, SHORT delta )
         pulScrollLines = min((UINT) descr->page_size, pulScrollLines);
         cLineScroll = pulScrollLines * (float)descr->wheel_remain / WHEEL_DELTA;
         descr->wheel_remain -= WHEEL_DELTA * cLineScroll / (int)pulScrollLines;
+#ifdef __REACTOS__
+        if (cLineScroll < 0)
+            cLineScroll -= descr->page_size;
+#endif
         LISTBOX_SetTopItem( descr, descr->top_item - cLineScroll, TRUE );
     }
     return 0;


### PR DESCRIPTION
[COMCTL32] Fix issue on scrolling icon list by mouse wheel and thumb

Accessing the Change Icon dialog through the "Tools / Folder Options" menu, it is only possible to scroll the icon list with the mouse wheel to one of the directions.
The thumb scroll is incorrect.

JIRA issue: [CORE-16162](https://jira.reactos.org/browse/CORE-16162)