### PR TITLE
[WIN32K:NTGDI] NtGdiOpenDCW(): Comment out useless 'pdmInit' assignment

### DIFF
--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -651,6 +651,8 @@ GreOpenDCW(
     PDC pdc;
     HDC hdc;
 
+    DBG_UNREFERENCED_PARAMETER(pdmInit);
+
     DPRINT("GreOpenDCW(%S, iType=%lu)\n",
            pustrDevice ? pustrDevice->Buffer : NULL, iType);
 
@@ -760,7 +762,7 @@ NtGdiOpenDCW(
     }
     else
     {
-        pdmInit = NULL;
+        // TODO, useless: pdmInit = NULL;
         pUMdhpdev = NULL;
         // return UserGetDesktopDC(iType, FALSE, TRUE);
     }


### PR DESCRIPTION
Detected by Cppcheck: uselessAssignmentPtrArg.

https://qarmin.gitlab.io/-/reactos/-/jobs/594511987/artifacts/report/1116.html#line-763