### PR TITLE
[GITHUB] clang-cl and msvc-amd64: Have CD uploads, but disabled

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,16 @@ jobs:
       run: |
         cmake --build . --target bootcd
         cmake --build . --target livecd
+#     - name: Upload bootcd
+#       uses: actions/upload-artifact@v1
+#       with:
+#         name: reactos-clang-cl-i386-${{github.sha}}
+#         path: build/bootcd.iso
+#     - name: Upload livecd
+#       uses: actions/upload-artifact@v1
+#       with:
+#         name: reactos-clang-cl-i386-${{github.sha}}
+#         path: build/livecd.iso
 
   build-msvc-i386:
     name: MSVC (i386)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,13 +181,13 @@ jobs:
       run: |
         cmake --build . --target bootcd
         cmake --build . --target livecd
-    - name: Upload bootcd
-      uses: actions/upload-artifact@v1
-      with:
-        name: reactos-msvc-amd64-${{github.sha}}
-        path: build/bootcd.iso
-    - name: Upload livecd
-      uses: actions/upload-artifact@v1
-      with:
-        name: reactos-msvc-amd64-${{github.sha}}
-        path: build/livecd.iso
+#     - name: Upload bootcd
+#       uses: actions/upload-artifact@v1
+#       with:
+#         name: reactos-msvc-amd64-${{github.sha}}
+#         path: build/bootcd.iso
+#     - name: Upload livecd
+#       uses: actions/upload-artifact@v1
+#       with:
+#         name: reactos-msvc-amd64-${{github.sha}}
+#         path: build/livecd.iso


### PR DESCRIPTION
Pave the way, but don't waste resources.

JIRA issue: [CORE-17202](https://jira.reactos.org/browse/CORE-17202)