### PR TITLE
[NFS41_NP][VFD] Add 2 'va_end()'

### DIFF
--- a/dll/np/nfs/nfs41_np.c
+++ b/dll/np/nfs/nfs41_np.c
@@ -52,6 +52,9 @@ ULONG _cdecl NFS41DbgPrint( __in LPTSTR Format, ... )
         OutputDebugString( TRACE_TAG );
         OutputDebugString( szbuffer );
     }
+#ifdef __REACTOS__
+    va_end(marker);
+#endif
 
     return rc;
 }

--- a/modules/rosapps/lib/vfdlib/vfdlib.c
+++ b/modules/rosapps/lib/vfdlib/vfdlib.c
@@ -179,6 +179,10 @@ void DebugTrace(
 
 	_vsnprintf(buf + len, sizeof(buf) - len, sFormat, args);
 
+#ifdef __REACTOS__
+    va_end(args);
+#endif
+
 	OutputDebugString(buf);
 }
 #endif	// _DEBUG


### PR DESCRIPTION
Detected by Cppcheck: va_end_missing.