### PR TITLE
[SHELL32] CRecyclerDropTarget spams log (Err rather than Trace) on nominal case (trivial fix)

### DIFF
--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -56,7 +56,7 @@ class CRecyclerDropTarget :
             FileOp.pFrom = (LPWSTR) (((byte*) lpdf) + lpdf->pFiles);;
             if ((fMask & CMIC_MASK_SHIFT_DOWN) == 0)
                 FileOp.fFlags = FOF_ALLOWUNDO;
-            ERR("Deleting file (just the first) = %s, allowundo: %d\n", debugstr_w(FileOp.pFrom), (FileOp.fFlags == FOF_ALLOWUNDO));
+            TRACE("Deleting file (just the first) = %s, allowundo: %d\n", debugstr_w(FileOp.pFrom), (FileOp.fFlags == FOF_ALLOWUNDO));
 
             if (SHFileOperationW(&FileOp) != 0)
             {


### PR DESCRIPTION
Trivial fix

## Purpose

- CRecyclerDropTarget spams log (Err rather than Trace) on nominal case

## Proposed changes

- replace ERR by TRACE.
