### PR TITLE
[IMM32] Rewrite ImmLockIMC

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1104,8 +1104,10 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
 }
 
 /***********************************************************************
-*		ImmLockIMC(IMM32.@)
-*/
+ *		ImmLockIMC(IMM32.@)
+ *
+ * NOTE: This is not ImmLockIMCC. Don't confuse.
+ */
 LPINPUTCONTEXT WINAPI ImmLockIMC(HIMC hIMC)
 {
     TRACE("(%p)\n", hIMC);

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -425,8 +425,6 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
     if (!pIC)
         goto Fail;
 
-    pIC->hCompStr = pIC->hCandInfo = pIC->hGuideLine = pIC->hMsgBuf = pIC->hPrivate = NULL;
-
     pIC->hCompStr = ImmCreateIMCC(sizeof(COMPOSITIONSTRING));
     if (!pIC->hCompStr)
         goto Fail;

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -566,10 +566,10 @@ LPINPUTCONTEXT APIENTRY Imm32LockIMCEx(HIMC hIMC, BOOL fSelect)
         // bInited = Imm32InitContext(hIMC, hKL, fSelect);
         bInited = Imm32InitContext(hIMC, pIC, pClientImc, hKL, fSelect);
         LocalUnlock(pClientImc->hInputContext);
-        pIC = NULL;
 
         if (!bInited)
         {
+            pIC = NULL;
             pClientImc->hInputContext = LocalFree(pClientImc->hInputContext);
             RtlLeaveCriticalSection(&pClientImc->cs);
             goto Quit;

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -426,16 +426,10 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
         goto Fail;
 
     pIC->hCompStr = ImmCreateIMCC(sizeof(COMPOSITIONSTRING));
-    if (!pIC->hCompStr)
-        goto Fail;
     pIC->hCandInfo = ImmCreateIMCC(sizeof(CANDIDATEINFO));
-    if (!pIC->hCandInfo)
-        goto Fail;
     pIC->hGuideLine = ImmCreateIMCC(sizeof(GUIDELINE));
-    if (!pIC->hGuideLine)
-        goto Fail;
     pIC->hMsgBuf = ImmCreateIMCC(sizeof(UINT));
-    if (!pIC->hMsgBuf)
+    if (!pIC->hCompStr || !pIC->hCandInfo || !pIC->hGuideLine || !pIC->hMsgBuf)
         goto Fail;
 
     pCS = ImmLockIMCC(pIC->hCompStr);

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -392,11 +392,11 @@ BOOL APIENTRY Imm32CleanupContext(HIMC hIMC, HKL hKL, BOOL bKeep)
         pClientImc->hKL = NULL;
     }
 
-    ImmDestroyIMCC(pIC->hPrivate);
-    ImmDestroyIMCC(pIC->hMsgBuf);
-    ImmDestroyIMCC(pIC->hGuideLine);
-    ImmDestroyIMCC(pIC->hCandInfo);
-    ImmDestroyIMCC(pIC->hCompStr);
+    pIC->hPrivate = ImmDestroyIMCC(pIC->hPrivate);
+    pIC->hMsgBuf = ImmDestroyIMCC(pIC->hMsgBuf);
+    pIC->hGuideLine = ImmDestroyIMCC(pIC->hGuideLine);
+    pIC->hCandInfo = ImmDestroyIMCC(pIC->hCandInfo);
+    pIC->hCompStr = ImmDestroyIMCC(pIC->hCompStr);
 
     Imm32CleanupContextExtra(pIC);
 
@@ -512,31 +512,11 @@ Fail:
     if (pImeDpi)
         ImmUnlockImeDpi(pImeDpi);
 
-    if (pIC->hCompStr)
-    {
-        ImmDestroyIMCC(pIC->hCompStr);
-        pIC->hCompStr = NULL;
-    }
-    if (pIC->hMsgBuf)
-    {
-        ImmDestroyIMCC(pIC->hMsgBuf);
-        pIC->hMsgBuf = NULL;
-    }
-    if (pIC->hGuideLine)
-    {
-        ImmDestroyIMCC(pIC->hGuideLine);
-        pIC->hGuideLine = NULL;
-    }
-    if (pIC->hCandInfo)
-    {
-        ImmDestroyIMCC(pIC->hCandInfo);
-        pIC->hCandInfo = NULL;
-    }
-    if (pIC->hCompStr)
-    {
-        ImmDestroyIMCC(pIC->hCompStr);
-        pIC->hCompStr = NULL;
-    }
+    pIC->hCompStr = ImmDestroyIMCC(pIC->hCompStr);
+    pIC->hMsgBuf = ImmDestroyIMCC(pIC->hMsgBuf);
+    pIC->hGuideLine = ImmDestroyIMCC(pIC->hGuideLine);
+    pIC->hCandInfo = ImmDestroyIMCC(pIC->hCandInfo);
+    pIC->hCompStr = ImmDestroyIMCC(pIC->hCompStr);
 
     ImmUnlockIMC(hIMC);
     return FALSE;

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -563,6 +563,7 @@ LPINPUTCONTEXT APIENTRY Imm32LockIMCEx(HIMC hIMC, BOOL fSelect)
         }
 
         hKL = GetKeyboardLayout(dwThreadId);
+        // bInited = Imm32InitContext(hIMC, hKL, fSelect);
         bInited = Imm32InitContext(hIMC, pIC, pClientImc, hKL, fSelect);
         LocalUnlock(pClientImc->hInputContext);
         pIC = NULL;

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -547,7 +547,7 @@ LPINPUTCONTEXT APIENTRY Imm32LockIMCEx(HIMC hIMC, BOOL fSelect)
         {
             hKL = GetKeyboardLayout(0);
             Word = LOWORD(hKL);
-            hNewKL = (HANDLE)(DWORD_PTR)MAKELONG(Word, Word);
+            hNewKL = (HKL)(DWORD_PTR)MAKELONG(Word, Word);
 
             pImeDpi = ImmLockOrLoadImeDpi(hNewKL);
             if (pImeDpi)

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -515,12 +515,10 @@ Fail:
     if (pImeDpi)
         ImmUnlockImeDpi(pImeDpi);
 
-    pIC->hCompStr = ImmDestroyIMCC(pIC->hCompStr);
     pIC->hMsgBuf = ImmDestroyIMCC(pIC->hMsgBuf);
     pIC->hGuideLine = ImmDestroyIMCC(pIC->hGuideLine);
     pIC->hCandInfo = ImmDestroyIMCC(pIC->hCandInfo);
     pIC->hCompStr = ImmDestroyIMCC(pIC->hCompStr);
-
     ImmUnlockIMC(hIMC);
     return FALSE;
 }

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -419,6 +419,7 @@ Imm32InitContext(HIMC hIMC, LPINPUTCONTEXT pIC, PCLIENTIMC pClientImc, HKL hKL, 
     LPCOMPOSITIONSTRING pCS;
     LPCANDIDATEINFO pCI;
     LPGUIDELINE pGL;
+    /* NOTE: Windows does recursive call ImmLockIMC here but we don't do so. */
 
     /* Create IC components */
     pIC->hCompStr = ImmCreateIMCC(sizeof(COMPOSITIONSTRING));

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -425,6 +425,7 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
     if (!pIC)
         goto Fail;
 
+    /* Create IC components */
     pIC->hCompStr = ImmCreateIMCC(sizeof(COMPOSITIONSTRING));
     pIC->hCandInfo = ImmCreateIMCC(sizeof(CANDIDATEINFO));
     pIC->hGuideLine = ImmCreateIMCC(sizeof(GUIDELINE));
@@ -432,6 +433,7 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
     if (!pIC->hCompStr || !pIC->hCandInfo || !pIC->hGuideLine || !pIC->hMsgBuf)
         goto Fail;
 
+    /* Initialize IC components */
     pCS = ImmLockIMCC(pIC->hCompStr);
     if (!pCS)
         goto Fail;
@@ -445,6 +447,8 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
     ImmUnlockIMCC(pIC->hCandInfo);
 
     pGL = ImmLockIMCC(pIC->hGuideLine);
+    if (!pGL)
+        goto Fail;
     pGL->dwSize = sizeof(GUIDELINE);
     ImmUnlockIMCC(pIC->hGuideLine);
 
@@ -455,6 +459,7 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
     for (dwIndex = 0; dwIndex < MAX_CANDIDATEFORM; ++dwIndex)
         pIC->cfCandForm[dwIndex].dwIndex = IMM_INVALID_CANDFORM;
 
+    /* Get private data size */
     pImeDpi = ImmLockImeDpi(hKL);
     if (!pImeDpi)
     {
@@ -466,21 +471,24 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
         if (!pClientImc)
             goto Fail;
 
+        /* Update CLIENTIMC */
+        pClientImc->uCodePage = pImeDpi->uCodePage;
         if (ImeDpi_IsUnicode(pImeDpi))
             pClientImc->dwFlags |= CLIENTIMC_WIDE;
 
-        pClientImc->uCodePage = pImeDpi->uCodePage;
         ImmUnlockClientImc(pClientImc);
 
         cbPrivate = pImeDpi->ImeInfo.dwPrivateDataSize;
     }
 
+    /* Create private data */
     pIC->hPrivate = ImmCreateIMCC(cbPrivate);
     if (!pIC->hPrivate)
         goto Fail;
 
     if (pImeDpi)
     {
+        /* Select the IME */
         if (fSelect)
         {
             if (IS_IME_HKL(hKL))
@@ -489,6 +497,7 @@ BOOL APIENTRY Imm32CreateContext(HIMC hIMC, HKL hKL, BOOL fSelect)
                 pImeDpi->CtfImeSelectEx(hIMC, TRUE, hKL);
         }
 
+        /* Set HKL */
         pClientImc = ImmLockClientImc(hIMC);
         if (pClientImc)
         {

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -259,7 +259,7 @@ DWORD WINAPI ImmGetIMCCSize(HIMCC imcc)
 DWORD WINAPI ImmGetIMCLockCount(HIMC hIMC)
 {
     DWORD ret;
-    HIMC hClientImc;
+    HANDLE hInputContext;
     PCLIENTIMC pClientImc;
 
     pClientImc = ImmLockClientImc(hIMC);
@@ -267,9 +267,9 @@ DWORD WINAPI ImmGetIMCLockCount(HIMC hIMC)
         return 0;
 
     ret = 0;
-    hClientImc = pClientImc->hImc;
-    if (hClientImc)
-        ret = (LocalFlags(hClientImc) & LMEM_LOCKCOUNT);
+    hInputContext = pClientImc->hInputContext;
+    if (hInputContext)
+        ret = (LocalFlags(hInputContext) & LMEM_LOCKCOUNT);
 
     ImmUnlockClientImc(pClientImc);
     return ret;

--- a/modules/rostests/apitests/imm32/clientimc.c
+++ b/modules/rostests/apitests/imm32/clientimc.c
@@ -24,15 +24,15 @@ START_TEST(clientimc)
     DWORD dwCode;
     CLIENTIMC *pClientImc = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(CLIENTIMC));
 
-    pClientImc->hImc = (HIMC)ImmCreateIMCC(4);
+    pClientImc->hInputContext = (HANDLE)ImmCreateIMCC(4);
     pClientImc->cLockObj = 2;
     pClientImc->dwFlags = 0x40;
     RtlInitializeCriticalSection(&pClientImc->cs);
-    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hImc), 4);
+    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hInputContext), 4);
 
     ImmUnlockClientImc(pClientImc);
     ok_long(pClientImc->cLockObj, 1);
-    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hImc), 4);
+    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hInputContext), 4);
 
     dwCode = 0;
     _SEH2_TRY
@@ -47,7 +47,7 @@ START_TEST(clientimc)
     ok_long(dwCode, STATUS_ACCESS_VIOLATION);
 
     ok_long(pClientImc->cLockObj, 0);
-    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hImc), 0);
+    ok_long(ImmGetIMCCSize((HIMCC)pClientImc->hInputContext), 0);
 
     HeapFree(GetProcessHeap(), 0, pClientImc);
 }

--- a/sdk/include/reactos/wine/ddk/imm.h
+++ b/sdk/include/reactos/wine/ddk/imm.h
@@ -92,17 +92,19 @@ typedef struct INPUTCONTEXTDX /* unconfirmed */
     INPUTCONTEXT;
     UINT nVKey;
     BOOL bNeedsTrans;
-    DWORD dwUnknownCat;
+    DWORD dwUnknown1;
     DWORD dwUIFlags;
-    DWORD dwUnknownDog;
-    void *pUnknownFox;
-    /* ... */
+    DWORD dwUnknown2;
+    void *pUnknown3;
+    DWORD dwUnknown4;
+    DWORD dwUnknown5;
 } INPUTCONTEXTDX, *LPINPUTCONTEXTDX;
 
 #ifndef _WIN64
 C_ASSERT(offsetof(INPUTCONTEXTDX, nVKey) == 0x140);
 C_ASSERT(offsetof(INPUTCONTEXTDX, bNeedsTrans) == 0x144);
 C_ASSERT(offsetof(INPUTCONTEXTDX, dwUIFlags) == 0x14c);
+C_ASSERT(sizeof(INPUTCONTEXTDX) == 0x160);
 #endif
 
 // bits of fdwInit of INPUTCONTEXT

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1290,7 +1290,7 @@ C_ASSERT(sizeof(IMEDPI) == 0xa8);
 /* unconfirmed */
 typedef struct tagCLIENTIMC
 {
-    HANDLE hInputContext;
+    HANDLE hInputContext;   /* LocalAlloc'ed LHND */
     LONG cLockObj;
     DWORD dwFlags;
     DWORD unknown;

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1290,21 +1290,22 @@ C_ASSERT(sizeof(IMEDPI) == 0xa8);
 /* unconfirmed */
 typedef struct tagCLIENTIMC
 {
-    HIMC hImc;
+    HANDLE hInputContext;
     LONG cLockObj;
     DWORD dwFlags;
     DWORD unknown;
     RTL_CRITICAL_SECTION cs;
-    DWORD unknown2;
+    UINT uCodePage;
     HKL hKL;
     BOOL bUnknown4;
 } CLIENTIMC, *PCLIENTIMC;
 
 #ifndef _WIN64
-C_ASSERT(offsetof(CLIENTIMC, hImc) == 0x0);
+C_ASSERT(offsetof(CLIENTIMC, hInputContext) == 0x0);
 C_ASSERT(offsetof(CLIENTIMC, cLockObj) == 0x4);
 C_ASSERT(offsetof(CLIENTIMC, dwFlags) == 0x8);
 C_ASSERT(offsetof(CLIENTIMC, cs) == 0x10);
+C_ASSERT(offsetof(CLIENTIMC, uCodePage) == 0x28);
 C_ASSERT(offsetof(CLIENTIMC, hKL) == 0x2c);
 C_ASSERT(sizeof(CLIENTIMC) == 0x34);
 #endif


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `Imm32InitContext` and `Imm32LockIMCEx` helper functions.
- Re-implement `ImmLockIMC` function (this is not `ImmLockIMCC`, don't confuse).
- Modify `CLIENTIMC` and `INPUTCONTEXTDX` structures.