### PR TITLE
[AFD] Don't mark a closed socket as Overread

### DIFF
--- a/drivers/network/afd/afd/read.c
+++ b/drivers/network/afd/afd/read.c
@@ -191,7 +191,6 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
             if( NextIrp->MdlAddress ) UnlockRequest( NextIrp, IoGetCurrentIrpStackLocation( NextIrp ) );
             (void)IoSetCancelRoutine(NextIrp, NULL);
             IoCompleteRequest( NextIrp, IO_NETWORK_INCREMENT );
-            FCB->Overread = TRUE;
         }
     } else {
         /* Kick the user that receive would be possible now */


### PR DESCRIPTION
## Purpose

No clue if this is correct, but it fixes the test (tm)

JIRA issue: [CORE-17425](https://jira.reactos.org/browse/CORE-17425)

