### PR TITLE
[NTDLL_APITEST] Add probing alignment tests for NtXxxInformationProcess

### DIFF
--- a/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
@@ -3,11 +3,136 @@
  * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
  * PURPOSE:         Tests for the NtQueryInformationProcess API
  * PROGRAMMER:      Thomas Faber <thomas.faber@reactos.org>
+ *                  George Bișoc <george.bisoc@reactos.org>
  */
 
 #include "precomp.h"
 
 static LARGE_INTEGER TestStartTime;
+
+static
+void
+Test_ProcessBasicInformationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBasicInformation,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBasicInformation,
+                                       (PVOID)1,
+                                       sizeof(PROCESS_BASIC_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBasicInformation,
+                                       (PVOID)2,
+                                       sizeof(PROCESS_BASIC_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessQuotaLimitsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)1,
+                                       sizeof(QUOTA_LIMITS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessQuotaLimits,
+                                       (PVOID)2,
+                                       sizeof(QUOTA_LIMITS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessIoCountersClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessIoCounters,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessIoCounters,
+                                       (PVOID)1,
+                                       sizeof(IO_COUNTERS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessIoCounters,
+                                       (PVOID)2,
+                                       sizeof(IO_COUNTERS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessVmCountersClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessVmCounters,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessVmCounters,
+                                       (PVOID)1,
+                                       sizeof(VM_COUNTERS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessVmCounters,
+                                       (PVOID)2,
+                                       sizeof(VM_COUNTERS),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
 
 static
 void
@@ -187,6 +312,68 @@ Test_ProcessTimes(void)
 
 static
 void
+Test_ProcessDebugPortClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugPort,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugPort,
+                                       (PVOID)1,
+                                       sizeof(HANDLE),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugPort,
+                                       (PVOID)2,
+                                       sizeof(HANDLE),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDefaultHardErrorModeClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDefaultHardErrorMode,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDefaultHardErrorMode,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDefaultHardErrorMode,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
 Test_ProcessPriorityClassAlignment(void)
 {
     NTSTATUS Status;
@@ -323,6 +510,409 @@ Test_ProcessWx86Information(void)
     trace("VdmPower = %lu\n", VdmPower);
 }
 
+static
+void
+Test_ProcessHandleCountClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessHandleCount,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessHandleCount,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessHandleCount,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessPriorityBoostClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessPriorityBoost,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessPriorityBoost,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessPriorityBoost,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDeviceMapClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDeviceMap,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDeviceMap,
+                                       (PVOID)1,
+                                       sizeof(PROCESS_DEVICEMAP_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDeviceMap,
+                                       (PVOID)2,
+                                       sizeof(PROCESS_DEVICEMAP_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessSessionInformationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessSessionInformation,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessSessionInformation,
+                                       (PVOID)1,
+                                       sizeof(PROCESS_SESSION_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessSessionInformation,
+                                       (PVOID)2,
+                                       sizeof(PROCESS_SESSION_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessWow64InformationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessWow64Information,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessWow64Information,
+                                       (PVOID)1,
+                                       sizeof(ULONG_PTR),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessWow64Information,
+                                       (PVOID)2,
+                                       sizeof(ULONG_PTR),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessImageFileNameClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageFileName,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageFileName,
+                                       (PVOID)1,
+                                       sizeof(UNICODE_STRING),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageFileName,
+                                       (PVOID)2,
+                                       sizeof(UNICODE_STRING),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessLUIDDeviceMapsEnabledClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessLUIDDeviceMapsEnabled,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessLUIDDeviceMapsEnabled,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessLUIDDeviceMapsEnabled,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessBreakOnTerminationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBreakOnTermination,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBreakOnTermination,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessBreakOnTermination,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDebugObjectHandleClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugObjectHandle,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugObjectHandle,
+                                       (PVOID)1,
+                                       sizeof(HANDLE),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugObjectHandle,
+                                       (PVOID)2,
+                                       sizeof(HANDLE),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDebugFlagsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugFlags,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugFlags,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessDebugFlags,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessExecuteFlagsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessExecuteFlags,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessExecuteFlags,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessExecuteFlags,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessCookieClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessCookie,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessCookie,
+                                       (PVOID)1,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessCookie,
+                                       (PVOID)2,
+                                       sizeof(ULONG),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessImageInformationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and information length is wrong */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageInformation,
+                                       (PVOID)1,
+                                       0,
+                                       NULL);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageInformation,
+                                       (PVOID)1,
+                                       sizeof(SECTION_IMAGE_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an assignement size of 2 */
+    Status = NtQueryInformationProcess(NtCurrentProcess(),
+                                       ProcessImageInformation,
+                                       (PVOID)2,
+                                       sizeof(SECTION_IMAGE_INFORMATION),
+                                       NULL);
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
 START_TEST(NtQueryInformationProcess)
 {
     NTSTATUS Status;
@@ -330,7 +920,26 @@ START_TEST(NtQueryInformationProcess)
     Status = NtQuerySystemTime(&TestStartTime);
     ok_hex(Status, STATUS_SUCCESS);
 
+    Test_ProcessBasicInformationClass();
+    Test_ProcessQuotaLimitsClass();
+    Test_ProcessIoCountersClass();
+    Test_ProcessVmCountersClass();
     Test_ProcessTimes();
+    Test_ProcessDebugPortClass();
+    Test_ProcessDefaultHardErrorModeClass();
     Test_ProcessPriorityClassAlignment();
     Test_ProcessWx86Information();
+    Test_ProcessHandleCountClass();
+    Test_ProcessPriorityBoostClass();
+    Test_ProcessDeviceMapClass();
+    Test_ProcessSessionInformationClass();
+    Test_ProcessWow64InformationClass();
+    Test_ProcessImageFileNameClass();
+    Test_ProcessLUIDDeviceMapsEnabledClass();
+    Test_ProcessBreakOnTerminationClass();
+    Test_ProcessDebugObjectHandleClass();
+    Test_ProcessDebugFlagsClass();
+    Test_ProcessExecuteFlagsClass();
+    Test_ProcessCookieClass();
+    Test_ProcessImageInformationClass();
 }

--- a/modules/rostests/apitests/ntdll/NtSetInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtSetInformationProcess.c
@@ -9,6 +9,34 @@
 
 static
 void
+Test_ProcessQuotaLimitsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessQuotaLimits,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessQuotaLimits,
+                                     (PVOID)1,
+                                     sizeof(QUOTA_LIMITS));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessQuotaLimits,
+                                     (PVOID)2,
+                                     sizeof(QUOTA_LIMITS));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
 Test_ProcBasePriorityClass(void)
 {
     NTSTATUS Status;
@@ -150,6 +178,132 @@ Test_ProcRaisePriorityClass(void)
 
 static
 void
+Test_ProcessExceptionPortClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExceptionPort,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExceptionPort,
+                                     (PVOID)1,
+                                     sizeof(HANDLE));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExceptionPort,
+                                     (PVOID)2,
+                                     sizeof(HANDLE));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessAccessTokenClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAccessToken,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAccessToken,
+                                     (PVOID)1,
+                                     sizeof(PROCESS_ACCESS_TOKEN));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAccessToken,
+                                     (PVOID)2,
+                                     sizeof(PROCESS_ACCESS_TOKEN));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDefaultHardErrorModeClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDefaultHardErrorMode,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDefaultHardErrorMode,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDefaultHardErrorMode,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessUserModeIOPLClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessUserModeIOPL,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessUserModeIOPL,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessEnableAlignmentFaultFixupClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessEnableAlignmentFaultFixup,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Alignment probing is not performed for this class */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessEnableAlignmentFaultFixup,
+                                     (PVOID)1,
+                                     sizeof(BOOLEAN));
+    ok_hex(Status, STATUS_ACCESS_VIOLATION);
+}
+
+static
+void
 Test_ProcForegroundBackgroundClass(void)
 {
     NTSTATUS Status;
@@ -217,6 +371,34 @@ Test_ProcForegroundBackgroundClass(void)
 
 static
 void
+Test_ProcessPriorityClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityClass,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityClass,
+                                     (PVOID)1,
+                                     sizeof(PROCESS_PRIORITY_CLASS));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityClass,
+                                     (PVOID)2,
+                                     sizeof(PROCESS_PRIORITY_CLASS));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
 Test_ProcessWx86InformationClass(void)
 {
     NTSTATUS Status;
@@ -265,10 +447,220 @@ Test_ProcessWx86InformationClass(void)
     ok_hex(Status, STATUS_PRIVILEGE_NOT_HELD);
 }
 
+static
+void
+Test_ProcessAffinityMaskClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAffinityMask,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAffinityMask,
+                                     (PVOID)1,
+                                     sizeof(KAFFINITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessAffinityMask,
+                                     (PVOID)2,
+                                     sizeof(KAFFINITY));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessPriorityBoostClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityBoost,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityBoost,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessPriorityBoost,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDeviceMapClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDeviceMap,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDeviceMap,
+                                     (PVOID)1,
+                                     sizeof(HANDLE));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDeviceMap,
+                                     (PVOID)2,
+                                     sizeof(HANDLE));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessSessionInformationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessSessionInformation,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessSessionInformation,
+                                     (PVOID)1,
+                                     sizeof(PROCESS_SESSION_INFORMATION));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessSessionInformation,
+                                     (PVOID)2,
+                                     sizeof(PROCESS_SESSION_INFORMATION));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessBreakOnTerminationClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBreakOnTermination,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBreakOnTermination,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessBreakOnTermination,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessDebugFlagsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDebugFlags,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDebugFlags,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessDebugFlags,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
+static
+void
+Test_ProcessExecuteFlagsClass(void)
+{
+    NTSTATUS Status;
+
+    /* The buffer is misaligned and the information length is wrong */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExecuteFlags,
+                                     (PVOID)1,
+                                     0);
+    ok_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* The buffer is misaligned */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExecuteFlags,
+                                     (PVOID)1,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+
+    /* The buffer is misaligned -- try with an alignment size of 2 */
+    Status = NtSetInformationProcess(NtCurrentProcess(),
+                                     ProcessExecuteFlags,
+                                     (PVOID)2,
+                                     sizeof(ULONG));
+    ok_hex(Status, STATUS_DATATYPE_MISALIGNMENT);
+}
+
 START_TEST(NtSetInformationProcess)
 {
+    Test_ProcessQuotaLimitsClass();
+    Test_ProcessExceptionPortClass();
+    Test_ProcessAccessTokenClass();
+    Test_ProcessDefaultHardErrorModeClass();
+    Test_ProcessUserModeIOPLClass();
+    Test_ProcessEnableAlignmentFaultFixupClass();
     Test_ProcForegroundBackgroundClass();
     Test_ProcBasePriorityClass();
     Test_ProcRaisePriorityClass();
     Test_ProcessWx86InformationClass();
+    Test_ProcessPriorityClass();
+    Test_ProcessAffinityMaskClass();
+    Test_ProcessPriorityBoostClass();
+    Test_ProcessDeviceMapClass();
+    Test_ProcessSessionInformationClass();
+    Test_ProcessBreakOnTerminationClass();
+    Test_ProcessDebugFlagsClass();
+    Test_ProcessExecuteFlagsClass();
 }


### PR DESCRIPTION
## Purpose
Implement several alignment probing tests for `NtXxxInformationProcess` functions needed to gather alignment details for #2874. Further tests will be added later.
**Windows Server 2003**
![Capture](https://user-images.githubusercontent.com/34916900/83977003-0529b380-a8fe-11ea-9695-a5606db669f5.PNG)
**Windows XP**
![Capture2](https://user-images.githubusercontent.com/34916900/83977007-0955d100-a8fe-11ea-86f7-284828b2b961.PNG)
**ReactOS**
![4](https://user-images.githubusercontent.com/34916900/83977015-11ae0c00-a8fe-11ea-864a-01226739ffc0.PNG)