### PR TITLE
[NTDLL_APITEST] Add NtXxxSystemEnvironmentValueEx testcases

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -29,6 +29,7 @@ list(APPEND SOURCE
     NtQueryInformationThread.c
     NtQueryKey.c
     NtQuerySystemEnvironmentValue.c
+    NtQuerySystemEnvironmentValueEx.c
     NtQuerySystemInformation.c
     NtQueryVolumeInformationFile.c
     NtReadFile.c
@@ -36,6 +37,7 @@ list(APPEND SOURCE
     NtSetInformationFile.c
     NtSetInformationProcess.c
     NtSetInformationThread.c
+    NtSetSystemEnvironmentValueEx.c
     NtSetValueKey.c
     NtSetVolumeInformationFile.c
     NtUnloadDriver.c

--- a/modules/rostests/apitests/ntdll/NtQuerySystemEnvironmentValueEx.c
+++ b/modules/rostests/apitests/ntdll/NtQuerySystemEnvironmentValueEx.c
@@ -1,0 +1,17 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtQuerySystemEnvironmentValueEx
+ * COPYRIGHT:       Copyright 2020 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+
+START_TEST(NtQuerySystemEnvironmentValueEx)
+{
+    NTSTATUS Status;
+
+    /* Do nothing, the function isn't implemented in Windows Server 2003 (Service Pack 2) */
+    Status = NtQuerySystemEnvironmentValueEx(NULL, NULL, NULL, NULL, NULL);
+    ok_hex(Status, STATUS_NOT_IMPLEMENTED);
+}

--- a/modules/rostests/apitests/ntdll/NtSetSystemEnvironmentValueEx.c
+++ b/modules/rostests/apitests/ntdll/NtSetSystemEnvironmentValueEx.c
@@ -1,0 +1,17 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtSetSystemEnvironmentValueEx
+ * COPYRIGHT:       Copyright 2020 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+
+START_TEST(NtSetSystemEnvironmentValueEx)
+{
+    NTSTATUS Status;
+
+    /* Do nothing, the function isn't implemented in Windows Server 2003 (Service Pack 2) */
+    Status = NtSetSystemEnvironmentValueEx(NULL, NULL, NULL, NULL, NULL);
+    ok_hex(Status, STATUS_NOT_IMPLEMENTED);
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -27,6 +27,7 @@ extern void func_NtQueryInformationProcess(void);
 extern void func_NtQueryInformationThread(void);
 extern void func_NtQueryKey(void);
 extern void func_NtQuerySystemEnvironmentValue(void);
+extern void func_NtQuerySystemEnvironmentValueEx(void);
 extern void func_NtQuerySystemInformation(void);
 extern void func_NtQueryVolumeInformationFile(void);
 extern void func_NtReadFile(void);
@@ -34,6 +35,7 @@ extern void func_NtSaveKey(void);
 extern void func_NtSetInformationFile(void);
 extern void func_NtSetInformationProcess(void);
 extern void func_NtSetInformationThread(void);
+extern void func_NtSetSystemEnvironmentValueEx(void);
 extern void func_NtSetValueKey(void);
 extern void func_NtSetVolumeInformationFile(void);
 extern void func_NtSystemInformation(void);
@@ -101,6 +103,7 @@ const struct test winetest_testlist[] =
     { "NtQueryInformationThread",       func_NtQueryInformationThread },
     { "NtQueryKey",                     func_NtQueryKey },
     { "NtQuerySystemEnvironmentValue",  func_NtQuerySystemEnvironmentValue },
+    { "NtQuerySystemEnvironmentValueEx", func_NtQuerySystemEnvironmentValueEx },
     { "NtQuerySystemInformation",       func_NtQuerySystemInformation },
     { "NtQueryVolumeInformationFile",   func_NtQueryVolumeInformationFile },
     { "NtReadFile",                     func_NtReadFile },
@@ -108,6 +111,7 @@ const struct test winetest_testlist[] =
     { "NtSetInformationFile",           func_NtSetInformationFile },
     { "NtSetInformationProcess",        func_NtSetInformationProcess },
     { "NtSetInformationThread",         func_NtSetInformationThread },
+    { "NtSetSystemEnvironmentValueEx",  func_NtSetSystemEnvironmentValueEx },
     { "NtSetValueKey",                  func_NtSetValueKey},
     { "NtSetVolumeInformationFile",     func_NtSetVolumeInformationFile },
     { "NtSystemInformation",            func_NtSystemInformation },


### PR DESCRIPTION
## Purpose
As `NtQuery/Set` functions aren't implemented in Windows Server 2003 either, the APITEST confirms this case.
**Windows Server 2003**
![Capture](https://user-images.githubusercontent.com/34916900/88399417-1f90f100-cdc7-11ea-9780-70968ad6e914.PNG)
**ReactOS**
![Capture2](https://user-images.githubusercontent.com/34916900/88399430-261f6880-cdc7-11ea-9ffb-ad254c96ac49.PNG)
