### PR TITLE
[NTUSER][USER32] Ignore QF_ACTIVATIONCHANGE flag on tracking menu

### DIFF
--- a/win32ss/user/ntuser/menu.c
+++ b/win32ss/user/ntuser/menu.c
@@ -4118,7 +4118,7 @@ static INT FASTCALL MENU_TrackMenu(PMENU pmenu, UINT wFlags, INT x, INT y,
                 /* ReactOS Checks */
                 if (!VerifyWnd(mt.OwnerWnd)                            ||
                     !ValidateHwndNoErr(mt.CurrentMenu->hWnd)           ||
-                     pti->MessageQueue->QF_flags & QF_ACTIVATIONCHANGE ||
+                     //pti->MessageQueue->QF_flags & QF_ACTIVATIONCHANGE || // See CORE-17338
                      capture_win != IntGetCapture() ) // Should not happen, but this is ReactOS...
                 {
                    ErrorExit = TRUE; // Do not wait on dead windows, now win test_capture_4 works.

--- a/win32ss/user/user32/windows/defwnd.c
+++ b/win32ss/user/user32/windows/defwnd.c
@@ -338,8 +338,11 @@ User32DefWindowProc(HWND hWnd,
             HMENU menu = GetSystemMenu(hWnd, FALSE);
             ERR("WM_POPUPSYSTEMMENU\n");
             if (menu)
+            {
+                SetForegroundWindow(hWnd);
                 TrackPopupMenu(menu, TPM_LEFTBUTTON|TPM_RIGHTBUTTON|TPM_SYSTEM_MENU,
                                LOWORD(lParam), HIWORD(lParam), 0, hWnd, NULL);
+            }
             return 0;
         }
 


### PR DESCRIPTION
## Purpose
On the setup program of Double Commanders, when the user Right-Clicked the taskbar pane, the system menu was quickly disappeared.
JIRA issue: [CORE-17338](https://jira.reactos.org/browse/CORE-17338)

## Proposed changes

- Disable `QF_ACTIVATIONCHANGE` flag check in `MENU_TrackMenu` function.
- Do call `SetForegroundWindow` function on default handling `WM_POPUPSYSTEMMENU` message.

## TODO

- [ ] Do tests.

## Screenshot
![VirtualBox_ReactOS_19_10_2021_14_44_05](https://user-images.githubusercontent.com/2107452/137851258-842ed187-897a-4119-97c8-85fae0f8e368.png)
Successful.