### PR TITLE
[REGEDIT] Display finished find messagebox after finishing the search via "Find Next" (F3) CORE-17368

### DIFF
--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -810,18 +810,23 @@ static INT_PTR CALLBACK FindDialogProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPAR
     return iResult;
 }
 
+void FindNextMessageBox(HWND hWnd)
+{
+    if (!FindNext(hWnd))
+    {
+        WCHAR msg[128], caption[128];
+
+        LoadStringW(hInst, IDS_FINISHEDFIND, msg, COUNT_OF(msg));
+        LoadStringW(hInst, IDS_APP_TITLE, caption, COUNT_OF(caption));
+        MessageBoxW(hWnd, msg, caption, MB_ICONINFORMATION);
+    }
+}
+
 void FindDialog(HWND hWnd)
 {
     if (DialogBoxParamW(GetModuleHandle(NULL), MAKEINTRESOURCEW(IDD_FIND),
                        hWnd, FindDialogProc, 0) != 0)
     {
-        if (!FindNext(hWnd))
-        {
-            WCHAR msg[128], caption[128];
-
-            LoadStringW(hInst, IDS_FINISHEDFIND, msg, COUNT_OF(msg));
-            LoadStringW(hInst, IDS_APP_TITLE, caption, COUNT_OF(caption));
-            MessageBoxW(hWnd, msg, caption, MB_ICONINFORMATION);
-        }
+        FindNextMessageBox(hWnd);
     }
 }

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -1230,7 +1230,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         FindDialog(hWnd);
         break;
     case ID_EDIT_FINDNEXT:
-        FindNext(hWnd);
+        FindNextMessageBox(hWnd);
         break;
     case ID_EDIT_COPYKEYNAME:
         CopyKeyName(hWnd, hKeyRoot, keyPath);

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -103,6 +103,7 @@ extern int InfoMessageBox(HWND hWnd, UINT uType, LPCWSTR lpTitle, LPCWSTR lpMess
 /* find.c */
 extern void FindDialog(HWND hWnd);
 extern BOOL FindNext(HWND hWnd);
+extern void FindNextMessageBox(HWND hWnd);
 
 /* framewnd.c */
 extern LRESULT CALLBACK FrameWndProc(HWND, UINT, WPARAM, LPARAM);


### PR DESCRIPTION
## Purpose

Display the notification messagebox if no more items were found when search via "Edit" -> "Find Next" (or just F3 hotkey).
Also move the messagebox into separate function and call it in all appropriate places: in `FindDialog`, where it was from the start, and in the `ID_EDIT_FINDNEXT`, which is responsible for "Find Next" action.
So now it is more understandable whether the search was finished.
It repeats behaviour of Windows Regedit.

JIRA issue: [CORE-17368](https://jira.reactos.org/browse/CORE-17368)