### PR TITLE
[IMM32_APITEST] Add clientimc testcase

### DIFF
--- a/modules/rostests/apitests/imm32/CMakeLists.txt
+++ b/modules/rostests/apitests/imm32/CMakeLists.txt
@@ -1,5 +1,8 @@
 
+include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+
 list(APPEND SOURCE
+    clientimc.c
     imcc.c
     testlist.c)
 

--- a/modules/rostests/apitests/imm32/clientimc.c
+++ b/modules/rostests/apitests/imm32/clientimc.c
@@ -1,0 +1,46 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for imm32 ImmLockClientImc/ImmUnlockClientImc
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
+#include <windows.h>
+#include <imm.h>
+#include <ddk/imm.h>
+#include <ndk/umtypes.h>
+#include <ndk/pstypes.h>
+#include "../../../win32ss/include/ntuser.h"
+#include <imm32_undoc.h>
+#include <ndk/rtlfuncs.h>
+#include <wine/test.h>
+#include <stdio.h>
+
+#if 0
+static void DumpBinary(LPCVOID pv, size_t cb)
+{
+    const BYTE *pb = pv;
+    while (cb--)
+    {
+        printf("%02X ", (BYTE)*pb++);
+    }
+    printf("\n");
+}
+#endif
+
+START_TEST(clientimc)
+{
+    CLIENTIMC ClientImc;
+    ZeroMemory(&ClientImc, sizeof(ClientImc));
+    ClientImc.cLockObj = 2;
+    ClientImc.dwFlags = 0;
+    RtlInitializeCriticalSection(&ClientImc.cs);
+
+    ImmUnlockClientImc(&ClientImc);
+    ok_long(ClientImc.cLockObj, 1);
+
+    ImmUnlockClientImc(&ClientImc);
+    ok_long(ClientImc.cLockObj, 0);
+}

--- a/modules/rostests/apitests/imm32/clientimc.c
+++ b/modules/rostests/apitests/imm32/clientimc.c
@@ -21,6 +21,7 @@ static void DumpBinary(LPCVOID pv, size_t cb)
 
 START_TEST(clientimc)
 {
+    DWORD dwCode;
     CLIENTIMC *pClientImc = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(CLIENTIMC));
 
     pClientImc->hImc = (HIMC)ImmCreateIMCC(4);
@@ -33,15 +34,17 @@ START_TEST(clientimc)
     ok_long(pClientImc->cLockObj, 1);
     ok_long(ImmGetIMCCSize(pClientImc->hImc), 4);
 
+    dwCode = 0;
     _SEH2_TRY
     {
         ImmUnlockClientImc(pClientImc);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
-        ;
+        dwCode = _SEH2_GetExceptionCode();
     }
     _SEH2_END;
+    ok_long(dwCode, STATUS_ACCESS_VIOLATION);
 
     ok_long(pClientImc->cLockObj, 0);
     ok_long(ImmGetIMCCSize(pClientImc->hImc), 0);

--- a/modules/rostests/apitests/imm32/clientimc.c
+++ b/modules/rostests/apitests/imm32/clientimc.c
@@ -5,18 +5,7 @@
  * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-#include <ntstatus.h>
-#define WIN32_NO_STATUS
-#include <windows.h>
-#include <imm.h>
-#include <ddk/imm.h>
-#include <ndk/umtypes.h>
-#include <ndk/pstypes.h>
-#include "../../../win32ss/include/ntuser.h"
-#include <imm32_undoc.h>
-#include <ndk/rtlfuncs.h>
-#include <wine/test.h>
-#include <stdio.h>
+#include "precomp.h"
 
 #if 0
 static void DumpBinary(LPCVOID pv, size_t cb)

--- a/modules/rostests/apitests/imm32/clientimc.c
+++ b/modules/rostests/apitests/imm32/clientimc.c
@@ -45,4 +45,6 @@ START_TEST(clientimc)
 
     ok_long(pClientImc->cLockObj, 0);
     ok_long(ImmGetIMCCSize(pClientImc->hImc), 0);
+
+    HeapFree(GetProcessHeap(), 0, pClientImc);
 }

--- a/modules/rostests/apitests/imm32/imcc.c
+++ b/modules/rostests/apitests/imm32/imcc.c
@@ -5,11 +5,7 @@
  * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */
 
-#include <ntstatus.h>
-#define WIN32_NO_STATUS
-#include <windows.h>
-#include <imm.h>
-#include "wine/test.h"
+#include "precomp.h"
 
 START_TEST(imcc)
 {

--- a/modules/rostests/apitests/imm32/precomp.h
+++ b/modules/rostests/apitests/imm32/precomp.h
@@ -5,6 +5,7 @@
 #include <windows.h>
 #include <imm.h>
 #include <ddk/imm.h>
+#include <pseh/pseh2.h>
 #include <ndk/umtypes.h>
 #include <ndk/pstypes.h>
 #include "../../../win32ss/include/ntuser.h"

--- a/modules/rostests/apitests/imm32/precomp.h
+++ b/modules/rostests/apitests/imm32/precomp.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <ntstatus.h>
+#define WIN32_NO_STATUS
+#include <windows.h>
+#include <imm.h>
+#include <ddk/imm.h>
+#include <ndk/umtypes.h>
+#include <ndk/pstypes.h>
+#include "../../../win32ss/include/ntuser.h"
+#include <imm32_undoc.h>
+#include <ndk/rtlfuncs.h>
+#include <wine/test.h>
+#include <stdio.h>

--- a/modules/rostests/apitests/imm32/testlist.c
+++ b/modules/rostests/apitests/imm32/testlist.c
@@ -2,10 +2,12 @@
 #define STANDALONE
 #include <wine/test.h>
 
+extern void func_clientimc(void);
 extern void func_imcc(void);
 
 const struct test winetest_testlist[] =
 {
+    { "clientimc", func_clientimc },
     { "imcc", func_imcc },
     { 0, 0 }
 };

--- a/sdk/include/reactos/imm32_undoc.h
+++ b/sdk/include/reactos/imm32_undoc.h
@@ -32,6 +32,9 @@ extern "C" {
 BOOL WINAPI
 ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx, IMEINFOEXCLASS SearchType, PVOID pvSearchKey);
 
+PCLIENTIMC WINAPI ImmLockClientImc(HIMC hImc);
+VOID WINAPI ImmUnlockClientImc(PCLIENTIMC pClientImc);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif


### PR DESCRIPTION
## Purpose
Add more testcase for proof.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `clientimc` testcase to `imm32_apitest`.
- Add `"precomp.h"`.

## Comparison

WinXP (Japanese):
![WinXP](https://user-images.githubusercontent.com/2107452/125229994-e2dd4300-e312-11eb-9e68-2a79af3c7172.png)
Successful.

Win2k3 (English):
![Win2k3](https://user-images.githubusercontent.com/2107452/125229996-e375d980-e312-11eb-9641-0a5f3e3e7d9e.png)
Successful.

Win10 x64 (Japanese):
![Win10](https://user-images.githubusercontent.com/2107452/125229998-e40e7000-e312-11eb-9150-57ee6c9090c8.png)
Successful.