### PR TITLE
[NTOS:MM] MiGetPageTableForProcess(): #if out unreachable code

### DIFF
--- a/ntoskrnl/mm/arm/stubs.c
+++ b/ntoskrnl/mm/arm/stubs.c
@@ -182,7 +182,9 @@ MiGetPageTableForProcess(IN PEPROCESS Process,
             //
             // THIS WHOLE PATH IS TODO
             //
+#if 1
             goto kernelHack;
+#else
             ASSERT(FALSE);
 
             //
@@ -200,6 +202,7 @@ MiGetPageTableForProcess(IN PEPROCESS Process,
             // Set it
             //
             *PointerPde = TempPde;
+#endif
         }
     }
 


### PR DESCRIPTION
No impact.

Detected by Cppcheck: unreachableCode.
Addendum to ddaf47dec3f096666757ff2cc9892adc01da887c (r34976).