### PR TITLE
[SHELL] Fix cmd.exe "history" output (missing linefeed)

### DIFF
--- a/base/shell/cmd/history.c
+++ b/base/shell/cmd/history.c
@@ -113,7 +113,7 @@ INT CommandHistory(LPTSTR param)
     else
     {
         for (h_tmp = Top->prev; h_tmp != Bottom; h_tmp = h_tmp->prev)
-            ConErrPuts(h_tmp->string);
+            ConErrPrintf(L"%s\n", h_tmp->string);
     }
     return 0;
 }

--- a/base/shell/cmd/history.c
+++ b/base/shell/cmd/history.c
@@ -113,7 +113,7 @@ INT CommandHistory(LPTSTR param)
     else
     {
         for (h_tmp = Top->prev; h_tmp != Bottom; h_tmp = h_tmp->prev)
-            ConErrPrintf(L"%s\n", h_tmp->string);
+            ConOutPrintf(_T("%s\n"), h_tmp->string);
     }
     return 0;
 }


### PR DESCRIPTION
## Purpose

- Cmd history command output is broken (missing linefeed)

JIRA issue: [CORE-12603](https://jira.reactos.org/browse/CORE-12603)

## Proposed changes

- Add linefeed as proposed by mjw and reviewed by @HBelusca in Jira

![image](https://user-images.githubusercontent.com/24843587/93531309-4ab73d00-f93f-11ea-86ba-effc4bed3da8.png)
