### PR TITLE
[REGEDIT] Improve importing registry files messagebox CORE-15494

### DIFF
--- a/base/applications/regedit/regedit.c
+++ b/base/applications/regedit/regedit.c
@@ -140,16 +140,31 @@ BOOL PerformRegAction(REGEDIT_ACTION action, LPWSTR s, BOOL silent)
         {
             WCHAR szText[512];
             WCHAR filename[MAX_PATH];
+            LPWSTR command_line = s;
+            UINT count = 0, mbType = MB_YESNO;
             FILE *fp;
 
-            get_file_name(&s, filename);
-            if (!filename[0])
+            get_file_name(&command_line, filename);
+            while (filename[0])
+            {
+                count++;
+                get_file_name(&command_line, filename);
+            }
+
+            if (count == 0)
             {
                 InfoMessageBox(NULL, MB_OK | MB_ICONINFORMATION, NULL, L"No file name is specified.");
                 InfoMessageBox(NULL, MB_OK | MB_ICONINFORMATION, szTitle, usage);
                 exit(4);
             }
 
+            if (count > 1)
+            {
+                /* Enable three buttons if we have more than one file */
+                mbType = MB_YESNOCANCEL;
+            }
+
+            get_file_name(&s, filename);
             while (filename[0])
             {
                 /* Request import confirmation */
@@ -159,7 +174,7 @@ BOOL PerformRegAction(REGEDIT_ACTION action, LPWSTR s, BOOL silent)
 
                     LoadStringW(hInst, IDS_IMPORT_PROMPT, szText, COUNT_OF(szText));
 
-                    choice = InfoMessageBox(NULL, MB_YESNOCANCEL | MB_ICONWARNING, szTitle, szText, filename);
+                    choice = InfoMessageBox(NULL, mbType | MB_ICONQUESTION, szTitle, szText, filename);
 
                     switch (choice)
                     {


### PR DESCRIPTION
## Purpose

Improve the messagebox responsible for importing the data from the *.reg file in Regedit.
Now it looks same as in Windows. The only difference is the translations, but I think it is not necessarily to make them identical to MS ones.

JIRA issue: [CORE-15494](https://jira.reactos.org/browse/CORE-15494)

## Proposed changes

- Remove "Cancel" button, since "No" and "Cancel" buttons do exactly the same thing. They both close the messagebox without applying the .reg file content and without terminating all other messageboxes if there is more than one.
Also remove IDCANCEL case for this.
- Disable Close button by setting the messagebox's window class style to `CS_NOCLOSE`, same as it done in Windows Regedit. Now it is not clickable, but still visible.
- Change the messagebox's icon type from warning icon to question icon, because this is done in Windows Regedit too.

## Result

Before:
![regedit_before](https://user-images.githubusercontent.com/26385117/88344962-88d41e00-cd4d-11ea-8d01-af141dfa1004.png)

- The "Cancel" button is here.
- The Close button is enabled (clickable).
- The message icon type is warning (exclamation).

After:
![regedit_after](https://user-images.githubusercontent.com/26385117/88345147-05ff9300-cd4e-11ea-8a5a-b56e29901607.png)

- There is no more "Cancel" button, only "Yes" and "No".
- The Close button is now disabled (not clickable).
- The message icon type is question.