### PR TITLE
[PORTCLS] fixed audio stutter with rosapps AC97 driver

### DIFF
--- a/drivers/wdm/audio/backpln/portcls/pin_wavecyclic.cpp
+++ b/drivers/wdm/audio/backpln/portcls/pin_wavecyclic.cpp
@@ -1300,7 +1300,7 @@ CPortPinWaveCyclic::Init(
     m_Stream->SetState(KSSTATE_STOP);
     m_State = KSSTATE_STOP;
     m_CommonBufferOffset = 0;
-    m_CommonBufferSize = m_DmaChannel->AllocatedBufferSize();
+    m_CommonBufferSize = m_DmaChannel->BufferSize();
     m_CommonBuffer = m_DmaChannel->SystemAddress();
     m_Capture = Capture;
     // delay of 10 millisec


### PR DESCRIPTION
## Purpose
Fix stutter that occurs with waveout mode in winamp using official ac97 driver

## Proposed changes
replace call to AllocatedBufferSize(), with BufferSize()
