### PR TITLE
[CMAKE] Remove obsolete 'GCC_VERSION' checks

### DIFF
--- a/modules/rosapps/applications/devutils/createspec/CMakeLists.txt
+++ b/modules/rosapps/applications/devutils/createspec/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-stringop-overflow")
 endif()
 

--- a/modules/rostests/winetests/advpack/CMakeLists.txt
+++ b/modules/rostests/winetests/advpack/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_definitions(-DUSE_WINE_TODOS)
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/fusion/CMakeLists.txt
+++ b/modules/rostests/winetests/fusion/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_definitions(-DUSE_WINE_TODOS)
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/msi/CMakeLists.txt
+++ b/modules/rostests/winetests/msi/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MSVC_IDE)
     include_directories($<TARGET_FILE_DIR:custom>)
 endif()
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/msvcrt/CMakeLists.txt
+++ b/modules/rostests/winetests/msvcrt/CMakeLists.txt
@@ -4,7 +4,7 @@ add_definitions(
     -D_CRT_NONSTDC_NO_DEPRECATE
     -D__msvcrt_ulong=ULONG)
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-stringop-truncation")
 endif()
 

--- a/modules/rostests/winetests/services/CMakeLists.txt
+++ b/modules/rostests/winetests/services/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/setupapi/CMakeLists.txt
+++ b/modules/rostests/winetests/setupapi/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/shell32/CMakeLists.txt
+++ b/modules/rostests/winetests/shell32/CMakeLists.txt
@@ -3,7 +3,7 @@ add_definitions(-DWINETEST_USE_DBGSTR_LONGLONG)
 
 remove_definitions(-DWINVER=0x502 -D_WIN32_IE=0x600 -D_WIN32_WINNT=0x502)
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/user32/CMakeLists.txt
+++ b/modules/rostests/winetests/user32/CMakeLists.txt
@@ -5,7 +5,7 @@ add_definitions(-DWINVER=0x602 -D_WIN32_WINNT=0x602)
 if(MSVC)
     # Disable warning C4477 (printf format warnings)
     add_compile_flags("/wd4477")
-elseif(GCC AND GCC_VERSION VERSION_GREATER 7)
+elseif(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/modules/rostests/winetests/version/CMakeLists.txt
+++ b/modules/rostests/winetests/version/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_definitions(-DUSE_WINE_TODOS)
 
-if(GCC AND GCC_VERSION VERSION_GREATER 7)
+if(GCC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -44,12 +44,8 @@ add_compile_flags("-pipe -fms-extensions -fno-strict-aliasing")
 # Prevent GCC from searching any of the default directories
 add_compile_flags("-nostdinc")
 
-if(GCC_VERSION VERSION_GREATER 4.7)
-    add_compile_flags("-mstackrealign")
-endif()
-if(NOT GCC_VERSION VERSION_LESS 4.8)
-    add_compile_flags("-fno-aggressive-loop-optimizations")
-endif()
+add_compile_flags("-mstackrealign")
+add_compile_flags("-fno-aggressive-loop-optimizations")
 
 if(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     add_compile_flags_language("-std=gnu99 -Wno-microsoft" "C")
@@ -112,9 +108,7 @@ endif()
 
 add_compile_flags("-Wall -Wpointer-arith")
 add_compile_flags("-Wno-char-subscripts -Wno-multichar -Wno-unused-value")
-if(NOT GCC_VERSION VERSION_LESS 6.1)
-    add_compile_flags("-Wno-unused-const-variable")
-endif()
+add_compile_flags("-Wno-unused-const-variable")
 add_compile_flags("-Wno-unused-local-typedefs")
 add_compile_flags("-Wno-deprecated")
 


### PR DESCRIPTION
following upgrade to GCC 8.4.