### PR TITLE
[NTOS:WMI] IoWMIWriteEvent(): Add WNODE_FLAG_TRACED_GUID case

### DIFF
--- a/ntoskrnl/wmi/wmi.c
+++ b/ntoskrnl/wmi/wmi.c
@@ -106,10 +106,10 @@ IoWMISuggestInstanceName(IN PDEVICE_OBJECT PhysicalDeviceObject OPTIONAL,
  */
 NTSTATUS
 NTAPI
-IoWMIWriteEvent(IN PVOID WnodeEventItem)
+IoWMIWriteEvent(_Inout_ PVOID WnodeEventItem)
 {
-    DPRINT1("IoWMIWriteEvent() called for WnodeEventItem %p, returning success\n",
-        WnodeEventItem);
+    DPRINT1("IoWMIWriteEvent() called for WnodeEventItem %p (Flags = 0x%08lx), returning success\n",
+            WnodeEventItem, ((PWNODE_HEADER)WnodeEventItem)->Flags);
 
     /* Free the buffer if we are returning success */
     if (WnodeEventItem != NULL)

--- a/ntoskrnl/wmi/wmi.c
+++ b/ntoskrnl/wmi/wmi.c
@@ -111,6 +111,15 @@ IoWMIWriteEvent(_Inout_ PVOID WnodeEventItem)
     DPRINT1("IoWMIWriteEvent() called for WnodeEventItem %p (Flags = 0x%08lx), returning success\n",
             WnodeEventItem, ((PWNODE_HEADER)WnodeEventItem)->Flags);
 
+    if (((PWNODE_HEADER)WnodeEventItem)->Flags & WNODE_FLAG_TRACED_GUID)
+    {
+        DPRINT("IoWMIWriteEvent(): Flags has WNODE_FLAG_TRACED_GUID\n");
+
+        // Never free WnodeEventItem in this case.
+
+        return STATUS_SUCCESS;
+    }
+
     /* Free the buffer if we are returning success */
     if (WnodeEventItem != NULL)
         ExFreePool(WnodeEventItem);


### PR DESCRIPTION
Supersedes #3381.

JIRA issue: [CORE-17384](https://jira.reactos.org/browse/CORE-17384)

Test log:
```
(/ntoskrnl/wmi/wmi.c:112) IoWMIWriteEvent() called for WnodeEventItem FCAD8708 (Flags = 0x00120000), returning success
(/ntoskrnl/wmi/wmi.c:116) IoWMIWriteEvent(): Flags has WNODE_FLAG_TRACED_GUID
```