### PR TITLE
[MORE][CONUTILS] Implement missing features of the MORE command.

### DIFF
--- a/base/applications/cmdutils/more/lang/bg-BG.rc
+++ b/base/applications/cmdutils/more/lang/bg-BG.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Продължаване --"
     IDS_CONTINUE_PROGRESS "-- Продължаване (%d%%) --"
     IDS_FILE_ACCESS "Няма достъп до файл %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/bg-BG.rc
+++ b/base/applications/cmdutils/more/lang/bg-BG.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Продължаване --"
     IDS_CONTINUE_PROGRESS "-- Продължаване (%d%%) --"

--- a/base/applications/cmdutils/more/lang/bg-BG.rc
+++ b/base/applications/cmdutils/more/lang/bg-BG.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Продължаване --"
     IDS_CONTINUE_PROGRESS "-- Продължаване (%d%%) --"
     IDS_FILE_ACCESS "Няма достъп до файл %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/bg-BG.rc
+++ b/base/applications/cmdutils/more/lang/bg-BG.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Продължаване (%d%%) --"
     IDS_FILE_ACCESS "Няма достъп до файл %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/bg-BG.rc
+++ b/base/applications/cmdutils/more/lang/bg-BG.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Продължаване --"
     IDS_CONTINUE_PROGRESS "-- Продължаване (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ca-ES.rc
+++ b/base/applications/cmdutils/more/lang/ca-ES.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ca-ES.rc
+++ b/base/applications/cmdutils/more/lang/ca-ES.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "No puc accedir al fitxer %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ca-ES.rc
+++ b/base/applications/cmdutils/more/lang/ca-ES.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "No puc accedir al fitxer %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ca-ES.rc
+++ b/base/applications/cmdutils/more/lang/ca-ES.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "No puc accedir al fitxer %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/ca-ES.rc
+++ b/base/applications/cmdutils/more/lang/ca-ES.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"

--- a/base/applications/cmdutils/more/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/more/lang/cs-CZ.rc
@@ -30,14 +30,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Pokračovat --"
     IDS_CONTINUE_PROGRESS "-- Pokračovat (%d%%) --"
     IDS_FILE_ACCESS "Nelze získat přístup k souboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/more/lang/cs-CZ.rc
@@ -37,7 +37,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Pokračovat (%d%%) --"
     IDS_FILE_ACCESS "Nelze získat přístup k souboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/more/lang/cs-CZ.rc
@@ -23,15 +23,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Pokračovat --"
     IDS_CONTINUE_PROGRESS "-- Pokračovat (%d%%) --"

--- a/base/applications/cmdutils/more/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/more/lang/cs-CZ.rc
@@ -30,13 +30,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Pokračovat --"
     IDS_CONTINUE_PROGRESS "-- Pokračovat (%d%%) --"
     IDS_FILE_ACCESS "Nelze získat přístup k souboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/cs-CZ.rc
+++ b/base/applications/cmdutils/more/lang/cs-CZ.rc
@@ -23,11 +23,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Pokračovat --"
     IDS_CONTINUE_PROGRESS "-- Pokračovat (%d%%) --"

--- a/base/applications/cmdutils/more/lang/de-DE.rc
+++ b/base/applications/cmdutils/more/lang/de-DE.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Fortsetzung --"
     IDS_CONTINUE_PROGRESS "-- Fortsetzung (%d%%) --"

--- a/base/applications/cmdutils/more/lang/de-DE.rc
+++ b/base/applications/cmdutils/more/lang/de-DE.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Fortsetzung --"
     IDS_CONTINUE_PROGRESS "-- Fortsetzung (%d%%) --"
     IDS_FILE_ACCESS "Auf die Datei %s kann nicht zugegriffen werden.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/de-DE.rc
+++ b/base/applications/cmdutils/more/lang/de-DE.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsetzung --"
     IDS_CONTINUE_PROGRESS "-- Fortsetzung (%d%%) --"
     IDS_FILE_ACCESS "Auf die Datei %s kann nicht zugegriffen werden.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/de-DE.rc
+++ b/base/applications/cmdutils/more/lang/de-DE.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Fortsetzung (%d%%) --"
     IDS_FILE_ACCESS "Auf die Datei %s kann nicht zugegriffen werden.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/de-DE.rc
+++ b/base/applications/cmdutils/more/lang/de-DE.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsetzung --"
     IDS_CONTINUE_PROGRESS "-- Fortsetzung (%d%%) --"

--- a/base/applications/cmdutils/more/lang/el-GR.rc
+++ b/base/applications/cmdutils/more/lang/el-GR.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Συνέχεια (%d%%) --"
     IDS_FILE_ACCESS "Δεν ήταν δυνατή η προσπέλαση του αρχείου %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/el-GR.rc
+++ b/base/applications/cmdutils/more/lang/el-GR.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Συνέχεια --"
     IDS_CONTINUE_PROGRESS "-- Συνέχεια (%d%%) --"

--- a/base/applications/cmdutils/more/lang/el-GR.rc
+++ b/base/applications/cmdutils/more/lang/el-GR.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Συνέχεια --"
     IDS_CONTINUE_PROGRESS "-- Συνέχεια (%d%%) --"
     IDS_FILE_ACCESS "Δεν ήταν δυνατή η προσπέλαση του αρχείου %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/el-GR.rc
+++ b/base/applications/cmdutils/more/lang/el-GR.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Συνέχεια --"
     IDS_CONTINUE_PROGRESS "-- Συνέχεια (%d%%) --"

--- a/base/applications/cmdutils/more/lang/el-GR.rc
+++ b/base/applications/cmdutils/more/lang/el-GR.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Συνέχεια --"
     IDS_CONTINUE_PROGRESS "-- Συνέχεια (%d%%) --"
     IDS_FILE_ACCESS "Δεν ήταν δυνατή η προσπέλαση του αρχείου %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/en-US.rc
+++ b/base/applications/cmdutils/more/lang/en-US.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continue --"
     IDS_CONTINUE_PROGRESS "-- Continue (%d%%) --"

--- a/base/applications/cmdutils/more/lang/en-US.rc
+++ b/base/applications/cmdutils/more/lang/en-US.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continue --"
     IDS_CONTINUE_PROGRESS "-- Continue (%d%%) --"
     IDS_FILE_ACCESS "Cannot access the file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/en-US.rc
+++ b/base/applications/cmdutils/more/lang/en-US.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continue --"
     IDS_CONTINUE_PROGRESS "-- Continue (%d%%) --"
     IDS_FILE_ACCESS "Cannot access the file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/en-US.rc
+++ b/base/applications/cmdutils/more/lang/en-US.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continue (%d%%) --"
     IDS_FILE_ACCESS "Cannot access the file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/en-US.rc
+++ b/base/applications/cmdutils/more/lang/en-US.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continue --"
     IDS_CONTINUE_PROGRESS "-- Continue (%d%%) --"

--- a/base/applications/cmdutils/more/lang/es-ES.rc
+++ b/base/applications/cmdutils/more/lang/es-ES.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continuar --"
     IDS_CONTINUE_PROGRESS "-- Continuar (%d%%) --"
     IDS_FILE_ACCESS "No se puede acceder al fichero %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/es-ES.rc
+++ b/base/applications/cmdutils/more/lang/es-ES.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuar --"
     IDS_CONTINUE_PROGRESS "-- Continuar (%d%%) --"

--- a/base/applications/cmdutils/more/lang/es-ES.rc
+++ b/base/applications/cmdutils/more/lang/es-ES.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuar --"
     IDS_CONTINUE_PROGRESS "-- Continuar (%d%%) --"
     IDS_FILE_ACCESS "No se puede acceder al fichero %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/es-ES.rc
+++ b/base/applications/cmdutils/more/lang/es-ES.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continuar (%d%%) --"
     IDS_FILE_ACCESS "No se puede acceder al fichero %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/es-ES.rc
+++ b/base/applications/cmdutils/more/lang/es-ES.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continuar --"
     IDS_CONTINUE_PROGRESS "-- Continuar (%d%%) --"

--- a/base/applications/cmdutils/more/lang/et-EE.rc
+++ b/base/applications/cmdutils/more/lang/et-EE.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Jätka (%d%%) --"
     IDS_FILE_ACCESS "Ei saa ligi failile %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/et-EE.rc
+++ b/base/applications/cmdutils/more/lang/et-EE.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Jätka --"
     IDS_CONTINUE_PROGRESS "-- Jätka (%d%%) --"

--- a/base/applications/cmdutils/more/lang/et-EE.rc
+++ b/base/applications/cmdutils/more/lang/et-EE.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Jätka --"
     IDS_CONTINUE_PROGRESS "-- Jätka (%d%%) --"
     IDS_FILE_ACCESS "Ei saa ligi failile %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/et-EE.rc
+++ b/base/applications/cmdutils/more/lang/et-EE.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Jätka --"
     IDS_CONTINUE_PROGRESS "-- Jätka (%d%%) --"

--- a/base/applications/cmdutils/more/lang/et-EE.rc
+++ b/base/applications/cmdutils/more/lang/et-EE.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Jätka --"
     IDS_CONTINUE_PROGRESS "-- Jätka (%d%%) --"
     IDS_FILE_ACCESS "Ei saa ligi failile %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/fr-FR.rc
+++ b/base/applications/cmdutils/more/lang/fr-FR.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continuer --"
     IDS_CONTINUE_PROGRESS "-- Continuer (%d %%) --"

--- a/base/applications/cmdutils/more/lang/fr-FR.rc
+++ b/base/applications/cmdutils/more/lang/fr-FR.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continuer (%d %%) --"
     IDS_FILE_ACCESS "Impossible d'accéder au fichier %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/fr-FR.rc
+++ b/base/applications/cmdutils/more/lang/fr-FR.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continuer --"
     IDS_CONTINUE_PROGRESS "-- Continuer (%d %%) --"
     IDS_FILE_ACCESS "Impossible d'accéder au fichier %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/fr-FR.rc
+++ b/base/applications/cmdutils/more/lang/fr-FR.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuer --"
     IDS_CONTINUE_PROGRESS "-- Continuer (%d %%) --"

--- a/base/applications/cmdutils/more/lang/fr-FR.rc
+++ b/base/applications/cmdutils/more/lang/fr-FR.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuer --"
     IDS_CONTINUE_PROGRESS "-- Continuer (%d %%) --"
     IDS_FILE_ACCESS "Impossible d'accéder au fichier %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/it-IT.rc
+++ b/base/applications/cmdutils/more/lang/it-IT.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"

--- a/base/applications/cmdutils/more/lang/it-IT.rc
+++ b/base/applications/cmdutils/more/lang/it-IT.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "Impossibile accedere al file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/it-IT.rc
+++ b/base/applications/cmdutils/more/lang/it-IT.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "Impossibile accedere al file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/it-IT.rc
+++ b/base/applications/cmdutils/more/lang/it-IT.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"
     IDS_FILE_ACCESS "Impossibile accedere al file %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/it-IT.rc
+++ b/base/applications/cmdutils/more/lang/it-IT.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continua --"
     IDS_CONTINUE_PROGRESS "-- Continua (%d%%) --"

--- a/base/applications/cmdutils/more/lang/lt-LT.rc
+++ b/base/applications/cmdutils/more/lang/lt-LT.rc
@@ -26,15 +26,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Toliau --"
     IDS_CONTINUE_PROGRESS "-- Toliau (%d%%) --"

--- a/base/applications/cmdutils/more/lang/lt-LT.rc
+++ b/base/applications/cmdutils/more/lang/lt-LT.rc
@@ -26,11 +26,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Toliau --"
     IDS_CONTINUE_PROGRESS "-- Toliau (%d%%) --"

--- a/base/applications/cmdutils/more/lang/lt-LT.rc
+++ b/base/applications/cmdutils/more/lang/lt-LT.rc
@@ -33,14 +33,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Toliau --"
     IDS_CONTINUE_PROGRESS "-- Toliau (%d%%) --"
     IDS_FILE_ACCESS "Nepavyko atverti bylos %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/lt-LT.rc
+++ b/base/applications/cmdutils/more/lang/lt-LT.rc
@@ -40,7 +40,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Toliau (%d%%) --"
     IDS_FILE_ACCESS "Nepavyko atverti bylos %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/lt-LT.rc
+++ b/base/applications/cmdutils/more/lang/lt-LT.rc
@@ -33,13 +33,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Toliau --"
     IDS_CONTINUE_PROGRESS "-- Toliau (%d%%) --"
     IDS_FILE_ACCESS "Nepavyko atverti bylos %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/no-NO.rc
+++ b/base/applications/cmdutils/more/lang/no-NO.rc
@@ -17,15 +17,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Fortsett --"
     IDS_CONTINUE_PROGRESS "-- Fortsett (%d%%) --"

--- a/base/applications/cmdutils/more/lang/no-NO.rc
+++ b/base/applications/cmdutils/more/lang/no-NO.rc
@@ -24,13 +24,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsett --"
     IDS_CONTINUE_PROGRESS "-- Fortsett (%d%%) --"
     IDS_FILE_ACCESS "Får ikke tilgang til filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/no-NO.rc
+++ b/base/applications/cmdutils/more/lang/no-NO.rc
@@ -31,7 +31,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Fortsett (%d%%) --"
     IDS_FILE_ACCESS "Får ikke tilgang til filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/no-NO.rc
+++ b/base/applications/cmdutils/more/lang/no-NO.rc
@@ -17,11 +17,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsett --"
     IDS_CONTINUE_PROGRESS "-- Fortsett (%d%%) --"

--- a/base/applications/cmdutils/more/lang/no-NO.rc
+++ b/base/applications/cmdutils/more/lang/no-NO.rc
@@ -24,14 +24,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Fortsett --"
     IDS_CONTINUE_PROGRESS "-- Fortsett (%d%%) --"
     IDS_FILE_ACCESS "Får ikke tilgang til filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/pl-PL.rc
+++ b/base/applications/cmdutils/more/lang/pl-PL.rc
@@ -25,15 +25,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Kontynuuj --"
     IDS_CONTINUE_PROGRESS "-- Kontynuuj (%d%%) --"

--- a/base/applications/cmdutils/more/lang/pl-PL.rc
+++ b/base/applications/cmdutils/more/lang/pl-PL.rc
@@ -39,7 +39,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Kontynuuj (%d%%) --"
     IDS_FILE_ACCESS "Brak dostępu do pliku: %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/pl-PL.rc
+++ b/base/applications/cmdutils/more/lang/pl-PL.rc
@@ -32,14 +32,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Kontynuuj --"
     IDS_CONTINUE_PROGRESS "-- Kontynuuj (%d%%) --"
     IDS_FILE_ACCESS "Brak dostępu do pliku: %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/pl-PL.rc
+++ b/base/applications/cmdutils/more/lang/pl-PL.rc
@@ -32,13 +32,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Kontynuuj --"
     IDS_CONTINUE_PROGRESS "-- Kontynuuj (%d%%) --"
     IDS_FILE_ACCESS "Brak dostępu do pliku: %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/pl-PL.rc
+++ b/base/applications/cmdutils/more/lang/pl-PL.rc
@@ -25,11 +25,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Kontynuuj --"
     IDS_CONTINUE_PROGRESS "-- Kontynuuj (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ro-RO.rc
+++ b/base/applications/cmdutils/more/lang/ro-RO.rc
@@ -32,13 +32,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuă --"
     IDS_CONTINUE_PROGRESS "-- Continuă (%d%%) --"
     IDS_FILE_ACCESS "Fișierul «%s» nu poate fi accesat!\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/ro-RO.rc
+++ b/base/applications/cmdutils/more/lang/ro-RO.rc
@@ -25,15 +25,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Continuă --"
     IDS_CONTINUE_PROGRESS "-- Continuă (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ro-RO.rc
+++ b/base/applications/cmdutils/more/lang/ro-RO.rc
@@ -25,11 +25,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Continuă --"
     IDS_CONTINUE_PROGRESS "-- Continuă (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ro-RO.rc
+++ b/base/applications/cmdutils/more/lang/ro-RO.rc
@@ -32,14 +32,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Continuă --"
     IDS_CONTINUE_PROGRESS "-- Continuă (%d%%) --"
     IDS_FILE_ACCESS "Fișierul «%s» nu poate fi accesat!\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ro-RO.rc
+++ b/base/applications/cmdutils/more/lang/ro-RO.rc
@@ -39,7 +39,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Continuă (%d%%) --"
     IDS_FILE_ACCESS "Fișierul «%s» nu poate fi accesat!\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ru-RU.rc
+++ b/base/applications/cmdutils/more/lang/ru-RU.rc
@@ -32,13 +32,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Продолжить --"
     IDS_CONTINUE_PROGRESS "-- Продолжить (%d%%) --"
     IDS_FILE_ACCESS "Нет доступа к файлу %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/ru-RU.rc
+++ b/base/applications/cmdutils/more/lang/ru-RU.rc
@@ -39,7 +39,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Продолжить (%d%%) --"
     IDS_FILE_ACCESS "Нет доступа к файлу %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ru-RU.rc
+++ b/base/applications/cmdutils/more/lang/ru-RU.rc
@@ -32,14 +32,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Продолжить --"
     IDS_CONTINUE_PROGRESS "-- Продолжить (%d%%) --"
     IDS_FILE_ACCESS "Нет доступа к файлу %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/ru-RU.rc
+++ b/base/applications/cmdutils/more/lang/ru-RU.rc
@@ -25,11 +25,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Продолжить --"
     IDS_CONTINUE_PROGRESS "-- Продолжить (%d%%) --"

--- a/base/applications/cmdutils/more/lang/ru-RU.rc
+++ b/base/applications/cmdutils/more/lang/ru-RU.rc
@@ -25,15 +25,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Продолжить --"
     IDS_CONTINUE_PROGRESS "-- Продолжить (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sk-SK.rc
+++ b/base/applications/cmdutils/more/lang/sk-SK.rc
@@ -28,13 +28,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Pokračujte --"
     IDS_CONTINUE_PROGRESS "-- Pokračujte (%d%%) --"
     IDS_FILE_ACCESS "Neviem získať prístup k súboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/sk-SK.rc
+++ b/base/applications/cmdutils/more/lang/sk-SK.rc
@@ -21,15 +21,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Pokračujte --"
     IDS_CONTINUE_PROGRESS "-- Pokračujte (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sk-SK.rc
+++ b/base/applications/cmdutils/more/lang/sk-SK.rc
@@ -28,14 +28,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Pokračujte --"
     IDS_CONTINUE_PROGRESS "-- Pokračujte (%d%%) --"
     IDS_FILE_ACCESS "Neviem získať prístup k súboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/sk-SK.rc
+++ b/base/applications/cmdutils/more/lang/sk-SK.rc
@@ -35,7 +35,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Pokračujte (%d%%) --"
     IDS_FILE_ACCESS "Neviem získať prístup k súboru %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/sk-SK.rc
+++ b/base/applications/cmdutils/more/lang/sk-SK.rc
@@ -21,11 +21,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Pokračujte --"
     IDS_CONTINUE_PROGRESS "-- Pokračujte (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sq-AL.rc
+++ b/base/applications/cmdutils/more/lang/sq-AL.rc
@@ -35,7 +35,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Vazhdo (%d%%) --"
     IDS_FILE_ACCESS "Nuk mund të aksesoj dokumentin %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/sq-AL.rc
+++ b/base/applications/cmdutils/more/lang/sq-AL.rc
@@ -21,15 +21,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Vazhdo --"
     IDS_CONTINUE_PROGRESS "-- Vazhdo (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sq-AL.rc
+++ b/base/applications/cmdutils/more/lang/sq-AL.rc
@@ -28,13 +28,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Vazhdo --"
     IDS_CONTINUE_PROGRESS "-- Vazhdo (%d%%) --"
     IDS_FILE_ACCESS "Nuk mund të aksesoj dokumentin %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/sq-AL.rc
+++ b/base/applications/cmdutils/more/lang/sq-AL.rc
@@ -28,14 +28,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Vazhdo --"
     IDS_CONTINUE_PROGRESS "-- Vazhdo (%d%%) --"
     IDS_FILE_ACCESS "Nuk mund të aksesoj dokumentin %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/sq-AL.rc
+++ b/base/applications/cmdutils/more/lang/sq-AL.rc
@@ -21,11 +21,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Vazhdo --"
     IDS_CONTINUE_PROGRESS "-- Vazhdo (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sv-SE.rc
+++ b/base/applications/cmdutils/more/lang/sv-SE.rc
@@ -24,15 +24,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Fortsätt --"
     IDS_CONTINUE_PROGRESS "-- Fortsätt (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sv-SE.rc
+++ b/base/applications/cmdutils/more/lang/sv-SE.rc
@@ -24,11 +24,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsätt --"
     IDS_CONTINUE_PROGRESS "-- Fortsätt (%d%%) --"

--- a/base/applications/cmdutils/more/lang/sv-SE.rc
+++ b/base/applications/cmdutils/more/lang/sv-SE.rc
@@ -31,13 +31,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Fortsätt --"
     IDS_CONTINUE_PROGRESS "-- Fortsätt (%d%%) --"
     IDS_FILE_ACCESS "Får inte tillgång till filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/sv-SE.rc
+++ b/base/applications/cmdutils/more/lang/sv-SE.rc
@@ -31,14 +31,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Fortsätt --"
     IDS_CONTINUE_PROGRESS "-- Fortsätt (%d%%) --"
     IDS_FILE_ACCESS "Får inte tillgång till filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/sv-SE.rc
+++ b/base/applications/cmdutils/more/lang/sv-SE.rc
@@ -38,7 +38,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Fortsätt (%d%%) --"
     IDS_FILE_ACCESS "Får inte tillgång till filen %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/tr-TR.rc
+++ b/base/applications/cmdutils/more/lang/tr-TR.rc
@@ -26,13 +26,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Sürdür --"
     IDS_CONTINUE_PROGRESS "-- Sürdür (%%%d) --"
     IDS_FILE_ACCESS "%s kütüğüne erişilemiyor.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/tr-TR.rc
+++ b/base/applications/cmdutils/more/lang/tr-TR.rc
@@ -33,7 +33,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Sürdür (%%%d) --"
     IDS_FILE_ACCESS "%s kütüğüne erişilemiyor.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/tr-TR.rc
+++ b/base/applications/cmdutils/more/lang/tr-TR.rc
@@ -26,14 +26,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Sürdür --"
     IDS_CONTINUE_PROGRESS "-- Sürdür (%%%d) --"
     IDS_FILE_ACCESS "%s kütüğüne erişilemiyor.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/tr-TR.rc
+++ b/base/applications/cmdutils/more/lang/tr-TR.rc
@@ -19,15 +19,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Sürdür --"
     IDS_CONTINUE_PROGRESS "-- Sürdür (%%%d) --"

--- a/base/applications/cmdutils/more/lang/tr-TR.rc
+++ b/base/applications/cmdutils/more/lang/tr-TR.rc
@@ -19,11 +19,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Sürdür --"
     IDS_CONTINUE_PROGRESS "-- Sürdür (%%%d) --"

--- a/base/applications/cmdutils/more/lang/uk-UA.rc
+++ b/base/applications/cmdutils/more/lang/uk-UA.rc
@@ -31,13 +31,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Далi --"
     IDS_CONTINUE_PROGRESS "-- Далi (%d%%) --"
     IDS_FILE_ACCESS "Не можу отримати доступ до файла %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/uk-UA.rc
+++ b/base/applications/cmdutils/more/lang/uk-UA.rc
@@ -24,15 +24,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- Далi --"
     IDS_CONTINUE_PROGRESS "-- Далi (%d%%) --"

--- a/base/applications/cmdutils/more/lang/uk-UA.rc
+++ b/base/applications/cmdutils/more/lang/uk-UA.rc
@@ -31,14 +31,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- Далi --"
     IDS_CONTINUE_PROGRESS "-- Далi (%d%%) --"
     IDS_FILE_ACCESS "Не можу отримати доступ до файла %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/uk-UA.rc
+++ b/base/applications/cmdutils/more/lang/uk-UA.rc
@@ -38,7 +38,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- Далi (%d%%) --"
     IDS_FILE_ACCESS "Не можу отримати доступ до файла %s.\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/uk-UA.rc
+++ b/base/applications/cmdutils/more/lang/uk-UA.rc
@@ -24,11 +24,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- Далi --"
     IDS_CONTINUE_PROGRESS "-- Далi (%d%%) --"

--- a/base/applications/cmdutils/more/lang/zh-CN.rc
+++ b/base/applications/cmdutils/more/lang/zh-CN.rc
@@ -26,13 +26,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- 继续 --"
     IDS_CONTINUE_PROGRESS "-- 继续 (%d%%) --"
     IDS_FILE_ACCESS "无法访问文件 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/lang/zh-CN.rc
+++ b/base/applications/cmdutils/more/lang/zh-CN.rc
@@ -33,7 +33,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- 继续 (%d%%) --"
     IDS_FILE_ACCESS "无法访问文件 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/zh-CN.rc
+++ b/base/applications/cmdutils/more/lang/zh-CN.rc
@@ -19,15 +19,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- 继续 --"
     IDS_CONTINUE_PROGRESS "-- 继续 (%d%%) --"

--- a/base/applications/cmdutils/more/lang/zh-CN.rc
+++ b/base/applications/cmdutils/more/lang/zh-CN.rc
@@ -26,14 +26,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- 继续 --"
     IDS_CONTINUE_PROGRESS "-- 继续 (%d%%) --"
     IDS_FILE_ACCESS "无法访问文件 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/zh-CN.rc
+++ b/base/applications/cmdutils/more/lang/zh-CN.rc
@@ -19,11 +19,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- 继续 --"
     IDS_CONTINUE_PROGRESS "-- 继续 (%d%%) --"

--- a/base/applications/cmdutils/more/lang/zh-TW.rc
+++ b/base/applications/cmdutils/more/lang/zh-TW.rc
@@ -33,7 +33,7 @@ at ""-- Continue --"" prompt:\n\
     IDS_CONTINUE_PROGRESS "-- 繼續 (%d%%) --"
     IDS_FILE_ACCESS "無法訪問檔案 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
-    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
+    IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/zh-TW.rc
+++ b/base/applications/cmdutils/more/lang/zh-TW.rc
@@ -19,15 +19,11 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.\n\
-   S n      Skip n lines.\n\
-   F        Display next file.\n\
-   Q        Quit.\n\
-   =        Show line number.\n\
-   ?        Show help line.\n\
-   <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   P n      Display n lines.        <Space>  Display next page.\n\
+   S n      Skip n lines.           <Enter>  Display next line.\n\
+   F        Display next file.      <Esc>    Same as Q.\n\
+   Q        Quit.                   =        Show line number.\n\
+   ?        Show help line.\n"
 
     IDS_CONTINUE "-- 繼續 --"
     IDS_CONTINUE_PROGRESS "-- 繼續 (%d%%) --"

--- a/base/applications/cmdutils/more/lang/zh-TW.rc
+++ b/base/applications/cmdutils/more/lang/zh-TW.rc
@@ -26,14 +26,13 @@ at ""-- Continue --"" prompt:\n\
    ?        Show help line.\n\
    =        Show line number.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n\
-   <Esc>    Same as Q.\n"
+   <Enter>  Display next line.\n"
 
     IDS_CONTINUE "-- 繼續 --"
     IDS_CONTINUE_PROGRESS "-- 繼續 (%d%%) --"
     IDS_FILE_ACCESS "無法訪問檔案 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter><Esc>] --"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) [Options: psfq=<Space><Enter>] --"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) [Line:%d] --"
 END

--- a/base/applications/cmdutils/more/lang/zh-TW.rc
+++ b/base/applications/cmdutils/more/lang/zh-TW.rc
@@ -19,11 +19,15 @@ Options:\n\
   Command                    A command, whose output shall be displayed.\n\n\
 If extended features are enabled, the following commands are available\n\
 at ""-- Continue --"" prompt:\n\
-   P n      Display n lines.        <Space>  Display next page.\n\
-   S n      Skip n lines.           <Enter>  Display next line.\n\
-   F        Display next file.      <Esc>    Same as Q.\n\
-   Q        Quit.                   =        Show line number.\n\
-   ?        Show help line.\n"
+   P n      Display n lines.\n\
+   S n      Skip n lines.\n\
+   F        Display next file.\n\
+   Q        Quit.\n\
+   ?        Show help line.\n\
+   =        Show line number.\n\
+   <Space>  Display next page.\n\
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- 繼續 --"
     IDS_CONTINUE_PROGRESS "-- 繼續 (%d%%) --"

--- a/base/applications/cmdutils/more/lang/zh-TW.rc
+++ b/base/applications/cmdutils/more/lang/zh-TW.rc
@@ -26,13 +26,14 @@ at ""-- Continue --"" prompt:\n\
    =        Show line number.\n\
    ?        Show help line.\n\
    <Space>  Display next page.\n\
-   <Enter>  Display next line.\n"
+   <Enter>  Display next line.\n\
+   <Esc>    Same as Q.\n"
 
     IDS_CONTINUE "-- 繼續 --"
     IDS_CONTINUE_PROGRESS "-- 繼續 (%d%%) --"
     IDS_FILE_ACCESS "無法訪問檔案 %s。\n"
     IDS_BAD_FLAG "Invalid argument - '%ls'\n"
-    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter>]"
+    IDS_CONTINUE_OPTIONS "-- Continue (%d%%) -- [Options: psfq=<Space><Enter><Esc>]"
     IDS_CONTINUE_LINES "-- Continue (%d%%) -- Lines: "
     IDS_CONTINUE_LINE_AT "-- Continue (%d%%) -- [Line:%d]"
 END

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -738,7 +738,7 @@ static BOOL IsFlag(PCWSTR param)
         pch = param + 1;
         if (*pch)
         {
-            wcstol(pch, &endptr, 10);
+            (void)wcstol(pch, &endptr, 10);
             return (*endptr == 0);
         }
     }

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -63,6 +63,8 @@ static DWORD s_dwFlags = FLAG_E;
 static DWORD s_nTabWidth = 8;
 static DWORD s_nNextLineNo = 0;
 static BOOL s_bPrevLineIsBlank = FALSE;
+static UINT s_nPromptID = IDS_CONTINUE_PROGRESS;
+static WCHAR s_chSubCommand = 0;
 
 static inline BOOL IsFlag(LPCWSTR param)
 {
@@ -217,8 +219,6 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
     BOOL fCtrl;
     DWORD nLines;
     WCHAR ch;
-    static UINT s_nPromptID = IDS_CONTINUE_PROGRESS;
-    static WCHAR s_chSubCommand = 0;
 Restart:
     nLines = 0;
 
@@ -1001,6 +1001,8 @@ int wmain(int argc, WCHAR* argv[])
     for (i = 1; i < argc; i++)
     {
         s_bPrevLineIsBlank = FALSE;
+        s_nPromptID = IDS_CONTINUE_PROGRESS;
+        s_chSubCommand = 0;
 
         if (IsFlag(argv[i]))
             continue;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -790,13 +790,10 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
                 }
                 break;
             case L'T':
-                if ((L'0' <= arg[2] && arg[2] <= L'9') || (arg[2] == L'-'))
-                {
-                    s_dwFlags |= FLAG_Tn;
-                    s_nTabWidth = wcstol(&arg[2], &endptr, 10);
-                    if (*endptr == 0)
-                        return TRUE;
-                }
+                s_dwFlags |= FLAG_Tn;
+                s_nTabWidth = wcstol(&arg[2], &endptr, 10);
+                if (*endptr == 0)
+                    return TRUE;
                 break;
             default:
                 break;
@@ -804,13 +801,10 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
     }
     else if (arg[0] == L'+')
     {
-        if ((L'0' <= arg[1] && arg[1] <= L'9') || (arg[1] == L'-'))
-        {
-            s_dwFlags |= FLAG_PLUSn;
-            s_nNextLineNo = wcstol(&arg[1], &endptr, 10) + 1;
-            if (*endptr == 0)
-                return TRUE;
-        }
+        s_dwFlags |= FLAG_PLUSn;
+        s_nNextLineNo = wcstol(&arg[1], &endptr, 10) + 1;
+        if (*endptr == 0)
+            return TRUE;
     }
 
     if (IsFlag(arg))

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -408,8 +408,8 @@ Restart:
     /* If extended features are available */
     if (s_dwFlags & FLAG_E)
     {
-        /* 'Q': Quit */
-        if (KeyEvent.wVirtualKeyCode == L'Q')
+        /* 'Q' or [Esc]: Quit */
+        if (KeyEvent.wVirtualKeyCode == L'Q' || KeyEvent.wVirtualKeyCode == VK_ESCAPE)
         {
             /* We break, output a newline */
             WCHAR ch = L'\n';

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -24,6 +24,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <assert.h>
 
 #include <windef.h>
 #include <winbase.h>
@@ -300,8 +301,9 @@ Restart:
             continue;
         }
 
-        /* Ignore any unsupported subcommand */
-        if (s_chSubCommand != L'P' && s_chSubCommand != L'S')
+        assert(s_chSubCommand == L'P' || s_chSubCommand == L'S' || s_chSubCommand == 0);
+
+        if (s_chSubCommand == 0)
             break;
 
         ch = KeyEvent.uChar.UnicodeChar;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -365,11 +365,9 @@ Restart:
     switch (chSubCommand)
     {
         case L'P':
-            chSubCommand = 0;
             Pager->ScrollRows = nLines;
             return TRUE;
         case L'S':
-            chSubCommand = 0;
             s_dwFlags |= FLAG_PLUSn;
             s_nNextLineNo = Pager->lineno + nLines;
             Pager->ScrollRows = Pager->ScreenRows - 1;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -144,7 +144,8 @@ MorePagerExpandTab(
 
     /* Store to buffer */
     iColumn = Pager->iColumn;
-    for (ich1 = ich2 = 0; ich1 < cch && ich2 < cch2; ++ich1)
+    // NOTE: Also, it would have been: ich2 <= cch2
+    for (ich1 = ich2 = 0; ich1 < cch /*&& ich2 < cch2*/; ++ich1)
     {
         if (line[ich1] == L'\t')
         {
@@ -278,7 +279,7 @@ Restart:
     // FIXME: Does not support TTY yet!
     for (;;)
     {
-        INPUT_RECORD ir;
+        INPUT_RECORD ir = {0};
         DWORD dwRead;
 
         do
@@ -885,9 +886,9 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
 
 static BOOL ParseMoreVariable(BOOL *pbHasFiles)
 {
+    BOOL ret = TRUE;
     LPWSTR psz, pch;
     DWORD cch;
-    BOOL ret;
 
     cch = GetEnvironmentVariableW(L"MORE", NULL, 0);
     if (cch == 0)
@@ -936,7 +937,7 @@ int wmain(int argc, WCHAR* argv[])
     PVOID FileCacheBuffer = NULL;
     PWCHAR StringBuffer = NULL;
     DWORD StringBufferLength = 0;
-    DWORD dwReadBytes, dwReadChars;
+    DWORD dwReadBytes = 0, dwReadChars = 0;
 
     TCHAR szFullPath[MAX_PATH];
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -257,8 +257,6 @@ Restart:
     }
     s_nPromptID = IDS_CONTINUE_PROGRESS;
 
-    // FIXME: Does not support TTY yet!
-
     /* RemoveBreakHandler */
     SetConsoleCtrlHandler(NULL, TRUE);
     /* ConInDisable */
@@ -950,11 +948,6 @@ int wmain(int argc, WCHAR* argv[])
     if (LoadRegistrySettings(HKEY_CURRENT_USER, bLoaded))
         s_dwFlags |= FLAG_E;
 
-    // TODO: First, load the "MORE" environment variable and parse it,
-    // then parse the command-line parameters.
-
-    // FIXME: Parse all the remaining parameters.
-    // Then the file list can be found at the very end.
     // FIXME2: Use the PARSER api that can be found in EVENTCREATE.
 
     // NOTE: We might try to duplicate the ConOut for read access... ?
@@ -972,6 +965,8 @@ int wmain(int argc, WCHAR* argv[])
         return 1;
     }
 
+    // First, load the "MORE" environment variable and parse it,
+    // then parse the command-line parameters.
     HasFiles = FALSE;
     if (!ParseMoreVariable(&HasFiles))
         return 1;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -215,6 +215,7 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
     BOOL fCtrl;
     DWORD nLines;
     WCHAR ch;
+
 Restart:
     nLines = 0;
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -710,7 +710,7 @@ LoadRegistrySettings(HKEY hKeyRoot)
                             L"EnableExtensions",
                             NULL,
                             &dwType,
-                            (LPBYTE)&Buffer,
+                            (PBYTE)&Buffer,
                             &len);
     if (lRet == ERROR_SUCCESS)
     {
@@ -725,10 +725,10 @@ LoadRegistrySettings(HKEY hKeyRoot)
     RegCloseKey(hKey);
 }
 
-static BOOL IsFlag(LPCWSTR param)
+static BOOL IsFlag(PCWSTR param)
 {
-    LPCWSTR pch;
-    LPWCH endptr;
+    PCWSTR pch;
+    PWCHAR endptr;
 
     if (param[0] == L'/')
         return TRUE;
@@ -745,9 +745,9 @@ static BOOL IsFlag(LPCWSTR param)
     return FALSE;
 }
 
-static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
+static BOOL ParseArgument(PCWSTR arg, BOOL* pbHasFiles)
 {
-    LPWCH endptr;
+    PWCHAR endptr;
 
     if (arg[0] == L'/')
     {
@@ -825,18 +825,18 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
     return TRUE;
 }
 
-static BOOL ParseMoreVariable(BOOL *pbHasFiles)
+static BOOL ParseMoreVariable(BOOL* pbHasFiles)
 {
     BOOL ret = TRUE;
-    LPWSTR psz;
-    LPWCH pch;
+    PWSTR psz;
+    PWCHAR pch;
     DWORD cch;
 
     cch = GetEnvironmentVariableW(L"MORE", NULL, 0);
     if (cch == 0)
         return TRUE;
 
-    psz = (LPWSTR)malloc((cch + 1) * sizeof(WCHAR));
+    psz = (PWSTR)malloc((cch + 1) * sizeof(WCHAR));
     if (!psz)
         return TRUE;
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -115,7 +115,7 @@ MorePagerExpandTab(
     }
 
     cch2 = ich2;
-    psz = malloc((cch2 + 1) * sizeof(WCHAR));
+    psz = malloc(cch2 * sizeof(WCHAR));
     if (!psz)
         return FALSE;
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -308,7 +308,6 @@ Restart:
         case L'S':
             s_dwFlags |= FLAG_PLUSn;
             s_nNextLineNo = Pager->lineno + nLines;
-            Pager->ScrollRows = Pager->ScreenRows - 1;
             return TRUE;
         default:
             chSubCommand = 0;
@@ -364,7 +363,6 @@ Restart:
                 /* Clear the screen */
                 ConClearScreen(Pager->Screen);
             }
-            Pager->ScrollRows = Pager->ScreenRows - 1;
             return TRUE;
         }
 
@@ -398,7 +396,6 @@ Restart:
     else
     {
         /* Extended features are unavailable: display one page */
-        Pager->ScrollRows = Pager->ScreenRows - 1;
         return TRUE;
     }
 }

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -194,7 +194,7 @@ Restart:
     // FIXME: Does not support TTY yet!
     for (;;)
     {
-        INPUT_RECORD ir = {0};
+        INPUT_RECORD ir;
         DWORD dwRead;
         WCHAR ch;
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -316,9 +316,9 @@ Restart:
         }
         if (KeyEvent.wVirtualKeyCode == VK_RETURN)
         {
-            s_chSubCommand = 0;
             if (nLines == 0)
             {
+                s_chSubCommand = 0;
                 ConClearLine(Pager->Screen->Stream);
                 goto Restart;
             }

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -913,7 +913,7 @@ int wmain(int argc, WCHAR* argv[])
 
     int i;
 
-    BOOL bRet, bContinue, bExtended;
+    BOOL bRet, bContinue;
 
     ENCODING Encoding;
     DWORD SkipBytes = 0;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -194,7 +194,7 @@ Restart:
     // FIXME: Does not support TTY yet!
     for (;;)
     {
-        INPUT_RECORD ir;
+        INPUT_RECORD ir = {0};
         DWORD dwRead;
         WCHAR ch;
 

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -121,8 +121,7 @@ MorePagerExpandTab(
 
     /* Store to buffer */
     iColumn = Pager->iColumn;
-    // NOTE: Also, it would have been: ich2 <= cch2
-    for (ich1 = ich2 = 0; ich1 < cch /*&& ich2 < cch2*/; ++ich1)
+    for (ich1 = ich2 = 0; ich1 < cch; ++ich1)
     {
         if (line[ich1] == L'\t')
         {

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -847,14 +847,11 @@ static BOOL ParseMoreVariable(BOOL *pbHasFiles)
         return TRUE;
     }
 
-    pch = wcstok(psz, L" ");
-    while (pch)
+    for (pch = wcstok(psz, L" "); pch; pch = wcstok(NULL, L" "))
     {
         ret = ParseArgument(pch, pbHasFiles);
         if (!ret)
             break;
-
-        pch = wcstok(NULL, L" ");
     }
 
     free(psz);

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -911,7 +911,7 @@ int wmain(int argc, WCHAR* argv[])
 
     int i;
 
-    BOOL bRet, bContinue, bLoaded;
+    BOOL bRet, bContinue, bExtended;
 
     ENCODING Encoding;
     DWORD SkipBytes = 0;
@@ -944,8 +944,9 @@ int wmain(int argc, WCHAR* argv[])
     }
 
     /* Load the registry settings */
-    bLoaded = LoadRegistrySettings(HKEY_LOCAL_MACHINE, FALSE);
-    if (LoadRegistrySettings(HKEY_CURRENT_USER, bLoaded))
+    bExtended = LoadRegistrySettings(HKEY_LOCAL_MACHINE, FALSE);
+    bExtended = LoadRegistrySettings(HKEY_CURRENT_USER, bExtended);
+    if (bExtended)
         s_dwFlags |= FLAG_E;
 
     // FIXME2: Use the PARSER api that can be found in EVENTCREATE.

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -1,14 +1,13 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS More Command
- * FILE:            base/applications/cmdutils/more/more.c
- * PURPOSE:         Displays text stream from STDIN or from an arbitrary number
- *                  of files to STDOUT, with screen capabilities (more than CAT,
- *                  but less than LESS ^^).
- * PROGRAMMERS:     Paolo Pantaleo
- *                  Timothy Schepens
- *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
- *                  Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * PROJECT:     ReactOS More Command
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Displays text stream from STDIN or from an arbitrary number
+ *              of files to STDOUT, with screen capabilities (more than CAT,
+ *              but less than LESS ^^).
+ * COPYRIGHT:   Copyright 1999 Paolo Pantaleo
+ *              Copyright 2003 Timothy Schepens
+ *              Copyright 2016-2021 Hermes Belusca-Maito
+ *              Copyright 2021 Katayama Hirofumi MZ
  */
 /*
  * MORE.C - external command.

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -112,6 +112,7 @@ MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
     BOOL ret;
     DWORD iColumn = Pager->iColumn;
 
+    /* Calculate expanded length */
     for (ich1 = ich2 = 0; ich1 < cch; ++ich1)
     {
         if (line[ich1] == L'\t')
@@ -137,6 +138,7 @@ MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
     if (!psz)
         return FALSE;
 
+    /* Store to buffer */
     iColumn = Pager->iColumn;
     for (ich1 = ich2 = 0; ich1 < cch && ich2 < cch2; ++ich1)
     {
@@ -161,6 +163,7 @@ MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
         }
     }
 
+    /* Do output */
     ret = (*Pager->DefPagerLine)(Pager, psz, ich2, pdwFlags);
     free(psz);
     Pager->iColumn = iColumn;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -27,6 +27,7 @@
 
 #include <windef.h>
 #include <winbase.h>
+#include <winnt.h>
 #include <winnls.h>
 #include <winreg.h>
 #include <winuser.h>
@@ -761,6 +762,8 @@ LoadRegistrySettings(HKEY hKeyRoot)
      * corresponding to the literal 0xFFFFFFFF (MAXULONG) in decimal.
      */
     WCHAR Buffer[11];
+    C_ASSERT(sizeof(Buffer) >= sizeof(L"4294967295"));
+    C_ASSERT(sizeof(Buffer) >= sizeof(DWORD));
 
     lRet = RegOpenKeyExW(hKeyRoot,
                          L"Software\\Microsoft\\Command Processor",

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -66,7 +66,6 @@ static DWORD s_nTabWidth = 8;
 static DWORD s_nNextLineNo = 0;
 static BOOL s_bPrevLineIsBlank = FALSE;
 static UINT s_nPromptID = IDS_CONTINUE_PROGRESS;
-static WCHAR s_chSubCommand = 0;
 static BOOL s_bDoNextFile = FALSE;
 
 static BOOL IsBlankLine(IN PCWCH line, IN DWORD cch)
@@ -111,8 +110,8 @@ MorePagerExpandTab(
         }
         else
         {
-            ++ich2;
             ++iColumn;
+            ++ich2;
         }
     }
 
@@ -142,8 +141,8 @@ MorePagerExpandTab(
         }
         else
         {
-            psz[ich2++] = line[ich1];
             ++iColumn;
+            psz[ich2++] = line[ich1];
         }
     }
 
@@ -203,6 +202,7 @@ PagePrompt(PCON_PAGER Pager, DWORD Done, DWORD Total)
     BOOL fCtrl;
     DWORD nLines;
     WCHAR ch;
+    WCHAR chSubCommand = 0;
 
 Restart:
     nLines = 0;
@@ -277,7 +277,7 @@ Restart:
         if (fCtrl && ((KeyEvent.wVirtualKeyCode == VK_ESCAPE) ||
                       (KeyEvent.wVirtualKeyCode == L'C')))
         {
-            s_chSubCommand = 0;
+            chSubCommand = 0;
             break;
         }
 
@@ -289,9 +289,9 @@ Restart:
             continue;
         }
 
-        assert(s_chSubCommand == L'P' || s_chSubCommand == L'S' || s_chSubCommand == 0);
+        assert(chSubCommand == L'P' || chSubCommand == L'S' || chSubCommand == 0);
 
-        if (s_chSubCommand == 0)
+        if (chSubCommand == 0)
             break;
 
         ch = KeyEvent.uChar.UnicodeChar;
@@ -308,7 +308,7 @@ Restart:
         {
             if (nLines == 0)
             {
-                s_chSubCommand = 0;
+                chSubCommand = 0;
                 ConClearLine(Pager->Screen->Stream);
                 goto Restart;
             }
@@ -316,7 +316,7 @@ Restart:
         }
         else if (KeyEvent.wVirtualKeyCode == VK_ESCAPE)
         {
-            s_chSubCommand = 0;
+            chSubCommand = 0;
             ConClearLine(Pager->Screen->Stream);
             goto Restart;
         }
@@ -354,20 +354,20 @@ Restart:
      */
     ConClearLine(Pager->Screen->Stream);
 
-    switch (s_chSubCommand)
+    switch (chSubCommand)
     {
         case L'P':
-            s_chSubCommand = 0;
+            chSubCommand = 0;
             Pager->ScrollRows = nLines;
             return TRUE;
         case L'S':
-            s_chSubCommand = 0;
+            chSubCommand = 0;
             s_dwFlags |= FLAG_PLUSn;
             s_nNextLineNo = Pager->lineno + nLines;
             Pager->ScrollRows = Pager->ScreenRows - 1;
             return TRUE;
         default:
-            s_chSubCommand = 0;
+            chSubCommand = 0;
             break;
     }
 
@@ -383,7 +383,7 @@ Restart:
 
     if (fCtrl)
     {
-        s_chSubCommand = 0;
+        chSubCommand = 0;
         goto Restart;
     }
 
@@ -436,7 +436,7 @@ Restart:
         if (KeyEvent.wVirtualKeyCode == L'P')
         {
             s_nPromptID = IDS_CONTINUE_LINES;
-            s_chSubCommand = L'P';
+            chSubCommand = L'P';
             goto Restart;
         }
 
@@ -444,7 +444,7 @@ Restart:
         if (KeyEvent.wVirtualKeyCode == L'S')
         {
             s_nPromptID = IDS_CONTINUE_LINES;
-            s_chSubCommand = L'S';
+            chSubCommand = L'S';
             goto Restart;
         }
 
@@ -457,7 +457,7 @@ Restart:
     }
 
     s_nPromptID = IDS_CONTINUE_PROGRESS;
-    s_chSubCommand = 0;
+    chSubCommand = 0;
     goto Restart;
 }
 
@@ -1053,7 +1053,6 @@ int wmain(int argc, WCHAR* argv[])
     {
         s_bPrevLineIsBlank = FALSE;
         s_nPromptID = IDS_CONTINUE_PROGRESS;
-        s_chSubCommand = 0;
         s_bDoNextFile = FALSE;
 
         if (IsFlag(argv[i]))

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -69,27 +69,6 @@ static UINT s_nPromptID = IDS_CONTINUE_PROGRESS;
 static WCHAR s_chSubCommand = 0;
 static BOOL s_bDoNextFile = FALSE;
 
-static inline BOOL IsFlag(LPCWSTR param)
-{
-    if (param[0] == L'/')
-        return TRUE;
-
-    if (param[0] == L'+')
-    {
-        LPCWSTR pch = param + 1;
-        if (L'0' <= *pch && *pch <= L'9')
-        {
-            do
-            {
-                ++pch;
-            } while (L'0' <= *pch && *pch <= L'9');
-
-            return (*pch == 0);
-        }
-    }
-    return FALSE;
-}
-
 static BOOL IsBlankLine(IN PCWCH line, IN DWORD cch)
 {
     DWORD ich;
@@ -802,6 +781,27 @@ LoadRegistrySettings(HKEY hKeyRoot)
     // else, use the default setting set globally.
 
     RegCloseKey(hKey);
+}
+
+static inline BOOL IsFlag(LPCWSTR param)
+{
+    if (param[0] == L'/')
+        return TRUE;
+
+    if (param[0] == L'+')
+    {
+        LPCWSTR pch = param + 1;
+        if (L'0' <= *pch && *pch <= L'9')
+        {
+            do
+            {
+                ++pch;
+            } while (L'0' <= *pch && *pch <= L'9');
+
+            return (*pch == 0);
+        }
+    }
+    return FALSE;
 }
 
 static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -90,7 +90,7 @@ static inline BOOL IsFlag(LPCWSTR param)
     return FALSE;
 }
 
-static BOOL IsBlankLine(LPCWSTR line, DWORD cch)
+static BOOL IsBlankLine(IN PCWCH line, IN DWORD cch)
 {
     DWORD ich;
     WORD wType;
@@ -104,10 +104,14 @@ static BOOL IsBlankLine(LPCWSTR line, DWORD cch)
     return TRUE;
 }
 
-static BOOL CALLBACK
-MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
+static BOOL __stdcall
+MorePagerExpandTab(
+    IN OUT PCON_PAGER Pager,
+    IN PCWCH line,
+    IN DWORD cch,
+    IN OUT PDWORD pdwFlags)
 {
-    LPWSTR psz;
+    PWCHAR psz;
     DWORD ich1, ich2, cch2, spaces;
     BOOL ret;
     DWORD iColumn = Pager->iColumn;
@@ -134,7 +138,7 @@ MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
     }
 
     cch2 = ich2;
-    psz = (LPWSTR)malloc((cch2 + 1) * sizeof(WCHAR));
+    psz = malloc((cch2 + 1) * sizeof(WCHAR));
     if (!psz)
         return FALSE;
 
@@ -164,14 +168,18 @@ MorePagerExpandTab(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
     }
 
     /* Do output */
-    ret = (*Pager->DefPagerLine)(Pager, psz, ich2, pdwFlags);
+    ret = Pager->DefPagerLine(Pager, psz, ich2, pdwFlags);
     free(psz);
     Pager->iColumn = iColumn;
     return ret;
 }
 
-static BOOL CALLBACK
-MorePagerLine(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
+static BOOL __stdcall
+MorePagerLine(
+    IN OUT PCON_PAGER Pager,
+    IN PCWCH line,
+    IN DWORD cch,
+    IN OUT PDWORD pdwFlags)
 {
     if (s_dwFlags & FLAG_PLUSn)
     {

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -126,7 +126,7 @@ MorePagerLine(
     }
 
     s_nNextLineNo = 0;
-    return Pager->DefPagerLine(Pager, line, cch);
+    return FALSE; /* Do output */
 }
 
 static BOOL

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -56,7 +56,7 @@ HANDLE hKeyboard;
 #define FLAG_Tn (1 << 5)
 #define FLAG_PLUSn (1 << 6)
 
-static DWORD s_dwFlags = FLAG_E;
+static DWORD s_dwFlags = 0;
 static DWORD s_nTabWidth = 8;
 static DWORD s_nNextLineNo = 0;
 static BOOL s_bPrevLineIsBlank = FALSE;
@@ -913,7 +913,7 @@ int wmain(int argc, WCHAR* argv[])
 
     int i;
 
-    BOOL bRet, bContinue;
+    BOOL bRet, bContinue, bLoaded;
 
     ENCODING Encoding;
     DWORD SkipBytes = 0;
@@ -946,17 +946,9 @@ int wmain(int argc, WCHAR* argv[])
     }
 
     /* Load the registry settings */
-    s_dwFlags = 0;
-    if (LoadRegistrySettings(HKEY_LOCAL_MACHINE, FALSE))
-    {
-        if (LoadRegistrySettings(HKEY_CURRENT_USER, TRUE))
-            s_dwFlags = FLAG_E;
-    }
-    else
-    {
-        if (LoadRegistrySettings(HKEY_CURRENT_USER, FALSE))
-            s_dwFlags = FLAG_E;
-    }
+    bLoaded = LoadRegistrySettings(HKEY_LOCAL_MACHINE, FALSE);
+    if (LoadRegistrySettings(HKEY_CURRENT_USER, bLoaded))
+        s_dwFlags |= FLAG_E;
 
     // TODO: First, load the "MORE" environment variable and parse it,
     // then parse the command-line parameters.

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -790,10 +790,13 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
                 }
                 break;
             case L'T':
-                s_dwFlags |= FLAG_Tn;
-                s_nTabWidth = wcstol(&arg[2], &endptr, 10);
-                if (*endptr == 0)
-                    return TRUE;
+                if (arg[2] != 0)
+                {
+                    s_dwFlags |= FLAG_Tn;
+                    s_nTabWidth = wcstol(&arg[2], &endptr, 10);
+                    if (*endptr == 0)
+                        return TRUE;
+                }
                 break;
             default:
                 break;
@@ -801,10 +804,13 @@ static BOOL ParseArgument(LPCWSTR arg, BOOL *pbHasFiles)
     }
     else if (arg[0] == L'+')
     {
-        s_dwFlags |= FLAG_PLUSn;
-        s_nNextLineNo = wcstol(&arg[1], &endptr, 10) + 1;
-        if (*endptr == 0)
-            return TRUE;
+        if (arg[1] != 0)
+        {
+            s_dwFlags |= FLAG_PLUSn;
+            s_nNextLineNo = wcstol(&arg[1], &endptr, 10) + 1;
+            if (*endptr == 0)
+                return TRUE;
+        }
     }
 
     if (IsFlag(arg))

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -109,6 +109,7 @@ MorePagerLine(
                 Pager->dwFlags |= CON_PAGER_FLAG_DONT_OUTPUT;
                 return TRUE; /* Don't output */
             }
+
             for (ich = 0; ich < cch; ++ich)
             {
                 if (line[ich] == L'\n')

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -716,7 +716,7 @@ LoadRegistrySettings(HKEY hKeyRoot)
     RegCloseKey(hKey);
 }
 
-static inline BOOL IsFlag(LPCWSTR param)
+static BOOL IsFlag(LPCWSTR param)
 {
     if (param[0] == L'/')
         return TRUE;

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -112,7 +112,10 @@ MorePagerLine(
             for (ich = 0; ich < cch; ++ich)
             {
                 if (line[ich] == L'\n')
+                {
                     s_bPrevLineIsBlank = TRUE;
+                    break;
+                }
             }
         }
         else

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -48,9 +48,6 @@ HANDLE hFile = INVALID_HANDLE_VALUE;
 HANDLE hStdIn, hStdOut;
 HANDLE hKeyboard;
 
-/* Enable/Disable extensions */
-BOOL s_bEnableExtensions = FALSE;
-
 #define FLAG_HELP (1 << 0)
 #define FLAG_E (1 << 1)
 #define FLAG_C (1 << 2)

--- a/base/applications/cmdutils/more/more.c
+++ b/base/applications/cmdutils/more/more.c
@@ -935,6 +935,8 @@ int wmain(int argc, WCHAR* argv[])
 
     Pager.PagerLine = MorePagerLine;
     Pager.dwFlags |= CON_PAGER_FLAG_EXPAND_TABS;
+    if (s_dwFlags & FLAG_P)
+        Pager.dwFlags |= CON_PAGER_FLAG_EXPAND_FF;
     Pager.nTabWidth = s_nTabWidth;
 
     /* Special case where we run 'MORE' without any argument: we use STDIN */

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -469,7 +469,6 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00
 
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
-HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010003,1
 
 ; Uninstall Application list
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",,0x00000012

--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -469,6 +469,7 @@ HKCU,"SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\BitBucket\Volume",,0x00
 
 ; CMD Settings
 HKLM,"SOFTWARE\Microsoft\Command Processor","AutoRun",0x00020000,""
+HKLM,"SOFTWARE\Microsoft\Command Processor","EnableExtensions",0x00010003,1
 
 ; Uninstall Application list
 HKLM,"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",,0x00000012

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -119,12 +119,6 @@ ExpandTab:
     for (; ich < cch && iLine < ScrollRows; ++ich)
     {
         Pager->lineno = lineno;
-        if (IsCJK)
-        {
-            nWidthOfChar = GetWidthOfCharCJK(nCodePage, TextBuff[ich]);
-            IsDoubleWidthCharTrailing = (nWidthOfChar == 2) &&
-                                        ((iColumn + 1) % ScreenColumns == 0);
-        }
 
         /* TAB character */
         if (TextBuff[ich] == TEXT('\t') &&
@@ -154,6 +148,13 @@ ExpandTab:
         }
 
         /* Other character - Handle double-width for CJK */
+
+        if (IsCJK)
+        {
+            nWidthOfChar = GetWidthOfCharCJK(nCodePage, TextBuff[ich]);
+            IsDoubleWidthCharTrailing = (nWidthOfChar == 2) &&
+                                        ((iColumn + 1) % ScreenColumns == 0);
+        }
 
         if ((iColumn + nWidthOfChar) % ScreenColumns == 0)
         {

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -151,7 +151,8 @@ ExpandTab:
             {
                 ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
                 ichLast = ich;
-                CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
+                if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                    CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
                 --ich;
             }
             else

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -58,16 +58,6 @@ GetWidthOfCharCJK(
     return ret;
 }
 
-static BOOL __stdcall
-ConDefaultPagerLine(
-    IN OUT PCON_PAGER Pager,
-    IN PCTCH line,
-    IN DWORD cch)
-{
-    CON_STREAM_WRITE(Pager->Screen->Stream, line, cch);
-    return TRUE;
-}
-
 static VOID
 ConCallPagerLine(
     IN OUT PCON_PAGER Pager,
@@ -77,7 +67,7 @@ ConCallPagerLine(
     Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT; /* Clear the flag */
 
     if (!Pager->PagerLine || !Pager->PagerLine(Pager, line, cch))
-        ConDefaultPagerLine(Pager, line, cch);
+        CON_STREAM_WRITE(Pager->Screen->Stream, line, cch);
 }
 
 static BOOL

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -91,7 +91,7 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
     DWORD lineno = Pager->lineno;
     const DWORD ScreenColumns = Pager->ScreenColumns;
     const DWORD ScrollRows = Pager->ScrollRows;
-    const DWORD nTabWidth = Pager->nTabWidth;
+    const LONG nTabWidth = Pager->nTabWidth;
     DWORD ichLast = ich;
     UINT nWidthOfChar = 1;
     UINT nCodePage;

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -147,19 +147,21 @@ ExpandTab:
 
         if ((iColumn + nWidthOfChar) % ScreenColumns == 0)
         {
-            if (IsDoubleWidthCharTrailing)
-            {
-                ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
-                ichLast = ich;
-                if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
-                    CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
-                --ich;
-            }
-            else
-            {
-                ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast + 1);
-                ichLast = ich + 1;
-            }
+            ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast + 1);
+            ichLast = ich + 1;
+            if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                ++iLine;
+            iColumn += nWidthOfChar;
+            continue;
+        }
+
+        if (IsDoubleWidthCharTrailing)
+        {
+            ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
+            ichLast = ich;
+            if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
+            --ich;
             if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
                 ++iLine;
             ++iColumn;

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -235,7 +235,10 @@ ConWritePaging(
     Pager->cch = len;
     Pager->TextBuff = szStr;
     if (StartPaging)
+    {
+        /* Reset to display one page by default */
         Pager->ScrollRows = Pager->ScreenRows - 1;
+    }
 
     if (len == 0 || szStr == NULL)
         return TRUE;
@@ -255,6 +258,9 @@ ConWritePaging(
             Pager->ScreenColumns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
             Pager->ScreenRows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
         }
+
+        /* Reset to display one page by default */
+        Pager->ScrollRows = Pager->ScreenRows - 1;
 
         /* Prompt the user; give him some values for statistics */
         if (!PagePrompt(Pager, Pager->ich, Pager->cch))

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -74,6 +74,8 @@ ConCallPagerLine(
     IN PCTCH line,
     IN DWORD cch)
 {
+    Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT; /* Clear the flag */
+
     if (!Pager->PagerLine || !Pager->PagerLine(Pager, line, cch))
         Pager->DefPagerLine(Pager, line, cch);
 }
@@ -107,7 +109,6 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
 ExpandTab:
         while ((Pager->nSpacePending > 0) && (iLine < ScrollRows))
         {
-            Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
             ConCallPagerLine(Pager, L" ", 1);
             --(Pager->nSpacePending);
             ++iColumn;
@@ -132,7 +133,6 @@ ExpandTab:
         if (TextBuff[ich] == TEXT('\t') &&
             (Pager->dwFlags & CON_PAGER_FLAG_EXPAND_TABS))
         {
-            Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
             ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
             ichLast = ++ich;
             Pager->nSpacePending += nTabWidth - (iColumn % nTabWidth);
@@ -140,7 +140,6 @@ ExpandTab:
         }
         if (TextBuff[ich] == TEXT('\n') || iColumn + nWidthOfChar >= ScreenColumns)
         {
-            Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
             ConCallPagerLine(Pager, &TextBuff[ichLast],
                              ich - ichLast + !IsDoubleWidthCharTrailing);
             ichLast = ich + !IsDoubleWidthCharTrailing;
@@ -160,10 +159,7 @@ ExpandTab:
     }
 
     if (iColumn > 0)
-    {
-        Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
         ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
-    }
 
     if (iLine >= ScrollRows)
         iLine = 0; /* Reset the count of lines being printed */
@@ -203,7 +199,6 @@ ConWritePaging(
     if (!ConGetScreenInfo(Pager->Screen, &csbi))
     {
         /* We assume it's a file handle */
-        Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
         ConCallPagerLine(Pager, szStr, len);
         return TRUE;
     }
@@ -224,7 +219,6 @@ ConWritePaging(
     /* Make sure the user doesn't have the screen too small */
     if (Pager->ScreenRows < 4)
     {
-        Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT;
         ConCallPagerLine(Pager, szStr, len);
         return TRUE;
     }

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -102,11 +102,10 @@ ExpandTab:
             ConCallPagerLine(Pager, L" ", 1);
             --(Pager->nSpacePending);
             ++iColumn;
-            if (iColumn >= ScreenColumns)
+            if (iColumn % ScreenColumns == 0)
             {
                 if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
                     ++iLine;
-                iColumn = 0;
             }
         }
     }
@@ -118,7 +117,7 @@ ExpandTab:
         {
             nWidthOfChar = GetWidthOfCharCJK(nCodePage, TextBuff[ich]);
             IsDoubleWidthCharTrailing = (nWidthOfChar == 2) &&
-                                        (iColumn + 1 == ScreenColumns);
+                                        ((iColumn + 1) % ScreenColumns == 0);
         }
 
         if (TextBuff[ich] == TEXT('\t') &&
@@ -135,7 +134,8 @@ ExpandTab:
             goto ExpandTab;
         }
 
-        if (TextBuff[ich] == TEXT('\n') || iColumn + nWidthOfChar >= ScreenColumns)
+        if (TextBuff[ich] == TEXT('\n') ||
+            ((iColumn + nWidthOfChar) % ScreenColumns == 0))
         {
             ConCallPagerLine(Pager, &TextBuff[ichLast],
                              ich - ichLast + !IsDoubleWidthCharTrailing);
@@ -148,14 +148,21 @@ ExpandTab:
             if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
                 ++iLine;
             if (TextBuff[ich] == TEXT('\n'))
+            {
                 ++lineno;
-            iColumn = 0;
+                iColumn = 0;
+            }
+            else
+            {
+                ++iColumn;
+            }
             continue;
         }
+
         iColumn += nWidthOfChar;
     }
 
-    if (iColumn > 0)
+    if (iColumn % ScreenColumns > 0)
         ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
 
     if (iLine >= ScrollRows)

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -80,7 +80,7 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
     DWORD lineno = Pager->lineno;
     const DWORD ScreenColumns = Pager->ScreenColumns;
     const DWORD ScrollRows = Pager->ScrollRows;
-    const LONG nTabWidth = Pager->nTabWidth;
+    LONG nTabWidth = Pager->nTabWidth;
     DWORD ichLast = ich;
     UINT nCodePage;
     BOOL IsCJK;
@@ -92,6 +92,13 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
 
     nCodePage = GetConsoleOutputCP();
     IsCJK = IsCJKCodePage(nCodePage);
+
+    /* Normalize the tab width: if negative or too large,
+     * cap it to the number of columns. */
+    if (nTabWidth < 0)
+        nTabWidth = Pager->ScreenColumns - 1;
+    else
+        nTabWidth = min(nTabWidth, Pager->ScreenColumns - 1);
 
     if (Pager->dwFlags & CON_PAGER_FLAG_EXPAND_TABS)
     {

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -45,7 +45,10 @@
   /* (CodePage) == CP_JOHAB || */ \
      (CodePage) == CP_BIG5     || (CodePage) == CP_GB2312)
 
-static inline INT GetWidthOfCharCJK(UINT nCodePage, WCHAR ch)
+static inline INT
+GetWidthOfCharCJK(
+    IN UINT nCodePage,
+    IN WCHAR ch)
 {
     INT ret = WideCharToMultiByte(nCodePage, 0, &ch, 1, NULL, 0, NULL, NULL);
     if (ret == 0)
@@ -55,21 +58,30 @@ static inline INT GetWidthOfCharCJK(UINT nCodePage, WCHAR ch)
     return ret;
 }
 
-static BOOL CALLBACK
-ConDefaultPagerLine(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
+static BOOL __stdcall
+ConDefaultPagerLine(
+    IN OUT PCON_PAGER Pager,
+    IN PCTCH line,
+    IN DWORD cch,
+    IN OUT PDWORD pdwFlags)
 {
     CON_STREAM_WRITE(Pager->Screen->Stream, line, cch);
     return TRUE;
 }
 
-static VOID CALLBACK
-ConCallPagerLine(PCON_PAGER Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags)
+static VOID
+ConCallPagerLine(
+    IN OUT PCON_PAGER Pager,
+    IN PCTCH line,
+    IN DWORD cch,
+    IN OUT PDWORD pdwFlags)
 {
-    if (!Pager->PagerLine || !(*Pager->PagerLine)(Pager, line, cch, pdwFlags))
-        (*Pager->DefPagerLine)(Pager, line, cch, pdwFlags);
+    if (!Pager->PagerLine || !Pager->PagerLine(Pager, line, cch, pdwFlags))
+        Pager->DefPagerLine(Pager, line, cch, pdwFlags);
 }
 
-static BOOL CALLBACK ConPagerDefaultAction(PCON_PAGER Pager)
+static BOOL
+ConPagerDefaultAction(IN PCON_PAGER Pager)
 {
     PCTCH TextBuff = Pager->TextBuff;
     DWORD ich = Pager->ich;

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -177,7 +177,6 @@ ConWritePaging(
     /* Fill the pager info */
     Pager->ScreenColumns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
     Pager->ScreenRows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
-    Pager->PagerAction = ConPagerDefaultAction;
     Pager->DefPagerLine = ConDefaultPagerLine;
     Pager->ich = 0;
     Pager->cch = len;
@@ -196,7 +195,7 @@ ConWritePaging(
         return TRUE;
     }
 
-    while (!Pager->PagerAction(Pager))
+    while (!ConPagerDefaultAction(Pager))
     {
         /* Recalculate the screen extent in case the user redimensions the window. */
         if (ConGetScreenInfo(Pager->Screen, &csbi))
@@ -204,9 +203,6 @@ ConWritePaging(
             Pager->ScreenColumns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
             Pager->ScreenRows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
         }
-
-        /* PagePrompt might change this value */
-        Pager->PagerAction = ConPagerDefaultAction;
 
         /* Prompt the user; give him some values for statistics */
         if (!PagePrompt(Pager, Pager->ich, Pager->cch))

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -70,7 +70,7 @@ ConCallPagerLine(
 }
 
 static BOOL
-ConPagerDefaultAction(IN PCON_PAGER Pager)
+ConPagerWorker(IN PCON_PAGER Pager)
 {
     PCTCH TextBuff = Pager->TextBuff;
     DWORD ich = Pager->ich;
@@ -88,7 +88,7 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
     BOOL IsDoubleWidthCharTrailing = FALSE;
 
     if (ich >= cch)
-        return TRUE;
+        return FALSE;
 
     nCodePage = GetConsoleOutputCP();
     IsCJK = IsCJKCodePage(nCodePage);
@@ -212,7 +212,7 @@ ExpandTab:
     Pager->iLine = iLine;
     Pager->lineno = lineno;
 
-    return (ich >= cch);
+    return (ich < cch);
 }
 
 /* Returns TRUE when all the text is displayed, and FALSE if display is stopped */
@@ -269,7 +269,7 @@ ConWritePaging(
         return TRUE;
     }
 
-    while (!ConPagerDefaultAction(Pager))
+    while (ConPagerWorker(Pager))
     {
         /* Recalculate the screen extent in case the user redimensions the window */
         if (ConGetScreenInfo(Pager->Screen, &csbi))

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -121,7 +121,7 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
             ichLast = ich + !IsDoubleWidthCharTrailing;
             if (IsDoubleWidthCharTrailing)
             {
-                CON_STREAM_WRITE(Pager->Screen->Stream, L" ", 1);
+                CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
                 --ich;
             }
             if (dwFlags & CON_PAGER_LINE_FLAG_NEWLINE)
@@ -138,7 +138,6 @@ ConPagerDefaultAction(IN PCON_PAGER Pager)
     {
         dwFlags &= ~CON_PAGER_LINE_FLAG_NEWLINE;
         ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast, &dwFlags);
-        iColumn = Pager->iColumn;
     }
 
     if (iLine >= ScrollRows)

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -130,6 +130,7 @@ ExpandTab:
             IsDoubleWidthCharTrailing = (nWidthOfChar == 2) &&
                                         (iColumn + 1 == ScreenColumns);
         }
+
         if (TextBuff[ich] == TEXT('\t') &&
             (Pager->dwFlags & CON_PAGER_FLAG_EXPAND_TABS))
         {
@@ -138,6 +139,7 @@ ExpandTab:
             Pager->nSpacePending += nTabWidth - (iColumn % nTabWidth);
             goto ExpandTab;
         }
+
         if (TextBuff[ich] == TEXT('\n') || iColumn + nWidthOfChar >= ScreenColumns)
         {
             ConCallPagerLine(Pager, &TextBuff[ichLast],

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -77,7 +77,7 @@ ConCallPagerLine(
     Pager->dwFlags &= ~CON_PAGER_FLAG_DONT_OUTPUT; /* Clear the flag */
 
     if (!Pager->PagerLine || !Pager->PagerLine(Pager, line, cch))
-        Pager->DefPagerLine(Pager, line, cch);
+        ConDefaultPagerLine(Pager, line, cch);
 }
 
 static BOOL
@@ -213,7 +213,6 @@ ConWritePaging(
     /* Fill the pager info */
     Pager->ScreenColumns = csbi.srWindow.Right - csbi.srWindow.Left + 1;
     Pager->ScreenRows = csbi.srWindow.Bottom - csbi.srWindow.Top + 1;
-    Pager->DefPagerLine = ConDefaultPagerLine;
     Pager->ich = 0;
     Pager->cch = len;
     Pager->TextBuff = szStr;

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -147,6 +147,25 @@ ExpandTab:
             continue;
         }
 
+        /* FORM-FEED character */
+        if (TextBuff[ich] == TEXT('\f') &&
+            (Pager->dwFlags & CON_PAGER_FLAG_EXPAND_FF))
+        {
+            /* Skip the form-feed and clear until the end of the screen */
+            ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
+            ichLast = ich + 1;
+            // FIXME: Should we handle CON_PAGER_FLAG_DONT_OUTPUT ?
+            while (iLine < ScrollRows)
+            {
+                ConCallPagerLine(Pager, L"\n", 1);
+                // CON_STREAM_WRITE(Pager->Screen->Stream, TEXT("\n"), 1);
+                // if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                ++iLine;
+            }
+            iColumn = 0;
+            continue;
+        }
+
         /* Other character - Handle double-width for CJK */
 
         if (IsCJK)

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -135,6 +135,11 @@ ExpandTab:
             (Pager->dwFlags & CON_PAGER_FLAG_EXPAND_TABS))
         {
             ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
+            if (nTabWidth == 0)
+            {
+                ichLast = ich + 1;
+                continue;
+            }
             ichLast = ++ich;
             Pager->nSpacePending += nTabWidth - (iColumn % nTabWidth);
             goto ExpandTab;

--- a/sdk/lib/conutils/pager.c
+++ b/sdk/lib/conutils/pager.c
@@ -134,28 +134,34 @@ ExpandTab:
             goto ExpandTab;
         }
 
-        if (TextBuff[ich] == TEXT('\n') ||
-            ((iColumn + nWidthOfChar) % ScreenColumns == 0))
+        if (TextBuff[ich] == TEXT('\n'))
         {
-            ConCallPagerLine(Pager, &TextBuff[ichLast],
-                             ich - ichLast + !IsDoubleWidthCharTrailing);
-            ichLast = ich + !IsDoubleWidthCharTrailing;
+            ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast + 1);
+            ichLast = ich + 1;
+            if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                ++iLine;
+            ++lineno;
+            iColumn = 0;
+            continue;
+        }
+
+        if ((iColumn + nWidthOfChar) % ScreenColumns == 0)
+        {
             if (IsDoubleWidthCharTrailing)
             {
+                ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast);
+                ichLast = ich;
                 CON_STREAM_WRITE(Pager->Screen->Stream, TEXT(" "), 1);
                 --ich;
             }
-            if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
-                ++iLine;
-            if (TextBuff[ich] == TEXT('\n'))
-            {
-                ++lineno;
-                iColumn = 0;
-            }
             else
             {
-                ++iColumn;
+                ConCallPagerLine(Pager, &TextBuff[ichLast], ich - ichLast + 1);
+                ichLast = ich + 1;
             }
+            if (!(Pager->dwFlags & CON_PAGER_FLAG_DONT_OUTPUT))
+                ++iLine;
+            ++iColumn;
             continue;
         }
 

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -41,19 +41,26 @@ typedef BOOL (__stdcall *CON_PAGER_LINE_FN)(
 
 typedef struct _CON_PAGER
 {
+    /* Console screen properties */
     PCON_SCREEN Screen;
     DWORD ScreenColumns;
     DWORD ScreenRows;
-    DWORD ScrollRows;
+
+    /* Paging parameters */
     CON_PAGER_LINE_FN PagerLine; /* The line function */
+    LONG  nTabWidth;
+    DWORD ScrollRows;
+
+    /* Data buffer */
     PCTCH TextBuff; /* The text buffer */
-    DWORD ich;      /* The current index of character */
     DWORD cch;      /* The total number of characters */
+
+    /* Paging state */
+    DWORD ich;      /* The current index of character */
     DWORD iColumn;  /* The current index of column */
     DWORD iLine;    /* The physical output line count of screen */
     DWORD lineno;   /* The logical line number */
     DWORD dwFlags;  /* The CON_PAGER_FLAG_... flags */
-    LONG nTabWidth;
     DWORD nSpacePending;
 } CON_PAGER, *PCON_PAGER;
 

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -29,10 +29,13 @@ extern "C" {
 // #include <wincon.h>
 
 struct _CON_PAGER;
-typedef BOOL (CALLBACK *CON_PAGER_LINE_FN)(
-    struct _CON_PAGER *Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags);
+typedef BOOL (__stdcall *CON_PAGER_LINE_FN)(
+    IN OUT struct _CON_PAGER *Pager,
+    IN PCTCH line,
+    IN DWORD cch,
+    IN OUT PDWORD pdwFlags);
 
-// flags for CON_PAGER_LINE_FN
+/* Flags for CON_PAGER_LINE_FN */
 #define CON_PAGER_LINE_FLAG_NEWLINE (1 << 0)
 
 typedef struct _CON_PAGER
@@ -53,10 +56,10 @@ typedef struct _CON_PAGER
 
 #define INIT_CON_PAGER(pScreen)     {(pScreen), 0}
 
-#define InitializeConPager(pPager, pScreen) \
+#define InitializeConPager(pPager, pScreen)  \
 do { \
     ZeroMemory((pPager), sizeof(*(pPager))); \
-    (pPager)->Screen = (pScreen); \
+    (pPager)->Screen = (pScreen);            \
 } while (0)
 
 

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -2,8 +2,8 @@
  * PROJECT:     ReactOS Console Utilities Library
  * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
  * PURPOSE:     Console/terminal paging functionality.
- * COPYRIGHT:   Copyright 2017-2018 ReactOS Team
- *              Copyright 2017-2018 Hermes Belusca-Maito
+ * COPYRIGHT:   Copyright 2017-2021 Hermes Belusca-Maito
+ *              Copyright 2021 Katayama Hirofumi MZ
  */
 
 /**
@@ -46,12 +46,12 @@ typedef struct _CON_PAGER
     DWORD ScrollRows;
     CON_PAGER_LINE_FN PagerLine; /* The line function */
     PCTCH TextBuff; /* The text buffer */
-    DWORD ich; /* The current index of character */
-    DWORD cch; /* The total number of characters */
-    DWORD iColumn; /* The current index of column */
-    DWORD iLine; /* The physical output line count of screen */
-    DWORD lineno; /* The logical line number */
-    DWORD dwFlags; /* The CON_PAGER_FLAG_... flags */
+    DWORD ich;      /* The current index of character */
+    DWORD cch;      /* The total number of characters */
+    DWORD iColumn;  /* The current index of column */
+    DWORD iLine;    /* The physical output line count of screen */
+    DWORD lineno;   /* The logical line number */
+    DWORD dwFlags;  /* The CON_PAGER_FLAG_... flags */
     LONG nTabWidth;
     DWORD nSpacePending;
 } CON_PAGER, *PCON_PAGER;

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -53,7 +53,7 @@ typedef struct _CON_PAGER
     DWORD iLine; /* The physical output line count of screen */
     DWORD lineno; /* The logical line number */
     DWORD dwFlags; /* The CON_PAGER_FLAG_... flags */
-    DWORD nTabWidth;
+    LONG nTabWidth;
     DWORD nSpacePending;
 } CON_PAGER, *PCON_PAGER;
 

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -35,7 +35,7 @@ typedef BOOL (__stdcall *CON_PAGER_LINE_FN)(
     IN DWORD cch);
 
 /* Flags for CON_PAGER */
-#define CON_PAGER_FLAG_NEWLINE (1 << 0)
+#define CON_PAGER_FLAG_DONT_OUTPUT (1 << 0)
 #define CON_PAGER_FLAG_EXPAND_TABS (1 << 1)
 
 typedef struct _CON_PAGER

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -49,8 +49,8 @@ typedef struct _CON_PAGER
     DWORD ich; /* The current index of character */
     DWORD cch; /* The total number of characters */
     DWORD iColumn; /* The current index of column */
-    DWORD iLine; /* The output line count */
-    DWORD lineno; /* The line number */
+    DWORD iLine; /* The physical output line count of screen */
+    DWORD lineno; /* The logical line number */
 } CON_PAGER, *PCON_PAGER;
 
 #define INIT_CON_PAGER(pScreen)     {(pScreen), 0}

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -37,6 +37,7 @@ typedef BOOL (__stdcall *CON_PAGER_LINE_FN)(
 /* Flags for CON_PAGER */
 #define CON_PAGER_FLAG_DONT_OUTPUT (1 << 0)
 #define CON_PAGER_FLAG_EXPAND_TABS (1 << 1)
+#define CON_PAGER_FLAG_EXPAND_FF   (1 << 2)
 
 typedef struct _CON_PAGER
 {

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -45,7 +45,6 @@ typedef struct _CON_PAGER
     DWORD ScreenRows;
     DWORD ScrollRows;
     CON_PAGER_LINE_FN PagerLine; /* The line function */
-    CON_PAGER_LINE_FN DefPagerLine; /* Default line function */
     PCTCH TextBuff; /* The text buffer */
     DWORD ich; /* The current index of character */
     DWORD cch; /* The total number of characters */

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -29,7 +29,6 @@ extern "C" {
 // #include <wincon.h>
 
 struct _CON_PAGER;
-typedef BOOL (CALLBACK *CON_PAGER_ACTION_FN)(struct _CON_PAGER *Pager);
 typedef BOOL (CALLBACK *CON_PAGER_LINE_FN)(
     struct _CON_PAGER *Pager, LPCWSTR line, DWORD cch, DWORD *pdwFlags);
 
@@ -42,7 +41,6 @@ typedef struct _CON_PAGER
     DWORD ScreenColumns;
     DWORD ScreenRows;
     DWORD ScrollRows;
-    CON_PAGER_ACTION_FN PagerAction; /* The action function */
     CON_PAGER_LINE_FN PagerLine; /* The line function */
     CON_PAGER_LINE_FN DefPagerLine; /* Default line function */
     PCTCH TextBuff; /* The text buffer */

--- a/sdk/lib/conutils/pager.h
+++ b/sdk/lib/conutils/pager.h
@@ -32,11 +32,11 @@ struct _CON_PAGER;
 typedef BOOL (__stdcall *CON_PAGER_LINE_FN)(
     IN OUT struct _CON_PAGER *Pager,
     IN PCTCH line,
-    IN DWORD cch,
-    IN OUT PDWORD pdwFlags);
+    IN DWORD cch);
 
-/* Flags for CON_PAGER_LINE_FN */
-#define CON_PAGER_LINE_FLAG_NEWLINE (1 << 0)
+/* Flags for CON_PAGER */
+#define CON_PAGER_FLAG_NEWLINE (1 << 0)
+#define CON_PAGER_FLAG_EXPAND_TABS (1 << 1)
 
 typedef struct _CON_PAGER
 {
@@ -52,6 +52,9 @@ typedef struct _CON_PAGER
     DWORD iColumn; /* The current index of column */
     DWORD iLine; /* The physical output line count of screen */
     DWORD lineno; /* The logical line number */
+    DWORD dwFlags; /* The CON_PAGER_FLAG_... flags */
+    DWORD nTabWidth;
+    DWORD nSpacePending;
 } CON_PAGER, *PCON_PAGER;
 
 #define INIT_CON_PAGER(pScreen)     {(pScreen), 0}


### PR DESCRIPTION
## Purpose

Implement missing features of the `MORE` command.

JIRA issue: [CORE-4019](https://jira.reactos.org/browse/CORE-4019)

## Proposed changes

- Extend `conutils` module.
- Implement all the subcommands of `MORE`.
- Handle long lines.
- Modify `IDS_USAGE` resource string.
- Add `IDS_BAD_FLAG`, `IDS_CONTINUE_OPTIONS`, `IDS_CONTINUE_LINES` and `IDS_CONTINUE_LINE_AT` resource strings.
- Handle command line options.

## TODO

- [x] Do test.
- [x] `/C` option.
- [x]  `/P` option.
- [x] `/S` option.
- [x] `/Tn` option.
- [x] `+n` option.
- [x] `P` subcommand.
- [x] `S` subcommand.
- [x] `F` subcommand.
- [x] `Q` subcommand.
- [x] `=` subcommand.
- [x]  `?` subcommand.
- [x] `<Space>` subcommand.
- [x] `<Enter>` subcommand.
- [x] Considering double-width characters.
- [x] Tabs