### PR TITLE
[NTUSER] Fix UserSendKeyboardInput() KEYEVENTF_SCANCODE use case

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND SOURCE
     GetUserObjectInformation.c
     GetWindowPlacement.c
     InitializeLpkHooks.c
+    keybd_event.c
     LoadImage.c
     LookupIconIdFromDirectoryEx.c
     MessageStateAnalyzer.c

--- a/modules/rostests/apitests/user32/keybd_event.c
+++ b/modules/rostests/apitests/user32/keybd_event.c
@@ -1,0 +1,42 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for keyboard inputs with flags KEYEVENTF_EXTENDEDKEY and KEYEVENTF_SCANCODE
+ * COPYRIGHT:   Copyright 2021 Arjav Garg <arjavgarg@gmail.com>
+ */
+
+#include "precomp.h"
+
+static void testScancodeExtendedKey(BYTE wVk, BYTE scanCode)
+{
+    trace("wVK: %x\tScancode: %x\n", wVk, scanCode);
+
+    keybd_event(0, scanCode, KEYEVENTF_SCANCODE | KEYEVENTF_EXTENDEDKEY, 0);
+    SHORT winKeyState = GetAsyncKeyState(wVk);
+    ok(winKeyState & 0x8000, "VK=%x should be detected as key down.\n", wVk);
+
+    keybd_event(0, scanCode, KEYEVENTF_SCANCODE | KEYEVENTF_EXTENDEDKEY | KEYEVENTF_KEYUP, 0);
+    winKeyState = GetAsyncKeyState(wVk);
+    ok(!(winKeyState & 0x8000), "VK=%x should be detected as key up.\n", wVk);
+}
+
+/* https://docs.microsoft.com/en-us/windows/win32/inputdev/about-keyboard-input#extended-key-flag */
+START_TEST(keybd_event)
+{
+    testScancodeExtendedKey(VK_RWIN, 0x5C);
+    testScancodeExtendedKey(VK_LWIN, 0x5B);
+    testScancodeExtendedKey(VK_RMENU, 0x38);
+    testScancodeExtendedKey(VK_RCONTROL, 0x1D);
+    testScancodeExtendedKey(VK_INSERT, 0x52);
+    testScancodeExtendedKey(VK_DELETE, 0x53);
+    testScancodeExtendedKey(VK_HOME, 0x47);
+    testScancodeExtendedKey(VK_END, 0x4f);
+    testScancodeExtendedKey(VK_PRIOR, 0x49);
+    testScancodeExtendedKey(VK_NEXT, 0x51);
+    testScancodeExtendedKey(VK_UP, 0x48);
+    testScancodeExtendedKey(VK_RIGHT, 0x4d);
+    testScancodeExtendedKey(VK_LEFT, 0x4b);
+    testScancodeExtendedKey(VK_DOWN, 0x50);
+    testScancodeExtendedKey(VK_DIVIDE, 0x35);
+    testScancodeExtendedKey(VK_RETURN, 0x1C);
+}

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -25,6 +25,7 @@ extern void func_GetSystemMetrics(void);
 extern void func_GetUserObjectInformation(void);
 extern void func_GetWindowPlacement(void);
 extern void func_InitializeLpkHooks(void);
+extern void func_keybd_event(void);
 extern void func_LoadImage(void);
 extern void func_LookupIconIdFromDirectoryEx(void);
 extern void func_MessageStateAnalyzer(void);
@@ -76,6 +77,7 @@ const struct test winetest_testlist[] =
     { "GetUserObjectInformation", func_GetUserObjectInformation },
     { "GetWindowPlacement", func_GetWindowPlacement },
     { "InitializeLpkHooks", func_InitializeLpkHooks },
+    { "keybd_event", func_keybd_event },
     { "LoadImage", func_LoadImage },
     { "LookupIconIdFromDirectoryEx", func_LookupIconIdFromDirectoryEx },
     { "MessageStateAnalyzer", func_MessageStateAnalyzer },

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1020,8 +1020,11 @@ UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected)
         }
         else
         {
-            wVk = pKbdInput->wVk & 0xFF;
+            wVk = pKbdInput->wVk;
         }
+
+        /* Remove all virtual key flags (KBDEXT, KBDMULTIVK, KBDSPECIAL, KBDNUMPAD) */
+        wVk &= 0xFF;
     }
 
     /* If time is given, use it */


### PR DESCRIPTION
When KEYEVENTF_SCANCODE is supplied, the edited routine is supposed to ignore the supplied VK and hence procure it itself from the given scancode. The word VK is getting values > 0xFE from the keyboard table which is incorrect (VK > 0xFE do not exist)

JIRA issue: [CORE-17144](https://jira.reactos.org/browse/CORE-17144)

Turns out, simply ```&= 0xFF``` makes the VK correspond to the correct value.