### PR TITLE
[NTOSKRNL] Use MI_IS_WRITE_ACCESS(), instead of magic values

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -118,9 +118,16 @@
 #endif
 
 /* Macros to identify the page fault reason from the error code */
-#define MI_IS_NOT_PRESENT_FAULT(FaultCode) !BooleanFlagOn(FaultCode, 0x1)
-#define MI_IS_WRITE_ACCESS(FaultCode) BooleanFlagOn(FaultCode, 0x2)
-#define MI_IS_INSTRUCTION_FETCH(FaultCode) BooleanFlagOn(FaultCode, 0x10)
+#define MI_IS_NOT_PRESENT_FAULT(FaultCode)  !BooleanFlagOn(FaultCode, 0x00000001)
+#define MI_IS_WRITE_ACCESS(FaultCode)        BooleanFlagOn(FaultCode, 0x00000002)
+// 0x00000004: user-mode access.
+// 0x00000008: reserved bit violation.
+#define MI_IS_INSTRUCTION_FETCH(FaultCode)   BooleanFlagOn(FaultCode, 0x00000010)
+// 0x00000020: protection-key violation.
+// 0x00000040: shadow-stack access.
+// Bits 7-14: reserved.
+// 0x00008000: violation of SGX-specific access-control requirements.
+// Bits 16-31: reserved.
 
 /* On x64, these are the same */
 #define MI_WRITE_VALID_PPE MI_WRITE_VALID_PTE

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -110,9 +110,16 @@
 
 
 /* Macros to identify the page fault reason from the error code */
-#define MI_IS_NOT_PRESENT_FAULT(FaultCode) !BooleanFlagOn(FaultCode, 0x1)
-#define MI_IS_WRITE_ACCESS(FaultCode) BooleanFlagOn(FaultCode, 0x2)
-#define MI_IS_INSTRUCTION_FETCH(FaultCode) BooleanFlagOn(FaultCode, 0x10)
+#define MI_IS_NOT_PRESENT_FAULT(FaultCode)  !BooleanFlagOn(FaultCode, 0x00000001)
+#define MI_IS_WRITE_ACCESS(FaultCode)        BooleanFlagOn(FaultCode, 0x00000002)
+// 0x00000004: user-mode access.
+// 0x00000008: reserved bit violation.
+#define MI_IS_INSTRUCTION_FETCH(FaultCode)   BooleanFlagOn(FaultCode, 0x00000010)
+// 0x00000020: protection-key violation.
+// 0x00000040: shadow-stack access.
+// Bits 7-14: reserved.
+// 0x00008000: violation of SGX-specific access-control requirements.
+// Bits 16-31: reserved.
 
 /* On x86, these two are the same */
 #define MI_WRITE_VALID_PPE MI_WRITE_VALID_PTE

--- a/ntoskrnl/ke/i386/traphdlr.c
+++ b/ntoskrnl/ke/i386/traphdlr.c
@@ -1321,7 +1321,6 @@ FASTCALL
 KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
 {
     PKTHREAD Thread;
-    BOOLEAN StoreInstruction;
     ULONG_PTR Cr2;
     NTSTATUS Status;
 
@@ -1346,9 +1345,6 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
 
     /* Enable interrupts */
     _enable();
-
-    /* Interpret the error code */
-    StoreInstruction = (TrapFrame->ErrCode & 2) != 0;
 
     /* Check if we came in with interrupts disabled */
     if (!(TrapFrame->EFlags & EFLAGS_INTERRUPT_MASK))
@@ -1412,7 +1408,7 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
         /* This status code is repurposed so we can recognize it later */
         KiDispatchException2Args(KI_EXCEPTION_ACCESS_VIOLATION,
                                  TrapFrame->Eip,
-                                 StoreInstruction,
+                                 MI_IS_WRITE_ACCESS(TrapFrame->ErrCode),
                                  Cr2,
                                  TrapFrame);
     }
@@ -1422,7 +1418,7 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
         /* These faults only have two parameters */
         KiDispatchException2Args(Status,
                                  TrapFrame->Eip,
-                                 StoreInstruction,
+                                 MI_IS_WRITE_ACCESS(TrapFrame->ErrCode),
                                  Cr2,
                                  TrapFrame);
     }
@@ -1432,7 +1428,7 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
                                      0,
                                      TrapFrame->Eip,
                                      3,
-                                     StoreInstruction,
+                                     MI_IS_WRITE_ACCESS(TrapFrame->ErrCode),
                                      Cr2,
                                      Status,
                                      TrapFrame);


### PR DESCRIPTION
Explicit macros vs magic values.