### PR TITLE
[CRT] Remove duplicate atexit/_onexit

### DIFF
--- a/modules/rostests/apitests/crt/atexit.c
+++ b/modules/rostests/apitests/crt/atexit.c
@@ -1,0 +1,93 @@
+/*
+* PROJECT:         ReactOS API tests
+* LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
+* PURPOSE:         Test for atexit
+* PROGRAMMER:      Timo Kreuzer <timo.kreuzer@reactos.org>
+*/
+
+#include <apitest.h>
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <ntndk.h>
+
+int g_sequence = 0;
+HANDLE g_hSemaphore;
+
+void exitfunc1(void)
+{
+    ok_int(g_sequence, 1);
+    g_sequence++;
+    ReleaseSemaphore(g_hSemaphore, 1, NULL);
+}
+
+void exitfunc2(void)
+{
+    ok_int(g_sequence, 2);
+    g_sequence++;
+    ReleaseSemaphore(g_hSemaphore, 1, NULL);
+}
+
+void exitfunc3(void)
+{
+    ok_int(g_sequence, 0);
+    g_sequence++;
+    ReleaseSemaphore(g_hSemaphore, 1, NULL);
+    printf("exitfunc3\n");
+}
+
+typedef int (__cdecl *PFN_atexit)(void (__cdecl*)(void));
+
+void Test_atexit()
+{
+    HMODULE hmod;
+    PFN_atexit patexit;
+
+    /* Open the named sempahore to count atexit callbacks */
+    g_hSemaphore = OpenSemaphoreA(SEMAPHORE_ALL_ACCESS, FALSE, "atext_apitest_sempahore");
+    ok(g_hSemaphore != NULL, "couldn't open semaphore.\n");
+
+    /* Load atexit from msvcrt.dll */
+    hmod = GetModuleHandleA("msvcrt.dll");
+    patexit = (PFN_atexit)GetProcAddress(hmod, "atexit");
+    ok(patexit != NULL, "failed to get atexit from msvcrt.dll\n");
+
+    /* Register 3 exit functions, the second one in msvcrt. */
+    ok_int(atexit(exitfunc1), 0);
+    if (patexit != NULL)
+    {
+        ok_int(patexit(exitfunc2), 0);
+    }
+    ok_int(atexit(exitfunc3), 0);
+}
+
+START_TEST(atexit)
+{
+    CHAR Buffer[MAX_PATH];
+    PSTR CommandLine;
+    int result;
+    HANDLE hSemaphore;
+    SEMAPHORE_BASIC_INFORMATION SemInfo;
+    NTSTATUS Status;
+
+    /* Check recursive call */
+    CommandLine = GetCommandLineA();
+    if (strstr(CommandLine, "-run") != NULL)
+    {
+        Test_atexit();
+        return;
+    }
+
+    /* Create a named semaphore to count atexit callbacks in remote process */
+    hSemaphore = CreateSemaphoreA(NULL, 1, 20, "atext_apitest_sempahore");
+
+    /* Run the actual test in a new process */
+    sprintf(Buffer, "%s -run", CommandLine);
+    result = system(Buffer);
+    ok_int(result, 0);
+
+    /* Check the new semaphore state */
+    Status = NtQuerySemaphore(hSemaphore, SemaphoreBasicInformation, &SemInfo, sizeof(SemInfo), NULL);
+    ok(NT_SUCCESS(Status), "NtQuerySemaphore failed: 0x%lx\n", Status);
+    ok_int(SemInfo.CurrentCount, 4);
+}

--- a/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
+++ b/modules/rostests/apitests/crt/msvcrt_crt_apitest.cmake
@@ -1014,7 +1014,7 @@ list(APPEND SOURCE_MSVCRT
 #    asin.c
 #    atan.c
 #    atan2.c
-#    atexit # <-- keep this as an extern, thank you
+    atexit.c
 #    atof.c
 #    atoi.c
 #    atol.c

--- a/modules/rostests/apitests/crt/testlist.c
+++ b/modules/rostests/apitests/crt/testlist.c
@@ -6,6 +6,7 @@
 #if defined(TEST_MSVCRT)
 extern void func__vscprintf(void);
 extern void func__vscwprintf(void);
+extern void func_atexit(void);
 #endif
 #if defined(TEST_NTDLL)
 extern void func__vscwprintf(void);
@@ -55,6 +56,7 @@ const struct test winetest_testlist[] =
 #endif
 #if defined(TEST_STATIC_CRT)
 #elif defined(TEST_MSVCRT)
+    { "atexit", func_atexit },
 #if defined(_M_IX86)
     { "__getmainargs", func___getmainargs },
 #endif

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -291,7 +291,7 @@ endfunction()
 
 function(generate_import_lib _libname _dllname _spec_file)
 
-    set(_def_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_exp.def)
+    set(_def_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def)
     set(_asm_stubs_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_stubs.asm)
 
     # Generate the asm stub file and the def file for import library

--- a/sdk/lib/crt/crt.cmake
+++ b/sdk/lib/crt/crt.cmake
@@ -197,7 +197,7 @@ list(APPEND CRT_SOURCE
     startup/natstart.c
     startup/charmax.c
     #startup/merr.c
-    #startup/atonexit.c
+    startup/atonexit.c
     #startup/txtmode.c
     startup/pesect.c
     startup/tlsmcrt.c

--- a/sdk/lib/crt/startup/atonexit.c
+++ b/sdk/lib/crt/startup/atonexit.c
@@ -24,13 +24,31 @@
 _PVFV *__onexitbegin;
 _PVFV *__onexitend;
 
-extern _CRTIMP _onexit_t __cdecl __dllonexit (_onexit_t, _PVFV**, _PVFV**);
+extern _onexit_t __cdecl __dllonexit (_onexit_t, _PVFV**, _PVFV**);
 extern _onexit_t (__cdecl * __MINGW_IMP_SYMBOL(_onexit)) (_onexit_t func);
 
-/* Choose a different name to prevent name conflicts. The CRT one works fine.  */
-_onexit_t __cdecl mingw_onexit(_onexit_t func);
+/* INTERNAL: call atexit functions */
+void __call_atexit(void)
+{
+    /* Note: should only be called with the exit lock held */
+    _PVFV *first, *last;
 
-_onexit_t __cdecl mingw_onexit(_onexit_t func)
+    first =  (_PVFV *)_decode_pointer(__onexitbegin);
+    last = (_PVFV *)_decode_pointer(__onexitend);;
+
+    if (!first) return;
+
+    while (--last >= first)
+        if (*last)
+            (**last)();
+
+    free(first);
+}
+
+/* Choose a different name to prevent name conflicts. The CRT one works fine.  */
+_onexit_t __cdecl _onexit(_onexit_t func);
+
+_onexit_t __cdecl _onexit(_onexit_t func)
 {
   _PVFV *onexitbegin;
   _PVFV *onexitend;
@@ -39,7 +57,17 @@ _onexit_t __cdecl mingw_onexit(_onexit_t func)
   onexitbegin = (_PVFV *) _decode_pointer (__onexitbegin);
 
   if (onexitbegin == (_PVFV *) -1)
+#ifdef __REACTOS__
+  {
+      onexitbegin = (_PVFV *)calloc(32, sizeof(_onexit_t));
+      if (onexitbegin == NULL)
+        return NULL;
+      __onexitbegin = _encode_pointer(onexitbegin);
+      __onexitend = _encode_pointer(onexitbegin + 32);
+  }
+#else
     return (* __MINGW_IMP_SYMBOL(_onexit)) (func);
+#endif
   _lock (_EXIT_LOCK1);
   onexitbegin = (_PVFV *) _decode_pointer (__onexitbegin);
   onexitend = (_PVFV *) _decode_pointer (__onexitend);
@@ -55,5 +83,5 @@ _onexit_t __cdecl mingw_onexit(_onexit_t func)
 int __cdecl
 atexit (_PVFV func)
 {
-  return (mingw_onexit((_onexit_t)func) == NULL) ? -1 : 0;
+  return (_onexit((_onexit_t)func) == NULL) ? -1 : 0;
 }

--- a/sdk/lib/crt/startup/crtexe.c
+++ b/sdk/lib/crt/startup/crtexe.c
@@ -211,6 +211,8 @@ int __cdecl mainCRTStartup (void)
   return ret;
 }
 
+void __call_atexit();
+
 static
 __declspec(noinline)
 int __cdecl
@@ -324,6 +326,7 @@ __tmainCRTStartup (void)
 #endif
     mainret = main (argc, argv, envp);
 #endif
+    __call_atexit();
     if (!managedapp)
       exit (mainret);
 


### PR DESCRIPTION
This improves the CRT situation a bit by removing the duplicated stuff and use the same code in msvcrtex as is exported from msvcrt. It also adds a simple apitest to validate that it works correctly.