### PR TITLE
[NTGDI] Support the wide pen

### DIFF
--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -137,6 +137,8 @@ IntGdiPolygon(PDC    dc,
                 PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
+
+                /* FIXME: Boundary */
             }
             else
             {
@@ -693,6 +695,8 @@ IntRectangle(PDC dc,
             PATH_UnlockPath(pPath);
             PATH_Delete(dc->dclevel.hPath);
             dc->dclevel.hPath = NULL;
+
+            /* FIXME: Boundary */
         }
         else
         {

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -23,7 +23,7 @@ IntGdiPolygon(PDC    dc,
     PBRUSH pbrLine, pbrFill;
     BOOL ret = FALSE; // Default to failure
     RECTL DestRect;
-    int CurrentPoint;
+    INT i, CurrentPoint;
     PDC_ATTR pdcattr;
     POINTL BrushOrigin;
     PPATH pPath;
@@ -106,8 +106,6 @@ IntGdiPolygon(PDC    dc,
         // Draw the Polygon Edges with the current pen ( if not a NULL pen )
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            int i;
-
             if (IntIsWideGeometricPen(pbrLine))
             {
                 /* Clear the path */

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -134,6 +134,7 @@ IntGdiPolygon(PDC    dc,
                 ret = PATH_StrokePath(dc, pPath);
 
                 /* Clear the path */
+                PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
             }
@@ -689,6 +690,7 @@ IntRectangle(PDC dc,
             ret = PATH_StrokePath(dc, pPath);
 
             /* Clear the path */
+            PATH_UnlockPath(pPath);
             PATH_Delete(dc->dclevel.hPath);
             dc->dclevel.hPath = NULL;
         }

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -106,7 +106,7 @@ IntGdiPolygon(PDC    dc,
         // Draw the Polygon Edges with the current pen ( if not a NULL pen )
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            if (IntIsWideGeometricPen(pbrLine))
+            if (IntIsGeometricWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
@@ -661,7 +661,7 @@ IntRectangle(PDC dc,
 
     if (!(pbrLine->flAttrs & BR_IS_NULL))
     {
-        if (IntIsWideGeometricPen(pbrLine))
+        if (IntIsGeometricWidePen(pbrLine))
         {
             /* Clear the path */
             PATH_Delete(dc->dclevel.hPath);

--- a/win32ss/gdi/ntgdi/fillshap.c
+++ b/win32ss/gdi/ntgdi/fillshap.c
@@ -106,7 +106,7 @@ IntGdiPolygon(PDC    dc,
         // Draw the Polygon Edges with the current pen ( if not a NULL pen )
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            if (IntIsGeometricWidePen(pbrLine))
+            if (IntIsEffectiveWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
@@ -662,7 +662,7 @@ IntRectangle(PDC dc,
 
     if (!(pbrLine->flAttrs & BR_IS_NULL))
     {
-        if (IntIsGeometricWidePen(pbrLine))
+        if (IntIsEffectiveWidePen(pbrLine))
         {
             /* Clear the path */
             PATH_Delete(dc->dclevel.hPath);

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -380,7 +380,9 @@ IntGdiPolyline(DC      *dc,
 
                 PATH_MoveTo(dc, pPath);
                 for (i = 1; i < Count; ++i)
+                {
                     PATH_LineTo(dc, pt[i].x, pt[i].y);
+                }
 
                 /* Close the path */
                 pPath->state = PATH_Closed;

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -8,7 +8,7 @@
 
 #include <win32k.h>
 
-//#define NDEBUG
+#define NDEBUG
 #include <debug.h>
 
 // Some code from the WINE project source (www.winehq.com)
@@ -154,6 +154,7 @@ IntGdiLineTo(DC  *dc,
     POINT     Points[2];
     PDC_ATTR pdcattr = dc->pdcattr;
     PPATH     pPath;
+
     ASSERT_DC_PREPARED(dc);
 
     if (PATH_IsPathOpen(dc->dclevel))
@@ -200,16 +201,8 @@ IntGdiLineTo(DC  *dc,
 
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            DPRINT1("pbrLine is not null\n");
-            DPRINT1("pbrLine->lWidth: %ld\n", pbrLine->lWidth);
-            DPRINT1("pbrLine->ulPenStyle: 0x%lX\n", pbrLine->ulPenStyle);
             if ((pbrLine->lWidth > 1) && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
             {
-                PPATH FASTCALL PATH_CreatePath(int count);
-                BOOL FASTCALL PATH_MoveTo(PDC dc, PPATH pPath);
-
-                DPRINT1("pbrLine is a geometric wide pen\n");
-
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -31,7 +31,7 @@ AddPenLinesBounds(PDC dc, int count, POINT *points)
     bounds.left = bounds.top = INT_MAX;
     bounds.right = bounds.bottom = INT_MIN;
 
-    if (IntIsWideGeometricPen(pbrLine))
+    if (IntIsGeometricWidePen(pbrLine))
     {
         /* Windows uses some heuristics to estimate the distance from the point that will be painted */
         lWidth = pbrLine->lWidth + 2;
@@ -203,7 +203,7 @@ IntGdiLineTo(DC  *dc,
 
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            if (IntIsWideGeometricPen(pbrLine))
+            if (IntIsGeometricWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
@@ -365,7 +365,7 @@ IntGdiPolyline(DC      *dc,
                AddPenLinesBounds(dc, Count, Points);
             }
 
-            if (IntIsWideGeometricPen(pbrLine))
+            if (IntIsGeometricWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -211,7 +211,7 @@ IntGdiLineTo(DC  *dc,
 
                 /* Begin a path */
                 pPath = PATH_CreatePath(2);
-                dc->dclevel.flPath |= DCPATH_ACTIVE; // Set active ASAP!
+                dc->dclevel.flPath |= DCPATH_ACTIVE;
                 dc->dclevel.hPath = pPath->BaseObject.hHmgr;
                 IntGetCurrentPositionEx(dc, &pPath->pos);
                 IntLPtoDP(dc, &pPath->pos, 1);

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -202,11 +202,13 @@ IntGdiLineTo(DC  *dc,
             if ((pbrLine->lWidth > 1) && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
             {
                 // TODO:
+                INT iSavedDC = SaveDC(hDC);
                 BeginPath(hDC);
                 MoveToEx(hDC, Points[0].x, Points[0].y, NULL);
                 LineTo(hDC, Points[1].x, Points[1].y);
                 EndPath(hDC);
                 Ret = StrokePath(hDC);
+                RestoreDC(hDC, iSavedDC);
             }
             else
             {

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -227,6 +227,7 @@ IntGdiLineTo(DC  *dc,
                 Ret = PATH_StrokePath(dc, pPath);
 
                 /* Clear the path */
+                PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
             }
@@ -392,6 +393,7 @@ IntGdiPolyline(DC      *dc,
                 Ret = PATH_StrokePath(dc, pPath);
 
                 /* Clear the path */
+                PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
             }

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -230,6 +230,8 @@ IntGdiLineTo(DC  *dc,
                 PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
+
+                /* FIXME: Boundary */
             }
             else
             {
@@ -396,6 +398,8 @@ IntGdiPolyline(DC      *dc,
                 PATH_UnlockPath(pPath);
                 PATH_Delete(dc->dclevel.hPath);
                 dc->dclevel.hPath = NULL;
+
+                /* FIXME: Boundary */
             }
             else
             {

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -199,15 +199,26 @@ IntGdiLineTo(DC  *dc,
 
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            Ret = IntEngLineTo(&psurf->SurfObj,
-                               (CLIPOBJ *)&dc->co,
-                               &dc->eboLine.BrushObject,
-                               Points[0].x, Points[0].y,
-                               Points[1].x, Points[1].y,
-                               &Bounds,
-                               ROP2_TO_MIX(pdcattr->jROP2));
+            if ((pbrLine->lWidth > 1) && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
+            {
+                // TODO:
+                BeginPath(hDC);
+                MoveToEx(hDC, Points[0].x, Points[0].y, NULL);
+                LineTo(hDC, Points[1].x, Points[1].y);
+                EndPath(hDC);
+                Ret = StrokePath(hDC);
+            }
+            else
+            {
+                Ret = IntEngLineTo(&psurf->SurfObj,
+                                   (CLIPOBJ *)&dc->co,
+                                   &dc->eboLine.BrushObject,
+                                   Points[0].x, Points[0].y,
+                                   Points[1].x, Points[1].y,
+                                   &Bounds,
+                                   ROP2_TO_MIX(pdcattr->jROP2));
+            }
         }
-
     }
 
     if (Ret)

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -31,7 +31,7 @@ AddPenLinesBounds(PDC dc, int count, POINT *points)
     bounds.left = bounds.top = INT_MAX;
     bounds.right = bounds.bottom = INT_MIN;
 
-    if (IntIsGeometricWidePen(pbrLine))
+    if (IntIsEffectiveWidePen(pbrLine))
     {
         /* Windows uses some heuristics to estimate the distance from the point that will be painted */
         lWidth = pbrLine->lWidth + 2;
@@ -203,7 +203,7 @@ IntGdiLineTo(DC  *dc,
 
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            if (IntIsGeometricWidePen(pbrLine))
+            if (IntIsEffectiveWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
@@ -366,7 +366,7 @@ IntGdiPolyline(DC      *dc,
                AddPenLinesBounds(dc, Count, Points);
             }
 
-            if (IntIsGeometricWidePen(pbrLine))
+            if (IntIsEffectiveWidePen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -31,7 +31,7 @@ AddPenLinesBounds(PDC dc, int count, POINT *points)
     bounds.left = bounds.top = INT_MAX;
     bounds.right = bounds.bottom = INT_MIN;
 
-    if (((pbrLine->ulPenStyle & PS_TYPE_MASK) & PS_GEOMETRIC) || (pbrLine->lWidth > 1))
+    if (IntIsWideGeometricPen(pbrLine))
     {
         /* Windows uses some heuristics to estimate the distance from the point that will be painted */
         lWidth = pbrLine->lWidth + 2;
@@ -203,7 +203,7 @@ IntGdiLineTo(DC  *dc,
 
         if (!(pbrLine->flAttrs & BR_IS_NULL))
         {
-            if ((pbrLine->lWidth > 1) && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
+            if (IntIsWideGeometricPen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);
@@ -331,7 +331,6 @@ IntGdiPolyline(DC      *dc,
     BOOL Ret = TRUE;
     LONG i;
     PDC_ATTR pdcattr = dc->pdcattr;
-    BOOL bWideGeometricPen;
     PPATH pPath;
 
     if (!dc->dclevel.pSurface)
@@ -345,8 +344,6 @@ IntGdiPolyline(DC      *dc,
     /* Get BRUSHOBJ from current pen. */
     pbrLine = dc->dclevel.pbrLine;
     ASSERT(pbrLine);
-    bWideGeometricPen =
-        (pbrLine->lWidth > 1 && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC);
 
     if (!(pbrLine->flAttrs & BR_IS_NULL))
     {
@@ -368,7 +365,7 @@ IntGdiPolyline(DC      *dc,
                AddPenLinesBounds(dc, Count, Points);
             }
 
-            if (bWideGeometricPen)
+            if (IntIsWideGeometricPen(pbrLine))
             {
                 /* Clear the path */
                 PATH_Delete(dc->dclevel.hPath);

--- a/win32ss/gdi/ntgdi/line.c
+++ b/win32ss/gdi/ntgdi/line.c
@@ -152,10 +152,12 @@ IntGdiLineTo(DC  *dc,
     PBRUSH pbrLine;
     RECTL     Bounds;
     POINT     Points[2];
-    PDC_ATTR pdcattr = dc->pdcattr;
+    PDC_ATTR  pdcattr;
     PPATH     pPath;
 
     ASSERT_DC_PREPARED(dc);
+
+    pdcattr = dc->pdcattr;
 
     if (PATH_IsPathOpen(dc->dclevel))
     {

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1624,7 +1624,6 @@ PATH_StrokePath(
             PATH_FillPathEx(dc, pNewPath, pbrLine);
             pdcattr->jFillMode = jOldFillMode;
 
-            PATH_UnlockPath(pNewPath);
             PATH_Delete(pNewPath->BaseObject.hHmgr);
             return TRUE;
         }

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -27,10 +27,6 @@ DBG_DEFAULT_CHANNEL(GdiPath);
 static int PathCount = 0;
 #endif
 
-PPATH
-FASTCALL
-PATH_WidenPathEx(DC *dc, PPATH pPath);
-
 /***********************************************************************
  * Internal functions
  */

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1624,6 +1624,7 @@ PATH_StrokePath(
             PATH_FillPathEx(dc, pNewPath, pbrLine);
             pdcattr->jFillMode = jOldFillMode;
 
+            PATH_UnlockPath(pNewPath);
             PATH_Delete(pNewPath->BaseObject.hHmgr);
             return TRUE;
         }
@@ -2145,7 +2146,6 @@ PATH_WidenPathEx(DC *dc, PPATH pPath)
     if (pPath->state != PATH_Closed)
     {
         TRACE("PWP 1\n");
-        PATH_UnlockPath(pPath);
         EngSetLastError(ERROR_CAN_NOT_COMPLETE);
         return NULL;
     }
@@ -2154,7 +2154,6 @@ PATH_WidenPathEx(DC *dc, PPATH pPath)
     if (!size)
     {
         TRACE("PWP 2\n");
-        PATH_UnlockPath(pPath);
         EngSetLastError(ERROR_CAN_NOT_COMPLETE);
         return NULL;
     }
@@ -2163,7 +2162,6 @@ PATH_WidenPathEx(DC *dc, PPATH pPath)
     if (elp == NULL)
     {
         TRACE("PWP 3\n");
-        PATH_UnlockPath(pPath);
         EngSetLastError(ERROR_OUTOFMEMORY);
         return NULL;
     }
@@ -2184,7 +2182,6 @@ PATH_WidenPathEx(DC *dc, PPATH pPath)
         TRACE("PWP 4\n");
         EngSetLastError(ERROR_CAN_NOT_COMPLETE);
         ExFreePoolWithTag(elp, TAG_PATH);
-        PATH_UnlockPath(pPath);
         return NULL;
     }
 
@@ -2196,7 +2193,6 @@ PATH_WidenPathEx(DC *dc, PPATH pPath)
         (PS_TYPE_MASK & penStyle) == PS_COSMETIC)
     {
         TRACE("PWP 5\n");
-        PATH_UnlockPath(pPath);
         EngSetLastError(ERROR_CAN_NOT_COMPLETE);
         return FALSE;
     }

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1624,7 +1624,6 @@ PATH_StrokePath(
         if (pNewPath)
         {
             PATH_FillPathEx(dc, pNewPath, pbrLine);
-            PATH_UnlockPath(pNewPath);
             PATH_Delete(pNewPath->BaseObject.hHmgr);
             return TRUE;
         }

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1614,7 +1614,7 @@ PATH_StrokePath(
     TRACE("Enter %s\n", __FUNCTION__);
 
     pbrLine = dc->dclevel.pbrLine;
-    if (IntIsWideGeometricPen(pbrLine))
+    if (IntIsGeometricWidePen(pbrLine))
     {
         pNewPath = PATH_WidenPathEx(dc, pPath);
         if (pNewPath)

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1600,8 +1600,7 @@ PATH_StrokePath(
     PPATH pPath)
 {
     BOOL ret = FALSE;
-    INT i = 0;
-    INT nLinePts, nAlloc;
+    INT nLinePts, nAlloc, jOldFillMode, i = 0;
     POINT *pLinePts = NULL;
     POINT ptViewportOrg, ptWindowOrg;
     SIZE szViewportExt, szWindowExt;
@@ -1619,7 +1618,12 @@ PATH_StrokePath(
         pNewPath = PATH_WidenPathEx(dc, pPath);
         if (pNewPath)
         {
+            /* Fill the path with the WINDING fill mode */
+            jOldFillMode = pdcattr->jFillMode;
+            pdcattr->jFillMode = WINDING;
             PATH_FillPathEx(dc, pNewPath, pbrLine);
+            pdcattr->jFillMode = jOldFillMode;
+
             PATH_Delete(pNewPath->BaseObject.hHmgr);
             return TRUE;
         }

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1614,7 +1614,7 @@ PATH_StrokePath(
     TRACE("Enter %s\n", __FUNCTION__);
 
     pbrLine = dc->dclevel.pbrLine;
-    if ((pbrLine->lWidth > 1) && (pbrLine->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
+    if (IntIsWideGeometricPen(pbrLine))
     {
         pNewPath = PATH_WidenPathEx(dc, pPath);
         if (pNewPath)

--- a/win32ss/gdi/ntgdi/path.c
+++ b/win32ss/gdi/ntgdi/path.c
@@ -1613,7 +1613,7 @@ PATH_StrokePath(
     TRACE("Enter %s\n", __FUNCTION__);
 
     pbrLine = dc->dclevel.pbrLine;
-    if (IntIsGeometricWidePen(pbrLine))
+    if (IntIsEffectiveWidePen(pbrLine))
     {
         pNewPath = PATH_WidenPathEx(dc, pPath);
         if (pNewPath)

--- a/win32ss/gdi/ntgdi/path.h
+++ b/win32ss/gdi/ntgdi/path.h
@@ -70,7 +70,7 @@ typedef struct _EPATHOBJ
 #define  PATH_LockPath(hPath) ((PPATH)GDIOBJ_ShareLockObj((HGDIOBJ)hPath, GDI_OBJECT_TYPE_PATH))
 #define  PATH_UnlockPath(pPath) GDIOBJ_vDereferenceObject((POBJ)pPath)
 #define PATH_IsPathOpen(dclevel) ( ((dclevel).hPath) && ((dclevel).flPath & DCPATH_ACTIVE) )
-#define IntIsWideGeometricPen(pbrLine) \
+#define IntIsGeometricWidePen(pbrLine) \
     ((pbrLine)->lWidth > 1 && ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
 
 BOOL FASTCALL PATH_Arc (PDC dc, INT x1, INT y1, INT x2, INT y2, INT xStart, INT yStart, INT xEnd, INT yEnd, INT direction, INT lines);

--- a/win32ss/gdi/ntgdi/path.h
+++ b/win32ss/gdi/ntgdi/path.h
@@ -70,8 +70,6 @@ typedef struct _EPATHOBJ
 #define  PATH_LockPath(hPath) ((PPATH)GDIOBJ_ShareLockObj((HGDIOBJ)hPath, GDI_OBJECT_TYPE_PATH))
 #define  PATH_UnlockPath(pPath) GDIOBJ_vDereferenceObject((POBJ)pPath)
 #define PATH_IsPathOpen(dclevel) ( ((dclevel).hPath) && ((dclevel).flPath & DCPATH_ACTIVE) )
-#define IntIsGeometricWidePen(pbrLine) \
-    ((pbrLine)->lWidth > 1 && ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
 
 BOOL FASTCALL PATH_Arc (PDC dc, INT x1, INT y1, INT x2, INT y2, INT xStart, INT yStart, INT xEnd, INT yEnd, INT direction, INT lines);
 BOOL PATH_Ellipse (PDC dc, INT x1, INT y1, INT x2, INT y2);

--- a/win32ss/gdi/ntgdi/path.h
+++ b/win32ss/gdi/ntgdi/path.h
@@ -75,8 +75,10 @@ typedef struct _EPATHOBJ
 
 BOOL FASTCALL PATH_Arc (PDC dc, INT x1, INT y1, INT x2, INT y2, INT xStart, INT yStart, INT xEnd, INT yEnd, INT direction, INT lines);
 BOOL PATH_Ellipse (PDC dc, INT x1, INT y1, INT x2, INT y2);
+PPATH FASTCALL PATH_CreatePath(int count);
 VOID FASTCALL PATH_EmptyPath (PPATH pPath);
 BOOL FASTCALL PATH_LineTo (PDC dc, INT x, INT y);
+BOOL FASTCALL PATH_MoveTo(PDC dc, PPATH pPath);
 BOOL FASTCALL PATH_PolyBezier (PDC dc, const POINT *pts, DWORD cbPoints);
 BOOL FASTCALL PATH_PolyBezierTo (PDC dc, const POINT *pts, DWORD cbPoints);
 BOOL FASTCALL PATH_PolyDraw(PDC dc, const POINT *pts, const BYTE *types, DWORD cbPoints);

--- a/win32ss/gdi/ntgdi/path.h
+++ b/win32ss/gdi/ntgdi/path.h
@@ -69,9 +69,9 @@ typedef struct _EPATHOBJ
 #define  PATH_AllocPathWithHandle() ((PPATH) GDIOBJ_AllocObjWithHandle (GDI_OBJECT_TYPE_PATH, sizeof(PATH)))
 #define  PATH_LockPath(hPath) ((PPATH)GDIOBJ_ShareLockObj((HGDIOBJ)hPath, GDI_OBJECT_TYPE_PATH))
 #define  PATH_UnlockPath(pPath) GDIOBJ_vDereferenceObject((POBJ)pPath)
-
-
 #define PATH_IsPathOpen(dclevel) ( ((dclevel).hPath) && ((dclevel).flPath & DCPATH_ACTIVE) )
+#define IntIsWideGeometricPen(pbrLine) \
+    ((pbrLine)->lWidth > 1 && ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
 
 BOOL FASTCALL PATH_Arc (PDC dc, INT x1, INT y1, INT x2, INT y2, INT xStart, INT yStart, INT xEnd, INT yEnd, INT direction, INT lines);
 BOOL PATH_Ellipse (PDC dc, INT x1, INT y1, INT x2, INT y2);

--- a/win32ss/gdi/ntgdi/path.h
+++ b/win32ss/gdi/ntgdi/path.h
@@ -95,6 +95,7 @@ BOOL FASTCALL PATH_AddFlatBezier (PPATH pPath, POINT *pt, BOOL closed);
 BOOL FASTCALL PATH_FillPath( PDC dc, PPATH pPath );
 BOOL FASTCALL PATH_FillPathEx(PDC dc, PPATH pPath, PBRUSH pbrFill);
 PPATH FASTCALL PATH_FlattenPath (PPATH pPath);
+PPATH FASTCALL PATH_WidenPathEx(DC *dc, PPATH pPath);
 
 BOOL FASTCALL PATH_ReserveEntries (PPATH pPath, INT numEntries);
 BOOL FASTCALL PATH_StrokePath(DC *dc, PPATH pPath);

--- a/win32ss/gdi/ntgdi/pen.c
+++ b/win32ss/gdi/ntgdi/pen.c
@@ -282,7 +282,7 @@ PEN_GetObject(PBRUSH pbrushPen, INT cbCount, PLOGPEN pBuffer)
                 pLogPen = (PLOGPEN)pBuffer;
                 pLogPen->lopnWidth.x = pbrushPen->lWidth;
                 pLogPen->lopnWidth.y = 0;
-                pLogPen->lopnStyle = pbrushPen->ulPenStyle;
+                pLogPen->lopnStyle = (pbrushPen->ulPenStyle & ~PS_GEOMETRIC);
                 pLogPen->lopnColor = pbrushPen->BrushAttr.lbColor;
             }
         }

--- a/win32ss/gdi/ntgdi/pen.c
+++ b/win32ss/gdi/ntgdi/pen.c
@@ -282,7 +282,7 @@ PEN_GetObject(PBRUSH pbrushPen, INT cbCount, PLOGPEN pBuffer)
                 pLogPen = (PLOGPEN)pBuffer;
                 pLogPen->lopnWidth.x = pbrushPen->lWidth;
                 pLogPen->lopnWidth.y = 0;
-                pLogPen->lopnStyle = (pbrushPen->ulPenStyle & ~PS_GEOMETRIC);
+                pLogPen->lopnStyle = pbrushPen->ulPenStyle;
                 pLogPen->lopnColor = pbrushPen->BrushAttr.lbColor;
             }
         }
@@ -331,7 +331,7 @@ NtGdiCreatePen(
         return NULL;
     }
 
-    return IntGdiExtCreatePen(PenStyle | PS_GEOMETRIC,
+    return IntGdiExtCreatePen(PenStyle,
                               Width,
                               BS_SOLID,
                               Color,

--- a/win32ss/gdi/ntgdi/pen.c
+++ b/win32ss/gdi/ntgdi/pen.c
@@ -331,7 +331,7 @@ NtGdiCreatePen(
         return NULL;
     }
 
-    return IntGdiExtCreatePen(PenStyle,
+    return IntGdiExtCreatePen(PenStyle | PS_GEOMETRIC,
                               Width,
                               BS_SOLID,
                               Color,

--- a/win32ss/gdi/ntgdi/pen.h
+++ b/win32ss/gdi/ntgdi/pen.h
@@ -29,3 +29,6 @@ PEN_GetObject(
     _Out_ PLOGPEN Buffer);
 
 VOID FASTCALL AddPenLinesBounds(PDC,int,POINT *);
+
+#define IntIsGeometricWidePen(pbrLine) \
+    ((pbrLine)->lWidth > 1 && ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)

--- a/win32ss/gdi/ntgdi/pen.h
+++ b/win32ss/gdi/ntgdi/pen.h
@@ -30,7 +30,7 @@ PEN_GetObject(
 
 VOID FASTCALL AddPenLinesBounds(PDC,int,POINT *);
 
-#define IntIsGeometricWidePen(pbrLine) ( \
+#define IntIsEffectiveWidePen(pbrLine) ( \
     (pbrLine)->lWidth > 1 && \
     ((pbrLine->flAttrs & BR_IS_OLDSTYLEPEN) || \
      ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC) \

--- a/win32ss/gdi/ntgdi/pen.h
+++ b/win32ss/gdi/ntgdi/pen.h
@@ -30,5 +30,8 @@ PEN_GetObject(
 
 VOID FASTCALL AddPenLinesBounds(PDC,int,POINT *);
 
-#define IntIsGeometricWidePen(pbrLine) \
-    ((pbrLine)->lWidth > 1 && ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC)
+#define IntIsGeometricWidePen(pbrLine) ( \
+    (pbrLine)->lWidth > 1 && \
+    ((pbrLine->flAttrs & BR_IS_OLDSTYLEPEN) || \
+     ((pbrLine)->ulPenStyle & PS_TYPE_MASK) == PS_GEOMETRIC) \
+)


### PR DESCRIPTION
## Purpose

Implement the pen width.
JIRA issue: [CORE-2527](https://jira.reactos.org/browse/CORE-2527), [CORE-8366](https://jira.reactos.org/browse/CORE-8366)

The test program: https://jira.reactos.org/secure/attachment/43554/PenTest2.zip

## Proposed changes

- Extend `PATH_WidenPath` function as `PATH_WidenPathEx` with the path argument.
- Use `PATH_WidenPathEx` and `PATH_FillPathEx` functions to implement wide pen drawing in `PATH_StrokePath` function.
- Add the code to `IntGdiLineTo`, `IntRectangle`, `IntGdiPolygon`, and `IntGdiPolyline` in order to stroke the path when the effective wide pen.

## TODO

- [x] Make it working.
- [x] Fix the handle leaking.
- [ ] Do tests.

## Comparison

Win10:
![PenTest2-Win10](https://user-images.githubusercontent.com/2107452/144699961-1d4df6de-cd5d-40c8-9c13-5da7a0624486.png)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/144709081-cb037cde-69ed-4f5f-af8c-212058e6e6fe.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/144709080-08de878e-7d88-4925-8933-d444785882e1.png)