### PR TITLE
[WIN32SS:NTUSER] Make sure to hold User Global Lock before playing with desktops.

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -561,6 +561,8 @@ IntResolveDesktop(
     BOOLEAN bInteractive = FALSE;
     BOOLEAN bAccessAllowed = FALSE;
 
+    ASSERT(UserIsEnteredExclusive());
+
     ASSERT(phWinSta);
     ASSERT(phDesktop);
     ASSERT(DesktopPath);
@@ -2329,6 +2331,8 @@ IntCreateDesktop(
 
     TRACE("Enter IntCreateDesktop\n");
 
+    ASSERT(UserIsEnteredExclusive());
+
     ASSERT(phDesktop);
     *phDesktop = NULL;
 
@@ -2808,7 +2812,7 @@ NtUserResolveDesktop(
     if (!NT_SUCCESS(Status))
         return NULL;
 
-    // UserEnterShared();
+    UserEnterExclusive();
 
     _SEH2_TRY
     {
@@ -2863,7 +2867,7 @@ NtUserResolveDesktop(
     ReleaseCapturedUnicodeString(&CapturedDesktopPath, UserMode);
 
 Quit:
-    // UserLeave();
+    UserLeave();
 
     /* Dereference the process object */
     ObDereferenceObject(Process);


### PR DESCRIPTION
## Purpose

Should fix the bug detected by @julcar :
![image](https://user-images.githubusercontent.com/1969829/138160229-0a683dc8-603d-4f28-b792-044c4f64cca0.png)
![image](https://user-images.githubusercontent.com/1969829/138160319-7374f61a-191a-490a-ae5d-fd6efe1bac61.png)
