### PR TITLE
[PORTCLS] Implement CIrpQueue::GetAcquiredTagRange

### DIFF
--- a/drivers/wdm/audio/backpln/portcls/interfaces.hpp
+++ b/drivers/wdm/audio/backpln/portcls/interfaces.hpp
@@ -396,8 +396,8 @@ DECLARE_INTERFACE_(IIrpQueue, IUnknown)
     STDMETHODIMP_(BOOLEAN) HasLastMappingFailed(THIS); \
     STDMETHODIMP_(ULONG) GetCurrentIrpOffset(THIS);    \
     STDMETHODIMP_(BOOLEAN) GetAcquiredTagRange(THIS_      \
-        IN PVOID * FirstTag,                           \
-        IN PVOID * LastTag);
+        OUT PVOID * FirstTag,                           \
+        OUT PVOID * LastTag);
 
 
 


### PR DESCRIPTION
## Purpose

Implement `CIrpQueue::GetAcquiredTagRange` method in IRP code of our portcls driver.
Also mark `FirstTag` and `LastTag` parameters output instead of input, since they are actually used as output parameters. Update the prototype in the header appropriately.
This method is called as well by `PinWavePciState` function from pin wavepci code, which is used by some audio drivers on real hardware (like Vinyl AC97 audio driver).

JIRA issue: [CORE-17742](https://jira.reactos.org/browse/CORE-17742)

## TODO

- [ ] The sound still does not work after my changes, so this implementation probably needs to be improved.