### PR TITLE
[WIN32SS][NTDDRAW] Improve DxEngGetDCState type 2 implementation

### DIFF
--- a/win32ss/reactx/ntddraw/dxeng.c
+++ b/win32ss/reactx/ntddraw/dxeng.c
@@ -464,8 +464,8 @@ DxEngGetDCState(HDC hDC,
                 retVal = (DWORD_PTR) pDC->fs & DC_FLAG_FULLSCREEN;
                 break;
             case 2:
-                /* Return the number of rectangles in the visible region. */
-                retVal = (DWORD_PTR) pDC->prgnRao ? pDC->prgnRao->rdh.nCount : pDC->prgnVis->rdh.nCount;
+                /* Return the complexity of the visible region. */
+                retVal = (DWORD_PTR) REGION_Complexity(pDC->prgnVis);
                 break;
             case 3:
             {
@@ -480,6 +480,8 @@ DxEngGetDCState(HDC hDC,
         }
         DC_UnlockDc(pDC);
     }
+
+    DPRINT1("Return value %08lx\n", retVal);
 
     return retVal;
 }


### PR DESCRIPTION
## Purpose

Add several improvements in `case 2` of `DxEngGetDCState` function in our win32k.
This allows to properly enable and use DirectDraw and Direct3D hardware acceleration with the following MS DirectX components: ddraw.dll, d3d8.dll, d3d9.dll and dxg.sys. As in VM, same on real hardware. :smiley: 
But note that now the bugcheck 0x50 (`PAGE_FAULT_IN_NONPAGED_AREA`) occurs when executing fullscreen DDraw apps, after switching display mode. It's unhidden by this fix. **To be reported.**
Addendum to 855bf46.

JIRA issue: [CORE-17561](https://jira.reactos.org/browse/CORE-17561)

## Proposed changes

- Use the `REGION_Complexity()` function to get the actual region complexity instead of just number of rectangles.
- Don't use `prgnRao` at all, because it is always uninitialized when passed to the function. So in condition between `prgnRao` and `prgnVis`, the 2nd one always succeeds.
- Update the comment accordingly.
- Additionally, add a `DPRINT` to the end of the function, which displays the returned value.

## Result

As visible on the following screenshots, DDraw acceleration (and D3D too) works properly after my changes. :slightly_smiling_face: 

Before:
![ddraw-before](https://user-images.githubusercontent.com/26385117/146682564-7c979373-fe84-4590-a645-fe37811d5b6d.png)

After:
![ddraw-after](https://user-images.githubusercontent.com/26385117/146682569-0bb9de93-010d-4008-a498-217bec20e356.png)

The 2 of 3 DirectDraw tests are now working with hardware acceleration, but 3rd (fullscreen) test causes a bugcheck mentioned above after display mode switch. But if to change display settings manually before starting the test, the 3rd one also works properly.
Also a lot of apps/games are now working with hardware acceleration, if they are running in window or in fullscreen, if to switch display mode to required manually before launching the app/game.
**Please note also that in order to see an effect from my changes, you need to apply all my previous ReactX improvements.**