### PR TITLE
[USETUP] Improve pt-PT translation

### DIFF
--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -1494,7 +1494,6 @@ static MUI_ENTRY ptPTBootLoaderEntries[] =
         6,
         8,
         "O instalador ir\240 configurar o gestor de arranque.",
-
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -1493,35 +1493,35 @@ static MUI_ENTRY ptPTBootLoaderEntries[] =
     {
         6,
         8,
-        "O instalador ir\240 configurar o ger\210nciador de inicializa\207\306o",
+        "O instalador ir\240 configurar o gestor de arranque.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         12,
-        "Instalar o ger\210nciador de inicializa\207\306o no disco r\241gido (MBR e VBR)",
+        "Instalar o gestor de arranque no disco r\241gido (MBR e VBR)",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "Instalar o ger\210nciador de inicializa\207\306o no disco r\241gido (apenas VBR)",
+        "Instalar o gestor de arranque no disco r\241gido (apenas VBR)",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         14,
-        "Instalar o ger\210nciador de inicializa\207\306o numa disquete",
+        "Instalar o gestor de arranque numa disquete",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "Saltar a instala\207\306o do ger\210nciador de inicializa\207\306o",
+        "Saltar a instala\207\306o do gestor de arranque",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3921,7 +3921,7 @@ BootLoaderPage(PINPUT_RECORD Ir)
     }
 
     MUIDisplayPage(BOOT_LOADER_PAGE);
-    CONSOLE_InvertTextXY(8, Line, 68, 1);
+    CONSOLE_InvertTextXY(8, Line, 60, 1);
 
     while (TRUE)
     {

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3930,7 +3930,7 @@ BootLoaderPage(PINPUT_RECORD Ir)
         if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
             (Ir->Event.KeyEvent.wVirtualKeyCode == VK_DOWN))  /* DOWN */
         {
-   //         CONSOLE_NormalTextXY(8, Line, 68, 1);
+            CONSOLE_NormalTextXY(8, Line, 60, 1);
 
             Line++;
             if (Line < 12)
@@ -3939,12 +3939,12 @@ BootLoaderPage(PINPUT_RECORD Ir)
             if (Line > 15)
                 Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 68, 1);
+            CONSOLE_InvertTextXY(8, Line, 60, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_UP))  /* UP */
         {
-            CONSOLE_NormalTextXY(8, Line, 68, 1);
+            CONSOLE_NormalTextXY(8, Line, 60, 1);
 
             Line--;
             if (Line < 12)
@@ -3953,25 +3953,25 @@ BootLoaderPage(PINPUT_RECORD Ir)
             if (Line > 15)
                 Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 68, 1);
+            CONSOLE_InvertTextXY(8, Line, 60, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_HOME))  /* HOME */
         {
-            CONSOLE_NormalTextXY(8, Line, 68, 1);
+            CONSOLE_NormalTextXY(8, Line, 60, 1);
 
             Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 68, 1);
+            CONSOLE_InvertTextXY(8, Line, 60, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_END))  /* END */
         {
-            CONSOLE_NormalTextXY(8, Line, 68, 1);
+            CONSOLE_NormalTextXY(8, Line, 60, 1);
 
             Line = 15;
 
-            CONSOLE_InvertTextXY(8, Line, 68, 1);
+            CONSOLE_InvertTextXY(8, Line, 60, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_F3))  /* F3 */

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -3921,7 +3921,7 @@ BootLoaderPage(PINPUT_RECORD Ir)
     }
 
     MUIDisplayPage(BOOT_LOADER_PAGE);
-    CONSOLE_InvertTextXY(8, Line, 60, 1);
+    CONSOLE_InvertTextXY(8, Line, 68, 1);
 
     while (TRUE)
     {
@@ -3930,7 +3930,7 @@ BootLoaderPage(PINPUT_RECORD Ir)
         if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
             (Ir->Event.KeyEvent.wVirtualKeyCode == VK_DOWN))  /* DOWN */
         {
-            CONSOLE_NormalTextXY(8, Line, 60, 1);
+   //         CONSOLE_NormalTextXY(8, Line, 68, 1);
 
             Line++;
             if (Line < 12)
@@ -3939,12 +3939,12 @@ BootLoaderPage(PINPUT_RECORD Ir)
             if (Line > 15)
                 Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 60, 1);
+            CONSOLE_InvertTextXY(8, Line, 68, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_UP))  /* UP */
         {
-            CONSOLE_NormalTextXY(8, Line, 60, 1);
+            CONSOLE_NormalTextXY(8, Line, 68, 1);
 
             Line--;
             if (Line < 12)
@@ -3953,25 +3953,25 @@ BootLoaderPage(PINPUT_RECORD Ir)
             if (Line > 15)
                 Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 60, 1);
+            CONSOLE_InvertTextXY(8, Line, 68, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_HOME))  /* HOME */
         {
-            CONSOLE_NormalTextXY(8, Line, 60, 1);
+            CONSOLE_NormalTextXY(8, Line, 68, 1);
 
             Line = 12;
 
-            CONSOLE_InvertTextXY(8, Line, 60, 1);
+            CONSOLE_InvertTextXY(8, Line, 68, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_END))  /* END */
         {
-            CONSOLE_NormalTextXY(8, Line, 60, 1);
+            CONSOLE_NormalTextXY(8, Line, 68, 1);
 
             Line = 15;
 
-            CONSOLE_InvertTextXY(8, Line, 60, 1);
+            CONSOLE_InvertTextXY(8, Line, 68, 1);
         }
         else if ((Ir->Event.KeyEvent.uChar.AsciiChar == 0x00) &&
                  (Ir->Event.KeyEvent.wVirtualKeyCode == VK_F3))  /* F3 */


### PR DESCRIPTION
[USETUP] Set menu item length to maximum string length

In pt-PT language in usetup.c BootLoaderPage  the menu bar when selected is shorter than the string length
Better solution by improving pt-PT translation 