### PR TITLE
[NTOS:IO] OpenRegistryHandlesFromSymbolicLink: Use REG_OPTION_NON_VOLATILE CORE-17361

### DIFF
--- a/ntoskrnl/io/iomgr/deviface.c
+++ b/ntoskrnl/io/iomgr/deviface.c
@@ -103,7 +103,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
                          &ObjectAttributes,
                          0,
                          NULL,
-                         REG_OPTION_VOLATILE,
+                         REG_OPTION_NON_VOLATILE,
                          NULL);
     ZwClose(ClassesKey);
     if (!NT_SUCCESS(Status))
@@ -154,7 +154,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
                          &ObjectAttributes,
                          0,
                          NULL,
-                         REG_OPTION_VOLATILE,
+                         REG_OPTION_NON_VOLATILE,
                          NULL);
     if (!NT_SUCCESS(Status))
     {
@@ -172,7 +172,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
                          &ObjectAttributes,
                          0,
                          NULL,
-                         REG_OPTION_VOLATILE,
+                         REG_OPTION_NON_VOLATILE,
                          NULL);
     if (!NT_SUCCESS(Status))
     {


### PR DESCRIPTION
## Purpose

Use `REG_OPTION_NON_VOLATILE` instead of `REG_OPTION_VOLATILE` in all `ZwCreateKey` calls of `OpenRegistryHandlesFromSymbolicLink`, since the keys created/opened by this function, should be non-volatile (in other words, saved after reboot).
Also `Device Parameters` subkey that is created in `IoOpenDeviceInterfaceRegistryKey` (which uses that routine as well), is non-volatile too, so the parent keys whose contain it, cannot be volatile.
It will fix an error with status `0xc0000181` (`STATUS_CHILD_MUST_BE_VOLATILE`) occuring during loading kernel mode audio drivers from Windows XP/2003, especially checked (debug) versions, with my `IoGetDeviceInterfaceAlias` implementation from previous PR #3510. Also it may fix other error cases.

JIRA issue: [CORE-17361](https://jira.reactos.org/browse/CORE-17361)