### PR TITLE
[NTOS:MM] PAE uses 2 levels of paging only, not 3

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -3,7 +3,9 @@
  */
 #pragma once
 
+// IA-32e paging, using 4-KByte pages.
 #define _MI_PAGING_LEVELS 4
+
 #define _MI_HAS_NO_EXECUTE 1
 
 /* Memory layout base addresses (This is based on Vista!) */

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -3,11 +3,12 @@
  */
 #pragma once
 
+// 32-bit/PAE paging, using 4-KByte pages.
+#define _MI_PAGING_LEVELS 2
+
 #ifdef _X86PAE_
-#define _MI_PAGING_LEVELS 3
 #define _MI_HAS_NO_EXECUTE 1
 #else
-#define _MI_PAGING_LEVELS 2
 #define _MI_HAS_NO_EXECUTE 0
 #endif
 

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -96,7 +96,7 @@
 #define MI_IS_PAGE_WRITEABLE(x)    ((x)->u.Hard.Writable == 1)
 #endif
 #define MI_IS_PAGE_COPY_ON_WRITE(x)((x)->u.Hard.CopyOnWrite == 1)
-#ifdef _X86PAE_
+#if _MI_HAS_NO_EXECUTE
 #define MI_IS_PAGE_EXECUTABLE(x)   ((x)->u.Hard.NoExecute == 0)
 #else
 #define MI_IS_PAGE_EXECUTABLE(x)   TRUE

--- a/ntoskrnl/mm/ARM3/largepag.c
+++ b/ntoskrnl/mm/ARM3/largepag.c
@@ -33,8 +33,8 @@ VOID
 NTAPI
 MiInitializeLargePageSupport(VOID)
 {
-#if _MI_PAGING_LEVELS > 2
-    DPRINT1("MiInitializeLargePageSupport: PAE/x64 Not Implemented\n");
+#if _MI_PAGING_LEVELS >= 3
+    DPRINT1("MiInitializeLargePageSupport: x64 Not Implemented\n");
     //ASSERT(FALSE);
 #else
     /* Initialize the large-page hyperspace PTE used for initial mapping */

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -1764,7 +1764,7 @@ MmArmAccessFault(IN ULONG FaultCode,
             (PointerPxe->u.Hard.Valid == 0) ||
 #endif
 #if (_MI_PAGING_LEVELS >= 3)
-            /* PAE/AMD64 system, check if PPE is invalid */
+            /* AMD64 system, check if PPE is invalid */
             (PointerPpe->u.Hard.Valid == 0) ||
 #endif
             /* Always check if the PDE is valid */

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -549,7 +549,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
                 PageFrameNumber = MiRemoveAnyPage(MI_GET_NEXT_COLOR());
                 TempPde.u.Hard.PageFrameNumber = PageFrameNumber;
 #if (_MI_PAGING_LEVELS >= 3)
-                /* On PAE/x64 systems, there's no double-buffering */
+                /* On x64 systems, there's no double-buffering */
                 /* Initialize the PFN entry for it */
                 MiInitializePfnForOtherProcess(PageFrameNumber,
                                                (PMMPTE)PointerPde,


### PR DESCRIPTION
## Purpose

Fix and be consistent.

JIRA issue: [CORE-16702](https://jira.reactos.org/browse/CORE-16702)

## Proposed changes

- [NTOS:MM] PAE uses 2 levels of paging only, not 3
- [NTOS:MM] MI_IS_PAGE_EXECUTABLE() depends on _MI_HAS_NO_EXECUTE now
