### PR TITLE
[NETAPI32] SamEnumerate*() callers: Skip ERR() for STATUS_NO_MORE_ENTRIES

### DIFF
--- a/dll/win32/netapi32/group_new.c
+++ b/dll/win32/netapi32/group_new.c
@@ -876,7 +876,10 @@ NetGroupEnum(
             TRACE("SamEnumerateGroupsInDomain returned (Status %08lx)\n", Status);
             if (!NT_SUCCESS(Status))
             {
-                ERR("SamEnumerateAliasesInDomain failed (Status %08lx)\n", Status);
+                if (Status != STATUS_NO_MORE_ENTRIES)
+                {
+                    ERR("SamEnumerateGroupsInDomain() failed (Status 0x%08lx)\n", Status);
+                }
                 ApiStatus = NetpNtStatusToApiStatus(Status);
                 goto done;
             }

--- a/dll/win32/netapi32/local_group.c
+++ b/dll/win32/netapi32/local_group.c
@@ -1070,7 +1070,10 @@ NetLocalGroupEnum(
             TRACE("SamEnumerateAliasesInDomain returned (Status %08lx)\n", Status);
             if (!NT_SUCCESS(Status))
             {
-                ERR("SamEnumerateAliasesInDomain failed (Status %08lx)\n", Status);
+                if (Status != STATUS_NO_MORE_ENTRIES)
+                {
+                    ERR("SamEnumerateAliasesInDomain() failed (Status 0x%08lx)\n", Status);
+                }
                 ApiStatus = NetpNtStatusToApiStatus(Status);
                 goto done;
             }

--- a/dll/win32/netapi32/user.c
+++ b/dll/win32/netapi32/user.c
@@ -2859,7 +2859,10 @@ NetUserEnum(LPCWSTR servername,
             TRACE("SamEnumerateUsersInDomain returned (Status %08lx)\n", Status);
             if (!NT_SUCCESS(Status))
             {
-                ERR("SamEnumerateUsersInDomain failed (Status %08lx)\n", Status);
+                if (Status != STATUS_NO_MORE_ENTRIES)
+                {
+                    ERR("SamEnumerateUsersInDomain() failed (Status 0x%08lx)\n", Status);
+                }
                 ApiStatus = NetpNtStatusToApiStatus(Status);
                 goto done;
             }

--- a/dll/win32/samsrv/samrpc.c
+++ b/dll/win32/samsrv/samrpc.c
@@ -709,6 +709,12 @@ SamrEnumerateDomainsInSamServer(IN SAMPR_HANDLE ServerHandle,
     }
 
     EnumBuffer->EntriesRead = EnumCount;
+    if (EnumCount == 0)
+    {
+        Status = STATUS_NO_MORE_ENTRIES;
+        goto done;
+    }
+
     EnumBuffer->Buffer = midl_user_allocate(EnumCount * sizeof(SAMPR_RID_ENUMERATION));
     if (EnumBuffer->Buffer == NULL)
     {


### PR DESCRIPTION
## Purpose

`STATUS_NO_MORE_ENTRIES` is not a failure.

JIRA issue: [CORE-11963](https://jira.reactos.org/browse/CORE-11963)

## Proposed changes

-  [NETAPI32] SamEnumerate*() callers: Skip ERR() for STATUS_NO_MORE_ENTRIES
-  [SAMSRV] SamrEnumerateDomainsInSamServer(): Return STATUS_NO_MORE_ENTRIES
