### PR TITLE
[NTOS:SE] Mark the token as no longer belonging to admin group upon e…

### DIFF
--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -1197,12 +1197,27 @@ SepDuplicateToken(
                 (AccessToken->UserAndGroups[GroupsIndex].Attributes & SE_GROUP_ENABLED) == 0)
             {
                 /*
+                 * If this group is an administrators group
+                 * and the token belongs to such group,
+                 * we've to take away TOKEN_HAS_ADMIN_GROUP
+                 * for the fact that's not enabled and as
+                 * such the token no longer belongs to
+                 * this group.
+                 */
+                if (RtlEqualSid(SeAliasAdminsSid,
+                                &AccessToken->UserAndGroups[GroupsIndex].Sid))
+                {
+                    AccessToken->TokenFlags &= ~TOKEN_HAS_ADMIN_GROUP;
+                }
+
+                /*
                  * A group is not enabled, it's time to remove
                  * from the token and update the groups index
                  * accordingly and continue with the next group.
                  */
                 SepRemoveUserGroupToken(AccessToken, GroupsIndex);
                 GroupsIndex--;
+                continue;
             }
         }
 
@@ -1228,6 +1243,7 @@ SepDuplicateToken(
                  */
                 SepRemovePrivilegeToken(AccessToken, PrivilegesIndex);
                 PrivilegesIndex--;
+                continue;
             }
         }
     }


### PR DESCRIPTION
…ffective duplication

A scenario where it happens that an access token belongs to an administrators group but it's disabled (that is, SeAliasAdminsSid has no attributes or it doesn't have SE_GROUP_ENABLED turn ON), the function removes this group from the token but still has TOKEN_HAS_ADMIN_GROUP flag which can lead to erratic behavior across the kernel and security modules -- implying that the token still belongs to administrators group.

This is an oversight from my part, so I thereby apology for that.
