### PR TITLE
[RAPPS] Implement support for architecture specific sections

### DIFF
--- a/base/applications/rapps/available.cpp
+++ b/base/applications/rapps/available.cpp
@@ -516,6 +516,15 @@ BOOL CAvailableApps::Enum(INT EnumType, AVAILENUMPROC lpEnumProc, PVOID param)
 
             // set a timestamp for the next time
             Info->SetLastWriteTime(&FindFileData.ftLastWriteTime);
+
+            /* Check if we have the download URL */
+            if (Info->m_szUrlDownload.IsEmpty())
+            {
+                /* Can't use it, delete it */
+                delete Info;
+                continue;
+            }
+
             m_InfoList.AddTail(Info);
 
         skip_if_cached:

--- a/base/applications/rapps/include/misc.h
+++ b/base/applications/rapps/include/misc.h
@@ -6,6 +6,19 @@
 #define EPOCH_DIFF 116444736000000000 //FILETIME starts from 1601-01-01 UTC, UnixTime starts from 1970-01-01
 #define RATE_DIFF 10000000
 
+#ifdef _M_IX86
+#define CurrentArchitecture L"x86"
+#elif defined(_M_AMD64)
+#define CurrentArchitecture L"amd64"
+#elif defined(_M_ARM)
+#define CurrentArchitecture L"arm"
+#elif defined(_M_ARM64)
+#define CurrentArchitecture L"arm64"
+#elif defined(_M_IA64)
+#define CurrentArchitecture L"ia64"
+#elif defined(_M_PPC)
+#define CurrentArchitecture L"ppc"
+#endif
 
 INT GetWindowWidth(HWND hwnd);
 INT GetWindowHeight(HWND hwnd);
@@ -41,6 +54,7 @@ class CConfigParser
 
     ATL::CStringW GetINIFullPath(const ATL::CStringW& FileName);
     VOID CacheINILocale();
+    BOOL GetStringWorker(const ATL::CStringW& KeyName, PCWSTR Suffix, ATL::CStringW& ResultString);
 
 public:
     CConfigParser(const ATL::CStringW& FileName = "");


### PR DESCRIPTION
This PR adds support for architecture specific section, e.g. [Section.amd64], [Section.0c0a.amd64])

See also https://github.com/reactos/rapps-db/pull/142

Example for a new entry:

```
[Section]
Name = 7-Zip
Version = 19.00
License = LGPL
Description = A file archiving utility with support for 7zip, zip, tar, rar and many other archive formats.
Size = 1.1 MiB
Category = 12
URLSite = https://www.7-zip.org/
URLDownload = https://www.7-zip.org/a/7z1900.exe
SHA1 = 2f23a6389470db5d0dd2095d64939657d8d3ea9d
CDPath = none
SizeBytes = 1185968

[Section.amd64]
URLSite = http://svn.reactos.org/
URLDownload = http://svn.reactos.org/packages/7z1900-x64.exe
SHA1 = 0138746b529d4d3a81302c2bc355a0b855a86d38
```
