### PR TITLE
[BROWSEUI_APITEST] Strengthen ACListISF testcase

### DIFF
--- a/modules/rostests/apitests/browseui/ACListISF.cpp
+++ b/modules/rostests/apitests/browseui/ACListISF.cpp
@@ -466,7 +466,7 @@ test_ACListISF_CURRENTDIR2()
     RemoveDirectoryW(L"C:\\BROWSEUI-1\\TEST1");
     RemoveDirectoryW(L"C:\\BROWSEUI-1\\TEST2");
     RemoveDirectoryW(L"C:\\BROWSEUI-1");
-    RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST3");
+    RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST4");
     RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST1");
     RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST2");
     RemoveDirectoryW(L"C:\\BROWSEUI-2");

--- a/modules/rostests/apitests/browseui/ACListISF.cpp
+++ b/modules/rostests/apitests/browseui/ACListISF.cpp
@@ -325,17 +325,9 @@ test_ACListISF_CURRENTDIR()
     ok_wstr(psz, L"tes2");
     CoTaskMemFree(psz);
 
-    hr = EnumStr->Next(1, &psz, &cGot);
-    ok_hr(hr, S_FALSE);
-    CoTaskMemFree(psz);
-
     StringCbCopyW(szPath, sizeof(szPath), szDir);
     StringCbCatW(szPath, sizeof(szPath), L"\\BROWSEUI-2");
     ok_hr(hr = CurrentWorkingDir->SetDirectory(szPath), S_OK);
-
-    hr = EnumStr->Next(1, &psz, &cGot);
-    ok_hr(hr, S_FALSE);
-    CoTaskMemFree(psz);
 
     EnumStr->Reset();
 
@@ -347,10 +339,6 @@ test_ACListISF_CURRENTDIR()
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
     ok_wstr(psz, L"tes2");
-    CoTaskMemFree(psz);
-
-    hr = EnumStr->Next(1, &psz, &cGot);
-    ok_hr(hr, S_FALSE);
     CoTaskMemFree(psz);
 
     StringCbCopyW(szPath, sizeof(szPath), szDir);
@@ -376,6 +364,112 @@ test_ACListISF_CURRENTDIR()
     StringCbCopyW(szPath, sizeof(szPath), szDir);
     StringCbCatW(szPath, sizeof(szPath), L"\\BROWSEUI-2");
     RemoveDirectoryW(szPath);
+}
+
+static void
+test_ACListISF_CURRENTDIR2()
+{
+    CComPtr<IEnumString> EnumStr;
+    HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
+    ok_hr(hr, S_OK);
+    if (!SUCCEEDED(hr))
+        return;
+
+    CComPtr<IACList2> ACList;
+    ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
+    if (!SUCCEEDED(hr))
+        return;
+
+    CComPtr<ICurrentWorkingDirectory> CurrentWorkingDir;
+    ok_hr(hr = EnumStr->QueryInterface(IID_ICurrentWorkingDirectory, (void**)&CurrentWorkingDir), S_OK);
+    if (!SUCCEEDED(hr))
+        return;
+
+    ok_hr(hr = ACList->SetOptions(ACLO_CURRENTDIR), S_OK);
+    test_at_end(EnumStr);
+
+    CreateDirectoryW(L"C:\\BROWSEUI-1", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-1\\TEST1", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-1\\TEST2", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-1\\TEST1\\TEST3", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-2", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST1", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST2", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST3", NULL);
+
+    ok_hr(hr = CurrentWorkingDir->SetDirectory(L"C:\\BROWSEUI-1\\TEST1"), S_OK);
+    test_at_end(EnumStr);
+
+    ok_hr(hr = ACList->Expand(L"C:\\BROWSEUI-2\\TEST1\\"), S_OK);
+
+    LPWSTR psz;
+    ULONG cGot;
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"C:\\BROWSEUI-2\\TEST1\\TEST3");
+    CoTaskMemFree(psz);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"TEST3");
+    CoTaskMemFree(psz);
+
+    test_at_end(EnumStr);
+
+    ok_hr(hr = ACList->Expand(L"C:\\BROWSEUI-1\\TEST1\\"), S_OK);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"C:\\BROWSEUI-1\\TEST1\\TEST3");
+    CoTaskMemFree(psz);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"TEST3");
+    CoTaskMemFree(psz);
+
+    test_at_end(EnumStr);
+
+    ok_hr(hr = CurrentWorkingDir->SetDirectory(L"C:\\BROWSEUI-2\\TEST1"), S_OK);
+    test_at_end(EnumStr);
+
+    ok_hr(hr = ACList->Expand(L"..\\TEST1\\"), S_OK);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"..\\TEST1\\TEST3");
+    CoTaskMemFree(psz);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"TEST3");
+    CoTaskMemFree(psz);
+
+    test_at_end(EnumStr);
+
+    ok_hr(hr = ACList->Expand(L"\\BROWSEUI-2\\TEST1\\"), S_OK);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"\\BROWSEUI-2\\TEST1\\TEST3");
+    CoTaskMemFree(psz);
+
+    hr = EnumStr->Next(1, &psz, &cGot);
+    ok_hr(hr, S_OK);
+    ok_wstr(psz, L"TEST3");
+    CoTaskMemFree(psz);
+
+    test_at_end(EnumStr);
+
+    RemoveDirectoryW(L"C:\\BROWSEUI-1\\TEST1\\TEST3");
+    RemoveDirectoryW(L"C:\\BROWSEUI-1\\TEST1");
+    RemoveDirectoryW(L"C:\\BROWSEUI-1\\TEST2");
+    RemoveDirectoryW(L"C:\\BROWSEUI-1");
+    RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST3");
+    RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST1");
+    RemoveDirectoryW(L"C:\\BROWSEUI-2\\TEST2");
+    RemoveDirectoryW(L"C:\\BROWSEUI-2");
 }
 
 static void
@@ -582,6 +676,7 @@ START_TEST(ACListISF)
 
     test_ACListISF_NONE();
     test_ACListISF_CURRENTDIR();
+    test_ACListISF_CURRENTDIR2();
     test_ACListISF_MYCOMPUTER();
     test_ACListISF_DESKTOP();
     test_ACListISF_FAVORITES();

--- a/modules/rostests/apitests/browseui/ACListISF.cpp
+++ b/modules/rostests/apitests/browseui/ACListISF.cpp
@@ -395,7 +395,7 @@ test_ACListISF_CURRENTDIR2()
     CreateDirectoryW(L"C:\\BROWSEUI-2", NULL);
     CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST1", NULL);
     CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST2", NULL);
-    CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST3", NULL);
+    CreateDirectoryW(L"C:\\BROWSEUI-2\\TEST1\\TEST4", NULL);
 
     ok_hr(hr = CurrentWorkingDir->SetDirectory(L"C:\\BROWSEUI-1\\TEST1"), S_OK);
     test_at_end(EnumStr);
@@ -407,7 +407,7 @@ test_ACListISF_CURRENTDIR2()
 
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
-    ok_wstr(psz, L"C:\\BROWSEUI-2\\TEST1\\TEST3");
+    ok_wstr(psz, L"C:\\BROWSEUI-2\\TEST1\\TEST4");
     CoTaskMemFree(psz);
 
     hr = EnumStr->Next(1, &psz, &cGot);
@@ -438,12 +438,12 @@ test_ACListISF_CURRENTDIR2()
 
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
-    ok_wstr(psz, L"..\\TEST1\\TEST3");
+    ok_wstr(psz, L"..\\TEST1\\TEST4");
     CoTaskMemFree(psz);
 
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
-    ok_wstr(psz, L"TEST3");
+    ok_wstr(psz, L"TEST4");
     CoTaskMemFree(psz);
 
     test_at_end(EnumStr);
@@ -452,12 +452,12 @@ test_ACListISF_CURRENTDIR2()
 
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
-    ok_wstr(psz, L"\\BROWSEUI-2\\TEST1\\TEST3");
+    ok_wstr(psz, L"\\BROWSEUI-2\\TEST1\\TEST4");
     CoTaskMemFree(psz);
 
     hr = EnumStr->Next(1, &psz, &cGot);
     ok_hr(hr, S_OK);
-    ok_wstr(psz, L"TEST3");
+    ok_wstr(psz, L"TEST4");
     CoTaskMemFree(psz);
 
     test_at_end(EnumStr);

--- a/modules/rostests/apitests/browseui/ACListISF.cpp
+++ b/modules/rostests/apitests/browseui/ACListISF.cpp
@@ -41,9 +41,6 @@ static DWORD g_WinVersion;
            #expression, (int)(expected), _value); \
     } while (0)
 
-
-
-
 static void test_at_end_imp(CComPtr<IEnumString>& EnumStr)
 {
     CComHeapPtr<OLECHAR> Result;
@@ -128,10 +125,8 @@ test_ExpectFolders_imp(CComPtr<IEnumString>& EnumStr, LPITEMIDLIST pidlTarget, c
         hr = EnumStr->Next(1, &Result, &Fetched);
         winetest_ok_hr(hr, S_OK);
 
-
         if (hr != S_OK)
             break;
-
 
         StringCchPrintfW(Buffer, _ARRAYSIZE(Buffer), L"%s%s", (options & IgnoreRoot) ? L"" : Root, (WCHAR*)DisplayName);
 
@@ -159,12 +154,18 @@ test_ACListISF_NONE()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_NONE), S_OK);
     test_at_end(EnumStr);
@@ -177,7 +178,10 @@ test_ACListISF_NONE()
     CComHeapPtr<ITEMIDLIST> pidlDiskRoot;
     ok_hr(hr = SHParseDisplayName(Buffer, NULL, &pidlDiskRoot, NULL, NULL), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("SHParseDisplayName failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->Expand(Buffer), S_OK);
     test_ExpectFolders(EnumStr, pidlDiskRoot, Buffer, CheckLast | IgnoreHidden);
@@ -497,7 +501,10 @@ test_ACListISF_MYCOMPUTER()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IACList2, &ACList));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     // Check the default
     DWORD CurrentOption = 0xdeadbeef;
@@ -509,18 +516,26 @@ test_ACListISF_MYCOMPUTER()
     CComPtr<IEnumString> EnumStr;
     ok_hr(hr = ACList->QueryInterface(IID_IEnumString, (void**)&EnumStr), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     CComPtr<IPersistFolder> PersistFolder;
     ok_hr(hr = EnumStr->QueryInterface(IID_IPersistFolder, (void**)&PersistFolder), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     CComHeapPtr<ITEMIDLIST> pidlMyComputer;
     ok_hr(hr = SHGetSpecialFolderLocation(NULL, CSIDL_DRIVES, &pidlMyComputer), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("SHGetSpecialFolderLocation failed\n");
         return;
-
+    }
 
     hr = EnumStr->Reset();
     if (g_WinVersion < WINVER_VISTA)
@@ -567,12 +582,18 @@ test_ACListISF_DESKTOP()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_DESKTOP), S_OK);
     test_ExpectFolders(EnumStr, NULL, NULL, IgnoreRoot | CheckLast | IgnoreHidden);
@@ -585,17 +606,26 @@ test_ACListISF_FAVORITES()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     CComHeapPtr<ITEMIDLIST> pidlFavorites;
     ok_hr(hr = SHGetSpecialFolderLocation(NULL, CSIDL_FAVORITES, &pidlFavorites), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("SHGetSpecialFolderLocation failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_FAVORITES), S_OK);
     test_ExpectFolders(EnumStr, pidlFavorites, NULL, IgnoreRoot | CheckLast | IgnoreHidden);
@@ -608,12 +638,18 @@ test_ACListISF_FILESYSONLY()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     WCHAR Buffer[MAX_PATH];
     GetSystemWindowsDirectoryW(Buffer, _ARRAYSIZE(Buffer));
@@ -622,7 +658,10 @@ test_ACListISF_FILESYSONLY()
     CComHeapPtr<ITEMIDLIST> pidlDiskRoot;
     ok_hr(hr = SHParseDisplayName(Buffer, NULL, &pidlDiskRoot, NULL, NULL), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("SHParseDisplayName failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_FILESYSONLY), S_OK);
     test_at_end(EnumStr);
@@ -638,12 +677,18 @@ test_ACListISF_FILESYSDIRS()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     WCHAR Buffer[MAX_PATH];
     GetSystemWindowsDirectoryW(Buffer, _ARRAYSIZE(Buffer));
@@ -690,7 +735,10 @@ START_TEST(ACListISF)
     CCoInit init;
     ok_hr(init.hres, S_OK);
     if (!SUCCEEDED(init.hres))
+    {
+        skip("CoInitialize failed\n");
         return;
+    }
 
     test_ACListISF_NONE();
     test_ACListISF_CURRENTDIR();

--- a/modules/rostests/apitests/browseui/ACListISF.cpp
+++ b/modules/rostests/apitests/browseui/ACListISF.cpp
@@ -195,17 +195,26 @@ test_ACListISF_CURRENTDIR()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     CComPtr<ICurrentWorkingDirectory> CurrentWorkingDir;
     ok_hr(hr = EnumStr->QueryInterface(IID_ICurrentWorkingDirectory, (void**)&CurrentWorkingDir), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_CURRENTDIR), S_OK);
     test_at_end(EnumStr);
@@ -373,17 +382,26 @@ test_ACListISF_CURRENTDIR2()
     HRESULT hr = CoCreateInstance(CLSID_ACListISF, NULL, CLSCTX_ALL, IID_PPV_ARG(IEnumString, &EnumStr));
     ok_hr(hr, S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("CoCreateInstance failed\n");
         return;
+    }
 
     CComPtr<IACList2> ACList;
     ok_hr(hr = EnumStr->QueryInterface(IID_IACList2, (void**)&ACList), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     CComPtr<ICurrentWorkingDirectory> CurrentWorkingDir;
     ok_hr(hr = EnumStr->QueryInterface(IID_ICurrentWorkingDirectory, (void**)&CurrentWorkingDir), S_OK);
     if (!SUCCEEDED(hr))
+    {
+        skip("QueryInterface failed\n");
         return;
+    }
 
     ok_hr(hr = ACList->SetOptions(ACLO_CURRENTDIR), S_OK);
     test_at_end(EnumStr);


### PR DESCRIPTION
## Purpose

Give power to `ACListISF` testcase to analyze `CLSID_ACListISF`'s behavior about relative paths.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `skip` calls.
- Add more tests for the relative paths.

## Comparison

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/113463304-09602800-9460-11eb-87de-a67395c0dc71.png)
Successful.

Win10:
![win10](https://user-images.githubusercontent.com/2107452/113463306-09f8be80-9460-11eb-9beb-b2b6ceb34c04.png)
Successful.
