### PR TITLE
[GITHUB] workflows: Upgrade 2 actions/* to v2 from v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path: src
       - name: Set up cache for ccache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ccache
           key: ccache-gcc-i386-${{github.sha}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,12 +45,12 @@ jobs:
       - name: Print ccache statistics
         run: ccache -s
       - name: Upload bootcd
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: reactos-gcc-i386-${{github.sha}}
           path: build/bootcd.iso
       - name: Upload livecd
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: reactos-gcc-i386-${{github.sha}}
           path: build/livecd.iso
@@ -124,12 +124,12 @@ jobs:
         cmake --build . --target bootcd
         cmake --build . --target livecd
     - name: Upload bootcd
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: reactos-msvc-i386-${{github.sha}}
         path: build/bootcd.iso
     - name: Upload livecd
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v2
       with:
         name: reactos-msvc-i386-${{github.sha}}
         path: build/livecd.iso
@@ -169,12 +169,12 @@ jobs:
         cmake --build . --target bootcd
         cmake --build . --target livecd
     # - name: Upload bootcd
-    #   uses: actions/upload-artifact@v1
+    #   uses: actions/upload-artifact@v2
     #   with:
     #     name: reactos-msvc-amd64-${{github.sha}}
     #     path: build/bootcd.iso
     # - name: Upload livecd
-    #   uses: actions/upload-artifact@v1
+    #   uses: actions/upload-artifact@v2
     #   with:
     #     name: reactos-msvc-amd64-${{github.sha}}
     #     path: build/livecd.iso


### PR DESCRIPTION
https://github.com/actions/cache
```
What's New

    Added support for multiple paths, glob patterns, and single file caches.

- name: Cache multiple paths
  uses: actions/cache@v2
  with:
    path: |
      ~/cache
      !~/cache/exclude
      **/node_modules
    key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}

    Increased performance and improved cache sizes using zstd compression for Linux and macOS runners
    Allowed caching for all events with a ref. See events that trigger workflow for info on which events do not have a GITHUB_REF
    Released the @actions/cache npm package to allow other actions to utilize caching
    Added a best-effort cleanup step to delete the archive after extraction to reduce storage space

Refer here for previous versions
```

--

https://github.com/actions/upload-artifact
```
What's new

    Easier upload
        Specify a wildcard pattern
        Specify an individual file
        Specify a directory (previously you were limited to only this option)
        Multi path upload
            Use a combination of individual files, wildcards or directories
            Support for excluding certain files
    Upload an artifact without providing a name
    Fix for artifact uploads sometimes not working with containers
    Proxy support out of the box
    Port entire action to typescript from a runner plugin so it is easier to collaborate and accept contributions

Refer here for the previous version
```