### PR TITLE
[INCLUDE] Move WM_IME_SYSTEM from ntuser.h to undocuser.h

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -31,6 +31,7 @@
 #include <ndk/rtlfuncs.h>
 #include "../../../win32ss/include/ntuser.h"
 #include "../../../win32ss/include/ntwin32.h"
+#include <undocuser.h>
 #include <imm32_undoc.h>
 #include <strsafe.h>
 

--- a/sdk/include/reactos/undocuser.h
+++ b/sdk/include/reactos/undocuser.h
@@ -56,6 +56,7 @@ extern "C" {
 #define WM_DRAGLOOP	        0x0000022D
 #define WM_DRAGSELECT       0x0000022E
 #define WM_DRAGMOVE	        0x0000022F
+#define WM_IME_SYSTEM       0x00000287
 #define WM_POPUPSYSTEMMENU  0x00000313
 #define WM_UAHINIT          0x0000031b
 #define WM_CBT              0x000003FF // ReactOS only.

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -7,8 +7,6 @@ struct _DESKTOP;
 struct _WND;
 struct tagPOPUPMENU;
 
-#define WM_IME_SYSTEM 0x287
-
 #define FIRST_USER_HANDLE 0x0020 /* first possible value for low word of user handle */
 #define LAST_USER_HANDLE 0xffef /* last possible value for low word of user handle */
 


### PR DESCRIPTION
## Purpose

Make code clean and clear.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Move `WM_IME_SYSTEM` macro from `ntuser.h` into `undocuser.h`.
- Add `#include <undocuser.h>` in `IMM32`.