### PR TITLE
[IMM32] Define Imm32HeapFree macro and use it

### DIFF
--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -1228,10 +1228,8 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
     ret = CandidateListWideToAnsi(pCL, lpDst, dwBufLen, CP_ACP);
 
 Quit:
-    if (pszSrcW)
-        Imm32HeapFree(pszSrcW);
-    if (pCL)
-        Imm32HeapFree(pCL);
+    Imm32HeapFree(pszSrcW);
+    Imm32HeapFree(pCL);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1285,10 +1283,8 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
     ret = CandidateListAnsiToWide(pCL, lpDst, dwBufLen, CP_ACP);
 
 Quit:
-    if (pszSrcA)
-        Imm32HeapFree(pszSrcA);
-    if (pCL)
-        Imm32HeapFree(pCL);
+    Imm32HeapFree(pszSrcA);
+    Imm32HeapFree(pCL);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1429,10 +1425,8 @@ DoIt:
     SendMessageW(hWnd, WM_IME_SYSTEM, 0x1A, 0);
 
 Quit:
-    if (RegWordW.lpReading)
-        Imm32HeapFree(RegWordW.lpReading);
-    if (RegWordW.lpWord)
-        Imm32HeapFree(RegWordW.lpWord);
+    Imm32HeapFree(RegWordW.lpReading);
+    Imm32HeapFree(RegWordW.lpWord);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1488,10 +1482,8 @@ DoIt:
     SendMessageW(hWnd, WM_IME_SYSTEM, 0x1A, 0);
 
 Quit:
-    if (RegWordA.lpReading)
-        Imm32HeapFree(RegWordA.lpReading);
-    if (RegWordA.lpWord)
-        Imm32HeapFree(RegWordA.lpWord);
+    Imm32HeapFree(RegWordA.lpReading);
+    Imm32HeapFree(RegWordA.lpWord);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -221,7 +221,7 @@ PIMEDPI APIENTRY Ime32LoadImeDpi(HKL hKL, BOOL bLock)
 
     if (!Imm32LoadImeInfo(&ImeInfoEx, pImeDpiNew))
     {
-        HeapFree(g_hImm32Heap, 0, pImeDpiNew);
+        Imm32HeapFree(pImeDpiNew);
         return FALSE;
     }
 
@@ -236,7 +236,7 @@ PIMEDPI APIENTRY Ime32LoadImeDpi(HKL hKL, BOOL bLock)
         RtlLeaveCriticalSection(&g_csImeDpi);
 
         Imm32FreeImeDpi(pImeDpiNew, FALSE);
-        HeapFree(g_hImm32Heap, 0, pImeDpiNew);
+        Imm32HeapFree(pImeDpiNew);
         return pImeDpiFound;
     }
     else
@@ -477,7 +477,7 @@ VOID WINAPI ImmUnlockImeDpi(PIMEDPI pImeDpi)
     }
 
     Imm32FreeImeDpi(pImeDpi, TRUE);
-    HeapFree(g_hImm32Heap, 0, pImeDpi);
+    Imm32HeapFree(pImeDpi);
 
     RtlLeaveCriticalSection(&g_csImeDpi);
 }
@@ -1229,9 +1229,9 @@ ImmGetConversionListA(HKL hKL, HIMC hIMC, LPCSTR pSrc, LPCANDIDATELIST lpDst,
 
 Quit:
     if (pszSrcW)
-        HeapFree(g_hImm32Heap, 0, pszSrcW);
+        Imm32HeapFree(pszSrcW);
     if (pCL)
-        HeapFree(g_hImm32Heap, 0, pCL);
+        Imm32HeapFree(pCL);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1286,9 +1286,9 @@ ImmGetConversionListW(HKL hKL, HIMC hIMC, LPCWSTR pSrc, LPCANDIDATELIST lpDst,
 
 Quit:
     if (pszSrcA)
-        HeapFree(g_hImm32Heap, 0, pszSrcA);
+        Imm32HeapFree(pszSrcA);
     if (pCL)
-        HeapFree(g_hImm32Heap, 0, pCL);
+        Imm32HeapFree(pCL);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1430,9 +1430,9 @@ DoIt:
 
 Quit:
     if (RegWordW.lpReading)
-        HeapFree(g_hImm32Heap, 0, RegWordW.lpReading);
+        Imm32HeapFree(RegWordW.lpReading);
     if (RegWordW.lpWord)
-        HeapFree(g_hImm32Heap, 0, RegWordW.lpWord);
+        Imm32HeapFree(RegWordW.lpWord);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -1489,9 +1489,9 @@ DoIt:
 
 Quit:
     if (RegWordA.lpReading)
-        HeapFree(g_hImm32Heap, 0, RegWordA.lpReading);
+        Imm32HeapFree(RegWordA.lpReading);
     if (RegWordA.lpWord)
-        HeapFree(g_hImm32Heap, 0, RegWordA.lpWord);
+        Imm32HeapFree(RegWordA.lpWord);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -321,7 +321,7 @@ HIMC WINAPI ImmCreateContext(void)
     hIMC = NtUserCreateInputContext(pClientImc);
     if (hIMC == NULL)
     {
-        HeapFree(g_hImm32Heap, 0, pClientImc);
+        Imm32HeapFree(pClientImc);
         return NULL;
     }
 
@@ -464,7 +464,7 @@ PCLIENTIMC WINAPI ImmLockClientImc(HIMC hImc)
 
         if (!NtUserUpdateInputContext(hImc, 0, pClientImc))
         {
-            HeapFree(g_hImm32Heap, 0, pClientImc);
+            Imm32HeapFree(pClientImc);
             return NULL;
         }
 
@@ -499,7 +499,7 @@ VOID WINAPI ImmUnlockClientImc(PCLIENTIMC pClientImc)
         LocalFree(hImc);
 
     RtlDeleteCriticalSection(&pClientImc->cs);
-    HeapFree(g_hImm32Heap, 0, pClientImc);
+    Imm32HeapFree(pClientImc);
 }
 
 static HIMC APIENTRY Imm32GetContextEx(HWND hWnd, DWORD dwContextFlags)
@@ -868,9 +868,9 @@ HKL WINAPI ImmInstallIMEA(LPCSTR lpszIMEFileName, LPCSTR lpszLayoutText)
 
 Quit:
     if (pszFileNameW)
-        HeapFree(g_hImm32Heap, 0, pszFileNameW);
+        Imm32HeapFree(pszFileNameW);
     if (pszLayoutTextW)
-        HeapFree(g_hImm32Heap, 0, pszLayoutTextW);
+        Imm32HeapFree(pszLayoutTextW);
     return hKL;
 }
 
@@ -1183,7 +1183,7 @@ BOOL WINAPI ImmEnumInputContext(DWORD dwThreadId, IMCENUMPROC lpfn, LPARAM lPara
             break;
     }
 
-    HeapFree(g_hImm32Heap, 0, phList);
+    Imm32HeapFree(phList);
     return ret;
 }
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -867,10 +867,8 @@ HKL WINAPI ImmInstallIMEA(LPCSTR lpszIMEFileName, LPCSTR lpszLayoutText)
     hKL = ImmInstallIMEW(pszFileNameW, pszLayoutTextW);
 
 Quit:
-    if (pszFileNameW)
-        Imm32HeapFree(pszFileNameW);
-    if (pszLayoutTextW)
-        Imm32HeapFree(pszLayoutTextW);
+    Imm32HeapFree(pszFileNameW);
+    Imm32HeapFree(pszLayoutTextW);
     return hKL;
 }
 

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -497,8 +497,7 @@ BOOL WINAPI ImmGenerateMessage(HIMC hIMC)
     }
 
 Quit:
-    if (pTrans)
-        Imm32HeapFree(pTrans);
+    Imm32HeapFree(pTrans);
     if (hMsgBuf)
         ImmUnlockIMCC(hMsgBuf);
     pIC->dwNumMsgBuf = 0; /* done */
@@ -557,7 +556,7 @@ Imm32PostMessages(HWND hwnd, HIMC hIMC, DWORD dwCount, LPTRANSMSG lpTransMsg)
     }
 
 #ifdef IMM_NT3_SUPPORT
-    if (pNewTransMsg && pNewTransMsg != lpTransMsg)
+    if (pNewTransMsg != lpTransMsg)
         Imm32HeapFree(pNewTransMsg);
 #endif
 }
@@ -678,8 +677,7 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
     }
 
 Quit:
-    if (pList)
-        Imm32HeapFree(pList);
+    Imm32HeapFree(pList);
     ImmUnlockImeDpi(pImeDpi);
     ImmUnlockIMC(hIMC);
     ImmReleaseContext(hwnd, hIMC);

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -498,7 +498,7 @@ BOOL WINAPI ImmGenerateMessage(HIMC hIMC)
 
 Quit:
     if (pTrans)
-        HeapFree(g_hImm32Heap, 0, pTrans);
+        Imm32HeapFree(pTrans);
     if (hMsgBuf)
         ImmUnlockIMCC(hMsgBuf);
     pIC->dwNumMsgBuf = 0; /* done */
@@ -558,7 +558,7 @@ Imm32PostMessages(HWND hwnd, HIMC hIMC, DWORD dwCount, LPTRANSMSG lpTransMsg)
 
 #ifdef IMM_NT3_SUPPORT
     if (pNewTransMsg && pNewTransMsg != lpTransMsg)
-        HeapFree(g_hImm32Heap, 0, pNewTransMsg);
+        Imm32HeapFree(pNewTransMsg);
 #endif
 }
 
@@ -679,7 +679,7 @@ BOOL WINAPI ImmTranslateMessage(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lKeyD
 
 Quit:
     if (pList)
-        HeapFree(g_hImm32Heap, 0, pList);
+        Imm32HeapFree(pList);
     ImmUnlockImeDpi(pImeDpi);
     ImmUnlockIMC(hIMC);
     ImmReleaseContext(hwnd, hIMC);

--- a/dll/win32/imm32/nt3.c
+++ b/dll/win32/imm32/nt3.c
@@ -166,7 +166,7 @@ DoDefault:
         }
     }
 
-    HeapFree(g_hImm32Heap, 0, pTempList);
+    Imm32HeapFree(pTempList);
     return ret;
 }
 

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -72,7 +72,10 @@ BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileNam
 VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW);
 VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA);
 PWND FASTCALL ValidateHwndNoErr(HWND hwnd);
+
 LPVOID APIENTRY Imm32HeapAlloc(DWORD dwFlags, DWORD dwBytes);
+#define Imm32HeapFree(lpData) HeapFree(g_hImm32Heap, 0, (lpData))
+
 LPWSTR APIENTRY Imm32WideFromAnsi(LPCSTR pszA);
 LPSTR APIENTRY Imm32AnsiFromWide(LPCWSTR pszW);
 PIMEDPI APIENTRY ImmLockOrLoadImeDpi(HKL hKL);

--- a/dll/win32/imm32/regword.c
+++ b/dll/win32/imm32/regword.c
@@ -52,9 +52,9 @@ Imm32EnumWordProcA2W(LPCSTR pszReadingA, DWORD dwStyle, LPCSTR pszRegisterA, LPV
 
 Quit:
     if (pszReadingW)
-        HeapFree(g_hImm32Heap, 0, pszReadingW);
+        Imm32HeapFree(pszReadingW);
     if (pszRegisterW)
-        HeapFree(g_hImm32Heap, 0, pszRegisterW);
+        Imm32HeapFree(pszRegisterW);
     return ret;
 }
 
@@ -84,9 +84,9 @@ Imm32EnumWordProcW2A(LPCWSTR pszReadingW, DWORD dwStyle, LPCWSTR pszRegisterW, L
 
 Quit:
     if (pszReadingA)
-        HeapFree(g_hImm32Heap, 0, pszReadingA);
+        Imm32HeapFree(pszReadingA);
     if (pszRegisterA)
-        HeapFree(g_hImm32Heap, 0, pszRegisterA);
+        Imm32HeapFree(pszRegisterA);
     return ret;
 }
 
@@ -141,9 +141,9 @@ ImmEnumRegisterWordA(HKL hKL, REGISTERWORDENUMPROCA lpfnEnumProc,
 
 Quit:
     if (pszReadingW)
-        HeapFree(g_hImm32Heap, 0, pszReadingW);
+        Imm32HeapFree(pszReadingW);
     if (pszRegisterW)
-        HeapFree(g_hImm32Heap, 0, pszRegisterW);
+        Imm32HeapFree(pszRegisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -199,9 +199,9 @@ ImmEnumRegisterWordW(HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc,
 
 Quit:
     if (pszReadingA)
-        HeapFree(g_hImm32Heap, 0, pszReadingA);
+        Imm32HeapFree(pszReadingA);
     if (pszRegisterA)
-        HeapFree(g_hImm32Heap, 0, pszRegisterA);
+        Imm32HeapFree(pszRegisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -260,7 +260,7 @@ UINT WINAPI ImmGetRegisterWordStyleA(HKL hKL, UINT nItem, LPSTYLEBUFA lpStyleBuf
 
 Quit:
     if (pNewStylesW)
-        HeapFree(g_hImm32Heap, 0, pNewStylesW);
+        Imm32HeapFree(pNewStylesW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -318,7 +318,7 @@ UINT WINAPI ImmGetRegisterWordStyleW(HKL hKL, UINT nItem, LPSTYLEBUFW lpStyleBuf
 
 Quit:
     if (pNewStylesA)
-        HeapFree(g_hImm32Heap, 0, pNewStylesA);
+        Imm32HeapFree(pNewStylesA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -365,9 +365,9 @@ ImmRegisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszRegister
 
 Quit:
     if (pszReadingW)
-        HeapFree(g_hImm32Heap, 0, pszReadingW);
+        Imm32HeapFree(pszReadingW);
     if (pszRegisterW)
-        HeapFree(g_hImm32Heap, 0, pszRegisterW);
+        Imm32HeapFree(pszRegisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -414,9 +414,9 @@ ImmRegisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszRegist
 
 Quit:
     if (pszReadingA)
-        HeapFree(g_hImm32Heap, 0, pszReadingA);
+        Imm32HeapFree(pszReadingA);
     if (pszRegisterA)
-        HeapFree(g_hImm32Heap, 0, pszRegisterA);
+        Imm32HeapFree(pszRegisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -463,9 +463,9 @@ ImmUnregisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszUnregi
 
 Quit:
     if (pszReadingW)
-        HeapFree(g_hImm32Heap, 0, pszReadingW);
+        Imm32HeapFree(pszReadingW);
     if (pszUnregisterW)
-        HeapFree(g_hImm32Heap, 0, pszUnregisterW);
+        Imm32HeapFree(pszUnregisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -512,9 +512,9 @@ ImmUnregisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszUnre
 
 Quit:
     if (pszReadingA)
-        HeapFree(g_hImm32Heap, 0, pszReadingA);
+        Imm32HeapFree(pszReadingA);
     if (pszUnregisterA)
-        HeapFree(g_hImm32Heap, 0, pszUnregisterA);
+        Imm32HeapFree(pszUnregisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }

--- a/dll/win32/imm32/regword.c
+++ b/dll/win32/imm32/regword.c
@@ -51,10 +51,8 @@ Imm32EnumWordProcA2W(LPCSTR pszReadingA, DWORD dwStyle, LPCSTR pszRegisterA, LPV
     lpEnumData->ret = ret;
 
 Quit:
-    if (pszReadingW)
-        Imm32HeapFree(pszReadingW);
-    if (pszRegisterW)
-        Imm32HeapFree(pszRegisterW);
+    Imm32HeapFree(pszReadingW);
+    Imm32HeapFree(pszRegisterW);
     return ret;
 }
 
@@ -83,10 +81,8 @@ Imm32EnumWordProcW2A(LPCWSTR pszReadingW, DWORD dwStyle, LPCWSTR pszRegisterW, L
     lpEnumData->ret = ret;
 
 Quit:
-    if (pszReadingA)
-        Imm32HeapFree(pszReadingA);
-    if (pszRegisterA)
-        Imm32HeapFree(pszRegisterA);
+    Imm32HeapFree(pszReadingA);
+    Imm32HeapFree(pszRegisterA);
     return ret;
 }
 
@@ -140,10 +136,8 @@ ImmEnumRegisterWordA(HKL hKL, REGISTERWORDENUMPROCA lpfnEnumProc,
     ret = EnumDataW2A.ret;
 
 Quit:
-    if (pszReadingW)
-        Imm32HeapFree(pszReadingW);
-    if (pszRegisterW)
-        Imm32HeapFree(pszRegisterW);
+    Imm32HeapFree(pszReadingW);
+    Imm32HeapFree(pszRegisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -198,10 +192,8 @@ ImmEnumRegisterWordW(HKL hKL, REGISTERWORDENUMPROCW lpfnEnumProc,
     ret = EnumDataA2W.ret;
 
 Quit:
-    if (pszReadingA)
-        Imm32HeapFree(pszReadingA);
-    if (pszRegisterA)
-        Imm32HeapFree(pszRegisterA);
+    Imm32HeapFree(pszReadingA);
+    Imm32HeapFree(pszRegisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -259,8 +251,7 @@ UINT WINAPI ImmGetRegisterWordStyleA(HKL hKL, UINT nItem, LPSTYLEBUFA lpStyleBuf
     }
 
 Quit:
-    if (pNewStylesW)
-        Imm32HeapFree(pNewStylesW);
+    Imm32HeapFree(pNewStylesW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -317,8 +308,7 @@ UINT WINAPI ImmGetRegisterWordStyleW(HKL hKL, UINT nItem, LPSTYLEBUFW lpStyleBuf
     }
 
 Quit:
-    if (pNewStylesA)
-        Imm32HeapFree(pNewStylesA);
+    Imm32HeapFree(pNewStylesA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -364,10 +354,8 @@ ImmRegisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszRegister
     ret = pImeDpi->ImeRegisterWord(pszReadingW, dwStyle, pszRegisterW);
 
 Quit:
-    if (pszReadingW)
-        Imm32HeapFree(pszReadingW);
-    if (pszRegisterW)
-        Imm32HeapFree(pszRegisterW);
+    Imm32HeapFree(pszReadingW);
+    Imm32HeapFree(pszRegisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -413,10 +401,8 @@ ImmRegisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszRegist
     ret = pImeDpi->ImeRegisterWord(pszReadingA, dwStyle, pszRegisterA);
 
 Quit:
-    if (pszReadingA)
-        Imm32HeapFree(pszReadingA);
-    if (pszRegisterA)
-        Imm32HeapFree(pszRegisterA);
+    Imm32HeapFree(pszReadingA);
+    Imm32HeapFree(pszRegisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -462,10 +448,8 @@ ImmUnregisterWordA(HKL hKL, LPCSTR lpszReading, DWORD dwStyle, LPCSTR lpszUnregi
     ret = pImeDpi->ImeUnregisterWord(pszReadingW, dwStyle, pszUnregisterW);
 
 Quit:
-    if (pszReadingW)
-        Imm32HeapFree(pszReadingW);
-    if (pszUnregisterW)
-        Imm32HeapFree(pszUnregisterW);
+    Imm32HeapFree(pszReadingW);
+    Imm32HeapFree(pszUnregisterW);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }
@@ -511,10 +495,8 @@ ImmUnregisterWordW(HKL hKL, LPCWSTR lpszReading, DWORD dwStyle, LPCWSTR lpszUnre
     ret = pImeDpi->ImeUnregisterWord(pszReadingA, dwStyle, pszUnregisterA);
 
 Quit:
-    if (pszReadingA)
-        Imm32HeapFree(pszReadingA);
-    if (pszUnregisterA)
-        Imm32HeapFree(pszUnregisterA);
+    Imm32HeapFree(pszReadingA);
+    Imm32HeapFree(pszUnregisterA);
     ImmUnlockImeDpi(pImeDpi);
     return ret;
 }

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -162,7 +162,7 @@ DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList)
     Status = NtUserBuildHimcList(dwThreadId, dwCount, phNewList, &dwCount);
     while (Status == STATUS_BUFFER_TOO_SMALL)
     {
-        HeapFree(g_hImm32Heap, 0, phNewList);
+        Imm32HeapFree(phNewList);
         if (cRetry++ >= MAX_RETRY)
             return 0;
 
@@ -175,7 +175,7 @@ DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList)
 
     if (NT_ERROR(Status) || !dwCount)
     {
-        HeapFree(g_hImm32Heap, 0, phNewList);
+        Imm32HeapFree(phNewList);
         return 0;
     }
 


### PR DESCRIPTION
## Purpose
Simplify `IMM32` code to improve readability.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Define `Imm32HeapFree` macro in `precomp.h`.
- Use it.
- Omit some NULL checks (thanks to `HeapFree`).
