### PR TITLE
[CSRSRV] CsrUnhandledExceptionFilter: Check RtlAdjustPrivilege() result

### DIFF
--- a/subsystems/win32/csrsrv/server.c
+++ b/subsystems/win32/csrsrv/server.c
@@ -650,6 +650,7 @@ CsrUnhandledExceptionFilter(IN PEXCEPTION_POINTERS ExceptionInfo)
                                         TRUE,
                                         TRUE,
                                         &OldValue);
+
             /* Use the Process token if that failed */
             if (Status == STATUS_NO_TOKEN)
             {


### PR DESCRIPTION
And remove unused NtRaiseHardError() assignment.

Detected by Cppcheck: redundantAssignment.
Addendum to d221bdfbb1581227c0933e7cf93c7de9cdead01d (r55647).