### PR TITLE
[SHELL32] Bypass OpenWith for Delete and F2 (Rename) Keys

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1573,7 +1573,7 @@ cleanup:
 LRESULT CDefView::OnExplorerCommand(UINT uCommand, BOOL bUseSelection)
 {
     HRESULT hResult;
-    HMENU hMenu;
+    HMENU hMenu = NULL;
 
     hResult = GetItemObject( bUseSelection ? SVGIO_SELECTION : SVGIO_BACKGROUND, IID_PPV_ARG(IContextMenu, &m_pCM));
     if (FAILED_UNEXPECTEDLY( hResult))


### PR DESCRIPTION
## Avoid calling unnecessary code when F2 and Delete keys are used

_This adds a bypass to calling the OpenWith menu code when F2 or Delete key is used._

JIRA issue: [CORE-17810](https://jira.reactos.org/browse/CORE-17810)

## Test keys in CDefView.cpp and bypass OpenWith code if we have Delete or F2