### PR TITLE
[UXTHEME] Enable NT6+ 'GetThemeTransitionDuration()' stub. CORE-11506

### DIFF
--- a/dll/win32/uxtheme/metric.c
+++ b/dll/win32/uxtheme/metric.c
@@ -220,7 +220,6 @@ HRESULT WINAPI GetThemeSysString(HTHEME hTheme, int iStringID,
     return E_PROP_ID_UNSUPPORTED;
 }
 
-#ifndef __REACTOS__
 /***********************************************************************
  *      GetThemeTransitionDuration                          (UXTHEME.@)
  */
@@ -232,4 +231,3 @@ HRESULT WINAPI GetThemeTransitionDuration(HTHEME hTheme, int iPartId, int iState
 
     return E_NOTIMPL;
 }
-#endif

--- a/dll/win32/uxtheme/uxtheme.spec
+++ b/dll/win32/uxtheme/uxtheme.spec
@@ -93,3 +93,4 @@
 93 stdcall SetThemeAppProperties(long)
 94 stdcall SetWindowTheme(ptr wstr wstr)
 95 stdcall ThemeInitApiHook(long ptr)
+@ stdcall -version=0x600+ GetThemeTransitionDuration(ptr long long long long ptr)

--- a/sdk/include/psdk/uxtheme.h
+++ b/sdk/include/psdk/uxtheme.h
@@ -128,6 +128,9 @@ int WINAPI GetThemeSysSize(HTHEME,int);
 HRESULT WINAPI GetThemeSysString(HTHEME,int,LPWSTR,int);
 HRESULT WINAPI GetThemeTextExtent(HTHEME,HDC,int,int,LPCWSTR,int,DWORD,const RECT*,RECT*);
 HRESULT WINAPI GetThemeTextMetrics(HTHEME,HDC,int,int,TEXTMETRICW*);
+#if _WIN32_WINNT >= 0x0600
+HRESULT WINAPI GetThemeTransitionDuration(HTHEME,int,int,int,int,DWORD*);
+#endif
 HTHEME WINAPI GetWindowTheme(HWND);
 HRESULT WINAPI HitTestThemeBackground(HTHEME,HDC,int,int,DWORD,const RECT*,HRGN,POINT,WORD*);
 BOOL WINAPI IsAppThemed(void);


### PR DESCRIPTION
Follow-up to 8eb8e09554eda425517e569e208be66dfcda8e0f (r73365).

JIRA issue: [CORE-11506](https://jira.reactos.org/browse/CORE-11506)