### PR TITLE
[SHLWAPI] Initial support of SHAutoComplete

### DIFF
--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -25,13 +25,13 @@ list(APPEND SOURCE
     reg.c
     regstream.c
     rosordinal.c
-    shlwapi_main.c
     stopwatch.c
     string.c
     thread.c
     url.c)
 
 list(APPEND PCH_SKIP_SOURCE
+    shlwapi_main.cpp
     autocomp.cpp
     wsprintf.c
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_stubs.c)

--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -9,8 +9,10 @@ add_definitions(
     -D_SHLWAPI_
     -D_ATL_NO_EXCEPTIONS)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
-include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/atl)
+set_cpp(WITH_RUNTIME)
+include_directories(BEFORE
+    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+    ${REACTOS_SOURCE_DIR}/sdk/lib/atl)
 spec2def(shlwapi.dll shlwapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -40,7 +42,7 @@ add_library(shlwapi MODULE
     shlwapi.rc
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi.def)
 
-set_module_type(shlwapi win32dll)
+set_module_type(shlwapi win32dll UNICODE)
 target_link_libraries(shlwapi uuid wine)
 add_delay_importlibs(shlwapi userenv oleaut32 ole32 comdlg32 mpr mlang urlmon shell32 winmm version)
 add_importlibs(shlwapi user32 gdi32 advapi32 wininet msvcrt kernel32 ntdll)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -184,13 +184,13 @@ static BOOL IsSlowDrive(LPCWSTR pszRoot)
     switch (GetDriveTypeW(pszRoot))
     {
         case DRIVE_REMOVABLE:
+            // Non-virtual floppy is slow
             ret = GetDriveFlags(pszRoot);
-            // Floppy and non-virtual is slow
             return ((ret & FILE_FLOPPY_DISKETTE) && !(ret & FILE_VIRTUAL_VOLUME));
 
         case DRIVE_CDROM:
+            // Non-virtual CD/DVD is slow
             ret = GetDriveFlags(pszRoot);
-            // CD/DVD and non-virtual is slow
             return !(ret & FILE_VIRTUAL_VOLUME);
     }
     return FALSE; // Not slow

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -32,7 +32,7 @@ public:
     CAutoCompleteEnumString(const CAutoCompleteEnumString& another);
     ~CAutoCompleteEnumString();
 
-    HRESULT AddString(LPCWSTR psz);
+    void AddString(LPCWSTR psz);
     void DoDir(LPCWSTR pszDir, BOOL bDirOnly);
     void DoDrives(BOOL bDirOnly);
     void DoURLHistory();
@@ -196,7 +196,7 @@ void CAutoCompleteEnumString::ResetContent()
     m_istr = 0;
 }
 
-HRESULT CAutoCompleteEnumString::AddString(LPCWSTR psz)
+void CAutoCompleteEnumString::AddString(LPCWSTR psz)
 {
     m_strs.Add(psz);
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -327,7 +327,7 @@ void CAutoCompleteEnumString::DoAll()
     }
 
     // Populate the items for URLs
-    if (!(m_dwSHACF & (SHACF_FILESYS_ONLY))) // Not filesystem-only
+    if (!(m_dwSHACF & SHACF_FILESYS_ONLY)) // Not filesystem-only
     {
         if (CanAddString() && (m_dwSHACF & SHACF_URLHISTORY)) // History URLs
             DoURLHistory();

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -167,7 +167,7 @@ BOOL CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
         if (attrs & FILE_ATTRIBUTE_DIRECTORY) // Is it a directory?
         {
             size_t cch = wcslen(pszQuery);
-            if (cch > 0 && pszQuery[cch - 1] == L'\\')
+            if (cch > 0 && pszQuery[cch - 1] == L'\\') // The last character is '\\'
             {
                 DoDir(pszQuery, bDirOnly); // Scan the directory
                 return FALSE; // Not exact match

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -161,16 +161,15 @@ GetDriveCharacteristics(HANDLE hDevice, ULONG *pCharacteristics)
 static DWORD GetDriveFlags(LPCWSTR pszRoot)
 {
     WCHAR szDevice[16];
-    HANDLE hDevice;
     ULONG ret = 0;
 
     StringCbCopyW(szDevice, sizeof(szDevice), L"\\\\.\\");
     szDevice[4] = pszRoot[0];
     szDevice[5] = L':';
     szDevice[6] = 0;
-    hDevice = CreateFileW(szDevice, FILE_READ_ATTRIBUTES,
-                          FILE_SHARE_READ | FILE_SHARE_WRITE,
-                          NULL, OPEN_EXISTING, 0, NULL);
+    HANDLE hDevice = CreateFileW(szDevice, FILE_READ_ATTRIBUTES,
+                                 FILE_SHARE_READ | FILE_SHARE_WRITE,
+                                 NULL, OPEN_EXISTING, 0, NULL);
     if (hDevice == INVALID_HANDLE_VALUE)
         return ret;
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -191,9 +191,6 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
         pszTypedPaths = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TypedPaths";
     WCHAR szName[32], szValue[MAX_PATH + 32], szPath[MAX_PATH];
 
-    if (!CanAddString())
-        return;
-
     size_t cch = wcslen(pszQuery); // The length of pszQuery
     if (cch >= MAX_PATH)
     {
@@ -306,9 +303,6 @@ STDMETHODIMP CAutoCompleteEnumString::Clone(IEnumString **ppenum)
 
 void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
 {
-    if (!CanAddString())
-        return;
-
     // Build a path with wildcard
     WCHAR szPath[MAX_PATH];
     StringCbCopyW(szPath, sizeof(szPath), pszDir);
@@ -362,9 +356,6 @@ void CAutoCompleteEnumString::DoURLHistory()
         pszTypedURLs = L"Software\\Microsoft\\Internet Explorer\\TypedURLs";
     WCHAR szName[32], szValue[MAX_PATH + 32];
 
-    if (!CanAddString())
-        return;
-
     // Open the registry key
     HKEY hKey;
     LONG result = RegOpenKeyExW(HKEY_CURRENT_USER, pszTypedURLs, 0, KEY_READ, &hKey);
@@ -403,9 +394,6 @@ void CAutoCompleteEnumString::DoURLMRU()
     static const LPCWSTR
         pszRunMRU = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\RunMRU";
     WCHAR szName[2], szMRUList[64], szValue[MAX_PATH + 32];
-
-    if (!CanAddString())
-        return;
 
     // Open the registry key
     HKEY hKey;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -34,12 +34,21 @@ public:
     {
     }
 
-    void AddString(LPCWSTR psz);
+    void AddString(LPCWSTR psz)
+    {
+        m_strs.Add(psz);
+    }
+
+    void ResetContent()
+    {
+        m_strs.RemoveAll();
+        m_istr = 0;
+    }
+
     void DoDir(LPCWSTR pszDir, BOOL bDirOnly);
     void DoDrives(BOOL bDirOnly);
     void DoURLHistory();
     void DoURLMRU();
-    void ResetContent();
 
     /* IEnumString interface */
     STDMETHODIMP Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched);
@@ -145,9 +154,7 @@ STDMETHODIMP CAutoCompleteEnumString::Reset()
         if (attrs != INVALID_FILE_ATTRIBUTES)
         {
             if (attrs & FILE_ATTRIBUTE_DIRECTORY)
-            {
                 DoDir(szText, bDirOnly);
-            }
         }
         else if (szText[0])
         {
@@ -163,13 +170,10 @@ STDMETHODIMP CAutoCompleteEnumString::Reset()
     if (!(dwSHACF & (SHACF_FILESYS_ONLY)))
     {
         if (dwSHACF & SHACF_URLHISTORY)
-        {
             DoURLHistory();
-        }
+
         if (dwSHACF & SHACF_URLMRU)
-        {
             DoURLMRU();
-        }
     }
 
     m_istr = 0;
@@ -186,17 +190,6 @@ STDMETHODIMP CAutoCompleteEnumString::Clone(IEnumString **ppenum)
 
     *ppenum = new CAutoCompleteEnumString(*this);
     return S_OK;
-}
-
-void CAutoCompleteEnumString::ResetContent()
-{
-    m_strs.RemoveAll();
-    m_istr = 0;
-}
-
-void CAutoCompleteEnumString::AddString(LPCWSTR psz)
-{
-    m_strs.Add(psz);
 }
 
 /* "." or ".." ? */
@@ -297,9 +290,7 @@ void CAutoCompleteEnumString::DoURLHistory()
             continue;
 
         if (UrlIsW(szValue, URLIS_URL))
-        {
             AddString(szValue);
-        }
     }
 
     RegCloseKey(hKey);
@@ -342,14 +333,10 @@ void CAutoCompleteEnumString::DoURLMRU()
 
             cch = wcslen(szValue);
             if (cch >= 2 && wcscmp(&szValue[cch - 2], L"\\1") == 0)
-            {
                 szValue[cch - 2] = 0;
-            }
 
             if (UrlIsW(szValue, URLIS_URL))
-            {
                 AddString(szValue);
-            }
         }
     }
 
@@ -413,9 +400,7 @@ AutoComplete_AdaptFlags(HWND hwndEdit, LPDWORD pdwACO, LPDWORD pdwSHACF)
         dwACO |= ACO_USETAB;
 
     if (GetWindowLongPtr(hwndEdit, GWL_EXSTYLE) & WS_EX_RTLREADING)
-    {
         dwACO |= ACO_RTLREADING;
-    }
 
     if (!(dwACO & (ACO_AUTOSUGGEST | ACO_AUTOAPPEND)))
     {
@@ -472,13 +457,9 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
 
     hr = pAC2->Init(hwndEdit, pES, NULL, L"www.%s.com");
     if (SUCCEEDED(hr))
-    {
         pAC2->SetOptions(dwACO);
-    }
     else
-    {
         ERR("IAutoComplete2::Init failed: 0x%lX\n", hr);
-    }
 
     return hr;
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -271,24 +271,15 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
 void CAutoCompleteEnumString::DoDrives(BOOL bDirOnly)
 {
     // For all the drives
-    WCHAR sz[4] = L"C:\\";
+    WCHAR szRoot[4] = L"C:\\";
     for (DWORD i = 0, dwBits = GetLogicalDrives(); i <= L'Z' - L'A'; ++i)
     {
         if ((dwBits & (1 << i)) == 0)
             continue; // The drive doesn't exist
 
-        sz[0] = (WCHAR)(L'A' + i); // Build a root path of the drive
-        if (!AddString(sz))
+        szRoot[0] = (WCHAR)(L'A' + i); // Build a root path of the drive
+        if (!AddString(szRoot))
             break;
-
-        switch (GetDriveTypeW(sz)) // Check the drive
-        {
-            case DRIVE_REMOTE: case DRIVE_RAMDISK: case DRIVE_FIXED:
-                DoDir(sz, bDirOnly);
-                break;
-            default:
-                break; // Don't scan slow drives
-        }
     }
 }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -178,7 +178,11 @@ void CAutoCompleteEnumString::DoAll()
 
     if (!IsWindow(m_hwndEdit)) // Check whether m_hwndEdit is valid
     {
-        TRACE("m_hwndEdit was invalid\n");
+        if (m_hwndEdit)
+        {
+            TRACE("m_hwndEdit was invalid\n");
+            m_hwndEdit = NULL;
+        }
         return;
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -470,7 +470,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         return E_FAIL;
     }
 
-    hr = pAC2->Init(hwndEdit, (LPUNKNOWN)pES, NULL, L"www.%s.com");
+    hr = pAC2->Init(hwndEdit, pES, NULL, L"www.%s.com");
     if (SUCCEEDED(hr))
     {
         pAC2->SetOptions(dwACO);

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -86,9 +86,7 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
         return S_FALSE;
 
     ULONG ielt;
-    for (ielt = 0;
-         ielt < celt && m_istr < m_strs.GetSize();
-         ++ielt, ++m_istr)
+    for (ielt = 0; ielt < celt && m_istr < m_strs.GetSize(); ++ielt, ++m_istr)
     {
         size_t cb = (wcslen(m_strs[m_istr]) + 1) * sizeof(WCHAR);
         rgelt[ielt] = (LPWSTR)CoTaskMemAlloc(cb);
@@ -106,7 +104,7 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
 
 STDMETHODIMP CAutoCompleteEnumString::Skip(ULONG celt)
 {
-    if (INT(m_istr + celt) >= m_strs.GetSize() || m_strs.GetSize() == 0)
+    if (m_strs.GetSize() == 0 || m_strs.GetSize() <= INT(m_istr + celt))
         return S_FALSE;
 
     m_istr += celt;
@@ -181,9 +179,7 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
     LPWSTR pch = PathFindFileNameW(szPath);
     do
     {
-        if (IS_DOTS(find.cFileName))
-            continue;
-        if (find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN)
+        if (IS_DOTS(find.cFileName) || (find.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN))
             continue;
         if (bDirOnly && !(find.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY))
             continue;
@@ -236,10 +232,7 @@ void CAutoCompleteEnumString::DoURLHistory()
 
         DWORD cbValue = sizeof(szValue), dwType;
         result = RegQueryValueExW(hKey, szName, NULL, &dwType, (LPBYTE)szValue, &cbValue);
-        if (result != ERROR_SUCCESS || dwType != REG_SZ)
-            continue;
-
-        if (UrlIsW(szValue, URLIS_URL))
+        if (result == ERROR_SUCCESS && dwType == REG_SZ && UrlIsW(szValue, URLIS_URL))
             AddString(szValue);
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -89,7 +89,6 @@ protected:
 
 void CAutoCompleteEnumString::Initialize(IAutoComplete2 *pAC2, DWORD dwSHACF, HWND hwndEdit)
 {
-    m_iItem = 0;
     m_hwndEdit = hwndEdit;
     m_dwSHACF = dwSHACF;
     Reset(); // Populate the items

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -115,8 +115,7 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
         CopyMemory(rgelt[ielt], (LPCWSTR)m_items[m_iItem], cb);
     }
     *pceltFetched = ielt; // The number of elements we got
-
-    return (ielt == celt) ? S_OK : S_FALSE;
+    return (ielt == celt) ? S_OK : S_FALSE; // Success or failure
 }
 
 STDMETHODIMP CAutoCompleteEnumString::Skip(ULONG celt)
@@ -125,7 +124,7 @@ STDMETHODIMP CAutoCompleteEnumString::Skip(ULONG celt)
         return S_FALSE; // Out of bound
 
     m_iItem += celt;
-    return S_OK;
+    return S_OK; // Success
 }
 
 void CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
@@ -168,18 +167,15 @@ void CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
     }
     else
     {
-        // Scan drives for an empty query
-        DoDrives(bDirOnly);
+        DoDrives(bDirOnly); // Scan drives
     }
 }
 
 void CAutoCompleteEnumString::DoAll()
 {
-    // Clear all the items
-    ResetContent();
+    ResetContent(); // Clear all the items
 
-    // Check whether m_hwndEdit is valid
-    if (!IsWindow(m_hwndEdit))
+    if (!IsWindow(m_hwndEdit)) // Check whether m_hwndEdit is valid
     {
         TRACE("m_hwndEdit was invalid\n");
         return;
@@ -189,16 +185,16 @@ void CAutoCompleteEnumString::DoAll()
     WCHAR szText[MAX_PATH];
     GetWindowTextW(m_hwndEdit, szText, _countof(szText));
 
-    // Populate the items
+    // Populate the items for filesystem
     if (m_dwSHACF & (SHACF_FILESYS_ONLY | SHACF_FILESYSTEM | SHACF_FILESYS_DIRS))
         DoFileSystem(szText);
 
-    if (!(m_dwSHACF & (SHACF_FILESYS_ONLY)))
+    // Populate the items for URLs
+    if (!(m_dwSHACF & (SHACF_FILESYS_ONLY))) // Not filesystem-only
     {
-        if (m_dwSHACF & SHACF_URLHISTORY)
+        if (m_dwSHACF & SHACF_URLHISTORY) // History URLs
             DoURLHistory();
-
-        if (m_dwSHACF & SHACF_URLMRU)
+        if (m_dwSHACF & SHACF_URLMRU) // Most-Recently-Used URLs
             DoURLMRU();
     }
 }
@@ -206,7 +202,7 @@ void CAutoCompleteEnumString::DoAll()
 STDMETHODIMP CAutoCompleteEnumString::Reset()
 {
     DoAll();
-    return S_OK;
+    return S_OK; // Always return S_OK
 }
 
 STDMETHODIMP CAutoCompleteEnumString::Clone(IEnumString **ppenum)
@@ -269,6 +265,7 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
 
 void CAutoCompleteEnumString::DoDrives(BOOL bDirOnly)
 {
+    // For all the drives
     WCHAR sz[4] = L"C:\\";
     for (DWORD i = 0, dwBits = GetLogicalDrives(); i <= L'Z' - L'A'; ++i)
     {
@@ -279,7 +276,7 @@ void CAutoCompleteEnumString::DoDrives(BOOL bDirOnly)
         if (!AddString(sz))
             break;
 
-        switch (GetDriveTypeW(sz))
+        switch (GetDriveTypeW(sz)) // Check the drive
         {
             case DRIVE_REMOTE: case DRIVE_RAMDISK: case DRIVE_FIXED:
                 DoDir(sz, bDirOnly);

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -102,7 +102,6 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
         return E_POINTER;
     }
 
-    // Initialize
     *pceltFetched = 0;
     *rgelt = NULL;
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -28,9 +28,12 @@ class CAutoCompleteEnumString :
     public IEnumString
 {
 public:
-    CAutoCompleteEnumString(DWORD dwSHACF, HWND hwndEdit);
+    CAutoCompleteEnumString(IAutoComplete2 *pAC2, DWORD dwSHACF, HWND hwndEdit);
     CAutoCompleteEnumString(const CAutoCompleteEnumString& another);
-    ~CAutoCompleteEnumString();
+
+    ~CAutoCompleteEnumString()
+    {
+    }
 
     void AddString(LPCWSTR psz);
     void DoDir(LPCWSTR pszDir, BOOL bDirOnly);
@@ -53,13 +56,15 @@ protected:
     INT m_istr;
     HWND m_hwndEdit;
     DWORD m_dwSHACF;
+    CComPtr<IAutoComplete2> m_pAC2;
     CSimpleArray<CStringW> m_strs;
 };
 
-CAutoCompleteEnumString::CAutoCompleteEnumString(DWORD dwSHACF, HWND hwndEdit)
+CAutoCompleteEnumString::CAutoCompleteEnumString(IAutoComplete2 *pAC2, DWORD dwSHACF, HWND hwndEdit)
     : m_istr(0)
     , m_hwndEdit(hwndEdit)
     , m_dwSHACF(dwSHACF)
+    , m_pAC2(pAC2)
 {
     Reset();
 }
@@ -68,11 +73,8 @@ CAutoCompleteEnumString::CAutoCompleteEnumString(const CAutoCompleteEnumString& 
     : m_istr(another.m_istr)
     , m_hwndEdit(another.m_hwndEdit)
     , m_dwSHACF(another.m_dwSHACF)
+    , m_pAC2(another.m_pAC2)
     , m_strs(another.m_strs)
-{
-}
-
-CAutoCompleteEnumString::~CAutoCompleteEnumString()
 {
 }
 
@@ -465,7 +467,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         return hr;
     }
 
-    pES = new CAutoCompleteEnumString(dwSHACF, hwndEdit);
+    pES = new CAutoCompleteEnumString(pAC2, dwFlags, hwndEdit);
     if (!pES)
     {
         ERR("Creating IEnumString failed.\n");

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -222,7 +222,7 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
         {
             if (!PathFileExistsW(szValue))
                 continue; // File or folder doesn't exist
-            if (!(m_dwSHACF & SHACF_FILESYS_DIRS) && !PathIsDirectoryW(szValue))
+            if ((m_dwSHACF & SHACF_FILESYS_DIRS) && !PathIsDirectoryW(szValue))
                 continue; // Directory-only and not a directory
 
             StringCbCopyW(szPath, sizeof(szPath), szValue); // Copy szValue

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -61,6 +61,7 @@ CAutoCompleteEnumString::CAutoCompleteEnumString(DWORD dwSHACF, HWND hwndEdit)
     , m_hwndEdit(hwndEdit)
     , m_dwSHACF(dwSHACF)
 {
+    Reset();
 }
 
 CAutoCompleteEnumString::CAutoCompleteEnumString(const CAutoCompleteEnumString& another)
@@ -430,18 +431,6 @@ AutoComplete_AdaptFlags(HWND hwndEdit, LPDWORD pdwACO, LPDWORD pdwSHACF)
     return TRUE;
 }
 
-static IEnumString *
-AutoComplete_CreateEnumString(IAutoComplete2 *pAC2, HWND hwndEdit, DWORD dwSHACF)
-{
-    CAutoCompleteEnumString *pEnum = new CAutoCompleteEnumString(dwSHACF, hwndEdit);
-    if (!pEnum)
-        return NULL;
-
-    IEnumString *ret = (IEnumString *)pEnum;
-    ret->Reset();
-    return ret;
-}
-
 /*************************************************************************
  *      SHAutoComplete  	[SHLWAPI.@]
  *
@@ -476,7 +465,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         return hr;
     }
 
-    pES = AutoComplete_CreateEnumString(pAC2, hwndEdit, dwFlags);
+    pES = new CAutoCompleteEnumString(dwSHACF, hwndEdit);
     if (!pES)
     {
         ERR("Creating IEnumString failed.\n");

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -212,6 +212,9 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
 
     for (DWORD i = 1; i <= MAX_ITEMS; ++i) // For all the URL entries
     {
+        if (!CanAddString())
+            break;
+
         // Build a registry value name
         StringCbPrintfW(szName, sizeof(szName), L"url%lu", i);
 
@@ -220,18 +223,17 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
         result = RegQueryValueExW(hKey, szName, NULL, &dwType, (LPBYTE)szValue, &cbValue);
         if (result == ERROR_SUCCESS && dwType == REG_SZ) // Could I read it?
         {
-            if (PathFileExistsW(szValue)) // File or folder does exist
-            {
-                if (!(m_dwSHACF & SHACF_FILESYS_DIRS) && !PathIsDirectoryW(szValue))
-                    continue; // Directory-only and not a directory
+            if (!PathFileExistsW(szValue))
+                continue; // File or folder doesn't exist
+            if (!(m_dwSHACF & SHACF_FILESYS_DIRS) && !PathIsDirectoryW(szValue))
+                continue; // Directory-only and not a directory
 
-                StringCbCopyW(szPath, sizeof(szPath), szValue); // Copy szValue
-                szPath[cch] = 0; // and truncate
-                if (_wcsicmp(pszQuery, szPath) == 0) // Matched
-                {
-                    if (!AddString(szValue))
-                        break;
-                }
+            StringCbCopyW(szPath, sizeof(szPath), szValue); // Copy szValue
+            szPath[cch] = 0; // and truncate
+            if (_wcsicmp(pszQuery, szPath) == 0) // Matched
+            {
+                if (!AddString(szValue))
+                    break;
             }
         }
     }
@@ -374,6 +376,9 @@ void CAutoCompleteEnumString::DoURLHistory()
 
     for (DWORD i = 1; i <= MAX_ITEMS; ++i) // For all the URL entries
     {
+        if (!CanAddString())
+            break;
+
         // Build a registry value name
         StringCbPrintfW(szName, sizeof(szName), L"url%lu", i);
 
@@ -422,6 +427,9 @@ void CAutoCompleteEnumString::DoURLMRU()
 
     for (DWORD i = 0; i <= L'z' - L'a' && szMRUList[i]; ++i) // for all the MRU items
     {
+        if (!CanAddString())
+            break;
+
         // Build a registry value name
         szName[0] = szMRUList[i];
         szName[1] = 0;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -292,7 +292,8 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
                 continue; // Directory-only and not a directory
 
             CStringW strPath = szValue;
-            strPath = strPath.Left(cch);
+            strPath = strPath.Left(cch); // Truncate
+
             if (_wcsicmp(pszQuery, strPath) == 0) // Matched
             {
                 if (!AddItem(szValue))
@@ -371,9 +372,8 @@ STDMETHODIMP CAutoCompleteEnumString::Clone(IEnumString **ppenum)
 
 void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
 {
-    // Add backslash
     CStringW strPath = pszDir;
-    strPath += L'\\';
+    strPath += L'\\'; // Add backslash
 
     CStringW strSpec = strPath;
     strSpec += L'*'; // Build a path with wildcard

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -31,11 +31,7 @@ class CAutoCompleteEnumString :
     public IEnumString
 {
 public:
-    CAutoCompleteEnumString()
-        : m_iItem(0)
-        , m_hwndEdit(NULL)
-        , m_dwSHACF(0)
-        , m_dwOldTicks(0)
+    CAutoCompleteEnumString() : m_iItem(0), m_hwndEdit(NULL)
     {
     }
 
@@ -358,7 +354,6 @@ STDMETHODIMP CAutoCompleteEnumString::Clone(IEnumString **ppenum)
     CAutoCompleteEnumString *pES = new CComObject<CAutoCompleteEnumString>();
     pES->AddRef();
     pES->m_iItem = m_iItem;
-    pES->m_hwndEdit = NULL;
     pES->m_dwSHACF = m_dwSHACF;
     pES->m_items = m_items;
     *ppenum = pES;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -119,11 +119,13 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
         if (!rgelt[ielt]) // Failed
         {
             ERR("Out of memory\n");
-
             // Clean up
             while (ielt-- > 0)
+            {
                 CoTaskMemFree(rgelt[ielt]);
-            return S_FALSE;
+                rgelt[ielt] = NULL;
+            }
+            return S_FALSE; // Failure
         }
         CopyMemory(rgelt[ielt], (LPCWSTR)m_items[m_iItem], cb);
     }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -19,8 +19,9 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
-#define MAX_ITEMS 50
+#define MAX_ITEMS 50 // Maximum number of items we can get
 
+// IEnumString interface for SHAutoComplete
 class CAutoCompleteEnumString :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
     public IEnumString
@@ -67,10 +68,10 @@ public:
     END_COM_MAP()
 
 protected:
-    INT m_iItem;
-    HWND m_hwndEdit;
-    DWORD m_dwSHACF;
-    CSimpleArray<CStringW> m_items;
+    INT m_iItem; // The position for Next and Skip
+    HWND m_hwndEdit; // The EDIT control
+    DWORD m_dwSHACF; // The SHACF_* flags
+    CSimpleArray<CStringW> m_items; // The items we got
 };
 
 void CAutoCompleteEnumString::Initialize(IAutoComplete2 *pAC2, DWORD dwSHACF, HWND hwndEdit)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -187,12 +187,12 @@ static BOOL IsSlowDrive(LPCWSTR pszRoot)
     {
         case DRIVE_REMOVABLE:
             ret = GetDriveFlags(pszRoot);
-            // Floppy and non-virtual
+            // Floppy and non-virtual is slow
             return ((ret & FILE_FLOPPY_DISKETTE) && !(ret & FILE_VIRTUAL_VOLUME));
 
         case DRIVE_CDROM:
             ret = GetDriveFlags(pszRoot);
-            // CD/DVD and non-virtual
+            // CD/DVD and non-virtual is slow
             return !(ret & FILE_VIRTUAL_VOLUME);
     }
     return FALSE; // Not slow

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -375,14 +375,17 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
     CStringW strPath = pszDir;
     strPath += L'\\';
 
-    // Build a path with wildcard
-    CStringW strSpec = strPath + L"\\*";
+    CStringW strSpec = strPath;
+    strSpec += L'*'; // Build a path with wildcard
 
     // Start the enumeration
     WIN32_FIND_DATAW find;
     HANDLE hFind = FindFirstFileW(strSpec, &find);
     if (hFind == INVALID_HANDLE_VALUE)
+    {
+        ERR("Not found\n");
         return;
+    }
 
     do
     {

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -20,7 +20,7 @@
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 #define MAX_ITEMS 50 // Maximum number of items we can get
-#define MAX_TICKS 800 // Wait upto 800 milliseconds
+#define MAX_TICKS 500 // We wait upto 500 milliseconds
 
 // IEnumString interface for SHAutoComplete
 class CAutoCompleteEnumString :

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -179,6 +179,9 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
         pszTypedPaths = L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\TypedPaths";
     WCHAR szName[32], szValue[MAX_PATH + 32], szPath[MAX_PATH];
 
+    if (m_items.GetSize() >= MAX_ITEMS)
+        return;
+
     size_t cch = wcslen(pszQuery); // The length of pszQuery
     if (cch >= MAX_PATH)
     {

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -257,7 +257,7 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
     size_t cch = wcslen(pszQuery); // The length of pszQuery
     if (cch == 0 || cch >= MAX_PATH)
     {
-        ERR("cch == 0 || cch >= MAX_PATH\n");
+        TRACE("cch == 0 || cch >= MAX_PATH\n");
         return;
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -188,15 +188,13 @@ static BOOL IsSlowDrive(LPCWSTR pszRoot)
     {
         case DRIVE_REMOVABLE:
             ret = GetDriveFlags(pszRoot);
-            if (!(ret & FILE_FLOPPY_DISKETTE) || (ret & FILE_VIRTUAL_VOLUME))
-                break;
-            return TRUE; // Floppy and non-virtual
+            // Floppy and non-virtual
+            return ((ret & FILE_FLOPPY_DISKETTE) && !(ret & FILE_VIRTUAL_VOLUME));
 
         case DRIVE_CDROM:
             ret = GetDriveFlags(pszRoot);
-            if (ret & FILE_VIRTUAL_VOLUME)
-                break;
-            return TRUE; // CD/DVD and non-virtual
+            // CD/DVD and non-virtual
+            return !(ret & FILE_VIRTUAL_VOLUME);
     }
     return FALSE; // Not slow
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -121,7 +121,7 @@ CAutoCompleteEnumString::Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
 
 STDMETHODIMP CAutoCompleteEnumString::Skip(ULONG celt)
 {
-    if (m_items.GetSize() <= INT(m_iItem + celt))
+    if (m_items.GetSize() < INT(m_iItem + celt))
         return S_FALSE; // Out of bound
 
     m_iItem += celt;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -42,7 +42,7 @@ public:
         if (m_items.GetSize() >= MAX_ITEMS)
             return FALSE;
         if (GetTickCount() - m_dwOldTicks >= MAX_TICKS)
-            return FALSE;
+            return FALSE; // Timeout
         return TRUE;
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -37,7 +37,7 @@ public:
 
     void Initialize(IAutoComplete2 *pAC2, DWORD dwSHACF, HWND hwndEdit);
 
-    BOOL CanAddString() const
+    BOOL CanAddItem() const
     {
         if (m_items.GetSize() >= MAX_ITEMS)
             return FALSE;
@@ -46,9 +46,9 @@ public:
         return TRUE;
     }
 
-    BOOL AddString(LPCWSTR psz)
+    BOOL AddItem(LPCWSTR psz)
     {
-        if (!CanAddString())
+        if (!CanAddItem())
             return FALSE;
         m_items.Add(psz);
         return m_items.GetSize() < MAX_ITEMS;
@@ -272,7 +272,7 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
 
     for (DWORD i = 1; i <= MAX_ITEMS; ++i) // For all the URL entries
     {
-        if (!CanAddString())
+        if (!CanAddItem())
             break;
 
         // Build a registry value name
@@ -292,7 +292,7 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
             szPath[cch] = 0; // and truncate
             if (_wcsicmp(pszQuery, szPath) == 0) // Matched
             {
-                if (!AddString(szValue))
+                if (!AddItem(szValue))
                     break;
             }
         }
@@ -322,16 +322,16 @@ void CAutoCompleteEnumString::DoAll()
     // Populate the items for filesystem and typed paths
     if (m_dwSHACF & (SHACF_FILESYS_ONLY | SHACF_FILESYSTEM | SHACF_FILESYS_DIRS))
     {
-        if (!DoFileSystem(szText) && CanAddString())
+        if (!DoFileSystem(szText) && CanAddItem())
             DoTypedPaths(szText);
     }
 
     // Populate the items for URLs
     if (!(m_dwSHACF & SHACF_FILESYS_ONLY)) // Not filesystem-only
     {
-        if (CanAddString() && (m_dwSHACF & SHACF_URLHISTORY)) // History URLs
+        if (CanAddItem() && (m_dwSHACF & SHACF_URLHISTORY)) // History URLs
             DoURLHistory();
-        if (CanAddString() && (m_dwSHACF & SHACF_URLMRU)) // Most-Recently-Used URLs
+        if (CanAddItem() && (m_dwSHACF & SHACF_URLMRU)) // Most-Recently-Used URLs
             DoURLMRU();
     }
 }
@@ -390,7 +390,7 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
         *pchFileTitle = 0; // Truncate the path
         if (PathAppendW(szPath, find.cFileName)) // Build a path
         {
-            if (!AddString(szPath))
+            if (!AddItem(szPath))
                 break;
         }
     } while (FindNextFileW(hFind, &find));
@@ -409,7 +409,7 @@ void CAutoCompleteEnumString::DoDrives(BOOL bDirOnly)
 
         szRoot[0] = (WCHAR)(L'A' + i); // Build a root path of the drive
         assert(PathIsRootW(szRoot));
-        if (!AddString(szRoot))
+        if (!AddItem(szRoot))
             break;
     }
 }
@@ -431,7 +431,7 @@ void CAutoCompleteEnumString::DoURLHistory()
 
     for (DWORD i = 1; i <= MAX_ITEMS; ++i) // For all the URL entries
     {
-        if (!CanAddString())
+        if (!CanAddItem())
             break;
 
         // Build a registry value name
@@ -444,7 +444,7 @@ void CAutoCompleteEnumString::DoURLHistory()
         {
             if (UrlIsW(szValue, URLIS_URL)) // Is it a URL?
             {
-                if (!AddString(szValue))
+                if (!AddItem(szValue))
                     break;
             }
         }
@@ -479,7 +479,7 @@ void CAutoCompleteEnumString::DoURLMRU()
 
     for (DWORD i = 0; i <= L'z' - L'a' && szMRUList[i]; ++i) // for all the MRU items
     {
-        if (!CanAddString())
+        if (!CanAddItem())
             break;
 
         // Build a registry value name
@@ -499,7 +499,7 @@ void CAutoCompleteEnumString::DoURLMRU()
 
         if (UrlIsW(szValue, URLIS_URL)) // Is it a URL?
         {
-            if (!AddString(szValue))
+            if (!AddItem(szValue))
                 break;
         }
     }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -166,9 +166,11 @@ void CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
     {
         // File or folder does exist
         if (attrs & FILE_ATTRIBUTE_DIRECTORY)
-            DoDir(pszQuery, bDirOnly); // Scan the directory
-        else
-            AddString(pszQuery); // A normal file
+        {
+            size_t cch = wcslen(pszQuery);
+            if (cch > 0 && pszQuery[cch - 1] == L'\\')
+                DoDir(pszQuery, bDirOnly); // Scan the directory
+        }
     }
     else if (pszQuery[0] && wcschr(pszQuery, L'\\') != NULL)
     {
@@ -192,9 +194,9 @@ void CAutoCompleteEnumString::DoTypedPaths(LPCWSTR pszQuery)
     WCHAR szName[32], szValue[MAX_PATH + 32], szPath[MAX_PATH];
 
     size_t cch = wcslen(pszQuery); // The length of pszQuery
-    if (cch >= MAX_PATH)
+    if (cch == 0 || cch >= MAX_PATH)
     {
-        ERR("cch >= MAX_PATH\n");
+        ERR("cch == 0 || cch >= MAX_PATH\n");
         return;
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -267,16 +267,16 @@ void CAutoCompleteEnumString::DoAll()
     // Populate the items for filesystem and typed paths
     if (m_dwSHACF & (SHACF_FILESYS_ONLY | SHACF_FILESYSTEM | SHACF_FILESYS_DIRS))
     {
-        if (!DoFileSystem(szText))
+        if (!DoFileSystem(szText) && CanAddString())
             DoTypedPaths(szText);
     }
 
     // Populate the items for URLs
     if (!(m_dwSHACF & (SHACF_FILESYS_ONLY))) // Not filesystem-only
     {
-        if (m_dwSHACF & SHACF_URLHISTORY) // History URLs
+        if (CanAddString() && (m_dwSHACF & SHACF_URLHISTORY)) // History URLs
             DoURLHistory();
-        if (m_dwSHACF & SHACF_URLMRU) // Most-Recently-Used URLs
+        if (CanAddString() && (m_dwSHACF & SHACF_URLMRU)) // Most-Recently-Used URLs
             DoURLMRU();
     }
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -152,12 +152,11 @@ GetDriveCharacteristics(HANDLE hDevice, ULONG *pCharacteristics)
     Status = NtQueryVolumeInformationFile(hDevice, &IoStatusBlock,
                                           &DeviceInfo, sizeof(DeviceInfo),
                                           FileFsDeviceInformation);
-    if (Status == NO_ERROR)
-    {
-        *pCharacteristics = DeviceInfo.Characteristics;
-        return TRUE;
-    }
-    return FALSE;
+    if (Status != NO_ERROR)
+        return FALSE;
+
+    *pCharacteristics = DeviceInfo.Characteristics;
+    return TRUE;
 }
 
 static DWORD GetDriveFlags(LPCWSTR pszRoot)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -5,7 +5,6 @@
  * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-#define COBJMACROS
 #include <windef.h>
 #include <winreg.h>
 #include <shldisp.h>

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -38,10 +38,6 @@ public:
     {
     }
 
-    ~CAutoCompleteEnumString()
-    {
-    }
-
     void AddString(LPCWSTR psz)
     {
         m_strs.Add(psz);
@@ -196,6 +192,7 @@ void CAutoCompleteEnumString::DoDir(LPCWSTR pszDir, BOOL bDirOnly)
         if (PathAppendW(szPath, find.cFileName))
             AddString(szPath);
     } while (FindNextFileW(hFind, &find));
+
     FindClose(hFind);
 }
 
@@ -209,7 +206,6 @@ void CAutoCompleteEnumString::DoDrives(BOOL bDirOnly)
 
         sz[0] = (WCHAR)(L'A' + i);
         AddString(sz);
-
         switch (GetDriveTypeW(sz))
         {
             case DRIVE_REMOTE: case DRIVE_RAMDISK: case DRIVE_FIXED:
@@ -272,7 +268,6 @@ void CAutoCompleteEnumString::DoURLMRU()
         for (DWORD i = 0; i <= L'z' - L'a' && szMRUList[i]; ++i)
         {
             szName[0] = szMRUList[i];
-
             cbValue = sizeof(szValue);
             result = RegQueryValueExW(hKey, szName, NULL, &dwType, (LPBYTE)szValue, &cbValue);
             if (result != ERROR_SUCCESS || dwType != REG_SZ)
@@ -400,6 +395,5 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         pAC2->SetOptions(dwACO);
     else
         ERR("IAutoComplete2::Init failed: 0x%lX\n", hr);
-
     return hr;
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -55,7 +55,6 @@ protected:
     INT m_istr;
     HWND m_hwndEdit;
     DWORD m_dwSHACF;
-    CComPtr<IAutoComplete2> m_pAC2;
     CSimpleArray<CStringW> m_strs;
 };
 
@@ -63,7 +62,6 @@ CAutoCompleteEnumString::CAutoCompleteEnumString(IAutoComplete2 *pAC2, DWORD dwS
     : m_istr(0)
     , m_hwndEdit(hwndEdit)
     , m_dwSHACF(dwSHACF)
-    , m_pAC2(pAC2)
 {
     Reset();
 }
@@ -72,7 +70,6 @@ CAutoCompleteEnumString::CAutoCompleteEnumString(const CAutoCompleteEnumString& 
     : m_istr(another.m_istr)
     , m_hwndEdit(another.m_hwndEdit)
     , m_dwSHACF(another.m_dwSHACF)
-    , m_pAC2(another.m_pAC2)
     , m_strs(another.m_strs)
 {
 }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -151,7 +151,7 @@ void CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
     DWORD attrs = GetFileAttributesW(pszQuery);
     if (attrs != INVALID_FILE_ATTRIBUTES) 
     {
-        // File or folder doesn't exist
+        // File or folder does exist
         if (attrs & FILE_ATTRIBUTE_DIRECTORY)
             DoDir(pszQuery, bDirOnly); // Scan the directory
         else
@@ -162,7 +162,7 @@ void CAutoCompleteEnumString::DoFileSystem(LPCWSTR pszQuery)
         // Non-existent but can be a partial path
         WCHAR szPath[MAX_PATH];
         StringCbCopyW(szPath, sizeof(szPath), pszQuery);
-        PathRemoveFileSpecW(szPath); // Remove file title part
+        PathRemoveFileSpecW(szPath); // Remove the file title part
 
         DoDir(szPath, bDirOnly); // Scan the directory
     }
@@ -205,7 +205,6 @@ void CAutoCompleteEnumString::DoAll()
 
 STDMETHODIMP CAutoCompleteEnumString::Reset()
 {
-    m_iItem = 0;
     DoAll();
     return S_OK;
 }

--- a/dll/win32/shlwapi/shlwapi_main.cpp
+++ b/dll/win32/shlwapi/shlwapi_main.cpp
@@ -3,6 +3,7 @@
  *
  *  Copyright 1998 Marcus Meissner
  *  Copyright 1998 Juergen Schmied (jsch)
+ *  Copyright 2020 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,19 +20,23 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include <stdarg.h>
-
-#include "windef.h"
-#include "winbase.h"
+#include <windef.h>
+#include <winbase.h>
 #define NO_SHLWAPI_REG
 #define NO_SHLWAPI_STREAM
-#include "shlwapi.h"
-#include "wine/debug.h"
+#include <shlwapi.h>
+#include <atlbase.h>
+#include <wine/debug.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+CComModule gModule;
+
+extern "C"
+{
 DECLSPEC_HIDDEN HINSTANCE shlwapi_hInstance = 0;
 DECLSPEC_HIDDEN DWORD SHLWAPI_ThreadRef_index = TLS_OUT_OF_INDEXES;
+}
 
 /*************************************************************************
  * SHLWAPI {SHLWAPI}
@@ -62,10 +67,12 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID fImpLoad)
             DisableThreadLibraryCalls(hinstDLL);
 	    shlwapi_hInstance = hinstDLL;
 	    SHLWAPI_ThreadRef_index = TlsAlloc();
+        //gModule.Init(ObjectMap, hinstDLL, NULL);
 	    break;
 	  case DLL_PROCESS_DETACH:
             if (fImpLoad) break;
 	    if (SHLWAPI_ThreadRef_index != TLS_OUT_OF_INDEXES) TlsFree(SHLWAPI_ThreadRef_index);
+        gModule.Term();
 	    break;
 	}
 	return TRUE;


### PR DESCRIPTION
## Purpose

Implement `shlwapi!SHAutoComplete` function.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `autocomp.cpp` and modify `CMakeLists.txt`.
- Implement `IEnumString` body for `SHAutoComplete` and use it in `SHAutoComplete`.
- Rename `shlwapi_main.c` as `shlwapi_main.cpp` and modify it to use ATL.

![after](https://user-images.githubusercontent.com/2107452/93760467-067db280-fc47-11ea-9964-5910090facf8.png)
