### PR TITLE
[NTOSKRNL] include/config.h: Sync it to current code

### DIFF
--- a/ntoskrnl/include/config.h
+++ b/ntoskrnl/include/config.h
@@ -1,40 +1,4 @@
 #pragma once
 
-/********** dbg/print.c **********/
-
-/* Enable serialization of debug messages printed with DbgPrint
- *
- * If this is enabled DbgPrint will queue messages if another thread is already
- * printing a message, and immediately returns. The other thread will print
- * queued messages before it returns.
- * It could happen that some messages are lost if the processor is halted before
- * the message queue was flushed.
- */
-#undef SERIALIZE_DBGPRINT
-
-/********** mm/ppool.c **********/
-
-/* Disable Debugging Features */
-#if !DBG
-    /* Enable strict checking of the nonpaged pool on every allocation */
-    #undef ENABLE_VALIDATE_POOL
-
-    /* Enable tracking of statistics about the tagged blocks in the pool */
-    #undef TAG_STATISTICS_TRACKING
-
-    /* Enable Memory Debugging Features/Helpers */
-    #undef POOL_DEBUG_APIS
-
-    /* Enable Redzone */
-    #define R_RZ 0
-
-    /* Enable Allocator Stack */
-    #define R_STACK 0
-
-    /*
-     * Put each block in its own range of pages and position the block at the
-     * end of the range so any accesses beyond the end of block are to invalid
-     * memory locations.
-     */
-    #undef WHOLE_PAGE_ALLOCATIONS
-#endif
+// Enable global page support.
+// #define _GLOBAL_PAGES_ARE_AWESOME_

--- a/ntoskrnl/include/ntoskrnl.h
+++ b/ntoskrnl/include/ntoskrnl.h
@@ -109,8 +109,8 @@ C_ASSERT(MAX_WIN32_PATH == MAX_PATH);
 #undef MAX_PATH
 
 /* Internal Headers */
-#include "internal/ntoskrnl.h"
 #include "config.h"
+#include "internal/ntoskrnl.h"
 
 #include <reactos/probe.h>
 #include "internal/probe.h"

--- a/ntoskrnl/include/ntoskrnl.h
+++ b/ntoskrnl/include/ntoskrnl.h
@@ -108,13 +108,6 @@
 C_ASSERT(MAX_WIN32_PATH == MAX_PATH);
 #undef MAX_PATH
 
-//
-// Switch for enabling global page support
-//
-
-//#define _GLOBAL_PAGES_ARE_AWESOME_
-
-
 /* Internal Headers */
 #include "internal/ntoskrnl.h"
 #include "config.h"


### PR DESCRIPTION
## Purpose

Cleanup.

## Proposed changes

```
* SERIALIZE_DBGPRINT: Removed on c15e04c (r18078).
* ENABLE_VALIDATE_POOL: Removed on 5899e14 (r42249).
* TAG_STATISTICS_TRACKING: Removed on 5899e14 (r42249).
* POOL_DEBUG_APIS: Removed on 5899e14 (r42249).
* R_RZ: Removed on 7d21cf7 (r48999).
* R_STACK: Removed on 7d21cf7 (r48999).
* WHOLE_PAGE_ALLOCATIONS: Removed on b431563 (r17306).
+
* _GLOBAL_PAGES_ARE_AWESOME_: Move it here.
```