### PR TITLE
[Win32SS][GDI] Fix pool memory disclosure in NtGdiGetOutlineTextMetricsInternalW

### DIFF
--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -927,6 +927,7 @@ NtGdiGetOutlineTextMetricsInternalW (HDC  hDC,
       EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
       return 0;
   }
+  RtlZeroMemory(potm, Size);
   IntGetOutlineTextMetrics(FontGDI, Size, potm);
 
   _SEH2_TRY


### PR DESCRIPTION
## Purpose

Fix pool memory disclosure in NtGdiGetOutlineTextMetricsInternalW

## Analysis

The memory disclosure occurs because the `Size` variable which is used at https://github.com/reactos/reactos/blob/a98bebb0b0a22ba833041eca08855955ecf60705/win32ss/gdi/ntgdi/font.c#L924 is greater than `sizeof(*potm)`. When I used msvc 14.0 x86 to compile ReactOS, `sizeof(*potm)` is 216 bytes whereas the value of `Size` variable is 300 bytes. This means that although all fields of `potm` are initialized then the redundant bytes still be uninitialized then they will be copied to user land memory at https://github.com/reactos/reactos/blob/a98bebb0b0a22ba833041eca08855955ecf60705/win32ss/gdi/ntgdi/font.c#L934-L935
