### PR TITLE
[WIN32SS][ENG] EngCreateBitmap: mark created bitmaps as API bitmaps

### DIFF
--- a/win32ss/gdi/eng/surface.c
+++ b/win32ss/gdi/eng/surface.c
@@ -332,6 +332,9 @@ EngCreateBitmap(
     /* Get the handle for the bitmap */
     hbmp = (HBITMAP)psurf->SurfObj.hsurf;
 
+    /* Mark as API bitmap */
+    psurf->flags = API_BITMAP;
+
     /* Set public ownership */
     GDIOBJ_vSetObjectOwner(&psurf->BaseObject, GDI_OBJ_HMGR_PUBLIC);
 


### PR DESCRIPTION
## Purpose

Set an `API_BITMAP` flag for bitmaps created by `EngCreateBitmap`.
This avoids failure when created bitmap is passed to `NtGdiSelectBitmap`, since it checks for this flag and fails if it isn't set.
Otherwise, if failure occurs, the bitmap is hot handled properly.
Setting this flag outside of that function is not an option at all, because it is a public (exported) function, and in many cases it's called directly by the caller (in case with MS DDraw stack, it can be called also by dxg.sys from `dxgthk!EngCreateBitmap`, which directly calls `win32k!EngCreateBitmap`).
In particular, it allows Windows XP/2003 DirectDraw stack (ddraw.dll & dxg.sys) to properly work in ReactOS (in software emulation mode), even on real hardware. So now, a lot of DirectX 1-7 apps and games (whose can work without hardware acceleation), are working properly with ddraw.dll + dxg.sys replacement! Also Justin Miller (@DarkFire01) confirmed that even Direct3D software emulation now also works correctly on real hardware! :smiley: 

JIRA issue: [CORE-17561](https://jira.reactos.org/browse/CORE-17561)

## Result

The following video proves that a lot of DirectX 1-7 apps and games are now working properly. :slightly_smiling_face: 

https://user-images.githubusercontent.com/26385117/145112643-558be109-d57b-4ac6-a389-d70858186ad2.mp4


In the video I tested the following:
- apps:
    - Microsoft DirectX 8.1 Diagnostic Tool (all 3 DirectDraw tests are now succeed instead of only 1).
- games:
    - Barbie Seahorse Adventures.
    - IcyTower from Rapps.
    - Mario Dash.
    - OpenSonic.
    - SimCity 3000 Demo.
    - Snoopy from Rapps.
    - Tux Racer.

I tested them many times earlier and can confirm that all of them use DirectDraw. They didn't work before my change and became work properly after them. :slightly_smiling_face: 