### PR TITLE
[comctl32] Wrong return value for ImageList_Remove

### DIFF
--- a/dll/win32/comctl32/imagelist.c
+++ b/dll/win32/comctl32/imagelist.c
@@ -4196,7 +4196,7 @@ ImageList_Remove (HIMAGELIST himl, INT i)
 {
     IImageList2* piml = IImageList2_from_impl(himl);
     if (!piml)
-        return -1;
+        return FALSE;
 
     return (piml->lpVtbl->Remove(piml, i) == S_OK) ? TRUE : FALSE;
 }


### PR DESCRIPTION
## Purpose

- Comctl32 ImageList_Remove "ReactOS hack" returns "-1" while expected retun type is BOOL

## Proposed changes

- Replace "-1" by FALSE
No need to open a WineHQ ticket as the change is only in ReactOS section (so called "The big bad reactos image list hack!")