### PR TITLE
[SHELL32_APITEST] Strengthen ShellExecCmdLine testcase

### DIFF
--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -13,7 +13,8 @@
 #include <debug.h>
 #include <stdio.h>
 
-//#define ShellExecCmdLine ShellExecCmdLine
+#define ShellExecCmdLine ShellExecCmdLine // In testing on ReactOS
+//#undef ShellExecCmdLine // In testing on Vista+
 
 #ifndef SECL_NO_UI
     #define SECL_NO_UI          0x2
@@ -38,6 +39,7 @@ static __inline void __SHCloneStrW(WCHAR **target, const WCHAR *source)
 	lstrcpyW(*target, source);
 }
 
+// NOTE: You have to sync the following code to dll/win32/shell32/shlexec.cpp.
 static LPCWSTR
 SplitParams(LPCWSTR psz, LPWSTR pszArg0, size_t cchArg0)
 {
@@ -396,6 +398,12 @@ static const TEST_ENTRY s_entries[] =
     { __LINE__, HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), TRUE, L"Notepad", L"\"invalid program.exe\"", L"C:\\Program Files" },
     { __LINE__, HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), TRUE, L"Notepad", L"\"invalid program.exe\" \"Test File.txt\"", NULL },
     { __LINE__, HRESULT_FROM_WIN32(ERROR_FILE_NOT_FOUND), TRUE, L"Notepad", L"\"invalid program.exe\" \"Test File.txt\"", L"." },
+    // My Documents
+    { __LINE__, S_OK, TRUE, NULL, L"::{450d8fba-ad25-11d0-98a8-0800361b1103}", NULL },
+    { __LINE__, S_OK, TRUE, NULL, L"shell:::{450d8fba-ad25-11d0-98a8-0800361b1103}", NULL },
+    // Control Panel
+    { __LINE__, S_OK, TRUE, NULL, L"::{5399E694-6CE5-4D6C-8FCE-1D8870FDCBA0}", NULL },
+    { __LINE__, S_OK, TRUE, NULL, L"shell:::{5399E694-6CE5-4D6C-8FCE-1D8870FDCBA0}", NULL },
 };
 
 static void DoEntry(const TEST_ENTRY *pEntry)
@@ -455,7 +463,6 @@ START_TEST(ShellExecCmdLine)
     using namespace std;
 
 #ifndef ShellExecCmdLine
-    // CHECKME
     if (!IsWindowsVistaOrGreater())
     {
         skip("ShellExecCmdLine is not available on this platform\n");


### PR DESCRIPTION
## Purpose

`ShellExecCmdLine` should support opening the special folders ("My Documents" and "Control Panel" etc.).

JIRA issue: [CORE-16939](https://jira.reactos.org/browse/CORE-16939)

## Proposed changes

- Add tests for "My Documents" and "Control Panel".
- Add some comments for usability.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/92987149-bf7f1700-f4fa-11ea-8401-fb277a34a6ef.png)
Successful.

ReactOS:
![ReactOS](https://user-images.githubusercontent.com/2107452/92987150-c4dc6180-f4fa-11ea-8755-c0fe21dd08a2.png)
There are some failures.