### PR TITLE
[APPHELP_APITEST] Properly handle a couple 'malloc()/free()'

### DIFF
--- a/modules/rostests/apitests/apphelp/data.c
+++ b/modules/rostests/apitests/apphelp/data.c
@@ -469,15 +469,23 @@ void test_create_exe_imp(const WCHAR* name, int skip_rsrc_exports)
     HANDLE file;
     char *buf, *cur;
     DWORD size = 0x800;
+
     buf = malloc(size);
+    winetest_ok(buf != NULL, "malloc failed\n");
+    if (buf == NULL)
+    {
+        return;
+    }
 
     file = CreateFileW(name, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
     winetest_ok(file != INVALID_HANDLE_VALUE, "can't create file\n");
-    if(file == INVALID_HANDLE_VALUE)
+    if (file == INVALID_HANDLE_VALUE)
+    {
+        free(buf);
         return;
+    }
 
     memset(buf, 0, size);
-    cur = buf;
     cur = memcpy(buf, &dos_header, sizeof(dos_header));
     cur += dos_header.e_lfanew;
 

--- a/modules/rostests/apitests/apphelp/layerapi.c
+++ b/modules/rostests/apitests/apphelp/layerapi.c
@@ -569,16 +569,26 @@ static BOOL create_file(LPCSTR dir, LPCSTR name, int filler, DWORD size)
 {
     char target[MAX_PATH], *tmp;
     HANDLE file;
-    PathCombineA(target, dir, name);
 
     tmp = malloc(size);
-    memset(tmp, filler, size);
+    if (tmp == NULL)
+    {
+        SetLastError(ERROR_OUTOFMEMORY);
+        return FALSE;
+    }
+
+    PathCombineA(target, dir, name);
 
     file = CreateFileA(target, GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-    if(file == INVALID_HANDLE_VALUE)
+    if (file == INVALID_HANDLE_VALUE)
+    {
+        free(tmp);
         return FALSE;
+    }
 
+    memset(tmp, filler, size);
     WriteFile(file, tmp, size, &size, NULL);
+
     CloseHandle(file);
     free(tmp);
     return TRUE;


### PR DESCRIPTION
Detected by Cppcheck: memleak, redundantAssignment.
Addendum to 78280ad21f833411074e7ff0aa3d3345fb9e0704 (r71226).