### PR TITLE
[BROWSEUI] Enable AutoAppend of auto-completion

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1142,7 +1142,7 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     // load quick completion info
     LoadQuickComplete(pwszRegKeyPath, pwszQuickComplete);
 
-    // any combobox
+    // any combobox for m_hwndEdit?
     m_hwndCombo = NULL;
     HWND hwndParent = ::GetParent(m_hwndEdit);
     WCHAR szClass[16];

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -320,7 +320,7 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             return ret;
         case WM_KEYDOWN:
             if (OnEditKeyDown(wParam, lParam))
-                return 1; // eat
+                return TRUE; // eat
             break;
         case WM_SETFOCUS:
             break;
@@ -511,10 +511,6 @@ LRESULT CACListView::OnNCHitTest(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
 //////////////////////////////////////////////////////////////////////////////
 // CACScrollBar
 
-CACScrollBar::CACScrollBar() : m_pDropDown(NULL)
-{
-}
-
 HWND CACScrollBar::Create(HWND hwndParent)
 {
     ATLASSERT(m_hWnd == NULL);
@@ -528,10 +524,6 @@ HWND CACScrollBar::Create(HWND hwndParent)
 
 //////////////////////////////////////////////////////////////////////////////
 // CACSizeBox
-
-CACSizeBox::CACSizeBox() : m_pDropDown(NULL), m_bDowner(TRUE), m_bLongList(FALSE)
-{
-}
 
 HWND CACSizeBox::Create(HWND hwndParent)
 {
@@ -1104,7 +1096,7 @@ BOOL CAutoComplete::OnListUpDown(UINT vk)
 // @implemented
 STDMETHODIMP CAutoComplete::Enable(BOOL fEnable)
 {
-    TRACE("(%p)->(%d)\n", this, fEnable);
+    TRACE("(%p)->Enable(%d)\n", this, fEnable);
     m_bEnabled = fEnable;
     return S_OK;
 }
@@ -1115,7 +1107,6 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
 {
     TRACE("(%p)->Init(0x%08lx, %p, %s, %s)\n",
           this, hwndEdit, punkACL, debugstr_w(pwszRegKeyPath), debugstr_w(pwszQuickComplete));
-
     // sanity check
     if (m_hwndEdit || !punkACL)
         return E_FAIL;

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -818,23 +818,29 @@ VOID CAutoComplete::DoAutoAppend()
 
     // get the common string
     CStringW strCommon;
+    BOOL bFound = FALSE;
     for (INT iItem = 0; iItem < cItems; ++iItem)
     {
         const CString& strItem = m_innerList[iItem]; // get the text of the item
-
-        if (iItem == 0) // the first item
+ 
+        if (::StrCmpNIW(strItem, strText, strText.GetLength()) == 0)
         {
-            strCommon = strItem; // store the text
-            continue;
-        }
-
-        for (INT ich = 0; ich < strCommon.GetLength(); ++ich)
-        {
-            if (ich < strItem.GetLength() &&
-                ::ChrCmpIW(strCommon[ich], strItem[ich]) != 0)
+            if (!bFound)
             {
-                strCommon = strCommon.Left(ich); // shrink the common string
-                break;
+                bFound = TRUE;
+                strCommon = strItem;
+                continue;
+            }
+
+            for (INT ich = 0; ich < strItem.GetLength(); ++ich)
+            {
+                if (strCommon.GetLength() <= ich)
+                    break;
+                if (ChrCmpIW(strCommon[ich], strItem[ich]) != 0)
+                {
+                    strCommon = strCommon.Left(ich);
+                    break;
+                }
             }
         }
     }
@@ -843,13 +849,10 @@ VOID CAutoComplete::DoAutoAppend()
         return; // no suggestion
 
     // append suggestion
-    INT cchOld = strText.GetLength();
-    INT cchAppend = strCommon.GetLength() - cchOld;
-    strText += strCommon.Right(cchAppend);
-    SetEditText(strText);
+    SetEditText(strCommon);
 
     // select the appended suggestion
-    SetEditSel(cchOld, strText.GetLength());
+    SetEditSel(strText.GetLength(), strCommon.GetLength());
 }
 
 // go back a word ([Ctrl]+[Backspace])
@@ -1607,13 +1610,11 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
             RepositionDropDown();
         else
             HideDropDown();
-        return;
     }
 
     if (CanAutoAppend() && bAppendOK) // can we auto-append?
     {
         DoAutoAppend();
-        return;
     }
 }
 

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -338,6 +338,7 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             break;
         case WM_DESTROY:
         {
+            HookWordBreakProc(FALSE);
             ::RemoveWindowSubclass(hwnd, EditSubclassProc, 0);
             if (::IsWindow(m_hWnd))
                 PostMessageW(WM_CLOSE, 0, 0);
@@ -1690,13 +1691,6 @@ LRESULT CAutoComplete::OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
     // hide
     if (IsWindowVisible())
         HideDropDown();
-
-    // unsubclass EDIT control
-    if (m_hwndEdit)
-    {
-        HookWordBreakProc(FALSE);
-        ::RemoveWindowSubclass(m_hwndEdit, EditSubclassProc, 0);
-    }
 
     // clear CAutoComplete pointers
     m_hwndList.m_pDropDown = NULL;

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -709,9 +709,7 @@ CStringW CAutoComplete::GetEditText()
 {
     WCHAR szText[L_MAX_URL_LENGTH];
     if (::GetWindowTextW(m_hwndEdit, szText, _countof(szText)))
-    {
         return szText;
-    }
     return L"";
 }
 

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -341,6 +341,7 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             ::RemoveWindowSubclass(hwnd, EditSubclassProc, 0);
             if (::IsWindow(m_hWnd))
                 PostMessageW(WM_CLOSE, 0, 0);
+            // remove reference to m_hwndEdit
             Release();
             break;
         }
@@ -1140,7 +1141,7 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     if (!::SetWindowSubclass(hwndEdit, EditSubclassProc, 0, reinterpret_cast<DWORD_PTR>(this)))
         return E_FAIL;
     m_hwndEdit = hwndEdit;
-    // add reference
+    // add reference to hwndEdit
     AddRef();
     // set word break procedure
     HookWordBreakProc(TRUE);
@@ -1317,9 +1318,7 @@ VOID CAutoComplete::UpdateDropDownState()
         // create the drop-down window if not existed
         if (!m_hWnd)
         {
-            AddRef();
-            if (!CreateDropDown())
-                Release();
+            CreateDropDown();
         }
     }
     else
@@ -1677,7 +1676,7 @@ LRESULT CAutoComplete::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
     m_hFont = reinterpret_cast<HFONT>(::GetStockObject(DEFAULT_GUI_FONT));
     m_hwndList.SetFont(m_hFont);
 
-    // add reference
+    // add reference to CAutoComplete::m_hWnd
     AddRef();
 
     return 0; // success
@@ -1711,6 +1710,7 @@ LRESULT CAutoComplete::OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 
     // clean up
     m_hwndCombo = NULL;
+    // remove reference to CAutoComplete::m_hWnd
     Release();
     return 0;
 }

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1392,7 +1392,7 @@ CStringW CAutoComplete::GetQuickEdit(LPCWSTR pszText)
 
 VOID CAutoComplete::RepositionDropDown()
 {
-    // get nearest monitor
+    // get nearest monitor from m_hwndEdit
     HMONITOR hMon = ::MonitorFromWindow(m_hwndEdit, MONITOR_DEFAULTTONEAREST);
     ATLASSERT(hMon != NULL);
     if (hMon == NULL)
@@ -1411,7 +1411,7 @@ VOID CAutoComplete::RepositionDropDown()
     INT cyItem = m_hwndList.m_cyItem;
     ATLASSERT(cyItem > 0);
 
-    // get position
+    // get m_hwndEdit position
     RECT rcEdit;
     ::GetWindowRect(m_hwndEdit, &rcEdit);
     INT x = rcEdit.left, y = rcEdit.bottom;
@@ -1657,7 +1657,6 @@ LRESULT CAutoComplete::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
 
     // add reference to CAutoComplete::m_hWnd
     AddRef();
-
     return 0; // success
 }
 
@@ -2024,7 +2023,7 @@ LRESULT CAutoComplete::OnTimer(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bH
         return 0;
     }
 
-    // moved?
+    // m_hwndEdit is moved?
     RECT rcEdit;
     ::GetWindowRect(m_hwndEdit, &rcEdit);
     if (!::EqualRect(&rcEdit, &m_rcEdit))

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -664,10 +664,8 @@ CAutoComplete::~CAutoComplete()
         ::DeleteObject(m_hFont);
         m_hFont = NULL;
     }
-    if (m_pEnum)
-        m_pEnum.Release();
-    if (m_pACList)
-        m_pACList.Release();
+    m_pEnum.Release();
+    m_pACList.Release();
 }
 
 BOOL CAutoComplete::CanAutoSuggest()
@@ -711,13 +709,12 @@ CStringW CAutoComplete::GetItemText(INT iItem)
 
 CStringW CAutoComplete::GetEditText()
 {
-    CStringW strText;
     WCHAR szText[L_MAX_URL_LENGTH];
     if (::GetWindowTextW(m_hwndEdit, szText, _countof(szText)))
     {
-        strText = szText;
+        return szText;
     }
-    return strText;
+    return L"";
 }
 
 VOID CAutoComplete::SetEditText(LPCWSTR pszText)
@@ -850,8 +847,7 @@ VOID CAutoComplete::DoBackWord()
     // get current selection
     INT ich0, ich1;
     ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, EM_GETSEL,
-                      reinterpret_cast<WPARAM>(&ich0),
-                      reinterpret_cast<LPARAM>(&ich1));
+                      reinterpret_cast<WPARAM>(&ich0), reinterpret_cast<LPARAM>(&ich1));
     if (ich0 <= 0 || ich0 != ich1) // there is selection or left-side end
         return; // don't do anything
     // get text
@@ -1235,7 +1231,6 @@ STDMETHODIMP CAutoComplete::ResetEnumerator()
 
     Reset();
     m_innerList.RemoveAll();
-
     return S_OK;
 }
 
@@ -1296,9 +1291,7 @@ VOID CAutoComplete::UpdateDropDownState()
     {
         // create the drop-down window if not existed
         if (!m_hWnd)
-        {
             CreateDropDown();
-        }
     }
     else
     {
@@ -1962,9 +1955,7 @@ LRESULT CAutoComplete::OnShowWindow(UINT uMsg, WPARAM wParam, LPARAM lParam, BOO
     if (bShow)
     {
         if (s_hWatchWnd != m_hWnd && ::IsWindowVisible(s_hWatchWnd))
-        {
             ::ShowWindowAsync(s_hWatchWnd, SW_HIDE);
-        }
         s_hWatchWnd = m_hWnd; // watch this
 
         // unhook mouse if any

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -22,11 +22,6 @@
 
 #include "precomp.h"
 
-#undef TRACE
-#define TRACE ERR
-#undef ATLASSERT
-#define ATLASSERT(x) do { if (x) ERR(#x); } while(0)
-
 /*
   TODO:
   - implement ACO_SEARCH style

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -662,6 +662,7 @@ CAutoComplete::~CAutoComplete()
         ::DeleteObject(m_hFont);
         m_hFont = NULL;
     }
+    // quit holding them
     m_pEnum.Release();
     m_pACList.Release();
 }
@@ -1124,14 +1125,14 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     punkACL->QueryInterface(IID_IEnumString, (VOID **)&m_pEnum);
     TRACE("m_pEnum: %p\n", static_cast<void *>(m_pEnum));
     if (m_pEnum)
-        m_pEnum->AddRef();
+        m_pEnum->AddRef(); // hold not to be freed
 
     // get an IACList
     ATLASSERT(!m_pACList);
     punkACL->QueryInterface(IID_IACList, (VOID **)&m_pACList);
     TRACE("m_pACList: %p\n", static_cast<void *>(m_pACList));
     if (m_pACList)
-        m_pACList->AddRef();
+        m_pACList->AddRef(); // hold not to be freed
 
     UpdateDropDownState(); // create/hide the drop-down window if necessary
 

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -326,7 +326,7 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
         case WM_KILLFOCUS:
             // hide the list if lost focus
             hwndGotFocus = (HWND)wParam;
-            if (hwndGotFocus != m_hWnd && hwndGotFocus != m_hWnd)
+            if (hwndGotFocus != m_hwndEdit && hwndGotFocus != m_hWnd)
             {
                 HideDropDown();
             }

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -327,9 +327,7 @@ LRESULT CAutoComplete::EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
             // hide the list if lost focus
             hwndGotFocus = (HWND)wParam;
             if (hwndGotFocus != m_hwndEdit && hwndGotFocus != m_hWnd)
-            {
                 HideDropDown();
-            }
             break;
         case WM_SETTEXT:
             if (!m_bInSetText)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -852,8 +852,9 @@ VOID CAutoComplete::DoBackWord()
 {
     // get current selection
     INT ich0, ich1;
-    ::SendMessageW(m_hwndEdit, EM_GETSEL, reinterpret_cast<WPARAM>(&ich0),
-                                          reinterpret_cast<LPARAM>(&ich1));
+    ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, EM_GETSEL,
+                      reinterpret_cast<WPARAM>(&ich0),
+                      reinterpret_cast<LPARAM>(&ich1));
     if (ich0 <= 0 || ich0 != ich1) // there is selection or left-side end
         return; // don't do anything
     // get text
@@ -866,7 +867,7 @@ VOID CAutoComplete::DoBackWord()
     // select range
     SetEditSel(ich0, ich1);
     // replace selection with empty text (this is actually deletion)
-    ::SendMessageW(m_hwndEdit, EM_REPLACESEL, TRUE, (LPARAM)L"");
+    ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, EM_REPLACESEL, TRUE, (LPARAM)L"");
 }
 
 VOID CAutoComplete::UpdateScrollBar()
@@ -936,7 +937,7 @@ BOOL CAutoComplete::OnEditKeyDown(WPARAM wParam, LPARAM lParam)
                 }
             }
             // select all
-            INT cch = ::SendMessageW(m_hwndEdit, WM_GETTEXTLENGTH, 0, 0);
+            INT cch = ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, WM_GETTEXTLENGTH, 0, 0);
             SetEditSel(0, cch);
             // hide
             HideDropDown();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -284,19 +284,14 @@ LRESULT CACEditCtrl::OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &
     ATLASSERT(m_pDropDown);
     CAutoComplete *pDropDown = m_pDropDown;
 
-    // unhook word break procedure
-    HookWordBreakProc(FALSE);
-
-    // unsubclass because we don't watch any more
-    HWND hwndEdit = UnsubclassWindow();
-
     // close the drop-down window
     if (pDropDown)
     {
         pDropDown->PostMessageW(WM_CLOSE, 0, 0);
     }
 
-    return ::DefWindowProcW(hwndEdit, uMsg, wParam, lParam); // do default
+    bHandled = FALSE; // do default
+    return 0;
 }
 
 // WM_GETDLGCODE
@@ -705,6 +700,10 @@ CAutoComplete::~CAutoComplete()
     {
         ::DeleteObject(m_hFont);
         m_hFont = NULL;
+    }
+    if (m_hWnd)
+    {
+        DestroyWindow();
     }
 }
 
@@ -1148,8 +1147,6 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     punkACL->QueryInterface(IID_IACList, (VOID **)&m_pACList);
     TRACE("m_pACList: %p\n", static_cast<void *>(m_pACList));
 
-    AddRef(); // add reference
-
     UpdateDropDownState(); // create/hide the drop-down window if necessary
 
     // load quick completion info
@@ -1307,9 +1304,7 @@ VOID CAutoComplete::UpdateDropDownState()
         // create the drop-down window if not existed
         if (!m_hWnd)
         {
-            AddRef();
-            if (!CreateDropDown())
-                Release();
+            CreateDropDown();
         }
     }
     else
@@ -1692,7 +1687,6 @@ LRESULT CAutoComplete::OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 
     // clean up
     m_hwndCombo = NULL;
-    Release();
 
     return 0;
 }

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -730,6 +730,11 @@ BOOL CAutoComplete::IsComboBoxDropped()
     return (BOOL)::SendMessageW(m_hwndCombo, CB_GETDROPPEDSTATE, 0, 0);
 }
 
+BOOL CAutoComplete::FilterPrefixes()
+{
+    return !!(m_dwOptions & ACO_FILTERPREFIXES) && m_bEnabled;
+}
+
 INT CAutoComplete::GetItemCount()
 {
     return m_outerList.GetSize();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1141,7 +1141,7 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     if (!::SetWindowSubclass(hwndEdit, EditSubclassProc, 0, reinterpret_cast<DWORD_PTR>(this)))
         return E_FAIL;
     m_hwndEdit = hwndEdit;
-    // add reference to hwndEdit
+    // add reference to m_hwndEdit
     AddRef();
     // set word break procedure
     HookWordBreakProc(TRUE);

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -809,7 +809,30 @@ VOID CAutoComplete::DoAutoAppend()
     for (INT iItem = 0; iItem < cItems; ++iItem)
     {
         const CStringW& strItem = m_innerList[iItem]; // get the text of the item
- 
+
+        CStringW strBody;
+        if (DropPrefix(strItem, strBody) &&
+            ::StrCmpNIW(strBody, strText, strText.GetLength()) == 0)
+        {
+            if (!bFound)
+            {
+                bFound = TRUE;
+                strCommon = strBody;
+                continue;
+            }
+            for (INT ich = 0; ich < strBody.GetLength(); ++ich)
+            {
+                if (strCommon.GetLength() <= ich)
+                    break;
+                if (ChrCmpIW(strCommon[ich], strBody[ich]) != 0)
+                {
+                    strCommon = strCommon.Left(ich);
+                    break;
+                }
+            }
+            continue;
+        }
+
         if (::StrCmpNIW(strItem, strText, strText.GetLength()) == 0)
         {
             if (!bFound)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -756,7 +756,7 @@ CStringW CAutoComplete::GetEditText()
 VOID CAutoComplete::SetEditText(LPCWSTR pszText)
 {
     m_bInSetText = TRUE; // don't hide drop-down
-    m_hwndEdit.SetWindowTextW(pszText);
+    m_hwndEdit.DefWindowProcW(WM_SETTEXT, 0, reinterpret_cast<LPARAM>(pszText));
     m_bInSetText = FALSE;
 }
 
@@ -771,7 +771,7 @@ CStringW CAutoComplete::GetStemText()
 
 VOID CAutoComplete::SetEditSel(INT ich0, INT ich1)
 {
-    m_hwndEdit.SendMessageW(EM_SETSEL, ich0, ich1);
+    m_hwndEdit.DefWindowProcW(EM_SETSEL, ich0, ich1);
 }
 
 VOID CAutoComplete::ShowDropDown()

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -111,40 +111,39 @@ typedef CSimpleArray<CStringW> list_t;
 
 static inline INT compare1(const CStringW& str1, const CStringW& str2)
 {
-    CStringW s1;
+    CStringW s1, s2;
     DropPrefix(str1, s1);
-    CStringW s2;
     DropPrefix(str2, s2);
     return s1.CompareNoCase(s2);
 }
 
-static inline INT pivot(list_t& a, INT i, INT j)
+static inline INT pivot(list_t& list, INT i, INT j)
 {
     INT k = i + 1;
-    while (k <= j && compare1(a[i], a[k]) == 0)
+    while (k <= j && compare1(list[i], list[k]) == 0)
         k++;
     if (k > j)
         return -1;
-    if (compare1(a[i], a[k]) >= 0)
+    if (compare1(list[i], list[k]) >= 0)
         return i;
     return k;
- }
+}
 
-static inline INT partition(list_t& a, INT i, INT j, const CStringW& x)
+static inline INT partition(list_t& list, INT i, INT j, const CStringW& x)
 {
     INT left = i, right = j;
     while (left <= right)
     {
-        while (left <= j && compare1(a[left], x) < 0)
+        while (left <= j && compare1(list[left], x) < 0)
             left++;
-        while (right >= i && compare1(a[right], x) >= 0)
+        while (right >= i && compare1(list[right], x) >= 0)
             right--;
         if (left > right)
             break;
 
-        CStringW tmp = a[left];
-        a[left] = a[right];
-        a[right] = tmp;
+        CStringW tmp = list[left];
+        list[left] = list[right];
+        list[right] = tmp;
 
         left++;
         right--;
@@ -152,16 +151,16 @@ static inline INT partition(list_t& a, INT i, INT j, const CStringW& x)
     return left;
 }
 
-static void quicksort(list_t& a, INT i, INT j)
+static void quicksort(list_t& list, INT i, INT j)
 {
     if (i == j)
         return;
-    INT p = pivot(a, i, j);
+    INT p = pivot(list, i, j);
     if (p == -1)
         return;
-    INT k = partition(a, i, j, a[p]);
-    quicksort(a, i, k - 1);
-    quicksort(a, k, j);
+    INT k = partition(list, i, j, list[p]);
+    quicksort(list, i, k - 1);
+    quicksort(list, k, j);
 }
 
 static inline void DoSort(list_t& list)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -254,23 +254,22 @@ EditWordBreakProcW(LPWSTR lpch, INT index, INT count, INT code)
     {
         case WB_ISDELIMITER:
             return IsWordBreak(lpch[index]);
-
         case WB_LEFT:
+        {
             if (index)
                 --index;
             while (index && !IsWordBreak(lpch[index]))
                 --index;
             return index;
-
+        }
         case WB_RIGHT:
+        {
             if (!count)
                 break;
             while (index < count && lpch[index] && !IsWordBreak(lpch[index]))
                 ++index;
             return index;
-
-        default:
-            break;
+        }
     }
     return 0;
 }
@@ -482,7 +481,7 @@ LRESULT CACListView::OnLButtonDown(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
     if (iItem != -1)
     {
         m_pDropDown->SelectItem(iItem); // select the item
-        CString strText = GetItemText(iItem); // get text of item
+        CStringW strText = GetItemText(iItem); // get text of item
         m_pDropDown->SetEditText(strText); // set text
         m_pDropDown->SetEditSel(0, strText.GetLength()); // select all
         m_pDropDown->HideDropDown(); // hide
@@ -809,7 +808,7 @@ VOID CAutoComplete::DoAutoAppend()
     BOOL bFound = FALSE;
     for (INT iItem = 0; iItem < cItems; ++iItem)
     {
-        const CString& strItem = m_innerList[iItem]; // get the text of the item
+        const CStringW& strItem = m_innerList[iItem]; // get the text of the item
  
         if (::StrCmpNIW(strItem, strText, strText.GetLength()) == 0)
         {
@@ -969,10 +968,6 @@ BOOL CAutoComplete::OnEditKeyDown(WPARAM wParam, LPARAM lParam)
             }
             break;
         }
-        default:
-        {
-            break;
-        }
     }
     return FALSE; // default
 }
@@ -990,7 +985,7 @@ LRESULT CAutoComplete::OnEditChar(WPARAM wParam, LPARAM lParam)
 
 VOID CAutoComplete::OnEditUpdate(BOOL bAppendOK)
 {
-    CString strText = GetEditText();
+    CStringW strText = GetEditText();
     if (m_strText.CompareNoCase(strText) == 0)
     {
         // no change

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -79,8 +79,7 @@ class CACScrollBar : public CWindowImpl<CACScrollBar>
 public:
     CAutoComplete* m_pDropDown;
     static LPCWSTR GetWndClassName() { return WC_SCROLLBARW; }
-
-    CACScrollBar();
+    CACScrollBar() : m_pDropDown(NULL) { }
     HWND Create(HWND hwndParent);
 
 protected:
@@ -97,8 +96,7 @@ class CACSizeBox : public CWindowImpl<CACSizeBox>
 public:
     CAutoComplete* m_pDropDown;
     static LPCWSTR GetWndClassName() { return WC_SCROLLBARW; }
-
-    CACSizeBox();
+    CACSizeBox() : m_pDropDown(NULL), m_bDowner(TRUE), m_bLongList(FALSE) { }
     HWND Create(HWND hwndParent);
     VOID SetStatus(BOOL bDowner, BOOL bLongList);
 

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -40,7 +40,7 @@ public:
     CAutoComplete* m_pDropDown;
     static LPCWSTR GetWndClassName() { return WC_EDITW; }
 
-    CACEditCtrl();
+    CACEditCtrl(CAutoComplete *pDropDown);
     VOID HookWordBreakProc(BOOL bHook);
 
     // message map
@@ -48,7 +48,7 @@ public:
         MESSAGE_HANDLER(WM_CHAR, OnChar)
         MESSAGE_HANDLER(WM_CLEAR, OnCutPasteClear)
         MESSAGE_HANDLER(WM_CUT, OnCutPasteClear)
-        MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
+        MESSAGE_HANDLER(WM_NCDESTROY, OnNCDestroy)
         MESSAGE_HANDLER(WM_GETDLGCODE, OnGetDlgCode)
         MESSAGE_HANDLER(WM_KEYDOWN, OnKeyDown)
         MESSAGE_HANDLER(WM_KILLFOCUS, OnKillFocus)
@@ -63,7 +63,7 @@ protected:
     // message handlers
     LRESULT OnChar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnCutPasteClear(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnGetDlgCode(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnKeyDown(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnKillFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
@@ -233,12 +233,12 @@ protected:
     HWND m_hwndCombo; // the combobox if any
     HFONT m_hFont; // the font
     BOOL m_bResized; // re-sized by size-box?
+    CACEditCtrl *m_phwndEdit; // subclassed to watch
     RECT m_rcEdit; // in screen coordinates, to watch the position
     // The following variables are non-POD:
     CStringW m_strText; // internal text (used in selecting item and reverting text)
     CStringW m_strStemText; // dirname + '\\'
     CStringW m_strQuickComplete; // used for [Ctrl]+[Enter]
-    CACEditCtrl m_hwndEdit; // subclassed to watch
     CACListView m_hwndList; // this listview is virtual
     CACScrollBar m_hwndScrollBar; // scroll bar contol
     CACSizeBox m_hwndSizeBox; // the size grip
@@ -259,7 +259,7 @@ protected:
     // message map
     BEGIN_MSG_MAP(CAutoComplete)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)
-        MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
+        MESSAGE_HANDLER(WM_NCDESTROY, OnNCDestroy)
         MESSAGE_HANDLER(WM_DRAWITEM, OnDrawItem)
         MESSAGE_HANDLER(WM_EXITSIZEMOVE, OnExitSizeMove)
         MESSAGE_HANDLER(WM_GETMINMAXINFO, OnGetMinMaxInfo)
@@ -276,7 +276,7 @@ protected:
     END_MSG_MAP()
     // message handlers
     LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+    LRESULT OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnDrawItem(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnExitSizeMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
     LRESULT OnGetMinMaxInfo(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -218,7 +218,6 @@ protected:
     INT UpdateInnerList();
     INT UpdateOuterList();
     VOID UpdateCompletion(BOOL bAppendOK);
-    VOID HookWordBreakProc(BOOL bHook);
     // message map
     BEGIN_MSG_MAP(CAutoComplete)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -195,6 +195,7 @@ protected:
     BOOL m_bResized; // re-sized by size-box?
     RECT m_rcEdit; // in screen coordinates, to watch the position
     HWND m_hwndEdit; // the textbox
+    WNDPROC m_fnOldEditProc; // old textbox procedure
     EDITWORDBREAKPROCW m_fnOldWordBreakProc;
     // The following variables are non-POD:
     CStringW m_strText; // internal text (used in selecting item and reverting text)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -24,52 +24,10 @@
 #include "atltypes.h"
 #include "rosctrls.h"
 
-class CACEditCtrl;
 class CACListView;
 class CACScrollBar;
 class CACSizeBox;
 class CAutoComplete;
-
-//////////////////////////////////////////////////////////////////////////////
-// CACEditCtrl --- auto-completion textbox
-
-class CACEditCtrl
-    : public CWindowImpl<CACEditCtrl, CWindow, CControlWinTraits>
-{
-public:
-    CAutoComplete* m_pDropDown;
-    static LPCWSTR GetWndClassName() { return WC_EDITW; }
-
-    CACEditCtrl(CAutoComplete *pDropDown);
-    VOID HookWordBreakProc(BOOL bHook);
-
-    // message map
-    BEGIN_MSG_MAP(CACEditCtrl)
-        MESSAGE_HANDLER(WM_CHAR, OnChar)
-        MESSAGE_HANDLER(WM_CLEAR, OnCutPasteClear)
-        MESSAGE_HANDLER(WM_CUT, OnCutPasteClear)
-        MESSAGE_HANDLER(WM_NCDESTROY, OnNCDestroy)
-        MESSAGE_HANDLER(WM_GETDLGCODE, OnGetDlgCode)
-        MESSAGE_HANDLER(WM_KEYDOWN, OnKeyDown)
-        MESSAGE_HANDLER(WM_KILLFOCUS, OnKillFocus)
-        MESSAGE_HANDLER(WM_PASTE, OnCutPasteClear)
-        MESSAGE_HANDLER(WM_SETFOCUS, OnSetFocus)
-        MESSAGE_HANDLER(WM_SETTEXT, OnSetText)
-    END_MSG_MAP()
-
-protected:
-    // protected variables
-    EDITWORDBREAKPROCW m_fnOldWordBreakProc;
-    // message handlers
-    LRESULT OnChar(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnCutPasteClear(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnNCDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnGetDlgCode(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnKeyDown(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnKillFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnSetFocus(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-    LRESULT OnSetText(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-};
 
 //////////////////////////////////////////////////////////////////////////////
 // CACListView --- auto-completion list control
@@ -204,6 +162,7 @@ public:
     VOID DoBackWord();
     VOID UpdateScrollBar();
 
+    LRESULT EditWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
     LRESULT OnEditChar(WPARAM wParam, LPARAM lParam);
     BOOL OnEditKeyDown(WPARAM wParam, LPARAM lParam);
     VOID OnEditUpdate(BOOL bAppendOK);
@@ -234,8 +193,9 @@ protected:
     HWND m_hwndCombo; // the combobox if any
     HFONT m_hFont; // the font
     BOOL m_bResized; // re-sized by size-box?
-    CACEditCtrl *m_phwndEdit; // subclassed to watch
     RECT m_rcEdit; // in screen coordinates, to watch the position
+    HWND m_hwndEdit; // the textbox
+    EDITWORDBREAKPROCW m_fnOldWordBreakProc;
     // The following variables are non-POD:
     CStringW m_strText; // internal text (used in selecting item and reverting text)
     CStringW m_strStemText; // dirname + '\\'
@@ -257,6 +217,7 @@ protected:
     INT UpdateInnerList();
     INT UpdateOuterList();
     VOID UpdateCompletion(BOOL bAppendOK);
+    VOID HookWordBreakProc(BOOL bHook);
     // message map
     BEGIN_MSG_MAP(CAutoComplete)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -188,6 +188,7 @@ public:
     BOOL CanAutoAppend();
     BOOL UseTab();
     BOOL IsComboBoxDropped();
+    BOOL FilterPrefixes();
     INT GetItemCount();
     CStringW GetItemText(INT iItem);
 


### PR DESCRIPTION
## Purpose

Fix and improve Auto-Append of auto-completion.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Implement `CAutoComplete::DoAutoAppend` method.
- Use `SetWindowSubclass` rather than `SubclassWindow`.
- Add `compare1` function to compare two items, and use it.
- Delete `CACEditCtrl` class and add `CAutoComplete::EditWndProc` method.
- Add `DropPrefix` function to handle the prefixes.
- Add `CAutoComplete::FilterPrefixes` method.

## Comparison

I used the test program of CORE-9281 `test.rar`.

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/112460099-e53a8200-8da1-11eb-8aba-951be3c6e13a.png)
![win2k3-2](https://user-images.githubusercontent.com/2107452/112460095-e4095500-8da1-11eb-8cab-6f4cc70a5e2b.png)
Correctly working.
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/112461143-0059c180-8da3-11eb-8298-2e51c163fecb.png)
It is not working.
AFTER:
![after2](https://user-images.githubusercontent.com/2107452/112420915-688faf80-8d71-11eb-9dbb-5c556771e5d5.png)
![after](https://user-images.githubusercontent.com/2107452/112419545-f28a4900-8d6e-11eb-9d0e-73eb431a5e6f.png)
AutoAppend is working well.

## TODO

- [x] AutoSuggest.
- [x] AutoAppend.
- [x] `shell32_winetest.exe autocomplete`.
- [x] Ctrl+Back.
- [x] Keyboard.
- [x] Mouse.