### PR TITLE
[CMLIB] arm64: Define PAGE_SIZE

### DIFF
--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -194,7 +194,8 @@
 // PAGE_SIZE definition
 //
 #ifndef PAGE_SIZE
-#if defined(TARGET_i386) || defined(TARGET_amd64) || defined(TARGET_arm)
+#if defined(TARGET_i386) || defined(TARGET_amd64) || \
+    defined(TARGET_arm)  || defined(TARGET_arm64)
 #define PAGE_SIZE 0x1000
 #else
 #error Local PAGE_SIZE definition required when built as host


### PR DESCRIPTION
MSVC arm64:
'...\cmlib.h(200): fatal error C1189: #error:  Local PAGE_SIZE definition required when built as host'

JIRA issue: [CORE-17518](https://jira.reactos.org/browse/CORE-17518)