### PR TITLE
[SHELL32] Stub SHGetShellStyleHInstance and SHGetAttributesFromDataObject CORE-17337

### DIFF
--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -456,7 +456,7 @@
 745 stub -noname Create_IUIElement
 747 stdcall SHLimitInputEdit(ptr ptr)
 748 stdcall -noname SHLimitInputCombo(ptr ptr)
-749 stdcall -noname SHGetShellStyleHInstance()
+749 stdcall -noname -version=0x501-0x502 SHGetShellStyleHInstance()
 750 stdcall -noname SHGetAttributesFromDataObject(ptr long long long)
 751 stub -noname SHSimulateDropOnClsid
 752 stdcall -noname SHGetComputerDisplayNameW(long long long long)

--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -456,8 +456,8 @@
 745 stub -noname Create_IUIElement
 747 stdcall SHLimitInputEdit(ptr ptr)
 748 stdcall -noname SHLimitInputCombo(ptr ptr)
-749 stub SHGetShellStyleHInstance
-750 stub SHGetAttributesFromDataObject
+749 stdcall -noname SHGetShellStyleHInstance()
+750 stdcall -noname SHGetAttributesFromDataObject(ptr long long long)
 751 stub -noname SHSimulateDropOnClsid
 752 stdcall -noname SHGetComputerDisplayNameW(long long long long)
 753 stdcall -noname CheckStagingArea()

--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -1301,3 +1301,28 @@ DWORD WINAPI SHGetComputerDisplayNameW(DWORD param1, DWORD param2, DWORD param3,
     FIXME("SHGetComputerDisplayNameW() stub\n");
     return E_FAIL;
 }
+
+/*
+ * Unimplemented
+ */
+EXTERN_C HRESULT
+WINAPI
+SHGetAttributesFromDataObject(IDataObject *pdo,
+                              DWORD dwAttributeMask,
+                              DWORD *pdwAttributes,
+                              UINT *pcItems)
+{
+    FIXME("SHGetAttributesFromDataObject() stub\n");
+    return E_NOTIMPL;
+}
+
+/*
+ * Unimplemented
+ */
+EXTERN_C HINSTANCE
+WINAPI
+SHGetShellStyleHInstance(VOID)
+{
+    FIXME("SHGetShellStyleHInstance() stub\n");
+    return NULL;
+}


### PR DESCRIPTION
## Purpose

Add a stubs for SHGetShellStyleHInstance and SHGetAttributesFromDataObject functions in our shell32.dll, according to the following references:
https://docs.microsoft.com/en-us/previous-versions/windows/desktop/legacy/bb762202(v=vs.85)
https://docs.microsoft.com/ru-ru/windows/win32/api/shlobj_core/nf-shlobj_core-shgetattributesfromdataobject
They are required by MS Picture and Fax Viewer (shimgvw.dll), together with replaced browseui.dll. Now it does no longer crash.

JIRA issue: [CORE-17337](https://jira.reactos.org/browse/CORE-17337)

## Result

Before:
![MS_shimgvw+MS_browseui](https://user-images.githubusercontent.com/26385117/95900724-fdda5100-0d9a-11eb-83fa-3c2a20bf6c2b.png)

After:
![MS_shimgvw+MS_browseui+patched_shell32](https://user-images.githubusercontent.com/26385117/95900782-0f235d80-0d9b-11eb-975a-3be9bab872ce.png)