### PR TITLE
[GITHUB] Remove VS 2015 build from the CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,24 +84,14 @@ jobs:
   build-msvc:
     strategy:
       matrix:
-        os: [windows-latest, windows-2019]
-        toolset: ['14.2', '14.1', '14.0'] # VS 2019, 2017, and 2015 (see below)
+        os: [windows-latest]
+        toolset: ['14.2', '14.1'] # VS 2019, and 2017 (see below)
         arch: [i386, amd64]
         config: [Debug, Release]
         dllver: ['0x502', '0x600']
-        exclude: # VS 2019, 2017 only with windows-latest; VS 2015 only with windows-2019
-          - os: windows-2019
-            toolset: '14.2'
-          - os: windows-2019
-            toolset: '14.1'
-          - os: windows-latest
-            toolset: '14.0'
-          - dllver: 0x600
-            os: windows-2019
+        exclude: # VS 2019, 2017 only with windows-latest
           - dllver: 0x600
             toolset: '14.1'
-          - dllver: 0x600
-            toolset: '14.0'
           - dllver: 0x600
             config: Release
       fail-fast: false

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The code of ReactOS is licensed under [GNU GPL 2.0](https://github.com/reactos/r
 To build the system it is strongly advised to use the _ReactOS Build Environment (RosBE)._
 Up-to-date versions for Windows and for Unix/GNU-Linux are available from our download page at: ["Build Environment"](https://reactos.org/wiki/Build_Environment).
 
-Alternatively one can use Microsoft Visual C++ (MSVC) version 2015+. Building with MSVC is covered here: ["Visual Studio or Microsoft Visual C++"](https://reactos.org/wiki/CMake#Visual_Studio_or_Microsoft_Visual_C.2B.2B).
+Alternatively one can use Microsoft Visual C++ (MSVC) version 2019+. Building with MSVC is covered here: ["Visual Studio or Microsoft Visual C++"](https://reactos.org/wiki/CMake#Visual_Studio_or_Microsoft_Visual_C.2B.2B).
 
 See ["Building ReactOS"](https://reactos.org/wiki/Building_ReactOS) article for more details.
 


### PR DESCRIPTION
Let's establish a set of rules regarding compiler support in ReactOS to avoid holywars in future.

## Proposed rules
- We officially support __no more than two versions__ of each compiler.
- The term "officially supported" means there is a job on one of our CI systems (either GitHub Actions or BuildBot) checking both Debug and Release builds for this compiler for supported platforms (currently it is i386 and amd64). Every developer has to check changes against those compilers and/or fix breakages ASAP if they happen.
- Two versions usually mean having one "stable" version which is not changed often and one "latest" version. For example, VS 2017 and VS 2019 (or that will likely be VS 2022 soon) or RosBE-provided GCC 8.4.0 and the current latest release (GCC 11.1.0).
- "stable" compiler should be upgraded once in 2-3 years, or by a demand (for example, when it can't support our code anymore without too many hacks)
- Contributors can maintain support for other compilers and toolchains, but the topic of merging such changes should be treated carefully. First of all, it shouldn't require too many changes in our code base, especially for 3rd party modules.

So according to this set of rules, I suggest to leave these compilers as "officially supported":
- GCC 8.4.0 for RosBE (aka "gcc-stable")
- MSVC/VS 2019 (aka "msvc-latest")
- MSVC/VS 2017 (aka "msvc-stable")
- LLVM/Clang 12 (with MSVC and GNU-like APIs) (aka "clang-latest")

Clang does not have a "stable" version yet, as the work about its support is still in progress.

## Reasoning
- Supporting each compiler requires an extra effort from every developer contributing to the project. Considering the size of our team, I think we may spend that time on something more useful. 4 versions is already a lot.
- The more a compiler gets old, the more work is required to update the codebase for a newer version. Remember our GCC 4.7.2 -> 8.4.0 transition, it took about 1.5 years in total to make it stable.
- Old compilers don't support newer language features and static analysis hints. This is especially relevant considering our plan to incorporate libcxx (LLVM's C++ standard library) into our project.
- Supporting two versions of a compiler is motivated by a fact that the majority of developers prefer using newer tooling, but that may lead to breakages from the compiler side (I'm looking at you, MSVC). In such a case, it is always better to have a more stable base to verify that the breakage is really caused by a compiler.


Additions and remarks are welcome.