### PR TITLE
[NTDLL_APITEST] Ensure that some noticeable time has passed since process creation to fix a flaky test.

### DIFF
--- a/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
+++ b/modules/rostests/apitests/ntdll/NtQueryInformationProcess.c
@@ -119,7 +119,6 @@ Test_ProcessTimes(void)
                                        sizeof(KERNEL_USER_TIMES),
                                        NULL);
     ok_hex(Status, STATUS_SUCCESS);
-    ros_skip_flaky
     ok(Times1.CreateTime.QuadPart < TestStartTime.QuadPart,
        "CreateTime is %I64u, expected < %I64u\n", Times1.CreateTime.QuadPart, TestStartTime.QuadPart);
     ok(Times1.CreateTime.QuadPart > TestStartTime.QuadPart - 100000000LL,
@@ -326,6 +325,9 @@ Test_ProcessWx86Information(void)
 START_TEST(NtQueryInformationProcess)
 {
     NTSTATUS Status;
+
+    /* Make sure that some time has passed since process creation, even if the resolution of our NtQuerySystemTime is low. */
+    Sleep(1);
 
     Status = NtQuerySystemTime(&TestStartTime);
     ok_hex(Status, STATUS_SUCCESS);


### PR DESCRIPTION
## Purpose

Attempt to fix one understandable case of a flaky test in ntdll_apitest.
Testbots will show if that test reliably passes now.

https://github.com/reactos/reactos/pull/2906#issuecomment-641274438 proves that this was a problem not just under ReactOS, but also under Windows Server 2003.

JIRA issue: [CORE-17483](https://jira.reactos.org/browse/CORE-17483)