### PR TITLE
[NOTEPAD][WORDPAD][MSPAINT]... Use newer file open dialog

### DIFF
--- a/base/applications/clipbrd/clipbrd.c
+++ b/base/applications/clipbrd/clipbrd.c
@@ -32,7 +32,7 @@ static void SaveClipboardToFile(void)
     sfn.lpstrFilter = szFilterMask;
     sfn.lpstrFile = szFileName;
     sfn.nMaxFile = ARRAYSIZE(szFileName);
-    sfn.Flags = OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
+    sfn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
     sfn.lpstrDefExt = L"clp";
 
     if (!GetSaveFileNameW(&sfn))

--- a/base/applications/mmc/console.c
+++ b/base/applications/mmc/console.c
@@ -249,7 +249,7 @@ DoSaveFileAs(
     saveas.lpstrFilter = L"MSC Files\0*.msc\0";
     saveas.lpstrFile = szPath;
     saveas.nMaxFile = MAX_PATH;
-    saveas.Flags = OFN_HIDEREADONLY | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
+    saveas.Flags = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
     saveas.lpstrDefExt = L"msc";
 
     if (GetSaveFileName(&saveas))

--- a/base/applications/mplay32/mplay32.c
+++ b/base/applications/mplay32/mplay32.c
@@ -1158,7 +1158,7 @@ OpenFileDialog(HWND hwnd, DWORD dwFilterIndex, LPTSTR lpType)
     OpenFileName.lpstrFilter     = szFilter;
     OpenFileName.lpstrFile       = szFile;
     OpenFileName.nMaxFile        = ARRAYSIZE(szFile);
-    OpenFileName.Flags           = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_SHAREAWARE;
+    OpenFileName.Flags           = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_SHAREAWARE;
     OpenFileName.lpstrDefExt     = _T("\0");
     OpenFileName.nFilterIndex = dwFilterIndex;
 

--- a/base/applications/mscutils/eventvwr/eventvwr.c
+++ b/base/applications/mscutils/eventvwr/eventvwr.c
@@ -3268,7 +3268,7 @@ InitInstance(HINSTANCE hInstance)
     sfn.hInstance       = hInstance;
     sfn.lpstrFilter     = szSaveFilter;
     sfn.lpstrInitialDir = NULL;
-    sfn.Flags           = OFN_HIDEREADONLY | OFN_SHAREAWARE;
+    sfn.Flags           = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_SHAREAWARE;
     sfn.lpstrDefExt     = NULL;
 
     ShowWindow(hwndMainWindow, Settings.wpPos.showCmd);

--- a/base/applications/mscutils/servman/propsheet_recovery.c
+++ b/base/applications/mscutils/servman/propsheet_recovery.c
@@ -351,7 +351,7 @@ BrowseFile(
     ZeroMemory(&ofn, sizeof(ofn));
 
     ofn.lStructSize = sizeof(ofn);
-    ofn.Flags = OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING;
+    ofn.Flags = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING;
     ofn.hwndOwner = hwndDlg;
     ofn.lpstrFilter = pszFilter;
     ofn.lpstrFile = szFile;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -282,7 +282,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     ofn.nMaxFile       = SIZEOF(ofnFilename);
     ofn.lpstrFileTitle = ofnFiletitle;
     ofn.nMaxFileTitle  = SIZEOF(ofnFiletitle);
-    ofn.Flags          = OFN_HIDEREADONLY;
+    ofn.Flags          = OFN_EXPLORER | OFN_HIDEREADONLY;
     ofn.lpstrDefExt    = L"bmp";
 
     CopyMemory(sfnFilename, filepathname, sizeof(filepathname));
@@ -298,7 +298,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     sfn.nMaxFile       = SIZEOF(sfnFilename);
     sfn.lpstrFileTitle = sfnFiletitle;
     sfn.nMaxFileTitle  = SIZEOF(sfnFiletitle);
-    sfn.Flags          = OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLEHOOK;
+    sfn.Flags          = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLEHOOK;
     sfn.lpfnHook       = OFNHookProc;
     sfn.lpstrDefExt    = L"bmp";
 

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -440,7 +440,7 @@ VOID DIALOG_FileOpen(VOID)
     openfilename.lpstrFilter = Globals.szFilter;
     openfilename.lpstrFile = szPath;
     openfilename.nMaxFile = ARRAY_SIZE(szPath);
-    openfilename.Flags = OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+    openfilename.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
     openfilename.lpstrDefExt = szDefaultExt;
 
     if (GetOpenFileName(&openfilename)) {

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -288,7 +288,7 @@ static BOOL InitOpenFileName(HWND hWnd, OPENFILENAME* pofn)
     pofn->nMaxFile = _MAX_PATH;
     pofn->lpstrFileTitle = FileTitleBuffer;
     pofn->nMaxFileTitle = _MAX_PATH;
-    pofn->Flags = OFN_HIDEREADONLY;
+    pofn->Flags = OFN_EXPLORER | OFN_HIDEREADONLY;
     pofn->lpstrDefExt = L"reg";
     return TRUE;
 }

--- a/base/applications/winhlp32/winhelp.c
+++ b/base/applications/winhlp32/winhelp.c
@@ -178,7 +178,7 @@ BOOL WINHELP_GetOpenFileName(LPSTR lpszFile, int len)
     openfilename.nMaxFileTitle     = 0;
     openfilename.lpstrInitialDir   = szDir;
     openfilename.lpstrTitle        = 0;
-    openfilename.Flags             = OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_READONLY;
+    openfilename.Flags             = OFN_EXPLORER | OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_READONLY;
     openfilename.nFileOffset       = 0;
     openfilename.nFileExtension    = 0;
     openfilename.lpstrDefExt       = 0;

--- a/base/applications/wordpad/print.c
+++ b/base/applications/wordpad/print.c
@@ -253,7 +253,7 @@ static LPWSTR dialog_print_to_file(HWND hMainWnd)
     ZeroMemory(&ofn, sizeof(ofn));
 
     ofn.lStructSize = sizeof(ofn);
-    ofn.Flags = OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
+    ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY | OFN_OVERWRITEPROMPT;
     ofn.hwndOwner = hMainWnd;
     ofn.lpstrFilter = file_filter;
     ofn.lpstrFile = file;

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -905,7 +905,7 @@ static BOOL DialogSaveFile(void)
     ZeroMemory(&sfn, sizeof(sfn));
 
     sfn.lStructSize = sizeof(sfn);
-    sfn.Flags = OFN_HIDEREADONLY | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_ENABLESIZING;
+    sfn.Flags = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_ENABLESIZING;
     sfn.hwndOwner = hMainWnd;
     sfn.lpstrFilter = wszFilter;
     sfn.lpstrFile = wszFile;
@@ -989,7 +989,7 @@ static void DialogOpenFile(void)
     ZeroMemory(&ofn, sizeof(ofn));
 
     ofn.lStructSize = sizeof(ofn);
-    ofn.Flags = OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING;
+    ofn.Flags = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_ENABLESIZING;
     ofn.hwndOwner = hMainWnd;
     ofn.lpstrFilter = wszFilter;
     ofn.lpstrFile = wszFile;

--- a/base/shell/progman/dialog.c
+++ b/base/shell/progman/dialog.c
@@ -69,7 +69,7 @@ DIALOG_Browse(HWND hWnd, LPCWSTR lpszzFilter, LPWSTR lpstrFile, INT nMaxFile)
     openfilename.lpstrFile         = lpstrFile;
     openfilename.nMaxFile          = nMaxFile;
     openfilename.lpstrInitialDir   = szDir;
-    openfilename.Flags             = 0;
+    openfilename.Flags             = OFN_EXPLORER;
     openfilename.lpstrDefExt       = L"exe";
     openfilename.lpstrCustomFilter = NULL;
     openfilename.nMaxCustFilter    = 0;

--- a/dll/shellext/shellbtrfs/recv.cpp
+++ b/dll/shellext/shellbtrfs/recv.cpp
@@ -1700,7 +1700,7 @@ void CALLBACK RecvSubvolGUIW(HWND hwnd, HINSTANCE hinst, LPWSTR lpszCmdLine, int
         ofn.hInstance = module;
         ofn.lpstrFile = file;
         ofn.nMaxFile = sizeof(file) / sizeof(WCHAR);
-        ofn.Flags = OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
+        ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 
         if (GetOpenFileNameW(&ofn)) {
             BtrfsRecv recv;

--- a/dll/shellext/shellbtrfs/send.cpp
+++ b/dll/shellext/shellbtrfs/send.cpp
@@ -303,6 +303,7 @@ void BtrfsSend::Browse(HWND hwnd) {
     ofn.hInstance = module;
     ofn.lpstrFile = file;
     ofn.nMaxFile = sizeof(file) / sizeof(WCHAR);
+    ofn.Flags = OFN_EXPLORER;
 
     if (!GetSaveFileNameW(&ofn))
         return;

--- a/dll/win32/cryptui/main.c
+++ b/dll/win32/cryptui/main.c
@@ -5114,6 +5114,9 @@ static LRESULT CALLBACK import_file_dlg_proc(HWND hwnd, UINT msg, WPARAM wp,
             ofn.lpstrFilter = make_import_file_filter(data->dwFlags);
             ofn.lpstrFile = fileBuf;
             ofn.nMaxFile = ARRAY_SIZE(fileBuf);
+#ifdef __REACTOS__
+            ofn.Flags = OFN_EXPLORER;
+#endif
             fileBuf[0] = 0;
             if (GetOpenFileNameW(&ofn))
                 SendMessageW(GetDlgItem(hwnd, IDC_IMPORT_FILENAME), WM_SETTEXT,

--- a/dll/win32/setupapi/dialog.c
+++ b/dll/win32/setupapi/dialog.c
@@ -119,7 +119,7 @@ static void promptdisk_browse(HWND hwnd, struct promptdisk_params *params)
     ZeroMemory(&ofn, sizeof(ofn));
 
     ofn.lStructSize = sizeof(ofn);
-    ofn.Flags = OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
+    ofn.Flags = OFN_EXPLORER | OFN_HIDEREADONLY | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST;
     ofn.hwndOwner = hwnd;
     ofn.nMaxFile = MAX_PATH;
     ofn.lpstrFile = HeapAlloc(GetProcessHeap(), 0, MAX_PATH*sizeof(WCHAR));

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -882,7 +882,7 @@ VOID COpenWithDialog::Browse()
     ofn.lStructSize  = sizeof(OPENFILENAMEW);
     ofn.hInstance = shell32_hInstance;
     ofn.hwndOwner = m_hDialog;
-    ofn.Flags = OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+    ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
     ofn.nMaxFile = (sizeof(wszPath) / sizeof(WCHAR));
     ofn.lpstrFile = wszPath;
     ofn.lpstrInitialDir = L"%programfiles%";

--- a/dll/win32/shell32/dialogs/filetypes.cpp
+++ b/dll/win32/shell32/dialogs/filetypes.cpp
@@ -834,7 +834,7 @@ ActionDlg_OnBrowse(HWND hwndDlg, PACTION_DIALOG pNewAct, BOOL bEdit = FALSE)
     ofn.lpstrFile = szFile;
     ofn.nMaxFile = _countof(szFile);
     ofn.lpstrTitle = strTitle;
-    ofn.Flags = OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
+    ofn.Flags = OFN_EXPLORER | OFN_ENABLESIZING | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
     ofn.lpstrDefExt = L"exe";
     if (GetOpenFileNameW(&ofn))
     {

--- a/modules/rosapps/applications/devutils/vgafontedit/opensave.c
+++ b/modules/rosapps/applications/devutils/vgafontedit/opensave.c
@@ -43,7 +43,7 @@ DoOpenFile(OUT PWSTR pszFileName)
         PrepareFilter(pszFilter);
         ofn.lpstrFilter = pszFilter;
         ofn.lpstrFile = pszFileName;
-        ofn.Flags = OFN_FILEMUSTEXIST;
+        ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST;
 
         bRet = GetOpenFileNameW(&ofn);
         HeapFree(hProcessHeap, 0, pszFilter);

--- a/modules/rosapps/applications/sysutils/utils/infinst/infinst.c
+++ b/modules/rosapps/applications/sysutils/utils/infinst/infinst.c
@@ -56,7 +56,7 @@ _tmain(int argc, TCHAR *argv[])
 		ofc.lpstrFilter = FILEOPEN_FILTER;
 		ofc.nFilterIndex = 1;
 		ofc.lpstrTitle = FILEOPEN_TITLE;
-		ofc.Flags = OFN_FILEMUSTEXIST | OFN_LONGNAMES | OFN_PATHMUSTEXIST;
+		ofc.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_LONGNAMES | OFN_PATHMUSTEXIST;
 		ofc.lpstrDefExt = FILEOPEN_DEFEXT;
 		ofc.lpstrFile = FileName;
 		ofc.nMaxFile = sizeof(FileName) / sizeof(TCHAR);

--- a/modules/rosapps/lib/vfdlib/vfdguiopen.c
+++ b/modules/rosapps/lib/vfdlib/vfdguiopen.c
@@ -404,7 +404,7 @@ void OnBrowse(
 	ofn.nMaxFile	= sizeof(file);
 	ofn.lpstrInitialDir = dir;
 	ofn.lpstrTitle	= title ? title : FALLBACK_IMAGE_TITLE;
-	ofn.Flags		= OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+	ofn.Flags		= OFN_EXPLORER | OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
 
 	//	show the open file dialog box
 

--- a/modules/rosapps/lib/vfdlib/vfdguisave.c
+++ b/modules/rosapps/lib/vfdlib/vfdguisave.c
@@ -422,7 +422,7 @@ void OnBrowse(
 	ofn.lpstrInitialDir = dir;
 	ofn.lpstrTitle	= title ? title : "Save Image";
 	ofn.lpstrFilter	= "*.*\0*.*\0";
-	ofn.Flags		= OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
+	ofn.Flags		= OFN_EXPLORER | OFN_ENABLESIZING | OFN_HIDEREADONLY | OFN_PATHMUSTEXIST;
 
 	if (GetSaveFileName(&ofn)) {
 		SetDlgItemText(hDlg, IDC_TARGETFILE, file);


### PR DESCRIPTION
## Purpose
Use new-style file open/save-as dialog. The new-style dialog has the place bar on left side, and the size-grip on lower right corner.
JIRA issue: N/A

## Proposed changes
- Add `OFN_EXPLORER` flag to `OPENFILENAME` structure in `notepad`, `wordpad`, `mspaint`, `clipbrd`, `mmc`, `mplay32`, `mscutils`, `regedit`, `winhlp32`, `progman`, `shellbtrfs`, `cryptui`, `shell32`, `setupapi`, `vgafontedit`, `infinst`, and `vfdlib` modules.
.
## Comparison

NOTEPAD (BEFORE):
![notepad-before](https://user-images.githubusercontent.com/2107452/113229436-f3bcf800-92d1-11eb-8e90-e22b0e77bc5a.png)
WORDPAD (BEFORE):
![wordpad-before](https://user-images.githubusercontent.com/2107452/113229435-f3246180-92d1-11eb-9595-af7e94433757.png)
MSPAINT (BEFORE):
![mspaint-before](https://user-images.githubusercontent.com/2107452/113229437-f4558e80-92d1-11eb-8836-47ee6df60817.png)
NOTEPAD (AFTER):
![notepad-after](https://user-images.githubusercontent.com/2107452/113229459-033c4100-92d2-11eb-8a60-c97e3bbb0f03.png)
WORDPAD (AFTER):
![wordpad-after](https://user-images.githubusercontent.com/2107452/113229463-046d6e00-92d2-11eb-8f65-8bb80ba8b4ef.png)
MSPAINT (AFTER):
![mspaint-after](https://user-images.githubusercontent.com/2107452/113229465-046d6e00-92d2-11eb-8e37-696f1fa7466f.png)