### PR TITLE
[IPHLPAPI] getNumInterfacesInt(): Remove 'if()' redundant condition

### DIFF
--- a/dll/win32/iphlpapi/ifenum_reactos.c
+++ b/dll/win32/iphlpapi/ifenum_reactos.c
@@ -246,8 +246,7 @@ static DWORD getNumInterfacesInt(BOOL onlyNonLoopback)
 
     for( i = 0; i < numEntities; i++ ) {
         if( isInterface( &entitySet[i] ) &&
-            (!onlyNonLoopback ||
-             (onlyNonLoopback && !isLoopback( tcpFile, &entitySet[i] ))) )
+            (!onlyNonLoopback || !isLoopback( tcpFile, &entitySet[i] )) )
             numInterfaces++;
     }
 


### PR DESCRIPTION
No impact.

Detected by Cppcheck: redundantCondition.
Addendum to 1fe3a2d6c307a1ec11d7728a9493360a5808e1ac (r9788).