### PR TITLE
[NTVDM] Add otya128's WineVDM integration code into ReactOS

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -2093,9 +2093,11 @@ LRESULT CDefView::OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
                 HWND hEdit = reinterpret_cast<HWND>(m_ListView.SendMessage(LVM_GETEDITCONTROL));
                 SHLimitInputEdit(hEdit, m_pSFParent);
 
-                if (!(dwAttr & SFGAO_LINK) && (lpdi->item.mask & LVIF_TEXT) && !SelectExtOnRename())
+                LPWSTR pszText = lpdi->item.pszText;
+                if (!(dwAttr & (SFGAO_LINK | SFGAO_FOLDER)) && (dwAttr & SFGAO_FILESYSTEM) &&
+                    (lpdi->item.mask & LVIF_TEXT) &&
+                    !SelectExtOnRename() && !SHELL_FS_HideExtension(pszText))
                 {
-                    LPWSTR pszText = lpdi->item.pszText;
                     LPWSTR pchDotExt = PathFindExtensionW(pszText);
                     ::PostMessageW(hEdit, EM_SETSEL, 0, pchDotExt - pszText);
                     ::PostMessageW(hEdit, EM_SCROLLCARET, 0, 0);

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -830,10 +830,13 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             }
             else
             {
+                /* Retrieve the actual path to the "Program Files" directory for displaying the error */
+                ExpandEnvironmentStringsA("%ProgramFiles%", ExpName, ARRAYSIZE(ExpName) - 1);
+
                 DisplayMessage(L"Trying to load '%S'.\n"
                                L"WOW16 applications are not supported internally by NTVDM at the moment.\n"
-                               L"Consider installing otvdm in 'C:\\Program files'. Press 'OK' to continue.",
-                               ProgramName);
+                               L"Consider installing OTVDM in '%S'. Press 'OK' to continue.",
+                               ProgramName, ExpName);
             }
             // Fall through
         }

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -832,7 +832,7 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             {
                 DisplayMessage(L"Trying to load '%S'.\n"
                                L"WOW16 applications are not supported internally by NTVDM at the moment.\n"
-                               L"Consider adding otvdm. Press 'OK' to continue.",
+                               L"Consider installing otvdm in 'C:\\Program files'. Press 'OK' to continue.",
                                ProgramName);
             }
             // Fall through

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -804,12 +804,12 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             strcat(ExpName, ProgramName);  // Append Program name
             strcat(ExpName, "\"");         // Add double-quote after ProgramName
             PROCESS_INFORMATION pi;
-            ZeroMemory( &si, sizeof(si) );
+            ZeroMemory(&pi, sizeof(pi));
+            ZeroMemory(&si, sizeof(si));
             si.cb = sizeof(si);
-            ZeroMemory( &pi, sizeof(pi) );
 
             /* Create the process. */
-            if(CreateProcessA( NULL,   // No Application Name
+            if (CreateProcessA(NULL,   // No Application Name
                 (LPSTR)ExpName,   // Just our Command Line
                 NULL,             // Cannot inherit Process Handle
                 NULL,             // Cannot inherit Thread Handle
@@ -818,7 +818,7 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
                 NULL,             // No environment block
                 NULL,             // No starting directory 
                 &si,              // STARTUPINFOA
-                &pi ))            // PROCESS_INFORMATION
+                &pi))             // PROCESS_INFORMATION
             {
                 /* Close handles. */
                 CloseHandle(pi.hProcess);
@@ -826,10 +826,12 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
                 break;
             }
             else
+            {
                 DisplayMessage(L"Trying to load '%S'.\n"
                                L"WOW16 applications are not supported internally by NTVDM at the moment.\n"
                                L"Consider adding otvdm. Press 'OK' to continue.",
                                ProgramName);
+            }
             // Fall through
         }
         case SCS_DOS_BINARY:

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -796,33 +796,36 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
         /* Those are handled by NTVDM */
         case SCS_WOW_BINARY:
         {
-            CHAR AppName[50] = "\"%programfiles%\\otvdm\\otvdmw.exe\" ";
+            static const PCSTR AppName = "\"%ProgramFiles%\\otvdm\\otvdmw.exe\" ";
+
             STARTUPINFOA si;
-            CHAR ExpName[256];
-            ExpandEnvironmentStringsA(AppName, ExpName, 255);
+            PROCESS_INFORMATION pi;
+            CHAR ExpName[MAX_PATH];
+
+            ExpandEnvironmentStringsA(AppName, ExpName, ARRAYSIZE(ExpName) - 1);
             strcat(ExpName, "\"");         // Add double-quote before ProgramName
             strcat(ExpName, ProgramName);  // Append Program name
             strcat(ExpName, "\"");         // Add double-quote after ProgramName
-            PROCESS_INFORMATION pi;
+
             ZeroMemory(&pi, sizeof(pi));
             ZeroMemory(&si, sizeof(si));
             si.cb = sizeof(si);
 
             /* Create the process. */
-            if (CreateProcessA(NULL,   // No Application Name
-                (LPSTR)ExpName,   // Just our Command Line
-                NULL,             // Cannot inherit Process Handle
-                NULL,             // Cannot inherit Thread Handle
-                FALSE,            // No handle inheritance
-                0,                // No extra creation flags
-                NULL,             // No environment block
-                NULL,             // No starting directory 
-                &si,              // STARTUPINFOA
-                &pi))             // PROCESS_INFORMATION
+            if (CreateProcessA(NULL,    // No Application Name
+                               ExpName, // Just our Command Line
+                               NULL,    // Cannot inherit Process Handle
+                               NULL,    // Cannot inherit Thread Handle
+                               FALSE,   // No handle inheritance
+                               0,       // No extra creation flags
+                               NULL,    // No environment block
+                               NULL,    // No starting directory 
+                               &si,
+                               &pi))
             {
-                /* Close handles. */
-                CloseHandle(pi.hProcess);
+                /* Close the handles */
                 CloseHandle(pi.hThread);
+                CloseHandle(pi.hProcess);
                 break;
             }
             else

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -835,7 +835,8 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
 
                 DisplayMessage(L"Trying to load '%S'.\n"
                                L"WOW16 applications are not supported internally by NTVDM at the moment.\n"
-                               L"Consider installing OTVDM in '%S'. Press 'OK' to continue.",
+                               L"Consider installing WineVDM from the ReactOS Applications Manager in\n'%S'.\n\n"
+                               L"Click on OK to continue.",
                                ProgramName, ExpName);
             }
             // Fall through

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -811,7 +811,7 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             ZeroMemory(&si, sizeof(si));
             si.cb = sizeof(si);
 
-            /* Create the process. */
+            /* Create the process */
             if (CreateProcessA(NULL,    // No Application Name
                                ExpName, // Just our Command Line
                                NULL,    // Cannot inherit Process Handle


### PR DESCRIPTION
## Enable 'WineVDM' to be integrated into ReactOS in a seamless manner

_Add otya128's WineVDM link code into the ReactOS NTVDM._

JIRA issue: [CORE-17852](https://jira.reactos.org/browse/CORE-17852)

## Allow ReactOS to use the WineVDM code if it is available to run WOW16 programs directly from Explorer