### PR TITLE
[USER32] MDIClientWndProc_common(): Properly sync to old Wine

### DIFF
--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -1106,18 +1106,18 @@ LRESULT WINAPI MDIClientWndProc_common( HWND hwnd, UINT message, WPARAM wParam, 
 
     if (!(ci = get_client_info( hwnd )))
     {
+#ifdef __REACTOS__
         if (message == WM_NCCREATE)
         {
-#ifdef __REACTOS__
           if (!(ci = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*ci))))
              return FALSE;
            SetWindowLongPtrW( hwnd, GWLP_MDIWND, (LONG_PTR)ci );
            ci->hBmpClose = 0;
            NtUserSetWindowFNID( hwnd, FNID_MDICLIENT); // wine uses WIN_ISMDICLIENT
-#else
-           if (message == WM_NCCREATE) win_set_flags( hwnd, WIN_ISMDICLIENT, 0 );
-#endif
         }
+#else
+        if (message == WM_NCCREATE) win_set_flags( hwnd, WIN_ISMDICLIENT, 0 );
+#endif
         return unicode ? DefWindowProcW( hwnd, message, wParam, lParam ) :
                          DefWindowProcA( hwnd, message, wParam, lParam );
     }


### PR DESCRIPTION
No impact.

Missed part of
https://source.winehq.org/git/wine.git/commit/fb6304119a967ea13688ff9e34ed9d819bd50785

Detected by Cppcheck: identicalInnerCondition.
Addendum to 303ece24219da7ec0cac1016767092287abd7877 (r72520).