### PR TITLE
[COMDLG32] Enable auto-completion on comdlg32

### DIFF
--- a/dll/win32/comdlg32/CMakeLists.txt
+++ b/dll/win32/comdlg32/CMakeLists.txt
@@ -7,6 +7,7 @@ include_directories(BEFORE ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 spec2def(comdlg32.dll comdlg32.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
+    autocomp.cpp
     cdlg32.c
     colordlg.c
     filedlg.c

--- a/dll/win32/comdlg32/autocomp.cpp
+++ b/dll/win32/comdlg32/autocomp.cpp
@@ -22,10 +22,9 @@ DoInitAutoCompleteWithCWD2(FileOpenDlgInfos *pInfo, HWND hwndEdit)
         return hr;
     }
     pACList->AddRef();
-    pInfo->pvACList = static_cast<void *>(pACList);
+    pInfo->pvACList = static_cast<LPVOID>(pACList);
 
     IAutoComplete2 *pAC = NULL;
-    pInfo->pvDropDown = NULL;
     hr = CoCreateInstance(CLSID_AutoComplete, NULL, CLSCTX_INPROC_SERVER,
                           IID_IAutoComplete2, reinterpret_cast<LPVOID *>(&pAC));
     if (SUCCEEDED(hr))
@@ -69,16 +68,16 @@ EXTERN_C HRESULT
 DoUpdateAutoCompleteWithCWD(const FileOpenDlgInfos *info, LPCITEMIDLIST pidl)
 {
     FileOpenDlgInfos *pInfo = const_cast<FileOpenDlgInfos*>(info);
-    if (!pInfo || !pInfo->pvCWD)
+    if (!pInfo)
         return E_POINTER;
 
-    ICurrentWorkingDirectory* pCWD;
-    pCWD = reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
+    ICurrentWorkingDirectory* pCWD =
+        reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
 
-    IAutoCompleteDropDown* pDropDown;
-    pDropDown = reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
+    IAutoCompleteDropDown* pDropDown =
+        reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
 
-    IACList2 *pACList = static_cast<IACList2*>(pInfo->pvACList);
+    IACList2* pACList = static_cast<IACList2*>(pInfo->pvACList);
 
     WCHAR szPath[MAX_PATH];
     if (!pidl || !SHGetPathFromIDListW(pidl, szPath))
@@ -102,13 +101,13 @@ DoReleaseAutoCompleteWithCWD(FileOpenDlgInfos *pInfo)
     if (!pInfo)
         return E_POINTER;
 
-    ICurrentWorkingDirectory* pCWD;
-    pCWD = reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
+    ICurrentWorkingDirectory* pCWD =
+        reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
     if (pCWD)
         pCWD->Release();
 
-    IAutoCompleteDropDown* pDropDown;
-    pDropDown = reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
+    IAutoCompleteDropDown* pDropDown =
+        reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
     if (pDropDown)
         pDropDown->Release();
 
@@ -116,9 +115,6 @@ DoReleaseAutoCompleteWithCWD(FileOpenDlgInfos *pInfo)
     if (pACList)
         pACList->Release();
 
-    pInfo->pvCWD = NULL;
-    pInfo->pvDropDown = NULL;
-    pInfo->pvACList = NULL;
-
+    pInfo->pvCWD = pInfo->pvDropDown = pInfo->pvACList = NULL;
     return S_OK;
 }

--- a/dll/win32/comdlg32/autocomp.cpp
+++ b/dll/win32/comdlg32/autocomp.cpp
@@ -38,6 +38,7 @@ DoInitAutoCompleteWithCWD2(FileOpenDlgInfos *pInfo, HWND hwndEdit)
     {
         TRACE("CoCreateInstance(CLSID_AutoComplete): 0x%08lX\n", hr);
         pACList->Release();
+        pInfo->pvACList = NULL;
         return hr;
     }
 

--- a/dll/win32/comdlg32/autocomp.cpp
+++ b/dll/win32/comdlg32/autocomp.cpp
@@ -21,7 +21,6 @@ DoInitAutoCompleteWithCWD2(FileOpenDlgInfos *pInfo, HWND hwndEdit)
         TRACE("CoCreateInstance(CLSID_ACListISF): 0x%08lX\n", hr);
         return hr;
     }
-    pACList->AddRef();
     pInfo->pvACList = static_cast<LPVOID>(pACList);
 
     IAutoComplete2 *pAC = NULL;

--- a/dll/win32/comdlg32/autocomp.cpp
+++ b/dll/win32/comdlg32/autocomp.cpp
@@ -1,0 +1,124 @@
+/*
+ * PROJECT:     ReactOS Common Dialogs
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Implement auto-completion for comdlg32
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+#include "precomp.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(commdlg);
+
+static HRESULT
+DoInitAutoCompleteWithCWD2(FileOpenDlgInfos *pInfo, HWND hwndEdit)
+{
+    pInfo->pvCWD = pInfo->pvDropDown = pInfo->pvACList = NULL;
+
+    IACList2 *pACList = NULL;
+    HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_INPROC_SERVER,
+                                  IID_IACList2, reinterpret_cast<LPVOID *>(&pACList));
+    if (FAILED(hr))
+    {
+        TRACE("CoCreateInstance(CLSID_ACListISF): 0x%08lX\n", hr);
+        return hr;
+    }
+    pACList->AddRef();
+    pInfo->pvACList = static_cast<void *>(pACList);
+
+    IAutoComplete2 *pAC = NULL;
+    pInfo->pvDropDown = NULL;
+    hr = CoCreateInstance(CLSID_AutoComplete, NULL, CLSCTX_INPROC_SERVER,
+                          IID_IAutoComplete2, reinterpret_cast<LPVOID *>(&pAC));
+    if (SUCCEEDED(hr))
+    {
+        pAC->Init(hwndEdit, pACList, NULL, NULL);
+        pAC->SetOptions(ACO_AUTOSUGGEST);
+        pAC->QueryInterface(IID_IAutoCompleteDropDown, &pInfo->pvDropDown);
+        pAC->Release();
+    }
+    else
+    {
+        TRACE("CoCreateInstance(CLSID_AutoComplete): 0x%08lX\n", hr);
+        pACList->Release();
+        return hr;
+    }
+
+    pACList->QueryInterface(IID_ICurrentWorkingDirectory, &pInfo->pvCWD);
+
+    return hr;
+}
+
+EXTERN_C HRESULT
+DoInitAutoCompleteWithCWD(FileOpenDlgInfos *pInfo, HWND hwndEdit)
+{
+    WCHAR szClass[32];
+    GetClassNameW(hwndEdit, szClass, _countof(szClass));
+    if (lstrcmpiW(szClass, WC_COMBOBOXW) == 0)
+    {
+        COMBOBOXINFO info = { sizeof(info) };
+        GetComboBoxInfo(hwndEdit, &info);
+        hwndEdit = info.hwndItem;
+    }
+    else if (lstrcmpiW(szClass, WC_COMBOBOXEXW) == 0)
+    {
+        hwndEdit = (HWND)SendMessageW(hwndEdit, CBEM_GETEDITCONTROL, 0, 0);
+    }
+    return DoInitAutoCompleteWithCWD2(pInfo, hwndEdit);
+}
+
+EXTERN_C HRESULT
+DoUpdateAutoCompleteWithCWD(const FileOpenDlgInfos *info, LPCITEMIDLIST pidl)
+{
+    FileOpenDlgInfos *pInfo = const_cast<FileOpenDlgInfos*>(info);
+    if (!pInfo || !pInfo->pvCWD)
+        return E_POINTER;
+
+    ICurrentWorkingDirectory* pCWD;
+    pCWD = reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
+
+    IAutoCompleteDropDown* pDropDown;
+    pDropDown = reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
+
+    IACList2 *pACList = static_cast<IACList2*>(pInfo->pvACList);
+
+    WCHAR szPath[MAX_PATH];
+    if (!pidl || !SHGetPathFromIDListW(pidl, szPath))
+    {
+        GetCurrentDirectoryW(_countof(szPath), szPath);
+    }
+
+    if (pCWD)
+        pCWD->SetDirectory(szPath);
+    if (pDropDown)
+        pDropDown->ResetEnumerator();
+    if (pACList)
+        pACList->Expand(L"");
+
+    return S_OK;
+}
+
+EXTERN_C HRESULT
+DoReleaseAutoCompleteWithCWD(FileOpenDlgInfos *pInfo)
+{
+    if (!pInfo)
+        return E_POINTER;
+
+    ICurrentWorkingDirectory* pCWD;
+    pCWD = reinterpret_cast<ICurrentWorkingDirectory*>(pInfo->pvCWD);
+    if (pCWD)
+        pCWD->Release();
+
+    IAutoCompleteDropDown* pDropDown;
+    pDropDown = reinterpret_cast<IAutoCompleteDropDown*>(pInfo->pvDropDown);
+    if (pDropDown)
+        pDropDown->Release();
+
+    IACList2 *pACList = static_cast<IACList2*>(pInfo->pvACList);
+    if (pACList)
+        pACList->Release();
+
+    pInfo->pvCWD = NULL;
+    pInfo->pvDropDown = NULL;
+    pInfo->pvACList = NULL;
+
+    return S_OK;
+}

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -1560,6 +1560,7 @@ INT_PTR CALLBACK FileOpenDlgProc95(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM l
               s_hFileDialogHook = NULL;
           }
           LeaveCriticalSection(&COMDLG32_OpenFileLock);
+          DoReleaseAutoCompleteWithCWD(fodInfos);
 #endif
           return FALSE;
       }

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -79,6 +79,8 @@
 #include "wine/heap.h"
 #ifdef __REACTOS__
 #include "wine/unicode.h"
+EXTERN_C HRESULT DoInitAutoCompleteWithCWD(FileOpenDlgInfos *pInfo, HWND hwndEdit);
+EXTERN_C HRESULT DoReleaseAutoCompleteWithCWD(FileOpenDlgInfos *pInfo);
 #endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(commdlg);
@@ -2030,6 +2032,9 @@ static LRESULT FILEDLG95_InitControls(HWND hwnd)
 
   /* Initialize the filter combo box */
   FILEDLG95_FILETYPE_Init(hwnd);
+#ifdef __REACTOS__
+  DoInitAutoCompleteWithCWD(fodInfos, fodInfos->DlgInfos.hwndFileName);
+#endif
 
   return 0;
 }

--- a/dll/win32/comdlg32/filedlgbrowser.c
+++ b/dll/win32/comdlg32/filedlgbrowser.c
@@ -41,6 +41,9 @@
 #include "servprov.h"
 #include "wine/debug.h"
 #include "wine/heap.h"
+#ifdef __REACTOS__
+EXTERN_C HRESULT DoUpdateAutoCompleteWithCWD(const FileOpenDlgInfos *info, LPCITEMIDLIST pidl);
+#endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(commdlg);
 
@@ -143,6 +146,9 @@ static void COMDLG32_UpdateCurrentDir(const FileOpenDlgInfos *fodInfos)
         if (SUCCEEDED(res))
             SetCurrentDirectoryW(wszCurrentDir);
     }
+#ifdef __REACTOS__
+    DoUpdateAutoCompleteWithCWD(fodInfos, fodInfos->ShellInfos.pidlAbsCurrent);
+#endif
     
     IShellFolder_Release(psfDesktop);
 }

--- a/dll/win32/comdlg32/filedlgbrowser.h
+++ b/dll/win32/comdlg32/filedlgbrowser.h
@@ -94,6 +94,11 @@ typedef struct
 
     BOOL ole_initialized;
     LPITEMIDLIST places[5];
+#ifdef __REACTOS__
+    LPVOID pvCWD; /* ICurrentWorkingDirectory */
+    LPVOID pvDropDown; /* IAutoCompleteDropDown */
+    LPVOID pvACList; /* IACList2 */
+#endif
 } FileOpenDlgInfos;
 
 /***********************************************************************


### PR DESCRIPTION
## Purpose
Auto-completion will be enabled when the user opens "Open" or "Save As" dialog of the common dialogs.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `autocomp.cpp` to implement in C++.
- Use `CLSID_ACListISF` and `CLSID_AutoComplete` objects to realize auto-completion.
- Modify `FileOpenDlgInfos` structure.
- Modify `FILEDLG95_InitControls` function and `COMDLG32_UpdateCurrentDir` function and `FileOpenDlgProc95` function.

## Observation

![1](https://user-images.githubusercontent.com/2107452/112940852-b25d0900-9168-11eb-9bb5-9e2341d3c473.png)
![2](https://user-images.githubusercontent.com/2107452/112940849-b1c47280-9168-11eb-838f-9fda825f8c39.png)
It is working.

NOTE: The relative pathes, `"..\"` and `"\"` are not working. Those are bugs in `CLSID_ACListISF`.