### PR TITLE
[SDK] config.cmake: Fix generic mtune flag

### DIFF
--- a/sdk/cmake/config.cmake
+++ b/sdk/cmake/config.cmake
@@ -30,7 +30,7 @@ if(ARCH STREQUAL "i386" OR ARCH STREQUAL "amd64")
     set(TUNE "generic" CACHE STRING
     "Which CPU ReactOS should be optimized for.")
 elseif(ARCH STREQUAL "arm")
-    set(TUNE "generic-arch" CACHE STRING
+    set(TUNE "generic-armv7-a" CACHE STRING
     "Which CPU ReactOS should be optimized for.")
 endif()
 


### PR DESCRIPTION
The correct `generic` type for armhf is generic-armv7-a, `generic-arch` does not exist.

## Purpose

ARM compilation progress

JIRA issue: 

## Proposed changes

- Switch to the correct mtune option
