### PR TITLE
[IMM32][NTUSER] Implement ImmGetHotKey

### DIFF
--- a/dll/win32/imm32/CMakeLists.txt
+++ b/dll/win32/imm32/CMakeLists.txt
@@ -14,6 +14,6 @@ list(APPEND SOURCE
 
 add_library(imm32 MODULE ${SOURCE} version.rc)
 set_module_type(imm32 win32dll)
-target_link_libraries(imm32 wine)
+target_link_libraries(imm32 wine win32ksys)
 add_importlibs(imm32 advapi32 user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET imm32 DESTINATION reactos/system32 FOR all)

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3161,6 +3161,8 @@ BOOL WINAPI ImmEnumInputContext(DWORD idThread, IMCENUMPROC lpfn, LPARAM lParam)
  */
 
 #ifdef __REACTOS__
+BOOL APIENTRY NtUserGetImeHotKey(DWORD, LPUINT, LPUINT, LPHKL); /* FIXME */
+
 BOOL WINAPI
 ImmGetHotKey(IN DWORD dwHotKey,
              OUT LPUINT lpuModifiers,

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3160,11 +3160,25 @@ BOOL WINAPI ImmEnumInputContext(DWORD idThread, IMCENUMPROC lpfn, LPARAM lParam)
  *              ImmGetHotKey(IMM32.@)
  */
 
+#ifdef __REACTOS__
+BOOL WINAPI
+ImmGetHotKey(IN DWORD dwHotKey,
+             OUT LPUINT lpuModifiers,
+             OUT LPUINT lpuVKey,
+             OUT LPHKL lphKL)
+{
+    TRACE("%lx, %p, %p, %p\n", dwHotKey, lpuModifiers, lpuVKey, lphKL);
+    if (lpuModifiers && lpuVKey)
+        return NtUserGetImeHotKey(dwHotKey, lpuModifiers, lpuVKey, lphKL);
+    return FALSE;
+}
+#else
 BOOL WINAPI ImmGetHotKey(DWORD hotkey, UINT *modifiers, UINT *key, HKL hkl)
 {
     FIXME("%x, %p, %p, %p: stub\n", hotkey, modifiers, key, hkl);
     return FALSE;
 }
+#endif
 
 /***********************************************************************
  *              ImmDisableLegacyIME(IMM32.@)

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -22,6 +22,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#ifdef __REACTOS__
+#define WIN32_NO_STATUS
+#endif
 #include "windef.h"
 #include "winbase.h"
 #include "wingdi.h"
@@ -33,6 +36,11 @@
 #include "winnls.h"
 #include "winreg.h"
 #include "wine/list.h"
+#ifdef __REACTOS__
+#include <ndk/umtypes.h>
+#include <ndk/pstypes.h>
+#include "../../../win32ss/include/ntuser.h"
+#endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
@@ -3161,8 +3169,6 @@ BOOL WINAPI ImmEnumInputContext(DWORD idThread, IMCENUMPROC lpfn, LPARAM lParam)
  */
 
 #ifdef __REACTOS__
-BOOL APIENTRY NtUserGetImeHotKey(DWORD, LPUINT, LPUINT, LPHKL); /* FIXME */
-
 BOOL WINAPI
 ImmGetHotKey(IN DWORD dwHotKey,
              OUT LPUINT lpuModifiers,

--- a/sdk/include/psdk/imm.h
+++ b/sdk/include/psdk/imm.h
@@ -27,6 +27,9 @@ extern "C" {
 
 typedef HANDLE HIMC;
 typedef HANDLE HIMCC;
+#ifdef __REACTOS__
+typedef HKL *LPHKL;
+#endif
 
 typedef struct tagREGISTERWORDA {
     LPSTR lpReading;

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2278,13 +2278,11 @@ NtUserGetIconSize(
     LONG *plcx,
     LONG *plcy);
 
-DWORD
-NTAPI
-NtUserGetImeHotKey(
-    DWORD Unknown0,
-    DWORD Unknown1,
-    DWORD Unknown2,
-    DWORD Unknown3);
+BOOL NTAPI
+NtUserGetImeHotKey(IN DWORD dwHotKey,
+                   OUT LPUINT lpuModifiers,
+                   OUT LPUINT lpuVKey,
+                   OUT LPHKL lphKL);
 
 DWORD
 NTAPI

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -36,18 +36,15 @@ IntImmProcessKey(PUSER_MESSAGE_QUEUE MessageQueue, PWND pWnd, UINT Msg, WPARAM w
     return 0;
 }
 
-
-DWORD
-APIENTRY
-NtUserGetImeHotKey(
-   DWORD Unknown0,
-   DWORD Unknown1,
-   DWORD Unknown2,
-   DWORD Unknown3)
+BOOL WINAPI
+NtUserGetImeHotKey(IN DWORD dwHotKey,
+                   OUT LPUINT lpuModifiers,
+                   OUT LPUINT lpuVKey,
+                   OUT LPHKL lphKL)
 {
    STUB
 
-   return 0;
+   return FALSE;
 }
 
 DWORD


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

- Implement `imm32!ImmGetHotKey` function.
- Modify `NtUserGetImeHotKey` function.
- Add `LPHKL` typedef into `<imm.h>` header.