### PR TITLE
Pfn lock fix

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -46,6 +46,8 @@ extern SIZE_T MmtotalCommitLimitMaximum;
 extern PVOID MiDebugMapping; // internal
 extern PMMPTE MmDebugPte; // internal
 
+extern KSPIN_LOCK MmPfnLock;
+
 struct _KTRAP_FRAME;
 struct _EPROCESS;
 struct _MM_RMAP_ENTRY;
@@ -940,7 +942,11 @@ MmGetSectionAssociation(PFN_NUMBER Page,
                         PLARGE_INTEGER Offset);
 
 /* freelist.c **********************************************************/
-
+_IRQL_raises_(DISPATCH_LEVEL)
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Requires_lock_not_held_(MmPfnLock)
+_Acquires_lock_(MmPfnLock)
+_IRQL_saves_
 FORCEINLINE
 KIRQL
 MiAcquirePfnLock(VOID)
@@ -948,14 +954,20 @@ MiAcquirePfnLock(VOID)
     return KeAcquireQueuedSpinLock(LockQueuePfnLock);
 }
 
+_Requires_lock_held_(MmPfnLock)
+_Releases_lock_(MmPfnLock)
+_IRQL_requires_(DISPATCH_LEVEL)
 FORCEINLINE
 VOID
 MiReleasePfnLock(
-    _In_ KIRQL OldIrql)
+    _In_ _IRQL_restores_ KIRQL OldIrql)
 {
     KeReleaseQueuedSpinLock(LockQueuePfnLock, OldIrql);
 }
 
+_IRQL_requires_min_(DISPATCH_LEVEL)
+_Requires_lock_not_held_(MmPfnLock)
+_Acquires_lock_(MmPfnLock)
 FORCEINLINE
 VOID
 MiAcquirePfnLockAtDpcLevel(VOID)
@@ -967,6 +979,9 @@ MiAcquirePfnLockAtDpcLevel(VOID)
     KeAcquireQueuedSpinLockAtDpcLevel(LockQueue);
 }
 
+_Requires_lock_held_(MmPfnLock)
+_Releases_lock_(MmPfnLock)
+_IRQL_requires_min_(DISPATCH_LEVEL)
 FORCEINLINE
 VOID
 MiReleasePfnLockFromDpcLevel(VOID)
@@ -978,7 +993,7 @@ MiReleasePfnLockFromDpcLevel(VOID)
     ASSERT(KeGetCurrentIrql() >= DISPATCH_LEVEL);
 }
 
-#define MI_ASSERT_PFN_LOCK_HELD() ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL)
+#define MI_ASSERT_PFN_LOCK_HELD() NT_ASSERT((KeGetCurrentIrql() >= DISPATCH_LEVEL) && (MmPfnLock != 0))
 
 FORCEINLINE
 PMMPFN
@@ -1476,10 +1491,18 @@ MmUnsharePageEntrySectionSegment(PMEMORY_AREA MemoryArea,
                                  BOOLEAN PageOut,
                                  ULONG_PTR *InEntry);
 
+_When_(OldIrql == MM_NOIRQL, _IRQL_requires_max_(DISPATCH_LEVEL))
+_When_(OldIrql == MM_NOIRQL, _Requires_lock_not_held_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _Requires_lock_held_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _Releases_lock_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _IRQL_restores_(OldIrql))
+_When_(OldIrql != MM_NOIRQL, _IRQL_requires_(DISPATCH_LEVEL))
 VOID
 NTAPI
 MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql);
 
+_IRQL_requires_max_(DISPATCH_LEVEL)
+_Requires_lock_not_held_(MmPfnLock)
 FORCEINLINE
 VOID
 MmDereferenceSegment(PMM_SECTION_SEGMENT Segment)

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -987,6 +987,12 @@ FreeSegmentPage(PMM_SECTION_SEGMENT Segment, PLARGE_INTEGER Offset)
     MmReleasePageMemoryConsumer(MC_USER, Page);
 }
 
+_When_(OldIrql == MM_NOIRQL, _IRQL_requires_max_(DISPATCH_LEVEL))
+_When_(OldIrql == MM_NOIRQL, _Requires_lock_not_held_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _Requires_lock_held_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _Releases_lock_(MmPfnLock))
+_When_(OldIrql != MM_NOIRQL, _IRQL_restores_(OldIrql))
+_When_(OldIrql != MM_NOIRQL, _IRQL_requires_(DISPATCH_LEVEL))
 VOID
 NTAPI
 MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql)

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -991,27 +991,21 @@ VOID
 NTAPI
 MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql)
 {
-    BOOLEAN HaveLock = FALSE;
-
     /* Lock the PFN lock because we mess around with SectionObjectPointers */
     if (OldIrql == MM_NOIRQL)
     {
-        HaveLock = TRUE;
         OldIrql = MiAcquirePfnLock();
     }
 
     if (InterlockedDecrement64(Segment->ReferenceCount) > 0)
     {
         /* Nothing to do yet */
-        if (HaveLock)
-            MiReleasePfnLock(OldIrql);
+        MiReleasePfnLock(OldIrql);
         return;
     }
 
     *Segment->Flags |= MM_SEGMENT_INDELETE;
-
-    if (HaveLock)
-        MiReleasePfnLock(OldIrql);
+    MiReleasePfnLock(OldIrql);
 
     /* Flush the segment */
     if (*Segment->Flags & MM_DATAFILE_SEGMENT)
@@ -1019,13 +1013,11 @@ MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql)
         /* Free the page table. This will flush any remaining dirty data */
         MmFreePageTablesSectionSegment(Segment, FreeSegmentPage);
 
-        if (HaveLock)
-            OldIrql = MiAcquirePfnLock();
+        OldIrql = MiAcquirePfnLock();
         /* Delete the pointer on the file */
         ASSERT(Segment->FileObject->SectionObjectPointer->DataSectionObject == Segment);
         Segment->FileObject->SectionObjectPointer->DataSectionObject = NULL;
-        if (HaveLock)
-            MiReleasePfnLock(OldIrql);
+        MiReleasePfnLock(OldIrql);
         ObDereferenceObject(Segment->FileObject);
 
         ExFreePoolWithTag(Segment, TAG_MM_SECTION_SEGMENT);
@@ -1038,13 +1030,11 @@ MmDereferenceSegmentWithLock(PMM_SECTION_SEGMENT Segment, KIRQL OldIrql)
         ULONG NrSegments;
         ULONG i;
 
-        if (HaveLock)
-            OldIrql = MiAcquirePfnLock();
+        OldIrql = MiAcquirePfnLock();
         /* Delete the pointer on the file */
         ASSERT(ImageSectionObject->FileObject->SectionObjectPointer->ImageSectionObject == ImageSectionObject);
         ImageSectionObject->FileObject->SectionObjectPointer->ImageSectionObject = NULL;
-        if (HaveLock)
-            MiReleasePfnLock(OldIrql);
+        MiReleasePfnLock(OldIrql);
 
         ObDereferenceObject(ImageSectionObject->FileObject);
 
@@ -2128,8 +2118,8 @@ MmpDeleteSection(PVOID ObjectBody)
 
         /* We just dereference the first segment */
         ASSERT(ImageSectionObject->RefCount > 0);
+        /* MmDereferenceSegmentWithLock releases PFN lock */
         MmDereferenceSegmentWithLock(ImageSectionObject->Segments, OldIrql);
-        MiReleasePfnLock(OldIrql);
     }
     else
     {
@@ -2145,8 +2135,8 @@ MmpDeleteSection(PVOID ObjectBody)
         KIRQL OldIrql = MiAcquirePfnLock();
         Segment->SectionCount--;
 
+        /* MmDereferenceSegmentWithLock releases PFN lock */
         MmDereferenceSegmentWithLock(Segment, OldIrql);
-        MiReleasePfnLock(OldIrql);
     }
 }
 
@@ -4264,9 +4254,9 @@ MmFlushImageSection (IN PSECTION_OBJECT_POINTERS SectionObjectPointer,
                 /*
                  * Someone actually created a section while we were not looking.
                  * Drop our ref and deny.
+                 * MmDereferenceSegmentWithLock releases Pfn lock
                  */
                 MmDereferenceSegmentWithLock(&ImageSectionObject->Segments[0], OldIrql);
-                MiReleasePfnLock(OldIrql);
                 return FALSE;
             }
 
@@ -4276,7 +4266,6 @@ MmFlushImageSection (IN PSECTION_OBJECT_POINTERS SectionObjectPointer,
 
             /* Dereference the first segment, this will free everything & release the lock */
             MmDereferenceSegmentWithLock(&ImageSectionObject->Segments[0], OldIrql);
-            MiReleasePfnLock(OldIrql);
             return TRUE;
         }
         case MmFlushForWrite:


### PR DESCRIPTION
## Purpose

Do not hold PFN lock when freeing section data.

JIRA issue: [CORE-17690](https://jira.reactos.org/browse/CORE-17690) [CORE-17698](https://jira.reactos.org/browse/CORE-17698) 

## Proposed changes

Always release the PFN lock in MmDereferenceSegmentWithLock
Add relevant annotations for this function & MiAcquirePfnLock & friends

Split from #3798 
