### PR TITLE
[NTFS] New defines & stub for reading encrypted files

### DIFF
--- a/drivers/filesystems/ntfs/fcb.c
+++ b/drivers/filesystems/ntfs/fcb.c
@@ -144,6 +144,12 @@ NtfsFCBIsCompressed(PNTFS_FCB Fcb)
 }
 
 BOOLEAN
+NtfsFCBIsEncrypted(PNTFS_FCB Fcb)
+{
+    return ((Fcb->Entry.FileAttributes & NTFS_FILE_TYPE_ENCRYPTED) == NTFS_FILE_TYPE_ENCRYPTED);
+}
+
+BOOLEAN
 NtfsFCBIsRoot(PNTFS_FCB Fcb)
 {
     return (wcscmp(Fcb->PathName, L"\\") == 0);

--- a/drivers/filesystems/ntfs/ntfs.h
+++ b/drivers/filesystems/ntfs/ntfs.h
@@ -936,6 +936,9 @@ BOOLEAN
 NtfsFCBIsCompressed(PNTFS_FCB Fcb);
 
 BOOLEAN
+NtfsFCBIsEncrypted(PNTFS_FCB Fcb);
+
+BOOLEAN
 NtfsFCBIsRoot(PNTFS_FCB Fcb);
 
 VOID

--- a/drivers/filesystems/ntfs/ntfs.h
+++ b/drivers/filesystems/ntfs/ntfs.h
@@ -223,8 +223,12 @@ typedef enum
 #define NTFS_FILE_TYPE_HIDDEN     0x2
 #define NTFS_FILE_TYPE_SYSTEM     0x4
 #define NTFS_FILE_TYPE_ARCHIVE    0x20
+#define NTFS_FILE_TYPE_TEMPORARY  0x100
+#define NTFS_FILE_TYPE_SPARSE     0x200
 #define NTFS_FILE_TYPE_REPARSE    0x400
 #define NTFS_FILE_TYPE_COMPRESSED 0x800
+#define NTFS_FILE_TYPE_OFFLINE    0x1000
+#define NTFS_FILE_TYPE_ENCRYPTED  0x4000
 #define NTFS_FILE_TYPE_DIRECTORY  0x10000000
 
 /* Indexed Flag in Resident attributes - still somewhat speculative */

--- a/drivers/filesystems/ntfs/rw.c
+++ b/drivers/filesystems/ntfs/rw.c
@@ -79,6 +79,13 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
         return STATUS_NOT_IMPLEMENTED;
     }
 
+    if (NtfsFCBIsEncrypted(Fcb))
+    {
+        DPRINT1("Encrypted file!\n");
+        UNIMPLEMENTED;
+        return STATUS_NOT_IMPLEMENTED;
+    }
+
     FileRecord = ExAllocateFromNPagedLookasideList(&DeviceExt->FileRecLookasideList);
     if (FileRecord == NULL)
     {


### PR DESCRIPTION
## Purpose
We shoudn't read file if it's encrypted.
Also I added several new defines for future contributions.

## Proposed changes
- Add new defines for NTFS's file attributes
- Don't read file if it's encrypted

