### PR TITLE
[NTOS:SE] Implement token groups adjusting

### DIFF
--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -10,6 +10,7 @@ list(APPEND SOURCE
     load_notifications.c
     locale.c
     NtAcceptConnectPort.c
+    NtAdjustGroupsToken.c
     NtAdjustPrivilegesToken.c
     NtAllocateVirtualMemory.c
     NtApphelpCacheControl.c

--- a/modules/rostests/apitests/ntdll/NtAdjustGroupsToken.c
+++ b/modules/rostests/apitests/ntdll/NtAdjustGroupsToken.c
@@ -1,0 +1,77 @@
+/*
+ * PROJECT:         ReactOS API tests
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Tests for the NtAdjustGroupsToken API
+ * COPYRIGHT:       Copyright 2021 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include "precomp.h"
+
+static
+HANDLE
+GetProcessToken(
+    _In_ DWORD Access)
+{
+    BOOL Success;
+    HANDLE Token;
+
+    Success = OpenProcessToken(GetCurrentProcess(), Access, &Token);
+    if (!Success)
+    {
+        skip("Failed to open the process' token (error code: %lu)!\n", GetLastError());
+        return NULL;
+    }
+
+    return Token;
+}
+
+START_TEST(NtAdjustGroupsToken)
+{
+    HANDLE TokenHandle;
+    NTSTATUS Status;
+
+    /* Get the token from current process but with incorrect rights */
+    TokenHandle = GetProcessToken(TOKEN_DUPLICATE);
+
+    /* We give an invalid handle */
+    Status = NtAdjustGroupsToken(NULL,
+                                 TRUE,
+                                 NULL,
+                                 0,
+                                 NULL,
+                                 NULL);
+    ok_hex(Status, STATUS_INVALID_HANDLE);
+
+    /* We're trying to adjust the token's groups with wrong rights */
+    Status = NtAdjustGroupsToken(TokenHandle,
+                                 TRUE,
+                                 NULL,
+                                 0,
+                                 NULL,
+                                 NULL);
+    ok_hex(Status, STATUS_ACCESS_DENIED);
+
+    /* Close our handle and open a new one with right access right */
+    CloseHandle(TokenHandle);
+    TokenHandle = GetProcessToken(TOKEN_ADJUST_GROUPS);
+
+    /* We don't give a list of groups to be adjusted in token */
+    Status = NtAdjustGroupsToken(TokenHandle,
+                                 FALSE,
+                                 NULL,
+                                 0,
+                                 NULL,
+                                 NULL);
+    ok_hex(Status, STATUS_INVALID_PARAMETER);
+
+    /* Reset the groups of an access token to default */
+    Status = NtAdjustGroupsToken(TokenHandle,
+                                 TRUE,
+                                 NULL,
+                                 0,
+                                 NULL,
+                                 NULL);
+    ok_hex(Status, STATUS_SUCCESS);
+
+    CloseHandle(TokenHandle);
+}

--- a/modules/rostests/apitests/ntdll/testlist.c
+++ b/modules/rostests/apitests/ntdll/testlist.c
@@ -6,6 +6,7 @@
 extern void func_LdrEnumResources(void);
 extern void func_load_notifications(void);
 extern void func_NtAcceptConnectPort(void);
+extern void func_NtAdjustGroupsToken(void);
 extern void func_NtAdjustPrivilegesToken(void);
 extern void func_NtAllocateVirtualMemory(void);
 extern void func_NtApphelpCacheControl(void);
@@ -92,6 +93,7 @@ const struct test winetest_testlist[] =
     { "LdrEnumResources",               func_LdrEnumResources },
     { "load_notifications",             func_load_notifications },
     { "NtAcceptConnectPort",            func_NtAcceptConnectPort },
+    { "NtAdjustGroupsToken",            func_NtAdjustGroupsToken },
     { "NtAdjustPrivilegesToken",        func_NtAdjustPrivilegesToken },
     { "NtAllocateVirtualMemory",        func_NtAllocateVirtualMemory },
     { "NtApphelpCacheControl",          func_NtApphelpCacheControl },

--- a/sdk/include/ndk/sefuncs.h
+++ b/sdk/include/ndk/sefuncs.h
@@ -150,7 +150,7 @@ NtAdjustGroupsToken(
     _In_opt_ PTOKEN_GROUPS NewState,
     _In_opt_ ULONG BufferLength,
     _Out_writes_bytes_to_opt_(BufferLength, *ReturnLength) PTOKEN_GROUPS PreviousState,
-    _Out_ PULONG ReturnLength);
+    _When_(PreviousState != NULL, _Out_) PULONG ReturnLength);
 
 _Must_inspect_result_
 __kernel_entry


### PR DESCRIPTION
This implements `NtAdjustGroupsToken` syscall which is roughly similar to the privileges counterpart in terms of implementation, with a few exceptions.