### PR TITLE
[NTOS:KE] Fix stack memory disclosure in KiInitializeUserApc

### DIFF
--- a/ntoskrnl/ke/amd64/stubs.c
+++ b/ntoskrnl/ke/amd64/stubs.c
@@ -207,7 +207,7 @@ KiInitializeUserApc(IN PKEXCEPTION_FRAME ExceptionFrame,
                     IN PVOID SystemArgument1,
                     IN PVOID SystemArgument2)
 {
-    CONTEXT Context;
+    CONTEXT Context = { 0 };
     ULONG64 AlignedRsp, Stack;
     EXCEPTION_RECORD SehExceptRecord;
 

--- a/ntoskrnl/ke/arm/usercall.c
+++ b/ntoskrnl/ke/arm/usercall.c
@@ -270,7 +270,7 @@ KiInitializeUserApc(IN PKEXCEPTION_FRAME ExceptionFrame,
                     IN PVOID SystemArgument1,
                     IN PVOID SystemArgument2)
 {
-    CONTEXT Context;
+    CONTEXT Context = { 0 };
     ULONG_PTR Stack;
     ULONG ContextLength;
     DPRINT1("User APC: %p %p %p\n", NormalContext, SystemArgument1, SystemArgument2);

--- a/ntoskrnl/ke/i386/usercall.c
+++ b/ntoskrnl/ke/i386/usercall.c
@@ -51,7 +51,7 @@ KiInitializeUserApc(IN PKEXCEPTION_FRAME ExceptionFrame,
                     IN PVOID SystemArgument1,
                     IN PVOID SystemArgument2)
 {
-    CONTEXT Context;
+    CONTEXT Context = { 0 };
     ULONG_PTR Stack, AlignedEsp;
     ULONG ContextLength;
     EXCEPTION_RECORD SehExceptRecord;


### PR DESCRIPTION
## Purpose

Fix stack memory disclosure in KiInitializeUserApc

## Analysis

In the function `KiInitializeUserApc`, the function `KeTrapFrameToContext` will initialize the value for local variable `Context` then copy value of `Context` to user land memory at https://github.com/reactos/reactos/blob/893a3c9d030fd8b078cbd747eeefd3f6ce57e560/ntoskrnl/ke/i386/usercall.c#L77-L84

But `KeTrapFrameToContext` will not initialize all fields of `Context`, it depends on the value of `Context.ContextFlags`. In x86 architecture, the value of `Context.ContextFlags` is `CONTEXT_FULL | CONTEXT_DEBUG_REGISTERS`, it still lacks some value, for example: `CONTEXT_EXTENDED_REGISTERS` so `KeTrapFrameToContext` will not execute bellow code:

https://github.com/reactos/reactos/blob/b20f81512688f26c91a131b81f41fc8cf9506f04/ntoskrnl/ke/i386/exp.c#L694-L712

then stack memory disclosure will happen. This is  the same for x64 and arm architecture.