### PR TITLE
[NTOS:IO] Fix pool memory disclosure in IopQueueTargetDeviceEvent

### DIFF
--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -64,6 +64,7 @@ IopQueueTargetDeviceEvent(const GUID *Guid,
                                 TotalSize + FIELD_OFFSET(PNP_EVENT_ENTRY, Event));
     if (!EventEntry)
         return STATUS_INSUFFICIENT_RESOURCES;
+    RtlZeroMemory(EventEntry, TotalSize + FIELD_OFFSET(PNP_EVENT_ENTRY, Event));
 
     /* Fill the buffer with the event GUID */
     RtlCopyMemory(&EventEntry->Event.EventGuid,


### PR DESCRIPTION
## Purpose

Fix pool memory disclosure in IopQueueTargetDeviceEvent


## Analysis

The device event entry is initialized at https://github.com/reactos/reactos/blob/a05051f5546ad2a118daf4e9de484b10b472f152/ntoskrnl/io/pnpmgr/plugplay.c#L63-L77 but some fields of it aren't initialized, for example: `EventEntry->Event.Result`, `EventEntry->Event.Flags`. The entry will be inserted into double linked list  at https://github.com/reactos/reactos/blob/a05051f5546ad2a118daf4e9de484b10b472f152/ntoskrnl/io/pnpmgr/plugplay.c#L84-L85

And at the function `IopQueueTargetDeviceEvent`, the event entry will be gotten at https://github.com/reactos/reactos/blob/a05051f5546ad2a118daf4e9de484b10b472f152/ntoskrnl/io/pnpmgr/plugplay.c#L1213-L1215 then copy its memory into user land memory at https://github.com/reactos/reactos/blob/a05051f5546ad2a118daf4e9de484b10b472f152/ntoskrnl/io/pnpmgr/plugplay.c#L1227-L1232

It causes to memory disclosure.