### PR TITLE
[VIDEOPRT] Fix video settings not persisting across reboots

### DIFF
--- a/win32ss/drivers/videoprt/registry.c
+++ b/win32ss/drivers/videoprt/registry.c
@@ -565,10 +565,10 @@ IntCreateNewRegistryPath(
                                 OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
                                 NULL,
                                 NULL);
-    Status = ZwOpenKey(&NewKey, KEY_READ, &ObjectAttributes);
+    Status = ZwOpenKey(&NewKey, KEY_READ | KEY_WRITE, &ObjectAttributes);
     if (!NT_SUCCESS(Status))
     {
-        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        ERR_(VIDEOPRT, "Failed to open NewKey. Status 0x%lx\n", Status);
         return Status;
     }
 
@@ -578,10 +578,10 @@ IntCreateNewRegistryPath(
                                 OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
                                 NULL,
                                 NULL);
-    Status = ZwOpenKey(&SettingsKey, KEY_READ, &ObjectAttributes);
+    Status = ZwOpenKey(&SettingsKey, KEY_READ | KEY_WRITE, &ObjectAttributes);
     if (!NT_SUCCESS(Status))
     {
-        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        ERR_(VIDEOPRT, "Failed to open SettingsKey. Status 0x%lx\n", Status);
         ObCloseHandle(NewKey, KernelMode);
         return Status;
     }

--- a/win32ss/drivers/videoprt/registry.c
+++ b/win32ss/drivers/videoprt/registry.c
@@ -586,6 +586,10 @@ IntCreateNewRegistryPath(
         return Status;
     }
 
+    /* Copy the saved resolution to the source key */
+    IntCopyRegistryValue(NewKey, SettingsKey, L"DefaultSettings.XResolution");
+    IntCopyRegistryValue(NewKey, SettingsKey, L"DefaultSettings.YResolution");
+
     /* Copy the registry data from the legacy key */
     Status = IntCopyRegistryKey(SettingsKey, NewKey);
 


### PR DESCRIPTION
## Video Settings should Persist across a Reboot

_Add code in the registry.c file to copy the saved settings to those about to be used._

JIRA issue: [CORE-17719](https://jira.reactos.org/browse/CORE-17719)

## Copy Saved Video Settings to Registry Key About to be Used

_This should fix the video settings not being saved after a reboot._
There are reports that not all emulators are fixed yet.
Maybe someone can review these in relation to this change and see why?
