### PR TITLE
[NTOS:CC] Implement CcRemapBcb and CcSetLogHandleForFile CORE-17409

### DIFF
--- a/ntoskrnl/cc/cacheman.c
+++ b/ntoskrnl/cc/cacheman.c
@@ -154,7 +154,7 @@ CcRemapBcb (
     IN PVOID Bcb
     )
 {
-    PINTERNAL_BCB iBcb = Bcb;
+    PINTERNAL_BCB iBcb = CONTAINING_RECORD(Bcb, INTERNAL_BCB, PFCB);
 
     CCTRACE(CC_API_DEBUG, "Bcb=%p\n", Bcb);
 

--- a/ntoskrnl/cc/cacheman.c
+++ b/ntoskrnl/cc/cacheman.c
@@ -137,8 +137,16 @@ CcGetFlushedValidData (
 	return i;
 }
 
-/*
- * @implemented
+/**
+ * @brief Remaps a buffer control block (BCB).
+ * 
+ * Maps data in a cache file for reading, similarly to CcMapData.
+ * This makes the data mapped, but not pinned, so it can't be modified.
+ * 
+ * @param [in] Bcb
+ * Pointer to the BCB.
+ * 
+ * @return Read-only BCB pointer.
  */
 PVOID
 NTAPI

--- a/ntoskrnl/cc/cacheman.c
+++ b/ntoskrnl/cc/cacheman.c
@@ -6,6 +6,7 @@
  *
  * PROGRAMMERS:     David Welch (welch@cwcom.net)
  *                  Pierre Schweitzer (pierre@reactos.org)
+ *                  Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
  */
 
 /* INCLUDES *****************************************************************/
@@ -137,7 +138,7 @@ CcGetFlushedValidData (
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 PVOID
 NTAPI
@@ -145,9 +146,12 @@ CcRemapBcb (
     IN PVOID Bcb
     )
 {
-	UNIMPLEMENTED;
+    PINTERNAL_BCB iBcb = Bcb;
 
-    return 0;
+    CCTRACE(CC_API_DEBUG, "Bcb=%p\n", Bcb);
+
+    iBcb->RefCount++;
+    return Bcb;
 }
 
 /*

--- a/ntoskrnl/cc/fs.c
+++ b/ntoskrnl/cc/fs.c
@@ -346,8 +346,20 @@ CcSetFileSizes (
     KeReleaseSpinLock(&SharedCacheMap->CacheMapLock, oldirql);
 }
 
-/*
- * @implemented
+/**
+ * @brief Sets a log handle for file.
+ * 
+ * @param [in] FileObject
+ * Pointer to the file object of file for which will be stored a log handle.
+ * 
+ * @param [in] LogHandle
+ * Pointer to the log handle which will be stored.
+ * 
+ * @param [in] FlushToLsnRoutine
+ * Pointer to a flush callback routine of the log file, which should be called
+ * before flushing buffers of the file.
+ * 
+ * @return None
  */
 VOID
 NTAPI

--- a/ntoskrnl/cc/fs.c
+++ b/ntoskrnl/cc/fs.c
@@ -5,6 +5,7 @@
  * PURPOSE:         Implements cache managers functions useful for File Systems
  *
  * PROGRAMMERS:     Alex Ionescu
+ *                  Oleg Dubinskiy
  */
 
 /* INCLUDES ******************************************************************/
@@ -346,7 +347,7 @@ CcSetFileSizes (
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 VOID
 NTAPI
@@ -355,10 +356,15 @@ CcSetLogHandleForFile (
     IN PVOID LogHandle,
     IN PFLUSH_TO_LSN FlushToLsnRoutine)
 {
+    PROS_SHARED_CACHE_MAP Map = FileObject->SectionObjectPointer->SharedCacheMap;
+
     CCTRACE(CC_API_DEBUG, "FileObject=%p LogHandle=%p FlushToLsnRoutine=%p\n",
         FileObject, LogHandle, FlushToLsnRoutine);
 
-    UNIMPLEMENTED;
+    if (!Map) return;
+
+    Map->LogHandle = LogHandle;
+    Map->FlushToLsn = FlushToLsnRoutine;
 }
 
 /*

--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -181,6 +181,8 @@ typedef struct _ROS_SHARED_CACHE_MAP
     ULONG Flags;
     PCACHE_MANAGER_CALLBACKS Callbacks;
     PVOID LazyWriteContext;
+    PVOID LogHandle;
+    PFLUSH_TO_LSN FlushToLsn;
     LIST_ENTRY PrivateList;
     ULONG DirtyPageThreshold;
     KSPIN_LOCK BcbSpinLock;


### PR DESCRIPTION
## Purpose

Add implementations of `CcRemapBcb` and `CcSetLogHandleForFile` routines in our cache controller (CC), (partially) based on the ones from new CC.
Since in new CC implementations of `CcRemapBcb` and  `CcRepinBcb` are nearly identical, and in MSDN they are described similarly, I decided to do the same in our current CC too. And it worked for me. :slightly_smiling_face: Also the implementation of `CcSetLogHandleForFile` is similar to the one in new CC, but the difference is using the internal structures of the current CC, whose are appropriate to the ones from new CC.

JIRA issue: [CORE-17409](https://jira.reactos.org/browse/CORE-17409)

## TODO

- [ ] Handle failure case in `CcRemapBcb` if needed. This is probably also required, but currently is not implemented in new CC.

## Result

This allows NTFS driver from Windows XP and 2003 properly recognize (and work with) NTFS volumes in ReactOS. :smiley: (in pair with @ThFabba's patch from [CORE-10147](https://jira.reactos.org/browse/CORE-10147))

Before:
![MS_ntfs_in_ReactOS_before](https://user-images.githubusercontent.com/26385117/103160952-e4ff0a80-47e3-11eb-9f97-52aa5ff6b04e.png)

After:
![MS_ntfs_in_ReactOS_wo_USB](https://user-images.githubusercontent.com/26385117/103160957-ef210900-47e3-11eb-8450-c8ffce678895.png)

Read/write support works as well.