### PR TITLE
[DSOUND] Don't force status to failure by default in primarybuffer_SetFormat

### DIFF
--- a/dll/directx/wine/dsound/primary.c
+++ b/dll/directx/wine/dsound/primary.c
@@ -459,7 +459,7 @@ LPWAVEFORMATEX DSOUND_CopyFormat(LPCWAVEFORMATEX wfex)
 
 HRESULT primarybuffer_SetFormat(DirectSoundDevice *device, LPCWAVEFORMATEX wfex)
 {
-	HRESULT err = DSERR_BUFFERLOST;
+	HRESULT err = S_OK;
 	int i;
 	DWORD nSamplesPerSec, bpp, chans;
 	LPWAVEFORMATEX oldpwfx;


### PR DESCRIPTION
## Purpose

Don't force `HRESULT` status to `DSERR_BUFFERLOST` by default in `primarybuffer_SetFormat` function. Assign to it `S_OK` instead, as done in current Wine: https://source.winehq.org/git/wine.git/blob/HEAD:/dlls/dsound/primary.c#l440.
That variable is already set to failure in other appropriate place, when this is indeed needed: https://git.reactos.org/?p=reactos.git;a=blob;f=dll/directx/wine/dsound/primary.c;h=b04a526929e4e817ff63aa652530e5901a3253a6;hb=HEAD#l511.
The assigned failure status caused executing failure handling code even when the fail actually didn't happen. In particular, `DSOUND_ReopenDevice` failed on `waveOutOpen` call when calling this was not needed.
After my changes, it's called only when needed, i. e., only when the actual failure happens. Otherwise, if all goes good, that code is not called, so the data is transferred successfully and the function is working correctly.
It fixes non-working playback in QMMP 0.11.1 (via DirectSound ouput plugin) and AIMP 3.10 and newer versions. Also it improves the DirectSound test results from MS DxDiag: now all 4 available tests are passing successfully, instead of only 2. Other dsound issues also might be fixed as well. :smiley: 

JIRA issue: [CORE-10907](https://jira.reactos.org/browse/CORE-10907), [CORE-14783](https://jira.reactos.org/browse/CORE-14783)