### PR TITLE
[SDK][INCLUDE] Fix offsetof and CCSIZEOF_STRUCT for Clang-CL build

### DIFF
--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -377,7 +377,7 @@ typedef __WCHAR_TYPE__ wchar_t;
 #ifndef offsetof
 
 /* Offset of member MEMBER in a struct of type TYPE. */
-#if defined(__GNUC__)
+#if defined(__GNUC__) || defined(__clang__)
 #define offsetof(TYPE, MEMBER) __builtin_offsetof (TYPE, MEMBER)
 #else
 #define offsetof(TYPE, MEMBER) ((size_t)&(((TYPE *)0)->MEMBER))

--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -388,9 +388,9 @@ typedef __WCHAR_TYPE__ wchar_t;
 #  endif
 # else
 #  ifdef _WIN64
-#   define offsetof(TYPE,MEMBER) ((size_t)(ptrdiff_t)&(((TYPE *)0)->MEMBER))
+#   define offsetof(TYPE,MEMBER) ((size_t)(ptrdiff_t)&(((TYPE*)0)->MEMBER))
 #  else
-#   define offsetof(TYPE,MEMBER) ((size_t)&(((TYPE *)0)->MEMBER))
+#   define offsetof(TYPE,MEMBER) ((size_t)&(((TYPE*)0)->MEMBER))
 #  endif
 # endif
 #endif

--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -382,9 +382,9 @@ typedef __WCHAR_TYPE__ wchar_t;
 #else
 # ifdef __cplusplus
 #  ifdef _WIN64
-#   define offsetof(TYPE,MEMBER) ((::size_t)(ptrdiff_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m)))
+#   define offsetof(TYPE,MEMBER) ((::size_t)(ptrdiff_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->MEMBER)))
 #  else
-#   define offsetof(TYPE,MEMBER) ((::size_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m)))
+#   define offsetof(TYPE,MEMBER) ((::size_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->MEMBER)))
 #  endif
 # else
 #  ifdef _WIN64

--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -377,10 +377,22 @@ typedef __WCHAR_TYPE__ wchar_t;
 #ifndef offsetof
 
 /* Offset of member MEMBER in a struct of type TYPE. */
-#if defined(__GNUC__) || defined(__clang__)
-#define offsetof(TYPE, MEMBER) __builtin_offsetof (TYPE, MEMBER)
+#if defined(__GNUC__) || defined(__clang__) || defined(_CRT_USE_BUILTIN_OFFSETOF)
+# define offsetof(TYPE,MEMBER) __builtin_offsetof(TYPE,MEMBER)
 #else
-#define offsetof(TYPE, MEMBER) ((size_t)&(((TYPE *)0)->MEMBER))
+# ifdef __cplusplus
+#  ifdef _WIN64
+#   define offsetof(TYPE,MEMBER) ((::size_t)((ptrdiff_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m))))
+#  else
+#   define offsetof(TYPE,MEMBER) ((::size_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m)))
+#  endif
+# else
+#  ifdef _WIN64
+#   define offsetof(TYPE,MEMBER) ((size_t)(ptrdiff_t)&(((TYPE *)0)->MEMBER))
+#  else
+#   define offsetof(TYPE,MEMBER) ((size_t)&(((TYPE *)0)->MEMBER))
+#  endif
+# endif
 #endif
 
 #endif /* !offsetof */

--- a/sdk/include/crt/stddef.h
+++ b/sdk/include/crt/stddef.h
@@ -382,7 +382,7 @@ typedef __WCHAR_TYPE__ wchar_t;
 #else
 # ifdef __cplusplus
 #  ifdef _WIN64
-#   define offsetof(TYPE,MEMBER) ((::size_t)((ptrdiff_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m))))
+#   define offsetof(TYPE,MEMBER) ((::size_t)(ptrdiff_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m)))
 #  else
 #   define offsetof(TYPE,MEMBER) ((::size_t)&reinterpret_cast<const volatile char&>((((TYPE*)0)->m)))
 #  endif

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -147,7 +147,7 @@ extern "C" {
 #define NM_THEMECHANGED (NM_FIRST-22)
 
 #ifndef CCSIZEOF_STRUCT
-#if defined(__GNUC__) || defined(__clang__)
+#if defined(__clang__) /* See CORE-17547 */
 #define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname,member) + sizeof(((structname*)0)->member))
 #else
 #define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -147,7 +147,11 @@ extern "C" {
 #define NM_THEMECHANGED (NM_FIRST-22)
 
 #ifndef CCSIZEOF_STRUCT
+#ifdef __clang__
+#define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname, member) + sizeof(((structname *)NULL)->mem))
+#else
 #define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))
+#endif
 #endif
 
   typedef struct tagNMTOOLTIPSCREATED {

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -148,7 +148,7 @@ extern "C" {
 
 #ifndef CCSIZEOF_STRUCT
 #ifdef __clang__
-#define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname, member) + sizeof(((structname *)NULL)->member))
+#define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname,member) + sizeof(((structname*)0)->member))
 #else
 #define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))
 #endif

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -147,7 +147,7 @@ extern "C" {
 #define NM_THEMECHANGED (NM_FIRST-22)
 
 #ifndef CCSIZEOF_STRUCT
-#if defined(__clang__) /* See CORE-17547 */
+#if defined(__clang__) /* Clang-CL fails without this workaround. See CORE-17547 */
 #define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname,member) + sizeof(((structname*)0)->member))
 #else
 #define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -150,7 +150,7 @@ extern "C" {
 #if defined(__GNUC__) || defined(__clang__)
 #define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname,member) + sizeof(((structname*)0)->member))
 #else
-#define CCSIZEOF_STRUCT(structname,member) ((size_t)&(((structname*)0)->member) + sizeof(((structname*)0)->member))
+#define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))
 #endif
 #endif
 

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -147,10 +147,10 @@ extern "C" {
 #define NM_THEMECHANGED (NM_FIRST-22)
 
 #ifndef CCSIZEOF_STRUCT
-#ifdef __clang__
+#if defined(__GNUC__) || defined(__clang__)
 #define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname,member) + sizeof(((structname*)0)->member))
 #else
-#define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))
+#define CCSIZEOF_STRUCT(structname,member) ((size_t)&(((structname*)0)->member) + sizeof(((structname*)0)->member))
 #endif
 #endif
 

--- a/sdk/include/psdk/commctrl.h
+++ b/sdk/include/psdk/commctrl.h
@@ -148,7 +148,7 @@ extern "C" {
 
 #ifndef CCSIZEOF_STRUCT
 #ifdef __clang__
-#define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname, member) + sizeof(((structname *)NULL)->mem))
+#define CCSIZEOF_STRUCT(structname,member) (__builtin_offsetof(structname, member) + sizeof(((structname *)NULL)->member))
 #else
 #define CCSIZEOF_STRUCT(structname,member) (((int)((LPBYTE)(&((structname*)0)->member) - ((LPBYTE)((structname*)0))))+sizeof(((structname*)0)->member))
 #endif


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17547](https://jira.reactos.org/browse/CORE-17547)

Clang-CL (i386) was failing:
```txt
In file included from D:\a\reactos\reactos\src\dll\appcompat\apphelp\shimeng.c:16:
D:\a\reactos\reactos\src\dll\appcompat\apphelp/shimeng.h(40,1): error: function declaration cannot have variably modified type
C_ASSERT(offsetof(HOOKAPIEX, pShimInfo) == offsetof(HOOKAPI, Reserved));
^
sdk\include\psdk\winnt.h(807,38): note: expanded from macro 'C_ASSERT'
#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
```
## Proposed changes

- Fix `offsetof` macro of CRT `<stddef.h>` if `__clang__` is defined.
- Fix `CCSIZEOF_STRUCT` macro in `<commctrl.h>`, using `__builtin_offsetof` operator.

## TODO

- [x] Check whether the build is fixed.
- [x] Get consensus.
