### PR TITLE
[NTOS:KD] KdpDebugLogInit(): Close the thread handle

### DIFF
--- a/ntoskrnl/kd/kdio.c
+++ b/ntoskrnl/kd/kdio.c
@@ -110,6 +110,8 @@ KdpLoggerThread(PVOID Context)
     ULONG beg, end, num;
     IO_STATUS_BLOCK Iosb;
 
+    ASSERT(ExGetPreviousMode() == KernelMode);
+
     KdpLoggingEnabled = TRUE;
 
     while (TRUE)

--- a/ntoskrnl/kd/kdio.c
+++ b/ntoskrnl/kd/kdio.c
@@ -296,6 +296,8 @@ KdpDebugLogInit(PKD_DISPATCH_TABLE DispatchTable,
                                ThreadPriority,
                                &Priority,
                                sizeof(Priority));
+
+        ZwClose(ThreadHandle);
     }
 }
 


### PR DESCRIPTION
And assert being in kernel mode
to be explicit that using Nt*() is safe.