### PR TITLE
[WIN32SS][ENG] Search for the correct display name when updating graphics devices list

### DIFF
--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -36,7 +36,7 @@ NTSTATUS
 EngpUpdateGraphicsDeviceList(VOID)
 {
     ULONG iDevNum, iVGACompatible = -1, ulMaxObjectNumber = 0;
-    WCHAR awcDeviceName[20];
+    WCHAR awcDeviceName[20], awcWinDeviceName[20];
     UNICODE_STRING ustrDeviceName;
     WCHAR awcBuffer[256];
     NTSTATUS Status;
@@ -74,7 +74,10 @@ EngpUpdateGraphicsDeviceList(VOID)
     {
         /* Create the adapter's key name */
         swprintf(awcDeviceName, L"\\Device\\Video%lu", iDevNum);
-        RtlInitUnicodeString(&ustrDeviceName, awcDeviceName);
+
+        /* Create the display device name */
+        swprintf(awcWinDeviceName, L"\\\\.\\DISPLAY%lu", iDevNum + 1);
+        RtlInitUnicodeString(&ustrDeviceName, awcWinDeviceName);
 
         /* Check if the device exists already */
         pGraphicsDevice = EngpFindGraphicsDevice(&ustrDeviceName, iDevNum, 0);


### PR DESCRIPTION
## Purpose

Pass the correct display name to `EngpFindGraphicsDevice` function in `EngpUpdateGraphicsDeviceList`. According to our TechWiki page: https://reactos.org/wiki/Techwiki:Win32k/GRAPHICS_DEVICE, it actually should look like `\\.\DISPLAY<n>` (since it comes from user mode), which that function searches, not `\\Device\\Video<n>`, like done in kernel mode. Otherwise, passing wrong name causes mismatch and further conflicts.
It fixes the problem with access to the video device (failure with status 0xc0000022 when trying to open it). Hence, it also removes the following logspam:
`(/win32ss/gdi/eng/device.c:350) err: Could not open device \Device\Video0, 0xc0000022`.
UPD: it also fixes screen resolution saving regression described in CORE-17719, as confirmed by @Doug-Lyons. :slightly_smiling_face: 
Addendum to 77e891b.

JIRA issue: [CORE-17719](https://jira.reactos.org/browse/CORE-17719), [CORE-17786](https://jira.reactos.org/browse/CORE-17786).

## Proposed changes

- Declare a new separate `WCHAR` variable.
- Fill it by `\\.\DISPLAY<n>`, where `n` is the `iDevNum` variable (device number) + `1`. I appended `1` because as I know, display device number numeration starts from `1`, while the first video device number is `0` (as it's assigned to `iDevNum` in the loop). Otherwise, if try to use zero `iDevNum`, the problem is not fixed again.
- Initialize passed unicode string by this, instead of video device number, which actually is a registry key name and used only for receiving registry data later.