### PR TITLE
[NTOS:OB] Do not close the handle if it's granted access to ObpAccess…

### DIFF
--- a/ntoskrnl/include/internal/ob.h
+++ b/ntoskrnl/include/internal/ob.h
@@ -54,6 +54,11 @@
                                                          OBJ_AUDIT_OBJECT_CLOSE)
 
 //
+// Handle Access Protection Close Flag
+//
+#define ObpAccessProtectCloseBit 0x02000000L
+
+//
 // Identifies a Kernel Handle
 //
 #ifdef _WIN64

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -18,7 +18,6 @@
 #include <debug.h>
 
 PHANDLE_TABLE ObpKernelHandleTable = NULL;
-ULONG ObpAccessProtectCloseBit = MAXIMUM_ALLOWED;
 
 #define TAG_OB_HANDLE 'dHbO'
 
@@ -726,7 +725,7 @@ ObpCloseHandleTableEntry(IN PHANDLE_TABLE HandleTable,
     }
 
     /* The callback allowed us to close it, but does the handle itself? */
-    if ((HandleEntry->ObAttributes & OBJ_PROTECT_CLOSE) &&
+    if ((HandleEntry->GrantedAccess & ObpAccessProtectCloseBit) &&
         !(IgnoreHandleProtection))
     {
         /* It doesn't, are we from user mode? */

--- a/ntoskrnl/ob/obref.c
+++ b/ntoskrnl/ob/obref.c
@@ -15,8 +15,6 @@
 #define NDEBUG
 #include <debug.h>
 
-extern ULONG ObpAccessProtectCloseBit;
-
 /* PRIVATE FUNCTIONS *********************************************************/
 
 BOOLEAN


### PR DESCRIPTION
…ProtectCloseBit
## Purpose

As of now the Object Manager private service, ObpCloseHandleTableEntry, looks for OBJ_PROTECT_CLOSE attribute if a handle should not be closed. However, in ObDuplicateObject if an attribute of OBJ_PROTECT_CLOSE is found as it's been filled to the caller (see L2466) this attribute is removed from the attributes list of the new handle and ObpAccessProtectCloseBit access is granted to the newly duplicated object handle.

With that being said ObpCloseHandleTableEntry indiscriminately closes the object handle albeit it shouldn't do so. As a matter of fact in Windows Server 2003 SP2 this service indeed checks for ObpAccessProtectCloseBit flag bit and if the condition is met then it returns STATUS_HANDLE_NOT_CLOSABLE as it should. Therefore we should do the same.

Now NtClose can properly warn the calling thread the object handle can't be closed which fixes a testcase failure within NtDuplicateObject NTDLL APITEST where this function gives handle close protection bit as requested by the caller.