### PR TITLE
[NTOS:KE] Rewrite KeZeroPages in assembly & add SSE version

### DIFF
--- a/ntoskrnl/ke/amd64/stubs.c
+++ b/ntoskrnl/ke/amd64/stubs.c
@@ -88,16 +88,6 @@ KiDpcInterruptHandler(VOID)
     KeLowerIrql(OldIrql);
 }
 
-
-VOID
-FASTCALL
-KeZeroPages(IN PVOID Address,
-            IN ULONG Size)
-{
-    /* Not using XMMI in this routine */
-    RtlZeroMemory(Address, Size);
-}
-
 PVOID
 KiSwitchKernelStackHelper(
     LONG_PTR StackOffset,

--- a/ntoskrnl/ke/amd64/zeropage.S
+++ b/ntoskrnl/ke/amd64/zeropage.S
@@ -1,0 +1,45 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Fast zeroing of pages
+ * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
+ */
+
+#include <asm.inc>
+
+/* FUNCTIONS ****************************************************************/
+.code
+
+/* Benchmarking from Timo on some AMD machine:
+    rep movsq : 128
+    movaps 175
+    movnti 620
+    movntdq: 620
+    movntps: 620
+    MS KeZeroPages (movnti unrolled): 883
+    MS KeZeroSinglePage (mov): 346
+
+    whole discussion in https://github.com/reactos/reactos/pull/3765
+    We stick with rep stosq.
+*/
+
+/*
+ * VOID
+ * KeZeroPages(PVOID Ptr, ULONG Size);
+ */
+PUBLIC KeZeroPages
+FUNC KeZeroPages
+    push rdi
+    .PUSHREG rdi
+    .ENDPROLOG
+
+    mov rdi, rcx
+    mov ecx, edx
+    shr ecx, 3
+    xor rax, rax
+    rep stosq
+    pop rdi
+    ret
+ENDFUNC
+
+END

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -1134,15 +1134,6 @@ KeInvalidateAllCaches(VOID)
 }
 
 VOID
-FASTCALL
-KeZeroPages(IN PVOID Address,
-            IN ULONG Size)
-{
-    /* Not using XMMI in this routine */
-    RtlZeroMemory(Address, Size);
-}
-
-VOID
 NTAPI
 KiSaveProcessorState(IN PKTRAP_FRAME TrapFrame,
                      IN PKEXCEPTION_FRAME ExceptionFrame)

--- a/ntoskrnl/ke/i386/zeropage.S
+++ b/ntoskrnl/ke/i386/zeropage.S
@@ -1,0 +1,32 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Fast zeroing of pages
+ * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
+ */
+
+#include <asm.inc>
+
+/* FUNCTIONS ****************************************************************/
+.code
+
+/*
+ * VOID
+ * FASTCALL
+ * KeZeroPages(void* ptr, ULONG Size)
+ */
+PUBLIC @KeZeroPages@8
+FUNC @KeZeroPages@8
+    FPO 0, 0, 0, 0, 0, FRAME_FPO
+
+    push edi
+    mov edi, ecx
+    mov ecx, edx
+    shr ecx, 2
+    xor eax, eax
+    rep stosd
+    pop edi
+    ret
+ENDFUNC
+
+END

--- a/ntoskrnl/mm/ARM3/hypermap.c
+++ b/ntoskrnl/mm/ARM3/hypermap.c
@@ -150,6 +150,10 @@ MiMapPagesInZeroSpace(IN PMMPFN Pfn1,
     PointerPte += (Offset + 1);
     TempPte = ValidKernelPte;
 
+    /* Disable cache. Write through */
+    MI_PAGE_DISABLE_CACHE(&TempPte);
+    MI_PAGE_WRITE_THROUGH(&TempPte);
+
     /* Make sure the list isn't empty and loop it */
     ASSERT(Pfn1 != (PVOID)LIST_HEAD);
     while (Pfn1 != (PVOID)LIST_HEAD)

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -674,6 +674,11 @@ MiResolveDemandZeroFault(IN PVOID Address,
             PageFrameNumber = MiRemoveAnyPage(Color);
             NeedZero = TRUE;
         }
+        else
+        {
+            /* Page guaranteed to be zero-filled */
+            NeedZero = FALSE;
+        }
     }
     else
     {
@@ -688,6 +693,8 @@ MiResolveDemandZeroFault(IN PVOID Address,
         {
             /* System wants a zero page, obtain one */
             PageFrameNumber = MiRemoveZeroPage(Color);
+            /* No need to zero-fill it */
+            NeedZero = FALSE;
         }
     }
 

--- a/ntoskrnl/mm/ARM3/zeropage.c
+++ b/ntoskrnl/mm/ARM3/zeropage.c
@@ -99,7 +99,7 @@ MmZeroPageThread(VOID)
 
             ZeroAddress = MiMapPagesInZeroSpace(Pfn1, 1);
             ASSERT(ZeroAddress);
-            RtlZeroMemory(ZeroAddress, PAGE_SIZE);
+            KeZeroPages(ZeroAddress, PAGE_SIZE);
             MiUnmapPagesInZeroSpace(ZeroAddress, 1);
 
             OldIrql = MiAcquirePfnLock();

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -298,6 +298,7 @@ if(ARCH STREQUAL "i386")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/ctxswitch.S
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/trap.s
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/usercall_asm.S
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/i386/zeropage.S
         ${REACTOS_SOURCE_DIR}/ntoskrnl/rtl/i386/stack.S)
     list(APPEND SOURCE
         ${REACTOS_SOURCE_DIR}/ntoskrnl/config/i386/cmhardwr.c

--- a/ntoskrnl/ntos.cmake
+++ b/ntoskrnl/ntos.cmake
@@ -328,7 +328,8 @@ elseif(ARCH STREQUAL "amd64")
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/boot.S
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/ctxswitch.S
         ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/trap.S
-        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/usercall_asm.S)
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/usercall_asm.S
+        ${REACTOS_SOURCE_DIR}/ntoskrnl/ke/amd64/zeropage.S)
     list(APPEND SOURCE
         ${REACTOS_SOURCE_DIR}/ntoskrnl/config/i386/cmhardwr.c
         ${REACTOS_SOURCE_DIR}/ntoskrnl/mm/i386/page.c


### PR DESCRIPTION
We spend a lot of time in this function, let's optimize it.
Noticed while running heavy memory tests like mshtml_winetest

