### PR TITLE
[NTOS:MM] MiWriteProtectSystemImage(): Leave image header as R/W, on …

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2480,7 +2480,9 @@ MiWriteProtectSystemImage(
     Protection = IMAGE_SCN_MEM_READ;
     if (LastPte >= FirstPte)
     {
+#if defined(CORE_16387_IS_FIXED) || DBG
         MiSetSystemCodeProtection(FirstPte, LastPte, IMAGE_SCN_MEM_READ);
+#endif
     }
 
     /* Loop the sections */


### PR DESCRIPTION
…non-Debug builds

## Purpose

Minimal workaround, compared to 'MmEnforceWriteProtection = FALSE' until now.

JIRA issue: [CORE-16387](https://jira.reactos.org/browse/CORE-16387)

## TODO

- [ ] Test whether this hack actually works around this issue. (I can't do it.)
