### PR TITLE
[NETAPI32] DsRoleFreeMemory(): Leak, for the time being

### DIFF
--- a/dll/win32/netapi32/dssetup.c
+++ b/dll/win32/netapi32/dssetup.c
@@ -83,7 +83,8 @@ DsRoleFreeMemory(
     _In_ PVOID Buffer)
 {
     TRACE("DsRoleFreeMemory(%p)\n", Buffer);
-    HeapFree(GetProcessHeap(), 0, Buffer);
+    // FIXME: Leak, until fixed to free the right memory. (CORE-13491)
+    // HeapFree(GetProcessHeap(), 0, Buffer);
 }
 
 


### PR DESCRIPTION
Better leak right memory than free wrong one.

Addendum to dc2aa92 (r66523).
JIRA issue: [CORE-13491](https://jira.reactos.org/browse/CORE-13491)
