### PR TITLE
[KERNEL32] Improve SetComputerNameExW

### DIFF
--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -28,15 +28,10 @@
 /* INCLUDES ******************************************************************/
 
 #include <k32.h>
+#include <windns.h>
 
 #define NDEBUG
 #include <debug.h>
-
-typedef enum _DNS_NAME_FORMAT
-{
-    DnsNameDomain, DnsNameDomainLabel, DnsNameHostnameFull,
-    DnsNameHostnameLabel, DnsNameWildcard, DnsNameSrvRecord
-} DNS_NAME_FORMAT;
 
 typedef NTSTATUS (WINAPI *FN_DnsValidateName_W)(LPCWSTR, DNS_NAME_FORMAT);
 

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -497,22 +497,22 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
     if (lpComputerName == NULL)
         return FALSE;
 
-    /* get string length */
+    /* Get string length */
     if (!NT_SUCCESS(RtlStringCchLengthW(lpComputerName, NTSTRSAFE_MAX_CCH, &Length)))
         return FALSE;
 
-    /* the empty name is invalid, except the empty DNS name */
+    /* An empty name is invalid, except a DNS name */
     if (Length == 0 && NameType != ComputerNamePhysicalDnsDomain)
         return FALSE;
 
-    /* leading or trailing spaces are invalid */
+    /* Leading or trailing spaces are invalid */
     if (Length > 0 &&
         (lpComputerName[0] == L' ' || lpComputerName[Length - 1] == L' '))
     {
         return FALSE;
     }
 
-    /* check whether the name contains any invalid character */
+    /* Check whether the name contains any invalid character */
     if (wcscspn(lpComputerName, s_szInvalidChars) < Length)
         return FALSE;
 
@@ -524,7 +524,7 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
             return TRUE;
 
         case ComputerNamePhysicalDnsDomain:
-            /* the empty DNS name is valid */
+            /* An empty DNS name is valid */
             if (Length != 0)
                 return BaseVerifyDnsName(lpComputerName);
             return TRUE;
@@ -590,7 +590,7 @@ SetComputerNameToRegistry(LPCWSTR RegistryKey,
     NtFlushKey(KeyHandle);
     NtClose(KeyHandle);
 
-    SetLastError(NO_ERROR);
+    SetLastError(ERROR_SUCCESS);
     return TRUE;
 }
 

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -497,9 +497,11 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
     if (lpComputerName == NULL)
         return FALSE;
 
+#define MAX_COMPUTER_NAME_EX 64
     /* Get string length */
-    if (!NT_SUCCESS(RtlStringCchLengthW(lpComputerName, NTSTRSAFE_MAX_CCH, &Length)))
+    if (!NT_SUCCESS(RtlStringCchLengthW(lpComputerName, MAX_COMPUTER_NAME_EX + 1, &Length)))
         return FALSE;
+#undef MAX_COMPUTER_NAME_EX
 
     /* An empty name is invalid, except a DNS name */
     if (Length == 0 && NameType != ComputerNamePhysicalDnsDomain)

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -459,7 +459,8 @@ GetComputerNameW(LPWSTR lpBuffer, LPDWORD lpnSize)
     return ret;
 }
 
-static BOOL
+static
+BOOL
 BaseVerifyDnsName(LPCWSTR lpDnsName)
 {
     HINSTANCE hDNSAPI;
@@ -487,7 +488,8 @@ BaseVerifyDnsName(LPCWSTR lpDnsName)
 /*
  * @implemented
  */
-static BOOL
+static
+BOOL
 IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
                     LPCWSTR lpComputerName)
 {

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -498,7 +498,7 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
         return FALSE;
 
     /* get string length */
-    RtlStringCchLengthW(lpComputerName, MAX_PATH, &Length);
+    RtlStringCchLengthW(lpComputerName, NTSTRSAFE_MAX_CCH, &Length);
 
     /* the empty name is invalid, except the empty DNS name */
     if (Length == 0 && NameType != ComputerNamePhysicalDnsDomain)

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -493,7 +493,6 @@ BOOL
 IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
                     LPCWSTR lpComputerName)
 {
-    BOOL ret;
     SIZE_T Length;
     static const WCHAR s_szInvalidChars[] =
         L"\"/\\[]:|<>+=;,?"
@@ -520,30 +519,25 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
     if (wcscspn(lpComputerName, s_szInvalidChars) < Length)
         return FALSE;
 
-    ret = TRUE;
     switch (NameType)
     {
         case ComputerNamePhysicalNetBIOS:
             if (Length > MAX_COMPUTERNAME_LENGTH)
-                ret = FALSE;
-            break;
+                return FALSE;
+            return TRUE;
 
         case ComputerNamePhysicalDnsDomain:
             /* the empty DNS name is valid */
             if (Length != 0)
-                ret = BaseVerifyDnsName(lpComputerName);
-            break;
+                return BaseVerifyDnsName(lpComputerName);
+            return TRUE;
 
         case ComputerNamePhysicalDnsHostname:
-            ret = BaseVerifyDnsName(lpComputerName);
-            break;
+            return BaseVerifyDnsName(lpComputerName);
 
         default:
-            ret = FALSE;
-            break;
+            return FALSE;
     }
-
-    return ret;
 }
 
 static

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -488,7 +488,7 @@ BOOL
 IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
                     LPCWSTR lpComputerName)
 {
-    SIZE_T Length;
+    size_t Length;
     static const WCHAR s_szInvalidChars[] =
         L"\"/\\[]:|<>+=;,?"
         L"\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F"
@@ -497,7 +497,8 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
     if (lpComputerName == NULL)
         return FALSE;
 
-    Length = wcslen(lpComputerName);
+    /* get string length */
+    RtlStringCchLengthW(lpComputerName, MAX_PATH, &Length);
 
     /* the empty name is invalid, except the empty DNS name */
     if (Length == 0 && NameType != ComputerNamePhysicalDnsDomain)

--- a/dll/win32/kernel32/client/compname.c
+++ b/dll/win32/kernel32/client/compname.c
@@ -498,7 +498,8 @@ IsValidComputerName(COMPUTER_NAME_FORMAT NameType,
         return FALSE;
 
     /* get string length */
-    RtlStringCchLengthW(lpComputerName, NTSTRSAFE_MAX_CCH, &Length);
+    if (!NT_SUCCESS(RtlStringCchLengthW(lpComputerName, NTSTRSAFE_MAX_CCH, &Length)))
+        return FALSE;
 
     /* the empty name is invalid, except the empty DNS name */
     if (Length == 0 && NameType != ComputerNamePhysicalDnsDomain)


### PR DESCRIPTION
## Purpose

Reduce failures of `kernel32_apitest` `SetComputerNameExW` testcase and improve `SetComputerNameExW`.

JIRA issue: N/A

## Proposed changes

- Improve `IsValidComputerName` function.
- Add `BaseVerifyDnsName` function to implement `IsValidComputerName`.
- Set last error.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/93016625-9eebb580-f5fd-11ea-9fe6-b47057f17e0e.png)
There were many failures.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/93016621-97c4a780-f5fd-11ea-8d26-45ae77fa30bf.png)
There is one failure. The last one failure is related to truncating.