### PR TITLE
[NTUSER][USER32] Simplify SwitchToThisWindow

### DIFF
--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -512,28 +512,25 @@ NtUserCallTwoParam(
             Ret = 0;
             Window = UserGetWindowObject(hwnd);
             if (!Window)
-            {
                 break;
-            }
-            if (MsqIsHung(Window->head.pti, MSQ_HUNG))
+
+            if (gpqForeground && !fAltTab)
             {
-                // TODO: Make the window ghosted and activate.
-                break;
-            }
-            if (fAltTab)
-            {
-                if (Window->style & WS_MINIMIZE)
+                PWND pwndActive = gpqForeground->spwndActive;
+                if (pwndActive && !(pwndActive->ExStyle & WS_EX_TOPMOST))
                 {
-                    UserPostMessage(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
+                    co_WinPosSetWindowPos(pwndActive, HWND_BOTTOM, 0, 0, 0, 0,
+                                          SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
+                                          SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS);
                 }
-                /* bring window to top and activate */
-                co_WinPosSetWindowPos(Window, HWND_TOP, 0, 0, 0, 0,
-                                      SWP_NOSIZE | SWP_NOMOVE | SWP_NOSENDCHANGING |
-                                      SWP_NOOWNERZORDER | SWP_ASYNCWINDOWPOS);
             }
-            else
+
+            UserSetActiveWindow(Window);
+
+            if (fAltTab && (Window->style & WS_MINIMIZE))
             {
-                UserSetActiveWindow(Window);
+                MSG msg = { Window->head.h, WM_SYSCOMMAND, SC_RESTORE, 0 };
+                MsqPostMessage(Window->head.pti, &msg, FALSE, QS_POSTMESSAGE, 0, 0);
             }
             break;
         }

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -124,11 +124,8 @@ void ResizeAndCenter(HWND hwnd, int width, int height)
 
 void MakeWindowActive(HWND hwnd)
 {
-   if (IsIconic(hwnd))
-      PostMessageW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0);
-
-   // See also: https://microsoft.public.win32.programmer.ui.narkive.com/RqOdKqZ8/bringwindowtotop-hangs-if-the-thread-is-busy
-   SwitchToThisWindow(hwnd, TRUE);
+    // See also: https://microsoft.public.win32.programmer.ui.narkive.com/RqOdKqZ8/bringwindowtotop-hangs-if-the-thread-is-busy
+    SwitchToThisWindow(hwnd, TRUE);
 }
 
 void CompleteSwitch(BOOL doSwitch)

--- a/win32ss/user/user32/controls/appswitch.c
+++ b/win32ss/user/user32/controls/appswitch.c
@@ -71,18 +71,6 @@ int CoolSwitchColumns = 7;
 const DWORD Style = WS_POPUP | WS_BORDER | WS_DISABLED;
 const DWORD ExStyle = WS_EX_TOPMOST | WS_EX_DLGMODALFRAME | WS_EX_TOOLWINDOW;
 
-DWORD wtodw(const WCHAR *psz)
-{
-   const WCHAR *pch = psz;
-   DWORD Value = 0;
-   while ('0' <= *pch && *pch <= '9')
-   {
-      Value *= 10;
-      Value += *pch - L'0';
-   }
-   return Value;
-}
-
 BOOL LoadCoolSwitchSettings(void)
 {
    CoolSwitch = TRUE;
@@ -122,12 +110,6 @@ void ResizeAndCenter(HWND hwnd, int width, int height)
    ptStart.y = y;
 }
 
-void MakeWindowActive(HWND hwnd)
-{
-    // See also: https://microsoft.public.win32.programmer.ui.narkive.com/RqOdKqZ8/bringwindowtotop-hangs-if-the-thread-is-busy
-    SwitchToThisWindow(hwnd, TRUE);
-}
-
 void CompleteSwitch(BOOL doSwitch)
 {
    if (!isOpen)
@@ -152,7 +134,7 @@ void CompleteSwitch(BOOL doSwitch)
 
          TRACE("[ATbot] CompleteSwitch Switching to 0x%08x (%ls)\n", hwnd, windowText);
 
-         MakeWindowActive(hwnd);
+         SwitchToThisWindow(hwnd, TRUE);
       }
    }
 
@@ -482,7 +464,7 @@ BOOL ProcessHotKey(VOID)
 
       if (windowCount == 1)
       {
-         MakeWindowActive(windowList[0]);
+         SwitchToThisWindow(windowList[0], TRUE);
          return FALSE;
       }
 
@@ -493,7 +475,7 @@ BOOL ProcessHotKey(VOID)
 
       TRACE("[ATbot] HotKey Received. Opening window.\n");
       ShowWindowAsync(switchdialog, SW_SHOWNORMAL);
-      MakeWindowActive(switchdialog);
+      SwitchToThisWindow(switchdialog, TRUE);
       isOpen = TRUE;
    }
    else
@@ -522,7 +504,7 @@ void RotateTasks(BOOL bShift)
                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                      SWP_NOOWNERZORDER | SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
 
-        MakeWindowActive(hwndLast);
+        SwitchToThisWindow(hwndLast, TRUE);
 
         Size = (windowCount - 1) * sizeof(HWND);
         MoveMemory(&windowList[1], &windowList[0], Size);
@@ -534,7 +516,7 @@ void RotateTasks(BOOL bShift)
                      SWP_NOMOVE | SWP_NOSIZE | SWP_NOACTIVATE |
                      SWP_NOOWNERZORDER | SWP_NOREPOSITION | SWP_ASYNCWINDOWPOS);
 
-        MakeWindowActive(windowList[1]);
+        SwitchToThisWindow(windowList[1], TRUE);
 
         Size = (windowCount - 1) * sizeof(HWND);
         MoveMemory(&windowList[0], &windowList[1], Size);


### PR DESCRIPTION
## Purpose
`user32.SwitchToThisWindow` function is used in Task Switcher.
JIRA issue: [CORE-17894](https://jira.reactos.org/browse/CORE-17894)

## Proposed changes
- Delete useless `wtodw` user function (because we already have `_wtoi` and `wcstol` functions).
- Delete `MakeWindowActive` user function and directly call `user32.SwitchToThisWindow` function in Task Switcher.
- Improve and simplify `user32.SwitchToThisWindow`.

## TODO

- [x] Do tests.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/145520458-64bec186-ad96-4b17-b1dc-a547a04d597a.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/145520452-27433fae-33ec-43d5-be21-c22f493bfd81.png)
No change.