### PR TITLE
[COMMCTL32] Fix height from object returned by GetObjectW when asked …

### DIFF
--- a/dll/win32/comctl32/static.c
+++ b/dll/win32/comctl32/static.c
@@ -103,15 +103,6 @@ static BOOL get_icon_size( HICON handle, SIZE *size )
     {
         size->cx = bmp.bmWidth;
         size->cy = bmp.bmHeight;
-#ifdef __REACTOS__
-        /*
-            If this structure defines a black and white icon, this bitmask is formatted
-            so that the upper half is the icon AND bitmask and the lower half is
-            the icon XOR bitmask.
-        */
-        if (!info.hbmColor)
-            size->cy /= 2;
-#endif
     }
 
     DeleteObject(info.hbmMask);

--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -704,12 +704,15 @@ NtGdiSetBitmapDimension(
 
 /*  Internal Functions  */
 
+PCURICON_OBJECT getCurrentIcon();
+
 HBITMAP
 FASTCALL
 BITMAP_CopyBitmap(HBITMAP hBitmap)
 {
     HBITMAP hbmNew;
     SURFACE *psurfSrc, *psurfNew;
+    LONG bmRealHeight;
 
     /* Fail, if no source bitmap is given */
     if (hBitmap == NULL) return 0;
@@ -721,9 +724,19 @@ BITMAP_CopyBitmap(HBITMAP hBitmap)
         return 0;
     }
 
+    bmRealHeight = psurfSrc->SurfObj.sizlBitmap.cy;
+    PCURICON_OBJECT curIcon = getCurrentIcon();
+
+
+    if (curIcon && curIcon->hbmColor == NULL)
+    {
+        if (psurfSrc->SurfObj.sizlBitmap.cy == (curIcon->cy * 2))
+            bmRealHeight = curIcon->cy;
+    }
+
     /* Allocate a new bitmap with the same dimensions as the source bmp */
     hbmNew = GreCreateBitmapEx(psurfSrc->SurfObj.sizlBitmap.cx,
-                               psurfSrc->SurfObj.sizlBitmap.cy,
+                               bmRealHeight,
                                abs(psurfSrc->SurfObj.lDelta),
                                psurfSrc->SurfObj.iBitmapFormat,
                                psurfSrc->SurfObj.fjBitmap & BMF_TOPDOWN,

--- a/win32ss/user/ntuser/cursoricon.c
+++ b/win32ss/user/ntuser/cursoricon.c
@@ -25,7 +25,9 @@ DBG_DEFAULT_CHANNEL(UserIcon);
 SYSTEM_CURSORINFO gSysCursorInfo;
 
 PCURICON_OBJECT gcurFirst = NULL; // After all is done, this should be WINLOGO!
+PCURICON_OBJECT FrameCurIcon = NULL;
 
+PCURICON_OBJECT getCurrentIcon(){return FrameCurIcon;}
 //
 //   System Cursors
 //
@@ -443,7 +445,7 @@ NtUserGetIconInfo(
     /* Give back the icon information */
     if (IconInfo)
     {
-        PCURICON_OBJECT FrameCurIcon = CurIcon;
+        FrameCurIcon = CurIcon;
         if (CurIcon->CURSORF_flags & CURSORF_ACON)
         {
             /* Get information from first frame. */


### PR DESCRIPTION
[COMMCTL32] Fix height from object returned by GetObjectW when asked for a cursor bitmap CORE-17752



On Windows, we found that after loading a cursor with
HCURSOR hCursor = LoadImage(NULL, MAKEINTRESOURCE(OCR_NORMAL), IMAGE_CURSOR, 0, 0, LR_DEFAULTSIZE|LR_SHARED)
and get the bitmap associated with GetIconInfo(hCursor, &info) and GetObjectW(info.bmMask, sizeof(bmp), &bmp),
this returns a bitmap with 32x32 1bpp;

On ReactOS return a bitmap with 32x64 1bpp.
