### PR TITLE
[RTL] Improve heap performance

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -5277,7 +5277,7 @@ NtFreeVirtualMemory(IN HANDLE ProcessHandle,
          (Vad->u.VadFlags.VadType != VadRotatePhysical)) ||
         (Vad->u.VadFlags.VadType == VadDevicePhysicalMemory))
     {
-        DPRINT1("Attempt to free section memory\n");
+        DPRINT("Attempt to free section memory\n");
         Status = STATUS_UNABLE_TO_DELETE_SECTION;
         goto FailPath;
     }

--- a/sdk/lib/rtl/heap.h
+++ b/sdk/lib/rtl/heap.h
@@ -144,6 +144,7 @@ C_ASSERT(sizeof(HEAP_ENTRY) == 16);
 C_ASSERT(sizeof(HEAP_ENTRY) == 8);
 #endif
 C_ASSERT((1 << HEAP_ENTRY_SHIFT) == sizeof(HEAP_ENTRY));
+C_ASSERT((2 << HEAP_ENTRY_SHIFT) == sizeof(HEAP_FREE_ENTRY));
 
 typedef struct _HEAP_TAG_ENTRY
 {
@@ -217,8 +218,7 @@ typedef struct _HEAP_LIST_LOOKUP
     ULONG NumberOfUnCommittedRanges;        \
     USHORT SegmentAllocatorBackTraceIndex;  \
     USHORT Reserved;                        \
-    LIST_ENTRY UCRSegmentList;              \
-    PVOID LastEntryInSegment //FIXME: non-Vista
+    LIST_ENTRY UCRSegmentList
 
 typedef struct _HEAP
 {

--- a/sdk/lib/rtl/heap.h
+++ b/sdk/lib/rtl/heap.h
@@ -12,7 +12,6 @@
 #define RTL_HEAP_H
 
 /* Core heap definitions */
-#define HEAP_FREELISTS 128
 #define HEAP_SEGMENTS 64
 
 #define HEAP_ENTRY_SIZE ((ULONG)sizeof(HEAP_ENTRY))
@@ -257,13 +256,7 @@ typedef struct _HEAP
     PVOID BlocksIndex; // HEAP_LIST_LOOKUP
     PVOID UCRIndex;
     PHEAP_PSEUDO_TAG_ENTRY PseudoTagEntries;
-    LIST_ENTRY FreeLists[HEAP_FREELISTS]; //FIXME: non-Vista
-    //LIST_ENTRY FreeLists;
-    union
-    {
-        ULONG FreeListsInUseUlong[HEAP_FREELISTS / (sizeof(ULONG) * 8)]; //FIXME: non-Vista
-        UCHAR FreeListsInUseBytes[HEAP_FREELISTS / (sizeof(UCHAR) * 8)]; //FIXME: non-Vista
-    } u;
+    LIST_ENTRY FreeLists;
     PHEAP_LOCK LockVariable;
     PRTL_HEAP_COMMIT_ROUTINE CommitRoutine;
     PVOID FrontEndHeap;
@@ -271,6 +264,8 @@ typedef struct _HEAP
     UCHAR FrontEndHeapType;
     HEAP_COUNTERS Counters;
     HEAP_TUNING_PARAMETERS TuningParameters;
+    RTL_BITMAP FreeHintBitmap;  // FIXME: non-Vista
+    PLIST_ENTRY FreeHints[ANYSIZE_ARRAY]; // FIXME: non-Vista
 } HEAP, *PHEAP;
 
 typedef struct _HEAP_SEGMENT


### PR DESCRIPTION
## Purpose

It's super annoying to work on memory-related stuff when any memory-intensive application takes hours to do its things when it should be minutes.

JIRA issue: [CORE-15793](https://jira.reactos.org/browse/CORE-15793)

## Proposed changes

AVOID BUSY LOOPS

- Add a "guard" heap entry at the end of each committed range in order to be able to quickly commit new range without having to scan the whole committed region to know what the previous entry is. 
- Turn the FreeLists array into a single list for free entries, and add a "hint" array + bitmap which will give instantly gives the caller a free entry which will be large enough to hold the required size.

The only loops left is when the required alloc size is bigger than the decommit threshold and there are free entries which are bigger that this threshold, and when inserting such free entries into the list. This happens, but this makes short loops since most free entries which are bigger than tyhe threshold are either decommitted (sic!) or split in order to honour smaller alloc requests.

