### PR TITLE
[FREELDR] DetectPnpBios(): Add 'i' to an ERR()

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -273,7 +273,7 @@ DetectPnpBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 
             if (PnpBufferSize + DeviceNode->Size > PnpBufferSizeLimit)
             {
-                ERR("Buffer too small! Ignoring remaining device nodes.\n");
+                ERR("Buffer too small! Ignoring remaining device nodes. (i = %d)\n", i);
                 break;
             }
 

--- a/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
@@ -1150,7 +1150,7 @@ DetectPnpBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
 
             if (PnpBufferSize + DeviceNode->Size > PnpBufferSizeLimit)
             {
-                ERR("Buffer too small! Ignoring remaining device nodes.\n");
+                ERR("Buffer too small! Ignoring remaining device nodes. (i = %d)\n", i);
                 break;
             }
 


### PR DESCRIPTION
Addendum to 17990b2 (r73617).
JIRA issue: [CORE-12623](https://jira.reactos.org/browse/CORE-12623)
