### PR TITLE
[REACTOS] RegQueryValueExW() wants bytes, not chars. CORE-9665

### DIFF
--- a/dll/win32/advpack/advpack.c
+++ b/dll/win32/advpack/advpack.c
@@ -907,7 +907,7 @@ HRESULT WINAPI UserInstStubWrapperW(HWND hWnd, HINSTANCE hInstance,
 {
     HKEY setup, guid;
     WCHAR stub[MAX_PATH];
-    DWORD size = MAX_PATH;
+    DWORD size = sizeof(stub);
     HRESULT hr = S_OK;
     BOOL res;
 

--- a/dll/win32/mscoree/metahost.c
+++ b/dll/win32/mscoree/metahost.c
@@ -377,7 +377,7 @@ static BOOL get_install_root(LPWSTR install_dir)
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, dotnet_key, 0, KEY_READ, &key))
         return FALSE;
 
-    len = MAX_PATH;
+    len = MAX_PATH * sizeof(WCHAR);
     if (RegQueryValueExW(key, install_root, 0, NULL, (LPBYTE)install_dir, &len))
     {
         RegCloseKey(key);

--- a/dll/win32/mscoree/mscoree_main.c
+++ b/dll/win32/mscoree/mscoree_main.c
@@ -53,7 +53,7 @@ static BOOL get_install_root(LPWSTR install_dir)
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, dotnet_key, 0, KEY_READ, &key))
         return FALSE;
 
-    len = MAX_PATH;
+    len = MAX_PATH * sizeof(WCHAR);
     if (RegQueryValueExW(key, install_root, 0, NULL, (LPBYTE)install_dir, &len))
     {
         RegCloseKey(key);

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4126,7 +4126,7 @@ BOOL WINAPI IsOS(DWORD feature)
  */
 HRESULT WINAPI SHLoadRegUIStringW(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD size)
 {
-    DWORD type, sz = size;
+    DWORD type, sz = size * sizeof(WCHAR);
 
     if(RegQueryValueExW(hkey, value, NULL, &type, (LPBYTE)buf, &sz) != ERROR_SUCCESS)
         return E_FAIL;


### PR DESCRIPTION
Cherry-pick:
https://source.winehq.org/git/wine.git/commit/a359e026662251b7c3367fe2815dcb6cb371af50
https://source.winehq.org/git/wine.git/commit/0662da18b85634928905e72041961ffd3a6e8045
https://source.winehq.org/git/wine.git/commit/e4e5eda3d9afcb5360747ddd97e6bf4fdc0c1c0f

JIRA issue: [CORE-9665](https://jira.reactos.org/browse/CORE-9665)

Co-authored-by: Victor Martinez <vicmarcal@gmail.com>