### PR TITLE
[CMAKE] toolchain-clang.cmake: Use overrides-gcc.cmake

### DIFF
--- a/toolchain-clang.cmake
+++ b/toolchain-clang.cmake
@@ -60,3 +60,5 @@ message(STATUS "Using linker ${LD_EXECUTABLE}")
 set(CMAKE_SHARED_LINKER_FLAGS_INIT "-nostdlib -Wl,--enable-auto-image-base,--disable-auto-import -fuse-ld=${LD_EXECUTABLE}")
 set(CMAKE_MODULE_LINKER_FLAGS_INIT "-nostdlib -Wl,--enable-auto-image-base,--disable-auto-import -fuse-ld=${LD_EXECUTABLE}")
 set(CMAKE_EXE_LINKER_FLAGS_INIT "-nostdlib -Wl,--enable-auto-image-base,--disable-auto-import -fuse-ld=${LD_EXECUTABLE}")
+
+set(CMAKE_USER_MAKE_RULES_OVERRIDE "${CMAKE_CURRENT_LIST_DIR}/overrides-gcc.cmake")


### PR DESCRIPTION
Sync Clang with Gcc.
Needed to fix Clang part of #3787.

Addendum to 8cd5c4e.
JIRA issue: [CORE-14513](https://jira.reactos.org/browse/CORE-14513)