### PR TITLE
[USER32] GetQueueStatus() should not return 0 when passing QS_ALLINPUT flag

### DIFF
--- a/win32ss/user/user32/windows/message.c
+++ b/win32ss/user/user32/windows/message.c
@@ -2899,7 +2899,7 @@ DWORD
 WINAPI
 RealGetQueueStatus(UINT flags)
 {
-   if (flags & ~(QS_SMRESULT|QS_ALLPOSTMESSAGE|QS_ALLINPUT))
+   if (flags & ~(QS_ALLINPUT|QS_ALLPOSTMESSAGE|QS_SMRESULT))
    {
       SetLastError( ERROR_INVALID_FLAGS );
       return 0;

--- a/win32ss/user/user32/windows/message.c
+++ b/win32ss/user/user32/windows/message.c
@@ -2904,6 +2904,16 @@ RealGetQueueStatus(UINT flags)
       SetLastError( ERROR_INVALID_FLAGS );
       return 0;
    }
+   /** ATM, we do not support QS_RAWINPUT, but we need to support apps that pass
+    ** this flag along, while also working around QS_RAWINPUT checks in winetests.
+    ** Just set the last error to ERROR_INVALID_FLAGS but do not fail the call.
+    **/
+   if (flags & QS_RAWINPUT)
+   {
+      SetLastError(ERROR_INVALID_FLAGS);
+      flags &= ~QS_RAWINPUT;
+   }
+   /**/
    return NtUserxGetQueueStatus(flags);
 }
 

--- a/win32ss/user/user32/windows/message.c
+++ b/win32ss/user/user32/windows/message.c
@@ -2900,12 +2900,14 @@ WINAPI
 RealGetQueueStatus(UINT flags)
 {
    #define QS_TEMPALLINPUT 255 // ATM, do not support QS_RAWINPUT
+   DWORD ret;
    if (flags & ~(QS_SMRESULT|QS_ALLPOSTMESSAGE|QS_TEMPALLINPUT))
    {
       SetLastError( ERROR_INVALID_FLAGS );
-      return 0;
+      ret = 0;
    }
-   return NtUserxGetQueueStatus(flags);
+   ret = NtUserxGetQueueStatus(flags);
+   return ret;
 }
 
 

--- a/win32ss/user/user32/windows/message.c
+++ b/win32ss/user/user32/windows/message.c
@@ -2899,15 +2899,12 @@ DWORD
 WINAPI
 RealGetQueueStatus(UINT flags)
 {
-   #define QS_TEMPALLINPUT 255 // ATM, do not support QS_RAWINPUT
-   DWORD ret;
-   if (flags & ~(QS_SMRESULT|QS_ALLPOSTMESSAGE|QS_TEMPALLINPUT))
+   if (flags & ~(QS_SMRESULT|QS_ALLPOSTMESSAGE|QS_ALLINPUT))
    {
       SetLastError( ERROR_INVALID_FLAGS );
-      ret = 0;
+      return 0;
    }
-   ret = NtUserxGetQueueStatus(flags);
-   return ret;
+   return NtUserxGetQueueStatus(flags);
 }
 
 


### PR DESCRIPTION
## Purpose
Some versions of libgdk-win32-2.0.0.dll enters into an infinite loop when calling GetQueueStatus() with QS_ALLINPUT flag.

This happens because the RealGetQueueStatus() function performs a wrong flag check, thus calling it with QS_ALLINPUT leads to a 0 returned and setting the last error to ERROR_INVALID_FLAGS.

This seems to be fatal for [libgdk calls to GetQueueStatus()](https://gitlab.gnome.org/search?search=GetQueueStatus&group_id=8&project_id=665&scope=&search_code=true&snippets=false&repository_ref=2.24.11&nav_source=navbar) as they relies in GetQueueStatus() not returning 0.

@julenuri told me some time ago that this issue is not present in Wine, so a quick look in [Wine's implementation of GetQueueStatus](https://source.winehq.org/git/wine.git/blob/32fb017d4a22be38ca271bf387e466e958601355:/dlls/user32/input.c#l527) can confirm this.

This fixes:
[CORE-15686](https://jira.reactos.org/browse/CORE-15686), [CORE-17551](https://jira.reactos.org/browse/CORE-17551), [CORE-11850](https://jira.reactos.org/browse/CORE-11850) and [CORE-8475](https://jira.reactos.org/browse/CORE-8475).
