### PR TITLE
[CMAKE] winetests/: Move '/wd4101' to kernel32/ only

### DIFF
--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -10,7 +10,6 @@ if(MSVC)
         /wd4305) # C4305: '=': truncation from 'double' to 'FLOAT'
     if(ARCH STREQUAL "amd64")
         add_compile_options(
-            /wd4101 # C4101: 'x': unreferenced local variable
             /wd4312 # C4312: 'type cast': conversion from 'unsigned int' to 'char *' of greater size
             /wd4334) # C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
     endif()

--- a/modules/rostests/winetests/kernel32/CMakeLists.txt
+++ b/modules/rostests/winetests/kernel32/CMakeLists.txt
@@ -48,6 +48,12 @@ add_executable(kernel32_winetest
 if(MSVC)
     # Disable warning C4477 (printf format warnings)
     remove_target_compile_option(kernel32_winetest "/we4477")
+
+    if(ARCH STREQUAL "amd64")
+        # error C4101: 'is_wow64': unreferenced local variable
+        remove_target_compile_option(kernel32_winetest "/we4101")
+        target_compile_options(kernel32_winetest PRIVATE /wd4101)
+    endif()
 endif()
 
 if(USE_CLANG_CL OR (NOT MSVC))


### PR DESCRIPTION
Is more explicit and re-enables the warning for all the other modules.

Also add matching remove_target_compile_option().

Addendum to 42d2d5e.

NB:
Also, this avoids the related failure on #3645.
I guess the `if` related to this variable is optimized out, which triggers this error.