### PR TITLE
[SYSSETUP][TIMEDATE] Use exact setTimer() timeouts, to stay in sync

### DIFF
--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -429,10 +429,6 @@ UINT CTrayClockWnd::CalculateDueTime()
     if (!g_TaskbarSettings.bShowSeconds)
         uiDueTime += (59 - (UINT) LocalTime.wSecond) * 1000;
 
-    /* Add an artificial delay of 0.050 second to make sure the timer
-       doesn't fire too early */
-    uiDueTime += 50;
-
     return uiDueTime;
 }
 

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -429,14 +429,9 @@ UINT CTrayClockWnd::CalculateDueTime()
     if (!g_TaskbarSettings.bShowSeconds)
         uiDueTime += (59 - (UINT) LocalTime.wSecond) * 1000;
 
-    if (uiDueTime < USER_TIMER_MINIMUM || uiDueTime > USER_TIMER_MAXIMUM)
-        uiDueTime = 1000;
-    else
-    {
-        /* Add an artificial delay of 0.05 seconds to make sure the timer
-            doesn't fire too early*/
-        uiDueTime += 50;
-    }
+    /* Add an artificial delay of 0.050 second to make sure the timer
+       doesn't fire too early */
+    uiDueTime += 50;
 
     return uiDueTime;
 }

--- a/dll/cpl/timedate/clock.c
+++ b/dll/cpl/timedate/clock.c
@@ -152,10 +152,10 @@ ClockWndProc(HWND hwnd,
             pClockData->hGreyPen = CreatePen(PS_SOLID, 1, RGB(128, 128, 128));
             pClockData->hGreyBrush = CreateSolidBrush(RGB(128, 128, 128));
 
-            SetTimer(hwnd, ID_TIMER, 1000, NULL);
-            pClockData->bTimer = TRUE;
             GetLocalTime(&pClockData->stCurrent);
             pClockData->stPrevious = pClockData->stCurrent;
+
+            pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000, NULL) != 0);
             break;
 
         case WM_SIZE:
@@ -255,8 +255,7 @@ ClockWndProc(HWND hwnd,
         case CLM_STARTCLOCK:
             if (!pClockData->bTimer)
             {
-                SetTimer(hwnd, ID_TIMER, 1000, NULL);
-                pClockData->bTimer = TRUE;
+                pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000, NULL) != 0);
             }
             break;
 

--- a/dll/cpl/timedate/clock.c
+++ b/dll/cpl/timedate/clock.c
@@ -155,7 +155,7 @@ ClockWndProc(HWND hwnd,
             GetLocalTime(&pClockData->stCurrent);
             pClockData->stPrevious = pClockData->stCurrent;
 
-            pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000, NULL) != 0);
+            pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000 - pClockData->stCurrent.wMilliseconds, NULL) != 0);
             break;
 
         case WM_SIZE:
@@ -168,6 +168,12 @@ ClockWndProc(HWND hwnd,
             GetLocalTime(&pClockData->stCurrent);
             InvalidateRect(hwnd, NULL, FALSE);
             pClockData->stPrevious = pClockData->stCurrent;
+
+            // Reset timeout.
+            if (pClockData->bTimer)
+            {
+                SetTimer(hwnd, ID_TIMER, 1000 - pClockData->stCurrent.wMilliseconds, NULL);
+            }
             break;
 
         case WM_PAINT:
@@ -255,7 +261,10 @@ ClockWndProc(HWND hwnd,
         case CLM_STARTCLOCK:
             if (!pClockData->bTimer)
             {
-                pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000, NULL) != 0);
+                SYSTEMTIME LocalTime;
+
+                GetLocalTime(&LocalTime);
+                pClockData->bTimer = (SetTimer(hwnd, ID_TIMER, 1000 - LocalTime.wMilliseconds, NULL) != 0);
             }
             break;
 

--- a/dll/cpl/timedate/dateandtime.c
+++ b/dll/cpl/timedate/dateandtime.c
@@ -276,17 +276,20 @@ DateTimePageProc(HWND hwndDlg,
             FillMonthsComboBox(GetDlgItem(hwndDlg,
                                           IDC_MONTHCB));
 
-            SetTimer(hwndDlg, ID_TIMER, 1000, NULL);
-
             /* Set range and current year */
             SendMessageW(GetDlgItem(hwndDlg, IDC_YEAR), UDM_SETRANGE, 0, MAKELONG ((short) 9999, (short) 1900));
             SendMessageW(GetDlgItem(hwndDlg, IDC_YEAR), UDM_SETPOS, 0, MAKELONG( (short) st.wYear, 0));
 
             pOldWndProc = (WNDPROC)SetWindowLongPtrW(GetDlgItem(hwndDlg, IDC_TIMEPICKER), GWLP_WNDPROC, (LONG_PTR)DTPProc);
+
+            SetTimer(hwndDlg, ID_TIMER, 1000 - st.wMilliseconds, NULL);
             break;
 
         case WM_TIMER:
             SendMessageW(GetDlgItem(hwndDlg, IDC_TIMEPICKER), DTM_SETSYSTEMTIME, GDT_VALID, (LPARAM) &st);
+
+            // Reset timeout.
+            SetTimer(hwndDlg, ID_TIMER, 1000 - st.wMilliseconds, NULL);
             break;
 
         case WM_COMMAND:
@@ -377,11 +380,12 @@ DateTimePageProc(HWND hwndDlg,
 
                         case PSN_APPLY:
                             SetLocalSystemTime(hwndDlg);
-                            SetTimer(hwndDlg, ID_TIMER, 1000, NULL);
 
                             /* Tell the clock to start ticking */
                             SendDlgItemMessageW(hwndDlg, IDC_CLOCKWND, CLM_STARTCLOCK,
                                                 0, 0);
+
+                            SetTimer(hwndDlg, ID_TIMER, 1000 - st.wMilliseconds, NULL);
                             return TRUE;
                     }
                     break;

--- a/dll/cpl/timedate/dateandtime.c
+++ b/dll/cpl/timedate/dateandtime.c
@@ -350,6 +350,8 @@ DateTimePageProc(HWND hwndDlg,
                             SendDlgItemMessageW(hwndDlg, IDC_CLOCKWND, CLM_STOPCLOCK,
                                                 0, 0);
 
+                            // TODO: Set the clock to the input time.
+
                             /* Enable the 'Apply' button */
                             PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
                             break;

--- a/dll/cpl/timedate/monthcal.c
+++ b/dll/cpl/timedate/monthcal.c
@@ -238,10 +238,8 @@ MonthCalSetupDayTimer(IN PMONTHCALWND infoPtr)
     uElapse += (59 - (UINT)LocalTime.wMinute) * 60 * 1000;
     uElapse += (23 - (UINT)LocalTime.wHour) * 60 * 60 * 1000;
 
-    if (uElapse < USER_TIMER_MINIMUM || uElapse > USER_TIMER_MAXIMUM)
-        uElapse = 1000;
-    else
-        uElapse += 100; /* Add a delay of 0.1 seconds */
+    /* Add a delay of 0.100 second */
+    uElapse += 100;
 
     /* Setup the new timer */
     if (SetTimer(infoPtr->hSelf,

--- a/dll/cpl/timedate/monthcal.c
+++ b/dll/cpl/timedate/monthcal.c
@@ -238,9 +238,6 @@ MonthCalSetupDayTimer(IN PMONTHCALWND infoPtr)
     uElapse += (59 - (UINT)LocalTime.wMinute) * 60 * 1000;
     uElapse += (23 - (UINT)LocalTime.wHour) * 60 * 60 * 1000;
 
-    /* Add a delay of 0.100 second */
-    uElapse += 100;
-
     /* Setup the new timer */
     if (SetTimer(infoPtr->hSelf,
                  ID_DAYTIMER,

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -1641,9 +1641,11 @@ DateTimePageDlgProc(HWND hwndDlg,
                     SYSTEMTIME LocalTime;
 
                     GetLocalTime(&LocalTime);
+                    UpdateLocalSystemTime(hwndDlg, LocalTime);
 
                     /* Enable the Back and Next buttons */
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
+
                     if (SetupData->UnattendSetup && WriteDateTimeSettings(hwndDlg, SetupData))
                     {
                         SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, SetupData->uFirstNetworkWizardPage);
@@ -1656,6 +1658,7 @@ DateTimePageDlgProc(HWND hwndDlg,
 
                 case PSN_KILLACTIVE:
                 case DTN_DATETIMECHANGE:
+                    // NB: Not re-set until changing page (PSN_SETACTIVE).
                     KillTimer(hwndDlg, 1);
                     break;
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -1542,11 +1542,8 @@ SetSystemLocalTime(HWND hwnd, PSETUPDATA SetupData)
 
 
 static VOID
-UpdateLocalSystemTime(HWND hwnd)
+UpdateLocalSystemTime(HWND hwnd, SYSTEMTIME LocalTime)
 {
-    SYSTEMTIME LocalTime;
-
-    GetLocalTime(&LocalTime);
     DateTime_SetSystemtime(GetDlgItem(hwnd, IDC_DATEPICKER), GDT_VALID, &LocalTime);
     DateTime_SetSystemtime(GetDlgItem(hwnd, IDC_TIMEPICKER), GDT_VALID, &LocalTime);
 }
@@ -1625,13 +1622,26 @@ DateTimePageDlgProc(HWND hwndDlg,
         }
 
         case WM_TIMER:
-            UpdateLocalSystemTime(hwndDlg);
+        {
+            SYSTEMTIME LocalTime;
+
+            GetLocalTime(&LocalTime);
+            UpdateLocalSystemTime(hwndDlg, LocalTime);
+
+            // Reset timeout.
+            SetTimer(hwndDlg, 1, 1000 - LocalTime.wMilliseconds, NULL);
             break;
+        }
 
         case WM_NOTIFY:
             switch (((LPNMHDR)lParam)->code)
             {
                 case PSN_SETACTIVE:
+                {
+                    SYSTEMTIME LocalTime;
+
+                    GetLocalTime(&LocalTime);
+
                     /* Enable the Back and Next buttons */
                     PropSheet_SetWizButtons(GetParent(hwndDlg), PSWIZB_BACK | PSWIZB_NEXT);
                     if (SetupData->UnattendSetup && WriteDateTimeSettings(hwndDlg, SetupData))
@@ -1639,8 +1649,10 @@ DateTimePageDlgProc(HWND hwndDlg,
                         SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, SetupData->uFirstNetworkWizardPage);
                         return TRUE;
                     }
-                    SetTimer(hwndDlg, 1, 1000, NULL);
+
+                    SetTimer(hwndDlg, 1, 1000 - LocalTime.wMilliseconds, NULL);
                     break;
+                }
 
                 case PSN_KILLACTIVE:
                 case DTN_DATETIMECHANGE:


### PR DESCRIPTION
And a few related improvements.

JIRA issue: [CORE-13121](https://jira.reactos.org/browse/CORE-13121)