### PR TITLE
Minor formatting + SAL annotations for NtQuery/SetSystemInformation 

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -2989,12 +2989,13 @@ NtQuerySystemInformation(
     return FStatus;
 }
 
-
+__kernel_entry
 NTSTATUS
 NTAPI
-NtSetSystemInformation (IN SYSTEM_INFORMATION_CLASS SystemInformationClass,
-                        IN PVOID SystemInformation,
-                        IN ULONG SystemInformationLength)
+NtSetSystemInformation(
+    _In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
+    _In_reads_bytes_(SystemInformationLength) PVOID SystemInformation,
+    _In_ ULONG SystemInformationLength)
 {
     NTSTATUS Status = STATUS_INVALID_INFO_CLASS;
     KPROCESSOR_MODE PreviousMode;

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1287,7 +1287,6 @@ QSI_DEF(SystemNonPagedPoolInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
 /* Class 16 - Handle Information */
 QSI_DEF(SystemHandleInformation)
 {
@@ -2070,7 +2069,6 @@ QSI_DEF(SystemCurrentTimeZoneInformation)
     return STATUS_SUCCESS;
 }
 
-
 SSI_DEF(SystemCurrentTimeZoneInformation)
 {
     /* Check user buffer's size */
@@ -2229,7 +2227,6 @@ Leave:
     return STATUS_SUCCESS;
 }
 
-
 /* Class 46 - Set time slip event */
 SSI_DEF(SystemTimeSlipNotification)
 {
@@ -2271,7 +2268,6 @@ SSI_DEF(SystemSessionCreate)
     return Status;
 }
 
-
 /* Class 48 - Delete an existing session (TSE) */
 SSI_DEF(SystemSessionDetach)
 {
@@ -2293,7 +2289,6 @@ SSI_DEF(SystemSessionDetach)
     return MmSessionDelete(SessionId);
 }
 
-
 /* Class 49 - UNKNOWN */
 QSI_DEF(SystemSessionInformation)
 {
@@ -2301,7 +2296,6 @@ QSI_DEF(SystemSessionInformation)
     DPRINT1("NtQuerySystemInformation - SystemSessionInformation not implemented\n");
     return STATUS_NOT_IMPLEMENTED;
 }
-
 
 /* Class 50 - System range start address */
 QSI_DEF(SystemRangeStartInformation)
@@ -2324,14 +2318,12 @@ QSI_DEF(SystemVerifierInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
 SSI_DEF(SystemVerifierInformation)
 {
     /* FIXME */
     DPRINT1("NtSetSystemInformation - SystemVerifierInformation not implemented\n");
     return STATUS_NOT_IMPLEMENTED;
 }
-
 
 /* Class 52 */
 SSI_DEF(SystemVerifierThunkExtend)
@@ -2341,15 +2333,13 @@ SSI_DEF(SystemVerifierThunkExtend)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
-/* Class 53 - A session's processes  */
+/* Class 53 - A session's processes */
 QSI_DEF(SystemSessionProcessesInformation)
 {
     /* FIXME */
     DPRINT1("NtQuerySystemInformation - SystemSessionProcessInformation not implemented\n");
     return STATUS_NOT_IMPLEMENTED;
 }
-
 
 /* Class 54 - Load & map in system space */
 SSI_DEF(SystemLoadGdiDriverInSystemSpaceInformation)
@@ -2359,8 +2349,7 @@ SSI_DEF(SystemLoadGdiDriverInSystemSpaceInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
-/* Class 55 - NUMA processor information  */
+/* Class 55 - NUMA processor information */
 QSI_DEF(SystemNumaProcessorMap)
 {
     ULONG MaxEntries, Node;
@@ -2406,8 +2395,7 @@ QSI_DEF(SystemNumaProcessorMap)
     return STATUS_SUCCESS;
 }
 
-
-/* Class 56 - Prefetcher information  */
+/* Class 56 - Prefetcher information */
 QSI_DEF(SystemPrefetcherInformation)
 {
     /* FIXME */
@@ -2415,8 +2403,7 @@ QSI_DEF(SystemPrefetcherInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
-/* Class 57 - Extended process information  */
+/* Class 57 - Extended process information */
 QSI_DEF(SystemExtendedProcessInformation)
 {
     /* FIXME */
@@ -2424,8 +2411,7 @@ QSI_DEF(SystemExtendedProcessInformation)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
-/* Class 58 - Recommended shared ata alignment  */
+/* Class 58 - Recommended shared data alignment */
 QSI_DEF(SystemRecommendedSharedDataAlignment)
 {
     /* FIXME */
@@ -2433,8 +2419,7 @@ QSI_DEF(SystemRecommendedSharedDataAlignment)
     return STATUS_NOT_IMPLEMENTED;
 }
 
-
-/* Class 60 - NUMA memory information  */
+/* Class 60 - NUMA memory information */
 QSI_DEF(SystemNumaAvailableMemory)
 {
     ULONG MaxEntries, Node;
@@ -2488,7 +2473,7 @@ QSI_DEF(SystemNumaAvailableMemory)
     return STATUS_SUCCESS;
 }
 
-/* Class 64 - Extended handle information  */
+/* Class 64 - Extended handle information */
 QSI_DEF(SystemExtendedHandleInformation)
 {
     PSYSTEM_HANDLE_INFORMATION_EX HandleInformation;
@@ -2619,7 +2604,7 @@ QSI_DEF(SystemExtendedHandleInformation)
     return Status;
 }
 
-/* Class 70 - System object security mode information  */
+/* Class 70 - System object security mode information */
 QSI_DEF(SystemObjectSecurityMode)
 {
     PULONG ObjectSecurityInfo = (PULONG)Buffer;
@@ -2635,7 +2620,7 @@ QSI_DEF(SystemObjectSecurityMode)
     return STATUS_SUCCESS;
 }
 
-/* Class 73 - Logical processor information  */
+/* Class 73 - Logical processor information */
 QSI_DEF(SystemLogicalProcessorInformation)
 {
     LONG i;
@@ -2719,7 +2704,7 @@ QSI_DEF(SystemLogicalProcessorInformation)
     return Status;
 }
 
-/* Class 76 - System firmware table information  */
+/* Class 76 - System firmware table information */
 QSI_DEF(SystemFirmwareTableInformation)
 {
     PSYSTEM_FIRMWARE_TABLE_INFORMATION SysFirmwareInfo = (PSYSTEM_FIRMWARE_TABLE_INFORMATION)Buffer;
@@ -2839,7 +2824,7 @@ struct _QSSI_CALLS
 
 static
 QSSI_CALLS
-CallQS [] =
+CallQS[] =
 {
     SI_QX(SystemBasicInformation),
     SI_QX(SystemProcessorInformation),
@@ -2922,7 +2907,7 @@ CallQS [] =
 
 C_ASSERT(SystemBasicInformation == 0);
 #define MIN_SYSTEM_INFO_CLASS (SystemBasicInformation)
-#define MAX_SYSTEM_INFO_CLASS (sizeof(CallQS) / sizeof(CallQS[0]))
+#define MAX_SYSTEM_INFO_CLASS RTL_NUMBER_OF(CallQS)
 
 /*
  * @implemented
@@ -2949,7 +2934,7 @@ NtQuerySystemInformation(
     {
 #if (NTDDI_VERSION >= NTDDI_VISTA)
         /*
-         * Check if the request is valid.
+         * Check whether the request is valid.
          */
         if (SystemInformationClass < MIN_SYSTEM_INFO_CLASS ||
             SystemInformationClass >= MAX_SYSTEM_INFO_CLASS)
@@ -2974,7 +2959,7 @@ NtQuerySystemInformation(
 
 #if (NTDDI_VERSION < NTDDI_VISTA)
         /*
-         * Check if the request is valid.
+         * Check whether the request is valid.
          */
         if (SystemInformationClass < MIN_SYSTEM_INFO_CLASS ||
             SystemInformationClass >= MAX_SYSTEM_INFO_CLASS)
@@ -2983,14 +2968,12 @@ NtQuerySystemInformation(
         }
 #endif
 
-        if (NULL != CallQS [SystemInformationClass].Query)
+        if (CallQS[SystemInformationClass].Query != NULL)
         {
-            /*
-             * Hand the request to a subhandler.
-             */
-            FStatus = CallQS [SystemInformationClass].Query(SystemInformation,
-                                                            Length,
-                                                            &ResultLength);
+            /* Hand the request to a subhandler */
+            FStatus = CallQS[SystemInformationClass].Query(SystemInformation,
+                                                           Length,
+                                                           &ResultLength);
 
             /* Save the result length to the caller */
             if (UnsafeResultLength)
@@ -3023,8 +3006,7 @@ NtSetSystemInformation (IN SYSTEM_INFORMATION_CLASS SystemInformationClass,
     _SEH2_TRY
     {
         /*
-         * If called from user mode, check
-         * possible unsafe arguments.
+         * If called from user mode, check possible unsafe arguments.
          */
         if (PreviousMode != KernelMode)
         {
@@ -3032,18 +3014,16 @@ NtSetSystemInformation (IN SYSTEM_INFORMATION_CLASS SystemInformationClass,
         }
 
         /*
-         * Check the request is valid.
+         * Check whether the request is valid.
          */
         if ((SystemInformationClass >= MIN_SYSTEM_INFO_CLASS) &&
             (SystemInformationClass < MAX_SYSTEM_INFO_CLASS))
         {
-            if (NULL != CallQS [SystemInformationClass].Set)
+            if (CallQS[SystemInformationClass].Set != NULL)
             {
-                /*
-                 * Hand the request to a subhandler.
-                 */
-                Status = CallQS [SystemInformationClass].Set(SystemInformation,
-                                                             SystemInformationLength);
+                /* Hand the request to a subhandler */
+                Status = CallQS[SystemInformationClass].Set(SystemInformation,
+                                                            SystemInformationLength);
             }
         }
     }

--- a/sdk/include/ndk/exfuncs.h
+++ b/sdk/include/ndk/exfuncs.h
@@ -555,12 +555,13 @@ NtSetSystemEnvironmentValueEx(
     _Inout_ PULONG Attributes
 );
 
+__kernel_entry
 NTSYSCALLAPI
 NTSTATUS
 NTAPI
 NtSetSystemInformation(
     _In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
-    _In_ PVOID SystemInformation,
+    _In_reads_bytes_(SystemInformationLength) PVOID SystemInformation,
     _In_ ULONG SystemInformationLength
 );
 
@@ -1000,8 +1001,8 @@ NTSTATUS
 NTAPI
 ZwSetSystemInformation(
     _In_ SYSTEM_INFORMATION_CLASS SystemInformationClass,
-    _In_ PVOID SystemInformation,
-    _In_ SIZE_T SystemInformationLength
+    _In_reads_bytes_(SystemInformationLength) PVOID SystemInformation,
+    _In_ ULONG SystemInformationLength
 );
 
 #ifdef NTOS_MODE_USER

--- a/sdk/include/ndk/extypes.h
+++ b/sdk/include/ndk/extypes.h
@@ -210,7 +210,7 @@ typedef enum _HARDERROR_RESPONSE
 } HARDERROR_RESPONSE, *PHARDERROR_RESPONSE;
 
 //
-//  System Information Classes for NtQuerySystemInformation
+// System Information Classes for NtQuerySystemInformation
 //
 typedef enum _SYSTEM_INFORMATION_CLASS
 {
@@ -316,7 +316,7 @@ typedef enum _SYSTEM_INFORMATION_CLASS
 } SYSTEM_INFORMATION_CLASS;
 
 //
-//  System Information Classes for NtQueryMutant
+// System Information Classes for NtQueryMutant
 //
 typedef enum _MUTANT_INFORMATION_CLASS
 {
@@ -325,7 +325,7 @@ typedef enum _MUTANT_INFORMATION_CLASS
 } MUTANT_INFORMATION_CLASS;
 
 //
-//  System Information Classes for NtQueryAtom
+// System Information Classes for NtQueryAtom
 //
 typedef enum _ATOM_INFORMATION_CLASS
 {
@@ -334,7 +334,7 @@ typedef enum _ATOM_INFORMATION_CLASS
 } ATOM_INFORMATION_CLASS;
 
 //
-//  System Information Classes for NtQueryTimer
+// System Information Classes for NtQueryTimer
 //
 typedef enum _TIMER_INFORMATION_CLASS
 {
@@ -342,7 +342,7 @@ typedef enum _TIMER_INFORMATION_CLASS
 } TIMER_INFORMATION_CLASS;
 
 //
-//  System Information Classes for NtQuerySemaphore
+// System Information Classes for NtQuerySemaphore
 //
 typedef enum _SEMAPHORE_INFORMATION_CLASS
 {
@@ -350,7 +350,7 @@ typedef enum _SEMAPHORE_INFORMATION_CLASS
 } SEMAPHORE_INFORMATION_CLASS;
 
 //
-//  System Information Classes for NtQueryEvent
+// System Information Classes for NtQueryEvent
 //
 typedef enum _EVENT_INFORMATION_CLASS
 {


### PR DESCRIPTION
[NDK][NTOS:EX] Minor formatting.
[NDK][NTOS:EX] Add/fix SAL annotations for Nt/ZwSetSystemInformation + last parameter type.
[NTOS:EX] NtQuerySystemInformation: Use same parameter names as documentation. FStatus --> Status.
