### PR TITLE
[FREELDR] Bootsector fix for CHS read on old BIOSes which lack INT 3e

### DIFF
--- a/boot/freeldr/bootsect/fat32.S
+++ b/boot/freeldr/bootsect/fat32.S
@@ -260,6 +260,7 @@ ReadSectorsCHSLoop:
 
     loop ReadSectorsCHSLoop                     // Read next sector
 
+    pop es
     ret
 
 // Displays a disk error message


### PR DESCRIPTION
## Purpose

This fixes a bug in the reactos bootcode

JIRA issue: [CORE-17178](https://jira.reactos.org/browse/CORE-17178)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- 
- 
