### PR TITLE
[GDI32] Revise IntTMWFixUp Raster Font List

### DIFF
--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -42,14 +42,13 @@ IntTMWFixUp(
      * out the problematic TrueType and Vector bits.
      * Our list below checks for Raster Font Facenames. */
     DPRINT("Font Facename is '%S'.\n", lf.lfFaceName);
-    if ((wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Courier") == 0) ||
+    if ((wcsicmp(lf.lfFaceName, L"Courier") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"FixedSys") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
         (wcsicmp(lf.lfFaceName, L"MS Sans Serif") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"MS Serif") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Times New Roman") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"MS Shell Dlg") == 0) ||
         (wcsicmp(lf.lfFaceName, L"System") == 0) ||
-        (wcsicmp(lf.lfFaceName, L"Terminal") == 0))
+        (wcsicmp(lf.lfFaceName, L"Terminal") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"Tms Rmn") == 0))
     {
         ptm->TextMetric.tmPitchAndFamily &= ~(TMPF_TRUETYPE | TMPF_VECTOR);
     }

--- a/win32ss/gdi/ntgdi/text.c
+++ b/win32ss/gdi/ntgdi/text.c
@@ -46,6 +46,7 @@ IntTMWFixUp(
         (wcsicmp(lf.lfFaceName, L"FixedSys") == 0) ||
         (wcsicmp(lf.lfFaceName, L"Helv") == 0) ||
         (wcsicmp(lf.lfFaceName, L"MS Sans Serif") == 0) ||
+        (wcsicmp(lf.lfFaceName, L"MS Serif") == 0) ||
         (wcsicmp(lf.lfFaceName, L"System") == 0) ||
         (wcsicmp(lf.lfFaceName, L"Terminal") == 0) ||
         (wcsicmp(lf.lfFaceName, L"Tms Rmn") == 0))


### PR DESCRIPTION
## Update IntTMWFixUp Raster Font List

_This list had fonts listed that ReactOS does not support and was missing fonts._

JIRA issues: [CORE-17662](https://jira.reactos.org/browse/CORE-17662) and [CORE-17723](https://jira.reactos.org/browse/CORE-17723)

## Add Two Fonts and Delete Two Fonts

_This fixes the text shown in the toolbar for Pidgin and Geany when using the Lunar theme ._
While we are editing this file, we will alphabetize the font names as well.

Here is my test program for proving that CORE-1091 is still fixed:

Before first patch:

![VB6_Install_Bad](https://user-images.githubusercontent.com/32620577/125043052-2bb9a100-e060-11eb-9f63-796b42080b09.png)

After 1st patch and current:

![VB6_Install_OK](https://user-images.githubusercontent.com/32620577/125042043-09735380-e05f-11eb-9c24-8ca6aa466b59.png)
