### PR TITLE
[KMTESTS:RTL] clang: Ignore a warning on a 'RtlFillMemory()' call

### DIFF
--- a/modules/rostests/kmtests/rtl/RtlMemory.c
+++ b/modules/rostests/kmtests/rtl/RtlMemory.c
@@ -426,12 +426,12 @@ START_TEST(RtlMemory)
     KeLowerIrql(Irql);
     Status = STATUS_SUCCESS;
     _SEH2_TRY {
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if (defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wmemset-transposed-args"
 #endif
         RtlFillMemory(NULL, 0, 0x55);
-#if defined(__GNUC__) && __GNUC__ >= 5
+#if (defined(__GNUC__) && __GNUC__ >= 5) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
     } _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER) {


### PR DESCRIPTION
'...\RtlMemory.c(433,29): warning: 'size' argument to memset is '0'; did you mean to transpose the last two arguments? [-Wmemset-transposed-args]'

JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)

(Split off from #3106.)