### PR TITLE
[ROSTESTS] Remove obsolete '#if __GNUC__ >= ...'s

### DIFF
--- a/modules/rostests/apitests/crt/sprintf.c
+++ b/modules/rostests/apitests/crt/sprintf.c
@@ -21,9 +21,7 @@
 #pragma GCC diagnostic ignored "-Wformat"
 #pragma GCC diagnostic ignored "-Wformat-zero-length"
 #pragma GCC diagnostic ignored "-Wnonnull"
-#if __GNUC__ >= 7
 #pragma GCC diagnostic ignored "-Wformat-overflow"
-#endif
 #endif
 
 /* NOTE: This test is not only used for all the CRT apitests, but also for

--- a/modules/rostests/kmtests/rtl/RtlMemory.c
+++ b/modules/rostests/kmtests/rtl/RtlMemory.c
@@ -426,12 +426,12 @@ START_TEST(RtlMemory)
     KeLowerIrql(Irql);
     Status = STATUS_SUCCESS;
     _SEH2_TRY {
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmemset-transposed-args"
 #endif
         RtlFillMemory(NULL, 0, 0x55);
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
     } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {


### PR DESCRIPTION
After upgrade to GCC 8.4.

(Split off from #3106.)