### PR TITLE
[EXPLORER] Registry key not closed on error (CORE-14519)

### DIFF
--- a/base/shell/explorer/shellservice.cpp
+++ b/base/shell/explorer/shellservice.cpp
@@ -92,6 +92,7 @@ HRESULT InitShellServices(HDPA * phdpa)
         if (FAILED_UNEXPECTEDLY(hr))
         {
             ERR("CLSIDFromString failed %08x.\n", hr);
+            RegCloseKey(hkey);
             goto cleanup;
         }
 
@@ -99,6 +100,7 @@ HRESULT InitShellServices(HDPA * phdpa)
         if (FAILED_UNEXPECTEDLY(hr))
         {
             ERR("CoCreateInstance failed %08x.\n", hr);
+            RegCloseKey(hkey);
             goto cleanup;
         }
 
@@ -112,6 +114,7 @@ HRESULT InitShellServices(HDPA * phdpa)
     {
         ERR("RegEnumValueW failed %08x.\n", ret);
         hr = HRESULT_FROM_WIN32(GetLastError());
+        RegCloseKey(hkey);
         goto cleanup;
     }
 

--- a/base/shell/explorer/shellservice.cpp
+++ b/base/shell/explorer/shellservice.cpp
@@ -92,7 +92,6 @@ HRESULT InitShellServices(HDPA * phdpa)
         if (FAILED_UNEXPECTEDLY(hr))
         {
             ERR("CLSIDFromString failed %08x.\n", hr);
-            RegCloseKey(hkey);
             goto cleanup;
         }
 
@@ -100,7 +99,6 @@ HRESULT InitShellServices(HDPA * phdpa)
         if (FAILED_UNEXPECTEDLY(hr))
         {
             ERR("CoCreateInstance failed %08x.\n", hr);
-            RegCloseKey(hkey);
             goto cleanup;
         }
 
@@ -114,7 +112,6 @@ HRESULT InitShellServices(HDPA * phdpa)
     {
         ERR("RegEnumValueW failed %08x.\n", ret);
         hr = HRESULT_FROM_WIN32(GetLastError());
-        RegCloseKey(hkey);
         goto cleanup;
     }
 
@@ -129,6 +126,7 @@ HRESULT InitShellServices(HDPA * phdpa)
     return count > 0 ? S_OK : S_FALSE;
 
 cleanup:
+    RegCloseKey(hkey);
     *phdpa = NULL;
     ShutdownShellServices(hdpa);
     return hr;

--- a/base/shell/explorer/shellservice.cpp
+++ b/base/shell/explorer/shellservice.cpp
@@ -115,12 +115,12 @@ HRESULT InitShellServices(HDPA * phdpa)
         goto cleanup;
     }
 
-    RegCloseKey(hkey);
-
     /* Initialize */
     DPA_EnumCallback(hdpa, InitializeAllCallback, &hr);
     if (FAILED_UNEXPECTEDLY(hr))
         goto cleanup;
+
+    RegCloseKey(hkey);
 
     *phdpa = hdpa;
     return count > 0 ? S_OK : S_FALSE;


### PR DESCRIPTION
## Purpose

- If goto cleanup is called, the key won't be closed.

JIRA issue: [CORE-14519](https://jira.reactos.org/browse/CORE-14519)

## Proposed changes

- Close key as 1st cleanup step (since neither nominal case which close the key, nor the failed key opening would lead there)