### PR TITLE
[COMCTL32] Fix crash on SB_GETPARTS

### DIFF
--- a/dll/win32/comctl32/status.c
+++ b/dll/win32/comctl32/status.c
@@ -432,6 +432,10 @@ STATUSBAR_GetParts (const STATUS_INFO *infoPtr, INT num_parts, INT parts[])
 
     TRACE("(%d)\n", num_parts);
     if (parts) {
+#ifdef __REACTOS__
+        if (num_parts > infoPtr->numParts)
+            num_parts = infoPtr->numParts;
+#endif
 	for (i = 0; i < num_parts; i++) {
 	    parts[i] = infoPtr->parts[i].x;
 	}


### PR DESCRIPTION
wParam (num_parts) is allowed to be bigger than the actual amount of parts

JIRA issue: [CORE-17842](https://jira.reactos.org/browse/CORE-17842)


This allows process explorer 16.02 to start.