### PR TITLE
[SHELL32][SHELLEXT] Fix use of SHFileOperation results and improve log on failure / fix log spam

### DIFF
--- a/dll/shellext/mydocs/CMyDocsDropHandler.cpp
+++ b/dll/shellext/mydocs/CMyDocsDropHandler.cpp
@@ -157,9 +157,12 @@ CMyDocsDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
     fileop.pFrom = pszzSrcList;
     fileop.pTo = szzDir;
     fileop.fFlags = FOF_ALLOWUNDO | FOF_FILESONLY | FOF_MULTIDESTFILES | FOF_NOCONFIRMMKDIR;
-    hr = SHFileOperationW(&fileop);
-    if (hr)
-        ERR("SHFileOperationW failed with 0x%x\n", hr);
+    int res = SHFileOperationW(&fileop);
+    if (res)
+    {
+        ERR("SHFileOperationW failed with 0x%x\n", res);
+        hr = E_FAIL;
+    }
 
     // unlock buffer
     strSrcList.ReleaseBuffer();

--- a/dll/shellext/mydocs/CMyDocsDropHandler.cpp
+++ b/dll/shellext/mydocs/CMyDocsDropHandler.cpp
@@ -158,7 +158,6 @@ CMyDocsDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
     fileop.pTo = szzDir;
     fileop.fFlags = FOF_ALLOWUNDO | FOF_FILESONLY | FOF_MULTIDESTFILES | FOF_NOCONFIRMMKDIR;
     hr = SHFileOperationW(&fileop);
-
     if (hr)
         ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
 

--- a/dll/shellext/mydocs/CMyDocsDropHandler.cpp
+++ b/dll/shellext/mydocs/CMyDocsDropHandler.cpp
@@ -157,7 +157,10 @@ CMyDocsDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
     fileop.pFrom = pszzSrcList;
     fileop.pTo = szzDir;
     fileop.fFlags = FOF_ALLOWUNDO | FOF_FILESONLY | FOF_MULTIDESTFILES | FOF_NOCONFIRMMKDIR;
-    SHFileOperationW(&fileop);
+    hr = SHFileOperationW(&fileop);
+
+    if (hr)
+        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
 
     // unlock buffer
     strSrcList.ReleaseBuffer();

--- a/dll/shellext/mydocs/CMyDocsDropHandler.cpp
+++ b/dll/shellext/mydocs/CMyDocsDropHandler.cpp
@@ -159,7 +159,7 @@ CMyDocsDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
     fileop.fFlags = FOF_ALLOWUNDO | FOF_FILESONLY | FOF_MULTIDESTFILES | FOF_NOCONFIRMMKDIR;
     hr = SHFileOperationW(&fileop);
     if (hr)
-        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", hr);
 
     // unlock buffer
     strSrcList.ReleaseBuffer();

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -211,9 +211,10 @@ HRESULT CCopyToMenu::DoRealCopy(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    if (SHFileOperationW(&op) != 0)
+    int res = SHFileOperationW(&op);
+    if (res != 0)
     {
-        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;
     }
     return S_OK;

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -211,9 +211,9 @@ HRESULT CCopyToMenu::DoRealCopy(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    if (SHFileOperation(&op) != 0)
+    if (SHFileOperationW(&op) != 0)
     {
-        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
         return E_FAIL;
     }
     return S_OK;

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -212,7 +212,7 @@ HRESULT CCopyToMenu::DoRealCopy(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
     int res = SHFileOperationW(&op);
-    if (res != 0)
+    if (res)
     {
         ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -211,7 +211,12 @@ HRESULT CCopyToMenu::DoRealCopy(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    return ((SHFileOperation(&op) == 0) ? S_OK : E_FAIL);
+    if (SHFileOperation(&op) != 0)
+    {
+        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+        return E_FAIL;
+    }
+    return S_OK;
 }
 
 CStringW CCopyToMenu::DoGetFileTitle()

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -178,9 +178,10 @@ HRESULT CMoveToMenu::DoRealMove(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    if (SHFileOperationW(&op) != 0)
+    int res = SHFileOperationW(&op);
+    if (res != 0)
     {
-        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;
     }
     return S_OK;

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -179,7 +179,7 @@ HRESULT CMoveToMenu::DoRealMove(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
     int res = SHFileOperationW(&op);
-    if (res != 0)
+    if (res)
     {
         ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -178,9 +178,9 @@ HRESULT CMoveToMenu::DoRealMove(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    if (SHFileOperation(&op) != 0)
+    if (SHFileOperationW(&op) != 0)
     {
-        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
         return E_FAIL;
     }
     return S_OK;

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -178,7 +178,12 @@ HRESULT CMoveToMenu::DoRealMove(LPCMINVOKECOMMANDINFO lpici, LPCITEMIDLIST pidl)
     op.pFrom = strFiles;
     op.pTo = szPath;
     op.fFlags = FOF_ALLOWUNDO;
-    return ((SHFileOperation(&op) == 0) ? S_OK : E_FAIL);
+    if (SHFileOperation(&op) != 0)
+    {
+        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+        return E_FAIL;
+    }
+    return S_OK;
 }
 
 CStringW CMoveToMenu::DoGetFileTitle()

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -600,9 +600,9 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                     }
 
                     hr = ppf->Save(wszTarget, FALSE);
-					if (FAILED(hr))
-						break;
-					SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszTarget, NULL);
+                    if (FAILED(hr))
+                        break;
+                    SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszTarget, NULL);
                 }
                 else
                 {
@@ -639,9 +639,9 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                         break;
 
                     hr = ppf->Save(wszTarget, TRUE);
-					if (FAILED(hr))
-						break;
-					SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszTarget, NULL);
+                    if (FAILED(hr))
+                        break;
+                    SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszTarget, NULL);
                 }
             }
         }
@@ -683,9 +683,13 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
             op.hwnd = m_hwndSite;
             op.wFunc = bCopy ? FO_COPY : FO_MOVE;
             op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMMKDIR;
-            hr = SHFileOperationW(&op);
-            if (hr)
-                ERR("SHFileOperationW failed with 0x%x\n", hr);
+            int res = SHFileOperationW(&op);
+            if (res)
+            {
+                ERR("SHFileOperationW failed with 0x%x\n", res);
+                hr = E_FAIL;
+            }
+            
             return hr;
         }
         ERR("Error calling GetData\n");

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -93,7 +93,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     if (res)
     {
-        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;
     }
     else
@@ -685,7 +685,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
             op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMMKDIR;
             hr = SHFileOperationW(&op);
             if (hr)
-                ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+                ERR("SHFileOperationW failed with 0x%x\n", hr);
             return hr;
         }
         ERR("Error calling GetData\n");

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -75,7 +75,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
         return hr;
 
     pszSrcList = BuildPathsList(strretFrom.pOleStr, cidl, apidl);
-    ERR("Source file (just the first) = %s, target path = %s, bCopy: %d\n", debugstr_w(pszSrcList), debugstr_w(m_sPathTarget), bCopy);
+    TRACE("Source file (just the first) = %s, target path = %s, bCopy: %d\n", debugstr_w(pszSrcList), debugstr_w(m_sPathTarget), bCopy);
     CoTaskMemFree(strretFrom.pOleStr);
     if (!pszSrcList)
         return E_OUTOFMEMORY;
@@ -92,7 +92,10 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
     HeapFree(GetProcessHeap(), 0, pszSrcList);
 
     if (res)
+    {
+        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
         return E_FAIL;
+    }
     else
         return S_OK;
 }

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -491,7 +491,10 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
     {
         hr = pDataObject->GetData(&fmt, &medium);
         TRACE("CFSTR_SHELLIDLIST.\n");
-
+        if (FAILED(hr))
+        {
+            ERR("CFSTR_SHELLIDLIST failed\n");
+        }
         /* lock the handle */
         LPIDA lpcida = (LPIDA)GlobalLock(medium.hGlobal);
         if (!lpcida)

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -96,8 +96,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
         ERR("SHFileOperationW failed with 0x%x\n", res);
         return E_FAIL;
     }
-    else
-        return S_OK;
+    return S_OK;
 }
 
 CFSDropTarget::CFSDropTarget():

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -93,7 +93,7 @@ HRESULT CFSDropTarget::_CopyItems(IShellFolder * pSFFrom, UINT cidl,
 
     if (res)
     {
-        ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+        ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
         return E_FAIL;
     }
     else
@@ -684,6 +684,8 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
             op.wFunc = bCopy ? FO_COPY : FO_MOVE;
             op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMMKDIR;
             hr = SHFileOperationW(&op);
+            if (hr)
+                ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
             return hr;
         }
         ERR("Error calling GetData\n");

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -59,7 +59,7 @@ class CRecyclerDropTarget :
             TRACE("Deleting file (just the first) = %s, allowundo: %d\n", debugstr_w(FileOp.pFrom), (FileOp.fFlags == FOF_ALLOWUNDO));
 
             int res = SHFileOperationW(&FileOp);
-            if (res != 0)
+            if (res)
             {
                 ERR("SHFileOperation failed with 0x%x\n", res);
                 hr = E_FAIL;

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -58,9 +58,10 @@ class CRecyclerDropTarget :
                 FileOp.fFlags = FOF_ALLOWUNDO;
             TRACE("Deleting file (just the first) = %s, allowundo: %d\n", debugstr_w(FileOp.pFrom), (FileOp.fFlags == FOF_ALLOWUNDO));
 
-            if (SHFileOperationW(&FileOp) != 0)
+            int res = SHFileOperationW(&FileOp);
+            if ( res!= 0)
             {
-                ERR("SHFileOperation failed with 0x%x\n", GetLastError());
+                ERR("SHFileOperation failed with 0x%x\n", res);
                 hr = E_FAIL;
             }
 

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -59,7 +59,7 @@ class CRecyclerDropTarget :
             TRACE("Deleting file (just the first) = %s, allowundo: %d\n", debugstr_w(FileOp.pFrom), (FileOp.fFlags == FOF_ALLOWUNDO));
 
             int res = SHFileOperationW(&FileOp);
-            if ( res!= 0)
+            if (res != 0)
             {
                 ERR("SHFileOperation failed with 0x%x\n", res);
                 hr = E_FAIL;

--- a/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
@@ -504,11 +504,11 @@ RecycleBin5_RecycleBin5_Restore(
             op.pTo = pDeletedFile->FileNameW;
 
             int res = SHFileOperationW(&op);
-            if (!res)
+            if (res)
             {
                 ERR("SHFileOperationW failed with 0x%x\n", res);
                 UnmapViewOfFile(pHeader);
-                return HRESULT_FROM_WIN32(GetLastError());
+                return E_FAIL;
             }
 
             /* Clear last entry in the file */

--- a/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
@@ -505,6 +505,7 @@ RecycleBin5_RecycleBin5_Restore(
 
             if (!SHFileOperationW(&op))
             {
+                ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
                 UnmapViewOfFile(pHeader);
                 return HRESULT_FROM_WIN32(GetLastError());
             }

--- a/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
@@ -503,9 +503,10 @@ RecycleBin5_RecycleBin5_Restore(
             op.pFrom = pDeletedFileName;
             op.pTo = pDeletedFile->FileNameW;
 
-            if (!SHFileOperationW(&op))
+            int res = SHFileOperationW(&op);
+            if (!res)
             {
-                ERR("SHFileOperationW failed with 0x%x\n", GetLastError());
+                ERR("SHFileOperationW failed with 0x%x\n", res);
                 UnmapViewOfFile(pHeader);
                 return HRESULT_FROM_WIN32(GetLastError());
             }

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1028,7 +1028,9 @@ int WINAPI SHFileOperationA(LPSHFILEOPSTRUCTA lpFileOp)
     // Call the actual function
     retCode = SHFileOperationW(&nFileOp);
     if (retCode)
+    {
         ERR("SHFileOperationW failed with 0x%x\n", retCode);
+    }
 
     // Cleanup
 cleanup:

--- a/dll/win32/shell32/shlfileop.cpp
+++ b/dll/win32/shell32/shlfileop.cpp
@@ -1027,6 +1027,8 @@ int WINAPI SHFileOperationA(LPSHFILEOPSTRUCTA lpFileOp)
 
     // Call the actual function
     retCode = SHFileOperationW(&nFileOp);
+    if (retCode)
+        ERR("SHFileOperationW failed with 0x%x\n", retCode);
 
     // Cleanup
 cleanup:


### PR DESCRIPTION
## Purpose

- We are currently not logging failures of SHFileOperation in a systematic and consistent way
- Some ERR() are unduly triggered for normal operations
- We use GetLastError() while MSDN states : "Do not use GetLastError with the return values of this function."
- Result sometime wrongly used as HRESULT

## Proposed changes

- Systematic design pattern for SHFileOperation logging
- Explicit use of SHFileOperationW
- Replace ERR() by TRACE() for normal operations
- ERR() shows return code instead of GetLastError as per MSDN
- Result never used as HRESULT