### PR TITLE
[SHELL32] Add missing flags in RegGetValueW call

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1125,14 +1125,14 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
         ret = RegGetValueW(HKEY_CURRENT_USER,
                            L"AppEvents\\Schemes\\Apps\\Explorer\\EmptyRecycleBin\\.Current",
                            NULL,
-                           RRF_RT_REG_SZ,
+                           RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ | RRF_NOEXPAND,
                            &dwType,
                            (PVOID)szPath,
                            &dwSize);
         if (ret != ERROR_SUCCESS)
             return S_OK;
 
-        if (dwType != REG_EXPAND_SZ) /* type dismatch */
+        if (dwType != REG_EXPAND_SZ || dwType != REG_SZ) /* type dismatch */
             return S_OK;
 
         szPath[_countof(szPath)-1] = L'\0';

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1132,7 +1132,7 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
         if (ret != ERROR_SUCCESS)
             return S_OK;
 
-        if (dwType != REG_EXPAND_SZ || dwType != REG_SZ) /* type dismatch */
+        if (dwType != REG_SZ || dwType != REG_EXPAND_SZ) /* Check whether the type is valid */
             return S_OK;
 
         szPath[_countof(szPath)-1] = L'\0';

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1137,7 +1137,7 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
 
         if (dwType == REG_EXPAND_SZ)
         {
-            if (!ExpandEnvironmentStringsW(szPath, szDest, MAX_PATH))
+            if (!ExpandEnvironmentStringsW(szPath, szDest, _countof(szDest)))
                 return S_OK;
         }
 

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1028,7 +1028,7 @@ HRESULT WINAPI SHEmptyRecycleBinA(HWND hwnd, LPCSTR pszRootPath, DWORD dwFlags)
 
 HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
 {
-    WCHAR szPath[MAX_PATH] = {0}, szBuffer[MAX_PATH];
+    WCHAR szPath[MAX_PATH] = {0}, szBuffer[MAX_PATH], szDest[MAX_PATH];
     DWORD dwSize, dwType, count;
     LONG ret;
     IShellFolder *pDesktop, *pRecycleBin;
@@ -1132,11 +1132,24 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
         if (ret != ERROR_SUCCESS)
             return S_OK;
 
-        if (dwType != REG_SZ || dwType != REG_EXPAND_SZ) /* Check whether the type is valid */
+        if (dwType != REG_SZ && dwType != REG_EXPAND_SZ) /* Check whether the type is valid */
             return S_OK;
 
-        szPath[_countof(szPath)-1] = L'\0';
-        PlaySoundW(szPath, NULL, SND_FILENAME);
+        ERR("szPath is %ls, size %d\n", szPath, dwSize);
+
+        if (dwType == REG_EXPAND_SZ)
+        {
+            if (!ExpandEnvironmentStringsW(szPath, szDest, MAX_PATH))
+            {
+                ERR("ExpandEnvironmentStringsW failed for %ls\n", szPath);
+                return S_OK;
+            }
+        }
+
+        ERR("szDest is %ls\n", szDest);
+
+        szDest[_countof(szDest)-1] = L'\0';
+        PlaySoundW(szDest, NULL, SND_FILENAME);
     }
     return S_OK;
 }

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1028,7 +1028,7 @@ HRESULT WINAPI SHEmptyRecycleBinA(HWND hwnd, LPCSTR pszRootPath, DWORD dwFlags)
 
 HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
 {
-    WCHAR szPath[MAX_PATH] = {0}, szBuffer[MAX_PATH], szDest[MAX_PATH];
+    WCHAR szPath[MAX_PATH] = {0}, szBuffer[MAX_PATH];
     DWORD dwSize, dwType, count;
     LONG ret;
     IShellFolder *pDesktop, *pRecycleBin;
@@ -1127,7 +1127,7 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
                            NULL,
                            RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ | RRF_NOEXPAND,
                            &dwType,
-                           (PVOID)szPath,
+                           (PVOID)szBuffer,
                            &dwSize);
         if (ret != ERROR_SUCCESS)
             return S_OK;
@@ -1137,12 +1137,12 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
 
         if (dwType == REG_EXPAND_SZ)
         {
-            if (!ExpandEnvironmentStringsW(szPath, szDest, _countof(szDest)))
+            if (!ExpandEnvironmentStringsW(szBuffer, szPath, _countof(szPath)))
                 return S_OK;
         }
 
-        szDest[_countof(szDest)-1] = L'\0';
-        PlaySoundW(szDest, NULL, SND_FILENAME);
+        szPath[_countof(szPath)-1] = L'\0';
+        PlaySoundW(szPath, NULL, SND_FILENAME);
     }
     return S_OK;
 }

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1135,18 +1135,11 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
         if (dwType != REG_SZ && dwType != REG_EXPAND_SZ) /* Check whether the type is valid */
             return S_OK;
 
-        ERR("szPath is %ls, size %d\n", szPath, dwSize);
-
         if (dwType == REG_EXPAND_SZ)
         {
             if (!ExpandEnvironmentStringsW(szPath, szDest, MAX_PATH))
-            {
-                ERR("ExpandEnvironmentStringsW failed for %ls\n", szPath);
                 return S_OK;
-            }
         }
-
-        ERR("szDest is %ls\n", szDest);
 
         szDest[_countof(szDest)-1] = L'\0';
         PlaySoundW(szDest, NULL, SND_FILENAME);

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1139,10 +1139,15 @@ HRESULT WINAPI SHEmptyRecycleBinW(HWND hwnd, LPCWSTR pszRootPath, DWORD dwFlags)
         {
             if (!ExpandEnvironmentStringsW(szBuffer, szPath, _countof(szPath)))
                 return S_OK;
-        }
 
-        szPath[_countof(szPath)-1] = L'\0';
-        PlaySoundW(szPath, NULL, SND_FILENAME);
+            szPath[_countof(szPath)-1] = L'\0';
+            PlaySoundW(szPath, NULL, SND_FILENAME);
+        }
+        else if (dwType == REG_SZ)
+        {
+            szBuffer[_countof(szBuffer)-1] = L'\0';
+            PlaySoundW(szBuffer, NULL, SND_FILENAME);
+        }
     }
     return S_OK;
 }


### PR DESCRIPTION
## Purpose

`SHEmptyRecycleBinW` should actually check for `REG_EXPAND_SZ` value of sound event (as it's provided by registry), not only `REG_SZ`.
Our mmsys.cpl always sets the `REG_EXPAND_SZ` values for sound events, same as they are in Windows by default. So the function fails to play the sound event if the value is not `REG_SZ`.
Moreover, it checks for the mismatch of the value type after calling `RegGetValueW`, and fails on this.
It allows to play Recycle Bin sound event properly when user empties the trash (after doing some winesync in winmm also).
Also fix the check for value type mismatch and expand environment variable from the string if it exists there.

JIRA issue: [CORE-13951](https://jira.reactos.org/browse/CORE-13951)

## TODO

- [x] Perhaps call `ExpandEnvironmentStringsW` and pass its output to `PlaySoundW`, since the string is expandable. I doubt is this badly required in this case, if the sound event is now playing properly even without doing that.

## Result

For the test, I used Recycle Bin sound from Windows Vista, since ReactOS currently has no appropriate sound for it, and not each sound plays correctly at all, due to limitations of AC97 VirtualBox driver.
As visible in the video, the sound event is now playing successfully after my changes. :slightly_smiling_face: 

https://user-images.githubusercontent.com/26385117/120683234-0c01ec80-c4a6-11eb-954a-fed3808c178f.mp4