### PR TITLE
[WIN32K] Fix 'use after free' in NtGdiStretchDIBitsInternal

### DIFF
--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1490,7 +1490,6 @@ NtGdiStretchDIBitsInternal(
         if (pdc) DC_UnlockDc(pdc);
     }
 
-    if (pbmiSafe) ExFreePoolWithTag(pbmiSafe, 'imBG');
     if (pvBits) ExFreePoolWithTag(pvBits, TAG_DIB);
 
     /* This is not what MSDN says is returned from this function, but it
@@ -1505,6 +1504,7 @@ NtGdiStretchDIBitsInternal(
         LinesCopied = pbmiSafe->bmiHeader.biHeight;
     }
 
+    ExFreePoolWithTag(pbmiSafe, 'imBG');
     return LinesCopied;
 }
 

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1505,6 +1505,7 @@ NtGdiStretchDIBitsInternal(
     }
 
     ExFreePoolWithTag(pbmiSafe, 'imBG');
+
     return LinesCopied;
 }
 


### PR DESCRIPTION
## Fix Crash of VS2010 Pro Installer

_Correct 'use after free' in dibobj.c._

JIRA issue: [CORE-17861](https://jira.reactos.org/browse/CORE-17861)

## Relocate ExFreePoolWithTag for pbmiSafe below last use