### PR TITLE
[WINMM] Improve implementation of timeGetTime, timeBeginPeriod, timeEndPeriod

### DIFF
--- a/dll/win32/winmm/time.c
+++ b/dll/win32/winmm/time.c
@@ -423,12 +423,14 @@ MMRESULT WINAPI timeGetDevCaps(LPTIMECAPS lpCaps, UINT wSize)
 MMRESULT WINAPI timeBeginPeriod(UINT wPeriod)
 {
     if (wPeriod < MMSYSTIME_MININTERVAL || wPeriod > MMSYSTIME_MAXINTERVAL)
-		return TIMERR_NOCANDO;
+        return TIMERR_NOCANDO;
 
     /*  High resolution timer requested, use QPC */
-    if (wPeriod <= 5 && TIME_qpcFreq.QuadPart == 0) 
+    if (wPeriod <= 5 && TIME_qpcFreq.QuadPart == 0)
+    {
         if(QueryPerformanceFrequency(&TIME_qpcFreq))
             TIME_qpcFreq.QuadPart /= 1000;
+    }
 
     if (wPeriod > MMSYSTIME_MININTERVAL)
     {
@@ -444,7 +446,7 @@ MMRESULT WINAPI timeBeginPeriod(UINT wPeriod)
 MMRESULT WINAPI timeEndPeriod(UINT wPeriod)
 {
     if (wPeriod < MMSYSTIME_MININTERVAL || wPeriod > MMSYSTIME_MAXINTERVAL)
-		return TIMERR_NOCANDO;
+        return TIMERR_NOCANDO;
 
     /*  High resolution timer no longer requested, stop using QPC */
     if (wPeriod <= 5 && TIME_qpcFreq.QuadPart != 0)
@@ -463,7 +465,7 @@ MMRESULT WINAPI timeEndPeriod(UINT wPeriod)
  */
 DWORD WINAPI timeGetTime(void)
 {
-	LARGE_INTEGER perfCount;
+    LARGE_INTEGER perfCount;
 #if defined(COMMENTOUTPRIORTODELETING)
     DWORD       count;
 
@@ -474,11 +476,11 @@ DWORD WINAPI timeGetTime(void)
     if (pFnRestoreThunkLock) pFnRestoreThunkLock(count);
 #endif
     /* Use QPC if a high-resolution timer was requested (<= 5ms) */
-    if (TIME_qpcFreq.QuadPart != 0) 
+    if (TIME_qpcFreq.QuadPart != 0)
     {
         QueryPerformanceCounter(&perfCount);
         return (DWORD)(perfCount.QuadPart / TIME_qpcFreq.QuadPart);
     }
-	/* Otherwise continue using GetTickCount */
+    /* Otherwise continue using GetTickCount */
     return GetTickCount();
 }

--- a/dll/win32/winmm/time.c
+++ b/dll/win32/winmm/time.c
@@ -47,6 +47,7 @@ static    LPWINE_TIMERENTRY 	TIME_TimersList;
 static    HANDLE                TIME_hKillEvent;
 static    HANDLE                TIME_hWakeEvent;
 static    BOOL                  TIME_TimeToDie = TRUE;
+static    LARGE_INTEGER         TIME_qpcFreq;
 
 /*
  * Some observations on the behavior of winmm on Windows.
@@ -422,7 +423,12 @@ MMRESULT WINAPI timeGetDevCaps(LPTIMECAPS lpCaps, UINT wSize)
 MMRESULT WINAPI timeBeginPeriod(UINT wPeriod)
 {
     if (wPeriod < MMSYSTIME_MININTERVAL || wPeriod > MMSYSTIME_MAXINTERVAL)
-	return TIMERR_NOCANDO;
+		return TIMERR_NOCANDO;
+
+    /*  High resolution timer requested, use QPC */
+    if (wPeriod <= 5 && TIME_qpcFreq.QuadPart == 0) 
+        if(QueryPerformanceFrequency(&TIME_qpcFreq))
+            TIME_qpcFreq.QuadPart /= 1000;
 
     if (wPeriod > MMSYSTIME_MININTERVAL)
     {
@@ -438,7 +444,11 @@ MMRESULT WINAPI timeBeginPeriod(UINT wPeriod)
 MMRESULT WINAPI timeEndPeriod(UINT wPeriod)
 {
     if (wPeriod < MMSYSTIME_MININTERVAL || wPeriod > MMSYSTIME_MAXINTERVAL)
-	return TIMERR_NOCANDO;
+		return TIMERR_NOCANDO;
+
+    /*  High resolution timer no longer requested, stop using QPC */
+    if (wPeriod <= 5 && TIME_qpcFreq.QuadPart != 0)
+        TIME_qpcFreq.QuadPart = 0;
 
     if (wPeriod > MMSYSTIME_MININTERVAL)
     {
@@ -453,6 +463,7 @@ MMRESULT WINAPI timeEndPeriod(UINT wPeriod)
  */
 DWORD WINAPI timeGetTime(void)
 {
+	LARGE_INTEGER perfCount;
 #if defined(COMMENTOUTPRIORTODELETING)
     DWORD       count;
 
@@ -462,6 +473,12 @@ DWORD WINAPI timeGetTime(void)
     if (pFnReleaseThunkLock) pFnReleaseThunkLock(&count);
     if (pFnRestoreThunkLock) pFnRestoreThunkLock(count);
 #endif
-
+    /* Use QPC if a high-resolution timer was requested (<= 5ms) */
+    if (TIME_qpcFreq.QuadPart != 0) 
+    {
+        QueryPerformanceCounter(&perfCount);
+        return (DWORD)(perfCount.QuadPart / TIME_qpcFreq.QuadPart);
+    }
+	/* Otherwise continue using GetTickCount */
     return GetTickCount();
 }

--- a/dll/win32/winmm/time.c
+++ b/dll/win32/winmm/time.c
@@ -428,7 +428,7 @@ MMRESULT WINAPI timeBeginPeriod(UINT wPeriod)
     /*  High resolution timer requested, use QPC */
     if (wPeriod <= 5 && TIME_qpcFreq.QuadPart == 0)
     {
-        if(QueryPerformanceFrequency(&TIME_qpcFreq))
+        if (QueryPerformanceFrequency(&TIME_qpcFreq))
             TIME_qpcFreq.QuadPart /= 1000;
     }
 


### PR DESCRIPTION
## Purpose

Improve Windows Multimedia timer implementations.  Many games that use a frame-limiter to keep their framerate locked rely on these functions giving millisecond accurate timing readings.  The previous implementation of wrapping GetTickCount only offers accuracy of tens of milliseconds leading to unstable or slow framerates and gameplay.

JIRA issue: [CORE-17121](https://jira.reactos.org/browse/CORE-17121)

## Proposed changes

- Improve timeGetTime by using the more accurate QueryPerformanceCounter function when a high-resolution timer was requested.
- timeBeginPeriod with a resolution of 5ms or less will switch timeGetTime from using GetTickCount to QueryPerformanceCounter.
- timeEndPeriod with a resolution of 5ms or less will switch timeGetTime back to GetTickCount.