### PR TITLE
[BROWSEUI_APITEST] SHExplorerParseCmdLine: /root,::{GUID}

### DIFF
--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -197,7 +197,8 @@ _Out_opt_ PUINT PWriteEnd)
                         SHGetPathFromIDListW(Info.pidl, szPath);
                         eq = ILIsEqual(Info.pidl, ExpectedPidl) || (szPath[0] && lstrcmpiW(szPath, pidlPathName) == 0);
 
-                        ok(eq, "Line %lu: Unexpected pidl value %p; pidlPathName=%S szPath=%S CSIDL=%d\n", TestLine, Info.pidl, pidlPathName, szPath, ExpectedCsidl);
+                        ok(eq, "Line %lu: Unexpected pidl value %p; pidlPathName=%S szPath=%S CSIDL=%d\n",
+                           TestLine, Info.pidl, pidlPathName, szPath, ExpectedCsidl);
 
                         ILFree(ExpectedPidl);
                     }

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -191,10 +191,15 @@ _Out_opt_ PUINT PWriteEnd)
                     ok(hr == S_OK, "Line %lu: SHGetFolderLocation returned %08lx\n", TestLine, hr);
                     if (SUCCEEDED(hr))
                     {
-                        BOOL eq = ILIsEqual(Info.pidl, ExpectedPidl);
-                        ILFree(ExpectedPidl);
+                        WCHAR szPath[MAX_PATH];
+                        BOOL eq;
 
-                        ok(eq, "Line %lu: Unexpected pidl value %p; pidlPathName=%S CSIDL=%d\n", TestLine, Info.pidl, pidlPathName, ExpectedCsidl);
+                        SHGetPathFromIDListW(Info.pidl, szPath);
+                        eq = ILIsEqual(Info.pidl, ExpectedPidl) || (szPath[0] && lstrcmpiW(szPath, pidlPathName) == 0);
+
+                        ok(eq, "Line %lu: Unexpected pidl value %p; pidlPathName=%S szPath=%S CSIDL=%d\n", TestLine, Info.pidl, pidlPathName, szPath, ExpectedCsidl);
+
+                        ILFree(ExpectedPidl);
                     }
                 }
             }
@@ -423,6 +428,8 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"/inproc,{20d04fe0-3aea-1069-a2d8-08002b30309d}", TRUE, PIDL_IS_UNTOUCHED, 0x00000400 },
         { __LINE__, L"shell:::{450D8FBA-AD25-11D0-98A8-0800361B1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000200 },
         { __LINE__, L"::{450d8fba-ad25-11d0-98a8-0800361b1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000200 },
+        { __LINE__, L"/root,shell:::{450D8FBA-AD25-11D0-98A8-0800361B1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000000 },
+        { __LINE__, L"/root,::{450d8fba-ad25-11d0-98a8-0800361b1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000000 },
     };
     const int TestCount = sizeof(Tests) / sizeof(Tests[0]);
     PWSTR CommandLine;

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -430,6 +430,8 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"::{450d8fba-ad25-11d0-98a8-0800361b1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000200 },
         { __LINE__, L"/root,shell:::{450D8FBA-AD25-11D0-98A8-0800361B1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000000 },
         { __LINE__, L"/root,::{450d8fba-ad25-11d0-98a8-0800361b1103}", TRUE, CSIDL_MYDOCUMENTS, 0x00000000 },
+        { __LINE__, L"/root,shell:::{20D04FE0-3AEA-1069-A2D8-08002B30309D}", TRUE, PIDL_IS_EMPTY, 0x00000000 },
+        { __LINE__, L"/root,::{20D04FE0-3AEA-1069-A2D8-08002B30309D}", TRUE, PIDL_IS_EMPTY, 0x00000000 },
     };
     const int TestCount = sizeof(Tests) / sizeof(Tests[0]);
     PWSTR CommandLine;


### PR DESCRIPTION
## Purpose

I want to support `explorer /root,{GUID}` command line.

JIRA issue: [CORE-16939](https://jira.reactos.org/browse/CORE-16939)

## Proposed changes

- Add tests for `/root,{GUID}`.
- Loose the test condition of path comparison.

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/93558223-e71d2600-f9b7-11ea-94e9-98ec871b758b.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/93558221-e5ebf900-f9b7-11ea-85a0-0b9a08a3f8fe.png)
Successful.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/93556127-e9c94c80-f9b2-11ea-9962-2e72185a5512.png)
Skipped.