### PR TITLE
[WIN32K:NTUSER] NC_IconForWindow(): Remove redundant if()

### DIFF
--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -696,7 +696,7 @@ PCURICON_OBJECT FASTCALL NC_IconForWindow( PWND pWnd )
    // it does not use the default icon! And it does not check for DS_MODALFRAME.
    if (!hIcon && !(pWnd->ExStyle & WS_EX_DLGMODALFRAME))
    {
-      if (!hIcon) hIcon = gpsi->hIconSmWindows; // Both are IDI_WINLOGO Small
+      hIcon = gpsi->hIconSmWindows; // Both are IDI_WINLOGO Small
       if (!hIcon) hIcon = gpsi->hIconWindows;   // Reg size.
    }
    if (hIcon)


### PR DESCRIPTION
No impact.

Detected by Cppcheck: identicalInnerCondition.
Addendum to 98060c28c8b051bc4cfd460bd008a2eff125658e (r60622).