### PR TITLE
[WINLOGON] Start screen saver with current user

### DIFF
--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -47,4 +47,10 @@ VOID SaveSettings(VOID)
         RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
         RegCloseKey(hkey);
     }
+    if (RegCreateKeyEx(HKEY_USERS, _T(".DEFAULT\\Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
+        _T(""), 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
+    {
+        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
+        RegCloseKey(hkey);
+    }
 }

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -101,7 +101,7 @@ VOID SaveSettings(VOID)
     size_t CbDestLength = 0;
 
     if (RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\ScreenSavers\\Text3D", 0,
-    L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
+        L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
         StringCbLengthW(m_Text, sizeof(m_Text), &CbDestLength);
         RegSetValueExW(hkey, L"DisplayString", 0, REG_SZ, (LPBYTE)m_Text, CbDestLength + sizeof(WCHAR));

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -18,39 +18,102 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+/* This program can actually be entered from two very different contexts.
+ * One is that it can be entered when a normal user is signed into Windows.
+ * This is the case when it is called from the Desk CPL in the ScreenSaver
+ * Tab. In this context, we will be able to open a registry key for the
+ * HKEY_CURRENT_USER and use it to find the Display String to use.
+ * The other case is when is is run when the screen saver timeout occurs.
+ * Now we are running without a normal logged in user and if we try and open
+ * HKEY_CURRENT_USER, we will get a Windows Error #2 - File not Found.
+ * In this case, we will have to use the values in HKEY_USER\.Default to
+ * find the Display String to use.
+*/
+
 #include "3dtext.h"
 
 #include <winreg.h>
+#include <strsafe.h>
 
-TCHAR m_Text[MAX_PATH] = _T("ReactOS Rocks!");
+WCHAR m_Text[MAX_PATH] = L"ReactOS Rocks!";
 
 VOID LoadSettings(VOID)
 {
-	HKEY hkey;
-	DWORD len = MAX_PATH * sizeof(TCHAR);
+    HKEY hkey;
+    DWORD len = MAX_PATH * sizeof(WCHAR);
+    DWORD dwRet;
 
-	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
-		_T(""), 0, KEY_READ, NULL, &hkey, NULL) == ERROR_SUCCESS)
+    dwRet = RegOpenKeyExW(HKEY_CURRENT_USER,
+                          L"Software\\Microsoft\\ScreenSavers\\Text3D",
+                          0,
+                          KEY_READ,
+                          &hkey);
+
+    if (dwRet == ERROR_SUCCESS)
     {
-        RegQueryValueEx(hkey, _T("DisplayString"), NULL, NULL, (LPBYTE)m_Text, &len);
-        RegCloseKey(hkey);
+        dwRet = RegQueryValueExW(hkey,
+                                 L"DisplayString",
+                                 NULL,
+                                 NULL,
+                                 (LPBYTE)m_Text,
+                                 &len);
+
+        if( dwRet == ERROR_SUCCESS )
+        {
+            /* This makes sure that the settings are saved in two places. */
+            SaveSettings();
+        }
+    }
+    else
+    {
+        dwRet = RegOpenKeyExW(HKEY_USERS,
+                              L".Default\\Software\\Microsoft\\ScreenSavers\\Text3D",
+                              0,
+                              KEY_READ,
+                              &hkey);
+
+        if( dwRet == ERROR_SUCCESS )
+        {
+            dwRet = RegQueryValueExW(hkey,
+                                     L"DisplayString",
+                                     NULL,
+                                     NULL,
+                                     (LPBYTE)m_Text,
+                                     &len);
+
+            if( dwRet == ERROR_SUCCESS )
+            {
+                /* This makes sure that the settings are saved in two places. */
+                SaveSettings();
+            }
+        }
+        else
+        {
+            /* Save Default Settings in two places. */
+            SaveSettings();
+        }
     }
 }
 
 VOID SaveSettings(VOID)
 {
-	HKEY hkey;
+    HKEY hkey;
+    size_t CbDestLength = 0;
 
-	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
-		_T(""), 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
+    if (RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\ScreenSavers\\Text3D", 0,
+    L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
+        StringCbLengthW(m_Text, sizeof(m_Text), &CbDestLength);
+        RegSetValueExW(hkey, L"DisplayString", 0, REG_SZ, (LPBYTE)m_Text, CbDestLength + sizeof(WCHAR));
         RegCloseKey(hkey);
     }
-    if (RegCreateKeyEx(HKEY_USERS, _T(".DEFAULT\\Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
-        _T(""), 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
+
+    CbDestLength = 0;
+    if (RegCreateKeyExW(HKEY_USERS, L".DEFAULT\\Software\\Microsoft\\ScreenSavers\\Text3D", 0,
+        L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
+        StringCbLengthW(m_Text, sizeof(m_Text), &CbDestLength);
+        RegSetValueExW(hkey, L"DisplayString", 0, REG_SZ, (LPBYTE)m_Text, CbDestLength + sizeof(WCHAR));
         RegCloseKey(hkey);
     }
 }

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -28,7 +28,7 @@
  * HKEY_CURRENT_USER, we will get a Windows Error #2 - File not Found.
  * In this case, we will have to use the values in HKEY_USER\.Default to
  * find the Display String to use.
-*/
+ */
 
 #include "3dtext.h"
 

--- a/base/applications/screensavers/3dtext/settings.c
+++ b/base/applications/screensavers/3dtext/settings.c
@@ -18,102 +18,33 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-/* This program can actually be entered from two very different contexts.
- * One is that it can be entered when a normal user is signed into Windows.
- * This is the case when it is called from the Desk CPL in the ScreenSaver
- * Tab. In this context, we will be able to open a registry key for the
- * HKEY_CURRENT_USER and use it to find the Display String to use.
- * The other case is when is is run when the screen saver timeout occurs.
- * Now we are running without a normal logged in user and if we try and open
- * HKEY_CURRENT_USER, we will get a Windows Error #2 - File not Found.
- * In this case, we will have to use the values in HKEY_USER\.Default to
- * find the Display String to use.
- */
-
 #include "3dtext.h"
 
 #include <winreg.h>
-#include <strsafe.h>
 
-WCHAR m_Text[MAX_PATH] = L"ReactOS Rocks!";
+TCHAR m_Text[MAX_PATH] = _T("ReactOS Rocks!");
 
 VOID LoadSettings(VOID)
 {
-    HKEY hkey;
-    DWORD len = MAX_PATH * sizeof(WCHAR);
-    DWORD dwRet;
+	HKEY hkey;
+	DWORD len = MAX_PATH * sizeof(TCHAR);
 
-    dwRet = RegOpenKeyExW(HKEY_CURRENT_USER,
-                          L"Software\\Microsoft\\ScreenSavers\\Text3D",
-                          0,
-                          KEY_READ,
-                          &hkey);
-
-    if (dwRet == ERROR_SUCCESS)
+	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
+		_T(""), 0, KEY_READ, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        dwRet = RegQueryValueExW(hkey,
-                                 L"DisplayString",
-                                 NULL,
-                                 NULL,
-                                 (LPBYTE)m_Text,
-                                 &len);
-
-        if( dwRet == ERROR_SUCCESS )
-        {
-            /* This makes sure that the settings are saved in two places. */
-            SaveSettings();
-        }
-    }
-    else
-    {
-        dwRet = RegOpenKeyExW(HKEY_USERS,
-                              L".Default\\Software\\Microsoft\\ScreenSavers\\Text3D",
-                              0,
-                              KEY_READ,
-                              &hkey);
-
-        if( dwRet == ERROR_SUCCESS )
-        {
-            dwRet = RegQueryValueExW(hkey,
-                                     L"DisplayString",
-                                     NULL,
-                                     NULL,
-                                     (LPBYTE)m_Text,
-                                     &len);
-
-            if( dwRet == ERROR_SUCCESS )
-            {
-                /* This makes sure that the settings are saved in two places. */
-                SaveSettings();
-            }
-        }
-        else
-        {
-            /* Save Default Settings in two places. */
-            SaveSettings();
-        }
+        RegQueryValueEx(hkey, _T("DisplayString"), NULL, NULL, (LPBYTE)m_Text, &len);
+        RegCloseKey(hkey);
     }
 }
 
 VOID SaveSettings(VOID)
 {
-    HKEY hkey;
-    size_t CbDestLength = 0;
+	HKEY hkey;
 
-    if (RegCreateKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\ScreenSavers\\Text3D", 0,
-        L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
+	if (RegCreateKeyEx(HKEY_CURRENT_USER, _T("Software\\Microsoft\\ScreenSavers\\Text3D"), 0,
+		_T(""), 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
     {
-        StringCbLengthW(m_Text, sizeof(m_Text), &CbDestLength);
-        RegSetValueExW(hkey, L"DisplayString", 0, REG_SZ, (LPBYTE)m_Text, CbDestLength + sizeof(WCHAR));
-        RegCloseKey(hkey);
-    }
-
-    CbDestLength = 0;
-    if (RegCreateKeyExW(HKEY_USERS, L".DEFAULT\\Software\\Microsoft\\ScreenSavers\\Text3D", 0,
-        L"", 0, KEY_WRITE, NULL, &hkey, NULL) == ERROR_SUCCESS)
-    {
-        StringCbLengthW(m_Text, sizeof(m_Text), &CbDestLength);
-        RegSetValueExW(hkey, L"DisplayString", 0, REG_SZ, (LPBYTE)m_Text, CbDestLength + sizeof(WCHAR));
+        RegSetValueEx(hkey, _T("DisplayString"), 0, REG_SZ, (LPBYTE)m_Text, (_tcslen(m_Text) + 1) * sizeof(TCHAR));
         RegCloseKey(hkey);
     }
 }

--- a/base/system/winlogon/screensaver.c
+++ b/base/system/winlogon/screensaver.c
@@ -338,7 +338,7 @@ StartScreenSaver(
                                NULL,
                                NULL,
                                FALSE,
-                               0,
+                               IDLE_PRIORITY_CLASS,
                                NULL,
                                NULL,
                                &StartupInfo,

--- a/base/system/winlogon/screensaver.c
+++ b/base/system/winlogon/screensaver.c
@@ -332,16 +332,17 @@ StartScreenSaver(
     /* FIXME: Run the screen saver on the secure screen saver desktop if required */
     StartupInfo.lpDesktop = L"WinSta0\\Default";
 
-    ret = CreateProcessW(szApplicationName,
-                         szCommandLine,
-                         NULL,
-                         NULL,
-                         FALSE,
-                         0,
-                         NULL,
-                         NULL,
-                         &StartupInfo,
-                         &ProcessInformation);
+    ret = CreateProcessAsUserW(Session->UserToken,
+                               szApplicationName,
+                               szCommandLine,
+                               NULL,
+                               NULL,
+                               FALSE,
+                               0,
+                               NULL,
+                               NULL,
+                               &StartupInfo,
+                               &ProcessInformation);
     if (!ret)
     {
         ERR("WL: Unable to start %S, error %lu\n", szApplicationName, GetLastError());


### PR DESCRIPTION
## Fix Wrong Text Displayed when 3D Text ScreenSaver Times Out

_Change User Context of creating the screensaver process in winlogon.exe ._

JIRA issue: [CORE-17875](https://jira.reactos.org/browse/CORE-17875)

## Change context that 3D Text ScreenSaver runs as to Current User

_This fixes the wrong text of "ReactOS Rocks!" being displayed when this screensaver times out._
