### PR TITLE
[GITHUB] build.yml: Extend MSVC ARM build to more applications

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,20 @@ jobs:
     - name: Build modules/rostests
       if: false # ${{ matrix.arch == 'arm' }}
       run: cmake --build build --target modules/rostests/all -- -k0
+    - name: Upload applications (as is)
+      uses: actions/upload-artifact@v2
+      with:
+        name: reactos-msvc${{matrix.toolset}}-${{matrix.arch}}-${{github.sha}}
+        path: |
+          build/base/applications
+          build/modules/rosapps
+          !**/CMakeFiles
+          !**/cmake_install.cmake
+    - name: Upload debug symbols
+      uses: actions/upload-artifact@v2
+      with:
+        name: reactos-syms-msvc${{matrix.toolset}}-${{matrix.arch}}-${{github.sha}}
+        path: build/msvc_pdb
 
   build-clang-cl:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,11 @@ jobs:
       run: cmake --build build --target rapps -- -k0
     - name: Build base/applications
       run: cmake --build build --target base/applications/all -- -k0
+    - name: Build modules/rosapps
+      run: cmake --build build --target modules/rosapps/all -- -k0
+    - name: Build modules/rostests
+      if: false # ${{ matrix.arch == 'arm' }}
+      run: cmake --build build --target modules/rostests/all -- -k0
 
   build-clang-cl:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,7 +164,10 @@ jobs:
     - name: Configure
       run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1
     - name: Build rapps
+      if: false # ${{ matrix.arch == 'arm64' }}
       run: cmake --build build --target rapps -- -k0
+    - name: Build base/applications
+      run: cmake --build build --target base/applications/all -- -k0
 
   build-clang-cl:
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,9 @@ jobs:
       matrix:
         toolset: ['14.2', '14.1'] # VS 2019, 2017
         arch: [arm]
+        include:
+        - arch: arm
+          toolset: '14.0' # VS 2015
       fail-fast: false
     runs-on: windows-latest
     steps:
@@ -152,7 +155,7 @@ jobs:
     - name: Activate VS cmd (arm)
       uses: ilammy/msvc-dev-cmd@v1
       with:
-        arch: x86_arm
+        arch: amd64_arm
         toolset: ${{matrix.toolset}}
     - name: Source checkout
       uses: actions/checkout@v2
@@ -161,7 +164,7 @@ jobs:
     - name: Configure
       run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1
     - name: Build rapps
-      run: cmake --build build --target rapps
+      run: cmake --build build --target rapps -- -k0
 
   build-clang-cl:
     strategy:


### PR DESCRIPTION
## Purpose

Almost complete Jira ticket, as filed.

JIRA issue: [CORE-17517](https://jira.reactos.org/browse/CORE-17517)

## Proposed changes

- Build all base apps.
Plus, build all ros apps.
- Upload artifacts.
- Prepare a bit more for follow-up ARM64 PR.