### PR TITLE
[IMM32] ImmDisableIME calls NtUserDisableThreadIme

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -850,6 +850,9 @@ BOOL WINAPI ImmDestroyContext(HIMC hIMC)
  */
 BOOL WINAPI ImmDisableIME(DWORD idThread)
 {
+#ifdef __REACTOS__
+    return NtUserDisableThreadIme(idThread);
+#else
     if (idThread == (DWORD)-1)
         disable_ime = TRUE;
     else {
@@ -859,6 +862,7 @@ BOOL WINAPI ImmDisableIME(DWORD idThread)
         LeaveCriticalSection(&threaddata_cs);
     }
     return TRUE;
+#endif
 }
 
 /***********************************************************************

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -851,7 +851,7 @@ BOOL WINAPI ImmDestroyContext(HIMC hIMC)
 BOOL WINAPI ImmDisableIME(DWORD idThread)
 {
 #ifdef __REACTOS__
-    return NtUserDisableThreadIme(idThread);
+    return NtUserDisableThreadIme(idThread); /* confirmed */
 #else
     if (idThread == (DWORD)-1)
         disable_ime = TRUE;

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -851,7 +851,7 @@ BOOL WINAPI ImmDestroyContext(HIMC hIMC)
 BOOL WINAPI ImmDisableIME(DWORD idThread)
 {
 #ifdef __REACTOS__
-    return NtUserDisableThreadIme(idThread); /* confirmed */
+    return NtUserDisableThreadIme(idThread);
 #else
     if (idThread == (DWORD)-1)
         disable_ime = TRUE;


### PR DESCRIPTION
## Purpose
I have started development of imm32-related stuffs.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Just call `NtUserDisableThreadIme` in `ImmDisableIME` directly.
