### PR TITLE
[OPENGL32] Fix Red and Green Color Swap

### DIFF
--- a/dll/opengl/opengl32/swimpl.c
+++ b/dll/opengl/opengl32/swimpl.c
@@ -1241,7 +1241,7 @@ static void read_color_span_##__bpp(GLcontext* ctx,                             
     {                                                                           \
         Buffer -= __pixel_size;                                                 \
         UNPACK_COLOR_##__bpp(GET_PIXEL_##__bpp((__type*)Buffer),                \
-                &blue[n], &green[n], &red[n]);                                  \
+                &red[n], &green[n], &blue[n]);                                  \
         alpha[n] = 0;                                                           \
     }                                                                           \
 }
@@ -1294,7 +1294,7 @@ static void read_color_pixels_##__bpp(GLcontext* ctx,                           
             BYTE *Buffer = fb->BackBuffer + y[n] * WIDTH_BYTES_ALIGN32(fb->width, __bpp)    \
                     + x[n] * __pixel_size;                                                  \
             UNPACK_COLOR_##__bpp(GET_PIXEL_##__bpp((__type*)Buffer),                        \
-                    &blue[n], &green[n], &red[n]);                                          \
+                    &red[n], &green[n], &blue[n]);                                          \
             alpha[n] = 0;                                                                   \
         }                                                                                   \
     }                                                                                       \

--- a/dll/opengl/opengl32/swimpl.c
+++ b/dll/opengl/opengl32/swimpl.c
@@ -1244,7 +1244,7 @@ static void read_color_span_##__bpp(GLcontext* ctx,                             
                 &red[n], &green[n], &blue[n]);                                  \
         alpha[n] = 0;                                                           \
     }                                                                           \
-} // CORE-16221 - Fixed by swap at Line #1244.
+}
 READ_COLOR_SPAN(8, BYTE, 1)
 READ_COLOR_SPAN(16, USHORT, 2)
 READ_COLOR_SPAN(24, ULONG, 3)


### PR DESCRIPTION
## Fix OPENGL32 Red and Green Color Swaps

_Swap red and green values in swimpl.c._

JIRA issue: [CORE-16221](https://jira.reactos.org/browse/CORE-16221)

## Swap Red and Green values in swimpl.c for specific circumstance