### PR TITLE
[KMTESTS:PS] Implement the basic kernel suite tests for process quota…

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -94,6 +94,7 @@ list(APPEND KMTEST_DRV_SOURCE
     ntos_ob/ObTypes.c
     ntos_ob/ObWait.c
     ntos_ps/PsNotify.c
+    ntos_ps/PsQuota.c
     ntos_se/SeHelpers.c
     ntos_se/SeInheritance.c
     ntos_se/SeQueryInfoToken.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -63,6 +63,7 @@ KMT_TESTFUNC Test_ObTypeClean;
 KMT_TESTFUNC Test_ObTypeNoClean;
 KMT_TESTFUNC Test_ObTypes;
 KMT_TESTFUNC Test_PsNotify;
+KMT_TESTFUNC Test_PsQuota;
 KMT_TESTFUNC Test_SeInheritance;
 KMT_TESTFUNC Test_SeQueryInfoToken;
 KMT_TESTFUNC Test_RtlAvlTree;
@@ -140,6 +141,7 @@ const KMT_TEST TestList[] =
     { "-ObTypeNoClean",                     Test_ObTypeNoClean },
     { "ObTypes",                            Test_ObTypes },
     { "PsNotify",                           Test_PsNotify },
+    { "PsQuota",                            Test_PsQuota },
     { "RtlAvlTreeKM",                       Test_RtlAvlTree },
     { "RtlExceptionKM",                     Test_RtlException },
     { "RtlIntSafeKM",                       Test_RtlIntSafe },

--- a/modules/rostests/kmtests/ntos_ps/PsQuota.c
+++ b/modules/rostests/kmtests/ntos_ps/PsQuota.c
@@ -1,0 +1,49 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Process Quota kernel mode tests suite
+ * COPYRIGHT:   Copyright 2020 George Bișoc (george.bisoc@reactos.org)
+ */
+
+#include <kmt_test.h>
+
+static
+VOID
+TestChargeProcessQuota(VOID)
+{
+    NTSTATUS Status;
+
+    /* We give an invalid EPROCESS */
+    KmtStartSeh()
+        PsChargePoolQuota(NULL, -1, 0);
+    KmtEndSeh(STATUS_ACCESS_VIOLATION);
+
+    Status = PsChargeProcessNonPagedPoolQuota(PsGetCurrentProcess(), 200);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_irql(PASSIVE_LEVEL);
+
+    Status = PsChargeProcessNonPagedPoolQuota(PsGetCurrentProcess(), -1);
+    ok_eq_hex(Status, STATUS_QUOTA_EXCEEDED);
+    ok_irql(PASSIVE_LEVEL);
+
+    Status = PsChargeProcessPagedPoolQuota(PsGetCurrentProcess(), 200);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_irql(PASSIVE_LEVEL);
+
+    Status = PsChargeProcessPagedPoolQuota(PsGetCurrentProcess(), -1);
+    ok_eq_hex(Status, STATUS_QUOTA_EXCEEDED);
+    ok_irql(PASSIVE_LEVEL);
+
+    Status = PsChargeProcessPoolQuota(PsGetCurrentProcess(), PagedPool, 200);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_irql(PASSIVE_LEVEL);
+
+    Status = PsChargeProcessPoolQuota(PsGetCurrentProcess(), NonPagedPool, 200);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+    ok_irql(PASSIVE_LEVEL);
+}
+
+START_TEST(PsQuota)
+{
+    TestChargeProcessQuota();
+}


### PR DESCRIPTION
… routines

## Purpose
Implement the basic KMTEST for process quota stuff. Currently the tests are covered for `PsCharge*` kernel routines for now, further tests will be added when needed.
**Windows Server 2003**
![Capture](https://user-images.githubusercontent.com/34916900/102717105-7223fa00-42e0-11eb-8797-0e6d13987cd5.PNG)
**ReactOS**
![Capture2](https://user-images.githubusercontent.com/34916900/102717107-76501780-42e0-11eb-9de0-81affd021860.PNG)