### PR TITLE
[WIN32K] Add StretchBlt function ability to flip images

### DIFF
--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -167,6 +167,15 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   /* Make WellOrdered with top < bottom and left < right */
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
   {
@@ -500,6 +509,10 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           /* Allocate enough pixels for a row in WORD's */
           WORD *store = ExAllocatePoolWithTag(NonPagedPool,
             (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 2, TAG_DIB);
+          if (store == NULL)
+          {
+            return FALSE;
+          }
           WORD  Index;
 
           /* This sets SourceLine to the top line */
@@ -556,6 +569,10 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           /* Allocate enough pixels for a column in WORD's */
           WORD *store = ExAllocatePoolWithTag(NonPagedPool,
             (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 2, TAG_DIB);
+          if (store == NULL)
+          {
+            return FALSE;
+          }
 
           /* This set the DestLine to the top line */
           DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -151,8 +151,8 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN   */
-  /* bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
+  /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN
+   * bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
@@ -247,7 +247,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_4BPP:
     DPRINT("4BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceBits_4BPP to the top line */
     SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0 +
@@ -315,7 +315,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_8BPP:
     DPRINT("8BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
@@ -368,15 +368,16 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_16BPP:
     DPRINT("16BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     DPRINT("BMF_16BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-            BltInfo->DestRect.left, BltInfo->DestRect.top,
-            BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-            BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.left, BltInfo->DestRect.top,
+      BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
-    if ((NULL == BltInfo->XlateSourceToDest || 0 !=
-      (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) && (!bTopToBottom && !bLeftToRight))
+    if ((BltInfo->XlateSourceToDest == NULL ||
+      (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL) != 0) &&
+      (!bTopToBottom && !bLeftToRight))
     {
       DPRINT("XO_TRIVIAL is TRUE.\n");
       if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
@@ -634,9 +635,9 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
   case BMF_24BPP:
 
     DPRINT("BMF_24BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-            BltInfo->DestRect.left, BltInfo->DestRect.top,
-            BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-            BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.left, BltInfo->DestRect.top,
+      BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -498,7 +498,8 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 1 or 3.\n");
 
           /* Allocate enough pixels for a row in DWORD's */
-          DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+          WORD *store = ExAllocatePoolWithTag(PagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 2, GDITAG_TEMP);
           WORD  Index;
 
           /* This sets SourceLine to the top line */
@@ -543,6 +544,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceLine += BltInfo->SourceSurface->lDelta;
             DestLine += BltInfo->DestSurface->lDelta;
           }
+          ExFreePoolWithTag(store, GDITAG_TEMP);
           OneDone = TRUE;
         }
 
@@ -552,7 +554,8 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DWORD  Index;
 
           /* Allocate enough pixels for a column in DWORD's */
-          WORD store[BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1];
+          WORD *store = ExAllocatePoolWithTag(PagedPool,
+            (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 2, GDITAG_TEMP);
 
           /* This set the DestLine to the top line */
           DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +
@@ -611,6 +614,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceLine += 2;
             DestLine += 2;
           }
+          ExFreePoolWithTag(store, GDITAG_TEMP);
         }
 
       }

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -544,7 +544,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceLine += BltInfo->SourceSurface->lDelta;
             DestLine += BltInfo->DestSurface->lDelta;
           }
-          ExFreePoolWithTag(store, GDITAG_TEMP);
+          ExFreePoolWithTag(store, TAG_DIB);
           OneDone = TRUE;
         }
 
@@ -614,7 +614,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceLine += 2;
             DestLine += 2;
           }
-          ExFreePoolWithTag(store, GDITAG_TEMP);
+          ExFreePoolWithTag(store, TAG_DIB);
         }
 
       }

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -14,6 +14,9 @@
 #define NDEBUG
 #include <debug.h>
 
+#define DEC_OR_INC(var, decTrue, amount) \
+    ((var) = (decTrue) ? ((var) - (amount)) : ((var) + (amount)))
+
 VOID
 DIB_16BPP_PutPixel(SURFOBJ *SurfObj, LONG x, LONG y, ULONG c)
 {
@@ -143,47 +146,36 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
   LONG     i, j, sx, sy, xColor, f1;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
-  PBYTE    SourceBitsT, SourceBitsB, DestBitsT, DestBitsB;
+  PWORD    Source32, Dest32;
+  DWORD    Index, StartLeft, EndRight;
   BOOLEAN  bTopToBottom, bLeftToRight;
 
   DPRINT("DIB_16BPP_BitBltSrcCopy: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
-    BltInfo->SourceSurface->sizlBitmap.cx, BltInfo->SourceSurface->sizlBitmap.cy,
-    BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
-    BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
+         BltInfo->SourceSurface->sizlBitmap.cx, BltInfo->SourceSurface->sizlBitmap.cy,
+         BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
+         BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
   /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN
    * bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
-  /* Get back flip here */
-  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    bLeftToRight = TRUE;
-  }
-  else
-  {
-    bLeftToRight = FALSE;
-  }
+  /* Get back left to right flip here */
+  bLeftToRight = BltInfo->DestRect.left > BltInfo->DestRect.right;
 
-  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from dibobj.c */ 
-  if ((BltInfo->DestRect.top > BltInfo->DestRect.bottom) || (BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN))
-  {
-    bTopToBottom = TRUE;
-  }
-  else
-  {
-    bTopToBottom = FALSE;
-  }
+  /* Check for top to bottom flip needed. */
+  /* The OR checks for flips coming from dibobj.c. It should be removed if the dib_flip.patch from CORE-14671 is committed */ 
+  bTopToBottom = ((BltInfo->DestRect.top > BltInfo->DestRect.bottom)
+                 || (BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN));
 
   DPRINT("BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
-    BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
+         BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   /* Make WellOrdered with top < bottom and left < right */
   RECTL_vMakeWellOrdered(&BltInfo->DestRect);
 
   DPRINT("BPP is '%d/%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
-    BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
+         BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0 + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + 2 * BltInfo->DestRect.left;
 
@@ -211,9 +203,16 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       {
         /* This sets the sx to the rightmost pixel */
         sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+        StartLeft = BltInfo->DestRect.left + 1;
+        EndRight = BltInfo->DestRect.right + 1;
+      }
+      else
+      {
+        StartLeft = BltInfo->DestRect.left;
+        EndRight = BltInfo->DestRect.right;
       }
 
-      for (i=BltInfo->DestRect.left; i<BltInfo->DestRect.right; i++)
+      for (i = StartLeft; i < EndRight; i++)
       {
         if(DIB_1BPP_GetPixel(BltInfo->SourceSurface, sx, sy) == 0)
         {
@@ -225,23 +224,9 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DIB_16BPP_PutPixel(BltInfo->DestSurface, i, j,
             XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, 1));
         }
-        if (bLeftToRight)
-        {
-          sx--;
-        }
-        else
-        {
-          sx++;
-        }
+        DEC_OR_INC(sx, bLeftToRight, 1);
       }
-      if (bTopToBottom)
-      {
-        sy--;
-      }
-      else
-      {
-        sy++;
-      }
+      DEC_OR_INC(sy, bTopToBottom, 1);
     }
     break;
 
@@ -279,28 +264,14 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         DIB_16BPP_PutPixel(BltInfo->DestSurface, i, j, xColor);
         if(f1 == 1)
         {
-          if (bLeftToRight)
-          {
-            SourceLine_4BPP--;
-          }
-          else
-          {
-            SourceLine_4BPP++;
-          }
+          DEC_OR_INC(SourceLine_4BPP, bLeftToRight, 1);
           f1 = 0;
         }
         else
         {
           f1 = 1;
         }
-        if (bLeftToRight)
-        {
-          sx--;
-        }
-        else
-        {
-          sx++;
-        }
+        DEC_OR_INC(sx, bLeftToRight, 1);
       }
       if (bTopToBottom)
       {
@@ -344,24 +315,10 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       {
         *((WORD *)DestBits) = (WORD)XLATEOBJ_iXlate(
           BltInfo->XlateSourceToDest, *SourceBits);
-        if (bLeftToRight)
-        {
-          SourceBits -= 1;
-        }
-        else
-        {
-          SourceBits += 1;
-        }
+        DEC_OR_INC(SourceBits, bLeftToRight, 1);
         DestBits += 2;
       }
-      if (bTopToBottom)
-      {
-        SourceLine -= BltInfo->SourceSurface->lDelta;
-      }
-      else
-      {
-        SourceLine += BltInfo->SourceSurface->lDelta;
-      }
+      DEC_OR_INC(SourceLine, bTopToBottom, BltInfo->SourceSurface->lDelta);
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;
@@ -508,47 +465,49 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           }
           WORD  Index;
 
-          /* This sets SourceLine to the top line */
-          SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
-            (BltInfo->SourcePoint.y *
-            BltInfo->SourceSurface->lDelta) + 2 *
-            BltInfo->SourcePoint.x;
+          /* This sets SourceBits to the bottom line */
+          SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
+            + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
+            * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
 
-          /* This set the DestLine to the top line */
-          DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +
-            (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) +
-            2 * BltInfo->DestRect.left;
+          /* Sets DestBits to the bottom line */
+          DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
+           + (BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta
+           + 2 * BltInfo->DestRect.left + 2;
 
-          for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
+          if (bTopToBottom)
           {
-            SourceBits = SourceLine;
-            DestBits = DestLine;
+            DPRINT("Adjusting DestBits for bTopToBottom.\n");
+            DestBits += BltInfo->DestSurface->lDelta;
+          }
 
-            /* This sets SourceBits to the rightmost pixel */
-            SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 2;
+          for (j = BltInfo->DestRect.bottom - 1; BltInfo->DestRect.top <= j; j--)
+          {
+
+            /* Set Dest32 to right pixel */
+            Dest32 = (WORD *) DestBits + (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+            Source32 = (WORD *) SourceBits;
 
             Index = 0;
 
-            for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
+            /* Store pixels from left to right */
+            for (i = BltInfo->DestRect.right - 1; BltInfo->DestRect.left <= i; i--)
             {
-              store[Index] = (WORD)XLATEOBJ_iXlate(
-                BltInfo->XlateSourceToDest,
-                *((WORD *)SourceBits));
-              SourceBits -= 2;
+              store[Index] = (WORD)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *(WORD *)Source32++);
               Index++;
             }
 
             Index = 0;
 
-            for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
+            /* Copy stored data to pixels from right to left */
+            for (i = BltInfo->DestRect.right - 1; BltInfo->DestRect.left <= i; i--)
             {
-              *((WORD *)DestBits) = store[Index];
-              DestBits += 2;
+              *(WORD *)Dest32-- = store[Index];
               Index++;
             }
 
-            SourceLine += BltInfo->SourceSurface->lDelta;
-            DestLine += BltInfo->DestSurface->lDelta;
+            SourceBits -= BltInfo->SourceSurface->lDelta;
+            DestBits -= BltInfo->DestSurface->lDelta;
           }
           ExFreePoolWithTag(store, TAG_DIB);
           OneDone = TRUE;
@@ -558,24 +517,35 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         {
           DPRINT("Flip is bTopToBottom.\n");
 
-          /* Allocate enough pixels for a row in WORD's */
+          /* Allocate enough pixels for a column in WORD's */
           WORD *store = ExAllocatePoolWithTag(NonPagedPool,
-            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 2, TAG_DIB);
+            (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 2, TAG_DIB);
           if (store == NULL)
           {
             DPRINT1("Storage Allocation Failed.\n");
             return FALSE;
           }
 
-          /* This set DestBitsT to the top line */
-          DestBitsT = (PBYTE)BltInfo->DestSurface->pvScan0
-            + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta)
-            + 2 * BltInfo->DestRect.left;
+          /* This set SourceBits to the top line */
+          SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
+            + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta)
+            + 2 * BltInfo->SourcePoint.x;
 
-          /* This sets DestBitsB to the bottom line */
-          DestBitsB = (PBYTE)BltInfo->DestSurface->pvScan0
-           + (BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta
+          /* This sets DestBits to the top line */
+          DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
+           + ((BltInfo->DestRect.top) * BltInfo->DestSurface->lDelta)
            + 2 * BltInfo->DestRect.left;
+
+          if (BltInfo->DestSurface->lDelta > 0)
+          {
+            DestBits += BltInfo->DestSurface->lDelta;
+          }
+
+          if (bLeftToRight)
+          {
+            DPRINT("Adjusting DestBits for bLeftToRight.\n");
+            DestBits += 2;
+          }
 
           /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight   */
           /* and have already completed the bLeftToRight. So we will lose our first flip output */
@@ -584,46 +554,38 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
           if (OneDone)
           {
-            /* This sets SourceBitsB to the bottom line */
-            SourceBitsB = DestBitsB;
-
-            /* This sets SourceBitsT to the top line */
-            SourceBitsT = DestBitsT;
-          }
-          else
-          {
-            /* This sets SourceBitsB to the bottom line */
-            SourceBitsB = (PBYTE)BltInfo->SourceSurface->pvScan0
-              + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
-              * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
-
-            /* This sets SourceBitsT to the top line */
-            SourceBitsT = (PBYTE)BltInfo->SourceSurface->pvScan0
-              + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
+            /* This sets SourceBits to the top line */
+            SourceBits = DestBits;
           }
 
-          for (j = 0; j < (BltInfo->DestRect.bottom - BltInfo->DestRect.top) / 2 ; j++)
+          for (j = BltInfo->DestRect.right - 1; BltInfo->DestRect.left <= j ; j--)
           {
-            /* Store bottom row */
-            RtlMoveMemory(&store[0], SourceBitsB, 2 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+            /* Set Dest32 to bottom pixel */
+            Dest32 = (WORD *) DestBits  + (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
+              * BltInfo->DestSurface->lDelta / 2;
+            Source32 = (WORD *) SourceBits;
 
-            /* Copy top row to bottom row overwriting it */
-            RtlMoveMemory(DestBitsB, SourceBitsT, 2 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+            Index = 0;
 
-            /* Copy stored bottom row to top row */
-            RtlMoveMemory(DestBitsT, &store[0], 2 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+            /* Store pixels from top to bottom */
+            for (i = BltInfo->DestRect.top; i <= BltInfo->DestRect.bottom - 1; i++)
+            {
+              store[Index] = XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *Source32);
+              Source32 += BltInfo->SourceSurface->lDelta / 2;
+              Index++;
+            }
 
-            /* Index top rows down and bottom rows up */
-            SourceBitsT += BltInfo->SourceSurface->lDelta;
-            SourceBitsB -= BltInfo->SourceSurface->lDelta;
+            Index = 0;
 
-            DestBitsT += BltInfo->DestSurface->lDelta;
-            DestBitsB -= BltInfo->DestSurface->lDelta;
-          }
-          if ((BltInfo->DestRect.bottom - BltInfo->DestRect.top) % 2)
-          {
-            /* If we had an odd number of lines we handle the center one here */
-            RtlMoveMemory(DestBitsB, SourceBitsT, 2 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+            /* Copy stored data to pixels from bottom to top */
+            for (i = BltInfo->DestRect.bottom - 1; BltInfo->DestRect.top <= i; i--)
+            {
+              *Dest32 = store[Index];
+              Dest32 -= BltInfo->DestSurface->lDelta / 2;
+              Index++;
+            }
+            SourceBits += 2;
+            DestBits += 2;
           }
           ExFreePoolWithTag(store, TAG_DIB);
         }
@@ -669,24 +631,10 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         *((WORD *)DestBits) = (WORD)XLATEOBJ_iXlate(
           BltInfo->XlateSourceToDest, xColor);
 
-        if (bLeftToRight)
-        {
-          SourceBits -= 3;
-        }
-        else
-        {
-          SourceBits += 3;
-        }
+        DEC_OR_INC(SourceBits, bLeftToRight, 3);
         DestBits += 2;
       }
-      if (bTopToBottom)
-      {
-        SourceLine -= BltInfo->SourceSurface->lDelta;
-      }
-      else
-      {
-        SourceLine += BltInfo->SourceSurface->lDelta;
-      }
+      DEC_OR_INC(SourceLine, bTopToBottom, BltInfo->SourceSurface->lDelta);
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;
@@ -722,25 +670,11 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         *((WORD *)DestBits) = (WORD)XLATEOBJ_iXlate(
           BltInfo->XlateSourceToDest,
           *((PDWORD) SourceBits));
-        if (bLeftToRight)
-        {
-          SourceBits -= 4;
-        }
-        else
-        {
-          SourceBits += 4;
-        }
+        DEC_OR_INC(SourceBits, bLeftToRight, 4);
         DestBits += 2;
       }
 
-      if (bTopToBottom)
-      {
-        SourceLine -= BltInfo->SourceSurface->lDelta;
-      }
-      else
-      {
-        SourceLine += BltInfo->SourceSurface->lDelta;
-      }
+      DEC_OR_INC(SourceLine, bTopToBottom, BltInfo->SourceSurface->lDelta);
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -497,9 +497,9 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         {
           DPRINT("Flip == 1 or 3.\n");
 
-          /* Allocate enough pixels for a row in DWORD's */
-          WORD *store = ExAllocatePoolWithTag(PagedPool,
-            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 2, GDITAG_TEMP);
+          /* Allocate enough pixels for a row in WORD's */
+          WORD *store = ExAllocatePoolWithTag(NonPagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 2, TAG_DIB);
           WORD  Index;
 
           /* This sets SourceLine to the top line */
@@ -553,9 +553,9 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 2 or 3.\n");    
           DWORD  Index;
 
-          /* Allocate enough pixels for a column in DWORD's */
-          WORD *store = ExAllocatePoolWithTag(PagedPool,
-            (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 2, GDITAG_TEMP);
+          /* Allocate enough pixels for a column in WORD's */
+          WORD *store = ExAllocatePoolWithTag(NonPagedPool,
+            (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 2, TAG_DIB);
 
           /* This set the DestLine to the top line */
           DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +

--- a/win32ss/gdi/dib/dib16bpp.c
+++ b/win32ss/gdi/dib/dib16bpp.c
@@ -232,7 +232,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_4BPP:
     DPRINT("4BPP Case Selected with DestRect Width of '%d'.\n",
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceBits_4BPP to the top line */
     SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0 +
@@ -273,20 +273,13 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         }
         DEC_OR_INC(sx, bLeftToRight, 1);
       }
-      if (bTopToBottom)
-      {
-        SourceBits_4BPP -= BltInfo->SourceSurface->lDelta;
-      }
-      else
-      {
-        SourceBits_4BPP += BltInfo->SourceSurface->lDelta;
-      }
+      DEC_OR_INC(SourceBits_4BPP, bTopToBottom, BltInfo->SourceSurface->lDelta);
     }
     break;
 
   case BMF_8BPP:
     DPRINT("8BPP Case Selected with DestRect Width of '%d'.\n",
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
@@ -297,7 +290,8 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     if (bTopToBottom)
     {
       /* This sets SourceLine to the bottom line */
-      SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+      SourceLine += BltInfo->SourceSurface->lDelta 
+        * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
     }
 
     for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
@@ -325,12 +319,12 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_16BPP:
     DPRINT("16BPP Case Selected with DestRect Width of '%d'.\n",
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     DPRINT("BMF_16BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-      BltInfo->DestRect.left, BltInfo->DestRect.top,
-      BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.left, BltInfo->DestRect.top,
+           BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     if ((BltInfo->XlateSourceToDest == NULL ||
       (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL) != 0) &&
@@ -536,7 +530,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
            + ((BltInfo->DestRect.top) * BltInfo->DestSurface->lDelta)
            + 2 * BltInfo->DestRect.left;
 
-          if (BltInfo->DestSurface->lDelta > 0)
+          if ((BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN) == 0)
           {
             DestBits += BltInfo->DestSurface->lDelta;
           }
@@ -547,10 +541,10 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DestBits += 2;
           }
 
-          /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight   */
-          /* and have already completed the bLeftToRight. So we will lose our first flip output */
-          /* unless we work with its output which is at the destination site. So in this case   */
-          /* our new Source becomes the previous outputs Destination. */
+          /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight
+           * and have already completed the bLeftToRight. So we will lose our first flip output
+           * unless we work with its output which is at the destination site. So in this case
+           * our new Source becomes the previous outputs Destination. */
 
           if (OneDone)
           {
@@ -597,9 +591,9 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
   case BMF_24BPP:
 
     DPRINT("BMF_24BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-      BltInfo->DestRect.left, BltInfo->DestRect.top,
-      BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.left, BltInfo->DestRect.top,
+           BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
@@ -641,7 +635,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_32BPP:
     DPRINT("32BPP Case Selected with DestRect Width of '%d'.\n",
-      BltInfo->DestRect.right - BltInfo->DestRect.left);
+           BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
       (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) +
@@ -681,7 +675,7 @@ DIB_16BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   default:
     DPRINT1("DIB_16BPP_BitBltSrcCopy: Unhandled Source BPP: %u\n",
-      BitsPerFormat(BltInfo->SourceSurface->iBitmapFormat));
+            BitsPerFormat(BltInfo->SourceSurface->iBitmapFormat));
     return FALSE;
   }
 

--- a/win32ss/gdi/dib/dib1bpp.c
+++ b/win32ss/gdi/dib/dib1bpp.c
@@ -110,13 +110,14 @@ DIB_1BPP_BitBltSrcCopy_From1BPP (
     if (bTopToBottom)
     {
       sy1 = SourcePoint->y + dy2 - dy1;
+      ySrcDelta = -SourceSurf->lDelta;
     }
     else
     {
       sy1 = SourcePoint->y;
+      ySrcDelta = SourceSurf->lDelta;
     }
     yinc = 1;
-    ySrcDelta = SourceSurf->lDelta;
     yDstDelta = DestSurf->lDelta;
   }
   else
@@ -128,13 +129,14 @@ DIB_1BPP_BitBltSrcCopy_From1BPP (
     if (bTopToBottom)
     {
       sy1 = SourcePoint->y;
+      ySrcDelta = SourceSurf->lDelta;
     }
     else
     {
       sy1 = SourcePoint->y + dy1 - dy2;
+      ySrcDelta = -SourceSurf->lDelta;
     }
     yinc = -1;
-    ySrcDelta = -SourceSurf->lDelta;
     yDstDelta = -DestSurf->lDelta;
   }
   if ( DestRect->left <= SourcePoint->x )

--- a/win32ss/gdi/dib/dib1bpp.c
+++ b/win32ss/gdi/dib/dib1bpp.c
@@ -309,6 +309,15 @@ DIB_1BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   // Make WellOrdered with top < bottom and left < right
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
   {

--- a/win32ss/gdi/dib/dib1bpp.c
+++ b/win32ss/gdi/dib/dib1bpp.c
@@ -100,7 +100,6 @@ DIB_1BPP_BitBltSrcCopy_From1BPP (
 
   xormask = 0xFF * (BYTE)XLATEOBJ_iXlate(pxlo, 0);
 
-
   if ( DestRect->top <= SourcePoint->y )
   {
     DPRINT("Moving up (scan top -> bottom).\n");
@@ -286,8 +285,8 @@ DIB_1BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* If we came from dibobj.c with a SourceSurface BMF_TOPDOWN bit set,       */
-  /* then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
+  /* If we came from dibobj.c with a SourceSurface BMF_TOPDOWN bit set,
+   * then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
@@ -375,9 +374,9 @@ DIB_1BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_8BPP:
     DPRINT("8BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-       BltInfo->DestRect.left, BltInfo->DestRect.top,
-       BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-       BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.left, BltInfo->DestRect.top,
+      BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
  
     if (bTopToBottom)
     {

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -390,7 +390,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a row in DWORD's */
-            DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+            DWORD *store = ExAllocatePoolWithTag(PagedPool,
+              (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
 
             sx = BltInfo->SourcePoint.x;
             /* This sets sy to the top line */
@@ -425,7 +426,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               }
               sy++;
             }
-          OneDone = TRUE;
+            ExFreePoolWithTag(store, GDITAG_TEMP);
+            OneDone = TRUE;
           }
 
           if ((flip == 2) || (flip == 3))
@@ -434,7 +436,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a column in DWORD's */
-            DWORD store[BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1];
+            DWORD *store = ExAllocatePoolWithTag(PagedPool,
+              (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 4, GDITAG_TEMP);
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */
@@ -491,6 +494,7 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               }
               sx++;
             }
+            ExFreePoolWithTag(store, GDITAG_TEMP);
           }
 
         }

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -426,7 +426,7 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               }
               sy++;
             }
-            ExFreePoolWithTag(store, GDITAG_TEMP);
+            ExFreePoolWithTag(store, TAG_DIB);
             OneDone = TRUE;
           }
 
@@ -494,7 +494,7 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               }
               sx++;
             }
-            ExFreePoolWithTag(store, GDITAG_TEMP);
+            ExFreePoolWithTag(store, TAG_DIB);
           }
 
         }

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -390,8 +390,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a row in DWORD's */
-            DWORD *store = ExAllocatePoolWithTag(PagedPool,
-              (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
+            DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
+              (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
 
             sx = BltInfo->SourcePoint.x;
             /* This sets sy to the top line */
@@ -436,8 +436,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a column in DWORD's */
-            DWORD *store = ExAllocatePoolWithTag(PagedPool,
-              (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 4, GDITAG_TEMP);
+            DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
+              (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 4, TAG_DIB);
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -322,7 +322,8 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       /* Check for no flips here because we are about to use RtlMoveMemory and it can only do increasing src & dst */
-      if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) &&
+      if ((BltInfo->XlateSourceToDest == NULL ||
+        (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL) != 0) &&
         (!bTopToBottom && !bLeftToRight))
       {
         DPRINT("XO_TRIVIAL is TRUE.\n");

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -50,7 +50,7 @@ DIB_24BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1, lTmp;
+  LONG     i, j, sx, sy, xColor, f1;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
   PWORD    SourceBits_16BPP, SourceLine_16BPP;
@@ -73,7 +73,7 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     bLeftToRight = FALSE;
   }
 
-  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from copybits.c */
+  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from dibobj.c */
   if ((BltInfo->DestRect.top > BltInfo->DestRect.bottom) || (BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN))
   {
     bTopToBottom = TRUE;
@@ -87,19 +87,7 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   /* Make WellOrdered by making top < bottom and left < right */
-  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    lTmp = BltInfo->DestRect.left;
-    BltInfo->DestRect.left = BltInfo->DestRect.right;
-    BltInfo->DestRect.right = lTmp;
-  }
-
-  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
-  {
-    lTmp = BltInfo->DestRect.top;
-    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
-    BltInfo->DestRect.bottom = lTmp;
-  }
+  RECTL_vMakeWellOrdered(&BltInfo->DestRect);
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0 + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left * 3;
 
@@ -650,21 +638,10 @@ DIB_24BPP_BitBlt(PBLTINFO BltInfo)
 BOOLEAN
 DIB_24BPP_ColorFill(SURFOBJ* DestSurface, RECTL* DestRect, ULONG color)
 {
-  LONG DestY, lTmp;
+  LONG DestY;
 
   /* Make WellOrdered by making top < bottom and left < right */
-  if (DestRect->left > DestRect->right)
-  {
-    lTmp = DestRect->left;
-    DestRect->left = DestRect->right;
-    DestRect->right = lTmp;
-  }
-  if (DestRect->top > DestRect->bottom)
-  {
-    lTmp = DestRect->top;
-    DestRect->top = DestRect->bottom;
-    DestRect->bottom = lTmp;
-  }
+  RECTL_vMakeWellOrdered(DestRect);
 
 #if defined(_M_IX86) && !defined(_MSC_VER)
   PBYTE xaddr = (PBYTE)DestSurface->pvScan0 + DestRect->top * DestSurface->lDelta + (DestRect->left << 1) + DestRect->left;

--- a/win32ss/gdi/dib/dib24bpp.c
+++ b/win32ss/gdi/dib/dib24bpp.c
@@ -78,6 +78,15 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   DPRINT("flip is '%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
     flip, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
@@ -392,6 +401,10 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* Allocate enough pixels for a row in DWORD's */
             DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
               (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
+            if (store == NULL)
+            {
+              return FALSE;
+            }
 
             sx = BltInfo->SourcePoint.x;
             /* This sets sy to the top line */
@@ -438,6 +451,10 @@ DIB_24BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* Allocate enough pixels for a column in DWORD's */
             DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
               (BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1) * 4, TAG_DIB);
+            if (store == NULL)
+            {
+              return FALSE;
+            }
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -50,7 +50,7 @@ DIB_32BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1, lTmp;
+  LONG     i, j, sx, sy, xColor, f1;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBitsT, SourceBitsB, DestBitsT, DestBitsB;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
@@ -64,7 +64,11 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  DPRINT("BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
+  DPRINT("SourceSurf->dhsurf is '%p', SourceSurface->hsurf is '%p'.\n",
+    BltInfo->SourceSurface->dhsurf, BltInfo->SourceSurface->hsurf);
+
+  DPRINT("BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n",
+    BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
   /* Get back flip here */
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
@@ -76,7 +80,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     bLeftToRight = FALSE;
   }
 
-  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from copybits.c */
+  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from dibobj.c */
   if ((BltInfo->DestRect.top > BltInfo->DestRect.bottom) || (BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN))
   {
     bTopToBottom = TRUE;
@@ -90,21 +94,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   /* Make WellOrdered with top < bottom and left < right */
-  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    DPRINT("Left to Right needs Fixes.\n");
-    lTmp = BltInfo->DestRect.left;
-    BltInfo->DestRect.left = BltInfo->DestRect.right;
-    BltInfo->DestRect.right = lTmp;
-  }
-
-  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
-  {
-    DPRINT("Top To Bottom needs Fixes.\n");
-    lTmp = BltInfo->DestRect.top;
-    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
-    BltInfo->DestRect.bottom = lTmp;
-  }
+  RECTL_vMakeWellOrdered(&BltInfo->DestRect);
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
     + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta)

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -541,7 +541,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceBits -= BltInfo->SourceSurface->lDelta;
             DestBits -= BltInfo->DestSurface->lDelta;
           }
-          ExFreePoolWithTag(store, GDITAG_TEMP);
+          ExFreePoolWithTag(store, TAG_DIB);
           OneDone = TRUE;
         }
 
@@ -616,7 +616,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* If we had an odd number of lines we handle the center one here */
             RtlMoveMemory(DestBitsB, SourceBitsT, 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
           }
-          ExFreePoolWithTag(store, GDITAG_TEMP);
+          ExFreePoolWithTag(store, TAG_DIB);
         }
 
       }

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -6,6 +6,7 @@
  * PROGRAMMERS:     Jason Filby
  *                  Thomas Bluemel
  *                  Gregor Anich
+ *                  Doug Lyons
  */
 
 #include <win32k.h>
@@ -49,25 +50,91 @@ DIB_32BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1;
+  LONG     i, j, sx, sy, xColor, f1, flip, lTmp;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
+  PBYTE    SourceBitsT, SourceBitsB, DestBitsT, DestBitsB;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
   PDWORD   Source32, Dest32;
+  DWORD    Index;
+
+  DPRINT("DIB_32BPP_BitBltSrcCopy: SrcPt (%d, %d), SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
+    BltInfo->SourcePoint.x, BltInfo->SourcePoint.y,
+    BltInfo->SourceSurface->sizlBitmap.cx, BltInfo->SourceSurface->sizlBitmap.cy,
+    BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
+    BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
+
+  /* Get back flip here */
+  if ((BltInfo->DestRect.left > BltInfo->DestRect.right) && (BltInfo->DestRect.top > BltInfo->DestRect.bottom))
+  {
+    flip = 3;
+  }
+  else if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
+  {
+    flip = 2;
+  }
+  else if (BltInfo->DestRect.left > BltInfo->DestRect.right)
+  {
+    flip = 1;
+  }
+  else
+  {
+    flip = 0;
+  }
+
+  DPRINT("flip is '%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
+    flip, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
+
+  /* Make WellOrdered with top < bottom and left < right */
+  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
+  {
+    lTmp = BltInfo->DestRect.left;
+    BltInfo->DestRect.left = BltInfo->DestRect.right;
+    BltInfo->DestRect.right = lTmp;
+  }
+  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
+  {
+    lTmp = BltInfo->DestRect.top;
+    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
+    BltInfo->DestRect.bottom = lTmp;
+  }
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
     + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta)
     + 4 * BltInfo->DestRect.left;
 
+  DPRINT("iBitmapFormat is %d and width,height is (%d,%d).\n", BltInfo->SourceSurface->iBitmapFormat,
+    BltInfo->DestRect.right - BltInfo->DestRect.left, BltInfo->DestRect.bottom - BltInfo->DestRect.top);
+
+  DPRINT("Being Drawn at point '(%d,%d)-(%d,%d)'.\n",
+    BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
+
   switch (BltInfo->SourceSurface->iBitmapFormat)
   {
   case BMF_1BPP:
+    DPRINT("1BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+           BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
 
     sx = BltInfo->SourcePoint.x;
+
+    /* This sets sy to the top line */
     sy = BltInfo->SourcePoint.y;
+
+    if ((flip == 2) || (flip ==3))
+    {
+      /* This sets sy to the bottom line */
+      sy += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+    }
 
     for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)
     {
       sx = BltInfo->SourcePoint.x;
+
+      if ((flip == 1) || (flip == 3))
+      {
+        /* This sets the sx to the rightmost pixel */
+        sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+      }
+
       for (i=BltInfo->DestRect.left; i<BltInfo->DestRect.right; i++)
       {
         if (DIB_1BPP_GetPixel(BltInfo->SourceSurface, sx, sy) == 0)
@@ -76,21 +143,53 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         } else {
           DIB_32BPP_PutPixel(BltInfo->DestSurface, i, j, XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, 1));
         }
-        sx++;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          sx--;
+        }
+        else
+        {
+          sx++;
+        }
       }
-      sy++;
+      if ((flip == 2) || (flip == 3))
+      {
+        sy--;
+      }
+      else
+      {
+        sy++;
+      }
     }
     break;
 
   case BMF_4BPP:
+    DPRINT("4BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+           BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+    /* This sets SourceBits_4BPP to the top line */
     SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0
       + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta)
       + (BltInfo->SourcePoint.x >> 1);
+
+    if ((flip == 2) || (flip ==3))
+    {
+      /* This sets SourceBits_4BPP to the bottom line */
+      SourceBits_4BPP += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+    }
 
     for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)
     {
       SourceLine_4BPP = SourceBits_4BPP;
       sx = BltInfo->SourcePoint.x;
+
+      if ((flip == 1) || (flip == 3))
+      {
+        /* This sets sx to the rightmost pixel */
+        sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+      }
+
       f1 = sx & 1;
 
       for (i=BltInfo->DestRect.left; i<BltInfo->DestRect.right; i++)
@@ -99,72 +198,168 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           (*SourceLine_4BPP & altnotmask[f1]) >> (4 * (1 - f1)));
         DIB_32BPP_PutPixel(BltInfo->DestSurface, i, j, xColor);
         if (f1 == 1) {
-          SourceLine_4BPP++;
+          if ((flip == 1) || (flip == 3))
+          {
+            SourceLine_4BPP--;
+          }
+          else
+          {
+            SourceLine_4BPP++;
+          }
           f1 = 0;
         } else {
           f1 = 1;
         }
-        sx++;
+        if ((flip == 1) || (flip == 3))
+        {
+          sx--;
+        }
+        else
+        {
+          sx++;
+        }
       }
-
-      SourceBits_4BPP += BltInfo->SourceSurface->lDelta;
+      if ((flip == 2) || (flip == 3))
+      {
+        SourceBits_4BPP -= BltInfo->SourceSurface->lDelta;
+      }
+      else
+      {
+        SourceBits_4BPP += BltInfo->SourceSurface->lDelta;
+      }
     }
     break;
 
   case BMF_8BPP:
+    DPRINT("8BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+           BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+    /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
     DestLine = DestBits;
+
+    if ((flip == 2) || (flip ==3))
+    {
+      /* This sets SourceLine to the bottom line */
+      SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+    }
 
     for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
     {
       SourceBits = SourceLine;
       DestBits = DestLine;
+
+      if ((flip == 1) || (flip == 3))
+      {
+        /* This sets the SourceBits to the rightmost pixel */
+        SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+      }
 
       for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
       {
         xColor = *SourceBits;
         *((PDWORD) DestBits) = (DWORD)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-        SourceBits += 1;
+        if ((flip == 1) || (flip == 3))
+        {
+          SourceBits--;
+        }
+        else
+        {
+          SourceBits++;
+        }
         DestBits += 4;
       }
-
-      SourceLine += BltInfo->SourceSurface->lDelta;
+      if ((flip == 2) || (flip == 3))
+      {
+        SourceLine -= BltInfo->SourceSurface->lDelta;
+      }
+      else
+      {
+        SourceLine += BltInfo->SourceSurface->lDelta;
+      }
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;
 
   case BMF_16BPP:
+    DPRINT("16BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+            BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+    /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
     DestLine = DestBits;
+
+    if ((flip == 2) || (flip ==3))
+    {
+      /* This sets SourceLine to the bottom line */
+      SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+    }
 
     for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
     {
       SourceBits = SourceLine;
       DestBits = DestLine;
+
+      if ((flip == 1) || (flip == 3))
+      {
+        /* This sets the SourceBits to the rightmost pixel */
+        SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 2;
+      }
 
       for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
       {
         xColor = *((PWORD) SourceBits);
         *((PDWORD) DestBits) = (DWORD)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-        SourceBits += 2;
+        if ((flip == 1) || (flip == 3))
+        {
+          SourceBits -= 2;
+        }
+        else
+        {
+          SourceBits += 2;
+        }
         DestBits += 4;
       }
 
-      SourceLine += BltInfo->SourceSurface->lDelta;
+      if ((flip == 2) || (flip == 3))
+      {
+        SourceLine -= BltInfo->SourceSurface->lDelta;
+      }
+      else
+      {
+        SourceLine += BltInfo->SourceSurface->lDelta;
+      }
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;
 
   case BMF_24BPP:
+    DPRINT("24BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+      BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+    /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0
       + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta)
       + 3 * BltInfo->SourcePoint.x;
+
+    if ((flip == 2) || (flip ==3))
+    {
+      /* This sets SourceLine to the bottom line */
+      SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+    }
+
     DestLine = DestBits;
 
     for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
     {
       SourceBits = SourceLine;
       DestBits = DestLine;
+
+      if ((flip == 1) || (flip == 3))
+      {
+        /* This sets the SourceBits to the rightmost pixel */
+        SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 3;
+      }
 
       for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
       {
@@ -172,19 +367,42 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           (*(SourceBits + 1) << 0x08) +
           (*(SourceBits));
         *((PDWORD)DestBits) = (DWORD)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-        SourceBits += 3;
+        if ((flip == 1) || (flip == 3))
+        {
+          SourceBits -= 3;
+        }
+        else
+        {
+          SourceBits += 3;
+        }
         DestBits += 4;
       }
 
-      SourceLine += BltInfo->SourceSurface->lDelta;
+      if ((flip == 2) || (flip ==3))
+      {
+        SourceLine -= BltInfo->SourceSurface->lDelta;
+      }
+      else
+      {
+        SourceLine += BltInfo->SourceSurface->lDelta;
+      }
       DestLine += BltInfo->DestSurface->lDelta;
     }
     break;
 
   case BMF_32BPP:
-    if (NULL == BltInfo->XlateSourceToDest ||
-      0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL))
+    DPRINT("32BPP Case Selected with SrcPt (%d,%d) and DestRect Width/height of '%d/%d' and flip of '%d'.\n",
+      BltInfo->SourcePoint.x, BltInfo->SourcePoint.y,
+      BltInfo->DestRect.right - BltInfo->DestRect.left,
+      BltInfo->DestRect.bottom - BltInfo->DestRect.top, flip);
+
+    /* This tests for whether we can use simplified/quicker code below which uses RtlMoveMemory.
+     * It works for increasing source and destination areas only where there is no full overlap and no flip.
+     */
+    if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL))
+      && (flip == 0))
     {
+      DPRINT("XO_TRIVIAL is TRUE.\n");
       if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
       {
         SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
@@ -213,6 +431,10 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     }
     else
     {
+      DPRINT("XO_TRIVIAL is NOT TRUE.\n");
+      if (flip == 0)
+      /* **Note: Indent is purposefully less than desired to keep reviewable differences to a minimum for PR** */
+      {
       if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
       {
         SourceBits = ((PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x);
@@ -269,10 +491,135 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         }
       }
     }
+    else
+      {
+        /* Buffering for source and destination flip overlaps. Fixes KHMZ MirrorTest CORE-16642 */
+        BOOL OneDone = FALSE;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          DPRINT("Flip == 1 or 3.\n");
+
+          /* Allocate enough pixels for a row in DWORD's */
+          DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+
+          /* This sets SourceBits to the bottom line */
+          SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
+            + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
+            * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
+
+          /* Set DestBits to bottom line */
+          DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
+           + (BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta
+           + 4 * BltInfo->DestRect.left;
+
+          for (j = BltInfo->DestRect.bottom - 1; BltInfo->DestRect.top <= j; j--)
+          {
+
+              /* Set Dest32 to right pixel */
+              Dest32 = (DWORD *) DestBits + (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+              Source32 = (DWORD *) SourceBits;
+
+              Index = 0;
+
+              /* Store pixels from left to right */
+              for (i = BltInfo->DestRect.right - 1; BltInfo->DestRect.left <= i; i--)
+              {
+                store[Index] = XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *Source32++);
+                Index++;
+              }
+
+              Index = 0;
+
+              /* Copy stored dat to pixels from right to left */
+              for (i = BltInfo->DestRect.right - 1; BltInfo->DestRect.left <= i; i--)
+              {
+                *Dest32-- = XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, store[Index]);
+                Index++;
+              }
+            SourceBits -= BltInfo->SourceSurface->lDelta;
+            DestBits -= BltInfo->DestSurface->lDelta;
+          }
+          OneDone = TRUE;
+        }
+
+        if ((flip == 2) || (flip == 3))
+        {
+
+          /* Note: It is very important that this code remain optimized for time used. */
+          /*   Otherwise you will have random crashes in ReactOS that are undesirable. */
+          /*   For an example of this just try executing the code here two times.      */
+
+          DPRINT("Flip == 2 or 3.\n");
+
+          /* Allocate enough pixels for a row in DWORD's */
+          DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+
+          /* This set DestBitsT to the top line */
+          DestBitsT = (PBYTE)BltInfo->DestSurface->pvScan0
+            + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta)
+            + 4 * BltInfo->DestRect.left;
+
+          /* This sets DestBitsB to the bottom line */
+          DestBitsB = (PBYTE)BltInfo->DestSurface->pvScan0
+           + (BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta
+           + 4 * BltInfo->DestRect.left;
+
+          /* The OneDone flag indicates that we are doing a flip == 3 and have already */
+          /* completed the flip == 1. So we will lose our first flip output unless     */
+          /* we work with its output which is at the destination site. So in this case */
+          /* our new Source becomes the previous outputs Destination. */
+
+          if (OneDone)
+          {
+            /* This sets SourceBitsB to the bottom line */
+            SourceBitsB = DestBitsB;
+
+            /* This sets SourceBitsT to the top line */
+            SourceBitsT = DestBitsT;
+          }
+          else
+          {
+            /* This sets SourceBitsB to the bottom line */
+            SourceBitsB = (PBYTE)BltInfo->SourceSurface->pvScan0
+              + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
+              * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
+
+            /* This sets SourceBitsT to the top line */
+            SourceBitsT = (PBYTE)BltInfo->SourceSurface->pvScan0
+              + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
+          }
+
+          for (j = 0; j < (BltInfo->DestRect.bottom - BltInfo->DestRect.top) / 2 ; j++)
+          {
+            /* Store bottom row */
+            RtlMoveMemory(&store[0], SourceBitsB, 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+
+            /* Copy top row to bottom row overwriting it */
+            RtlMoveMemory(DestBitsB, SourceBitsT, 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+
+            /* Copy stored bottom row to top row */
+            RtlMoveMemory(DestBitsT, &store[0], 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+
+            /* Index top rows down and bottom rows up */
+            SourceBitsT += BltInfo->SourceSurface->lDelta;
+            SourceBitsB -= BltInfo->SourceSurface->lDelta;
+
+            DestBitsT += BltInfo->DestSurface->lDelta;
+            DestBitsB -= BltInfo->DestSurface->lDelta;
+          }
+          if ((BltInfo->DestRect.bottom - BltInfo->DestRect.top) % 2)
+          {
+            /* If we had an odd number of lines we handle the center one here */
+            RtlMoveMemory(DestBitsB, SourceBitsT, 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
+          }
+        }
+      }
+    }
     break;
 
   default:
-    DPRINT1("DIB_32BPP_Bitblt: Unhandled Source BPP: %u\n", BitsPerFormat(BltInfo->SourceSurface->iBitmapFormat));
+    DPRINT1("DIB_32BPP_BitBltSrcCopy: Unhandled Source BPP: %u\n", BitsPerFormat(BltInfo->SourceSurface->iBitmapFormat));
     return FALSE;
   }
 

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -501,7 +501,8 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 1 or 3.\n");
 
           /* Allocate enough pixels for a row in DWORD's */
-          DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+          DWORD *store = ExAllocatePoolWithTag(PagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
 
           /* This sets SourceBits to the bottom line */
           SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
@@ -540,6 +541,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             SourceBits -= BltInfo->SourceSurface->lDelta;
             DestBits -= BltInfo->DestSurface->lDelta;
           }
+          ExFreePoolWithTag(store, GDITAG_TEMP);
           OneDone = TRUE;
         }
 
@@ -553,7 +555,8 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 2 or 3.\n");
 
           /* Allocate enough pixels for a row in DWORD's */
-          DWORD store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+          DWORD *store = ExAllocatePoolWithTag(PagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
 
           /* This set DestBitsT to the top line */
           DestBitsT = (PBYTE)BltInfo->DestSurface->pvScan0
@@ -613,7 +616,9 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* If we had an odd number of lines we handle the center one here */
             RtlMoveMemory(DestBitsB, SourceBitsT, 4 * (BltInfo->DestRect.right - BltInfo->DestRect.left));
           }
+          ExFreePoolWithTag(store, GDITAG_TEMP);
         }
+
       }
     }
     break;

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -503,7 +503,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             + ((BltInfo->DestRect.top) * BltInfo->DestSurface->lDelta)
             + 4 * BltInfo->DestRect.left;
 
-          if (BltInfo->DestSurface->lDelta > 0)
+          if ((BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN) == 0)
           {
             DestBits += BltInfo->DestSurface->lDelta;
           }

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -81,6 +81,15 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   DPRINT("flip is '%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
     flip, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
@@ -503,6 +512,10 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           /* Allocate enough pixels for a row in DWORD's */
           DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
             (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
+          if (store == NULL)
+          {
+            return FALSE;
+          }
 
           /* This sets SourceBits to the bottom line */
           SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
@@ -557,6 +570,10 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           /* Allocate enough pixels for a row in DWORD's */
           DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
             (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
+          if (store == NULL)
+          {
+            return FALSE;
+          }
 
           /* This set DestBitsT to the top line */
           DestBitsT = (PBYTE)BltInfo->DestSurface->pvScan0

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -110,7 +110,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
   {
   case BMF_1BPP:
     DPRINT("1BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     sx = BltInfo->SourcePoint.x;
 
@@ -164,7 +164,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_4BPP:
     DPRINT("4BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceBits_4BPP to the top line */
     SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0
@@ -230,7 +230,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_8BPP:
     DPRINT("8BPP Case Selected with DestRect Width of '%d'.\n",
-           BltInfo->DestRect.right - BltInfo->DestRect.left);
+      BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
@@ -281,7 +281,7 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
   case BMF_16BPP:
     DPRINT("16BPP Case Selected with DestRect Width of '%d'.\n",
-            BltInfo->DestRect.right - BltInfo->DestRect.left);
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
     /* This sets SourceLine to the top line */
     SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
@@ -397,8 +397,9 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     /* This tests for whether we can use simplified/quicker code below which uses RtlMoveMemory.
      * It works for increasing source and destination areas only where there is no full overlap and no flip.
      */
-    if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL))
-      && (!bTopToBottom && !bLeftToRight))
+    if ((BltInfo->XlateSourceToDest == NULL ||
+      (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL) != 0) &&
+      (!bTopToBottom && !bLeftToRight))
     {
       DPRINT("XO_TRIVIAL is TRUE.\n");
       if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
@@ -551,9 +552,9 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         if (bTopToBottom)
         {
 
-          /* Note: It is very important that this code remain optimized for time used. */
-          /*   Otherwise you will have random crashes in ReactOS that are undesirable. */
-          /*   For an example of this just try executing the code here two times.      */
+          /* Note: It is very important that this code remain optimized for time used.
+           *   Otherwise you will have random crashes in ReactOS that are undesirable.
+           *   For an example of this just try executing the code here two times. */
 
           DPRINT("Flip is bTopToBottom.\n");
 
@@ -576,10 +577,10 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
            + (BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta
            + 4 * BltInfo->DestRect.left;
 
-          /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight   */
-          /* and have already completed the bLeftToRight. So we will lose our first flip output */
-          /* unless we work with its output which is at the destination site. So in this case   */
-          /* our new Source becomes the previous outputs Destination. */
+          /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight
+           * and have already completed the bLeftToRight. So we will lose our first flip output
+           * unless we work with its output which is at the destination site. So in this case
+           * our new Source becomes the previous outputs Destination. */
 
           if (OneDone)
           {

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -498,12 +498,17 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta)
             + 4 * BltInfo->SourcePoint.x;
 
+          if (BltInfo->SourceSurface->lDelta < 0)
+          {
+            SourceBits -= BltInfo->SourceSurface->lDelta;
+          }
+
           /* This set DestBits to the top line */
           DestBits = (PBYTE)BltInfo->DestSurface->pvScan0
             + ((BltInfo->DestRect.top) * BltInfo->DestSurface->lDelta)
             + 4 * BltInfo->DestRect.left;
 
-          if ((BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN) == 0)
+          if (((BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN) == 0) && (BltInfo->DestSurface->lDelta > 0))
           {
             DestBits += BltInfo->DestSurface->lDelta;
           }

--- a/win32ss/gdi/dib/dib32bpp.c
+++ b/win32ss/gdi/dib/dib32bpp.c
@@ -501,8 +501,8 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 1 or 3.\n");
 
           /* Allocate enough pixels for a row in DWORD's */
-          DWORD *store = ExAllocatePoolWithTag(PagedPool,
-            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
+          DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
 
           /* This sets SourceBits to the bottom line */
           SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0
@@ -555,8 +555,8 @@ DIB_32BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DPRINT("Flip == 2 or 3.\n");
 
           /* Allocate enough pixels for a row in DWORD's */
-          DWORD *store = ExAllocatePoolWithTag(PagedPool,
-            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, GDITAG_TEMP);
+          DWORD *store = ExAllocatePoolWithTag(NonPagedPool,
+            (BltInfo->DestRect.right - BltInfo->DestRect.left + 1) * 4, TAG_DIB);
 
           /* This set DestBitsT to the top line */
           DestBitsT = (PBYTE)BltInfo->DestSurface->pvScan0

--- a/win32ss/gdi/dib/dib32bppc.c
+++ b/win32ss/gdi/dib/dib32bppc.c
@@ -32,6 +32,9 @@ DIB_32BPP_ColorFill(SURFOBJ* DestSurface, RECTL* DestRect, ULONG color)
 {
   ULONG DestY;
 
+  /* Make WellOrdered by making top < bottom and left < right */
+  RECTL_vMakeWellOrdered(DestRect);
+
   for (DestY = DestRect->top; DestY< DestRect->bottom; DestY++)
   {
     DIB_32BPP_HLine (DestSurface, DestRect->left, DestRect->right, DestY, color);

--- a/win32ss/gdi/dib/dib4bpp.c
+++ b/win32ss/gdi/dib/dib4bpp.c
@@ -234,7 +234,7 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       if ((flip == 2) || (flip == 3))
       {
         /* This sets SourceBits to the bottom line */
-        SourceBits_8BPP = (PBYTE)((LONG)SourceBits_8BPP +
+        SourceBits_8BPP = (PBYTE)((LONG_PTR)SourceBits_8BPP +
           ((BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) *
           BltInfo->SourceSurface->lDelta));
       }

--- a/win32ss/gdi/dib/dib4bpp.c
+++ b/win32ss/gdi/dib/dib4bpp.c
@@ -90,6 +90,15 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   /* Then we make top < bottom and left < right */
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
   {

--- a/win32ss/gdi/dib/dib4bpp.c
+++ b/win32ss/gdi/dib/dib4bpp.c
@@ -71,8 +71,8 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM   */
-  /* bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
+  /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM
+   * bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
@@ -223,12 +223,12 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
     case BMF_8BPP:
       DPRINT("8BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-         BltInfo->DestRect.left, BltInfo->DestRect.top,
-         BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-         BltInfo->DestRect.right - BltInfo->DestRect.left);
+        BltInfo->DestRect.left, BltInfo->DestRect.top,
+        BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       SourceBits_8BPP = (PBYTE)BltInfo->SourceSurface->pvScan0 + 
-          (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
+        (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
 
       if (bTopToBottom)
       {

--- a/win32ss/gdi/dib/dib4bpp.c
+++ b/win32ss/gdi/dib/dib4bpp.c
@@ -60,7 +60,7 @@ DIB_4BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, f2, xColor, lTmp;;
+  LONG     i, j, sx, sy, f2, xColor;
   PBYTE    SourceBits_24BPP, SourceLine_24BPP;
   PBYTE    DestBits, DestLine, SourceBits_8BPP, SourceLine_8BPP;
   PBYTE    SourceBits, SourceLine;
@@ -71,7 +71,7 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* If we came from copybits.c with a TBltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM   */
+  /* If we came from dibobj.c with a TBltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM   */
   /* bit set, then we need a flip of bTopToBottom. This mostly fixes Lazarus and PeaZip. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
@@ -87,7 +87,7 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     bLeftToRight = FALSE;
   }
 
-  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from copybits.c */
+  /* The OR for BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN checks for coming from dibobj.c */
   if ((BltInfo->DestRect.top > BltInfo->DestRect.bottom) || (BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN ))
   {
     bTopToBottom = TRUE;
@@ -97,20 +97,8 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     bTopToBottom = FALSE;
   }
 
-  /* Then we make top < bottom and left < right */
-  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    lTmp = BltInfo->DestRect.left;
-    BltInfo->DestRect.left = BltInfo->DestRect.right;
-    BltInfo->DestRect.right = lTmp;
-  }
-
-  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
-  {
-    lTmp = BltInfo->DestRect.top;
-    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
-    BltInfo->DestRect.bottom = lTmp;
-  }
+  /* Make WellOrdered with top < bottom and left < right */
+  RECTL_vMakeWellOrdered(&BltInfo->DestRect);
 
   DPRINT("BPP is '%d/%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
     BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
@@ -621,21 +609,10 @@ DIB_4BPP_BitBlt(PBLTINFO BltInfo)
 BOOLEAN
 DIB_4BPP_ColorFill(SURFOBJ* DestSurface, RECTL* DestRect, ULONG color)
 {
-  LONG DestY, lTmp;
+  LONG DestY;
 
-/* Make WellOrdered by making top < bottom and left < right */
-    if (DestRect->left > DestRect->right)
-    {
-        lTmp = DestRect->left;
-        DestRect->left = DestRect->right;
-        DestRect->right = lTmp;
-    }
-    if (DestRect->top > DestRect->bottom)
-    {
-        lTmp = DestRect->top;
-        DestRect->top = DestRect->bottom;
-        DestRect->bottom = lTmp;
-    }
+  /* Make WellOrdered by making top < bottom and left < right */
+  RECTL_vMakeWellOrdered(DestRect);
 
   for (DestY = DestRect->top; DestY < DestRect->bottom; DestY++)
   {

--- a/win32ss/gdi/dib/dib4bpp.c
+++ b/win32ss/gdi/dib/dib4bpp.c
@@ -234,7 +234,7 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       if ((flip == 2) || (flip == 3))
       {
         /* This sets SourceBits to the bottom line */
-        SourceBits = (PBYTE)((LONG)SourceBits +
+        SourceBits_8BPP = (PBYTE)((LONG)SourceBits_8BPP +
           ((BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) *
           BltInfo->SourceSurface->lDelta));
       }
@@ -351,7 +351,7 @@ DIB_4BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       if ((flip == 2) || (flip ==3))
       {
         /* This sets SourceLine to the bottom line */
-        SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+        SourceBits_24BPP += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
       }
 
       for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -86,6 +86,15 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     flip = 0;
   }
 
+  DPRINT("Flip is '%d'.\n", flip);
+
+  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
+  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
+  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  {
+    flip = 2;
+  }
+
   /* Make WellOrdered by making top < bottom and left < right */
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
   {
@@ -317,6 +326,10 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* Allocate enough pixels for a row in BYTE's */
             BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
               BltInfo->DestRect.right - BltInfo->DestRect.left + 1, TAG_DIB);
+            if (store == NULL)
+            {
+              return FALSE;
+            }
             WORD  Index;
 
             /* This sets SourceLine to the top line */
@@ -374,6 +387,10 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             /* Allocate enough pixels for a column in BYTE's */
             BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
               BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, TAG_DIB);
+            if (store == NULL)
+            {
+              return FALSE;
+            }
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -14,6 +14,7 @@
 
 #define NDEBUG
 #include <debug.h>
+#include <stdlib.h>
 
 VOID
 DIB_8BPP_PutPixel(SURFOBJ *SurfObj, LONG x, LONG y, ULONG c)
@@ -313,9 +314,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           {
             DPRINT("Flip == 1 or 3.\n");
 
-            /* Allocate enough pixels for a row in DWORD's */
-            BYTE *store = ExAllocatePoolWithTag(PagedPool,
-              BltInfo->DestRect.right - BltInfo->DestRect.left + 1, GDITAG_TEMP);
+            /* Allocate enough pixels for a row in BYTE's */
+            BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
+              BltInfo->DestRect.right - BltInfo->DestRect.left + 1, TAG_DIB);
             WORD  Index;
 
             /* This sets SourceLine to the top line */
@@ -370,9 +371,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     
             DWORD  Index;
 
-            /* Allocate enough pixels for a column in DWORD's */
-            BYTE *store = ExAllocatePoolWithTag(PagedPool,
-              BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, GDITAG_TEMP);
+            /* Allocate enough pixels for a column in BYTE's */
+            BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
+              BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, TAG_DIB);
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -361,7 +361,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += BltInfo->SourceSurface->lDelta;
               DestLine += BltInfo->DestSurface->lDelta;
             }
-            ExFreePoolWithTag(store, GDITAG_TEMP);
+            ExFreePoolWithTag(store, TAG_DIB);
             OneDone = TRUE;
           }
 
@@ -432,7 +432,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += 1;
               DestLine += 1;
             }
-            ExFreePoolWithTag(store, GDITAG_TEMP);
+            ExFreePoolWithTag(store, TAG_DIB);
           }
 
         }

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -60,7 +60,8 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
   LONG     i, j, sx, sy, xColor, f1;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
-  PBYTE    SourceBits_4BPP, SourceLine_4BPP;
+  PBYTE    SourceBits_4BPP, SourceLine_4BPP, Store;
+  DWORD    Count;
   BOOLEAN  bTopToBottom, bLeftToRight;
 
   DPRINT("DIB_8BPP_BitBltSrcCopy: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
@@ -266,9 +267,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DPRINT("Flip is bLeftToRight.\n");
 
             /* Allocate enough pixels for a row in BYTE's */
-            BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
-              BltInfo->DestRect.right - BltInfo->DestRect.left + 1, TAG_DIB);
-            if (store == NULL)
+            Count = BltInfo->DestRect.right - BltInfo->DestRect.left + 1;
+            Store = ExAllocatePoolWithTag(NonPagedPool, Count, TAG_DIB);
+            if (Store == NULL)
             {
               DPRINT1("Storage Allocation Failed.\n");
               return FALSE;
@@ -298,7 +299,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
               for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
               {
-                store[Index] = (BYTE)XLATEOBJ_iXlate(
+                Store[Index] = (BYTE)XLATEOBJ_iXlate(
                   BltInfo->XlateSourceToDest,
                   *SourceBits);
                 SourceBits--;
@@ -309,7 +310,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
               for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
               {
-                *DestBits = store[Index];
+                *DestBits = Store[Index];
                 DestBits++;
                 Index++;
               }
@@ -317,7 +318,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += BltInfo->SourceSurface->lDelta;
               DestLine += BltInfo->DestSurface->lDelta;
             }
-            ExFreePoolWithTag(store, TAG_DIB);
+            ExFreePoolWithTag(Store, TAG_DIB);
             OneDone = TRUE;
           }
 
@@ -328,9 +329,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a column in BYTE's */
-            BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
-              BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, TAG_DIB);
-            if (store == NULL)
+            Count = BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1;
+            Store = ExAllocatePoolWithTag(NonPagedPool, Count, TAG_DIB);
+            if (Store == NULL)
             {
               DPRINT1("Storage Allocation Failed.\n");
               return FALSE;
@@ -374,7 +375,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               /* Read up the column and store the pixels */
               for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
               {
-                store[Index] = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *SourceBits);
+                Store[Index] = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *SourceBits);
                 /* Go up a line */
                 SourceBits -= BltInfo->SourceSurface->lDelta;
                 Index++;
@@ -385,7 +386,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               /* Get the stored pixel and copy then down the column */
               for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
               {
-                *DestBits = store[Index];
+                *DestBits = Store[Index];
                 /* Go down a line */
                 DestBits += BltInfo->SourceSurface->lDelta;
                 Index++;
@@ -394,7 +395,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += 1;
               DestLine += 1;
             }
-            ExFreePoolWithTag(store, TAG_DIB);
+            ExFreePoolWithTag(Store, TAG_DIB);
           }
 
         }

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -6,6 +6,7 @@
  * PROGRAMMERS:     Jason Filby
  *                  Thomas Bluemel
  *                  Gregor Anich
+ *                  Doug Lyons
  */
 
 #include <win32k.h>
@@ -54,21 +55,82 @@ DIB_8BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1;
+  LONG     i, j, sx, sy, xColor, f1, flip, lTmp;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
+
+  DPRINT("DIB_8BPP_BitBltSrcCopy: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
+    BltInfo->SourceSurface->sizlBitmap.cx, BltInfo->SourceSurface->sizlBitmap.cy,
+    BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
+    BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
+
+  /* Retrieve flip here and then make Well-Ordered again */
+  /* Get back flip here */
+
+  if ((BltInfo->DestRect.left > BltInfo->DestRect.right) && (BltInfo->DestRect.top > BltInfo->DestRect.bottom))
+  {
+    flip = 3;
+  }
+  else if (BltInfo->DestRect.left > BltInfo->DestRect.right)
+  {
+    flip = 1;
+  }
+  else if  (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
+  {
+    flip = 2;
+  }
+  else
+  {
+    flip = 0;
+  }
+
+  /* Make WellOrdered by making top < bottom and left < right */
+  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
+  {
+    lTmp = BltInfo->DestRect.left;
+    BltInfo->DestRect.left = BltInfo->DestRect.right;
+    BltInfo->DestRect.right = lTmp;
+  }
+
+  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
+  {
+    lTmp = BltInfo->DestRect.top;
+    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
+    BltInfo->DestRect.bottom = lTmp;
+  }
+
+  DPRINT("flip/bpp is '%d/%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
+    flip, BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0 + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left;
 
   switch(BltInfo->SourceSurface->iBitmapFormat)
   {
     case BMF_1BPP:
+      DPRINT("1BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
       sx = BltInfo->SourcePoint.x;
+
+      /* This sets sy to the top line */
       sy = BltInfo->SourcePoint.y;
+
+      if ((flip == 2) || (flip ==3))
+      {
+        /* This sets sy to the bottom line */
+        sy += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
+      }
 
       for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)
       {
         sx = BltInfo->SourcePoint.x;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          /* This sets the sx to the rightmost pixel */
+          sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+        }
+
         for (i=BltInfo->DestRect.left; i<BltInfo->DestRect.right; i++)
         {
           if(DIB_1BPP_GetPixel(BltInfo->SourceSurface, sx, sy) == 0)
@@ -79,19 +141,50 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           {
             DIB_8BPP_PutPixel(BltInfo->DestSurface, i, j, XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, 1));
           }
-          sx++;
+          if ((flip == 1) || (flip == 3))
+          {
+            sx--;
+          }
+          else
+          {
+            sx++;
+          }
         }
-        sy++;
+        if ((flip == 2) || (flip == 3))
+        {
+          sy--;
+        }
+        else
+        {
+          sy++;
+        }
       }
       break;
 
     case BMF_4BPP:
+      DPRINT("4BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+      /* This sets SourceBits_4BPP to the top line */
       SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + (BltInfo->SourcePoint.x >> 1);
+
+      if ((flip == 2) || (flip ==3))
+      {
+        /* This sets SourceBits_4BPP to the bottom line */
+        SourceBits_4BPP += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
+      }
 
       for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)
       {
         SourceLine_4BPP = SourceBits_4BPP;
         sx = BltInfo->SourcePoint.x;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          /* This sets sx to the rightmost pixel */
+          sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+        }
+
         f1 = sx & 1;
 
         for (i=BltInfo->DestRect.left; i<BltInfo->DestRect.right; i++)
@@ -99,19 +192,54 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           xColor = XLATEOBJ_iXlate(BltInfo->XlateSourceToDest,
               (*SourceLine_4BPP & altnotmask[f1]) >> (4 * (1 - f1)));
           DIB_8BPP_PutPixel(BltInfo->DestSurface, i, j, xColor);
-          if(f1 == 1) { SourceLine_4BPP++; f1 = 0; } else { f1 = 1; }
-          sx++;
-        }
+          if(f1 == 1)
+          {
+            if ((flip == 1) || (flip == 3))
+            {
+              SourceLine_4BPP--;
+            }
+            else
+            {
+              SourceLine_4BPP++;
+            }
+            f1 = 0;
+          }
+          else
+          {
+            f1 = 1;
+          }
 
-        SourceBits_4BPP += BltInfo->SourceSurface->lDelta;
+          if ((flip == 1) || (flip == 3))
+          {
+            sx--;
+          }
+          else
+          {
+            sx++;
+          }
+        }
+        if ((flip == 2) || (flip == 3))
+        {
+          SourceBits_4BPP -= BltInfo->SourceSurface->lDelta;
+        }
+        else
+        {
+          SourceBits_4BPP += BltInfo->SourceSurface->lDelta;
+        }
       }
       break;
 
     case BMF_8BPP:
-      if (NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL))
+      DPRINT("8BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
+         BltInfo->DestRect.left, BltInfo->DestRect.top,
+         BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+         BltInfo->DestRect.right - BltInfo->DestRect.left);
+
+      if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) && (flip == 0))
       {
         if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
         {
+          DPRINT("BltInfo->DestRect.top < BltInfo->SourcePoint.y.\n");
           SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
           for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
           {
@@ -122,6 +250,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         }
         else
         {
+          DPRINT("BltInfo->DestRect.top >= BltInfo->SourcePoint.y.\n");
           SourceBits = (PBYTE)BltInfo->SourceSurface->pvScan0 + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
           DestBits = (PBYTE)BltInfo->DestSurface->pvScan0 + ((BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left;
           for (j = BltInfo->DestRect.bottom - 1; BltInfo->DestRect.top <= j; j--)
@@ -134,8 +263,14 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       }
       else
       {
+        DPRINT("XO_TRIVIAL is NOT TRUE or (flip != 0).\n");
+
+        if (flip == 0)
+      /* **Note: Indent is purposefully less than desired to keep reviewable differences to a minimum for PR** */
+        {
         if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
         {
+          DPRINT("Dest.top < SourcePoint.y.\n");
           SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
           DestLine = DestBits;
           for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
@@ -152,6 +287,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         }
         else
         {
+          DPRINT("Dest.top >= SourcePoint.y.\n");
           SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x;
           DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 + ((BltInfo->DestRect.bottom - 1) * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left;
           for (j = BltInfo->DestRect.bottom - 1; BltInfo->DestRect.top <= j; j--)
@@ -167,38 +303,218 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           }
         }
       }
+      else
+      {
+          /* Buffering for source and destination flip overlaps. Fixes KHMZ MirrorTest CORE-16642 */
+          BOOL OneDone = FALSE;
+
+          if ((flip == 1) || (flip == 3))
+          {
+            DPRINT("Flip == 1 or 3.\n");
+
+            /* Allocate enough pixels for a row in DWORD's */
+            BYTE store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+            WORD  Index;
+
+            /* This sets SourceLine to the top line */
+            SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
+              (BltInfo->SourcePoint.y *
+              BltInfo->SourceSurface->lDelta) +
+              BltInfo->SourcePoint.x;
+
+            /* This set the DestLine to the top line */
+            DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +
+              (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) +
+              BltInfo->DestRect.left;
+
+            for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
+            {
+              SourceBits = SourceLine;
+              DestBits = DestLine;
+
+              /* This sets SourceBits to the rightmost pixel */
+              SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
+
+              Index = 0;
+
+              for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
+              {
+                store[Index] = (BYTE)XLATEOBJ_iXlate(
+                  BltInfo->XlateSourceToDest,
+                  *SourceBits);
+                SourceBits--;
+                Index++;
+              }
+
+              Index = 0;
+
+              for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
+              {
+                *DestBits = store[Index];
+                DestBits++;
+                Index++;
+              }
+
+              SourceLine += BltInfo->SourceSurface->lDelta;
+              DestLine += BltInfo->DestSurface->lDelta;
+            }
+            OneDone = TRUE;
+          }
+
+          if ((flip == 2) || (flip == 3))
+          {
+            DPRINT("Flip == 2 or 3.\n");
+    
+            DWORD  Index;
+
+            /* Allocate enough pixels for a column in DWORD's */
+            BYTE store[BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1];
+
+            /* The OneDone flag indicates that we are doing a flip == 3 and have already */
+            /* completed the flip == 1. So we will lose our first flip output unless     */
+            /* we work with its output which is at the destination site. So in this case */
+            /* our new Source becomes the previous outputs Destination. */
+
+            if (OneDone)
+            {
+              /* This sets SourceLine to the bottom line of our previous destination */
+              SourceLine = (PBYTE)BltInfo->DestSurface->pvScan0 + 
+                (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left  +
+                (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->DestSurface->lDelta;
+            }
+            else
+            {
+              /* This sets SourceLine to the bottom line */
+              SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + 
+                (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x  +
+                (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
+            }
+
+            /* This set the DestLine to the top line */
+            DestLine = (PBYTE)BltInfo->DestSurface->pvScan0 +
+              (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) +
+              BltInfo->DestRect.left;
+
+            /* Read columns */
+            for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
+            {
+
+              DestBits = DestLine;
+              SourceBits = SourceLine;
+
+              Index = 0;
+
+              /* Read up the column and store the pixels */
+              for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
+              {
+                store[Index] = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, *SourceBits);
+                /* Go up a line */
+                SourceBits -= BltInfo->SourceSurface->lDelta;
+                Index++;
+              }
+ 
+              Index = 0;
+
+              /* Get the stored pixel and copy then down the column */
+              for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
+              {
+                *DestBits = store[Index];
+                /* Go down a line */
+                DestBits += BltInfo->SourceSurface->lDelta;
+                Index++;
+              }
+              /* Index to next column */
+              SourceLine += 1;
+              DestLine += 1;
+            }
+          }
+
+        }
+      }
       break;
 
     case BMF_16BPP:
+      DPRINT("16BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
+      DPRINT("BMF_16BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
+        BltInfo->DestRect.left, BltInfo->DestRect.top,
+        BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
+
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
+
+      if ((flip == 2) || (flip ==3))
+      {
+        /* This sets SourceLine to the bottom line */
+        SourceLine += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;;
+      }
       DestLine = DestBits;
 
       for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
       {
         SourceBits = SourceLine;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          /* This sets SourceBits to the rightmost pixel */
+          SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 2;
+        }
         DestBits = DestLine;
 
         for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
         {
           xColor = *((PWORD) SourceBits);
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-          SourceBits += 2;
+
+          if ((flip == 1) || (flip ==3))
+          {
+            SourceBits -= 2;
+          }
+          else
+          {
+            SourceBits += 2;
+          }
           DestBits += 1;
         }
-
-        SourceLine += BltInfo->SourceSurface->lDelta;
+        if ((flip == 2) || (flip ==3))
+        {
+          SourceLine -= BltInfo->SourceSurface->lDelta;
+        }
+        else
+        {
+          SourceLine += BltInfo->SourceSurface->lDelta;
+        }
         DestLine += BltInfo->DestSurface->lDelta;
       }
       break;
 
     case BMF_24BPP:
+
+      DPRINT("24BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
+        BltInfo->DestRect.left, BltInfo->DestRect.top,
+        BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
+
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 3 * BltInfo->SourcePoint.x;
       DestLine = DestBits;
+
+      if ((flip == 2) || (flip ==3))
+      {
+        /* This sets SourceLine to the bottom line */
+        SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
+      }
 
       for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
       {
         SourceBits = SourceLine;
         DestBits = DestLine;
+
+        if ((flip == 1) || (flip == 3))
+        {
+          /* This sets the SourceBits to the rightmost pixel */
+          SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 3;
+        }
 
         for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
         {
@@ -206,17 +522,40 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
              (*(SourceBits + 1) << 0x08) +
              (*(SourceBits));
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-          SourceBits += 3;
+          if ((flip == 1) || (flip == 3))
+          {
+             SourceBits -= 3;
+          }
+          else
+          {
+             SourceBits += 3;
+          }
           DestBits += 1;
         }
-
-        SourceLine += BltInfo->SourceSurface->lDelta;
+        if ((flip == 2) || (flip ==3))
+        {
+          SourceLine -= BltInfo->SourceSurface->lDelta;
+        }
+        else
+        {
+          SourceLine += BltInfo->SourceSurface->lDelta;
+        }
         DestLine += BltInfo->DestSurface->lDelta;
       }
       break;
 
     case BMF_32BPP:
+
+      DPRINT("32BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
+
+      if ((flip == 2) || (flip ==3))
+      {
+        /* This sets SourceLine to the bottom line */
+        SourceLine += BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1;
+      }
       DestLine = DestBits;
 
       for (j = BltInfo->DestRect.top; j < BltInfo->DestRect.bottom; j++)
@@ -224,15 +563,35 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         SourceBits = SourceLine;
         DestBits = DestLine;
 
+        if ((flip == 1) || (flip == 3))
+        {
+          /* This sets SourceBits to the rightmost pixel */
+          SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 4;
+        }
+
         for (i = BltInfo->DestRect.left; i < BltInfo->DestRect.right; i++)
         {
           xColor = *((PDWORD) SourceBits);
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-          SourceBits += 4;
+
+          if ((flip == 1) || (flip ==3))
+          {
+            SourceBits -= 4;
+          }
+          else
+          {
+            SourceBits += 4;
+          }
           DestBits += 1;
         }
-
-        SourceLine += BltInfo->SourceSurface->lDelta;
+        if ((flip == 2) || (flip ==3))
+        {
+          SourceLine -= BltInfo->SourceSurface->lDelta;
+        }
+        else
+        {
+          SourceLine += BltInfo->SourceSurface->lDelta;
+        }
         DestLine += BltInfo->DestSurface->lDelta;
       }
       break;
@@ -249,7 +608,22 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 BOOLEAN
 DIB_8BPP_ColorFill(SURFOBJ* DestSurface, RECTL* DestRect, ULONG color)
 {
-  LONG DestY;
+  LONG DestY, lTmp;
+
+  /* Make WellOrdered by making top < bottom and left < right */
+  if (DestRect->left > DestRect->right)
+  {
+    lTmp = DestRect->left;
+    DestRect->left = DestRect->right;
+    DestRect->right = lTmp;
+  }
+  if (DestRect->top > DestRect->bottom)
+  {
+    lTmp = DestRect->top;
+    DestRect->top = DestRect->bottom;
+    DestRect->bottom = lTmp;
+  }
+
   for (DestY = DestRect->top; DestY< DestRect->bottom; DestY++)
   {
     DIB_8BPP_HLine(DestSurface, DestRect->left, DestRect->right, DestY, color);

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -11,6 +11,7 @@
 
 #include <win32k.h>
 
+
 #define NDEBUG
 #include <debug.h>
 
@@ -313,7 +314,8 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DPRINT("Flip == 1 or 3.\n");
 
             /* Allocate enough pixels for a row in DWORD's */
-            BYTE store[BltInfo->DestRect.right - BltInfo->DestRect.left + 1];
+            BYTE *store = ExAllocatePoolWithTag(PagedPool,
+              BltInfo->DestRect.right - BltInfo->DestRect.left + 1, GDITAG_TEMP);
             WORD  Index;
 
             /* This sets SourceLine to the top line */
@@ -358,6 +360,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += BltInfo->SourceSurface->lDelta;
               DestLine += BltInfo->DestSurface->lDelta;
             }
+            ExFreePoolWithTag(store, GDITAG_TEMP);
             OneDone = TRUE;
           }
 
@@ -368,7 +371,8 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             DWORD  Index;
 
             /* Allocate enough pixels for a column in DWORD's */
-            BYTE store[BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1];
+            BYTE *store = ExAllocatePoolWithTag(PagedPool,
+              BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, GDITAG_TEMP);
 
             /* The OneDone flag indicates that we are doing a flip == 3 and have already */
             /* completed the flip == 1. So we will lose our first flip output unless     */
@@ -427,6 +431,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               SourceLine += 1;
               DestLine += 1;
             }
+            ExFreePoolWithTag(store, GDITAG_TEMP);
           }
 
         }

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -11,10 +11,8 @@
 
 #include <win32k.h>
 
-
 #define NDEBUG
 #include <debug.h>
-#include <stdlib.h>
 
 VOID
 DIB_8BPP_PutPixel(SURFOBJ *SurfObj, LONG x, LONG y, ULONG c)
@@ -57,43 +55,41 @@ DIB_8BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1, flip, lTmp;
+  LONG     i, j, sx, sy, xColor, f1, lTmp;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
+  BOOLEAN  bTopToBottom, bLeftToRight;
 
   DPRINT("DIB_8BPP_BitBltSrcCopy: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
     BltInfo->SourceSurface->sizlBitmap.cx, BltInfo->SourceSurface->sizlBitmap.cy,
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* Retrieve flip here and then make Well-Ordered again */
-  /* Get back flip here */
+  /* Normally,if we came from copybits.c with a BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN     */
+  /* bit set, we have to set the bTopToBottom flip bit for Lazarus and PeaZip. But for some reason */
+  /* for the 8 BPP here we need to ignore this bit or we get fails in gdi32:CreateDIBPatternBrush. */
 
-  if ((BltInfo->DestRect.left > BltInfo->DestRect.right) && (BltInfo->DestRect.top > BltInfo->DestRect.bottom))
+  DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
+
+  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
   {
-    flip = 3;
-  }
-  else if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    flip = 1;
-  }
-  else if  (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
-  {
-    flip = 2;
+    bLeftToRight = TRUE;
   }
   else
   {
-    flip = 0;
+    bLeftToRight = FALSE;
   }
 
-  DPRINT("Flip is '%d'.\n", flip);
-
-  /* If we came from copybits.c with a Top-Down SourceSurface bit set, */
-  /* then we need a flip of 2. This mostly fixes Lazarus and PeaZip.   */
-  if ((BltInfo->SourceSurface->fjBitmap & BMF_UMPDMEM) && (flip == 0))
+  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
   {
-    flip = 2;
+    bTopToBottom = TRUE;
   }
+  else
+  {
+    bTopToBottom = FALSE;
+  }
+
+  DPRINT("bTopToBottom is '%d' and bLeftToRight is '%d'.\n", bTopToBottom, bLeftToRight);
 
   /* Make WellOrdered by making top < bottom and left < right */
   if (BltInfo->DestRect.left > BltInfo->DestRect.right)
@@ -110,33 +106,33 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestRect.bottom = lTmp;
   }
 
-  DPRINT("flip/bpp is '%d/%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
-    flip, BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
+  DPRINT("BPP is '%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
+    BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
 
   DestBits = (PBYTE)BltInfo->DestSurface->pvScan0 + (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left;
 
   switch(BltInfo->SourceSurface->iBitmapFormat)
   {
     case BMF_1BPP:
-      DPRINT("1BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
-        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+      DPRINT("1BPP Case Selected with DestRect Width of '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       sx = BltInfo->SourcePoint.x;
 
       /* This sets sy to the top line */
       sy = BltInfo->SourcePoint.y;
 
-      if ((flip == 2) || (flip ==3))
+      if (bTopToBottom)
       {
         /* This sets sy to the bottom line */
-        sy += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
+        sy += BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1;
       }
 
       for (j=BltInfo->DestRect.top; j<BltInfo->DestRect.bottom; j++)
       {
         sx = BltInfo->SourcePoint.x;
 
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           /* This sets the sx to the rightmost pixel */
           sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
@@ -152,7 +148,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           {
             DIB_8BPP_PutPixel(BltInfo->DestSurface, i, j, XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, 1));
           }
-          if ((flip == 1) || (flip == 3))
+          if (bLeftToRight)
           {
             sx--;
           }
@@ -161,7 +157,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             sx++;
           }
         }
-        if ((flip == 2) || (flip == 3))
+        if (bTopToBottom)
         {
           sy--;
         }
@@ -173,13 +169,13 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       break;
 
     case BMF_4BPP:
-      DPRINT("4BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
-        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+      DPRINT("4BPP Case Selected with DestRect Width of '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       /* This sets SourceBits_4BPP to the top line */
       SourceBits_4BPP = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + (BltInfo->SourcePoint.x >> 1);
 
-      if ((flip == 2) || (flip ==3))
+      if (bTopToBottom)
       {
         /* This sets SourceBits_4BPP to the bottom line */
         SourceBits_4BPP += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
@@ -190,7 +186,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         SourceLine_4BPP = SourceBits_4BPP;
         sx = BltInfo->SourcePoint.x;
 
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           /* This sets sx to the rightmost pixel */
           sx += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1);
@@ -205,7 +201,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           DIB_8BPP_PutPixel(BltInfo->DestSurface, i, j, xColor);
           if(f1 == 1)
           {
-            if ((flip == 1) || (flip == 3))
+            if (bLeftToRight)
             {
               SourceLine_4BPP--;
             }
@@ -220,7 +216,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             f1 = 1;
           }
 
-          if ((flip == 1) || (flip == 3))
+          if (bLeftToRight)
           {
             sx--;
           }
@@ -229,7 +225,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             sx++;
           }
         }
-        if ((flip == 2) || (flip == 3))
+        if (bTopToBottom)
         {
           SourceBits_4BPP -= BltInfo->SourceSurface->lDelta;
         }
@@ -246,7 +242,8 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
          BltInfo->DestRect.right, BltInfo->DestRect.bottom,
          BltInfo->DestRect.right - BltInfo->DestRect.left);
 
-      if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) && (flip == 0))
+      if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) &&
+        (!bTopToBottom && !bLeftToRight))
       {
         if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
         {
@@ -274,9 +271,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       }
       else
       {
-        DPRINT("XO_TRIVIAL is NOT TRUE or (flip != 0).\n");
+        DPRINT("XO_TRIVIAL is NOT TRUE or we have flips.\n");
 
-        if (flip == 0)
+        if (!bTopToBottom && !bLeftToRight)
       /* **Note: Indent is purposefully less than desired to keep reviewable differences to a minimum for PR** */
         {
         if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
@@ -319,15 +316,16 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           /* Buffering for source and destination flip overlaps. Fixes KHMZ MirrorTest CORE-16642 */
           BOOL OneDone = FALSE;
 
-          if ((flip == 1) || (flip == 3))
+          if (bLeftToRight)
           {
-            DPRINT("Flip == 1 or 3.\n");
+            DPRINT("Flip is bLeftToRight.\n");
 
             /* Allocate enough pixels for a row in BYTE's */
             BYTE *store = ExAllocatePoolWithTag(NonPagedPool,
               BltInfo->DestRect.right - BltInfo->DestRect.left + 1, TAG_DIB);
             if (store == NULL)
             {
+              DPRINT1("Storage Allocation Failed.\n");
               return FALSE;
             }
             WORD  Index;
@@ -378,9 +376,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             OneDone = TRUE;
           }
 
-          if ((flip == 2) || (flip == 3))
+          if (bTopToBottom)
           {
-            DPRINT("Flip == 2 or 3.\n");
+            DPRINT("Flip is bTopToBottom.\n");
     
             DWORD  Index;
 
@@ -389,16 +387,18 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               BltInfo->DestRect.bottom - BltInfo->DestRect.top + 1, TAG_DIB);
             if (store == NULL)
             {
+              DPRINT1("Storage Allocation Failed.\n");
               return FALSE;
             }
 
-            /* The OneDone flag indicates that we are doing a flip == 3 and have already */
-            /* completed the flip == 1. So we will lose our first flip output unless     */
-            /* we work with its output which is at the destination site. So in this case */
+            /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight   */
+            /* and have already completed the bLeftToRight. So we will lose our first flip output */
+            /* unless we work with its output which is at the destination site. So in this case   */
             /* our new Source becomes the previous outputs Destination. */
 
             if (OneDone)
             {
+
               /* This sets SourceLine to the bottom line of our previous destination */
               SourceLine = (PBYTE)BltInfo->DestSurface->pvScan0 + 
                 (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left  +
@@ -407,9 +407,10 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
             else
             {
               /* This sets SourceLine to the bottom line */
-              SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + 
-                (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + BltInfo->SourcePoint.x  +
-                (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;
+              SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 +
+                ((BltInfo->SourcePoint.y + BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1)
+                * BltInfo->SourceSurface->lDelta) +
+                BltInfo->SourcePoint.x;
             }
 
             /* This set the DestLine to the top line */
@@ -457,8 +458,8 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       break;
 
     case BMF_16BPP:
-      DPRINT("16BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
-        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+      DPRINT("16BPP Case Selected with DestRect Width of '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       DPRINT("BMF_16BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
         BltInfo->DestRect.left, BltInfo->DestRect.top,
@@ -467,7 +468,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 2 * BltInfo->SourcePoint.x;
 
-      if ((flip == 2) || (flip ==3))
+      if (bTopToBottom)
       {
         /* This sets SourceLine to the bottom line */
         SourceLine += (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1) * BltInfo->SourceSurface->lDelta;;
@@ -478,7 +479,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       {
         SourceBits = SourceLine;
 
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           /* This sets SourceBits to the rightmost pixel */
           SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 2;
@@ -490,7 +491,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           xColor = *((PWORD) SourceBits);
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
 
-          if ((flip == 1) || (flip ==3))
+          if (bLeftToRight)
           {
             SourceBits -= 2;
           }
@@ -500,7 +501,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           }
           DestBits += 1;
         }
-        if ((flip == 2) || (flip ==3))
+        if (bTopToBottom)
         {
           SourceLine -= BltInfo->SourceSurface->lDelta;
         }
@@ -522,7 +523,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 3 * BltInfo->SourcePoint.x;
       DestLine = DestBits;
 
-      if ((flip == 2) || (flip ==3))
+      if (bTopToBottom)
       {
         /* This sets SourceLine to the bottom line */
         SourceLine += BltInfo->SourceSurface->lDelta * (BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1);
@@ -533,7 +534,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         SourceBits = SourceLine;
         DestBits = DestLine;
 
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           /* This sets the SourceBits to the rightmost pixel */
           SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 3;
@@ -545,7 +546,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
              (*(SourceBits + 1) << 0x08) +
              (*(SourceBits));
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
-          if ((flip == 1) || (flip == 3))
+          if (bLeftToRight)
           {
              SourceBits -= 3;
           }
@@ -555,7 +556,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           }
           DestBits += 1;
         }
-        if ((flip == 2) || (flip ==3))
+        if (bTopToBottom)
         {
           SourceLine -= BltInfo->SourceSurface->lDelta;
         }
@@ -569,12 +570,12 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
     case BMF_32BPP:
 
-      DPRINT("32BPP Case Selected with DestRect Width of '%d' and flip is '%d'.\n",
-        BltInfo->DestRect.right - BltInfo->DestRect.left, flip);
+      DPRINT("32BPP Case Selected with DestRect Width of '%d'.\n",
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
       SourceLine = (PBYTE)BltInfo->SourceSurface->pvScan0 + (BltInfo->SourcePoint.y * BltInfo->SourceSurface->lDelta) + 4 * BltInfo->SourcePoint.x;
 
-      if ((flip == 2) || (flip ==3))
+      if (bTopToBottom)
       {
         /* This sets SourceLine to the bottom line */
         SourceLine += BltInfo->DestRect.bottom - BltInfo->DestRect.top - 1;
@@ -586,7 +587,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
         SourceBits = SourceLine;
         DestBits = DestLine;
 
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           /* This sets SourceBits to the rightmost pixel */
           SourceBits += (BltInfo->DestRect.right - BltInfo->DestRect.left - 1) * 4;
@@ -597,7 +598,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           xColor = *((PDWORD) SourceBits);
           *DestBits = (BYTE)XLATEOBJ_iXlate(BltInfo->XlateSourceToDest, xColor);
 
-          if ((flip == 1) || (flip ==3))
+          if (bLeftToRight)
           {
             SourceBits -= 4;
           }
@@ -607,7 +608,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
           }
           DestBits += 1;
         }
-        if ((flip == 2) || (flip ==3))
+        if (bTopToBottom)
         {
           SourceLine -= BltInfo->SourceSurface->lDelta;
         }

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -55,7 +55,7 @@ DIB_8BPP_VLine(SURFOBJ *SurfObj, LONG x, LONG y1, LONG y2, ULONG c)
 BOOLEAN
 DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 {
-  LONG     i, j, sx, sy, xColor, f1, lTmp;
+  LONG     i, j, sx, sy, xColor, f1;
   PBYTE    SourceBits, DestBits, SourceLine, DestLine;
   PBYTE    SourceBits_4BPP, SourceLine_4BPP;
   BOOLEAN  bTopToBottom, bLeftToRight;
@@ -65,7 +65,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* Normally,if we came from copybits.c with a BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN     */
+  /* Normally,if we came from dibobj.c with a BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN     */
   /* bit set, we have to set the bTopToBottom flip bit for Lazarus and PeaZip. But for some reason */
   /* for the 8 BPP here we need to ignore this bit or we get fails in gdi32:CreateDIBPatternBrush. */
 
@@ -92,19 +92,7 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
   DPRINT("bTopToBottom is '%d' and bLeftToRight is '%d'.\n", bTopToBottom, bLeftToRight);
 
   /* Make WellOrdered by making top < bottom and left < right */
-  if (BltInfo->DestRect.left > BltInfo->DestRect.right)
-  {
-    lTmp = BltInfo->DestRect.left;
-    BltInfo->DestRect.left = BltInfo->DestRect.right;
-    BltInfo->DestRect.right = lTmp;
-  }
-
-  if (BltInfo->DestRect.top > BltInfo->DestRect.bottom)
-  {
-    lTmp = BltInfo->DestRect.top;
-    BltInfo->DestRect.top = BltInfo->DestRect.bottom;
-    BltInfo->DestRect.bottom = lTmp;
-  }
+  RECTL_vMakeWellOrdered(&BltInfo->DestRect);
 
   DPRINT("BPP is '%d' & BltInfo->SourcePoint.x is '%d' & BltInfo->SourcePoint.y is '%d'.\n",
     BltInfo->SourceSurface->iBitmapFormat, BltInfo->SourcePoint.x, BltInfo->SourcePoint.y);
@@ -632,21 +620,10 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 BOOLEAN
 DIB_8BPP_ColorFill(SURFOBJ* DestSurface, RECTL* DestRect, ULONG color)
 {
-  LONG DestY, lTmp;
+  LONG DestY;
 
   /* Make WellOrdered by making top < bottom and left < right */
-  if (DestRect->left > DestRect->right)
-  {
-    lTmp = DestRect->left;
-    DestRect->left = DestRect->right;
-    DestRect->right = lTmp;
-  }
-  if (DestRect->top > DestRect->bottom)
-  {
-    lTmp = DestRect->top;
-    DestRect->top = DestRect->bottom;
-    DestRect->bottom = lTmp;
-  }
+  RECTL_vMakeWellOrdered(DestRect);
 
   for (DestY = DestRect->top; DestY< DestRect->bottom; DestY++)
   {

--- a/win32ss/gdi/dib/dib8bpp.c
+++ b/win32ss/gdi/dib/dib8bpp.c
@@ -65,9 +65,9 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
     BltInfo->DestSurface->sizlBitmap.cx, BltInfo->DestSurface->sizlBitmap.cy,
     BltInfo->DestRect.left, BltInfo->DestRect.top, BltInfo->DestRect.right, BltInfo->DestRect.bottom);
 
-  /* Normally,if we came from dibobj.c with a BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN     */
-  /* bit set, we have to set the bTopToBottom flip bit for Lazarus and PeaZip. But for some reason */
-  /* for the 8 BPP here we need to ignore this bit or we get fails in gdi32:CreateDIBPatternBrush. */
+  /* Normally,if we came from dibobj.c with a BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN
+   * bit set, we have to set the bTopToBottom flip bit for Lazarus and PeaZip. But for some reason
+   * for the 8 BPP here we need to ignore this bit or we get fails in gdi32:CreateDIBPatternBrush. */
 
   DPRINT("SourceSurface->fjBitmap & BMF_TOPDOWN is '%d'.\n", BltInfo->SourceSurface->fjBitmap & BMF_TOPDOWN);
 
@@ -226,11 +226,12 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
 
     case BMF_8BPP:
       DPRINT("8BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
-         BltInfo->DestRect.left, BltInfo->DestRect.top,
-         BltInfo->DestRect.right, BltInfo->DestRect.bottom,
-         BltInfo->DestRect.right - BltInfo->DestRect.left);
+        BltInfo->DestRect.left, BltInfo->DestRect.top,
+        BltInfo->DestRect.right, BltInfo->DestRect.bottom,
+        BltInfo->DestRect.right - BltInfo->DestRect.left);
 
-      if ((NULL == BltInfo->XlateSourceToDest || 0 != (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL)) &&
+      if ((BltInfo->XlateSourceToDest == NULL ||
+        (BltInfo->XlateSourceToDest->flXlate & XO_TRIVIAL) != 0) &&
         (!bTopToBottom && !bLeftToRight))
       {
         if (BltInfo->DestRect.top < BltInfo->SourcePoint.y)
@@ -379,14 +380,13 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
               return FALSE;
             }
 
-            /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight   */
-            /* and have already completed the bLeftToRight. So we will lose our first flip output */
-            /* unless we work with its output which is at the destination site. So in this case   */
-            /* our new Source becomes the previous outputs Destination. */
+            /* The OneDone flag indicates that we are flipping for bTopToBottom and bLeftToRight
+             * and have already completed the bLeftToRight. So we will lose our first flip output
+             * unless we work with its output which is at the destination site. So in this case
+             * our new Source becomes the previous outputs Destination. */
 
             if (OneDone)
             {
-
               /* This sets SourceLine to the bottom line of our previous destination */
               SourceLine = (PBYTE)BltInfo->DestSurface->pvScan0 + 
                 (BltInfo->DestRect.top * BltInfo->DestSurface->lDelta) + BltInfo->DestRect.left  +
@@ -502,7 +502,6 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       break;
 
     case BMF_24BPP:
-
       DPRINT("24BPP-dstRect: (%d,%d)-(%d,%d) and Width of '%d'.\n", 
         BltInfo->DestRect.left, BltInfo->DestRect.top,
         BltInfo->DestRect.right, BltInfo->DestRect.bottom,
@@ -557,7 +556,6 @@ DIB_8BPP_BitBltSrcCopy(PBLTINFO BltInfo)
       break;
 
     case BMF_32BPP:
-
       DPRINT("32BPP Case Selected with DestRect Width of '%d'.\n",
         BltInfo->DestRect.right - BltInfo->DestRect.left);
 

--- a/win32ss/gdi/dib/stretchblt.c
+++ b/win32ss/gdi/dib/stretchblt.c
@@ -63,16 +63,16 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
   SrcHeight = SourceRect->bottom - SourceRect->top;
   SrcWidth = SourceRect->right - SourceRect->left;
 
-    /* Here we do the tests and set our conditions */
-    if (((SrcWidth < 0) && (DstWidth < 0)) || ((SrcWidth >= 0) && (DstWidth >= 0)))
-        bLeftToRight = FALSE;
-    else
-        bLeftToRight = TRUE;
+  /* Here we do the tests and set our conditions */
+  if (((SrcWidth < 0) && (DstWidth < 0)) || ((SrcWidth >= 0) && (DstWidth >= 0)))
+    bLeftToRight = FALSE;
+  else
+    bLeftToRight = TRUE;
 
-    if (((SrcHeight < 0) && (DstHeight < 0)) || ((SrcHeight >= 0) && (DstHeight >= 0)))
-        bTopToBottom = FALSE;
-    else
-        bTopToBottom = TRUE;
+  if (((SrcHeight < 0) && (DstHeight < 0)) || ((SrcHeight >= 0) && (DstHeight >= 0)))
+    bTopToBottom = FALSE;
+  else
+    bTopToBottom = TRUE;
 
   /* Make Well Ordered to start */
   RECTL_vMakeWellOrdered(DestRect);

--- a/win32ss/gdi/dib/stretchblt.c
+++ b/win32ss/gdi/dib/stretchblt.c
@@ -48,7 +48,6 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
 
   BOOL UsesSource = ROP4_USES_SOURCE(ROP);
   BOOL UsesPattern = ROP4_USES_PATTERN(ROP);
-  RECTL OutputRect;
   BOOLEAN bTopToBottom, bLeftToRight;
 
   ASSERT(IS_VALID_ROP4(ROP));
@@ -76,9 +75,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
         bTopToBottom = TRUE;
 
   /* Make Well Ordered to start */
-  OutputRect = *DestRect;
-  RECTL_vMakeWellOrdered(&OutputRect);
-  *DestRect = OutputRect;
+  RECTL_vMakeWellOrdered(DestRect);
 
   if (UsesSource)
   {

--- a/win32ss/gdi/dib/stretchblt.c
+++ b/win32ss/gdi/dib/stretchblt.c
@@ -48,9 +48,8 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
 
   BOOL UsesSource = ROP4_USES_SOURCE(ROP);
   BOOL UsesPattern = ROP4_USES_PATTERN(ROP);
-  LONG flip;
-  BOOL flipx, flipy;
   RECTL OutputRect;
+  BOOLEAN bTopToBottom, bLeftToRight;
 
   ASSERT(IS_VALID_ROP4(ROP));
 
@@ -65,45 +64,16 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
   SrcHeight = SourceRect->bottom - SourceRect->top;
   SrcWidth = SourceRect->right - SourceRect->left;
 
-  /* Here we do the flip tests and set our conditions */
-  if (((SrcWidth < 0) && (DstWidth < 0)) || ((SrcWidth >= 0) && (DstWidth >= 0)))
-  {
-    flipy = FALSE;
-  }
-  else
-  {
-    flipy = TRUE;
-  }
+    /* Here we do the tests and set our conditions */
+    if (((SrcWidth < 0) && (DstWidth < 0)) || ((SrcWidth >= 0) && (DstWidth >= 0)))
+        bLeftToRight = FALSE;
+    else
+        bLeftToRight = TRUE;
 
-  if (((SrcHeight < 0) && (DstHeight < 0)) || ((SrcHeight >= 0) && (DstHeight >= 0)))
-  {
-    flipx = FALSE;
-  }
-  else
-  {
-    flipx = TRUE;
-  }
-
-  DPRINT("flip about x-axis is '%d' and flip and y-axis is '%d'.\n", flipx, flipy);
-
-  if (!flipx && !flipy)
-  {
-    flip = 0;
-  }
-  else if (!flipx && flipy)
-  {
-    flip = 1;
-  }
-  else if (flipx && !flipy)
-  {
-    flip = 2;
-  }
-  else
-  {
-    flip = 3;
-  }
-
-  DPRINT("flip is '%d'.\n", flip);
+    if (((SrcHeight < 0) && (DstHeight < 0)) || ((SrcHeight >= 0) && (DstHeight >= 0)))
+        bTopToBottom = FALSE;
+    else
+        bTopToBottom = TRUE;
 
   /* Make Well Ordered to start */
   OutputRect = *DestRect;
@@ -168,6 +138,8 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
     DPRINT("PatternSurface is not NULL.\n");
   }
 
+  DPRINT("bLeftToRight is '%d' and bTopToBottom is '%d'.\n", bLeftToRight, bTopToBottom);
+
   for (DesY = DestRect->top; DesY < DestRect->bottom; DesY++)
   {
     if (PatternSurface)
@@ -180,7 +152,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
     }
     if (UsesSource)
     {
-      if ((flip == 2) || (flip == 3))
+      if (bTopToBottom)
       {
         sy = SourceRect->bottom-(DesY - DestRect->top) * SrcHeight / DstHeight;  // flips about the x-axis
       }
@@ -196,7 +168,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
 
       if (fnMask_GetPixel)
       {
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           sx = SourceRect->right-(DesX - DestRect->left) * SrcWidth / DstWidth;  // flips about the y-axis
         }
@@ -214,7 +186,7 @@ BOOLEAN DIB_XXBPP_StretchBlt(SURFOBJ *DestSurf, SURFOBJ *SourceSurf, SURFOBJ *Ma
 
       if (UsesSource && CanDraw)
       {
-        if ((flip == 1) || (flip == 3))
+        if (bLeftToRight)
         {
           sx = SourceRect->right-(DesX - DestRect->left) * SrcWidth / DstWidth;  // flips about the y-axis
         }

--- a/win32ss/gdi/eng/bitblt.c
+++ b/win32ss/gdi/eng/bitblt.c
@@ -264,7 +264,7 @@ CallDibBitBlt(SURFOBJ* OutputObj,
     RECTL_vMakeWellOrdered(&BltInfo.DestRect);
 
     DPRINT("CallDibBitBlt: dstRect: (%d,%d)-(%d,%d)\n",
-      BltInfo.DestRect.left, BltInfo.DestRect.top, BltInfo.DestRect.right, BltInfo.DestRect.bottom);
+           BltInfo.DestRect.left, BltInfo.DestRect.top, BltInfo.DestRect.right, BltInfo.DestRect.bottom);
 
     Result = DibFunctionsForBitmapFormat[OutputObj->iBitmapFormat].DIB_BitBlt(&BltInfo);
 
@@ -393,10 +393,10 @@ EngBitBlt(
     RECTL_vMakeWellOrdered(&OutputRect);
 
     DPRINT("EngBitBlt: prclTrg: (%d,%d)-(%d,%d)\n",
-        prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
+           prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
 
     DPRINT("EngBitBlt: OutputRect: (%d,%d)-(%d,%d)\n",
-        OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
+           OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
 
     if (UsesSource)
     {
@@ -684,7 +684,7 @@ IntEngBitBlt(
     ASSERT(psoTrg);
 
     DPRINT("IntEngBitBlt: prclTrg: (%d,%d)-(%d,%d)\n",
-        prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
+           prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
 
     psurfTrg = CONTAINING_RECORD(psoTrg, SURFACE, SurfObj);
 

--- a/win32ss/gdi/eng/bitblt.c
+++ b/win32ss/gdi/eng/bitblt.c
@@ -264,7 +264,7 @@ CallDibBitBlt(SURFOBJ* OutputObj,
     RECTL_vMakeWellOrdered(&BltInfo.DestRect);
 
     DPRINT("CallDibBitBlt: dstRect: (%d,%d)-(%d,%d)\n",
-           BltInfo.DestRect.left, BltInfo.DestRect.top, BltInfo.DestRect.right, BltInfo.DestRect.bottom);
+      BltInfo.DestRect.left, BltInfo.DestRect.top, BltInfo.DestRect.right, BltInfo.DestRect.bottom);
 
     Result = DibFunctionsForBitmapFormat[OutputObj->iBitmapFormat].DIB_BitBlt(&BltInfo);
 
@@ -393,10 +393,10 @@ EngBitBlt(
     RECTL_vMakeWellOrdered(&OutputRect);
 
     DPRINT("EngBitBlt: prclTrg: (%d,%d)-(%d,%d)\n",
-           prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
+        prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
 
     DPRINT("EngBitBlt: OutputRect: (%d,%d)-(%d,%d)\n",
-           OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
+        OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
 
     if (UsesSource)
     {
@@ -684,7 +684,7 @@ IntEngBitBlt(
     ASSERT(psoTrg);
 
     DPRINT("IntEngBitBlt: prclTrg: (%d,%d)-(%d,%d)\n",
-           prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
+        prclTrg->left, prclTrg->top, prclTrg->right, prclTrg->bottom);
 
     psurfTrg = CONTAINING_RECORD(psoTrg, SURFACE, SurfObj);
 

--- a/win32ss/gdi/eng/bitblt.c
+++ b/win32ss/gdi/eng/bitblt.c
@@ -690,23 +690,8 @@ IntEngBitBlt(
 
     DPRINT("psoSrc->fjBitmap & BMF_TOPDOWN is '%d'.\n", psoSrc->fjBitmap & BMF_TOPDOWN);
 
-    if (prclTrg->left > prclTrg->right)
-    {
-      bLeftToRight = TRUE;
-    }
-    else
-    {
-      bLeftToRight = FALSE;
-    }
-
-    if (prclTrg->top > prclTrg->bottom)
-    {
-      bTopToBottom = TRUE;
-    }
-    else
-    {
-      bTopToBottom = FALSE;
-    }
+    bLeftToRight = prclTrg->left > prclTrg->right;
+    bTopToBottom = prclTrg->top > prclTrg->bottom;
 
     /* Get the target rect and make it well ordered */
     rclClipped = *prclTrg;

--- a/win32ss/gdi/eng/bitblt.c
+++ b/win32ss/gdi/eng/bitblt.c
@@ -223,7 +223,6 @@ CallDibBitBlt(SURFOBJ* OutputObj,
     BLTINFO BltInfo;
     SURFOBJ *psoPattern;
     BOOLEAN Result;
-    LONG    lTmp; 
 
     BltInfo.DestSurface = OutputObj;
     BltInfo.SourceSurface = InputObj;
@@ -257,19 +256,8 @@ CallDibBitBlt(SURFOBJ* OutputObj,
         psoPattern = NULL;
     }
 
-    /* Make the top < bottom and left < right if needed */
-    if (BltInfo.DestRect.left > BltInfo.DestRect.right)
-    {
-        lTmp = BltInfo.DestRect.left;
-        BltInfo.DestRect.left = BltInfo.DestRect.right;
-        BltInfo.DestRect.right = lTmp;
-    }
-    if (BltInfo.DestRect.top > BltInfo.DestRect.bottom)
-    {
-        lTmp = BltInfo.DestRect.top;
-        BltInfo.DestRect.top = BltInfo.DestRect.bottom;
-        BltInfo.DestRect.bottom = lTmp;
-    }
+    /* Make WellOrdered with top < bottom and left < right */
+    RECTL_vMakeWellOrdered(&BltInfo.DestRect);
 
     DPRINT("CallDibBitBlt: dstRect: (%d,%d)-(%d,%d)\n",
            BltInfo.DestRect.left, BltInfo.DestRect.top, BltInfo.DestRect.right, BltInfo.DestRect.bottom);

--- a/win32ss/gdi/eng/bitblt.c
+++ b/win32ss/gdi/eng/bitblt.c
@@ -6,6 +6,10 @@
  * PROGRAMERS:       Jason Filby
  *                   Timo Kreuzer
  *                   Doug Lyons
+ *
+ * WARNING: Modify this file with extreme caution. It is very sensitive to timing changes.
+ *   Adding code can cause the system to show a Fatal Exception Error and fail to boot!.
+ *   This is especially true in CallDibBitBlt, IntEngBitBlt and EngBitBlt (even DPRINT's).
  */
 
 #include <win32k.h>

--- a/win32ss/gdi/eng/copybits.c
+++ b/win32ss/gdi/eng/copybits.c
@@ -3,7 +3,7 @@
  * PROJECT:          ReactOS kernel
  * PURPOSE:          GDI EngCopyBits Function
  * FILE:             win32ss/gdi/eng/copybits.c
- * PROGRAMERS        Jason Filby
+ * PROGRAMERS:       Jason Filby
  *                   Doug Lyons
  */
 
@@ -41,13 +41,13 @@ EngCopyBits(
 
     DPRINT("Source cx/cy is %d/%d and Dest cx/cy is %d/%d.\n",
         psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy);
+
     if (psoSource)
     {
-    DPRINT("psoSource->fjBitmap & BMF_TOPDOWN is '%d'.\n", psoSource->fjBitmap & BMF_TOPDOWN);
+        DPRINT("psoSource->fjBitmap & BMF_TOPDOWN is '%d'.\n", psoSource->fjBitmap & BMF_TOPDOWN);
     }
 
     /* Retrieve Top Down/flip here and then make Well-Ordered again */
-
     if (DestRect->top > DestRect->bottom)
     {
         bTopToBottom = TRUE;
@@ -58,6 +58,7 @@ EngCopyBits(
     }
     else
         bTopToBottom = FALSE;
+
     DPRINT("bTopToBottom is '%d'.\n", bTopToBottom);
 
     ASSERT(psoDest != NULL && psoSource != NULL && DestRect != NULL && SourcePoint != NULL);

--- a/win32ss/gdi/eng/copybits.c
+++ b/win32ss/gdi/eng/copybits.c
@@ -37,10 +37,10 @@ EngCopyBits(
     BOOL      bTopToBottom;
 
     DPRINT("Entering EngCopyBits with SourcePoint (%d,%d) and DestRect (%d,%d)-(%d,%d).\n",
-        SourcePoint->x, SourcePoint->y, DestRect->left, DestRect->top, DestRect->right, DestRect->bottom);
+           SourcePoint->x, SourcePoint->y, DestRect->left, DestRect->top, DestRect->right, DestRect->bottom);
 
     DPRINT("Source cx/cy is %d/%d and Dest cx/cy is %d/%d.\n",
-        psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy);
+           psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy);
 
     if (psoSource)
     {
@@ -57,7 +57,9 @@ EngCopyBits(
         rclDest = *DestRect;
     }
     else
+    {
         bTopToBottom = FALSE;
+    }
 
     DPRINT("bTopToBottom is '%d'.\n", bTopToBottom);
 

--- a/win32ss/gdi/eng/mouse.c
+++ b/win32ss/gdi/eng/mouse.c
@@ -169,6 +169,10 @@ IntHideMousePointer(
     ptlSave.x = rclDest.left - pt.x;
     ptlSave.y = rclDest.top - pt.y;
 
+    // Not used from here. If not cleared this makes it
+    // impossible to use this bit for Lazarus and PeaZip flip info
+    pgp->psurfSave->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
+
     IntEngBitBlt(psoDest,
                  &pgp->psurfSave->SurfObj,
                  NULL,
@@ -223,6 +227,10 @@ IntShowMousePointer(
     rclPointer.right = min(pgp->Size.cx, psoDest->sizlBitmap.cx - pt.x);
     rclPointer.bottom = min(pgp->Size.cy, psoDest->sizlBitmap.cy - pt.y);
 
+    // Not used from here. If not cleared this makes it
+    // impossible to use this bit for Lazarus and PeaZip flip info
+    psoDest->fjBitmap &= ~BMF_TOPDOWN;
+
     /* Copy the pixels under the cursor to temporary surface. */
     IntEngBitBlt(&pgp->psurfSave->SurfObj,
                  psoDest,
@@ -241,6 +249,13 @@ IntShowMousePointer(
     {
         if(!(pgp->flags & SPS_ALPHA))
         {
+            // Not used from here. If not cleared this makes it
+            // impossible to use this bit for Lazarus and PeaZip flip info
+            if (pgp->psurfMask)
+            {
+                pgp->psurfMask->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
+            }
+
             IntEngBitBlt(psoDest,
                          &pgp->psurfMask->SurfObj,
                          NULL,
@@ -252,6 +267,13 @@ IntShowMousePointer(
                          NULL,
                          NULL,
                          ROP4_SRCAND);
+
+            // Not used from here. If not cleared this makes it
+            // impossible to use this bit for Lazarus and PeaZip flip info
+            if (pgp->psurfColor)
+            {
+                pgp->psurfColor->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
+            }
 
             IntEngBitBlt(psoDest,
                          &pgp->psurfColor->SurfObj,
@@ -285,6 +307,14 @@ IntShowMousePointer(
     }
     else
     {
+
+        // Not used from here. If not cleared this makes it
+        // impossible to use this bit for Lazarus and PeaZip flip info
+        if (pgp->psurfMask)
+        {
+            pgp->psurfMask->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
+        }
+
         IntEngBitBlt(psoDest,
                      &pgp->psurfMask->SurfObj,
                      NULL,

--- a/win32ss/gdi/eng/mouse.c
+++ b/win32ss/gdi/eng/mouse.c
@@ -169,10 +169,6 @@ IntHideMousePointer(
     ptlSave.x = rclDest.left - pt.x;
     ptlSave.y = rclDest.top - pt.y;
 
-    // Not used from here. If not cleared this makes it
-    // impossible to use this bit for Lazarus and PeaZip flip info
-    pgp->psurfSave->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
-
     IntEngBitBlt(psoDest,
                  &pgp->psurfSave->SurfObj,
                  NULL,
@@ -227,10 +223,6 @@ IntShowMousePointer(
     rclPointer.right = min(pgp->Size.cx, psoDest->sizlBitmap.cx - pt.x);
     rclPointer.bottom = min(pgp->Size.cy, psoDest->sizlBitmap.cy - pt.y);
 
-    // Not used from here. If not cleared this makes it
-    // impossible to use this bit for Lazarus and PeaZip flip info
-    psoDest->fjBitmap &= ~BMF_TOPDOWN;
-
     /* Copy the pixels under the cursor to temporary surface. */
     IntEngBitBlt(&pgp->psurfSave->SurfObj,
                  psoDest,
@@ -249,13 +241,6 @@ IntShowMousePointer(
     {
         if(!(pgp->flags & SPS_ALPHA))
         {
-            // Not used from here. If not cleared this makes it
-            // impossible to use this bit for Lazarus and PeaZip flip info
-            if (pgp->psurfMask)
-            {
-                pgp->psurfMask->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
-            }
-
             IntEngBitBlt(psoDest,
                          &pgp->psurfMask->SurfObj,
                          NULL,
@@ -267,13 +252,6 @@ IntShowMousePointer(
                          NULL,
                          NULL,
                          ROP4_SRCAND);
-
-            // Not used from here. If not cleared this makes it
-            // impossible to use this bit for Lazarus and PeaZip flip info
-            if (pgp->psurfColor)
-            {
-                pgp->psurfColor->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
-            }
 
             IntEngBitBlt(psoDest,
                          &pgp->psurfColor->SurfObj,
@@ -307,14 +285,6 @@ IntShowMousePointer(
     }
     else
     {
-
-        // Not used from here. If not cleared this makes it
-        // impossible to use this bit for Lazarus and PeaZip flip info
-        if (pgp->psurfMask)
-        {
-            pgp->psurfMask->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
-        }
-
         IntEngBitBlt(psoDest,
                      &pgp->psurfMask->SurfObj,
                      NULL,
@@ -405,7 +375,7 @@ EngSetPointerShape(
         hbmSave = EngCreateBitmap(sizel,
                                   lDelta,
                                   pso->iBitmapFormat,
-                                  BMF_TOPDOWN | BMF_NOZEROINIT,
+                                  BMF_NOZEROINIT,
                                   NULL);
         psurfSave = SURFACE_ShareLockSurface(hbmSave);
         if (!psurfSave) goto failure;
@@ -425,7 +395,7 @@ EngSetPointerShape(
             hbmColor = EngCreateBitmap(psoColor->sizlBitmap,
                 WIDTH_BYTES_ALIGN32(sizel.cx, 32),
                 BMF_32BPP,
-                BMF_TOPDOWN | BMF_NOZEROINIT,
+                BMF_NOZEROINIT,
                 NULL);
             psurfColor = SURFACE_ShareLockSurface(hbmColor);
             if (!psurfColor) goto failure;
@@ -454,7 +424,7 @@ EngSetPointerShape(
             hbmColor = EngCreateBitmap(psoColor->sizlBitmap,
                                lDelta,
                                pso->iBitmapFormat,
-                               BMF_TOPDOWN | BMF_NOZEROINIT,
+                               BMF_NOZEROINIT,
                                NULL);
             psurfColor = SURFACE_ShareLockSurface(hbmColor);
             if (!psurfColor) goto failure;
@@ -483,7 +453,7 @@ EngSetPointerShape(
         hbmMask = EngCreateBitmap(psoMask->sizlBitmap,
                                   lDelta,
                                   pso->iBitmapFormat,
-                                  BMF_TOPDOWN | BMF_NOZEROINIT,
+                                  BMF_NOZEROINIT,
                                   NULL);
         psurfMask = SURFACE_ShareLockSurface(hbmMask);
         if (!psurfMask) goto failure;
@@ -760,6 +730,13 @@ GreSetPointerShape(
 
     /* We must have a valid surface in case of alpha bitmap */
     ASSERT(((fl & SPS_ALPHA) && psurfColor) || !(fl & SPS_ALPHA));
+
+
+    // The line below clears the BMF_TOPDOWN bit of psurf->SurfObj.fjBitmap.
+    // The BMF_TOPDOWN bit is not needed or wanted in the IntEngSetPointerShape when
+    // it is called from here. If it is not cleared here then it will interfere with
+    // how Lazarus and PeaZip call CreateDIBitmap to test whether a bitmap is flipped.
+    psurf->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
 
     /* Call the driver or eng function */
     ulResult = IntEngSetPointerShape(&psurf->SurfObj,

--- a/win32ss/gdi/eng/mouse.c
+++ b/win32ss/gdi/eng/mouse.c
@@ -731,11 +731,10 @@ GreSetPointerShape(
     /* We must have a valid surface in case of alpha bitmap */
     ASSERT(((fl & SPS_ALPHA) && psurfColor) || !(fl & SPS_ALPHA));
 
-
-    // The line below clears the BMF_TOPDOWN bit of psurf->SurfObj.fjBitmap.
-    // The BMF_TOPDOWN bit is not needed or wanted in the IntEngSetPointerShape when
-    // it is called from here. If it is not cleared here then it will interfere with
-    // how Lazarus and PeaZip call CreateDIBitmap to test whether a bitmap is flipped.
+    /* The line below clears the BMF_TOPDOWN bit of psurf->SurfObj.fjBitmap.
+     * The BMF_TOPDOWN bit is not needed or wanted in the IntEngSetPointerShape when
+     * it is called from here. If it is not cleared here then it will interfere with
+     * how Lazarus and PeaZip call CreateDIBitmap to test whether a bitmap is flipped. */
     psurf->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
 
     /* Call the driver or eng function */

--- a/win32ss/gdi/eng/stretchblt.c
+++ b/win32ss/gdi/eng/stretchblt.c
@@ -543,7 +543,7 @@ IntEngStretchBlt(SURFOBJ *psoDest,
            DestRect->left, DestRect->top, cxDest, cyDest,
            SourceRect->left, SourceRect->top, cxSrc, cySrc);
 
-    /* Check if source and dest size are equal */
+    /* Check if source and dest size are equal in size */
     if ((abs(cxDest) == abs(cxSrc)) && (abs(cyDest) == abs(cySrc)))
     {
         /* if cxSrc < 0 and cxDest <0 (both negative, we change both their signs  */

--- a/win32ss/gdi/eng/stretchblt.c
+++ b/win32ss/gdi/eng/stretchblt.c
@@ -297,7 +297,7 @@ EngStretchBltROP(
         case DC_TRIVIAL:
             if (bLeftToRight)
             {
-               lTmp = OutputRect.left;
+                lTmp = OutputRect.left;
                 OutputRect.left = OutputRect.right;
                 OutputRect.right = lTmp;
             }
@@ -310,7 +310,7 @@ EngStretchBltROP(
             }
 
             DPRINT("About to call CallDibStretchBlt?: OutputRect: (%d,%d)-(%d,%d)\n",
-                   OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
+                OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
 
             Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                          ColorTranslation, &OutputRect, &InputRect, MaskOrigin,
@@ -331,7 +331,7 @@ EngStretchBltROP(
 
                 if (bLeftToRight)
                 {
-                   lTmp = CombinedRect.left;
+                    lTmp = CombinedRect.left;
                     CombinedRect.left = CombinedRect.right;
                     CombinedRect.right = lTmp;
                 }
@@ -344,7 +344,7 @@ EngStretchBltROP(
                 }
 
                 DPRINT("About to call CallDibStretchBlt?: CombinedRect: (%d,%d)-(%d,%d)\n",
-                       CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
+                    CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
 
                 Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                            ColorTranslation,
@@ -394,7 +394,7 @@ EngStretchBltROP(
 
                         if (bLeftToRight)
                         {
-                           lTmp = OutputRect.left;
+                            lTmp = OutputRect.left;
                             OutputRect.left = OutputRect.right;
                             OutputRect.right = lTmp;
                         }
@@ -407,7 +407,7 @@ EngStretchBltROP(
                         }
 
                         DPRINT("About to call CallDibStretchBlt?: CombinedRect: (%d,%d)-(%d,%d)\n",
-                               CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
+                            CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
 
                         Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                            ColorTranslation,
@@ -513,18 +513,18 @@ IntEngStretchBlt(SURFOBJ *psoDest,
     cyDest = DestRect->bottom - DestRect->top;
 
     DPRINT("SourceRect is (%d,%d)-(%d,%d) and DestRect is (%d,%d)-(%d,%d)\n",
-           DestRect->left, DestRect->top, DestRect->right, DestRect->bottom,
-           SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom);
+        DestRect->left, DestRect->top, DestRect->right, DestRect->bottom,
+        SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom);
 
     DPRINT("cxDest(%d) cyDest(%d) cxSrc(%d) cySrc(%d)\n",
-           cxDest, cyDest, cxSrc, cySrc);
+        cxDest, cyDest, cxSrc, cySrc);
 
     /* Check if source and dest size are equal in size */
     if ((abs(cxDest) == abs(cxSrc)) && (abs(cyDest) == abs(cySrc)))
     {
-        /* if cxSrc < 0 and cxDest <0 (both negative, we change both their signs  */
-        /* because the outcome is the same as if they were both positive and we   */
-        /* reverse both their top and bottom values                               */
+        /* if cxSrc < 0 and cxDest <0 (both negative, we change both their signs
+         * because the outcome is the same as if they were both positive and we
+         * reverse both their top and bottom values */
         if ((cxSrc < 0) && (cxDest < 0))
         {
             lTmp = DestRect->left;
@@ -537,9 +537,9 @@ IntEngStretchBlt(SURFOBJ *psoDest,
             cxDest = abs(cxDest);
         }
 
-        /* if cySrc < 0 and cyDest <0 (both negative, we change both their signs  */
-        /* because the outcome is the same as if they were both positive and we   */
-        /* reverse both their top and bottom values                               */
+        /* if cySrc < 0 and cyDest <0 (both negative, we change both their signs
+         * because the outcome is the same as if they were both positive and we
+         * reverse both their top and bottom values */
         if ((cySrc < 0) && (cyDest < 0))
         {
             lTmp = DestRect->top;
@@ -552,16 +552,16 @@ IntEngStretchBlt(SURFOBJ *psoDest,
             cyDest = -cyDest;
         }
 
-        /* if the cxDest >= 0 and cxSrc < 0 then we reverse  */
-        /* the signs of both cxDest and cxSrc                */
+        /* if the cxDest >= 0 and cxSrc < 0 then we reverse
+         * the signs of both cxDest and cxSrc */
         if ((cxDest >= 0) && (cxSrc < 0))
         {
             cxDest = -cxDest;
             cxSrc = -cxSrc;
         }
 
-        /* if the cxDest < 0 and cxSrc >= 0 then we reverse */
-        /* the left and right values                        */
+        /* if the cxDest < 0 and cxSrc >= 0 then we reverse
+         * the left and right values */
         else if ((cxDest < 0) && (cxSrc >= 0))
         {
             lTmp = SourceRect->left;
@@ -569,16 +569,16 @@ IntEngStretchBlt(SURFOBJ *psoDest,
             SourceRect->right = lTmp;
         }
 
-        /* if the cyDest >= 0 and cySrc < 0 then we reverse  */
-        /* the signs of both cxDest and cxSrc                */
+        /* if the cyDest >= 0 and cySrc < 0 then we reverse
+         * the signs of both cxDest and cxSrc */
         if ((cyDest >= 0) && (cySrc < 0))
         {
             cyDest = -cyDest;
             cySrc = -cySrc;
         }
 
-        /* if the cyDest < 0 and cySrc >= 0 then we reverse */
-        /* the top and bottom values                        */
+        /* if the cyDest < 0 and cySrc >= 0 then we reverse
+         * the top and bottom values */
         else if ((cyDest <= 0) && (cySrc > 0))
         {
             lTmp = SourceRect->top;
@@ -648,8 +648,8 @@ IntEngStretchBlt(SURFOBJ *psoDest,
 
     DPRINT("bLeftToRight is '%d' and bTopToBottom is '%d'.\n", bLeftToRight, bTopToBottom);
 
-    /* if cxSrc < 0 then we change the signs for both cxSrc and cxDest and */
-    /* we reverse their coordinates, because these outcomes are the same.  */
+    /* if cxSrc < 0 then we change the signs for both cxSrc and cxDest and
+     * we reverse their coordinates, because these outcomes are the same. */
     if (cxSrc < 0)
     {
         lTmp = SourceRect->left;
@@ -662,8 +662,8 @@ IntEngStretchBlt(SURFOBJ *psoDest,
         cxDest = -cxDest;
     }
 
-    /* if cySrc < 0 then we change the signs for both cySrc and cyDest and */
-    /* we reverse their coordinates, because these outcomes are the same.  */
+    /* if cySrc < 0 then we change the signs for both cySrc and cyDest and
+     * we reverse their coordinates, because these outcomes are the same. */
     if (cySrc < 0)
     {
         lTmp = DestRect->top;
@@ -760,9 +760,9 @@ IntEngStretchBlt(SURFOBJ *psoDest,
     if (! ret)
     {
         DPRINT("bLeftToRight is '%d' and bTopToBottom is '%d'.\n", bLeftToRight, bTopToBottom);
-        /* set OutputRect to follow flip */
-        /* Above we converted cxSrc and cySrc to   */
-        /* positive so no need to check these here */
+        /* Set OutputRect to follow flip.
+         * Above we converted cxSrc and cySrc to
+         * positive so no need to check these here. */
         if (bLeftToRight)
         {
             lTmp = OutputRect.left;

--- a/win32ss/gdi/eng/stretchblt.c
+++ b/win32ss/gdi/eng/stretchblt.c
@@ -588,9 +588,8 @@ IntEngStretchBlt(SURFOBJ *psoDest,
     }
 
     /* Make Well Ordered to start */
+    RECTL_vMakeWellOrdered(DestRect);
     OutputRect = *DestRect;
-    RECTL_vMakeWellOrdered(&OutputRect);
-    *DestRect = OutputRect;
 
     /* Here we do the tests and set our conditions */
     if (((cxSrc < 0) && (cxDest < 0)) || ((cxSrc >= 0) && (cxDest >= 0)))

--- a/win32ss/gdi/eng/stretchblt.c
+++ b/win32ss/gdi/eng/stretchblt.c
@@ -56,9 +56,9 @@ CallDibStretchBlt(SURFOBJ* psoDest,
     BOOL bResult;
 
     DPRINT("Entering CallDibStretchBlt: psoSource cx/cy (%d/%d), psoDest cx/cy (%d/%d) OutputRect: (%d,%d)-(%d,%d)\n",
-        psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy,
-        psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
-        OutputRect->left, OutputRect->top, OutputRect->right, OutputRect->bottom);
+           psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy,
+           psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
+           OutputRect->left, OutputRect->top, OutputRect->right, OutputRect->bottom);
 
     if (BrushOrigin == NULL)
     {
@@ -142,9 +142,9 @@ EngStretchBltROP(
     LONG lTmp;
 
     DPRINT("Entering EngStretchBltROP: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
-        psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, //SourceRect->right, SourceRect->bottom,
-        psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
-        prclDest->left, prclDest->top, prclDest->right, prclDest->bottom);
+           psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, //SourceRect->right, SourceRect->bottom,
+           psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
+           prclDest->left, prclDest->top, prclDest->right, prclDest->bottom);
 
     cxSrc = prclSrc->right - prclSrc->left;
     cySrc = prclSrc->bottom - prclSrc->top;
@@ -310,7 +310,7 @@ EngStretchBltROP(
             }
 
             DPRINT("About to call CallDibStretchBlt?: OutputRect: (%d,%d)-(%d,%d)\n",
-                OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
+                   OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
 
             Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                          ColorTranslation, &OutputRect, &InputRect, MaskOrigin,
@@ -344,7 +344,7 @@ EngStretchBltROP(
                 }
 
                 DPRINT("About to call CallDibStretchBlt?: CombinedRect: (%d,%d)-(%d,%d)\n",
-                    CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
+                       CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
 
                 Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                            ColorTranslation,
@@ -407,7 +407,7 @@ EngStretchBltROP(
                         }
 
                         DPRINT("About to call CallDibStretchBlt?: CombinedRect: (%d,%d)-(%d,%d)\n",
-                            CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
+                               CombinedRect.left, CombinedRect.top, CombinedRect.right, CombinedRect.bottom);
 
                         Ret = (*BltRectFunc)(psoOutput, psoInput, Mask,
                            ColorTranslation,
@@ -513,16 +513,16 @@ IntEngStretchBlt(SURFOBJ *psoDest,
     cyDest = DestRect->bottom - DestRect->top;
 
     DPRINT("SourceRect is (%d,%d)-(%d,%d) and DestRect is (%d,%d)-(%d,%d)\n",
-        DestRect->left, DestRect->top, DestRect->right, DestRect->bottom,
-        SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom);
+           DestRect->left, DestRect->top, DestRect->right, DestRect->bottom,
+           SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom);
 
     DPRINT("cxDest(%d) cyDest(%d) cxSrc(%d) cySrc(%d)\n",
-        cxDest, cyDest, cxSrc, cySrc);
+           cxDest, cyDest, cxSrc, cySrc);
 
     /* Check if source and dest size are equal in size */
     if ((abs(cxDest) == abs(cxSrc)) && (abs(cyDest) == abs(cySrc)))
     {
-        /* if cxSrc < 0 and cxDest <0 (both negative, we change both their signs
+        /* if cxSrc < 0 and cxDest < 0 (both negative, we change both their signs
          * because the outcome is the same as if they were both positive and we
          * reverse both their top and bottom values */
         if ((cxSrc < 0) && (cxDest < 0))
@@ -533,11 +533,11 @@ IntEngStretchBlt(SURFOBJ *psoDest,
             lTmp = SourceRect->left;
             SourceRect->left = SourceRect->right;
             SourceRect->right = lTmp;
-            cxSrc = abs(cxSrc);
-            cxDest = abs(cxDest);
+            cxSrc = -cxSrc;
+            cxDest = -cxDest;
         }
 
-        /* if cySrc < 0 and cyDest <0 (both negative, we change both their signs
+        /* if cySrc < 0 and cyDest < 0 (both negative, we change both their signs
          * because the outcome is the same as if they were both positive and we
          * reverse both their top and bottom values */
         if ((cySrc < 0) && (cyDest < 0))
@@ -609,8 +609,8 @@ IntEngStretchBlt(SURFOBJ *psoDest,
         DPRINT("source and dest size are equal.\n");
 
         DPRINT("xDest(%d) yDest(%d) cxDest(%d) cyDest(%d) xSrc(%d) ySrc(%d) cxSrc(%d) cySrc(%d)\n",
-            DestRect->left, DestRect->top, cxDest, cyDest,
-            SourceRect->left, SourceRect->top, cxSrc, cySrc);
+               DestRect->left, DestRect->top, cxDest, cyDest,
+               SourceRect->left, SourceRect->top, cxSrc, cySrc);
 
         if ((cxSrc < 0) != (cxDest < 0)) // Not same sign
         {
@@ -778,9 +778,9 @@ IntEngStretchBlt(SURFOBJ *psoDest,
         }
 
         DPRINT("About to call EngStretchBltROP: SrcSurf cx/cy (%d/%d), DestSuft cx/cy (%d/%d) dstRect: (%d,%d)-(%d,%d)\n",
-            psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, //SourceRect->right, SourceRect->bottom,
-            psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
-            OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
+               psoSource->sizlBitmap.cx, psoSource->sizlBitmap.cy, //SourceRect->right, SourceRect->bottom,
+               psoDest->sizlBitmap.cx, psoDest->sizlBitmap.cy,
+               OutputRect.left, OutputRect.top, OutputRect.right, OutputRect.bottom);
 
         ret = EngStretchBltROP(psoDest,
                                psoSource,

--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -489,16 +489,16 @@ NtGdiMaskBlt(
         XlateObj = &exlo.xlo;
     }
 
-    // Should not be used from here. If not cleared this makes it
-    // impossible to use this bit for Lazarus and PeaZip flip info
+    /* Should not be used from here. If not cleared this makes it
+     * impossible to use this bit for Lazarus and PeaZip flip info */
     if (BitmapSrc)
     {
         BitmapSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN; 
     }
 
     DPRINT("DestRect: (%d,%d)-(%d,%d) and SourcePoint is (%d,%d)\n",
-           DestRect.left, DestRect.top, DestRect.right, DestRect.bottom,
-           SourcePoint.x, SourcePoint.y);
+        DestRect.left, DestRect.top, DestRect.right, DestRect.bottom,
+        SourcePoint.x, SourcePoint.y);
 
     DPRINT("nWidth is '%d' and nHeight is '%d'.\n", nWidth, nHeight);
 
@@ -657,9 +657,9 @@ GreStretchBltMask(
     pdcattr = DCDest->pdcattr;
 
     DPRINT("XOriginSrc/YOriginSrc is (%d,%d) and XOriginDest/YOriginDest is (%d,%d).\n",
-      XOriginSrc, YOriginSrc, XOriginDest, YOriginDest);
+        XOriginSrc, YOriginSrc, XOriginDest, YOriginDest);
     DPRINT("WidthSrc/HeightSrc is '%d/%d' and WidthDest/HeightDest is '%d/%d'.\n",
-      WidthSrc, HeightSrc, WidthDest, HeightDest);
+        WidthSrc, HeightSrc, WidthDest, HeightDest);
 
     DestRect.left   = XOriginDest;
     DestRect.top    = YOriginDest;
@@ -683,8 +683,8 @@ GreStretchBltMask(
     SourceRect.bottom = YOriginSrc+HeightSrc;
 
     DPRINT("SourceRect is (%d,%d)-(%d,%d) and DestRect is (%d,%d)-(%d,%d)\n",
-           SourceRect.left, SourceRect.top, SourceRect.right, SourceRect.bottom,
-           DestRect.left, DestRect.top, DestRect.right, DestRect.bottom);
+        SourceRect.left, SourceRect.top, SourceRect.right, SourceRect.bottom,
+        DestRect.left, DestRect.top, DestRect.right, DestRect.bottom);
 
     if (UsesSource)
     {
@@ -746,9 +746,9 @@ GreStretchBltMask(
         MaskPoint.y += DCMask->ptlDCOrig.y;
     }
 
-    /* The code for the BitmapSrc->SurfObj.fjBitmap BMF_TOPDOWN bit */
-    /* for flipping of the Lazarus taskbar icon comes though here.  */
-    /* Clear this bit to fix the Lazarus flipped taskbar icon.      */
+    /* The code for the BitmapSrc->SurfObj.fjBitmap BMF_TOPDOWN bit
+     * for flipping of the Lazarus taskbar icon comes though here.
+     * Clear this bit to fix the Lazarus flipped taskbar icon. */
     if (BitmapSrc)
     {
         BitmapSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
@@ -1600,4 +1600,3 @@ leave:
     /* Return the new RGB color or -1 on failure */
     return ulRGBColor;
 }
-

--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -480,6 +480,14 @@ NtGdiMaskBlt(
         XlateObj = &exlo.xlo;
     }
 
+
+    // Should not be used from here. If not cleared this makes it
+    // impossible to use this bit for Lazarus and PeaZip flip info
+    if (BitmapSrc)
+    {
+        BitmapSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN; 
+    }
+
     /* Perform the bitblt operation */
     Status = IntEngBitBlt(&BitmapDest->SurfObj,
                           BitmapSrc ? &BitmapSrc->SurfObj : NULL,

--- a/win32ss/gdi/ntgdi/bitblt.c
+++ b/win32ss/gdi/ntgdi/bitblt.c
@@ -480,7 +480,6 @@ NtGdiMaskBlt(
         XlateObj = &exlo.xlo;
     }
 
-
     // Should not be used from here. If not cleared this makes it
     // impossible to use this bit for Lazarus and PeaZip flip info
     if (BitmapSrc)
@@ -704,6 +703,14 @@ GreStretchBltMask(
         IntLPtoDP(DCMask, &MaskPoint, 1);
         MaskPoint.x += DCMask->ptlDCOrig.x;
         MaskPoint.y += DCMask->ptlDCOrig.y;
+    }
+
+    /* The code for the BitmapSrc->SurfObj.fjBitmap BMF_TOPDOWN bit */
+    /* for flipping of the Lazarus taskbar icon comes though here.  */
+    /* Clear this bit to fix the Lazarus flipped taskbar icon.      */
+    if (BitmapSrc)
+    {
+        BitmapSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN;
     }
 
     /* Perform the bitblt operation */

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -320,9 +320,15 @@ IntSetDIBits(
     ptSrc.x = 0;
     ptSrc.y = 0;
 
-    /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
+    /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit   */
     /* for flipping of the Lazarus icons comes though this location. */
-    
+    /* Allowing this bit to pass fixes the first Lazarus Lion Setup  */
+    /* icon and it fixes the flips for SPINA Thyr and SimThyr. But,  */
+    /* it causes the Lazarus pull down menus to flip on mouse touch. */
+
+    DPRINT("psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
+      psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN);
+
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
                             NULL,
@@ -1017,6 +1023,13 @@ GreGetDIBitsInternal(
 
         /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
         /* for flipping of the PeaZip icons comes though this location. */
+        /* Allowing this bit to pass fixes both PeaZip and Lazarus menu */
+        /* flips. It fixes the menubar icons for Double Commander too.  */
+
+        DPRINT("psurf->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
+          psurf->SurfObj.fjBitmap & BMF_TOPDOWN);
+
+        DPRINT("Info->bmiHeader.biHeight is '%d'.\n", Info->bmiHeader.biHeight);
 
         ret = IntEngCopyBits(&psurfDest->SurfObj,
                              &psurf->SurfObj,

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -320,6 +320,10 @@ IntSetDIBits(
     ptSrc.x = 0;
     ptSrc.y = 0;
 
+    // Not used from here. If not cleared this makes it
+    // impossible to use this bit for Lazarus and PeaZip flip info
+    psurfSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN; 
+
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
                             NULL,
@@ -631,6 +635,11 @@ NtGdiSetDIBitsToDeviceInternal(
     DPRINT("BitsToDev with dstsurf=(%d|%d) (%d|%d), src=(%d|%d) w=%d h=%d\n",
            rcDest.left, rcDest.top, rcDest.right, rcDest.bottom,
            ptSource.x, ptSource.y, SourceSize.cx, SourceSize.cy);
+
+    // Not used from here. If not cleared this makes it
+    // impossible to use this bit for Lazarus and PeaZip flip info
+    pSourceSurf->fjBitmap &= ~BMF_TOPDOWN;
+
     bResult = IntEngBitBlt(pDestSurf,
                           pSourceSurf,
                           pMaskSurf,

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -320,14 +320,6 @@ IntSetDIBits(
     ptSrc.x = 0;
     ptSrc.y = 0;
 
-    /* Here we adjust for Top Down to flip bmp for Lazarus */
-    if (psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN)  // Source surface TopDown bit
-    {
-        LONG lTmp = rcDst.top;
-        rcDst.top = rcDst.bottom;
-        rcDst.bottom = lTmp;
-    }
-
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
                             NULL,
@@ -698,7 +690,7 @@ GreGetDIBitsInternal(
     RGBQUAD* rgbQuads;
     VOID* colorPtr;
 
-    DPRINT("Entered GreGetDIBitsInternal() and height is '%d'.\n", Info->bmiHeader.biHeight);
+    DPRINT("Entered GreGetDIBitsInternal()\n");
 
     if ((Usage && Usage != DIB_PAL_COLORS) || !Info || !hBitmap)
         return 0;
@@ -1015,16 +1007,6 @@ GreGetDIBitsInternal(
 
         EXLATEOBJ_vInitialize(&exlo, psurf->ppal, psurfDest->ppal, 0xffffff, 0xffffff, 0);
 
-        /* Here we adjust for Top Down to flip bmp for PeaZip */
-        /* This fixes Double Commander menubar icons, but not */
-        /* its Configure - Options icons.                     */
-        if (psurf->SurfObj.fjBitmap & BMF_TOPDOWN)  // Source surface TopDown bit
-        {
-            LONG lTmp = rcDest.top;
-            rcDest.top = rcDest.bottom;
-            rcDest.bottom = lTmp;
-        }
-
         ret = IntEngCopyBits(&psurfDest->SurfObj,
                              &psurf->SurfObj,
                              NULL,
@@ -1208,9 +1190,6 @@ NtGdiStretchDIBitsInternal(
     EXLATEOBJ exlo;
     PVOID pvBits;
 
-DPRINT("NtGdiStretchDIBitsInternal Src(%d,%d) Dst(%d,%d) cxSrc/cySrc(%d/%d) cxDst/cyDst(%d/%d).\n",
-    xSrc, ySrc, xDst, yDst, cxSrc, cySrc, cxDst, cyDst);
- 
     if (!(pdc = DC_LockDc(hdc)))
     {
         EngSetLastError(ERROR_INVALID_HANDLE);

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -321,7 +321,7 @@ IntSetDIBits(
     ptSrc.y = 0;
 
     /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
-    /*  for flipping ofthe Lazarus icons comes though this location. */
+    /* for flipping of the Lazarus icons comes though this location. */
     
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
@@ -1014,6 +1014,9 @@ GreGetDIBitsInternal(
         }
 
         EXLATEOBJ_vInitialize(&exlo, psurf->ppal, psurfDest->ppal, 0xffffff, 0xffffff, 0);
+
+        /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
+        /* for flipping of the PeaZip icons comes though this location. */
 
         ret = IntEngCopyBits(&psurfDest->SurfObj,
                              &psurf->SurfObj,

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -320,10 +320,9 @@ IntSetDIBits(
     ptSrc.x = 0;
     ptSrc.y = 0;
 
-    // Not used from here. If not cleared this makes it
-    // impossible to use this bit for Lazarus and PeaZip flip info
-    psurfSrc->SurfObj.fjBitmap &= ~BMF_TOPDOWN; 
-
+    /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
+    /*  for flipping ofthe Lazarus icons comes though this location. */
+    
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
                             NULL,

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -327,7 +327,7 @@ IntSetDIBits(
      * it causes the Lazarus pull down menus to flip on mouse touch. */
 
     DPRINT("psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
-        psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN);
+           psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN);
 
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
@@ -494,7 +494,7 @@ NtGdiSetDIBitsToDeviceInternal(
     BOOL bResult;
 
     DPRINT("XDest/YDest is '%d/%d' Width is '%d' Height is '%d' XSrc/YSrc is '%d/%d' StartScan is '%d' ScanLines is '%d'.\n",
-        XDest, YDest, Width, Height, XSrc, YSrc, StartScan, ScanLines);
+           XDest, YDest, Width, Height, XSrc, YSrc, StartScan, ScanLines);
 
     if (!Bits) return 0;
 
@@ -1037,7 +1037,7 @@ GreGetDIBitsInternal(
          * flips. It fixes the menubar icons for Double Commander too. */
 
         DPRINT("psurf->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
-            psurf->SurfObj.fjBitmap & BMF_TOPDOWN);
+               psurf->SurfObj.fjBitmap & BMF_TOPDOWN);
 
         DPRINT("Info->bmiHeader.biHeight is '%d'.\n", Info->bmiHeader.biHeight);
 

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -320,14 +320,14 @@ IntSetDIBits(
     ptSrc.x = 0;
     ptSrc.y = 0;
 
-    /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit   */
-    /* for flipping of the Lazarus icons comes though this location. */
-    /* Allowing this bit to pass fixes the first Lazarus Lion Setup  */
-    /* icon and it fixes the flips for SPINA Thyr and SimThyr. But,  */
-    /* it causes the Lazarus pull down menus to flip on mouse touch. */
+    /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit
+     * for flipping of the Lazarus icons comes though this location.
+     * Allowing this bit to pass fixes the first Lazarus Lion Setup
+     * icon and it fixes the flips for SPINA Thyr and SimThyr. But,
+     * it causes the Lazarus pull down menus to flip on mouse touch. */
 
     DPRINT("psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
-      psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN);
+        psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN);
 
     result = IntEngCopyBits(&psurfDst->SurfObj,
                             &psurfSrc->SurfObj,
@@ -644,8 +644,8 @@ NtGdiSetDIBitsToDeviceInternal(
            rcDest.left, rcDest.top, rcDest.right, rcDest.bottom,
            ptSource.x, ptSource.y, SourceSize.cx, SourceSize.cy);
 
-    // Not used from here. If not cleared this makes it
-    // impossible to use this bit for Lazarus and PeaZip flip info
+    /* Not used from here. If not cleared this makes it
+     * impossible to use this bit for Lazarus and PeaZip flip info */
     pSourceSurf->fjBitmap &= ~BMF_TOPDOWN;
 
     /* This fixes the large Google text on Google.com from being upside down */
@@ -1031,13 +1031,13 @@ GreGetDIBitsInternal(
 
         EXLATEOBJ_vInitialize(&exlo, psurf->ppal, psurfDest->ppal, 0xffffff, 0xffffff, 0);
 
-        /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit  */
-        /* for flipping of the PeaZip icons comes though this location. */
-        /* Allowing this bit to pass fixes both PeaZip and Lazarus menu */
-        /* flips. It fixes the menubar icons for Double Commander too.  */
+        /* The code for the psurfSrc->SurfObj.fjBitmap BMF_TOPDOWN bit
+         * for flipping of the PeaZip icons comes though this location.
+         * Allowing this bit to pass fixes both PeaZip and Lazarus menu
+         * flips. It fixes the menubar icons for Double Commander too. */
 
         DPRINT("psurf->SurfObj.fjBitmap & BMF_TOPDOWN is '%d'.\n",
-          psurf->SurfObj.fjBitmap & BMF_TOPDOWN);
+            psurf->SurfObj.fjBitmap & BMF_TOPDOWN);
 
         DPRINT("Info->bmiHeader.biHeight is '%d'.\n", Info->bmiHeader.biHeight);
 

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS user32.dll
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:         ReactOS user32.dll
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c
@@ -312,7 +312,7 @@ create_alpha_bitmap(
             goto done;
         info->bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
         info->bmiHeader.biWidth = bm.bmWidth;
-        info->bmiHeader.biHeight = -bm.bmHeight;
+        info->bmiHeader.biHeight = bm.bmHeight;
         info->bmiHeader.biPlanes = 1;
         info->bmiHeader.biBitCount = 32;
         info->bmiHeader.biCompression = BI_RGB;


### PR DESCRIPTION

## Fix StretchBlt function to allow flipped images

_Modify dib\dibxxbpp.c programs to understand flipped images._

JIRA issue: [CORE-16642](https://jira.reactos.org/browse/CORE-16642)
                  and [CORE-16984](https://jira.reactos.org/browse/CORE-16984)
                  and [CORE-13273](https://jira.reactos.org/browse/CORE-13273)
                  and [CORE-14671](https://jira.reactos.org/browse/CORE-14671)

![SpinaThyr_Good](https://user-images.githubusercontent.com/32620577/85238754-bd268880-b3f5-11ea-9d3c-689399325af6.png)

![Trurlg_Good](https://user-images.githubusercontent.com/32620577/85238760-c0ba0f80-b3f5-11ea-89be-11223c489804.png)

![Lazarus_PeaZip_OK](https://user-images.githubusercontent.com/32620577/85239210-4939af80-b3f8-11ea-90d9-afb4a0615638.png)

