### PR TITLE
[SDK][XDK] Fix C_ASSERT and Clang-CL (i386) build

### DIFF
--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,7 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+#define C_ASSERT(expr) extern char (*c_assert[(expr) ? 1 : -1])(void)
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,7 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) extern char (*c_assert[(expr) ? 1 : -1])(void)
+#define C_ASSERT(expr) typedef char (*c_assert[(expr) ? 1 : -1])(void)
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,13 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) typedef char (*c_assert[(expr) ? 1 : -1])(void)
+#ifndef C_ASSERT
+# ifdef _MSC_VER
+#  define C_ASSERT(e) typedef char __C_ASSERT__[(e)?1:-1]
+# else
+#  define C_ASSERT(e) extern void __C_ASSERT__(int [(e)?1:-1])
+# endif
+#endif
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)


### PR DESCRIPTION
## Purpose

Trying to fix Clang-CL (i386) build.
JIRA issue: N/A

Clang-CL (i386) was failing:
```txt
In file included from D:\a\reactos\reactos\src\dll\appcompat\apphelp\shimeng.c:16:
D:\a\reactos\reactos\src\dll\appcompat\apphelp/shimeng.h(40,1): error: function declaration cannot have variably modified type
C_ASSERT(offsetof(HOOKAPIEX, pShimInfo) == offsetof(HOOKAPI, Reserved));
^
sdk\include\psdk\winnt.h(807,38): note: expanded from macro 'C_ASSERT'
#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
```

## Proposed changes

- Change `C_ASSERT` macro definition in `sdk/include/xdk/ntbasedef.h`.

## TODO

- [ ] Confirm whether the build is fixed.
- [ ] Get consensus