### PR TITLE
[FORMATTING] GitHub: Enforce 2-space indentation within 'steps:'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,150 +107,150 @@ jobs:
     name: Clang-CL (i386)
     runs-on: windows-latest
     steps:
-    - name: Install packages
-      run: |
-        choco install ninja -y
-        choco install --x86 -y llvm
-    - name: Install Flex and Bison
-      run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Add CL to PATH
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64_x86
-    - uses: actions/checkout@v2
-      with:
-        path: src
-    - name: Configure
-      run: |
-        mkdir build
-        cd build
-        $env:PATH = "${env:PROGRAMFILES(X86)}\llvm\bin;$env:PATH"
-        cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 -DUSE_CLANG_CL:BOOL=1 ${{github.workspace}}\src
-    - name: Build
-      working-directory: ${{github.workspace}}\build
-      run: cmake --build .
-    - name: Generate ISOs
-      working-directory: ${{github.workspace}}\build
-      run: |
-        cmake --build . --target bootcd
-        cmake --build . --target livecd
+      - name: Install packages
+        run: |
+          choco install ninja -y
+          choco install --x86 -y llvm
+      - name: Install Flex and Bison
+        run: |
+          curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+          7z x flexbison.7z -O${{github.workspace}}\bin
+          echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Add CL to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+      - uses: actions/checkout@v2
+        with:
+          path: src
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          $env:PATH = "${env:PROGRAMFILES(X86)}\llvm\bin;$env:PATH"
+          cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 -DUSE_CLANG_CL:BOOL=1 ${{github.workspace}}\src
+      - name: Build
+        working-directory: ${{github.workspace}}\build
+        run: cmake --build .
+      - name: Generate ISOs
+        working-directory: ${{github.workspace}}\build
+        run: |
+          cmake --build . --target bootcd
+          cmake --build . --target livecd
 
   build-msvc-i386:
     name: MSVC (i386)
     runs-on: windows-latest
     steps:
-    - name: Install packages
-      run: choco install ninja -y
-    - name: Install Flex and Bison
-      run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Add CL to PATH
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64_x86
-    - uses: actions/checkout@v2
-      with:
-        path: src
-    - name: Configure
-      run: |
-        mkdir build
-        cd build
-        cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
-    - name: Build
-      working-directory: ${{github.workspace}}\build
-      run: cmake --build .
-    - name: Generate ISOs
-      working-directory: ${{github.workspace}}\build
-      run: |
-        cmake --build . --target bootcd
-        cmake --build . --target livecd
-    - name: Upload bootcd
-      uses: actions/upload-artifact@v2
-      with:
-        name: reactos-msvc-i386-${{github.sha}}
-        path: build/bootcd.iso
-    - name: Upload livecd
-      uses: actions/upload-artifact@v2
-      with:
-        name: reactos-msvc-i386-${{github.sha}}
-        path: build/livecd.iso
+      - name: Install packages
+        run: choco install ninja -y
+      - name: Install Flex and Bison
+        run: |
+          curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+          7z x flexbison.7z -O${{github.workspace}}\bin
+          echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Add CL to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+      - uses: actions/checkout@v2
+        with:
+          path: src
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+      - name: Build
+        working-directory: ${{github.workspace}}\build
+        run: cmake --build .
+      - name: Generate ISOs
+        working-directory: ${{github.workspace}}\build
+        run: |
+          cmake --build . --target bootcd
+          cmake --build . --target livecd
+      - name: Upload bootcd
+        uses: actions/upload-artifact@v2
+        with:
+          name: reactos-msvc-i386-${{github.sha}}
+          path: build/bootcd.iso
+      - name: Upload livecd
+        uses: actions/upload-artifact@v2
+        with:
+          name: reactos-msvc-i386-${{github.sha}}
+          path: build/livecd.iso
 
   build-msvc-amd64:
     name: MSVC (amd64)
     runs-on: windows-latest
     steps:
-    - name: Install packages
-      run: choco install ninja -y
-    - name: Install Flex and Bison
-      run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Add CL to PATH
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64
-    - uses: actions/checkout@v2
-      with:
-        path: src
-    - name: Configure
-      run: |
-        mkdir build
-        cd build
-        cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=amd64 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
-    - name: Build
-      working-directory: ${{github.workspace}}\build
-      run: |
-        cmake --build .
-    - name: Generate ISOs
-      working-directory: ${{github.workspace}}\build
-      run: |
-        cmake --build . --target bootcd
-        cmake --build . --target livecd
-    - name: Upload bootcd
-      uses: actions/upload-artifact@v2
-      with:
-        name: reactos-msvc-amd64-${{github.sha}}
-        path: build/bootcd.iso
-    - name: Upload livecd
-      uses: actions/upload-artifact@v2
-      with:
-        name: reactos-msvc-amd64-${{github.sha}}
-        path: build/livecd.iso
+      - name: Install packages
+        run: choco install ninja -y
+      - name: Install Flex and Bison
+        run: |
+          curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+          7z x flexbison.7z -O${{github.workspace}}\bin
+          echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Add CL to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64
+      - uses: actions/checkout@v2
+        with:
+          path: src
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=amd64 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+      - name: Build
+        working-directory: ${{github.workspace}}\build
+        run: |
+          cmake --build .
+      - name: Generate ISOs
+        working-directory: ${{github.workspace}}\build
+        run: |
+          cmake --build . --target bootcd
+          cmake --build . --target livecd
+      - name: Upload bootcd
+        uses: actions/upload-artifact@v2
+        with:
+          name: reactos-msvc-amd64-${{github.sha}}
+          path: build/bootcd.iso
+      - name: Upload livecd
+        uses: actions/upload-artifact@v2
+        with:
+          name: reactos-msvc-amd64-${{github.sha}}
+          path: build/livecd.iso
 
   build-msbuild-i386:
     name: MSBuild (i386)
     runs-on: windows-latest
     steps:
-    - name: Install Flex and Bison
-      run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Add CL to PATH
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64_x86
-    - uses: actions/checkout@v2
-      with:
-        path: src
-    - name: Configure
-      run: |
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
-    - name: Build
-      run: cmake --build ${{github.workspace}}\build --target bootcd --target livecd
+      - name: Install Flex and Bison
+        run: |
+          curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+          7z x flexbison.7z -O${{github.workspace}}\bin
+          echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+      - name: Add CL to PATH
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: amd64_x86
+      - uses: actions/checkout@v2
+        with:
+          path: src
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+      - name: Build
+        run: cmake --build ${{github.workspace}}\build --target bootcd --target livecd

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v3
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+      - uses: actions/labeler@v3
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Split off from #3576.

## Purpose

Ease comparing, copy-pasting, ...,
especially Linux and Windows builds within build.yml.

## Proposed changes

I prefer 2-space indentation.
If you prefer no indentation, just ask for it.
In any case, please, choose an identical indentation...