### PR TITLE
[BROWSEUI_APITEST] Strengthen IAutoComplete on WM_KEYDOWN

### DIFF
--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -681,7 +681,7 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
         ok_long(dwThreadId1, dwThreadId2);
 
         WCHAR szText[64];
-        GetWindowTextW(hwndEdit, szText, 64);
+        GetWindowTextW(hwndEdit, szText, _countof(szText));
         CStringW strText = szText;
         INT ich0, ich1;
         SendMessageW(hwndEdit, EM_GETSEL, (WPARAM)&ich0, (LPARAM)&ich1);

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -661,10 +661,6 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
             hwndList = GetNextWindow(hwndSizeBox, GW_HWNDNEXT);
         }
 
-        DWORD dwThreadId1 = GetWindowThreadProcessId(hwndEdit, NULL);
-        DWORD dwThreadId2 = GetWindowThreadProcessId(hwndDropDown, NULL);
-        ok_long(dwThreadId1, dwThreadId2);
-
         WCHAR szText[64];
         GetWindowTextW(hwndEdit, szText, _countof(szText));
         CStringW strText = szText;

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -566,8 +566,7 @@ struct TEST_B_ENTRY
     BOOL m_bVisible;
     INT m_ich0, m_ich1;
     INT m_iItem;
-    BOOL m_bReset;
-    BOOL m_bExpand;
+    BOOL m_bReset, m_bExpand;
     LPCWSTR m_expand;
 };
 
@@ -588,7 +587,7 @@ DoesMatch(LPWSTR *pList, UINT nCount, LPCWSTR psz)
 // the testcase B
 static VOID
 DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
-            const TEST_B_ENTRY *pEntries, SIZE_T cEntries)
+            const TEST_B_ENTRY *pEntries, UINT cEntries)
 {
     MSG msg;
     s_bExpand = s_bReset = FALSE;
@@ -604,7 +603,6 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
         TranslateMessage(&msg);
         DispatchMessageW(&msg);
     }
-
     ok_int(IsWindowVisible(hwndEdit), TRUE);
 
     // set the list data

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -652,9 +652,7 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
         if (!IsWindow(hwndDropDown))
         {
             hwndDropDown = FindWindowW(L"Auto-Suggest Dropdown", L"");
-            hwndScrollBar = NULL;
-            hwndSizeBox = NULL;
-            hwndList = NULL;
+            hwndScrollBar = hwndSizeBox = hwndList = NULL;
         }
         if (IsWindowVisible(hwndDropDown))
         {

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -22,8 +22,6 @@
 // compare wide strings
 #define ok_wstri(x, y) \
     ok(lstrcmpiW(x, y) == 0, "Wrong string. Expected '%S', got '%S'\n", y, x)
-#define ok_wstr_line(line, x, y) \
-    ok(lstrcmpW(x, y) == 0, "Line %d: Wrong string. Expected '%S', got '%S'\n", line, y, x)
 
 struct CCoInit
 {

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -571,7 +571,7 @@ struct TEST_B_ENTRY
     CStringW m_strExpand;
 
     TEST_B_ENTRY(INT line, UINT uMsg, WPARAM wParam, LPARAM lParam,
-                 CStringW text, BOOL bVisible, INT ich0, INT ich1,
+                 LPCWSTR text, BOOL bVisible, INT ich0, INT ich1,
                  INT iItem = -1, BOOL bReset = FALSE, BOOL bExpand = FALSE,
                  LPCWSTR pszExpand = L"")
         : m_line(line), m_uMsg(uMsg), m_wParam(wParam), m_lParam(lParam)

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -574,17 +574,9 @@ struct TEST_B_ENTRY
                  CStringW text, BOOL bVisible, INT ich0, INT ich1,
                  INT iItem = -1, BOOL bReset = FALSE, BOOL bExpand = FALSE,
                  LPCWSTR pszExpand = L"")
-        : m_line(line)
-        , m_uMsg(uMsg)
-        , m_wParam(wParam)
-        , m_lParam(lParam)
-        , m_text(text)
-        , m_bVisible(bVisible)
-        , m_ich0(ich0)
-        , m_ich1(ich1)
-        , m_iItem(iItem)
-        , m_bReset(bReset)
-        , m_bExpand(bExpand)
+        : m_line(line), m_uMsg(uMsg), m_wParam(wParam), m_lParam(lParam)
+        , m_text(text), m_bVisible(bVisible), m_ich0(ich0), m_ich1(ich1)
+        , m_iItem(iItem), m_bReset(bReset), m_bExpand(bExpand)
         , m_strExpand(pszExpand)
     {
     }

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -24,8 +24,6 @@
     ok(lstrcmpiW(x, y) == 0, "Wrong string. Expected '%S', got '%S'\n", y, x)
 #define ok_wstr_line(line, x, y) \
     ok(lstrcmpW(x, y) == 0, "Line %d: Wrong string. Expected '%S', got '%S'\n", line, y, x)
-#define ok_wstri_line(line, x, y) \
-    ok(lstrcmpiW(x, y) == 0, "Line %d: Wrong string. Expected '%S', got '%S'\n", line, y, x)
 
 struct CCoInit
 {
@@ -691,7 +689,7 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
             iItem = ListView_GetNextItem(hwndList, -1, LVNI_ALL | LVNI_SELECTED);
         }
 
-        ok_wstr_line(entry.m_line, szText, (LPCWSTR)entry.m_text);
+        ok(strText == entry.m_text, "Line %d: szText was %S\n", entry.m_line, (LPCWSTR)strText);
         ok(ich0 == entry.m_ich0, "Line %d: ich0 was %d\n", entry.m_line, ich0);
         ok(ich1 == entry.m_ich1, "Line %d: ich1 was %d\n", entry.m_line, ich1);
         ok(iItem == entry.m_iItem, "Line %d: iItem was %d\n", entry.m_line, iItem);

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -582,6 +582,20 @@ struct TEST_B_ENTRY
     }
 };
 
+static BOOL
+DoesMatch(LPWSTR *pList, UINT nCount, LPCWSTR psz)
+{
+    INT cch = lstrlenW(psz);
+    if (cch == 0)
+        return FALSE;
+    for (UINT i = 0; i < nCount; ++i)
+    {
+        if (::StrCmpNIW(pList[i], psz, cch) == 0)
+            return TRUE;
+    }
+    return FALSE;
+}
+
 // the testcase B
 static VOID
 DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
@@ -644,7 +658,8 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
             TranslateMessage(&msg);
             DispatchMessageW(&msg);
 
-            Sleep(100); // another thread is working
+            if (msg.message == WM_CHAR || msg.message == WM_KEYDOWN)
+                Sleep(100); // another thread is working
         }
 
         if (!IsWindow(hwndDropDown))
@@ -678,6 +693,8 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
         {
             iItem = ListView_GetNextItem(hwndList, -1, LVNI_ALL | LVNI_SELECTED);
         }
+        BOOL bDidMatch = DoesMatch(pList, nCount, strText);
+        ok(bVisible == bDidMatch, "Line %d: bVisible != bDidMatch\n", entry.m_line);
 
         ok(strText == entry.m_text, "Line %d: szText was %S\n", entry.m_line, (LPCWSTR)strText);
         ok(ich0 == entry.m_ich0, "Line %d: ich0 was %d\n", entry.m_line, ich0);

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -675,7 +675,7 @@ DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
         trace("i:%d, ch:%C, bVisible:%d, iItem:%d, s_bReset:%d, szText:%S, s_strExpand:%S\n",
               i, ch, bVisible, iItem, s_bReset, szText, (LPCWSTR)s_strExpand);
 
-        ok_wstri(szText, (LPCWSTR)entry.m_text);
+        ok_wstr(szText, (LPCWSTR)entry.m_text);
         ok_int(ich0, entry.m_ich0);
         ok_int(ich1, entry.m_ich1);
 
@@ -810,21 +810,21 @@ START_TEST(IAutoComplete)
     entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"t", TRUE, 1, 1));
     entries.Add(TestB_Entry(WM_CHAR, L'e', 0, L"te", TRUE, 2, 2));
     entries.Add(TestB_Entry(WM_CHAR, L's', 0, L"tes", TRUE, 3, 3));
-    entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"test", TRUE, 4, 4));
-    entries.Add(TestB_Entry(WM_CHAR, L'\\', 0, L"test\\", TRUE, 5, 5));
-    entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"test\\t", FALSE, 6, 6));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"test\\", TRUE, 5, 5));
-    entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"test\\t", FALSE, 6, 6));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"test\\", TRUE, 5, 5));
-    entries.Add(TestB_Entry(WM_CHAR, L'i', 0, L"test\\i", TRUE, 6, 6));
+    entries.Add(TestB_Entry(WM_CHAR, L'T', 0, L"tesT", TRUE, 4, 4));
+    entries.Add(TestB_Entry(WM_CHAR, L'\\', 0, L"tesT\\", TRUE, 5, 5));
+    entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"tesT\\t", FALSE, 6, 6));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"tesT\\", TRUE, 5, 5));
+    entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"tesT\\t", FALSE, 6, 6));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"tesT\\", TRUE, 5, 5));
+    entries.Add(TestB_Entry(WM_CHAR, L'i', 0, L"tesT\\i", TRUE, 6, 6));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_DOWN, 0, L"test\\item-0", TRUE, 11, 11));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_DOWN, 0, L"test\\item-1", TRUE, 11, 11));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_UP, 0, L"test\\item-0", TRUE, 11, 11));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_UP, 0, L"test\\i", TRUE, 6, 6));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_UP, 0, L"tesT\\i", TRUE, 6, 6));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_UP, 0, L"test\\item-9", TRUE, 11, 11));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_DOWN, 0, L"test\\i", TRUE, 6, 6));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"test\\", TRUE, 5, 5));
-    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"test", TRUE, 4, 4));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_DOWN, 0, L"tesT\\i", TRUE, 6, 6));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"tesT\\", TRUE, 5, 5));
+    entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"tesT", TRUE, 4, 4));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"tes", TRUE, 3, 3));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"te", TRUE, 2, 2));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_BACK, 0, L"t", TRUE, 1, 1));

--- a/modules/rostests/apitests/browseui/IAutoComplete.cpp
+++ b/modules/rostests/apitests/browseui/IAutoComplete.cpp
@@ -257,10 +257,10 @@ static VOID DoWordBreakProc(EDITWORDBREAKPROC fn)
 #endif
 }
 
-// the test A
+// the testcase A
 static VOID
-DoTestA(INT x, INT y, INT cx, INT cy, LPCWSTR pszInput,
-        LPWSTR *pList, UINT nCount, BOOL bDowner, BOOL bLong)
+DoTestCaseA(INT x, INT y, INT cx, INT cy, LPCWSTR pszInput,
+            LPWSTR *pList, UINT nCount, BOOL bDowner, BOOL bLong)
 {
     MSG msg;
     s_bExpand = s_bReset = FALSE;
@@ -578,10 +578,10 @@ struct TestB_Entry
     }
 };
 
-// the test B
+// the testcase B
 static VOID
-DoTestB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
-        CSimpleArray<TestB_Entry>& entries)
+DoTestCaseB(INT x, INT y, INT cx, INT cy, LPWSTR *pList, UINT nCount,
+            CSimpleArray<TestB_Entry>& entries)
 {
     MSG msg;
     s_bExpand = s_bReset = FALSE;
@@ -733,17 +733,17 @@ START_TEST(IAutoComplete)
     LPWSTR *pList;
     WCHAR szText[64];
 
-    // Test #1 (A)
-    trace("Test #1 (downer, short) ------------------------------\n");
+    // Test case #1 (A)
+    trace("Testcase #1 (downer, short) ------------------------------\n");
     nCount = 3;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     SHStrDupW(L"test\\AA", &pList[0]);
     SHStrDupW(L"test\\BBB", &pList[1]);
     SHStrDupW(L"test\\CCC", &pList[2]);
-    DoTestA(0, 0, 100, 30, L"test\\", pList, nCount, TRUE, FALSE);
+    DoTestCaseA(0, 0, 100, 30, L"test\\", pList, nCount, TRUE, FALSE);
 
-    // Test #2 (A)
-    trace("Test #2 (downer, long) ------------------------------\n");
+    // Test case #2 (A)
+    trace("Testcase #2 (downer, long) ------------------------------\n");
     nCount = 300;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     for (UINT i = 0; i < nCount; ++i)
@@ -751,30 +751,30 @@ START_TEST(IAutoComplete)
         StringCbPrintfW(szText, sizeof(szText), L"test\\%u", i);
         SHStrDupW(szText, &pList[i]);
     }
-    DoTestA(100, 20, 100, 30, L"test\\", pList, nCount, TRUE, TRUE);
+    DoTestCaseA(100, 20, 100, 30, L"test\\", pList, nCount, TRUE, TRUE);
 
-    // Test #3 (A)
-    trace("Test #3 (upper, short) ------------------------------\n");
+    // Test case #3 (A)
+    trace("Testcase #3 (upper, short) ------------------------------\n");
     nCount = 2;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     SHStrDupW(L"test/AA", &pList[0]);
     SHStrDupW(L"test/BBB", &pList[0]);
     SHStrDupW(L"test/CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC", &pList[1]);
-    DoTestA(rcWork.right - 100, rcWork.bottom - 30, 80, 40, L"test/",
+    DoTestCaseA(rcWork.right - 100, rcWork.bottom - 30, 80, 40, L"test/",
                 pList, nCount, FALSE, FALSE);
 
-    // Test #4 (A)
-    trace("Test #4 (upper, short) ------------------------------\n");
+    // Test case #4 (A)
+    trace("Testcase #4 (upper, short) ------------------------------\n");
     nCount = 2;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     SHStrDupW(L"testtest\\AA", &pList[0]);
     SHStrDupW(L"testtest\\BBB", &pList[0]);
     SHStrDupW(L"testtest\\CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC", &pList[1]);
-    DoTestA(rcWork.right - 100, rcWork.bottom - 30, 80, 40, L"testtest\\",
+    DoTestCaseA(rcWork.right - 100, rcWork.bottom - 30, 80, 40, L"testtest\\",
                 pList, nCount, FALSE, FALSE);
 
-    // Test #5 (A)
-    trace("Test #5 (upper, long) ------------------------------\n");
+    // Test case #5 (A)
+    trace("Testcase #5 (upper, long) ------------------------------\n");
     nCount = 300;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     for (UINT i = 0; i < nCount; ++i)
@@ -782,10 +782,10 @@ START_TEST(IAutoComplete)
         StringCbPrintfW(szText, sizeof(szText), L"testtest/%u", i);
         SHStrDupW(szText, &pList[i]);
     }
-    DoTestA(0, rcWork.bottom - 30, 80, 30, L"testtest/", pList, nCount, FALSE, TRUE);
+    DoTestCaseA(0, rcWork.bottom - 30, 80, 30, L"testtest/", pList, nCount, FALSE, TRUE);
 
-    // Test #6 (A)
-    trace("Test #6 (upper, long) ------------------------------\n");
+    // Test case #6 (A)
+    trace("Testcase #6 (upper, long) ------------------------------\n");
     nCount = 2000;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     for (UINT i = 0; i < nCount; ++i)
@@ -793,12 +793,12 @@ START_TEST(IAutoComplete)
         StringCbPrintfW(szText, sizeof(szText), L"testtest\\item-%u", i);
         SHStrDupW(szText, &pList[i]);
     }
-    DoTestA(0, rcWork.bottom - 30, 80, 40, L"testtest\\", pList, nCount, FALSE, TRUE);
+    DoTestCaseA(0, rcWork.bottom - 30, 80, 40, L"testtest\\", pList, nCount, FALSE, TRUE);
 
     CSimpleArray<TestB_Entry> entries;
 
-    // Test #7 (B)
-    trace("Test #7 ------------------------------\n");
+    // Test case #7 (B)
+    trace("Testcase #7 ------------------------------\n");
     nCount = 16;
     pList = (LPWSTR *)CoTaskMemAlloc(nCount * sizeof(LPWSTR));
     for (UINT i = 0; i < nCount; ++i)
@@ -832,5 +832,5 @@ START_TEST(IAutoComplete)
     entries.Add(TestB_Entry(WM_CHAR, L't', 0, L"t", TRUE, 1, 1));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_LEFT, 0, L"t", TRUE, 0, 0));
     entries.Add(TestB_Entry(WM_KEYDOWN, VK_RIGHT, 0, L"t", TRUE, 1, 1));
-    DoTestB(0, 0, 100, 30, pList, nCount, entries);
+    DoTestCaseB(0, 0, 100, 30, pList, nCount, entries);
 }


### PR DESCRIPTION
## Purpose

Improve the `IAutoComplete` testcase.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed Changes

- Simplify the test mechanism.
- Add more tests for `WM_KEYDOWN` message.

WinXP:
![winxp](https://user-images.githubusercontent.com/2107452/109889781-5cac5280-7cc9-11eb-9a85-dd95f6e00f29.png)

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/109889782-5cac5280-7cc9-11eb-97cc-a46d8494d9c8.png)

Win10:
![win10](https://user-images.githubusercontent.com/2107452/109889776-5b7b2580-7cc9-11eb-9d41-ce0bdcdd2c96.png)