### PR TITLE
[NTOS:KE] Test spinlock ownership on both UP & MP build

### DIFF
--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -277,14 +277,11 @@ if(MSVC)
 else()
     target_link_options(freeldr_pe PRIVATE -Wl,--exclude-all-symbols,--file-alignment,0x200,--section-alignment,0x200)
     add_linker_script(freeldr_pe freeldr_gcc.lds)
-    if (NOT SEPARATE_DBG)
-        target_link_options(freeldr_pe PRIVATE -Wl,--strip-all)
-    else()
-        # Strip everything (more than objcopy --strip-debug does)
-        add_custom_command(TARGET freeldr_pe
-                        POST_BUILD
-                        COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:freeldr_pe>)
-    endif()
+    # Strip everything, including rossym data
+    add_custom_command(TARGET freeldr_pe
+                    POST_BUILD
+                    COMMAND ${CMAKE_STRIP} --remove-section=.rossym $<TARGET_FILE:freeldr_pe>
+                    COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:freeldr_pe>)
 endif()
 
 set_image_base(freeldr_pe 0x10000)

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -1,11 +1,4 @@
 
-if(SEPARATE_DBG)
-    # FIXME: http://sourceware.org/bugzilla/show_bug.cgi?id=11822
-    set(CMAKE_LDR_PE_HELPER_LINK_EXECUTABLE "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
-    set(CMAKE_LDR_PE_HELPER_STANDARD_LIBRARIES_INIT "")
-    set(CMAKE_LDR_PE_HELPER_STANDARD_LIBRARIES "-lgcc" CACHE STRING "Standard C Libraries")
-endif()
-
 if(MSVC)
     # Explicitly use string pooling
     add_compile_options("/GF")
@@ -265,69 +258,56 @@ if(ARCH STREQUAL "i386")
 endif()
 
 add_executable(freeldr_pe ${FREELDR_BASE_SOURCE})
-add_executable(freeldr_pe_dbg EXCLUDE_FROM_ALL ${FREELDR_BASE_SOURCE})
 
-set_target_properties(freeldr_pe freeldr_pe_dbg
+set_target_properties(freeldr_pe
     PROPERTIES
     ENABLE_EXPORTS TRUE
     DEFINE_SYMBOL "")
 
-if(NOT MSVC AND SEPARATE_DBG)
-    set_target_properties(freeldr_pe PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)
-    set_target_properties(freeldr_pe_dbg PROPERTIES LINKER_LANGUAGE LDR_PE_HELPER)
-endif()
-
 if(MSVC)
     if(ARCH STREQUAL "arm")
         add_target_link_flags(freeldr_pe "/ignore:4078 /ignore:4254 /DRIVER")
-        add_target_link_flags(freeldr_pe_dbg "/ignore:4078 /ignore:4254 /DRIVER")
     else()
         target_link_options(freeldr_pe PRIVATE /ignore:4078 /ignore:4254 /DYNAMICBASE:NO /FIXED /FILEALIGN:512 /ALIGN:512)
         add_linker_script(freeldr_pe freeldr_i386.msvc.lds)
-        target_link_options(freeldr_pe_dbg PRIVATE /ignore:4078 /ignore:4254 /DYNAMICBASE:NO /FIXED /FILEALIGN:512 /ALIGN:512)
-        add_linker_script(freeldr_pe_dbg freeldr_i386.msvc.lds)
     endif()
     # We don't need hotpatching
     remove_target_compile_option(freeldr_pe "/hotpatch")
-    remove_target_compile_option(freeldr_pe_dbg "/hotpatch")
     remove_target_compile_option(freeldr_common "/hotpatch")
 else()
-    add_target_link_flags(freeldr_pe "-Wl,--strip-all,--exclude-all-symbols,--file-alignment,0x200,--section-alignment,0x200")
+    target_link_options(freeldr_pe PRIVATE -Wl,--exclude-all-symbols,--file-alignment,0x200,--section-alignment,0x200)
     add_linker_script(freeldr_pe freeldr_gcc.lds)
-    add_target_link_flags(freeldr_pe_dbg "-Wl,--exclude-all-symbols,--file-alignment,0x200,--section-alignment,0x200")
-    add_linker_script(freeldr_pe_dbg freeldr_gcc.lds)
+    if (NOT SEPARATE_DBG)
+        target_link_options(freeldr_pe PRIVATE -Wl,--strip-all)
+    else()
+        # Strip everything (more than objcopy --strip-debug does)
+        add_custom_command(TARGET freeldr_pe
+                        POST_BUILD
+                        COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:freeldr_pe>)
+    endif()
 endif()
 
 set_image_base(freeldr_pe 0x10000)
 set_subsystem(freeldr_pe native)
 set_entrypoint(freeldr_pe RealEntryPoint)
 
-set_image_base(freeldr_pe_dbg 0x10000)
-set_subsystem(freeldr_pe_dbg native)
-set_entrypoint(freeldr_pe_dbg RealEntryPoint)
-
 if(ARCH STREQUAL "i386")
     target_link_libraries(freeldr_pe mini_hal)
-    target_link_libraries(freeldr_pe_dbg mini_hal)
 endif()
 
 target_link_libraries(freeldr_pe freeldr_common cportlib cmlib rtl libcntpr)
-target_link_libraries(freeldr_pe_dbg freeldr_common cportlib cmlib rtl libcntpr)
 
 # dynamic analysis switches
 if(STACK_PROTECTOR)
     target_sources(freeldr_pe PRIVATE $<TARGET_OBJECTS:gcc_ssp_nt>)
-    target_sources(freeldr_pe_dbg PRIVATE $<TARGET_OBJECTS:gcc_ssp_nt>)
 endif()
 
 if(RUNTIME_CHECKS)
     target_link_libraries(freeldr_pe runtmchk)
-    target_link_libraries(freeldr_pe_dbg runtmchk)
     add_target_link_flags(freeldr_pe "/MERGE:.rtc=.text")
 endif()
 
 add_dependencies(freeldr_pe asm)
-add_dependencies(freeldr_pe_dbg asm)
 
 if(SARCH STREQUAL "pc98")
     file(MAKE_DIRECTORY ${REACTOS_BINARY_DIR}/PC98)

--- a/boot/freeldr/freeldr/arch/i386/ntoskrnl.c
+++ b/boot/freeldr/freeldr/arch/i386/ntoskrnl.c
@@ -28,6 +28,14 @@ FASTCALL
 KefAcquireSpinLockAtDpcLevel(
     IN PKSPIN_LOCK SpinLock)
 {
+#if DBG
+    /* To be on par with HAL/NTOSKRNL */
+#ifdef _M_AMD64
+    *SpinLock = (KSPIN_LOCK)KeGetCurrentThread() | 1;
+#else
+    *SpinLock = (KSPIN_LOCK)(((PKIPCR)KeGetPcr())->PrcbData.CurrentThread) | 1;
+#endif
+#endif
 }
 
 VOID

--- a/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
+++ b/modules/rostests/kmtests/ntos_ke/KeSpinLock.c
@@ -167,12 +167,16 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
 {                                                                                   \
     PKTHREAD Thread = KeGetCurrentThread();                                         \
     (VOID)Thread;                                                                   \
-    if (KmtIsMultiProcessorBuild)                                                   \
+    if (KmtIsMultiProcessorBuild || KmtIsCheckedBuild)                              \
     {                                                                               \
         ok_eq_bool(Ret, (Value) == 0);                                              \
         if (SpinLock)                                                               \
-            ok_eq_ulongptr(*(SpinLock),                                             \
-                        (Value) ? (ULONG_PTR)Thread | 1 : 0);                       \
+        {                                                                           \
+            if (KmtIsCheckedBuild)                                                  \
+                ok_eq_ulongptr(*(SpinLock), (Value) ? (ULONG_PTR)Thread | 1 : 0);   \
+            else                                                                    \
+                ok_eq_ulongptr(*(SpinLock), (Value) ? 1 : 0);                       \
+        }                                                                           \
     }                                                                               \
     else                                                                            \
     {                                                                               \
@@ -192,7 +196,7 @@ BOOLEAN TryNoRaise(PKSPIN_LOCK SpinLock, PCHECK_DATA CheckData) {
 
 #define CheckSpinLockQueueHandle(SpinLock, CheckData, Value) do                     \
 {                                                                                   \
-    if (KmtIsMultiProcessorBuild)                                                   \
+    if (KmtIsMultiProcessorBuild || KmtIsCheckedBuild)                              \
     {                                                                               \
         ok_eq_bool(Ret, (Value) == 0);                                              \
         if (SpinLock)                                                               \

--- a/ntoskrnl/cache/newcc.h
+++ b/ntoskrnl/cache/newcc.h
@@ -160,3 +160,16 @@ CcpPinMappedData(IN PNOCC_CACHE_MAP Map,
                  IN ULONG Length,
                  IN ULONG Flags,
                  IN OUT PVOID *Bcb);
+
+ULONG
+MmGetReferenceCountPageWithoutLock(PFN_NUMBER Page)
+{
+    ULONG Ret;
+    KIRQL OldIrql = MiAcquirePfnLock();
+
+    Ret = MmGetReferenceCountPage(Page);
+
+    MiReleasePfnLock(OldIrql);
+
+    return Ret;
+}

--- a/ntoskrnl/cache/section/data.c
+++ b/ntoskrnl/cache/section/data.c
@@ -643,7 +643,7 @@ MiFreeSegmentPage(PMM_SECTION_SEGMENT Segment,
                 OldPage,
                 FileOffset->QuadPart,
                 Segment,
-                MmGetReferenceCountPage(OldPage),
+                MmGetReferenceCountPageWithoutLock(OldPage),
                 Entry,
                 IS_DIRTY_SSE(Entry) ? "true" : "false");
 

--- a/ntoskrnl/cache/section/swapout.c
+++ b/ntoskrnl/cache/section/swapout.c
@@ -172,11 +172,11 @@ MmFinalizeSectionPageOut(PMM_SECTION_SEGMENT Segment,
     SWAPENTRY Swap = MmGetSavedSwapEntryPage(Page);
 
     /* Bail early if the reference count isn't where we need it */
-    if (MmGetReferenceCountPage(Page) != 1)
+    if (MmGetReferenceCountPageWithoutLock(Page) != 1)
     {
         DPRINT1("Cannot page out locked page %x with ref count %lu\n",
                 Page,
-                MmGetReferenceCountPage(Page));
+                MmGetReferenceCountPageWithoutLock(Page));
         return STATUS_UNSUCCESSFUL;
     }
 
@@ -357,7 +357,7 @@ MmpPageOutPhysicalAddress(PFN_NUMBER Page)
     NTSTATUS Status = STATUS_SUCCESS;
     MM_REQUIRED_RESOURCES Resources = { 0 };
 
-    DPRINTC("Page out %x (ref ct %x)\n", Page, MmGetReferenceCountPage(Page));
+    DPRINTC("Page out %x (ref ct %x)\n", Page, MmGetReferenceCountPageWithoutLock(Page));
 
     ExAcquireFastMutex(&MiGlobalPageOperation);
     if ((Segment = MmGetSectionAssociation(Page, &FileOffset)))

--- a/ntoskrnl/include/internal/kd64.h
+++ b/ntoskrnl/include/internal/kd64.h
@@ -514,6 +514,11 @@ KdpDprintf(
     ...
 );
 
+BOOLEAN
+NTAPI
+KdpPrintString(
+    _In_ PSTRING Output);
+
 //
 // Global KD Data
 //

--- a/ntoskrnl/include/internal/ke.h
+++ b/ntoskrnl/include/internal/ke.h
@@ -986,16 +986,22 @@ VOID
 NTAPI
 KeThawExecution(IN BOOLEAN Enable);
 
+_IRQL_requires_min_(DISPATCH_LEVEL)
+_Acquires_nonreentrant_lock_(*LockHandle->Lock)
+_Acquires_exclusive_lock_(*LockHandle->Lock)
 VOID
 FASTCALL
 KeAcquireQueuedSpinLockAtDpcLevel(
-    IN OUT PKSPIN_LOCK_QUEUE LockQueue
+    _Inout_ PKSPIN_LOCK_QUEUE LockQueue
 );
 
+_IRQL_requires_min_(DISPATCH_LEVEL)
+_Releases_nonreentrant_lock_(*LockHandle->Lock)
+_Releases_exclusive_lock_(*LockHandle->Lock)
 VOID
 FASTCALL
 KeReleaseQueuedSpinLockFromDpcLevel(
-    IN OUT PKSPIN_LOCK_QUEUE LockQueue
+    _Inout_ PKSPIN_LOCK_QUEUE LockQueue
 );
 
 VOID

--- a/ntoskrnl/include/internal/spinlock.h
+++ b/ntoskrnl/include/internal/spinlock.h
@@ -6,50 +6,25 @@
 * PROGRAMMERS:     Alex Ionescu (alex.ionescu@reactos.org)
 */
 
+#if defined(_M_IX86)
 VOID
 NTAPI
 Kii386SpinOnSpinLock(PKSPIN_LOCK SpinLock, ULONG Flags);
-
-#ifndef CONFIG_SMP
-
-//
-// Spinlock Acquire at IRQL >= DISPATCH_LEVEL
-//
-FORCEINLINE
-VOID
-KxAcquireSpinLock(IN PKSPIN_LOCK SpinLock)
-{
-    /* On UP builds, spinlocks don't exist at IRQL >= DISPATCH */
-    UNREFERENCED_PARAMETER(SpinLock);
-
-    /* Add an explicit memory barrier to prevent the compiler from reordering
-       memory accesses across the borders of spinlocks */
-    KeMemoryBarrierWithoutFence();
-}
-
-//
-// Spinlock Release at IRQL >= DISPATCH_LEVEL
-//
-FORCEINLINE
-VOID
-KxReleaseSpinLock(IN PKSPIN_LOCK SpinLock)
-{
-    /* On UP builds, spinlocks don't exist at IRQL >= DISPATCH */
-    UNREFERENCED_PARAMETER(SpinLock);
-
-    /* Add an explicit memory barrier to prevent the compiler from reordering
-       memory accesses across the borders of spinlocks */
-    KeMemoryBarrierWithoutFence();
-}
-
-#else
+#endif
 
 //
 // Spinlock Acquisition at IRQL >= DISPATCH_LEVEL
 //
+_Acquires_nonreentrant_lock_(SpinLock)
 FORCEINLINE
 VOID
-KxAcquireSpinLock(IN PKSPIN_LOCK SpinLock)
+KxAcquireSpinLock(
+#if defined(CONFIG_SMP) || DBG
+    _Inout_
+#else
+    _Unreferenced_parameter_
+#endif
+    PKSPIN_LOCK SpinLock)
 {
 #if DBG
     /* Make sure that we don't own the lock already */
@@ -60,6 +35,7 @@ KxAcquireSpinLock(IN PKSPIN_LOCK SpinLock)
     }
 #endif
 
+#ifdef CONFIG_SMP
     /* Try to acquire the lock */
     while (InterlockedBitTestAndSet((PLONG)SpinLock, 0))
     {
@@ -75,6 +51,12 @@ KxAcquireSpinLock(IN PKSPIN_LOCK SpinLock)
         }
 #endif
     }
+#endif
+
+    /* Add an explicit memory barrier to prevent the compiler from reordering
+       memory accesses across the borders of spinlocks */
+    KeMemoryBarrierWithoutFence();
+
 #if DBG
     /* On debug builds, we OR in the KTHREAD */
     *SpinLock = (KSPIN_LOCK)KeGetCurrentThread() | 1;
@@ -84,9 +66,16 @@ KxAcquireSpinLock(IN PKSPIN_LOCK SpinLock)
 //
 // Spinlock Release at IRQL >= DISPATCH_LEVEL
 //
+_Releases_nonreentrant_lock_(SpinLock)
 FORCEINLINE
 VOID
-KxReleaseSpinLock(IN PKSPIN_LOCK SpinLock)
+KxReleaseSpinLock(
+#if defined(CONFIG_SMP) || DBG
+    _Inout_
+#else
+    _Unreferenced_parameter_
+#endif
+    PKSPIN_LOCK SpinLock)
 {
 #if DBG
     /* Make sure that the threads match */
@@ -96,12 +85,17 @@ KxReleaseSpinLock(IN PKSPIN_LOCK SpinLock)
         KeBugCheckEx(SPIN_LOCK_NOT_OWNED, (ULONG_PTR)SpinLock, 0, 0, 0);
     }
 #endif
-    /* Clear the lock */
+
+#if defined(CONFIG_SMP) || DBG
+    /* Clear the lock  */
 #ifdef _WIN64
     InterlockedAnd64((PLONG64)SpinLock, 0);
 #else
     InterlockedAnd((PLONG)SpinLock, 0);
 #endif
-}
-
 #endif
+
+    /* Add an explicit memory barrier to prevent the compiler from reordering
+       memory accesses across the borders of spinlocks */
+    KeMemoryBarrierWithoutFence();
+}

--- a/ntoskrnl/kd/kdio.c
+++ b/ntoskrnl/kd/kdio.c
@@ -772,6 +772,9 @@ KdReceivePacket(
         OldIrql = KdpAcquireLock(&KdpSerialSpinLock);
     }
 
+    /* Release the spinlock */
+    KdpReleaseLock(&KdpSerialSpinLock, OldIrql);
+
     /* Print a new line */
     *StringChar.Buffer = '\n';
     KdpPrintString(&StringChar);
@@ -782,9 +785,6 @@ KdReceivePacket(
 
     if (!(KdbDebugState & KD_DEBUG_KDSERIAL))
         KbdEnableMouse();
-
-    /* Release the spinlock */
-    KdpReleaseLock(&KdpSerialSpinLock, OldIrql);
 
 #endif
     return KdPacketReceived;

--- a/ntoskrnl/kd/kdio.c
+++ b/ntoskrnl/kd/kdio.c
@@ -580,13 +580,10 @@ KdSendPacket(
         {
 #ifdef KDBG
             PLDR_DATA_TABLE_ENTRY LdrEntry;
-            if (!WaitStateChange->u.LoadSymbols.UnloadSymbols)
+            /* Load symbols. Currently implemented only for KDBG! */
+            if (KdbpSymFindModule((PVOID)(ULONG_PTR)WaitStateChange->u.LoadSymbols.BaseOfDll, -1, &LdrEntry))
             {
-                /* Load symbols. Currently implemented only for KDBG! */
-                if (KdbpSymFindModule((PVOID)(ULONG_PTR)WaitStateChange->u.LoadSymbols.BaseOfDll, NULL, -1, &LdrEntry))
-                {
-                    KdbSymProcessSymbols(LdrEntry);
-                }
+                KdbSymProcessSymbols(LdrEntry, !WaitStateChange->u.LoadSymbols.UnloadSymbols);
             }
 #endif
             return;

--- a/ntoskrnl/kd64/kdlock.c
+++ b/ntoskrnl/kd64/kdlock.c
@@ -92,7 +92,9 @@ KdPollBreakIn(VOID)
         }
         else
         {
+            KIRQL OldIrql;
             /* Try to acquire the lock */
+            KeRaiseIrql(HIGH_LEVEL, &OldIrql);
             if (KeTryToAcquireSpinLockAtDpcLevel(&KdpDebuggerLock))
             {
                 /* Now get a packet */
@@ -110,6 +112,7 @@ KdPollBreakIn(VOID)
                 /* Let go of the port */
                 KdpPortUnlock();
             }
+            KeLowerIrql(OldIrql);
         }
 
         /* Re-enable interrupts if they were enabled previously */

--- a/ntoskrnl/kd64/kdprint.c
+++ b/ntoskrnl/kd64/kdprint.c
@@ -445,7 +445,7 @@ KdpDprintf(
     STRING String;
     USHORT Length;
     va_list ap;
-    CHAR Buffer[100];
+    CHAR Buffer[512];
 
     /* Format the string */
     va_start(ap, Format);

--- a/ntoskrnl/kd64/kdtrap.c
+++ b/ntoskrnl/kd64/kdtrap.c
@@ -144,6 +144,10 @@ KdpTrap(IN PKTRAP_FRAME TrapFrame,
     BOOLEAN Handled;
     NTSTATUS ReturnStatus;
     USHORT ReturnLength;
+    KIRQL OldIrql;
+
+    /* Raise as high as we can. */
+    KeRaiseIrql(HIGH_LEVEL, &OldIrql);
 
     /*
      * Check if we got a STATUS_BREAKPOINT with a SubID for Print, Prompt or
@@ -256,6 +260,8 @@ KdpTrap(IN PKTRAP_FRAME TrapFrame,
                             PreviousMode,
                             SecondChanceException);
     }
+
+    KeLowerIrql(OldIrql);
 
     /* Return TRUE or FALSE to caller */
     return Handled;

--- a/ntoskrnl/kdbg/i386/i386-dis.c
+++ b/ntoskrnl/kdbg/i386/i386-dis.c
@@ -51,7 +51,7 @@ KdbpPrintDisasm(void* Ignored, const char* fmt, ...)
 
   va_start(ap, fmt);
   ret = vsprintf(buffer, fmt, ap);
-  DbgPrint("%s", buffer);
+  KdpDprintf("%s", buffer);
   va_end(ap);
   return(ret);
 }
@@ -80,7 +80,7 @@ KdbpPrintAddressInCode(unsigned int Addr, struct disassemble_info * Ignored)
 {
     if (!KdbSymPrintAddress((void*)Addr, NULL))
     {
-      DbgPrint("<%08x>", Addr);
+      KdpDprintf("<%08x>", Addr);
     }
 }
 

--- a/ntoskrnl/kdbg/kdb.h
+++ b/ntoskrnl/kdbg/kdb.h
@@ -148,7 +148,6 @@ KdbpRpnEvaluateParsedExpression(
 BOOLEAN
 KdbpSymFindModule(
     IN PVOID Address  OPTIONAL,
-    IN LPCWSTR Name  OPTIONAL,
     IN INT Index  OPTIONAL,
     OUT PLDR_DATA_TABLE_ENTRY* pLdrEntry);
 
@@ -160,7 +159,8 @@ KdbSymPrintAddress(
 
 VOID
 KdbSymProcessSymbols(
-    IN PLDR_DATA_TABLE_ENTRY LdrEntry);
+    _Inout_ PLDR_DATA_TABLE_ENTRY LdrEntry,
+    _In_ BOOLEAN Load);
 
 /* from kdb.c */
 

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -1977,7 +1977,7 @@ KdbpCmdMod(
 
         Address = (ULONG_PTR)Result;
 
-        if (!KdbpSymFindModule((PVOID)Address, NULL, -1, &LdrEntry))
+        if (!KdbpSymFindModule((PVOID)Address, -1, &LdrEntry))
         {
             KdbpPrint("No module containing address 0x%p found!\n", Address);
             return TRUE;
@@ -1987,7 +1987,7 @@ KdbpCmdMod(
     }
     else
     {
-        if (!KdbpSymFindModule(NULL, NULL, 0, &LdrEntry))
+        if (!KdbpSymFindModule(NULL, 0, &LdrEntry))
         {
             ULONG_PTR ntoskrnlBase = ((ULONG_PTR)KdbpCmdMod) & 0xfff00000;
             KdbpPrint("  Base      Size      Name\n");
@@ -2003,7 +2003,7 @@ KdbpCmdMod(
     {
         KdbpPrint("  %08x  %08x  %wZ\n", LdrEntry->DllBase, LdrEntry->SizeOfImage, &LdrEntry->BaseDllName);
 
-        if(DisplayOnlyOneModule || !KdbpSymFindModule(NULL, NULL, i++, &LdrEntry))
+        if(DisplayOnlyOneModule || !KdbpSymFindModule(NULL, i++, &LdrEntry))
             break;
     }
 

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -2710,6 +2710,7 @@ KdbpCmdHelp(
  * \note Doesn't correctly handle \\t and terminal escape sequences when calculating the
  *       number of lines required to print a single line from the Buffer in the terminal.
  *       Prints maximum 4096 chars, because of its buffer size.
+ *       Uses KdpDPrintf internally (NOT DbgPrint!). Callers must already hold the debugger lock.
  */
 VOID
 KdbpPrint(
@@ -2735,11 +2736,11 @@ KdbpPrint(
     /* Initialize the terminal */
     if (!TerminalInitialized)
     {
-        DbgPrint("\x1b[7h");      /* Enable linewrap */
+        KdpDprintf("\x1b[7h");      /* Enable linewrap */
 
         /* Query terminal type */
         /*DbgPrint("\x1b[Z");*/
-        DbgPrint("\x05");
+        KdpDprintf("\x05");
 
         TerminalInitialized = TRUE;
         Length = 0;
@@ -2770,7 +2771,7 @@ KdbpPrint(
             /* Try to query number of rows from terminal. A reply looks like "\x1b[8;24;80t" */
             TerminalReportsSize = FALSE;
             KeStallExecutionProcessor(100000);
-            DbgPrint("\x1b[18t");
+            KdpDprintf("\x1b[18t");
             c = KdbpTryGetCharSerial(5000);
 
             if (c == KEY_ESC)
@@ -2855,9 +2856,9 @@ KdbpPrint(
             KdbRepeatLastCommand = FALSE;
 
             if (KdbNumberOfColsPrinted > 0)
-                DbgPrint("\n");
+                KdpDprintf("\n");
 
-            DbgPrint("--- Press q to abort, any other key to continue ---");
+            KdpDprintf("--- Press q to abort, any other key to continue ---");
             RowsPrintedByTerminal++; /* added by Mna. */
 
             if (KdbDebugState & KD_DEBUG_KDSERIAL)
@@ -2876,7 +2877,7 @@ KdbpPrint(
                     c = KdbpTryGetCharKeyboard(&ScanCode, 5);
             }
 
-            DbgPrint("\n");
+            KdpDprintf("\n");
             if (c == 'q')
             {
                 KdbOutputAborted = TRUE;
@@ -2917,7 +2918,7 @@ KdbpPrint(
             }
         }
 
-        DbgPrint("%s", p);
+        KdpDprintf("%s", p);
 
         if (c != '\0')
             p[i + 1] = c;
@@ -3052,11 +3053,11 @@ KdbpPager(
     /* Initialize the terminal */
     if (!TerminalInitialized)
     {
-        DbgPrint("\x1b[7h");      /* Enable linewrap */
+        KdpDprintf("\x1b[7h");      /* Enable linewrap */
 
         /* Query terminal type */
         /*DbgPrint("\x1b[Z");*/
-        DbgPrint("\x05");
+        KdpDprintf("\x05");
 
         TerminalInitialized = TRUE;
         Length = 0;
@@ -3087,7 +3088,7 @@ KdbpPager(
             /* Try to query number of rows from terminal. A reply looks like "\x1b[8;24;80t" */
             TerminalReportsSize = FALSE;
             KeStallExecutionProcessor(100000);
-            DbgPrint("\x1b[18t");
+            KdpDprintf("\x1b[18t");
             c = KdbpTryGetCharSerial(5000);
 
             if (c == KEY_ESC)
@@ -3148,7 +3149,7 @@ KdbpPager(
     {
         if ( p > Buffer+BufLength)
         {
-          DbgPrint("Dmesg: error, p > Buffer+BufLength,d=%d", p - (Buffer+BufLength));
+          KdpDprintf("Dmesg: error, p > Buffer+BufLength,d=%d", p - (Buffer+BufLength));
           return;
         }
         i = strcspn(p, "\n");
@@ -3178,9 +3179,9 @@ KdbpPager(
             KdbRepeatLastCommand = FALSE;
 
             if (KdbNumberOfColsPrinted > 0)
-                DbgPrint("\n");
+                KdpDprintf("\n");
 
-            DbgPrint("--- Press q to abort, e/End,h/Home,u/PgUp, other key/PgDn ---");
+            KdpDprintf("--- Press q to abort, e/End,h/Home,u/PgUp, other key/PgDn ---");
             RowsPrintedByTerminal++;
 
             if (KdbDebugState & KD_DEBUG_KDSERIAL)
@@ -3200,7 +3201,7 @@ KdbpPager(
             }
 
             //DbgPrint("\n"); //Consize version: don't show pressed key
-            DbgPrint(" '%c'/scan=%04x\n", c, ScanCode); // Shows pressed key
+            KdpDprintf(" '%c'/scan=%04x\n", c, ScanCode); // Shows pressed key
 
             if (c == 'q')
             {
@@ -3264,7 +3265,7 @@ KdbpPager(
         }
 
         // The main printing of the current line:
-        DbgPrint(p);
+        KdpDprintf(p);
 
         // restore not null char with saved:
         if (c != '\0')

--- a/ntoskrnl/kdbg/kdb_expr.c
+++ b/ntoskrnl/kdbg/kdb_expr.c
@@ -253,7 +253,7 @@ RpnpDumpStack(
     ULONG ul;
 
     ASSERT(Stack);
-    DbgPrint("\nStack size: %ld\n", Stack->Sp);
+    KdpDprintf("\nStack size: %ld\n", Stack->Sp);
 
     for (ul = 0; ul < Stack->Sp; ul++)
     {
@@ -261,60 +261,60 @@ RpnpDumpStack(
         switch (Op->Type)
         {
             case RpnOpNop:
-                DbgPrint("NOP,");
+                KdpDprintf("NOP,");
                 break;
 
             case RpnOpImmediate:
-                DbgPrint("0x%I64x,", Op->Data.Immediate);
+                KdpDprintf("0x%I64x,", Op->Data.Immediate);
                 break;
 
             case RpnOpBinaryOperator:
                 if (Op->Data.BinaryOperator == RpnBinaryOperatorAdd)
-                    DbgPrint("+,");
+                    KdpDprintf("+,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorSub)
-                    DbgPrint("-,");
+                    KdpDprintf("-,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorMul)
-                    DbgPrint("*,");
+                    KdpDprintf("*,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorDiv)
-                    DbgPrint("/,");
+                    KdpDprintf("/,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorMod)
-                    DbgPrint("%%,");
+                    KdpDprintf("%%,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorEquals)
-                    DbgPrint("==,");
+                    KdpDprintf("==,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorNotEquals)
-                    DbgPrint("!=,");
+                    KdpDprintf("!=,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorLessThan)
-                    DbgPrint("<,");
+                    KdpDprintf("<,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorLessThanOrEquals)
-                    DbgPrint("<=,");
+                    KdpDprintf("<=,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorGreaterThan)
-                    DbgPrint(">,");
+                    KdpDprintf(">,");
                 else if (Op->Data.BinaryOperator == RpnBinaryOperatorGreaterThanOrEquals)
-                    DbgPrint(">=,");
+                    KdpDprintf(">=,");
                 else
-                    DbgPrint("UNKNOWN OP,");
+                    KdpDprintf("UNKNOWN OP,");
 
                 break;
 
             case RpnOpRegister:
-                DbgPrint("%s,", RegisterToTrapFrame[Op->Data.Register].Name);
+                KdpDprintf("%s,", RegisterToTrapFrame[Op->Data.Register].Name);
                 break;
 
             case RpnOpDereference:
-                DbgPrint("[%s],",
+                KdpDprintf("[%s],",
                     (Op->Data.DerefMemorySize == 1) ? ("byte") :
                     ((Op->Data.DerefMemorySize == 2) ? ("word") :
                     ((Op->Data.DerefMemorySize == 4) ? ("dword") : ("qword"))));
                 break;
 
             default:
-                DbgPrint("\nUnsupported Type: %d\n", Op->Type);
+                KdpDprintf("\nUnsupported Type: %d\n", Op->Type);
                 ul = Stack->Sp;
                 break;
         }
     }
 
-    DbgPrint("\n");
+    KdpDprintf("\n");
 }
 
 /*!\brief Clears the given RPN stack.

--- a/ntoskrnl/kdbg/kdb_symbols.c
+++ b/ntoskrnl/kdbg/kdb_symbols.c
@@ -180,12 +180,12 @@ KdbSymPrintAddress(
                                          FunctionName);
     if (NT_SUCCESS(Status))
     {
-        DbgPrint("<%s:%x (%s:%d (%s))>",
+        KdpDprintf("<%s:%x (%s:%d (%s))>",
             ModuleNameAnsi, RelativeAddress, FileName, LineNumber, FunctionName);
     }
     else
     {
-        DbgPrint("<%s:%x>", ModuleNameAnsi, RelativeAddress);
+        KdpDprintf("<%s:%x>", ModuleNameAnsi, RelativeAddress);
     }
 
     return TRUE;

--- a/ntoskrnl/kdbg/kdb_symbols.c
+++ b/ntoskrnl/kdbg/kdb_symbols.c
@@ -27,27 +27,19 @@ typedef struct _IMAGE_SYMBOL_INFO_CACHE
 IMAGE_SYMBOL_INFO_CACHE, *PIMAGE_SYMBOL_INFO_CACHE;
 
 static BOOLEAN LoadSymbols;
-static LIST_ENTRY SymbolFileListHead;
-static KSPIN_LOCK SymbolFileListLock;
-BOOLEAN KdbpSymbolsInitialized = FALSE;
+static LIST_ENTRY SymbolsToLoad;
+static KSPIN_LOCK SymbolsToLoadLock;
+static KEVENT SymbolsToLoadEvent;
 
 /* FUNCTIONS ****************************************************************/
 
-static NTSTATUS
-KdbSymGetAddressInformation(
-    IN PROSSYM_INFO RosSymInfo,
-    IN ULONG_PTR RelativeAddress,
-    OUT PULONG LineNumber  OPTIONAL,
-    OUT PCH FileName  OPTIONAL,
-    OUT PCH FunctionName  OPTIONAL);
-
-static BOOLEAN
+static
+BOOLEAN
 KdbpSymSearchModuleList(
     IN PLIST_ENTRY current_entry,
     IN PLIST_ENTRY end_entry,
     IN PLONG Count,
     IN PVOID Address,
-    IN LPCWSTR Name,
     IN INT Index,
     OUT PLDR_DATA_TABLE_ENTRY* pLdrEntry)
 {
@@ -56,7 +48,6 @@ KdbpSymSearchModuleList(
         *pLdrEntry = CONTAINING_RECORD(current_entry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
 
         if ((Address && Address >= (PVOID)(*pLdrEntry)->DllBase && Address < (PVOID)((ULONG_PTR)(*pLdrEntry)->DllBase + (*pLdrEntry)->SizeOfImage)) ||
-            (Name && !_wcsnicmp((*pLdrEntry)->BaseDllName.Buffer, Name, (*pLdrEntry)->BaseDllName.Length / sizeof(WCHAR))) ||
             (Index >= 0 && (*Count)++ == Index))
         {
             return TRUE;
@@ -83,7 +74,6 @@ KdbpSymSearchModuleList(
 BOOLEAN
 KdbpSymFindModule(
     IN PVOID Address  OPTIONAL,
-    IN LPCWSTR Name  OPTIONAL,
     IN INT Index  OPTIONAL,
     OUT PLDR_DATA_TABLE_ENTRY* pLdrEntry)
 {
@@ -91,16 +81,18 @@ KdbpSymFindModule(
     PEPROCESS CurrentProcess;
 
     /* First try to look up the module in the kernel module list. */
+    KeAcquireSpinLockAtDpcLevel(&PsLoadedModuleSpinLock);
     if(KdbpSymSearchModuleList(PsLoadedModuleList.Flink,
                                &PsLoadedModuleList,
                                &Count,
                                Address,
-                               Name,
                                Index,
                                pLdrEntry))
     {
+        KeReleaseSpinLockFromDpcLevel(&PsLoadedModuleSpinLock);
         return TRUE;
     }
+    KeReleaseSpinLockFromDpcLevel(&PsLoadedModuleSpinLock);
 
     /* That didn't succeed. Try the module list of the current process now. */
     CurrentProcess = PsGetCurrentProcess();
@@ -112,11 +104,11 @@ KdbpSymFindModule(
                                    &CurrentProcess->Peb->Ldr->InLoadOrderModuleList,
                                    &Count,
                                    Address,
-                                   Name,
                                    Index,
                                    pLdrEntry);
 }
 
+static
 PCHAR
 NTAPI
 KdbpSymUnicodeToAnsi(IN PUNICODE_STRING Unicode,
@@ -159,233 +151,183 @@ KdbSymPrintAddress(
 {
     PLDR_DATA_TABLE_ENTRY LdrEntry;
     ULONG_PTR RelativeAddress;
-    NTSTATUS Status;
-    ULONG LineNumber;
-    CHAR FileName[256];
-    CHAR FunctionName[256];
+    BOOLEAN Printed = FALSE;
     CHAR ModuleNameAnsi[64];
 
-    if (!KdbpSymbolsInitialized || !KdbpSymFindModule(Address, NULL, -1, &LdrEntry))
+    if (!KdbpSymFindModule(Address, -1, &LdrEntry))
         return FALSE;
 
-    KdbpSymUnicodeToAnsi(&LdrEntry->BaseDllName,
-                         ModuleNameAnsi,
-                         sizeof(ModuleNameAnsi));
-
     RelativeAddress = (ULONG_PTR)Address - (ULONG_PTR)LdrEntry->DllBase;
-    Status = KdbSymGetAddressInformation(LdrEntry->PatchInformation,
-                                         RelativeAddress,
-                                         &LineNumber,
-                                         FileName,
-                                         FunctionName);
-    if (NT_SUCCESS(Status))
+
+    KdbpSymUnicodeToAnsi(&LdrEntry->BaseDllName,
+                        ModuleNameAnsi,
+                        sizeof(ModuleNameAnsi));
+
+    if (LdrEntry->PatchInformation)
     {
-        KdpDprintf("<%s:%x (%s:%d (%s))>",
-            ModuleNameAnsi, RelativeAddress, FileName, LineNumber, FunctionName);
+        ULONG LineNumber;
+        CHAR FileName[256];
+        CHAR FunctionName[256];
+
+        if (RosSymGetAddressInformation(LdrEntry->PatchInformation, RelativeAddress, &LineNumber, FileName, FunctionName))
+        {
+            STRING str;
+            /* Use KdpPrintString because KdpDprintf is limited wrt string size */
+            KdpDprintf("<%s:%x (", ModuleNameAnsi, RelativeAddress);
+            str.Buffer = FileName;
+            str.Length = strnlen(FileName, sizeof(FileName));
+            str.MaximumLength = sizeof(FileName);
+            KdpPrintString(&str);
+            KdpDprintf(":%d (%s))>", LineNumber, FunctionName);
+
+            Printed = TRUE;
+        }
     }
-    else
+
+    if (!Printed)
     {
+        /* Just print module & address */
         KdpDprintf("<%s:%x>", ModuleNameAnsi, RelativeAddress);
     }
 
     return TRUE;
 }
 
-
-/*! \brief Get information for an address (source file, line number,
- *         function name)
+static KSTART_ROUTINE LoadSymbolsRoutine;
+/*! \brief          The symbol loader thread routine.
+ *                  This opens the image file for reading and loads the symbols
+ *                  section from there.
  *
- * \param SymbolInfo       Pointer to ROSSYM_INFO.
- * \param RelativeAddress  Relative address to look up.
- * \param LineNumber       Pointer to an ULONG which is filled with the line
- *                         number (can be NULL)
- * \param FileName         Pointer to an array of CHARs which gets filled with
- *                         the filename (can be NULL)
- * \param FunctionName     Pointer to an array of CHARs which gets filled with
- *                         the function name (can be NULL)
+ * \note            We must do this because KdbSymProcessSymbols is
+ *                  called at high IRQL and we can't set the event from here
  *
- * \returns NTSTATUS error code.
- * \retval STATUS_SUCCESS  At least one of the requested informations was found.
- * \retval STATUS_UNSUCCESSFUL  None of the requested information was found.
+ * \param Context   Unused
  */
-static NTSTATUS
-KdbSymGetAddressInformation(
-    IN PROSSYM_INFO RosSymInfo,
-    IN ULONG_PTR RelativeAddress,
-    OUT PULONG LineNumber  OPTIONAL,
-    OUT PCH FileName  OPTIONAL,
-    OUT PCH FunctionName  OPTIONAL)
+_Use_decl_annotations_
+VOID
+NTAPI
+LoadSymbolsRoutine(
+    _In_ PVOID Context)
 {
-    if (!KdbpSymbolsInitialized ||
-        !RosSymInfo ||
-        !RosSymGetAddressInformation(RosSymInfo, RelativeAddress, LineNumber, FileName, FunctionName))
+    UNREFERENCED_PARAMETER(Context);
+
+    while (TRUE)
     {
-        return STATUS_UNSUCCESSFUL;
-    }
-
-    return STATUS_SUCCESS;
-}
-
-/*! \brief Find cached symbol file.
- *
- * Looks through the list of cached symbol files and tries to find an already
- * loaded one.
- *
- * \param FileName  FileName of the symbol file to look for.
- *
- * \returns A pointer to the cached symbol info.
- * \retval NULL  No cached info found.
- *
- * \sa KdbpSymAddCachedFile
- */
-static PROSSYM_INFO
-KdbpSymFindCachedFile(
-    IN PUNICODE_STRING FileName)
-{
-    PIMAGE_SYMBOL_INFO_CACHE Current;
-    PLIST_ENTRY CurrentEntry;
-
-    DPRINT("Looking for cached symbol file %wZ\n", FileName);
-
-    KeAcquireSpinLockAtDpcLevel(&SymbolFileListLock);
-
-    CurrentEntry = SymbolFileListHead.Flink;
-    while (CurrentEntry != (&SymbolFileListHead))
-    {
-        Current = CONTAINING_RECORD(CurrentEntry, IMAGE_SYMBOL_INFO_CACHE, ListEntry);
-
-        DPRINT("Current->FileName %wZ FileName %wZ\n", &Current->FileName, FileName);
-        if (RtlEqualUnicodeString(&Current->FileName, FileName, TRUE))
+        PLIST_ENTRY ListEntry;
+        NTSTATUS Status = KeWaitForSingleObject(&SymbolsToLoadEvent, WrKernel, KernelMode, FALSE, NULL);
+        if (!NT_SUCCESS(Status))
         {
-            Current->RefCount++;
-            KeReleaseSpinLockFromDpcLevel(&SymbolFileListLock);
-            DPRINT("Found cached file!\n");
-            return Current->RosSymInfo;
-        }
-
-        CurrentEntry = CurrentEntry->Flink;
-    }
-
-    KeReleaseSpinLockFromDpcLevel(&SymbolFileListLock);
-
-    DPRINT("Cached file not found!\n");
-    return NULL;
-}
-
-/*! \brief Add a symbol file to the cache.
- *
- * \param FileName    Filename of the symbol file.
- * \param RosSymInfo  Pointer to the symbol info.
- *
- * \sa KdbpSymRemoveCachedFile
- */
-static VOID
-KdbpSymAddCachedFile(
-    IN PUNICODE_STRING FileName,
-    IN PROSSYM_INFO RosSymInfo)
-{
-    PIMAGE_SYMBOL_INFO_CACHE CacheEntry;
-    KIRQL Irql;
-
-    DPRINT("Adding symbol file: RosSymInfo = %p\n", RosSymInfo);
-
-    /* allocate entry */
-    CacheEntry = ExAllocatePoolWithTag(NonPagedPool, sizeof (IMAGE_SYMBOL_INFO_CACHE), TAG_KDBS);
-    ASSERT(CacheEntry);
-    RtlZeroMemory(CacheEntry, sizeof (IMAGE_SYMBOL_INFO_CACHE));
-
-    /* fill entry */
-    CacheEntry->FileName.Buffer = ExAllocatePoolWithTag(NonPagedPool,
-                                                        FileName->Length,
-                                                        TAG_KDBS);
-    RtlCopyUnicodeString(&CacheEntry->FileName, FileName);
-    ASSERT(CacheEntry->FileName.Buffer);
-    CacheEntry->RefCount = 1;
-    CacheEntry->RosSymInfo = RosSymInfo;
-    KeAcquireSpinLock(&SymbolFileListLock, &Irql);
-    InsertTailList(&SymbolFileListHead, &CacheEntry->ListEntry);
-    KeReleaseSpinLock(&SymbolFileListLock, Irql);
-}
-
-/*! \brief Remove a symbol file (reference) from the cache.
- *
- * Tries to find a cache entry matching the given symbol info and decreases
- * it's reference count. If the refcount is 0 after decreasing it the cache
- * entry will be removed from the list and freed.
- *
- * \param RosSymInfo  Pointer to the symbol info.
- *
- * \sa KdbpSymAddCachedFile
- */
-static VOID
-KdbpSymRemoveCachedFile(
-    IN PROSSYM_INFO RosSymInfo)
-{
-    PIMAGE_SYMBOL_INFO_CACHE Current;
-    PLIST_ENTRY CurrentEntry;
-    KIRQL Irql;
-
-    KeAcquireSpinLock(&SymbolFileListLock, &Irql);
-
-    CurrentEntry = SymbolFileListHead.Flink;
-    while (CurrentEntry != (&SymbolFileListHead))
-    {
-        Current = CONTAINING_RECORD(CurrentEntry, IMAGE_SYMBOL_INFO_CACHE, ListEntry);
-
-        if (Current->RosSymInfo == RosSymInfo) /* found */
-        {
-            ASSERT(Current->RefCount > 0);
-            Current->RefCount--;
-            if (Current->RefCount < 1)
-            {
-                RemoveEntryList(&Current->ListEntry);
-                RosSymDelete(Current->RosSymInfo);
-                ExFreePool(Current);
-            }
-
-            KeReleaseSpinLock(&SymbolFileListLock, Irql);
+            DPRINT1("KeWaitForSingleObject failed?! 0x%08x\n", Status);
+            LoadSymbols = FALSE;
             return;
         }
 
-        CurrentEntry = CurrentEntry->Flink;
-    }
+        while ((ListEntry = ExInterlockedRemoveHeadList(&SymbolsToLoad, &SymbolsToLoadLock)))
+        {
+            PLDR_DATA_TABLE_ENTRY LdrEntry = CONTAINING_RECORD(ListEntry, LDR_DATA_TABLE_ENTRY, InInitializationOrderLinks);
+            HANDLE FileHandle;
+            OBJECT_ATTRIBUTES Attrib;
+            IO_STATUS_BLOCK Iosb;
+            InitializeObjectAttributes(&Attrib, &LdrEntry->FullDllName, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+            DPRINT1("Trying %wZ\n", &LdrEntry->FullDllName);
+            Status = ZwOpenFile(&FileHandle,
+                                FILE_READ_ACCESS | SYNCHRONIZE,
+                                &Attrib,
+                                &Iosb,
+                                FILE_SHARE_READ,
+                                FILE_SYNCHRONOUS_IO_NONALERT);
+            if (!NT_SUCCESS(Status))
+            {
+                /* Try system paths */
+                static const UNICODE_STRING System32Dir = RTL_CONSTANT_STRING(L"\\SystemRoot\\system32\\");
+                UNICODE_STRING ImagePath;
+                WCHAR ImagePathBuffer[256];
+                RtlInitEmptyUnicodeString(&ImagePath, ImagePathBuffer, sizeof(ImagePathBuffer));
+                RtlCopyUnicodeString(&ImagePath, &System32Dir);
+                RtlAppendUnicodeStringToString(&ImagePath, &LdrEntry->BaseDllName);
+                InitializeObjectAttributes(&Attrib, &ImagePath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+                DPRINT1("Trying %wZ\n", &ImagePath);
+                Status = ZwOpenFile(&FileHandle,
+                                    FILE_READ_ACCESS | SYNCHRONIZE,
+                                    &Attrib,
+                                    &Iosb,
+                                    FILE_SHARE_READ,
+                                    FILE_SYNCHRONOUS_IO_NONALERT);
+                if (!NT_SUCCESS(Status))
+                {
+                    static const UNICODE_STRING DriversDir= RTL_CONSTANT_STRING(L"\\SystemRoot\\system32\\drivers\\");
 
-    KeReleaseSpinLock(&SymbolFileListLock, Irql);
-    DPRINT1("Warning: Removing unknown symbol file: RosSymInfo = %p\n", RosSymInfo);
+                    RtlInitEmptyUnicodeString(&ImagePath, ImagePathBuffer, sizeof(ImagePathBuffer));
+                    RtlCopyUnicodeString(&ImagePath, &DriversDir);
+                    RtlAppendUnicodeStringToString(&ImagePath, &LdrEntry->BaseDllName);
+                    InitializeObjectAttributes(&Attrib, &ImagePath, OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE, NULL, NULL);
+                    DPRINT1("Trying %wZ\n", &ImagePath);
+                    Status = ZwOpenFile(&FileHandle,
+                                        FILE_READ_ACCESS | SYNCHRONIZE,
+                                        &Attrib,
+                                        &Iosb,
+                                        FILE_SHARE_READ,
+                                        FILE_SYNCHRONOUS_IO_NONALERT);
+                }
+            }
+
+            if (!NT_SUCCESS(Status))
+            {
+                DPRINT1("Failed opening file %wZ (%wZ) for reading symbols (0x%08x)\n", &LdrEntry->FullDllName, &LdrEntry->BaseDllName, Status);
+                /* We took a ref previously */
+                MmUnloadSystemImage(LdrEntry);
+                continue;
+            }
+
+            /* Hand it to Rossym */
+            if (!RosSymCreateFromFile(&FileHandle, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
+                LdrEntry->PatchInformation = NULL;
+
+            /* We're done for this one. */
+            NtClose(FileHandle);
+            MmUnloadSystemImage(LdrEntry);
+        }
+    }
 }
 
+/*! \brief          Load symbols from image mapping. If this fails,
+ *
+ * \param LdrEntry  The entry to load symbols from
+ */
 VOID
 KdbSymProcessSymbols(
-    IN PLDR_DATA_TABLE_ENTRY LdrEntry)
+    _Inout_ PLDR_DATA_TABLE_ENTRY LdrEntry,
+    _In_ BOOLEAN Load)
 {
     if (!LoadSymbols)
+        return;
+
+    /* Check if this is unload */
+    if (!Load)
     {
-        LdrEntry->PatchInformation = NULL;
+        /* Did we process it */
+        if (LdrEntry->PatchInformation)
+        {
+            RosSymDelete(LdrEntry->PatchInformation);
+            LdrEntry->PatchInformation = NULL;
+        }
         return;
     }
 
-    /* Remove symbol info if it already exists */
-    if (LdrEntry->PatchInformation)
-        KdbpSymRemoveCachedFile(LdrEntry->PatchInformation);
-
-    /* Check cache */
-    LdrEntry->PatchInformation = KdbpSymFindCachedFile(&LdrEntry->FullDllName);
-
-    if (!LdrEntry->PatchInformation)
+    if (RosSymCreateFromMem(LdrEntry->DllBase, LdrEntry->SizeOfImage, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
     {
-        /* Load new symbol information */
-        if (RosSymCreateFromMem(LdrEntry->DllBase, LdrEntry->SizeOfImage, (PROSSYM_INFO*)&LdrEntry->PatchInformation))
-        {
-            /* Add file to cache */
-            KdbpSymAddCachedFile(&LdrEntry->FullDllName, LdrEntry->PatchInformation);
-        }
+        return;
     }
 
-    DPRINT("Installed symbols: %wZ@%p-%p %p\n",
-           &LdrEntry->BaseDllName,
-           LdrEntry->DllBase,
-           (PVOID)(LdrEntry->SizeOfImage + (ULONG_PTR)LdrEntry->DllBase),
-           LdrEntry->PatchInformation);
+    /* Add a ref until we really process it */
+    LdrEntry->LoadCount++;
+
+    /* Tell our worker thread to read from it */
+    KeAcquireSpinLockAtDpcLevel(&SymbolsToLoadLock);
+    InsertTailList(&SymbolsToLoad, &LdrEntry->InInitializationOrderLinks);
+    KeReleaseSpinLockFromDpcLevel(&SymbolsToLoadLock);
+
+    KeSetEvent(&SymbolsToLoadEvent, IO_NO_INCREMENT, FALSE);
 }
 
 VOID
@@ -412,7 +354,6 @@ KdbInitialize(
     PCHAR p1, p2;
     SHORT Found = FALSE;
     CHAR YesNo;
-    PLDR_DATA_TABLE_ENTRY LdrEntry;
 
     DPRINT("KdbSymInit() BootPhase=%d\n", BootPhase);
 
@@ -436,9 +377,6 @@ KdbInitialize(
         /* Perform actual initialization of symbol module */
         //NtoskrnlModuleObject->PatchInformation = NULL;
         //LdrHalModuleObject->PatchInformation = NULL;
-
-        InitializeListHead(&SymbolFileListHead);
-        KeInitializeSpinLock(&SymbolFileListLock);
 
         /* Check the command line for /LOADSYMBOLS, /NOLOADSYMBOLS,
         * /LOADSYMBOLS={YES|NO}, /NOLOADSYMBOLS={YES|NO} */
@@ -481,24 +419,39 @@ KdbInitialize(
             }
             p1 = p2;
         }
+    }
+    else if ((BootPhase == 1) && LoadSymbols)
+    {
+        HANDLE Thread;
+        NTSTATUS Status;
+        KIRQL OldIrql;
+
+        /* Launch our worker thread */
+        InitializeListHead(&SymbolsToLoad);
+        KeInitializeSpinLock(&SymbolsToLoadLock);
+        KeInitializeEvent(&SymbolsToLoadEvent, SynchronizationEvent, FALSE);
+
+        Status = PsCreateSystemThread(&Thread, THREAD_ALL_ACCESS, NULL, NULL, NULL, LoadSymbolsRoutine, NULL);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("Failed starting symbols loader thread: 0x%08x\n", Status);
+            LoadSymbols = FALSE;
+            return;
+        }
 
         RosSymInitKernelMode();
-    }
-    else if (BootPhase == 1)
-    {
-        KIRQL OldIrql;
-        /* Load symbols for NTOSKRNL.EXE.
-           It is always the first module in PsLoadedModuleList. KeLoaderBlock can't be used here as its content is just temporary. */
-        OldIrql = KeRaiseIrqlToDpcLevel();
-        LdrEntry = CONTAINING_RECORD(PsLoadedModuleList.Flink, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-        KdbSymProcessSymbols(LdrEntry);
 
-        /* Also load them for HAL.DLL. */
-        LdrEntry = CONTAINING_RECORD(PsLoadedModuleList.Flink->Flink, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
-        KdbSymProcessSymbols(LdrEntry);
-        KeLowerIrql(OldIrql);
+        KeAcquireSpinLock(&PsLoadedModuleSpinLock, &OldIrql);
 
-        KdbpSymbolsInitialized = TRUE;
+        PLIST_ENTRY ListEntry = PsLoadedModuleList.Flink;
+        while (ListEntry != &PsLoadedModuleList)
+        {
+            PLDR_DATA_TABLE_ENTRY LdrEntry = CONTAINING_RECORD(ListEntry, LDR_DATA_TABLE_ENTRY, InLoadOrderLinks);
+            KdbSymProcessSymbols(LdrEntry, TRUE);
+            ListEntry = ListEntry->Flink;
+        }
+
+        KeReleaseSpinLock(&PsLoadedModuleSpinLock, OldIrql);
     }
 }
 

--- a/ntoskrnl/ke/spinlock.c
+++ b/ntoskrnl/ke/spinlock.c
@@ -413,25 +413,32 @@ KeReleaseSpinLockForDpc(IN PKSPIN_LOCK SpinLock,
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 VOID
 FASTCALL
 KeAcquireInStackQueuedSpinLockForDpc(IN PKSPIN_LOCK SpinLock,
                                      IN PKLOCK_QUEUE_HANDLE LockHandle)
 {
-    UNIMPLEMENTED;
-    return;
+    LockHandle->OldIrql = KeGetCurrentIrql();
+    if (LockHandle->OldIrql >= DISPATCH_LEVEL)
+        KeAcquireInStackQueuedSpinLockAtDpcLevel(SpinLock, LockHandle);
+    else
+        KeAcquireInStackQueuedSpinLock(SpinLock, LockHandle);
 }
 
 /*
- * @unimplemented
+ * @implemented
  */
 VOID
 FASTCALL
 KeReleaseInStackQueuedSpinLockForDpc(IN PKLOCK_QUEUE_HANDLE LockHandle)
 {
-    UNIMPLEMENTED;
+    if (LockHandle->OldIrql >= DISPATCH_LEVEL)
+        KeReleaseInStackQueuedSpinLockFromDpcLevel(LockHandle);
+    else
+        KeReleaseInStackQueuedSpinLock(LockHandle);
+
 }
 
 /*

--- a/ntoskrnl/mm/freelist.c
+++ b/ntoskrnl/mm/freelist.c
@@ -537,20 +537,19 @@ ULONG
 NTAPI
 MmGetReferenceCountPage(PFN_NUMBER Pfn)
 {
-    KIRQL oldIrql;
     ULONG RCount;
     PMMPFN Pfn1;
 
+    MI_ASSERT_PFN_LOCK_HELD();
+
     DPRINT("MmGetReferenceCountPage(PhysicalAddress %x)\n", Pfn << PAGE_SHIFT);
 
-    oldIrql = MiAcquirePfnLock();
     Pfn1 = MiGetPfnEntry(Pfn);
     ASSERT(Pfn1);
     ASSERT_IS_ROS_PFN(Pfn1);
 
     RCount = Pfn1->u3.e2.ReferenceCount;
 
-    MiReleasePfnLock(oldIrql);
     return(RCount);
 }
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -194,27 +194,34 @@ if(SEPARATE_DBG)
     else()
         set(SYMBOL_FILE <TARGET>)
     endif()
-    set(OBJCOPY ${CMAKE_OBJCOPY})
+
+    if (NOT NO_ROSSYM)
+        get_target_property(RSYM native-rsym IMPORTED_LOCATION)
+        set(strip_debug "${RSYM} -s ${REACTOS_SOURCE_DIR} <TARGET> <TARGET>")
+    else()
+        set(strip_debug "${CMAKE_STRIP} --strip-debug <TARGET>")
+    endif()
+
     set(CMAKE_C_LINK_EXECUTABLE
         "<CMAKE_C_COMPILER> <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>"
-        "${OBJCOPY} --only-keep-debug <TARGET> ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
-        "${OBJCOPY} --strip-debug <TARGET>")
+        "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
+        ${strip_debug})
     set(CMAKE_CXX_LINK_EXECUTABLE
         "<CMAKE_CXX_COMPILER> <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>"
-        "${OBJCOPY} --only-keep-debug <TARGET> ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
-        "${OBJCOPY} --strip-debug <TARGET>")
+        "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
+        ${strip_debug})
     set(CMAKE_C_CREATE_SHARED_LIBRARY
         "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>"
-        "${OBJCOPY} --only-keep-debug <TARGET> ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
-        "${OBJCOPY} --strip-debug <TARGET>")
+        "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
+        ${strip_debug})
     set(CMAKE_CXX_CREATE_SHARED_LIBRARY
         "<CMAKE_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_CXX_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>"
-        "${OBJCOPY} --only-keep-debug <TARGET> ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
-        "${OBJCOPY} --strip-debug <TARGET>")
+        "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
+        ${strip_debug})
     set(CMAKE_RC_CREATE_SHARED_LIBRARY
         "<CMAKE_C_COMPILER> <CMAKE_SHARED_LIBRARY_C_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>"
-        "${OBJCOPY} --only-keep-debug <TARGET> ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
-        "${OBJCOPY} --strip-debug <TARGET>")
+        "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
+        ${strip_debug})
 elseif(NO_ROSSYM)
     # Dwarf-based build
     message(STATUS "Generating a dwarf-based build (no rsym)")

--- a/sdk/include/reactos/rossym.h
+++ b/sdk/include/reactos/rossym.h
@@ -119,7 +119,12 @@ typedef struct _ROSSYM_OWN_FILECONTEXT {
 struct Dwarf;
 typedef struct Dwarf *PROSSYM_INFO;
 #else
-typedef struct _ROSSYM_INFO *PROSSYM_INFO;
+typedef struct _ROSSYM_INFO {
+  PROSSYM_ENTRY Symbols;
+  ULONG SymbolsCount;
+  PCHAR Strings;
+  ULONG StringsLength;
+} ROSSYM_INFO, *PROSSYM_INFO;
 #endif
 
 VOID RosSymInit(PROSSYM_CALLBACKS Callbacks);

--- a/sdk/lib/crt/crt.cmake
+++ b/sdk/lib/crt/crt.cmake
@@ -117,6 +117,7 @@ list(APPEND CRT_SOURCE
     mem/memcmp.c
     mem/memccpy.c
     mem/memicmp.c
+    mem/memset.c
     misc/__crt_MessageBoxA.c
     misc/amsg.c
     misc/assert.c
@@ -399,7 +400,7 @@ if(ARCH STREQUAL "i386")
         math/i386/fmodf_asm.s
         mem/i386/memchr_asm.s
         mem/i386/memmove_asm.s
-        mem/i386/memset_asm.s
+        # mem/i386/memset_asm.s
         misc/i386/readcr4.S
         setjmp/i386/setjmp.s
         string/i386/strcat_asm.s

--- a/sdk/lib/crt/libcntpr.cmake
+++ b/sdk/lib/crt/libcntpr.cmake
@@ -9,6 +9,7 @@ list(APPEND LIBCNTPR_SOURCE
     mem/memccpy.c
     mem/memcmp.c
     mem/memicmp.c
+    mem/memset.c
     misc/fltused.c
     printf/_snprintf.c
     printf/_snwprintf.c
@@ -186,7 +187,7 @@ if(ARCH STREQUAL "i386")
     list(APPEND LIBCNTPR_ASM_SOURCE
         mem/i386/memchr_asm.s
         mem/i386/memmove_asm.s
-        mem/i386/memset_asm.s
+        # mem/i386/memset_asm.s
         string/i386/strcat_asm.s
         string/i386/strchr_asm.s
         string/i386/strcmp_asm.s

--- a/sdk/lib/rossym/rossympriv.h
+++ b/sdk/lib/rossym/rossympriv.h
@@ -9,13 +9,6 @@
 
 #pragma once
 
-typedef struct _ROSSYM_INFO {
-  PROSSYM_ENTRY Symbols;
-  ULONG SymbolsCount;
-  PCHAR Strings;
-  ULONG StringsLength;
-} ROSSYM_INFO;
-
 extern ROSSYM_CALLBACKS RosSymCallbacks;
 
 #define RosSymAllocMem(Size) (*RosSymCallbacks.AllocMemProc)(Size)

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1105,7 +1105,7 @@ UserProcessKeyboardInput(
         if (wVk & KBDEXT)
             KbdInput.dwFlags |= KEYEVENTF_EXTENDEDKEY;
         //
-        // Based on wine input:test_Input_blackbox this is okay. It seems the 
+        // Based on wine input:test_Input_blackbox this is okay. It seems the
         // bit did not get set and more research is needed. Now the right
         // shift works.
         //
@@ -1341,6 +1341,7 @@ NtUserToUnicodeEx(
     PWCHAR pwszBuff = NULL;
     INT i, iRet = 0;
     PKL pKl = NULL;
+    NTSTATUS Status;
 
     TRACE("Enter NtUserSetKeyboardState\n");
 
@@ -1390,16 +1391,34 @@ NtUserToUnicodeEx(
         pKl = pti->KeyboardLayout;
     }
 
-    iRet = IntToUnicodeEx(wVirtKey,
-                          wScanCode,
-                          afKeyState,
-                          pwszBuff,
-                          cchBuff,
-                          wFlags,
-                          pKl ? pKl->spkf->pKbdTbl : NULL);
+    if (pKl)
+    {
+        iRet = IntToUnicodeEx(wVirtKey,
+                            wScanCode,
+                            afKeyState,
+                            pwszBuff,
+                            cchBuff,
+                            wFlags,
+                            pKl->spkf->pKbdTbl);
 
-    MmCopyToCaller(pwszBuffUnsafe, pwszBuff, cchBuff * sizeof(WCHAR));
+        if (iRet)
+        {
+            Status = MmCopyToCaller(pwszBuffUnsafe, pwszBuff, cchBuff * sizeof(WCHAR));
+        }
+    }
+    else
+    {
+        ERR("No keyboard layout ?!\n");
+        Status = STATUS_INVALID_HANDLE;
+    }
+
     ExFreePoolWithTag(pwszBuff, TAG_STRING);
+
+    if (!NT_SUCCESS(Status))
+    {
+        iRet = 0;
+        SetLastNtError(Status);
+    }
 
     UserLeave();
     TRACE("Leave NtUserSetKeyboardState, ret=%i\n", iRet);


### PR DESCRIPTION
Partly based on @ThFabba proposal

## Purpose

374fef2d59f39b714ff3152f1590f6af843c8bf5 is so embarrassing that I can't just sit there and do nothing. Let's make that not happen again.

## Proposed changes

Check that we don't own spin locks before acquiring them.

## TODO

- [x] Check that we are at DISPATCH_LEVEL for the FromDpcLevel variants
