### PR TITLE
[NTOS:MM] Replace ASSERT by UNIMPLEMENTED_ONCE macro for unimplemented code path CORE-16478

### DIFF
--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -2303,7 +2303,7 @@ MiRemoveMappedPtes(IN PVOID BaseAddress,
                 ProtoPte = MiProtoPteToPte(&PteContents);
 
                 /* We don't support anything else atm */
-                ASSERT(ProtoPte->u.Long == 0);
+                if (ProtoPte->u.Long != 0) UNIMPLEMENTED_ONCE;
             }
         }
 


### PR DESCRIPTION
## Purpose

Replace the `ASSERT` by `UNIMPLEMENTED_ONCE` macro with checking the data of `ProtoPte` variable for unimplemented code path in `MiRemoveMappedPtes` function of our MM.
It seems to me that asserts should not be used in unimplemented code paths, so I replaced it by the correct macro instead.
It allows ReactOS win32k Frankenstein no longer hang (in debug builds) when using any apps which require layered window support (e. g. RocketDock 1.3.5) and also in some other cases, like when trying to use VirtualBox display integration mode.

JIRA issue: [CORE-16478](https://jira.reactos.org/browse/CORE-16478)

## Result

RocketDock 1.3.5:
![RocketDock_MS_Win32SS_fixed](https://user-images.githubusercontent.com/26385117/88908449-89474a00-d262-11ea-9311-023b26787da2.gif)

VirtualBox 5.1.38 display integration mode:
![VBox_mode_after](https://user-images.githubusercontent.com/26385117/88908606-bf84c980-d262-11ea-9b81-73e4f0bd522f.png)