### PR TITLE
[EXPLORER] Fixed issue in TaskBar AUTOHIDE CORE-17093

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1870,13 +1870,13 @@ ChangePos:
                 m_AutoHideOffset.cy = 0;
                 m_AutoHideOffset.cx -= AUTOHIDE_SPEED_HIDE;
                 if (m_AutoHideOffset.cx < -w)
-                    m_AutoHideOffset.cx = -w;
+                    m_AutoHideOffset.cx = w;
                 break;
             case ABE_TOP:
                 m_AutoHideOffset.cx = 0;
                 m_AutoHideOffset.cy -= AUTOHIDE_SPEED_HIDE;
                 if (m_AutoHideOffset.cy < -h)
-                    m_AutoHideOffset.cy = -h;
+                    m_AutoHideOffset.cy = h;
                 break;
             case ABE_RIGHT:
                 m_AutoHideOffset.cy = 0;


### PR DESCRIPTION
[EXPLORER] Fixed issue in TaskBar AUTOHIDE

In the "Taskbar and Start Menu Properties" dialog box,
with option "Auto-Hide TaskBar" checked, and
  unlocking and moving the taskbar to the top or the left side of the desktop, the CTrayWindow :: ProcessAutoHide () method enters an infinite loop.

In case ABE_LEFT and ABE_TOP the m_AutoHideOffset attribute never reaches the local variable "w" or "h", so that the timer be not restarted again in line 1897.

JIRA issue: CORE-17093