### PR TITLE
[ROSAUTOTEST] Run tests with current dir set to the test dir

### DIFF
--- a/modules/rostests/rosautotest/CWineTest.cpp
+++ b/modules/rostests/rosautotest/CWineTest.cpp
@@ -298,6 +298,8 @@ CWineTest::RunTest(CTestInfo* TestInfo)
     ss << "Running Wine Test, Module: " << TestInfo->Module << ", Test: " << TestInfo->Test << endl;
     StringOut(ss.str());
 
+    SetCurrentDirectoryW(m_TestPath.c_str());
+
     StartTime = GetTickCount();
 
     try


### PR DESCRIPTION
This fixes a number of tests on Test WHS.
- advapi32:RtlEncryptMemory: 2 failures -> 0 failures
- browseui:ACListISF: CRASH -> 0 failures
- gdi32:AddFontResource: 8 failures -> 0 failures
- kernel32:path: 1 failure -> 0 failures
- kernel32:process: 27 failures -> 13 failures
- usp10:usp10: 24 tests more executed (+ 3 failures)

Regression:
- ntdll:file: 0 failures -> 1 failure

Comparison: https://reactos.org/testman/compare.php?ids=77657,77910,77911,77915,78025 (this PR on the right)
