### PR TITLE
[SHELL32] Fixing COpenWithMenu.cpp for handling path strings with spaces

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -155,7 +155,7 @@ COpenWithList::SApp *COpenWithList::Add(LPCWSTR pwszPath)
 
     if (pApp)
     {
-        StringCbPrintfW(pApp->wszCmd, sizeof(pApp->wszCmd), L"\"%s\" %%1", pwszPath);
+        StringCbPrintfW(pApp->wszCmd, sizeof(pApp->wszCmd), L"\"%s\" \"%%1\"", pwszPath);
         SaveApp(pApp);
     }
 


### PR DESCRIPTION
## Purpose

Fixing the bug where open with menu where OpenWithMenu does not handle handler's path when there are spaces in the path string.

JIRA issue: [CORE-17445](https://jira.reactos.org/browse/CORE-17445)

## Proposed changes

- Adds quote marks around %1 when recording the registry entry for file handler.

