### PR TITLE
[LOCALSPL] InitializePrinterDrivers(): Fix LocalGetPrinterDriverDirec…

### DIFF
--- a/win32ss/printing/providers/localspl/printerdrivers.c
+++ b/win32ss/printing/providers/localspl/printerdrivers.c
@@ -94,7 +94,7 @@ InitializePrinterDrivers(VOID)
     StringCbCopyW(wszPrintUiFile, sizeof(wszPrintUiFile), szSysDir);
     StringCbCatW(wszPrintUiFile, sizeof(wszPrintUiFile), L"\\printui.dll");
 
-    if (!LocalGetPrinterDriverDirectory( NULL, (PWSTR)wszCurrentEnvironment, 1, (PBYTE)szSysDir, cbBuf, &cbBuf ) )
+    if (!LocalGetPrinterDriverDirectory(NULL, (PWSTR)wszCurrentEnvironment, 1, (PBYTE)szSysDir, (DWORD)sizeof(szSysDir), &cbBuf))
     {
         ERR("LocalGetPrinterDriverDirectory failed\n");
         return FALSE;


### PR DESCRIPTION
…tory) call

Fix Clang-Cl
'...\printerdrivers.c(97,98): warning: variable 'cbBuf' is uninitialized when used here [-Wuninitialized]'

Addendum to 62c4b82.
JIRA issue: [CORE-14306](https://jira.reactos.org/browse/CORE-14306)