### PR TITLE
[CRT] Do Not lock ioinfo when Spawning Functions

### DIFF
--- a/sdk/lib/crt/stdio/file.c
+++ b/sdk/lib/crt/stdio/file.c
@@ -434,7 +434,7 @@ unsigned create_io_inherit_block(WORD *size, BYTE **block)
   for (fd = 0; fd < last_fd; fd++)
   {
     /* to be inherited, we need it to be open, and that DONTINHERIT isn't set */
-    fdinfo = get_ioinfo(fd);
+    fdinfo = get_ioinfo_nolock(fd);
     if ((fdinfo->wxflag & (WX_OPEN | WX_DONTINHERIT)) == WX_OPEN)
     {
       *wxflag_ptr = fdinfo->wxflag;
@@ -445,7 +445,6 @@ unsigned create_io_inherit_block(WORD *size, BYTE **block)
       *wxflag_ptr = 0;
       *handle_ptr = INVALID_HANDLE_VALUE;
     }
-    release_ioinfo(fdinfo);
     wxflag_ptr++; handle_ptr++;
   }
   return TRUE;


### PR DESCRIPTION
## Change locking ioinfo when spawning to not lock it

_Revert locking ioinfo when spawing to previous logic._

JIRA issue: [CORE-15176](https://jira.reactos.org/browse/CORE-15176)

## Change create_io_inherit_block in file.c to not lock ioinfo

_Stops GIMP Version 2.6.11 from freezing when opening a file._
