### PR TITLE
[USER32] Partially fix freezing of Task Switcher

### DIFF
--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -164,16 +164,16 @@ void CompleteSwitch(BOOL doSwitch)
 
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
-#define GET_ICON_TIMEOUT 100 // in milliseconds
-#define GET_ICON_RETRY_COUNT 10
+#define ICON_TIMEOUT 100 // in milliseconds
+#define ICON_RETRY_COUNT 10
    HICON hIcon;
    LRESULT ret;
-   UINT uFlags = SMTO_ABORTIFHUNG | SMTO_NORMAL, cRetry = GET_ICON_RETRY_COUNT;
+   UINT uFlags = SMTO_ABORTIFHUNG | SMTO_NORMAL, cRetry = ICON_RETRY_COUNT;
 
    UNREFERENCED_PARAMETER(lParam);
 
    // First try to get the big icon assigned to the window
-   ret = SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, uFlags, GET_ICON_TIMEOUT,
+   ret = SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, uFlags, ICON_TIMEOUT,
                              (DWORD_PTR *)&hIcon);
    if (!ret)
    {
@@ -184,7 +184,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
          // If we still don't have an icon, see if we can do with the small icon,
          // or a default application icon
          ret = SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0, uFlags,
-                                   GET_ICON_TIMEOUT, (DWORD_PTR *)&hIcon);
+                                   ICON_TIMEOUT, (DWORD_PTR *)&hIcon);
          if (!ret)
          {
             // using windows logo icon as default
@@ -200,7 +200,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 
    windowList[windowCount] = window;
    while (!hIcon && --cRetry > 0)
-      Sleep(GET_ICON_TIMEOUT / GET_ICON_RETRY_COUNT);
+      Sleep(ICON_TIMEOUT / ICON_RETRY_COUNT);
    iconList[windowCount] = CopyIcon(hIcon);
 
    windowCount++;
@@ -211,8 +211,8 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
       return FALSE;
 
    return TRUE;
-#undef GET_ICON_TIMEOUT
-#undef GET_ICON_RETRY_COUNT
+#undef ICON_TIMEOUT
+#undef ICON_RETRY_COUNT
 }
 
 static HWND GetNiceRootOwner(HWND hwnd)

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -139,7 +139,7 @@ void CompleteSwitch(BOOL doSwitch)
    isOpen = FALSE;
 
    TRACE("[ATbot] CompleteSwitch Hiding Window.\n");
-   ShowWindow(switchdialog, SW_HIDE);
+   ShowWindowAsync(switchdialog, SW_HIDE);
 
    if(doSwitch)
    {
@@ -498,7 +498,7 @@ BOOL ProcessHotKey(VOID)
       selectedWindow = 1;
 
       TRACE("[ATbot] HotKey Received. Opening window.\n");
-      ShowWindow(switchdialog, SW_SHOWNORMAL);
+      ShowWindowAsync(switchdialog, SW_SHOWNORMAL);
       MakeWindowActive(switchdialog);
       isOpen = TRUE;
    }

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -164,7 +164,7 @@ void CompleteSwitch(BOOL doSwitch)
 
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
-#define ICON_TIMEOUT 100 // in milliseconds
+#define ICON_TIMEOUT 80 // in milliseconds
 #define ICON_RETRY_COUNT 10
    HICON hIcon = NULL;
    LRESULT ret;
@@ -202,15 +202,11 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
    while (!hIcon && --cRetry > 0)
       Sleep(ICON_TIMEOUT / ICON_RETRY_COUNT);
    iconList[windowCount] = CopyIcon(hIcon);
-
-   windowCount++;
+   ++windowCount;
 
    // If we got to the max number of windows,
    // we won't be able to add any more
-   if(windowCount >= MAX_WINDOWS)
-      return FALSE;
-
-   return TRUE;
+   return (windowCount < MAX_WINDOWS);
 #undef ICON_TIMEOUT
 #undef ICON_RETRY_COUNT
 }

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -526,7 +526,7 @@ void RotateTasks(BOOL bShift)
     {
         SetWindowPos(hwndLast, HWND_TOP, 0, 0, 0, 0,
                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
-                     SWP_NOOWNERZORDER | SWP_NOREPOSITION);
+                     SWP_NOOWNERZORDER | SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
 
         MakeWindowActive(hwndLast);
 
@@ -538,7 +538,7 @@ void RotateTasks(BOOL bShift)
     {
         SetWindowPos(hwndFirst, hwndLast, 0, 0, 0, 0,
                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
-                     SWP_NOOWNERZORDER | SWP_NOREPOSITION);
+                     SWP_NOOWNERZORDER | SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
 
         MakeWindowActive(windowList[1]);
 

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -168,7 +168,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 #define ICON_RETRY_COUNT 10
    HICON hIcon = NULL;
    LRESULT ret;
-   UINT uFlags = SMTO_ABORTIFHUNG | SMTO_NORMAL, cRetry = ICON_RETRY_COUNT;
+   UINT uFlags = SMTO_ABORTIFHUNG | SMTO_NORMAL, cRetry;
 
    UNREFERENCED_PARAMETER(lParam);
 
@@ -199,13 +199,14 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
    }
 
    windowList[windowCount] = window;
-   while (!hIcon && --cRetry > 0)
+
+   for (cRetry = ICON_RETRY_COUNT; !hIcon && cRetry > 0; --cRetry)
       Sleep(ICON_TIMEOUT / ICON_RETRY_COUNT);
+
    iconList[windowCount] = CopyIcon(hIcon);
    windowCount++;
 
-   // If we got to the max number of windows,
-   // we won't be able to add any more
+   // If we got to the max number of windows, we won't be able to add any more
    return (windowCount < MAX_WINDOWS);
 #undef ICON_TIMEOUT
 #undef ICON_RETRY_COUNT

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -124,11 +124,11 @@ void ResizeAndCenter(HWND hwnd, int width, int height)
 
 void MakeWindowActive(HWND hwnd)
 {
-    if (IsIconic(hwnd))
-        PostMessageW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
+   if (IsIconic(hwnd))
+      PostMessageW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
 
-    // See also: https://microsoft.public.win32.programmer.ui.narkive.com/RqOdKqZ8/bringwindowtotop-hangs-if-the-thread-is-busy
-    SwitchToThisWindow(hwnd, TRUE);
+   // See also: https://microsoft.public.win32.programmer.ui.narkive.com/RqOdKqZ8/bringwindowtotop-hangs-if-the-thread-is-busy
+   SwitchToThisWindow(hwnd, TRUE);
 }
 
 void CompleteSwitch(BOOL doSwitch)
@@ -202,7 +202,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
    while (!hIcon && --cRetry > 0)
       Sleep(ICON_TIMEOUT / ICON_RETRY_COUNT);
    iconList[windowCount] = CopyIcon(hIcon);
-   ++windowCount;
+   windowCount++;
 
    // If we got to the max number of windows,
    // we won't be able to add any more

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -165,17 +165,14 @@ void CompleteSwitch(BOOL doSwitch)
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
     HICON hIcon = NULL;
-    BOOL bHung = IsHungAppWindow(window);
+    LRESULT bAlive;
 
     UNREFERENCED_PARAMETER(lParam);
 
     // First try to get the big icon assigned to the window
 #define ICON_TIMEOUT 100 // in milliseconds
-    if (!bHung)
-    {
-        SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
-                            ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
-    }
+    bAlive = SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
+                                 ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
     if (!hIcon)
     {
         // If no icon is assigned, try to get the icon assigned to the windows' class
@@ -184,7 +181,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
         {
             // If we still don't have an icon, see if we can do with the small icon,
             // or a default application icon
-            if (!bHung)
+            if (bAlive)
             {
                 SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0,
                                     SMTO_ABORTIFHUNG | SMTO_BLOCK, ICON_TIMEOUT,

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -165,15 +165,14 @@ void CompleteSwitch(BOOL doSwitch)
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
    HICON hIcon;
-   LRESULT ret;
 
    UNREFERENCED_PARAMETER(lParam);
 
    // First try to get the big icon assigned to the window
 #define ICON_TIMEOUT 100 // in milliseconds
-   ret = SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
-                             ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
-   if (!ret)
+   SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
+                       ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
+   if (!hIcon)
    {
       // If no icon is assigned, try to get the icon assigned to the windows' class
       hIcon = (HICON)GetClassLongPtrW(window, GCL_HICON);
@@ -181,11 +180,10 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
       {
          // If we still don't have an icon, see if we can do with the small icon,
          // or a default application icon
-         ret = SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0,
-                                   SMTO_ABORTIFHUNG | SMTO_BLOCK, ICON_TIMEOUT,
-                                   (PDWORD_PTR)&hIcon);
+         SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0,
+                             SMTO_ABORTIFHUNG | SMTO_BLOCK, ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
 #undef ICON_TIMEOUT
-         if (!ret)
+         if (!hIcon)
          {
             // using windows logo icon as default
             hIcon = gpsi->hIconWindows;

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -166,7 +166,7 @@ BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
 #define ICON_TIMEOUT 100 // in milliseconds
 #define ICON_RETRY_COUNT 10
-   HICON hIcon;
+   HICON hIcon = NULL;
    LRESULT ret;
    UINT uFlags = SMTO_ABORTIFHUNG | SMTO_NORMAL, cRetry = ICON_RETRY_COUNT;
 

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -164,44 +164,52 @@ void CompleteSwitch(BOOL doSwitch)
 
 BOOL CALLBACK EnumerateCallback(HWND window, LPARAM lParam)
 {
-   HICON hIcon;
+    HICON hIcon = NULL;
+    BOOL bHung = IsHungAppWindow(window);
 
-   UNREFERENCED_PARAMETER(lParam);
+    UNREFERENCED_PARAMETER(lParam);
 
-   // First try to get the big icon assigned to the window
+    // First try to get the big icon assigned to the window
 #define ICON_TIMEOUT 100 // in milliseconds
-   SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
-                       ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
-   if (!hIcon)
-   {
-      // If no icon is assigned, try to get the icon assigned to the windows' class
-      hIcon = (HICON)GetClassLongPtrW(window, GCL_HICON);
-      if (!hIcon)
-      {
-         // If we still don't have an icon, see if we can do with the small icon,
-         // or a default application icon
-         SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0,
-                             SMTO_ABORTIFHUNG | SMTO_BLOCK, ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
+    if (!bHung)
+    {
+        SendMessageTimeoutW(window, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK,
+                            ICON_TIMEOUT, (PDWORD_PTR)&hIcon);
+    }
+    if (!hIcon)
+    {
+        // If no icon is assigned, try to get the icon assigned to the windows' class
+        hIcon = (HICON)GetClassLongPtrW(window, GCL_HICON);
+        if (!hIcon)
+        {
+            // If we still don't have an icon, see if we can do with the small icon,
+            // or a default application icon
+            if (!bHung)
+            {
+                SendMessageTimeoutW(window, WM_GETICON, ICON_SMALL2, 0,
+                                    SMTO_ABORTIFHUNG | SMTO_BLOCK, ICON_TIMEOUT,
+                                    (PDWORD_PTR)&hIcon);
+            }
 #undef ICON_TIMEOUT
-         if (!hIcon)
-         {
-            // using windows logo icon as default
-            hIcon = gpsi->hIconWindows;
             if (!hIcon)
             {
-               //if all attempts to get icon fails go to the next window
-               return TRUE;
+                // using windows logo icon as default
+                hIcon = gpsi->hIconWindows;
+                if (!hIcon)
+                {
+                    //if all attempts to get icon fails go to the next window
+                    return TRUE;
+                }
             }
-         }
-      }
-   }
+        }
+    }
 
-   windowList[windowCount] = window;
-   iconList[windowCount] = CopyIcon(hIcon);
-   windowCount++;
+    windowList[windowCount] = window;
+    iconList[windowCount] = CopyIcon(hIcon);
+    windowCount++;
 
-   // If we got to the max number of windows, we won't be able to add any more
-   return (windowCount < MAX_WINDOWS);
+    // If we got to the max number of windows, we won't be able to add any more
+    return (windowCount < MAX_WINDOWS);
 }
 
 static HWND GetNiceRootOwner(HWND hwnd)


### PR DESCRIPTION
## Purpose

Task Switcher (`Alt+Tab`) used to be hung up if there were any halted windows.
JIRA issue: [CORE-17894](https://jira.reactos.org/browse/CORE-17894)

## Proposed changes

NOTE: This is not the perfect fix.
- Use `SendMessageTimeout` instead of `SendMessage`.
- Use `SwitchToThisWindow` instead of `BringWindowToTop`.
- Use `ShowWindowAsync` instead of `ShowWindow`.
- Use `SWP_ASYNCWINDOWPOS` for `SetWindowPos`.

## TODO

- [x] Optimize for speed.
- [x] Do tests.
