### PR TITLE
[SYSSETUP] Add en-GB.rc

### DIFF
--- a/dll/win32/syssetup/lang/bg-BG.rc
+++ b/dll/win32/syssetup/lang/bg-BG.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/cs-CZ.rc
+++ b/dll/win32/syssetup/lang/cs-CZ.rc
@@ -250,7 +250,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/da-DK.rc
+++ b/dll/win32/syssetup/lang/da-DK.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/el-GR.rc
+++ b/dll/win32/syssetup/lang/el-GR.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/en-GB.rc
+++ b/dll/win32/syssetup/lang/en-GB.rc
@@ -1,22 +1,3 @@
-/*
- * Copyright (C) 2004 Filip Navara
- * Copyright (C) 2004 Eric Kohl
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
-
 LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
 
 IDD_WELCOMEPAGE DIALOGEX 0, 0, 317, 193

--- a/dll/win32/syssetup/lang/en-GB.rc
+++ b/dll/win32/syssetup/lang/en-GB.rc
@@ -1,0 +1,273 @@
+/*
+ * Copyright (C) 2004 Filip Navara
+ * Copyright (C) 2004 Eric Kohl
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+LANGUAGE LANG_ENGLISH, SUBLANG_ENGLISH_UK
+
+IDD_WELCOMEPAGE DIALOGEX 0, 0, 317, 193
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT "Welcome to the ReactOS Setup Wizard.", IDC_WELCOMETITLE, 115, 8, 195, 24
+    LTEXT "This wizard installs ReactOS on your computer. The wizard needs to gather some information about you and your computer to set up ReactOS properly.", IDC_STATIC, 115, 40, 195, 100
+    LTEXT "Click Next to continue with Setup.", IDC_STATIC, 115, 169, 195, 17
+END
+
+IDD_ACKPAGE DIALOGEX 0, 0, 317, 145
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg", 0, 0, 0x0
+BEGIN
+    LTEXT "The ReactOS developers would like to acknowledge the following Open Source projects, (parts of) which were used to create ReactOS:", IDC_STATIC, 15, 7, 286, 19
+    LISTBOX IDC_PROJECTS, 15, 30, 286, 75, LBS_NOSEL | LBS_HASSTRINGS | LBS_NOINTEGRALHEIGHT | WS_VSCROLL
+    LTEXT "ReactOS is licensed under the GPL, so if you want to reuse or redistribute (parts of) it you must respect the GPL.", IDC_STATIC, 15, 110, 227, 19
+    PUSHBUTTON "&View GPL...", IDC_VIEWGPL, 251, 110, 50, 19
+    LTEXT "Click Next to continue with Setup.", IDC_STATIC, 15, 136, 195, 17
+END
+
+IDD_PRODUCT DIALOGEX 0, 0, 317, 143
+CAPTION "ReactOS Setup"
+STYLE DS_MODALFRAME | DS_SHELLFONT | WS_POPUPWINDOW | WS_CAPTION | WS_VISIBLE
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON "", IDC_PRODUCT_ICON, 5, 5, 20, 20
+    LTEXT "Please choose a product option:", IDC_STATIC, 35, 7, 230, 12
+    LTEXT "Product &Options:", IDC_STATIC, 5, 32, 85, 10
+    COMBOBOX IDC_PRODUCT_OPTIONS, 95, 30, 170, 300, CBS_HASSTRINGS | CBS_AUTOHSCROLL | CBS_DROPDOWNLIST | WS_VSCROLL | WS_TABSTOP
+    GROUPBOX "Product Information", IDC_STATIC, 5, 50, 305, 85
+    LTEXT "Description:", IDC_STATIC, 20, 65, 70, 10
+    EDITTEXT IDC_PRODUCT_DESCRIPTION, 95, 65, 205, 60, ES_READONLY | ES_AUTOVSCROLL | ES_MULTILINE | WS_VSCROLL
+END
+
+IDD_OWNERPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON IDI_ICON2, IDC_STATIC, 21, 7, 20, 20
+    LTEXT "Type your full name and the name of your company or organisation.", IDC_STATIC, 54, 7, 242, 21
+    LTEXT "Na&me:", IDC_STATIC, 54, 37, 44, 8
+    EDITTEXT IDC_OWNERNAME, 132, 35, 163, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL
+    LTEXT "&Organisation:", IDC_STATIC, 54, 57, 44, 8
+    EDITTEXT IDC_OWNERORGANIZATION, 132, 55, 163, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL
+END
+
+IDD_COMPUTERPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON IDI_ICON1, IDC_STATIC, 21, 7, 20, 20
+    LTEXT "Type a name for your computer that is 15 characters or less. If you are on a network, your computer name must be unique.", IDC_STATIC, 54, 7, 250, 24
+    LTEXT "&Computer Name:", IDC_STATIC, 54, 38, 75, 8
+    EDITTEXT IDC_COMPUTERNAME, 165, 35, 148, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL | ES_UPPERCASE
+    ICON IDI_ICON5, IDC_STATIC, 21, 57, 20, 20
+    LTEXT "Setup will create a user account on your computer called Administrator. You can use this account if you need full access to your computer.", IDC_STATIC, 54, 57, 250, 25
+    LTEXT "Type an Administrator Password that is 127 characters or less.", IDC_STATIC, 54, 87, 250, 8
+    LTEXT "&Administrator Password:", IDC_STATIC, 54, 104, 105, 8
+    EDITTEXT IDC_ADMINPASSWORD1, 165, 101, 148, 14, WS_VISIBLE | WS_TABSTOP | ES_PASSWORD
+    LTEXT "C&onfirm Password:", IDC_STATIC, 54, 123, 105, 8
+    EDITTEXT IDC_ADMINPASSWORD2, 165, 120, 148, 14, WS_VISIBLE | WS_TABSTOP | ES_PASSWORD
+END
+
+IDD_LOCALEPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON IDI_ICON4, IDC_STATIC, 21, 7, 20, 20
+    LTEXT "The system locale should match the language of the applications you want to use. The user locale controls how numbers, currencies, and dates appear.", IDC_STATIC, 53, 7, 253, 20
+    LTEXT "", IDC_LOCALETEXT, 53, 29, 250, 16
+    LTEXT "To change system or user locale settings, click Customise.", IDC_STATIC, 53, 60, 196, 8
+    PUSHBUTTON "&Customise...", IDC_CUSTOMLOCALE, 250, 57, 50, 14
+    LTEXT "The keyboard layout controls the characters that appear when you type.", IDC_STATIC, 53, 86, 253, 8
+    LTEXT "", IDC_LAYOUTTEXT, 53, 100, 250, 16
+    LTEXT "To change the keyboard layout, click Customise.", IDC_STATIC, 53, 126, 184, 8
+    PUSHBUTTON "C&ustomise...", IDC_CUSTOMLAYOUT, 250, 122, 50, 14
+END
+
+IDD_DATETIMEPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    ICON IDI_ICON3, IDC_STATIC, 21, 10, 20, 20
+    LTEXT "Date and Time:", IDC_STATIC, 53, 7, 253, 8
+    CONTROL "", IDC_DATEPICKER, "SysDateTimePick32", DTS_LONGDATEFORMAT | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 53, 17, 137, 14
+    CONTROL "", IDC_TIMEPICKER, "SysDateTimePick32", DTS_TIMEFORMAT | WS_CHILD | WS_VISIBLE | WS_TABSTOP, 200, 17, 54, 14
+    LTEXT "Timezone:", IDC_STATIC, 53, 42, 253, 8
+    COMBOBOX IDC_TIMEZONELIST, 53, 52, 201, 93, CBS_DROPDOWNLIST | CBS_NOINTEGRALHEIGHT | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL
+    AUTOCHECKBOX "Automatically adjust clock for &daylight saving changes", IDC_AUTODAYLIGHT, 53, 124, 201, 10
+END
+
+IDD_THEMEPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    CONTROL "", IDC_THEMEPICKER, "SysListView32", LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_ALIGNLEFT | WS_TABSTOP, 18, 8, 288, 130
+END
+
+IDD_PROCESSPAGE DIALOGEX 0, 0, 317, 143
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT "", IDC_ACTIVITY, 53, 7, 253, 20
+    LTEXT "", IDC_ITEM, 53, 29, 253, 20
+    CONTROL "", IDC_PROCESSPROGRESS, "msctls_progress32", PBS_SMOOTH | WS_CHILD | WS_VISIBLE | WS_BORDER, 53, 70, 253, 8
+END
+
+IDD_FINISHPAGE DIALOGEX 0, 0, 317, 193
+STYLE DS_SHELLFONT | DS_MODALFRAME | WS_POPUP | WS_VISIBLE | WS_CAPTION | WS_SYSMENU
+CAPTION "Completing ReactOS Setup"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    LTEXT "Completing the ReactOS Setup Wizard", IDC_FINISHTITLE, 115, 8, 195, 24
+    LTEXT "You have successfully completed ReactOS Setup.\n\nWhen you click Finish, your computer will restart.", IDC_STATIC, 115, 40, 195, 100
+    CONTROL "", IDC_RESTART_PROGRESS, "msctls_progress32", PBS_SMOOTH | WS_CHILD | WS_VISIBLE | WS_BORDER, 115, 138, 188, 12
+    LTEXT "If there is a CD in a drive, remove it. Then, to restart your computer, click Finish.", IDC_STATIC, 115, 169, 195, 17
+END
+
+IDD_GPL DIALOGEX 0, 0, 333, 230
+STYLE DS_SHELLFONT | DS_CENTER | DS_MODALFRAME | WS_POPUP | WS_CAPTION | WS_SYSMENU
+CAPTION "GNU General Public License"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    EDITTEXT IDC_GPL_TEXT, 7, 7, 319, 190, ES_MULTILINE | ES_AUTOHSCROLL | ES_READONLY | WS_VSCROLL
+    DEFPUSHBUTTON "OK", IDOK, 141, 209, 50, 14
+END
+
+IDD_STATUSWINDOW_DLG DIALOGEX 0, 0, 275, 78
+STYLE NOT WS_VISIBLE | DS_CENTER | DS_MODALFRAME | DS_SHELLFONT | WS_BORDER | WS_CAPTION | WS_DLGFRAME | WS_POPUP
+CAPTION "Please wait..."
+FONT 8, "MS Shell Dlg", 400, 0, 1
+BEGIN
+    CONTROL IDB_REACTOS, IDC_ROSLOGO, "Static", SS_BITMAP, 0, 0, 275, 54
+    CONTROL "", IDC_BAR, "Static", SS_OWNERDRAW, 0, 44, 275, 4
+    LTEXT "", IDC_STATUSLABEL, 7, 59, 235, 12, SS_WORDELLIPSIS
+END
+
+IDD_PS2MOUSEPROPERTIES DIALOGEX 0, 0, 252, 218
+STYLE WS_CHILD | WS_VISIBLE | WS_CAPTION
+CAPTION "Advanced Settings"
+FONT 8, "MS Shell Dlg"
+BEGIN
+    GROUPBOX "", IDC_PS2STATIC, 5, 20, 242, 110
+    RTEXT "&Sample Rate:", -1, 27, 35, 90, 8
+    LTEXT "reports per second", -1, 169, 35, 76, 8
+    COMBOBOX IDC_PS2MOUSESAMPLERATE, 124, 33, 42, 41, CBS_DROPDOWNLIST | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL
+    RTEXT "&Wheel Detection:", -1, 27, 55, 90, 8
+    COMBOBOX IDC_PS2MOUSEWHEEL, 124, 53, 95, 46, CBS_DROPDOWNLIST | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_VSCROLL
+    RTEXT "&Input buffer length:", -1, 27, 75, 90, 8
+    LTEXT "packets", -1, 169, 75, 26, 8
+    EDITTEXT IDC_PS2MOUSEINPUTLEN, 124, 72, 40, 14, ES_LEFT | ES_AUTOHSCROLL | ES_READONLY | ES_NUMBER | WS_CHILD | WS_VISIBLE | WS_TABSTOP | WS_BORDER
+    CONTROL "", IDC_PS2MOUSEINPUTUPDN, "msctls_updown32", UDS_SETBUDDYINT | UDS_ALIGNRIGHT | UDS_AUTOBUDDY | UDS_ARROWKEYS | WS_CHILD | WS_VISIBLE, 168, 70, 10, 14
+    AUTOCHECKBOX "&Fast Initialisation", IDC_PS2MOUSEFASTINIT, 124, 97, 90, 10
+    PUSHBUTTON "&Defaults", IDC_PS2MOUSEDEFAULTS, 195, 188, 50, 14
+END
+
+STRINGTABLE
+BEGIN
+    IDS_ACKTITLE "Acknowledgements"
+    IDS_ACKSUBTITLE "The shoulders ReactOS stands on and license information"
+    IDS_OWNERTITLE "Personalise your Software"
+    IDS_OWNERSUBTITLE "Setup uses this information about yourself to personalise ReactOS."
+    IDS_COMPUTERTITLE "Computer Name and Administrator Password"
+    IDS_COMPUTERSUBTITLE "You must provide a name and an Administrator Password for your computer."
+    IDS_LOCALETITLE "Regional settings"
+    IDS_LOCALESUBTITLE "You can customise ReactOS for different regions and languages."
+    IDS_DATETIMETITLE "Date and Time"
+    IDS_DATETIMESUBTITLE "Set the correct date and time for your computer."
+    IDS_PROCESSTITLE "Registering Components"
+    IDS_PROCESSSUBTITLE "Please wait..."
+    IDS_THEMESELECTIONTITLE "Appearance"
+    IDS_THEMESELECTIONSUBTITLE "Select the theme you prefer."
+
+END
+
+STRINGTABLE
+BEGIN
+    IDS_REACTOS_SETUP "ReactOS Setup"
+    IDS_UNKNOWN_ERROR "Unknown error"
+    IDS_REGISTERING_COMPONENTS "Registering components..."
+    IDS_LOADLIBRARY_FAILED "LoadLibrary failed: "
+    IDS_GETPROCADDR_FAILED "GetProcAddr failed: "
+    IDS_REGSVR_FAILED "DllRegisterServer failed: "
+    IDS_DLLINSTALL_FAILED "DllInstall failed: "
+    IDS_TIMEOUT "Timeout during registration"
+    IDS_REASON_UNKNOWN ""
+    /*
+     * ATTENTION:
+     *   If you translate the administrator account name, keep IDS_ADMINISTRATOR_NAME and
+     *   samsrv.dll:IDS_USER_ADMINISTRATOR_NAME synchronized.
+     *   Also check the IDD_COMPUTERPAGE dialog.
+     */
+    IDS_ADMINISTRATOR_NAME "Administrator"
+    IDS_MACHINE_OWNER_NAME "Owner"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_WZD_NAME "Setup cannot continue until you enter your name."
+    IDS_WZD_SETCOMPUTERNAME "Setup failed to set the computer name."
+    IDS_WZD_COMPUTERNAME "Setup cannot continue until you enter the name of your computer."
+    IDS_WZD_PASSWORDEMPTY "You must enter a password !"
+    IDS_WZD_PASSWORDMATCH "The passwords you entered do not match. Please enter the desired password again."
+    IDS_WZD_PASSWORDCHAR "The password you entered contains invalid characters. Please enter a cleaned password."
+    IDS_WZD_LOCALTIME "Setup was unable to set the local time."
+END
+
+STRINGTABLE
+BEGIN
+    IDS_STATUS_INSTALL_DEV "Installing devices..."
+END
+
+/* ATTENTION: Synchronize these strings with dll/win32/shell32/lang */
+STRINGTABLE
+BEGIN
+    IDS_PROGRAMFILES "%SystemDrive%\\Program Files"
+    IDS_COMMONFILES "Common Files"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_DETECTIONDISABLED "Detection disabled"
+    IDS_LOOKFORWHEEL "Look for wheel"
+    IDS_ASSUMEPRESENT "Assume wheel is present"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_CLASSIC "Classic"
+    IDS_LAUTUS "Lautus"
+    IDS_LUNAR "Lunar"
+    IDS_MIZU "Mizu"
+END
+
+STRINGTABLE
+BEGIN
+    IDS_PRODUCTTITLE "Product Options"
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSERVERNAME "ReactOS Server"
+    IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
+    IDS_PRODUCTSERVERINFO "The system will be recognised as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."
+    IDS_PRODUCTWORKSTATIONINFO "The system will be recognised as a workstation. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are in ""My Documents""."
+    IDS_DEFAULT "(Default)"
+END

--- a/dll/win32/syssetup/lang/en-US.rc
+++ b/dll/win32/syssetup/lang/en-US.rc
@@ -264,7 +264,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/et-EE.rc
+++ b/dll/win32/syssetup/lang/et-EE.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/fi-FI.rc
+++ b/dll/win32/syssetup/lang/fi-FI.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/he-IL.rc
+++ b/dll/win32/syssetup/lang/he-IL.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/hi-IN.rc
+++ b/dll/win32/syssetup/lang/hi-IN.rc
@@ -252,7 +252,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/it-IT.rc
+++ b/dll/win32/syssetup/lang/it-IT.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/lt-LT.rc
+++ b/dll/win32/syssetup/lang/lt-LT.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/nl-NL.rc
+++ b/dll/win32/syssetup/lang/nl-NL.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/no-NO.rc
+++ b/dll/win32/syssetup/lang/no-NO.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/pt-BR.rc
+++ b/dll/win32/syssetup/lang/pt-BR.rc
@@ -244,7 +244,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/ro-RO.rc
+++ b/dll/win32/syssetup/lang/ro-RO.rc
@@ -253,7 +253,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/sk-SK.rc
+++ b/dll/win32/syssetup/lang/sk-SK.rc
@@ -250,7 +250,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/sq-AL.rc
+++ b/dll/win32/syssetup/lang/sq-AL.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/sv-SE.rc
+++ b/dll/win32/syssetup/lang/sv-SE.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/th-TH.rc
+++ b/dll/win32/syssetup/lang/th-TH.rc
@@ -263,7 +263,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/zh-CN.rc
+++ b/dll/win32/syssetup/lang/zh-CN.rc
@@ -249,7 +249,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "Product Options"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/lang/zh-TW.rc
+++ b/dll/win32/syssetup/lang/zh-TW.rc
@@ -274,7 +274,7 @@ END
 STRINGTABLE
 BEGIN
     IDS_PRODUCTTITLE "產品選擇"
-    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behaviour of the system."
+    IDS_PRODUCTSUBTITLE "You can choose a product option that affects the behavior of the system."
     IDS_PRODUCTSERVERNAME "ReactOS Server"
     IDS_PRODUCTWORKSTATIONNAME "ReactOS Workstation"
     IDS_PRODUCTSERVERINFO "The system will be recognized as a server. Private folders ""My Pictures"", ""My Videos"" and ""My Music"" are independent from ""My Documents""."

--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -62,6 +62,9 @@ IDR_GPL RT_TEXT "COPYING"
 #ifdef LANGUAGE_EL_GR
     #include "lang/el-GR.rc"
 #endif
+#ifdef LANGUAGE_EN_GB
+    #include "lang/en-GB.rc"
+#endif
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
 #endif


### PR DESCRIPTION
The British Language wasn't included here. However, i have corrected some texts that are still American English.

## Purpose

The British English resource wasn't exist while during Setup. however, There might include various American English text including the word "Customize", So i have decided add these on it.

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- The file en-GB.rc isn't exist on SYSSETUP Language Resource folder.
