### PR TITLE
[ATL] Close m_hKey in CRegKey destructor

### DIFF
--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1043,6 +1043,7 @@ public:
 
     ~CRegKey() throw()
     {
+        Close();
     }
 
     void Attach(HKEY hKey) throw()
@@ -1359,7 +1360,11 @@ public:
 
     CRegKey& operator=(CRegKey& key) throw()
     {
-        Attach(key.Detach());
+        if (m_hKey != key.m_hKey)
+        {
+            Close();
+            Attach(key.Detach());
+        }
         return *this;
     }
 


### PR DESCRIPTION
## Purpose

As is described in MSDN [here](https://docs.microsoft.com/en-us/cpp/atl/reference/cregkey-class?view=msvc-160#dtor), `~CRegKey` should release `m_hKey` 

but the code in ReactOS's ATL seems to do nothing at all


## Proposed changes

- make up the missing cleanup code in  `~CRegKey` 

