### PR TITLE
[TASKMGR] PerfData*CommandLine*(): Do not skip 'global_cache' last entry

### DIFF
--- a/base/applications/taskmgr/perfdata.c
+++ b/base/applications/taskmgr/perfdata.c
@@ -566,7 +566,7 @@ BOOL PerfDataGetCommandLine(ULONG Index, LPWSTR lpCommandLine, ULONG nMaxCount)
     PCMD_LINE_CACHE cache = global_cache;
 
     /* [A] Search for a string already in cache? If so, use it */
-    while (cache && cache->pnext != NULL)
+    while (cache)
     {
         if (cache->idx == Index && cache->str != NULL)
         {
@@ -575,6 +575,10 @@ BOOL PerfDataGetCommandLine(ULONG Index, LPWSTR lpCommandLine, ULONG nMaxCount)
             wcscpy(lpCommandLine + CMD_LINE_MIN(nMaxCount, cache->len) - wcslen(ellipsis), ellipsis);
             return TRUE;
         }
+
+        // Keep 'cache' pointing to the last entry, to add after it.
+        if (!cache->pnext)
+            break;
 
         cache = cache->pnext;
     }
@@ -656,17 +660,15 @@ cleanup:
     return TRUE;
 }
 
-void PerfDataDeallocCommandLineCache()
+void PerfDataDeallocCommandLineCache(void)
 {
-    PCMD_LINE_CACHE cache = global_cache;
-    PCMD_LINE_CACHE cache_old;
+    PCMD_LINE_CACHE cache_entry;
 
-    while (cache && cache->pnext != NULL)
+    while (global_cache)
     {
-        cache_old = cache;
-        cache = cache->pnext;
-
-        HeapFree(GetProcessHeap(), 0, cache_old);
+        cache_entry = global_cache;
+        global_cache = global_cache->pnext;
+        HeapFree(GetProcessHeap(), 0, cache_entry);
     }
 }
 

--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -78,7 +78,7 @@ ULONG	PerfDataGetProcessId(ULONG Index);
 BOOL	PerfDataGetUserName(ULONG Index, LPWSTR lpUserName, ULONG nMaxCount);
 
 BOOL	PerfDataGetCommandLine(ULONG Index, LPWSTR lpCommandLine, ULONG nMaxCount);
-void	PerfDataDeallocCommandLineCache();
+void	PerfDataDeallocCommandLineCache(void);
 
 ULONG	PerfDataGetSessionId(ULONG Index);
 ULONG	PerfDataGetCPUUsage(ULONG Index);


### PR DESCRIPTION
Avoids:
* Get: Playing hide and seek.
* Exit: Leaking.

Addendum to f43bb8d (r65469).