### PR TITLE
[SHELL32] Implement PathResolveW function

### DIFF
--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -117,3 +117,4 @@ add_importlibs(shell32 advapi32 gdi32 user32 comctl32 comdlg32 shlwapi msvcrt ke
 add_dependencies(shell32 stdole2) # shell32_shldisp.tlb needs stdole2.tlb
 add_pch(shell32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET shell32 DESTINATION reactos/system32 FOR all)
+target_compile_definitions(shell32 PRIVATE NTDDI_VERSION=NTDDI_WS03SP1)

--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -117,4 +117,3 @@ add_importlibs(shell32 advapi32 gdi32 user32 comctl32 comdlg32 shlwapi msvcrt ke
 add_dependencies(shell32 stdole2) # shell32_shldisp.tlb needs stdole2.tlb
 add_pch(shell32 precomp.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET shell32 DESTINATION reactos/system32 FOR all)
-target_compile_definitions(shell32 PRIVATE NTDDI_VERSION=NTDDI_WS03SP1)

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2209,7 +2209,6 @@ HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
             /* This failed, try to resolve the path, then create a simple PIDL */
 
             StringCchCopyW(szPath, _countof(szPath), pszFile);
-
             PathResolveW(szPath, NULL, PRF_TRYPROGRAMEXTENSIONS);
 
             pidlNew = SHSimpleIDListFromPathW(szPath);

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2178,8 +2178,6 @@ HRESULT CShellLink::SetAdvertiseInfo(LPCWSTR str)
     return S_OK;
 }
 
-BOOL PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags);
-
 HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
 {
     HRESULT hr = S_OK;

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2218,6 +2218,9 @@ HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
             {
                 hr = S_OK;
                 pidlNew = SHSimpleIDListFromPathW(szPath);
+                // NOTE: Don't make it failed here even if pidlNew was NULL.
+                // We don't fail on purpose even if SHSimpleIDListFromPathW returns NULL.
+                // This behaviour has been verified with tests.
             }
         }
     }

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2209,11 +2209,16 @@ HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
             StringCchCopyW(szPath, _countof(szPath), pszFile);
             PathResolveW(szPath, NULL, PRF_TRYPROGRAMEXTENSIONS);
 
-            pidlNew = SHSimpleIDListFromPathW(szPath);
-            /******************************************************/
-            /* Question: Why this line is needed only for files?? */
-            hr = (*szPath ? S_OK : E_INVALIDARG); // S_FALSE
-            /******************************************************/
+            if (PathIsFileSpecW(szPath))
+            {
+                hr = E_INVALIDARG;
+                szPath[0] = 0;
+            }
+            else
+            {
+                hr = S_OK;
+                pidlNew = SHSimpleIDListFromPathW(szPath);
+            }
         }
     }
     // else if (!pidl && !pszFile) { pidlNew = NULL; hr = S_OK; }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -141,6 +141,8 @@ static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
 }
 #endif
 
+/* NOTE: GetShortPathName fails if the pathname didn't exist.
+         GetShortPathNameAbsentW should set the short path name that even doesn't exist. */
 static DWORD GetShortPathNameAbsentW(LPCWSTR pszLong, LPWSTR pszShort, DWORD cchShort)
 {
     FIXME("GetShortPathNameAbsentW(%ls, %p, %ld): stub\n", pszLong, pszShort, cchShort);
@@ -631,7 +633,7 @@ BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
 }
 
 #define WHICH_DONTFINDLNK (WHICH_PIF | WHICH_COM | WHICH_EXE | WHICH_BAT)
-#define WHICH_DEFAULT (WHICH_PIF | WHICH_COM | WHICH_EXE | WHICH_BAT | WHICH_LNK | WHICH_CMD)
+#define WHICH_DEFAULT (WHICH_DONTFINDLNK | WHICH_LNK | WHICH_CMD)
 
 BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -151,6 +151,7 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
     WCHAR szRoot[MAX_PATH], szCopy[MAX_PATH], szCurDir[MAX_PATH];
     LPWSTR pch;
     LONG cch;
+    BOOL bCheckLFN;
 
     if (FAILED(StringCchCopyW(szCopy, _countof(szCopy), pszPath)))
         return;
@@ -176,16 +177,22 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
             if (pch)
                 *pch = 0;
             PathAddBackslashW(szRoot); /* \\MyServer\MyShare\ */
-
-            if (!IsLFNDriveW(szRoot))
-                GetShortPathNameW(szCopy, szCopy, _countof(szCopy));
+            bCheckLFN = TRUE;
+        }
+        else
+        {
+            bCheckLFN = FALSE;
         }
     }
     else
     {
         PathStripToRootW(szRoot);
         PathAddBackslashW(szRoot); /* X:\ */
+        bCheckLFN = TRUE;
+    }
 
+    if (bCheckLFN)
+    {
         if (!IsLFNDriveW(szRoot))
         {
             if (!GetFullPathNameW(szCopy, _countof(szRoot), szRoot, NULL))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -626,13 +626,13 @@ VOID WINAPI PathQualifyAW(LPVOID pszPath)
         PathQualifyA(pszPath);
 }
 
-static BOOL PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
+BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
 {
     FIXME("(%s,%p,0x%08x),stub!\n", debugstr_a(path), dirs, flags);
     return FALSE;
 }
 
-static BOOL PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
+BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 {
     DWORD dwWhich;
     TRACE("PathResolveW(%s,%p,0x%08x)\n", debugstr_w(path), dirs, flags);

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -108,15 +108,15 @@ DoGetProductType(PNT_PRODUCT_TYPE ProductType)
 
 /* @implemented */
 static BOOL WINAPI
-PathSearchOnExtensionsW(LPWSTR path, LPCWSTR *dirs, BOOL flag, DWORD dwWhich)
+PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD dwWhich)
 {
-    if (*PathFindExtensionW(path) != 0)
+    if (*PathFindExtensionW(pszPath) != 0)
         return FALSE;
 
-    if (flag)
-        return PathFindOnPathExW(path, dirs, dwWhich);
+    if (bDoSearch)
+        return PathFindOnPathExW(pszPath, ppszDirs, dwWhich);
     else
-        return PathFileExistsDefExtW(path, dwWhich);
+        return PathFileExistsDefExtW(pszPath, dwWhich);
 }
 
 #if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -174,13 +174,11 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
         {
             pch = StrChrW(&pch[1], L'\\');
             if (pch)
-            {
                 *pch = 0;
-                PathAddBackslashW(szRoot); /* \\MyServer\MyShare\ */
+            PathAddBackslashW(szRoot); /* \\MyServer\MyShare\ */
 
-                if (!IsLFNDriveW(szRoot))
-                    GetShortPathNameW(szCopy, szCopy, _countof(szCopy));
-            }
+            if (!IsLFNDriveW(szRoot))
+                GetShortPathNameW(szCopy, szCopy, _countof(szCopy));
         }
     }
     else

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -166,7 +166,7 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
     if (pszDir)
     {
         cch = GetCurrentDirectoryW(_countof(szCurDir), szCurDir);
-        if (cch <= 0 || cch >= MAX_PATH || !SetCurrentDirectoryW(pszDir))
+        if (cch <= 0 || cch >= _countof(szCurDir) || !SetCurrentDirectoryW(pszDir))
             pszDir = NULL;
     }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -632,12 +632,14 @@ BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
     return FALSE;
 }
 
+#define WHICH_DONTFINDLNK (WHICH_PIF | WHICH_COM | WHICH_EXE | WHICH_BAT)
+#define WHICH_DEFAULT (WHICH_PIF | WHICH_COM | WHICH_EXE | WHICH_BAT | WHICH_LNK | WHICH_CMD)
+
 BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 {
     DWORD dwWhich;
     TRACE("PathResolveW(%s,%p,0x%08x)\n", debugstr_w(path), dirs, flags);
-
-    dwWhich = ((flags & PRF_DONTFINDLNK) ? 0xF : 0x3F);
+    dwWhich = ((flags & PRF_DONTFINDLNK) ? WHICH_DONTFINDLNK : WHICH_DEFAULT);
 
     if (flags & PRF_VERIFYEXISTS)
         SetLastError(ERROR_FILE_NOT_FOUND);

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -119,7 +119,7 @@ PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD
         return PathFileExistsDefExtW(pszPath, dwWhich);
 }
 
-#ifdef REQUIREABSOLUTE /* Vista+ */
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
 /* @implemented */
 static BOOL WINAPI PathIsAbsoluteW(LPCWSTR path)
 {
@@ -668,7 +668,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 
         if (PathFindOnPathW(path, dirs))
         {
-#ifdef REQUIREABSOLUTE /* Vista+ */
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
             if (!(flags & PRF_REQUIREABSOLUTE))
                 return TRUE;
 
@@ -699,7 +699,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
             }
         }
 
-#ifdef REQUIREABSOLUTE /* Vista+ */
+#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
         if (flags & PRF_REQUIREABSOLUTE)
         {
             if (!PathIsAbsoluteW(path))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -598,24 +598,24 @@ int WINAPI PathCleanupSpec( LPCWSTR lpszPathW, LPWSTR lpszFileW )
 }
 
 /*************************************************************************
- * PathQualifyW		[SHELL32]
- */
-static VOID PathQualifyW(LPWSTR pszPath)
-{
-    TRACE("%s\n",debugstr_w(pszPath));
-    PathQualifyExW(pszPath, NULL, 0);
-}
-
-/*************************************************************************
  * PathQualifyA		[SHELL32]
  */
-static VOID PathQualifyA(LPSTR pszPath)
+VOID WINAPI PathQualifyA(LPSTR pszPath)
 {
     WCHAR szPath[MAX_PATH];
     TRACE("%s\n",pszPath);
     SHAnsiToUnicode(pszPath, szPath, _countof(szPath));
     PathQualifyW(szPath);
     SHUnicodeToAnsi(szPath, pszPath, MAX_PATH);
+}
+
+/*************************************************************************
+ * PathQualifyW		[SHELL32]
+ */
+VOID WINAPI PathQualifyW(LPWSTR pszPath)
+{
+    TRACE("%s\n",debugstr_w(pszPath));
+    PathQualifyExW(pszPath, NULL, 0);
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -198,19 +198,16 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
         bCheckLFN = TRUE;
     }
 
-    if (bCheckLFN)
+    if (bCheckLFN && !IsLFNDriveW(szRoot))
     {
-        if (!IsLFNDriveW(szRoot))
+        if (!GetFullPathNameW(szCopy, _countof(szRoot), szRoot, NULL))
+            goto Quit;
+        cch = GetShortPathNameW(szRoot, szCopy, _countof(szCopy));
+        if (!cch)
         {
-            if (!GetFullPathNameW(szCopy, _countof(szRoot), szRoot, NULL))
-                goto Quit;
-            cch = GetShortPathNameW(szRoot, szCopy, _countof(szCopy));
+            cch = GetShortPathNameAbsentW(szRoot, szCopy, _countof(szCopy));
             if (!cch)
-            {
-                cch = GetShortPathNameAbsentW(szRoot, szCopy, _countof(szCopy));
-                if (!cch)
-                    goto Quit;
-            }
+                goto Quit;
         }
     }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -709,7 +709,6 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
                 return PathMakeAbsoluteW(path) && PathFileExistsAndAttributesW(path, NULL);
         }
 #endif
-
         return TRUE;
     }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -119,28 +119,6 @@ PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD
         return PathFileExistsDefExtW(pszPath, dwWhich);
 }
 
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
-/* @implemented */
-static BOOL WINAPI PathIsAbsoluteW(LPCWSTR path)
-{
-    return PathIsUNCW(path) || (PathGetDriveNumberW(path) != -1 && path[2] == L'\\');
-}
-
-/* @implemented */
-static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
-{
-    WCHAR path1[MAX_PATH];
-    DWORD cch;
-
-    if (path == NULL)
-        return FALSE;
-    cch = GetCurrentDirectoryW(_countof(path1), path1);
-    if (!cch || cch > _countof(path1))
-        return FALSE;
-    return (PathCombineW(path, path1, path) != NULL);
-}
-#endif
-
 /* NOTE: GetShortPathName fails if the pathname didn't exist.
          GetShortPathNameAbsentW should set the short path name that even doesn't exist. */
 static DWORD GetShortPathNameAbsentW(LPCWSTR pszLong, LPWSTR pszShort, DWORD cchShort)
@@ -667,17 +645,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
             return TRUE;
 
         if (PathFindOnPathW(path, dirs))
-        {
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
-            if (!(flags & PRF_REQUIREABSOLUTE))
-                return TRUE;
-
-            if (!PathIsAbsoluteW(path))
-                return PathMakeAbsoluteW(path) && PathFileExistsAndAttributesW(path, NULL);
-#else
             return TRUE;
-#endif
-        }
     }
     else if (!PathIsURLW(path))
     {
@@ -699,13 +667,6 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
             }
         }
 
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
-        if (flags & PRF_REQUIREABSOLUTE)
-        {
-            if (!PathIsAbsoluteW(path))
-                return PathMakeAbsoluteW(path) && PathFileExistsAndAttributesW(path, NULL);
-        }
-#endif
         return TRUE;
     }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -206,7 +206,11 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
                 goto Quit;
             cch = GetShortPathNameW(szRoot, szCopy, _countof(szCopy));
             if (!cch)
-                GetShortPathNameAbsentW(szRoot, szCopy, _countof(szCopy));
+            {
+                cch = GetShortPathNameAbsentW(szRoot, szCopy, _countof(szCopy));
+                if (!cch)
+                    goto Quit;
+            }
         }
     }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -134,8 +134,8 @@ static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
 
     if (path == NULL)
         return FALSE;
-    cch = GetCurrentDirectoryW(MAX_PATH, path1);
-    if (!cch || cch > MAX_PATH)
+    cch = GetCurrentDirectoryW(_countof(path1), path1);
+    if (!cch || cch > _countof(path1))
         return FALSE;
     return (PathCombineW(path, path1, path) != NULL);
 }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -583,7 +583,7 @@ int WINAPI PathCleanupSpec( LPCWSTR lpszPathW, LPWSTR lpszFileW )
  */
 static VOID PathQualifyW(LPWSTR pszPath)
 {
-	TRACE("%s\n",debugstr_w(pszPath));
+    TRACE("%s\n",debugstr_w(pszPath));
     PathQualifyExW(pszPath, NULL, 0);
 }
 
@@ -612,7 +612,7 @@ VOID WINAPI PathQualifyAW(LPVOID pszPath)
 
 static BOOL PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
 {
-    FIXME("(%s,%p,0x%08x)\n", debugstr_a(path), dirs, flags);
+    FIXME("(%s,%p,0x%08x),stub!\n", debugstr_a(path), dirs, flags);
     return FALSE;
 }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -633,7 +633,7 @@ static BOOL PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
         if ((path[0] == L'\\' && path[1] == 0) ||
             PathIsUNCServerW(path) || PathIsUNCServerShareW(path))
         {
-            if ((flags & PRF_FIRSTDIRDEF) == 0)
+            if (flags & PRF_FIRSTDIRDEF)
                 PathQualifyExW(path, dirs[0], 0);
             else
                 PathQualifyExW(path, NULL, 0);

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -119,7 +119,7 @@ PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD
         return PathFileExistsDefExtW(pszPath, dwWhich);
 }
 
-#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
+#ifdef REQUIREABSOLUTE /* Vista+ */
 /* @implemented */
 static BOOL WINAPI PathIsAbsoluteW(LPCWSTR path)
 {
@@ -668,7 +668,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 
         if (PathFindOnPathW(path, dirs))
         {
-#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
+#ifdef REQUIREABSOLUTE /* Vista+ */
             if (!(flags & PRF_REQUIREABSOLUTE))
                 return TRUE;
 
@@ -699,7 +699,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
             }
         }
 
-#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
+#ifdef REQUIREABSOLUTE /* Vista+ */
         if (flags & PRF_REQUIREABSOLUTE)
         {
             if (!PathIsAbsoluteW(path))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -119,9 +119,7 @@ PathSearchOnExtensionsW(LPWSTR path, LPCWSTR *dirs, BOOL flag, DWORD dwWhich)
         return PathFileExistsDefExtW(path, dwWhich);
 }
 
-/* #define REQUIREABSOLUTE */
-
-#ifdef REQUIREABSOLUTE
+#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
 /* @implemented */
 static BOOL WINAPI PathIsAbsoluteW(LPCWSTR path)
 {
@@ -141,7 +139,7 @@ static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
         return FALSE;
     return (PathCombineW(path, path1, path) != NULL);
 }
-#endif /* def REQUIREABSOLUTE */
+#endif
 
 static DWORD GetShortPathNameAbsentW(LPCWSTR pszLong, LPWSTR pszShort, DWORD cchShort)
 {
@@ -668,7 +666,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 
         if (PathFindOnPathW(path, dirs))
         {
-#ifdef REQUIREABSOLUTE
+#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
             if (!(flags & PRF_REQUIREABSOLUTE))
                 return TRUE;
 
@@ -699,7 +697,7 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
             }
         }
 
-#ifdef REQUIREABSOLUTE
+#if (NTDDI_VERSION >= NTDDI_VISTA) /* Vista+ */
         if (flags & PRF_REQUIREABSOLUTE)
         {
             if (!PathIsAbsoluteW(path))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -143,6 +143,13 @@ static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
 }
 #endif /* def REQUIREABSOLUTE */
 
+static DWORD GetShortPathNameAbsentW(LPCWSTR pszLong, LPWSTR pszShort, DWORD cchShort)
+{
+    FIXME("GetShortPathNameAbsentW(%ls, %p, %ld): stub\n", pszLong, pszShort, cchShort);
+    StringCchCopyW(pszShort, cchShort, pszLong);
+    return lstrlenW(pszShort);
+}
+
 BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath);
 
 /* @unconfirmed */
@@ -197,7 +204,9 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
         {
             if (!GetFullPathNameW(szCopy, _countof(szRoot), szRoot, NULL))
                 goto Quit;
-            GetShortPathNameW(szRoot, szCopy, _countof(szCopy));
+            cch = GetShortPathNameW(szRoot, szCopy, _countof(szCopy));
+            if (!cch)
+                GetShortPathNameAbsentW(szRoot, szCopy, _countof(szCopy));
         }
     }
 

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -150,8 +150,16 @@ ShellMessageBoxWrapW(
   _In_ UINT fuStyle,
   ...);
 
-BOOL WINAPI PathFileExistsDefExtW(LPWSTR, DWORD);
-BOOL WINAPI PathFindOnPathExW(LPWSTR, LPCWSTR*, DWORD);
+/* dwWhich flags for PathFileExistsDefExtW and PathFindOnPathExW */
+#define WHICH_PIF (1 << 0)
+#define WHICH_COM (1 << 1)
+#define WHICH_EXE (1 << 2)
+#define WHICH_BAT (1 << 3)
+#define WHICH_LNK (1 << 4)
+#define WHICH_CMD (1 << 5)
+
+BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath, DWORD dwWhich);
+BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
 
 #ifdef __cplusplus

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -150,6 +150,10 @@ ShellMessageBoxWrapW(
   _In_ UINT fuStyle,
   ...);
 
+BOOL WINAPI PathFileExistsDefExtW(LPWSTR, DWORD);
+BOOL WINAPI PathFindOnPathExW(LPWSTR, LPCWSTR*, DWORD);
+VOID WINAPI FixSlashesAndColonW(LPWSTR);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -440,6 +440,8 @@ BOOL WINAPI PathYetAnotherMakeUniqueName(
     LPCWSTR lpszShortName,
     LPCWSTR lpszLongName);
 
+VOID WINAPI PathQualifyA(LPSTR pszPath);
+VOID WINAPI PathQualifyW(LPWSTR pszPath);
 VOID WINAPI PathQualifyAW(LPVOID path);
 
 /* PathResolve flags */

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -448,6 +448,8 @@ VOID WINAPI PathQualifyAW(LPVOID path);
 #define PRF_QUALIFYONPATH   0x04
 #define PRF_WINDOWS31       0x08
 
+BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags);
+BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags);
 BOOL WINAPI PathResolveAW(LPVOID lpszPath, LPCVOID *alpszPaths, DWORD dwFlags);
 
 VOID WINAPI PathSetDlgItemPathAW(HWND hDlg, int nIDDlgItem, LPCVOID lpszPath);

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -440,8 +440,7 @@ BOOL WINAPI PathYetAnotherMakeUniqueName(
     LPCWSTR lpszShortName,
     LPCWSTR lpszLongName);
 
-BOOL  WINAPI PathQualifyAW(LPCVOID path);
-
+VOID WINAPI PathQualifyAW(LPVOID path);
 
 /* PathResolve flags */
 #define PRF_CHECKEXISTANCE  0x01


### PR DESCRIPTION
## Purpose
Our shell needs `shell32!PathResolve` function to go deep.
JIRA issue: [CORE-12665](https://jira.reactos.org/browse/CORE-12665)

## Proposed changes

- Implement `PathResolveW` function.
- Implement `PathQualifyA/W` functions using newly-defined `PathQualifyExW` function.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![PathResolve-before](https://user-images.githubusercontent.com/2107452/123055124-863be600-d440-11eb-9884-ca38500c1967.png)
Too many failures (2976).
AFTER:
![after](https://user-images.githubusercontent.com/2107452/123055121-850ab900-d440-11eb-8795-40393793cd47.png)
Failures are reduced a lot (down to 324).