### PR TITLE
[NEWDEV] Enable auto-completion on Hardware Wizard

### DIFF
--- a/dll/win32/newdev/CMakeLists.txt
+++ b/dll/win32/newdev/CMakeLists.txt
@@ -15,6 +15,6 @@ add_library(newdev MODULE
 
 set_module_type(newdev win32dll UNICODE)
 target_link_libraries(newdev wine)
-add_importlibs(newdev gdi32 comctl32 setupapi advapi32 user32 shell32 msvcrt kernel32 ntdll)
+add_importlibs(newdev gdi32 comctl32 setupapi advapi32 user32 shell32 shlwapi ole32 msvcrt kernel32 ntdll)
 add_pch(newdev newdev_private.h SOURCE)
 add_cd_file(TARGET newdev DESTINATION reactos/system32 FOR all)

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -23,6 +23,7 @@
 #include <wincon.h>
 #include <cfgmgr32.h>
 #include <shlobj.h>
+#include <shlwapi.h>
 
 HANDLE hThread;
 
@@ -573,8 +574,9 @@ CHSourceDlgProc(
     {
         case WM_INITDIALOG:
         {
-            HWND hwndControl;
+            HWND hwndControl, hwndCombo, hwndEdit;
             DWORD dwStyle;
+            COMBOBOXINFO info = { sizeof(info) };
 
             /* Get pointer to the global setup data */
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
@@ -589,7 +591,12 @@ CHSourceDlgProc(
             dwStyle = GetWindowLongPtr(hwndControl, GWL_STYLE);
             SetWindowLongPtr(hwndControl, GWL_STYLE, dwStyle & ~WS_SYSMENU);
 
-            PopulateCustomPathCombo(GetDlgItem(hwndDlg, IDC_COMBO_PATH));
+            hwndCombo = GetDlgItem(hwndDlg, IDC_COMBO_PATH);
+            PopulateCustomPathCombo(hwndCombo);
+
+            GetComboBoxInfo(hwndCombo, &info);
+            hwndEdit = info.hwndItem;
+            SHAutoComplete(hwndEdit, SHACF_FILESYS_DIRS);
 
             SendDlgItemMessage(
                 hwndDlg,
@@ -1303,6 +1310,7 @@ DisplayWizard(
     PROPSHEETHEADER psh = {0};
     HPROPSHEETPAGE ahpsp[IDD_MAXIMUMPAGE + 1];
     PROPSHEETPAGE psp = {0};
+    HRESULT hr = CoInitialize(NULL); /* for SHAutoComplete */
 
     /* zero based index */
     startPage -= IDD_FIRSTPAGE;
@@ -1382,5 +1390,7 @@ DisplayWizard(
 
     DeleteObject(DevInstData->hTitleFont);
 
+    if (SUCCEEDED(hr))
+        CoUninitialize();
     return TRUE;
 }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -574,7 +574,7 @@ CHSourceDlgProc(
     {
         case WM_INITDIALOG:
         {
-            HWND hwndControl, hwndCombo, hwndEdit;
+            HWND hwndControl, hwndCombo;
             DWORD dwStyle;
             COMBOBOXINFO info = { sizeof(info) };
 
@@ -595,8 +595,7 @@ CHSourceDlgProc(
             PopulateCustomPathCombo(hwndCombo);
 
             GetComboBoxInfo(hwndCombo, &info);
-            hwndEdit = info.hwndItem;
-            SHAutoComplete(hwndEdit, SHACF_FILESYS_DIRS);
+            SHAutoComplete(info.hwndItem, SHACF_FILESYS_DIRS);
 
             SendDlgItemMessage(
                 hwndDlg,


### PR DESCRIPTION
## Purpose
Realize auto-completion on Hardware Wizard.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Call `SHAutoComplete` function.
- Add `CoInitialize`/`CoUninitialize` function calls (for `SHAutoComplete`).
- Add links to `shlwapi` and `ole32`.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/113367666-9e4b1e80-9397-11eb-9956-febf6e5b8e70.png)
Auto-completion won't work.
AFTER:
![after](https://user-images.githubusercontent.com/2107452/113367660-9be8c480-9397-11eb-9fdd-83c92c7f3dfb.png)
Auto-completion does work.