### PR TITLE
[REGEDIT] Prevent launching multiple instances of application CORE-17379

### DIFF
--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -194,6 +194,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
                       int       nCmdShow)
 {
     MSG msg;
+    HANDLE hMutex;
     HACCEL hAccel;
 
     UNREFERENCED_PARAMETER(hPrevInstance);
@@ -217,6 +218,29 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
         default:
             break;
     }
+
+    /* Prevent multiple instances of application */
+    hMutex = CreateMutexW(NULL, FALSE, L"Regedit");
+
+    if (hMutex)
+    {
+        if (GetLastError() == ERROR_ALREADY_EXISTS)
+        {
+            /* The application's instance is already running */
+            HWND hCurrentWnd = FindWindowW(szFrameClass, szTitle);
+
+            if (hCurrentWnd)
+            {
+                /* Activate and show the window of current instance */
+                SetForegroundWindow(hCurrentWnd);
+                ShowWindow(hCurrentWnd, nCmdShow);
+            }
+
+            CloseHandle(hMutex);
+            return 0;
+        }
+    }
+
     /* Store instance handle in our global variable */
     hInst = hInstance;
 
@@ -239,6 +263,13 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
     }
 
     ExitInstance(hInstance);
+
+    if (hMutex)
+    {
+        ReleaseMutex(hMutex);
+        CloseHandle(hMutex);
+    }
+
     return (int)msg.wParam;
 }
 


### PR DESCRIPTION
## Purpose

Prevent the possibility to launch multiple instances of our Regedit at the same time.
This repeats MS behaviour. XP/2003 Regedit allows to launch only one instance of it.
Also make the window of current instance active and show it when trying to launch the app second time.

JIRA issue: [CORE-17379](https://jira.reactos.org/browse/CORE-17379)

## Result

Tested our Regedit on Win2k3, before and after my changes.

Before:
![regedit_before_2k3](https://user-images.githubusercontent.com/26385117/99911430-12e0c300-2cfd-11eb-933d-174370add9fe.gif)

After:
![regedit_after_2k3](https://user-images.githubusercontent.com/26385117/99911436-1d9b5800-2cfd-11eb-8c7e-abd6e4524659.gif)

MS Regedit (for comparison):
![MS_regedit_2k3](https://user-images.githubusercontent.com/26385117/99911450-2ab84700-2cfd-11eb-8519-eecb9a18e050.gif)