### PR TITLE
[KMTESTS:EX] ExUuid: Fix version check, Add variant check

### DIFF
--- a/modules/rostests/kmtests/ntos_ex/ExUuid.c
+++ b/modules/rostests/kmtests/ntos_ex/ExUuid.c
@@ -3,6 +3,7 @@
  * LICENSE:         LGPLv2+ - See COPYING.LIB in the top level directory
  * PURPOSE:         Kernel-Mode Test Suite UUIDs test
  * PROGRAMMER:      Pierre Schweitzer <pierre@reactos.org>
+ *                  Serge Gautherie <reactos-git_serge_171003@gautherie.fr>
  */
 
 #include <kmt_test.h>
@@ -16,6 +17,14 @@ START_TEST(ExUuid)
     NTSTATUS Status;
 
     Status = ExUuidCreate(&Uuid);
+    // FIXME: Why does Test WHS report RPC_NT_UUID_LOCAL_ONLY instead? (ROSTESTS-359)
     ok(Status == STATUS_SUCCESS, "ExUuidCreate returned unexpected status: %lx\n", Status);
-    ok((Uuid.Data3 & 0x1000) == 0x1000, "Invalid UUID version: %x\n", (Uuid.Data3 & 0xF000));
+
+    ok((Uuid.Data3 & 0xF000) >> 12 == 1,
+       "UUID version: expected 1, got %u\n",
+       (Uuid.Data3 & 0xF000) >> 12);
+
+    ok(((Uuid.Data4[0] & 0xF0) >> 4 & 0b1100) == 0b1000,
+       "UUID variant: expected 0b10nn (v1), got 0x%X\n",
+       (Uuid.Data4[0] & 0xF0) >> 4);
 }


### PR DESCRIPTION
Version copypasta: actually check whole 4-bit value, not 1 bit only.

Addendum to bbfb3ca.

[WTB 74181](https://testbot.winehq.org/JobDetails.pl?Key=74181)