### PR TITLE
[NTOS:MM][NTOS:SE] Mute some noisy stubs CORE-17409

### DIFF
--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -3341,7 +3341,7 @@ ULONG
 NTAPI
 MmDoesFileHaveUserWritableReferences(IN PSECTION_OBJECT_POINTERS SectionPointer)
 {
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
     return 0;
 }
 

--- a/ntoskrnl/se/audit.c
+++ b/ntoskrnl/se/audit.c
@@ -731,7 +731,7 @@ SeAuditingFileEventsWithContext(IN BOOLEAN AccessGranted,
                                 IN PSECURITY_DESCRIPTOR SecurityDescriptor,
                                 IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext OPTIONAL)
 {
-    UNIMPLEMENTED;
+    UNIMPLEMENTED_ONCE;
     return FALSE;
 }
 


### PR DESCRIPTION
## Purpose

Mute debug prints of `MmDoesFileHaveUserWritableReferences` and `SeAuditingFileEventsWithContext` stubs.
These stubs are very noisy and create a lot of spam in the log when using Microsoft NTFS driver in ReactOS (with some other improvements applied).
Implementing those functions isn't badly required for the proper work of this driver, so better way for now is just mute these stubs a bit.
After my changes, they will be displayed only once, and the log will be more clear, so it will seem to be enough to understand that the driver calls these routines.

JIRA issue: [CORE-17409](https://jira.reactos.org/browse/CORE-17409)