### PR TITLE
[SDK] wine/typeof.h: Remove duplicate ImeGetRegisterWordStyle line

### DIFF
--- a/sdk/include/reactos/wine/typeof.h
+++ b/sdk/include/reactos/wine/typeof.h
@@ -47,7 +47,6 @@ typedef unsigned int (__stdcall typeof(ImeEnumRegisterWord))(int (__stdcall *)(c
 typedef int (__stdcall typeof(ImeSetCompositionString))(void *, unsigned int, const void *, unsigned int, const void *, unsigned int);
 typedef unsigned int (__stdcall typeof(ImeConversionList))(void *, const __typeof_wchar *, struct tagCANDIDATELIST *, unsigned int, unsigned int);
 typedef int (__stdcall typeof(ImeProcessKey))(void *, unsigned int, __typeof_longptr, unsigned char *);
-typedef unsigned int (__stdcall typeof(ImeGetRegisterWordStyle))(unsigned int, struct tagSTYLEBUFW *);
 typedef unsigned int (__stdcall typeof(ImeGetImeMenuItems))(void *, unsigned int, unsigned int, struct tagIMEMENUITEMINFOW *, struct tagIMEMENUITEMINFOW *, unsigned int);
 typedef struct _xmlDoc * (__cdecl typeof(xsltApplyStylesheet))(struct _xsltStylesheet *, struct _xmlDoc *, const char **);
 typedef struct _xmlDoc * (__cdecl typeof(xsltApplyStylesheetUser))(struct _xsltStylesheet *, struct _xmlDoc *, const char **, const char *, struct _iobuf *, struct _xsltTransformContext *);


### PR DESCRIPTION
Fix msbuild amd64
'...\sdk\include\reactos\wine/typeof.h(50,64): error C2059: syntax error: '<parameter-list>' [D:\a\reactos\reactos\build\dll\win32\msxml3\msxml3.vcxproj]'

Addendum to 32072cf (r42469).

NB:
Line 50 duplicates line 45.