### PR TITLE
[WIN32SS] Log spam & log trivial fix

### DIFF
--- a/win32ss/user/ntuser/message.c
+++ b/win32ss/user/ntuser/message.c
@@ -800,7 +800,7 @@ static LRESULT handle_internal_message( PWND pWnd, UINT msg, WPARAM wparam, LPAR
        }
        case WM_ASYNC_DESTROYWINDOW:
        {
-          ERR("WM_ASYNC_DESTROYWINDOW\n");
+          TRACE("WM_ASYNC_DESTROYWINDOW\n");
           if (pWnd->style & WS_CHILD)
              return co_UserFreeWindow(pWnd, PsGetCurrentProcessWin32Process(), PsGetCurrentThreadWin32Thread(), TRUE);
           else
@@ -1867,8 +1867,8 @@ co_IntSendMessageWithCallBack( HWND hWnd,
 
     if(!(Message = AllocateUserMessage(FALSE)))
     {
-        ERR("MsqSendMessage(): Not enough memory to allocate a message");
-        RETURN( FALSE);
+        ERR("MsqSendMessage(): Not enough memory to allocate a message\n");
+        RETURN(FALSE);
     }
 
     Message->Msg.hwnd = hWnd;


### PR DESCRIPTION
## Purpose

- Log spam issue with WM_ASYNC_DESTROYWINDOW, similar to past JIRA ticket https://jira.reactos.org/browse/CORE-10539 about WM_PAINT
- Missing \n in ERR() macro
- Formatting issues

## Proposed changes

- Change ERR to TRACE in WM_ASYNC_DESTROYWINDOW
- Fixed missing \n
- Fixed code formatting