### PR TITLE
[NTOS:MM] MiIsPdeForAddressValid is NOT an INIT function!

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -295,7 +295,6 @@ MI_IS_MAPPED_PTE(PMMPTE PointerPte)
             (PointerPte->u.Hard.PageFrameNumber != 0));
 }
 
-CODE_SEG("INIT")
 FORCEINLINE
 BOOLEAN
 MiIsPdeForAddressValid(PVOID Address)


### PR DESCRIPTION
Crash a bit less.