### PR TITLE
[WIN32K:NTGDI] Improve failure handling a bit

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3537,7 +3537,8 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
         error = FT_Get_WinFNT_Header(face, &WinFNT);
         if (error)
         {
-            DPRINT1("%s: Failed to request font size.\n", face->family_name);
+            DPRINT1("'%S', %s: Failed to request font size\n",
+                    FontGDI->Filename, face->family_name);
             ASSERT(FALSE);
             return error;
         }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1205,11 +1205,10 @@ IntGdiLoadFontsFromMemory(PGDI_LOAD_FONT pLoadFont,
         PrivateEntry = ExAllocatePoolWithTag(PagedPool, sizeof(FONT_ENTRY_MEM), TAG_FONT);
         if (!PrivateEntry)
         {
-            if (FontGDI->Filename)
-                ExFreePoolWithTag(FontGDI->Filename, GDITAG_PFF);
             EngFreeMem(FontGDI);
             SharedFace_Release(SharedFace);
             ExFreePoolWithTag(Entry, TAG_FONT);
+            EngSetLastError(ERROR_NOT_ENOUGH_MEMORY);
             return 0;
         }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17682](https://jira.reactos.org/browse/CORE-17682)

## Proposed changes

- Remove useless code and call `EngSetLastError()`.
- Enhance a `DPRINT1()`.