### PR TITLE
[SHELL32] Add File Extension for BAT and CMD to auto tests for files to be executed

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -28,6 +28,8 @@ WINE_DEFAULT_DEBUG_CHANNEL(exec);
 static const WCHAR wszOpen[] = L"open";
 static const WCHAR wszExe[] = L".exe";
 static const WCHAR wszCom[] = L".com";
+static const WCHAR wszBat[] = L".bat";
+static const WCHAR wszCmd[] = L".cmd";
 
 #define SEE_MASK_CLASSALL (SEE_MASK_CLASSNAME | SEE_MASK_CLASSKEY)
 
@@ -2480,20 +2482,28 @@ HRESULT WINAPI ShellExecCmdLine(
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
         else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(NULL, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszBat, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, szFile, wszCmd, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(pwszStartDir, szFile, wszExe, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, szFile, wszCom, _countof(szFile2), szFile2, NULL))
+                 SearchPathW(pwszStartDir, szFile, wszBat, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, szFile, wszCmd, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
         else if (SearchPathW(NULL, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, lpCommand, wszExe, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(NULL, lpCommand, wszCom, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, lpCommand, wszExe, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, lpCommand, wszBat, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(NULL, lpCommand, wszCmd, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(pwszStartDir, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, lpCommand, wszCom, _countof(szFile2), szFile2, NULL) ||
                  SearchPathW(pwszStartDir, lpCommand, wszExe, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, lpCommand, wszCom, _countof(szFile2), szFile2, NULL))
+                 SearchPathW(pwszStartDir, lpCommand, wszBat, _countof(szFile2), szFile2, NULL) ||
+                 SearchPathW(pwszStartDir, lpCommand, wszCmd, _countof(szFile2), szFile2, NULL))
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
             pchParams = NULL;


### PR DESCRIPTION
## Allow files with extensions of BAT and CMD to be executed without having to add their extensions

_Extend the file extensions tested for auto execution by adding BAT and CMD._

JIRA issue: [CORE-17612](https://jira.reactos.org/browse/CORE-17612)

## Add additional programming lines to test for BAT and CMD to automatically tested file extensions.

Also while we are changing this code, we adjust the testing order in which the extensions are evaluated.
This order should be COM, EXE, BAT, and then CMD (first to last).
This is the fallback order even if the environment variable PATHEXT does not exist.

Testbot Results:

CORE-17612 JID59850 shlexec_cpp_02.patch on top of aea4cfb

KVM:  https://reactos.org/testman/compare.php?ids=78259,78265 LGTM
 VBox: https://reactos.org/testman/compare.php?ids=78261,78263 LGTM
