### PR TITLE
[HHPCOMP] Add ARM (32-bit) types

### DIFF
--- a/sdk/tools/hhpcomp/chmc/chm.h
+++ b/sdk/tools/hhpcomp/chmc/chm.h
@@ -49,7 +49,8 @@ typedef unsigned __int64        UInt64;
 /* Sparc        */
 /* MIPS         */
 /* PPC          */
-#elif __i386__ || __sun || __sgi || __ppc__
+/* ARM (32-bit) */
+#elif __i386__ || __sun || __sgi || __ppc__ || __arm__
 typedef unsigned char           UChar;
 typedef short                   Int16;
 typedef unsigned short          UInt16;


### PR DESCRIPTION
ARM32 seems to use the same type defines as i386 and friends.
Let's allow the thing to be compiled again!

Signed-off-by: Konrad Dybcio <konrad.dybcio@somainline.org>

## Purpose

One step closer to getting ARM back on the track

JIRA issue: [CORE-17517](https://jira.reactos.org/browse/CORE-17517) seems the closest

## Proposed changes

Add type definitions for ARM

