### PR TITLE
[NTOS:PS] NtQueryInformationProcess(): Fix ProcessDeviceMap case

### DIFF
--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -56,11 +56,12 @@ PsReferenceProcessFilePointer(IN PEPROCESS Process,
  */
 NTSTATUS
 NTAPI
-NtQueryInformationProcess(IN HANDLE ProcessHandle,
-                          IN PROCESSINFOCLASS ProcessInformationClass,
-                          OUT PVOID ProcessInformation,
-                          IN ULONG ProcessInformationLength,
-                          OUT PULONG ReturnLength OPTIONAL)
+NtQueryInformationProcess(
+    _In_ HANDLE ProcessHandle,
+    _In_ PROCESSINFOCLASS ProcessInformationClass,
+    _Out_ PVOID ProcessInformation,
+    _In_ ULONG ProcessInformationLength,
+    _Out_opt_ PULONG ReturnLength)
 {
     PEPROCESS Process;
     KPROCESSOR_MODE PreviousMode = ExGetPreviousMode();

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -578,13 +578,9 @@ NtQueryInformationProcess(
                 {
                     /* Get the exception code */
                     Status = _SEH2_GetExceptionCode();
+                    _SEH2_YIELD(break);
                 }
                 _SEH2_END;
-
-                if (!NT_SUCCESS(Status))
-                {
-                    break;
-                }
 
                 /* Only one flag is supported and it needs LUID mappings */
                 if ((Flags & ~PROCESS_LUID_DOSDEVICES_ONLY) != 0 ||


### PR DESCRIPTION
Fix Clang-Cl
'...\ntoskrnl\ps\query.c(583,33): warning: variable 'Status' is uninitialized when used here [-Wuninitialized]'

Addendum to 1074a9a.