### PR TITLE
[SHELL32] Fix Shift-Delete to Permanently Delete Files and Folders

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1398,10 +1398,10 @@ HRESULT CDefView::InvokeContextMenuCommand(UINT uCommand)
     cmi.lpVerb = MAKEINTRESOURCEA(uCommand);
     cmi.hwnd = m_hWnd;
 
-    if (GetAsyncKeyState(VK_SHIFT) < 0)
+    if (GetKeyState(VK_SHIFT) & 0x8000)
         cmi.fMask |= CMIC_MASK_SHIFT_DOWN;
 
-    if (GetAsyncKeyState(VK_CONTROL) < 0)
+    if (GetKeyState(VK_CONTROL) & 0x8000)
         cmi.fMask |= CMIC_MASK_CONTROL_DOWN;
 
     HRESULT hr = m_pCM->InvokeCommand(&cmi);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1398,10 +1398,10 @@ HRESULT CDefView::InvokeContextMenuCommand(UINT uCommand)
     cmi.lpVerb = MAKEINTRESOURCEA(uCommand);
     cmi.hwnd = m_hWnd;
 
-    if (GetKeyState(VK_SHIFT) & 0x8000)
+    if (GetAsyncKeyState(VK_SHIFT) < 0)
         cmi.fMask |= CMIC_MASK_SHIFT_DOWN;
 
-    if (GetKeyState(VK_CONTROL) & 0x8000)
+    if (GetAsyncKeyState(VK_CONTROL) < 0)
         cmi.fMask |= CMIC_MASK_CONTROL_DOWN;
 
     HRESULT hr = m_pCM->InvokeCommand(&cmi);
@@ -3573,6 +3573,11 @@ HRESULT WINAPI CDefView::Drop(IDataObject* pDataObject, DWORD grfKeyState, POINT
 {
     ImageList_DragLeave(m_hWnd);
     ImageList_EndDrag();
+
+    if (GetAsyncKeyState(VK_SHIFT) < 0)
+        grfKeyState |= MK_SHIFT;
+    else
+        grfKeyState &= ~MK_SHIFT;
 
     if ((IsDropOnSource(NULL) == S_OK) &&
         (*pdwEffect & DROPEFFECT_MOVE) &&

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -3574,11 +3574,6 @@ HRESULT WINAPI CDefView::Drop(IDataObject* pDataObject, DWORD grfKeyState, POINT
     ImageList_DragLeave(m_hWnd);
     ImageList_EndDrag();
 
-    if (GetAsyncKeyState(VK_SHIFT) < 0)
-        grfKeyState |= MK_SHIFT;
-    else
-        grfKeyState &= ~MK_SHIFT;
-
     if ((IsDropOnSource(NULL) == S_OK) &&
         (*pdwEffect & DROPEFFECT_MOVE) &&
         (m_grfKeyState & MK_LBUTTON))

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -833,7 +833,8 @@ HRESULT CDefaultContextMenu::DoDelete(LPCMINVOKECOMMANDINFO lpcmi)
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    SHSimulateDrop(pDT, m_pDataObj, 0, NULL, NULL);
+    DWORD grfKeyState = (lpcmi->fMask & CMIC_MASK_SHIFT_DOWN) ? MK_SHIFT : 0;
+    SHSimulateDrop(pDT, m_pDataObj, grfKeyState, NULL, NULL);
 
     return S_OK;
 }

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -140,11 +140,9 @@ class CRecyclerDropTarget :
         }
 
         HRESULT WINAPI Drop(IDataObject *pDataObject,
-                                       DWORD dwKeyState, POINTL pt, DWORD *pdwEffect)
+                                       DWORD grfKeyState, POINTL pt, DWORD *pdwEffect)
         {
             TRACE("(%p) object dropped on recycle bin, effect %u\n", this, *pdwEffect);
-
-            /* TODO: pdwEffect should be read and make the drop object be permanently deleted in the move case (shift held) */
 
             FORMATETC fmt;
             TRACE("(%p)->(DataObject=%p)\n", this, pDataObject);
@@ -155,7 +153,7 @@ class CRecyclerDropTarget :
             {
                 DWORD fMask = 0;
 
-                if ((dwKeyState & MK_SHIFT) == MK_SHIFT)
+                if ((grfKeyState & MK_SHIFT) == MK_SHIFT)
                     fMask |= CMIC_MASK_SHIFT_DOWN;
 
                 _DoDeleteAsync(pDataObject, fMask);

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -140,7 +140,7 @@ class CRecyclerDropTarget :
         }
 
         HRESULT WINAPI Drop(IDataObject *pDataObject,
-                                       DWORD grfKeyState, POINTL pt, DWORD *pdwEffect)
+                            DWORD grfKeyState, POINTL pt, DWORD *pdwEffect)
         {
             TRACE("(%p) object dropped on recycle bin, effect %u\n", this, *pdwEffect);
 


### PR DESCRIPTION
## Fix Shift-Delete to Permanently Delete Items

_Fixes to shell32 files to allow permanent deletion using shift-delete._

JIRA issue: [CORE-17802](https://jira.reactos.org/browse/CORE-17802)

## Updates to two shell32 files.