### PR TITLE
[CMAKE] Define _DEBUG for better ATL debugging (Retry)

### DIFF
--- a/base/applications/rapps/include/defines.h
+++ b/base/applications/rapps/include/defines.h
@@ -4,7 +4,6 @@
 #define _INC_WINDOWS
 #define COM_NO_WINDOWS_H
 #define COBJMACROS
-#define _DEBUG
 #include <tchar.h>
 #include <stdarg.h>
 

--- a/sdk/lib/atl/CMakeLists.txt
+++ b/sdk/lib/atl/CMakeLists.txt
@@ -1,5 +1,6 @@
 
 add_library(atl_classes INTERFACE)
+target_compile_definitions(atl_classes INTERFACE _DEBUG)
 
 target_include_directories(atl_classes INTERFACE
     $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/sdk/lib/atl/CMakeLists.txt
+++ b/sdk/lib/atl/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 add_library(atl_classes INTERFACE)
-target_compile_definitions(atl_classes INTERFACE _DEBUG)
+if(DBG)
+    target_compile_definitions(atl_classes INTERFACE _DEBUG)
+endif(DBG)
 
 target_include_directories(atl_classes INTERFACE
     $<$<COMPILE_LANGUAGE:CXX>:${CMAKE_CURRENT_SOURCE_DIR}>)

--- a/sdk/lib/atl/atlcom.h
+++ b/sdk/lib/atl/atlcom.h
@@ -456,7 +456,7 @@ class CComCreator2
 public:
     static HRESULT WINAPI CreateInstance(void *pv, REFIID riid, LPVOID *ppv)
     {
-        ATLASSERT(ppv != NULL && &riid != NULL);
+        ATLASSERT(ppv != NULL);
 
         if (pv == NULL)
             return T1::CreateInstance(NULL, riid, ppv);

--- a/sdk/lib/atl/statreg.h
+++ b/sdk/lib/atl/statreg.h
@@ -68,19 +68,19 @@ public:
 
     HRESULT STDMETHODCALLTYPE QueryInterface(const IID & /* riid */, void ** /* ppvObject */ )
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return E_NOTIMPL;
     }
 
     ULONG STDMETHODCALLTYPE AddRef()
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return 1;
     }
 
     ULONG STDMETHODCALLTYPE Release()
     {
-        ATLASSERT(_T("statically linked in CRegObject is not a com object. Do not callthis function"));
+        ATLASSERT(FALSE && TEXT("statically linked in CRegObject is not a com object. Do not call this function"));
         return 0;
     }
 


### PR DESCRIPTION
## Purpose

Currently `ATLASSERT` macro won't work in some environments, due to lack of `_DEBUG` macro.
Microsoft-style debugging needs `_DEBUG` macro definition. Thanks to @zefklop.

JIRA issue: [CORE-17505](https://jira.reactos.org/browse/CORE-17505)

## Proposed changes

- `if(DBG) target_compile_definitions(atl_classes INTERFACE _DEBUG) endif(DBG)` in `sdk/lib/atl`.
- Fix `sdk/lib/atl/statreg.h` (misuse of `ATLASSERT`).
- Fix `sdk/lib/atl/atlcom.h` (non-NULL check for non-NULL).
- Fix `base/applications/rapps/include/defines.h` (redefinition of `_DEBUG`).

## TODO

- [ ] Fix build.
- [x] @zefklop confirmed.