### PR TITLE
[FRAMEBUF] DrvGetDirectDrawInfo(): Comment out useless 'pvmList' assignment

### DIFF
--- a/sdk/include/psdk/winddi.h
+++ b/sdk/include/psdk/winddi.h
@@ -4222,12 +4222,12 @@ extern FN_DrvEnableDirectDraw DrvEnableDirectDraw;
 
 typedef BOOL
 (APIENTRY FN_DrvGetDirectDrawInfo)(
-    _In_ DHPDEV dhpdev,
+    _Inout_ DHPDEV dhpdev,
     _Out_ DD_HALINFO *pHalInfo,
     _Out_ DWORD *pdwNumHeaps,
-    _Out_ VIDEOMEMORY *pvmList,
+    _Out_opt_ VIDEOMEMORY *pvmList,
     _Out_ DWORD *pdwNumFourCCCodes,
-    _Out_ DWORD *pdwFourCC);
+    _Out_opt_ DWORD *pdwFourCC);
 typedef FN_DrvGetDirectDrawInfo *PFN_DrvGetDirectDrawInfo;
 extern FN_DrvGetDirectDrawInfo DrvGetDirectDrawInfo;
 

--- a/win32ss/drivers/displays/framebuf/ddenable.c
+++ b/win32ss/drivers/displays/framebuf/ddenable.c
@@ -129,12 +129,12 @@ DrvEnableDirectDraw(
 
 BOOL APIENTRY
 DrvGetDirectDrawInfo(
-  IN DHPDEV  dhpdev,
-  OUT DD_HALINFO  *pHalInfo,
-  OUT DWORD  *pdwNumHeaps,
-  OUT VIDEOMEMORY  *pvmList,
-  OUT DWORD  *pdwNumFourCCCodes,
-  OUT DWORD  *pdwFourCC)
+    _Inout_ DHPDEV dhpdev,
+    _Out_ DD_HALINFO *pHalInfo,
+    _Out_ DWORD *pdwNumHeaps,
+    _Out_opt_ VIDEOMEMORY *pvmList,
+    _Out_ DWORD *pdwNumFourCCCodes,
+    _Out_opt_ DWORD *pdwFourCC)
 {
 	PPDEV ppdev = (PPDEV)dhpdev;
 	LONG i;

--- a/win32ss/drivers/displays/framebuf/ddenable.c
+++ b/win32ss/drivers/displays/framebuf/ddenable.c
@@ -252,7 +252,7 @@ DrvGetDirectDrawInfo(
 		pvmList->ddsCaps.dwCaps =  DDSCAPS_FRONTBUFFER | DDSCAPS_BACKBUFFER ;
 		pvmList->ddsCapsAlt.dwCaps = DDSCAPS_FRONTBUFFER | DDSCAPS_BACKBUFFER;
 
-		pvmList = ppdev->pvmList;
+		// TODO, useless: pvmList = ppdev->pvmList;
 	}
 
 	return TRUE;

--- a/win32ss/drivers/displays/framebufacc/ddenable.c
+++ b/win32ss/drivers/displays/framebufacc/ddenable.c
@@ -129,12 +129,12 @@ DrvEnableDirectDraw(
 
 BOOL APIENTRY
 DrvGetDirectDrawInfo(
-  IN DHPDEV  dhpdev,
-  OUT DD_HALINFO  *pHalInfo,
-  OUT DWORD  *pdwNumHeaps,
-  OUT VIDEOMEMORY  *pvmList,
-  OUT DWORD  *pdwNumFourCCCodes,
-  OUT DWORD  *pdwFourCC)
+    _Inout_ DHPDEV dhpdev,
+    _Out_ DD_HALINFO *pHalInfo,
+    _Out_ DWORD *pdwNumHeaps,
+    _Out_opt_ VIDEOMEMORY *pvmList,
+    _Out_ DWORD *pdwNumFourCCCodes,
+    _Out_opt_ DWORD *pdwFourCC)
 {
 	PPDEV ppdev = (PPDEV)dhpdev;
 	LONG i;
@@ -257,4 +257,3 @@ DrvGetDirectDrawInfo(
 
 	return TRUE;
 }
-

--- a/win32ss/drivers/displays/framebufacc/ddenable.c
+++ b/win32ss/drivers/displays/framebufacc/ddenable.c
@@ -252,7 +252,7 @@ DrvGetDirectDrawInfo(
 		pvmList->ddsCaps.dwCaps =  DDSCAPS_FRONTBUFFER | DDSCAPS_BACKBUFFER ;
 		pvmList->ddsCapsAlt.dwCaps = DDSCAPS_FRONTBUFFER | DDSCAPS_BACKBUFFER;
 
-		pvmList = ppdev->pvmList;
+		// TODO, useless: pvmList = ppdev->pvmList;
 	}
 
 	return TRUE;

--- a/win32ss/gdi/eng/drvdbg.c
+++ b/win32ss/gdi/eng/drvdbg.c
@@ -843,12 +843,12 @@ DbgDrvNextBand(
 BOOL
 APIENTRY
 DbgDrvGetDirectDrawInfo(
-    DHPDEV dhpdev,
-    DD_HALINFO *pHalInfo,
-    DWORD *pdwNumHeaps,
-    VIDEOMEMORY *pvmList,
-    DWORD *pdwNumFourCCCodes,
-    DWORD *pdwFourCC)
+    _Inout_ DHPDEV dhpdev,
+    _Out_ DD_HALINFO *pHalInfo,
+    _Out_ DWORD *pdwNumHeaps,
+    _Out_opt_ VIDEOMEMORY *pvmList,
+    _Out_ DWORD *pdwNumFourCCCodes,
+    _Out_opt_ DWORD *pdwFourCC)
 {
     PPDEVOBJ ppdev = DbgLookupDHPDEV(dhpdev);
 


### PR DESCRIPTION
Detected by Cppcheck: uselessAssignmentPtrArg.

https://qarmin.gitlab.io/-/reactos/-/jobs/594511987/artifacts/report/1099.html#line-255
https://qarmin.gitlab.io/-/reactos/-/jobs/594511987/artifacts/report/1100.html#line-255