### PR TITLE
[MSI_WINETEST][NTOSKRNL] CMakeLists.txt: Improve/Fix 2 CMAKE_VERSION checks

### DIFF
--- a/modules/rostests/winetests/msi/CMakeLists.txt
+++ b/modules/rostests/winetests/msi/CMakeLists.txt
@@ -32,7 +32,7 @@ list(APPEND SOURCE
     suminfo.c
     precomp.h)
 
-if(NOT ${CMAKE_VERSION} VERSION_LESS "3.9.0")
+if(NOT CMAKE_VERSION VERSION_LESS 3.9.0)
     # CMake 3.9 and higher requires to specify this dependency manually
     # see https://gitlab.kitware.com/cmake/cmake/issues/19933
     set_property(SOURCE msi_winetest.rc PROPERTY OBJECT_DEPENDS custom.dll)

--- a/ntoskrnl/CMakeLists.txt
+++ b/ntoskrnl/CMakeLists.txt
@@ -21,7 +21,9 @@ add_executable(ntoskrnl
 set_property(TARGET ntoskrnl PROPERTY ENABLE_EXPORTS TRUE)
 set_target_properties(ntoskrnl PROPERTIES DEFINE_SYMBOL "")
 
-source_group(TREE ${REACTOS_SOURCE_DIR}/ntoskrnl PREFIX "Source Files" FILES ${NTOSKRNL_SOURCE})
+if(NOT CMAKE_VERSION VERSION_LESS 3.8.0)
+    source_group(TREE ${REACTOS_SOURCE_DIR}/ntoskrnl PREFIX "Source Files" FILES ${NTOSKRNL_SOURCE})
+endif()
 
 if(ARCH STREQUAL "i386")
     set_entrypoint(ntoskrnl KiSystemStartup 4)


### PR DESCRIPTION
Support RosBE 2.1.x builds a while longer...

```
CMake Error at ntoskrnl/CMakeLists.txt:24 (source_group):
source_group Unknown argument "C:/projects/reactos-git/ntoskrnl". Perhaps
the FILES keyword is missing.
```