### PR TITLE
[SDK][ATL] Improve registering window classes

### DIFF
--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -29,6 +29,10 @@
 #define Unused(x)    (x);
 #endif // __GNUC__
 
+#ifndef _STRSAFE_H_INCLUDED_
+    #include <strsafe.h>
+#endif
+
 #if !defined(_WIN64)
 #ifdef SetWindowLongPtr
 #undef SetWindowLongPtr
@@ -75,12 +79,11 @@ struct _ATL_WNDCLASSINFOW
 
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
-        // FIXME: CORE-17503 insecure
         // NOTE: "%p" may add "0x" in some environments.
 #ifdef _WIN64
-        _stprintf(pszName, TEXT("ATL:%016llX"), (LONG_PTR)this);
+        StringCchPrintf(pszName, cchNameMax, TEXT("ATL:%016llX"), (LONG_PTR)this);
 #else
-        _stprintf(pszName, TEXT("ATL:%08lX"), (LONG_PTR)this);
+        StringCchPrintf(pszName, cchNameMax, TEXT("ATL:%08lX"), (LONG_PTR)this);
 #endif
     }
 

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -100,6 +100,7 @@ struct _ATL_WNDCLASSINFOW
             m_wc.lpszClassName = m_szAutoName;
         }
 
+        // https://devblogs.microsoft.com/oldnewthing/20041011-00/?p=37603
         m_atom = (ATOM)::GetClassInfoEx(NULL, m_wc.lpszClassName, &m_wc);
         if (m_atom)
             return m_atom;

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -74,7 +74,7 @@ struct _ATL_WNDCLASSINFOW
 
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
-        ::swprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
+        _stprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
     }
 
     ATOM Register(WNDPROC *p)

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -79,9 +79,9 @@ struct _ATL_WNDCLASSINFOW
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
 #ifdef _STRSAFE_H_INCLUDED_
-        StringCchPrintf(pszName, cchNameMax, TEXT("ATL:%p"), this);
+        StringCchPrintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
 #else
-        ::wnsprintf(pszName, cchNameMax, TEXT("ATL:%p"), this);
+        ::wnsprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
 #endif
     }
 

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -28,10 +28,6 @@
 #define Unused(x)    (x);
 #endif // __GNUC__
 
-#ifndef _STRSAFE_H_INCLUDED_
-    #include <shlwapi.h>
-#endif
-
 #if !defined(_WIN64)
 #ifdef SetWindowLongPtr
 #undef SetWindowLongPtr
@@ -78,11 +74,7 @@ struct _ATL_WNDCLASSINFOW
 
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
-#ifdef _STRSAFE_H_INCLUDED_
-        StringCchPrintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
-#else
-        ::wnsprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
-#endif
+        ::swprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
     }
 
     ATOM Register(WNDPROC *p)

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -74,7 +74,7 @@ struct _ATL_WNDCLASSINFOW
 
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
-        _stprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
+        _sntprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
     }
 
     ATOM Register(WNDPROC *p)

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <stdio.h>
 
 #if defined(__GNUC__) || defined(__clang__)
 #define GCCU(x)    x __attribute__((unused))
@@ -74,7 +75,13 @@ struct _ATL_WNDCLASSINFOW
 
     VOID FormatWindowClassName(LPTSTR pszName, size_t cchNameMax)
     {
-        _sntprintf(pszName, cchNameMax, TEXT("ATL:%zX"), (LONG_PTR)this);
+        // FIXME: CORE-17503 insecure
+        // NOTE: "%p" may add "0x" in some environments.
+#ifdef _WIN64
+        _stprintf(pszName, TEXT("ATL:%016llX"), (LONG_PTR)this);
+#else
+        _stprintf(pszName, TEXT("ATL:%08lX"), (LONG_PTR)this);
+#endif
     }
 
     ATOM Register(WNDPROC *p)


### PR DESCRIPTION
## Purpose

ReactOS' ATL lacks `DECLARE_WND_CLASS` macro and `CWindowImpl::GetWndClassInfo` function. So, we could not create a global class window with ATL's `CWindow`.

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `DECLARE_WND_CLASS` macro.
- Check the existence of the window class by `::GetClassInfoEx` function before registering window class.
- Insert `DECLARE_WND_CLASS(NULL)` into `CWindowImpl` template class.
- Add `GetWndClassName` method into `CDialogImpl` template class.

## References

`CWindowImpl` Class
https://docs.microsoft.com/en-US/cpp/atl/reference/cwindowimpl-class?view=msvc-160
`CWindowImpl::GetWndClassInfo`
https://docs.microsoft.com/en-US/cpp/atl/reference/cwindowimpl-class?view=msvc-160#getwndclassinfo
A Japanese article about `CWndClassInfo`
http://hp.vector.co.jp/authors/VA022575/c/msgmap.html