### PR TITLE
[IMM32][USER32] Add SEH handling in ValidateHwndNoErr

### DIFF
--- a/dll/win32/imm32/CMakeLists.txt
+++ b/dll/win32/imm32/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
+include_directories(
+    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
+    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/subsys)
 add_definitions(-D__WINESRC__)
 
 remove_definitions(-D_WIN32_WINNT=0x502)
@@ -14,6 +16,6 @@ list(APPEND SOURCE
 
 add_library(imm32 MODULE ${SOURCE} version.rc)
 set_module_type(imm32 win32dll)
-target_link_libraries(imm32 wine win32ksys)
+target_link_libraries(imm32 wine pseh win32ksys)
 add_importlibs(imm32 advapi32 user32 gdi32 msvcrt kernel32 ntdll)
 add_cd_file(TARGET imm32 DESTINATION reactos/system32 FOR all)

--- a/dll/win32/imm32/CMakeLists.txt
+++ b/dll/win32/imm32/CMakeLists.txt
@@ -1,7 +1,5 @@
 
-include_directories(
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine
-    ${REACTOS_SOURCE_DIR}/sdk/include/reactos/subsys)
+include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 add_definitions(-D__WINESRC__)
 
 remove_definitions(-D_WIN32_WINNT=0x502)

--- a/win32ss/user/user32/misc/dllmain.c
+++ b/win32ss/user/user32/misc/dllmain.c
@@ -439,6 +439,7 @@ Init(PUSERCONNECT UserCon /*PUSERSRV_API_CONNECTINFO*/)
         gHandleEntries = SharedPtrToUser(gHandleTable->handles);
         gSharedInfo = UserCon->siClient;
         gSharedInfo.psi = gpsi;
+        gSharedInfo.aheList = gHandleTable;
     }
 
     // FIXME: Yet another hack... This call should normally not be done here, but


### PR DESCRIPTION
## Purpose
Fix Wine Internet Explorer crash (CORE-17741).
JIRA issue: [CORE-17741](https://jira.reactos.org/browse/CORE-17741), [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Include `<pseh/pseh2.h>` and link `pseh`.
- Add SEH (structured-exception-handling) in `ValidateHwndNoErr` function to avoid crash.
- Initialize `gSharedInfo.aheList` with `gHandleTable` in `USER32`.

## Screenshot

AFTER:
![after](https://user-images.githubusercontent.com/2107452/131479778-0db52024-d632-46a1-86cc-82ca95738afb.png)