### PR TITLE
[3DTEXT] Fix 3dtext.scr using near 100% CPU

### DIFF
--- a/base/applications/screensavers/3dtext/3dtext.c
+++ b/base/applications/screensavers/3dtext/3dtext.c
@@ -41,6 +41,8 @@ GLfloat extentY = 0.0f;
 
 HINSTANCE hInstance;
 BOOL fullscreen = FALSE;
+#define APP_TIMER             1                         // Graphics Update Timer ID
+#define APP_TIMER_INTERVAL    USER_TIMER_MINIMUM * 5    // Graphics Update Interval
 
 // Build Our Bitmap Font
 GLvoid BuildFont(GLvoid)
@@ -338,6 +340,7 @@ ScreenSaverProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
             // Initialize The GL Screen Using Screen Info
             InitGL(Screen.right, Screen.bottom);
+            SetTimer(hWnd, APP_TIMER, APP_TIMER_INTERVAL, NULL);    // Graphics update timer
             break;
 
         case WM_DESTROY:
@@ -360,11 +363,16 @@ ScreenSaverProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
         case WM_PAINT:
             DrawGLScene();
             SwapBuffers(hDC);
+            ValidateRect(hWnd, NULL);   // Don't update here. Wait for timer.
             break;
 
         case WM_SIZE: // Resizing The Screen
             // Resize To The New Window Size
             ReSizeGLScene(LOWORD(lParam), HIWORD(lParam));
+            break;
+
+        case WM_TIMER:  // Used to update graphic based on timer udpate interval
+            InvalidateRect(hWnd, NULL, TRUE);
             break;
 
         default:


### PR DESCRIPTION
## Stop 3D Text ScreenSaver using near 100% CPY

_Add Timer to allow updating screen less often._

JIRA issue: [CORE-17866](https://jira.reactos.org/browse/CORE-17866)

## Add Timer to 3dtext.c to slow screen update to reasonable level

_This fixes the 3D Text ScreenSaver using near 100% CPU._