### PR TITLE
[NTOS:PS] Fix stack memory disclosure in PsGetContextThread

### DIFF
--- a/ntoskrnl/ps/debug.c
+++ b/ntoskrnl/ps/debug.c
@@ -112,7 +112,7 @@ PsGetContextThread(IN PETHREAD Thread,
     /* Enter SEH */
     _SEH2_TRY
     {
-        /* Set default ength */
+        /* Set default length */
         Size = sizeof(CONTEXT);
 
         /* Read the flags */
@@ -146,6 +146,7 @@ PsGetContextThread(IN PETHREAD Thread,
     KeInitializeEvent(&GetSetContext.Event, NotificationEvent, FALSE);
 
     /* Set the flags and previous mode */
+    RtlZeroMemory(&GetSetContext.Context, Size);
     GetSetContext.Context.ContextFlags = Flags;
     GetSetContext.Mode = PreviousMode;
 


### PR DESCRIPTION
## Purpose

Fix stack memory disclosure in PsGetContextThread.

## Analysis

There is only one field of `GetSetContext.Context` is initialized at https://github.com/reactos/reactos/blob/8723be733c9fdc865fbd7ff4f7bac7a19ed301fa/ntoskrnl/ps/debug.c#L149 but `GetSetContext.Context` still be used to copy into user land memory at https://github.com/reactos/reactos/blob/8723be733c9fdc865fbd7ff4f7bac7a19ed301fa/ntoskrnl/ps/debug.c#L207 so it leads to stack memory disclosure.
