### PR TITLE
[NTOS:MM] Properly set PTE dirty bit after serving an access fault.

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -822,16 +822,26 @@ NTAPI
 MmFreeSpecialPool(
     IN PVOID P);
 
-/* mm.c **********************************************************************/
+/* mmfault.c **********************************************************************/
 
 NTSTATUS
-NTAPI
-MmAccessFault(
+MmRosAccessFault(
     IN ULONG FaultCode,
+    IN PMMSUPPORT AddressSpace,
+    IN PMEMORY_AREA MemoryArea,
     IN PVOID Address,
     IN KPROCESSOR_MODE Mode,
     IN PVOID TrapInformation
 );
+
+/* pagfault.c *********************************************************************/
+NTSTATUS
+NTAPI
+MmAccessFault(
+    _In_ ULONG FaultCode,
+    _In_ PVOID Address,
+    _In_ KPROCESSOR_MODE Mode,
+    _In_ PVOID TrapInformation);
 
 /* process.c *****************************************************************/
 
@@ -1226,8 +1236,7 @@ NTSTATUS
 NTAPI
 MmGetExecuteOptions(IN PULONG ExecuteOptions);
 
-VOID
-NTAPI
+BOOLEAN
 MmDeleteVirtualMapping(
     struct _EPROCESS *Process,
     PVOID Address,
@@ -1380,8 +1389,7 @@ NTAPI
 MmNotPresentFaultSectionView(
     PMMSUPPORT AddressSpace,
     MEMORY_AREA* MemoryArea,
-    PVOID Address,
-    BOOLEAN Locked
+    PVOID Address
 );
 
 NTSTATUS
@@ -1403,8 +1411,7 @@ NTAPI
 MmAccessFaultSectionView(
     PMMSUPPORT AddressSpace,
     MEMORY_AREA* MemoryArea,
-    PVOID Address,
-    BOOLEAN Locked
+    PVOID Address
 );
 
 VOID

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -163,27 +163,6 @@ extern const ULONG_PTR MmProtectToPteMask[32];
 extern const ULONG MmProtectToValue[32];
 
 //
-// Assertions for session images, addresses, and PTEs
-//
-#define MI_IS_SESSION_IMAGE_ADDRESS(Address) \
-    (((Address) >= MiSessionImageStart) && ((Address) < MiSessionImageEnd))
-
-#define MI_IS_SESSION_ADDRESS(Address) \
-    (((Address) >= MmSessionBase) && ((Address) < MiSessionSpaceEnd))
-
-#define MI_IS_SESSION_PTE(Pte) \
-    ((((PMMPTE)Pte) >= MiSessionBasePte) && (((PMMPTE)Pte) < MiSessionLastPte))
-
-#define MI_IS_PAGE_TABLE_ADDRESS(Address) \
-    (((PVOID)(Address) >= (PVOID)PTE_BASE) && ((PVOID)(Address) <= (PVOID)PTE_TOP))
-
-#define MI_IS_SYSTEM_PAGE_TABLE_ADDRESS(Address) \
-    (((Address) >= (PVOID)MiAddressToPte(MmSystemRangeStart)) && ((Address) <= (PVOID)PTE_TOP))
-
-#define MI_IS_PAGE_TABLE_OR_HYPER_ADDRESS(Address) \
-    (((PVOID)(Address) >= (PVOID)PTE_BASE) && ((PVOID)(Address) <= (PVOID)MmHyperSpaceEnd))
-
-//
 // Creates a software PTE with the given protection
 //
 #define MI_MAKE_SOFTWARE_PTE(p, x)          ((p)->u.Long = (x << MM_PTE_SOFTWARE_PROTECTION_BITS))
@@ -732,6 +711,37 @@ MiIsUserPte(PVOID Address)
     return (Address <= (PVOID)MiHighestUserPte);
 }
 #endif
+
+//
+// Assertions for session images, addresses, and PTEs
+//
+#define MI_IS_SESSION_IMAGE_ADDRESS(Address) \
+    (((Address) >= MiSessionImageStart) && ((Address) < MiSessionImageEnd))
+
+#define MI_IS_SESSION_ADDRESS(Address) \
+    (((Address) >= MmSessionBase) && ((Address) < MiSessionSpaceEnd))
+
+#define MI_IS_SESSION_PTE(Pte) \
+    ((((PMMPTE)Pte) >= MiSessionBasePte) && (((PMMPTE)Pte) < MiSessionLastPte))
+
+#define MI_IS_PAGE_TABLE_ADDRESS(Address) \
+    (((PVOID)(Address) >= (PVOID)PTE_BASE) && ((PVOID)(Address) <= (PVOID)PTE_TOP))
+
+#define MI_IS_SYSTEM_PAGE_TABLE_ADDRESS(Address) \
+    (((Address) >= (PVOID)MiAddressToPte(MmSystemRangeStart)) && ((Address) <= (PVOID)PTE_TOP))
+
+#define MI_IS_PAGE_TABLE_OR_HYPER_ADDRESS(Address) \
+    (((PVOID)(Address) >= (PVOID)PTE_BASE) && ((PVOID)(Address) <= (PVOID)MmHyperSpaceEnd))
+
+FORCEINLINE
+BOOLEAN
+MI_IS_NON_PAGED_POOL_ADDRESS(PVOID Address)
+{
+    return (((Address >= MmNonPagedPoolStart) &&
+            (Address < (PVOID)((ULONG_PTR)MmNonPagedPoolStart + MmSizeOfNonPagedPoolInBytes))) ||
+            ((Address >= MmNonPagedPoolExpansionStart) &&
+            (Address < MmNonPagedPoolEnd)));
+}
 
 //
 // Figures out the hardware bits for a PTE

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -1917,25 +1917,6 @@ MiSyncARM3WithROS(
 );
 
 NTSTATUS
-NTAPI
-MiRosProtectVirtualMemory(
-    IN PEPROCESS Process,
-    IN OUT PVOID *BaseAddress,
-    IN OUT PSIZE_T NumberOfBytesToProtect,
-    IN ULONG NewAccessProtection,
-    OUT PULONG OldAccessProtection OPTIONAL
-);
-
-NTSTATUS
-NTAPI
-MmArmAccessFault(
-    IN ULONG FaultCode,
-    IN PVOID Address,
-    IN KPROCESSOR_MODE Mode,
-    IN PVOID TrapInformation
-);
-
-NTSTATUS
 FASTCALL
 MiCheckPdeForPagedPool(
     IN PVOID Address

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2336,11 +2336,11 @@ MiDeletePte(
     IN PMMPTE PrototypePte
 );
 
-ULONG
-NTAPI
+_Must_inspect_result_
+BOOLEAN
 MiMakeSystemAddressValid(
-    IN PVOID PageTableVirtualAddress,
-    IN PEPROCESS CurrentProcess
+    _In_ PVOID PageTableVirtualAddress,
+    _In_ PEPROCESS CurrentProcess
 );
 
 ULONG

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -2230,16 +2230,9 @@ UserFault:
 
         if (ProtectionCode == MM_NOACCESS)
         {
-#if (_MI_PAGING_LEVELS == 2)
-            /* Could be a page table for paged pool */
-            MiCheckPdeForPagedPool(Address);
-#endif
-            /* Has the code above changed anything -- is this now a valid PTE? */
-            Status = (PointerPde->u.Hard.Valid == 1) ? STATUS_SUCCESS : STATUS_ACCESS_VIOLATION;
-
-            /* Either this was a bogus VA or we've fixed up a paged pool PDE */
+            /* This is a bogus VA. */
             MiUnlockProcessWorkingSet(CurrentProcess, CurrentThread);
-            return Status;
+            return STATUS_ACCESS_VIOLATION;
         }
 
         /* Resolve a demand zero fault */
@@ -2420,17 +2413,10 @@ UserFault:
         ProtoPte = MiCheckVirtualAddress(Address, &ProtectionCode, &Vad);
         if (ProtectionCode == MM_NOACCESS)
         {
-#if (_MI_PAGING_LEVELS == 2)
-            /* Could be a page table for paged pool */
-            MiCheckPdeForPagedPool(Address);
-#endif
-            /* Has the code above changed anything -- is this now a valid PTE? */
-            Status = (PointerPte->u.Hard.Valid == 1) ? STATUS_SUCCESS : STATUS_ACCESS_VIOLATION;
-
-            /* Either this was a bogus VA or we've fixed up a paged pool PDE */
+            /* This was a bogus VA */
             if (TrapInformation)
                 MiUnlockProcessWorkingSet(CurrentProcess, CurrentThread);
-            return Status;
+            return STATUS_ACCESS_VIOLATION;
         }
 
         /*

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -205,7 +205,7 @@ MiMakeSystemAddressValid(IN PVOID PageTableVirtualAddress,
                                           &WsShared);
 
         /* Fault it in */
-        Status = MmAccessFault(FALSE, PageTableVirtualAddress, KernelMode, NULL);
+        Status = MmAccessFault(FALSE, PageTableVirtualAddress, KernelMode, (PVOID)0xabcdef0123456789ull);
         if (!NT_SUCCESS(Status))
         {
             /* This should not fail */

--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -3431,24 +3431,18 @@ MiLockVirtualMemory(
                (PointerPde->u.Hard.Valid == 0) ||
                (PointerPte->u.Hard.Valid == 0))
         {
-            /* Release process working set */
-            MiUnlockProcessWorkingSet(CurrentProcess, PsGetCurrentThread());
-
             /* Access the page */
             CurrentVa = MiPteToAddress(PointerPte);
 
-            //HACK: Pass a placeholder TrapInformation so the fault handler knows we're unlocked
-            TempStatus = MmAccessFault(TRUE, CurrentVa, KernelMode, (PVOID)(ULONG_PTR)0xBADBADA3BADBADA3ULL);
+            TempStatus = MmAccessFault(TRUE, CurrentVa, KernelMode, NULL);
             if (!NT_SUCCESS(TempStatus))
             {
                 // This should only happen, when remote backing storage is not accessible
                 ASSERT(FALSE);
                 Status = TempStatus;
+                MiUnlockProcessWorkingSet(CurrentProcess, PsGetCurrentThread());
                 goto Cleanup;
             }
-
-            /* Lock the process working set */
-            MiLockProcessWorkingSet(CurrentProcess, PsGetCurrentThread());
         }
 
         /* Get the PFN */

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -263,7 +263,7 @@ MmDeleteVirtualMapping(PEPROCESS Process, PVOID Address,
         }
 
         /* Only for current process !!! */
-        ASSERT(Process = PsGetCurrentProcess());
+        ASSERT(Process == PsGetCurrentProcess());
         ASSERT(PsGetCurrentThread()->OwnsProcessWorkingSetExclusive);
 
         /* No PDE --> No page */
@@ -586,7 +586,7 @@ MmCreateVirtualMappingUnsafe(PEPROCESS Process,
         }
 
         /* Only for current process !!! */
-        ASSERT(Process = PsGetCurrentProcess());
+        ASSERT(Process == PsGetCurrentProcess());
         NT_ASSERT(PsGetCurrentThread()->OwnsProcessWorkingSetExclusive);
 
         MiMakePdeExistAndMakeValid(MiAddressToPde(Address), Process, MM_NOIRQL);

--- a/ntoskrnl/mm/mmfault.c
+++ b/ntoskrnl/mm/mmfault.c
@@ -20,66 +20,25 @@
 
 NTSTATUS
 NTAPI
-MmpAccessFault(KPROCESSOR_MODE Mode,
-               ULONG_PTR Address,
-               BOOLEAN FromMdl)
+MmpAccessFault(
+    PMMSUPPORT AddressSpace,
+    PMEMORY_AREA MemoryArea,
+    ULONG_PTR Address,
+    KPROCESSOR_MODE Mode)
 {
-    PMMSUPPORT AddressSpace;
-    MEMORY_AREA* MemoryArea;
     NTSTATUS Status;
 
     DPRINT("MmAccessFault(Mode %d, Address %x)\n", Mode, Address);
 
-    if (KeGetCurrentIrql() >= DISPATCH_LEVEL)
-    {
-        DPRINT1("Page fault at high IRQL was %u\n", KeGetCurrentIrql());
-        return(STATUS_UNSUCCESSFUL);
-    }
-
-    /*
-     * Find the memory area for the faulting address
-     */
-    if (Address >= (ULONG_PTR)MmSystemRangeStart)
-    {
-        /*
-         * Check permissions
-         */
-        if (Mode != KernelMode)
-        {
-            DPRINT1("MmAccessFault(Mode %d, Address %x)\n", Mode, Address);
-            return(STATUS_ACCESS_VIOLATION);
-        }
-        AddressSpace = MmGetKernelAddressSpace();
-    }
-    else
-    {
-        AddressSpace = &PsGetCurrentProcess()->Vm;
-    }
-
-    if (!FromMdl)
-    {
-        MmLockAddressSpace(AddressSpace);
-    }
     do
     {
-        MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, (PVOID)Address);
-        if (MemoryArea == NULL || MemoryArea->DeleteInProgress)
-        {
-            if (!FromMdl)
-            {
-                MmUnlockAddressSpace(AddressSpace);
-            }
-            return (STATUS_ACCESS_VIOLATION);
-        }
-
         switch (MemoryArea->Type)
         {
         case MEMORY_AREA_SECTION_VIEW:
             Status = MmAccessFaultSectionView(AddressSpace,
-                                              MemoryArea,
-                                              (PVOID)Address,
-                                              !FromMdl);
-            break;
+                                            MemoryArea,
+                                            (PVOID)Address);
+        break;
 #ifdef NEWCC
         case MEMORY_AREA_CACHE:
             // This code locks for itself to keep from having to break a lock
@@ -95,82 +54,38 @@ MmpAccessFault(KPROCESSOR_MODE Mode,
             Status = STATUS_ACCESS_VIOLATION;
             break;
         }
-    }
-    while (Status == STATUS_MM_RESTART_OPERATION);
+    } while (Status == STATUS_MM_RESTART_OPERATION);
 
     DPRINT("Completed page fault handling\n");
-    if (!FromMdl)
-    {
-        MmUnlockAddressSpace(AddressSpace);
-    }
-    return(Status);
+    return Status;
 }
 
 NTSTATUS
 NTAPI
-MmNotPresentFault(KPROCESSOR_MODE Mode,
-                  ULONG_PTR Address,
-                  BOOLEAN FromMdl)
+MmNotPresentFault(
+    PMMSUPPORT AddressSpace,
+    PMEMORY_AREA MemoryArea,
+    ULONG_PTR Address,
+    KPROCESSOR_MODE Mode)
 {
-    PMMSUPPORT AddressSpace;
-    MEMORY_AREA* MemoryArea;
     NTSTATUS Status;
 
     DPRINT("MmNotPresentFault(Mode %d, Address %x)\n", Mode, Address);
-
-    if (KeGetCurrentIrql() >= DISPATCH_LEVEL)
-    {
-        DPRINT1("Page fault at high IRQL was %u, address %x\n", KeGetCurrentIrql(), Address);
-        return(STATUS_UNSUCCESSFUL);
-    }
-
-    /*
-     * Find the memory area for the faulting address
-     */
-    if (Address >= (ULONG_PTR)MmSystemRangeStart)
-    {
-        /*
-         * Check permissions
-         */
-        if (Mode != KernelMode)
-        {
-            DPRINT1("Address: %x\n", Address);
-            return(STATUS_ACCESS_VIOLATION);
-        }
-        AddressSpace = MmGetKernelAddressSpace();
-    }
-    else
-    {
-        AddressSpace = &PsGetCurrentProcess()->Vm;
-    }
-
-    if (!FromMdl)
-    {
-        MmLockAddressSpace(AddressSpace);
-    }
 
     /*
      * Call the memory area specific fault handler
      */
     do
     {
-        MemoryArea = MmLocateMemoryAreaByAddress(AddressSpace, (PVOID)Address);
-        if (MemoryArea == NULL || MemoryArea->DeleteInProgress)
-        {
-            if (!FromMdl)
-            {
-                MmUnlockAddressSpace(AddressSpace);
-            }
+        if (MemoryArea->DeleteInProgress)
             return (STATUS_ACCESS_VIOLATION);
-        }
 
         switch (MemoryArea->Type)
         {
         case MEMORY_AREA_SECTION_VIEW:
             Status = MmNotPresentFaultSectionView(AddressSpace,
                                                   MemoryArea,
-                                                  (PVOID)Address,
-                                                  !FromMdl);
+                                                  (PVOID)Address);
             break;
 #ifdef NEWCC
         case MEMORY_AREA_CACHE:
@@ -191,77 +106,36 @@ MmNotPresentFault(KPROCESSOR_MODE Mode,
     while (Status == STATUS_MM_RESTART_OPERATION);
 
     DPRINT("Completed page fault handling\n");
-    if (!FromMdl)
-    {
-        MmUnlockAddressSpace(AddressSpace);
-    }
     return(Status);
 }
 
 extern BOOLEAN Mmi386MakeKernelPageTableGlobal(PVOID Address);
 
 NTSTATUS
-NTAPI
-MmAccessFault(IN ULONG FaultCode,
-              IN PVOID Address,
-              IN KPROCESSOR_MODE Mode,
-              IN PVOID TrapInformation)
+MmRosAccessFault(
+    IN ULONG FaultCode,
+    IN PMMSUPPORT AddressSpace,
+    IN PMEMORY_AREA MemoryArea,
+    IN PVOID Address,
+    IN KPROCESSOR_MODE Mode,
+    IN PVOID TrapInformation)
 {
-    PMEMORY_AREA MemoryArea = NULL;
-
-    /* Cute little hack for ROS */
-    if ((ULONG_PTR)Address >= (ULONG_PTR)MmSystemRangeStart)
-    {
-#ifdef _M_IX86
-        /* Check for an invalid page directory in kernel mode */
-        if (Mmi386MakeKernelPageTableGlobal(Address))
-        {
-            /* All is well with the world */
-            return STATUS_SUCCESS;
-        }
-#endif
-    }
-
-    /* Handle shared user page, which doesn't have a VAD / MemoryArea */
-    if (PAGE_ALIGN(Address) == (PVOID)MM_SHARED_USER_DATA_VA)
-    {
-        /* This is an ARM3 fault */
-        DPRINT("ARM3 fault %p\n", MemoryArea);
-        return MmArmAccessFault(FaultCode, Address, Mode, TrapInformation);
-    }
-
-    /* Is there a ReactOS address space yet? */
-    if (MmGetKernelAddressSpace())
-    {
-        /* Check if this is an ARM3 memory area */
-        MemoryArea = MmLocateMemoryAreaByAddress(MmGetKernelAddressSpace(), Address);
-        if (!(MemoryArea) && (Address <= MM_HIGHEST_USER_ADDRESS))
-        {
-            /* Could this be a VAD fault from user-mode? */
-            MemoryArea = MmLocateMemoryAreaByAddress(MmGetCurrentAddressSpace(), Address);
-        }
-    }
-
-    /* Is this an ARM3 memory area, or is there no address space yet? */
-    if (((MemoryArea) && (MemoryArea->Type == MEMORY_AREA_OWNED_BY_ARM3)) ||
-            (!(MemoryArea) && ((ULONG_PTR)Address >= (ULONG_PTR)MmPagedPoolStart)) ||
-            (!MmGetKernelAddressSpace()))
-    {
-        /* This is an ARM3 fault */
-        DPRINT("ARM3 fault %p\n", MemoryArea);
-        return MmArmAccessFault(FaultCode, Address, Mode, TrapInformation);
-    }
-
     /* Keep same old ReactOS Behaviour */
     if (!MI_IS_NOT_PRESENT_FAULT(FaultCode))
     {
         /* Call access fault */
-        return MmpAccessFault(Mode, (ULONG_PTR)Address, TrapInformation ? FALSE : TRUE);
+        return MmpAccessFault(AddressSpace,
+                              MemoryArea,
+                              (ULONG_PTR)Address,
+                              Mode);
     }
     else
     {
         /* Call not present */
-        return MmNotPresentFault(Mode, (ULONG_PTR)Address, TrapInformation ? FALSE : TRUE);
+        return MmNotPresentFault(AddressSpace,
+                                 MemoryArea,
+                                 (ULONG_PTR)Address,
+                                 Mode);
     }
 }
 


### PR DESCRIPTION
## Purpose

Set the dirty bit. The CPU is actually writing to the page, but it doesn't set the bit.

JIRA issue: [CORE-17595](https://jira.reactos.org/browse/CORE-17595)
