### PR TITLE
[GDI32] Fix wrong ordering of parameters in NtGdiDdGetDC call

### DIFF
--- a/win32ss/gdi/gdi32/misc/gdientry.c
+++ b/win32ss/gdi/gdi32/misc/gdientry.c
@@ -1924,7 +1924,7 @@ DdGetDC(LPDDRAWI_DDRAWSURFACE_LCL pSurfaceLocal,
         LPPALETTEENTRY pColorTable)
 {
     /* Call win32k directly */
-    return NtGdiDdGetDC(pColorTable, (HANDLE) pSurfaceLocal->hDDSurface);
+    return NtGdiDdGetDC((HANDLE) pSurfaceLocal->hDDSurface, pColorTable);
 }
 
 /*

--- a/win32ss/gdi/gdi32/misc/gdientry.c
+++ b/win32ss/gdi/gdi32/misc/gdientry.c
@@ -1924,7 +1924,7 @@ DdGetDC(LPDDRAWI_DDRAWSURFACE_LCL pSurfaceLocal,
         LPPALETTEENTRY pColorTable)
 {
     /* Call win32k directly */
-    return NtGdiDdGetDC((HANDLE) pSurfaceLocal->hDDSurface, pColorTable);
+    return NtGdiDdGetDC((HANDLE)pSurfaceLocal->hDDSurface, pColorTable);
 }
 
 /*
@@ -2078,7 +2078,6 @@ DdSetGammaRamp(LPDDRAWI_DIRECTDRAW_LCL pDDraw,
                                hdc,
                                lpGammaRamp);
 }
-
 
 
 


### PR DESCRIPTION
## Purpose

Place `pColorTable` after `pSurfaceLocal->hDDSurface`, instead of before it, since such ordering is used in the calling `NtGdiDdGetDC`. See https://docs.microsoft.com/en-us/windows/win32/devnotes/-dxgkernel-ntgdiddgetdc for the reference.
It allows to properly pass the DirectDraw surface handle (and palette entry pointer) from MS ddraw into win32k.
Otherwise, they are passing into the wrong parameters of actual `NtGdi`* function, and due to this, since they're detected as invalid, they become `NULL`, and that function does not work correctly.
Required by MS DirectDraw stack (ddraw.dll & dxg.sys). Although it does not completely fix the issue, but it at least improves the situation.

JIRA issue: [CORE-17561](https://jira.reactos.org/browse/CORE-17561)