### PR TITLE
[WIN32K:ENG] EngInitializeSafeSemaphore(): Do not busy wait

### DIFF
--- a/win32ss/gdi/eng/semaphor.c
+++ b/win32ss/gdi/eng/semaphor.c
@@ -167,7 +167,10 @@ EngInitializeSafeSemaphore(
         /* Wait for the other thread to create the semaphore */
         ASSERT(Semaphore->lCount > 1);
         ASSERT_IRQL_LESS_OR_EQUAL(PASSIVE_LEVEL);
-        while (Semaphore->hsem == NULL);
+        while (Semaphore->hsem == NULL)
+        {
+            ZwYieldExecution();
+        }
     }
 
     return TRUE;


### PR DESCRIPTION
Minor improvement.