### PR TITLE
[NTOS:PNP] Implement PlugPlayControlStartDevice control class and use it

### DIFF
--- a/base/services/umpnpmgr/rpcserver.c
+++ b/base/services/umpnpmgr/rpcserver.c
@@ -3081,7 +3081,7 @@ static CONFIGRET
 EnableDeviceInstance(
     _In_ LPWSTR pszDeviceInstance)
 {
-    PLUGPLAY_CONTROL_RESET_DEVICE_DATA ResetDeviceData;
+    PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ResetDeviceData;
     CONFIGRET ret = CR_SUCCESS;
     NTSTATUS Status;
 
@@ -3091,7 +3091,7 @@ EnableDeviceInstance(
                          pszDeviceInstance);
     Status = NtPlugPlayControl(PlugPlayControlResetDevice,
                                &ResetDeviceData,
-                               sizeof(PLUGPLAY_CONTROL_RESET_DEVICE_DATA));
+                               sizeof(PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA));
     if (!NT_SUCCESS(Status))
         ret = NtStatusToCrError(Status);
 

--- a/base/services/umpnpmgr/rpcserver.c
+++ b/base/services/umpnpmgr/rpcserver.c
@@ -3081,17 +3081,14 @@ static CONFIGRET
 EnableDeviceInstance(
     _In_ LPWSTR pszDeviceInstance)
 {
-    PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ResetDeviceData;
+    PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ControlData;
     CONFIGRET ret = CR_SUCCESS;
     NTSTATUS Status;
 
     DPRINT("Enable device instance %S\n", pszDeviceInstance);
 
-    RtlInitUnicodeString(&ResetDeviceData.DeviceInstance,
-                         pszDeviceInstance);
-    Status = NtPlugPlayControl(PlugPlayControlResetDevice,
-                               &ResetDeviceData,
-                               sizeof(PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA));
+    RtlInitUnicodeString(&ControlData.DeviceInstance, pszDeviceInstance);
+    Status = NtPlugPlayControl(PlugPlayControlStartDevice, &ControlData, sizeof(ControlData));
     if (!NT_SUCCESS(Status))
         ret = NtStatusToCrError(Status);
 

--- a/base/setup/usetup/devinst.c
+++ b/base/setup/usetup/devinst.c
@@ -42,11 +42,11 @@ static BOOLEAN
 ResetDevice(
     IN LPCWSTR DeviceId)
 {
-    PLUGPLAY_CONTROL_RESET_DEVICE_DATA ResetDeviceData;
+    PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ResetDeviceData;
     NTSTATUS Status;
 
     RtlInitUnicodeString(&ResetDeviceData.DeviceInstance, DeviceId);
-    Status = NtPlugPlayControl(PlugPlayControlResetDevice, &ResetDeviceData, sizeof(PLUGPLAY_CONTROL_RESET_DEVICE_DATA));
+    Status = NtPlugPlayControl(PlugPlayControlResetDevice, &ResetDeviceData, sizeof(PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA));
     if (!NT_SUCCESS(Status))
     {
         DPRINT1("NtPlugPlayControl() failed with status 0x%08x\n", Status);

--- a/base/setup/usetup/devinst.c
+++ b/base/setup/usetup/devinst.c
@@ -39,20 +39,25 @@ typedef struct
 /* FUNCTIONS ****************************************************************/
 
 static BOOLEAN
-ResetDevice(
-    IN LPCWSTR DeviceId)
+AreDriversLoaded(
+    IN PCWSTR DeviceId)
 {
-    PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ResetDeviceData;
+    PLUGPLAY_CONTROL_STATUS_DATA PlugPlayData;
     NTSTATUS Status;
 
-    RtlInitUnicodeString(&ResetDeviceData.DeviceInstance, DeviceId);
-    Status = NtPlugPlayControl(PlugPlayControlResetDevice, &ResetDeviceData, sizeof(PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA));
-    if (!NT_SUCCESS(Status))
+    RtlInitUnicodeString(&PlugPlayData.DeviceInstance, DeviceId);
+    PlugPlayData.Operation = PNP_GET_DEVICE_STATUS;
+
+    Status = NtPlugPlayControl(PlugPlayControlDeviceStatus, &PlugPlayData, sizeof(PlugPlayData));
+    if (NT_SUCCESS(Status))
     {
-        DPRINT1("NtPlugPlayControl() failed with status 0x%08x\n", Status);
+        return (_Bool)((PlugPlayData.DeviceStatus & DN_DRIVER_LOADED) &&
+                       !(PlugPlayData.DeviceStatus & DN_HAS_PROBLEM));
+    }
+    else
+    {
         return FALSE;
     }
-    return TRUE;
 }
 
 static BOOLEAN
@@ -80,6 +85,10 @@ InstallDriver(
     ULONG Disposition;
     NTSTATUS Status;
     BOOLEAN deviceInstalled = FALSE;
+
+    /* First check if the driver needs any action at all */
+    if (AreDriversLoaded(DeviceId))
+        return TRUE;
 
     /* Check if we know the hardware */
     if (!SpInfFindFirstLine(hInf, L"HardwareIdsDatabase", HardwareId, &Context))
@@ -190,8 +199,17 @@ InstallDriver(
                            (wcslen(Driver) + 1) * sizeof(WCHAR));
     if (NT_SUCCESS(Status))
     {
-        /* Restart the device, so it will use the driver we registered */
-        deviceInstalled = ResetDevice(DeviceId);
+        /* We've registered the driver, time to start a device */
+        PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ControlData;
+        RtlInitUnicodeString(&ControlData.DeviceInstance, DeviceId);
+
+        Status = NtPlugPlayControl(PlugPlayControlStartDevice, &ControlData, sizeof(ControlData));
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("NtPlugPlayControl() failed with status 0x%08x\n", Status);
+        }
+
+        deviceInstalled = NT_SUCCESS(Status);
     }
 
     INF_FreeData(Driver);

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -534,7 +534,8 @@ typedef enum _DEVICE_ACTION
     PiActionEnumDeviceTree,
     PiActionEnumRootDevices,
     PiActionResetDevice,
-    PiActionAddBootDevices
+    PiActionAddBootDevices,
+    PiActionStartDevice
 } DEVICE_ACTION;
 
 //

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -2482,6 +2482,8 @@ ActionToStr(
             return "PiActionResetDevice";
         case PiActionAddBootDevices:
             return "PiActionAddBootDevices";
+        case PiActionStartDevice:
+            return "PiActionStartDevice";
         default:
             return "(request unknown)";
     }
@@ -2538,6 +2540,22 @@ PipDeviceActionWorker(
                 // TODO: the operation is a no-op for everything except removed nodes
                 // for removed nodes, it returns them back to DeviceNodeUninitialized
                 status = STATUS_SUCCESS;
+                break;
+
+            case PiActionStartDevice:
+                // This action is triggered from usermode, when a driver is installed
+                // for a non-critical PDO
+                if (deviceNode->State == DeviceNodeInitialized && 
+                    !(deviceNode->Flags & DNF_HAS_PROBLEM))
+                {
+                    PiDevNodeStateMachine(deviceNode);
+                }
+                else
+                {
+                    DPRINT1("NOTE: attempt to start an already started/uninitialized device %wZ\n",
+                            &deviceNode->InstancePath);
+                    status = STATUS_UNSUCCESSFUL;
+                }
                 break;
 
             default:

--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -1044,7 +1044,7 @@ IopGetDeviceDepth(PPLUGPLAY_CONTROL_DEPTH_DATA DepthData)
 
 
 static NTSTATUS
-IopResetDevice(PPLUGPLAY_CONTROL_RESET_DEVICE_DATA ResetDeviceData)
+IopResetDevice(PPLUGPLAY_CONTROL_DEVICE_CONTROL_DATA ResetDeviceData)
 {
     PDEVICE_OBJECT DeviceObject;
     NTSTATUS Status;
@@ -1364,9 +1364,9 @@ NtPlugPlayControl(IN PLUGPLAY_CONTROL_CLASS PlugPlayControlClass,
 //        case PlugPlayControlRetrieveDock:
 
         case PlugPlayControlResetDevice:
-            if (!Buffer || BufferLength < sizeof(PLUGPLAY_CONTROL_RESET_DEVICE_DATA))
+            if (!Buffer || BufferLength < sizeof(PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA))
                 return STATUS_INVALID_PARAMETER;
-            return IopResetDevice((PPLUGPLAY_CONTROL_RESET_DEVICE_DATA)Buffer);
+            return IopResetDevice((PPLUGPLAY_CONTROL_DEVICE_CONTROL_DATA)Buffer);
 
 //        case PlugPlayControlHaltDevice:
 //        case PlugPlayControlGetBlockedDriverList:

--- a/sdk/include/ndk/cmtypes.h
+++ b/sdk/include/ndk/cmtypes.h
@@ -453,14 +453,26 @@ typedef struct _PLUGPLAY_EVENT_BLOCK
 // Plug and Play Control Classes
 //
 
-// Class 0x00
+// PlugPlayControlEnumerateDevice (0x00)
 typedef struct _PLUGPLAY_CONTROL_ENUMERATE_DEVICE_DATA
 {
     UNICODE_STRING DeviceInstance;
     ULONG Flags;
 } PLUGPLAY_CONTROL_ENUMERATE_DEVICE_DATA, *PPLUGPLAY_CONTROL_ENUMERATE_DEVICE_DATA;
 
-// Class 0x06
+// PlugPlayControlRegisterNewDevice (0x1)
+// PlugPlayControlDeregisterDevice (0x2)
+// PlugPlayControlInitializeDevice (0x3)
+// PlugPlayControlStartDevice (0x4)
+// PlugPlayControlUnlockDevice (0x5)
+// PlugPlayControlResetDevice (0x14)
+// PlugPlayControlHaltDevice (0x15)
+typedef struct _PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA
+{
+    UNICODE_STRING DeviceInstance;
+} PLUGPLAY_CONTROL_DEVICE_CONTROL_DATA, *PPLUGPLAY_CONTROL_DEVICE_CONTROL_DATA;
+
+// PlugPlayControlQueryAndRemoveDevice (0x06)
 typedef struct _PLUGPLAY_CONTROL_QUERY_REMOVE_DATA
 {
     UNICODE_STRING DeviceInstance;
@@ -470,7 +482,7 @@ typedef struct _PLUGPLAY_CONTROL_QUERY_REMOVE_DATA
     ULONG NameLength;
 } PLUGPLAY_CONTROL_QUERY_REMOVE_DATA, *PPLUGPLAY_CONTROL_QUERY_REMOVE_DATA;
 
-// Class 0x07
+// PlugPlayControlUserResponse (0x07)
 typedef struct _PLUGPLAY_CONTROL_USER_RESPONSE_DATA
 {
     ULONG Unknown1;
@@ -479,7 +491,7 @@ typedef struct _PLUGPLAY_CONTROL_USER_RESPONSE_DATA
     ULONG Unknown4;
 } PLUGPLAY_CONTROL_USER_RESPONSE_DATA, *PPLUGPLAY_CONTROL_USER_RESPONSE_DATA;
 
-// Class 0x09
+// PlugPlayControlGetInterfaceDeviceList (0x09)
 typedef struct _PLUGPLAY_CONTROL_INTERFACE_DEVICE_LIST_DATA
 {
     UNICODE_STRING DeviceInstance;
@@ -489,7 +501,7 @@ typedef struct _PLUGPLAY_CONTROL_INTERFACE_DEVICE_LIST_DATA
     ULONG BufferSize;
 } PLUGPLAY_CONTROL_INTERFACE_DEVICE_LIST_DATA, *PPLUGPLAY_CONTROL_INTERFACE_DEVICE_LIST_DATA;
 
-//Class 0x0A
+// PlugPlayControlProperty (0x0A)
 typedef struct _PLUGPLAY_CONTROL_PROPERTY_DATA
 {
     UNICODE_STRING DeviceInstance;
@@ -498,7 +510,7 @@ typedef struct _PLUGPLAY_CONTROL_PROPERTY_DATA
     ULONG BufferSize;
 } PLUGPLAY_CONTROL_PROPERTY_DATA, *PPLUGPLAY_CONTROL_PROPERTY_DATA;
 
-// Class 0x0C
+// PlugPlayControlGetRelatedDevice (0x0C)
 typedef struct _PLUGPLAY_CONTROL_RELATED_DEVICE_DATA
 {
     UNICODE_STRING TargetDeviceInstance;
@@ -507,7 +519,7 @@ typedef struct _PLUGPLAY_CONTROL_RELATED_DEVICE_DATA
     ULONG RelatedDeviceInstanceLength;
 } PLUGPLAY_CONTROL_RELATED_DEVICE_DATA, *PPLUGPLAY_CONTROL_RELATED_DEVICE_DATA;
 
-// Class 0x0E
+// PlugPlayControlDeviceStatus (0x0E)
 typedef struct _PLUGPLAY_CONTOL_STATUS_DATA
 {
     UNICODE_STRING DeviceInstance;
@@ -516,14 +528,14 @@ typedef struct _PLUGPLAY_CONTOL_STATUS_DATA
     ULONG DeviceProblem;
 } PLUGPLAY_CONTROL_STATUS_DATA, *PPLUGPLAY_CONTROL_STATUS_DATA;
 
-// Class 0x0F
+// PlugPlayControlGetDeviceDepth (0x0F)
 typedef struct _PLUGPLAY_CONTROL_DEPTH_DATA
 {
     UNICODE_STRING DeviceInstance;
     ULONG Depth;
 } PLUGPLAY_CONTROL_DEPTH_DATA, *PPLUGPLAY_CONTROL_DEPTH_DATA;
 
-// Class 0x10
+// PlugPlayControlQueryDeviceRelations (0x10)
 typedef struct _PLUGPLAY_CONTROL_DEVICE_RELATIONS_DATA
 {
     UNICODE_STRING DeviceInstance;
@@ -532,18 +544,12 @@ typedef struct _PLUGPLAY_CONTROL_DEVICE_RELATIONS_DATA
     PWCHAR Buffer;
 } PLUGPLAY_CONTROL_DEVICE_RELATIONS_DATA, *PPLUGPLAY_CONTROL_DEVICE_RELATIONS_DATA;
 
-// Class 0x13
+// PlugPlayControlRetrieveDock (0x13)
 typedef struct _PLUGPLAY_CONTROL_RETRIEVE_DOCK_DATA
 {
     ULONG DeviceInstanceLength;
     PWSTR DeviceInstance;
 } PLUGPLAY_CONTROL_RETRIEVE_DOCK_DATA, *PPLUGPLAY_CONTROL_RETRIEVE_DOCK_DATA;
-
-// Class 0x14
-typedef struct _PLUGPLAY_CONTROL_RESET_DEVICE_DATA
-{
-    UNICODE_STRING DeviceInstance;
-} PLUGPLAY_CONTROL_RESET_DEVICE_DATA, *PPLUGPLAY_CONTROL_RESET_DEVICE_DATA;
 
 //
 // Plug and Play Bus Type Definition


### PR DESCRIPTION
This adds another action for starting devices after usermode PnP service enables the driver for it.
`PlugPlayControlResetDevice` is wrong in this case, because it returns the device node back to `DeviceNodeUninitialized` state, which is an overkill here (initialization phase is completed successfully, no need to repeat it)

Should fix: [CORE-17490](https://jira.reactos.org/browse/CORE-17490), [CORE-17463](https://jira.reactos.org/browse/CORE-17463)