### PR TITLE
[SHELL32] Hide edit control on 'Copy to' and 'Move to'

### DIFF
--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -277,7 +277,7 @@ HRESULT CCopyToMenu::DoCopyToFolder(LPCMINVOKECOMMANDINFO lpici)
     BROWSEINFOW info = { lpici->hwnd };
     info.pidlRoot = NULL;
     info.lpszTitle = strTitle;
-    info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI;
+    info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
     info.lpfn = BrowseCallbackProc;
     info.lParam = reinterpret_cast<LPARAM>(this);
     CComHeapPtr<ITEMIDLIST> pidl(SHBrowseForFolder(&info));

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -244,7 +244,7 @@ HRESULT CMoveToMenu::DoMoveToFolder(LPCMINVOKECOMMANDINFO lpici)
     BROWSEINFOW info = { lpici->hwnd };
     info.pidlRoot = NULL;
     info.lpszTitle = strTitle;
-    info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_USENEWUI;
+    info.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
     info.lpfn = BrowseCallbackProc;
     info.lParam = reinterpret_cast<LPARAM>(this);
     CComHeapPtr<ITEMIDLIST> pidl(SHBrowseForFolder(&info));


### PR DESCRIPTION
## Purpose

'Copy to' and'Move to' are features of Explorer for beginners. Displaying the textbox is confusing for beginners.
This PR hides the textbox in actions of 'Copy To' and 'Move To' features.

JIRA issue: N/A

## Proposed changes

- Use `BIF_NEWDIALOGSTYLE` style rather than `BIF_USENEWUI`.

## Comparison

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/111090161-20eb7580-8572-11eb-87ad-1e43f5ccc6b4.png)
Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/111090162-20eb7580-8572-11eb-980d-119e7c3be15a.png)
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/111090163-21840c00-8572-11eb-9fc5-ebdd548e7658.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/111090160-1fba4880-8572-11eb-974b-cc6424c08b90.png)