### PR TITLE
[SETUP][REACTOS] Improve Japanese translation

### DIFF
--- a/base/setup/reactos/lang/ja-JP.rc
+++ b/base/setup/reactos/lang/ja-JP.rc
@@ -65,7 +65,7 @@ STYLE DS_SHELLFONT | WS_VISIBLE | WS_CAPTION
 CAPTION "パーティションの作成"
 FONT 9, "MS UI Gothic"
 BEGIN
-    CONTROL "", IDC_UPDOWN1, "msctls_updown32", 0, 129, 22, 9, 13
+    CONTROL "", IDC_UPDOWN1, "msctls_updown32", WS_VISIBLE, 129, 22, 9, 13
     CONTROL "パーティションを作成し、フォーマットします", IDC_STATIC, "Button", BS_GROUPBOX, 6, 5, 161, 57
     LTEXT "サイズ:", IDC_STATIC, 13, 24, 27, 9
     EDITTEXT IDC_PARTSIZE, 83, 22, 47, 13, WS_VISIBLE | WS_TABSTOP
@@ -114,7 +114,7 @@ BEGIN
     EDITTEXT IDC_PATH, 95, 88, 210, 13, ES_READONLY | ES_AUTOHSCROLL | WS_VISIBLE | NOT WS_BORDER | NOT WS_TABSTOP
     AUTOCHECKBOX "すべてのインストール設定が正しいことを確認しました。また、ReactOSがまだアルファ版であり、あなたのコンピュータやデータを壊す恐れがあることを理解しています。",
         IDC_CONFIRM_INSTALL, 7, 104, 303, 18, BS_MULTILINE
-    LTEXT "すべてのインストール設定が正しいことを確認し、インストールプロセスを開始するために、インストールをクリックして下さい。", IDC_STATIC, 7, 124, 303, 18
+    LTEXT "すべてのインストール設定が正しいことを確認し、インストール プロセスを開始するために、インストールをクリックして下さい。", IDC_STATIC, 7, 124, 303, 18
 END
 
 IDD_PROCESSPAGE DIALOGEX 0, 0, 317, 143


### PR DESCRIPTION
## Purpose

Improve the Japanese GUI of ReactOS Setup.
JIRA issue: N/A

## Proposed changes

- Modify Japanese resource.

## Screenshots
I got some screenshots from compiled binary by using `RisohEditor` with replacing `"MS UI Gothic"` font with `"Droid Sans Fallback"`:

### BEFORE
![無題1](https://user-images.githubusercontent.com/2107452/137277538-0468565a-3891-4805-ae45-75561880c43b.png)
![無題2](https://user-images.githubusercontent.com/2107452/137277613-f42b71d5-2239-46b6-9092-0c23a9ce5067.png)
![無題3](https://user-images.githubusercontent.com/2107452/137277531-cd608d17-0388-48e2-8427-e85af9920eaa.png)
![無題4](https://user-images.githubusercontent.com/2107452/137277747-801bfee5-a839-48ca-9fba-c3f62207deed.png)

### AFTER
![無題1](https://user-images.githubusercontent.com/2107452/137253429-3ffcc962-3928-4586-a4d4-1a50ac43f2f5.png)
![無題2](https://user-images.githubusercontent.com/2107452/137254343-ccbebbdd-a97b-43aa-b997-babe7ca16b64.png)
![無題3](https://user-images.githubusercontent.com/2107452/137253434-21a93a4d-a460-496d-a561-f7114ee967b2.png)
![無題4](https://user-images.githubusercontent.com/2107452/137253427-4c00211a-04c8-416e-ad7b-4cd02d0e1cb2.png)