### PR TITLE
[NTOS:MM] MmLoadSystemImage(): Leave whole image as R/W, on non-Debug…

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -3249,7 +3249,9 @@ LoaderScan:
     /* FIXME: Call driver verifier's loader function */
 
     /* Write-protect the system image */
+#if defined(CORE_16449_IS_FIXED) || DBG
     MiWriteProtectSystemImage(LdrEntry->DllBase);
+#endif
 
     /* Check if notifications are enabled */
     if (PsImageNotifyEnabled)

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -3250,8 +3250,12 @@ LoaderScan:
 
     /* Write-protect the system image */
 #if !defined(CORE_16449_IS_FIXED) && DBG
-    DPRINT1("(CORE-16449) Calling MiWriteProtectSystemImage(%p) for %wZ\n",
-            LdrEntry->DllBase, &LdrEntry->FullDllName);
+    if (wcscmp(LdrEntry->BaseDllName.Buffer, L"ftfd.dll"  ) == 0 ||
+        wcscmp(LdrEntry->BaseDllName.Buffer, L"win32k.sys") == 0)
+    {
+        DPRINT1("(CORE-16449) Calling MiWriteProtectSystemImage(%p) for %wZ\n",
+                LdrEntry->DllBase, &LdrEntry->FullDllName);
+    }
 #endif
 #if defined(CORE_16449_IS_FIXED) || DBG
     MiWriteProtectSystemImage(LdrEntry->DllBase);

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -3249,6 +3249,10 @@ LoaderScan:
     /* FIXME: Call driver verifier's loader function */
 
     /* Write-protect the system image */
+#if !defined(CORE_16449_IS_FIXED) && DBG
+    DPRINT1("(CORE-16449) Calling MiWriteProtectSystemImage(%p) for %wZ\n",
+            LdrEntry->DllBase, &LdrEntry->FullDllName);
+#endif
 #if defined(CORE_16449_IS_FIXED) || DBG
     MiWriteProtectSystemImage(LdrEntry->DllBase);
 #endif

--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2415,8 +2415,8 @@ MiSetSystemCodeProtection(
         /* Make sure it's valid */
         if (TempPte.u.Hard.Valid != 1)
         {
-            DPRINT1("CORE-16449: FirstPte=%p, LastPte=%p, Protection=%lx\n", FirstPte, LastPte, Protection);
-            DPRINT1("CORE-16449: PointerPte=%p, TempPte=%lx\n", PointerPte, TempPte.u.Long);
+            DPRINT1("CORE-16449: FirstPte=%p, LastPte=%p, Protection=0x%08lx\n", FirstPte, LastPte, Protection);
+            DPRINT1("CORE-16449: PointerPte=%p, TempPte=0x%08lx\n", PointerPte, TempPte.u.Long);
             DPRINT1("CORE-16449: Please issue the 'mod' and 'bt' (KDBG) or 'lm' and 'kp' (WinDbg) commands. Then report this in Jira.\n");
             ASSERT(TempPte.u.Hard.Valid == 1);
             break;


### PR DESCRIPTION
… builds

## Purpose

Minimal workaround, compared to 'MmEnforceWriteProtection = FALSE' until now.

JIRA issue: [CORE-16449](https://jira.reactos.org/browse/CORE-16449)

## Proposed changes

And add a couple DPRINT1(), to automatically log data.
