### PR TITLE
[CMAKE][BOOTDATA]  Fix root CA certificates for Live CD

### DIFF
--- a/boot/bootdata/CMakeLists.txt
+++ b/boot/bootdata/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_target(converted_caroots_inf DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/caro
 add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf
                    COMMAND native-utf16le "${CMAKE_CURRENT_SOURCE_DIR}/caroots.inf" "${CMAKE_CURRENT_BINARY_DIR}/caroots.inf"
                    DEPENDS native-utf16le ${CMAKE_CURRENT_SOURCE_DIR}/caroots.inf)
-add_cd_file(TARGET converted_caroots_inf FILE ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf DESTINATION reactos NO_CAB FOR all)
+add_cd_file(TARGET converted_caroots_inf FILE ${CMAKE_CURRENT_BINARY_DIR}/caroots.inf DESTINATION reactos NO_CAB FOR bootcd regtest)
 
 add_registry_inf(
     hivecls.inf

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -794,7 +794,8 @@ function(create_registry_hives)
     # LiveCD hives
     list(APPEND _livecd_inf_files
         ${_registry_inf}
-        ${CMAKE_SOURCE_DIR}/boot/bootdata/livecd.inf)
+        ${CMAKE_SOURCE_DIR}/boot/bootdata/livecd.inf
+        ${CMAKE_SOURCE_DIR}/boot/bootdata/caroots.inf)
     if(SARCH STREQUAL "xbox")
         list(APPEND _livecd_inf_files
             ${CMAKE_SOURCE_DIR}/boot/bootdata/hiveinst_xbox.inf)


### PR DESCRIPTION
## Purpose

Starting with commit 6158207c318bccaf1767d1a5c1545de45beb113d, caroots.inf is no longer added to LiveCD image builds, this turns into a trouble when a LiveCD user tries to load TLS/SSL sites using our built-in secure channel, and what they find is that the CA chains cannot be generated and thus failing.

JIRA issue: [CORE-17739](https://jira.reactos.org/browse/CORE-17739)

## Proposed changes

1) Add caroots.inf contents directly to the registry hives when building the LiveCD ISO.
2) Do not include the file caroots.inf in the LiveCD ISO, because it is added directly into the registry.