### PR TITLE
[HAL:HALPPC] HalAllocateCrashDumpRegisters(): Remove redundant MapReg…

### DIFF
--- a/hal/halppc/generic/dma.c
+++ b/hal/halppc/generic/dma.c
@@ -1979,7 +1979,6 @@ HalAllocateCrashDumpRegisters(IN PADAPTER_OBJECT AdapterObject,
         }
 
         /* Try to find free map registers */
-        MapRegisterNumber = MAXULONG;
         MapRegisterNumber = RtlFindClearBitsAndSet(MasterAdapter->MapRegisters,
                                                    *NumberOfMapRegisters,
                                                    0);


### PR DESCRIPTION
…isterNumber assignment

No impact.

Detected by CppCheck: redundantAssignment.
Addendum to 81f092736fbbf02462da976c927b99c939d24988 (r28793).