### PR TITLE
[NTUSER] Fix Shell Hook HSHELL_WINDOWCREATED

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2281,20 +2281,6 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    /* Send the WM_PARENTNOTIFY message */
    IntSendParentNotify(Window, WM_CREATE);
 
-   /* Notify the shell that a new window was created */
-   if (Window->spwndOwner == NULL ||
-       !(Window->spwndOwner->style & WS_VISIBLE) ||
-       (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
-   {
-      if (UserIsDesktopWindow(Window->spwndParent) &&
-          (Window->style & WS_VISIBLE) &&
-          (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
-           (Window->ExStyle & WS_EX_APPWINDOW)))
-      {
-         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
-      }
-   }
-
    /* Initialize and show the window's scrollbars */
    if (Window->style & WS_VSCROLL)
    {

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2282,17 +2282,12 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    IntSendParentNotify(Window, WM_CREATE);
 
    /* Notify the shell that a new window was created */
-   if (Window->spwndOwner == NULL ||
-       !(Window->spwndOwner->style & WS_VISIBLE) ||
-       (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
+   if ((Window->style & WS_VISIBLE) &&
+       ((Window->ExStyle & (WS_EX_APPWINDOW | WS_EX_TOOLWINDOW)) >= WS_EX_APPWINDOW ||
+        (!(Window->ExStyle & WS_EX_TOOLWINDOW) && !Window->spwndOwner &&
+         (!Window->spwndParent || UserIsDesktopWindow(Window->spwndParent)))))
    {
-      if (UserIsDesktopWindow(Window->spwndParent) &&
-          (Window->style & WS_VISIBLE) &&
-          (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
-           (Window->ExStyle & WS_EX_APPWINDOW)))
-      {
-         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
-      }
+      co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
    }
 
    /* Initialize and show the window's scrollbars */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2282,12 +2282,17 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    IntSendParentNotify(Window, WM_CREATE);
 
    /* Notify the shell that a new window was created */
-   if ((Window->style & WS_VISIBLE) &&
-       ((Window->ExStyle & (WS_EX_APPWINDOW | WS_EX_TOOLWINDOW)) >= WS_EX_APPWINDOW ||
-        (!(Window->ExStyle & WS_EX_TOOLWINDOW) && !Window->spwndOwner &&
-         (!Window->spwndParent || UserIsDesktopWindow(Window->spwndParent)))))
+   if (Window->spwndOwner == NULL ||
+       !(Window->spwndOwner->style & WS_VISIBLE) ||
+       (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
    {
-      co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
+      if (UserIsDesktopWindow(Window->spwndParent) &&
+          (Window->style & WS_VISIBLE) &&
+          (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
+           (Window->ExStyle & WS_EX_APPWINDOW)))
+      {
+         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
+      }
    }
 
    /* Initialize and show the window's scrollbars */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2281,6 +2281,20 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    /* Send the WM_PARENTNOTIFY message */
    IntSendParentNotify(Window, WM_CREATE);
 
+   /* Notify the shell that a new window was created */
+   if (Window->spwndOwner == NULL ||
+       !(Window->spwndOwner->style & WS_VISIBLE) ||
+       (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
+   {
+      if (UserIsDesktopWindow(Window->spwndParent) &&
+          (Window->style & WS_VISIBLE) &&
+          (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
+           (Window->ExStyle & WS_EX_APPWINDOW)))
+      {
+         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)hWnd, 0);
+      }
+   }
+
    /* Initialize and show the window's scrollbars */
    if (Window->style & WS_VSCROLL)
    {

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1904,18 +1904,13 @@ co_WinPosSetWindowPos(
    }
    else if (WinPos.flags & SWP_SHOWWINDOW)
    {
-      if (Window->spwndOwner == NULL ||
-          !(Window->spwndOwner->style & WS_VISIBLE) ||
-          (Window->spwndOwner->ExStyle & WS_EX_TOOLWINDOW))
+      if ((Window->ExStyle & (WS_EX_APPWINDOW | WS_EX_TOOLWINDOW)) >= WS_EX_APPWINDOW ||
+          (!(Window->ExStyle & WS_EX_TOOLWINDOW) && !Window->spwndOwner &&
+           (!Window->spwndParent || UserIsDesktopWindow(Window->spwndParent))))
       {
-         if (UserIsDesktopWindow(Window->spwndParent) &&
-             (!(Window->ExStyle & WS_EX_TOOLWINDOW) ||
-              (Window->ExStyle & WS_EX_APPWINDOW)))
-         {
-            co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
-            if (!(WinPos.flags & SWP_NOACTIVATE))
-               UpdateShellHook(Window);
-         }
+         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
+         if (!(WinPos.flags & SWP_NOACTIVATE))
+            UpdateShellHook(Window);
       }
 
       Window->style |= WS_VISIBLE; //IntSetStyle( Window, WS_VISIBLE, 0 );

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1904,7 +1904,7 @@ co_WinPosSetWindowPos(
    }
    else if (WinPos.flags & SWP_SHOWWINDOW)
    {
-      if ((Window->ExStyle & (WS_EX_APPWINDOW | WS_EX_TOOLWINDOW)) >= WS_EX_APPWINDOW ||
+      if ((Window->ExStyle & WS_EX_APPWINDOW) ||
           (!(Window->ExStyle & WS_EX_TOOLWINDOW) && !Window->spwndOwner &&
            (!Window->spwndParent || UserIsDesktopWindow(Window->spwndParent))))
       {


### PR DESCRIPTION
## Purpose

Fix Shell Hook and reduce failures of `shell32_apitest ShellHook` testcase.

JIRA issue: [CORE-17330](https://jira.reactos.org/browse/CORE-17330)

## Proposed changes

- Fix the condition of notifying shell hook `HSHELL_WINDOWCREATED` in `ntuser/winpos.c`.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/95712043-00578080-0c9f-11eb-8bf3-abd2b5c7b37b.png)
Some failures.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/95712040-fe8dbd00-0c9e-11eb-9d6e-18fd64454e02.png)
Successful.