### PR TITLE
[SETUP] French translation of missing elements

### DIFF
--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -398,7 +398,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         28,
-        "l'ADEQUATION POUR UN USAGE EN PARTICULIER",
+        "l'AD\220QUATION POUR UN USAGE EN PARTICULIER",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -220,7 +220,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         15,
-        "Sauvez vos donn\202es ou testez sur un ordinateur secondaire",
+        "Sauvegardez vos donn\202es ou testez sur un ordinateur secondaire",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -384,7 +384,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         26,
-        "l'ADEQUATION POUR UN USAGE",
+        "l'ADEQUATION POUR UN USAGE EN PARTICULIER",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -293,7 +293,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         10,
-        "autres licenses compatibles telles que X11, BSD et GNU LGPL.",
+        "d'autres licences compatibles telles que X11, BSD et GNU LGPL.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -206,7 +206,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         12,
-        "et est en cours de d\202veloppement. A n'utiliser que pour",
+        "et est en cours de d\202veloppement. Il est recommand\202 de ne l'utiliser",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -192,63 +192,63 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         8,
-        "ReactOS Version Status",
+        "Status de version de ReactOS",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         6,
         11,
-        "ReactOS is in Alpha stage, meaning it is not feature-complete",
+        "ReactOS est en version Alpha, ce qui signifie qu'il n'est pas complet",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         12,
-        "and is under heavy development. It is recommended to use it only for",
+        "et est en cours de d\202veloppement. A n'utiliser que pour",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         13,
-        "evaluation and testing purposes and not as your daily-usage OS.",
+        "\202valuation et test, pas pour un usage quotidien.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         15,
-        "Backup your data or test on a secondary computer if you attempt",
+        "Sauvez vos donn\202es ou testez sur un ordinateur secondaire",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         6,
         16,
-        "to run ReactOS on real hardware.",
+        "si vous souhaitez utiliser ReactOS sur du mat\202riel.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "\x07  Press ENTER to continue ReactOS Setup.",
+        "\x07  Appuyez sur ENTR\220E pour continuer l'installation de ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         21,
-        "\x07  Press F3 to quit without installing ReactOS.",
+        "\x07  Appuyez sur F3 pour quitter sans installer ReactOS.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         0,
         0,
-        "ENTER = Continue   F3 = Quit",
+        "ENTR\220E = Continuer   F3 = Quitter",
         TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
         TEXT_ID_STATIC
     },
@@ -279,77 +279,77 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         8,
-        "The ReactOS System is licensed under the terms of the",
+        "La licence du syst\212me ReactOS System est sous les termes de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         9,
-        "GNU GPL with parts containing code from other compatible",
+        "GNU GPL avec des parties contenant du code sous",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         10,
-        "licenses such as the X11 or BSD and GNU LGPL licenses.",
+        "autres licenses compatibles telles que X11, BSD et GNU LGPL.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         11,
-        "All software that is part of the ReactOS system is",
+        "Tout le logiciel constituant le syst\212me ReactOS est",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         12,
-        "therefore released under the GNU GPL as well as maintaining",
+        "par cons\202quent distribu\202 sous licence GNU GPL tout en",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "the original license.",
+        "maintenant la licence d'origine.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "This software comes with NO WARRANTY or restrictions on usage",
+        "Ce logiciel vient SANS GARANTIE ou restriction d'usage",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         16,
-        "save applicable local and international law. The licensing of",
+        "save applicable local and international law. La licence de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "ReactOS only covers distribution to third parties.",
+        "ReactOS ne couvre que la distribution à des tierces parties.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         18,
-        "If for some reason you did not receive a copy of the",
+        "Si vous n'avez pas obtenu une copie de la",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "GNU General Public License with ReactOS please visit",
+        "GNU General Public License avec ReactOS veuillez visiter",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
@@ -370,21 +370,21 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         24,
-        "This is free software; see the source for copying conditions.",
+        "Ce logiciel est gratuit. Voir les sources pour les conditions de copie.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         25,
-        "There is NO warranty; not even for MERCHANTABILITY or",
+        "Il n'y a AUCUNE garantie; pas même sur la QUALITE ou ",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         26,
-        "FITNESS FOR A PARTICULAR PURPOSE",
+        "l'ADEQUATION POUR UN USAGE",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -335,55 +335,69 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         17,
-        "La licence de ReactOS ne couvre que la distribution aux tierces parties.",
+        "La licence de ReactOS ne couvre que la distribution",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         18,
-        "Si vous n'avez pas obtenu une copie de la",
+        "aux tierces parties.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         19,
-        "GNU General Public License avec ReactOS veuillez visiter",
+        "Si vous n'avez pas obtenu une copie de la",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         20,
+        "GNU General Public License avec ReactOS veuillez visiter",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        8,
+        21,
         "http://www.gnu.org/licenses/licenses.html",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         8,
-        22,
+        23,
         "Garantie :",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },
     {
         8,
-        24,
-        "Ce logiciel est gratuit. Voir les sources pour les conditions de copie.",
-        TEXT_STYLE_NORMAL,
-        TEXT_ID_STATIC
-    },
-    {
-        8,
         25,
-        "Il n'y a AUCUNE garantie; pas même sur la QUALITE ou",
+        "Ce logiciel est gratuit. Voir les sources pour les",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         26,
+        "conditions de copie.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        8,
+        27,
+        "Il n'y a AUCUNE garantie; pas m\202me sur la QUALITE ou",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        8,
+        28,
         "l'ADEQUATION POUR UN USAGE EN PARTICULIER",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -192,7 +192,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         8,
-        "Status de version de ReactOS",
+        "Statut de version de ReactOS",
         TEXT_STYLE_HIGHLIGHT,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -335,7 +335,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         17,
-        "La licence de ReactOS ne couvre que la distribution à des tierces parties.",
+        "La licence de ReactOS ne couvre que la distribution aux tierces parties.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -213,7 +213,7 @@ static MUI_ENTRY frFRIntroPageEntries[] =
     {
         6,
         13,
-        "\202valuation et test, pas pour un usage quotidien.",
+        "que pour \202valuation et test, pas pour un usage quotidien.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -328,7 +328,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         16,
-        "sous lois locales ou intenationales applicables.",
+        "sous les lois locales ou internationales applicables.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -279,7 +279,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         8,
-        "La licence du syst\212me ReactOS System est sous les termes de",
+        "La licence du syst\212me ReactOS est sous les termes de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -328,7 +328,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         16,
-        "sous lois lois locales ou intenationales applicables.",
+        "sous lois locales ou intenationales applicables.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -391,7 +391,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         27,
-        "Il n'y a AUCUNE garantie; pas m\210me sur la QUALITE ou",
+        "Il n'y a AUCUNE garantie; pas m\210me sur la QUALIT\220 ou",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -286,7 +286,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         9,
-        "GNU GPL avec des parties contenant du code sous",
+        "la licence GNU GPL avec des parties contenant du code sous",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -328,14 +328,14 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         16,
-        "save applicable local and international law. La licence de",
+        "sous lois lois locales ou intenationales applicables.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         17,
-        "ReactOS ne couvre que la distribution à des tierces parties.",
+        "La licence de ReactOS ne couvre que la distribution à des tierces parties.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -391,7 +391,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         27,
-        "Il n'y a AUCUNE garantie; pas m\202me sur la QUALITE ou",
+        "Il n'y a AUCUNE garantie; pas m\210me sur la QUALITE ou",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -377,7 +377,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         25,
-        "Il n'y a AUCUNE garantie; pas même sur la QUALITE ou ",
+        "Il n'y a AUCUNE garantie; pas même sur la QUALITE ou",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -279,7 +279,7 @@ static MUI_ENTRY frFRLicensePageEntries[] =
     {
         8,
         8,
-        "La licence du syst\212me ReactOS est sous les termes de",
+        "Le syst\212me ReactOS est distribu\202 sous les termes de",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },


### PR DESCRIPTION
## Purpose

- After selecting "French" during setup, 2 pages are still en english : version status and Licence T&C

![install2](https://user-images.githubusercontent.com/24843587/91655830-21c82880-eab4-11ea-81b2-667e5eea90cc.png)
![install](https://user-images.githubusercontent.com/24843587/91655833-2260bf00-eab4-11ea-9291-03c7aff206a2.png)

## Proposed changes

- Translation in French of the above mentionned 2 pages.

![VirtualBox_ReactOS_30_08_2020_20_08_15](https://user-images.githubusercontent.com/24843587/91666395-a048b880-eafc-11ea-8c0d-a51c835dbe43.png)
![VirtualBox_ReactOS_30_08_2020_16_39_28](https://user-images.githubusercontent.com/24843587/91661941-7a60eb00-eadf-11ea-804f-a071f916fadc.png)

