### PR TITLE
[SHELL32_APITEST] Strengthen ShellExecuteW testcase

### DIFF
--- a/modules/rostests/apitests/shell32/ShellExecuteW.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteW.cpp
@@ -119,6 +119,32 @@ START_TEST(ShellExecuteW)
         hWnd = FindWindowW(L"CabinetWClass", L"Search Results");
         PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
     }
+
+    // TEST #7: Open My Documents ("::{450d8fba-ad25-11d0-98a8-0800361b1103}")
+    hInstance = ShellExecuteW(NULL, NULL, L"::{450d8fba-ad25-11d0-98a8-0800361b1103}", NULL, NULL, SW_SHOWNORMAL);
+    ret = (INT)(UINT_PTR)hInstance;
+    ok(ret > 31, "TEST #7: ret:%d, LastError: %ld\n", ret, GetLastError());
+    trace("TEST #7 ret: %d.\n", ret);
+    if (hInstance)
+    {
+        Sleep(WAIT_SLEEP);
+        // Terminate Window
+        hWnd = FindWindowW(L"CabinetWClass", NULL);
+        PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
+    }
+
+    // TEST #8: Open My Documents ("shell:::{450d8fba-ad25-11d0-98a8-0800361b1103}")
+    hInstance = ShellExecuteW(NULL, L"open", L"shell:::{450d8fba-ad25-11d0-98a8-0800361b1103}", NULL, NULL, SW_SHOWNORMAL);
+    ret = (INT)(UINT_PTR)hInstance;
+    ok(ret > 31, "TEST #8: ret:%d, LastError: %ld\n", ret, GetLastError());
+    trace("TEST #8 ret: %d.\n", ret);
+    if (hInstance)
+    {
+        Sleep(WAIT_SLEEP);
+        // Terminate Window
+        hWnd = FindWindowW(L"CabinetWClass", NULL);
+        PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
+    }
 }
 
 // Windows Server 2003 and Windows XP SP3 return values (Win 7 returns 42 in all cases)


### PR DESCRIPTION
## Purpose

I want to support opening the special folders in `ShellExecute` function.

JIRA issue: [CORE-16939](https://jira.reactos.org/browse/CORE-16939)

## Proposed changes

- Add tests for special folders.

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/92987729-31a62a80-f500-11ea-9c67-457a4ffc610b.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/92987731-34a11b00-f500-11ea-81f1-7586734ab762.png)
Successful.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/92987728-310d9400-f500-11ea-8388-27f72a910dd5.png)
Successful.

ReactOS:
![ReactOS](https://user-images.githubusercontent.com/2107452/92987725-2fdc6700-f500-11ea-805f-59e9649c2ac2.png)
There are some failures.