### PR TITLE
[NTGDI] Fix stack memory disclosure in NtGdiGetTextMetricsW

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4610,9 +4610,6 @@ ftGdiGetTextMetricsW(
             if (NT_SUCCESS(Status) || !Error)
             {
                 FillTM(&ptmwi->TextMetric, FontGDI, pOS2, pHori, !Error ? &Win : 0);
-
-                /* FIXME: Fill Diff member */
-                RtlZeroMemory(&ptmwi->Diff, sizeof(ptmwi->Diff));
             }
 
             IntUnLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4560,6 +4560,7 @@ ftGdiGetTextMetricsW(
         EngSetLastError(STATUS_INVALID_PARAMETER);
         return FALSE;
     }
+    RtlZeroMemory(ptmwi, sizeof(TMW_INTERNAL));
 
     if (!(dc = DC_LockDc(hDC)))
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4610,6 +4610,8 @@ ftGdiGetTextMetricsW(
             if (NT_SUCCESS(Status) || !Error)
             {
                 FillTM(&ptmwi->TextMetric, FontGDI, pOS2, pHori, !Error ? &Win : 0);
+
+                /* FIXME: Fill Diff member */
             }
 
             IntUnLockFreeType();

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -549,7 +549,7 @@ NtGdiGetTextMetricsW(
     OUT TMW_INTERNAL * pUnsafeTmwi,
     IN ULONG cj)
 {
-    TMW_INTERNAL Tmwi = { 0 };
+    TMW_INTERNAL Tmwi;
 
     if ( cj <= sizeof(TMW_INTERNAL) )
     {

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -549,7 +549,7 @@ NtGdiGetTextMetricsW(
     OUT TMW_INTERNAL * pUnsafeTmwi,
     IN ULONG cj)
 {
-    TMW_INTERNAL Tmwi;
+    TMW_INTERNAL Tmwi = { 0 };
 
     if ( cj <= sizeof(TMW_INTERNAL) )
     {


### PR DESCRIPTION
## Purpose

Fix structure alignment leads to stack memory disclosure in NtGdiGetTextMetricsW

## Analysis

In msvc x86 build, compiler add 3 padding bytes after `TextMetric.tmCharSet` in the structure `TMW_INTERNAL`

```
kd> dt -b TMW_INTERNAL
win32k!TMW_INTERNAL
   +0x000 TextMetric       : tagTEXTMETRICW
      +0x000 tmHeight         : Int4B
      +0x004 tmAscent         : Int4B
      +0x008 tmDescent        : Int4B
      +0x00c tmInternalLeading : Int4B
      +0x010 tmExternalLeading : Int4B
      +0x014 tmAveCharWidth   : Int4B
      +0x018 tmMaxCharWidth   : Int4B
      +0x01c tmWeight         : Int4B
      +0x020 tmOverhang       : Int4B
      +0x024 tmDigitizedAspectX : Int4B
      +0x028 tmDigitizedAspectY : Int4B
      +0x02c tmFirstChar      : Wchar
      +0x02e tmLastChar       : Wchar
      +0x030 tmDefaultChar    : Wchar
      +0x032 tmBreakChar      : Wchar
      +0x034 tmItalic         : UChar
      +0x035 tmUnderlined     : UChar
      +0x036 tmStruckOut      : UChar
      +0x037 tmPitchAndFamily : UChar
      +0x038 tmCharSet        : UChar
   +0x03c Diff             : _TMDIFF
      +0x000 cjotma           : Uint4B
      +0x004 chFirst          : Char
      +0x005 chLast           : Char
      +0x006 ChDefault        : Char
      +0x007 ChBreak          : Char
```

`TMW_INTERNAL` is type of local variable `Tmwi`, then `Tmwi` will be copied into user land memory at https://github.com/reactos/reactos/blob/c8749d379beeb3a078c296feca1f4cdb3e9d11f1/win32ss/gdi/ntgdi/text.c#L560-L561

It will cause to stack memory disclosure.