### PR TITLE
[CMAKE] winetests/: Move '/wd4334' to 3 sub-modules only

### DIFF
--- a/modules/rostests/winetests/CMakeLists.txt
+++ b/modules/rostests/winetests/CMakeLists.txt
@@ -11,7 +11,7 @@ if(MSVC)
     if(ARCH STREQUAL "amd64")
         add_compile_options(
             /wd4312 # C4312: 'type cast': conversion from 'unsigned int' to 'char *' of greater size
-            /wd4334) # C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+            )
     endif()
 endif()
 

--- a/modules/rostests/winetests/comctl32/CMakeLists.txt
+++ b/modules/rostests/winetests/comctl32/CMakeLists.txt
@@ -42,6 +42,11 @@ add_executable(comctl32_winetest
     ${PCH_SKIP_SOURCE}
     rsrc.rc)
 
+if(MSVC AND ARCH STREQUAL "amd64")
+    # warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+    target_compile_options(comctl32_winetest PRIVATE /wd4334)
+endif()
+
 target_compile_options(comctl32_winetest PRIVATE $<$<NOT:$<C_COMPILER_ID:MSVC>>:-Wno-format>)
 
 set_module_type(comctl32_winetest win32cui)

--- a/modules/rostests/winetests/gdi32/CMakeLists.txt
+++ b/modules/rostests/winetests/gdi32/CMakeLists.txt
@@ -25,6 +25,11 @@ add_executable(gdi32_winetest
     ${PCH_SKIP_SOURCE}
     resource.rc)
 
+if(MSVC AND ARCH STREQUAL "amd64")
+    # warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+    target_compile_options(gdi32_winetest PRIVATE /wd4334)
+endif()
+
 set_module_type(gdi32_winetest win32cui)
 add_importlibs(gdi32_winetest gdi32 user32 advapi32 msvcrt kernel32)
 

--- a/modules/rostests/winetests/ntdll/CMakeLists.txt
+++ b/modules/rostests/winetests/ntdll/CMakeLists.txt
@@ -38,6 +38,11 @@ add_executable(ntdll_winetest
 
 target_link_libraries(ntdll_winetest pseh)
 
+if(MSVC AND ARCH STREQUAL "amd64")
+    # warning C4334: '<<': result of 32-bit shift implicitly converted to 64 bits (was 64-bit shift intended?)
+    target_compile_options(ntdll_winetest PRIVATE /wd4334)
+endif()
+
 if(USE_CLANG_CL OR (NOT MSVC))
     target_compile_options(ntdll_winetest PRIVATE "-Wno-format")
 endif()


### PR DESCRIPTION
Is more explicit and re-enables the warning for all the other modules.

Addendum to 42d2d5e.

NB:
Also, this avoids the related failures on #3645.