### PR TITLE
[KS] Fix length of the media categories path in KspReadMediaCategory CORE-17361

### DIFF
--- a/drivers/ksfilter/ks/connectivity.c
+++ b/drivers/ksfilter/ks/connectivity.c
@@ -248,7 +248,7 @@ KspReadMediaCategory(
         return Status;
 
     /* allocate buffer for the registry key */
-    Path.Length = 0;
+    Path.Length = MediaPath.Length + GuidString.Length;
     Path.MaximumLength = MediaPath.MaximumLength + GuidString.MaximumLength;
     Path.Buffer = AllocateItem(NonPagedPool, Path.MaximumLength);
     if (!Path.Buffer)


### PR DESCRIPTION
## Purpose

Fix length of the media categories path in `KspReadMediaCategory`.
It will allow our Kernel Streaming driver to properly load MS audio stack (portcls.sys, sysaudio.sys and wdmaud.sys from Windows XP/2003). :smiley: 

## Analysis

Currently, it's just set to zero.
Actually, it contains the path to the media categories registry key plus key name for each media category.
So it should have the appropriate length.

JIRA issue: [CORE-17361](https://jira.reactos.org/browse/CORE-17361)

## Result

Before:
![MS_audio_stack_before](https://user-images.githubusercontent.com/26385117/102218410-9483d500-3ee6-11eb-88db-c70f11808c48.png)

After:
![MS_audio_stack_after](https://user-images.githubusercontent.com/26385117/102218452-a1a0c400-3ee6-11eb-827a-2f78d692474b.png)

Although the sound does no logner work with such replacement (at least with AC97 VirtualBox driver), but nevertheless it's booting.
According to the log, MS audio drivers need `KSEVENTSETID_Sysaudio` event set from our Kernel Streaming, which should be available from `KsGernerateEventList` function, which, in its turn, uses `KsGenerateEvents`. These functions are currently unimplemented on our side.