### PR TITLE
[FILESYSTEMS] Fix pool memory disclosure in filesystem drivers supporting FS_INFORMATION_CLASS.FileFsVolumeInformation

### DIFF
--- a/drivers/filesystems/cdfs/volinfo.c
+++ b/drivers/filesystems/cdfs/volinfo.c
@@ -160,6 +160,8 @@ Return Value:
         //  and false if it couldn't wait for any I/O to complete.
         //
 
+        RtlZeroMemory(Irp->AssociatedIrp.SystemBuffer, Length);
+
         switch (IrpSp->Parameters.QueryVolume.FsInformationClass) {
 
         case FileFsSizeInformation:

--- a/drivers/filesystems/cdfs/volinfo.c
+++ b/drivers/filesystems/cdfs/volinfo.c
@@ -160,7 +160,9 @@ Return Value:
         //  and false if it couldn't wait for any I/O to complete.
         //
 
+#ifdef __REACTOS__
         RtlZeroMemory(Irp->AssociatedIrp.SystemBuffer, Length);
+#endif // __REACTOS__
 
         switch (IrpSp->Parameters.QueryVolume.FsInformationClass) {
 
@@ -358,6 +360,7 @@ Return Value:
 
     Buffer->TotalAllocationUnits.QuadPart = LlSectorsFromBytes( Vcb->VolumeDasdFcb->AllocationSize.QuadPart );
 
+    Buffer->AvailableAllocationUnits.QuadPart = 0;
     Buffer->SectorsPerAllocationUnit = 1;
     Buffer->BytesPerSector = SECTOR_SIZE;
 

--- a/drivers/filesystems/cdfs/volinfo.c
+++ b/drivers/filesystems/cdfs/volinfo.c
@@ -358,7 +358,6 @@ Return Value:
 
     Buffer->TotalAllocationUnits.QuadPart = LlSectorsFromBytes( Vcb->VolumeDasdFcb->AllocationSize.QuadPart );
 
-    Buffer->AvailableAllocationUnits.QuadPart = 0;
     Buffer->SectorsPerAllocationUnit = 1;
     Buffer->BytesPerSector = SECTOR_SIZE;
 

--- a/drivers/filesystems/fastfat/volume.c
+++ b/drivers/filesystems/fastfat/volume.c
@@ -48,7 +48,6 @@ FsdGetFsVolumeInformation(
         RtlCopyMemory(FsVolumeInfo->VolumeLabel,
                       DeviceObject->Vpb->VolumeLabel,
                       *BufferLength);
-        *BufferLength = 0;
     }
     else
     {

--- a/drivers/filesystems/fastfat/volume.c
+++ b/drivers/filesystems/fastfat/volume.c
@@ -457,6 +457,8 @@ VfatQueryVolumeInformation(
     DPRINT("FsInformationClass %d\n", FsInformationClass);
     DPRINT("SystemBuffer %p\n", SystemBuffer);
 
+    RtlZeroMemory(SystemBuffer, BufferLength);
+
     switch (FsInformationClass)
     {
         case FileFsVolumeInformation:

--- a/drivers/filesystems/nfs/nfs41_driver.c
+++ b/drivers/filesystems/nfs/nfs41_driver.c
@@ -4546,6 +4546,8 @@ NTSTATUS nfs41_QueryVolumeInformation(
     status = check_nfs41_dirquery_args(RxContext);
     if (status) goto out;
 
+    RtlZeroMemory(RxContext->Info.Buffer, RxContext->Info.LengthRemaining);
+
     switch (InfoClass) {
     case FileFsVolumeInformation:
         if ((ULONG)RxContext->Info.LengthRemaining >= DevExt->VolAttrsLen) {

--- a/drivers/filesystems/nfs/nfs41_driver.c
+++ b/drivers/filesystems/nfs/nfs41_driver.c
@@ -4546,7 +4546,9 @@ NTSTATUS nfs41_QueryVolumeInformation(
     status = check_nfs41_dirquery_args(RxContext);
     if (status) goto out;
 
+#ifdef __REACTOS__
     RtlZeroMemory(RxContext->Info.Buffer, RxContext->Info.LengthRemaining);
+#endif // __REACTOS__
 
     switch (InfoClass) {
     case FileFsVolumeInformation:

--- a/drivers/filesystems/npfs/volinfo.c
+++ b/drivers/filesystems/npfs/volinfo.c
@@ -27,8 +27,6 @@ NpQueryFsVolumeInfo(IN PVOID Buffer,
 
     *Length -= FIELD_OFFSET(FILE_FS_VOLUME_INFORMATION, VolumeLabel);
 
-    InfoBuffer->VolumeCreationTime.QuadPart = 0;
-    InfoBuffer->VolumeSerialNumber = 0;
     InfoBuffer->SupportsObjects = 0;
 
     NameLength = 18;
@@ -61,8 +59,6 @@ NpQueryFsSizeInfo(IN PVOID Buffer,
 
     *Length -= sizeof(*InfoBuffer);
 
-    InfoBuffer->TotalAllocationUnits.QuadPart = 0;
-    InfoBuffer->AvailableAllocationUnits.QuadPart = 0;
     InfoBuffer->SectorsPerAllocationUnit = 1;
     InfoBuffer->BytesPerSector = 1;
 
@@ -78,7 +74,6 @@ NpQueryFsDeviceInfo(IN PVOID Buffer,
     PFILE_FS_DEVICE_INFORMATION InfoBuffer = Buffer;
     TRACE("Entered\n");
 
-    InfoBuffer->DeviceType = 0;
     InfoBuffer->Characteristics = 0;
     InfoBuffer->DeviceType = FILE_DEVICE_NAMED_PIPE;
     *Length -= sizeof(*InfoBuffer);

--- a/drivers/filesystems/npfs/volinfo.c
+++ b/drivers/filesystems/npfs/volinfo.c
@@ -74,7 +74,6 @@ NpQueryFsDeviceInfo(IN PVOID Buffer,
     PFILE_FS_DEVICE_INFORMATION InfoBuffer = Buffer;
     TRACE("Entered\n");
 
-    InfoBuffer->Characteristics = 0;
     InfoBuffer->DeviceType = FILE_DEVICE_NAMED_PIPE;
     *Length -= sizeof(*InfoBuffer);
 

--- a/drivers/filesystems/npfs/volinfo.c
+++ b/drivers/filesystems/npfs/volinfo.c
@@ -153,6 +153,8 @@ NpCommonQueryVolumeInformation(IN PDEVICE_OBJECT DeviceObject,
     Length = IoStack->Parameters.QueryVolume.Length;
     InfoClass = IoStack->Parameters.QueryVolume.FsInformationClass;
 
+    RtlZeroMemory(Buffer, Length);
+
     switch (InfoClass)
     {
         case FileFsVolumeInformation:

--- a/drivers/filesystems/udfs/volinfo.cpp
+++ b/drivers/filesystems/udfs/volinfo.cpp
@@ -197,6 +197,9 @@ UDFCommonQueryVolInfo(
             try_return(RC);
         }
 #endif //UDF_ENABLE_SECURITY
+
+        RtlZeroMemory(Irp->AssociatedIrp.SystemBuffer, Length);
+
         switch (IrpSp->Parameters.QueryVolume.FsInformationClass) {
     
         case FileFsVolumeInformation:


### PR DESCRIPTION
## Purpose

Fix structure alignment leads to pool memory disclosure in drivers support `FS_INFORMATION_CLASS.FileFsVolumeInformation`

## Analysis

The structure `_FILE_FS_VOLUME_INFORMATION`

```
kd> dt _FIlE_FS_VOLUME_INFORMATION
shell32!_FILE_FS_VOLUME_INFORMATION
   +0x000 VolumeCreationTime : _LARGE_INTEGER
   +0x008 VolumeSerialNumber : Uint4B
   +0x00c VolumeLabelLength : Uint4B
   +0x010 SupportsObjects  : UChar
   +0x012 VolumeLabel      : [1] Wchar
```

is added 1 padding byte after the field `SupportsObjects` so it will lead to memory disclosure although all fields are initialized.

The backtrace report of bochspwn-reloaded:

```
 #0  0x80581cb8 ((00181cb8) ntoskrnl.exe!memcpy+48)
 #1  0x80485686 ((00085686) ntoskrnl.exe!IopCompleteRequest+1c6 [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 292])
 #2  0x8047b3aa ((0007b3aa) ntoskrnl.exe!IopPerformSynchronousRequest+ba [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 158])
 #3  0x8047dd80 ((0007dd80) ntoskrnl.exe!NtQueryVolumeInformationFile+6c0 [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 4341])
 #4  0x8054dc5b ((0014dc5b) ntoskrnl.exe!KiSystemCallTrampoline+1b [h:\project\reactos\ntoskrnl\include\internal\i386\ke.h @ 766])
 #5  0x8054bac8 ((0014bac8) ntoskrnl.exe!KiSystemServiceHandler+278 [h:\project\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1846])
 #6  0x80403ea5 ((00003ea5) ntoskrnl.exe!KiFastCallEntry+96)
```

This bug affects all filesystem drivers support `FS_INFORMATION_CLASS.FileFsVolumeInformation`. Luckily some of them are zeroed system memory before using so I only zeroing the rest.

For btrfs driver, I think I should pull request to it instead of fixing this bug in ReactOS.