### PR TITLE
[BOOTVID] Fix drawing strings on top of the bitmap

### DIFF
--- a/drivers/base/bootvid/arm/bootvid.c
+++ b/drivers/base/bootvid/arm/bootvid.c
@@ -255,7 +255,7 @@ VidCleanUp(VOID)
 VOID
 NTAPI
 VidScreenToBufferBlt(
-    _Out_ PUCHAR Buffer,
+    _Out_writes_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,

--- a/drivers/base/bootvid/common.c
+++ b/drivers/base/bootvid/common.c
@@ -55,9 +55,9 @@ BitBlt(
     _In_ ULONG BitsPerPixel,
     _In_ ULONG Delta)
 {
-    ULONG sx, dx, dy;
-    UCHAR color;
-    ULONG offset = 0;
+    ULONG X, Y, Pixel;
+    UCHAR Colors;
+    PUCHAR InputBuffer;
     const ULONG Bottom = Top + Height;
     const ULONG Right = Left + Width;
 
@@ -82,24 +82,28 @@ BitBlt(
     PrepareForSetPixel();
 
     /* 4bpp blitting */
-    for (dy = Top; dy < Bottom; ++dy)
+    for (Y = Top; Y < Bottom; ++Y)
     {
-        sx = 0;
-        do
+        InputBuffer = Buffer;
+
+        for (X = Left, Pixel = 0;
+             X < Right;
+             ++X, ++Pixel)
         {
-            /* Extract color */
-            color = Buffer[offset + sx];
+            if (Pixel % 2 == 0)
+            {
+                /* Extract colors at every two pixels */
+                Colors = *InputBuffer++;
 
-            /* Calc destination x */
-            dx = Left + (sx << 1);
+                SetPixel(X, Y, Colors >> 4);
+            }
+            else
+            {
+                SetPixel(X, Y, Colors & 0x0F);
+            }
+        }
 
-            /* Set two pixels */
-            SetPixel(dx, dy, color >> 4);
-            SetPixel(dx + 1, dy, color & 0x0F);
-
-            sx++;
-        } while (dx < Right);
-        offset += Delta;
+        Buffer += Delta;
     }
 }
 

--- a/drivers/base/bootvid/common.c
+++ b/drivers/base/bootvid/common.c
@@ -51,7 +51,7 @@ BitBlt(
     _In_ ULONG Top,
     _In_ ULONG Width,
     _In_ ULONG Height,
-    _In_ PUCHAR Buffer,
+    _In_reads_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG BitsPerPixel,
     _In_ ULONG Delta)
 {
@@ -318,7 +318,7 @@ VidSetTextColor(
 VOID
 NTAPI
 VidDisplayStringXY(
-    _In_ PUCHAR String,
+    _In_z_ PUCHAR String,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ BOOLEAN Transparent)
@@ -368,7 +368,7 @@ VidSetScrollRegion(
 VOID
 NTAPI
 VidDisplayString(
-    _In_ PUCHAR String)
+    _In_z_ PUCHAR String)
 {
     /* Start looping the string */
     for (; *String; ++String)
@@ -446,7 +446,7 @@ VidDisplayString(
 VOID
 NTAPI
 VidBufferToScreenBlt(
-    _In_ PUCHAR Buffer,
+    _In_reads_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,

--- a/drivers/base/bootvid/i386/pc/pc.h
+++ b/drivers/base/bootvid/i386/pc/pc.h
@@ -43,8 +43,11 @@ SetPixel(
     /* Select the bitmask register and write the mask */
     __outpw(VGA_BASE_IO_PORT + GRAPH_ADDRESS_PORT, (PixelMask[Left & 7] << 8) | IND_BIT_MASK);
 
-    /* Read the current pixel value and add our color */
-    WRITE_REGISTER_UCHAR(PixelPosition, READ_REGISTER_UCHAR(PixelPosition) & Color);
+    /* Dummy read to load latch registers */
+    (VOID)READ_REGISTER_UCHAR(PixelPosition);
+
+    /* Set the new color */
+    WRITE_REGISTER_UCHAR(PixelPosition, Color);
 }
 
 VOID

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -331,7 +331,7 @@ VidCleanUp(VOID)
 VOID
 NTAPI
 VidScreenToBufferBlt(
-    _Out_ PUCHAR Buffer,
+    _Out_writes_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,

--- a/drivers/base/bootvid/i386/pc/vga.c
+++ b/drivers/base/bootvid/i386/pc/vga.c
@@ -94,6 +94,8 @@ PrepareForSetPixel(VOID)
 do {                                                        \
     /* Select the bitmask register and write the mask */    \
     __outpw(VGA_BASE_IO_PORT + GRAPH_ADDRESS_PORT, ((_PixelMask) << 8) | IND_BIT_MASK); \
+    /* Dummy read to load latch registers */                \
+    (VOID)READ_REGISTER_UCHAR((_PixelPtr));                 \
     /* Set the new color */                                 \
     WRITE_REGISTER_UCHAR((_PixelPtr), (UCHAR)(_TextColor)); \
 } while (0);

--- a/drivers/base/bootvid/i386/pc98/bootvid.c
+++ b/drivers/base/bootvid/i386/pc98/bootvid.c
@@ -283,24 +283,24 @@ PreserveRow(
     _In_ ULONG TopDelta,
     _In_ BOOLEAN Restore)
 {
-    PUCHAR OldPosition, NewPosition;
-    ULONG PixelCount = TopDelta * SCREEN_WIDTH;
+    PULONG OldPosition, NewPosition;
+    ULONG PixelCount = TopDelta * (SCREEN_WIDTH / sizeof(ULONG));
 
     if (Restore)
     {
         /* Restore the row by copying back the contents saved off-screen */
-        OldPosition = (PUCHAR)(FrameBuffer + FB_OFFSET(0, SCREEN_HEIGHT));
-        NewPosition = (PUCHAR)(FrameBuffer + FB_OFFSET(0, CurrentTop));
+        OldPosition = (PULONG)(FrameBuffer + FB_OFFSET(0, SCREEN_HEIGHT));
+        NewPosition = (PULONG)(FrameBuffer + FB_OFFSET(0, CurrentTop));
     }
     else
     {
         /* Preserve the row by saving its contents off-screen */
-        OldPosition = (PUCHAR)(FrameBuffer + FB_OFFSET(0, CurrentTop));
-        NewPosition = (PUCHAR)(FrameBuffer + FB_OFFSET(0, SCREEN_HEIGHT));
+        OldPosition = (PULONG)(FrameBuffer + FB_OFFSET(0, CurrentTop));
+        NewPosition = (PULONG)(FrameBuffer + FB_OFFSET(0, SCREEN_HEIGHT));
     }
 
     while (PixelCount--)
-        WRITE_REGISTER_UCHAR(NewPosition++, READ_REGISTER_UCHAR(OldPosition++));
+        WRITE_REGISTER_ULONG(NewPosition++, READ_REGISTER_ULONG(OldPosition++));
 }
 
 VOID

--- a/drivers/base/bootvid/i386/pc98/bootvid.c
+++ b/drivers/base/bootvid/i386/pc98/bootvid.c
@@ -411,7 +411,7 @@ VidResetDisplay(
 VOID
 NTAPI
 VidScreenToBufferBlt(
-    _Out_ PUCHAR Buffer,
+    _Out_writes_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,
@@ -430,7 +430,7 @@ VidScreenToBufferBlt(
     {
         OutputBuffer = Buffer + Y * Delta;
 
-        for (X = 0; X < Width; X += 2)
+        for (X = 0; X < Width; X += sizeof(USHORT))
         {
             Px = READ_REGISTER_USHORT(PixelsPosition++);
             *OutputBuffer++ = (FIRSTBYTE(Px) << 4) | (SECONDBYTE(Px) & 0x0F);

--- a/drivers/base/bootvid/i386/pc98/bootvid.c
+++ b/drivers/base/bootvid/i386/pc98/bootvid.c
@@ -421,7 +421,7 @@ VidScreenToBufferBlt(
     ULONG X, Y;
     PUCHAR OutputBuffer;
     USHORT Px;
-    PUSHORT PixelsPosition = (PUSHORT)(FrameBuffer + FB_OFFSET(Left, Top));
+    PUSHORT PixelsPosition;
 
     /* Clear the destination buffer */
     RtlZeroMemory(Buffer, Delta * Height);
@@ -429,6 +429,7 @@ VidScreenToBufferBlt(
     for (Y = 0; Y < Height; Y++)
     {
         OutputBuffer = Buffer + Y * Delta;
+        PixelsPosition = (PUSHORT)(FrameBuffer + FB_OFFSET(Left, Top + Y));
 
         for (X = 0; X < Width; X += sizeof(USHORT))
         {

--- a/drivers/base/bootvid/i386/xbox/bootvid.c
+++ b/drivers/base/bootvid/i386/xbox/bootvid.c
@@ -412,7 +412,7 @@ VidSolidColorFill(
 VOID
 NTAPI
 VidScreenToBufferBlt(
-    _Out_ PUCHAR Buffer,
+    _Out_writes_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,
@@ -430,7 +430,7 @@ VidScreenToBufferBlt(
         PUCHAR Buf = Buffer + y * Delta;
 
         /* Start the X inner loop */
-        for (ULONG x = 0; x < Width; x += 2)
+        for (ULONG x = 0; x < Width; x += sizeof(USHORT))
         {
             /* Read the current value */
             *Buf = (*Back++ & 0xF) << 4;

--- a/sdk/include/reactos/drivers/bootvid/bootvid.h
+++ b/sdk/include/reactos/drivers/bootvid/bootvid.h
@@ -30,7 +30,7 @@ VidSetTextColor(
 VOID
 NTAPI
 VidDisplayStringXY(
-    _In_ PUCHAR String,
+    _In_z_ PUCHAR String,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ BOOLEAN Transparent);
@@ -50,7 +50,7 @@ VidCleanUp(VOID);
 VOID
 NTAPI
 VidBufferToScreenBlt(
-    _In_ PUCHAR Buffer,
+    _In_reads_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,
@@ -60,7 +60,7 @@ VidBufferToScreenBlt(
 VOID
 NTAPI
 VidDisplayString(
-    _In_ PUCHAR String);
+    _In_z_ PUCHAR String);
 
 VOID
 NTAPI
@@ -72,7 +72,7 @@ VidBitBlt(
 VOID
 NTAPI
 VidScreenToBufferBlt(
-    _Out_ PUCHAR Buffer,
+    _Out_writes_bytes_(Delta * Height) PUCHAR Buffer,
     _In_ ULONG Left,
     _In_ ULONG Top,
     _In_ ULONG Width,

--- a/sdk/include/reactos/drivers/pc98/video.h
+++ b/sdk/include/reactos/drivers/pc98/video.h
@@ -22,6 +22,8 @@
 #define PEGC_FRAMEBUFFER_PACKED  0xF00000
 #define PEGC_FRAMEBUFFER_SIZE    0x080000
 
+#define PEGC_CONTROL_SIZE        0x000200
+
 /* High-resolution machine */
 #define VRAM_HI_RESO_PLANE_B     0xC0000
 #define VRAM_HI_RESO_PLANE_G     0xC8000


### PR DESCRIPTION
## Purpose

 Fix drawing strings on top of the bitmap.

JIRA issue: [CORE-15896](https://jira.reactos.org/browse/CORE-15896)

## Proposed changes

- Fix VGA pixel drawing
- Minor improvements
  - Annotate some functions to avoid confusing
  - Fix BitBlt behavior
  - PC-98
    - Improve text scrolling performance
    - Fix failure handling
    - Reduce memory mapping that's not needed
    - Fix screen buffer copying code
