### PR TITLE
[MMIXER] Add support for WAVE_FORMAT_EXTENSIBLE audio format

### DIFF
--- a/sdk/lib/drivers/sound/mmixer/wave.c
+++ b/sdk/lib/drivers/sound/mmixer/wave.c
@@ -126,8 +126,8 @@ MMixerInitializeDataFormat(
     DataFormat->WaveFormatEx.nBlockAlign = WaveFormatEx->nBlockAlign;
     DataFormat->WaveFormatEx.nAvgBytesPerSec = WaveFormatEx->nAvgBytesPerSec;
     DataFormat->WaveFormatEx.wBitsPerSample = WaveFormatEx->wBitsPerSample;
-    DataFormat->WaveFormatEx.cbSize = 0;
-    DataFormat->DataFormat.FormatSize = sizeof(KSDATAFORMAT) + sizeof(WAVEFORMATEX);
+    DataFormat->WaveFormatEx.cbSize = WaveFormatEx->cbSize;
+    DataFormat->DataFormat.FormatSize = sizeof(KSDATAFORMAT) + sizeof(WAVEFORMATEX) + WaveFormatEx->cbSize;
     DataFormat->DataFormat.Flags = 0;
     DataFormat->DataFormat.Reserved = 0;
     DataFormat->DataFormat.MajorFormat = KSDATAFORMAT_TYPE_AUDIO;
@@ -459,9 +459,11 @@ MMixerOpenWave(
     /* grab mixer list */
     MixerList = (PMIXER_LIST)MixerContext->MixerContext;
 
-    if (WaveFormat->wFormatTag != WAVE_FORMAT_PCM)
+    if (WaveFormat->wFormatTag != WAVE_FORMAT_PCM &&
+        WaveFormat->wFormatTag != WAVE_FORMAT_EXTENSIBLE)
     {
         /* not implemented */
+        DPRINT1("Unsupported format tag 0x%x requested\n", WaveFormat->wFormatTag);
         return MM_STATUS_NOT_IMPLEMENTED;
     }
 


### PR DESCRIPTION
## Purpose

Enable support for `WAVE_FORMAT_EXTENSIBLE` audio format in MMixer library.
In general, it allows to properly play/capture the sound by apps whose specify `WAVE_FORMAT_EXTENSIBLE` format tag.
For example, after this fix, AIMP 4.71 is playing the audio files correctly with 16 bps and 2 (stereo) channels. Debug output proves that it passes `WAVE_FORMAT_EXTENSIBLE` format in `WAVEFORMATEX.cbSize`, and with 16 bit & stereo channels (only that is supported by Intel AC97 driver), playback is working properly.

JIRA issue: [CORE-10907](https://jira.reactos.org/browse/CORE-10907)

## Proposed changes

Allow using `WAVE_FORMAT_EXTENSIBLE` format tag for newly created audio pins:
- Add it into the formats check, to pass it further for creating a new pin, so now the check does not fail with `MM_STATUS_NOT_IMPLEMENTED` when requesting this format.
- Add additional debug print in this check, which will be displayed when any other unsupported yet format will be called (besides `WAVE_FORMAT_PCM` and `WAVE_FORMAT_EXTENSIBLE`).
- Set the correct size for `WAVEFORMATEX.cbSize` member. MS says it should have the size of additional data (for additional formats), but not zero, as for standard formats, since `WAVEFORMATEXTENSIBLE` structure, in essence, is just an addition for `WAVEFORMATEX`. It stores all additional data, which has some size (stored in `cbSize` member). This data can be different, since it is specified by the caller, and the size of it also can be different appropriately.
- Do the same for `KSDATAFORMAT.FormatSize` member.

## TODO

- [x] Perhaps add additional size to `KSDATAFORMAT.FormatSize` also, instead of dumb `sizeof(WAVEFORMATEX)` (since `cbSize` is `0` by default), because it requires the actual size of the data, so logically it looks correct.