### PR TITLE
[MSWSOCK] Use a correct prototype for SvchostPushServiceGlobals stub

### DIFF
--- a/dll/win32/mswsock/mswsock.spec
+++ b/dll/win32/mswsock/mswsock.spec
@@ -18,7 +18,7 @@
 @ stdcall SetServiceW(long long long ptr ptr ptr)
 @ stdcall StartWsdpService()
 @ stdcall StopWsdpService()
-@ stdcall SvchostPushServiceGlobals(long)
+@ stdcall SvchostPushServiceGlobals(ptr)
 @ stdcall TransmitFile(long long long long ptr ptr long)
 @ stdcall WSARecvEx(long ptr long ptr)
 @ stdcall WSPStartup(long ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr ptr)

--- a/dll/win32/mswsock/stubs.c
+++ b/dll/win32/mswsock/stubs.c
@@ -12,6 +12,7 @@
 #include <windef.h>
 #include <ws2spi.h>
 #include <nspapi.h>
+#include <svc.h>
 
 typedef DWORD (* LPFN_NSPAPI)(VOID);
 typedef struct _NS_ROUTINE {
@@ -441,14 +442,14 @@ StopWsdpService()
 
 /*
  * @unimplemented
+ * 
+ * See https://www.geoffchappell.com/studies/windows/win32/services/svchost/dll/svchostpushserviceglobals.htm
  */
-DWORD
+VOID
 WINAPI
-SvchostPushServiceGlobals(DWORD Value)
+SvchostPushServiceGlobals(SVCHOST_GLOBALS *lpGlobals)
 {
   OutputDebugStringW(L"mswsock SvchostPushServiceGlobals stub called\n");
-
-  return 0;
 }
 
 


### PR DESCRIPTION
## Purpose

Update the prototype of SvchostPushServiceGlobals() stub in mswsock, according to https://www.geoffchappell.com/studies/windows/win32/services/svchost/dll/svchostpushserviceglobals.htm, because this is completely undocumented from MS side.
It uses a public sdk/include/reactos/svc.h with global svchost declarations, which I added in my previous #2931 PR. Without that PR applied, the checks will fail. So please merge that first.

JIRA issue: None.

## Proposed changes

- Update the function prototype;
- Include svc.h header added in the previous PR;
- Update the comment by adding a link to the documentation.