### PR TITLE
[NTOS:CC] CcMdl*Complete(): Return if FastIO succeeded

### DIFF
--- a/ntoskrnl/cc/mdl.c
+++ b/ntoskrnl/cc/mdl.c
@@ -99,12 +99,15 @@ CcMdlReadComplete (
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;
 
     /* Check if we support Fast Calls, and check this one */
-    if (FastDispatch && FastDispatch->MdlReadComplete)
-    {
-         /* Use the fast path */
+    /* Use the fast path */
+    if (FastDispatch != NULL &&
+        FastDispatch->MdlReadComplete != NULL &&
         FastDispatch->MdlReadComplete(FileObject,
                                       MdlChain,
-                                      DeviceObject);
+                                      DeviceObject))
+    {
+        /* Request was handled */
+        return;
     }
 
     /* Use slow path */
@@ -129,13 +132,16 @@ CcMdlWriteComplete (
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;
 
     /* Check if we support Fast Calls, and check this one */
-    if (FastDispatch && FastDispatch->MdlWriteComplete)
-    {
-         /* Use the fast path */
+    /* Use the fast path */
+    if (FastDispatch != NULL &&
+        FastDispatch->MdlWriteComplete != NULL &&
         FastDispatch->MdlWriteComplete(FileObject,
                                        FileOffset,
                                        MdlChain,
-                                       DeviceObject);
+                                       DeviceObject))
+    {
+        /* Request was handled */
+        return;
     }
 
     /* Use slow path */

--- a/ntoskrnl/cc/mdl.c
+++ b/ntoskrnl/cc/mdl.c
@@ -99,15 +99,16 @@ CcMdlReadComplete (
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;
 
     /* Check if we support Fast Calls, and check this one */
-    /* Use the fast path */
-    if (FastDispatch != NULL &&
-        FastDispatch->MdlReadComplete != NULL &&
-        FastDispatch->MdlReadComplete(FileObject,
-                                      MdlChain,
-                                      DeviceObject))
+    if (FastDispatch && FastDispatch->MdlReadComplete)
     {
-        /* Request was handled */
-        return;
+        /* Use the fast path */
+        if (FastDispatch->MdlReadComplete(FileObject,
+                                          MdlChain,
+                                          DeviceObject))
+        {
+            /* Request was handled */
+            return;
+        }
     }
 
     /* Use slow path */
@@ -132,16 +133,17 @@ CcMdlWriteComplete (
     FastDispatch = DeviceObject->DriverObject->FastIoDispatch;
 
     /* Check if we support Fast Calls, and check this one */
-    /* Use the fast path */
-    if (FastDispatch != NULL &&
-        FastDispatch->MdlWriteComplete != NULL &&
-        FastDispatch->MdlWriteComplete(FileObject,
-                                       FileOffset,
-                                       MdlChain,
-                                       DeviceObject))
+    if (FastDispatch && FastDispatch->MdlWriteComplete)
     {
-        /* Request was handled */
-        return;
+        /* Use the fast path */
+        if (FastDispatch->MdlWriteComplete(FileObject,
+                                           FileOffset,
+                                           MdlChain,
+                                           DeviceObject))
+        {
+            /* Request was handled */
+            return;
+        }
     }
 
     /* Use slow path */


### PR DESCRIPTION
Otherwise, drivers that have `MdlReadComplete = FsRtlMdlReadCompleteDev` are calling `CcMdlReadComplete2()` twice.

https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=FsRtlMdlReadCompleteDev

JIRA issue: [CORE-17342](https://jira.reactos.org/browse/CORE-17342)
