### PR TITLE
Implement MmFlushImageSection(MmFlushForDelete)

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -52,6 +52,11 @@ struct _MM_RMAP_ENTRY;
 typedef ULONG_PTR SWAPENTRY;
 
 //
+// Special IRQL value (found in assertions)
+//
+#define MM_NOIRQL ((KIRQL)0xFFFFFFFF)
+
+//
 // MmDbgCopyMemory Flags
 //
 #define MMDBG_COPY_WRITE            0x00000001
@@ -175,6 +180,7 @@ typedef ULONG_PTR SWAPENTRY;
 
 typedef struct _MM_SECTION_SEGMENT
 {
+    LONG64 RefCount;
     PFILE_OBJECT FileObject;
 
     FAST_MUTEX Lock;		/* lock which protects the page directory */
@@ -194,7 +200,6 @@ typedef struct _MM_SECTION_SEGMENT
 		ULONG Characteristics;
 	} Image;
 
-	LONG64 RefCount;
 	ULONG SegFlags;
 
     ULONGLONG LastPage;
@@ -204,9 +209,10 @@ typedef struct _MM_SECTION_SEGMENT
 
 typedef struct _MM_IMAGE_SECTION_OBJECT
 {
-    PFILE_OBJECT FileObject;
-
     LONG64 RefCount;
+    PFILE_OBJECT FileObject;
+    ULONG SectionCount;
+    LONG MapCount;
     ULONG SegFlags;
 
     SECTION_IMAGE_INFORMATION ImageInformation;
@@ -219,6 +225,7 @@ typedef struct _MM_IMAGE_SECTION_OBJECT
 #define MM_DATAFILE_SEGMENT                 (0x2)
 #define MM_SEGMENT_INDELETE                 (0x4)
 #define MM_SEGMENT_INCREATE                 (0x8)
+#define MM_IMAGE_SECTION_FLUSH_DELETE       (0x10)
 
 
 #define MA_GetStartingAddress(_MemoryArea) ((_MemoryArea)->VadNode.StartingVpn << PAGE_SHIFT)
@@ -1470,7 +1477,14 @@ MmUnsharePageEntrySectionSegment(PMEMORY_AREA MemoryArea,
 
 VOID
 NTAPI
-MmDereferenceSegment(PMM_SECTION_SEGMENT Segment);
+MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql);
+
+FORCEINLINE
+VOID
+MmDereferenceSegment(PMM_SECTION_SEGMENT Segment)
+{
+    MmDereferenceSegmentWithLock(Segment, MM_NOIRQL);
+}
 
 NTSTATUS
 NTAPI

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -231,11 +231,6 @@ extern const ULONG MmProtectToValue[32];
 #endif
 
 //
-// Special IRQL value (found in assertions)
-//
-#define MM_NOIRQL (KIRQL)0xFFFFFFFF
-
-//
 // Returns the color of a page
 //
 #define MI_GET_PAGE_COLOR(x)                ((x) & MmSecondaryColorMask)

--- a/ntoskrnl/mm/rmap.c
+++ b/ntoskrnl/mm/rmap.c
@@ -300,7 +300,6 @@ WriteSegment:
         Released = MmCheckDirtySegment(Segment, &SegmentOffset, FALSE, TRUE);
 
         MmUnlockSectionSegment(Segment);
-
         MmDereferenceSegment(Segment);
 
         if (Released)
@@ -475,8 +474,6 @@ MmGetSegmentRmap(PFN_NUMBER Page, PULONG RawOffset)
                 MiReleasePfnLock(OldIrql);
                 return NULL;
             }
-
-            InterlockedIncrement64(Result->Segment->ReferenceCount);
             MiReleasePfnLock(OldIrql);
             return Result;
         }


### PR DESCRIPTION
## Purpose

Fix case when you can't delete an executable file after having executed it.

JIRA issue: [CORE-17544](https://jira.reactos.org/browse/CORE-17544)

## Proposed changes

Actually free the pages lying around when all image sections are deleted and MmFlushImageSection(MmFlushForDelete) is called. This makes the image section drops all its refcount and finally be deleted.