### PR TITLE
[SHELL32] Improve empty recycle bin sound code.

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1008,6 +1008,7 @@ static void TRASH_PlayEmptyRecycleBinSound()
 
         if (lRegStatus != ERROR_SUCCESS)
         {
+            RegCloseKey(hRegKey);
             return;
         }
     }

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -1006,8 +1006,6 @@ static void TRASH_PlayEmptyRecycleBinSound()
         /* If fail then open .Default */
         lRegStatus = RegOpenKeyExW(hRegKey, L".Default", 0, KEY_QUERY_VALUE, &hRegSnd);
 
-        RegCloseKey(hRegKey);
-
         if (lRegStatus != ERROR_SUCCESS)
         {
             return;


### PR DESCRIPTION
[SHELL32] Improve empty recycle bin sound code.

JIRA issue: [CORE-13951](https://jira.reactos.org/browse/CORE-13951)

- Open .Default registry key if failed to open .Current
- There's no need to define _WIN32_WINNT 0x0600 for registry functions.
- No MAX_PATH limit
- Code rewrite