### PR TITLE
[FORMAT] Fix of output text overlap in console when finished

### DIFF
--- a/base/system/format/format.c
+++ b/base/system/format/format.c
@@ -562,6 +562,7 @@ int wmain(int argc, WCHAR *argv[])
     FormatEx(RootDirectory, media, FileSystem, Label, QuickFormat,
              ClusterSize, FormatExCallback);
     if (Error) return -1;
+    ConPuts(StdOut, L"\n");
     ConResPuts(StdOut, STRING_FMT_COMPLETE);
 
     //


### PR DESCRIPTION
## Purpose

- At the end of the format operation, text in console gets overwritten and leftovers from previous line remain displayed.

![formatbug](https://user-images.githubusercontent.com/24843587/93020819-b3b95080-f5df-11ea-9279-ec4ca1388a6e.png)

## Proposed changes

- Output the missing linefeed.

![formatbugfix](https://user-images.githubusercontent.com/24843587/93020820-b7e56e00-f5df-11ea-8d4b-a9254a97fa14.png)
