### PR TITLE
[BASE] Improve Spanish translation

### DIFF
--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -5,6 +5,7 @@
  * PURPOSE:     Spanish Language resource file
  * TRANSLATORS: Gabriel Ilardi
  *              Ismael Ferreras Morezuelas
+ *              Catalin Gabriel Draghita
  */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
@@ -18,19 +19,19 @@ BEGIN
         MENUITEM "&Guardar\tCtrl+G", IDM_FILESAVE
         MENUITEM "Guardar &como...", IDM_FILESAVEAS
         MENUITEM SEPARATOR
-        MENUITEM "From Scanner or Camera...", IDM_FILEFROMSCANNERORCAMERA
+        MENUITEM "Desde un Escáner o Cámara...", IDM_FILEFROMSCANNERORCAMERA
         MENUITEM SEPARATOR
         MENUITEM "Vista de página", IDM_FILEPAGEVIEW
         MENUITEM "Configurar página...", IDM_FILEPAGESETUP
         MENUITEM "&Imprimir...\tCtrl+P", IDM_FILEPRINT
         MENUITEM SEPARATOR
-        MENUITEM "Send...", IDM_FILESEND
+        MENUITEM "Enviar...", IDM_FILESEND
         MENUITEM SEPARATOR
         MENUITEM "Fondo de pantalla (normal)", IDM_FILEASWALLPAPERPLANE
         MENUITEM "Fondo de pantalla (centrado)", IDM_FILEASWALLPAPERCENTERED
         MENUITEM "Fondo de pantalla (extendido)", IDM_FILEASWALLPAPERSTRETCHED
         MENUITEM SEPARATOR
-        MENUITEM "Most recently used file", IDM_FILEMOSTRECENTLYUSEDFILE, GRAYED
+        MENUITEM "Archivos recientes", IDM_FILEMOSTRECENTLYUSEDFILE, GRAYED
         MENUITEM SEPARATOR
         MENUITEM "Sa&lir\tAlt+F4", IDM_FILEEXIT
     END
@@ -218,7 +219,7 @@ BEGIN
     IDS_TOOLTIP15 "Elipse"
     IDS_TOOLTIP16 "Rectángulo redondeado"
     IDS_ALLFILES "Todos los archivos"
-    IDS_ALLPICTUREFILES "All Picture Files"
+    IDS_ALLPICTUREFILES "Todos los archivos de imagen"
     IDS_FILESIZE "%d bytes"
     IDS_PRINTRES "%d x %d píxeles/m"
     IDS_INTNUMBERS "Sólo se admiten números sin decimales."

--- a/base/applications/network/ping/lang/es-ES.rc
+++ b/base/applications/network/ping/lang/es-ES.rc
@@ -2,6 +2,7 @@
  * FILE:        base/applications/network/ping/lang/es-ES.rc
  * PURPOSE:     Spanish translations for ReactOS Ping Command
  * TRANSLATORS: Ismael Ferreras Morezuelas
+ *              Catalin Gabriel Draghita
  */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
@@ -13,47 +14,47 @@ Uso: ping [-t] [-a] [-n cuenta] [-l tamaño] [-f] [-i TTL] [-v TOS]\n\
           [-w tiempo_de_espera] [-4] [-6] nombre_de_destino\n\
 \n\
 Opciones:\n\
-    -t          Ping the specified host until stopped.\n\
-                To see statistics and continue - type Control-Break;\n\
-                To stop - type Control-C.\n\
-    -a          Resolve addresses to hostnames.\n\
+    -t          Hacer ping al host especificado hasta que se detenga.\n\
+                Para ver estadísticas y continuar - pulse Control-Break;\n\
+                Para detener - pulse Control-C.\n\
+    -a          Resuelve direcciones a nombres del host.\n\
     -n cuenta   Número de solicitudes de eco a enviar.\n\
     -l tamaño   Tamaño de búfer a enviar.\n\
-    -f          Set Don't Fragment flag in packet (IPv4-only).\n\
-    -i TTL      Time To Live.\n\
-    -v TOS      Type Of Service (IPv4-only. This setting has been deprecated\n\
-                and has no effect on the type of service field in the IP\n\
-                Header).\n\
+    -f          Establecer marca No Fragmentar en paquetes (solo IPv4).\n\
+    -i TTL      Periodo de vida.\n\
+    -v TOS      Tipo de Servicio (solo IPv4. Esta opción esta desusada\n\
+                y no tiene ningún efecto sobre el campo de tipo de servicio\n\
+                del encabezado IP).\n\
     -w t_espera Tiempo de espera en milisegundos para cada respuesta.\n\
-    -4          Force using IPv4.\n\
-    -6          Force using IPv6.\n\
+    -4          Forzar el uso de IPv4.\n\
+    -6          Forzar el uso de IPv6.\n\
 \n"
 
     IDS_CTRL_BREAK "Control-Break\n"
     IDS_CTRL_C "Control-C\n"
     IDS_NO_RESOURCES "No hay suficientes recursos libres disponibles.\n"
-    IDS_MISSING_ADDRESS "IP address must be specified.\n"
-    IDS_MISSING_VALUE "Value must be supplied for option %s.\n"
+    IDS_MISSING_ADDRESS "Debe especificar una dirección IP.\n"
+    IDS_MISSING_VALUE "Debe introducir un valor para la opción %s.\n"
     IDS_BAD_OPTION "La opción %s no es válida.\n"
     IDS_BAD_PARAMETER "El parámetro %s no es válido.\n"
     IDS_BAD_VALUE "El valor para la opción %s no es válido, debe de estar entre %u y %u.\n"
-    IDS_WRONG_FAMILY "The option %s is only supported for %s.\n"
-    IDS_UNKNOWN_HOST "Ping could not find host %s. Please check the name and try again.\n"
+    IDS_WRONG_FAMILY "La opción %s solo funciona con %s.\n"
+    IDS_UNKNOWN_HOST "La solicitud de ping no ha podido encontrar el host %s. Por favor, compruebe el nombre y vuelva a intentarlo.\n"
     IDS_PINGING_ADDRESS "\nHaciendo ping a %s "
     IDS_PINGING_HOSTNAME "\nHaciendo ping a %s [%s] "
-    IDS_SOURCE_ADDRESS "from %s %s"
+    IDS_SOURCE_ADDRESS "de %s %s"
     IDS_PING_SIZE "con %lu bytes de datos:\n\n"
     IDS_REPLY_FROM "Respuesta desde %s: "
     IDS_REPLY_BYTES "bytes=%d "
     IDS_REPLY_TIME_MS "tiempo=%lums "
     IDS_REPLY_TIME_0MS "tiempo<1ms "
     IDS_REPLY_TTL "TTL=%d\n"
-    IDS_REPLY_STATUS "Echo reply returned %lu.\n"
-    IDS_DEST_HOST_UNREACHABLE "Destination host unreachable.\n"
-    IDS_DEST_NET_UNREACHABLE "Destination network unreachable.\n"
+    IDS_REPLY_STATUS "La respuesta de echo devolvió %lu.\n"
+    IDS_DEST_HOST_UNREACHABLE "Host destino inalcanzable.\n"
+    IDS_DEST_NET_UNREACHABLE "Red destino inalcanzable.\n"
     IDS_REQUEST_TIMED_OUT "La petición ha caducado.\n"
-    IDS_TTL_EXPIRED "TTL expired in transit.\n"
-    IDS_TRANSMIT_FAILED "PING: transmit failed. (Error %u)\n"
+    IDS_TTL_EXPIRED "TTL expiró durante el tránsito.\n"
+    IDS_TRANSMIT_FAILED "PING: trasmisión fallida. (Error %u)\n"
 
     IDS_STATISTICS "\n\
 Estadísticas de ping para %s:\n\
@@ -62,5 +63,5 @@ Estadísticas de ping para %s:\n\
     IDS_APPROXIMATE_RTT "Tiempos aproximados de ida y vuelta en milisegundos:\n\
     Mínimo = %lums, Máximo = %lums, Media = %lums\n"
 
-    IDS_WINSOCK_FAIL "Failed to initialize WinSock: %i\n"
+    IDS_WINSOCK_FAIL "No se ha podido inicializar WinSock: %i\n"
 END

--- a/base/applications/notepad/lang/es-ES.rc
+++ b/base/applications/notepad/lang/es-ES.rc
@@ -1,4 +1,4 @@
-/* Spanish translation by Ismael Ferreras Morezuelas (Swyter) */
+/* Spanish translation by Ismael Ferreras Morezuelas (Swyter), Catalin Gabriel Draghita (jeffbox12) */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
@@ -64,7 +64,7 @@ BEGIN
     BEGIN
         MENUITEM "Í&ndice", CMD_HELP_CONTENTS
         MENUITEM SEPARATOR
-        MENUITEM "&About Notepad", CMD_HELP_ABOUT_NOTEPAD
+        MENUITEM "&Acerca de Bloc de notas", CMD_HELP_ABOUT_NOTEPAD
     END
 END
 

--- a/base/applications/osk/lang/es-ES.rc
+++ b/base/applications/osk/lang/es-ES.rc
@@ -5,12 +5,13 @@
  * PURPOSE:         On screen keyboard (Spanish resources)
  * PROGRAMMERS:     Denis ROBERT
  * TRANSLATOR:      Ismael Ferreras Morezuelas <swyterzone+ros@gmail.com>
+ *                  Catalin Gabriel Draghita <catalin.draghita@gmail.com>
  */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
 MAIN_DIALOG_ENHANCED_KB DIALOGEX DISCARDABLE 0, 0, 608, 164
-CAPTION "Teclado en pantalla"
+CAPTION "Teclado en Pantalla"
 FONT 8, "MS Shell Dlg"
 MENU IDR_OSK_MENU
 STYLE WS_SYSMENU | WS_MINIMIZEBOX
@@ -130,7 +131,7 @@ BEGIN
 END
 
 MAIN_DIALOG_STANDARD_KB DIALOGEX DISCARDABLE 0, 0, 362, 115
-CAPTION "On screen keyboard"
+CAPTION "Teclado en Pantalla"
 FONT 8, "MS Shell Dlg"
 MENU IDR_OSK_MENU
 STYLE WS_SYSMENU | WS_MINIMIZEBOX
@@ -179,7 +180,7 @@ BEGIN
     PUSHBUTTON      "p",SCAN_CODE_26,213,41,15,15
     PUSHBUTTON      "[",SCAN_CODE_27,232,41,15,15
     PUSHBUTTON      "]",SCAN_CODE_28,251,41,15,15
-    PUSHBUTTON      "lock",SCAN_CODE_30,3,60,46,15,BS_ICON
+    PUSHBUTTON      "bloq",SCAN_CODE_30,3,60,46,15,BS_ICON
     PUSHBUTTON      "a",SCAN_CODE_31,53,60,15,15
     PUSHBUTTON      "s",SCAN_CODE_32,72,60,15,15
     PUSHBUTTON      "d",SCAN_CODE_33,91,60,15,15
@@ -215,15 +216,15 @@ BEGIN
     PUSHBUTTON      "menu",SCAN_CODE_129,248,98,24,15,BS_ICON
     PUSHBUTTON      "ctrl",SCAN_CODE_64,275,98,24,15,BS_PUSHLIKE|BS_AUTOCHECKBOX
     PUSHBUTTON      "ins",SCAN_CODE_75,304,22,15,15
-    PUSHBUTTON      "del",SCAN_CODE_76,304,41,15,15
-    PUSHBUTTON      "hm",SCAN_CODE_80,324,22,15,15
-    PUSHBUTTON      "end",SCAN_CODE_81,324,41,15,15
-    PUSHBUTTON      "pup",SCAN_CODE_85,344,22,15,15
-    PUSHBUTTON      "pdn",SCAN_CODE_86,344,41,15,15
+    PUSHBUTTON      "supr",SCAN_CODE_76,304,41,15,15
+    PUSHBUTTON      "ini",SCAN_CODE_80,324,22,15,15
+    PUSHBUTTON      "fin",SCAN_CODE_81,324,41,15,15
+    PUSHBUTTON      "ReP",SCAN_CODE_85,344,22,15,15
+    PUSHBUTTON      "AvP",SCAN_CODE_86,344,41,15,15
     PUSHBUTTON      "<-",SCAN_CODE_79,304,98,15,15,BS_ICON
     PUSHBUTTON      "^",SCAN_CODE_83,324,79,15,15,BS_ICON
     PUSHBUTTON      "->",SCAN_CODE_89,344,98,15,15,BS_ICON
-    PUSHBUTTON      "nlk",SCAN_CODE_90,364,22,15,15
+    PUSHBUTTON      "bln",SCAN_CODE_90,364,22,15,15
     PUSHBUTTON      "7",SCAN_CODE_91,364,41,15,15
     PUSHBUTTON      "4",SCAN_CODE_92,364,60,15,15
     PUSHBUTTON      "1",SCAN_CODE_93,364,79,15,15
@@ -239,69 +240,69 @@ BEGIN
     PUSHBUTTON      ".",SCAN_CODE_104,404,98,15,15
     PUSHBUTTON      "-",SCAN_CODE_105,424,22,15,15
     PUSHBUTTON      "+",SCAN_CODE_106,424,41,15,35
-    PUSHBUTTON      "ent",SCAN_CODE_108,424,78,15,35
+    PUSHBUTTON      "int",SCAN_CODE_108,424,78,15,35
     CTEXT           "Num",IDC_STATIC,364,3,21,8
     CONTROL         "",IDC_LED_NUM,"Static",SS_CENTER|SS_NOTIFY,372,15,4,3
-    CTEXT           "Caps",IDC_STATIC,389,3,21,8
+    CTEXT           "Mayús",IDC_STATIC,389,3,21,8
     CONTROL         "",IDC_LED_CAPS,"Static",SS_CENTER|SS_NOTIFY,398,15,4,3
-    CTEXT           "Scroll",IDC_STATIC,414,3,21,8
+    CTEXT           "Bl. Desp",IDC_STATIC,414,3,21,8
     CONTROL         "",IDC_LED_SCROLL,"Static",SS_CENTER|SS_NOTIFY,424,15,4,3
 END
 
 IDR_OSK_MENU MENU DISCARDABLE
 BEGIN
-    POPUP "File"
+    POPUP "Archivo"
     BEGIN
-        MENUITEM "&Exit", IDM_EXIT
+        MENUITEM "&Cerrar", IDM_EXIT
     END
 
-    POPUP "Keyboard"
+    POPUP "Teclado"
     BEGIN
-        MENUITEM "Enhanced Keyboard", IDM_ENHANCED_KB, CHECKED
-        MENUITEM "Standard Keyboard", IDM_STANDARD_KB
+        MENUITEM "Teclado Mejorado", IDM_ENHANCED_KB, CHECKED
+        MENUITEM "Teclado Estándar", IDM_STANDARD_KB
         MENUITEM SEPARATOR
-        MENUITEM "Regular Layout", IDM_REG_LAYOUT, CHECKED, GRAYED
-        MENUITEM "Block Layout", IDM_BLOCK_LAYOUT, GRAYED
+        MENUITEM "Diseño Regular", IDM_REG_LAYOUT, CHECKED, GRAYED
+        MENUITEM "Bloquear Diseño", IDM_BLOCK_LAYOUT, GRAYED
         MENUITEM SEPARATOR
-        MENUITEM "101 keys", IDM_101_KEYS, CHECKED, GRAYED
-        MENUITEM "102 keys", IDM_102_KEYS, GRAYED
-        MENUITEM "106 keys", IDM_106_KEYS, GRAYED
+        MENUITEM "101 teclas", IDM_101_KEYS, CHECKED, GRAYED
+        MENUITEM "102 teclas", IDM_102_KEYS, GRAYED
+        MENUITEM "106 teclas", IDM_106_KEYS, GRAYED
     END
 
-    POPUP "Settings"
+    POPUP "Configuración"
     BEGIN
-        MENUITEM "Always on Top", IDM_ON_TOP, CHECKED
+        MENUITEM "Siempre encima", IDM_ON_TOP, CHECKED
         MENUITEM SEPARATOR
-        MENUITEM "&Use Click Sound", IDM_CLICK_SOUND
+        MENUITEM "&Hacer sonar la Tecla", IDM_CLICK_SOUND
         MENUITEM SEPARATOR
-        MENUITEM "&Typing Mode...", IDM_TYPE_MODE, GRAYED
+        MENUITEM "&Modo de Escritura...", IDM_TYPE_MODE, GRAYED
         MENUITEM SEPARATOR
-        MENUITEM "&Font...", IDM_FONT, GRAYED
+        MENUITEM "&Fuente...", IDM_FONT, GRAYED
     END
 
-    POPUP "Help"
+    POPUP "Ayuda"
     BEGIN
-        MENUITEM "&Help Topics", IDM_HELP_TOPICS, GRAYED
+        MENUITEM "&Temas de Ayuda", IDM_HELP_TOPICS, GRAYED
         MENUITEM SEPARATOR
-        MENUITEM "&About On-Screen Keyboard...", IDM_ABOUT
+        MENUITEM "&Acerca de Teclado en Pantalla...", IDM_ABOUT
     END
 END
 
 IDD_WARNINGDIALOG_OSK DIALOGEX 0, 0, 250, 97
 STYLE DS_SHELLFONT | DS_MODALFRAME | DS_CENTER | WS_POPUP | WS_CAPTION
-CAPTION "On-Screen Keyboard"
+CAPTION "Teclado en Pantalla"
 FONT 8, "MS Shell Dlg", 400, 0, 0x1
 BEGIN
-    DEFPUSHBUTTON "OK", IDOK, 193, 76, 50, 14
+    DEFPUSHBUTTON "Aceptar", IDOK, 193, 76, 50, 14
     ICON IDI_OSK, IDC_STATIC, 7, 17, 20, 20
-    LTEXT "On-Screen Keyboard provides a minimum level of functionality for mobility-impaired users. Mobility-impaired users will need a utility program with higher functionality for daily use.", IDC_STATIC, 36, 7, 207, 33
-    CONTROL "Do not show this message again", IDC_SHOWWARNINGCHECK, "Button",
+    LTEXT "Teclado en Pantalla proporciona un nivel mínimo de funcionalidad para usuarios con movibilidad limitada. Los usuarios con movibilidad limitada necesitarán un programa con mayor funcionalidad para uso diario.", IDC_STATIC, 36, 7, 207, 33
+    CONTROL "No volver a mostrar este mensaje", IDC_SHOWWARNINGCHECK, "Button",
             BS_AUTOCHECKBOX | WS_TABSTOP, 43, 80, 137, 10
 END
 
 STRINGTABLE
 BEGIN
-    STRING_OSK "On-Screen Keyboard"
+    STRING_OSK "Teclado en Pantalla"
     STRING_AUTHORS "Copyright Denis Robert"
 END
 

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -1,5 +1,5 @@
 /* Spanish Language resource file.
- * Translated by: ?? and Ismael Ferreras Morezuelas (Swyter) <2014-11-07> and Julen Urizar Compains 2020-04-14 */
+ * Translated by: ?? and Ismael Ferreras Morezuelas (Swyter) <2014-11-07> and Julen Urizar Compains 2020-04-14 and Catalin Gabriel Draghita 2020-08-22 */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
@@ -69,9 +69,9 @@ BEGIN
     EDITTEXT IDC_DOWNLOAD_DIR_EDIT, 15, 86, 166, 12, WS_CHILD | WS_VISIBLE | WS_GROUP | ES_AUTOHSCROLL
     PUSHBUTTON "&Seleccionar", IDC_CHOOSE, 187, 85, 50, 14
     AUTOCHECKBOX "&Borrar el instalador del programa tras su instalación", IDC_DEL_AFTER_INSTALL, 16, 100, 218, 12
-    GROUPBOX "Software source", -1, 4, 118, 240, 46
-    CONTROL "Use default", IDC_SOURCE_DEFAULT, "Button", BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP, 15, 132, 74, 10
-    CONTROL "Specified source", IDC_USE_SOURCE, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 15, 147, 74, 10
+    GROUPBOX "Origen del Software", -1, 4, 118, 240, 46
+    CONTROL "Usar predeterminado", IDC_SOURCE_DEFAULT, "Button", BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP, 15, 132, 74, 10
+    CONTROL "Origen especificado", IDC_USE_SOURCE, "Button", BS_AUTORADIOBUTTON | WS_TABSTOP, 15, 147, 74, 10
     EDITTEXT IDC_SOURCE_URL, 97, 147, 140, 12, ES_AUTOHSCROLL | WS_DISABLED
     GROUPBOX "Proxy", -1, 4, 166, 240, 76
     CONTROL "Utilizar el proxy del sistema", IDC_PROXY_DEFAULT, "Button", BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP, 15, 180, 210, 10
@@ -155,7 +155,7 @@ BEGIN
     IDS_AINFO_URLSITE "\nPágina Web: "
     IDS_AINFO_LICENSE "\nLicencia: "
     IDS_AINFO_URLDOWNLOAD "\nDescargar: "
-    IDS_AINFO_LANGUAGES "\nLanguages: "
+    IDS_AINFO_LANGUAGES "\nIdiomas: "
 END
 
 STRINGTABLE
@@ -175,7 +175,7 @@ BEGIN
     IDS_CAT_SCIENCE "Ciencia"
     IDS_CAT_TOOLS "Herramientas"
     IDS_CAT_VIDEO "Vídeo"
-    IDS_CAT_THEMES "Themes"
+    IDS_CAT_THEMES "Temas"
 END
 
 STRINGTABLE
@@ -196,7 +196,7 @@ BEGIN
     IDS_APPLICATIONS "Aplicaciones"
     IDS_CHOOSE_FOLDER_TEXT "Seleccione una carpeta de donde se descargarán los programas:"
     IDS_CHOOSE_FOLDER_ERROR "La carpeta especificada no existe."
-    IDS_URL_INVALID "The URL you have specified is invalid or not supported. Please correct it!"
+    IDS_URL_INVALID "La URL que ha especificado es inválido o no esta disponible. Por favor, corrígelo."
     IDS_APP_REG_REMOVE "¿Está seguro de querer borrar del Registro los datos de instalación del programa?"
     IDS_INFORMATION "Información"
     IDS_UNABLE_TO_DOWNLOAD "No se pudo descargar el paquete. No se ha encontrado la dirección de Internet."
@@ -212,7 +212,7 @@ BEGIN
     IDS_INSTALL_SELECTED "Instalar selección"
     IDS_SELECTEDFORINST "Seleccionados para instalar"
     IDS_MISMATCH_CERT_INFO "El certificado que usa es desconocido:\nSujeto: %s\nEmisor: %s\n¿Quiere continuar a pesar de ello?"
-    IDS_UNABLE_PATH "Incorrect path format."
+    IDS_UNABLE_PATH "Formato de ruta incorrecto."
 END
 
 STRINGTABLE
@@ -248,5 +248,5 @@ STRINGTABLE
 BEGIN
     IDS_DL_DIALOG_DB_DISP "Base de datos de aplicaciones"
     IDS_DL_DIALOG_DB_DOWNLOAD_DISP "Actualizando listado…"
-    IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Updating Database… (Unofficial source)"
+    IDS_DL_DIALOG_DB_UNOFFICIAL_DOWNLOAD_DISP "Actualizando listado… (Origen no oficial)"
 END

--- a/base/shell/cmd/lang/es-ES.rc
+++ b/base/shell/cmd/lang/es-ES.rc
@@ -1,16 +1,16 @@
-/* Spanish translation by HUMA2000, Jose Pedro Fernández Pascual e Ismael Ferreras Morezuelas (Swyter) */
+/* Spanish translation by HUMA2000, Jose Pedro Fernández Pascual, Ismael Ferreras Morezuelas (Swyter) e Catalin Gabriel Draghita */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
 STRINGTABLE
 BEGIN
-    STRING_ASSOC_HELP "Modify file extension associations.\n\n\
+    STRING_ASSOC_HELP "Modifica la extensión del archivo asociado.\n\n\
 assoc [.ext[=[FileType]]]\n\
 \n\
-assoc (print all associations)\n\
-assoc .ext (print specific association)\n\
-assoc .ext= (remove specific association)\n\
-assoc .ext=FileType (add new association)\n"
+assoc (muestra todas las asociaciones)\n\
+assoc .ext (muestra asociaciones especificas)\n\
+assoc .ext= (eliminar asociación especifica)\n\
+assoc .ext=FileType (añadir nueva asociación)\n"
     STRING_ALIAS_HELP "Pone, borra o muestra los alias.\n\n\
 ALIAS [alias=[command]]\n\n\
   alias    Nombre para un alias.\n\
@@ -92,14 +92,15 @@ COPY [/V][/Y|/-Y][/A|/B] origen [/A|/B]\n\
                existente.\n\n\
 El parametro /Y tiene que estar presente en las variables de entorno de COPYCMD.\n\
 ...\n"
-    STRING_CTTY_HELP "Changes the standard I/O terminal device to an auxiliary device.\n\n\
+    STRING_CTTY_HELP "Cambia el estándar del dispositivo terminal de E/S a un dispositivo auxiliar.\n\n\
 CTTY device\n\n\
-  device    The terminal device you want to use as the new standard I/O device.\n\
-            This name must refer to a valid character device:\n\
+  device    El dispositivo terminal que quiere usar como nuevo dispositivo\n\
+            estándar de E/S. Este nombre debe referir a un dispositivo con\n\
+            un carácter válido:\n\
             AUX, COMx (x=1..N), CON, LPTx (x=1..N), PRN, NUL.\n\
-            CON is usually the default standard I/O device.\n\n\
-To return control to the standard console, type: CTTY CON on the auxiliary\n\
-device."
+            CON normalmente es el dispositivo estándar de E/S predeterminado.\n\n\
+Para devolver el control a la consola estándar, escriba: CTTY CON en el\n\
+dispositivo auxiliar."
     STRING_DATE_HELP1 "\nIntroduce la nueva fecha (mm%cdd%cyyyy): "
     STRING_DATE_HELP2 "\nIntroduce la nueva fecha (dd%cmm%cyyyy): "
     STRING_DATE_HELP3 "\nIntroduce la nueva fecha (yyyy%cmm%cdd): "
@@ -320,11 +321,11 @@ códigos especiales:\n\n\
     STRING_PROMPT_HELP2 "  $+   Muestra la profundidad actual de la pila de directorios"
     STRING_PROMPT_HELP3 "\nEscribe PROMPT sin parámetros para resetear el símbolo de\n\
 comandos a su configuración por defecto."
-    STRING_REM_HELP "Comienza una liena de comentarios en un archivo por lotes\n\nREM [Comentario]"
+    STRING_REM_HELP "Comienza una linea de comentarios en un archivo por lotes\n\nREM [Comentario]"
     STRING_RMDIR_HELP "Elimina un directorio.\n\n\
 RMDIR [/S] [/Q] [unidad:]ruta\nRD [/S] [/Q] [unidad:]ruta\n\
-  /S    Deletes all files and folders within the target.\n\
-  /Q    Doesn't prompt for user.\n"
+  /S    Elimina todos los archivos y carpetas dentro del objetivo.\n\
+  /Q    No avisa al usuario.\n"
     STRING_RMDIR_HELP2 "La carpeta no está vacía.\n"
     STRING_REN_HELP1 "Renombra un archivo/directorio o varios archivos/directorios.\n\n\
 RENAME [/E /N /P /Q /S /T] nombre_antiguo ... nuevo_nombre\n\
@@ -344,26 +345,27 @@ el comando MOVE para este propósito.\n"
 REPLACE [drive1:][path1]filename [drive2:][path2] [/A] [/P] [/R] [/W]\n\
 REPLACE [drive1:][path1]filename [drive2:][path2] [/P] [/R] [/S] [/W] [/U]\n\n\
   [drive1:][path1]filename Especifica el archivo o archivos de origen.\n\
-  [drive2:][path2]         Especifica el nombre de la carpeta donde\n\
-                           se reemplacen los archivos.\n\
-  /A                       Adds new files to destination directory. Cannot\n\
-                           use with /S or /U switches.\n\
-  /P                       Prompts for confirmation before replacing a file or\n\
-                           adding a source file.\n\
-  /R                       Replaces read-only files as well as unprotected\n\
-                           files.\n\
-  /S                       Replaces files in all subdirectories of the\n\
-                           destination directory. Cannot use with the /A\n\
-                           switch.\n\
-  /W                       Waits for you to insert a disk before beginning.\n\
-  /U                       Replaces (updates) only files that are older than\n\
-                           source files. Cannot use with the /A switch.\n"
-    STRING_REPLACE_HELP2 "Source path required\n"
-    STRING_REPLACE_HELP3 "No files replaced\n"
-    STRING_REPLACE_HELP4 "%lu file(s) replaced\n"
+  [drive2:][path2]         Especifica el nombre de la carpeta donde se\n\
+                           reemplacen los archivos.\n\
+  /A                       Añade nuevos archivos al directorio destino. No\n\
+                           se puede usar con las opciones /S o /U.\n\
+  /P                       Pregunta para confirmación antes de reemplazar un\n\
+                           archivo o añadir un archivo origen.\n\
+  /R                       Reemplaza todos los archivos solo lectura y los\n\
+                           archivos no protegidos.\n\
+  /S                       Reemplaza todos los archivos en todos los\n\
+                           subdirectorios\n\
+                           del directorio destino. No se puede usar con la opción /A\n\
+  /W                       Espera que insertes un disco antes de empezar.\n\
+  /U                       Reemplaza (actualiza) solo los archivos que son más\n\
+                           antiguos que los de origen. No se puede usar con\n\
+                           la opción /A.\n"
+    STRING_REPLACE_HELP2 "Ruta de origen requerida\n"
+    STRING_REPLACE_HELP3 "No se han reemplazado archivos\n"
+    STRING_REPLACE_HELP4 "Se han reemplazado %lu archivo(s)\n"
     STRING_REPLACE_HELP5 "Reemplazando %s\n"
     STRING_REPLACE_HELP6 "Reemplazar %s\n"
-    STRING_REPLACE_HELP7 "No files added\n"
+    STRING_REPLACE_HELP7 "No se han añadido archivos\n"
     STRING_REPLACE_HELP8 "%lu archivo(s) añadidos\n"
     STRING_REPLACE_HELP9 "Añadir %s (S/N)? "
     STRING_REPLACE_HELP10 "Reemplazar %s (S/N)? "
@@ -378,22 +380,22 @@ SCREEN fila columna [texto]\n\n\
     STRING_SET_HELP "Muestra, cambia o borra las variables de entorno.\n\n\
 SET [variable[=][cadena]]\n\n\
   variable  Especifica el nombre de la variable de entorno.\n\
-  string    Especifies la serie de caracteres para asignar a la variable.\n\n\
+  string    Especifica la serie de carácteres para asignar a la variable.\n\n\
 Escribe SET sin parámetros para mostrar las variables de entorno actuales.\n"
     STRING_START_HELP1 "Empieza un comando.\n\n\
 START [""title""] [/D path] [/I] [/B] [/MIN] [/MAX] [/WAIT]\n\
       [command/program] [parameters]\n\n\
-  ""title""     Title of the window.\n\
-  path        Specifies the startup directory.\n\
-  I           Uses the original environment given to cmd.exe,\n\
-              instead of the current environment.\n\
-  B           Starts the command or program without creating any window.\n\
-  MIN         Starts with a minimized window.\n\
-  MAX         Starts with a maximized window.\n\
-  WAIT        Starts the command or program and waits for its termination.\n\
+  ""title""     Titulo de la ventana.\n\
+  path        Especifica el directorio de inicio.\n\
+  I           Utiliza en entorno original dado de cmd.exe,\n\
+              en vez del entorno actual.\n\
+  B           Inicia el comando o programa sin crear ventanas.\n\
+  MIN         Inicia con la ventana minimizada.\n\
+  MAX         Inicia con la ventana maximizada.\n\
+  WAIT        Inicia el comando o programa y luego espera a que termine.\n\
   comando     Especifica el comando a ejecutar.\n\
-  parameters  Specifies the parameters to be given to the command or program.\n"
-    STRING_TITLE_HELP "Cambia el título de la ventqana del intérprete de comandos.\n\n\
+  parameters  Especifica el parámetro a ser dado para el comando o programa.\n"
+    STRING_TITLE_HELP "Cambia el título de la ventana del intérprete de comandos.\n\n\
 TITLE [cadena]\n\n\
 cadena       Especifica el título de la ventana del intérprete de comandos.\n"
     STRING_TIME_HELP1 "Muestra o cambia la hora del sistema.\n\n\

--- a/base/system/subst/lang/es-ES.rc
+++ b/base/system/subst/lang/es-ES.rc
@@ -1,3 +1,8 @@
+/*
+ * TRANSLATION: ??
+                2020 - Catalin Gabriel Draghita (catalin.draghita@gmail.com)
+ */
+
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
 STRINGTABLE
@@ -5,8 +10,8 @@ BEGIN
     IDS_INCORRECT_PARAMETER_COUNT "Cantidad de parámetros incorrecta - %s\n"
     IDS_INVALID_PARAMETER "Cantidad de parámetros incorrecta - %s\n"
     IDS_INVALID_PARAMETER2 "Parámetro incorrecto - %s\n"
-    IDS_PATH_NOT_FOUND "Path not found - %s\n"
-    IDS_ACCESS_DENIED "Access denied - %s\n"
+    IDS_PATH_NOT_FOUND "Ruta no encontrada - %s\n"
+    IDS_ACCESS_DENIED "Acceso denegado - %s\n"
     IDS_DRIVE_ALREADY_SUBSTED "Unidad ya sustituida\n"
     IDS_FAILED_WITH_ERRORCODE "Falla con código de error 0x%x: %s\n"
     IDS_USAGE "Asocia una ruta con una letra de unidad.\n\n\

--- a/base/system/userinit/lang/es-ES.rc
+++ b/base/system/userinit/lang/es-ES.rc
@@ -1,3 +1,8 @@
+/*
+ * TRANSLATION: ??
+                2020 - Catalin Gabriel Draghita (catalin.draghita@gmail.com)
+ */
+
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
 IDD_LOCALEPAGE DIALOGEX 0, 0, 317, 193
@@ -6,15 +11,15 @@ CAPTION "ReactOS LiveCD"
 FONT 8, "MS Shell Dlg"
 BEGIN
     CONTROL "IDB_LOGO", IDC_LOCALELOGO, "Static", WS_CHILD | WS_VISIBLE | SS_OWNERDRAW, 18, 4, 290, 99
-    RTEXT "&Language:", IDC_STATIC, 20, 109, 106, 11, WS_CHILD | WS_VISIBLE | WS_GROUP
+    RTEXT "&Idioma:", IDC_STATIC, 20, 109, 106, 11, WS_CHILD | WS_VISIBLE | WS_GROUP
     COMBOBOX IDC_LANGUAGELIST, 132, 107, 176, 142, CBS_DROPDOWNLIST | CBS_NOINTEGRALHEIGHT | CBS_SORT | WS_VSCROLL | WS_CHILD | WS_VISIBLE | WS_TABSTOP
-    RTEXT "&Keyboard layout:", IDC_STATIC, 20, 132, 106, 11, WS_CHILD | WS_VISIBLE | WS_GROUP
+    RTEXT "&Distribución del teclado:", IDC_STATIC, 20, 132, 106, 11, WS_CHILD | WS_VISIBLE | WS_GROUP
     COMBOBOX IDC_LAYOUTLIST, 132, 130, 176, 81, CBS_DROPDOWNLIST | CBS_NOINTEGRALHEIGHT | CBS_SORT | WS_VSCROLL | WS_CHILD | WS_VISIBLE | WS_TABSTOP
-    LTEXT "Select your language and keyboard layout and click Next to continue.", IDC_STATIC, 7, 152, 300, 8
+    LTEXT "Seleccióne el idioma y la distribución del teclado y haga clic en Siguiente para continuar.", IDC_STATIC, 7, 152, 300, 8
 
     CONTROL "", IDC_STATIC, "STATIC", SS_ETCHEDHORZ, 0, 165, 317, 1
-    DEFPUSHBUTTON "&Next", IDOK, 205, 172, 50, 14
-    PUSHBUTTON "&Cancel", IDCANCEL, 260, 172, 50, 14
+    DEFPUSHBUTTON "&Siguiente", IDOK, 205, 172, 50, 14
+    PUSHBUTTON "&Cancelar", IDCANCEL, 260, 172, 50, 14
 END
 
 IDD_STARTPAGE DIALOGEX 0, 0, 317, 193
@@ -23,24 +28,24 @@ CAPTION "ReactOS LiveCD"
 FONT 8, "MS Shell Dlg"
 BEGIN
     CONTROL "IDB_LOGO", IDC_STARTLOGO, "Static", WS_CHILD | WS_VISIBLE | SS_OWNERDRAW, 18, 4, 290, 99
-    DEFPUSHBUTTON "Run ReactOS &Live CD", IDC_RUN, 71, 108, 175, 21
-    PUSHBUTTON "&Install ReactOS", IDC_INSTALL, 71, 136, 175, 21
+    DEFPUSHBUTTON "Iniciar &Live CD de ReactOS", IDC_RUN, 71, 108, 175, 21
+    PUSHBUTTON "&Instalar ReactOS", IDC_INSTALL, 71, 136, 175, 21
 
     // LTEXT "", IDC_STATIC, 7, 152, 300, 8
 
     CONTROL "", IDC_STATIC, "STATIC", SS_ETCHEDHORZ, 0, 165, 317, 1
-    PUSHBUTTON "&Previous", IDOK, 205, 172, 50, 14
-    PUSHBUTTON "&Cancel", IDCANCEL, 260, 172, 50, 14
+    PUSHBUTTON "&Anterior", IDOK, 205, 172, 50, 14
+    PUSHBUTTON "&Cancelar", IDCANCEL, 260, 172, 50, 14
 END
 
 STRINGTABLE
 BEGIN
-    IDS_SHELL_FAIL "Userinit no pudo iniciar el shell con éxito!"
-    IDS_INSTALLER_FAIL "Userinit failed to start the installer!"
-    IDS_CANCEL_CONFIRM "Are you sure you want to quit the ReactOS LiveCD?\nIf you choose to do so, your computer might restart."
+    IDS_SHELL_FAIL "¡Userinit no pudo iniciar el shell con éxito!"
+    IDS_INSTALLER_FAIL "¡Userinit no pudo iniciar el instalador!"
+    IDS_CANCEL_CONFIRM "¿Seguro que quieres salir de LiveCD de ReactOS?\nSi es así, tu equipo se reiniciará."
 END
 
 STRINGTABLE
 BEGIN
-    IDS_SPAIN "Spanish (Spain)"
+    IDS_SPAIN "Español (España)"
 END

--- a/base/system/winlogon/lang/es-ES.rc
+++ b/base/system/winlogon/lang/es-ES.rc
@@ -1,4 +1,4 @@
-/* Spanish translation by Lucio Diaz-Flores Varela. Reviewed by Jose Pedro Fernandez Pascual. */
+/* Spanish translation by Lucio Diaz-Flores Varela & Catalin Gabriel Draghita. Reviewed by Jose Pedro Fernandez Pascual. */
 
 LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
 
@@ -24,14 +24,14 @@ END
 
 IDD_SYSSHUTDOWN DIALOGEX 50, 50, 180, 140
 STYLE DS_SHELLFONT | DS_MODALFRAME | DS_CENTER | WS_VISIBLE | WS_CAPTION | WS_POPUP
-CAPTION "System Shutdown"
+CAPTION "Apagar el Sistema"
 FONT 8, "MS Shell Dlg"
 BEGIN
     ICON IDI_WARNING, IDC_SYSSHUTDOWNICON, 6, 7, 18, 20
-    LTEXT "A system shutdown has been initiated. Please save all your work and terminate your session. All unsaved work will be lost when the system shuts down.", -1, 38, 7, 135, 40
-    LTEXT "The system shuts down in:", -1, 38, 50, 90, 8
+    LTEXT "Se ha iniciado el apagado del sistema. Por favor, guarda todo tu trabajo y cierra la sesión. Se perderá todo el trabajo no guardado.", -1, 38, 7, 135, 40
+    LTEXT "El sistema se apagará en:", -1, 38, 50, 90, 8
     LTEXT "00:00:00", IDC_SYSSHUTDOWNTIMELEFT, 132, 50, 41, 8
-    LTEXT "Message:", -1, 38, 65, 135, 8
+    LTEXT "Mensaje:", -1, 38, 65, 135, 8
     EDITTEXT IDC_SYSSHUTDOWNMESSAGE, 34, 75, 139, 58, ES_LEFT | ES_MULTILINE | ES_AUTOVSCROLL | ES_READONLY | NOT WS_BORDER | NOT WS_TABSTOP, WS_EX_STATICEDGE
 END
 


### PR DESCRIPTION
## Purpose

General translation in Spanish.

## Changes

Missing translations and spell corrections.

- Missing translations from applications: `mspaint`, `notepad` & `rapps`

- Missing translations and improvements on `osk`

- Missing translations on cmd help descriptions: `assoc`, `CTTY`, `replace`, `prompt `& `set`

- Missing translation on system: `subst`, `userinit` & `winlogon`