### PR TITLE
[BROWSEUI] Accept TypedURLs to CLSID_ACLCustomMRU

### DIFF
--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -38,6 +38,7 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
     if (!psz)
         return S_FALSE;
 
+    CopyMemory(psz, (LPCWSTR)m_MRUData[m_ielt], cb);
     *rgelt = psz;
     *pceltFetched = 1;
     ++m_ielt;
@@ -115,7 +116,6 @@ HRESULT CACLCustomMRU::LoadTypedURLs(DWORD dwMax)
     dwMax = max(0, dwMax);
     dwMax = min(29, dwMax);
 
-    BOOL bLoaded = FALSE;
     for (DWORD i = 1; i <= dwMax; ++i)
     {
         // Build a registry value name
@@ -129,10 +129,9 @@ HRESULT CACLCustomMRU::LoadTypedURLs(DWORD dwMax)
             break;
 
         m_MRUData.Add(strData);
-        bLoaded = TRUE;
     }
 
-    return bLoaded ? S_OK : E_FAIL;
+    return S_OK;
 }
 
 // *** IACLCustomMRU methods ***

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -90,8 +90,6 @@ void CACLCustomMRU::PersistMRU()
 static LSTATUS
 RegQueryCStringW(CRegKey& key, LPCWSTR pszValueName, CStringW& str)
 {
-    str = L"";
-
     // Check type and size
     DWORD dwType, cbData;
     LSTATUS ret = key.QueryValue(pszValueName, &dwType, NULL, &cbData);
@@ -118,15 +116,16 @@ HRESULT CACLCustomMRU::LoadTypedURLs(DWORD dwMax)
     dwMax = max(0, dwMax);
     dwMax = min(29, dwMax);
 
+    WCHAR szName[32];
+    CStringW strData;
+    LSTATUS status;
     for (DWORD i = 1; i <= dwMax; ++i)
     {
         // Build a registry value name
-        WCHAR szName[32];
         StringCbPrintfW(szName, sizeof(szName), L"url%lu", i);
 
         // Read a registry value
-        CStringW strData;
-        LSTATUS status = RegQueryCStringW(m_Key, szName, strData);
+        status = RegQueryCStringW(m_Key, szName, strData);
         if (status != ERROR_SUCCESS)
             break;
 

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -20,7 +20,7 @@ CACLCustomMRU::~CACLCustomMRU()
     PersistMRU();
 }
 
-STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR * rgelt, ULONG * pceltFetched)
+STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
 {
     if (!pceltFetched || !rgelt)
         return E_POINTER;
@@ -34,8 +34,10 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR * rgelt, ULONG * pceltFetche
     LPWSTR psz = (LPWSTR)CoTaskMemAlloc(cb);
     if (!psz)
         return S_FALSE;
+
     *rgelt = psz;
     *pceltFetched = 1;
+    ++m_ielt;
     return S_OK;
 }
 

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -87,14 +87,14 @@ void CACLCustomMRU::PersistMRU()
     }
 }
 
-static LONG
+static LSTATUS
 RegQueryCStringW(CRegKey& key, LPCWSTR pszValueName, CStringW& str)
 {
     str = L"";
 
     // Check type and size
     DWORD dwType, cbData;
-    LONG ret = key.QueryValue(pszValueName, &dwType, NULL, &cbData);
+    LSTATUS ret = key.QueryValue(pszValueName, &dwType, NULL, &cbData);
     if (ret != ERROR_SUCCESS)
         return ret;
     if (dwType != REG_SZ && dwType != REG_EXPAND_SZ)

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -18,15 +18,15 @@ CACLCustomMRU::CACLCustomMRU()
 CACLCustomMRU::~CACLCustomMRU()
 {
     PersistMRU();
-    m_Key.Close();
 }
 
 void CACLCustomMRU::PersistMRU()
 {
+    if (!m_bDirty || m_bTypedURLs)
+        return;
+
     WCHAR Key[2] = { 0, 0 };
 
-    if (!m_bDirty)
-        return;
     m_bDirty = false;
 
     if (m_Key.m_hKey)

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -90,6 +90,8 @@ void CACLCustomMRU::PersistMRU()
 static LONG
 RegQueryCStringW(CRegKey& key, LPCWSTR pszValueName, CStringW& str)
 {
+    str = L"";
+
     // Check type and size
     DWORD dwType, cbData;
     LONG ret = key.QueryValue(pszValueName, &dwType, NULL, &cbData);
@@ -123,7 +125,7 @@ HRESULT CACLCustomMRU::LoadTypedURLs(DWORD dwMax)
         StringCbPrintfW(szName, sizeof(szName), L"url%lu", i);
 
         // Read a registry value
-        CString strData;
+        CStringW strData;
         LSTATUS status = RegQueryCStringW(m_Key, szName, strData);
         if (status != ERROR_SUCCESS)
             break;

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -26,6 +26,9 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
         return E_POINTER;
 
     *pceltFetched = 0;
+    if (celt == 0)
+        return S_OK;
+
     *rgelt = NULL;
     if (INT(m_ielt) >= m_MRUData.GetSize())
         return S_FALSE;

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -148,8 +148,15 @@ HRESULT STDMETHODCALLTYPE CACLCustomMRU::Initialize(LPCWSTR pwszMRURegKey, DWORD
         m_bTypedURLs = TRUE;
         return LoadTypedURLs(dwMax);
     }
-    m_bTypedURLs = FALSE;
+    else
+    {
+        m_bTypedURLs = FALSE;
+        return LoadMRUList(dwMax);
+    }
+}
 
+HRESULT CACLCustomMRU::LoadMRUList(DWORD dwMax)
+{
     m_MRUData.RemoveAll();
     dwMax = max(0, dwMax);
     dwMax = min(29, dwMax);
@@ -159,7 +166,7 @@ HRESULT STDMETHODCALLTYPE CACLCustomMRU::Initialize(LPCWSTR pwszMRURegKey, DWORD
     WCHAR MRUList[40];
     ULONG nChars = _countof(MRUList);
 
-    Status = m_Key.QueryStringValue(L"MRUList", MRUList, &nChars);
+    LSTATUS Status = m_Key.QueryStringValue(L"MRUList", MRUList, &nChars);
     if (Status != ERROR_SUCCESS)
         return S_OK;
 

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -109,8 +109,6 @@ RegQueryCStringW(CRegKey& key, LPCWSTR pszValueName, CStringW& str)
 
 HRESULT CACLCustomMRU::LoadTypedURLs(DWORD dwMax)
 {
-    m_MRUData.RemoveAll();
-
     dwMax = max(0, dwMax);
     dwMax = min(29, dwMax);
 
@@ -143,6 +141,7 @@ HRESULT STDMETHODCALLTYPE CACLCustomMRU::Initialize(LPCWSTR pwszMRURegKey, DWORD
     if (Status != ERROR_SUCCESS)
         return HRESULT_FROM_WIN32(Status);
 
+    m_MRUData.RemoveAll();
     if (lstrcmpiW(pwszMRURegKey, TYPED_URLS_KEY) == 0)
     {
         m_bTypedURLs = TRUE;
@@ -157,7 +156,6 @@ HRESULT STDMETHODCALLTYPE CACLCustomMRU::Initialize(LPCWSTR pwszMRURegKey, DWORD
 
 HRESULT CACLCustomMRU::LoadMRUList(DWORD dwMax)
 {
-    m_MRUData.RemoveAll();
     dwMax = max(0, dwMax);
     dwMax = min(29, dwMax);
     while (dwMax--)

--- a/dll/win32/browseui/ACLCustomMRU.h
+++ b/dll/win32/browseui/ACLCustomMRU.h
@@ -11,6 +11,8 @@
 class CACLCustomMRU :
     public CComCoClass<CACLCustomMRU, &CLSID_ACLCustomMRU>,
     public CComObjectRootEx<CComMultiThreadModelNoCS>,
+    public IEnumString,
+    public IACList,
     public IACLCustomMRU
 {
 private:
@@ -19,6 +21,7 @@ private:
     CSimpleArray<CStringW> m_MRUData;
     bool m_bDirty;
     BOOL m_bTypedURLs;
+    ULONG m_ielt;
 
     void PersistMRU();
     HRESULT LoadTypedURLs(DWORD dwMax);
@@ -27,9 +30,18 @@ public:
     CACLCustomMRU();
     ~CACLCustomMRU();
 
+    // *** IEnumString methods ***
+    STDMETHODIMP Next(ULONG celt, LPWSTR * rgelt, ULONG * pceltFetched) override;
+    STDMETHODIMP Skip(ULONG celt) override;
+    STDMETHODIMP Reset() override;
+    STDMETHODIMP Clone(IEnumString ** ppenum) override;
+
+    // *** IACList methods ***
+    STDMETHODIMP Expand(LPCOLESTR pszExpand) override;
+
     // *** IACLCustomMRU methods ***
-    virtual HRESULT STDMETHODCALLTYPE Initialize(LPCWSTR pwszMRURegKey, DWORD dwMax);
-    virtual HRESULT STDMETHODCALLTYPE AddMRUString(LPCWSTR pwszEntry);
+    STDMETHODIMP Initialize(LPCWSTR pwszMRURegKey, DWORD dwMax) override;
+    STDMETHODIMP AddMRUString(LPCWSTR pwszEntry) override;
 
 public:
 
@@ -39,6 +51,8 @@ public:
     DECLARE_PROTECT_FINAL_CONSTRUCT()
 
     BEGIN_COM_MAP(CACLCustomMRU)
+        COM_INTERFACE_ENTRY_IID(IID_IEnumString, IEnumString)
+        COM_INTERFACE_ENTRY_IID(IID_IACList, IACList)
         COM_INTERFACE_ENTRY_IID(IID_IACLCustomMRU, IACLCustomMRU)
     END_COM_MAP()
 };

--- a/dll/win32/browseui/ACLCustomMRU.h
+++ b/dll/win32/browseui/ACLCustomMRU.h
@@ -3,6 +3,7 @@
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Custom MRU AutoComplete List
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
 #pragma once
@@ -17,8 +18,10 @@ private:
     CStringW m_MRUList;
     CSimpleArray<CStringW> m_MRUData;
     bool m_bDirty;
+    BOOL m_bTypedURLs;
 
     void PersistMRU();
+    HRESULT LoadTypedURLs(DWORD dwMax);
 
 public:
     CACLCustomMRU();

--- a/dll/win32/browseui/ACLCustomMRU.h
+++ b/dll/win32/browseui/ACLCustomMRU.h
@@ -31,7 +31,7 @@ public:
     ~CACLCustomMRU();
 
     // *** IEnumString methods ***
-    STDMETHODIMP Next(ULONG celt, LPWSTR * rgelt, ULONG * pceltFetched) override;
+    STDMETHODIMP Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched) override;
     STDMETHODIMP Skip(ULONG celt) override;
     STDMETHODIMP Reset() override;
     STDMETHODIMP Clone(IEnumString ** ppenum) override;

--- a/dll/win32/browseui/ACLCustomMRU.h
+++ b/dll/win32/browseui/ACLCustomMRU.h
@@ -25,6 +25,7 @@ private:
 
     void PersistMRU();
     HRESULT LoadTypedURLs(DWORD dwMax);
+    HRESULT LoadMRUList(DWORD dwMax);
 
 public:
     CACLCustomMRU();


### PR DESCRIPTION
## Purpose

Related to #3249. `IACLCustomMRU` has to load the `TypedURLs` key correctly.
The `TypedURLs` key consists of the registry values of `"url1", "url2", "url3" etc` instead of `"MRUList"`, `"a"`, `"b"` etc.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- In `CACLCustomMRU::Initialize` method, if the key was `TypedURLs`, then load the `TypedURLs` registry key.
- If the key was `TypedURLs`, then don't save the entries.
- Implement `IEnumString` and `IACList`.

## TODOs

- [x] Reduce failures.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/94735326-89b8aa00-03a5-11eb-8674-c464e6e7f745.png)
2 failures, 1 skipped.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/94735322-89201380-03a5-11eb-8963-f195435dc53e.png)
Successful.