### PR TITLE
Revert "Revert "[VIDEOPRT] Fix updating of new registry path values""

### DIFF
--- a/win32ss/drivers/videoprt/registry.c
+++ b/win32ss/drivers/videoprt/registry.c
@@ -557,41 +557,41 @@ IntCreateNewRegistryPath(
             ERR_(VIDEOPRT, "Failed create key '%wZ'\n", &DeviceExtension->NewRegistryPath);
             return Status;
         }
-
-        /* Open the new key */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &DeviceExtension->NewRegistryPath,
-                                   OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-        Status = ZwOpenKey(&NewKey, KEY_READ, &ObjectAttributes);
-        if (!NT_SUCCESS(Status))
-        {
-            ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
-            return Status;
-        }
-
-        /* Open the device profile key */
-        InitializeObjectAttributes(&ObjectAttributes,
-                                   &DeviceExtension->RegistryPath,
-                                   OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
-                                   NULL,
-                                   NULL);
-        Status = ZwOpenKey(&SettingsKey, KEY_READ, &ObjectAttributes);
-        if (!NT_SUCCESS(Status))
-        {
-            ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
-            ObCloseHandle(NewKey, KernelMode);
-            return Status;
-        }
-
-        /* Copy the registry data from the legacy key */
-        Status = IntCopyRegistryKey(SettingsKey, NewKey);
-
-        /* Close the key handles */
-        ObCloseHandle(SettingsKey, KernelMode);
-        ObCloseHandle(NewKey, KernelMode);
     }
+
+    /* Open the new key */
+    InitializeObjectAttributes(&ObjectAttributes,
+                                &DeviceExtension->NewRegistryPath,
+                                OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                NULL,
+                                NULL);
+    Status = ZwOpenKey(&NewKey, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        return Status;
+    }
+
+    /* Open the device profile key */
+    InitializeObjectAttributes(&ObjectAttributes,
+                                &DeviceExtension->RegistryPath,
+                                OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                NULL,
+                                NULL);
+    Status = ZwOpenKey(&SettingsKey, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR_(VIDEOPRT, "Failed to open settings key. Status 0x%lx\n", Status);
+        ObCloseHandle(NewKey, KernelMode);
+        return Status;
+    }
+
+    /* Copy the registry data from the legacy key */
+    Status = IntCopyRegistryKey(SettingsKey, NewKey);
+
+    /* Close the key handles */
+    ObCloseHandle(SettingsKey, KernelMode);
+    ObCloseHandle(NewKey, KernelMode);
 
     return Status;
 }


### PR DESCRIPTION
Restore the proper handling of registry data back, reverted in 5dc56dd1d67c95dd52a3cf9803e24b0a0b3ca69c, because reverting that doesn't actually fix [CORE-17688](https://jira.reactos.org/browse/CORE-17688) (as it was found later), and introduces a lot of new regressions: [CORE-17896](https://jira.reactos.org/browse/CORE-17896), [CORE-17897](https://jira.reactos.org/browse/CORE-17897) and [CORE-17909](https://jira.reactos.org/browse/CORE-17909).
Committing this back fixes all issues mentioned above again, but reintroduces [CORE-17719](https://jira.reactos.org/browse/CORE-17719) instead. :man_shrugging: 