### PR TITLE
Fix msvc x86 warnings

### DIFF
--- a/base/applications/mstsc/CMakeLists.txt
+++ b/base/applications/mstsc/CMakeLists.txt
@@ -38,3 +38,8 @@ set_module_type(mstsc win32gui UNICODE)
 add_importlibs(mstsc user32 gdi32 comctl32 ws2_32 crypt32 secur32 advapi32 shell32 ole32 comdlg32 msvcrt kernel32)
 add_pch(mstsc precomp.h SOURCE)
 add_cd_file(TARGET mstsc DESTINATION reactos/system32 FOR all)
+
+if(MSVC)
+    # Disable warning C4267: 'initializing': conversion from 'size_t' to 'uint16', possible loss of data
+    target_compile_options(mstsc PRIVATE /wd4267)
+endif()

--- a/base/applications/network/telnet/CMakeLists.txt
+++ b/base/applications/network/telnet/CMakeLists.txt
@@ -25,6 +25,12 @@ add_executable(telnet ${SOURCE} telnet.rc)
 target_link_libraries(telnet cppstl)
 set_target_cpp_properties(telnet WITH_EXCEPTIONS)
 
+if (MSVC)
+    # C4838: conversion from 'int' to 'SHORT' requires a narrowing conversion
+    # C4996: 'strnicmp': Deprecated POSIX name, Try _strnicmp instead!
+    target_compile_options(telnet PRIVATE /wd4838 /wd4996)
+endif()
+
 if (NOT MSVC)
     target_compile_definitions(telnet PRIVATE _CRT_NONSTDC_NO_DEPRECATE)
 endif()

--- a/base/applications/sndvol32/dialog.c
+++ b/base/applications/sndvol32/dialog.c
@@ -338,7 +338,7 @@ LoadDialog(
     LPWORD Offset;
     WORD FontSize;
     WCHAR FontName[100];
-    WORD Length;
+    SIZE_T Length;
     int width;
 
     DWORD units = GetDialogBaseUnits();

--- a/base/services/nfsd/CMakeLists.txt
+++ b/base/services/nfsd/CMakeLists.txt
@@ -50,7 +50,7 @@ add_executable(nfsd ${SOURCE} nfsd.rc)
 
 if(MSVC AND (NOT USE_CLANG_CL))
     # Disable warning C4477 (printf format warnings)
-    remove_target_compile_option(nfsd "/we4477")
+    target_compile_options(nfsd PRIVATE /wd4477)
 else()
     # FIXME: Tons of warnings.
     target_compile_options(nfsd PRIVATE "-w")

--- a/base/services/tftpd/CMakeLists.txt
+++ b/base/services/tftpd/CMakeLists.txt
@@ -4,6 +4,11 @@ set_module_type(tftpd win32cui)
 add_importlibs(tftpd advapi32 ws2_32 iphlpapi msvcrt kernel32)
 add_cd_file(TARGET tftpd DESTINATION reactos/system32 FOR all)
 
+if (MSVC)
+    # Disable warning C4267: 'initializing': conversion from 'size_t' to 'unsigned short', possible loss of data
+    target_compile_options(tftpd PRIVATE /wd4267)
+endif()
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(tftpd PRIVATE -Wno-format-overflow)
 endif()

--- a/base/services/wkssvc/wkssvc.c
+++ b/base/services/wkssvc/wkssvc.c
@@ -73,7 +73,8 @@ static
 DWORD
 ServiceInit(VOID)
 {
-    LSA_STRING ProcessName, PackageName;
+    LSA_STRING ProcessName = RTL_CONSTANT_STRING("Workstation");
+    LSA_STRING PackageName = RTL_CONSTANT_STRING(MSV1_0_PACKAGE_NAME);
     LSA_OPERATIONAL_MODE Mode;
     HANDLE hThread;
     NTSTATUS Status;
@@ -84,10 +85,6 @@ ServiceInit(VOID)
     VersionInfo.dwOSVersionInfoSize = sizeof(VersionInfo);
     GetVersionExW(&VersionInfo);
 
-    ProcessName.Buffer = "Workstation";
-    ProcessName.Length = strlen(ProcessName.Buffer);
-    ProcessName.MaximumLength = ProcessName.Length + 1;
-
     Status = LsaRegisterLogonProcess(&ProcessName,
                                      &LsaHandle,
                                      &Mode);
@@ -96,10 +93,6 @@ ServiceInit(VOID)
         ERR("LsaRegisterLogonProcess() failed! (Status 0x%08lx)\n", Status);
         return 1;
     }
-
-    PackageName.Buffer = MSV1_0_PACKAGE_NAME;
-    PackageName.Length = strlen(PackageName.Buffer);
-    PackageName.MaximumLength = PackageName.Length + 1;
 
     Status = LsaLookupAuthenticationPackage(LsaHandle,
                                             &PackageName,

--- a/base/setup/lib/utils/osdetect.c
+++ b/base/setup/lib/utils/osdetect.c
@@ -320,7 +320,7 @@ CheckForValidPEAndVendor(
 
             RtlStringCbCopyNW(VendorName->Buffer, VendorName->MaximumLength,
                               pvData, BufLen * sizeof(WCHAR));
-            VendorName->Length = wcslen(VendorName->Buffer) * sizeof(WCHAR);
+            VendorName->Length = (USHORT)wcslen(VendorName->Buffer) * sizeof(WCHAR);
 
             Success = TRUE;
         }

--- a/base/setup/lib/utils/regutil.c
+++ b/base/setup/lib/utils/regutil.c
@@ -78,7 +78,7 @@ CreateNestedKey(PHANDLE KeyHandle,
             break;
         }
         *Ptr = (WCHAR)0;
-        LocalKeyName.Length = wcslen(LocalKeyName.Buffer) * sizeof(WCHAR);
+        LocalKeyName.Length = (Ptr - LocalKeyName.Buffer) * sizeof(WCHAR);
 
         Status = NtCreateKey(&LocalKeyHandle,
                              KEY_CREATE_SUB_KEY,
@@ -110,7 +110,7 @@ CreateNestedKey(PHANDLE KeyHandle,
         NtClose(LocalKeyHandle);
 
         LocalKeyName.Buffer[LocalKeyName.Length / sizeof(WCHAR)] = L'\\';
-        LocalKeyName.Length = wcslen(LocalKeyName.Buffer) * sizeof(WCHAR);
+        LocalKeyName.Length = (USHORT)wcslen(LocalKeyName.Buffer) * sizeof(WCHAR);
 
         Status = NtCreateKey(&LocalKeyHandle,
                              KEY_ALL_ACCESS,

--- a/base/setup/usetup/cmdcons.c
+++ b/base/setup/usetup/cmdcons.c
@@ -1026,7 +1026,7 @@ ReadCommand(
             {
                 /* If this character insertion will cause screen scrolling,
                  * adjust the saved origin of the command prompt. */
-                tempscreen = strlen(str + current) + curx;
+                tempscreen = (USHORT)strlen(str + current) + curx;
                 if ((tempscreen % State->maxx) == (State->maxx - 1) &&
                     (tempscreen / State->maxx) + cury == (State->maxy - 1))
                 {

--- a/base/setup/usetup/mui.c
+++ b/base/setup/usetup/mui.c
@@ -140,7 +140,7 @@ MUIClearPage(
         CONSOLE_ClearStyledText(entry[index].X,
                                 entry[index].Y,
                                 entry[index].Flags,
-                                strlen(entry[index].Buffer));
+                                (USHORT)strlen(entry[index].Buffer));
         index++;
     }
 }
@@ -347,7 +347,7 @@ MUIClearText(
         CONSOLE_ClearTextXY(
             entry[Index].X,
             entry[Index].Y,
-            (ULONG)strlen(entry[Index].Buffer));
+            (USHORT)strlen(entry[Index].Buffer));
 
         /* Increment the index and loop over next entires with the same ID */
         Index++;
@@ -404,7 +404,7 @@ MUIClearStyledText(
             entry[Index].X,
             entry[Index].Y,
             Flags,
-            (ULONG)strlen(entry[Index].Buffer));
+            (USHORT)strlen(entry[Index].Buffer));
 
         /* Increment the index and loop over next entires with the same ID */
         Index++;

--- a/base/setup/usetup/progress.c
+++ b/base/setup/usetup/progress.c
@@ -240,7 +240,7 @@ DrawProgressBar(
     if (Bar->UpdateProgressProc &&
         Bar->UpdateProgressProc(Bar, TRUE, TextBuffer, ARRAYSIZE(TextBuffer)))
     {
-        coPos.X = Bar->Left + (Bar->Width - strlen(TextBuffer) + 1) / 2;
+        coPos.X = Bar->Left + (Bar->Width - (USHORT)strlen(TextBuffer) + 1) / 2;
         coPos.Y = Bar->Top;
         WriteConsoleOutputCharacterA(StdOutput,
                                      TextBuffer,
@@ -383,7 +383,7 @@ ProgressSetStep(
     if (Bar->UpdateProgressProc &&
         Bar->UpdateProgressProc(Bar, FALSE, TextBuffer, ARRAYSIZE(TextBuffer)))
     {
-        coPos.X = Bar->Left + (Bar->Width - strlen(TextBuffer) + 1) / 2;
+        coPos.X = Bar->Left + (Bar->Width - (USHORT)strlen(TextBuffer) + 1) / 2;
         coPos.Y = Bar->Top;
         WriteConsoleOutputCharacterA(StdOutput,
                                      TextBuffer,

--- a/base/setup/usetup/spapisup/cabinet.c
+++ b/base/setup/usetup/spapisup/cabinet.c
@@ -981,6 +981,7 @@ CabinetExtractFile(
     PCFFOLDER CurrentFolder;
     LARGE_INTEGER MaxDestFileSize;
     LONG InputLength, OutputLength;
+    SIZE_T StringLength;
     char Chunk[512];
 
     if (wcscmp(Search->Cabinet, CabinetContext->CabinetName) != 0)
@@ -1039,8 +1040,9 @@ CabinetExtractFile(
     {
         RtlInitAnsiString(&AnsiString, Search->File->FileName);
         wcscpy(DestName, CabinetContext->DestPath);
-        UnicodeString.MaximumLength = sizeof(DestName) - wcslen(DestName) * sizeof(WCHAR);
-        UnicodeString.Buffer = DestName + wcslen(DestName);
+        StringLength = wcslen(DestName);
+        UnicodeString.MaximumLength = sizeof(DestName) - (USHORT)StringLength * sizeof(WCHAR);
+        UnicodeString.Buffer = DestName + StringLength;
         UnicodeString.Length = 0;
         RtlAnsiStringToUnicodeString(&UnicodeString, &AnsiString, FALSE);
 

--- a/base/setup/usetup/spapisup/cabinet.c
+++ b/base/setup/usetup/spapisup/cabinet.c
@@ -628,6 +628,7 @@ CabinetOpen(
     OBJECT_ATTRIBUTES ObjectAttributes;
     IO_STATUS_BLOCK IoStatusBlock;
     UNICODE_STRING FileName;
+    USHORT StringLength;
     NTSTATUS NtStatus;
 
     if (CabinetContext->FileOpen)
@@ -732,11 +733,14 @@ CabinetOpen(
            the same directory as the current */
         wcscpy(CabinetContext->CabinetPrev, CabinetContext->CabinetName);
         RemoveFileName(CabinetContext->CabinetPrev);
-        CabinetNormalizePath(CabinetContext->CabinetPrev, 256);
+        CabinetNormalizePath(CabinetContext->CabinetPrev, sizeof(CabinetContext->CabinetPrev));
         RtlInitAnsiString(&astring, (LPSTR)Buffer);
-        ustring.Length = wcslen(CabinetContext->CabinetPrev);
-        ustring.Buffer = CabinetContext->CabinetPrev + ustring.Length;
-        ustring.MaximumLength = sizeof(CabinetContext->CabinetPrev) - ustring.Length;
+
+        /* Initialize ustring with the remaining buffer */
+        StringLength = (USHORT)wcslen(CabinetContext->CabinetPrev) * sizeof(WCHAR);
+        ustring.Buffer = CabinetContext->CabinetPrev + StringLength;
+        ustring.MaximumLength = sizeof(CabinetContext->CabinetPrev) - StringLength;
+        ustring.Length = 0;
         RtlAnsiStringToUnicodeString(&ustring, &astring, FALSE);
         Buffer += astring.Length + 1;
 
@@ -762,9 +766,12 @@ CabinetOpen(
         RemoveFileName(CabinetContext->CabinetNext);
         CabinetNormalizePath(CabinetContext->CabinetNext, 256);
         RtlInitAnsiString(&astring, (LPSTR)Buffer);
-        ustring.Length = wcslen(CabinetContext->CabinetNext);
-        ustring.Buffer = CabinetContext->CabinetNext + ustring.Length;
-        ustring.MaximumLength = sizeof(CabinetContext->CabinetNext) - ustring.Length;
+
+        /* Initialize ustring with the remaining buffer */
+        StringLength = (USHORT)wcslen(CabinetContext->CabinetNext) * sizeof(WCHAR);
+        ustring.Buffer = CabinetContext->CabinetNext + StringLength;
+        ustring.MaximumLength = sizeof(CabinetContext->CabinetNext) - StringLength;
+        ustring.Length = 0;
         RtlAnsiStringToUnicodeString(&ustring, &astring, FALSE);
         Buffer += astring.Length + 1;
 

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -1907,7 +1907,7 @@ ShowPartitionSizeInputBox(SHORT Left,
     coPos.X = Left + 2;
     coPos.Y = Top + 2;
     strcpy(Buffer, MUIGetString(STRING_PARTITIONSIZE));
-    iLeft = coPos.X + strlen(Buffer) + 1;
+    iLeft = coPos.X + (USHORT)strlen(Buffer) + 1;
     iTop = coPos.Y;
 
     WriteConsoleOutputCharacterA(StdOutput,

--- a/base/shell/cmd/cmdinput.c
+++ b/base/shell/cmd/cmdinput.c
@@ -96,7 +96,7 @@
  *    30-Apr-2004 (Filip Navara <xnavara@volny.cz>)
  *        Fixed problems when the screen was scrolled away.
  *
- *    28-September-2007 (Hervé Poussineau)
+ *    28-September-2007 (HervÃ© Poussineau)
  *        Added history possibilities to right key.
  */
 
@@ -142,7 +142,7 @@ BOOL ReadCommand(LPTSTR str, INT maxlen)
     SHORT orgy;
     SHORT curx;     /*current x/y cursor position*/
     SHORT cury;
-    SHORT tempscreen;
+    SIZE_T tempscreen;
     INT   count;    /*used in some for loops*/
     INT   current = 0;  /*the position of the cursor in the string (str)*/
     INT   charcount = 0;/*chars in the string (str)*/

--- a/base/system/services/config.c
+++ b/base/system/services/config.c
@@ -476,8 +476,15 @@ ScmSetServicePassword(
     UNICODE_STRING Password;
     NTSTATUS Status;
     DWORD dwError = ERROR_SUCCESS;
+    SIZE_T ServiceNameLength;
 
     RtlZeroMemory(&ObjectAttributes, sizeof(OBJECT_ATTRIBUTES));
+
+    ServiceNameLength = wcslen(pszServiceName);
+    if (ServiceNameLength > (UNICODE_STRING_MAX_CHARS - 4))
+    {
+        return ERROR_INVALID_PARAMETER;
+    }
 
     Status = LsaOpenPolicy(NULL,
                            &ObjectAttributes,
@@ -486,7 +493,7 @@ ScmSetServicePassword(
     if (!NT_SUCCESS(Status))
         return RtlNtStatusToDosError(Status);
 
-    ServiceName.Length = (wcslen(pszServiceName) + 4) * sizeof(WCHAR);
+    ServiceName.Length = ((USHORT)ServiceNameLength + 4) * sizeof(WCHAR);
     ServiceName.MaximumLength = ServiceName.Length + sizeof(WCHAR);
     ServiceName.Buffer = HeapAlloc(GetProcessHeap(),
                                    HEAP_ZERO_MEMORY,

--- a/dll/3rdparty/libtirpc/CMakeLists.txt
+++ b/dll/3rdparty/libtirpc/CMakeLists.txt
@@ -94,14 +94,10 @@ add_library(libtirpc MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/libtirpc.def)
 
 if(MSVC)
-    # error C4133: '=': incompatible types - from 'char *' to 'int32_t *'
-    remove_target_compile_option(libtirpc "/we4133")
-    # Disable warning C4313 (format string conflicts)
-    remove_target_compile_option(libtirpc "/we4313")
-    # Disable warning C4477 (printf format warnings)
-    remove_target_compile_option(libtirpc "/we4477")
+    # Disable warning C4273: 'strtok_s': inconsistent dll linkage
+    # Disable warning C4313: 'fprintf': '%x' in format string conflicts with argument 2 of type 'HANDLE'
+    target_compile_options(libtirpc PRIVATE /wd4273 /wd4313)
     if (NOT USE_CLANG_CL)
-        remove_target_compile_option(libtirpc "/we4101")
         target_compile_options(libtirpc PRIVATE /wd4101 /wd4133 /wd4473 /wd4477)
     endif()
 else()

--- a/dll/directx/wine/CMakeLists.txt
+++ b/dll/directx/wine/CMakeLists.txt
@@ -1,4 +1,10 @@
 
+if (MSVC)
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    add_compile_options(/wd4090 /wd4146)
+endif()
+
 add_subdirectory(amstream)
 add_subdirectory(d3d8)
 add_subdirectory(d3d9)

--- a/dll/win32/aclui/sidcache.c
+++ b/dll/win32/aclui/sidcache.c
@@ -176,11 +176,18 @@ OpenLSAPolicyHandle(IN LPWSTR SystemName,
     LSA_OBJECT_ATTRIBUTES LsaObjectAttributes = {0};
     LSA_UNICODE_STRING LsaSystemName, *psn;
     NTSTATUS Status;
+    SIZE_T NameLength;
 
     if (SystemName != NULL && SystemName[0] != L'\0')
     {
+        NameLength = wcslen(SystemName);
+        if (NameLength > UNICODE_STRING_MAX_CHARS)
+        {
+            return FALSE;
+        }
+
         LsaSystemName.Buffer = SystemName;
-        LsaSystemName.Length = wcslen(SystemName) * sizeof(WCHAR);
+        LsaSystemName.Length = NameLength * sizeof(WCHAR);
         LsaSystemName.MaximumLength = LsaSystemName.Length + sizeof(WCHAR);
         psn = &LsaSystemName;
     }

--- a/dll/win32/advapi32/misc/hwprofiles.c
+++ b/dll/win32/advapi32/misc/hwprofiles.c
@@ -42,8 +42,8 @@ GetCurrentHwProfileA(LPHW_PROFILE_INFOA lpHwProfileInfo)
     lpHwProfileInfo->dwDockInfo = ProfileInfo.dwDockInfo;
 
     /* Convert the profile GUID to ANSI */
-    StringU.Buffer = (PWCHAR)ProfileInfo.szHwProfileGuid;
-    StringU.Length = wcslen(ProfileInfo.szHwProfileGuid) * sizeof(WCHAR);
+    StringU.Buffer = ProfileInfo.szHwProfileGuid;
+    StringU.Length = (USHORT)wcslen(ProfileInfo.szHwProfileGuid) * sizeof(WCHAR);
     StringU.MaximumLength = HW_PROFILE_GUIDLEN * sizeof(WCHAR);
     StringA.Buffer = (PCHAR)&lpHwProfileInfo->szHwProfileGuid;
     StringA.Length = 0;
@@ -58,8 +58,8 @@ GetCurrentHwProfileA(LPHW_PROFILE_INFOA lpHwProfileInfo)
     }
 
     /* Convert the profile name to ANSI */
-    StringU.Buffer = (PWCHAR)ProfileInfo.szHwProfileName;
-    StringU.Length = wcslen(ProfileInfo.szHwProfileName) * sizeof(WCHAR);
+    StringU.Buffer = ProfileInfo.szHwProfileName;
+    StringU.Length = (USHORT)wcslen(ProfileInfo.szHwProfileName) * sizeof(WCHAR);
     StringU.MaximumLength = MAX_PROFILE_LEN * sizeof(WCHAR);
     StringA.Buffer = (PCHAR)&lpHwProfileInfo->szHwProfileName;
     StringA.Length = 0;

--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -961,7 +961,7 @@ CreateNestedKey(PHKEY KeyHandle,
         }
 
         *Ptr = (WCHAR)0;
-        LocalKeyName.Length = wcslen(LocalKeyName.Buffer) * sizeof(WCHAR);
+        LocalKeyName.Length = (USHORT)wcslen(LocalKeyName.Buffer) * sizeof(WCHAR);
 
         Status = NtCreateKey(&LocalKeyHandle,
                              KEY_CREATE_SUB_KEY,

--- a/dll/win32/avifil32/CMakeLists.txt
+++ b/dll/win32/avifil32/CMakeLists.txt
@@ -30,6 +30,11 @@ add_library(avifil32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/proxy.dlldata.c
     ${CMAKE_CURRENT_BINARY_DIR}/avifil32.def)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    target_compile_options(avifil32 PRIVATE /wd4146)
+endif()
+
 set_module_type(avifil32 win32dll)
 target_link_libraries(avifil32 wine ${PSEH_LIB})
 add_importlibs(avifil32 msacm32 msvfw32 winmm ole32 user32 advapi32 rpcrt4 msvcrt kernel32 ntdll)

--- a/dll/win32/comctl32/CMakeLists.txt
+++ b/dll/win32/comctl32/CMakeLists.txt
@@ -65,8 +65,10 @@ add_library(comctl32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/comctl32.def)
 
 if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # Disable warning C4267: '=': conversion from 'size_t' to 'WORD', possible loss of data
     # Disable warning C4477 (printf format warnings)
-    remove_target_compile_option(comctl32 "/we4477")
+    target_compile_options(comctl32 PRIVATE /wd4146 /wd4267 /wd4477)
 endif()
 
 set_module_type(comctl32 win32dll UNICODE)

--- a/dll/win32/crypt32/CMakeLists.txt
+++ b/dll/win32/crypt32/CMakeLists.txt
@@ -47,8 +47,9 @@ add_library(crypt32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/crypt32.def)
 
 if(MSVC)
-    # error C4312: 'type cast': conversion from 'unsigned int' to 'void *' of greater size
-    remove_target_compile_option(crypt32 "/we4312")
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    # Disable warning C4312: 'type cast': conversion from 'unsigned int' to 'void *' of greater size
+    target_compile_options(crypt32 PRIVATE /wd4090 /wd4312)
 endif()
 
 set_module_type(crypt32 win32dll)

--- a/dll/win32/dbghelp/CMakeLists.txt
+++ b/dll/win32/dbghelp/CMakeLists.txt
@@ -81,7 +81,8 @@ else()
     add_cd_file(TARGET dbghelp DESTINATION reactos/system32 FOR all)
 
     if(MSVC)
+        # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
         # Disable warning C4477 (printf format warnings)
-        remove_target_compile_option(dbghelp "/we4477")
+        target_compile_options(dbghelp PRIVATE /wd4146 /wd4477)
     endif()
 endif()

--- a/dll/win32/gdiplus/CMakeLists.txt
+++ b/dll/win32/gdiplus/CMakeLists.txt
@@ -33,6 +33,12 @@ add_library(gdiplus MODULE
     gdiplus.rc
     ${CMAKE_CURRENT_BINARY_DIR}/gdiplus.def)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # Disable warning C4305: '=': truncation from 'double' to 'REAL'
+    target_compile_options(gdiplus PRIVATE /wd4146 /wd4305)
+endif()
+
 set_module_type(gdiplus win32dll)
 target_link_libraries(gdiplus wine)
 add_delay_importlibs(gdiplus windowscodecs)

--- a/dll/win32/jscript/CMakeLists.txt
+++ b/dll/win32/jscript/CMakeLists.txt
@@ -55,6 +55,12 @@ add_library(jscript MODULE
     rsrc.rc
     ${CMAKE_CURRENT_BINARY_DIR}/jscript.def)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # Disable warning C4267: '=': conversion from 'size_t' to 'WCHAR', possible loss of data
+    target_compile_options(jscript PRIVATE /wd4146 /wd4267)
+endif()
+
 add_idl_headers(jscript_idlheader jscript_classes.idl)
 add_typelib(jsglobal.idl)
 add_dependencies(jscript jscript_idlheader stdole2)

--- a/dll/win32/kernel32/CMakeLists.txt
+++ b/dll/win32/kernel32/CMakeLists.txt
@@ -93,6 +93,11 @@ list(APPEND SOURCE
     winnls/string/sortkey.c
     k32.h)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    set_source_files_properties(wine/res.c PROPERTIES COMPILE_FLAGS /wd4146)
+endif()
+
 if(ARCH STREQUAL "i386")
     list(APPEND ASM_SOURCE
         client/i386/fiber.S

--- a/dll/win32/kernel32/client/vdm.c
+++ b/dll/win32/kernel32/client/vdm.c
@@ -105,7 +105,7 @@ BaseCheckVDM(IN ULONG BinaryType,
     PWCHAR CurrentDir = NULL;
     PWCHAR ShortAppName = NULL;
     PWCHAR ShortCurrentDir = NULL;
-    ULONG Length;
+    SIZE_T Length;
     PCHAR AnsiCmdLine = NULL;
     PCHAR AnsiAppName = NULL;
     PCHAR AnsiCurDirectory = NULL;
@@ -283,16 +283,24 @@ BaseCheckVDM(IN ULONG BinaryType,
         goto Cleanup;
     }
 
+    /* Make sure that the command line isn't too long */
+    Length = wcslen(CommandLine);
+    if (Length > UNICODE_STRING_MAX_CHARS - 1)
+    {
+        Status = STATUS_INVALID_PARAMETER;
+        goto Cleanup;
+    }
+
     /* Setup the input parameters */
     CheckVdm->ConsoleHandle = NtCurrentPeb()->ProcessParameters->ConsoleHandle;
     CheckVdm->BinaryType = BinaryType;
     CheckVdm->CodePage = CP_ACP;
     CheckVdm->dwCreationFlags = CreationFlags;
     CheckVdm->CurDrive = CurrentDirectory[0] - L'A';
-    CheckVdm->CmdLen = wcslen(CommandLine) + 1;
-    CheckVdm->AppLen = wcslen(ShortAppName) + 1;
+    CheckVdm->CmdLen = (USHORT)Length + 1;
+    CheckVdm->AppLen = (USHORT)wcslen(ShortAppName) + 1;
     CheckVdm->PifLen = 0; // TODO: PIF file support!
-    CheckVdm->CurDirectoryLen = wcslen(ShortCurrentDir) + 1;
+    CheckVdm->CurDirectoryLen = (USHORT)wcslen(ShortCurrentDir) + 1;
     CheckVdm->EnvLen = AnsiEnvironment->Length;
     CheckVdm->DesktopLen = (StartupInfo->lpDesktop != NULL) ? (wcslen(StartupInfo->lpDesktop) + 1) : 0;
     CheckVdm->TitleLen = (StartupInfo->lpTitle != NULL) ? (wcslen(StartupInfo->lpTitle) + 1) : 0;

--- a/dll/win32/lsasrv/lookup.c
+++ b/dll/win32/lsasrv/lookup.c
@@ -96,8 +96,17 @@ LsapCreateSid(PSID_IDENTIFIER_AUTHORITY IdentifierAuthority,
               PSID *SidPtr)
 {
     PWELL_KNOWN_SID SidEntry;
+    SIZE_T AccountNameLength, DomainNameLength;
     PULONG p;
     ULONG i;
+
+    AccountNameLength = wcslen(AccountName);
+    DomainNameLength = wcslen(DomainName);
+    if ((AccountNameLength > UNICODE_STRING_MAX_CHARS) ||
+        (DomainNameLength > UNICODE_STRING_MAX_CHARS))
+    {
+        return FALSE;
+    }
 
     SidEntry = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WELL_KNOWN_SID));
     if (SidEntry == NULL)
@@ -126,7 +135,7 @@ LsapCreateSid(PSID_IDENTIFIER_AUTHORITY IdentifierAuthority,
 
 //    RtlInitUnicodeString(&SidEntry->AccountName,
 //                         AccountName);
-    SidEntry->AccountName.Length = wcslen(AccountName) * sizeof(WCHAR);
+    SidEntry->AccountName.Length = (USHORT)AccountNameLength * sizeof(WCHAR);
     SidEntry->AccountName.MaximumLength = SidEntry->AccountName.Length + sizeof(WCHAR);
     SidEntry->AccountName.Buffer = RtlAllocateHeap(RtlGetProcessHeap(), 0,
                                                    SidEntry->AccountName.MaximumLength);
@@ -142,7 +151,7 @@ LsapCreateSid(PSID_IDENTIFIER_AUTHORITY IdentifierAuthority,
 
 //    RtlInitUnicodeString(&SidEntry->DomainName,
 //                         DomainName);
-    SidEntry->DomainName.Length = wcslen(DomainName) * sizeof(WCHAR);
+    SidEntry->DomainName.Length = (USHORT)DomainNameLength * sizeof(WCHAR);
     SidEntry->DomainName.MaximumLength = SidEntry->DomainName.Length + sizeof(WCHAR);
     SidEntry->DomainName.Buffer = RtlAllocateHeap(RtlGetProcessHeap(), 0,
                                                   SidEntry->DomainName.MaximumLength);

--- a/dll/win32/lsasrv/privileges.c
+++ b/dll/win32/lsasrv/privileges.c
@@ -99,7 +99,7 @@ LsarpLookupPrivilegeName(PLUID Value,
             if (NameBuffer == NULL)
                 return STATUS_NO_MEMORY;
 
-            NameBuffer->Length = wcslen(WellKnownPrivileges[Priv].Name) * sizeof(WCHAR);
+            NameBuffer->Length = (USHORT)wcslen(WellKnownPrivileges[Priv].Name) * sizeof(WCHAR);
             NameBuffer->MaximumLength = NameBuffer->Length + sizeof(WCHAR);
 
             NameBuffer->Buffer = MIDL_user_allocate(NameBuffer->MaximumLength);
@@ -354,7 +354,7 @@ LsapLookupAccountRightName(ULONG RightValue,
             if (NameBuffer == NULL)
                 return STATUS_NO_MEMORY;
 
-            NameBuffer->Length = wcslen(WellKnownRights[i].Name) * sizeof(WCHAR);
+            NameBuffer->Length = (USHORT)wcslen(WellKnownRights[i].Name) * sizeof(WCHAR);
             NameBuffer->MaximumLength = NameBuffer->Length + sizeof(WCHAR);
 
             NameBuffer->Buffer = MIDL_user_allocate(NameBuffer->MaximumLength);

--- a/dll/win32/mciseq/CMakeLists.txt
+++ b/dll/win32/mciseq/CMakeLists.txt
@@ -13,6 +13,9 @@ target_link_libraries(mciseq wine)
 add_importlibs(mciseq winmm user32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET mciseq DESTINATION reactos/system32 FOR all)
 
-if(NOT MSVC)
+if(MSVC)
+    # Disable warning C4305: '=': truncation from 'UINT' to 'WORD'
+    target_compile_options(mciseq PRIVATE /wd4305)
+else()
     target_compile_options(mciseq PRIVATE "-Wno-overflow")
 endif()

--- a/dll/win32/mciwave/CMakeLists.txt
+++ b/dll/win32/mciwave/CMakeLists.txt
@@ -16,6 +16,9 @@ target_link_libraries(mciwave wine)
 add_importlibs(mciwave user32 winmm msvcrt kernel32 ntdll)
 add_cd_file(TARGET mciwave DESTINATION reactos/system32 FOR all)
 
-if(NOT MSVC)
+if(MSVC)
+    # Disable warning C4305: '=': truncation from 'UINT' to 'WORD'
+    target_compile_options(mciwave PRIVATE /wd4305)
+else()
     target_compile_options(mciwave PRIVATE "-Wno-overflow")
 endif()

--- a/dll/win32/msgina/gui.c
+++ b/dll/win32/msgina/gui.c
@@ -580,7 +580,7 @@ DoChangePassword(
     Ptr = (LPWSTR)((ULONG_PTR)RequestBuffer + sizeof(MSV1_0_CHANGEPASSWORD_REQUEST));
 
     /* Pack the domain name */
-    RequestBuffer->DomainName.Length = wcslen(Domain) * sizeof(WCHAR);
+    RequestBuffer->DomainName.Length = (USHORT)wcslen(Domain) * sizeof(WCHAR);
     RequestBuffer->DomainName.MaximumLength = RequestBuffer->DomainName.Length + sizeof(WCHAR);
     RequestBuffer->DomainName.Buffer = Ptr;
 
@@ -591,7 +591,7 @@ DoChangePassword(
     Ptr = (LPWSTR)((ULONG_PTR)Ptr + RequestBuffer->DomainName.MaximumLength);
 
     /* Pack the user name */
-    RequestBuffer->AccountName.Length = wcslen(UserName) * sizeof(WCHAR);
+    RequestBuffer->AccountName.Length = (USHORT)wcslen(UserName) * sizeof(WCHAR);
     RequestBuffer->AccountName.MaximumLength = RequestBuffer->AccountName.Length + sizeof(WCHAR);
     RequestBuffer->AccountName.Buffer = Ptr;
 
@@ -602,7 +602,7 @@ DoChangePassword(
     Ptr = (LPWSTR)((ULONG_PTR)Ptr + RequestBuffer->AccountName.MaximumLength);
 
     /* Pack the old password */
-    RequestBuffer->OldPassword.Length = wcslen(OldPassword) * sizeof(WCHAR);
+    RequestBuffer->OldPassword.Length = (USHORT)wcslen(OldPassword) * sizeof(WCHAR);
     RequestBuffer->OldPassword.MaximumLength = RequestBuffer->OldPassword.Length + sizeof(WCHAR);
     RequestBuffer->OldPassword.Buffer = Ptr;
 
@@ -613,7 +613,7 @@ DoChangePassword(
     Ptr = (LPWSTR)((ULONG_PTR)Ptr + RequestBuffer->OldPassword.MaximumLength);
 
     /* Pack the new password */
-    RequestBuffer->NewPassword.Length = wcslen(NewPassword1) * sizeof(WCHAR);
+    RequestBuffer->NewPassword.Length = (USHORT)wcslen(NewPassword1) * sizeof(WCHAR);
     RequestBuffer->NewPassword.MaximumLength = RequestBuffer->NewPassword.Length + sizeof(WCHAR);
     RequestBuffer->NewPassword.Buffer = Ptr;
 

--- a/dll/win32/msi/CMakeLists.txt
+++ b/dll/win32/msi/CMakeLists.txt
@@ -64,11 +64,11 @@ add_library(msi MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/msi.def)
 
 if(MSVC)
-    #  error C4133: 'function': incompatible types - from 'UINT *' to 'MSIINSTALLCONTEXT *'
-    remove_target_compile_option(msi "/we4133")
-
-    # error C4312: 'type cast': conversion from 'unsigned int' to 'HANDLE' of greater size
-    remove_target_compile_option(msi "/we4312")
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    # Disable warning C4133: 'function': incompatible types - from 'UINT *' to 'MSIINSTALLCONTEXT *'
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # Disable warning C4312: 'type cast': conversion from 'unsigned int' to 'HANDLE' of greater size
+    target_compile_options(msi PRIVATE /wd4090 /wd4133 /wd4146 /wd4312)
 endif()
 
 add_idl_headers(msi_idlheader msiserver.idl)

--- a/dll/win32/msv1_0/msv1_0.c
+++ b/dll/win32/msv1_0/msv1_0.c
@@ -102,10 +102,16 @@ BuildInteractiveProfileBuffer(IN PLSA_CLIENT_REQUEST ClientRequest,
     PVOID ClientBaseAddress = NULL;
     LPWSTR Ptr;
     ULONG BufferLength;
+    USHORT ComputerNameLength;
     NTSTATUS Status = STATUS_SUCCESS;
 
     *ProfileBuffer = NULL;
     *ProfileBufferLength = 0;
+
+    if (UIntPtrToUShort(wcslen(ComputerName), &ComputerNameLength) != S_OK)
+    {
+        return STATUS_INVALID_PARAMETER;
+    }
 
     BufferLength = sizeof(MSV1_0_INTERACTIVE_PROFILE) +
                    UserInfo->All.FullName.Length + sizeof(WCHAR) +
@@ -113,7 +119,7 @@ BuildInteractiveProfileBuffer(IN PLSA_CLIENT_REQUEST ClientRequest,
                    UserInfo->All.HomeDirectoryDrive.Length + sizeof(WCHAR) +
                    UserInfo->All.ScriptPath.Length + sizeof(WCHAR) +
                    UserInfo->All.ProfilePath.Length + sizeof(WCHAR) +
-                   ((wcslen(ComputerName) + 3) * sizeof(WCHAR));
+                   ((ComputerNameLength + 3) * sizeof(WCHAR));
 
     LocalBuffer = DispatchTable.AllocateLsaHeap(BufferLength);
     if (LocalBuffer == NULL)
@@ -204,7 +210,7 @@ BuildInteractiveProfileBuffer(IN PLSA_CLIENT_REQUEST ClientRequest,
 
     Ptr = (LPWSTR)((ULONG_PTR)Ptr + LocalBuffer->HomeDirectoryDrive.MaximumLength);
 
-    LocalBuffer->LogonServer.Length = (wcslen(ComputerName) + 2) * sizeof(WCHAR);
+    LocalBuffer->LogonServer.Length = (ComputerNameLength + 2) * sizeof(WCHAR);
     LocalBuffer->LogonServer.MaximumLength = LocalBuffer->LogonServer.Length + sizeof(WCHAR);
     LocalBuffer->LogonServer.Buffer = (LPWSTR)((ULONG_PTR)ClientBaseAddress + (ULONG_PTR)Ptr - (ULONG_PTR)LocalBuffer);
     wcscpy(Ptr, L"\\");

--- a/dll/win32/msv1_0/precomp.h
+++ b/dll/win32/msv1_0/precomp.h
@@ -8,6 +8,7 @@
 #include <windef.h>
 #include <winbase.h>
 #include <winreg.h>
+#include <intsafe.h>
 #define NTOS_MODE_USER
 #include <ndk/cmfuncs.h>
 #include <ndk/kefuncs.h>

--- a/dll/win32/msxml3/CMakeLists.txt
+++ b/dll/win32/msxml3/CMakeLists.txt
@@ -76,6 +76,9 @@ target_link_libraries(msxml3 libxml2 iconv-static uuid wine zlib)
 
 if(MSVC)
     target_compile_options(msxml3 PRIVATE /FIwine/typeof.h /FImsvc.h)
+
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    target_compile_options(msxml3 PRIVATE /wd4090)
 endif()
 
 add_importlibs(msxml3 urlmon ws2_32 shlwapi oleaut32 ole32 user32 msvcrt kernel32 ntdll)

--- a/dll/win32/netapi32/CMakeLists.txt
+++ b/dll/win32/netapi32/CMakeLists.txt
@@ -58,3 +58,8 @@ add_delay_importlibs(netapi32 samlib secur32)
 add_importlibs(netapi32 iphlpapi ws2_32 advapi32 rpcrt4 msvcrt kernel32 ntdll)
 add_pch(netapi32 netapi32.h "${PCH_SKIP_SOURCE}")
 add_cd_file(TARGET netapi32 DESTINATION reactos/system32 FOR all)
+
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
+    target_compile_options(netapi32 PRIVATE /wd4267)
+endif()

--- a/dll/win32/ntmarta/ntmarta.c
+++ b/dll/win32/ntmarta/ntmarta.c
@@ -403,12 +403,19 @@ AccpOpenLSAPolicyHandle(IN LPWSTR SystemName,
 {
     LSA_OBJECT_ATTRIBUTES LsaObjectAttributes = {0};
     LSA_UNICODE_STRING LsaSystemName, *psn;
+    SIZE_T SystemNameLength;
     NTSTATUS Status;
 
     if (SystemName != NULL && SystemName[0] != L'\0')
     {
+        SystemNameLength = wcslen(SystemName);
+        if (SystemNameLength > UNICODE_STRING_MAX_CHARS)
+        {
+            return ERROR_INVALID_PARAMETER;
+        }
+
         LsaSystemName.Buffer = SystemName;
-        LsaSystemName.Length = wcslen(SystemName) * sizeof(WCHAR);
+        LsaSystemName.Length = (USHORT)SystemNameLength * sizeof(WCHAR);
         LsaSystemName.MaximumLength = LsaSystemName.Length + sizeof(WCHAR);
         psn = &LsaSystemName;
     }
@@ -498,10 +505,17 @@ AccpLookupSidByName(IN LSA_HANDLE PolicyHandle,
     PLSA_REFERENCED_DOMAIN_LIST ReferencedDomains = NULL;
     PLSA_TRANSLATED_SID2 TranslatedSid = NULL;
     DWORD SidLen;
+    SIZE_T NameLength;
     DWORD Ret = ERROR_SUCCESS;
 
+    NameLength = wcslen(Name);
+    if (NameLength > UNICODE_STRING_MAX_CHARS)
+    {
+        return ERROR_INVALID_PARAMETER;
+    }
+
     LsaNames[0].Buffer = Name;
-    LsaNames[0].Length = wcslen(Name) * sizeof(WCHAR);
+    LsaNames[0].Length = (USHORT)NameLength * sizeof(WCHAR);
     LsaNames[0].MaximumLength = LsaNames[0].Length + sizeof(WCHAR);
 
     Status = LsaLookupNames2(PolicyHandle,

--- a/dll/win32/ole32/CMakeLists.txt
+++ b/dll/win32/ole32/CMakeLists.txt
@@ -81,6 +81,12 @@ add_library(ole32 MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/irot_c.c
     ${CMAKE_CURRENT_BINARY_DIR}/ole32.def)
 
+if(MSVC)
+    # Disable warning C4090: '=': different 'const' qualifiers
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    target_compile_options(ole32 PRIVATE /wd4090 /wd4146)
+endif()
+
 set_module_type(ole32 win32dll)
 target_link_libraries(ole32 wine uuid ${PSEH_LIB})
 add_delay_importlibs(ole32 oleaut32)

--- a/dll/win32/oleaut32/CMakeLists.txt
+++ b/dll/win32/oleaut32/CMakeLists.txt
@@ -49,6 +49,12 @@ add_library(oleaut32 MODULE
     oleaut32.rc
     ${CMAKE_CURRENT_BINARY_DIR}/oleaut32.def)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    # Disable warning C4267: 'initializing': conversion from 'size_t' to 'BYTE', possible loss of data
+    target_compile_options(oleaut32 PRIVATE /wd4146 /wd4267)
+endif()
+
 add_idl_headers(oleaut32_idlheader oleaut32_oaidl.idl)
 add_dependencies(oleaut32 oleaut32_idlheader)
 set_module_type(oleaut32 win32dll)

--- a/dll/win32/rpcrt4/CMakeLists.txt
+++ b/dll/win32/rpcrt4/CMakeLists.txt
@@ -58,6 +58,11 @@ add_library(rpcrt4 MODULE
     rpcrt4.rc
     ${CMAKE_CURRENT_BINARY_DIR}/rpcrt4.def)
 
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to 'short', possible loss of data
+    target_compile_options(rpcrt4 PRIVATE /wd4267)
+endif()
+
 set_module_type(rpcrt4 win32dll)
 target_link_libraries(rpcrt4 wine uuid ${PSEH_LIB})
 add_delay_importlibs(rpcrt4 iphlpapi wininet secur32 user32 oleaut32)

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -784,16 +784,24 @@ HRESULT STDMETHODCALLTYPE CShellLink::Load(IStream *stm)
  */
 static HRESULT Stream_WriteString(IStream* stm, LPCWSTR str)
 {
-    USHORT len = wcslen(str) + 1; // FIXME: Possible overflows?
+    SIZE_T length;
+    USHORT len;
     DWORD count;
 
+    length = wcslen(str) + 1;
+    if (length > MAXUSHORT)
+    {
+        return E_INVALIDARG;
+    }
+
+    len = (USHORT)length;
     HRESULT hr = stm->Write(&len, sizeof(len), &count);
     if (FAILED(hr))
         return hr;
 
-    len *= sizeof(WCHAR);
+    length *= sizeof(WCHAR);
 
-    hr = stm->Write(str, len, &count);
+    hr = stm->Write(str, (ULONG)length, &count);
     if (FAILED(hr))
         return hr;
 

--- a/dll/win32/shell32/folders/CPrinterFolder.cpp
+++ b/dll/win32/shell32/folders/CPrinterFolder.cpp
@@ -102,17 +102,25 @@ static LPITEMIDLIST _ILCreatePrinterItem(PRINTER_INFO_4W *pi)
     PIDLPrinterStruct * p;
     int size0 = (char*)&tmp.u.cprinter.szName - (char*)&tmp.u.cprinter;
     int size = size0;
+    SIZE_T cchPrinterName, cchServerName;
+
+    cchPrinterName = wcslen(pi->pPrinterName);
+    cchServerName = wcslen(pi->pServerName);
+    if ((cchPrinterName + cchServerName) > (MAXUSHORT - 2))
+    {
+        return NULL;
+    }
 
     tmp.type = 0x00;
     tmp.u.cprinter.dummy = 0xFF;
     if (pi->pPrinterName)
-        tmp.u.cprinter.offsServer = wcslen(pi->pPrinterName) + 1;
+        tmp.u.cprinter.offsServer = cchPrinterName + 1;
     else
         tmp.u.cprinter.offsServer = 1;
 
     size += tmp.u.cprinter.offsServer * sizeof(WCHAR);
     if (pi->pServerName)
-        size += (wcslen(pi->pServerName) + 1) * sizeof(WCHAR);
+        size += (cchServerName + 1) * sizeof(WCHAR);
     else
         size += sizeof(WCHAR);
 

--- a/dll/win32/syssetup/security.c
+++ b/dll/win32/syssetup/security.c
@@ -38,9 +38,19 @@ SetAccountsDomainSid(
     SAM_HANDLE DomainHandle = NULL;
     DOMAIN_NAME_INFORMATION DomainNameInfo;
 
+    SIZE_T DomainNameLength = 0;
     NTSTATUS Status;
 
     DPRINT("SYSSETUP: SetAccountsDomainSid\n");
+
+    if (DomainName != NULL)
+    {
+        DomainNameLength = wcslen(DomainName);
+        if (DomainNameLength > UNICODE_STRING_MAX_CHARS)
+        {
+            return STATUS_INVALID_PARAMETER;
+        }
+    }
 
     memset(&ObjectAttributes, 0, sizeof(LSA_OBJECT_ATTRIBUTES));
     ObjectAttributes.Length = sizeof(LSA_OBJECT_ATTRIBUTES);
@@ -69,7 +79,7 @@ SetAccountsDomainSid(
         else
         {
             Info.DomainName.Buffer = (LPWSTR)DomainName;
-            Info.DomainName.Length = wcslen(DomainName) * sizeof(WCHAR);
+            Info.DomainName.Length = DomainNameLength * sizeof(WCHAR);
             Info.DomainName.MaximumLength = Info.DomainName.Length + sizeof(WCHAR);
         }
 
@@ -81,7 +91,7 @@ SetAccountsDomainSid(
     else
     {
         Info.DomainName.Buffer = (LPWSTR)DomainName;
-        Info.DomainName.Length = wcslen(DomainName) * sizeof(WCHAR);
+        Info.DomainName.Length = DomainNameLength * sizeof(WCHAR);
         Info.DomainName.MaximumLength = Info.DomainName.Length + sizeof(WCHAR);
         Info.DomainSid = DomainSid;
     }
@@ -99,7 +109,7 @@ SetAccountsDomainSid(
 
     LsaClose(PolicyHandle);
 
-    DomainNameInfo.DomainName.Length = wcslen(DomainName) * sizeof(WCHAR);
+    DomainNameInfo.DomainName.Length = DomainNameLength * sizeof(WCHAR);
     DomainNameInfo.DomainName.MaximumLength = DomainNameInfo.DomainName.Length + sizeof(WCHAR);
     DomainNameInfo.DomainName.Buffer = (LPWSTR)DomainName;
 
@@ -147,9 +157,19 @@ SetPrimaryDomain(LPCWSTR DomainName,
     POLICY_PRIMARY_DOMAIN_INFO Info;
     LSA_OBJECT_ATTRIBUTES ObjectAttributes;
     LSA_HANDLE PolicyHandle;
+    SIZE_T DomainNameLength = 0;
     NTSTATUS Status;
 
     DPRINT1("SYSSETUP: SetPrimaryDomain()\n");
+
+    if (DomainName != NULL)
+    {
+        DomainNameLength = wcslen(DomainName);
+        if (DomainNameLength > UNICODE_STRING_MAX_CHARS)
+        {
+            return STATUS_INVALID_PARAMETER;
+        }
+    }
 
     memset(&ObjectAttributes, 0, sizeof(LSA_OBJECT_ATTRIBUTES));
     ObjectAttributes.Length = sizeof(LSA_OBJECT_ATTRIBUTES);
@@ -178,7 +198,7 @@ SetPrimaryDomain(LPCWSTR DomainName,
         else
         {
             Info.Name.Buffer = (LPWSTR)DomainName;
-            Info.Name.Length = wcslen(DomainName) * sizeof(WCHAR);
+            Info.Name.Length = DomainNameLength * sizeof(WCHAR);
             Info.Name.MaximumLength = Info.Name.Length + sizeof(WCHAR);
         }
 
@@ -190,7 +210,7 @@ SetPrimaryDomain(LPCWSTR DomainName,
     else
     {
         Info.Name.Buffer = (LPWSTR)DomainName;
-        Info.Name.Length = wcslen(DomainName) * sizeof(WCHAR);
+        Info.Name.Length = DomainNameLength * sizeof(WCHAR);
         Info.Name.MaximumLength = Info.Name.Length + sizeof(WCHAR);
         Info.Sid = DomainSid;
     }
@@ -1251,6 +1271,8 @@ SetNewAccountName(
     if (dwLength == 0)
         return;
 
+    ASSERT(dwLength <= UNICODE_STRING_MAX_CHARS);
+
     pszName = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, dwLength * sizeof(WCHAR));
     if (pszName == NULL)
     {
@@ -1280,7 +1302,7 @@ SetNewAccountName(
         goto done;
     }
 
-    NameInfo.UserName.Length = wcslen(pszName) * sizeof(WCHAR);
+    NameInfo.UserName.Length = (USHORT)wcslen(pszName) * sizeof(WCHAR);
     NameInfo.UserName.MaximumLength = NameInfo.UserName.Length + sizeof(WCHAR);
     NameInfo.UserName.Buffer = pszName;
     NameInfo.FullName.Length = 0;

--- a/dll/win32/vbscript/CMakeLists.txt
+++ b/dll/win32/vbscript/CMakeLists.txt
@@ -39,6 +39,11 @@ add_library(vbscript MODULE
     vbscript.rc
     ${CMAKE_CURRENT_BINARY_DIR}/vbscript.def)
 
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to 'WCHAR', possible loss of data
+    target_compile_options(vbscript PRIVATE /wd4267)
+endif()
+
 set_module_type(vbscript win32dll)
 target_link_libraries(vbscript uuid wine)
 add_importlibs(vbscript oleaut32 ole32 user32 msvcrt kernel32 ntdll)

--- a/dll/win32/windowscodecs/CMakeLists.txt
+++ b/dll/win32/windowscodecs/CMakeLists.txt
@@ -71,8 +71,9 @@ add_library(windowscodecs MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/windowscodecs.def)
 
 if(MSVC)
-    # error C4133: 'function': incompatible types - from 'WICPixelFormatNumericRepresentation *' to 'DWORD *'
-    remove_target_compile_option(windowscodecs "/we4133")
+    # Disable warning C4133: 'function': incompatible types - from 'WICPixelFormatNumericRepresentation *' to 'DWORD *'
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    target_compile_options(windowscodecs PRIVATE /wd4133 /wd4146)
 
     target_compile_options(windowscodecs PRIVATE /FItypeof.h)
 endif()

--- a/dll/win32/wininet/CMakeLists.txt
+++ b/dll/win32/wininet/CMakeLists.txt
@@ -39,6 +39,11 @@ add_library(wininet MODULE
     rsrc.rc
     ${CMAKE_CURRENT_BINARY_DIR}/wininet.def)
 
+if(MSVC)
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    target_compile_options(wininet PRIVATE /wd4090)
+endif()
+
 set_module_type(wininet win32dll)
 target_link_libraries(wininet wine ${PSEH_LIB} oldnames)
 

--- a/dll/win32/winmm/CMakeLists.txt
+++ b/dll/win32/winmm/CMakeLists.txt
@@ -23,8 +23,9 @@ add_library(winmm MODULE
 
 
 if(MSVC)
-    # error C4312: 'type cast': conversion from 'DWORD' to 'HTASK' of greater size
-    remove_target_compile_option(winmm "/we4312")
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    # Disable warning C4312: 'type cast': conversion from 'DWORD' to 'HTASK' of greater size
+    target_compile_options(winmm PRIVATE /wd4090 /wd4312)
 endif()
 
 set_module_type(winmm win32dll)

--- a/dll/win32/wintrust/CMakeLists.txt
+++ b/dll/win32/wintrust/CMakeLists.txt
@@ -17,6 +17,11 @@ add_library(wintrust MODULE
     version.rc
     ${CMAKE_CURRENT_BINARY_DIR}/wintrust.def)
 
+if(MSVC)
+    # Disable warning C4090: 'function': different 'const' qualifiers
+    target_compile_options(wintrust PRIVATE /wd4090)
+endif()
+
 set_module_type(wintrust win32dll)
 target_link_libraries(wintrust wine ${PSEH_LIB})
 # FIXME: imagehlp should be delay-imported. See CORE-6504

--- a/dll/win32/xmllite/CMakeLists.txt
+++ b/dll/win32/xmllite/CMakeLists.txt
@@ -15,6 +15,11 @@ add_library(xmllite MODULE
     guid.c
     ${CMAKE_CURRENT_BINARY_DIR}/xmllite.def)
 
+if(MSVC)
+    # Disable warning C4146: unary minus operator applied to unsigned type, result still unsigned
+    target_compile_options(xmllite PRIVATE /wd4146)
+endif()
+
 set_module_type(xmllite win32dll)
 target_link_libraries(xmllite uuid wine)
 add_importlibs(xmllite msvcrt kernel32 ntdll)

--- a/drivers/bluetooth/fbtusb/CMakeLists.txt
+++ b/drivers/bluetooth/fbtusb/CMakeLists.txt
@@ -16,6 +16,11 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(fbtusb PRIVATE -Wno-unused-but-set-variable)
 endif()
 
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
+    target_compile_options(fbtusb PRIVATE /wd4267)
+endif()
+
 set_module_type(fbtusb kernelmodedriver)
 add_importlibs(fbtusb ntoskrnl hal usbd)
 add_pch(fbtusb precomp.h SOURCE)

--- a/drivers/filesystems/btrfs/CMakeLists.txt
+++ b/drivers/filesystems/btrfs/CMakeLists.txt
@@ -65,6 +65,11 @@ add_asm_files(btrfs_asm ${ASM_SOURCE})
 
 add_library(btrfs MODULE ${SOURCE} ${btrfs_asm} btrfs.rc)
 
+if(MSVC)
+    # Disable warning C4267: 'function': conversion from 'size_t' to 'uint16_t', possible loss of data
+    target_compile_options(btrfs PRIVATE /wd4267)
+endif()
+
 add_definitions(-D__KERNEL__)
 set_module_type(btrfs kernelmodedriver)
 target_link_libraries(btrfs rtlver zlib_solo chkstk wdmguid ${PSEH_LIB})

--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -93,11 +93,11 @@ if(USE_CLANG_CL)
 endif()
 
 if(MSVC)
-    # Disable warnings: "unreferenced local variable", "initialized, but not used variable", "benign include"
     if (NOT CLANG)
-        remove_target_compile_option(ext2fs "/we4101")
-        remove_target_compile_option(ext2fs "/we4189")
-        target_compile_options(ext2fs PRIVATE /wd4189 /wd4142 /wd4101)
+        # Disable warning C4101: 'i': unreferenced local variable
+        # Disable warning C4189: 'sbi': local variable is initialized but not referenced
+        # Disable warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
+        target_compile_options(ext2fs PRIVATE /wd4101 /wd4189 /wd4267)
     endif()
 else()
     target_compile_options(ext2fs PRIVATE

--- a/drivers/filesystems/fastfat_new/fatstruc.h
+++ b/drivers/filesystems/fastfat_new/fatstruc.h
@@ -20,6 +20,7 @@ Abstract:
 typedef PVOID PBCB;     //**** Bcb's are now part of the cache module
 
 #ifdef __REACTOS__
+#undef __volatile
 #define __volatile volatile
 #endif
 

--- a/drivers/filesystems/npfs/main.c
+++ b/drivers/filesystems/npfs/main.c
@@ -42,7 +42,7 @@ NpReadAlias(
 {
     PNPFS_QUERY_VALUE_CONTEXT QueryContext = Context;
     PWSTR CurrentString;
-    USHORT Length;
+    SIZE_T Length;
     PNPFS_ALIAS CurrentAlias;
     UNICODE_STRING TempString;
     PUNICODE_STRING CurrentTargetName;

--- a/drivers/input/kbdclass/kbdclass.c
+++ b/drivers/input/kbdclass/kbdclass.c
@@ -4,7 +4,7 @@
  * FILE:            drivers/kbdclass/kbdclass.c
  * PURPOSE:         Keyboard class driver
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "kbdclass.h"
@@ -321,7 +321,7 @@ CreateClassDeviceObject(
 	DriverExtension = IoGetDriverObjectExtension(DriverObject, DriverObject);
 	DeviceNameU.Length = 0;
 	DeviceNameU.MaximumLength =
-		wcslen(L"\\Device\\") * sizeof(WCHAR)    /* "\Device\" */
+		(USHORT)wcslen(L"\\Device\\") * sizeof(WCHAR) /* "\Device\" */
 		+ DriverExtension->DeviceBaseName.Length /* "KeyboardClass" */
 		+ 4 * sizeof(WCHAR)                      /* Id between 0 and 9999 */
 		+ sizeof(UNICODE_NULL);                  /* Final NULL char */

--- a/drivers/input/mouclass/mouclass.c
+++ b/drivers/input/mouclass/mouclass.c
@@ -4,7 +4,7 @@
  * FILE:            drivers/mouclass/mouclass.c
  * PURPOSE:         Mouse class driver
  *
- * PROGRAMMERS:     Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS:     HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "mouclass.h"
@@ -297,7 +297,7 @@ CreateClassDeviceObject(
 	DriverExtension = IoGetDriverObjectExtension(DriverObject, DriverObject);
 	DeviceNameU.Length = 0;
 	DeviceNameU.MaximumLength =
-		wcslen(L"\\Device\\") * sizeof(WCHAR)    /* "\Device\" */
+		(USHORT)wcslen(L"\\Device\\") * sizeof(WCHAR)    /* "\Device\" */
 		+ DriverExtension->DeviceBaseName.Length /* "PointerClass" */
 		+ 4 * sizeof(WCHAR)                      /* Id between 0 and 9999 */
 		+ sizeof(UNICODE_NULL);                  /* Final NULL char */

--- a/drivers/storage/floppy/floppy/ioctl.c
+++ b/drivers/storage/floppy/floppy/ioctl.c
@@ -266,7 +266,7 @@ DeviceIoctlPassive(PDRIVE_INFO DriveInfo, PIRP Irp)
         }
 
         UniqueId = Irp->AssociatedIrp.SystemBuffer;
-        UniqueId->UniqueIdLength = wcslen(&DriveInfo->DeviceNameBuffer[0]) * sizeof(WCHAR);
+        UniqueId->UniqueIdLength = (USHORT)wcslen(&DriveInfo->DeviceNameBuffer[0]) * sizeof(WCHAR);
 
         if(OutputLength < FIELD_OFFSET(MOUNTDEV_UNIQUE_ID, UniqueId) + UniqueId->UniqueIdLength)
         {
@@ -291,7 +291,7 @@ DeviceIoctlPassive(PDRIVE_INFO DriveInfo, PIRP Irp)
         }
 
         Name = Irp->AssociatedIrp.SystemBuffer;
-        Name->NameLength = wcslen(&DriveInfo->DeviceNameBuffer[0]) * sizeof(WCHAR);
+        Name->NameLength = (USHORT)wcslen(&DriveInfo->DeviceNameBuffer[0]) * sizeof(WCHAR);
 
         if(OutputLength < FIELD_OFFSET(MOUNTDEV_NAME, Name) + Name->NameLength)
         {

--- a/drivers/storage/ide/uniata/CMakeLists.txt
+++ b/drivers/storage/ide/uniata/CMakeLists.txt
@@ -28,6 +28,12 @@ if(USE_CLANG_CL OR (NOT MSVC))
     endif()
 endif()
 
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to 'USHORT', possible loss of data
+    # Disable warning C4838: conversion from 'int' to 'ULONG' requires a narrowing conversion
+    target_compile_options(uniata PRIVATE /wd4267 /wd4838)
+endif()
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     target_compile_options(uniata PRIVATE -Wno-unused-but-set-variable)
 endif()

--- a/modules/rosapps/applications/explorer-old/shell/ntobjfs.cpp
+++ b/modules/rosapps/applications/explorer-old/shell/ntobjfs.cpp
@@ -140,7 +140,7 @@ struct UnicodeString : public RtlUnicodeString {
 
 	UnicodeString(size_t len, LPWSTR buffer)
 	{
-		alloc_len = len;
+		alloc_len = (WORD)len;
 		string_ptr = buffer;
 	}
 

--- a/modules/rosapps/applications/fraginator/Unfrag.cpp
+++ b/modules/rosapps/applications/fraginator/Unfrag.cpp
@@ -233,7 +233,7 @@ extern "C" int wmain (int argc, wchar_t **argv)
 
         // Now set back to the beginning
         ScreenInfo.dwCursorPosition.X = 0;
-        ScreenInfo.dwCursorPosition.Y -= Drives.size();
+        ScreenInfo.dwCursorPosition.Y -= (USHORT)Drives.size();
         SetConsoleCursorPosition (Screen, ScreenInfo.dwCursorPosition);
 
         for (size_t d = 0; d < Drives.size (); d++)

--- a/modules/rosapps/applications/net/netreg/netreg.cpp
+++ b/modules/rosapps/applications/net/netreg/netreg.cpp
@@ -182,10 +182,10 @@ private:
   }
 
   string present_value( DWORD type, const char *data, DWORD len ) {
-    switch( type ) {
-    default:
+    //switch( type ) {
+    //default:
       return bindump( data, len );
-    }
+    //}
   }
 
   void process_valid_request( HKEY open_reg_key, string key_name ) {

--- a/modules/rosapps/applications/net/roshttpd/include/httpd.h
+++ b/modules/rosapps/applications/net/roshttpd/include/httpd.h
@@ -67,7 +67,7 @@ public:
 	virtual BOOL Stop();
 	virtual LPCServerClientSocket OnGetSocket(LPCServerSocket lpServerSocket);
 	virtual LPCServerClientThread OnGetThread(LPCServerClientSocket Socket);
-	virtual void OnAccept(const LPCServerClientThread lpThread);
+	virtual void OnAccept(LPCServerClientThread lpThread);
 private:
 	HTTPdState State;
 };

--- a/modules/rosapps/applications/notevil/notevil.c
+++ b/modules/rosapps/applications/notevil/notevil.c
@@ -44,25 +44,25 @@ WriteStringAt(LPWSTR lpString,
               WORD   wColor)
 {
     DWORD cWritten = 0;
-    WORD  wLen;
+    DWORD dwLen;
 
     if (!lpString || *lpString == 0) return;
 
-    wLen = wcslen(lpString);
+    dwLen = (DWORD)wcslen(lpString);
 
     /* Don't bother writing text when erasing */
     if (wColor)
     {
         WriteConsoleOutputCharacterW(ScreenBuffer,
                                      lpString,
-                                     wLen,
+                                     dwLen,
                                      xy,
                                      &cWritten);
     }
 
     FillConsoleOutputAttribute(ScreenBuffer,
                                wColor,
-                               wLen,
+                               dwLen,
                                xy,
                                &cWritten);
 }
@@ -103,7 +103,7 @@ DisplayTitle(VOID)
     LPWSTR szTitle = L"ReactOS Coders Console Parade";
     COORD  xy;
 
-    xy.X = (ScreenBufferInfo.dwSize.X - wcslen(szTitle)) / 2;
+    xy.X = (ScreenBufferInfo.dwSize.X - (USHORT)wcslen(szTitle)) / 2;
     xy.Y = ScreenBufferInfo.dwSize.Y / 2;
 
     WriteStringAt(szTitle, xy,

--- a/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
+++ b/modules/rosapps/applications/screensavers/cylfrac/cylfrac.c
@@ -106,8 +106,8 @@ void DrawScene(HWND hwnd, HDC dc, int ticks)
     angle += ticks * 0.01;
     colorh += ticks * 0.003;
     if (colorh > 360.0) colorh -= 360.0;
-    HLStoRGB(colorh, 1.0, 0.7, &rval, &gval, &bval);
-    DrawCylinder(lvls, angle, 0.2);
+    HLStoRGB(colorh, 1.0f, 0.7f, &rval, &gval, &bval);
+    DrawCylinder(lvls, angle, 0.2f);
     SwapBuffers(dc);
     EndPaint(hwnd, &ps);
 }
@@ -134,7 +134,7 @@ void MyPixelFormat(HDC dc)
 
 void InitGL(HWND hwnd)
 {
-    GLfloat lightpos[4] = {2.0, 2.0, -2.0, 0.7};
+    GLfloat lightpos[4] = {2.0f, 2.0f, -2.0f, 0.7f};
     GLfloat ca = 1.0;
     dc = GetDC(hwnd);
     MyPixelFormat(dc);

--- a/modules/rostests/apitests/atl/SubclassWindow.cpp
+++ b/modules/rostests/apitests/atl/SubclassWindow.cpp
@@ -8,6 +8,7 @@
 #ifdef HAVE_APITEST
     #include <apitest.h>
     #define ATLASSUME(x) /*empty*/
+    #undef ATLASSERT
     #define ATLASSERT(x) /*empty*/
 #else
     #include "atltest.h"

--- a/modules/rostests/winetests/riched20/CMakeLists.txt
+++ b/modules/rostests/winetests/riched20/CMakeLists.txt
@@ -7,10 +7,6 @@ list(APPEND SOURCE
     testlist.c
     txtsrv.c)
 
-if(MSVC)
-    set_property(SOURCE editor.c APPEND_STRING PROPERTY COMPILE_FLAGS " /w14189")
-endif()
-
 add_executable(riched20_winetest ${SOURCE})
 set_module_type(riched20_winetest win32cui)
 add_importlibs(riched20_winetest ole32 oleaut32 user32 gdi32 msvcrt kernel32)

--- a/ntoskrnl/ke/wait.c
+++ b/ntoskrnl/ke/wait.c
@@ -470,7 +470,7 @@ KeWaitForSingleObject(IN PVOID Object,
                     (Thread == CurrentObject->OwnerThread))
                 {
                     /* Just unwait this guy and exit */
-                    if (CurrentObject->Header.SignalState != (LONG)MINLONG)
+                    if (CurrentObject->Header.SignalState != MINLONG)
                     {
                         /* It has a normal signal state. Unwait and return */
                         KiSatisfyMutantWait(CurrentObject, Thread);

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -88,6 +88,22 @@ add_compile_options(/wd4244 /wd4290 /wd4800 /wd4200 /wd4214)
 # FIXME: Temporarily disable C4018 until we fix more of the others. CORE-10113
 add_compile_options(/wd4018)
 
+# Allow all warnings on msbuild/VS IDE
+if (MSVC_IDE)
+    set(ALLOW_WARNINGS TRUE)
+endif()
+
+# On x86 Debug builds, if it's not Clang-CL or msbuild, treat all warnings as errors
+if ((ARCH STREQUAL "i386") AND (CMAKE_BUILD_TYPE STREQUAL "Debug") AND (NOT USE_CLANG_CL) AND (NOT MSVC_IDE))
+    set(TREAT_ALL_WARNINGS_AS_ERRORS=TRUE)
+endif()
+
+# Define ALLOW_WARNINGS=TRUE on the cmake/configure command line to bypass errors
+if (ALLOW_WARNINGS)
+    # Nothing
+elseif (TREAT_ALL_WARNINGS_AS_ERRORS)
+    add_compile_options(/WX)
+else()
 # The following warnings are treated as errors:
 # - C4013: implicit function declaration
 # - C4020: too many actual parameters
@@ -117,6 +133,8 @@ add_compile_options(/we4013 /we4020 /we4022 /we4028 /we4047 /we4098 /we4113 /we4
 # Not in Release mode, msbuild generator doesn't like CMAKE_BUILD_TYPE
 if(MSVC_IDE OR CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_options(/we4101 /we4189)
+endif()
+
 endif()
 
 # Enable warnings above the default level, but don't treat them as errors:
@@ -194,8 +212,8 @@ if (NOT MSVC_IDE)
 endif()
 
 if(_VS_ANALYZE_)
-    message("VS static analysis enabled!")
-    add_compile_options(/analyze)
+    message("-- VS static analysis enabled!")
+    add_compile_options(/analyze:WX-)
 elseif(_PREFAST_)
     message("PREFAST enabled!")
     set(CMAKE_C_COMPILE_OBJECT "prefast <CMAKE_C_COMPILER> ${CMAKE_START_TEMP_FILE} ${CMAKE_CL_NOLOGO} <INCLUDES> <FLAGS> <DEFINES> /Fo<OBJECT> -c <SOURCE>${CMAKE_END_TEMP_FILE}"

--- a/sdk/include/ddk/acpiioct.h
+++ b/sdk/include/ddk/acpiioct.h
@@ -159,7 +159,7 @@ typedef ACPI_ENUM_CHILDREN_OUTPUT_BUFFER UNALIGNED *PACPI_ENUM_CHILDREN_OUTPUT_B
 
 #define ACPI_METHOD_SET_ARGUMENT_STRING( Argument, StrData )                \
   { Argument->Type = ACPI_METHOD_ARGUMENT_STRING;                           \
-    Argument->DataLength = strlen((PCHAR)StrData) + sizeof(UCHAR);          \
+    Argument->DataLength = (USHORT)strlen((PCHAR)StrData) + sizeof(UCHAR);  \
     RtlCopyMemory(&Argument->Data[0],(PUCHAR)StrData,Argument->DataLength); }
 
 #define ACPI_METHOD_SET_ARGUMENT_BUFFER( Argument, BuffData, BuffLength )   \

--- a/sdk/include/ndk/umtypes.h
+++ b/sdk/include/ndk/umtypes.h
@@ -108,12 +108,12 @@ Author:
 //
 // Limits
 //
-#define MINCHAR                         (-128)
-#define MAXCHAR                         127
-#define MINSHORT                        (-32768)
-#define MAXSHORT                        32767
-#define MINLONG                         (-2147483648)
-#define MAXLONG                         2147483647
+#define MINCHAR                         0x80
+#define MAXCHAR                         0x7f
+#define MINSHORT                        0x8000
+#define MAXSHORT                        0x7fff
+#define MINLONG                         0x80000000
+#define MAXLONG                         0x7fffffff
 #define MAXUCHAR                        0xff
 #define MAXUSHORT                       0xffff
 #define MAXULONG                        0xffffffff

--- a/sdk/include/psdk/intsafe.h
+++ b/sdk/include/psdk/intsafe.h
@@ -46,9 +46,11 @@ typedef _Return_type_success_(return >= 0) long NTSTATUS;
 #ifndef _HRESULT_DEFINED
 typedef _Return_type_success_(return >= 0) long HRESULT;
 #endif
+#ifndef SUCCEEDED
 #define SUCCEEDED(hr) (((HRESULT)(hr)) >= 0)
 #define FAILED(hr) (((HRESULT)(hr)) < 0)
 #define S_OK    ((HRESULT)0L)
+#endif
 #define INTSAFE_RESULT HRESULT
 #define INTSAFE_SUCCESS S_OK
 #define INTSAFE_E_ARITHMETIC_OVERFLOW ((HRESULT)0x80070216L)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -735,12 +735,12 @@ extern "C++" { \
 #define COMPILETIME_OR_5FLAGS(a,b,c,d,e)    ((UINT)(a)|(UINT)(b)|(UINT)(c)|(UINT)(d)|(UINT)(e))
 
 /* Type Limits */
-#define MINCHAR   (-128)
-#define MAXCHAR   127
-#define MINSHORT  (-32768)
-#define MAXSHORT  32767
-#define MINLONG   (-2147483648)
-#define MAXLONG   2147483647
+#define MINCHAR   0x80
+#define MAXCHAR   0x7f
+#define MINSHORT  0x8000
+#define MAXSHORT  0x7fff
+#define MINLONG   0x80000000
+#define MAXLONG   0x7fffffff
 $if(_NTDEF_)
 #define MAXUCHAR  0xff
 #define MAXUSHORT 0xffff

--- a/sdk/lib/crt/string/wtoi64.c
+++ b/sdk/lib/crt/string/wtoi64.c
@@ -6,7 +6,7 @@
  */
 __int64 CDECL _wtoi64_l(const wchar_t *str, _locale_t locale)
 {
-    ULONGLONG RunningTotal = 0;
+    LONGLONG RunningTotal = 0;
     BOOL bMinus = FALSE;
 
     while (iswctype((int)*str, _SPACE)) {
@@ -191,7 +191,7 @@ unsigned __int64 CDECL _wcstoui64_l(const wchar_t *nptr,
     if(endptr)
         *endptr = (wchar_t*)nptr;
 
-    return negative ? -ret : ret;
+    return negative ? -(__int64)ret : ret;
 }
 
 /*********************************************************************

--- a/sdk/lib/drivers/ip/network/loopback.c
+++ b/sdk/lib/drivers/ip/network/loopback.c
@@ -124,7 +124,7 @@ NDIS_STATUS LoopRegisterAdapter(
 
   Loopback->Name.Buffer = L"Loopback";
   Loopback->Name.MaximumLength = Loopback->Name.Length =
-      wcslen(Loopback->Name.Buffer) * sizeof(WCHAR);
+      (USHORT)wcslen(Loopback->Name.Buffer) * sizeof(WCHAR);
 
   AddrInitIPv4(&Loopback->Unicast, LOOPBACK_ADDRESS_IPv4);
   AddrInitIPv4(&Loopback->Netmask, LOOPBACK_ADDRMASK_IPv4);

--- a/sdk/lib/fslib/ext2lib/CMakeLists.txt
+++ b/sdk/lib/fslib/ext2lib/CMakeLists.txt
@@ -14,3 +14,8 @@ list(APPEND SOURCE
 add_library(ext2lib ${SOURCE})
 add_pch(ext2lib Mke2fs.h SOURCE)
 add_dependencies(ext2lib psdk)
+
+if(MSVC)
+    # Disable warning C4267: '=': conversion from 'size_t' to '__u8', possible loss of data
+    target_compile_options(ext2lib PRIVATE /wd4267)
+endif()

--- a/subsystems/mvdm/ntvdm/dos/dem.c
+++ b/subsystems/mvdm/ntvdm/dos/dem.c
@@ -1131,7 +1131,7 @@ static VOID WINAPI DosInitialize(LPWORD Stack)
     /* Get the DOS BIOS file name (NULL-terminated) */
     // FIXME: Isn't it possible to use some DS:SI instead??
     LPCSTR DosBiosFileName = (LPCSTR)SEG_OFF_TO_PTR(getCS(), getIP());
-    setIP(getIP() + strlen(DosBiosFileName) + 1); // Skip it
+    setIP(getIP() + (USHORT)strlen(DosBiosFileName) + 1); // Skip it
 
     DPRINT("DosInitialize('%s')\n", DosBiosFileName);
 

--- a/win32ss/printing/providers/localspl/tools.c
+++ b/win32ss/printing/providers/localspl/tools.c
@@ -109,7 +109,7 @@ LONG copy_servername_from_name(LPCWSTR name, LPWSTR target)
 
     FIXME("found %s\n", debugstr_wn(server, serverlen));
 
-    if (serverlen > MAX_COMPUTERNAME_LENGTH) return -serverlen;
+    if (serverlen > MAX_COMPUTERNAME_LENGTH) return -(LONG)serverlen;
 
     if (target)
     {

--- a/win32ss/user/user32/windows/class.c
+++ b/win32ss/user/user32/windows/class.c
@@ -111,7 +111,7 @@ ClassNameToVersion(
             ERR("Couldn't get atom name for atom %x !\n", LOWORD((DWORD_PTR)lpszClass));
             return NULL;
         }
-        SectionName.Length = wcslen(SectionNameBuf) * sizeof(WCHAR);
+        SectionName.Length = (USHORT)wcslen(SectionNameBuf) * sizeof(WCHAR);
         TRACE("ClassNameToVersion got name %wZ from atom\n", &SectionName);
     }
     else


### PR DESCRIPTION
This PR fixes all remaining MSVC x86 warnings in our code, disables them in 3rd-party code and turns all warnings (except static analysis warnings) into errors.
