### PR TITLE
[FREELDR] Sort out /BASEVIDEO and /NOVESA handling

### DIFF
--- a/boot/freeldr/freeldr/options.c
+++ b/boot/freeldr/freeldr/options.c
@@ -84,8 +84,9 @@ enum BootOption
 
 static enum BootOption BootOptionChoice = NO_OPTION;
 static BOOLEAN BootLogging = FALSE;
-static BOOLEAN VgaMode = FALSE;
+static BOOLEAN VgaMode = FALSE; // Use 640*480*N resolution(s) only, with current video driver.
 static BOOLEAN DebuggingMode = FALSE;
+static BOOLEAN VgaDriverOnly = FALSE; // Use VGA driver only.
 
 /* FUNCTIONS ******************************************************************/
 
@@ -116,14 +117,17 @@ VOID DoOptionsMenu(IN OperatingSystemItem* OperatingSystem)
         case 0: // Safe Mode
             BootOptionChoice = SAFE_MODE;
             BootLogging = TRUE;
+            VgaDriverOnly = TRUE;
             break;
         case 1: // Safe Mode with Networking
             BootOptionChoice = SAFE_MODE_WITH_NETWORKING;
             BootLogging = TRUE;
+            VgaDriverOnly = TRUE;
             break;
         case 2: // Safe Mode with Command Prompt
             BootOptionChoice = SAFE_MODE_WITH_COMMAND_PROMPT;
             BootLogging = TRUE;
+            VgaDriverOnly = TRUE;
             break;
         // case 3: // Separator
         //     break;
@@ -159,6 +163,7 @@ VOID DoOptionsMenu(IN OperatingSystemItem* OperatingSystem)
             BootLogging = FALSE;
             VgaMode = FALSE;
             DebuggingMode = FALSE;
+            VgaDriverOnly = FALSE;
             break;
 #ifdef HAS_OPTION_MENU_EDIT_CMDLINE
         case 12: // Edit command line
@@ -214,31 +219,23 @@ VOID DisplayBootTimeOptions(VOID)
              (BootOptionChoice != SAFE_MODE_WITH_NETWORKING) &&
              (BootOptionChoice != SAFE_MODE_WITH_COMMAND_PROMPT) )
         {
-            if (BootOptionChoice != NO_OPTION)
-            {
+            if (BootOptions[0] != ANSI_NULL)
                 strcat(BootOptions, ", ");
-            }
             strcat(BootOptions, OptionsMenuList[4]);
         }
     }
 
     if (VgaMode)
     {
-        if ((BootOptionChoice != NO_OPTION) ||
-             BootLogging)
-        {
+        if (BootOptions[0] != ANSI_NULL)
             strcat(BootOptions, ", ");
-        }
         strcat(BootOptions, OptionsMenuList[5]);
     }
 
     if (DebuggingMode)
     {
-        if ((BootOptionChoice != NO_OPTION) ||
-             BootLogging || VgaMode)
-        {
+        if (BootOptions[0] != ANSI_NULL)
             strcat(BootOptions, ", ");
-        }
         strcat(BootOptions, OptionsMenuList[8]);
     }
 
@@ -281,8 +278,11 @@ VOID AppendBootTimeOptions(PCHAR BootOptions)
         strcat(BootOptions, " /BOOTLOG");
 
     if (VgaMode)
-        strcat(BootOptions, " /BASEVIDEO");
+        strcat(BootOptions, " /NOVESA");
 
     if (DebuggingMode)
         strcat(BootOptions, " /DEBUG");
+
+    if (VgaDriverOnly)
+        strcat(BootOptions, " /BASEVIDEO");
 }

--- a/win32ss/user/ntuser/display.c
+++ b/win32ss/user/ntuser/display.c
@@ -160,13 +160,14 @@ InitVideo(VOID)
 
     TRACE("----------------------------- InitVideo() -------------------------------\n");
 
-    /* Check if VGA mode is requested, by finding the special volatile key created by VIDEOPRT */
+    /* Check if BaseVideo mode is requested, by finding the special volatile key created by VIDEOPRT */
     Status = RegOpenKey(L"\\Registry\\Machine\\System\\CurrentControlSet\\Control\\GraphicsDrivers\\BaseVideo", &hkey);
-    if (NT_SUCCESS(Status))
-        ZwClose(hkey);
     gbBaseVideo = NT_SUCCESS(Status);
     if (gbBaseVideo)
-        ERR("VGA mode requested.\n");
+    {
+        ZwClose(hkey);
+        ERR("BaseVideo mode requested\n");
+    }
 
     /* Initialize all display devices */
     Status = EngpUpdateGraphicsDeviceList();


### PR DESCRIPTION
## Purpose

Properly handle requesting VGA driver itself (Safe mode) or VGA-like resolution only (VGA mode).

JIRA issue: [CORE-10236](https://jira.reactos.org/browse/CORE-10236)

## Proposed changes

- Tweak NTUSER.
- Improve VIDEOPRT.
- Fix FREELDR.

## TODO

- [ ] `NOVESA` option seems undocumented and not to exist on WXP/WS03.
Where does it come from?
I wonder if it should be replaced by checking `BASEVIDEO` and the relevant `SAFEBOOT:...`, in VIDEOPRT?
Even though WXP (VIDEOPRT) does not seem to do it that way either.
- [ ] This PR does not try to fix VBE driver (handling): 'VGA mode' still behaves like (new) 'Safe mode'.
Ideas welcome, or will remain as a follow-up.