### PR TITLE
[WIN32SS:GDI] Add all known function calls to NtCurrentTeb for resetting spins.

### DIFF
--- a/win32ss/gdi/gdi32/objects/arc.c
+++ b/win32ss/gdi/gdi32/objects/arc.c
@@ -28,6 +28,7 @@ Arc(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiArcInternal(GdiTypeArc,
                             hdc,
                             xLeft,
@@ -66,6 +67,7 @@ AngleArc(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiAngleArc(hdc,
                          x,
                          y,
@@ -102,6 +104,7 @@ ArcTo(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiArcInternal(GdiTypeArcTo,
                             hdc,
                             xLeft,
@@ -142,6 +145,7 @@ Chord(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiArcInternal(GdiTypeChord,
                             hdc,
                             xLeft,
@@ -186,6 +190,7 @@ Pie(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiArcInternal(GdiTypePie,
                             hdc,
                             xLeft,

--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -731,6 +731,8 @@ SetDIBitsToDevice(
 
     cjBmpScanSize = DIB_BitmapMaxBitsSize((LPBITMAPINFO) lpbmi, ScanLines);
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
+
     pvSafeBits = RtlAllocateHeap(GetProcessHeap(), 0, cjBmpScanSize);
     if (pvSafeBits)
     {
@@ -838,6 +840,8 @@ StretchDIBits(
     }
 
     cjBmpScanSize = GdiGetBitmapBitsSize((BITMAPINFO *) pConvertedInfo);
+
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
 
     if (lpBits)
     {

--- a/win32ss/gdi/gdi32/objects/painting.c
+++ b/win32ss/gdi/gdi32/objects/painting.c
@@ -15,6 +15,7 @@ LineTo(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiLineTo(hdc, x, y);
 }
 
@@ -79,6 +80,7 @@ Ellipse(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiEllipse(hdc, left, top, right, bottom);
 }
 
@@ -99,6 +101,7 @@ Rectangle(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiRectangle(hdc, left, top, right, bottom);
 }
 
@@ -121,6 +124,7 @@ RoundRect(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiRoundRect(hdc, left, top, right, bottom, width, height);
 }
 
@@ -156,6 +160,7 @@ SetPixel(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiSetPixel(hdc, x, y, crColor);
 }
 
@@ -193,6 +198,7 @@ FillRgn(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiFillRgn(hdc, hrgn, hbr);
 }
 
@@ -217,6 +223,7 @@ FrameRgn(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiFrameRgn(hdc, hrgn, hbr, nWidth, nHeight);
 }
 
@@ -238,6 +245,7 @@ InvertRgn(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiInvertRgn(hdc, hrgn);
 }
 
@@ -421,6 +429,7 @@ ExtFloodFill(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiExtFloodFill(hdc, xStart, yStart, crFill, fuFillType);
 }
 
@@ -477,6 +486,7 @@ BitBlt(
 
     if ( GdiConvertAndCheckDC(hdcDest) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiBitBlt(hdcDest, xDest, yDest, cx, cy, hdcSrc, xSrc, ySrc, dwRop, 0, 0);
 }
 
@@ -495,6 +505,8 @@ PatBlt(
     HANDLE_EMETAFDC(BOOL, PatBlt, FALSE, hdc, nXLeft, nYLeft, nWidth, nHeight, dwRop);
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
+
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
 
     /* Get the DC attribute */
     pdcattr = GdiGetDcAttr(hdc);
@@ -575,6 +587,8 @@ PolyPatBlt(
         return bResult;
     }
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
+
     /* Get the DC attribute */
     pdcattr = GdiGetDcAttr(hdc);
     if (nCount && pdcattr && !(pdcattr->ulDirty_ & DC_DIBSECTION))
@@ -650,6 +664,7 @@ StretchBlt(
 
     if ( GdiConvertAndCheckDC(hdcDest) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiStretchBlt(hdcDest,
                            xDest,
                            yDest,
@@ -702,6 +717,7 @@ MaskBlt(
 
     if ( GdiConvertAndCheckDC(hdcDest) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiMaskBlt(hdcDest,
                         xDest,
                         yDest,
@@ -751,6 +767,7 @@ PlgBlt(
 
     if ( GdiConvertAndCheckDC(hdcDest) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiPlgBlt(hdcDest,
                        (LPPOINT)ppt,
                        hdcSrc,
@@ -800,6 +817,7 @@ GdiAlphaBlend(
 
     if ( GdiConvertAndCheckDC(hdcDst) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiAlphaBlend(hdcDst,
                            xDst,
                            yDst,
@@ -850,6 +868,7 @@ GdiTransparentBlt(
 
     if ( GdiConvertAndCheckDC(hdcDst) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiTransparentBlt(hdcDst, xDst, yDst, cxDst, cyDst, hdcSrc, xSrc, ySrc, cxSrc, cySrc, crTransparent);
 }
 
@@ -872,5 +891,6 @@ GdiGradientFill(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiGradientFill(hdc, pVertex, nVertex, pMesh, nCount, ulMode);
 }

--- a/win32ss/gdi/gdi32/objects/path.c
+++ b/win32ss/gdi/gdi32/objects/path.c
@@ -70,6 +70,8 @@ FillPath(
     HDC	hdc)
 {
     HANDLE_METADC0P(BOOL, FillPath, FALSE, hdc);
+
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiFillPath( hdc );
 }
 
@@ -154,6 +156,8 @@ StrokeAndFillPath(
     HDC	hdc)
 {
     HANDLE_METADC0P(BOOL, StrokeAndFillPath, FALSE, hdc);
+
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiStrokeAndFillPath ( hdc );
 }
 
@@ -167,6 +171,8 @@ StrokePath(
     HDC	hdc)
 {
     HANDLE_METADC0P(BOOL, StrokePath, FALSE, hdc);
+
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
     return NtGdiStrokePath ( hdc );
 }
 

--- a/win32ss/gdi/gdi32/objects/text.c
+++ b/win32ss/gdi/gdi32/objects/text.c
@@ -511,6 +511,8 @@ ExtTextOutW(
 
     if ( GdiConvertAndCheckDC(hdc) == NULL ) return FALSE;
 
+    ((PW32CLIENTINFO)NtCurrentTeb()->Win32ClientInfo)->cSpins = 0;
+
     if (!(fuOptions & (ETO_GLYPH_INDEX | ETO_IGNORELANGUAGE)))
     {
         bBypassETOWMF = TRUE;


### PR DESCRIPTION
## Purpose and proposed change

I noticed missing writes to the spin count in ClientInfo within GDI32 while debugging API tests with James Tabor's recent changes to the GDI Metafile process. This doesn't appear to functionally break anything, and if I understand correctly, these lines are certainly in the original GDI subsystem for optimizing polling.

Unsure if there any additional writes of the same kind in NT 6.x.