### PR TITLE
[USER32] Detect White followed by Black in color table as monochrome

### DIFF
--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -122,12 +122,12 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         if (((const BITMAPCOREINFO*)info)->bmciHeader.bcBitCount != 1) return FALSE;
 
         /* Check if the first color is black */
-        if ((rgb[0].rgbtRed == 0) && (rgb[0].rgbtGreen == 0) &&
-            (rgb[0].rgbtBlue == 0))
+        if (RGB(rgb[0].rgbtRed, rgb[0].rgbtGreen, rgb[0].rgbtBlue) ==
+            RGB(0, 0, 0))
         {
             /* Check if the second color is white */
-            if ((rgb[1].rgbtRed == 0xff) && (rgb[1].rgbtGreen == 0xff) &&
-                (rgb[1].rgbtBlue == 0xff))
+            if (RGB(rgb[1].rgbtRed, rgb[1].rgbtGreen, rgb[1].rgbtBlue) ==
+                RGB(0xff, 0xff, 0xff))
             {
                 return TRUE;
             }
@@ -138,12 +138,12 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         }
 
         /* Check if the first color is white */
-        if ((rgb[0].rgbtRed == 0xff) && (rgb[0].rgbtGreen == 0xff) &&
-            (rgb[0].rgbtBlue == 0xff))
+        if (RGB(rgb[0].rgbtRed, rgb[0].rgbtGreen, rgb[0].rgbtBlue) ==
+            RGB(0xff, 0xff, 0xff))
         {
             /* Check if the second color is black */
-            if ((rgb[1].rgbtRed == 0) && (rgb[1].rgbtGreen == 0) &&
-                (rgb[1].rgbtBlue == 0))
+            if (RGB(rgb[1].rgbtRed, rgb[1].rgbtGreen, rgb[1].rgbtBlue) ==
+                RGB(0, 0, 0))
             {
                 return TRUE;
             }
@@ -158,12 +158,12 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         if (info->bmiHeader.biBitCount != 1) return FALSE;
 
         /* Check if the first color is black */
-        if ((rgb[0].rgbRed == 0) && (rgb[0].rgbGreen == 0) &&
-            (rgb[0].rgbBlue == 0) && (rgb[0].rgbReserved == 0))
+        if (RGBA(rgb[0].rgbRed, rgb[0].rgbGreen, rgb[0].rgbBlue,
+            rgb[0].rgbReserved) == RGBA(0, 0, 0, 0))
         {
             /* Check if the second color is white */
-            if ((rgb[1].rgbRed == 0xff) && (rgb[1].rgbGreen == 0xff) &&
-                (rgb[1].rgbBlue == 0xff) && (rgb[1].rgbReserved == 0))
+            if (RGBA(rgb[1].rgbRed, rgb[1].rgbGreen, rgb[1].rgbBlue,
+                rgb[1].rgbReserved) == RGBA(0xff, 0xff, 0xff, 0))
             {
                 return TRUE;
             }
@@ -174,12 +174,12 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         }
 
         /* Check if the first color is white */
-        if ((rgb[0].rgbRed == 0xff) && (rgb[0].rgbGreen == 0xff) &&
-            (rgb[0].rgbBlue == 0xff) && (rgb[0].rgbReserved == 0))
+        if (RGBA(rgb[0].rgbRed, rgb[0].rgbGreen, rgb[0].rgbBlue,
+            rgb[0].rgbReserved) == RGBA(0xff, 0xff, 0xff, 0))
         {
             /* Check if the second color is black */
-            if ((rgb[1].rgbRed == 0) && (rgb[1].rgbGreen == 0) &&
-                (rgb[1].rgbBlue == 0) && (rgb[1].rgbReserved == 0))
+            if (RGBA(rgb[1].rgbRed, rgb[1].rgbGreen, rgb[1].rgbBlue,
+                rgb[1].rgbReserved) == RGBA(0, 0, 0, 0))
             {
                 return TRUE;
             }

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * PROJECT:         ReactOS user32.dll
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c
@@ -139,7 +139,7 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         {
             /* Check if the second color is black */
             if ((rgb[1].rgbtRed == 0) && (rgb[1].rgbtGreen == 0) &&
-            (rgb[1].rgbtBlue == 0))
+                (rgb[1].rgbtBlue == 0))
             {
                 return TRUE;
             }

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -122,15 +122,25 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         if (((const BITMAPCOREINFO*)info)->bmciHeader.bcBitCount != 1) return FALSE;
 
         /* Check if the first color is black */
-        if ((rgb->rgbtRed == 0) && (rgb->rgbtGreen == 0) && (rgb->rgbtBlue == 0))
+        if ((rgb[0].rgbtRed == 0) && (rgb[0].rgbtGreen == 0) &&
+            (rgb[0].rgbtBlue == 0))
         {
-            rgb++;
-
             /* Check if the second color is white */
-            return ((rgb->rgbtRed == 0xff) && (rgb->rgbtGreen == 0xff)
-                 && (rgb->rgbtBlue == 0xff));
+            if ((rgb[1].rgbtRed == 0xff) && (rgb[1].rgbtGreen == 0xff) &&
+                (rgb[1].rgbtBlue == 0xff))
+                return TRUE;
         }
-        else return FALSE;
+
+        /* Check if the first color is white */
+        if ((rgb[0].rgbtRed == 0xff) && (rgb[0].rgbtGreen == 0xff) &&
+            (rgb[0].rgbtBlue == 0xff))
+        {
+            /* Check if the second color is black */
+            if ((rgb[1].rgbtRed == 0) && (rgb[1].rgbtGreen == 0) &&
+            (rgb[1].rgbtBlue == 0))
+                return TRUE;
+        }
+        return FALSE;
     }
     else  /* assume BITMAPINFOHEADER */
     {
@@ -139,16 +149,25 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
         if (info->bmiHeader.biBitCount != 1) return FALSE;
 
         /* Check if the first color is black */
-        if ((rgb->rgbRed == 0) && (rgb->rgbGreen == 0) &&
-            (rgb->rgbBlue == 0) && (rgb->rgbReserved == 0))
+        if ((rgb[0].rgbRed == 0) && (rgb[0].rgbGreen == 0) &&
+            (rgb[0].rgbBlue == 0) && (rgb[0].rgbReserved == 0))
         {
-            rgb++;
-
             /* Check if the second color is white */
-            return ((rgb->rgbRed == 0xff) && (rgb->rgbGreen == 0xff)
-                 && (rgb->rgbBlue == 0xff) && (rgb->rgbReserved == 0));
+            if ((rgb[1].rgbRed == 0xff) && (rgb[1].rgbGreen == 0xff) &&
+                (rgb[1].rgbBlue == 0xff) && (rgb[1].rgbReserved == 0))
+                return TRUE;
         }
-        else return FALSE;
+
+        /* Check if the first color is white */
+        if ((rgb[0].rgbRed == 0xff) && (rgb[0].rgbGreen == 0xff) &&
+            (rgb[0].rgbBlue == 0xff) && (rgb[0].rgbReserved == 0))
+        {
+            /* Check if the second color is black */
+            if ((rgb[1].rgbRed == 0) && (rgb[1].rgbGreen == 0) &&
+                (rgb[1].rgbBlue == 0) && (rgb[1].rgbReserved == 0))
+                return TRUE;
+        }
+        return FALSE;
     }
 }
 

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -131,6 +131,10 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
             {
                 return TRUE;
             }
+            else
+            {
+                return FALSE;
+            }
         }
 
         /* Check if the first color is white */
@@ -162,6 +166,10 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
                 (rgb[1].rgbBlue == 0xff) && (rgb[1].rgbReserved == 0))
             {
                 return TRUE;
+            }
+            else
+            {
+                return FALSE;
             }
         }
 

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * PROJECT:         ReactOS user32.dll
  * COPYRIGHT:       GPL - See COPYING in the top level directory
  * FILE:            win32ss/user/user32/windows/cursoricon.c
@@ -128,7 +128,9 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
             /* Check if the second color is white */
             if ((rgb[1].rgbtRed == 0xff) && (rgb[1].rgbtGreen == 0xff) &&
                 (rgb[1].rgbtBlue == 0xff))
+            {
                 return TRUE;
+            }
         }
 
         /* Check if the first color is white */
@@ -138,8 +140,11 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
             /* Check if the second color is black */
             if ((rgb[1].rgbtRed == 0) && (rgb[1].rgbtGreen == 0) &&
             (rgb[1].rgbtBlue == 0))
+            {
                 return TRUE;
+            }
         }
+
         return FALSE;
     }
     else  /* assume BITMAPINFOHEADER */
@@ -155,7 +160,9 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
             /* Check if the second color is white */
             if ((rgb[1].rgbRed == 0xff) && (rgb[1].rgbGreen == 0xff) &&
                 (rgb[1].rgbBlue == 0xff) && (rgb[1].rgbReserved == 0))
+            {
                 return TRUE;
+            }
         }
 
         /* Check if the first color is white */
@@ -165,8 +172,11 @@ static BOOL is_dib_monochrome( const BITMAPINFO* info )
             /* Check if the second color is black */
             if ((rgb[1].rgbRed == 0) && (rgb[1].rgbGreen == 0) &&
                 (rgb[1].rgbBlue == 0) && (rgb[1].rgbReserved == 0))
+            {
                 return TRUE;
+            }
         }
+
         return FALSE;
     }
 }


### PR DESCRIPTION
## Allows color table with White and then Black to be detected as monochrome

_Add additional code in is_dib_monochrome for this option._

JIRA issue: [CORE-13935](https://jira.reactos.org/browse/CORE-13935)

## Additional code testing White then Black added to original test for Black and then White

This code is a modification of code originally proposed by Fabian Maurer as a Wine Fix.
See https://bugs.winehq.org/show_bug.cgi?id=47486