### PR TITLE
[CMAKE] Make unattended bootcd configurable via cmake

### DIFF
--- a/boot/bootdata/CMakeLists.txt
+++ b/boot/bootdata/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_subdirectory(packages)
+add_subdirectory(bootcd)
 
 # Common hives
 
@@ -61,7 +62,6 @@ add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/hybridcd.ini DESTINATION root NAME_
 
 # Unattend
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootcdregtest/unattend.inf DESTINATION reactos NO_CAB FOR regtest)
-add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/bootcd/unattend.inf DESTINATION reactos NO_CAB FOR bootcd)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/livecd/unattend.inf DESTINATION reactos NO_CAB FOR livecd)
 
 # LiveCD shortcuts

--- a/boot/bootdata/bootcd/CMakeLists.txt
+++ b/boot/bootdata/bootcd/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(UNATTENDED_BOOTCD "no" CACHE STRING "Whether to build a self-installing bootcd (yes/no)")
+
+function(add_unattended_bootcd_option _var _default _doc)
+    if (UNATTENDED_BOOTCD STREQUAL "yes")
+        set(${_var} "${_default}" CACHE STRING ${_doc})
+    endif()
+endfunction()
+
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_DestinationDiskNumber "0"
+    "The Disk Number ReactOS will be installed on during bootcd unattended setup")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_DestinationPartitionNumber "1"
+    "The Partition Number ReactOS will be installed on during bootcd unattended setup")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_InstallationDirectory "ReactOS"
+    "The directory ReactOS will be installed in during bootcd unattended setup")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_MBRInstallType "2"
+    "MBR installation type during bootcd unattended setup: 0: skip, 1: On floppy, 2: On HDD")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_FullName "MyName"
+    "The user name used for unattended bootcd installation")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_OrgName ""
+    "The organisation name used for unattended bootcd installation (None if empty)")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_ComputerName "MYCOMPUTERNAME"
+    "The computer name used for unattended bootcd installation")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_AdminPassword ""
+    "The administrator password used for unattended bootcd installation (None if empty)")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_FormatPartition "1"
+    "Whether to format the partition during bootcd unattended setup. 0: Don't format, 1: Format)")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_AutoPartition "1"
+    "Whether to automatically create the partition during bootcd unattended setup. 0: Don't create partition, 1: Create partition")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_FsType "0"
+    "The filesystem used during bootcd unattended setup. 0: FAT, 1: BTRFS")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_DisableGeckoInst "no"
+    "Whether to disable the Gecko module installation. (yes/no)")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_LocaleID "409"
+    "The locale used during bootcd unattended setup. See hivesys.inf for values")
+add_unattended_bootcd_option(UNATTENDED_BOOTCD_ProductOption "0"
+    "The product installed during bootcd unattended setup. 0: Server, 1: WorkStation")
+
+if (UNATTENDED_BOOTCD STREQUAL "yes")
+    configure_file(unattend.inf.in unattend.inf @ONLY)
+    add_cd_file(FILE ${CMAKE_CURRENT_BINARY_DIR}/unattend.inf DESTINATION reactos NO_CAB FOR bootcd)
+endif()
+

--- a/boot/bootdata/bootcd/unattend.inf.in
+++ b/boot/bootdata/bootcd/unattend.inf.in
@@ -4,22 +4,22 @@ Signature = "$ReactOS$"
 ; Set UnattendSetupEnabled to yes in order to get unattended setup working
 ; yes - unattend setup enabled
 ; no - unattend setup disabled
-UnattendSetupEnabled = no
+UnattendSetupEnabled = @UNATTENDED_BOOTCD@
 
 ; Install to \Device\Harddisk0\Partition1\ReactOS
-DestinationDiskNumber = 0
-DestinationPartitionNumber = 1
-InstallationDirectory=ReactOS
+DestinationDiskNumber = @UNATTENDED_BOOTCD_DestinationDiskNumber@
+DestinationPartitionNumber = @UNATTENDED_BOOTCD_DestinationPartitionNumber@
+InstallationDirectory=@UNATTENDED_BOOTCD_InstallationDirectory@
 
 ; MBRInstallType=0  skips MBR installation
 ; MBRInstallType=1  install MBR on floppy
 ; MBRInstallType=2  install MBR on hdd
-MBRInstallType=2
+MBRInstallType=@UNATTENDED_BOOTCD_MBRInstallType@
 
-FullName="MyName"
-;OrgName="MyOrg"
-ComputerName="MYCOMPUTERNAME"
-;AdminPassword="MyPassword"
+FullName="@UNATTENDED_BOOTCD_FullName@"
+OrgName="@UNATTENDED_BOOTCD_OrgName@"
+ComputerName="@UNATTENDED_BOOTCD_ComputerName@"
+AdminPassword="@UNATTENDED_BOOTCD_AdminPassword@"
 
 ; TimeZone is set GMT as default
 TimeZoneIndex=85
@@ -30,33 +30,33 @@ TimeZoneIndex=85
 ; enable this setting to format the selected partition
 ; 1 - format enabled
 ; 0 - format disabled
-FormatPartition=1
+FormatPartition=@UNATTENDED_BOOTCD_FormatPartition@
 
 ; enable this setting to automatically create a partition
 ; during installation
 ; 1 - enabled
 ; 0 - disabled
-AutoPartition = 1
+AutoPartition = @UNATTENDED_BOOTCD_AutoPartition@
 
 ; choose default file system type
 ; 0 - FAT
 ; 1 - BtrFS
-FsType = 0
+FsType = @UNATTENDED_BOOTCD_FsType@
 
 ; enable this setting to disable Gecko install
 ; yes - disabled
 ; no  - enabled
-DisableGeckoInst = no
+DisableGeckoInst = @UNATTENDED_BOOTCD_DisableGeckoInst@
 
 ; set this option to automatically
 ; specify language in 2nd mode setup
 ; see hivesys.inf for available languages
-LocaleID = 409
+LocaleID = @UNATTENDED_BOOTCD_LocaleID@
 
 ; set product option
 ; 0: ReactOS Server
 ; 1: ReactOS Workstation
-ProductOption = 0
+ProductOption = @UNATTENDED_BOOTCD_ProductOption@
 
 ; enable this section to automatically launch programs
 ; after 3rd boot


### PR DESCRIPTION
Instead of messing around with a file in the source tree and risk commiting it

use cmake -DUNATTENDED_BOOTCD=yes to enable it, and use the UNATTENDED_BOOTCD_* cache variables to configure