### PR TITLE
[RTL] vDbgPrintExWithPrefixInternal(): Make 'strncpy()' length more u…

### DIFF
--- a/sdk/lib/rtl/debug.c
+++ b/sdk/lib/rtl/debug.c
@@ -81,7 +81,7 @@ vDbgPrintExWithPrefixInternal(IN PCCH Prefix,
         if (PrefixLength > sizeof(Buffer)) PrefixLength = sizeof(Buffer);
 
         /* Copy it */
-        strncpy(Buffer, Prefix, PrefixLength);
+        strncpy(Buffer, Prefix, sizeof(Buffer));
 
         /* Do the printf */
         Length = _vsnprintf(Buffer + PrefixLength,


### PR DESCRIPTION
…sual

Fix GCC 'RelWithDebInfo'
'.../debug.c:84:9: error: 'strncpy' specified bound depends on the length of the source argument [-Werror=stringop-overflow=]'