### PR TITLE
[EXPLORER] Fix for Start Button Wrong size when Using Themes

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1631,13 +1631,11 @@ ChangePos:
         HWND hwndTaskToolbar = ::GetWindow(m_TaskSwitch, GW_CHILD);
         if (hwndTaskToolbar)
         {
-            SIZE EdgeSize;
-            EdgeSize.cy = GetSystemMetrics(SM_CYEDGE);
+            LONG EdgeSizeY = GetSystemMetrics(SM_CYEDGE);
             DWORD size = SendMessageW(hwndTaskToolbar, TB_GETBUTTONSIZE, 0, 0);
 
             /* Themed button covers Edge area as well */
-            StartSize.cy = HIWORD(size) + (m_Theme ? GetSystemMetrics(SM_CYEDGE) : 0);
-            }
+            StartSize.cy = HIWORD(size) + (m_Theme ? EdgeSizeY : 0);
         }
 
         if (m_StartButton.m_hWnd != NULL)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1562,7 +1562,7 @@ ChangePos:
         else
         {
             WndSize.cx = StartBtnSize.cx;
-            WndSize.cy = StartBtnSize.cy - EdgeSize.cx;
+            WndSize.cy = StartBtnSize.cy - EdgeSize.cy;
         }
 
         if (WndSize.cx < g_TaskbarSettings.sr.Size.cx)
@@ -1628,13 +1628,20 @@ ChangePos:
         if (StartSize.cx > rcClient.right)
             StartSize.cx = rcClient.right;
 
-        if (!m_Theme)
+        HWND hwndTaskToolbar = ::GetWindow(m_TaskSwitch, GW_CHILD);
+        if (hwndTaskToolbar)
         {
-            HWND hwndTaskToolbar = ::GetWindow(m_TaskSwitch, GW_CHILD);
-            if (hwndTaskToolbar)
+            SIZE EdgeSize;
+            EdgeSize.cy = GetSystemMetrics(SM_CYEDGE);
+            DWORD size = SendMessageW(hwndTaskToolbar, TB_GETBUTTONSIZE, 0, 0);
+            if (!m_Theme)
             {
-                DWORD size = SendMessageW(hwndTaskToolbar, TB_GETBUTTONSIZE, 0, 0);
                 StartSize.cy = HIWORD(size);
+            }
+            else
+            {
+                /* Themed button covers Edge area as well */
+                StartSize.cy = HIWORD(size) + EdgeSize.cy;
             }
         }
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1631,11 +1631,10 @@ ChangePos:
         HWND hwndTaskToolbar = ::GetWindow(m_TaskSwitch, GW_CHILD);
         if (hwndTaskToolbar)
         {
-            LONG EdgeSizeY = GetSystemMetrics(SM_CYEDGE);
             DWORD size = SendMessageW(hwndTaskToolbar, TB_GETBUTTONSIZE, 0, 0);
 
             /* Themed button covers Edge area as well */
-            StartSize.cy = HIWORD(size) + (m_Theme ? EdgeSizeY : 0);
+            StartSize.cy = HIWORD(size) + (m_Theme ? GetSystemMetrics(SM_CYEDGE) : 0);
         }
 
         if (m_StartButton.m_hWnd != NULL)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1634,14 +1634,9 @@ ChangePos:
             SIZE EdgeSize;
             EdgeSize.cy = GetSystemMetrics(SM_CYEDGE);
             DWORD size = SendMessageW(hwndTaskToolbar, TB_GETBUTTONSIZE, 0, 0);
-            if (!m_Theme)
-            {
-                StartSize.cy = HIWORD(size);
-            }
-            else
-            {
-                /* Themed button covers Edge area as well */
-                StartSize.cy = HIWORD(size) + EdgeSize.cy;
+
+            /* Themed button covers Edge area as well */
+            StartSize.cy = HIWORD(size) + (m_Theme ? GetSystemMetrics(SM_CYEDGE) : 0);
             }
         }
 


### PR DESCRIPTION
## Fix for Themed Start Buttons not being full-sized in y-dimension

_Changes to code to allow different calculation for 'cy' when theme is active._

JIRA issue: [CORE-16742](https://jira.reactos.org/browse/CORE-16742)

## Make Themed Start Buttons Taller to fill space available