### PR TITLE
[NETSHELL] Improve workgroup vs. domain wording

### DIFF
--- a/dll/shellext/netshell/lang/bg-BG.rc
+++ b/dll/shellext/netshell/lang/bg-BG.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/bg-BG.rc
+++ b/dll/shellext/netshell/lang/bg-BG.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/da-DK.rc
+++ b/dll/shellext/netshell/lang/da-DK.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/da-DK.rc
+++ b/dll/shellext/netshell/lang/da-DK.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/el-GR.rc
+++ b/dll/shellext/netshell/lang/el-GR.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/el-GR.rc
+++ b/dll/shellext/netshell/lang/el-GR.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/en-US.rc
+++ b/dll/shellext/netshell/lang/en-US.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/en-US.rc
+++ b/dll/shellext/netshell/lang/en-US.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/he-IL.rc
+++ b/dll/shellext/netshell/lang/he-IL.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/he-IL.rc
+++ b/dll/shellext/netshell/lang/he-IL.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/id-ID.rc
+++ b/dll/shellext/netshell/lang/id-ID.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/id-ID.rc
+++ b/dll/shellext/netshell/lang/id-ID.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/it-IT.rc
+++ b/dll/shellext/netshell/lang/it-IT.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/it-IT.rc
+++ b/dll/shellext/netshell/lang/it-IT.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/nl-NL.rc
+++ b/dll/shellext/netshell/lang/nl-NL.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/nl-NL.rc
+++ b/dll/shellext/netshell/lang/nl-NL.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/no-NO.rc
+++ b/dll/shellext/netshell/lang/no-NO.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/no-NO.rc
+++ b/dll/shellext/netshell/lang/no-NO.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sk-SK.rc
+++ b/dll/shellext/netshell/lang/sk-SK.rc
@@ -116,7 +116,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sk-SK.rc
+++ b/dll/shellext/netshell/lang/sk-SK.rc
@@ -116,7 +116,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sq-AL.rc
+++ b/dll/shellext/netshell/lang/sq-AL.rc
@@ -115,7 +115,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sq-AL.rc
+++ b/dll/shellext/netshell/lang/sq-AL.rc
@@ -115,7 +115,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sv-SE.rc
+++ b/dll/shellext/netshell/lang/sv-SE.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL

--- a/dll/shellext/netshell/lang/sv-SE.rc
+++ b/dll/shellext/netshell/lang/sv-SE.rc
@@ -111,7 +111,7 @@ FONT 8, "MS Shell Dlg"
 BEGIN
     LTEXT "Do you want this computer to be a member of a domain?\n\
 (You can obtain this information from your network administrator.)", IDC_STATIC, 33, 2, 263, 50
-    AUTORADIOBUTTON "No, this computer will not be part of a workgroup.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
+    AUTORADIOBUTTON "No, this computer will be part of a workgroup instead.", IDC_SELECT_WORKGROUP, 33, 32, 253, 20, WS_TABSTOP | WS_GROUP
     AUTORADIOBUTTON "Yes, this computer will be part of a domain.", IDC_SELECT_DOMAIN, 33, 47, 253, 20, WS_TABSTOP
     LTEXT "Workgroup or Domain Name:", IDC_STATIC, 33, 72, 126, 14
     EDITTEXT IDC_DOMAIN_NAME, 33, 82, 126, 14, WS_VISIBLE | WS_TABSTOP | ES_AUTOHSCROLL


### PR DESCRIPTION
## Purpose

A string in the installer is missing the word "not", and as a result is slightly confusing.  Add the missing word.