### PR TITLE
[NTDLL] Use lowest OS version GUID in the application manifest

### DIFF
--- a/dll/ntdll/ldr/ldrinit.c
+++ b/dll/ntdll/ldr/ldrinit.c
@@ -1636,8 +1636,13 @@ LdrpInitializeProcessCompat(PVOID pProcessActctx, PVOID* pOldShimData)
     if (ContextCompatInfo->ElementCount == 0)
         return;
 
-    /* Search for known GUID's, starting from newest to oldest. */
-    for (cur = 0; cur < RTL_NUMBER_OF(KnownCompatGuids); ++cur)
+    /* Search for known GUIDs, starting from oldest to newest.
+       Note that on Windows it is somewhat reversed, starting from the latest known
+       version, going down. But we are not Windows, trying to allow a lower version,
+       we are ReactOS trying to fake a higher version. So we interpret what Windows
+       does as "try the closest version to the actual version", so we start with the
+       lowest version, which is closest to Windows 2003, which we mostly are. */
+    for (cur = RTL_NUMBER_OF(KnownCompatGuids) - 1; cur != -1; --cur)
     {
         for (n = 0; n < ContextCompatInfo->ElementCount; ++n)
         {
@@ -1671,9 +1676,11 @@ LdrpInitializeProcessCompat(PVOID pProcessActctx, PVOID* pOldShimData)
                     *pOldShimData = pShimData;
                 }
 
-                /* Store the highest found version, and bail out. */
+                /* Store the lowest found version, and bail out. */
                 pShimData->dwRosProcessCompatVersion = KnownCompatGuids[cur].Version;
-                DPRINT1("LdrpInitializeProcessCompat: Found guid for winver 0x%x\n", KnownCompatGuids[cur].Version);
+                DPRINT1("LdrpInitializeProcessCompat: Found guid for winver 0x%x in manifest from %wZ\n",
+                        KnownCompatGuids[cur].Version,
+                        &(NtCurrentPeb()->ProcessParameters->ImagePathName));
                 return;
             }
         }


### PR DESCRIPTION
Use lowest OS version GUID in the application manifest, instead of highest
