### PR TITLE
[RAPPS] Restore event logging of install/uninstall actions

### DIFF
--- a/base/applications/rapps/installed.cpp
+++ b/base/applications/rapps/installed.cpp
@@ -138,6 +138,9 @@ BOOL CInstalledApplicationInfo::RetrieveIcon(ATL::CStringW& IconLocation)
 
 BOOL CInstalledApplicationInfo::UninstallApplication(BOOL bModify)
 {
+    if (!bModify)
+        WriteLogMessage(EVENTLOG_SUCCESS, MSG_SUCCESS_REMOVE, szDisplayName);
+
     return StartProcess(bModify ? szModifyPath : szUninstallString, TRUE);
 }
 

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -931,6 +931,9 @@ run:
             shExInfo.lpParameters = L"";
             shExInfo.nShow = SW_SHOW;
 
+            /* FIXME: Do we want to log installer status? */
+            WriteLogMessage(EVENTLOG_SUCCESS, MSG_SUCCESS_INSTALL, InfoArray[iAppId].szName);
+
             if (ShellExecuteExW(&shExInfo))
             {
                 //reflect installation progress in the titlebar


### PR DESCRIPTION
Rapps used to have this, it got lost during refactoring.
Does it make sense to restore this?
Do we optionally want to increase verbosity? (e.g. log install success/failure, maybe download start/failure/stop?)