### PR TITLE
[NETSTAT] Fixes coverity #1477187 "Double free"

### DIFF
--- a/base/applications/network/netstat/netstat.c
+++ b/base/applications/network/netstat/netstat.c
@@ -434,7 +434,6 @@ BOOL ShowTcpTable(VOID)
     {
         ConResPrintf(StdErr, IDS_ERROR_TCP_SNAPSHOT);
         DoFormatMessage(error);
-        HeapFree(GetProcessHeap(), 0, tcpTable);
         return FALSE;
     }
 


### PR DESCRIPTION
Within the current ShowTcpTable function logic, tcpTable would be freed twice. This pull request removes the second tcpTable free and should fix coverity #1477187.

JIRA issue: [CORE-17831](https://jira.reactos.org/browse/CORE-17831)