### PR TITLE
[TASKMGR] Fix CORE-17115 by removing caching

### DIFF
--- a/base/applications/taskmgr/perfdata.h
+++ b/base/applications/taskmgr/perfdata.h
@@ -55,14 +55,6 @@ typedef struct _PERFDATA
 	LARGE_INTEGER		KernelTime;
 } PERFDATA, *PPERFDATA;
 
-typedef struct _CMD_LINE_CACHE
-{
-     DWORD idx;
-    LPWSTR str;
-     ULONG len;
-    struct _CMD_LINE_CACHE* pnext;
-} CMD_LINE_CACHE, *PCMD_LINE_CACHE;
-
 BOOL	PerfDataInitialize(void);
 void	PerfDataUninitialize(void);
 void	PerfDataRefresh(void);
@@ -78,7 +70,6 @@ ULONG	PerfDataGetProcessId(ULONG Index);
 BOOL	PerfDataGetUserName(ULONG Index, LPWSTR lpUserName, ULONG nMaxCount);
 
 BOOL	PerfDataGetCommandLine(ULONG Index, LPWSTR lpCommandLine, ULONG nMaxCount);
-void	PerfDataDeallocCommandLineCache();
 
 ULONG	PerfDataGetSessionId(ULONG Index);
 ULONG	PerfDataGetCPUUsage(ULONG Index);

--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -490,8 +490,6 @@ TaskManagerWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             TaskManagerSettings.Maximized = TRUE;
         else
             TaskManagerSettings.Maximized = FALSE;
-        /* Get rid of the allocated command line cache, if any */
-        PerfDataDeallocCommandLineCache();
         if (hWindowMenu)
             DestroyMenu(hWindowMenu);
         return DefWindowProcW(hDlg, message, wParam, lParam);


### PR DESCRIPTION
The command line caching system was faulty. Indexes do not persist the actual program across different programs. PID is also not a solution because it would eventually collide as well given enough opening and closing of processes. After timing the function, I've determined it to be fast enough to not require caching. 

[CORE-17115](https://jira.reactos.org/browse/CORE-17115)