### PR TITLE
[MLANG] Fix scripts values in fnIMLangFontLink2_GetScriptFontInfo()

### DIFF
--- a/dll/win32/mlang/mlang.c
+++ b/dll/win32/mlang/mlang.c
@@ -3565,7 +3565,7 @@ static HRESULT WINAPI fnIMLangFontLink2_GetScriptFontInfo(IMLangFontLink2* This,
             {
                 if (j >= *puiFonts) break;
 
-                pScriptFont[j].scripts = 1 << mlang_data[i].sid;
+                pScriptFont[j].scripts = (SCRIPT_IDS)1 << mlang_data[i].sid;
                 if (dwFlags == SCRIPTCONTF_FIXED_FONT)
                 {
                     MultiByteToWideChar(CP_ACP, 0, mlang_data[i].fixed_font, -1,


### PR DESCRIPTION
MSVC:
'...\mlang.c(3568): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)'

Import
https://source.winehq.org/git/wine.git/commit/2dc0758b5d0fe4ef49b7d0635299e5cb9e0360df