### PR TITLE
[SETUP] Identical expression in setup/reactos/treelist.c

### DIFF
--- a/base/setup/reactos/treelist.c
+++ b/base/setup/reactos/treelist.c
@@ -4928,7 +4928,7 @@ static int TreeListSetItem(TreeListData *pData, const TV_ITEM *pItem) {
 		}
 
 		if((uBits & TVIS_EXPANDED) && pEntry->uFirstChild) {	// Sollen Teile auf/zugeklappt werden
-			uMask		   &= TVIS_EXPANDPARTIAL | TVIS_EXPANDPARTIAL;
+			uMask		   &= TVIS_EXPANDED | TVIS_EXPANDPARTIAL;
 			pEntry->uState ^= TVIS_EXPANDED;
 			pEntry->uState ^= uBits & uMask;
 			iVal			= uMask & pItem->state;


### PR DESCRIPTION
## Purpose

- Identical expression in setup/reactos/treelist.c
uMask &= TVIS_EXPANDPARTIAL | TVIS_EXPANDPARTIAL;

JIRA issue: [CORE-16036](https://jira.reactos.org/browse/CORE-16036)

## Proposed changes

- Fix by uMask &= TVIS_EXPANDED | TVIS_EXPANDPARTIAL;
as suggested by @SergeGautherie 