### PR TITLE
Define _DEBUG for better ATL debugging

### DIFF
--- a/base/applications/charmap_new/precomp.h
+++ b/base/applications/charmap_new/precomp.h
@@ -1,5 +1,9 @@
 //#pragma once
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #ifndef __REACTOS__
 
 #define WIN32_LEAN_AND_MEAN

--- a/base/applications/drwtsn32/precomp.h
+++ b/base/applications/drwtsn32/precomp.h
@@ -8,6 +8,10 @@
 #ifndef _DRWTSN32_PRECOMP_H_
 #define _DRWTSN32_PRECOMP_H_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <ntstatus.h>
 #define WIN32_NO_STATUS
 

--- a/base/applications/fltmc/fltmc.cpp
+++ b/base/applications/fltmc/fltmc.cpp
@@ -6,6 +6,10 @@
 * PROGRAMMERS: Copyright 2016 Ged Murphy (gedmurphy@gmail.com)
 */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 // Please leave this temporary hack in place
 // it's used to keep VS2015 happy for development.
 #ifdef __REACTOS__

--- a/base/applications/msconfig_new/precomp.h
+++ b/base/applications/msconfig_new/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _MSCONFIG_PCH_
 #define _MSCONFIG_PCH_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <assert.h>
 
 #include <stdarg.h>

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _MSPAINT_H
 #define _MSPAINT_H
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdarg.h>
 
 #include <windef.h>

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -1,6 +1,10 @@
 #ifndef _RAPPS_H
 #define _RAPPS_H
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include "defines.h"
 
 #include "dialogs.h"

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _EXPLORER_PRECOMP__H_
 #define _EXPLORER_PRECOMP__H_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define WIN7_COMPAT_MODE 0
 #define WIN7_DEBUG_MODE 0
 

--- a/base/shell/rshell/CQuickLaunchBand.cpp
+++ b/base/shell/rshell/CQuickLaunchBand.cpp
@@ -6,6 +6,9 @@
  * PROGRAMMERS: Shriraj Sawant a.k.a SR13 <sr.official@hotmail.com>
  */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
 
 #define WIN32_NO_STATUS
 #define _INC_WINDOWS

--- a/base/shell/rshell/misc.cpp
+++ b/base/shell/rshell/misc.cpp
@@ -18,6 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
 
 #include <stdio.h>
 #include <tchar.h>

--- a/dll/shellext/acppage/precomp.h
+++ b/dll/shellext/acppage/precomp.h
@@ -1,6 +1,10 @@
 #ifndef ACPPAGE_PRECOMP_H
 #define ACPPAGE_PRECOMP_H
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define COBJMACROS
 #define WIN32_NO_STATUS
 #define _INC_WINDOWS

--- a/dll/shellext/fontext/precomp.h
+++ b/dll/shellext/fontext/precomp.h
@@ -1,6 +1,9 @@
 #ifndef FONTEXT_PRECOMP_H
 #define FONTEXT_PRECOMP_H
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
 
 #define WIN32_NO_STATUS
 #define COM_NO_WINDOWS_H

--- a/dll/shellext/mydocs/precomp.hpp
+++ b/dll/shellext/mydocs/precomp.hpp
@@ -5,6 +5,10 @@
  * COPYRIGHT:   Copyright 2020 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define COBJMACROS
 #define WIN32_NO_STATUS
 #include <windows.h>

--- a/dll/shellext/netshell/precomp.h
+++ b/dll/shellext/netshell/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _PRECOMP_H__
 #define _PRECOMP_H__
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdio.h>
 
 #define WIN32_NO_STATUS

--- a/dll/shellext/ntobjshex/precomp.h
+++ b/dll/shellext/ntobjshex/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _NTOBJSHEX_PRECOMP_H_
 #define _NTOBJSHEX_PRECOMP_H_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdarg.h>
 #include <tchar.h>
 

--- a/dll/shellext/sendmail/precomp.hpp
+++ b/dll/shellext/sendmail/precomp.hpp
@@ -5,6 +5,10 @@
  * COPYRIGHT:   Copyright 2019 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define COBJMACROS
 #define WIN32_NO_STATUS
 #include <windows.h>

--- a/dll/shellext/zipfldr/precomp.h
+++ b/dll/shellext/zipfldr/precomp.h
@@ -1,6 +1,10 @@
 #ifndef ZIPFLDR_PRECOMP_H
 #define ZIPFLDR_PRECOMP_H
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define COBJMACROS
 #define COM_NO_WINDOWS_H
 #define NTOS_MODE_USER

--- a/dll/win32/browseui/precomp.h
+++ b/dll/win32/browseui/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _BROWSEUI_PCH_
 #define _BROWSEUI_PCH_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdarg.h>
 
 #define WIN32_NO_STATUS

--- a/dll/win32/devmgr/precomp.h
+++ b/dll/win32/devmgr/precomp.h
@@ -1,5 +1,9 @@
 //#pragma once
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #ifndef __REACTOS__
 
 #define WIN32_LEAN_AND_MEAN

--- a/dll/win32/msgina/dimmedwindow.cpp
+++ b/dll/win32/msgina/dimmedwindow.cpp
@@ -6,6 +6,10 @@
  * PROGRAMMER:      Mark Jansen
  */
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #define COM_NO_WINDOWS_H
 #include "msgina.h"
 #include <wingdi.h>

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -1,6 +1,10 @@
 #ifndef _PRECOMP_H__
 #define _PRECOMP_H__
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdarg.h>
 #include <assert.h>
 

--- a/dll/win32/shlwapi/precomp.h
+++ b/dll/win32/shlwapi/precomp.h
@@ -2,6 +2,10 @@
 #ifndef _SHLWAPI_PCH_
 #define _SHLWAPI_PCH_
 
+#if !defined(_DEBUG) && !defined(NDEBUG)
+    #define _DEBUG
+#endif
+
 #include <wine/config.h>
 
 #include <stdarg.h>

--- a/sdk/lib/atl/atlcom.h
+++ b/sdk/lib/atl/atlcom.h
@@ -456,7 +456,7 @@ class CComCreator2
 public:
     static HRESULT WINAPI CreateInstance(void *pv, REFIID riid, LPVOID *ppv)
     {
-        ATLASSERT(ppv != NULL && &riid != NULL);
+        ATLASSERT(ppv != NULL);
 
         if (pv == NULL)
             return T1::CreateInstance(NULL, riid, ppv);

--- a/sdk/lib/atl/statreg.h
+++ b/sdk/lib/atl/statreg.h
@@ -68,19 +68,19 @@ public:
 
     HRESULT STDMETHODCALLTYPE QueryInterface(const IID & /* riid */, void ** /* ppvObject */ )
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return E_NOTIMPL;
     }
 
     ULONG STDMETHODCALLTYPE AddRef()
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not callthis function"));
         return 1;
     }
 
     ULONG STDMETHODCALLTYPE Release()
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not callthis function"));
         return 0;
     }
 

--- a/sdk/lib/atl/statreg.h
+++ b/sdk/lib/atl/statreg.h
@@ -74,13 +74,13 @@ public:
 
     ULONG STDMETHODCALLTYPE AddRef()
     {
-        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return 1;
     }
 
     ULONG STDMETHODCALLTYPE Release()
     {
-        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return 0;
     }
 


### PR DESCRIPTION
## Purpose

Currently `ATLASSERT` macro won't work in GCC compilers, due to lack of `_DEBUG` macro.
Microsoft-style debugging needs `_DEBUG` macro definition.

JIRA issue: [CORE-17505](https://jira.reactos.org/browse/CORE-17505)

## Proposed changes

- Define `_DEBUG` macro as follows in some precompiled header that uses ATL module.

```c
#if !defined(_DEBUG) && !defined(NDEBUG)
    #define _DEBUG
#endif
```
- Fix `sdk/lib/atl/atlcom.h`.
- Fix `sdk/lib/atl/statreg.h`.

## TODO

- [x] Can build
- [x] Can test successful
- [ ] Get consensus of team