### PR TITLE
[KS] Restore old hack for MS portcls

### DIFF
--- a/drivers/ksfilter/ks/irp.c
+++ b/drivers/ksfilter/ks/irp.c
@@ -919,6 +919,9 @@ ProbeMdl:
             goto ProbeMdl;
     }
 
+    // HACK for MS portcls
+    HeaderSize = Length;
+
     /* probe user mode buffers */
     if (Length && ( (!HeaderSize) || (Length % HeaderSize == 0) || ((ProbeFlags & KSPROBE_ALLOWFORMATCHANGE) && (Length == sizeof(KSSTREAM_HEADER))) ) )
     {
@@ -1662,18 +1665,6 @@ KsAddIrpToCancelableQueue(
 
     DPRINT("KsAddIrpToCancelableQueue QueueHead %p SpinLock %p Irp %p ListLocation %x DriverCancel %p\n", QueueHead, SpinLock, Irp, ListLocation, DriverCancel);
 
-    // HACK for ms portcls
-    if (IoStack->MajorFunction == IRP_MJ_CREATE)
-    {
-        // complete the request
-        DPRINT1("MS HACK\n");
-        Irp->IoStatus.Status = STATUS_SUCCESS;
-        CompleteRequest(Irp, IO_NO_INCREMENT);
-
-        return;
-    }
-
-
     if (!DriverCancel)
     {
         /* default to KsCancelRoutine */
@@ -2031,6 +2022,9 @@ KsSetMajorFunctionHandler(
     IN  ULONG MajorFunction)
 {
     DPRINT("KsSetMajorFunctionHandler Function %x\n", MajorFunction);
+
+    // HACK for MS portcls
+    DriverObject->MajorFunction[IRP_MJ_CREATE] = KspCreate;
 
     switch ( MajorFunction )
     {


### PR DESCRIPTION
## Purpose

Restore an old hack required by MS portcls driver.
Replace current hack from https://git.reactos.org/?p=reactos.git;a=blob;f=drivers/ksfilter/ks/irp.c;hb=22d1e7a4e4175b2d579428493434eaab28323cca#l1665 by old one that was removed in the following commit: https://git.reactos.org/?p=reactos-deprecated-gitsvn-dont-use.git;a=commitdiff;h=563682ad9a5751a7d5c3f9ffb4ac4f67bf0adc71.
This allows to boot ReactOS (and play the sound) properly again with portcls.sys driver from Windows XP/2003. :smiley: 
Note that in order to get the best result from this fix, you need to use legacy APIs in wdmaud.drv, instead of MMixer APIs, those are currently enabled by default. You can switch to them by removing (or just commenting out) `USE_MMIXER_LIB` define in dll/win32/wdmaud.drv/wdmaud.c.

JIRA issue: [CORE-17237](https://jira.reactos.org/browse/CORE-17237)

## Result

As visible on the following screenshots, ReactOS is now loading portcls.sys driver as from Windows XP SP3:
![portcls-xpsp3](https://user-images.githubusercontent.com/26385117/139956939-8302b388-f8ac-44f5-b13a-cb52d798413f.png)

same with version from Windows Server 2003 SP2:
![portcls-2k3sp2](https://user-images.githubusercontent.com/26385117/139956959-e9fd6360-2f97-45ac-8c87-f3f2f857d35d.png)