### PR TITLE
[SYSSETUP] Enable sound events for Workstation

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -471,6 +471,7 @@ DoWriteSoundEvents(HKEY hKey,
         goto Error;
     }
 
+    /* Set each sound event */
     for (i = 0; i < dwSize; i++)
     {
         /* Open all sound event subkeys */

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -463,7 +463,7 @@ DoWriteSoundEvents(HKEY hKey,
     DWORD cbData;
 
 
-    /* Open sound events key */
+    /* Open the sound events key */
     error = RegOpenKeyExW(hKey, lpSubkey, 0, KEY_READ, &hRootKey);
     if (error)
     {

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -453,7 +453,7 @@ static const WCHAR* s_ExplorerSoundEvents[][2] =
 static BOOL
 DoWriteSoundEvents(HKEY hKey,
                    LPCWSTR lpSubkey,
-                   LPCWSTR lpValue[],
+                   LPCWSTR lpEventsArray[][2],
                    DWORD dwSize)
 {
     HKEY hRootKey, hEventKey, hDefaultKey;

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -459,7 +459,8 @@ DoWriteSoundEvents(HKEY hKey,
     HKEY hRootKey, hEventKey, hDefaultKey;
     LONG error;
     ULONG i;
-    LPCWSTR pszData, pszDest[MAX_PATH][2];
+    WCHAR szDest[MAX_PATH];
+    DWORD dwAttribs;
     DWORD cbData;
 
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -509,6 +509,7 @@ DoWriteSoundEvents(HKEY hKey,
 
         /* Open .Default subkey */
         error = RegOpenKeyExW(hEventKey, L".Default", 0, KEY_WRITE, &hDefaultKey);
+        RegCloseKey(hEventKey);
         if (error)
         {
             DPRINT1("RegOpenKeyExW failed\n");

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -7,6 +7,7 @@
  *                  Pierre Schweitzer <heis_spiter@hotmail.com>
  *                  Ismael Ferreras Morezuelas <swyterzone+ros@gmail.com>
  *                  Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *                  Oleg Dubinskiy <oleg.dubinskij2013@yandex.ua>
  */
 
 /* INCLUDES *****************************************************************/
@@ -395,6 +396,8 @@ static const WCHAR s_szProductOptions[] = L"SYSTEM\\CurrentControlSet\\Control\\
 static const WCHAR s_szRosVersion[] = L"SYSTEM\\CurrentControlSet\\Control\\ReactOS\\Settings\\Version";
 static const WCHAR s_szControlWindows[] = L"SYSTEM\\CurrentControlSet\\Control\\Windows";
 static const WCHAR s_szWinlogon[] = L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon";
+static const WCHAR s_szDefaultSoundEvents[] = L"AppEvents\\Schemes\\Apps\\.Default";
+static const WCHAR s_szExplorerSoundEvents[] = L"AppEvents\\Schemes\\Apps\\Explorer";
 
 typedef struct _PRODUCT_OPTION_DATA
 {
@@ -410,6 +413,123 @@ static const PRODUCT_OPTION_DATA s_ProductOptionData[] =
     { L"Terminal Server\0", L"ServerNT", 0, 0x200, 0 },
     { L"\0", L"WinNT", 1, 0x300, 1 }
 };
+
+static const WCHAR* s_DefaultSoundEvents[][2] = 
+{
+    { L".Default", L"%SystemRoot%\\Media\\ReactOS_Default.wav" },
+    { L"AppGPFault", L"" },
+    { L"Close", L"" },
+    { L"CriticalBatteryAlarm", L"%SystemRoot%\\Media\\ReactOS_Battery_Critical.wav" },
+    { L"DeviceConnect",  L"%SystemRoot%\\Media\\ReactOS_Hardware_Insert.wav" },
+    { L"DeviceDisconnect", L"%SystemRoot%\\Media\\ReactOS_Hardware_Remove.wav" },
+    { L"DeviceFail", L"%SystemRoot%\\Media\\ReactOS_Hardware_Fail.wav" },
+    { L"LowBatteryAlarm", L"%SystemRoot%\\Media\\ReactOS_Battery_Low.wav" },
+    { L"MailBeep", L"%SystemRoot%\\Media\\ReactOS_Notify.wav" },
+    { L"Maximize", L"%SystemRoot%\\Media\\ReactOS_Restore.wav" },
+    { L"MenuCommand", L"%SystemRoot%\\Media\\ReactOS_Menu_Command.wav" },
+    { L"MenuPopup", L"" },
+    { L"Minimize", L"%SystemRoot%\\Media\\ReactOS_Minimize.wav" },
+    { L"Open", L"" },
+    { L"PrintComplete", L"%SystemRoot%\\Media\\ReactOS_Print_Complete.wav" },
+    { L"RestoreDown", L"" },
+    { L"RestoreUp", L"" },
+    { L"SystemAsterisk", L"%SystemRoot%\\Media\\ReactOS_Ding.wav" },
+    { L"SystemExclamation", L"%SystemRoot%\\Media\\ReactOS_Exclamation.wav" },
+    { L"SystemExit", L"%SystemRoot%\\Media\\ReactOS_Shutdown.wav" },
+    { L"SystemHand", L"%SystemRoot%\\Media\\ReactOS_Critical_Stop.wav" },
+    { L"SystemNotification", L"%SystemRoot%\\Media\\ReactOS_Balloon.wav" },
+    { L"SystemQuestion", L"%SystemRoot%\\Media\\ReactOS_Ding.wav" },
+    { L"SystemStart", L"%SystemRoot%\\Media\\ReactOS_Startup.wav" },
+    { L"WindowsLogoff", L"%SystemRoot%\\Media\\ReactOS_LogOff.wav" }
+/* Logon sound is already set by default for both Server and Workstation */
+};
+
+static const WCHAR* s_ExplorerSoundEvents[][2] = 
+{
+    { L"EmptyRecycleBin", L"%SystemRoot%\\Media\\ReactOS_Recycle.wav" },
+    { L"Navigating", L"%SystemRoot%\\Media\\ReactOS_Start.wav" }
+};
+
+static BOOL
+DoWriteSoundEvents(HKEY hKey,
+                   LPCWSTR lpSubkey,
+                   LPCWSTR lpValue[],
+                   DWORD dwSize)
+{
+    HKEY hRootKey, hEventKey, hDefaultKey;
+    LONG error;
+    ULONG i;
+    LPCWSTR pszData, pszDest[MAX_PATH][2];
+    DWORD cbData;
+
+    for (i = 0; i < dwSize; i++)
+    {
+        /* Expand environment variable from string */
+        if (!ExpandEnvironmentStringsW(&lpValue[i][1], (LPWSTR)pszDest, _countof(pszDest)))
+        {
+            /* Failed to expand, continue with the other files */
+            continue;
+        }
+
+        /* Check if the sound file exists and isn't a directory */
+        if (GetFileAttributesW(pszDest[i][1]) == INVALID_FILE_ATTRIBUTES ||
+            GetFileAttributesW(pszDest[i][1]) == FILE_ATTRIBUTE_DIRECTORY)
+        {
+            /* It does not, just continue with the other files */
+            continue;
+        }
+    }
+
+    /* Open sound events key */
+    error = RegOpenKeyExW(hKey, lpSubkey, 0, KEY_READ, &hRootKey);
+    if (error)
+    {
+        DPRINT1("RegOpenKeyExW failed\n");
+        goto Error;
+    }
+
+    for (i = 0; i < dwSize; i++)
+    {
+        /* Open all sound event subkeys */
+        error = RegOpenKeyExW(hRootKey, &lpValue[i][0], 0, KEY_READ, &hEventKey);
+        if (error)
+        {
+            DPRINT1("RegOpenKeyExW failed\n");
+            goto Error;
+        }
+
+        /* Open .Default subkey */
+        error = RegOpenKeyExW(hEventKey, L".Default", 0, KEY_WRITE, &hDefaultKey);
+        if (error)
+        {
+            DPRINT1("RegOpenKeyExW failed\n");
+            goto Error;
+        }
+
+        /* Write appropriate values for them */
+        pszData = &lpValue[i][1];
+        cbData = (lstrlenW(pszData) + 1) * sizeof(WCHAR);
+        error = RegSetValueExW(hDefaultKey, NULL, 0, REG_EXPAND_SZ, (const BYTE *)pszData, cbData);
+        if (error)
+        {
+            DPRINT1("RegSetValueExW failed\n");
+            goto Error;
+        }
+        
+    }
+
+Error:
+    if (hDefaultKey)
+        RegCloseKey(hDefaultKey);
+
+    if (hEventKey)
+        RegCloseKey(hEventKey);
+
+    if (hRootKey)
+        RegCloseKey(hRootKey);
+
+    return error == ERROR_SUCCESS;
+}
 
 static BOOL
 DoWriteProductOption(PRODUCT_OPTION nOption)
@@ -507,6 +627,13 @@ DoWriteProductOption(PRODUCT_OPTION nOption)
     {
         DPRINT1("RegSetValueExW failed\n");
         goto Error;
+    }
+
+    if (nOption == PRODUCT_OPTION_WORKSTATION)
+    {
+        /* Write system sound events values for Workstation */
+        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szDefaultSoundEvents, (LPCWSTR *)s_DefaultSoundEvents[_countof(s_DefaultSoundEvents)][2], _countof(s_DefaultSoundEvents));
+        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szExplorerSoundEvents, (LPCWSTR *)s_ExplorerSoundEvents[_countof(s_ExplorerSoundEvents)][2], _countof(s_ExplorerSoundEvents));
     }
 
 Error:

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -463,7 +463,6 @@ DoWriteSoundEvents(HKEY hKey,
     DWORD dwAttribs;
     DWORD cbData;
 
-
     /* Open the sound events key */
     error = RegOpenKeyExW(hKey, lpSubkey, 0, KEY_READ, &hRootKey);
     if (error)
@@ -503,8 +502,8 @@ DoWriteSoundEvents(HKEY hKey,
         error = RegOpenKeyExW(hRootKey, lpEventsArray[i][0], 0, KEY_READ, &hEventKey);
         if (error)
         {
-            DPRINT1("RegOpenKeyExW failed\n");
-            goto Error;
+            /* Failed to open, continue with next sound event */
+            continue;
         }
 
         /* Open .Default subkey */
@@ -512,18 +511,18 @@ DoWriteSoundEvents(HKEY hKey,
         RegCloseKey(hEventKey);
         if (error)
         {
-            DPRINT1("RegOpenKeyExW failed\n");
-            goto Error;
+            /* Failed to open, continue with next sound event */
+            continue;
         }
 
         /* Associate the sound file to this sound event */
-        cbData = (lstrlenW(lpValue[i][1]) + 1) * sizeof(WCHAR);
-        error = RegSetValueExW(hDefaultKey, NULL, 0, REG_EXPAND_SZ, (const BYTE *)lpValue[i][1], cbData);
+        cbData = (lstrlenW(lpEventsArray[i][1]) + 1) * sizeof(WCHAR);
+        error = RegSetValueExW(hDefaultKey, NULL, 0, REG_EXPAND_SZ, (const BYTE *)lpEventsArray[i][1], cbData);
         RegCloseKey(hDefaultKey);
         if (error)
         {
-            DPRINT1("RegSetValueExW failed\n");
-            goto Error;
+            /* Failed to set the value, continue with next sound event */
+            continue;
         }
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -515,7 +515,6 @@ DoWriteSoundEvents(HKEY hKey,
             DPRINT1("RegSetValueExW failed\n");
             goto Error;
         }
-        
     }
 
 Error:

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -514,10 +514,10 @@ DoWriteSoundEvents(HKEY hKey,
             goto Error;
         }
 
-        /* Write appropriate values for them */
-        pszData = &lpValue[i][1];
-        cbData = (lstrlenW(pszData) + 1) * sizeof(WCHAR);
-        error = RegSetValueExW(hDefaultKey, NULL, 0, REG_EXPAND_SZ, (const BYTE *)pszData, cbData);
+        /* Associate the sound file to this sound event */
+        cbData = (lstrlenW(lpValue[i][1]) + 1) * sizeof(WCHAR);
+        error = RegSetValueExW(hDefaultKey, NULL, 0, REG_EXPAND_SZ, (const BYTE *)lpValue[i][1], cbData);
+        RegCloseKey(hDefaultKey);
         if (error)
         {
             DPRINT1("RegSetValueExW failed\n");

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -528,12 +528,6 @@ DoWriteSoundEvents(HKEY hKey,
     }
 
 Error:
-    if (hDefaultKey)
-        RegCloseKey(hDefaultKey);
-
-    if (hEventKey)
-        RegCloseKey(hEventKey);
-
     if (hRootKey)
         RegCloseKey(hRootKey);
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -632,8 +632,8 @@ DoWriteProductOption(PRODUCT_OPTION nOption)
     if (nOption == PRODUCT_OPTION_WORKSTATION)
     {
         /* Write system sound events values for Workstation */
-        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szDefaultSoundEvents, (LPCWSTR *)s_DefaultSoundEvents[_countof(s_DefaultSoundEvents)][2], _countof(s_DefaultSoundEvents));
-        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szExplorerSoundEvents, (LPCWSTR *)s_ExplorerSoundEvents[_countof(s_ExplorerSoundEvents)][2], _countof(s_ExplorerSoundEvents));
+        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szDefaultSoundEvents, s_DefaultSoundEvents, _countof(s_DefaultSoundEvents));
+        DoWriteSoundEvents(HKEY_CURRENT_USER, s_szExplorerSoundEvents, s_ExplorerSoundEvents, _countof(s_ExplorerSoundEvents));
     }
 
 Error:

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -474,8 +474,32 @@ DoWriteSoundEvents(HKEY hKey,
     /* Set each sound event */
     for (i = 0; i < dwSize; i++)
     {
-        /* Open all sound event subkeys */
-        error = RegOpenKeyExW(hRootKey, &lpValue[i][0], 0, KEY_READ, &hEventKey);
+        /*
+         * Verify that the sound file exists and is an actual file.
+         */
+
+        /* Expand the sound file path */
+        if (!ExpandEnvironmentStringsW(lpEventsArray[i][1], szDest, _countof(szDest)))
+        {
+            /* Failed to expand, continue with the next sound event */
+            continue;
+        }
+
+        /* Check if the sound file exists and isn't a directory */
+        dwAttribs = GetFileAttributesW(szDest);
+        if ((dwAttribs == INVALID_FILE_ATTRIBUTES) ||
+            (dwAttribs & FILE_ATTRIBUTE_DIRECTORY))
+        {
+            /* It does not, just continue with the next sound event */
+            continue;
+        }
+
+        /*
+         * Create the sound event entry.
+         */
+
+        /* Open the sound event subkey */
+        error = RegOpenKeyExW(hRootKey, lpEventsArray[i][0], 0, KEY_READ, &hEventKey);
         if (error)
         {
             DPRINT1("RegOpenKeyExW failed\n");

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -462,23 +462,6 @@ DoWriteSoundEvents(HKEY hKey,
     LPCWSTR pszData, pszDest[MAX_PATH][2];
     DWORD cbData;
 
-    for (i = 0; i < dwSize; i++)
-    {
-        /* Expand environment variable from string */
-        if (!ExpandEnvironmentStringsW(&lpValue[i][1], (LPWSTR)pszDest, _countof(pszDest)))
-        {
-            /* Failed to expand, continue with the other files */
-            continue;
-        }
-
-        /* Check if the sound file exists and isn't a directory */
-        if (GetFileAttributesW(pszDest[i][1]) == INVALID_FILE_ATTRIBUTES ||
-            GetFileAttributesW(pszDest[i][1]) == FILE_ATTRIBUTE_DIRECTORY)
-        {
-            /* It does not, just continue with the other files */
-            continue;
-        }
-    }
 
     /* Open sound events key */
     error = RegOpenKeyExW(hKey, lpSubkey, 0, KEY_READ, &hRootKey);


### PR DESCRIPTION
## Purpose

Write sound events values in registry in case user selected Workstation setup during 2nd setup stage.
This makes ROS behaving more like XP (which is also Workstation), since all sound events are enabled there by default.

JIRA issue: [CORE-13951](https://jira.reactos.org/browse/CORE-13951)

## Proposed changes

- Define sound events registry keys and arrays with sound events values.
- Implement helper `DoWriteSoundEvent` function, which does all work.
- Call it in `DoWriteProductOption` in case if Workstation was selected.

## TODO

- [x] **Test it.**