### PR TITLE
[NDK][XDK] Use decimal literals for MINxxxx defines

### DIFF
--- a/sdk/include/ndk/umtypes.h
+++ b/sdk/include/ndk/umtypes.h
@@ -108,12 +108,12 @@ Author:
 //
 // Limits
 //
-#define MINCHAR                         0x80
-#define MAXCHAR                         0x7f
-#define MINSHORT                        0x8000
-#define MAXSHORT                        0x7fff
-#define MINLONG                         0x80000000
-#define MAXLONG                         0x7fffffff
+#define MINCHAR                         (-128)
+#define MAXCHAR                         127
+#define MINSHORT                        (-32768)
+#define MAXSHORT                        32767
+#define MINLONG                         (-2147483648)
+#define MAXLONG                         2147483647
 #define MAXUCHAR                        0xff
 #define MAXUSHORT                       0xffff
 #define MAXULONG                        0xffffffff

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -735,12 +735,12 @@ extern "C++" { \
 #define COMPILETIME_OR_5FLAGS(a,b,c,d,e)    ((UINT)(a)|(UINT)(b)|(UINT)(c)|(UINT)(d)|(UINT)(e))
 
 /* Type Limits */
-#define MINCHAR   0x80
-#define MAXCHAR   0x7f
-#define MINSHORT  0x8000
-#define MAXSHORT  0x7fff
-#define MINLONG   0x80000000
-#define MAXLONG   0x7fffffff
+#define MINCHAR   (-128)
+#define MAXCHAR   127
+#define MINSHORT  (-32768)
+#define MAXSHORT  32767
+#define MINLONG   (-2147483648)
+#define MAXLONG   2147483647
 $if(_NTDEF_)
 #define MAXUCHAR  0xff
 #define MAXUSHORT 0xffff


### PR DESCRIPTION
Because myLongLong < MINLONG is supposed to behave like you'd expect.

I accept donations for being such a talented developer.