### PR TITLE
[WIN32K] Revert NtGdiStretchDIBitsInternal to Previous Logic

### DIFF
--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1394,8 +1394,6 @@ NtGdiStretchDIBitsInternal(
         NtGdiDeleteObjectApp(hdcMem);
         GreDeleteObject(hBitmap);
 
-        if (pvBits) ExFreePoolWithTag(pvBits, TAG_DIB);
-
     } /* End of dwRop == SRCCOPY */
     else
     { /* Start of dwRop != SRCCOPY */
@@ -1490,10 +1488,10 @@ NtGdiStretchDIBitsInternal(
         if (psurfTmp) SURFACE_ShareUnlockSurface(psurfTmp);
         if (hbmTmp) GreDeleteObject(hbmTmp);
         if (pdc) DC_UnlockDc(pdc);
-        if (pvBits) ExFreePoolWithTag(pvBits, TAG_DIB);
     }
 
     if (pbmiSafe) ExFreePoolWithTag(pbmiSafe, 'imBG');
+    if (pvBits) ExFreePoolWithTag(pvBits, TAG_DIB);
 
     /* This is not what MSDN says is returned from this function, but it
      * follows Wine's dlls/gdi32/dib.c function nulldrv_StretchDIBits

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1131,7 +1131,7 @@ NtGdiGetDIBitsInternal(
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
-        _SEH2_YIELD(goto cleanup;)
+        goto cleanup;
     }
     _SEH2_END;
 
@@ -1229,7 +1229,6 @@ NtGdiStretchDIBitsInternal(
     ULONG BmpFormat = 0;
     INT LinesCopied = 0;
 
-  /* Following Code shamelessly copied from NtGdiGetDIBitsInternal */
     /* Check for bad iUsage */
     if (dwUsage > 2) return 0;
 
@@ -1283,7 +1282,6 @@ NtGdiStretchDIBitsInternal(
         ExFreePoolWithTag(pbmiSafe, 'imBG');
         return 0;
     }
-  /* End of Code shamelessly copied from NtGdiGetDIBitsInternal */
 
     if (!(pdc = DC_LockDc(hdc)))
     {
@@ -1321,7 +1319,7 @@ NtGdiStretchDIBitsInternal(
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
             ExFreePoolWithTag(pvBits, TAG_DIB);
-            _SEH2_YIELD(return 0);
+            return 0;
         }
         _SEH2_END;
     }
@@ -1361,23 +1359,6 @@ NtGdiStretchDIBitsInternal(
         {
             hPal = NtGdiGetDCObject(hdc, GDI_OBJECT_TYPE_PALETTE);
             hPal = GdiSelectPalette(hdcMem, hPal, FALSE);
-        }
-
-        if (pbmiSafe->bmiHeader.biCompression == BI_RLE4 ||
-                pbmiSafe->bmiHeader.biCompression == BI_RLE8)
-        {
-            /* copy existing bitmap from destination dc */
-            if (cxSrc == cyDst && cySrc == cyDst)
-            {
-                NtGdiBitBlt(hdcMem, xSrc, abs(pbmiSafe->bmiHeader.biHeight) - cySrc - ySrc,
-                            cxSrc, cySrc, hdc, xDst, yDst,  dwRop, 0, 0);
-            }
-            else
-            {
-                NtGdiStretchBlt(hdcMem, xSrc, abs(pbmiSafe->bmiHeader.biHeight) -     cySrc - ySrc,
-                                cxSrc, cySrc, hdc, xDst, yDst, cxDst, cyDst,
-                                dwRop, 0);
-            }
         }
 
         pdc = DC_LockDc(hdcMem);

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1364,7 +1364,7 @@ NtGdiStretchDIBitsInternal(
         pdc = DC_LockDc(hdcMem);
         if (pdc != NULL)
         {
-            IntSetDIBits(pdc, hBitmap, 0, abs(pbmi->bmiHeader.biHeight), pvBits,
+            IntSetDIBits(pdc, hBitmap, 0, abs(pbmiSafe->bmiHeader.biHeight), pvBits,
                          cjMaxBits, pbmiSafe, dwUsage);
             DC_UnlockDc(pdc);
         }


### PR DESCRIPTION
## Revert to old logic for NtGdiStretchDIBitsInternal to fix SIMS graphics.

_Reviewed full history of changes to this function and merged significant changes into reverted logic._

JIRA issue: [CORE-16236](https://jira.reactos.org/browse/CORE-16236)

## Fix SIMS graphics by reverting problematic function change.

Updated and Commit Cleaned Replacement for PR #3757.

First testing results:
CORE-16236 JID59763 NtGdiStretchDIBitsInternal_14.patch on top of 835c302
KVM: https://reactos.org/testman/compare.php?ids=78051,78058
VBOX: https://reactos.org/testman/compare.php?ids=78053,78059
Over 100 fewer failures in gdi32:dib
Four (4) fewer failures in gdi32:bitmap
No difference in gdiplus:graphics.

Next Test Results:
CORE-16236 JID59765 NtGdiStretchDIBitsInternal_15.patch on top of 0ffbbab
KVM:  https://reactos.org/testman/compare.php?ids=78054,78060
VBox: https://reactos.org/testman/compare.php?ids=78057,78061
Over 100 fewer failures in gdi32:dib
Five (5) fewer failures in gdi32:bitmap
No difference in gdiplus:graphics.

New Improvement in gdi32:bitmap
https://reactos.org/testman/compare.php?ids=78059,78061

Next Test Results:
CORE-16236 JID59768 NtGdiStretchDIBitsInternal_16.patch on top of 0ffbbab
KVM:  https://reactos.org/testman/compare.php?ids=78054,78065
VBox: https://reactos.org/testman/compare.php?ids=78057,78066
Over 100 fewer failures in gdi32:dib
Five (5) fewer failures in gdi32:bitmap
No difference in gdiplus:graphics.

Next Test Results:
CORE-16236 JID59769 NtGdiStretchDIBitsInternal_17.patch on top of 0ffbbab
KVM:  https://reactos.org/testman/compare.php?ids=78054,78071
VBox: https://reactos.org/testman/compare.php?ids=78057,78070
Over 100 fewer failures in gdi32:dib
Five (5) fewer failures in gdi32:bitmap
No difference in gdiplus:graphics.

Current Test Results:
CORE-16236 JID59793 NtGdiStretchDIBitsInternal_18.patch on top of 0ffbbab
KVM:  https://reactos.org/testman/compare.php?ids=78054,78075
VBox: https://reactos.org/testman/compare.php?ids=78057,78076
Over 100 fewer failures in gdi32:dib
Five (5) fewer failures in gdi32:bitmap
No difference in gdiplus:graphics.