### PR TITLE
[CONSRV] SetConWndConsoleLeaderCID(): Check must be before deref

### DIFF
--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -51,8 +51,8 @@ SetConWndConsoleLeaderCID(IN PGUI_CONSOLE_DATA GuiData)
 
     ProcessData = ConSrvGetConsoleLeaderProcess(GuiData->Console);
 
-    DPRINT("ProcessData: %p, ProcessData->Process %p.\n", ProcessData, ProcessData->Process);
     ASSERT(ProcessData != NULL);
+    DPRINT("ProcessData: %p, ProcessData->Process %p.\n", ProcessData, ProcessData->Process);
 
     if (ProcessData->Process)
     {


### PR DESCRIPTION
Addendum to f12e601.