### PR TITLE
[KMTESTS:NTOS] Report FastIO calls, Set SizeOfFastIoDispatch

### DIFF
--- a/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
@@ -36,6 +36,9 @@ FastIoRead(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(TRUE, "\n");
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }

--- a/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcCopyRead_drv.c
@@ -65,9 +65,9 @@ TestEntry(
     KmtRegisterIrpHandler(IRP_MJ_CREATE, NULL, TestIrpHandler);
     KmtRegisterIrpHandler(IRP_MJ_READ, NULL, TestIrpHandler);
 
+    TestFastIoDispatch.SizeOfFastIoDispatch = sizeof(TestFastIoDispatch);
     TestFastIoDispatch.FastIoRead = FastIoRead;
     DriverObject->FastIoDispatch = &TestFastIoDispatch;
-
 
     return Status;
 }

--- a/modules/rostests/kmtests/ntos_cc/CcCopyWrite_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcCopyWrite_drv.c
@@ -87,10 +87,10 @@ TestEntry(
     KmtRegisterIrpHandler(IRP_MJ_WRITE, NULL, TestIrpHandler);
     KmtRegisterIrpHandler(IRP_MJ_FLUSH_BUFFERS, NULL, TestIrpHandler);
 
+    TestFastIoDispatch.SizeOfFastIoDispatch = sizeof(TestFastIoDispatch);
     TestFastIoDispatch.FastIoRead = FastIoRead;
     TestFastIoDispatch.FastIoWrite = FastIoWrite;
     DriverObject->FastIoDispatch = &TestFastIoDispatch;
-
 
     return Status;
 }

--- a/modules/rostests/kmtests/ntos_cc/CcCopyWrite_drv.c
+++ b/modules/rostests/kmtests/ntos_cc/CcCopyWrite_drv.c
@@ -36,6 +36,9 @@ FastIoRead(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(FALSE, "%s() unexpectedly called\n", __FUNCTION__);
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }
@@ -53,6 +56,9 @@ FastIoWrite(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(TRUE, "\n");
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }

--- a/modules/rostests/kmtests/ntos_io/IoReadWrite_drv.c
+++ b/modules/rostests/kmtests/ntos_io/IoReadWrite_drv.c
@@ -47,6 +47,7 @@ TestEntry(
              TESTENTRY_BUFFERED_IO_DEVICE |
              TESTENTRY_NO_READONLY_DEVICE;
 
+    TestFastIoDispatch.SizeOfFastIoDispatch = sizeof(TestFastIoDispatch);
     TestFastIoDispatch.FastIoRead = TestFastIoRead;
     TestFastIoDispatch.FastIoWrite = TestFastIoWrite;
     DriverObject->FastIoDispatch = &TestFastIoDispatch;

--- a/modules/rostests/kmtests/ntos_io/IoReadWrite_drv.c
+++ b/modules/rostests/kmtests/ntos_io/IoReadWrite_drv.c
@@ -158,6 +158,9 @@ TestFastIoRead(
     PTEST_FCB Fcb;
     NTSTATUS Status;
 
+    // Report whether this FastIO function is actually called or not.
+    ok(TRUE, "\n");
+
     //trace("FastIoRead: %p %lx %I64d+%lu -> %p\n", FileObject, LockKey, FileOffset->QuadPart, Length, Buffer);
     ok_eq_pointer(FileObject, TestFileObject);
     ok_bool_true(Wait, "Wait is");
@@ -226,6 +229,9 @@ TestFastIoWrite(
 {
     PTEST_FCB Fcb;
     NTSTATUS Status;
+
+    // Report whether this FastIO function is actually called or not.
+    ok(TRUE, "\n");
 
     //trace("FastIoWrite: %p %lx %p -> %I64d+%lu\n", FileObject, LockKey, Buffer, FileOffset->QuadPart, Length);
     ok_eq_pointer(FileObject, TestFileObject);

--- a/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
+++ b/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
@@ -39,6 +39,9 @@ FastIoRead(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(FALSE, "%s() unexpectedly called\n", __FUNCTION__);
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }
@@ -56,6 +59,9 @@ FastIoWrite(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(FALSE, "%s() unexpectedly called\n", __FUNCTION__);
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }
@@ -70,6 +76,9 @@ FastIoQueryStandardInfo(
     _Out_ PIO_STATUS_BLOCK IoStatus,
     _In_ PDEVICE_OBJECT DeviceObject)
 {
+    // Report whether this FastIO function is actually called or not.
+    ok(TRUE, "\n");
+
     IoStatus->Status = STATUS_NOT_SUPPORTED;
     return FALSE;
 }

--- a/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
+++ b/modules/rostests/kmtests/ntos_mm/NtCreateSection_drv.c
@@ -108,11 +108,11 @@ TestEntry(
     KmtRegisterIrpHandler(IRP_MJ_QUERY_INFORMATION, NULL, TestIrpHandler);
     KmtRegisterIrpHandler(IRP_MJ_SET_INFORMATION, NULL, TestIrpHandler);
 
+    TestFastIoDispatch.SizeOfFastIoDispatch = sizeof(TestFastIoDispatch);
     TestFastIoDispatch.FastIoRead = FastIoRead;
     TestFastIoDispatch.FastIoWrite = FastIoWrite;
     TestFastIoDispatch.FastIoQueryStandardInfo = FastIoQueryStandardInfo;
     DriverObject->FastIoDispatch = &TestFastIoDispatch;
-
 
     return Status;
 }


### PR DESCRIPTION
## Purpose

Be more explicit and correct.

JIRA issue: [CORE-17342](https://jira.reactos.org/browse/CORE-17342)

## Notes

- CcCopyRead: number of test varies between 188/200/212 before, add 10 after.
I am not checking why it is not constant.
- NtCreateSection: a few new failures on ROS+FASTFAT.
To be investigated when existing failures are fixed. (Simple fallout? Maybe ROS-FAT vs MS-NTFS? ...)