### PR TITLE
[SHELL32][SHLWAPI] Forward shell32.ShellMessageBoxW directly to shlwapi.ShellMessageBoxWrapW.

### DIFF
--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -45,6 +45,19 @@
 #undef ShellExecute
 #include <undocshell.h>
 
+/*
+ * For versions < Vista+, redefine ShellMessageBoxW to ShellMessageBoxWrapW
+ * (this is needed to avoid a linker error). On Vista+ onwards, shell32.ShellMessageBoxW
+ * redirects to shlwapi.ShellMessageBoxW so the #define should not be needed.
+ *
+ * However our shell32 is built with _WIN32_WINNT set to 0x600 (Vista+),
+ * yet its exports (especially regarding ShellMessageBoxA/W) are Win2003
+ * compatible. So the #define is still needed, and the check be disabled.
+ */
+// #if (_WIN32_WINNT < 0x0600)
+#define ShellMessageBoxW ShellMessageBoxWrapW
+// #endif
+
 #include <browseui_undoc.h>
 
 #include <shellutils.h>

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -178,7 +178,7 @@
 179 stdcall SHGetNewLinkInfoA(str str ptr long long)
 180 stdcall SHGetNewLinkInfoW(wstr wstr ptr long long)
 181 stdcall -noname RegisterShellHook(long long)
-182 varargs ShellMessageBoxW(long long wstr wstr long)
+182 varargs ShellMessageBoxW(long long wstr wstr long) shlwapi.ShellMessageBoxWrapW
 183 varargs ShellMessageBoxA(long long str str long)
 184 stdcall -noname ArrangeWindows(long long long long long)
 185 stdcall -noname SHHandleDiskFull(ptr long)

--- a/sdk/include/psdk/shellapi.h
+++ b/sdk/include/psdk/shellapi.h
@@ -511,6 +511,7 @@ ShellAboutW(
   _In_opt_ HICON hIcon);
 
 int
+WINAPIV
 ShellMessageBoxA(
   _In_opt_ HINSTANCE hAppInst,
   _In_opt_ HWND hWnd,
@@ -520,6 +521,7 @@ ShellMessageBoxA(
   ...);
 
 int
+WINAPIV
 ShellMessageBoxW(
   _In_opt_ HINSTANCE hAppInst,
   _In_opt_ HWND hWnd,

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -120,6 +120,16 @@ INT WINAPI SHUnicodeToAnsi(LPCWSTR lpSrcStr, LPSTR lpDstStr, INT iLen);
 
 PVOID WINAPI SHLockSharedEx(HANDLE hData, DWORD dwProcessId, BOOL bWriteAccess);
 
+int
+WINAPIV
+ShellMessageBoxWrapW(
+  _In_opt_ HINSTANCE hAppInst,
+  _In_opt_ HWND hWnd,
+  _In_ LPCWSTR lpcText,
+  _In_opt_ LPCWSTR lpcTitle,
+  _In_ UINT fuStyle,
+  ...);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* defined(__cplusplus) */


### PR DESCRIPTION
And:
[PSDK] Explicily use WINAPIV for the variadic ShellMessageBoxA/W functions.
[INCLUDE/REACTOS] Add ShellMessageBoxWrapW in shlwapi_undoc.h .

## Purpose

JIRA issue: [CORE-17271](https://jira.reactos.org/browse/CORE-17271)
See also PR #3172 by @KyleKatarn31.

## Proposed changes

This makes ShellMessageBoxW use the correct implementation where the
text buffer size is dynamic, instead of having a too small hardcoded
size.

However we cannot straightforwardly implement ShellMessageBoxA around
ShellMessageBoxW, by converting some parameters from ANSI to UNICODE,
because there may be some variadic ANSI strings, associated with '%s'
printf-like formatters inside the format string, that would also need
to be converted; however there is no way for us to find these and perform
the conversion ourselves.
Therefore, we re-implement ShellMessageBoxA by doing a copy-paste ANSI
adaptation of the shlwapi.ShellMessageBoxWrapW function.

Note that, on Vista+ onwards, shlwapi implements both ShellMessageBoxA/W,
and shell32 directly forwards these exports to shlwapi, thus avoiding
these workarounds.
