### PR TITLE
[RDBSSLIB] RxFastIoDispatch: Fully zero it

### DIFF
--- a/sdk/lib/drivers/rdbsslib/rdbss.c
+++ b/sdk/lib/drivers/rdbsslib/rdbss.c
@@ -6908,16 +6908,11 @@ RxInitializeDispatchVectors(
     ASSERT(RxDeviceFCBVector[IRP_MJ_MAXIMUM_FUNCTION].CommonRoutine != NULL);
 
     DriverObject->FastIoDispatch = &RxFastIoDispatch;
+    RtlZeroMemory(&RxFastIoDispatch, sizeof(RxFastIoDispatch));
     RxFastIoDispatch.SizeOfFastIoDispatch = sizeof(RxFastIoDispatch);
     RxFastIoDispatch.FastIoCheckIfPossible = RxFastIoCheckIfPossible;
     RxFastIoDispatch.FastIoRead = RxFastIoRead;
     RxFastIoDispatch.FastIoWrite = RxFastIoWrite;
-    RxFastIoDispatch.FastIoQueryBasicInfo = NULL;
-    RxFastIoDispatch.FastIoQueryStandardInfo = NULL;
-    RxFastIoDispatch.FastIoLock = NULL;
-    RxFastIoDispatch.FastIoUnlockSingle = NULL;
-    RxFastIoDispatch.FastIoUnlockAll = NULL;
-    RxFastIoDispatch.FastIoUnlockAllByKey = NULL;
     RxFastIoDispatch.FastIoDeviceControl = RxFastIoDeviceControl;
     RxFastIoDispatch.AcquireFileForNtCreateSection = RxAcquireFileForNtCreateSection;
     RxFastIoDispatch.ReleaseFileForNtCreateSection = RxReleaseFileForNtCreateSection;


### PR DESCRIPTION
#3306, the other way round.

JIRA issue: [CORE-17342](https://jira.reactos.org/browse/CORE-17342)