### PR TITLE
[BROWSEUI_APITEST] Strengthen IAutoComplete testcase on extended LV style

### DIFF
--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -453,11 +453,16 @@ DoTestCaseA(INT x, INT y, INT cx, INT cy, LPCWSTR pszInput,
         ok(style == LIST_STYLE_2, "style was 0x%08lx\n", style);
     ok_long(exstyle, 0);
     ok_long((LONG)id, 0);
-#define LIST_EXTENDED_LV_STYLE_1 0x10068
-#define LIST_EXTENDED_LV_STYLE_2 0x68
+#define LIST_EXTENDED_LV_STYLE_1 \
+    (LVS_EX_DOUBLEBUFFER | LVS_EX_ONECLICKACTIVATE | \
+     LVS_EX_FULLROWSELECT | LVS_EX_TRACKSELECT) // 0x10068
+#define LIST_EXTENDED_LV_STYLE_2 \
+    (LVS_EX_ONECLICKACTIVATE | LVS_EX_FULLROWSELECT | \
+     LVS_EX_TRACKSELECT) // 0x68
     exstyle = ListView_GetExtendedListViewStyle(hwndList);
     ok(exstyle == LIST_EXTENDED_LV_STYLE_1 /* Win10 */ ||
-       exstyle == LIST_EXTENDED_LV_STYLE_2 /* WinXP */, "exstyle was 0x%08lx\n", exstyle);
+       exstyle == LIST_EXTENDED_LV_STYLE_2 /* WinXP/Win2k3 */,
+       "exstyle was 0x%08lx\n", exstyle);
 
     // no more controls
     hwndNone = GetNextWindow(hwndList, GW_HWNDNEXT);

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -453,6 +453,11 @@ DoTestCaseA(INT x, INT y, INT cx, INT cy, LPCWSTR pszInput,
         ok(style == LIST_STYLE_2, "style was 0x%08lx\n", style);
     ok_long(exstyle, 0);
     ok_long((LONG)id, 0);
+#define LIST_EXTENDED_LV_STYLE_1 0x10068
+#define LIST_EXTENDED_LV_STYLE_2 0x68
+    exstyle = ListView_GetExtendedListViewStyle(hwndList);
+    ok(exstyle == LIST_EXTENDED_LV_STYLE_1 /* Win10 */ ||
+       exstyle == LIST_EXTENDED_LV_STYLE_2 /* WinXP */, "exstyle was 0x%08lx\n", exstyle);
 
     // no more controls
     hwndNone = GetNextWindow(hwndList, GW_HWNDNEXT);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Test the extended list-view style of the listview.


WinXP:
![winxp](https://user-images.githubusercontent.com/2107452/109603957-0d014600-7b66-11eb-8c54-d19388ad1218.png)
Successful.

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/109603953-0bd01900-7b66-11eb-94ae-30cee12f336f.png)
Successful.

Win10:
![win10](https://user-images.githubusercontent.com/2107452/109603955-0c68af80-7b66-11eb-9105-eadd0b902401.png)
Successful.