### PR TITLE
[MSXML3_WINETEST] Fix schema test crashes and sync to Wine-6.14

### DIFF
--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -131,7 +131,13 @@ dll/win32/msvfw32             # Synced to WineStaging-4.18
 dll/win32/msvidc32            # Synced to WineStaging-4.0
 dll/win32/msxml               # Synced to WineStaging-3.3
 dll/win32/msxml2              # Synced to WineStaging-3.3
-dll/win32/msxml3              # Synced to WineStaging-4.18
+dll/win32/msxml3/domdoc       # Synced to WineStaging-4.18
+dll/win32/msxml3/httpreq      # Synced to WineStaging-4.18
+dll/win32/msxml3/saxreader    # Synced to WineStaging-4.18
+dll/win32/msxml3/schema       # Synced to Wine-6.14
+dll/win32/msxml3/xmldoc       # Synced to WineStaging-4.18
+dll/win32/msxml3/xmlparser    # Synced to WineStaging-4.18
+dll/win32/msxml3/xmlview      # Synced to WineStaging-4.18
 dll/win32/msxml4              # Synced to WineStaging-3.3
 dll/win32/msxml6              # Synced to WineStaging-3.3
 dll/win32/nddeapi             # Synced to WineStaging-3.3

--- a/modules/rostests/winetests/msxml3/schema.c
+++ b/modules/rostests/winetests/msxml3/schema.c
@@ -19,8 +19,6 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-/* Synced to Wine-6.14 by Doug Lyons on September 21, 2021 */
-
 #include <stdio.h>
 #include <assert.h>
 #define COBJMACROS


### PR DESCRIPTION
## Fix test crashes and Sync to Wine-6.14

_Add four ifdef REACTOS to bypass code causing crashes and Sync to Wine-6.14._

JIRA issue: [CORE-17783](https://jira.reactos.org/browse/CORE-17783)

## Update modules/rostests/winetests/msxml3/schema.c to eliminate crashes