### PR TITLE
[BOOTDATA] Add new Setup Debug/Screen boot entries in BootCD/HybridCD/PC98 boot menus.

### DIFF
--- a/boot/bootdata/bootcd.ini
+++ b/boot/bootdata/bootcd.ini
@@ -26,6 +26,21 @@ TimeText=Seconds until highlighted choice will be started automatically:
 
 [Operating Systems]
 Setup="Setup"
+Setup_Debug="Setup (Debug)"
+Setup_Aacpi="Setup ACPI APIC (Debug)"
+Setup_Screen="Setup (Screen)"
 
 [Setup]
 BootType=ReactOSSetup
+
+[Setup_Debug]
+BootType=ReactOSSetup
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Aacpi]
+BootType=ReactOSSetup
+Options=/HAL=halaacpi.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Screen]
+BootType=ReactOSSetup
+Options=/DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE

--- a/boot/bootdata/floppy_pc98.ini
+++ b/boot/bootdata/floppy_pc98.ini
@@ -25,11 +25,27 @@ MinimalUI=Yes
 TimeText=Seconds until highlighted choice will be started automatically:   
 
 [Operating Systems]
+Setup="Setup"
+Setup_Debug="Setup (Debug)"
+Setup_Screen="Setup (Screen)"
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
 LiveCD_Screen="LiveCD (Screen)"
 LiveCD_LogFile="LiveCD (Log file)"
-Setup="Setup"
+
+[Setup]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\reactos
+
+[Setup_Debug]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\reactos
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=9600 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Screen]
+BootType=ReactOSSetup
+SystemPath=multi(0)disk(0)cdrom(0)\reactos
+Options=/DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE
 
 [LiveCD]
 BootType=Windows2003
@@ -50,7 +66,3 @@ Options=/DEBUG /DEBUGPORT=SCREEN /SOS /MININT
 BootType=Windows2003
 SystemPath=multi(0)disk(0)cdrom(0)\reactos
 Options=/DEBUG /DEBUGPORT=FILE:\Device\HarddiskX\PartitionY\debug.log /SOS /MININT
-
-[Setup]
-BootType=ReactOSSetup
-SystemPath=multi(0)disk(0)cdrom(0)\reactos

--- a/boot/bootdata/hybridcd.ini
+++ b/boot/bootdata/hybridcd.ini
@@ -26,6 +26,8 @@ TimeText=Seconds until highlighted choice will be started automatically:
 
 [Operating Systems]
 Setup="Setup"
+Setup_Debug="Setup (Debug)"
+Setup_Screen="Setup (Screen)"
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
 LiveCD_Screen="LiveCD (Screen)"
@@ -37,6 +39,16 @@ LiveCD_RamDisk_Screen="LiveCD in RAM (Screen)"
 [Setup]
 BootType=ReactOSSetup
 SystemPath=\bootcd
+
+[Setup_Debug]
+BootType=ReactOSSetup
+SystemPath=\bootcd
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /NOGUIBOOT /SIFOPTIONSOVERRIDE
+
+[Setup_Screen]
+BootType=ReactOSSetup
+SystemPath=\bootcd
+Options=/DEBUG /DEBUGPORT=SCREEN /SIFOPTIONSOVERRIDE
 
 [LiveCD]
 BootType=Windows2003

--- a/boot/bootdata/livecd.ini
+++ b/boot/bootdata/livecd.ini
@@ -27,8 +27,8 @@ TimeText=Seconds until highlighted choice will be started automatically:
 [Operating Systems]
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
-LiveCD_VBoxDebug="LiveCD (VBox Debug)"
 LiveCD_Aacpi="LiveCD ACPI APIC (Debug)"
+LiveCD_VBoxDebug="LiveCD (VBox Debug)"
 LiveCD_Screen="LiveCD (Screen)"
 LiveCD_LogFile="LiveCD (Log file)"
 
@@ -42,16 +42,15 @@ BootType=Windows2003
 SystemPath=\reactos
 Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
 
+[LiveCD_Aacpi]
+BootType=Windows2003
+SystemPath=\reactos
+Options=/HAL=halaacpi.dll /DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+
 [LiveCD_VBoxDebug]
 BootType=Windows2003
 SystemPath=\reactos
 Options=/DEBUG /DEBUGPORT=VBOX /SOS /MININT
-
-[LiveCD_Aacpi]
-BootType=Windows2003
-SystemPath=\reactos
-Hal=HALAACPI.DLL
-Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
 
 [LiveCD_Screen]
 BootType=Windows2003


### PR DESCRIPTION
## Purpose

Based on the idea proposed by @vgalnt in:
JIRA issue: [CORE-17350](https://jira.reactos.org/browse/CORE-17350)

Makes testing easier on real hardware (especially for these configs
where debugging can only be done via screen mode).

Add also an experimental Setup ACPI APIC entry in bootcd.ini for testing
purposes, along the lines of commit 5ee0925 .
In the similar LiveCD entry, use instead the /HAL= option.