### PR TITLE
[SHELL32] Fix uninitialized variable usage.

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuToolbars.cpp
@@ -258,6 +258,10 @@ HRESULT CMenuToolbarBase::OnCustomDraw(LPNMTBCUSTOMDRAW cdraw, LRESULT * theResu
         }
         *theResult = TRUE;
         return S_OK;
+
+    default:
+        *theResult = 0L;
+        break;
     }
     return S_OK;
 }


### PR DESCRIPTION
This fixes log spam about NM_CUSTOMDRAW not being handled

