### PR TITLE
[WIN32SS][NTUSER] Fix uninitialized memory cause memory disclosure used for KeUserModeCallback

### DIFF
--- a/win32ss/user/ntuser/callback.c
+++ b/win32ss/user/ntuser/callback.c
@@ -35,6 +35,7 @@ IntCbAllocateMemory(ULONG Size)
       return NULL;
    }
 
+   RtlZeroMemory(Mem, Size + sizeof(INT_CALLBACK_HEADER));
    W32Thread = PsGetCurrentThreadWin32Thread();
    ASSERT(W32Thread);
 
@@ -185,10 +186,6 @@ co_IntClientLoadLibrary(PUNICODE_STRING pstrLibName,
        pLibNameBuffer -= (ULONG_PTR)pArguments;
        pArguments->strLibraryName.Buffer = (PWCHAR)(pLibNameBuffer);
    }
-   else
-   {
-       RtlZeroMemory(&pArguments->strLibraryName, sizeof(UNICODE_STRING));
-   }
 
    if(pstrInitFunc)
    {
@@ -201,10 +198,6 @@ co_IntClientLoadLibrary(PUNICODE_STRING pstrLibName,
        /* Fix argument pointers to be relative to the argument */
        pInitFuncBuffer -= (ULONG_PTR)pArguments;
        pArguments->strInitFuncName.Buffer = (PWCHAR)(pInitFuncBuffer);
-   }
-   else
-   {
-       RtlZeroMemory(&pArguments->strInitFuncName, sizeof(UNICODE_STRING));
    }
 
    /* Do the callback */
@@ -294,7 +287,7 @@ co_IntCallWindowProc(WNDPROC Proc,
                      LPARAM lParam,
                      INT lParamBufferSize)
 {
-   WINDOWPROC_CALLBACK_ARGUMENTS StackArguments;
+   WINDOWPROC_CALLBACK_ARGUMENTS StackArguments = { 0 };
    PWINDOWPROC_CALLBACK_ARGUMENTS Arguments;
    NTSTATUS Status;
    PVOID ResultPointer, pActCtx;
@@ -662,7 +655,6 @@ co_IntCallHookProc(INT HookId,
    Common->offPfn = offPfn;
    Common->Ansi = Ansi;
    Common->lParamSize = lParamSize;
-   RtlZeroMemory(&Common->ModuleName, sizeof(Common->ModuleName));
    if (ModuleName->Buffer && ModuleName->Length)
    {
       RtlCopyMemory(&Common->ModuleName, ModuleName->Buffer, ModuleName->Length);
@@ -928,9 +920,6 @@ co_IntCallLoadMenu( HINSTANCE hModule,
       return 0;
    }
    Common = (PLOADMENU_CALLBACK_ARGUMENTS) Argument;
-
-   // Help Intersource check and MenuName is now 4 bytes + so zero it.
-   RtlZeroMemory(Common, ArgumentLength);
 
    Common->hModule = hModule;
    if (pMenuName->Length)

--- a/win32ss/user/rtl/text.c
+++ b/win32ss/user/rtl/text.c
@@ -997,7 +997,6 @@ BOOL UserExtTextOutW(HDC hdc,
     }
     else
     {
-        RtlZeroMemory(&Argument->rect, sizeof(RECT));
         Argument->bRect = FALSE;
     }
 


### PR DESCRIPTION
## Purpose

Fix uninitialized memory cause memory disclosure used for `KeUserModeCallback`.

## PoC
<details>
<summary>Click to see</summary>

```c
#ifndef UNICODE
#define UNICODE
#endif 

#include <windows.h>
#include <stdio.h>

LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);

typedef struct _WINDOWPROC_CALLBACK_ARGUMENTS
{
    WNDPROC Proc;
    BOOL IsAnsiProc;
    HWND Wnd;
    UINT Msg;
    WPARAM wParam;
    LPARAM lParam;
    INT lParamBufferSize;
    LRESULT Result;
    /* char Buffer[]; */
} WINDOWPROC_CALLBACK_ARGUMENTS, *PWINDOWPROC_CALLBACK_ARGUMENTS;

int main()
{
    return wWinMain(GetModuleHandle(NULL), NULL, GetCommandLineW(), SW_SHOWNORMAL);
}

int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE, PWSTR pCmdLine, int nCmdShow)
{
    // Register the window class.
    const wchar_t CLASS_NAME[] = L"Sample Window Class";

    WNDCLASS wc = { };

    wc.lpfnWndProc = WindowProc;
    wc.hInstance = hInstance;
    wc.lpszClassName = CLASS_NAME;

    RegisterClass(&wc);

    // Create the window.
    HWND hwnd = CreateWindowEx(
        0,                              // Optional window styles.
        CLASS_NAME,                     // Window class
        L"Learn to Program Windows",    // Window text
        WS_OVERLAPPEDWINDOW,            // Window style
        // Size and position
        CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
        NULL,       // Parent window    
        NULL,       // Menu
        hInstance,  // Instance handle
        NULL        // Additional application data
    );

    if (hwnd == NULL)
    {
        return 0;
    }

    ShowWindow(hwnd, nCmdShow);

    // Run the message loop.
    MSG msg = { };
    while (GetMessage(&msg, NULL, 0, 0))
    {
        TranslateMessage(&msg);
        DispatchMessage(&msg);
    }

    return 0;
}

LRESULT CALLBACK WindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
{
    /*
    kd> k
     # ChildEBP RetAddr
    00 0012fbe4 77a9e6ca WinApp!WindowProc+0x38
    01 0012fc14 77a8c8f6 USER32!CALL_EXTERN_WNDPROC+0x1a
    02 0012fcf8 77a92560 USER32!IntCallWindowProcW+0x656 [h:\project\reactos\win32ss\user\user32\windows\message.c @ 1547]
    03 0012fd98 7c9372d1 USER32!User32CallWindowProcFromKernel+0x360 [h:\project\reactos\win32ss\user\user32\windows\message.c @ 3005]
    04 0012ff40 0044eb4e ntdll!KiUserCallbackDispatcher+0x2e
    05 0012ff58 0044e9b0 WinApp!invoke_main+0x1e [f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl @ 118]
    06 0012ffb0 0044e84d WinApp!__scrt_common_main_seh+0x150 [f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl @ 253]
    07 0012ffb8 0044eb68 WinApp!__scrt_common_main+0xd [f:\dd\vctools\crt\vcstartup\src\startup\exe_common.inl @ 296]
    08 0012ffc0 7c636934 WinApp!wWinMainCRTStartup+0x8 [f:\dd\vctools\crt\vcstartup\src\startup\exe_wwinmain.cpp @ 17]
    WARNING: Stack unwind information not available. Following frames may be wrong.
    09 0012fff0 00000000 kernel32+0x16934

    From stack trace, I can get address of `Arguments` argument of USER32!User32CallWindowProcFromKernel function
    by using ChildEBP#3 minus ChildEBP#0
    */
    PWINDOWPROC_CALLBACK_ARGUMENTS Arguments = 0; // [ebp - 0xC]
    Arguments = (PWINDOWPROC_CALLBACK_ARGUMENTS)(*(DWORD *)((DWORD)(&Arguments) + 0xC + 0x0012fd98 - 0x0012fbe4 + 8));

    // Some uMsg value only has above stack trace so I choose 0x7f
    if (uMsg == 0x7f)
    {
        wprintf(L"Leaked memory value: %d\n", Arguments->Result);
    }

    switch (uMsg)
    {
        case WM_DESTROY:
            PostQuitMessage(0);
            return 0;
    
        case WM_PAINT:
        {
            PAINTSTRUCT ps;
            HDC hdc = BeginPaint(hwnd, &ps);
    
            FillRect(hdc, &ps.rcPaint, (HBRUSH)(COLOR_WINDOW + 1));
            EndPaint(hwnd, &ps);
        }
        return 0;
    }

    return DefWindowProc(hwnd, uMsg, wParam, lParam);
}
```

Stack trace:
```
 #0  0x80581c6d ((00181c6d) ntoskrnl.exe!memcpy+3d)
 #1  0x8054e4b1 ((0014e4b1) ntoskrnl.exe!KeUserModeCallback+f1 [h:\project\reactos\ntoskrnl\ke\i386\usercall.c @ 162])
 #2  0xf760b48d ((0003648d) win32k.sys!co_IntCallWindowProc+27d [h:\project\reactos\win32ss\user\ntuser\callback.c @ 343])
 #3  0xf7656879 ((00081879) win32k.sys!co_IntSendMessageTimeoutSingle+569 [h:\project\reactos\win32ss\user\ntuser\message.c @ 1567])
 #4  0xf76561d4 ((000811d4) win32k.sys!co_IntSendMessageTimeout+54 [h:\project\reactos\win32ss\user\ntuser\message.c @ 1668])
 #5  0xf76560a4 ((000810a4) win32k.sys!co_IntSendMessage+44 [h:\project\reactos\win32ss\user\ntuser\message.c @ 1453])
 #6  0xf768a90f ((000b590f) win32k.sys!co_UserCreateWindowEx+a7f [h:\project\reactos\win32ss\user\ntuser\window.c @ 2222])
 #7  0xf768c678 ((000b7678) win32k.sys!NtUserCreateWindowEx+408 [h:\project\reactos\win32ss\user\ntuser\window.c @ 2551])
 #8  0x8054dc1b ((0014dc1b) ntoskrnl.exe!KiSystemCallTrampoline+1b [h:\project\reactos\ntoskrnl\include\internal\i386\ke.h @ 766])
 #9  0x8054ba88 ((0014ba88) ntoskrnl.exe!KiSystemServiceHandler+278 [h:\project\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1846])
 #10  0x80403ea5 ((00003ea5) ntoskrnl.exe!KiFastCallEntry+96)
```
</details>

## Analysis

The `Arguments` variable is allocated by function `IntCbAllocateMemory` or on stack then its fields are initialized at https://github.com/reactos/reactos/blob/568b6d0558d047df1826d7438448432643d7fe5c/win32ss/user/ntuser/callback.c#L329-L344 but it doesn't initialize the field `Arguments->Result` so it leads to memory disclosure when pass to `KeUserModeCallback`.

Additionally, I see all memories which are allocated by the function `IntCbAllocateMemory` without uninitializing then they will be passed to `KeUserModeCallback` as `InputBuffer` argument. They also cause to memory disclosure. 

For example: https://github.com/reactos/reactos/blob/568b6d0558d047df1826d7438448432643d7fe5c/win32ss/user/ntuser/callback.c#L167-L183
The field `pArguments->strLibraryName.Length` is also uninitialized.

So I decided to use `RtlZeroMemory` inside the function `IntCbAllocateMemory` to prevent memory disclosure.