### PR TITLE
[SYSDM] Set the proper icon in title/task bar

### DIFF
--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -128,7 +128,7 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
     {
         case PSCB_INITIALIZED:
         {
-            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_USERPROF));
+            hIcon = LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_CPLSYSTEM));
             SendMessageW(hwndDlg, WM_SETICON, ICON_BIG, (LPARAM)hIcon);
             break;
         }
@@ -161,7 +161,7 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     psh.dwFlags =  PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
-    psh.pszIcon = MAKEINTRESOURCEW(IDI_USERPROF);
+    psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLSYSTEM);
     psh.pszCaption = MAKEINTRESOURCE(IDS_CPLSYSTEMNAME);
     psh.nPages = 0;
     psh.nStartPage = 0;


### PR DESCRIPTION
Currently, sysdm.cpl loads a different icon for the title/task bar than what is used in Control Panel. This patch loads the proper icon.
![Comparison](https://user-images.githubusercontent.com/15203817/85911005-c2197c80-b7e7-11ea-8564-f8eab469368c.png)
