### PR TITLE
[BROWSEUI][BROWSEUI_APITEST] SHExplorerParseCmdLine(): Sync and improve

### DIFF
--- a/dll/win32/browseui/browseui.spec
+++ b/dll/win32/browseui/browseui.spec
@@ -4,7 +4,7 @@
 @ stdcall -private DllCanUnloadNow()
 105 stdcall -noname SHCreateSavedWindows()
 106 stdcall -noname SHCreateFromDesktop(ptr)
-107 stdcall -noname SHExplorerParseCmdLine(wstr)
+107 stdcall -noname SHExplorerParseCmdLine(ptr)
 @ stdcall -private DllGetClassObject(ptr ptr ptr)
 @ stdcall -private DllGetVersion(ptr)
 @ stdcall -private DllInstall(long wstr)

--- a/dll/win32/browseui/browseui.spec
+++ b/dll/win32/browseui/browseui.spec
@@ -3,7 +3,7 @@
 103 stdcall -noname SHOpenNewFrame(ptr ptr long long)
 @ stdcall -private DllCanUnloadNow()
 105 stdcall -noname SHCreateSavedWindows()
-106 stdcall -noname SHCreateFromDesktop(long)
+106 stdcall -noname SHCreateFromDesktop(ptr)
 107 stdcall -noname SHExplorerParseCmdLine(wstr)
 @ stdcall -private DllGetClassObject(ptr ptr ptr)
 @ stdcall -private DllGetVersion(ptr)

--- a/dll/win32/browseui/desktopipc.cpp
+++ b/dll/win32/browseui/desktopipc.cpp
@@ -609,7 +609,7 @@ extern "C" HRESULT WINAPI SHOpenNewFrame(LPITEMIDLIST pidl, IUnknown *paramC, lo
 * SHCreateFromDesktop			[BROWSEUI.106]
 * parameter is a FolderInfo
 */
-BOOL WINAPI SHCreateFromDesktop(ExplorerCommandLineParseResults * parseResults)
+BOOL WINAPI SHCreateFromDesktop(_In_ PEXPLORER_CMDLINE_PARSE_RESULTS parseResults)
 {
     TRACE("SHCreateFromDesktop\n");
 

--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -228,7 +228,7 @@ static LPITEMIDLIST _GetDocumentsPidl()
 extern "C"
 UINT_PTR
 WINAPI
-SHExplorerParseCmdLine(ExplorerCommandLineParseResults * pInfo)
+SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
 {
     WCHAR   strField[MAX_PATH];
     WCHAR   strDir[MAX_PATH];

--- a/dll/win32/browseui/parsecmdline.cpp
+++ b/dll/win32/browseui/parsecmdline.cpp
@@ -225,6 +225,7 @@ static LPITEMIDLIST _GetDocumentsPidl()
 /*************************************************************************
 * SHExplorerParseCmdLine		[BROWSEUI.107]
 */
+// Returns FALSE, TRUE or an address.
 extern "C"
 UINT_PTR
 WINAPI
@@ -246,7 +247,7 @@ SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo)
             PathStripToRootW(strDir);
             pInfo->pidlPath = ILCreateFromPathW(strDir);
         }
-        return (LONG_PTR)(pInfo->pidlPath);
+        return (UINT_PTR)pInfo->pidlPath;
     }
 
     PCWSTR strNextArg = _FindFirstField(strFieldArray);

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -201,19 +201,26 @@ _Out_opt_ PUINT PWriteEnd)
 
     for (i = 0; i < sizeof(Info) / sizeof(DWORD); i++)
     {
-        switch (i*4)
+        switch (i * sizeof(DWORD))
         {
-        case 0x00: // strPath
-        case 0x04: // pidlPath
-        case 0x08: // dwFlags
-        case 0x20: // pidlRoot
-        case 0x34: // guidInproc (1/4)
-        case 0x38: // guidInproc (2/4)
-        case 0x3C: // guidInproc (3/4)
-        case 0x40: // guidInproc (4/4)
-            break;
-        default:
-            ok(InfoWords[i] == 0x55555555, "Line %lu: Word 0x%02lx has been set to 0x%08lx\n", TestLine, i * 4, InfoWords[i]);
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, strPath):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, pidlPath):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, dwFlags):
+            // TODO: 'case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, nCmdShow):'?
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, pidlRoot):
+            // TODO: 'case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, clsid):'?
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, guidInproc) + (0 * sizeof(DWORD)):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, guidInproc) + (1 * sizeof(DWORD)):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, guidInproc) + (2 * sizeof(DWORD)):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, guidInproc) + (3 * sizeof(DWORD)):
+#ifdef _WIN64
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, strPath) + sizeof(DWORD):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, pidlPath) + sizeof(DWORD):
+            case FIELD_OFFSET(EXPLORER_CMDLINE_PARSE_RESULTS, pidlRoot) + sizeof(DWORD):
+#endif
+                break;
+            default:
+                ok(InfoWords[i] == 0x55555555, "Line %lu: Word 0x%02lx has been set to 0x%08lx\n", TestLine, i * sizeof(DWORD), InfoWords[i]);
         }
     }
 

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -81,7 +81,7 @@ static
 VOID
 TestCommandLine(
 _In_ ULONG TestLine,
-_In_ INT ExpectedRet,
+_In_ UINT_PTR ExpectedRet,
 _In_ INT ExpectedCsidl,
 _In_ DWORD ExpectedFlags,
 _In_ PCWSTR ExpectedFileName,
@@ -100,9 +100,13 @@ _Out_opt_ PUINT PWriteEnd)
 
     // Special case for empty cmdline: Ret is the PIDL for the selected folder.
     if (ExpectedRet == -1)
-        ok((LPITEMIDLIST) Ret == Info.pidl, "Line %lu: Ret = %x, expected %p\n", TestLine, Ret, Info.pidl);
+    {
+        ok(Ret == (UINT_PTR)Info.pidl, "Line %lu: Ret = %p, expected %p\n", TestLine, (PVOID)Ret, Info.pidl);
+    }
     else
-        ok(Ret == ExpectedRet, "Line %lu: Ret = %x, expected %08x\n", TestLine, Ret, ExpectedRet);
+    {
+        ok(Ret == ExpectedRet, "Line %lu: Ret = 0x%Ix, expected 0x%Ix\n", TestLine, Ret, ExpectedRet);
+    }
 
     if (ExpectedFileName == NULL)
         ok(Info.FileName == InvalidPointer, "Line %lu: FileName = %p\n", TestLine, Info.FileName);
@@ -262,7 +266,7 @@ START_TEST(SHExplorerParseCmdLine)
     {
         INT TestLine;
         PCWSTR CommandLine;
-        INT ExpectedRet;
+        UINT_PTR ExpectedRet;
         INT ExpectedCsidl;
         DWORD ExpectedFlags;
         PCWSTR ExpectedFileName;
@@ -309,8 +313,8 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"\"c:\\\" program files", TRUE, PIDL_IS_NULL, 0x02000000, L"c:\\ program files"},
         { __LINE__, L"\"c:\\\", \"c:\\program files\"", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
         { __LINE__, L"c:\\,c:\\program files", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
-        { __LINE__, L"/root", 0, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"\"/root\"", 0, CSIDL_MYDOCUMENTS, 0x00000000},
+        { __LINE__, L"/root", FALSE, CSIDL_MYDOCUMENTS, 0x00000000},
+        { __LINE__, L"\"/root\"", FALSE, CSIDL_MYDOCUMENTS, 0x00000000},
         { __LINE__, L"/root,", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
         { __LINE__, L"/root,c", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
         { __LINE__, L"/root,\"\"", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},

--- a/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
+++ b/modules/rostests/apitests/browseui/SHExplorerParseCmdLine.c
@@ -103,7 +103,8 @@ _Out_opt_ PUINT PWriteEnd)
     }
     else
     {
-        ok(Info.strPath != NULL && Info.strPath != InvalidPointer, "Line %lu: strPath = %p\n", TestLine, Info.strPath);
+        ok(Info.strPath != InvalidPointer, "Line %lu: strPath = InvalidPointer\n", TestLine);
+        ok(Info.strPath != NULL, "Line %lu: strPath = NULL\n", TestLine);
         if (Info.strPath != NULL && Info.strPath != InvalidPointer)
         {
             ok(!wcscmp(Info.strPath, ExpectedFileName), "Line %lu: strPath = %ls, expected %ls\n", TestLine, Info.strPath, ExpectedFileName);
@@ -126,7 +127,8 @@ _Out_opt_ PUINT PWriteEnd)
         PIDLIST_ABSOLUTE ExpectedPidl;
         HRESULT hr;
 
-        ok(Info.pidlPath != NULL, "Line %lu: pidlPath = %p\n", TestLine, Info.pidlPath);
+        ok(Info.pidlPath != InvalidPointer, "Line %lu: pidlPath = InvalidPointer\n", TestLine);
+        ok(Info.pidlPath != NULL, "Line %lu: pidlPath = NULL\n", TestLine);
         if (Info.pidlPath != NULL && Info.pidlPath != InvalidPointer)
         {
             WCHAR pidlPathName[MAX_PATH] = L"";
@@ -311,17 +313,17 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"\"c:\\\" program files", TRUE, PIDL_IS_NULL, 0x02000000, L"c:\\ program files"},
         { __LINE__, L"\"c:\\\", \"c:\\program files\"", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
         { __LINE__, L"c:\\,c:\\program files", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
-        { __LINE__, L"/root", FALSE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"\"/root\"", FALSE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"/root,", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"/root,c", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"/root,\"\"", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"/root,wrong", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
-        { __LINE__, L"/root,0", TRUE, CSIDL_MYDOCUMENTS, 0x00000000},
+        { __LINE__, L"/root", FALSE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"\"/root\"", FALSE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"/root,", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"/root,c", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"/root,\"\"", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"/root,wrong", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
+        { __LINE__, L"/root,0", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
         { __LINE__, L"/root,c:\\", TRUE, PIDL_PATH_EQUALS_PATH, 0x00000000, NULL, L"c:\\" },
         { __LINE__, L"/root,\"c:\\\"", TRUE, PIDL_PATH_EQUALS_PATH, 0x00000000, NULL, L"c:\\" },
         { __LINE__, L"/root \"c:\\\"", TRUE, PIDL_IS_NULL, 0x02000000, L"/root c:\\"},
-        { __LINE__, L"/root,\"c:\\\"\"program files\"", TRUE, PIDL_IS_PATH, 0x00000000},
+        { __LINE__, L"/root,\"c:\\\"\"program files\"", TRUE, PIDL_IS_UNTOUCHED, 0x00000000 },
         { __LINE__, L"/root,\"c:\\\"program files", TRUE, PIDL_PATH_EQUALS_PATH, 0x00000000, NULL, L"c:\\Program Files" },
         { __LINE__, L"/root,c:\\,c:\\Program Files", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\Program Files" },
         { __LINE__, L"/root,c:\\,Program Files", TRUE, PIDL_IS_NULL, 0x02000000, L"Program Files"},
@@ -330,7 +332,7 @@ START_TEST(SHExplorerParseCmdLine)
 //        { __LINE__, L"a:\\,/root,c:\\", TRUE, PIDL_PATH_EQUALS_PATH, 0x00000200, NULL, L"c:\\" },
 //        { __LINE__, L"a:\\,/root,c", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"A:\\" },
         { __LINE__, L"c:\\,/root,c", TRUE, PIDL_IS_PATH, 0x00000200, NULL, L"C:\\" },
-        { __LINE__, L"/select", TRUE, CSIDL_MYDOCUMENTS, 0x00000040},
+        { __LINE__, L"/select", TRUE, PIDL_IS_UNTOUCHED, 0x00000040 },
         { __LINE__, L"/select,", TRUE, CSIDL_DRIVES, 0x00000240 },
         { __LINE__, L"/select,c", TRUE, PIDL_IS_NULL, 0x02000040, L"c"},
         { __LINE__, L"/select,0", TRUE, PIDL_IS_NULL, 0x02000040, L"0"},
@@ -347,7 +349,7 @@ START_TEST(SHExplorerParseCmdLine)
 //        { __LINE__, L"a:\\,/select,c:\\", TRUE, PIDL_IS_PATH, 0x00000240, NULL, L"C:\\" },
         { __LINE__, L"a:\\,/select,c", TRUE, PIDL_IS_NULL, 0x02000040, L"c"},
         { __LINE__, L"c:\\,/select,c", TRUE, PIDL_IS_NULL, 0x02000240, L"c"},
-        { __LINE__, L"/e", TRUE, CSIDL_MYDOCUMENTS, 0x00000008},
+        { __LINE__, L"/e", TRUE, PIDL_IS_UNTOUCHED, 0x00000008 },
         { __LINE__, L"/e,", TRUE, CSIDL_DRIVES, 0x00000208 },
         { __LINE__, L"/e,\"", TRUE, CSIDL_DRIVES, 0x00000208 },
         { __LINE__, L"/e,\"\"", TRUE, CSIDL_DRIVES, 0x00000208 },
@@ -367,7 +369,7 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"http:\\\\www.reactos.org", TRUE, PIDL_IS_NULL, 0x02000000, L"http:\\\\www.reactos.org"},
         { __LINE__, L"/e,http:\\\\www.reactos.org", TRUE, PIDL_IS_NULL, 0x02000008, L"http:\\\\www.reactos.org"},
         { __LINE__, L"/root,c:\\,http:\\\\www.reactos.org", TRUE, PIDL_IS_NULL, 0x02000000, L"http:\\\\www.reactos.org"},
-        { __LINE__, L"/separate ", TRUE, CSIDL_MYDOCUMENTS, 0x00020000},
+        { __LINE__, L"/separate ", TRUE, PIDL_IS_UNTOUCHED, 0x00020000 },
         { __LINE__, L"/separate,c:\\ program files", TRUE, PIDL_IS_NULL, 0x02020000, L"c:\\ program files"},
         { __LINE__, L"/separate,           c:\\program files", TRUE, PIDL_IS_PATH, 0x00020200, NULL, L"C:\\Program Files" },
         { __LINE__, L"/separate,           c:\\program files           ,/e", TRUE, PIDL_IS_PATH, 0x00020208, NULL, L"C:\\Program Files" },
@@ -413,10 +415,10 @@ START_TEST(SHExplorerParseCmdLine)
         { __LINE__, L"\"\"\"", TRUE, PIDL_IS_NULL, 0x02000000, L"\""},
         { __LINE__, L"\"\"\"\"", TRUE, PIDL_IS_NULL, 0x02000000, L"\""},
         { __LINE__, L"\"\"\"\"\"", TRUE, PIDL_IS_NULL, 0x02000000, L"\"\""},
-        { __LINE__, L"/s", TRUE, CSIDL_MYDOCUMENTS, 0x00000002},
-        { __LINE__, L"/noui", TRUE, CSIDL_MYDOCUMENTS, 0x00001000},
+        { __LINE__, L"/s", TRUE, PIDL_IS_UNTOUCHED, 0x00000002 },
+        { __LINE__, L"/noui", TRUE, PIDL_IS_UNTOUCHED, 0x00001000 },
         { __LINE__, L"/idlist", TRUE, PIDL_IS_UNTOUCHED, 0x00000000},
-        { __LINE__, L"-embedding", TRUE, CSIDL_MYDOCUMENTS, 0x00000080 },
+        { __LINE__, L"-embedding", TRUE, PIDL_IS_UNTOUCHED, 0x00000080 },
         { __LINE__, L"/inproc", FALSE, PIDL_IS_UNTOUCHED, 0x00000000 },
         { __LINE__, L"/inproc,1", FALSE, PIDL_IS_UNTOUCHED, 0x00000000 },
         { __LINE__, L"/inproc,a", FALSE, PIDL_IS_UNTOUCHED, 0x00000000 },

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -98,16 +98,19 @@ typedef struct IEThreadParamBlock
 typedef struct ExplorerCommandLineParseResults
 {
     LPWSTR                  strPath;
+    // TODO: PIDLIST_ABSOLUTE?
     LPITEMIDLIST            pidlPath;
     DWORD                   dwFlags;
     int                     nCmdShow;
-    DWORD                           offset10;
-    DWORD                           offset14;
-    DWORD                           offset18;
-    DWORD                           offset1C;
+    DWORD                   offset10_18;
+    DWORD                   offset14_1C;
+    DWORD                   offset18_20;
+    DWORD                   offset1C_24;
+    // TODO: PIDLIST_ABSOLUTE?
     LPITEMIDLIST            pidlRoot;
     CLSID                   clsid;
     GUID                    guidInproc;
+    // TODO: 'ULONG                   Padding[0x100];'?
 } EXPLORER_CMDLINE_PARSE_RESULTS, *PEXPLORER_CMDLINE_PARSE_RESULTS;
 
 #define SH_EXPLORER_CMDLINE_FLAG_ONE      0x00000001

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -143,7 +143,7 @@ typedef struct ExplorerCommandLineParseResults
 void WINAPI InitOCHostClass(long param8);
 long WINAPI SHOpenFolderWindow(PIE_THREAD_PARAM_BLOCK parameters);
 void WINAPI SHCreateSavedWindows(void);
-BOOL WINAPI SHCreateFromDesktop(PEXPLORER_CMDLINE_PARSE_RESULTS parseResults);
+BOOL WINAPI SHCreateFromDesktop(_In_ PEXPLORER_CMDLINE_PARSE_RESULTS parseResults);
 UINT_PTR WINAPI SHExplorerParseCmdLine(PEXPLORER_CMDLINE_PARSE_RESULTS pParseResults);
 void WINAPI UEMRegisterNotify(long param8, long paramC);
 HRESULT WINAPI SHCreateBandForPidl(LPCITEMIDLIST param8, IUnknown *paramC, BOOL param10);

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -144,7 +144,7 @@ void WINAPI InitOCHostClass(long param8);
 long WINAPI SHOpenFolderWindow(PIE_THREAD_PARAM_BLOCK parameters);
 void WINAPI SHCreateSavedWindows(void);
 BOOL WINAPI SHCreateFromDesktop(_In_ PEXPLORER_CMDLINE_PARSE_RESULTS parseResults);
-UINT_PTR WINAPI SHExplorerParseCmdLine(PEXPLORER_CMDLINE_PARSE_RESULTS pParseResults);
+UINT_PTR WINAPI SHExplorerParseCmdLine(_Out_ PEXPLORER_CMDLINE_PARSE_RESULTS pInfo);
 void WINAPI UEMRegisterNotify(long param8, long paramC);
 HRESULT WINAPI SHCreateBandForPidl(LPCITEMIDLIST param8, IUnknown *paramC, BOOL param10);
 HRESULT WINAPI SHPidlFromDataObject(IDataObject *param8, long *paramC, long param10, FILEDESCRIPTORW *param14);


### PR DESCRIPTION
NB:
Major drop in executed checks, simply as `Padding` is commented out.

JIRA issue: [ROSTESTS-302](https://jira.reactos.org/browse/ROSTESTS-302)

Cc @katahiromz