### PR TITLE
[NTOS:KE] Avoid SEH in trap handlers. CORE-15723

### DIFF
--- a/ntoskrnl/include/internal/i386/asmmacro.S
+++ b/ntoskrnl/include/internal/i386/asmmacro.S
@@ -207,6 +207,10 @@ set_sane_segs:
         mov fs, ax
     endif
 
+    /* Save ExceptionList, since the C handler might use SEH */
+    mov eax, fs:[KPCR_EXCEPTION_LIST]
+    mov [esp + KTRAP_FRAME_EXCEPTION_LIST], eax
+
 #if DBG
     /* Keep the frame chain intact */
     mov eax, [esp + KTRAP_FRAME_EIP]

--- a/ntoskrnl/include/internal/i386/trap_x.h
+++ b/ntoskrnl/include/internal/i386/trap_x.h
@@ -349,8 +349,12 @@ FORCEINLINE
 VOID
 KiEnterV86Trap(IN PKTRAP_FRAME TrapFrame)
 {
-    /* Save exception list */
-    TrapFrame->ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    PVOID ExceptionList;
+
+    /* Check exception list */
+    ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    ASSERTMSG("V86 trap handler must not register an SEH frame\n",
+              ExceptionList == TrapFrame->ExceptionList);
 
     /* Save DR7 and check for debugging */
     TrapFrame->Dr7 = __readdr(7);
@@ -368,8 +372,12 @@ FORCEINLINE
 VOID
 KiEnterInterruptTrap(IN PKTRAP_FRAME TrapFrame)
 {
-    /* Save exception list and terminate it */
-    TrapFrame->ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    PVOID ExceptionList;
+
+    /* Check exception list and terminate it */
+    ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    ASSERTMSG("Interrupt handler must not register an SEH frame\n",
+              ExceptionList == TrapFrame->ExceptionList);
     KeGetPcr()->NtTib.ExceptionList = EXCEPTION_CHAIN_END;
 
     /* Default to debugging disabled */
@@ -398,8 +406,12 @@ FORCEINLINE
 VOID
 KiEnterTrap(IN PKTRAP_FRAME TrapFrame)
 {
-    /* Save exception list */
-    TrapFrame->ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    PVOID ExceptionList;
+
+    /* Check exception list */
+    ExceptionList = KeGetPcr()->NtTib.ExceptionList;
+    ASSERTMSG("Trap handler must not register an SEH frame\n",
+              ExceptionList == TrapFrame->ExceptionList);
 
     /* Default to debugging disabled */
     TrapFrame->Dr7 = 0;

--- a/sdk/lib/rtl/i386/except_asm.s
+++ b/sdk/lib/rtl/i386/except_asm.s
@@ -128,7 +128,8 @@ _RtlpExecuteHandlerForUnwind@20:
     mov edx, offset _RtlpUnwindProtector
 
 
-_RtlpExecuteHandler@20:
+.PROC _RtlpExecuteHandler@20
+    FPO 0, 0, 0, 0, 0, FRAME_FPO
 
     /* Save non-volatile */
     push ebx
@@ -155,6 +156,7 @@ _RtlpExecuteHandler@20:
     pop ebx
     ret 20
 
+.ENDP
 
 PUBLIC _RtlpExecuteHandler2@20
 _RtlpExecuteHandler2@20:


### PR DESCRIPTION
If SEH is used in a C trap handler, the exception frame will be registered before the call to KiEnterTrap, which means we save the wrong exception frame. We'll therefore also restore this wrong frame for the excepting code, resulting in a stale SEH chain.

We avoid this problem by saving the handler in the assembly trap entry code. However, SEH in a C trap handler function will also not be correctly unwound, since the function never exits (it uses KiEoiHelper instead). This may result in finally handlers not running or other unexpected behavior. Therefore we still forbid doing this through asserts in the C KiEnterTrap variants.

JIRA issue: [CORE-15723](https://jira.reactos.org/browse/CORE-15723)