### PR TITLE
[NTOS:MM] Do not map Process Working Set List in kernel space

### DIFF
--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -916,7 +916,7 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
     PWCHAR Source;
     PCHAR Destination;
     USHORT Length = 0;
-    MMPTE TempPte;
+
 #if (_MI_PAGING_LEVELS >= 3)
     PMMPPE PointerPpe;
 #endif
@@ -1002,13 +1002,6 @@ MmInitializeProcessAddressSpace(IN PEPROCESS Process,
 
     /* Now initialize the working set list */
     MiInitializeWorkingSetList(&Process->Vm);
-
-    /* Map the process working set in kernel space */
-    /* FIXME: there should be no need */
-    PointerPte = MiReserveSystemPtes(1, SystemPteSpace);
-    MI_MAKE_HARDWARE_PTE_KERNEL(&TempPte, PointerPte, MM_READWRITE, Process->WorkingSetPage);
-    MI_WRITE_VALID_PTE(PointerPte, TempPte);
-    Process->Vm.VmWorkingSetList = MiPteToAddress(PointerPte);
 
     /* The rule is that the owner process is always in the FLINK of the PDE's PFN entry */
     Pfn = MiGetPfnEntry(Process->Pcb.DirectoryTableBase[0] >> PAGE_SHIFT);
@@ -1361,7 +1354,6 @@ MmDeleteProcessAddressSpace2(IN PEPROCESS Process)
         MiDecrementShareCount(Pfn2, Pfn1->u4.PteFrame);
         MiDecrementShareCount(Pfn1, Process->WorkingSetPage);
         ASSERT((Pfn1->u3.e2.ReferenceCount == 0) || (Pfn1->u3.e1.WriteInProgress));
-        MiReleaseSystemPtes(MiAddressToPte(Process->Vm.VmWorkingSetList), 1, SystemPteSpace);
 
         /* Now map hyperspace and its page table */
         PageFrameIndex = Process->Pcb.DirectoryTableBase[1] >> PAGE_SHIFT;


### PR DESCRIPTION
This is not needed anymore and causes havoc on amd64

## Purpose
Remove a hack which is not necessary anymore and only wastes System PTE space

