### PR TITLE
[GITPOD] change extract directory to automatically extract to RosBE, …

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -14,8 +14,7 @@ RUN sudo apt-get -q update && \
     sudo rm -rf /var/lib/apt/lists/*
 
 RUN wget https://svn.reactos.org/amine/RosBEBinFull.tar.gz && \
-    sudo tar -xzf RosBEBinFull.tar.gz -C /usr/local && \
-    sudo mv /usr/local/RosBEBinFull /usr/local/RosBE && \
+    sudo tar -xzvf RosBEBinFull.tar.gz -C /usr/local --one-top-level=RosBE --strip-components 1 && \
     rm -f RosBEBinFull.tar.gz
 
 RUN echo 'export PATH=/usr/local/RosBE/i386/bin:$PATH' >> /home/gitpod/.profile


### PR DESCRIPTION
## Purpose

change extract directory to automatically extract to RosBE, and set tar to verbose mode shorting the waiting time for the user and have verbose mode activated to show if there were any issues with the file itself. therefore helping the user and developer.

JIRA issue: [CORE-XXXX](https://jira.reactos.org/browse/CORE-XXXX)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- verbose mode flag activated
- tar directory flags changed