### PR TITLE
[RTL/x64] Fix a typo RtplUnwindInternal -> RtlpUnwindInternal

### DIFF
--- a/sdk/lib/rtl/amd64/except.c
+++ b/sdk/lib/rtl/amd64/except.c
@@ -70,7 +70,7 @@ RtlpGetExceptionAddress(VOID)
 
 BOOLEAN
 NTAPI
-RtplUnwindInternal(
+RtlpUnwindInternal(
     _In_opt_ PVOID TargetFrame,
     _In_opt_ PVOID TargetIp,
     _In_ PEXCEPTION_RECORD ExceptionRecord,
@@ -101,7 +101,7 @@ RtlDispatchException(
     }
 
     /* Call the internal unwind routine */
-    Handled = RtplUnwindInternal(NULL, // TargetFrame
+    Handled = RtlpUnwindInternal(NULL, // TargetFrame
                                  NULL, // TargetIp
                                  ExceptionRecord,
                                  0, // ReturnValue

--- a/sdk/lib/rtl/amd64/unwind.c
+++ b/sdk/lib/rtl/amd64/unwind.c
@@ -683,7 +683,7 @@ Exit:
 */
 BOOLEAN
 NTAPI
-RtplUnwindInternal(
+RtlpUnwindInternal(
     _In_opt_ PVOID TargetFrame,
     _In_opt_ PVOID TargetIp,
     _In_ PEXCEPTION_RECORD ExceptionRecord,
@@ -907,7 +907,7 @@ RtlUnwindEx(
     }
 
     /* Call the internal function */
-    RtplUnwindInternal(TargetFrame,
+    RtlpUnwindInternal(TargetFrame,
                        TargetIp,
                        ExceptionRecord,
                        ReturnValue,


### PR DESCRIPTION
## Purpose

I think `RtplUnwindInternal` implemented at #3708 is a typo.
`Rtlp` means **R**un**T**ime **L**ibrary **P**rivate.

Is it intentional use? Correct me if I am wrong. :)