### PR TITLE
[RAPPS] Use `RegDeleteKeyExW` for deleting the apps strings from registry only if it is available in advapi32

### DIFF
--- a/base/applications/rapps/installed.cpp
+++ b/base/applications/rapps/installed.cpp
@@ -131,16 +131,34 @@ BOOL CInstalledApplicationInfo::UninstallApplication(BOOL bModify)
     return StartProcess(bModify ? szModifyPath : szUninstallString, TRUE);
 }
 
+typedef LSTATUS (WINAPI *RegDeleteKeyExWProc)(HKEY, LPCWSTR, REGSAM, DWORD);
+
 LSTATUS CInstalledApplicationInfo::RemoveFromRegistry()
 {
     ATL::CStringW szFullName = L"Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\" + szKeyName;
+    HMODULE hMod = GetModuleHandleW(L"advapi32.dll");
+    RegDeleteKeyExWProc pRegDeleteKeyExW;
 
-    // TODO: if there are subkeys inside, simply RegDeleteKeyExW will fail
+    // TODO: if there are subkeys inside, simply RegDeleteKeyExW
+    // (or RegDeleteKeyW on Server 2003 SP0 and earlier) will fail
     // we don't have RegDeleteTree for ReactOS now. (It's a WinVista API)
     // write a function to delete all subkeys recursively to solve this
     // or consider letting ReactOS having this API
 
-    return RegDeleteKeyExW(IsUserKey ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, szFullName, WowKey, 0);
+    /* Load RegDeleteKeyExW from advapi32.dll if available */
+    if (hMod)
+    {
+        pRegDeleteKeyExW = (RegDeleteKeyExWProc)GetProcAddress(hMod, "RegDeleteKeyExW");
+
+        if (pRegDeleteKeyExW)
+        {
+            /* Return it */
+            return pRegDeleteKeyExW(IsUserKey ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, szFullName, WowKey, 0);
+        }
+    }
+
+    /* Otherwise, return non-Ex function */
+    return RegDeleteKeyW(IsUserKey ? HKEY_CURRENT_USER : HKEY_LOCAL_MACHINE, szFullName);
 }
 
 BOOL CInstalledApps::Enum(INT EnumType, APPENUMPROC lpEnumProc, PVOID param)


### PR DESCRIPTION
## Purpose

Use `RegDeleteKeyW` function instead of `RegDeleteKeyExW` for deleting the aspplications strings from registry, if the 2nd one is not available in advapi32.dll, on Windows versions whose don't have the Ex function (XP SP3 x32, Server 2003 SP0 and earlier). So now, on XP x64/Server 2003 SP1+, it will use Ex function, and on earlier versions - non-Ex one.
It will fix a regression with Rapps startup on these systems, due to that missing function.

JIRA issue: [CORE-17264](https://jira.reactos.org/browse/CORE-17264)

## Proposed changes

- First retrieve the advapi32 handle.
- It it has been found, get the address of `RegDeleteKeyExW` function.
- If the address has been found too, call that function from advapi32.dll with all required parameters.
- Otherwise, if it has not been found, call `RegDeleteKeyW` instead.
- Add/update the comments accordingly.

## Result

Before:
![rapps_before](https://user-images.githubusercontent.com/26385117/93359771-a7d1c680-f84b-11ea-851b-73d5f4e541a4.png)

After:
![rapps_after](https://user-images.githubusercontent.com/26385117/93359873-bcae5a00-f84b-11ea-87fd-54eec37452a6.png)