### PR TITLE
[USETUP] Display the "check the FS" section as a MUI page

### DIFF
--- a/base/setup/usetup/lang/bg-BG.h
+++ b/base/setup/usetup/lang/bg-BG.h
@@ -1339,6 +1339,36 @@ static MUI_ENTRY bgBGFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY bgBGCheckFSEntries[] =
+{
+    {
+        4,
+        3, " \221\253\240\243\240\255\245 \255\240 \220\245\240\252\342\216\221 " KERNEL_VERSION_STR " .",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "\222\245\347\245 \257\340\256\242\245\340\252\240 \255\240 \250\247\241\340\240\255\250\357 \244\357\253.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\217\256\347\240\252\240\251\342\245...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY bgBGInstallDirectoryEntries[] =
 {
     {
@@ -2114,6 +2144,10 @@ MUI_PAGE bgBGPages[] =
         bgBGFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        bgBGCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         bgBGDeletePartitionEntries
     },
@@ -2199,8 +2233,6 @@ MUI_STRING bgBGStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "\221\253\240\243\240\255\245 \255\240 \220\245\240\252\342\216\221 \242\352\340\345\343 \244\357\253"},
-    {STRING_CHECKINGPART,
-    "\222\245\347\245 \257\340\256\242\245\340\252\240 \255\240 \250\247\241\340\240\255\250\357 \244\357\253."},
     {STRING_CONTINUE,
     "ENTER = \217\340\256\244\352\253\246\240\242\240\255\245"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/bn-BD.h
+++ b/base/setup/usetup/lang/bn-BD.h
@@ -1329,6 +1329,37 @@ static MUI_ENTRY bnBDFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY bnBDCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup is now checking the selected partition.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Please wait...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY bnBDInstallDirectoryEntries[] =
 {
     {
@@ -2101,6 +2132,10 @@ MUI_PAGE bnBDPages[] =
         bnBDFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        bnBDCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         bnBDDeletePartitionEntries
     },
@@ -2184,8 +2219,6 @@ MUI_STRING bnBDStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup installs ReactOS onto Partition"},
-    {STRING_CHECKINGPART,
-    "Setup is now checking the selected partition."},
     {STRING_CONTINUE,
     "ENTER = Continue"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/cs-CZ.h
+++ b/base/setup/usetup/lang/cs-CZ.h
@@ -1337,6 +1337,37 @@ static MUI_ENTRY csCZFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY csCZCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instalace ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Instalace nyn\241 kontroluje zvolen\354 odd\241l.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\254ekejte, pros\241m...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY csCZInstallDirectoryEntries[] =
 {
     {
@@ -2109,6 +2140,10 @@ MUI_PAGE csCZPages[] =
         csCZFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        csCZCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         csCZDeletePartitionEntries
     },
@@ -2192,8 +2227,6 @@ MUI_STRING csCZStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Instalace nakop\241ruje ReactOS na odd\241l"},
-    {STRING_CHECKINGPART,
-    "Instalace nyn\241 kontroluje zvolen\354 odd\241l."},
     {STRING_CONTINUE,
     "ENTER = Pokra\237ovat"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/da-DK.h
+++ b/base/setup/usetup/lang/da-DK.h
@@ -1331,6 +1331,37 @@ static MUI_ENTRY daDKFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY daDKCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " installationen ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Installationen tjekker den valgte partition.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Vent...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY daDKInstallDirectoryEntries[] =
 {
     {
@@ -2104,6 +2135,10 @@ MUI_PAGE daDKPages[] =
         daDKFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        daDKCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         daDKDeletePartitionEntries
     },
@@ -2187,8 +2222,6 @@ MUI_STRING daDKStrings[] =
     "Den nye partition er endnu ikke blevet formateret."},
     {STRING_INSTALLONPART,
     "Installationen installere ReactOS p\206 partitionen"},
-    {STRING_CHECKINGPART,
-    "Installationen tjekker den valgte partition."},
     {STRING_CONTINUE,
     "ENTER = Forts\221t"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/de-DE.h
+++ b/base/setup/usetup/lang/de-DE.h
@@ -1331,6 +1331,37 @@ static MUI_ENTRY deDEFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY deDECheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Die ausgew\204hlte Partition wird \201berpr\201ft.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Bitte warten...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY deDEInstallDirectoryEntries[] =
 {
     {
@@ -2106,6 +2137,10 @@ MUI_PAGE deDEPages[] =
         deDEFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        deDECheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         deDEDeletePartitionEntries
     },
@@ -2189,8 +2224,6 @@ MUI_STRING deDEStrings[] =
     "Die neue Partition ist noch nicht formatiert."},
     {STRING_INSTALLONPART,
     "ReactOS wird auf dieser Partition installiert."},
-    {STRING_CHECKINGPART,
-    "Die ausgew\204hlte Partition wird \201berpr\201ft."},
     {STRING_CONTINUE,
     "EINGABETASTE = Fortsetzen"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/el-GR.h
+++ b/base/setup/usetup/lang/el-GR.h
@@ -1346,6 +1346,37 @@ static MUI_ENTRY elGRFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY elGRCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " \204\232\241\230\253\341\251\253\230\251\236 \253\246\254 ReactOS " KERNEL_VERSION_STR,
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "\206 \234\232\241\230\253\341\251\253\230\251\236 \234\242\342\232\256\234\240 \253\351\250\230 \253\246 \234\247\240\242\234\232\243\342\244\246 partition.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\217\230\250\230\241\230\242\351 \247\234\250\240\243\342\244\234\253\234...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY elGRInstallDirectoryEntries[] =
 {
     {
@@ -2117,6 +2148,10 @@ MUI_PAGE elGRPages[] =
         elGRFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        elGRCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         elGRDeletePartitionEntries
     },
@@ -2202,8 +2237,6 @@ MUI_STRING elGRStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup install ReactOS onto Partition"},
-    {STRING_CHECKINGPART,
-    "\206 \234\232\241\230\253\341\251\253\230\251\236 \234\242\342\232\256\234\240 \253\351\250\230 \253\246 \234\247\240\242\234\232\243\342\244\246 partition."},
     {STRING_CONTINUE,
     "ENTER = \221\254\244\342\256\234\240\230"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/en-US.h
+++ b/base/setup/usetup/lang/en-US.h
@@ -1329,6 +1329,37 @@ static MUI_ENTRY enUSFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY enUSCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup is now checking the selected partition.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Please wait...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY enUSInstallDirectoryEntries[] =
 {
     {
@@ -2101,6 +2132,10 @@ MUI_PAGE enUSPages[] =
         enUSFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        enUSCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         enUSDeletePartitionEntries
     },
@@ -2184,8 +2219,6 @@ MUI_STRING enUSStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup installs ReactOS onto Partition"},
-    {STRING_CHECKINGPART,
-    "Setup is now checking the selected partition."},
     {STRING_CONTINUE,
     "ENTER = Continue"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/es-ES.h
+++ b/base/setup/usetup/lang/es-ES.h
@@ -1335,6 +1335,37 @@ static MUI_ENTRY esESFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY esESCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instalaci\242n de ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "El instalador est\240 comprobando la Partici\242n seleccionada.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Espere un momento...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY esESInstallDirectoryEntries[] =
 {
     {
@@ -2107,6 +2138,10 @@ MUI_PAGE esESPages[] =
         esESFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        esESCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         esESDeletePartitionEntries
     },
@@ -2190,8 +2225,6 @@ MUI_STRING esESStrings[] =
     "La Partici\242n nueva todav\241a no ha sido formateada."},
     {STRING_INSTALLONPART,
     "El instalador est\240 instalando ReactOS en la Partici\242n"},
-    {STRING_CHECKINGPART,
-    "El instalador est\240 comprobando la Partici\242n seleccionada."},
     {STRING_CONTINUE,
     "INTRO = Continuar"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/et-EE.h
+++ b/base/setup/usetup/lang/et-EE.h
@@ -1332,6 +1332,37 @@ static MUI_ENTRY etEEFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY etEECheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " paigaldus ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Valitud partitsiooni kontrollitakse.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Palun oota...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY etEEInstallDirectoryEntries[] =
 {
     {
@@ -2102,6 +2133,10 @@ MUI_PAGE etEEPages[] =
         etEEFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        etEECheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         etEEDeletePartitionEntries
     },
@@ -2186,8 +2221,6 @@ MUI_STRING etEEStrings[] =
     "Uus partitsioon on veel vormindamata."},
     {STRING_INSTALLONPART,
     "ReactOS paigaldatakse partitsioonile"},
-    {STRING_CHECKINGPART,
-    "Valitud partitsiooni kontrollitakse."},
     {STRING_CONTINUE,
     "ENTER = J\204tka"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/eu-ES.h
+++ b/base/setup/usetup/lang/eu-ES.h
@@ -1330,6 +1330,37 @@ static MUI_ENTRY euESFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY euESCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Instalazioa ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Instalazioa ikusi du partizio aukertatutan.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Itxaron mesedez...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY euESInstallDirectoryEntries[] =
 {
     {
@@ -2102,6 +2133,10 @@ MUI_PAGE euESPages[] =
         euESFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        euESCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         euESDeletePartitionEntries
     },
@@ -2185,8 +2220,6 @@ MUI_STRING euESStrings[] =
     "Oraindik partizio berria ez dago formatuta."},
     {STRING_INSTALLONPART,
     "Instalazioa ReactOS instalatu du partizio barruan"},
-    {STRING_CHECKINGPART,
-    "Instalazioa ikusi du partizio aukertatutan."},
     {STRING_CONTINUE,
     "SARTU = Jarraitu"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/fr-FR.h
+++ b/base/setup/usetup/lang/fr-FR.h
@@ -1366,6 +1366,37 @@ static MUI_ENTRY frFRFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY frFRCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Installation de ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup v\202rifie la partition s\202lectionn\202e.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Veuillez patienter...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY frFRInstallDirectoryEntries[] =
 {
     {
@@ -2138,6 +2169,10 @@ MUI_PAGE frFRPages[] =
         frFRFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        frFRCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         frFRDeletePartitionEntries
     },
@@ -2221,8 +2256,6 @@ MUI_STRING frFRStrings[] =
     "La nouvelle partition n'est pas encore format\202e."},
     {STRING_INSTALLONPART,
     "Setup installe ReactOS sur la partition"},
-    {STRING_CHECKINGPART,
-    "Setup v\202rifie la partition s\202lectionn\202e."},
     {STRING_CONTINUE,
     "ENTR\220E = Continuer"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/he-IL.h
+++ b/base/setup/usetup/lang/he-IL.h
@@ -1333,6 +1333,37 @@ static MUI_ENTRY heILFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY heILCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " \232\220\227\232\204 ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        ".\204\230\207\201\220\231 \204\226\211\207\216\204 \232\200 \232\227\203\205\201 \205\211\231\213\222 \204\220\227\232\204\204 \232\211\220\213\232",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "...\217\211\232\216\204\214 \200\220",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY heILInstallDirectoryEntries[] =
 {
     {
@@ -2103,6 +2134,10 @@ MUI_PAGE heILPages[] =
         heILFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        heILCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         heILDeletePartitionEntries
     },
@@ -2186,8 +2221,6 @@ MUI_STRING heILStrings[] =
     ".\232\214\207\232\205\200\216 \200\214 \217\211\211\203\222 \204\231\203\207\204 \204\226\211\207\216\204"},
     {STRING_INSTALLONPART,
     "\204\226\211\207\216 \214\222 ReactOS \232\200 \204\220\211\227\232\216 \204\220\227\232\204\204 \232\211\220\213\232"},
-    {STRING_CHECKINGPART,
-    ".\204\230\207\201\220\231 \204\226\211\207\216\204 \232\200 \232\227\203\205\201 \205\211\231\213\222 \204\220\227\232\204\204 \232\211\220\213\232"},
     {STRING_CONTINUE,
     "\212\231\216\204 = ENTER"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/hu-HU.h
+++ b/base/setup/usetup/lang/hu-HU.h
@@ -1223,6 +1223,37 @@ static MUI_ENTRY huHUFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY huHUCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " telep\241t\213 ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "A telep\241t\213 most ellen\213rzi a kijel\224lt part\241ci\242t.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "K\202rem v\240rjon...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY huHUInstallDirectoryEntries[] =
 {
     {
@@ -1992,6 +2023,10 @@ MUI_PAGE huHUPages[] =
         huHUFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        huHUCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         huHUDeletePartitionEntries
     },
@@ -2075,8 +2110,6 @@ MUI_STRING huHUStrings[] =
     "Az \243j part\241ci\242 m\202g nincs form\240zva."},
     {STRING_INSTALLONPART,
     "A telep\241t\213 az al\240bbi part\241ci\242ra telep\241ti a ReactOS-t:"},
-    {STRING_CHECKINGPART,
-    "A telep\241t\213 most ellen\213rzi a kijel\224lt part\241ci\242t."},
     {STRING_CONTINUE,
     "ENTER = Folytat\240s"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/id-ID.h
+++ b/base/setup/usetup/lang/id-ID.h
@@ -1329,6 +1329,37 @@ static MUI_ENTRY idIDFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY idIDCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Penyetelan ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Penyetelan sekarang memeriksa partisi terpilih.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Mohon tunggu...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY idIDInstallDirectoryEntries[] =
 {
     {
@@ -2101,6 +2132,10 @@ MUI_PAGE idIDPages[] =
         idIDFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        idIDCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         idIDDeletePartitionEntries
     },
@@ -2184,8 +2219,6 @@ MUI_STRING idIDStrings[] =
     "Partisi baru ini belum diformat."},
     {STRING_INSTALLONPART,
     "Penyetelan memasang ReactOS pada Partisi"},
-    {STRING_CHECKINGPART,
-    "Penyetelan sekarang memeriksa partisi terpilih."},
     {STRING_CONTINUE,
     "ENTER = Lanjut"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/it-IT.h
+++ b/base/setup/usetup/lang/it-IT.h
@@ -1335,6 +1335,37 @@ static MUI_ENTRY itITFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY itITCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Installazione di ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup sta controllando la partizione selezionata.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Attendere...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY itITInstallDirectoryEntries[] =
 {
     {
@@ -2107,6 +2138,10 @@ MUI_PAGE itITPages[] =
         itITFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        itITCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         itITDeletePartitionEntries
     },
@@ -2190,8 +2225,6 @@ MUI_STRING itITStrings[] =
     "La nuova partizione non \x8A stata ancora formattata."},
     {STRING_INSTALLONPART,
     "Il setup installer\x85 ReactOS sulla partitione"},
-    {STRING_CHECKINGPART,
-    "Setup sta controllando la partizione selezionata."},
     {STRING_CONTINUE,
     "INVIO = Continua"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/ja-JP.h
+++ b/base/setup/usetup/lang/ja-JP.h
@@ -1332,6 +1332,37 @@ static MUI_ENTRY jaJPFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY jaJPCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " \276\257\304\261\257\314\337 ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "\276\257\304\261\257\314\337\312 \276\335\300\270 \273\332\300 \312\337\260\303\250\274\256\335\246 \271\335\273 \274\303\262\317\275\241",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\265\317\301 \270\300\336\273\262...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY jaJPInstallDirectoryEntries[] =
 {
     {
@@ -2104,6 +2135,10 @@ MUI_PAGE jaJPPages[] =
         jaJPFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        jaJPCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         jaJPDeletePartitionEntries
     },
@@ -2189,8 +2224,6 @@ MUI_STRING jaJPStrings[] =
     "\261\300\327\274\262 \312\337\260\303\250\274\256\335 \312 \317\300\336 \314\253\260\317\257\304 \273\332\303 \262\317\276\335\241"},
     {STRING_INSTALLONPART,
     "\276\257\304\261\257\314\337\312 ReactOS\246 \312\337\260\303\250\274\256\335 \274\336\256\263\306 \262\335\275\304\260\331\274\317\275\241"},
-    {STRING_CHECKINGPART,
-    "\276\257\304\261\257\314\337\312 \276\335\300\270 \273\332\300 \312\337\260\303\250\274\256\335\246 \271\335\273 \274\303\262\317\275\241"},
     {STRING_CONTINUE,
     "ENTER = \277\336\257\272\263"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/lt-LT.h
+++ b/base/setup/usetup/lang/lt-LT.h
@@ -1340,6 +1340,37 @@ static MUI_ENTRY ltLTFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY ltLTCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " diegimo programa ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup is now checking the selected partition.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Please wait...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY ltLTInstallDirectoryEntries[] =
 {
     {
@@ -2112,6 +2143,10 @@ MUI_PAGE ltLTPages[] =
         ltLTFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        ltLTCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         ltLTDeletePartitionEntries
     },
@@ -2195,8 +2230,6 @@ MUI_STRING ltLTStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup installs ReactOS onto Partition"},
-    {STRING_CHECKINGPART,
-    "Setup is now checking the selected partition."},
     {STRING_CONTINUE,
     "ENTER = Continue"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/ms-MY.h
+++ b/base/setup/usetup/lang/ms-MY.h
@@ -1321,6 +1321,37 @@ static MUI_ENTRY msMYFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY msMYCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Persediaan ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Persediaan kini sedang menyemak sekatan yang dipilih.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Sila tunggu...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY msMYInstallDirectoryEntries[] =
 {
     {
@@ -2086,6 +2117,10 @@ MUI_PAGE msMYPages[] =
         msMYFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        msMYCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         msMYDeletePartitionEntries
     },
@@ -2169,8 +2204,6 @@ MUI_STRING msMYStrings[] =
     "Partition baru tidak diformat lagi."},
     {STRING_INSTALLONPART,
     "Persediaan memasang ReactOS ke Partition"},
-    {STRING_CHECKINGPART,
-    "Persediaan kini sedang menyemak sekatan yang dipilih."},
     {STRING_CONTINUE,
     "ENTER = Teruskan"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/nl-NL.h
+++ b/base/setup/usetup/lang/nl-NL.h
@@ -1344,6 +1344,37 @@ static MUI_ENTRY nlNLFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY nlNLCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup controleert nu de geselecteerde partitie.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Een ogenblik geduld...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY nlNLInstallDirectoryEntries[] =
 {
     {
@@ -2126,6 +2157,10 @@ MUI_PAGE nlNLPages[] =
         nlNLFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        nlNLCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         nlNLDeletePartitionEntries
     },
@@ -2211,8 +2246,6 @@ MUI_STRING nlNLStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup installeert ReactOS op Partitie"},
-    {STRING_CHECKINGPART,
-    "Setup controleert nu de geselecteerde partitie."},
     {STRING_CONTINUE,
     "ENTER = Doorgaan"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/pl-PL.h
+++ b/base/setup/usetup/lang/pl-PL.h
@@ -1340,6 +1340,37 @@ static MUI_ENTRY plPLFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY plPLCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instalator ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Instalator sprawdza wybran\245 partycj\251.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Prosz\251 czeka\206...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY plPLInstallDirectoryEntries[] =
 {
     {
@@ -2109,6 +2140,10 @@ MUI_PAGE plPLPages[] =
         plPLFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        plPLCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         plPLDeletePartitionEntries
     },
@@ -2192,8 +2227,6 @@ MUI_STRING plPLStrings[] =
     "Nowa partycja nie jest jeszcze sformatowana."},
     {STRING_INSTALLONPART,
     "Instalator kopiuje pliki systemu na wybran\245 partycj\251."},
-    {STRING_CHECKINGPART,
-    "Instalator sprawdza wybran\245 partycj\251."},
     {STRING_CONTINUE,
     "ENTER = Kontynuacja"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/pt-BR.h
+++ b/base/setup/usetup/lang/pt-BR.h
@@ -1346,6 +1346,37 @@ static MUI_ENTRY ptBRFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY ptBRCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instala\207\306o do ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "O instalador est\240 verificando a parti\207\306o selecionada.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Por favor, aguarde...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY ptBRInstallDirectoryEntries[] =
 {
     {
@@ -2139,6 +2170,10 @@ MUI_PAGE ptBRPages[] =
         ptBRFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        ptBRCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         ptBRDeletePartitionEntries
     },
@@ -2224,8 +2259,6 @@ MUI_STRING ptBRStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "O instalador instala o ReactOS na parti\207\306o"},
-    {STRING_CHECKINGPART,
-    "O instalador est\240 verificando a parti\207\306o selecionada."},
     {STRING_CONTINUE,
     "ENTER=Continuar"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -1346,6 +1346,37 @@ static MUI_ENTRY ptPTFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY ptPTCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instala\207\306o do ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "O instalador est\240 a verificar a parti\207\306o seleccionada.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Por favor, aguarde...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY ptPTInstallDirectoryEntries[] =
 {
     {
@@ -2124,6 +2155,10 @@ MUI_PAGE ptPTPages[] =
         ptPTFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        ptPTCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         ptPTDeletePartitionEntries
     },
@@ -2208,8 +2243,6 @@ MUI_STRING ptPTStrings[] =
     "A nova parti\207\306o ainda n\306o est\240 formatada."},
     {STRING_INSTALLONPART,
     "O instalador instala o ReactOS na parti\207\306o"},
-    {STRING_CHECKINGPART,
-    "O instalador est\240 a verificar a parti\207\306o seleccionada."},
     {STRING_CONTINUE,
     "ENTER=Continuar"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/ro-RO.h
+++ b/base/setup/usetup/lang/ro-RO.h
@@ -1361,6 +1361,37 @@ static MUI_ENTRY roROFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY roROCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instalare ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Programul de instalare verific\343 acum parti\376ia aleas\343.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "A\272tepta\376i...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY roROInstallDirectoryEntries[] =
 {
     {
@@ -2147,6 +2178,10 @@ MUI_PAGE roROPages[] =
         roROFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        roROCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         roRODeletePartitionEntries
     },
@@ -2230,8 +2265,6 @@ MUI_STRING roROStrings[] =
     "Noua parti\376ie \356nc\343 nu a fost formatat\343."},
     {STRING_INSTALLONPART,
     "ReactOS va fi instalat pe parti\376ia"},
-    {STRING_CHECKINGPART,
-    "Programul de instalare verific\343 acum parti\376ia aleas\343."},
     {STRING_CONTINUE,
     "ENTER = Continuare"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/ru-RU.h
+++ b/base/setup/usetup/lang/ru-RU.h
@@ -1352,6 +1352,37 @@ static MUI_ENTRY ruRUFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY ruRUCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " \223\341\342\240\255\256\242\252\240 ReactOS " KERNEL_VERSION_STR,
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "\217\340\256\243\340\240\254\254\240 \343\341\342\240\255\256\242\252\250 \257\340\256\242\245\340\357\245\342 \242\353\241\340\240\255\255\353\251 \340\240\247\244\245\253.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\217\256\246\240\253\343\251\341\342\240, \257\256\244\256\246\244\250\342\245...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY ruRUInstallDirectoryEntries[] =
 {
     {
@@ -2124,6 +2155,10 @@ MUI_PAGE ruRUPages[] =
         ruRUFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        ruRUCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         ruRUDeletePartitionEntries
     },
@@ -2207,8 +2242,6 @@ MUI_STRING ruRUStrings[] =
     "\215\256\242\353\251 \340\240\247\244\245\253 \255\245 \256\342\344\256\340\254\240\342\250\340\256\242\240\255."},
     {STRING_INSTALLONPART,
     "ReactOS \343\341\342\240\255\240\242\253\250\242\240\245\342\341\357 \255\240 \340\240\247\244\245\253:"},
-    {STRING_CHECKINGPART,
-    "\217\340\256\243\340\240\254\254\240 \343\341\342\240\255\256\242\252\250 \257\340\256\242\245\340\357\245\342 \242\353\241\340\240\255\255\353\251 \340\240\247\244\245\253."},
     {STRING_CONTINUE,
     "ENTER = \217\340\256\244\256\253\246\250\342\354"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/sk-SK.h
+++ b/base/setup/usetup/lang/sk-SK.h
@@ -1338,6 +1338,37 @@ static MUI_ENTRY skSKFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY skSKCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " In\347tal\240tor syst\202mu ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "In\347tal\240tor teraz skontroluje vybran\243 oblas\234.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Po\237kajte, pros\241m ...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY skSKInstallDirectoryEntries[] =
 {
     {
@@ -2113,6 +2144,10 @@ MUI_PAGE skSKPages[] =
         skSKFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        skSKCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         skSKDeletePartitionEntries
     },
@@ -2198,8 +2233,6 @@ MUI_STRING skSKStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "In\347tal\240tor nain\347taluje syst\202m ReactOS na oblas\234"},
-    {STRING_CHECKINGPART,
-    "In\347tal\240tor teraz skontroluje vybran\243 oblas\234."},
     {STRING_CONTINUE,
     "ENTER = Pokra\237ova\234"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/sq-AL.h
+++ b/base/setup/usetup/lang/sq-AL.h
@@ -1336,6 +1336,37 @@ static MUI_ENTRY sqALFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY sqALCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " Instalimi i ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Instalimi tani \211sht\211 duke kontrolluar particionin e p\211rzgjedhur.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Ju lutem prisni...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY sqALInstallDirectoryEntries[] =
 {
     {
@@ -2114,6 +2145,10 @@ MUI_PAGE sqALPages[] =
         sqALFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        sqALCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         sqALDeletePartitionEntries
     },
@@ -2199,8 +2234,6 @@ MUI_STRING sqALStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Instalimi i ReactOS ne Particion"},
-    {STRING_CHECKINGPART,
-    "Instalimi tani \211sht\211 duke kontrolluar particionin e p\211rzgjedhur."},
     {STRING_CONTINUE,
     "ENTER = Vazhdo"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/sv-SE.h
+++ b/base/setup/usetup/lang/sv-SE.h
@@ -1338,6 +1338,37 @@ static MUI_ENTRY svSEFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY svSECheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Setup ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Setup unders\224ker nu den valda partitionen.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "Var v\204nlig v\204nta...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY svSEInstallDirectoryEntries[] =
 {
     {
@@ -2110,6 +2141,10 @@ MUI_PAGE svSEPages[] =
         svSEFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        svSECheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         svSEDeletePartitionEntries
     },
@@ -2195,8 +2230,6 @@ MUI_STRING svSEStrings[] =
     "The new partition is not formatted yet."},
     {STRING_INSTALLONPART,
     "Setup installerar ReactOS till Partitionen"},
-    {STRING_CHECKINGPART,
-    "Setup unders\224ker nu den valda partitionen."},
     {STRING_CONTINUE,
     "ENTER = Forts\204tt"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/tr-TR.h
+++ b/base/setup/usetup/lang/tr-TR.h
@@ -1313,6 +1313,37 @@ static MUI_ENTRY trTRFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY trTRCheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " ReactOS " KERNEL_VERSION_STR " Kur ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "Kur, \237imdi se\207ili b\224l\201m\201 g\224zden ge\207iriyor.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "L\201tfen bekleyiniz...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY trTRInstallDirectoryEntries[] =
 {
     {
@@ -2078,6 +2109,10 @@ MUI_PAGE trTRPages[] =
         trTRFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        trTRCheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         trTRDeletePartitionEntries
     },
@@ -2161,8 +2196,6 @@ MUI_STRING trTRStrings[] =
     "Yeni b\224l\201m daha bi\207imlendirilmemi\237."},
     {STRING_INSTALLONPART,
     "Kur, ReactOS'u b\224l\201m \201zerine kurar."},
-    {STRING_CHECKINGPART,
-    "Kur, \237imdi se\207ili b\224l\201m\201 g\224zden ge\207iriyor."},
     {STRING_CONTINUE,
     "ENTER = S\201rd\201r"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/lang/uk-UA.h
+++ b/base/setup/usetup/lang/uk-UA.h
@@ -1337,6 +1337,37 @@ static MUI_ENTRY ukUAFormatPartitionEntries[] =
     }
 };
 
+static MUI_ENTRY ukUACheckFSEntries[] =
+{
+    {
+        4,
+        3,
+        " \202\341\342\240\255\256\242\253\245\255\255\357 ReactOS " KERNEL_VERSION_STR " ",
+        TEXT_STYLE_UNDERLINE,
+        TEXT_ID_STATIC
+    },
+    {
+        6,
+        8,
+        "\202\341\342\240\255\256\242\253\356\242\240\347 \257\245\340\245\242i\340\357\363 \242\250\241\340\240\255\250\251 \340\256\247\244i\253.",
+        TEXT_STYLE_NORMAL,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        "\201\343\244\354-\253\240\341\252\240, \247\240\347\245\252\240\251\342\245...",
+        TEXT_TYPE_STATUS | TEXT_PADDING_BIG,
+        TEXT_ID_STATIC
+    },
+    {
+        0,
+        0,
+        NULL,
+        0
+    }
+};
+
 static MUI_ENTRY ukUAInstallDirectoryEntries[] =
 {
     {
@@ -2110,6 +2141,10 @@ MUI_PAGE ukUAPages[] =
         ukUAFormatPartitionEntries
     },
     {
+        CHECK_FILE_SYSTEM_PAGE,
+        ukUACheckFSEntries
+    },
+    {
         DELETE_PARTITION_PAGE,
         ukUADeletePartitionEntries
     },
@@ -2195,8 +2230,6 @@ MUI_STRING ukUAStrings[] =
     "\215\256\242\250\251 \340\256\247\244i\253 \255\245 \242i\244\344\256\340\254\240\342\256\242\240\255\256."},
     {STRING_INSTALLONPART,
     "ReactOS \242\341\342\240\255\256\242\253\356\363\342\354\341\357 \255\240 \340\256\247\244i\253"},
-    {STRING_CHECKINGPART,
-    "\202\341\342\240\255\256\242\253\356\242\240\347 \257\245\340\245\242i\340\357\363 \242\250\241\340\240\255\250\251 \340\256\247\244i\253."},
     {STRING_CONTINUE,
     "ENTER = \217\340\256\244\256\242\246\250\342\250"},
     {STRING_QUITCONTINUE,

--- a/base/setup/usetup/mui.h
+++ b/base/setup/usetup/mui.h
@@ -124,7 +124,6 @@ MUISetStyledText(
 #define STRING_NONFORMATTEDSYSTEMPART    62
 #define STRING_NONFORMATTEDOTHERPART     63
 #define STRING_INSTALLONPART             10
-#define STRING_CHECKINGPART              11
 #define STRING_CONTINUE                  12
 #define STRING_QUITCONTINUE              13
 #define STRING_REBOOTCOMPUTER            14

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3157,6 +3157,8 @@ CheckFileSystemPage(PINPUT_RECORD Ir)
     PPARTENTRY PartEntry;
     CHAR Buffer[MAX_PATH];
 
+    MUIDisplayPage(CHECK_FILE_SYSTEM_PAGE);
+
     if (PartitionList == NULL)
     {
         /* FIXME: show an error dialog */
@@ -3169,9 +3171,6 @@ CheckFileSystemPage(PINPUT_RECORD Ir)
     }
 
     ASSERT(PartEntry->IsPartitioned && PartEntry->PartitionNumber != 0);
-
-    CONSOLE_SetTextXY(6, 8, MUIGetString(STRING_CHECKINGPART));
-    CONSOLE_SetStatusText(MUIGetString(STRING_PLEASEWAIT));
 
     DPRINT1("CheckFileSystemPage -- PartitionType: 0x%02X ; FileSystem: %S\n",
             PartEntry->PartitionType, (*PartEntry->FileSystem ? PartEntry->FileSystem : L"n/a"));


### PR DESCRIPTION
`Check the filesystem` is the only section of USETUP that doesn't belong to its own MUI page, `CHECK_FILE_SYSTEM_PAGE`, but instead the contents inside that section are hardcoded in `CheckFileSystemPage` page function. With that said, display such section as a MUI page so that stuff can be localised.