### PR TITLE
[NTOS:SE] Capture the groups length when creating a token

### DIFF
--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -4197,7 +4197,7 @@ NtCreateToken(
                             CapturedUser,
                             GroupCount,
                             CapturedGroups,
-                            0, // FIXME: Should capture
+                            GroupsLength,
                             PrivilegeCount,
                             CapturedPrivileges,
                             CapturedOwnerSid,


### PR DESCRIPTION
The groups length is already returned by SeCaptureSidAndAttributesArray, it doesn't make sense to not use it.