### PR TITLE
[BROWSEUI] Update the current directory before creating a view

### DIFF
--- a/dll/win32/browseui/desktopipc.cpp
+++ b/dll/win32/browseui/desktopipc.cpp
@@ -550,10 +550,16 @@ extern "C" HRESULT WINAPI SHOpenFolderWindow(PIE_THREAD_PARAM_BLOCK parameters)
     HANDLE                                  threadHandle;
     DWORD                                   threadID;
 
-    WCHAR debugStr[MAX_PATH + 1];
-    SHGetPathFromIDListW(parameters->directoryPIDL, debugStr);
-
-    TRACE("SHOpenFolderWindow %p(%S)\n", parameters->directoryPIDL, debugStr);
+    // Only try to convert the pidl when it is going to be printed
+    if (TRACE_ON(browseui))
+    {
+        WCHAR debugStr[MAX_PATH + 2] = { 0 };
+        if (!ILGetDisplayName(parameters->directoryPIDL, debugStr))
+        {
+            debugStr[0] = UNICODE_NULL;
+        }
+        TRACE("SHOpenFolderWindow %p(%S)\n", parameters->directoryPIDL, debugStr);
+    }
 
     PIE_THREAD_PARAM_BLOCK paramsCopy = SHCloneIETHREADPARAM(parameters);
 

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -913,7 +913,6 @@ long IEGetNameAndFlags(LPITEMIDLIST pidl, SHGDNF uFlags, LPWSTR pszBuf, UINT cch
 HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
     LPCITEMIDLIST absolutePIDL, FOLDERSETTINGS *folderSettings, long flags)
 {
-    CComPtr<IObjectWithSite>                objectWithSite;
     CComPtr<IShellFolder>                   saveCurrentShellFolder;
     CComPtr<IShellView>                     saveCurrentShellView;
     CComPtr<IShellView>                     newShellView;
@@ -988,9 +987,6 @@ HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
         SetCursor(saveCursor);
         return hResult;
     }
-
-    if (objectWithSite.p != NULL)
-        hResult = objectWithSite->SetSite(NULL);
 
     // update current pidl
     ILFree(fCurrentDirectoryPIDL);

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -974,6 +974,10 @@ HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
         ZeroMemory(&shellViewWindowBounds, sizeof(shellViewWindowBounds));
     ::MapWindowPoints(0, m_hWnd, reinterpret_cast<POINT *>(&shellViewWindowBounds), 2);
 
+    // update current pidl
+    ILFree(fCurrentDirectoryPIDL);
+    fCurrentDirectoryPIDL = ILClone(absolutePIDL);
+
     // create view window
     hResult = newShellView->CreateViewWindow(saveCurrentShellView, folderSettings,
         this, &shellViewWindowBounds, &newShellViewWindow);
@@ -987,10 +991,6 @@ HRESULT CShellBrowser::BrowseToPath(IShellFolder *newShellFolder,
         SetCursor(saveCursor);
         return hResult;
     }
-
-    // update current pidl
-    ILFree(fCurrentDirectoryPIDL);
-    fCurrentDirectoryPIDL = ILClone(absolutePIDL);
 
     // update view window
     if (saveCurrentShellView != NULL)

--- a/dll/win32/browseui/travellog.cpp
+++ b/dll/win32/browseui/travellog.cpp
@@ -125,7 +125,7 @@ HRESULT CTravelEntry::GetToolTipText(IUnknown *punk, LPWSTR pwzText) const
 {
     HRESULT                                 hResult;
 
-    hResult = ILGetDisplayNameEx(NULL, fPIDL, pwzText, ILGDN_NORMAL) ? S_OK : S_FALSE;
+    hResult = ILGetDisplayNameEx(NULL, fPIDL, pwzText, ILGDN_NORMAL) ? S_OK : E_FAIL;
     if (FAILED_UNEXPECTEDLY(hResult))
         return hResult;
 

--- a/dll/win32/shell32/CFolder.cpp
+++ b/dll/win32/shell32/CFolder.cpp
@@ -42,7 +42,7 @@ HRESULT STDMETHODCALLTYPE CFolder::get_Title(BSTR *pbs)
         return E_POINTER;
 
     WCHAR path[MAX_PATH+2] = {0};
-    HRESULT hr = ILGetDisplayNameExW(NULL, m_idlist, path, ILGDN_INFOLDER);
+    HRESULT hr = ILGetDisplayNameExW(NULL, m_idlist, path, ILGDN_INFOLDER) ? S_OK : E_FAIL;
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 


### PR DESCRIPTION
This way, when the view asks for a directory _during creation_ it
does not get either an old, or an invalid directory

Also include some vaguely related bugfixes

JIRA issue: [CORE-17270](https://jira.reactos.org/browse/CORE-17270)
