### PR TITLE
[VIDEOPRT] Mark range 0x00000000 - 0x000A0000 as no access outside of dedicated functions

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -5035,7 +5035,7 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
             if (PointerPte->u.Soft.Valid == 0)
             {
                 ASSERT(PointerPte->u.Soft.Prototype == 0);
-                ASSERT(PointerPte->u.Soft.PageFileHigh == 0);
+                ASSERT((PointerPte->u.Soft.PageFileHigh == 0) || (PointerPte->u.Soft.Transition == 1));
             }
 
             //

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -48,14 +48,25 @@ VOID
 SetConWndConsoleLeaderCID(IN PGUI_CONSOLE_DATA GuiData)
 {
     PCONSOLE_PROCESS_DATA ProcessData;
-    CLIENT_ID ConsoleLeaderCID;
 
     ProcessData = ConSrvGetConsoleLeaderProcess(GuiData->Console);
-    ConsoleLeaderCID = ProcessData->Process->ClientId;
-    SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_PID,
-                      (LONG_PTR)(ConsoleLeaderCID.UniqueProcess));
-    SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_TID,
-                      (LONG_PTR)(ConsoleLeaderCID.UniqueThread));
+
+    DPRINT("ProcessData: %p, ProcessData->Process %p.\n", ProcessData, ProcessData->Process);
+    ASSERT(ProcessData != NULL);
+
+    if (ProcessData->Process)
+    {
+        CLIENT_ID ConsoleLeaderCID = ProcessData->Process->ClientId;
+        SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_PID,
+                          (LONG_PTR)(ConsoleLeaderCID.UniqueProcess));
+        SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_TID,
+                          (LONG_PTR)(ConsoleLeaderCID.UniqueThread));
+    }
+    else
+    {
+        SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_PID, 0);
+        SetWindowLongPtrW(GuiData->hWindow, GWLP_CONSOLE_LEADER_TID, 0);
+    }
 }
 /**************************************************************/
 


### PR DESCRIPTION
## Purpose

Make that address range unavailable to user-mode (only CSRSS.exe affected) and avoid weird behaviour such as NOT CRASHING ON NULL ACCESS.

## Proposed changes

- Call ZwAllocateVirtualMemory(PAGE_NOCCESS) on the said memory range once we are done with it. ZwProtectVirtualMemory is unavailable for kernel drivers...