### PR TITLE
[KS] Add more diagnostic DPRINTs in KspReadMediaCategory CORE-17361

### DIFF
--- a/drivers/ksfilter/ks/connectivity.c
+++ b/drivers/ksfilter/ks/connectivity.c
@@ -284,9 +284,13 @@ KspReadMediaCategory(
 
     /* query the name size */
     Status = ZwQueryValueKey(hKey, &Name, KeyValuePartialInformation, NULL, 0, &Size);
+
+    DPRINT("ZwQueryValueKey() status 0x%08lx %wZ\n", Status, &Name);
+
     if (!NT_SUCCESS(Status) && Status != STATUS_BUFFER_TOO_SMALL)
     {
         /* failed to query for name key */
+        DPRINT1("ZwQueryValueKey() failed with status 0x%08lx\n", Status);
         ZwClose(hKey);
         return Status;
     }
@@ -303,12 +307,15 @@ KspReadMediaCategory(
     /* now read the info */
     Status = ZwQueryValueKey(hKey, &Name, KeyValuePartialInformation, (PVOID)KeyInfo, Size, &Size);
 
+    DPRINT("ZwQueryValueKey() status 0x%08lx %wZ\n", Status, &Name);
+
     /* close the key */
     ZwClose(hKey);
 
     if (!NT_SUCCESS(Status))
     {
         /* failed to read key */
+        DPRINT1("ZwQueryValueKey() failed with status 0x%08lx\n", Status);
         FreeItem(KeyInfo);
         return Status;
     }


### PR DESCRIPTION
## Purpose

Add some more diagnostic `DPRINT`s in two `ZwQueryValueKey` calls of `KspReadMediaCategory`, when querying the size of the buffer and when reading the media categories names from registry. For both cases: on success and on failure.
They helped me to track the actual problem with fail to loading MS audio stack in ReactOS (portcls.sys, sysaudio.sys and wdmaud.sys from Windows XP/2003). Btw, I already fixed it in my previous #3390 PR. :slightly_smiling_face: 

JIRA issue: [CORE-17361](https://jira.reactos.org/browse/CORE-17361)