### PR TITLE
[FREELDR] Add/Fix FrLdrHeapAlloc() failure handling and related

### DIFF
--- a/boot/freeldr/freeldr/arch/i386/hwacpi.c
+++ b/boot/freeldr/freeldr/arch/i386/hwacpi.c
@@ -75,7 +75,6 @@ DetectAcpiBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
         PartialResourceList =
             FrLdrHeapAlloc(sizeof(CM_PARTIAL_RESOURCE_LIST) + TableSize,
                            TAG_HW_RESOURCE_LIST);
-
         if (PartialResourceList == NULL)
         {
             ERR("Failed to allocate resource descriptor\n");

--- a/boot/freeldr/freeldr/arch/i386/hwpci.c
+++ b/boot/freeldr/freeldr/arch/i386/hwpci.c
@@ -229,7 +229,8 @@ DetectPciBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
                 PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
                 if (!PartialResourceList)
                 {
-                    ERR("Failed to allocate resource descriptor\n");
+                    ERR("Failed to allocate resource descriptor! Ignoring remaining PCI buses. (i = %lu, NoBuses = %lu)\n",
+                        i, (ULONG)BusData.NoBuses);
                     return;
                 }
 
@@ -254,7 +255,8 @@ DetectPciBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
                 PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
                 if (!PartialResourceList)
                 {
-                    ERR("Failed to allocate resource descriptor\n");
+                    ERR("Failed to allocate resource descriptor! Ignoring remaining PCI buses. (i = %lu, NoBuses = %lu)\n",
+                        i, (ULONG)BusData.NoBuses);
                     return;
                 }
 

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -689,7 +689,8 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
         PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
         if (PartialResourceList == NULL)
         {
-            ERR("Failed to allocate resource descriptor\n");
+            ERR("Failed to allocate resource descriptor! Ignoring remaining serial ports. (i = %lu, Count = %lu)\n",
+                i, Count);
             break;
         }
 
@@ -792,7 +793,7 @@ DetectParallelPorts(PCONFIGURATION_COMPONENT_DATA BusKey)
         PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
         if (PartialResourceList == NULL)
         {
-            ERR("Failed to allocate resource descriptor\n");
+            ERR("Failed to allocate resource descriptor! Ignoring remaining parallel ports. (i = %lu)\n", i);
             break;
         }
 

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -238,7 +238,7 @@ DetectPnpBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
     }
 
     /* Initialize resource descriptor */
-    memset(PartialResourceList, 0, Size);
+    RtlZeroMemory(PartialResourceList, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 1;
@@ -694,7 +694,7 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
         }
 
         /* Initialize resource descriptor */
-        memset(PartialResourceList, 0, Size);
+        RtlZeroMemory(PartialResourceList, Size);
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = 3;
@@ -797,7 +797,7 @@ DetectParallelPorts(PCONFIGURATION_COMPONENT_DATA BusKey)
         }
 
         /* Initialize resource descriptor */
-        memset(PartialResourceList, 0, Size);
+        RtlZeroMemory(PartialResourceList, Size);
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = (Irq[i] != (ULONG) - 1) ? 2 : 1;
@@ -1175,7 +1175,7 @@ DetectPS2Mouse(PCONFIGURATION_COMPONENT_DATA BusKey)
         }
 
         /* Initialize resource descriptor */
-        memset(PartialResourceList, 0, sizeof(CM_PARTIAL_RESOURCE_LIST));
+        RtlZeroMemory(PartialResourceList, sizeof(CM_PARTIAL_RESOURCE_LIST));
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = 1;

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -690,7 +690,7 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
         if (PartialResourceList == NULL)
         {
             ERR("Failed to allocate resource descriptor\n");
-            continue;
+            break;
         }
 
         /* Initialize resource descriptor */
@@ -793,7 +793,7 @@ DetectParallelPorts(PCONFIGURATION_COMPONENT_DATA BusKey)
         if (PartialResourceList == NULL)
         {
             ERR("Failed to allocate resource descriptor\n");
-            continue;
+            break;
         }
 
         /* Initialize resource descriptor */

--- a/boot/freeldr/freeldr/arch/i386/pc/machpc.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/machpc.c
@@ -236,9 +236,9 @@ DetectPnpBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
         ERR("Failed to allocate resource descriptor\n");
         return;
     }
-    memset(PartialResourceList, 0, Size);
 
     /* Initialize resource descriptor */
+    memset(PartialResourceList, 0, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 1;
@@ -692,9 +692,9 @@ DetectSerialPorts(PCONFIGURATION_COMPONENT_DATA BusKey, GET_SERIAL_PORT MachGetS
             ERR("Failed to allocate resource descriptor\n");
             continue;
         }
-        memset(PartialResourceList, 0, Size);
 
         /* Initialize resource descriptor */
+        memset(PartialResourceList, 0, Size);
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = 3;
@@ -795,9 +795,9 @@ DetectParallelPorts(PCONFIGURATION_COMPONENT_DATA BusKey)
             ERR("Failed to allocate resource descriptor\n");
             continue;
         }
-        memset(PartialResourceList, 0, Size);
 
         /* Initialize resource descriptor */
+        memset(PartialResourceList, 0, Size);
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = (Irq[i] != (ULONG) - 1) ? 2 : 1;
@@ -1173,9 +1173,9 @@ DetectPS2Mouse(PCONFIGURATION_COMPONENT_DATA BusKey)
             ERR("Failed to allocate resource descriptor\n");
             return;
         }
-        memset(PartialResourceList, 0, sizeof(CM_PARTIAL_RESOURCE_LIST));
 
         /* Initialize resource descriptor */
+        memset(PartialResourceList, 0, sizeof(CM_PARTIAL_RESOURCE_LIST));
         PartialResourceList->Version = 1;
         PartialResourceList->Revision = 1;
         PartialResourceList->Count = 1;

--- a/boot/freeldr/freeldr/arch/i386/pc/pchw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/pchw.c
@@ -290,7 +290,7 @@ DetectBiosFloppyController(PCONFIGURATION_COMPONENT_DATA BusKey)
     }
 
     /* Initialize resource descriptor */
-    memset(PartialResourceList, 0, Size);
+    RtlZeroMemory(PartialResourceList, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 3;

--- a/boot/freeldr/freeldr/arch/i386/pc/pchw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/pchw.c
@@ -288,9 +288,9 @@ DetectBiosFloppyController(PCONFIGURATION_COMPONENT_DATA BusKey)
         ERR("Failed to allocate resource descriptor\n");
         return NULL;
     }
-    memset(PartialResourceList, 0, Size);
 
     /* Initialize resource descriptor */
+    memset(PartialResourceList, 0, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 3;

--- a/boot/freeldr/freeldr/arch/i386/pc/pchw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc/pchw.c
@@ -230,7 +230,8 @@ DetectBiosFloppyPeripheral(PCONFIGURATION_COMPONENT_DATA ControllerKey)
         PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
         if (PartialResourceList == NULL)
         {
-            ERR("Failed to allocate resource descriptor\n");
+            ERR("Failed to allocate resource descriptor! Ignoring remaining floppy peripherals. (FloppyNumber = %u)\n",
+                FloppyNumber);
             return;
         }
 

--- a/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
@@ -1113,9 +1113,9 @@ DetectPnpBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
         ERR("Failed to allocate resource descriptor\n");
         return;
     }
-    RtlZeroMemory(PartialResourceList, Size);
 
     /* Initialize resource descriptor */
+    RtlZeroMemory(PartialResourceList, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 1;

--- a/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
+++ b/boot/freeldr/freeldr/arch/i386/pc98/pc98hw.c
@@ -176,7 +176,8 @@ DetectBiosFloppyPeripheral(PCONFIGURATION_COMPONENT_DATA ControllerKey)
         PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
         if (PartialResourceList == NULL)
         {
-            ERR("Failed to allocate resource descriptor\n");
+            ERR("Failed to allocate resource descriptor! Ignoring remaining floppy peripherals. (FloppyNumber = %u, FloppyCount = %u)\n",
+                FloppyNumber, Pc98GetFloppyCount());
             return;
         }
         RtlZeroMemory(PartialResourceList, Size);

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -106,7 +106,7 @@ XboxGetHarddiskConfigurationData(UCHAR DriveNumber, ULONG* pSize)
     PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
     if (PartialResourceList == NULL)
     {
-        ERR("Failed to allocate a full resource descriptor\n");
+        ERR("Failed to allocate resource descriptor\n");
         return NULL;
     }
 
@@ -218,7 +218,7 @@ DetectIsaBios(PCONFIGURATION_COMPONENT_DATA SystemKey, ULONG *BusNumber)
     PartialResourceList = FrLdrHeapAlloc(Size, TAG_HW_RESOURCE_LIST);
     if (PartialResourceList == NULL)
     {
-        TRACE("Failed to allocate resource descriptor\n");
+        ERR("Failed to allocate resource descriptor\n");
         return;
     }
 

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -177,7 +177,7 @@ DetectDisplayController(PCONFIGURATION_COMPONENT_DATA BusKey)
     }
 
     /* Initialize resource descriptor */
-    memset(PartialResourceList, 0, Size);
+    RtlZeroMemory(PartialResourceList, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 1;

--- a/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
+++ b/boot/freeldr/freeldr/arch/i386/xbox/machxbox.c
@@ -175,9 +175,9 @@ DetectDisplayController(PCONFIGURATION_COMPONENT_DATA BusKey)
         ERR("Failed to allocate resource descriptor\n");
         return;
     }
-    memset(PartialResourceList, 0, Size);
 
     /* Initialize resource descriptor */
+    memset(PartialResourceList, 0, Size);
     PartialResourceList->Version = 1;
     PartialResourceList->Revision = 1;
     PartialResourceList->Count = 1;

--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -625,15 +625,15 @@ PeLdrAllocateDataTableEntry(
         return FALSE;
     }
 
-    RtlZeroMemory(Buffer, Length);
-    while (*BaseDllName != 0)
-    {
-        *Buffer++ = *BaseDllName++;
-    }
-
     DataTableEntry->BaseDllName.Length = Length;
     DataTableEntry->BaseDllName.MaximumLength = Length;
     DataTableEntry->BaseDllName.Buffer = PaToVa(Buffer);
+
+    RtlZeroMemory(Buffer, Length);
+    while (Length--)
+    {
+        *Buffer++ = *BaseDllName++;
+    }
 
     /* Initialize FullDllName field (UNICODE_STRING) from the Ansi FullDllName
        using the same method */
@@ -645,15 +645,15 @@ PeLdrAllocateDataTableEntry(
         return FALSE;
     }
 
-    RtlZeroMemory(Buffer, Length);
-    while (*FullDllName != 0)
-    {
-        *Buffer++ = *FullDllName++;
-    }
-
     DataTableEntry->FullDllName.Length = Length;
     DataTableEntry->FullDllName.MaximumLength = Length;
     DataTableEntry->FullDllName.Buffer = PaToVa(Buffer);
+
+    RtlZeroMemory(Buffer, Length);
+    while (Length--)
+    {
+        *Buffer++ = *FullDllName++;
+    }
 
     /* Initialize what's left - LoadCount which is 1, and set Flags so that
        we know this entry is processed */

--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -590,7 +590,7 @@ PeLdrAllocateDataTableEntry(
     OUT PLDR_DATA_TABLE_ENTRY *NewEntry)
 {
     PVOID BaseVA = PaToVa(BasePA);
-    PWSTR Buffer;
+    PWSTR BaseDllNameBuffer, Buffer;
     PLDR_DATA_TABLE_ENTRY DataTableEntry;
     PIMAGE_NT_HEADERS NtHeaders;
     USHORT Length;
@@ -629,6 +629,9 @@ PeLdrAllocateDataTableEntry(
     DataTableEntry->BaseDllName.MaximumLength = Length;
     DataTableEntry->BaseDllName.Buffer = PaToVa(Buffer);
 
+    // Save Buffer, in case of later failure.
+    BaseDllNameBuffer = Buffer;
+
     RtlZeroMemory(Buffer, Length);
     while (Length--)
     {
@@ -641,6 +644,7 @@ PeLdrAllocateDataTableEntry(
     Buffer = (PWSTR)FrLdrHeapAlloc(Length, TAG_WLDR_NAME);
     if (Buffer == NULL)
     {
+        FrLdrHeapFree(BaseDllNameBuffer, TAG_WLDR_NAME);
         FrLdrHeapFree(DataTableEntry, TAG_WLDR_DTE);
         return FALSE;
     }

--- a/boot/freeldr/freeldr/lib/peloader.c
+++ b/boot/freeldr/freeldr/lib/peloader.c
@@ -19,8 +19,8 @@
 /* INCLUDES ******************************************************************/
 
 #include <freeldr.h>
-#include <debug.h>
 
+#include <debug.h>
 DBG_DEFAULT_CHANNEL(PELOADER);
 
 /* PRIVATE FUNCTIONS *********************************************************/
@@ -603,12 +603,12 @@ PeLdrAllocateDataTableEntry(
                                                            TAG_WLDR_DTE);
     if (DataTableEntry == NULL)
         return FALSE;
-    RtlZeroMemory(DataTableEntry, sizeof(LDR_DATA_TABLE_ENTRY));
 
     /* Get NT headers from the image */
     NtHeaders = RtlImageNtHeader(BasePA);
 
     /* Initialize corresponding fields of DTE based on NT headers value */
+    RtlZeroMemory(DataTableEntry, sizeof(LDR_DATA_TABLE_ENTRY));
     DataTableEntry->DllBase = BaseVA;
     DataTableEntry->SizeOfImage = NtHeaders->OptionalHeader.SizeOfImage;
     DataTableEntry->EntryPoint = RVA(BaseVA, NtHeaders->OptionalHeader.AddressOfEntryPoint);
@@ -624,15 +624,16 @@ PeLdrAllocateDataTableEntry(
         FrLdrHeapFree(DataTableEntry, TAG_WLDR_DTE);
         return FALSE;
     }
-    RtlZeroMemory(Buffer, Length);
 
-    DataTableEntry->BaseDllName.Length = Length;
-    DataTableEntry->BaseDllName.MaximumLength = Length;
-    DataTableEntry->BaseDllName.Buffer = PaToVa(Buffer);
+    RtlZeroMemory(Buffer, Length);
     while (*BaseDllName != 0)
     {
         *Buffer++ = *BaseDllName++;
     }
+
+    DataTableEntry->BaseDllName.Length = Length;
+    DataTableEntry->BaseDllName.MaximumLength = Length;
+    DataTableEntry->BaseDllName.Buffer = PaToVa(Buffer);
 
     /* Initialize FullDllName field (UNICODE_STRING) from the Ansi FullDllName
        using the same method */
@@ -643,15 +644,16 @@ PeLdrAllocateDataTableEntry(
         FrLdrHeapFree(DataTableEntry, TAG_WLDR_DTE);
         return FALSE;
     }
-    RtlZeroMemory(Buffer, Length);
 
-    DataTableEntry->FullDllName.Length = Length;
-    DataTableEntry->FullDllName.MaximumLength = Length;
-    DataTableEntry->FullDllName.Buffer = PaToVa(Buffer);
+    RtlZeroMemory(Buffer, Length);
     while (*FullDllName != 0)
     {
         *Buffer++ = *FullDllName++;
     }
+
+    DataTableEntry->FullDllName.Length = Length;
+    DataTableEntry->FullDllName.MaximumLength = Length;
+    DataTableEntry->FullDllName.Buffer = PaToVa(Buffer);
 
     /* Initialize what's left - LoadCount which is 1, and set Flags so that
        we know this entry is processed */

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -172,6 +172,8 @@ WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
         ArcDiskSig = FrLdrHeapAlloc(sizeof(ARC_DISK_SIGNATURE_EX), 'giSD');
         if (!ArcDiskSig)
         {
+            ERR("Failed to allocate ARC structure! Ignoring remaining ARC disks. (i = %lu, DiskCount = %lu)\n",
+                i, reactos_disk_count);
             break;
         }
 

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -170,6 +170,10 @@ WinLdrInitializePhase1(PLOADER_PARAMETER_BLOCK LoaderBlock,
 
         /* Allocate the ARC structure */
         ArcDiskSig = FrLdrHeapAlloc(sizeof(ARC_DISK_SIGNATURE_EX), 'giSD');
+        if (!ArcDiskSig)
+        {
+            break;
+        }
 
         /* Copy the data over */
         RtlCopyMemory(ArcDiskSig, &reactos_arc_disk_info[i], sizeof(ARC_DISK_SIGNATURE_EX));

--- a/boot/freeldr/freeldr/ntldr/wlregistry.c
+++ b/boot/freeldr/freeldr/ntldr/wlregistry.c
@@ -775,7 +775,6 @@ WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
     USHORT PathLength;
 
     BootDriverEntry = FrLdrHeapAlloc(sizeof(BOOT_DRIVER_LIST_ENTRY), TAG_WLDR_BDE);
-
     if (!BootDriverEntry)
         return FALSE;
 
@@ -792,7 +791,6 @@ WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
         BootDriverEntry->FilePath.Length = 0;
         BootDriverEntry->FilePath.MaximumLength = PathLength;
         BootDriverEntry->FilePath.Buffer = FrLdrHeapAlloc(PathLength, TAG_WLDR_NAME);
-
         if (!BootDriverEntry->FilePath.Buffer)
         {
             FrLdrHeapFree(BootDriverEntry, TAG_WLDR_BDE);
@@ -814,7 +812,6 @@ WinLdrAddDriverToList(LIST_ENTRY *BootDriverListHead,
         BootDriverEntry->FilePath.Length = 0;
         BootDriverEntry->FilePath.MaximumLength = PathLength;
         BootDriverEntry->FilePath.Buffer = FrLdrHeapAlloc(PathLength, TAG_WLDR_NAME);
-
         if (!BootDriverEntry->FilePath.Buffer)
         {
             FrLdrHeapFree(BootDriverEntry, TAG_WLDR_NAME);


### PR DESCRIPTION
Rebased patch that used to be attached to Jira, which @ThFabba had a look at 4 years ago.

JIRA issue: [CORE-12802](https://jira.reactos.org/browse/CORE-12802)

NB:
I am not working on added 'FIXME: Close these keys?', for the time being.