### PR TITLE
[RAPPS] move icon to a field in .txt file

### DIFF
--- a/base/applications/rapps/available.cpp
+++ b/base/applications/rapps/available.cpp
@@ -72,14 +72,16 @@ VOID CAvailableApplicationInfo::RetrieveGeneralInfo(AvailableStrings& AvlbString
         }
         else
         {
-            // TODO: Does the filename contain anything stuff like "\\" ".." ":" "<" ">" ?
+            // TODO: Does the filename contain anything stuff like ":" "<" ">" ?
             // these stuff may lead to security issues
-
             ATL::CStringW ScrnshotName = AvlbStrings.szAppsPath;
             PathAppendW(ScrnshotName.GetBuffer(MAX_PATH), L"screenshots");
-            PathAppendW(ScrnshotName.GetBuffer(), ScrnshotLocation.GetString());
+            BOOL bSuccess = PathAppendNoDirEscapeW(ScrnshotName.GetBuffer(), ScrnshotLocation.GetString());
             ScrnshotName.ReleaseBuffer();
-            m_szScrnshotLocation.Add(ScrnshotName);
+            if (bSuccess)
+            {
+                m_szScrnshotLocation.Add(ScrnshotName);
+            }
         }
     }
 
@@ -87,13 +89,17 @@ VOID CAvailableApplicationInfo::RetrieveGeneralInfo(AvailableStrings& AvlbString
     ATL::CStringW IconLocation;
     if (GetString(L"Icon", IconLocation))
     {
-        // TODO: Does the filename contain anything stuff like "\\" ".." ":" "<" ">" ?
+        // TODO: Does the filename contain anything stuff like ":" "<" ">" ?
         // these stuff may lead to security issues
         ATL::CStringW IconPath = AvlbStrings.szAppsPath;
         PathAppendW(IconPath.GetBuffer(MAX_PATH), L"icons");
-        PathAppendW(IconPath.GetBuffer(), IconLocation.GetString());
+        BOOL bSuccess = PathAppendNoDirEscapeW(IconPath.GetBuffer(), IconLocation.GetString());
         IconPath.ReleaseBuffer();
-        m_szIconLocation = IconPath;
+
+        if (bSuccess)
+        {
+            m_szIconLocation = IconPath;
+        }
     }
 
     RetrieveSize();

--- a/base/applications/rapps/available.cpp
+++ b/base/applications/rapps/available.cpp
@@ -83,6 +83,19 @@ VOID CAvailableApplicationInfo::RetrieveGeneralInfo(AvailableStrings& AvlbString
         }
     }
 
+    // TODO: are we going to support specify an URL for an icon ?
+    ATL::CStringW IconLocation;
+    if (GetString(L"Icon", IconLocation))
+    {
+        // TODO: Does the filename contain anything stuff like "\\" ".." ":" "<" ">" ?
+        // these stuff may lead to security issues
+        ATL::CStringW IconPath = AvlbStrings.szAppsPath;
+        PathAppendW(IconPath.GetBuffer(MAX_PATH), L"icons");
+        PathAppendW(IconPath.GetBuffer(), IconLocation.GetString());
+        IconPath.ReleaseBuffer();
+        m_szIconLocation = IconPath;
+    }
+
     RetrieveSize();
     RetrieveLicenseType();
     RetrieveLanguages();
@@ -243,6 +256,16 @@ BOOL CAvailableApplicationInfo::RetrieveScrnshot(UINT Index,ATL::CStringW& Scrns
         return FALSE;
     }
     ScrnshotLocation = m_szScrnshotLocation[Index];
+    return TRUE;
+}
+
+BOOL CAvailableApplicationInfo::RetrieveIcon(ATL::CStringW& IconLocation) const
+{
+    if (m_szIconLocation.IsEmpty())
+    {
+        return FALSE;
+    }
+    IconLocation = m_szIconLocation;
     return TRUE;
 }
 

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -2394,18 +2394,16 @@ private:
         }
 
         /* Load icon from file */
-        ATL::CStringW szIconPath = szFolderPath;
-        PathAppendW(szIconPath.GetBuffer(MAX_PATH), L"icons");
-        PathAppendW(szIconPath.GetBuffer(), Info->m_szName.GetString());
-        PathAddExtensionW(szIconPath.GetBuffer(), L".ico");
-        szIconPath.ReleaseBuffer();
-
-        hIcon = (HICON) LoadImageW(NULL,
-                                   szIconPath.GetString(),
-                                   IMAGE_ICON,
-                                   LISTVIEW_ICON_SIZE,
-                                   LISTVIEW_ICON_SIZE,
-                                   LR_LOADFROMFILE);
+        ATL::CStringW szIconPath;
+        if (Info->RetrieveIcon(szIconPath))
+        {
+            hIcon = (HICON)LoadImageW(NULL,
+                szIconPath.GetString(),
+                IMAGE_ICON,
+                LISTVIEW_ICON_SIZE,
+                LISTVIEW_ICON_SIZE,
+                LR_LOADFROMFILE);
+        }
 
         if (!hIcon || GetLastError() != ERROR_SUCCESS)
         {

--- a/base/applications/rapps/include/available.h
+++ b/base/applications/rapps/include/available.h
@@ -52,6 +52,7 @@ struct CAvailableApplicationInfo
     ATL::CStringW m_szUrlDownload;
     ATL::CSimpleArray<LCID> m_LanguageLCIDs;
     ATL::CSimpleArray<ATL::CStringW> m_szScrnshotLocation;
+    ATL::CStringW m_szIconLocation;
 
     ULONG m_SizeBytes;
 
@@ -75,6 +76,7 @@ struct CAvailableApplicationInfo
     BOOL HasInstalledVersion() const;
     BOOL HasUpdate() const;
     BOOL RetrieveScrnshot(UINT Index, ATL::CStringW& ScrnshotLocation) const;
+    BOOL RetrieveIcon(ATL::CStringW& IconLocation) const;
     // Set a timestamp
     VOID SetLastWriteTime(FILETIME* ftTime);
 

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -44,3 +44,5 @@ public:
     BOOL GetString(const ATL::CStringW& KeyName, ATL::CStringW& ResultString);
     BOOL GetInt(const ATL::CStringW& KeyName, INT& iResult);
 };
+
+BOOL PathAppendNoDirEscapeW(LPWSTR pszPath, LPCWSTR pszMore);

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -407,3 +407,49 @@ BOOL CConfigParser::GetInt(const ATL::CStringW& KeyName, INT& iResult)
     return (iResult > 0);
 }
 // CConfigParser
+
+
+BOOL PathAppendNoDirEscapeW(LPWSTR pszPath, LPCWSTR pszMore)
+{
+    WCHAR pszPathBuffer[MAX_PATH]; // buffer to store result
+    WCHAR pszPathCopy[MAX_PATH];
+
+    if (!PathCanonicalizeW(pszPathCopy, pszPath))
+    {
+        return FALSE;
+    }
+
+    PathRemoveBackslashW(pszPathCopy);
+
+    if (StringCchCopyW(pszPathBuffer, _countof(pszPathBuffer), pszPathCopy) != S_OK)
+    {
+        return FALSE;
+    }
+
+    if (!PathAppendW(pszPathBuffer, pszMore))
+    {
+        return FALSE;
+    }
+
+    size_t PathLen;
+    if (StringCchLengthW(pszPathCopy, _countof(pszPathCopy), &PathLen) != S_OK)
+    {
+        return FALSE;
+    }
+    int CommonPrefixLen = PathCommonPrefixW(pszPathCopy, pszPathBuffer, NULL);
+
+    if (CommonPrefixLen != PathLen)
+    {
+        // pszPathBuffer should be a file/folder under pszPath.
+        // but now common prefix len is smaller than length of pszPathCopy
+        // hacking use ".." ?
+        return FALSE;
+    }
+
+    if (StringCchCopyW(pszPath, MAX_PATH, pszPathBuffer) != S_OK)
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+}

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -438,7 +438,7 @@ BOOL PathAppendNoDirEscapeW(LPWSTR pszPath, LPCWSTR pszMore)
     }
     int CommonPrefixLen = PathCommonPrefixW(pszPathCopy, pszPathBuffer, NULL);
 
-    if (CommonPrefixLen != PathLen)
+    if ((unsigned int)CommonPrefixLen != PathLen)
     {
         // pszPathBuffer should be a file/folder under pszPath.
         // but now common prefix len is smaller than length of pszPathCopy


### PR DESCRIPTION
## Purpose

move icon to a field in .txt file, no longer use the software's name

using the software's name may lead to some problems like the software name is too long, or contain some illegal chars (for example, ```Code::Blocks```. in a normal file name ```:``` is not allowed. ```:``` is used for alternate data streams in NTFS?)

some code is also added to check if ```../``` is used for directory escape