### PR TITLE
[SDK][ATL] Implement UnsubclassWindow methods

### DIFF
--- a/modules/rostests/apitests/atl/CMakeLists.txt
+++ b/modules/rostests/apitests/atl/CMakeLists.txt
@@ -16,7 +16,8 @@ list(APPEND SOURCE
     CRegKey.cpp
     CSimpleArray.cpp
     CSimpleMap.cpp
-    CString.cpp)
+    CString.cpp
+    SubclassWindow.cpp)
 
 list(APPEND PCH_SKIP_SOURCE
     testlist.c)

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -202,7 +202,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -223,7 +223,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -234,27 +234,7 @@ START_TEST(SubclassWindow)
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 == fn2, "fn1 == fn2\n");
-        DestroyWindow(hwnd2);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
-    }
-
-    {
-        CMyCtrl2 Ctrl2;
-        s_flag = FALSE; // "STATIC"
-        hwnd1 = MyCreateWindow(style);
-        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
-        fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
-        b = Ctrl2.SubclassWindow(hwnd1);
-        ok_int(b, TRUE);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
-        fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
-        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
-        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
-        fn2 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != fn2, "fn1 == fn2\n");
-        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         DestroyWindow(hwnd2);
         ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
     }
@@ -265,7 +245,29 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -276,8 +278,9 @@ START_TEST(SubclassWindow)
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn2 != DefWindowProc, "fn2 was %p\n", fn2); // ntdll.dll!NtdllEditWndProc_W
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         DestroyWindow(hwnd2);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
     }
 
     {
@@ -286,7 +289,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -294,8 +297,8 @@ START_TEST(SubclassWindow)
         hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
         ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
         fn2 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != fn2, "fn1 == fn2\n");
         ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "hwnd != NULL\n");
         DestroyWindow(hwnd2);
         ok(Ctrl2.m_hWnd == NULL, "hwnd != NULL\n");
     }
@@ -309,7 +312,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -320,6 +323,7 @@ START_TEST(SubclassWindow)
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != fn2, "fn1 == fn2\n");
         ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         DestroyWindow(hwnd2);
         ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
     }
@@ -330,7 +334,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -340,28 +344,8 @@ START_TEST(SubclassWindow)
         hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == fn2, "fn1 == fn2\n");
-        DestroyWindow(hwnd2);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
-    }
-
-    {
-        CMyCtrl2 Ctrl2;
-        s_flag = FALSE; // "STATIC"
-        hwnd1 = MyCreateWindow(style);
-        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
-        fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
-        b = Ctrl2.SubclassWindow(hwnd1);
-        ok_int(b, TRUE);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
-        fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
-        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
-        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
-        fn2 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != fn2, "fn1 == fn2\n");
-        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(fn2 == fn1, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         DestroyWindow(hwnd2);
         ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
     }
@@ -372,7 +356,29 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -383,8 +389,9 @@ START_TEST(SubclassWindow)
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn2 != DefWindowProc, "fn2 was %p\n", fn2); // ntdll.dll!NtdllEditWndProc_W
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         DestroyWindow(hwnd2);
-        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
     }
 
     {
@@ -393,7 +400,7 @@ START_TEST(SubclassWindow)
         hwnd1 = MyCreateWindow(style);
         ok(hwnd1 != NULL, "hwnd1 was NULL\n");
         fn1 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
         b = Ctrl2.SubclassWindow(hwnd1);
         ok_int(b, TRUE);
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
@@ -401,8 +408,8 @@ START_TEST(SubclassWindow)
         hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
         ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
         fn2 = Ctrl2.m_pfnSuperWindowProc;
-        ok(fn1 != fn2, "fn1 == fn2\n");
         ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        ok(Ctrl2.m_hWnd == NULL, "hwnd != NULL\n");
         DestroyWindow(hwnd2);
         ok(Ctrl2.m_hWnd == NULL, "hwnd != NULL\n");
     }

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -1,0 +1,256 @@
+/*
+ * PROJECT:         ReactOS api tests
+ * LICENSE:         LGPLv2.1+ - See COPYING.LIB in the top level directory
+ * PURPOSE:         Test for SubclassWindow/UnsubclassWindow
+ * PROGRAMMER:      Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#ifdef HAVE_APITEST
+    #include <apitest.h>
+#else
+    #include "atltest.h"
+#endif
+
+#define ATLASSUME(x) /*empty*/
+#define ATLASSERT(x) /*empty*/
+
+#include <atlbase.h>
+#include <atlwin.h>
+
+#define INVALID_HWND ((HWND)(ULONG_PTR)0xFFFFFFFF)
+#define INVALID_PROC ((WNDPROC)(ULONG_PTR)0xFFFFFFFF)
+
+static BOOL s_flag = TRUE;
+
+class CMyCtrl1 : public CWindowImpl<CMyCtrl1, CWindow>
+{
+public:
+    static LPCWSTR GetWndClassName()
+    {
+        if (s_flag)
+            return L"EDIT";
+        else
+            return L"STATIC";
+    }
+
+    CMyCtrl1()
+    {
+    }
+    virtual ~CMyCtrl1()
+    {
+    }
+
+    BEGIN_MSG_MAP(CMyCtrl1)
+    END_MSG_MAP()
+};
+
+class CMyCtrl2 : public CContainedWindow
+{
+public:
+    static LPCWSTR GetWndClassName()
+    {
+        if (s_flag)
+            return L"EDIT";
+        else
+            return L"STATIC";
+    }
+
+    CMyCtrl2()
+    {
+    }
+    virtual ~CMyCtrl2()
+    {
+    }
+
+    BEGIN_MSG_MAP(CMyCtrl2)
+    END_MSG_MAP()
+};
+
+static HWND MyCreateWindow(DWORD style)
+{
+    return CreateWindowW(L"EDIT", NULL, style,
+                         CW_USEDEFAULT, CW_USEDEFAULT, 100, 100,
+                         NULL, NULL, GetModuleHandleW(NULL), NULL);
+}
+
+START_TEST(SubclassWindow)
+{
+    const DWORD style = WS_POPUPWINDOW | ES_MULTILINE;
+    HWND hwnd1, hwnd2;
+    WNDPROC fn1, fn2;
+    BOOL b;
+
+    //
+    // Ctrl1
+    //
+    {
+        CMyCtrl1 Ctrl1;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl1.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl1.m_hWnd == hwnd1, "Ctrl1.m_hWnd was %p\n", Ctrl1.m_hWnd);
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl1.UnsubclassWindow();
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl1.m_hWnd == NULL, "hwnd != NULL\n");
+    }
+
+    {
+        CMyCtrl1 Ctrl1;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl1.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl1.m_hWnd == hwnd1, "Ctrl1.m_hWnd was %p\n", Ctrl1.m_hWnd);
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl1.UnsubclassWindow();
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn2 == fn1, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl1.m_hWnd == NULL, "hwnd != NULL\n");
+    }
+
+    {
+        CMyCtrl1 Ctrl1;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl1.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl1.m_hWnd == hwnd1, "Ctrl1.m_hWnd was %p\n", Ctrl1.m_hWnd);
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl1.UnsubclassWindow();
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl1.m_hWnd == NULL, "hwnd != NULL\n");
+    }
+
+    {
+        CMyCtrl1 Ctrl1;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 == DefWindowProc, "fn1 was %p\n", fn1);
+        b = Ctrl1.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl1.m_hWnd == hwnd1, "Ctrl1.m_hWnd was %p\n", Ctrl1.m_hWnd);
+        fn1 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl1.UnsubclassWindow();
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl1.m_pfnSuperWindowProc;
+        ok(fn1 == fn2, "fn1 != fn2\n");
+        DestroyWindow(hwnd2);
+        ok(Ctrl1.m_hWnd == NULL, "hwnd != NULL\n");
+    }
+
+    //
+    // Ctrl2
+    //
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow();
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl2.UnsubclassWindow();
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == fn2, "fn1 == fn2\n");
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow();
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl2.UnsubclassWindow();
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn2 != DefWindowProc, "fn2 was %p\n", fn2); // ntdll.dll!NtdllEditWndProc_W
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+}

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -94,6 +94,8 @@ START_TEST(SubclassWindow)
     HWND hwnd1, hwnd2;
     WNDPROC fn1, fn2;
     BOOL b;
+    trace("DefWindowProc: %p\n", DefWindowProc);
+    trace("MyWindowProc: %p\n", MyWindowProc);
 
     //
     // Ctrl1

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -94,8 +94,9 @@ START_TEST(SubclassWindow)
     HWND hwnd1, hwnd2;
     WNDPROC fn1, fn2;
     BOOL b;
-    trace("DefWindowProc: %p\n", DefWindowProc);
-    trace("MyWindowProc: %p\n", MyWindowProc);
+    trace("DefWindowProcA == %p\n", DefWindowProcA);
+    trace("DefWindowProcW == %p\n", DefWindowProcW);
+    trace("MyWindowProc == %p\n", MyWindowProc);
 
     //
     // Ctrl1

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -43,7 +43,8 @@ public:
     END_MSG_MAP()
 };
 
-class CMyCtrl2 : public CContainedWindow
+class CMyCtrl2
+    : public CContainedWindowT<CWindowImpl<CMyCtrl2, CWindow> >
 {
 public:
     static LPCWSTR GetWndClassName()
@@ -54,7 +55,7 @@ public:
             return L"STATIC";
     }
 
-    CMyCtrl2()
+    CMyCtrl2() : CContainedWindowT<CWindowImpl<CMyCtrl2, CWindow> >(this)
     {
     }
     virtual ~CMyCtrl2()

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -7,12 +7,17 @@
 
 #ifdef HAVE_APITEST
     #include <apitest.h>
+    #define ATLASSUME(x) /*empty*/
+    #define ATLASSERT(x) /*empty*/
 #else
     #include "atltest.h"
+    #define ATLASSUME(x) do { \
+        trace("ATLASSUME(%s) %s.\n", #x, ((x) ? "success" : "failure")); \
+    } while (0)
+    #define ATLASSERT(x) do { \
+        trace("ATLASSERT(%s) %s.\n", #x, ((x) ? "success" : "failure")); \
+    } while (0)
 #endif
-
-#define ATLASSUME(x) /*empty*/
-#define ATLASSERT(x) /*empty*/
 
 #include <atlbase.h>
 #include <atlwin.h>

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -22,7 +22,11 @@
 #include <atlbase.h>
 #include <atlwin.h>
 
-#define INVALID_HWND ((HWND)(ULONG_PTR)0xFFFFFFFF)
+#ifdef _WIN64
+    #define INVALID_HWND ((HWND)(ULONG_PTR)0xDEADBEEFDEADBEEFULL)
+#else
+    #define INVALID_HWND ((HWND)(ULONG_PTR)0xDEADBEEF)
+#endif
 
 static BOOL s_flag = TRUE;
 

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -168,7 +168,7 @@ START_TEST(SubclassWindow)
     }
 
     //
-    // Ctrl2
+    // Ctrl2 (Not Forced)
     //
     {
         CMyCtrl2 Ctrl2;
@@ -182,7 +182,7 @@ START_TEST(SubclassWindow)
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         fn1 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
-        hwnd2 = Ctrl2.UnsubclassWindow();
+        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
         ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != fn2, "fn1 == fn2\n");
@@ -204,7 +204,7 @@ START_TEST(SubclassWindow)
         fn1 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
         DestroyWindow(hwnd1); // destroy now
-        hwnd2 = Ctrl2.UnsubclassWindow();
+        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 == fn2, "fn1 == fn2\n");
@@ -224,7 +224,7 @@ START_TEST(SubclassWindow)
         ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
         fn1 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
-        hwnd2 = Ctrl2.UnsubclassWindow();
+        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
         ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != fn2, "fn1 == fn2\n");
@@ -246,7 +246,94 @@ START_TEST(SubclassWindow)
         fn1 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
         DestroyWindow(hwnd1); // destroy now
-        hwnd2 = Ctrl2.UnsubclassWindow();
+        hwnd2 = Ctrl2.UnsubclassWindow(FALSE);
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn2 != DefWindowProc, "fn2 was %p\n", fn2); // ntdll.dll!NtdllEditWndProc_W
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    //
+    // Ctrl2 (Forced)
+    //
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = TRUE; // "EDIT"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
+        ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == fn2, "fn1 == fn2\n");
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
+        ok(hwnd1 == hwnd2, "hwnd1 != hwnd2\n");
+        fn2 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != fn2, "fn1 == fn2\n");
+        ok(fn2 == DefWindowProc, "fn2 was %p\n", fn2);
+        DestroyWindow(hwnd2);
+        ok(Ctrl2.m_hWnd == NULL, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+    }
+
+    {
+        CMyCtrl2 Ctrl2;
+        s_flag = FALSE; // "STATIC"
+        hwnd1 = MyCreateWindow(style);
+        ok(hwnd1 != NULL, "hwnd1 was NULL\n");
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 == NULL, "fn1 was %p\n", fn1);
+        b = Ctrl2.SubclassWindow(hwnd1);
+        ok_int(b, TRUE);
+        ok(Ctrl2.m_hWnd == hwnd1, "Ctrl2.m_hWnd was %p\n", Ctrl2.m_hWnd);
+        fn1 = Ctrl2.m_pfnSuperWindowProc;
+        ok(fn1 != DefWindowProc, "fn1 was %p\n", fn1);
+        DestroyWindow(hwnd1); // destroy now
+        hwnd2 = Ctrl2.UnsubclassWindow(TRUE);
         ok(hwnd2 == NULL, "hwnd2 was %p\n", hwnd2);
         fn2 = Ctrl2.m_pfnSuperWindowProc;
         ok(fn2 != DefWindowProc, "fn2 was %p\n", fn2); // ntdll.dll!NtdllEditWndProc_W

--- a/modules/rostests/apitests/atl/devenv/.gitignore
+++ b/modules/rostests/apitests/atl/devenv/.gitignore
@@ -1,0 +1,16 @@
+*.opendb
+*.db
+x64/
+.vs/
+CAtlArray/
+CAtlFileMapping/
+CAtlList/
+CComHeapPtr/
+CComObject/
+CComQIPtr/
+CHeapPtrList/
+CImage/
+CSimpleArray/
+CSimpleMap/
+CString/
+SubclassWindow/

--- a/modules/rostests/apitests/atl/devenv/ATLTest.sln
+++ b/modules/rostests/apitests/atl/devenv/ATLTest.sln
@@ -25,6 +25,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CHeapPtrList", "CHeapPtrLis
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CComHeapPtr", "CComHeapPtr.vcxproj", "{F10E34E3-FB53-4650-985A-28BD1905D65C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "SubclassWindow", "SubclassWindow.vcxproj", "{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -121,6 +123,14 @@ Global
 		{F10E34E3-FB53-4650-985A-28BD1905D65C}.Release|x64.Build.0 = Release|x64
 		{F10E34E3-FB53-4650-985A-28BD1905D65C}.Release|x86.ActiveCfg = Release|Win32
 		{F10E34E3-FB53-4650-985A-28BD1905D65C}.Release|x86.Build.0 = Release|Win32
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Debug|x64.ActiveCfg = Debug|x64
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Debug|x64.Build.0 = Debug|x64
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Debug|x86.ActiveCfg = Debug|Win32
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Debug|x86.Build.0 = Debug|Win32
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Release|x64.ActiveCfg = Release|x64
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Release|x64.Build.0 = Release|x64
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Release|x86.ActiveCfg = Release|Win32
+		{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/modules/rostests/apitests/atl/devenv/SubclassWindow.vcxproj
+++ b/modules/rostests/apitests/atl/devenv/SubclassWindow.vcxproj
@@ -1,0 +1,189 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{ABACDAE7-3936-17E1-7525-96C4A7DA4CD2}</ProjectGuid>
+    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <Keyword>AtlProj</Keyword>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v140_xp</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
+    <LinkIncremental>true</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <IgnoreImportLibrary>true</IgnoreImportLibrary>
+    <LinkIncremental>false</LinkIncremental>
+    <IntDir>$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>WIN32;_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <PreprocessorDefinitions>_WINDOWS;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <SDLCheck>true</SDLCheck>
+    </ClCompile>
+    <ResourceCompile>
+      <Culture>0x0409</Culture>
+      <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ResourceCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="../SubclassWindow.cpp">
+      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Release|x64'">MultiThreaded</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">MultiThreadedDebug</RuntimeLibrary>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">NotUsing</PrecompiledHeader>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\resource.h" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\atl_apitest.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\cstring.inl" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/modules/rostests/apitests/atl/testlist.c
+++ b/modules/rostests/apitests/atl/testlist.c
@@ -16,6 +16,7 @@ extern void func_CRegKey(void);
 extern void func_CSimpleArray(void);
 extern void func_CSimpleMap(void);
 extern void func_CString(void);
+extern void func_SubclassWindow(void);
 
 const struct test winetest_testlist[] =
 {
@@ -34,5 +35,6 @@ const struct test winetest_testlist[] =
     { "CSimpleArray", func_CSimpleArray },
     { "CSimpleMap", func_CSimpleMap },
     { "CString", func_CString },
+    { "SubclassWindow", func_SubclassWindow },
     { 0, 0 }
 };

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -1510,7 +1510,7 @@ public:
         pThis = reinterpret_cast<CWindowImplBaseT<TBase, TWinTraits>*>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
-        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, m_pfnSuperWindowProc);
+        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }
@@ -1741,7 +1741,7 @@ public:
         pThis = reinterpret_cast<CContainedWindowT<TBase> *>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
-        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, m_pfnSuperWindowProc);
+        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -1510,7 +1510,7 @@ public:
         pThis = reinterpret_cast<CWindowImplBaseT<TBase, TWinTraits>*>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
-        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
+        ::SetWindowLongPtr(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }
@@ -1620,7 +1620,7 @@ public:
             MenuOrID.m_hMenu = (HMENU)(UINT_PTR)this;
         if (rect.m_lpRect == NULL)
             rect.m_lpRect = &TBase::rcDefault;
-        hWnd = ::CreateWindowEx(dwExStyle, reinterpret_cast<LPCWSTR>(MAKEINTATOM(atom)), szWindowName, dwStyle, rect.m_lpRect->left,
+        hWnd = ::CreateWindowEx(dwExStyle, MAKEINTATOM(atom), szWindowName, dwStyle, rect.m_lpRect->left,
                     rect.m_lpRect->top, rect.m_lpRect->right - rect.m_lpRect->left, rect.m_lpRect->bottom - rect.m_lpRect->top,
                     hWndParent, MenuOrID.m_hMenu, _AtlBaseModule.GetModuleInstance(), lpCreateParam);
 
@@ -1692,7 +1692,7 @@ public:
         m_pCurrentMsg = NULL;
     }
 
-    CContainedWindowT(LPTSTR lpszClassName, CMessageMap *pObject, DWORD dwMsgMapID = 0)
+    CContainedWindowT(LPCTSTR lpszClassName, CMessageMap *pObject, DWORD dwMsgMapID = 0)
     {
         m_lpszClassName = lpszClassName;
         m_pfnSuperWindowProc = ::DefWindowProc;
@@ -1741,7 +1741,7 @@ public:
         pThis = reinterpret_cast<CContainedWindowT<TBase> *>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
-        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
+        ::SetWindowLongPtr(hwndOld, GWLP_WNDPROC, (LONG_PTR)m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }
@@ -1924,13 +1924,13 @@ static ATL::CWndClassInfo& GetWndClassInfo()                                    
 
 struct _ATL_WNDCLASSINFOW
 {
-    WNDCLASSEXW m_wc;
-    LPCWSTR m_lpszOrigName;
+    WNDCLASSEX m_wc;
+    LPCTSTR m_lpszOrigName;
     WNDPROC pWndProc;
-    LPCWSTR m_lpszCursorID;
+    LPCTSTR m_lpszCursorID;
     BOOL m_bSystemCursor;
     ATOM m_atom;
-    WCHAR m_szAutoName[sizeof("ATL:") + sizeof(void *) * 2]; // == 4 characters + NULL + number of hexadecimal digits describing a pointer.
+    TCHAR m_szAutoName[sizeof("ATL:") + sizeof(void *) * 2]; // == 4 characters + NULL + number of hexadecimal digits describing a pointer.
 
     ATOM Register(WNDPROC *p)
     {

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -1504,6 +1504,16 @@ public:
         return TRUE;
     }
 
+    HWND UnsubclassWindow()
+    {
+        CWindowImplBaseT<TBase, TWinTraits> *pThis;
+        pThis = reinterpret_cast<CWindowImplBaseT<TBase, TWinTraits>*>(this);
+        HWND hwndOld = pThis->m_hWnd;
+        pThis->m_hWnd = NULL;
+        m_pfnSuperWindowProc = ::DefWindowProc;
+        return hwndOld;
+    }
+
     virtual WNDPROC GetWindowProc()
     {
         return WindowProc;
@@ -1717,6 +1727,21 @@ public:
         m_pfnSuperWindowProc = oldWindowProc;
         pThis->m_hWnd = hWnd;
         return TRUE;
+    }
+
+    HWND UnsubclassWindow(BOOL bForce = FALSE)
+    {
+        if (!bForce)
+        {
+            // TODO:
+            return NULL;
+        }
+        CContainedWindowT<TBase> *pThis;
+        pThis = reinterpret_cast<CContainedWindowT<TBase> *>(this);
+        HWND hwndOld = pThis->m_hWnd;
+        pThis->m_hWnd = NULL;
+        m_pfnSuperWindowProc = ::DefWindowProc;
+        return hwndOld;
     }
 
     static LRESULT CALLBACK StartWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -1510,6 +1510,7 @@ public:
         pThis = reinterpret_cast<CWindowImplBaseT<TBase, TWinTraits>*>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
+        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }
@@ -1740,6 +1741,7 @@ public:
         pThis = reinterpret_cast<CContainedWindowT<TBase> *>(this);
         HWND hwndOld = pThis->m_hWnd;
         pThis->m_hWnd = NULL;
+        ::SetWindowLongPtrW(hwndOld, GWLP_WNDPROC, m_pfnSuperWindowProc);
         m_pfnSuperWindowProc = ::DefWindowProc;
         return hwndOld;
     }


### PR DESCRIPTION
## Purpose
I want `CWindowImpl::UnsubclassWindow` and `CContainedWindowT::UnsubclassWindow` to implement AutoComplete (auto input completion).

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Implement `CWindowImpl::UnsubclassWindow` method.
- Implement `CContainedWindowT::UnsubclassWindow` method.
- Add `SubclassWindow` testcase to `atl_apitest` test program.
- Fix generic text mapping of `<atlwin.h>`.

## TODO

- [x] `CContainedWindowT::UnsubclassWindow`.