### PR TITLE
[NTOS:KE] Move the SList fault check after the MmAccessFault() handling in KiTrap0EHandler().

### DIFF
--- a/ntoskrnl/ke/i386/traphdlr.c
+++ b/ntoskrnl/ke/i386/traphdlr.c
@@ -1362,13 +1362,6 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
                          TrapFrame);
     }
 
-    /* Check for S-List fault */
-    if (KiCheckForSListFault(TrapFrame))
-    {
-        /* Continue execution */
-        KiEoiHelper(TrapFrame);
-    }
-
     /* Call the access fault handler */
     Status = MmAccessFault(TrapFrame->ErrCode,
                            (PVOID)Cr2,
@@ -1379,6 +1372,13 @@ KiTrap0EHandler(IN PKTRAP_FRAME TrapFrame)
         /* Check whether the kernel debugger has owed breakpoints to be inserted */
         KdSetOwedBreakpoints();
         /* We succeeded, return */
+        KiEoiHelper(TrapFrame);
+    }
+
+    /* Check for S-List fault */
+    if (KiCheckForSListFault(TrapFrame))
+    {
+        /* Continue execution */
         KiEoiHelper(TrapFrame);
     }
 


### PR DESCRIPTION
- SList faults are much less common than regular access faults.

- Breakpoint handling in SList fault handlers could be applied first
  (via the owed BPs) before handling the SList faults??
  (WIP -- under question...)
