### PR TITLE
[CMAKE] MSVC RUNTIME_CHECKS is a 'Debug'-only feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,8 @@ if(POLICY CMP0065)
     cmake_policy(SET CMP0065 NEW)
 endif()
 
+include(CMakeDependentOption)
+
 project(REACTOS)
 
 # Versioning

--- a/sdk/cmake/config-amd64.cmake
+++ b/sdk/cmake/config-amd64.cmake
@@ -44,5 +44,10 @@ set(USERMODE TRUE CACHE BOOL
 if(MSVC)
 set(_PREFAST_ FALSE CACHE BOOL
 "Whether to enable PREFAST while compiling.")
-    option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    else()
+        # RTC are incompatible with compiler optimizations.
+        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
+    endif()
 endif()

--- a/sdk/cmake/config-amd64.cmake
+++ b/sdk/cmake/config-amd64.cmake
@@ -44,10 +44,7 @@ set(USERMODE TRUE CACHE BOOL
 if(MSVC)
 set(_PREFAST_ FALSE CACHE BOOL
 "Whether to enable PREFAST while compiling.")
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
-    else()
-        # RTC are incompatible with compiler optimizations.
-        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
-    endif()
+    # RTC are incompatible with compiler optimizations.
+    CMAKE_DEPENDENT_OPTION(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON
+                           "CMAKE_BUILD_TYPE STREQUAL \"Debug\"" OFF)
 endif()

--- a/sdk/cmake/config-arm.cmake
+++ b/sdk/cmake/config-arm.cmake
@@ -45,10 +45,7 @@ set(NEWSPRINTF FALSE CACHE BOOL
 "Whether to compile the new sprintf.")
 
 if(MSVC)
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
-    else()
-        # RTC are incompatible with compiler optimizations.
-        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
-    endif()
+    # RTC are incompatible with compiler optimizations.
+    CMAKE_DEPENDENT_OPTION(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON
+                           "CMAKE_BUILD_TYPE STREQUAL \"Debug\"" OFF)
 endif()

--- a/sdk/cmake/config-arm.cmake
+++ b/sdk/cmake/config-arm.cmake
@@ -45,5 +45,10 @@ set(NEWSPRINTF FALSE CACHE BOOL
 "Whether to compile the new sprintf.")
 
 if(MSVC)
-    option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    else()
+        # RTC are incompatible with compiler optimizations.
+        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
+    endif()
 endif()

--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -83,8 +83,12 @@ set(_PREFAST_ FALSE CACHE BOOL
 "Whether to enable PREFAST while compiling.")
 set(_VS_ANALYZE_ FALSE CACHE BOOL
 "Whether to enable static analysis while compiling.")
-
-    option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
+    else()
+        # RTC are incompatible with compiler optimizations.
+        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
+    endif()
 endif()
 
 if(GCC)

--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -83,12 +83,9 @@ set(_PREFAST_ FALSE CACHE BOOL
 "Whether to enable PREFAST while compiling.")
 set(_VS_ANALYZE_ FALSE CACHE BOOL
 "Whether to enable static analysis while compiling.")
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-        option(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON)
-    else()
-        # RTC are incompatible with compiler optimizations.
-        set(RUNTIME_CHECKS FALSE CACHE BOOL "Whether to enable runtime checks on MSVC")
-    endif()
+    # RTC are incompatible with compiler optimizations.
+    CMAKE_DEPENDENT_OPTION(RUNTIME_CHECKS "Whether to enable runtime checks on MSVC" ON
+                           "CMAKE_BUILD_TYPE STREQUAL \"Debug\"" OFF)
 endif()
 
 if(GCC)


### PR DESCRIPTION
"cl : Command line error D8016 : '/Ox' and '/RTC1' command-line options are incompatible"

Addendum to 92dfec219d8c53a84c68ca069abbc170fc8bdb49.