### PR TITLE
[NTVDM] Use strsafe functions for concantenation of strings in otvdm code.

### DIFF
--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -13,6 +13,7 @@
 
 #define NDEBUG
 #include <debug.h>
+#include <strsafe.h>
 
 #include "emulator.h"
 #include "cpu/cpu.h"
@@ -803,9 +804,9 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             CHAR ExpName[MAX_PATH];
 
             ExpandEnvironmentStringsA(AppName, ExpName, ARRAYSIZE(ExpName) - 1);
-            strcat(ExpName, "\"");         // Add double-quote before ProgramName
-            strcat(ExpName, ProgramName);  // Append Program name
-            strcat(ExpName, "\"");         // Add double-quote after ProgramName
+            StringCbCatA(ExpName, MAX_PATH, "\"");         // Add double-quote before ProgramName
+            StringCbCatA(ExpName, MAX_PATH, ProgramName);  // Append Program name
+            StringCbCatA(ExpName, MAX_PATH, "\"");         // Add double-quote after ProgramName
 
             ZeroMemory(&pi, sizeof(pi));
             ZeroMemory(&si, sizeof(si));

--- a/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
+++ b/subsystems/mvdm/ntvdm/dos/dos32krnl/process.c
@@ -804,9 +804,9 @@ WORD DosCreateProcess(IN LPCSTR ProgramName,
             CHAR ExpName[MAX_PATH];
 
             ExpandEnvironmentStringsA(AppName, ExpName, ARRAYSIZE(ExpName) - 1);
-            StringCbCatA(ExpName, MAX_PATH, "\"");         // Add double-quote before ProgramName
-            StringCbCatA(ExpName, MAX_PATH, ProgramName);  // Append Program name
-            StringCbCatA(ExpName, MAX_PATH, "\"");         // Add double-quote after ProgramName
+            StringCbCatA(ExpName, sizeof(ExpName), "\"");         // Add double-quote before ProgramName
+            StringCbCatA(ExpName, sizeof(ExpName), ProgramName);  // Append Program name
+            StringCbCatA(ExpName, sizeof(ExpName), "\"");         // Add double-quote after ProgramName
 
             ZeroMemory(&pi, sizeof(pi));
             ZeroMemory(&si, sizeof(si));


### PR DESCRIPTION
## Replace previous string concatenation functions with strsafe ones

_Change strcat functions to StringCbCatA ones._

JIRA issue: [CORE-17852](https://jira.reactos.org/browse/CORE-17852)

## Make code more secure

This is an extension of https://github.com/reactos/reactos/pull/4113