### PR TITLE
[IPHLPAPI] GetAdaptersInfo(): Update Wine registry key name

### DIFF
--- a/dll/win32/iphlpapi/iphlpapi_main.c
+++ b/dll/win32/iphlpapi/iphlpapi_main.c
@@ -808,9 +808,8 @@ DWORD WINAPI GetAdaptersInfo(PIP_ADAPTER_INFO pAdapterInfo, PULONG pOutBufLen)
             IP_ADDRESS_STRING primaryWINS, secondaryWINS;
 
             memset(pAdapterInfo, 0, size);
-            if (RegOpenKeyExA(HKEY_LOCAL_MACHINE,
-             "Software\\Wine\\Wine\\Config\\Network", 0, KEY_READ,
-             &hKey) == ERROR_SUCCESS) {
+            /* @@ Wine registry key: HKCU\Software\Wine\Network */
+            if (RegOpenKeyA(HKEY_CURRENT_USER, "Software\\Wine\\Network", &hKey) == ERROR_SUCCESS) {
               DWORD size = sizeof(primaryWINS.String);
               unsigned long addr;
 

--- a/dll/win32/iphlpapi/merge-notes.txt
+++ b/dll/win32/iphlpapi/merge-notes.txt
@@ -1,5 +1,5 @@
 GetAdaptersInfo --
-Wine uses: Software\\Wine\\Wine\\Config\\Network
+Wine uses: HKEY_CURRENT_USER, "Software\\Wine\\Network"
      -- Wins support is todo so this part isn't so important.
      -- Overall, workable
 Wine uses ansi functions


### PR DESCRIPTION
WineSync missed part of
https://source.winehq.org/git/wine.git/commit/629352bdc4683a5059f6d9c735df6930b1ea30c3

JIRA issue: [CORE-8454](https://jira.reactos.org/browse/CORE-8454)