### PR TITLE
[SHELL32][SHLWAPI] Fix ShellMessageBoxW use of fixed sized buffer

### DIFF
--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -371,7 +371,8 @@ int ShellMessageBoxW(
             if (szText) LoadStringW(hInstance, LOWORD(lpText), szText, len + 1);
         }
         pszText = szText;
-        if (!pszText) {
+        if (!pszText)
+        {
             WARN("Failed to load id %d\n", LOWORD(lpText));
             __ms_va_end(args);
             return 0;
@@ -446,7 +447,8 @@ int ShellMessageBoxA(
             if (szText) LoadStringA(hInstance, LOWORD(lpText), szText, len + 1);;
         }
         pszText = szText;
-        if (!pszText) {
+        if (!pszText)
+        {
             WARN("Failed to load id %d\n", LOWORD(lpText));
             __ms_va_end(args);
             return 0;

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4812,51 +4812,7 @@ DWORD WINAPI GetUIVersion(void)
 INT WINAPIV ShellMessageBoxWrapW(HINSTANCE hInstance, HWND hWnd, LPCWSTR lpText,
                                  LPCWSTR lpCaption, UINT uType, ...)
 {
-    WCHAR *szText = NULL, szTitle[100];
-    LPCWSTR pszText, pszTitle = szTitle;
-    LPWSTR pszTemp;
-    __ms_va_list args;
-    int ret;
-
-    __ms_va_start(args, uType);
-
-    TRACE("(%p,%p,%p,%p,%08x)\n", hInstance, hWnd, lpText, lpCaption, uType);
-
-    if (IS_INTRESOURCE(lpCaption))
-        LoadStringW(hInstance, LOWORD(lpCaption), szTitle, sizeof(szTitle)/sizeof(szTitle[0]));
-    else
-        pszTitle = lpCaption;
-
-    if (IS_INTRESOURCE(lpText))
-    {
-        const WCHAR *ptr;
-        UINT len = LoadStringW(hInstance, LOWORD(lpText), (LPWSTR)&ptr, 0);
-
-        if (len)
-        {
-            szText = HeapAlloc(GetProcessHeap(), 0, (len + 1) * sizeof(WCHAR));
-            if (szText) LoadStringW(hInstance, LOWORD(lpText), szText, len + 1);
-        }
-        pszText = szText;
-        if (!pszText) {
-            WARN("Failed to load id %d\n", LOWORD(lpText));
-            __ms_va_end(args);
-            return 0;
-        }
-    }
-    else
-        pszText = lpText;
-
-    FormatMessageW(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_STRING,
-                   pszText, 0, 0, (LPWSTR)&pszTemp, 0, &args);
-
-    __ms_va_end(args);
-
-    ret = MessageBoxW(hWnd, pszTemp, pszTitle, uType);
-
-    HeapFree(GetProcessHeap(), 0, szText);
-    LocalFree(pszTemp);
-    return ret;
+    return ShellMessageBoxW(hInstance, hWnd, lpText, lpCaption, uType);
 }
 
 /***********************************************************************


### PR DESCRIPTION
## Purpose

- ShellMessageBoxW truncates mesages longer than 100 chars due to use of fixed size buffer

JIRA issue: [CORE-17271](https://jira.reactos.org/browse/CORE-17271)
![ShellMessageBoxW](https://user-images.githubusercontent.com/24843587/93017332-1272d000-f5c8-11ea-83ac-de9431a6351c.png)

## Proposed changes

- Fix ShellMessageBoxW implementation
- Proper redirect of ShellMessageBoxWrapW to ShellMessageBoxW
- Fixes in ShellMessageBoxA implementation

![ShellMessageBoxW_fix](https://user-images.githubusercontent.com/24843587/93017336-156dc080-f5c8-11ea-9a81-f4119e35fb57.png)