### PR TITLE
[NTOS:IO] OpenRegistryHandlesFromSymbolicLink: Add missing OBJ_OPENIF CORE-17361

### DIFF
--- a/ntoskrnl/io/iomgr/deviface.c
+++ b/ntoskrnl/io/iomgr/deviface.c
@@ -95,7 +95,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &GuidString,
-                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE | OBJ_OPENIF,
                                ClassesKey,
                                NULL);
     Status = ZwCreateKey(GuidKeyRealP,
@@ -146,7 +146,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &SubKeyName,
-                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE | OBJ_OPENIF,
                                *GuidKeyRealP,
                                NULL);
     Status = ZwCreateKey(DeviceKeyRealP,
@@ -164,7 +164,7 @@ OpenRegistryHandlesFromSymbolicLink(IN PUNICODE_STRING SymbolicLinkName,
 
     InitializeObjectAttributes(&ObjectAttributes,
                                &ReferenceString,
-                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE | OBJ_OPENIF,
                                *DeviceKeyRealP,
                                NULL);
     Status = ZwCreateKey(InstanceKeyRealP,


### PR DESCRIPTION
## Purpose

Add missing `OBJ_OPENIF` flags in all `ZwCreateKey` calls of `OpenRegistryHandlesFromSymbolicLink`.
It will prevent this function from forced (re)creating the keys and possible overwriting data, in case they're already exist in registry. If they were already created before, they just should be opened (which seems to be more correct).
It also will improve the situation when loading Windows XP/2003 audio drivers in ReactOS, because that routine is used for loading them as well in my current implementation of PR #3510.

JIRA issue: [CORE-17361](https://jira.reactos.org/browse/CORE-17361)