### PR TITLE
[SHELLEXT] Trivial cleanup by removing unused/unnecessary command lines from localization files (.rc) 

### DIFF
--- a/dll/shellext/stobject/lang/cs-CZ.rc
+++ b/dll/shellext/stobject/lang/cs-CZ.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Upravit možnosti napájení"
     IDS_PWR_METER             "&Otevřít ukazatel spotřeby"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "zbývá %u%%"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Zbývá neznámo"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Bezpečně odebrat hardware"
     IDS_HOTPLUG_REMOVE_2 "&Bezpečně odebrat hardwar"
     IDS_HOTPLUG_REMOVE_3 "Bezpečně odebrat%s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Jednotka(%s)"
     IDS_HOTPLUG_DRIVES " - Jednotky(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Hlasitost"
     IDS_VOL_ADJUST "&Upravit vlastnosti zvuku"
     IDS_VOL_OPEN "&Otevřít ovládání hlasitosti"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Hlasitost (ztlumeno)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/de-DE.rc
+++ b/dll/shellext/stobject/lang/de-DE.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Energieverwaltungseigenschaften einstellen"
     IDS_PWR_METER             "Batterieanzeige ö&ffnen"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% verbleibend"
     IDS_PWR_CHARGING          "%u%% und wird geladen"
     IDS_PWR_UNKNOWN_REMAINING "Unbekannt verbleibend"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Hardware sicher entfernen"
     IDS_HOTPLUG_REMOVE_2 "&Hardware sicher entfernen"
     IDS_HOTPLUG_REMOVE_3 "%s entfernen"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Laufwerk (%s)"
     IDS_HOTPLUG_DRIVES " - Laufwerke (%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Lautstärke"
     IDS_VOL_ADJUST "&Audioeigenschaften einstellen"
     IDS_VOL_OPEN "&Lautstärkeregelung öffnen"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Lautstärke (ausgeschaltet)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/en-US.rc
+++ b/dll/shellext/stobject/lang/en-US.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Adjust Power Properties"
     IDS_PWR_METER             "&Open Power Meter"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% remaining"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Unknown remaining"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Safely Remove Hardware"
     IDS_HOTPLUG_REMOVE_2 "&Safely Remove Hardware"
     IDS_HOTPLUG_REMOVE_3 "Safely remove %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Drive(%s)"
     IDS_HOTPLUG_DRIVES " - Drives(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Volume"
     IDS_VOL_ADJUST "&Adjust Audio Properties"
     IDS_VOL_OPEN "&Open Volume Control"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Volume (muted)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/es-ES.rc
+++ b/dll/shellext/stobject/lang/es-ES.rc
@@ -18,7 +18,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Ajustar propiedades de energía"
     IDS_PWR_METER             "Abrir &medidor de energía"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "Queda un %u%%"
     IDS_PWR_CHARGING          "%u%% y cargando"
     IDS_PWR_UNKNOWN_REMAINING "Estado de batería desconocido"
@@ -30,7 +29,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Desconectar de forma segura"
     IDS_HOTPLUG_REMOVE_2 "&Desconectar de forma segura"
     IDS_HOTPLUG_REMOVE_3 "Desconectar de forma segura %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Unidad(%s)"
     IDS_HOTPLUG_DRIVES " - Unidades(%s)"
@@ -42,7 +40,6 @@ BEGIN
     IDS_VOL_VOLUME "Volumen"
     IDS_VOL_ADJUST "&Ajustar propiedades de audio"
     IDS_VOL_OPEN "Abrir &control de volumen"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Volumen (silenciado)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/fr-FR.rc
+++ b/dll/shellext/stobject/lang/fr-FR.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Modifier les paramètres d'alimentation"
     IDS_PWR_METER             "&Open Power Meter"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% remaining"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Unknown remaining"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Safely Remove Hardware"
     IDS_HOTPLUG_REMOVE_2 "&Safely Remove Hardware"
     IDS_HOTPLUG_REMOVE_3 "Safely remove %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Drive(%s)"
     IDS_HOTPLUG_DRIVES " - Drives(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Volume"
     IDS_VOL_ADJUST "&Ajuster les propriétés audio"
     IDS_VOL_OPEN "&Ouvrir le controle du volume"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Volume (muet)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/hi-IN.rc
+++ b/dll/shellext/stobject/lang/hi-IN.rc
@@ -24,7 +24,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "पावर &गुण समायोजित करें"
     IDS_PWR_METER             "पावर मीटर &खोलें"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% शेष"
     IDS_PWR_CHARGING          "%u%% और चार्ज"
     IDS_PWR_UNKNOWN_REMAINING "अज्ञात शेष"
@@ -36,7 +35,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "हार्डवेयर सुरक्षित रूप से निकालें"
     IDS_HOTPLUG_REMOVE_2 "हार्डवेयर &सुरक्षित रूप से निकालें"
     IDS_HOTPLUG_REMOVE_3 "%s को सुरक्षित रूप से हटा दें"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - ड्राइव(%s)"
     IDS_HOTPLUG_DRIVES " - ड्राइव(%s)"
@@ -48,7 +46,6 @@ BEGIN
     IDS_VOL_VOLUME "वॉल्यूम"
     IDS_VOL_ADJUST "ऑडियो गुण &समायोजित करें"
     IDS_VOL_OPEN "वॉल्यूम नियंत्रण &खोलें"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "वॉल्यूम (मौन)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/it-IT.rc
+++ b/dll/shellext/stobject/lang/it-IT.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Modifica proprietà alimentazione"
     IDS_PWR_METER             "&Apri misuratore alimentazione"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% rimanenti"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Autonomia sconosciuta"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1  "Rimozione sicura dell'Hardware"
     IDS_HOTPLUG_REMOVE_2  "&Rimozione sicura dell'Hardware"
     IDS_HOTPLUG_REMOVE_3  "Rimozione sicura di %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA     ", "
     IDS_HOTPLUG_DRIVE     " - Unità disco(%s)"
     IDS_HOTPLUG_DRIVES    " - Unità dischi(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME  "Volume"
     IDS_VOL_ADJUST  "&Modifica proprietà audio"
     IDS_VOL_OPEN    "&Apri controllo del Volume"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED   "Volume (spento)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/pl-PL.rc
+++ b/dll/shellext/stobject/lang/pl-PL.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Opcje zasilania"
     IDS_PWR_METER             "&Otwórz miernik baterii"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "Pozostało %u%%"
     IDS_PWR_CHARGING          "%u%% i ładuje"
     IDS_PWR_UNKNOWN_REMAINING "Stan naładowania nieznany"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Bezpieczne usuwanie sprzętu"
     IDS_HOTPLUG_REMOVE_2 "&Bezpieczne usuwanie sprzętu"
     IDS_HOTPLUG_REMOVE_3 "Wysuń %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Dysk(%s)"
     IDS_HOTPLUG_DRIVES " - Dyski(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Dźwięk"
     IDS_VOL_ADJUST "&Właściwości dźwięku"
     IDS_VOL_OPEN "&Otwórz regulację głośności"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Głośność (wyciszona)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/pt-PT.rc
+++ b/dll/shellext/stobject/lang/pt-PT.rc
@@ -17,7 +17,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Ajustar propriedades de energia"
     IDS_PWR_METER             "&Abrir ""Medidor de energia"""
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% remanescente"
     IDS_PWR_CHARGING          "%u%% a carregar"
     IDS_PWR_UNKNOWN_REMAINING "remanescente deconhecido"
@@ -29,7 +28,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "&Remover Hardware em segurança"
     IDS_HOTPLUG_REMOVE_2 "&Remover Hardware em segurança"
     IDS_HOTPLUG_REMOVE_3 "Remover em segurança %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Controlador(%s)"
     IDS_HOTPLUG_DRIVES " - Controladores(%s)"
@@ -41,7 +39,6 @@ BEGIN
     IDS_VOL_VOLUME "Volume"
     IDS_VOL_ADJUST "&Ajustar Propriedades de Audio"
     IDS_VOL_OPEN "&Abrir o Control de volume"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Volume (em mute)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/ro-RO.rc
+++ b/dll/shellext/stobject/lang/ro-RO.rc
@@ -19,7 +19,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Ajustare proprietăți de consum energie"
     IDS_PWR_METER             "&Deschide Contor de energie"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "Au mai rămas %u%%"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Nu este disponibil cât a mai rămas"
@@ -31,7 +30,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Scoate în siguranță acest dispozitiv"
     IDS_HOTPLUG_REMOVE_2 "S&coate în siguranță acest dispozitiv"
     IDS_HOTPLUG_REMOVE_3 "Scoate în siguranță %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - unitate (%s)"
     IDS_HOTPLUG_DRIVES " - unități (%s)"
@@ -43,7 +41,6 @@ BEGIN
     IDS_VOL_VOLUME "Volum"
     IDS_VOL_ADJUST "&Ajustează proprietăți audio"
     IDS_VOL_OPEN "&Deschide control de volum"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Volum (mut)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/ru-RU.rc
+++ b/dll/shellext/stobject/lang/ru-RU.rc
@@ -19,7 +19,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Настройка параметров электропитания"
     IDS_PWR_METER             "&Открыть показатели питания"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%u%% осталось"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "Неизвестно"
@@ -31,7 +30,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Безопасное извлечение устройства"
     IDS_HOTPLUG_REMOVE_2 "&Безопасное извлечение устройства"
     IDS_HOTPLUG_REMOVE_3 "Безопасное извлечение %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Диск(%s)"
     IDS_HOTPLUG_DRIVES " - Диски(%s)"
@@ -43,7 +41,6 @@ BEGIN
     IDS_VOL_VOLUME "Громкость"
     IDS_VOL_ADJUST "&Настройка параметров аудио"
     IDS_VOL_OPEN "&Открыть управление громкостью"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Громкость (выключено)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/tr-TR.rc
+++ b/dll/shellext/stobject/lang/tr-TR.rc
@@ -19,7 +19,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "&Güç Özelliklerini Düzenle"
     IDS_PWR_METER             "G&üç Ölçücüsünü Aç"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "%%%u kaldı."
     IDS_PWR_CHARGING          "%%%u (Yükleniyor)"
     IDS_PWR_UNKNOWN_REMAINING "Bilinmeyen kalan."
@@ -31,7 +30,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "Donanımı Güvenli Kaldır"
     IDS_HOTPLUG_REMOVE_2 "&Donanımı Güvenli Kaldır"
     IDS_HOTPLUG_REMOVE_3 "%s Donanımını Güvenli Kaldır"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - Sürücü (%s)"
     IDS_HOTPLUG_DRIVES " - Sürücüler (%s)"
@@ -43,7 +41,6 @@ BEGIN
     IDS_VOL_VOLUME "Ses Düzeyi"
     IDS_VOL_ADJUST "&Ses Özelliklerini Düzenle"
     IDS_VOL_OPEN "&Ses Düzeyi Denetimini Aç"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "Ses Düzeyi (Sessiz)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/zh-CN.rc
+++ b/dll/shellext/stobject/lang/zh-CN.rc
@@ -19,7 +19,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "调整电源属性(&A)"
     IDS_PWR_METER             "开放式电源表(&O)"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "剩余 %u%%"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "未知剩余"
@@ -31,7 +30,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "安全地删除硬件"
     IDS_HOTPLUG_REMOVE_2 "安全地删除硬件(&S)"
     IDS_HOTPLUG_REMOVE_3 "安全地删除 %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - 磁盘(%s)"
     IDS_HOTPLUG_DRIVES " - 磁盘(%s)"
@@ -43,7 +41,6 @@ BEGIN
     IDS_VOL_VOLUME "音量"
     IDS_VOL_ADJUST "调整音频属性(&A)"
     IDS_VOL_OPEN "打开音量控制(&O)"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "(静音)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/lang/zh-TW.rc
+++ b/dll/shellext/stobject/lang/zh-TW.rc
@@ -19,7 +19,6 @@ BEGIN
     //Power related strings
     IDS_PWR_PROPERTIES        "調整電源屬性(&A)"
     IDS_PWR_METER             "開放式電源表(&O)"
-    IDS_PWR_RUN               "shell32.dll,Control_RunDLL PowerCfg.cpl"
     IDS_PWR_PERCENT_REMAINING "剩餘 %u%%"
     IDS_PWR_CHARGING          "%u%% and charging"
     IDS_PWR_UNKNOWN_REMAINING "未知剩餘"
@@ -31,7 +30,6 @@ BEGIN
     IDS_HOTPLUG_REMOVE_1 "安全地刪除硬體"
     IDS_HOTPLUG_REMOVE_2 "安全地刪除硬體(&S)"
     IDS_HOTPLUG_REMOVE_3 "安全地刪除 %s"
-    IDS_HOTPLUG_RUN "shell32.dll,Control_RunDLL hotplug.dll"
     IDS_HOTPLUG_COMMA ", "
     IDS_HOTPLUG_DRIVE " - 磁碟(%s)"
     IDS_HOTPLUG_DRIVES " - 磁碟(%s)"
@@ -43,7 +41,6 @@ BEGIN
     IDS_VOL_VOLUME "音量"
     IDS_VOL_ADJUST "調整音訊屬性(&A)"
     IDS_VOL_OPEN "開啟音量控制(&O)"
-    IDS_VOL_RUN "SNDVOL32.EXE"
     IDS_VOL_MUTED "(靜音)"
 
     //Keyboard-Mouse related strings

--- a/dll/shellext/stobject/resource.h
+++ b/dll/shellext/stobject/resource.h
@@ -4,7 +4,6 @@
 
 #define IDS_PWR_PROPERTIES        152
 #define IDS_PWR_METER             153
-#define IDS_PWR_RUN               157
 #define IDS_PWR_PERCENT_REMAINING 158
 #define IDS_PWR_CHARGING          159
 #define IDS_PWR_UNKNOWN_REMAINING 160
@@ -18,7 +17,6 @@
 #define IDS_HOTPLUG_REMOVE_1      211
 #define IDS_HOTPLUG_REMOVE_2      215
 #define IDS_HOTPLUG_REMOVE_3      216
-#define IDS_HOTPLUG_RUN           217
 #define IDS_HOTPLUG_COMMA         218
 #define IDS_HOTPLUG_DRIVE         219
 #define IDS_HOTPLUG_DRIVES        220
@@ -32,7 +30,6 @@
 #define IDS_VOL_VOLUME            252
 #define IDS_VOL_ADJUST            255
 #define IDS_VOL_OPEN              256
-#define IDS_VOL_RUN               257
 #define IDS_VOL_MUTED             258
 
 #define IDS_KEYS_STICKY           330


### PR DESCRIPTION
## Purpose

- ShellExt .rc file contain command line elements which are neither a good design solution, nor language-dependant nor even used in the code at all.

## Proposed changes

- removal of these unused elements
