### PR TITLE
[WIN32SS][NTUSER] ShowWindow.SW_MINIMIZE should show window

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2551,9 +2551,8 @@ co_WinPosShowWindow(PWND Wnd, INT Cmd)
          Swp |= SWP_NOACTIVATE | SWP_NOZORDER;
          /* Fall through. */
       case SW_SHOWMINIMIZED:
+      case SW_MINIMIZE: /* CORE-15669: SW_MINIMIZE also shows */
          Swp |= SWP_SHOWWINDOW;
-         /* Fall through. */
-      case SW_MINIMIZE:
          {
             Swp |= SWP_NOACTIVATE;
             if (!(style & WS_MINIMIZE))
@@ -2648,7 +2647,7 @@ co_WinPosShowWindow(PWND Wnd, INT Cmd)
 
       default:
          //ERR("co_WinPosShowWindow Exit Good 4\n");
-         return WasVisible;
+         return FALSE;
    }
 
    ShowFlag = (Cmd != SW_HIDE);


### PR DESCRIPTION
## Purpose
Improve compatibility of `user32!ShowWindow` function.
JIRA issue: [CORE-15669](https://jira.reactos.org/browse/CORE-15669)

## Proposed changes

- `user32!ShowWindow.SW_MINIMIZE` should show the window.
- Fix the return value of `ShowWindow` function on invalid parameter.

## TODO

- [x] Do test in depth.

## Comparison

BEFORE:
![before-1](https://user-images.githubusercontent.com/2107452/120089700-afb26c00-c137-11eb-8a39-d7871c45220f.png)
There were some failures.
AFTER:
![after-1](https://user-images.githubusercontent.com/2107452/120089699-ae813f00-c137-11eb-8882-b16f4c750ac8.png)
Successful.

BEFORE:
![before-2](https://user-images.githubusercontent.com/2107452/120089701-afb26c00-c137-11eb-97d4-6342e668958f.png)
The setup program of DVD Write Now won't show the taskbar pane.
AFTER:
![after-2](https://user-images.githubusercontent.com/2107452/120089707-bb9e2e00-c137-11eb-9218-ba1c632098ab.png)
The setup program of DVD Write Now shows the taskbar pane.
Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/120090438-7ed53580-c13d-11eb-851a-16596cf07824.png)