### PR TITLE
[RICHED20] Fail elegantly if pRow or pPara is NULL on ME_EnsureVisible

### DIFF
--- a/dll/win32/riched20/paint.c
+++ b/dll/win32/riched20/paint.c
@@ -1279,6 +1279,9 @@ void ME_EnsureVisible(ME_TextEditor *editor, ME_Cursor *pCursor)
   ME_DisplayItem *pPara = pCursor->pPara;
   int x, y, yheight;
 
+#ifdef __REACTOS__
+  if (!pRow || !pPara) return;
+#endif
   assert(pRow);
   assert(pPara);
 

--- a/dll/win32/riched20/paint.c
+++ b/dll/win32/riched20/paint.c
@@ -1280,10 +1280,12 @@ void ME_EnsureVisible(ME_TextEditor *editor, ME_Cursor *pCursor)
   int x, y, yheight;
 
 #ifdef __REACTOS__
-  if (!pRow || !pPara) return;
-#endif
+  if (!pRow || !pPara)
+    return;
+#else
   assert(pRow);
   assert(pPara);
+#endif
 
   if (editor->styleFlags & ES_AUTOHSCROLL)
   {


### PR DESCRIPTION
## Purpose
Baidu Browser installer used to get an assertion failure.
JIRA issue: [CORE-16578](https://jira.reactos.org/browse/CORE-16578)

## Proposed changes

- Fail elegantly on `ME_EnsureVisible` function if `pRow` or `pPara` is `NULL`.

## TODO

- [x] Do tests.

## Screenshots
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/143663648-a88857ed-706c-4cec-a564-c211b144e496.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/143663651-beb90447-d20d-483a-8980-e5b281e481e5.png)