### PR TITLE
[SHELLFIND] Encoding-aware file search

### DIFF
--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -199,7 +199,11 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
     }
 
     if (size == INVALID_FILE_SIZE)
-        size = 32 * 1024 * 1024; // Use first 32 MB
+    {
+        MEMORYSTATUS status = { sizeof(status) };
+        GlobalMemoryStatus(&status);
+        size = status.dwAvailPhys * 2 / 3;
+    }
 
     HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, size, NULL);
     CloseHandle(hFile);

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -203,8 +203,8 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
         MEMORYSTATUSEX status;
         status.dwLength = sizeof(status);
         GlobalMemoryStatusEx(&status);
-        if (status.ullAvailPhys >= 1024 * 1024 * 1024)
-            size = 1024 * 1024 * 1024; // 1GB
+        if (status.ullAvailPhys >= 2 * 1024 * 1024 * 1024) // 2GB
+            size = 2 * 1024 * 1024 * 1024 - 1;
         else
             size = (DWORD)(status.ullAvailPhys * 2 / 3); // 2/3 of physical memory
     }

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -219,14 +219,12 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
              (memcmp(lpFileContent, "\xFE\xFF", 2) == 0 || (!lpFileContent[0] && lpFileContent[1])))
     {
         // UTF-16 BE
-        bFound = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryU16BE,
-                            pSearchData->szQueryU16BE.GetLength());
+        bFound = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryU16BE, size / sizeof(WCHAR));
     }
     else if (size >= 3 && memcmp(lpFileContent, "\xEF\xBB\xBF", 3) == 0)
     {
         // UTF-8
-        bFound = StrFindNIA((LPCSTR) lpFileContent, pSearchData->szQueryU8,
-                            pSearchData->szQueryU8.GetLength());
+        bFound = StrFindNIA((LPCSTR) lpFileContent, pSearchData->szQueryU8, size / sizeof(CHAR));
     }
     else
     {

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -208,35 +208,35 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
     if (!lpFileContent)
         return 0;
 
-    BOOL bMatch;
+    BOOL bFound;
     if (size >= 2 &&
         (memcmp(lpFileContent, "\xFF\xFE", 2) == 0 || (lpFileContent[0] && !lpFileContent[1])))
     {
         // UTF-16
-        bMatch = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryW, size / sizeof(WCHAR));
+        bFound = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryW, size / sizeof(WCHAR));
     }
     else if (size >= 2 &&
              (memcmp(lpFileContent, "\xFE\xFF", 2) == 0 || (!lpFileContent[0] && lpFileContent[1])))
     {
         // UTF-16 BE
-        bMatch = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryU16BE,
+        bFound = StrFindNIW((LPCWSTR) lpFileContent, pSearchData->szQueryU16BE,
                             pSearchData->szQueryU16BE.GetLength());
     }
     else if (size >= 3 && memcmp(lpFileContent, "\xEF\xBB\xBF", 3) == 0)
     {
         // UTF-8
-        bMatch = StrFindNIA((LPCSTR) lpFileContent, pSearchData->szQueryU8,
+        bFound = StrFindNIA((LPCSTR) lpFileContent, pSearchData->szQueryU8,
                             pSearchData->szQueryU8.GetLength());
     }
     else
     {
         // ANSI
-        bMatch = StrFindNIA((LPCSTR)lpFileContent, pSearchData->szQueryA, size / sizeof(CHAR));
+        bFound = StrFindNIA((LPCSTR)lpFileContent, pSearchData->szQueryA, size / sizeof(CHAR));
     }
 
     UnmapViewOfFile(lpFileContent);
 
-    return bMatch;
+    return bFound;
 }
 
 static BOOL FileNameMatch(LPCWSTR FindDataFileName, _SearchData *pSearchData)

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -200,7 +200,8 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
 
     if (size == INVALID_FILE_SIZE)
     {
-        MEMORYSTATUSEX status = { sizeof(status) };
+        MEMORYSTATUSEX status;
+        status.dwLength = sizeof(status);
         GlobalMemoryStatusEx(&status);
         if (status.ullAvailPhys >= 0x7FFFFFFF)
             size = 1024 * 1024 * 1024; // Use first 1 GB

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -200,9 +200,12 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
 
     if (size == INVALID_FILE_SIZE)
     {
-        MEMORYSTATUS status = { sizeof(status) };
-        GlobalMemoryStatus(&status);
-        size = status.dwAvailPhys * 2 / 3;
+        MEMORYSTATUSEX status = { sizeof(status) };
+        GlobalMemoryStatusEx(&status);
+        if (status.ullAvailPhys >= 0x7FFFFFFF)
+            size = 1024 * 1024 * 1024; // Use first 1 GB
+        else
+            size = (DWORD)(status.ullAvailPhys * 2 / 3); // physical memory * 2/3
     }
 
     HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, size, NULL);

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -206,7 +206,7 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
         if (status.ullAvailPhys >= 0x7FFFFFFF)
             size = 1024 * 1024 * 1024; // Use first 1 GB
         else
-            size = (DWORD)(status.ullAvailPhys * 2 / 3); // physical memory * 2/3
+            size = (DWORD)(status.ullAvailPhys * 2 / 3); // 2/3 of physical memory
     }
 
     HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, size, NULL);

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -191,22 +191,12 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
     if (hFile == INVALID_HANDLE_VALUE)
         return FALSE;
 
+    // FIXME: support large file
     DWORD size = GetFileSize(hFile, NULL);
-    if (size == 0)
+    if (size == 0 || size == INVALID_FILE_SIZE)
     {
         CloseHandle(hFile);
         return FALSE;
-    }
-
-    if (size == INVALID_FILE_SIZE)
-    {
-        MEMORYSTATUSEX status;
-        status.dwLength = sizeof(status);
-        GlobalMemoryStatusEx(&status);
-        if (status.ullAvailPhys > 0x7FFFFFFF) // 2GB
-            size = 0x7FFFFFFF;
-        else
-            size = (DWORD)(status.ullAvailPhys * 2 / 3); // 2/3 of physical memory
     }
 
     HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, size, NULL);

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -203,8 +203,8 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
         MEMORYSTATUSEX status;
         status.dwLength = sizeof(status);
         GlobalMemoryStatusEx(&status);
-        if (status.ullAvailPhys >= 2 * 1024 * 1024 * 1024) // 2GB
-            size = 2 * 1024 * 1024 * 1024 - 1;
+        if (status.ullAvailPhys >= (DWORD)(2 * 1024 * 1024 * 1024)) // 2GB
+            size = (DWORD)(2 * 1024 * 1024 * 1024 - 1);
         else
             size = (DWORD)(status.ullAvailPhys * 2 / 3); // 2/3 of physical memory
     }

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -192,13 +192,16 @@ static BOOL SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
         return 0;
 
     DWORD size = GetFileSize(hFile, NULL);
-    if (size == 0 || size == INVALID_FILE_SIZE)
+    if (size == 0)
     {
         CloseHandle(hFile);
         return 0;
     }
 
-    HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+    if (size == INVALID_FILE_SIZE)
+        size = 32 * 1024 * 1024; // Use first 32 MB
+
+    HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, size, NULL);
     CloseHandle(hFile);
     if (hFileMap == INVALID_HANDLE_VALUE)
         return 0;

--- a/dll/win32/browseui/shellfind/CFindFolder.cpp
+++ b/dll/win32/browseui/shellfind/CFindFolder.cpp
@@ -205,7 +205,10 @@ static UINT SearchFile(LPCWSTR lpFilePath, _SearchData *pSearchData)
 
     DWORD size = GetFileSize(hFile, NULL);
     if (size == 0 || size == INVALID_FILE_SIZE)
+    {
+        CloseHandle(hFile);
         return 0;
+    }
 
     HANDLE hFileMap = CreateFileMappingW(hFile, NULL, PAGE_READONLY, 0, 0, NULL);
     CloseHandle(hFile);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17250](https://jira.reactos.org/browse/CORE-17250)

- Consider UTF-8/UTF-16/UTF-16BE encodings in file search.
- Optimize for speed.

TestData:
![TestData](https://user-images.githubusercontent.com/2107452/92315489-285d1f80-f021-11ea-9c98-1fb18cef1e24.png)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/92315490-298e4c80-f021-11ea-9520-82ed44d0fa5f.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/92315488-26935c00-f021-11ea-84cc-c5e44a4261a0.png)

## Proposed Changes

- Look the BOM (byte order mark) or NUL characters at the beginning of the file if any and find the text.
- If found, it became a match of a file item.