### PR TITLE
[W32TIME] Add Spanish (es-ES) translation

### DIFF
--- a/base/services/w32time/lang/es-ES.rc
+++ b/base/services/w32time/lang/es-ES.rc
@@ -1,0 +1,15 @@
+/*
+ * PROJECT:     ReactOS W32Time Service
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Spanish resource file
+ * TRANSLATORS: Copyright 2021 Julen Urizar Compains <julenuri@hotmail.com>
+ *              Copyright 2021 Javier Fernandez <elhoir@gmail.com>
+ */
+
+LANGUAGE LANG_SPANISH, SUBLANG_NEUTRAL
+
+STRINGTABLE
+BEGIN
+    IDS_DISPLAYNAME "Servicio de hora"
+    IDS_DESCRIPTION "Mantiene la sincronización de fecha y hora en todos los servidores y clientes de la red."
+END

--- a/base/services/w32time/w32time.rc
+++ b/base/services/w32time/w32time.rc
@@ -18,3 +18,6 @@
 #ifdef LANGUAGE_EN_US
     #include "lang/en-US.rc"
 #endif
+#ifdef LANGUAGE_ES_ES
+    #include "lang/es-ES.rc"
+#endif


### PR DESCRIPTION
Spanish translation of w32time service. Created es-ES.rc file.
