### PR TITLE
[HHPCOMP] lz_nonslide.h: Define u_char on Linux

### DIFF
--- a/sdk/tools/hhpcomp/lzx_compress/lz_nonslide.h
+++ b/sdk/tools/hhpcomp/lzx_compress/lz_nonslide.h
@@ -16,7 +16,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 */
 
-#if defined(_WIN32) || defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__) || defined(__linux__)
 typedef unsigned char           u_char;
 #endif
 


### PR DESCRIPTION
## Purpose

Not defining the type breaks the compilation on (at least arm) Linux. Add a check for Linux-as-build-host to make it pass.

JIRA issue: none?

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- define the type so that the compiler knows what on earth u_char is

