### PR TITLE
Hpoussin multi video

### DIFF
--- a/dll/cpl/desk/classinst.c
+++ b/dll/cpl/desk/classinst.c
@@ -25,6 +25,7 @@ DisplayClassInstaller(
     TCHAR ServiceName[MAX_SERVICE_NAME_LEN];
     TCHAR DeviceName[12];
     SP_DRVINFO_DETAIL_DATA DriverInfoDetailData;
+    DISPLAY_DEVICE DisplayDevice;
     HKEY hDriverKey = INVALID_HANDLE_VALUE; /* SetupDiOpenDevRegKey returns INVALID_HANDLE_VALUE in case of error! */
     HKEY hSettingsKey = NULL;
     HKEY hServicesKey = NULL;
@@ -244,6 +245,18 @@ DisplayClassInstaller(
     }
 
     /* FIXME: install OpenGLSoftwareSettings section */
+
+    /* Start the device */
+    if (!SetupDiRestartDevices(DeviceInfoSet, DeviceInfoData))
+    {
+        rc = GetLastError();
+        DPRINT1("SetupDiRestartDevices() failed with error 0x%lx\n", rc);
+        goto cleanup;
+    }
+
+    /* Reenumerate display devices ; this will rescan for potential new devices */
+    DisplayDevice.cb = sizeof(DISPLAY_DEVICE);
+    EnumDisplayDevices(NULL, 0, &DisplayDevice, 0);
 
     rc = ERROR_SUCCESS;
 

--- a/win32ss/drivers/miniport/vbe/vbemp.c
+++ b/win32ss/drivers/miniport/vbe/vbemp.c
@@ -90,12 +90,6 @@ VBEFindAdapter(
 static int
 VBESortModesCallback(PVBE_MODEINFO VbeModeInfoA, PVBE_MODEINFO VbeModeInfoB)
 {
-   VideoPortDebugPrint(Info, "VBESortModesCallback: %dx%dx%d / %dx%dx%d\n",
-      VbeModeInfoA->XResolution, VbeModeInfoA->YResolution,
-      VbeModeInfoA->BitsPerPixel,
-      VbeModeInfoB->XResolution, VbeModeInfoB->YResolution,
-      VbeModeInfoB->BitsPerPixel);
-
    /*
     * FIXME: Until some reasonable method for changing video modes will
     * be available we favor more bits per pixel. It should be changed

--- a/win32ss/drivers/videoprt/dispatch.c
+++ b/win32ss/drivers/videoprt/dispatch.c
@@ -347,9 +347,10 @@ IntVideoPortAddDevice(
                                                    DriverExtension,
                                                    PhysicalDeviceObject,
                                                    &DeviceObject);
-    if (NT_SUCCESS(Status))
-        VideoPortDeviceNumber++;
-
+    if (!NT_SUCCESS(Status))
+    {
+        ERR_(VIDEOPRT, "IntVideoPortCreateAdapterDeviceObject() failed with status 0x%lx\n", Status);
+    }
     return Status;
 }
 

--- a/win32ss/drivers/videoprt/dispatch.c
+++ b/win32ss/drivers/videoprt/dispatch.c
@@ -346,6 +346,8 @@ IntVideoPortAddDevice(
     Status = IntVideoPortCreateAdapterDeviceObject(DriverObject,
                                                    DriverExtension,
                                                    PhysicalDeviceObject,
+                                                   DriverExtension->InitializationData.StartingDeviceNumber,
+                                                   0,
                                                    &DeviceObject);
     if (!NT_SUCCESS(Status))
     {

--- a/win32ss/drivers/videoprt/videoprt.c
+++ b/win32ss/drivers/videoprt/videoprt.c
@@ -74,8 +74,8 @@ IntVideoPortAddDeviceMapLink(
                                    L"VIDEO",
                                    DeviceBuffer,
                                    REG_SZ,
-                                   DeviceExtension->RegistryPath.Buffer,
-                                   DeviceExtension->RegistryPath.Length + sizeof(UNICODE_NULL));
+                                   DeviceExtension->NewRegistryPath.Buffer,
+                                   DeviceExtension->NewRegistryPath.Length + sizeof(UNICODE_NULL));
     if (!NT_SUCCESS(Status))
     {
         ERR_(VIDEOPRT, "Failed to create DEViCEMAP registry entry: 0x%X\n", Status);

--- a/win32ss/drivers/videoprt/videoprt.c
+++ b/win32ss/drivers/videoprt/videoprt.c
@@ -1350,8 +1350,44 @@ VideoPortCreateSecondaryDisplay(
     IN OUT PVOID *SecondaryDeviceExtension,
     IN ULONG Flag)
 {
-    UNIMPLEMENTED;
-    return ERROR_DEV_NOT_EXIST;
+    PDEVICE_OBJECT DeviceObject;
+    PVIDEO_PORT_DEVICE_EXTENSION FirstDeviceExtension, DeviceExtension;
+    NTSTATUS Status;
+
+    ASSERT(SecondaryDeviceExtension);
+
+    if (Flag != 0)
+    {
+        UNIMPLEMENTED;
+    }
+
+    FirstDeviceExtension = VIDEO_PORT_GET_DEVICE_EXTENSION(HwDeviceExtension);
+
+    if (FirstDeviceExtension->DisplayNumber != 0)
+    {
+        DPRINT1("Calling VideoPortCreateSecondaryDisplay for InstanceId %lu\n",
+                FirstDeviceExtension->DisplayNumber);
+    }
+
+    Status = IntVideoPortCreateAdapterDeviceObject(FirstDeviceExtension->DriverObject,
+                                                   FirstDeviceExtension->DriverExtension,
+                                                   FirstDeviceExtension->PhysicalDeviceObject,
+                                                   FirstDeviceExtension->AdapterNumber,
+                                                   FirstDeviceExtension->NumberOfSecondaryDisplays + 1,
+                                                   &DeviceObject);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("IntVideoPortCreateAdapterDeviceObject() failed with status 0x%08x\n", Status);
+        return ERROR_DEV_NOT_EXIST;
+    }
+
+    DeviceExtension = DeviceObject->DeviceExtension;
+
+    /* Increment secondary display count */
+    FirstDeviceExtension->NumberOfSecondaryDisplays++;
+
+    *SecondaryDeviceExtension = DeviceExtension->MiniPortDeviceExtension;
+    return NO_ERROR;
 }
 
 /*

--- a/win32ss/drivers/videoprt/videoprt.c
+++ b/win32ss/drivers/videoprt/videoprt.c
@@ -298,7 +298,7 @@ IntVideoPortCreateAdapterDeviceObject(
     KeInitializeMutex(&DeviceExtension->DeviceLock, 0);
 
     /* Attach the device. */
-    if (PhysicalDeviceObject != NULL)
+    if ((PhysicalDeviceObject != NULL) && (DisplayNumber == 0))
         DeviceExtension->NextDeviceObject = IoAttachDeviceToDeviceStack(
                                                 *DeviceObject,
                                                 PhysicalDeviceObject);

--- a/win32ss/drivers/videoprt/videoprt.h
+++ b/win32ss/drivers/videoprt/videoprt.h
@@ -107,7 +107,10 @@ typedef struct _VIDEO_PORT_DEVICE_EXTENSTION
    LIST_ENTRY DmaAdapterList, ChildDeviceList;
    LIST_ENTRY HwResetListEntry;
    ULONG SessionId;
-   CHAR MiniPortDeviceExtension[1];
+   USHORT AdapterNumber;
+   USHORT DisplayNumber;
+   ULONG NumberOfSecondaryDisplays;
+   CHAR POINTER_ALIGNMENT MiniPortDeviceExtension[1];
 } VIDEO_PORT_DEVICE_EXTENSION, *PVIDEO_PORT_DEVICE_EXTENSION;
 
 typedef struct _VIDEO_PORT_CHILD_EXTENSION
@@ -260,6 +263,8 @@ IntVideoPortCreateAdapterDeviceObject(
    _In_ PDRIVER_OBJECT DriverObject,
    _In_ PVIDEO_PORT_DRIVER_EXTENSION DriverExtension,
    _In_opt_ PDEVICE_OBJECT PhysicalDeviceObject,
+   _In_ USHORT AdapterNumber,
+   _In_ USHORT DisplayNumber,
    _Out_opt_ PDEVICE_OBJECT *DeviceObject);
 
 NTSTATUS NTAPI

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -439,6 +439,17 @@ EngpRegisterGraphicsDevice(
     EngReleaseSemaphore(ghsemGraphicsDeviceList);
     TRACE("Prepared %lu modes for %ls\n", pGraphicsDevice->cDevModes, pGraphicsDevice->pwszDescription);
 
+    /* HACK: already in graphic mode; display wallpaper on this new display */
+    if (ScreenDeviceContext)
+    {
+        UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"DISPLAY");
+        UNICODE_STRING DisplayName;
+        HDC hdc;
+        RtlInitUnicodeString(&DisplayName, pGraphicsDevice->szWinDeviceName);
+        hdc = IntGdiCreateDC(&DriverName, &DisplayName, NULL, NULL, FALSE);
+        IntPaintDesktop(hdc);
+    }
+
     return pGraphicsDevice;
 }
 

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -32,6 +32,84 @@ InitDeviceImpl(VOID)
     return STATUS_SUCCESS;
 }
 
+NTSTATUS
+EngpUpdateGraphicsDeviceList(VOID)
+{
+    ULONG iDevNum, iVGACompatible = -1, ulMaxObjectNumber = 0;
+    WCHAR awcDeviceName[20];
+    WCHAR awcBuffer[256];
+    NTSTATUS Status;
+    PGRAPHICS_DEVICE pGraphicsDevice;
+    ULONG cbValue;
+    HKEY hkey;
+
+    /* Open the key for the adapters */
+    Status = RegOpenKey(L"\\Registry\\Machine\\HARDWARE\\DEVICEMAP\\VIDEO", &hkey);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("Could not open HARDWARE\\DEVICEMAP\\VIDEO registry key:0x%lx\n", Status);
+        return Status;
+    }
+
+    /* Read the name of the VGA adapter */
+    cbValue = sizeof(awcDeviceName);
+    Status = RegQueryValue(hkey, L"VgaCompatible", REG_SZ, awcDeviceName, &cbValue);
+    if (NT_SUCCESS(Status))
+    {
+        iVGACompatible = _wtoi(&awcDeviceName[sizeof("\\Device\\Video")-1]);
+        ERR("VGA adapter = %lu\n", iVGACompatible);
+    }
+
+    /* Get the maximum mumber of adapters */
+    if (!RegReadDWORD(hkey, L"MaxObjectNumber", &ulMaxObjectNumber))
+    {
+        ERR("Could not read MaxObjectNumber, defaulting to 0.\n");
+    }
+
+    TRACE("Found %lu devices\n", ulMaxObjectNumber + 1);
+
+    /* Loop through all adapters */
+    for (iDevNum = 0; iDevNum <= ulMaxObjectNumber; iDevNum++)
+    {
+        /* Create the adapter's key name */
+        swprintf(awcDeviceName, L"\\Device\\Video%lu", iDevNum);
+
+        /* Read the reg key name */
+        cbValue = sizeof(awcBuffer);
+        Status = RegQueryValue(hkey, awcDeviceName, REG_SZ, awcBuffer, &cbValue);
+        if (!NT_SUCCESS(Status))
+        {
+            ERR("failed to query the registry path:0x%lx\n", Status);
+            continue;
+        }
+
+        /* Initialize the driver for this device */
+        pGraphicsDevice = InitDisplayDriver(awcDeviceName, awcBuffer);
+        if (!pGraphicsDevice) continue;
+
+        /* Check if this is a VGA compatible adapter */
+        if (pGraphicsDevice->StateFlags & DISPLAY_DEVICE_VGA_COMPATIBLE)
+        {
+            /* Save this as the VGA adapter */
+            if (!gpVgaGraphicsDevice)
+                gpVgaGraphicsDevice = pGraphicsDevice;
+            TRACE("gpVgaGraphicsDevice = %p\n", gpVgaGraphicsDevice);
+        }
+        else
+        {
+            /* Set the first one as primary device */
+            if (!gpPrimaryGraphicsDevice)
+                gpPrimaryGraphicsDevice = pGraphicsDevice;
+            TRACE("gpPrimaryGraphicsDevice = %p\n", gpPrimaryGraphicsDevice);
+        }
+    }
+
+    /* Close the device map registry key */
+    ZwClose(hkey);
+
+    return STATUS_SUCCESS;
+}
+
 BOOLEAN
 EngpPopulateDeviceModeList(
     _Inout_ PGRAPHICS_DEVICE pGraphicsDevice,

--- a/win32ss/gdi/eng/device.h
+++ b/win32ss/gdi/eng/device.h
@@ -39,6 +39,9 @@ EngpPopulateDeviceModeList(
     _Inout_ PGRAPHICS_DEVICE pGraphicsDevice,
     _In_ PDEVMODEW pdmDefault);
 
+NTSTATUS
+EngpUpdateGraphicsDeviceList(VOID);
+
 CODE_SEG("INIT")
 NTSTATUS
 NTAPI

--- a/win32ss/user/ntuser/ntuser.h
+++ b/win32ss/user/ntuser/ntuser.h
@@ -48,4 +48,10 @@ RegWriteUserSetting(
     _In_reads_bytes_(cjDataSize) const VOID *pvData,
     _In_ ULONG cjDataSize);
 
+PGRAPHICS_DEVICE
+NTAPI
+InitDisplayDriver(
+    IN PWSTR pwszDeviceName,
+    IN PWSTR pwszRegKey);
+
 /* EOF */

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -327,6 +327,22 @@ co_IntInitializeDesktopGraphics(VOID)
     ASSERT(pdesk);
     co_IntShowDesktop(pdesk, gpsi->aiSysMet[SM_CXSCREEN], gpsi->aiSysMet[SM_CYSCREEN], TRUE);
 
+    /* HACK: display wallpaper on all secondary displays */
+    {
+        PGRAPHICS_DEVICE pGraphicsDevice;
+        UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"DISPLAY");
+        UNICODE_STRING DisplayName;
+        HDC hdc;
+        ULONG iDevNum;
+
+        for (iDevNum = 1; (pGraphicsDevice = EngpFindGraphicsDevice(NULL, iDevNum, 0)) != NULL; iDevNum++)
+        {
+            RtlInitUnicodeString(&DisplayName, pGraphicsDevice->szWinDeviceName);
+            hdc = IntGdiCreateDC(&DriverName, &DisplayName, NULL, NULL, FALSE);
+            IntPaintDesktop(hdc);
+        }
+    }
+
     return TRUE;
 }
 


### PR DESCRIPTION
This implements initial support for multiple display adapters. This should allow to use more than 1 display to be shown.
So far all it does is to draw the desktop background on each display.
It doesn't yet support display adapters with secondary displays (like VBox provides), but I have a patch for that.

TBD:
* Implement a multi-display driver, that provides a virtual surface stretching across all displays.

PS: This is was started by Herve and I joined in to make it work on VBox. It might be useful to review one commit at a time.