### PR TITLE
[COMCTL32] Improve IP Address Controls (Tab and caret)

### DIFF
--- a/dll/win32/comctl32/ipaddress.c
+++ b/dll/win32/comctl32/ipaddress.c
@@ -453,6 +453,9 @@ static BOOL IPADDRESS_GotoNextField (const IPADDRESS_INFO *infoPtr, int cur, int
 		    end = -1;
 	        SendMessageW(next->EditHwnd, EM_SETSEL, start, end);
 	    }
+#ifdef __REACTOS__
+	    SetFocus(next->EditHwnd);
+#endif
 	    return TRUE;
 	}
 
@@ -563,6 +566,26 @@ IPADDRESS_SubclassProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 			return 0;
 		    }
 		    break;
+#ifdef __REACTOS__
+        case VK_TAB:
+            if (GetKeyState(VK_SHIFT) < 0)
+            {
+                /* Shift+Tab */
+                if (index == 0)
+                    SetFocus(GetNextDlgTabItem(GetParent(infoPtr->Self), infoPtr->Self, TRUE));
+                else
+                    IPADDRESS_GotoNextField(infoPtr, index - 2, POS_RIGHT);
+            }
+            else
+            {
+                /* Tab */
+                if (index == 3)
+                    SetFocus(GetNextDlgTabItem(GetParent(infoPtr->Self), infoPtr->Self, FALSE));
+                else
+                    IPADDRESS_GotoNextField(infoPtr, index, POS_SELALL);
+            }
+            break;
+#endif
 	    }
 	    break;
 	case WM_KILLFOCUS:
@@ -573,6 +596,13 @@ IPADDRESS_SubclassProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	    if (IPADDRESS_GetPartIndex(infoPtr, (HWND)wParam) < 0)
 		IPADDRESS_Notify(infoPtr, EN_SETFOCUS);
 	    break;
+#ifdef __REACTOS__
+    case WM_GETDLGCODE:
+        {
+            LRESULT ret = DefWindowProcW(hwnd, uMsg, wParam, lParam);
+            return ret | DLGC_WANTTAB;
+        }
+#endif
     }
     return CallWindowProcW (part->OrigProc, hwnd, uMsg, wParam, lParam);
 }

--- a/dll/win32/comctl32/ipaddress.c
+++ b/dll/win32/comctl32/ipaddress.c
@@ -632,6 +632,11 @@ IPADDRESS_WindowProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 	case WM_PAINT:
 	    return IPADDRESS_Paint (infoPtr, (HDC)wParam);
 
+#ifdef __REACTOS__
+    case WM_SETFOCUS:
+        SetFocus(infoPtr->Part[0].EditHwnd);
+        return 0;
+#endif
 	case WM_COMMAND:
 	    switch(wParam >> 16) {
 		case EN_CHANGE:

--- a/dll/win32/comctl32/ipaddress.c
+++ b/dll/win32/comctl32/ipaddress.c
@@ -574,7 +574,7 @@ IPADDRESS_SubclassProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 if (index == 0)
                     SetFocus(GetNextDlgTabItem(GetParent(infoPtr->Self), infoPtr->Self, TRUE));
                 else
-                    IPADDRESS_GotoNextField(infoPtr, index - 2, POS_RIGHT);
+                    IPADDRESS_GotoNextField(infoPtr, index - 2, POS_SELALL);
             }
             else
             {
@@ -634,7 +634,7 @@ IPADDRESS_WindowProc (HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 
 #ifdef __REACTOS__
     case WM_SETFOCUS:
-        SetFocus(infoPtr->Part[0].EditHwnd);
+        IPADDRESS_GotoNextField(infoPtr, -1, POS_SELALL);
         return 0;
 #endif
 	case WM_COMMAND:


### PR DESCRIPTION
## Purpose

Improve IP address controls.

JIRA issue: [CORE-3479](https://jira.reactos.org/browse/CORE-3479)

## Proposed changes

- Set focus to `EDIT` control to show caret.
- Process `WM_GETDLGCODE` messages on `EDIT` control to catch Tab key.
- Process `Tab` key and `Shift+Tab` key in processing `WM_KEYDOWN`.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/93667832-b0343680-fac3-11ea-8c3c-cbee42e70894.png)
Tab not working, Caret invisible.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/93667830-af030980-fac3-11ea-9641-f4b8286d59f4.png)
Tab working, Caret visible.