### PR TITLE
[IMM32] Rewrite ImmGetRegisterWordStyleA/W

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3093,7 +3093,7 @@ UINT WINAPI ImmGetRegisterWordStyleA(
 
     ret = pImeDpi->ImeGetRegisterWordStyle(nItem, pNewStylesW);
 
-    if (nItem > 0 && ret > 0)
+    if (nItem > 0)
     {
         /* lpStyleBuf <-- pNewStylesW */
         for (iItem = 0; iItem < ret; ++iItem)
@@ -3153,7 +3153,7 @@ UINT WINAPI ImmGetRegisterWordStyleW(
 
     ret = pImeDpi->ImeGetRegisterWordStyle(nItem, pNewStylesA);
 
-    if (nItem > 0 && ret > 0)
+    if (nItem > 0)
     {
         /* lpStyleBuf <-- pNewStylesA */
         for (iItem = 0; iItem < ret; ++iItem)

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -3096,7 +3096,7 @@ UINT WINAPI ImmGetRegisterWordStyleA(
     if (nItem > 0 && ret > 0)
     {
         /* lpStyleBuf <-- pNewStylesW */
-        for (iItem = 0; iItem < nItem; ++iItem)
+        for (iItem = 0; iItem < ret; ++iItem)
         {
             pSrcW = &pNewStylesW[iItem];
             pDestA = &lpStyleBuf[iItem];
@@ -3156,7 +3156,7 @@ UINT WINAPI ImmGetRegisterWordStyleW(
     if (nItem > 0 && ret > 0)
     {
         /* lpStyleBuf <-- pNewStylesA */
-        for (iItem = 0; iItem < nItem; ++iItem)
+        for (iItem = 0; iItem < ret; ++iItem)
         {
             pSrcA = &pNewStylesA[iItem];
             pDestW = &lpStyleBuf[iItem];

--- a/win32ss/include/imetable.h
+++ b/win32ss/include/imetable.h
@@ -3,7 +3,7 @@ DEFINE_IME_ENTRY(BOOL, ImeInquire, (LPIMEINFO lpIMEInfo, LPVOID lpszWndClass, DW
 DEFINE_IME_ENTRY(DWORD, ImeConversionList, (HIMC hIMC, LPCVOID lpSrc, LPCANDIDATELIST lpDst, DWORD dwBufLen, UINT uFlag), FALSE)
 DEFINE_IME_ENTRY(BOOL, ImeRegisterWord, (LPCVOID lpszReading, DWORD dwStyle, LPCVOID lpszString), FALSE)
 DEFINE_IME_ENTRY(BOOL, ImeUnregisterWord, (LPCVOID lpszReading, DWORD dwStyle, LPCVOID lpszString), FALSE)
-DEFINE_IME_ENTRY(UINT, ImeGetRegisterWordStyle, (UINT nItem, LPSTYLEBUFW lpStyleBuf), FALSE)
+DEFINE_IME_ENTRY(UINT, ImeGetRegisterWordStyle, (UINT nItem, LPVOID lpStyleBuf), FALSE)
 DEFINE_IME_ENTRY(UINT, ImeEnumRegisterWord, (HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc, LPCVOID lpszReading, DWORD dwStyle, LPCVOID lpszString, LPVOID lpData), FALSE)
 DEFINE_IME_ENTRY(BOOL, ImeConfigure, (HKL hKL, HWND hWnd, DWORD dwMode, LPVOID lpData), FALSE)
 DEFINE_IME_ENTRY(BOOL, ImeDestroy, (UINT uReserved), FALSE)


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Rewrite `ImmGetRegisterWordStyleA` and `ImmGetRegisterWordStyleW` functions.
- Modify `win32ss/include/imetable.h` table.