### PR TITLE
[SHELL32] SetForegroundWindow before TrackPopupMenu

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1547,7 +1547,7 @@ LRESULT CDefView::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
         y = pt.y;
     }
 
-    ::SetForegroundWindow(m_hWnd);
+    ::SetForegroundWindow(m_hWnd); // CORE-15524
     uCommand = TrackPopupMenu(m_hContextMenu,
                               TPM_LEFTALIGN | TPM_RETURNCMD | TPM_LEFTBUTTON | TPM_RIGHTBUTTON,
                               x, y, 0, m_hWnd, NULL);
@@ -3243,7 +3243,7 @@ HRESULT WINAPI CDefView::Exec(const GUID *pguidCmdGroup, DWORD nCmdID, DWORD nCm
                 DeleteMenu(hmenuViewPopup, GetMenuItemCount(hmenuViewPopup) - 1, MF_BYPOSITION);
                 DeleteMenu(hmenuViewPopup, GetMenuItemCount(hmenuViewPopup) - 1, MF_BYPOSITION);
                 CheckViewMode(hmenuViewPopup);
-                ::SetForegroundWindow(m_hWndParent);
+                ::SetForegroundWindow(m_hWndParent); // CORE-15524
                 TrackPopupMenuEx(hmenuViewPopup, TPM_LEFTALIGN | TPM_TOPALIGN, params.rcExclude.left, params.rcExclude.bottom, m_hWndParent, &params);
                 ::DestroyMenu(hmenuViewPopup);
             }

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -221,7 +221,7 @@ HRESULT CFSDropTarget::_GetEffectFromMenu(IDataObject *pDataObject, POINTL pt, D
                               NULL,
                               NULL,
                               NULL);
-    ::SetForegroundWindow(hwndDummy);
+    ::SetForegroundWindow(hwndDummy); // CORE-15524
     UINT uCommand = TrackPopupMenu(hpopupmenu,
                                    TPM_LEFTALIGN | TPM_RETURNCMD | TPM_LEFTBUTTON | TPM_RIGHTBUTTON | TPM_NONOTIFY,
                                    pt.x, pt.y, 0, hwndDummy, NULL);


### PR DESCRIPTION
## Purpose

`USER32!TrackPopupMenu` function has a well-known focus bug in both Windows and ReactOS. We have to call `USER32!SetForegroundWindow` function before `TrackPopupMenu` call for workaround.
JIRA issue: [CORE-15524](https://jira.reactos.org/browse/CORE-15524)

## Proposed changes

- Call `SetForegroundWindow` function before `TrackPopupMenu` call.
- In `CDefView::OnContextMenu`, deselect the selected item if the right-clicked point is not on the item.

## TODO

- [ ] Do tests

## Screenshots
BEFORE:
![two-menus](https://user-images.githubusercontent.com/2107452/138624193-b3a0e2e3-0406-4dd0-ac56-4428ee1c1926.png)
Failure.
AFTER:
![after2](https://user-images.githubusercontent.com/2107452/138624289-d5c1b2d6-7d6c-49b1-b9e0-dffdf3d838b7.png)
Successful.