### PR TITLE
[UNIATA] Workaround a regression

### DIFF
--- a/drivers/storage/ide/uniata/CMakeLists.txt
+++ b/drivers/storage/ide/uniata/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND SOURCE
     id_queue.cpp
     id_sata.cpp
     ros_glue/ros_glue.cpp
-    stdafx.h)
+    stdafx.h) # Not stdafx.cpp (which only includes the .h), to fix PCH.
 
 add_library(uniata MODULE ${SOURCE} idedma.rc)
 

--- a/drivers/storage/ide/uniata/CMakeLists.txt
+++ b/drivers/storage/ide/uniata/CMakeLists.txt
@@ -17,7 +17,7 @@ list(APPEND SOURCE
     id_queue.cpp
     id_sata.cpp
     ros_glue/ros_glue.cpp
-    stdafx.h) # Not stdafx.cpp (which only includes the .h), to fix PCH.
+    stdafx.h)
 
 add_library(uniata MODULE ${SOURCE} idedma.rc)
 

--- a/drivers/storage/ide/uniata/bm_devs.h
+++ b/drivers/storage/ide/uniata/bm_devs.h
@@ -143,7 +143,11 @@ BUSMASTER_CONTROLLER_INFORMATION_BASE const BusMasterAdapters[] = {
     
     PCI_DEV_HW_SPEC_BM( 1230, 8086, 0x00, ATA_WDMA2, "Intel PIIX"       , UNIATA_CHAN_TIMINGS                     ),
     PCI_DEV_HW_SPEC_BM( 7010, 8086, 0x00, ATA_WDMA2, "Intel PIIX3"      , 0                                       ),
+#ifndef __REACTOS__
     PCI_DEV_HW_SPEC_BM( 7111, 8086, 0x00, ATA_UDMA2, "Intel PIIX3"      , 0                                       ),
+#else
+    PCI_DEV_HW_SPEC_BM( 7111, 8086, 0x00, ATA_UDMA2, "Intel PIIX4"      , 0                                       ),
+#endif
     PCI_DEV_HW_SPEC_BM( 7199, 8086, 0x00, ATA_UDMA2, "Intel PIIX4"      , 0                                       ),
     PCI_DEV_HW_SPEC_BM( 84ca, 8086, 0x00, ATA_UDMA2, "Intel PIIX4"      , 0                                       ),
     PCI_DEV_HW_SPEC_BM( 7601, 8086, 0x00, ATA_UDMA2, "Intel ICH0"       , 0                                       ),

--- a/drivers/storage/ide/uniata/id_queue.cpp
+++ b/drivers/storage/ide/uniata/id_queue.cpp
@@ -231,7 +231,9 @@ UniataQueueRequest(
         AtaReq->next_req = NULL;
         LunExt->first_req =
         LunExt->last_req = AtaReq;
+#ifndef __REACTOS__ // CORE-17371.
         chan->cur_cdev = GET_CDEV(Srb);
+#endif
     }
     LunExt->queue_depth++;
     chan->queue_depth++;


### PR DESCRIPTION
Fix random crashes on Virtual PC (2004, at least).

- Workaround regressions.

JIRA issue: [CORE-17371](https://jira.reactos.org/browse/CORE-17371)