### PR TITLE
[RAPPS] cmdline enhancement

### DIFF
--- a/base/applications/rapps/CMakeLists.txt
+++ b/base/applications/rapps/CMakeLists.txt
@@ -4,6 +4,7 @@ set_cpp(WITH_RUNTIME)
 
 include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/atl)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/cryptlib)
+include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/conutils)
 include_directories(include)
 
 list(APPEND SOURCE
@@ -42,8 +43,8 @@ add_definitions(
 file(GLOB_RECURSE rapps_rc_deps res/*.*)
 add_rc_deps(rapps.rc ${rapps_rc_deps})
 add_executable(rapps ${SOURCE} rapps.rc)
-set_module_type(rapps win32gui UNICODE)
-target_link_libraries(rapps uuid wine)
+set_module_type(rapps win32cui UNICODE)
+target_link_libraries(rapps conutils ${PSEH_LIB} uuid wine)
 add_importlibs(rapps advapi32 comctl32 gdi32 wininet user32 shell32 shlwapi ole32 setupapi gdiplus msvcrt kernel32 ntdll)
 add_pch(rapps include/rapps.h SOURCE)
 add_dependencies(rapps rappsmsg)

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -51,7 +51,7 @@ HTREEITEM CSideTreeView::AddItem(HTREEITEM hParent, ATL::CStringW &Text, INT Ima
 HTREEITEM CSideTreeView::AddCategory(HTREEITEM hRootItem, UINT TextIndex, UINT IconIndex)
 {
     ATL::CStringW szText;
-    INT Index;
+    INT Index = 0;
     HICON hIcon;
 
     hIcon = (HICON)LoadImageW(hInst,
@@ -861,7 +861,7 @@ void CMainWindow::HandleTabOrder(int direction)
 
 
 
-VOID ShowMainWindow(INT nShowCmd)
+VOID MainWindowLoop(INT nShowCmd)
 {
     HACCEL KeyBrd;
     MSG Msg;

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -614,14 +614,6 @@ VOID CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
     }
 }
 
-BOOL CMainWindow::SearchPatternMatch(LPCWSTR szHaystack, LPCWSTR szNeedle)
-{
-    if (!*szNeedle)
-        return TRUE;
-    /* TODO: Improve pattern search beyond a simple case-insensitive substring search. */
-    return StrStrIW(szHaystack, szNeedle) != NULL;
-}
-
 BOOL CALLBACK CMainWindow::EnumInstalledAppProc(CInstalledApplicationInfo *Info)
 {
     if (!SearchPatternMatch(Info->szDisplayName.GetString(), szSearchPattern))

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -15,6 +15,7 @@
 #include "misc.h"
 #include "gui.h"
 #include "appview.h"
+#include "winmain.h"
 #include <shlobj_undoc.h>
 #include <shlguid_undoc.h>
 
@@ -723,7 +724,7 @@ ATL::CWndClassInfo &CMainWindow::GetWndClassInfo()
             LoadCursorW(NULL, IDC_ARROW),
             (HBRUSH)(COLOR_BTNFACE + 1),
             MAKEINTRESOURCEW(IDR_MAINMENU),
-            L"RAppsWnd",
+            szWindowClass,
             NULL
         },
         NULL, NULL, IDC_ARROW, TRUE, 0, _T("")

--- a/base/applications/rapps/include/dialogs.h
+++ b/base/applications/rapps/include/dialogs.h
@@ -9,7 +9,7 @@
 VOID CreateSettingsDlg(HWND hwnd);
 
 //Main window
-VOID ShowMainWindow(INT nShowCmd);
+VOID MainWindowLoop(INT nShowCmd);
 
 // Download dialogs
 VOID DownloadApplicationsDB(LPCWSTR lpUrl, BOOL IsOfficial);

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -98,8 +98,6 @@ private:
 
     VOID OnCommand(WPARAM wParam, LPARAM lParam);
 
-    static BOOL SearchPatternMatch(LPCWSTR szHaystack, LPCWSTR szNeedle);
-
     BOOL CALLBACK EnumInstalledAppProc(CInstalledApplicationInfo *Info);
 
     BOOL CALLBACK EnumAvailableAppProc(CAvailableApplicationInfo *Info, BOOL bInitialCheckState);

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -134,4 +134,4 @@ public:
 };
 
 
-VOID ShowMainWindow(INT nShowCmd);
+VOID MainWindowLoop(INT nShowCmd);

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -56,3 +56,5 @@ BOOL IsSystem64Bit();
 INT GetSystemColorDepth();
 
 void UnixTimeToFileTime(DWORD dwUnixTime, LPFILETIME pFileTime);
+
+BOOL SearchPatternMatch(LPCWSTR szHaystack, LPCWSTR szNeedle);

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -218,6 +218,11 @@
 #define IDS_DL_DIALOG_DB_DOWNLOAD_DISP          951
 #define IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP 952
 
+/* Command-line related strings */
+#define IDS_CMD_USAGE                           953
+#define IDS_CMD_NEED_PACKAGE_NAME               954
+#define IDS_CMD_NEED_FILE_NAME                  955
+
 /* Accelerators */
 #define HOTKEYS                  715
 

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -222,7 +222,9 @@
 #define IDS_CMD_USAGE                           953
 #define IDS_CMD_NEED_PACKAGE_NAME               954
 #define IDS_CMD_NEED_FILE_NAME                  955
-#define IDS_CMD_INVALID_OPTION                  956
+#define IDS_CMD_NEED_PARAMS                     956
+#define IDS_CMD_INVALID_OPTION                  957
+#define IDS_CMD_FIND_RESULT_FOR                 958
 
 /* Accelerators */
 #define HOTKEYS                  715

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -222,6 +222,7 @@
 #define IDS_CMD_USAGE                           953
 #define IDS_CMD_NEED_PACKAGE_NAME               954
 #define IDS_CMD_NEED_FILE_NAME                  955
+#define IDS_CMD_INVALID_OPTION                  956
 
 /* Accelerators */
 #define HOTKEYS                  715

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -225,6 +225,8 @@
 #define IDS_CMD_NEED_PARAMS                     956
 #define IDS_CMD_INVALID_OPTION                  957
 #define IDS_CMD_FIND_RESULT_FOR                 958
+#define IDS_CMD_PACKAGE_NOT_FOUND               959
+#define IDS_CMD_PACKAGE_INFO                    960
 
 /* Accelerators */
 #define HOTKEYS                  715

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -3,6 +3,7 @@
 #define CMD_KEY_INSTALL L"INSTALL"
 #define CMD_KEY_SETUP L"SETUP"
 #define CMD_KEY_FIND L"FIND"
+#define CMD_KEY_INFO L"INFO"
 #define CMD_KEY_HELP L"?"
 
 const WCHAR UsageString[] = L"RAPPS [/" CMD_KEY_HELP "] [/" CMD_KEY_INSTALL " packagename] [/" CMD_KEY_SETUP " filename]";

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -2,6 +2,9 @@
 
 #define CMD_KEY_INSTALL L"/INSTALL"
 #define CMD_KEY_SETUP L"/SETUP"
+#define CMD_KEY_HELP L"/HELP"
+
+const WCHAR UsageString[] = L"RAPPS [/INSTALL packagename] [/SETUP filename]";
 
 // return TRUE if the SETUP key was valid
-BOOL UseCmdParameters(LPWSTR lpCmdLine);
+BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow);

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -2,6 +2,7 @@
 
 #define CMD_KEY_INSTALL L"INSTALL"
 #define CMD_KEY_SETUP L"SETUP"
+#define CMD_KEY_FIND L"FIND"
 #define CMD_KEY_HELP L"?"
 
 const WCHAR UsageString[] = L"RAPPS [/" CMD_KEY_HELP "] [/" CMD_KEY_INSTALL " packagename] [/" CMD_KEY_SETUP " filename]";

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#define CMD_KEY_INSTALL L"/INSTALL"
-#define CMD_KEY_SETUP L"/SETUP"
-#define CMD_KEY_HELP L"/HELP"
+#define CMD_KEY_INSTALL L"INSTALL"
+#define CMD_KEY_SETUP L"SETUP"
+#define CMD_KEY_HELP L"HELP"
 
 const WCHAR UsageString[] = L"RAPPS [/INSTALL packagename] [/SETUP filename]";
 

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -2,8 +2,8 @@
 
 #define CMD_KEY_INSTALL L"INSTALL"
 #define CMD_KEY_SETUP L"SETUP"
-#define CMD_KEY_HELP L"HELP"
+#define CMD_KEY_HELP L"?"
 
-const WCHAR UsageString[] = L"RAPPS [/INSTALL packagename] [/SETUP filename]";
+const WCHAR UsageString[] = L"RAPPS [/?] [/INSTALL packagename] [/SETUP filename]";
 
 BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow);

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -6,5 +6,4 @@
 
 const WCHAR UsageString[] = L"RAPPS [/INSTALL packagename] [/SETUP filename]";
 
-// return TRUE if the SETUP key was valid
 BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow);

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -4,6 +4,6 @@
 #define CMD_KEY_SETUP L"SETUP"
 #define CMD_KEY_HELP L"?"
 
-const WCHAR UsageString[] = L"RAPPS [/?] [/INSTALL packagename] [/SETUP filename]";
+const WCHAR UsageString[] = L"RAPPS [/" CMD_KEY_HELP "] [/" CMD_KEY_INSTALL " packagename] [/" CMD_KEY_SETUP " filename]";
 
 BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow);

--- a/base/applications/rapps/include/winmain.h
+++ b/base/applications/rapps/include/winmain.h
@@ -2,6 +2,8 @@
 #include <windef.h>
 #include <wininet.h>
 
+extern LPCWSTR szWindowClass;
+
 //TODO: Separate main and settings related definitions
 struct SETTINGS_INFO
 {

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -264,4 +264,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -259,11 +259,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -261,5 +261,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -255,3 +255,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -260,11 +260,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -262,5 +262,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -265,4 +265,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -256,3 +256,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Datenbank-Aktualisierung…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -260,5 +260,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -260,4 +260,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -254,3 +254,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Actualizando listado…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -263,4 +263,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -258,11 +258,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -262,12 +262,12 @@ END
 
 STRINGTABLE
 BEGIN
-    IDS_CMD_USAGE "Usage: %1\n"
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -268,4 +268,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -265,5 +265,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: %1\n"
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -265,4 +265,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: %1\n"
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -259,3 +259,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Andmebaasi uuendamine…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: %1\n"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Mise à jour de la base de données…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Mise à jour de la base de données… (Non officielle)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -257,3 +257,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "מעדכן את מסד הנתונים..."
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -266,4 +266,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -261,11 +261,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -263,5 +263,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -263,4 +263,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Memperbarui database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Aggiornamento Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "データベースを更新中..."
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -265,5 +265,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -259,3 +259,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Aktualizowanie bazy programów…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -263,11 +263,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -265,4 +265,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -268,4 +268,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -257,11 +257,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -253,3 +253,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -259,5 +259,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -262,4 +262,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -259,4 +259,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -257,11 +257,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -259,5 +259,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -262,4 +262,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -253,3 +253,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Actualizar base de dados…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "A actualizar Base de dados… (Fonte não oficial)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -259,4 +259,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -269,4 +269,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -264,11 +264,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -266,4 +266,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -266,5 +266,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -260,3 +260,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Actualizare baza de date…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -255,11 +255,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -260,4 +260,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -257,4 +257,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -257,5 +257,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -251,3 +251,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Обновление базы данных…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -260,11 +260,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -262,5 +262,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -262,4 +262,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -265,4 +265,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -256,3 +256,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -264,4 +264,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -259,11 +259,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -261,4 +261,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -261,5 +261,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -255,3 +255,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -262,11 +262,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -267,4 +267,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -264,4 +264,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -258,3 +258,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Updating Database…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -264,5 +264,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -257,11 +257,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -253,3 +253,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Veri Tabanı güncelleniyor…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -259,5 +259,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -262,4 +262,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -259,4 +259,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -265,5 +265,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -263,11 +263,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -265,4 +265,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -259,3 +259,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Оновлення списку програм…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -268,4 +268,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -260,5 +260,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -254,3 +254,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "正在更新数据库…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "正在更新数据库… (非官方源)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -260,4 +260,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -263,4 +263,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -258,11 +258,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -257,11 +257,11 @@ END
 STRINGTABLE
 BEGIN
     IDS_CMD_USAGE "Usage: "
-    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
-    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
-    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
-    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
-    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
-    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
-    IDS_CMD_PACKAGE_INFO "Information about package %1:"
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name.\n"
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name.\n"
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters.\n"
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified.\n"
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:\n"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1.\n"
+    IDS_CMD_PACKAGE_INFO "Information about package %1:\n"
 END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -259,5 +259,7 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
+    IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
 END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -262,4 +262,6 @@ BEGIN
     IDS_CMD_NEED_PARAMS "Error: option %1 expects one or more parameters"
     IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
     IDS_CMD_FIND_RESULT_FOR "Find result for %1:"
+    IDS_CMD_PACKAGE_NOT_FOUND "Failed to find package %1."
+    IDS_CMD_PACKAGE_INFO "Information about package %1:"
 END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -253,3 +253,10 @@ BEGIN
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "更新資料庫…"
     IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "正在更新資料庫… (非官方源)"
 END
+
+STRINGTABLE
+BEGIN
+    IDS_CMD_USAGE "Usage: "
+    IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
+    IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+END

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -259,4 +259,5 @@ BEGIN
     IDS_CMD_USAGE "Usage: "
     IDS_CMD_NEED_PACKAGE_NAME "Error: option %1 expects one or more package name."
     IDS_CMD_NEED_FILE_NAME "Error: option %1 expects a file name."
+    IDS_CMD_INVALID_OPTION "Error: Unknown or invalid command line option specified."
 END

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -522,3 +522,11 @@ void UnixTimeToFileTime(DWORD dwUnixTime, LPFILETIME pFileTime)
     pFileTime->dwLowDateTime = (DWORD)ll;
     pFileTime->dwHighDateTime = ll >> 32;
 }
+
+BOOL SearchPatternMatch(LPCWSTR szHaystack, LPCWSTR szNeedle)
+{
+    if (!*szNeedle)
+        return TRUE;
+    /* TODO: Improve pattern search beyond a simple case-insensitive substring search. */
+    return StrStrIW(szHaystack, szNeedle) != NULL;
+}

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -150,6 +150,77 @@ BOOL HandleFindCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
     return TRUE;
 }
 
+BOOL HandleInfoCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
+{
+    if (argcLeft < 1)
+    {
+        ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_PARAMS, szCommand);
+        ConPrintf(StdOut, (LPWSTR)L"\n");
+        return FALSE;
+    }
+
+    CAvailableApps apps;
+    apps.UpdateAppsDB();
+    apps.Enum(ENUM_ALL_AVAILABLE, NULL, NULL);
+
+    for (int i = 0; i < argcLeft; i++)
+    {
+        CAvailableApplicationInfo *AppInfo = apps.FindAppByPkgName(argvLeft[i]);
+        if (!AppInfo)
+        {
+            ConResMsgPrintf(StdOut, NULL, IDS_CMD_PACKAGE_NOT_FOUND, argvLeft[i]);
+        }
+        else
+        {
+            ConResMsgPrintf(StdOut, NULL, IDS_CMD_PACKAGE_INFO, argvLeft[i]);
+            ConPrintf(StdOut, (LPWSTR)L"\n");
+            // TODO: code about extracting information from CAvailableApplicationInfo (in appview.cpp, class CAppRichEdit)
+            // is in a mess. It should be refactored, and should not placed in class CAppRichEdit.
+            // and the code here should reused that code after refactor.
+
+            ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szName);
+
+            if (AppInfo->m_szVersion)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_VERSION);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szVersion);
+            }
+
+            if (AppInfo->m_szLicense)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_LICENSE);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szLicense);
+            }
+
+            if (AppInfo->m_szSize)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_SIZE);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szSize);
+            }
+
+            if (AppInfo->m_szUrlSite)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_URLSITE);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szUrlSite);
+            }
+
+            if (AppInfo->m_szDesc)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_DESCRIPTION);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szDesc);
+            }
+
+            if (AppInfo->m_szUrlDownload)
+            {
+                ConResPrintf(StdOut, IDS_AINFO_URLDOWNLOAD);
+                ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szUrlDownload);
+            }
+        }
+        ConPrintf(StdOut, (LPWSTR)L"\n\n");
+    }
+    return TRUE;
+}
+
 BOOL HandleHelpCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
 {
     if (argcLeft != 0)
@@ -216,6 +287,10 @@ BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     else if (MatchCmdOption(argv[1], CMD_KEY_FIND))
     {
         return HandleFindCommand(argv[1], argc - 2, argv + 2);
+    }
+    else if (MatchCmdOption(argv[1], CMD_KEY_INFO))
+    {
+        return HandleInfoCommand(argv[1], argc - 2, argv + 2);
     }
     else if (MatchCmdOption(argv[1], CMD_KEY_HELP))
     {

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Functions to parse command-line flags and process them
  * COPYRIGHT:   Copyright 2017 Alexander Shaposhnikov (sanchaez@reactos.org)
+ *              Copyright 2020 He Yang                (1160386205@qq.com)
  */
 #include "rapps.h"
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -38,7 +38,7 @@ BOOL HandleInstallCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
     if (argcLeft == 0)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_PACKAGE_NAME, szCommand);
-        ConPrintf(StdOut, L"\n");
+        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
     FreeConsole();
@@ -71,7 +71,7 @@ BOOL HandleSetupCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
     if (argcLeft != 1)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_FILE_NAME, szCommand);
-        ConPrintf(StdOut, L"\n");
+        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
 
@@ -119,12 +119,12 @@ BOOL HandleHelpCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
         return FALSE;
     }
 
-    ConPrintf(StdOut, L"\n");
+    ConPrintf(StdOut, (LPWSTR)L"\n");
     ConResPuts(StdOut, IDS_APPTITLE);
-    ConPrintf(StdOut, L"\n\n");
+    ConPrintf(StdOut, (LPWSTR)L"\n\n");
 
     ConResPuts(StdOut, IDS_CMD_USAGE);
-    ConPrintf(StdOut, L"%ls\n", UsageString);
+    ConPrintf(StdOut, (LPWSTR)L"%ls\n", UsageString);
     return TRUE;
 }
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -16,7 +16,7 @@ BOOL MatchCmdOption(LPWSTR argvOption, LPCWSTR szOptToMacth)
 {
     WCHAR FirstCharList[] = { L'-', L'/' };
 
-    for (int i = 0; i < _countof(FirstCharList); i++)
+    for (UINT i = 0; i < _countof(FirstCharList); i++)
     {
         if (argvOption[0] == FirstCharList[i])
         {

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -40,7 +40,6 @@ BOOL HandleInstallCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
     if (argcLeft == 0)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_PACKAGE_NAME, szCommand);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
     FreeConsole();
@@ -73,7 +72,6 @@ BOOL HandleSetupCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
     if (argcLeft != 1)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_FILE_NAME, szCommand);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
 
@@ -132,7 +130,6 @@ BOOL HandleFindCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
     if (argcLeft < 1)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_PARAMS, szCommand);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
 
@@ -142,7 +139,6 @@ BOOL HandleFindCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
     for (int i = 0; i < argcLeft; i++)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_FIND_RESULT_FOR, argvLeft[i]);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         apps.Enum(ENUM_ALL_AVAILABLE, CmdFindAppEnum, argvLeft[i]);
         ConPrintf(StdOut, (LPWSTR)L"\n");
     }
@@ -155,7 +151,6 @@ BOOL HandleInfoCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
     if (argcLeft < 1)
     {
         ConResMsgPrintf(StdOut, NULL, IDS_CMD_NEED_PARAMS, szCommand);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
 
@@ -173,7 +168,6 @@ BOOL HandleInfoCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
         else
         {
             ConResMsgPrintf(StdOut, NULL, IDS_CMD_PACKAGE_INFO, argvLeft[i]);
-            ConPrintf(StdOut, (LPWSTR)L"\n");
             // TODO: code about extracting information from CAvailableApplicationInfo (in appview.cpp, class CAppRichEdit)
             // is in a mess. It should be refactored, and should not placed in class CAppRichEdit.
             // and the code here should reused that code after refactor.
@@ -215,8 +209,10 @@ BOOL HandleInfoCommand(LPWSTR szCommand, int argcLeft, LPWSTR *argvLeft)
                 ConResPrintf(StdOut, IDS_AINFO_URLDOWNLOAD);
                 ConPuts(StdOut, (LPWSTR)(LPCWSTR)AppInfo->m_szUrlDownload);
             }
+
+            ConPrintf(StdOut, (LPWSTR)L"\n");
         }
-        ConPrintf(StdOut, (LPWSTR)L"\n\n");
+        ConPrintf(StdOut, (LPWSTR)L"\n");
     }
     return TRUE;
 }
@@ -300,7 +296,6 @@ BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     {
         // unrecognized/invalid options
         ConResPuts(StdOut, IDS_CMD_INVALID_OPTION);
-        ConPrintf(StdOut, (LPWSTR)L"\n");
         return FALSE;
     }
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -138,7 +138,7 @@ BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
         return FALSE;
     }
 
-    if (argc == 1)
+    if (argc == 1) // RAPPS is launched without options
     {
         // Close the console, and open MainWindow
         FreeConsole();
@@ -148,21 +148,26 @@ BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 
         MainWindowLoop(nCmdShow);
     }
+    else if (MatchCmdOption(argv[1], CMD_KEY_INSTALL))
+    {
+        return HandleInstallCommand(argv[1], argc - 2, argv + 2);
+    }
+    else if (MatchCmdOption(argv[1], CMD_KEY_SETUP))
+    {
+        return HandleSetupCommand(argv[1], argc - 2, argv + 2);
+    }
+    else if (MatchCmdOption(argv[1], CMD_KEY_HELP))
+    {
+        return HandleHelpCommand(argv[1], argc - 2, argv + 2);
+    }
     else
     {
-        if (MatchCmdOption(argv[1], CMD_KEY_INSTALL))
-        {
-            return HandleInstallCommand(argv[1], argc - 2, argv + 2);
-        }
-        else if (MatchCmdOption(argv[1], CMD_KEY_SETUP))
-        {
-            return HandleSetupCommand(argv[1], argc - 2, argv + 2);
-        }
-        else if (MatchCmdOption(argv[1], CMD_KEY_HELP))
-        {
-            return HandleHelpCommand(argv[1], argc - 2, argv + 2);
-        }
+        // unrecognized/invalid options
+        ConResPuts(StdOut, IDS_CMD_INVALID_OPTION);
+        ConPrintf(StdOut, (LPWSTR)L"\n");
+        return FALSE;
     }
+
 
     return TRUE;
 }

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -12,6 +12,26 @@
 
 #include <conutils.h>
 
+BOOL MatchCmdOption(LPWSTR argvOption, LPCWSTR szOptToMacth)
+{
+    WCHAR FirstCharList[] = { L'-', L'/' };
+
+    for (int i = 0; i < _countof(FirstCharList); i++)
+    {
+        if (argvOption[0] == FirstCharList[i])
+        {
+            if (StrCmpIW(argvOption + 1, szOptToMacth) == 0)
+            {
+                return TRUE;
+            }
+            else
+            {
+                return FALSE;
+            }
+        }
+    }
+    return FALSE;
+}
 
 BOOL HandleInstallCommand(LPWSTR szCommand, int argcLeft, LPWSTR * argvLeft)
 {
@@ -130,15 +150,15 @@ BOOL ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     }
     else
     {
-        if (StrCmpIW(argv[1], CMD_KEY_INSTALL) == 0)
+        if (MatchCmdOption(argv[1], CMD_KEY_INSTALL))
         {
             return HandleInstallCommand(argv[1], argc - 2, argv + 2);
         }
-        else if (StrCmpIW(argv[1], CMD_KEY_SETUP) == 0)
+        else if (MatchCmdOption(argv[1], CMD_KEY_SETUP))
         {
             return HandleSetupCommand(argv[1], argc - 2, argv + 2);
         }
-        else if (StrCmpIW(argv[1], CMD_KEY_HELP) == 0)
+        else if (MatchCmdOption(argv[1], CMD_KEY_HELP))
         {
             return HandleHelpCommand(argv[1], argc - 2, argv + 2);
         }

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -123,7 +123,7 @@ BOOL CALLBACK CmdFindAppEnum(CAvailableApplicationInfo *Info, BOOL bInitialCheck
         return TRUE;
     }
 
-    ConPrintf(StdOut, L"%s (%s)\n", (LPCWSTR)(Info->m_szName), (LPCWSTR)(Info->m_szPkgName));
+    ConPrintf(StdOut, (LPWSTR)L"%s (%s)\n", (LPCWSTR)(Info->m_szName), (LPCWSTR)(Info->m_szPkgName));
     return TRUE;
 }
 

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -16,6 +16,8 @@
 
 #include <conutils.h>
 
+LPCWSTR szWindowClass = L"ROSAPPMGR";
+
 HWND hMainWnd;
 HINSTANCE hInst;
 SETTINGS_INFO SettingsInfo;
@@ -145,8 +147,6 @@ int wmain(int argc, wchar_t *argv[])
 {
     ConInitStdStreams(); // Initialize the Console Standard Streams
 
-    LPCWSTR szWindowClass = L"ROSAPPMGR";
-    HANDLE hMutex;
     BOOL bIsFirstLaunch;
     
     InitializeAtlModule(GetModuleHandle(NULL), TRUE);
@@ -159,17 +159,6 @@ int wmain(int argc, wchar_t *argv[])
 
     hInst = GetModuleHandle(NULL);
 
-    hMutex = CreateMutexW(NULL, FALSE, szWindowClass);
-    if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
-    {
-        /* If already started, it is found its window */
-        HWND hWindow = FindWindowW(szWindowClass, NULL);
-
-        /* Activate window */
-        ShowWindow(hWindow, SW_SHOWNORMAL);
-        SetForegroundWindow(hWindow);
-        return 1;
-    }
     bIsFirstLaunch = !LoadSettings();
     if (bIsFirstLaunch)
     {
@@ -182,9 +171,6 @@ int wmain(int argc, wchar_t *argv[])
     // parse cmd-line and perform the corresponding operation
     BOOL bSuccess = ParseCmdAndExecute(GetCommandLineW(), bIsFirstLaunch, SW_SHOWNORMAL);
     
-    if (hMutex)
-        CloseHandle(hMutex);
-
     InitializeGDIPlus(FALSE);
     InitializeAtlModule(GetModuleHandle(NULL), FALSE);
 

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -143,7 +143,6 @@ VOID SaveSettings(HWND hwnd)
 
 int wmain(int argc, wchar_t *argv[])
 {
-    MessageBoxW(0, L"", L"", 0);
     ConInitStdStreams(); // Initialize the Console Standard Streams
 
     LPCWSTR szWindowClass = L"ROSAPPMGR";


### PR DESCRIPTION
## Purpose

Improve RAPPS command-line handling

## Proposed changes

- Change RAPPS from an GUI application to a CLI application. ( In order to interact with console ). It will detach the console when it's asked to run in GUI mode （e.g. when no parameters being passed to it).
- Refactor code about command-line parse.
- Add ```/?``` command.
- Some function are renamed to a better name.
- now both ```/``` and ```-``` prefix will work ( e.g. ```/INSTALL``` and ```-INSTALL``` both works )

## TODO

- [x] Check whether ```/SETUP``` option still works after refactor. I need to get a sample of origin ```.inf``` file used with this option to test it.
- [x] Refactor command-line parse further
- [x] Add ```/find``` and ```/info``` command (for search and displaying software information)