### PR TITLE
[CABMAN] Add commandline support for creating a cab with folders

### DIFF
--- a/base/applications/rapps/CreateCabFile.bat
+++ b/base/applications/rapps/CreateCabFile.bat
@@ -1,12 +1,32 @@
 @echo off
 
-cd ..\..\..\media
+IF "%1"=="" GOTO show_usage
+IF "%2"=="" GOTO show_usage
+IF "%3"=="" GOTO show_usage
 
-mkdir rapps\utf16
+SET CABMAN_CMD=%1
+SET UTF16LE_CMD=%2
+SET RAPPSDB_PATH=%3
 
-for %%f in (rapps\*.txt) do (
-     ..\output-MinGW-i386\host-tools\utf16le.exe "rapps\%%~nf.txt" "rapps\utf16\%%~nf.txt"
+mkdir "%RAPPSDB_PATH%\utf16"
+
+echo Converting txt files to utf16
+for %%f in (%RAPPSDB_PATH%\*.txt) do (
+     %UTF16LE_CMD% "%RAPPSDB_PATH%\%%~nf.txt" "%RAPPSDB_PATH%\utf16\%%~nf.txt"
 )
 
-..\output-MinGW-i386\host-tools\cabman.exe -M mszip -S rapps\rappmgr.cab rapps\utf16\*.txt
-rmdir /s /q rapps\utf16
+echo Building rappmgr.cab
+%CABMAN_CMD% -M mszip -S "%RAPPSDB_PATH%\rappmgr.cab" "%RAPPSDB_PATH%\utf16\*.txt"
+
+echo Building rappmgr2.cab
+%CABMAN_CMD% -M mszip -S "%RAPPSDB_PATH%\rappmgr2.cab" "%RAPPSDB_PATH%\utf16\*.txt" -F icons "%RAPPSDB_PATH%\icons\*.ico"
+
+echo Cleaning up
+rmdir /s /q "%RAPPSDB_PATH%\utf16"
+
+echo Done
+
+goto :eof
+
+:show_usage
+echo Usage: CreateCabFile.bat path\to\cabman.exe path\to\utf16le.exe path\to\rapps-db

--- a/base/applications/rapps/CreateCabFile.sh
+++ b/base/applications/rapps/CreateCabFile.sh
@@ -1,9 +1,29 @@
 #/bin/sh
-cd ../../../media
-mkdir rapps/utf16
-for i in $(find -type f); do
-  ../../host-tools/utf16le $i utf16/$i
+
+if [ "$#" != "3" ]; then
+    echo "Usage: CreateCabFile.sh path/to/cabman path/to/utf16le path/to/rapps-db"
+    exit -1
+fi
+
+CABMAN_CMD="$1"
+UTF16LE_CMD="$2"
+RAPPSDB_PATH="$3"
+
+mkdir "$RAPPSDB_PATH/utf16"
+
+echo Converting txt files to utf16
+for filename in $RAPPSDB_PATH/*.txt; do
+    just_filename=$(basename -- "$filename")
+    $UTF16LE_CMD "$filename" "$RAPPSDB_PATH/utf16/$just_filename"
 done
-cd ..
-../../host-tools/cabman -M mszip -S rapps/rappmgr.cab rapps/utf16/*.txt
-rm -r rapps/uft16
+
+echo Building rappmgr.cab
+$CABMAN_CMD -M mszip -S "$RAPPSDB_PATH/rappmgr.cab" "$RAPPSDB_PATH/utf16/*.txt"
+
+echo Building rappmgr2.cab
+$CABMAN_CMD -M mszip -S "$RAPPSDB_PATH/rappmgr2.cab" "$RAPPSDB_PATH/utf16/*.txt" -F icons "$RAPPSDB_PATH/icons/*.ico"
+
+echo Cleaning up
+rm -r "$RAPPSDB_PATH/utf16"
+
+echo Done

--- a/sdk/tools/cabman/cabinet.h
+++ b/sdk/tools/cabman/cabinet.h
@@ -227,6 +227,7 @@ typedef struct _CFFILE_NODE
 {
     CFFILE              File = { 0 };
     std::string         FileName;
+    std::string         TargetFolder;
     PCFDATA_NODE        DataBlock = nullptr;    // First data block of file. NULL if not known
     bool                Commit = false;         // true if the file data should be committed
     bool                Delete = false;         // true if marked for deletion
@@ -235,7 +236,8 @@ typedef struct _CFFILE_NODE
 
 typedef struct _SEARCH_CRITERIA
 {
-    std::string              Search;            // The actual search criteria
+    std::string             Search;             // The actual search criteria
+    std::string             TargetFolder;       // The filename will be TargetFolder\file
 } SEARCH_CRITERIA, *PSEARCH_CRITERIA;
 
 typedef struct _CAB_SEARCH
@@ -311,8 +313,8 @@ public:
     bool IsSeparator(char Char);
     /* Replaces \ or / with the one used be the host environment */
     void ConvertPath(std::string& Path);
-    /* Returns a pointer to the filename part of a fully qualified filename */
-    const char* GetFileName(const char* Path);
+    /* Returns the filename part of a fully qualified filename */
+    std::string GetFileName(const std::string& Path);
     /* Normalizes a path */
     void NormalizePath(std::string& Path);
     /* Returns name of cabinet file */
@@ -342,11 +344,13 @@ public:
     /* Returns whether a codec engine is selected */
     bool IsCodecSelected();
     /* Adds a search criteria for adding files to a simple cabinet, displaying files in a cabinet or extracting them */
-    ULONG AddSearchCriteria(const char* SearchCriteria);
+    ULONG AddSearchCriteria(const std::string& SearchCriteria, const std::string& TargetFolder);
     /* Destroys the search criteria list */
     void DestroySearchCriteria();
     /* Returns whether we have search criteria */
     bool HasSearchCriteria();
+
+    std::string CreateCabFilename(PCFFILE_NODE Node);
 
 #ifndef CAB_READ_ONLY
     /* Creates a simple cabinet based on the search criteria data */
@@ -370,7 +374,7 @@ public:
     /* Closes the current cabinet */
     ULONG CloseCabinet();
     /* Adds a file to the current disk */
-    ULONG AddFile(char* FileName);
+    ULONG AddFile(const std::string& FileName, const std::string& TargetFolder);
     /* Sets the maximum size of the current disk */
     void SetMaxDiskSize(ULONG Size);
 #endif /* CAB_READ_ONLY */

--- a/sdk/tools/cabman/cabman.cxx
+++ b/sdk/tools/cabman/cabman.cxx
@@ -193,7 +193,7 @@ void CCABManager::Usage()
     printf("ReactOS Cabinet Manager\n\n");
     printf("CABMAN [-D | -E] [-A] [-L dir] cabinet [filename ...]\n");
     printf("CABMAN [-M mode] -C dirfile [-I] [-RC file] [-P dir]\n");
-    printf("CABMAN [-M mode] -S cabinet filename [...]\n");
+    printf("CABMAN [-M mode] -S cabinet filename [-F folder] [filename] [...]\n");
     printf("  cabinet   Cabinet file.\n");
     printf("  filename  Name of the file to add to or extract from the cabinet.\n");
     printf("            Wild cards and multiple filenames\n");
@@ -206,6 +206,7 @@ void CCABManager::Usage()
     printf("  -C        Create cabinet.\n");
     printf("  -D        Display cabinet directory.\n");
     printf("  -E        Extract files from cabinet.\n");
+    printf("  -F        Put the files from the next 'filename' filter in the cab in folder\filename.\n");
     printf("  -I        Don't create the cabinet, only the .inf file.\n");
     printf("  -L dir    Location to place extracted or generated files\n");
     printf("            (default is current directory).\n");
@@ -233,7 +234,7 @@ bool CCABManager::ParseCmdline(int argc, char* argv[])
     int i;
     bool ShowUsage;
     bool FoundCabinet = false;
-
+    std::string NextFolder;
     ShowUsage = (argc < 2);
 
     for (i = 1; i < argc; i++)
@@ -260,6 +261,19 @@ bool CCABManager::ParseCmdline(int argc, char* argv[])
                 case 'e':
                 case 'E':
                     Mode = CM_MODE_EXTRACT;
+                    break;
+
+                case 'f':
+                case 'F':
+                    if (argv[i][2] == 0)
+                    {
+                        i++;
+                        NextFolder = argv[i];
+                    }
+                    else
+                    {
+                        NextFolder = argv[i] + 2;
+                    }
                     break;
 
                 case 'i':
@@ -374,7 +388,8 @@ bool CCABManager::ParseCmdline(int argc, char* argv[])
             else if(FoundCabinet)
             {
                 // For creating simple cabinets, displaying or extracting them, add the argument as a search criteria
-                AddSearchCriteria(argv[i]);
+                AddSearchCriteria(argv[i], NextFolder);
+                NextFolder.clear();
             }
             else
             {
@@ -618,7 +633,7 @@ void CCABManager::OnExtract(PCFFILE File,
 {
     if (Verbose)
     {
-        printf("Extracting %s\n", GetFileName(FileName));
+        printf("Extracting %s\n", GetFileName(FileName).c_str());
     }
 }
 
@@ -651,7 +666,7 @@ void CCABManager::OnAdd(PCFFILE File,
 {
     if (Verbose)
     {
-        printf("Adding %s\n", GetFileName(FileName));
+        printf("Adding %s\n", GetFileName(FileName).c_str());
     }
 }
 

--- a/sdk/tools/cabman/dfp.cxx
+++ b/sdk/tools/cabman/dfp.cxx
@@ -6,7 +6,7 @@
  * PROGRAMMERS: Casper S. Hornstrup (chorns@users.sourceforge.net)
  *              Colin Finck <mail@colinfinck.de>
  * NOTES:       The directive file format is similar to the
- *              directive file format used by Microsoft's MAKECAB
+ *              directive file format used by Microsoft's MAKECAB (But not entirely compatible!)
  * REVISIONS:
  *   CSH 21/03-2001 Created
  *   CSH 15/08-2003 Made it portable
@@ -1123,17 +1123,17 @@ ULONG CDFParser::PerformFileCopy()
 
     DPRINT(MID_TRACE, ("Adding file: '%s'   destination: '%s'.\n", SrcName, DstName));
 
-    Status = AddFile(SrcName);
+    Status = AddFile(SrcName, std::string());
     if (Status == CAB_STATUS_CANNOT_OPEN)
     {
         strcpy(SrcName, FileRelativePath.c_str());
         strcat(SrcName, BaseFilename);
-        Status = AddFile(SrcName);
+        Status = AddFile(SrcName, std::string());
     }
     switch (Status)
     {
         case CAB_STATUS_SUCCESS:
-            sprintf(InfLine, "%s=%s", GetFileName(SrcName), DstName);
+            sprintf(InfLine, "%s=%s", GetFileName(SrcName).c_str(), DstName);
             WriteInfLine(InfLine);
             break;
 


### PR DESCRIPTION
Update rapps example scripts for new usage

JIRA issue: [CORE-17230](https://jira.reactos.org/browse/CORE-17230)

We need to create 2 .cab files, since rapps cannot handle extracting folders without a code change.
To work around this, the first file does not include the icons (but rapps cannot extract it anyway),
and the second file (with a new name) does include the icons (and since rapps needs an update to change the filename, folder extraction can be added in the same update)