### PR TITLE
[GDI32] Fix double cx's in call to HANDLE_METADC in win32ss painting.c

### DIFF
--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -469,12 +469,12 @@ BitBlt(
                   xDest,
                   yDest,
                   cx,
-                  cx,
+                  cy,
                   hdcSrc,
                   xSrc,
                   ySrc,
                   cx,
-                  cx,
+                  cy,
                   dwRop);
 
     if ( GdiConvertAndCheckDC(hdcDest) == NULL ) return FALSE;


### PR DESCRIPTION
## Typo Fix for win32ss//gdi/gdi32/objects/painting.c

_Fix 2 cases of cx used instead of cy._

No JIRA related issue

I stumbled onto this looking into fixing the StretchBlt function.
I discussed this with Jim Tabor and he agreed it was a typo error.