### PR TITLE
[SDK][ATL] Fix CWindow::GetWindowText method of BSTR

### DIFF
--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -788,6 +788,7 @@ public:
         if (::GetWindowTextW(m_hWnd, bstrText, length + 1))
             return TRUE;
         ::SysFreeString(bstrText);
+        bstrText = NULL;
         return FALSE;
     }
 

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -782,11 +782,13 @@ public:
     BOOL GetWindowText(BSTR& bstrText)
     {
         ATLASSERT(::IsWindow(m_hWnd));
-        int length = ::GetWindowTextLength(m_hWnd);
-        if (!SysReAllocStringLen(&bstrText, NULL, length))
+        INT length = ::GetWindowTextLengthW(m_hWnd);
+        if (!::SysReAllocStringLen(&bstrText, NULL, length))
             return FALSE;
-        ::GetWindowText(m_hWnd, (LPTSTR)&bstrText[2], length);
-        return TRUE;
+        if (::GetWindowTextW(m_hWnd, bstrText, length + 1))
+            return TRUE;
+        ::SysFreeString(bstrText);
+        return FALSE;
     }
 
     int GetWindowTextLength() const


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Fix generic text mapping for `GetWindowText` and `GetWindowTextLength` functions.
- Fix the length.
- Fail elegantly if necessary.