### PR TITLE
[NTOS:EX] Clarify the situation with the SystemPathInformation class.

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -861,13 +861,21 @@ QSI_DEF(SystemTimeOfDayInformation)
     return STATUS_SUCCESS;
 }
 
-/* Class 4 - Path Information */
+/* Class 4 - Path Information (DEPRECATED) */
 QSI_DEF(SystemPathInformation)
 {
-    /* FIXME: QSI returns STATUS_BREAKPOINT. Why? */
-    DPRINT1("NtQuerySystemInformation - SystemPathInformation not implemented\n");
-
-    return STATUS_BREAKPOINT;
+    /*
+     * Since NT 3.51, this information class is trivially implemented.
+     * The path to the NT directory is now stored in KUSER_SHARED_DATA
+     * as the NtSystemRoot member.
+     * Windows Checked builds show the following message and break to
+     * the debugger before failing the function as not implemented.
+     */
+#if DBG
+    DPRINT1("EX: SystemPathInformation now available via SharedUserData\n");
+    // DbgBreakPoint(); // Not needed in ReactOS.
+#endif
+    return STATUS_NOT_IMPLEMENTED;
 }
 
 /* Class 5 - Process Information */
@@ -2830,7 +2838,7 @@ CallQS[] =
     SI_QX(SystemProcessorInformation),
     SI_QX(SystemPerformanceInformation),
     SI_QX(SystemTimeOfDayInformation),
-    SI_QX(SystemPathInformation), /* should be SI_XX */
+    SI_QX(SystemPathInformation),
     SI_QX(SystemProcessInformation),
     SI_QX(SystemCallCountInformation),
     SI_QX(SystemDeviceInformation),


### PR DESCRIPTION
Since NT 3.51, this information class is trivially implemented.
The path to the NT directory is now stored in the KUSER_SHARED_DATA
as the NtSystemRoot member.
Windows Checked builds break to the debugger to show a message
before failing the function as not implemented:

EX: SystemPathInformation now available via SharedUserData

See https://www.geoffchappell.com/studies/windows/km/ntoskrnl/api/ex/sysinfo/query.htm
and https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntexapi_x/kuser_shared_data/index.htm
for more information.
