### PR TITLE
[EXPLORER] Send WM_POPUPSYSTEMMENU asynchronously

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1630,6 +1630,11 @@ public:
         return FALSE;
     }
 
+    static VOID CALLBACK
+    SendAsyncProc(HWND hwnd, UINT uMsg, DWORD_PTR dwData, LRESULT lResult)
+    {
+        ::PostMessageW(hwnd, WM_NULL, 0, 0);
+    }
 
     VOID HandleTaskItemRightClick(IN OUT PTASK_ITEM TaskItem)
     {
@@ -1640,14 +1645,11 @@ public:
 
         ActivateTask(TaskItem->hWnd);
 
-       /* Wait up to 2 seconds for the window to process the foreground notification. */
-        DWORD_PTR resultDummy;
-        if (!SendMessageTimeout(TaskItem->hWnd, WM_NULL, 0, 0, 0, 2000, &resultDummy))
-            ERR("HandleTaskItemRightClick detected the window was unresponsive for 2 seconds, or was destroyed\n");
         if (GetForegroundWindow() != TaskItem->hWnd)
             ERR("HandleTaskItemRightClick detected the window did not become foreground\n");
 
-        ::SendMessageW(TaskItem->hWnd, WM_POPUPSYSTEMMENU, 0, MAKELPARAM(pt.x, pt.y));
+        ::SendMessageCallbackW(TaskItem->hWnd, WM_POPUPSYSTEMMENU, 0, MAKELPARAM(pt.x, pt.y),
+                               SendAsyncProc, (ULONG_PTR)TaskItem);
     }
 
     VOID HandleTaskGroupRightClick(IN OUT PTASK_GROUP TaskGroup)


### PR DESCRIPTION
## Purpose
Fix CORE-16353.
JIRA issue: [CORE-16353](https://jira.reactos.org/browse/CORE-16353)

## Proposed changes

- Delete useless `SendMessageTimeout:WM_NULL` call.
- Add useful `SendMessageCallbackW:WM_POPUPSYSTEMMENU` call.
- In the callback function of `SendMessageCallbackW`, do `PostMessageW:WM_NULL` to properly handle the popup menu.

## TODO

- [x] Do test.

## Screenshot

![VirtualBox_ReactOS_18_10_2021_20_53_04](https://user-images.githubusercontent.com/2107452/137726297-20faed5a-881d-4ef5-bc64-aa37ab439bf9.png)
Successful.