### PR TITLE
[KERNEL32][NTDLL] Implement SetSearchPathMode and RtlSetSearchPathMode

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -1158,6 +1158,7 @@
 @ stub -version=0x600+ RtlSetProcessDebugInformation
 @ cdecl RtlSetProcessIsCritical(long ptr long)
 @ stdcall RtlSetSaclSecurityDescriptor(ptr long ptr long)
+@ stdcall RtlSetSearchPathMode(long)
 @ stdcall RtlSetSecurityDescriptorRMControl(ptr ptr)
 @ stdcall RtlSetSecurityObject(long ptr ptr ptr ptr)
 @ stdcall RtlSetSecurityObjectEx(long ptr ptr long ptr ptr)

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -1120,7 +1120,7 @@ GetFullPathNameW(IN LPCWSTR lpFileName,
  */
 BOOL
 WINAPI
-SetSearchPathMode(IN DWORD dwFlags)
+SetSearchPathMode(_In_ DWORD dwFlags)
 {
     NTSTATUS Status;
 

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -4,6 +4,7 @@
  * FILE:            dll/win32/kernel32/client/path.c
  * PURPOSE:         Handles path APIs
  * PROGRAMMERS:     Alex Ionescu (alex.ionescu@reactos.org)
+ *                  Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
  */
 
 /* INCLUDES *******************************************************************/
@@ -1112,6 +1113,26 @@ GetFullPathNameW(IN LPCWSTR lpFileName,
                                 nBufferLength * sizeof(WCHAR),
                                 lpBuffer,
                                 lpFilePart) / sizeof(WCHAR);
+}
+
+/*
+ * @implemented
+ */
+BOOL
+WINAPI
+SetSearchPathMode(IN DWORD dwFlags)
+{
+    NTSTATUS Status;
+
+    /* Call Rtl to do the work */
+    Status = RtlSetSearchPathMode(dwFlags);
+    if (!NT_SUCCESS(Status))
+    {
+        SetLastError(RtlNtStatusToDosError(Status));
+        return FALSE;
+    }
+
+    return NT_SUCCESS(Status);
 }
 
 /*

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -1128,7 +1128,7 @@ SetSearchPathMode(IN DWORD dwFlags)
     Status = RtlSetSearchPathMode(dwFlags);
     if (!NT_SUCCESS(Status))
     {
-        SetLastError(RtlNtStatusToDosError(Status));
+        BaseSetLastNTError(Status);
         return FALSE;
     }
 

--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -1132,7 +1132,7 @@ SetSearchPathMode(IN DWORD dwFlags)
         return FALSE;
     }
 
-    return NT_SUCCESS(Status);
+    return TRUE;
 }
 
 /*

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -1060,6 +1060,7 @@
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)
 @ stdcall SetProcessWorkingSetSizeEx(long long long long)
+@ stdcall SetSearchPathMode(long)
 @ stdcall SetStdHandle(long long)
 @ stub -version=0x600+ SetStdHandleEx
 @ stdcall SetSystemFileCacheSize(long long long)

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -4825,6 +4825,16 @@ RtlStatMemoryStream(
     _In_ ULONG Flags
 );
 
+//
+// Search functions
+//
+NTSYSAPI
+NTSTATUS
+NTAPI
+RtlSetSearchPathMode(
+    _In_ ULONG Flags
+);
+
 // Dummy functions
 NTSYSAPI
 HRESULT

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -3166,6 +3166,7 @@ BOOL WINAPI SetProcessAffinityMask(_In_ HANDLE, _In_ DWORD_PTR);
 BOOL WINAPI SetProcessPriorityBoost(_In_ HANDLE, _In_ BOOL);
 BOOL WINAPI SetProcessShutdownParameters(DWORD,DWORD);
 BOOL WINAPI SetProcessWorkingSetSize(_In_ HANDLE, _In_ SIZE_T, _In_ SIZE_T);
+BOOL WINAPI SetSearchPathMode(_In_ DWORD);
 #if (_WIN32_WINNT >= 0x0600)
 VOID WINAPI SetSecurityAccessMask(SECURITY_INFORMATION,LPDWORD);
 #endif

--- a/sdk/lib/rtl/path.c
+++ b/sdk/lib/rtl/path.c
@@ -2177,17 +2177,17 @@ RtlSetSearchPathMode(_In_ ULONG Flags)
 
     switch (Flags)
     {
-    case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE:
-        RetVal = 1;
-        break;
-    case BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE:
-        RetVal = 0;
-        break;
-    case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT:
-        InterlockedExchange((LONG *)&RtlPathSafeMode, 2);
-        return STATUS_SUCCESS;
-    default:
-        return STATUS_INVALID_PARAMETER;
+        case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE:
+            RetVal = 1;
+            break;
+        case BASE_SEARCH_PATH_DISABLE_SAFE_SEARCHMODE:
+            RetVal = 0;
+            break;
+        case BASE_SEARCH_PATH_ENABLE_SAFE_SEARCHMODE | BASE_SEARCH_PATH_PERMANENT:
+            InterlockedExchange((LONG *)&RtlPathSafeMode, 2);
+            return STATUS_SUCCESS;
+        default:
+            return STATUS_INVALID_PARAMETER;
     }
 
     for (;;)

--- a/sdk/lib/rtl/path.c
+++ b/sdk/lib/rtl/path.c
@@ -2171,7 +2171,7 @@ NTSTATUS NTAPI RtlNtPathNameToDosPathName(IN ULONG Flags,
  */
 NTSTATUS
 NTAPI
-RtlSetSearchPathMode(IN ULONG Flags)
+RtlSetSearchPathMode(_In_ ULONG Flags)
 {
     LONG RetVal;
 

--- a/sdk/lib/rtl/path.c
+++ b/sdk/lib/rtl/path.c
@@ -52,7 +52,7 @@ static const UNICODE_STRING RtlpDefaultExtension = RTL_CONSTANT_STRING(L".DLL");
 static const UNICODE_STRING RtlpDotLocal = RTL_CONSTANT_STRING(L".Local\\");
 static const UNICODE_STRING RtlpPathDividers = RTL_CONSTANT_STRING(L"\\/");
 
-/* Search mode used by RtlDosSearchPath_Ustr() and RtlSetSeatchPathMode() */
+/* Search mode used by RtlDosSearchPath_Ustr() and RtlSetSearchPathMode() */
 // TODO: this value should be obtained from predefined registry entry.
 // Perhaps RtlDosSearchPath_Ustr() should do it.
 // For now initialize it as zero.


### PR DESCRIPTION
## Purpose

Implement `SetSearchPathMode` in kernel32 and call an appropriate `RtlSetSearchPathMode` from ntdll inside it, which I also implemented (partially based on Wine's one).
Although from the start these APIs were introduced since Windows 7/Server 2008 R2, they are also available for XP/2003 via update, so they exist as well on XPSP3/2K3SP2.
Required by KeePassX 0.4.4 to start successfully.

JIRA issue: [CORE-17586](https://jira.reactos.org/browse/CORE-17586)

## TODO

- [ ] Properly obtain the search mode value from registry in failure case. I'm not sure about where it should be implemented. Or it just should be done by the caller itself, judging by MSDN?... :thinking: 

## Result

Although my implementation is still incomplete, nevertheless it is enough to allow KeePassX to start successfully, as visible on screenshots. :slightly_smiling_face: 

Before:
![keepassx-error](https://user-images.githubusercontent.com/26385117/118373582-63581f80-b5c0-11eb-81aa-68d270549476.png)

After:
![keepassx-ros](https://user-images.githubusercontent.com/26385117/118373590-6d7a1e00-b5c0-11eb-84da-7ed2e2609f26.png)

XP:
![keepassx-xp](https://user-images.githubusercontent.com/26385117/118373774-2d676b00-b5c1-11eb-9e96-2e813519ff5d.png)