### PR TITLE
[CMAKE] CMakeLists.txt: Print CMAKE_CONFIGURATION_TYPES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,14 @@ else()
     # We don't need CMake importlib handling.
     unset(CMAKE_IMPORT_LIBRARY_SUFFIX)
 
-    # Print build type
-    message("-- Build Type: ${CMAKE_BUILD_TYPE}")
+    # Print build type(s)
+    if(CMAKE_CONFIGURATION_TYPES)
+        # Multi-config generators, like Visual Studio (MSBuild).
+        message("-- Configuration types: ${CMAKE_CONFIGURATION_TYPES}")
+    else()
+        # Single-configuration generators, like Ninja.
+        message("-- Build type: ${CMAKE_BUILD_TYPE}")
+    endif()
 
     # Always add /MT in VS CMAKE_GENERATOR and define _SBCS otherwise VS thinks it's a multi-byte or whatever project
     if (MSVC_IDE)


### PR DESCRIPTION
On `build-msbuild-i386`:
`-- Build Type: `
is replaced by
`-- Configuration types: Debug;Release;MinSizeRel;RelWithDebInfo`

Follow-up to d10728a.