### PR TITLE
[USER32] Implement checking for animated mouse cursors in CURSORICON_LoadFileFromW CORE-14166

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -3,7 +3,8 @@
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c
  * PURPOSE:         cursor and icons implementation
- * PROGRAMMER:      Jérôme Gardou (jerome.gardou@reactos.org)
+ * PROGRAMMERS:     Jérôme Gardou (jerome.gardou@reactos.org)
+ *                  Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
  */
 
 #include <user32.h>
@@ -1354,7 +1355,7 @@ CURSORICON_LoadFromFileW(
     /* Check for .ani. */
     if (memcmp( bits, "RIFF", 4 ) == 0)
     {
-        UNIMPLEMENTED;
+        hCurIcon = (HANDLE)CURSORICON_GetCursorDataFromANI(&cursorData, bits, filesize, fuLoad);
         goto end;
     }
 


### PR DESCRIPTION
## Purpose

Implement checking for available animated mouse cursors (.ani), which are set via main.cpl, in internal CURSORICON_LoadFileFromW function. My implementation simply assigns `CURSORICON_GetCursorDataFromANI` call with all required parameters, to `hCurIcon` variable, similarly to as it done in Wine: https://source.winehq.org/git/wine.git/blob/95ac10e526f9949802c8b76a969a942a9a4c2727:/dlls/user32/cursoricon.c#l1108.

JIRA issue: [CORE-14166](https://jira.reactos.org/browse/CORE-14166)

## Proposed changes

- Implement the checking for .ani cursors in according code path of CURSORICON_LoadFileFromW function.
- Update copyrights.

## TODO

- [ ] Investigate why it still doesn't work (due to another issue in win32k or something is still wrong in my implementation instead). Now, after my changes, it spams about fail in UserGetCurIconObject function from win32k for some reason. See the ticket comment for details: https://jira.reactos.org/browse/CORE-14166?focusedCommentId=124356&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-124356.