### PR TITLE
[BROWSEUI] Remove '\1' from AutoComplete list

### DIFF
--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -35,7 +35,7 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
 
     CStringW str = m_MRUData[m_ielt];
 
-    if (!m_bTypedURLs && !PathFileExistsW(str))
+    if (!m_bTypedURLs)
     {
         // Erase the last "\\1" etc. (indicates SW_* value)
         INT ich = str.ReverseFind(L'\\');

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -33,12 +33,22 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
     if (INT(m_ielt) >= m_MRUData.GetSize())
         return S_FALSE;
 
-    size_t cb = (m_MRUData[m_ielt].GetLength() + 1) * sizeof(WCHAR);
+    CStringW str = m_MRUData[m_ielt];
+
+    if (!m_bTypedURLs)
+    {
+        // Erase the last "\\1" etc. (indicates SW_* value)
+        INT ich = str.ReverseFind(L'\\');
+        if (ich >= 0)
+            str = str.Left(ich);
+    }
+
+    size_t cb = (str.GetLength() + 1) * sizeof(WCHAR);
     LPWSTR psz = (LPWSTR)CoTaskMemAlloc(cb);
     if (!psz)
         return S_FALSE;
 
-    CopyMemory(psz, (LPCWSTR)m_MRUData[m_ielt], cb);
+    CopyMemory(psz, (LPCWSTR)str, cb);
     *rgelt = psz;
     *pceltFetched = 1;
     ++m_ielt;

--- a/dll/win32/browseui/ACLCustomMRU.cpp
+++ b/dll/win32/browseui/ACLCustomMRU.cpp
@@ -35,7 +35,7 @@ STDMETHODIMP CACLCustomMRU::Next(ULONG celt, LPWSTR *rgelt, ULONG *pceltFetched)
 
     CStringW str = m_MRUData[m_ielt];
 
-    if (!m_bTypedURLs)
+    if (!m_bTypedURLs && !PathFileExistsW(str))
     {
         // Erase the last "\\1" etc. (indicates SW_* value)
         INT ich = str.ReverseFind(L'\\');


### PR DESCRIPTION
## Purpose

Delete "backslash one" (indicates `SW_` values) from auto-completion list.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/95041520-e1427700-0711-11eb-83c9-1ebc6837b81e.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/95041517-e0a9e080-0711-11eb-8299-4220947c8b1c.png)