### PR TITLE
[NTOS:PS] Fix several issues within info classes in AMD64 build

### DIFF
--- a/ntoskrnl/include/internal/icif.h
+++ b/ntoskrnl/include/internal/icif.h
@@ -37,5 +37,8 @@ typedef struct _INFORMATION_CLASS_INFO
 #define IQS(TypeQuery, AlignmentQuery, TypeSet, AlignmentSet, Flags) \
   { sizeof(TypeQuery), sizeof(AlignmentQuery), sizeof(TypeSet), sizeof(AlignmentSet), Flags }
 
+#define IQS_NO_TYPE_LENGTH(Alignment, Flags) \
+  { 0, sizeof(Alignment), 0, sizeof(Alignment), Flags }
+
 #define IQS_NONE \
   { 0, sizeof(CHAR), 0, sizeof(CHAR), ICIF_NONE }

--- a/ntoskrnl/include/internal/ps_i.h
+++ b/ntoskrnl/include/internal/ps_i.h
@@ -142,13 +142,16 @@ static const INFORMATION_CLASS_INFO PsProcessInfoClass[] =
         ICIF_QUERY | ICIF_SET | ICIF_SET_SIZE_VARIABLE
     ),
 
-    /* ProcessUserModeIOPL */
-    IQS_SAME
+    /* ProcessUserModeIOPL is only implemented in x86 */
+#if defined (_X86_)
+    IQS_NO_TYPE_LENGTH
     (
-        UCHAR,
         ULONG,
         ICIF_SET
     ),
+#else
+    IQS_NONE,
+#endif
 
     /* ProcessEnableAlignmentFaultFixup */
     IQS
@@ -233,7 +236,7 @@ static const INFORMATION_CLASS_INFO PsProcessInfoClass[] =
     /* ProcessWow64Information */
     IQS_SAME
     (
-        ULONG,
+        ULONG_PTR,
         ULONG,
         ICIF_QUERY
     ),
@@ -443,7 +446,7 @@ static const INFORMATION_CLASS_INFO PsThreadInfoClass[] =
     /* ThreadZeroTlsCell */
     IQS_SAME
     (
-        ULONG_PTR,
+        ULONG,
         ULONG,
         ICIF_SET
     ),

--- a/ntoskrnl/ps/query.c
+++ b/ntoskrnl/ps/query.c
@@ -1172,7 +1172,7 @@ NtSetInformationProcess(IN HANDLE ProcessHandle,
         case ProcessWx86Information:
 
             /* Check buffer length */
-            if (ProcessInformationLength != sizeof(HANDLE))
+            if (ProcessInformationLength != sizeof(ULONG))
             {
                 Status = STATUS_INFO_LENGTH_MISMATCH;
                 break;
@@ -2439,7 +2439,7 @@ NtSetInformationThread(IN HANDLE ThreadHandle,
         case ThreadZeroTlsCell:
 
             /* Check buffer length */
-            if (ThreadInformationLength != sizeof(ULONG_PTR))
+            if (ThreadInformationLength != sizeof(ULONG))
             {
                 Status = STATUS_INFO_LENGTH_MISMATCH;
                 break;
@@ -2449,7 +2449,7 @@ NtSetInformationThread(IN HANDLE ThreadHandle,
             _SEH2_TRY
             {
                 /* Get the priority */
-                TlsIndex = *(PULONG_PTR)ThreadInformation;
+                TlsIndex = *(PULONG)ThreadInformation;
             }
             _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
             {

--- a/subsystems/win32/csrss/csrss.c
+++ b/subsystems/win32/csrss/csrss.c
@@ -52,6 +52,7 @@ _main(int argc,
                             &BasePriority,
                             sizeof(KPRIORITY));
 
+#if defined (_X86_)
     /* Give us IOPL so that we can access the VGA registers */
     Status = NtSetInformationProcess(NtCurrentProcess(),
                                      ProcessUserModeIOPL,
@@ -70,6 +71,7 @@ _main(int argc,
                                   &Response);
 #endif
     }
+#endif
 
     /* Initialize CSR through CSRSRV */
     Status = CsrServerInitialization(argc, argv);


### PR DESCRIPTION
This fixes several issues regarding process/thread information classes where they fail with a size mismatch status error in AMD64 build.

## TODO
- [x] Keep investigating for other potential issues until we're assured that things work fine as they should
