### PR TITLE
[SDK][INCLUDE] Add offset info to INPUTCONTEXT

### DIFF
--- a/sdk/include/reactos/wine/ddk/imm.h
+++ b/sdk/include/reactos/wine/ddk/imm.h
@@ -25,27 +25,27 @@
 #include <psdk/imm.h>
 
 typedef struct _tagINPUTCONTEXT {
-    HWND                hWnd;
-    BOOL                fOpen;
-    POINT               ptStatusWndPos;
-    POINT               ptSoftKbdPos;
-    DWORD               fdwConversion;
-    DWORD               fdwSentence;
+    HWND                hWnd;               /* offset 0x0 */
+    BOOL                fOpen;              /* offset 0x4 */
+    POINT               ptStatusWndPos;     /* offset 0x8 */
+    POINT               ptSoftKbdPos;       /* offset 0x10 */
+    DWORD               fdwConversion;      /* offset 0x18 */
+    DWORD               fdwSentence;        /* offset 0x1c */
     union   {
         LOGFONTA        A;
         LOGFONTW        W;
-    } lfFont;
-    COMPOSITIONFORM     cfCompForm;
-    CANDIDATEFORM       cfCandForm[4];
-    HIMCC               hCompStr;
-    HIMCC               hCandInfo;
-    HIMCC               hGuideLine;
-    HIMCC               hPrivate;
-    DWORD               dwNumMsgBuf;
-    HIMCC               hMsgBuf;
-    DWORD               fdwInit;
-    DWORD               dwReserve[3];
-} INPUTCONTEXT, *LPINPUTCONTEXT;
+    } lfFont;                               /* offset 0x20 */
+    COMPOSITIONFORM     cfCompForm;         /* offset 0x7c */
+    CANDIDATEFORM       cfCandForm[4];      /* offset 0x98 */
+    HIMCC               hCompStr;           /* offset 0x118 */
+    HIMCC               hCandInfo;          /* offset 0x11c */
+    HIMCC               hGuideLine;         /* offset 0x120 */
+    HIMCC               hPrivate;           /* offset 0x124 */
+    DWORD               dwNumMsgBuf;        /* offset 0x128 */
+    HIMCC               hMsgBuf;            /* offset 0x12c */
+    DWORD               fdwInit;            /* offset 0x130 */
+    DWORD               dwReserve[3];       /* offset 0x134 */
+} INPUTCONTEXT, *LPINPUTCONTEXT;            /* size 0x140 */
 
 LPINPUTCONTEXT WINAPI ImmLockIMC(HIMC);
 

--- a/sdk/include/reactos/wine/ddk/imm.h
+++ b/sdk/include/reactos/wine/ddk/imm.h
@@ -25,27 +25,67 @@
 #include <psdk/imm.h>
 
 typedef struct _tagINPUTCONTEXT {
-    HWND                hWnd;               /* offset 0x0 */
-    BOOL                fOpen;              /* offset 0x4 */
-    POINT               ptStatusWndPos;     /* offset 0x8 */
-    POINT               ptSoftKbdPos;       /* offset 0x10 */
-    DWORD               fdwConversion;      /* offset 0x18 */
-    DWORD               fdwSentence;        /* offset 0x1c */
+    HWND                hWnd;
+    BOOL                fOpen;
+    POINT               ptStatusWndPos;
+    POINT               ptSoftKbdPos;
+    DWORD               fdwConversion;
+    DWORD               fdwSentence;
     union   {
         LOGFONTA        A;
         LOGFONTW        W;
-    } lfFont;                               /* offset 0x20 */
-    COMPOSITIONFORM     cfCompForm;         /* offset 0x7c */
-    CANDIDATEFORM       cfCandForm[4];      /* offset 0x98 */
-    HIMCC               hCompStr;           /* offset 0x118 */
-    HIMCC               hCandInfo;          /* offset 0x11c */
-    HIMCC               hGuideLine;         /* offset 0x120 */
-    HIMCC               hPrivate;           /* offset 0x124 */
-    DWORD               dwNumMsgBuf;        /* offset 0x128 */
-    HIMCC               hMsgBuf;            /* offset 0x12c */
-    DWORD               fdwInit;            /* offset 0x130 */
-    DWORD               dwReserve[3];       /* offset 0x134 */
-} INPUTCONTEXT, *LPINPUTCONTEXT;            /* size 0x140 */
+    } lfFont;
+    COMPOSITIONFORM     cfCompForm;
+    CANDIDATEFORM       cfCandForm[4];
+    HIMCC               hCompStr;
+    HIMCC               hCandInfo;
+    HIMCC               hGuideLine;
+    HIMCC               hPrivate;
+    DWORD               dwNumMsgBuf;
+    HIMCC               hMsgBuf;
+    DWORD               fdwInit;
+    DWORD               dwReserve[3];
+} INPUTCONTEXT, *LPINPUTCONTEXT;
+
+#ifdef _WIN64
+C_ASSERT(offsetof(INPUTCONTEXT, hWnd) == 0x0);
+C_ASSERT(offsetof(INPUTCONTEXT, fOpen) == 0x8);
+C_ASSERT(offsetof(INPUTCONTEXT, ptStatusWndPos) == 0xc);
+C_ASSERT(offsetof(INPUTCONTEXT, ptSoftKbdPos) == 0x14);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwConversion) == 0x1c);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwSentence) == 0x20);
+C_ASSERT(offsetof(INPUTCONTEXT, lfFont) == 0x24);
+C_ASSERT(offsetof(INPUTCONTEXT, cfCompForm) == 0x80);
+C_ASSERT(offsetof(INPUTCONTEXT, cfCandForm) == 0x9c);
+C_ASSERT(offsetof(INPUTCONTEXT, hCompStr) == 0x120);
+C_ASSERT(offsetof(INPUTCONTEXT, hCandInfo) == 0x128);
+C_ASSERT(offsetof(INPUTCONTEXT, hGuideLine) == 0x130);
+C_ASSERT(offsetof(INPUTCONTEXT, hPrivate) == 0x138);
+C_ASSERT(offsetof(INPUTCONTEXT, dwNumMsgBuf) == 0x140);
+C_ASSERT(offsetof(INPUTCONTEXT, hMsgBuf) == 0x148);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwInit) == 0x150);
+C_ASSERT(offsetof(INPUTCONTEXT, dwReserve) == 0x154);
+C_ASSERT(sizeof(INPUTCONTEXT) == 0x160);
+#else
+C_ASSERT(offsetof(INPUTCONTEXT, hWnd) == 0x0);
+C_ASSERT(offsetof(INPUTCONTEXT, fOpen) == 0x4);
+C_ASSERT(offsetof(INPUTCONTEXT, ptStatusWndPos) == 0x8);
+C_ASSERT(offsetof(INPUTCONTEXT, ptSoftKbdPos) == 0x10);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwConversion) == 0x18);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwSentence) == 0x1c);
+C_ASSERT(offsetof(INPUTCONTEXT, lfFont) == 0x20);
+C_ASSERT(offsetof(INPUTCONTEXT, cfCompForm) == 0x7c);
+C_ASSERT(offsetof(INPUTCONTEXT, cfCandForm) == 0x98);
+C_ASSERT(offsetof(INPUTCONTEXT, hCompStr) == 0x118);
+C_ASSERT(offsetof(INPUTCONTEXT, hCandInfo) == 0x11c);
+C_ASSERT(offsetof(INPUTCONTEXT, hGuideLine) == 0x120);
+C_ASSERT(offsetof(INPUTCONTEXT, hPrivate) == 0x124);
+C_ASSERT(offsetof(INPUTCONTEXT, dwNumMsgBuf) == 0x128);
+C_ASSERT(offsetof(INPUTCONTEXT, hMsgBuf) == 0x12c);
+C_ASSERT(offsetof(INPUTCONTEXT, fdwInit) == 0x130);
+C_ASSERT(offsetof(INPUTCONTEXT, dwReserve) == 0x134);
+C_ASSERT(sizeof(INPUTCONTEXT) == 0x140);
+#endif
 
 LPINPUTCONTEXT WINAPI ImmLockIMC(HIMC);
 


### PR DESCRIPTION
## Purpose
Add offset and size information to `INPUTCONTEXT` structure for information help.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Use `C_ASSERT` and `offsetof` macros against `INPUTCONTEXT` structure.