### PR TITLE
[NTUSER] Set ERROR_INVALID_WINDOW_HANDLE when PostMessage failed

### DIFF
--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -1423,7 +1423,7 @@ UserPostMessage( HWND Wnd,
         if ( Window->state & WNDS_DESTROYED )
         {
             ERR("Attempted to post message to window %p that is being destroyed!\n", Wnd);
-            /* FIXME: Last error code? */
+            EngSetLastError(ERROR_INVALID_WINDOW_HANDLE);
             return FALSE;
         }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12124](https://jira.reactos.org/browse/CORE-12124)

Set the last error code `ERROR_INVALID_WINDOW_HANDLE` when `user32!PostMessage` failed with destroyed window.