### PR TITLE
[REACTOS] *FastIoDispatch: Remove redundant zero'ing

### DIFF
--- a/drivers/base/null/null.c
+++ b/drivers/base/null/null.c
@@ -202,7 +202,6 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
     DriverObject->DriverUnload = NullUnload;
 
     /* Initialize the fast I/O dispatch table */
-    RtlZeroMemory(&FastIoDispatch, sizeof(FastIoDispatch));
     FastIoDispatch.SizeOfFastIoDispatch = sizeof(FastIoDispatch);
 
     /* Setup our pointers */

--- a/ntoskrnl/wmi/wmidrv.c
+++ b/ntoskrnl/wmi/wmidrv.c
@@ -685,7 +685,6 @@ WmipDriverEntry(
     DriverObject->MajorFunction[IRP_MJ_SHUTDOWN] = WmipShutdown;
 
     /* Initialize fast dispatch */
-    RtlZeroMemory(&WmipFastIoDispatch, sizeof(WmipFastIoDispatch));
     WmipFastIoDispatch.SizeOfFastIoDispatch = sizeof(WmipFastIoDispatch);
     WmipFastIoDispatch.FastIoDeviceControl = WmipFastIoDeviceControl;
     DriverObject->FastIoDispatch = &WmipFastIoDispatch;

--- a/sdk/lib/drivers/rdbsslib/rdbss.c
+++ b/sdk/lib/drivers/rdbsslib/rdbss.c
@@ -6912,12 +6912,6 @@ RxInitializeDispatchVectors(
     RxFastIoDispatch.FastIoCheckIfPossible = RxFastIoCheckIfPossible;
     RxFastIoDispatch.FastIoRead = RxFastIoRead;
     RxFastIoDispatch.FastIoWrite = RxFastIoWrite;
-    RxFastIoDispatch.FastIoQueryBasicInfo = NULL;
-    RxFastIoDispatch.FastIoQueryStandardInfo = NULL;
-    RxFastIoDispatch.FastIoLock = NULL;
-    RxFastIoDispatch.FastIoUnlockSingle = NULL;
-    RxFastIoDispatch.FastIoUnlockAll = NULL;
-    RxFastIoDispatch.FastIoUnlockAllByKey = NULL;
     RxFastIoDispatch.FastIoDeviceControl = RxFastIoDeviceControl;
     RxFastIoDispatch.AcquireFileForNtCreateSection = RxAcquireFileForNtCreateSection;
     RxFastIoDispatch.ReleaseFileForNtCreateSection = RxReleaseFileForNtCreateSection;


### PR DESCRIPTION
## Purpose

Cleanup.

JIRA issue: [CORE-17342](https://jira.reactos.org/browse/CORE-17342)