### PR TITLE
[SHELLFIND] Fix directory search upon non-empty word/phrase query

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -280,7 +280,7 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
         if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             CStringW status;
-            if (pSearchData->szQueryA.IsEmpty() &&
+            if (pSearchData->szQueryW.IsEmpty() &&
                 FileNameMatch(FindData.cFileName, pSearchData) &&
                 AttribHiddenMatch(FindData.dwFileAttributes, pSearchData))
             {

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -280,8 +280,9 @@ static UINT RecursiveFind(LPCWSTR lpPath, _SearchData *pSearchData)
         if (FindData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
         {
             CStringW status;
-            if (FileNameMatch(FindData.cFileName, pSearchData)
-                && AttribHiddenMatch(FindData.dwFileAttributes, pSearchData))
+            if (pSearchData->szQueryA.IsEmpty() &&
+                FileNameMatch(FindData.cFileName, pSearchData) &&
+                AttribHiddenMatch(FindData.dwFileAttributes, pSearchData))
             {
                 PostMessageW(pSearchData->hwnd, WM_SEARCH_ADD_RESULT, 0, (LPARAM) StrDupW(szPath));
                 uTotalFound++;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17244](https://jira.reactos.org/browse/CORE-17244)

If the search phrase was not empty, it must not match the directory.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/92306688-008f9c80-efcc-11ea-91c3-9f4435e07418.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/92306682-fb325200-efcb-11ea-8e1c-04d4657a12ae.png)

## Proposed Changes
- If there is the phrase to search, its match isn't a directory.