### PR TITLE
[COMCTL32] SysListView32  headers disappears

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -2095,6 +2095,7 @@ static INT LISTVIEW_UpdateHScroll(LISTVIEW_INFO *infoPtr)
     dx -= SetScrollInfo(infoPtr->hwndSelf, SB_HORZ, &horzInfo, TRUE);
     TRACE("horzInfo=%s\n", debugscrollinfo(&horzInfo));
 
+#ifndef __REACTOS__
     /* Update the Header Control */
     if (infoPtr->hwndHeader)
     {
@@ -2104,6 +2105,7 @@ static INT LISTVIEW_UpdateHScroll(LISTVIEW_INFO *infoPtr)
     }
 
     LISTVIEW_UpdateSize(infoPtr);
+#endif
     return dx;
 }
 
@@ -2154,7 +2156,9 @@ static INT LISTVIEW_UpdateVScroll(LISTVIEW_INFO *infoPtr)
     dy -= SetScrollInfo(infoPtr->hwndSelf, SB_VERT, &vertInfo, TRUE);
     TRACE("vertInfo=%s\n", debugscrollinfo(&vertInfo));
 
+#ifndef __REACTOS__
     LISTVIEW_UpdateSize(infoPtr);
+#endif
     return dy;
 }
 


### PR DESCRIPTION
 In a SysListView32 object with adjustable width header,
 with the number of elements greater than the size of a page and
 with the index of the first visible element greater than zero
 (by scrolling down one or more elements)
 if in these circumstances we adjust the width of a column, the entire header disappears.

Changes:
          In the file comctl32 / listview.c function LISTVIEW_UpdateVScroll and
	  LISTVIEW_UpdateHScroll (lines 2103, 2106 and 2161)
	  we do not want to change the size of the header, nor the size of the list.
         These functions are about scrolling 

 https://jira.reactos.org/browse/CORE-16988

Teste on:
         Control Panel/Administrative Tools/System Config/Services 
       or Control Panel/User Accounts/Users (after adding 6 new users)
       or Control Panel/User Accounts/Groups