### PR TITLE
[NTOS:SE] Add/remove referenced logon sessions of tokens

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -353,6 +353,18 @@ SepCreateImpersonationTokenDacl(
     _Out_ PACL* Dacl
 );
 
+NTSTATUS
+NTAPI
+SepRmInsertLogonSessionIntoToken(
+    _Inout_ PTOKEN Token
+);
+
+NTSTATUS
+NTAPI
+SepRmRemoveLogonSessionFromToken(
+    _Inout_ PTOKEN Token
+);
+
 CODE_SEG("INIT")
 VOID
 NTAPI

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -170,25 +170,26 @@
 #define TAG_HDTB  'BTDH'
 
 /* Security Manager Tags */
-#define TAG_SE                '  eS'
-#define TAG_ACL               'cAeS'
-#define TAG_SID               'iSeS'
-#define TAG_SD                'dSeS'
-#define TAG_QOS               'sQeS'
-#define TAG_LUID              'uLeS'
-#define TAG_PRIVILEGE_SET     'rPeS'
-#define TAG_TOKEN_DYNAMIC     'dTeS'
-#define TAG_SE_HANDLES_TAB    'aHeS'
-#define TAG_SE_DIR_BUFFER     'bDeS'
-#define TAG_SE_PROXY_DATA     'dPoT'
-#define TAG_SE_TOKEN_LOCK     'lTeS'
+#define TAG_SE                 '  eS'
+#define TAG_ACL                'cAeS'
+#define TAG_SID                'iSeS'
+#define TAG_SD                 'dSeS'
+#define TAG_QOS                'sQeS'
+#define TAG_LUID               'uLeS'
+#define TAG_SEPA               'aPeS'
+#define TAG_PRIVILEGE_SET      'rPeS'
+#define TAG_TOKEN_DYNAMIC      'dTeS'
+#define TAG_SE_HANDLES_TAB     'aHeS'
+#define TAG_SE_DIR_BUFFER      'bDeS'
+#define TAG_SE_PROXY_DATA      'dPoT'
+#define TAG_SE_TOKEN_LOCK      'lTeS'
+#define TAG_LOGON_SESSION      'sLeS'
+#define TAG_LOGON_NOTIFICATION 'nLeS'
+#define TAG_SID_AND_ATTRIBUTES 'aSeS'
 
 /* LPC Tags */
 #define TAG_LPC_MESSAGE   'McpL'
 #define TAG_LPC_ZONE      'ZcpL'
-
-/* Se Process Audit */
-#define TAG_SEPA          'aPeS'
 
 #define TAG_WAIT            'tiaW'
 #define TAG_SEC_QUERY       'qSbO'

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -13,8 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define TAG_SID_AND_ATTRIBUTES 'aSeS'
-
 /* GLOBALS ********************************************************************/
 
 SID_IDENTIFIER_AUTHORITY SeNullSidAuthority = {SECURITY_NULL_SID_AUTHORITY};

--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -19,9 +19,6 @@ extern LUID SeAnonymousAuthenticationId;
 
 /* PRIVATE DEFINITIONS ********************************************************/
 
-#define SEP_LOGON_SESSION_TAG 'sLeS'
-#define SEP_LOGON_NOTIFICATION_TAG 'nLeS'
-
 typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION
 {
     struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION *Next;
@@ -334,7 +331,7 @@ SepRmCreateLogonSession(
     /* Allocate a new session structure */
     NewSession = ExAllocatePoolWithTag(PagedPool,
                                        sizeof(SEP_LOGON_SESSION_REFERENCES),
-                                       SEP_LOGON_SESSION_TAG);
+                                       TAG_LOGON_SESSION);
     if (NewSession == NULL)
     {
         return STATUS_INSUFFICIENT_RESOURCES;
@@ -375,7 +372,7 @@ Leave:
 
     if (!NT_SUCCESS(Status))
     {
-        ExFreePoolWithTag(NewSession, SEP_LOGON_SESSION_TAG);
+        ExFreePoolWithTag(NewSession, TAG_LOGON_SESSION);
     }
 
     return Status;
@@ -482,7 +479,7 @@ SepRmDeleteLogonSession(
     /* If we're here then we've deleted the logon session successfully */
     DPRINT("SepRmDeleteLogonSession(): Logon session deleted with success!\n");
     Status = STATUS_SUCCESS;
-    ExFreePoolWithTag(SessionToDelete, SEP_LOGON_SESSION_TAG);
+    ExFreePoolWithTag(SessionToDelete, TAG_LOGON_SESSION);
 
 Leave:
     /* Release the database lock */
@@ -1307,7 +1304,7 @@ SeRegisterLogonSessionTerminatedRoutine(
     /* Allocate a new notification item */
     Notification = ExAllocatePoolWithTag(PagedPool,
                                          sizeof(SEP_LOGON_SESSION_TERMINATED_NOTIFICATION),
-                                         SEP_LOGON_NOTIFICATION_TAG);
+                                         TAG_LOGON_NOTIFICATION);
     if (Notification == NULL)
         return STATUS_INSUFFICIENT_RESOURCES;
 
@@ -1373,7 +1370,7 @@ SeUnregisterLogonSessionTerminatedRoutine(
 
         /* Free the current notification item */
         ExFreePoolWithTag(Current,
-                          SEP_LOGON_NOTIFICATION_TAG);
+                          TAG_LOGON_NOTIFICATION);
 
         Status = STATUS_SUCCESS;
     }


### PR DESCRIPTION
With the introduction of a missing member of the TOKEN data structure in [`f5dc1c7`](https://github.com/reactos/reactos/commit/f5dc1c77b5803c35f7cc60ea53806d74d29ec3a7#diff-12dc4fd6f09d553b9b2dd23d1fb4a7462b79cee172b777ced18077cf75c24ea8) (why was this important member missing but whatever), we gotta have to implement session reference tracking of logons on tokens. 

The next step is to implement session referencing handling on LSASRV side by setting token information with `TokenSessionReference` for proper session referencing in tokens.

[CORE-17700](https://jira.reactos.org/browse/CORE-17700)