### PR TITLE
[NTOSKRNL] Remove remnant 'IQS()' and 'IQS_SAME()' defines

### DIFF
--- a/ntoskrnl/include/internal/ntoskrnl.h
+++ b/ntoskrnl/include/internal/ntoskrnl.h
@@ -106,15 +106,6 @@ typedef struct _INFORMATION_CLASS_INFO
 #define ICI_SQ(TypeQuery, TypeSet, AlignmentQuery, AlignmentSet, Flags)        \
   { TypeQuery, TypeSet, AlignmentQuery, AlignmentSet, Flags }
 
-//
-// TEMPORARY
-//
-#define IQS_SAME(Type, Alignment, Flags)                                    \
-  { sizeof(Type), sizeof(Type), sizeof(Alignment), sizeof(Alignment), Flags }
-
-#define IQS(TypeQuery, TypeSet, AlignmentQuery, AlignmentSet, Flags)        \
-  { sizeof(TypeQuery), sizeof(TypeSet), sizeof(AlignmentQuery), sizeof(AlignmentSet), Flags }
-
 /*
  * Use IsPointerOffset to test whether a pointer should be interpreted as an offset
  * or as a pointer

--- a/ntoskrnl/include/internal/ps_i.h
+++ b/ntoskrnl/include/internal/ps_i.h
@@ -1,8 +1,0 @@
-/*
-* PROJECT:         ReactOS Kernel
-* LICENSE:         GPL - See COPYING in the top level directory
-* FILE:            ntoskrnl/include/internal/ps_i.h
-* PURPOSE:         Info Classes for the Process Manager
-* PROGRAMMERS:     Alex Ionescu (alex.ionescu@reactos.org)
-*                  Thomas Weidenmueller (w3seek@reactos.org)
-*/


### PR DESCRIPTION
And actually delete empty 'ps_i.h'.

Addendum to bf493b9 (r59859).