### PR TITLE
[CMAKE] winetests/: Move '/wd4133' to gdiplus/ only

### DIFF
--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -4,7 +4,6 @@ add_definitions(-D__ROS_LONG64__)
 if(MSVC)
     add_compile_options(
         /wd4090 # C4090: 'function': different 'const' qualifiers
-        /wd4133 # C4133: 'function': incompatible types - from '<enum> *' to 'UINT *'
         /wd4146 # C4146: unary minus operator applied to unsigned type, result still unsigned
         /wd4189 # C4189: 'x': local variable is initialized but not referenced
         /wd4267 # C4267: '=': conversion from 'size_t' to 'int', possible loss of data

--- a/modules/rostests/winetests/gdiplus/CMakeLists.txt
+++ b/modules/rostests/winetests/gdiplus/CMakeLists.txt
@@ -32,4 +32,5 @@ add_rostests_file(TARGET gdiplus_winetest)
 if(MSVC)
     # error C4133: 'function': incompatible types - from 'ImageFlags *' to 'UINT *'
     remove_target_compile_option(gdiplus_winetest "/we4133")
+    target_compile_options(gdiplus_winetest PRIVATE /wd4133)
 endif()


### PR DESCRIPTION
Is more explicit and re-enables the warning for all the other modules.

Addendum to 42d2d5e.
JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)