### PR TITLE
[winsrv] improve zh-CN translation

### DIFF
--- a/win32ss/user/winsrv/consrv/frontends/gui/lang/zh-CN.rc
+++ b/win32ss/user/winsrv/consrv/frontends/gui/lang/zh-CN.rc
@@ -5,7 +5,7 @@ BEGIN
     IDS_EDIT "编辑"
     IDS_MARK "标记"
     IDS_COPY "复制\tEnter"
-    IDS_PASTE "黏贴"
+    IDS_PASTE "粘贴"
     IDS_SELECTALL "全部选择"
     IDS_SCROLL "滚动"
     IDS_FIND "查找..."


### PR DESCRIPTION
The new word is more in line with PRC people's usage habits, and it
is actually used in the Simplified Chinese translation of Windows.
