### PR TITLE
[OPENGL32_APITEST] Fix incorrectly failing test

### DIFF
--- a/modules/rostests/apitests/opengl32/sw_extensions.c
+++ b/modules/rostests/apitests/opengl32/sw_extensions.c
@@ -61,7 +61,7 @@ START_TEST(sw_extensions)
 
     /* Get the version */
     output = (const char*)glGetString(GL_VERSION);
-    ok(strcmp(output, "1.1.0") == 0, "Expected version 1.1.0, got \"%s\".\n", output);
+    ok(strcmp(output, "1.1") == 0, "Expected version 1.1, got \"%s\".\n", output);
 
     /* Get the extensions list */
     output = (const char*)glGetString(GL_EXTENSIONS);


### PR DESCRIPTION
```Test failed: Expected version 1.1.0, got "1.1".```
This is the same, and not something that a test should fail for. 
https://reactos.org/testman/detail.php?id=50067026&prev=0
