### PR TITLE
[CMAKE] Store and re-use M4 and BISON_PKGDATADIR env variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,41 @@ endif()
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 
+if(MSVC_IDE)
+    # Bison needs M4 and BISON_PKGDATADIR set at build time,
+    # but visual studio is hardly ever opened from the configure-time environment.
+    # Since cmake does not support setting env variables for a custom command,
+    # we have to write a wrapper that sets the variables and then executes bison.
+    # Idea taken from https://stackoverflow.com/a/35032051/4928207
+    if(DEFINED ENV{M4})
+        # Store this environment variable for configure re-runs from withing visual studio.
+        SET(ROS_SAVED_M4 "$ENV{M4}" CACHE INTERNAL "")
+    endif()
+    if(DEFINED ENV{BISON_PKGDATADIR})
+        SET(ROS_SAVED_BISON_PKGDATADIR "$ENV{BISON_PKGDATADIR}" CACHE INTERNAL "")
+    endif()
+
+    # Tell the user about a misconfigured environment
+    if("x${ROS_SAVED_M4}x" STREQUAL "xx" OR "x${ROS_SAVED_BISON_PKGDATADIR}x" STREQUAL "xx")
+        message(FATAL_ERROR "\nM4 or BISON_PKGDATADIR environment variables not set, cannot continue!\n"
+            "See https://reactos.org/wiki/Visual_Studio for more information!")
+    endif()
+
+    file(WRITE "${CMAKE_BINARY_DIR}/bison_wrapper.cmd"
+                "@ECHO OFF\n"
+                "set M4=${ROS_SAVED_M4}\n"
+                "set BISON_PKGDATADIR=${ROS_SAVED_BISON_PKGDATADIR}\n"
+                "${BISON_EXECUTABLE} %*\n")
+    set(BISON_EXECUTABLE "${CMAKE_BINARY_DIR}/bison_wrapper.cmd")
+    # And the same hacks for FLEX
+    file(WRITE "${CMAKE_BINARY_DIR}/flex_wrapper.cmd"
+                "@ECHO OFF\n"
+                "set M4=${ROS_SAVED_M4}\n"
+                "set BISON_PKGDATADIR=${ROS_SAVED_BISON_PKGDATADIR}\n"
+                "${FLEX_EXECUTABLE} %*\n")
+    set(FLEX_EXECUTABLE "${CMAKE_BINARY_DIR}/flex_wrapper.cmd")
+endif()
+
 if(NOT CMAKE_CROSSCOMPILING)
     set(TOOLS_FOLDER ${CMAKE_CURRENT_BINARY_DIR})
     add_definitions(-DTARGET_${ARCH})

--- a/sdk/cmake/host-tools.cmake
+++ b/sdk/cmake/host-tools.cmake
@@ -45,6 +45,8 @@ function(setup_host_tools)
             -DARCH:STRING=${ARCH}
             -DCMAKE_INSTALL_PREFIX=${REACTOS_BINARY_DIR}/host-tools
             -DTOOLS_FOLDER=${REACTOS_BINARY_DIR}/host-tools/bin
+            -DROS_SAVED_M4=${ROS_SAVED_M4}
+            -DROS_SAVED_BISON_PKGDATADIR=${ROS_SAVED_BISON_PKGDATADIR}
             -DTARGET_COMPILER_ID=${CMAKE_C_COMPILER_ID}
             ${CMAKE_HOST_TOOLS_EXTRA_ARGS}
         BUILD_ALWAYS TRUE


### PR DESCRIPTION

## Purpose

Configure time environment variables are not stored / re-used by cmake,
and bison/flex need environment variables to function.

JIRA issue: [ROSBE-174](https://jira.reactos.org/browse/ROSBE-174)
