### PR TITLE
Update en-GB.rc

### DIFF
--- a/dll/cpl/desk/lang/en-GB.rc
+++ b/dll/cpl/desk/lang/en-GB.rc
@@ -5,7 +5,7 @@ CAPTION "Themes"
 STYLE DS_SHELLFONT | WS_CHILD | WS_DISABLED | WS_CAPTION
 FONT 8, "MS Shell Dlg"
 BEGIN
-    LTEXT "A theme is a background plus a set of sounds, icons, and other elements to help you personalize your computer with one click.", IDC_STATIC, 5, 5, 235, 30
+    LTEXT "A theme is a background plus a set of sounds, icons, and other elements to help you personalise your computer with one click.", IDC_STATIC, 5, 5, 235, 30
     LTEXT "Theme:", IDC_STATIC, 5, 42, 55, 10
     COMBOBOX IDC_THEMES_COMBOBOX, 5, 52, 160, 300, CBS_HASSTRINGS | CBS_AUTOHSCROLL | CBS_DROPDOWN | WS_VSCROLL | WS_TABSTOP
     PUSHBUTTON "Save &As...", IDC_THEMES_SAVE_AS, 170, 52, 70, 14


### PR DESCRIPTION
Personalize should be personalise for British.

## Purpose

The Resource String "Personalize" still shows in American English at Theme Tab, While Windows 8 language was added British English, this should be able to change the text are appearing one American English text.

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- The text shows "Personalize" in American English.
- The text should be "Personalise" in British English.
