### PR TITLE
[FLOPPY][FLOPPY_NEW][HIVESYS] Inf: Use 'd' for 'Primary disk'

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -1773,7 +1773,7 @@ HKLM,"SYSTEM\CurrentControlSet\Services\usbuhci","Type",0x00010001,0x00000001
 
 ; USB storage driver
 HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","ErrorControl",0x00010001,0x00000001
-HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","Group",0x00000000,"Primary Disk"
+HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","Group",0x00000000,"Primary disk"
 HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","ImagePath",0x00020000,"system32\drivers\usbstor.sys"
 HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","Start",0x00010001,0x00000000
 HKLM,"SYSTEM\CurrentControlSet\Services\usbstor","Type",0x00010001,0x00000001

--- a/drivers/storage/floppy/floppy/floppy_reg.inf
+++ b/drivers/storage/floppy/floppy/floppy_reg.inf
@@ -1,7 +1,7 @@
 ; Floppy driver
 [AddReg]
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","ErrorControl",0x00010001,0x00000000
-HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Group",0x00000000,"Primary Disk"
+HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Group",0x00000000,"Primary disk"
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","ImagePath",0x00020000,"system32\drivers\floppy.sys"
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Start",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Type",0x00010001,0x00000001

--- a/drivers/storage/floppy_new/floppy_reg.inf
+++ b/drivers/storage/floppy_new/floppy_reg.inf
@@ -1,7 +1,7 @@
 ; Floppy driver
 [AddReg]
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","ErrorControl",0x00010001,0x00000000
-HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Group",0x00000000,"Primary Disk"
+HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Group",0x00000000,"Primary disk"
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","ImagePath",0x00020000,"system32\drivers\floppy.sys"
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Start",0x00010001,0x00000001
 HKLM,"SYSTEM\CurrentControlSet\Services\Floppy","Type",0x00010001,0x00000001


### PR DESCRIPTION
as 'Group' value.

NB:
Only hivesys '...\ServiceGroupOrder' list has a 'D'.

## Purpose

Match WXP/WS03.