### PR TITLE
[CSRSRV] CsrGetProcessLuid(): Check 1st NtQueryInformationToken() res…

### DIFF
--- a/subsystems/win32/csrsrv/procsup.c
+++ b/subsystems/win32/csrsrv/procsup.c
@@ -873,7 +873,7 @@ CsrGetProcessLuid(IN HANDLE hProcess OPTIONAL,
                                      NULL,
                                      0,
                                      &Length);
-    if (!NT_SUCCESS(Status))
+    if (Status != STATUS_BUFFER_TOO_SMALL)
     {
         /* Close the token and fail */
         NtClose(hToken);

--- a/subsystems/win32/csrsrv/procsup.c
+++ b/subsystems/win32/csrsrv/procsup.c
@@ -873,6 +873,12 @@ CsrGetProcessLuid(IN HANDLE hProcess OPTIONAL,
                                      NULL,
                                      0,
                                      &Length);
+    if (!NT_SUCCESS(Status))
+    {
+        /* Close the token and fail */
+        NtClose(hToken);
+        return Status;
+    }
 
     /* Allocate memory for the Token Info */
     if (!(TokenStats = RtlAllocateHeap(CsrHeap, 0, Length)))


### PR DESCRIPTION
…ult too

Detected by Cppcheck: redundantAssignment.