### PR TITLE
[UXTHEME][NTUSER] Fix flashing of scrollbar when scrolling

### DIFF
--- a/dll/win32/uxtheme/themehooks.c
+++ b/dll/win32/uxtheme/themehooks.c
@@ -576,6 +576,29 @@ dodefault:
     return g_user32ApiHook.GetScrollInfo(hwnd, fnBar, lpsi);
 }
 
+INT WINAPI ThemeSetScrollInfo(HWND hWnd, int fnBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
+{
+    PWND_DATA pwndData;
+    SCROLLINFO siout;
+    LPSCROLLINFO lpsiout = &siout;
+    BOOL IsThemed = FALSE;
+
+    pwndData = ThemeGetWndData(hWnd);
+
+    if (!pwndData)
+        goto dodefault;
+
+    if (pwndData->hthemeScrollbar)
+        IsThemed = TRUE;
+
+    memcpy(&siout, lpsi, sizeof(SCROLLINFO));
+    if (IsThemed)
+        siout.fMask |= SIF_THEMED;
+
+dodefault:
+    return g_user32ApiHook.SetScrollInfo(hWnd, fnBar, lpsiout, bRedraw);
+}
+
 /**********************************************************************
  *      Exports
  */
@@ -611,6 +634,7 @@ ThemeInitApiHook(UAPIHK State, PUSERAPIHOOK puah)
 
     puah->SetWindowRgn = ThemeSetWindowRgn;
     puah->GetScrollInfo = ThemeGetScrollInfo;
+    puah->SetScrollInfo = ThemeSetScrollInfo;
 
     UAH_HOOK_MESSAGE(puah->DefWndProcArray, WM_NCPAINT);
     UAH_HOOK_MESSAGE(puah->DefWndProcArray, WM_NCACTIVATE);

--- a/sdk/include/psdk/winuser.h
+++ b/sdk/include/psdk/winuser.h
@@ -1221,6 +1221,7 @@ extern "C" {
 #define SIF_RANGE 1
 #define SIF_DISABLENOSCROLL 8
 #define SIF_TRACKPOS   16
+#define SIF_THEMED 128      /* REACTOS Specific Only */
 #define SWP_DRAWFRAME 32
 #define SWP_FRAMECHANGED 32
 #define SWP_HIDEWINDOW 128


### PR DESCRIPTION
## Fix flashing of scrollbar arrows and interior when scrolling whether themed and not.

_Add themehook.c code to implement ThemeSetScrollInfo and use this to send Themed or not info to scrollbar.c._

JIRA issue: [CORE-16735](https://jira.reactos.org/browse/CORE-16735)

## Use I_Kill_Bugs code to fix scrollbar flashing when using themes.

_This fixes scrollbar arrows and interior flashing both when themed and not themed._