### PR TITLE
[CMAKE] CMakeLists.txt: Add arm64 to ARCH allowed values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_STANDARD 11)
 
 # check that the ARCH (target architecture) variable is defined
 if(NOT ARCH)
-    message(FATAL_ERROR "Target architecture (ARCH) is not defined. Please, choose one of: i386, amd64, arm")
+    message(FATAL_ERROR "Target architecture (ARCH) is not defined. Please, choose one of: i386, amd64, arm, arm64")
 endif()
 # Now the ARCH variable will be in lowercase.
 # It is needed because STREQUAL comparison
@@ -40,7 +40,7 @@ endif()
 string(TOLOWER ${ARCH} ARCH)
 
 # set possible values for cmake GUI
-set_property(CACHE ARCH PROPERTY STRINGS "i386" "amd64" "arm")
+set_property(CACHE ARCH PROPERTY STRINGS "i386" "amd64" "arm" "arm64")
 
 # Alternative WinNT-compatible architecture string
 if(ARCH STREQUAL "i386")


### PR DESCRIPTION
## Purpose

Some code already use this value, but the latter is not allowed yet.
Another tiny step, to help ARM64 PRs which add actual code.

JIRA issue: [CORE-17518](https://jira.reactos.org/browse/CORE-17518)
