### PR TITLE
[CRT] Remove remnant '__globallocalestatus' code

### DIFF
--- a/sdk/include/crt/ctype.h
+++ b/sdk/include/crt/ctype.h
@@ -54,7 +54,6 @@ extern "C" {
   extern const unsigned char __newcumap[];
   extern pthreadlocinfo __ptlocinfo;
   extern pthreadmbcinfo __ptmbcinfo;
-  extern int __globallocalestatus;
   extern int __locale_changed;
   extern struct threadlocaleinfostruct __initiallocinfo;
   extern _locale_tstruct __initiallocalestructinfo;

--- a/sdk/include/crt/mbctype.h
+++ b/sdk/include/crt/mbctype.h
@@ -41,7 +41,6 @@ extern "C" {
   /* CRT stuff */
 #if 1
   extern pthreadmbcinfo __ptmbcinfo;
-  extern int __globallocalestatus;
   extern int __locale_changed;
   extern struct threadmbcinfostruct __initialmbcinfo;
   pthreadmbcinfo __cdecl __updatetmbcinfo(void);

--- a/sdk/lib/crt/startup/crtexe.c
+++ b/sdk/lib/crt/startup/crtexe.c
@@ -137,11 +137,7 @@ pre_c_init (void)
     {
       __setusermatherr (_matherr);
     }
-#ifndef __clang__ /* FIXME: CORE-14042 */
-  if (__globallocalestatus == -1)
-    {
-    }
-#endif
+
   return 0;
 }
 


### PR DESCRIPTION
Addendum to 183b263 (r55869).
JIRA issue: [CORE-14042](https://jira.reactos.org/browse/CORE-14042)