### PR TITLE
[IMM32] Rewrite ImmSetCompositionFontA/W

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3480,24 +3480,26 @@ BOOL WINAPI ImmSetCandidateWindow(
 static VOID APIENTRY WideToAnsiLogFont(const LOGFONTW *plfW, LPLOGFONTA plfA)
 {
     BOOL bUsedDef;
-    size_t cchW;
-    const size_t cchA = _countof(plfA->lfFaceName);
+    size_t cchW, cchA = _countof(plfA->lfFaceName);
     RtlCopyMemory(plfA, plfW, offsetof(LOGFONTA, lfFaceName));
     StringCchLengthW(plfW->lfFaceName, _countof(plfW->lfFaceName), &cchW);
-    WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cchW,
-                        plfA->lfFaceName, (INT)cchA, NULL, &bUsedDef);
-    plfA->lfFaceName[cchA - 1] = 0;
+    cchA = WideCharToMultiByte(CP_ACP, 0, plfW->lfFaceName, (INT)cchW,
+                               plfA->lfFaceName, (INT)cchA, NULL, &bUsedDef);
+    if (cchA > _countof(plfA->lfFaceName) - 1)
+        cchA = _countof(plfA->lfFaceName) - 1;
+    plfA->lfFaceName[cchA] = 0;
 }
 
 static VOID APIENTRY AnsiToWideLogFont(const LOGFONTA *plfA, LPLOGFONTW plfW)
 {
-    size_t cchA;
-    const size_t cchW = _countof(plfW->lfFaceName);
-    RtlCopyMemory(plfW, plfA, offsetof(LOGFONTA, lfFaceName));
+    size_t cchA, cchW = _countof(plfW->lfFaceName);
+    RtlCopyMemory(plfW, plfA, offsetof(LOGFONTW, lfFaceName));
     StringCchLengthA(plfA->lfFaceName, _countof(plfA->lfFaceName), &cchA);
-    MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cchA,
-                        plfW->lfFaceName, cchW);
-    plfW->lfFaceName[cchW - 1] = 0;
+    cchW = MultiByteToWideChar(CP_ACP, MB_PRECOMPOSED, plfA->lfFaceName, (INT)cchA,
+                               plfW->lfFaceName, cchW);
+    if (cchW > _countof(plfW->lfFaceName) - 1)
+        cchW = _countof(plfW->lfFaceName) - 1;
+    plfW->lfFaceName[cchW] = 0;
 }
 
 /***********************************************************************

--- a/sdk/include/reactos/wine/ddk/imm.h
+++ b/sdk/include/reactos/wine/ddk/imm.h
@@ -87,6 +87,24 @@ C_ASSERT(offsetof(INPUTCONTEXT, dwReserve) == 0x134);
 C_ASSERT(sizeof(INPUTCONTEXT) == 0x140);
 #endif
 
+typedef struct INPUTCONTEXTDX /* unconfirmed */
+{
+    INPUTCONTEXT;
+    UINT nVKey;
+    BOOL bHasVKey;
+    DWORD dwUnknown148;
+    DWORD dwUIFlags;
+    DWORD dwUnknown150;
+    void *pUnknown154;
+    /* ... */
+} INPUTCONTEXTDX, *LPINPUTCONTEXTDX;
+
+#ifndef _WIN64
+C_ASSERT(offsetof(INPUTCONTEXTDX, nVKey) == 0x140);
+C_ASSERT(offsetof(INPUTCONTEXTDX, bHasVKey) == 0x144);
+C_ASSERT(offsetof(INPUTCONTEXTDX, dwUIFlags) == 0x14c);
+#endif
+
 // bits of fdwInit of INPUTCONTEXT
 #define INIT_STATUSWNDPOS               0x00000001
 #define INIT_CONVERSION                 0x00000002
@@ -94,6 +112,25 @@ C_ASSERT(sizeof(INPUTCONTEXT) == 0x140);
 #define INIT_LOGFONT                    0x00000008
 #define INIT_COMPFORM                   0x00000010
 #define INIT_SOFTKBDPOS                 0x00000020
+
+#ifndef WM_IME_REPORT
+    #define WM_IME_REPORT 0x280
+#endif
+
+// WM_IME_REPORT wParam
+#define IR_STRINGSTART   0x100
+#define IR_STRINGEND     0x101
+#define IR_OPENCONVERT   0x120
+#define IR_CHANGECONVERT 0x121
+#define IR_CLOSECONVERT  0x122
+#define IR_FULLCONVERT   0x123
+#define IR_IMESELECT     0x130
+#define IR_STRING        0x140
+#define IR_DBCSCHAR      0x160
+#define IR_UNDETERMINE   0x170
+#define IR_STRINGEX      0x180
+#define IR_MODEINFO      0x190
+
 
 LPINPUTCONTEXT WINAPI ImmLockIMC(HIMC);
 


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `WideToAnsiLogFont` and `AnsiToWideLogFont` helper functions.
- Rewrite `ImmSetCompositionFontA` and `ImmSetCompositionFontW` functions.
- Add `INPUTCONTEXTDX` structure as an extension of `INPUTCONTEXT`.