### PR TITLE
[NTOS:SE] Do not use a global lock for tokens

### DIFF
--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -181,6 +181,7 @@
 #define TAG_SE_HANDLES_TAB    'aHeS'
 #define TAG_SE_DIR_BUFFER     'bDeS'
 #define TAG_SE_PROXY_DATA     'dPoT'
+#define TAG_SE_TOKEN_LOCK     'lTeS'
 
 /* LPC Tags */
 #define TAG_LPC_MESSAGE   'McpL'

--- a/sdk/include/ndk/setypes.h
+++ b/sdk/include/ndk/setypes.h
@@ -188,7 +188,7 @@ typedef struct _TOKEN
     LUID AuthenticationId;                            /* 0x18 */
     LUID ParentTokenId;                               /* 0x20 */
     LARGE_INTEGER ExpirationTime;                     /* 0x28 */
-    struct _ERESOURCE *TokenLock;                     /* 0x30 */
+    PERESOURCE TokenLock;                             /* 0x30 */
     SEP_AUDIT_POLICY  AuditPolicy;                    /* 0x38 */
     LUID ModifiedId;                                  /* 0x40 */
     ULONG SessionId;                                  /* 0x48 */


### PR DESCRIPTION
Instead of using a global lock for tokens, initialise the lock locally every time a token is about to be created or duplicated (as in Windows Server 2003).
