### PR TITLE
[REACTOS] Fix GetTokenInformation() usage

### DIFF
--- a/base/applications/cmdutils/eventcreate/eventcreate.c
+++ b/base/applications/cmdutils/eventcreate/eventcreate.c
@@ -126,8 +126,9 @@ GetUserToken(
     BOOL Success = FALSE;
     DWORD dwError;
     HANDLE hToken;
-    DWORD cbTokenBuffer = 0;
+    DWORD cbTokenBuffer;
     PTOKEN_USER pUserToken = NULL;
+    BOOL bRet;
 
     *ppUserToken = NULL;
 
@@ -136,11 +137,12 @@ GetUserToken(
         return FALSE;
 
     /* Retrieve token's information */
-    if (!GetTokenInformation(hToken, TokenUser, NULL, 0, &cbTokenBuffer))
+    bRet = GetTokenInformation(hToken, TokenUser, NULL, 0, &cbTokenBuffer);
+    if (bRet || GetLastError() != ERROR_INSUFFICIENT_BUFFER)
     {
-        dwError = GetLastError();
-        if (dwError != ERROR_INSUFFICIENT_BUFFER)
-            goto Quit;
+        // Fake an error code if need be.
+        dwError = bRet ? ERROR_INVALID_DATA : GetLastError();
+        goto Quit;
     }
 
     pUserToken = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cbTokenBuffer);

--- a/base/services/rpcss/setup.c
+++ b/base/services/rpcss/setup.c
@@ -58,7 +58,7 @@ RunningAsSYSTEM(VOID)
     BOOL bRet = FALSE;
     PTOKEN_USER pTokenUser;
     HANDLE hToken;
-    DWORD cbTokenBuffer = 0;
+    DWORD cbTokenBuffer;
 
     /* Get the process token */
     if (!OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken))

--- a/base/shell/progman/main.c
+++ b/base/shell/progman/main.c
@@ -185,7 +185,7 @@ GetUserAndDomainName(OUT LPWSTR* UserName,
 {
     BOOL bRet = TRUE;
     HANDLE hToken;
-    DWORD cbTokenBuffer = 0;
+    DWORD cbTokenBuffer;
     PTOKEN_USER pUserToken;
 
     LPWSTR lpUserName   = NULL;
@@ -200,13 +200,11 @@ GetUserAndDomainName(OUT LPWSTR* UserName,
         return FALSE;
 
     /* Retrieve token's information */
-    if (!GetTokenInformation(hToken, TokenUser, NULL, 0, &cbTokenBuffer))
+    if (GetTokenInformation(hToken, TokenUser, NULL, 0, &cbTokenBuffer) ||
+        GetLastError() != ERROR_INSUFFICIENT_BUFFER)
     {
-        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-        {
-            CloseHandle(hToken);
-            return FALSE;
-        }
+        CloseHandle(hToken);
+        return FALSE;
     }
 
     pUserToken = Alloc(HEAP_ZERO_MEMORY, cbTokenBuffer);

--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -432,27 +432,24 @@ AllowWinstaAccess(PWLSESSION Session)
 {
     BOOL bSuccess = FALSE;
     DWORD dwIndex;
-    DWORD dwLength = 0;
-    PTOKEN_GROUPS ptg = NULL;
+    DWORD dwLength;
+    PTOKEN_GROUPS ptg;
     PSID psid;
     TOKEN_STATISTICS Stats;
     DWORD cbStats;
     DWORD ret;
 
     // Get required buffer size and allocate the TOKEN_GROUPS buffer.
-
-    if (!GetTokenInformation(Session->UserToken,
-                             TokenGroups,
-                             ptg,
-                             0,
-                             &dwLength))
+    if (GetTokenInformation(Session->UserToken, TokenGroups, NULL, 0, &dwLength) ||
+        GetLastError() != ERROR_INSUFFICIENT_BUFFER)
     {
-        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-            return FALSE;
+        return FALSE;
+    }
 
-        ptg = (PTOKEN_GROUPS)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, dwLength);
-        if (ptg == NULL)
-            return FALSE;
+    ptg = (PTOKEN_GROUPS)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, dwLength);
+    if (!ptg)
+    {
+        return FALSE;
     }
 
     // Get the token group information from the access token.

--- a/dll/cpl/sysdm/userprofile.c
+++ b/dll/cpl/sysdm/userprofile.c
@@ -687,7 +687,7 @@ AddUserProfiles(
     DWORD dwSidLength;
     FILETIME ftLastWrite;
     DWORD dwSize;
-    HANDLE hToken = NULL;
+    HANDLE hToken;
     PTOKEN_USER pTokenUser = NULL;
     PSID pProfileSid;
     PWSTR pszProfileSid;

--- a/dll/win32/userenv/profile.c
+++ b/dll/win32/userenv/profile.c
@@ -357,22 +357,21 @@ CheckForGuestsAndAdmins(
     PTOKEN_GROUPS pGroupInfo = NULL;
     PSID pAdministratorsSID = NULL;
     PSID pGuestsSID = NULL;
-    DWORD i, dwSize = 0;
+    DWORD i, dwSize;
     DWORD dwError = ERROR_SUCCESS;
+    BOOL bRet;
 
     DPRINT("CheckForGuestsAndAdmins(%p %p)\n", hToken, pdwState);
 
     /* Get the buffer size */
-    if (!GetTokenInformation(hToken, TokenGroups, NULL, dwSize, &dwSize))
+    bRet = GetTokenInformation(hToken, TokenGroups, NULL, 0, &dwSize);
+    if (bRet || GetLastError() != ERROR_INSUFFICIENT_BUFFER)
     {
         dwError = GetLastError();
-        if (dwError != ERROR_INSUFFICIENT_BUFFER)
-        {
-            DPRINT1("GetTokenInformation() failed (Error %lu)\n", dwError);
-            return dwError;
-        }
-
-        dwError = ERROR_SUCCESS;
+        DPRINT1("GetTokenInformation() failed (Error %lu)\n",
+                bRet ? ERROR_SUCCESS : dwError);
+        // Fake a return code if need be.
+        return bRet ? ERROR_INVALID_DATA : dwError;
     }
 
     /* Allocate the buffer */

--- a/modules/rostests/tests/tokentest/tokentest.c
+++ b/modules/rostests/tests/tokentest/tokentest.c
@@ -278,18 +278,25 @@ GetFromToken(HANDLE hToken, TOKEN_INFORMATION_CLASS tic)
 {
 	BOOL bResult;
     DWORD n;
-	PBYTE p = 0;
+	PBYTE p;
 
-    bResult = GetTokenInformation(hToken, tic, 0, 0, &n);
-    if ( ! bResult && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-		return 0;
+    bResult = GetTokenInformation(hToken, tic, NULL, 0, &n);
+    if (bResult || GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    {
+		return NULL;
+    }
 
     p = (PBYTE) malloc(n);
+    if (!p)
+    {
+		return NULL;
+    }
+
     if ( ! GetTokenInformation(hToken, tic, p, n, &n) )
 	{
-		printf("GetFromToken() failed for TOKEN_INFORMATION_CLASS(%d): %d\n", tic, GetLastError());
+		printf("GetFromToken() failed for TOKEN_INFORMATION_CLASS(%d): %lu\n", tic, GetLastError());
 		free(p);
-		return 0;
+		return NULL;
 	}
 
 	return p;


### PR DESCRIPTION
The first call to GetTokenInformation is used to determine the size of a TokenInformation buffer.
It should fail and return ERROR_INSUFFICIENT_BUFFER

Follow-up to 98bbe83.