### PR TITLE
[BROWSEUI] Fix auto-completion on VK_DELETE

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -961,8 +961,7 @@ BOOL CAutoComplete::OnEditKeyDown(WPARAM wParam, LPARAM lParam)
             if (!CanAutoSuggest())
                 return FALSE; // do default
             m_hwndEdit.DefWindowProcW(WM_KEYDOWN, VK_DELETE, 0); // do default
-            if (IsWindowVisible())
-                OnEditUpdate(FALSE);
+            OnEditUpdate(FALSE);
             return TRUE; // eat
         }
         case VK_BACK:


### PR DESCRIPTION
## Purpose

Reduce failures against Delete key on auto-completion.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- On `VK_DELETE`, delete the check of `IsWindowVisible()`.

## Comparison

BEFORE:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 214 tests executed (0 marked as todo, 48 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 546 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66275 tests executed (0 marked as todo, 56 failures), 0 skipped.
```

AFTER:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 214 tests executed (0 marked as todo, 48 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 546 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66275 tests executed (0 marked as todo, 43 failures), 0 skipped.
```
This PR reduces 13 failures.