### PR TITLE
[NTOS:PNP] Fix regression of HAL recognition in Device Manager

### DIFF
--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1337,6 +1337,11 @@ PiPerformSyncDeviceAction(
     _In_ PDEVICE_OBJECT DeviceObject,
     _In_ DEVICE_ACTION Action);
 
+NTSTATUS
+IopInitializeDeviceDescription(
+    _In_ PDEVICE_NODE DeviceNode,
+    _In_ HANDLE InstanceKey);
+
 //
 // PnP notifications
 //


### PR DESCRIPTION
Send `GUID_DEVICE_ENUMERATED` event for root devices.

According to Victor, Windows Server 2003 does not do this, however this fixes the regression with least changes in the kernel.

- Also initialize device description registry value, as it's required by New device installer (newdev.dll) to install driver from INF file.

JIRA issues: [CORE-17212](https://jira.reactos.org/browse/CORE-17212) [CORE-17398](https://jira.reactos.org/browse/CORE-17398)