### PR TITLE
[CMD] Properly handle case when command is given with leading or trailing spaces

### DIFF
--- a/base/shell/cmd/where.c
+++ b/base/shell/cmd/where.c
@@ -106,7 +106,7 @@ SearchForExecutableSingle (LPCTSTR pFileName, LPTSTR pFullName, LPTSTR pPathExt,
     if (IsExistingFile (szPathBuffer))
     {
         TRACE ("Found: \'%s\'\n", debugstr_aw(szPathBuffer));
-        _tcscpy (pFullName, szPathBuffer);
+        GetFullPathName(szPathBuffer, MAX_PATH, pFullName, NULL);
         return TRUE;
     }
 
@@ -130,7 +130,7 @@ SearchForExecutableSingle (LPCTSTR pFileName, LPTSTR pFullName, LPTSTR pPathExt,
         if (IsExistingFile (szPathBuffer))
         {
             TRACE ("Found: \'%s\'\n", debugstr_aw(szPathBuffer));
-            _tcscpy (pFullName, szPathBuffer);
+            GetFullPathName(szPathBuffer, MAX_PATH, pFullName, NULL);
             return TRUE;
         }
     }


### PR DESCRIPTION
For the testbot

JIRA issue: [CORE-17351](https://jira.reactos.org/browse/CORE-17351), [CORE-16898](https://jira.reactos.org/browse/CORE-16898), [CORE-17612](https://jira.reactos.org/browse/CORE-17612)