### PR TITLE
Fixup of resource sections in GCC builds

### DIFF
--- a/drivers/bus/pcix/CMakeLists.txt
+++ b/drivers/bus/pcix/CMakeLists.txt
@@ -48,6 +48,14 @@ add_library(pcix MODULE
 
 set_module_type(pcix kernelmodedriver)
 target_link_libraries(pcix arbiter)
+if(MSVC)
+    target_link_options(pcix PRIVATE /SECTION:.rsrc,!D)
+else()
+    add_custom_command(
+        TARGET pcix POST_BUILD
+        COMMAND native-pefixup --section:.rsrc,!D $<TARGET_FILE:pcix>
+        VERBATIM)
+endif()
 add_importlibs(pcix ntoskrnl hal)
 add_pch(pcix pci.h "${PCH_SKIP_SOURCE}")
 add_dependencies(pcix pciclass)

--- a/drivers/storage/ide/pciide/CMakeLists.txt
+++ b/drivers/storage/ide/pciide/CMakeLists.txt
@@ -1,5 +1,13 @@
 
 add_library(pciide MODULE pciide.c pciide.rc)
 set_module_type(pciide kernelmodedriver)
+if(MSVC)
+    target_link_options(pciide PRIVATE /SECTION:.rsrc,!D)
+else()
+    add_custom_command(
+        TARGET pciide POST_BUILD
+        COMMAND native-pefixup --section:.rsrc,!D $<TARGET_FILE:pciide>
+        VERBATIM)
+endif()
 add_importlibs(pciide pciidex ntoskrnl)
 add_cd_file(TARGET pciide DESTINATION reactos/system32/drivers NO_CAB FOR all)

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -307,7 +307,7 @@ function(set_module_type_toolchain MODULE TYPE)
         # Fixup section characteristics
         #  - Remove flags that LD overzealously puts (alignment flag, Initialized flags for code sections)
         #  - INIT section is made discardable
-        #  - .rsrc is made read-only
+        #  - .rsrc is made read-only and discardable
         #  - PAGE & .edata sections are made pageable.
         add_custom_command(TARGET ${MODULE} POST_BUILD
             COMMAND native-pefixup --${TYPE} $<TARGET_FILE:${MODULE}>)

--- a/sdk/tools/pefixup.c
+++ b/sdk/tools/pefixup.c
@@ -142,9 +142,15 @@ static int driver_fixup(enum fixup_mode mode, unsigned char *buffer, PIMAGE_NT_H
         if (Section->Characteristics & IMAGE_SCN_CNT_CODE)
             Section->Characteristics &= ~IMAGE_SCN_CNT_INITIALIZED_DATA;
 
-        /* For some reason, .rsrc is made writable by windres */
         if (strncmp((char*)Section->Name, ".rsrc", 5) == 0)
         {
+            /* .rsrc is discardable for driver images, WDM drivers and Kernel-Mode DLLs */
+            if (mode == MODE_KERNELDRIVER || mode == MODE_WDMDRIVER || mode == MODE_KERNELDLL)
+            {
+                Section->Characteristics |= IMAGE_SCN_MEM_DISCARDABLE;
+            }
+
+            /* For some reason, .rsrc is made writable by windres */
             Section->Characteristics &= ~IMAGE_SCN_MEM_WRITE;
             continue;
         }
@@ -356,10 +362,10 @@ print_usage(void)
     printf("Usage: %s <options> <filename>\n\n", g_ApplicationName);
     printf("<options> can be one of the following options:\n"
            "  --loadconfig          Fix the LOAD_CONFIG directory entry;\n"
-           "  --kernelmodedriver    Fix code and data sections for driver images;\n"
-           "  --wdmdriver           Fix code and data sections for WDM drivers;\n"
-           "  --kerneldll           Fix code and data sections for Kernel-Mode DLLs;\n"
-           "  --kernel              Fix code and data sections for kernels;\n"
+           "  --kernelmodedriver    Fix code, data and resource sections for driver images;\n"
+           "  --wdmdriver           Fix code, data and resource sections for WDM drivers;\n"
+           "  --kerneldll           Fix code, data and resource sections for Kernel-Mode DLLs;\n"
+           "  --kernel              Fix code, data and resource sections for kernels;\n"
            "\n"
            "and/or a combination of the following ones:\n"
            "  --section:name[=newname][,[[!]{CDEIKOMPRSUW}][A{1248PTSX}]]\n"


### PR DESCRIPTION
## Proposed changes

- GCC: Make resource sections discardable for kernel-mode drivers and DLLs
- Fix pciide and pcix drivers

JIRA issue: [CORE-17401](https://jira.reactos.org/browse/CORE-17401)
