### PR TITLE
[NTOS:MM] MiWriteProtectSystemImage(): Add an explicit text to a DPRI…

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2533,7 +2533,7 @@ MiWriteProtectSystemImage(
     if (ALIGN_UP_POINTER_BY(SectionEnd, PAGE_SIZE) !=
         Add2Ptr(ImageBase, NtHeaders->OptionalHeader.SizeOfImage))
     {
-        DPRINT1("ImageBase 0x%p ImageSize 0x%lx Section %u VA 0x%lx Raw 0x%lx virt 0x%lx\n",
+        DPRINT1("WARNING: Image does not end with its last section. (ImageBase 0x%p ImageSize 0x%lx Section %lu VA 0x%lx Raw 0x%lx virt 0x%lx)\n",
             ImageBase,
             NtHeaders->OptionalHeader.SizeOfImage,
             i,


### PR DESCRIPTION
…NT1()

## Purpose

Draw more attention to this case.

JIRA issue: [CORE-16387](https://jira.reactos.org/browse/CORE-16387)
