### PR TITLE
[RICHED20_WINETEST] txtsrv.c: Workaround for 'thiscall' handling

### DIFF
--- a/modules/rostests/winetests/riched20/txtsrv.c
+++ b/modules/rostests/winetests/riched20/txtsrv.c
@@ -48,7 +48,7 @@ static PCreateTextServices pCreateTextServices;
 
 /* Use a special table for x86 machines to convert the thiscall
  * calling convention.  This isn't needed on other platforms. */
-#if defined(__i386__) && !defined(__MINGW32__)
+#if defined(__i386__) && (defined(__REACTOS__) || !defined(__MINGW32__))
 static ITextServicesVtbl itextServicesStdcallVtbl;
 #define TXTSERV_VTABLE(This) (&itextServicesStdcallVtbl)
 #else /* __i386__ */
@@ -535,7 +535,7 @@ typedef struct
 
 static void setup_thiscall_wrappers(void)
 {
-#if defined(__i386__) && !defined(__MINGW32__)
+#if defined(__i386__) && (defined(__REACTOS__) || !defined(__MINGW32__))
     void** pVtable;
     void** pVtableEnd;
     THISCALL_TO_STDCALL_THUNK *thunk;


### PR DESCRIPTION
Pseudo-revert a part of 76cf09c.

JIRA issue: [ROSTESTS-355](https://jira.reactos.org/browse/ROSTESTS-355)

NB:
* GCC: 4 failures, instead of crash. Should fix test runs!
* MSVC: still crash. I did not check whether it was already broken before the Wine 4.18 update...