### PR TITLE
[ADVAPI32] SaferComputeTokenFromLevel(): Stub-plement 'SAFER_TOKEN_NULL_IF_EQUAL' case

### DIFF
--- a/dll/win32/advapi32/sec/safer.c
+++ b/dll/win32/advapi32/sec/safer.c
@@ -155,6 +155,26 @@ SaferComputeTokenFromLevel(
     _Inout_opt_ PVOID pReserved)
 {
     FIXME("(%p, %p, %p, 0x%lx, %p) stub\n", LevelHandle, InAccessToken, OutAccessToken, dwFlags, pReserved);
+
+    if (!InAccessToken)
+    {
+        FIXME("(In=NULL): Get thread/process token\n");
+    }
+
+    if (dwFlags == SAFER_TOKEN_NULL_IF_EQUAL)
+    // TODO: if (dwFlags & SAFER_TOKEN_NULL_IF_EQUAL != 0)
+    {
+        // TODO: Compare should eventually be done in other cases too.
+        FIXME("(F=SAFER_TOKEN_NULL_IF_EQUAL): Compare tokens\n");
+
+        // Default to 'not more restrictive' result.
+        *OutAccessToken = NULL;
+        TRACE("(F=SAFER_TOKEN_NULL_IF_EQUAL) returns TRUE\n");
+        return TRUE;
+    }
+
+    *OutAccessToken = (HANDLE)(ULONG_PTR)0xdeadbeefdeadbeefULL; // Extra-safety.
+    TRACE("(...) returns FALSE (Unimplemented)\n");
     SetLastError(ERROR_CALL_NOT_IMPLEMENTED);
     return FALSE;
 }


### PR DESCRIPTION
Testcase:
LiveCD > XP cmd.exe > regtest.cmd (Twice, to better see.)

For the record, it now triggers an additional log:
`(/dll/win32/kernel32/client/vdm.c:1375) CmdBatNotification() is UNIMPLEMENTED!`

JIRA issue: [CORE-14015](https://jira.reactos.org/browse/CORE-14015)