### PR TITLE
[SHELL32] Drop a shortcut of the drive

### DIFF
--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -547,7 +547,8 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
         if (bLinking)
         {
-            WCHAR wszSrcPath[MAX_PATH], wszSaveTo[MAX_PATH];
+            WCHAR wszSrcPath[MAX_PATH];
+            WCHAR wszTarget[MAX_PATH];
 
             TRACE("target path: %s\n", debugstr_w(m_sPathTarget));
 
@@ -626,7 +627,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 }
 
                 // Create a pathname to save the new link.
-                _GetUniqueFileName(wszCombined, L".lnk", wszSaveTo, TRUE);
+                _GetUniqueFileName(wszCombined, L".lnk", wszTarget, TRUE);
 
                 CComPtr<IPersistFile> ppf;
                 if (fSourceIsLink)
@@ -660,11 +661,11 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                         break;
                 }
 
-                hr = ppf->Save(wszSaveTo, !fSourceIsLink);
+                hr = ppf->Save(wszTarget, !fSourceIsLink);
                 if (FAILED_UNEXPECTEDLY(hr))
                     break;
 
-                SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszSaveTo, NULL);
+                SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszTarget, NULL);
             }
         }
         else

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -547,13 +547,12 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
         if (bLinking)
         {
-            WCHAR wszSrcPath[MAX_PATH];
+            WCHAR wszPath[MAX_PATH];
             WCHAR wszTarget[MAX_PATH];
 
-            TRACE("target path: %s\n", debugstr_w(m_sPathTarget));
+            TRACE("target path = %s\n", debugstr_w(m_sPathTarget));
 
-            // We need to create a link for each pidl in the copied items,
-            // so step through the pidls from the clipboard.
+            /* We need to create a link for each pidl in the copied items, so step through the pidls from the clipboard */
             for (UINT i = 0; i < lpcida->cidl; i++)
             {
                 // Find out which file we're linking.
@@ -562,15 +561,15 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 if (FAILED_UNEXPECTEDLY(hr))
                     break;
 
-                hr = StrRetToBufW(&strFile, apidl[i], wszSrcPath, _countof(wszSrcPath));
+                hr = StrRetToBufW(&strFile, apidl[i], wszPath, _countof(wszPath));
                 if (FAILED_UNEXPECTEDLY(hr))
                     break;
 
-                TRACE("source path: %s\n", debugstr_w(wszSrcPath));
+                TRACE("source path = %s\n", debugstr_w(wszPath));
 
                 WCHAR wszDisplayName[MAX_PATH];
-                LPWSTR pwszFileName = PathFindFileNameW(wszSrcPath);
-                if (PathIsRootW(wszSrcPath)) // Drive?
+                LPWSTR pwszFileName = PathFindFileNameW(wszPath);
+                if (PathIsRootW(wszPath)) // Drive?
                 {
                     hr = psfFrom->GetDisplayNameOf(apidl[i], 0, &strFile);
                     if (FAILED_UNEXPECTEDLY(hr))
@@ -594,13 +593,13 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
                     pwszFileName = wszDisplayName; // Use wszDisplayName
                 }
-                else if (wszSrcPath[0] == L':' && wszSrcPath[1] == L':') // ::{GUID}?
+                else if (wszPath[0] == L':' && wszPath[1] == L':') // ::{GUID}?
                 {
                     CLSID clsid;
-                    hr = ::CLSIDFromString(&wszSrcPath[2], &clsid);
+                    hr = ::CLSIDFromString(&wszPath[2], &clsid);
                     if (SUCCEEDED(hr))
                     {
-                        LPITEMIDLIST pidl = ILCreateFromPathW(wszSrcPath);
+                        LPITEMIDLIST pidl = ILCreateFromPathW(wszPath);
                         if (pidl)
                         {
                             SHFILEINFOW fi = { NULL };
@@ -622,7 +621,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
                 // Check to see if the source is a link
                 BOOL fSourceIsLink = FALSE;
-                if (!wcsicmp(PathFindExtensionW(wszSrcPath), L".lnk"))
+                if (!wcsicmp(PathFindExtensionW(wszPath), L".lnk"))
                 {
                     fSourceIsLink = TRUE;
                     PathRemoveExtensionW(wszCombined);
@@ -634,7 +633,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 CComPtr<IPersistFile> ppf;
                 if (fSourceIsLink)
                 {
-                    hr = IShellLink_ConstructFromPath(wszSrcPath, IID_PPV_ARG(IPersistFile, &ppf));
+                    hr = IShellLink_ConstructFromPath(wszPath, IID_PPV_ARG(IPersistFile, &ppf));
                     if (FAILED_UNEXPECTEDLY(hr))
                         break;
                 }
@@ -646,11 +645,11 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                         break;
 
                     WCHAR szDirPath[MAX_PATH], *pwszFile;
-                    GetFullPathName(wszSrcPath, MAX_PATH, szDirPath, &pwszFile);
+                    GetFullPathName(wszPath, MAX_PATH, szDirPath, &pwszFile);
                     if (pwszFile)
                         pwszFile[0] = 0;
 
-                    hr = pLink->SetPath(wszSrcPath);
+                    hr = pLink->SetPath(wszPath);
                     if (FAILED_UNEXPECTEDLY(hr))
                         break;
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -591,6 +591,27 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
                     pwszFileName = wszDisplayName; // Use wszDisplayName
                 }
+                else if (wszSrcPath[0] == L':' && wszSrcPath[1] == L':') // ::{GUID}?
+                {
+                    CLSID clsid;
+                    hr = ::CLSIDFromString(&wszSrcPath[2], &clsid);
+                    if (SUCCEEDED(hr))
+                    {
+                        LPITEMIDLIST pidl = ILCreateFromPathW(wszSrcPath);
+                        if (pidl)
+                        {
+                            SHFILEINFOW fi = { NULL };
+                            SHGetFileInfoW((LPCWSTR)pidl, 0, &fi, sizeof(fi),
+                                           SHGFI_DISPLAYNAME | SHGFI_PIDL);
+                            if (fi.szDisplayName[0])
+                            {
+                                lstrcpynW(wszDisplayName, fi.szDisplayName, _countof(wszDisplayName));
+                                pwszFileName = wszDisplayName; // Use wszDisplayName
+                            }
+                            ILFree(pidl);
+                        }
+                    }
+                }
 
                 // Creating a buffer to hold the combined path.
                 WCHAR wszCombined[MAX_PATH];

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -583,12 +583,10 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                     LPWSTR pch0 = wcschr(wszDisplayName, L':'), pch1;
                     if (pch0)
                     {
-                        pch1 = pch0;
-                        for (++pch0; *pch0; ++pch0, ++pch1)
+                        do
                         {
-                            *pch1 = *pch0;
-                        }
-                        *pch1 = 0;
+                            *pch0 = *(pch0+1);
+                        } while (*++pch0);
                     }
 
                     pwszFileName = wszDisplayName; // Use wszDisplayName

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -571,7 +571,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 LPWSTR pwszFileName = PathFindFileNameW(wszPath);
                 if (PathIsRootW(wszPath)) // Drive?
                 {
-                    hr = psfFrom->GetDisplayNameOf(apidl[i], 0, &strFile);
+                    hr = psfFrom->GetDisplayNameOf(apidl[i], SHGDN_NORMAL, &strFile);
                     if (FAILED_UNEXPECTEDLY(hr))
                         break;
 

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -551,10 +551,11 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
 
             TRACE("target path = %s\n", debugstr_w(m_sPathTarget));
 
-            /* We need to create a link for each pidl in the copied items, so step through the pidls from the clipboard */
+            // We need to create a link for each pidl in the copied items,
+            // so step through the pidls from the clipboard
             for (UINT i = 0; i < lpcida->cidl; i++)
             {
-                //Find out which file we're copying
+                // Find out which file we're copying
                 STRRET strFile;
                 hr = psfFrom->GetDisplayNameOf(apidl[i], SHGDN_FORPARSING, &strFile);
                 if (FAILED_UNEXPECTEDLY(hr))
@@ -595,7 +596,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 WCHAR wszCombined[MAX_PATH];
                 PathCombineW(wszCombined, m_sPathTarget, pwszFileName);
 
-                // Check to see if it's already a link.
+                // Check to see if the source is a link.
                 BOOL fSourceIsLink = FALSE;
                 LPWSTR pwszExt = PathFindExtensionW(wszSrcPath);
                 if (!wcsicmp(pwszExt, L".lnk"))
@@ -605,6 +606,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                     fSourceIsLink = TRUE;
                 }
 
+                // Create a pathname for the new link
                 if (!_GetUniqueFileName(wszCombined, L".lnk", wszSaveTo, TRUE))
                 {
                     ERR("Error getting unique file name\n");

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -132,7 +132,7 @@ CFSDropTarget::~CFSDropTarget()
 }
 
 BOOL
-CFSDropTarget::_GetUniqueFileName(LPWSTR pwszBasePath, LPCWSTR pwszExt, LPWSTR pwszTarget, BOOL bShortcut)
+CFSDropTarget::_GetUniqueFileName(LPCWSTR pwszBasePath, LPCWSTR pwszExt, LPWSTR pwszTarget, BOOL bShortcut)
 {
     WCHAR wszLink[40];
 
@@ -608,11 +608,12 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 LPWSTR placementPath = PathCombineW(buffer_1, m_sPathTarget, pwszFileName);
                 CComPtr<IPersistFile> ppf;
 
-                //Check to see if it's already a link.
+                // Check to see if it's already a link.
                 if (!wcsicmp(pwszExt, L".lnk"))
                 {
-                    //It's a link so, we create a new one which copies the old.
-                    if(!_GetUniqueFileName(placementPath, pwszExt, wszTarget, TRUE))
+                    // It's a link so, we create a new one which copies the old.
+                    PathRemoveExtensionW(placementPath);
+                    if (!_GetUniqueFileName(placementPath, L".lnk", wszTarget, TRUE))
                     {
                         ERR("Error getting unique file name");
                         hr = E_FAIL;

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -580,13 +580,14 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                         break;
 
                     // Delete a ':' in wszDisplayName.
-                    LPWSTR pch0 = wcschr(wszDisplayName, L':'), pch1;
+                    LPWSTR pch0 = wcschr(wszDisplayName, L':');
                     if (pch0)
                     {
                         do
                         {
-                            *pch0 = *(pch0+1);
-                        } while (*++pch0);
+                            *pch0 = *(pch0 + 1);
+                            ++pch0;
+                        } while (*pch0);
                     }
 
                     pwszFileName = wszDisplayName; // Use wszDisplayName

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -580,15 +580,17 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                     if (FAILED_UNEXPECTEDLY(hr))
                         break;
 
-                    // Delete ':' in wszDisplayName.
-                    LPWSTR pch0, pch1;
-                    for (pch0 = pch1 = wszDisplayName; *pch0; ++pch0)
+                    // Delete a ':' in wszDisplayName.
+                    LPWSTR pch0 = wcschr(wszDisplayName, L':'), pch1;
+                    if (pch0)
                     {
-                        if (*pch0 == L':')
-                            continue;
-                        *pch1++ = *pch0;
+                        pch1 = pch0;
+                        for (++pch0; *pch0; ++pch0, ++pch1)
+                        {
+                            *pch1 = *pch0;
+                        }
+                        *pch1 = 0;
                     }
-                    *pch1 = 0;
 
                     pwszFileName = wszDisplayName; // Use wszDisplayName
                 }

--- a/dll/win32/shell32/droptargets/CFSDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.cpp
@@ -645,7 +645,7 @@ HRESULT CFSDropTarget::_DoDrop(IDataObject *pDataObject,
                 }
 
                 hr = ppf->Save(wszSaveTo, !fSourceIsLink);
-                if (FAILED(hr))
+                if (FAILED_UNEXPECTEDLY(hr))
                     break;
 
                 SHChangeNotify(SHCNE_CREATE, SHCNF_PATHW, wszSaveTo, NULL);

--- a/dll/win32/shell32/droptargets/CFSDropTarget.h
+++ b/dll/win32/shell32/droptargets/CFSDropTarget.h
@@ -40,7 +40,7 @@ class CFSDropTarget :
         BOOL _QueryDrop (DWORD dwKeyState, LPDWORD pdwEffect);
         HRESULT _DoDrop(IDataObject *pDataObject, DWORD dwKeyState, POINTL pt, DWORD *pdwEffect);
         HRESULT _CopyItems(IShellFolder *pSFFrom, UINT cidl, LPCITEMIDLIST *apidl, BOOL bCopy);
-        BOOL _GetUniqueFileName(LPWSTR pwszBasePath, LPCWSTR pwszExt, LPWSTR pwszTarget, BOOL bShortcut);
+        BOOL _GetUniqueFileName(LPCWSTR pwszBasePath, LPCWSTR pwszExt, LPWSTR pwszTarget, BOOL bShortcut);
         static DWORD WINAPI _DoDropThreadProc(LPVOID lpParameter);
         HRESULT _GetEffectFromMenu(IDataObject *pDataObject, POINTL pt, DWORD *pdwEffect, DWORD dwAvailableEffects);
         HRESULT _RepositionItems(IShellFolderView *psfv, IDataObject *pDataObject, POINTL pt);


### PR DESCRIPTION
## Purpose

We couldn't create a shortcut of a drive correctly. This PR will fix the behavior of right-drag-and-drop.  
JIRA issue: [CORE-17813](https://jira.reactos.org/browse/CORE-17813)

## Proposed changes

- If the Right-dropped item was a drive, then get the display name of the drive and use it.
- Use `FAILED_UNEXPECTEDLY` instead of `FAILED` macro.
- Accept `::{GUID}`.
- Refactoring.

## TODO

- [x] Do tests

## Screenshots
![after](https://user-images.githubusercontent.com/2107452/138624887-02467992-e85c-472a-9564-825307243524.png)
Successful.
![VirtualBox_ReactOS_25_10_2021_18_19_48](https://user-images.githubusercontent.com/2107452/138669699-10180779-4823-495d-a0a2-1f6ff8592de7.png)
Able to create the `::{GUID}` shortcut.