### PR TITLE
[FONTEXT] Initial implementation of CFontExt::DoGetFontTitle

### DIFF
--- a/dll/shellext/fontext/CFontExt.cpp
+++ b/dll/shellext/fontext/CFontExt.cpp
@@ -615,7 +615,7 @@ CFontExt::DoGetFontTitle(IN LPCWSTR pszFontPath, OUT CStringW& strFontName)
     strFontName.ReleaseBuffer();
     if (ret)
     {
-        TRACE("pszFontName: %S\n", pszBuffer);
+        TRACE("pszFontName: %S\n", (LPCWSTR)strFontName);
         return S_OK;
     }
 

--- a/dll/shellext/fontext/CFontExt.cpp
+++ b/dll/shellext/fontext/CFontExt.cpp
@@ -578,7 +578,7 @@ HRESULT CFontExt::DoInstallFontFile(LPCWSTR pszFontPath, LPCWSTR pszFontsDir, HK
         return E_FAIL;
     }
 
-    if (!AddFontResourceW(pszFileTitle))
+    if (!AddFontResourceW(szDestFile))
     {
         ERR("AddFontResourceW('%S') failed\n", pszFileTitle);
         DeleteFileW(szDestFile);
@@ -587,7 +587,7 @@ HRESULT CFontExt::DoInstallFontFile(LPCWSTR pszFontPath, LPCWSTR pszFontsDir, HK
 
     DWORD cbData = (wcslen(pszFileTitle) + 1) * sizeof(WCHAR);
     LONG nError = RegSetValueExW(hkeyFonts, strFontName, 0, REG_SZ,
-                                 (const BYTE *)(LPCWSTR)strFontName, cbData);
+                                 (const BYTE *)pszFileTitle, cbData);
     if (nError)
     {
         ERR("RegSetValueExW failed with %ld\n", nError);

--- a/dll/shellext/fontext/CFontExt.hpp
+++ b/dll/shellext/fontext/CFontExt.hpp
@@ -93,5 +93,5 @@ public:
     END_COM_MAP()
 
     HRESULT DoInstallFontFile(LPCWSTR pszFontPath, LPCWSTR pszFontsDir, HKEY hkeyFonts);
-    HRESULT DoGetFontTitle(LPCWSTR pszFontPath, LPCWSTR pszFontName);
+    HRESULT DoGetFontTitle(IN LPCWSTR pszFontPath, OUT LPWSTR pszFontName, IN DWORD cbFontName);
 };

--- a/dll/shellext/fontext/CFontExt.hpp
+++ b/dll/shellext/fontext/CFontExt.hpp
@@ -93,5 +93,5 @@ public:
     END_COM_MAP()
 
     HRESULT DoInstallFontFile(LPCWSTR pszFontPath, LPCWSTR pszFontsDir, HKEY hkeyFonts);
-    HRESULT DoGetFontTitle(IN LPCWSTR pszFontPath, OUT LPWSTR pszFontName, IN DWORD cbFontName);
+    HRESULT DoGetFontTitle(IN LPCWSTR pszFontPath, OUT CStringW& strFontName);
 };

--- a/sdk/include/reactos/undocgdi.h
+++ b/sdk/include/reactos/undocgdi.h
@@ -26,19 +26,24 @@ typedef struct GDI_DRAW_STREAM_TAG
     DWORD   crTransparent; // transparent color.
 } GDI_DRAW_STREAM, *PGDI_DRAW_STREAM;
 
-BOOL
-WINAPI
+EXTERN_C BOOL WINAPI
 GdiDrawStream(HDC dc, ULONG l, PGDI_DRAW_STREAM pDS);
 
-BOOL
-WINAPI
+EXTERN_C BOOL WINAPI
 GetTextExtentExPointWPri(
     HDC hdc,
-    LPCWSTR lpwsz, 
+    LPCWSTR lpwsz,
     INT cwc,
-    INT dxMax, 
-    LPINT pcCh, 
-    LPINT pdxOut, 
+    INT dxMax,
+    LPINT pcCh,
+    LPINT pdxOut,
     LPSIZE psize);
+
+EXTERN_C BOOL WINAPI
+GetFontResourceInfoW(
+    _In_z_ LPCWSTR lpFileName,
+    _Inout_ DWORD *pdwBufSize,
+    _Out_writes_to_opt_(*pdwBufSize, 1) PVOID lpBuffer,
+    _In_ DWORD dwType);
 
 #endif

--- a/sdk/include/reactos/undocgdi.h
+++ b/sdk/include/reactos/undocgdi.h
@@ -2,6 +2,10 @@
 #ifndef _UNDOCGDI_H
 #define _UNDOCGDI_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define DS_TILE 0x2
 #define DS_TRANSPARENTALPHA 0x4
 #define DS_TRANSPARENTCLR 0x8
@@ -26,10 +30,9 @@ typedef struct GDI_DRAW_STREAM_TAG
     DWORD   crTransparent; // transparent color.
 } GDI_DRAW_STREAM, *PGDI_DRAW_STREAM;
 
-EXTERN_C BOOL WINAPI
-GdiDrawStream(HDC dc, ULONG l, PGDI_DRAW_STREAM pDS);
+BOOL WINAPI GdiDrawStream(HDC dc, ULONG l, PGDI_DRAW_STREAM pDS);
 
-EXTERN_C BOOL WINAPI
+BOOL WINAPI
 GetTextExtentExPointWPri(
     HDC hdc,
     LPCWSTR lpwsz,
@@ -39,11 +42,15 @@ GetTextExtentExPointWPri(
     LPINT pdxOut,
     LPSIZE psize);
 
-EXTERN_C BOOL WINAPI
+BOOL WINAPI
 GetFontResourceInfoW(
     _In_z_ LPCWSTR lpFileName,
     _Inout_ DWORD *pdwBufSize,
     _Out_writes_to_opt_(*pdwBufSize, 1) PVOID lpBuffer,
     _In_ DWORD dwType);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-12861](https://jira.reactos.org/browse/CORE-12861)

This PR is a preparation of fonts folder implementation.

![not-working-yet](https://user-images.githubusercontent.com/2107452/92231126-2c852200-eee7-11ea-8d67-083ddf6de627.png)
Not working yet.

## Proposed Changes
- Use  `GetFontResourceInfoW` to get the font name.