### PR TITLE
[MSI] Improve previous msi/dialog.c patch to match code committed to Wine.

### DIFF
--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -3841,11 +3841,7 @@ static void process_pending_messages( HWND hdlg )
 static UINT dialog_run_message_loop( msi_dialog *dialog )
 {
     DWORD style;
-#ifdef __REACTOS__
     HWND hwnd, parent;
-#else
-    HWND hwnd;
-#endif
 
     if( uiThreadId != GetCurrentThreadId() )
         return SendMessageW( hMsiHiddenWindow, WM_MSI_DIALOG_CREATE, 0, (LPARAM) dialog );
@@ -3858,17 +3854,11 @@ static UINT dialog_run_message_loop( msi_dialog *dialog )
     if (dialog->parent == NULL && (dialog->attributes & msidbDialogAttributesMinimize))
         style |= WS_MINIMIZEBOX;
 
-#ifdef __REACTOS__
     parent = dialog->parent ? dialog->parent->hwnd : 0;
 
     hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
                      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                      parent, NULL, NULL, dialog );
-#else
-    hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
-                     CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-                     NULL, NULL, NULL, dialog );
-#endif
 
     if( !hwnd )
     {

--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -171,10 +171,6 @@ static const WCHAR szHyperLink[] = {'H','y','p','e','r','L','i','n','k',0};
 static DWORD uiThreadId;
 static HWND hMsiHiddenWindow;
 
-#ifdef __REACTOS__
-static HANDLE hPrevious = NULL;
-#endif
-
 static LPWSTR msi_get_window_text( HWND hwnd )
 {
     UINT sz, r;
@@ -3823,9 +3819,6 @@ static LRESULT WINAPI MSIDialog_WndProc( HWND hwnd, UINT msg,
 
     case WM_DESTROY:
         dialog->hwnd = NULL;
-#ifdef __REACTOS__
-        hPrevious = NULL;
-#endif
         return 0;
     case WM_NOTIFY:
         return msi_dialog_onnotify( dialog, lParam );
@@ -3848,7 +3841,11 @@ static void process_pending_messages( HWND hdlg )
 static UINT dialog_run_message_loop( msi_dialog *dialog )
 {
     DWORD style;
+#ifdef __REACTOS__
+    HWND hwnd, parent;
+#else
     HWND hwnd;
+#endif
 
     if( uiThreadId != GetCurrentThreadId() )
         return SendMessageW( hMsiHiddenWindow, WM_MSI_DIALOG_CREATE, 0, (LPARAM) dialog );
@@ -3862,9 +3859,11 @@ static UINT dialog_run_message_loop( msi_dialog *dialog )
         style |= WS_MINIMIZEBOX;
 
 #ifdef __REACTOS__
+    parent = dialog->parent ? dialog->parent->hwnd : 0;
+
     hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
                      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
-                     hPrevious, NULL, NULL, dialog );
+                     parent, NULL, NULL, dialog );
 #else
     hwnd = CreateWindowW( szMsiDialogClass, dialog->name, style,
                      CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
@@ -3876,10 +3875,6 @@ static UINT dialog_run_message_loop( msi_dialog *dialog )
         ERR("Failed to create dialog %s\n", debugstr_w( dialog->name ));
         return ERROR_FUNCTION_FAILED;
     }
-
-#ifdef __REACTOS__
-    hPrevious = hwnd;
-#endif
 
     ShowWindow( hwnd, SW_SHOW );
     /* UpdateWindow( hwnd ); - and causes the transparent static controls not to paint */


### PR DESCRIPTION
## Improvements to msi/dialog.c (PR#3861) to match final code committed to Wine

_Only show the main dialog pane in the taskbar when executing a Cancel dialog._

JIRA issue: [CORE-17702](https://jira.reactos.org/browse/CORE-17702)

## Modifies CreateWindowW to use 'parent'.
