### PR TITLE
[SHELL32] Auto-completion on Properties for Shortcut

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -6,7 +6,7 @@
  *      Copyright 2009  Andrew Hill
  *      Copyright 2013  Dominik Hornung
  *      Copyright 2017  Hermes Belusca-Maito
- *      Copyright 2018  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *      Copyright 2018-2021 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2886,6 +2886,10 @@ BOOL CShellLink::OnInitDialog(HWND hwndDlg, HWND hwndFocus, LPARAM lParam)
     /* Description */
     if (m_sDescription)
         SetDlgItemTextW(hwndDlg, IDC_SHORTCUT_COMMENT_EDIT, m_sDescription);
+
+    /* auto-completion */
+    SHAutoComplete(GetDlgItem(hwndDlg, IDC_SHORTCUT_TARGET_TEXT), SHACF_DEFAULT);
+    SHAutoComplete(GetDlgItem(hwndDlg, IDC_SHORTCUT_START_IN_EDIT), SHACF_DEFAULT);
 
     m_bInInit = FALSE;
 


### PR DESCRIPTION
## Purpose
Enable auto-completion on "Properties for Shortcut files".
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Call `SHAutoComplete` against dialog controls `IDC_SHORTCUT_TARGET_TEXT` and `IDC_SHORTCUT_START_IN_EDIT`.

## Observation

![after-1](https://user-images.githubusercontent.com/2107452/113389380-e6cfff80-93ca-11eb-8042-6f690cfa19cf.png)
![after-2](https://user-images.githubusercontent.com/2107452/113389375-e59ed280-93ca-11eb-9777-af88b8cd1885.png)