### PR TITLE
[SHELL32] Show "size on disk" in file/folder properties

### DIFF
--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1371,7 +1371,7 @@ CFileDefExt::_CountFolderAndFilesThreadProc(LPVOID lpParameter)
 }
 
 BOOL
-CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
+CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPCWSTR pwszBuf, DWORD *ticks)
 {
     CString sBuf = pwszBuf;
     sBuf += L"\\" ;
@@ -1380,10 +1380,10 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
     CString sFileName;
 
     WIN32_FIND_DATAW wfd;
-    HANDLE hFind = FindFirstFileW(sSearch.GetBuffer(), &wfd);
+    HANDLE hFind = FindFirstFileW(sSearch, &wfd);
     if (hFind == INVALID_HANDLE_VALUE)
     {
-        ERR("FindFirstFileW %ls failed\n", sSearch.GetBuffer());
+        ERR("FindFirstFileW %ls failed\n", sSearch.GetString());
         return FALSE;
     }
 
@@ -1405,7 +1405,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
 
             ++m_cFolders;
 
-            CountFolderAndFiles(hwndDlg, sFileName.GetBuffer(), ticks);
+            CountFolderAndFiles(hwndDlg, sFileName, ticks);
         }
         else
         {
@@ -1416,8 +1416,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
             FileSize.u.HighPart = wfd.nFileSizeHigh;
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
-            if (!GetPhysicalFileSize(sFileName.GetBuffer(), &FileSize))
-                ERR("GetPhysicalFileSize failed for %ls\n", sFileName.GetBuffer());
+            if (!GetPhysicalFileSize(sFileName.GetString(), &FileSize))
+                ERR("GetPhysicalFileSize failed for %ls\n", sFileName.GetString());
             m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
         }
         if (GetTickCount() - *ticks > (DWORD) 300)

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -568,7 +568,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                     if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
                     {
                         ulBlockSize = ulBytesPerSector * ulSectorsPerCluster;
-                        if(FileSize.QuadPart % (ulBlockSize))
+                        if (FileSize.QuadPart % ulBlockSize)
                         {
                             FileSize.QuadPart = ((FileSize.QuadPart / (ulBlockSize))+1)*ulBlockSize;
                             SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf));

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1409,7 +1409,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
 
     do
     {
-        ZeroMemory(WorkBuffer,sizeof(WorkBuffer));
+        ZeroMemory(WorkBuffer, sizeof(WorkBuffer));
         wcscpy(WorkBuffer,PathBuffer);
         wcscat(WorkBuffer,wfd.cFileName);
         if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1420,9 +1420,10 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     {
         cchWorkBuf = wcslen(PathBuffer) + wcslen(wfd.cFileName) + 1;
         WorkBuffer = (WCHAR *)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, cchWorkBuf * 2);
-        if (!PathBuffer)
+        if (!WorkBuffer)
         {
             ERR("HeapAlloc failed\n");
+            HeapFree(GetProcessHeap(), 0, PathBuffer);
             return FALSE;
         }
         StringCchCopyW(WorkBuffer, cchWorkBuf, PathBuffer);
@@ -1498,6 +1499,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
 
     FindClose(hFind);
 
-    HeapFree(GetProcessHeap(), 0, PathBuffer);    
+    HeapFree(GetProcessHeap(), 0, PathBuffer);
     return TRUE;
 }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -613,7 +613,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 if (GetPhysicalFileSize(m_wszPath, &FileSize))
                     SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf));
                 else
-                    ERR("Unreliable size on disk");
+                    ERR("Unreliable size on disk\n");
 
                 SetDlgItemTextW(hwndDlg, 14012, wszBuf);
             }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -611,8 +611,8 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 // Compute file on disk. If fails, use logical size
                 if (GetPhysicalFileSize(m_wszPath, &FileSize))
                     SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf));
-                    else
-                    ERR("Unreliable size on disl");
+                else
+                    ERR("Unreliable size on disk");
 
                SetDlgItemTextW(hwndDlg, 14012, wszBuf);
             }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -71,7 +71,7 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
     NtClose(FileHandle);
     if (!NT_SUCCESS(Status))
     {
-        ERR("NtQueryInformationFile failed for %S\n", PathBuffer);
+        ERR("NtQueryInformationFile failed for %S (Status: %08lX)\n", PathBuffer, Status);
         return FALSE;
     }
     

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -567,7 +567,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 {
                     if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
                     {
-                        ulBlockSize = ulBytesPerSector*ulSectorsPerCluster;
+                        ulBlockSize = ulBytesPerSector * ulSectorsPerCluster;
                         if(FileSize.QuadPart % (ulBlockSize))
                         {
                             FileSize.QuadPart = ((FileSize.QuadPart / (ulBlockSize))+1)*ulBlockSize;

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -562,6 +562,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 // Calculate size on disc
                 // Calculate size on disc
                 // if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
+                // This could be improved as per : https://docs.microsoft.com/en-us/previous-versions/technet-magazine/hh148159(v=msdn.10)
                 if (GetVolumePathName(m_wszPath, szVolumePathName, _countof(szVolumePathName)))
                 {
                     if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
@@ -1386,6 +1387,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
             // if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
+            // This could be improved as per : https://docs.microsoft.com/en-us/previous-versions/technet-magazine/hh148159(v=msdn.10)
             if (GetVolumePathName(pwszBuf, szVolumePathName, _countof(szVolumePathName)))
             {
                 if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -558,8 +558,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
             FileSize.u.HighPart = FileInfo.nFileSizeHigh;
             if (SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf)))
             {    
-                SetDlgItemTextW(hwndDlg, 14011, wszBuf);
-                // Calculate size on disc
+                SetDlgItemTextW(hwndDlg, 14011, wszBuf);                
                 // Calculate size on disc
                 // if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
                 // This could be improved as per : https://docs.microsoft.com/en-us/previous-versions/technet-magazine/hh148159(v=msdn.10)
@@ -570,7 +569,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                         ulBlockSize = ulBytesPerSector * ulSectorsPerCluster;
                         if (FileSize.QuadPart % ulBlockSize)
                         {
-                            FileSize.QuadPart = ((FileSize.QuadPart / (ulBlockSize))+1)*ulBlockSize;
+                            FileSize.QuadPart = ((FileSize.QuadPart / (ulBlockSize)) + 1) * ulBlockSize;
                             SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf));
                         }
                    }
@@ -1392,8 +1391,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             {
                 if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
                 {
-                    ulBlockSize = ulBytesPerSector*ulSectorsPerCluster;
-                    m_DirSizeOnDisc.QuadPart += FileSize.QuadPart % (ulBlockSize) ? ((FileSize.QuadPart/(ulBlockSize))+1)*ulBlockSize : FileSize.QuadPart;
+                    ulBlockSize = ulBytesPerSector * ulSectorsPerCluster;
+                    m_DirSizeOnDisc.QuadPart += FileSize.QuadPart % (ulBlockSize) ? ((FileSize.QuadPart/(ulBlockSize)) + 1) * ulBlockSize : FileSize.QuadPart;
                 }
                 else
                     m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -20,8 +20,10 @@
  */
 
 #include "precomp.h"
-#include "iofuncs.h"
-#include "obfuncs.h"
+
+#define NTOS_MODE_USER
+#include <ndk/iofuncs.h>
+#include <ndk/obfuncs.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -55,6 +55,7 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
                         &IoStatusBlock,
                         FILE_SHARE_READ,
                         FILE_SYNCHRONOUS_IO_NONALERT);
+    RtlFreeUnicodeString(&FileName);
     if (!NT_SUCCESS(Status))
     {
         ERR("NtOpenFile failed for %S (Status 0x%08lx)\n", PathBuffer, Status);
@@ -1386,7 +1387,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     --cchFilenameMax;
 
     // Store path without wildcard
-    ZeroMemory(PathBuffer, sizeof(PathBuffer));
     StringCchCopyW(PathBuffer, sizeof(PathBuffer), pwszBuf);
 
     /* Find all files, FIXME: shouldn't be "*"? */

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1387,7 +1387,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     --cchFilenameMax;
 
     // Store path without wildcard
-    StringCchCopyW(PathBuffer, sizeof(PathBuffer), pwszBuf);
+    StringCbCopyW(PathBuffer, sizeof(PathBuffer), pwszBuf);
 
     /* Find all files, FIXME: shouldn't be "*"? */
     StringCchCopyW(pwszFilename, cchFilenameMax, L"*");

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1360,7 +1360,6 @@ CFileDefExt::_CountFolderAndFilesThreadProc(LPVOID lpParameter)
 {
     _CountFolderAndFilesData *data = static_cast<_CountFolderAndFilesData*>(lpParameter);
     DWORD ticks = 0;
-
     data->This->CountFolderAndFiles(data->hwndDlg, data->pwszBuf, &ticks);
 
     //Release the CFileDefExt and data object holds in the copying thread.
@@ -1413,7 +1412,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
             m_cFiles++;
 
             ULARGE_INTEGER FileSize;
-
             FileSize.u.LowPart  = wfd.nFileSizeLow;
             FileSize.u.HighPart = wfd.nFileSizeHigh;
             m_DirSize.QuadPart += FileSize.QuadPart;

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -561,7 +561,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 SetDlgItemTextW(hwndDlg, 14011, wszBuf);
                 // Calculate size on disc
                 // Calculate size on disc
-                //if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
+                // if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
                 if (GetVolumePathName(m_wszPath, szVolumePathName, _countof(szVolumePathName)))
                 {
                     if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
@@ -1385,7 +1385,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             FileSize.u.HighPart = wfd.nFileSizeHigh;
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
-            //if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
+            // if disk usage is not aligned on a complete disk geometry block (sector/cluster), align on the next block size, depending on disk geometry data
             if (GetVolumePathName(pwszBuf, szVolumePathName, _countof(szVolumePathName)))
             {
                 if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
@@ -1395,7 +1395,9 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
                 }
                 else
                     m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
-            } else {
+            }
+            else
+            {
                 m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
             }
         }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1409,8 +1409,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     do
     {
         ZeroMemory(WorkBuffer, sizeof(WorkBuffer));
-        StringCchCopyW(WorkBuffer, sizeof(WorkBuffer), PathBuffer);
-        StringCchCatW(WorkBuffer, sizeof(WorkBuffer), wfd.cFileName);
+        StringCbCopyW(WorkBuffer, sizeof(WorkBuffer), PathBuffer);
+        StringCbCatW(WorkBuffer, sizeof(WorkBuffer), wfd.cFileName);
 
         if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1386,7 +1386,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     --cchFilenameMax;
 
     // Store path without wildcard
-    ZeroMemory(PathBuffer,sizeof(PathBuffer));
+    ZeroMemory(PathBuffer, sizeof(PathBuffer));
     wcscpy(PathBuffer,pwszBuf);
 
     /* Find all files, FIXME: shouldn't be "*"? */

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1380,8 +1380,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     /* Find filename position */
     UINT cchBuf = wcslen(pwszBuf);
     WCHAR *pwszFilename = pwszBuf + cchBuf;
-    WCHAR * PathBuffer;
-    WCHAR * WorkBuffer;
+    WCHAR *PathBuffer;
+    WCHAR *WorkBuffer;
     UINT cchWorkBuf;
 
     size_t cchFilenameMax = cchBufMax - cchBuf;

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -71,7 +71,6 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
     if (!NT_SUCCESS(Status))
     {
         ERR("NtQueryInformationFile failed for %S\n", StdPathBuffer);
-        NtClose(FileHandle);
         return FALSE;
     }
     

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -39,8 +39,8 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
     NTSTATUS Status;
     WCHAR StdPathBuffer[MAX_PATH] = L"";
         
-    wcscpy(StdPathBuffer,L"\\??\\");
-    wcscat(StdPathBuffer,PathBuffer);
+    wcscpy(StdPathBuffer, L"\\??\\");
+    wcscat(StdPathBuffer, PathBuffer);
     
     //wcscpy(StdPathBuffer,PathBuffer);
     RtlInitUnicodeString(&FileName, StdPathBuffer);

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1376,8 +1376,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     /* Find filename position */
     UINT cchBuf = wcslen(pwszBuf);
     WCHAR *pwszFilename = pwszBuf + cchBuf;
-    WCHAR PathBuffer[MAX_PATH]=L"";
-    WCHAR WorkBuffer[MAX_PATH]=L"";
+    WCHAR PathBuffer[MAX_PATH] = L"";
+    WCHAR WorkBuffer[MAX_PATH] = L"";
 
     size_t cchFilenameMax = cchBufMax - cchBuf;
     if (!cchFilenameMax)

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -615,7 +615,7 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
                 else
                     ERR("Unreliable size on disk");
 
-               SetDlgItemTextW(hwndDlg, 14012, wszBuf);
+                SetDlgItemTextW(hwndDlg, 14012, wszBuf);
             }
         }
     }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -76,7 +76,6 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
     }
     
     Size->QuadPart = FileInfo.AllocationSize.QuadPart;
-    NtClose(FileHandle);
     return TRUE;
 }
 

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1410,8 +1410,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     do
     {
         ZeroMemory(WorkBuffer, sizeof(WorkBuffer));
-        wcscpy(WorkBuffer,PathBuffer);
-        wcscat(WorkBuffer,wfd.cFileName);
+        wcscpy(WorkBuffer, PathBuffer);
+        wcscat(WorkBuffer, wfd.cFileName);
         if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             /* Don't process "." and ".." items */

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -485,9 +485,9 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
     WIN32_FIND_DATAW FileInfo; // WIN32_FILE_ATTRIBUTE_DATA
     WCHAR wszBuf[MAX_PATH];
 
-    ULONG lpBytesPerSector;
-    ULONG lpSectorsPerCluster;
-    TCHAR lpszVolumePathName[MAX_PATH];
+    ULONG ulBytesPerSector;
+    ULONG ulSectorsPerCluster;
+    TCHAR szVolumePathName[MAX_PATH];
 
     TRACE("InitFileAttr %ls\n", m_wszPath);
 
@@ -559,11 +559,13 @@ CFileDefExt::InitFileAttr(HWND hwndDlg)
             {    
                 SetDlgItemTextW(hwndDlg, 14011, wszBuf);
                 // Calculate size on disc
-                if( GetVolumePathName(m_wszPath, lpszVolumePathName, sizeof(lpszVolumePathName) / sizeof(TCHAR)) ) {
-                    if( GetDiskFreeSpace(lpszVolumePathName, &lpSectorsPerCluster, &lpBytesPerSector, NULL, NULL) ) {
-                        if(FileSize.QuadPart % (lpBytesPerSector*lpSectorsPerCluster))
+                if (GetVolumePathName(m_wszPath, szVolumePathName, _countof(szVolumePathName)))
+                {
+                    if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &ulBytesPerSector, NULL, NULL))
+                    {
+                        if(FileSize.QuadPart % (ulBytesPerSector*ulSectorsPerCluster))
                         {
-                            FileSize.QuadPart = ((FileSize.QuadPart / (lpBytesPerSector*lpSectorsPerCluster))+1)*lpBytesPerSector*lpSectorsPerCluster;
+                            FileSize.QuadPart = ((FileSize.QuadPart / (ulBytesPerSector*ulSectorsPerCluster))+1)*ulBytesPerSector*ulSectorsPerCluster;
                             SH_FormatFileSizeWithBytes(&FileSize, wszBuf, _countof(wszBuf));
                         }
                    }
@@ -1331,8 +1333,8 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
     UINT cchBuf = wcslen(pwszBuf);
     WCHAR *pwszFilename = pwszBuf + cchBuf;
     ULONG lpBytesPerSector;
-    ULONG lpSectorsPerCluster;
-    TCHAR lpszVolumePathName[MAX_PATH];
+    ULONG ulSectorsPerCluster;
+    TCHAR szVolumePathName[MAX_PATH];
     size_t cchFilenameMax = cchBufMax - cchBuf;
     if (!cchFilenameMax)
         return FALSE;
@@ -1378,9 +1380,10 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             FileSize.u.HighPart = wfd.nFileSizeHigh;
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
-            if( GetVolumePathName(pwszBuf, lpszVolumePathName, sizeof(lpszVolumePathName) / sizeof(TCHAR)) ) {
-                if( GetDiskFreeSpace(lpszVolumePathName, &lpSectorsPerCluster, &lpBytesPerSector, NULL, NULL) )
-                    m_DirSizeOnDisc.QuadPart += FileSize.QuadPart % (lpBytesPerSector*lpSectorsPerCluster) ? ((FileSize.QuadPart/(lpBytesPerSector*lpSectorsPerCluster))+1)*lpBytesPerSector*lpSectorsPerCluster : FileSize.QuadPart;
+            if (GetVolumePathName(pwszBuf, szVolumePathName, _countof(szVolumePathName)))
+            {
+                if (GetDiskFreeSpace(szVolumePathName, &ulSectorsPerCluster, &lpBytesPerSector, NULL, NULL))
+                    m_DirSizeOnDisc.QuadPart += FileSize.QuadPart % (lpBytesPerSector*ulSectorsPerCluster) ? ((FileSize.QuadPart/(lpBytesPerSector*ulSectorsPerCluster))+1)*lpBytesPerSector*ulSectorsPerCluster : FileSize.QuadPart;
                 else
                     m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
             } else {

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1432,7 +1432,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             FileSize.u.HighPart = wfd.nFileSizeHigh;
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
-            if(!GetPhysicalFileSize(WorkBuffer, &FileSize))
+            if (!GetPhysicalFileSize(WorkBuffer, &FileSize))
                 ERR("GetPhysicalFileSize failed for %ls",WorkBuffer);
             
             m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1418,7 +1418,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
             // Calculate size on disc
             if (!GetPhysicalFileSize(sFileName.GetBuffer(), &FileSize))
                 ERR("GetPhysicalFileSize failed for %ls\n", sFileName.GetBuffer());
-            
             m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
         }
         if (GetTickCount() - *ticks > (DWORD) 300)
@@ -1444,7 +1443,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
             else
                 break;
         }
-
     } while(FindNextFileW(hFind, &wfd));
 
     if (root && IsWindow(hwndDlg))
@@ -1465,6 +1463,5 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, DWORD *ticks)
     }
 
     FindClose(hFind);
-
     return TRUE;
 }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1433,7 +1433,7 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
             m_DirSize.QuadPart += FileSize.QuadPart;
             // Calculate size on disc
             if (!GetPhysicalFileSize(WorkBuffer, &FileSize))
-                ERR("GetPhysicalFileSize failed for %ls",WorkBuffer);
+                ERR("GetPhysicalFileSize failed for %ls", WorkBuffer);
             
             m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
         }

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1419,7 +1419,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
 
             ++m_cFolders;
 
-            StringCchCopyW(pwszFilename, cchFilenameMax, wfd.cFileName);
             CountFolderAndFiles(hwndDlg, WorkBuffer, cchBufMax, ticks);
         }
         else

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -67,7 +67,7 @@ BOOL GetPhysicalFileSize(LPCWSTR PathBuffer, PULARGE_INTEGER Size)
                                     &FileInfo,
                                     sizeof(FileInfo),
                                     FileStandardInformation);
-                                    
+    NtClose(FileHandle);
     if (!NT_SUCCESS(Status))
     {
         ERR("NtQueryInformationFile failed for %S\n", StdPathBuffer);

--- a/dll/win32/shell32/dialogs/filedefext.cpp
+++ b/dll/win32/shell32/dialogs/filedefext.cpp
@@ -1436,7 +1436,6 @@ CFileDefExt::CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, D
                 ERR("GetPhysicalFileSize failed for %ls",WorkBuffer);
             
             m_DirSizeOnDisc.QuadPart += FileSize.QuadPart;
-            
         }
         if (GetTickCount() - *ticks > (DWORD) 300)
         {

--- a/dll/win32/shell32/dialogs/filedefext.h
+++ b/dll/win32/shell32/dialogs/filedefext.h
@@ -75,7 +75,7 @@ private:
     static INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-	BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, LPDWORD ticks);
+	BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, LPDWORD ticks);
 
 	WCHAR m_wszPath[MAX_PATH];
 	CFileVersionInfo m_VerInfo;
@@ -137,7 +137,6 @@ struct _CountFolderAndFilesData {
     CFileDefExt *This;
     HWND hwndDlg;
     LPWSTR pwszBuf;
-    UINT cchBufMax;
 };
 
 #endif /* _FILE_DEF_EXT_H_ */

--- a/dll/win32/shell32/dialogs/filedefext.h
+++ b/dll/win32/shell32/dialogs/filedefext.h
@@ -54,12 +54,12 @@ class CFileVersionInfo
 };
 
 class CFileDefExt :
-    public CComCoClass<CFileDefExt, &CLSID_ShellFileDefExt>,
-    public CComObjectRootEx<CComMultiThreadModelNoCS>,
-    public IShellExtInit,
-    public IContextMenu,
-    public IShellPropSheetExt,
-    public IObjectWithSite
+	public CComCoClass<CFileDefExt, &CLSID_ShellFileDefExt>,
+	public CComObjectRootEx<CComMultiThreadModelNoCS>,
+	public IShellExtInit,
+	public IContextMenu,
+	public IShellPropSheetExt,
+	public IObjectWithSite
 {
 private:
     VOID InitOpensWithField(HWND hwndDlg);
@@ -73,15 +73,15 @@ private:
     BOOL InitVersionPage(HWND hwndDlg);
     BOOL InitFolderCustomizePage(HWND hwndDlg);
     static INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, LPDWORD ticks);
+	static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+	BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, LPDWORD ticks);
 
-    WCHAR m_wszPath[MAX_PATH];
-    CFileVersionInfo m_VerInfo;
-    BOOL m_bDir;
+	WCHAR m_wszPath[MAX_PATH];
+	CFileVersionInfo m_VerInfo;
+	BOOL m_bDir;
 
-    DWORD m_cFiles;
+	DWORD m_cFiles;
     DWORD m_cFolders;
     ULARGE_INTEGER m_DirSize;
     ULARGE_INTEGER m_DirSizeOnDisc;
@@ -95,8 +95,8 @@ private:
     BOOL    m_bFolderIconIsSet;
 
 public:
-    CFileDefExt();
-    ~CFileDefExt();
+	CFileDefExt();
+	~CFileDefExt();
 
     // FolderCustomize
     BOOL OnFolderCustApply(HWND hwndDlg);
@@ -104,21 +104,21 @@ public:
     void OnFolderCustDestroy(HWND hwndDlg);
     void UpdateFolderIcon(HWND hwndDlg);
 
-    // IShellExtInit
-    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+	// IShellExtInit
+	virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
 
     // IContextMenu
-    virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-    virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-    virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+	virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
+	virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
+	virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
 
-    // IShellPropSheetExt
-    virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-    virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
+	// IShellPropSheetExt
+	virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
+	virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
 
     // IObjectWithSite
-    virtual HRESULT WINAPI SetSite(IUnknown *punk);
-    virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
+	virtual HRESULT WINAPI SetSite(IUnknown *punk);
+	virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
 
 DECLARE_REGISTRY_RESOURCEID(IDR_FILEDEFEXT)
 DECLARE_NOT_AGGREGATABLE(CFileDefExt)
@@ -126,10 +126,10 @@ DECLARE_NOT_AGGREGATABLE(CFileDefExt)
 DECLARE_PROTECT_FINAL_CONSTRUCT()
 
 BEGIN_COM_MAP(CFileDefExt)
-    COM_INTERFACE_ENTRY_IID(IID_IShellExtInit, IShellExtInit)
-    COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
-    COM_INTERFACE_ENTRY_IID(IID_IShellPropSheetExt, IShellPropSheetExt)
-    COM_INTERFACE_ENTRY_IID(IID_IObjectWithSite, IObjectWithSite)
+	COM_INTERFACE_ENTRY_IID(IID_IShellExtInit, IShellExtInit)
+	COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
+	COM_INTERFACE_ENTRY_IID(IID_IShellPropSheetExt, IShellPropSheetExt)
+	COM_INTERFACE_ENTRY_IID(IID_IObjectWithSite, IObjectWithSite)
 END_COM_MAP()
 };
 

--- a/dll/win32/shell32/dialogs/filedefext.h
+++ b/dll/win32/shell32/dialogs/filedefext.h
@@ -75,7 +75,7 @@ private:
     static INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-	BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, LPDWORD ticks);
+	BOOL CountFolderAndFiles(HWND hwndDlg, LPCWSTR pwszBuf, LPDWORD ticks);
 
 	WCHAR m_wszPath[MAX_PATH];
 	CFileVersionInfo m_VerInfo;

--- a/dll/win32/shell32/dialogs/filedefext.h
+++ b/dll/win32/shell32/dialogs/filedefext.h
@@ -54,12 +54,12 @@ class CFileVersionInfo
 };
 
 class CFileDefExt :
-	public CComCoClass<CFileDefExt, &CLSID_ShellFileDefExt>,
-	public CComObjectRootEx<CComMultiThreadModelNoCS>,
-	public IShellExtInit,
-	public IContextMenu,
-	public IShellPropSheetExt,
-	public IObjectWithSite
+    public CComCoClass<CFileDefExt, &CLSID_ShellFileDefExt>,
+    public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IShellExtInit,
+    public IContextMenu,
+    public IShellPropSheetExt,
+    public IObjectWithSite
 {
 private:
     VOID InitOpensWithField(HWND hwndDlg);
@@ -73,17 +73,18 @@ private:
     BOOL InitVersionPage(HWND hwndDlg);
     BOOL InitFolderCustomizePage(HWND hwndDlg);
     static INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-	static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-	static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
-	BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, LPDWORD ticks);
+    static INT_PTR CALLBACK VersionPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    static INT_PTR CALLBACK FolderCustomizePageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    BOOL CountFolderAndFiles(HWND hwndDlg, LPWSTR pwszBuf, UINT cchBufMax, LPDWORD ticks);
 
-	WCHAR m_wszPath[MAX_PATH];
-	CFileVersionInfo m_VerInfo;
-	BOOL m_bDir;
+    WCHAR m_wszPath[MAX_PATH];
+    CFileVersionInfo m_VerInfo;
+    BOOL m_bDir;
 
-	DWORD m_cFiles;
+    DWORD m_cFiles;
     DWORD m_cFolders;
     ULARGE_INTEGER m_DirSize;
+    ULARGE_INTEGER m_DirSizeOnDisc;
 
     static DWORD WINAPI _CountFolderAndFilesThreadProc(LPVOID lpParameter);
 
@@ -94,8 +95,8 @@ private:
     BOOL    m_bFolderIconIsSet;
 
 public:
-	CFileDefExt();
-	~CFileDefExt();
+    CFileDefExt();
+    ~CFileDefExt();
 
     // FolderCustomize
     BOOL OnFolderCustApply(HWND hwndDlg);
@@ -103,21 +104,21 @@ public:
     void OnFolderCustDestroy(HWND hwndDlg);
     void UpdateFolderIcon(HWND hwndDlg);
 
-	// IShellExtInit
-	virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
+    // IShellExtInit
+    virtual HRESULT STDMETHODCALLTYPE Initialize(PCIDLIST_ABSOLUTE pidlFolder, IDataObject *pdtobj, HKEY hkeyProgID);
 
     // IContextMenu
-	virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
-	virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
-	virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
+    virtual HRESULT WINAPI QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
+    virtual HRESULT WINAPI InvokeCommand(LPCMINVOKECOMMANDINFO lpici);
+    virtual HRESULT WINAPI GetCommandString(UINT_PTR idCmd, UINT uType, UINT *pwReserved, LPSTR pszName, UINT cchMax);
 
-	// IShellPropSheetExt
-	virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
-	virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
+    // IShellPropSheetExt
+    virtual HRESULT WINAPI AddPages(LPFNADDPROPSHEETPAGE pfnAddPage, LPARAM lParam);
+    virtual HRESULT WINAPI ReplacePage(UINT uPageID, LPFNADDPROPSHEETPAGE pfnReplacePage, LPARAM lParam);
 
     // IObjectWithSite
-	virtual HRESULT WINAPI SetSite(IUnknown *punk);
-	virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
+    virtual HRESULT WINAPI SetSite(IUnknown *punk);
+    virtual HRESULT WINAPI GetSite(REFIID iid, void **ppvSite);
 
 DECLARE_REGISTRY_RESOURCEID(IDR_FILEDEFEXT)
 DECLARE_NOT_AGGREGATABLE(CFileDefExt)
@@ -125,10 +126,10 @@ DECLARE_NOT_AGGREGATABLE(CFileDefExt)
 DECLARE_PROTECT_FINAL_CONSTRUCT()
 
 BEGIN_COM_MAP(CFileDefExt)
-	COM_INTERFACE_ENTRY_IID(IID_IShellExtInit, IShellExtInit)
-	COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
-	COM_INTERFACE_ENTRY_IID(IID_IShellPropSheetExt, IShellPropSheetExt)
-	COM_INTERFACE_ENTRY_IID(IID_IObjectWithSite, IObjectWithSite)
+    COM_INTERFACE_ENTRY_IID(IID_IShellExtInit, IShellExtInit)
+    COM_INTERFACE_ENTRY_IID(IID_IContextMenu, IContextMenu)
+    COM_INTERFACE_ENTRY_IID(IID_IShellPropSheetExt, IShellPropSheetExt)
+    COM_INTERFACE_ENTRY_IID(IID_IObjectWithSite, IObjectWithSite)
 END_COM_MAP()
 };
 


### PR DESCRIPTION
## Purpose

- Current design of ReactOS shows blank "size on disk" field in file & folders properties dialog from Explorer
- Current design does not take credit of C++ functions for String management (using CString class) 
- Current design use MAX_PATH sized buffers for strings not related to file path.

JIRA issue: [CORE-12559](https://jira.reactos.org/browse/CORE-12559)

![image](https://user-images.githubusercontent.com/24843587/91559354-3384c100-e938-11ea-98e3-17634a5389c6.png)

## Proposed changes

- Implement computation and display of "size on disk", following recommendation from @Extravert-ir (Differs from initial code proposed by @amber8706 in comments of the Jira Ticket https://jira.reactos.org/browse/CORE-12559 )
- Refactoring of the recursive routine using CString, following recommendation from @learn-more

![image](https://user-images.githubusercontent.com/24843587/91559360-3a133880-e938-11ea-9e12-2bd47dcc6e88.png)