### PR TITLE
[NTVDM] GetNextFreeVDDEntry(): Remove 'Entry' redundant initialization

### DIFF
--- a/subsystems/mvdm/ntvdm/vddsup.c
+++ b/subsystems/mvdm/ntvdm/vddsup.c
@@ -59,7 +59,7 @@ static LIST_ENTRY VddUserHooksList = {&VddUserHooksList, &VddUserHooksList};
 
 static USHORT GetNextFreeVDDEntry(VOID)
 {
-    USHORT Entry = MAX_VDD_MODULES;
+    USHORT Entry;
     for (Entry = 0; Entry < ARRAYSIZE(VDDList); ++Entry)
     {
         if (VDDList[Entry].hDll == NULL) break;


### PR DESCRIPTION
No impact.

Detected by Cppcheck: redundantInitialization.
Addendum to ed874b41fc691f2dee27796b6d2f16777dc10d50 (r61283).