### PR TITLE
[CMAKE] Make reactos_cab_inf really depend on reactos.inf

### DIFF
--- a/boot/bootdata/packages/CMakeLists.txt
+++ b/boot/bootdata/packages/CMakeLists.txt
@@ -31,17 +31,19 @@ add_custom_command(
                              -D SRC2=${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.$<CONFIG>.dyn
                              -D DST=${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.maydiff
                              -P ${CMAKE_CURRENT_BINARY_DIR}/concat.cmake
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different 
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
                              ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.maydiff
                              ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff
     DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/reactos.dff.in
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff.$<CONFIG>.dyn)
 
-add_custom_target(
-    reactos_cab_inf
+add_custom_command(
     COMMAND native-cabman -C ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff -L ${CMAKE_CURRENT_BINARY_DIR} -I -P ${REACTOS_SOURCE_DIR}
     DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.dff native-cabman
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf)
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf)
+
+add_custom_target(
+    reactos_cab_inf DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/reactos.inf)
 
 add_cd_file(
     TARGET reactos_cab_inf


### PR DESCRIPTION
Instead of being always out of date & always trigger reactos.cab creation
