### PR TITLE
[EXPLORER] Quick taskbar menu even if any halted window

### DIFF
--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -488,28 +488,27 @@ public:
 
     HICON GetWndIcon(HWND hwnd)
     {
-        const DWORD dwTimeout = 100; // in milliseconds
         HICON hIcon = NULL;
-        LRESULT bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG,
-                                            dwTimeout, (PDWORD_PTR)&hIcon);
+#define GET_ICON(type) \
+    SendMessageTimeout(hwnd, WM_GETICON, (type), 0, SMTO_ABORTIFHUNG, 100, (PDWORD_PTR)&hIcon)
+        LRESULT bAlive = GET_ICON(ICON_SMALL2);
         if (hIcon)
             return hIcon;
 
         if (bAlive)
         {
-            bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL, 0, SMTO_ABORTIFHUNG,
-                                        dwTimeout, (PDWORD_PTR)&hIcon);
+            bAlive = GET_ICON(ICON_SMALL);
             if (hIcon)
                 return hIcon;
         }
 
         if (bAlive)
         {
-            SendMessageTimeout(hwnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG,
-                               dwTimeout, (PDWORD_PTR)&hIcon);
+            GET_ICON(ICON_BIG);
             if (hIcon)
                 return hIcon;
         }
+#undef GET_ICON
 
         hIcon = (HICON)GetClassLongPtr(hwnd, GCL_HICONSM);
         if (hIcon)

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -488,26 +488,39 @@ public:
 
     HICON GetWndIcon(HWND hwnd)
     {
-        HICON hIcon = 0;
+        HICON hIcon = NULL;
+        const DWORD dwTimeout = 100; // in milliseconds
+        LRESULT bAlive = TRUE;
 
-        SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG, 1000, (PDWORD_PTR) &hIcon);
-        if (hIcon)
-            return hIcon;
+        if (bAlive)
+        {
+            bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG,
+                                        dwTimeout, (PDWORD_PTR)&hIcon);
+            if (hIcon)
+                return hIcon;
+        }
 
-        SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL, 0, SMTO_ABORTIFHUNG, 1000, (PDWORD_PTR) &hIcon);
-        if (hIcon)
-            return hIcon;
+        if (bAlive)
+        {
+            bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL, 0, SMTO_ABORTIFHUNG,
+                                        dwTimeout, (PDWORD_PTR)&hIcon);
+            if (hIcon)
+                return hIcon;
+        }
 
-        SendMessageTimeout(hwnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG, 1000, (PDWORD_PTR) &hIcon);
-        if (hIcon)
-            return hIcon;
+        if (bAlive)
+        {
+            SendMessageTimeout(hwnd, WM_GETICON, ICON_BIG, 0, SMTO_ABORTIFHUNG,
+                               dwTimeout, (PDWORD_PTR)&hIcon);
+            if (hIcon)
+                return hIcon;
+        }
 
         hIcon = (HICON) GetClassLongPtr(hwnd, GCL_HICONSM);
         if (hIcon)
             return hIcon;
 
         hIcon = (HICON) GetClassLongPtr(hwnd, GCL_HICON);
-
         return hIcon;
     }
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -488,17 +488,12 @@ public:
 
     HICON GetWndIcon(HWND hwnd)
     {
-        HICON hIcon = NULL;
         const DWORD dwTimeout = 100; // in milliseconds
-        LRESULT bAlive = TRUE;
-
-        if (bAlive)
-        {
-            bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG,
-                                        dwTimeout, (PDWORD_PTR)&hIcon);
-            if (hIcon)
-                return hIcon;
-        }
+        HICON hIcon = NULL;
+        LRESULT bAlive = SendMessageTimeout(hwnd, WM_GETICON, ICON_SMALL2, 0, SMTO_ABORTIFHUNG,
+                                            dwTimeout, (PDWORD_PTR)&hIcon);
+        if (hIcon)
+            return hIcon;
 
         if (bAlive)
         {

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -511,12 +511,11 @@ public:
                 return hIcon;
         }
 
-        hIcon = (HICON) GetClassLongPtr(hwnd, GCL_HICONSM);
+        hIcon = (HICON)GetClassLongPtr(hwnd, GCL_HICONSM);
         if (hIcon)
             return hIcon;
 
-        hIcon = (HICON) GetClassLongPtr(hwnd, GCL_HICON);
-        return hIcon;
+        return (HICON)GetClassLongPtr(hwnd, GCL_HICON);
     }
 
     INT UpdateTaskItemButton(IN PTASK_ITEM TaskItem)

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -491,6 +491,7 @@ public:
         HICON hIcon = NULL;
 #define GET_ICON(type) \
     SendMessageTimeout(hwnd, WM_GETICON, (type), 0, SMTO_ABORTIFHUNG, 100, (PDWORD_PTR)&hIcon)
+
         LRESULT bAlive = GET_ICON(ICON_SMALL2);
         if (hIcon)
             return hIcon;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17894](https://jira.reactos.org/browse/CORE-17894)

## Proposed changes

- Reduce the timeout amount for `SendMessageTimeout` calls.
- Add `bAlive` flag to check whether the window is hung-up in order to optimize for speed.

## Screenshot
AFTER:
![after](https://user-images.githubusercontent.com/2107452/146114623-ff63cb78-df0a-4de0-9f76-6dac0090d4c4.png)
The taskbar right-click menu is able to appear quickly even if there is a halted window.