### PR TITLE
[SHELL32] Enable OpenWith to handle "NoOpenWith" and "NoStartPage" registry keys

### DIFF
--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -110,10 +110,11 @@ COpenWithList::~COpenWithList()
 
 BOOL COpenWithList::Load()
 {
-    HKEY hKey;
+    HKEY hKey, hKeyApp;
     WCHAR wszName[256], wszBuf[100];
     DWORD i = 0, cchName, dwSize;
     SApp *pApp;
+    PHKEY phKeyApp = &hKeyApp;
 
     if (RegOpenKeyEx(HKEY_CLASSES_ROOT, L"Applications", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
     {
@@ -131,15 +132,34 @@ BOOL COpenWithList::Load()
 
         if (pApp)
         {
-            StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s\\shell\\open\\command", wszName);
-            dwSize = sizeof(pApp->wszCmd);
-            if (RegGetValueW(hKey, wszBuf, L"", RRF_RT_REG_SZ, NULL, pApp->wszCmd, &dwSize) != ERROR_SUCCESS)
+            StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s", wszName);
+            if (RegOpenKeyW(hKey, wszBuf, phKeyApp) == ERROR_SUCCESS)
             {
-                ERR("Failed to add app %ls\n", wszName);
-                pApp->bHidden = TRUE;
+                if ((RegQueryValueExW(hKeyApp, L"NoOpenWith", NULL,  NULL, NULL, NULL)
+                    != ERROR_SUCCESS) &&
+                    (RegQueryValueExW(hKeyApp, L"NoStartPage", NULL,  NULL, NULL, NULL)
+                    != ERROR_SUCCESS))
+                {
+                    StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s\\shell\\open\\command", wszName);
+                     dwSize = sizeof(pApp->wszCmd);
+                    if (RegGetValueW(hKey, wszBuf, L"", RRF_RT_REG_SZ, NULL, pApp->wszCmd, &dwSize) != ERROR_SUCCESS)
+                    {
+                        ERR("Failed to add app %ls\n", wszName);
+                        pApp->bHidden = TRUE;
+                    }
+                    else
+                        TRACE("App added %ls\n", pApp->wszCmd);
+                }
+                else
+                {
+                    pApp->bHidden = TRUE;
+                }
+                RegCloseKey(hKeyApp);
             }
             else
-                TRACE("App added %ls\n", pApp->wszCmd);
+            {
+                pApp->bHidden = TRUE;
+            }
         }
         else
             ERR("AddInternal failed\n");

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -131,8 +131,7 @@ BOOL COpenWithList::Load()
 
         if (pApp)
         {
-            StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s", wszName);
-            if (RegOpenKeyW(hKey, wszBuf, &hKeyApp) == ERROR_SUCCESS)
+            if (RegOpenKeyW(hKey, wszName, &hKeyApp) == ERROR_SUCCESS)
             {
                 if ((RegQueryValueExW(hKeyApp, L"NoOpenWith", NULL,  NULL, NULL, NULL) != ERROR_SUCCESS) &&
                     (RegQueryValueExW(hKeyApp, L"NoStartPage", NULL,  NULL, NULL, NULL) != ERROR_SUCCESS))

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -148,7 +148,9 @@ BOOL COpenWithList::Load()
                         pApp->bHidden = TRUE;
                     }
                     else
+                    {
                         TRACE("App added %ls\n", pApp->wszCmd);
+                    }
                 }
                 else
                 {
@@ -162,7 +164,9 @@ BOOL COpenWithList::Load()
             }
         }
         else
+        {
             ERR("AddInternal failed\n");
+        }
     }
 
     RegCloseKey(hKey);

--- a/dll/win32/shell32/COpenWithMenu.cpp
+++ b/dll/win32/shell32/COpenWithMenu.cpp
@@ -114,7 +114,6 @@ BOOL COpenWithList::Load()
     WCHAR wszName[256], wszBuf[100];
     DWORD i = 0, cchName, dwSize;
     SApp *pApp;
-    PHKEY phKeyApp = &hKeyApp;
 
     if (RegOpenKeyEx(HKEY_CLASSES_ROOT, L"Applications", 0, KEY_READ, &hKey) != ERROR_SUCCESS)
     {
@@ -133,15 +132,13 @@ BOOL COpenWithList::Load()
         if (pApp)
         {
             StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s", wszName);
-            if (RegOpenKeyW(hKey, wszBuf, phKeyApp) == ERROR_SUCCESS)
+            if (RegOpenKeyW(hKey, wszBuf, &hKeyApp) == ERROR_SUCCESS)
             {
-                if ((RegQueryValueExW(hKeyApp, L"NoOpenWith", NULL,  NULL, NULL, NULL)
-                    != ERROR_SUCCESS) &&
-                    (RegQueryValueExW(hKeyApp, L"NoStartPage", NULL,  NULL, NULL, NULL)
-                    != ERROR_SUCCESS))
+                if ((RegQueryValueExW(hKeyApp, L"NoOpenWith", NULL,  NULL, NULL, NULL) != ERROR_SUCCESS) &&
+                    (RegQueryValueExW(hKeyApp, L"NoStartPage", NULL,  NULL, NULL, NULL) != ERROR_SUCCESS))
                 {
                     StringCbPrintfW(wszBuf, sizeof(wszBuf), L"%s\\shell\\open\\command", wszName);
-                     dwSize = sizeof(pApp->wszCmd);
+                    dwSize = sizeof(pApp->wszCmd);
                     if (RegGetValueW(hKey, wszBuf, L"", RRF_RT_REG_SZ, NULL, pApp->wszCmd, &dwSize) != ERROR_SUCCESS)
                     {
                         ERR("Failed to add app %ls\n", wszName);


### PR DESCRIPTION
## Stop logspam when right-click menu testing for OpenWith is done.

_Add registry handling of two keys to COpenWithMenu.cpp._

JIRA issue: [CORE-17816](https://jira.reactos.org/browse/CORE-17816)

## Add code to stop OpenWith from using registry entries that should be excluded.