### PR TITLE
[SHELL32] Enable auto-completion on 'Folder Options' > 'Change Icon'

### DIFF
--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -233,7 +233,7 @@ INT_PTR CALLBACK PickIconProc(
                 SendMessageW(pIconContext->hDlgCtrl, LB_SETTOPINDEX, pIconContext->Index, 0);
             }
 
-            SHAutoComplete(GetDlgItem(hwndDlg, IDC_EDIT_PATH), 0);
+            SHAutoComplete(GetDlgItem(hwndDlg, IDC_EDIT_PATH), SHACF_DEFAULT);
             return TRUE;
         }
 

--- a/dll/win32/shell32/dialogs/dialogs.cpp
+++ b/dll/win32/shell32/dialogs/dialogs.cpp
@@ -232,6 +232,8 @@ INT_PTR CALLBACK PickIconProc(
                 SendMessageW(pIconContext->hDlgCtrl, LB_SETCURSEL, pIconContext->Index, 0);
                 SendMessageW(pIconContext->hDlgCtrl, LB_SETTOPINDEX, pIconContext->Index, 0);
             }
+
+            SHAutoComplete(GetDlgItem(hwndDlg, IDC_EDIT_PATH), 0);
             return TRUE;
         }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

AFTER:
![VirtualBox_ReactOS_10_03_2021_20_32_09](https://user-images.githubusercontent.com/2107452/110623283-f9965080-81df-11eb-91bd-83125a3ecf17.png)