### PR TITLE
[WIN32SS] Do not remove message from the Message Queue if not ours

### DIFF
--- a/win32ss/user/ntuser/msgqueue.c
+++ b/win32ss/user/ntuser/msgqueue.c
@@ -1524,7 +1524,7 @@ BOOL co_IntProcessMouseMessage(MSG* msg, BOOL* RemoveMessages, BOOL* NotForUs, L
     {
         // This is not for us and we should leave so the other thread can check for messages!!!
         *NotForUs = TRUE;
-        *RemoveMessages = TRUE;
+        *RemoveMessages = FALSE;
         return FALSE;
     }
 


### PR DESCRIPTION
## Stop dropping Left Mouse clicks under certain conditions.

_Implement I_Kill_Bugs 'No remove' patch._

JIRA issue: [CORE-8217](https://jira.reactos.org/browse/CORE-8217)

## Change Message Queue handling to not remove messages if message not 'ours'

_This fixes one component of the 3dtext screensaver not being responsive._