### PR TITLE
[KDBG] Fixed handle leak in KdbpSymLoadModuleSymbols() when RosSymCreateFromFile() fails

### DIFF
--- a/ntoskrnl/kdbg/kdb_symbols.c
+++ b/ntoskrnl/kdbg/kdb_symbols.c
@@ -363,6 +363,7 @@ KdbpSymLoadModuleSymbols(
     HANDLE FileHandle;
     NTSTATUS Status;
     IO_STATUS_BLOCK IoStatusBlock;
+    BOOLEAN Result;
 
     /* Allow KDB to break on module load */
     KdbModuleLoaded(FileName);
@@ -404,13 +405,14 @@ KdbpSymLoadModuleSymbols(
 
     DPRINT("Loading symbols from %wZ...\n", FileName);
 
-    if (!RosSymCreateFromFile(&FileHandle, RosSymInfo))
+    Result = RosSymCreateFromFile(&FileHandle, RosSymInfo);
+    ZwClose(FileHandle);
+    
+    if (!Result)
     {
         DPRINT("Failed to load symbols from %wZ\n", FileName);
         return;
     }
-
-    ZwClose(FileHandle);
 
     DPRINT("Symbols loaded.\n");
 


### PR DESCRIPTION
## Purpose
kdbg leaks file handle when it fails to load the symbols from a module. This fixes that leak

## Proposed changes
Reorder operations so that file handle is always closed
