### PR TITLE
[NTOS:EX] ExpInitializeExecutive(): Fix 'PerfMem' copypasta

### DIFF
--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -1000,7 +1000,7 @@ ExpInitializeExecutive(IN ULONG Cpu,
             {
                 /* Read the number of pages we'll use */
                 PerfMemUsed = atol(PerfMem + 1) * (1024 * 1024 / PAGE_SIZE);
-                if (PerfMem)
+                if (PerfMemUsed)
                 {
                     /* FIXME: TODO */
                     DPRINT1("BBT performance mode not yet supported."


### PR DESCRIPTION
Detected by Cppcheck: identicalInnerCondition.
Addendum to c307d73c126758e2b123f32fb6f3e39299522a8e (r25621).
