### PR TITLE
[COMDLG32] Support shortcut keys on Open/Save Dialog

### DIFF
--- a/dll/win32/comdlg32/cdlg.h
+++ b/dll/win32/comdlg32/cdlg.h
@@ -27,6 +27,9 @@
 #define COMDLG32_Atom   MAKEINTATOM(0xa000)     /* MS uses this one to identify props */
 
 extern HINSTANCE	COMDLG32_hInstance DECLSPEC_HIDDEN;
+#ifdef __REACTOS__
+extern CRITICAL_SECTION COMDLG32_OpenFileLock DECLSPEC_HIDDEN;
+#endif
 
 void	COMDLG32_SetCommDlgExtendedError(DWORD err) DECLSPEC_HIDDEN;
 LPVOID	COMDLG32_AllocMem(int size) __WINE_ALLOC_SIZE(1) DECLSPEC_HIDDEN;

--- a/dll/win32/comdlg32/cdlg32.c
+++ b/dll/win32/comdlg32/cdlg32.c
@@ -80,7 +80,7 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD Reason, LPVOID Reserved)
 
 		SHELL32_hInstance = GetModuleHandleA("SHELL32.DLL");
 #ifdef __REACTOS__
-        InitializeCriticalSection(&COMDLG32_OpenFileLock);
+		InitializeCriticalSection(&COMDLG32_OpenFileLock);
 #endif
 
 		/* SHELL */

--- a/dll/win32/comdlg32/cdlg32.c
+++ b/dll/win32/comdlg32/cdlg32.c
@@ -40,6 +40,9 @@ WINE_DEFAULT_DEBUG_CHANNEL(commdlg);
 
 
 DECLSPEC_HIDDEN HINSTANCE	COMDLG32_hInstance = 0;
+#ifdef __REACTOS__
+CRITICAL_SECTION COMDLG32_OpenFileLock DECLSPEC_HIDDEN;
+#endif
 
 static DWORD COMDLG32_TlsIndex = TLS_OUT_OF_INDEXES;
 
@@ -76,6 +79,9 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD Reason, LPVOID Reserved)
 		DisableThreadLibraryCalls(hInstance);
 
 		SHELL32_hInstance = GetModuleHandleA("SHELL32.DLL");
+#ifdef __REACTOS__
+        InitializeCriticalSection(&COMDLG32_OpenFileLock);
+#endif
 
 		/* SHELL */
 		GPA(COMDLG32_SHSimpleIDListFromPathAW, SHELL32_hInstance, (LPCSTR)162);
@@ -84,6 +90,9 @@ BOOL WINAPI DllMain(HINSTANCE hInstance, DWORD Reason, LPVOID Reserved)
 	case DLL_PROCESS_DETACH:
             if (Reserved) break;
             if (COMDLG32_TlsIndex != TLS_OUT_OF_INDEXES) TlsFree(COMDLG32_TlsIndex);
+#ifdef __REACTOS__
+            DeleteCriticalSection(&COMDLG32_OpenFileLock);
+#endif
             break;
 	}
 	return TRUE;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -114,8 +114,8 @@ static LRESULT CALLBACK
 OpenFileMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
 {
     LPMSG pMsg;
+    HWND hwndFocus;
     FileOpenDlgInfos *fodInfos;
-    DWORD tid1, tid2;
 
     if (nCode < 0)
         return CallNextHookEx(s_hFileDialogHook, nCode, wParam, lParam);
@@ -130,9 +130,9 @@ OpenFileMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
     pMsg = (LPMSG)lParam;
     if (WM_KEYFIRST <= pMsg->message && pMsg->message <= WM_KEYLAST)
     {
-        tid1 = GetWindowThreadProcessId(pMsg->hwnd, NULL);
-        tid2 = GetWindowThreadProcessId(s_hwndFileDialog, NULL);
-        if (tid1 == tid2)
+        hwndFocus = GetFocus();
+        if (fodInfos->ShellInfos.hwndView == hwndFocus ||
+            IsChild(fodInfos->ShellInfos.hwndView, hwndFocus))
         {
             IShellView_TranslateAccelerator(fodInfos->Shell.FOIShellView, pMsg);
         }

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -115,6 +115,7 @@ OpenFileMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
 {
     LPMSG pMsg;
     FileOpenDlgInfos *fodInfos;
+    DWORD tid1, tid2;
 
     if (nCode < 0)
         return CallNextHookEx(s_hFileDialogHook, nCode, wParam, lParam);
@@ -129,7 +130,12 @@ OpenFileMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
     pMsg = (LPMSG)lParam;
     if (WM_KEYFIRST <= pMsg->message && pMsg->message <= WM_KEYLAST)
     {
-        IShellView_TranslateAccelerator(fodInfos->Shell.FOIShellView, pMsg);
+        tid1 = GetWindowThreadProcessId(pMsg->hwnd, NULL);
+        tid2 = GetWindowThreadProcessId(s_hwndFileDialog, NULL);
+        if (tid1 == tid2)
+        {
+            IShellView_TranslateAccelerator(fodInfos->Shell.FOIShellView, pMsg);
+        }
     }
 
     return 0;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -1514,7 +1514,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
              SendCustomDlgNotificationMessage(hwnd,CDN_SELCHANGE);
 
 #ifdef __REACTOS__
-             /* Enable hook */
+         /* Enable hook */
          if (InterlockedIncrement(&s_nFileDialogHookLock) == 1)
          {
              s_hFileDialogHook = SetWindowsHookEx(WH_MSGFILTER, FILEDLG95_TranslateMsgProc,

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -107,9 +107,13 @@ typedef struct tagLookInInfo
 } LookInInfos;
 
 #ifdef __REACTOS__
+/* We have to call IShellView::TranslateAccelerator to handle
+   the standard keyboard bindings of File Open Dialog.
+   We use hook to realize them. */
 static HWND s_hwndFileDialog = NULL;
 static HHOOK s_hFileDialogHook = NULL;
 
+/* WH_MSGFILTER hook procedure */
 static LRESULT CALLBACK
 OpenFileMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
 {
@@ -1466,6 +1470,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
 #ifdef __REACTOS__
          if (s_hFileDialogHook == NULL)
          {
+             /* Enable hook */
              s_hwndFileDialog = hwnd;
              s_hFileDialogHook = SetWindowsHookEx(WH_MSGFILTER, OpenFileMsgProc, 0,
                                                   GetCurrentThreadId());
@@ -1509,6 +1514,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
               ImageList_Destroy(himl);
           }
 #ifdef __REACTOS__
+          /* Disable hook */
           UnhookWindowsHookEx(s_hFileDialogHook);
           s_hFileDialogHook = NULL;
           s_hwndFileDialog = NULL;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -132,6 +132,7 @@ static __inline BOOL
 FILEDLG95_DoTranslate(LONG i, HWND hwndFocus, LPMSG pMsg)
 {
     FileOpenDlgInfos *fodInfos;
+    HWND hwndView;
 
     if (s_ahwndTranslate[i] == NULL)
         return FALSE;
@@ -140,8 +141,8 @@ FILEDLG95_DoTranslate(LONG i, HWND hwndFocus, LPMSG pMsg)
     if (fodInfos == NULL)
         return FALSE;
 
-    if (fodInfos->ShellInfos.hwndView == hwndFocus ||
-        IsChild(fodInfos->ShellInfos.hwndView, hwndFocus))
+    hwndView = fodInfos->ShellInfos.hwndView;
+    if (hwndView == hwndFocus || IsChild(hwndView, hwndFocus))
     {
         IShellView_TranslateAccelerator(fodInfos->Shell.FOIShellView, pMsg);
         return TRUE;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -159,7 +159,6 @@ FILEDLG95_DoTranslate(LONG i, HWND hwndFocus, LPMSG pMsg)
         IShellView_TranslateAccelerator(fodInfos->Shell.FOIShellView, pMsg);
         return TRUE;
     }
-
     return FALSE;
 }
 
@@ -168,19 +167,17 @@ static LRESULT CALLBACK
 FILEDLG95_TranslateMsgProc(INT nCode, WPARAM wParam, LPARAM lParam)
 {
     LPMSG pMsg;
-    HWND hwndFocus;
-    LONG i;
 
     if (nCode < 0)
         return CallNextHookEx(s_hFileDialogHook, nCode, wParam, lParam);
-
     if (nCode != MSGF_DIALOGBOX)
         return 0;
 
     pMsg = (LPMSG)lParam;
     if (WM_KEYFIRST <= pMsg->message && pMsg->message <= WM_KEYLAST)
     {
-        hwndFocus = GetFocus();
+        LONG i;
+        HWND hwndFocus = GetFocus();
         for (i = 0; i < MAX_TRANSLATE; ++i)
         {
             if (FILEDLG95_DoTranslate(i, hwndFocus, pMsg))

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -1514,7 +1514,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
              SendCustomDlgNotificationMessage(hwnd,CDN_SELCHANGE);
 
 #ifdef __REACTOS__
-         /* Enable hook */
+         /* Enable hook and translate */
          if (InterlockedIncrement(&s_nFileDialogHookLock) == 1)
          {
              s_hFileDialogHook = SetWindowsHookEx(WH_MSGFILTER, FILEDLG95_TranslateMsgProc,
@@ -1560,13 +1560,13 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
               ImageList_Destroy(himl);
           }
 #ifdef __REACTOS__
-          /* Disable hook */
+          /* Disable hook and translate */
+          FILEDLG95_RemoveTranslate(hwnd);
           if (InterlockedDecrement(&s_nFileDialogHookLock) == 0)
           {
               UnhookWindowsHookEx(s_hFileDialogHook);
               s_hFileDialogHook = NULL;
           }
-          FILEDLG95_RemoveTranslate(hwnd);
 #endif
           return FALSE;
       }

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -1555,9 +1555,9 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
           FILEDLG95_AddRemoveTranslate(hwnd, NULL);
           if (InterlockedDecrement(&s_nFileDialogHookCount) == 0)
           {
+              DeleteCriticalSection(&s_csFileDialogHookLock);
               UnhookWindowsHookEx(s_hFileDialogHook);
               s_hFileDialogHook = NULL;
-              DeleteCriticalSection(&s_csFileDialogHookLock);
           }
 #endif
           return FALSE;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -115,27 +115,14 @@ static LONG s_nFileDialogHookLock = 0;
 #define MAX_TRANSLATE 8
 static HWND s_ahwndTranslate[MAX_TRANSLATE] = { NULL };
 
-static __inline void FILEDLG95_AddTranslate(HWND hwnd)
+static __inline void FILEDLG95_AddRemoveTranslate(HWND hwndOld, HWND hwndNew)
 {
     LONG i;
     for (i = 0; i < MAX_TRANSLATE; ++i)
     {
-        if (s_ahwndTranslate[i] == NULL)
+        if (s_ahwndTranslate[i] == hwndOld)
         {
-            s_ahwndTranslate[i] = hwnd;
-            return;
-        }
-    }
-}
-
-static __inline void FILEDLG95_RemoveTranslate(HWND hwnd)
-{
-    LONG i;
-    for (i = 0; i < MAX_TRANSLATE; ++i)
-    {
-        if (s_ahwndTranslate[i] == hwnd)
-        {
-            s_ahwndTranslate[i] = NULL;
+            s_ahwndTranslate[i] = hwndNew;
             return;
         }
     }
@@ -1517,7 +1504,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
              s_hFileDialogHook = SetWindowsHookEx(WH_MSGFILTER, FILEDLG95_TranslateMsgProc,
                                                   0, GetCurrentThreadId());
          }
-         FILEDLG95_AddTranslate(hwnd);
+         FILEDLG95_AddRemoveTranslate(NULL, hwnd);
 #endif
          return 0;
        }
@@ -1558,7 +1545,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
           }
 #ifdef __REACTOS__
           /* Disable hook and translate */
-          FILEDLG95_RemoveTranslate(hwnd);
+          FILEDLG95_AddRemoveTranslate(hwnd, NULL);
           if (InterlockedDecrement(&s_nFileDialogHookLock) == 0)
           {
               UnhookWindowsHookEx(s_hFileDialogHook);


### PR DESCRIPTION
## Purpose

Enable key accelerators on File Open/Save Dialog.

JIRA issue: [CORE-14332](https://jira.reactos.org/browse/CORE-14332)

## Proposed changes

- Introduce `WH_MSGFILTER` hook upon `WM_INITDIALOG`.
- Add a critical section `COMDLG32_OpenFileLock`.
- The hook procedure `OpenFileMsgProc` calls `IShellView::TranslateAccelerator`.
- Disable hook upon `WM_DESTROY`.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/94335423-8e343a00-0016-11eb-9e60-e17d55c8df0e.png)
`F2` and `Delete` keys are enabled.