### PR TITLE
[BROWSEUI] auto-completion: Support large number items

### DIFF
--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1470,19 +1470,19 @@ VOID CAutoComplete::ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW
     }
 }
 
-INT CAutoComplete::ReLoadInnerList(const CStringW& strText)
+VOID CAutoComplete::ReLoadInnerList(const CStringW& strText)
 {
     m_innerList.RemoveAll(); // clear contents
+    m_bPartialList = FALSE;
 
-    if (!m_pEnum)
-        return 0;
+    if (!m_pEnum || strText.IsEmpty())
+        return;
 
     // reload the items
     LPWSTR pszItem;
     ULONG cGot;
     CStringW strTarget;
     HRESULT hr;
-    m_bPartialList = FALSE;
     for (;;)
     {
         // get next item
@@ -1525,8 +1525,6 @@ INT CAutoComplete::ReLoadInnerList(const CStringW& strText)
         if (::GetTickCount() - m_dwTick >= COMPLETION_TIMEOUT)
             break; // too late
     }
-
-    return m_innerList.GetSize(); // the number of items
 }
 
 // update inner list and m_strText and m_strStemText

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -722,7 +722,7 @@ VOID CAutoComplete::SetEditText(LPCWSTR pszText)
     m_bInSetText = FALSE;
 }
 
-CStringW CAutoComplete::GetStemText(const CStringW& strText)
+CStringW CAutoComplete::GetStemText(const CStringW& strText) const
 {
     INT ich = strText.ReverseFind(L'\\');
     if (ich == -1)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1607,9 +1607,12 @@ INT CAutoComplete::UpdateOuterList(const CStringW& strText)
         }
     }
 
-    // sort and unique
-    DoSort(m_outerList);
-    DoUniqueAndTrim(m_outerList);
+    if (::GetTickCount() - m_dwTick < COMPLETION_TIMEOUT)
+    {
+        // sort and unique
+        DoSort(m_outerList);
+        DoUniqueAndTrim(m_outerList);
+    }
 
     // set the item count of the virtual listview
     INT cItems = m_outerList.GetSize();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1444,7 +1444,8 @@ VOID CAutoComplete::RepositionDropDown()
     ShowWindow(SW_SHOWNOACTIVATE);
 }
 
-BOOL CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText) const
+inline BOOL
+CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText) const
 {
     CStringW strBody;
     if (DropPrefix(strTarget, strBody))

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1446,7 +1446,7 @@ VOID CAutoComplete::RepositionDropDown()
 
 inline BOOL
 CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText) const
-
+{
     CStringW strBody;
     if (DropPrefix(strTarget, strBody))
     {
@@ -1550,9 +1550,7 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
 
     // if the previous enumeration is too large
     if (m_bPartialList)
-    {
         bReset = bExpand = TRUE; // retry enumeratation
-    }
 
     // reset if necessary
     if (bReset && m_pEnum)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -668,39 +668,39 @@ CAutoComplete::~CAutoComplete()
     m_pACList.Release();
 }
 
-BOOL CAutoComplete::CanAutoSuggest()
+BOOL CAutoComplete::CanAutoSuggest() const
 {
     return !!(m_dwOptions & ACO_AUTOSUGGEST) && m_bEnabled;
 }
 
-BOOL CAutoComplete::CanAutoAppend()
+BOOL CAutoComplete::CanAutoAppend() const
 {
     return !!(m_dwOptions & ACO_AUTOAPPEND) && m_bEnabled;
 }
 
-BOOL CAutoComplete::UseTab()
+BOOL CAutoComplete::UseTab() const
 {
     return !!(m_dwOptions & ACO_USETAB) && m_bEnabled;
 }
 
-BOOL CAutoComplete::IsComboBoxDropped()
+BOOL CAutoComplete::IsComboBoxDropped() const
 {
     if (!::IsWindow(m_hwndCombo))
         return FALSE;
     return (BOOL)::SendMessageW(m_hwndCombo, CB_GETDROPPEDSTATE, 0, 0);
 }
 
-BOOL CAutoComplete::FilterPrefixes()
+BOOL CAutoComplete::FilterPrefixes() const
 {
     return !!(m_dwOptions & ACO_FILTERPREFIXES) && m_bEnabled;
 }
 
-INT CAutoComplete::GetItemCount()
+INT CAutoComplete::GetItemCount() const
 {
     return m_outerList.GetSize();
 }
 
-CStringW CAutoComplete::GetItemText(INT iItem)
+CStringW CAutoComplete::GetItemText(INT iItem) const
 {
     if (iItem < 0 || m_outerList.GetSize() <= iItem)
         return L"";

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1446,14 +1446,12 @@ VOID CAutoComplete::RepositionDropDown()
 
 inline BOOL
 CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText) const
-{
+
     CStringW strBody;
     if (DropPrefix(strTarget, strBody))
     {
         if (::StrCmpNIW(strBody, strText, strText.GetLength()) == 0)
-        {
             return TRUE;
-        }
     }
     else if (::StrCmpNIW(strTarget, strText, strText.GetLength()) == 0)
     {

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1527,7 +1527,7 @@ VOID CAutoComplete::ReLoadInnerList(const CStringW& strText)
 }
 
 // update inner list and m_strText and m_strStemText
-INT CAutoComplete::UpdateInnerList(const CStringW& strText)
+VOID CAutoComplete::UpdateInnerList(const CStringW& strText)
 {
     BOOL bReset = FALSE, bExpand = FALSE; // flags
 
@@ -1574,16 +1574,14 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
         // reload the inner list
         ReLoadInnerList(strText);
     }
-
-    return m_innerList.GetSize();
 }
 
-INT CAutoComplete::UpdateOuterList(const CStringW& strText)
+VOID CAutoComplete::UpdateOuterList(const CStringW& strText)
 {
     if (strText.IsEmpty())
     {
         m_outerList.RemoveAll();
-        return 0;
+        return;
     }
 
     if (m_bPartialList)
@@ -1616,9 +1614,7 @@ INT CAutoComplete::UpdateOuterList(const CStringW& strText)
     }
 
     // set the item count of the virtual listview
-    INT cItems = m_outerList.GetSize();
-    m_hwndList.SendMessageW(LVM_SETITEMCOUNT, cItems, 0);
-    return cItems; // the number of items
+    m_hwndList.SendMessageW(LVM_SETITEMCOUNT, m_outerList.GetSize(), 0);
 }
 
 VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
@@ -1635,8 +1631,8 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
     }
 
     // update inner list
-    UINT cItems = UpdateInnerList(strText);
-    if (cItems == 0) // no items
+    UpdateInnerList(strText);
+    if (m_innerList.GetSize() <= 0) // no items
     {
         HideDropDown();
         return;
@@ -1648,7 +1644,8 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
         SelectItem(-1); // select none
         m_bInSelectItem = FALSE;
 
-        if (UpdateOuterList(strText))
+        UpdateOuterList(strText);
+        if (m_outerList.GetSize() > 0)
             RepositionDropDown();
         else
             HideDropDown();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1478,19 +1478,20 @@ INT CAutoComplete::ReLoadInnerList(const CStringW& strText)
         return 0;
 
     // reload the items
+    LPWSTR pszItem;
+    ULONG cGot;
+    CStringW strTarget;
     HRESULT hr;
     m_bPartialList = FALSE;
     for (;;)
     {
         // get next item
-        LPWSTR pszItem;
-        ULONG cGot;
         hr = m_pEnum->Next(1, &pszItem, &cGot);
         //TRACE("m_pEnum->Next(%p): 0x%08lx\n", reinterpret_cast<IUnknown *>(m_pEnum), hr);
         if (hr != S_OK)
             break;
 
-        CStringW strTarget = pszItem;
+        strTarget = pszItem;
         ::CoTaskMemFree(pszItem); // free
 
         if (m_bPartialList) // if items are too many

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1580,6 +1580,12 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
 
 INT CAutoComplete::UpdateOuterList(const CStringW& strText)
 {
+    if (strText.IsEmpty())
+    {
+        m_outerList.RemoveAll();
+        return 0;
+    }
+
     if (m_bPartialList)
     {
         // it is already filtered
@@ -1611,10 +1617,7 @@ INT CAutoComplete::UpdateOuterList(const CStringW& strText)
 
     // set the item count of the virtual listview
     INT cItems = m_outerList.GetSize();
-    if (strText.IsEmpty())
-        cItems = 0;
     m_hwndList.SendMessageW(LVM_SETITEMCOUNT, cItems, 0);
-
     return cItems; // the number of items
 }
 

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -707,7 +707,7 @@ CStringW CAutoComplete::GetItemText(INT iItem) const
     return m_outerList[iItem];
 }
 
-CStringW CAutoComplete::GetEditText()
+CStringW CAutoComplete::GetEditText() const
 {
     WCHAR szText[L_MAX_URL_LENGTH];
     if (::GetWindowTextW(m_hwndEdit, szText, _countof(szText)))

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1454,7 +1454,7 @@ BOOL CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText
             return TRUE;
         }
     }
-    if (::StrCmpNIW(strTarget, strText, strText.GetLength()) == 0)
+    else if (::StrCmpNIW(strTarget, strText, strText.GetLength()) == 0)
     {
         return TRUE;
     }

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1443,7 +1443,7 @@ VOID CAutoComplete::RepositionDropDown()
     ShowWindow(SW_SHOWNOACTIVATE);
 }
 
-INT CAutoComplete::ReLoadInnerList()
+INT CAutoComplete::ReLoadInnerList(const CStringW& strText)
 {
     m_innerList.RemoveAll(); // clear contents
 
@@ -1517,7 +1517,7 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
     if (bExpand || m_innerList.GetSize() == 0)
     {
         // reload the inner list
-        ReLoadInnerList();
+        ReLoadInnerList(strText);
     }
 
     return m_innerList.GetSize();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1524,10 +1524,8 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
     return m_innerList.GetSize();
 }
 
-INT CAutoComplete::UpdateOuterList()
+INT CAutoComplete::UpdateOuterList(const CStringW& strText)
 {
-    CStringW strText = GetEditText(); // get the text
-
     // update the outer list from the inner list
     m_outerList.RemoveAll();
     for (INT iItem = 0; iItem < m_innerList.GetSize(); ++iItem)
@@ -1549,9 +1547,8 @@ INT CAutoComplete::UpdateOuterList()
         }
     }
 
-    // sort the list
+    // sort and unique
     DoSort(m_outerList);
-    // unique
     DoUniqueAndTrim(m_outerList);
 
     // set the item count of the virtual listview
@@ -1588,7 +1585,7 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
         SelectItem(-1); // select none
         m_bInSelectItem = FALSE;
 
-        if (UpdateOuterList())
+        if (UpdateOuterList(strText))
             RepositionDropDown();
         else
             HideDropDown();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -721,9 +721,8 @@ VOID CAutoComplete::SetEditText(LPCWSTR pszText)
     m_bInSetText = FALSE;
 }
 
-CStringW CAutoComplete::GetStemText()
+CStringW CAutoComplete::GetStemText(const CStringW& strText)
 {
-    CStringW strText = GetEditText();
     INT ich = strText.ReverseFind(L'\\');
     if (ich == -1)
         return L""; // no stem
@@ -1490,7 +1489,7 @@ INT CAutoComplete::UpdateInnerList(const CStringW& strText)
     m_strText = strText;
 
     // do expand the items if the stem is changed
-    CStringW strStemText = GetStemText();
+    CStringW strStemText = GetStemText(strText);
     if (m_strStemText.CompareNoCase(strStemText) != 0)
     {
         m_strStemText = strStemText;

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -668,34 +668,34 @@ CAutoComplete::~CAutoComplete()
     m_pACList.Release();
 }
 
-BOOL CAutoComplete::CanAutoSuggest() const
+inline BOOL CAutoComplete::CanAutoSuggest() const
 {
     return !!(m_dwOptions & ACO_AUTOSUGGEST) && m_bEnabled;
 }
 
-BOOL CAutoComplete::CanAutoAppend() const
+inline BOOL CAutoComplete::CanAutoAppend() const
 {
     return !!(m_dwOptions & ACO_AUTOAPPEND) && m_bEnabled;
 }
 
-BOOL CAutoComplete::UseTab() const
+inline BOOL CAutoComplete::UseTab() const
 {
     return !!(m_dwOptions & ACO_USETAB) && m_bEnabled;
 }
 
-BOOL CAutoComplete::IsComboBoxDropped() const
+inline BOOL CAutoComplete::IsComboBoxDropped() const
 {
     if (!::IsWindow(m_hwndCombo))
         return FALSE;
     return (BOOL)::SendMessageW(m_hwndCombo, CB_GETDROPPEDSTATE, 0, 0);
 }
 
-BOOL CAutoComplete::FilterPrefixes() const
+inline BOOL CAutoComplete::FilterPrefixes() const
 {
     return !!(m_dwOptions & ACO_FILTERPREFIXES) && m_bEnabled;
 }
 
-INT CAutoComplete::GetItemCount() const
+inline INT CAutoComplete::GetItemCount() const
 {
     return m_outerList.GetSize();
 }
@@ -707,7 +707,7 @@ CStringW CAutoComplete::GetItemText(INT iItem) const
     return m_outerList[iItem];
 }
 
-CStringW CAutoComplete::GetEditText() const
+inline CStringW CAutoComplete::GetEditText() const
 {
     WCHAR szText[L_MAX_URL_LENGTH];
     if (::GetWindowTextW(m_hwndEdit, szText, _countof(szText)))
@@ -722,7 +722,7 @@ VOID CAutoComplete::SetEditText(LPCWSTR pszText)
     m_bInSetText = FALSE;
 }
 
-CStringW CAutoComplete::GetStemText(const CStringW& strText) const
+inline CStringW CAutoComplete::GetStemText(const CStringW& strText) const
 {
     INT ich = strText.ReverseFind(L'\\');
     if (ich == -1)

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1354,7 +1354,7 @@ VOID CAutoComplete::LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickC
     }
 }
 
-CStringW CAutoComplete::GetQuickEdit(LPCWSTR pszText)
+CStringW CAutoComplete::GetQuickEdit(LPCWSTR pszText) const
 {
     if (pszText[0] == 0 || m_strQuickComplete.IsEmpty())
         return pszText;

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -668,39 +668,39 @@ CAutoComplete::~CAutoComplete()
     m_pACList.Release();
 }
 
-inline BOOL CAutoComplete::CanAutoSuggest() const
+BOOL CAutoComplete::CanAutoSuggest() const
 {
     return !!(m_dwOptions & ACO_AUTOSUGGEST) && m_bEnabled;
 }
 
-inline BOOL CAutoComplete::CanAutoAppend() const
+BOOL CAutoComplete::CanAutoAppend() const
 {
     return !!(m_dwOptions & ACO_AUTOAPPEND) && m_bEnabled;
 }
 
-inline BOOL CAutoComplete::UseTab() const
+BOOL CAutoComplete::UseTab() const
 {
     return !!(m_dwOptions & ACO_USETAB) && m_bEnabled;
 }
 
-inline BOOL CAutoComplete::IsComboBoxDropped() const
+BOOL CAutoComplete::IsComboBoxDropped() const
 {
     if (!::IsWindow(m_hwndCombo))
         return FALSE;
     return (BOOL)::SendMessageW(m_hwndCombo, CB_GETDROPPEDSTATE, 0, 0);
 }
 
-inline BOOL CAutoComplete::FilterPrefixes() const
+BOOL CAutoComplete::FilterPrefixes() const
 {
     return !!(m_dwOptions & ACO_FILTERPREFIXES) && m_bEnabled;
 }
 
-inline INT CAutoComplete::GetItemCount() const
+INT CAutoComplete::GetItemCount() const
 {
     return m_outerList.GetSize();
 }
 
-inline CStringW CAutoComplete::GetItemText(INT iItem) const
+CStringW CAutoComplete::GetItemText(INT iItem) const
 {
     if (iItem < 0 || m_outerList.GetSize() <= iItem)
         return L"";
@@ -715,14 +715,14 @@ CStringW CAutoComplete::GetEditText() const
     return L"";
 }
 
-inline VOID CAutoComplete::SetEditText(LPCWSTR pszText)
+VOID CAutoComplete::SetEditText(LPCWSTR pszText)
 {
     m_bInSetText = TRUE; // don't hide drop-down
     ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, WM_SETTEXT, 0, reinterpret_cast<LPARAM>(pszText));
     m_bInSetText = FALSE;
 }
 
-inline CStringW CAutoComplete::GetStemText(const CStringW& strText) const
+CStringW CAutoComplete::GetStemText(const CStringW& strText) const
 {
     INT ich = strText.ReverseFind(L'\\');
     if (ich == -1)
@@ -730,7 +730,7 @@ inline CStringW CAutoComplete::GetStemText(const CStringW& strText) const
     return strText.Left(ich + 1);
 }
 
-inline VOID CAutoComplete::SetEditSel(INT ich0, INT ich1)
+VOID CAutoComplete::SetEditSel(INT ich0, INT ich1)
 {
     ::CallWindowProcW(m_fnOldEditProc, m_hwndEdit, EM_SETSEL, ich0, ich1);
 }
@@ -756,7 +756,7 @@ VOID CAutoComplete::HideDropDown()
     ShowWindow(SW_HIDE);
 }
 
-inline VOID CAutoComplete::SelectItem(INT iItem)
+VOID CAutoComplete::SelectItem(INT iItem)
 {
     m_hwndList.SetCurSel(iItem);
     if (iItem != -1)
@@ -1463,7 +1463,6 @@ BOOL CAutoComplete::DoesMatch(const CStringW& strTarget, const CStringW& strText
 
 VOID CAutoComplete::ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array)
 {
-    // the reverse order is optimal
     for (INT iItem = array.GetSize() - 1; iItem >= 0; --iItem)
     {
         if (!DoesMatch(array[iItem], strText))
@@ -1471,12 +1470,12 @@ VOID CAutoComplete::ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW
     }
 }
 
-VOID CAutoComplete::ReLoadInnerList(const CStringW& strText)
+INT CAutoComplete::ReLoadInnerList(const CStringW& strText)
 {
     m_innerList.RemoveAll(); // clear contents
 
     if (!m_pEnum)
-        return;
+        return 0;
 
     // reload the items
     LPWSTR pszItem;
@@ -1526,17 +1525,20 @@ VOID CAutoComplete::ReLoadInnerList(const CStringW& strText)
         if (::GetTickCount() - m_dwTick >= COMPLETION_TIMEOUT)
             break; // too late
     }
+
+    return m_innerList.GetSize(); // the number of items
 }
 
 // update inner list and m_strText and m_strStemText
-VOID CAutoComplete::UpdateInnerList(const CStringW& strText)
+INT CAutoComplete::UpdateInnerList(const CStringW& strText)
 {
     BOOL bReset = FALSE, bExpand = FALSE; // flags
 
     // if previous text was empty
     if (m_strText.IsEmpty())
+    {
         bReset = TRUE;
-
+    }
     // save text
     m_strText = strText;
 
@@ -1551,7 +1553,9 @@ VOID CAutoComplete::UpdateInnerList(const CStringW& strText)
 
     // if the previous enumeration is too large
     if (m_bPartialList)
+    {
         bReset = bExpand = TRUE; // retry enumeratation
+    }
 
     // reset if necessary
     if (bReset && m_pEnum)
@@ -1571,10 +1575,15 @@ VOID CAutoComplete::UpdateInnerList(const CStringW& strText)
     }
 
     if (bExpand || m_innerList.GetSize() == 0)
-        ReLoadInnerList(strText); // reload the inner list
+    {
+        // reload the inner list
+        ReLoadInnerList(strText);
+    }
+
+    return m_innerList.GetSize();
 }
 
-VOID CAutoComplete::UpdateOuterList(const CStringW& strText)
+INT CAutoComplete::UpdateOuterList(const CStringW& strText)
 {
     if (m_bPartialList)
     {
@@ -1607,6 +1616,8 @@ VOID CAutoComplete::UpdateOuterList(const CStringW& strText)
     if (strText.IsEmpty())
         cItems = 0;
     m_hwndList.SendMessageW(LVM_SETITEMCOUNT, cItems, 0);
+
+    return cItems; // the number of items
 }
 
 VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
@@ -1623,8 +1634,8 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
     }
 
     // update inner list
-    UpdateInnerList(strText);
-    if (m_innerList.GetSize() == 0) // no items
+    UINT cItems = UpdateInnerList(strText);
+    if (cItems == 0) // no items
     {
         HideDropDown();
         return;
@@ -1636,8 +1647,7 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
         SelectItem(-1); // select none
         m_bInSelectItem = FALSE;
 
-        UpdateOuterList(strText);
-        if (m_outerList.GetSize() > 0)
+        if (UpdateOuterList(strText))
             RepositionDropDown();
         else
             HideDropDown();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1477,11 +1477,8 @@ INT CAutoComplete::ReLoadInnerList()
 }
 
 // update inner list and m_strText and m_strStemText
-INT CAutoComplete::UpdateInnerList()
+INT CAutoComplete::UpdateInnerList(const CStringW& strText)
 {
-    // get text
-    CStringW strText = GetEditText();
-
     BOOL bReset = FALSE, bExpand = FALSE; // flags
 
     // if previous text was empty
@@ -1578,7 +1575,7 @@ VOID CAutoComplete::UpdateCompletion(BOOL bAppendOK)
     }
 
     // update inner list
-    UINT cItems = UpdateInnerList();
+    UINT cItems = UpdateInnerList(strText);
     if (cItems == 0) // no items
     {
         HideDropDown();

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1284,7 +1284,7 @@ VOID CAutoComplete::UpdateDropDownState()
 }
 
 // calculate the positions of the controls
-VOID CAutoComplete::CalcRects(BOOL bDowner, RECT& rcList, RECT& rcScrollBar, RECT& rcSizeBox)
+VOID CAutoComplete::CalcRects(BOOL bDowner, RECT& rcList, RECT& rcScrollBar, RECT& rcSizeBox) const
 {
     // get the client rectangle
     RECT rcClient;

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -212,7 +212,7 @@ protected:
     CStringW GetQuickEdit(LPCWSTR pszText);
     VOID RepositionDropDown();
     INT ReLoadInnerList();
-    INT UpdateInnerList();
+    INT UpdateInnerList(const CStringW& strText);
     INT UpdateOuterList();
     VOID UpdateCompletion(BOOL bAppendOK);
     // message map

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -213,7 +213,7 @@ protected:
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
     CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();
-    INT ReLoadInnerList(const CStringW& strText);
+    VOID ReLoadInnerList(const CStringW& strText);
     INT UpdateInnerList(const CStringW& strText);
     INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -148,7 +148,7 @@ public:
     INT GetItemCount() const;
     CStringW GetItemText(INT iItem) const;
 
-    CStringW GetEditText();
+    CStringW GetEditText() const;
     VOID SetEditText(LPCWSTR pszText);
     CStringW GetStemText(const CStringW& strText) const;
     VOID SetEditSel(INT ich0, INT ich1);

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -209,7 +209,7 @@ protected:
     CSimpleArray<CStringW> m_outerList; // owner data for virtual listview
     // protected methods
     VOID UpdateDropDownState();
-    VOID CalcRects(BOOL bDowner, RECT& rcListView, RECT& rcScrollBar, RECT& rcSizeBox);
+    VOID CalcRects(BOOL bDowner, RECT& rcListView, RECT& rcScrollBar, RECT& rcSizeBox) const;
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
     CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -218,6 +218,7 @@ protected:
     INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
     VOID ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array);
+    BOOL DoesMatch(const CStringW& strTarget, const CStringW& strText) const;
     // message map
     BEGIN_MSG_MAP(CAutoComplete)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -214,8 +214,8 @@ protected:
     CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();
     VOID ReLoadInnerList(const CStringW& strText);
-    INT UpdateInnerList(const CStringW& strText);
-    INT UpdateOuterList(const CStringW& strText);
+    VOID UpdateInnerList(const CStringW& strText);
+    VOID UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
     VOID ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array);
     BOOL DoesMatch(const CStringW& strTarget, const CStringW& strText) const;

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -194,6 +194,8 @@ protected:
     HWND m_hwndEdit; // the textbox
     WNDPROC m_fnOldEditProc; // old textbox procedure
     EDITWORDBREAKPROCW m_fnOldWordBreakProc;
+    BOOL m_bPartialList; // is the list partial?
+    DWORD m_dwTick; // to check timeout
     // The following variables are non-POD:
     CStringW m_strText; // internal text (used in selecting item and reverting text)
     CStringW m_strStemText; // dirname + '\\'
@@ -215,6 +217,7 @@ protected:
     INT UpdateInnerList(const CStringW& strText);
     INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
+    VOID ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array);
     // message map
     BEGIN_MSG_MAP(CAutoComplete)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -213,9 +213,9 @@ protected:
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
     CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();
-    VOID ReLoadInnerList(const CStringW& strText);
-    VOID UpdateInnerList(const CStringW& strText);
-    VOID UpdateOuterList(const CStringW& strText);
+    INT ReLoadInnerList(const CStringW& strText);
+    INT UpdateInnerList(const CStringW& strText);
+    INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
     VOID ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array);
     BOOL DoesMatch(const CStringW& strTarget, const CStringW& strText) const;

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -213,7 +213,7 @@ protected:
     VOID RepositionDropDown();
     INT ReLoadInnerList();
     INT UpdateInnerList(const CStringW& strText);
-    INT UpdateOuterList();
+    INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
     // message map
     BEGIN_MSG_MAP(CAutoComplete)

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -211,7 +211,7 @@ protected:
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
     CStringW GetQuickEdit(LPCWSTR pszText);
     VOID RepositionDropDown();
-    INT ReLoadInnerList();
+    INT ReLoadInnerList(const CStringW& strText);
     INT UpdateInnerList(const CStringW& strText);
     INT UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -150,7 +150,7 @@ public:
 
     CStringW GetEditText();
     VOID SetEditText(LPCWSTR pszText);
-    CStringW GetStemText();
+    CStringW GetStemText(const CStringW& strText);
     VOID SetEditSel(INT ich0, INT ich1);
 
     VOID ShowDropDown();

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -140,13 +140,13 @@ public:
     HWND CreateDropDown();
     virtual ~CAutoComplete();
 
-    BOOL CanAutoSuggest();
-    BOOL CanAutoAppend();
-    BOOL UseTab();
-    BOOL IsComboBoxDropped();
-    BOOL FilterPrefixes();
-    INT GetItemCount();
-    CStringW GetItemText(INT iItem);
+    BOOL CanAutoSuggest() const;
+    BOOL CanAutoAppend() const;
+    BOOL UseTab() const;
+    BOOL IsComboBoxDropped() const;
+    BOOL FilterPrefixes() const;
+    INT GetItemCount() const;
+    CStringW GetItemText(INT iItem) const;
 
     CStringW GetEditText();
     VOID SetEditText(LPCWSTR pszText);

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -213,9 +213,9 @@ protected:
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
     CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();
-    INT ReLoadInnerList(const CStringW& strText);
-    INT UpdateInnerList(const CStringW& strText);
-    INT UpdateOuterList(const CStringW& strText);
+    VOID ReLoadInnerList(const CStringW& strText);
+    VOID UpdateInnerList(const CStringW& strText);
+    VOID UpdateOuterList(const CStringW& strText);
     VOID UpdateCompletion(BOOL bAppendOK);
     VOID ScrapeOffList(const CStringW& strText, CSimpleArray<CStringW>& array);
     BOOL DoesMatch(const CStringW& strTarget, const CStringW& strText) const;

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -150,7 +150,7 @@ public:
 
     CStringW GetEditText();
     VOID SetEditText(LPCWSTR pszText);
-    CStringW GetStemText(const CStringW& strText);
+    CStringW GetStemText(const CStringW& strText) const;
     VOID SetEditSel(INT ich0, INT ich1);
 
     VOID ShowDropDown();

--- a/dll/win32/browseui/CAutoComplete.h
+++ b/dll/win32/browseui/CAutoComplete.h
@@ -211,7 +211,7 @@ protected:
     VOID UpdateDropDownState();
     VOID CalcRects(BOOL bDowner, RECT& rcListView, RECT& rcScrollBar, RECT& rcSizeBox);
     VOID LoadQuickComplete(LPCWSTR pwszRegKeyPath, LPCWSTR pwszQuickComplete);
-    CStringW GetQuickEdit(LPCWSTR pszText);
+    CStringW GetQuickEdit(LPCWSTR pszText) const;
     VOID RepositionDropDown();
     INT ReLoadInnerList(const CStringW& strText);
     INT UpdateInnerList(const CStringW& strText);


### PR DESCRIPTION
## Purpose
Enable filtering on enumeration of large number of items to process the items correctly.
JIRA issue: [CORE-9281](https://jira.reactos.org/browse/CORE-9281)

## Proposed changes

- Add `m_bPartialList` and `m_dwTick` members.
- Add `CAutoComplete::ScrapeOffList` and `CAutoComplete::DoesMatch` methods.
- If the items are too many, enable filtering in item enumeration.
- Add `strText` parameter to some methods.
- Make some methods `const`.
- Improve match condition.

## TODO

- [x] Do test.

## Comparison

BEFORE:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 215 tests executed (0 marked as todo, 36 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 563 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66415 tests executed (0 marked as todo, 41 failures), 0 skipped.
```
AFTER:
```txt
# browseui_winetest.exe autocomplete 
autocomplete: 65 tests executed (0 marked as todo, 0 failures), 1 skipped.
# shell32_winetest.exe autocomplete 
autocomplete: 215 tests executed (0 marked as todo, 27 failures), 0 skipped.
# browseui_apitest.exe ACListISF 
ACListISF: 563 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IACLCustomMRU 
IACLCustomMRU: 331 tests executed (0 marked as todo, 0 failures), 0 skipped.
# browseui_apitest.exe IAutoComplete 
IAutoComplete: 66415 tests executed (0 marked as todo, 41 failures), 0 skipped.
```