### PR TITLE
[SHELL32] spec: Fix SHGetAttributesFromDataObject() parameter types

### DIFF
--- a/dll/win32/shell32/shell32.spec
+++ b/dll/win32/shell32/shell32.spec
@@ -457,7 +457,7 @@
 747 stdcall SHLimitInputEdit(ptr ptr)
 748 stdcall -noname SHLimitInputCombo(ptr ptr)
 749 stdcall -noname -version=0x501-0x502 SHGetShellStyleHInstance()
-750 stdcall -noname SHGetAttributesFromDataObject(ptr long long long)
+750 stdcall -noname SHGetAttributesFromDataObject(ptr long ptr ptr)
 751 stub -noname SHSimulateDropOnClsid
 752 stdcall -noname SHGetComputerDisplayNameW(long long long long)
 753 stdcall -noname CheckStagingArea()


### PR DESCRIPTION
Addendum to cdb48b8.
JIRA issue: [CORE-17337](https://jira.reactos.org/browse/CORE-17337)