### PR TITLE
Revert "[DSOUND] Don't force status to failure by default in primarybuffer_SetFormat (#3911)"

### DIFF
--- a/dll/directx/wine/dsound/primary.c
+++ b/dll/directx/wine/dsound/primary.c
@@ -459,7 +459,7 @@ LPWAVEFORMATEX DSOUND_CopyFormat(LPCWAVEFORMATEX wfex)
 
 HRESULT primarybuffer_SetFormat(DirectSoundDevice *device, LPCWAVEFORMATEX wfex)
 {
-	HRESULT err = S_OK;
+	HRESULT err = DSERR_BUFFERLOST;
 	int i;
 	DWORD nSamplesPerSec, bpp, chans;
 	LPWAVEFORMATEX oldpwfx;


### PR DESCRIPTION
## Purpose

Revert my last dsound fix, because it does not fix the actual problem with audio formats support. It only makes the situation worse. It avoids the error when creating an audio stream, but the sound is not playing correctly, both in ReactOS and Windows (with our dsound.dll). Without this fix, it works perfectly on Windows, but does not in ROS.
In particular, the sound is not playing properly in AIMP 4.71 with other audio formats besides default (44100 Hz, 16 bit, stereo). And any other apps which request these audio formats should be also affected as well.
Force the status back to failure, because otherwise the badly required code is not executed at all.
I've made a more correct fix(es) in other audio component(s) instead and will submit them if further PRs.

JIRA issue: [CORE-10907](https://jira.reactos.org/browse/CORE-10907)