### PR TITLE
[APPWIZ] Don't hung up in Gecko download cancellation

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -59,7 +59,7 @@ static const addon_info_t addons_info[] = {
 static const addon_info_t *addon;
 
 static HWND install_dialog = NULL;
-static IBinding *download_binding;
+static IBinding *download_binding = NULL;
 
 static WCHAR GeckoUrl[] = L"https://svn.reactos.org/amine/wine_gecko-2.40-x86.msi";
 
@@ -382,7 +382,7 @@ static DWORD WINAPI download_proc(PVOID arg)
     }
 
     DeleteFileW(tmp_file);
-    EndDialog(install_dialog, 0);
+    PostMessageW(install_dialog, WM_COMMAND, IDCANCEL, 0);
     return 0;
 }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14538](https://jira.reactos.org/browse/CORE-14538)

- Do not call `EndDialog` outside the dialog procedure.

![1](https://user-images.githubusercontent.com/2107452/90255913-e9073d00-de7f-11ea-8deb-b126606597a6.png)
![2](https://user-images.githubusercontent.com/2107452/90255915-e99fd380-de7f-11ea-9532-390fe3ff345e.png)
![3](https://user-images.githubusercontent.com/2107452/90255908-e7d61000-de7f-11ea-9ac7-80f3e5774535.png)