### PR TITLE
[CRT] mem/: Fix msvc14.0-amd64 build

### DIFF
--- a/sdk/lib/crt/mem/memchr.c
+++ b/sdk/lib/crt/mem/memchr.c
@@ -1,7 +1,7 @@
 
 #include <string.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (_MSC_VER >= 1910 || !defined(_WIN64))
 #pragma function(memchr)
 #endif /* _MSC_VER */
 

--- a/sdk/lib/crt/mem/memmove.c
+++ b/sdk/lib/crt/mem/memmove.c
@@ -1,6 +1,6 @@
 #include <string.h>
 
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (_MSC_VER >= 1910 || !defined(_WIN64))
 #pragma function(memmove)
 #endif /* _MSC_VER */
 


### PR DESCRIPTION
Fix (AppVeyor/GitHub) MSVC 14.0 amd64.
A.k.a. unbreak VS 2015 amd64 build. (VS 2017/2019 still have unrelated CORE-17585.)

Addendum to aea4cfb.

--

[Minimal testcase](https://github.com/SergeGautherie/reactos/actions/runs/1035792736):
```
sdk\lib\crt\mem\memchr.c(5): error C4163: 'memchr': not available as an intrinsic function
sdk\lib\crt\mem\memmove.c(4): error C4163: 'memmove': not available as an intrinsic function
```