### PR TITLE
[SHELL32] ShellExecCmdLine: Apply scheme for URL-like execution

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2423,7 +2423,7 @@ HRESULT WINAPI ShellExecCmdLine(
     SHELLEXECUTEINFOW info;
     DWORD dwSize, dwError, dwType, dwFlags = SEE_MASK_DOENVSUBST | SEE_MASK_NOASYNC;
     LPCWSTR pszVerb = NULL;
-    WCHAR szFile[INTERNET_MAX_URL_LENGTH], szFile2[MAX_PATH];
+    WCHAR szFile[L_MAX_URL_LENGTH], szFile2[MAX_PATH];
     HRESULT hr;
     LPCWSTR pchParams;
     LPWSTR lpCommand = NULL;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2423,7 +2423,7 @@ HRESULT WINAPI ShellExecCmdLine(
     SHELLEXECUTEINFOW info;
     DWORD dwSize, dwError, dwType, dwFlags = SEE_MASK_DOENVSUBST | SEE_MASK_NOASYNC;
     LPCWSTR pszVerb = NULL;
-    WCHAR szFile[MAX_PATH], szFile2[MAX_PATH];
+    WCHAR szFile[INTERNET_MAX_URL_LENGTH], szFile2[MAX_PATH];
     HRESULT hr;
     LPCWSTR pchParams;
     LPWSTR lpCommand = NULL;

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -3,7 +3,7 @@
  *
  * Copyright 1998 Marcus Meissner
  * Copyright 2002 Eric Pouech
- * Copyright 2018-2019 Katayama Hirofumi MZ
+ * Copyright 2018-2021 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -2452,9 +2452,14 @@ HRESULT WINAPI ShellExecCmdLine(
         }
     }
 
-    if (PathIsURLW(lpCommand) || UrlIsW(lpCommand, URLIS_APPLIABLE))
+    dwSize = _countof(szFile);
+    if (UrlIsW(lpCommand, URLIS_URL))
     {
         StringCchCopyW(szFile, _countof(szFile), lpCommand);
+        pchParams = NULL;
+    }
+    else if (UrlApplySchemeW(lpCommand, szFile, &dwSize, URL_APPLY_GUESSSCHEME) == S_OK)
+    {
         pchParams = NULL;
     }
     else

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -124,9 +124,14 @@ HRESULT WINAPI ShellExecCmdLine(
         }
     }
 
-    if (UrlIsFileUrlW(lpCommand))
+    dwSize = _countof(szFile);
+    if (UrlIsW(lpCommand, URLIS_URL))
     {
         StringCchCopyW(szFile, _countof(szFile), lpCommand);
+        pchParams = NULL;
+    }
+    else if (UrlApplySchemeW(lpCommand, szFile, &dwSize, URL_APPLY_GUESSSCHEME) == S_OK)
+    {
         pchParams = NULL;
     }
     else

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -95,7 +95,7 @@ HRESULT WINAPI ShellExecCmdLine(
     SHELLEXECUTEINFOW info;
     DWORD dwSize, dwError, dwType, dwFlags = SEE_MASK_DOENVSUBST | SEE_MASK_NOASYNC;
     LPCWSTR pszVerb = NULL;
-    WCHAR szFile[INTERNET_MAX_URL_LENGTH], szFile2[MAX_PATH];
+    WCHAR szFile[L_MAX_URL_LENGTH], szFile2[MAX_PATH];
     HRESULT hr;
     LPCWSTR pchParams;
     LPWSTR lpCommand = NULL;

--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -95,7 +95,7 @@ HRESULT WINAPI ShellExecCmdLine(
     SHELLEXECUTEINFOW info;
     DWORD dwSize, dwError, dwType, dwFlags = SEE_MASK_DOENVSUBST | SEE_MASK_NOASYNC;
     LPCWSTR pszVerb = NULL;
-    WCHAR szFile[MAX_PATH], szFile2[MAX_PATH];
+    WCHAR szFile[INTERNET_MAX_URL_LENGTH], szFile2[MAX_PATH];
     HRESULT hr;
     LPCWSTR pchParams;
     LPWSTR lpCommand = NULL;


### PR DESCRIPTION
## Purpose

Retrial of #3711. Fix Run dialog and CORE-17351.
JIRA issue: [CORE-17351](https://jira.reactos.org/browse/CORE-17351)

## Proposed changes
- Enlong `szFile` up to `L_MAX_URL_LENGTH`.
- Use `UrlIsW` function instead of `PathIsURLW` function.
- Apply the URL scheme for URL-like prefixes (`"www."` etc.).

## TODO

- [x] Do tests.