### PR TITLE
[DSOUND] Improvements to DirectSound(Capture)EnumerateW

### DIFF
--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -36,7 +36,7 @@ dll/directx/wine/dmusic         # Synced to WineStaging-4.18
 dll/directx/wine/dplay          # Synced to WineStaging-3.3
 dll/directx/wine/dplayx         # Synced to WineStaging-4.18
 dll/directx/wine/dpnhpast       # Synced to WineStaging-4.18
-dll/directx/wine/dsound         # Synced to Wine-1.3.29
+dll/directx/wine/dsound         # Forked at Wine-1.3.29. Newer versions are depending on NT6+ mmdevapi, so the further syncing makes no sense until we're retargeted to Vista or newer.
 dll/directx/wine/dxdiagn        # Synced to WineStaging-4.18
 dll/directx/wine/msdmo          # Synced to WineStaging-4.18
 dll/directx/wine/qcap           # Synced to WineStaging-3.3


### PR DESCRIPTION
## Purpose

Fix and improve `DirectSoundEnumerateW` and `DirectSoundCaptureEnumerateW` implementations in our dsound.
Use the Windows-compatible way to get the device name and pass it to a callback.
This fixes incorrect detection of DirectSound audio input and output devices, so now a lot of apps are able to detect it correctly, and can play the sound properly (e. g., AIMP 2.61 and IcyTower from Rapps). :smiley: 

JIRA issue: [CORE-7535](https://jira.reactos.org/browse/CORE-7535), [CORE-10907](https://jira.reactos.org/browse/CORE-10907), [CORE-15324](https://jira.reactos.org/browse/CORE-15324), [CORE-15533](https://jira.reactos.org/browse/CORE-15533), [CORE-16340](https://jira.reactos.org/browse/CORE-16340) (Pocket Tanks 1.6, Stamina, Dave Gnukem all do improve)

## Proposed changes

- Don't use Wine-specific `DSDRIVERDESC` structure and `DRV_QUERYDSOUNDDESC` message, declared in sdk/include/dxsdk/dsdriver.h, whose are obsolete even in Wine for now.
- Instead, declare a new `WAVEINCAPSW` and `WAVEOUTCAPSW` structures (for input and output appropriately), call `waveInGetDevCapsW` and `WaveOutGetDevCapsW` for enumerated device ID and store retrieved device name in these strucutres.
- Then pass these names to a `lpDSEnumCallbackW` as-is, without Ansi to Unicode conversion (since the retrieved strings are Unicode already).
- Do this both for capture and playback functions.
- Addtionally, add `MMSYSERR_BADDEVICEID` status code to `mmErr` macro, because it also might me returned by `waveIn`/`OutGetDevCapsW` as well, in case of failure.

## Result

As is visible on the following screenshot, after my changes, AIMP 2.61 now detects the output audio device correctly, so it does not show error code -23 at start anymore, and is able to play the audio files properly. :smiley: 
![AIMP2-fixed](https://user-images.githubusercontent.com/26385117/129090712-10bb143a-de36-499f-96f2-94863cc4f11a.png)

See demo video as well also:

https://user-images.githubusercontent.com/26385117/129097904-eedd7078-de73-4dc0-ad0d-75352432159a.mp4

In general, I managed to get the sound working at least in my following apps/games: AIMP 2.61, CrystalWolf Audio Player 1.7, IcyTower 1.5.1 from Rapps, PC Radio 6.0.2, Radiocent 3.5 and many more. ^^)