### PR TITLE
[BROWSEUI] Fix auto-completion on relative paths

### DIFF
--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -328,28 +328,21 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
 {
     TRACE("(%p, %ls)\n", this, pszExpand);
 
+    m_szExpand = pszExpand;
+    m_iNextLocation = LT_DIRECTORY;
+
     // get full path
-    WCHAR szFullPath[MAX_PATH];
-    if (PathIsRelativeW(pszExpand))
+    WCHAR szFullPath[MAX_PATH], szCurDir[MAX_PATH], szPath[MAX_PATH];
+    if (PathIsRelativeW(pszExpand) &&
+        SHGetPathFromIDListW(m_pidlCurDir, szCurDir) &&
+        PathCombineW(szPath, szCurDir, pszExpand))
     {
-        WCHAR szCurDir[MAX_PATH], szPath[MAX_PATH];
-        if (SHGetPathFromIDListW(m_pidlCurDir, szCurDir) &&
-            PathCombineW(szPath, szCurDir, pszExpand))
-        {
-            GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
-        }
-        else
-        {
-            GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
-        }
+        GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
     }
     else
     {
         GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }
-
-    m_szExpand = pszExpand;
-    m_iNextLocation = LT_DIRECTORY;
 
     CComHeapPtr<ITEMIDLIST> pidl;
     HRESULT hr = SHParseDisplayName(szFullPath, NULL, &pidl, NULL, NULL);

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -330,11 +330,11 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
 
     // get full path
     WCHAR szFullPath[MAX_PATH];
-    if (pszExpand[0] == L'\\')
+    if (pszExpand[0] == L'\\' || !PathIsRelativeW(pszExpand))
     {
         GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }
-    else if (PathIsRelativeW(pszExpand))
+    else
     {
         WCHAR szCurDir[MAX_PATH], szPath[MAX_PATH];
         if (!SHGetPathFromIDListW(m_pidlCurDir, szCurDir) ||
@@ -343,10 +343,6 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
             StringCbCopyW(szPath, sizeof(szPath), pszExpand);
         }
         GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
-    }
-    else
-    {
-        GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }
 
     m_szExpand = pszExpand;

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -330,11 +330,7 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
 
     // get full path
     WCHAR szFullPath[MAX_PATH];
-    if (!PathIsRelativeW(pszExpand))
-    {
-        GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
-    }
-    else
+    if (PathIsRelativeW(pszExpand))
     {
         WCHAR szCurDir[MAX_PATH], szPath[MAX_PATH];
         if (!SHGetPathFromIDListW(m_pidlCurDir, szCurDir) ||
@@ -343,6 +339,10 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
             StringCbCopyW(szPath, sizeof(szPath), pszExpand);
         }
         GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
+    }
+    else
+    {
+        GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }
 
     m_szExpand = pszExpand;

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -330,7 +330,7 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
 
     // get full path
     WCHAR szFullPath[MAX_PATH];
-    if (pszExpand[0] == L'\\' || !PathIsRelativeW(pszExpand))
+    if (!PathIsRelativeW(pszExpand))
     {
         GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -337,12 +337,9 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
         SHGetPathFromIDListW(m_pidlCurDir, szCurDir) &&
         PathCombineW(szPath, szCurDir, pszExpand))
     {
-        GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
+        pszExpand = szPath;
     }
-    else
-    {
-        GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
-    }
+    GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
 
     CComHeapPtr<ITEMIDLIST> pidl;
     HRESULT hr = SHParseDisplayName(szFullPath, NULL, &pidl, NULL, NULL);

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -333,12 +333,15 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
     if (PathIsRelativeW(pszExpand))
     {
         WCHAR szCurDir[MAX_PATH], szPath[MAX_PATH];
-        if (!SHGetPathFromIDListW(m_pidlCurDir, szCurDir) ||
-            !PathCombineW(szPath, szCurDir, pszExpand))
+        if (SHGetPathFromIDListW(m_pidlCurDir, szCurDir) &&
+            PathCombineW(szPath, szCurDir, pszExpand))
         {
-            StringCbCopyW(szPath, sizeof(szPath), pszExpand);
+            GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
         }
-        GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
+        else
+        {
+            GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
+        }
     }
     else
     {

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -332,17 +332,17 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
     m_iNextLocation = LT_DIRECTORY;
 
     // get full path
-    WCHAR szFullPath[MAX_PATH], szCurDir[MAX_PATH], szPath[MAX_PATH];
+    WCHAR szPath1[MAX_PATH], szPath2[MAX_PATH];
     if (PathIsRelativeW(pszExpand) &&
-        SHGetPathFromIDListW(m_pidlCurDir, szCurDir) &&
-        PathCombineW(szPath, szCurDir, pszExpand))
+        SHGetPathFromIDListW(m_pidlCurDir, szPath1) &&
+        PathCombineW(szPath2, szPath1, pszExpand))
     {
-        pszExpand = szPath;
+        pszExpand = szPath2;
     }
-    GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
+    GetFullPathNameW(pszExpand, _countof(szPath1), szPath1, NULL);
 
     CComHeapPtr<ITEMIDLIST> pidl;
-    HRESULT hr = SHParseDisplayName(szFullPath, NULL, &pidl, NULL, NULL);
+    HRESULT hr = SHParseDisplayName(szPath1, NULL, &pidl, NULL, NULL);
     if (SUCCEEDED(hr))
     {
         hr = SetLocation(pidl.Detach());

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -2,7 +2,7 @@
  *  Shell AutoComplete list
  *
  *  Copyright 2015  Thomas Faber
- *  Copyright 2020  Katayama Hirofumi MZ
+ *  Copyright 2020-2021 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/dll/win32/browseui/aclistisf.cpp
+++ b/dll/win32/browseui/aclistisf.cpp
@@ -346,7 +346,7 @@ STDMETHODIMP CACListISF::Expand(LPCOLESTR pszExpand)
     }
     else
     {
-        StringCbCopyW(szFullPath, sizeof(szFullPath), pszExpand);
+        GetFullPathNameW(pszExpand, _countof(szFullPath), szFullPath, NULL);
     }
 
     m_szExpand = pszExpand;


### PR DESCRIPTION
## Purpose

Fix the `CLSID_ACListISF` object about relative paths.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- If the given path is relative at `CACListISF::Expand`, then convert it to a full path.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/113473518-eefc6d80-94a4-11eb-88eb-506ce0b3f73e.png)
There was a hung up.
AFTER:
![after](https://user-images.githubusercontent.com/2107452/113473517-edcb4080-94a4-11eb-8a78-3dc17e3f35dc.png)
There is no failure.