### PR TITLE
[VIDEOPRT] Fix updating of new registry path values

### DIFF
--- a/win32ss/drivers/videoprt/registry.c
+++ b/win32ss/drivers/videoprt/registry.c
@@ -498,41 +498,41 @@ IntCreateNewRegistryPath(
             ERR_(VIDEOPRT, "Failed create key '%wZ'\n", &DeviceExtension->NewRegistryPath);
             return Status;
         }
-
-        /* Open the new key */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &DeviceExtension->NewRegistryPath,
-                                   OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-        Status = ZwOpenKey(&NewKey, KEY_READ, &ObjectAttributes);
-        if (!NT_SUCCESS(Status))
-        {
-            ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
-            return Status;
-        }
-
-        /* Open the device profile key */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &DeviceExtension->RegistryPath,
-                                   OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-        Status = ZwOpenKey(&SettingsKey, KEY_READ, &ObjectAttributes);
-        if (!NT_SUCCESS(Status))
-        {
-            ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
-            ObCloseHandle(NewKey, KernelMode);
-            return Status;
-        }
-
-        /* Copy the registry data from the legacy key */
-        Status = IntCopyRegistryKey(SettingsKey, NewKey);
-
-        /* Close the key handles */
-        ObCloseHandle(SettingsKey, KernelMode);
-        ObCloseHandle(NewKey, KernelMode);
     }
+
+    /* Open the new key */
+    InitializeObjectAttributes(&ObjectAttributes,
+                                &DeviceExtension->NewRegistryPath,
+                                OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                NULL,
+                                NULL);
+    Status = ZwOpenKey(&NewKey, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        return Status;
+    }
+
+    /* Open the device profile key */
+    InitializeObjectAttributes(&ObjectAttributes,
+                                &DeviceExtension->RegistryPath,
+                                OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                NULL,
+                                NULL);
+    Status = ZwOpenKey(&SettingsKey, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        ObCloseHandle(NewKey, KernelMode);
+        return Status;
+    }
+
+    /* Copy the registry data from the legacy key */
+    Status = IntCopyRegistryKey(SettingsKey, NewKey);
+
+    /* Close the key handles */
+    ObCloseHandle(SettingsKey, KernelMode);
+    ObCloseHandle(NewKey, KernelMode);
 
     return Status;
 }

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1341,7 +1341,7 @@ NtUserToUnicodeEx(
     PWCHAR pwszBuff = NULL;
     INT i, iRet = 0;
     PKL pKl = NULL;
-    NTSTATUS Status;
+    NTSTATUS Status = STATUS_SUCCESS;
 
     TRACE("Enter NtUserSetKeyboardState\n");
 


### PR DESCRIPTION
JIRA issue: [CORE-17688](https://jira.reactos.org/browse/CORE-17688)

When a new driver is installed for the same device (like VBoxVideo), it uses the same hardware enum registry key and thus reuses the same DisplayId and the same display registry key. Therefore we need to update the setting in that key, even when the key already exists.

This seems to work good and not cause any issues, but testing indicated that on Windows some values are only updated, when the driver has changed. If neccessary, this can be achieved by updating and querying the ActiveService value in the device enum key (e.g. HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Enum\PCI\VEN_80EE&DEV_BEEF&SUSYS_00000000&REV_00\3&267a616a&0&10\Control: ActiveService). If that doesn't match the current device name (from DriverExtension->RegistryPath) the values should be copied over.

And also fixes an unrelated uninitialized variable introduced 3 weeks ago, which makes MSVC builds constantly break, but nobody seems to care about.