### PR TITLE
[EXPLORER] Check fullscreen and bring the tray down or up

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1565,6 +1565,7 @@ public:
         case HSHELL_RUDEAPPACTIVATED:
         case HSHELL_WINDOWACTIVATED:
             ActivateTask((HWND) lParam);
+            CheckFullscreen((HWND)lParam);
             break;
 
         case HSHELL_FLASH:


### PR DESCRIPTION
## Purpose

The taskbar used to be blocking the full screen app.
JIRA issue: [CORE-16130](https://jira.reactos.org/browse/CORE-16130)

## Proposed changes

- Check whether the activated window is fullscreen upon `HSHELL_WINDOWCREATED`, `HSHELL_WINDOWDESTROYED`, `HSHELL_RUDEAPPACTIVATED` and `HSHELL_WINDOWACTIVATED`.
- If the window was fullscreen and not a special window, then adjust the taskbar Z-order.

## TODO

- [ ] Do tests.
