### PR TITLE
Amd64/hacky code

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1373,7 +1373,7 @@ GetPrimaryScreenRect:
 
                 m_TrayRects[m_Position] = rcTray;
             }
-            else
+            else if (m_Position != (DWORD)-1)
             {
                 /* If the user isn't resizing the tray window we need to make sure the
                    new size or position is valid. this is to prevent changes to the window

--- a/dll/win32/browseui/desktopipc.cpp
+++ b/dll/win32/browseui/desktopipc.cpp
@@ -454,7 +454,7 @@ extern "C" IEThreadParamBlock *WINAPI SHCreateIETHREADPARAM(
 
     TRACE("SHCreateIETHREADPARAM\n");
 
-    result = (IEThreadParamBlock *) LocalAlloc(LMEM_ZEROINIT, 256);
+    result = (IEThreadParamBlock *) LocalAlloc(LMEM_ZEROINIT, sizeof(*result));
     if (result == NULL)
         return NULL;
     result->offset0 = param8;
@@ -477,10 +477,10 @@ extern "C" IEThreadParamBlock *WINAPI SHCloneIETHREADPARAM(IEThreadParamBlock *p
 
     TRACE("SHCloneIETHREADPARAM\n");
 
-    result = (IEThreadParamBlock *) LocalAlloc(LMEM_FIXED, 256);
+    result = (IEThreadParamBlock *) LocalAlloc(LMEM_FIXED, sizeof(*result));
     if (result == NULL)
         return NULL;
-    memcpy(result, param, 0x40 * 4);
+    *result = *param;
     if (result->directoryPIDL != NULL)
         result->directoryPIDL = ILClone(result->directoryPIDL);
     if (result->offset7C != NULL)


### PR DESCRIPTION
* [BROWSEUI] Disable broken code on x64
* [EXPLORER] Do not initialize m_Position to -1 to stop crashing on x64
