### PR TITLE
WIP - [UMPNPMGR] Investigate bug crash. CORE-16103

### DIFF
--- a/base/services/umpnpmgr/precomp.h
+++ b/base/services/umpnpmgr/precomp.h
@@ -35,8 +35,8 @@
 
 typedef struct
 {
-    SLIST_ENTRY ListEntry;
-    WCHAR DeviceIds[1];
+    LIST_ENTRY ListEntry;
+    WCHAR DeviceIds[ANYSIZE_ARRAY];
 } DeviceInstallParams;
 
 /* install.c */
@@ -45,7 +45,9 @@ extern HANDLE hUserToken;
 extern HANDLE hInstallEvent;
 extern HANDLE hNoPendingInstalls;
 
-extern SLIST_HEADER DeviceInstallListHead;
+/* Device-install event list */
+extern HANDLE hDeviceInstallListMutex;
+extern LIST_ENTRY DeviceInstallListHead;
 extern HANDLE hDeviceInstallListNotEmpty;
 
 BOOL


### PR DESCRIPTION
Actually use linked-lists. Reverts part of commit 043a98dd (see also commit b2aeafca).

## Purpose

Investigation of the bug crash reported at
JIRA issue: [CORE-16103](https://jira.reactos.org/browse/CORE-16103)

## Proposed changes

I investigate the usage of regular (doubly) linked lists with explicit mutex locking.
