### PR TITLE
[BROWSEUI] Fix return value on sanity check of auto-completion

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1133,7 +1133,7 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     if (m_hwndEdit || !punkACL)
     {
         ATLASSERT(0);
-        return E_INVALIDARG;
+        return E_FAIL;
     }
 
     // set this pointer to m_hwndEdit


### PR DESCRIPTION
## Purpose
Reduce failures on sanity check of auto-completion.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Return `E_FAIL` rather than `E_INVALIDARG` in sanity check of `CAutoComplete::Init` (`IAutoComplete::Init`).

## Comparison

BEFORE:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 214 tests executed (0 marked as todo, 48 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 550 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66275 tests executed (0 marked as todo, 43 failures), 0 skipped.
```
AFTER:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 214 tests executed (0 marked as todo, 46 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 546 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66275 tests executed (0 marked as todo, 43 failures), 0 skipped.
```
This PR reduces 2 failures.