### PR TITLE
[NTUSER][USER32] Use async way in TileWindows and CascadeWindows

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2125,7 +2125,11 @@ NtUserEnableScrollBar(
     UINT wSBflags,
     UINT wArrows);
 
-BOOL NTAPI NtUserEndDeferWindowPosEx(HDWP WinPosInfo, BOOL bAsync);
+BOOL
+NTAPI
+NtUserEndDeferWindowPosEx(
+    HDWP WinPosInfo,
+    BOOL bAsync);
 
 BOOL
 NTAPI

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2125,11 +2125,7 @@ NtUserEnableScrollBar(
     UINT wSBflags,
     UINT wArrows);
 
-BOOL
-NTAPI
-NtUserEndDeferWindowPosEx(
-    HDWP WinPosInfo,
-    BOOL bAsync);
+BOOL NTAPI NtUserEndDeferWindowPosEx(HDWP WinPosInfo, BOOL bAsync);
 
 BOOL
 NTAPI

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2129,7 +2129,7 @@ BOOL
 NTAPI
 NtUserEndDeferWindowPosEx(
     HDWP WinPosInfo,
-    DWORD Unknown1);
+    BOOL bAsync);
 
 BOOL
 NTAPI

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3164,12 +3164,12 @@ NtUserChildWindowFromPointEx(HWND hwndParent,
  */
 BOOL APIENTRY
 NtUserEndDeferWindowPosEx(HDWP WinPosInfo,
-                          DWORD Unknown1)
+                          BOOL bAsync)
 {
    BOOL Ret;
    TRACE("Enter NtUserEndDeferWindowPosEx\n");
    UserEnterExclusive();
-   Ret = IntEndDeferWindowPosEx(WinPosInfo, (BOOL)Unknown1);
+   Ret = IntEndDeferWindowPosEx(WinPosInfo, bAsync);
    TRACE("Leave NtUserEndDeferWindowPosEx, ret=%i\n", Ret);
    UserLeave();
    return Ret;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3163,7 +3163,8 @@ NtUserChildWindowFromPointEx(HWND hwndParent,
  * @implemented
  */
 BOOL APIENTRY
-NtUserEndDeferWindowPosEx(HDWP WinPosInfo, BOOL bAsync)
+NtUserEndDeferWindowPosEx(HDWP WinPosInfo,
+                          BOOL bAsync)
 {
    BOOL Ret;
    TRACE("Enter NtUserEndDeferWindowPosEx\n");

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3163,8 +3163,7 @@ NtUserChildWindowFromPointEx(HWND hwndParent,
  * @implemented
  */
 BOOL APIENTRY
-NtUserEndDeferWindowPosEx(HDWP WinPosInfo,
-                          BOOL bAsync)
+NtUserEndDeferWindowPosEx(HDWP WinPosInfo, BOOL bAsync)
 {
    BOOL Ret;
    TRACE("Enter NtUserEndDeferWindowPosEx\n");

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2190,7 +2190,7 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         ++ret;
     }
 
-    EndDeferWindowPos(hDWP);
+    NtUserEndDeferWindowPosEx(hDWP, TRUE);
 
     if (hwndPrev)
         SetForegroundWindow(hwndPrev);
@@ -2384,7 +2384,7 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         ++ret;
     }
 
-    EndDeferWindowPos(hDWP);
+    NtUserEndDeferWindowPosEx(hDWP, TRUE);
 
     if (hwndPrev)
         SetForegroundWindow(hwndPrev);

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -645,7 +645,7 @@ DeferWindowPos(HDWP hWinPosInfo,
 BOOL WINAPI
 EndDeferWindowPos(HDWP hWinPosInfo)
 {
-    return NtUserEndDeferWindowPosEx(hWinPosInfo, 0);
+    return NtUserEndDeferWindowPosEx(hWinPosInfo, FALSE);
 }
 
 


### PR DESCRIPTION
## Purpose

Hanging used to happen because `user32.TileWindows` and `user32!CascadeWindows` were processing synchronously.

JIRA issue: [CORE-17894](https://jira.reactos.org/browse/CORE-17894)

## Proposed changes

- Modify `NtUserEndDeferWindowPosEx` prototype.
- Use asynchronous way in `TileWindows` and `CascadeWindows` functions.

## TODO

- [x] Do tests.