### PR TITLE
[WIN32SS][NTUSER] Add ENABLE_IME_SUPPORT CMake option

### DIFF
--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -4,6 +4,11 @@ set(USE_DIBLIB FALSE)
 # Give WIN32 subsystem its own project.
 PROJECT(WIN32SS)
 
+option(ENABLE_IME_SUPPORT "Enable IME/IMM support" OFF)
+if (ENABLE_IME_SUPPORT)
+    add_definitions(-DENABLE_IME_SUPPORT)
+endif()
+
 add_subdirectory(drivers)
 
 if(USE_DIBLIB)

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -155,7 +155,11 @@ InitMetrics(VOID)
     piSysMet[SM_MIDEASTENABLED] = 0;
     piSysMet[SM_CMONITORS] = 1;
     piSysMet[SM_SAMEDISPLAYFORMAT] = 1;
+#ifdef ENABLE_IME_SUPPORT
+    piSysMet[SM_IMMENABLED] = 1;
+#else
     piSysMet[SM_IMMENABLED] = 0;
+#endif
 
     /* Reserved */
     piSysMet[SM_RESERVED1] = 0;


### PR DESCRIPTION
## Purpose
To clarify the code area of the IME/IMM support and to switch IME/IMM support, I want to add an option for IME/IMM support.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `ENABLE_IME_SUPPORT` CMake option into `win32ss/CMakeLists.txt`.
- Define `ENABLE_IME_SUPPORT` macro if `ENABLE_IME_SUPPORT` option is enabled.
- Apply the option to the `SM_IMMENABLED` system metric.

## TODO

- [ ] Get team's consensus.
