### PR TITLE
[IMM32_APITEST] Add ImmGetImeInfoEx testcase

### DIFF
--- a/modules/rostests/apitests/imm32/CMakeLists.txt
+++ b/modules/rostests/apitests/imm32/CMakeLists.txt
@@ -5,8 +5,8 @@ list(APPEND SOURCE
     clientimc.c
     himc.c
     imcc.c
-    ImmIsUIMessage.c
     ImmGetImeInfoEx.c
+    ImmIsUIMessage.c
     testlist.c)
 
 add_executable(imm32_apitest ${SOURCE})

--- a/modules/rostests/apitests/imm32/CMakeLists.txt
+++ b/modules/rostests/apitests/imm32/CMakeLists.txt
@@ -6,6 +6,7 @@ list(APPEND SOURCE
     himc.c
     imcc.c
     ImmIsUIMessage.c
+    ImmGetImeInfoEx.c
     testlist.c)
 
 add_executable(imm32_apitest ${SOURCE})

--- a/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
+++ b/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
@@ -1,0 +1,90 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Test for ImmGetImeInfoEx
+ * COPYRIGHT:   Copyright 2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include "precomp.h"
+
+//#define DO_PRINT
+
+typedef BOOL (WINAPI *FN_ImmGetImeInfoEx)(PIMEINFOEX, IMEINFOEXCLASS, PVOID);
+
+static VOID PrintInfoEx(PIMEINFOEX pInfoEx)
+{
+#ifdef DO_PRINT
+    trace("---\n");
+    trace("hkl: %p\n", pInfoEx->hkl);
+    trace("ImeInfo.dwPrivateDataSize: 0x%lX\n", pInfoEx->ImeInfo.dwPrivateDataSize);
+    trace("ImeInfo.fdwProperty: 0x%lX\n", pInfoEx->ImeInfo.fdwProperty);
+    trace("ImeInfo.fdwConversionCaps: 0x%lX\n", pInfoEx->ImeInfo.fdwConversionCaps);
+    trace("ImeInfo.fdwSentenceCaps: 0x%lX\n", pInfoEx->ImeInfo.fdwSentenceCaps);
+    trace("ImeInfo.fdwUICaps: 0x%lX\n", pInfoEx->ImeInfo.fdwUICaps);
+    trace("ImeInfo.fdwSCSCaps: 0x%lX\n", pInfoEx->ImeInfo.fdwSCSCaps);
+    trace("ImeInfo.fdwSelectCaps: 0x%lX\n", pInfoEx->ImeInfo.fdwSelectCaps);
+    trace("wszUIClass: '%ls'\n", pInfoEx->wszUIClass);
+    trace("fdwInitConvMode: 0x%lX\n", pInfoEx->fdwInitConvMode);
+    trace("fInitOpen: %d\n", pInfoEx->fInitOpen);
+    trace("fLoadFlag: %d\n", pInfoEx->fLoadFlag);
+    trace("dwProdVersion: 0x%lX\n", pInfoEx->dwProdVersion);
+    trace("dwImeWinVersion: 0x%lX\n", pInfoEx->dwImeWinVersion);
+    trace("wszImeDescription: '%ls'\n", pInfoEx->wszImeDescription);
+    trace("wszImeFile: '%ls'\n", pInfoEx->wszImeFile);
+    trace("fInitOpen: %d\n", pInfoEx->fInitOpen);
+#endif
+}
+
+START_TEST(ImmGetImeInfoEx)
+{
+    IMEINFOEX InfoEx;
+    BOOL ret;
+    LANGID LangID = GetSystemDefaultLangID();
+    HKL hKL = GetKeyboardLayout(0);
+
+    HMODULE hImm32 = GetModuleHandleA("imm32");
+    FN_ImmGetImeInfoEx fnImmGetImeInfoEx = GetProcAddress(hImm32, "ImmGetImeInfoEx");
+    if (!fnImmGetImeInfoEx)
+    {
+        skip("ImmGetImeInfoEx not found\n");
+        return;
+    }
+
+    if (!GetSystemMetrics(SM_IMMENABLED))
+    {
+        skip("IME is not available\n");
+        return;
+    }
+
+    // ImeInfoExKeyboardLayout
+    FillMemory(&InfoEx, sizeof(InfoEx), 0xCC);
+    ret = fnImmGetImeInfoEx(&InfoEx, ImeInfoExKeyboardLayout, &hKL);
+    PrintInfoEx(&InfoEx);
+
+    if ((HIWORD(InfoEx.hkl) & 0xe000) == 0xe000)
+        ok_long(LOWORD(InfoEx.hkl), LangID);
+    else
+        ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
+    ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
+    ok(InfoEx.wszUIClass[0] != 0, "\n");
+    ok_long(InfoEx.dwImeWinVersion, 0x40000);
+    ok(InfoEx.wszImeFile[0] != 0, "wszImeFile was empty\n");
+    ok_int(ret, TRUE);
+
+    // ImeInfoExImeWindow
+    FillMemory(&InfoEx, sizeof(InfoEx), 0xCC);
+    ret = fnImmGetImeInfoEx(&InfoEx, ImeInfoExImeWindow, &hKL);
+    PrintInfoEx(&InfoEx);
+
+    if ((HIWORD(InfoEx.hkl) & 0xe000) == 0xe000)
+        ok_long(LOWORD(InfoEx.hkl), LangID);
+    else
+        ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
+    ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
+    ok(InfoEx.wszUIClass[0] != 0, "\n");
+    ok_long(InfoEx.dwImeWinVersion, 0x40000);
+    ok(InfoEx.wszImeFile[0] != 0, "wszImeFile was empty\n");
+    ok_int(ret, TRUE);
+
+    // TODO: ImeInfoExImeFileName
+}

--- a/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
+++ b/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
@@ -44,7 +44,8 @@ START_TEST(ImmGetImeInfoEx)
     HKL hKL = GetKeyboardLayout(0), hOldKL;
 
     HMODULE hImm32 = GetModuleHandleA("imm32");
-    FN_ImmGetImeInfoEx fnImmGetImeInfoEx = GetProcAddress(hImm32, "ImmGetImeInfoEx");
+    FN_ImmGetImeInfoEx fnImmGetImeInfoEx =
+        (FN_ImmGetImeInfoEx)GetProcAddress(hImm32, "ImmGetImeInfoEx");
     if (!fnImmGetImeInfoEx)
     {
         skip("ImmGetImeInfoEx not found\n");

--- a/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
+++ b/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
@@ -65,7 +65,7 @@ START_TEST(ImmGetImeInfoEx)
     PrintInfoEx(&InfoEx);
     ok_int(ret, TRUE);
     ok_long((DWORD)(DWORD_PTR)hOldKL, (DWORD)(DWORD_PTR)hKL);
-    if ((HIWORD(InfoEx.hkl) & 0xe000) == 0xe000)
+    if (IS_IME_HKL(InfoEx.hkl))
         ok_long(LOWORD(InfoEx.hkl), LangID);
     else
         ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
@@ -82,7 +82,7 @@ START_TEST(ImmGetImeInfoEx)
     ret = fnImmGetImeInfoEx(&InfoEx, ImeInfoExImeWindow, &hKL);
     PrintInfoEx(&InfoEx);
     ok_int(ret, TRUE);
-    if ((HIWORD(InfoEx.hkl) & 0xe000) == 0xe000)
+    if (IS_IME_HKL(InfoEx.hkl))
         ok_long(LOWORD(InfoEx.hkl), LangID);
     else
         ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));

--- a/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
+++ b/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
@@ -67,9 +67,14 @@ START_TEST(ImmGetImeInfoEx)
     ok_int(ret, TRUE);
     ok_long((DWORD)(DWORD_PTR)hOldKL, (DWORD)(DWORD_PTR)hKL);
     if (IS_IME_HKL(InfoEx.hkl))
+    {
         ok_long(LOWORD(InfoEx.hkl), LangID);
+    }
     else
-        ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
+    {
+        ok_int(LOWORD(InfoEx.hkl), LangID);
+        ok_int(HIWORD(InfoEx.hkl), LangID);
+    }
     ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
     ok(InfoEx.wszUIClass[0] != 0, "wszUIClass was empty\n");
     ok_long(InfoEx.dwImeWinVersion, 0x40000);
@@ -84,9 +89,14 @@ START_TEST(ImmGetImeInfoEx)
     PrintInfoEx(&InfoEx);
     ok_int(ret, TRUE);
     if (IS_IME_HKL(InfoEx.hkl))
+    {
         ok_long(LOWORD(InfoEx.hkl), LangID);
+    }
     else
-        ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
+    {
+        ok_int(LOWORD(InfoEx.hkl), LangID);
+        ok_int(HIWORD(InfoEx.hkl), LangID);
+    }
     ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
     ok(InfoEx.wszUIClass[0] != 0, "wszUIClass was empty\n");
     ok_long(InfoEx.dwImeWinVersion, 0x40000);

--- a/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
+++ b/modules/rostests/apitests/imm32/ImmGetImeInfoEx.c
@@ -58,6 +58,7 @@ START_TEST(ImmGetImeInfoEx)
 
     // ImeInfoExKeyboardLayout
     FillMemory(&InfoEx, sizeof(InfoEx), 0xCC);
+    InfoEx.wszUIClass[0] = InfoEx.wszImeFile[0] = 0;
     ret = fnImmGetImeInfoEx(&InfoEx, ImeInfoExKeyboardLayout, &hKL);
     PrintInfoEx(&InfoEx);
 
@@ -66,13 +67,14 @@ START_TEST(ImmGetImeInfoEx)
     else
         ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
     ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
-    ok(InfoEx.wszUIClass[0] != 0, "\n");
+    ok(InfoEx.wszUIClass[0] != 0, "wszUIClass was empty\n");
     ok_long(InfoEx.dwImeWinVersion, 0x40000);
     ok(InfoEx.wszImeFile[0] != 0, "wszImeFile was empty\n");
     ok_int(ret, TRUE);
 
     // ImeInfoExImeWindow
     FillMemory(&InfoEx, sizeof(InfoEx), 0xCC);
+    InfoEx.wszUIClass[0] = InfoEx.wszImeFile[0] = 0;
     ret = fnImmGetImeInfoEx(&InfoEx, ImeInfoExImeWindow, &hKL);
     PrintInfoEx(&InfoEx);
 
@@ -81,7 +83,7 @@ START_TEST(ImmGetImeInfoEx)
     else
         ok_long((DWORD)(DWORD_PTR)InfoEx.hkl, MAKELONG(LangID, LangID));
     ok(InfoEx.ImeInfo.dwPrivateDataSize >= 4, "\n");
-    ok(InfoEx.wszUIClass[0] != 0, "\n");
+    ok(InfoEx.wszUIClass[0] != 0, "wszUIClass was empty\n");
     ok_long(InfoEx.dwImeWinVersion, 0x40000);
     ok(InfoEx.wszImeFile[0] != 0, "wszImeFile was empty\n");
     ok_int(ret, TRUE);

--- a/modules/rostests/apitests/imm32/testlist.c
+++ b/modules/rostests/apitests/imm32/testlist.c
@@ -5,15 +5,15 @@
 extern void func_clientimc(void);
 extern void func_himc(void);
 extern void func_imcc(void);
-extern void func_ImmIsUIMessage(void);
 extern void func_ImmGetImeInfoEx(void);
+extern void func_ImmIsUIMessage(void);
 
 const struct test winetest_testlist[] =
 {
     { "clientimc", func_clientimc },
     { "himc", func_himc },
     { "imcc", func_imcc },
-    { "ImmIsUIMessage", func_ImmIsUIMessage },
     { "ImmGetImeInfoEx", func_ImmGetImeInfoEx },
+    { "ImmIsUIMessage", func_ImmIsUIMessage },
     { 0, 0 }
 };

--- a/modules/rostests/apitests/imm32/testlist.c
+++ b/modules/rostests/apitests/imm32/testlist.c
@@ -6,6 +6,7 @@ extern void func_clientimc(void);
 extern void func_himc(void);
 extern void func_imcc(void);
 extern void func_ImmIsUIMessage(void);
+extern void func_ImmGetImeInfoEx(void);
 
 const struct test winetest_testlist[] =
 {
@@ -13,5 +14,6 @@ const struct test winetest_testlist[] =
     { "himc", func_himc },
     { "imcc", func_imcc },
     { "ImmIsUIMessage", func_ImmIsUIMessage },
+    { "ImmGetImeInfoEx", func_ImmGetImeInfoEx },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose
Investigate `IMM32` implementation.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `ImmGetImeInfoEx` testcase.

## Screenshots

WinXP (Japanese):
![WinXP](https://user-images.githubusercontent.com/2107452/135701499-cbc79d22-0cc7-4c01-9c94-fc3b6e690a1c.png)
Successful.

Win2k3 (English):
![Win2k3](https://user-images.githubusercontent.com/2107452/135701501-b3227a17-d6f9-4b4c-bfa7-f3cacb1b37fe.png)
Successful.

Win10 (Japanese):
![Win10](https://user-images.githubusercontent.com/2107452/135701510-68bb9f60-edeb-49b8-8529-9ce40f15f2c0.png)
Successful.