### PR TITLE
[NTDLL_APITEST] RtlBitmapApi: Fix OS version checks, and more

### DIFF
--- a/modules/rostests/apitests/ntdll/RtlBitmap.c
+++ b/modules/rostests/apitests/ntdll/RtlBitmap.c
@@ -597,8 +597,7 @@ Test_RtlFindLongestRunClear(void)
 {
 }
 
-
-START_TEST(RtlBitmap)
+START_TEST(RtlBitmapApi)
 {
     /* Windows 2003 has broken bitmap code that modifies the buffer */
     if (!IsWindows7OrGreater() && !IsReactOS())
@@ -627,4 +626,3 @@ START_TEST(RtlBitmap)
     Test_RtlFindClearRuns();
     Test_RtlFindLongestRunClear();
 }
-

--- a/modules/rostests/apitests/ntdll/RtlBitmap.c
+++ b/modules/rostests/apitests/ntdll/RtlBitmap.c
@@ -600,7 +600,7 @@ Test_RtlFindLongestRunClear(void)
 START_TEST(RtlBitmapApi)
 {
     /* Windows 2003 has broken bitmap code that modifies the buffer */
-    if (!IsWindows7OrGreater() && !IsReactOS())
+    if (!IsWindowsVistaOrGreater() && !IsReactOS())
     {
         IsBroken = TRUE;
     }

--- a/modules/rostests/apitests/ntdll/RtlBitmap.c
+++ b/modules/rostests/apitests/ntdll/RtlBitmap.c
@@ -580,21 +580,29 @@ Test_RtlFindNextForwardRunClear(void)
 void
 Test_RtlFindFirstRunClear(void)
 {
+  todo_if(TRUE)
+    ok(FALSE, "%s() is UNIMPLEMENTED\n", __FUNCTION__);
 }
 
 void
 Test_RtlFindLastBackwardRunClear(void)
 {
+  todo_if(TRUE)
+    ok(FALSE, "%s() is UNIMPLEMENTED\n", __FUNCTION__);
 }
 
 void
 Test_RtlFindClearRuns(void)
 {
+  todo_if(TRUE)
+    ok(FALSE, "%s() is UNIMPLEMENTED\n", __FUNCTION__);
 }
 
 void
 Test_RtlFindLongestRunClear(void)
 {
+  todo_if(TRUE)
+    ok(FALSE, "%s() is UNIMPLEMENTED\n", __FUNCTION__);
 }
 
 START_TEST(RtlBitmapApi)

--- a/modules/rostests/apitests/ntdll/RtlBitmap.c
+++ b/modules/rostests/apitests/ntdll/RtlBitmap.c
@@ -2,7 +2,7 @@
 #include "precomp.h"
 #include <versionhelpers.h>
 
-static BOOL IsBroken = FALSE;
+static BOOL IsBroken = FALSE, IsBrokenS2003 = FALSE;
 
 void
 Test_RtlFindMostSignificantBit(void)
@@ -335,17 +335,17 @@ Test_RtlNumberOfClearBits(void)
 
     RtlInitializeBitMap(&BitMapHeader, Buffer, 31);
     ok_int(RtlNumberOfClearBits(&BitMapHeader), 12);
-    ok_hex(Buffer[0], IsBroken ? 0x7f00fff0 : 0xff00fff0);
+    ok_hex(Buffer[0], IsBrokenS2003 ? 0x7f00fff0 : 0xff00fff0);
     ok_hex(Buffer[1], 0x3F303F30);
 
     RtlInitializeBitMap(&BitMapHeader, Buffer, 4);
     ok_int(RtlNumberOfClearBits(&BitMapHeader), 4);
-    ok_hex(Buffer[0], IsBroken ? 0x7f00ff00 : 0xff00fff0);
+    ok_hex(Buffer[0], IsBrokenS2003 ? 0x7f00ff00 : 0xff00fff0);
     ok_hex(Buffer[1], 0x3F303F30);
 
     RtlInitializeBitMap(&BitMapHeader, Buffer, 0);
     ok_int(RtlNumberOfClearBits(&BitMapHeader), 0);
-    ok_hex(Buffer[0], IsBroken ? 0x7f00ff00 : 0xff00fff0);
+    ok_hex(Buffer[0], IsBrokenS2003 ? 0x7f00ff00 : 0xff00fff0);
     ok_hex(Buffer[1], 0x3F303F30);
 
     FreeGuarded(Buffer);
@@ -599,10 +599,16 @@ Test_RtlFindLongestRunClear(void)
 
 START_TEST(RtlBitmapApi)
 {
-    /* Windows 2003 has broken bitmap code that modifies the buffer */
+    /* Windows Server 2003 has broken bitmap code that modifies the buffer.
+       Windows XP has additional failures. Too bad */
     if (!IsWindowsVistaOrGreater() && !IsReactOS())
     {
         IsBroken = TRUE;
+
+        if (IsWindowsServer2003OrGreater())
+        {
+            IsBrokenS2003 = TRUE;
+        }
     }
 
     Test_RtlFindMostSignificantBit();

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -40,7 +40,7 @@ extern void func_NtSystemInformation(void);
 extern void func_NtUnloadDriver(void);
 extern void func_NtWriteFile(void);
 extern void func_RtlAllocateHeap(void);
-extern void func_RtlBitmap(void);
+extern void func_RtlBitmapApi(void);
 extern void func_RtlComputePrivatizedDllName_U(void);
 extern void func_RtlCopyMappedMemory(void);
 extern void func_RtlDebugInformation(void);
@@ -114,7 +114,7 @@ const struct test winetest_testlist[] =
     { "NtUnloadDriver",                 func_NtUnloadDriver },
     { "NtWriteFile",                    func_NtWriteFile },
     { "RtlAllocateHeap",                func_RtlAllocateHeap },
-    { "RtlBitmapApi",                   func_RtlBitmap },
+    { "RtlBitmapApi",                   func_RtlBitmapApi },
     { "RtlComputePrivatizedDllName_U",  func_RtlComputePrivatizedDllName_U },
     { "RtlCopyMappedMemory",            func_RtlCopyMappedMemory },
     { "RtlDebugInformation",            func_RtlDebugInformation },

--- a/sdk/include/psdk/versionhelpers.h
+++ b/sdk/include/psdk/versionhelpers.h
@@ -43,85 +43,103 @@ IsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WORD wServiceP
 }
 
 VERSIONHELPERAPI
-IsWindowsXPOrGreater()
+IsWindowsXPOrGreater(void)
 {
     return IsWindowsVersionOrGreater(5, 1, 0);
 }
 
 VERSIONHELPERAPI
-IsWindowsXPSP1OrGreater()
+IsWindowsXPSP1OrGreater(void)
 {
     return IsWindowsVersionOrGreater(5, 1, 1);
 }
 
 VERSIONHELPERAPI
-IsWindowsXPSP2OrGreater()
+IsWindowsXPSP2OrGreater(void)
 {
     return IsWindowsVersionOrGreater(5, 1, 2);
 }
 
 VERSIONHELPERAPI
-IsWindowsXPSP3OrGreater()
+IsWindowsXPSP3OrGreater(void)
 {
     return IsWindowsVersionOrGreater(5, 1, 3);
 }
 
 VERSIONHELPERAPI
-IsWindowsVistaOrGreater()
+IsWindowsServer2003OrGreater(void)
+{
+    return IsWindowsVersionOrGreater(5, 2, 0);
+}
+
+VERSIONHELPERAPI
+IsWindowsServer2003SP1OrGreater(void)
+{
+    return IsWindowsVersionOrGreater(5, 2, 1);
+}
+
+VERSIONHELPERAPI
+IsWindowsServer2003SP2OrGreater(void)
+{
+    return IsWindowsVersionOrGreater(5, 2, 2);
+}
+
+VERSIONHELPERAPI
+IsWindowsVistaOrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 0, 0);
 }
 
 VERSIONHELPERAPI
-IsWindowsVistaSP1OrGreater()
+IsWindowsVistaSP1OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 0, 1);
 }
 
 VERSIONHELPERAPI
-IsWindowsVistaSP2OrGreater()
+IsWindowsVistaSP2OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 0, 2);
 }
 
 VERSIONHELPERAPI
-IsWindows7OrGreater()
+IsWindows7OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 1, 0);
 }
 
 VERSIONHELPERAPI
-IsWindows7SP1OrGreater()
+IsWindows7SP1OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 1, 1);
 }
 
 VERSIONHELPERAPI
-IsWindows8OrGreater()
+IsWindows8OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 2, 0);
 }
 
 VERSIONHELPERAPI
-IsWindows8Point1OrGreater()
+IsWindows8Point1OrGreater(void)
 {
     return IsWindowsVersionOrGreater(6, 3, 0);
 }
 
 VERSIONHELPERAPI
-IsWindowsThresholdOrGreater()
+IsWindowsThresholdOrGreater(void)
 {
     return IsWindowsVersionOrGreater(10, 0, 0);
 }
 
 VERSIONHELPERAPI
-IsWindows10OrGreater()
+IsWindows10OrGreater(void)
 {
     return IsWindowsVersionOrGreater(10, 0, 0);
 }
 
 VERSIONHELPERAPI
-IsWindowsServer()
+IsWindowsServer(void)
 {
     OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0, 0, VER_NT_WORKSTATION };
     DWORDLONG const dwlConditionMask = VerSetConditionMask(0, VER_PRODUCT_TYPE, VER_EQUAL);
@@ -129,7 +147,7 @@ IsWindowsServer()
 }
 
 VERSIONHELPERAPI
-IsActiveSessionCountLimited()
+IsActiveSessionCountLimited(void)
 {
     OSVERSIONINFOEXW osvi = { sizeof(osvi), 0, 0, 0, 0, {0}, 0, 0, 0, 0, 0 };
     DWORDLONG dwlConditionMask = VerSetConditionMask(0, VER_SUITENAME, VER_AND);
@@ -146,7 +164,7 @@ IsActiveSessionCountLimited()
 
 #ifdef __REACTOS__
 VERSIONHELPERAPI
-IsReactOS()
+IsReactOS(void)
 {
     // FIXME: Find a better method!
     WCHAR szWinDir[MAX_PATH];


### PR DESCRIPTION
Follow-up to b217d8b (#3221): additional fixes to 465745b, plus a couple related improvements to be more explicit.
Especially, fix expected results on NT6.0 and partially on NT5.1.

[WTB 79117](https://testbot.winehq.org/JobDetails.pl?Key=79117)