### PR TITLE
[RAPPS] Display custom applications icons for installed applications CORE-17257

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1407,7 +1407,7 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
     if (!hIcon)
     {
         /* Load default icon */
-        hIcon = (HICON)LoadIconW(hInst, MAKEINTRESOURCE(IDI_MAIN));
+        hIcon = LoadIconW(hInst, MAKEINTRESOURCEW(IDI_MAIN));
     }
 
     int IconIndex = ImageList_AddIcon(m_hImageListView, hIcon);

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1387,11 +1387,11 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
     ATL::CStringW szIconPath;
     if (InstAppInfo->RetrieveIcon(szIconPath))
     {
-        INT Ret = PathParseIconLocationW((LPWSTR)szIconPath.GetString());
+        PathParseIconLocationW((LPWSTR)szIconPath.GetString());
 
         hIcon = ExtractIconW(hInst,
                              szIconPath.GetString(),
-                             Ret);
+                             0);
     }
 
     if (!hIcon)

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1398,9 +1398,9 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
         }
         else if (!Ret)
         {
-            hIcon = (HICON)ExtractIconW(hInst,
-                szIconPath.GetString(),
-                0);
+            hIcon = ExtractIconW(hInst,
+                                 szIconPath.GetString(),
+                                 0);
         }
     }
 

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1389,19 +1389,9 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
     {
         INT Ret = PathParseIconLocationW((LPWSTR)szIconPath.GetString());
 
-        /* Check if icon location is zero-terminated */
-        if (Ret == 0)
-        {
-            hIcon = ExtractIconW(hInst,
-                                 szIconPath.GetString(),
-                                 Ret);
-        }
-        else if (!Ret)
-        {
-            hIcon = ExtractIconW(hInst,
-                                 szIconPath.GetString(),
-                                 0);
-        }
+        hIcon = ExtractIconW(hInst,
+                             szIconPath.GetString(),
+                             Ret);
     }
 
     if (!hIcon)

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1382,7 +1382,33 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
         return FALSE;
     }
 
-    HICON hIcon = (HICON)LoadIconW(hInst, MAKEINTRESOURCEW(IDI_MAIN));
+    /* Load icon from registry */
+    HICON hIcon = NULL;
+    ATL::CStringW szIconPath;
+    if (InstAppInfo->RetrieveIcon(szIconPath))
+    {
+        INT Ret = PathParseIconLocationW((LPWSTR)szIconPath.GetString());
+
+        /* Check if icon location is zero-terminated */
+        if (Ret == 0)
+        {
+            hIcon = (HICON)ExtractIconW(hInst,
+                szIconPath.GetString(),
+                Ret);
+        }
+        else if (!Ret)
+        {
+            hIcon = (HICON)ExtractIconW(hInst,
+                szIconPath.GetString(),
+                0);
+        }
+    }
+
+    if (!hIcon)
+    {
+        /* Load default icon */
+        hIcon = (HICON)LoadIconW(hInst, MAKEINTRESOURCE(IDI_MAIN));
+    }
 
     int IconIndex = ImageList_AddIcon(m_hImageListView, hIcon);
     DestroyIcon(hIcon);

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1392,9 +1392,9 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
         /* Check if icon location is zero-terminated */
         if (Ret == 0)
         {
-            hIcon = (HICON)ExtractIconW(hInst,
-                szIconPath.GetString(),
-                Ret);
+            hIcon = ExtractIconW(hInst,
+                                 szIconPath.GetString(),
+                                 Ret);
         }
         else if (!Ret)
         {
@@ -2050,4 +2050,3 @@ BOOL CApplicationView::ItemCheckStateChanged(BOOL bChecked, LPVOID CallbackParam
     return TRUE;
 }
 // **** CApplicationView ****
-

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1389,6 +1389,9 @@ BOOL CAppsListView::AddInstalledApplication(CInstalledApplicationInfo *InstAppIn
     {
         PathParseIconLocationW((LPWSTR)szIconPath.GetString());
 
+        /* Load only the 1st icon from the application executable,
+         * because all apps provide the executables which have the main icon
+         * as 1st in the index , so we don't need other icons here */
         hIcon = ExtractIconW(hInst,
                              szIconPath.GetString(),
                              0);

--- a/base/applications/rapps/include/appview.h
+++ b/base/applications/rapps/include/appview.h
@@ -20,7 +20,7 @@
 
 using namespace Gdiplus;
 
-#define LISTVIEW_ICON_SIZE 24
+#define LISTVIEW_ICON_SIZE 32
 
 // default broken-image icon size
 #define BROKENIMG_ICON_SIZE 96

--- a/base/applications/rapps/include/installed.h
+++ b/base/applications/rapps/include/installed.h
@@ -16,9 +16,11 @@ public:
     CInstalledApplicationInfo(BOOL bIsUserKey, REGSAM RegWowKey, HKEY hKey);
     BOOL GetApplicationRegString(LPCWSTR lpKeyName, ATL::CStringW& String);
     BOOL GetApplicationRegDword(LPCWSTR lpKeyName, DWORD *lpValue);
+    BOOL RetrieveIcon(ATL::CStringW& IconLocation);
     BOOL UninstallApplication(BOOL bModify);
     LSTATUS RemoveFromRegistry();
 
+    ATL::CStringW szDisplayIcon;
     ATL::CStringW szDisplayName;
     ATL::CStringW szDisplayVersion;
     ATL::CStringW szPublisher;

--- a/base/applications/rapps/installed.cpp
+++ b/base/applications/rapps/installed.cpp
@@ -126,6 +126,16 @@ BOOL CInstalledApplicationInfo::GetApplicationRegDword(LPCWSTR lpKeyName, DWORD 
     return TRUE;
 }
 
+BOOL CInstalledApplicationInfo::RetrieveIcon(ATL::CStringW& IconLocation)
+{
+    if (szDisplayIcon.IsEmpty())
+    {
+        return FALSE;
+    }
+    IconLocation = szDisplayIcon;
+    return TRUE;
+}
+
 BOOL CInstalledApplicationInfo::UninstallApplication(BOOL bModify)
 {
     return StartProcess(bModify ? szModifyPath : szUninstallString, TRUE);
@@ -206,6 +216,7 @@ BOOL CInstalledApps::Enum(INT EnumType, APPENUMPROC lpEnumProc, PVOID param)
                     // those items without display name are ignored
                     if (Info->GetApplicationRegString(L"DisplayName", Info->szDisplayName))
                     {
+                        Info->GetApplicationRegString(L"DisplayIcon", Info->szDisplayIcon);
                         Info->GetApplicationRegString(L"DisplayVersion", Info->szDisplayVersion);
                         Info->GetApplicationRegString(L"Publisher", Info->szPublisher);
                         Info->GetApplicationRegString(L"RegOwner", Info->szRegOwner);


### PR DESCRIPTION
## Purpose

Allow Rapps to display custom app icons for installed software instead of just default Rapps icon.
In my opinion, default icon for each application looks monotonously and not informatively, because it doesn't display what it should. So displaying the custom app's icon instead will make it less hard to understand which app is actually installed.
Moreover, it already has been done for available apps (during GSoC 2020).

JIRA issue: [CORE-17257](https://jira.reactos.org/browse/CORE-17257)

## Proposed changes

- Implement `RetrieveIcon` helper function in `CInstalledApplicationInfo` class, which retrueves the current app's icon from registrty, same as it done for `CAvailableApplicationInfo`.
- Use it for loading the icon in `CAppsListView::AddInstalledApplication` function, via `ExtractIconW`. Load default Rapps icon only when the app has no its custom icon.
- Retrieve `DisplayIcon` value from registry in `CInstalledApps::Enum` function, same as other registry values (like app name, description, etc).Store it in `szDisplayIcon` string, which is used in `CInstalledApplicationInfo::RetrieveIcon` for retrieving the data of that value.
- Increase `LISTVIEW_ICON_SIZE` macro from 24 to 32, so 32x32 icon size is now used instead of 24x24. This makes displayed icons more accurate, since most of apps contain 32x32 icon, so they look a bit distorted with 24x24 size.

## TODO

- [x] Display the icons also for apps, whose strings in registry are terminated by zero. Currently, my patch implements displaying the icons only for apps, which have direct string. E. g. for: `C:\AppPath\AppName.exe` it displays the icon correctly, but for `C:\AppPath\AppName.exe,0` it does not. :frowning_face: 

## Result

Before:
![rapps_icons_before](https://user-images.githubusercontent.com/26385117/92413886-bf79c280-f15a-11ea-8c47-9e3af315beb1.png)

After:
![rapps_icons_after](https://user-images.githubusercontent.com/26385117/92413904-d3252900-f15a-11ea-8116-da944e3780bc.png)