### PR TITLE
[CMAKE] Add a TODO about an obsolete 'CMAKE_CXX_COMPILER_VERSION' check

### DIFF
--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -253,6 +253,7 @@ set(CMAKE_EXE_LINKER_FLAGS "-nostdlib -Wl,--enable-auto-image-base,--disable-aut
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS_INIT} -Wl,--disable-stdcall-fixup")
 set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS_INIT} -Wl,--disable-stdcall-fixup")
 
+# TODO: Now-dead block, after upgrade to GCC 8.4. (CORE-16798)
 if((CMAKE_C_COMPILER_ID STREQUAL "GNU") AND
    (NOT CMAKE_BUILD_TYPE STREQUAL "Release") AND
    (NOT CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 7.0))


### PR DESCRIPTION
following upgrade to RosBE 2.2.0 support and GCC 8.4.

JIRA issue: [CORE-16798](https://jira.reactos.org/browse/CORE-16798)

Split off from #2979.