### PR TITLE
[MSTASK] Add C stubs and comment out decorated exports

### DIFF
--- a/dll/win32/mstask/CMakeLists.txt
+++ b/dll/win32/mstask/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 add_definitions(-D__WINESRC__)
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+include_directories(BEFORE
+    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+    ${REACTOS_BINARY_DIR}/dll/win32/netapi32)
 generate_idl_iids(mstask_local.idl)
 spec2def(mstask.dll mstask.spec)
 
@@ -10,6 +12,7 @@ list(APPEND SOURCE
     task.c
     task_scheduler.c
     task_trigger.c
+    stubs.c
     precomp.h
     ${CMAKE_CURRENT_BINARY_DIR}/mstask_local_i.c
     ${CMAKE_CURRENT_BINARY_DIR}/mstask_stubs.c)

--- a/dll/win32/mstask/mstask.spec
+++ b/dll/win32/mstask/mstask.spec
@@ -1,28 +1,28 @@
-@ stub ConvertAtJobsToTasks
+@ stdcall ConvertAtJobsToTasks()
 @ stdcall -private DllCanUnloadNow()
 @ stdcall -private DllGetClassObject(ptr ptr ptr)
-@ stub GetNetScheduleAccountInformation
-@ stub NetrJobAdd
-@ stub NetrJobDel
-@ stub NetrJobEnum
-@ stub NetrJobGetInfo
-@ stub SAGetAccountInformation
-@ stub SAGetNSAccountInformation
-@ stub SASetAccountInformation
-@ stub SASetNSAccountInformation
-@ stub SetNetScheduleAccountInformation
-@ stub _ConvertAtJobsToTasks@0
-@ stub _DllCanUnloadNow@0
-@ stub _DllGetClassObject@12
-@ stub _GetNetScheduleAccountInformation@12
-@ stub _NetrJobAdd@12
-@ stub _NetrJobDel@12
-@ stub _NetrJobEnum@20
-@ stub _NetrJobGetInfo@12
-@ stub _SAGetAccountInformation@16
-@ stub _SAGetNSAccountInformation@12
-@ stub _SASetAccountInformation@20
-@ stub _SASetNSAccountInformation@12
-@ stub _SetNetScheduleAccountInformation@12
+@ stdcall GetNetScheduleAccountInformation(wstr long ptr)
+@ stdcall NetrJobAdd(wstr ptr ptr)
+@ stdcall NetrJobDel(wstr long long)
+@ stdcall NetrJobEnum(wstr ptr long ptr ptr)
+@ stdcall NetrJobGetInfo(wstr long ptr)
+@ stdcall SAGetAccountInformation(wstr ptr long ptr)
+@ stdcall SAGetNSAccountInformation(wstr long ptr)
+@ stdcall SASetAccountInformation(wstr wstr wstr wstr long)
+@ stdcall SASetNSAccountInformation(wstr wstr wstr)
+@ stdcall SetNetScheduleAccountInformation(wstr wstr wstr)
+#@ stdcall _ConvertAtJobsToTasks@0() mstask.ConvertAtJobsToTasks
+#@ stdcall _DllCanUnloadNow@0() DllCanUnloadNow
+#@ stdcall _DllGetClassObject@12(ptr ptr ptr) DllGetClassObject
+#@ stdcall _GetNetScheduleAccountInformation@12(wstr ptr long ptr) GetNetScheduleAccountInformation
+#@ stdcall _NetrJobAdd@12(wstr ptr ptr) NetrJobAdd
+#@ stdcall _NetrJobDel@12(wstr long long) NetrJobDel
+#@ stdcall _NetrJobEnum@20(wstr ptr long ptr ptr) NetrJobEnum
+#@ stdcall _NetrJobGetInfo@12(wstr long ptr) NetrJobGetInfo
+#@ stdcall _SAGetAccountInformation@16(wstr ptr long ptr) SAGetAccountInformation
+#@ stdcall _SAGetNSAccountInformation@12(wstr long ptr) SAGetNSAccountInformation
+#@ stdcall _SASetAccountInformation@20(wstr wstr wstr wstr long) SASetAccountInformation
+#@ stdcall _SASetNSAccountInformation@12(wstr wstr wstr) SASetNSAccountInformation
+#@ stdcall _SetNetScheduleAccountInformation@12(wstr wstr wstr) SetNetScheduleAccountInformation
 @ stdcall -private DllRegisterServer()
 @ stdcall -private DllUnregisterServer()

--- a/dll/win32/mstask/stubs.c
+++ b/dll/win32/mstask/stubs.c
@@ -1,0 +1,135 @@
+
+#include "precomp.h"
+#include <atsvc_c.h>
+
+WINE_DEFAULT_DEBUG_CHANNEL(mstask);
+
+typedef PWSTR SASEC_HANDLE;
+
+HRESULT
+WINAPI
+ConvertAtJobsToTasks(void)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+// See https://docs.microsoft.com/en-us/windows/win32/api/atacct/nf-atacct-getnetscheduleaccountinformation
+HRESULT
+WINAPI
+GetNetScheduleAccountInformation(
+    _In_z_ LPCWSTR pwszServerName,
+    _In_ DWORD ccAccount,
+    _Out_bytecap_(ccAccount) WCHAR wszAccount[])
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+// For the following functions see https://winprotocoldoc.blob.core.windows.net/productionwindowsarchives/MS-TSCH/%5BMS-TSCH%5D.pdf
+
+NET_API_STATUS
+WINAPI
+NetrJobAdd(
+    _In_z_ ATSVC_HANDLE ServerName,
+    _In_ LPAT_INFO pAtInfo,
+    _Out_ LPDWORD pJobId)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+NET_API_STATUS
+WINAPI
+NetrJobDel(
+    _In_z_ ATSVC_HANDLE ServerName,
+    _In_ DWORD MinJobId,
+    _In_ DWORD MaxJobId)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+NET_API_STATUS
+WINAPI
+NetrJobEnum(
+    _In_z_ ATSVC_HANDLE ServerName,
+    _Inout_ LPAT_ENUM_CONTAINER pEnumContainer,
+    _In_ DWORD PreferedMaximumLength,
+    _Out_ LPDWORD pTotalEntries,
+    _Inout_ LPDWORD pResumeHandle)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+NET_API_STATUS
+WINAPI
+NetrJobGetInfo(
+    _In_z_ ATSVC_HANDLE ServerName,
+    _In_ DWORD JobId,
+    _Outptr_ LPAT_INFO* ppAtInfo)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+#define MAX_BUFFER_SIZE 273
+
+HRESULT
+WINAPI
+SAGetAccountInformation( 
+    _In_z_ SASEC_HANDLE Handle,
+    _In_z_ const wchar_t* pwszJobName,
+    _In_range_(0, MAX_BUFFER_SIZE) DWORD ccBufferSize,
+    _Inout_updates_z_(ccBufferSize) wchar_t wszBuffer[])
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+HRESULT
+WINAPI
+SAGetNSAccountInformation( 
+    _In_z_ SASEC_HANDLE Handle,
+    _In_range_(0, MAX_BUFFER_SIZE) DWORD ccBufferSize,
+    _Inout_updates_z_(ccBufferSize) wchar_t wszBuffer[])
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+HRESULT
+WINAPI
+SASetAccountInformation( 
+    _In_z_ SASEC_HANDLE Handle,
+    _In_z_ const wchar_t* pwszJobName,
+    _In_z_ const wchar_t* pwszAccount,
+    _In_z_ const wchar_t* pwszPassword,
+    _In_ DWORD dwJobFlags)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+HRESULT
+WINAPI
+SASetNSAccountInformation( 
+    _In_z_ SASEC_HANDLE Handle,
+    _In_z_ const wchar_t* pwszAccount,
+    _In_z_ const wchar_t* pwszPassword)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}
+
+HRESULT
+WINAPI
+SetNetScheduleAccountInformation(
+    _In_z_ LPCWSTR pwszServerName,
+    _In_z_ LPCWSTR pwszAccount,
+    _In_z_ LPCWSTR pwszPassword)
+{
+    UNIMPLEMENTED;
+    return E_NOTIMPL;
+}


### PR DESCRIPTION
MSVC's LINK is not able to export both the undecorated and decorated symbol from the same dll. This results in an incoherence between the spec file entries and the actual exports, breaking the dll export versioning.
