### PR TITLE
[SHELL32] Fix 'Create New' context menu under the desktop folder

### DIFF
--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -429,7 +429,8 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
 	
     hr = lpDesktopSF->BindToObject(m_pidlFolder, NULL, IID_IShellFolder, (PVOID*)&lpCurrentSF);
 	
-    if (lpCurrentSF) {
+    if (lpCurrentSF)
+    {
         pszFileName = PathFindFileNameW(pszName);
 
         /* Find the pidl of the new item from the parent folder */

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -434,7 +434,8 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
 
         /* Find the pidl of the new item from the parent folder */
         lpCurrentSF->ParseDisplayName(NULL, NULL, (LPWSTR)pszFileName, NULL, &pidlNewItem, NULL);
-        if (pidlNewItem) {
+        if (pidlNewItem)
+        {
             pidlFullNewItem = ILCombine(m_pidlFolder, pidlNewItem);
 			
             /* Notify the view object about the new item */

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -407,7 +407,7 @@ CNewMenu::SHELLNEW_ITEM *CNewMenu::FindItemFromIdOffset(UINT IdOffset)
 HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL bRename)
 {
     CComPtr<IShellFolder> lpDesktopSF;
-	CComPtr<IShellFolder> lpCurrentSF;
+    CComPtr<IShellFolder> lpCurrentSF;
     CComPtr<IShellView> lpSV;
     HRESULT hr = E_FAIL;
     LPITEMIDLIST pidlFullNewItem = NULL;

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -432,7 +432,7 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
     if (lpCurrentSF) {
         pszFileName = PathFindFileNameW(pszName);
 
-        /* Find pidl of the new item from parent folder */
+        /* Find the pidl of the new item from the parent folder */
         lpCurrentSF->ParseDisplayName(NULL, NULL, (LPWSTR)pszFileName, NULL, &pidlNewItem, NULL);
         if (pidlNewItem) {
             pidlFullNewItem = ILCombine(m_pidlFolder, pidlNewItem);


### PR DESCRIPTION
## Purpose
Access the current folder directly from your desktop and if you create a new file or folder through the context menu, item does not showed it until manually refresh it.

Before
![fix_before](https://user-images.githubusercontent.com/12496720/117094789-adaaf680-ad9f-11eb-91c7-de5bf6978335.png)

After
![fix_after](https://user-images.githubusercontent.com/12496720/117094805-bbf91280-ad9f-11eb-902c-4d6239b40e3a.png)


## Proposed changes

Original codes notify new item using filesystem path. so item does not update when current folder is under 'Desktop' namespace extension.

New codes notify new item using PIDL from current parent folder. so item now update when current folder is under 'Desktop' namespace extension.

