### PR TITLE
[XDK] Fix compilation with MSVC version 19.28

### DIFF
--- a/sdk/include/xdk/interlocked.h
+++ b/sdk/include/xdk/interlocked.h
@@ -299,6 +299,7 @@
 #define InterlockedXor64NoFence __NF_(_InterlockedXor64)
 #endif /* _M_ARM */
 
+#if !(defined(_MSC_VER) && _MSC_VER >= 1928)
 #ifdef _M_IX86
 
 FORCEINLINE
@@ -535,4 +536,5 @@ _InterlockedBitTestAndComplement64(
 }
 
 #endif /* M_IA64 */
+#endif /* MSVC >= 1928 */
 


### PR DESCRIPTION
## Purpose

This version of MSVC (included in VS 16.8 preview 1) introduces a change wherein it treats the definition of any intrinsic function (such as those in xdk/interlocked.h) as a fatal error. Use of `/Oi-` to suppress intrinsics use does not help here. I have verified that this code is still valid under GCC.

JIRA issue: [CORE-17190](https://jira.reactos.org/browse/CORE-17190)

## Proposed changes

- `#if` out the offending code.
