### PR TITLE
[FASTFAT_NEW] "Fix" Flags bitfield to avoid RTC error

### DIFF
--- a/drivers/filesystems/fastfat_new/fatstruc.h
+++ b/drivers/filesystems/fastfat_new/fatstruc.h
@@ -1370,8 +1370,12 @@ typedef struct _CCB {
     //  Define a 24bit wide field for Flags, but a UCHAR for Wild Cards Present
     //  since it is used so often.  Line these up on byte boundaries for grins.
     //
-
+#ifdef __REACTOS__
+    ULONG Flags; // Due to https://developercommunity.visualstudio.com/t/Broken-runtime-checks-with-CL-19293013/1503629
+    // Note: the following BOOLEAN will not be packed anyway!
+#else
     ULONG Flags:24;
+#endif
     BOOLEAN ContainsWildCards;
 
     //


### PR DESCRIPTION
Since VS 16.11 the compiler sometimes emits calls to _RTC_UninitUse, when parts of a bitfield are initialized (See https://developercommunity.visualstudio.com/t/Broken-runtime-checks-with-CL-19293013/1503629). Fix this by using an ULONG instead of a bitfield.
Note: The structure uses a 24 bit bitfield plus an UCHAR, which is supposed to form a 32 bit field, but that doesn't work anyway.
