### PR TITLE
[BOOTDATA] Link the Accessibility Utility Manager for LiveCD builds

### DIFF
--- a/boot/bootdata/CMakeLists.txt
+++ b/boot/bootdata/CMakeLists.txt
@@ -83,6 +83,7 @@ add_livecd_shortcut("Device Manager" devmgmt.exe "Profiles/All Users/Start Menu/
 add_livecd_shortcut("Event Viewer" eventvwr.exe "Profiles/All Users/Start Menu/Programs/Administrative Tools")
 add_livecd_shortcut("Service Manager" servman.exe "Profiles/All Users/Start Menu/Programs/Administrative Tools")
 add_livecd_shortcut("System Configuration" msconfig.exe "Profiles/All Users/Start Menu/Programs/Administrative Tools")
+add_livecd_shortcut("Accessibility Utility Manager" utilman.exe "Profiles/All Users/Start Menu/Programs/Accessories/Accessibility")
 add_livecd_shortcut("Magnify" magnify.exe "Profiles/All Users/Start Menu/Programs/Accessories/Accessibility")
 add_livecd_shortcut("On-Screen Keyboard" osk.exe "Profiles/All Users/Start Menu/Programs/Accessories/Accessibility")
 add_livecd_shortcut("Remote Desktop Connection" mstsc.exe "Profiles/All Users/Start Menu/Programs/Accessories/Communications")


### PR DESCRIPTION
The program is listed in Start Menu accessibility items for BootCD builds but not in LiveCD ones.