### PR TITLE
[RDBSSLIB] RxCommonWrite(): 'BreakpointsSave' is 'DBG'-only

### DIFF
--- a/sdk/lib/drivers/rdbsslib/rdbss.c
+++ b/sdk/lib/drivers/rdbsslib/rdbss.c
@@ -4648,7 +4648,9 @@ RxCommonWrite(
             else
             {
                 PVOID SystemBuffer;
+#if DBG
                 ULONG BreakpointsSave;
+#endif
 
                 /* Map the user buffer */
                 SystemBuffer = RxNewMapUserBuffer(RxContext);


### PR DESCRIPTION
MSVC 'Release' build reports:
'sdk\lib\drivers\rdbsslib\rdbss.c(4651): error C4101: 'BreakpointsSave': unreferenced local variable'

Addendum to f8e1661 (r75398).