### PR TITLE
[IMM32] Re-implement ImmGetCompositionStringA/W

### DIFF
--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -53,7 +53,7 @@ Imm32CompAttrWideToAnsi(const BYTE *src, INT src_len, LPCWSTR text,
 
         for (i = 0; i < str_len; ++i, ++k)
         {
-            len = WideCharToMultiByte(uCodePage, 0, text + i, 1, NULL, 0, NULL, NULL);
+            len = WideCharToMultiByte(uCodePage, 0, &text[i], 1, NULL, 0, NULL, NULL);
             for (; len > 0; --len)
             {
                 dst[j++] = src[k];


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Re-implement `ImmGetCompositionStringA` and `ImmGetCompositionStringW` functions.
- Add `Imm32CompStrAnsiToWide`, `Imm32CompStrWideToAnsi`, `Imm32CompAttrWideToAnsi`, `Imm32CompAttrAnsiToWide`, `Imm32CompClauseAnsiToWide`, and `Imm32CompClauseWideToAnsi` helper functions.

