### PR TITLE
[NTOS:MM] Fix MiSetSystemCodeProtection

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2486,13 +2486,13 @@ MiWriteProtectSystemImage(
     /* Get the base address of the first section */
     SectionBase = Add2Ptr(ImageBase, SectionHeaders[0].VirtualAddress);
 
-    /* Start protecting the image header as R/O */
+    /* Start protecting the image header as R/W */
     FirstPte = MiAddressToPte(ImageBase);
     LastPte = MiAddressToPte(SectionBase) - 1;
-    Protection = IMAGE_SCN_MEM_READ;
+    Protection = IMAGE_SCN_MEM_READ | IMAGE_SCN_MEM_WRITE;
     if (LastPte >= FirstPte)
     {
-        MiSetSystemCodeProtection(FirstPte, LastPte, IMAGE_SCN_MEM_READ);
+        MiSetSystemCodeProtection(FirstPte, LastPte, Protection);
     }
 
     /* Loop the sections */


### PR DESCRIPTION
CORE-16387 CORE-17638
Windows only makes the header RO for session space mapped drivers (win32k, dx and display drivers)
