### PR TITLE
[GDIPLUS] GdipCreateBitmapFromStream should accept metafiles

### DIFF
--- a/dll/win32/gdiplus/image.c
+++ b/dll/win32/gdiplus/image.c
@@ -1897,6 +1897,42 @@ GpStatus WINGDIPAPI GdipCreateBitmapFromScan0(INT width, INT height, INT stride,
     return Ok;
 }
 
+#ifdef __REACTOS__
+static HBITMAP hbitmap_from_emf(HENHMETAFILE hemf)
+{
+    BITMAPINFO bmi;
+    HBITMAP hbm;
+    SIZE size;
+    ENHMETAHEADER header;
+    HGDIOBJ hbmOld;
+    RECT rc;
+    LPVOID pvBits;
+    HDC hdc;
+
+    GetEnhMetaFileHeader(hemf, sizeof(header), &header);
+
+    hdc = CreateCompatibleDC(NULL);
+    size.cx = header.rclBounds.right - header.rclBounds.left + 1;
+    size.cy = header.rclBounds.bottom - header.rclBounds.top + 1;
+
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
+    bmi.bmiHeader.biWidth = size.cx;
+    bmi.bmiHeader.biHeight = size.cy;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 24;
+    hbm = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pvBits, NULL, 0);
+
+    hbmOld = SelectObject(hdc, hbm);
+    SetRect(&rc, 0, 0, size.cx, size.cy);
+    PlayEnhMetaFile(hdc, hemf, &rc);
+    SelectObject(hdc, hbmOld);
+
+    DeleteDC(hdc);
+    return hbm;
+}
+
+#endif
 GpStatus WINGDIPAPI GdipCreateBitmapFromStream(IStream* stream,
     GpBitmap **bitmap)
 {
@@ -1909,6 +1945,19 @@ GpStatus WINGDIPAPI GdipCreateBitmapFromStream(IStream* stream,
     if(stat != Ok)
         return stat;
 
+#ifdef __REACTOS__
+    if ((*bitmap)->image.type == ImageTypeMetafile)
+    {
+        HBITMAP hbm = hbitmap_from_emf(((GpMetafile*)*bitmap)->hemf);
+        GdipDisposeImage(&(*bitmap)->image);
+        if (!hbm)
+            return GenericError; /* FIXME: what error to return? */
+
+        GdipCreateBitmapFromHBITMAP(hbm, NULL, bitmap);
+        DeleteObject(hbm);
+    }
+    else
+#endif
     if((*bitmap)->image.type != ImageTypeBitmap){
         GdipDisposeImage(&(*bitmap)->image);
         *bitmap = NULL;

--- a/dll/win32/gdiplus/image.c
+++ b/dll/win32/gdiplus/image.c
@@ -1906,12 +1906,9 @@ static HBITMAP hbitmap_from_emf(HENHMETAFILE hemf)
     ENHMETAHEADER header;
     HGDIOBJ hbmOld;
     RECT rc;
-    LPVOID pvBits;
     HDC hdc;
 
     GetEnhMetaFileHeader(hemf, sizeof(header), &header);
-
-    hdc = CreateCompatibleDC(NULL);
     size.cx = header.rclBounds.right - header.rclBounds.left + 1;
     size.cy = header.rclBounds.bottom - header.rclBounds.top + 1;
 
@@ -1921,7 +1918,9 @@ static HBITMAP hbitmap_from_emf(HENHMETAFILE hemf)
     bmi.bmiHeader.biHeight = size.cy;
     bmi.bmiHeader.biPlanes = 1;
     bmi.bmiHeader.biBitCount = 24;
-    hbm = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, &pvBits, NULL, 0);
+
+    hdc = CreateCompatibleDC(NULL);
+    hbm = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, NULL, NULL, 0);
 
     hbmOld = SelectObject(hdc, hbm);
     SetRect(&rc, 0, 0, size.cx, size.cy);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17814](https://jira.reactos.org/browse/CORE-17814)

## Proposed changes

- Add `hbitmap_from_emf` helper function.
- `GdipCreateBitmapFromStream` accepts the metafiles.

## TODO

- [x] Do tests.

## Screenshot

![after](https://user-images.githubusercontent.com/2107452/147354332-d0e88f96-590d-42c7-901d-390973ff2bcc.png)