### PR TITLE
[CMD] Fix a typo in filename completion

### DIFF
--- a/base/shell/cmd/filecomp.c
+++ b/base/shell/cmd/filecomp.c
@@ -395,9 +395,9 @@ VOID FindPrefixAndSuffix(LPTSTR strIN, LPTSTR szPrefix, LPTSTR szSuffix)
         szSearch1 = _tcsrchr(str, _T('\"'));
         szSearch2 = _tcsrchr(str, _T('\\'));
         szSearch3 = _tcsrchr(str, _T('/'));
-        if (szSearch2 != NULL && _tcslen(szSearch1) > _tcslen(szSearch2))
+        if ((szSearch2 != NULL) && (szSearch1 < szSearch2))
             szSearch = szSearch2;
-        else if (szSearch3 != NULL && _tcslen(szSearch1) > _tcslen(szSearch3))
+        else if ((szSearch3 != NULL) && (szSearch1 < szSearch3))
             szSearch = szSearch3;
         else
             szSearch = szSearch1;

--- a/base/shell/cmd/filecomp.c
+++ b/base/shell/cmd/filecomp.c
@@ -394,7 +394,7 @@ VOID FindPrefixAndSuffix(LPTSTR strIN, LPTSTR szPrefix, LPTSTR szSuffix)
         /* Find the one closest to end */
         szSearch1 = _tcsrchr(str, _T('\"'));
         szSearch2 = _tcsrchr(str, _T('\\'));
-        szSearch3 = _tcsrchr(str, _T('.'));
+        szSearch3 = _tcsrchr(str, _T('/'));
         if (szSearch2 != NULL && _tcslen(szSearch1) > _tcslen(szSearch2))
             szSearch = szSearch2;
         else if (szSearch3 != NULL && _tcslen(szSearch1) > _tcslen(szSearch3))

--- a/base/shell/cmd/filecomp.c
+++ b/base/shell/cmd/filecomp.c
@@ -440,9 +440,9 @@ VOID FindPrefixAndSuffix(LPTSTR strIN, LPTSTR szPrefix, LPTSTR szSuffix)
         szSearch1 = _tcsrchr(str, _T(' '));
         szSearch2 = _tcsrchr(str, _T('\\'));
         szSearch3 = _tcsrchr(str, _T('/'));
-        if (szSearch2 != NULL && _tcslen(szSearch1) > _tcslen(szSearch2))
+        if ((szSearch2 != NULL) && (szSearch1 < szSearch2))
             szSearch = szSearch2;
-        else if (szSearch3 != NULL && _tcslen(szSearch1) > _tcslen(szSearch3))
+        else if ((szSearch3 != NULL) && (szSearch1 < szSearch3))
             szSearch = szSearch3;
         else
             szSearch = szSearch1;


### PR DESCRIPTION
When using cmd, you can press TAB to invoke auto filename completion,
but it could cause a incorrect result. For example, if the current
directory is `C:\Documents and Settings\Administrator\`, then you input
`".` and press TAB, the completion result would be `".Administrator"`,
which even does not exist.

Maybe it is a typo, because the `.` and the `/` are neighboring on the
keyboard.
