### PR TITLE
Set Afd window sizes based on System Size

### DIFF
--- a/drivers/network/afd/afd/main.c
+++ b/drivers/network/afd/afd/main.c
@@ -22,10 +22,6 @@ DWORD DebugTraceLevel = MIN_TRACE;
 
 #endif /* DBG */
 
-/* FIXME: should depend on SystemSize */
-ULONG AfdReceiveWindowSize = 0x2000;
-ULONG AfdSendWindowSize = 0x2000;
-
 void OskitDumpBuffer( PCHAR Data, UINT Len ) {
     unsigned int i;
 
@@ -310,6 +306,7 @@ AfdCreateSocket(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     PWCHAR EaInfoValue = NULL;
     //UINT Disposition;
     UINT i;
+    ULONG AfdReceiveWindowSize, AfdSendWindowSize;
     NTSTATUS Status = STATUS_SUCCESS;
 
     AFD_DbgPrint(MID_TRACE,("AfdCreate(DeviceObject %p Irp %p)\n",
@@ -347,6 +344,21 @@ AfdCreateSocket(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                             FCB, FileObject, ConnectInfo ? ConnectInfo->EndpointFlags : 0));
 
     RtlZeroMemory( FCB, sizeof( *FCB ) );
+
+    switch (MmQuerySystemSize()) {
+        case MmSmallSystem:
+            AfdReceiveWindowSize = SMALL_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = SMALL_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+        case MmMediumSystem:
+            AfdReceiveWindowSize = MEDIUM_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = MEDIUM_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+        case MmLargeSystem:
+            AfdReceiveWindowSize = LARGE_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = LARGE_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+    }
 
     FCB->Flags = ConnectInfo ? ConnectInfo->EndpointFlags : 0;
     FCB->GroupID = ConnectInfo ? ConnectInfo->GroupID : 0;

--- a/drivers/network/afd/afd/main.c
+++ b/drivers/network/afd/afd/main.c
@@ -1313,7 +1313,11 @@ DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath)
     PAFD_DEVICE_EXTENSION DeviceExt;
     NTSTATUS Status;
 
-    switch (MmQuerySystemSize()) {
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    /* set window sizes based on system size */
+    switch (MmQuerySystemSize())
+    {
         case MmSmallSystem:
             AfdReceiveWindowSize = SMALL_SYSTEM_RECEIVE_WINDOW_SIZE;
             AfdSendWindowSize = SMALL_SYSTEM_SEND_WINDOW_SIZE;
@@ -1328,7 +1332,6 @@ DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath)
             break;
     }
 
-    UNREFERENCED_PARAMETER(RegistryPath);
     /* register driver routines */
     DriverObject->MajorFunction[IRP_MJ_CLOSE] = AfdDispatch;
     DriverObject->MajorFunction[IRP_MJ_CREATE] = AfdDispatch;

--- a/drivers/network/afd/afd/main.c
+++ b/drivers/network/afd/afd/main.c
@@ -22,6 +22,8 @@ DWORD DebugTraceLevel = MIN_TRACE;
 
 #endif /* DBG */
 
+ULONG AfdReceiveWindowSize, AfdSendWindowSize;
+
 void OskitDumpBuffer( PCHAR Data, UINT Len ) {
     unsigned int i;
 
@@ -306,7 +308,6 @@ AfdCreateSocket(PDEVICE_OBJECT DeviceObject, PIRP Irp,
     PWCHAR EaInfoValue = NULL;
     //UINT Disposition;
     UINT i;
-    ULONG AfdReceiveWindowSize, AfdSendWindowSize;
     NTSTATUS Status = STATUS_SUCCESS;
 
     AFD_DbgPrint(MID_TRACE,("AfdCreate(DeviceObject %p Irp %p)\n",
@@ -344,21 +345,6 @@ AfdCreateSocket(PDEVICE_OBJECT DeviceObject, PIRP Irp,
                             FCB, FileObject, ConnectInfo ? ConnectInfo->EndpointFlags : 0));
 
     RtlZeroMemory( FCB, sizeof( *FCB ) );
-
-    switch (MmQuerySystemSize()) {
-        case MmSmallSystem:
-            AfdReceiveWindowSize = SMALL_SYSTEM_RECEIVE_WINDOW_SIZE;
-            AfdSendWindowSize = SMALL_SYSTEM_SEND_WINDOW_SIZE;
-            break;
-        case MmMediumSystem:
-            AfdReceiveWindowSize = MEDIUM_SYSTEM_RECEIVE_WINDOW_SIZE;
-            AfdSendWindowSize = MEDIUM_SYSTEM_SEND_WINDOW_SIZE;
-            break;
-        case MmLargeSystem:
-            AfdReceiveWindowSize = LARGE_SYSTEM_RECEIVE_WINDOW_SIZE;
-            AfdSendWindowSize = LARGE_SYSTEM_SEND_WINDOW_SIZE;
-            break;
-    }
 
     FCB->Flags = ConnectInfo ? ConnectInfo->EndpointFlags : 0;
     FCB->GroupID = ConnectInfo ? ConnectInfo->GroupID : 0;
@@ -1326,6 +1312,21 @@ DriverEntry(PDRIVER_OBJECT DriverObject, PUNICODE_STRING RegistryPath)
     UNICODE_STRING wstrDeviceName = RTL_CONSTANT_STRING(L"\\Device\\Afd");
     PAFD_DEVICE_EXTENSION DeviceExt;
     NTSTATUS Status;
+
+    switch (MmQuerySystemSize()) {
+        case MmSmallSystem:
+            AfdReceiveWindowSize = SMALL_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = SMALL_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+        case MmMediumSystem:
+            AfdReceiveWindowSize = MEDIUM_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = MEDIUM_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+        case MmLargeSystem:
+            AfdReceiveWindowSize = LARGE_SYSTEM_RECEIVE_WINDOW_SIZE;
+            AfdSendWindowSize = LARGE_SYSTEM_SEND_WINDOW_SIZE;
+            break;
+    }
 
     UNREFERENCED_PARAMETER(RegistryPath);
     /* register driver routines */

--- a/drivers/network/afd/include/afd.h
+++ b/drivers/network/afd/include/afd.h
@@ -13,6 +13,7 @@
 
 #include <ntifs.h>
 #include <ndk/obtypes.h>
+#include <ndk/mmfuncs.h>
 #include <tdi.h>
 #include <tcpioctl.h>
 #define _WINBASE_
@@ -52,6 +53,14 @@
 #define TAG_AFD_SNMP_ADDRESS_INFO          'asfA'
 #define TAG_AFD_TDI_CONNECTION_INFORMATION 'cTfA'
 #define TAG_AFD_WSA_BUFFER                 'bWfA'
+
+/* Window Sizes for Send & Receive */
+#define SMALL_SYSTEM_SEND_WINDOW_SIZE     0x1000
+#define SMALL_SYSTEM_RECEIVE_WINDOW_SIZE  0x1000
+#define MEDIUM_SYSTEM_SEND_WINDOW_SIZE    0x2000
+#define MEDIUM_SYSTEM_RECEIVE_WINDOW_SIZE 0x2000
+#define LARGE_SYSTEM_SEND_WINDOW_SIZE     0x2000
+#define LARGE_SYSTEM_RECEIVE_WINDOW_SIZE  0x2000
 
 typedef struct IPADDR_ENTRY {
 	ULONG  Addr;


### PR DESCRIPTION
## Purpose

Until now, Afd Window Sizes are set by default with a static value, but according to [this post](http://smallvoid.com/article/winnt-winsock-buffer.html) that behavior is wrong, the correct way is to query the system size and then set the sizes based on that value.