### PR TITLE
[USETUP] Fix usetup screen transition. CORE-17312

### DIFF
--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -235,17 +235,32 @@ CONSOLE_ClearScreen(VOID)
     coPos.X = 0;
     coPos.Y = 0;
 
+    /*
+     * Hide everything under the same foreground & background colors, so that
+     * the actual color and text blanking reset does not create a visual "blinking".
+     * We do this because we cannot do the screen scrolling trick that would
+     * allow to change both the text and the colors at the same time (the
+     * function is currently not available in our console "emulation" layer).
+     */
     FillConsoleOutputAttribute(StdOutput,
-                               FOREGROUND_WHITE | BACKGROUND_BLUE,
+                               FOREGROUND_BLUE | BACKGROUND_BLUE,
                                xScreen * yScreen,
                                coPos,
                                &Written);
 
+    /* Blank the text */
     FillConsoleOutputCharacterA(StdOutput,
                                 ' ',
                                 xScreen * yScreen,
                                 coPos,
                                 &Written);
+
+    /* Reset the actual foreground & background colors */
+    FillConsoleOutputAttribute(StdOutput,
+                               FOREGROUND_WHITE | BACKGROUND_BLUE,
+                               xScreen * yScreen,
+                               coPos,
+                               &Written);
 }
 
 VOID

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -42,8 +42,7 @@ SHORT yScreen = 0;
 /* FUNCTIONS *****************************************************************/
 
 BOOLEAN
-CONSOLE_Init(
-    VOID)
+CONSOLE_Init(VOID)
 {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
     if (!AllocConsole())
@@ -108,12 +107,11 @@ CONSOLE_ConOutChar(
 {
     DWORD Written;
 
-    WriteConsole(
-        StdOutput,
-        &c,
-        1,
-        &Written,
-        NULL);
+    WriteConsole(StdOutput,
+                 &c,
+                 1,
+                 &Written,
+                 NULL);
 }
 
 VOID
@@ -122,18 +120,16 @@ CONSOLE_ConOutPuts(
 {
     DWORD Written;
 
-    WriteConsole(
-        StdOutput,
-        szText,
-        (ULONG)strlen(szText),
-        &Written,
-        NULL);
-    WriteConsole(
-        StdOutput,
-        "\n",
-        1,
-        &Written,
-        NULL);
+    WriteConsole(StdOutput,
+                 szText,
+                 (ULONG)strlen(szText),
+                 &Written,
+                 NULL);
+    WriteConsole(StdOutput,
+                 "\n",
+                 1,
+                 &Written,
+                 NULL);
 }
 
 VOID
@@ -146,12 +142,11 @@ CONSOLE_ConOutPrintfV(
 
     vsprintf(szOut, szFormat, args);
 
-    WriteConsole(
-        StdOutput,
-        szOut,
-        (ULONG)strlen(szOut),
-        &dwWritten,
-        NULL);
+    WriteConsole(StdOutput,
+                 szOut,
+                 (ULONG)strlen(szOut),
+                 &dwWritten,
+                 NULL);
 }
 
 VOID
@@ -175,8 +170,8 @@ CONSOLE_Flush(VOID)
 
 VOID
 CONSOLE_GetCursorXY(
-    PSHORT x,
-    PSHORT y)
+    OUT PSHORT x,
+    OUT PSHORT y)
 {
     CONSOLE_SCREEN_BUFFER_INFO csbi;
 
@@ -240,19 +235,17 @@ CONSOLE_ClearScreen(VOID)
     coPos.X = 0;
     coPos.Y = 0;
 
-    FillConsoleOutputAttribute(
-        StdOutput,
-        FOREGROUND_WHITE | BACKGROUND_BLUE,
-        xScreen * yScreen,
-        coPos,
-        &Written);
+    FillConsoleOutputAttribute(StdOutput,
+                               FOREGROUND_WHITE | BACKGROUND_BLUE,
+                               xScreen * yScreen,
+                               coPos,
+                               &Written);
 
-    FillConsoleOutputCharacterA(
-        StdOutput,
-        ' ',
-        xScreen * yScreen,
-        coPos,
-        &Written);
+    FillConsoleOutputCharacterA(StdOutput,
+                                ' ',
+                                xScreen * yScreen,
+                                coPos,
+                                &Written);
 }
 
 VOID
@@ -269,12 +262,11 @@ CONSOLE_InvertTextXY(
     {
         coPos.X = x;
 
-        FillConsoleOutputAttribute(
-            StdOutput,
-            FOREGROUND_BLUE | BACKGROUND_WHITE,
-            col,
-            coPos,
-            &Written);
+        FillConsoleOutputAttribute(StdOutput,
+                                   FOREGROUND_BLUE | BACKGROUND_WHITE,
+                                   col,
+                                   coPos,
+                                   &Written);
     }
 }
 
@@ -292,12 +284,11 @@ CONSOLE_NormalTextXY(
     {
         coPos.X = x;
 
-        FillConsoleOutputAttribute(
-            StdOutput,
-            FOREGROUND_WHITE | BACKGROUND_BLUE,
-            col,
-            coPos,
-            &Written);
+        FillConsoleOutputAttribute(StdOutput,
+                                   FOREGROUND_WHITE | BACKGROUND_BLUE,
+                                   col,
+                                   coPos,
+                                   &Written);
     }
 }
 
@@ -313,12 +304,11 @@ CONSOLE_SetTextXY(
     coPos.X = x;
     coPos.Y = y;
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        Text,
-        (ULONG)strlen(Text),
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 Text,
+                                 (ULONG)strlen(Text),
+                                 coPos,
+                                 &Written);
 }
 
 VOID
@@ -357,29 +347,26 @@ CONSOLE_SetInputTextXY(
     if (Length > len - 1)
         Length = len - 1;
 
-    FillConsoleOutputAttribute(
-        StdOutput,
-        BACKGROUND_WHITE,
-        len,
-        coPos,
-        &Written);
+    FillConsoleOutputAttribute(StdOutput,
+                               BACKGROUND_WHITE,
+                               len,
+                               coPos,
+                               &Written);
 
-    WriteConsoleOutputCharacterW(
-        StdOutput,
-        Text,
-        (ULONG)Length,
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterW(StdOutput,
+                                 Text,
+                                 (ULONG)Length,
+                                 coPos,
+                                 &Written);
 
     coPos.X += Length;
     if (len > Length)
     {
-        FillConsoleOutputCharacterA(
-            StdOutput,
-            ' ',
-            len - Length,
-            coPos,
-            &Written);
+        FillConsoleOutputCharacterA(StdOutput,
+                                    ' ',
+                                    len - Length,
+                                    coPos,
+                                    &Written);
     }
 }
 
@@ -398,20 +385,18 @@ CONSOLE_SetUnderlinedTextXY(
 
     Length = (ULONG)strlen(Text);
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        Text,
-        Length,
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 Text,
+                                 Length,
+                                 coPos,
+                                 &Written);
 
     coPos.Y++;
-    FillConsoleOutputCharacterA(
-        StdOutput,
-        0xCD,
-        Length,
-        coPos,
-        &Written);
+    FillConsoleOutputCharacterA(StdOutput,
+                                0xCD,
+                                Length,
+                                coPos,
+                                &Written);
 }
 
 VOID
@@ -429,28 +414,25 @@ CONSOLE_SetStatusTextXV(
     coPos.X = 0;
     coPos.Y = yScreen - 1;
 
-    FillConsoleOutputAttribute(
-        StdOutput,
-        BACKGROUND_WHITE,
-        xScreen,
-        coPos,
-        &Written);
+    FillConsoleOutputAttribute(StdOutput,
+                               BACKGROUND_WHITE,
+                               xScreen,
+                               coPos,
+                               &Written);
 
-    FillConsoleOutputCharacterA(
-        StdOutput,
-        ' ',
-        xScreen,
-        coPos,
-        &Written);
+    FillConsoleOutputCharacterA(StdOutput,
+                                ' ',
+                                xScreen,
+                                coPos,
+                                &Written);
 
     coPos.X = x;
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        Buffer,
-        (ULONG)strlen(Buffer),
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 Buffer,
+                                 (ULONG)strlen(Buffer),
+                                 coPos,
+                                 &Written);
 }
 
 VOID
@@ -490,8 +472,9 @@ CONSOLE_SetStatusText(
 
 static
 VOID
-CONSOLE_ClearStatusTextX(IN SHORT x,
-                         IN SHORT Length)
+CONSOLE_ClearStatusTextX(
+    IN SHORT x,
+    IN SHORT Length)
 {
     COORD coPos;
     DWORD Written;
@@ -506,12 +489,12 @@ CONSOLE_ClearStatusTextX(IN SHORT x,
                                 &Written);
 }
 
-
 VOID
 __cdecl
 CONSOLE_SetStatusTextAutoFitX(
     IN SHORT x,
-    IN LPCSTR fmt, ...)
+    IN LPCSTR fmt,
+    ...)
 {
     CHAR Buffer[128];
     DWORD Length;
@@ -525,11 +508,11 @@ CONSOLE_SetStatusTextAutoFitX(
 
     if (Length + x <= 79)
     {
-        CONSOLE_SetStatusTextX (x , Buffer);
+        CONSOLE_SetStatusTextX(x , Buffer);
     }
     else
     {
-        CONSOLE_SetStatusTextX (79 - Length , Buffer);
+        CONSOLE_SetStatusTextX(79 - Length , Buffer);
     }
 }
 
@@ -548,19 +531,17 @@ CONSOLE_SetInvertedTextXY(
 
     Length = (ULONG)strlen(Text);
 
-    FillConsoleOutputAttribute(
-        StdOutput,
-        FOREGROUND_BLUE | BACKGROUND_WHITE,
-        Length,
-        coPos,
-        &Written);
+    FillConsoleOutputAttribute(StdOutput,
+                               FOREGROUND_BLUE | BACKGROUND_WHITE,
+                               Length,
+                               coPos,
+                               &Written);
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        Text,
-        Length,
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 Text,
+                                 Length,
+                                 coPos,
+                                 &Written);
 }
 
 VOID
@@ -578,19 +559,17 @@ CONSOLE_SetHighlightedTextXY(
 
     Length = (ULONG)strlen(Text);
 
-    FillConsoleOutputAttribute(
-        StdOutput,
-        FOREGROUND_WHITE | FOREGROUND_INTENSITY | BACKGROUND_BLUE,
-        Length,
-        coPos,
-        &Written);
+    FillConsoleOutputAttribute(StdOutput,
+                               FOREGROUND_WHITE | FOREGROUND_INTENSITY | BACKGROUND_BLUE,
+                               Length,
+                               coPos,
+                               &Written);
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        Text,
-        Length,
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 Text,
+                                 Length,
+                                 coPos,
+                                 &Written);
 }
 
 VOID
@@ -598,7 +577,8 @@ __cdecl
 CONSOLE_PrintTextXY(
     IN SHORT x,
     IN SHORT y,
-    IN LPCSTR fmt, ...)
+    IN LPCSTR fmt,
+    ...)
 {
     CHAR buffer[512];
     va_list ap;
@@ -612,12 +592,11 @@ CONSOLE_PrintTextXY(
     coPos.X = x;
     coPos.Y = y;
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        buffer,
-        (ULONG)strlen(buffer),
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 buffer,
+                                 (ULONG)strlen(buffer),
+                                 coPos,
+                                 &Written);
 }
 
 VOID
@@ -626,7 +605,8 @@ CONSOLE_PrintTextXYN(
     IN SHORT x,
     IN SHORT y,
     IN SHORT len,
-    IN LPCSTR fmt, ...)
+    IN LPCSTR fmt,
+    ...)
 {
     CHAR buffer[512];
     va_list ap;
@@ -645,23 +625,21 @@ CONSOLE_PrintTextXYN(
     if (Length > len - 1)
         Length = len - 1;
 
-    WriteConsoleOutputCharacterA(
-        StdOutput,
-        buffer,
-        Length,
-        coPos,
-        &Written);
+    WriteConsoleOutputCharacterA(StdOutput,
+                                 buffer,
+                                 Length,
+                                 coPos,
+                                 &Written);
 
     coPos.X += Length;
 
     if (len > Length)
     {
-        FillConsoleOutputCharacterA(
-            StdOutput,
-            ' ',
-            len - Length,
-            coPos,
-            &Written);
+        FillConsoleOutputCharacterA(StdOutput,
+                                    ' ',
+                                    len - Length,
+                                    coPos,
+                                    &Written);
     }
 }
 
@@ -693,7 +671,7 @@ CONSOLE_SetStyledText(
 
     if (Flags & TEXT_ALIGN_CENTER)
     {
-        coPos.X = (xScreen - Length) /2;
+        coPos.X = (xScreen - Length) / 2;
     }
     else if(Flags & TEXT_ALIGN_RIGHT)
     {
@@ -749,12 +727,12 @@ CONSOLE_SetStyledText(
     }
 }
 
-
 VOID
-CONSOLE_ClearStyledText(IN SHORT x,
-                        IN SHORT y,
-                        IN INT Flags,
-                        IN SHORT Length)
+CONSOLE_ClearStyledText(
+    IN SHORT x,
+    IN SHORT y,
+    IN INT Flags,
+    IN SHORT Length)
 {
     COORD coPos;
 
@@ -774,7 +752,7 @@ CONSOLE_ClearStyledText(IN SHORT x,
 
     if (Flags & TEXT_ALIGN_CENTER)
     {
-        coPos.X = (xScreen - Length) /2;
+        coPos.X = (xScreen - Length) / 2;
     }
     else if(Flags & TEXT_ALIGN_RIGHT)
     {

--- a/base/setup/usetup/consup.h
+++ b/base/setup/usetup/consup.h
@@ -54,8 +54,7 @@ extern HANDLE StdInput, StdOutput;
 extern SHORT xScreen, yScreen;
 
 BOOLEAN
-CONSOLE_Init(
-    VOID);
+CONSOLE_Init(VOID);
 
 VOID
 CONSOLE_ClearScreen(VOID);
@@ -92,8 +91,8 @@ CONSOLE_Flush(VOID);
 
 VOID
 CONSOLE_GetCursorXY(
-    PSHORT x,
-    PSHORT y);
+    OUT PSHORT x,
+    OUT PSHORT y);
 
 SHORT
 CONSOLE_GetCursorX(VOID);
@@ -120,7 +119,8 @@ __cdecl
 CONSOLE_PrintTextXY(
     IN SHORT x,
     IN SHORT y,
-    IN LPCSTR fmt, ...);
+    IN LPCSTR fmt,
+    ...);
 
 VOID
 __cdecl
@@ -128,7 +128,8 @@ CONSOLE_PrintTextXYN(
     IN SHORT x,
     IN SHORT y,
     IN SHORT len,
-    IN LPCSTR fmt, ...);
+    IN LPCSTR fmt,
+    ...);
 
 VOID
 CONSOLE_SetCursorType(
@@ -192,7 +193,8 @@ VOID
 __cdecl
 CONSOLE_SetStatusTextAutoFitX(
     IN SHORT x,
-    IN LPCSTR fmt, ...);
+    IN LPCSTR fmt,
+    ...);
 
 VOID
 CONSOLE_SetTextXY(
@@ -220,9 +222,10 @@ CONSOLE_SetStyledText(
     IN LPCSTR Text);
 
 VOID
-CONSOLE_ClearStyledText(IN SHORT x,
-                        IN SHORT y,
-                        IN INT Flags,
-                        IN SHORT Length);
+CONSOLE_ClearStyledText(
+    IN SHORT x,
+    IN SHORT y,
+    IN INT Flags,
+    IN SHORT Length);
 
 /* EOF */


### PR DESCRIPTION
## Purpose

Fix the visual "blinking" that occurs due to screen clearing, whenever a screen transition is done.

JIRA issue: [CORE-17312](https://jira.reactos.org/browse/CORE-17312)

## Proposed changes

Hide everything under the same foreground & background colors, so that
the actual color and text blanking reset does not create a visual "blinking".
Then, blank the text and finally reset the actual foreground &
background colors.

We do this because we cannot do the screen scrolling trick that would
allow to change both the text and the colors at the same time (the
function is currently not available in our console "emulation" layer).
