### PR TITLE
[WIN32K:NTUSER] Make sure to hold User Global Lock before mapping des…

### DIFF
--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -202,12 +202,16 @@ NTAPI
 IntDesktopObjectOpen(
     _In_ PVOID Parameters)
 {
+    NTSTATUS Ret;
     PWIN32_OPENMETHOD_PARAMETERS OpenParameters = Parameters;
     PPROCESSINFO ppi = PsGetProcessWin32Process(OpenParameters->Process);
     if (ppi == NULL)
         return STATUS_SUCCESS;
 
-    return IntMapDesktopView((PDESKTOP)OpenParameters->Object);
+    UserEnterExclusive();
+    Ret = IntMapDesktopView((PDESKTOP)OpenParameters->Object);
+    UserLeave();
+    return Ret;
 }
 
 NTSTATUS


### PR DESCRIPTION
…ktop heap

Addendum to 8c098ee (0.4.15-dev-3001).
JIRA issue: [CORE-17890](https://jira.reactos.org/browse/CORE-17890)