### PR TITLE
[GITHUB] clang-cl: Upload CDs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,16 @@ jobs:
       run: |
         cmake --build . --target bootcd
         cmake --build . --target livecd
+    # - name: Upload bootcd
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: reactos-clang-cl-i386-${{github.sha}}
+    #     path: build/bootcd.iso
+    # - name: Upload livecd
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: reactos-clang-cl-i386-${{github.sha}}
+    #     path: build/livecd.iso
 
   build-msvc-i386:
     name: MSVC (i386)


### PR DESCRIPTION
Disabled by default, until they are usable/useful.

CORE-17202

(Remaining part of #3105.)