### PR TITLE
[SETUPLIB][CPL/INPUT] Move zh-MO to ChineseTraditionalFonts group

### DIFF
--- a/base/setup/lib/muilanguages.h
+++ b/base/setup/lib/muilanguages.h
@@ -509,7 +509,7 @@ const MUI_LANGUAGE MUILanguageList[] =
     {L"00001004", L"936", L"936", L"10008", L"Chinese (Singapore)", L"215", ChineseSimplifiedFonts, zhSGLayouts},
 #endif
 #ifdef LANGUAGE_ZH_MO
-    {L"00001404", L"950", L"950", L"10002", L"Chinese (Macau S.A.R.)", L"151", ChineseSimplifiedFonts, zhMOLayouts},
+    {L"00001404", L"950", L"950", L"10002", L"Chinese (Macau S.A.R.)", L"151", ChineseTraditionalFonts, zhMOLayouts},
 #endif
 #ifdef LANGUAGE_HR_HR
     {L"0000041A", L"1250", L"852", L"10029", L"Croatian", L"108", LatinFonts, hrHRLayouts},

--- a/dll/cpl/input/input_list.c
+++ b/dll/cpl/input/input_list.c
@@ -79,11 +79,11 @@ InputList_SetFontSubstitutes(LCID dwLocaleId)
             {
                 case SUBLANG_CHINESE_SIMPLIFIED:
                 case SUBLANG_CHINESE_SINGAPORE:
-                case SUBLANG_CHINESE_MACAU:
                     pSubstitutes = ChineseSimplifiedFonts;
                     break;
                 case SUBLANG_CHINESE_TRADITIONAL:
                 case SUBLANG_CHINESE_HONGKONG:
+                case SUBLANG_CHINESE_MACAU:
                     pSubstitutes = ChineseTraditionalFonts;
                     break;
                 default:


### PR DESCRIPTION
## Proposed changes
A trivial fix for moving Chinese (Macau S.A.R.) related definition/ code to ChineseTraditionalFonts group.

**Reason**: 
* the use of Traditional Chinese character is far more than Simplified one. (according to Wikipedia)
* the codepage used on zh-MO is 950, which is Traditional Chinese's one.
* In [this page](https://support.microsoft.com/en-us/windows/microsoft-traditional-chinese-ime-ef596ca5-aff7-4272-b34b-0ac7c2631a38#ID0EBBD=Microsoft_ChangJie/Quick), zh-MO is described as Traditional Chinese.

## P.S.
* I don't think this language will be available when ROS<s> 1.0 is officially released</s> enter beta stage lol
