### PR TITLE
[SHLWAPI] 1/3-implement SHAutoComplete

### DIFF
--- a/dll/win32/shlwapi/CMakeLists.txt
+++ b/dll/win32/shlwapi/CMakeLists.txt
@@ -6,9 +6,13 @@ add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(
     -D__WINESRC__
-    -D_SHLWAPI_)
+    -D_SHLWAPI_
+    -D_ATL_NO_EXCEPTIONS)
 
-include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+set_cpp(WITH_RUNTIME)
+include_directories(BEFORE
+    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+    ${REACTOS_SOURCE_DIR}/sdk/lib/atl)
 spec2def(shlwapi.dll shlwapi.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
@@ -28,6 +32,7 @@ list(APPEND SOURCE
     url.c)
 
 list(APPEND PCH_SKIP_SOURCE
+    autocomp.cpp
     wsprintf.c
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_stubs.c)
 
@@ -37,7 +42,7 @@ add_library(shlwapi MODULE
     shlwapi.rc
     ${CMAKE_CURRENT_BINARY_DIR}/shlwapi.def)
 
-set_module_type(shlwapi win32dll)
+set_module_type(shlwapi win32dll UNICODE)
 target_link_libraries(shlwapi uuid wine)
 add_delay_importlibs(shlwapi userenv oleaut32 ole32 comdlg32 mpr mlang urlmon shell32 winmm version)
 add_importlibs(shlwapi user32 gdi32 advapi32 wininet msvcrt kernel32 ntdll)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -97,7 +97,8 @@ AutoComplete_LoadList(DWORD dwSHACF, DWORD dwACLO)
         if (SUCCEEDED(hr))
         {
             pManager->Append(pHistory); // Add to the manager
-            IUnknown_SetOptions(pHistory, dwACLO); // Set ACLO_* options
+            // Set ACLO_* options
+            IUnknown_SetOptions(pHistory, dwACLO | ACLO_CURRENTDIR | ACLO_MYCOMPUTER);
         }
         else
         {

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -31,6 +31,16 @@ IUnknown_SetOptions(IUnknown *punk, DWORD dwACLO)
     return hr;
 }
 
+static HRESULT
+AutoComplete_CreateObjectByCLSID(CComPtr<IUnknown>& punk, const CLSID& clsid)
+{
+    HRESULT hr = CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER,
+                                  IID_IUnknown, (LPVOID *)&punk);
+    if (FAILED(hr))
+        ERR("hr: 0x%08lX", hr);
+    return hr;
+}
+
 static CComPtr<IUnknown>
 AutoComplete_CreateLists(DWORD dwSHACF, DWORD dwACLO)
 {
@@ -54,48 +64,33 @@ AutoComplete_CreateLists(DWORD dwSHACF, DWORD dwACLO)
     if (dwSHACF & SHACF_URLMRU)
     {
         CComPtr<IUnknown> pACLMRU;
-        hr = CoCreateInstance(CLSID_ACLMRU, NULL, CLSCTX_INPROC_SERVER,
-                              IID_IUnknown, (LPVOID *)&pACLMRU);
+        hr = AutoComplete_CreateObjectByCLSID(pACLMRU, CLSID_ACLMRU);
         if (SUCCEEDED(hr))
         {
             pManager->Append(pACLMRU);
             IUnknown_SetOptions(pACLMRU, dwACLO);
-        }
-        else
-        {
-            ERR("hr: 0x%08lX", hr);
         }
     }
 
     if (dwSHACF & SHACF_URLHISTORY)
     {
         CComPtr<IUnknown> pACLHistory;
-        hr = CoCreateInstance(CLSID_ACLHistory, NULL, CLSCTX_INPROC_SERVER,
-                              IID_IUnknown, (LPVOID *)&pACLHistory);
+        hr = AutoComplete_CreateObjectByCLSID(pACLHistory, CLSID_ACLHistory);
         if (SUCCEEDED(hr))
         {
             pManager->Append(pACLHistory);
             IUnknown_SetOptions(pACLHistory, dwACLO);
-        }
-        else
-        {
-            ERR("hr: 0x%08lX", hr);
         }
     }
 
     if (dwSHACF & SHACF_FILESYSTEM)
     {
         CComPtr<IUnknown> pACListISF;
-        hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_INPROC_SERVER,
-                              IID_IUnknown, (LPVOID *)&pACListISF);
+        hr = AutoComplete_CreateObjectByCLSID(pACListISF, CLSID_ACListISF);
         if (SUCCEEDED(hr))
         {
             pManager->Append(pACListISF);
             IUnknown_SetOptions(pACListISF, dwACLO);
-        }
-        else
-        {
-            ERR("hr: 0x%08lX", hr);
         }
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -193,7 +193,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
     hr = E_FAIL;
     if (SHPinDllOfCLSID(CLSID_ACListISF) && SHPinDllOfCLSID(CLSID_AutoComplete))
     {
-        // Initalize the auto-completion for auto-completion
+        // Initialize IAutoComplete2 for auto-completion
         if (dwSHACF & SHACF_URLALL)
             hr = pAC2->Init(hwndEdit, pList, NULL, L"www.%s.com");
         else

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -31,14 +31,15 @@ IUnknown_SetOptions(IUnknown *punk, DWORD dwACLO)
     return hr;
 }
 
-static HRESULT
-AutoComplete_CreateObjectByCLSID(CComPtr<IUnknown>& punk, const CLSID& clsid)
+static CComPtr<IUnknown>
+ObjectFromCLSID(const CLSID& clsid)
 {
+    CComPtr<IUnknown> ret;
     HRESULT hr = CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER,
-                                  IID_IUnknown, (LPVOID *)&punk);
+                                  IID_IUnknown, (LPVOID *)&ret);
     if (FAILED(hr))
         ERR("hr: 0x%08lX", hr);
-    return hr;
+    return ret;
 }
 
 static CComPtr<IUnknown>
@@ -63,34 +64,31 @@ AutoComplete_CreateLists(DWORD dwSHACF, DWORD dwACLO)
 
     if (dwSHACF & SHACF_URLMRU)
     {
-        CComPtr<IUnknown> pACLMRU;
-        hr = AutoComplete_CreateObjectByCLSID(pACLMRU, CLSID_ACLMRU);
-        if (SUCCEEDED(hr))
+        CComPtr<IUnknown> pMRU = ObjectFromCLSID(CLSID_ACLMRU);
+        if (pMRU)
         {
-            pManager->Append(pACLMRU);
-            IUnknown_SetOptions(pACLMRU, dwACLO);
+            pManager->Append(pMRU);
+            IUnknown_SetOptions(pMRU, dwACLO);
         }
     }
 
     if (dwSHACF & SHACF_URLHISTORY)
     {
-        CComPtr<IUnknown> pACLHistory;
-        hr = AutoComplete_CreateObjectByCLSID(pACLHistory, CLSID_ACLHistory);
-        if (SUCCEEDED(hr))
+        CComPtr<IUnknown> pHistory = ObjectFromCLSID(CLSID_ACLHistory);
+        if (pHistory)
         {
-            pManager->Append(pACLHistory);
-            IUnknown_SetOptions(pACLHistory, dwACLO);
+            pManager->Append(pHistory);
+            IUnknown_SetOptions(pHistory, dwACLO);
         }
     }
 
     if (dwSHACF & SHACF_FILESYSTEM)
     {
-        CComPtr<IUnknown> pACListISF;
-        hr = AutoComplete_CreateObjectByCLSID(pACListISF, CLSID_ACListISF);
-        if (SUCCEEDED(hr))
+        CComPtr<IUnknown> pISF = ObjectFromCLSID(CLSID_ACListISF);
+        if (pISF)
         {
-            pManager->Append(pACListISF);
-            IUnknown_SetOptions(pACListISF, dwACLO);
+            pManager->Append(pISF);
+            IUnknown_SetOptions(pISF, dwACLO);
         }
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -20,7 +20,7 @@ static HRESULT
 AutoComplete_AddMRU(CComPtr<IObjMgr> pManager, LPCWSTR pszKey)
 {
     CComPtr<IACLCustomMRU> pMRU;
-    HRESULT hr = CoCreateInstance(CLSID_ACLMRU, NULL, CLSCTX_INPROC_SERVER,
+    HRESULT hr = CoCreateInstance(CLSID_ACLCustomMRU, NULL, CLSCTX_INPROC_SERVER,
                                   IID_IACLCustomMRU, (LPVOID *)&pMRU);
     if (FAILED(hr))
     {

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -158,17 +158,18 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         return hr;
     }
 
+    hr = E_FAIL;
     if (SHPinDllOfCLSID(CLSID_ACListISF) && SHPinDllOfCLSID(CLSID_AutoComplete))
     {
-        hr = pAC2->Init(hwndEdit, pList, NULL, L"www.%s.com");
+        if (dwSHACF & SHACF_URLALL)
+            hr = pAC2->Init(hwndEdit, pList, NULL, L"www.%s.com");
+        else
+            hr = pAC2->Init(hwndEdit, pList, NULL, NULL);
+
         if (SUCCEEDED(hr))
             pAC2->SetOptions(dwACO);
         else
             ERR("IAutoComplete2::Init failed: 0x%lX\n", hr);
-    }
-    else
-    {
-        hr = E_FAIL;
     }
 
     return hr;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -123,7 +123,7 @@ AutoComplete_AdaptFlags(IN HWND hwndEdit,
 
     if (!(dwSHACF & SHACF_AUTOSUGGEST_FORCE_OFF) &&
         ((dwSHACF & SHACF_AUTOSUGGEST_FORCE_ON) ||
-         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"AutoSuggest", FALSE, FALSE)))
+         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"AutoSuggest", FALSE, TRUE)))
     {
         dwACO |= ACO_AUTOSUGGEST;
     }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -108,7 +108,7 @@ AutoComplete_AdaptFlags(IN HWND hwndEdit,
                         OUT LPDWORD pdwACO,
                         OUT LPDWORD pdwACLO)
 {
-#define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Internet Explorer\\AutoComplete"
+#define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoComplete"
 
     DWORD dwSHACF = *pdwSHACF, dwACO = 0, dwACLO = 0;
     if (dwSHACF == SHACF_DEFAULT)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -96,7 +96,7 @@ AutoComplete_CreateList(DWORD dwSHACF, DWORD dwACLO)
 
 #define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoComplete"
 
-static BOOL
+static VOID
 AutoComplete_AdaptFlags(IN HWND hwndEdit,
                         IN OUT LPDWORD pdwSHACF,
                         OUT LPDWORD pdwACO,
@@ -120,9 +120,6 @@ AutoComplete_AdaptFlags(IN HWND hwndEdit,
         dwACO |= ACO_AUTOSUGGEST;
     }
 
-    if (!(dwACO & (ACO_AUTOSUGGEST | ACO_AUTOAPPEND)))
-        return FALSE;
-
     if (dwSHACF & SHACF_FILESYS_ONLY)
         dwACLO |= ACLO_FILESYSONLY;
 
@@ -138,7 +135,6 @@ AutoComplete_AdaptFlags(IN HWND hwndEdit,
     *pdwACO = dwACO;
     *pdwSHACF = dwSHACF;
     *pdwACLO = dwACLO;
-    return TRUE;
 }
 
 /*************************************************************************
@@ -159,8 +155,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
     TRACE("SHAutoComplete(%p, 0x%lX)\n", hwndEdit, dwFlags);
 
     DWORD dwACO = 0, dwACLO = 0, dwSHACF = dwFlags;
-    if (!AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF))
-        return S_OK;
+    AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF);
 
     CComPtr<IUnknown> pACL = AutoComplete_CreateList(dwSHACF, dwACLO);
     if (!pACL)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -72,9 +72,7 @@ AutoComplete_AddRunMRU(CComPtr<IACLCustomMRU> pMRU)
     for (INT i = 0; i <= L'z' - L'a' && i < strMRUList.GetLength(); ++i)
     {
         // Build a registry value name
-        WCHAR szName[2];
-        szName[0] = strMRUList[i];
-        szName[1] = 0;
+        WCHAR szName[2] = {strMRUList[i]};
 
         // Read a registry value
         result = RegQueryCStringW(key, szName, strData);

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -19,8 +19,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(shell);
 static HRESULT
 AutoComplete_AddMRU(CComPtr<IObjMgr> pManager, LPCWSTR pszKey)
 {
-    // FIXME: CLSID_ACLCustomMRU or CLSID_ACLMRU?
-    CComPtr<IACLCustomMRU> pMRU;
+    CComPtr<IACLCustomMRU> pMRU; // Create an MRU list
     HRESULT hr = CoCreateInstance(CLSID_ACLCustomMRU, NULL, CLSCTX_INPROC_SERVER,
                                   IID_IACLCustomMRU, (LPVOID *)&pMRU);
     if (FAILED(hr))

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -151,7 +151,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
 
     CComPtr<IAutoComplete2> pAC2;
     HRESULT hr = CoCreateInstance(CLSID_AutoComplete, NULL, CLSCTX_INPROC_SERVER,
-                                  IID_IAutoComplete, (LPVOID *)&pAC2);
+                                  IID_IAutoComplete2, (LPVOID *)&pAC2);
     if (FAILED(hr))
     {
         ERR("CoCreateInstance(CLSID_AutoComplete) failed: 0x%lX\n", hr);

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -157,10 +157,10 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
     DWORD dwACO = 0, dwACLO = 0, dwSHACF = dwFlags;
     AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF);
 
-    CComPtr<IUnknown> pACL = AutoComplete_CreateList(dwSHACF, dwACLO);
-    if (!pACL)
+    CComPtr<IUnknown> pList = AutoComplete_CreateList(dwSHACF, dwACLO);
+    if (!pList)
     {
-        ERR("AutoComplete_CreateList failed\n");
+        ERR("Out of memory\n");
         return E_OUTOFMEMORY;
     }
 
@@ -173,7 +173,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
         return hr;
     }
 
-    hr = pAC2->Init(hwndEdit, pACL, NULL, L"www.%s.com");
+    hr = pAC2->Init(hwndEdit, pList, NULL, L"www.%s.com");
     if (SUCCEEDED(hr))
         pAC2->SetOptions(dwACO);
     else

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -32,13 +32,16 @@ IUnknown_SetOptions(IUnknown *punk, DWORD dwACLO)
 }
 
 static CComPtr<IUnknown>
-CreateUnknownFromCLSID(const CLSID& clsid, const char *name)
+CreateUnknownFromCLSID(const CLSID& clsid, LPCSTR name)
 {
     CComPtr<IUnknown> ret;
     HRESULT hr = CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER,
                                   IID_IUnknown, (LPVOID *)&ret);
     if (FAILED(hr))
-        ERR("%s: hr: 0x%08lX", name, hr);
+    {
+        ERR("%s: hr:0x%08lX", name, hr);
+        return NULL;
+    }
     return ret;
 }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -58,7 +58,7 @@ AutoComplete_CreateList(DWORD dwSHACF, DWORD dwACLO)
     HRESULT hr = pList->QueryInterface(IID_IObjMgr, (LPVOID *)&pManager);
     if (FAILED(hr))
     {
-        ERR("IObjMgr::QueryInterface failed: 0x%08lX\n", hr);
+        ERR("pList->QueryInterface failed: 0x%08lX\n", hr);
         return NULL;
     }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -163,8 +163,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
     if (!AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF))
         return S_OK;
 
-    CComPtr<IUnknown> pACL;
-    pACL = AutoComplete_CreateList(dwSHACF, dwACLO);
+    CComPtr<IUnknown> pACL = AutoComplete_CreateList(dwSHACF, dwACLO);
     if (!pACL)
     {
         ERR("AutoComplete_CreateList failed\n");

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -84,10 +84,7 @@ AutoComplete_AddRunMRU(CComPtr<IACLCustomMRU> pMRU)
         if (cch >= 2 && wcscmp(&strData[cch - 2], L"\\1") == 0)
             strData = strData.Left(cch - 2);
 
-        if (UrlIsW(strData, URLIS_URL)) // Is it a URL?
-        {
-            pMRU->AddMRUString(strData);
-        }
+        pMRU->AddMRUString(strData);
     }
 }
 

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -32,7 +32,7 @@ IUnknown_SetOptions(IUnknown *punk, DWORD dwACLO)
 }
 
 static CComPtr<IUnknown>
-CreateUnknownFromCLSID(const CLSID& clsid, LPCSTR name)
+AutoComplete_CreateUnknownFromCLSID(const CLSID& clsid, LPCSTR name)
 {
     CComPtr<IUnknown> ret;
     HRESULT hr = CoCreateInstance(clsid, NULL, CLSCTX_INPROC_SERVER,
@@ -45,7 +45,7 @@ CreateUnknownFromCLSID(const CLSID& clsid, LPCSTR name)
     return ret;
 }
 
-#define CREATE_FROM_CLSID(name) CreateUnknownFromCLSID(name, #name)
+#define CREATE_FROM_CLSID(name) AutoComplete_CreateUnknownFromCLSID(name, #name)
 
 static CComPtr<IUnknown>
 AutoComplete_CreateList(DWORD dwSHACF, DWORD dwACLO)

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -59,7 +59,7 @@ IUnknown_SetOptions(CComPtr<IUnknown> punk, DWORD dwACLO)
 }
 
 static CComPtr<IUnknown>
-AutoComplete_LoadList(HWND hwndEdit, DWORD dwSHACF, DWORD dwACLO)
+AutoComplete_LoadList(DWORD dwSHACF, DWORD dwACLO)
 {
     // Create a multiple list (with IEnumString interface)
     CComPtr<IUnknown> pList;
@@ -127,7 +127,8 @@ AutoComplete_LoadList(HWND hwndEdit, DWORD dwSHACF, DWORD dwACLO)
 }
 
 static VOID
-AutoComplete_AdaptFlags(IN OUT LPDWORD pdwSHACF,
+AutoComplete_AdaptFlags(IN HWND hwndEdit,
+                        IN OUT LPDWORD pdwSHACF,
                         OUT LPDWORD pdwACO,
                         OUT LPDWORD pdwACLO)
 {
@@ -188,10 +189,10 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
     TRACE("SHAutoComplete(%p, 0x%lX)\n", hwndEdit, dwFlags);
 
     DWORD dwACO = 0, dwACLO = 0, dwSHACF = dwFlags;
-    AutoComplete_AdaptFlags(&dwACO, &dwACLO, &dwSHACF);
+    AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF);
 
     // Load the list (with IEnumString interface)
-    CComPtr<IUnknown> pList = AutoComplete_LoadList(hwndEdit, dwSHACF, dwACLO);
+    CComPtr<IUnknown> pList = AutoComplete_LoadList(dwSHACF, dwACLO);
     if (!pList)
     {
         ERR("Out of memory\n");

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -1,0 +1,197 @@
+/*
+ * PROJECT:     ReactOS shlwapi
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Implement SHAutoComplete
+ * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+#include <windef.h>
+#include <shlobj.h>
+#include <shldisp.h>
+#include <shlwapi.h>
+#include <atlbase.h>
+#include <atlcom.h>
+#include <wine/debug.h>
+
+WINE_DEFAULT_DEBUG_CHANNEL(shell);
+
+static HRESULT
+IUnknown_SetOptions(IUnknown *punk, DWORD dwACLO)
+{
+    CComPtr<IACList2> pAL2;
+    HRESULT hr = punk->QueryInterface(IID_IACList2, (LPVOID *)&pAL2);
+    if (FAILED(hr))
+    {
+        ERR("QueryInterface(IID_IACList2) failed: 0x%08lX\n", hr);
+        return hr;
+    }
+
+    hr = pAL2->SetOptions(dwACLO);
+    if (FAILED(hr))
+        ERR("pAL2->SetOptions failed: 0x%08lX\n", hr);
+    return hr;
+}
+
+static CComPtr<IUnknown>
+AutoComplete_CreateLists(DWORD dwSHACF, DWORD dwACLO)
+{
+    CComPtr<IUnknown> pLists;
+    HRESULT hr = CoCreateInstance(CLSID_ACLMulti, NULL, CLSCTX_INPROC_SERVER,
+                                  IID_IUnknown, (LPVOID *)&pLists);
+    if (FAILED(hr))
+    {
+        ERR("CoCreateInstance(CLSID_ACLMulti) failed: 0x%08lX\n", hr);
+        return NULL;
+    }
+
+    CComPtr<IObjMgr> pManager;
+    hr = pLists->QueryInterface(IID_IObjMgr, (LPVOID *)&pManager);
+    if (FAILED(hr))
+    {
+        ERR("IObjMgr::QueryInterface failed: 0x%08lX\n", hr);
+        return NULL;
+    }
+
+    if (dwSHACF & SHACF_URLMRU)
+    {
+        CComPtr<IUnknown> pACLMRU;
+        hr = CoCreateInstance(CLSID_ACLMRU, NULL, CLSCTX_INPROC_SERVER,
+                              IID_IUnknown, (LPVOID *)&pACLMRU);
+        if (SUCCEEDED(hr))
+        {
+            pManager->Append(pACLMRU);
+            IUnknown_SetOptions(pACLMRU, dwACLO);
+        }
+        else
+        {
+            ERR("hr: 0x%08lX", hr);
+        }
+    }
+
+    if (dwSHACF & SHACF_URLHISTORY)
+    {
+        CComPtr<IUnknown> pACLHistory;
+        hr = CoCreateInstance(CLSID_ACLHistory, NULL, CLSCTX_INPROC_SERVER,
+                              IID_IUnknown, (LPVOID *)&pACLHistory);
+        if (SUCCEEDED(hr))
+        {
+            pManager->Append(pACLHistory);
+            IUnknown_SetOptions(pACLHistory, dwACLO);
+        }
+        else
+        {
+            ERR("hr: 0x%08lX", hr);
+        }
+    }
+
+    if (dwSHACF & SHACF_FILESYSTEM)
+    {
+        CComPtr<IUnknown> pACListISF;
+        hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_INPROC_SERVER,
+                              IID_IUnknown, (LPVOID *)&pACListISF);
+        if (SUCCEEDED(hr))
+        {
+            pManager->Append(pACListISF);
+            IUnknown_SetOptions(pACListISF, dwACLO);
+        }
+        else
+        {
+            ERR("hr: 0x%08lX", hr);
+        }
+    }
+
+    return pLists;
+}
+
+static BOOL
+AutoComplete_AdaptFlags(IN HWND hwndEdit,
+                        IN OUT LPDWORD pdwSHACF,
+                        OUT LPDWORD pdwACO,
+                        OUT LPDWORD pdwACLO)
+{
+#define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Internet Explorer\\AutoComplete"
+
+    DWORD dwSHACF = *pdwSHACF, dwACO = 0, dwACLO = 0;
+    if (dwSHACF == SHACF_DEFAULT)
+        dwSHACF = SHACF_FILESYSTEM | SHACF_URLALL;
+
+    if (!(dwSHACF & SHACF_AUTOAPPEND_FORCE_OFF) &&
+        ((dwSHACF & SHACF_AUTOAPPEND_FORCE_ON) ||
+         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"Append Completion", FALSE, FALSE)))
+    {
+        dwACO |= ACO_AUTOAPPEND;
+    }
+
+    if (!(dwSHACF & SHACF_AUTOSUGGEST_FORCE_OFF) &&
+        ((dwSHACF & SHACF_AUTOSUGGEST_FORCE_ON) ||
+         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"Append AutoSuggest", FALSE, FALSE)))
+    {
+        dwACO |= ACO_AUTOSUGGEST;
+    }
+
+    if (!(dwACO & (ACO_AUTOSUGGEST | ACO_AUTOAPPEND)))
+        return FALSE;
+
+    if (dwSHACF & SHACF_FILESYS_ONLY)
+        dwACLO |= ACLO_FILESYSONLY;
+
+    if ((dwSHACF & SHACF_USETAB) ||
+        SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"Always Use Tab", FALSE, FALSE))
+    {
+        dwACO |= ACO_USETAB;
+    }
+
+    if (GetWindowLongPtrW(hwndEdit, GWL_EXSTYLE) & WS_EX_RTLREADING)
+        dwACO |= ACO_RTLREADING;
+
+    *pdwACO = dwACO;
+    *pdwSHACF = dwSHACF;
+    *pdwACLO = dwACLO;
+    return TRUE;
+}
+
+/*************************************************************************
+ *      SHAutoComplete  	[SHLWAPI.@]
+ *
+ * Enable auto-completion for an edit control.
+ *
+ * PARAMS
+ *  hwndEdit [I] Handle of control to enable auto-completion for
+ *  dwFlags  [I] SHACF_ flags from "shlwapi.h"
+ *
+ * RETURNS
+ *  Success: S_OK. Auto-completion is enabled for the control.
+ *  Failure: An HRESULT error code indicating the error.
+ */
+HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
+{
+    TRACE("SHAutoComplete(%p, 0x%lX)\n", hwndEdit, dwFlags);
+
+    DWORD dwACO = 0, dwACLO = 0, dwSHACF = dwFlags;
+    if (!AutoComplete_AdaptFlags(hwndEdit, &dwACO, &dwACLO, &dwSHACF))
+        return S_OK;
+
+    CComPtr<IUnknown> pACL;
+    pACL = AutoComplete_CreateLists(dwSHACF, dwACLO);
+    if (!pACL)
+    {
+        ERR("AutoComplete_CreateLists failed\n");
+        return E_OUTOFMEMORY;
+    }
+
+    CComPtr<IAutoComplete2> pAC2;
+    HRESULT hr = CoCreateInstance(CLSID_AutoComplete, NULL, CLSCTX_INPROC_SERVER,
+                                  IID_IAutoComplete, (LPVOID *)&pAC2);
+    if (FAILED(hr))
+    {
+        ERR("CoCreateInstance(CLSID_AutoComplete) failed: 0x%lX\n", hr);
+        return hr;
+    }
+
+    hr = pAC2->Init(hwndEdit, pACL, NULL, L"www.%s.com");
+    if (SUCCEEDED(hr))
+        pAC2->SetOptions(dwACO);
+    else
+        ERR("IAutoComplete2::Init failed: 0x%lX\n", hr);
+
+    return hr;
+}

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -44,7 +44,6 @@ AutoComplete_CreateUnknownFromCLSID(const CLSID& clsid, LPCSTR name)
     }
     return ret;
 }
-
 #define CREATE_FROM_CLSID(name) AutoComplete_CreateUnknownFromCLSID(name, #name)
 
 static CComPtr<IUnknown>
@@ -95,14 +94,14 @@ AutoComplete_CreateList(DWORD dwSHACF, DWORD dwACLO)
     return pList;
 }
 
+#define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoComplete"
+
 static BOOL
 AutoComplete_AdaptFlags(IN HWND hwndEdit,
                         IN OUT LPDWORD pdwSHACF,
                         OUT LPDWORD pdwACO,
                         OUT LPDWORD pdwACLO)
 {
-#define AUTOCOMPLETE_KEY L"Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\AutoComplete"
-
     DWORD dwSHACF = *pdwSHACF, dwACO = 0, dwACLO = 0;
     if (dwSHACF == SHACF_DEFAULT)
         dwSHACF = SHACF_FILESYSTEM | SHACF_URLALL;

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -123,7 +123,7 @@ AutoComplete_AdaptFlags(IN HWND hwndEdit,
 
     if (!(dwSHACF & SHACF_AUTOSUGGEST_FORCE_OFF) &&
         ((dwSHACF & SHACF_AUTOSUGGEST_FORCE_ON) ||
-         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"Append AutoSuggest", FALSE, FALSE)))
+         SHRegGetBoolUSValueW(AUTOCOMPLETE_KEY, L"AutoSuggest", FALSE, FALSE)))
     {
         dwACO |= ACO_AUTOSUGGEST;
     }

--- a/dll/win32/shlwapi/autocomp.cpp
+++ b/dll/win32/shlwapi/autocomp.cpp
@@ -19,6 +19,8 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
+#define MAX_ITEMS 50
+
 static LONG
 RegQueryCStringW(CRegKey& key, LPCWSTR pszValueName, CStringW& str)
 {
@@ -101,7 +103,7 @@ AutoComplete_AddTypedURLs(CComPtr<IACLCustomMRU> pMRU)
         return;
     }
 
-    for (LONG i = 0; i < 50; ++i)
+    for (LONG i = 1; i <= MAX_ITEMS; ++i)
     {
         // Build a registry value name
         WCHAR szName[32];

--- a/dll/win32/shlwapi/url.c
+++ b/dll/win32/shlwapi/url.c
@@ -2514,6 +2514,7 @@ HRESULT WINAPI UrlCreateFromPathW(LPCWSTR pszPath, LPWSTR pszUrl, LPDWORD pcchUr
     return ret;
 }
 
+#ifndef __REACTOS__
 /*************************************************************************
  *      SHAutoComplete  	[SHLWAPI.@]
  *
@@ -2532,6 +2533,7 @@ HRESULT WINAPI SHAutoComplete(HWND hwndEdit, DWORD dwFlags)
   FIXME("stub\n");
   return S_FALSE;
 }
+#endif
 
 /*************************************************************************
  *  MLBuildResURLA	[SHLWAPI.405]

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -33,6 +33,7 @@ BOOL WINAPI SHAboutInfoW(LPWSTR lpszDest, DWORD dwDestLen);
 #define SHAboutInfo SHAboutInfoA
 #endif
 
+HMODULE WINAPI SHPinDllOfCLSID(REFIID refiid);
 HRESULT WINAPI IUnknown_QueryStatus(IUnknown *lpUnknown, REFGUID pguidCmdGroup, ULONG cCmds, OLECMD *prgCmds, OLECMDTEXT* pCmdText);
 HRESULT WINAPI IUnknown_Exec(IUnknown* lpUnknown, REFGUID pguidCmdGroup, DWORD nCmdID, DWORD nCmdexecopt, VARIANT* pvaIn, VARIANT* pvaOut);
 LONG WINAPI SHSetWindowBits(HWND hwnd, INT offset, UINT wMask, UINT wFlags);


### PR DESCRIPTION
## Purpose
Retrial of #3214. Try to implment `shlwapi!SHAutoComplete` function.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Modify `CMakeLists.txt` to add and compile `autocomp.cpp`.
- Add some functions to implement `SHAutoComplete`.
- Add `shlwapi!SHPinDllOfCLSID` function prototype into `shlwapi_undoc.h`.
- Try to implement `SHAutoComplete`.