### PR TITLE
[REACTOS] Properly check 1st NtQueryInformationToken() result

### DIFF
--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -3494,6 +3494,12 @@ ReadTokenSid:
                                      &RequiredLength);
     if (Status != STATUS_BUFFER_TOO_SMALL)
     {
+        if (NT_SUCCESS(Status))
+        {
+            ERR("NtQueryInformationToken(0) succeeded unexpectedly (Status 0x%08lx)\n", Status);
+            return ERROR_NO_TOKEN;
+        }
+
         /* NOTE - as opposed to all other registry functions windows does indeed
                   change the last error code in case the caller supplied a invalid
                   handle for example! */

--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -3492,7 +3492,7 @@ ReadTokenSid:
                                      NULL,
                                      0,
                                      &RequiredLength);
-    if (!NT_SUCCESS(Status) && (Status != STATUS_BUFFER_TOO_SMALL))
+    if (Status != STATUS_BUFFER_TOO_SMALL)
     {
         /* NOTE - as opposed to all other registry functions windows does indeed
                   change the last error code in case the caller supplied a invalid

--- a/dll/win32/lsasrv/authport.c
+++ b/dll/win32/lsasrv/authport.c
@@ -58,7 +58,7 @@ LsapIsTrustedClient(
                                      NULL,
                                      0,
                                      &Size);
-    if (!NT_SUCCESS(Status) && Status != STATUS_BUFFER_TOO_SMALL)
+    if (Status != STATUS_BUFFER_TOO_SMALL)
         goto done;
 
     Privileges = RtlAllocateHeap(RtlGetProcessHeap(), 0, Size);

--- a/dll/win32/msgina/msgina.c
+++ b/dll/win32/msgina/msgina.c
@@ -705,14 +705,21 @@ DoAdminUnlock(
                                      &Size);
     if (Status != STATUS_BUFFER_TOO_SMALL)
     {
-        TRACE("NtQueryInformationToken() failed (Status 0x%08lx)\n", Status);
+        if (NT_SUCCESS(Status))
+        {
+            ERR("NtQueryInformationToken(0) succeeded unexpectedly (Status 0x%08lx)\n", Status);
+        }
+        else
+        {
+            WARN("NtQueryInformationToken() failed (Status 0x%08lx)\n", Status);
+        }
         goto done;
     }
 
     Groups = HeapAlloc(GetProcessHeap(), 0, Size);
     if (Groups == NULL)
     {
-        TRACE("HeapAlloc() failed\n");
+        ERR("HeapAlloc() failed\n");
         goto done;
     }
 
@@ -723,7 +730,7 @@ DoAdminUnlock(
                                      &Size);
     if (!NT_SUCCESS(Status))
     {
-        TRACE("NtQueryInformationToken() failed (Status 0x%08lx)\n", Status);
+        WARN("NtQueryInformationToken() failed (Status 0x%08lx)\n", Status);
         goto done;
     }
 

--- a/dll/win32/msgina/msgina.c
+++ b/dll/win32/msgina/msgina.c
@@ -703,7 +703,7 @@ DoAdminUnlock(
                                      NULL,
                                      0,
                                      &Size);
-    if ((Status != STATUS_SUCCESS) && (Status != STATUS_BUFFER_TOO_SMALL))
+    if (Status != STATUS_BUFFER_TOO_SMALL)
     {
         TRACE("NtQueryInformationToken() failed (Status 0x%08lx)\n", Status);
         goto done;


### PR DESCRIPTION
(Everywhere) We don't want to continue with `size = 0`, do we?

Follow-up to #2857.