### PR TITLE
[NTOS:SE] Implement anonymous logon token impersonation

### DIFF
--- a/boot/bootdata/hivesys.inf
+++ b/boot/bootdata/hivesys.inf
@@ -894,6 +894,7 @@ HKLM,"SYSTEM\CurrentControlSet\Control\Keyboard Layout\DosKeybIDs","00020408",2,
 
 ; Lsa
 HKLM,"SYSTEM\CurrentControlSet\Control\Lsa","Authentication Packages",0x00010000,"msv1_0"
+HKLM,"SYSTEM\CurrentControlSet\Control\Lsa","EveryoneIncludesAnonymous",0x00010001,0
 HKLM,"SYSTEM\CurrentControlSet\Control\Lsa\FipsAlgorithmPolicy","Enabled",0x00010001,0
 
 ; Network

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -18,6 +18,7 @@ list(APPEND SOURCE
     NtDeleteKey.c
     NtDuplicateObject.c
     NtFreeVirtualMemory.c
+    NtImpersonateAnonymousToken.c
     NtLoadUnloadKey.c
     NtMapViewOfSection.c
     NtMutant.c

--- a/modules/rostests/apitests/ntdll/NtImpersonateAnonymousToken.c
+++ b/modules/rostests/apitests/ntdll/NtImpersonateAnonymousToken.c
@@ -1,0 +1,112 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtImpersonateAnonymousToken API
+ * COPYRIGHT:       Copyright 2021 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+#include <winreg.h>
+
+#define TOKEN_WITH_EVERYONE_GROUP    1
+#define TOKEN_WITHOUT_EVERYONE_GROUP 0
+
+static
+HANDLE
+GetThreadFromCurrentProcess(_In_ DWORD DesiredAccess)
+{
+    HANDLE Thread;
+
+    Thread = OpenThread(DesiredAccess, FALSE, GetCurrentThreadId());
+    if (!Thread)
+    {
+        skip("OpenThread() has failed to open the current process' thread (error code: %lu)\n", GetLastError());
+        return NULL;
+    }
+
+    return Thread;
+}
+
+static
+VOID
+ImpersonateTokenWithEveryoneOrWithout(_In_ DWORD Value)
+{
+    LONG Result;
+    HKEY Key;
+
+    Result = RegOpenKeyExW(HKEY_LOCAL_MACHINE,
+                           L"SYSTEM\\CurrentControlSet\\Control\\Lsa",
+                           0,
+                           KEY_SET_VALUE,
+                           &Key);
+    if (Result != ERROR_SUCCESS)
+    {
+        skip("RegOpenKeyExW() has failed to open the key (error code: %li)\n", Result);
+        return;
+    }
+
+    Result = RegSetValueExW(Key,
+                            L"EveryoneIncludesAnonymous",
+                            0,
+                            REG_DWORD,
+                            (PBYTE)&Value,
+                            sizeof(Value));
+    if (Result != ERROR_SUCCESS)
+    {
+        skip("RegSetValueExW() has failed to set the value (error code: %li)\n", Result);
+        RegCloseKey(Key);
+        return;
+    }
+
+    RegCloseKey(Key);
+}
+
+START_TEST(NtImpersonateAnonymousToken)
+{
+    NTSTATUS Status;
+    BOOL Success;
+    HANDLE ThreadHandle;
+
+    ThreadHandle = GetThreadFromCurrentProcess(THREAD_IMPERSONATE);
+
+    /* We give an invalid thread handle */
+    Status = NtImpersonateAnonymousToken(NULL);
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* We want to impersonate the token including Everyone Group SID */
+    ImpersonateTokenWithEveryoneOrWithout(TOKEN_WITH_EVERYONE_GROUP);
+
+    /* Impersonate the anonymous logon token */
+    Status = NtImpersonateAnonymousToken(ThreadHandle);
+    ok_hex(Status, STATUS_SUCCESS);
+
+    /* Now revert to the previous security properties */
+    Success = RevertToSelf();
+    ok(Success == TRUE, "We should have terminated the impersonation but we couldn't (error code: %lu)\n", GetLastError());
+
+    /* Return to default setting -- token without Everyone Group SID */
+    ImpersonateTokenWithEveryoneOrWithout(TOKEN_WITHOUT_EVERYONE_GROUP);
+
+    /* Impersonate the anonymous logon token again */
+    Status = NtImpersonateAnonymousToken(ThreadHandle);
+    ok_hex(Status, STATUS_SUCCESS);
+
+    /* Now revert to the previous security properties */
+    Success = RevertToSelf();
+    ok(Success == TRUE, "We should have terminated the impersonation but we couldn't (error code: %lu)\n", GetLastError());
+
+    /*
+     * Invalidate the handle and open a new one. This time
+     * with the wrong access right mask, the function will
+     * outright fail on impersonating the token.
+     */
+    CloseHandle(ThreadHandle);
+    ThreadHandle = GetThreadFromCurrentProcess(SYNCHRONIZE);
+
+    /* The thread handle has incorrect right access */
+    Status = NtImpersonateAnonymousToken(ThreadHandle);
+    ok_hex(Status, STATUS_ACCESS_DENIED);
+
+    /* We're done with the tests */
+    CloseHandle(ThreadHandle);
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -16,6 +16,7 @@ extern void func_NtCreateThread(void);
 extern void func_NtDeleteKey(void);
 extern void func_NtDuplicateObject(void);
 extern void func_NtFreeVirtualMemory(void);
+extern void func_NtImpersonateAnonymousToken(void);
 extern void func_NtLoadUnloadKey(void);
 extern void func_NtMapViewOfSection(void);
 extern void func_NtMutant(void);
@@ -93,6 +94,7 @@ const struct test winetest_testlist[] =
     { "NtDeleteKey",                    func_NtDeleteKey },
     { "NtDuplicateObject",              func_NtDuplicateObject },
     { "NtFreeVirtualMemory",            func_NtFreeVirtualMemory },
+    { "NtImpersonateAnonymousToken",    func_NtImpersonateAnonymousToken },
     { "NtLoadUnloadKey",                func_NtLoadUnloadKey },
     { "NtMapViewOfSection",             func_NtMapViewOfSection },
     { "NtMutant",                       func_NtMutant },

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -573,6 +573,15 @@ SeCopyClientToken(
     OUT PACCESS_TOKEN* NewToken
 );
 
+NTSTATUS
+NTAPI
+SepRegQueryHelper(
+    _In_ PCWSTR KeyName,
+    _In_ PCWSTR ValueName,
+    _In_ ULONG ValueType,
+    _In_ ULONG DataLength,
+    _Out_ PVOID ValueData);
+
 VOID NTAPI
 SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
                           OUT PACCESS_MASK DesiredAccess);

--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -74,14 +74,38 @@ PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION SepLogonNotifications = NULL;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+/**
+ * @brief
+ * A private registry helper that returns the desired value
+ * data based on the specifics requested by the caller.
+ *
+ * @param[in] KeyName
+ * Name of the key.
+ *
+ * @param[in] ValueName
+ * Name of the registry value.
+ *
+ * @param[in] ValueType
+ * The type of the registry value.
+ *
+ * @param[in] DataLength
+ * The data length, in bytes, representing the size of the registry value.
+ *
+ * @param[out] ValueData
+ * The requested value data provided by the function.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the operations have completed successfully,
+ * otherwise a failure NTSTATUS code is returned.
+ */
 NTSTATUS
 NTAPI
 SepRegQueryHelper(
-    PCWSTR KeyName,
-    PCWSTR ValueName,
-    ULONG ValueType,
-    ULONG DataLength,
-    PVOID ValueData)
+    _In_ PCWSTR KeyName,
+    _In_ PCWSTR ValueName,
+    _In_ ULONG ValueType,
+    _In_ ULONG DataLength,
+    _Out_ PVOID ValueData)
 {
     UNICODE_STRING ValueNameString;
     UNICODE_STRING KeyNameString;
@@ -127,7 +151,6 @@ SepRegQueryHelper(
         Status = STATUS_OBJECT_TYPE_MISMATCH;
         goto Cleanup;
     }
-
 
     if (ValueType == REG_BINARY)
     {

--- a/sdk/include/ndk/sefuncs.h
+++ b/sdk/include/ndk/sefuncs.h
@@ -239,7 +239,7 @@ NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtImpersonateAnonymousToken(
-    _In_ HANDLE Thread
+    _In_ HANDLE ThreadHandle
 );
 
 __kernel_entry


### PR DESCRIPTION
This implements the `NtImpersonateAnonymousToken` system call function, so that we can finally impersonate the logon token whether by calling the system call or `ImpersonateAnonymousToken` user mode service from ADVAPI32 library.
## Proposed Changes
* Add `EveryoneIncludesAnonymous` registry value to Lsa (Local Security Authority) registry key
* Add the prototype of `SepRegQueryHelper` to the internal kernel header, making it public for other kernel code to use, and also annotate its parameters and include a documentation header
* Implement `SepImpersonateAnonymousToken`