### PR TITLE
[BROWSEUI_APITEST] Add ACLMulti testcase

### DIFF
--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -18,9 +18,15 @@
 CComModule gModule;
 static CStringA s_strTest;
 
+#define USE_ENUM_AC_STRING
+
 class CEnumString :
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
+#ifdef USE_ENUM_AC_STRING
+    public IEnumACString,
+#else
     public IEnumString,
+#endif
     public IACList2
 {
 public:
@@ -49,6 +55,9 @@ public:
         COM_INTERFACE_ENTRY_IID(IID_IEnumString, IEnumString)
         COM_INTERFACE_ENTRY_IID(IID_IACList2, IACList2)
         COM_INTERFACE_ENTRY_IID(IID_IACList, IACList)
+#ifdef USE_ENUM_AC_STRING
+        COM_INTERFACE_ENTRY_IID(IID_IEnumACString, IEnumACString)
+#endif
     END_COM_MAP()
 
     // IEnumString
@@ -114,6 +123,34 @@ public:
         *pdwFlags = 0;
         return S_OK;
     }
+
+#ifdef USE_ENUM_AC_STRING
+    // IEnumACString
+    STDMETHODIMP NextItem(LPWSTR pszUrl, ULONG cchMax, ULONG *pulSortIndex)
+    {
+        Log('M');
+        if (m_i < m_c)
+        {
+            ++m_i;
+            lstrcpynW(pszUrl, L"TEST", cchMax);
+            *pulSortIndex = m_i;
+            return S_OK;
+        }
+        return S_FALSE;
+    }
+    STDMETHODIMP SetEnumOptions(DWORD dwOptions)
+    {
+        Log('P');
+        trace("SetEnumOptions(0x%lX)\n", dwOptions);
+        return S_OK;
+    }
+    STDMETHODIMP GetEnumOptions(DWORD *pdwOptions)
+    {
+        Log('p');
+        *pdwOptions = 0;
+        return S_OK;
+    }
+#endif
 
     IUnknown *GetUnknown()
     {

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -1,0 +1,303 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Test for CLSID_ACLMulti
+ * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+#define _UNICODE
+#define UNICODE
+#include <apitest.h>
+#include <shlobj.h>
+#include <atlbase.h>
+#include <tchar.h>
+#include <atlcom.h>
+#include <atlwin.h>
+#include <atlstr.h>
+#include <stdio.h>
+#include <shellutils.h>
+#include <shlwapi.h>
+#include <strsafe.h>
+
+CComModule gModule;
+static CStringA *s_pstrTest = NULL;
+
+class CEnumString1 :
+    public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IEnumString,
+    public IACList2
+{
+public:
+    INT m_i, m_c;
+
+    CEnumString1() : m_i(0), m_c(2)
+    {
+    }
+    virtual ~CEnumString1()
+    {
+    }
+
+    BEGIN_COM_MAP(CEnumString1)
+        COM_INTERFACE_ENTRY_IID(IID_IEnumString, IEnumString)
+        COM_INTERFACE_ENTRY_IID(IID_IACList2, IACList2)
+        COM_INTERFACE_ENTRY_IID(IID_IACList, IACList)
+    END_COM_MAP()
+
+    // IEnumString
+    STDMETHODIMP Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
+    {
+        *s_pstrTest += 'n';
+
+        *rgelt = NULL;
+        *pceltFetched = 0;
+
+        if (m_i < m_c)
+        {
+            ++m_i;
+            *rgelt = (LPOLESTR)CoTaskMemAlloc((4 + 1) * sizeof(WCHAR));
+            lstrcpyW(*rgelt, L"TEST");
+            *pceltFetched = 1;
+            return S_OK;
+        }
+
+        return S_FALSE;
+    }
+    STDMETHODIMP Skip(ULONG celt)
+    {
+        *s_pstrTest += 's';
+        if (m_i < m_c)
+        {
+            ++m_i;
+            return S_OK;
+        }
+        return S_FALSE;
+    }
+    STDMETHODIMP Reset()
+    {
+        *s_pstrTest += 'r';
+        m_i = 0;
+        return S_OK;
+    }
+    STDMETHODIMP Clone(IEnumString **ppenum)
+    {
+        *s_pstrTest += 'c';
+        return E_NOTIMPL;
+    }
+
+    // IACList
+    STDMETHODIMP Expand(LPCOLESTR pszExpand)
+    {
+        *s_pstrTest += 'e';
+        return S_OK;
+    }
+
+    // IACList2
+    STDMETHODIMP SetOptions(DWORD dwFlags)
+    {
+        *s_pstrTest += 'o';
+        return S_OK;
+    }
+    STDMETHODIMP GetOptions(DWORD* pdwFlags)
+    {
+        *s_pstrTest += 'g';
+        *pdwFlags = 0;
+        return S_OK;
+    }
+};
+
+class CEnumString2 :
+    public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IEnumString,
+    public IACList2
+{
+public:
+    INT m_i, m_c;
+
+    CEnumString2() : m_i(0), m_c(2)
+    {
+    }
+    virtual ~CEnumString2()
+    {
+    }
+
+    BEGIN_COM_MAP(CEnumString1)
+        COM_INTERFACE_ENTRY_IID(IID_IEnumString, IEnumString)
+        COM_INTERFACE_ENTRY_IID(IID_IACList2, IACList2)
+        COM_INTERFACE_ENTRY_IID(IID_IACList, IACList)
+    END_COM_MAP()
+
+    // IEnumString
+    STDMETHODIMP Next(ULONG celt, LPOLESTR *rgelt, ULONG *pceltFetched)
+    {
+        *s_pstrTest += 'N';
+
+        *rgelt = NULL;
+        *pceltFetched = 0;
+
+        if (m_i < m_c)
+        {
+            ++m_i;
+            *rgelt = (LPOLESTR)CoTaskMemAlloc((4 + 1) * sizeof(WCHAR));
+            lstrcpyW(*rgelt, L"TEST");
+            *pceltFetched = 1;
+            return S_OK;
+        }
+
+        return S_FALSE;
+    }
+    STDMETHODIMP Skip(ULONG celt)
+    {
+        *s_pstrTest += 'S';
+        if (m_i < m_c)
+        {
+            ++m_i;
+            return S_OK;
+        }
+        return S_FALSE;
+    }
+    STDMETHODIMP Reset()
+    {
+        *s_pstrTest += 'R';
+        m_i = 0;
+        return S_OK;
+    }
+    STDMETHODIMP Clone(IEnumString **ppenum)
+    {
+        *s_pstrTest += 'C';
+        return E_NOTIMPL;
+    }
+
+    // IACList
+    STDMETHODIMP Expand(LPCOLESTR pszExpand)
+    {
+        *s_pstrTest += 'E';
+        return S_OK;
+    }
+
+    // IACList2
+    STDMETHODIMP SetOptions(DWORD dwFlags)
+    {
+        *s_pstrTest += 'O';
+        return S_OK;
+    }
+    STDMETHODIMP GetOptions(DWORD* pdwFlags)
+    {
+        *s_pstrTest += 'G';
+        *pdwFlags = 0;
+        return S_OK;
+    }
+};
+
+struct CCoInit
+{
+    CCoInit() { hres = CoInitialize(NULL); }
+    ~CCoInit() { if (SUCCEEDED(hres)) { CoUninitialize(); } }
+    HRESULT hres;
+};
+
+START_TEST(ACLMulti)
+{
+    CCoInit init;
+    ok_hr(init.hres, S_OK);
+    if (!SUCCEEDED(init.hres))
+    {
+        skip("CCoInit failed\n");
+        return;
+    }
+
+    s_pstrTest = new CStringA();
+
+    CComPtr<IObjMgr> pList;
+    HRESULT hr = CoCreateInstance(CLSID_ACLMulti, NULL, CLSCTX_ALL,
+                                  IID_IObjMgr, (LPVOID *)&pList);
+    ok_hr(hr, S_OK);
+    if (!pList)
+    {
+        skip("CoCreateInstance failed\n");
+        return;
+    }
+
+    CComPtr<IEnumString> pEnum;
+    hr = pList->QueryInterface(IID_IEnumString, (LPVOID *)&pEnum);
+    ok_hr(hr, S_OK);
+    if (!pEnum)
+    {
+        skip("QueryInterface failed\n");
+        return;
+    }
+
+    CComPtr<IEnumString> p1(new CComObject<CEnumString1>());
+    hr = pList->Append(p1);
+    ok_hr(hr, S_OK);
+
+    CComPtr<IEnumString> p2(new CComObject<CEnumString2>());
+    hr = pList->Append(p2);
+    ok_hr(hr, S_OK);
+
+    hr = pEnum->Reset();
+    ok_hr(hr, S_OK);
+
+    LPOLESTR psz;
+    ULONG c;
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    hr = pEnum->Skip(1);
+    ok_hr(hr, E_NOTIMPL);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_FALSE);
+    ok_int(c, 0);
+    CoTaskMemFree(psz);
+
+    pEnum->Reset();
+
+    psz = NULL;
+    hr = pEnum->Next(2, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    hr = pEnum->Skip(2);
+    ok_hr(hr, E_NOTIMPL);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    hr = pEnum->Skip(1);
+    ok_hr(hr, E_NOTIMPL);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_OK);
+    ok_int(c, 1);
+    CoTaskMemFree(psz);
+
+    ok_str(s_pstrTest->GetString(), "rRnnnNNNrRnnnN");
+    delete s_pstrTest;
+}

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -9,14 +9,8 @@
 #include <apitest.h>
 #include <shlobj.h>
 #include <atlbase.h>
-#include <tchar.h>
 #include <atlcom.h>
-#include <atlwin.h>
 #include <atlstr.h>
-#include <stdio.h>
-#include <shellutils.h>
-#include <shlwapi.h>
-#include <strsafe.h>
 
 CComModule gModule;
 static CStringA *s_pstrTest = NULL;

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -182,7 +182,7 @@ START_TEST(ACLMulti)
     CComPtr<IACList> pACL;
     hr = pManager->QueryInterface(IID_IACList, (LPVOID *)&pACL);
     ok_hr(hr, S_OK);
-    if (!pEnum)
+    if (!pACL)
     {
         skip("QueryInterface failed\n");
         return;

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -287,6 +287,8 @@ START_TEST(ACLMulti)
 
     s_strTest += '|';
     pEnum->Reset();
+    p1->Initialize(2, '1');
+    p2->Initialize(1, '2');
     s_strTest += '|';
 
     psz = NULL;
@@ -313,7 +315,19 @@ START_TEST(ACLMulti)
     ok_int(c, 1);
     CoTaskMemFree(psz);
 
-    ok_str((LPCSTR)s_strTest, "m1a1s1|m2a2s2|R1R2|N1N1N1N2N2N2|R1R2|N1N1N1N2");
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_FALSE);
+    ok_int(c, 0);
+    CoTaskMemFree(psz);
+
+    psz = NULL;
+    hr = pEnum->Next(1, &psz, &c);
+    ok_hr(hr, S_FALSE);
+    ok_int(c, 0);
+    CoTaskMemFree(psz);
+
+    ok_str((LPCSTR)s_strTest, "m1a1s1|m2a2s2|R1R2|N1N1N1N2N2N2|R1R2|N1N1N1N2N2");
 
     s_strTest = "";
 
@@ -324,5 +338,5 @@ START_TEST(ACLMulti)
     ok_hr(hr, S_OK);
     s_strTest += '|';
 
-    ok(s_strTest == "E1E2|E1E2|" || s_strTest == "E1|E1|", "\n");
+    ok(s_strTest == "E1E2|E1E2|" || s_strTest == "E1|E1|", "s_strTest was %s\n", (LPCSTR)s_strTest);
 }

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -13,6 +13,7 @@
 #include <atlstr.h>
 #include <shlwapi_undoc.h>
 #include <shlguid_undoc.h>
+#include <shellutils.h>
 
 CComModule gModule;
 static CStringA s_strTest;
@@ -162,7 +163,7 @@ START_TEST(ACLMulti)
 
     CComPtr<IObjMgr> pManager;
     HRESULT hr = CoCreateInstance(CLSID_ACLMulti, NULL, CLSCTX_ALL,
-                                  IID_IObjMgr, (LPVOID *)&pManager);
+                                  IID_PPV_ARG(IObjMgr, &pManager));
     ok_hr(hr, S_OK);
     if (!pManager)
     {
@@ -171,7 +172,7 @@ START_TEST(ACLMulti)
     }
 
     CComPtr<IEnumString> pEnum;
-    hr = pManager->QueryInterface(IID_IEnumString, (LPVOID *)&pEnum);
+    hr = pManager->QueryInterface(IID_PPV_ARG(IEnumString, &pEnum));
     ok_hr(hr, S_OK);
     if (!pEnum)
     {
@@ -180,7 +181,7 @@ START_TEST(ACLMulti)
     }
 
     CComPtr<IACList> pACL;
-    hr = pManager->QueryInterface(IID_IACList, (LPVOID *)&pACL);
+    hr = pManager->QueryInterface(IID_PPV_ARG(IACList, &pACL));
     ok_hr(hr, S_OK);
     if (!pACL)
     {

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -11,9 +11,11 @@
 #include <atlbase.h>
 #include <atlcom.h>
 #include <atlstr.h>
+#include <string.h>
 #include <shlwapi_undoc.h>
 #include <shlguid_undoc.h>
 #include <shellutils.h>
+#include <strsafe.h>
 
 CComModule gModule;
 static CStringA s_strTest;
@@ -70,9 +72,11 @@ public:
 
         if (m_i < m_c)
         {
+            static const WCHAR szText[] = L"TEST";
             ++m_i;
-            *rgelt = (LPOLESTR)CoTaskMemAlloc((4 + 1) * sizeof(WCHAR));
-            lstrcpyW(*rgelt, L"TEST");
+            size_t cb = (wcslen(szText) + 1) * sizeof(WCHAR);
+            *rgelt = (LPOLESTR)CoTaskMemAlloc(cb);
+            StringCbCopyW(*rgelt, cb, szText);
             *pceltFetched = 1;
             return S_OK;
         }
@@ -132,7 +136,7 @@ public:
         if (m_i < m_c)
         {
             ++m_i;
-            lstrcpynW(pszUrl, L"TEST", cchMax);
+            StringCchCopyW(pszUrl, cchMax, L"TEST");
             *pulSortIndex = m_i;
             return S_OK;
         }

--- a/modules/rostests/apitests/browseui/ACLMulti.cpp
+++ b/modules/rostests/apitests/browseui/ACLMulti.cpp
@@ -314,4 +314,15 @@ START_TEST(ACLMulti)
     CoTaskMemFree(psz);
 
     ok_str((LPCSTR)s_strTest, "m1a1s1|m2a2s2|R1R2|N1N1N1N2N2N2|R1R2|N1N1N1N2");
+
+    s_strTest = "";
+
+    hr = pACL->Expand(L"C:");
+    ok_hr(hr, S_OK);
+    s_strTest += '|';
+    hr = pACL->Expand(L"C:\\");
+    ok_hr(hr, S_OK);
+    s_strTest += '|';
+
+    ok(s_strTest == "E1E2|E1E2|" || s_strTest == "E1|E1|", "\n");
 }

--- a/modules/rostests/apitests/browseui/CMakeLists.txt
+++ b/modules/rostests/apitests/browseui/CMakeLists.txt
@@ -10,6 +10,7 @@ include_directories(
     includes)
 
 list(APPEND SOURCE
+	ACLMulti.cpp
     ACListISF.cpp
     IACLCustomMRU.cpp
     SHEnumClassesOfCategories.cpp

--- a/modules/rostests/apitests/browseui/CMakeLists.txt
+++ b/modules/rostests/apitests/browseui/CMakeLists.txt
@@ -10,8 +10,8 @@ include_directories(
     includes)
 
 list(APPEND SOURCE
-	ACLMulti.cpp
     ACListISF.cpp
+    ACLMulti.cpp
     IACLCustomMRU.cpp
     SHEnumClassesOfCategories.cpp
     SHExplorerParseCmdLine.c

--- a/modules/rostests/apitests/browseui/testlist.c
+++ b/modules/rostests/apitests/browseui/testlist.c
@@ -3,16 +3,16 @@
 #define STANDALONE
 #include <apitest.h>
 
-extern void func_ACLMulti(void);
 extern void func_ACListISF(void);
+extern void func_ACLMulti(void);
 extern void func_IACLCustomMRU(void);
 extern void func_SHEnumClassesOfCategories(void);
 extern void func_SHExplorerParseCmdLine(void);
 
 const struct test winetest_testlist[] =
 {
-    { "ACLMulti", func_ACLMulti },
     { "ACListISF", func_ACListISF },
+    { "ACLMulti", func_ACLMulti },
     { "IACLCustomMRU", func_IACLCustomMRU },
     { "SHEnumClassesOfCategories", func_SHEnumClassesOfCategories },
     { "SHExplorerParseCmdLine", func_SHExplorerParseCmdLine },

--- a/modules/rostests/apitests/browseui/testlist.c
+++ b/modules/rostests/apitests/browseui/testlist.c
@@ -3,6 +3,7 @@
 #define STANDALONE
 #include <apitest.h>
 
+extern void func_ACLMulti(void);
 extern void func_ACListISF(void);
 extern void func_IACLCustomMRU(void);
 extern void func_SHEnumClassesOfCategories(void);
@@ -10,6 +11,7 @@ extern void func_SHExplorerParseCmdLine(void);
 
 const struct test winetest_testlist[] =
 {
+    { "ACLMulti", func_ACLMulti },
     { "ACListISF", func_ACListISF },
     { "IACLCustomMRU", func_IACLCustomMRU },
     { "SHEnumClassesOfCategories", func_SHEnumClassesOfCategories },


### PR DESCRIPTION
## Purpose
Add a testcase for `CLSID_ACLMulti`, that owns zero or more AutoComplete list(s) and enumerates.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `ACLMulti.cpp` and modify `CMakeLists.cpp` and `testlist.c`.
- Define `CEnumString` class.
- Add test codes.

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/94352614-2deada00-00a2-11eb-96f4-71031c3b8786.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/94352613-2d524380-00a2-11eb-9b61-bffc56f8578c.png)
Successful.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/94352615-2e837080-00a2-11eb-96a4-40ca3d4055f2.png)
Successful.