### PR TITLE
[LOAD][UNLOAD] Fix w*printf() format strings

### DIFF
--- a/modules/rosapps/applications/sysutils/utils/driver/load/load.c
+++ b/modules/rosapps/applications/sysutils/utils/driver/load/load.c
@@ -16,18 +16,22 @@ int wmain(int argc, WCHAR * argv[])
       wprintf(L"Usage: load <ServiceName>\n");
       return 0;
    }
-   ServiceName.Length = (wcslen(argv[1]) + 52) * sizeof(WCHAR);
-   ServiceName.Buffer = (LPWSTR)malloc(ServiceName.Length + sizeof(UNICODE_NULL));
+
+   ServiceName.Length = (USHORT)((52 + wcslen(argv[1])) * sizeof(WCHAR));
+   ServiceName.MaximumLength = ServiceName.Length + sizeof(UNICODE_NULL);
+   ServiceName.Buffer = malloc(ServiceName.MaximumLength);
    wsprintf(ServiceName.Buffer,
-      L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\%S",
+      L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\%s",
       argv[1]);
-   wprintf(L"%s %u %Id\n", ServiceName.Buffer, ServiceName.Length, wcslen(ServiceName.Buffer));
+   wprintf(L"Loading %wZ\n", &ServiceName);
+
    Status = NtLoadDriver(&ServiceName);
    free(ServiceName.Buffer);
    if (!NT_SUCCESS(Status))
    {
-      wprintf(L"Failed: %x\n", Status);
+      wprintf(L"Failed: 0x%08lx\n", Status);
       return 1;
    }
+
    return 0;
 }

--- a/modules/rosapps/applications/sysutils/utils/driver/unload/unload.c
+++ b/modules/rosapps/applications/sysutils/utils/driver/unload/unload.c
@@ -16,18 +16,22 @@ int wmain(int argc, WCHAR * argv[])
       wprintf(L"Usage: unload <ServiceName>\n");
       return 0;
    }
-   ServiceName.Length = (wcslen(argv[1]) + 52) * sizeof(WCHAR);
-   ServiceName.Buffer = (LPWSTR)malloc(ServiceName.Length + sizeof(UNICODE_NULL));
+
+   ServiceName.Length = (USHORT)((52 + wcslen(argv[1])) * sizeof(WCHAR));
+   ServiceName.MaximumLength = ServiceName.Length + sizeof(UNICODE_NULL);
+   ServiceName.Buffer = malloc(ServiceName.MaximumLength);
    wsprintf(ServiceName.Buffer,
-      L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\%S",
+      L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\%s",
       argv[1]);
-   wprintf(L"%s %d %Ud\n", ServiceName.Buffer, ServiceName.Length, wcslen(ServiceName.Buffer));
+   wprintf(L"Unloading %wZ\n", &ServiceName);
+
    Status = NtUnloadDriver(&ServiceName);
    free(ServiceName.Buffer);
    if (!NT_SUCCESS(Status))
    {
-      wprintf(L"Failed: %X\n", Status);
+      wprintf(L"Failed: 0x%08lx\n", Status);
       return 1;
    }
+
    return 0;
 }


### PR DESCRIPTION
## Purpose

Less warnings, work better.

NB:
I don't know a successful case.
*WXP: Various NTSTATUS.
*ROS: Always '0xc0000061 = STATUS_PRIVILEGE_NOT_HELD'.

## Proposed changes

Also:
*Set ServiceName.MaximumLength.
*Fix MSVC warnings.

'...\load\load.c(19): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
+
'...\unload\unload.c(19): warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data'
'...\unload\unload.c(24): warning C4476: 'wprintf' : unknown type field character 'U' in format specifier'
'...\unload\unload.c(24): warning C4474: 'wprintf' : too many arguments passed for format string'
