### PR TITLE
[WIN32KNT_APITEST] Add NtUserGetThreadState testcase

### DIFF
--- a/modules/rostests/apitests/win32nt/CMakeLists.txt
+++ b/modules/rostests/apitests/win32nt/CMakeLists.txt
@@ -54,6 +54,7 @@ list(APPEND SOURCE
     ntuser/NtUserFindExistingCursorIcon.c
     ntuser/NtUserGetClassInfo.c
 #    ntuser/NtUserGetIconInfo.c
+    ntuser/NtUserGetThreadState.c
     ntuser/NtUserGetTitleBarInfo.c
     ntuser/NtUserProcessConnect.c
     ntuser/NtUserRedrawWindow.c
@@ -85,7 +86,7 @@ add_importlibs(win32knt_apitest
     msvcrt
     kernel32
     ntdll)
-add_delay_importlibs(win32knt_apitest win32u)
+add_delay_importlibs(win32knt_apitest win32u imm32)
 add_dependencies(win32knt_apitest xdk)
 add_pch(win32knt_apitest win32nt.h "${PCH_SKIP_SOURCE}")
 add_rostests_file(TARGET win32knt_apitest)

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -6,6 +6,7 @@
  */
 
 #include <win32nt.h>
+#include <pseh/pseh2.h>
 
 #define MAX_COUNT 8
 #define IGNORED 0xDEADFACE

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -232,7 +232,6 @@ static VOID DoTest_BUTTON(VOID)
     DO_CHECK(3, hImeWnd);
     DO_CHECK(4, hIMC);
 
-    ImmReleaseContext(GetDesktopWindow(), hIMC);
     DestroyWindow(hWnd);
 }
 

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -1,0 +1,136 @@
+#include <win32nt.h>
+
+#define MAX_COUNT 8
+#define IGNORED 0xDEADFACE
+#define RAISED 0xBADBEEF
+
+#undef DO_PRINT
+
+#ifdef DO_PRINT
+static void PrintThreadState(HWND hWnd, int lineno)
+{
+    INT i;
+    HIMC hIMC = ImmGetContext(hWnd);
+    HWND hImeWnd = ImmGetDefaultIMEWnd(hWnd);
+
+    trace("---\n");
+    trace("__LINE__: %d\n", lineno);
+    trace("hWnd: %p\n", (LPVOID)hWnd);
+    trace("GetFocus(): %p\n", (LPVOID)GetFocus());
+    trace("GetCapture(): %p\n", (LPVOID)GetCapture());
+    trace("GetActiveWindow(): %p\n", (LPVOID)GetActiveWindow());
+    trace("ImmGetContext(): %p\n", (LPVOID)hIMC);
+    trace("ImmGetDefaultIMEWnd(): %p\n", (LPVOID)hImeWnd);
+
+    for (i = 0; i < MAX_COUNT; ++i)
+    {
+        _SEH2_TRY
+        {
+            trace("ThreadState[%d]: %p\n", i, (LPVOID)NtUserGetThreadState(i));
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            trace("ThreadState[%d]: exception\n", i);
+        }
+        _SEH2_END;
+    }
+
+    ImmReleaseContext(hWnd, hIMC);
+}
+#endif
+
+static void CheckThreadState(INT i, DWORD_PTR dwState)
+{
+    DWORD_PTR dwValue;
+
+    _SEH2_TRY
+    {
+        dwValue = (DWORD_PTR)NtUserGetThreadState(i);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        dwValue = RAISED;
+    }
+    _SEH2_END;
+
+    if (dwState != IGNORED)
+        ok_long((DWORD)dwValue, (DWORD)dwState);
+}
+
+START_TEST(NtUserGetThreadState)
+{
+    HWND hWnd, hImeWnd;
+    HIMC hIMC;
+
+    hWnd = CreateWindowA("EDIT", "Test", ES_LEFT | ES_MULTILINE | WS_VISIBLE,
+                         0, 0, 50, 30,
+                         NULL, NULL, GetModuleHandleW(NULL), NULL);
+    hImeWnd = ImmGetDefaultIMEWnd(hWnd);
+    hIMC = ImmGetContext(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)hWnd);
+    CheckThreadState(1, (DWORD_PTR)hWnd);
+    CheckThreadState(2, (DWORD_PTR)0);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    SetCapture(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)hWnd);
+    CheckThreadState(1, (DWORD_PTR)hWnd);
+    CheckThreadState(2, (DWORD_PTR)hWnd);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    ReleaseCapture();
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)hWnd);
+    CheckThreadState(1, (DWORD_PTR)hWnd);
+    CheckThreadState(2, (DWORD_PTR)0);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    SetFocus(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)hWnd);
+    CheckThreadState(1, (DWORD_PTR)hWnd);
+    CheckThreadState(2, (DWORD_PTR)0);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    SetActiveWindow(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)hWnd);
+    CheckThreadState(1, (DWORD_PTR)hWnd);
+    CheckThreadState(2, (DWORD_PTR)0);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    SetActiveWindow(NULL);
+
+#ifdef DO_PRINT
+    PrintThreadState(hWnd, __LINE__);
+#endif
+    CheckThreadState(0, (DWORD_PTR)0);
+    CheckThreadState(1, (DWORD_PTR)0);
+    CheckThreadState(2, (DWORD_PTR)0);
+    CheckThreadState(3, (DWORD_PTR)hImeWnd);
+    CheckThreadState(4, (DWORD_PTR)hIMC);
+
+    DestroyWindow(hWnd);
+}

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -14,7 +14,7 @@
 #undef DO_PRINT
 
 #ifdef DO_PRINT
-static void PrintThreadState(HWND hWnd, int lineno)
+static VOID PrintThreadState(HWND hWnd, INT lineno)
 {
     INT i;
     HIMC hIMC = ImmGetContext(hWnd);
@@ -46,7 +46,7 @@ static void PrintThreadState(HWND hWnd, int lineno)
 }
 #endif
 
-static void CheckThreadState(INT i, DWORD_PTR dwState)
+static VOID CheckThreadState(INT lineno, INT i, DWORD_PTR dwState)
 {
     DWORD_PTR dwValue;
 
@@ -61,7 +61,10 @@ static void CheckThreadState(INT i, DWORD_PTR dwState)
     _SEH2_END;
 
     if (dwState != IGNORED)
-        ok_long((DWORD)dwValue, (DWORD)dwState);
+    {
+        ok(dwValue == dwState, "Line %d: Mismatch 0x%lX vs. 0x%lX\n",
+           lineno, (DWORD)dwValue, (DWORD)dwState);
+    }
 }
 
 START_TEST(NtUserGetThreadState)
@@ -75,69 +78,72 @@ START_TEST(NtUserGetThreadState)
     hImeWnd = ImmGetDefaultIMEWnd(hWnd);
     hIMC = ImmGetContext(hWnd);
 
+#define CHECK_THIS(i, value) \
+    CheckThreadState(__LINE__, (i), (DWORD_PTR)(value));
+
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)hWnd);
-    CheckThreadState(1, (DWORD_PTR)hWnd);
-    CheckThreadState(2, (DWORD_PTR)0);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, hWnd);
+    CHECK_THIS(1, hWnd);
+    CHECK_THIS(2, 0);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     SetCapture(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)hWnd);
-    CheckThreadState(1, (DWORD_PTR)hWnd);
-    CheckThreadState(2, (DWORD_PTR)hWnd);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, hWnd);
+    CHECK_THIS(1, hWnd);
+    CHECK_THIS(2, hWnd);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     ReleaseCapture();
 
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)hWnd);
-    CheckThreadState(1, (DWORD_PTR)hWnd);
-    CheckThreadState(2, (DWORD_PTR)0);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, hWnd);
+    CHECK_THIS(1, hWnd);
+    CHECK_THIS(2, 0);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     SetFocus(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)hWnd);
-    CheckThreadState(1, (DWORD_PTR)hWnd);
-    CheckThreadState(2, (DWORD_PTR)0);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, hWnd);
+    CHECK_THIS(1, hWnd);
+    CHECK_THIS(2, 0);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     SetActiveWindow(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)hWnd);
-    CheckThreadState(1, (DWORD_PTR)hWnd);
-    CheckThreadState(2, (DWORD_PTR)0);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, hWnd);
+    CHECK_THIS(1, hWnd);
+    CHECK_THIS(2, 0);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     SetActiveWindow(NULL);
 
 #ifdef DO_PRINT
     PrintThreadState(hWnd, __LINE__);
 #endif
-    CheckThreadState(0, (DWORD_PTR)0);
-    CheckThreadState(1, (DWORD_PTR)0);
-    CheckThreadState(2, (DWORD_PTR)0);
-    CheckThreadState(3, (DWORD_PTR)hImeWnd);
-    CheckThreadState(4, (DWORD_PTR)hIMC);
+    CHECK_THIS(0, 0);
+    CHECK_THIS(1, 0);
+    CHECK_THIS(2, 0);
+    CHECK_THIS(3, hImeWnd);
+    CHECK_THIS(4, hIMC);
 
     DestroyWindow(hWnd);
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -14,7 +14,7 @@
 #undef DO_PRINT
 
 #ifdef DO_PRINT
-static VOID PrintThreadState(HWND hWnd, INT lineno)
+static VOID PrintThreadState(INT lineno, HWND hWnd)
 {
     INT i;
     HIMC hIMC = ImmGetContext(hWnd);
@@ -82,7 +82,7 @@ START_TEST(NtUserGetThreadState)
     CheckThreadState(__LINE__, (i), (DWORD_PTR)(value));
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, hWnd);
     CHECK_THIS(1, hWnd);
@@ -93,7 +93,7 @@ START_TEST(NtUserGetThreadState)
     SetCapture(hWnd);
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, hWnd);
     CHECK_THIS(1, hWnd);
@@ -104,7 +104,7 @@ START_TEST(NtUserGetThreadState)
     ReleaseCapture();
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, hWnd);
     CHECK_THIS(1, hWnd);
@@ -115,7 +115,7 @@ START_TEST(NtUserGetThreadState)
     SetFocus(hWnd);
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, hWnd);
     CHECK_THIS(1, hWnd);
@@ -126,7 +126,7 @@ START_TEST(NtUserGetThreadState)
     SetActiveWindow(hWnd);
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, hWnd);
     CHECK_THIS(1, hWnd);
@@ -137,7 +137,7 @@ START_TEST(NtUserGetThreadState)
     SetActiveWindow(NULL);
 
 #ifdef DO_PRINT
-    PrintThreadState(hWnd, __LINE__);
+    PrintThreadState(__LINE__, hWnd);
 #endif
     CHECK_THIS(0, 0);
     CHECK_THIS(1, 0);

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -10,6 +10,7 @@
 #define MAX_COUNT 8
 #define IGNORED 0xDEADFACE
 #define RAISED 0xBADBEEF
+#define DO_CHECK(i, value) CheckThreadState(__LINE__, (i), (DWORD_PTR)(value))
 
 #undef DO_PRINT
 
@@ -67,7 +68,7 @@ static VOID CheckThreadState(INT lineno, INT i, DWORD_PTR dwState)
     }
 }
 
-START_TEST(NtUserGetThreadState)
+static VOID DoTest_EDIT(VOID)
 {
     HWND hWnd, hImeWnd;
     HIMC hIMC;
@@ -76,74 +77,167 @@ START_TEST(NtUserGetThreadState)
                          0, 0, 50, 30,
                          NULL, NULL, GetModuleHandleW(NULL), NULL);
     hImeWnd = ImmGetDefaultIMEWnd(hWnd);
-    hIMC = ImmGetContext(hWnd);
+    ok_int(hImeWnd != NULL, TRUE);
 
-#define CHECK_THIS(i, value) \
-    CheckThreadState(__LINE__, (i), (DWORD_PTR)(value));
+    hIMC = ImmGetContext(hWnd);
+    ok_int(hIMC != NULL, TRUE);
+    ok_int(hIMC == (HIMC)NtUserGetThreadState(4), TRUE);
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, hWnd);
-    CHECK_THIS(1, hWnd);
-    CHECK_THIS(2, 0);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
     SetCapture(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, hWnd);
-    CHECK_THIS(1, hWnd);
-    CHECK_THIS(2, hWnd);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, hWnd);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
     ReleaseCapture();
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, hWnd);
-    CHECK_THIS(1, hWnd);
-    CHECK_THIS(2, 0);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
     SetFocus(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, hWnd);
-    CHECK_THIS(1, hWnd);
-    CHECK_THIS(2, 0);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
     SetActiveWindow(hWnd);
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, hWnd);
-    CHECK_THIS(1, hWnd);
-    CHECK_THIS(2, 0);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
     SetActiveWindow(NULL);
 
 #ifdef DO_PRINT
     PrintThreadState(__LINE__, hWnd);
 #endif
-    CHECK_THIS(0, 0);
-    CHECK_THIS(1, 0);
-    CHECK_THIS(2, 0);
-    CHECK_THIS(3, hImeWnd);
-    CHECK_THIS(4, hIMC);
+    DO_CHECK(0, IGNORED);
+    DO_CHECK(1, IGNORED);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
 
+    ImmReleaseContext(hWnd, hIMC);
     DestroyWindow(hWnd);
+}
+
+static VOID DoTest_BUTTON(VOID)
+{
+    HWND hWnd, hImeWnd;
+    HIMC hIMC;
+
+    hWnd = CreateWindowA("BUTTON", "Test", BS_PUSHBUTTON | WS_VISIBLE,
+                         0, 0, 50, 30,
+                         NULL, NULL, GetModuleHandleW(NULL), NULL);
+    hImeWnd = ImmGetDefaultIMEWnd(hWnd);
+    ok_int(hImeWnd != NULL, TRUE);
+
+    hIMC = ImmGetContext(hWnd);
+    ok_int(hIMC != NULL, FALSE);
+
+    hIMC = (HIMC)NtUserGetThreadState(4);
+    ok_int(hIMC != NULL, TRUE);
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    SetCapture(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, hWnd);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    ReleaseCapture();
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    SetFocus(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    SetActiveWindow(hWnd);
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, hWnd);
+    DO_CHECK(1, hWnd);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    SetActiveWindow(NULL);
+
+#ifdef DO_PRINT
+    PrintThreadState(__LINE__, hWnd);
+#endif
+    DO_CHECK(0, IGNORED);
+    DO_CHECK(1, IGNORED);
+    DO_CHECK(2, 0);
+    DO_CHECK(3, hImeWnd);
+    DO_CHECK(4, hIMC);
+
+    ImmReleaseContext(GetDesktopWindow(), hIMC);
+    DestroyWindow(hWnd);
+}
+
+START_TEST(NtUserGetThreadState)
+{
+    DoTest_EDIT();
+    DoTest_BUTTON();
 }

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -1,3 +1,10 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Test for NtUserGetThreadState
+ * COPYRIGHT:   Copyright 2021 Mike Blablabla <katayama.hirofumi.mz@gmail.com>
+ */
+
 #include <win32nt.h>
 
 #define MAX_COUNT 8

--- a/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserGetThreadState.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS api tests
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:     Test for NtUserGetThreadState
- * COPYRIGHT:   Copyright 2021 Mike Blablabla <katayama.hirofumi.mz@gmail.com>
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include <win32nt.h>

--- a/modules/rostests/apitests/win32nt/testlist.c
+++ b/modules/rostests/apitests/win32nt/testlist.c
@@ -53,6 +53,7 @@ extern void func_NtUserCreateWindowEx(void);
 extern void func_NtUserEnumDisplaySettings(void);
 extern void func_NtUserFindExistingCursorIcon(void);
 extern void func_NtUserGetClassInfo(void);
+extern void func_NtUserGetThreadState(void);
 //extern void func_NtUserGetIconInfo(void);
 extern void func_NtUserGetTitleBarInfo(void);
 extern void func_NtUserProcessConnect(void);
@@ -119,6 +120,7 @@ const struct test winetest_testlist[] =
     { "NtUserEnumDisplaySettings", func_NtUserEnumDisplaySettings },
     { "NtUserFindExistingCursorIcon", func_NtUserFindExistingCursorIcon },
     { "NtUserGetClassInfo", func_NtUserGetClassInfo },
+    { "NtUserGetThreadState", func_NtUserGetThreadState },
     //{ "NtUserGetIconInfo", func_NtUserGetIconInfo },
     { "NtUserGetTitleBarInfo", func_NtUserGetTitleBarInfo },
     { "NtUserProcessConnect", func_NtUserProcessConnect },


### PR DESCRIPTION
## Purpose
I want to fix `NtUserGetThreadState` function and `enum ThreadStateRoutines`.
JIRA issue: [CORE-17732](https://jira.reactos.org/browse/CORE-17732), [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `NtUserGetThreadState` testcase.

## Screenshots

WinXP:
![winxp](https://user-images.githubusercontent.com/2107452/130191497-5717c5a2-4788-4f6e-8c7c-0075ca570eaa.png)
Successful.

Win2k3:
![win2k3](https://user-images.githubusercontent.com/2107452/130191502-33ea595c-d557-4b7f-9a3e-a1afc24a688a.png)
Successful.