### PR TITLE
[APISETS] api-ms-win-crt-utility-l1-1-0: Fix 'llabs' return type

### DIFF
--- a/dll/apisets/api-ms-win-crt-utility-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-utility-l1-1-0.spec
@@ -18,7 +18,7 @@
 @ stub imaxdiv
 @ stdcall labs() msvcrt.labs
 @ stdcall ldiv() msvcrt.ldiv
-@ stub llabs
+@ stub -ret64 llabs
 @ stub lldiv
 @ stdcall qsort() msvcrt.qsort
 @ stub qsort_s


### PR DESCRIPTION
MSVC 'Release' build reports:
'dll\apisets\api-ms-win-crt-utility-l1-1-0_stubs.c(41): warning C4391: 'int llabs()': incorrect return type for intrinsic function, expected '__int64''

Addendum to 3f15a0d.