### PR TITLE
[WDMAUD.DRV] Add Define USE_MMIXER_LIB

### DIFF
--- a/dll/win32/wdmaud.drv/wdmaud.c
+++ b/dll/win32/wdmaud.drv/wdmaud.c
@@ -17,6 +17,7 @@
 #define NDEBUG
 #include <debug.h>
 #include <mmebuddy_debug.h>
+#define USE_MMIXER_LIB
 
 #ifndef USE_MMIXER_LIB
 #define FUNC_NAME(x) x##ByLegacy


### PR DESCRIPTION
## Purpose

Gets ReactOS to not rely on the broken wdmaud and sysaud drivers. Adding this will fix the linked JIRA issues along with many others.

JIRA issue: [CORE-13202](https://jira.reactos.org/browse/CORE-13202)
JIRA issue: [CORE-13488](https://jira.reactos.org/browse/CORE-13488)

## Proposed changes

- Adds the USE_MMIXER_LIB define
