### PR TITLE
[COMCTL32] Fixes 'Start | Shutdown' leaving Start button depressed

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1150,10 +1150,18 @@ static LRESULT CALLBACK BUTTON_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
             infoPtr->state = state;
 
 #ifdef __REACTOS__
-            if ((infoPtr->state == 0) && (btn_type == 0) && (infoPtr->imlData.himl))
-                paint_button( infoPtr, btn_type, ODA_SELECT );
+            /* We are in the Button Message SETSTATE processing here.
+             * If we have a normal pushbutton and it is not focused
+             * and it has an image list then we just need to use
+             * paint_button with ODA_SELECT to process it.
+             * This fixes the START button staying down after
+             * the Shutdown menu selection has been made. CORE-17845 */
+            if ((btn_type == BS_PUSHBUTTON)  &&
+                !(infoPtr->state & BST_FOCUS) &&
+                (infoPtr->imlData.himl))
+                paint_button(infoPtr, btn_type, ODA_SELECT);
             else
-                InvalidateRect( hWnd, NULL, FALSE );
+                InvalidateRect(hWnd, NULL, FALSE);
 #else
             InvalidateRect( hWnd, NULL, FALSE );
 #endif

--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1149,7 +1149,14 @@ static LRESULT CALLBACK BUTTON_WindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, L
                 BUTTON_NOTIFY_PARENT( hWnd, (state & BST_PUSHED) ? BN_HILITE : BN_UNHILITE );
             infoPtr->state = state;
 
+#ifdef __REACTOS__
+            if ((infoPtr->state == 0) && (btn_type == 0) && (infoPtr->imlData.himl))
+                paint_button( infoPtr, btn_type, ODA_SELECT );
+            else
+                InvalidateRect( hWnd, NULL, FALSE );
+#else
             InvalidateRect( hWnd, NULL, FALSE );
+#endif
         }
         break;
 


### PR DESCRIPTION
## Allow Start Button to return to unpressed state after Shutdown is selected

_Revise programming in comctl32 button.c file._

JIRA issue: [CORE-17845](https://jira.reactos.org/browse/CORE-17845)

## Revise handling of BM_SETCHECK in button.c

_Fixes 'Start | Shutdown' leaving Start button depressed._
