### PR TITLE
[NFSD] readdir_copy_shortname(): Add needed brackets to '*name_size_out'. CORE-17078

### DIFF
--- a/base/services/nfsd/readdir.c
+++ b/base/services/nfsd/readdir.c
@@ -165,7 +165,11 @@ static void readdir_copy_shortname(
     /* GetShortPathName returns number of characters, not including \0 */
     *name_size_out = (CCHAR)GetShortPathNameW(name, name_out, 12);
     if (*name_size_out) {
+#ifndef __REACTOS__
         *name_size_out++;
+#else
+        (*name_size_out)++;
+#endif
         *name_size_out *= sizeof(WCHAR);
     }
 }


### PR DESCRIPTION
Obviously, increase the value, not move the pointer!

JIRA issue: [CORE-17078](https://jira.reactos.org/browse/CORE-17078)