### PR TITLE
[DRIVERS] Fix pool memory disclsoure in CreateDiskDeviceObject of disk driver

### DIFF
--- a/drivers/storage/class/disk/disk.c
+++ b/drivers/storage/class/disk/disk.c
@@ -902,6 +902,7 @@ Return Value:
         goto CreateDiskDeviceObjectsExit;
     }
 
+    RtlZeroMemory(diskGeometry, sizeof(DISK_GEOMETRY_EX));
     deviceExtension->DiskGeometry = diskGeometry;
 
     //


### PR DESCRIPTION
## Purpose

Fix pool memory disclosure in CreateDiskDeviceObject of disk driver.

## Analysis

There are padding bytes at the end of structure `DISK_GEOMETRY_EX`

```
kd> dt DISK_GEOMETRY_EX
nt!DISK_GEOMETRY_EX
   +0x000 Geometry         : _DISK_GEOMETRY
   +0x018 DiskSize         : _LARGE_INTEGER
   +0x020 Data             : [1] UChar
kd> ??sizeof(DISK_GEOMETRY_EX)
unsigned int 0x28
```

Disk driver uses this structure at https://github.com/reactos/reactos/blob/b68104dd87b61c361c327cf44cc8845436c924ec/drivers/storage/class/disk/disk.c#L895-L905 and then it will copy value into user land memory via `SystemBuffer` of IRP at https://github.com/reactos/reactos/blob/b68104dd87b61c361c327cf44cc8845436c924ec/drivers/storage/class/disk/disk.c#L2284-L2286

To trigger this bug, run `kernel32_apitest.exe DeviceIoControl` of rosautotest in command prompt.

Stack trace from bochspwn-reloaded:

```
 #0  0x805454dd ((001454dd) ntoskrnl.exe!memcpy+3d)
 #1  0x8046edc7 ((0006edc7) ntoskrnl.exe!IopCompleteRequest+1b7 [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 292])
 #2  0x8048483c ((0008483c) ntoskrnl.exe!KiDeliverApc+16c [h:\project\reactos\ntoskrnl\ke\apc.c @ 375])
 #3  0x802b6acf ((0000dacf) hal.dll!VendorTable+827f)
 #4  0x802b633c ((0000d33c) hal.dll!VendorTable+7aec)
 #5  0x802b7420 ((0000e420) hal.dll!VendorTable+8bd0)
 #6  0x802b6545 ((0000d545) hal.dll!VendorTable+7cf5)
 #7  0x804918ff ((000918ff) ntoskrnl.exe!KiExitDispatcher+14f [h:\project\reactos\ntoskrnl\ke\wait.c @ 266])
 #8  0x80484512 ((00084512) ntoskrnl.exe!KeInsertQueueApc+e2 [h:\project\reactos\ntoskrnl\ke\apc.c @ 769])
 #9  0x8046d7fb ((0006d7fb) ntoskrnl.exe!IofCompleteRequest+56b [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 1578])
 #10  0xf7a6268f ((0000768f) disk.sys!ScsiDiskDeviceControl+182f [h:\project\reactos\drivers\storage\class\disk\disk.c @ 2960])
 #11  0xf7a50bc5 ((00002bc5) class2.sys!ScsiClassDeviceControlDispatch+85 [h:\project\reactos\drivers\storage\class\class2\class2.c @ 3912])
 #12  0x8046d27d ((0006d27d) ntoskrnl.exe!IofCallDriver+ad [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 1288])
 #13  0x80466642 ((00066642) ntoskrnl.exe!IopPerformSynchronousRequest+32 [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 142])
 #14  0x80465eae ((00065eae) ntoskrnl.exe!IopDeviceFsIoControl+7fe [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 646])
 #15  0x80466b64 ((00066b64) ntoskrnl.exe!NtDeviceIoControlFile+34 [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 1451])
 #16  0x805197fb ((001197fb) ntoskrnl.exe!KiSystemCallTrampoline+1b [h:\project\reactos\ntoskrnl\include\internal\i386\ke.h @ 766])
 #17  0x8051778c ((0011778c) ntoskrnl.exe!KiSystemServiceHandler+25c [h:\project\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1833])
 #18  0x80403da3 ((00003da3) ntoskrnl.exe!KiFastCallEntry+8c)
```
