### PR TITLE
[KERNEL32] FatalAppExitW: Add an 'UNREFERENCED_LOCAL_VARIABLE(Status)'

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -1609,6 +1609,8 @@ FatalAppExitW(IN UINT uAction,
 #if DBG
     /* Give the user a chance to abort */
     if ((NT_SUCCESS(Status)) && (Response == ResponseCancel)) return;
+#else
+    UNREFERENCED_LOCAL_VARIABLE(Status);
 #endif
 
     /* Otherwise kill the process */


### PR DESCRIPTION
Addendum to 21d2accad37825f47e3caa78ff36153751652238 (r71793).