### PR TITLE
[BASESRV] Re-enable CsrValidateMessageBuffer() checks in BaseSrvDefineDosDevice().

### DIFF
--- a/subsystems/win/basesrv/dosdev.c
+++ b/subsystems/win/basesrv/dosdev.c
@@ -514,22 +514,21 @@ CSR_API(BaseSrvDefineDosDevice)
     PWSTR InterPtr;
     BOOLEAN RemoveFound;
 
-#if 0
-    /* FIXME: Check why it fails.... */
     if (!CsrValidateMessageBuffer(ApiMessage,
-                                  (PVOID*)&DefineDosDeviceRequest->DeviceName,
+                                  (PVOID*)&DefineDosDeviceRequest->DeviceName.Buffer,
                                   DefineDosDeviceRequest->DeviceName.Length,
-                                  1) ||
+                                  sizeof(BYTE)) ||
         (DefineDosDeviceRequest->DeviceName.Length & 1) != 0 ||
         !CsrValidateMessageBuffer(ApiMessage,
-                                  (PVOID*)&DefineDosDeviceRequest->TargetPath,
-                                  (DefineDosDeviceRequest->TargetPath.Length != 0 ? sizeof(UNICODE_NULL) : 0) + DefineDosDeviceRequest->TargetPath.Length,
-                                  1) ||
+                                  (PVOID*)&DefineDosDeviceRequest->TargetPath.Buffer,
+                                  DefineDosDeviceRequest->TargetPath.Length +
+                                    (DefineDosDeviceRequest->TargetPath.Length != 0
+                                        ? sizeof(UNICODE_NULL) : 0),
+                                  sizeof(BYTE)) ||
         (DefineDosDeviceRequest->TargetPath.Length & 1) != 0)
     {
         return STATUS_INVALID_PARAMETER;
     }
-#endif
 
     DPRINT("BaseSrvDefineDosDevice entered, Flags:%d, DeviceName:%wZ (%d), TargetPath:%wZ (%d)\n",
            DefineDosDeviceRequest->Flags,


### PR DESCRIPTION
Addendum to commit 0a392b18.

## Purpose

Does what the title says :)

JIRA issue: None.

## Proposed changes

Re-enable validity checks that were originally disabled in 0a392b18 due to an unknown problem, that may have been fixed by my recent commit b3fa53f8.