### PR TITLE
[LOG2LINES] Fix 'getFmt()'

### DIFF
--- a/sdk/tools/log2lines/util.c
+++ b/sdk/tools/log2lines/util.c
@@ -117,6 +117,7 @@ basename(char *path)
     return path;
 }
 
+static
 const char *
 getFmt(const char *a)
 {

--- a/sdk/tools/log2lines/util.c
+++ b/sdk/tools/log2lines/util.c
@@ -117,18 +117,20 @@ basename(char *path)
     return path;
 }
 
-static
-const char *
-getFmt(const char *a)
+int
+isOffset(const char *a)
 {
     const char *fmt = "%x";
+    int i = 0;
+
+    if (strchr(a, '.'))
+        return 0;
 
     if (*a == '0')
     {
         switch (*++a)
         {
         case 'x':
-            fmt = "%x";
             ++a;
             break;
         case 'd':
@@ -137,19 +139,10 @@ getFmt(const char *a)
             break;
         default:
             fmt = "%o";
-            break;
         }
     }
-    return fmt;
-}
 
-int
-isOffset(const char *a)
-{
-    int i = 0;
-    if (strchr(a, '.'))
-        return 0;
-    return sscanf(a, getFmt(a), &i);
+    return sscanf(a, fmt, &i);
 }
 
 int

--- a/sdk/tools/log2lines/util.c
+++ b/sdk/tools/log2lines/util.c
@@ -143,14 +143,6 @@ getFmt(const char *a)
     return fmt;
 }
 
-long
-my_atoi(const char *a)
-{
-    int i = 0;
-    sscanf(a, getFmt(a), &i);
-    return i;
-}
-
 int
 isOffset(const char *a)
 {

--- a/sdk/tools/log2lines/util.h
+++ b/sdk/tools/log2lines/util.h
@@ -41,7 +41,6 @@
 int file_exists(char *name);
 int mkPath(char *path, int isDir);
 char *basename(char *path);
-long my_atoi(const char *a);
 int isOffset(const char *a);
 int copy_file(char *src, char *dst);
 int set_LogFile(FILE **plogFile);

--- a/sdk/tools/log2lines/util.h
+++ b/sdk/tools/log2lines/util.h
@@ -41,7 +41,6 @@
 int file_exists(char *name);
 int mkPath(char *path, int isDir);
 char *basename(char *path);
-const char *getFmt(const char *a);
 long my_atoi(const char *a);
 int isOffset(const char *a);
 int copy_file(char *src, char *dst);


### PR DESCRIPTION
This fixes 'd' case.

Detected by Cppcheck: uselessAssignmentPtrArg.