### PR TITLE
[NTOS:KE] KiInitializePcr(): Zero the actual PCR size, not PAGE_SIZE

### DIFF
--- a/ntoskrnl/ke/amd64/kiinit.c
+++ b/ntoskrnl/ke/amd64/kiinit.c
@@ -97,7 +97,7 @@ KiInitializePcr(IN PKIPCR Pcr,
     USHORT Tr = 0;
 
     /* Zero out the PCR */
-    RtlZeroMemory(Pcr, sizeof(KIPCR));
+    RtlZeroMemory(Pcr, sizeof(*Pcr));
 
     /* Set pointers to ourselves */
     Pcr->Self = (PKPCR)Pcr;
@@ -147,10 +147,6 @@ KiInitializePcr(IN PKIPCR Pcr,
 
     /* Setup the processor set */
     Pcr->Prcb.MultiThreadProcessorSet = Pcr->Prcb.SetMember;
-
-    /* Clear DR6/7 to cleanup bootloader debugging */
-    Pcr->Prcb.ProcessorState.SpecialRegisters.KernelDr6 = 0;
-    Pcr->Prcb.ProcessorState.SpecialRegisters.KernelDr7 = 0;
 
     /* Set the Current Thread */
     Pcr->Prcb.CurrentThread = IdleThread;

--- a/ntoskrnl/ke/arm/kiinit.c
+++ b/ntoskrnl/ke/arm/kiinit.c
@@ -183,6 +183,9 @@ KiInitializePcr(IN ULONG ProcessorNumber,
 {
     ULONG i;
 
+    /* Zero out the PCR */
+    RtlZeroMemory(Pcr, sizeof(*Pcr));
+
     /* Set the Current Thread */
     Pcr->Prcb.CurrentThread = IdleThread;
 
@@ -356,7 +359,6 @@ KiInitializeSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     if (Cpu) goto AppCpuInit;
 
     /* Initialize the PCR */
-    RtlZeroMemory(Pcr, PAGE_SIZE);
     KiInitializePcr(Cpu,
                     Pcr,
                     InitialThread,

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -341,6 +341,9 @@ KiInitializePcr(IN ULONG ProcessorNumber,
                 IN PKTHREAD IdleThread,
                 IN PVOID DpcStack)
 {
+    /* Zero out the PCR */
+    RtlZeroMemory(Pcr, sizeof(*Pcr));
+
     /* Setup the TIB */
     Pcr->NtTib.ExceptionList = EXCEPTION_CHAIN_END;
     Pcr->NtTib.StackBase = 0;
@@ -760,7 +763,6 @@ KiSystemStartup(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     Ki386InitializeTss(Tss, Idt, Gdt);
 
     /* Initialize the PCR */
-    RtlZeroMemory(Pcr, PAGE_SIZE);
     KiInitializePcr(Cpu,
                     Pcr,
                     Idt,

--- a/ntoskrnl/ke/powerpc/kiinit.c
+++ b/ntoskrnl/ke/powerpc/kiinit.c
@@ -85,6 +85,9 @@ KiInitializePcr(IN ULONG ProcessorNumber,
                 IN PKTHREAD IdleThread,
                 IN PVOID DpcStack)
 {
+    /* Zero out the PCR */
+    RtlZeroMemory(Pcr, sizeof(*Pcr));
+
     Pcr->MajorVersion = PCR_MAJOR_VERSION;
     Pcr->MinorVersion = PCR_MINOR_VERSION;
     Pcr->CurrentIrql = PASSIVE_LEVEL;
@@ -298,7 +301,6 @@ KiSystemStartupReal(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     if (Cpu) goto AppCpuInit;
 
     /* Initialize the PCR */
-    RtlZeroMemory(Pcr, PAGE_SIZE);
     KiInitializePcr(Cpu,
                     Pcr,
                     &KiInitialThread.Tcb,


### PR DESCRIPTION
## Purpose

Better safe than sorry: no overrun.

## Proposed changes

For example, on i386: 4064 < 4096.

Follow-up to 597c140 (r55405).
