### PR TITLE
[Win32SS][GDI] Fix pool memory disclosure in NtGdiGetGlyphOutline

### DIFF
--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -743,13 +743,12 @@ NtGdiGetGlyphOutline(
 
   if (UnsafeBuf && cjBuf)
   {
-     pvBuf = ExAllocatePoolWithTag(PagedPool, cjBuf, GDITAG_TEXT);
+     pvBuf = ExAllocatePoolZero(PagedPool, cjBuf, GDITAG_TEXT);
      if (!pvBuf)
      {
         EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
         goto Exit;
      }
-     RtlZeroMemory(pvBuf, cjBuf);
   }
 
   Ret = ftGdiGetGlyphOutline( dc,

--- a/win32ss/gdi/ntgdi/font.c
+++ b/win32ss/gdi/ntgdi/font.c
@@ -749,6 +749,7 @@ NtGdiGetGlyphOutline(
         EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
         goto Exit;
      }
+     RtlZeroMemory(pvBuf, cjBuf);
   }
 
   Ret = ftGdiGetGlyphOutline( dc,


### PR DESCRIPTION
## Purpose

Fix pool memory disclosure in NtGdiGetGlyphOutline.

## Analysis

The value of `pvBuf` will be initialized in function `ftGdiGetGlyphOutline`. But in some cases like https://github.com/reactos/reactos/blob/52fb8c1a8d1d1ef2ddb46c017b461011b26188ee/win32ss/gdi/ntgdi/freetype.c#L4016-L4017 `ftGdiGetGlyphOutline` will return without initializing `pvBuf` so it will lead to memory disclosure when execute this https://github.com/reactos/reactos/blob/50510538db49b58b3364a0938a82879bc08890a3/win32ss/gdi/ntgdi/font.c#L767-L768

I guess this is a bug pattern when initializer function does a comparison then return immediately without initializing.
## TODO

~~- [ ] Remove redundant RtlZeroMemory functions in `ftGdiGetGlyphOutline`~~
