### PR TITLE
[KERNEL32] GetPriorityClass(): Return explicit 0, not FALSE

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -1683,7 +1683,7 @@ GetPriorityClass(IN HANDLE hProcess)
 
     /* Failure path */
     BaseSetLastNTError(Status);
-    return FALSE;
+    return 0;
 }
 
 /*


### PR DESCRIPTION
Match return type, to reduce confusion.

JIRA issue: [CORE-16757](https://jira.reactos.org/browse/CORE-16757)