### PR TITLE
[BROWSEUI][SHELL32] Enable Ctrl+Backspace in AutoComplete edit boxes

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -302,11 +302,9 @@ static void Edit_BackWord(HWND hwndEdit)
         return;
     }
 
-    WORD wType;
     for (; 0 < iStart; --iStart)
     {
-        GetStringTypeW(CT_CTYPE1, &pszText[iStart - 1], 1, &wType);
-        if ((wType & C1_SPACE) && IsCharAlphaNumericW(pszText[iStart]))
+        if (IsCharSpaceW(pszText[iStart - 1]) && IsCharAlphaNumericW(pszText[iStart]))
         {
             SendMessageW(hwndEdit, EM_SETSEL, iStart, iEnd);
             SendMessageW(hwndEdit, EM_REPLACESEL, TRUE, (LPARAM)L"");

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -302,10 +302,11 @@ static void Edit_BackWord(HWND hwndEdit)
         return;
     }
 
+    WORD wType;
     for (; 0 < iStart; --iStart)
     {
-        if (pszText[iStart - 1] == L' ' &&
-            IsCharAlphaNumericW(pszText[iStart]))
+        GetStringTypeW(CT_CTYPE1, &pszText[iStart - 1], 1, &wType);
+        if ((wType & C1_SPACE) && IsCharAlphaNumericW(pszText[iStart]))
         {
             SendMessageW(hwndEdit, EM_SETSEL, iStart, iEnd);
             SendMessageW(hwndEdit, EM_REPLACESEL, TRUE, (LPARAM)L"");

--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -547,10 +547,17 @@ static INT_PTR CALLBACK RunDlgProc(HWND hwnd, UINT message, WPARAM wParam, LPARA
             ComboInfo.cbSize = sizeof(ComboInfo);
             GetComboBoxInfo(hwndCombo, &ComboInfo);
             hwndEdit = ComboInfo.hwndItem;
+            ASSERT(::IsWindow(hwndEdit));
+
+            CoInitializeEx(NULL, COINIT_APARTMENTTHREADED); // SHAutoComplete needs co init
             SHAutoComplete(hwndEdit, SHACF_FILESYSTEM | SHACF_FILESYS_ONLY | SHACF_URLALL);
 
             SetFocus(hwndCombo);
             return TRUE;
+
+        case WM_DESTROY:
+            CoUninitialize();
+            break;
 
         case WM_COMMAND:
             switch (LOWORD(wParam))


### PR DESCRIPTION
## Purpose

Improve the usability of `Ctrl+Back` key combination on auto-completion (`AutoComplete`) edit boxes.

JIRA issue: [CORE-1419](https://jira.reactos.org/browse/CORE-1419)

## Proposed changes

- In module `browseui`, add `Edit_BackWord` function to delete previous word of caret.
- Use `Edit_BackWord` upon `WM_KEYDOWN` `VK_CONTROL`+`VK_BACK` (`Ctrl+Back`).
- In module `shell32`, add `CoInitializeEx` and `CoUninitialize` calls in `Run` dialog.

## TODO

- [x] `Ctrl+Back` on `Run` dialog box.

![after](https://user-images.githubusercontent.com/2107452/94360171-7926dc00-00e6-11eb-91b3-fb4c269e89af.png)
The key combination `Ctrl+Back` is well working in auto-completion edit boxes!