### PR TITLE
[BCRYPT] Sync with Wine-6.7. Added mbedtls.c stubs of key operation functions.

### DIFF
--- a/dll/win32/bcrypt/CMakeLists.txt
+++ b/dll/win32/bcrypt/CMakeLists.txt
@@ -7,6 +7,10 @@ spec2def(bcrypt.dll bcrypt.spec ADD_IMPORTLIB)
 
 list(APPEND SOURCE
     bcrypt_main.c
+    mbedtls.c
+    md2.c
+    sha256.c
+    sha512.c
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/bcrypt_stubs.c
     ${CMAKE_CURRENT_BINARY_DIR}/bcrypt.def)

--- a/dll/win32/bcrypt/bcrypt.spec
+++ b/dll/win32/bcrypt/bcrypt.spec
@@ -1,56 +1,58 @@
-@ stub BCryptAddContextFunction
-@ stub BCryptAddContextFunctionProvider
+@ stdcall BCryptAddContextFunction(long wstr long wstr long)
+@ stdcall BCryptAddContextFunctionProvider(long wstr long wstr wstr long)
 @ stdcall BCryptCloseAlgorithmProvider(ptr long)
 @ stub BCryptConfigureContext
 @ stub BCryptConfigureContextFunction
 @ stub BCryptCreateContext
 @ stdcall BCryptCreateHash(ptr ptr ptr long ptr long long)
-@ stub BCryptDecrypt
+@ stdcall BCryptDecrypt(ptr ptr long ptr ptr long ptr long ptr long)
 @ stub BCryptDeleteContext
-@ stub BCryptDeriveKey
+@ stdcall BCryptDeriveKey(ptr wstr ptr ptr long ptr long)
+@ stdcall BCryptDeriveKeyCapi(ptr ptr ptr long long)
+@ stdcall BCryptDeriveKeyPBKDF2(ptr ptr long ptr long int64 ptr long long)
 @ stdcall BCryptDestroyHash(ptr)
-@ stdcall -stub BCryptDestroyKey(ptr)
-@ stub BCryptDestroySecret
-@ stub BCryptDuplicateHash
-@ stub BCryptDuplicateKey
-@ stub BCryptEncrypt
+@ stdcall BCryptDestroyKey(ptr)
+@ stdcall BCryptDestroySecret(ptr)
+@ stdcall BCryptDuplicateHash(ptr ptr ptr long long)
+@ stdcall BCryptDuplicateKey(ptr ptr ptr long long)
+@ stdcall BCryptEncrypt(ptr ptr long ptr ptr long ptr long ptr long)
 @ stdcall BCryptEnumAlgorithms(long ptr ptr long)
 @ stub BCryptEnumContextFunctionProviders
-@ stub BCryptEnumContextFunctions
+@ stdcall BCryptEnumContextFunctions(long wstr long ptr ptr)
 @ stub BCryptEnumContexts
 @ stub BCryptEnumProviders
 @ stub BCryptEnumRegisteredProviders
-@ stub BCryptExportKey
-@ stub BCryptFinalizeKeyPair
+@ stdcall BCryptExportKey(ptr ptr wstr ptr long ptr long)
+@ stdcall BCryptFinalizeKeyPair(ptr long)
 @ stdcall BCryptFinishHash(ptr ptr long long)
-@ stub BCryptFreeBuffer
+@ stdcall BCryptFreeBuffer(ptr)
 @ stdcall BCryptGenRandom(ptr ptr long long)
-@ stub BCryptGenerateKeyPair
-@ stub BCryptGenerateSymmetricKey
+@ stdcall BCryptGenerateKeyPair(ptr ptr long long)
+@ stdcall BCryptGenerateSymmetricKey(ptr ptr ptr long ptr long long)
 @ stdcall BCryptGetFipsAlgorithmMode(ptr)
 @ stdcall BCryptGetProperty(ptr wstr ptr long ptr long)
 @ stdcall BCryptHash(ptr ptr long ptr long ptr long)
 @ stdcall BCryptHashData(ptr ptr long long)
-@ stub BCryptImportKey
-@ stdcall -stub BCryptImportKeyPair(ptr ptr wstr ptr ptr long long)
+@ stdcall BCryptImportKey(ptr ptr wstr ptr ptr long ptr long long)
+@ stdcall BCryptImportKeyPair(ptr ptr wstr ptr ptr long long)
 @ stdcall BCryptOpenAlgorithmProvider(ptr wstr wstr long)
 @ stub BCryptQueryContextConfiguration
 @ stub BCryptQueryContextFunctionConfiguration
 @ stub BCryptQueryContextFunctionProperty
 @ stub BCryptQueryProviderRegistration
 @ stub BCryptRegisterConfigChangeNotify
-@ stub BCryptRegisterProvider
-@ stub BCryptRemoveContextFunction
-@ stub BCryptRemoveContextFunctionProvider
+@ stdcall BCryptRegisterProvider(wstr long ptr)
+@ stdcall BCryptRemoveContextFunction(long wstr long wstr)
+@ stdcall BCryptRemoveContextFunctionProvider(long wstr long wstr wstr)
 @ stub BCryptResolveProviders
-@ stub BCryptSecretAgreement
+@ stdcall BCryptSecretAgreement(ptr ptr ptr long)
 @ stub BCryptSetAuditingInterface
 @ stub BCryptSetContextFunctionProperty
-@ stub BCryptSetProperty
-@ stub BCryptSignHash
+@ stdcall BCryptSetProperty(ptr wstr ptr long long)
+@ stdcall BCryptSignHash(ptr ptr ptr long ptr long ptr long)
 @ stub BCryptUnregisterConfigChangeNotify
-@ stub BCryptUnregisterProvider
-@ stdcall -stub BCryptVerifySignature(ptr ptr ptr long ptr long long)
+@ stdcall BCryptUnregisterProvider(wstr)
+@ stdcall BCryptVerifySignature(ptr ptr ptr long ptr long long)
 @ stub GetAsymmetricEncryptionInterface
 @ stub GetCipherInterface
 @ stub GetHashInterface

--- a/dll/win32/bcrypt/bcrypt_internal.h
+++ b/dll/win32/bcrypt/bcrypt_internal.h
@@ -1,0 +1,226 @@
+/*
+ * Copyright 2016 Michael Müller
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+#ifndef __BCRYPT_INTERNAL_H
+#define __BCRYPT_INTERNAL_H
+
+#include <stdarg.h>
+
+#include "windef.h"
+#include "winbase.h"
+#include "wincrypt.h"
+#include "bcrypt.h"
+
+#define MAGIC_DSS1 ('D' | ('S' << 8) | ('S' << 16) | ('1' << 24))
+#define MAGIC_DSS2 ('D' | ('S' << 8) | ('S' << 16) | ('2' << 24))
+
+typedef struct
+{
+    ULONG64 len;
+    DWORD h[8];
+    UCHAR buf[64];
+} SHA256_CTX;
+
+void sha256_init(SHA256_CTX *ctx) DECLSPEC_HIDDEN;
+void sha256_update(SHA256_CTX *ctx, const UCHAR *buffer, ULONG len) DECLSPEC_HIDDEN;
+void sha256_finalize(SHA256_CTX *ctx, UCHAR *buffer) DECLSPEC_HIDDEN;
+
+typedef struct
+{
+  ULONG64 len;
+  ULONG64 h[8];
+  UCHAR buf[128];
+} SHA512_CTX;
+
+void sha512_init(SHA512_CTX *ctx) DECLSPEC_HIDDEN;
+void sha512_update(SHA512_CTX *ctx, const UCHAR *buffer, ULONG len) DECLSPEC_HIDDEN;
+void sha512_finalize(SHA512_CTX *ctx, UCHAR *buffer) DECLSPEC_HIDDEN;
+
+void sha384_init(SHA512_CTX *ctx) DECLSPEC_HIDDEN;
+#define sha384_update sha512_update
+void sha384_finalize(SHA512_CTX *ctx, UCHAR *buffer) DECLSPEC_HIDDEN;
+
+typedef struct {
+    unsigned char chksum[16], X[48], buf[16];
+    unsigned long curlen;
+} MD2_CTX;
+
+void md2_init(MD2_CTX *ctx) DECLSPEC_HIDDEN;
+void md2_update(MD2_CTX *ctx, const unsigned char *buf, ULONG len) DECLSPEC_HIDDEN;
+void md2_finalize(MD2_CTX *ctx, unsigned char *hash) DECLSPEC_HIDDEN;
+
+/* Definitions from advapi32 */
+typedef struct tagMD4_CTX {
+    unsigned int buf[4];
+    unsigned int i[2];
+    unsigned char in[64];
+    unsigned char digest[16];
+} MD4_CTX;
+
+VOID WINAPI MD4Init(MD4_CTX *ctx);
+VOID WINAPI MD4Update(MD4_CTX *ctx, const unsigned char *buf, unsigned int len);
+VOID WINAPI MD4Final(MD4_CTX *ctx);
+
+typedef struct
+{
+    unsigned int i[2];
+    unsigned int buf[4];
+    unsigned char in[64];
+    unsigned char digest[16];
+} MD5_CTX;
+
+VOID WINAPI MD5Init(MD5_CTX *ctx);
+VOID WINAPI MD5Update(MD5_CTX *ctx, const unsigned char *buf, unsigned int len);
+VOID WINAPI MD5Final(MD5_CTX *ctx);
+
+typedef struct
+{
+   ULONG Unknown[6];
+   ULONG State[5];
+   ULONG Count[2];
+   UCHAR Buffer[64];
+} SHA_CTX;
+
+VOID WINAPI A_SHAInit(SHA_CTX *ctx);
+VOID WINAPI A_SHAUpdate(SHA_CTX *ctx, const UCHAR *buffer, UINT size);
+VOID WINAPI A_SHAFinal(SHA_CTX *ctx, PULONG result);
+
+#define MAGIC_ALG  (('A' << 24) | ('L' << 16) | ('G' << 8) | '0')
+#define MAGIC_HASH (('H' << 24) | ('A' << 16) | ('S' << 8) | 'H')
+#define MAGIC_KEY  (('K' << 24) | ('E' << 16) | ('Y' << 8) | '0')
+#define MAGIC_SECRET (('S' << 24) | ('C' << 16) | ('R' << 8) | 'T')
+struct object
+{
+    ULONG magic;
+};
+
+enum alg_id
+{
+    /* cipher */
+    ALG_ID_3DES,
+    ALG_ID_AES,
+
+    /* hash */
+    ALG_ID_SHA256,
+    ALG_ID_SHA384,
+    ALG_ID_SHA512,
+    ALG_ID_SHA1,
+    ALG_ID_MD5,
+    ALG_ID_MD4,
+    ALG_ID_MD2,
+
+    /* asymmetric encryption */
+    ALG_ID_RSA,
+
+    /* secret agreement */
+    ALG_ID_ECDH_P256,
+
+    /* signature */
+    ALG_ID_RSA_SIGN,
+    ALG_ID_ECDSA_P256,
+    ALG_ID_ECDSA_P384,
+    ALG_ID_DSA,
+
+    /* rng */
+    ALG_ID_RNG,
+};
+
+enum mode_id
+{
+    MODE_ID_ECB,
+    MODE_ID_CBC,
+    MODE_ID_GCM
+};
+
+struct algorithm
+{
+    struct object hdr;
+    enum alg_id   id;
+    enum mode_id  mode;
+    ULONG         flags;
+};
+
+struct key_symmetric
+{
+    enum mode_id mode;
+    ULONG        block_size;
+    UCHAR       *vector;
+    ULONG        vector_len;
+    UCHAR       *secret;
+    ULONG        secret_len;
+    CRITICAL_SECTION cs;
+};
+
+#define KEY_FLAG_LEGACY_DSA_V2  0x00000001
+
+struct key_asymmetric
+{
+    ULONG             bitlen;     /* ignored for ECC keys */
+    ULONG             flags;
+    UCHAR            *pubkey;
+    ULONG             pubkey_len;
+    DSSSEED           dss_seed;
+};
+
+struct key
+{
+    struct object hdr;
+    enum alg_id   alg_id;
+    void         *private[2];  /* private data for backend */
+    union
+    {
+        struct key_symmetric s;
+        struct key_asymmetric a;
+    } u;
+};
+
+struct secret
+{
+    struct object hdr;
+};
+
+struct key_funcs
+{
+    NTSTATUS (CDECL *key_set_property)( struct key *, const WCHAR *, UCHAR *, ULONG, ULONG );
+    NTSTATUS (CDECL *key_symmetric_init)( struct key * );
+    void     (CDECL *key_symmetric_vector_reset)( struct key * );
+    NTSTATUS (CDECL *key_symmetric_set_auth_data)( struct key *, UCHAR *, ULONG );
+    NTSTATUS (CDECL *key_symmetric_encrypt)( struct key *, const UCHAR *, ULONG, UCHAR *, ULONG );
+    NTSTATUS (CDECL *key_symmetric_decrypt)( struct key *, const UCHAR *, ULONG, UCHAR *, ULONG );
+    NTSTATUS (CDECL *key_symmetric_get_tag)( struct key *, UCHAR *, ULONG );
+    void     (CDECL *key_symmetric_destroy)( struct key * );
+    NTSTATUS (CDECL *key_asymmetric_init)( struct key * );
+    NTSTATUS (CDECL *key_asymmetric_generate)( struct key * );
+    NTSTATUS (CDECL *key_asymmetric_decrypt)( struct key *, UCHAR *, ULONG, UCHAR *, ULONG, ULONG * );
+    NTSTATUS (CDECL *key_asymmetric_duplicate)( struct key *, struct key * );
+    NTSTATUS (CDECL *key_asymmetric_sign)( struct key *, void *, UCHAR *, ULONG, UCHAR *, ULONG, ULONG *, ULONG );
+    NTSTATUS (CDECL *key_asymmetric_verify)( struct key *, void *, UCHAR *, ULONG, UCHAR *, ULONG, DWORD );
+    void     (CDECL *key_asymmetric_destroy)( struct key * );
+    NTSTATUS (CDECL *key_export_dsa_capi)( struct key *, UCHAR *, ULONG, ULONG * );
+    NTSTATUS (CDECL *key_export_ecc)( struct key *, UCHAR *, ULONG, ULONG * );
+    NTSTATUS (CDECL *key_import_dsa_capi)( struct key *, UCHAR *, ULONG );
+    NTSTATUS (CDECL *key_import_ecc)( struct key *, UCHAR *, ULONG );
+    NTSTATUS (CDECL *key_import_rsa)( struct key *, UCHAR *, ULONG );
+};
+
+#ifdef __REACTOS__
+extern NTSTATUS CDECL __wine_init_unix_lib( HMODULE module, DWORD reason, const void *ptr_in, void *ptr_out );
+#endif
+
+#endif /* __BCRYPT_INTERNAL_H */

--- a/dll/win32/bcrypt/bcrypt_main.c
+++ b/dll/win32/bcrypt/bcrypt_main.c
@@ -17,276 +17,160 @@
  *
  */
 
-#include <wine/config.h>
-#include <wine/port.h>
+#include <stdarg.h>
 
-#include <ntstatus.h>
+#include "ntstatus.h"
 #define WIN32_NO_STATUS
-#include <windef.h>
-#include <winbase.h>
-#include <ntsecapi.h>
-#include <bcrypt.h>
-
-#include <wine/debug.h>
-#include <wine/unicode.h>
-#include <wine/library.h>
-
-#ifdef SONAME_LIBMBEDTLS
-#include <mbedtls/md.h>
-#include <mbedtls/md5.h>
-#include <mbedtls/sha1.h>
-#include <mbedtls/sha256.h>
-#include <mbedtls/sha512.h>
+#include "windef.h"
+#include "winbase.h"
+#include "ntsecapi.h"
+#include "wincrypt.h"
+#ifndef __REACTOS__
+#include "winternl.h"
 #endif
+#include "bcrypt.h"
+
+#include "bcrypt_internal.h"
+
+#include "wine/debug.h"
+#include "wine/heap.h"
 
 WINE_DEFAULT_DEBUG_CHANNEL(bcrypt);
 
 static HINSTANCE instance;
 
-#if defined(HAVE_GNUTLS_HASH) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H)
-WINE_DECLARE_DEBUG_CHANNEL(winediag);
+static const struct key_funcs *key_funcs;
 
-static void *libgnutls_handle;
-#define MAKE_FUNCPTR(f) static typeof(f) * p##f
-MAKE_FUNCPTR(gnutls_global_deinit);
-MAKE_FUNCPTR(gnutls_global_init);
-MAKE_FUNCPTR(gnutls_global_set_log_function);
-MAKE_FUNCPTR(gnutls_global_set_log_level);
-MAKE_FUNCPTR(gnutls_hash);
-MAKE_FUNCPTR(gnutls_hash_deinit);
-MAKE_FUNCPTR(gnutls_hash_init);
-MAKE_FUNCPTR(gnutls_hmac);
-MAKE_FUNCPTR(gnutls_hmac_deinit);
-MAKE_FUNCPTR(gnutls_hmac_init);
-MAKE_FUNCPTR(gnutls_perror);
-#undef MAKE_FUNCPTR
-
-static void gnutls_log( int level, const char *msg )
+NTSTATUS WINAPI BCryptAddContextFunction(ULONG table, LPCWSTR context, ULONG iface, LPCWSTR function, ULONG pos)
 {
-    TRACE( "<%d> %s", level, msg );
+    FIXME("%08x, %s, %08x, %s, %u: stub\n", table, debugstr_w(context), iface, debugstr_w(function), pos);
+    return STATUS_SUCCESS;
 }
 
-static BOOL gnutls_initialize(void)
+NTSTATUS WINAPI BCryptAddContextFunctionProvider(ULONG table, LPCWSTR context, ULONG iface, LPCWSTR function, LPCWSTR provider, ULONG pos)
 {
-    int ret;
-
-    if (!(libgnutls_handle = wine_dlopen( SONAME_LIBGNUTLS, RTLD_NOW, NULL, 0 )))
-    {
-        ERR_(winediag)( "failed to load libgnutls, no support for crypto hashes\n" );
-        return FALSE;
-    }
-
-#define LOAD_FUNCPTR(f) \
-    if (!(p##f = wine_dlsym( libgnutls_handle, #f, NULL, 0 ))) \
-    { \
-        ERR( "failed to load %s\n", #f ); \
-        goto fail; \
-    }
-
-    LOAD_FUNCPTR(gnutls_global_deinit)
-    LOAD_FUNCPTR(gnutls_global_init)
-    LOAD_FUNCPTR(gnutls_global_set_log_function)
-    LOAD_FUNCPTR(gnutls_global_set_log_level)
-    LOAD_FUNCPTR(gnutls_hash);
-    LOAD_FUNCPTR(gnutls_hash_deinit);
-    LOAD_FUNCPTR(gnutls_hash_init);
-    LOAD_FUNCPTR(gnutls_hmac);
-    LOAD_FUNCPTR(gnutls_hmac_deinit);
-    LOAD_FUNCPTR(gnutls_hmac_init);
-    LOAD_FUNCPTR(gnutls_perror)
-#undef LOAD_FUNCPTR
-
-    if ((ret = pgnutls_global_init()) != GNUTLS_E_SUCCESS)
-    {
-        pgnutls_perror( ret );
-        goto fail;
-    }
-
-    if (TRACE_ON( bcrypt ))
-    {
-        pgnutls_global_set_log_level( 4 );
-        pgnutls_global_set_log_function( gnutls_log );
-    }
-
-    return TRUE;
-
-fail:
-    wine_dlclose( libgnutls_handle, NULL, 0 );
-    libgnutls_handle = NULL;
-    return FALSE;
+    FIXME("%08x, %s, %08x, %s, %s, %u: stub\n", table, debugstr_w(context), iface, debugstr_w(function), debugstr_w(provider), pos);
+    return STATUS_SUCCESS;
 }
 
-static void gnutls_uninitialize(void)
+NTSTATUS WINAPI BCryptRemoveContextFunction(ULONG table, LPCWSTR context, ULONG iface, LPCWSTR function)
 {
-    pgnutls_global_deinit();
-    wine_dlclose( libgnutls_handle, NULL, 0 );
-    libgnutls_handle = NULL;
-}
-#elif defined(SONAME_LIBMBEDTLS) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H) && !defined(__REACTOS__)
-WINE_DECLARE_DEBUG_CHANNEL(winediag);
-
-void *libmbedtls_handle;
-
-#define MAKE_FUNCPTR(f) static typeof(f) * p##f
-MAKE_FUNCPTR(mbedtls_md_init);
-MAKE_FUNCPTR(mbedtls_md_setup);
-MAKE_FUNCPTR(mbedtls_md_update);
-MAKE_FUNCPTR(mbedtls_md_hmac_starts);
-MAKE_FUNCPTR(mbedtls_md_hmac_finish);
-MAKE_FUNCPTR(mbedtls_md_free);
-MAKE_FUNCPTR(mbedtls_md5_init);
-MAKE_FUNCPTR(mbedtls_md5_starts);
-MAKE_FUNCPTR(mbedtls_md5_update);
-MAKE_FUNCPTR(mbedtls_md5_finish);
-MAKE_FUNCPTR(mbedtls_md5_free);
-MAKE_FUNCPTR(mbedtls_sha1_init);
-MAKE_FUNCPTR(mbedtls_sha1_starts);
-MAKE_FUNCPTR(mbedtls_sha1_update);
-MAKE_FUNCPTR(mbedtls_sha1_finish);
-MAKE_FUNCPTR(mbedtls_sha1_free);
-MAKE_FUNCPTR(mbedtls_sha256_init);
-MAKE_FUNCPTR(mbedtls_sha256_starts);
-MAKE_FUNCPTR(mbedtls_sha256_update);
-MAKE_FUNCPTR(mbedtls_sha256_finish);
-MAKE_FUNCPTR(mbedtls_sha256_free);
-MAKE_FUNCPTR(mbedtls_sha512_init);
-MAKE_FUNCPTR(mbedtls_sha512_starts);
-MAKE_FUNCPTR(mbedtls_sha512_update);
-MAKE_FUNCPTR(mbedtls_sha512_finish);
-MAKE_FUNCPTR(mbedtls_sha512_free);
-#undef MAKE_FUNCPTR
-
-#define mbedtls_md_init             pmbedtls_md_init
-#define mbedtls_md_setup            pmbedtls_md_setup
-#define mbedtls_md_update           pmbedtls_md_update
-#define mbedtls_md_hmac_starts      pmbedtls_md_hmac_starts
-#define mbedtls_md_hmac_finish      pmbedtls_md_hmac_finish
-#define mbedtls_md_free             pmbedtls_md_free
-#define mbedtls_md5_init            pmbedtls_md5_init
-#define mbedtls_md5_starts          pmbedtls_md5_starts
-#define mbedtls_md5_update          pmbedtls_md5_update
-#define mbedtls_md5_finish          pmbedtls_md5_finish
-#define mbedtls_md5_free            pmbedtls_md5_free
-#define mbedtls_sha1_init           pmbedtls_sha1_init
-#define mbedtls_sha1_starts         pmbedtls_sha1_starts
-#define mbedtls_sha1_update         pmbedtls_sha1_update
-#define mbedtls_sha1_finish         pmbedtls_sha1_finish
-#define mbedtls_sha1_free           pmbedtls_sha1_free
-#define mbedtls_sha256_init         pmbedtls_sha256_init
-#define mbedtls_sha256_starts       pmbedtls_sha256_starts
-#define mbedtls_sha256_update       pmbedtls_sha256_update
-#define mbedtls_sha256_finish       pmbedtls_sha256_finish
-#define mbedtls_sha256_free         pmbedtls_sha256_free
-#define mbedtls_sha512_init         pmbedtls_sha512_init
-#define mbedtls_sha512_starts       pmbedtls_sha512_starts
-#define mbedtls_sha512_update       pmbedtls_sha512_update
-#define mbedtls_sha512_finish       pmbedtls_sha512_finish
-#define mbedtls_sha512_free         pmbedtls_sha512_free
-
-static BOOL mbedtls_initialize(void)
-{
-    if (!(libmbedtls_handle = wine_dlopen( SONAME_LIBMBEDTLS, RTLD_NOW, NULL, 0 )))
-    {
-        ERR_(winediag)( "failed to load libmbedtls, no support for crypto hashes\n" );
-        return FALSE;
-    }
-
-#define LOAD_FUNCPTR(f) \
-    if (!(p##f = wine_dlsym( libmbedtls_handle, #f, NULL, 0 ))) \
-    { \
-        ERR( "failed to load %s\n", #f ); \
-        goto fail; \
-    }
-
-    LOAD_FUNCPTR(mbedtls_md_init)
-    LOAD_FUNCPTR(mbedtls_md_setup)
-    LOAD_FUNCPTR(mbedtls_md_update)
-    LOAD_FUNCPTR(mbedtls_md_hmac_starts)
-    LOAD_FUNCPTR(mbedtls_md_hmac_finish)
-    LOAD_FUNCPTR(mbedtls_md_free);
-    LOAD_FUNCPTR(mbedtls_md5_init)
-    LOAD_FUNCPTR(mbedtls_md5_starts)
-    LOAD_FUNCPTR(mbedtls_md5_update)
-    LOAD_FUNCPTR(mbedtls_md5_finish)
-    LOAD_FUNCPTR(mbedtls_md5_free);
-    LOAD_FUNCPTR(mbedtls_sha1_init)
-    LOAD_FUNCPTR(mbedtls_sha1_starts)
-    LOAD_FUNCPTR(mbedtls_sha1_update)
-    LOAD_FUNCPTR(mbedtls_sha1_finish)
-    LOAD_FUNCPTR(mbedtls_sha1_free);
-    LOAD_FUNCPTR(mbedtls_sha256_init)
-    LOAD_FUNCPTR(mbedtls_sha256_starts)
-    LOAD_FUNCPTR(mbedtls_sha256_update)
-    LOAD_FUNCPTR(mbedtls_sha256_finish)
-    LOAD_FUNCPTR(mbedtls_sha256_free);
-    LOAD_FUNCPTR(mbedtls_sha512_init)
-    LOAD_FUNCPTR(mbedtls_sha512_starts)
-    LOAD_FUNCPTR(mbedtls_sha512_update)
-    LOAD_FUNCPTR(mbedtls_sha512_finish)
-    LOAD_FUNCPTR(mbedtls_sha512_free);
-#undef LOAD_FUNCPTR
-
-    return TRUE;
-
-fail:
-    wine_dlclose( libmbedtls_handle, NULL, 0 );
-    libmbedtls_handle = NULL;
-    return FALSE;
-}
-
-static void mbedtls_uninitialize(void)
-{
-    wine_dlclose( libmbedtls_handle, NULL, 0 );
-    libmbedtls_handle = NULL;
-}
-#endif /* SONAME_LIBMBEDTLS && !HAVE_COMMONCRYPTO_COMMONDIGEST_H && !__REACTOS__ */
-
-NTSTATUS WINAPI BCryptEnumAlgorithms(ULONG dwAlgOperations, ULONG *pAlgCount,
-                                     BCRYPT_ALGORITHM_IDENTIFIER **ppAlgList, ULONG dwFlags)
-{
-    FIXME("%08x, %p, %p, %08x - stub\n", dwAlgOperations, pAlgCount, ppAlgList, dwFlags);
-
-    *ppAlgList=NULL;
-    *pAlgCount=0;
-
+    FIXME("%08x, %s, %08x, %s: stub\n", table, debugstr_w(context), iface, debugstr_w(function));
     return STATUS_NOT_IMPLEMENTED;
 }
 
-#define MAGIC_ALG  (('A' << 24) | ('L' << 16) | ('G' << 8) | '0')
-#define MAGIC_HASH (('H' << 24) | ('A' << 16) | ('S' << 8) | 'H')
-struct object
+NTSTATUS WINAPI BCryptRemoveContextFunctionProvider(ULONG table, LPCWSTR context, ULONG iface, LPCWSTR function, LPCWSTR provider)
 {
-    ULONG magic;
+    FIXME("%08x, %s, %08x, %s, %s: stub\n", table, debugstr_w(context), iface, debugstr_w(function), debugstr_w(provider));
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+NTSTATUS WINAPI BCryptEnumContextFunctions( ULONG table, const WCHAR *ctx, ULONG iface, ULONG *buflen,
+                                            CRYPT_CONTEXT_FUNCTIONS **buffer )
+{
+    FIXME( "%u, %s, %u, %p, %p\n", table, debugstr_w(ctx), iface, buflen, buffer );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+void WINAPI BCryptFreeBuffer( void *buffer )
+{
+    FIXME( "%p\n", buffer );
+}
+
+NTSTATUS WINAPI BCryptRegisterProvider(LPCWSTR provider, ULONG flags, PCRYPT_PROVIDER_REG reg)
+{
+    FIXME("%s, %08x, %p: stub\n", debugstr_w(provider), flags, reg);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptUnregisterProvider(LPCWSTR provider)
+{
+    FIXME("%s: stub\n", debugstr_w(provider));
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+#define MAX_HASH_OUTPUT_BYTES 64
+#define MAX_HASH_BLOCK_BITS 1024
+
+/* ordered by class, keep in sync with enum alg_id */
+static const struct
+{
+    const WCHAR *name;
+    ULONG        class;
+    ULONG        object_length;
+    ULONG        hash_length;
+    ULONG        block_bits;
+}
+builtin_algorithms[] =
+{
+    {  BCRYPT_3DES_ALGORITHM,       BCRYPT_CIPHER_INTERFACE,                522,    0,    0 },
+    {  BCRYPT_AES_ALGORITHM,        BCRYPT_CIPHER_INTERFACE,                654,    0,    0 },
+    {  BCRYPT_SHA256_ALGORITHM,     BCRYPT_HASH_INTERFACE,                  286,   32,  512 },
+    {  BCRYPT_SHA384_ALGORITHM,     BCRYPT_HASH_INTERFACE,                  382,   48, 1024 },
+    {  BCRYPT_SHA512_ALGORITHM,     BCRYPT_HASH_INTERFACE,                  382,   64, 1024 },
+    {  BCRYPT_SHA1_ALGORITHM,       BCRYPT_HASH_INTERFACE,                  278,   20,  512 },
+    {  BCRYPT_MD5_ALGORITHM,        BCRYPT_HASH_INTERFACE,                  274,   16,  512 },
+    {  BCRYPT_MD4_ALGORITHM,        BCRYPT_HASH_INTERFACE,                  270,   16,  512 },
+    {  BCRYPT_MD2_ALGORITHM,        BCRYPT_HASH_INTERFACE,                  270,   16,  128 },
+    {  BCRYPT_RSA_ALGORITHM,        BCRYPT_ASYMMETRIC_ENCRYPTION_INTERFACE, 0,      0,    0 },
+    {  BCRYPT_ECDH_P256_ALGORITHM,  BCRYPT_SECRET_AGREEMENT_INTERFACE,      0,      0,    0 },
+    {  BCRYPT_RSA_SIGN_ALGORITHM,   BCRYPT_SIGNATURE_INTERFACE,             0,      0,    0 },
+    {  BCRYPT_ECDSA_P256_ALGORITHM, BCRYPT_SIGNATURE_INTERFACE,             0,      0,    0 },
+    {  BCRYPT_ECDSA_P384_ALGORITHM, BCRYPT_SIGNATURE_INTERFACE,             0,      0,    0 },
+    {  BCRYPT_DSA_ALGORITHM,        BCRYPT_SIGNATURE_INTERFACE,             0,      0,    0 },
+    {  BCRYPT_RNG_ALGORITHM,        BCRYPT_RNG_INTERFACE,                   0,      0,    0 },
 };
 
-enum alg_id
+static BOOL match_operation_type( ULONG type, ULONG class )
 {
-    ALG_ID_MD5,
-    ALG_ID_RNG,
-    ALG_ID_SHA1,
-    ALG_ID_SHA256,
-    ALG_ID_SHA384,
-    ALG_ID_SHA512
-};
+    if (!type) return TRUE;
+    switch (class)
+    {
+    case BCRYPT_CIPHER_INTERFACE:                return type & BCRYPT_CIPHER_OPERATION;
+    case BCRYPT_HASH_INTERFACE:                  return type & BCRYPT_HASH_OPERATION;
+    case BCRYPT_ASYMMETRIC_ENCRYPTION_INTERFACE: return type & BCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION;
+    case BCRYPT_SECRET_AGREEMENT_INTERFACE:      return type & BCRYPT_SECRET_AGREEMENT_OPERATION;
+    case BCRYPT_SIGNATURE_INTERFACE:             return type & BCRYPT_SIGNATURE_OPERATION;
+    case BCRYPT_RNG_INTERFACE:                   return type & BCRYPT_RNG_OPERATION;
+    default: break;
+    }
+    return FALSE;
+}
 
-static const struct {
-    ULONG hash_length;
-    const WCHAR *alg_name;
-} alg_props[] = {
-    /* ALG_ID_MD5    */ { 16, BCRYPT_MD5_ALGORITHM },
-    /* ALG_ID_RNG    */ {  0, BCRYPT_RNG_ALGORITHM },
-    /* ALG_ID_SHA1   */ { 20, BCRYPT_SHA1_ALGORITHM },
-    /* ALG_ID_SHA256 */ { 32, BCRYPT_SHA256_ALGORITHM },
-    /* ALG_ID_SHA384 */ { 48, BCRYPT_SHA384_ALGORITHM },
-    /* ALG_ID_SHA512 */ { 64, BCRYPT_SHA512_ALGORITHM }
-};
-
-struct algorithm
+NTSTATUS WINAPI BCryptEnumAlgorithms( ULONG type, ULONG *ret_count, BCRYPT_ALGORITHM_IDENTIFIER **ret_list, ULONG flags )
 {
-    struct object hdr;
-    enum alg_id   id;
-    BOOL hmac;
-};
+    static const ULONG supported = BCRYPT_CIPHER_OPERATION |\
+                                   BCRYPT_HASH_OPERATION |\
+                                   BCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION |\
+                                   BCRYPT_SECRET_AGREEMENT_OPERATION |\
+                                   BCRYPT_SIGNATURE_OPERATION |\
+                                   BCRYPT_RNG_OPERATION;
+    BCRYPT_ALGORITHM_IDENTIFIER *list;
+    ULONG i, count = 0;
+
+    TRACE( "%08x, %p, %p, %08x\n", type, ret_count, ret_list, flags );
+
+    if (!ret_count || !ret_list || (type & ~supported)) return STATUS_INVALID_PARAMETER;
+
+    for (i = 0; i < ARRAY_SIZE( builtin_algorithms ); i++)
+    {
+        if (match_operation_type( type, builtin_algorithms[i].class )) count++;
+    }
+
+    if (!(list = heap_alloc( count * sizeof(*list) ))) return STATUS_NO_MEMORY;
+
+    for (i = 0; i < ARRAY_SIZE( builtin_algorithms ); i++)
+    {
+        if (!match_operation_type( type, builtin_algorithms[i].class )) continue;
+        list[i].pszName = (WCHAR *)builtin_algorithms[i].name;
+        list[i].dwClass = builtin_algorithms[i].class;
+        list[i].dwFlags = 0;
+    }
+
+    *ret_count = count;
+    *ret_list = list;
+    return STATUS_SUCCESS;
+}
 
 NTSTATUS WINAPI BCryptGenRandom(BCRYPT_ALG_HANDLE handle, UCHAR *buffer, ULONG count, ULONG flags)
 {
@@ -331,10 +215,10 @@ NTSTATUS WINAPI BCryptGenRandom(BCRYPT_ALG_HANDLE handle, UCHAR *buffer, ULONG c
 
 NTSTATUS WINAPI BCryptOpenAlgorithmProvider( BCRYPT_ALG_HANDLE *handle, LPCWSTR id, LPCWSTR implementation, DWORD flags )
 {
+    const DWORD supported_flags = BCRYPT_ALG_HANDLE_HMAC_FLAG | BCRYPT_HASH_REUSABLE_FLAG;
     struct algorithm *alg;
     enum alg_id alg_id;
-
-    const DWORD supported_flags = BCRYPT_ALG_HANDLE_HMAC_FLAG;
+    ULONG i;
 
     TRACE( "%p, %s, %s, %08x\n", handle, wine_dbgstr_w(id), wine_dbgstr_w(implementation), flags );
 
@@ -345,27 +229,31 @@ NTSTATUS WINAPI BCryptOpenAlgorithmProvider( BCRYPT_ALG_HANDLE *handle, LPCWSTR 
         return STATUS_NOT_IMPLEMENTED;
     }
 
-    if (!strcmpW( id, BCRYPT_SHA1_ALGORITHM )) alg_id = ALG_ID_SHA1;
-    else if (!strcmpW( id, BCRYPT_MD5_ALGORITHM )) alg_id = ALG_ID_MD5;
-    else if (!strcmpW( id, BCRYPT_RNG_ALGORITHM )) alg_id = ALG_ID_RNG;
-    else if (!strcmpW( id, BCRYPT_SHA256_ALGORITHM )) alg_id = ALG_ID_SHA256;
-    else if (!strcmpW( id, BCRYPT_SHA384_ALGORITHM )) alg_id = ALG_ID_SHA384;
-    else if (!strcmpW( id, BCRYPT_SHA512_ALGORITHM )) alg_id = ALG_ID_SHA512;
-    else
+    for (i = 0; i < ARRAY_SIZE( builtin_algorithms ); i++)
+    {
+        if (!wcscmp( id, builtin_algorithms[i].name))
+        {
+            alg_id = i;
+            break;
+        }
+    }
+    if (i == ARRAY_SIZE( builtin_algorithms ))
     {
         FIXME( "algorithm %s not supported\n", debugstr_w(id) );
         return STATUS_NOT_IMPLEMENTED;
     }
-    if (implementation && strcmpW( implementation, MS_PRIMITIVE_PROVIDER ))
+
+    if (implementation && wcscmp( implementation, MS_PRIMITIVE_PROVIDER ))
     {
         FIXME( "implementation %s not supported\n", debugstr_w(implementation) );
         return STATUS_NOT_IMPLEMENTED;
     }
 
-    if (!(alg = HeapAlloc( GetProcessHeap(), 0, sizeof(*alg) ))) return STATUS_NO_MEMORY;
+    if (!(alg = heap_alloc( sizeof(*alg) ))) return STATUS_NO_MEMORY;
     alg->hdr.magic = MAGIC_ALG;
     alg->id        = alg_id;
-    alg->hmac      = flags & BCRYPT_ALG_HANDLE_HMAC_FLAG;
+    alg->mode      = MODE_ID_CBC;
+    alg->flags     = flags;
 
     *handle = alg;
     return STATUS_SUCCESS;
@@ -378,7 +266,8 @@ NTSTATUS WINAPI BCryptCloseAlgorithmProvider( BCRYPT_ALG_HANDLE handle, DWORD fl
     TRACE( "%p, %08x\n", handle, flags );
 
     if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
-    HeapFree( GetProcessHeap(), 0, alg );
+    alg->hdr.magic = 0;
+    heap_free( alg );
     return STATUS_SUCCESS;
 }
 
@@ -393,580 +282,423 @@ NTSTATUS WINAPI BCryptGetFipsAlgorithmMode(BOOLEAN *enabled)
     return STATUS_SUCCESS;
 }
 
-#ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
-struct hash
+struct hash_impl
 {
-    struct object hdr;
-    enum alg_id   alg_id;
-    BOOL hmac;
     union
     {
-        CC_MD5_CTX    md5_ctx;
-        CC_SHA1_CTX   sha1_ctx;
-        CC_SHA256_CTX sha256_ctx;
-        CC_SHA512_CTX sha512_ctx;
-        CCHmacContext hmac_ctx;
+        MD2_CTX md2;
+        MD4_CTX md4;
+        MD5_CTX md5;
+        SHA_CTX sha1;
+        SHA256_CTX sha256;
+        SHA512_CTX sha512;
     } u;
 };
 
-static NTSTATUS hash_init( struct hash *hash )
+static NTSTATUS hash_init( struct hash_impl *hash, enum alg_id alg_id )
 {
-    switch (hash->alg_id)
+    switch (alg_id)
     {
+    case ALG_ID_MD2:
+        md2_init( &hash->u.md2 );
+        break;
+
+    case ALG_ID_MD4:
+        MD4Init( &hash->u.md4 );
+        break;
+
     case ALG_ID_MD5:
-        CC_MD5_Init( &hash->u.md5_ctx );
+        MD5Init( &hash->u.md5 );
         break;
 
     case ALG_ID_SHA1:
-        CC_SHA1_Init( &hash->u.sha1_ctx );
+        A_SHAInit( &hash->u.sha1 );
         break;
 
     case ALG_ID_SHA256:
-        CC_SHA256_Init( &hash->u.sha256_ctx );
+        sha256_init( &hash->u.sha256 );
         break;
 
     case ALG_ID_SHA384:
-        CC_SHA384_Init( &hash->u.sha512_ctx );
+        sha384_init( &hash->u.sha512 );
         break;
 
     case ALG_ID_SHA512:
-        CC_SHA512_Init( &hash->u.sha512_ctx );
+        sha512_init( &hash->u.sha512 );
         break;
 
     default:
-        ERR( "unhandled id %u\n", hash->alg_id );
+        ERR( "unhandled id %u\n", alg_id );
         return STATUS_NOT_IMPLEMENTED;
     }
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS hmac_init( struct hash *hash, UCHAR *key, ULONG key_size )
+static NTSTATUS hash_update( struct hash_impl *hash, enum alg_id alg_id,
+                             UCHAR *input, ULONG size )
 {
-    CCHmacAlgorithm cc_algorithm;
-    switch (hash->alg_id)
+    switch (alg_id)
     {
+    case ALG_ID_MD2:
+        md2_update( &hash->u.md2, input, size );
+        break;
+
+    case ALG_ID_MD4:
+        MD4Update( &hash->u.md4, input, size );
+        break;
+
     case ALG_ID_MD5:
-        cc_algorithm = kCCHmacAlgMD5;
+        MD5Update( &hash->u.md5, input, size );
         break;
 
     case ALG_ID_SHA1:
-        cc_algorithm = kCCHmacAlgSHA1;
+        A_SHAUpdate( &hash->u.sha1, input, size );
         break;
 
     case ALG_ID_SHA256:
-        cc_algorithm = kCCHmacAlgSHA256;
+        sha256_update( &hash->u.sha256, input, size );
         break;
 
     case ALG_ID_SHA384:
-        cc_algorithm = kCCHmacAlgSHA384;
+        sha384_update( &hash->u.sha512, input, size );
         break;
 
     case ALG_ID_SHA512:
-        cc_algorithm = kCCHmacAlgSHA512;
+        sha512_update( &hash->u.sha512, input, size );
         break;
 
     default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    CCHmacInit( &hash->u.hmac_ctx, cc_algorithm, key, key_size );
-    return STATUS_SUCCESS;
-}
-
-
-static NTSTATUS hash_update( struct hash *hash, UCHAR *input, ULONG size )
-{
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        CC_MD5_Update( &hash->u.md5_ctx, input, size );
-        break;
-
-    case ALG_ID_SHA1:
-        CC_SHA1_Update( &hash->u.sha1_ctx, input, size );
-        break;
-
-    case ALG_ID_SHA256:
-        CC_SHA256_Update( &hash->u.sha256_ctx, input, size );
-        break;
-
-    case ALG_ID_SHA384:
-        CC_SHA384_Update( &hash->u.sha512_ctx, input, size );
-        break;
-
-    case ALG_ID_SHA512:
-        CC_SHA512_Update( &hash->u.sha512_ctx, input, size );
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
+        ERR( "unhandled id %u\n", alg_id );
         return STATUS_NOT_IMPLEMENTED;
     }
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS hmac_update( struct hash *hash, UCHAR *input, ULONG size )
+static NTSTATUS hash_finish( struct hash_impl *hash, enum alg_id alg_id,
+                             UCHAR *output, ULONG size )
 {
-    CCHmacUpdate( &hash->u.hmac_ctx, input, size );
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hash_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-    switch (hash->alg_id)
+    switch (alg_id)
     {
+    case ALG_ID_MD2:
+        md2_finalize( &hash->u.md2, output );
+        break;
+
+    case ALG_ID_MD4:
+        MD4Final( &hash->u.md4 );
+        memcpy( output, hash->u.md4.digest, 16 );
+        break;
+
     case ALG_ID_MD5:
-        CC_MD5_Final( output, &hash->u.md5_ctx );
+        MD5Final( &hash->u.md5 );
+        memcpy( output, hash->u.md5.digest, 16 );
         break;
 
     case ALG_ID_SHA1:
-        CC_SHA1_Final( output, &hash->u.sha1_ctx );
+        A_SHAFinal( &hash->u.sha1, (ULONG *)output );
         break;
 
     case ALG_ID_SHA256:
-        CC_SHA256_Final( output, &hash->u.sha256_ctx );
+        sha256_finalize( &hash->u.sha256, output );
         break;
 
     case ALG_ID_SHA384:
-        CC_SHA384_Final( output, &hash->u.sha512_ctx );
+        sha384_finalize( &hash->u.sha512, output );
         break;
 
     case ALG_ID_SHA512:
-        CC_SHA512_Final( output, &hash->u.sha512_ctx );
+        sha512_finalize( &hash->u.sha512, output );
         break;
 
     default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        break;
+        ERR( "unhandled id %u\n", alg_id );
+        return STATUS_NOT_IMPLEMENTED;
     }
     return STATUS_SUCCESS;
 }
 
-static NTSTATUS hmac_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-    CCHmacFinal( &hash->u.hmac_ctx, output );
-
-    return STATUS_SUCCESS;
-}
-#elif defined(HAVE_GNUTLS_HASH)
+#define HASH_FLAG_HMAC      0x01
+#define HASH_FLAG_REUSABLE  0x02
 struct hash
 {
-    struct object    hdr;
-    enum alg_id      alg_id;
-    BOOL hmac;
-    union
-    {
-        gnutls_hash_hd_t hash_handle;
-        gnutls_hmac_hd_t hmac_handle;
-    } u;
+    struct object     hdr;
+    enum alg_id       alg_id;
+    ULONG             flags;
+    UCHAR            *secret;
+    ULONG             secret_len;
+    struct hash_impl  outer;
+    struct hash_impl  inner;
 };
 
-static NTSTATUS hash_init( struct hash *hash )
-{
-    gnutls_digest_algorithm_t alg;
-
-    if (!libgnutls_handle) return STATUS_INTERNAL_ERROR;
-
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        alg = GNUTLS_DIG_MD5;
-        break;
-    case ALG_ID_SHA1:
-        alg = GNUTLS_DIG_SHA1;
-        break;
-
-    case ALG_ID_SHA256:
-        alg = GNUTLS_DIG_SHA256;
-        break;
-
-    case ALG_ID_SHA384:
-        alg = GNUTLS_DIG_SHA384;
-        break;
-
-    case ALG_ID_SHA512:
-        alg = GNUTLS_DIG_SHA512;
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    if (pgnutls_hash_init( &hash->u.hash_handle, alg )) return STATUS_INTERNAL_ERROR;
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_init( struct hash *hash, UCHAR *key, ULONG key_size )
-{
-    gnutls_mac_algorithm_t alg;
-
-    if (!libgnutls_handle) return STATUS_INTERNAL_ERROR;
-
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        alg = GNUTLS_MAC_MD5;
-        break;
-    case ALG_ID_SHA1:
-        alg = GNUTLS_MAC_SHA1;
-        break;
-
-    case ALG_ID_SHA256:
-        alg = GNUTLS_MAC_SHA256;
-        break;
-
-    case ALG_ID_SHA384:
-        alg = GNUTLS_MAC_SHA384;
-        break;
-
-    case ALG_ID_SHA512:
-        alg = GNUTLS_MAC_SHA512;
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    if (pgnutls_hmac_init( &hash->u.hmac_handle, alg, key, key_size )) return STATUS_INTERNAL_ERROR;
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hash_update( struct hash *hash, UCHAR *input, ULONG size )
-{
-    if (pgnutls_hash( hash->u.hash_handle, input, size )) return STATUS_INTERNAL_ERROR;
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_update( struct hash *hash, UCHAR *input, ULONG size )
-{
-    if (pgnutls_hmac( hash->u.hmac_handle, input, size )) return STATUS_INTERNAL_ERROR;
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hash_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-    pgnutls_hash_deinit( hash->u.hash_handle, output );
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-    pgnutls_hmac_deinit( hash->u.hmac_handle, output );
-    return STATUS_SUCCESS;
-}
-#elif defined(SONAME_LIBMBEDTLS)
-struct hash
-{
-    struct object hdr;
-    BOOL hmac;
-    enum alg_id   alg_id;
-    union
-    {
-        mbedtls_md5_context    md5_ctx;
-        mbedtls_sha1_context   sha1_ctx;
-        mbedtls_sha256_context sha256_ctx;
-        mbedtls_sha512_context sha512_ctx;
-        mbedtls_md_context_t   hmac_ctx;
-    } u;
-};
-
-static NTSTATUS hash_init( struct hash *hash )
-{
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        mbedtls_md5_init(&hash->u.md5_ctx);
-        mbedtls_md5_starts(&hash->u.md5_ctx);
-        break;
-
-    case ALG_ID_SHA1:
-        mbedtls_sha1_init(&hash->u.sha1_ctx);
-        mbedtls_sha1_starts(&hash->u.sha1_ctx);
-        break;
-
-    case ALG_ID_SHA256:
-        mbedtls_sha256_init(&hash->u.sha256_ctx);
-        mbedtls_sha256_starts(&hash->u.sha256_ctx, FALSE);
-        break;
-
-    case ALG_ID_SHA384:
-    case ALG_ID_SHA512:
-        mbedtls_sha512_init(&hash->u.sha512_ctx);
-        mbedtls_sha512_starts(&hash->u.sha512_ctx, hash->alg_id==ALG_ID_SHA384);
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_init( struct hash *hash, UCHAR *key, ULONG key_size )
-{
-    const mbedtls_md_info_t *md_info;
-    mbedtls_md_type_t md_type;
-    int ret;
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    mbedtls_md_init(&hash->u.hmac_ctx);
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        md_type = MBEDTLS_MD_MD5;
-        break;
-
-    case ALG_ID_SHA1:
-        md_type = MBEDTLS_MD_SHA1;
-        break;
-
-    case ALG_ID_SHA256:
-        md_type = MBEDTLS_MD_SHA256;
-        break;
-
-    case ALG_ID_SHA384:
-        md_type = MBEDTLS_MD_SHA384;
-        break;
-
-    case ALG_ID_SHA512:
-        md_type = MBEDTLS_MD_SHA512;
-        break;
-
-    default:
-        ERR("unhandled id %u\n", hash->alg_id);
-        return STATUS_NOT_IMPLEMENTED;
-    }
-    if ((md_info = mbedtls_md_info_from_type(md_type)) == NULL)
-    {
-        mbedtls_md_free(&hash->u.hmac_ctx);
-        return STATUS_INTERNAL_ERROR;
-    }
-
-    if ((ret = mbedtls_md_setup(&hash->u.hmac_ctx, md_info, 1)) != 0)
-    {
-        mbedtls_md_free(&hash->u.hmac_ctx);
-        return STATUS_INTERNAL_ERROR;
-    }
-
-    mbedtls_md_hmac_starts(&hash->u.hmac_ctx, key, key_size);
-
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hash_update( struct hash *hash, UCHAR *input, ULONG size )
-{
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        mbedtls_md5_update(&hash->u.md5_ctx, input, size);
-        break;
-
-    case ALG_ID_SHA1:
-        mbedtls_sha1_update(&hash->u.sha1_ctx, input, size);
-        break;
-
-    case ALG_ID_SHA256:
-        mbedtls_sha256_update(&hash->u.sha256_ctx, input, size);
-        break;
-
-    case ALG_ID_SHA384:
-    case ALG_ID_SHA512:
-        mbedtls_sha512_update(&hash->u.sha512_ctx, input, size);
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_update( struct hash *hash, UCHAR *input, ULONG size )
-{
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    mbedtls_md_update(&hash->u.hmac_ctx, input, size);
-
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hash_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    switch (hash->alg_id)
-    {
-    case ALG_ID_MD5:
-        mbedtls_md5_finish(&hash->u.md5_ctx, output);
-        mbedtls_md5_free(&hash->u.md5_ctx);
-        break;
-
-    case ALG_ID_SHA1:
-        mbedtls_sha1_finish(&hash->u.sha1_ctx, output);
-        mbedtls_sha1_free(&hash->u.sha1_ctx);
-        break;
-
-    case ALG_ID_SHA256:
-        mbedtls_sha256_finish(&hash->u.sha256_ctx, output);
-        mbedtls_sha256_free(&hash->u.sha256_ctx);
-        break;
-
-    case ALG_ID_SHA384:
-    case ALG_ID_SHA512:
-        mbedtls_sha512_finish(&hash->u.sha512_ctx, output);
-        mbedtls_sha512_free(&hash->u.sha512_ctx);
-        break;
-
-    default:
-        ERR( "unhandled id %u\n", hash->alg_id );
-        return STATUS_NOT_IMPLEMENTED;
-    }
-
-    return STATUS_SUCCESS;
-}
-
-static NTSTATUS hmac_finish( struct hash *hash, UCHAR *output, ULONG size )
-{
-#ifndef __REACTOS__
-    if (!libmbedtls_handle) return STATUS_INTERNAL_ERROR;
-#endif
-    mbedtls_md_hmac_finish(&hash->u.hmac_ctx, output);
-    mbedtls_md_free(&hash->u.hmac_ctx);
-
-    return STATUS_SUCCESS;
-}
-#endif
-
-#define OBJECT_LENGTH_MD5       274
-#define OBJECT_LENGTH_SHA1      278
-#define OBJECT_LENGTH_SHA256    286
-#define OBJECT_LENGTH_SHA384    382
-#define OBJECT_LENGTH_SHA512    382
+#define BLOCK_LENGTH_3DES       8
+#define BLOCK_LENGTH_AES        16
 
 static NTSTATUS generic_alg_property( enum alg_id id, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
 {
-    if (!strcmpW( prop, BCRYPT_HASH_LENGTH ))
+    if (!wcscmp( prop, BCRYPT_OBJECT_LENGTH ))
     {
+        if (!builtin_algorithms[id].object_length)
+            return STATUS_NOT_SUPPORTED;
+        *ret_size = sizeof(ULONG);
+        if (size < sizeof(ULONG))
+            return STATUS_BUFFER_TOO_SMALL;
+        if (buf)
+            *(ULONG *)buf = builtin_algorithms[id].object_length;
+        return STATUS_SUCCESS;
+    }
+
+    if (!wcscmp( prop, BCRYPT_HASH_LENGTH ))
+    {
+        if (!builtin_algorithms[id].hash_length)
+            return STATUS_NOT_SUPPORTED;
         *ret_size = sizeof(ULONG);
         if (size < sizeof(ULONG))
             return STATUS_BUFFER_TOO_SMALL;
         if(buf)
-            *(ULONG*)buf = alg_props[id].hash_length;
+            *(ULONG*)buf = builtin_algorithms[id].hash_length;
         return STATUS_SUCCESS;
     }
 
-    if (!strcmpW( prop, BCRYPT_ALGORITHM_NAME ))
+    if (!wcscmp( prop, BCRYPT_ALGORITHM_NAME ))
     {
-        *ret_size = (strlenW(alg_props[id].alg_name)+1)*sizeof(WCHAR);
+        *ret_size = (lstrlenW(builtin_algorithms[id].name) + 1) * sizeof(WCHAR);
         if (size < *ret_size)
             return STATUS_BUFFER_TOO_SMALL;
         if(buf)
-            memcpy(buf, alg_props[id].alg_name, *ret_size);
+            memcpy(buf, builtin_algorithms[id].name, *ret_size);
         return STATUS_SUCCESS;
     }
 
     return STATUS_NOT_IMPLEMENTED;
 }
 
-static NTSTATUS get_alg_property( enum alg_id id, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+static NTSTATUS get_3des_property( enum mode_id mode, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+{
+    if (!wcscmp( prop, BCRYPT_BLOCK_LENGTH ))
+    {
+        *ret_size = sizeof(ULONG);
+        if (size < sizeof(ULONG)) return STATUS_BUFFER_TOO_SMALL;
+        if (buf) *(ULONG *)buf = BLOCK_LENGTH_3DES;
+        return STATUS_SUCCESS;
+    }
+    if (!wcscmp( prop, BCRYPT_CHAINING_MODE ))
+    {
+        const WCHAR *str;
+        switch (mode)
+        {
+        case MODE_ID_CBC: str = BCRYPT_CHAIN_MODE_CBC; break;
+        default: return STATUS_NOT_IMPLEMENTED;
+        }
+
+        *ret_size = 64;
+        if (size < *ret_size) return STATUS_BUFFER_TOO_SMALL;
+        memcpy( buf, str, (lstrlenW(str) + 1) * sizeof(WCHAR) );
+        return STATUS_SUCCESS;
+    }
+    if (!wcscmp( prop, BCRYPT_KEY_LENGTHS ))
+    {
+        BCRYPT_KEY_LENGTHS_STRUCT *key_lengths = (void *)buf;
+        *ret_size = sizeof(*key_lengths);
+        if (key_lengths && size < *ret_size) return STATUS_BUFFER_TOO_SMALL;
+        if (key_lengths)
+        {
+            key_lengths->dwMinLength = 192;
+            key_lengths->dwMaxLength = 192;
+            key_lengths->dwIncrement = 0;
+        }
+        return STATUS_SUCCESS;
+    }
+    FIXME( "unsupported property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS get_aes_property( enum mode_id mode, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+{
+    if (!wcscmp( prop, BCRYPT_BLOCK_LENGTH ))
+    {
+        *ret_size = sizeof(ULONG);
+        if (size < sizeof(ULONG)) return STATUS_BUFFER_TOO_SMALL;
+        if (buf) *(ULONG *)buf = BLOCK_LENGTH_AES;
+        return STATUS_SUCCESS;
+    }
+    if (!wcscmp( prop, BCRYPT_CHAINING_MODE ))
+    {
+        const WCHAR *str;
+        switch (mode)
+        {
+        case MODE_ID_ECB: str = BCRYPT_CHAIN_MODE_ECB; break;
+        case MODE_ID_CBC: str = BCRYPT_CHAIN_MODE_CBC; break;
+        case MODE_ID_GCM: str = BCRYPT_CHAIN_MODE_GCM; break;
+        default: return STATUS_NOT_IMPLEMENTED;
+        }
+
+        *ret_size = 64;
+        if (size < *ret_size) return STATUS_BUFFER_TOO_SMALL;
+        memcpy( buf, str, (lstrlenW(str) + 1) * sizeof(WCHAR) );
+        return STATUS_SUCCESS;
+    }
+    if (!wcscmp( prop, BCRYPT_KEY_LENGTHS ))
+    {
+        BCRYPT_KEY_LENGTHS_STRUCT *key_lengths = (void *)buf;
+        *ret_size = sizeof(*key_lengths);
+        if (key_lengths && size < *ret_size) return STATUS_BUFFER_TOO_SMALL;
+        if (key_lengths)
+        {
+            key_lengths->dwMinLength = 128;
+            key_lengths->dwMaxLength = 256;
+            key_lengths->dwIncrement = 64;
+        }
+        return STATUS_SUCCESS;
+    }
+    if (!wcscmp( prop, BCRYPT_AUTH_TAG_LENGTH ))
+    {
+        BCRYPT_AUTH_TAG_LENGTHS_STRUCT *tag_length = (void *)buf;
+        if (mode != MODE_ID_GCM) return STATUS_NOT_SUPPORTED;
+        *ret_size = sizeof(*tag_length);
+        if (tag_length && size < *ret_size) return STATUS_BUFFER_TOO_SMALL;
+        if (tag_length)
+        {
+            tag_length->dwMinLength = 12;
+            tag_length->dwMaxLength = 16;
+            tag_length->dwIncrement =  1;
+        }
+        return STATUS_SUCCESS;
+    }
+
+    FIXME( "unsupported property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS get_rsa_property( enum mode_id mode, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+{
+    if (!wcscmp( prop, BCRYPT_PADDING_SCHEMES ))
+    {
+        *ret_size = sizeof(ULONG);
+        if (size < sizeof(ULONG)) return STATUS_BUFFER_TOO_SMALL;
+        if (buf) *(ULONG *)buf = BCRYPT_SUPPORTED_PAD_PKCS1_SIG;
+        return STATUS_SUCCESS;
+    }
+
+    FIXME( "unsupported property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS get_dsa_property( enum mode_id mode, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+{
+    if (!wcscmp( prop, BCRYPT_PADDING_SCHEMES )) return STATUS_NOT_SUPPORTED;
+    FIXME( "unsupported property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS get_alg_property( const struct algorithm *alg, const WCHAR *prop,
+                                  UCHAR *buf, ULONG size, ULONG *ret_size )
 {
     NTSTATUS status;
-    ULONG value;
 
-    status = generic_alg_property( id, prop, buf, size, ret_size );
+    status = generic_alg_property( alg->id, prop, buf, size, ret_size );
     if (status != STATUS_NOT_IMPLEMENTED)
         return status;
 
-    switch (id)
+    switch (alg->id)
     {
-    case ALG_ID_MD5:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH ))
+    case ALG_ID_3DES:
+        return get_3des_property( alg->mode, prop, buf, size, ret_size );
+
+    case ALG_ID_AES:
+        return get_aes_property( alg->mode, prop, buf, size, ret_size );
+
+    case ALG_ID_RSA:
+        return get_rsa_property( alg->mode, prop, buf, size, ret_size );
+
+    case ALG_ID_DSA:
+        return get_dsa_property( alg->mode, prop, buf, size, ret_size );
+
+    default:
+        break;
+    }
+
+    FIXME( "unsupported property %s algorithm %u\n", debugstr_w(prop), alg->id );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS set_alg_property( struct algorithm *alg, const WCHAR *prop, UCHAR *value, ULONG size, ULONG flags )
+{
+    switch (alg->id)
+    {
+    case ALG_ID_3DES:
+        if (!wcscmp( prop, BCRYPT_CHAINING_MODE ))
         {
-            value = OBJECT_LENGTH_MD5;
-            break;
+            if (!wcscmp( (WCHAR *)value, BCRYPT_CHAIN_MODE_CBC ))
+            {
+                alg->mode = MODE_ID_CBC;
+                return STATUS_SUCCESS;
+            }
+            else
+            {
+                FIXME( "unsupported mode %s\n", debugstr_w((WCHAR *)value) );
+                return STATUS_NOT_SUPPORTED;
+            }
         }
-        FIXME( "unsupported md5 algorithm property %s\n", debugstr_w(prop) );
+        FIXME( "unsupported 3des algorithm property %s\n", debugstr_w(prop) );
         return STATUS_NOT_IMPLEMENTED;
 
-    case ALG_ID_RNG:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH )) return STATUS_NOT_SUPPORTED;
-        FIXME( "unsupported rng algorithm property %s\n", debugstr_w(prop) );
-        return STATUS_NOT_IMPLEMENTED;
-
-    case ALG_ID_SHA1:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH ))
+    case ALG_ID_AES:
+        if (!wcscmp( prop, BCRYPT_CHAINING_MODE ))
         {
-            value = OBJECT_LENGTH_SHA1;
-            break;
+            if (!wcscmp( (WCHAR *)value, BCRYPT_CHAIN_MODE_ECB ))
+            {
+                alg->mode = MODE_ID_ECB;
+                return STATUS_SUCCESS;
+            }
+            else if (!wcscmp( (WCHAR *)value, BCRYPT_CHAIN_MODE_CBC ))
+            {
+                alg->mode = MODE_ID_CBC;
+                return STATUS_SUCCESS;
+            }
+            else if (!wcscmp( (WCHAR *)value, BCRYPT_CHAIN_MODE_GCM ))
+            {
+                alg->mode = MODE_ID_GCM;
+                return STATUS_SUCCESS;
+            }
+            else
+            {
+                FIXME( "unsupported mode %s\n", debugstr_w((WCHAR *)value) );
+                return STATUS_NOT_IMPLEMENTED;
+            }
         }
-        FIXME( "unsupported sha1 algorithm property %s\n", debugstr_w(prop) );
-        return STATUS_NOT_IMPLEMENTED;
-
-    case ALG_ID_SHA256:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH ))
-        {
-            value = OBJECT_LENGTH_SHA256;
-            break;
-        }
-        FIXME( "unsupported sha256 algorithm property %s\n", debugstr_w(prop) );
-        return STATUS_NOT_IMPLEMENTED;
-
-    case ALG_ID_SHA384:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH ))
-        {
-            value = OBJECT_LENGTH_SHA384;
-            break;
-        }
-        FIXME( "unsupported sha384 algorithm property %s\n", debugstr_w(prop) );
-        return STATUS_NOT_IMPLEMENTED;
-
-    case ALG_ID_SHA512:
-        if (!strcmpW( prop, BCRYPT_OBJECT_LENGTH ))
-        {
-            value = OBJECT_LENGTH_SHA512;
-            break;
-        }
-        FIXME( "unsupported sha512 algorithm property %s\n", debugstr_w(prop) );
+        FIXME( "unsupported aes algorithm property %s\n", debugstr_w(prop) );
         return STATUS_NOT_IMPLEMENTED;
 
     default:
-        FIXME( "unsupported algorithm %u\n", id );
+        FIXME( "unsupported algorithm %u\n", alg->id );
         return STATUS_NOT_IMPLEMENTED;
     }
-
-    if (size < sizeof(ULONG))
-    {
-        *ret_size = sizeof(ULONG);
-        return STATUS_BUFFER_TOO_SMALL;
-    }
-    if (buf) *(ULONG *)buf = value;
-    *ret_size = sizeof(ULONG);
-
-    return STATUS_SUCCESS;
 }
 
-static NTSTATUS get_hash_property( enum alg_id id, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+static NTSTATUS get_hash_property( const struct hash *hash, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
 {
     NTSTATUS status;
 
-    status = generic_alg_property( id, prop, buf, size, ret_size );
+    status = generic_alg_property( hash->alg_id, prop, buf, size, ret_size );
     if (status == STATUS_NOT_IMPLEMENTED)
         FIXME( "unsupported property %s\n", debugstr_w(prop) );
     return status;
+}
+
+static NTSTATUS get_key_property( const struct key *key, const WCHAR *prop, UCHAR *buf, ULONG size, ULONG *ret_size )
+{
+    switch (key->alg_id)
+    {
+    case ALG_ID_3DES:
+        return get_3des_property( key->u.s.mode, prop, buf, size, ret_size );
+
+    case ALG_ID_AES:
+        if (!wcscmp( prop, BCRYPT_AUTH_TAG_LENGTH )) return STATUS_NOT_SUPPORTED;
+        return get_aes_property( key->u.s.mode, prop, buf, size, ret_size );
+
+    default:
+        FIXME( "unsupported algorithm %u\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
 }
 
 NTSTATUS WINAPI BCryptGetProperty( BCRYPT_HANDLE handle, LPCWSTR prop, UCHAR *buffer, ULONG count, ULONG *res, ULONG flags )
@@ -983,12 +715,17 @@ NTSTATUS WINAPI BCryptGetProperty( BCRYPT_HANDLE handle, LPCWSTR prop, UCHAR *bu
     case MAGIC_ALG:
     {
         const struct algorithm *alg = (const struct algorithm *)object;
-        return get_alg_property( alg->id, prop, buffer, count, res );
+        return get_alg_property( alg, prop, buffer, count, res );
+    }
+    case MAGIC_KEY:
+    {
+        const struct key *key = (const struct key *)object;
+        return get_key_property( key, prop, buffer, count, res );
     }
     case MAGIC_HASH:
     {
         const struct hash *hash = (const struct hash *)object;
-        return get_hash_property( hash->alg_id, prop, buffer, count, res );
+        return get_hash_property( hash, prop, buffer, count, res );
     }
     default:
         WARN( "unknown magic %08x\n", object->magic );
@@ -996,16 +733,77 @@ NTSTATUS WINAPI BCryptGetProperty( BCRYPT_HANDLE handle, LPCWSTR prop, UCHAR *bu
     }
 }
 
-NTSTATUS WINAPI BCryptCreateHash( BCRYPT_ALG_HANDLE algorithm, BCRYPT_HASH_HANDLE *handle, UCHAR *object, ULONG objectlen,
-                                  UCHAR *secret, ULONG secretlen, ULONG flags )
+static NTSTATUS hash_prepare( struct hash *hash )
+{
+    UCHAR buffer[MAX_HASH_BLOCK_BITS / 8] = {0};
+    int block_bytes, i;
+    NTSTATUS status;
+
+    /* initialize hash */
+    if ((status = hash_init( &hash->inner, hash->alg_id ))) return status;
+    if (!(hash->flags & HASH_FLAG_HMAC)) return STATUS_SUCCESS;
+
+    /* initialize hmac */
+    if ((status = hash_init( &hash->outer, hash->alg_id ))) return status;
+    block_bytes = builtin_algorithms[hash->alg_id].block_bits / 8;
+    if (hash->secret_len > block_bytes)
+    {
+        struct hash_impl temp;
+        if ((status = hash_init( &temp, hash->alg_id ))) return status;
+        if ((status = hash_update( &temp, hash->alg_id, hash->secret, hash->secret_len ))) return status;
+        if ((status = hash_finish( &temp, hash->alg_id, buffer,
+                                   builtin_algorithms[hash->alg_id].hash_length ))) return status;
+    }
+    else memcpy( buffer, hash->secret, hash->secret_len );
+
+    for (i = 0; i < block_bytes; i++) buffer[i] ^= 0x5c;
+    if ((status = hash_update( &hash->outer, hash->alg_id, buffer, block_bytes ))) return status;
+    for (i = 0; i < block_bytes; i++) buffer[i] ^= (0x5c ^ 0x36);
+    return hash_update( &hash->inner, hash->alg_id, buffer, block_bytes );
+}
+
+static NTSTATUS hash_create( const struct algorithm *alg, UCHAR *secret, ULONG secret_len, ULONG flags,
+                             struct hash **ret_hash )
+{
+    struct hash *hash;
+    NTSTATUS status;
+
+    if (!(hash = heap_alloc_zero( sizeof(*hash) ))) return STATUS_NO_MEMORY;
+    hash->hdr.magic = MAGIC_HASH;
+    hash->alg_id    = alg->id;
+    if (alg->flags & BCRYPT_ALG_HANDLE_HMAC_FLAG) hash->flags = HASH_FLAG_HMAC;
+    if ((alg->flags & BCRYPT_HASH_REUSABLE_FLAG) || (flags & BCRYPT_HASH_REUSABLE_FLAG))
+        hash->flags |= HASH_FLAG_REUSABLE;
+
+    if (secret_len && !(hash->secret = heap_alloc( secret_len )))
+    {
+        heap_free( hash );
+        return STATUS_NO_MEMORY;
+    }
+    memcpy( hash->secret, secret, secret_len );
+    hash->secret_len = secret_len;
+
+    if ((status = hash_prepare( hash )))
+    {
+        heap_free( hash->secret );
+        heap_free( hash );
+        return status;
+    }
+
+    *ret_hash = hash;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptCreateHash( BCRYPT_ALG_HANDLE algorithm, BCRYPT_HASH_HANDLE *handle, UCHAR *object,
+                                  ULONG object_len, UCHAR *secret, ULONG secret_len, ULONG flags )
 {
     struct algorithm *alg = algorithm;
     struct hash *hash;
     NTSTATUS status;
 
-    TRACE( "%p, %p, %p, %u, %p, %u, %08x - stub\n", algorithm, handle, object, objectlen,
-           secret, secretlen, flags );
-    if (flags)
+    TRACE( "%p, %p, %p, %u, %p, %u, %08x\n", algorithm, handle, object, object_len,
+           secret, secret_len, flags );
+    if (flags & ~BCRYPT_HASH_REUSABLE_FLAG)
     {
         FIXME( "unimplemented flags %08x\n", flags );
         return STATUS_NOT_IMPLEMENTED;
@@ -1014,28 +812,44 @@ NTSTATUS WINAPI BCryptCreateHash( BCRYPT_ALG_HANDLE algorithm, BCRYPT_HASH_HANDL
     if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
     if (object) FIXME( "ignoring object buffer\n" );
 
-    if (!(hash = HeapAlloc( GetProcessHeap(), 0, sizeof(*hash) ))) return STATUS_NO_MEMORY;
-    hash->hdr.magic = MAGIC_HASH;
-    hash->alg_id    = alg->id;
-    hash->hmac      = alg->hmac;
-
-    if (hash->hmac)
-    {
-        status = hmac_init( hash, secret, secretlen );
-    }
-    else
-    {
-        status = hash_init( hash );
-    }
-
-    if (status != STATUS_SUCCESS)
-    {
-        HeapFree( GetProcessHeap(), 0, hash );
-        return status;
-    }
-
+    if ((status = hash_create( alg, secret, secret_len, flags, &hash ))) return status;
     *handle = hash;
     return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptDuplicateHash( BCRYPT_HASH_HANDLE handle, BCRYPT_HASH_HANDLE *handle_copy,
+                                     UCHAR *object, ULONG objectlen, ULONG flags )
+{
+    struct hash *hash_orig = handle;
+    struct hash *hash_copy;
+
+    TRACE( "%p, %p, %p, %u, %u\n", handle, handle_copy, object, objectlen, flags );
+
+    if (!hash_orig || hash_orig->hdr.magic != MAGIC_HASH) return STATUS_INVALID_HANDLE;
+    if (!handle_copy) return STATUS_INVALID_PARAMETER;
+    if (object) FIXME( "ignoring object buffer\n" );
+
+    if (!(hash_copy = heap_alloc( sizeof(*hash_copy) )))
+        return STATUS_NO_MEMORY;
+
+    memcpy( hash_copy, hash_orig, sizeof(*hash_orig) );
+    if (hash_orig->secret && !(hash_copy->secret = heap_alloc( hash_orig->secret_len )))
+    {
+        heap_free( hash_copy );
+        return STATUS_NO_MEMORY;
+    }
+    memcpy( hash_copy->secret, hash_orig->secret, hash_orig->secret_len );
+
+    *handle_copy = hash_copy;
+    return STATUS_SUCCESS;
+}
+
+static void hash_destroy( struct hash *hash )
+{
+    if (!hash) return;
+    hash->hdr.magic = 0;
+    heap_free( hash->secret );
+    heap_free( hash );
 }
 
 NTSTATUS WINAPI BCryptDestroyHash( BCRYPT_HASH_HANDLE handle )
@@ -1044,8 +858,8 @@ NTSTATUS WINAPI BCryptDestroyHash( BCRYPT_HASH_HANDLE handle )
 
     TRACE( "%p\n", handle );
 
-    if (!hash || hash->hdr.magic != MAGIC_HASH) return STATUS_INVALID_HANDLE;
-    HeapFree( GetProcessHeap(), 0, hash );
+    if (!hash || hash->hdr.magic != MAGIC_HASH) return STATUS_INVALID_PARAMETER;
+    hash_destroy( hash );
     return STATUS_SUCCESS;
 }
 
@@ -1058,14 +872,29 @@ NTSTATUS WINAPI BCryptHashData( BCRYPT_HASH_HANDLE handle, UCHAR *input, ULONG s
     if (!hash || hash->hdr.magic != MAGIC_HASH) return STATUS_INVALID_HANDLE;
     if (!input) return STATUS_SUCCESS;
 
-    if (hash->hmac)
+    return hash_update( &hash->inner, hash->alg_id, input, size );
+}
+
+static NTSTATUS hash_finalize( struct hash *hash, UCHAR *output, ULONG size )
+{
+    UCHAR buffer[MAX_HASH_OUTPUT_BYTES];
+    int hash_length;
+    NTSTATUS status;
+
+    if (!(hash->flags & HASH_FLAG_HMAC))
     {
-        return hmac_update( hash, input, size );
+        if ((status = hash_finish( &hash->inner, hash->alg_id, output, size ))) return status;
+        if (hash->flags & HASH_FLAG_REUSABLE) return hash_prepare( hash );
+        return STATUS_SUCCESS;
     }
-    else
-    {
-        return hash_update( hash, input, size );
-    }
+
+    hash_length = builtin_algorithms[hash->alg_id].hash_length;
+    if ((status = hash_finish( &hash->inner, hash->alg_id, buffer, hash_length ))) return status;
+    if ((status = hash_update( &hash->outer, hash->alg_id, buffer, hash_length ))) return status;
+    if ((status = hash_finish( &hash->outer, hash->alg_id, output, size ))) return status;
+
+    if (hash->flags & HASH_FLAG_REUSABLE) return hash_prepare( hash );
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS WINAPI BCryptFinishHash( BCRYPT_HASH_HANDLE handle, UCHAR *output, ULONG size, ULONG flags )
@@ -1077,46 +906,1065 @@ NTSTATUS WINAPI BCryptFinishHash( BCRYPT_HASH_HANDLE handle, UCHAR *output, ULON
     if (!hash || hash->hdr.magic != MAGIC_HASH) return STATUS_INVALID_HANDLE;
     if (!output) return STATUS_INVALID_PARAMETER;
 
-    if (hash->hmac)
+    return hash_finalize( hash, output, size );
+}
+
+NTSTATUS WINAPI BCryptHash( BCRYPT_ALG_HANDLE algorithm, UCHAR *secret, ULONG secret_len,
+                            UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len )
+{
+    struct algorithm *alg = algorithm;
+    struct hash *hash;
+    NTSTATUS status;
+
+    TRACE( "%p, %p, %u, %p, %u, %p, %u\n", algorithm, secret, secret_len, input, input_len, output, output_len );
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+
+    if ((status = hash_create( alg, secret, secret_len, 0, &hash ))) return status;
+    if ((status = hash_update( &hash->inner, hash->alg_id, input, input_len )))
     {
-        return hmac_finish( hash, output, size );
+        hash_destroy( hash );
+        return status;
+    }
+    status = hash_finalize( hash, output, output_len );
+    hash_destroy( hash );
+    return status;
+}
+
+static NTSTATUS key_asymmetric_create( struct key **ret_key, struct algorithm *alg, ULONG bitlen,
+                                       const UCHAR *pubkey, ULONG pubkey_len )
+{
+    struct key *key;
+    NTSTATUS status;
+
+    if (!key_funcs)
+    {
+        ERR( "no encryption support\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (!(key = heap_alloc_zero( sizeof(*key) ))) return STATUS_NO_MEMORY;
+    key->hdr.magic  = MAGIC_KEY;
+    key->alg_id     = alg->id;
+    key->u.a.bitlen = bitlen;
+
+    if (pubkey_len)
+    {
+        if (!(key->u.a.pubkey = heap_alloc( pubkey_len )))
+        {
+            heap_free( key );
+            return STATUS_NO_MEMORY;
+        }
+        memcpy( key->u.a.pubkey, pubkey, pubkey_len );
+        key->u.a.pubkey_len = pubkey_len;
+    }
+    if ((status = key_funcs->key_asymmetric_init( key )))
+    {
+        heap_free( key->u.a.pubkey );
+        heap_free( key );
+        return status;
+    }
+    *ret_key = key;
+    return STATUS_SUCCESS;
+}
+
+static BOOL key_is_symmetric( struct key *key )
+{
+    return builtin_algorithms[key->alg_id].class == BCRYPT_CIPHER_INTERFACE;
+}
+
+static BOOL is_zero_vector( const UCHAR *vector, ULONG len )
+{
+    ULONG i;
+    if (!vector) return FALSE;
+    for (i = 0; i < len; i++) if (vector[i]) return FALSE;
+    return TRUE;
+}
+
+static BOOL is_equal_vector( const UCHAR *vector, ULONG len, const UCHAR *vector2, ULONG len2 )
+{
+    if (!vector && !vector2) return TRUE;
+    if (len != len2) return FALSE;
+    return !memcmp( vector, vector2, len );
+}
+
+static NTSTATUS key_symmetric_set_vector( struct key *key, UCHAR *vector, ULONG vector_len )
+{
+    BOOL needs_reset = (!is_zero_vector( vector, vector_len ) ||
+                        !is_equal_vector( key->u.s.vector, key->u.s.vector_len, vector, vector_len ));
+
+    heap_free( key->u.s.vector );
+    key->u.s.vector = NULL;
+    key->u.s.vector_len = 0;
+    if (vector)
+    {
+        if (!(key->u.s.vector = heap_alloc( vector_len ))) return STATUS_NO_MEMORY;
+        memcpy( key->u.s.vector, vector, vector_len );
+        key->u.s.vector_len = vector_len;
+    }
+    if (needs_reset) key_funcs->key_symmetric_vector_reset( key );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS key_import( BCRYPT_ALG_HANDLE algorithm, const WCHAR *type, BCRYPT_KEY_HANDLE *key, UCHAR *object,
+                            ULONG object_len, UCHAR *input, ULONG input_len )
+{
+    ULONG len;
+
+    if (!wcscmp( type, BCRYPT_KEY_DATA_BLOB ))
+    {
+        BCRYPT_KEY_DATA_BLOB_HEADER *header = (BCRYPT_KEY_DATA_BLOB_HEADER *)input;
+
+        if (input_len < sizeof(BCRYPT_KEY_DATA_BLOB_HEADER)) return STATUS_BUFFER_TOO_SMALL;
+        if (header->dwMagic != BCRYPT_KEY_DATA_BLOB_MAGIC) return STATUS_INVALID_PARAMETER;
+        if (header->dwVersion != BCRYPT_KEY_DATA_BLOB_VERSION1)
+        {
+            FIXME( "unknown key data blob version %u\n", header->dwVersion );
+            return STATUS_INVALID_PARAMETER;
+        }
+        len = header->cbKeyData;
+        if (len + sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) > input_len) return STATUS_INVALID_PARAMETER;
+
+        return BCryptGenerateSymmetricKey( algorithm, key, object, object_len, (UCHAR *)&header[1], len, 0 );
+    }
+    else if (!wcscmp( type, BCRYPT_OPAQUE_KEY_BLOB ))
+    {
+        if (input_len < sizeof(len)) return STATUS_BUFFER_TOO_SMALL;
+        len = *(ULONG *)input;
+        if (len + sizeof(len) > input_len) return STATUS_INVALID_PARAMETER;
+
+        return BCryptGenerateSymmetricKey( algorithm, key, object, object_len, input + sizeof(len), len, 0 );
+    }
+
+    FIXME( "unsupported key type %s\n", debugstr_w(type) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS key_export( struct key *key, const WCHAR *type, UCHAR *output, ULONG output_len, ULONG *size )
+{
+    if (!wcscmp( type, BCRYPT_KEY_DATA_BLOB ))
+    {
+        BCRYPT_KEY_DATA_BLOB_HEADER *header = (BCRYPT_KEY_DATA_BLOB_HEADER *)output;
+        ULONG req_size = sizeof(BCRYPT_KEY_DATA_BLOB_HEADER) + key->u.s.secret_len;
+
+        *size = req_size;
+        if (output_len < req_size) return STATUS_BUFFER_TOO_SMALL;
+        if (output)
+        {
+            header->dwMagic   = BCRYPT_KEY_DATA_BLOB_MAGIC;
+            header->dwVersion = BCRYPT_KEY_DATA_BLOB_VERSION1;
+            header->cbKeyData = key->u.s.secret_len;
+            memcpy( &header[1], key->u.s.secret, key->u.s.secret_len );
+        }
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, BCRYPT_OPAQUE_KEY_BLOB ))
+    {
+        ULONG len, req_size = sizeof(len) + key->u.s.secret_len;
+
+        *size = req_size;
+        if (output_len < req_size) return STATUS_BUFFER_TOO_SMALL;
+        if (output)
+        {
+            *(ULONG *)output = key->u.s.secret_len;
+            memcpy( output + sizeof(len), key->u.s.secret, key->u.s.secret_len );
+        }
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, BCRYPT_RSAPUBLIC_BLOB ) || !wcscmp( type, BCRYPT_DSA_PUBLIC_BLOB ) ||
+             !wcscmp( type, BCRYPT_ECCPUBLIC_BLOB ) || !wcscmp( type, LEGACY_DSA_V2_PUBLIC_BLOB ))
+    {
+        *size = key->u.a.pubkey_len;
+        if (output_len < key->u.a.pubkey_len) return STATUS_SUCCESS;
+        if (output) memcpy( output, key->u.a.pubkey, key->u.a.pubkey_len );
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, BCRYPT_ECCPRIVATE_BLOB ))
+    {
+        return key_funcs->key_export_ecc( key, output, output_len, size );
+    }
+    else if (!wcscmp( type, LEGACY_DSA_V2_PRIVATE_BLOB ))
+    {
+        return key_funcs->key_export_dsa_capi( key, output, output_len, size );
+    }
+
+    FIXME( "unsupported key type %s\n", debugstr_w(type) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS key_symmetric_encrypt( struct key *key,  UCHAR *input, ULONG input_len, void *padding, UCHAR *iv,
+                                       ULONG iv_len, UCHAR *output, ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    ULONG bytes_left = input_len;
+    UCHAR *buf, *src, *dst;
+    NTSTATUS status;
+
+    if (key->u.s.mode == MODE_ID_GCM)
+    {
+        BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO *auth_info = padding;
+
+        if (!auth_info) return STATUS_INVALID_PARAMETER;
+        if (!auth_info->pbNonce) return STATUS_INVALID_PARAMETER;
+        if (!auth_info->pbTag) return STATUS_INVALID_PARAMETER;
+        if (auth_info->cbTag < 12 || auth_info->cbTag > 16) return STATUS_INVALID_PARAMETER;
+        if (auth_info->dwFlags & BCRYPT_AUTH_MODE_CHAIN_CALLS_FLAG)
+            FIXME( "call chaining not implemented\n" );
+
+        if ((status = key_symmetric_set_vector( key, auth_info->pbNonce, auth_info->cbNonce )))
+            return status;
+
+        *ret_len = input_len;
+        if (flags & BCRYPT_BLOCK_PADDING) return STATUS_INVALID_PARAMETER;
+        if (input && !output) return STATUS_SUCCESS;
+        if (output_len < *ret_len) return STATUS_BUFFER_TOO_SMALL;
+
+        if ((status = key_funcs->key_symmetric_set_auth_data( key, auth_info->pbAuthData, auth_info->cbAuthData )))
+            return status;
+        if ((status = key_funcs->key_symmetric_encrypt( key, input, input_len, output, output_len ))) return status;
+
+        return key_funcs->key_symmetric_get_tag( key, auth_info->pbTag, auth_info->cbTag );
+    }
+
+    *ret_len = input_len;
+
+    if (flags & BCRYPT_BLOCK_PADDING)
+        *ret_len = (input_len + key->u.s.block_size) & ~(key->u.s.block_size - 1);
+    else if (input_len & (key->u.s.block_size - 1))
+        return STATUS_INVALID_BUFFER_SIZE;
+
+    if (!output) return STATUS_SUCCESS;
+    if (output_len < *ret_len) return STATUS_BUFFER_TOO_SMALL;
+    if (key->u.s.mode == MODE_ID_ECB && iv) return STATUS_INVALID_PARAMETER;
+    if ((status = key_symmetric_set_vector( key, iv, iv_len ))) return status;
+
+    src = input;
+    dst = output;
+    while (bytes_left >= key->u.s.block_size)
+    {
+        if ((status = key_funcs->key_symmetric_encrypt( key, src, key->u.s.block_size, dst, key->u.s.block_size )))
+            return status;
+        if (key->u.s.mode == MODE_ID_ECB && (status = key_symmetric_set_vector( key, NULL, 0 )))
+            return status;
+        bytes_left -= key->u.s.block_size;
+        src += key->u.s.block_size;
+        dst += key->u.s.block_size;
+    }
+
+    if (flags & BCRYPT_BLOCK_PADDING)
+    {
+        if (!(buf = heap_alloc( key->u.s.block_size ))) return STATUS_NO_MEMORY;
+        memcpy( buf, src, bytes_left );
+        memset( buf + bytes_left, key->u.s.block_size - bytes_left, key->u.s.block_size - bytes_left );
+        status = key_funcs->key_symmetric_encrypt( key, buf, key->u.s.block_size, dst, key->u.s.block_size );
+        heap_free( buf );
+    }
+
+    return status;
+}
+
+static NTSTATUS key_symmetric_decrypt( struct key *key, UCHAR *input, ULONG input_len, void *padding, UCHAR *iv,
+                                       ULONG iv_len, UCHAR *output, ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    ULONG bytes_left = input_len;
+    UCHAR *buf, *src, *dst;
+    NTSTATUS status;
+
+    if (key->u.s.mode == MODE_ID_GCM)
+    {
+        BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO *auth_info = padding;
+        UCHAR tag[16];
+
+        if (!auth_info) return STATUS_INVALID_PARAMETER;
+        if (!auth_info->pbNonce) return STATUS_INVALID_PARAMETER;
+        if (!auth_info->pbTag) return STATUS_INVALID_PARAMETER;
+        if (auth_info->cbTag < 12 || auth_info->cbTag > 16) return STATUS_INVALID_PARAMETER;
+
+        if ((status = key_symmetric_set_vector( key, auth_info->pbNonce, auth_info->cbNonce )))
+            return status;
+
+        *ret_len = input_len;
+        if (flags & BCRYPT_BLOCK_PADDING) return STATUS_INVALID_PARAMETER;
+        if (!output) return STATUS_SUCCESS;
+        if (output_len < *ret_len) return STATUS_BUFFER_TOO_SMALL;
+
+        if ((status = key_funcs->key_symmetric_set_auth_data( key, auth_info->pbAuthData, auth_info->cbAuthData )))
+            return status;
+        if ((status = key_funcs->key_symmetric_decrypt( key, input, input_len, output, output_len ))) return status;
+
+        if ((status = key_funcs->key_symmetric_get_tag( key, tag, sizeof(tag) ))) return status;
+        if (memcmp( tag, auth_info->pbTag, auth_info->cbTag )) return STATUS_AUTH_TAG_MISMATCH;
+
+        return STATUS_SUCCESS;
+    }
+
+    *ret_len = input_len;
+
+    if (input_len & (key->u.s.block_size - 1)) return STATUS_INVALID_BUFFER_SIZE;
+    if (!output) return STATUS_SUCCESS;
+    if (flags & BCRYPT_BLOCK_PADDING)
+    {
+        if (output_len + key->u.s.block_size < *ret_len) return STATUS_BUFFER_TOO_SMALL;
+        if (input_len < key->u.s.block_size) return STATUS_BUFFER_TOO_SMALL;
+        bytes_left -= key->u.s.block_size;
+    }
+    else if (output_len < *ret_len) return STATUS_BUFFER_TOO_SMALL;
+
+    if (key->u.s.mode == MODE_ID_ECB && iv) return STATUS_INVALID_PARAMETER;
+    if ((status = key_symmetric_set_vector( key, iv, iv_len ))) return status;
+
+    src = input;
+    dst = output;
+    while (bytes_left >= key->u.s.block_size)
+    {
+        if ((status = key_funcs->key_symmetric_decrypt( key, src, key->u.s.block_size, dst, key->u.s.block_size )))
+            return status;
+        if (key->u.s.mode == MODE_ID_ECB && (status = key_symmetric_set_vector( key, NULL, 0 )))
+            return status;
+        bytes_left -= key->u.s.block_size;
+        src += key->u.s.block_size;
+        dst += key->u.s.block_size;
+    }
+
+    if (flags & BCRYPT_BLOCK_PADDING)
+    {
+        if (!(buf = heap_alloc( key->u.s.block_size ))) return STATUS_NO_MEMORY;
+        status = key_funcs->key_symmetric_decrypt( key, src, key->u.s.block_size, buf, key->u.s.block_size );
+        if (!status && buf[ key->u.s.block_size - 1 ] <= key->u.s.block_size)
+        {
+            *ret_len -= buf[ key->u.s.block_size - 1 ];
+            if (output_len < *ret_len) status = STATUS_BUFFER_TOO_SMALL;
+            else memcpy( dst, buf, key->u.s.block_size - buf[ key->u.s.block_size - 1 ] );
+        }
+        else status = STATUS_UNSUCCESSFUL; /* FIXME: invalid padding */
+        heap_free( buf );
+    }
+
+    return status;
+}
+
+static NTSTATUS key_import_pair( struct algorithm *alg, const WCHAR *type, BCRYPT_KEY_HANDLE *ret_key, UCHAR *input,
+                                 ULONG input_len )
+{
+    struct key *key;
+    NTSTATUS status;
+
+    if (!wcscmp( type, BCRYPT_ECCPUBLIC_BLOB ))
+    {
+        BCRYPT_ECCKEY_BLOB *ecc_blob = (BCRYPT_ECCKEY_BLOB *)input;
+        DWORD key_size, magic, size;
+
+        if (input_len < sizeof(*ecc_blob)) return STATUS_INVALID_PARAMETER;
+
+        switch (alg->id)
+        {
+        case ALG_ID_ECDH_P256:
+            key_size = 32;
+            magic = BCRYPT_ECDH_PUBLIC_P256_MAGIC;
+            break;
+
+        case ALG_ID_ECDSA_P256:
+            key_size = 32;
+            magic = BCRYPT_ECDSA_PUBLIC_P256_MAGIC;
+            break;
+
+        case ALG_ID_ECDSA_P384:
+            key_size = 48;
+            magic = BCRYPT_ECDSA_PUBLIC_P384_MAGIC;
+            break;
+
+        default:
+            FIXME( "algorithm %u does not yet support importing blob of type %s\n", alg->id, debugstr_w(type) );
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        if (ecc_blob->dwMagic != magic) return STATUS_INVALID_PARAMETER;
+        if (ecc_blob->cbKey != key_size || input_len < sizeof(*ecc_blob) + ecc_blob->cbKey * 2)
+            return STATUS_INVALID_PARAMETER;
+
+        size = sizeof(*ecc_blob) + ecc_blob->cbKey * 2;
+        return key_asymmetric_create( (struct key **)ret_key, alg, key_size * 8, (BYTE *)ecc_blob, size );
+    }
+    else if (!wcscmp( type, BCRYPT_ECCPRIVATE_BLOB ))
+    {
+        BCRYPT_ECCKEY_BLOB *ecc_blob = (BCRYPT_ECCKEY_BLOB *)input;
+        DWORD key_size, magic;
+
+        if (input_len < sizeof(*ecc_blob)) return STATUS_INVALID_PARAMETER;
+
+        switch (alg->id)
+        {
+        case ALG_ID_ECDH_P256:
+            key_size = 32;
+            magic = BCRYPT_ECDH_PRIVATE_P256_MAGIC;
+            break;
+        case ALG_ID_ECDSA_P256:
+            key_size = 32;
+            magic = BCRYPT_ECDSA_PRIVATE_P256_MAGIC;
+            break;
+
+        default:
+            FIXME( "algorithm %u does not yet support importing blob of type %s\n", alg->id, debugstr_w(type) );
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        if (ecc_blob->dwMagic != magic) return STATUS_INVALID_PARAMETER;
+        if (ecc_blob->cbKey != key_size || input_len < sizeof(*ecc_blob) + ecc_blob->cbKey * 3)
+            return STATUS_INVALID_PARAMETER;
+
+        if ((status = key_asymmetric_create( &key, alg, key_size * 8, NULL, 0 ))) return status;
+        if ((status = key_funcs->key_import_ecc( key, input, input_len )))
+        {
+            BCryptDestroyKey( key );
+            return status;
+        }
+
+        *ret_key = key;
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, BCRYPT_RSAPUBLIC_BLOB ))
+    {
+        BCRYPT_RSAKEY_BLOB *rsa_blob = (BCRYPT_RSAKEY_BLOB *)input;
+        ULONG size;
+
+        if (input_len < sizeof(*rsa_blob)) return STATUS_INVALID_PARAMETER;
+        if ((alg->id != ALG_ID_RSA && alg->id != ALG_ID_RSA_SIGN) || rsa_blob->Magic != BCRYPT_RSAPUBLIC_MAGIC)
+            return STATUS_NOT_SUPPORTED;
+
+        size = sizeof(*rsa_blob) + rsa_blob->cbPublicExp + rsa_blob->cbModulus;
+        return key_asymmetric_create( (struct key **)ret_key, alg, rsa_blob->BitLength, (BYTE *)rsa_blob, size );
+    }
+    else if (!wcscmp( type, BCRYPT_RSAPRIVATE_BLOB ))
+    {
+        BCRYPT_RSAKEY_BLOB *rsa_blob = (BCRYPT_RSAKEY_BLOB *)input;
+        ULONG size;
+
+        if (input_len < sizeof(*rsa_blob)) return STATUS_INVALID_PARAMETER;
+        if (alg->id != ALG_ID_RSA || rsa_blob->Magic != BCRYPT_RSAPRIVATE_MAGIC)
+            return STATUS_NOT_SUPPORTED;
+
+        size = sizeof(*rsa_blob) + rsa_blob->cbPublicExp + rsa_blob->cbModulus;
+        if ((status = key_asymmetric_create( &key, alg, rsa_blob->BitLength, (BYTE *)rsa_blob, size )))
+            return status;
+        if ((status = key_funcs->key_import_rsa( key, input, input_len )))
+        {
+            BCryptDestroyKey( key );
+            return status;
+        }
+
+        *ret_key = key;
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, BCRYPT_DSA_PUBLIC_BLOB ))
+    {
+        BCRYPT_DSA_KEY_BLOB *dsa_blob = (BCRYPT_DSA_KEY_BLOB *)input;
+        ULONG size;
+
+        if (input_len < sizeof(*dsa_blob)) return STATUS_INVALID_PARAMETER;
+        if ((alg->id != ALG_ID_DSA) || dsa_blob->dwMagic != BCRYPT_DSA_PUBLIC_MAGIC)
+            return STATUS_NOT_SUPPORTED;
+
+        size = sizeof(*dsa_blob) + dsa_blob->cbKey * 3;
+        return key_asymmetric_create( (struct key **)ret_key, alg, dsa_blob->cbKey * 8, (BYTE *)dsa_blob, size );
+    }
+    else if (!wcscmp( type, LEGACY_DSA_V2_PRIVATE_BLOB ))
+    {
+        BLOBHEADER *hdr = (BLOBHEADER *)input;
+        DSSPUBKEY *pubkey;
+
+        if (input_len < sizeof(*hdr)) return STATUS_INVALID_PARAMETER;
+
+        if (hdr->bType != PRIVATEKEYBLOB && hdr->bVersion != 2 && hdr->aiKeyAlg != CALG_DSS_SIGN)
+        {
+            FIXME( "blob type %u version %u alg id %u not supported\n", hdr->bType, hdr->bVersion, hdr->aiKeyAlg );
+            return STATUS_NOT_SUPPORTED;
+        }
+        if (alg->id != ALG_ID_DSA)
+        {
+            FIXME( "algorithm %u does not support importing blob of type %s\n", alg->id, debugstr_w(type) );
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        if (input_len < sizeof(*hdr) + sizeof(*pubkey)) return STATUS_INVALID_PARAMETER;
+        pubkey = (DSSPUBKEY *)(hdr + 1);
+        if (pubkey->magic != MAGIC_DSS2) return STATUS_NOT_SUPPORTED;
+
+        if (input_len < sizeof(*hdr) + sizeof(*pubkey) + (pubkey->bitlen / 8) * 2 + 40 + sizeof(DSSSEED))
+            return STATUS_INVALID_PARAMETER;
+
+        if ((status = key_asymmetric_create( &key, alg, pubkey->bitlen, NULL, 0 ))) return status;
+        if ((status = key_funcs->key_import_dsa_capi( key, input, input_len )))
+        {
+            BCryptDestroyKey( key );
+            return status;
+        }
+
+        *ret_key = key;
+        return STATUS_SUCCESS;
+    }
+    else if (!wcscmp( type, LEGACY_DSA_V2_PUBLIC_BLOB )) /* not supported on native */
+    {
+        BLOBHEADER *hdr = (BLOBHEADER *)input;
+        DSSPUBKEY *pubkey;
+        ULONG size;
+
+        if (alg->id != ALG_ID_DSA) return STATUS_NOT_SUPPORTED;
+        if (input_len < sizeof(*hdr)) return STATUS_INVALID_PARAMETER;
+
+        if (hdr->bType != PUBLICKEYBLOB && hdr->bVersion != 2 && hdr->aiKeyAlg != CALG_DSS_SIGN)
+        {
+            FIXME( "blob type %u version %u alg id %u not supported\n", hdr->bType, hdr->bVersion, hdr->aiKeyAlg );
+            return STATUS_NOT_SUPPORTED;
+        }
+
+        if (input_len < sizeof(*hdr) + sizeof(*pubkey)) return STATUS_INVALID_PARAMETER;
+        pubkey = (DSSPUBKEY *)(hdr + 1);
+        if (pubkey->magic != MAGIC_DSS1) return STATUS_NOT_SUPPORTED;
+
+        size = sizeof(*hdr) + sizeof(*pubkey) + (pubkey->bitlen / 8) * 3 + 20 + sizeof(DSSSEED);
+        if (input_len < size) return STATUS_INVALID_PARAMETER;
+
+        if ((status = key_asymmetric_create( &key, alg, pubkey->bitlen, (BYTE *)hdr, size ))) return status;
+        key->u.a.flags |= KEY_FLAG_LEGACY_DSA_V2;
+
+        *ret_key = key;
+        return STATUS_SUCCESS;
+    }
+
+    FIXME( "unsupported key type %s\n", debugstr_w(type) );
+    return STATUS_NOT_SUPPORTED;
+}
+
+static ULONG get_block_size( struct algorithm *alg )
+{
+    ULONG ret = 0, size = sizeof(ret);
+    get_alg_property( alg, BCRYPT_BLOCK_LENGTH, (UCHAR *)&ret, sizeof(ret), &size );
+    return ret;
+}
+
+NTSTATUS WINAPI BCryptGenerateSymmetricKey( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HANDLE *handle,
+                                            UCHAR *object, ULONG object_len, UCHAR *secret, ULONG secret_len,
+                                            ULONG flags )
+{
+    struct algorithm *alg = algorithm;
+    struct key *key;
+    ULONG block_size;
+    NTSTATUS status;
+
+    TRACE( "%p, %p, %p, %u, %p, %u, %08x\n", algorithm, handle, object, object_len, secret, secret_len, flags );
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+    if (object) FIXME( "ignoring object buffer\n" );
+
+    if (!key_funcs)
+    {
+        ERR( "no encryption support\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (!(block_size = get_block_size( alg ))) return STATUS_INVALID_PARAMETER;
+
+    if (!(key = heap_alloc_zero( sizeof(*key) ))) return STATUS_NO_MEMORY;
+    InitializeCriticalSection( &key->u.s.cs );
+    key->hdr.magic      = MAGIC_KEY;
+    key->alg_id         = alg->id;
+    key->u.s.mode       = alg->mode;
+    key->u.s.block_size = block_size;
+
+    if (!(key->u.s.secret = heap_alloc( secret_len )))
+    {
+        heap_free( key );
+        return STATUS_NO_MEMORY;
+    }
+    memcpy( key->u.s.secret, secret, secret_len );
+    key->u.s.secret_len = secret_len;
+
+    if ((status = key_funcs->key_symmetric_init( key )))
+    {
+        heap_free( key->u.s.secret );
+        heap_free( key );
+        return status;
+    }
+
+    *handle = key;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptGenerateKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HANDLE *handle, ULONG key_len,
+                                       ULONG flags )
+{
+    struct algorithm *alg = algorithm;
+    struct key *key;
+    NTSTATUS status;
+
+    TRACE( "%p, %p, %u, %08x\n", algorithm, handle, key_len, flags );
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+    if (!handle) return STATUS_INVALID_PARAMETER;
+
+    if (!(status = key_asymmetric_create( &key, alg, key_len, NULL, 0 ))) *handle = key;
+    return status;
+}
+
+NTSTATUS WINAPI BCryptFinalizeKeyPair( BCRYPT_KEY_HANDLE handle, ULONG flags )
+{
+    struct key *key = handle;
+
+    TRACE( "%p, %08x\n", key, flags );
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+
+    return key_funcs->key_asymmetric_generate( key );
+}
+
+NTSTATUS WINAPI BCryptImportKey( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HANDLE decrypt_key, LPCWSTR type,
+                                 BCRYPT_KEY_HANDLE *key, PUCHAR object, ULONG object_len, PUCHAR input,
+                                 ULONG input_len, ULONG flags )
+{
+    struct algorithm *alg = algorithm;
+
+    TRACE("%p, %p, %s, %p, %p, %u, %p, %u, %u\n", algorithm, decrypt_key, debugstr_w(type), key, object,
+          object_len, input, input_len, flags);
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+    if (!key || !type || !input) return STATUS_INVALID_PARAMETER;
+
+    if (decrypt_key)
+    {
+        FIXME( "decryption of key not yet supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    return key_import( algorithm, type, key, object, object_len, input, input_len );
+}
+
+NTSTATUS WINAPI BCryptExportKey( BCRYPT_KEY_HANDLE export_key, BCRYPT_KEY_HANDLE encrypt_key, LPCWSTR type,
+                                 PUCHAR output, ULONG output_len, ULONG *size, ULONG flags )
+{
+    struct key *key = export_key;
+
+    TRACE("%p, %p, %s, %p, %u, %p, %u\n", key, encrypt_key, debugstr_w(type), output, output_len, size, flags);
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!type || !size) return STATUS_INVALID_PARAMETER;
+
+    if (encrypt_key)
+    {
+        FIXME( "encryption of key not yet supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    return key_export( key, type, output, output_len, size );
+}
+
+static NTSTATUS key_duplicate( struct key *key_orig, struct key *key_copy )
+{
+    UCHAR *buffer;
+    NTSTATUS status;
+
+    memset( key_copy, 0, sizeof(*key_copy) );
+    key_copy->hdr    = key_orig->hdr;
+    key_copy->alg_id = key_orig->alg_id;
+
+    if (key_is_symmetric( key_orig ))
+    {
+        if (!(buffer = heap_alloc( key_orig->u.s.secret_len ))) return STATUS_NO_MEMORY;
+        memcpy( buffer, key_orig->u.s.secret, key_orig->u.s.secret_len );
+
+        key_copy->u.s.mode       = key_orig->u.s.mode;
+        key_copy->u.s.block_size = key_orig->u.s.block_size;
+        key_copy->u.s.secret     = buffer;
+        key_copy->u.s.secret_len = key_orig->u.s.secret_len;
+        InitializeCriticalSection( &key_copy->u.s.cs );
     }
     else
     {
-        return hash_finish( hash, output, size );
+        if (!(buffer = heap_alloc( key_orig->u.a.pubkey_len ))) return STATUS_NO_MEMORY;
+        memcpy( buffer, key_orig->u.a.pubkey, key_orig->u.a.pubkey_len );
+
+        key_copy->u.a.bitlen     = key_orig->u.a.bitlen;
+        key_copy->u.a.flags      = key_orig->u.a.flags;
+        key_copy->u.a.pubkey     = buffer;
+        key_copy->u.a.pubkey_len = key_orig->u.a.pubkey_len;
+        key_copy->u.a.dss_seed   = key_orig->u.a.dss_seed;
+
+        if ((status = key_funcs->key_asymmetric_duplicate( key_orig, key_copy ))) return status;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static void key_destroy( struct key *key )
+{
+    if (key_is_symmetric( key ))
+    {
+        key_funcs->key_symmetric_destroy( key );
+        heap_free( key->u.s.vector );
+        heap_free( key->u.s.secret );
+        DeleteCriticalSection( &key->u.s.cs );
+    }
+    else
+    {
+        key_funcs->key_asymmetric_destroy( key );
+        heap_free( key->u.a.pubkey );
+    }
+    key->hdr.magic = 0;
+    heap_free( key );
+}
+
+NTSTATUS WINAPI BCryptDuplicateKey( BCRYPT_KEY_HANDLE handle, BCRYPT_KEY_HANDLE *handle_copy,
+                                    UCHAR *object, ULONG object_len, ULONG flags )
+{
+    struct key *key_orig = handle;
+    struct key *key_copy;
+    NTSTATUS status;
+
+    TRACE( "%p, %p, %p, %u, %08x\n", handle, handle_copy, object, object_len, flags );
+    if (object) FIXME( "ignoring object buffer\n" );
+
+    if (!key_orig || key_orig->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!handle_copy) return STATUS_INVALID_PARAMETER;
+    if (!(key_copy = heap_alloc( sizeof(*key_copy) ))) return STATUS_NO_MEMORY;
+
+    if ((status = key_duplicate( key_orig, key_copy )))
+    {
+        key_destroy( key_copy );
+        return status;
+    }
+
+    *handle_copy = key_copy;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptImportKeyPair( BCRYPT_ALG_HANDLE algorithm, BCRYPT_KEY_HANDLE decrypt_key, const WCHAR *type,
+                                     BCRYPT_KEY_HANDLE *ret_key, UCHAR *input, ULONG input_len, ULONG flags )
+{
+    struct algorithm *alg = algorithm;
+
+    TRACE( "%p, %p, %s, %p, %p, %u, %08x\n", algorithm, decrypt_key, debugstr_w(type), ret_key, input,
+           input_len, flags );
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+    if (!ret_key || !type || !input) return STATUS_INVALID_PARAMETER;
+    if (decrypt_key)
+    {
+        FIXME( "decryption of key not yet supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    return key_import_pair( alg, type, ret_key, input, input_len );
+}
+
+NTSTATUS WINAPI BCryptSignHash( BCRYPT_KEY_HANDLE handle, void *padding, UCHAR *input, ULONG input_len,
+                                UCHAR *output, ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    struct key *key = handle;
+
+    TRACE( "%p, %p, %p, %u, %p, %u, %p, %08x\n", handle, padding, input, input_len, output, output_len,
+           ret_len, flags );
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (key_is_symmetric( key ))
+    {
+        FIXME( "signing with symmetric keys not yet supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    return key_funcs->key_asymmetric_sign( key, padding, input, input_len, output, output_len, ret_len, flags );
+}
+
+NTSTATUS WINAPI BCryptVerifySignature( BCRYPT_KEY_HANDLE handle, void *padding, UCHAR *hash, ULONG hash_len,
+                                       UCHAR *signature, ULONG signature_len, ULONG flags )
+{
+    struct key *key = handle;
+
+    TRACE( "%p, %p, %p, %u, %p, %u, %08x\n", handle, padding, hash, hash_len, signature, signature_len, flags );
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!hash || !hash_len || !signature || !signature_len) return STATUS_INVALID_PARAMETER;
+    if (key_is_symmetric( key )) return STATUS_NOT_SUPPORTED;
+
+    return key_funcs->key_asymmetric_verify( key, padding, hash, hash_len, signature, signature_len, flags );
+}
+
+NTSTATUS WINAPI BCryptDestroyKey( BCRYPT_KEY_HANDLE handle )
+{
+    struct key *key = handle;
+
+    TRACE( "%p\n", handle );
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+
+    key_destroy( key );
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptEncrypt( BCRYPT_KEY_HANDLE handle, UCHAR *input, ULONG input_len, void *padding, UCHAR *iv,
+                               ULONG iv_len, UCHAR *output, ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    struct key *key = handle;
+    NTSTATUS ret;
+
+    TRACE( "%p, %p, %u, %p, %p, %u, %p, %u, %p, %08x\n", handle, input, input_len, padding, iv, iv_len, output,
+           output_len, ret_len, flags );
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!key_is_symmetric( key ))
+    {
+        FIXME( "encryption with asymmetric keys not yet supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+    if (flags & ~BCRYPT_BLOCK_PADDING)
+    {
+        FIXME( "flags %08x not implemented\n", flags );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    EnterCriticalSection( &key->u.s.cs );
+    ret = key_symmetric_encrypt( key, input, input_len, padding, iv, iv_len, output, output_len, ret_len, flags );
+    LeaveCriticalSection( &key->u.s.cs );
+    return ret;
+}
+
+NTSTATUS WINAPI BCryptDecrypt( BCRYPT_KEY_HANDLE handle, UCHAR *input, ULONG input_len, void *padding, UCHAR *iv,
+                               ULONG iv_len, UCHAR *output, ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    struct key *key = handle;
+
+    TRACE( "%p, %p, %u, %p, %p, %u, %p, %u, %p, %08x\n", handle, input, input_len, padding, iv, iv_len, output,
+           output_len, ret_len, flags );
+
+    if (!key || key->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (flags & ~BCRYPT_BLOCK_PADDING)
+    {
+        FIXME( "flags %08x not supported\n", flags );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (key_is_symmetric( key ))
+    {
+        NTSTATUS ret;
+        EnterCriticalSection( &key->u.s.cs );
+        ret = key_symmetric_decrypt( key, input, input_len, padding, iv, iv_len, output, output_len, ret_len, flags );
+        LeaveCriticalSection( &key->u.s.cs );
+        return ret;
+    }
+
+    return key_funcs->key_asymmetric_decrypt( key, input, input_len, output, output_len, ret_len );
+}
+
+NTSTATUS WINAPI BCryptSetProperty( BCRYPT_HANDLE handle, const WCHAR *prop, UCHAR *value, ULONG size, ULONG flags )
+{
+    struct object *object = handle;
+
+    TRACE( "%p, %s, %p, %u, %08x\n", handle, debugstr_w(prop), value, size, flags );
+
+    if (!object) return STATUS_INVALID_HANDLE;
+
+    switch (object->magic)
+    {
+    case MAGIC_ALG:
+    {
+        struct algorithm *alg = (struct algorithm *)object;
+        return set_alg_property( alg, prop, value, size, flags );
+    }
+    case MAGIC_KEY:
+    {
+        struct key *key = (struct key *)object;
+        return key_funcs->key_set_property( key, prop, value, size, flags );
+    }
+    default:
+        WARN( "unknown magic %08x\n", object->magic );
+        return STATUS_INVALID_HANDLE;
     }
 }
 
-NTSTATUS WINAPI BCryptHash( BCRYPT_ALG_HANDLE algorithm, UCHAR *secret, ULONG secretlen,
-                            UCHAR *input, ULONG inputlen, UCHAR *output, ULONG outputlen )
+#define HMAC_PAD_LEN 64
+NTSTATUS WINAPI BCryptDeriveKeyCapi( BCRYPT_HASH_HANDLE handle, BCRYPT_ALG_HANDLE halg, UCHAR *key, ULONG keylen, ULONG flags )
 {
+    struct hash *hash = handle;
+    UCHAR buf[MAX_HASH_OUTPUT_BYTES * 2];
     NTSTATUS status;
-    BCRYPT_HASH_HANDLE handle;
+    ULONG len;
 
-    TRACE( "%p, %p, %u, %p, %u, %p, %u\n", algorithm, secret, secretlen,
-           input, inputlen, output, outputlen );
+    TRACE( "%p, %p, %p, %u, %08x\n", handle, halg, key, keylen, flags );
 
-    status = BCryptCreateHash( algorithm, &handle, NULL, 0, secret, secretlen, 0);
-    if (status != STATUS_SUCCESS)
+    if (!key || !keylen) return STATUS_INVALID_PARAMETER;
+    if (!hash || hash->hdr.magic != MAGIC_HASH) return STATUS_INVALID_HANDLE;
+    if (keylen > builtin_algorithms[hash->alg_id].hash_length * 2) return STATUS_INVALID_PARAMETER;
+
+    if (halg)
     {
-        return status;
+        FIXME( "algorithm handle not supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
     }
 
-    status = BCryptHashData( handle, input, inputlen, 0 );
-    if (status != STATUS_SUCCESS)
+    len = builtin_algorithms[hash->alg_id].hash_length;
+    if ((status = hash_finalize( hash, buf, len ))) return status;
+
+    if (len < keylen)
     {
-        BCryptDestroyHash( handle );
-        return status;
+        UCHAR pad1[HMAC_PAD_LEN], pad2[HMAC_PAD_LEN];
+        ULONG i;
+
+        for (i = 0; i < sizeof(pad1); i++)
+        {
+            pad1[i] = 0x36 ^ (i < len ? buf[i] : 0);
+            pad2[i] = 0x5c ^ (i < len ? buf[i] : 0);
+        }
+
+        if ((status = hash_prepare( hash )) ||
+            (status = hash_update( &hash->inner, hash->alg_id, pad1, sizeof(pad1) )) ||
+            (status = hash_finalize( hash, buf, len ))) return status;
+
+        if ((status = hash_prepare( hash )) ||
+            (status = hash_update( &hash->inner, hash->alg_id, pad2, sizeof(pad2) )) ||
+            (status = hash_finalize( hash, buf + len, len ))) return status;
     }
 
-    status = BCryptFinishHash( handle, output, outputlen, 0 );
-    if (status != STATUS_SUCCESS)
+    memcpy( key, buf, keylen );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS pbkdf2( struct hash *hash, UCHAR *pwd, ULONG pwd_len, UCHAR *salt, ULONG salt_len,
+                        ULONGLONG iterations, ULONG i, UCHAR *dst, ULONG hash_len )
+{
+    NTSTATUS status = STATUS_INVALID_PARAMETER;
+    UCHAR bytes[4], *buf;
+    ULONG j, k;
+
+    if (!(buf = heap_alloc( hash_len ))) return STATUS_NO_MEMORY;
+
+    for (j = 0; j < iterations; j++)
     {
-        BCryptDestroyHash( handle );
-        return status;
+        if (j == 0)
+        {
+            /* use salt || INT(i) */
+            if ((status = hash_update( &hash->inner, hash->alg_id, salt, salt_len )))
+            {
+                heap_free( buf );
+                return status;
+            }
+            bytes[0] = (i >> 24) & 0xff;
+            bytes[1] = (i >> 16) & 0xff;
+            bytes[2] = (i >> 8) & 0xff;
+            bytes[3] = i & 0xff;
+            status = hash_update( &hash->inner, hash->alg_id, bytes, 4 );
+        }
+        else status = hash_update( &hash->inner, hash->alg_id, buf, hash_len ); /* use U_j */
+
+        if (status)
+        {
+            heap_free( buf );
+            return status;
+        }
+
+        if ((status = hash_finalize( hash, buf, hash_len )))
+        {
+            heap_free( buf );
+            return status;
+        }
+
+        if (j == 0) memcpy( dst, buf, hash_len );
+        else for (k = 0; k < hash_len; k++) dst[k] ^= buf[k];
     }
 
-    return BCryptDestroyHash( handle );
+    heap_free( buf );
+    return status;
+}
+
+NTSTATUS WINAPI BCryptDeriveKeyPBKDF2( BCRYPT_ALG_HANDLE handle, UCHAR *pwd, ULONG pwd_len, UCHAR *salt, ULONG salt_len,
+                                       ULONGLONG iterations, UCHAR *dk, ULONG dk_len, ULONG flags )
+{
+    struct algorithm *alg = handle;
+    ULONG hash_len, block_count, bytes_left, i;
+    struct hash *hash;
+    UCHAR *partial;
+    NTSTATUS status;
+
+    TRACE( "%p, %p, %u, %p, %u, %s, %p, %u, %08x\n", handle, pwd, pwd_len, salt, salt_len,
+           wine_dbgstr_longlong(iterations), dk, dk_len, flags );
+
+    if (!alg || alg->hdr.magic != MAGIC_ALG) return STATUS_INVALID_HANDLE;
+
+    hash_len = builtin_algorithms[alg->id].hash_length;
+    if (dk_len <= 0 || dk_len > ((((ULONGLONG)1) << 32) - 1) * hash_len) return STATUS_INVALID_PARAMETER;
+
+    block_count = 1 + ((dk_len - 1) / hash_len); /* ceil(dk_len / hash_len) */
+    bytes_left = dk_len - (block_count - 1) * hash_len;
+
+    if ((status = hash_create( alg, pwd, pwd_len, BCRYPT_HASH_REUSABLE_FLAG, &hash ))) return status;
+
+    /* full blocks */
+    for (i = 1; i < block_count; i++)
+    {
+        if ((status = pbkdf2( hash, pwd, pwd_len, salt, salt_len, iterations, i, dk + ((i - 1) * hash_len), hash_len )))
+        {
+            hash_destroy( hash );
+            return status;
+        }
+    }
+
+    /* final partial block */
+    if (!(partial = heap_alloc( hash_len )))
+    {
+        hash_destroy( hash );
+        return STATUS_NO_MEMORY;
+    }
+
+    if ((status = pbkdf2( hash, pwd, pwd_len, salt, salt_len, iterations, block_count, partial, hash_len )))
+    {
+        hash_destroy( hash );
+        heap_free( partial );
+        return status;
+    }
+    memcpy( dk + ((block_count - 1) * hash_len), partial, bytes_left );
+
+    hash_destroy( hash );
+    heap_free( partial );
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptSecretAgreement(BCRYPT_KEY_HANDLE privatekey, BCRYPT_KEY_HANDLE publickey, BCRYPT_SECRET_HANDLE *handle, ULONG flags)
+{
+    struct key *privkey = privatekey;
+    struct key *pubkey = publickey;
+    struct secret *secret;
+
+    FIXME( "%p, %p, %p, %08x\n", privatekey, publickey, handle, flags );
+
+    if (!privkey || privkey->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!pubkey || pubkey->hdr.magic != MAGIC_KEY) return STATUS_INVALID_HANDLE;
+    if (!handle) return STATUS_INVALID_PARAMETER;
+
+    if (!(secret = heap_alloc_zero( sizeof(*secret) ))) return STATUS_NO_MEMORY;
+    secret->hdr.magic = MAGIC_SECRET;
+
+    *handle = secret;
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptDestroySecret(BCRYPT_SECRET_HANDLE handle)
+{
+    struct secret *secret = handle;
+
+    FIXME( "%p\n", handle );
+
+    if (!secret || secret->hdr.magic != MAGIC_SECRET) return STATUS_INVALID_HANDLE;
+    secret->hdr.magic = 0;
+    heap_free( secret );
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS WINAPI BCryptDeriveKey(BCRYPT_SECRET_HANDLE handle, LPCWSTR kdf, BCryptBufferDesc *parameter,
+        PUCHAR derived, ULONG derived_size, ULONG *result, ULONG flags)
+{
+    struct secret *secret = handle;
+
+    FIXME( "%p, %s, %p, %p, %d, %p, %08x\n", secret, debugstr_w(kdf), parameter, derived, derived_size, result, flags );
+
+    if (!secret || secret->hdr.magic != MAGIC_SECRET) return STATUS_INVALID_HANDLE;
+    if (!kdf) return STATUS_INVALID_PARAMETER;
+
+    return STATUS_INTERNAL_ERROR;
 }
 
 BOOL WINAPI DllMain( HINSTANCE hinst, DWORD reason, LPVOID reserved )
@@ -1126,20 +1974,11 @@ BOOL WINAPI DllMain( HINSTANCE hinst, DWORD reason, LPVOID reserved )
     case DLL_PROCESS_ATTACH:
         instance = hinst;
         DisableThreadLibraryCalls( hinst );
-#if defined(HAVE_GNUTLS_HASH) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H)
-        gnutls_initialize();
-#elif defined(SONAME_LIBMBEDTLS) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H) && !defined(__REACTOS__)
-        mbedtls_initialize();
-#endif
+        __wine_init_unix_lib( hinst, reason, NULL, &key_funcs );
         break;
-
     case DLL_PROCESS_DETACH:
         if (reserved) break;
-#if defined(HAVE_GNUTLS_HASH) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H)
-        gnutls_uninitialize();
-#elif defined(SONAME_LIBMBEDTLS) && !defined(HAVE_COMMONCRYPTO_COMMONDIGEST_H) && !defined(__REACTOS__)
-        mbedtls_uninitialize();
-#endif
+        __wine_init_unix_lib( hinst, reason, NULL, NULL );
         break;
     }
     return TRUE;

--- a/dll/win32/bcrypt/gnutls.c
+++ b/dll/win32/bcrypt/gnutls.c
@@ -1,0 +1,1911 @@
+/*
+ * Copyright 2009 Henri Verbeet for CodeWeavers
+ * Copyright 2018 Hans Leidekker for CodeWeavers
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+#if 0
+#pragma makedep unix
+#endif
+
+#include "config.h"
+#include "wine/port.h"
+
+#ifdef HAVE_GNUTLS_CIPHER_INIT
+
+#include <stdarg.h>
+#include <assert.h>
+#include <gnutls/gnutls.h>
+#include <gnutls/crypto.h>
+#include <gnutls/abstract.h>
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "winternl.h"
+#include "ntsecapi.h"
+#include "wincrypt.h"
+#include "bcrypt.h"
+
+#include "bcrypt_internal.h"
+
+#include "wine/debug.h"
+#include "wine/unicode.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(bcrypt);
+WINE_DECLARE_DEBUG_CHANNEL(winediag);
+
+#if GNUTLS_VERSION_MAJOR < 3
+#define GNUTLS_CIPHER_AES_192_CBC 92
+#define GNUTLS_CIPHER_AES_128_GCM 93
+#define GNUTLS_CIPHER_AES_256_GCM 94
+#define GNUTLS_PK_ECC 4
+
+#define GNUTLS_CURVE_TO_BITS(curve) (unsigned int)(((unsigned int)1<<31)|((unsigned int)(curve)))
+
+typedef enum
+{
+    GNUTLS_ECC_CURVE_INVALID,
+    GNUTLS_ECC_CURVE_SECP224R1,
+    GNUTLS_ECC_CURVE_SECP256R1,
+    GNUTLS_ECC_CURVE_SECP384R1,
+    GNUTLS_ECC_CURVE_SECP521R1,
+} gnutls_ecc_curve_t;
+#endif
+
+union key_data
+{
+    gnutls_cipher_hd_t cipher;
+    gnutls_privkey_t   privkey;
+};
+C_ASSERT( sizeof(union key_data) <= sizeof(((struct key *)0)->private) );
+
+static union key_data *key_data( struct key *key )
+{
+    return (union key_data *)key->private;
+}
+
+/* Not present in gnutls version < 3.0 */
+static int (*pgnutls_cipher_tag)(gnutls_cipher_hd_t, void *, size_t);
+static int (*pgnutls_cipher_add_auth)(gnutls_cipher_hd_t, const void *, size_t);
+static gnutls_sign_algorithm_t (*pgnutls_pk_to_sign)(gnutls_pk_algorithm_t, gnutls_digest_algorithm_t);
+static int (*pgnutls_pubkey_import_ecc_raw)(gnutls_pubkey_t, gnutls_ecc_curve_t,
+                                            const gnutls_datum_t *, const gnutls_datum_t *);
+static int (*pgnutls_privkey_import_ecc_raw)(gnutls_privkey_t, gnutls_ecc_curve_t, const gnutls_datum_t *,
+                                             const gnutls_datum_t *, const gnutls_datum_t *);
+static int (*pgnutls_pubkey_verify_hash2)(gnutls_pubkey_t, gnutls_sign_algorithm_t, unsigned int,
+                                          const gnutls_datum_t *, const gnutls_datum_t *);
+
+/* Not present in gnutls version < 2.11.0 */
+static int (*pgnutls_pubkey_import_rsa_raw)(gnutls_pubkey_t, const gnutls_datum_t *, const gnutls_datum_t *);
+
+/* Not present in gnutls version < 2.12.0 */
+static int (*pgnutls_pubkey_import_dsa_raw)(gnutls_pubkey_t, const gnutls_datum_t *, const gnutls_datum_t *,
+                                            const gnutls_datum_t *, const gnutls_datum_t *);
+
+/* Not present in gnutls version < 3.3.0 */
+static int (*pgnutls_privkey_export_ecc_raw)(gnutls_privkey_t, gnutls_ecc_curve_t *,
+                                             gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *);
+static int (*pgnutls_privkey_export_rsa_raw)(gnutls_privkey_t, gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *,
+                                             gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *,
+                                             gnutls_datum_t *);
+static int (*pgnutls_privkey_export_dsa_raw)(gnutls_privkey_t, gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *,
+                                             gnutls_datum_t *, gnutls_datum_t *);
+static int (*pgnutls_privkey_generate)(gnutls_privkey_t, gnutls_pk_algorithm_t, unsigned int, unsigned int);
+static int (*pgnutls_privkey_import_rsa_raw)(gnutls_privkey_t, const gnutls_datum_t *, const gnutls_datum_t *,
+                                             const gnutls_datum_t *, const gnutls_datum_t *, const gnutls_datum_t *,
+                                             const gnutls_datum_t *, const gnutls_datum_t *, const gnutls_datum_t *);
+static int (*pgnutls_privkey_decrypt_data)(gnutls_privkey_t, unsigned int flags, const gnutls_datum_t *, gnutls_datum_t *);
+
+/* Not present in gnutls version < 3.6.0 */
+static int (*pgnutls_decode_rs_value)(const gnutls_datum_t *, gnutls_datum_t *, gnutls_datum_t *);
+
+static void *libgnutls_handle;
+#define MAKE_FUNCPTR(f) static typeof(f) * p##f
+MAKE_FUNCPTR(gnutls_cipher_decrypt2);
+MAKE_FUNCPTR(gnutls_cipher_deinit);
+MAKE_FUNCPTR(gnutls_cipher_encrypt2);
+MAKE_FUNCPTR(gnutls_cipher_init);
+MAKE_FUNCPTR(gnutls_global_deinit);
+MAKE_FUNCPTR(gnutls_global_init);
+MAKE_FUNCPTR(gnutls_global_set_log_function);
+MAKE_FUNCPTR(gnutls_global_set_log_level);
+MAKE_FUNCPTR(gnutls_perror);
+MAKE_FUNCPTR(gnutls_privkey_decrypt_data);
+MAKE_FUNCPTR(gnutls_privkey_deinit);
+MAKE_FUNCPTR(gnutls_privkey_import_dsa_raw);
+MAKE_FUNCPTR(gnutls_privkey_init);
+MAKE_FUNCPTR(gnutls_privkey_sign_hash);
+MAKE_FUNCPTR(gnutls_pubkey_deinit);
+MAKE_FUNCPTR(gnutls_pubkey_init);
+#undef MAKE_FUNCPTR
+
+static int compat_gnutls_cipher_tag(gnutls_cipher_hd_t handle, void *tag, size_t tag_size)
+{
+    return GNUTLS_E_UNKNOWN_CIPHER_TYPE;
+}
+
+static int compat_gnutls_cipher_add_auth(gnutls_cipher_hd_t handle, const void *ptext, size_t ptext_size)
+{
+    return GNUTLS_E_UNKNOWN_CIPHER_TYPE;
+}
+
+static int compat_gnutls_pubkey_import_ecc_raw(gnutls_pubkey_t key, gnutls_ecc_curve_t curve,
+                                               const gnutls_datum_t *x, const gnutls_datum_t *y)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_export_rsa_raw(gnutls_privkey_t key, gnutls_datum_t *m, gnutls_datum_t *e,
+                                                gnutls_datum_t *d, gnutls_datum_t *p, gnutls_datum_t *q,
+                                                gnutls_datum_t *u, gnutls_datum_t *e1, gnutls_datum_t *e2)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_export_ecc_raw(gnutls_privkey_t key, gnutls_ecc_curve_t *curve,
+                                                gnutls_datum_t *x, gnutls_datum_t *y, gnutls_datum_t *k)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_import_ecc_raw(gnutls_privkey_t key, gnutls_ecc_curve_t curve,
+                                                const gnutls_datum_t *x, const gnutls_datum_t *y,
+                                                const gnutls_datum_t *k)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_export_dsa_raw(gnutls_privkey_t key, gnutls_datum_t *p, gnutls_datum_t *q,
+                                                gnutls_datum_t *g, gnutls_datum_t *y, gnutls_datum_t *x)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static gnutls_sign_algorithm_t compat_gnutls_pk_to_sign(gnutls_pk_algorithm_t pk, gnutls_digest_algorithm_t hash)
+{
+    return GNUTLS_SIGN_UNKNOWN;
+}
+
+static int compat_gnutls_pubkey_verify_hash2(gnutls_pubkey_t key, gnutls_sign_algorithm_t algo,
+                                             unsigned int flags, const gnutls_datum_t *hash,
+                                             const gnutls_datum_t *signature)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_pubkey_import_rsa_raw(gnutls_pubkey_t key, const gnutls_datum_t *m, const gnutls_datum_t *e)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_pubkey_import_dsa_raw(gnutls_pubkey_t key, const gnutls_datum_t *p, const gnutls_datum_t *q,
+                                               const gnutls_datum_t *g, const gnutls_datum_t *y)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_generate(gnutls_privkey_t key, gnutls_pk_algorithm_t algo, unsigned int bits,
+                                          unsigned int flags)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_decode_rs_value(const gnutls_datum_t * sig_value, gnutls_datum_t * r, gnutls_datum_t * s)
+{
+    return GNUTLS_E_INTERNAL_ERROR;
+}
+
+static int compat_gnutls_privkey_import_rsa_raw(gnutls_privkey_t key, const gnutls_datum_t *m, const gnutls_datum_t *e,
+                                                const gnutls_datum_t *d, const gnutls_datum_t *p, const gnutls_datum_t *q,
+                                                const gnutls_datum_t *u, const gnutls_datum_t *e1, const gnutls_datum_t *e2)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static int compat_gnutls_privkey_decrypt_data(gnutls_privkey_t key, unsigned int flags, const gnutls_datum_t *cipher_text,
+                                              gnutls_datum_t *plain_text)
+{
+    return GNUTLS_E_UNKNOWN_PK_ALGORITHM;
+}
+
+static void gnutls_log( int level, const char *msg )
+{
+    TRACE( "<%d> %s", level, msg );
+}
+
+static BOOL gnutls_initialize(void)
+{
+    const char *env_str;
+    int ret;
+
+    if ((env_str = getenv("GNUTLS_SYSTEM_PRIORITY_FILE")))
+    {
+        WARN("GNUTLS_SYSTEM_PRIORITY_FILE is %s.\n", debugstr_a(env_str));
+    }
+    else
+    {
+        WARN("Setting GNUTLS_SYSTEM_PRIORITY_FILE to \"/dev/null\".\n");
+        setenv("GNUTLS_SYSTEM_PRIORITY_FILE", "/dev/null", 0);
+    }
+
+    if (!(libgnutls_handle = dlopen( SONAME_LIBGNUTLS, RTLD_NOW )))
+    {
+        ERR_(winediag)( "failed to load libgnutls, no support for encryption\n" );
+        return FALSE;
+    }
+
+#define LOAD_FUNCPTR(f) \
+    if (!(p##f = dlsym( libgnutls_handle, #f ))) \
+    { \
+        ERR( "failed to load %s\n", #f ); \
+        goto fail; \
+    }
+
+    LOAD_FUNCPTR(gnutls_cipher_decrypt2)
+    LOAD_FUNCPTR(gnutls_cipher_deinit)
+    LOAD_FUNCPTR(gnutls_cipher_encrypt2)
+    LOAD_FUNCPTR(gnutls_cipher_init)
+    LOAD_FUNCPTR(gnutls_global_deinit)
+    LOAD_FUNCPTR(gnutls_global_init)
+    LOAD_FUNCPTR(gnutls_global_set_log_function)
+    LOAD_FUNCPTR(gnutls_global_set_log_level)
+    LOAD_FUNCPTR(gnutls_perror)
+    LOAD_FUNCPTR(gnutls_privkey_deinit);
+    LOAD_FUNCPTR(gnutls_privkey_import_dsa_raw);
+    LOAD_FUNCPTR(gnutls_privkey_init);
+    LOAD_FUNCPTR(gnutls_privkey_sign_hash);
+    LOAD_FUNCPTR(gnutls_pubkey_deinit);
+    LOAD_FUNCPTR(gnutls_pubkey_init);
+#undef LOAD_FUNCPTR
+
+    if (!(pgnutls_cipher_tag = dlsym( libgnutls_handle, "gnutls_cipher_tag" )))
+    {
+        WARN("gnutls_cipher_tag not found\n");
+        pgnutls_cipher_tag = compat_gnutls_cipher_tag;
+    }
+    if (!(pgnutls_cipher_add_auth = dlsym( libgnutls_handle, "gnutls_cipher_add_auth" )))
+    {
+        WARN("gnutls_cipher_add_auth not found\n");
+        pgnutls_cipher_add_auth = compat_gnutls_cipher_add_auth;
+    }
+
+    if ((ret = pgnutls_global_init()) != GNUTLS_E_SUCCESS)
+    {
+        pgnutls_perror( ret );
+        goto fail;
+    }
+    if (!(pgnutls_pubkey_import_ecc_raw = dlsym( libgnutls_handle, "gnutls_pubkey_import_ecc_raw" )))
+    {
+        WARN("gnutls_pubkey_import_ecc_raw not found\n");
+        pgnutls_pubkey_import_ecc_raw = compat_gnutls_pubkey_import_ecc_raw;
+    }
+    if (!(pgnutls_privkey_export_rsa_raw = dlsym( libgnutls_handle, "gnutls_privkey_export_rsa_raw" )))
+    {
+        WARN("gnutls_privkey_export_rsa_raw not found\n");
+        pgnutls_privkey_export_rsa_raw = compat_gnutls_privkey_export_rsa_raw;
+    }
+    if (!(pgnutls_privkey_export_ecc_raw = dlsym( libgnutls_handle, "gnutls_privkey_export_ecc_raw" )))
+    {
+        WARN("gnutls_privkey_export_ecc_raw not found\n");
+        pgnutls_privkey_export_ecc_raw = compat_gnutls_privkey_export_ecc_raw;
+    }
+    if (!(pgnutls_privkey_import_ecc_raw = dlsym( libgnutls_handle, "gnutls_privkey_import_ecc_raw" )))
+    {
+        WARN("gnutls_privkey_import_ecc_raw not found\n");
+        pgnutls_privkey_import_ecc_raw = compat_gnutls_privkey_import_ecc_raw;
+    }
+    if (!(pgnutls_privkey_export_dsa_raw = dlsym( libgnutls_handle, "gnutls_privkey_export_dsa_raw" )))
+    {
+        WARN("gnutls_privkey_export_dsa_raw not found\n");
+        pgnutls_privkey_export_dsa_raw = compat_gnutls_privkey_export_dsa_raw;
+    }
+    if (!(pgnutls_pk_to_sign = dlsym( libgnutls_handle, "gnutls_pk_to_sign" )))
+    {
+        WARN("gnutls_pk_to_sign not found\n");
+        pgnutls_pk_to_sign = compat_gnutls_pk_to_sign;
+    }
+    if (!(pgnutls_pubkey_verify_hash2 = dlsym( libgnutls_handle, "gnutls_pubkey_verify_hash2" )))
+    {
+        WARN("gnutls_pubkey_verify_hash2 not found\n");
+        pgnutls_pubkey_verify_hash2 = compat_gnutls_pubkey_verify_hash2;
+    }
+    if (!(pgnutls_pubkey_import_rsa_raw = dlsym( libgnutls_handle, "gnutls_pubkey_import_rsa_raw" )))
+    {
+        WARN("gnutls_pubkey_import_rsa_raw not found\n");
+        pgnutls_pubkey_import_rsa_raw = compat_gnutls_pubkey_import_rsa_raw;
+    }
+    if (!(pgnutls_pubkey_import_dsa_raw = dlsym( libgnutls_handle, "gnutls_pubkey_import_dsa_raw" )))
+    {
+        WARN("gnutls_pubkey_import_dsa_raw not found\n");
+        pgnutls_pubkey_import_dsa_raw = compat_gnutls_pubkey_import_dsa_raw;
+    }
+    if (!(pgnutls_privkey_generate = dlsym( libgnutls_handle, "gnutls_privkey_generate" )))
+    {
+        WARN("gnutls_privkey_generate not found\n");
+        pgnutls_privkey_generate = compat_gnutls_privkey_generate;
+    }
+    if (!(pgnutls_decode_rs_value = dlsym( libgnutls_handle, "gnutls_decode_rs_value" )))
+    {
+        WARN("gnutls_decode_rs_value not found\n");
+        pgnutls_decode_rs_value = compat_gnutls_decode_rs_value;
+    }
+    if (!(pgnutls_privkey_import_rsa_raw = dlsym( libgnutls_handle, "gnutls_privkey_import_rsa_raw" )))
+    {
+        WARN("gnutls_privkey_import_rsa_raw not found\n");
+        pgnutls_privkey_import_rsa_raw = compat_gnutls_privkey_import_rsa_raw;
+    }
+    if (!(pgnutls_privkey_decrypt_data = dlsym( libgnutls_handle, "gnutls_privkey_decrypt_data" )))
+    {
+        WARN("gnutls_privkey_decrypt_data not found\n");
+        pgnutls_privkey_decrypt_data = compat_gnutls_privkey_decrypt_data;
+    }
+
+    if (TRACE_ON( bcrypt ))
+    {
+        pgnutls_global_set_log_level( 4 );
+        pgnutls_global_set_log_function( gnutls_log );
+    }
+
+    return TRUE;
+
+fail:
+    dlclose( libgnutls_handle );
+    libgnutls_handle = NULL;
+    return FALSE;
+}
+
+static void gnutls_uninitialize(void)
+{
+    pgnutls_global_deinit();
+    dlclose( libgnutls_handle );
+    libgnutls_handle = NULL;
+}
+
+struct buffer
+{
+    BYTE  *buffer;
+    DWORD  length;
+    DWORD  pos;
+    BOOL   error;
+};
+
+static void buffer_init( struct buffer *buffer )
+{
+    buffer->buffer = NULL;
+    buffer->length = 0;
+    buffer->pos    = 0;
+    buffer->error  = FALSE;
+}
+
+static void buffer_free( struct buffer *buffer )
+{
+    free( buffer->buffer );
+}
+
+static void buffer_append( struct buffer *buffer, BYTE *data, DWORD len )
+{
+    if (!len) return;
+
+    if (buffer->pos + len > buffer->length)
+    {
+        DWORD new_length = max( max( buffer->pos + len, buffer->length * 2 ), 64 );
+        BYTE *new_buffer;
+
+        if (!(new_buffer = realloc( buffer->buffer, new_length )))
+        {
+            ERR( "out of memory\n" );
+            buffer->error = TRUE;
+            return;
+        }
+
+        buffer->buffer = new_buffer;
+        buffer->length = new_length;
+    }
+
+    memcpy( &buffer->buffer[buffer->pos], data, len );
+    buffer->pos += len;
+}
+
+static void buffer_append_byte( struct buffer *buffer, BYTE value )
+{
+    buffer_append( buffer, &value, sizeof(value) );
+}
+
+static void buffer_append_asn1_length( struct buffer *buffer, DWORD length )
+{
+    DWORD num_bytes;
+
+    if (length < 128)
+    {
+        buffer_append_byte( buffer, length );
+        return;
+    }
+
+    if (length <= 0xff) num_bytes = 1;
+    else if (length <= 0xffff) num_bytes = 2;
+    else if (length <= 0xffffff) num_bytes = 3;
+    else num_bytes = 4;
+
+    buffer_append_byte( buffer, 0x80 | num_bytes );
+    while (num_bytes--) buffer_append_byte( buffer, length >> (num_bytes * 8) );
+}
+
+static void buffer_append_asn1_integer( struct buffer *buffer, BYTE *data, DWORD len )
+{
+    DWORD leading_zero = (*data & 0x80) != 0;
+
+    buffer_append_byte( buffer, 0x02 );  /* tag */
+    buffer_append_asn1_length( buffer, len + leading_zero );
+    if (leading_zero) buffer_append_byte( buffer, 0 );
+    buffer_append( buffer, data, len );
+}
+
+static void buffer_append_asn1_sequence( struct buffer *buffer, struct buffer *content )
+{
+    if (content->error)
+    {
+        buffer->error = TRUE;
+        return;
+    }
+
+    buffer_append_byte( buffer, 0x30 );  /* tag */
+    buffer_append_asn1_length( buffer, content->pos );
+    buffer_append( buffer, content->buffer, content->pos );
+}
+
+static void buffer_append_asn1_r_s( struct buffer *buffer, BYTE *r, DWORD r_len, BYTE *s, DWORD s_len )
+{
+    struct buffer value;
+
+    buffer_init( &value );
+    buffer_append_asn1_integer( &value, r, r_len );
+    buffer_append_asn1_integer( &value, s, s_len );
+    buffer_append_asn1_sequence( buffer, &value );
+    buffer_free( &value );
+}
+
+static NTSTATUS CDECL key_set_property( struct key *key, const WCHAR *prop, UCHAR *value, ULONG size, ULONG flags )
+{
+    if (!strcmpW( prop, BCRYPT_CHAINING_MODE ))
+    {
+        if (!strcmpW( (WCHAR *)value, BCRYPT_CHAIN_MODE_ECB ))
+        {
+            key->u.s.mode = MODE_ID_ECB;
+            return STATUS_SUCCESS;
+        }
+        else if (!strcmpW( (WCHAR *)value, BCRYPT_CHAIN_MODE_CBC ))
+        {
+            key->u.s.mode = MODE_ID_CBC;
+            return STATUS_SUCCESS;
+        }
+        else if (!strcmpW( (WCHAR *)value, BCRYPT_CHAIN_MODE_GCM ))
+        {
+            key->u.s.mode = MODE_ID_GCM;
+            return STATUS_SUCCESS;
+        }
+        else
+        {
+            FIXME( "unsupported mode %s\n", debugstr_w((WCHAR *)value) );
+            return STATUS_NOT_IMPLEMENTED;
+        }
+    }
+
+    FIXME( "unsupported key property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_init( struct key *key )
+{
+    if (!libgnutls_handle) return STATUS_INTERNAL_ERROR;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_3DES:
+    case ALG_ID_AES:
+        return STATUS_SUCCESS;
+
+    default:
+        FIXME( "algorithm %u not supported\n", key->alg_id );
+        return STATUS_NOT_SUPPORTED;
+    }
+}
+
+static gnutls_cipher_algorithm_t get_gnutls_cipher( const struct key *key )
+{
+    switch (key->alg_id)
+    {
+    case ALG_ID_3DES:
+        WARN( "handle block size\n" );
+        switch (key->u.s.mode)
+        {
+        case MODE_ID_CBC:
+            return GNUTLS_CIPHER_3DES_CBC;
+        default:
+            break;
+        }
+        FIXME( "3DES mode %u with key length %u not supported\n", key->u.s.mode, key->u.s.secret_len );
+        return GNUTLS_CIPHER_UNKNOWN;
+
+    case ALG_ID_AES:
+        WARN( "handle block size\n" );
+        switch (key->u.s.mode)
+        {
+        case MODE_ID_GCM:
+            if (key->u.s.secret_len == 16) return GNUTLS_CIPHER_AES_128_GCM;
+            if (key->u.s.secret_len == 32) return GNUTLS_CIPHER_AES_256_GCM;
+            break;
+        case MODE_ID_ECB: /* can be emulated with CBC + empty IV */
+        case MODE_ID_CBC:
+            if (key->u.s.secret_len == 16) return GNUTLS_CIPHER_AES_128_CBC;
+            if (key->u.s.secret_len == 24) return GNUTLS_CIPHER_AES_192_CBC;
+            if (key->u.s.secret_len == 32) return GNUTLS_CIPHER_AES_256_CBC;
+            break;
+        default:
+            break;
+        }
+        FIXME( "AES mode %u with key length %u not supported\n", key->u.s.mode, key->u.s.secret_len );
+        return GNUTLS_CIPHER_UNKNOWN;
+
+    default:
+        FIXME( "algorithm %u not supported\n", key->alg_id );
+        return GNUTLS_CIPHER_UNKNOWN;
+    }
+}
+
+static void CDECL key_symmetric_vector_reset( struct key *key )
+{
+    if (!key_data(key)->cipher) return;
+    TRACE( "invalidating cipher handle\n" );
+    pgnutls_cipher_deinit( key_data(key)->cipher );
+    key_data(key)->cipher = NULL;
+}
+
+static NTSTATUS init_cipher_handle( struct key *key )
+{
+    gnutls_cipher_algorithm_t cipher;
+    gnutls_datum_t secret, vector;
+    int ret;
+
+    if (key_data(key)->cipher) return STATUS_SUCCESS;
+    if ((cipher = get_gnutls_cipher( key )) == GNUTLS_CIPHER_UNKNOWN) return STATUS_NOT_SUPPORTED;
+
+    secret.data = key->u.s.secret;
+    secret.size = key->u.s.secret_len;
+
+    vector.data = key->u.s.vector;
+    vector.size = key->u.s.vector_len;
+
+    if ((ret = pgnutls_cipher_init( &key_data(key)->cipher, cipher, &secret, key->u.s.vector ? &vector : NULL )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_set_auth_data( struct key *key, UCHAR *auth_data, ULONG len )
+{
+    NTSTATUS status;
+    int ret;
+
+    if (!auth_data) return STATUS_SUCCESS;
+    if ((status = init_cipher_handle( key ))) return status;
+
+    if ((ret = pgnutls_cipher_add_auth( key_data(key)->cipher, auth_data, len )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_encrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len )
+{
+    NTSTATUS status;
+    int ret;
+
+    if ((status = init_cipher_handle( key ))) return status;
+
+    if ((ret = pgnutls_cipher_encrypt2( key_data(key)->cipher, input, input_len, output, output_len )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_decrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len  )
+{
+    NTSTATUS status;
+    int ret;
+
+    if ((status = init_cipher_handle( key ))) return status;
+
+    if ((ret = pgnutls_cipher_decrypt2( key_data(key)->cipher, input, input_len, output, output_len )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_get_tag( struct key *key, UCHAR *tag, ULONG len )
+{
+    NTSTATUS status;
+    int ret;
+
+    if ((status = init_cipher_handle( key ))) return status;
+
+    if ((ret = pgnutls_cipher_tag( key_data(key)->cipher, tag, len )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static void CDECL key_symmetric_destroy( struct key *key )
+{
+    if (key_data(key)->cipher) pgnutls_cipher_deinit( key_data(key)->cipher );
+}
+
+static void export_gnutls_datum( UCHAR *buffer, ULONG length, gnutls_datum_t *d, ULONG *actual_length )
+{
+    ULONG size = d->size;
+    UCHAR *src = d->data;
+    ULONG offset;
+
+    assert( size <= length + 1 );
+    if (size == length + 1)
+    {
+        assert(!src[0]);
+        ++src;
+        --size;
+    }
+    if (actual_length)
+    {
+        offset = 0;
+        *actual_length = size;
+    }
+    else
+    {
+        offset = length - size;
+        memset( buffer, 0, offset );
+    }
+    memcpy( buffer + offset, src, size );
+}
+
+static NTSTATUS export_gnutls_pubkey_rsa( gnutls_privkey_t gnutls_key, ULONG bitlen, UCHAR **pubkey, ULONG *pubkey_len )
+{
+    BCRYPT_RSAKEY_BLOB *rsa_blob;
+    gnutls_datum_t m, e;
+    UCHAR *dst;
+    int ret;
+
+    if ((ret = pgnutls_privkey_export_rsa_raw( gnutls_key, &m, &e, NULL, NULL, NULL, NULL, NULL, NULL )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (!(rsa_blob = RtlAllocateHeap( GetProcessHeap(), 0, sizeof(*rsa_blob) + e.size + m.size )))
+    {
+        pgnutls_perror( ret );
+        free( e.data ); free( m.data );
+        return STATUS_NO_MEMORY;
+    }
+
+    dst = (UCHAR *)(rsa_blob + 1);
+    export_gnutls_datum( dst, bitlen / 8, &e, &rsa_blob->cbPublicExp );
+
+    dst += rsa_blob->cbPublicExp;
+    export_gnutls_datum( dst, bitlen / 8, &m, &rsa_blob->cbModulus );
+
+    rsa_blob->Magic       = BCRYPT_RSAPUBLIC_MAGIC;
+    rsa_blob->BitLength   = bitlen;
+    rsa_blob->cbPrime1    = 0;
+    rsa_blob->cbPrime2    = 0;
+
+    *pubkey = (UCHAR *)rsa_blob;
+    *pubkey_len = sizeof(*rsa_blob) + rsa_blob->cbPublicExp + rsa_blob->cbModulus;
+
+    free( e.data ); free( m.data );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS export_gnutls_pubkey_ecc( gnutls_privkey_t gnutls_key, enum alg_id alg_id, UCHAR **pubkey,
+                                          ULONG *pubkey_len )
+{
+    BCRYPT_ECCKEY_BLOB *ecc_blob;
+    gnutls_ecc_curve_t curve;
+    gnutls_datum_t x, y;
+    DWORD magic, size;
+    UCHAR *dst;
+    int ret;
+
+    switch (alg_id)
+    {
+    case ALG_ID_ECDH_P256:
+        magic = BCRYPT_ECDH_PUBLIC_P256_MAGIC;
+        size = 32;
+        break;
+    case ALG_ID_ECDSA_P256:
+        magic = BCRYPT_ECDSA_PUBLIC_P256_MAGIC;
+        size = 32;
+        break;
+    default:
+        FIXME( "algorithm %u not supported\n", alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((ret = pgnutls_privkey_export_ecc_raw( gnutls_key, &curve, &x, &y, NULL )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (curve != GNUTLS_ECC_CURVE_SECP256R1)
+    {
+        FIXME( "curve %u not supported\n", curve );
+        free( x.data ); free( y.data );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (!(ecc_blob = RtlAllocateHeap( GetProcessHeap(), 0, sizeof(*ecc_blob) + size * 2 )))
+    {
+        pgnutls_perror( ret );
+        free( x.data ); free( y.data );
+        return STATUS_NO_MEMORY;
+    }
+
+    ecc_blob->dwMagic = magic;
+    ecc_blob->cbKey   = size;
+
+    dst = (UCHAR *)(ecc_blob + 1);
+    export_gnutls_datum( dst, size, &x, NULL );
+
+    dst += size;
+    export_gnutls_datum( dst, size, &y, NULL );
+
+    *pubkey = (UCHAR *)ecc_blob;
+    *pubkey_len = sizeof(*ecc_blob) + ecc_blob->cbKey * 2;
+
+    free( x.data ); free( y.data );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS export_gnutls_pubkey_dsa( gnutls_privkey_t gnutls_key, ULONG bitlen, UCHAR **pubkey, ULONG *pubkey_len )
+{
+    BCRYPT_DSA_KEY_BLOB *dsa_blob;
+    gnutls_datum_t p, q, g, y;
+    UCHAR *dst;
+    int ret;
+
+    if ((ret = pgnutls_privkey_export_dsa_raw( gnutls_key, &p, &q, &g, &y, NULL )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (bitlen > 1024)
+    {
+        FIXME( "bitlen > 1024 not supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (!(dsa_blob = RtlAllocateHeap( GetProcessHeap(), 0, sizeof(*dsa_blob) + bitlen / 8 * 3 )))
+    {
+        pgnutls_perror( ret );
+        free( p.data ); free( q.data ); free( g.data ); free( y.data );
+        return STATUS_NO_MEMORY;
+    }
+
+    dst = (UCHAR *)(dsa_blob + 1);
+    export_gnutls_datum( dst, bitlen / 8, &p, NULL );
+
+    dst += bitlen / 8;
+    export_gnutls_datum( dst, bitlen / 8, &g, NULL );
+
+    dst += bitlen / 8;
+    export_gnutls_datum( dst, bitlen / 8, &y, NULL );
+
+    dst = dsa_blob->q;
+    export_gnutls_datum( dst, sizeof(dsa_blob->q), &q, NULL );
+
+    dsa_blob->dwMagic = BCRYPT_DSA_PUBLIC_MAGIC;
+    dsa_blob->cbKey   = bitlen / 8;
+    memset( dsa_blob->Count, 0, sizeof(dsa_blob->Count) ); /* FIXME */
+    memset( dsa_blob->Seed, 0, sizeof(dsa_blob->Seed) ); /* FIXME */
+
+    *pubkey = (UCHAR *)dsa_blob;
+    *pubkey_len = sizeof(*dsa_blob) + dsa_blob->cbKey * 3;
+
+    free( p.data ); free( q.data ); free( g.data ); free( y.data );
+    return STATUS_SUCCESS;
+}
+
+static void reverse_bytes( UCHAR *buf, ULONG len )
+{
+    unsigned int i;
+    UCHAR tmp;
+
+    for (i = 0; i < len / 2; ++i)
+    {
+        tmp = buf[i];
+        buf[i] = buf[len - i - 1];
+        buf[len - i - 1] = tmp;
+    }
+}
+
+#define Q_SIZE 20
+static NTSTATUS export_gnutls_pubkey_dsa_capi( gnutls_privkey_t gnutls_key, const DSSSEED *seed, ULONG bitlen,
+                                               UCHAR **pubkey, ULONG *pubkey_len )
+{
+    BLOBHEADER *hdr;
+    DSSPUBKEY *dsskey;
+    gnutls_datum_t p, q, g, y;
+    UCHAR *dst;
+    int ret, size = sizeof(*hdr) + sizeof(*dsskey) + sizeof(*seed);
+
+    if (bitlen > 1024)
+    {
+        FIXME( "bitlen > 1024 not supported\n" );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((ret = pgnutls_privkey_export_dsa_raw( gnutls_key, &p, &q, &g, &y, NULL )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (!(hdr = RtlAllocateHeap( GetProcessHeap(), 0, size + bitlen / 8 * 3 + Q_SIZE )))
+    {
+        pgnutls_perror( ret );
+        free( p.data ); free( q.data ); free( g.data ); free( y.data );
+        return STATUS_NO_MEMORY;
+    }
+
+    hdr->bType    = PUBLICKEYBLOB;
+    hdr->bVersion = 2;
+    hdr->reserved = 0;
+    hdr->aiKeyAlg = CALG_DSS_SIGN;
+
+    dsskey = (DSSPUBKEY *)(hdr + 1);
+    dsskey->magic  = MAGIC_DSS1;
+    dsskey->bitlen = bitlen;
+
+    dst = (UCHAR *)(dsskey + 1);
+    export_gnutls_datum( dst, bitlen / 8, &p, NULL );
+    reverse_bytes( dst, bitlen / 8 );
+    dst += bitlen / 8;
+
+    export_gnutls_datum( dst, Q_SIZE, &q, NULL );
+    reverse_bytes( dst, Q_SIZE );
+    dst += Q_SIZE;
+
+    export_gnutls_datum( dst, bitlen / 8, &g, NULL );
+    reverse_bytes( dst, bitlen / 8 );
+    dst += bitlen / 8;
+
+    export_gnutls_datum( dst, bitlen / 8, &y, NULL );
+    reverse_bytes( dst, bitlen / 8 );
+    dst += bitlen / 8;
+
+    memcpy( dst, seed, sizeof(*seed) );
+
+    *pubkey = (UCHAR *)hdr;
+    *pubkey_len = size + bitlen / 8 * 3 + Q_SIZE;
+
+    free( p.data ); free( q.data ); free( g.data ); free( y.data );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_asymmetric_generate( struct key *key )
+{
+    gnutls_pk_algorithm_t pk_alg;
+    gnutls_privkey_t handle;
+    unsigned int bitlen;
+    NTSTATUS status;
+    int ret;
+
+    if (!libgnutls_handle) return STATUS_INTERNAL_ERROR;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+        pk_alg = GNUTLS_PK_RSA;
+        bitlen = key->u.a.bitlen;
+        break;
+
+    case ALG_ID_DSA:
+        pk_alg = GNUTLS_PK_DSA;
+        bitlen = key->u.a.bitlen;
+        break;
+
+    case ALG_ID_ECDH_P256:
+    case ALG_ID_ECDSA_P256:
+        pk_alg = GNUTLS_PK_ECC; /* compatible with ECDSA and ECDH */
+        bitlen = GNUTLS_CURVE_TO_BITS( GNUTLS_ECC_CURVE_SECP256R1 );
+        break;
+
+    default:
+        FIXME( "algorithm %u not supported\n", key->alg_id );
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    if ((ret = pgnutls_privkey_init( &handle )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if ((ret = pgnutls_privkey_generate( handle, pk_alg, bitlen, 0 )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_privkey_deinit( handle );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    switch (pk_alg)
+    {
+    case GNUTLS_PK_RSA:
+        status = export_gnutls_pubkey_rsa( handle, key->u.a.bitlen, &key->u.a.pubkey, &key->u.a.pubkey_len );
+        break;
+
+    case GNUTLS_PK_ECC:
+        status = export_gnutls_pubkey_ecc( handle, key->alg_id, &key->u.a.pubkey, &key->u.a.pubkey_len );
+        break;
+
+    case GNUTLS_PK_DSA:
+        status = export_gnutls_pubkey_dsa( handle, key->u.a.bitlen, &key->u.a.pubkey, &key->u.a.pubkey_len );
+        break;
+
+    default:
+        ERR( "unhandled algorithm %u\n", pk_alg );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (status)
+    {
+        pgnutls_privkey_deinit( handle );
+        return status;
+    }
+
+    key_data(key)->privkey = handle;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_export_ecc( struct key *key, UCHAR *buf, ULONG len, ULONG *ret_len )
+{
+    BCRYPT_ECCKEY_BLOB *ecc_blob;
+    gnutls_ecc_curve_t curve;
+    gnutls_datum_t x, y, d;
+    DWORD magic, size;
+    UCHAR *dst;
+    int ret;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDH_P256:
+        magic = BCRYPT_ECDH_PRIVATE_P256_MAGIC;
+        size = 32;
+        break;
+    case ALG_ID_ECDSA_P256:
+        magic = BCRYPT_ECDSA_PRIVATE_P256_MAGIC;
+        size = 32;
+        break;
+
+    default:
+        FIXME( "algorithm %u does not yet support exporting ecc blob\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((ret = pgnutls_privkey_export_ecc_raw( key_data(key)->privkey, &curve, &x, &y, &d )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (curve != GNUTLS_ECC_CURVE_SECP256R1)
+    {
+        FIXME( "curve %u not supported\n", curve );
+        free( x.data ); free( y.data ); free( d.data );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    *ret_len = sizeof(*ecc_blob) + size * 3;
+    if (len >= *ret_len && buf)
+    {
+        ecc_blob = (BCRYPT_ECCKEY_BLOB *)buf;
+        ecc_blob->dwMagic = magic;
+        ecc_blob->cbKey   = size;
+
+        dst = (UCHAR *)(ecc_blob + 1);
+        export_gnutls_datum( dst, size, &x, NULL );
+        dst += size;
+
+        export_gnutls_datum( dst, size, &y, NULL );
+        dst += size;
+
+        export_gnutls_datum( dst, size, &d, NULL );
+    }
+
+    free( x.data ); free( y.data ); free( d.data );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_import_ecc( struct key *key, UCHAR *buf, ULONG len )
+{
+    BCRYPT_ECCKEY_BLOB *ecc_blob;
+    gnutls_ecc_curve_t curve;
+    gnutls_privkey_t handle;
+    gnutls_datum_t x, y, k;
+    NTSTATUS status;
+    int ret;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDH_P256:
+    case ALG_ID_ECDSA_P256:
+        curve = GNUTLS_ECC_CURVE_SECP256R1;
+        break;
+
+    default:
+        FIXME( "algorithm %u not yet supported\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((ret = pgnutls_privkey_init( &handle )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    ecc_blob = (BCRYPT_ECCKEY_BLOB *)buf;
+    x.data = (unsigned char *)(ecc_blob + 1);
+    x.size = ecc_blob->cbKey;
+    y.data = x.data + ecc_blob->cbKey;
+    y.size = ecc_blob->cbKey;
+    k.data = y.data + ecc_blob->cbKey;
+    k.size = ecc_blob->cbKey;
+
+    if ((ret = pgnutls_privkey_import_ecc_raw( handle, curve, &x, &y, &k )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_privkey_deinit( handle );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if ((status = export_gnutls_pubkey_ecc( handle, key->alg_id, &key->u.a.pubkey, &key->u.a.pubkey_len )))
+    {
+        pgnutls_privkey_deinit( handle );
+        return status;
+    }
+
+    key_data(key)->privkey = handle;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_import_rsa( struct key *key, UCHAR *buf, ULONG len )
+{
+    BCRYPT_RSAKEY_BLOB *rsa_blob = (BCRYPT_RSAKEY_BLOB *)buf;
+    gnutls_datum_t m, e, p, q;
+    gnutls_privkey_t handle;
+    int ret;
+
+    if ((ret = pgnutls_privkey_init( &handle )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    e.data = (unsigned char *)(rsa_blob + 1);
+    e.size = rsa_blob->cbPublicExp;
+    m.data = e.data + e.size;
+    m.size = rsa_blob->cbModulus;
+    p.data = m.data + m.size;
+    p.size = rsa_blob->cbPrime1;
+    q.data = p.data + p.size;
+    q.size = rsa_blob->cbPrime2;
+
+    if ((ret = pgnutls_privkey_import_rsa_raw( handle, &m, &e, NULL, &p, &q, NULL, NULL, NULL )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_privkey_deinit( handle );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    key_data(key)->privkey = handle;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_export_dsa_capi( struct key *key, UCHAR *buf, ULONG len, ULONG *ret_len )
+{
+    BLOBHEADER *hdr;
+    DSSPUBKEY *pubkey;
+    gnutls_datum_t p, q, g, y, x;
+    UCHAR *dst;
+    int ret, size;
+
+    if ((ret = pgnutls_privkey_export_dsa_raw( key_data(key)->privkey, &p, &q, &g, &y, &x )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if (q.size > 21 || x.size > 21)
+    {
+        ERR( "can't export key in this format\n" );
+        free( p.data ); free( q.data ); free( g.data ); free( y.data ); free( x.data );
+        return STATUS_NOT_SUPPORTED;
+    }
+
+    size = key->u.a.bitlen / 8;
+    *ret_len = sizeof(*hdr) + sizeof(*pubkey) + size * 2 + 40 + sizeof(key->u.a.dss_seed);
+    if (len >= *ret_len && buf)
+    {
+        hdr = (BLOBHEADER *)buf;
+        hdr->bType    = PRIVATEKEYBLOB;
+        hdr->bVersion = 2;
+        hdr->reserved = 0;
+        hdr->aiKeyAlg = CALG_DSS_SIGN;
+
+        pubkey = (DSSPUBKEY *)(hdr + 1);
+        pubkey->magic  = MAGIC_DSS2;
+        pubkey->bitlen = key->u.a.bitlen;
+
+        dst = (UCHAR *)(pubkey + 1);
+        export_gnutls_datum( dst, size, &p, NULL );
+        reverse_bytes( dst, size );
+        dst += size;
+
+        export_gnutls_datum( dst, 20, &q, NULL );
+        reverse_bytes( dst, 20 );
+        dst += 20;
+
+        export_gnutls_datum( dst, size, &g, NULL );
+        reverse_bytes( dst, size );
+        dst += size;
+
+        export_gnutls_datum( dst, 20, &x, NULL );
+        reverse_bytes( dst, 20 );
+        dst += 20;
+
+        memcpy( dst, &key->u.a.dss_seed, sizeof(key->u.a.dss_seed) );
+    }
+
+    free( p.data ); free( q.data ); free( g.data ); free( y.data ); free( x.data );
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_import_dsa_capi( struct key *key, UCHAR *buf, ULONG len )
+{
+    BLOBHEADER *hdr = (BLOBHEADER *)buf;
+    DSSPUBKEY *pubkey;
+    gnutls_privkey_t handle;
+    gnutls_datum_t p, q, g, y, x;
+    unsigned char dummy[128];
+    unsigned char *data, p_data[128], q_data[20], g_data[128], x_data[20];
+    int i, ret, size;
+    NTSTATUS status;
+
+    if ((ret = pgnutls_privkey_init( &handle )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    hdr = (BLOBHEADER *)buf;
+    pubkey = (DSSPUBKEY *)(hdr + 1);
+    if ((size = pubkey->bitlen / 8) > sizeof(p_data))
+    {
+        FIXME( "size %u not supported\n", size );
+        pgnutls_privkey_deinit( handle );
+        return STATUS_NOT_SUPPORTED;
+    }
+    data = (unsigned char *)(pubkey + 1);
+
+    p.data = p_data;
+    p.size = size;
+    for (i = 0; i < p.size; i++) p.data[i] = data[p.size - i - 1];
+    data += p.size;
+
+    q.data = q_data;
+    q.size = sizeof(q_data);
+    for (i = 0; i < q.size; i++) q.data[i] = data[q.size - i - 1];
+    data += q.size;
+
+    g.data = g_data;
+    g.size = size;
+    for (i = 0; i < g.size; i++) g.data[i] = data[g.size - i - 1];
+    data += g.size;
+
+    x.data = x_data;
+    x.size = sizeof(x_data);
+    for (i = 0; i < x.size; i++) x.data[i] = data[x.size - i - 1];
+    data += x.size;
+
+    WARN( "using dummy public key\n" );
+    memset( dummy, 1, sizeof(dummy) );
+    y.data = dummy;
+    y.size = min( p.size, sizeof(dummy) );
+
+    if ((ret = pgnutls_privkey_import_dsa_raw( handle, &p, &q, &g, &y, &x )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_privkey_deinit( handle );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    if ((status = export_gnutls_pubkey_dsa_capi( handle, &key->u.a.dss_seed, key->u.a.bitlen, &key->u.a.pubkey,
+                                                 &key->u.a.pubkey_len )))
+    {
+        pgnutls_privkey_deinit( handle );
+        return status;
+    }
+
+    memcpy( &key->u.a.dss_seed, data, sizeof(key->u.a.dss_seed) );
+
+    key->u.a.flags |= KEY_FLAG_LEGACY_DSA_V2;
+    key_data(key)->privkey = handle;
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_asymmetric_init( struct key *key )
+{
+    if (!libgnutls_handle) return STATUS_INTERNAL_ERROR;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDH_P256:
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+    case ALG_ID_DSA:
+        return STATUS_SUCCESS;
+
+    default:
+        FIXME( "algorithm %u not supported\n", key->alg_id );
+        return STATUS_NOT_SUPPORTED;
+    }
+}
+
+static NTSTATUS import_gnutls_pubkey_ecc( struct key *key, gnutls_pubkey_t *gnutls_key )
+{
+    BCRYPT_ECCKEY_BLOB *ecc_blob;
+    gnutls_ecc_curve_t curve;
+    gnutls_datum_t x, y;
+    int ret;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDSA_P256: curve = GNUTLS_ECC_CURVE_SECP256R1; break;
+    case ALG_ID_ECDSA_P384: curve = GNUTLS_ECC_CURVE_SECP384R1; break;
+
+    default:
+        FIXME( "algorithm %u not yet supported\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((ret = pgnutls_pubkey_init( gnutls_key )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    ecc_blob = (BCRYPT_ECCKEY_BLOB *)key->u.a.pubkey;
+    x.data = key->u.a.pubkey + sizeof(*ecc_blob);
+    x.size = ecc_blob->cbKey;
+    y.data = key->u.a.pubkey + sizeof(*ecc_blob) + ecc_blob->cbKey;
+    y.size = ecc_blob->cbKey;
+
+    if ((ret = pgnutls_pubkey_import_ecc_raw( *gnutls_key, curve, &x, &y )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_pubkey_deinit( *gnutls_key );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS import_gnutls_pubkey_rsa( struct key *key, gnutls_pubkey_t *gnutls_key )
+{
+    BCRYPT_RSAKEY_BLOB *rsa_blob;
+    gnutls_datum_t m, e;
+    int ret;
+
+    if ((ret = pgnutls_pubkey_init( gnutls_key )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    rsa_blob = (BCRYPT_RSAKEY_BLOB *)key->u.a.pubkey;
+    e.data = key->u.a.pubkey + sizeof(*rsa_blob);
+    e.size = rsa_blob->cbPublicExp;
+    m.data = key->u.a.pubkey + sizeof(*rsa_blob) + rsa_blob->cbPublicExp;
+    m.size = rsa_blob->cbModulus;
+
+    if ((ret = pgnutls_pubkey_import_rsa_raw( *gnutls_key, &m, &e )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_pubkey_deinit( *gnutls_key );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS import_gnutls_pubkey_dsa( struct key *key, gnutls_pubkey_t *gnutls_key )
+{
+    BCRYPT_DSA_KEY_BLOB *dsa_blob;
+    gnutls_datum_t p, q, g, y;
+    int ret;
+
+    if ((ret = pgnutls_pubkey_init( gnutls_key )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    dsa_blob = (BCRYPT_DSA_KEY_BLOB *)key->u.a.pubkey;
+    p.data = key->u.a.pubkey + sizeof(*dsa_blob);
+    p.size = dsa_blob->cbKey;
+    q.data = dsa_blob->q;
+    q.size = sizeof(dsa_blob->q);
+    g.data = key->u.a.pubkey + sizeof(*dsa_blob) + dsa_blob->cbKey;
+    g.size = dsa_blob->cbKey;
+    y.data = key->u.a.pubkey + sizeof(*dsa_blob) + dsa_blob->cbKey * 2;
+    y.size = dsa_blob->cbKey;
+
+    if ((ret = pgnutls_pubkey_import_dsa_raw( *gnutls_key, &p, &q, &g, &y )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_pubkey_deinit( *gnutls_key );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS import_gnutls_pubkey_dsa_capi( struct key *key, gnutls_pubkey_t *gnutls_key )
+{
+    BLOBHEADER *hdr;
+    DSSPUBKEY *pubkey;
+    gnutls_datum_t p, q, g, y;
+    unsigned char *data, p_data[128], q_data[20], g_data[128], y_data[128];
+    int i, ret, size;
+
+    if ((ret = pgnutls_pubkey_init( gnutls_key )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    hdr = (BLOBHEADER *)key->u.a.pubkey;
+    pubkey = (DSSPUBKEY *)(hdr + 1);
+    size = pubkey->bitlen / 8;
+    data = (unsigned char *)(pubkey + 1);
+
+    p.data = p_data;
+    p.size = size;
+    for (i = 0; i < p.size; i++) p.data[i] = data[p.size - i - 1];
+    data += p.size;
+
+    q.data = q_data;
+    q.size = sizeof(q_data);
+    for (i = 0; i < q.size; i++) q.data[i] = data[q.size - i - 1];
+    data += q.size;
+
+    g.data = g_data;
+    g.size = size;
+    for (i = 0; i < g.size; i++) g.data[i] = data[g.size - i - 1];
+    data += g.size;
+
+    y.data = y_data;
+    y.size = sizeof(y_data);
+    for (i = 0; i < y.size; i++) y.data[i] = data[y.size - i - 1];
+
+    if ((ret = pgnutls_pubkey_import_dsa_raw( *gnutls_key, &p, &q, &g, &y )))
+    {
+        pgnutls_perror( ret );
+        pgnutls_pubkey_deinit( *gnutls_key );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS import_gnutls_pubkey( struct key *key, gnutls_pubkey_t *gnutls_key )
+{
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+        return import_gnutls_pubkey_ecc( key, gnutls_key );
+
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+        return import_gnutls_pubkey_rsa( key, gnutls_key );
+
+    case ALG_ID_DSA:
+        if (key->u.a.flags & KEY_FLAG_LEGACY_DSA_V2)
+            return import_gnutls_pubkey_dsa_capi( key, gnutls_key );
+        else
+            return import_gnutls_pubkey_dsa( key, gnutls_key );
+
+    default:
+        FIXME("algorithm %u not yet supported\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+}
+
+static NTSTATUS prepare_gnutls_signature_dsa( struct key *key, UCHAR *signature, ULONG signature_len,
+                                              gnutls_datum_t *gnutls_signature )
+{
+    struct buffer buffer;
+    DWORD r_len = signature_len / 2;
+    DWORD s_len = r_len;
+    BYTE *r = signature;
+    BYTE *s = signature + r_len;
+
+    buffer_init( &buffer );
+    buffer_append_asn1_r_s( &buffer, r, r_len, s, s_len );
+    if (buffer.error)
+    {
+        buffer_free( &buffer );
+        return STATUS_NO_MEMORY;
+    }
+
+    gnutls_signature->data = buffer.buffer;
+    gnutls_signature->size = buffer.pos;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS prepare_gnutls_signature_rsa( struct key *key, UCHAR *signature, ULONG signature_len,
+                                              gnutls_datum_t *gnutls_signature )
+{
+    gnutls_signature->data = signature;
+    gnutls_signature->size = signature_len;
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS prepare_gnutls_signature( struct key *key, UCHAR *signature, ULONG signature_len,
+                                          gnutls_datum_t *gnutls_signature )
+{
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+    case ALG_ID_DSA:
+        return prepare_gnutls_signature_dsa( key, signature, signature_len, gnutls_signature );
+
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+        return prepare_gnutls_signature_rsa( key, signature, signature_len, gnutls_signature );
+
+    default:
+        FIXME( "algorithm %u not yet supported\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+}
+
+static gnutls_digest_algorithm_t get_digest_from_id( const WCHAR *alg_id )
+{
+    if (!strcmpW( alg_id, BCRYPT_SHA1_ALGORITHM ))   return GNUTLS_DIG_SHA1;
+    if (!strcmpW( alg_id, BCRYPT_SHA256_ALGORITHM )) return GNUTLS_DIG_SHA256;
+    if (!strcmpW( alg_id, BCRYPT_SHA384_ALGORITHM )) return GNUTLS_DIG_SHA384;
+    if (!strcmpW( alg_id, BCRYPT_SHA512_ALGORITHM )) return GNUTLS_DIG_SHA512;
+    if (!strcmpW( alg_id, BCRYPT_MD2_ALGORITHM ))    return GNUTLS_DIG_MD2;
+    if (!strcmpW( alg_id, BCRYPT_MD5_ALGORITHM ))    return GNUTLS_DIG_MD5;
+    return -1;
+}
+
+static NTSTATUS CDECL key_asymmetric_verify( struct key *key, void *padding, UCHAR *hash, ULONG hash_len,
+                                             UCHAR *signature, ULONG signature_len, DWORD flags )
+{
+    gnutls_digest_algorithm_t hash_alg;
+    gnutls_sign_algorithm_t sign_alg;
+    gnutls_datum_t gnutls_hash, gnutls_signature;
+    gnutls_pk_algorithm_t pk_alg;
+    gnutls_pubkey_t gnutls_key;
+    NTSTATUS status;
+    int ret;
+
+    switch (key->alg_id)
+    {
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+    {
+        if (flags) FIXME( "flags %08x not supported\n", flags );
+
+        /* only the hash size must match, not the actual hash function */
+        switch (hash_len)
+        {
+        case 20: hash_alg = GNUTLS_DIG_SHA1; break;
+        case 32: hash_alg = GNUTLS_DIG_SHA256; break;
+        case 48: hash_alg = GNUTLS_DIG_SHA384; break;
+
+        default:
+            FIXME( "hash size %u not yet supported\n", hash_len );
+            return STATUS_INVALID_SIGNATURE;
+        }
+        pk_alg = GNUTLS_PK_ECC;
+        break;
+    }
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+    {
+        BCRYPT_PKCS1_PADDING_INFO *info = (BCRYPT_PKCS1_PADDING_INFO *)padding;
+
+        if (!(flags & BCRYPT_PAD_PKCS1) || !info) return STATUS_INVALID_PARAMETER;
+        if (!info->pszAlgId) return STATUS_INVALID_SIGNATURE;
+
+        if ((hash_alg = get_digest_from_id(info->pszAlgId)) == -1)
+        {
+            FIXME( "hash algorithm %s not supported\n", debugstr_w(info->pszAlgId) );
+            return STATUS_NOT_SUPPORTED;
+        }
+        pk_alg = GNUTLS_PK_RSA;
+        break;
+    }
+    case ALG_ID_DSA:
+    {
+        if (flags) FIXME( "flags %08x not supported\n", flags );
+        if (hash_len != 20)
+        {
+            FIXME( "hash size %u not supported\n", hash_len );
+            return STATUS_INVALID_PARAMETER;
+        }
+        hash_alg = GNUTLS_DIG_SHA1;
+        pk_alg = GNUTLS_PK_DSA;
+        break;
+    }
+    default:
+        FIXME( "algorithm %u not yet supported\n", key->alg_id );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((sign_alg = pgnutls_pk_to_sign( pk_alg, hash_alg )) == GNUTLS_SIGN_UNKNOWN)
+    {
+        FIXME("GnuTLS does not support algorithm %u with hash len %u\n", key->alg_id, hash_len );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if ((status = import_gnutls_pubkey( key, &gnutls_key ))) return status;
+    if ((status = prepare_gnutls_signature( key, signature, signature_len, &gnutls_signature )))
+    {
+        pgnutls_pubkey_deinit( gnutls_key );
+        return status;
+    }
+
+    gnutls_hash.data = hash;
+    gnutls_hash.size = hash_len;
+    ret = pgnutls_pubkey_verify_hash2( gnutls_key, sign_alg, 0, &gnutls_hash, &gnutls_signature );
+
+    if (gnutls_signature.data != signature) free( gnutls_signature.data );
+    pgnutls_pubkey_deinit( gnutls_key );
+    return (ret < 0) ? STATUS_INVALID_SIGNATURE : STATUS_SUCCESS;
+}
+
+static unsigned int get_signature_length( enum alg_id id )
+{
+    switch (id)
+    {
+    case ALG_ID_ECDSA_P256: return 64;
+    case ALG_ID_ECDSA_P384: return 96;
+    case ALG_ID_DSA:        return 40;
+    default:
+        FIXME( "unhandled algorithm %u\n", id );
+        return 0;
+    }
+}
+
+static NTSTATUS format_gnutls_signature( enum alg_id type, gnutls_datum_t signature,
+                                         UCHAR *output, ULONG output_len, ULONG *ret_len )
+{
+    switch (type)
+    {
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+    {
+        *ret_len = signature.size;
+        if (output_len < signature.size) return STATUS_BUFFER_TOO_SMALL;
+        if (output) memcpy( output, signature.data, signature.size );
+        return STATUS_SUCCESS;
+    }
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+    case ALG_ID_DSA:
+    {
+        int err;
+        unsigned int sig_len = get_signature_length( type );
+        gnutls_datum_t r, s; /* format as r||s */
+
+        if ((err = pgnutls_decode_rs_value( &signature, &r, &s )))
+        {
+            pgnutls_perror( err );
+            return STATUS_INTERNAL_ERROR;
+        }
+
+        *ret_len = sig_len;
+        if (output_len < sig_len) return STATUS_BUFFER_TOO_SMALL;
+
+        if (r.size > sig_len / 2 + 1 || s.size > sig_len / 2 + 1)
+        {
+            ERR( "we didn't get a correct signature\n" );
+            return STATUS_INTERNAL_ERROR;
+        }
+
+        if (output)
+        {
+            export_gnutls_datum( output, sig_len / 2, &r, NULL );
+            export_gnutls_datum( output + sig_len / 2, sig_len / 2, &s, NULL );
+        }
+
+        free( r.data ); free( s.data );
+        return STATUS_SUCCESS;
+    }
+    default:
+        return STATUS_INTERNAL_ERROR;
+    }
+}
+
+static NTSTATUS CDECL key_asymmetric_sign( struct key *key, void *padding, UCHAR *input, ULONG input_len, UCHAR *output,
+                                           ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    BCRYPT_PKCS1_PADDING_INFO *pad = padding;
+    gnutls_datum_t hash, signature;
+    gnutls_digest_algorithm_t hash_alg;
+    NTSTATUS status;
+    int ret;
+
+    if (key->alg_id == ALG_ID_ECDSA_P256 || key->alg_id == ALG_ID_ECDSA_P384)
+    {
+        /* With ECDSA, we find the digest algorithm from the hash length, and verify it */
+        switch (input_len)
+        {
+        case 20: hash_alg = GNUTLS_DIG_SHA1; break;
+        case 32: hash_alg = GNUTLS_DIG_SHA256; break;
+        case 48: hash_alg = GNUTLS_DIG_SHA384; break;
+        case 64: hash_alg = GNUTLS_DIG_SHA512; break;
+
+        default:
+            FIXME( "hash size %u not yet supported\n", input_len );
+            return STATUS_INVALID_PARAMETER;
+        }
+
+        if (flags == BCRYPT_PAD_PKCS1 && pad && pad->pszAlgId && get_digest_from_id( pad->pszAlgId ) != hash_alg)
+        {
+            WARN( "incorrect hashing algorithm %s, expected %u\n", debugstr_w(pad->pszAlgId), hash_alg );
+            return STATUS_INVALID_PARAMETER;
+        }
+    }
+    else if (key->alg_id == ALG_ID_DSA)
+    {
+        if (flags) FIXME( "flags %08x not supported\n", flags );
+        if (input_len != 20)
+        {
+            FIXME( "hash size %u not supported\n", input_len );
+            return STATUS_INVALID_PARAMETER;
+        }
+        hash_alg = GNUTLS_DIG_SHA1;
+    }
+    else if (flags == BCRYPT_PAD_PKCS1)
+    {
+        if (!pad || !pad->pszAlgId)
+        {
+            WARN( "padding info not found\n" );
+            return STATUS_INVALID_PARAMETER;
+        }
+
+        if ((hash_alg = get_digest_from_id( pad->pszAlgId )) == -1)
+        {
+            FIXME( "hash algorithm %s not recognized\n", debugstr_w(pad->pszAlgId) );
+            return STATUS_NOT_SUPPORTED;
+        }
+    }
+    else if (!flags)
+    {
+         WARN( "invalid flags %08x\n", flags );
+         return STATUS_INVALID_PARAMETER;
+    }
+    else
+    {
+        FIXME( "flags %08x not implemented\n", flags );
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
+    if (!input)
+    {
+        *ret_len = key->u.a.bitlen / 8;
+        return STATUS_SUCCESS;
+    }
+    if (!key_data(key)->privkey) return STATUS_INVALID_PARAMETER;
+
+    hash.data = input;
+    hash.size = input_len;
+
+    signature.data = NULL;
+    signature.size = 0;
+
+    if ((ret = pgnutls_privkey_sign_hash( key_data(key)->privkey, hash_alg, 0, &hash, &signature )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    status = format_gnutls_signature( key->alg_id, signature, output, output_len, ret_len );
+
+    free( signature.data );
+    return status;
+}
+
+static void CDECL key_asymmetric_destroy( struct key *key )
+{
+    if (key_data(key)->privkey) pgnutls_privkey_deinit( key_data(key)->privkey );
+}
+
+static NTSTATUS CDECL key_asymmetric_duplicate( struct key *key_orig, struct key *key_copy )
+{
+    int ret;
+
+    if (!key_data(key_orig)->privkey) return STATUS_SUCCESS;
+
+    if ((ret = pgnutls_privkey_init( &key_data(key_copy)->privkey )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    switch (key_orig->alg_id)
+    {
+    case ALG_ID_RSA:
+    case ALG_ID_RSA_SIGN:
+    {
+        gnutls_datum_t m, e, d, p, q, u, e1, e2;
+        if ((ret = pgnutls_privkey_export_rsa_raw( key_data(key_orig)->privkey, &m, &e, &d, &p, &q, &u, &e1, &e2 )))
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        ret = pgnutls_privkey_import_rsa_raw( key_data(key_copy)->privkey, &m, &e, &d, &p, &q, &u, &e1, &e2 );
+        free( m.data ); free( e.data ); free( d.data ); free( p.data ); free( q.data ); free( u.data );
+        free( e1.data ); free( e2.data );
+        if (ret)
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        break;
+    }
+    case ALG_ID_DSA:
+    {
+        gnutls_datum_t p, q, g, y, x;
+        if ((ret = pgnutls_privkey_export_dsa_raw( key_data(key_orig)->privkey, &p, &q, &g, &y, &x )))
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        ret = pgnutls_privkey_import_dsa_raw( key_data(key_copy)->privkey, &p, &q, &g, &y, &x );
+        free( p.data ); free( q.data ); free( g.data ); free( y.data ); free( x.data );
+        if (ret)
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        break;
+    }
+    case ALG_ID_ECDH_P256:
+    case ALG_ID_ECDSA_P256:
+    case ALG_ID_ECDSA_P384:
+    {
+        gnutls_ecc_curve_t curve;
+        gnutls_datum_t x, y, k;
+        if ((ret = pgnutls_privkey_export_ecc_raw( key_data(key_orig)->privkey, &curve, &x, &y, &k )))
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        ret = pgnutls_privkey_import_ecc_raw( key_data(key_copy)->privkey, curve, &x, &y, &k );
+        free( x.data ); free( y.data ); free( k.data );
+        if (ret)
+        {
+            pgnutls_perror( ret );
+            return STATUS_INTERNAL_ERROR;
+        }
+        break;
+    }
+    default:
+        ERR( "unhandled algorithm %u\n", key_orig->alg_id );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_asymmetric_decrypt( struct key *key, UCHAR *input, ULONG input_len, UCHAR *output,
+                                              ULONG output_len, ULONG *ret_len )
+{
+    gnutls_datum_t e, d = { 0 };
+    NTSTATUS status = STATUS_SUCCESS;
+    int ret;
+
+    e.data = input;
+    e.size = input_len;
+    if ((ret = pgnutls_privkey_decrypt_data( key_data(key)->privkey, 0, &e, &d )))
+    {
+        pgnutls_perror( ret );
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    *ret_len = d.size;
+    if (output_len >= d.size) memcpy( output, d.data, *ret_len );
+    else status = STATUS_BUFFER_TOO_SMALL;
+
+    free( d.data );
+    return status;
+}
+
+static const struct key_funcs key_funcs =
+{
+    key_set_property,
+    key_symmetric_init,
+    key_symmetric_vector_reset,
+    key_symmetric_set_auth_data,
+    key_symmetric_encrypt,
+    key_symmetric_decrypt,
+    key_symmetric_get_tag,
+    key_symmetric_destroy,
+    key_asymmetric_init,
+    key_asymmetric_generate,
+    key_asymmetric_decrypt,
+    key_asymmetric_duplicate,
+    key_asymmetric_sign,
+    key_asymmetric_verify,
+    key_asymmetric_destroy,
+    key_export_dsa_capi,
+    key_export_ecc,
+    key_import_dsa_capi,
+    key_import_ecc,
+    key_import_rsa
+};
+
+NTSTATUS CDECL __wine_init_unix_lib( HMODULE module, DWORD reason, const void *ptr_in, void *ptr_out )
+{
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        if (!gnutls_initialize()) return STATUS_DLL_NOT_FOUND;
+        *(const struct key_funcs **)ptr_out = &key_funcs;
+        break;
+    case DLL_PROCESS_DETACH:
+        if (libgnutls_handle) gnutls_uninitialize();
+        break;
+    }
+    return STATUS_SUCCESS;
+}
+
+#endif /* HAVE_GNUTLS_CIPHER_INIT */

--- a/dll/win32/bcrypt/macos.c
+++ b/dll/win32/bcrypt/macos.c
@@ -1,0 +1,312 @@
+/*
+ * Copyright 2009 Henri Verbeet for CodeWeavers
+ * Copyright 2018 Hans Leidekker for CodeWeavers
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+#if 0
+#pragma makedep unix
+#endif
+
+#include "config.h"
+#include "wine/port.h"
+
+#include <stdarg.h>
+#ifdef HAVE_COMMONCRYPTO_COMMONCRYPTOR_H
+#include <AvailabilityMacros.h>
+#include <CommonCrypto/CommonCryptor.h>
+#endif
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "ntsecapi.h"
+#include "bcrypt.h"
+
+#include "bcrypt_internal.h"
+
+#include "wine/debug.h"
+#include "wine/unicode.h"
+
+#if defined(HAVE_COMMONCRYPTO_COMMONCRYPTOR_H) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1080 && !defined(HAVE_GNUTLS_CIPHER_INIT)
+WINE_DEFAULT_DEBUG_CHANNEL(bcrypt);
+
+struct key_data
+{
+    CCCryptorRef   ref_encrypt;
+    CCCryptorRef   ref_decrypt;
+};
+C_ASSERT( sizeof(struct key_data) <= sizeof(((struct key *)0)->private) );
+
+static struct key_data *key_data( struct key *key )
+{
+    return (struct key_data *)key->private;
+}
+
+static NTSTATUS CDECL key_set_property( struct key *key, const WCHAR *prop, UCHAR *value, ULONG size, ULONG flags )
+{
+    if (!strcmpW( prop, BCRYPT_CHAINING_MODE ))
+    {
+        if (!strcmpW( (WCHAR *)value, BCRYPT_CHAIN_MODE_ECB ))
+        {
+            key->u.s.mode = MODE_ID_ECB;
+            return STATUS_SUCCESS;
+        }
+        else if (!strcmpW( (WCHAR *)value, BCRYPT_CHAIN_MODE_CBC ))
+        {
+            key->u.s.mode = MODE_ID_CBC;
+            return STATUS_SUCCESS;
+        }
+        else
+        {
+            FIXME( "unsupported mode %s\n", debugstr_w((WCHAR *)value) );
+            return STATUS_NOT_IMPLEMENTED;
+        }
+    }
+
+    FIXME( "unsupported key property %s\n", debugstr_w(prop) );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_init( struct key *key )
+{
+    switch (key->alg_id)
+    {
+    case ALG_ID_AES:
+        switch (key->u.s.mode)
+        {
+        case MODE_ID_ECB:
+        case MODE_ID_CBC:
+            break;
+        default:
+            FIXME( "mode %u not supported\n", key->u.s.mode );
+            return STATUS_NOT_SUPPORTED;
+        }
+        return STATUS_SUCCESS;
+
+    default:
+        FIXME( "algorithm %u not supported\n", key->alg_id );
+        return STATUS_NOT_SUPPORTED;
+    }
+}
+
+static CCMode get_cryptor_mode( struct key *key )
+{
+    switch (key->u.s.mode)
+    {
+    case MODE_ID_ECB: return kCCModeECB;
+    case MODE_ID_CBC: return kCCModeCBC;
+    default:
+        FIXME( "unsupported mode %u\n", key->u.s.mode );
+        return 0;
+    }
+}
+
+static void CDECL key_symmetric_vector_reset( struct key *key )
+{
+    if (!key_data(key)->ref_encrypt) return;
+
+    TRACE( "invalidating cryptor handles\n" );
+    CCCryptorRelease( key_data(key)->ref_encrypt );
+    key_data(key)->ref_encrypt = NULL;
+
+    CCCryptorRelease( key_data(key)->ref_decrypt );
+    key_data(key)->ref_decrypt = NULL;
+}
+
+static NTSTATUS init_cryptor_handles( struct key *key )
+{
+    CCCryptorStatus status;
+    CCMode mode;
+
+    if (key_data(key)->ref_encrypt) return STATUS_SUCCESS;
+    if (!(mode = get_cryptor_mode( key ))) return STATUS_NOT_SUPPORTED;
+
+    if ((status = CCCryptorCreateWithMode( kCCEncrypt, mode, kCCAlgorithmAES128, ccNoPadding, key->u.s.vector,
+                                           key->u.s.secret, key->u.s.secret_len, NULL, 0, 0, 0,
+                                           &key_data(key)->ref_encrypt )) != kCCSuccess)
+    {
+        WARN( "CCCryptorCreateWithMode failed %d\n", status );
+        return STATUS_INTERNAL_ERROR;
+    }
+    if ((status = CCCryptorCreateWithMode( kCCDecrypt, mode, kCCAlgorithmAES128, ccNoPadding, key->u.s.vector,
+                                           key->u.s.secret, key->u.s.secret_len, NULL, 0, 0, 0,
+                                           &key_data(key)->ref_decrypt )) != kCCSuccess)
+    {
+        WARN( "CCCryptorCreateWithMode failed %d\n", status );
+        CCCryptorRelease( key_data(key)->ref_encrypt );
+        key_data(key)->ref_encrypt = NULL;
+        return STATUS_INTERNAL_ERROR;
+    }
+
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_set_auth_data( struct key *key, UCHAR *auth_data, ULONG len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_encrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len  )
+{
+    CCCryptorStatus status;
+    NTSTATUS ret;
+
+    if ((ret = init_cryptor_handles( key ))) return ret;
+
+    if ((status = CCCryptorUpdate( key_data(key)->ref_encrypt, input, input_len, output, output_len, NULL  )) != kCCSuccess)
+    {
+        WARN( "CCCryptorUpdate failed %d\n", status );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_decrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len )
+{
+    CCCryptorStatus status;
+    NTSTATUS ret;
+
+    if ((ret = init_cryptor_handles( key ))) return ret;
+
+    if ((status = CCCryptorUpdate( key_data(key)->ref_decrypt, input, input_len, output, output_len, NULL  )) != kCCSuccess)
+    {
+        WARN( "CCCryptorUpdate failed %d\n", status );
+        return STATUS_INTERNAL_ERROR;
+    }
+    return STATUS_SUCCESS;
+}
+
+static NTSTATUS CDECL key_symmetric_get_tag( struct key *key, UCHAR *tag, ULONG len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static void CDECL key_symmetric_destroy( struct key *key )
+{
+    if (key_data(key)->ref_encrypt) CCCryptorRelease( key_data(key)->ref_encrypt );
+    if (key_data(key)->ref_decrypt) CCCryptorRelease( key_data(key)->ref_decrypt );
+}
+
+static NTSTATUS CDECL key_asymmetric_init( struct key *key )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_sign( struct key *key, void *padding, UCHAR *input, ULONG input_len, UCHAR *output,
+                                           ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_verify( struct key *key, void *padding, UCHAR *hash, ULONG hash_len,
+                                             UCHAR *signature, ULONG signature_len, DWORD flags )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_export_dsa_capi( struct key *key, UCHAR *buf, ULONG len, ULONG *ret_len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_export_ecc( struct key *key, UCHAR *output, ULONG len, ULONG *ret_len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_dsa_capi( struct key *key, UCHAR *buf, ULONG len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_ecc( struct key *key, UCHAR *input, ULONG len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_rsa( struct key *key, UCHAR *input, ULONG len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_generate( struct key *key )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static void CDECL key_asymmetric_destroy( struct key *key )
+{
+}
+
+static NTSTATUS CDECL key_asymmetric_duplicate( struct key *key_orig, struct key *key_copy )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_decrypt( struct key *key, UCHAR *input, ULONG input_len,
+        UCHAR *output, ULONG *output_len )
+{
+    FIXME( "not implemented on Mac\n" );
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static const struct key_funcs key_funcs =
+{
+    key_set_property,
+    key_symmetric_init,
+    key_symmetric_vector_reset,
+    key_symmetric_set_auth_data,
+    key_symmetric_encrypt,
+    key_symmetric_decrypt,
+    key_symmetric_get_tag,
+    key_symmetric_destroy,
+    key_asymmetric_init,
+    key_asymmetric_generate,
+    key_asymmetric_decrypt,
+    key_asymmetric_duplicate,
+    key_asymmetric_sign,
+    key_asymmetric_verify,
+    key_asymmetric_destroy,
+    key_export_dsa_capi,
+    key_export_ecc,
+    key_import_dsa_capi,
+    key_import_ecc,
+    key_import_rsa
+};
+
+NTSTATUS CDECL __wine_init_unix_lib( HMODULE module, DWORD reason, const void *ptr_in, void *ptr_out )
+{
+    if (reason != DLL_PROCESS_ATTACH) return STATUS_SUCCESS;
+    *(const struct key_funcs **)ptr_out = &key_funcs;
+    return STATUS_SUCCESS;
+}
+
+#endif

--- a/dll/win32/bcrypt/mbedtls.c
+++ b/dll/win32/bcrypt/mbedtls.c
@@ -1,0 +1,272 @@
+/*
+ * Copyright 2009 Henri Verbeet for CodeWeavers
+ * Copyright 2018 Hans Leidekker for CodeWeavers
+ * Copyright 2021 Micah Andersen & ReactOS Team
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+
+#include "config.h"
+#include "wine/port.h"
+
+#ifndef SONAME_LIBMBEDTLS
+#define SONAME_LIBMBEDTLS
+#endif
+
+#ifdef SONAME_LIBMBEDTLS
+
+#include <stdarg.h>
+#include <assert.h>
+
+#include <mbedtls/md.h>
+#include <mbedtls/md5.h>
+#include <mbedtls/sha1.h>
+#include <mbedtls/sha256.h>
+#include <mbedtls/sha512.h>
+#include <mbedtls/ecdsa.h>
+
+#include "ntstatus.h"
+#define WIN32_NO_STATUS
+#include "windef.h"
+#include "winbase.h"
+#include "ntsecapi.h"
+#include "wincrypt.h"
+#include "bcrypt.h"
+
+#include "bcrypt_internal.h"
+
+#include "wine/debug.h"
+#include "wine/unicode.h"
+#include "wine/library.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(bcrypt);
+WINE_DECLARE_DEBUG_CHANNEL(winediag);
+
+#ifdef __GNUC__         //runtime loaded version (wine-preferred) only works with GCC
+
+void *libmbedtls_handle;
+
+#define MAKE_FUNCPTR(f) static typeof(f) *p##f
+MAKE_FUNCPTR(mbedtls_md_init);
+//imports go here
+#undef MAKE_FUNCPTR
+
+#define mbedtls_md_init             pmbedtls_md_init
+//imports go here
+
+static BOOL mbedtls_initialize(void)
+{
+    if (!(libmbedtls_handle = wine_dlopen( SONAME_LIBMBEDTLS, RTLD_NOW, NULL, 0 )))
+    {
+        ERR_(winediag)( "failed to load libmbedtls, no support for crypto hashes\n" );
+        return FALSE;
+    }
+
+#define LOAD_FUNCPTR(f) \
+    if (!(p##f = wine_dlsym( libmbedtls_handle, #f, NULL, 0 ))) \
+    { \
+        ERR( "failed to load %s\n", #f ); \
+        goto fail; \
+    }
+
+    LOAD_FUNCPTR(mbedtls_md_init)
+    //imports go here
+#undef LOAD_FUNCPTR
+
+    return TRUE;
+
+fail:
+    wine_dlclose( libmbedtls_handle, NULL, 0 );
+    libmbedtls_handle = NULL;
+    return FALSE;
+}
+
+static void mbedtls_uninitialize(void)
+{
+    wine_dlclose( libmbedtls_handle, NULL, 0 );
+    libmbedtls_handle = NULL;
+}
+#endif /* GNUC */
+
+
+static NTSTATUS CDECL key_set_property( struct key *key, const WCHAR *prop, UCHAR *value, ULONG size, ULONG flags )
+{
+    FIXME("key_set_property stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_init( struct key *key )
+{
+    FIXME("key_symmetric_init stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static void CDECL key_symmetric_vector_reset( struct key *key )
+{
+    FIXME("key_symmetric_vector_reset stub\n");
+    return; // STATUS_NOT_IMPLEMENTED
+}
+
+static NTSTATUS CDECL key_symmetric_set_auth_data( struct key *key, UCHAR *auth_data, ULONG len )
+{
+    FIXME("key_symmetric_set_auth_data stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_encrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len )
+{
+    FIXME("key_symmetric_encrypt stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_decrypt( struct key *key, const UCHAR *input, ULONG input_len, UCHAR *output, ULONG output_len  )
+{
+    FIXME("key_symmetric_decrypt stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_symmetric_get_tag( struct key *key, UCHAR *tag, ULONG len )
+{
+    FIXME("key_symmetric_get_tag stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static void CDECL key_symmetric_destroy( struct key *key )
+{
+    FIXME("key_symmetric_destroy stub\n");
+    return; // STATUS_NOT_IMPLEMENTED
+}
+
+static NTSTATUS CDECL key_asymmetric_generate( struct key *key )
+{
+    FIXME("key_asymmetric_generate stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_export_ecc( struct key *key, UCHAR *buf, ULONG len, ULONG *ret_len )
+{
+    FIXME("key_export_ecc stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_ecc( struct key *key, UCHAR *buf, ULONG len )
+{
+    FIXME("key_import_ecc stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_rsa( struct key *key, UCHAR *buf, ULONG len )
+{
+    FIXME("key_import_rsa stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_export_dsa_capi( struct key *key, UCHAR *buf, ULONG len, ULONG *ret_len )
+{
+    FIXME("key_export_dsa_capi stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_import_dsa_capi( struct key *key, UCHAR *buf, ULONG len )
+{
+    FIXME("key_import_dsa_capi stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_init( struct key *key )
+{
+    FIXME("key_asymmetric_init stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_verify( struct key *key, void *padding, UCHAR *hash, ULONG hash_len,
+                                             UCHAR *signature, ULONG signature_len, DWORD flags )
+{
+    FIXME("key_asymmetric_verify stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_sign( struct key *key, void *padding, UCHAR *input, ULONG input_len, UCHAR *output,
+                                           ULONG output_len, ULONG *ret_len, ULONG flags )
+{
+    FIXME("key_asymmetric_sign stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static void CDECL key_asymmetric_destroy( struct key *key )
+{
+    FIXME("key_asymmetric_destroy stub\n");
+    return; // STATUS_NOT_IMPLEMENTED
+}
+
+static NTSTATUS CDECL key_asymmetric_duplicate( struct key *key_orig, struct key *key_copy )
+{
+    FIXME("key_asymmetric_duplicate stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static NTSTATUS CDECL key_asymmetric_decrypt( struct key *key, UCHAR *input, ULONG input_len, UCHAR *output,
+                                              ULONG output_len, ULONG *ret_len )
+{
+    FIXME("key_asymmetric_decrypt stub\n");
+    return STATUS_NOT_IMPLEMENTED;
+}
+
+static const struct key_funcs key_funcs =
+{
+    key_set_property,
+    key_symmetric_init,
+    key_symmetric_vector_reset,
+    key_symmetric_set_auth_data,
+    key_symmetric_encrypt,
+    key_symmetric_decrypt,
+    key_symmetric_get_tag,
+    key_symmetric_destroy,
+    key_asymmetric_init,
+    key_asymmetric_generate,
+    key_asymmetric_decrypt,
+    key_asymmetric_duplicate,
+    key_asymmetric_sign,
+    key_asymmetric_verify,
+    key_asymmetric_destroy,
+    key_export_dsa_capi,
+    key_export_ecc,
+    key_import_dsa_capi,
+    key_import_ecc,
+    key_import_rsa
+};
+
+NTSTATUS CDECL __wine_init_unix_lib( HMODULE module, DWORD reason, const void *ptr_in, void *ptr_out )
+{
+    switch (reason)
+    {
+    case DLL_PROCESS_ATTACH:
+        #ifdef __GNUC__
+        if (!mbedtls_initialize()) return STATUS_DLL_NOT_FOUND;
+        #endif
+        *(const struct key_funcs **)ptr_out = &key_funcs;
+        break;
+    case DLL_PROCESS_DETACH:
+        #ifdef __GNUC__
+        if (libmbedtls_handle) mbedtls_uninitialize();
+        #endif
+        break;
+    }
+    return STATUS_SUCCESS;
+}
+
+#endif /* SONAME_LIBMBEDTLS */

--- a/dll/win32/bcrypt/md2.c
+++ b/dll/win32/bcrypt/md2.c
@@ -1,0 +1,144 @@
+/*
+ * MD2 (RFC 1319) hash function implementation by Tom St Denis
+ *
+ * Copyright 2004 Michael Jung
+ * Based on public domain code by Tom St Denis (tomstdenis@iahu.ca)
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+/*
+ * This file contains code from the LibTomCrypt cryptographic
+ * library written by Tom St Denis (tomstdenis@iahu.ca). LibTomCrypt
+ * is in the public domain. The code in this file is tailored to
+ * special requirements. Take a look at http://libtomcrypt.org for the
+ * original version.
+ */
+
+#include <assert.h>
+#include "bcrypt_internal.h"
+
+static const unsigned char PI_SUBST[256] = {
+  41, 46, 67, 201, 162, 216, 124, 1, 61, 54, 84, 161, 236, 240, 6,
+  19, 98, 167, 5, 243, 192, 199, 115, 140, 152, 147, 43, 217, 188,
+  76, 130, 202, 30, 155, 87, 60, 253, 212, 224, 22, 103, 66, 111, 24,
+  138, 23, 229, 18, 190, 78, 196, 214, 218, 158, 222, 73, 160, 251,
+  245, 142, 187, 47, 238, 122, 169, 104, 121, 145, 21, 178, 7, 63,
+  148, 194, 16, 137, 11, 34, 95, 33, 128, 127, 93, 154, 90, 144, 50,
+  39, 53, 62, 204, 231, 191, 247, 151, 3, 255, 25, 48, 179, 72, 165,
+  181, 209, 215, 94, 146, 42, 172, 86, 170, 198, 79, 184, 56, 210,
+  150, 164, 125, 182, 118, 252, 107, 226, 156, 116, 4, 241, 69, 157,
+  112, 89, 100, 113, 135, 32, 134, 91, 207, 101, 230, 45, 168, 2, 27,
+  96, 37, 173, 174, 176, 185, 246, 28, 70, 97, 105, 52, 64, 126, 15,
+  85, 71, 163, 35, 221, 81, 175, 58, 195, 92, 249, 206, 186, 197,
+  234, 38, 44, 83, 13, 110, 133, 40, 132, 9, 211, 223, 205, 244, 65,
+  129, 77, 82, 106, 220, 55, 200, 108, 193, 171, 250, 36, 225, 123,
+  8, 12, 189, 177, 74, 120, 136, 149, 139, 227, 99, 232, 109, 233,
+  203, 213, 254, 59, 0, 29, 57, 242, 239, 183, 14, 102, 88, 208, 228,
+  166, 119, 114, 248, 235, 117, 75, 10, 49, 68, 80, 180, 143, 237,
+  31, 26, 219, 153, 141, 51, 159, 17, 131, 20
+};
+
+/* adds 16 bytes to the checksum */
+static void md2_update_chksum(MD2_CTX *md2)
+{
+    int j;
+    unsigned char L;
+    L = md2->chksum[15];
+    for (j = 0; j < 16; j++) {
+
+/* caution, the RFC says its "C[j] = S[M[i*16+j] xor L]" but the reference source code [and test vectors] say
+   otherwise.
+*/
+        L = (md2->chksum[j] ^= PI_SUBST[(int)(md2->buf[j] ^ L)] & 255);
+    }
+}
+
+static void md2_compress(MD2_CTX *md2)
+{
+    int j, k;
+    unsigned char t;
+
+    /* copy block */
+    for (j = 0; j < 16; j++) {
+        md2->X[16+j] = md2->buf[j];
+        md2->X[32+j] = md2->X[j] ^ md2->X[16+j];
+    }
+
+    t = 0;
+
+    /* do 18 rounds */
+    for (j = 0; j < 18; j++) {
+        for (k = 0; k < 48; k++) {
+            t = (md2->X[k] ^= PI_SUBST[(int)(t & 255)]);
+        }
+        t = (t + (unsigned char)j) & 255;
+    }
+}
+
+void md2_init(MD2_CTX *md2)
+{
+    /* MD2 uses a zero'ed state... */
+    memset(md2->X, 0, sizeof(md2->X));
+    memset(md2->chksum, 0, sizeof(md2->chksum));
+    memset(md2->buf, 0, sizeof(md2->buf));
+    md2->curlen = 0;
+}
+
+void md2_update(MD2_CTX *md2, const unsigned char *buf, ULONG len)
+{
+    unsigned long n;
+
+    assert(md2->curlen <= sizeof(md2->buf));
+
+    while (len > 0) {
+        n = min(len, (16 - md2->curlen));
+        memcpy(md2->buf + md2->curlen, buf, (size_t)n);
+        md2->curlen += n;
+        buf         += n;
+        len         -= n;
+
+        /* is 16 bytes full? */
+        if (md2->curlen == 16) {
+            md2_compress(md2);
+            md2_update_chksum(md2);
+            md2->curlen = 0;
+        }
+    }
+}
+
+void md2_finalize(MD2_CTX * md2, unsigned char *hash)
+{
+    unsigned long i, k;
+
+    assert(md2->curlen <= sizeof(md2->buf));
+
+    /* pad the message */
+    k = 16 - md2->curlen;
+    for (i = md2->curlen; i < 16; i++) {
+        md2->buf[i] = (unsigned char)k;
+    }
+
+    /* hash and update */
+    md2_compress(md2);
+    md2_update_chksum(md2);
+
+    /* hash checksum */
+    memcpy(md2->buf, md2->chksum, 16);
+    md2_compress(md2);
+
+    /* output is lower 16 bytes of X */
+    memcpy(hash, md2->X, 16);
+}

--- a/dll/win32/bcrypt/sha256.c
+++ b/dll/win32/bcrypt/sha256.c
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2016 Michael Müller
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+/* Based on public domain implementation from
+   https://git.musl-libc.org/cgit/musl/tree/src/crypt/crypt_sha256.c */
+
+#include "bcrypt_internal.h"
+
+static DWORD ror(DWORD n, int k) { return (n >> k) | (n << (32-k)); }
+#define Ch(x,y,z)  (z ^ (x & (y ^ z)))
+#define Maj(x,y,z) ((x & y) | (z & (x | y)))
+#define S0(x)      (ror(x,2) ^ ror(x,13) ^ ror(x,22))
+#define S1(x)      (ror(x,6) ^ ror(x,11) ^ ror(x,25))
+#define R0(x)      (ror(x,7) ^ ror(x,18) ^ (x>>3))
+#define R1(x)      (ror(x,17) ^ ror(x,19) ^ (x>>10))
+
+static const DWORD K[64] =
+{
+  0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
+  0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
+  0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+  0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967,
+  0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85,
+  0xa2bfe8a1, 0xa81a664b, 0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+  0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+  0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2
+};
+
+static void processblock(SHA256_CTX *ctx, const UCHAR *buffer)
+{
+    DWORD W[64], t1, t2, a, b, c, d, e, f, g, h;
+    int i;
+
+    for (i = 0; i < 16; i++)
+    {
+        W[i]  = (DWORD)buffer[4*i]<<24;
+        W[i] |= (DWORD)buffer[4*i+1]<<16;
+        W[i] |= (DWORD)buffer[4*i+2]<<8;
+        W[i] |= buffer[4*i+3];
+    }
+
+    for (; i < 64; i++)
+        W[i] = R1(W[i-2]) + W[i-7] + R0(W[i-15]) + W[i-16];
+
+    a = ctx->h[0];
+    b = ctx->h[1];
+    c = ctx->h[2];
+    d = ctx->h[3];
+    e = ctx->h[4];
+    f = ctx->h[5];
+    g = ctx->h[6];
+    h = ctx->h[7];
+
+    for (i = 0; i < 64; i++)
+    {
+        t1 = h + S1(e) + Ch(e,f,g) + K[i] + W[i];
+        t2 = S0(a) + Maj(a,b,c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    ctx->h[0] += a;
+    ctx->h[1] += b;
+    ctx->h[2] += c;
+    ctx->h[3] += d;
+    ctx->h[4] += e;
+    ctx->h[5] += f;
+    ctx->h[6] += g;
+    ctx->h[7] += h;
+}
+
+static void pad(SHA256_CTX *ctx)
+{
+    ULONG64 r = ctx->len % 64;
+
+    ctx->buf[r++] = 0x80;
+
+    if (r > 56)
+    {
+        memset(ctx->buf + r, 0, 64 - r);
+        r = 0;
+        processblock(ctx, ctx->buf);
+    }
+
+    memset(ctx->buf + r, 0, 56 - r);
+    ctx->len *= 8;
+    ctx->buf[56] = ctx->len >> 56;
+    ctx->buf[57] = ctx->len >> 48;
+    ctx->buf[58] = ctx->len >> 40;
+    ctx->buf[59] = ctx->len >> 32;
+    ctx->buf[60] = ctx->len >> 24;
+    ctx->buf[61] = ctx->len >> 16;
+    ctx->buf[62] = ctx->len >> 8;
+    ctx->buf[63] = ctx->len;
+
+    processblock(ctx, ctx->buf);
+}
+
+void sha256_init(SHA256_CTX *ctx)
+{
+    ctx->len = 0;
+    ctx->h[0] = 0x6a09e667;
+    ctx->h[1] = 0xbb67ae85;
+    ctx->h[2] = 0x3c6ef372;
+    ctx->h[3] = 0xa54ff53a;
+    ctx->h[4] = 0x510e527f;
+    ctx->h[5] = 0x9b05688c;
+    ctx->h[6] = 0x1f83d9ab;
+    ctx->h[7] = 0x5be0cd19;
+}
+
+void sha256_update(SHA256_CTX *ctx, const UCHAR *buffer, ULONG len)
+{
+    const UCHAR *p = buffer;
+    ULONG64 r = ctx->len % 64;
+
+    ctx->len += len;
+    if (r)
+    {
+        if (len < 64 - r)
+        {
+            memcpy(ctx->buf + r, p, len);
+            return;
+        }
+        memcpy(ctx->buf + r, p, 64 - r);
+        len -= 64 - r;
+        p += 64 - r;
+        processblock(ctx, ctx->buf);
+    }
+    for (; len >= 64; len -= 64, p += 64)
+        processblock(ctx, p);
+    memcpy(ctx->buf, p, len);
+}
+
+void sha256_finalize(SHA256_CTX *ctx, UCHAR *buffer)
+{
+    int i;
+
+    pad(ctx);
+    for (i = 0; i < 8; i++)
+    {
+        buffer[4*i]   = ctx->h[i] >> 24;
+        buffer[4*i+1] = ctx->h[i] >> 16;
+        buffer[4*i+2] = ctx->h[i] >> 8;
+        buffer[4*i+3] = ctx->h[i];
+    }
+}

--- a/dll/win32/bcrypt/sha512.c
+++ b/dll/win32/bcrypt/sha512.c
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2016 Michael Müller
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ */
+
+/* Based on public domain implementation from
+   https://git.musl-libc.org/cgit/musl/tree/src/crypt/crypt_sha512.c */
+
+#include "bcrypt_internal.h"
+
+static ULONG64 ror(ULONG64 n, int k) { return (n >> k) | (n << (64-k)); }
+#define Ch(x,y,z)  (z ^ (x & (y ^ z)))
+#define Maj(x,y,z) ((x & y) | (z & (x | y)))
+#define S0(x)      (ror(x,28) ^ ror(x,34) ^ ror(x,39))
+#define S1(x)      (ror(x,14) ^ ror(x,18) ^ ror(x,41))
+#define R0(x)      (ror(x,1) ^ ror(x,8) ^ (x>>7))
+#define R1(x)      (ror(x,19) ^ ror(x,61) ^ (x>>6))
+#define ULL(a,b)   (((ULONG64)(a) << 32) | (b))
+
+static const ULONG64 K[80] =
+{
+    ULL(0x428a2f98,0xd728ae22), ULL(0x71374491,0x23ef65cd), ULL(0xb5c0fbcf,0xec4d3b2f), ULL(0xe9b5dba5,0x8189dbbc),
+    ULL(0x3956c25b,0xf348b538), ULL(0x59f111f1,0xb605d019), ULL(0x923f82a4,0xaf194f9b), ULL(0xab1c5ed5,0xda6d8118),
+    ULL(0xd807aa98,0xa3030242), ULL(0x12835b01,0x45706fbe), ULL(0x243185be,0x4ee4b28c), ULL(0x550c7dc3,0xd5ffb4e2),
+    ULL(0x72be5d74,0xf27b896f), ULL(0x80deb1fe,0x3b1696b1), ULL(0x9bdc06a7,0x25c71235), ULL(0xc19bf174,0xcf692694),
+    ULL(0xe49b69c1,0x9ef14ad2), ULL(0xefbe4786,0x384f25e3), ULL(0x0fc19dc6,0x8b8cd5b5), ULL(0x240ca1cc,0x77ac9c65),
+    ULL(0x2de92c6f,0x592b0275), ULL(0x4a7484aa,0x6ea6e483), ULL(0x5cb0a9dc,0xbd41fbd4), ULL(0x76f988da,0x831153b5),
+    ULL(0x983e5152,0xee66dfab), ULL(0xa831c66d,0x2db43210), ULL(0xb00327c8,0x98fb213f), ULL(0xbf597fc7,0xbeef0ee4),
+    ULL(0xc6e00bf3,0x3da88fc2), ULL(0xd5a79147,0x930aa725), ULL(0x06ca6351,0xe003826f), ULL(0x14292967,0x0a0e6e70),
+    ULL(0x27b70a85,0x46d22ffc), ULL(0x2e1b2138,0x5c26c926), ULL(0x4d2c6dfc,0x5ac42aed), ULL(0x53380d13,0x9d95b3df),
+    ULL(0x650a7354,0x8baf63de), ULL(0x766a0abb,0x3c77b2a8), ULL(0x81c2c92e,0x47edaee6), ULL(0x92722c85,0x1482353b),
+    ULL(0xa2bfe8a1,0x4cf10364), ULL(0xa81a664b,0xbc423001), ULL(0xc24b8b70,0xd0f89791), ULL(0xc76c51a3,0x0654be30),
+    ULL(0xd192e819,0xd6ef5218), ULL(0xd6990624,0x5565a910), ULL(0xf40e3585,0x5771202a), ULL(0x106aa070,0x32bbd1b8),
+    ULL(0x19a4c116,0xb8d2d0c8), ULL(0x1e376c08,0x5141ab53), ULL(0x2748774c,0xdf8eeb99), ULL(0x34b0bcb5,0xe19b48a8),
+    ULL(0x391c0cb3,0xc5c95a63), ULL(0x4ed8aa4a,0xe3418acb), ULL(0x5b9cca4f,0x7763e373), ULL(0x682e6ff3,0xd6b2b8a3),
+    ULL(0x748f82ee,0x5defb2fc), ULL(0x78a5636f,0x43172f60), ULL(0x84c87814,0xa1f0ab72), ULL(0x8cc70208,0x1a6439ec),
+    ULL(0x90befffa,0x23631e28), ULL(0xa4506ceb,0xde82bde9), ULL(0xbef9a3f7,0xb2c67915), ULL(0xc67178f2,0xe372532b),
+    ULL(0xca273ece,0xea26619c), ULL(0xd186b8c7,0x21c0c207), ULL(0xeada7dd6,0xcde0eb1e), ULL(0xf57d4f7f,0xee6ed178),
+    ULL(0x06f067aa,0x72176fba), ULL(0x0a637dc5,0xa2c898a6), ULL(0x113f9804,0xbef90dae), ULL(0x1b710b35,0x131c471b),
+    ULL(0x28db77f5,0x23047d84), ULL(0x32caab7b,0x40c72493), ULL(0x3c9ebe0a,0x15c9bebc), ULL(0x431d67c4,0x9c100d4c),
+    ULL(0x4cc5d4be,0xcb3e42b6), ULL(0x597f299c,0xfc657e2a), ULL(0x5fcb6fab,0x3ad6faec), ULL(0x6c44198c,0x4a475817)
+};
+
+static void processblock(SHA512_CTX *ctx, const UCHAR *buffer)
+{
+    ULONG64 W[80], t1, t2, a, b, c, d, e, f, g, h;
+    int i;
+
+    for (i = 0; i < 16; i++)
+    {
+        W[i]  = (ULONG64)buffer[8*i]<<56;
+        W[i] |= (ULONG64)buffer[8*i+1]<<48;
+        W[i] |= (ULONG64)buffer[8*i+2]<<40;
+        W[i] |= (ULONG64)buffer[8*i+3]<<32;
+        W[i] |= (ULONG64)buffer[8*i+4]<<24;
+        W[i] |= (ULONG64)buffer[8*i+5]<<16;
+        W[i] |= (ULONG64)buffer[8*i+6]<<8;
+        W[i] |= buffer[8*i+7];
+    }
+
+    for (; i < 80; i++)
+        W[i] = R1(W[i-2]) + W[i-7] + R0(W[i-15]) + W[i-16];
+
+    a = ctx->h[0];
+    b = ctx->h[1];
+    c = ctx->h[2];
+    d = ctx->h[3];
+    e = ctx->h[4];
+    f = ctx->h[5];
+    g = ctx->h[6];
+    h = ctx->h[7];
+
+    for (i = 0; i < 80; i++)
+    {
+        t1 = h + S1(e) + Ch(e,f,g) + K[i] + W[i];
+        t2 = S0(a) + Maj(a,b,c);
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    ctx->h[0] += a;
+    ctx->h[1] += b;
+    ctx->h[2] += c;
+    ctx->h[3] += d;
+    ctx->h[4] += e;
+    ctx->h[5] += f;
+    ctx->h[6] += g;
+    ctx->h[7] += h;
+}
+
+static void pad(SHA512_CTX *ctx)
+{
+    ULONG64 r = ctx->len % 128;
+
+    ctx->buf[r++] = 0x80;
+    if (r > 112)
+    {
+        memset(ctx->buf + r, 0, 128 - r);
+        r = 0;
+        processblock(ctx, ctx->buf);
+    }
+
+    memset(ctx->buf + r, 0, 120 - r);
+    ctx->len *= 8;
+    ctx->buf[120] = ctx->len >> 56;
+    ctx->buf[121] = ctx->len >> 48;
+    ctx->buf[122] = ctx->len >> 40;
+    ctx->buf[123] = ctx->len >> 32;
+    ctx->buf[124] = ctx->len >> 24;
+    ctx->buf[125] = ctx->len >> 16;
+    ctx->buf[126] = ctx->len >> 8;
+    ctx->buf[127] = ctx->len;
+
+    processblock(ctx, ctx->buf);
+}
+
+void sha512_init(SHA512_CTX *ctx)
+{
+    ctx->len = 0;
+    ctx->h[0] = ULL(0x6a09e667,0xf3bcc908);
+    ctx->h[1] = ULL(0xbb67ae85,0x84caa73b);
+    ctx->h[2] = ULL(0x3c6ef372,0xfe94f82b);
+    ctx->h[3] = ULL(0xa54ff53a,0x5f1d36f1);
+    ctx->h[4] = ULL(0x510e527f,0xade682d1);
+    ctx->h[5] = ULL(0x9b05688c,0x2b3e6c1f);
+    ctx->h[6] = ULL(0x1f83d9ab,0xfb41bd6b);
+    ctx->h[7] = ULL(0x5be0cd19,0x137e2179);
+}
+
+void sha512_update(SHA512_CTX *ctx, const UCHAR *buffer, ULONG len)
+{
+    const UCHAR *p = buffer;
+    unsigned r = ctx->len % 128;
+
+    ctx->len += len;
+    if (r)
+    {
+        if (len < 128 - r)
+        {
+            memcpy(ctx->buf + r, p, len);
+            return;
+        }
+        memcpy(ctx->buf + r, p, 128 - r);
+        len -= 128 - r;
+        p += 128 - r;
+        processblock(ctx, ctx->buf);
+    }
+
+    for (; len >= 128; len -= 128, p += 128)
+        processblock(ctx, p);
+
+    memcpy(ctx->buf, p, len);
+}
+
+void sha512_finalize(SHA512_CTX *ctx, UCHAR *buffer)
+{
+    int i;
+
+    pad(ctx);
+    for (i = 0; i < 8; i++)
+    {
+        buffer[8*i] = ctx->h[i] >> 56;
+        buffer[8*i+1] = ctx->h[i] >> 48;
+        buffer[8*i+2] = ctx->h[i] >> 40;
+        buffer[8*i+3] = ctx->h[i] >> 32;
+        buffer[8*i+4] = ctx->h[i] >> 24;
+        buffer[8*i+5] = ctx->h[i] >> 16;
+        buffer[8*i+6] = ctx->h[i] >> 8;
+        buffer[8*i+7] = ctx->h[i];
+    }
+}
+
+void sha384_init(SHA512_CTX *ctx)
+{
+    ctx->len = 0;
+    ctx->h[0] = ULL(0xcbbb9d5d,0xc1059ed8);
+    ctx->h[1] = ULL(0x629a292a,0x367cd507);
+    ctx->h[2] = ULL(0x9159015a,0x3070dd17);
+    ctx->h[3] = ULL(0x152fecd8,0xf70e5939);
+    ctx->h[4] = ULL(0x67332667,0xffc00b31);
+    ctx->h[5] = ULL(0x8eb44a87,0x68581511);
+    ctx->h[6] = ULL(0xdb0c2e0d,0x64f98fa7);
+    ctx->h[7] = ULL(0x47b5481d,0xbefa4fa4);
+}
+
+void sha384_finalize(SHA512_CTX *ctx, UCHAR *buffer)
+{
+    UCHAR buffer512[64];
+
+    sha512_finalize(ctx, buffer512);
+    memcpy(buffer, buffer512, 48);
+}

--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -51,7 +51,7 @@ dll/win32/atl                 # Synced to WineStaging-4.18
 dll/win32/atl80               # Synced to WineStaging-4.18
 dll/win32/atl100              # Synced to WineStaging-3.3
 dll/win32/avifil32            # Synced to WineStaging-4.18
-dll/win32/bcrypt              # Synced to WineStaging-1.9.23
+dll/win32/bcrypt              # Synced to Wine-6.7
 dll/win32/browseui            # Out of sync
 dll/win32/cabinet             # Synced to WineStaging-4.18
 dll/win32/clusapi             # Synced to WineStaging-3.3

--- a/sdk/include/psdk/bcrypt.h
+++ b/sdk/include/psdk/bcrypt.h
@@ -35,49 +35,164 @@
 #define OPTIONAL
 #endif
 
+#ifdef __REACTOS__
 #ifndef _NTDEF_
 typedef _Return_type_success_(return >= 0) LONG NTSTATUS;
 typedef NTSTATUS *PNTSTATUS;
 #endif
+#define STATUS_AUTH_TAG_MISMATCH         ((NTSTATUS) 0xC000A002)    //remove when ntstatus.h is winesynced
+#else
+#ifndef WINE_NTSTATUS_DECLARED
+#define WINE_NTSTATUS_DECLARED
+typedef LONG NTSTATUS;
+#endif
+#endif
 
-#define BCRYPT_ALGORITHM_NAME L"AlgorithmName"
-#define BCRYPT_AUTH_TAG_LENGTH L"AuthTagLength"
-#define BCRYPT_BLOCK_LENGTH L"BlockLength"
-#define BCRYPT_BLOCK_SIZE_LIST L"BlockSizeList"
-#define BCRYPT_CHAINING_MODE L"ChainingMode"
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#define BCRYPT_ALGORITHM_NAME       L"AlgorithmName"
+#define BCRYPT_AUTH_TAG_LENGTH      L"AuthTagLength"
+#define BCRYPT_BLOCK_LENGTH         L"BlockLength"
+#define BCRYPT_BLOCK_SIZE_LIST      L"BlockSizeList"
+#define BCRYPT_CHAINING_MODE        L"ChainingMode"
 #define BCRYPT_EFFECTIVE_KEY_LENGTH L"EffectiveKeyLength"
-#define BCRYPT_HASH_BLOCK_LENGTH L"HashBlockLength"
-#define BCRYPT_HASH_LENGTH L"HashDigestLength"
-#define BCRYPT_HASH_OID_LIST L"HashOIDList"
-#define BCRYPT_KEY_LENGTH L"KeyLength"
-#define BCRYPT_KEY_LENGTHS L"KeyLengths"
-#define BCRYPT_KEY_OBJECT_LENGTH L"KeyObjectLength"
-#define BCRYPT_KEY_STRENGTH L"KeyStrength"
-#define BCRYPT_OBJECT_LENGTH L"ObjectLength"
-#define BCRYPT_PADDING_SCHEMES L"PaddingSchemes"
-#define BCRYPT_PROVIDER_HANDLE L"ProviderHandle"
-#define BCRYPT_SIGNATURE_LENGTH L"SignatureLength"
+#define BCRYPT_HASH_BLOCK_LENGTH    L"HashBlockLength"
+#define BCRYPT_HASH_LENGTH          L"HashDigestLength"
+#define BCRYPT_HASH_OID_LIST        L"HashOIDList"
+#define BCRYPT_KEY_LENGTH           L"KeyLength"
+#define BCRYPT_KEY_LENGTHS          L"KeyLengths"
+#define BCRYPT_KEY_OBJECT_LENGTH    L"KeyObjectLength"
+#define BCRYPT_KEY_STRENGTH         L"KeyStrength"
+#define BCRYPT_OBJECT_LENGTH        L"ObjectLength"
+#define BCRYPT_PADDING_SCHEMES      L"PaddingSchemes"
+#define BCRYPT_PROVIDER_HANDLE      L"ProviderHandle"
+#define BCRYPT_SIGNATURE_LENGTH     L"SignatureLength"
 
-#define BCRYPT_OPAQUE_KEY_BLOB   L"OpaqueKeyBlob"
-#define BCRYPT_KEY_DATA_BLOB     L"KeyDataBlob"
-#define BCRYPT_AES_WRAP_KEY_BLOB L"Rfc3565KeyWrapBlob"
-#define BCRYPT_ECCPUBLIC_BLOB    L"ECCPUBLICBLOB"
-#define BCRYPT_ECCPRIVATE_BLOB   L"ECCPRIVATEBLOB"
-#define BCRYPT_RSAPUBLIC_BLOB    L"RSAPUBLICBLOB"
-#define BCRYPT_RSAPRIVATE_BLOB   L"RSAPRIVATEBLOB"
+#define BCRYPT_OPAQUE_KEY_BLOB      L"OpaqueKeyBlob"
+#define BCRYPT_KEY_DATA_BLOB        L"KeyDataBlob"
+#define BCRYPT_AES_WRAP_KEY_BLOB    L"Rfc3565KeyWrapBlob"
+#define BCRYPT_ECCPUBLIC_BLOB       L"ECCPUBLICBLOB"
+#define BCRYPT_ECCPRIVATE_BLOB      L"ECCPRIVATEBLOB"
+#define BCRYPT_RSAPUBLIC_BLOB       L"RSAPUBLICBLOB"
+#define BCRYPT_RSAPRIVATE_BLOB      L"RSAPRIVATEBLOB"
+#define BCRYPT_DSA_PUBLIC_BLOB      L"DSAPUBLICBLOB"
+#define BCRYPT_DSA_PRIVATE_BLOB     L"DSAPRIVATEBLOB"
+#define BCRYPT_PUBLIC_KEY_BLOB      L"PUBLICBLOB"
+#define BCRYPT_PRIVATE_KEY_BLOB     L"PRIVATEBLOB"
+#define LEGACY_DSA_PUBLIC_BLOB      L"CAPIDSAPUBLICBLOB"
+#define LEGACY_DSA_PRIVATE_BLOB     L"CAPIDSAPRIVATEBLOB"
+#define LEGACY_DSA_V2_PUBLIC_BLOB   L"V2CAPIDSAPUBLICBLOB"
+#define LEGACY_DSA_V2_PRIVATE_BLOB  L"V2CAPIDSAPRIVATEBLOB"
 
-#define MS_PRIMITIVE_PROVIDER L"Microsoft Primitive Provider"
+#define MS_PRIMITIVE_PROVIDER       L"Microsoft Primitive Provider"
 #define MS_PLATFORM_CRYPTO_PROVIDER L"Microsoft Platform Crypto Provider"
 
+#define BCRYPT_3DES_ALGORITHM       L"3DES"
+#define BCRYPT_AES_ALGORITHM        L"AES"
+#define BCRYPT_DES_ALGORITHM        L"DES"
+#define BCRYPT_DSA_ALGORITHM        L"DSA"
+#define BCRYPT_ECDH_P256_ALGORITHM  L"ECDH_P256"
+#define BCRYPT_ECDSA_P256_ALGORITHM L"ECDSA_P256"
+#define BCRYPT_ECDSA_P384_ALGORITHM L"ECDSA_P384"
+#define BCRYPT_ECDSA_P521_ALGORITHM L"ECDSA_P521"
+#define BCRYPT_MD2_ALGORITHM        L"MD2"
+#define BCRYPT_MD4_ALGORITHM        L"MD4"
 #define BCRYPT_MD5_ALGORITHM        L"MD5"
+#define BCRYPT_RC2_ALGORITHM        L"RC2"
+#define BCRYPT_RC4_ALGORITHM        L"RC4"
 #define BCRYPT_RNG_ALGORITHM        L"RNG"
+#define BCRYPT_RSA_ALGORITHM        L"RSA"
+#define BCRYPT_RSA_SIGN_ALGORITHM   L"RSA_SIGN"
 #define BCRYPT_SHA1_ALGORITHM       L"SHA1"
 #define BCRYPT_SHA256_ALGORITHM     L"SHA256"
 #define BCRYPT_SHA384_ALGORITHM     L"SHA384"
 #define BCRYPT_SHA512_ALGORITHM     L"SHA512"
-#define BCRYPT_ECDSA_P256_ALGORITHM L"ECDSA_P256"
-#define BCRYPT_ECDSA_P384_ALGORITHM L"ECDSA_P384"
-#define BCRYPT_ECDSA_P521_ALGORITHM L"ECDSA_P521"
+
+#define BCRYPT_CHAIN_MODE_NA        L"ChainingModeN/A"
+#define BCRYPT_CHAIN_MODE_CBC       L"ChainingModeCBC"
+#define BCRYPT_CHAIN_MODE_ECB       L"ChainingModeECB"
+#define BCRYPT_CHAIN_MODE_CFB       L"ChainingModeCFB"
+#define BCRYPT_CHAIN_MODE_CCM       L"ChainingModeCCM"
+#define BCRYPT_CHAIN_MODE_GCM       L"ChainingModeGCM"
+
+#define BCRYPT_KDF_HASH             L"HASH"
+#define BCRYPT_KDF_HMAC             L"HMAC"
+#define BCRYPT_KDF_TLS_PRF          L"TLS_PRF"
+#define BCRYPT_KDF_SP80056A_CONCAT  L"SP800_56A_CONCAT"
+#define BCRYPT_KDF_RAW_SECRET       L"TRUNCATE"
+#else
+static const WCHAR BCRYPT_ALGORITHM_NAME[] = {'A','l','g','o','r','i','t','h','m','N','a','m','e',0};
+static const WCHAR BCRYPT_AUTH_TAG_LENGTH[] = {'A','u','t','h','T','a','g','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_BLOCK_LENGTH[] = {'B','l','o','c','k','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_BLOCK_SIZE_LIST[] = {'B','l','o','c','k','S','i','z','e','L','i','s','t',0};
+static const WCHAR BCRYPT_CHAINING_MODE[] = {'C','h','a','i','n','i','n','g','M','o','d','e',0};
+static const WCHAR BCRYPT_EFFECTIVE_KEY_LENGTH[] = {'E','f','f','e','c','t','i','v','e','K','e','y','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_BLOCK_LENGTH[] = {'H','a','s','h','B','l','o','c','k','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_LENGTH[] = {'H','a','s','h','D','i','g','e','s','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_HASH_OID_LIST[] = {'H','a','s','h','O','I','D','L','i','s','t',0};
+static const WCHAR BCRYPT_KEY_LENGTH[] = {'K','e','y','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_KEY_LENGTHS[] = {'K','e','y','L','e','n','g','t','h','s',0};
+static const WCHAR BCRYPT_KEY_OBJECT_LENGTH[] = {'K','e','y','O','b','j','e','c','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_KEY_STRENGTH[] = {'K','e','y','S','t','r','e','n','g','t','h',0};
+static const WCHAR BCRYPT_OBJECT_LENGTH[] = {'O','b','j','e','c','t','L','e','n','g','t','h',0};
+static const WCHAR BCRYPT_PADDING_SCHEMES[] = {'P','a','d','d','i','n','g','S','c','h','e','m','e','s',0};
+static const WCHAR BCRYPT_PROVIDER_HANDLE[] = {'P','r','o','v','i','d','e','r','H','a','n','d','l','e',0};
+static const WCHAR BCRYPT_SIGNATURE_LENGTH[] = {'S','i','g','n','a','t','u','r','e','L','e','n','g','t','h',0};
+
+static const WCHAR BCRYPT_OPAQUE_KEY_BLOB[] = {'O','p','a','q','u','e','K','e','y','B','l','o','b',0};
+static const WCHAR BCRYPT_KEY_DATA_BLOB[] = {'K','e','y','D','a','t','a','B','l','o','b',0};
+static const WCHAR BCRYPT_AES_WRAP_KEY_BLOB[] = {'R','f','c','3','5','6','5','K','e','y','W','r','a','p','B','l','o','b',0};
+static const WCHAR BCRYPT_ECCPUBLIC_BLOB[] = {'E','C','C','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_ECCPRIVATE_BLOB[] = {'E','C','C','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_RSAPUBLIC_BLOB[] = {'R','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_RSAPRIVATE_BLOB[] = {'R','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_DSA_PUBLIC_BLOB[] = {'D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_DSA_PRIVATE_BLOB[] = {'D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR BCRYPT_PUBLIC_KEY_BLOB[] = {'P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR BCRYPT_PRIVATE_KEY_BLOB[] = {'P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_PUBLIC_BLOB[] = {'C','A','P','I','D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_PRIVATE_BLOB[] = {'C','A','P','I','D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_V2_PUBLIC_BLOB[] = {'V','2','C','A','P','I','D','S','A','P','U','B','L','I','C','B','L','O','B',0};
+static const WCHAR LEGACY_DSA_V2_PRIVATE_BLOB[] = {'V','2','C','A','P','I','D','S','A','P','R','I','V','A','T','E','B','L','O','B',0};
+
+static const WCHAR MS_PRIMITIVE_PROVIDER[] = \
+{'M','i','c','r','o','s','o','f','t',' ','P','r','i','m','i','t','i','v','e',' ','P','r','o','v','i','d','e','r',0};
+static const WCHAR MS_PLATFORM_CRYPTO_PROVIDER[] = \
+{'M','i','c','r','o','s','o','f','t',' ','P','l','a','t','f','o','r','m',' ','C','r','y','p','t','o',' ','P','r','o','v','i','d','e','r',0};
+
+static const WCHAR BCRYPT_3DES_ALGORITHM[] = {'3','D','E','S',0};
+static const WCHAR BCRYPT_AES_ALGORITHM[] = {'A','E','S',0};
+static const WCHAR BCRYPT_DES_ALGORITHM[] = {'D','E','S',0};
+static const WCHAR BCRYPT_DSA_ALGORITHM[] = {'D','S','A',0};
+static const WCHAR BCRYPT_ECDH_P256_ALGORITHM[] = {'E','C','D','H','_','P','2','5','6',0};
+static const WCHAR BCRYPT_ECDSA_P256_ALGORITHM[] = {'E','C','D','S','A','_','P','2','5','6',0};
+static const WCHAR BCRYPT_ECDSA_P384_ALGORITHM[] = {'E','C','D','S','A','_','P','3','8','4',0};
+static const WCHAR BCRYPT_ECDSA_P521_ALGORITHM[] = {'E','C','D','S','A','_','P','5','2','1',0};
+static const WCHAR BCRYPT_MD2_ALGORITHM[] = {'M','D','2',0};
+static const WCHAR BCRYPT_MD4_ALGORITHM[] = {'M','D','4',0};
+static const WCHAR BCRYPT_MD5_ALGORITHM[] = {'M','D','5',0};
+static const WCHAR BCRYPT_RC2_ALGORITHM[] = {'R','C','2',0};
+static const WCHAR BCRYPT_RC4_ALGORITHM[] = {'R','C','4',0};
+static const WCHAR BCRYPT_RNG_ALGORITHM[] = {'R','N','G',0};
+static const WCHAR BCRYPT_RSA_ALGORITHM[] = {'R','S','A',0};
+static const WCHAR BCRYPT_RSA_SIGN_ALGORITHM[] = {'R','S','A','_','S','I','G','N',0};
+static const WCHAR BCRYPT_SHA1_ALGORITHM[] = {'S','H','A','1',0};
+static const WCHAR BCRYPT_SHA256_ALGORITHM[] = {'S','H','A','2','5','6',0};
+static const WCHAR BCRYPT_SHA384_ALGORITHM[] = {'S','H','A','3','8','4',0};
+static const WCHAR BCRYPT_SHA512_ALGORITHM[] = {'S','H','A','5','1','2',0};
+
+static const WCHAR BCRYPT_CHAIN_MODE_NA[] = {'C','h','a','i','n','i','n','g','M','o','d','e','N','/','A',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CBC[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','B','C',0};
+static const WCHAR BCRYPT_CHAIN_MODE_ECB[] = {'C','h','a','i','n','i','n','g','M','o','d','e','E','C','B',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CFB[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','F','B',0};
+static const WCHAR BCRYPT_CHAIN_MODE_CCM[] = {'C','h','a','i','n','i','n','g','M','o','d','e','C','C','M',0};
+static const WCHAR BCRYPT_CHAIN_MODE_GCM[] = {'C','h','a','i','n','i','n','g','M','o','d','e','G','C','M',0};
+
+static const WCHAR BCRYPT_KDF_HASH[] = {'H','A','S','H',0};
+static const WCHAR BCRYPT_KDF_HMAC[] = {'H','M','A','C',0};
+static const WCHAR BCRYPT_KDF_TLS_PRF[] = {'T','L','S','_','P','R','F',0};
+static const WCHAR BCRYPT_KDF_SP80056A_CONCAT[] = {'S','P','8','0','0','_','5','6','A','_','C','O','N','C','A','T',0};
+static const WCHAR BCRYPT_KDF_RAW_SECRET[] = {'T','R','U','N','C','A','T','E',0};
+#endif
 
 #define BCRYPT_ECDSA_PUBLIC_P256_MAGIC  0x31534345
 #define BCRYPT_ECDSA_PRIVATE_P256_MAGIC 0x32534345
@@ -85,6 +200,34 @@ typedef NTSTATUS *PNTSTATUS;
 #define BCRYPT_ECDSA_PRIVATE_P384_MAGIC 0x34534345
 #define BCRYPT_ECDSA_PUBLIC_P521_MAGIC  0x35534345
 #define BCRYPT_ECDSA_PRIVATE_P521_MAGIC 0x36534345
+
+#define BCRYPT_ECDH_PUBLIC_P256_MAGIC  0x314b4345
+#define BCRYPT_ECDH_PRIVATE_P256_MAGIC 0x324b4345
+#define BCRYPT_ECDH_PUBLIC_P384_MAGIC  0x334b4345
+#define BCRYPT_ECDH_PRIVATE_P384_MAGIC 0x344b4345
+#define BCRYPT_ECDH_PUBLIC_P521_MAGIC  0x354b4345
+#define BCRYPT_ECDH_PRIVATE_P521_MAGIC 0x364b4345
+
+#define BCRYPT_CIPHER_OPERATION                 0x00000001
+#define BCRYPT_HASH_OPERATION                   0x00000002
+#define BCRYPT_ASYMMETRIC_ENCRYPTION_OPERATION  0x00000004
+#define BCRYPT_SECRET_AGREEMENT_OPERATION       0x00000008
+#define BCRYPT_SIGNATURE_OPERATION              0x00000010
+#define BCRYPT_RNG_OPERATION                    0x00000020
+
+#define BCRYPT_CIPHER_INTERFACE                 0x00000001
+#define BCRYPT_HASH_INTERFACE                   0x00000002
+#define BCRYPT_ASYMMETRIC_ENCRYPTION_INTERFACE  0x00000003
+#define BCRYPT_SECRET_AGREEMENT_INTERFACE       0x00000004
+#define BCRYPT_SIGNATURE_INTERFACE              0x00000005
+#define BCRYPT_RNG_INTERFACE                    0x00000006
+#define BCRYPT_KEY_DERIVATION_INTERFACE         0x00000007
+
+#define BCRYPT_SUPPORTED_PAD_ROUTER     0x00000001
+#define BCRYPT_SUPPORTED_PAD_PKCS1_ENC  0x00000002
+#define BCRYPT_SUPPORTED_PAD_PKCS1_SIG  0x00000004
+#define BCRYPT_SUPPORTED_PAD_OAEP       0x00000008
+#define BCRYPT_SUPPORTED_PAD_PSS        0x00000010
 
 typedef struct _BCRYPT_ALGORITHM_IDENTIFIER
 {
@@ -99,13 +242,6 @@ typedef struct __BCRYPT_KEY_LENGTHS_STRUCT
     ULONG dwMaxLength;
     ULONG dwIncrement;
 } BCRYPT_KEY_LENGTHS_STRUCT, BCRYPT_AUTH_TAG_LENGTHS_STRUCT;
-
-typedef struct _BCRYPT_KEY_DATA_BLOB_HEADER
-{
-    ULONG dwMagic;
-    ULONG dwVersion;
-    ULONG cbKeyData;
-} BCRYPT_KEY_DATA_BLOB_HEADER, *PBCRYPT_KEY_DATA_BLOB_HEADER;
 
 typedef struct _BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO
 {
@@ -149,15 +285,105 @@ typedef struct _BCRYPT_PKCS1_PADDING_INFO
     LPCWSTR pszAlgId;
 } BCRYPT_PKCS1_PADDING_INFO;
 
-#define BCRYPT_PAD_NONE   0x00000001
-#define BCRYPT_PAD_PKCS1  0x00000002
-#define BCRYPT_PAD_OAEP   0x00000004
-#define BCRYPT_PAD_PSS    0x00000008
+#define BCRYPT_PAD_NONE                     0x00000001
+#define BCRYPT_PAD_PKCS1                    0x00000002
+#define BCRYPT_PAD_OAEP                     0x00000004
+#define BCRYPT_PAD_PSS                      0x00000008
+#define BCRYPT_PAD_PKCS1_OPTIONAL_HASH_OID  0x00000010
+
+#define BCRYPT_DSA_PUBLIC_MAGIC     0x42505344
+#define BCRYPT_DSA_PRIVATE_MAGIC    0x56505344
+
+typedef struct _BCRYPT_DSA_KEY_BLOB
+{
+    ULONG dwMagic;
+    ULONG cbKey;
+    UCHAR Count[4];
+    UCHAR Seed[20];
+    UCHAR q[20];
+} BCRYPT_DSA_KEY_BLOB, *PBCRYPT_DSA_KEY_BLOB;
+
+#define BCRYPT_DSA_PUBLIC_MAGIC_V2  0x32425044
+#define BCRYPT_DSA_PRIVATE_MAGIC_V2 0x32565044
+
+typedef enum
+{
+    DSA_HASH_ALGORITHM_SHA1,
+    DSA_HASH_ALGORITHM_SHA256,
+    DSA_HASH_ALGORITHM_SHA512
+} HASHALGORITHM_ENUM;
+
+typedef enum
+{
+    DSA_FIPS186_2,
+    DSA_FIPS186_3
+} DSAFIPSVERSION_ENUM;
+
+typedef struct _BCRYPT_DSA_KEY_BLOB_V2
+{
+    ULONG               dwMagic;
+    ULONG               cbKey;
+    HASHALGORITHM_ENUM  hashAlgorithm;
+    DSAFIPSVERSION_ENUM standardVersion;
+    ULONG               cbSeedLength;
+    ULONG               cbGroupSize;
+    UCHAR               Count[4];
+} BCRYPT_DSA_KEY_BLOB_V2, *PBCRYPT_DSA_KEY_BLOB_V2;
 
 #define BCRYPT_AUTHENTICATED_CIPHER_MODE_INFO_VERSION 1
 
 #define BCRYPT_AUTH_MODE_CHAIN_CALLS_FLAG 0x00000001
 #define BCRYPT_AUTH_MODE_IN_PROGRESS_FLAG 0x00000002
+
+typedef struct _CRYPT_INTERFACE_REG
+{
+    ULONG dwInterface;
+    ULONG dwFlags;
+    ULONG cFunctions;
+    PWSTR *rgpszFunctions;
+} CRYPT_INTERFACE_REG, *PCRYPT_INTERFACE_REG;
+
+typedef struct _CRYPT_IMAGE_REG
+{
+    PWSTR pszImage;
+    ULONG cInterfaces;
+    PCRYPT_INTERFACE_REG *rgpInterfaces;
+} CRYPT_IMAGE_REG, *PCRYPT_IMAGE_REG;
+
+typedef struct _CRYPT_PROVIDER_REG
+{
+    ULONG cAliases;
+    PWSTR *rgpszAliases;
+    PCRYPT_IMAGE_REG pUM;
+    PCRYPT_IMAGE_REG pKM;
+} CRYPT_PROVIDER_REG, *PCRYPT_PROVIDER_REG;
+
+typedef struct _BCRYPT_KEY_DATA_BLOB_HEADER
+{
+    ULONG dwMagic;
+    ULONG dwVersion;
+    ULONG cbKeyData;
+} BCRYPT_KEY_DATA_BLOB_HEADER, *PBCRYPT_KEY_DATA_BLOB_HEADER;
+
+#define KDF_HASH_ALGORITHM 0x00000000
+#define KDF_SECRET_PREPEND 0x00000001
+#define KDF_SECRET_APPEND  0x00000002
+
+typedef struct _BCryptBuffer
+{
+    ULONG cbBuffer;
+    ULONG BufferType;
+    void  *pvBuffer;
+} BCryptBuffer, *PBCryptBuffer;
+
+#define BCRYPTBUFFER_VERSION        0
+
+typedef struct _BCryptBufferDesc
+{
+    ULONG ulVersion;
+    ULONG cBuffers;
+    PBCryptBuffer pBuffers;
+} BCryptBufferDesc, *PBCryptBufferDesc;
 
 #define BCRYPT_KEY_DATA_BLOB_MAGIC    0x4d42444b
 #define BCRYPT_KEY_DATA_BLOB_VERSION1 1
@@ -166,29 +392,63 @@ typedef PVOID BCRYPT_ALG_HANDLE;
 typedef PVOID BCRYPT_KEY_HANDLE;
 typedef PVOID BCRYPT_HANDLE;
 typedef PVOID BCRYPT_HASH_HANDLE;
+typedef PVOID BCRYPT_SECRET_HANDLE;
 
+/* Flags for BCryptGenRandom */
 #define BCRYPT_RNG_USE_ENTROPY_IN_BUFFER 0x00000001
 #define BCRYPT_USE_SYSTEM_PREFERRED_RNG  0x00000002
+
+/* Flags for BCryptOpenAlgorithmProvider */
 #define BCRYPT_ALG_HANDLE_HMAC_FLAG 0x00000008
 
+/* Flags for BCryptEncrypt/BCryptDecrypt */
+#define BCRYPT_BLOCK_PADDING        0x00000001
+
+/* Flags for BCryptCreateHash */
+#define BCRYPT_HASH_REUSABLE_FLAG   0x00000020
+
+#define CRYPT_LOCAL     0x00000001
+#define CRYPT_DOMAIN    0x00000002
+
+typedef struct _CRYPT_CONTEXT_FUNCTIONS
+{
+    ULONG cFunctions;
+    WCHAR **rgpszFunctions;
+} CRYPT_CONTEXT_FUNCTIONS, *PCRYPT_CONTEXT_FUNCTIONS;
+
+NTSTATUS WINAPI BCryptAddContextFunction(ULONG, LPCWSTR, ULONG, LPCWSTR, ULONG);
 NTSTATUS WINAPI BCryptCloseAlgorithmProvider(BCRYPT_ALG_HANDLE, ULONG);
 NTSTATUS WINAPI BCryptCreateHash(BCRYPT_ALG_HANDLE, BCRYPT_HASH_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptDecrypt(BCRYPT_KEY_HANDLE, PUCHAR, ULONG, VOID *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptDeriveKey(BCRYPT_SECRET_HANDLE, LPCWSTR, BCryptBufferDesc*, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptDeriveKeyCapi(BCRYPT_HASH_HANDLE, BCRYPT_ALG_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptDeriveKeyPBKDF2(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, PUCHAR, ULONG, ULONGLONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptDestroyHash(BCRYPT_HASH_HANDLE);
 NTSTATUS WINAPI BCryptDestroyKey(BCRYPT_KEY_HANDLE);
+NTSTATUS WINAPI BCryptDestroySecret(BCRYPT_SECRET_HANDLE);
+NTSTATUS WINAPI BCryptDuplicateHash(BCRYPT_HASH_HANDLE, BCRYPT_HASH_HANDLE *, UCHAR *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptDuplicateKey(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptEncrypt(BCRYPT_KEY_HANDLE, PUCHAR, ULONG, VOID *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptEnumAlgorithms(ULONG, ULONG *, BCRYPT_ALGORITHM_IDENTIFIER **, ULONG);
+NTSTATUS WINAPI BCryptEnumContextFunctions(ULONG, const WCHAR *, ULONG, ULONG *, CRYPT_CONTEXT_FUNCTIONS **);
+NTSTATUS WINAPI BCryptExportKey(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG *, ULONG);
+NTSTATUS WINAPI BCryptFinalizeKeyPair(BCRYPT_KEY_HANDLE, ULONG);
 NTSTATUS WINAPI BCryptFinishHash(BCRYPT_HASH_HANDLE, PUCHAR, ULONG, ULONG);
-NTSTATUS WINAPI BCryptGenerateSymmetricKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
+void     WINAPI BCryptFreeBuffer(void *);
 NTSTATUS WINAPI BCryptGenRandom(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptGenerateKeyPair(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptGenerateSymmetricKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptGetFipsAlgorithmMode(BOOLEAN *);
 NTSTATUS WINAPI BCryptGetProperty(BCRYPT_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptHash(BCRYPT_ALG_HANDLE, PUCHAR, ULONG, PUCHAR, ULONG, PUCHAR, ULONG);
 NTSTATUS WINAPI BCryptHashData(BCRYPT_HASH_HANDLE, PUCHAR, ULONG, ULONG);
+NTSTATUS WINAPI BCryptImportKey(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, BCRYPT_KEY_HANDLE *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG);
 NTSTATUS WINAPI BCryptImportKeyPair(BCRYPT_ALG_HANDLE, BCRYPT_KEY_HANDLE, LPCWSTR, BCRYPT_KEY_HANDLE *, UCHAR *, ULONG, ULONG);
 NTSTATUS WINAPI BCryptOpenAlgorithmProvider(BCRYPT_ALG_HANDLE *, LPCWSTR, LPCWSTR, ULONG);
+NTSTATUS WINAPI BCryptRemoveContextFunction(ULONG, LPCWSTR, ULONG, LPCWSTR);
+NTSTATUS WINAPI BCryptSecretAgreement(BCRYPT_KEY_HANDLE, BCRYPT_KEY_HANDLE, BCRYPT_SECRET_HANDLE *, ULONG);
 NTSTATUS WINAPI BCryptSetProperty(BCRYPT_HANDLE, LPCWSTR, PUCHAR, ULONG, ULONG);
-NTSTATUS WINAPI BCryptDuplicateHash(BCRYPT_HASH_HANDLE, BCRYPT_HASH_HANDLE *, UCHAR *, ULONG, ULONG);
+NTSTATUS WINAPI BCryptSignHash(BCRYPT_KEY_HANDLE, void *, PUCHAR, ULONG, PUCHAR, ULONG, ULONG *, ULONG);
 NTSTATUS WINAPI BCryptVerifySignature(BCRYPT_KEY_HANDLE, void *, UCHAR *, ULONG, UCHAR *, ULONG, ULONG);
 
 #endif  /* __WINE_BCRYPT_H */


### PR DESCRIPTION
## Purpose

Updates BCRYPT to the latest Wine version. I plan to submit mbedtls-based ECC cert support in a future PR after this is merged.
This is my first PR for ReactOS, so please let me know if I'm doing something incorrectly. Thank you.

## Proposed changes

- Updates BCRYPT to the latest Wine version. This version:
    - splits out the key operation functions (which need an external library such as gnuTLS or mbedtls) into a separate interface.
    - has built-in support for many of the hash functions which our old copy needed mbedtls for.

- because of the separate interface, there are now only 3 __REACTOS__ #ifdefs! 🎉

- After this is merged successfully, I will eventually submit a PR with implementations for the portions of the mbedtls.c file needed for ECC cert support (so we can download from GitHub with rapps again 😄)

## TODO

- [X] passes bcrypt_winetest.exe successfully:
![image](https://user-images.githubusercontent.com/22065960/117412485-d8ea2e80-aee2-11eb-8a8e-0027bdd28608.png)
- [X] non-ECC cert https links download fine in rapps
-  please help test this and let me know if I did this right, as this is my first pull request for reactos
