### PR TITLE
[Win32SS][USER] Fix stack memory disclosure in NtUserBuildPropList

### DIFF
--- a/win32ss/user/ntuser/prop.c
+++ b/win32ss/user/ntuser/prop.c
@@ -143,7 +143,7 @@ NtUserBuildPropList(
     PWND Window;
     PPROPERTY Property;
     PLIST_ENTRY ListEntry;
-    PROPLISTITEM listitem, *li;
+    PROPLISTITEM listitem = { 0 }, *li;
     NTSTATUS Status;
     DWORD Cnt = 0;
 


### PR DESCRIPTION
## Purpose

Fix structure alignment cause to stack memory disclosure in NtUserBuildPropList

## Analysis
```
kd> dt win32k!PROPLISTITEM
   +0x000 Atom             : Uint2B
   +0x004 Data             : Ptr32 Void
kd> ??sizeof(PROPLISTITEM)
unsigned int 8
```

There are 2 padding bytes after field `Atom` and that structure is type of local variable `listitem`, value of `listitem` will be copied into user land memory at https://github.com/reactos/reactos/blob/c2c66aff7dacc62d125f2cd61d1167e9a2aa3fd6/win32ss/user/ntuser/prop.c#L181 so it leads to memory disclosure.
