### PR TITLE
[IMM32][NTUSER] Add ImmGetImeInfoEx

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3242,4 +3242,31 @@ BOOL WINAPI ImmRegisterClient(PVOID ptr, /* FIXME: should point to SHAREDINFO st
     FIXME("Stub\n");
     return TRUE;
 }
+
+/***********************************************************************
+ *              ImmGetImeInfoEx (IMM32.@)
+ */
+BOOL WINAPI
+ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx,
+                IMEINFOEXCLASS SearchType,
+                PVOID pvSearchKey)
+{
+    switch (SearchType)
+    {
+        case ImeInfoExKeyboardLayout:
+            pImeInfoEx->hkl = *(LPHKL)pvSearchKey;
+            if (!IS_IME_HKL(pImeInfoEx->hkl))
+                return FALSE;
+            break;
+
+        case ImeInfoExImeFileName:
+            lstrcpynW(pImeInfoEx->wszImeFile, (LPWSTR)pvSearchKey,
+                      ARRAY_SIZE(pImeInfoEx->wszImeFile));
+            break;
+
+        default:
+            return FALSE;
+    }
+    return NtUserGetImeInfoEx(pImeInfoEx, SearchType);
+}
 #endif

--- a/dll/win32/imm32/imm32.spec
+++ b/dll/win32/imm32/imm32.spec
@@ -46,7 +46,7 @@
 @ stdcall ImmGetIMCLockCount(long)
 @ stdcall ImmGetIMEFileNameA(long ptr long)
 @ stdcall ImmGetIMEFileNameW(long ptr long)
-@ stub ImmGetImeInfoEx
+@ stdcall ImmGetImeInfoEx(ptr long ptr)
 @ stdcall ImmGetImeMenuItemsA(long long long ptr ptr long)
 @ stdcall ImmGetImeMenuItemsW(long long long ptr ptr long)
 @ stdcall ImmGetOpenStatus(long)

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1174,6 +1174,14 @@ typedef struct tagIMEINFOEX
     };
 } IMEINFOEX, *PIMEINFOEX;
 
+typedef enum IMEINFOEXCLASS
+{
+    ImeInfoExKeyboardLayout,
+    ImeInfoExImeFileName
+} IMEINFOEXCLASS;
+
+#define IS_IME_HKL(hkl) ((((ULONG_PTR)(hkl)) & 0xF0000000) == 0xE0000000)
+
 typedef struct tagIMEUI
 {
     PWND spwnd;
@@ -2284,11 +2292,11 @@ NtUserGetImeHotKey(IN DWORD dwHotKey,
                    OUT LPUINT lpuVKey,
                    OUT LPHKL lphKL);
 
-DWORD
+BOOL
 NTAPI
 NtUserGetImeInfoEx(
     PIMEINFOEX pImeInfoEx,
-    DWORD dwUnknown2);
+    IMEINFOEXCLASS SearchType);
 
 DWORD
 NTAPI

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -103,14 +103,14 @@ NtUserGetAppImeLevel(
     return 0;
 }
 
-DWORD
+BOOL
 APIENTRY
 NtUserGetImeInfoEx(
     PIMEINFOEX pImeInfoEx,
-    DWORD dwUnknown2)
+    IMEINFOEXCLASS SearchType)
 {
     STUB;
-    return 0;
+    return FALSE;
 }
 
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

- Add the definition of `imm32!ImmGetImeInfoEx` function.
- Add `IMEINFOEXCLASS` and `IS_IME_HKL` into `"ntuser.h"`.
- Modify `NtUserGetImeInfoEx` function prototype.