### PR TITLE
[OpenGL32] Remove Err Log Spam from wglMakeCurrent in nominal cases CORE-17224

### DIFF
--- a/dll/opengl/opengl32/wgl.c
+++ b/dll/opengl/opengl32/wgl.c
@@ -744,6 +744,7 @@ BOOL WINAPI wglMakeCurrent(HDC hdc, HGLRC hglrc)
         /* Winetest conformance */
         if (GetObjectType( hdc ) != OBJ_DC && GetObjectType( hdc ) != OBJ_MEMDC)
         {
+            if (hdc) ERR( "Error: hdc is not a DC handle!\n");
             SetLastError( ERROR_INVALID_HANDLE );
             return FALSE;
         }

--- a/dll/opengl/opengl32/wgl.c
+++ b/dll/opengl/opengl32/wgl.c
@@ -744,7 +744,10 @@ BOOL WINAPI wglMakeCurrent(HDC hdc, HGLRC hglrc)
         /* Winetest conformance */
         if (GetObjectType( hdc ) != OBJ_DC && GetObjectType( hdc ) != OBJ_MEMDC)
         {
-            if (hdc) ERR( "Error: hdc is not a DC handle!\n");
+            if (hdc)
+            {
+                ERR("hdc (%p) is not a DC handle!\n", hdc);
+            }
             SetLastError( ERROR_INVALID_HANDLE );
             return FALSE;
         }

--- a/dll/opengl/opengl32/wgl.c
+++ b/dll/opengl/opengl32/wgl.c
@@ -742,7 +742,6 @@ BOOL WINAPI wglMakeCurrent(HDC hdc, HGLRC hglrc)
     else
     {
         /* Winetest conformance */
-        
         DWORD objType = GetObjectType(hdc);
         if (objType != OBJ_DC && objType != OBJ_MEMDC)
         {

--- a/dll/opengl/opengl32/wgl.c
+++ b/dll/opengl/opengl32/wgl.c
@@ -742,11 +742,13 @@ BOOL WINAPI wglMakeCurrent(HDC hdc, HGLRC hglrc)
     else
     {
         /* Winetest conformance */
-        if (GetObjectType( hdc ) != OBJ_DC && GetObjectType( hdc ) != OBJ_MEMDC)
+        
+        DWORD objType = GetObjectType(hdc);
+        if (objType != OBJ_DC && objType != OBJ_MEMDC)
         {
             if (hdc)
             {
-                ERR("hdc (%p) is not a DC handle!\n", hdc);
+                ERR("hdc (%p) is not a DC handle (ObjectType: %d)!\n", hdc, objType);
             }
             SetLastError( ERROR_INVALID_HANDLE );
             return FALSE;

--- a/dll/opengl/opengl32/wgl.c
+++ b/dll/opengl/opengl32/wgl.c
@@ -744,7 +744,6 @@ BOOL WINAPI wglMakeCurrent(HDC hdc, HGLRC hglrc)
         /* Winetest conformance */
         if (GetObjectType( hdc ) != OBJ_DC && GetObjectType( hdc ) != OBJ_MEMDC)
         {
-            ERR( "Error: hdc is not a DC handle!\n");
             SetLastError( ERROR_INVALID_HANDLE );
             return FALSE;
         }


### PR DESCRIPTION
## Purpose

- wglCurrentContext raises the following error :
err:(dll/opengl/opengl32/wgl.c:747) Error: hdc is not a DC handle!
In particular during ROS installation, after declining Wine Gecko installation.
- Looking at the code and inspecting wgl.c from Wine HEAD : https://source.winehq.org/git/wine.git/blob_plain/HEAD:/dlls/opengl32/wgl.c
it appears that this "Err" is not an error, since we will naturally fall into this branch in particular when wglMakeCurrent(NULL, NULL) is called (from DLL_THREAD_DETACH or DLL_PROCESS_DETACH,....)
- This Err is not present in Wine's head (where the wglMakeCurrent is also much lighter)

JIRA: https://jira.reactos.org/browse/CORE-17224

## Proposed changes

- Remove unecssary ERR macro call.
