### PR TITLE
[SDK][SVCHOST] Move all global svchost declarations to public header

### DIFF
--- a/base/services/svchost/svchost.h
+++ b/base/services/svchost/svchost.h
@@ -15,11 +15,9 @@
 #include <rpc.h>
 #include <ndk/rtlfuncs.h>
 #include <ndk/kdtypes.h>
+#include <dpfilter.h>
 
-//
-// FIXME: Should go in public headers
-//
-#define DPFLTR_SVCHOST_ID 28
+#include <svc.h>
 
 //
 // This prints out a SVCHOST-specific debug print, with the PID/TID
@@ -34,49 +32,6 @@
 
 #define DBG_ERR(fmt, ...)   SvchostDbgPrint(1, fmt, __VA_ARGS__)
 #define DBG_TRACE(fmt, ...) SvchostDbgPrint(4, fmt, __VA_ARGS__)
-
-//
-// This is the callback that a hosted service can register for stop notification
-// FIXME: GLOBAL HEADER
-//
-typedef VOID
-    (CALLBACK *PSVCHOST_STOP_CALLBACK) (
-    _In_ PVOID lpParameter,
-    _In_ BOOLEAN TimerOrWaitFired
-    );
-
-//
-// Hosted Services and SvcHost Use this Structure
-// FIXME: GLOBAL HEADER
-//
-typedef struct _SVCHOST_GLOBALS
-{
-    PVOID NullSid;
-    PVOID WorldSid;
-    PVOID LocalSid;
-    PVOID NetworkSid;
-    PVOID LocalSystemSid;
-    PVOID LocalServiceSid;
-    PVOID NetworkServiceSid;
-    PVOID BuiltinDomainSid;
-    PVOID AuthenticatedUserSid;
-    PVOID AnonymousLogonSid;
-    PVOID AliasAdminsSid;
-    PVOID AliasUsersSid;
-    PVOID AliasGuestsSid;
-    PVOID AliasPowerUsersSid;
-    PVOID AliasAccountOpsSid;
-    PVOID AliasSystemOpsSid;
-    PVOID AliasPrintOpsSid;
-    PVOID AliasBackupOpsSid;
-    PVOID RpcpStartRpcServer;
-    PVOID RpcpStopRpcServer;
-    PVOID RpcpStopRpcServerEx;
-    PVOID SvcNetBiosOpen;
-    PVOID SvcNetBiosClose;
-    PVOID SvcNetBiosReset;
-    PVOID SvcRegisterStopCallback;
-} SVCHOST_GLOBALS, *PSVCHOST_GLOBALS;
 
 //
 // This is the callback for them to receive it

--- a/sdk/include/reactos/svc.h
+++ b/sdk/include/reactos/svc.h
@@ -1,0 +1,54 @@
+/*
+ * PROJECT:     ReactOS Service Host
+ * LICENSE:     BSD - See COPYING.ARM in the top level directory
+ * FILE:        sdk/include/reactos/svc.h
+ * PURPOSE:     Global Header for Service Host
+ * PROGRAMMERS: ReactOS Portable Systems Group
+ */
+/* See https://www.geoffchappell.com/studies/windows/win32/services/svchost/process/globaldata.htm?tx=78 */
+
+#ifndef __SVC_H
+#define __SVC_H
+
+//
+// This is the callback that a hosted service can register for stop notification
+//
+typedef VOID
+(CALLBACK *PSVCHOST_STOP_CALLBACK) (
+    _In_ PVOID lpParameter,
+    _In_ BOOLEAN TimerOrWaitFired
+    );
+
+//
+// Hosted Services and SvcHost Use this Structure
+//
+typedef struct _SVCHOST_GLOBALS
+{
+    PVOID NullSid;
+    PVOID WorldSid;
+    PVOID LocalSid;
+    PVOID NetworkSid;
+    PVOID LocalSystemSid;
+    PVOID LocalServiceSid;
+    PVOID NetworkServiceSid;
+    PVOID BuiltinDomainSid;
+    PVOID AuthenticatedUserSid;
+    PVOID AnonymousLogonSid;
+    PVOID AliasAdminsSid;
+    PVOID AliasUsersSid;
+    PVOID AliasGuestsSid;
+    PVOID AliasPowerUsersSid;
+    PVOID AliasAccountOpsSid;
+    PVOID AliasSystemOpsSid;
+    PVOID AliasPrintOpsSid;
+    PVOID AliasBackupOpsSid;
+    PVOID RpcpStartRpcServer;
+    PVOID RpcpStopRpcServer;
+    PVOID RpcpStopRpcServerEx;
+    PVOID SvcNetBiosOpen;
+    PVOID SvcNetBiosClose;
+    PVOID SvcNetBiosReset;
+    PVOID SvcRegisterStopCallback;
+} SVCHOST_GLOBALS, *PSVCHOST_GLOBALS;
+
+#endif /* __SVC_H */


### PR DESCRIPTION
## Purpose

Move all svchost declarations which should be global, from private svchost.h header to public svc.h header.
It will allow to use those declarations globally where they are required (e. g. for SvchostPushServiceGlobals functions in some services: https://www.geoffchappell.com/studies/windows/win32/services/svchost/dll/svchostpushserviceglobals.htm?tx=76).
That public header probably will be ROS-specific, since MS did not document it, see https://www.geoffchappell.com/studies/windows/win32/services/svchost/process/globaldata.htm?tx=78 instead.
No functional changes.

JIRA issue: None.

## Proposed changes

- Create a public sdk/include/reactos/svc.h header;
- Move there all declarations which should be public, from private base/services/svchost/svchost.h;
- Update the includes in svchost.h accordingly. Move all previous includes to the public header, since they are required by global svchost declarations. But they are still used by private declarations also, because I included the public header there too.