### PR TITLE
[BROWSEUI] Refactoring CAutoComplete Part 2

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -327,9 +327,8 @@ static void Edit_BackWord(HWND hwndEdit)
 LRESULT CALLBACK CAutoComplete::ACEditSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     CAutoComplete *pThis = static_cast<CAutoComplete *>(GetPropW(hwnd, autocomplete_propertyW));
-    if (pThis)
-        return pThis->ACEditSubclassProcInner(hwnd, uMsg, wParam, lParam);
-    return 0;
+    assert(pThis);
+    return pThis->ACEditSubclassProcInner(hwnd, uMsg, wParam, lParam);
 }
 
 LRESULT CAutoComplete::ACEditSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -585,9 +584,8 @@ LRESULT CAutoComplete::ACEditSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wPar
 LRESULT CALLBACK CAutoComplete::ACLBoxSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     CAutoComplete *pThis = reinterpret_cast<CAutoComplete *>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
-    if (pThis)
-        return pThis->ACLBoxSubclassProcInner(hwnd, uMsg, wParam, lParam);
-    return 0;
+    assert(pThis);
+    return pThis->ACLBoxSubclassProcInner(hwnd, uMsg, wParam, lParam);
 }
 
 LRESULT CAutoComplete::ACLBoxSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -327,7 +327,9 @@ static void Edit_BackWord(HWND hwndEdit)
 LRESULT CALLBACK CAutoComplete::ACEditSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     CAutoComplete *pThis = static_cast<CAutoComplete *>(GetPropW(hwnd, autocomplete_propertyW));
-    return pThis->ACEditSubclassProcInner(hwnd, uMsg, wParam, lParam);
+    if (pThis)
+        return pThis->ACEditSubclassProcInner(hwnd, uMsg, wParam, lParam);
+    return 0;
 }
 
 LRESULT CAutoComplete::ACEditSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
@@ -583,7 +585,9 @@ LRESULT CAutoComplete::ACEditSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wPar
 LRESULT CALLBACK CAutoComplete::ACLBoxSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
     CAutoComplete *pThis = reinterpret_cast<CAutoComplete *>(GetWindowLongPtrW(hwnd, GWLP_USERDATA));
-    return pThis->ACLBoxSubclassProcInner(hwnd, uMsg, wParam, lParam);
+    if (pThis)
+        return pThis->ACLBoxSubclassProcInner(hwnd, uMsg, wParam, lParam);
+    return 0;
 }
 
 LRESULT CAutoComplete::ACLBoxSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -46,8 +46,11 @@ public:
     CAutoComplete();
     ~CAutoComplete();
 
-    static LRESULT APIENTRY ACEditSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
-    static LRESULT APIENTRY ACLBoxSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    static LRESULT CALLBACK ACEditSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    static LRESULT CALLBACK ACLBoxSubclassProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+
+    LRESULT ACEditSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
+    LRESULT ACLBoxSubclassProcInner(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
     void CreateListbox();
 

--- a/dll/win32/browseui/precomp.h
+++ b/dll/win32/browseui/precomp.h
@@ -19,6 +19,7 @@
 #include <shlguid_undoc.h>
 #include <shdeprecated.h>
 #include <tchar.h>
+#include <assert.h>
 #include <atlbase.h>
 #include <atlcom.h>
 #include <atlwin.h>


### PR DESCRIPTION
## Purpose
Simplify and improve readability of `CAutoComplete` code.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Make `ACEditSubclassProc` and `ACLBoxSubclassProc` `CALLBACK` functions.
- Add `ACEditSubclassProcInner` and `ACLBoxSubclassProcInner` methods.
- Delete many `pThis->`'s.
- Insert `pThis != NULL` check.