### PR TITLE
[BROWSEUI] Set DT_VCENTER to Explorer Bars' title

### DIFF
--- a/dll/win32/browseui/basebarsite.cpp
+++ b/dll/win32/browseui/basebarsite.cpp
@@ -729,12 +729,13 @@ LRESULT CBaseBarSite::OnCustomDraw(LPNMCUSTOMDRAW pnmcd)
                 rt = pnmcd->rc;
                 rt.right -= 24;
                 rt.left += 2;
+                rt.bottom -= 1;
                 if (FAILED_UNEXPECTEDLY(GetInternalBandInfo(index, &info, RBBIM_TEXT)))
                     return CDRF_SKIPDEFAULT;
                 newFont = GetTitleFont();
                 if (newFont)
                     oldFont = (HFONT)SelectObject(pnmcd->hdc, newFont);
-                DrawText(pnmcd->hdc, info.lpText, -1, &rt, DT_SINGLELINE | DT_LEFT);
+                DrawText(pnmcd->hdc, info.lpText, -1, &rt, DT_SINGLELINE | DT_LEFT | DT_VCENTER);
                 SelectObject(pnmcd->hdc, oldFont);
                 DeleteObject(newFont);
                 return CDRF_SKIPDEFAULT;


### PR DESCRIPTION
## Purpose

JIRA issue: N/A

- Make the captions of the explorer bars vertically centered.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/92318159-45a2e580-f043-11ea-8a40-e2249b24d3a7.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/92318160-46d41280-f043-11ea-9f12-e58775e61cb5.png)

AFTER:
![after2](https://user-images.githubusercontent.com/2107452/92318162-48053f80-f043-11ea-845b-565318eaba1d.png)

## Proposed Changes

- Use `DT_VCENTER` to vertically center the text.
- Shrink the rectangle bottom 1 pixel.