### PR TITLE
[WIN32SS] Scrollbars - Integer underflow/wraparound

### DIFF
--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -597,7 +597,8 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    if (lpsi->fMask & (SIF_RANGE | SIF_PAGE | SIF_DISABLENOSCROLL))
    {
       new_flags = Window->pSBInfo->WSBflags;
-      if (Info->nMin >= (int)(Info->nMax - max(Info->nPage - 1, 0)))
+      /* Cast Info->nPage to int to prevent wraparound/underflow. Fixes CORE-16491 */
+      if (Info->nMin >= (int)(Info->nMax - max((int)Info->nPage - 1, 0)))
       {
          /* Hide or disable scroll-bar */
          if (lpsi->fMask & SIF_DISABLENOSCROLL)


### PR DESCRIPTION
## Purpose

The Scrollinfo member nPage is an unsigned integer (UINT). 
If nPage is 0, subtracting 1 will give 4294967295. This may cause a scrollbar not to be hidden or disabled.

JIRA issue: [CORE-16491](https://jira.reactos.org/browse/CORE-16491)

## Proposed changes

- explicit cast to int in order to be robust to undeflow/wraparound
Patch proposed by "I_Kill_Bugs" in Jira