### PR TITLE
[BOOTDATA] Add empty SystemPrefix value

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -2220,6 +2220,7 @@ HKLM,"SYSTEM\Setup","CmdLine",0x00000000,"setup -newsetup"
 HKLM,"SYSTEM\Setup","OsLoaderPath",0x00000000,"\"
 HKLM,"SYSTEM\Setup","SetupType",0x00010001,0x00000001
 HKLM,"SYSTEM\Setup","SystemPartition",0x00000000,"\Device\Harddisk0\Partition1"
+HKLM,"SYSTEM\Setup","SystemPrefix",0x00000001
 HKLM,"SYSTEM\Setup","SystemSetupInProgress",0x00010001,0x00000001
 
 ; Debug channels


### PR DESCRIPTION
This gets ReactOS with Win2003 NT kernel + HAL boot a bit further.

Before:
<img width="320" alt="vmplayer_tJMhGCjCra" src="https://user-images.githubusercontent.com/32551254/98538872-b5c02880-228b-11eb-9a2e-98313828f470.png">

After:
<img width="320" alt="vmplayer_LQBTIRIoF2" src="https://user-images.githubusercontent.com/32551254/98538893-bce73680-228b-11eb-9da2-a24569b5fa97.png">

