### PR TITLE
[WIN32SS:NTUSER:USER32][IMM] Fix NtUserProcessConnect() returned pointers.

### DIFF
--- a/modules/rostests/apitests/win32nt/ntuser/NtUserProcessConnect.c
+++ b/modules/rostests/apitests/win32nt/ntuser/NtUserProcessConnect.c
@@ -1,22 +1,29 @@
 /*
- * PROJECT:         ReactOS api tests
- * LICENSE:         GPL - See COPYING in the top level directory
- * PURPOSE:         Test for NtUserProcessConnect
- * PROGRAMMERS:
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Test for NtUserProcessConnect
+ * COPYRIGHT:   Copyright 2008-2020 Timo Kreuzer
+ *              Copyright 2021 Hermes Belusca-Maito
  */
 
 #include <win32nt.h>
+
+#define NTOS_MODE_USER
+#include <ndk/exfuncs.h>
 
 START_TEST(NtUserProcessConnect)
 {
     HANDLE hProcess;
     NTSTATUS Status;
     USERCONNECT UserConnect = {0};
+    SYSTEM_BASIC_INFORMATION SystemInformation;
+    ULONG_PTR MaximumUserModeAddress;
 
     hProcess = GetCurrentProcess();
 
-    UserConnect.ulVersion = MAKELONG(0, 5);
-    Status = NtUserProcessConnect(hProcess, &UserConnect, sizeof(USERCONNECT));
+    UserConnect.ulVersion = MAKELONG(0, 5); // == USER_VERSION
+    // UserConnect.dwDispatchCount;
+    Status = NtUserProcessConnect(hProcess, &UserConnect, sizeof(UserConnect));
     TEST(NT_SUCCESS(Status));
 
     printf("UserConnect.ulVersion = 0x%lx\n", UserConnect.ulVersion);
@@ -27,4 +34,25 @@ START_TEST(NtUserProcessConnect)
     printf("UserConnect.siClient.pDispInfo = 0x%p\n", UserConnect.siClient.pDispInfo);
     printf("UserConnect.siClient.ulSharedDelta = 0x%Ix\n", UserConnect.siClient.ulSharedDelta);
 
+    /* Verify the validity of some mandatory fields */
+    TEST(UserConnect.ulVersion == MAKELONG(0, 5));
+    TEST(UserConnect.ulCurrentVersion == 0);
+    TEST(UserConnect.siClient.ulSharedDelta != 0);
+
+    /* Get the max um address */
+    Status = NtQuerySystemInformation(SystemBasicInformation,
+                                      &SystemInformation,
+                                      sizeof(SystemInformation),
+                                      NULL);
+    TEST(NT_SUCCESS(Status));
+
+    MaximumUserModeAddress = SystemInformation.MaximumUserModeAddress;
+
+    /* Verify the validity of pointers -- They must be in client space */
+    TEST(UserConnect.siClient.psi != NULL);
+    TEST(UserConnect.siClient.aheList != NULL);
+    // TEST(UserConnect.siClient.pDispInfo != NULL);
+    TEST((ULONG_PTR)UserConnect.siClient.psi < MaximumUserModeAddress);
+    TEST((ULONG_PTR)UserConnect.siClient.aheList < MaximumUserModeAddress);
+    // TEST((ULONG_PTR)UserConnect.siClient.pDispInfo < MaximumUserModeAddress);
 }

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -858,10 +858,11 @@ typedef LONG_PTR
 #define FNID_TOOLTIPS               0x02B6
 #define FNID_SENDNOTIFYMESSAGE      0x02B7
 #define FNID_SENDMESSAGECALLBACK    0x02B8
-#define FNID_LAST                   0x02B9
 
-#define FNID_NUM FNID_LAST - FNID_FIRST + 1
-#define FNID_NUMSERVERPROC FNID_SWITCH - FNID_FIRST + 1
+#define FNID_LAST                   FNID_SENDMESSAGECALLBACK
+
+#define FNID_NUM                    (FNID_LAST - FNID_FIRST + 1)
+#define FNID_NUMSERVERPROC          (FNID_SWITCH - FNID_FIRST + 1)
 
 #define FNID_DDEML   0x2000 /* Registers DDEML */
 #define FNID_DESTROY 0x4000 /* This is sent when WM_NCDESTROY or in the support routine. */
@@ -1084,11 +1085,11 @@ typedef struct _WNDMSG
 
 typedef struct _SHAREDINFO
 {
-    PSERVERINFO psi; /* global Server Info */
-    PVOID aheList; /* Handle Entry List */
-    PVOID pDispInfo; /* global PDISPLAYINFO pointer */
-    ULONG_PTR ulSharedDelta; /* Heap delta */
-    WNDMSG awmControl[FNID_LAST - FNID_FIRST];
+    PSERVERINFO psi;         /* Global Server Info */
+    PVOID aheList;           /* Handle Entry List */
+    PVOID pDispInfo;         /* Global PDISPLAYINFO pointer */
+    ULONG_PTR ulSharedDelta; /* Shared USER mapped section delta */
+    WNDMSG awmControl[FNID_NUM];
     WNDMSG DefWindowMsgs;
     WNDMSG DefWindowSpecMsgs;
 } SHAREDINFO, *PSHAREDINFO;

--- a/win32ss/user/user32/include/user32p.h
+++ b/win32ss/user/user32/include/user32p.h
@@ -39,13 +39,12 @@ typedef struct
 extern HINSTANCE User32Instance;
 #define user32_module User32Instance
 extern PPROCESSINFO g_ppi;
-extern ULONG_PTR g_ulSharedDelta;
-extern PSERVERINFO gpsi;
 extern SHAREDINFO gSharedInfo;
-extern BOOLEAN gfLogonProcess;
-extern BOOLEAN gfServerProcess;
+extern PSERVERINFO gpsi;
 extern PUSER_HANDLE_TABLE gHandleTable;
 extern PUSER_HANDLE_ENTRY gHandleEntries;
+extern BOOLEAN gfLogonProcess;
+extern BOOLEAN gfServerProcess;
 extern CRITICAL_SECTION U32AccelCacheLock;
 extern HINSTANCE ghImm32;
 extern RTL_CRITICAL_SECTION gcsUserApiHook;

--- a/win32ss/user/user32/include/user_x.h
+++ b/win32ss/user/user32/include/user_x.h
@@ -4,8 +4,8 @@ static __inline PVOID
 SharedPtrToUser(PVOID Ptr)
 {
     ASSERT(Ptr != NULL);
-    ASSERT(g_ulSharedDelta != 0);
-    return (PVOID)((ULONG_PTR)Ptr - g_ulSharedDelta);
+    ASSERT(gSharedInfo.ulSharedDelta != 0);
+    return (PVOID)((ULONG_PTR)Ptr - gSharedInfo.ulSharedDelta);
 }
 
 static __inline PVOID

--- a/win32ss/user/user32/misc/dllmain.c
+++ b/win32ss/user/user32/misc/dllmain.c
@@ -27,11 +27,10 @@ static ULONG User32TlsIndex;
 HINSTANCE User32Instance;
 
 PPROCESSINFO g_ppi = NULL;
+SHAREDINFO gSharedInfo = {0};
+PSERVERINFO gpsi = NULL;
 PUSER_HANDLE_TABLE gHandleTable = NULL;
 PUSER_HANDLE_ENTRY gHandleEntries = NULL;
-PSERVERINFO gpsi = NULL;
-SHAREDINFO gSharedInfo = {0};
-ULONG_PTR g_ulSharedDelta;
 BOOLEAN gfLogonProcess  = FALSE;
 BOOLEAN gfServerProcess = FALSE;
 BOOLEAN gfFirstThread   = TRUE;
@@ -271,6 +270,7 @@ ClientThreadSetupHelper(BOOL IsCallback)
 
         /* Minimal setup of the connect info structure */
         UserCon.ulVersion = USER_VERSION;
+        // UserCon.dwDispatchCount;
 
         /* Connect to win32k */
         Status = NtUserProcessConnect(NtCurrentProcess(),
@@ -280,13 +280,13 @@ ClientThreadSetupHelper(BOOL IsCallback)
 
         /* Retrieve data */
         g_ppi = ClientInfo->ppi; // Snapshot PI, used as pointer only!
-        g_ulSharedDelta = UserCon.siClient.ulSharedDelta;
-        gpsi = SharedPtrToUser(UserCon.siClient.psi);
-        gHandleTable = SharedPtrToUser(UserCon.siClient.aheList);
-        gHandleEntries = SharedPtrToUser(gHandleTable->handles);
         gSharedInfo = UserCon.siClient;
+        gpsi = gSharedInfo.psi;
+        gHandleTable = gSharedInfo.aheList;
+        /* ReactOS-Specific! */ gHandleEntries = SharedPtrToUser(gHandleTable->handles);
 
-        // ERR("1 SI 0x%x : HT 0x%x : D 0x%x\n", UserCon.siClient.psi, UserCon.siClient.aheList,  g_ulSharedDelta);
+        // ERR("1 SI 0x%x : HT 0x%x : D 0x%x\n",
+        //     gSharedInfo.psi, gSharedInfo.aheList, gSharedInfo.ulSharedDelta);
     }
 
     TRACE("Checkpoint (register PFN)\n");
@@ -418,6 +418,7 @@ Init(PUSERCONNECT UserCon /*PUSERSRV_API_CONNECTINFO*/)
 
             /* Minimal setup of the connect info structure */
             UserCon->ulVersion = USER_VERSION;
+            // UserCon->dwDispatchCount;
 
             TRACE("HACK: Hackish NtUserProcessConnect call!!\n");
             /* Connect to win32k */
@@ -433,12 +434,10 @@ Init(PUSERCONNECT UserCon /*PUSERSRV_API_CONNECTINFO*/)
 
         /* Retrieve data */
         g_ppi = GetWin32ClientInfo()->ppi; // Snapshot PI, used as pointer only!
-        g_ulSharedDelta = UserCon->siClient.ulSharedDelta;
-        gpsi = SharedPtrToUser(UserCon->siClient.psi);
-        gHandleTable = SharedPtrToUser(UserCon->siClient.aheList);
-        gHandleEntries = SharedPtrToUser(gHandleTable->handles);
         gSharedInfo = UserCon->siClient;
-        gSharedInfo.psi = gpsi;
+        gpsi = gSharedInfo.psi;
+        gHandleTable = gSharedInfo.aheList;
+        /* ReactOS-Specific! */ gHandleEntries = SharedPtrToUser(gHandleTable->handles);
     }
 
     // FIXME: Yet another hack... This call should normally not be done here, but


### PR DESCRIPTION
## Purpose

Do the server/client-space pointers conversion in `NtUserProcessConnect()`, instead of having the client (who calls this function) to do the job. Should make the behaviour Windows-compatible, and remove some of the hackfixes in e.g. PR #3935.

Fixes also the IMM32-induced crash reported in [CORE-17741](https://jira.reactos.org/browse/CORE-17741)

## TODO

- [x] Actually implement the code fix.
- [x] Add test to `modules/rostests/apitests/win32nt/ntuser/NtUserProcessConnect.c`.
