### PR TITLE
[NTOS:PNP] Halfplement IoInvalidateDeviceState

### DIFF
--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -527,7 +527,8 @@ typedef enum _DEVICE_ACTION
     PiActionEnumRootDevices,
     PiActionResetDevice,
     PiActionAddBootDevices,
-    PiActionStartDevice
+    PiActionStartDevice,
+    PiActionQueryState,
 } DEVICE_ACTION;
 
 //
@@ -1402,6 +1403,16 @@ NTSTATUS
 PiIrpQueryDeviceRelations(
     _In_ PDEVICE_NODE DeviceNode,
     _In_ DEVICE_RELATION_TYPE Type);
+
+NTSTATUS
+PiIrpQueryResources(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PCM_RESOURCE_LIST *Resources);
+
+NTSTATUS
+PiIrpQueryResourceRequirements(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PIO_RESOURCE_REQUIREMENTS_LIST *Resources);
 
 NTSTATUS
 PiIrpQueryDeviceText(

--- a/ntoskrnl/io/pnpmgr/pnpirp.c
+++ b/ntoskrnl/io/pnpmgr/pnpirp.c
@@ -196,6 +196,58 @@ PiIrpQueryDeviceRelations(
     return status;
 }
 
+// IRP_MN_QUERY_RESOURCES (0x0A)
+NTSTATUS
+PiIrpQueryResources(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PCM_RESOURCE_LIST *Resources)
+{
+    PAGED_CODE();
+
+    ASSERT(DeviceNode);
+
+    ULONG_PTR longRes;
+    IO_STACK_LOCATION stack = {
+        .MajorFunction = IRP_MJ_PNP,
+        .MinorFunction = IRP_MN_QUERY_RESOURCES
+    };
+
+    NTSTATUS status;
+    status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, (PVOID)&longRes);
+    if (NT_SUCCESS(status))
+    {
+        *Resources = (PVOID)longRes;
+    }
+
+    return status;
+}
+
+// IRP_MN_QUERY_RESOURCE_REQUIREMENTS (0x0B)
+NTSTATUS
+PiIrpQueryResourceRequirements(
+    _In_ PDEVICE_NODE DeviceNode,
+    _Out_ PIO_RESOURCE_REQUIREMENTS_LIST *Resources)
+{
+    PAGED_CODE();
+
+    ASSERT(DeviceNode);
+
+    ULONG_PTR longRes;
+    IO_STACK_LOCATION stack = {
+        .MajorFunction = IRP_MJ_PNP,
+        .MinorFunction = IRP_MN_QUERY_RESOURCE_REQUIREMENTS
+    };
+
+    NTSTATUS status;
+    status = IopSynchronousCall(DeviceNode->PhysicalDeviceObject, &stack, (PVOID)&longRes);
+    if (NT_SUCCESS(status))
+    {
+        *Resources = (PVOID)longRes;
+    }
+
+    return status;
+}
+
 // IRP_MN_QUERY_DEVICE_TEXT (0x0C)
 NTSTATUS
 PiIrpQueryDeviceText(
@@ -236,7 +288,8 @@ PiIrpQueryPnPDeviceState(
     PAGED_CODE();
 
     ASSERT(DeviceNode);
-    ASSERT(DeviceNode->State == DeviceNodeStartPostWork ||
+    ASSERT(DeviceNode->State == DeviceNodeResourcesAssigned ||
+           DeviceNode->State == DeviceNodeStartPostWork ||
            DeviceNode->State == DeviceNodeStarted);
 
     ULONG_PTR longState;

--- a/ntoskrnl/io/pnpmgr/pnpmgr.c
+++ b/ntoskrnl/io/pnpmgr/pnpmgr.c
@@ -2412,3 +2412,11 @@ IoTranslateBusAddress(IN INTERFACE_TYPE InterfaceType,
                                   AddressSpace,
                                   TranslatedAddress);
 }
+
+VOID
+NTAPI
+IoInvalidateDeviceState(
+    IN PDEVICE_OBJECT DeviceObject)
+{
+    PiQueueDeviceAction(DeviceObject, PiActionQueryState, NULL, NULL);
+}


### PR DESCRIPTION
Implement the correct start-stop sequence for resource rebalancing
without the actual rebalancing. Also move IoInvalidateDeviceState
processing into the enumeration thread as it should be.

Jira issue: [CORE-17519](https://jira.reactos.org/browse/CORE-17519)