### PR TITLE
[NTOS:MM] Fail NP pool allocations when running out of pages

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2551,7 +2551,9 @@ ExFreePoolWithTag(IN PVOID P,
         {
             DPRINT1("Freeing pool - invalid tag specified: %.4s != %.4s\n", (char*)&TagToFree, (char*)&Tag);
 #if DBG
-            KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
+            /* Do not bugcheck in case this is a big allocation for which we didn't manage to insert the tag */
+            if (Tag != ' GIB')
+                KeBugCheckEx(BAD_POOL_CALLER, 0x0A, (ULONG_PTR)P, Tag, TagToFree);
 #endif
         }
 

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -1734,7 +1734,7 @@ ExpFindAndRemoveTagBigPages(IN PVOID Va,
     // Set the free bit, and decrement the number of allocations. Finally, release
     // the lock and return the tag that was located
     //
-    InterlockedIncrement((PLONG)&Entry->Va);
+    Entry->Va = (PVOID)((ULONG_PTR)Entry->Va | POOL_BIG_TABLE_ENTRY_FREE);
 
     ExpPoolBigEntriesInUse--;
 

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -1517,7 +1517,7 @@ ExpReallocateBigPageTable(
     NewTable = MiAllocatePoolPages(NonPagedPool, NewSizeInBytes);
     if (NewTable == NULL)
     {
-        DPRINT1("Could not allocate %lu bytes for new big page table\n", NewSizeInBytes);
+        DPRINT("Could not allocate %lu bytes for new big page table\n", NewSizeInBytes);
         KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
         return FALSE;
     }

--- a/ntoskrnl/mm/ARM3/pool.c
+++ b/ntoskrnl/mm/ARM3/pool.c
@@ -835,7 +835,7 @@ MiAllocatePoolPages(IN POOL_TYPE PoolType,
         //
         // Ran out of memory
         //
-        DPRINT1("Out of NP Expansion Pool\n");
+        DPRINT("Out of NP Expansion Pool\n");
         return NULL;
     }
 

--- a/ntoskrnl/mm/ARM3/syspte.c
+++ b/ntoskrnl/mm/ARM3/syspte.c
@@ -254,17 +254,6 @@ MiReserveSystemPtes(IN ULONG NumberOfPtes,
     PointerPte = MiReserveAlignedSystemPtes(NumberOfPtes, SystemPtePoolType, 0);
 
     //
-    // Check if allocation failed
-    //
-    if (!PointerPte)
-    {
-        //
-        // Warn that we are out of memory
-        //
-        DPRINT1("MiReserveSystemPtes: Failed to reserve %lu PTE(s)!\n", NumberOfPtes);
-    }
-
-    //
     // Return the PTE Pointer
     //
     return PointerPte;


### PR DESCRIPTION
## Purpose

Instead of blindly asking for pages when allocating and happily crash, just fail the allocation and let the caller handle that.