### PR TITLE
Fix a few MSVC amd64 C4334 warnings

### DIFF
--- a/base/applications/taskmgr/affinity.c
+++ b/base/applications/taskmgr/affinity.c
@@ -90,13 +90,13 @@ AffinityDialogWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
             /*
              * Enable a checkbox for each processor present in the system
              */
-            if (dwSystemAffinityMask & (1 << nCpu))
+            if (dwSystemAffinityMask & ((DWORD_PTR)1 << nCpu))
                 EnableWindow(GetDlgItem(hDlg, dwCpuTable[nCpu]), TRUE);
             /*
              * Check each checkbox that the current process
              * has affinity with
              */
-            if (dwProcessAffinityMask & (1 << nCpu))
+            if (dwProcessAffinityMask & ((DWORD_PTR)1 << nCpu))
                 CheckDlgButton(hDlg, dwCpuTable[nCpu], BST_CHECKED);
         }
 
@@ -124,7 +124,7 @@ AffinityDialogWndProc(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
                  * checkbox that the user checked.
                  */
                 if (IsDlgButtonChecked(hDlg, dwCpuTable[nCpu]))
-                    dwProcessAffinityMask |= (1 << nCpu);
+                    dwProcessAffinityMask |= ((DWORD_PTR)1 << nCpu);
             }
 
             /*

--- a/sdk/lib/rtl/compress.c
+++ b/sdk/lib/rtl/compress.c
@@ -59,7 +59,15 @@ static PUCHAR lznt1_decompress_chunk(UCHAR *dst, ULONG dst_size, UCHAR *src, ULO
 
                 /* find length / displacement bits */
                 for (displacement_bits = 12; displacement_bits > 4; displacement_bits--)
+#ifndef __REACTOS__
                     if ((1 << (displacement_bits - 1)) < dst_cur - dst) break;
+#else
+// Wine is not interested in fixing this MSVC amd64 C4334 "false positive" (a.k.a. no actual bug).
+                {
+                    if (((SIZE_T)1 << (displacement_bits - 1)) < dst_cur - dst)
+                        break;
+                }
+#endif
                 length_bits       = 16 - displacement_bits;
                 code_length       = (code & ((1 << length_bits) - 1)) + 3;
                 code_displacement = (code >> length_bits) + 1;
@@ -85,7 +93,6 @@ static PUCHAR lznt1_decompress_chunk(UCHAR *dst, ULONG dst_size, UCHAR *src, ULO
             }
             flags >>= 1;
         }
-
     }
 
     return dst_cur;

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -2162,13 +2162,13 @@ DIB_FreeConvertedBitmapInfo(BITMAPINFO* converted, BITMAPINFO* orig, DWORD usage
         if(!numColors) numColors = 1 << pbmci->bmciHeader.bcBitCount;
         if(usage == DIB_PAL_COLORS)
         {
-            RtlZeroMemory(pbmci->bmciColors, (1 << pbmci->bmciHeader.bcBitCount) * sizeof(WORD));
+            RtlZeroMemory(pbmci->bmciColors, ((SIZE_T)1 << pbmci->bmciHeader.bcBitCount) * sizeof(WORD));
             RtlCopyMemory(pbmci->bmciColors, converted->bmiColors, numColors * sizeof(WORD));
         }
         else
         {
             UINT i;
-            RtlZeroMemory(pbmci->bmciColors, (1 << pbmci->bmciHeader.bcBitCount) * sizeof(RGBTRIPLE));
+            RtlZeroMemory(pbmci->bmciColors, ((SIZE_T)1 << pbmci->bmciHeader.bcBitCount) * sizeof(RGBTRIPLE));
             for(i=0; i<numColors; i++)
             {
                 pbmci->bmciColors[i].rgbtRed = converted->bmiColors[i].rgbRed;


### PR DESCRIPTION
Trivial.

'...(...): warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)'