### PR TITLE
[MSI][OLE32] 1+1 removals, related to wine/asm.h

### DIFF
--- a/dll/win32/msi/msi_ros.diff
+++ b/dll/win32/msi/msi_ros.diff
@@ -197,10 +197,9 @@ Index: D:/trunk/dll/win32/msi/msvchelper.h
 ===================================================================
 --- D:/trunk/dll/win32/msi/msvchelper.h	(revision 0)
 +++ D:/trunk/dll/win32/msi/msvchelper.h	(revision 51711)
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,12 @@
 +
 +#ifdef __i386__
-+#define __ASM_DEFINE_FUNC(name,suffix,code)
 +
 +typedef unsigned int (__stdcall *__MSVC__MsiCustomActionEntryPoint)(unsigned int);
 +

--- a/dll/win32/msi/msvchelper.h
+++ b/dll/win32/msi/msvchelper.h
@@ -1,6 +1,5 @@
 
 #ifdef __i386__
-#define __ASM_DEFINE_FUNC(name,suffix,code)
 
 typedef unsigned int (__stdcall *__MSVC__MsiCustomActionEntryPoint)(unsigned int);
 

--- a/dll/win32/ole32/ole32_ros.diff
+++ b/dll/win32/ole32/ole32_ros.diff
@@ -40,17 +40,6 @@ diff -pudN e:\wine\dlls\ole32/compobj.c e:\reactos\dll\win32\ole32/compobj.c
 diff -pudN e:\wine\dlls\ole32/stg_prop.c e:\reactos\dll\win32\ole32/stg_prop.c
 --- e:\wine\dlls\ole32/stg_prop.c	2016-11-16 17:29:23 +0100
 +++ e:\reactos\dll\win32\ole32/stg_prop.c	2016-08-15 16:49:04 +0100
-@@ -41,6 +41,10 @@
- 
- WINE_DEFAULT_DEBUG_CHANNEL(storage);
- 
-+#ifdef _MSC_VER
-+#define __ASM_STDCALL_FUNC(name,args,code)
-+#endif
-+
- static inline StorageImpl *impl_from_IPropertySetStorage( IPropertySetStorage *iface )
- {
-     return CONTAINING_RECORD(iface, StorageImpl, base.IPropertySetStorage_iface);
 @@ -1013,7 +1017,13 @@ static HRESULT PropertyStorage_ReadDicti
      return hr;
  }


### PR DESCRIPTION
MSVC build reports:
{{
dll\win32\msi\msvchelper.h(3): warning C4005: '__ASM_DEFINE_FUNC': macro redefinition
sdk\include\reactos\wine/asm.h(60): note: see previous definition of '__ASM_DEFINE_FUNC'
dll\win32\msi\custom.c(547): warning C4003: not enough actual parameters for macro '__ASM_DEFINE_FUNC'
}}

Addendum to 476c99b and 9efafd6.