### PR TITLE
[FASTFAT] Ensure that deferred write IRP contexts are not touched.

### DIFF
--- a/drivers/filesystems/fastfat/vfat.h
+++ b/drivers/filesystems/fastfat/vfat.h
@@ -1189,7 +1189,7 @@ VfatRead(
 
 NTSTATUS
 VfatWrite(
-    PVFAT_IRP_CONTEXT IrpContext);
+    PVFAT_IRP_CONTEXT *pIrpContext);
 
 NTSTATUS
 NextCluster(


### PR DESCRIPTION
Cc may decide to process deferred writes any time, so the context might
already be freed by the time we return from CcDeferWrite.
Also mark the IRPs as pending.

JIRA issue: [CORE-17328](https://jira.reactos.org/browse/CORE-17328)