### PR TITLE
[WIN32K] Fix handling of upper 32 bits of GDI handles on x64

### DIFF
--- a/modules/rostests/apitests/win32nt/ntgdi/NtGdiDeleteObjectApp.c
+++ b/modules/rostests/apitests/win32nt/ntgdi/NtGdiDeleteObjectApp.c
@@ -32,6 +32,23 @@ START_TEST(NtGdiDeleteObjectApp)
     ok_long(GetLastError(), 0);
     ok_int(GdiIsHandleValid(hdc), 0);
 
+#ifdef _WIN64
+    /* Test upper 32 bits */
+    SetLastError(0);
+    hdc = (HDC)((ULONG64)CreateCompatibleDC(NULL) | 0xFFFFFFFF00000000ULL);
+    ok_int(GdiIsHandleValid(hdc), 1);
+    ok_int(NtGdiDeleteObjectApp(hdc), 1);
+    ok_long(GetLastError(), 0);
+    ok_int(GdiIsHandleValid(hdc), 0);
+
+    SetLastError(0);
+    hdc = (HDC)((ULONG64)CreateCompatibleDC(NULL) | 0x537F9F2F00000000ULL);
+    ok_int(GdiIsHandleValid(hdc), 1);
+    ok_int(NtGdiDeleteObjectApp(hdc), 1);
+    ok_long(GetLastError(), 0);
+    ok_int(GdiIsHandleValid(hdc), 0);
+#endif
+
     /* Delete a display DC */
     SetLastError(0);
     hdc = CreateDC("DISPLAY", NULL, NULL, NULL);
@@ -55,6 +72,7 @@ START_TEST(NtGdiDeleteObjectApp)
     ok_long(GetLastError(), ERROR_INVALID_PARAMETER);
     /* Make sure */
     ok_ptr((void *)NtUserCallOneParam((DWORD_PTR)hdc, ONEPARAM_ROUTINE_RELEASEDC), NULL);
+
 
     /* Delete a brush */
     SetLastError(0);

--- a/win32ss/gdi/ntgdi/gdiobj.c
+++ b/win32ss/gdi/ntgdi/gdiobj.c
@@ -526,7 +526,10 @@ ENTRY_ReferenceEntryByHandle(HGDIOBJ hobj, FLONG fl)
 
     /* Integrity checks */
     ASSERT((pentry->FullUnique & 0x1f) == pentry->Objt);
-    ASSERT(pentry->einfo.pobj && pentry->einfo.pobj->hHmgr == hobj);
+    ASSERT(pentry->einfo.pobj != NULL);
+
+    /* Check if lower 32 bits match, the upper 32 bits are ignored */
+    ASSERT(pentry->einfo.pobj->hHmgr == UlongToPtr(PtrToUlong(hobj)));
 
     return pentry;
 }


### PR DESCRIPTION
* [WIN32NT_APITEST] Add tests for truncated and extended handle to NtGdiDeleteObjectApp test
* [WIN32K] Fix an ASSERT to ignore the upper 32 bits of a passed in GDI handle

This PR wants @ColinFinck to fix the WHS x64 tester.