### PR TITLE
[NTOS:OB] ObReferenceObjectByHandle(): Add 2 DRIVER_VERIFIER_DETECTED_VIOLATION cases

### DIFF
--- a/ntoskrnl/include/config.h
+++ b/ntoskrnl/include/config.h
@@ -1,4 +1,7 @@
 #pragma once
 
+// Enable Driver Verifier checks in ObReferenceObjectByHandle(). (CORE-10207)
+// #define ENABLE_DRIVER_VERIFIER_OBREFERENCEOBJECTBYHANDLE
+
 // Enable global page support.
 // #define _GLOBAL_PAGES_ARE_AWESOME_


### PR DESCRIPTION
Commit Thomas's patch, plus a few tweaks.
Especially, make it depend on a define, until the D.V. management feature is added.

JIRA issue: [CORE-10207](https://jira.reactos.org/browse/CORE-10207)