### PR TITLE
[IMM32] Delete Wine-specific functions

### DIFF
--- a/dll/win32/imm32/imm32.spec
+++ b/dll/win32/imm32/imm32.spec
@@ -113,9 +113,3 @@
 @ stdcall -stub ImmWINNLSEnableIME(ptr long)
 @ stdcall -stub ImmWINNLSGetEnableStatus(ptr)
 @ stub ImmWINNLSGetIMEHotkey
-
-################################################################
-# Wine internal extensions
-@ stdcall __wine_get_ui_window(ptr)
-@ stdcall __wine_register_window(long)
-@ stdcall __wine_unregister_window(long)


### PR DESCRIPTION
## Purpose
We don't need Wine-specific functions for Japanese input.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Delete `__wine_get_ui_window`, `__wine_register_window` and `__wine_unregister_window` functions.
- Modify `imm32.spec`.