### PR TITLE
[SCSIPORT] Append GEN_SCSIADAPTER compatible ID for legacy adapters

### DIFF
--- a/media/inf/scsi.inf
+++ b/media/inf/scsi.inf
@@ -26,6 +26,7 @@ DefaultDestDir = 12
 %GenericMfg% = GenericMfg
 
 [GenericMfg]
+%GEN_SCSIADAPTER.DeviceDesc% = NO_DRV,,GEN_SCSIADAPTER
 %PCI\VEN_104B&CC_0100.DeviceDesc% = BusLogic_Inst,PCI\VEN_104B&CC_0100
 
 ;----------------------------- ScsiPort Driver ----------------------------
@@ -39,6 +40,13 @@ StartType     = 0
 ErrorControl  = 0
 ServiceBinary = %12%\scsiport.sys
 LoadOrderGroup = SCSI Port
+
+;---------------------------- NO DRIVER REQ -----------------------------
+
+[NO_DRV]
+
+[NO_DRV.Services]
+AddService = , 0x00000002
 
 ;----------------------------- BusLogic Driver ----------------------------
 
@@ -66,6 +74,7 @@ ReactOS = "ReactOS Team"
 SCSIClassName = "SCSI and RAID Controllers"
 
 GenericMfg = "(Standard SCSI and RAID controllers)"
+GEN_SCSIADAPTER.DeviceDesc = "SCSI/RAID Host Controller"
 PCI\VEN_104B&CC_0100.DeviceDesc = "BusLogic SCSI Controller"
 
 [Strings.0405]
@@ -120,6 +129,7 @@ ReactOS = "Команда ReactOS"
 SCSIClassName = "SCSI и RAID контроллеры"
 
 GenericMfg = "(Стандартные SCSI и RAID контроллеры)"
+GEN_SCSIADAPTER.DeviceDesc = "SCSI/RAID хост-контроллер"
 PCI\VEN_104B&CC_0100.DeviceDesc = "Контроллер BusLogic SCSI"
 
 [Strings.041B]


### PR DESCRIPTION
Fixes UniATA root SCSI devices detection in the Device Manager. **IMPORTANT:** This depends on PR #3437.

![image](https://user-images.githubusercontent.com/578406/106372157-e80a8f00-637d-11eb-8d73-6d7d1a4cd06c.png)

Based on the description of `GEN_SCSIADAPTER` from Windows `pnpscsi.inf` (see also [this reference](https://community.osr.com/discussion/41967/installing-isa-scsi-miniport-driver-through-f6-on-fresh-install-of-windows-2000-problem)):
```
;*********************************
;Generic scsi adpater - compatible ID match on GEN_SCSIADAPTER
;as a method of making all non-pnp miniports have their adapters
;show up as scsi adapters in devmgr. Scsiport adds this id to
;legacy detected adapters.
```

See also chat messages:
- https://chat.reactos.org/reactos/pl/qii1w36wu7yrxyukh9b5dzwnje
- https://chat.reactos.org/reactos/pl/f5tanc9nfjdb5m17nhrq33994a

JIRA issue: [CORE-17398](https://jira.reactos.org/browse/CORE-17398)