### PR TITLE
[LABEL] wmain(): Initialize 'szBuffer'. CORE-9444

### DIFF
--- a/base/applications/cmdutils/label/label.c
+++ b/base/applications/cmdutils/label/label.c
@@ -142,17 +142,14 @@ PromptYesNo(VOID)
 int wmain(int argc, WCHAR *argv[])
 {
     WCHAR szRootPath[] = L" :\\";
-    WCHAR szBuffer[80];
-    WCHAR szLabel[80];
+    WCHAR szBuffer[80] = L"";
+    WCHAR szLabel[80] = L"";
     WCHAR szOldLabel[80];
     DWORD dwSerialNr;
     INT len, i;
 
     /* Initialize the Console Standard Streams */
     ConInitStdStreams();
-
-    /* set empty label string */
-    szLabel[0] = UNICODE_NULL;
 
     /* print help */
     if (argc > 1 && wcscmp(argv[1], L"/?") == 0)


### PR DESCRIPTION
Detected by Cppcheck: uninitvar.
Addendum to 6bfe4f68aff2011f2a840ddfe16cd42067033d8e.
JIRA issue: [CORE-9444](https://jira.reactos.org/browse/CORE-9444)
