### PR TITLE
[TIMEDATE] Improve analog clock appearance

### DIFF
--- a/dll/cpl/timedate/clock.c
+++ b/dll/cpl/timedate/clock.c
@@ -22,7 +22,7 @@ typedef struct _CLOCKDATA
     INT Radius;
     POINT Center;
     HPEN hHourPen, hMinutePen, hSecondPen, hBoldPen;
-    HBRUSH hGreenBrush, hGreyBrush;
+    HBRUSH hBlueBrush, hGreyBrush;
     HBITMAP hbmBackScreen;
     SYSTEMTIME stCurrent;
     SYSTEMTIME stPrevious;
@@ -162,7 +162,7 @@ DrawHands(HDC hdc, PCLOCKDATA pClockData)
     Line(hdc, Center, Point);
 
     /* The center disc */
-    HGDIOBJ hOldBrush = SelectObject(hdc, pClockData->hGreenBrush);
+    HGDIOBJ hOldBrush = SelectObject(hdc, pClockData->hBlueBrush);
     const INT cxy = 5;
     Ellipse(hdc, Center.x - cxy, Center.y - cxy, Center.x + cxy, Center.y + cxy);
     SelectObject(hdc, hOldBrush);
@@ -198,10 +198,10 @@ ClockWnd_CreateData(HWND hwnd)
         return NULL;
 
     pClockData->hHourPen = CreatePen(PS_SOLID, 7, RGB(255, 0, 0)); /* Red */
-    pClockData->hMinutePen = CreatePen(PS_SOLID, 5, RGB(0, 0, 255)); /* Blue */
-    pClockData->hSecondPen = CreatePen(PS_SOLID, 2, RGB(0, 100, 0)); /* DarkGreen */
+    pClockData->hMinutePen = CreatePen(PS_SOLID, 4, RGB(0, 100, 0)); /* DarkGreen */
+    pClockData->hSecondPen = CreatePen(PS_SOLID, 2, RGB(0, 0, 255)); /* Blue */
     pClockData->hBoldPen = CreatePen(PS_SOLID, 3, RGB(0, 0, 0)); /* Black */
-    pClockData->hGreenBrush = CreateSolidBrush(RGB(0, 100, 0)); /* DarkGreen */
+    pClockData->hBlueBrush = CreateSolidBrush(RGB(0, 0, 2555)); /* Blue */
     pClockData->hGreyBrush = CreateSolidBrush(RGB(128, 128, 128)); /* Gray */
 
     SetTimer(hwnd, ID_TIMER, 1000, NULL);
@@ -220,7 +220,7 @@ ClockWnd_DestroyData(HWND hwnd, PCLOCKDATA pClockData)
     DeleteObject(pClockData->hMinutePen);
     DeleteObject(pClockData->hSecondPen);
     DeleteObject(pClockData->hBoldPen);
-    DeleteObject(pClockData->hGreenBrush);
+    DeleteObject(pClockData->hBlueBrush);
     DeleteObject(pClockData->hGreyBrush);
     DeleteObject(pClockData->hbmBackScreen);
 

--- a/dll/cpl/timedate/clock.c
+++ b/dll/cpl/timedate/clock.c
@@ -18,7 +18,6 @@ typedef struct _CLOCKDATA
 {
     INT cxClient;
     INT cyClient;
-    BOOL bTimer;
     INT Radius;
     POINT Center;
     HPEN hHourPen, hMinutePen, hSecondPen, hBoldPen;
@@ -26,6 +25,7 @@ typedef struct _CLOCKDATA
     HBITMAP hbmBackScreen;
     SYSTEMTIME stCurrent;
     SYSTEMTIME stPrevious;
+    BOOL bTimer;
 } CLOCKDATA, *PCLOCKDATA;
 
 #ifndef M_PI
@@ -62,9 +62,7 @@ Line(HDC hDC, POINT pt0, POINT pt1)
 
     HBRUSH hbr = CreateSolidBrush(LogPen.lopnColor);
     HGDIOBJ hbrOld = SelectObject(hDC, hbr);
-
     FillPath(hDC);
-
     SelectObject(hDC, hbrOld);
     DeleteObject(hbr);
 #else
@@ -192,8 +190,7 @@ ClockWnd_OnDraw(HWND hwnd, HDC hdc, PCLOCKDATA pClockData)
 static PCLOCKDATA
 ClockWnd_CreateData(HWND hwnd)
 {
-    PCLOCKDATA pClockData;
-    pClockData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(CLOCKDATA));
+    PCLOCKDATA pClockData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(CLOCKDATA));
     if (!pClockData)
         return NULL;
 

--- a/dll/cpl/timedate/clock.c
+++ b/dll/cpl/timedate/clock.c
@@ -117,18 +117,21 @@ DrawClock(HDC hdc, PCLOCKDATA pClockData)
     /* Draw dots */
     for (INT iAngle = 0; iAngle < 360; iAngle += 6)
     {
-        SetClockCoodinates(&Points[0], Center, Radius - 7, iAngle);
         if (iAngle % 5 == 0)
         {
+            SetClockCoodinates(&Points[0], Center, Radius - 7, iAngle);
             SetClockCoodinates(&Points[1], Center, Radius - 13, iAngle);
             SelectObject(hdc, pClockData->hBoldPen);
+            Line(hdc, Points[0], Points[1]);
         }
         else
         {
-            SetClockCoodinates(&Points[1], Center, Radius - 10, iAngle);
-            SelectObject(hdc, pClockData->hGreyPen);
+            SetClockCoodinates(&Points[1], Center, Radius - 8, iAngle);
+            SelectObject(hdc, GetStockObject(NULL_PEN));
+            SelectObject(hdc, pClockData->hGreyBrush);
+            const INT cxy = 2;
+            Ellipse(hdc, Points[1].x - cxy, Points[1].y - cxy, Points[1].x + cxy, Points[1].y + cxy);
         }
-        Line(hdc, Points[0], Points[1]);
     }
 
     SelectObject(hdc, hOldPen);


### PR DESCRIPTION
## Purpose

Improve analog clock appearance of Control Panel Applet `timedate`.

## Proposed changes

- Totally rewrite the clock-related code.
- Emulates line width by `WidenPath` trick.

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/107930923-fa600c00-6fbe-11eb-8e68-014387d09d12.png)
AFTER:
![VirtualBox_ReactOS_15_02_2021_22_28_00](https://user-images.githubusercontent.com/2107452/107952539-3c984600-6fdd-11eb-8951-4798c06102df.png)