### PR TITLE
[MSI] Fix dialog.c showing two taskbar panes on Cancel

### DIFF
--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -171,6 +171,10 @@ static const WCHAR szHyperLink[] = {'H','y','p','e','r','L','i','n','k',0};
 static DWORD uiThreadId;
 static HWND hMsiHiddenWindow;
 
+#ifdef __REACTOS__
+static HANDLE hPrevious = NULL;
+#endif
+
 static LPWSTR msi_get_window_text( HWND hwnd )
 {
     UINT sz, r;
@@ -3819,6 +3823,9 @@ static LRESULT WINAPI MSIDialog_WndProc( HWND hwnd, UINT msg,
 
     case WM_DESTROY:
         dialog->hwnd = NULL;
+#ifdef __REACTOS__
+        hPrevious = NULL;
+#endif
         return 0;
     case WM_NOTIFY:
         return msi_dialog_onnotify( dialog, lParam );
@@ -3854,14 +3861,25 @@ static UINT dialog_run_message_loop( msi_dialog *dialog )
     if (dialog->parent == NULL && (dialog->attributes & msidbDialogAttributesMinimize))
         style |= WS_MINIMIZEBOX;
 
+#ifdef __REACTOS__
+    hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
+                     CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+                     hPrevious, NULL, NULL, dialog );
+#else
     hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
                      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                      NULL, NULL, NULL, dialog );
+#endif
+
     if( !hwnd )
     {
         ERR("Failed to create dialog %s\n", debugstr_w( dialog->name ));
         return ERROR_FUNCTION_FAILED;
     }
+
+#ifdef __REACTOS__
+    hPrevious = hwnd;
+#endif
 
     ShowWindow( hwnd, SW_SHOW );
     /* UpdateWindow( hwnd ); - and causes the transparent static controls not to paint */


### PR DESCRIPTION
## Fix Cancel showing second taskbar pane.

_Only show the main dialog pane in the taskbar when executing a Cancel dialog._

JIRA issue: [CORE-17702](https://jira.reactos.org/browse/CORE-17702)

## Assign previous hwnd as Parent to new Cancel dialog box.