### PR TITLE
[COMCTL32] Fix desktop arrow keys

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -7449,7 +7449,9 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
     UINT uMask = 0;
     LVFINDINFOW lvFindInfo;
     INT nCountPerColumn;
+#ifndef __REACTOS__
     INT nCountPerRow;
+#endif
     INT i;
 
     TRACE("nItem=%d, uFlags=%x, nItemCount=%d\n", nItem, uFlags, infoPtr->nItemCount);
@@ -7490,6 +7492,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
       }
       else
       {
+#ifndef __REACTOS__
         /* Special case for autoarrange - move 'til the top of a list */
         if (is_autoarrange(infoPtr))
         {
@@ -7502,6 +7505,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
           }
           return -1;
         }
+#endif
         lvFindInfo.flags = LVFI_NEARESTXY;
         lvFindInfo.vkDirection = VK_UP;
         LISTVIEW_GetItemPosition(infoPtr, nItem, &lvFindInfo.pt);
@@ -7525,6 +7529,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
       }
       else
       {
+#ifndef __REACTOS__
         /* Special case for autoarrange - move 'til the bottom of a list */
         if (is_autoarrange(infoPtr))
         {
@@ -7537,6 +7542,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
           }
           return -1;
         }
+#endif
         lvFindInfo.flags = LVFI_NEARESTXY;
         lvFindInfo.vkDirection = VK_DOWN;
         LISTVIEW_GetItemPosition(infoPtr, nItem, &lvFindInfo.pt);
@@ -7561,6 +7567,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
       }
       else if ((infoPtr->uView == LV_VIEW_SMALLICON) || (infoPtr->uView == LV_VIEW_ICON))
       {
+#ifndef __REACTOS__
         /* Special case for autoarrange - move 'til the beginning of a row */
         if (is_autoarrange(infoPtr))
         {
@@ -7573,6 +7580,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
           }
           return -1;
         }
+#endif
         lvFindInfo.flags = LVFI_NEARESTXY;
         lvFindInfo.vkDirection = VK_LEFT;
         LISTVIEW_GetItemPosition(infoPtr, nItem, &lvFindInfo.pt);
@@ -7597,6 +7605,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
       }
       else if ((infoPtr->uView == LV_VIEW_SMALLICON) || (infoPtr->uView == LV_VIEW_ICON))
       {
+#ifndef __REACTOS__
         /* Special case for autoarrange - move 'til the end of a row */
         if (is_autoarrange(infoPtr))
         {
@@ -7609,6 +7618,7 @@ static INT LISTVIEW_GetNextItem(const LISTVIEW_INFO *infoPtr, INT nItem, UINT uF
           }
           return -1;
         }
+#endif
         lvFindInfo.flags = LVFI_NEARESTXY;
         lvFindInfo.vkDirection = VK_RIGHT;
         LISTVIEW_GetItemPosition(infoPtr, nItem, &lvFindInfo.pt);

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -9227,14 +9227,12 @@ static BOOL LISTVIEW_SetItemPosition(LISTVIEW_INFO *infoPtr, INT nItem, const PO
             return FALSE;
 
         Pt = *pt;
-        Pt.x += GetScrollPos(infoPtr->hwndSelf, SB_HORZ);
-        Pt.y += GetScrollPos(infoPtr->hwndSelf, SB_VERT);
         i1 = nItem;
         i2 = LISTVIEW_HitTestBlank(infoPtr, Pt);
         if (i1 < i2)
             --i2;
 
-        wsprintfW(sz, L"(%d, %d), (%d, %d), (%d, %d), (%d, %d)", i1, i2, Pt.x, Pt.y, Origin.x, Origin.y, infoPtr->rcList.left, infoPtr->rcList.top);
+        wsprintfW(sz, L"(%d, %d), (%d, %d), (%d, %d)", i1, i2, Pt.x, Pt.y, infoPtr->rcList.left, infoPtr->rcList.top);
         MessageBoxW(NULL, sz, L"listview.c", 0);
 
         infoPtr->pPairs = pPairs;

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -9132,30 +9132,31 @@ static void SwapShiftRelay(LISTVIEW_INFO *infoPtr, INT iFrom, INT iTo)
 /* hit test for auto-arrange */
 static INT LISTVIEW_HitTestBlank(const LISTVIEW_INFO *infoPtr, POINT pt)
 {
-    INT iItem, x, y, xy0 = -1;
+    INT iItem, x, y, xy0 = 0xFFFF;
     WCHAR sz[64];
-    RECT rc;
+    POINT Origin, Position;
+
+    LISTVIEW_GetOrigin(infoPtr, &Origin);
 
     if (infoPtr->dwStyle & LVS_ALIGNLEFT)
     {
         // vertically
         for (iItem = 0; iItem < infoPtr->nItemCount; ++iItem)
         {
-            rc.left = LVIR_LABEL;
-            LISTVIEW_GetItemRect(infoPtr, iItem, &rc);
-            x = (rc.left + rc.right) / 2 + infoPtr->nItemWidth / 2;
-            y = (rc.top + rc.bottom) / 2;
-            if (xy0 == -1)
+            LISTVIEW_GetItemOrigin(infoPtr, iItem, &Position);
+            x = Position.x + Origin.x + infoPtr->nItemWidth;
+            y = Position.y + Origin.y + infoPtr->iconSize.cy / 2;
+            if (xy0 == 0xFFFF)
                 xy0 = x;
             if (xy0 < x && y < pt.y)
             {
-                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), rc:(%d, %d, %d, %d), %d", x, y, pt.x, pt.y, rc.left, rc.top, rc.right, rc.bottom, xy0);
+                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), %d", x, y, pt.x, pt.y, xy0);
                 MessageBoxW(NULL, sz, L"1", 0);
                 return iItem;
             }
             if (pt.y <= y && pt.x <= x)
             {
-                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), rc:(%d, %d, %d, %d), %d", x, y, pt.x, pt.y, rc.left, rc.top, rc.right, rc.bottom, xy0);
+                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), %d", x, y, pt.x, pt.y, xy0);
                 MessageBoxW(NULL, sz, L"2", 0);
                 return iItem;
             }
@@ -9167,21 +9168,20 @@ static INT LISTVIEW_HitTestBlank(const LISTVIEW_INFO *infoPtr, POINT pt)
         // horizontally
         for (iItem = 0; iItem < infoPtr->nItemCount; ++iItem)
         {
-            rc.left = LVIR_LABEL;
-            LISTVIEW_GetItemRect(infoPtr, iItem, &rc);
-            y = (rc.top + rc.bottom) / 2 + infoPtr->nItemHeight / 2;
-            x = (rc.left + rc.right) / 2;
-            if (xy0 == -1)
+            LISTVIEW_GetItemOrigin(infoPtr, iItem, &Position);
+            x = Position.x + Origin.x + infoPtr->nItemWidth / 2;
+            y = Position.y + Origin.y + infoPtr->nItemHeight;
+            if (xy0 == 0xFFFF)
                 xy0 = y;
             if (xy0 < y && x < pt.x)
             {
-                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), rc:(%d, %d, %d, %d), %d", x, y, pt.x, pt.y, rc.left, rc.top, rc.right, rc.bottom, xy0);
+                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), %d", x, y, pt.x, pt.y, xy0);
                 MessageBoxW(NULL, sz, L"3", 0);
                 return iItem;
             }
             if (pt.x <= x && pt.y <= y)
             {
-                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), rc:(%d, %d, %d, %d), %d", x, y, pt.x, pt.y, rc.left, rc.top, rc.right, rc.bottom, xy0);
+                wsprintfW(sz, L"x,y:(%d, %d), pt:(%d, %d), %d", x, y, pt.x, pt.y, xy0);
                 MessageBoxW(NULL, sz, L"4", 0);
                 return iItem;
             }

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -9147,8 +9147,6 @@ static BOOL LISTVIEW_SetItemPosition(LISTVIEW_INFO *infoPtr, INT nItem, const PO
 	!(infoPtr->uView == LV_VIEW_ICON || infoPtr->uView == LV_VIEW_SMALLICON)) return FALSE;
 
 #ifdef __REACTOS__
-    /* FIXME:  This should really call snap to grid if auto-arrange is enabled
-       and limit the size of the grid to nItemCount elements */
     if (is_autoarrange(infoPtr))
     {
         INT i1 = nItem;

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2031,6 +2031,15 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
 
                     m_pSourceDataObject = pda;
                     m_ptFirstMousePos = params->ptAction;
+                    {
+                        HDC hDC = ::GetDC(m_ListView);
+                        SelectObject(hDC, CreatePen(PS_SOLID, 0, RGB(0, 255, 0)));
+                        MoveToEx(hDC, m_ptFirstMousePos.x, m_ptFirstMousePos.y - 15, NULL);
+                        LineTo(hDC, m_ptFirstMousePos.x, m_ptFirstMousePos.y + 15);
+                        MoveToEx(hDC, m_ptFirstMousePos.x - 15, m_ptFirstMousePos.y, NULL);
+                        LineTo(hDC, m_ptFirstMousePos.x + 15, m_ptFirstMousePos.y);
+                        ::ReleaseDC(m_ListView, hDC);
+                    }
                     ClientToListView(m_ListView, &m_ptFirstMousePos);
 
                     HIMAGELIST big_icons, small_icons;
@@ -3407,6 +3416,15 @@ HRESULT WINAPI CDefView::Drop(IDataObject* pDataObject, DWORD grfKeyState, POINT
         }
 
         POINT ptDrop = { pt.x, pt.y };
+        {
+            HDC hDC = ::GetDC(NULL);
+            SelectObject(hDC, CreatePen(PS_SOLID, 0, RGB(255, 0, 0)));
+            MoveToEx(hDC, ptDrop.x, ptDrop.y - 20, NULL);
+            LineTo(hDC, ptDrop.x, ptDrop.y + 20);
+            MoveToEx(hDC, ptDrop.x - 20, ptDrop.y, NULL);
+            LineTo(hDC, ptDrop.x + 20, ptDrop.y);
+            ::ReleaseDC(NULL, hDC);
+        }
         ::ScreenToClient(m_ListView, &ptDrop);
         ::ClientToListView(m_ListView, &ptDrop);
 
@@ -3417,6 +3435,9 @@ HRESULT WINAPI CDefView::Drop(IDataObject* pDataObject, DWORD grfKeyState, POINT
             POINT ptItem;
             if (m_ListView.GetItemPosition(iItem, &ptItem))
             {
+                WCHAR sz[64];
+                wsprintfW(sz, L"(%d, %d)", ptDrop.x - m_ptFirstMousePos.x, ptDrop.y - m_ptFirstMousePos.y);
+                ::MessageBoxW(NULL, sz, L"pos", 0);
                 ptItem.x += ptDrop.x - m_ptFirstMousePos.x;
                 ptItem.y += ptDrop.y - m_ptFirstMousePos.y;
                 m_ListView.SetItemPosition(iItem, &ptItem);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3393,23 +3393,19 @@ HRESULT WINAPI CDefView::Drop(IDataObject* pDataObject, DWORD grfKeyState, POINT
             m_pCurDropTarget.Release();
         }
 
-        /* Restore the selection */
-        m_ListView.SetItemState(-1, 0, LVIS_SELECTED);
-        for (UINT i = 0 ; i < m_cidl; i++)
-            SelectItem(m_apidl[i], SVSI_SELECT);
-
-        /* Reposition the items */
-        int lvIndex = -1;
-        while ((lvIndex = m_ListView.GetNextItem(lvIndex,  LVNI_SELECTED)) > -1)
+        INT iItem = -1;
+        m_ListView.SetRedraw(FALSE);
+        while ((iItem = m_ListView.GetNextItem(iItem, LVNI_SELECTED)) >= 0)
         {
             POINT ptItem;
-            if (m_ListView.GetItemPosition(lvIndex, &ptItem))
+            if (m_ListView.GetItemPosition(iItem, &ptItem))
             {
                 ptItem.x += pt.x - m_ptFirstMousePos.x;
                 ptItem.y += pt.y - m_ptFirstMousePos.y;
-                m_ListView.SetItemPosition(lvIndex, &ptItem);
+                m_ListView.SetItemPosition(iItem, &ptItem);
             }
         }
+        m_ListView.SetRedraw(TRUE);
     }
     else if (m_pCurDropTarget)
     {


### PR DESCRIPTION
## Purpose

Fix the behaviors of keyboard arrow keys on desktop.

JIRA issue: [CORE-16875](https://jira.reactos.org/browse/CORE-16875)

## Proposed changes

- Disable special auto-arrange codes in `LISTVIEW_GetNextItem` function.
- Improve `LISTVIEW_SetItemPosition` function for auto-arrange.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/92391118-0e255d80-f157-11ea-9cb3-a426a6a03fe2.png)
Arrow keys won't work correctly.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/92391113-0cf43080-f157-11ea-9946-c5b3612722e5.png)
Arrow keys works well.