### PR TITLE
[REGEDIT] Use InitCommonControlsEx instead of InitCommonControls

### DIFF
--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -2,6 +2,7 @@
  * Regedit main function
  *
  * Copyright (C) 2002 Robert Dickenson <robd@reactos.org>
+ * Copyright (C) 2021 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -57,7 +58,7 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
 {
     BOOL AclUiAvailable;
     HMENU hEditMenu;
-
+    INITCOMMONCONTROLSEX icce;
     WNDCLASSEXW wcFrame;
     WNDCLASSEXW wcChild;
     ATOM hFrameWndClass;
@@ -97,8 +98,9 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
     hPopupMenus = LoadMenuW(hInstance, MAKEINTRESOURCEW(IDR_POPUP_MENUS));
 
     /* Initialize the Windows Common Controls DLL */
-    // TODO: Replace this call by InitCommonControlsEx(_something_)
-    InitCommonControls();
+    icce.dwSize = sizeof(icce);
+    icce.dwICC = 0xFFFF; /* Windows does this! */
+    InitCommonControlsEx(&icce);
 
     hEditMenu = GetSubMenu(hMenuFrame, 1);
 

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -98,8 +98,9 @@ BOOL InitInstance(HINSTANCE hInstance, int nCmdShow)
     hPopupMenus = LoadMenuW(hInstance, MAKEINTRESOURCEW(IDR_POPUP_MENUS));
 
     /* Initialize the Windows Common Controls DLL */
+    /* NOTE: Windows sets 0xFFFF to icce.dwICC but we use better value. */
     icce.dwSize = sizeof(icce);
-    icce.dwICC = 0xFFFF; /* Windows does this! */
+    icce.dwICC = ICC_WIN95_CLASSES | ICC_STANDARD_CLASSES | ICC_USEREX_CLASSES;
     InitCommonControlsEx(&icce);
 
     hEditMenu = GetSubMenu(hMenuFrame, 1);

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -2,7 +2,6 @@
  * Regedit main function
  *
  * Copyright (C) 2002 Robert Dickenson <robd@reactos.org>
- * Copyright (C) 2021 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public


### PR DESCRIPTION
## Purpose

JIRA issue: N/A

## Proposed changes

- Call `comctl32!InitCommonControlsEx` function rather than `comctl32!InitCommonControls` funciton.

![no-change](https://user-images.githubusercontent.com/2107452/119448960-f5081f80-bd6c-11eb-92d4-3bc2b4b471b7.png)
No change.