### PR TITLE
[NTOS:WMI] Don't free the buffer on success in IoWMIWriteEvent CORE-17384

### DIFF
--- a/ntoskrnl/wmi/wmi.c
+++ b/ntoskrnl/wmi/wmi.c
@@ -111,10 +111,6 @@ IoWMIWriteEvent(IN PVOID WnodeEventItem)
     DPRINT1("IoWMIWriteEvent() called for WnodeEventItem %p, returning success\n",
         WnodeEventItem);
 
-    /* Free the buffer if we are returning success */
-    if (WnodeEventItem != NULL)
-        ExFreePool(WnodeEventItem);
-
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Purpose

Don't call `ExFreePool` when `IoWMIWriteEvent` returns success.
It will fix several asserts when trying to boot ReactOS with acpi.sys from XP/2003.
Although the system still doesn't boot properly, but nevertheless this improves the situation a bit.
Based on @ThFabba's comment: https://jira.reactos.org/browse/CORE-17384?focusedCommentId=126435&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-126435

JIRA issue: [CORE-17384](https://jira.reactos.org/browse/CORE-17384)