### PR TITLE
[RAPPS] Fix attempt to delete an already destroyed ImageList

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -141,8 +141,7 @@ HWND CMainToolbar::Create(HWND hwndParent)
         return FALSE;
     }
 
-    //ImageList_Destroy(SetImageList(hImageList));
-	SetImageList(hImageList);
+    SetImageList(hImageList);
 
     AddButtons(_countof(Buttons), Buttons);
 

--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -141,7 +141,8 @@ HWND CMainToolbar::Create(HWND hwndParent)
         return FALSE;
     }
 
-    ImageList_Destroy(SetImageList(hImageList));
+    //ImageList_Destroy(SetImageList(hImageList));
+	SetImageList(hImageList);
 
     AddButtons(_countof(Buttons), Buttons);
 


### PR DESCRIPTION
## Purpose

- When closing RAPPS, attempt is made to destroy ImageList that have already been destroyed. This is due to explicit call ImageList_Destroy while these ImageList are also linked to a CMainToolbar object which also tries to delete these ImageList in TOOLBAR_Destroy (inherited from comctl32 toolbar)

JIRA issue: [CORE-17295](https://jira.reactos.org/browse/CORE-17295)

## Proposed changes

- Remove unneeded calls to ImageList_Destroy