### PR TITLE
[NTOS:PO] Check for optional parameter in the completion routine

### DIFF
--- a/ntoskrnl/po/power.c
+++ b/ntoskrnl/po/power.c
@@ -124,12 +124,15 @@ PopPresentIrp(
     return Status;
 }
 
+static IO_COMPLETION_ROUTINE PopRequestPowerIrpCompletion;
+
 static
 NTSTATUS
 NTAPI
-PopRequestPowerIrpCompletion(IN PDEVICE_OBJECT DeviceObject,
-                             IN PIRP Irp,
-                             IN PVOID Context)
+PopRequestPowerIrpCompletion(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp,
+    _In_reads_opt_(_Inexpressible_("varies")) PVOID Context)
 {
     PIO_STACK_LOCATION Stack;
     PREQUEST_POWER_COMPLETE CompletionRoutine;
@@ -139,11 +142,15 @@ PopRequestPowerIrpCompletion(IN PDEVICE_OBJECT DeviceObject,
     CompletionRoutine = Context;
 
     PowerState.DeviceState = (ULONG_PTR)Stack->Parameters.Others.Argument3;
-    CompletionRoutine(Stack->Parameters.Others.Argument1,
-                      (UCHAR)(ULONG_PTR)Stack->Parameters.Others.Argument2,
-                      PowerState,
-                      Stack->Parameters.Others.Argument4,
-                      &Irp->IoStatus);
+
+    if (CompletionRoutine)
+    {
+        CompletionRoutine(Stack->Parameters.Others.Argument1,
+                          (UCHAR)(ULONG_PTR)Stack->Parameters.Others.Argument2,
+                          PowerState,
+                          Stack->Parameters.Others.Argument4,
+                          &Irp->IoStatus);
+    }
 
     IoSkipCurrentIrpStackLocation(Irp);
     IoFreeIrp(Irp);
@@ -636,12 +643,13 @@ PoRegisterSystemState(IN PVOID StateHandle,
  */
 NTSTATUS
 NTAPI
-PoRequestPowerIrp(IN PDEVICE_OBJECT DeviceObject,
-                  IN UCHAR MinorFunction,
-                  IN POWER_STATE PowerState,
-                  IN PREQUEST_POWER_COMPLETE CompletionFunction,
-                  IN PVOID Context,
-                  OUT PIRP *pIrp OPTIONAL)
+PoRequestPowerIrp(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ UCHAR MinorFunction,
+    _In_ POWER_STATE PowerState,
+    _In_opt_ PREQUEST_POWER_COMPLETE CompletionFunction,
+    _In_opt_ __drv_aliasesMem PVOID Context,
+    _Outptr_opt_ PIRP *pIrp)
 {
     PDEVICE_OBJECT TopDeviceObject;
     PIO_STACK_LOCATION Stack;

--- a/sdk/include/xdk/iotypes.h
+++ b/sdk/include/xdk/iotypes.h
@@ -2826,11 +2826,12 @@ typedef enum _IO_PAGING_PRIORITY {
 
 _Function_class_(IO_COMPLETION_ROUTINE)
 _IRQL_requires_same_
+_IRQL_requires_max_(DISPATCH_LEVEL)
 typedef NTSTATUS
 (NTAPI IO_COMPLETION_ROUTINE)(
   _In_ struct _DEVICE_OBJECT *DeviceObject,
   _In_ struct _IRP *Irp,
-  _In_opt_ PVOID Context);
+  _In_reads_opt_(_Inexpressible_("varies")) PVOID Context);
 typedef IO_COMPLETION_ROUTINE *PIO_COMPLETION_ROUTINE;
 
 _Function_class_(IO_DPC_ROUTINE)


### PR DESCRIPTION
## Purpose

The `CompletionFunction` parameter is really optional.
This fixes a bugcheck caused by shutdown with IDE driver stack.

JIRA issue: [CORE-17401](https://jira.reactos.org/browse/CORE-17401)