### PR TITLE
[REGEDIT] Make finished find messagebox owned by Regedit window CORE-17367

### DIFF
--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -821,7 +821,7 @@ void FindDialog(HWND hWnd)
 
             LoadStringW(hInst, IDS_FINISHEDFIND, msg, COUNT_OF(msg));
             LoadStringW(hInst, IDS_APP_TITLE, caption, COUNT_OF(caption));
-            MessageBoxW(0, msg, caption, MB_ICONINFORMATION);
+            MessageBoxW(hWnd, msg, caption, MB_ICONINFORMATION);
         }
     }
 }


### PR DESCRIPTION
## Purpose

Make the messagebox which notifies the user about finishing the search in registry, when no more items are found, owned by the main Regedit window. Now user will always see the notification on top until he will not close it manually. It repeats the behaviour of Windows Regedit.

JIRA issue: [CORE-17367](https://jira.reactos.org/browse/CORE-17367)