### PR TITLE
Win32k heap checks

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -215,6 +215,7 @@ NTAPI
 IntDesktopObjectClose(
     _In_ PVOID Parameters)
 {
+    NTSTATUS Ret;
     PWIN32_CLOSEMETHOD_PARAMETERS CloseParameters = Parameters;
     PPROCESSINFO ppi = PsGetProcessWin32Process(CloseParameters->Process);
     if (ppi == NULL)
@@ -224,7 +225,10 @@ IntDesktopObjectClose(
         return STATUS_SUCCESS;
     }
 
-    return IntUnmapDesktopView((PDESKTOP)CloseParameters->Object);
+    UserEnterExclusive();
+    Ret = IntUnmapDesktopView((PDESKTOP)CloseParameters->Object);
+    UserLeave();
+    return Ret;
 }
 
 

--- a/win32ss/user/ntuser/desktop.h
+++ b/win32ss/user/ntuser/desktop.h
@@ -230,6 +230,8 @@ static __inline PVOID
 DesktopHeapAlloc(IN PDESKTOP Desktop,
                  IN SIZE_T Bytes)
 {
+    /* Desktop heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
     return RtlAllocateHeap(Desktop->pheapDesktop,
                            HEAP_NO_SERIALIZE,
                            Bytes);
@@ -239,6 +241,8 @@ static __inline BOOL
 DesktopHeapFree(IN PDESKTOP Desktop,
                 IN PVOID lpMem)
 {
+    /* Desktop heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
     return RtlFreeHeap(Desktop->pheapDesktop,
                        HEAP_NO_SERIALIZE,
                        lpMem);
@@ -258,6 +262,9 @@ DesktopHeapReAlloc(IN PDESKTOP Desktop,
 #else
     SIZE_T PrevSize;
     PVOID pNew;
+
+    /* Desktop heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
 
     PrevSize = RtlSizeHeap(Desktop->pheapDesktop,
                            HEAP_NO_SERIALIZE,

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -968,16 +968,7 @@ DriverEntry(
         return STATUS_UNSUCCESSFUL;
     }
 
-    /* Allocate global server info structure */
-    gpsi = UserHeapAlloc(sizeof(*gpsi));
-    if (!gpsi)
-    {
-        DPRINT1("Failed allocate server info structure!\n");
-        return STATUS_UNSUCCESSFUL;
-    }
-
-    RtlZeroMemory(gpsi, sizeof(*gpsi));
-    DPRINT("Global Server Data -> %p\n", gpsi);
+    NT_ROF(InitUserImpl());
 
     NT_ROF(InitGdiHandleTable());
     NT_ROF(InitPaletteImpl());
@@ -992,7 +983,6 @@ DriverEntry(
     NT_ROF(InitLDEVImpl());
     NT_ROF(InitDeviceImpl());
     NT_ROF(InitDcImpl());
-    NT_ROF(InitUserImpl());
     NT_ROF(InitWindowStationImpl());
     NT_ROF(InitDesktopImpl());
     NT_ROF(InitInputImpl());

--- a/win32ss/user/ntuser/ntuser.c
+++ b/win32ss/user/ntuser/ntuser.c
@@ -81,6 +81,20 @@ InitUserImpl(VOID)
 
     ExInitializeResourceLite(&UserLock);
 
+    /* Hold global resource to make sanity checks happy. */
+    UserEnterExclusive();
+
+    /* Allocate global server info structure */
+    gpsi = UserHeapAlloc(sizeof(*gpsi));
+    if (!gpsi)
+    {
+        ERR("Failed allocate server info structure!\n");
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    RtlZeroMemory(gpsi, sizeof(*gpsi));
+    TRACE("Global Server Data -> %p\n", gpsi);
+
     if (!UserCreateHandleTable())
     {
         ERR("Failed creating handle table\n");
@@ -107,6 +121,8 @@ InitUserImpl(VOID)
     }
 
     InitSysParams();
+
+    UserLeave();
 
     return STATUS_SUCCESS;
 }

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -761,7 +761,14 @@ NtUserCallHwndParam(
     switch (Routine)
     {
         case HWNDPARAM_ROUTINE_KILLSYSTEMTIMER:
-            return IntKillTimer(UserGetWindowObject(hWnd), (UINT_PTR)Param, TRUE);
+        {
+            DWORD ret;
+
+            UserEnterExclusive();
+            ret = IntKillTimer(UserGetWindowObject(hWnd), (UINT_PTR)Param, TRUE);
+            UserLeave();
+            return ret;
+        }
 
         case HWNDPARAM_ROUTINE_SETWNDCONTEXTHLPID:
         {

--- a/win32ss/user/ntuser/timer.c
+++ b/win32ss/user/ntuser/timer.c
@@ -635,19 +635,18 @@ NtUserSetTimer
 )
 {
    PWND Window = NULL;
-   DECLARE_RETURN(UINT_PTR);
+   UINT_PTR ret;
 
    TRACE("Enter NtUserSetTimer\n");
    UserEnterExclusive();
    if (hWnd) Window = UserGetWindowObject(hWnd);
+
+   ret = IntSetTimer(Window, nIDEvent, uElapse, lpTimerFunc, TMRF_TIFROMWND);
+
    UserLeave();
+   TRACE("Leave NtUserSetTimer, ret=%u\n", ret);
 
-   RETURN(IntSetTimer(Window, nIDEvent, uElapse, lpTimerFunc, TMRF_TIFROMWND));
-
-CLEANUP:
-   TRACE("Leave NtUserSetTimer, ret=%u\n", _ret_);
-
-   END_CLEANUP;
+   return ret;
 }
 
 
@@ -660,18 +659,18 @@ NtUserKillTimer
 )
 {
    PWND Window = NULL;
-   DECLARE_RETURN(BOOL);
+   BOOL ret;
 
    TRACE("Enter NtUserKillTimer\n");
    UserEnterExclusive();
    if (hWnd) Window = UserGetWindowObject(hWnd);
+
+   ret = IntKillTimer(Window, uIDEvent, FALSE);
+
    UserLeave();
 
-   RETURN(IntKillTimer(Window, uIDEvent, FALSE));
-
-CLEANUP:
-   TRACE("Leave NtUserKillTimer, ret=%i\n", _ret_);
-   END_CLEANUP;
+   TRACE("Leave NtUserKillTimer, ret=%i\n", ret);
+   return ret;
 }
 
 
@@ -684,15 +683,17 @@ NtUserSetSystemTimer(
    TIMERPROC lpTimerFunc
 )
 {
-   DECLARE_RETURN(UINT_PTR);
+    UINT_PTR ret;
 
-   TRACE("Enter NtUserSetSystemTimer\n");
+    UserEnterExclusive();
+    TRACE("Enter NtUserSetSystemTimer\n");
 
-   RETURN(IntSetTimer(UserGetWindowObject(hWnd), nIDEvent, uElapse, NULL, TMRF_SYSTEM));
+    ret = IntSetTimer(UserGetWindowObject(hWnd), nIDEvent, uElapse, NULL, TMRF_SYSTEM);
 
-CLEANUP:
-   TRACE("Leave NtUserSetSystemTimer, ret=%u\n", _ret_);
-   END_CLEANUP;
+    UserLeave();
+
+    TRACE("Leave NtUserSetSystemTimer, ret=%u\n", ret);
+    return ret;
 }
 
 BOOL

--- a/win32ss/user/ntuser/usrheap.c
+++ b/win32ss/user/ntuser/usrheap.c
@@ -163,7 +163,11 @@ IntUserHeapCreate(IN PVOID SectionObject,
     Parameters.InitialReserve = (SIZE_T)HeapSize;
     Parameters.CommitRoutine = IntUserHeapCommitRoutine;
 
-    pHeap = RtlCreateHeap(HEAP_ZERO_MEMORY | HEAP_NO_SERIALIZE,
+    pHeap = RtlCreateHeap(
+#if DBG /* Enable checks on debug builds */
+                          HEAP_FREE_CHECKING_ENABLED | HEAP_TAIL_CHECKING_ENABLED |
+#endif
+                          HEAP_ZERO_MEMORY | HEAP_NO_SERIALIZE,
                           *SystemMappedBase,
                           (SIZE_T)HeapSize,
                           ViewSize,

--- a/win32ss/user/ntuser/usrheap.h
+++ b/win32ss/user/ntuser/usrheap.h
@@ -33,6 +33,8 @@ MapGlobalUserHeap(IN  PEPROCESS Process,
 static __inline PVOID
 UserHeapAlloc(SIZE_T Bytes)
 {
+    /* User heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
     return RtlAllocateHeap(GlobalUserHeap,
                            HEAP_NO_SERIALIZE,
                            Bytes);
@@ -41,6 +43,8 @@ UserHeapAlloc(SIZE_T Bytes)
 static __inline BOOL
 UserHeapFree(PVOID lpMem)
 {
+    /* User heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
     return RtlFreeHeap(GlobalUserHeap,
                        HEAP_NO_SERIALIZE,
                        lpMem);
@@ -59,6 +63,9 @@ UserHeapReAlloc(PVOID lpMem,
 #else
     SIZE_T PrevSize;
     PVOID pNew;
+
+    /* User heap has no lock, using global user lock instead. */
+    ASSERT(UserIsEnteredExclusive());
 
     PrevSize = RtlSizeHeap(GlobalUserHeap,
                            HEAP_NO_SERIALIZE,

--- a/win32ss/win32kp.h
+++ b/win32ss/win32kp.h
@@ -58,9 +58,9 @@ typedef struct _DC *PDC;
 #include "user/ntuser/win32.h"
 #include "user/ntuser/tags.h"
 #ifndef __cplusplus
+#include "user/ntuser/ntuser.h"
 #include "user/ntuser/usrheap.h"
 #include "user/ntuser/object.h"
-#include "user/ntuser/ntuser.h"
 #include "user/ntuser/shutdown.h"
 #include "user/ntuser/cursoricon.h"
 #include "user/ntuser/accelerator.h"


### PR DESCRIPTION
## Purpose

Fix some win32k potential heap corruptions.

## Proposed changes

Enable Heap use-after-free & overflow helpers in debug build for win32k
ASSERT that we hold the user global lock when using win32k heaps
Fix bugs uncovered by the previous two.

