### PR TITLE
[HHPCOMP] Add ARM64/AARCH64 types

### DIFF
--- a/sdk/tools/hhpcomp/chmc/chm.h
+++ b/sdk/tools/hhpcomp/chmc/chm.h
@@ -59,9 +59,11 @@ typedef unsigned long           UInt32;
 typedef long long               Int64;
 typedef unsigned long long      UInt64;
 
-/* x86-64 */
+/* x86-64        */
+/* IA-64         */
+/* ARM64/AArch64 */
 /* Note that these may be appropriate for other 64-bit machines. */
-#elif __x86_64__ || __ia64__
+#elif __x86_64__ || __ia64__ || __aarch64__
 typedef unsigned char           UChar;
 typedef short                   Int16;
 typedef unsigned short          UInt16;


### PR DESCRIPTION
These were missing.. not anymore!


Tested on a PinePhone of all things..

Big hack that allows it to build (on Linux for Linux.. arm-windows-winpe in llvm when!?):

`
mkdir build
cd build
cmake .. -DARCH=arm -DWINARCH=arm -DCMAKE_CXX_COMPILER=g++ -DCMAKE_C_COMPILER=gcc -DCMAKE_C_COMPILER_TARGET=aarch64-linux-eabi -DCMAKE_CXX_COMPILER_TARGET=aarch64-linux-eabi -DCMAKE_C_COMPILER_FORCED=TRUE -DCMAKE_CXX_COMPILER_FORCED=TRUE -DLD_EXECUTABLE=ld
make -j4 -k
`

The apps that managed to build do run on linux/arm64.