### PR TITLE
[MSHTML] MSVC: There is no 'error C4028' anymore

### DIFF
--- a/dll/win32/mshtml/CMakeLists.txt
+++ b/dll/win32/mshtml/CMakeLists.txt
@@ -100,11 +100,6 @@ add_library(mshtml MODULE
     rsrc.rc
     ${CMAKE_CURRENT_BINARY_DIR}/mshtml.def)
 
-if(MSVC)
-    # error C4028: formal parameter 3 different from declaration
-    remove_target_compile_option(mshtml "/we4028")
-endif()
-
 list(APPEND mshtml_rc_deps
     ${CMAKE_CURRENT_SOURCE_DIR}/blank.htm
     ${CMAKE_CURRENT_SOURCE_DIR}/mshtml.inf


### PR DESCRIPTION
MSVC amd64
'...\dll\win32\mshtml\nsio.c(3755): error C4028: formal parameter 3 different from declaration'
was fixed by 5ed1867.

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)