### PR TITLE
[SYSSETUP] Register type libraries before signaling we are done

### DIFF
--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2041,6 +2041,12 @@ RegistrationProc(LPVOID Parameter)
     RegistrationNotify.Progress = RegistrationData->DllCount;
     RegistrationNotify.ActivityID = IDS_REGISTERING_COMPONENTS;
     RegistrationNotify.CurrentItem = NULL;
+
+    RegisterTypeLibraries(hSysSetupInf, L"TypeLibraries");
+
+    // FIXME: Move this call to a separate cleanup page!
+    RtlCreateBootStatusDataFile();
+
     SendMessage(RegistrationData->hwndDlg, PM_REGISTRATION_NOTIFY,
                 1, (LPARAM) &RegistrationNotify);
     if (NULL != RegistrationNotify.ErrorMessage &&
@@ -2051,11 +2057,6 @@ RegistrationProc(LPVOID Parameter)
 
     SetupTermDefaultQueueCallback(RegistrationData->DefaultContext);
     HeapFree(GetProcessHeap(), 0, RegistrationData);
-
-    RegisterTypeLibraries(hSysSetupInf, L"TypeLibraries");
-
-    // FIXME: Move this call to a separate cleanup page!
-    RtlCreateBootStatusDataFile();
 
     return 0;
 }


### PR DESCRIPTION
This prevents a race condition, where hSysSetupInf could be closed before all type libraries are registered
