### PR TITLE
[CLASS2]: Set DiskSize member of deviceExtension->DiskGeometry in Scs…

### DIFF
--- a/drivers/storage/class/class2/class2.c
+++ b/drivers/storage/class/class2/class2.c
@@ -828,19 +828,19 @@ Retry:
             lastSector + 1));
 
         //
-        // Calculate media capacity in bytes.
-        //
-
-        deviceExtension->PartitionLength.QuadPart = (LONGLONG)(lastSector + 1);
-
-        //
         // Calculate number of cylinders.
         //
 
         deviceExtension->DiskGeometry->Geometry.Cylinders.QuadPart = (LONGLONG)((lastSector + 1)/(DEFAULT_SECTORS_PER_TRACK * DEFAULT_TRACKS_PER_CYLINDER));
 
+        //
+        // Calculate media capacity in bytes.
+        //
+
+        deviceExtension->PartitionLength.QuadPart = (LONGLONG)(lastSector + 1);
         deviceExtension->PartitionLength.QuadPart =
             (deviceExtension->PartitionLength.QuadPart << deviceExtension->SectorShift);
+        deviceExtension->DiskGeometry->DiskSize.QuadPart = deviceExtension->PartitionLength.QuadPart;
 
         if (DeviceObject->Characteristics & FILE_REMOVABLE_MEDIA) {
 
@@ -903,6 +903,7 @@ Retry:
         deviceExtension->DiskGeometry->Geometry.BytesPerSector = 512;
         deviceExtension->SectorShift = 9;
         deviceExtension->PartitionLength.QuadPart = (LONGLONG) 0;
+        deviceExtension->DiskGeometry->DiskSize.QuadPart = (LONGLONG) 0;
 
         if (DeviceObject->Characteristics & FILE_REMOVABLE_MEDIA) {
 


### PR DESCRIPTION
…iClassReadDriveCapacity(). Consolidate code and comment for setting media capacity in bytes. CORE-17166

## Purpose

This resolves the issue with the size of disk drives not being detected & reported properly, which leads to BSOD's when ReactOS is installed and missing partitions when booting from a livecd. This resolves CORE-17166.

JIRA issue: [CORE-17166](https://jira.reactos.org/browse/CORE-17166)

## Proposed changes

We need to set the DiskSize member of the DISK_GEOMETRY_EX struct deviceExtension->DiskGeometry.