### PR TITLE
[NTOS:CC] Assign resource thread to BCB's owner thread in CcUnpinDataForThread

### DIFF
--- a/ntoskrnl/cc/pin.c
+++ b/ntoskrnl/cc/pin.c
@@ -585,6 +585,9 @@ CcUnpinDataForThread (
 
     if (iBcb->PinCount != 0)
     {
+        /* Assign resource thread to BCB */
+        iBcb->Lock.OwnerEntry.OwnerThread = ResourceThreadId;
+
         ExReleaseResourceForThreadLite(&iBcb->Lock, ResourceThreadId);
         iBcb->PinCount--;
     }


### PR DESCRIPTION
## Purpose

Assign resource thread to BCB's owner thread in CcUnpinDataForThread before releasing the BCB lock, since it actually should acquire that, according to the documentation: https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/nf-ntifs-ccunpindataforthread.
It fixes an assert when loading (or writing any data onto NTFS partitions with replaced) Microsoft NTFS driver (together with a patch from [CORE-10147](https://jira.reactos.org/browse/CORE-10147) and PR #3400 applied). So now it loads successfully again. :smiley: 
Although I'm not completely sure that this solution is right, but it looks correct at first glance.

JIRA issue: [CORE-17499](https://jira.reactos.org/browse/CORE-17499)