### PR TITLE
[UNIATA] DriverEntry(): Fix 'Paramaters' typo, in reg key names

### DIFF
--- a/base/applications/utilman/umandlg/umandlg.c
+++ b/base/applications/utilman/umandlg/umandlg.c
@@ -283,7 +283,7 @@ INT ListBoxRefreshContents(VOID)
  *     Message parameter (in UINT_PTR).
  *
  * @param[in]   lParam
- *     Message paramater (in LONG_PTR).
+ *     Message parameter (in LONG_PTR).
  *
  * @return
  *     Returns 0 to inform the system that the procedure has been handled.

--- a/base/shell/cmd/lang/de-DE.rc
+++ b/base/shell/cmd/lang/de-DE.rc
@@ -350,7 +350,7 @@ REPLACE [Laufwerk1:][Pfad1]Dateiname [Laufwerk2:][Pfad2] [/P] [/R] [/S] [/W] [/U
   /W                           Wartet vor dem Start, bis ein Datenträger\n\
                                eingelegt wurde.\n\
   /U                           Ersetzt (aktualisiert) nur Dateien, die älter\n\
-                               sind als die Quelldaten. Kann nicht mit Paramater\n\
+                               sind als die Quelldaten. Kann nicht mit Parameter\n\
                                /A genutzt werden\n"
     STRING_REPLACE_HELP2 "Quellpfad benötigt\n"
     STRING_REPLACE_HELP3 "Keine Dateien ersetzt\n"

--- a/drivers/storage/ide/uniata/id_ata.cpp
+++ b/drivers/storage/ide/uniata/id_ata.cpp
@@ -10754,11 +10754,19 @@ DriverEntry(
     }
 
     if(WinVer_Id() >= WinVer_2k) {
+#ifndef __REACTOS__
         if(AtapiRegCheckParameterValue(NULL, L"Paramaters\\PnpInterface", L"1", 0)) {
+#else
+        if(AtapiRegCheckParameterValue(NULL, L"Parameters\\PnpInterface", L"1", 0)) {
+#endif
             KdPrint(("UniATA: Behave as WDM, mlia (1)\n"));
             WinVer_WDM_Model = TRUE;
         }
+#ifndef __REACTOS__
         if(AtapiRegCheckParameterValue(NULL, L"Paramaters\\PnpInterface", L"5", 0)) {
+#else
+        if(AtapiRegCheckParameterValue(NULL, L"Parameters\\PnpInterface", L"5", 0)) {
+#endif
             KdPrint(("UniATA: Behave as WDM, mlia (5)\n"));
             WinVer_WDM_Model = TRUE;
         }


### PR DESCRIPTION
Read the expected/actual keys, otherwise results are always nonexistent/false.

JIRA issue: [CORE-17524](https://jira.reactos.org/browse/CORE-17524)

While here, fix typo elsewhere too.