### PR TITLE
[NTUSER] Use call procedure handle if available

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1623,6 +1623,7 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
    PTHREADINFO pti = NULL;
    BOOL MenuChanged;
    BOOL bUnicodeWindow;
+   PCALLPROCDATA pcpd = NULL;
 
    pti = pdeskCreated ? gptiDesktopThread : GetW32ThreadInfo();
 
@@ -1769,7 +1770,17 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
     see what problems this would cause. */
 
    // Set WndProc from Class.
-   pWnd->lpfnWndProc  = pWnd->pcls->lpfnWndProc;
+   if (IsCallProcHandle(pWnd->pcls->lpfnWndProc))
+   {
+      pcpd = UserGetObject(gHandleTable, pWnd->pcls->lpfnWndProc, TYPE_CALLPROC);
+      if (pcpd)
+         pWnd->lpfnWndProc = pcpd->pfnClientPrevious;
+      pcpd = NULL;
+   }
+   else
+   {
+      pWnd->lpfnWndProc  = pWnd->pcls->lpfnWndProc;
+   }
 
    // GetWindowProc, test for non server side default classes and set WndProc.
     if ( pWnd->pcls->fnid <= FNID_GHOST && pWnd->pcls->fnid >= FNID_BUTTON )

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1779,7 +1779,7 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
    }
    else
    {
-      pWnd->lpfnWndProc  = pWnd->pcls->lpfnWndProc;
+      pWnd->lpfnWndProc = pWnd->pcls->lpfnWndProc;
    }
 
    // GetWindowProc, test for non server side default classes and set WndProc.

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1623,7 +1623,7 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
    PTHREADINFO pti = NULL;
    BOOL MenuChanged;
    BOOL bUnicodeWindow;
-   PCALLPROCDATA pcpd = NULL;
+   PCALLPROCDATA pcpd;
 
    pti = pdeskCreated ? gptiDesktopThread : GetW32ThreadInfo();
 
@@ -1775,7 +1775,6 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
       pcpd = UserGetObject(gHandleTable, pWnd->pcls->lpfnWndProc, TYPE_CALLPROC);
       if (pcpd)
          pWnd->lpfnWndProc = pcpd->pfnClientPrevious;
-      pcpd = NULL;
    }
    else
    {


### PR DESCRIPTION
## Purpose

Based on `I_Kill_Bugs`' patch.
JIRA issue: [CORE-10499](https://jira.reactos.org/browse/CORE-10499)

## Proposed changes

- Use `IsCallProcHandle` to check if the procedure is a call procedure handle.
- If so, use the call procedure.

## TODO

- [ ] Do tests.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/147175874-da0f3ff6-4ce2-4151-884c-c198960e51e3.png)
FAILED.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/147175873-fd2ac307-e022-476b-926c-d4b7dd466ecd.png)
Successful.