### PR TITLE
[SHELL32] Implement SHGetShellStyleHInstance

### DIFF
--- a/dll/win32/shell32/stubs.cpp
+++ b/dll/win32/shell32/stubs.cpp
@@ -1315,14 +1315,3 @@ SHGetAttributesFromDataObject(IDataObject *pdo,
     FIXME("SHGetAttributesFromDataObject() stub\n");
     return E_NOTIMPL;
 }
-
-/*
- * Unimplemented
- */
-EXTERN_C HINSTANCE
-WINAPI
-SHGetShellStyleHInstance(VOID)
-{
-    FIXME("SHGetShellStyleHInstance() stub\n");
-    return NULL;
-}


### PR DESCRIPTION
## Purpose

Imlement SHGetShellStyleHInstance function, which loads theme's or system shellstyle.dll.
For now, shellstyle support is completely unimplemented. This function is required only for some MS system components from XP/2003, like Add/remove programs applet (appwiz.cpl) and Picture and Fax Viewer (shimgvw.dll).
It allows to properly start MS appwiz.cpl with our shell32.dll in Windows XP/2003 at least (only from Control Panel, from system32 it still crashes), in case shellstyle.dll exists in theme/system directory, but it still does not start yet in ReactOS.
Some another issue(s) are still preventing the correct work of it in ROS, but nevertheless shell32 part is now (partially) fixed.

JIRA issue: [CORE-17707](https://jira.reactos.org/browse/CORE-17707)

## Analysis

This is maximally similar implementation to what Windows does:
![shgetshellstylehinstance](https://user-images.githubusercontent.com/26385117/127026227-c0eed5ba-48ce-40a8-bf64-bb095412499c.png)

Although some calls are unresolved, nevertheless it's visible what this function does in general.

## Result

As visible on the following screenshots, at least in Windows XP/2003 with our shell32.dll, MS Add/remove programs applet (appwiz.cpl) is now starting/working properly (if to launch it from Control Panel). :slightly_smiling_face: 

Before:
![MS-appwiz-before](https://user-images.githubusercontent.com/26385117/127027165-40a10943-278f-47d7-98ac-2dfe122a1080.png)

After:
![MS-appwiz-after](https://user-images.githubusercontent.com/26385117/127027199-cb2720af-3410-4198-8519-935254378503.png)

But unfortunately, it still does not start in ReactOS, due to some other issue(s) from other component(s).

![appwiz-do-launch-crash](https://user-images.githubusercontent.com/26385117/127027521-24f55f43-cfeb-4dc1-9cb6-b1884f79ca4c.png)

If try to launch that from system32 directory without Control Panel (just by double-clicking), it crashes both in Windows and ReactOS. In this case, the problem is caused obviously by some another bug in our shell32, but in case of using Control Panel, the source of problem is caused by something other that causes an assert in (checked) MS duser.dll (used by appwiz.cpl) and prevents it from successful loading. :slightly_frowning_face: 