### PR TITLE
[IMM32] Rewrite ImmGetCompositionFontA/W

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1417,7 +1417,7 @@ BOOL WINAPI ImmGetCandidateWindow(
     return TRUE;
 }
 
-static VOID LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
+static VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
 {
     size_t cch;
     RtlCopyMemory(plfW, plfA, offsetof(LOGFONTA, lfFaceName));
@@ -1426,7 +1426,7 @@ static VOID LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
                         plfW->lfFaceName, _countof(plfW->lfFaceName));
 }
 
-static VOID LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
+static VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
 {
     size_t cch;
     RtlCopyMemory(plfA, plfW, offsetof(LOGFONTW, lfFaceName));

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1440,7 +1440,6 @@ static VOID LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
  */
 BOOL WINAPI ImmGetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
 {
-    LOGFONTW lfW;
     PCLIENTIMC pClientImc;
     BOOL ret = FALSE, bWide;
     LPINPUTCONTEXT pIC;
@@ -1458,18 +1457,13 @@ BOOL WINAPI ImmGetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
     if (pIC == NULL)
         return FALSE;
 
-    if (bWide)
-    {
-        ImmUnlockIMC(hIMC);
-        if (!ImmGetCompositionFontW(hIMC, &lfW))
-            return FALSE;
-        LogFontWideToAnsi(&lfW, lplf);
-        return TRUE;
-    }
-
     if (pIC->fdwInit & INIT_LOGFONT)
     {
-        *lplf = pIC->lfFont.A;
+        if (bWide)
+            LogFontWideToAnsi(&pIC->lfFont.W, lplf);
+        else
+            *lplf = pIC->lfFont.A;
+
         ret = TRUE;
     }
 
@@ -1482,7 +1476,6 @@ BOOL WINAPI ImmGetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
  */
 BOOL WINAPI ImmGetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
 {
-    LOGFONTA lfA;
     PCLIENTIMC pClientImc;
     BOOL bWide;
     LPINPUTCONTEXT pIC;
@@ -1501,23 +1494,17 @@ BOOL WINAPI ImmGetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
     if (pIC == NULL)
         return FALSE;
 
-    if (!bWide)
-    {
-        ImmUnlockIMC(hIMC);
-        if (!ImmGetCompositionFontA(hIMC, &lfA))
-            return FALSE;
-        LogFontAnsiToWide(&lfA, lplf);
-        return TRUE;
-    }
-
     if (pIC->fdwInit & INIT_LOGFONT)
     {
-        *lplf = pIC->lfFont.W;
+        if (!bWide)
+            LogFontAnsiToWide(&pIC->lfFont.A, lplf);
+        else
+            *lplf = pIC->lfFont.W;
+
         ret = TRUE;
     }
 
     ImmUnlockIMC(hIMC);
-
     return ret;
 }
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1424,6 +1424,8 @@ static VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
     StringCchLengthA(plfA->lfFaceName, _countof(plfA->lfFaceName), &cch);
     cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cch,
                               plfW->lfFaceName, _countof(plfW->lfFaceName));
+    if (cch >= _countof(plfW->lfFaceName))
+        cch = _countof(plfW->lfFaceName) - 1;
     plfW->lfFaceName[cch] = 0;
 }
 
@@ -1434,6 +1436,8 @@ static VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
     StringCchLengthW(plfW->lfFaceName, _countof(plfW->lfFaceName), &cch);
     cch = WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cch,
                               plfA->lfFaceName, _countof(plfA->lfFaceName), NULL, NULL);
+    if (cch >= _countof(plfA->lfFaceName))
+        cch = _countof(plfA->lfFaceName) - 1;
     plfA->lfFaceName[cch] = 0;
 }
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1424,7 +1424,7 @@ static VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
     StringCchLengthA(plfA->lfFaceName, _countof(plfA->lfFaceName), &cch);
     cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cch,
                               plfW->lfFaceName, _countof(plfW->lfFaceName));
-    if (cch >= _countof(plfW->lfFaceName))
+    if (cch > _countof(plfW->lfFaceName) - 1)
         cch = _countof(plfW->lfFaceName) - 1;
     plfW->lfFaceName[cch] = 0;
 }
@@ -1436,7 +1436,7 @@ static VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
     StringCchLengthW(plfW->lfFaceName, _countof(plfW->lfFaceName), &cch);
     cch = WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cch,
                               plfA->lfFaceName, _countof(plfA->lfFaceName), NULL, NULL);
-    if (cch >= _countof(plfA->lfFaceName))
+    if (cch > _countof(plfA->lfFaceName) - 1)
         cch = _countof(plfA->lfFaceName) - 1;
     plfA->lfFaceName[cch] = 0;
 }

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1422,8 +1422,9 @@ static VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
     size_t cch;
     RtlCopyMemory(plfW, plfA, offsetof(LOGFONTA, lfFaceName));
     StringCchLengthA(plfA->lfFaceName, _countof(plfA->lfFaceName), &cch);
-    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cch,
-                        plfW->lfFaceName, _countof(plfW->lfFaceName));
+    cch = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cch,
+                              plfW->lfFaceName, _countof(plfW->lfFaceName));
+    plfW->lfFaceName[cch] = 0;
 }
 
 static VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
@@ -1431,8 +1432,9 @@ static VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
     size_t cch;
     RtlCopyMemory(plfA, plfW, offsetof(LOGFONTW, lfFaceName));
     StringCchLengthW(plfW->lfFaceName, _countof(plfW->lfFaceName), &cch);
-    WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cch,
-                        plfA->lfFaceName, _countof(plfA->lfFaceName), NULL, NULL);
+    cch = WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cch,
+                              plfA->lfFaceName, _countof(plfA->lfFaceName), NULL, NULL);
+    plfA->lfFaceName[cch] = 0;
 }
 
 /***********************************************************************

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1496,10 +1496,10 @@ BOOL WINAPI ImmGetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
 
     if (pIC->fdwInit & INIT_LOGFONT)
     {
-        if (!bWide)
-            LogFontAnsiToWide(&pIC->lfFont.A, lplf);
-        else
+        if (bWide)
             *lplf = pIC->lfFont.W;
+        else
+            LogFontAnsiToWide(&pIC->lfFont.A, lplf);
 
         ret = TRUE;
     }

--- a/sdk/include/reactos/wine/ddk/imm.h
+++ b/sdk/include/reactos/wine/ddk/imm.h
@@ -87,6 +87,14 @@ C_ASSERT(offsetof(INPUTCONTEXT, dwReserve) == 0x134);
 C_ASSERT(sizeof(INPUTCONTEXT) == 0x140);
 #endif
 
+// bits of fdwInit of INPUTCONTEXT
+#define INIT_STATUSWNDPOS               0x00000001
+#define INIT_CONVERSION                 0x00000002
+#define INIT_SENTENCE                   0x00000004
+#define INIT_LOGFONT                    0x00000008
+#define INIT_COMPFORM                   0x00000010
+#define INIT_SOFTKBDPOS                 0x00000020
+
 LPINPUTCONTEXT WINAPI ImmLockIMC(HIMC);
 
 #endif /* _WINE_IMM_H_ */


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Rewrite `ImmGetCompositionFontA` and `ImmGetCompositionFontW` functions.
- Add `INIT_*` macro definitions in `<ddk/imm.h>`.
