### PR TITLE
[SDK][MKISOFS] varargs.h: Don't check for VA_LIST_IS_ARRAY on Linux/ARM(64)

### DIFF
--- a/sdk/tools/mkisofs/reactos/xconfig.h
+++ b/sdk/tools/mkisofs/reactos/xconfig.h
@@ -180,7 +180,9 @@
 #define HAVE_LONGLONG 1
 
 #ifndef _WIN32
+#if !defined(__arm__) && !defined(__aarch64__)
     #define VA_LIST_IS_ARRAY 1
+#endif
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
For some bizzare reason ARM toolchains have some peculiar issues with various va_arg macros,
as this is not the first time one of these is problematic (though I don't remember the previous one,
it was a long, long time ago :tm:).. They always seem to expect va_list as an argument though, so
let's make them happy and by extension make ros-tools compile on Linux/arm(64) compile again!

## Purpose

Make ros-tools compile on Linux/arm(64)

JIRA issue: none?

## Proposed changes

- Skip the VA_LIST_IS_ARRAY check on Linux/arm(64)
