### PR TITLE
[ATL][SHELL32][EXPLORER] Disable ATLASSERT

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -989,6 +989,7 @@ VOID CAppInfoDisplay::ResizeChildren(int Width, int Height)
 #if DBG
     ATLASSERT(dwError == ERROR_SUCCESS);
 #endif
+    UNREFERENCED_PARAMETER(dwError);
 
     UpdateWindow();
 }

--- a/base/shell/explorer/syspager.cpp
+++ b/base/shell/explorer/syspager.cpp
@@ -1231,10 +1231,8 @@ void CNotifyToolbar::Initialize(HWND hWndParent, CBalloonQueue * queue)
         TBSTYLE_FLAT | TBSTYLE_TOOLTIPS | TBSTYLE_WRAPABLE | TBSTYLE_TRANSPARENT |
         CCS_TOP | CCS_NORESIZE | CCS_NOPARENTALIGN | CCS_NODIVIDER;
 
-    HWND toolbar = CToolbar::Create(hWndParent, styles);
-    //HACK: We have not created this toolbar properly, so we need to subclass it now!
-    m_hWnd = NULL;
-    SubclassWindow(toolbar);
+    // HACK & FIXME: CORE-17505
+    SubclassWindow(CToolbar::Create(hWndParent, styles));
 
     // Force the toolbar tooltips window to always show tooltips even if not foreground
     HWND tooltipsWnd = (HWND)SendMessageW(TB_GETTOOLTIPS);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -287,8 +287,7 @@ public:
 
         HWND toolbar = CToolbar::Create(hWndParent, styles);
         SetDrawTextFlags(DT_NOPREFIX, DT_NOPREFIX);
-        //HACK: We have not created this toolbar properly, so we need to subclass it now!
-        m_hWnd = NULL;
+        // HACK & FIXME: CORE-17505
         return SubclassWindow(toolbar);
     }
 };

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -200,10 +200,8 @@ public:
 
     VOID Initialize()
     {
-        //HACK: We have not created this button properly, so we need to subclass it now!
-        HWND button = m_hWnd;
-        m_hWnd = NULL;
-        SubclassWindow(button);
+        // HACK & FIXME: CORE-17505
+        SubclassWindow(m_hWnd);
 
         SetWindowTheme(m_hWnd, L"Start", NULL);
 

--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -398,7 +398,8 @@ HRESULT CMenuToolbarBase::CreateToolbar(HWND hwndParent, DWORD dwFlags)
         rc.bottom = 1;
     }
 
-    CToolbar::Create(hwndParent, tbStyles, tbExStyles);
+    // HACK & FIXME: CORE-17505
+    SubclassWindow(CToolbar::Create(hwndParent, tbStyles, tbExStyles));
 
     SetWindowTheme(m_hWnd, L"", L"");
 

--- a/sdk/lib/atl/CMakeLists.txt
+++ b/sdk/lib/atl/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_library(atl_classes INTERFACE)
 if(DBG)
-    #target_compile_definitions(atl_classes INTERFACE _DEBUG)
+    #target_compile_definitions(atl_classes INTERFACE _DEBUG) # HACK & FIXME: CORE-17505
 endif()
 
 target_include_directories(atl_classes INTERFACE

--- a/sdk/lib/atl/CMakeLists.txt
+++ b/sdk/lib/atl/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 add_library(atl_classes INTERFACE)
 if(DBG)
-    target_compile_definitions(atl_classes INTERFACE _DEBUG)
+    #target_compile_definitions(atl_classes INTERFACE _DEBUG)
 endif()
 
 target_include_directories(atl_classes INTERFACE


### PR DESCRIPTION
## Purpose

We are not ready for enabling `ATLASSERT`. Enabling ATL assertions takes time to realize.
JIRA issue: [CORE-17505](https://jira.reactos.org/browse/CORE-17505)

## Proposed changes

- Disable `ATLASSERT` by undefining `_DEBUG`.
- Revert currently non-fixable codes.