### PR TITLE
[NTOS:MM] MmDeleteProcessAddressSpace(): Move 'Address' to where it b…

### DIFF
--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -572,7 +572,6 @@ MmDeleteProcessAddressSpace(PEPROCESS Process)
 {
 #ifndef _M_AMD64
     KIRQL OldIrql;
-    PVOID Address;
 #endif
 
     DPRINT("MmDeleteProcessAddressSpace(Process %p (%s))\n", Process,
@@ -591,7 +590,9 @@ MmDeleteProcessAddressSpace(PEPROCESS Process)
 #if (_MI_PAGING_LEVELS == 2)
     {
         KIRQL OldIrql;
+        PVOID Address;
         PMMPDE pointerPde;
+
         /* Attach to Process */
         KeAttachProcess(&Process->Pcb);
 


### PR DESCRIPTION
…elongs

No impact.

Detected by Cppcheck: unusedVariable.
Addendum to 2dade10d543589e1f5f762bbc1695f2917341171.