### PR TITLE
[NTOS:SE] Validate the SID lengths when capturing them

### DIFF
--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -186,6 +186,7 @@
 #define TAG_LOGON_SESSION      'sLeS'
 #define TAG_LOGON_NOTIFICATION 'nLeS'
 #define TAG_SID_AND_ATTRIBUTES 'aSeS'
+#define TAG_SID_VALIDATE       'vSeS'
 
 /* LPC Tags */
 #define TAG_LPC_MESSAGE   'McpL'


### PR DESCRIPTION
SIDs are variadic by nature which means their lengths can vary in a given amount of time and certain factors that allow for this happen. This also especially can lead to issues when capturing SIDs and attributes because SeCaptureSidAndAttributesArray might end up overwriting the buffer during the time it's been called.

Therefore when we're copying the SIDs, validate their lengths. In addition to that, update the documentation header accordingly.