### PR TITLE
[BROWSEUI_APITEST] Strengthen IACLCustomMRU testcase

### DIFF
--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -410,7 +410,7 @@ test_IACLCustomMRU_TypedURLs()
     // TypedURLs is special case
 #define TYPED_URL_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
 
-    CStringW url1, url2;
+    CStringW url1, url2; // Save
     {
         CRegKey key;
         WCHAR Value[MAX_PATH];
@@ -427,6 +427,7 @@ test_IACLCustomMRU_TypedURLs()
         if (!result)
             url2 = Value;
 
+        // Set values
         key.SetStringValue(L"url1", L"aaa");
         key.SetStringValue(L"url2", L"bbb");
     }

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -502,6 +502,10 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
         return;
     }
 
+    CComPtr<IEnumString> pEnumClone;
+    hr = pEnum->Clone(&pEnumClone);
+    ok_hex(hr, E_NOTIMPL);
+
     hr = pEnum->Skip(1);
     ok_hex(hr, E_NOTIMPL);
 

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -402,13 +402,13 @@ test_IACLCustomMRU_Continue()
     verify_mru(CustomMRU, L"ba", L"FIRST_ENTRY", L"SECOND_ENTRY");
 }
 
-#define TYPED_URL_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
+#define TYPED_URLS_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
 
 static void
 RestoreTypedURLs(const CStringW& url1, const CStringW& url2)
 {
     CRegKey key;
-    key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_WRITE);
+    key.Open(HKEY_CURRENT_USER, TYPED_URLS_KEY, KEY_WRITE);
     if (url1 != L"")
         key.SetStringValue(L"url1", url1);
     if (url2 != L"")
@@ -421,7 +421,7 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
     CStringW url1, url2; // Save values
     {
         CRegKey key;
-        key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_READ | KEY_WRITE);
+        key.Open(HKEY_CURRENT_USER, TYPED_URLS_KEY, KEY_READ | KEY_WRITE);
 
         WCHAR Value[MAX_PATH];
         ULONG cch = _countof(Value);
@@ -450,7 +450,7 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
         return;
     }
 
-    hr = CustomMRU->Initialize(TYPED_URL_KEY, 64);
+    hr = CustomMRU->Initialize(TYPED_URLS_KEY, 64);
     ok_hex(hr, S_OK);
 
     CComPtr<IEnumString> pEnum;

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -479,6 +479,13 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
     ok_int(c, 1);
     CoTaskMemFree(psz);
 
+    hr = CustomMRU->AddMRUString(L"https://google.co.jp");
+    ok_hex(hr, E_FAIL);
+    hr = CustomMRU->AddMRUString(L"C:");
+    ok_hex(hr, E_FAIL);
+    hr = CustomMRU->AddMRUString(L"C:\\");
+    ok_hex(hr, E_FAIL);
+
     RestoreTypedURLs(url1, url2);
 }
 

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -502,9 +502,12 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
         return;
     }
 
+    hr = pEnum->Skip(1);
+    ok_hex(hr, E_NOTIMPL);
+
     LPOLESTR psz = NULL;
     ULONG c = 0;
-    hr = pEnum->Next(1, &psz, &c);
+    hr = pEnum->Next(2, &psz, &c);
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"aaa");
     ok_int(c, 1);

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -433,19 +433,13 @@ test_IACLCustomMRU_TypedURLs()
     HRESULT hr = CoCreateInstance(CLSID_ACLCustomMRU, NULL, CLSCTX_ALL,
                                   IID_PPV_ARG(IACLCustomMRU, &CustomMRU));
     ok_hex(hr, S_OK);
-    if (!SUCCEEDED(hr))
-        return;
 
-    hr = CustomMRU->Initialize(TYPED_URL_KEY, 3);
+    hr = CustomMRU->Initialize(TYPED_URL_KEY, 64);
     ok_hex(hr, S_OK);
-    if (!SUCCEEDED(hr))
-        return;
 
     CComPtr<IEnumString> pEnum;
     hr = CustomMRU->QueryInterface(IID_PPV_ARG(IEnumString, &pEnum));
     ok_hex(hr, S_OK);
-    if (!SUCCEEDED(hr))
-        return;
 
     LPOLESTR psz = NULL;
     ULONG c = 0;

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -457,6 +457,7 @@ test_IACLCustomMRU_TypedURLs()
     hr = pEnum->Next(1, &psz, &c);
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"aaa");
+    ok_int(c, 1);
     if (psz)
         CoTaskMemFree(psz);
 
@@ -465,6 +466,7 @@ test_IACLCustomMRU_TypedURLs()
     hr = pEnum->Next(1, &psz, &c);
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"bbb");
+    ok_int(c, 1);
     if (psz)
         CoTaskMemFree(psz);
 

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -410,7 +410,7 @@ test_IACLCustomMRU_TypedURLs()
     // TypedURLs is special case
 #define TYPED_URL_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
 
-    CStringW url1, url2; // Save
+    CStringW url1, url2; // Save values
     {
         CRegKey key;
         WCHAR Value[MAX_PATH];
@@ -450,11 +450,8 @@ test_IACLCustomMRU_TypedURLs()
     if (!SUCCEEDED(hr))
         return;
 
-    LPOLESTR psz;
-    ULONG c;
-
-    psz = NULL;
-    c = 0;
+    LPOLESTR psz = NULL;
+    ULONG c = 0;
     hr = pEnum->Next(1, &psz, &c);
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"aaa");
@@ -472,14 +469,12 @@ test_IACLCustomMRU_TypedURLs()
         CoTaskMemFree(psz);
 
     // Restore
-    {
-        CRegKey key;
-        key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_WRITE);
-        if (url1 != L"")
-            key.SetStringValue(L"url1", url1);
-        if (url2 != L"")
-            key.SetStringValue(L"url2", url2);
-    }
+    CRegKey key;
+    key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_WRITE);
+    if (url1 != L"")
+        key.SetStringValue(L"url1", url1);
+    if (url2 != L"")
+        key.SetStringValue(L"url2", url2);
 }
 
 START_TEST(IACLCustomMRU)

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -450,8 +450,47 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
         return;
     }
 
+    CComPtr<IACList> ACList;
+    hr = CustomMRU->QueryInterface(IID_PPV_ARG(IACList, &ACList));
+    ok_hex(hr, S_OK);
+    if (SUCCEEDED(hr))
+    {
+        hr = ACList->Expand(L"C:");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\Program Files");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\Program Files\\");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"http://");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"https://");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"https://google.co.jp/");
+        ok_hex(hr, E_NOTIMPL);
+    }
+
     hr = CustomMRU->Initialize(TYPED_URLS_KEY, 64);
     ok_hex(hr, S_OK);
+
+    if (ACList)
+    {
+        hr = ACList->Expand(L"C:");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\Program Files");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"C:\\Program Files\\");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"http://");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"https://");
+        ok_hex(hr, E_NOTIMPL);
+        hr = ACList->Expand(L"https://google.co.jp/");
+        ok_hex(hr, E_NOTIMPL);
+    }
 
     CComPtr<IEnumString> pEnum;
     hr = CustomMRU->QueryInterface(IID_PPV_ARG(IEnumString, &pEnum));

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -505,13 +505,22 @@ test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
     hr = pEnum->Skip(1);
     ok_hex(hr, E_NOTIMPL);
 
-    LPOLESTR psz = NULL;
+#define INVALID_LPOLESTR ((LPOLESTR)(LONG_PTR)0xDEADBEEF)
+    LPOLESTR apsz[2] = { NULL, INVALID_LPOLESTR };
     ULONG c = 0;
-    hr = pEnum->Next(2, &psz, &c);
+    hr = pEnum->Next(2, apsz, &c);
     ok_hex(hr, S_OK);
-    ok_wstri(psz, L"aaa");
+    ok_wstri(apsz[0], L"aaa");
     ok_int(c, 1);
-    CoTaskMemFree(psz);
+    ok(apsz[1] == INVALID_LPOLESTR, "apsz[1] was '%S'\n", apsz[1]);
+    CoTaskMemFree(apsz[0]);
+
+    LPOLESTR psz = INVALID_LPOLESTR;
+    c = 0;
+    hr = pEnum->Next(0, &psz, &c);
+    ok_hex(hr, S_OK);
+    ok(psz == INVALID_LPOLESTR, "psz was '%S'\n", psz);
+    ok_int(c, 0);
 
     psz = NULL;
     c = 0;

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -433,6 +433,11 @@ test_IACLCustomMRU_TypedURLs()
     HRESULT hr = CoCreateInstance(CLSID_ACLCustomMRU, NULL, CLSCTX_ALL,
                                   IID_PPV_ARG(IACLCustomMRU, &CustomMRU));
     ok_hex(hr, S_OK);
+    if (FAILED(hr))
+    {
+        skip("IACLCustomMRU was NULL\n");
+        return;
+    }
 
     hr = CustomMRU->Initialize(TYPED_URL_KEY, 64);
     ok_hex(hr, S_OK);
@@ -440,6 +445,11 @@ test_IACLCustomMRU_TypedURLs()
     CComPtr<IEnumString> pEnum;
     hr = CustomMRU->QueryInterface(IID_PPV_ARG(IEnumString, &pEnum));
     ok_hex(hr, S_OK);
+    if (FAILED(hr))
+    {
+        skip("IEnumString was NULL\n");
+        return;
+    }
 
     LPOLESTR psz = NULL;
     ULONG c = 0;
@@ -447,8 +457,7 @@ test_IACLCustomMRU_TypedURLs()
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"aaa");
     ok_int(c, 1);
-    if (psz)
-        CoTaskMemFree(psz);
+    CoTaskMemFree(psz);
 
     psz = NULL;
     c = 0;
@@ -456,8 +465,7 @@ test_IACLCustomMRU_TypedURLs()
     ok_hex(hr, S_OK);
     ok_wstri(psz, L"bbb");
     ok_int(c, 1);
-    if (psz)
-        CoTaskMemFree(psz);
+    CoTaskMemFree(psz);
 
     // Restore
     CRegKey key;

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -405,8 +405,6 @@ test_IACLCustomMRU_Continue()
 static void
 test_IACLCustomMRU_TypedURLs()
 {
-    Cleanup_Testdata();
-
     // TypedURLs is special case
 #define TYPED_URL_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
 

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -402,12 +402,22 @@ test_IACLCustomMRU_Continue()
     verify_mru(CustomMRU, L"ba", L"FIRST_ENTRY", L"SECOND_ENTRY");
 }
 
-static void
-test_IACLCustomMRU_TypedURLs()
-{
-    // TypedURLs is special case
 #define TYPED_URL_KEY L"Software\\Microsoft\\Internet Explorer\\TypedURLs"
 
+static void
+RestoreTypedURLs(const CStringW& url1, const CStringW& url2)
+{
+    CRegKey key;
+    key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_WRITE);
+    if (url1 != L"")
+        key.SetStringValue(L"url1", url1);
+    if (url2 != L"")
+        key.SetStringValue(L"url2", url2);
+}
+
+static void
+test_IACLCustomMRU_TypedURLs() // TypedURLs is special case
+{
     CStringW url1, url2; // Save values
     {
         CRegKey key;
@@ -436,6 +446,7 @@ test_IACLCustomMRU_TypedURLs()
     if (FAILED(hr))
     {
         skip("IACLCustomMRU was NULL\n");
+        RestoreTypedURLs(url1, url2);
         return;
     }
 
@@ -448,6 +459,7 @@ test_IACLCustomMRU_TypedURLs()
     if (FAILED(hr))
     {
         skip("IEnumString was NULL\n");
+        RestoreTypedURLs(url1, url2);
         return;
     }
 
@@ -467,13 +479,7 @@ test_IACLCustomMRU_TypedURLs()
     ok_int(c, 1);
     CoTaskMemFree(psz);
 
-    // Restore
-    CRegKey key;
-    key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_WRITE);
-    if (url1 != L"")
-        key.SetStringValue(L"url1", url1);
-    if (url2 != L"")
-        key.SetStringValue(L"url2", url2);
+    RestoreTypedURLs(url1, url2);
 }
 
 START_TEST(IACLCustomMRU)

--- a/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
+++ b/modules/rostests/apitests/browseui/IACLCustomMRU.cpp
@@ -413,18 +413,17 @@ test_IACLCustomMRU_TypedURLs()
     CStringW url1, url2; // Save values
     {
         CRegKey key;
-        WCHAR Value[MAX_PATH];
-        ULONG cch;
         key.Open(HKEY_CURRENT_USER, TYPED_URL_KEY, KEY_READ | KEY_WRITE);
 
-        cch = _countof(Value);
-        LONG result = key.QueryStringValue(L"url1", Value, &cch);
-        if (!result)
+        WCHAR Value[MAX_PATH];
+        ULONG cch = _countof(Value);
+        LSTATUS Status = key.QueryStringValue(L"url1", Value, &cch);
+        if (!Status)
             url1 = Value;
 
         cch = _countof(Value);
-        result = key.QueryStringValue(L"url2", Value, &cch);
-        if (!result)
+        Status = key.QueryStringValue(L"url2", Value, &cch);
+        if (!Status)
             url2 = Value;
 
         // Set values


### PR DESCRIPTION
## Purpose

Add some tests for `"TypedURLs"` of a special case.
The `TypedURLs` key consists of the registry values of `"url1", "url2", "url3"` etc instead of `"MRUList", "a", "b"` etc.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- On registry key `"Software\\Microsoft\\Internet Explorer\\TypedURLs"`, save the `"url1"` and `"url2"` registry values.
- And then set `"aaa"` and `"bbb"` to the registry values.
- Create a `CLSID_ACLCustomMRU` with interface `IACLCustomMRU`.
- Initialize `IACLCustomMRU` with `TypedURLs`.
- Query `IEnumString` interface.
- Call `Next` and verify the values `"aaa"` and `"bbb"`.
- Restore `"url1"` and `"url2"` registry values.

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/94506359-22d1ae80-0248-11eb-9042-9a0488f6d7d6.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/94506353-1f3e2780-0248-11eb-9d49-4dd6442e0d0a.png)
Successful.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/94506358-22d1ae80-0248-11eb-941b-e9f41c5f7289.png)
Successful.