### PR TITLE
[KEYBOARD][NTDLL_APITEST] Remove 'set_property(... C_STANDARD 99)'

### DIFF
--- a/dll/keyboard/CMakeLists.txt
+++ b/dll/keyboard/CMakeLists.txt
@@ -102,9 +102,6 @@ foreach(_keyboard_layout ${_keyboard_layouts})
     else()
         # Use a custom linker script
         add_target_link_flags(${_keyboard_layout} "-Wl,-T,${CMAKE_CURRENT_SOURCE_DIR}/kbdlayout.lds")
-
-        # Avoid "universal character names are only valid in C++ and C99" error.
-        set_property(TARGET ${_keyboard_layout} PROPERTY C_STANDARD 99)
     endif()
 
     # dynamic analysis switches

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -100,9 +100,6 @@ add_pch(ntdll_apitest precomp.h "${PCH_SKIP_SOURCE}")
 
 if(NOT MSVC)
     set_source_files_properties(RtlGetFullPathName_UstrEx.c PROPERTIES COMPILE_FLAGS "-Wno-format")
-
-    # Avoid "universal character names are only valid in C++ and C99" error.
-    set_property(TARGET ntdll_apitest PROPERTY C_STANDARD 99)
 endif()
 
 add_rostests_file(TARGET ntdll_apitest)


### PR DESCRIPTION
## Purpose

Cleanup.

## Proposed changes

C99 is the default now.

Follow-up to 95483b4.