### PR TITLE
Add MSVCRT Vista exports

### DIFF
--- a/dll/apisets/api-ms-win-crt-private-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-private-l1-1-0.spec
@@ -18,7 +18,7 @@
 @ stub __BuildCatchObject
 @ stub __BuildCatchObjectHelper
 @ stdcall -arch=x86_64,arm __C_specific_handler() msvcrt.__C_specific_handler
-@ stdcall __CxxDetectRethrow() msvcrt.__CxxDetectRethrow
+@ stdcall -arch=i386 __CxxDetectRethrow() msvcrt.__CxxDetectRethrow
 @ stub __CxxExceptionFilter
 @ stdcall -arch=i386,x86_64 __CxxFrameHandler() msvcrt.__CxxFrameHandler
 @ stdcall -arch=i386 __CxxFrameHandler2() msvcrt.__CxxFrameHandler2

--- a/dll/apisets/api-ms-win-crt-runtime-l1-1-0.spec
+++ b/dll/apisets/api-ms-win-crt-runtime-l1-1-0.spec
@@ -39,7 +39,8 @@
 @ stdcall _errno() msvcrt._errno
 @ stub -version=0xA00+ _execute_onexit_table
 @ stdcall _exit() msvcrt._exit
-@ stdcall _fpieee_flt() msvcrt._fpieee_flt
+@ stdcall -arch=i386 _fpieee_flt() msvcrt._fpieee_flt
+@ stdcall -stub -arch=x86_64 _fpieee_flt() # ucrtbase._fpieee_flt (msvcrt x64 doesn't have this!)
 @ stdcall _fpreset() msvcrt._fpreset
 @ stub _get_doserrno
 @ stub _get_errno

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -3,64 +3,64 @@
 @ cdecl -arch=x86_64 -version=0x502 $I10_OUTPUT() MSVCRT_I10_OUTPUT
 
 # **************** x86 C++ functions ****************
-@ cdecl -i386 -norelay ??0__non_rtti_object@@QAE@ABV0@@Z(ptr) MSVCRT___non_rtti_object_copy_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(class __non_rtti_object const &)
-@ cdecl -i386 -norelay ??0__non_rtti_object@@QAE@PBD@Z(ptr) MSVCRT___non_rtti_object_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(char const *)
-@ cdecl -i386 -norelay ??0bad_cast@@AAE@PBQBD@Z(ptr) MSVCRT_bad_cast_ctor # private: __thiscall bad_cast::bad_cast(char const * const *)
-@ cdecl -i386 -norelay ??0bad_cast@@QAE@ABQBD@Z(ptr) MSVCRT_bad_cast_ctor # public: __thiscall bad_cast::bad_cast(char const * const &)
-@ cdecl -i386 -norelay ??0bad_cast@@QAE@ABV0@@Z(ptr) MSVCRT_bad_cast_copy_ctor # public: __thiscall bad_cast::bad_cast(class bad_cast const &)
-@ cdecl -i386 -norelay ??0bad_cast@@QAE@PBD@Z(ptr) MSVCRT_bad_cast_ctor_charptr # public: __thiscall bad_cast::bad_cast(char const *)
-@ cdecl -i386 -norelay ??0bad_typeid@@QAE@ABV0@@Z(ptr) MSVCRT_bad_typeid_copy_ctor # public: __thiscall bad_typeid::bad_typeid(class bad_typeid const &)
-@ cdecl -i386 -norelay ??0bad_typeid@@QAE@PBD@Z(ptr) MSVCRT_bad_typeid_ctor # public: __thiscall bad_typeid::bad_typeid(char const *)
-@ cdecl -i386 -norelay ??0exception@@QAE@ABQBD@Z(ptr) MSVCRT_exception_ctor # public: __thiscall exception::exception(char const * const &)
-@ cdecl -i386 -norelay ??0exception@@QAE@ABQBDH@Z(ptr long) MSVCRT_exception_ctor_noalloc # public: __thiscall exception::exception(char const * const &,int)
-@ cdecl -i386 -norelay ??0exception@@QAE@ABV0@@Z(ptr) MSVCRT_exception_copy_ctor # public: __thiscall exception::exception(class exception const &)
-@ cdecl -i386 -norelay ??0exception@@QAE@XZ() MSVCRT_exception_default_ctor # public: __thiscall exception::exception(void)
-@ cdecl -i386 -norelay ??1__non_rtti_object@@UAE@XZ() MSVCRT___non_rtti_object_dtor # public: virtual __thiscall __non_rtti_object::~__non_rtti_object(void)
-@ cdecl -i386 -norelay ??1bad_cast@@UAE@XZ() MSVCRT_bad_cast_dtor # public: virtual __thiscall bad_cast::~bad_cast(void)
-@ cdecl -i386 -norelay ??1bad_typeid@@UAE@XZ() MSVCRT_bad_typeid_dtor # public: virtual __thiscall bad_typeid::~bad_typeid(void)
-@ cdecl -i386 -norelay ??1exception@@UAE@XZ() MSVCRT_exception_dtor # public: virtual __thiscall exception::~exception(void)
-@ cdecl -i386 -norelay ??1type_info@@UAE@XZ() MSVCRT_type_info_dtor # public: virtual __thiscall type_info::~type_info(void)
-@ cdecl -i386 ??2@YAPAXI@Z(long) MSVCRT_operator_new # void * __cdecl operator new(unsigned int)
-;@ cdecl -i386 ??2@YAPAXIHPBDH@Z(long long str long) MSVCRT_operator_new_dbg # void * __cdecl operator new(unsigned int,int,char const *,int)
-@ cdecl -i386 ??3@YAXPAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete(void *)
-@ cdecl -i386 -norelay ??4__non_rtti_object@@QAEAAV0@ABV0@@Z(ptr) MSVCRT___non_rtti_object_opequals # public: class __non_rtti_object & __thiscall __non_rtti_object::operator=(class __non_rtti_object const &)
-@ cdecl -i386 -norelay ??4bad_cast@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_bad_cast_opequals # public: class bad_cast & __thiscall bad_cast::operator=(class bad_cast const &)
-@ cdecl -i386 -norelay ??4bad_typeid@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_bad_typeid_opequals # public: class bad_typeid & __thiscall bad_typeid::operator=(class bad_typeid const &)
-@ cdecl -i386 -norelay ??4exception@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_exception_opequals # public: class exception & __thiscall exception::operator=(class exception const &)
-@ cdecl -i386 -norelay ??8type_info@@QBEHABV0@@Z(ptr) MSVCRT_type_info_opequals_equals # public: int __thiscall type_info::operator==(class type_info const &)const
-@ cdecl -i386 -norelay ??9type_info@@QBEHABV0@@Z(ptr) MSVCRT_type_info_opnot_equals # public: int __thiscall type_info::operator!=(class type_info const &)const
-@ extern -i386 ??_7__non_rtti_object@@6B@ MSVCRT___non_rtti_object_vtable # const __non_rtti_object::`vftable'
-@ extern -i386 ??_7bad_cast@@6B@ MSVCRT_bad_cast_vtable # const bad_cast::`vftable'
-@ extern -i386 ??_7bad_typeid@@6B@ MSVCRT_bad_typeid_vtable # const bad_typeid::`vftable'
-@ extern -i386 ??_7exception@@6B@ MSVCRT_exception_vtable # const exception::`vftable'
-@ cdecl -i386 -norelay ??_E__non_rtti_object@@UAEPAXI@Z(long) MSVCRT___non_rtti_object_vector_dtor # public: virtual void * __thiscall __non_rtti_object::`vector deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Ebad_cast@@UAEPAXI@Z(long) MSVCRT_bad_cast_vector_dtor # public: virtual void * __thiscall bad_cast::`vector deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Ebad_typeid@@UAEPAXI@Z(long) MSVCRT_bad_typeid_vector_dtor # public: virtual void * __thiscall bad_typeid::`vector deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Eexception@@UAEPAXI@Z(long) MSVCRT_exception_vector_dtor # public: virtual void * __thiscall exception::`vector deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Fbad_cast@@QAEXXZ() MSVCRT_bad_cast_default_ctor # public: void __thiscall bad_cast::`default constructor closure'(void)
-@ cdecl -i386 -norelay ??_Fbad_typeid@@QAEXXZ() MSVCRT_bad_typeid_default_ctor # public: void __thiscall bad_typeid::`default constructor closure'(void)
-@ cdecl -i386 -norelay ??_G__non_rtti_object@@UAEPAXI@Z(long) MSVCRT___non_rtti_object_scalar_dtor # public: virtual void * __thiscall __non_rtti_object::`scalar deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Gbad_cast@@UAEPAXI@Z(long) MSVCRT_bad_cast_scalar_dtor # public: virtual void * __thiscall bad_cast::`scalar deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Gbad_typeid@@UAEPAXI@Z(long) MSVCRT_bad_typeid_scalar_dtor # public: virtual void * __thiscall bad_typeid::`scalar deleting destructor'(unsigned int)
-@ cdecl -i386 -norelay ??_Gexception@@UAEPAXI@Z(long) MSVCRT_exception_scalar_dtor # public: virtual void * __thiscall exception::`scalar deleting destructor'(unsigned int)
-@ cdecl -i386 ??_U@YAPAXI@Z(long) MSVCRT_operator_new # void * __cdecl operator new[](unsigned int)
-;@ cdecl -i386 ??_U@YAPAXIHPBDH@Z(long long str long) MSVCRT_operator_new_dbg # void * __cdecl operator new[](unsigned int,int,char const *,int)
-@ cdecl -i386 ??_V@YAXPAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete[](void *)
-@ cdecl -i386 -norelay __uncaught_exception(ptr) MSVCRT___uncaught_exception
-@ cdecl -i386 -norelay ?_query_new_handler@@YAP6AHI@ZXZ() MSVCRT__query_new_handler # int (__cdecl*__cdecl _query_new_handler(void))(unsigned int)
-@ cdecl -i386 ?_query_new_mode@@YAHXZ() MSVCRT__query_new_mode # int __cdecl _query_new_mode(void)
-@ cdecl -i386 -norelay ?_set_new_handler@@YAP6AHI@ZP6AHI@Z@Z(ptr) MSVCRT__set_new_handler # int (__cdecl*__cdecl _set_new_handler(int (__cdecl*)(unsigned int)))(unsigned int)
-@ cdecl -i386 ?_set_new_mode@@YAHH@Z(long) MSVCRT__set_new_mode # int __cdecl _set_new_mode(int)
-@ cdecl -i386 -norelay ?_set_se_translator@@YAP6AXIPAU_EXCEPTION_POINTERS@@@ZP6AXI0@Z@Z(ptr) MSVCRT__set_se_translator # void (__cdecl*__cdecl _set_se_translator(void (__cdecl*)(unsigned int,struct _EXCEPTION_POINTERS *)))(unsigned int,struct _EXCEPTION_POINTERS *)
-@ cdecl -i386 -norelay ?before@type_info@@QBEHABV1@@Z(ptr) MSVCRT_type_info_before # public: int __thiscall type_info::before(class type_info const &)const
-@ cdecl -i386 -norelay ?name@type_info@@QBEPBDXZ() MSVCRT_type_info_name # public: char const * __thiscall type_info::name(void)const
-@ cdecl -i386 -norelay ?raw_name@type_info@@QBEPBDXZ() MSVCRT_type_info_raw_name # public: char const * __thiscall type_info::raw_name(void)const
-@ cdecl -i386 ?set_new_handler@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_new_handler # void (__cdecl*__cdecl set_new_handler(void (__cdecl*)(void)))(void)
-@ cdecl -i386 ?set_terminate@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_terminate # void (__cdecl*__cdecl set_terminate(void (__cdecl*)(void)))(void)
-@ cdecl -i386 ?set_unexpected@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_unexpected # void (__cdecl*__cdecl set_unexpected(void (__cdecl*)(void)))(void)
-@ cdecl -i386 ?terminate@@YAXXZ() MSVCRT_terminate # void __cdecl terminate(void)
-@ cdecl -i386 ?unexpected@@YAXXZ() MSVCRT_unexpected # void __cdecl unexpected(void)
-@ cdecl -i386 -norelay ?what@exception@@UBEPBDXZ() MSVCRT_what_exception # public: virtual char const * __thiscall exception::what(void)const
+@ cdecl -arch=i386 -norelay ??0__non_rtti_object@@QAE@ABV0@@Z(ptr) MSVCRT___non_rtti_object_copy_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(class __non_rtti_object const &)
+@ cdecl -arch=i386 -norelay ??0__non_rtti_object@@QAE@PBD@Z(ptr) MSVCRT___non_rtti_object_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(char const *)
+@ cdecl -arch=i386 -norelay ??0bad_cast@@AAE@PBQBD@Z(ptr) MSVCRT_bad_cast_ctor # private: __thiscall bad_cast::bad_cast(char const * const *)
+@ cdecl -arch=i386 -norelay ??0bad_cast@@QAE@ABQBD@Z(ptr) MSVCRT_bad_cast_ctor # public: __thiscall bad_cast::bad_cast(char const * const &)
+@ cdecl -arch=i386 -norelay ??0bad_cast@@QAE@ABV0@@Z(ptr) MSVCRT_bad_cast_copy_ctor # public: __thiscall bad_cast::bad_cast(class bad_cast const &)
+@ cdecl -arch=i386 -norelay ??0bad_cast@@QAE@PBD@Z(ptr) MSVCRT_bad_cast_ctor_charptr # public: __thiscall bad_cast::bad_cast(char const *)
+@ cdecl -arch=i386 -norelay ??0bad_typeid@@QAE@ABV0@@Z(ptr) MSVCRT_bad_typeid_copy_ctor # public: __thiscall bad_typeid::bad_typeid(class bad_typeid const &)
+@ cdecl -arch=i386 -norelay ??0bad_typeid@@QAE@PBD@Z(ptr) MSVCRT_bad_typeid_ctor # public: __thiscall bad_typeid::bad_typeid(char const *)
+@ cdecl -arch=i386 -norelay ??0exception@@QAE@ABQBD@Z(ptr) MSVCRT_exception_ctor # public: __thiscall exception::exception(char const * const &)
+@ cdecl -arch=i386 -norelay ??0exception@@QAE@ABQBDH@Z(ptr long) MSVCRT_exception_ctor_noalloc # public: __thiscall exception::exception(char const * const &,int)
+@ cdecl -arch=i386 -norelay ??0exception@@QAE@ABV0@@Z(ptr) MSVCRT_exception_copy_ctor # public: __thiscall exception::exception(class exception const &)
+@ cdecl -arch=i386 -norelay ??0exception@@QAE@XZ() MSVCRT_exception_default_ctor # public: __thiscall exception::exception(void)
+@ cdecl -arch=i386 -norelay ??1__non_rtti_object@@UAE@XZ() MSVCRT___non_rtti_object_dtor # public: virtual __thiscall __non_rtti_object::~__non_rtti_object(void)
+@ cdecl -arch=i386 -norelay ??1bad_cast@@UAE@XZ() MSVCRT_bad_cast_dtor # public: virtual __thiscall bad_cast::~bad_cast(void)
+@ cdecl -arch=i386 -norelay ??1bad_typeid@@UAE@XZ() MSVCRT_bad_typeid_dtor # public: virtual __thiscall bad_typeid::~bad_typeid(void)
+@ cdecl -arch=i386 -norelay ??1exception@@UAE@XZ() MSVCRT_exception_dtor # public: virtual __thiscall exception::~exception(void)
+@ cdecl -arch=i386 -norelay ??1type_info@@UAE@XZ() MSVCRT_type_info_dtor # public: virtual __thiscall type_info::~type_info(void)
+@ cdecl -arch=i386 ??2@YAPAXI@Z(long) MSVCRT_operator_new # void * __cdecl operator new(unsigned int)
+;@ cdecl -arch=i386 ??2@YAPAXIHPBDH@Z(long long str long) MSVCRT_operator_new_dbg # void * __cdecl operator new(unsigned int,int,char const *,int)
+@ cdecl -arch=i386 ??3@YAXPAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete(void *)
+@ cdecl -arch=i386 -norelay ??4__non_rtti_object@@QAEAAV0@ABV0@@Z(ptr) MSVCRT___non_rtti_object_opequals # public: class __non_rtti_object & __thiscall __non_rtti_object::operator=(class __non_rtti_object const &)
+@ cdecl -arch=i386 -norelay ??4bad_cast@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_bad_cast_opequals # public: class bad_cast & __thiscall bad_cast::operator=(class bad_cast const &)
+@ cdecl -arch=i386 -norelay ??4bad_typeid@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_bad_typeid_opequals # public: class bad_typeid & __thiscall bad_typeid::operator=(class bad_typeid const &)
+@ cdecl -arch=i386 -norelay ??4exception@@QAEAAV0@ABV0@@Z(ptr) MSVCRT_exception_opequals # public: class exception & __thiscall exception::operator=(class exception const &)
+@ cdecl -arch=i386 -norelay ??8type_info@@QBEHABV0@@Z(ptr) MSVCRT_type_info_opequals_equals # public: int __thiscall type_info::operator==(class type_info const &)const
+@ cdecl -arch=i386 -norelay ??9type_info@@QBEHABV0@@Z(ptr) MSVCRT_type_info_opnot_equals # public: int __thiscall type_info::operator!=(class type_info const &)const
+@ extern -arch=i386 ??_7__non_rtti_object@@6B@ MSVCRT___non_rtti_object_vtable # const __non_rtti_object::`vftable'
+@ extern -arch=i386 ??_7bad_cast@@6B@ MSVCRT_bad_cast_vtable # const bad_cast::`vftable'
+@ extern -arch=i386 ??_7bad_typeid@@6B@ MSVCRT_bad_typeid_vtable # const bad_typeid::`vftable'
+@ extern -arch=i386 ??_7exception@@6B@ MSVCRT_exception_vtable # const exception::`vftable'
+@ cdecl -arch=i386 -norelay ??_E__non_rtti_object@@UAEPAXI@Z(long) MSVCRT___non_rtti_object_vector_dtor # public: virtual void * __thiscall __non_rtti_object::`vector deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Ebad_cast@@UAEPAXI@Z(long) MSVCRT_bad_cast_vector_dtor # public: virtual void * __thiscall bad_cast::`vector deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Ebad_typeid@@UAEPAXI@Z(long) MSVCRT_bad_typeid_vector_dtor # public: virtual void * __thiscall bad_typeid::`vector deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Eexception@@UAEPAXI@Z(long) MSVCRT_exception_vector_dtor # public: virtual void * __thiscall exception::`vector deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Fbad_cast@@QAEXXZ() MSVCRT_bad_cast_default_ctor # public: void __thiscall bad_cast::`default constructor closure'(void)
+@ cdecl -arch=i386 -norelay ??_Fbad_typeid@@QAEXXZ() MSVCRT_bad_typeid_default_ctor # public: void __thiscall bad_typeid::`default constructor closure'(void)
+@ cdecl -arch=i386 -norelay ??_G__non_rtti_object@@UAEPAXI@Z(long) MSVCRT___non_rtti_object_scalar_dtor # public: virtual void * __thiscall __non_rtti_object::`scalar deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Gbad_cast@@UAEPAXI@Z(long) MSVCRT_bad_cast_scalar_dtor # public: virtual void * __thiscall bad_cast::`scalar deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Gbad_typeid@@UAEPAXI@Z(long) MSVCRT_bad_typeid_scalar_dtor # public: virtual void * __thiscall bad_typeid::`scalar deleting destructor'(unsigned int)
+@ cdecl -arch=i386 -norelay ??_Gexception@@UAEPAXI@Z(long) MSVCRT_exception_scalar_dtor # public: virtual void * __thiscall exception::`scalar deleting destructor'(unsigned int)
+@ cdecl -arch=i386 ??_U@YAPAXI@Z(long) MSVCRT_operator_new # void * __cdecl operator new[](unsigned int)
+;@ cdecl -arch=i386 ??_U@YAPAXIHPBDH@Z(long long str long) MSVCRT_operator_new_dbg # void * __cdecl operator new[](unsigned int,int,char const *,int)
+@ cdecl -arch=i386 ??_V@YAXPAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete[](void *)
+@ cdecl -arch=i386 -norelay __uncaught_exception(ptr) MSVCRT___uncaught_exception
+@ cdecl -arch=i386 -norelay ?_query_new_handler@@YAP6AHI@ZXZ() MSVCRT__query_new_handler # int (__cdecl*__cdecl _query_new_handler(void))(unsigned int)
+@ cdecl -arch=i386 ?_query_new_mode@@YAHXZ() MSVCRT__query_new_mode # int __cdecl _query_new_mode(void)
+@ cdecl -arch=i386 -norelay ?_set_new_handler@@YAP6AHI@ZP6AHI@Z@Z(ptr) MSVCRT__set_new_handler # int (__cdecl*__cdecl _set_new_handler(int (__cdecl*)(unsigned int)))(unsigned int)
+@ cdecl -arch=i386 ?_set_new_mode@@YAHH@Z(long) MSVCRT__set_new_mode # int __cdecl _set_new_mode(int)
+@ cdecl -arch=i386 -norelay ?_set_se_translator@@YAP6AXIPAU_EXCEPTION_POINTERS@@@ZP6AXI0@Z@Z(ptr) MSVCRT__set_se_translator # void (__cdecl*__cdecl _set_se_translator(void (__cdecl*)(unsigned int,struct _EXCEPTION_POINTERS *)))(unsigned int,struct _EXCEPTION_POINTERS *)
+@ cdecl -arch=i386 -norelay ?before@type_info@@QBEHABV1@@Z(ptr) MSVCRT_type_info_before # public: int __thiscall type_info::before(class type_info const &)const
+@ cdecl -arch=i386 -norelay ?name@type_info@@QBEPBDXZ() MSVCRT_type_info_name # public: char const * __thiscall type_info::name(void)const
+@ cdecl -arch=i386 -norelay ?raw_name@type_info@@QBEPBDXZ() MSVCRT_type_info_raw_name # public: char const * __thiscall type_info::raw_name(void)const
+@ cdecl -arch=i386 ?set_new_handler@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_new_handler # void (__cdecl*__cdecl set_new_handler(void (__cdecl*)(void)))(void)
+@ cdecl -arch=i386 ?set_terminate@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_terminate # void (__cdecl*__cdecl set_terminate(void (__cdecl*)(void)))(void)
+@ cdecl -arch=i386 ?set_unexpected@@YAP6AXXZP6AXXZ@Z(ptr) MSVCRT_set_unexpected # void (__cdecl*__cdecl set_unexpected(void (__cdecl*)(void)))(void)
+@ cdecl -arch=i386 ?terminate@@YAXXZ() MSVCRT_terminate # void __cdecl terminate(void)
+@ cdecl -arch=i386 ?unexpected@@YAXXZ() MSVCRT_unexpected # void __cdecl unexpected(void)
+@ cdecl -arch=i386 -norelay ?what@exception@@UBEPBDXZ() MSVCRT_what_exception # public: virtual char const * __thiscall exception::what(void)const
 
 # **************** win64 C++ functions ****************
 @ cdecl -arch=win64 ??0__non_rtti_object@@QEAA@AEBV0@@Z(ptr) MSVCRT___non_rtti_object_copy_ctor # public: __cdecl __non_rtti_object::__non_rtti_object(class __non_rtti_object const & __ptr64) __ptr64
@@ -198,7 +198,7 @@
 @ cdecl -arch=i386 _CItan()
 @ cdecl -arch=i386 _CItanh()
 @ stdcall _CxxThrowException(long long)
-@ cdecl -i386 -norelay _EH_prolog()
+@ cdecl -arch=i386 -norelay _EH_prolog()
 @ cdecl _Getdays()
 @ cdecl _Getmonths()
 @ cdecl _Gettnames()
@@ -214,10 +214,10 @@
 @ cdecl -arch=i386,x86_64 -norelay __CxxFrameHandler(ptr ptr ptr ptr)
 @ cdecl -arch=i386 -norelay __CxxFrameHandler2(ptr ptr ptr ptr) __CxxFrameHandler
 @ cdecl -arch=arm -norelay __CxxFrameHandler3(ptr ptr ptr ptr)
-@ stdcall -i386 __CxxLongjmpUnwind(ptr)
-@ cdecl -i386 __CxxQueryExceptionSize()
-@ cdecl -i386 __CxxRegisterExceptionObject()
-@ cdecl -i386 __CxxUnregisterExceptionObject()
+@ stdcall -arch=i386 __CxxLongjmpUnwind(ptr)
+@ cdecl -arch=i386 __CxxQueryExceptionSize()
+@ cdecl -arch=i386 __CxxRegisterExceptionObject()
+@ cdecl -arch=i386 __CxxUnregisterExceptionObject()
 @ cdecl __DestructExceptionObject(ptr)
 @ cdecl __RTCastToVoid(ptr) MSVCRT___RTCastToVoid
 @ cdecl __RTDynamicCast(ptr long ptr ptr long) MSVCRT___RTDynamicCast
@@ -340,7 +340,7 @@
 @ cdecl _chdrive(long)
 @ cdecl _chgsign(double)
 @ cdecl -arch=x86_64,arm _chgsignf(long)
-@ cdecl -i386 -norelay _chkesp()
+@ cdecl -arch=i386 -norelay _chkesp()
 @ cdecl _chmod(str long)
 @ cdecl _chsize(long long)
 @ cdecl -arch=i386,x86_64 _clearfp()
@@ -371,9 +371,9 @@
 @ extern _environ
 @ cdecl _eof(long)
 @ cdecl _errno()
-@ cdecl -i386 _except_handler2(ptr ptr ptr ptr)
-@ cdecl -i386 _except_handler3(ptr ptr ptr ptr)
-@ cdecl -i386 -version=0x600+ _except_handler4_common(ptr ptr ptr ptr ptr ptr)
+@ cdecl -arch=i386 _except_handler2(ptr ptr ptr ptr)
+@ cdecl -arch=i386 _except_handler3(ptr ptr ptr ptr)
+@ cdecl -arch=i386 -version=0x600+ _except_handler4_common(ptr ptr ptr ptr ptr ptr)
 @ varargs _execl(str str)
 @ varargs _execle(str str)
 @ varargs _execlp(str str)
@@ -443,7 +443,7 @@
 @ cdecl -stub _getwch()
 @ cdecl -stub _getwche()
 @ cdecl _getws(ptr)
-@ cdecl -i386 _global_unwind2(ptr)
+@ cdecl -arch=i386 _global_unwind2(ptr)
 @ cdecl _gmtime64(ptr)
 @ cdecl _heapadd(ptr long)
 @ cdecl _heapchk()
@@ -504,13 +504,13 @@
 @ cdecl -arch=i386 _loaddll(str)
 @ cdecl -arch=x86_64 -version=0x502 _loaddll(str)
 @ cdecl -arch=x86_64 _local_unwind(ptr ptr)
-@ cdecl -i386 _local_unwind2(ptr long)
-@ cdecl -i386 -version=0x600+ _local_unwind4(ptr ptr long)
+@ cdecl -arch=i386 _local_unwind2(ptr long)
+@ cdecl -arch=i386 -version=0x600+ _local_unwind4(ptr ptr long)
 @ cdecl _localtime64(ptr)
 @ cdecl _lock(long)
 @ cdecl _locking(long long long)
 @ cdecl _logb(double)
-@ cdecl -i386 _longjmpex(ptr long) longjmp
+@ cdecl -arch=i386 _longjmpex(ptr long) longjmp
 @ cdecl _lrotl(long long)
 @ cdecl _lrotr(long long)
 @ cdecl _lsearch(ptr ptr long long ptr)
@@ -621,7 +621,7 @@
 @ varargs _scprintf(str)
 @ varargs _scwprintf(wstr)
 @ cdecl _searchenv(str str ptr)
-@ stdcall -i386 _seh_longjmp_unwind(ptr)
+@ stdcall -arch=i386 _seh_longjmp_unwind(ptr)
 @ stub -arch=i386 _set_SSE2_enable
 @ cdecl _set_error_mode(long)
 @ cdecl _set_sbh_threshold(long)

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -1,5 +1,7 @@
 # msvcrt.dll - MS VC++ Run Time Library
 
+@ cdecl -arch=x86_64 -version=0x502 $I10_OUTPUT() MSVCRT_I10_OUTPUT
+
 # **************** x86 C++ functions ****************
 @ cdecl -i386 -norelay ??0__non_rtti_object@@QAE@ABV0@@Z(ptr) MSVCRT___non_rtti_object_copy_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(class __non_rtti_object const &)
 @ cdecl -i386 -norelay ??0__non_rtti_object@@QAE@PBD@Z(ptr) MSVCRT___non_rtti_object_ctor # public: __thiscall __non_rtti_object::__non_rtti_object(char const *)
@@ -63,7 +65,9 @@
 # **************** win64 C++ functions ****************
 @ cdecl -arch=win64 ??0__non_rtti_object@@QEAA@AEBV0@@Z(ptr) MSVCRT___non_rtti_object_copy_ctor # public: __cdecl __non_rtti_object::__non_rtti_object(class __non_rtti_object const & __ptr64) __ptr64
 @ cdecl -arch=win64 ??0__non_rtti_object@@QEAA@PEBD@Z(ptr) MSVCRT___non_rtti_object_ctor # public: __cdecl __non_rtti_object::__non_rtti_object(char const * __ptr64) __ptr64
+@ cdecl -arch=win64 ??0bad_cast@@AAE@PBQBD@Z(ptr) MSVCRT_bad_cast_ctor # private: __thiscall bad_cast::bad_cast(char const near * const near *)
 @ cdecl -arch=win64 ??0bad_cast@@AEAA@PEBQEBD@Z(ptr) MSVCRT_bad_cast_ctor # private: __cdecl bad_cast::bad_cast(char const * __ptr64 const * __ptr64) __ptr64
+@ cdecl -arch=win64 ??0bad_cast@@QAE@ABQBD@Z(ptr) MSVCRT_bad_cast_ctor # public: __thiscall bad_cast::bad_cast(char const near * const near &)
 @ cdecl -arch=win64 ??0bad_cast@@QEAA@AEBQEBD@Z(ptr) MSVCRT_bad_cast_ctor # public: __cdecl bad_cast::bad_cast(char const * __ptr64 const & __ptr64) __ptr64
 @ cdecl -arch=win64 ??0bad_cast@@QEAA@AEBV0@@Z(ptr) MSVCRT_bad_cast_copy_ctor # public: __cdecl bad_cast::bad_cast(class bad_cast const & __ptr64) __ptr64
 @ cdecl -arch=win64 ??0bad_cast@@QEAA@PEBD@Z(ptr) MSVCRT_bad_cast_ctor_charptr # public: __cdecl bad_cast::bad_cast(char const * __ptr64) __ptr64
@@ -79,6 +83,7 @@
 @ cdecl -arch=win64 ??1exception@@UEAA@XZ() MSVCRT_exception_dtor # public: virtual __cdecl exception::~exception(void) __ptr64
 @ cdecl -arch=win64 ??1type_info@@UEAA@XZ() MSVCRT_type_info_dtor # public: virtual __cdecl type_info::~type_info(void) __ptr64
 @ cdecl -arch=win64 ??2@YAPEAX_K@Z(double) MSVCRT_operator_new # void * __ptr64 __cdecl operator new(unsigned __int64)
+@ cdecl -arch=win64 ??2@YAPEAX_KHPEBDH@Z(int64 long str long) MSVCRT_operator_new_dbg # void * __ptr64 __cdecl operator new(unsigned __int64,int,char const * __ptr64,int)
 @ cdecl -arch=win64 ??3@YAXPEAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete(void * __ptr64)
 @ cdecl -arch=win64 ??4__non_rtti_object@@QEAAAEAV0@AEBV0@@Z(ptr) MSVCRT___non_rtti_object_opequals # public: class __non_rtti_object & __ptr64 __cdecl __non_rtti_object::operator=(class __non_rtti_object const & __ptr64) __ptr64
 @ cdecl -arch=win64 ??4bad_cast@@QEAAAEAV0@AEBV0@@Z(ptr) MSVCRT_bad_cast_opequals # public: class bad_cast & __ptr64 __cdecl bad_cast::operator=(class bad_cast const & __ptr64) __ptr64
@@ -93,6 +98,7 @@
 @ cdecl -arch=win64 ??_Fbad_cast@@QEAAXXZ() MSVCRT_bad_cast_default_ctor # public: void __cdecl bad_cast::`default constructor closure'(void) __ptr64
 @ cdecl -arch=win64 ??_Fbad_typeid@@QEAAXXZ() MSVCRT_bad_typeid_default_ctor # public: void __cdecl bad_typeid::`default constructor closure'(void) __ptr64
 @ cdecl -arch=win64 ??_U@YAPEAX_K@Z(long) MSVCRT_operator_new # void * __ptr64 __cdecl operator new[](unsigned __int64)
+@ cdecl -arch=win64 ??_U@YAPEAX_KHPEBDH@Z(int64 long str long) MSVCRT_operator_new_dbg # void * __ptr64 __cdecl operator new[](unsigned __int64,int,char const * __ptr64,int)
 @ cdecl -arch=win64 ??_V@YAXPEAX@Z(ptr) MSVCRT_operator_delete # void __cdecl operator delete[](void * __ptr64)
 @ cdecl -arch=win64 __uncaught_exception(ptr) MSVCRT___uncaught_exception
 @ cdecl -arch=win64 ?_query_new_handler@@YAP6AH_K@ZXZ() MSVCRT__query_new_handler # int (__cdecl*__cdecl _query_new_handler(void))(unsigned __int64)
@@ -174,7 +180,7 @@
 
 
 # **************** Common functions ****************
-@ cdecl $I10_OUTPUT() MSVCRT_I10_OUTPUT
+@ cdecl -arch=i386 $I10_OUTPUT() MSVCRT_I10_OUTPUT
 @ cdecl -arch=i386 _CIacos()
 @ cdecl -arch=i386 _CIasin()
 @ cdecl -arch=i386 _CIatan()
@@ -201,10 +207,10 @@
 @ cdecl _XcptFilter(long ptr)
 @ stdcall -arch=x86_64,arm __C_specific_handler(ptr long ptr ptr)
 @ cdecl __CppXcptFilter(long ptr)
-# stub __CxxCallUnwindDtor
-# stub __CxxCallUnwindVecDtor
-@ cdecl __CxxDetectRethrow(ptr)
-@ cdecl __CxxExceptionFilter()
+@ stub -arch=i386 __CxxCallUnwindDtor
+@ stub -arch=i386 __CxxCallUnwindVecDtor
+@ cdecl -arch=i386 __CxxDetectRethrow(ptr)
+@ cdecl -arch=i386 __CxxExceptionFilter()
 @ cdecl -arch=i386,x86_64 -norelay __CxxFrameHandler(ptr ptr ptr ptr)
 @ cdecl -arch=i386 -norelay __CxxFrameHandler2(ptr ptr ptr ptr) __CxxFrameHandler
 @ cdecl -arch=arm -norelay __CxxFrameHandler3(ptr ptr ptr ptr)
@@ -292,7 +298,7 @@
 @ cdecl __wcserror(wstr)
 @ cdecl __wgetmainargs(ptr ptr ptr long ptr)
 @ extern __winitenv
-@ cdecl _abnormal_termination()
+@ cdecl -arch=i386 _abnormal_termination()
 # stub _abs64
 @ cdecl _access(str long)
 @ extern _acmdln
@@ -396,11 +402,13 @@
 @ cdecl _findnext64(long ptr)
 @ cdecl _findnexti64(long ptr)
 @ cdecl _finite(double)
+@ stub -arch=x86_64 _finitef
 @ cdecl _flsbuf(long ptr)
 @ cdecl _flushall()
 @ extern _fmode
 @ cdecl _fpclass(double)
-@ cdecl _fpieee_flt(long ptr ptr)
+@ cdecl -stub -arch=x86_64 _fpclassf(long)
+@ cdecl -arch=i386 _fpieee_flt(long ptr ptr)
 @ cdecl _fpreset()
 @ cdecl _fputchar(long)
 @ cdecl _fputwchar(long)
@@ -423,7 +431,8 @@
 @ cdecl _getcwd(str long)
 @ cdecl _getdcwd(long str long)
 @ cdecl _getdiskfree(long ptr)
-@ cdecl _getdllprocaddr(long str long)
+@ cdecl -arch=i386 _getdllprocaddr(long str long)
+@ cdecl -arch=x86_64 -version=0x502 _getdllprocaddr(long str long)
 @ cdecl _getdrive()
 @ cdecl _getdrives() kernel32.GetLogicalDrives
 @ cdecl _getmaxstdio()
@@ -440,7 +449,8 @@
 @ cdecl _heapchk()
 @ cdecl _heapmin()
 @ cdecl _heapset(long)
-@ cdecl _heapused(ptr ptr)
+@ cdecl -arch=i386 _heapused(ptr ptr)
+@ cdecl -arch=x86_64 -version=0x502 _heapused(ptr ptr)
 @ cdecl _heapwalk(ptr)
 @ cdecl _hypot(double double)
 @ cdecl -arch=x86_64,arm _hypotf(long long)
@@ -483,6 +493,7 @@
 @ cdecl _ismbslead(ptr ptr)
 @ cdecl _ismbstrail(ptr ptr)
 @ cdecl _isnan(double)
+@ stub -arch=x86_64 _isnanf
 @ cdecl _itoa(long ptr long)
 @ cdecl _itow(long ptr long)
 @ cdecl _j0(double)
@@ -490,7 +501,9 @@
 @ cdecl _jn(long double)
 @ cdecl _kbhit()
 @ cdecl _lfind(ptr ptr ptr long ptr)
-@ cdecl _loaddll(str)
+@ cdecl -arch=i386 _loaddll(str)
+@ cdecl -arch=x86_64 -version=0x502 _loaddll(str)
+@ cdecl -arch=x86_64 _local_unwind(ptr ptr)
 @ cdecl -i386 _local_unwind2(ptr long)
 @ cdecl -i386 -version=0x600+ _local_unwind4(ptr ptr long)
 @ cdecl _localtime64(ptr)
@@ -570,6 +583,7 @@
 @ cdecl _mktime64(ptr)
 @ cdecl _msize(ptr)
 @ cdecl _nextafter(double double)
+@ stub -arch=x86_64 _nextafterf
 @ cdecl _onexit(ptr)
 @ varargs _open(str long)
 @ cdecl _open_osfhandle(long long)
@@ -603,11 +617,12 @@
 @ cdecl -arch=i386 _safe_fprem()
 @ cdecl -arch=i386 _safe_fprem1()
 @ cdecl _scalb(double long)
+@ stub -arch=x86_64 _scalbf
 @ varargs _scprintf(str)
 @ varargs _scwprintf(wstr)
 @ cdecl _searchenv(str str ptr)
 @ stdcall -i386 _seh_longjmp_unwind(ptr)
-# stub _set_SSE2_enable
+@ stub -arch=i386 _set_SSE2_enable
 @ cdecl _set_error_mode(long)
 @ cdecl _set_sbh_threshold(long)
 @ cdecl _seterrormode(long)
@@ -674,7 +689,8 @@
 @ cdecl _ungetch(long)
 # stub _ungetwch
 @ cdecl _unlink(str)
-@ cdecl _unloaddll(long)
+@ cdecl -arch=i386 _unloaddll(ptr)
+@ cdecl -arch=x86_64 -version=0x502 _unloaddll(ptr)
 @ cdecl _unlock(long)
 @ cdecl _utime(str ptr)
 @ cdecl _utime64(str ptr)

--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -197,6 +197,31 @@
 @ cdecl -arch=i386 _CIsqrt()
 @ cdecl -arch=i386 _CItan()
 @ cdecl -arch=i386 _CItanh()
+@ stub -version=0x600+ _CrtCheckMemory
+@ stub -version=0x600+ _CrtDbgBreak
+@ stub -version=0x600+ _CrtDbgReport
+@ stub -version=0x600+ _CrtDbgReportV
+@ stub -version=0x600+ _CrtDbgReportW
+@ stub -version=0x600+ _CrtDbgReportWV
+@ stub -version=0x600+ _CrtDoForAllClientObjects
+@ stub -version=0x600+ _CrtDumpMemoryLeaks
+@ stub -version=0x600+ _CrtIsMemoryBlock
+@ stub -version=0x600+ _CrtIsValidHeapPointer
+@ stub -version=0x600+ _CrtIsValidPointer
+@ stub -version=0x600+ _CrtMemCheckpoint
+@ stub -version=0x600+ _CrtMemDifference
+@ stub -version=0x600+ _CrtMemDumpAllObjectsSince
+@ stub -version=0x600+ _CrtMemDumpStatistics
+@ stub -version=0x600+ _CrtReportBlockType
+@ stub -version=0x600+ _CrtSetAllocHook
+@ stub -version=0x600+ _CrtSetBreakAlloc
+@ stub -version=0x600+ _CrtSetDbgBlockType
+@ stub -version=0x600+ _CrtSetDbgFlag
+@ stub -version=0x600+ _CrtSetDumpClient
+@ stub -version=0x600+ _CrtSetReportFile
+@ stub -version=0x600+ _CrtSetReportHook
+@ stub -version=0x600+ _CrtSetReportHook2
+@ stub -version=0x600+ _CrtSetReportMode
 @ stdcall _CxxThrowException(long long)
 @ cdecl -arch=i386 -norelay _EH_prolog()
 @ cdecl _Getdays()
@@ -207,13 +232,16 @@
 @ cdecl _XcptFilter(long ptr)
 @ stdcall -arch=x86_64,arm __C_specific_handler(ptr long ptr ptr)
 @ cdecl __CppXcptFilter(long ptr)
+@ stub -version=0x600+ -arch=i386 __CxxCallUnwindDelDtor
 @ stub -arch=i386 __CxxCallUnwindDtor
 @ stub -arch=i386 __CxxCallUnwindVecDtor
 @ cdecl -arch=i386 __CxxDetectRethrow(ptr)
 @ cdecl -arch=i386 __CxxExceptionFilter()
 @ cdecl -arch=i386,x86_64 -norelay __CxxFrameHandler(ptr ptr ptr ptr)
 @ cdecl -arch=i386 -norelay __CxxFrameHandler2(ptr ptr ptr ptr) __CxxFrameHandler
+@ cdecl -version=0x600+ -arch=x86_64 -norelay __CxxFrameHandler2(ptr ptr ptr ptr) __CxxFrameHandler
 @ cdecl -arch=arm -norelay __CxxFrameHandler3(ptr ptr ptr ptr)
+@ cdecl -version=0x600+ -arch=i386,x86_64 -norelay __CxxFrameHandler3(ptr ptr ptr ptr)
 @ stdcall -arch=i386 __CxxLongjmpUnwind(ptr)
 @ cdecl -arch=i386 __CxxQueryExceptionSize()
 @ cdecl -arch=i386 __CxxRegisterExceptionObject()
@@ -238,8 +266,10 @@
 @ cdecl __crtGetStringTypeW(long long wstr long ptr)
 @ cdecl __crtLCMapStringA(long long str long str long long long)
 @ cdecl __crtLCMapStringW(long long wstr long wstr long long long)
+@ stub -version=0x600+ __daylight
 @ cdecl __dllonexit(ptr ptr ptr)
 @ cdecl __doserrno()
+@ stub -version=0x600+ __dstbias
 @ cdecl __fpecode()
 @ cdecl __getmainargs(ptr ptr ptr long ptr)
 @ extern __initenv
@@ -251,6 +281,27 @@
 @ extern __lc_collate_cp MSVCRT___lc_collate_cp
 @ extern __lc_handle MSVCRT___lc_handle
 @ cdecl __lconv_init()
+@ stub -version=0x600+ -arch=i386 __libm_sse2_acos
+@ stub -version=0x600+ -arch=i386 __libm_sse2_acosf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_asin
+@ stub -version=0x600+ -arch=i386 __libm_sse2_asinf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_atan
+@ stub -version=0x600+ -arch=i386 __libm_sse2_atan2
+@ stub -version=0x600+ -arch=i386 __libm_sse2_atanf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_cos
+@ stub -version=0x600+ -arch=i386 __libm_sse2_cosf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_exp
+@ stub -version=0x600+ -arch=i386 __libm_sse2_expf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_log
+@ stub -version=0x600+ -arch=i386 __libm_sse2_log10
+@ stub -version=0x600+ -arch=i386 __libm_sse2_log10f
+@ stub -version=0x600+ -arch=i386 __libm_sse2_logf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_pow
+@ stub -version=0x600+ -arch=i386 __libm_sse2_powf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_sin
+@ stub -version=0x600+ -arch=i386 __libm_sse2_sinf
+@ stub -version=0x600+ -arch=i386 __libm_sse2_tan
+@ stub -version=0x600+ -arch=i386 __libm_sse2_tanf
 @ extern __mb_cur_max
 @ cdecl -arch=i386 __p___argc()
 @ cdecl -arch=i386 __p___argv()
@@ -288,6 +339,7 @@
 @ cdecl __set_app_type(long)
 @ extern __setlc_active
 @ cdecl __setusermatherr(ptr)
+@ stub -version=0x600+ __strncnt
 @ cdecl __threadhandle() kernel32.GetCurrentThread
 @ cdecl __threadid() kernel32.GetCurrentThreadId
 @ cdecl __toascii(long)
@@ -296,11 +348,14 @@
 @ extern __unguarded_readlc_active
 @ extern __wargv __wargv
 @ cdecl __wcserror(wstr)
+@ cdecl -version=0x600+ __wcserror_s(ptr long wstr)
+@ stub -version=0x600+ __wcsncnt
 @ cdecl __wgetmainargs(ptr ptr ptr long ptr)
 @ extern __winitenv
 @ cdecl -arch=i386 _abnormal_termination()
 # stub _abs64
 @ cdecl _access(str long)
+@ cdecl -version=0x600+ _access_s(str long)
 @ extern _acmdln
 @ stdcall -arch=i386 _adj_fdiv_m16i(long)
 @ stdcall -arch=i386 _adj_fdiv_m32(long)
@@ -318,24 +373,39 @@
 @ extern -arch=i386 _adjust_fdiv
 @ extern _aexit_rtn
 @ cdecl _aligned_free(ptr)
+@ stub -version=0x600+ _aligned_free_dbg
 @ cdecl _aligned_malloc(long long)
+@ stub -version=0x600+ _aligned_malloc_dbg
 @ cdecl _aligned_offset_malloc(long long long)
+@ stub -version=0x600+ _aligned_offset_malloc_dbg
 @ cdecl _aligned_offset_realloc(ptr long long long)
+@ stub -version=0x600+ _aligned_offset_realloc_dbg
 @ cdecl _aligned_realloc(ptr long long)
+@ stub -version=0x600+ _aligned_realloc_dbg
 @ cdecl _amsg_exit(long)
 @ cdecl _assert(str str long)
 @ cdecl _atodbl(ptr str)
+@ stub -version=0x600+ _atodbl_l
+@ stub -version=0x600+ _atof_l
+@ stub -version=0x600+ _atoflt_l
 @ cdecl -ret64 _atoi64(str)
+@ stub -version=0x600+ _atoi64_l
+@ stub -version=0x600+ _atoi_l
+@ stub -version=0x600+ _atol_l
 @ cdecl _atoldbl(ptr str)
+@ stub -version=0x600+ _atoldbl_l
 @ cdecl _beep(long long)
 @ cdecl _beginthread(ptr long ptr)
 @ cdecl _beginthreadex(ptr long ptr ptr long ptr)
 @ cdecl _c_exit()
 @ cdecl _cabs(long)
 @ cdecl _callnewh(long)
+@ stub -version=0x600+ _calloc_dbg
 @ cdecl _cexit()
 @ cdecl _cgets(str)
+@ stub -version=0x600+ _cgets_s
 @ cdecl -stub _cgetws(wstr)
+@ stub -version=0x600+ _cgetws_s
 @ cdecl _chdir(str)
 @ cdecl _chdrive(long)
 @ cdecl _chgsign(double)
@@ -343,29 +413,58 @@
 @ cdecl -arch=i386 -norelay _chkesp()
 @ cdecl _chmod(str long)
 @ cdecl _chsize(long long)
+@ cdecl -version=0x600+ _chsize_s(long int64)
+@ stub -version=0x600+ _chvalidator
+@ stub -version=0x600+ _chvalidator_l
 @ cdecl -arch=i386,x86_64 _clearfp()
 @ cdecl _close(long)
 @ cdecl _commit(long)
 @ extern _commode
 @ cdecl -arch=i386,x86_64 _control87(long long)
 @ cdecl _controlfp(long long)
+@ cdecl -version=0x600+ _controlfp_s(ptr long long)
 @ cdecl _copysign( double double )
 @ cdecl -arch=x86_64,arm _copysignf(long long)
 @ varargs _cprintf(str)
+@ stub -version=0x600+ _cprintf_l
+@ stub -version=0x600+ _cprintf_p
+@ stub -version=0x600+ _cprintf_p_l
+@ stub -version=0x600+ _cprintf_s
+@ stub -version=0x600+ _cprintf_s_l
 @ cdecl _cputs(str)
 @ cdecl -stub _cputws(wstr)
 @ cdecl _creat(str long)
+@ stub -version=0x600+ _crtAssertBusy
+@ stub -version=0x600+ _crtBreakAlloc
+@ stub -version=0x600+ _crtDbgFlag
 @ varargs _cscanf(str)
+@ stub -version=0x600+ _cscanf_l
+@ stub -version=0x600+ _cscanf_s
+@ stub -version=0x600+ _cscanf_s_l
+@ stub -version=0x600+ _ctime32
+@ stub -version=0x600+ _ctime32_s
 @ cdecl _ctime64(ptr)
+@ cdecl -version=0x600+ _ctime64_s(ptr long ptr)
 @ extern _ctype
 @ cdecl _cwait(ptr long long)
 @ varargs _cwprintf(wstr)
+@ stub -version=0x600+ _cwprintf_l
+@ stub -version=0x600+ _cwprintf_p
+@ stub -version=0x600+ _cwprintf_p_l
+@ stub -version=0x600+ _cwprintf_s
+@ stub -version=0x600+ _cwprintf_s_l
 @ varargs -stub _cwscanf(wstr)
+@ stub -version=0x600+ _cwscanf_l
+@ stub -version=0x600+ _cwscanf_s
+@ stub -version=0x600+ _cwscanf_s_l
 @ extern _daylight
+@ stub -version=0x600+ _difftime32
+@ stub -version=0x600+ _difftime64
 @ extern _dstbias
 @ cdecl _dup(long)
 @ cdecl _dup2(long long)
 @ cdecl _ecvt(double long ptr ptr)
+@ stub -version=0x600+ _ecvt_s
 @ cdecl _endthread()
 @ cdecl _endthreadex(long)
 @ extern _environ
@@ -384,8 +483,10 @@
 @ cdecl _execvpe(str ptr ptr)
 @ cdecl _exit(long)
 @ cdecl _expand(ptr long)
+@ stub -version=0x600+ _expand_dbg
 @ cdecl _fcloseall()
 @ cdecl _fcvt(double long ptr ptr)
+@ stub -version=0x600+ _fcvt_s
 @ cdecl _fdopen(long str)
 @ cdecl _fgetchar()
 @ cdecl _fgetwchar()
@@ -410,22 +511,61 @@
 @ cdecl -stub -arch=x86_64 _fpclassf(long)
 @ cdecl -arch=i386 _fpieee_flt(long ptr ptr)
 @ cdecl _fpreset()
+@ stub -version=0x600+ _fprintf_l
+@ stub -version=0x600+ _fprintf_p
+@ stub -version=0x600+ _fprintf_p_l
+@ stub -version=0x600+ _fprintf_s_l
 @ cdecl _fputchar(long)
 @ cdecl _fputwchar(long)
+@ stub -version=0x600+ _free_dbg
+@ stub -version=0x600+ _freea
+@ stub -version=0x600+ _freea_s
+@ stub -version=0x600+ _fscanf_l
+@ stub -version=0x600+ _fscanf_s_l
+@ cdecl -version=0x600+ _fseeki64(ptr int64 long)
 @ cdecl _fsopen(str str long)
 @ cdecl _fstat(long ptr)
 @ cdecl _fstat64(long ptr)
 @ cdecl _fstati64(long ptr)
 @ cdecl _ftime(ptr)
+@ stub -version=0x600+ _ftime32
+@ stub -version=0x600+ _ftime32_s
 @ cdecl _ftime64(ptr)
+@ cdecl -version=0x600+ _ftime64_s(ptr)
 @ cdecl -arch=i386 -ret64 _ftol()
+@ cdecl -version=0x600+ -arch=i386 _ftol2(long)
+@ cdecl -version=0x600+ -arch=i386 _ftol2_sse(long)
+@ stub -version=0x600+ -arch=i386 _ftol2_sse_excpt
 @ cdecl _fullpath(ptr str long)
+@ stub -version=0x600+ _fullpath_dbg
 @ cdecl _futime(long ptr)
+@ stub -version=0x600+ _futime32
 @ cdecl _futime64(long ptr)
+@ stub -version=0x600+ _fwprintf_l
+@ stub -version=0x600+ _fwprintf_p
+@ stub -version=0x600+ _fwprintf_p_l
+@ stub -version=0x600+ _fwprintf_s_l
+@ stub -version=0x600+ _fwscanf_l
+@ stub -version=0x600+ _fwscanf_s_l
 @ cdecl _gcvt(double long str)
+@ stub -version=0x600+ _gcvt_s
+@ cdecl -version=0x600+ _get_doserrno(ptr)
+@ stub -version=0x600+ _get_environ
+@ cdecl -version=0x600+ _get_errno(ptr)
+@ stub -version=0x600+ _get_fileinfo
+@ stub -version=0x600+ _get_fmode
 # @ cdecl _get_heap_handle()
 @ cdecl _get_osfhandle(long)
+@ cdecl -version=0x600+ _get_osplatform(ptr)
+@ stub -version=0x600+ _get_osver
+@ cdecl -version=0x600+ _get_output_format()
+@ cdecl -version=0x600+ _get_pgmptr(ptr)
 @ cdecl _get_sbh_threshold()
+@ stub -version=0x600+ _get_wenviron
+@ stub -version=0x600+ _get_winmajor
+@ stub -version=0x600+ _get_winminor
+@ stub -version=0x600+ _get_winver
+@ cdecl -version=0x600+ _get_wpgmptr(ptr)
 @ cdecl _getch()
 @ cdecl _getche()
 @ cdecl _getcwd(str long)
@@ -444,7 +584,10 @@
 @ cdecl -stub _getwche()
 @ cdecl _getws(ptr)
 @ cdecl -arch=i386 _global_unwind2(ptr)
+@ cdecl -version=0x600+ _gmtime32(ptr)
+@ cdecl -version=0x600+ _gmtime32_s(ptr ptr)
 @ cdecl _gmtime64(ptr)
+@ cdecl -version=0x600+ _gmtime64_s(ptr ptr)
 @ cdecl _heapadd(ptr long)
 @ cdecl _heapchk()
 @ cdecl _heapmin()
@@ -455,58 +598,121 @@
 @ cdecl _hypot(double double)
 @ cdecl -arch=x86_64,arm _hypotf(long long)
 @ cdecl _i64toa(long long ptr long)
+@ cdecl -version=0x600+ _i64toa_s(int64 ptr long long)
 @ cdecl _i64tow(long long ptr long)
+@ cdecl -version=0x600+ _i64tow_s(int64 ptr long long)
 @ cdecl _initterm(ptr ptr)
+@ cdecl -version=0x600+ _initterm_e(ptr ptr)
 @ cdecl -arch=i386 _inp(long) MSVCRT__inp
 @ cdecl -arch=i386 _inpd(long) MSVCRT__inpd
 @ cdecl -arch=i386 _inpw(long) MSVCRT__inpw
+@ cdecl -version=0x600+ _invalid_parameter(wstr wstr wstr long long)
 @ extern _iob
+@ cdecl -version=0x600+ _isalnum_l(long ptr)
+@ cdecl -version=0x600+ _isalpha_l(long ptr)
 @ cdecl _isatty(long)
+@ cdecl -version=0x600+ _iscntrl_l(long ptr)
 @ cdecl _isctype(long long)
+@ cdecl -version=0x600+ _isctype_l(long long ptr)
+@ cdecl -version=0x600+ _isdigit_l(long ptr)
+@ cdecl -version=0x600+ _isgraph_l(long ptr)
+@ cdecl -version=0x600+ _isleadbyte_l(long ptr)
+@ cdecl -version=0x600+ _islower_l(long ptr)
 @ cdecl _ismbbalnum(long)
+@ stub -version=0x600+ _ismbbalnum_l
 @ cdecl _ismbbalpha(long)
+@ stub -version=0x600+ _ismbbalpha_l
 @ cdecl _ismbbgraph(long)
+@ stub -version=0x600+ _ismbbgraph_l
 @ cdecl _ismbbkalnum(long)
+@ stub -version=0x600+ _ismbbkalnum_l
 @ cdecl _ismbbkana(long)
+@ stub -version=0x600+ _ismbbkana_l
 @ cdecl _ismbbkprint(long)
+@ stub -version=0x600+ _ismbbkprint_l
 @ cdecl _ismbbkpunct(long)
+@ stub -version=0x600+ _ismbbkpunct_l
 @ cdecl _ismbblead(long)
+@ stub -version=0x600+ _ismbblead_l
 @ cdecl _ismbbprint(long)
+@ stub -version=0x600+ _ismbbprint_l
 @ cdecl _ismbbpunct(long)
+@ stub -version=0x600+ _ismbbpunct_l
 @ cdecl _ismbbtrail(long)
+@ stub -version=0x600+ _ismbbtrail_l
 @ cdecl _ismbcalnum(long)
+@ stub -version=0x600+ _ismbcalnum_l
 @ cdecl _ismbcalpha(long)
+@ stub -version=0x600+ _ismbcalpha_l
 @ cdecl _ismbcdigit(long)
+@ stub -version=0x600+ _ismbcdigit_l
 @ cdecl _ismbcgraph(long)
+@ stub -version=0x600+ _ismbcgraph_l
 @ cdecl _ismbchira(long)
+@ stub -version=0x600+ _ismbchira_l
 @ cdecl _ismbckata(long)
+@ stub -version=0x600+ _ismbckata_l
 @ cdecl _ismbcl0(long)
+@ stub -version=0x600+ _ismbcl0_l
 @ cdecl _ismbcl1(long)
+@ stub -version=0x600+ _ismbcl1_l
 @ cdecl _ismbcl2(long)
+@ stub -version=0x600+ _ismbcl2_l
 @ cdecl _ismbclegal(long)
+@ stub -version=0x600+ _ismbclegal_l
 @ cdecl _ismbclower(long)
+@ stub -version=0x600+ _ismbclower_l
 @ cdecl _ismbcprint(long)
+@ stub -version=0x600+ _ismbcprint_l
 @ cdecl _ismbcpunct(long)
+@ stub -version=0x600+ _ismbcpunct_l
 @ cdecl _ismbcspace(long)
+@ stub -version=0x600+ _ismbcspace_l
 @ cdecl _ismbcsymbol(long)
+@ stub -version=0x600+ _ismbcsymbol_l
 @ cdecl _ismbcupper(long)
+@ stub -version=0x600+ _ismbcupper_l
 @ cdecl _ismbslead(ptr ptr)
+@ stub -version=0x600+ _ismbslead_l
 @ cdecl _ismbstrail(ptr ptr)
+@ stub -version=0x600+ _ismbstrail_l
 @ cdecl _isnan(double)
 @ stub -arch=x86_64 _isnanf
+@ cdecl -version=0x600+ _isprint_l(long ptr)
+@ cdecl -version=0x600+ _isspace_l(long ptr)
+@ cdecl -version=0x600+ _isupper_l(long ptr)
+@ cdecl -version=0x600+ _iswalnum_l(long ptr)
+@ cdecl -version=0x600+ _iswalpha_l(long ptr)
+@ cdecl -version=0x600+ _iswcntrl_l(long ptr)
+@ cdecl -version=0x600+ _iswctype_l(long ptr)
+@ cdecl -version=0x600+ _iswdigit_l(long ptr)
+@ cdecl -version=0x600+ _iswgraph_l(long ptr)
+@ cdecl -version=0x600+ _iswlower_l(long ptr)
+@ cdecl -version=0x600+ _iswprint_l(long ptr)
+@ cdecl -version=0x600+ _iswpunct_l(long ptr)
+@ cdecl -version=0x600+ _iswspace_l(long ptr)
+@ cdecl -version=0x600+ _iswupper_l(long ptr)
+@ cdecl -version=0x600+ _iswxdigit_l(long ptr)
+@ cdecl -version=0x600+ _isxdigit_l(long ptr)
 @ cdecl _itoa(long ptr long)
+@ cdecl -version=0x600+ _itoa_s(long str long long)
 @ cdecl _itow(long ptr long)
+@ cdecl -version=0x600+ _itow_s() # FIXME
 @ cdecl _j0(double)
 @ cdecl _j1(double)
 @ cdecl _jn(long double)
 @ cdecl _kbhit()
 @ cdecl _lfind(ptr ptr ptr long ptr)
+@ stub -version=0x600+ _lfind_s
 @ cdecl -arch=i386 _loaddll(str)
 @ cdecl -arch=x86_64 -version=0x502 _loaddll(str)
 @ cdecl -arch=x86_64 _local_unwind(ptr ptr)
 @ cdecl -arch=i386 _local_unwind2(ptr long)
 @ cdecl -arch=i386 -version=0x600+ _local_unwind4(ptr ptr long)
+@ stub -version=0x600+ _localtime32
+@ stub -version=0x600+ _localtime32_s
 @ cdecl _localtime64(ptr)
+@ cdecl -version=0x600+ _localtime64_s(ptr ptr)
 @ cdecl _lock(long)
 @ cdecl _locking(long long long)
 @ cdecl _logb(double)
@@ -514,74 +720,167 @@
 @ cdecl _lrotl(long long)
 @ cdecl _lrotr(long long)
 @ cdecl _lsearch(ptr ptr long long ptr)
+@ stub -version=0x600+ _lsearch_s
 @ cdecl _lseek(long long long)
 @ cdecl -ret64 _lseeki64(long double long)
 @ cdecl _ltoa(long ptr long)
+@ cdecl -version=0x600+ _ltoa_s(long str long long)
 @ cdecl _ltow(long ptr long)
+@ cdecl -version=0x600+ _ltow_s(long ptr long long)
 @ cdecl _makepath(ptr str str str str)
+@ stub -version=0x600+ _makepath_s
+@ stub -version=0x600+ _malloc_dbg
 @ cdecl _mbbtombc(long)
+@ stub -version=0x600+ _mbbtombc_l
 @ cdecl _mbbtype(long long)
 @ extern _mbcasemap
 @ cdecl _mbccpy (str str)
+@ stub -version=0x600+ _mbccpy_l
+@ stub -version=0x600+ _mbccpy_s
+@ stub -version=0x600+ _mbccpy_s_l
 @ cdecl _mbcjistojms(long)
+@ stub -version=0x600+ _mbcjistojms_l
 @ cdecl _mbcjmstojis(long)
+@ stub -version=0x600+ _mbcjmstojis_l
 @ cdecl _mbclen(ptr)
+@ stub -version=0x600+ _mbclen_l
 @ cdecl _mbctohira(long)
+@ stub -version=0x600+ _mbctohira_l
 @ cdecl _mbctokata(long)
+@ stub -version=0x600+ _mbctokata_l
 @ cdecl _mbctolower(long)
+@ stub -version=0x600+ _mbctolower_l
 @ cdecl _mbctombb(long)
+@ stub -version=0x600+ _mbctombb_l
 @ cdecl _mbctoupper(long)
+@ stub -version=0x600+ _mbctoupper_l
 @ extern _mbctype
+@ stub -version=0x600+ _mblen_l
 @ cdecl _mbsbtype(str long)
+@ stub -version=0x600+ _mbsbtype_l
 @ cdecl _mbscat(str str)
+@ stub -version=0x600+ _mbscat_s
+@ stub -version=0x600+ _mbscat_s_l
 @ cdecl _mbschr(str long)
+@ stub -version=0x600+ _mbschr_l
 @ cdecl _mbscmp(str str)
+@ stub -version=0x600+ _mbscmp_l
 @ cdecl _mbscoll(str str)
+@ stub -version=0x600+ _mbscoll_l
 @ cdecl _mbscpy(ptr str)
+@ stub -version=0x600+ _mbscpy_s
+@ stub -version=0x600+ _mbscpy_s_l
 @ cdecl _mbscspn(str str)
+@ stub -version=0x600+ _mbscspn_l
 @ cdecl _mbsdec(ptr ptr)
+@ stub -version=0x600+ _mbsdec_l
 @ cdecl _mbsdup(str)
 @ cdecl _mbsicmp(str str)
+@ stub -version=0x600+ _mbsicmp_l
 @ cdecl _mbsicoll(str str)
+@ stub -version=0x600+ _mbsicoll_l
 @ cdecl _mbsinc(str)
+@ stub -version=0x600+ _mbsinc_l
 @ cdecl _mbslen(str)
+@ stub -version=0x600+ _mbslen_l
 @ cdecl _mbslwr(str)
+@ stub -version=0x600+ _mbslwr_l
+@ stub -version=0x600+ _mbslwr_s
+@ stub -version=0x600+ _mbslwr_s_l
 @ cdecl _mbsnbcat(str str long)
+@ stub -version=0x600+ _mbsnbcat_l
+@ stub -version=0x600+ _mbsnbcat_s
+@ stub -version=0x600+ _mbsnbcat_s_l
 @ cdecl _mbsnbcmp(str str long)
+@ stub -version=0x600+ _mbsnbcmp_l
 @ cdecl _mbsnbcnt(ptr long)
+@ stub -version=0x600+ _mbsnbcnt_l
 @ cdecl _mbsnbcoll(str str long)
+@ stub -version=0x600+ _mbsnbcoll_l
 @ cdecl _mbsnbcpy(ptr str long)
+@ stub -version=0x600+ _mbsnbcpy_l
+@ cdecl -version=0x600+ _mbsnbcpy_s(ptr long str long)
+@ stub -version=0x600+ _mbsnbcpy_s_l
 @ cdecl _mbsnbicmp(str str long)
+@ stub -version=0x600+ _mbsnbicmp_l
 @ cdecl _mbsnbicoll(str str long)
+@ stub -version=0x600+ _mbsnbicoll_l
 @ cdecl _mbsnbset(str long long)
+@ stub -version=0x600+ _mbsnbset_l
+@ stub -version=0x600+ _mbsnbset_s
+@ stub -version=0x600+ _mbsnbset_s_l
 @ cdecl _mbsncat(str str long)
+@ stub -version=0x600+ _mbsncat_l
+@ stub -version=0x600+ _mbsncat_s
+@ stub -version=0x600+ _mbsncat_s_l
 @ cdecl _mbsnccnt(str long)
+@ stub -version=0x600+ _mbsnccnt_l
 @ cdecl _mbsncmp(str str long)
+@ stub -version=0x600+ _mbsncmp_l
 @ cdecl _mbsncoll(str str long)
+@ stub -version=0x600+ _mbsncoll_l
 @ cdecl _mbsncpy(str str long)
+@ stub -version=0x600+ _mbsncpy_l
+@ stub -version=0x600+ _mbsncpy_s
+@ stub -version=0x600+ _mbsncpy_s_l
 @ cdecl _mbsnextc(str)
+@ stub -version=0x600+ _mbsnextc_l
 @ cdecl _mbsnicmp(str str long)
+@ stub -version=0x600+ _mbsnicmp_l
 @ cdecl _mbsnicoll(str str long)
+@ stub -version=0x600+ _mbsnicoll_l
 @ cdecl _mbsninc(str long)
+@ stub -version=0x600+ _mbsninc_l
+@ stub -version=0x600+ _mbsnlen
+@ stub -version=0x600+ _mbsnlen_l
 @ cdecl _mbsnset(str long long)
+@ stub -version=0x600+ _mbsnset_l
+@ stub -version=0x600+ _mbsnset_s
+@ stub -version=0x600+ _mbsnset_s_l
 @ cdecl _mbspbrk(str str)
+@ stub -version=0x600+ _mbspbrk_l
 @ cdecl _mbsrchr(str long)
+@ stub -version=0x600+ _mbsrchr_l
 @ cdecl _mbsrev(str)
+@ stub -version=0x600+ _mbsrev_l
 @ cdecl _mbsset(str long)
+@ stub -version=0x600+ _mbsset_l
+@ stub -version=0x600+ _mbsset_s
+@ stub -version=0x600+ _mbsset_s_l
 @ cdecl _mbsspn(str str)
+@ stub -version=0x600+ _mbsspn_l
 @ cdecl _mbsspnp(str str)
+@ stub -version=0x600+ _mbsspnp_l
 @ cdecl _mbsstr(str str)
+@ stub -version=0x600+ _mbsstr_l
 @ cdecl _mbstok(str str)
+@ stub -version=0x600+ _mbstok_l
+@ stub -version=0x600+ _mbstok_s
+@ stub -version=0x600+ _mbstok_s_l
+@ cdecl -version=0x600+ _mbstowcs_l(ptr str long ptr)
+@ stub -version=0x600+ _mbstowcs_s_l
 @ cdecl _mbstrlen(str)
+@ stub -version=0x600+ _mbstrlen_l
+@ stub -version=0x600+ _mbstrnlen
+@ stub -version=0x600+ _mbstrnlen_l
 @ cdecl _mbsupr(str)
+@ stub -version=0x600+ _mbsupr_l
+@ stub -version=0x600+ _mbsupr_s
+@ stub -version=0x600+ _mbsupr_s_l
+@ cdecl -version=0x600+ _mbtowc_l(ptr wstr long long)
 @ cdecl _memccpy(ptr ptr long long)
 @ cdecl _memicmp(str str long)
+@ cdecl -version=0x600+ _memicmp_l(ptr ptr long ptr)
 @ cdecl _mkdir(str)
 @ cdecl _mkgmtime(ptr)
+@ cdecl -version=0x600+ _mkgmtime32(ptr)
 @ cdecl _mkgmtime64(ptr)
 @ cdecl _mktemp(str)
+@ stub -version=0x600+ _mktemp_s
+@ cdecl -version=0x600+ _mktime32(ptr)
 @ cdecl _mktime64(ptr)
 @ cdecl _msize(ptr)
+@ stub -version=0x600+ -arch=i386 _msize_debug
 @ cdecl _nextafter(double double)
 @ stub -arch=x86_64 _nextafterf
 @ cdecl _onexit(ptr)
@@ -597,14 +896,20 @@
 @ extern _pgmptr
 @ cdecl _pipe(ptr long long)
 @ cdecl _popen(str str)
+@ stub -version=0x600+ _printf_l
+@ stub -version=0x600+ _printf_p
+@ stub -version=0x600+ _printf_p_l
+@ stub -version=0x600+ _printf_s_l
 @ cdecl _purecall()
 @ cdecl _putch(long)
 @ cdecl _putenv(str)
+@ stub -version=0x600+ _putenv_s
 @ cdecl _putw(long ptr)
 @ cdecl _putwch(long)
 @ cdecl _putws(wstr)
 @ extern _pwctype
 @ cdecl _read(long ptr long)
+@ stub -version=0x600+ _realloc_dbg
 @ cdecl _resetstkoflw()
 @ cdecl _rmdir(str)
 @ cdecl _rmtmp()
@@ -618,12 +923,26 @@
 @ cdecl -arch=i386 _safe_fprem1()
 @ cdecl _scalb(double long)
 @ stub -arch=x86_64 _scalbf
+@ stub -version=0x600+ _scanf_l
+@ stub -version=0x600+ _scanf_s_l
 @ varargs _scprintf(str)
+@ stub -version=0x600+ _scprintf_l
+@ stub -version=0x600+ _scprintf_p_l
 @ varargs _scwprintf(wstr)
+@ stub -version=0x600+ _scwprintf_l
+@ stub -version=0x600+ _scwprintf_p_l
 @ cdecl _searchenv(str str ptr)
+@ cdecl -version=0x600+ _searchenv_s(str str ptr long)
+@ stub -version=0x600+ -arch=i386 _seh_longjmp_unwind4
 @ stdcall -arch=i386 _seh_longjmp_unwind(ptr)
 @ stub -arch=i386 _set_SSE2_enable
+@ stub -version=0x600+ _set_controlfp
+@ cdecl -version=0x600+ _set_doserrno(long)
+@ cdecl -version=0x600+ _set_errno(long)
 @ cdecl _set_error_mode(long)
+@ stub -version=0x600+ _set_fileinfo
+@ stub -version=0x600+ _set_fmode
+@ stub -version=0x600+ _set_output_format
 @ cdecl _set_sbh_threshold(long)
 @ cdecl _seterrormode(long)
 @ cdecl -norelay _setjmp(ptr)
@@ -635,10 +954,25 @@
 @ cdecl _setsystime(ptr long)
 @ cdecl _sleep(long)
 @ varargs _snprintf(ptr long str)
+@ stub -version=0x600+ _snprintf_c
+@ stub -version=0x600+ _snprintf_c_l
+@ stub -version=0x600+ _snprintf_l
+@ stub -version=0x600+ _snprintf_s
+@ stub -version=0x600+ _snprintf_s_l
 @ varargs _snscanf(str long str)
+@ stub -version=0x600+ _snscanf_l
+@ stub -version=0x600+ _snscanf_s
+@ stub -version=0x600+ _snscanf_s_l
 @ varargs _snwprintf(ptr long wstr)
+@ stub -version=0x600+ _snwprintf_l
+@ stub -version=0x600+ _snwprintf_s
+@ stub -version=0x600+ _snwprintf_s_l
 @ varargs _snwscanf(wstr long wstr)
+@ stub -version=0x600+ _snwscanf_l
+@ stub -version=0x600+ _snwscanf_s
+@ stub -version=0x600+ _snwscanf_s_l
 @ varargs _sopen(str long long)
+@ cdecl -version=0x600+ _sopen_s(ptr str long long long)
 @ varargs _spawnl(long str str)
 @ varargs _spawnle(long str str)
 @ varargs _spawnlp(long str str)
@@ -648,44 +982,92 @@
 @ cdecl _spawnvp(long str ptr)
 @ cdecl _spawnvpe(long str ptr ptr)
 @ cdecl _splitpath(str ptr ptr ptr ptr)
+@ stub -version=0x600+ _splitpath_s
+@ stub -version=0x600+ _sprintf_l
+@ stub -version=0x600+ _sprintf_p_l
+@ stub -version=0x600+ _sprintf_s_l
+@ stub -version=0x600+ _sscanf_l
+@ stub -version=0x600+ _sscanf_s_l
 @ cdecl _stat(str ptr)
 @ cdecl _stat64(str ptr)
 @ cdecl _stati64(str ptr)
 @ cdecl _statusfp()
 @ cdecl _strcmpi(str str)
+@ cdecl -version=0x600+ _strcoll_l(str str ptr)
 @ cdecl _strdate(ptr)
+@ cdecl -version=0x600+ _strdate_s(ptr long)
 @ cdecl _strdup(str)
+@ stub -version=0x600+ _strdup_dbg
 @ cdecl _strerror(long)
+@ cdecl -version=0x600+ _strerror_s(ptr long str)
 @ cdecl _stricmp(str str)
+@ cdecl -version=0x600+ _stricmp_l(str str ptr)
 @ cdecl _stricoll(str str)
+@ cdecl -version=0x600+ _stricoll_l(str str ptr)
 @ cdecl _strlwr(str)
+@ stub -version=0x600+ _strlwr_l
+@ cdecl -version=0x600+ _strlwr_s(str long)
+@ cdecl -version=0x600+ _strlwr_s_l(str long ptr)
 @ cdecl _strncoll(str str long)
+@ cdecl -version=0x600+ _strncoll_l(str str long ptr)
 @ cdecl _strnicmp(str str long)
+@ cdecl -version=0x600+ _strnicmp_l(str str long ptr)
 @ cdecl _strnicoll(str str long)
+@ cdecl -version=0x600+ _strnicoll_l(str str long ptr)
 @ cdecl _strnset(str long long)
+@ cdecl -version=0x600+ _strnset_s(str long long long)
 @ cdecl _strrev(str)
 @ cdecl _strset(str long)
+@ cdecl -version=0x600+ _strset_s(str long long)
 @ cdecl _strtime(ptr)
+@ cdecl -version=0x600+ _strtime_s(ptr long)
+@ stub -version=0x600+ _strtod_l
 @ cdecl _strtoi64(str ptr long)
+@ cdecl -version=0x600+ _strtoi64_l(str ptr long ptr)
+@ stub -version=0x600+ _strtol_l
 @ cdecl _strtoui64(str ptr long) strtoull
+@ stub -version=0x600+ _strtoui64_l
+@ cdecl -version=0x600+ _strtoul_l(str ptr long ptr)
 @ cdecl _strupr(str)
+@ cdecl -version=0x600+ _strupr_l(str ptr)
+@ cdecl -version=0x600+ _strupr_s(str long)
+@ cdecl -version=0x600+ _strupr_s_l(str long ptr)
+@ cdecl -version=0x600+ _strxfrm_l(ptr str long ptr)
 @ cdecl _swab(str str long)
+@ stub -version=0x600+ _swprintf
+@ stub -version=0x600+ _swprintf_c
+@ stub -version=0x600+ _swprintf_c_l
+@ stub -version=0x600+ _swprintf_p_l
+@ stub -version=0x600+ _swprintf_s_l
+@ stub -version=0x600+ _swscanf_l
+@ stub -version=0x600+ _swscanf_s_l
 @ extern _sys_errlist
 @ extern _sys_nerr
 @ cdecl _tell(long)
 @ cdecl -ret64 _telli64(long)
 @ cdecl _tempnam(str str)
+@ stub -version=0x600+ _tempnam_dbg
+@ stub -version=0x600+ _time32
 @ cdecl _time64(ptr)
 @ extern _timezone
 @ cdecl _tolower(long)
+@ cdecl -version=0x600+ _tolower_l(long ptr)
 @ cdecl _toupper(long)
+@ cdecl -version=0x600+ _toupper_l(long ptr)
+@ cdecl -version=0x600+ _towlower_l(long ptr)
+@ cdecl -version=0x600+ _towupper_l(long ptr)
 @ extern _tzname
 @ cdecl _tzset()
 @ cdecl _ui64toa(long long ptr long)
+@ cdecl -version=0x600+ _ui64toa_s(int64 ptr long long)
 @ cdecl _ui64tow(long long ptr long)
+@ cdecl -version=0x600+ _ui64tow_s(int64 ptr long long)
 @ cdecl _ultoa(long ptr long)
+@ stub -version=0x600+ _ultoa_s
 @ cdecl _ultow(long ptr long)
+@ stub -version=0x600+ _ultow_s
 @ cdecl _umask(long)
+@ stub -version=0x600+ _umask_s
 @ cdecl _ungetch(long)
 # stub _ungetwch
 @ cdecl _unlink(str)
@@ -693,33 +1075,116 @@
 @ cdecl -arch=x86_64 -version=0x502 _unloaddll(ptr)
 @ cdecl _unlock(long)
 @ cdecl _utime(str ptr)
+@ stub -version=0x600+ _utime32
 @ cdecl _utime64(str ptr)
+@ stub -version=0x600+ _vcprintf
+@ stub -version=0x600+ _vcprintf_l
+@ stub -version=0x600+ _vcprintf_p
+@ stub -version=0x600+ _vcprintf_p_l
+@ stub -version=0x600+ _vcprintf_s
+@ stub -version=0x600+ _vcprintf_s_l
+@ stub -version=0x600+ _vcwprintf
+@ stub -version=0x600+ _vcwprintf_l
+@ stub -version=0x600+ _vcwprintf_p
+@ stub -version=0x600+ _vcwprintf_p_l
+@ stub -version=0x600+ _vcwprintf_s
+@ stub -version=0x600+ _vcwprintf_s_l
+@ stub -version=0x600+ _vfprintf_l
+@ stub -version=0x600+ _vfprintf_p
+@ stub -version=0x600+ _vfprintf_p_l
+@ stub -version=0x600+ _vfprintf_s_l
+@ stub -version=0x600+ _vfwprintf_l
+@ stub -version=0x600+ _vfwprintf_p
+@ stub -version=0x600+ _vfwprintf_p_l
+@ stub -version=0x600+ _vfwprintf_s_l
+@ stub -version=0x600+ _vprintf_l
+@ stub -version=0x600+ _vprintf_p
+@ stub -version=0x600+ _vprintf_p_l
+@ stub -version=0x600+ _vprintf_s_l
 @ cdecl _vscprintf(str ptr)
+@ stub -version=0x600+ _vscprintf_l
+@ stub -version=0x600+ _vscprintf_p_l
 @ cdecl _vscwprintf(wstr ptr)
+@ stub -version=0x600+ _vscwprintf_l
+@ stub -version=0x600+ _vscwprintf_p_l
 @ cdecl _vsnprintf(ptr long str ptr)
+@ stub -version=0x600+ _vsnprintf_c
+@ stub -version=0x600+ _vsnprintf_c_l
+@ stub -version=0x600+ _vsnprintf_l
+@ stub -version=0x600+ _vsnprintf_s
+@ stub -version=0x600+ _vsnprintf_s_l
 @ cdecl _vsnwprintf(ptr long wstr ptr)
+@ stub -version=0x600+ _vsnwprintf_l
+@ stub -version=0x600+ _vsnwprintf_s
+@ stub -version=0x600+ _vsnwprintf_s_l
+@ stub -version=0x600+ _vsprintf_l
+@ stub -version=0x600+ _vsprintf_p
+@ stub -version=0x600+ _vsprintf_p_l
+@ stub -version=0x600+ _vsprintf_s_l
+@ stub -version=0x600+ _vswprintf
+@ stub -version=0x600+ _vswprintf_c
+@ stub -version=0x600+ _vswprintf_c_l
+@ stub -version=0x600+ _vswprintf_l
+@ stub -version=0x600+ _vswprintf_p_l
+@ stub -version=0x600+ _vswprintf_s_l
+@ stub -version=0x600+ _vwprintf_l
+@ stub -version=0x600+ _vwprintf_p
+@ stub -version=0x600+ _vwprintf_p_l
+@ stub -version=0x600+ _vwprintf_s_l
 @ cdecl _waccess(wstr long)
+@ cdecl -version=0x600+ _waccess_s(wstr long)
 @ cdecl _wasctime(ptr)
+@ cdecl -version=0x600+ _wasctime_s(ptr long ptr)
+@ stub -version=0x600+ _wassert
 @ cdecl _wchdir(wstr)
 @ cdecl _wchmod(wstr long)
 @ extern _wcmdln
 @ cdecl _wcreat(wstr long)
+@ cdecl -version=0x600+ _wcscoll_l(str str ptr)
 @ cdecl _wcsdup(wstr)
+@ stub -version=0x600+ _wcsdup_dbg
 @ cdecl _wcserror(long)
+@ cdecl -version=0x600+ _wcserror_s(ptr long long)
+@ stub -version=0x600+ _wcsftime_l
 @ cdecl _wcsicmp(wstr wstr)
+@ cdecl -version=0x600+ _wcsicmp_l(wstr wstr ptr)
 @ cdecl _wcsicoll(wstr wstr)
+@ cdecl -version=0x600+ _wcsicoll_l(wstr wstr ptr)
 @ cdecl _wcslwr(wstr)
+@ cdecl -version=0x600+ _wcslwr_l(wstr ptr)
+@ cdecl -version=0x600+ _wcslwr_s(wstr long)
+@ cdecl -version=0x600+ _wcslwr_s_l(wstr long ptr)
 @ cdecl _wcsncoll(wstr wstr long)
+@ cdecl -version=0x600+ _wcsncoll_l(wstr wstr long ptr)
 @ cdecl _wcsnicmp(wstr wstr long)
+@ cdecl -version=0x600+ _wcsnicmp_l(wstr wstr long ptr)
 @ cdecl _wcsnicoll(wstr wstr long)
+@ cdecl -version=0x600+ _wcsnicoll_l(wstr str long ptr)
 @ cdecl _wcsnset(wstr long long)
+@ cdecl -version=0x600+ _wcsnset_s(wstr long long long)
 @ cdecl _wcsrev(wstr)
 @ cdecl _wcsset(wstr long)
+@ cdecl -version=0x600+ _wcsset_s(ptr long long)
 @ cdecl _wcstoi64(wstr ptr long)
+@ cdecl -version=0x600+ _wcstoi64_l(wstr ptr long ptr)
+@ stub -version=0x600+ _wcstol_l
+@ cdecl -version=0x600+ _wcstombs_l(ptr wstr long ptr)
+@ stub -version=0x600+ _wcstombs_s_l
 @ cdecl _wcstoui64(wstr ptr long)
+@ cdecl -version=0x600+ _wcstoui64_l(wstr ptr long ptr)
+@ stub -version=0x600+ _wcstoul_l
 @ cdecl _wcsupr(wstr)
+@ cdecl -version=0x600+ _wcsupr_l(wstr ptr)
+@ cdecl -version=0x600+ _wcsupr_s(wstr long)
+@ cdecl -version=0x600+ _wcsupr_s_l(ptr long ptr)
+@ cdecl -version=0x600+ _wcsxfrm_l(ptr wstr long ptr)
 @ cdecl _wctime(ptr)
+@ stub -version=0x600+ _wctime32
+@ stub -version=0x600+ _wctime32_s
 @ cdecl _wctime64(ptr)
+@ cdecl -version=0x600+ _wctime64_s(ptr long ptr)
+@ stub -version=0x600+ _wctomb_l
+@ stub -version=0x600+ _wctomb_s_l
 # stub _wctype
 @ extern _wenviron
 @ varargs _wexecl(wstr wstr)
@@ -738,30 +1203,47 @@
 # stub _wfindnext64
 @ cdecl _wfindnexti64(long ptr)
 @ cdecl _wfopen(wstr wstr)
+@ cdecl -version=0x600+ _wfopen_s(ptr wstr wstr)
 @ cdecl _wfreopen(wstr wstr ptr)
+@ stub -version=0x600+ _wfreopen_s
 @ cdecl _wfsopen(wstr wstr long)
 @ cdecl _wfullpath(ptr wstr long)
+@ stub -version=0x600+ _wfullpath_dbg
 @ cdecl _wgetcwd(wstr long)
 @ cdecl _wgetdcwd(long wstr long)
 @ cdecl _wgetenv(wstr)
+@ stub -version=0x600+ _wgetenv_s
 @ extern _winmajor
 @ extern _winminor
+@ stub -version=0x600+ _winput_s
 @ extern _winver
 @ cdecl _wmakepath(ptr wstr wstr wstr wstr)
+@ stub -version=0x600+ _wmakepath_s
 @ cdecl _wmkdir(wstr)
 @ cdecl _wmktemp(wstr)
+@ stub -version=0x600+ _wmktemp_s
 @ varargs _wopen(wstr long)
+@ stub -version=0x600+ _woutput_s
 @ cdecl _wperror(wstr)
 @ extern _wpgmptr
 @ cdecl _wpopen(wstr wstr)
+@ stub -version=0x600+ _wprintf_l
+@ stub -version=0x600+ _wprintf_p
+@ stub -version=0x600+ _wprintf_p_l
+@ stub -version=0x600+ _wprintf_s_l
 @ cdecl _wputenv(wstr)
+@ stub -version=0x600+ _wputenv_s
 @ cdecl _wremove(wstr)
 @ cdecl _wrename(wstr wstr)
 @ cdecl _write(long ptr long)
 @ cdecl _wrmdir(wstr)
+@ stub -version=0x600+ _wscanf_l
+@ stub -version=0x600+ _wscanf_s_l
 @ cdecl _wsearchenv(wstr wstr ptr)
+@ cdecl -version=0x600+ _wsearchenv_s(wstr wstr ptr long)
 @ cdecl _wsetlocale(long wstr)
 @ varargs _wsopen(wstr long long)
+@ cdecl -version=0x600+ _wsopen_s(ptr wstr long long long)
 @ varargs _wspawnl(long wstr wstr)
 @ varargs _wspawnle(long wstr wstr)
 @ varargs _wspawnlp(long wstr wstr)
@@ -771,20 +1253,30 @@
 @ cdecl _wspawnvp(long wstr ptr)
 @ cdecl _wspawnvpe(long wstr ptr ptr)
 @ cdecl _wsplitpath(wstr ptr ptr ptr ptr)
+@ stub -version=0x600+ _wsplitpath_s
 @ cdecl _wstat(wstr ptr)
 @ cdecl _wstat64(wstr ptr)
 @ cdecl _wstati64(wstr ptr)
 @ cdecl _wstrdate(ptr)
+@ cdecl -version=0x600+ _wstrdate_s(ptr long)
 @ cdecl _wstrtime(ptr)
+@ stub -version=0x600+ _wstrtime_s
 @ cdecl _wsystem(wstr)
 @ cdecl _wtempnam(wstr wstr)
+@ stub -version=0x600+ _wtempnam_dbg
 @ cdecl _wtmpnam(ptr)
+@ stub -version=0x600+ _wtmpnam_s
 @ cdecl _wtof(wstr)
+@ stub -version=0x600+ _wtof_l
 @ cdecl _wtoi(wstr)
 @ cdecl _wtoi64(wstr)
+@ cdecl -version=0x600+ _wtoi64_l(wstr ptr)
+@ stub -version=0x600+ _wtoi_l
 @ cdecl _wtol(wstr)
+@ stub -version=0x600+ _wtol_l
 @ cdecl _wunlink(wstr)
 @ cdecl _wutime(wstr ptr)
+@ stub -version=0x600+ _wutime32
 @ cdecl _wutime64(wstr ptr)
 @ cdecl _y0(double)
 @ cdecl _y1(double)
@@ -794,6 +1286,7 @@
 @ cdecl acos(double)
 @ cdecl -arch=x86_64,arm acosf(long)
 @ cdecl asctime(ptr)
+@ cdecl -version=0x600+ asctime_s(ptr long ptr)
 @ cdecl asin(double)
 @ cdecl -arch=x86_64,arm asinf(long)
 @ cdecl atan(double)
@@ -805,10 +1298,13 @@
 @ cdecl atoi(str)
 @ cdecl atol(str)
 @ cdecl bsearch(ptr ptr long long ptr)
+@ stub -version=0x600+ bsearch_s
+@ stub -version=0x600+ btowc
 @ cdecl calloc(long long)
 @ cdecl ceil(double)
 @ cdecl -arch=x86_64,arm ceilf(long)
 @ cdecl clearerr(ptr)
+@ stub -version=0x600+ clearerr_s
 @ cdecl clock()
 @ cdecl cos(double)
 @ cdecl -arch=x86_64,arm cosf(long)
@@ -836,7 +1332,9 @@
 @ cdecl fmod(double double)
 @ cdecl -arch=x86_64,arm fmodf(long)
 @ cdecl fopen(str str)
+@ cdecl -version=0x600+ fopen_s(ptr str str)
 @ varargs fprintf(ptr str)
+@ stub -version=0x600+ fprintf_s
 @ cdecl fputc(long ptr)
 @ cdecl fputs(str ptr)
 @ cdecl fputwc(long ptr)
@@ -844,17 +1342,22 @@
 @ cdecl fread(ptr long long ptr)
 @ cdecl free(ptr)
 @ cdecl freopen(str str ptr)
+@ stub -version=0x600+ freopen_s
 @ cdecl frexp(double ptr)
 @ varargs fscanf(ptr str)
+@ stub -version=0x600+ fscanf_s
 @ cdecl fseek(ptr long long)
 @ cdecl fsetpos(ptr ptr)
 @ cdecl ftell(ptr)
 @ varargs fwprintf(ptr wstr)
+@ stub -version=0x600+ fwprintf_s
 @ cdecl fwrite(ptr long long ptr)
 @ varargs fwscanf(ptr wstr)
+@ stub -version=0x600+ fwscanf_s
 @ cdecl getc(ptr)
 @ cdecl getchar()
 @ cdecl getenv(str)
+@ stub -version=0x600+ getenv_s
 @ cdecl gets(str)
 @ cdecl getwc(ptr)
 @ cdecl getwchar()
@@ -897,12 +1400,20 @@
 @ cdecl longjmp(ptr long)
 @ cdecl malloc(long)
 @ cdecl mblen(ptr long)
+@ cdecl -version=0x600+ mbrlen(str long ptr)
+@ stub -version=0x600+ mbrtowc
+@ stub -version=0x600+ mbsdup_dbg
+@ stub -version=0x600+ mbsrtowcs
+@ stub -version=0x600+ mbsrtowcs_s
 @ cdecl mbstowcs(ptr str long)
+@ stub -version=0x600+ mbstowcs_s
 @ cdecl mbtowc(wstr str long)
 @ cdecl memchr(ptr long long)
 @ cdecl memcmp(ptr ptr long)
 @ cdecl memcpy(ptr ptr long)
+@ stub -version=0x600+ memcpy_s
 @ cdecl memmove(ptr ptr long)
+@ cdecl -version=0x600+ memmove_s(ptr long ptr long)
 @ cdecl memset(ptr long long)
 @ cdecl mktime(ptr)
 @ cdecl modf(double ptr)
@@ -911,19 +1422,23 @@
 @ cdecl pow(double double)
 @ cdecl -arch=x86_64,arm powf(long)
 @ varargs printf(str)
+@ stub -version=0x600+ printf_s
 @ cdecl putc(long ptr)
 @ cdecl putchar(long)
 @ cdecl puts(str)
 @ cdecl putwc(long ptr) fputwc
 @ cdecl putwchar(long) _fputwchar
 @ cdecl qsort(ptr long long ptr)
+@ stub -version=0x600+ qsort_s
 @ cdecl raise(long)
 @ cdecl rand()
+@ cdecl -version=0x600+ rand_s(ptr)
 @ cdecl realloc(ptr long)
 @ cdecl remove(str)
 @ cdecl rename(str str)
 @ cdecl rewind(ptr)
 @ varargs scanf(str)
+@ stub -version=0x600+ scanf_s
 @ cdecl setbuf(ptr ptr)
 @ cdecl -arch=x86_64,arm -norelay setjmp(ptr ptr) _setjmp
 @ cdecl setlocale(long str)
@@ -934,33 +1449,44 @@
 @ cdecl sinh(double)
 @ cdecl -arch=x86_64,arm sinhf(long)
 @ varargs sprintf(ptr str)
+@ stub -version=0x600+ sprintf_s
 @ cdecl sqrt(double)
 @ cdecl -arch=x86_64,arm sqrtf(long)
 @ cdecl srand(long)
 @ varargs sscanf(str str)
+@ stub -version=0x600+ sscanf_s
 @ cdecl strcat(str str)
+@ cdecl -version=0x600+ strcat_s(ptr long str)
 @ cdecl strchr(str long)
 @ cdecl strcmp(str str)
 @ cdecl strcoll(str str)
 @ cdecl strcpy(ptr str)
+@ cdecl -version=0x600+ strcpy_s(ptr long str)
 @ cdecl strcspn(str str)
 @ cdecl strerror(long)
+@ cdecl -version=0x600+ strerror_s(ptr long long)
 @ cdecl strftime(str long str ptr)
 @ cdecl strlen(str)
 @ cdecl strncat(str str long)
+@ cdecl -version=0x600+ strncat_s(str long str long)
 @ cdecl strncmp(str str long)
 @ cdecl strncpy(ptr str long)
+@ cdecl -version=0x600+ strncpy_s(ptr long str long)
+@ cdecl -version=0x600+ strnlen(str long)
 @ cdecl strpbrk(str str)
 @ cdecl strrchr(str long)
 @ cdecl strspn(str str)
 @ cdecl strstr(str str)
 @ cdecl strtod(str ptr)
 @ cdecl strtok(str str)
+@ cdecl -version=0x600+ strtok_s(str str ptr)
 @ cdecl strtol(str ptr long)
 @ cdecl strtoul(str ptr long)
 @ cdecl strxfrm(ptr str long)
 @ varargs swprintf(ptr wstr)
+@ stub -version=0x600+ swprintf_s
 @ varargs swscanf(wstr wstr)
+@ stub -version=0x600+ swscanf_s
 @ cdecl system(str)
 @ cdecl tan(double)
 @ cdecl -arch=x86_64,arm tanf(long)
@@ -968,40 +1494,65 @@
 @ cdecl -arch=x86_64,arm tanhf(long)
 @ cdecl time(ptr)
 @ cdecl tmpfile()
+@ stub -version=0x600+ tmpfile_s
 @ cdecl tmpnam(ptr)
+@ stub -version=0x600+ tmpnam_s
 @ cdecl tolower(long)
 @ cdecl toupper(long)
 @ cdecl towlower(long)
 @ cdecl towupper(long)
 @ cdecl ungetc(long ptr)
 @ cdecl ungetwc(long ptr)
+@ stub -version=0x600+ utime
 @ cdecl vfprintf(ptr str ptr)
+@ stub -version=0x600+ vfprintf_s
 @ cdecl vfwprintf(ptr wstr ptr)
+@ stub -version=0x600+ vfwprintf_s
 @ cdecl vprintf(str ptr)
+@ stub -version=0x600+ vprintf_s
+@ cdecl -version=0x600+ vsnprintf(ptr long str ptr)
 @ cdecl vsprintf(ptr str ptr)
+@ stub -version=0x600+ vsprintf_s
 @ cdecl vswprintf(ptr wstr ptr)
+@ stub -version=0x600+ vswprintf_s
 @ cdecl vwprintf(wstr ptr)
+@ stub -version=0x600+ vwprintf_s
+@ stub -version=0x600+ wcrtomb
+@ stub -version=0x600+ wcrtomb_s
 @ cdecl wcscat(wstr wstr)
+@ cdecl -version=0x600+ wcscat_s(wstr long wstr)
 @ cdecl wcschr(wstr long)
 @ cdecl wcscmp(wstr wstr)
 @ cdecl wcscoll(wstr wstr)
 @ cdecl wcscpy(ptr wstr)
+@ cdecl -version=0x600+ wcscpy_s(wstr long wstr)
 @ cdecl wcscspn(wstr wstr)
 @ cdecl wcsftime(ptr long wstr ptr)
 @ cdecl wcslen(wstr)
 @ cdecl wcsncat(wstr wstr long)
+@ cdecl -version=0x600+ wcsncat_s(wstr long wstr long)
 @ cdecl wcsncmp(wstr wstr long)
 @ cdecl wcsncpy(ptr wstr long)
+@ cdecl -version=0x600+ wcsncpy_s(ptr long wstr long)
+@ cdecl -version=0x600+ wcsnlen(wstr long)
 @ cdecl wcspbrk(wstr wstr)
 @ cdecl wcsrchr(wstr long)
+@ stub -version=0x600+ wcsrtombs
+@ stub -version=0x600+ wcsrtombs_s
 @ cdecl wcsspn(wstr wstr)
 @ cdecl wcsstr(wstr wstr)
 @ cdecl wcstod(wstr ptr)
 @ cdecl wcstok(wstr wstr)
+@ cdecl -version=0x600+ wcstok_s(wstr wstr ptr)
 @ cdecl wcstol(wstr ptr long)
 @ cdecl wcstombs(ptr ptr long)
+@ stub -version=0x600+ wcstombs_s
 @ cdecl wcstoul(wstr ptr long)
 @ cdecl wcsxfrm(ptr wstr long)
+@ stub -version=0x600+ wctob
 @ cdecl wctomb(ptr long)
+@ stub -version=0x600+ wctomb_s
 @ varargs wprintf(wstr)
+@ stub -version=0x600+ wprintf_s
 @ varargs wscanf(wstr)
+@ stub -version=0x600+ wscanf_s

--- a/dll/win32/msvcrt/stubs.c
+++ b/dll/win32/msvcrt/stubs.c
@@ -88,3 +88,834 @@ unsigned long MSVCRT__outpd(
     return _outpd(port, dataword);
 }
 #endif
+
+typedef struct __crt_locale_data_public
+{
+      unsigned short const* _locale_pctype;
+    _Field_range_(1, 2) int _locale_mb_cur_max;
+               unsigned int _locale_lc_codepage;
+} __crt_locale_data_public;
+
+__inline
+__crt_locale_data_public*
+__CRTDECL
+__acrt_get_locale_data_prefix(
+    void const volatile* const _LocalePointers)
+{
+    _locale_t const _TypedLocalePointers = (_locale_t)_LocalePointers;
+    return (__crt_locale_data_public*)_TypedLocalePointers->locinfo;
+}
+
+__inline
+int
+__CRTDECL
+__acrt_locale_get_ctype_array_value(
+    _In_reads_(_Char_value + 1) unsigned short const * const locale_pctype_array,
+    _In_range_(-1, 255) int const c,
+    _In_ int const mask
+    )
+{
+    if (c >= -1 && c <= 255)
+    {
+        return locale_pctype_array[c] & mask;
+    }
+    return 0;
+}
+
+const unsigned short* __cdecl __pctype_func(void);
+
+#if defined _CRT_DISABLE_PERFCRIT_LOCKS && !defined _DLL
+    #define __PCTYPE_FUNC  _pctype
+#else
+    #define __PCTYPE_FUNC __pctype_func()
+#endif
+
+#ifdef _DEBUG
+    _ACRTIMP int __cdecl _chvalidator(_In_ int c, _In_ int mask);
+    #define __chvalidchk(a, b) _chvalidator(a, b)
+#else
+    #define __chvalidchk(a, b) (__acrt_locale_get_ctype_array_value(__PCTYPE_FUNC, (a), (b)))
+#endif
+
+__inline
+int
+__CRTDECL
+_chvalidchk_l(
+    _In_ int const c,
+    _In_ int const mask,
+    _In_opt_ _locale_t const locale
+    )
+{
+#ifdef _DEBUG
+    return _chvalidator_l(locale, c, mask);
+#else
+    if (locale)
+    {
+        return __acrt_locale_get_ctype_array_value(__acrt_get_locale_data_prefix(locale)->_locale_pctype, c, mask);
+    }
+
+    return __chvalidchk(c, mask);
+#endif
+}
+
+__inline
+int
+__CRTDECL
+_ischartype_l(
+    _In_ int const c,
+    _In_ int const mask,
+    _In_opt_ _locale_t const locale)
+{
+    if (locale)
+    {
+        if (c >= -1 && c <= 255)
+        {
+            return __acrt_get_locale_data_prefix(locale)->_locale_pctype[c] & mask;
+        }
+
+        if (__acrt_get_locale_data_prefix(locale)->_locale_mb_cur_max > 1)
+        {
+            return _isctype_l(c, mask, locale);
+        }
+
+        return 0; // >0xFF and SBCS locale
+    }
+
+    return _chvalidchk_l(c, mask, 0);
+}
+
+//#undef _isalnum_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isalnum_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return  _ischartype_l(c, _ALPHA | _DIGIT, locale);
+}
+
+#undef _isalpha_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isalpha_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _ALPHA, locale);
+}
+
+#undef _iscntrl_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iscntrl_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _CONTROL, locale);
+}
+
+#undef _isdigit_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isdigit_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _DIGIT, locale);
+}
+
+#undef _isgraph_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isgraph_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _PUNCT | _ALPHA | _DIGIT, locale);
+}
+
+#undef _islower_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_islower_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _LOWER, locale);
+}
+
+#undef _isprint_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isprint_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _BLANK | _PUNCT | _ALPHA | _DIGIT, locale);
+}
+
+#undef _isspace_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isspace_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _SPACE, locale);
+}
+
+#undef _isupper_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isupper_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _UPPER, locale);
+}
+
+#undef _iswalnum_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswalnum_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _ALPHA|_DIGIT, locale);
+}
+
+#undef _iswalpha_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswalpha_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _ALPHA, locale);
+}
+
+#undef _iswcntrl_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswcntrl_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return _iswctype_l(c, _CONTROL, locale);
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswctype_l(
+    _In_ wint_t c,
+    _In_ wctype_t type,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+#undef _iswdigit_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswdigit_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _DIGIT, locale);
+}
+
+#undef _iswgraph_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswgraph_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _PUNCT | _ALPHA | _DIGIT, locale);
+}
+
+#undef _iswlower_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswlower_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c , _LOWER, locale);
+}
+
+#undef _iswprint_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswprint_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _BLANK | _PUNCT | _ALPHA | _DIGIT, locale);
+}
+
+#undef _iswpunct_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswpunct_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _PUNCT, locale);
+}
+
+#undef _iswspace_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswspace_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _SPACE, locale);
+}
+
+#undef _iswupper_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswupper_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _UPPER, locale);
+}
+
+#undef _iswxdigit_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_iswxdigit_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    return _iswctype_l(c, _HEX, locale);
+}
+
+#undef _isxdigit_l
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_isxdigit_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    return _ischartype_l(c, _HEX, locale);
+}
+
+_Must_inspect_result_
+_CRTIMP
+int
+__cdecl
+_memicmp_l(
+    _In_reads_bytes_opt_(size) const void *buf1,
+    _In_reads_bytes_opt_(size) const void *buf2,
+    _In_ size_t size,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_strcoll_l(
+    _In_z_ const char *str1,
+    _In_z_ const char *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_stricmp_l(
+    _In_z_ const char *str1,
+    _In_z_ const char *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_stricoll_l(
+    _In_z_ const char *str1,
+    _In_z_ const char *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strlwr_s(
+    _Inout_updates_z_(size) char *str,
+    _In_ size_t size)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strlwr_s_l(
+    _Inout_updates_z_(size) char *str,
+    _In_ size_t size,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_strncoll_l(
+    _In_z_ const char *str1,
+    _In_z_ const char *str2,
+    _In_ size_t maxcount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_strnicmp_l(
+    _In_reads_or_z_(maxcount) const char *str1,
+    _In_reads_or_z_(maxcount) const char *str2,
+    _In_ size_t maxcount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_strnicoll_l(
+    _In_z_ const char *str1,
+    _In_z_ const char *str2,
+    _In_ size_t maxcount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strnset_s(
+    _Inout_updates_z_(size) char *str,
+    _In_ size_t size,
+    _In_ int val,
+    _In_ size_t _MaxCount)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_CRTIMP
+char*
+_strupr_l(
+    char *str,
+    _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+wint_t
+__cdecl
+_towlower_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+wint_t
+__cdecl
+_towupper_l(
+    _In_ wint_t c,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_CRTIMP
+wchar_t*
+_wcslwr_l(
+    wchar_t *str,
+    _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_CRTIMP
+wchar_t*
+_wcsupr_l(
+    wchar_t *str,
+    _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_opt_
+_CRTIMP
+size_t
+__cdecl
+_wcsxfrm_l(
+    _Out_writes_opt_(maxcount) _Post_maybez_ wchar_t *dst,
+    _In_z_ const wchar_t *src,
+    _In_ size_t maxcount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strset_s(
+    _Inout_updates_z_(size) char *dst,
+    _In_ size_t size,
+    _In_ int val)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strupr_s(
+    _Inout_updates_z_(size) char *str,
+    _In_ size_t size)
+{
+    return _strupr_s_l(str, size, 0);
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strupr_s_l(
+    _Inout_updates_z_(_Size) char *str,
+    _In_ size_t size,
+    _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return ENOTSUP;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_tolower_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_toupper_l(
+    _In_ int c,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcscoll_l(
+    _In_z_ const wchar_t *str1,
+    _In_z_ const wchar_t *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcsicmp_l(
+    _In_z_ const wchar_t *str1,
+    _In_z_ const wchar_t *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcsicoll_l(
+    _In_z_ const wchar_t *str1,
+    _In_z_ const wchar_t *str2,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_wcslwr_s(
+    _Inout_updates_z_(sizeInWords) wchar_t *str,
+    _In_ size_t sizeInWords)
+{
+    return _wcslwr_s_l(str, sizeInWords, NULL);
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_wcslwr_s_l(
+    _Inout_updates_z_(sizeInWords) wchar_t *str,
+    _In_ size_t sizeInWords,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return ENOTSUP;
+}
+
+typedef size_t rsize_t;
+
+_Check_return_wat_
+_CRTIMP // _ACRTIMP
+errno_t
+__cdecl
+strncat_s(
+    _Inout_updates_z_(size) char* dest,
+    _In_ rsize_t size,
+    _In_reads_or_z_(maxCount) char const* src,
+    _In_ rsize_t  maxCount)
+{
+    UNIMPLEMENTED;
+    return ENOTSUP;
+}
+
+_Check_return_opt_
+_CRTIMP
+_CRT_INSECURE_DEPRECATE(vsnprintf_s)
+int
+__cdecl
+vsnprintf_(
+    _Out_writes_(maxCount) char *dst,
+    _In_ size_t maxCount,
+    _In_z_ _Printf_format_string_ const char *format,
+    va_list argptr)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcsnicoll_l(
+    _In_z_ const wchar_t *str1,
+    _In_z_ const wchar_t *str2,
+    _In_ size_t maxCount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcsnicmp_l(
+    _In_reads_or_z_(_MaxCount) const wchar_t *str1,
+    _In_reads_or_z_(_MaxCount) const wchar_t *str2,
+    _In_ size_t maxCount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_
+_CRTIMP
+int
+__cdecl
+_wcsncoll_l(
+    _In_z_ const wchar_t *str1,
+    _In_z_ const wchar_t *str2,
+    _In_ size_t maxCount,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_strerror_s(
+    _Out_writes_z_(_SizeInBytes) char *buf,
+    _In_ size_t sizeInBytes,
+    _In_opt_z_ const char *errMsg)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_wcsnset_s(
+    _Inout_updates_z_(_DstSizeInWords) wchar_t *dst,
+    _In_ size_t sizeInWords,
+    _In_ wchar_t val,
+    _In_ size_t maxCount)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_wcsset_s(
+    _Inout_updates_z_(_SizeInWords) wchar_t *str,
+    _In_ size_t sizeInWords,
+    _In_ wchar_t val)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_wat_
+_CRTIMP
+errno_t
+__cdecl
+_wcsupr_s_l(
+    _Inout_updates_z_(_Size) wchar_t *str,
+    _In_ size_t size,
+    _In_opt_ _locale_t locale)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+_Check_return_opt_
+_CRTIMP
+_CRT_INSECURE_DEPRECATE(vsnprintf_s)
+int
+__cdecl
+vsnprintf(
+    _Out_writes_(_MaxCount) char *dest,
+    _In_ size_t maxCount,
+    _In_z_ _Printf_format_string_ const char *format,
+    va_list argptr)
+{
+    UNIMPLEMENTED;
+    return 0;
+}
+
+
+

--- a/sdk/lib/crt/crt.cmake
+++ b/sdk/lib/crt/crt.cmake
@@ -292,7 +292,7 @@ list(APPEND CRT_SOURCE
     string/strtod.c
     string/strtoi64.c
     string/strtok.c
-    #string/strtok_s.c
+    string/strtok_s.c
     string/strtol.c
     string/strtoul.c
     string/strtoull.c

--- a/sdk/lib/crt/except/amd64/cpp.s
+++ b/sdk/lib/crt/except/amd64/cpp.s
@@ -36,8 +36,10 @@ ENDM
 
 DEFINE_ALIAS ??3@YAXPEAX@Z, MSVCRT_operator_delete
 DEFINE_ALIAS ??_U@YAPEAX_K@Z, MSVCRT_operator_new
+DEFINE_ALIAS ??_U@YAPEAX_KHPEBDH@Z, MSVCRT_operator_new_dbg
 DEFINE_ALIAS ??_V@YAXPEAX@Z, MSVCRT_operator_delete
 DEFINE_ALIAS ??2@YAPEAX_K@Z, MSVCRT_operator_new
+DEFINE_ALIAS ??2@YAPEAX_KHPEBDH@Z, MSVCRT_operator_new_dbg
 DEFINE_ALIAS ?_query_new_handler@@YAP6AHI@ZXZ, MSVCRT__query_new_handler
 DEFINE_ALIAS ?_set_new_handler@@YAP6AHI@ZP6AHI@Z@Z, MSVCRT__set_new_handler
 DEFINE_ALIAS ?set_new_handler@@YAP6AXXZP6AXXZ@Z, MSVCRT_set_new_handler
@@ -57,7 +59,9 @@ DEFINE_ALIAS ??4exception@@QEAAAEAV0@AEBV0@@Z, MSVCRT_exception_opequals
 DEFINE_ALIAS ??1type_info@@UEAA@XZ, MSVCRT_type_info_dtor
 DEFINE_ALIAS ??0__non_rtti_object@@QEAA@AEBV0@@Z, MSVCRT___non_rtti_object_copy_ctor
 DEFINE_ALIAS ??0__non_rtti_object@@QEAA@PEBD@Z, MSVCRT___non_rtti_object_ctor
+DEFINE_ALIAS ??0bad_cast@@AAE@PBQBD@Z, MSVCRT_bad_cast_ctor
 DEFINE_ALIAS ??0bad_cast@@AEAA@PEBQEBD@Z, MSVCRT_bad_cast_ctor
+DEFINE_ALIAS ??0bad_cast@@QAE@ABQBD@Z, MSVCRT_bad_cast_ctor
 DEFINE_ALIAS ??0bad_cast@@QEAA@AEBQEBD@Z, MSVCRT_bad_cast_ctor
 DEFINE_ALIAS ??0bad_cast@@QEAA@AEBV0@@Z, MSVCRT_bad_cast_copy_ctor
 DEFINE_ALIAS ??0bad_cast@@QEAA@PEBD@Z, MSVCRT_bad_cast_ctor_charptr


### PR DESCRIPTION
This adds/fixes some architecture specific exports, adds Vista specific exports and turns a few stubs into implementations.