### PR TITLE
[WIN32K] Revert incorrect part of R50928 for RealizePalette.

### DIFF
--- a/win32ss/gdi/ntgdi/palette.c
+++ b/win32ss/gdi/ntgdi/palette.c
@@ -730,7 +730,7 @@ UINT
 FASTCALL
 IntGdiRealizePalette(HDC hDC)
 {
-    UINT i, realize = 0;
+    UINT /*i,*/ realize = 0;  // Removed i for CORE-13748 revert.
     PDC pdc;
     PALETTE *ppalSurf, *ppalDC;
 
@@ -769,12 +769,24 @@ IntGdiRealizePalette(HDC hDC)
 
     ASSERT(ppalDC->flFlags & PAL_INDEXED);
 
+/* These next lines are removed because of failures shown in CORE-13748 */
+#if 0
     // FIXME: Should we resize ppalSurf if it's too small?
     realize = (ppalDC->NumColors < ppalSurf->NumColors) ? ppalDC->NumColors : ppalSurf->NumColors;
 
     for (i=0; i<realize; i++)
     {
         InterlockedExchange((LONG*)&ppalSurf->IndexedColors[i], *(LONG*)&ppalDC->IndexedColors[i]);
+    }
+#endif
+    /* These next lines provide messages showing functions needing implementation */
+    if(pdc->dctype == DC_TYPE_MEMORY)
+    {
+        DPRINT1("RealizePalette unimplemented for memory managed DCs\n");
+    }
+    else
+    {
+        DPRINT1("RealizePalette unimplemented for device DCs\n");
     }
 
 cleanup:

--- a/win32ss/gdi/ntgdi/palette.c
+++ b/win32ss/gdi/ntgdi/palette.c
@@ -730,7 +730,7 @@ UINT
 FASTCALL
 IntGdiRealizePalette(HDC hDC)
 {
-    UINT /*i,*/ realize = 0;  // Removed i for CORE-13748 revert.
+    UINT realize = 0;
     PDC pdc;
     PALETTE *ppalSurf, *ppalDC;
 
@@ -769,25 +769,8 @@ IntGdiRealizePalette(HDC hDC)
 
     ASSERT(ppalDC->flFlags & PAL_INDEXED);
 
-/* These next lines are removed because of failures shown in CORE-13748 */
-#if 0
-    // FIXME: Should we resize ppalSurf if it's too small?
-    realize = (ppalDC->NumColors < ppalSurf->NumColors) ? ppalDC->NumColors : ppalSurf->NumColors;
-
-    for (i=0; i<realize; i++)
-    {
-        InterlockedExchange((LONG*)&ppalSurf->IndexedColors[i], *(LONG*)&ppalDC->IndexedColors[i]);
-    }
-#endif
-    /* These next lines provide messages showing functions needing implementation */
-    if(pdc->dctype == DC_TYPE_MEMORY)
-    {
-        DPRINT1("RealizePalette unimplemented for memory managed DCs\n");
-    }
-    else
-    {
-        DPRINT1("RealizePalette unimplemented for device DCs\n");
-    }
+    DPRINT1("RealizePalette unimplemented for %s\n", 
+            (pdc->dctype == DC_TYPE_MEMORY ? "memory managed DCs" : "device DCs"));
 
 cleanup:
     DC_UnlockDc(pdc);


### PR DESCRIPTION
## Revert incorrect code for Realize Palette

_Revert part of R50928 that causes Durak card suites to have wrong colors._

JIRA issue: [CORE-13748](https://jira.reactos.org/browse/CORE-13748) <= Durak Example
JIRA issue: [CORE-16510](https://jira.reactos.org/browse/CORE-16510) <= GDIProg Example

## Revert RealizePalette Code that causes wrong colors in Durak and GDIProg.

Durak in R50927
![DURAK_Show_all_Cards-50927](https://user-images.githubusercontent.com/32620577/119295220-e827e680-bc1b-11eb-8f46-90ef9158e57d.png)

Durak in R50928
![DURAK_Show_all_Cards-50928](https://user-images.githubusercontent.com/32620577/119295253-faa22000-bc1b-11eb-96f3-ffdfba167330.png)

Correct GDIProg from CORE-17164
![GDIProg_OK](https://user-images.githubusercontent.com/32620577/119321860-b4ac8280-bc42-11eb-9f86-082809d35bab.png)

GDIProg Menu Before:
![GDIProg_Menu_Bad](https://user-images.githubusercontent.com/32620577/119413370-14427680-bcb3-11eb-990e-0e04def24dab.png)

GDIProg Menu After:
![GDIProg_Menu_Good](https://user-images.githubusercontent.com/32620577/119413394-1efd0b80-bcb3-11eb-9a4c-f93f74d85836.png)

GDIProg Palette Before:
![GDIProg_Palette_Bad](https://user-images.githubusercontent.com/32620577/119413435-363bf900-bcb3-11eb-8b84-5537d5d194f2.png)

GDIProg Palette After:
![GDIProg_Palette_Good](https://user-images.githubusercontent.com/32620577/119413448-3dfb9d80-bcb3-11eb-863b-ec6ca1169804.png)
