### PR TITLE
Cmake enable exports default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,9 @@ else()
     # We don't need CMake importlib handling.
     unset(CMAKE_IMPORT_LIBRARY_SUFFIX)
 
+    # Enable executables (not only libraries) to be able to export symbols.
+    set(CMAKE_ENABLE_EXPORTS TRUE)
+
     # Print build type(s)
     if(CMAKE_CONFIGURATION_TYPES)
         # Multi-config generators, like Visual Studio (MSBuild).

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -259,11 +259,6 @@ endif()
 
 add_executable(freeldr_pe ${FREELDR_BASE_SOURCE})
 
-set_target_properties(freeldr_pe
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 if(MSVC)
     if(ARCH STREQUAL "arm")
         target_link_options(freeldr_pe PRIVATE /ignore:4078 /ignore:4254 /DRIVER)

--- a/modules/rostests/apitests/loadconfig/CMakeLists.txt
+++ b/modules/rostests/apitests/loadconfig/CMakeLists.txt
@@ -8,11 +8,6 @@ list(APPEND SOURCE
 
 add_executable(loadconfig_apitest ${SOURCE} testlist.c ${CMAKE_CURRENT_BINARY_DIR}/loadconfig_apitest.def)
 
-set_target_properties(loadconfig_apitest
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 target_link_libraries(loadconfig_apitest wine ${PSEH_LIB})
 set_module_type(loadconfig_apitest win32cui)
 add_importlibs(loadconfig_apitest msvcrt kernel32 ntdll)

--- a/modules/rostests/apitests/ntdll/CMakeLists.txt
+++ b/modules/rostests/apitests/ntdll/CMakeLists.txt
@@ -110,11 +110,6 @@ add_executable(ntdll_apitest
     testdata.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntdll_apitest.def)
 
-set_target_properties(ntdll_apitest
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 target_link_libraries(ntdll_apitest wine uuid ${PSEH_LIB})
 set_module_type(ntdll_apitest win32cui)
 add_importlibs(ntdll_apitest msvcrt advapi32 kernel32 ntdll)

--- a/modules/rostests/apitests/shell32/CMakeLists.txt
+++ b/modules/rostests/apitests/shell32/CMakeLists.txt
@@ -41,11 +41,6 @@ add_executable(shell32_apitest
     resource.rc
     ${CMAKE_CURRENT_BINARY_DIR}/shell32_apitest.def)
 
-set_target_properties(shell32_apitest
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 target_link_libraries(shell32_apitest wine uuid ${PSEH_LIB} cpprt atl_classes)
 set_module_type(shell32_apitest win32cui)
 add_importlibs(shell32_apitest user32 gdi32 shell32 ole32 oleaut32 advapi32 shlwapi msvcrt kernel32 ntdll)

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -496,6 +496,8 @@ if(NOT MSVC_IDE)
 
     function(add_executable name)
         _add_executable(${name} ${ARGN})
+        # cmake adds a module_EXPORTS define when compiling a module with exports. We don't use that.
+        set_target_properties(${name} PROPERTIES DEFINE_SYMBOL "")
         add_clean_target(${name})
     endfunction()
 elseif(USE_FOLDER_STRUCTURE)
@@ -528,6 +530,8 @@ elseif(USE_FOLDER_STRUCTURE)
 
     function(add_executable name)
         _add_executable(${name} ${ARGN})
+        # cmake adds a module_EXPORTS define when compiling a module with exports. We don't use that.
+        set_target_properties(${name} PROPERTIES DEFINE_SYMBOL "")
         string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_SOURCE_DIR_LENGTH} -1 CMAKE_CURRENT_SOURCE_DIR_RELATIVE)
         set_property(TARGET "${name}" PROPERTY FOLDER "${CMAKE_CURRENT_SOURCE_DIR_RELATIVE}")
     endfunction()
@@ -539,6 +543,12 @@ else()
         if(_type MATCHES SHARED_LIBRARY|MODULE_LIBRARY)
             set_target_properties(${name} PROPERTIES DEFINE_SYMBOL "")
         endif()
+    endfunction()
+
+    function(add_executable name)
+        _add_executable(${name} ${ARGN})
+        # cmake adds a module_EXPORTS define when compiling a module with exports. We don't use that.
+        set_target_properties(${name} PROPERTIES DEFINE_SYMBOL "")
     endfunction()
 endif()
 
@@ -665,14 +675,6 @@ function(set_module_type MODULE TYPE)
         if((${TYPE} STREQUAL kernelmodedriver) OR (${TYPE} STREQUAL wdmdriver))
             set_target_properties(${MODULE} PROPERTIES SUFFIX ".sys")
         endif()
-    endif()
-
-    if(TYPE STREQUAL kernel)
-        # Kernels are executables with exports
-        set_target_properties(${MODULE}
-            PROPERTIES
-            ENABLE_EXPORTS TRUE
-            DEFINE_SYMBOL "")
     endif()
 
     if(${TYPE} STREQUAL win32ocx)

--- a/subsystems/mvdm/ntvdm/CMakeLists.txt
+++ b/subsystems/mvdm/ntvdm/CMakeLists.txt
@@ -73,11 +73,6 @@ add_executable(ntvdm
     ntvdm.rc
     ${CMAKE_CURRENT_BINARY_DIR}/ntvdm.def)
 
-set_target_properties(ntvdm
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 add_pch(ntvdm ntvdm.h SOURCE)
 set_module_type(ntvdm win32cui UNICODE IMAGEBASE 0x0F000000)
 target_link_libraries(ntvdm fast486 ${PSEH_LIB})

--- a/win32ss/printing/base/spoolsv/CMakeLists.txt
+++ b/win32ss/printing/base/spoolsv/CMakeLists.txt
@@ -30,11 +30,6 @@ add_executable(spoolsv
     spoolsv.rc
     ${CMAKE_CURRENT_BINARY_DIR}/spoolsv.def)
 
-set_target_properties(spoolsv
-    PROPERTIES
-    ENABLE_EXPORTS TRUE
-    DEFINE_SYMBOL "")
-
 if(USE_CLANG_CL)
     target_compile_options(spoolsv PRIVATE "-Wno-cast-calling-convention")
 endif()


### PR DESCRIPTION
## Purpose

"Recent" CMake versions do not allow EXECUTABLE targets to export symbols (only libraries), unless the `ENABLE_EXPORTS` property is enabled by-target. I argue that this is unnatural, because the original behaviour (allowing EXE targets to export symbols) is what is natural for PE binaries on Windows/NT-like platforms.

Therefore, I globally enable `ENABLE_EXPORTS` to be set (`ON`, or `TRUE`), by setting the global [`CMAKE_ENABLE_EXPORTS`](https://cmake.org/cmake/help/latest/variable/CMAKE_ENABLE_EXPORTS.html) variable, only when build-configuring the main targets (not the host-tools).

Related JIRA issue: [CORE-15406](https://jira.reactos.org/browse/CORE-15406)
See also PR #1335 and #808, as well as commit 957e566.

## Proposed changes

```
[CMAKE] Globally enable executables (not only libraries) to be able to export symbols...

... following the ENABLE_EXPORTS CMake "débâcle", partly-fixed originally
by commit d8e92b5 (see PR #1335), and finally by commit 957e566.
```

```
[APITESTS][FREELDR][NTVDM][SPOOLSV] Remove now-unneeded ENABLE_EXPORTS property.
```