### PR TITLE
[KERNEL32] Implement SetFileCompletionNotificationModes

### DIFF
--- a/dll/win32/kernel32/client/file/iocompl.c
+++ b/dll/win32/kernel32/client/file/iocompl.c
@@ -3,7 +3,8 @@
  * PROJECT:         ReactOS system libraries
  * FILE:            dll/win32/kernel32/client/file/iocompl.c
  * PURPOSE:         Io Completion functions
- * PROGRAMMER:      Ariadne ( ariadne@xs4all.nl)
+ * PROGRAMMERS:     Ariadne (ariadne@xs4all.nl)
+ *                  Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
  * UPDATE HISTORY:
  *                  Created 01/11/98
  */
@@ -23,21 +24,37 @@
 #endif
 
 /*
- * @unimplemented
+ * @implemented
  */
 BOOL
 WINAPI
 SetFileCompletionNotificationModes(IN HANDLE FileHandle,
                                    IN UCHAR Flags)
 {
+    NTSTATUS Status;
+    FILE_IO_COMPLETION_NOTIFICATION_INFORMATION FileInformation;
+    IO_STATUS_BLOCK IoStatusBlock;
+
     if (Flags & ~(FILE_SKIP_COMPLETION_PORT_ON_SUCCESS | FILE_SKIP_SET_EVENT_ON_HANDLE))
     {
         SetLastError(ERROR_INVALID_PARAMETER);
         return FALSE;
     }
 
-    UNIMPLEMENTED;
-    return FALSE;
+    FileInformation.Flags = Flags;
+
+    Status = NtSetInformationFile(FileHandle,
+                                  &IoStatusBlock,
+                                  &FileInformation,
+                                  sizeof(FileInformation),
+                                  FileIoCompletionNotificationInformation);
+    if (!NT_SUCCESS(Status))
+    {
+        BaseSetLastNTError(Status);
+        return FALSE;
+    }
+
+    return TRUE;
 }
 
 /*

--- a/dll/win32/kernel32/k32.h
+++ b/dll/win32/kernel32/k32.h
@@ -35,6 +35,7 @@
 #include <ndk/cmfuncs.h>
 #include <ndk/exfuncs.h>
 #include <ndk/iofuncs.h>
+#include <ndk/iotypes.h>
 #include <ndk/kdtypes.h>
 #include <ndk/kefuncs.h>
 #include <ndk/ldrfuncs.h>

--- a/sdk/include/ndk/iotypes.h
+++ b/sdk/include/ndk/iotypes.h
@@ -323,8 +323,8 @@ typedef enum _FILE_INFORMATION_CLASS
     FileIdFullDirectoryInformation,
     FileValidDataLengthInformation,
     FileShortNameInformation,
-#if (NTDDI_VERSION >= NTDDI_VISTA)
     FileIoCompletionNotificationInformation,
+#if (NTDDI_VERSION >= NTDDI_VISTA)
     FileIoStatusBlockRangeInformation,
     FileIoPriorityHintInformation,
     FileSfioReserveInformation,
@@ -603,6 +603,11 @@ typedef struct _FILE_COMPLETION_INFORMATION
     HANDLE Port;
     PVOID Key;
 } FILE_COMPLETION_INFORMATION, *PFILE_COMPLETION_INFORMATION;
+
+typedef struct _FILE_IO_COMPLETION_NOTIFICATION_INFORMATION
+{
+    ULONG Flags;
+} FILE_IO_COMPLETION_NOTIFICATION_INFORMATION, *PFILE_IO_COMPLETION_NOTIFICATION_INFORMATION;
 
 typedef struct _FILE_LINK_INFORMATION
 {


### PR DESCRIPTION
## Purpose

Implement `SetFileCompletionNotificationModes` function in our kernel32. MSDN says this function was added since Vista+, but according to @HBelusca's comment on Jira, this API is also present in Windows Server 2003 SP2: https://jira.reactos.org/browse/CORE-17821?focusedCommentId=130199&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-130199.
Call native Nt* function to do the actual work, similarly to as it done in Wine: https://source.winehq.org/git/wine.git/blob/530c1839603bd3caa1b9d17fe458b5bd341ccfc9:/dlls/kernel32/file.c#l258.
Also add/fix some declarations in internal kernel32/public NDK headers, to fix compilation.
It does not fix the actual issue, but at least makes some progress on it.

JIRA issue: [CORE-17821](https://jira.reactos.org/browse/CORE-17821)

## Proposed changes

- Implement the function itself.
- Include required header in kernel32.
- Add missing structure declaration into public NDK header.