### PR TITLE
[NTOS:SE] Create two system anonymous logon tokens on boot

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -187,6 +187,7 @@ extern PACL SePublicDefaultUnrestrictedDacl;
 extern PACL SePublicOpenDacl;
 extern PACL SePublicOpenUnrestrictedDacl;
 extern PACL SeUnrestrictedDacl;
+extern PACL SeSystemAnonymousLogonDacl;
 
 /* SDs */
 extern PSECURITY_DESCRIPTOR SePublicDefaultSd;
@@ -195,6 +196,7 @@ extern PSECURITY_DESCRIPTOR SePublicOpenSd;
 extern PSECURITY_DESCRIPTOR SePublicOpenUnrestrictedSd;
 extern PSECURITY_DESCRIPTOR SeSystemDefaultSd;
 extern PSECURITY_DESCRIPTOR SeUnrestrictedSd;
+extern PSECURITY_DESCRIPTOR SeSystemAnonymousLogonSd;
 
 
 #define SepAcquireTokenLockExclusive(Token)                                    \

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -335,6 +335,12 @@ PTOKEN
 NTAPI
 SepCreateSystemProcessToken(VOID);
 
+PTOKEN
+SepCreateSystemAnonymousLogonToken(VOID);
+
+PTOKEN
+SepCreateSystemAnonymousLogonTokenNoEveryone(VOID);
+
 BOOLEAN
 NTAPI
 SeDetailedAuditingWithToken(IN PTOKEN Token);

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -198,6 +198,10 @@ extern PSECURITY_DESCRIPTOR SeSystemDefaultSd;
 extern PSECURITY_DESCRIPTOR SeUnrestrictedSd;
 extern PSECURITY_DESCRIPTOR SeSystemAnonymousLogonSd;
 
+/* Anonymous Logon Tokens */
+extern PTOKEN SeAnonymousLogonToken;
+extern PTOKEN SeAnonymousLogonTokenNoEveryone;
+
 
 #define SepAcquireTokenLockExclusive(Token)                                    \
 {                                                                              \

--- a/ntoskrnl/se/acl.c
+++ b/ntoskrnl/se/acl.c
@@ -21,6 +21,7 @@ PACL SePublicDefaultUnrestrictedDacl = NULL;
 PACL SePublicOpenDacl = NULL;
 PACL SePublicOpenUnrestrictedDacl = NULL;
 PACL SeUnrestrictedDacl = NULL;
+PACL SeSystemAnonymousLogonDacl = NULL;
 
 /* FUNCTIONS ******************************************************************/
 
@@ -216,6 +217,31 @@ SepInitDACLs(VOID)
                            ACL_REVISION,
                            GENERIC_READ | GENERIC_EXECUTE,
                            SeRestrictedCodeSid);
+
+    /* create SystemAnonymousLogonDacl */
+    AclLength = sizeof(ACL) +
+                (sizeof(ACE) + RtlLengthSid(SeWorldSid)) +
+                (sizeof(ACE) + RtlLengthSid(SeAnonymousLogonSid));
+
+    SeSystemAnonymousLogonDacl = ExAllocatePoolWithTag(PagedPool,
+                                                       AclLength,
+                                                       TAG_ACL);
+    if (SeSystemAnonymousLogonDacl == NULL)
+        return FALSE;
+
+    RtlCreateAcl(SeSystemAnonymousLogonDacl,
+                 AclLength,
+                 ACL_REVISION);
+
+    RtlAddAccessAllowedAce(SeSystemAnonymousLogonDacl,
+                           ACL_REVISION,
+                           GENERIC_ALL,
+                           SeWorldSid);
+
+    RtlAddAccessAllowedAce(SeSystemAnonymousLogonDacl,
+                           ACL_REVISION,
+                           GENERIC_ALL,
+                           SeAnonymousLogonSid);
 
     return TRUE;
 }

--- a/ntoskrnl/se/sd.c
+++ b/ntoskrnl/se/sd.c
@@ -21,6 +21,7 @@ PSECURITY_DESCRIPTOR SePublicOpenSd = NULL;
 PSECURITY_DESCRIPTOR SePublicOpenUnrestrictedSd = NULL;
 PSECURITY_DESCRIPTOR SeSystemDefaultSd = NULL;
 PSECURITY_DESCRIPTOR SeUnrestrictedSd = NULL;
+PSECURITY_DESCRIPTOR SeSystemAnonymousLogonSd = NULL;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -105,6 +106,19 @@ SepInitSDs(VOID)
     RtlSetDaclSecurityDescriptor(SeUnrestrictedSd,
                                  TRUE,
                                  SeUnrestrictedDacl,
+                                 FALSE);
+
+    /* Create SystemAnonymousLogonSd */
+    SeSystemAnonymousLogonSd = ExAllocatePoolWithTag(PagedPool,
+                                                     sizeof(SECURITY_DESCRIPTOR), TAG_SD);
+    if (SeSystemAnonymousLogonSd == NULL)
+        return FALSE;
+
+    RtlCreateSecurityDescriptor(SeSystemAnonymousLogonSd,
+                                SECURITY_DESCRIPTOR_REVISION);
+    RtlSetDaclSecurityDescriptor(SeSystemAnonymousLogonSd,
+                                 TRUE,
+                                 SeSystemAnonymousLogonDacl,
                                  FALSE);
 
     return TRUE;

--- a/ntoskrnl/se/semgr.c
+++ b/ntoskrnl/se/semgr.c
@@ -15,6 +15,8 @@
 
 /* GLOBALS ********************************************************************/
 
+PTOKEN SeAnonymousLogonToken = NULL;
+PTOKEN SeAnonymousLogonTokenNoEveryone = NULL;
 PSE_EXPORTS SeExports = NULL;
 SE_EXPORTS SepExports;
 ULONG SidInTokenCalls = 0;
@@ -122,6 +124,16 @@ SepInitializationPhase0(VOID)
     ObInitializeFastReference(&PsGetCurrentProcess()->Token, NULL);
     ObInitializeFastReference(&PsGetCurrentProcess()->Token,
                               SepCreateSystemProcessToken());
+
+    /* Initialise the anonymous logon tokens */
+    SeAnonymousLogonToken = SepCreateSystemAnonymousLogonToken();
+    if (!SeAnonymousLogonToken)
+        return FALSE;
+
+    SeAnonymousLogonTokenNoEveryone = SepCreateSystemAnonymousLogonTokenNoEveryone();
+    if (!SeAnonymousLogonTokenNoEveryone)
+        return FALSE;
+
     return TRUE;
 }
 

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -1389,6 +1389,15 @@ Quit:
     return Status;
 }
 
+/**
+ * @brief
+ * Creates the system process token.
+ *
+ * @return
+ * Returns the system process token if the operations have
+ * completed successfully.
+ */
+CODE_SEG("INIT")
 PTOKEN
 NTAPI
 SepCreateSystemProcessToken(VOID)


### PR DESCRIPTION
On Windows three kind of system tokens are being created -- 1) system process token (which we already do that in ReactOS, 2) anonymous logon token not including the "Everyone SID group" and 3) anonymous logon token that includes such SID group.

The latter two tokens are created during phase 0 of the initialisation process of the SRM kernel component and they're needed for eventual impersonation of such tokens and such. With that being said, this is a next step closer to the implementation of `NtImpersonateAnonymousToken`.
## Proposed Changes
* Implement `SepCreateSystemAnonymousLogonToken` and `SepCreateSystemAnonymousLogonTokenNoEveryone` functions (they're equivalent to `SeMakeAnonymousLogonToken` and `SeMakeAnonymousLogonTokenNoEveryone` on Windows).
* Set up a security descriptor and an access control list for the anonymous logon.
* [Additional] `SeMakeSystemToken` is set in the INIT code segment section on Windows so do that for `SepCreateSystemProcessToken` as well. Also include the documentation header.