### PR TITLE
[CMAKE] Remove obsolete 'CMAKE_CXX_COMPILER_VERSION' checks

### DIFF
--- a/base/applications/network/telnet/CMakeLists.txt
+++ b/base/applications/network/telnet/CMakeLists.txt
@@ -3,7 +3,7 @@ set_cpp(WITH_EXCEPTIONS WITH_STL)
 
 add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)
 
-if(NOT MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+if(NOT MSVC)
     add_compile_flags("-Wno-restrict")
 endif()
 

--- a/base/services/tftpd/CMakeLists.txt
+++ b/base/services/tftpd/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(NOT MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+if(NOT MSVC)
     add_compile_flags("-Wno-format-overflow")
 endif()
 

--- a/dll/3rdparty/libxslt/CMakeLists.txt
+++ b/dll/3rdparty/libxslt/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-if(NOT MSVC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0)
+if(NOT MSVC)
     add_compile_flags("-Wno-misleading-indentation")
 endif()
 


### PR DESCRIPTION
following upgrade to RosBE 2.2.0 support and GCC 8.4.

Split off from #2979.