### PR TITLE
[CDMAKE] Add 'DECLSPEC_NORETURN' to 'error_exit()'

### DIFF
--- a/modules/rosapps/applications/devutils/cdmake/cdmake.c
+++ b/modules/rosapps/applications/devutils/cdmake/cdmake.c
@@ -312,7 +312,9 @@ This function edits and displays an error message and then jumps back to the
 error exit point in main().
 -----------------------------------------------------------------------------*/
 
-static void error_exit(const char* fmt, ...)
+static
+DECLSPEC_NORETURN
+void error_exit(const char* fmt, ...)
 {
     va_list arg;
 


### PR DESCRIPTION
No impact.

Detected by Cppcheck: doubleFree.