### PR TITLE
[MOUNTMGR] Fix pool memory disclosure in QueryPointsFromMemory

### DIFF
--- a/drivers/filters/mountmgr/point.c
+++ b/drivers/filters/mountmgr/point.c
@@ -335,6 +335,7 @@ QueryPointsFromMemory(IN PDEVICE_EXTENSION DeviceExtension,
     /* Now, ensure output buffer can hold everything */
     Stack = IoGetCurrentIrpStackLocation(Irp);
     MountPoints = (PMOUNTMGR_MOUNT_POINTS)Irp->AssociatedIrp.SystemBuffer;
+    RtlZeroMemory(MountPoints, Stack->Parameters.DeviceIoControl.OutputBufferLength);
 
     /* Ensure we set output to let user reallocate! */
     MountPoints->Size = sizeof(MOUNTMGR_MOUNT_POINTS) + TotalSymLinks * sizeof(MOUNTMGR_MOUNT_POINT) + TotalSize;


### PR DESCRIPTION
## Purpose

Fix pool memory disclosure in QueryPointsFromMemory of mountmgr driver

## Analysis

The memory disclosure happens when the comparison https://github.com/reactos/reactos/blob/a058e680b662ad4aca76e1fe4803fe033c124aa2/drivers/filters/mountmgr/point.c#L344-L354 is true or the loop at https://github.com/reactos/reactos/blob/a058e680b662ad4aca76e1fe4803fe033c124aa2/drivers/filters/mountmgr/point.c#L359-L361 doesn't execute (in case `DeviceEntry == &(DeviceExtension->DeviceListHead`) then `MountPoints` will be uninitialized.

Additional, structure type of `MountPoints` is MOUNTMGR_MOUNT_POINTS which has padding bytes.

```
kd> dt -b MOUNTMGR_MOUNT_POINTS
mountmgr_apitest!MOUNTMGR_MOUNT_POINTS
   +0x000 Size             : Uint4B
   +0x004 NumberOfMountPoints : Uint4B
   +0x008 MountPoints      : _MOUNTMGR_MOUNT_POINT
      +0x000 SymbolicLinkNameOffset : Uint4B
      +0x004 SymbolicLinkNameLength : Uint2B
      +0x008 UniqueIdOffset   : Uint4B
      +0x00c UniqueIdLength   : Uint2B
      +0x010 DeviceNameOffset : Uint4B
      +0x014 DeviceNameLength : Uint2B
kd> ??sizeof(MOUNTMGR_MOUNT_POINTS)
unsigned int 0x20
```

2 padding bytes after `SymbolicLinkNameLength`, 2 padding bytes after `UniqueIdLength` and 2 bytes after `DeviceNameLength`.

To trigger this bug, run `mountmgr_apitest.exe` of rosautotest in command prompt.

Stack trace of bochspwn-reloaded:

```
 #0  0x805454dd ((001454dd) ntoskrnl.exe!memcpy+3d)
 #1  0x8046edc7 ((0006edc7) ntoskrnl.exe!IopCompleteRequest+1b7 [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 292])
 #2  0x8048483c ((0008483c) ntoskrnl.exe!KiDeliverApc+16c [h:\project\reactos\ntoskrnl\ke\apc.c @ 375])
 #3  0x802b6acf ((0000dacf) hal.dll!VendorTable+827f)
 #4  0x802b633c ((0000d33c) hal.dll!VendorTable+7aec)
 #5  0x802b7420 ((0000e420) hal.dll!VendorTable+8bd0)
 #6  0x802b6545 ((0000d545) hal.dll!VendorTable+7cf5)
 #7  0x804918ff ((000918ff) ntoskrnl.exe!KiExitDispatcher+14f [h:\project\reactos\ntoskrnl\ke\wait.c @ 266])
 #8  0x80484512 ((00084512) ntoskrnl.exe!KeInsertQueueApc+e2 [h:\project\reactos\ntoskrnl\ke\apc.c @ 769])
 #9  0x8046d7fb ((0006d7fb) ntoskrnl.exe!IofCompleteRequest+56b [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 1578])
 #10  0xf7a82e0f ((00004e0f) mountmgr.sys!MountMgrDeviceControl+40f [h:\project\reactos\drivers\filters\mountmgr\device.c @ 2811])
 #11  0x8046d27d ((0006d27d) ntoskrnl.exe!IofCallDriver+ad [h:\project\reactos\ntoskrnl\io\iomgr\irp.c @ 1288])
 #12  0x80466642 ((00066642) ntoskrnl.exe!IopPerformSynchronousRequest+32 [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 142])
 #13  0x80465eae ((00065eae) ntoskrnl.exe!IopDeviceFsIoControl+7fe [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 646])
 #14  0x80466b64 ((00066b64) ntoskrnl.exe!NtDeviceIoControlFile+34 [h:\project\reactos\ntoskrnl\io\iomgr\iofunc.c @ 1451])
 #15  0x805197fb ((001197fb) ntoskrnl.exe!KiSystemCallTrampoline+1b [h:\project\reactos\ntoskrnl\include\internal\i386\ke.h @ 766])
 #16  0x8051778c ((0011778c) ntoskrnl.exe!KiSystemServiceHandler+25c [h:\project\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1833])
 #17  0x80403da3 ((00003da3) ntoskrnl.exe!KiFastCallEntry+8c)
```
