### PR TITLE
[SDK] Add dummy import lib files for MSVC_IDE build,

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -172,6 +172,13 @@ string(REPLACE "/implib:<TARGET_IMPLIB>" "" CMAKE_CXX_CREATE_SHARED_LIBRARY "${C
 string(REPLACE "/implib:<TARGET_IMPLIB>" "" CMAKE_C_CREATE_SHARED_MODULE "${CMAKE_C_CREATE_SHARED_MODULE}")
 string(REPLACE "/implib:<TARGET_IMPLIB>" "" CMAKE_CXX_CREATE_SHARED_MODULE "${CMAKE_CXX_CREATE_SHARED_MODULE}")
 
+# HACK2: CMake lacks the ability to completely remove the 'implib' argument for solution files...
+# To work around this, we just let it create a dummy file
+if(MSVC_IDE)
+    set(CMAKE_IMPORT_LIBRARY_SUFFIX ".dummy")
+endif()
+
+
 if(CMAKE_DISABLE_NINJA_DEPSLOG)
     set(cl_includes_flag "")
 else()


### PR DESCRIPTION
to work around a CMake bug generating broken dll targets

JIRA issue: [ROSBE-159](https://jira.reactos.org/browse/ROSBE-159)

https://gitlab.kitware.com/cmake/cmake/-/issues/21180