### PR TITLE
[NTOS:KD64] Diverse IRQL usage fixes.

### DIFF
--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -1890,7 +1890,7 @@ KdEnterDebugger(IN PKTRAP_FRAME TrapFrame,
     /* Save the current IRQL */
     KeGetCurrentPrcb()->DebuggerSavedIRQL = KeGetCurrentIrql();
 
-    /* Freeze all CPUs */
+    /* Freeze all CPUs, raising also the IRQL to HIGH_LEVEL */
     Enable = KeFreezeExecution(TrapFrame, ExceptionFrame);
 
     /* Lock the port, save the state and set debugger entered */
@@ -1929,7 +1929,7 @@ KdExitDebugger(IN BOOLEAN Enable)
     KdRestore(FALSE);
     if (KdpPortLocked) KdpPortUnlock();
 
-    /* Unfreeze the CPUs */
+    /* Unfreeze the CPUs, restoring also the IRQL */
     KeThawExecution(Enable);
 
     /* Compare time with the one from KdEnterDebugger */

--- a/ntoskrnl/kd64/kdapi.c
+++ b/ntoskrnl/kd64/kdapi.c
@@ -1987,8 +1987,8 @@ KdEnableDebuggerWithLock(IN BOOLEAN NeedLock)
         if (NeedLock)
         {
             /* Do the unlock */
-            KeLowerIrql(OldIrql);
             KdpPortUnlock();
+            KeLowerIrql(OldIrql);
 
             /* Fail: We're already enabled */
             return STATUS_INVALID_PARAMETER;
@@ -2022,8 +2022,8 @@ KdEnableDebuggerWithLock(IN BOOLEAN NeedLock)
     if (NeedLock)
     {
         /* Yes, now unlock it */
-        KeLowerIrql(OldIrql);
         KdpPortUnlock();
+        KeLowerIrql(OldIrql);
     }
 
     /* We're done */
@@ -2083,8 +2083,8 @@ KdDisableDebuggerWithLock(IN BOOLEAN NeedLock)
             if (!NT_SUCCESS(Status))
             {
                 /* Release the lock and fail */
-                KeLowerIrql(OldIrql);
                 KdpPortUnlock();
+                KeLowerIrql(OldIrql);
                 return Status;
             }
         }
@@ -2112,8 +2112,8 @@ KdDisableDebuggerWithLock(IN BOOLEAN NeedLock)
     if (NeedLock)
     {
         /* Yes, now unlock it */
-        KeLowerIrql(OldIrql);
         KdpPortUnlock();
+        KeLowerIrql(OldIrql);
     }
 
     /* We're done */

--- a/ntoskrnl/kd64/kdlock.c
+++ b/ntoskrnl/kd64/kdlock.c
@@ -115,8 +115,8 @@ KdPollBreakIn(VOID)
             KeLowerIrql(OldIrql);
         }
 
-        /* Re-enable interrupts if they were enabled previously */
-        if (Enable) _enable();
+        /* Re-enable interrupts */
+        KeRestoreInterrupts(Enable);
     }
 
     /* Tell the caller to do a break */

--- a/ntoskrnl/kd64/kdtrap.c
+++ b/ntoskrnl/kd64/kdtrap.c
@@ -144,11 +144,6 @@ KdpTrap(IN PKTRAP_FRAME TrapFrame,
     BOOLEAN Handled;
     NTSTATUS ReturnStatus;
     USHORT ReturnLength;
-    KIRQL OldIrql = DISPATCH_LEVEL;
-
-    /* Raise if we have to. */
-    if (KeGetCurrentIrql() < DISPATCH_LEVEL)
-        OldIrql = KeRaiseIrqlToDpcLevel();
 
     /*
      * Check if we got a STATUS_BREAKPOINT with a SubID for Print, Prompt or
@@ -261,9 +256,6 @@ KdpTrap(IN PKTRAP_FRAME TrapFrame,
                             PreviousMode,
                             SecondChanceException);
     }
-
-    if (OldIrql < DISPATCH_LEVEL)
-        KeLowerIrql(OldIrql);
 
     /* Return TRUE or FALSE to caller */
     return Handled;


### PR DESCRIPTION
## Purpose

Commits 608032bd and 835c3023 improved the usage of IRQL in diverse parts of the KD; however one aspect was overlooked: the IRQL is raised/lowered respectively by `KeFreezeExecution()` and `KeThawExecution()` (that are called respectively by `KdEnterDebugger()` and `KdExitDebugger()`).

This allows removing the `KeRaiseIrqlToDpcLevel()` call that was added in `KdpTrap()`, but should be absent (and is, on Windows), since the IRQL will be adjusted when actually entering/leaving the debugger.

Without this, one would encounter an `IRQL_NOT_GREATER_OR_EQUAL` BSOD in the following case:
1. manually break into kd in order to add a breakpoint into some kernel-mode code (for example, `win32k!NtUserProcessConnect`)
2. start some win32 app.
3. When the function is hit (and kd breaks), I refresh the call stack, then (in windbg) click onto the user-mode function that called that `NtUserProcessConnect` (e.g. the `user32!Init` one) and manually add a breakpoint in that user-mode function, but without having manually switched the debugging context with a windbg command.
4. resume execution (e.g. F5 of g command) and when doing that, the following crash happens:
```
kd> g

*** Fatal System Error: 0x00000009
                       (0x805E3410,0x00000000,0x00000000,0x00000000)

Break instruction exception - code 80000003 (first chance)

[...]

kd> kp
ChildEBP RetAddr      
f7e618a0 804a4328     nt!RtlpBreakWithStatusInstruction
f7e618d0 804a3406     nt!KiBugCheckDebugBreak(unsigned long StatusCode = 3)+0x38 [D:\reactos\ntoskrnl\ke\bug.c @ 501]
f7e61c98 804a2cb0     nt!KeBugCheckWithTf(unsigned long BugCheckCode = 9, unsigned long BugCheckParameter1 = 0x805e3410, unsigned long BugCheckParameter2 = 0, unsigned long BugCheckParameter3 = 0, unsigned long BugCheckParameter4 = 0, struct _KTRAP_FRAME * TrapFrame = 0x00000000)+0x6b6 [D:\reactos\ntoskrnl\ke\bug.c @ 1071]
f7e61cb8 804acd9a     nt!KeBugCheckEx(unsigned long BugCheckCode = 9, unsigned long BugCheckParameter1 = 0x805e3410, unsigned long BugCheckParameter2 = 0, unsigned long BugCheckParameter3 = 0, unsigned long BugCheckParameter4 = 0)+0x20 [D:\reactos\ntoskrnl\ke\bug.c @ 1419]
f7e61cdc 8049bf64     nt!KeTryToAcquireSpinLockAtDpcLevel(unsigned long * SpinLock = 0x805e3410)+0x4a [D:\reactos\ntoskrnl\ke\spinlock.c @ 324]
f7e61cf0 8049f039     nt!KdEnterDebugger(struct _KTRAP_FRAME * TrapFrame = 0x00000000, struct _KEXCEPTION_FRAME * ExceptionFrame = 0x00000000)+0x94 [D:\reactos\ntoskrnl\kd64\kdapi.c @ 1897]
f7e61d1c 80551619     nt!KdSetOwedBreakpoints(void)+0x39 [D:\reactos\ntoskrnl\kd64\kdbreak.c @ 116]
f7e61d5c 804036fe     nt!KiTrap0EHandler(struct _KTRAP_FRAME * TrapFrame = 0xf7e61d64)+0x169 [D:\reactos\ntoskrnl\ke\i386\traphdlr.c @ 1382]
f7e61d5c 77a5b0c5 (T) nt!KiTrap0E+0x99
```
When an 0x0E exception happens (and `KiTrap0EHandler` gets called), the original IRQL can be of any value, greater or lower than `DISPATCH_LEVEL`.