### PR TITLE
[MSI] Fix MS Office 2000/2003 Installs by Wine-6.8 Sync of MSI_OpenPackageW

### DIFF
--- a/dll/win32/msi/package.c
+++ b/dll/win32/msi/package.c
@@ -1498,6 +1498,8 @@ UINT MSI_OpenPackageW(LPCWSTR szPackage, MSIPACKAGE **pPackage)
         r = get_local_package( file, localfile );
         if (r != ERROR_SUCCESS || GetFileAttributesW( localfile ) == INVALID_FILE_ATTRIBUTES)
         {
+            DWORD localfile_attr;
+
             r = msi_create_empty_local_file( localfile, dotmsi );
             if (r != ERROR_SUCCESS)
             {
@@ -1514,6 +1516,11 @@ UINT MSI_OpenPackageW(LPCWSTR szPackage, MSIPACKAGE **pPackage)
                 return r;
             }
             delete_on_close = TRUE;
+
+            /* Remove read-only bit, we are opening it with write access in MSI_OpenDatabaseW below. */
+            localfile_attr = GetFileAttributesW( localfile );
+            if (localfile_attr & FILE_ATTRIBUTE_READONLY)
+                SetFileAttributesW( localfile, localfile_attr & ~FILE_ATTRIBUTE_READONLY);
         }
         TRACE("opening package %s\n", debugstr_w( localfile ));
         r = MSI_OpenDatabaseW( localfile, MSIDBOPEN_TRANSACT, &db );


### PR DESCRIPTION
## Fix MS Office 2000/2003 Install Failures by updating MSI_OpenPackageW

_Partial Wine-6.8 sync of package.c for MSI_OpenPackageW._

JIRA issue: [CORE-17693](https://jira.reactos.org/browse/CORE-17693)

## Partial Wine Sync of MSI_OpenPackageW
