### PR TITLE
[CPL][APPWIZ] Make gecko download cancellable by keyboard

### DIFF
--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -388,10 +388,17 @@ static DWORD WINAPI download_proc(PVOID arg)
 
 static INT_PTR CALLBACK installer_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
-    HWND hwndInstallButton;
+    HWND hwndProgress, hwndInstallButton;
     switch(msg) {
     case WM_INITDIALOG:
-        ShowWindow(GetDlgItem(hwnd, ID_DWL_PROGRESS), SW_HIDE);
+
+        hwndProgress = GetDlgItem(hwnd, ID_DWL_PROGRESS);
+        if (hwndProgress == GetFocus()) /* Avoid CORE-5737 */
+        {
+            SendMessageW(hwnd, WM_NEXTDLGCTL, 0, FALSE);
+        }
+        ShowWindow(hwndProgress, SW_HIDE);
+
         install_dialog = hwnd;
         return TRUE;
 

--- a/dll/cpl/appwiz/addons.c
+++ b/dll/cpl/appwiz/addons.c
@@ -388,6 +388,7 @@ static DWORD WINAPI download_proc(PVOID arg)
 
 static INT_PTR CALLBACK installer_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
+    HWND hwndInstallButton;
     switch(msg) {
     case WM_INITDIALOG:
         ShowWindow(GetDlgItem(hwnd, ID_DWL_PROGRESS), SW_HIDE);
@@ -410,7 +411,15 @@ static INT_PTR CALLBACK installer_proc(HWND hwnd, UINT msg, WPARAM wParam, LPARA
 
         case ID_DWL_INSTALL:
             ShowWindow(GetDlgItem(hwnd, ID_DWL_PROGRESS), SW_SHOW);
-            EnableWindow(GetDlgItem(hwnd, ID_DWL_INSTALL), 0);
+
+            /* CORE-17550: Never leave focus on a disabled control (Old/New/Thing p.228) */
+            hwndInstallButton = GetDlgItem(hwnd, ID_DWL_INSTALL);
+            if (hwndInstallButton == GetFocus())
+            {
+                SendMessageW(hwnd, WM_NEXTDLGCTL, 0, FALSE);
+            }
+            EnableWindow(hwndInstallButton, FALSE);
+
             CloseHandle( CreateThread(NULL, 0, download_proc, NULL, 0, NULL));
             return FALSE;
         }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17550](https://jira.reactos.org/browse/CORE-17550), [CORE-5737](https://jira.reactos.org/browse/CORE-5737)

## Proposed changes

- Move the focus by sending `WM_NEXTDLGCTL` before making the focus control disabled or hidden.

## Screenshots

Start download of gecko by pressing `Enter` key...
![VirtualBox_ReactOS_05_06_2021_17_12_50](https://user-images.githubusercontent.com/2107452/120885035-a20e5200-c621-11eb-8861-f2539fbf9da2.png)
And cancel by keyboard `Esc` key.
![VirtualBox_ReactOS_05_06_2021_17_13_03](https://user-images.githubusercontent.com/2107452/120885031-a0448e80-c621-11eb-9193-2dde16505350.png)
OK.