### PR TITLE
[CMD] Improve performance

### DIFF
--- a/base/shell/cmd/CMakeLists.txt
+++ b/base/shell/cmd/CMakeLists.txt
@@ -1,6 +1,4 @@
 
-add_definitions(-D_DEBUG_MEM)
-
 include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/conutils)
 

--- a/base/shell/cmd/batch.c
+++ b/base/shell/cmd/batch.c
@@ -75,7 +75,6 @@ BOOL bEcho = TRUE;  /* The echo flag */
 /* Buffer for reading Batch file lines */
 TCHAR textline[BATCH_BUFFSIZE];
 
-
 /*
  * Returns a pointer to the n'th parameter of the current batch file.
  * If no such parameter exists returns pointer to empty string.
@@ -527,47 +526,31 @@ VOID AddBatchRedirection(REDIRECTION **RedirList)
  */
 BOOL BatchGetString(LPTSTR lpBuffer, INT nBufferLength)
 {
-    LPSTR lpString;
     INT len = 0;
-#ifdef _UNICODE
-    lpString = cmd_alloc(nBufferLength);
-    if (!lpString)
-    {
-        WARN("Cannot allocate memory for lpString\n");
-        error_out_of_memory();
-        return FALSE;
-    }
-#else
-    lpString = lpBuffer;
-#endif
+
     /* read all chars from memory until a '\n' is encountered */
     if (bc->mem)
     {
-        for (; (bc->mempos < bc->memsize  &&  len < (nBufferLength-1)); len++)
-        { 
-            lpString[len] = bc->mem[bc->mempos++];
-            if (lpString[len] == '\n' )
+        for (; ((bc->mempos + len) < bc->memsize  &&  len < (nBufferLength-1)); len++)
+        {
+#ifndef _UNICODE
+            lpBuffer[len] = bc->mem[bc->mempos + len];
+#endif
+            if (bc->mem[bc->mempos + len] == '\n')
             {
                 len++;
                 break;
             }
         }
+#ifdef _UNICODE
+        nBufferLength = MultiByteToWideChar(OutputCodePage, 0, &bc->mem[bc->mempos], len, lpBuffer, nBufferLength);
+        lpBuffer[nBufferLength] = L'\0';
+        lpBuffer[len] = '\0';
+#endif
+        bc->mempos += len;
     }
 
-    if (!len)
-    {
-#ifdef _UNICODE
-        cmd_free(lpString);
-#endif
-        return FALSE;
-    }
-
-    lpString[len++] = '\0';
-#ifdef _UNICODE
-    MultiByteToWideChar(OutputCodePage, 0, lpString, -1, lpBuffer, len);
-    cmd_free(lpString);
-#endif
-    return TRUE;
+    return len != 0;
 }
 
 /*

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2333,6 +2333,17 @@ static VOID Cleanup(VOID)
         ParseCommandLine(_T("\\cmdexit.bat"));
     }
 
+    /* Remove ctrl break handler */
+    RemoveBreakHandler();
+
+    /* Restore the default console mode */
+    SetConsoleMode(ConStreamGetOSHandle(StdIn),
+                   ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
+    SetConsoleMode(ConStreamGetOSHandle(StdOut),
+                   ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT);
+
+
+#ifdef _DEBUG_MEM
 #ifdef FEATURE_DIRECTORY_STACK
     /* Destroy directory stack */
     DestroyDirectoryStack();
@@ -2344,15 +2355,7 @@ static VOID Cleanup(VOID)
 
     /* Free GetEnvVar's buffer */
     GetEnvVar(NULL);
-
-    /* Remove ctrl break handler */
-    RemoveBreakHandler();
-
-    /* Restore the default console mode */
-    SetConsoleMode(ConStreamGetOSHandle(StdIn),
-                   ENABLE_PROCESSED_INPUT | ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
-    SetConsoleMode(ConStreamGetOSHandle(StdOut),
-                   ENABLE_PROCESSED_OUTPUT | ENABLE_WRAP_AT_EOL_OUTPUT);
+#endif /* _DEBUG_MEM */
 
     DeleteCriticalSection(&ChildProcessRunningLock);
 }


### PR DESCRIPTION
## Purpose

Sledgehammer deletion of weird outdated debug stuff, because I am tired of seeing cmd:batch taking way too much time when I run the test suite.

## Proposed changes

Do not use custom alloc/free functions. If you need this, use DPH.
Do not free resources at process exit.
 - You're doing it brick by brick while the OS does that with a bulldozer better than you do.