### PR TITLE
[CMAKE] gcc.cmake: Remove unwanted ${MODULE} in an add_compile_flags()

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -35,7 +35,7 @@ if(USE_DUMMY_PSEH)
 endif()
 
 if(STACK_PROTECTOR)
-    add_compile_flags(${MODULE} "-fstack-protector-all")
+    add_compile_flags("-fstack-protector-all")
 endif()
 
 # Compiler Core


### PR DESCRIPTION
Addendum to 87daca2bea39195687569ae47d51bf186768658d (r64527).