### PR TITLE
[FREELDR] debug.h: Add an explicit VOID parameter type

### DIFF
--- a/boot/freeldr/freeldr/include/debug.h
+++ b/boot/freeldr/freeldr/include/debug.h
@@ -44,7 +44,7 @@
     ULONG   DbgPrint(const char *Format, ...);
     VOID    DbgPrint2(ULONG Mask, ULONG Level, const char *File, ULONG Line, char *Format, ...);
     VOID    DebugDumpBuffer(ULONG Mask, PVOID Buffer, ULONG Length);
-    VOID    DebugDisableScreenPort();
+    VOID    DebugDisableScreenPort(VOID);
     VOID    DbgParseDebugChannels(PCHAR Value);
 
     #define ERR_LEVEL      0x1


### PR DESCRIPTION
Be explicit.

Addendum to 0.4.15-dev-200-g98c17d3.
JIRA issue: [CORE-16216](https://jira.reactos.org/browse/CORE-16216)
