### PR TITLE
[WIN32K:NTUSER] IntCreateDesktop(): Update a 'KernelMode' remnant

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -2368,7 +2368,7 @@ IntCreateDesktop(
     Status = ObReferenceObjectByHandle(hDesk,
                                        0,
                                        ExDesktopObjectType,
-                                       KernelMode,
+                                       AccessMode,
                                        (PVOID*)&pdesk,
                                        NULL);
     if (!NT_SUCCESS(Status))


### PR DESCRIPTION
Addendum to 765f094 (r57632) then 1abeb90.
JIRA issue: [CORE-10207](https://jira.reactos.org/browse/CORE-10207)

--

NB:
Currently, `AccessMode == UserMode`.
@HBelusca, Is it worth having this value as a parameter? // Yes, for future use.