### PR TITLE
[WIN32SS:NTUSER] Fix window state after restoring snapped window. CORE-16477

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -815,9 +815,16 @@ IntDefWindowProc(
                if (wParam == VK_DOWN)
                {
                    if (topWnd->style & WS_MAXIMIZE)
+                   {
                        co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_RESTORE, lParam);
+
+                       /* "Normal size" must be erased after restoring, otherwise it will block next side snap actions */
+                       RECTL_vSetEmptyRect(&topWnd->InternalPos.NormalRect);
+                   }
                    else
+                   {
                        co_IntSendMessage(hwndTop, WM_SYSCOMMAND, SC_MINIMIZE, lParam);
+                   }
                }
                else if (wParam == VK_UP)
                {


### PR DESCRIPTION
InternalPos.NormalRect is a key data for detecting is window was snapped. Keeping it after restore affecting next snap actions

JIRA issue: [CORE-16477](https://jira.reactos.org/browse/CORE-16477)
