### PR TITLE
[NTOS:EX] QSISystem*HandleInformation(): Fix number of handles

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1303,12 +1303,15 @@ QSI_DEF(SystemHandleInformation)
 
     DPRINT("NtQuerySystemInformation - SystemHandleInformation\n");
 
-    /* Set initial required buffer size */
-    *ReqSize = FIELD_OFFSET(SYSTEM_HANDLE_INFORMATION, Handles);
+    /* Set minimal input buffer size */
+    *ReqSize = sizeof(SYSTEM_HANDLE_INFORMATION);
 
     /* Check user's buffer size */
     if (Size < *ReqSize)
     {
+#if (NTDDI_VERSION < NTDDI_VISTA)
+        *ReqSize = 0;
+#endif
         return STATUS_INFO_LENGTH_MISMATCH;
     }
 
@@ -1324,6 +1327,9 @@ QSI_DEF(SystemHandleInformation)
         DPRINT1("Failed to lock the user buffer: 0x%lx\n", Status);
         return Status;
     }
+
+    /* Set initial required buffer size */
+    *ReqSize = FIELD_OFFSET(SYSTEM_HANDLE_INFORMATION, Handles);
 
     /* Reset of count of handles */
     HandleInformation->NumberOfHandles = 0;
@@ -2503,12 +2509,15 @@ QSI_DEF(SystemExtendedHandleInformation)
 
     DPRINT("NtQuerySystemInformation - SystemExtendedHandleInformation\n");
 
-    /* Set initial required buffer size */
-    *ReqSize = FIELD_OFFSET(SYSTEM_HANDLE_INFORMATION_EX, Handle);
+    /* Set minimal input buffer size */
+    *ReqSize = sizeof(SYSTEM_HANDLE_INFORMATION_EX);
 
     /* Check user's buffer size */
     if (Size < *ReqSize)
     {
+#if (NTDDI_VERSION < NTDDI_VISTA)
+        *ReqSize = 0;
+#endif
         return STATUS_INFO_LENGTH_MISMATCH;
     }
 
@@ -2524,6 +2533,9 @@ QSI_DEF(SystemExtendedHandleInformation)
         DPRINT1("Failed to lock the user buffer: 0x%lx\n", Status);
         return Status;
     }
+
+    /* Set initial required buffer size */
+    *ReqSize = FIELD_OFFSET(SYSTEM_HANDLE_INFORMATION_EX, Handle);
 
     /* Reset of count of handles */
     HandleInformation->Count = 0;


### PR DESCRIPTION
## Purpose

Do not increase number of handles, when locking a handle failed.
Plus related optimizations.

JIRA issue: [CORE-11978](https://jira.reactos.org/browse/CORE-11978)

## Proposed changes

- Set number of handles once only, with correct value.
- Set error status once only, when buffer is too small.

And while there:
- Require a full struct, on input.
- Return 0 as required size, if input buffer size is less than minimal.