### PR TITLE
[SDK] Add setjmp for the arm64 architecture

### DIFF
--- a/sdk/include/crt/setjmp.h
+++ b/sdk/include/crt/setjmp.h
@@ -150,6 +150,32 @@ extern "C" {
     unsigned long long D[8]; // D8-D15 VFP/NEON regs
   } _JUMP_BUFFER;
 
+#elif defined(_M_ARM64)
+
+#define _JBLEN 24
+#define _JBTYPE unsigned __int64
+
+typedef struct __JUMP_BUFFER {
+    unsigned __int64 Frame;
+    unsigned __int64 Reserved;
+    unsigned __int64 X19;
+    unsigned __int64 X20;
+    unsigned __int64 X21;
+    unsigned __int64 X22;
+    unsigned __int64 X23;
+    unsigned __int64 X24;
+    unsigned __int64 X25;
+    unsigned __int64 X26;
+    unsigned __int64 X27;
+    unsigned __int64 X28;
+    unsigned __int64 Fp;
+    unsigned __int64 Lr;
+    unsigned __int64 Sp;
+    unsigned long Fpcr;
+    unsigned long Fpsr;
+    double D[8];
+  } _JUMP_BUFFER;
+
 #else
 
 #error Define Setjmp for this architecture!


### PR DESCRIPTION
## Purpose
Added in setjmp for arm64.
Pulled from:
mingw-w64 v9.0.0

JIRA issue: [CORE-17622](https://jira.reactos.org/browse/CORE-17622)

## Proposed changes
- Add setjmp for arm64