### PR TITLE
[NDK] Rename Reserved to MaximumProcessors in SYSTEM_PROCESSOR_INFORMATION

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -657,7 +657,7 @@ QSI_DEF(SystemProcessorInformation)
     Spi->ProcessorArchitecture = KeProcessorArchitecture;
     Spi->ProcessorLevel = KeProcessorLevel;
     Spi->ProcessorRevision = KeProcessorRevision;
-    Spi->Reserved = 0;
+    Spi->MaximumProcessors = 0;
     Spi->ProcessorFeatureBits = KeFeatureBits;
 
     DPRINT("Arch %u Level %u Rev 0x%x\n", Spi->ProcessorArchitecture,

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -657,7 +657,11 @@ QSI_DEF(SystemProcessorInformation)
     Spi->ProcessorArchitecture = KeProcessorArchitecture;
     Spi->ProcessorLevel = KeProcessorLevel;
     Spi->ProcessorRevision = KeProcessorRevision;
+#if (NTDDI_VERSION < NTDDI_WIN8)
+    Spi->Reserved = 0;
+#else
     Spi->MaximumProcessors = 0;
+#endif
     Spi->ProcessorFeatureBits = KeFeatureBits;
 
     DPRINT("Arch %u Level %u Rev 0x%x\n", Spi->ProcessorArchitecture,

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -756,7 +756,7 @@ typedef struct _SYSTEM_PROCESSOR_INFORMATION
     USHORT ProcessorArchitecture;
     USHORT ProcessorLevel;
     USHORT ProcessorRevision;
-    USHORT Reserved;
+    USHORT MaximumProcessors;
     ULONG ProcessorFeatureBits;
 } SYSTEM_PROCESSOR_INFORMATION, *PSYSTEM_PROCESSOR_INFORMATION;
 

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -756,7 +756,11 @@ typedef struct _SYSTEM_PROCESSOR_INFORMATION
     USHORT ProcessorArchitecture;
     USHORT ProcessorLevel;
     USHORT ProcessorRevision;
+#if (NTDDI_VERSION < NTDDI_WIN8)
+    USHORT Reserved;
+#else
     USHORT MaximumProcessors;
+#endif
     ULONG ProcessorFeatureBits;
 } SYSTEM_PROCESSOR_INFORMATION, *PSYSTEM_PROCESSOR_INFORMATION;
 


### PR DESCRIPTION
This field is the current number of processors in the system plus the number of processors that could be added without rebooting.

https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/processor.htm