### PR TITLE
[PCIIDEX] Add missing exported function

### DIFF
--- a/drivers/storage/ide/pciidex/miniport.c
+++ b/drivers/storage/ide/pciidex/miniport.c
@@ -11,6 +11,9 @@
 #define NDEBUG
 #include <debug.h>
 
+/** @brief Global debugging level. Valid values are between 0 (Error) and 3 (Trace). */
+ULONG PciIdeDebug = 0;
+
 static DRIVER_DISPATCH PciIdeXForwardOrIgnore;
 static NTSTATUS NTAPI
 PciIdeXForwardOrIgnore(
@@ -88,6 +91,32 @@ PciIdeXPnpDispatch(
 		return PciIdeXFdoPnpDispatch(DeviceObject, Irp);
 	else
 		return PciIdeXPdoPnpDispatch(DeviceObject, Irp);
+}
+
+/**
+ * @brief Prints the given string with printf-like formatting to the kernel debugger.
+ * @param[in] DebugPrintLevel Level of the debug message.
+ *                            Valid values are between 0 (Error) and 3 (Trace).
+ * @param[in] DebugMessage    Format of the string/arguments.
+ * @param[in] ...             Variable number of arguments matching the format
+ *                            specified in \a DebugMessage.
+ * @sa PciIdeDebug
+ */
+VOID
+PciIdeXDebugPrint(
+    _In_ ULONG DebugPrintLevel,
+    _In_z_ _Printf_format_string_ PCCHAR DebugMessage,
+    ...)
+{
+    va_list ap;
+
+    /* Check if we can print anything */
+    if (DebugPrintLevel <= PciIdeDebug)
+        DebugPrintLevel = 0;
+
+    va_start(ap, DebugMessage);
+    vDbgPrintEx(DPFLTR_PCIIDE_ID, DebugPrintLevel, DebugMessage, ap);
+    va_end(ap);
 }
 
 NTSTATUS NTAPI

--- a/drivers/storage/ide/pciidex/pciidex.spec
+++ b/drivers/storage/ide/pciidex/pciidex.spec
@@ -1,4 +1,4 @@
-@ varargs PciIdeXDebugPrint(long ptr)
+@ varargs PciIdeXDebugPrint(long str)
 @ stdcall PciIdeXGetBusData(ptr ptr long long)
 @ stdcall PciIdeXInitialize(ptr ptr ptr long)
 @ stdcall PciIdeXSetBusData(ptr ptr ptr long long)

--- a/drivers/storage/ide/pciidex/pciidex.spec
+++ b/drivers/storage/ide/pciidex/pciidex.spec
@@ -1,3 +1,4 @@
+@ varargs PciIdeXDebugPrint(long ptr)
 @ stdcall PciIdeXGetBusData(ptr ptr long long)
 @ stdcall PciIdeXInitialize(ptr ptr ptr long)
 @ stdcall PciIdeXSetBusData(ptr ptr ptr long long)

--- a/drivers/storage/inc/ide.h
+++ b/drivers/storage/inc/ide.h
@@ -478,8 +478,8 @@ typedef struct _PCIIDE_CONFIG_HEADER {
 
 VOID
 PciIdeXDebugPrint(
-    ULONG DebugPrintLevel,
-    PCCHAR DebugMessage,
+    _In_ ULONG DebugPrintLevel,
+    _In_z_ _Printf_format_string_ PCCHAR DebugMessage,
     ...
     );
 


### PR DESCRIPTION
## Purpose

Useful for debugging IDE controller minidrivers.

JIRA issue: [CORE-17256](https://jira.reactos.org/browse/CORE-17256)

AFTER:
![drv](https://user-images.githubusercontent.com/37072976/92856412-39d56b80-f415-11ea-880f-48998c11112d.png)

