### PR TITLE
[ACPI] AcpiRegOpenKey(): Add a missing OBJ_KERNEL_HANDLE

### DIFF
--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -349,7 +349,7 @@ AcpiRegOpenKey(IN HANDLE ParentKeyHandle,
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &Name,
-                               OBJ_CASE_INSENSITIVE,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                ParentKeyHandle,
                                NULL);
 


### PR DESCRIPTION
JIRA issue: [CORE-10207](https://jira.reactos.org/browse/CORE-10207)