### PR TITLE
[MMSYS] Add the OFN_EXPLORER flag to the Browse for sound dialog

### DIFF
--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -1151,7 +1151,7 @@ SoundsDlgProc(HWND hwndDlg,
                     LoadStringW(hApplet, IDS_BROWSE_FOR_SOUND, szTitle, _countof(szTitle));
                     ofn.lpstrTitle = szTitle;
                     ofn.lpstrInitialDir = L"%SystemRoot%\\Media";
-                    ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
+                    ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 
                     if (GetOpenFileNameW(&ofn) != FALSE)
                     {


### PR DESCRIPTION
Add the OFN_EXPLORER flag to the Browse for sound dialog to take advantage of the newer XP/Server 2003 style dialog.


![VirtualBox_ReactOS_14_02_2021_13_35_34](https://user-images.githubusercontent.com/15203817/107887142-898af800-6ec9-11eb-967c-0779f40aa867.png)

