### PR TITLE
[NTOS:SE] Document the whole subsystem in Doxygen format

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -36,7 +36,8 @@ typedef struct _TOKEN_AUDIT_POLICY_INFORMATION
 
 FORCEINLINE
 PSID
-SepGetGroupFromDescriptor(PVOID _Descriptor)
+SepGetGroupFromDescriptor(
+    _Inout_ PVOID _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -55,7 +56,8 @@ SepGetGroupFromDescriptor(PVOID _Descriptor)
 
 FORCEINLINE
 PSID
-SepGetOwnerFromDescriptor(PVOID _Descriptor)
+SepGetOwnerFromDescriptor(
+    _Inout_ PVOID _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -74,7 +76,8 @@ SepGetOwnerFromDescriptor(PVOID _Descriptor)
 
 FORCEINLINE
 PACL
-SepGetDaclFromDescriptor(PVOID _Descriptor)
+SepGetDaclFromDescriptor(
+    _Inout_ PVOID _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -95,7 +98,8 @@ SepGetDaclFromDescriptor(PVOID _Descriptor)
 
 FORCEINLINE
 PACL
-SepGetSaclFromDescriptor(PVOID _Descriptor)
+SepGetSaclFromDescriptor(
+    _Inout_ PVOID _Descriptor)
 {
     PISECURITY_DESCRIPTOR Descriptor = (PISECURITY_DESCRIPTOR)_Descriptor;
     PISECURITY_DESCRIPTOR_RELATIVE SdRel;
@@ -236,27 +240,24 @@ extern PTOKEN SeAnonymousLogonTokenNoEveryone;
 BOOLEAN
 NTAPI
 SepTokenIsOwner(
-    IN PACCESS_TOKEN _Token,
-    IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-    IN BOOLEAN TokenLocked
-);
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ BOOLEAN TokenLocked);
 
 BOOLEAN
 NTAPI
 SepSidInToken(
-    IN PACCESS_TOKEN _Token,
-    IN PSID Sid
-);
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSID Sid);
 
 BOOLEAN
 NTAPI
 SepSidInTokenEx(
-    IN PACCESS_TOKEN _Token,
-    IN PSID PrincipalSelfSid,
-    IN PSID _Sid,
-    IN BOOLEAN Deny,
-    IN BOOLEAN Restricted
-);
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSID PrincipalSelfSid,
+    _In_ PSID _Sid,
+    _In_ BOOLEAN Deny,
+    _In_ BOOLEAN Restricted);
 
 BOOLEAN
 NTAPI
@@ -301,69 +302,62 @@ SeRmInitPhase1(VOID);
 
 VOID
 NTAPI
-SeDeassignPrimaryToken(struct _EPROCESS *Process);
+SeDeassignPrimaryToken(
+    _Inout_ PEPROCESS Process);
 
 NTSTATUS
 NTAPI
 SeSubProcessToken(
-    IN PTOKEN Parent,
-    OUT PTOKEN *Token,
-    IN BOOLEAN InUse,
-    IN ULONG SessionId
-);
+    _In_ PTOKEN Parent,
+    _Out_ PTOKEN *Token,
+    _In_ BOOLEAN InUse,
+    _In_ ULONG SessionId);
 
 NTSTATUS
 NTAPI
 SeInitializeProcessAuditName(
-    IN PFILE_OBJECT FileObject,
-    IN BOOLEAN DoAudit,
-    OUT POBJECT_NAME_INFORMATION *AuditInfo
-);
+    _In_ PFILE_OBJECT FileObject,
+    _In_ BOOLEAN DoAudit,
+    _Out_ POBJECT_NAME_INFORMATION *AuditInfo);
 
 NTSTATUS
 NTAPI
 SeCreateAccessStateEx(
-    IN PETHREAD Thread,
-    IN PEPROCESS Process,
-    IN OUT PACCESS_STATE AccessState,
-    IN PAUX_ACCESS_DATA AuxData,
-    IN ACCESS_MASK Access,
-    IN PGENERIC_MAPPING GenericMapping
-);
+    _In_ PETHREAD Thread,
+    _In_ PEPROCESS Process,
+    _In_ OUT PACCESS_STATE AccessState,
+    _In_ PAUX_ACCESS_DATA AuxData,
+    _In_ ACCESS_MASK Access,
+    _In_ PGENERIC_MAPPING GenericMapping);
 
 NTSTATUS
 NTAPI
 SeIsTokenChild(
-    IN PTOKEN Token,
-    OUT PBOOLEAN IsChild
-);
+    _In_ PTOKEN Token,
+    _Out_ PBOOLEAN IsChild);
 
 NTSTATUS
 NTAPI
 SeIsTokenSibling(
-    IN PTOKEN Token,
-    OUT PBOOLEAN IsSibling
-);
+    _In_ PTOKEN Token,
+    _Out_ PBOOLEAN IsSibling);
 
 NTSTATUS
 NTAPI
 SepCreateImpersonationTokenDacl(
     _In_ PTOKEN Token,
     _In_ PTOKEN PrimaryToken,
-    _Out_ PACL* Dacl
-);
+    _Out_ PACL* Dacl);
 
 NTSTATUS
 NTAPI
 SepRmInsertLogonSessionIntoToken(
-    _Inout_ PTOKEN Token
-);
+    _Inout_ PTOKEN Token);
 
 NTSTATUS
 NTAPI
 SepRmRemoveLogonSessionFromToken(
-    _Inout_ PTOKEN Token
-);
+    _Inout_ PTOKEN Token);
 
 CODE_SEG("INIT")
 VOID
@@ -385,63 +379,61 @@ SepCreateSystemAnonymousLogonTokenNoEveryone(VOID);
 
 BOOLEAN
 NTAPI
-SeDetailedAuditingWithToken(IN PTOKEN Token);
+SeDetailedAuditingWithToken(
+    _In_ PTOKEN Token);
 
 VOID
 NTAPI
-SeAuditProcessExit(IN PEPROCESS Process);
+SeAuditProcessExit(
+    _In_ PEPROCESS Process);
 
 VOID
 NTAPI
-SeAuditProcessCreate(IN PEPROCESS Process);
+SeAuditProcessCreate(
+    _In_ PEPROCESS Process);
 
 NTSTATUS
 NTAPI
 SeExchangePrimaryToken(
     _In_ PEPROCESS Process,
     _In_ PACCESS_TOKEN NewAccessToken,
-    _Out_ PACCESS_TOKEN* OldAccessToken
-);
+    _Out_ PACCESS_TOKEN* OldAccessToken);
 
 VOID
 NTAPI
 SeCaptureSubjectContextEx(
-    IN PETHREAD Thread,
-    IN PEPROCESS Process,
-    OUT PSECURITY_SUBJECT_CONTEXT SubjectContext
-);
+    _In_ PETHREAD Thread,
+    _In_ PEPROCESS Process,
+    _Out_ PSECURITY_SUBJECT_CONTEXT SubjectContext);
 
 NTSTATUS
 NTAPI
 SeCaptureLuidAndAttributesArray(
-    PLUID_AND_ATTRIBUTES Src,
-    ULONG PrivilegeCount,
-    KPROCESSOR_MODE PreviousMode,
-    PLUID_AND_ATTRIBUTES AllocatedMem,
-    ULONG AllocatedLength,
-    POOL_TYPE PoolType,
-    BOOLEAN CaptureIfKernel,
-    PLUID_AND_ATTRIBUTES* Dest,
-    PULONG Length
-);
+    _In_ PLUID_AND_ATTRIBUTES Src,
+    _In_ ULONG PrivilegeCount,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _In_ PLUID_AND_ATTRIBUTES AllocatedMem,
+    _In_ ULONG AllocatedLength,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PLUID_AND_ATTRIBUTES* Dest,
+    _Inout_ PULONG Length);
 
 VOID
 NTAPI
 SeReleaseLuidAndAttributesArray(
-    PLUID_AND_ATTRIBUTES Privilege,
-    KPROCESSOR_MODE PreviousMode,
-    BOOLEAN CaptureIfKernel
-);
+    _In_ PLUID_AND_ATTRIBUTES Privilege,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _In_ BOOLEAN CaptureIfKernel);
 
 BOOLEAN
 NTAPI
 SepPrivilegeCheck(
-    PTOKEN Token,
-    PLUID_AND_ATTRIBUTES Privileges,
-    ULONG PrivilegeCount,
-    ULONG PrivilegeControl,
-    KPROCESSOR_MODE PreviousMode
-);
+    _In_ PTOKEN Token,
+    _In_ PLUID_AND_ATTRIBUTES Privileges,
+    _In_ ULONG PrivilegeCount,
+    _In_ ULONG PrivilegeControl,
+    _In_ KPROCESSOR_MODE PreviousMode);
 
 NTSTATUS
 NTAPI
@@ -456,11 +448,10 @@ SePrivilegePolicyCheck(
 BOOLEAN
 NTAPI
 SeCheckPrivilegedObject(
-    IN LUID PrivilegeValue,
-    IN HANDLE ObjectHandle,
-    IN ACCESS_MASK DesiredAccess,
-    IN KPROCESSOR_MODE PreviousMode
-);
+    _In_ LUID PrivilegeValue,
+    _In_ HANDLE ObjectHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ KPROCESSOR_MODE PreviousMode);
 
 NTSTATUS
 NTAPI
@@ -471,8 +462,7 @@ SepDuplicateToken(
     _In_ TOKEN_TYPE TokenType,
     _In_ SECURITY_IMPERSONATION_LEVEL Level,
     _In_ KPROCESSOR_MODE PreviousMode,
-    _Out_ PTOKEN* NewAccessToken
-);
+    _Out_ PTOKEN* NewAccessToken);
 
 NTSTATUS
 NTAPI
@@ -482,34 +472,30 @@ SepCaptureSecurityQualityOfService(
     _In_ POOL_TYPE PoolType,
     _In_ BOOLEAN CaptureIfKernel,
     _Out_ PSECURITY_QUALITY_OF_SERVICE *CapturedSecurityQualityOfService,
-    _Out_ PBOOLEAN Present
-);
+    _Out_ PBOOLEAN Present);
 
 VOID
 NTAPI
 SepReleaseSecurityQualityOfService(
     _In_opt_ PSECURITY_QUALITY_OF_SERVICE CapturedSecurityQualityOfService,
     _In_ KPROCESSOR_MODE AccessMode,
-    _In_ BOOLEAN CaptureIfKernel
-);
+    _In_ BOOLEAN CaptureIfKernel);
 
 NTSTATUS
 NTAPI
 SepCaptureSid(
-    IN PSID InputSid,
-    IN KPROCESSOR_MODE AccessMode,
-    IN POOL_TYPE PoolType,
-    IN BOOLEAN CaptureIfKernel,
-    OUT PSID *CapturedSid
-);
+    _In_ PSID InputSid,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PSID *CapturedSid);
 
 VOID
 NTAPI
 SepReleaseSid(
-    IN PSID CapturedSid,
-    IN KPROCESSOR_MODE AccessMode,
-    IN BOOLEAN CaptureIfKernel
-);
+    _In_ PSID CapturedSid,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ BOOLEAN CaptureIfKernel);
 
 NTSTATUS
 NTAPI
@@ -540,20 +526,18 @@ SeComputeQuotaInformationSize(
 NTSTATUS
 NTAPI
 SepCaptureAcl(
-    IN PACL InputAcl,
-    IN KPROCESSOR_MODE AccessMode,
-    IN POOL_TYPE PoolType,
-    IN BOOLEAN CaptureIfKernel,
-    OUT PACL *CapturedAcl
-);
+    _In_ PACL InputAcl,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PACL *CapturedAcl);
 
 VOID
 NTAPI
 SepReleaseAcl(
-    IN PACL CapturedAcl,
-    IN KPROCESSOR_MODE AccessMode,
-    IN BOOLEAN CaptureIfKernel
-);
+    _In_ PACL CapturedAcl,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ BOOLEAN CaptureIfKernel);
 
 NTSTATUS
 SepPropagateAcl(
@@ -584,32 +568,29 @@ SepSelectAcl(
 NTSTATUS
 NTAPI
 SeDefaultObjectMethod(
-    PVOID Object,
-    SECURITY_OPERATION_CODE OperationType,
-    PSECURITY_INFORMATION SecurityInformation,
-    PSECURITY_DESCRIPTOR NewSecurityDescriptor,
-    PULONG ReturnLength,
-    PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
-    POOL_TYPE PoolType,
-    PGENERIC_MAPPING GenericMapping
-);
+    _In_ PVOID Object,
+    _In_ SECURITY_OPERATION_CODE OperationType,
+    _In_ PSECURITY_INFORMATION SecurityInformation,
+    _Inout_opt_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Inout_opt_ PULONG ReturnLength,
+    _Inout_opt_ PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
+    _In_ POOL_TYPE PoolType,
+    _In_ PGENERIC_MAPPING GenericMapping);
 
 NTSTATUS
 NTAPI
 SeSetWorldSecurityDescriptor(
-    SECURITY_INFORMATION SecurityInformation,
-    PISECURITY_DESCRIPTOR SecurityDescriptor,
-    PULONG BufferLength
-);
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _In_ PISECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PULONG BufferLength);
 
 NTSTATUS
 NTAPI
 SeCopyClientToken(
-    IN PACCESS_TOKEN Token,
-    IN SECURITY_IMPERSONATION_LEVEL Level,
-    IN KPROCESSOR_MODE PreviousMode,
-    OUT PACCESS_TOKEN* NewToken
-);
+    _In_ PACCESS_TOKEN Token,
+    _In_ SECURITY_IMPERSONATION_LEVEL Level,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _Out_ PACCESS_TOKEN* NewToken);
 
 NTSTATUS
 NTAPI
@@ -620,20 +601,25 @@ SepRegQueryHelper(
     _In_ ULONG DataLength,
     _Out_ PVOID ValueData);
 
-VOID NTAPI
-SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
-                          OUT PACCESS_MASK DesiredAccess);
+VOID 
+NTAPI
+SeQuerySecurityAccessMask(
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _Out_ PACCESS_MASK DesiredAccess);
 
-VOID NTAPI
-SeSetSecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
-                        OUT PACCESS_MASK DesiredAccess);
+VOID 
+NTAPI
+SeSetSecurityAccessMask(
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _Out_ PACCESS_MASK DesiredAccess);
 
 BOOLEAN
 NTAPI
-SeFastTraverseCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                    IN PACCESS_STATE AccessState,
-                    IN ACCESS_MASK DesiredAccess,
-                    IN KPROCESSOR_MODE AccessMode);
+SeFastTraverseCheck(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PACCESS_STATE AccessState,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ KPROCESSOR_MODE AccessMode);
 
 BOOLEAN
 NTAPI
@@ -651,17 +637,17 @@ SePrivilegedServiceAuditAlarm(
 
 NTSTATUS
 SepRmReferenceLogonSession(
-    PLUID LogonLuid);
+    _Inout_ PLUID LogonLuid);
 
 NTSTATUS
 SepRmDereferenceLogonSession(
-    PLUID LogonLuid);
+    _Inout_ PLUID LogonLuid);
 
 NTSTATUS
 NTAPI
 SeGetLogonIdDeviceMap(
-    IN PLUID LogonId,
-    OUT PDEVICE_MAP * DeviceMap);
+    _In_ PLUID LogonId,
+    _Out_ PDEVICE_MAP *DeviceMap);
 
 #endif
 

--- a/ntoskrnl/se/access.c
+++ b/ntoskrnl/se/access.c
@@ -45,11 +45,12 @@ ERESOURCE SepSubjectContextLock;
  */
 BOOLEAN
 NTAPI
-SepSidInTokenEx(IN PACCESS_TOKEN _Token,
-                IN PSID PrincipalSelfSid,
-                IN PSID _Sid,
-                IN BOOLEAN Deny,
-                IN BOOLEAN Restricted)
+SepSidInTokenEx(
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSID PrincipalSelfSid,
+    _In_ PSID _Sid,
+    _In_ BOOLEAN Deny,
+    _In_ BOOLEAN Restricted)
 {
     ULONG i;
     PTOKEN Token = (PTOKEN)_Token;
@@ -145,8 +146,9 @@ SepSidInTokenEx(IN PACCESS_TOKEN _Token,
  */
 BOOLEAN
 NTAPI
-SepSidInToken(IN PACCESS_TOKEN _Token,
-              IN PSID Sid)
+SepSidInToken(
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSID Sid)
 {
     /* Call extended API */
     return SepSidInTokenEx(_Token, NULL, Sid, FALSE, FALSE);
@@ -172,9 +174,10 @@ SepSidInToken(IN PACCESS_TOKEN _Token,
  */
 BOOLEAN
 NTAPI
-SepTokenIsOwner(IN PACCESS_TOKEN _Token,
-                IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                IN BOOLEAN TokenLocked)
+SepTokenIsOwner(
+    _In_ PACCESS_TOKEN _Token,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ BOOLEAN TokenLocked)
 {
     PSID Sid;
     BOOLEAN Result;
@@ -216,8 +219,9 @@ SepTokenIsOwner(IN PACCESS_TOKEN _Token,
  */
 VOID
 NTAPI
-SeGetTokenControlInformation(IN PACCESS_TOKEN _Token,
-                             OUT PTOKEN_CONTROL TokenControl)
+SeGetTokenControlInformation(
+    _In_ PACCESS_TOKEN _Token,
+    _Out_ PTOKEN_CONTROL TokenControl)
 {
     PTOKEN Token = _Token;
     PAGED_CODE();
@@ -274,13 +278,14 @@ SeGetTokenControlInformation(IN PACCESS_TOKEN _Token,
  */
 NTSTATUS
 NTAPI
-SepCreateClientSecurity(IN PACCESS_TOKEN Token,
-                        IN PSECURITY_QUALITY_OF_SERVICE ClientSecurityQos,
-                        IN BOOLEAN ServerIsRemote,
-                        IN TOKEN_TYPE TokenType,
-                        IN BOOLEAN ThreadEffectiveOnly,
-                        IN SECURITY_IMPERSONATION_LEVEL ImpersonationLevel,
-                        OUT PSECURITY_CLIENT_CONTEXT ClientContext)
+SepCreateClientSecurity(
+    _In_ PACCESS_TOKEN Token,
+    _In_ PSECURITY_QUALITY_OF_SERVICE ClientSecurityQos,
+    _In_ BOOLEAN ServerIsRemote,
+    _In_ TOKEN_TYPE TokenType,
+    _In_ BOOLEAN ThreadEffectiveOnly,
+    _In_ SECURITY_IMPERSONATION_LEVEL ImpersonationLevel,
+    _Out_ PSECURITY_CLIENT_CONTEXT ClientContext)
 {
     NTSTATUS Status;
     PACCESS_TOKEN NewToken;
@@ -382,9 +387,10 @@ SepCreateClientSecurity(IN PACCESS_TOKEN Token,
  */
 VOID
 NTAPI
-SeCaptureSubjectContextEx(IN PETHREAD Thread,
-                          IN PEPROCESS Process,
-                          OUT PSECURITY_SUBJECT_CONTEXT SubjectContext)
+SeCaptureSubjectContextEx(
+    _In_ PETHREAD Thread,
+    _In_ PEPROCESS Process,
+    _Out_ PSECURITY_SUBJECT_CONTEXT SubjectContext)
 {
     BOOLEAN CopyOnOpen, EffectiveOnly;
 
@@ -425,7 +431,8 @@ SeCaptureSubjectContextEx(IN PETHREAD Thread,
  */
 VOID
 NTAPI
-SeCaptureSubjectContext(OUT PSECURITY_SUBJECT_CONTEXT SubjectContext)
+SeCaptureSubjectContext(
+    _Out_ PSECURITY_SUBJECT_CONTEXT SubjectContext)
 {
     /* Call the extended API */
     SeCaptureSubjectContextEx(PsGetCurrentThread(),
@@ -446,7 +453,8 @@ SeCaptureSubjectContext(OUT PSECURITY_SUBJECT_CONTEXT SubjectContext)
  */
 VOID
 NTAPI
-SeLockSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
+SeLockSubjectContext(
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext)
 {
     PTOKEN PrimaryToken, ClientToken;
     PAGED_CODE();
@@ -476,7 +484,8 @@ SeLockSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
  */
 VOID
 NTAPI
-SeUnlockSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
+SeUnlockSubjectContext(
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext)
 {
     PTOKEN PrimaryToken, ClientToken;
     PAGED_CODE();
@@ -508,7 +517,8 @@ SeUnlockSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
  */
 VOID
 NTAPI
-SeReleaseSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
+SeReleaseSubjectContext(
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext)
 {
     PAGED_CODE();
 
@@ -531,7 +541,7 @@ SeReleaseSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
  * @param[in] Process
  * Valid process object where subject context is to be captured.
  * 
- * @param[in, out] AccessState
+ * @param[in,out] AccessState
  * An initialized returned parameter to an access state.
  * 
  * @param[in] AuxData
@@ -548,12 +558,13 @@ SeReleaseSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext)
  */
 NTSTATUS
 NTAPI
-SeCreateAccessStateEx(IN PETHREAD Thread,
-                      IN PEPROCESS Process,
-                      IN OUT PACCESS_STATE AccessState,
-                      IN PAUX_ACCESS_DATA AuxData,
-                      IN ACCESS_MASK Access,
-                      IN PGENERIC_MAPPING GenericMapping)
+SeCreateAccessStateEx(
+    _In_ PETHREAD Thread,
+    _In_ PEPROCESS Process,
+    _Inout_ PACCESS_STATE AccessState,
+    _In_ PAUX_ACCESS_DATA AuxData,
+    _In_ ACCESS_MASK Access,
+    _In_ PGENERIC_MAPPING GenericMapping)
 {
     ACCESS_MASK AccessMask = Access;
     PTOKEN Token;
@@ -608,7 +619,7 @@ SeCreateAccessStateEx(IN PETHREAD Thread,
  * @brief
  * Creates an access state.
  * 
- * @param[in, out] AccessState
+ * @param[in,out] AccessState
  * An initialized returned parameter to an access state.
  * 
  * @param[in] AuxData
@@ -625,10 +636,11 @@ SeCreateAccessStateEx(IN PETHREAD Thread,
  */
 NTSTATUS
 NTAPI
-SeCreateAccessState(IN OUT PACCESS_STATE AccessState,
-                    IN PAUX_ACCESS_DATA AuxData,
-                    IN ACCESS_MASK Access,
-                    IN PGENERIC_MAPPING GenericMapping)
+SeCreateAccessState(
+    _Inout_ PACCESS_STATE AccessState,
+    _In_ PAUX_ACCESS_DATA AuxData,
+    _In_ ACCESS_MASK Access,
+    _In_ PGENERIC_MAPPING GenericMapping)
 {
     PAGED_CODE();
 
@@ -653,7 +665,8 @@ SeCreateAccessState(IN OUT PACCESS_STATE AccessState,
  */
 VOID
 NTAPI
-SeDeleteAccessState(IN PACCESS_STATE AccessState)
+SeDeleteAccessState(
+    _In_ PACCESS_STATE AccessState)
 {
     PAUX_ACCESS_DATA AuxData;
     PAGED_CODE();
@@ -695,8 +708,9 @@ SeDeleteAccessState(IN PACCESS_STATE AccessState)
  */
 VOID
 NTAPI
-SeSetAccessStateGenericMapping(IN PACCESS_STATE AccessState,
-                               IN PGENERIC_MAPPING GenericMapping)
+SeSetAccessStateGenericMapping(
+    _In_ PACCESS_STATE AccessState,
+    _In_ PGENERIC_MAPPING GenericMapping)
 {
     PAGED_CODE();
 
@@ -725,10 +739,11 @@ SeSetAccessStateGenericMapping(IN PACCESS_STATE AccessState,
  */
 NTSTATUS
 NTAPI
-SeCreateClientSecurity(IN PETHREAD Thread,
-                       IN PSECURITY_QUALITY_OF_SERVICE Qos,
-                       IN BOOLEAN RemoteClient,
-                       OUT PSECURITY_CLIENT_CONTEXT ClientContext)
+SeCreateClientSecurity(
+    _In_ PETHREAD Thread,
+    _In_ PSECURITY_QUALITY_OF_SERVICE Qos,
+    _In_ BOOLEAN RemoteClient,
+    _Out_ PSECURITY_CLIENT_CONTEXT ClientContext)
 {
     TOKEN_TYPE TokenType;
     BOOLEAN ThreadEffectiveOnly;
@@ -786,10 +801,11 @@ SeCreateClientSecurity(IN PETHREAD Thread,
  */
 NTSTATUS
 NTAPI
-SeCreateClientSecurityFromSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectContext,
-                                         IN PSECURITY_QUALITY_OF_SERVICE ClientSecurityQos,
-                                         IN BOOLEAN ServerIsRemote,
-                                         OUT PSECURITY_CLIENT_CONTEXT ClientContext)
+SeCreateClientSecurityFromSubjectContext(
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext,
+    _In_ PSECURITY_QUALITY_OF_SERVICE ClientSecurityQos,
+    _In_ BOOLEAN ServerIsRemote,
+    _Out_ PSECURITY_CLIENT_CONTEXT ClientContext)
 {
     PACCESS_TOKEN Token;
     NTSTATUS Status;
@@ -837,8 +853,9 @@ SeCreateClientSecurityFromSubjectContext(IN PSECURITY_SUBJECT_CONTEXT SubjectCon
  */
 NTSTATUS
 NTAPI
-SeImpersonateClientEx(IN PSECURITY_CLIENT_CONTEXT ClientContext,
-                      IN PETHREAD ServerThread OPTIONAL)
+SeImpersonateClientEx(
+    _In_ PSECURITY_CLIENT_CONTEXT ClientContext,
+    _In_opt_ PETHREAD ServerThread)
 {
     BOOLEAN EffectiveOnly;
     PAGED_CODE();
@@ -881,8 +898,9 @@ SeImpersonateClientEx(IN PSECURITY_CLIENT_CONTEXT ClientContext,
  */
 VOID
 NTAPI
-SeImpersonateClient(IN PSECURITY_CLIENT_CONTEXT ClientContext,
-                    IN PETHREAD ServerThread OPTIONAL)
+SeImpersonateClient(
+    _In_ PSECURITY_CLIENT_CONTEXT ClientContext,
+    _In_opt_ PETHREAD ServerThread)
 {
     PAGED_CODE();
 

--- a/ntoskrnl/se/accesschk.c
+++ b/ntoskrnl/se/accesschk.c
@@ -66,18 +66,19 @@
  * The function is currently incomplete!
  */
 BOOLEAN NTAPI
-SepAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-               IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
-               IN ACCESS_MASK DesiredAccess,
-               IN POBJECT_TYPE_LIST ObjectTypeList,
-               IN ULONG ObjectTypeListLength,
-               IN ACCESS_MASK PreviouslyGrantedAccess,
-               OUT PPRIVILEGE_SET* Privileges,
-               IN PGENERIC_MAPPING GenericMapping,
-               IN KPROCESSOR_MODE AccessMode,
-               OUT PACCESS_MASK GrantedAccessList,
-               OUT PNTSTATUS AccessStatusList,
-               IN BOOLEAN UseResultList)
+SepAccessCheck(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_TYPE_LIST ObjectTypeList,
+    _In_ ULONG ObjectTypeListLength,
+    _In_ ACCESS_MASK PreviouslyGrantedAccess,
+    _Out_ PPRIVILEGE_SET* Privileges,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _Out_ PACCESS_MASK GrantedAccessList,
+    _Out_ PNTSTATUS AccessStatusList,
+    _In_ BOOLEAN UseResultList)
 {
     ACCESS_MASK RemainingAccess;
     ACCESS_MASK TempAccess;
@@ -342,7 +343,8 @@ ReturnCommonStatus:
  * Returns a SID that represents the main user (owner).
  */
 static PSID
-SepGetSDOwner(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
+SepGetSDOwner(
+    _In_ PSECURITY_DESCRIPTOR _SecurityDescriptor)
 {
     PISECURITY_DESCRIPTOR SecurityDescriptor = _SecurityDescriptor;
     PSID Owner;
@@ -368,7 +370,8 @@ SepGetSDOwner(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
  * Returns a SID that represents a group.
  */
 static PSID
-SepGetSDGroup(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
+SepGetSDGroup(
+    _In_ PSECURITY_DESCRIPTOR _SecurityDescriptor)
 {
     PISECURITY_DESCRIPTOR SecurityDescriptor = _SecurityDescriptor;
     PSID Group;
@@ -394,7 +397,8 @@ SepGetSDGroup(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
  */
 static
 ULONG
-SepGetPrivilegeSetLength(IN PPRIVILEGE_SET PrivilegeSet)
+SepGetPrivilegeSetLength(
+    _In_ PPRIVILEGE_SET PrivilegeSet)
 {
     if (PrivilegeSet == NULL)
         return 0;
@@ -452,16 +456,17 @@ SepGetPrivilegeSetLength(IN PPRIVILEGE_SET PrivilegeSet)
  */
 BOOLEAN
 NTAPI
-SeAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-              IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
-              IN BOOLEAN SubjectContextLocked,
-              IN ACCESS_MASK DesiredAccess,
-              IN ACCESS_MASK PreviouslyGrantedAccess,
-              OUT PPRIVILEGE_SET* Privileges,
-              IN PGENERIC_MAPPING GenericMapping,
-              IN KPROCESSOR_MODE AccessMode,
-              OUT PACCESS_MASK GrantedAccess,
-              OUT PNTSTATUS AccessStatus)
+SeAccessCheck(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
+    _In_ BOOLEAN SubjectContextLocked,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ ACCESS_MASK PreviouslyGrantedAccess,
+    _Out_ PPRIVILEGE_SET* Privileges,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _Out_ PACCESS_MASK GrantedAccess,
+    _Out_ PNTSTATUS AccessStatus)
 {
     BOOLEAN ret;
 
@@ -593,10 +598,11 @@ SeAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
  */
 BOOLEAN
 NTAPI
-SeFastTraverseCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                    IN PACCESS_STATE AccessState,
-                    IN ACCESS_MASK DesiredAccess,
-                    IN KPROCESSOR_MODE AccessMode)
+SeFastTraverseCheck(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PACCESS_STATE AccessState,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ KPROCESSOR_MODE AccessMode)
 {
     PACL Dacl;
     ULONG AceIndex;
@@ -702,14 +708,15 @@ SeFastTraverseCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
  */
 NTSTATUS
 NTAPI
-NtAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-              IN HANDLE TokenHandle,
-              IN ACCESS_MASK DesiredAccess,
-              IN PGENERIC_MAPPING GenericMapping,
-              OUT PPRIVILEGE_SET PrivilegeSet OPTIONAL,
-              IN OUT PULONG PrivilegeSetLength,
-              OUT PACCESS_MASK GrantedAccess,
-              OUT PNTSTATUS AccessStatus)
+NtAccessCheck(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ HANDLE TokenHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _Out_opt_ PPRIVILEGE_SET PrivilegeSet,
+    _Inout_ PULONG PrivilegeSetLength,
+    _Out_ PACCESS_MASK GrantedAccess,
+    _Out_ PNTSTATUS AccessStatus)
 {
     PSECURITY_DESCRIPTOR CapturedSecurityDescriptor = NULL;
     SECURITY_SUBJECT_CONTEXT SubjectSecurityContext;
@@ -988,17 +995,18 @@ NtAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
  */
 NTSTATUS
 NTAPI
-NtAccessCheckByType(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                    IN PSID PrincipalSelfSid,
-                    IN HANDLE ClientToken,
-                    IN ACCESS_MASK DesiredAccess,
-                    IN POBJECT_TYPE_LIST ObjectTypeList,
-                    IN ULONG ObjectTypeLength,
-                    IN PGENERIC_MAPPING GenericMapping,
-                    IN PPRIVILEGE_SET PrivilegeSet,
-                    IN OUT PULONG PrivilegeSetLength,
-                    OUT PACCESS_MASK GrantedAccess,
-                    OUT PNTSTATUS AccessStatus)
+NtAccessCheckByType(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PSID PrincipalSelfSid,
+    _In_ HANDLE ClientToken,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_TYPE_LIST ObjectTypeList,
+    _In_ ULONG ObjectTypeLength,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ PPRIVILEGE_SET PrivilegeSet,
+    _Inout_ PULONG PrivilegeSetLength,
+    _Out_ PACCESS_MASK GrantedAccess,
+    _Out_ PNTSTATUS AccessStatus)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -1049,17 +1057,18 @@ NtAccessCheckByType(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
  */
 NTSTATUS
 NTAPI
-NtAccessCheckByTypeResultList(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                              IN PSID PrincipalSelfSid,
-                              IN HANDLE ClientToken,
-                              IN ACCESS_MASK DesiredAccess,
-                              IN POBJECT_TYPE_LIST ObjectTypeList,
-                              IN ULONG ObjectTypeLength,
-                              IN PGENERIC_MAPPING GenericMapping,
-                              IN PPRIVILEGE_SET PrivilegeSet,
-                              IN OUT PULONG PrivilegeSetLength,
-                              OUT PACCESS_MASK GrantedAccess,
-                              OUT PNTSTATUS AccessStatus)
+NtAccessCheckByTypeResultList(
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PSID PrincipalSelfSid,
+    _In_ HANDLE ClientToken,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ POBJECT_TYPE_LIST ObjectTypeList,
+    _In_ ULONG ObjectTypeLength,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_ PPRIVILEGE_SET PrivilegeSet,
+    _Inout_ PULONG PrivilegeSetLength,
+    _Out_ PACCESS_MASK GrantedAccess,
+    _Out_ PNTSTATUS AccessStatus)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;

--- a/ntoskrnl/se/accesschk.c
+++ b/ntoskrnl/se/accesschk.c
@@ -1,10 +1,9 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/accesschk.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     No programmer listed.
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security access check control implementation
+ * COPYRIGHT:       Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                  Copyright Eric Kohl
  */
 
 /* INCLUDES *******************************************************************/
@@ -18,8 +17,53 @@
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
-/*
- * FIXME: Incomplete!
+/**
+ * @brief
+ * Private function that determines whether security access rights can be given
+ * to an object depending on the security descriptor and other security context
+ * entities, such as an owner.
+ * 
+ * @param[in] SecurityDescriptor
+ * Security descriptor of the object that is being accessed.
+ * 
+ * @param[in] SubjectSecurityContext
+ * The captured subject security context.
+ * 
+ * @param[in] DesiredAccess
+ * Access right bitmask that the calling thread wants to acquire.
+ * 
+ * @param[in] ObjectTypeListLength
+ * The length of a object type list.
+ * 
+ * @param[in] PreviouslyGrantedAccess
+ * The access rights previously acquired in the past.
+ * 
+ * @param[out] Privileges
+ * The returned set of privileges.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights of an object type.
+ * 
+ * @param[in] AccessMode
+ * The processor request level mode.
+ * 
+ * @param[out] GrantedAccessList
+ * A list of granted access rights.
+ * 
+ * @param[out] AccessStatusList
+ * The returned status code specifying why access cannot be made
+ * onto an object (if said access is denied in the first place).
+ * 
+ * @param[in] UseResultList
+ * If set to TRUE, the function will return complete lists of 
+ * access status codes and granted access rights.
+ * 
+ * @return
+ * Returns TRUE if access onto the specific object is allowed, FALSE
+ * otherwise.
+ * 
+ * @remarks
+ * The function is currently incomplete!
  */
 BOOLEAN NTAPI
 SepAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
@@ -286,6 +330,17 @@ ReturnCommonStatus:
     return NT_SUCCESS(Status);
 }
 
+/**
+ * @brief
+ * Retrieves the main user from a security descriptor.
+ * 
+ * @param[in] SecurityDescriptor
+ * A valid allocated security descriptor structure where the owner
+ * is to be retrieved.
+ * 
+ * @return
+ * Returns a SID that represents the main user (owner).
+ */
 static PSID
 SepGetSDOwner(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
 {
@@ -301,6 +356,17 @@ SepGetSDOwner(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
     return Owner;
 }
 
+/**
+ * @brief
+ * Retrieves the group from a security descriptor.
+ * 
+ * @param[in] SecurityDescriptor
+ * A valid allocated security descriptor structure where the group
+ * is to be retrieved.
+ * 
+ * @return
+ * Returns a SID that represents a group.
+ */
 static PSID
 SepGetSDGroup(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
 {
@@ -316,6 +382,16 @@ SepGetSDGroup(IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
     return Group;
 }
 
+/**
+ * @brief
+ * Retrieves the length size of a set list of privileges structure.
+ * 
+ * @param[in] PrivilegeSet
+ * A valid set of privileges.
+ * 
+ * @return
+ * Returns the total length of a set of privileges.
+ */
 static
 ULONG
 SepGetPrivilegeSetLength(IN PPRIVILEGE_SET PrivilegeSet)
@@ -332,8 +408,47 @@ SepGetPrivilegeSetLength(IN PPRIVILEGE_SET PrivilegeSet)
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
- * @implemented
+/**
+ * @brief
+ * Determines whether security access rights can be given to an object
+ * depending on the security descriptor and other security context
+ * entities, such as an owner.
+ * 
+ * @param[in] SecurityDescriptor
+ * Security descriptor of the object that is being accessed.
+ * 
+ * @param[in] SubjectSecurityContext
+ * The captured subject security context.
+ * 
+ * @param[in] SubjectContextLocked
+ * If set to TRUE, a lock must be acquired for the security subject
+ * context.
+ * 
+ * @param[in] DesiredAccess
+ * Access right bitmask that the calling thread wants to acquire.
+ * 
+ * @param[in] PreviouslyGrantedAccess
+ * The access rights previously acquired in the past.
+ * 
+ * @param[out] Privileges
+ * The returned set of privileges.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights of an object type.
+ * 
+ * @param[in] AccessMode
+ * The processor request level mode.
+ * 
+ * @param[out] GrantedAccess
+ * A list of granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * The returned status code specifying why access cannot be made
+ * onto an object (if said access is denied in the first place).
+ * 
+ * @return
+ * Returns TRUE if access onto the specific object is allowed, FALSE
+ * otherwise.
  */
 BOOLEAN
 NTAPI
@@ -452,8 +567,29 @@ SeAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
     return ret;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Determines whether security access rights can be given to an object
+ * depending on the security descriptor. Unlike the regular access check
+ * procedure in the NT kernel, the fast traverse check is a faster way
+ * to quickly check if access can be made into an object.
+ * 
+ * @param[in] SecurityDescriptor
+ * Security descriptor of the object that is being accessed.
+ * 
+ * @param[in] AccessState
+ * An access state to determine if the access token in the current
+ * security context of the object is an restricted token.
+ * 
+ * @param[in] DesiredAccess
+ * The access right bitmask where the calling thread wants to acquire.
+ * 
+ * @param[in] AccessMode
+ * Process level request mode.
+ * 
+ * @return
+ * Returns TRUE if access onto the specific object is allowed, FALSE
+ * otherwise.
  */
 BOOLEAN
 NTAPI
@@ -521,8 +657,48 @@ SeFastTraverseCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
 
 /* SYSTEM CALLS ***************************************************************/
 
-/*
- * @implemented
+/**
+ * @brief
+ * Determines whether security access rights can be given to an object
+ * depending on the security descriptor and a valid handle to an access
+ * token.
+ * 
+ * @param[in] SecurityDescriptor
+ * Security descriptor of the object that is being accessed.
+ * 
+ * @param[in] TokenHandle
+ * A handle to a token.
+ * 
+ * @param[in] DesiredAccess
+ * The access right bitmask where the calling thread wants to acquire.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights of an object type.
+ * 
+ * @param[out] PrivilegeSet
+ * The returned set of privileges.
+ * 
+ * @param[in,out] PrivilegeSetLength
+ * The total length size of a set of privileges.
+ * 
+ * @param[out] GrantedAccess
+ * A list of granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * The returned status code specifying why access cannot be made
+ * onto an object (if said access is denied in the first place).
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if access check has been done without problems
+ * and that the object can be accessed. STATUS_GENERIC_NOT_MAPPED is returned
+ * if no generic access right is mapped. STATUS_NO_IMPERSONATION_TOKEN is returned
+ * if the token from the handle is not an impersonation token.
+ * STATUS_BAD_IMPERSONATION_LEVEL is returned if the token cannot be impersonated
+ * because the current security impersonation level doesn't permit so.
+ * STATUS_INVALID_SECURITY_DESCR is returned if the security descriptor given
+ * to the call is not a valid one. STATUS_BUFFER_TOO_SMALL is returned if
+ * the buffer to the captured privileges has a length that is less than the required
+ * size of the set of privileges. A failure NTSTATUS code is returned otherwise.
  */
 NTSTATUS
 NTAPI
@@ -768,7 +944,48 @@ NtAccessCheck(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
     return STATUS_SUCCESS;
 }
 
-
+/**
+ * @brief
+ * Determines whether security access could be granted or not on
+ * an object by the requestor who wants such access through type.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor with information data for auditing.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] ClientToken
+ * A client access token.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access masks rights requested by the caller.
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping list of access masks rights.
+ * 
+ * @param[in] PrivilegeSet
+ * An array set of privileges.
+ * 
+ * @param[in,out] PrivilegeSetLength
+ * The length size of the array set of privileges.
+ * 
+ * @param[out] GrantedAccess
+ * The returned granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * The returned NTSTATUS code indicating the final results
+ * of auditing.
+ * 
+ * @return
+ * To be added...
+ */
 NTSTATUS
 NTAPI
 NtAccessCheckByType(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
@@ -787,6 +1004,49 @@ NtAccessCheckByType(IN PSECURITY_DESCRIPTOR SecurityDescriptor,
     return STATUS_NOT_IMPLEMENTED;
 }
 
+/**
+ * @brief
+ * Determines whether security access could be granted or not on
+ * an object by the requestor who wants such access through
+ * type list.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor with information data for auditing.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] ClientToken
+ * A client access token.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access masks rights requested by the caller.
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping list of access masks rights.
+ * 
+ * @param[in] PrivilegeSet
+ * An array set of privileges.
+ * 
+ * @param[in,out] PrivilegeSetLength
+ * The length size of the array set of privileges.
+ * 
+ * @param[out] GrantedAccess
+ * The returned granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * The returned NTSTATUS code indicating the final results
+ * of auditing.
+ * 
+ * @return
+ * To be added...
+ */
 NTSTATUS
 NTAPI
 NtAccessCheckByTypeResultList(IN PSECURITY_DESCRIPTOR SecurityDescriptor,

--- a/ntoskrnl/se/acl.c
+++ b/ntoskrnl/se/acl.c
@@ -1,10 +1,8 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/acl.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     David Welch <welch@cwcom.net>
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Access control lists (ACLs) implementation
+ * COPYRIGHT:       Copyright David Welch <welch@cwcom.net>
  */
 
 /* INCLUDES *******************************************************************/
@@ -25,6 +23,15 @@ PACL SeSystemAnonymousLogonDacl = NULL;
 
 /* FUNCTIONS ******************************************************************/
 
+/**
+ * @brief
+ * Initializes known discretionary access control lists in the system upon
+ * kernel and Executive initialization procedure.
+ * 
+ * @return
+ * Returns TRUE if all the DACLs have been successfully initialized,
+ * FALSE otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -246,6 +253,25 @@ SepInitDACLs(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Allocates a discretionary access control list based on certain properties
+ * of a regular and primary access tokens.
+ * 
+ * @param[in] Token
+ * An access token.
+ * 
+ * @param[in] PrimaryToken
+ * A primary access token.
+ * 
+ * @param[out] Dacl
+ * The returned allocated DACL.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if DACL creation from tokens has completed
+ * successfully. STATUS_INSUFFICIENT_RESOURCES is returned if DACL
+ * allocation from memory pool fails otherwise.
+ */
 NTSTATUS
 NTAPI
 SepCreateImpersonationTokenDacl(
@@ -294,6 +320,33 @@ SepCreateImpersonationTokenDacl(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Captures an access control list from an already valid input ACL.
+ * 
+ * @param[in] InputAcl
+ * A valid ACL.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode. The processor mode determines how
+ * are the input arguments probed.
+ * 
+ * @param[in] PoolType
+ * Pool type for new captured ACL for creation. The pool type determines
+ * how the ACL data should reside in the pool memory.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE and the processor access mode being KernelMode, we're
+ * capturing an ACL directly in the kernel. Otherwise we're capturing
+ * within a kernel mode driver.
+ * 
+ * @param[out] CapturedAcl
+ * The returned and allocated captured ACL.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the ACL has been successfully captured.
+ * STATUS_INSUFFICIENT_RESOURCES is returned otherwise.
+ */
 NTSTATUS
 NTAPI
 SepCaptureAcl(IN PACL InputAcl,
@@ -382,6 +435,24 @@ SepCaptureAcl(IN PACL InputAcl,
     return Status;
 }
 
+/**
+ * @brief
+ * Releases (frees) a captured ACL from the memory pool.
+ * 
+ * @param[in] CapturedAcl
+ * A valid captured ACL to free.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE and the processor access mode being KernelMode, we're
+ * releasing an ACL directly in the kernel. Otherwise we're releasing
+ * within a kernel mode driver.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepReleaseAcl(IN PACL CapturedAcl,
@@ -398,6 +469,29 @@ SepReleaseAcl(IN PACL CapturedAcl,
     }
 }
 
+/**
+ * @brief
+ * Determines if a certain ACE can or cannot be propagated based on
+ * ACE inheritation flags and whatnot.
+ * 
+ * @param[in] AceFlags
+ * Bit flags of an ACE to perform propagation checks.
+ * 
+ * @param[out] NewAceFlags
+ * New ACE bit blags based on the specific ACE flags of the first
+ * argument parameter.
+ * 
+ * @param[in] IsInherited
+ * If set to TRUE, an ACE is deemed as directly inherited from another
+ * instance. In that case we're allowed to propagate.
+ * 
+ * @param[in] IsDirectoryObject
+ * If set to TRUE, an object directly inherits this ACE so we can propagate
+ * it.
+ * 
+ * @return
+ * Returns TRUE if an ACE can be propagated, FALSE otherwise.
+ */
 BOOLEAN
 SepShouldPropagateAce(
     _In_ UCHAR AceFlags,
@@ -446,6 +540,42 @@ SepShouldPropagateAce(
     return FALSE;
 }
 
+/**
+ * @brief
+ * Propagates (copies) an access control list.
+ * 
+ * @param[out] AclDest
+ * The destination parameter with propagated ACL.
+ * 
+ * @param[in,out] AclLength
+ * The length of the ACL that we propagate.
+ * 
+ * @param[in] AclSource
+ * The source instance of a valid ACL.
+ * 
+ * @param[in] Owner
+ * A SID that represents the main user that identifies the ACL.
+ * 
+ * @param[in] Group
+ * A SID that represents a group that identifies the ACL.
+ * 
+ * @param[in] IsInherited
+ * If set to TRUE, that means the ACL is directly inherited.
+ * 
+ * @param[in] IsDirectoryObject
+ * If set to TRUE, that means the ACL is directly inherited because
+ * of the object that inherits it.
+ * 
+ * @param[in] GenericMapping
+ * Generic mapping of access rights to map only certain effective
+ * ACEs.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if ACL has been propagated successfully.
+ * STATUS_BUFFER_TOO_SMALL is returned if the ACL length is not greater
+ * than the maximum written size of the buffer for ACL propagation
+ * otherwise.
+ */
 NTSTATUS
 SepPropagateAcl(
     _Out_writes_bytes_opt_(AclLength) PACL AclDest,
@@ -609,6 +739,60 @@ SepPropagateAcl(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Selects an ACL and returns it to the caller.
+ * 
+ * @param[in] ExplicitAcl
+ * If specified, the specified ACL to the call will be
+ * the selected ACL for the caller.
+ * 
+ * @param[in] ExplicitPresent
+ * If set to TRUE and with specific ACL filled to the call, the
+ * function will immediately return the specific ACL as the selected
+ * ACL for the caller.
+ * 
+ * @param[in] ExplicitDefaulted
+ * If set to FALSE and with specific ACL filled to the call, the ACL
+ * is not a default ACL. Otherwise it's a default ACL that we cannot
+ * select it as is.
+ * 
+ * @param[in] ParentAcl
+ * If specified, the parent ACL will be used to determine the exact ACL
+ * length to check  if the ACL in question is not empty. If the list
+ * is not empty then the function will select such ACL to the caller.
+ * 
+ * @param[in] DefaultAcl
+ * If specified, the default ACL will be the selected one for the caller.
+ * 
+ * @param[out] AclLength
+ * The size length of an ACL.
+ * 
+ * @param[in] Owner
+ * A SID that represents the main user that identifies the ACL.
+ * 
+ * @param[in] Group
+ * A SID that represents a group that identifies the ACL.
+ * 
+ * @param[out] AclPresent
+ * The returned boolean value, indicating if the ACL that we want to select
+ * does actually exist.
+ * 
+ * @param[out] IsInherited
+ * The returned boolean value, indicating if the ACL we want to select it
+ * is actually inherited or not.
+ * 
+ * @param[in] IsDirectoryObject
+ * If set to TRUE, the object inherits this ACL.
+ * 
+ * @param[in] GenericMapping
+ * Generic mapping of access rights to map only certain effective
+ * ACEs of an ACL that we want to select it.
+ * 
+ * @return
+ * Returns the selected access control list (ACL) to the caller,
+ * NULL otherwise.
+ */
 PACL
 SepSelectAcl(
     _In_opt_ PACL ExplicitAcl,

--- a/ntoskrnl/se/acl.c
+++ b/ntoskrnl/se/acl.c
@@ -349,11 +349,12 @@ SepCreateImpersonationTokenDacl(
  */
 NTSTATUS
 NTAPI
-SepCaptureAcl(IN PACL InputAcl,
-              IN KPROCESSOR_MODE AccessMode,
-              IN POOL_TYPE PoolType,
-              IN BOOLEAN CaptureIfKernel,
-              OUT PACL *CapturedAcl)
+SepCaptureAcl(
+    _In_ PACL InputAcl,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PACL *CapturedAcl)
 {
     PACL NewAcl;
     ULONG AclSize = 0;
@@ -455,9 +456,10 @@ SepCaptureAcl(IN PACL InputAcl,
  */
 VOID
 NTAPI
-SepReleaseAcl(IN PACL CapturedAcl,
-              IN KPROCESSOR_MODE AccessMode,
-              IN BOOLEAN CaptureIfKernel)
+SepReleaseAcl(
+    _In_ PACL CapturedAcl,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ BOOLEAN CaptureIfKernel)
 {
     PAGED_CODE();
 

--- a/ntoskrnl/se/audit.c
+++ b/ntoskrnl/se/audit.c
@@ -31,7 +31,8 @@ UNICODE_STRING SeSubsystemName = RTL_CONSTANT_STRING(L"Security");
  */
 BOOLEAN
 NTAPI
-SeDetailedAuditingWithToken(IN PTOKEN Token)
+SeDetailedAuditingWithToken(
+    _In_ PTOKEN Token)
 {
     /* FIXME */
     return FALSE;
@@ -52,7 +53,8 @@ SeDetailedAuditingWithToken(IN PTOKEN Token)
  */
 VOID
 NTAPI
-SeAuditProcessCreate(IN PEPROCESS Process)
+SeAuditProcessCreate(
+    _In_ PEPROCESS Process)
 {
     /* FIXME */
 }
@@ -72,7 +74,8 @@ SeAuditProcessCreate(IN PEPROCESS Process)
  */
 VOID
 NTAPI
-SeAuditProcessExit(IN PEPROCESS Process)
+SeAuditProcessExit(
+    _In_ PEPROCESS Process)
 {
     /* FIXME */
 }
@@ -99,9 +102,10 @@ SeAuditProcessExit(IN PEPROCESS Process)
  */
 NTSTATUS
 NTAPI
-SeInitializeProcessAuditName(IN PFILE_OBJECT FileObject,
-                             IN BOOLEAN DoAudit,
-                             OUT POBJECT_NAME_INFORMATION *AuditInfo)
+SeInitializeProcessAuditName(
+    _In_ PFILE_OBJECT FileObject,
+    _In_ BOOLEAN DoAudit,
+    _Out_ POBJECT_NAME_INFORMATION *AuditInfo)
 {
     OBJECT_NAME_INFORMATION LocalNameInfo;
     POBJECT_NAME_INFORMATION ObjectNameInfo = NULL;
@@ -192,8 +196,9 @@ SeInitializeProcessAuditName(IN PFILE_OBJECT FileObject,
  */
 NTSTATUS
 NTAPI
-SeLocateProcessImageName(IN PEPROCESS Process,
-                         OUT PUNICODE_STRING *ProcessImageName)
+SeLocateProcessImageName(
+    _In_ PEPROCESS Process,
+    _Out_ PUNICODE_STRING *ProcessImageName)
 {
     POBJECT_NAME_INFORMATION AuditName;
     PUNICODE_STRING ImageName;
@@ -280,9 +285,9 @@ SeLocateProcessImageName(IN PEPROCESS Process,
 VOID
 NTAPI
 SepAdtCloseObjectAuditAlarm(
-    PUNICODE_STRING SubsystemName,
-    PVOID HandleId,
-    PSID Sid)
+    _In_ PUNICODE_STRING SubsystemName,
+    _In_ PVOID HandleId,
+    _In_ PSID Sid)
 {
     UNIMPLEMENTED;
 }
@@ -325,7 +330,7 @@ SepAdtCloseObjectAuditAlarm(
 VOID
 NTAPI
 SepAdtPrivilegedServiceAuditAlarm(
-    PSECURITY_SUBJECT_CONTEXT SubjectContext,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext,
     _In_opt_ PUNICODE_STRING SubsystemName,
     _In_opt_ PUNICODE_STRING ServiceName,
     _In_ PTOKEN Token,
@@ -1060,9 +1065,10 @@ Cleanup:
  */
 VOID
 NTAPI
-SeAuditHardLinkCreation(IN PUNICODE_STRING FileName,
-                        IN PUNICODE_STRING LinkName,
-                        IN BOOLEAN bSuccess)
+SeAuditHardLinkCreation(
+    _In_ PUNICODE_STRING FileName,
+    _In_ PUNICODE_STRING LinkName,
+    _In_ BOOLEAN bSuccess)
 {
     UNIMPLEMENTED;
 }
@@ -1085,8 +1091,9 @@ SeAuditHardLinkCreation(IN PUNICODE_STRING FileName,
  */
 BOOLEAN
 NTAPI
-SeAuditingFileEvents(IN BOOLEAN AccessGranted,
-                     IN PSECURITY_DESCRIPTOR SecurityDescriptor)
+SeAuditingFileEvents(
+    _In_ BOOLEAN AccessGranted,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor)
 {
     UNIMPLEMENTED;
     return FALSE;
@@ -1114,9 +1121,10 @@ SeAuditingFileEvents(IN BOOLEAN AccessGranted,
  */
 BOOLEAN
 NTAPI
-SeAuditingFileEventsWithContext(IN BOOLEAN AccessGranted,
-                                IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                                IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext OPTIONAL)
+SeAuditingFileEventsWithContext(
+    _In_ BOOLEAN AccessGranted,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_opt_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext)
 {
     UNIMPLEMENTED_ONCE;
     return FALSE;
@@ -1140,8 +1148,9 @@ SeAuditingFileEventsWithContext(IN BOOLEAN AccessGranted,
  */
 BOOLEAN
 NTAPI
-SeAuditingHardLinkEvents(IN BOOLEAN AccessGranted,
-                         IN PSECURITY_DESCRIPTOR SecurityDescriptor)
+SeAuditingHardLinkEvents(
+    _In_ BOOLEAN AccessGranted,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor)
 {
     UNIMPLEMENTED;
     return FALSE;
@@ -1169,9 +1178,10 @@ SeAuditingHardLinkEvents(IN BOOLEAN AccessGranted,
  */
 BOOLEAN
 NTAPI
-SeAuditingHardLinkEventsWithContext(IN BOOLEAN AccessGranted,
-                                    IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                                    IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext OPTIONAL)
+SeAuditingHardLinkEventsWithContext(
+    _In_ BOOLEAN AccessGranted,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_opt_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext)
 {
     UNIMPLEMENTED;
     return FALSE;
@@ -1199,9 +1209,10 @@ SeAuditingHardLinkEventsWithContext(IN BOOLEAN AccessGranted,
  */
 BOOLEAN
 NTAPI
-SeAuditingFileOrGlobalEvents(IN BOOLEAN AccessGranted,
-                             IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                             IN PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext)
+SeAuditingFileOrGlobalEvents(
+    _In_ BOOLEAN AccessGranted,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext)
 {
     UNIMPLEMENTED;
     return FALSE;
@@ -1227,9 +1238,10 @@ SeAuditingFileOrGlobalEvents(IN BOOLEAN AccessGranted,
  */
 VOID
 NTAPI
-SeCloseObjectAuditAlarm(IN PVOID Object,
-                        IN HANDLE Handle,
-                        IN BOOLEAN PerformAction)
+SeCloseObjectAuditAlarm(
+    _In_ PVOID Object,
+    _In_ HANDLE Handle,
+    _In_ BOOLEAN PerformAction)
 {
     UNIMPLEMENTED;
 }
@@ -1249,8 +1261,9 @@ SeCloseObjectAuditAlarm(IN PVOID Object,
  * Nothing.
  */
 VOID NTAPI
-SeDeleteObjectAuditAlarm(IN PVOID Object,
-                         IN HANDLE Handle)
+SeDeleteObjectAuditAlarm(
+    _In_ PVOID Object,
+    _In_ HANDLE Handle)
 {
     UNIMPLEMENTED;
 }
@@ -1298,15 +1311,16 @@ SeDeleteObjectAuditAlarm(IN PVOID Object,
  */
 VOID
 NTAPI
-SeOpenObjectAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
-                       IN PVOID Object OPTIONAL,
-                       IN PUNICODE_STRING AbsoluteObjectName OPTIONAL,
-                       IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                       IN PACCESS_STATE AccessState,
-                       IN BOOLEAN ObjectCreated,
-                       IN BOOLEAN AccessGranted,
-                       IN KPROCESSOR_MODE AccessMode,
-                       OUT PBOOLEAN GenerateOnClose)
+SeOpenObjectAuditAlarm(
+    _In_ PUNICODE_STRING ObjectTypeName,
+    _In_opt_ PVOID Object,
+    _In_opt_ PUNICODE_STRING AbsoluteObjectName,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PACCESS_STATE AccessState,
+    _In_ BOOLEAN ObjectCreated,
+    _In_ BOOLEAN AccessGranted,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _Out_ PBOOLEAN GenerateOnClose)
 {
     PAGED_CODE();
 
@@ -1360,15 +1374,16 @@ SeOpenObjectAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
  * Nothing.
  */
 VOID NTAPI
-SeOpenObjectForDeleteAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
-                                IN PVOID Object OPTIONAL,
-                                IN PUNICODE_STRING AbsoluteObjectName OPTIONAL,
-                                IN PSECURITY_DESCRIPTOR SecurityDescriptor,
-                                IN PACCESS_STATE AccessState,
-                                IN BOOLEAN ObjectCreated,
-                                IN BOOLEAN AccessGranted,
-                                IN KPROCESSOR_MODE AccessMode,
-                                OUT PBOOLEAN GenerateOnClose)
+SeOpenObjectForDeleteAuditAlarm(
+    _In_ PUNICODE_STRING ObjectTypeName,
+    _In_opt_ PVOID Object,
+    _In_opt_ PUNICODE_STRING AbsoluteObjectName,
+    _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PACCESS_STATE AccessState,
+    _In_ BOOLEAN ObjectCreated,
+    _In_ BOOLEAN AccessGranted,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _Out_ PBOOLEAN GenerateOnClose)
 {
     UNIMPLEMENTED;
 }
@@ -1404,12 +1419,13 @@ SeOpenObjectForDeleteAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
  */
 VOID
 NTAPI
-SePrivilegeObjectAuditAlarm(IN HANDLE Handle,
-                            IN PSECURITY_SUBJECT_CONTEXT SubjectContext,
-                            IN ACCESS_MASK DesiredAccess,
-                            IN PPRIVILEGE_SET Privileges,
-                            IN BOOLEAN AccessGranted,
-                            IN KPROCESSOR_MODE CurrentMode)
+SePrivilegeObjectAuditAlarm(
+    _In_ HANDLE Handle,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ PPRIVILEGE_SET Privileges,
+    _In_ BOOLEAN AccessGranted,
+    _In_ KPROCESSOR_MODE CurrentMode)
 {
     UNIMPLEMENTED;
 }
@@ -1441,9 +1457,9 @@ SePrivilegeObjectAuditAlarm(IN HANDLE Handle,
 NTSTATUS
 NTAPI
 NtCloseObjectAuditAlarm(
-    PUNICODE_STRING SubsystemName,
-    PVOID HandleId,
-    BOOLEAN GenerateOnClose)
+    _In_ PUNICODE_STRING SubsystemName,
+    _In_ PVOID HandleId,
+    _In_ BOOLEAN GenerateOnClose)
 {
     SECURITY_SUBJECT_CONTEXT SubjectContext;
     UNICODE_STRING CapturedSubsystemName;
@@ -1557,9 +1573,10 @@ Cleanup:
  * To be added...
  */
 NTSTATUS NTAPI
-NtDeleteObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
-                         IN PVOID HandleId,
-                         IN BOOLEAN GenerateOnClose)
+NtDeleteObjectAuditAlarm(
+    _In_ PUNICODE_STRING SubsystemName,
+    _In_ PVOID HandleId,
+    _In_ BOOLEAN GenerateOnClose)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -1969,7 +1986,7 @@ NtPrivilegedServiceAuditAlarm(
     _In_opt_ PUNICODE_STRING ServiceName,
     _In_ HANDLE ClientTokenHandle,
     _In_ PPRIVILEGE_SET Privileges,
-    _In_ BOOLEAN AccessGranted )
+    _In_ BOOLEAN AccessGranted)
 {
     KPROCESSOR_MODE PreviousMode;
     PTOKEN ClientToken;
@@ -2147,12 +2164,13 @@ Cleanup:
  * To be added...
  */
 NTSTATUS NTAPI
-NtPrivilegeObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
-                            IN PVOID HandleId,
-                            IN HANDLE ClientToken,
-                            IN ULONG DesiredAccess,
-                            IN PPRIVILEGE_SET Privileges,
-                            IN BOOLEAN AccessGranted)
+NtPrivilegeObjectAuditAlarm(
+    _In_ PUNICODE_STRING SubsystemName,
+    _In_ PVOID HandleId,
+    _In_ HANDLE ClientToken,
+    _In_ ULONG DesiredAccess,
+    _In_ PPRIVILEGE_SET Privileges,
+    _In_ BOOLEAN AccessGranted)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;

--- a/ntoskrnl/se/audit.c
+++ b/ntoskrnl/se/audit.c
@@ -1,11 +1,9 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/audit.c
- * PURPOSE:         Audit functions
- *
- * PROGRAMMERS:     Eric Kohl
- *                  Timo Kreuzer (timo.kreuzer@reactos.org)
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security auditing functions
+ * COPYRIGHT:       Copyright Eric Kohl
+ *                  Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/
@@ -20,6 +18,17 @@ UNICODE_STRING SeSubsystemName = RTL_CONSTANT_STRING(L"Security");
 
 /* PRIVATE FUNCTIONS***********************************************************/
 
+/**
+ * @unimplemented
+ * @brief
+ * Peforms a detailed security auditing with an access token.
+ * 
+ * @param[in] Token
+ * A valid token object.
+ *
+ * @return
+ * To be added...
+ */
 BOOLEAN
 NTAPI
 SeDetailedAuditingWithToken(IN PTOKEN Token)
@@ -28,6 +37,19 @@ SeDetailedAuditingWithToken(IN PTOKEN Token)
     return FALSE;
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Peforms a security auditing against a process that is about to
+ * be created.
+ * 
+ * @param[in] Process
+ * An object that points to a process which is in process of
+ * creation.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeAuditProcessCreate(IN PEPROCESS Process)
@@ -35,6 +57,19 @@ SeAuditProcessCreate(IN PEPROCESS Process)
     /* FIXME */
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Peforms a security auditing against a process that is about to
+ * be terminated.
+ * 
+ * @param[in] Process
+ * An object that points to a process which is in process of
+ * termination.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeAuditProcessExit(IN PEPROCESS Process)
@@ -42,6 +77,26 @@ SeAuditProcessExit(IN PEPROCESS Process)
     /* FIXME */
 }
 
+/**
+ * @brief
+ * Initializes a process audit name and returns it to the caller.
+ * 
+ * @param[in] FileObject
+ * File object that points to a name to be queried.
+ * 
+ * @param[in] DoAudit
+ * If set to TRUE, the function will perform various security
+ * auditing onto the audit name. 
+ * 
+ * @param[out] AuditInfo
+ * The returned audit info data.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if process audit name initialization
+ * has completed successfully. STATUS_NO_MEMORY is returned if
+ * pool allocation for object name info has failed. A failure
+ * NTSTATUS code is returned otherwise.
+ */
 NTSTATUS
 NTAPI
 SeInitializeProcessAuditName(IN PFILE_OBJECT FileObject,
@@ -117,6 +172,24 @@ SeInitializeProcessAuditName(IN PFILE_OBJECT FileObject,
     return Status;
 }
 
+/**
+ * @brief
+ * Finds the process image name of a specific process.
+ * 
+ * @param[in] Process
+ * Process object submitted by the caller, where the image name
+ * is to be located.
+ * 
+ * @param[out] ProcessImageName
+ * An output Unicode string structure with the located process
+ * image name.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if process image name has been located
+ * successfully. STATUS_NO_MEMORY is returned if pool allocation
+ * for the image name has failed. A failure NTSTATUS code is
+ * returned otherwise.
+ */
 NTSTATUS
 NTAPI
 SeLocateProcessImageName(IN PEPROCESS Process,
@@ -185,6 +258,25 @@ SeLocateProcessImageName(IN PEPROCESS Process,
     return Status;
 }
 
+/**
+ * @brief
+ * Closes an audit alarm event of an object.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string pointing to the name of the subsystem where auditing
+ * alarm event has to be closed.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID where such ID represents the identification of the
+ * object where audit alarm is to be closed.
+ *
+ * @param[in] Sid
+ * A SID that represents the user who attempted to close the audit
+ * alarm.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepAdtCloseObjectAuditAlarm(
@@ -195,6 +287,41 @@ SepAdtCloseObjectAuditAlarm(
     UNIMPLEMENTED;
 }
 
+/**
+ * @brief
+ * Performs an audit alarm to a privileged service request.
+ * This is a worker function.
+ * 
+ * @param[in] SubjectContext
+ * A security subject context used for the auditing process.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that represents the name of a subsystem that
+ * actuated the procedure of alarm auditing of a privileged
+ * service.
+ *
+ * @param[in] ServiceName
+ * A Unicode string that represents the name of a privileged
+ * service request for auditing.
+ * 
+ * @param[in] Token
+ * An access token.
+ * 
+ * @param[in] PrimaryToken
+ * A primary access token. 
+ * 
+ * @param[in] Privileges
+ * An array set of privileges used to check if the privileged
+ * service does actually have all the required set of privileges
+ * for security access.
+ * 
+ * @param[in] AccessGranted
+ * When auditing is done, the function will return TRUE to the caller
+ * if access is granted, FALSE otherwise.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepAdtPrivilegedServiceAuditAlarm(
@@ -209,6 +336,29 @@ SepAdtPrivilegedServiceAuditAlarm(
     DPRINT("SepAdtPrivilegedServiceAuditAlarm is unimplemented\n");
 }
 
+/**
+ * @brief
+ * Performs an audit alarm to a privileged service request.
+ * 
+ * @param[in] ServiceName
+ * A Unicode string that represents the name of a privileged
+ * service request for auditing.
+ * 
+ * @param[in] SubjectContext
+ * A security subject context used for the auditing process.
+ * 
+ * @param[in] PrivilegeSet
+ * An array set of privileges used to check if the privileged
+ * service does actually have all the required set of privileges
+ * for security access.
+ * 
+ * @param[in] AccessGranted
+ * When auditing is done, the function will return TRUE to the caller
+ * if access is granted, FALSE otherwise.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SePrivilegedServiceAuditAlarm(
@@ -256,7 +406,28 @@ SePrivilegedServiceAuditAlarm(
 
 }
 
-
+/**
+ * @brief
+ * Captures a list of object types.
+ * 
+ * @param[in] ObjectTypeList
+ * An existing list of object types.
+ * 
+ * @param[in] ObjectTypeListLength
+ * The length size of the list.
+ * 
+ * @param[in] PreviousMode
+ * Processor access level mode.
+ * 
+ * @param[out] CapturedObjectTypeList
+ * The captured list of object types.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the list of object types has been captured
+ * successfully. STATUS_INVALID_PARAMETER is returned if the caller hasn't
+ * supplied a buffer list of object types. STATUS_INSUFFICIENT_RESOURCES
+ * is returned if pool memory allocation for the captured list has failed.
+ */
 static
 NTSTATUS
 SeCaptureObjectTypeList(
@@ -313,6 +484,19 @@ SeCaptureObjectTypeList(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Releases a buffer list of object types.
+ * 
+ * @param[in] CapturedObjectTypeList
+ * A list of object types to free.
+ * 
+ * @param[in] PreviousMode
+ * Processor access level mode.
+ * 
+ * @return
+ * Nothing.
+ */
 static
 VOID
 SeReleaseObjectTypeList(
@@ -323,6 +507,78 @@ SeReleaseObjectTypeList(
         ExFreePoolWithTag(CapturedObjectTypeList, TAG_SEPA);
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Worker function that serves as the main heart and brain of the whole
+ * concept and implementation of auditing in the kernel.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that represents the name of a subsystem that
+ * actuates the auditing process.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID used to identify an object where auditing
+ * is to be done.
+ * 
+ * @param[in] SubjectContext
+ * Security subject context.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that represents the name of an object type.
+ * 
+ * @param[in] ObjectName
+ * The name of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor with internal security information details
+ * for audit.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] AuditType
+ * Type of audit to start. This parameter influences how an audit
+ * should be done.
+ * 
+ * @param[in] HaveAuditPrivilege
+ * If set to TRUE, the security subject context has the audit privilege thus
+ * it is allowed the ability to perform the audit. 
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeListLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping table of access rights used whilst performing auditing
+ * sequence procedure.
+ * 
+ * @param[out] GrantedAccessList
+ * This parameter is used to return to the caller a list of actual granted access
+ * rights masks that the audited object has.
+ * 
+ * @param[out] AccessStatusList
+ * This parameter is used to return to the caller a list of status return codes.
+ * The function may actually return a single NTSTATUS code if the calling thread
+ * sets UseResultList parameter to FALSE.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @param[in] UseResultList
+ * If set to TRUE, the caller wants that the function should only return a single
+ * NTSTATUS code.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the function has completed the whole internal
+ * auditing procedure mechanism with success.
+ */
 _Must_inspect_result_
 static
 NTSTATUS
@@ -365,6 +621,89 @@ SepAccessCheckAndAuditAlarmWorker(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Performs security auditing, if the specific object can be granted
+ * security access or not.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that represents the name of a subsystem that
+ * actuates the auditing process.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID used to identify an object where auditing
+ * is to be done.
+ * 
+ * @param[in] SubjectContext
+ * Security subject context.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that represents the name of an object type.
+ * 
+ * @param[in] ObjectName
+ * The name of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor with internal security information details
+ * for audit.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] AuditType
+ * Type of audit to start. This parameter influences how an audit
+ * should be done.
+ * 
+ * @param[in] Flags
+ * Flag bitmask parameter.
+ * 
+ * @param[in] HaveAuditPrivilege
+ * If set to TRUE, the security subject context has the audit privilege thus
+ * it is allowed the ability to perform the audit. 
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeListLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping table of access rights used whilst performing auditing
+ * sequence procedure.
+ * 
+ * @param[out] GrantedAccessList
+ * This parameter is used to return to the caller a list of actual granted access
+ * rights masks that the audited object has.
+ * 
+ * @param[out] AccessStatusList
+ * This parameter is used to return to the caller a list of status return codes.
+ * The function may actually return a single NTSTATUS code if the calling thread
+ * sets UseResultList parameter to FALSE.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @param[in] UseResultList
+ * If set to TRUE, the caller wants that the function should only return a single
+ * NTSTATUS code.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the function has completed the whole internal
+ * auditing procedure mechanism with success. STATUS_INVALID_PARAMETER is
+ * returned if one of the parameters do not satisfy the general requirements
+ * by the function. STATUS_INSUFFICIENT_RESOURCES is returned if pool memory
+ * allocation has failed. STATUS_PRIVILEGE_NOT_HELD is returned if the current
+ * security subject context does not have the required audit privilege to actually
+ * perform auditing in the first place. STATUS_INVALID_SECURITY_DESCR is returned
+ * if the security descriptor provided by the caller is not valid, that is, such
+ * descriptor doesn't belong to the main user (owner) and current group.
+ * STATUS_GENERIC_NOT_MAPPED is returned if the access rights masks aren't actually
+ * mapped. A failure NTSTATUS code is returned otherwise.
+ */
 _Must_inspect_result_
 NTSTATUS
 NTAPI
@@ -700,8 +1039,24 @@ Cleanup:
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Performs an audit against a hard link creation.
+ * 
+ * @param[in] FileName
+ * A Unicode string that points to the name of the file.
+ * 
+ * @param[in] LinkName
+ * A Unicode string that points to a link.
+ * 
+ * @param[out] bSuccess
+ * If TRUE, the function has successfully audited
+ * the hard link and security access can be granted,
+ * FALSE otherwise.
+ * 
+ * @return
+ * Nothing.
  */
 VOID
 NTAPI
@@ -712,8 +1067,21 @@ SeAuditHardLinkCreation(IN PUNICODE_STRING FileName,
     UNIMPLEMENTED;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Determines whether auditing against file events is being
+ * done or not.
+ * 
+ * @param[in] AccessGranted
+ * If set to TRUE, the access attempt is deemed as successful
+ * otherwise set it to FALSE.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @return
+ * Returns TRUE if auditing is being currently done, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -724,8 +1092,25 @@ SeAuditingFileEvents(IN BOOLEAN AccessGranted,
     return FALSE;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Determines whether auditing against file events with subject context
+ * is being done or not.
+ * 
+ * @param[in] AccessGranted
+ * If set to TRUE, the access attempt is deemed as successful
+ * otherwise set it to FALSE.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] SubjectSecurityContext
+ * If specified, the function will check if security auditing is currently
+ * being done with this context.
+ * 
+ * @return
+ * Returns TRUE if auditing is being currently done, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -737,8 +1122,21 @@ SeAuditingFileEventsWithContext(IN BOOLEAN AccessGranted,
     return FALSE;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Determines whether auditing against hard links events is being
+ * done or not.
+ * 
+ * @param[in] AccessGranted
+ * If set to TRUE, the access attempt is deemed as successful
+ * otherwise set it to FALSE.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @return
+ * Returns TRUE if auditing is being currently done, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -749,8 +1147,25 @@ SeAuditingHardLinkEvents(IN BOOLEAN AccessGranted,
     return FALSE;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Determines whether auditing against hard links events with subject context
+ * is being done or not.
+ * 
+ * @param[in] AccessGranted
+ * If set to TRUE, the access attempt is deemed as successful
+ * otherwise set it to FALSE.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] SubjectSecurityContext
+ * If specified, the function will check if security auditing is currently
+ * being done with this context.
+ * 
+ * @return
+ * Returns TRUE if auditing is being currently done, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -762,8 +1177,25 @@ SeAuditingHardLinkEventsWithContext(IN BOOLEAN AccessGranted,
     return FALSE;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Determines whether auditing against files or global events with
+ * subject context is being done or not.
+ * 
+ * @param[in] AccessGranted
+ * If set to TRUE, the access attempt is deemed as successful
+ * otherwise set it to FALSE.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] SubjectSecurityContext
+ * If specified, the function will check if security auditing is currently
+ * being done with this context.
+ * 
+ * @return
+ * Returns TRUE if auditing is being currently done, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -775,8 +1207,23 @@ SeAuditingFileOrGlobalEvents(IN BOOLEAN AccessGranted,
     return FALSE;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Closes an alarm audit of an object.
+ * 
+ * @param[in] Object
+ * An arbitrary pointer data that points to the object.
+ * 
+ * @param[in] Handle
+ * A handle of the said object.
+ * 
+ * @param[in] PerformAction
+ * Set this to TRUE to perform any auxiliary action, otherwise
+ * set to FALSE.
+ * 
+ * @return
+ * Nothing.
  */
 VOID
 NTAPI
@@ -787,8 +1234,19 @@ SeCloseObjectAuditAlarm(IN PVOID Object,
     UNIMPLEMENTED;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Deletes an alarm audit of an object.
+ * 
+ * @param[in] Object
+ * An arbitrary pointer data that points to the object.
+ * 
+ * @param[in] Handle
+ * A handle of the said object.
+ * 
+ * @return
+ * Nothing.
  */
 VOID NTAPI
 SeDeleteObjectAuditAlarm(IN PVOID Object,
@@ -797,8 +1255,46 @@ SeDeleteObjectAuditAlarm(IN PVOID Object,
     UNIMPLEMENTED;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Creates an audit with alarm notification of an object
+ * that is being opened.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that points to the object type name.
+ * 
+ * @param[in] Object
+ * If specified, the function will use this parameter to
+ * directly open the object.
+ * 
+ * @param[in] AbsoluteObjectName
+ * If specified, the function will use this parameter to
+ * directly open the object through the absolute name
+ * of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] AccessState
+ * An access state right mask when opening the object.
+ * 
+ * @param[in] ObjectCreated
+ * Set this to TRUE if the object has been fully created,
+ * FALSE otherwise.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if access was deemed as granted.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode.
+ * 
+ * @param[out] GenerateOnClose
+ * A boolean flag returned to the caller once audit generation procedure
+ * finishes.
+ * 
+ * @return
+ * Nothing.
  */
 VOID
 NTAPI
@@ -822,8 +1318,46 @@ SeOpenObjectAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
     return;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Creates an audit with alarm notification of an object
+ * that is being opened for deletion.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that points to the object type name.
+ * 
+ * @param[in] Object
+ * If specified, the function will use this parameter to
+ * directly open the object.
+ * 
+ * @param[in] AbsoluteObjectName
+ * If specified, the function will use this parameter to
+ * directly open the object through the absolute name
+ * of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] AccessState
+ * An access state right mask when opening the object.
+ * 
+ * @param[in] ObjectCreated
+ * Set this to TRUE if the object has been fully created,
+ * FALSE otherwise.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if access was deemed as granted.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode.
+ * 
+ * @param[out] GenerateOnClose
+ * A boolean flag returned to the caller once audit generation procedure
+ * finishes.
+ * 
+ * @return
+ * Nothing.
  */
 VOID NTAPI
 SeOpenObjectForDeleteAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
@@ -839,8 +1373,34 @@ SeOpenObjectForDeleteAuditAlarm(IN PUNICODE_STRING ObjectTypeName,
     UNIMPLEMENTED;
 }
 
-/*
+/**
  * @unimplemented
+ * @brief
+ * Raises an audit with alarm notification message
+ * when an object tries to acquire this privilege.
+ * 
+ * @param[in] Handle
+ * A handle to an object.
+ * 
+ * @param[in] SubjectContext
+ * The security subject context for auditing.
+ * 
+ * @param[in] DesiredAccess
+ * The desired right access masks requested by the caller.
+ * 
+ * @param[in] Privileges
+ * An array set of privileges for auditing.
+ * 
+ * @param[out] AccessGranted
+ * When the auditing procedure routine ends, it returns TRUE to the
+ * caller if the object has the required privileges for access,
+ * FALSE otherwise.
+ * 
+ * @param[in] CurrentMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Nothing.
  */
 VOID
 NTAPI
@@ -856,6 +1416,28 @@ SePrivilegeObjectAuditAlarm(IN HANDLE Handle,
 
 /* SYSTEM CALLS ***************************************************************/
 
+/**
+ * @brief
+ * Raises an alarm audit message when an object is about
+ * to be closed.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to the name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle of an ID used for identification instance for auditing.
+ * 
+ * @param[in] GenerateOnClose
+ * A boolean value previously created by the "open" equivalent of this
+ * function. If the caller explicitly sets this to FALSE, the function
+ * assumes that the object is not opened.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if all the operations have completed successfully.
+ * STATUS_PRIVILEGE_NOT_HELD is returned if the security subject context
+ * does not have the audit privilege to actually begin auditing procedures
+ * in the first place.
+ */
 NTSTATUS
 NTAPI
 NtCloseObjectAuditAlarm(
@@ -954,7 +1536,26 @@ Cleanup:
     return Status;
 }
 
-
+/**
+ * @unimplemented
+ * @brief
+ * Raises an alarm audit message when an object is about
+ * to be deleted.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to the name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle of an ID used for identification instance for auditing.
+ * 
+ * @param[in] GenerateOnClose
+ * A boolean value previously created by the "open" equivalent of this
+ * function. If the caller explicitly sets this to FALSE, the function
+ * assumes that the object is not opened.
+ * 
+ * @return
+ * To be added...
+ */
 NTSTATUS NTAPI
 NtDeleteObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
                          IN PVOID HandleId,
@@ -964,6 +1565,55 @@ NtDeleteObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
     return STATUS_NOT_IMPLEMENTED;
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Raises an alarm audit message when an object is about
+ * to be opened.
+ * 
+ * @param[in] SubjectContext
+ * A security subject context for auditing.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID used for identification instance for auditing.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that points to an object type name.
+ * 
+ * @param[in] ObjectName
+ * The name of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] ClientToken
+ * A client access token, representing the client we want to impersonate.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] GrantedAccess
+ * The granted access mask rights.
+ * 
+ * @param[in] Privileges
+ * If specified, the function will use this set of privileges to audit.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if the access attempt was deemed as granted.
+ * 
+ * @param[out] GenerateOnClose
+ * A boolean flag returned to the caller once audit generation procedure
+ * finishes.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepOpenObjectAuditAlarm(
@@ -997,6 +1647,59 @@ SepOpenObjectAuditAlarm(
     *GenerateOnClose = FALSE;
 }
 
+/**
+ * @brief
+ * Raises an alarm audit message when an object is about
+ * to be opened.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID used for identification instance for auditing.
+ * 
+ * @param[in] ObjectTypeName
+ * A Unicode string that points to an object type name.
+ * 
+ * @param[in] ObjectName
+ * The name of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] ClientTokenHandle
+ * A handle to a client access token.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] GrantedAccess
+ * The granted access mask rights.
+ * 
+ * @param[in] PrivilegeSet
+ * If specified, the function will use this set of privileges to audit.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if the access attempt was deemed as granted.
+ * 
+ * @param[out] GenerateOnClose
+ * A boolean flag returned to the caller once audit generation procedure
+ * finishes.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if all the operations have been completed successfully.
+ * STATUS_PRIVILEGE_NOT_HELD is returned if the given subject context does not
+ * hold the required audit privilege to actually begin auditing in the first place.
+ * STATUS_BAD_IMPERSONATION_LEVEL is returned if the security impersonation level
+ * of the client token is not on par with the impersonation level that alllows
+ * impersonation. STATUS_INVALID_PARAMETER is returned if the caller has
+ * submitted a bogus set of privileges as such array set exceeds the maximum
+ * count of privileges that the kernel can accept. A failure NTSTATUS code
+ * is returned otherwise.
+ */
 __kernel_entry
 NTSTATUS
 NTAPI
@@ -1227,7 +1930,37 @@ Cleanup:
     return Status;
 }
 
-
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to request
+ * a privileged service call.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] ServiceName
+ * A Unicode string that points to a name of the privileged service.
+ * 
+ * @param[in] ClientTokenHandle
+ * A handle to a client access token.
+ * 
+ * @param[in] Privileges
+ * An array set of privileges.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if the access attempt was deemed as granted.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if all the operations have been completed successfully.
+ * STATUS_PRIVILEGE_NOT_HELD is returned if the given subject context does not
+ * hold the required audit privilege to actually begin auditing in the first place.
+ * STATUS_BAD_IMPERSONATION_LEVEL is returned if the security impersonation level
+ * of the client token is not on par with the impersonation level that alllows
+ * impersonation. STATUS_INVALID_PARAMETER is returned if the caller has
+ * submitted a bogus set of privileges as such array set exceeds the maximum
+ * count of privileges that the kernel can accept. A failure NTSTATUS code
+ * is returned otherwise.
+ */
 __kernel_entry
 NTSTATUS
 NTAPI
@@ -1387,7 +2120,32 @@ Cleanup:
     return Status;
 }
 
-
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to access a
+ * privileged object.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID that is used as identification instance for auditing.
+ * 
+ * @param[in] ClientToken
+ * A handle to a client access token.
+ * 
+ * @param[in] DesiredAccess
+ * A handle to a client access token.
+ * 
+ * @param[in] Privileges
+ * An array set of privileges.
+ * 
+ * @param[in] AccessGranted
+ * Set this to TRUE if the access attempt was deemed as granted.
+ * 
+ * @return
+ * To be added...
+ */
 NTSTATUS NTAPI
 NtPrivilegeObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
                             IN PVOID HandleId,
@@ -1400,7 +2158,49 @@ NtPrivilegeObjectAuditAlarm(IN PUNICODE_STRING SubsystemName,
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to access an
+ * object and determine if the access can be made.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID that is used as identification instance for auditing.
+ * 
+ * @param[in] ObjectTypeName
+ * The name of the object type.
+ * 
+ * @param[in] ObjectName
+ * The object name.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access mask rights.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[out] GrantedAccess
+ * Returns the granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * Returns a NTSTATUS status code indicating whether access check
+ * can be granted or not.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @return
+ * See SepAccessCheckAndAuditAlarm.
+ */
 _Must_inspect_result_
 __kernel_entry
 NTSTATUS
@@ -1438,6 +2238,66 @@ NtAccessCheckAndAuditAlarm(
                                        FALSE);
 }
 
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to access an
+ * object and determine if the access can be made by type.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID that is used as identification instance for auditing.
+ * 
+ * @param[in] ObjectTypeName
+ * The name of the object type.
+ * 
+ * @param[in] ObjectName
+ * The object name.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] AuditType
+ * Type of audit to start, influencing how the audit should
+ * be done.
+ * 
+ * @param[in] Flags
+ * Flag bitmask, used to check if auditing can be done
+ * without privileges.
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access mask rights.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[out] GrantedAccess
+ * Returns the granted access rights.
+ * 
+ * @param[out] AccessStatus
+ * Returns a NTSTATUS status code indicating whether access check
+ * can be granted or not.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @return
+ * See SepAccessCheckAndAuditAlarm.
+ */
 _Must_inspect_result_
 __kernel_entry
 NTSTATUS
@@ -1480,6 +2340,66 @@ NtAccessCheckByTypeAndAuditAlarm(
                                        FALSE);
 }
 
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to access an
+ * object and determine if the access can be made by given type result.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID that is used as identification instance for auditing.
+ * 
+ * @param[in] ObjectTypeName
+ * The name of the object type.
+ * 
+ * @param[in] ObjectName
+ * The object name.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] AuditType
+ * Type of audit to start, influencing how the audit should
+ * be done.
+ * 
+ * @param[in] Flags
+ * Flag bitmask, used to check if auditing can be done
+ * without privileges.
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access mask rights.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[out] GrantedAccessList
+ * Returns the granted access rights.
+ * 
+ * @param[out] AccessStatusList
+ * Returns a NTSTATUS status code indicating whether access check
+ * can be granted or not.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @return
+ * See SepAccessCheckAndAuditAlarm.
+ */
 _Must_inspect_result_
 __kernel_entry
 NTSTATUS
@@ -1522,6 +2442,70 @@ NtAccessCheckByTypeResultListAndAuditAlarm(
                                        TRUE);
 }
 
+/**
+ * @brief
+ * Raises an alarm audit message when a caller attempts to access an
+ * object and determine if the access can be made by given type result
+ * and a token handle.
+ * 
+ * @param[in] SubsystemName
+ * A Unicode string that points to a name of the subsystem.
+ * 
+ * @param[in] HandleId
+ * A handle to an ID that is used as identification instance for auditing.
+ * 
+ * @param[in] ClientToken
+ * A handle to a client access token.
+ * 
+ * @param[in] ObjectTypeName
+ * The name of the object type.
+ * 
+ * @param[in] ObjectName
+ * The object name.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[in] PrincipalSelfSid
+ * A principal self user SID.
+ * 
+ * @param[in] DesiredAccess
+ * The desired access rights masks requested by the caller.
+ * 
+ * @param[in] AuditType
+ * Type of audit to start, influencing how the audit should
+ * be done.
+ * 
+ * @param[in] Flags
+ * Flag bitmask, used to check if auditing can be done
+ * without privileges.
+ * 
+ * @param[in] ObjectTypeList
+ * A list of object types.
+ * 
+ * @param[in] ObjectTypeLength
+ * The length size of the list.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access mask rights.
+ * 
+ * @param[in] ObjectCreation
+ * Set this to TRUE if the object has just been created.
+ * 
+ * @param[out] GrantedAccessList
+ * Returns the granted access rights.
+ * 
+ * @param[out] AccessStatusList
+ * Returns a NTSTATUS status code indicating whether access check
+ * can be granted or not.
+ * 
+ * @param[out] GenerateOnClose
+ * Returns TRUE if the function has generated a list of granted access rights and
+ * status codes on termination, FALSE otherwise.
+ * 
+ * @return
+ * See SepAccessCheckAndAuditAlarm.
+ */
 _Must_inspect_result_
 __kernel_entry
 NTSTATUS

--- a/ntoskrnl/se/priv.c
+++ b/ntoskrnl/se/priv.c
@@ -99,11 +99,12 @@ SepInitPrivileges(VOID)
  */
 BOOLEAN
 NTAPI
-SepPrivilegeCheck(PTOKEN Token,
-                  PLUID_AND_ATTRIBUTES Privileges,
-                  ULONG PrivilegeCount,
-                  ULONG PrivilegeControl,
-                  KPROCESSOR_MODE PreviousMode)
+SepPrivilegeCheck(
+    _In_ PTOKEN Token,
+    _In_ PLUID_AND_ATTRIBUTES Privileges,
+    _In_ ULONG PrivilegeCount,
+    _In_ ULONG PrivilegeControl,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     ULONG i;
     ULONG j;
@@ -185,9 +186,9 @@ SepPrivilegeCheck(PTOKEN Token,
 NTSTATUS
 NTAPI
 SepSinglePrivilegeCheck(
-    LUID PrivilegeValue,
-    PTOKEN Token,
-    KPROCESSOR_MODE PreviousMode)
+    _In_ LUID PrivilegeValue,
+    _In_ PTOKEN Token,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     LUID_AND_ATTRIBUTES Privilege;
     PAGED_CODE();
@@ -430,15 +431,16 @@ SeCheckAuditPrivilege(
  */
 NTSTATUS
 NTAPI
-SeCaptureLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Src,
-                                ULONG PrivilegeCount,
-                                KPROCESSOR_MODE PreviousMode,
-                                PLUID_AND_ATTRIBUTES AllocatedMem,
-                                ULONG AllocatedLength,
-                                POOL_TYPE PoolType,
-                                BOOLEAN CaptureIfKernel,
-                                PLUID_AND_ATTRIBUTES *Dest,
-                                PULONG Length)
+SeCaptureLuidAndAttributesArray(
+    _In_ PLUID_AND_ATTRIBUTES Src,
+    _In_ ULONG PrivilegeCount,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _In_opt_ PLUID_AND_ATTRIBUTES AllocatedMem,
+    _In_opt_ ULONG AllocatedLength,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PLUID_AND_ATTRIBUTES *Dest,
+    _Inout_ PULONG Length)
 {
     ULONG BufferSize;
     NTSTATUS Status = STATUS_SUCCESS;
@@ -543,9 +545,10 @@ SeCaptureLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Src,
  */
 VOID
 NTAPI
-SeReleaseLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Privilege,
-                                KPROCESSOR_MODE PreviousMode,
-                                BOOLEAN CaptureIfKernel)
+SeReleaseLuidAndAttributesArray(
+    _In_ PLUID_AND_ATTRIBUTES Privilege,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _In_ BOOLEAN CaptureIfKernel)
 {
     PAGED_CODE();
 
@@ -576,8 +579,9 @@ SeReleaseLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Privilege,
  */
 NTSTATUS
 NTAPI
-SeAppendPrivileges(IN OUT PACCESS_STATE AccessState,
-                   IN PPRIVILEGE_SET Privileges)
+SeAppendPrivileges(
+    _Inout_ PACCESS_STATE AccessState,
+    _In_ PPRIVILEGE_SET Privileges)
 {
     PAUX_ACCESS_DATA AuxData;
     ULONG OldPrivilegeSetSize;
@@ -656,7 +660,8 @@ SeAppendPrivileges(IN OUT PACCESS_STATE AccessState,
  */
 VOID
 NTAPI
-SeFreePrivileges(IN PPRIVILEGE_SET Privileges)
+SeFreePrivileges(
+    _In_ PPRIVILEGE_SET Privileges)
 {
     PAGED_CODE();
     ExFreePoolWithTag(Privileges, TAG_PRIVILEGE_SET);
@@ -684,9 +689,10 @@ SeFreePrivileges(IN PPRIVILEGE_SET Privileges)
  */
 BOOLEAN
 NTAPI
-SePrivilegeCheck(PPRIVILEGE_SET Privileges,
-                 PSECURITY_SUBJECT_CONTEXT SubjectContext,
-                 KPROCESSOR_MODE PreviousMode)
+SePrivilegeCheck(
+    _In_ PPRIVILEGE_SET Privileges,
+    _In_ PSECURITY_SUBJECT_CONTEXT SubjectContext,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     PACCESS_TOKEN Token = NULL;
 
@@ -729,8 +735,9 @@ SePrivilegeCheck(PPRIVILEGE_SET Privileges,
  */
 BOOLEAN
 NTAPI
-SeSinglePrivilegeCheck(IN LUID PrivilegeValue,
-                       IN KPROCESSOR_MODE PreviousMode)
+SeSinglePrivilegeCheck(
+    _In_ LUID PrivilegeValue,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     SECURITY_SUBJECT_CONTEXT SubjectContext;
     PRIVILEGE_SET Priv;
@@ -787,10 +794,11 @@ SeSinglePrivilegeCheck(IN LUID PrivilegeValue,
  */
 BOOLEAN
 NTAPI
-SeCheckPrivilegedObject(IN LUID PrivilegeValue,
-                        IN HANDLE ObjectHandle,
-                        IN ACCESS_MASK DesiredAccess,
-                        IN KPROCESSOR_MODE PreviousMode)
+SeCheckPrivilegedObject(
+    _In_ LUID PrivilegeValue,
+    _In_ HANDLE ObjectHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ KPROCESSOR_MODE PreviousMode)
 {
     SECURITY_SUBJECT_CONTEXT SubjectContext;
     PRIVILEGE_SET Priv;
@@ -851,9 +859,10 @@ SeCheckPrivilegedObject(IN LUID PrivilegeValue,
  */
 NTSTATUS
 NTAPI
-NtPrivilegeCheck(IN HANDLE ClientToken,
-                 IN PPRIVILEGE_SET RequiredPrivileges,
-                 OUT PBOOLEAN Result)
+NtPrivilegeCheck(
+    _In_ HANDLE ClientToken,
+    _In_ PPRIVILEGE_SET RequiredPrivileges,
+    _Out_ PBOOLEAN Result)
 {
     PLUID_AND_ATTRIBUTES Privileges;
     PTOKEN Token;

--- a/ntoskrnl/se/priv.c
+++ b/ntoskrnl/se/priv.c
@@ -1,10 +1,10 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/priv.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     No programmer listed.
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security privileges support
+ * COPYRIGHT:       Copyright Alex Ionescu <alex@relsoft.net>
+ *                  Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                  Copyright Eric Kohl
  */
 
 /* INCLUDES ******************************************************************/
@@ -54,6 +54,15 @@ const LUID SeCreateSymbolicLinkPrivilege = CONST_LUID(SE_CREATE_SYMBOLIC_LINK_PR
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+/**
+ * @brief
+ * Initializes the privileges during the startup phase of the security
+ * manager module. This function serves as a placeholder as it currently
+ * does nothing.
+ * 
+ * @return
+ * Nothing.
+ */
 CODE_SEG("INIT")
 VOID
 NTAPI
@@ -62,7 +71,32 @@ SepInitPrivileges(VOID)
 
 }
 
-
+/**
+ * @brief
+ * Checks the privileges pointed by Privileges array argument if they exist and
+ * match with the privileges from an access token.
+ * 
+ * @param[in] Token
+ * An access token where privileges are to be checked.
+ * 
+ * @param[in] Privileges
+ * An array of privileges with attributes used as checking indicator for
+ * the function.
+ * 
+ * @param[in] PrivilegeCount
+ * The total number count of privileges in the array.
+ * 
+ * @param[in] PrivilegeControl
+ * Privilege control bit mask to determine if we should check all the
+ * privileges based on the number count of privileges or not.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if the required privileges exist and that they do match.
+ * Otherwise the functions returns FALSE.
+ */
 BOOLEAN
 NTAPI
 SepPrivilegeCheck(PTOKEN Token,
@@ -129,6 +163,25 @@ SepPrivilegeCheck(PTOKEN Token,
     return FALSE;
 }
 
+/**
+ * @brief
+ * Checks only single privilege based upon the privilege pointed by a LUID and
+ * if it matches with the one from an access token.
+ * 
+ * @param[in] PrivilegeValue
+ * The privilege to be checked.
+ * 
+ * @param[in] Token
+ * An access token where its privilege is to be checked against the one
+ * provided by the caller.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if the required privilege exists and that it matches
+ * with the one from the access token, FALSE otherwise.
+ */
 NTSTATUS
 NTAPI
 SepSinglePrivilegeCheck(
@@ -149,6 +202,40 @@ SepSinglePrivilegeCheck(
                              PreviousMode);
 }
 
+/**
+ * @brief
+ * Checks the security policy and returns a set of privileges
+ * based upon the said security policy context.
+ * 
+ * @param[in,out] DesiredAccess
+ * The desired access right mask.
+ * 
+ * @param[in,out] GrantedAccess
+ * The granted access rights masks. The rights are granted depending
+ * on the desired access rights requested by the calling thread.
+ * 
+ * @param[in] SubjectContext
+ * Security subject context. If the caller supplies one, the access token
+ * supplied by the caller will be assigned to one of client or primary tokens
+ * of the subject context in question.
+ * 
+ * @param[in] Token
+ * An access token.
+ * 
+ * @param[out] OutPrivilegeSet
+ * An array set of privileges to be reported to the caller, if the actual
+ * calling thread wants such set of privileges in the first place.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns STATUS_PRIVILEGE_NOT_HELD if the respective operations have succeeded
+ * without problems. STATUS_PRIVILEGE_NOT_HELD is returned if the access token
+ * doesn't have SeSecurityPrivilege privilege to warrant ACCESS_SYSTEM_SECURITY
+ * access right. STATUS_INSUFFICIENT_RESOURCES is returned if we failed
+ * to allocate block of memory pool for the array set of privileges.
+ */
 NTSTATUS
 NTAPI
 SePrivilegePolicyCheck(
@@ -248,6 +335,23 @@ SePrivilegePolicyCheck(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Checks a single privilege and performs an audit
+ * against a privileged service based on a security subject
+ * context.
+ * 
+ * @param[in] DesiredAccess
+ * Security subject context used for privileged service
+ * auditing.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if service auditing and privilege checking
+ * tests have succeeded, FALSE otherwise.
+ */
 BOOLEAN
 NTAPI
 SeCheckAuditPrivilege(
@@ -282,6 +386,48 @@ SeCheckAuditPrivilege(
     return Result;
 }
 
+/**
+ * @brief
+ * Captures a LUID with attributes structure. This function is mainly
+ * tied in the context of privileges.
+ * 
+ * @param[in] Src
+ * Source of a valid LUID with attributes structure.
+ * 
+ * @param[in] PrivilegeCount
+ * Count number of privileges to be captured.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @param[in] AllocatedMem
+ * If specified, the function will use this allocated block memory
+ * buffer for the captured LUID and attributes structure. Otherwise
+ * the function will automatically allocate some buffer for it.
+ * 
+ * @param[in] AllocatedLength
+ * The length of the buffer, pointed by AllocatedMem.
+ * 
+ * @param[in] PoolType
+ * Pool type of the memory allocation.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the capturing is done in the kernel itself.
+ * FALSE if the capturing is done in a kernel mode driver instead.
+ * 
+ * @param[out] Dest
+ * The captured LUID with attributes buffer.
+ * 
+ * @param[in,out] Length
+ * The length of the captured privileges count.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the LUID and attributes array
+ * has been captured successfully. STATUS_INSUFFICIENT_RESOURCES is returned
+ * if memory pool allocation for the captured buffer has failed.
+ * STATUS_BUFFER_TOO_SMALL is returned if the buffer size is less than the
+ * required size.
+ */
 NTSTATUS
 NTAPI
 SeCaptureLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Src,
@@ -378,6 +524,23 @@ SeCaptureLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Src,
     return Status;
 }
 
+/**
+ * @brief
+ * Releases a LUID with attributes structure.
+ * 
+ * @param[in] Privilege
+ * Array of a LUID and attributes that represents a privilege.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the releasing is done in the kernel itself.
+ * FALSE if the releasing is done in a kernel mode driver instead.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeReleaseLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Privilege,
@@ -395,8 +558,21 @@ SeReleaseLuidAndAttributesArray(PLUID_AND_ATTRIBUTES Privilege,
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
- * @implemented
+/**
+ * @brief
+ * Appends additional privileges.
+ * 
+ * @param[in] AccessState
+ * Access request to append.
+ * 
+ * @param[in] Privileges
+ * Set of new privileges to append.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the privileges have been successfully
+ * appended. Otherwise STATUS_INSUFFICIENT_RESOURCES is returned,
+ * indicating that pool allocation has failed for the buffer to hold
+ * the new set of privileges.
  */
 NTSTATUS
 NTAPI
@@ -468,8 +644,15 @@ SeAppendPrivileges(IN OUT PACCESS_STATE AccessState,
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Frees a set of privileges.
+ * 
+ * @param[in] Privileges
+ * Set of privileges array to be freed.
+ * 
+ * @return
+ * Nothing.
  */
 VOID
 NTAPI
@@ -479,8 +662,25 @@ SeFreePrivileges(IN PPRIVILEGE_SET Privileges)
     ExFreePoolWithTag(Privileges, TAG_PRIVILEGE_SET);
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Checks if a set of privileges exist and match within a
+ * security subject context.
+ * 
+ * @param[in] Privileges
+ * A set of privileges where the check must be performed
+ * against the subject context.
+ * 
+ * @param[in] SubjectContext
+ * A subject security context.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if all the privileges do exist and match
+ * with the ones specified by the caller and subject
+ * context, FALSE otherwise.
  */
 BOOLEAN
 NTAPI
@@ -512,8 +712,20 @@ SePrivilegeCheck(PPRIVILEGE_SET Privileges,
                              PreviousMode);
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Checks if a single privilege is present in the context
+ * of the calling thread.
+ * 
+ * @param[in] PrivilegeValue
+ * The specific privilege to be checked.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if the privilege is present, FALSE
+ * otherwise.
  */
 BOOLEAN
 NTAPI
@@ -551,6 +763,28 @@ SeSinglePrivilegeCheck(IN LUID PrivilegeValue,
     return Result;
 }
 
+/**
+ * @brief
+ * Checks a privileged object if such object has
+ * the specific privilege submitted by the caller.
+ * 
+ * @param[in] PrivilegeValue
+ * A privilege to be checked against the one from
+ * the object.
+ * 
+ * @param[in] ObjectHandle
+ * A handle to any kind of object.
+ * 
+ * @param[in] DesiredAccess
+ * Desired access right mask requested by the caller.
+ * 
+ * @param[in] PreviousMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns TRUE if the privilege is present, FALSE
+ * otherwise.
+ */
 BOOLEAN
 NTAPI
 SeCheckPrivilegedObject(IN LUID PrivilegeValue,
@@ -591,6 +825,30 @@ SeCheckPrivilegedObject(IN LUID PrivilegeValue,
 
 /* SYSTEM CALLS ***************************************************************/
 
+/**
+ * @brief
+ * Checks a client access token if it has the required set of
+ * privileges.
+ * 
+ * @param[in] ClientToken
+ * A handle to an access client token.
+ * 
+ * @param[in] RequiredPrivileges
+ * A set of required privileges to be checked against the privileges
+ * of the access token.
+ * 
+ * @param[out] Result
+ * The result, as a boolean value. If TRUE, the token has all the required
+ * privileges, FALSE otherwise.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the function has completed successfully.
+ * STATUS_INVALID_PARAMETER is returned if the set array of required
+ * privileges has a bogus number of privileges, that is, the array
+ * has a count of privileges that exceeds the maximum threshold
+ * (or in other words, an integer overflow). A failure NTSTATUS code
+ * is returned otherwise.
+ */
 NTSTATUS
 NTAPI
 NtPrivilegeCheck(IN HANDLE ClientToken,

--- a/ntoskrnl/se/sd.c
+++ b/ntoskrnl/se/sd.c
@@ -152,9 +152,10 @@ SepInitSDs(VOID)
  */
 NTSTATUS
 NTAPI
-SeSetWorldSecurityDescriptor(SECURITY_INFORMATION SecurityInformation,
-                             PISECURITY_DESCRIPTOR SecurityDescriptor,
-                             PULONG BufferLength)
+SeSetWorldSecurityDescriptor(
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _In_ PISECURITY_DESCRIPTOR SecurityDescriptor,
+    _In_ PULONG BufferLength)
 {
     ULONG Current;
     ULONG SidSize;
@@ -263,9 +264,9 @@ SeSetWorldSecurityDescriptor(SECURITY_INFORMATION SecurityInformation,
 static
 ULONG
 DetermineSIDSize(
-    PISID Sid,
-    PULONG OutSAC,
-    KPROCESSOR_MODE ProcessorMode)
+    _In_ PISID Sid,
+    _Inout_ PULONG OutSAC,
+    _In_ KPROCESSOR_MODE ProcessorMode)
 {
     ULONG Size;
 
@@ -309,8 +310,8 @@ DetermineSIDSize(
 static
 ULONG
 DetermineACLSize(
-    PACL Acl,
-    KPROCESSOR_MODE ProcessorMode)
+    _In_ PACL Acl,
+    _In_ KPROCESSOR_MODE ProcessorMode)
 {
     ULONG Size;
 
@@ -359,11 +360,11 @@ DetermineACLSize(
 NTSTATUS
 NTAPI
 SeCaptureSecurityDescriptor(
-    IN PSECURITY_DESCRIPTOR _OriginalSecurityDescriptor,
-    IN KPROCESSOR_MODE CurrentMode,
-    IN POOL_TYPE PoolType,
-    IN BOOLEAN CaptureIfKernel,
-    OUT PSECURITY_DESCRIPTOR *CapturedSecurityDescriptor)
+    _In_ PSECURITY_DESCRIPTOR _OriginalSecurityDescriptor,
+    _In_ KPROCESSOR_MODE CurrentMode,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PSECURITY_DESCRIPTOR *CapturedSecurityDescriptor)
 {
     PISECURITY_DESCRIPTOR OriginalDescriptor = _OriginalSecurityDescriptor;
     SECURITY_DESCRIPTOR DescriptorCopy;
@@ -732,9 +733,10 @@ SeQuerySecurityDescriptorInfo(
  */
 NTSTATUS
 NTAPI
-SeReleaseSecurityDescriptor(IN PSECURITY_DESCRIPTOR CapturedSecurityDescriptor,
-                            IN KPROCESSOR_MODE CurrentMode,
-                            IN BOOLEAN CaptureIfKernelMode)
+SeReleaseSecurityDescriptor(
+    _In_ PSECURITY_DESCRIPTOR CapturedSecurityDescriptor,
+    _In_ KPROCESSOR_MODE CurrentMode,
+    _In_ BOOLEAN CaptureIfKernelMode)
 {
     PAGED_CODE();
 
@@ -998,8 +1000,9 @@ SeSetSecurityDescriptorInfoEx(
  * FALSE otherwise.
  */
 BOOLEAN NTAPI
-SeValidSecurityDescriptor(IN ULONG Length,
-                          IN PSECURITY_DESCRIPTOR _SecurityDescriptor)
+SeValidSecurityDescriptor(
+    _In_ ULONG Length,
+    _In_ PSECURITY_DESCRIPTOR _SecurityDescriptor)
 {
     ULONG SdLength;
     PISID Sid;

--- a/ntoskrnl/se/sd.c
+++ b/ntoskrnl/se/sd.c
@@ -1,10 +1,8 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/sd.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     David Welch <welch@cwcom.net>
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security descriptors (SDs) implementation support
+ * COPYRIGHT:       Copyright David Welch <welch@cwcom.net>
  */
 
 /* INCLUDES *******************************************************************/
@@ -25,6 +23,14 @@ PSECURITY_DESCRIPTOR SeSystemAnonymousLogonSd = NULL;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+/**
+ * @brief
+ * Initializes the known security descriptors in the system.
+ * 
+ * @return
+ * Returns TRUE if all the security descriptors have been initialized,
+ * FALSE otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -124,6 +130,26 @@ SepInitSDs(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Sets a "World" security descriptor.
+ * 
+ * @param[in] SecurityInformation
+ * Security information details, alongside with the security
+ * descriptor to set the World SD.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor buffer.
+ * 
+ * @param[in] BufferLength
+ * Length size of the buffer.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the World security descriptor has been
+ * set. STATUS_ACCESS_DENIED is returned if the caller hasn't
+ * provided security information details thus the SD cannot
+ * be set.
+ */
 NTSTATUS
 NTAPI
 SeSetWorldSecurityDescriptor(SECURITY_INFORMATION SecurityInformation,
@@ -217,6 +243,23 @@ SeSetWorldSecurityDescriptor(SECURITY_INFORMATION SecurityInformation,
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
+/**
+ * @brief
+ * Determines the size of a SID.
+ * 
+ * @param[in] Sid
+ * A security identifier where its size is to be determined.
+ * 
+ * @param[in,out] OutSAC
+ * The returned sub authority count of the security
+ * identifier.
+ * 
+ * @param[in] ProcessorMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns the size length of a security identifier (SID).
+ */
 static
 ULONG
 DetermineSIDSize(
@@ -248,6 +291,21 @@ DetermineSIDSize(
     return Size;
 }
 
+/**
+ * @brief
+ * Determines the size of an ACL.
+ * 
+ * @param[in] Acl
+ * An access control list where its size is to be
+ * determined.
+ * 
+ * @param[in] ProcessorMode
+ * Processor level access mode.
+ * 
+ * @return
+ * Returns the size length of a an access control
+ * list (ACL).
+ */
 static
 ULONG
 DetermineACLSize(
@@ -267,6 +325,37 @@ DetermineACLSize(
     return Size;
 }
 
+/**
+ * @brief
+ * Captures a security descriptor.
+ * 
+ * @param[in] _OriginalSecurityDescriptor
+ * An already existing and valid security descriptor
+ * to be captured.
+ * 
+ * @param[in] CurrentMode
+ * Processor level access mode.
+ * 
+ * @param[in] PoolType
+ * Pool type to be used when allocating the captured
+ * buffer.
+ * 
+ * @param[in] CaptureIfKernel
+ * Set this to TRUE if capturing is done within the
+ * kernel.
+ * 
+ * @param[out] CapturedSecurityDescriptor
+ * The captured security descriptor.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the operations have been
+ * completed successfully and that the security descriptor
+ * has been captured. STATUS_UNKNOWN_REVISION is returned
+ * if the security descriptor has an unknown revision.
+ * STATUS_INSUFFICIENT_RESOURCES is returned if memory
+ * pool allocation for the captured buffer has failed.
+ * A failure NTSTATUS code is returned otherwise.
+ */
 NTSTATUS
 NTAPI
 SeCaptureSecurityDescriptor(
@@ -452,8 +541,32 @@ SeCaptureSecurityDescriptor(
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Queries information details about a security
+ * descriptor.
+ * 
+ * @param[in] SecurityInformation
+ * Security information details to be queried
+ * from a security descriptor.
+ * 
+ * @param[out] SecurityDescriptor
+ * The returned security descriptor with security information
+ * data.
+ * 
+ * @param[in,out] Length
+ * The returned length of a security descriptor.
+ * 
+ * @param[in,out] ObjectsSecurityDescriptor
+ * The returned object security descriptor.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the operations have been
+ * completed successfully and that the specific information
+ * about the security descriptor has been queried.
+ * STATUS_BUFFER_TOO_SMALL is returned if the buffer size
+ * is too small to contain the queried info about the
+ * security descriptor.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -600,8 +713,22 @@ SeQuerySecurityDescriptorInfo(
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Releases a captured security descriptor buffer.
+ * 
+ * @param[in] CapturedSecurityDescriptor
+ * The captured security descriptor to be freed.
+ * 
+ * @param[in] CurrentMode
+ * Processor level access mode.
+ * 
+ * @param[in] CaptureIfKernelMode
+ * Set this to TRUE if the releasing is to be done within
+ * the kernel.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS.
  */
 NTSTATUS
 NTAPI
@@ -627,8 +754,32 @@ SeReleaseSecurityDescriptor(IN PSECURITY_DESCRIPTOR CapturedSecurityDescriptor,
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Modifies some information data about a security
+ * descriptor.
+ * 
+ * @param[in] Object
+ * If specified, the function will use this arbitrary
+ * object that points to an object security descriptor.
+ * 
+ * @param[in] SecurityInformation
+ * Security information details to be set.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor where its info is to be changed.
+ * 
+ * @param[in,out] ObjectsSecurityDescriptor
+ * The returned pointer to security descriptor objects.
+ * 
+ * @param[in] PoolType
+ * Pool type for the new security descriptor to allocate.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights masks.
+ * 
+ * @return
+ * See SeSetSecurityDescriptorInfoEx.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -652,8 +803,42 @@ SeSetSecurityDescriptorInfo(
                                          GenericMapping);
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * An extended function that sets new information data to
+ * a security descriptor.
+ * 
+ * @param[in] Object
+ * If specified, the function will use this arbitrary
+ * object that points to an object security descriptor.
+ * 
+ * @param[in] SecurityInformation
+ * Security information details to be set.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor where its info is to be changed.
+ * 
+ * @param[in,out] ObjectsSecurityDescriptor
+ * The returned pointer to security descriptor objects.
+ * 
+ * @param[in] AutoInheritFlags
+ * Flags bitmask inheritation, influencing how the security
+ * descriptor can be inherited and if it can be in the first
+ * place.
+ * 
+ * @param[in] PoolType
+ * Pool type for the new security descriptor to allocate.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights masks.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the operations have been
+ * completed without problems and that new info has been
+ * set to the security descriptor. STATUS_NO_SECURITY_ON_OBJECT
+ * is returned if the object does not have a security descriptor.
+ * STATUS_INSUFFICIENT_RESOURCES is returned if memory pool allocation
+ * for the new security descriptor with new info set has failed.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -795,9 +980,22 @@ SeSetSecurityDescriptorInfoEx(
     return STATUS_SUCCESS;
 }
 
-
-/*
- * @implemented
+/**
+ * @brief
+ * Determines if a security descriptor is valid according
+ * to the general security requirements and conditions
+ * set by the kernel.
+ * 
+ * @param[in] Length
+ * The length of a security descriptor.
+ * 
+ * @param[in] _SecurityDescriptor
+ * A security descriptor where its properties are to be
+ * checked for validity.
+ * 
+ * @return
+ * Returns TRUE if the given security descriptor is valid,
+ * FALSE otherwise.
  */
 BOOLEAN NTAPI
 SeValidSecurityDescriptor(IN ULONG Length,
@@ -932,8 +1130,15 @@ SeValidSecurityDescriptor(IN ULONG Length,
     return TRUE;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Frees a security descriptor.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor to be freed from memory.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -952,8 +1157,58 @@ SeDeassignSecurity(
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * An extended function that assigns a security descriptor for a new
+ * object.
+ * 
+ * @param[in] _ParentDescriptor
+ * A security descriptor of the parent object that is being
+ * created.
+ * 
+ * @param[in] _ExplicitDescriptor
+ * An explicit security descriptor that is applied to a new
+ * object.
+ * 
+ * @param[out] NewDescriptor
+ * The new allocated security descriptor.
+ * 
+ * @param[in] ObjectType
+ * The type of the new object.
+ * 
+ * @param[in] IsDirectoryObject
+ * Set this to TRUE if the newly created object is a directory
+ * object, otherwise set this to FALSE.
+ * 
+ * @param[in] AutoInheritFlags
+ * Automatic inheritance flags that influence how access control
+ * entries within ACLs from security descriptors are inherited.
+ * 
+ * @param[in] SubjectContext
+ * Security subject context of the new object.
+ * 
+ * @param[in] GenericMapping
+ * Generic mapping of access mask rights.
+ * 
+ * @param[in] PoolType
+ * This parameter is unused.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the operations have been completed
+ * successfully and that the security descriptor has been
+ * assigned to the new object. STATUS_NO_TOKEN is returned
+ * if the caller hasn't supplied a valid argument to a security
+ * subject context. STATUS_INVALID_OWNER is returned if the caller
+ * hasn't supplied a parent descriptor that belongs to the main
+ * user (owner). STATUS_INVALID_PRIMARY_GROUP is returned
+ * by the same reason as with the previous NTSTATUS code.
+ * The two NTSTATUS codes are returned if the calling thread
+ * stated that the owner and/or group is defaulted to the
+ * parent descriptor (SEF_DEFAULT_OWNER_FROM_PARENT and/or
+ * SEF_DEFAULT_GROUP_FROM_PARENT respectively).
+ * STATUS_INSUFFICIENT_RESOURCES is returned if memory pool allocation
+ * for the descriptor buffer has failed. A failure NTSTATUS is returned
+ * otherwise.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -1244,8 +1499,36 @@ SeAssignSecurityEx(
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Assigns a security descriptor for a new object.
+ * 
+ * @param[in] ParentDescriptor
+ * A security descriptor of the parent object that is being
+ * created.
+ * 
+ * @param[in] ExplicitDescriptor
+ * An explicit security descriptor that is applied to a new
+ * object.
+ * 
+ * @param[out] NewDescriptor
+ * The new allocated security descriptor.
+ * 
+ * @param[in] IsDirectoryObject
+ * Set this to TRUE if the newly created object is a directory
+ * object, otherwise set this to FALSE.
+ * 
+ * @param[in] SubjectContext
+ * Security subject context of the new object.
+ * 
+ * @param[in] GenericMapping
+ * Generic mapping of access mask rights.
+ * 
+ * @param[in] PoolType
+ * This parameter is unused.
+ * 
+ * @return
+ * See SeAssignSecurityEx.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS
@@ -1272,8 +1555,23 @@ SeAssignSecurity(
                               PoolType);
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Computes the quota size of a security descriptor.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor.
+ * 
+ * @param[out] QuotaInfoSize
+ * The returned quota size of the given security descriptor to
+ * the caller. The function may return 0 to this parameter if
+ * the descriptor doesn't have a group or a discretionary
+ * access control list (DACL) even.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the quota size of a security
+ * descriptor has been computed successfully. STATUS_UNKNOWN_REVISION
+ * is returned if the security descriptor has an invalid revision.
  */
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSTATUS

--- a/ntoskrnl/se/semgr.c
+++ b/ntoskrnl/se/semgr.c
@@ -325,14 +325,14 @@ SeInitSystem(VOID)
  * @param[in] SecurityInformation
  * Auxiliary security information of the object.
  * 
- * @param[in] SecurityDescriptor
+ * @param[in,out] SecurityDescriptor
  * A security descriptor. This SD is used accordingly to the operation type
  * requested by the caller.
  * 
- * @param[in] ReturnLength
+ * @param[in,out] ReturnLength
  * The length size of the queried security descriptor, in bytes.
  * 
- * @param[in] OldSecurityDescriptor
+ * @param[in,out] OldSecurityDescriptor
  * The old SD that belonged to the object, in case we're either deleting
  * or replacing it.
  * 
@@ -348,14 +348,15 @@ SeInitSystem(VOID)
  */
 NTSTATUS
 NTAPI
-SeDefaultObjectMethod(IN PVOID Object,
-                      IN SECURITY_OPERATION_CODE OperationType,
-                      IN PSECURITY_INFORMATION SecurityInformation,
-                      IN OUT PSECURITY_DESCRIPTOR SecurityDescriptor,
-                      IN OUT PULONG ReturnLength OPTIONAL,
-                      IN OUT PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
-                      IN POOL_TYPE PoolType,
-                      IN PGENERIC_MAPPING GenericMapping)
+SeDefaultObjectMethod(
+    _In_ PVOID Object,
+    _In_ SECURITY_OPERATION_CODE OperationType,
+    _In_ PSECURITY_INFORMATION SecurityInformation,
+    _Inout_ PSECURITY_DESCRIPTOR SecurityDescriptor,
+    _Inout_opt_ PULONG ReturnLength,
+    _Inout_ PSECURITY_DESCRIPTOR *OldSecurityDescriptor,
+    _In_ POOL_TYPE PoolType,
+    _In_ PGENERIC_MAPPING GenericMapping)
 {
     PAGED_CODE();
 
@@ -423,8 +424,9 @@ SeDefaultObjectMethod(IN PVOID Object,
  */
 VOID
 NTAPI
-SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
-                          OUT PACCESS_MASK DesiredAccess)
+SeQuerySecurityAccessMask(
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _Out_ PACCESS_MASK DesiredAccess)
 {
     *DesiredAccess = 0;
 
@@ -455,8 +457,9 @@ SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
  */
 VOID
 NTAPI
-SeSetSecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
-                        OUT PACCESS_MASK DesiredAccess)
+SeSetSecurityAccessMask(
+    _In_ SECURITY_INFORMATION SecurityInformation,
+    _Out_ PACCESS_MASK DesiredAccess)
 {
     *DesiredAccess = 0;
 

--- a/ntoskrnl/se/semgr.c
+++ b/ntoskrnl/se/semgr.c
@@ -1,10 +1,11 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/semgr.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     No programmer listed.
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security manager infrastructure
+ * COPYRIGHT:       Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                  Copyright Eric Kohl
+ *                  Copyright Aleksey Bragin
+ *                  Copyright Alex Ionescu <alex@relsoft.net>
  */
 
 /* INCLUDES *******************************************************************/
@@ -26,6 +27,14 @@ extern ERESOURCE SepSubjectContextLock;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
+/**
+ * @brief
+ * Initializes all the security exports upon initialization phase of
+ * the module.
+ *
+ * @return
+ * Returns TRUE.
+ */
 static
 CODE_SEG("INIT")
 BOOLEAN
@@ -91,7 +100,15 @@ SepInitExports(VOID)
     return TRUE;
 }
 
-
+/**
+ * @brief
+ * Handles the phase 0 procedure of the SRM initialization.
+ *
+ * @return
+ * Returns TRUE if the phase 0 initialization has succeeded and that
+ * we can proceed further with next initialization phase, FALSE
+ * otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -137,6 +154,14 @@ SepInitializationPhase0(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Handles the phase 1 procedure of the SRM initialization.
+ *
+ * @return
+ * Returns TRUE if the phase 1 initialization has succeeded, FALSE
+ * otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -245,6 +270,15 @@ SepInitializationPhase1(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Main security manager initialization function.
+ *
+ * @return
+ * Returns a boolean value according to the phase initialization
+ * routine that handles it. If TRUE, the routine deems the initialization
+ * phase as complete, FALSE otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -275,6 +309,43 @@ SeInitSystem(VOID)
     }
 }
 
+/**
+ * @brief
+ * Internal function that is responsible for querying, deleting, assigning and
+ * setting a security descriptor for an object in the NT kernel. It is the default
+ * security method for objects regarding the security context of objects.
+ * 
+ * @param[in] Object
+ * The object that has the default security method, which the function has been
+ * called upon.
+ * 
+ * @param[in] OperationType
+ * Operation type to perform to that object.
+ * 
+ * @param[in] SecurityInformation
+ * Auxiliary security information of the object.
+ * 
+ * @param[in] SecurityDescriptor
+ * A security descriptor. This SD is used accordingly to the operation type
+ * requested by the caller.
+ * 
+ * @param[in] ReturnLength
+ * The length size of the queried security descriptor, in bytes.
+ * 
+ * @param[in] OldSecurityDescriptor
+ * The old SD that belonged to the object, in case we're either deleting
+ * or replacing it.
+ * 
+ * @param[in] PoolType
+ * Pool type allocation for the security descriptor.
+ * 
+ * @param[in] GenericMapping
+ * The generic mapping of access rights masks for the object.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the specific operation tasked has been
+ * completed. Otherwise a failure NTSTATUS code is returned.
+ */
 NTSTATUS
 NTAPI
 SeDefaultObjectMethod(IN PVOID Object,
@@ -336,6 +407,20 @@ SeDefaultObjectMethod(IN PVOID Object,
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Queries the access mask from a security information context.
+ * 
+ * @param[in] SecurityInformation
+ * The security information context where the access mask is to be
+ * gathered.
+ * 
+ * @param[out] DesiredAccess
+ * The queried access mask right.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
@@ -355,6 +440,19 @@ SeQuerySecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
     }
 }
 
+/**
+ * @brief
+ * Sets the access mask for a security information context.
+ * 
+ * @param[in] SecurityInformation
+ * The security information context to apply a new access right.
+ * 
+ * @param[out] DesiredAccess
+ * The returned access mask right.
+ * 
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeSetSecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
@@ -378,6 +476,30 @@ SeSetSecurityAccessMask(IN SECURITY_INFORMATION SecurityInformation,
     }
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Report a security event to the security manager.
+ * 
+ * @param[in] Flags
+ * Flags that influence how the event should be reported.
+ * 
+ * @param[in] SourceName
+ * A Unicode string that represents the source name of the event.
+ * 
+ * @param[in] UserSid
+ * The SID that represents a user that initiated the reporting.
+ * 
+ * @param[in] AuditParameters
+ * An array of parameters for auditing purposes. This is used
+ * for reporting the event which the security manager will take
+ * care subsequently of doing eventual security auditing.
+ * 
+ * @return
+ * Returns STATUS_SUCCESS if the security event has been reported.
+ * STATUS_INVALID_PARAMETER is returned if one of the parameters
+ * do not satisfy the requirements expected by the function.
+ */
 NTSTATUS
 NTAPI
 SeReportSecurityEvent(
@@ -447,6 +569,28 @@ SeReportSecurityEvent(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @unimplemented
+ * @brief
+ * Sets an array of audit parameters for later security auditing use.
+ * 
+ * @param[in,out] AuditParameters
+ * An array of audit parameters to be set.
+ * 
+ * @param[in] Type
+ * The type of audit parameters to be set.
+ * 
+ * @param[in] Index
+ * Index number that represents an instance of an audit parameters.
+ * Such index must be within the maximum range of audit parameters.
+ * 
+ * @param[in] Data
+ * An arbitrary buffer data that is bounds to what kind of audit parameter
+ * type must be set.
+ * 
+ * @return
+ * To be added...
+ */
 _Const_
 NTSTATUS
 NTAPI

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -1,10 +1,8 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS kernel
- * FILE:            ntoskrnl/se/sid.c
- * PURPOSE:         Security manager
- *
- * PROGRAMMERS:     David Welch <welch@cwcom.net>
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security Identifier (SID) implementation support and handling
+ * COPYRIGHT:       Copyright David Welch <welch@cwcom.net>
  */
 
 /* INCLUDES *******************************************************************/
@@ -54,6 +52,13 @@ PSID SeNetworkServiceSid = NULL;
 
 /* FUNCTIONS ******************************************************************/
 
+/**
+ * @brief
+ * Frees all the known initialized SIDs in the system from the memory.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 FreeInitializedSids(VOID)
@@ -88,6 +93,14 @@ FreeInitializedSids(VOID)
     if (SeAnonymousLogonSid) ExFreePoolWithTag(SeAnonymousLogonSid, TAG_SID);
 }
 
+/**
+ * @brief
+ * Initializes all the SIDs known in the system.
+ *
+ * @return
+ * Returns TRUE if all the SIDs have been initialized,
+ * FALSE otherwise.
+ */
 CODE_SEG("INIT")
 BOOLEAN
 NTAPI
@@ -263,6 +276,31 @@ SepInitSecurityIDs(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Captures a SID.
+ * 
+ * @param[in] InputSid
+ * A valid security identifier to be captured.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode.
+ * 
+ * @param[in] PoolType
+ * Pool memory type for the captured SID to assign upon
+ * allocation.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the capturing is done within the kernel.
+ * Otherwise the capturing is done in a kernel mode driver.
+ * 
+ * @param[out] CapturedSid
+ * The captured security identifier, returned to the caller.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the SID was captured. STATUS_INSUFFICIENT_RESOURCES
+ * is returned if memory pool allocation for the captured SID has failed.
+ */
 NTSTATUS
 NTAPI
 SepCaptureSid(IN PSID InputSid,
@@ -331,6 +369,23 @@ SepCaptureSid(IN PSID InputSid,
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Releases a captured SID.
+ * 
+ * @param[in] CapturedSid
+ * The captured SID to be released.
+ * 
+ * @param[in] AccessMode
+ * Processor level access mode.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the releasing is done within the kernel.
+ * Otherwise the releasing is done in a kernel mode driver.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepReleaseSid(IN PSID CapturedSid,
@@ -347,6 +402,52 @@ SepReleaseSid(IN PSID CapturedSid,
     }
 }
 
+/**
+ * @brief
+ * Captures a SID with attributes.
+ * 
+ * @param[in] SrcSidAndAttributes
+ * Source of the SID with attributes to be captured.
+ * 
+ * @param[in] AttributeCount
+ * The number count of attributes, in total.
+ * 
+ * @param[in] PreviousMode
+ * Processor access level mode.
+ * 
+ * @param[in] AllocatedMem
+ * The allocated memory buffer for the captured SID. If the caller
+ * supplies no allocated block of memory then the function will
+ * allocate some buffer block of memory for the captured SID
+ * automatically.
+ * 
+ * @param[in] AllocatedLength
+ * The length of the buffer that points to the allocated memory,
+ * in bytes.
+ * 
+ * @param[in] PoolType
+ * The pool type for the captured SID and attributes to assign.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the capturing is done within the kernel.
+ * Otherwise the capturing is done in a kernel mode driver.
+ * 
+ * @param[out] CapturedSidAndAttributes
+ * The captured SID and attributes.
+ * 
+ * @param[out] ResultLength
+ * The length of the captured SID and attributes, in bytes.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if SID and attributes capturing
+ * has been completed successfully. STATUS_INVALID_PARAMETER
+ * is returned if the count of attributes exceeds the maximum
+ * threshold that the kernel can permit. STATUS_INSUFFICIENT_RESOURCES
+ * is returned if memory pool allocation for the captured SID has failed.
+ * STATUS_BUFFER_TOO_SMALL is returned if the length of the allocated
+ * buffer is less than the required size. A failure NTSTATUS code is
+ * returned otherwise.
+ */
 NTSTATUS
 NTAPI
 SeCaptureSidAndAttributesArray(
@@ -548,6 +649,23 @@ SeCaptureSidAndAttributesArray(
     return Status;
 }
 
+/**
+ * @brief
+ * Releases a captured SID with attributes.
+ * 
+ * @param[in] CapturedSidAndAttributes
+ * The captured SID with attributes to be released.
+ * 
+ * @param[in] AccessMode
+ * Processor access level mode.
+ * 
+ * @param[in] CaptureIfKernel
+ * If set to TRUE, the releasing is done within the kernel.
+ * Otherwise the releasing is done in a kernel mode driver.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SeReleaseSidAndAttributesArray(
@@ -563,6 +681,5 @@ SeReleaseSidAndAttributesArray(
         ExFreePoolWithTag(CapturedSidAndAttributes, TAG_SID_AND_ATTRIBUTES);
     }
 }
-
 
 /* EOF */

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -303,11 +303,12 @@ SepInitSecurityIDs(VOID)
  */
 NTSTATUS
 NTAPI
-SepCaptureSid(IN PSID InputSid,
-              IN KPROCESSOR_MODE AccessMode,
-              IN POOL_TYPE PoolType,
-              IN BOOLEAN CaptureIfKernel,
-              OUT PSID *CapturedSid)
+SepCaptureSid(
+    _In_ PSID InputSid,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ POOL_TYPE PoolType,
+    _In_ BOOLEAN CaptureIfKernel,
+    _Out_ PSID *CapturedSid)
 {
     ULONG SidSize = 0;
     PISID NewSid, Sid = (PISID)InputSid;
@@ -388,9 +389,10 @@ SepCaptureSid(IN PSID InputSid,
  */
 VOID
 NTAPI
-SepReleaseSid(IN PSID CapturedSid,
-              IN KPROCESSOR_MODE AccessMode,
-              IN BOOLEAN CaptureIfKernel)
+SepReleaseSid(
+    _In_ PSID CapturedSid,
+    _In_ KPROCESSOR_MODE AccessMode,
+    _In_ BOOLEAN CaptureIfKernel)
 {
     PAGED_CODE();
 

--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -13,9 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-extern LUID SeSystemAuthenticationId;
-extern LUID SeAnonymousAuthenticationId;
-
 /* PRIVATE DEFINITIONS ********************************************************/
 
 typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION
@@ -42,6 +39,9 @@ SepRmCreateLogonSession(
 
 /* GLOBALS ********************************************************************/
 
+extern LUID SeSystemAuthenticationId;
+extern LUID SeAnonymousAuthenticationId;
+
 HANDLE SeRmCommandPort;
 HANDLE SeLsaInitEvent;
 
@@ -61,7 +61,6 @@ UCHAR SeAuditingState[POLICY_AUDIT_EVENT_TYPE_COUNT];
 KGUARDED_MUTEX SepRmDbLock;
 PSEP_LOGON_SESSION_REFERENCES SepLogonSessions = NULL;
 PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION SepLogonNotifications = NULL;
-
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -163,7 +162,15 @@ Cleanup:
     return Status;
 }
 
-
+/**
+ * @brief
+ * Manages the phase 0 initialization of the security reference
+ * monitoring module of the kernel.
+ *
+ * @return
+ * Returns TRUE when phase 0 initialization has completed without
+ * problems, FALSE otherwise.
+ */
 BOOLEAN
 NTAPI
 SeRmInitPhase0(VOID)
@@ -190,7 +197,15 @@ SeRmInitPhase0(VOID)
     return TRUE;
 }
 
-
+/**
+ * @brief
+ * Manages the phase 1 initialization of the security reference
+ * monitoring module of the kernel.
+ *
+ * @return
+ * Returns TRUE when phase 1 initialization has completed without
+ * problems, FALSE otherwise.
+ */
 BOOLEAN
 NTAPI
 SeRmInitPhase1(VOID)
@@ -247,6 +262,13 @@ SeRmInitPhase1(VOID)
     return TRUE;
 }
 
+/**
+ * @brief
+ * Initializes the local security authority audit bounds.
+ *
+ * @return
+ * Nothing.
+ */
 static
 VOID
 SepAdtInitializeBounds(VOID)
@@ -285,7 +307,18 @@ SepAdtInitializeBounds(VOID)
     SepAdtMaxListLength = ListBounds.MaxLength;
 }
 
-
+/**
+ * @brief
+ * Sets an audit event for future security auditing monitoring.
+ * 
+ * @param[in,out] Message
+ * The reference monitoring API message. It is used to determine
+ * if the right API message number is provided, RmAuditSetCommand
+ * in this case.
+ *
+ * @return
+ * Returns STATUS_SUCCESS.
+ */
 static
 NTSTATUS
 SepRmSetAuditEvent(
@@ -456,6 +489,24 @@ SepRmRemoveLogonSessionFromToken(
     return STATUS_SUCCESS;
 }
 
+/**
+ * @brief
+ * Creates a logon session. The security reference monitoring (SRM)
+ * module of Executive uses this as an internal kernel data for
+ * respective logon sessions management within the kernel,
+ * as in form of a SEP_LOGON_SESSION_REFERENCES data structure.
+ * 
+ * @param[in,out] LogonLuid
+ * A logon ID represented as a LUID. This LUID is used to create
+ * our logon session and add it to the sessions database.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the logon has been created successfully.
+ * STATUS_LOGON_SESSION_EXISTS is returned if a logon session with
+ * the pointed logon ID in the call already exists.
+ * STATUS_INSUFFICIENT_RESOURCES is returned if logon session allocation
+ * has failed because of lack of memory pool resources.
+ */
 static
 NTSTATUS
 SepRmCreateLogonSession(
@@ -627,7 +678,19 @@ Leave:
     return Status;
 }
 
-
+/**
+ * @brief
+ * References a logon session.
+ * 
+ * @param[in,out] LogonLuid
+ * A valid LUID that points to the logon session in the database that
+ * we're going to reference it.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the logon has been referenced.
+ * STATUS_NO_SUCH_LOGON_SESSION is returned if the session couldn't be
+ * found otherwise.
+ */
 NTSTATUS
 SepRmReferenceLogonSession(
     PLUID LogonLuid)
@@ -667,6 +730,22 @@ SepRmReferenceLogonSession(
     return STATUS_NO_SUCH_LOGON_SESSION;
 }
 
+/**
+ * @brief
+ * Cleans the DOS device map directory of a logon
+ * session.
+ * 
+ * @param[in] LogonLuid
+ * A logon session ID where its DOS device map directory
+ * is to be cleaned.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the device map directory has been
+ * successfully cleaned from the logon session. STATUS_INVALID_PARAMETER
+ * is returned if the caller hasn't submitted any logon ID. STATUS_NO_MEMORY
+ * is returned if buffer allocation for links has failed. A failure
+ * NTSTATUS code is returned otherwise.
+ */
 static
 NTSTATUS
 SepCleanupLUIDDeviceMapDirectory(
@@ -910,7 +989,21 @@ AllocateLinksAgain:
     return Status;
 }
 
-
+/**
+ * @brief
+ * De-references a logon session. If the session has a reference
+ * count of 0 by the time the function has de-referenced the logon,
+ * that means the session is no longer used and can be safely deleted
+ * from the logon sessions database.
+ * 
+ * @param[in,out] LogonLuid
+ * A logon session ID to de-reference.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the logon session has been de-referenced
+ * without issues. STATUS_NO_SUCH_LOGON_SESSION is returned if no
+ * such logon exists otherwise.
+ */
 NTSTATUS
 SepRmDereferenceLogonSession(
     PLUID LogonLuid)
@@ -965,7 +1058,18 @@ SepRmDereferenceLogonSession(
     return STATUS_NO_SUCH_LOGON_SESSION;
 }
 
-
+/**
+ * @brief
+ * Main SRM server thread initialization function. It deals
+ * with security manager and LSASS port connection, thus
+ * thereby allowing communication between the kernel side
+ * (the SRM) and user mode side (the LSASS) of the security
+ * world of the operating system.
+ *
+ * @return
+ * Returns TRUE if command server connection between SRM
+ * and LSASS has succeeded, FALSE otherwise.
+ */
 BOOLEAN
 NTAPI
 SepRmCommandServerThreadInit(VOID)
@@ -1108,6 +1212,15 @@ Cleanup:
     return Result;
 }
 
+/**
+ * @brief
+ * Manages the SRM server API commands, that is, receiving such API
+ * command messages from the user mode side of the security standpoint,
+ * the LSASS.
+ *
+ * @return
+ * Nothing.
+ */
 VOID
 NTAPI
 SepRmCommandServerThread(
@@ -1211,8 +1324,23 @@ SepRmCommandServerThread(
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 
-/*
- * @unimplemented
+/**
+ * @brief
+ * Retrieves the DOS device map from a logon session.
+ * 
+ * @param[in] LogonId
+ * A valid logon session ID.
+ * 
+ * @param[out] DeviceMap
+ * The returned device map buffer from the logon session.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the device map could be gathered
+ * from the logon session. STATUS_INVALID_PARAMETER is returned if
+ * one of the parameters aren't initialized (that is, the caller has
+ * submitted a NULL pointer variable). STATUS_NO_SUCH_LOGON_SESSION is
+ * returned if no such session could be found. A failure NTSTATUS code
+ * is returned otherwise.
  */
 NTSTATUS
 NTAPI
@@ -1425,9 +1553,20 @@ SeMarkLogonSessionForTerminationNotification(
     return STATUS_SUCCESS;
 }
 
-
-/*
- * @implemented
+/**
+ * @brief
+ * Registers a callback that will be called once a logon session
+ * terminates.
+ * 
+ * @param[in] CallbackRoutine
+ * Callback routine address.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the callback routine was registered
+ * successfully. STATUS_INVALID_PARAMETER is returned if the caller
+ * did not provide a callback routine. STATUS_INSUFFICIENT_RESOURCES
+ * is returned if the callback notification data couldn't be allocated
+ * because of lack of memory pool resources.
  */
 NTSTATUS
 NTAPI
@@ -1464,9 +1603,19 @@ SeRegisterLogonSessionTerminatedRoutine(
     return STATUS_SUCCESS;
 }
 
-
-/*
- * @implemented
+/**
+ * @brief
+ * Un-registers a callback routine, previously registered by
+ * SeRegisterLogonSessionTerminatedRoutine function.
+ * 
+ * @param[in] CallbackRoutine
+ * Callback routine address to un-register.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the callback routine was un-registered
+ * successfully. STATUS_INVALID_PARAMETER is returned if the caller
+ * did not provide a callback routine. STATUS_NOT_FOUND is returned
+ * if the callback notification item couldn't be found.
  */
 NTSTATUS
 NTAPI
@@ -1520,3 +1669,5 @@ SeUnregisterLogonSessionTerminatedRoutine(
 
     return Status;
 }
+
+/* EOF */

--- a/ntoskrnl/se/srm.c
+++ b/ntoskrnl/se/srm.c
@@ -24,7 +24,7 @@ typedef struct _SEP_LOGON_SESSION_TERMINATED_NOTIFICATION
 VOID
 NTAPI
 SepRmCommandServerThread(
-    PVOID StartContext);
+    _In_ PVOID StartContext);
 
 static
 NTSTATUS
@@ -34,7 +34,7 @@ SepCleanupLUIDDeviceMapDirectory(
 static
 NTSTATUS
 SepRmCreateLogonSession(
-    PLUID LogonLuid);
+    _In_ PLUID LogonLuid);
 
 
 /* GLOBALS ********************************************************************/
@@ -322,7 +322,7 @@ SepAdtInitializeBounds(VOID)
 static
 NTSTATUS
 SepRmSetAuditEvent(
-    PSEP_RM_API_MESSAGE Message)
+    _Inout_ PSEP_RM_API_MESSAGE Message)
 {
     ULONG i;
     PAGED_CODE();
@@ -496,7 +496,7 @@ SepRmRemoveLogonSessionFromToken(
  * respective logon sessions management within the kernel,
  * as in form of a SEP_LOGON_SESSION_REFERENCES data structure.
  * 
- * @param[in,out] LogonLuid
+ * @param[in] LogonLuid
  * A logon ID represented as a LUID. This LUID is used to create
  * our logon session and add it to the sessions database.
  *
@@ -510,7 +510,7 @@ SepRmRemoveLogonSessionFromToken(
 static
 NTSTATUS
 SepRmCreateLogonSession(
-    PLUID LogonLuid)
+    _In_ PLUID LogonLuid)
 {
     PSEP_LOGON_SESSION_REFERENCES CurrentSession, NewSession;
     NTSTATUS Status;
@@ -682,7 +682,7 @@ Leave:
  * @brief
  * References a logon session.
  * 
- * @param[in,out] LogonLuid
+ * @param[in] LogonLuid
  * A valid LUID that points to the logon session in the database that
  * we're going to reference it.
  *
@@ -693,7 +693,7 @@ Leave:
  */
 NTSTATUS
 SepRmReferenceLogonSession(
-    PLUID LogonLuid)
+    _In_ PLUID LogonLuid)
 {
     PSEP_LOGON_SESSION_REFERENCES CurrentSession;
 
@@ -996,7 +996,7 @@ AllocateLinksAgain:
  * that means the session is no longer used and can be safely deleted
  * from the logon sessions database.
  * 
- * @param[in,out] LogonLuid
+ * @param[in] LogonLuid
  * A logon session ID to de-reference.
  *
  * @return
@@ -1006,7 +1006,7 @@ AllocateLinksAgain:
  */
 NTSTATUS
 SepRmDereferenceLogonSession(
-    PLUID LogonLuid)
+    _In_ PLUID LogonLuid)
 {
     ULONG RefCount;
     PDEVICE_MAP DeviceMap;
@@ -1224,7 +1224,7 @@ Cleanup:
 VOID
 NTAPI
 SepRmCommandServerThread(
-    PVOID StartContext)
+    _In_ PVOID StartContext)
 {
     SEP_RM_API_MESSAGE Message;
     PPORT_MESSAGE ReplyMessage;
@@ -1345,9 +1345,8 @@ SepRmCommandServerThread(
 NTSTATUS
 NTAPI
 SeGetLogonIdDeviceMap(
-    IN PLUID LogonId,
-    OUT PDEVICE_MAP * DeviceMap
-    )
+    _In_ PLUID LogonId,
+    _Out_ PDEVICE_MAP *DeviceMap)
 {
     NTSTATUS Status;
     WCHAR Buffer[63];
@@ -1571,7 +1570,7 @@ SeMarkLogonSessionForTerminationNotification(
 NTSTATUS
 NTAPI
 SeRegisterLogonSessionTerminatedRoutine(
-    IN PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine)
+    _In_ PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine)
 {
     PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION Notification;
     PAGED_CODE();
@@ -1620,7 +1619,7 @@ SeRegisterLogonSessionTerminatedRoutine(
 NTSTATUS
 NTAPI
 SeUnregisterLogonSessionTerminatedRoutine(
-    IN PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine)
+    _In_ PSE_LOGON_SESSION_TERMINATED_ROUTINE CallbackRoutine)
 {
     PSEP_LOGON_SESSION_TERMINATED_NOTIFICATION Current, Previous = NULL;
     NTSTATUS Status;

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -611,7 +611,8 @@ SepRemovePrivilegeToken(
  */
 VOID
 NTAPI
-SepFreeProxyData(PVOID ProxyData)
+SepFreeProxyData(
+    _Inout_ PVOID ProxyData)
 {
     UNIMPLEMENTED;
 }
@@ -624,7 +625,7 @@ SepFreeProxyData(PVOID ProxyData)
  * @param[out] Dest
  * The destination path where the proxy data is to be copied to.
  * 
- * @param[out] Src
+ * @param[in] Src
  * The source path where the proxy data is be copied from.
  *
  * @return
@@ -632,8 +633,9 @@ SepFreeProxyData(PVOID ProxyData)
  */
 NTSTATUS
 NTAPI
-SepCopyProxyData(PVOID* Dest,
-                 PVOID Src)
+SepCopyProxyData(
+    _Out_ PVOID* Dest,
+    _In_ PVOID Src)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -744,7 +746,7 @@ SeExchangePrimaryToken(
  * @brief
  * Removes the primary token of a process.
  *
- * @param[in, out] Process
+ * @param[in,out] Process
  * The process instance with the access token to be removed.
  *
  * @return
@@ -752,7 +754,8 @@ SeExchangePrimaryToken(
  */
 VOID
 NTAPI
-SeDeassignPrimaryToken(PEPROCESS Process)
+SeDeassignPrimaryToken(
+    _Inout_ PEPROCESS Process)
 {
     PTOKEN OldToken;
 
@@ -780,8 +783,9 @@ SeDeassignPrimaryToken(PEPROCESS Process)
  * Returns the total length of a SID size.
  */
 static ULONG
-RtlLengthSidAndAttributes(ULONG Count,
-                          PSID_AND_ATTRIBUTES Src)
+RtlLengthSidAndAttributes(
+    _In_ ULONG Count,
+    _In_ PSID_AND_ATTRIBUTES Src)
 {
     ULONG i;
     ULONG uLength;
@@ -1216,10 +1220,11 @@ Quit:
  */
 NTSTATUS
 NTAPI
-SeSubProcessToken(IN PTOKEN ParentToken,
-                  OUT PTOKEN *Token,
-                  IN BOOLEAN InUse,
-                  IN ULONG SessionId)
+SeSubProcessToken(
+    _In_ PTOKEN ParentToken,
+    _Out_ PTOKEN *Token,
+    _In_ BOOLEAN InUse,
+    _In_ ULONG SessionId)
 {
     PTOKEN NewToken;
     OBJECT_ATTRIBUTES ObjectAttributes;
@@ -1275,8 +1280,9 @@ SeSubProcessToken(IN PTOKEN ParentToken,
  */
 NTSTATUS
 NTAPI
-SeIsTokenChild(IN PTOKEN Token,
-               OUT PBOOLEAN IsChild)
+SeIsTokenChild(
+    _In_ PTOKEN Token,
+    _Out_ PBOOLEAN IsChild)
 {
     PTOKEN ProcessToken;
     LUID ProcessTokenId, CallerParentId;
@@ -1323,8 +1329,9 @@ SeIsTokenChild(IN PTOKEN Token,
  */
 NTSTATUS
 NTAPI
-SeIsTokenSibling(IN PTOKEN Token,
-                 OUT PBOOLEAN IsSibling)
+SeIsTokenSibling(
+    _In_ PTOKEN Token,
+    _Out_ PBOOLEAN IsSibling)
 {
     PTOKEN ProcessToken;
     LUID ProcessParentId, ProcessAuthId;
@@ -1382,10 +1389,11 @@ SeIsTokenSibling(IN PTOKEN Token,
  */
 NTSTATUS
 NTAPI
-SeCopyClientToken(IN PACCESS_TOKEN Token,
-                  IN SECURITY_IMPERSONATION_LEVEL Level,
-                  IN KPROCESSOR_MODE PreviousMode,
-                  OUT PACCESS_TOKEN* NewToken)
+SeCopyClientToken(
+    _In_ PACCESS_TOKEN Token,
+    _In_ SECURITY_IMPERSONATION_LEVEL Level,
+    _In_ KPROCESSOR_MODE PreviousMode,
+    _Out_ PACCESS_TOKEN* NewToken)
 {
     NTSTATUS Status;
     OBJECT_ATTRIBUTES ObjectAttributes;
@@ -1423,7 +1431,8 @@ SeCopyClientToken(IN PACCESS_TOKEN Token,
  */
 VOID
 NTAPI
-SepDeleteToken(PVOID ObjectBody)
+SepDeleteToken(
+    _In_ PVOID ObjectBody)
 {
     NTSTATUS Status;
     PTOKEN AccessToken = (PTOKEN)ObjectBody;
@@ -1503,8 +1512,9 @@ SepInitializeTokenImplementation(VOID)
  */
 VOID
 NTAPI
-SeAssignPrimaryToken(IN PEPROCESS Process,
-                     IN PTOKEN Token)
+SeAssignPrimaryToken(
+    _In_ PEPROCESS Process,
+    _In_ PTOKEN Token)
 {
     PAGED_CODE();
 
@@ -2180,12 +2190,13 @@ SepCreateSystemAnonymousLogonTokenNoEveryone(VOID)
  */
 NTSTATUS
 NTAPI
-SeFilterToken(IN PACCESS_TOKEN ExistingToken,
-              IN ULONG Flags,
-              IN PTOKEN_GROUPS SidsToDisable OPTIONAL,
-              IN PTOKEN_PRIVILEGES PrivilegesToDelete OPTIONAL,
-              IN PTOKEN_GROUPS RestrictedSids OPTIONAL,
-              OUT PACCESS_TOKEN * FilteredToken)
+SeFilterToken(
+    _In_ PACCESS_TOKEN ExistingToken,
+    _In_ ULONG Flags,
+    _In_opt_ PTOKEN_GROUPS SidsToDisable,
+    _In_opt_ PTOKEN_PRIVILEGES PrivilegesToDelete,
+    _In_opt_ PTOKEN_GROUPS RestrictedSids,
+    _Out_ PACCESS_TOKEN * FilteredToken)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -2575,8 +2586,9 @@ SeQueryInformationToken(
  */
 NTSTATUS
 NTAPI
-SeQuerySessionIdToken(IN PACCESS_TOKEN Token,
-                      IN PULONG pSessionId)
+SeQuerySessionIdToken(
+    _In_ PACCESS_TOKEN Token,
+    _Out_ PULONG pSessionId)
 {
     PAGED_CODE();
 
@@ -2606,8 +2618,9 @@ SeQuerySessionIdToken(IN PACCESS_TOKEN Token,
  */
 NTSTATUS
 NTAPI
-SeQueryAuthenticationIdToken(IN PACCESS_TOKEN Token,
-                             OUT PLUID LogonId)
+SeQueryAuthenticationIdToken(
+    _In_ PACCESS_TOKEN Token,
+    _Out_ PLUID LogonId)
 {
     PAGED_CODE();
 
@@ -2628,7 +2641,8 @@ SeQueryAuthenticationIdToken(IN PACCESS_TOKEN Token,
  */
 SECURITY_IMPERSONATION_LEVEL
 NTAPI
-SeTokenImpersonationLevel(IN PACCESS_TOKEN Token)
+SeTokenImpersonationLevel(
+    _In_ PACCESS_TOKEN Token)
 {
     PAGED_CODE();
 
@@ -2646,8 +2660,10 @@ SeTokenImpersonationLevel(IN PACCESS_TOKEN Token)
  * @return
  * Returns the token type from a valid token.
  */
-TOKEN_TYPE NTAPI
-SeTokenType(IN PACCESS_TOKEN Token)
+TOKEN_TYPE
+NTAPI
+SeTokenType(
+    _In_ PACCESS_TOKEN Token)
 {
     PAGED_CODE();
 
@@ -2669,7 +2685,8 @@ SeTokenType(IN PACCESS_TOKEN Token)
  */
 BOOLEAN
 NTAPI
-SeTokenIsAdmin(IN PACCESS_TOKEN Token)
+SeTokenIsAdmin(
+    _In_ PACCESS_TOKEN Token)
 {
     PAGED_CODE();
 
@@ -2691,7 +2708,8 @@ SeTokenIsAdmin(IN PACCESS_TOKEN Token)
  */
 BOOLEAN
 NTAPI
-SeTokenIsRestricted(IN PACCESS_TOKEN Token)
+SeTokenIsRestricted(
+    _In_ PACCESS_TOKEN Token)
 {
     PAGED_CODE();
 
@@ -2715,7 +2733,8 @@ SeTokenIsRestricted(IN PACCESS_TOKEN Token)
  */
 BOOLEAN
 NTAPI
-SeTokenIsWriteRestricted(IN PACCESS_TOKEN Token)
+SeTokenIsWriteRestricted(
+    _In_ PACCESS_TOKEN Token)
 {
     PAGED_CODE();
 
@@ -4192,13 +4211,15 @@ NtDuplicateToken(
  * @return
  * To be added...
  */
-NTSTATUS NTAPI
-NtAdjustGroupsToken(IN HANDLE TokenHandle,
-                    IN BOOLEAN ResetToDefault,
-                    IN PTOKEN_GROUPS NewState,
-                    IN ULONG BufferLength,
-                    OUT PTOKEN_GROUPS PreviousState OPTIONAL,
-                    OUT PULONG ReturnLength)
+NTSTATUS
+NTAPI
+NtAdjustGroupsToken(
+    _In_ HANDLE TokenHandle,
+    _In_ BOOLEAN ResetToDefault,
+    _In_ PTOKEN_GROUPS NewState,
+    _In_ ULONG BufferLength,
+    _Out_opt_ PTOKEN_GROUPS PreviousState,
+    _Out_ PULONG ReturnLength)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;
@@ -4946,11 +4967,12 @@ Cleanup:
  */
 NTSTATUS
 NTAPI
-NtOpenThreadTokenEx(IN HANDLE ThreadHandle,
-                    IN ACCESS_MASK DesiredAccess,
-                    IN BOOLEAN OpenAsSelf,
-                    IN ULONG HandleAttributes,
-                    OUT PHANDLE TokenHandle)
+NtOpenThreadTokenEx(
+    _In_ HANDLE ThreadHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ BOOLEAN OpenAsSelf,
+    _In_ ULONG HandleAttributes,
+    _Out_ PHANDLE TokenHandle)
 {
     PETHREAD Thread;
     HANDLE hToken;
@@ -5145,11 +5167,13 @@ NtOpenThreadTokenEx(IN HANDLE ThreadHandle,
  * @return
  * See NtOpenThreadTokenEx.
  */
-NTSTATUS NTAPI
-NtOpenThreadToken(IN HANDLE ThreadHandle,
-                  IN ACCESS_MASK DesiredAccess,
-                  IN BOOLEAN OpenAsSelf,
-                  OUT PHANDLE TokenHandle)
+NTSTATUS
+NTAPI
+NtOpenThreadToken(
+    _In_ HANDLE ThreadHandle,
+    _In_ ACCESS_MASK DesiredAccess,
+    _In_ BOOLEAN OpenAsSelf,
+    _Out_ PHANDLE TokenHandle)
 {
     return NtOpenThreadTokenEx(ThreadHandle, DesiredAccess, OpenAsSelf, 0,
                                TokenHandle);
@@ -5286,12 +5310,13 @@ NtCompareTokens(
  */
 NTSTATUS
 NTAPI
-NtFilterToken(IN HANDLE ExistingTokenHandle,
-              IN ULONG Flags,
-              IN PTOKEN_GROUPS SidsToDisable OPTIONAL,
-              IN PTOKEN_PRIVILEGES PrivilegesToDelete OPTIONAL,
-              IN PTOKEN_GROUPS RestrictedSids OPTIONAL,
-              OUT PHANDLE NewTokenHandle)
+NtFilterToken(
+    _In_ HANDLE ExistingTokenHandle,
+    _In_ ULONG Flags,
+    _In_opt_ PTOKEN_GROUPS SidsToDisable,
+    _In_opt_ PTOKEN_PRIVILEGES PrivilegesToDelete,
+    _In_opt_ PTOKEN_GROUPS RestrictedSids,
+    _Out_ PHANDLE NewTokenHandle)
 {
     UNIMPLEMENTED;
     return STATUS_NOT_IMPLEMENTED;

--- a/sdk/include/ndk/sefuncs.h
+++ b/sdk/include/ndk/sefuncs.h
@@ -37,8 +37,7 @@ SeCaptureSecurityDescriptor(
     _In_ KPROCESSOR_MODE CurrentMode,
     _In_ POOL_TYPE PoolType,
     _In_ BOOLEAN CaptureIfKernel,
-    _Out_ PSECURITY_DESCRIPTOR *CapturedSecurityDescriptor
-);
+    _Out_ PSECURITY_DESCRIPTOR *CapturedSecurityDescriptor);
 
 NTKERNELAPI
 NTSTATUS
@@ -46,8 +45,7 @@ NTAPI
 SeReleaseSecurityDescriptor(
     _In_ PSECURITY_DESCRIPTOR CapturedSecurityDescriptor,
     _In_ KPROCESSOR_MODE CurrentMode,
-    _In_ BOOLEAN CaptureIfKernelMode
-);
+    _In_ BOOLEAN CaptureIfKernelMode);
 
 //
 // Access States
@@ -56,18 +54,16 @@ NTKERNELAPI
 NTSTATUS
 NTAPI
 SeCreateAccessState(
-    PACCESS_STATE AccessState,
-    PAUX_ACCESS_DATA AuxData,
-    ACCESS_MASK Access,
-    PGENERIC_MAPPING GenericMapping
-);
+    _In_ PACCESS_STATE AccessState,
+    _In_ PAUX_ACCESS_DATA AuxData,
+    _In_ ACCESS_MASK Access,
+    _In_ PGENERIC_MAPPING GenericMapping);
 
 NTKERNELAPI
 VOID
 NTAPI
 SeDeleteAccessState(
-    _In_ PACCESS_STATE AccessState
-);
+    _In_ PACCESS_STATE AccessState);
 
 //
 // Impersonation
@@ -76,8 +72,7 @@ NTKERNELAPI
 SECURITY_IMPERSONATION_LEVEL
 NTAPI
 SeTokenImpersonationLevel(
-    _In_ PACCESS_TOKEN Token
-);
+    _In_ PACCESS_TOKEN Token);
 
 #endif
 
@@ -95,8 +90,7 @@ NtAccessCheck(
     _Out_ PPRIVILEGE_SET PrivilegeSet,
     _Out_ PULONG ReturnLength,
     _Out_ PACCESS_MASK GrantedAccess,
-    _Out_ PNTSTATUS AccessStatus
-);
+    _Out_ PNTSTATUS AccessStatus);
 
 NTSTATUS
 NTAPI
@@ -111,8 +105,7 @@ NtAccessCheckByType(
     _In_ PPRIVILEGE_SET PrivilegeSet,
     _Inout_ PULONG PrivilegeSetLength,
     _Out_ PACCESS_MASK GrantedAccess,
-    _Out_ PNTSTATUS AccessStatus
-);
+    _Out_ PNTSTATUS AccessStatus);
 
 NTSTATUS
 NTAPI
@@ -127,8 +120,7 @@ NtAccessCheckByTypeResultList(
     _In_ PPRIVILEGE_SET PrivilegeSet,
     _Inout_ PULONG PrivilegeSetLength,
     _Out_ PACCESS_MASK GrantedAccess,
-    _Out_ PNTSTATUS AccessStatus
-);
+    _Out_ PNTSTATUS AccessStatus);
 
 _Must_inspect_result_
 __kernel_entry NTSYSCALLAPI
@@ -145,8 +137,7 @@ NtAccessCheckAndAuditAlarm(
     _In_ BOOLEAN ObjectCreation,
     _Out_ PACCESS_MASK GrantedAccess,
     _Out_ PNTSTATUS AccessStatus,
-    _Out_ PBOOLEAN GenerateOnClose
-);
+    _Out_ PBOOLEAN GenerateOnClose);
 
 _Must_inspect_result_
 __kernel_entry
@@ -159,8 +150,7 @@ NtAdjustGroupsToken(
     _In_opt_ PTOKEN_GROUPS NewState,
     _In_opt_ ULONG BufferLength,
     _Out_writes_bytes_to_opt_(BufferLength, *ReturnLength) PTOKEN_GROUPS PreviousState,
-    _Out_ PULONG ReturnLength
-);
+    _Out_ PULONG ReturnLength);
 
 _Must_inspect_result_
 __kernel_entry
@@ -173,25 +163,22 @@ NtAdjustPrivilegesToken(
     _In_opt_ PTOKEN_PRIVILEGES NewState,
     _In_ ULONG BufferLength,
     _Out_writes_bytes_to_opt_(BufferLength, *ReturnLength) PTOKEN_PRIVILEGES PreviousState,
-    _When_(PreviousState != NULL, _Out_) PULONG ReturnLength
-);
+    _When_(PreviousState != NULL, _Out_) PULONG ReturnLength);
 
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtAllocateLocallyUniqueId(
-    _Out_ LUID *LocallyUniqueId
-);
+    _Out_ LUID *LocallyUniqueId);
 
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtAllocateUuids(
-    PULARGE_INTEGER Time,
-    PULONG Range,
-    PULONG Sequence,
-    PUCHAR Seed
-);
+    _Out_ PULARGE_INTEGER Time,
+    _Out_ PULONG Range,
+    _Out_ PULONG Sequence,
+    _Out_ PUCHAR Seed);
 
 NTSYSCALLAPI
 NTSTATUS
@@ -218,8 +205,7 @@ NtCreateToken(
     _In_opt_ PTOKEN_OWNER TokenOwner,
     _In_ PTOKEN_PRIMARY_GROUP TokenPrimaryGroup,
     _In_opt_ PTOKEN_DEFAULT_DACL TokenDefaultDacl,
-    _In_ PTOKEN_SOURCE TokenSource
-);
+    _In_ PTOKEN_SOURCE TokenSource);
 
 _Must_inspect_result_
 __kernel_entry
@@ -232,15 +218,13 @@ NtDuplicateToken(
     _In_opt_ POBJECT_ATTRIBUTES ObjectAttributes,
     _In_ BOOLEAN EffectiveOnly,
     _In_ TOKEN_TYPE TokenType,
-    _Out_ PHANDLE NewTokenHandle
-);
+    _Out_ PHANDLE NewTokenHandle);
 
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtImpersonateAnonymousToken(
-    _In_ HANDLE ThreadHandle
-);
+    _In_ HANDLE ThreadHandle);
 
 __kernel_entry
 NTSYSCALLAPI
@@ -258,8 +242,7 @@ NtOpenObjectAuditAlarm(
     _In_opt_ PPRIVILEGE_SET Privileges,
     _In_ BOOLEAN ObjectCreation,
     _In_ BOOLEAN AccessGranted,
-    _Out_ PBOOLEAN GenerateOnClose
-);
+    _Out_ PBOOLEAN GenerateOnClose);
 
 NTSYSCALLAPI
 NTSTATUS
@@ -268,8 +251,7 @@ NtOpenProcessTokenEx(
     _In_ HANDLE ProcessHandle,
     _In_ ACCESS_MASK DesiredAccess,
     _In_ ULONG HandleAttributes,
-    _Out_ PHANDLE TokenHandle
-);
+    _Out_ PHANDLE TokenHandle);
 
 _Must_inspect_result_
 __kernel_entry
@@ -279,8 +261,7 @@ NTAPI
 NtPrivilegeCheck(
     _In_ HANDLE ClientToken,
     _Inout_ PPRIVILEGE_SET RequiredPrivileges,
-    _Out_ PBOOLEAN Result
-);
+    _Out_ PBOOLEAN Result);
 
 NTSYSCALLAPI
 NTSTATUS
@@ -290,8 +271,7 @@ NtPrivilegedServiceAuditAlarm(
     _In_ PUNICODE_STRING ServiceName,
     _In_ HANDLE ClientToken,
     _In_ PPRIVILEGE_SET Privileges,
-    _In_ BOOLEAN AccessGranted
-);
+    _In_ BOOLEAN AccessGranted);
 
 __kernel_entry
 NTSYSCALLAPI
@@ -303,8 +283,7 @@ NtPrivilegeObjectAuditAlarm(
     _In_ HANDLE ClientToken,
     _In_ ACCESS_MASK DesiredAccess,
     _In_ PPRIVILEGE_SET Privileges,
-    _In_ BOOLEAN AccessGranted
-);
+    _In_ BOOLEAN AccessGranted);
 
 _When_(TokenInformationClass == TokenAccessInformation,
     _At_(TokenInformationLength, _In_range_(>=, sizeof(TOKEN_ACCESS_INFORMATION))))
@@ -318,8 +297,7 @@ NtQueryInformationToken(
     _In_ TOKEN_INFORMATION_CLASS TokenInformationClass,
     _Out_writes_bytes_to_opt_(TokenInformationLength, *ReturnLength) PVOID TokenInformation,
     _In_ ULONG TokenInformationLength,
-    _Out_ PULONG ReturnLength
-);
+    _Out_ PULONG ReturnLength);
 
 _Must_inspect_result_
 __kernel_entry
@@ -330,8 +308,7 @@ NtSetInformationToken(
     _In_ HANDLE TokenHandle,
     _In_ TOKEN_INFORMATION_CLASS TokenInformationClass,
     _In_reads_bytes_(TokenInformationLength) PVOID TokenInformation,
-    _In_ ULONG TokenInformationLength
-);
+    _In_ ULONG TokenInformationLength);
 
 NTSYSAPI
 NTSTATUS
@@ -344,8 +321,7 @@ ZwAccessCheck(
     _Out_ PPRIVILEGE_SET PrivilegeSet,
     _Out_ PULONG ReturnLength,
     _Out_ PACCESS_MASK GrantedAccess,
-    _Out_ PNTSTATUS AccessStatus
-);
+    _Out_ PNTSTATUS AccessStatus);
 
 NTSYSAPI
 NTSTATUS
@@ -356,8 +332,7 @@ ZwAdjustGroupsToken(
     _In_ PTOKEN_GROUPS NewState,
     _In_ ULONG BufferLength,
     _Out_opt_ PTOKEN_GROUPS PreviousState,
-    _Out_ PULONG ReturnLength
-);
+    _Out_ PULONG ReturnLength);
 
 _Must_inspect_result_
 NTSYSAPI
@@ -369,25 +344,22 @@ ZwAdjustPrivilegesToken(
     _In_opt_ PTOKEN_PRIVILEGES NewState,
     _In_ ULONG BufferLength,
     _Out_writes_bytes_to_opt_(BufferLength, *ReturnLength) PTOKEN_PRIVILEGES PreviousState,
-    _When_(PreviousState != NULL, _Out_) PULONG ReturnLength
-);
+    _When_(PreviousState != NULL, _Out_) PULONG ReturnLength);
 
 NTSYSAPI
 NTSTATUS
 NTAPI
 ZwAllocateLocallyUniqueId(
-    _Out_ LUID *LocallyUniqueId
-);
+    _Out_ LUID *LocallyUniqueId);
 
 NTSYSAPI
 NTSTATUS
 NTAPI
 ZwAllocateUuids(
-    PULARGE_INTEGER Time,
-    PULONG Range,
-    PULONG Sequence,
-    PUCHAR Seed
-);
+    _Out_ PULARGE_INTEGER Time,
+    _Out_ PULONG Range,
+    _Out_ PULONG Sequence,
+    _Out_ PUCHAR Seed);
 
 NTSYSAPI
 NTSTATUS
@@ -405,8 +377,7 @@ ZwCreateToken(
     _In_ PTOKEN_OWNER TokenOwner,
     _In_ PTOKEN_PRIMARY_GROUP TokenPrimaryGroup,
     _In_ PTOKEN_DEFAULT_DACL TokenDefaultDacl,
-    _In_ PTOKEN_SOURCE TokenSource
-);
+    _In_ PTOKEN_SOURCE TokenSource);
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
@@ -418,15 +389,13 @@ ZwDuplicateToken(
     _In_opt_ POBJECT_ATTRIBUTES ObjectAttributes,
     _In_ BOOLEAN EffectiveOnly,
     _In_ TOKEN_TYPE TokenType,
-    _Out_ PHANDLE NewTokenHandle
-);
+    _Out_ PHANDLE NewTokenHandle);
 
 NTSYSAPI
 NTSTATUS
 NTAPI
 ZwImpersonateAnonymousToken(
-    _In_ HANDLE Thread
-);
+    _In_ HANDLE Thread);
 
 NTSYSAPI
 NTSTATUS
@@ -443,8 +412,7 @@ ZwOpenObjectAuditAlarm(
     _In_ PPRIVILEGE_SET Privileges,
     _In_ BOOLEAN ObjectCreation,
     _In_ BOOLEAN AccessGranted,
-    _Out_ PBOOLEAN GenerateOnClose
-);
+    _Out_ PBOOLEAN GenerateOnClose);
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
@@ -453,8 +421,7 @@ NTAPI
 ZwOpenProcessToken(
     _In_ HANDLE ProcessHandle,
     _In_ ACCESS_MASK DesiredAccess,
-    _Out_ PHANDLE TokenHandle
-);
+    _Out_ PHANDLE TokenHandle);
 
 NTSYSAPI
 NTSTATUS
@@ -463,8 +430,7 @@ ZwOpenProcessTokenEx(
     _In_ HANDLE ProcessHandle,
     _In_ ACCESS_MASK DesiredAccess,
     _In_ ULONG HandleAttributes,
-    _Out_ PHANDLE TokenHandle
-);
+    _Out_ PHANDLE TokenHandle);
 
 NTSYSAPI
 NTSTATUS
@@ -472,8 +438,7 @@ NTAPI
 ZwPrivilegeCheck(
     _In_ HANDLE ClientToken,
     _In_ PPRIVILEGE_SET RequiredPrivileges,
-    _In_ PBOOLEAN Result
-);
+    _In_ PBOOLEAN Result);
 
 NTSYSAPI
 NTSTATUS
@@ -483,8 +448,7 @@ ZwPrivilegedServiceAuditAlarm(
     _In_ PUNICODE_STRING ServiceName,
     _In_ HANDLE ClientToken,
     _In_ PPRIVILEGE_SET Privileges,
-    _In_ BOOLEAN AccessGranted
-);
+    _In_ BOOLEAN AccessGranted);
 
 NTSYSAPI
 NTSTATUS
@@ -495,8 +459,7 @@ ZwPrivilegeObjectAuditAlarm(
     _In_ HANDLE ClientToken,
     _In_ ULONG DesiredAccess,
     _In_ PPRIVILEGE_SET Privileges,
-    _In_ BOOLEAN AccessGranted
-);
+    _In_ BOOLEAN AccessGranted);
 
 _IRQL_requires_max_(PASSIVE_LEVEL)
 NTSYSAPI
@@ -507,8 +470,7 @@ ZwQueryInformationToken(
     _In_ TOKEN_INFORMATION_CLASS TokenInformationClass,
     _Out_writes_bytes_to_opt_(Length,*ResultLength) PVOID TokenInformation,
     _In_ ULONG Length,
-    _Out_ PULONG ResultLength
-);
+    _Out_ PULONG ResultLength);
 
 NTSYSAPI
 NTSTATUS
@@ -517,6 +479,6 @@ ZwSetInformationToken(
     _In_ HANDLE TokenHandle,
     _In_ TOKEN_INFORMATION_CLASS TokenInformationClass,
     _Out_ PVOID TokenInformation,
-    _In_ ULONG TokenInformationLength
-);
+    _In_ ULONG TokenInformationLength);
+
 #endif


### PR DESCRIPTION
As the title says, write document comment headers in Doxygen format for all the functions in SRM for once and for all. The documentation headers will be updated regularly when time calls for it. In addition of documenting the subsystem module, update the file headers and annotate the remaining functions with SAL. ~~Currently WIP.~~
# TODO

- [x] access.c
- [x] accesschk.c
- [x] acl.c
- [x] audit.c
- [x] priv.c
- [x] sd.c
- [x] semgr.c
- [x] sid.c
- [x] sqos.c
- [x] srm.c
- [x] token.c