### PR TITLE
|CMAKE] Use ExternalProject for host-tools build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,7 @@ if(NOT CMAKE_CROSSCOMPILING)
         list(APPEND NATIVE_TARGETS rsym pefixup)
     endif()
 
-    export(TARGETS ${NATIVE_TARGETS} FILE ${CMAKE_BINARY_DIR}/ImportExecutables.cmake NAMESPACE native- )
-    configure_file(sdk/cmake/host-tools.in ${CMAKE_BINARY_DIR}/TargetList.cmake)
-
+    install(TARGETS ${NATIVE_TARGETS})
 else()
     # Add host tools target
     include(sdk/cmake/host-tools.cmake)

--- a/modules/rostests/tests/spec2def/CMakeLists.txt
+++ b/modules/rostests/tests/spec2def/CMakeLists.txt
@@ -1,3 +1,3 @@
 
 add_custom_target(spec2def_test
-    py -3 ${CMAKE_CURRENT_SOURCE_DIR}/test.py $<TARGET_FILE:native-spec2def>)
+    py -3 ${CMAKE_CURRENT_SOURCE_DIR}/test.py $<TARGET_PROPERTY:native-spec2def,IMPORTED_LOCATION>)

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -213,7 +213,7 @@ elseif(NO_ROSSYM)
     set(CMAKE_RC_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> ${CMAKE_C_FLAGS} <CMAKE_SHARED_LIBRARY_C_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")
 else()
     # Normal rsym build
-    get_target_property(RSYM native-rsym IMPORTED_LOCATION_NOCONFIG)
+    get_target_property(RSYM native-rsym IMPORTED_LOCATION)
 
     set(CMAKE_C_LINK_EXECUTABLE
         "<CMAKE_C_COMPILER> ${CMAKE_C_FLAGS} <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>"
@@ -309,11 +309,10 @@ if(NOT ARCH STREQUAL "i386")
 endif()
 
 function(fixup_load_config _target)
-    get_target_property(PEFIXUP native-pefixup IMPORTED_LOCATION_NOCONFIG)
     add_custom_command(TARGET ${_target} POST_BUILD
-        COMMAND "${PEFIXUP}"
-                "$<TARGET_FILE:${_target}>"
-        COMMENT "Patching in LOAD_CONFIG")
+        COMMAND native-pefixup "$<TARGET_FILE:${_target}>"
+        COMMENT "Patching in LOAD_CONFIG"
+        DEPENDS native-pefixup)
 endfunction()
 
 function(generate_import_lib _libname _dllname _spec_file)

--- a/sdk/cmake/host-tools.cmake
+++ b/sdk/cmake/host-tools.cmake
@@ -1,72 +1,31 @@
 
-function(configure_host_tools HOST_TOOLS_DIR)
-    file(MAKE_DIRECTORY ${HOST_TOOLS_DIR})
-
-    message(STATUS "Configuring host tools...")
-    # cmake sets CC and CXX when those languages are enabled
-    # so we need to clear them here
-    execute_process(COMMAND
-        ${CMAKE_COMMAND}
-            -E env --unset=CC --unset=CXX
-        ${CMAKE_COMMAND}
-            -G "${CMAKE_GENERATOR}"
-            -DARCH:STRING=${ARCH}
-            ${USE_CLANG_CL_ARG}
-            ${REACTOS_SOURCE_DIR}
-        WORKING_DIRECTORY ${HOST_TOOLS_DIR}
-        RESULT_VARIABLE _host_config_result
-        OUTPUT_VARIABLE _host_config_log
-        ERROR_VARIABLE  _host_config_log)
-
-    # Show cmake output only if host-tools breaks
-    if(NOT _host_config_result EQUAL 0)
-        message("\nHost tools log:")
-        message("${_host_config_log}")
-        message(FATAL_ERROR "Failed to configure host tools")
-    endif()
-
-    set_property(SOURCE host_tools PROPERTY SYMBOLIC 1)
-
-    include(${HOST_TOOLS_DIR}/ImportExecutables.cmake)
-    include(${HOST_TOOLS_DIR}/TargetList.cmake)
-
-    foreach(_target ${NATIVE_TARGETS})
-        get_target_property(_target_location native-${_target} LOCATION)
-        list(APPEND _target_locations ${_target_location})
-    endforeach()
-
-    # Make a host-tools target so it'll be built when needed
-    # custom target + symbolic output prevents cmake from running
-    # the command multiple times per build
-    # Specify the --config option, so the Release/Debug setting from the IDE can be used
-    add_custom_command(
-        COMMAND ${CMAKE_COMMAND} --build ${HOST_TOOLS_DIR} --config $<CONFIG>
-        OUTPUT host_tools
-        BYPRODUCTS ${_target_locations})
-    add_custom_target(build-host-tools ALL DEPENDS host_tools)
-
-    foreach(_target ${NATIVE_TARGETS})
-        add_dependencies(native-${_target} build-host-tools)
-    endforeach()
-
-endfunction()
+include(ExternalProject)
 
 function(setup_host_tools)
-    if(WITH_HOST_TOOLS)
-        # Use pre-built tools, required for cross compiling with msvc
-        # as only one target architecture is available at a time
-        find_path(HOST_TOOLS_DIR
-            NAMES ImportExecutables.cmake
-            HINTS ${WITH_HOST_TOOLS} ${REACTOS_SOURCE_DIR}/${WITH_HOST_TOOLS}
-            NO_CMAKE_PATH
-            NO_CMAKE_ENVIRONMENT_PATH)
-        message(STATUS "Using prebuilt host tools: ${HOST_TOOLS_DIR}")
-        include(${HOST_TOOLS_DIR}/ImportExecutables.cmake)
-    else()
-        # Build host-tools. Changes to tool sources will rebuild targets
-        # using that tool
-        set(HOST_TOOLS_DIR ${REACTOS_BINARY_DIR}/host-tools)
-        configure_host_tools(${HOST_TOOLS_DIR})
+    list(APPEND HOST_TOOLS bin2c widl gendib cabman fatten hpp isohybrid mkhive mkisofs obj2bin spec2def geninc mkshelllink utf16le xml2sdb)
+    if(NOT MSVC)
+        list(APPEND HOST_TOOLS rsym pefixup)
+    endif()
+    list(TRANSFORM HOST_TOOLS PREPEND "${REACTOS_BINARY_DIR}/host-tools/bin/" OUTPUT_VARIABLE HOST_TOOLS_OUTPUT)
+    if (CMAKE_HOST_WIN32)
+        list(TRANSFORM HOST_TOOLS_OUTPUT APPEND ".exe")
+        set(HOST_EXE_SUFFIX ".exe")
     endif()
 
+    ExternalProject_Add(host-tools
+        SOURCE_DIR ${REACTOS_SOURCE_DIR}
+        PREFIX ${REACTOS_BINARY_DIR}/host-tools
+        INSTALL_DIR ${REACTOS_BINARY_DIR}/host-tools
+        CMAKE_ARGS -UCMAKE_TOOLCHAIN_FILE -DARCH:STRING=${ARCH} -DCMAKE_INSTALL_PREFIX=${REACTOS_BINARY_DIR}/host-tools
+        BUILD_ALWAYS TRUE
+        BUILD_BYPRODUCTS ${HOST_TOOLS_OUTPUT}
+    )
+
+    ExternalProject_Get_Property(host-tools INSTALL_DIR)
+
+    foreach(_tool ${HOST_TOOLS})
+        add_executable(native-${_tool} IMPORTED)
+        set_target_properties(native-${_tool} PROPERTIES IMPORTED_LOCATION ${INSTALL_DIR}/bin/${_tool}${HOST_EXE_SUFFIX})
+        add_dependencies(native-${_tool} host-tools)
+    endforeach()
 endfunction()


### PR DESCRIPTION
## Purpose

Use the ExternalProject CMake module instead of manually executing the process.