### PR TITLE
[REACTOS] Do not use LoadLibraryEx() NT6+ flags

### DIFF
--- a/base/shell/progman/dialog.c
+++ b/base/shell/progman/dialog.c
@@ -586,7 +586,7 @@ DIALOG_SYMBOL_DlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
             SetDlgItemTextW(hDlg, PM_ICON_FILE, pIconContext->szName);
             SendMessageA(pIconContext->hDlgCtrl, LB_SETITEMHEIGHT, 0, 32);
 
-            pIconContext->hLibrary = LoadLibraryExW(pIconContext->szName, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE);
+            pIconContext->hLibrary = LoadLibraryExW(pIconContext->szName, NULL, /* NT6+: LOAD_LIBRARY_AS_IMAGE_RESOURCE | */ LOAD_LIBRARY_AS_DATAFILE);
             if (pIconContext->hLibrary)
             {
                 EnumResourceNamesW(pIconContext->hLibrary,
@@ -635,7 +635,7 @@ DIALOG_SYMBOL_DlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                     SetDlgItemTextW(hDlg, PM_ICON_FILE, filename);
                     DestroyIconList(pIconContext->hDlgCtrl);
-                    pIconContext->hLibrary = LoadLibraryExW(filename, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE);
+                    pIconContext->hLibrary = LoadLibraryExW(filename, NULL, /* NT6+: LOAD_LIBRARY_AS_IMAGE_RESOURCE | */ LOAD_LIBRARY_AS_DATAFILE);
                     if (pIconContext->hLibrary)
                     {
                         EnumResourceNamesW(pIconContext->hLibrary,

--- a/sdk/lib/crt/misc/dbgrpt.cpp
+++ b/sdk/lib/crt/misc/dbgrpt.cpp
@@ -113,7 +113,7 @@ HMODULE _CrtGetUser32()
 {
     if (_CrtUser32Handle == NULL)
     {
-        HMODULE mod = LoadLibraryExW(L"user32.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
+        HMODULE mod = LoadLibraryExW(L"user32.dll", NULL, 0 /* NT6+: LOAD_LIBRARY_SEARCH_SYSTEM32 */);
         if (mod == NULL)
             mod = (HMODULE)INVALID_HANDLE_VALUE;
 

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1866,7 +1866,7 @@ CURSORICON_CopyImage(
             ustrRsrc.Buffer, IS_INTRESOURCE(ustrRsrc.Buffer) ? L"" : ustrRsrc.Buffer);
 
         /* Get the module handle or load the module */
-        hModule = LoadLibraryExW(ustrModule.Buffer, NULL, LOAD_LIBRARY_AS_IMAGE_RESOURCE | LOAD_LIBRARY_AS_DATAFILE);
+        hModule = LoadLibraryExW(ustrModule.Buffer, NULL, /* NT6+: LOAD_LIBRARY_AS_IMAGE_RESOURCE | */ LOAD_LIBRARY_AS_DATAFILE);
         if (!hModule)
         {
             DWORD err = GetLastError();


### PR DESCRIPTION
These modules are not compiled as NT6+.

JIRA issue: [CORE-12004](https://jira.reactos.org/browse/CORE-12004)