### PR TITLE
[ROSTEST] Fix copy paste bug in RtlBitmap.c

### DIFF
--- a/modules/rostests/apitests/ntdll/RtlBitmap.c
+++ b/modules/rostests/apitests/ntdll/RtlBitmap.c
@@ -307,7 +307,7 @@ Test_RtlNumberOfSetBits(void)
 
     RtlInitializeBitMap(&BitMapHeader, Buffer, 0);
     ok_int(RtlNumberOfSetBits(&BitMapHeader), 0);
-    ok_hex(Buffer[0], IsBroken ? 0x7f00ff0f : 0x7f00ff0f);
+    ok_hex(Buffer[0], IsBroken ? 0x7f00ff0f : 0xff00ff0f);
     ok_hex(Buffer[1], 0x3F303F30);
 
     FreeGuarded(Buffer);


### PR DESCRIPTION
## Purpose

- Obvious copy/paste issue

JIRA issue: [ROSTESTS-356](https://jira.reactos.org/browse/ROSTESTS-356)

## Proposed changes

- Fix copy/paste issue (similar to other test case results)