### PR TITLE
[IMM32_APITEST] Add himc testcase

### DIFF
--- a/modules/rostests/apitests/imm32/CMakeLists.txt
+++ b/modules/rostests/apitests/imm32/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/wine)
 
 list(APPEND SOURCE
     clientimc.c
+    himc.c
     imcc.c
     ImmIsUIMessage.c
     testlist.c)
@@ -10,5 +11,5 @@ list(APPEND SOURCE
 add_executable(imm32_apitest ${SOURCE})
 target_link_libraries(imm32_apitest wine ${PSEH_LIB})
 set_module_type(imm32_apitest win32cui)
-add_importlibs(imm32_apitest imm32 msvcrt kernel32 ntdll)
+add_importlibs(imm32_apitest imm32 msvcrt user32 kernel32 ntdll)
 add_rostests_file(TARGET imm32_apitest)

--- a/modules/rostests/apitests/imm32/himc.c
+++ b/modules/rostests/apitests/imm32/himc.c
@@ -43,6 +43,29 @@ START_TEST(himc)
     ok_int(hIMC != NULL, TRUE);
     pIC = ImmLockIMC(hIMC);
     ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->hWnd == NULL, TRUE);
+    ok_int(pIC->fOpen, FALSE);
+    ok_int(ImmGetIMCCSize(pIC->hCompStr) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hCandInfo) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hGuideLine) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hPrivate) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hMsgBuf) != 0, TRUE);
+    ImmUnlockIMC(hNewIMC);
+    SetFocus(hwndEdit);
+    pIC = ImmLockIMC(hIMC);
+    ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->hWnd != NULL, TRUE);
+    ok_int(pIC->fOpen, FALSE);
+    ImmUnlockIMC(hNewIMC);
+    SetFocus(NULL);
+    pIC = ImmLockIMC(hIMC);
+    ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->hWnd == hwndEdit, TRUE);
+    ImmUnlockIMC(hNewIMC);
+    ok_int(ImmSetOpenStatus(hIMC, TRUE), TRUE);
+    pIC = ImmLockIMC(hIMC);
+    ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->fOpen, TRUE);
     ImmUnlockIMC(hNewIMC);
     ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
 
@@ -50,6 +73,12 @@ START_TEST(himc)
     ok_int(hIMC != NULL, TRUE);
     pIC = ImmLockIMC(hIMC);
     ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->hWnd == hwndEdit, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hCompStr) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hCandInfo) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hGuideLine) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hPrivate) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hMsgBuf) != 0, TRUE);
     ImmUnlockIMC(hNewIMC);
     ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
 
@@ -58,11 +87,23 @@ START_TEST(himc)
     /* ImmAssociateContext */
     hNewIMC = ImmCreateContext();
     ok_int(hNewIMC != NULL, TRUE);
+    pIC = ImmLockIMC(hNewIMC);
+    ok_int(pIC != NULL, TRUE);
+    ImmUnlockIMC(hNewIMC);
     hOldIMC = ImmAssociateContext(hwndEdit, hNewIMC);
     ok_int(hNewIMC != hOldIMC, TRUE);
     hIMC = ImmGetContext(hwndEdit);
     ok_int(hIMC == hNewIMC, TRUE);
     ok_int(hIMC != hOldIMC, TRUE);
+    pIC = ImmLockIMC(hNewIMC);
+    ok_int(pIC != NULL, TRUE);
+    ok_int(pIC->hWnd == NULL, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hCompStr) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hCandInfo) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hGuideLine) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hPrivate) != 0, TRUE);
+    ok_int(ImmGetIMCCSize(pIC->hMsgBuf) != 0, TRUE);
+    ImmUnlockIMC(hNewIMC);
     ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
     ok_int(ImmDestroyContext(hNewIMC), TRUE);
 

--- a/modules/rostests/apitests/imm32/himc.c
+++ b/modules/rostests/apitests/imm32/himc.c
@@ -54,7 +54,7 @@ START_TEST(himc)
     SetFocus(hwndEdit);
     pIC = ImmLockIMC(hIMC);
     ok_int(pIC != NULL, TRUE);
-    ok_int(pIC->hWnd != NULL, TRUE);
+    ok_int(pIC->hWnd == hwndEdit, TRUE);
     ok_int(pIC->fOpen, FALSE);
     ImmUnlockIMC(hNewIMC);
     SetFocus(NULL);

--- a/modules/rostests/apitests/imm32/himc.c
+++ b/modules/rostests/apitests/imm32/himc.c
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for imm32 HIMC
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "precomp.h"
+
+START_TEST(himc)
+{
+    DWORD style;
+    HWND hwndEdit, hwndStatic;
+    HIMC hNewIMC, hOldIMC, hIMC, hIMC1, hIMC2;
+    LPINPUTCONTEXT pIC;
+
+    /* ImmCreateContext/ImmDestroyContext and ImmLockIMC/ImmUnlockIMC */
+    hNewIMC = ImmCreateContext();
+    ok_int(hNewIMC != NULL, TRUE);
+    pIC = ImmLockIMC(hNewIMC);
+    ok_int(pIC == NULL, TRUE);
+    ImmUnlockIMC(hNewIMC);
+    ok_int(ImmDestroyContext(hNewIMC), TRUE);
+
+    /* ImmGetContext against NULL */
+    hIMC = ImmGetContext(NULL);
+    ok_int(hIMC == NULL, TRUE);
+
+    /* Create EDIT control */
+    style = ES_MULTILINE | ES_LEFT;
+    hwndEdit = CreateWindowW(L"EDIT", NULL, style, 0, 0, 100, 20, NULL, NULL,
+                             GetModuleHandleW(NULL), NULL);
+    ok_int(hwndEdit != NULL, TRUE);
+
+    /* Create STATIC control */
+    style = SS_LEFT;
+    hwndStatic = CreateWindowW(L"STATIC", NULL, style, 0, 30, 100, 20, NULL, NULL,
+                               GetModuleHandleW(NULL), NULL);
+    ok_int(hwndStatic != NULL, TRUE);
+
+    /* ImmGetContext/ImmReleaseContext and ImmLockIMC/ImmUnlockIMC */
+    hIMC1 = hIMC = ImmGetContext(hwndEdit);
+    ok_int(hIMC != NULL, TRUE);
+    pIC = ImmLockIMC(hIMC);
+    ok_int(pIC != NULL, TRUE);
+    ImmUnlockIMC(hNewIMC);
+    ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
+
+    hIMC2 = hIMC = ImmGetContext(hwndStatic);
+    ok_int(hIMC != NULL, TRUE);
+    pIC = ImmLockIMC(hIMC);
+    ok_int(pIC != NULL, TRUE);
+    ImmUnlockIMC(hNewIMC);
+    ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
+
+    ok_int(hIMC1 == hIMC2, TRUE);
+
+    /* ImmAssociateContext */
+    hNewIMC = ImmCreateContext();
+    ok_int(hNewIMC != NULL, TRUE);
+    hOldIMC = ImmAssociateContext(hwndEdit, hNewIMC);
+    ok_int(hNewIMC != hOldIMC, TRUE);
+    hIMC = ImmGetContext(hwndEdit);
+    ok_int(hIMC == hNewIMC, TRUE);
+    ok_int(hIMC != hOldIMC, TRUE);
+    ok_int(ImmReleaseContext(hwndEdit, hIMC), TRUE);
+    ok_int(ImmDestroyContext(hNewIMC), TRUE);
+
+    DestroyWindow(hwndEdit);
+    DestroyWindow(hwndStatic);
+}

--- a/modules/rostests/apitests/imm32/testlist.c
+++ b/modules/rostests/apitests/imm32/testlist.c
@@ -3,12 +3,14 @@
 #include <wine/test.h>
 
 extern void func_clientimc(void);
+extern void func_himc(void);
 extern void func_imcc(void);
 extern void func_ImmIsUIMessage(void);
 
 const struct test winetest_testlist[] =
 {
     { "clientimc", func_clientimc },
+    { "himc", func_himc },
     { "imcc", func_imcc },
     { "ImmIsUIMessage", func_ImmIsUIMessage },
     { 0, 0 }


### PR DESCRIPTION
## Purpose
Provide the way to confirm the IMM32 implementation.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `himc` testcase.

## Screenshots
WinXP (Japanese):
![winxp](https://user-images.githubusercontent.com/2107452/133911863-573a01f2-9e1e-479d-858d-73e7d9401734.png)
Win2k3 (English):
![win2k3](https://user-images.githubusercontent.com/2107452/133911864-e18ebfb8-4992-4d07-9f8a-b6ace85170b2.png)
Win10 (Japanese):
![win10](https://user-images.githubusercontent.com/2107452/133911865-ed44781f-7877-47a2-91d5-a181fe4071f1.png)