### PR TITLE
[PCI] Filter out devices with null vendor and device ID

### DIFF
--- a/drivers/bus/pci/fdo.c
+++ b/drivers/bus/pci/fdo.c
@@ -151,6 +151,12 @@ FdoEnumerateDevices(
                    PciConfig.VendorID,
                    PciConfig.DeviceID);
 
+            if (PciConfig.VendorID == 0 && PciConfig.DeviceID == 0)
+            {
+                DPRINT("Filter out devices with null vendor and device ID\n");
+                continue;
+            }
+
             Status = FdoLocateChildDevice(&Device, DeviceExtension, SlotNumber, &PciConfig);
             if (!NT_SUCCESS(Status))
             {


### PR DESCRIPTION
This is how Windows pci.sys works. Fixes [CORE-17636](https://jira.reactos.org/browse/CORE-17636)