### PR TITLE
[CMDUTILS][FC] Implement text file comparison

### DIFF
--- a/base/applications/cmdutils/fc/CMakeLists.txt
+++ b/base/applications/cmdutils/fc/CMakeLists.txt
@@ -1,6 +1,6 @@
 include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/conutils)
 
-add_executable(fc fc.c fc.rc)
+add_executable(fc fc.c texta.c textw.c fc.rc)
 set_module_type(fc win32cui UNICODE)
 target_link_libraries(fc conutils ${PSEH_LIB})
 add_importlibs(fc msvcrt user32 kernel32)

--- a/base/applications/cmdutils/fc/CMakeLists.txt
+++ b/base/applications/cmdutils/fc/CMakeLists.txt
@@ -2,6 +2,6 @@ include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/conutils)
 
 add_executable(fc fc.c texta.c textw.c fc.rc)
 set_module_type(fc win32cui UNICODE)
-target_link_libraries(fc conutils ${PSEH_LIB})
-add_importlibs(fc msvcrt user32 kernel32)
+target_link_libraries(fc conutils wine ${PSEH_LIB})
+add_importlibs(fc msvcrt user32 kernel32 ntdll)
 add_cd_file(TARGET fc DESTINATION reactos/system32 FOR all)

--- a/base/applications/cmdutils/fc/fc.c
+++ b/base/applications/cmdutils/fc/fc.c
@@ -64,28 +64,19 @@ VOID PrintDots(VOID)
     ConPuts(StdOut, L"...\n");
 }
 
-VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz)
+VOID PrintLineW(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz)
 {
     if (pFC->dwFlags & FLAG_N)
         ConPrintf(StdOut, L"%5d:  %ls\n", lineno, psz);
     else
         ConPrintf(StdOut, L"%ls\n", psz);
 }
-VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz)
+VOID PrintLineA(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz)
 {
     if (pFC->dwFlags & FLAG_N)
         ConPrintf(StdOut, L"%5d:  %hs\n", lineno, psz);
     else
         ConPrintf(StdOut, L"%hs\n", psz);
-}
-
-VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node)
-{
-    PrintLine2W(pFC, node->lineno, node->pszLine);
-}
-VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node)
-{
-    PrintLine2A(pFC, node->lineno, node->pszLine);
 }
 
 HANDLE DoOpenFileForInput(LPCWSTR file)
@@ -330,6 +321,8 @@ static FCRET FileCompare(FILECOMPARE *pFC)
 
 static FCRET WildcardFileCompare(FILECOMPARE *pFC)
 {
+    FCRET ret;
+
     if (pFC->dwFlags & FLAG_HELP)
     {
         ConResPuts(StdOut, IDS_USAGE);
@@ -348,7 +341,9 @@ static FCRET WildcardFileCompare(FILECOMPARE *pFC)
         ConResPuts(StdErr, IDS_CANT_USE_WILDCARD);
     }
 
-    return FileCompare(pFC);
+    ret = FileCompare(pFC);
+    ConPuts(StdOut, L"\n");
+    return ret;
 }
 
 int wmain(int argc, WCHAR **argv)

--- a/base/applications/cmdutils/fc/fc.c
+++ b/base/applications/cmdutils/fc/fc.c
@@ -10,6 +10,7 @@
     #include <conutils.h>
 #else
     #include <stdio.h>
+    #define ConInitStdStreams() /* empty */
     #define StdOut stdout
     #define StdErr stderr
     void ConPuts(FILE *fp, LPCWSTR psz)
@@ -26,7 +27,7 @@
     void ConResPuts(FILE *fp, UINT nID)
     {
         WCHAR sz[MAX_PATH];
-        LoadStringW(NULL, nID, sz, MAX_PATH);
+        LoadStringW(NULL, nID, sz, _countof(sz));
         fputws(sz, fp);
     }
     void ConResPrintf(FILE *fp, UINT nID, ...)
@@ -34,7 +35,7 @@
         va_list va;
         WCHAR sz[MAX_PATH];
         va_start(va, nID);
-        LoadStringW(NULL, nID, sz, MAX_PATH);
+        LoadStringW(NULL, nID, sz, _countof(sz));
         vfwprintf(fp, sz, va);
         va_end(va);
     }
@@ -377,10 +378,9 @@ int wmain(int argc, WCHAR **argv)
     PWCHAR endptr;
     INT i;
 
-#ifdef __REACTOS__
     /* Initialize the Console Standard Streams */
     ConInitStdStreams();
-#endif
+
     for (i = 1; i < argc; ++i)
     {
         if (argv[i][0] != L'/')

--- a/base/applications/cmdutils/fc/fc.c
+++ b/base/applications/cmdutils/fc/fc.c
@@ -43,7 +43,7 @@ FCRET InvalidSwitch(VOID)
     return FCRET_INVALID;
 }
 
-FCRET ResynchFailed(VOID)
+FCRET ResyncFailed(VOID)
 {
     ConResPuts(StdOut, IDS_RESYNC_FAILED);
     return FCRET_DIFFERENT;

--- a/base/applications/cmdutils/fc/fc.c
+++ b/base/applications/cmdutils/fc/fc.c
@@ -49,22 +49,32 @@ FCRET ResyncFailed(VOID)
     return FCRET_DIFFERENT;
 }
 
-VOID ShowCaption(LPCWSTR file)
+VOID PrintCaption(LPCWSTR file)
 {
     ConPrintf(StdOut, L"***** %ls\n", file);
+}
+
+VOID PrintEndOfDiff(VOID)
+{
+    ConPuts(StdOut, L"*****\n\n");
+}
+
+VOID PrintDots(VOID)
+{
+    ConPuts(StdOut, L"...\n");
 }
 
 VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz)
 {
     if (pFC->dwFlags & FLAG_N)
-        ConPrintf(StdOut, L"%5d%ls\n", lineno, psz);
+        ConPrintf(StdOut, L"%5d:  %ls\n", lineno, psz);
     else
         ConPrintf(StdOut, L"%ls\n", psz);
 }
 VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz)
 {
     if (pFC->dwFlags & FLAG_N)
-        ConPrintf(StdOut, L"%5d%hs\n", lineno, psz);
+        ConPrintf(StdOut, L"%5d:  %hs\n", lineno, psz);
     else
         ConPrintf(StdOut, L"%hs\n", psz);
 }
@@ -76,11 +86,6 @@ VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node)
 VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node)
 {
     PrintLine2A(pFC, node->lineno, node->pszLine);
-}
-
-VOID PrintDots(VOID)
-{
-    ConPrintf(StdOut, L"...\n");
 }
 
 HANDLE DoOpenFileForInput(LPCWSTR file)

--- a/base/applications/cmdutils/fc/fc.c
+++ b/base/applications/cmdutils/fc/fc.c
@@ -4,87 +4,86 @@
  * PURPOSE:     Comparing files
  * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
-#include <windef.h>
-#include <winbase.h>
-#include <winuser.h>
-#include <winnls.h>
+#include "fc.h"
 #include <conutils.h>
-#include "resource.h"
 
-// See also: https://stackoverflow.com/questions/33125766/compare-files-with-a-cmd
-typedef enum FCRET { // return code of FC command
-    FCRET_INVALID = -1,
-    FCRET_IDENTICAL = 0,
-    FCRET_DIFFERENT = 1,
-    FCRET_CANT_FIND = 2
-} FCRET;
-
-#ifdef _WIN64
-    #define MAX_VIEW_SIZE (256 * 1024 * 1024) // 256 MB
-#else
-    #define MAX_VIEW_SIZE (64 * 1024 * 1024) // 64 MB
-#endif
-
-#define FLAG_A (1 << 0)
-#define FLAG_B (1 << 1)
-#define FLAG_C (1 << 2)
-#define FLAG_L (1 << 3)
-#define FLAG_LBn (1 << 4)
-#define FLAG_N (1 << 5)
-#define FLAG_OFFLINE (1 << 6)
-#define FLAG_T (1 << 7)
-#define FLAG_U (1 << 8)
-#define FLAG_W (1 << 9)
-#define FLAG_nnnn (1 << 10)
-#define FLAG_HELP (1 << 11)
-
-typedef struct FILECOMPARE
-{
-    DWORD dwFlags; // FLAG_...
-    INT n, nnnn;
-    LPCWSTR file1, file2;
-} FILECOMPARE;
-
-static FCRET NoDifference(VOID)
+FCRET NoDifference(VOID)
 {
     ConResPuts(StdOut, IDS_NO_DIFFERENCE);
     return FCRET_IDENTICAL;
 }
 
-static FCRET Different(LPCWSTR file1, LPCWSTR file2)
+FCRET Different(LPCWSTR file1, LPCWSTR file2)
 {
     ConResPrintf(StdOut, IDS_DIFFERENT, file1, file2);
     return FCRET_DIFFERENT;
 }
 
-static FCRET LongerThan(LPCWSTR file1, LPCWSTR file2)
+FCRET LongerThan(LPCWSTR file1, LPCWSTR file2)
 {
     ConResPrintf(StdOut, IDS_LONGER_THAN, file1, file2);
     return FCRET_DIFFERENT;
 }
 
-static FCRET OutOfMemory(VOID)
+FCRET OutOfMemory(VOID)
 {
     ConResPuts(StdErr, IDS_OUT_OF_MEMORY);
     return FCRET_INVALID;
 }
 
-static FCRET CannotRead(LPCWSTR file)
+FCRET CannotRead(LPCWSTR file)
 {
     ConResPrintf(StdErr, IDS_CANNOT_READ, file);
     return FCRET_INVALID;
 }
 
-static FCRET InvalidSwitch(VOID)
+FCRET InvalidSwitch(VOID)
 {
     ConResPuts(StdErr, IDS_INVALID_SWITCH);
     return FCRET_INVALID;
 }
 
-static HANDLE DoOpenFileForInput(LPCWSTR file)
+FCRET ResynchFailed(VOID)
+{
+    ConResPuts(StdOut, IDS_RESYNC_FAILED);
+    return FCRET_DIFFERENT;
+}
+
+VOID ShowCaption(LPCWSTR file)
+{
+    ConPrintf(StdOut, L"***** %ls\n", file);
+}
+
+VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz)
+{
+    if (pFC->dwFlags & FLAG_N)
+        ConPrintf(StdOut, L"%5d%ls\n", lineno, psz);
+    else
+        ConPrintf(StdOut, L"%ls\n", psz);
+}
+VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz)
+{
+    if (pFC->dwFlags & FLAG_N)
+        ConPrintf(StdOut, L"%5d%hs\n", lineno, psz);
+    else
+        ConPrintf(StdOut, L"%hs\n", psz);
+}
+
+VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node)
+{
+    PrintLine2W(pFC, node->lineno, node->pszLine);
+}
+VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node)
+{
+    PrintLine2A(pFC, node->lineno, node->pszLine);
+}
+
+VOID PrintDots(VOID)
+{
+    ConPrintf(StdOut, L"...\n");
+}
+
+HANDLE DoOpenFileForInput(LPCWSTR file)
 {
     HANDLE hFile = CreateFileW(file, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, 0, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
@@ -103,10 +102,10 @@ static FCRET BinaryFileCompare(FILECOMPARE *pFC)
     DWORD cbView, ibView;
     BOOL fDifferent = FALSE;
 
-    hFile1 = DoOpenFileForInput(pFC->file1);
+    hFile1 = DoOpenFileForInput(pFC->file[0]);
     if (hFile1 == INVALID_HANDLE_VALUE)
         return FCRET_CANT_FIND;
-    hFile2 = DoOpenFileForInput(pFC->file2);
+    hFile2 = DoOpenFileForInput(pFC->file[1]);
     if (hFile2 == INVALID_HANDLE_VALUE)
     {
         CloseHandle(hFile1);
@@ -115,19 +114,19 @@ static FCRET BinaryFileCompare(FILECOMPARE *pFC)
 
     do
     {
-        if (_wcsicmp(pFC->file1, pFC->file2) == 0)
+        if (_wcsicmp(pFC->file[0], pFC->file[1]) == 0)
         {
             ret = NoDifference();
             break;
         }
         if (!GetFileSizeEx(hFile1, &cb1))
         {
-            ret = CannotRead(pFC->file1);
+            ret = CannotRead(pFC->file[0]);
             break;
         }
         if (!GetFileSizeEx(hFile2, &cb2))
         {
-            ret = CannotRead(pFC->file2);
+            ret = CannotRead(pFC->file[1]);
             break;
         }
         cbCommon.QuadPart = min(cb1.QuadPart, cb2.QuadPart);
@@ -137,14 +136,14 @@ static FCRET BinaryFileCompare(FILECOMPARE *pFC)
                                            cb1.HighPart, cb1.LowPart, NULL);
             if (hMapping1 == NULL)
             {
-                ret = CannotRead(pFC->file1);
+                ret = CannotRead(pFC->file[0]);
                 break;
             }
             hMapping2 = CreateFileMappingW(hFile2, NULL, PAGE_READONLY,
                                            cb2.HighPart, cb2.LowPart, NULL);
             if (hMapping2 == NULL)
             {
-                ret = CannotRead(pFC->file2);
+                ret = CannotRead(pFC->file[1]);
                 break;
             }
 
@@ -185,11 +184,11 @@ static FCRET BinaryFileCompare(FILECOMPARE *pFC)
         }
 
         if (cb1.QuadPart < cb2.QuadPart)
-            ret = LongerThan(pFC->file2, pFC->file1);
+            ret = LongerThan(pFC->file[1], pFC->file[0]);
         else if (cb1.QuadPart > cb2.QuadPart)
-            ret = LongerThan(pFC->file1, pFC->file2);
+            ret = LongerThan(pFC->file[0], pFC->file[1]);
         else if (fDifferent)
-            ret = Different(pFC->file1, pFC->file2);
+            ret = Different(pFC->file[0], pFC->file[1]);
         else
             ret = NoDifference();
     } while (0);
@@ -203,82 +202,6 @@ static FCRET BinaryFileCompare(FILECOMPARE *pFC)
     return ret;
 }
 
-static FCRET
-UnicodeTextCompare(FILECOMPARE *pFC, HANDLE hMapping1, const LARGE_INTEGER *pcb1,
-                                     HANDLE hMapping2, const LARGE_INTEGER *pcb2)
-{
-    FCRET ret;
-    BOOL fIgnoreCase = !!(pFC->dwFlags & FLAG_C);
-    DWORD dwCmpFlags = (fIgnoreCase ? NORM_IGNORECASE : 0);
-    LPCWSTR psz1, psz2;
-    LARGE_INTEGER cch1 = { .QuadPart = pcb1->QuadPart / sizeof(WCHAR) };
-    LARGE_INTEGER cch2 = { .QuadPart = pcb1->QuadPart / sizeof(WCHAR) };
-
-    do
-    {
-        psz1 = MapViewOfFile(hMapping1, FILE_MAP_READ, 0, 0, pcb1->LowPart);
-        psz2 = MapViewOfFile(hMapping2, FILE_MAP_READ, 0, 0, pcb2->LowPart);
-        if (!psz1 || !psz2)
-        {
-            ret = OutOfMemory();
-            break;
-        }
-        if (cch1.QuadPart < MAXLONG && cch2.QuadPart < MAXLONG)
-        {
-            if (CompareStringW(0, dwCmpFlags, psz1, cch1.LowPart,
-                                              psz2, cch2.LowPart) == CSTR_EQUAL)
-            {
-                ret = NoDifference();
-                break;
-            }
-        }
-        // TODO: compare each lines
-        // TODO: large file support
-        ret = Different(pFC->file1, pFC->file2);
-    } while (0);
-
-    UnmapViewOfFile(psz1);
-    UnmapViewOfFile(psz2);
-    return ret;
-}
-
-static FCRET
-AnsiTextCompare(FILECOMPARE *pFC, HANDLE hMapping1, const LARGE_INTEGER *pcb1,
-                                  HANDLE hMapping2, const LARGE_INTEGER *pcb2)
-{
-    FCRET ret;
-    BOOL fIgnoreCase = !!(pFC->dwFlags & FLAG_C);
-    DWORD dwCmpFlags = (fIgnoreCase ? NORM_IGNORECASE : 0);
-    LPSTR psz1, psz2;
-
-    do
-    {
-        psz1 = MapViewOfFile(hMapping1, FILE_MAP_READ, 0, 0, pcb1->LowPart);
-        psz2 = MapViewOfFile(hMapping2, FILE_MAP_READ, 0, 0, pcb2->LowPart);
-        if (!psz1 || !psz2)
-        {
-            ret = OutOfMemory();
-            break;
-        }
-        if (pcb1->QuadPart < MAXLONG && pcb2->QuadPart < MAXLONG)
-        {
-            if (CompareStringA(0, dwCmpFlags, psz1, pcb1->LowPart,
-                                              psz2, pcb2->LowPart) == CSTR_EQUAL)
-            {
-                ret = NoDifference();
-                break;
-            }
-        }
-        // TODO: compare each lines
-        // TODO: large file support
-        ret = Different(pFC->file1, pFC->file2);
-    } while (0);
-
-    UnmapViewOfFile(psz1);
-    UnmapViewOfFile(psz2);
-    return ret;
-}
-
 static FCRET TextFileCompare(FILECOMPARE *pFC)
 {
     FCRET ret;
@@ -286,10 +209,10 @@ static FCRET TextFileCompare(FILECOMPARE *pFC)
     LARGE_INTEGER cb1, cb2;
     BOOL fUnicode = !!(pFC->dwFlags & FLAG_U);
 
-    hFile1 = DoOpenFileForInput(pFC->file1);
+    hFile1 = DoOpenFileForInput(pFC->file[0]);
     if (hFile1 == INVALID_HANDLE_VALUE)
         return FCRET_CANT_FIND;
-    hFile2 = DoOpenFileForInput(pFC->file2);
+    hFile2 = DoOpenFileForInput(pFC->file[1]);
     if (hFile2 == INVALID_HANDLE_VALUE)
     {
         CloseHandle(hFile1);
@@ -298,19 +221,19 @@ static FCRET TextFileCompare(FILECOMPARE *pFC)
 
     do
     {
-        if (_wcsicmp(pFC->file1, pFC->file2) == 0)
+        if (_wcsicmp(pFC->file[0], pFC->file[1]) == 0)
         {
             ret = NoDifference();
             break;
         }
         if (!GetFileSizeEx(hFile1, &cb1))
         {
-            ret = CannotRead(pFC->file1);
+            ret = CannotRead(pFC->file[0]);
             break;
         }
         if (!GetFileSizeEx(hFile2, &cb2))
         {
-            ret = CannotRead(pFC->file2);
+            ret = CannotRead(pFC->file[1]);
             break;
         }
         if (cb1.QuadPart == 0 && cb2.QuadPart == 0)
@@ -322,21 +245,29 @@ static FCRET TextFileCompare(FILECOMPARE *pFC)
                                        cb1.HighPart, cb1.LowPart, NULL);
         if (hMapping1 == NULL)
         {
-            ret = CannotRead(pFC->file1);
+            ret = CannotRead(pFC->file[0]);
             break;
         }
         hMapping2 = CreateFileMappingW(hFile2, NULL, PAGE_READONLY,
                                        cb2.HighPart, cb2.LowPart, NULL);
         if (hMapping2 == NULL)
         {
-            ret = CannotRead(pFC->file2);
+            ret = CannotRead(pFC->file[1]);
             break;
         }
 
         if (fUnicode)
-            ret = UnicodeTextCompare(pFC, hMapping1, &cb1, hMapping2, &cb2);
+        {
+            ret = TextCompareW(pFC, &hMapping1, &cb1, &hMapping2, &cb2);
+            free(pFC->last_matchW[0]);
+            free(pFC->last_matchW[1]);
+        }
         else
-            ret = AnsiTextCompare(pFC, hMapping1, &cb1, hMapping2, &cb2);
+        {
+            ret = TextCompareA(pFC, &hMapping1, &cb1, &hMapping2, &cb2);
+            free(pFC->last_matchA[0]);
+            free(pFC->last_matchA[1]);
+        }
     } while (0);
 
     CloseHandle(hMapping1);
@@ -382,10 +313,10 @@ static BOOL IsBinaryExt(LPCWSTR filename)
 
 static FCRET FileCompare(FILECOMPARE *pFC)
 {
-    ConResPrintf(StdOut, IDS_COMPARING, pFC->file1, pFC->file2);
+    ConResPrintf(StdOut, IDS_COMPARING, pFC->file[0], pFC->file[1]);
 
     if (!(pFC->dwFlags & FLAG_L) &&
-        ((pFC->dwFlags & FLAG_B) || IsBinaryExt(pFC->file1) || IsBinaryExt(pFC->file2)))
+        ((pFC->dwFlags & FLAG_B) || IsBinaryExt(pFC->file[0]) || IsBinaryExt(pFC->file[1])))
     {
         return BinaryFileCompare(pFC);
     }
@@ -400,13 +331,13 @@ static FCRET WildcardFileCompare(FILECOMPARE *pFC)
         return FCRET_INVALID;
     }
 
-    if (!pFC->file1 || !pFC->file2)
+    if (!pFC->file[0] || !pFC->file[1])
     {
         ConResPuts(StdErr, IDS_NEEDS_FILES);
         return FCRET_INVALID;
     }
 
-    if (HasWildcard(pFC->file1) || HasWildcard(pFC->file2))
+    if (HasWildcard(pFC->file[0]) || HasWildcard(pFC->file[1]))
     {
         // TODO: wildcard
         ConResPuts(StdErr, IDS_CANT_USE_WILDCARD);
@@ -428,10 +359,10 @@ int wmain(int argc, WCHAR **argv)
     {
         if (argv[i][0] != L'/')
         {
-            if (!fc.file1)
-                fc.file1 = argv[i];
-            else if (!fc.file2)
-                fc.file2 = argv[i];
+            if (!fc.file[0])
+                fc.file[0] = argv[i];
+            else if (!fc.file[1])
+                fc.file[1] = argv[i];
             else
                 return InvalidSwitch();
             continue;

--- a/base/applications/cmdutils/fc/fc.h
+++ b/base/applications/cmdutils/fc/fc.h
@@ -1,0 +1,97 @@
+/*
+ * PROJECT:     ReactOS FC Command
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Comparing files
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+#pragma once
+
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <windef.h>
+#include <winbase.h>
+#include <winuser.h>
+#include <winnls.h>
+#include <wine/list.h>
+#include "resource.h"
+
+// See also: https://stackoverflow.com/questions/33125766/compare-files-with-a-cmd
+typedef enum FCRET // return code of FC command
+{
+    FCRET_INVALID = -1,
+    FCRET_IDENTICAL = 0,
+    FCRET_DIFFERENT = 1,
+    FCRET_CANT_FIND = 2,
+    FCRET_NO_MORE_DATA = 3 // (extension)
+} FCRET;
+
+typedef struct NODE_W
+{
+    struct list entry;
+    LPWSTR pszLine;
+    DWORD lineno;
+    DWORD cch;
+} NODE_W;
+typedef struct NODE_A
+{
+    struct list entry;
+    LPSTR pszLine;
+    DWORD cch;
+    DWORD lineno;
+} NODE_A;
+
+#define FLAG_A (1 << 0) // abbreviation
+#define FLAG_B (1 << 1) // binary
+#define FLAG_C (1 << 2) // ignore cases
+#define FLAG_L (1 << 3) // ASCII mode
+#define FLAG_LBn (1 << 4) // line buffers
+#define FLAG_N (1 << 5) // show line numbers
+#define FLAG_OFFLINE (1 << 6) // ???
+#define FLAG_T (1 << 7) // prevent fc from converting tabs to spaces
+#define FLAG_U (1 << 8) // Unicode
+#define FLAG_W (1 << 9) // compress white space
+#define FLAG_nnnn (1 << 10) // ???
+#define FLAG_HELP (1 << 11) // show usage
+
+typedef struct FILECOMPARE
+{
+    DWORD dwFlags; // FLAG_...
+    INT n; // # of line buffers
+    INT nnnn; // retry count before resynch
+    LPCWSTR file[2];
+    DWORD last_lineno[2];
+    LPWSTR last_matchW[2];
+    LPSTR last_matchA[2];
+    struct list list[2];
+} FILECOMPARE;
+
+// text.h
+FCRET TextCompareW(FILECOMPARE *pFC,
+                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
+                   HANDLE *phMapping2, const LARGE_INTEGER *pcb2);
+FCRET TextCompareA(FILECOMPARE *pFC,
+                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
+                   HANDLE *phMapping2, const LARGE_INTEGER *pcb2);
+
+// fc.c
+VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node);
+VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node);
+VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz);
+VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz);
+VOID PrintDots(VOID);
+FCRET NoDifference(VOID);
+FCRET Different(LPCWSTR file1, LPCWSTR file2);
+FCRET LongerThan(LPCWSTR file1, LPCWSTR file2);
+FCRET OutOfMemory(VOID);
+FCRET CannotRead(LPCWSTR file);
+FCRET InvalidSwitch(VOID);
+FCRET ResynchFailed(VOID);
+HANDLE DoOpenFileForInput(LPCWSTR file);
+VOID ShowCaption(LPCWSTR file);
+
+#ifdef _WIN64
+    #define MAX_VIEW_SIZE (256 * 1024 * 1024) // 256 MB
+#else
+    #define MAX_VIEW_SIZE (64 * 1024 * 1024) // 64 MB
+#endif

--- a/base/applications/cmdutils/fc/fc.h
+++ b/base/applications/cmdutils/fc/fc.h
@@ -8,10 +8,14 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
-#include <windef.h>
-#include <winbase.h>
-#include <winuser.h>
-#include <winnls.h>
+#ifdef __REACTOS__
+    #include <windef.h>
+    #include <winbase.h>
+    #include <winuser.h>
+    #include <winnls.h>
+#else
+    #include <windows.h>
+#endif
 #include <wine/list.h>
 #include "resource.h"
 
@@ -29,6 +33,7 @@ typedef struct NODE_W
 {
     struct list entry;
     LPWSTR pszLine;
+    LPWSTR pszComp; // compressed
     DWORD lineno;
     DWORD hash;
 } NODE_W;
@@ -36,6 +41,7 @@ typedef struct NODE_A
 {
     struct list entry;
     LPSTR pszLine;
+    LPSTR pszComp; // compressed
     DWORD lineno;
     DWORD hash;
 } NODE_A;
@@ -59,19 +65,16 @@ typedef struct FILECOMPARE
     INT n; // # of line buffers
     INT nnnn; // retry count before resynch
     LPCWSTR file[2];
-    DWORD last_lineno[2];
-    LPWSTR last_matchW[2];
-    LPSTR last_matchA[2];
     struct list list[2];
 } FILECOMPARE;
 
 // text.h
 FCRET TextCompareW(FILECOMPARE *pFC,
-                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
-                   HANDLE *phMapping2, const LARGE_INTEGER *pcb2);
+                   HANDLE *phMapping0, const LARGE_INTEGER *pcb0,
+                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1);
 FCRET TextCompareA(FILECOMPARE *pFC,
-                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
-                   HANDLE *phMapping2, const LARGE_INTEGER *pcb2);
+                   HANDLE *phMapping0, const LARGE_INTEGER *pcb0,
+                   HANDLE *phMapping1, const LARGE_INTEGER *pcb1);
 // fc.c
 VOID PrintLineW(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz);
 VOID PrintLineA(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz);
@@ -79,8 +82,8 @@ VOID PrintCaption(LPCWSTR file);
 VOID PrintEndOfDiff(VOID);
 VOID PrintDots(VOID);
 FCRET NoDifference(VOID);
-FCRET Different(LPCWSTR file1, LPCWSTR file2);
-FCRET LongerThan(LPCWSTR file1, LPCWSTR file2);
+FCRET Different(LPCWSTR file0, LPCWSTR file1);
+FCRET LongerThan(LPCWSTR file0, LPCWSTR file1);
 FCRET OutOfMemory(VOID);
 FCRET CannotRead(LPCWSTR file);
 FCRET InvalidSwitch(VOID);

--- a/base/applications/cmdutils/fc/fc.h
+++ b/base/applications/cmdutils/fc/fc.h
@@ -86,7 +86,7 @@ FCRET LongerThan(LPCWSTR file1, LPCWSTR file2);
 FCRET OutOfMemory(VOID);
 FCRET CannotRead(LPCWSTR file);
 FCRET InvalidSwitch(VOID);
-FCRET ResynchFailed(VOID);
+FCRET ResyncFailed(VOID);
 HANDLE DoOpenFileForInput(LPCWSTR file);
 VOID ShowCaption(LPCWSTR file);
 

--- a/base/applications/cmdutils/fc/fc.h
+++ b/base/applications/cmdutils/fc/fc.h
@@ -31,13 +31,11 @@ typedef struct NODE_W
     struct list entry;
     LPWSTR pszLine;
     DWORD lineno;
-    DWORD cch;
 } NODE_W;
 typedef struct NODE_A
 {
     struct list entry;
     LPSTR pszLine;
-    DWORD cch;
     DWORD lineno;
 } NODE_A;
 
@@ -79,7 +77,9 @@ VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node);
 VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node);
 VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz);
 VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz);
+VOID PrintEndOfDiff(VOID);
 VOID PrintDots(VOID);
+VOID PrintCaption(LPCWSTR file);
 FCRET NoDifference(VOID);
 FCRET Different(LPCWSTR file1, LPCWSTR file2);
 FCRET LongerThan(LPCWSTR file1, LPCWSTR file2);
@@ -88,7 +88,6 @@ FCRET CannotRead(LPCWSTR file);
 FCRET InvalidSwitch(VOID);
 FCRET ResyncFailed(VOID);
 HANDLE DoOpenFileForInput(LPCWSTR file);
-VOID ShowCaption(LPCWSTR file);
 
 #ifdef _WIN64
     #define MAX_VIEW_SIZE (256 * 1024 * 1024) // 256 MB

--- a/base/applications/cmdutils/fc/fc.h
+++ b/base/applications/cmdutils/fc/fc.h
@@ -5,7 +5,6 @@
  * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 #pragma once
-
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
@@ -31,12 +30,14 @@ typedef struct NODE_W
     struct list entry;
     LPWSTR pszLine;
     DWORD lineno;
+    DWORD hash;
 } NODE_W;
 typedef struct NODE_A
 {
     struct list entry;
     LPSTR pszLine;
     DWORD lineno;
+    DWORD hash;
 } NODE_A;
 
 #define FLAG_A (1 << 0) // abbreviation
@@ -71,15 +72,12 @@ FCRET TextCompareW(FILECOMPARE *pFC,
 FCRET TextCompareA(FILECOMPARE *pFC,
                    HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
                    HANDLE *phMapping2, const LARGE_INTEGER *pcb2);
-
 // fc.c
-VOID PrintLineW(const FILECOMPARE *pFC, const NODE_W *node);
-VOID PrintLineA(const FILECOMPARE *pFC, const NODE_A *node);
-VOID PrintLine2W(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz);
-VOID PrintLine2A(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz);
+VOID PrintLineW(const FILECOMPARE *pFC, DWORD lineno, LPCWSTR psz);
+VOID PrintLineA(const FILECOMPARE *pFC, DWORD lineno, LPCSTR psz);
+VOID PrintCaption(LPCWSTR file);
 VOID PrintEndOfDiff(VOID);
 VOID PrintDots(VOID);
-VOID PrintCaption(LPCWSTR file);
 FCRET NoDifference(VOID);
 FCRET Different(LPCWSTR file1, LPCWSTR file2);
 FCRET LongerThan(LPCWSTR file1, LPCWSTR file2);

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -327,20 +327,45 @@ ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
 }
 
 static VOID
-ShowDiff(FILECOMPARE *pFC, INT i, struct list *first, struct list *last)
+ShowDiff(FILECOMPARE *pFC, INT i, struct list *begin, struct list *end)
 {
     NODE* node;
     struct list *list = &pFC->list[i];
+    struct list *first = NULL, *last = NULL;
     PrintCaption(pFC->file[i]);
-    if (first && list_prev(list, first))
-        first = list_prev(list, first);
-    while (first != last)
+    if (begin && list_prev(list, begin))
+        begin = list_prev(list, begin);
+    while (begin != end)
     {
-        node = LIST_ENTRY(first, NODE, entry);
+        node = LIST_ENTRY(begin, NODE, entry);
         if (IsEOFNode(node))
             break;
+        if (!first)
+            first = begin;
+        last = begin;
+        if (!(pFC->dwFlags & FLAG_A))
+            PrintLine(pFC, node->lineno, node->pszLine);
+        begin = list_next(list, begin);
+    }
+    if ((pFC->dwFlags & FLAG_A) && first)
+    {
+        node = LIST_ENTRY(first, NODE, entry);
         PrintLine(pFC, node->lineno, node->pszLine);
         first = list_next(list, first);
+        if (first != last)
+        {
+            if (list_next(list, first) == last)
+            {
+                node = LIST_ENTRY(first, NODE, entry);
+                PrintLine(pFC, node->lineno, node->pszLine);
+            }
+            else
+            {
+                PrintDots();
+            }
+        }
+        node = LIST_ENTRY(last, NODE, entry);
+        PrintLine(pFC, node->lineno, node->pszLine);
     }
 }
 

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -369,25 +369,25 @@ ShowDiff(FILECOMPARE *pFC, INT i, struct list *begin, struct list *end)
     }
 }
 
-static FCRET
+static INT 
 SkipIdentical(FILECOMPARE *pFC, struct list **pptr0, struct list **pptr1)
 {
     struct list *ptr0 = *pptr0, *ptr1 = *pptr1;
     FCRET ret;
+    INT count = 0;
     while (ptr0 && ptr1)
     {
         NODE *node0 = LIST_ENTRY(ptr0, NODE, entry);
         NODE *node1 = LIST_ENTRY(ptr1, NODE, entry);
-        ret = CompareNode(pFC, node0, node1);
-        if (ret != FCRET_IDENTICAL)
+        if (CompareNode(pFC, node0, node1) != FCRET_IDENTICAL)
             break;
-
         ptr0 = list_next(&pFC->list[0], ptr0);
         ptr1 = list_next(&pFC->list[1], ptr1);
+        ++count;
     }
     *pptr0 = ptr0;
     *pptr1 = ptr1;
-    return ret;
+    return count;
 }
 
 static FCRET
@@ -413,8 +413,6 @@ Resync(FILECOMPARE *pFC, struct list **pptr0, struct list **pptr1)
             node0 = LIST_ENTRY(ptr0, NODE, entry);
             node1 = LIST_ENTRY(ptr1, NODE, entry);
             ret = CompareNode(pFC, node0, node1);
-            if (ret == FCRET_INVALID)
-                return ret;
             if (ret == FCRET_IDENTICAL)
             {
                 penalty = i0 + 2 * i1 + 3 * abs(i1 - i0);
@@ -531,10 +529,8 @@ FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping0, const LARGE_INTEGER *pcb
                 goto quit;
 
             // skip identical (sync'ed)
-            ret = SkipIdentical(pFC, &ptr0, &ptr1);
-            if (ret == FCRET_INVALID)
-                goto cleanup;
-            if (ret == FCRET_DIFFERENT)
+            SkipIdentical(pFC, &ptr0, &ptr1);
+            if (ptr0 || ptr1)
                 fDifferent = TRUE;
             if (!ptr0 || !ptr1)
                 goto quit;

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -592,13 +592,14 @@ FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping0, const LARGE_INTEGER *pcb
             {
                 // resync failed
                 ret = ResyncFailed();
+                // show the difference
                 ShowDiff(pFC, 0, save0, ptr0);
                 ShowDiff(pFC, 1, save1, ptr1);
                 PrintEndOfDiff();
                 goto cleanup;
             }
 
-            // now, show the difference (with clean-up)
+            // show the difference
             fDifferent = TRUE;
             next0 = ptr0 ? list_next(list0, ptr0) : ptr0;
             next1 = ptr1 ? list_next(list1, ptr1) : ptr1;

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -381,7 +381,7 @@ SkipIdentical(FILECOMPARE *pFC, struct list **pptr1, struct list **pptr2)
 }
 
 static FCRET
-Resynch(FILECOMPARE *pFC, struct list *head1, struct list *head2, INT *pi1, INT *pi2)
+Resync(FILECOMPARE *pFC, struct list *head1, struct list *head2, INT *pi1, INT *pi2)
 {
     FCRET ret;
     INT i1, i2, m, p, k;
@@ -506,21 +506,21 @@ FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping1, const LARGE_INTEGER *pcb
             head2 = next;
         }
 
-        // try to resynch
-        ret = Resynch(pFC, head1, head2, &i1, &i2);
+        // try to resync
+        ret = Resync(pFC, head1, head2, &i1, &i2);
         if (ret == FCRET_INVALID)
             goto hell;
         if (ret == FCRET_DIFFERENT)
         {
-            // resynch failed
-            ret = ResynchFailed();
+            // resync failed
+            ret = ResyncFailed();
             goto hell;
         }
         // now, show the difference (with clean-up)
         fDifferent = TRUE;
         ShowDiffAndClean(pFC, head1, head2, i1, i2);
 
-        // now resynch'ed
+        // now resync'ed
     } while (ret1 != FCRET_NO_MORE_DATA && ret2 != FCRET_NO_MORE_DATA);
 
 quit:

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -189,7 +189,7 @@ static DWORD GetHash(LPCTSTR psz, BOOL bIgnoreCase)
     return (ret & HASH_MASK);
 }
 
-static NODE *AllocEOFHash(VOID)
+static NODE *AllocEOFNode(VOID)
 {
     NODE *node = AllocNode(AllocLine(NULL, 0), 0);
     if (node == NULL)
@@ -204,7 +204,7 @@ static NODE *AllocEOFHash(VOID)
     return node;
 }
 
-static __inline BOOL IsEOFHash(NODE *node)
+static __inline BOOL IsEOFNode(NODE *node)
 {
     return !node || node->hash == HASH_EOF;
 }
@@ -318,7 +318,7 @@ ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
         return FCRET_IDENTICAL;
 
     // append EOF node
-    node = AllocEOFHash();
+    node = AllocEOFNode();
     if (!node)
         return OutOfMemory();
     list_add_tail(list, &node->entry);
@@ -327,17 +327,17 @@ ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
 }
 
 static VOID
-ShowDiff(FILECOMPARE *pFC, INT i, struct list *first, struct list *last, BOOL fLast)
+ShowDiff(FILECOMPARE *pFC, INT i, struct list *first, struct list *last)
 {
     NODE* node;
     struct list *list = &pFC->list[i];
     PrintCaption(pFC->file[i]);
-    if (first && list_prev(list, first) && fLast)
+    if (first && list_prev(list, first))
         first = list_prev(list, first);
     while (first != last)
     {
         node = LIST_ENTRY(first, NODE, entry);
-        if (IsEOFHash(node))
+        if (IsEOFNode(node))
             break;
         PrintLine(pFC, node->lineno, node->pszLine);
         first = list_next(list, first);
@@ -382,12 +382,10 @@ Resync(FILECOMPARE *pFC, struct list **pptr0, struct list **pptr1)
     ptr0 = *pptr0;
     for (i0 = 0; i0 < pFC->n; ++i0)
     {
-        if (i1 >= min_penalty)
-            break;
         ptr1 = *pptr1;
         for (i1 = 0; i1 < pFC->n; ++i1)
         {
-            penalty = i0 + i1;
+            penalty = i0 + i1 + 3 * abs(i1 - i0);
             if (penalty >= min_penalty)
                 continue;
 
@@ -436,10 +434,10 @@ Finalize(FILECOMPARE* pFC, struct list *ptr0, struct list* ptr1, BOOL fDifferent
     {
         node0 = LIST_ENTRY(ptr0, NODE, entry);
         node1 = LIST_ENTRY(ptr1, NODE, entry);
-        if (!IsEOFHash(node0) || !IsEOFHash(node1))
+        if (!IsEOFNode(node0) || !IsEOFNode(node1))
         {
-            ShowDiff(pFC, 0, ptr0, NULL, TRUE);
-            ShowDiff(pFC, 1, ptr1, NULL, TRUE);
+            ShowDiff(pFC, 0, ptr0, NULL);
+            ShowDiff(pFC, 1, ptr1, NULL);
             PrintEndOfDiff();
         }
         return FCRET_DIFFERENT;
@@ -465,7 +463,6 @@ FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping0, const LARGE_INTEGER *pcb
 {
     FCRET ret, ret0, ret1;
     struct list *list0, *list1, *ptr0, *ptr1, *save0, *save1, *next0, *next1;
-    NODE *node0, *node1;
     BOOL fDifferent = FALSE;
     LARGE_INTEGER ib0 = { .QuadPart = 0 }, ib1 = { .QuadPart = 0 };
     list0 = &pFC->list[0];
@@ -515,10 +512,8 @@ FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping0, const LARGE_INTEGER *pcb
         next1 = list_next(list1, ptr1);
         ptr0 = (next0 ? next0 : ptr0);
         ptr1 = (next1 ? next1 : ptr1);
-        node0 = LIST_ENTRY(ptr0, NODE, entry);
-        node1 = LIST_ENTRY(ptr1, NODE, entry);
-        ShowDiff(pFC, 0, save0, ptr0, IsEOFHash(node0));
-        ShowDiff(pFC, 1, save1, ptr1, IsEOFHash(node1));
+        ShowDiff(pFC, 0, save0, ptr0);
+        ShowDiff(pFC, 1, save1, ptr1);
         PrintEndOfDiff();
 
         DeleteNodes(list0, list_head(list0), ptr0);

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -1,0 +1,533 @@
+/*
+ * PROJECT:     ReactOS FC Command
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Comparing text files
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+#include "fc.h"
+
+#define IS_SPACEW(ch) ((ch) == L' ' || (ch) == L'\t')
+#define IS_SPACEA(ch) ((ch) == ' ' || (ch) == '\t')
+
+#ifdef UNICODE
+    #define NODE NODE_W
+    #define IS_SPACE IS_SPACEW
+    #define PrintLine PrintLineW
+    #define PrintLine2 PrintLine2W
+    #define TextCompare TextCompareW
+    #define last_match last_matchW
+#else
+    #define NODE NODE_A
+    #define IS_SPACE IS_SPACEA
+    #define PrintLine PrintLineA
+    #define PrintLine2 PrintLine2A
+    #define TextCompare TextCompareA
+    #define last_match last_matchA
+#endif
+
+static BOOL FindNextLine(LPCTSTR pch, DWORD ich, DWORD cch, LPDWORD pich)
+{
+    while (ich < cch)
+    {
+        if (pch[ich] == TEXT('\n'))
+        {
+            *pich = ich;
+            return TRUE;
+        }
+        ++ich;
+    }
+    *pich = cch;
+    return FALSE;
+}
+
+static LPTSTR AllocLine(LPCTSTR pch, DWORD cch)
+{
+    LPTSTR pszNew = malloc((cch + 1) * sizeof(TCHAR));
+    if (!pszNew)
+        return NULL;
+    memcpy(pszNew, pch, cch * sizeof(TCHAR));
+    pszNew[cch] = 0;
+    return pszNew;
+}
+
+static NODE *AllocNode(LPTSTR psz, DWORD cch, DWORD lineno)
+{
+    NODE *node;
+    if (!psz)
+        return NULL;
+    node = calloc(1, sizeof(NODE));
+    if (!node)
+    {
+        free(psz);
+        return NULL;
+    }
+    node->pszLine = psz;
+    node->cch = cch;
+    node->lineno = lineno;
+    return node;
+}
+
+static __inline VOID DeleteNode(NODE *node)
+{
+    if (node)
+    {
+        free(node->pszLine);
+        free(node);
+    }
+}
+
+static VOID DeleteList(struct list *list)
+{
+    struct list *ptr;
+    NODE *node;
+    while ((ptr = list_head(list)) != NULL)
+    {
+        list_remove(ptr);
+        node = LIST_ENTRY(ptr, NODE, entry);
+        DeleteNode(node);
+    }
+}
+
+static __inline LPCTSTR SkipSpace(LPCTSTR pch)
+{
+    while (IS_SPACE(*pch))
+        ++pch;
+    return pch;
+}
+
+static __inline LPCTSTR LastNonSpace(LPCTSTR pch)
+{
+    LPCTSTR pchLast = NULL;
+    while (*pch)
+    {
+        if (!IS_SPACE(*pch))
+            pchLast = pch;
+        ++pch;
+    }
+    return pchLast;
+}
+
+static LPTSTR CompressSpace(LPCTSTR line)
+{
+    LPTSTR pszNew, pch1, pch2;
+    LPCTSTR pchLast;
+
+    line = SkipSpace(line);
+    pchLast = LastNonSpace(line);
+    if (pchLast == NULL)
+        return AllocLine(TEXT(""), 0);
+
+    pszNew = AllocLine(line, (DWORD)(pchLast - line) + 1);
+    if (!pszNew)
+        return NULL;
+
+    for (pch1 = pch2 = pszNew; *pch1; ++pch1)
+    {
+        *pch2++ = *pch1;
+        if (IS_SPACE(*pch1))
+        {
+            // skip duplicated spaces
+            do
+            {
+                ++pch1;
+            } while (IS_SPACE(*pch1));
+            --pch1;
+        }
+    }
+    *pch2 = 0;
+    return pszNew;
+}
+
+#define TAB_WIDTH 8
+
+static INT ExpandTabLength(LPCTSTR line)
+{
+    LPCTSTR pch;
+    INT cch = 0;
+    for (pch = line; *pch; ++pch)
+    {
+        if (*pch == TEXT('\t'))
+            cch += TAB_WIDTH - (cch % TAB_WIDTH);
+        else
+            ++cch;
+    }
+    return cch;
+}
+
+static LPTSTR ExpandTab(LPCTSTR line)
+{
+    INT spaces, cch = ExpandTabLength(line);
+    LPTSTR pszNew = malloc((cch + 1) * sizeof(TCHAR));
+    LPCTSTR pch;
+    if (!pszNew)
+        return NULL;
+    cch = 0;
+    for (pch = line; *pch; ++pch)
+    {
+        if (*pch == TEXT('\t'))
+        {
+            spaces = TAB_WIDTH - (cch % TAB_WIDTH);
+            while (spaces-- > 0)
+            {
+                pszNew[cch++] = TEXT(' ');
+            }
+        }
+        else
+        {
+            pszNew[cch++] = *pch;
+        }
+    }
+    pszNew[cch] = 0;
+    return pszNew;
+}
+
+static BOOL ExpandNode(const FILECOMPARE *pFC, NODE *node)
+{
+    if (!(pFC->dwFlags & FLAG_T))
+    {
+        LPTSTR tmp = ExpandTab(node->pszLine);
+        if (!tmp)
+            return FALSE;
+        free(node->pszLine);
+        node->pszLine = tmp;
+        node->cch = lstrlen(tmp);
+    }
+    return TRUE;
+}
+
+static FCRET CompareNode(const FILECOMPARE *pFC, const NODE *node1, const NODE *node2)
+{
+    DWORD dwCmpFlags = ((pFC->dwFlags & FLAG_C) ? NORM_IGNORECASE : 0);
+    LPTSTR line1 = node1->pszLine, line2 = node2->pszLine;
+    DWORD cch1 = node1->cch, cch2 = node2->cch;
+    INT ret;
+    if (pFC->dwFlags & FLAG_W) // compress space
+    {
+        LPTSTR psz1 = CompressSpace(line1);
+        LPTSTR psz2 = CompressSpace(line2);
+        if (psz1 && psz2)
+        {
+            ret = CompareString(LOCALE_USER_DEFAULT, dwCmpFlags, psz1, -1, psz2, -1);
+            ret = ((ret == CSTR_EQUAL) ? FCRET_IDENTICAL : FCRET_DIFFERENT);
+        }
+        else
+        {
+            ret = OutOfMemory();
+        }
+        free(psz1);
+        free(psz2);
+    }
+    else
+    {
+        ret = CompareString(LOCALE_USER_DEFAULT, dwCmpFlags, line1, cch1, line2, cch2);
+        ret = (ret == CSTR_EQUAL) ? FCRET_IDENTICAL : FCRET_DIFFERENT;
+    }
+    return ret;
+}
+
+static FCRET
+ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
+           LARGE_INTEGER *pib, const LARGE_INTEGER *pcb, struct list *list)
+{
+    DWORD lineno = 1, ich, cch, ichNext, cbView, cchNode;
+    LPTSTR psz;
+    BOOL fLast, bCR;
+    NODE *node;
+
+    if (*phMapping == NULL)
+        return FCRET_NO_MORE_DATA;
+
+    if (pib->QuadPart >= pcb->QuadPart)
+    {
+        CloseHandle(*phMapping);
+        *phMapping = NULL;
+        return FCRET_NO_MORE_DATA;
+    }
+
+    cbView = (DWORD)min(pcb->QuadPart - pib->QuadPart, MAX_VIEW_SIZE);
+    psz = MapViewOfFile(*phMapping, FILE_MAP_READ, pib->HighPart, pib->LowPart, cbView);
+    if (!psz)
+    {
+        return OutOfMemory();
+    }
+
+    ich = 0;
+    cch = cbView / sizeof(TCHAR);
+    fLast = (pib->QuadPart + cbView >= pcb->QuadPart);
+    while (FindNextLine(psz, ich, cch, &ichNext) ||
+           (ichNext == cch && (fLast || ich == 0)))
+    {
+        bCR = (ichNext > 0) && (psz[ichNext - 1] == TEXT('\r'));
+        cchNode = ichNext - ich - bCR;
+        node = AllocNode(AllocLine(&psz[ich], cchNode), cchNode, lineno++);
+        if (!node || !ExpandNode(pFC, node))
+        {
+            DeleteNode(node);
+            UnmapViewOfFile(psz);
+            return OutOfMemory();
+        }
+        list_add_tail(list, &node->entry);
+        ich = ichNext + 1;
+    }
+
+    UnmapViewOfFile(psz);
+    psz = NULL;
+
+    pib->QuadPart += ichNext * sizeof(WCHAR);
+
+    if (pib->QuadPart < pcb->QuadPart)
+        return FCRET_IDENTICAL;
+    return FCRET_NO_MORE_DATA;
+}
+
+static VOID ShowDiffAndClean(FILECOMPARE *pFC, struct list *ptr1, struct list *ptr2, INT i1, INT i2)
+{
+    struct list *next, *ptr[2] = { ptr1, ptr2 };
+    INT ai[2] = { i1, i2 };
+    BOOL fFirst;
+    NODE *node;
+    BOOL fAbbrev = (pFC->dwFlags & FLAG_A);
+
+    for (INT i = 0; i < 2; ++i)
+    {
+        ShowCaption(pFC->file[i]);
+        if (!ptr[i])
+            continue;
+
+        fFirst = TRUE;
+
+        if (pFC->last_match[i])
+        {
+            PrintLine2(pFC, pFC->last_lineno[i], pFC->last_match[i]);
+            fFirst = FALSE;
+        }
+
+        while (ptr[i] && ai[i]-- > 0)
+        {
+            node = LIST_ENTRY(ptr[i], NODE, entry);
+            if (!fAbbrev || fFirst)
+            {
+                PrintLine(pFC, node);
+                fFirst = FALSE;
+            }
+            next = list_next(&pFC->list[i], ptr[i]);
+
+            // clean up
+            DeleteNode(node);
+            list_remove(ptr[i]);
+
+            ptr[i] = next;
+        }
+
+        if (fAbbrev && !fFirst && ptr[i])
+        {
+            node = LIST_ENTRY(ptr[i], NODE, entry);
+            PrintDots();
+            PrintLine(pFC, node);
+        }
+    }
+}
+
+static FCRET
+Finalize(FILECOMPARE *pFC, struct list *ptr1, struct list *ptr2, BOOL fDifferent)
+{
+    if (!ptr1 && !ptr2)
+    {
+        if (fDifferent)
+        {
+            ShowCaption(L"");
+            return Different(pFC->file[0], pFC->file[1]);
+        }
+        return NoDifference();
+    }
+
+    ShowDiffAndClean(pFC, ptr1, ptr2, pFC->n, pFC->n);
+    ShowCaption(L"");
+    return FCRET_DIFFERENT;
+}
+
+static VOID
+SaveLastMatch(FILECOMPARE *pFC, const NODE *node1, const NODE *node2)
+{
+    free(pFC->last_match[0]);
+    free(pFC->last_match[1]);
+    pFC->last_match[0] = AllocLine(node1->pszLine, lstrlen(node1->pszLine));
+    pFC->last_match[1] = AllocLine(node2->pszLine, lstrlen(node2->pszLine));
+    pFC->last_lineno[0] = node1->lineno;
+    pFC->last_lineno[1] = node2->lineno;
+}
+
+static FCRET
+SkipIdentical(FILECOMPARE *pFC, struct list **pptr1, struct list **pptr2)
+{
+    struct list *ptr1 = *pptr1, *ptr2 = *pptr2;
+    while (ptr1 && ptr2)
+    {
+        NODE *node1 = LIST_ENTRY(ptr1, NODE, entry);
+        NODE *node2 = LIST_ENTRY(ptr2, NODE, entry);
+        FCRET ret = CompareNode(pFC, node1, node2);
+        if (ret != FCRET_IDENTICAL)
+            return ret;
+
+        // save last match
+        SaveLastMatch(pFC, node1, node2);
+
+        ptr1 = list_next(&pFC->list[0], ptr1);
+        ptr2 = list_next(&pFC->list[1], ptr2);
+    }
+    *pptr1 = ptr1;
+    *pptr2 = ptr2;
+    return FCRET_IDENTICAL;
+}
+
+static FCRET
+Resynch(FILECOMPARE *pFC, struct list *head1, struct list *head2, INT *pi1, INT *pi2)
+{
+    FCRET ret;
+    INT i1, i2, m, p, k;
+    struct list *ptr1, *ptr2, *ptr3, *ptr4;
+    NODE *node1, *node2;
+    struct list *list1 = &pFC->list[0], *list2 = &pFC->list[1];
+    INT n = min(pFC->n, max(list_count(list1), list_count(list2)));
+
+    // ``If the files that you are comparing have more than pFC->n consecutive
+    //   differing lines, FC cancels the comparison,,
+    // ``If the number of matching lines in the files is less than pFC->nnnn,
+    //   FC displays the matching lines as differences,,
+    for (m = 0; m < n; ++m) // m in [0, pFC->n)
+    {
+        for (p = 0; p <= m; ++p) // p in [0, m]
+        {
+            // resume pointers
+            ptr1 = head1;
+            ptr2 = head2;
+            // skip ptr1 (m - p) times if possible. i1 in [0, m - p)
+            for (i1 = 0; ptr1 && i1 < m - p; ++i1)
+                ptr1 = list_next(list1, ptr1);
+            if (!ptr1)
+                continue; // beyond the list
+            // skip ptr2 p times if possible. i2 in [0, p)
+            for (i2 = 0; ptr2 && i2 < p; ++i2)
+                ptr2 = list_next(list2, ptr2);
+            if (!ptr2)
+                continue; // beyond the list
+
+            // compare
+            node1 = LIST_ENTRY(ptr1, NODE, entry);
+            node2 = LIST_ENTRY(ptr2, NODE, entry);
+            ret = CompareNode(pFC, node1, node2);
+            if (ret == FCRET_INVALID)
+                return ret;
+            if (ret == FCRET_DIFFERENT)
+                continue;
+
+            ptr3 = list_next(list1, ptr1);
+            ptr4 = list_next(list2, ptr2);
+            k = 1;
+            while (ptr3 && ptr4 && i1 < pFC->n && i2 < pFC->n && k < pFC->nnnn)
+            {
+                node1 = LIST_ENTRY(ptr3, NODE, entry);
+                node2 = LIST_ENTRY(ptr4, NODE, entry);
+                ret = CompareNode(pFC, node1, node2);
+                if (ret == FCRET_INVALID)
+                    return ret;
+                if (ret == FCRET_DIFFERENT)
+                    break;
+                ++i1, ++i2;
+                ++k;
+                ptr3 = list_next(list1, ptr3);
+                ptr4 = list_next(list2, ptr4);
+            }
+
+            if (k >= pFC->nnnn)
+            {
+                *pi1 = i1;
+                *pi2 = i2;
+                return FCRET_IDENTICAL;
+            }
+        }
+    }
+
+    *pi1 = i1;
+    *pi2 = i2;
+    return FCRET_DIFFERENT;
+}
+
+FCRET TextCompare(FILECOMPARE *pFC, HANDLE *phMapping1, const LARGE_INTEGER *pcb1,
+                                    HANDLE *phMapping2, const LARGE_INTEGER *pcb2)
+{
+    FCRET ret, ret1, ret2;
+    struct list *list1, *list2, *ptr1, *ptr2, *head1, *head2, *next;
+    NODE *node1, *node2;
+    BOOL fDifferent = FALSE;
+    INT i1, i2;
+    LARGE_INTEGER ib1 = { .QuadPart = 0 }, ib2 = { .QuadPart = 0 };
+    list1 = &pFC->list[0];
+    list2 = &pFC->list[1];
+    list_init(list1);
+    list_init(list2);
+
+    do
+    {
+        ret1 = ParseLines(pFC, phMapping1, &ib1, pcb1, list1);
+        if (ret1 == FCRET_INVALID)
+            return ret1;
+        ret2 = ParseLines(pFC, phMapping2, &ib2, pcb2, list2);
+        if (ret2 == FCRET_INVALID)
+            return ret2;
+
+        head1 = ptr1 = list_head(list1);
+        head2 = ptr2 = list_head(list2);
+        if (!ptr1 || !ptr2)
+            goto quit;
+
+        // skip identical (synch'ed)
+        ret = SkipIdentical(pFC, &ptr1, &ptr2);
+        if (ret == FCRET_INVALID)
+            goto hell;
+        if (ret == FCRET_DIFFERENT)
+            fDifferent = TRUE;
+        if (!ptr1 || !ptr2)
+            goto quit;
+
+        // free useless data
+        while (head1 && head1 != ptr1)
+        {
+            node1 = LIST_ENTRY(ptr1, NODE, entry);
+            next = list_next(list1, head1);
+            DeleteNode(node1);
+            head1 = next;
+        }
+        while (head2 && head2 != ptr2)
+        {
+            node2 = LIST_ENTRY(ptr2, NODE, entry);
+            next = list_next(list2, head2);
+            DeleteNode(node2);
+            head2 = next;
+        }
+
+        // try to resynch
+        ret = Resynch(pFC, head1, head2, &i1, &i2);
+        if (ret == FCRET_INVALID)
+            goto hell;
+        if (ret == FCRET_DIFFERENT)
+        {
+            // resynch failed
+            ret = ResynchFailed();
+            goto hell;
+        }
+        // now, show the difference (with clean-up)
+        fDifferent = TRUE;
+        ShowDiffAndClean(pFC, head1, head2, i1, i2);
+
+        // now resynch'ed
+    } while (ret1 != FCRET_NO_MORE_DATA && ret2 != FCRET_NO_MORE_DATA);
+
+quit:
+    // finalizing...
+    ret = Finalize(pFC, ptr1, ptr2, fDifferent);
+hell:
+    DeleteList(list1);
+    DeleteList(list2);
+    return ret;
+}

--- a/base/applications/cmdutils/fc/text.h
+++ b/base/applications/cmdutils/fc/text.h
@@ -6,39 +6,21 @@
  */
 #include "fc.h"
 
-#define IS_SPACEW(ch) ((ch) == L' ' || (ch) == L'\t')
-#define IS_SPACEA(ch) ((ch) == ' ' || (ch) == '\t')
+#define IS_SPACEW(ch) ((ch) == TEXT(' ') || (ch) == TEXT('\t'))
 
 #ifdef UNICODE
     #define NODE NODE_W
-    #define IS_SPACE IS_SPACEW
     #define PrintLine PrintLineW
     #define PrintLine2 PrintLine2W
     #define TextCompare TextCompareW
     #define last_match last_matchW
 #else
     #define NODE NODE_A
-    #define IS_SPACE IS_SPACEA
     #define PrintLine PrintLineA
     #define PrintLine2 PrintLine2A
     #define TextCompare TextCompareA
     #define last_match last_matchA
 #endif
-
-static BOOL FindNextLine(LPCTSTR pch, DWORD ich, DWORD cch, LPDWORD pich)
-{
-    while (ich < cch)
-    {
-        if (pch[ich] == TEXT('\n') || pch[ich] == TEXT('\0'))
-        {
-            *pich = ich;
-            return TRUE;
-        }
-        ++ich;
-    }
-    *pich = cch;
-    return FALSE;
-}
 
 static LPTSTR AllocLine(LPCTSTR pch, DWORD cch)
 {
@@ -227,6 +209,21 @@ static FCRET CompareNode(const FILECOMPARE *pFC, const NODE *node1, const NODE *
     return ret;
 }
 
+static BOOL FindNextLine(LPCTSTR pch, DWORD ich, DWORD cch, LPDWORD pich)
+{
+    while (ich < cch)
+    {
+        if (pch[ich] == TEXT('\n') || pch[ich] == TEXT('\0'))
+        {
+            *pich = ich;
+            return TRUE;
+        }
+        ++ich;
+    }
+    *pich = cch;
+    return FALSE;
+}
+
 static FCRET
 ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
            LARGE_INTEGER *pib, const LARGE_INTEGER *pcb, struct list *list)
@@ -271,8 +268,7 @@ ParseLines(const FILECOMPARE *pFC, HANDLE *phMapping,
             return OutOfMemory();
         }
         list_add_tail(list, &node->entry);
-        ich = ichNext + !fLast;
-        fLast = (pib->QuadPart + cbView >= pcb->QuadPart);
+        ich = ichNext + 1;
     }
 
     UnmapViewOfFile(psz);

--- a/base/applications/cmdutils/fc/texta.c
+++ b/base/applications/cmdutils/fc/texta.c
@@ -1,0 +1,6 @@
+#undef UNICODE
+#undef _UNICODE
+#ifndef _MBCS
+    #define _MBCS
+#endif
+#include "text.h"

--- a/base/applications/cmdutils/fc/textw.c
+++ b/base/applications/cmdutils/fc/textw.c
@@ -1,0 +1,8 @@
+#ifndef UNICODE
+    #define UNICODE
+#endif
+#ifndef _UNICODE
+    #define _UNICODE
+#endif
+#undef _MBCS
+#include "text.h"


### PR DESCRIPTION
## Purpose

Implement text file comparison by using file mappings (both Unicode and ANSI).
JIRA issue: [CORE-17500](https://jira.reactos.org/browse/CORE-17500)

![shot](https://user-images.githubusercontent.com/2107452/116771269-ec317000-aa84-11eb-95e2-34d53a6ef3fe.png)

## Proposed changes

- We split text into lines, and then compare lines.
- If two text file are identical, return `FCRET_IDENTICAL`.
- If different, show the difference and return `FCRET_DIFFERENT`.
- If any error occurred, then return `FCRET_INVALID`.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/116771261-e0de4480-aa84-11eb-973e-28e4849957f3.png)
61 failures.
AFTER:
![after](https://user-images.githubusercontent.com/2107452/116978008-19d51e00-acfe-11eb-8ae8-4748381fc492.png)
7 failures.

## TODO

- [x] `/C`: Ignores the letter case.
- [ ] `/LBn`: Sets the number of lines for the internal line buffer to N. The default length of the line buffer is 100 lines. If the files that you are comparing have more than 100 consecutive differing lines, fc cancels the comparison.
- [x] `/N`: Displays the line numbers during an ASCII comparison.
- [ ] `/nnnn`: Specifies the number of consecutive lines that must match following a mismatch, before fc considers the files to be resynchronized. If the number of matching lines in the files is less than nnnn, fc displays the matching lines as differences. The default value is 2.
- [x] `/T`: Prevents fc from converting tabs to spaces.
- [x] `/U`: Compares files as Unicode text files.
- [x] `/W`: Compresses white space (that is, tabs and spaces) during the comparison. If a line contains many consecutive spaces or tabs, /w treats these characters as a single space. When used with /w, fc ignores white space at the beginning and end of a line.
- [x] Do test.

## See also

https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/fc