### PR TITLE
[MSGINA] Implement ShellTurnOffDialog CORE-17313

### DIFF
--- a/dll/win32/msgina/msgina.spec
+++ b/dll/win32/msgina/msgina.spec
@@ -6,7 +6,7 @@
 6 stub -noname ShellEnableFriendlyUI    ; (long)
 7 stub -noname ShellEnableMultipleUsers ; (long)
 8 stub -noname ShellEnableRemoteConnections ; (long)
-9 stub -noname ShellTurnOffDialog ; (long)
+9 stdcall -noname ShellTurnOffDialog(ptr)
 10 stub -noname ShellIsMultipleUsersEnabled ; ()
 11 stub -noname ShellACPIPowerButtonPressed ; (long long long)
 12 stub -noname ShellIsSingleUserNoPassword ; (wstr wstr)

--- a/dll/win32/msgina/shutdown.c
+++ b/dll/win32/msgina/shutdown.c
@@ -825,3 +825,14 @@ ShellShutdownDialog(
 
     return 0;
 }
+
+/*
+ * NOTES:
+ * - Undocumented, called from MS shell32.dll to show the turn off dialog.
+ * - Seems to have the same purpose as ShellShutdownDialog.
+ */
+DWORD WINAPI
+ShellTurnOffDialog(HWND hWnd)
+{
+    return ShellShutdownDialog(hWnd, NULL, FALSE);
+}


### PR DESCRIPTION
## Purpose

Implement undocumented `ShellTurnOffDialog` function based on the (most of all correct) following prototype: http://diendan.congdongcviet.com/threads/t13622::tim-handle-cua-cua-so-tat-may-tren-windows-nhu-the-nao.cpp?p=69284#post69284 (line 32) and return ShellShutdownDialog from it with all required parameters.
It fixes the crash when trying to open the shutdown dialog from the Start Menu with shell32.dll (and other required dlls) from Windows Server 2003 SP2 (when installing ReactOS as Workstation). So now it opens successfully, and it is possible to restart or shutdown the system properly from Start Menu without logging off (with replaced shell).

JIRA issue: [CORE-17313](https://jira.reactos.org/browse/CORE-17313)

## Result

Before:
![MS_shell32_shudtdown_dlg_bug](https://user-images.githubusercontent.com/26385117/94751592-caa6c380-0391-11eb-880e-e3a128243da5.png)

After:
![MS_shell32_shudtdown_dlg_fixed](https://user-images.githubusercontent.com/26385117/94751657-d4c8c200-0391-11eb-8e9e-babbbce9e184.png)