### PR TITLE
[TASKMGR] Chooseable page after 'Go To Process'

### DIFF
--- a/base/applications/taskmgr/applpage.c
+++ b/base/applications/taskmgr/applpage.c
@@ -950,7 +950,11 @@ void ApplicationPage_OnGotoProcess(void)
         /*
          * Switch to the process tab
          */
-        TabCtrl_SetCurFocus(hTabWnd, 1);
+        TabCtrl_SetCurSel(hTabWnd, 1);
+        {
+            NMHDR nmhdr = { hTabWnd, IDC_TAB, TCN_SELCHANGE };
+            SendMessageW(hTabWnd, WM_NOTIFY, IDC_TAB, (LPARAM)&nmhdr);
+        }
         /*
          * Select the process item in the list
          */


### PR DESCRIPTION
## Purpose

JIRA issue: N/A

- Manually send `WM_NOTIFY` message after `TabCtrl_SetCurSel` call.

![1](https://user-images.githubusercontent.com/2107452/90301923-b429d300-dedd-11ea-949f-a7a90e86a36b.png)
![2](https://user-images.githubusercontent.com/2107452/90301925-b429d300-dedd-11ea-9a71-176243b8a8cb.png)
![3](https://user-images.githubusercontent.com/2107452/90301922-b2f8a600-dedd-11ea-8913-adc7b086dace.png)