### PR TITLE
[IPHLPAPI] Fix for hasArp which crashes some iphlpapi tests.

### DIFF
--- a/dll/win32/iphlpapi/ifenum_reactos.c
+++ b/dll/win32/iphlpapi/ifenum_reactos.c
@@ -149,8 +149,7 @@ BOOL hasArp( HANDLE tcpFile, TDIEntityID *arp_maybe ) {
                               NULL );
     if( !NT_SUCCESS(status) ) return FALSE;
 
-    /* This was previously treated incorrectly as a single bitmapped flag.
-     * But this is not correct because AT_ARP is 0x280. */
+    /* AT_ARP corresponds to an individual TDI entity type */
     return (type == AT_ARP);
 }
 

--- a/dll/win32/iphlpapi/ifenum_reactos.c
+++ b/dll/win32/iphlpapi/ifenum_reactos.c
@@ -149,7 +149,9 @@ BOOL hasArp( HANDLE tcpFile, TDIEntityID *arp_maybe ) {
                               NULL );
     if( !NT_SUCCESS(status) ) return FALSE;
 
-    return (type & AT_ARP);
+    /* This was previously treated incorrectly as a single bitmapped flag.
+     * But this is not correct because AT_ARP is 0x280. */
+    return (type == AT_ARP);
 }
 
 static NTSTATUS getInterfaceInfoSet( HANDLE tcpFile,


### PR DESCRIPTION
## Fix hasArp function.

JIRA issue: [CORE-16513](https://jira.reactos.org/browse/CORE-16513)

## Change return value from testing on "&" to testing on "==".

_Fix iphlpapi regressiion tests which tend to cause multiple ASSERTS at present._

The comment is included to help speed the review and should be removed or updated on the commit or afterwards.