### PR TITLE
[WIN32SS] Fix CF_DIB format not being saved to clipboard on Print Screen key

### DIFF
--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -221,7 +221,9 @@ static PVOID AllocSysObjectCB(
     ASSERT(Size > sizeof(HEAD));
 
     /* Allocate the clipboard data */
-    Object = ExAllocatePoolZero(PagedPool, Size, USERTAG_CLIPBOARD);
+    // FIXME: This allocation should be done on the current session pool;
+    // however ReactOS' MM doesn't support session pool yet.
+    Object = ExAllocatePoolZero(/* SESSION_POOL_MASK | */ PagedPool, Size, USERTAG_CLIPBOARD);
     if (!Object)
     {
         ERR("ExAllocatePoolZero failed. No object created.\n");

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -207,10 +207,43 @@ static PVOID AllocSysObject(
     return Object;
 }
 
+_Success_(return!=NULL)
+static PVOID AllocSysObjectCB(
+    _In_ PDESKTOP pDesk,
+    _In_ PTHREADINFO pti,
+    _In_ SIZE_T Size,
+    _Out_ PVOID* ObjectOwner)
+{
+    PVOID Object;
+
+    UNREFERENCED_PARAMETER(pDesk);
+    UNREFERENCED_PARAMETER(pti);
+    ASSERT(Size > sizeof(HEAD));
+
+    /* Allocate the clipboard data */
+    Object =  ExAllocatePoolWithTag(PagedPool, Size, USERTAG_CLIPBOARD);
+
+    if (!Object)
+    {
+        ERR("Object is NULL-No Object Created.\n");
+        return NULL;
+    }
+
+    *ObjectOwner = NULL;
+    RtlZeroMemory(Object, Size);
+    return Object;
+}
+
 static void FreeSysObject(
     _In_ PVOID Object)
 {
     UserHeapFree(Object);
+}
+
+static void FreeSysObjectCB(
+    _In_ PVOID Object)
+{
+    ExFreePoolWithTag(Object, USERTAG_CLIPBOARD);
 }
 
 static const struct
@@ -226,7 +259,7 @@ static const struct
     { AllocProcMarkObject,      IntDestroyCurIconObject,    FreeCurIconObject },    /* TYPE_CURSOR */
     { AllocSysObject,           /*UserSetWindowPosCleanup*/NULL, FreeSysObject },   /* TYPE_SETWINDOWPOS */
     { AllocDeskThreadObject,    IntRemoveHook,              FreeDeskThreadObject }, /* TYPE_HOOK */
-    { AllocSysObject,           /*UserClipDataCleanup*/NULL,FreeSysObject },        /* TYPE_CLIPDATA */
+    { AllocSysObjectCB,         /*UserClipDataCleanup*/NULL,FreeSysObjectCB },      /* TYPE_CLIPDATA */
     { AllocDeskProcObject,      DestroyCallProc,            FreeDeskProcObject },   /* TYPE_CALLPROC */
     { AllocProcMarkObject,      UserDestroyAccelTable,      FreeProcMarkObject },   /* TYPE_ACCELTABLE */
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDEACCESS */

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -221,16 +221,14 @@ static PVOID AllocSysObjectCB(
     ASSERT(Size > sizeof(HEAD));
 
     /* Allocate the clipboard data */
-    Object = ExAllocatePoolWithTag(PagedPool, Size, USERTAG_CLIPBOARD);
-
+    Object = ExAllocatePoolZero(PagedPool, Size, USERTAG_CLIPBOARD);
     if (!Object)
     {
-        ERR("ExAllocatePoolWithTag failed, no object created.\n");
+        ERR("ExAllocatePoolZero failed. No object created.\n");
         return NULL;
     }
 
     *ObjectOwner = NULL;
-    RtlZeroMemory(Object, Size);
     return Object;
 }
 

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -221,11 +221,11 @@ static PVOID AllocSysObjectCB(
     ASSERT(Size > sizeof(HEAD));
 
     /* Allocate the clipboard data */
-    Object =  ExAllocatePoolWithTag(PagedPool, Size, USERTAG_CLIPBOARD);
+    Object = ExAllocatePoolWithTag(PagedPool, Size, USERTAG_CLIPBOARD);
 
     if (!Object)
     {
-        ERR("Object is NULL-No Object Created.\n");
+        ERR("ExAllocatePoolWithTag failed, no object created.\n");
         return NULL;
     }
 


### PR DESCRIPTION
##  Send CF_DIB data to clipboard when the PrntScrn key is hit

_Add memory allocation for CF_DIB formatted data on clipboard_

JIRA issue: [CORE-17318](https://jira.reactos.org/browse/CORE-17318)

## Add code to Allocate and Free pool memory for use by CF_DIB formatted data