### PR TITLE
CMake spec2def improve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,9 @@ if(NOT CMAKE_CROSSCOMPILING)
         if(ARCH STREQUAL "i386")
             add_definitions(/D_X86_ /D__i386__ /DWIN32 /D_WINDOWS)
         elseif(ARCH STREQUAL "amd64")
-            add_definitions(-D_AMD64_ -D__x86_64__ /DWIN32 -D_WINDOWS)
+            # '__x86_64': This is NOT a typo.
+            # See https://software.intel.com/en-us/forums/topic/404643
+            add_definitions(-D_AMD64_ -D__x86_64__ -D__x86_64 /DWIN32 -D_WINDOWS)
         endif()
         if(MSVC_VERSION GREATER 1699)
             add_definitions(/D_ALLOW_KEYWORD_MACROS)
@@ -256,7 +258,9 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
         if (NOT (MSVC AND CMAKE_C_COMPILER_ID STREQUAL "Clang"))
             add_compile_definitions(_M_AMD64)
         endif()
-        add_definitions(-D_AMD64_ -D__x86_64__ -D_WIN64)
+        # '__x86_64': This is NOT a typo.
+        # See https://software.intel.com/en-us/forums/topic/404643
+        add_definitions(-D_AMD64_ -D__x86_64__ -D__x86_64 -D_WIN64)
     elseif(ARCH STREQUAL "arm")
         # _M_ARM is already defined by toolchain
         add_definitions(-D_ARM_ -D__arm__ -DWIN32)
@@ -325,7 +329,7 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
         sdk/include/reactos/libs)
 
     if(ARCH STREQUAL "arm")
-        include_directories(${REACTOS_SOURCE_DIR}/sdk/include/reactos/arm)
+        include_directories(sdk/include/reactos/arm)
     endif()
 
     add_dependency_header()

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -466,6 +466,47 @@ function(create_iso_lists)
          INPUT ${REACTOS_BINARY_DIR}/boot/bootcdregtest.cmake.lst)
 endfunction()
 
+function(spec2def _dllname _spec_file)
+    cmake_parse_arguments(__spec2def "ADD_IMPORTLIB;NO_PRIVATE_WARNINGS;WITH_RELAY" "VERSION" "" ${ARGN})
+
+    # Get library basename
+    get_filename_component(_file ${_dllname} NAME_WE)
+
+    # Error out on anything else than spec
+    if(NOT ${_spec_file} MATCHES ".*\\.spec")
+        message(FATAL_ERROR "spec2def only takes spec files as input.")
+    endif()
+
+    if(__spec2def_WITH_RELAY)
+        set(__with_relay_arg "--with-tracing")
+    endif()
+
+    if(__spec2def_VERSION)
+        set(__version_arg "--version=0x${__spec2def_VERSION}")
+    endif()
+
+    # Generate exports def and C stubs file for the DLL
+    add_custom_command(
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file}.def ${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c
+        COMMAND ${COMMAND_SPEC2DEF} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_file}.def -s=${CMAKE_CURRENT_BINARY_DIR}/${_file}_stubs.c ${__with_relay_arg} ${__version_arg} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        DEPENDS native-spec2def ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file})
+
+    if(__spec2def_ADD_IMPORTLIB)
+        if(MSVC)
+            generate_import_lib(lib${_file} ${_dllname} ${_spec_file})
+            if(__spec2def_NO_PRIVATE_WARNINGS)
+                set_property(TARGET lib${_file} APPEND PROPERTY STATIC_LIBRARY_OPTIONS /ignore:4104)
+            endif()
+        else()
+            set(_extraflags)
+            if(__spec2def_NO_PRIVATE_WARNINGS)
+                set(_extraflags --no-private-warnings)
+            endif()
+            generate_import_lib(lib${_file} ${_dllname} ${_spec_file} ${_extraflags})
+        endif()
+    endif()
+endfunction()
+
 # Create module_clean targets
 function(add_clean_target _target)
     set(_clean_working_directory ${CMAKE_CURRENT_BINARY_DIR})

--- a/sdk/cmake/CMakeMacros.cmake
+++ b/sdk/cmake/CMakeMacros.cmake
@@ -44,7 +44,7 @@ function(add_message_headers _type)
             OUTPUT "${_converted_file}"
             COMMAND native-utf16le "${_source_file}" "${_converted_file}" nobom
             DEPENDS native-utf16le "${_source_file}")
-        macro_mc(${_flag} ${_converted_file})
+        set(COMMAND_MC ${CMAKE_MC_COMPILER} -u ${_flag} -b -h ${CMAKE_CURRENT_BINARY_DIR}/ -r ${CMAKE_CURRENT_BINARY_DIR}/ ${_converted_file})
         add_custom_command(
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_file_name}.h ${CMAKE_CURRENT_BINARY_DIR}/${_file_name}.rc
             COMMAND ${COMMAND_MC}

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -432,10 +432,6 @@ function(spec2def _dllname _spec_file)
     endif()
 endfunction()
 
-macro(macro_mc FLAG FILE)
-    set(COMMAND_MC ${CMAKE_MC_COMPILER} -u ${FLAG} -b -h ${CMAKE_CURRENT_BINARY_DIR}/ -r ${CMAKE_CURRENT_BINARY_DIR}/ ${FILE})
-endmacro()
-
 # PSEH lib, needed with mingw
 set(PSEH_LIB "pseh")
 

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -356,8 +356,8 @@ function(generate_import_lib _libname _dllname _spec_file)
     # Generate the def for the import lib
     add_custom_command(
         OUTPUT ${_def_file}
-        COMMAND ${COMMAND_SPEC2DEF} --implib ${ARGN} -n=${_dllname} -d=${_def_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
+        COMMAND ${COMMAND_SPEC2DEF} --implib ${ARGN} -n=${_dllname} -d=${_def_file} ${_spec_file}
+        DEPENDS native-spec2def ${_spec_file})
 
     # With this, we let DLLTOOL create an import library
     set(LIBRARY_PRIVATE_DIR ${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/${_libname}.dir)

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -349,10 +349,12 @@ else()
 endif()
 
 function(generate_import_lib _libname _dllname _spec_file)
+    set(_def_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def)
+
     # Generate the def for the import lib
     add_custom_command(
-        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def
-        COMMAND native-spec2def -a=${SPEC2DEF_ARCH} --implib ${ARGN} -n=${_dllname} -d=${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
+        OUTPUT ${_def_file}
+        COMMAND native-spec2def -a=${SPEC2DEF_ARCH} --implib ${ARGN} -n=${_dllname} -d=${_def_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
         DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
 
     # With this, we let DLLTOOL create an import library
@@ -361,8 +363,8 @@ function(generate_import_lib _libname _dllname _spec_file)
         OUTPUT ${LIBRARY_PRIVATE_DIR}/${_libname}.a
         # ar just puts stuff into the archive, without looking twice. Just delete the lib, we're going to rebuild it anyway
         COMMAND ${CMAKE_COMMAND} -E rm -f $<TARGET_FILE:${_libname}>
-        COMMAND ${CMAKE_DLLTOOL} --def ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def --kill-at --output-lib=${_libname}.a -t ${_libname}
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def
+        COMMAND ${CMAKE_DLLTOOL} --def ${_def_file} --kill-at --output-lib=${_libname}.a -t ${_libname}
+        DEPENDS ${_def_file}
         WORKING_DIRECTORY ${LIBRARY_PRIVATE_DIR})
 
     # We create a static library with the importlib thus created as object. AR will extract the obj files and archive it again as a thin lib
@@ -383,8 +385,8 @@ function(generate_import_lib _libname _dllname _spec_file)
         OUTPUT ${LIBRARY_PRIVATE_DIR}/${_libname}_delayed.a
         # ar just puts stuff into the archive, without looking twice. Just delete the lib, we're going to rebuild it anyway
         COMMAND ${CMAKE_COMMAND} -E rm -f $<TARGET_FILE:${_libname}_delayed>
-        COMMAND ${CMAKE_DLLTOOL} --def ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def --kill-at --output-delaylib=${_libname}_delayed.a -t ${_libname}_delayed
-        DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def
+        COMMAND ${CMAKE_DLLTOOL} --def ${_def_file} --kill-at --output-delaylib=${_libname}_delayed.a -t ${_libname}_delayed
+        DEPENDS ${_def_file}
         WORKING_DIRECTORY ${LIBRARY_PRIVATE_DIR})
 
     # We create a static library with the importlib thus created. AR will extract the obj files and archive it again as a thin lib

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -405,10 +405,6 @@ function(spec2def _dllname _spec_file)
     endif()
 endfunction()
 
-macro(macro_mc FLAG FILE)
-    set(COMMAND_MC ${CMAKE_MC_COMPILER} -u ${FLAG} -b -h ${CMAKE_CURRENT_BINARY_DIR}/ -r ${CMAKE_CURRENT_BINARY_DIR}/ ${FILE})
-endmacro()
-
 # PSEH workaround
 set(PSEH_LIB "pseh")
 

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -326,7 +326,6 @@ else()
 endif()
 
 function(generate_import_lib _libname _dllname _spec_file)
-
     set(_def_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_implib.def)
     set(_asm_stubs_file ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_stubs.asm)
 
@@ -351,7 +350,7 @@ function(generate_import_lib _libname _dllname _spec_file)
     set(_libfile_tmp ${CMAKE_CURRENT_BINARY_DIR}/${_libname}_tmp.lib)
 
     set(_implib_command ${CMAKE_LINKER} /LIB /NOLOGO /MACHINE:${WINARCH}
-        $<TARGET_PROPERTY:${_libname},STATIC_LIBRARY_FLAGS> $<TARGET_PROPERTY:${_libname},STATIC_LIBRARY_OPTIONS>
+        $<TARGET_PROPERTY:${_libname},STATIC_LIBRARY_OPTIONS>
         /DEF:${_def_file} /OUT:${_libfile_tmp} ${_asm_stubs_file}.obj)
 
     add_custom_command(

--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -334,8 +334,8 @@ function(generate_import_lib _libname _dllname _spec_file)
     # Generate the def and asm stub files
     add_custom_command(
         OUTPUT ${_asm_stubs_file} ${_def_file}
-        COMMAND ${COMMAND_SPEC2DEF} --implib -n=${_dllname} -d=${_def_file} -l=${_asm_stubs_file} ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file}
-        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/${_spec_file} native-spec2def)
+        COMMAND ${COMMAND_SPEC2DEF} --implib -n=${_dllname} -d=${_def_file} -l=${_asm_stubs_file} ${_spec_file}
+        DEPENDS native-spec2def ${_spec_file})
 
     # Compile the generated asm stub file
     if(ARCH STREQUAL "arm" OR ARCH STREQUAL "arm64")


### PR DESCRIPTION
## Purpose

Do some simple cmake files cleanup, and improve some aspects of `spec2def()` function.

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- Some cmake files cleanup:
```
[CMAKE] Get rid of the macro_mc() macro.

Since COMMAND_MC is the same for both MSVC and GCC, get rid of the
macro_mc() macro and directly use said command in add_message_headers().
```
```
[CMAKE] MSVC's "SPEC2DEF_ARCH" == GCC's "ARCH2", so use a common name instead. Simplify its initialization. Move __x86_64 to global CMakeLists.txt.
```
```
[CMAKE] Simplify generate_import_lib() code.

- Simplify by storing the implib def file name in a variable, as done in msvc.cmake.
- Remove deprecated STATIC_LIBRARY_FLAGS usage.
```

- Improve cmake-file `spec2def()` function:
```
[CMAKE] Move spec2def() function common implementation into CMakeMacros.cmake.

The slight different spec2def invocation command definition is stored
in a COMMAND_SPEC2DEF variable, used by both generate_import_lib() and
spec2def() functions.
```
```
[CMAKE] Allow the spec2def() function to take a list of .spec files (more than one).

When more than one .spec file are present, they get concatenated
together and the resulting file is passed to spec2def.
```