### PR TITLE
[WIN32K:NTUSER] Add WindowArrangementActive flag support

### DIFF
--- a/boot/bootdata/hivedef.inf
+++ b/boot/bootdata/hivedef.inf
@@ -82,6 +82,7 @@ HKCU,"Control Panel\Desktop","PowerOffTimeOut",2,"0"
 HKCU,"Control Panel\Desktop","MenuShowDelay",2,"400"
 HKCU,"Control Panel\Desktop","WheelScrollLines",2,"3"
 HKCU,"Control Panel\Desktop","WheelScrollChars",2,"3"
+HKCU,"Control Panel\Desktop","WindowArrangementActive",2,"1"
 
 HKCU,"Control Panel\Desktop\WindowMetrics","AppliedDPI",0x00010003,0x00000060
 HKCU,"Control Panel\Desktop\WindowMetrics","ScrollWidth",2,"16"

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -37,6 +37,7 @@ HDC ScreenDeviceContext = NULL;
 PTHREADINFO gptiDesktopThread = NULL;
 HCURSOR gDesktopCursor = NULL;
 PKEVENT gpDesktopThreadStartedEvent = NULL;
+BOOL g_AllowSnappingWindows = TRUE; // Default ReactOS behaviour is to snap windows
 
 /* OBJECT CALLBACKS **********************************************************/
 
@@ -259,6 +260,16 @@ InitDesktopImpl(VOID)
     KeInitializeEvent(gpDesktopThreadStartedEvent,
                       SynchronizationEvent,
                       FALSE);
+
+    /* Check if user has disabled window snapping */
+    DWORD EntryValue = 0;
+    if (RegReadUserSetting(L"Control Panel\\Desktop",
+                           L"WindowArrangementActive",
+                           REG_SZ, &EntryValue, sizeof(EntryValue)))
+    {
+        EntryValue = atoi((PCHAR)&EntryValue);
+        g_AllowSnappingWindows = EntryValue != 0;
+    }
 
     return STATUS_SUCCESS;
 }

--- a/win32ss/user/ntuser/desktop.h
+++ b/win32ss/user/ntuser/desktop.h
@@ -87,6 +87,7 @@ extern HDC ScreenDeviceContext;
 extern PTHREADINFO gptiForeground;
 extern PTHREADINFO gptiDesktopThread;
 extern PKEVENT gpDesktopThreadStartedEvent;
+extern BOOL g_AllowSnappingWindows;
 
 typedef struct _SHELL_HOOK_WINDOW
 {

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -411,7 +411,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
          TRACE("This %s the TaskBar.\n", IsTaskBar ? "is" : "is not");
 
          // check for snapping if was moved by caption
-         if (hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)
+         if (g_AllowSnappingWindows && hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)
          {
             RECT snapRect;
             BOOL doSideSnap = FALSE;


### PR DESCRIPTION
## Purpose

This PR adds support for disabling window snappiung via WindowArrangementActive in `HKEY_CURRENT_USER\Control Panel\Desktop`

JIRA issue: [CORE-16379](https://jira.reactos.org/browse/CORE-16379)

## Proposed changes

- Add the WindowArrangementActive flag and set it active by default (matches current ReactOS behaviour)
- Add a global and initialize it along with other parameters in `sysparams` (would `ntuser` be a better choice?)
- Check the flag in `nosclient` before performing the snap