### PR TITLE
[SHELL32_APITEST] Strengthen ShellHook testcase for fullscreen

### DIFF
--- a/modules/rostests/apitests/shell32/ShellHook.cpp
+++ b/modules/rostests/apitests/shell32/ShellHook.cpp
@@ -443,7 +443,6 @@ static void DoRudeAppTest1(const RUDEAPP_TEST_ENTRY *pEntry)
         SetForegroundWindow(s_hwndTarget);
     if (pEntry->bSetFullscreen)
     {
-        s_nRudeAppActivated = 0;
         MoveWindow(s_hwndTarget, 0, 0,
                    GetSystemMetrics(SM_CXSCREEN), GetSystemMetrics(SM_CYSCREEN), TRUE);
     }


### PR DESCRIPTION
## Purpose

Investigate on `HSHELL_RUDEAPPACTIVATED` shell hook.
JIRA issue: [CORE-16130](https://jira.reactos.org/browse/CORE-16130)

## Proposed changes

- Add tests for `HSHELL_RUDEAPPACTIVATED`.

## Screenshots

WinXP:
![WinXP](https://user-images.githubusercontent.com/2107452/138096895-3766e14c-1309-4a42-9a4f-c24afcef6f61.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/138096905-4a9112f5-45a6-4136-935d-fc3b517598c8.png)
Successful.

Win10:
![Win10](https://user-images.githubusercontent.com/2107452/138096903-1e2a69e7-1225-435a-817c-74a187602ca3.png)
Some failures.