### PR TITLE
Fix several problems with ProcessorNameString registry value

### DIFF
--- a/base/applications/dxdiag/system.c
+++ b/base/applications/dxdiag/system.c
@@ -196,6 +196,7 @@ InitializeSystemPage(HWND hwndDlg)
     OSVERSIONINFO VersionInfo;
     PVOID SMBiosBuf;
     PCHAR DmiStrings[ID_STRINGS_MAX] = { 0 };
+    BOOL Result;
 
     /* set date/time */
     szTime[0] = L'\0';
@@ -322,7 +323,16 @@ InitializeSystemPage(HWND hwndDlg)
     FreeSMBiosData(SMBiosBuf);
 
     /* set processor string */
-    if (GetRegValue(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", L"ProcessorNameString", REG_SZ, szDesc, sizeof(szDesc)))
+    Result = GetRegValue(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", L"ProcessorNameString", REG_SZ, szDesc, sizeof(szDesc));
+    if (!Result)
+    {
+        /* Processor Brand String not found */
+        /* FIXME: Implement CPU name detection routine */
+
+        /* Finally try to use Identifier string */
+        Result = GetRegValue(HKEY_LOCAL_MACHINE, L"Hardware\\Description\\System\\CentralProcessor\\0", L"Identifier", REG_SZ, szDesc, sizeof(szDesc));
+    }
+    if (Result)
     {
         TrimDmiStringW(szDesc);
         /* FIXME retrieve current speed */

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -479,14 +479,29 @@ static VOID GetSystemInformation(HWND hwnd)
      */
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, ProcKey, 0, KEY_READ, &hKey) == ERROR_SUCCESS)
     {
+        INT PrevMachineLine;
+
         SetRegTextData(hwnd, hKey, _T("VendorIdentifier"), CurMachineLine);
         CurMachineLine++;
 
+        PrevMachineLine = CurMachineLine;
         CurMachineLine += SetProcNameString(hwnd,
                                             hKey,
                                             _T("ProcessorNameString"),
                                             CurMachineLine,
                                             CurMachineLine + 1);
+
+        if (CurMachineLine == PrevMachineLine)
+        {
+            /* TODO: Try obtaining CPU name from WMI (i.e. CIM_Processor) */
+
+            /* Brand String is not available, use Identifier instead */
+            CurMachineLine += SetProcNameString(hwnd,
+                                                hKey,
+                                                _T("Identifier"),
+                                                CurMachineLine,
+                                                CurMachineLine + 1);
+        }
 
         SetProcSpeed(hwnd, hKey, _T("~MHz"), CurMachineLine);
         CurMachineLine++;

--- a/drivers/bus/acpi/main.c
+++ b/drivers/bus/acpi/main.c
@@ -520,32 +520,29 @@ GetProcessorInformation(VOID)
                                NULL,
                                NULL,
                                &Length);
-    if (!NT_SUCCESS(Status))
+    if (NT_SUCCESS(Status))
     {
-        DPRINT1("Failed to query ProcessorNameString value: 0x%lx\n", Status);
-        goto done;
-    }
+        /* Allocate a buffer large enough to be zero terminated */
+        Length += sizeof(UNICODE_NULL);
+        ProcessorNameString = ExAllocatePoolWithTag(PagedPool, Length, 'IpcA');
+        if (ProcessorNameString == NULL)
+        {
+            DPRINT1("Failed to allocate 0x%lx bytes\n", Length);
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto done;
+        }
 
-    /* Allocate a buffer large enough to be zero terminated */
-    Length += sizeof(UNICODE_NULL);
-    ProcessorNameString = ExAllocatePoolWithTag(PagedPool, Length, 'IpcA');
-    if (ProcessorNameString == NULL)
-    {
-        DPRINT1("Failed to allocate 0x%lx bytes\n", Length);
-        Status = STATUS_INSUFFICIENT_RESOURCES;
-        goto done;
-    }
-
-    /* Query the processor name string */
-    Status = AcpiRegQueryValue(ProcessorHandle,
-                               L"ProcessorNameString",
-                               NULL,
-                               ProcessorNameString,
-                               &Length);
-    if (!NT_SUCCESS(Status))
-    {
-        DPRINT1("Failed to query ProcessorNameString value: 0x%lx\n", Status);
-        goto done;
+        /* Query the processor name string */
+        Status = AcpiRegQueryValue(ProcessorHandle,
+                                   L"ProcessorNameString",
+                                   NULL,
+                                   ProcessorNameString,
+                                   &Length);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("Failed to query ProcessorNameString value: 0x%lx\n", Status);
+            goto done;
+        }
     }
 
     /* Query the vendor identifier length */


### PR DESCRIPTION
Creating this Pull Request to run on test bots, gonna merge quickly on success, but feel free to review anyway.

JIRA issues: [CORE-17413](https://jira.reactos.org/browse/CORE-17413) and [CORE-7952](https://jira.reactos.org/browse/CORE-7952)

## Proposed changes

- Properly fix ACPI driver (regression introduced by @tkreuzer in CORE-7952)
- Revert hack in Configuration Manager (committed by @christophvw in 7a985425)
- Fix displaying CPU identifier in System Properties and DxDiag

## Showcase

Fortunately our Device Manager didn't needed any changes at all and handled this gracefully. :slightly_smiling_face: 

#### QEMU BEFORE
![qemu-before](https://user-images.githubusercontent.com/578406/103364308-7f09d000-4ace-11eb-9972-dfda7fcc5ee4.png)

#### QEMU AFTER
![qemu-after](https://user-images.githubusercontent.com/578406/103364319-83ce8400-4ace-11eb-925a-eda212c8dea6.png)
