### PR TITLE
[RAPPS] Fix of unhandled exception when trying to modify/uninstall without selection

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -278,16 +278,20 @@ BOOL CMainWindow::RemoveSelectedAppFromRegistry()
     if (MessageBoxW(szMsgText, szMsgTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
     {
         CInstalledApplicationInfo *InstalledApp = (CInstalledApplicationInfo *)m_ApplicationView->GetFocusedItemData();
-        LSTATUS Result = InstalledApp->RemoveFromRegistry();
-        if (Result != ERROR_SUCCESS)
+        if (InstalledApp)
         {
-            // TODO: popup a messagebox telling user it fails somehow
-            return FALSE;
-        }
+            LSTATUS Result = InstalledApp->RemoveFromRegistry();
+            if (Result != ERROR_SUCCESS)
+            {
+                // TODO: popup a messagebox telling user it fails somehow
+                return FALSE;
+            }
 
-        // as it's already removed form registry, this will also remove it from the list
-        UpdateApplicationsList(-1);
-        return TRUE;
+            // as it's already removed form registry, this will also remove it from the list
+            UpdateApplicationsList(-1);
+            return TRUE;
+        }
+            return FALSE;
     }
 
     return FALSE;
@@ -299,7 +303,7 @@ BOOL CMainWindow::UninstallSelectedApp(BOOL bModify)
         return FALSE;
 
     CInstalledApplicationInfo *InstalledApp = (CInstalledApplicationInfo *)m_ApplicationView->GetFocusedItemData();
-
+    if(!InstalledApp) return FALSE;
     return InstalledApp->UninstallApplication(bModify);
 }
 

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -278,20 +278,19 @@ BOOL CMainWindow::RemoveSelectedAppFromRegistry()
     if (MessageBoxW(szMsgText, szMsgTitle, MB_YESNO | MB_ICONQUESTION) == IDYES)
     {
         CInstalledApplicationInfo *InstalledApp = (CInstalledApplicationInfo *)m_ApplicationView->GetFocusedItemData();
-        if (InstalledApp)
-        {
-            LSTATUS Result = InstalledApp->RemoveFromRegistry();
-            if (Result != ERROR_SUCCESS)
-            {
-                // TODO: popup a messagebox telling user it fails somehow
-                return FALSE;
-            }
-
-            // as it's already removed form registry, this will also remove it from the list
-            UpdateApplicationsList(-1);
-            return TRUE;
-        }
+        if (!InstalledApp)
             return FALSE;
+        
+        LSTATUS Result = InstalledApp->RemoveFromRegistry();
+        if (Result != ERROR_SUCCESS)
+        {
+            // TODO: popup a messagebox telling user it fails somehow
+            return FALSE;
+        }
+
+        // as it's already removed form registry, this will also remove it from the list
+        UpdateApplicationsList(-1);
+        return TRUE;
     }
 
     return FALSE;

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -302,7 +302,9 @@ BOOL CMainWindow::UninstallSelectedApp(BOOL bModify)
         return FALSE;
 
     CInstalledApplicationInfo *InstalledApp = (CInstalledApplicationInfo *)m_ApplicationView->GetFocusedItemData();
-    if (!InstalledApp) return FALSE;
+    if (!InstalledApp)
+        return FALSE;
+
     return InstalledApp->UninstallApplication(bModify);
 }
 

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -303,7 +303,7 @@ BOOL CMainWindow::UninstallSelectedApp(BOOL bModify)
         return FALSE;
 
     CInstalledApplicationInfo *InstalledApp = (CInstalledApplicationInfo *)m_ApplicationView->GetFocusedItemData();
-    if(!InstalledApp) return FALSE;
+    if (!InstalledApp) return FALSE;
     return InstalledApp->UninstallApplication(bModify);
 }
 


### PR DESCRIPTION
## Purpose

- When tying to modify/uninstall and empty selection, RAPPS crashes due to unhandled exception. This is due to the result of GetFocusedItemData() behind used without being checked non NULL.

![image](https://user-images.githubusercontent.com/24843587/93127489-4b956800-f6ce-11ea-99c3-9b77b8d6c8b4.png)

JIRA issue: [CORE-17279](https://jira.reactos.org/browse/CORE-17279)

## Proposed changes

- Return FALSE and do nothing (as expected) when GetFocusedItemData() is NULL.

![image](https://user-images.githubusercontent.com/24843587/93127503-54863980-f6ce-11ea-8985-3068682a86b0.png)