### PR TITLE
[BOOTDATA] Comment out biosinfo.inf

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -5,7 +5,7 @@ Signature = "$Windows NT$"
 
 HKLM,"SYSTEM\CurrentControlSet\Control","CurrentUser",2,"USERNAME"
 HKLM,"SYSTEM\CurrentControlSet\Control","WaitToKillServiceTimeout",2,"20000"
-HKLM,"SYSTEM\CurrentControlSet\Control\Biosinfo","InfName",2,"biosinfo.inf"
+;HKLM,"SYSTEM\CurrentControlSet\Control\Biosinfo","InfName",2,"biosinfo.inf"
 HKLM,"SYSTEM\CurrentControlSet\Control\PnP",,0x00000012
 HKLM,"SYSTEM\CurrentControlSet\Control\Video",,0x00000012
 


### PR DESCRIPTION
This entry is unused as there is no biosinfo.inf anywhere yet, and it only breaks boot with NTLDR

Before:
<img width="360" alt="vmplayer_sCAi8sUNEl" src="https://user-images.githubusercontent.com/32551254/95082970-27043d00-071c-11eb-942a-29b07be8411a.png">

After:
<img width="400" alt="vmplayer_3VBA87p7UE" src="https://user-images.githubusercontent.com/32551254/95082999-2ec3e180-071c-11eb-8982-85ff932e9a90.png">

