### PR TITLE
[FASTFAT] VfatGetVolumeBitmap(): Add 'UNIMPLEMENTED'. ROSAPPS-332

### DIFF
--- a/drivers/filesystems/fastfat/fsctl.c
+++ b/drivers/filesystems/fastfat/fsctl.c
@@ -936,6 +936,7 @@ VfatGetVolumeBitmap(
     PVFAT_IRP_CONTEXT IrpContext)
 {
     DPRINT("VfatGetVolumeBitmap (IrpContext %p)\n", IrpContext);
+    UNIMPLEMENTED;
     return STATUS_INVALID_DEVICE_REQUEST;
 }
 


### PR DESCRIPTION
Be explicit.

JIRA issue: [ROSAPPS-332](https://jira.reactos.org/browse/ROSAPPS-332)