### PR TITLE
[MORE] Implement 'Q' key for 'Quit'

### DIFF
--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -8,6 +8,7 @@
  * PROGRAMMERS:     Paolo Pantaleo
  *                  Timothy Schepens
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
+ *                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 /*
  * MORE.C - external command.
@@ -133,9 +134,20 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
      */
     ConClearLine(Pager->Screen->Stream);
 
+    /* Ctrl+C or Ctrl+Esc: Control Break */
     if ((KeyEvent.wVirtualKeyCode == VK_ESCAPE) ||
         ((KeyEvent.wVirtualKeyCode == L'C') &&
          (KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))))
+    {
+        /* We break, output a newline */
+        WCHAR ch = L'\n';
+        ConStreamWrite(Pager->Screen->Stream, &ch, 1);
+        return FALSE;
+    }
+
+    /* 'Q': Quit */
+    if ((KeyEvent.wVirtualKeyCode == L'Q') &&
+        !(KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)))
     {
         /* We break, output a newline */
         WCHAR ch = L'\n';

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -146,6 +146,7 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
     }
 
     /* 'Q': Quit */
+    // FIXME: Available only when command extensions are enabled.
     if ((KeyEvent.wVirtualKeyCode == L'Q') &&
         !(KeyEvent.dwControlKeyState & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED)))
     {


### PR DESCRIPTION
## Purpose

This PR will implement the 'Q' key on the command line tool 'MORE'.

JIRA issue: [CORE-4019](https://jira.reactos.org/browse/CORE-4019)

## Proposed changes

- Implement 'Quit' action for keyboard key 'Q'.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/93665129-1c586f80-faaf-11ea-95e8-afbf88412bb2.png)
It goes next page.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/93665126-1bbfd900-faaf-11ea-867d-545ea1ce0b07.png)
It quits.