### PR TITLE
[KERNEL32] Implement Data Execution Prevention (DEP) support

### DIFF
--- a/dll/win32/kernel32/CMakeLists.txt
+++ b/dll/win32/kernel32/CMakeLists.txt
@@ -19,6 +19,7 @@ list(APPEND SOURCE
     client/atom.c
     client/compname.c
     client/debugger.c
+    client/dep.c
     client/dosdev.c
     client/dllmain.c
     client/environ.c

--- a/dll/win32/kernel32/client/dep.c
+++ b/dll/win32/kernel32/client/dep.c
@@ -1,0 +1,147 @@
+/*
+ * PROJECT:         ReactOS system libraries
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * FILE:            dll/win32/kernel32/client/dep.c
+ * PURPOSE:         ReactOS Data Execution Prevention (DEP) functions
+ * COPYRIGHT:       Copyright 2021 Oleg Dubinskiy (oleg.dubinskij2013@yandex.ua)
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <k32.h>
+
+#define NDEBUG
+#include <debug.h>
+
+/* PUBLIC FUNCTIONS ***********************************************************/
+
+/**
+ * @brief Retrieves the data execution prevention (DEP) and thunk emulation (DEP-ATL)
+ * settings for the process.
+ * 
+ * On Windows XP SP3, the current process is handled.
+ * On Vista and newer, the process specified in hProcess parameter is handled.
+ * 
+ * @param [in] hProcess
+ * A handle to a process with PROCESS_QUERY_INFORMATION privilege.
+ * Ignored on Windows XP SP3.
+ * 
+ * @param [out] lpFlags
+ * Pointer to a variable that receives the flags:
+ * 0 - DEP is disabled.
+ * PROCESS_DEP_ENABLE - DEP is enabled.
+ * PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION - DEP-ATL is disabled.
+ * 
+ * @param [out] lpPermanent
+ * Pointer to a variable that specifies whether DEP is enabled or disabled permanently.
+ * 
+ * @return
+ * TRUE on success, FALSE on failure.
+ * 
+ * @remarks
+ * Supported for 32-bit processes only. Returns ERROR_NOT_SUPPORTED for 64-bit processes.
+ * 
+ */
+BOOL
+WINAPI
+GetProcessDEPPolicy(_In_ HANDLE hProcess,
+                    _Out_ LPDWORD lpFlags,
+                    _Out_ PBOOL lpPermanent)
+{
+    ULONG Flags;
+    NTSTATUS Status;
+
+    Status = NtQueryInformationProcess(GetCurrentProcess(),
+                                       ProcessExecuteFlags,
+                                       &Flags,
+                                       sizeof(Flags),
+                                       NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        BaseSetLastNTError(Status);
+        return FALSE;
+    }
+
+    if (lpFlags)
+    {
+        *lpFlags = 0;
+        if (Flags & MEM_EXECUTE_OPTION_DISABLE)
+            *lpFlags |= PROCESS_DEP_ENABLE;
+        if (Flags & MEM_EXECUTE_OPTION_DISABLE_THUNK_EMULATION)
+            *lpFlags |= PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION;
+    }
+
+    if (lpPermanent)
+        *lpPermanent = (Flags & MEM_EXECUTE_OPTION_PERMANENT) != 0;
+
+    return TRUE;
+}
+
+/**
+ * @brief Sets the data execution prevention (DEP) and thunk emulation (DEP-ATL)
+ * settings for the current process.
+ * 
+ * @param [in] dwFlags
+ * Variable that specifies the flags to set:
+ * 0 - disables DEP;
+ * PROCESS_DEP_ENABLE - enables DEP permanently.
+ * PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION - disables DEP-ATL. Can be specified
+ *                                           only with PROCESS_DEP_ENABLE.
+ * 
+ * @return
+ * TRUE on success, FALSE on failure.
+ * 
+ * @remarks
+ * Supported for 32-bit processes only. Returns ERROR_NOT_SUPPORTED for 64-bit processes.
+ * 
+ */
+BOOL
+WINAPI
+SetProcessDEPPolicy(_In_ DWORD dwFlags)
+{
+    ULONG Flags = 0;
+    NTSTATUS Status;
+
+    if (dwFlags & PROCESS_DEP_ENABLE)
+        Flags |= MEM_EXECUTE_OPTION_DISABLE | MEM_EXECUTE_OPTION_PERMANENT;
+    if (dwFlags & PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION)
+        Flags |= MEM_EXECUTE_OPTION_DISABLE_THUNK_EMULATION;
+
+    Status = NtSetInformationProcess(GetCurrentProcess(),
+                                     ProcessExecuteFlags,
+                                     &Flags,
+                                     sizeof(Flags));
+    if (!NT_SUCCESS(Status))
+    {
+        BaseSetLastNTError(Status);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+/**
+ * @brief Retrieves the system data execution prevention (DEP) and thunk emulation (DEP-ATL)
+ * settings.
+ * 
+ * @return
+ * One of DEP_SYSTEM_POLICY_TYPE enumeration values:
+ * AlwaysOff - DEP is always disabled system-wide.
+ * AlwaysOn - DEP is always enabled system-wide.
+ * OptIn - DEP is enabled only for system components.
+ *         Default for client Windows versions.
+ * OptOut - DEP is enabled for system components and processes.
+ *          Default for server Windows versions.
+ * 
+ * @remarks
+ * Supported for 32-bit processes only.
+ * 
+ */
+DEP_SYSTEM_POLICY_TYPE
+WINAPI
+GetSystemDEPPolicy(VOID)
+{
+    return SharedUserData->NXSupportPolicy;
+}
+
+/* EOF */

--- a/dll/win32/kernel32/k32.h
+++ b/dll/win32/kernel32/k32.h
@@ -38,10 +38,13 @@
 #include <ndk/iotypes.h>
 #include <ndk/kdtypes.h>
 #include <ndk/kefuncs.h>
+#include <ndk/ketypes.h>
 #include <ndk/ldrfuncs.h>
 #include <ndk/mmfuncs.h>
+#include <ndk/mmtypes.h>
 #include <ndk/obfuncs.h>
 #include <ndk/psfuncs.h>
+#include <ndk/pstypes.h>
 #include <ndk/rtlfuncs.h>
 #include <ndk/setypes.h>
 #include <ndk/umfuncs.h>

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -557,7 +557,7 @@
 @ stdcall GetPrivateProfileStructW(wstr wstr ptr long wstr)
 @ stdcall GetProcAddress(long str)
 @ stdcall GetProcessAffinityMask(long ptr ptr)
-@ stub -version=0x600+ GetProcessDEPPolicy
+@ stdcall GetProcessDEPPolicy(ptr ptr ptr)
 @ stdcall GetProcessHandleCount(long ptr)
 @ stdcall -norelay GetProcessHeap()
 @ stdcall GetProcessHeaps(long ptr)
@@ -589,7 +589,7 @@
 @ stdcall GetStringTypeExA(long long str long ptr)
 @ stdcall GetStringTypeExW(long long wstr long ptr)
 @ stdcall GetStringTypeW(long wstr long ptr)
-@ stub -version=0x600+ GetSystemDEPPolicy
+@ stdcall GetSystemDEPPolicy()
 @ stdcall GetSystemDefaultLCID()
 @ stdcall GetSystemDefaultLangID()
 @ stub -version=0x600+ GetSystemDefaultLocaleName
@@ -1055,7 +1055,7 @@
 @ stdcall SetPriorityClass(long long)
 @ stdcall SetProcessAffinityMask(long long)
 @ stub -version=0x600+ SetProcessAffinityUpdateMode
-@ stub -version=0x600+ SetProcessDEPPolicy
+@ stdcall SetProcessDEPPolicy(long)
 @ stdcall SetProcessPriorityBoost(long long)
 @ stdcall SetProcessShutdownParameters(long long)
 @ stdcall SetProcessWorkingSetSize(long long long)

--- a/sdk/include/psdk/winbase.h
+++ b/sdk/include/psdk/winbase.h
@@ -608,10 +608,15 @@ extern "C" {
 
 #define INIT_ONCE_STATIC_INIT RTL_RUN_ONCE_INIT
 
-#if (_WIN32_WINNT >= 0x0600)
+typedef enum _DEP_SYSTEM_POLICY_TYPE {
+    AlwaysOff = 0,
+    AlwaysOn = 1,
+    OptIn = 2,
+    OptOut = 3
+} DEP_SYSTEM_POLICY_TYPE;
+
 #define PROCESS_DEP_ENABLE 0x00000001
 #define PROCESS_DEP_DISABLE_ATL_THUNK_EMULATION 0x00000002
-#endif
 
 #ifndef RC_INVOKED
 


### PR DESCRIPTION
## Purpose

Implement support for Data Execution Prevention (DEP), which is represented by three functions: `GetProcessDEPPolicy`, `GetSystemDEPPolicy` and `SetProcessDEPPolicy` (my implementations are based on Wine's ones if what). They were introduced since Windows XP SP2.
These functions are required by some apps (like MiniBrowser 1.0), they only allow to get and set DEP policy settings of/for the operating system/current process.
This is only user mode part. To complete supporting this feature, in case of software emulation, `RtlIsValidHandler()` needs to be implemented in the kernel, for SafeSEH support: https://git.reactos.org/?p=reactos.git;a=blob;f=sdk/lib/rtl/i386/except.c;hb=c8b6abab80db2d2856dcedaa907f5b22eab3280e#l121.
But theoretically, if there is any emulated/real hardware that supports NX executable bit (required for DEP), and ROS amd64 port is able to boot there, it now might work as expected. :slightly_smiling_face: 
Also note that the appropriate tab in our System Properties (sysdm.cpl) is missing, but in Windows 2003, it is provided by ws03res.dll, so we're able to change the DEP settings in registry via MS sysdm.cpl + ws03res.dll.

JIRA issue: [CORE-16503](https://jira.reactos.org/browse/CORE-16503)

## Proposed changes

- Implement the functions itself in separate file (dll/win32/kernel32/client/dep.c).
- Add the Doxygen documentation for them.
- Include this file in CMakeLists.txt of kernel32.
- Add `DEP_SYSTEM_POLICY_TYPE` enumeration in sdk/include/psdk/winbase.h. It's required by `GetSystemDEPPolicy`.
- Include required ndk headers into internal dll/win32/kernel32/k32.h header.
- Fix exports (spec entries).

## Analysis

This is how these implementations are done in Windows:
![dep](https://user-images.githubusercontent.com/26385117/141701167-32f59c62-60c0-49c9-b4b3-c1a25d326a9a.png)

They same are getting/setting flags, calling `NtQuery`/`SetInformationProcess` for doing the actual work, and retrun an appropiate error code via `BaseSetLastNtError` in case of failure. So my implementations appear to be correct. :slightly_smiling_face: 
Regarding `GetSystemDEPPolicy`, I'm not completely sure that it's correct, but this way it's done in Wine at least: https://source.winehq.org/git/wine.git/blob/be0684dad50ffbc93b3ded4fbfebf1d1e4690589:/dlls/kernel32/process.c#l555, and in full WinDBG unassemble, global `SharedUserData` variable, which points to `_KUSER_SHARED_DATA` structure, is also visible.

## Result

After my changes, at least MiniBrowser 1.0 starts successfully, although works with a lot of errors. :slightly_frowning_face: 