### PR TITLE
[MSPAINT] Make PNG default instead of BMP

### DIFF
--- a/base/applications/mspaint/lang/bg-BG.rc
+++ b/base/applications/mspaint/lang/bg-BG.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Рисувач (Paint) за РеактОС"
     IDS_INFOTEXT "Достъпен под GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Искате ли да запишете промените в %s?"
-    IDS_DEFAULTFILENAME "Без име.bmp"
+    IDS_DEFAULTFILENAME "Без име.png"
     IDS_MINIATURETITLE "Изображенийце"
     IDS_TOOLTIP1 "Свободно избиране"
     IDS_TOOLTIP2 "Избор"

--- a/base/applications/mspaint/lang/cs-CZ.rc
+++ b/base/applications/mspaint/lang/cs-CZ.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS Malování"
     IDS_INFOTEXT "Dostupné pod licencí GNU Lesser General Public License (LGPL, viz. www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Chcete uložit provedené změny v %s?"
-    IDS_DEFAULTFILENAME "Bez názvu.bmp"
+    IDS_DEFAULTFILENAME "Bez názvu.png"
     IDS_MINIATURETITLE "Miniatura"
     IDS_TOOLTIP1 "Volný výběr"
     IDS_TOOLTIP2 "Výběr"

--- a/base/applications/mspaint/lang/de-DE.rc
+++ b/base/applications/mspaint/lang/de-DE.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint für ReactOS"
     IDS_INFOTEXT "Unter der GNU Lesser General Public License stehen (LGPL, siehe www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Möchten Sie die Änderungen an %s speichern?"
-    IDS_DEFAULTFILENAME "Unbenannt.bmp"
+    IDS_DEFAULTFILENAME "Unbenannt.png"
     IDS_MINIATURETITLE "Miniaturansicht"
     IDS_TOOLTIP1 "Freie Auswahl"
     IDS_TOOLTIP2 "Auswahl"

--- a/base/applications/mspaint/lang/en-GB.rc
+++ b/base/applications/mspaint/lang/en-GB.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint for ReactOS"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Do you want to save the changes to %s?"
-    IDS_DEFAULTFILENAME "Unnamed.bmp"
+    IDS_DEFAULTFILENAME "Unnamed.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Free selection"
     IDS_TOOLTIP2 "Selection"

--- a/base/applications/mspaint/lang/en-US.rc
+++ b/base/applications/mspaint/lang/en-US.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint for ReactOS"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Do you want to save the changes to %s?"
-    IDS_DEFAULTFILENAME "Unnamed.bmp"
+    IDS_DEFAULTFILENAME "Unnamed.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Free selection"
     IDS_TOOLTIP2 "Selection"

--- a/base/applications/mspaint/lang/es-ES.rc
+++ b/base/applications/mspaint/lang/es-ES.rc
@@ -200,7 +200,7 @@ BEGIN
     IDS_INFOTITLE "Paint para ReactOS"
     IDS_INFOTEXT "Disponible bajo los términos de la GNU Lesser General Public License (LGPL, ver www.gnu.org)"
     IDS_SAVEPROMPTTEXT "¿Guardar cambios a %s?"
-    IDS_DEFAULTFILENAME "Sin título.bmp"
+    IDS_DEFAULTFILENAME "Sin título.png"
     IDS_MINIATURETITLE "Miniatura"
     IDS_TOOLTIP1 "Selección de forma libre"
     IDS_TOOLTIP2 "Selección"

--- a/base/applications/mspaint/lang/et-EE.rc
+++ b/base/applications/mspaint/lang/et-EE.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint ReactOS'ile"
     IDS_INFOTEXT "On saadaval ""GNU Lesser General Public License"" litsentsi all (LGPL, vaata www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Kas soovid salvesta muudatusi failis %s?"
-    IDS_DEFAULTFILENAME "Nimetu.bmp"
+    IDS_DEFAULTFILENAME "Nimetu.png"
     IDS_MINIATURETITLE "Miniatuur"
     IDS_TOOLTIP1 "Vaba valik"
     IDS_TOOLTIP2 "Valik"

--- a/base/applications/mspaint/lang/eu-ES.rc
+++ b/base/applications/mspaint/lang/eu-ES.rc
@@ -190,7 +190,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS-ko Paint"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, ver www.gnu.org)"
     IDS_SAVEPROMPTTEXT "%s aldaketak gorde nahi duzu?"
-    IDS_DEFAULTFILENAME "Izegabea.bmp"
+    IDS_DEFAULTFILENAME "Izegabea.png"
     IDS_MINIATURETITLE "Miniatura"
     IDS_TOOLTIP1 "Hautatu forma librea"
     IDS_TOOLTIP2 "Hautatu"

--- a/base/applications/mspaint/lang/fr-FR.rc
+++ b/base/applications/mspaint/lang/fr-FR.rc
@@ -190,7 +190,7 @@ BEGIN
     IDS_INFOTITLE "Paint pour ReactOS"
     IDS_INFOTEXT "Mis à disposition sous la Licence publique générale limitée GNU (LGPL, voir www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Voulez-vous enregistrer les modifications de %s?"
-    IDS_DEFAULTFILENAME "Sans titre.bmp"
+    IDS_DEFAULTFILENAME "Sans titre.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Sélection libre"
     IDS_TOOLTIP2 "Sélection"

--- a/base/applications/mspaint/lang/he-IL.rc
+++ b/base/applications/mspaint/lang/he-IL.rc
@@ -193,7 +193,7 @@ BEGIN
     IDS_INFOTITLE "צייר עבור ReactOS"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "האם ברצונך לשמור את השינויים של %s?"
-    IDS_DEFAULTFILENAME "ללא שם.bmp"
+    IDS_DEFAULTFILENAME "ללא שם.png"
     IDS_MINIATURETITLE "ממוזער"
     IDS_TOOLTIP1 "בחירה חופשית"
     IDS_TOOLTIP2 "בחירה"

--- a/base/applications/mspaint/lang/hu-HU.rc
+++ b/base/applications/mspaint/lang/hu-HU.rc
@@ -190,7 +190,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS Paint"
     IDS_INFOTEXT "A GNU Lesser General Public License (LGPL) alatt érhető el (lásd www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Kívánja menteni %s változásait?"
-    IDS_DEFAULTFILENAME "Névtelen.bmp"
+    IDS_DEFAULTFILENAME "Névtelen.png"
     IDS_MINIATURETITLE "Miniatúra"
     IDS_TOOLTIP1 "Szabadkézi kijelölés"
     IDS_TOOLTIP2 "Kijelölés"

--- a/base/applications/mspaint/lang/id-ID.rc
+++ b/base/applications/mspaint/lang/id-ID.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint untuk ReactOS"
     IDS_INFOTEXT "Tersedia di bawah GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Ingin menyimpan perubahan untuk %s?"
-    IDS_DEFAULTFILENAME "Tanpa Nama.bmp"
+    IDS_DEFAULTFILENAME "Tanpa Nama.png"
     IDS_MINIATURETITLE "Miniatur"
     IDS_TOOLTIP1 "Pilihan Bebas"
     IDS_TOOLTIP2 "Pilihan"

--- a/base/applications/mspaint/lang/it-IT.rc
+++ b/base/applications/mspaint/lang/it-IT.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint per ReactOS"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Volete salvare le modifiche a %s?"
-    IDS_DEFAULTFILENAME "SenzaNome.bmp"
+    IDS_DEFAULTFILENAME "SenzaNome.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Selezione libera"
     IDS_TOOLTIP2 "Selezione"

--- a/base/applications/mspaint/lang/ja-JP.rc
+++ b/base/applications/mspaint/lang/ja-JP.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS ペイント"
     IDS_INFOTEXT "GNU Lesser General Public License (LGPL, 詳細は www.gnu.org) の下で利用可能です。"
     IDS_SAVEPROMPTTEXT "%s の変更内容を保存しますか？"
-    IDS_DEFAULTFILENAME "無題.bmp"
+    IDS_DEFAULTFILENAME "無題.png"
     IDS_MINIATURETITLE "縮小図"
     IDS_TOOLTIP1 "自由選択"
     IDS_TOOLTIP2 "選択"

--- a/base/applications/mspaint/lang/nl-NL.rc
+++ b/base/applications/mspaint/lang/nl-NL.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint for ReactOS"
     IDS_INFOTEXT "Available under the GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Wilt u de wijzigingen die zijn aangebracht in %s opslaan?"
-    IDS_DEFAULTFILENAME "Naamloos.bmp"
+    IDS_DEFAULTFILENAME "Naamloos.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Vrij selecteren"
     IDS_TOOLTIP2 "Selecteren"

--- a/base/applications/mspaint/lang/no-NO.rc
+++ b/base/applications/mspaint/lang/no-NO.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint for ReactOS"
     IDS_INFOTEXT "Tilgjengelig under GNU Lesser General Public License (LGPL, se http://www.gnu.org/home.nb.html)"
     IDS_SAVEPROMPTTEXT "Vil du lagre endringene til %s?"
-    IDS_DEFAULTFILENAME "Utennavn.bmp"
+    IDS_DEFAULTFILENAME "Utennavn.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Frihåndmerking"
     IDS_TOOLTIP2 "Merk"

--- a/base/applications/mspaint/lang/pl-PL.rc
+++ b/base/applications/mspaint/lang/pl-PL.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_INFOTITLE "Paint dla ReactOS"
     IDS_INFOTEXT "Dostępny na licencji GNU Lesser General Public License (LGPL, www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Czy chcesz zapisać zmiany do %s?"
-    IDS_DEFAULTFILENAME "bez tytułu.bmp"
+    IDS_DEFAULTFILENAME "bez tytułu.png"
     IDS_MINIATURETITLE "Miniatura"
     IDS_TOOLTIP1 "Zaznaczenie dowolne"
     IDS_TOOLTIP2 "Zaznaczenie"

--- a/base/applications/mspaint/lang/pt-BR.rc
+++ b/base/applications/mspaint/lang/pt-BR.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint para ReactOS"
     IDS_INFOTEXT "Disponível sob a licença GNU Lesser General Public License (LGPL, visite www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Salvar as alterações em %s?"
-    IDS_DEFAULTFILENAME "Imagem.bmp"
+    IDS_DEFAULTFILENAME "Imagem.png"
     IDS_MINIATURETITLE "Miniatura"
     IDS_TOOLTIP1 "Selecionar forma livre"
     IDS_TOOLTIP2 "Selecionar"

--- a/base/applications/mspaint/lang/pt-PT.rc
+++ b/base/applications/mspaint/lang/pt-PT.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint para ReactOS"
     IDS_INFOTEXT "Disponível sob a licença GNU Lesser General Public License (LGPL, visite www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Pretende guardar as alterações a %s?"
-    IDS_DEFAULTFILENAME "Imagem.bmp"
+    IDS_DEFAULTFILENAME "Imagem.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Selecionar forma livre"
     IDS_TOOLTIP2 "Selecionar"

--- a/base/applications/mspaint/lang/ro-RO.rc
+++ b/base/applications/mspaint/lang/ro-RO.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_INFOTITLE "Pictare pentru ReactOS"
     IDS_INFOTEXT "Disponibilă sub licența GNU Lesser General Public (vedeți www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Doriți păstrarea modificărilor din %s?"
-    IDS_DEFAULTFILENAME "FărăNume.bmp"
+    IDS_DEFAULTFILENAME "FărăNume.png"
     IDS_MINIATURETITLE "Miniatură"
     IDS_TOOLTIP1 "Golire selecție"
     IDS_TOOLTIP2 "Selecție"

--- a/base/applications/mspaint/lang/ru-RU.rc
+++ b/base/applications/mspaint/lang/ru-RU.rc
@@ -190,7 +190,7 @@ BEGIN
     IDS_INFOTITLE "Paint для ReactOS"
     IDS_INFOTEXT "Распространяется под лицензией GNU Lesser General Public License (LGPL, см. www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Сохранить изменения в %s?"
-    IDS_DEFAULTFILENAME "Безымянный.bmp"
+    IDS_DEFAULTFILENAME "Безымянный.png"
     IDS_MINIATURETITLE "Эскиз"
     IDS_TOOLTIP1 "Выделение произвольной области"
     IDS_TOOLTIP2 "Выделение"

--- a/base/applications/mspaint/lang/sk-SK.rc
+++ b/base/applications/mspaint/lang/sk-SK.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_INFOTITLE "Skicár systému ReactOS"
     IDS_INFOTEXT "Dostupný za podmienok GNU Lesser General Public License (LGPL, viď www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Chcete uložiť vykonané zmeny do %s?"
-    IDS_DEFAULTFILENAME "Bez názvu.bmp"
+    IDS_DEFAULTFILENAME "Bez názvu.png"
     IDS_MINIATURETITLE "Miniature"
     IDS_TOOLTIP1 "Voľný výber"
     IDS_TOOLTIP2 "Výber"

--- a/base/applications/mspaint/lang/sq-AL.rc
+++ b/base/applications/mspaint/lang/sq-AL.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint për ReactOS"
     IDS_INFOTEXT "Ësht i disponueshme nën GNU Lesser General Public License (LGPL, see www.gnu.org)"
     IDS_SAVEPROMPTTEXT "A doni të ruani ndryshimet tek %s?"
-    IDS_DEFAULTFILENAME "Unnamed.bmp"
+    IDS_DEFAULTFILENAME "Unnamed.png"
     IDS_MINIATURETITLE "Miniaturë"
     IDS_TOOLTIP1 "Zgjedhje e lire"
     IDS_TOOLTIP2 "Zgjedhje"

--- a/base/applications/mspaint/lang/sv-SE.rc
+++ b/base/applications/mspaint/lang/sv-SE.rc
@@ -190,7 +190,7 @@ BEGIN
     IDS_INFOTITLE "Paint för ReactOS"
     IDS_INFOTEXT "Tillgänglig under GNU Lesser General Public License (LGPL, se www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Vill du spara ändringarna till %s?"
-    IDS_DEFAULTFILENAME "Namnlös.bmp"
+    IDS_DEFAULTFILENAME "Namnlös.png"
     IDS_MINIATURETITLE "Miniatyr"
     IDS_TOOLTIP1 "Lasso"
     IDS_TOOLTIP2 "Markering"

--- a/base/applications/mspaint/lang/tr-TR.rc
+++ b/base/applications/mspaint/lang/tr-TR.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS için Paint"
     IDS_INFOTEXT "GNU Kısıtlı Genel Kamu Lisansı (LGPL, bakınız: www.gnu.org) altındadır."
     IDS_SAVEPROMPTTEXT "%s için yapılan değişiklikleri kaydetmek ister misiniz?"
-    IDS_DEFAULTFILENAME "Adsız.bmp"
+    IDS_DEFAULTFILENAME "Adsız.png"
     IDS_MINIATURETITLE "Küçük Resim"
     IDS_TOOLTIP1 "Serbest seçim"
     IDS_TOOLTIP2 "Seçim"

--- a/base/applications/mspaint/lang/uk-UA.rc
+++ b/base/applications/mspaint/lang/uk-UA.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Paint для ReactOS"
     IDS_INFOTEXT "Доступний згідно з GNU Lesser General Public License (LGPL, дивіться www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Зберегти зміни до %s?"
-    IDS_DEFAULTFILENAME "Без_імені.bmp"
+    IDS_DEFAULTFILENAME "Без_імені.png"
     IDS_MINIATURETITLE "Мініатюра"
     IDS_TOOLTIP1 "Виділення довільної області"
     IDS_TOOLTIP2 "Виділення"

--- a/base/applications/mspaint/lang/vi-VN.rc
+++ b/base/applications/mspaint/lang/vi-VN.rc
@@ -198,7 +198,7 @@ BEGIN
     IDS_INFOTITLE "Trình Vẽ cho ReactOS"
     IDS_INFOTEXT "Được cung cấp theo điều lệ trong GNU Lesser General Public License (LGPL, xem www.gnu.org)"
     IDS_SAVEPROMPTTEXT "Bạn có muốn lưu lại những thay đổi trong %s?"
-    IDS_DEFAULTFILENAME "Khongten.bmp"
+    IDS_DEFAULTFILENAME "Khongten.png"
     IDS_MINIATURETITLE "Ảnh nhỏ"
     IDS_TOOLTIP1 "Chọn tự do"
     IDS_TOOLTIP2 "Chọn"

--- a/base/applications/mspaint/lang/zh-CN.rc
+++ b/base/applications/mspaint/lang/zh-CN.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS 画图"
     IDS_INFOTEXT "GNU LGPL 许可证下发布的 (详见 www.gnu.org)"
     IDS_SAVEPROMPTTEXT "您想把改变保存到 %s 吗？"
-    IDS_DEFAULTFILENAME "未命名.bmp"
+    IDS_DEFAULTFILENAME "未命名.png"
     IDS_MINIATURETITLE "缩略图"
     IDS_TOOLTIP1 "自由选择"
     IDS_TOOLTIP2 "选择"

--- a/base/applications/mspaint/lang/zh-TW.rc
+++ b/base/applications/mspaint/lang/zh-TW.rc
@@ -199,7 +199,7 @@ BEGIN
     IDS_INFOTITLE "ReactOS 畫圖"
     IDS_INFOTEXT "GNU LGPL 下發佈的 (詳見 www.gnu.org)"
     IDS_SAVEPROMPTTEXT "您想把變更儲存到 %s 嗎？"
-    IDS_DEFAULTFILENAME "未命名.bmp"
+    IDS_DEFAULTFILENAME "未命名.png"
     IDS_MINIATURETITLE "縮圖"
     IDS_TOOLTIP1 "自由選擇"
     IDS_TOOLTIP2 "選擇"

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -304,7 +304,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     // Choose PNG
     for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
     {
-        if (IsEqualIID(aguidFileTypesE[i], Gdiplus::ImageFormatPNG))
+        if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)
         {
             sfn.nFilterIndex = i + 1;
             break;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -264,7 +264,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     choosecolor.lpCustColors   = custColors;
 
     /* initializing the OPENFILENAME structure for use with GetOpenFileName and GetSaveFileName */
-    CopyMemory(ofnFilename, filepathname, sizeof(filepathname));
+    ofnFilename[0] = 0;
     CString strImporters;
     CSimpleArray<GUID> aguidFileTypesI;
     CString strAllPictureFiles;
@@ -283,7 +283,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     ofn.lpstrFileTitle = ofnFiletitle;
     ofn.nMaxFileTitle  = SIZEOF(ofnFiletitle);
     ofn.Flags          = OFN_EXPLORER | OFN_HIDEREADONLY;
-    ofn.lpstrDefExt    = L"bmp";
+    ofn.lpstrDefExt    = L"png";
 
     CopyMemory(sfnFilename, filepathname, sizeof(filepathname));
     CString strExporters;
@@ -300,7 +300,16 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     sfn.nMaxFileTitle  = SIZEOF(sfnFiletitle);
     sfn.Flags          = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLEHOOK;
     sfn.lpfnHook       = OFNHookProc;
-    sfn.lpstrDefExt    = L"bmp";
+    sfn.lpstrDefExt    = L"png";
+    // Choose PNG
+    for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
+    {
+        if (IsEqualIID(aguidFileTypesE[i], Gdiplus::ImageFormatPNG))
+        {
+            sfn.nFilterIndex = i + 1;
+            break;
+        }
+    }
 
     /* creating the size boxes */
     RECT sizeboxPos = {0, 0, 0 + 3, 0 + 3};


### PR DESCRIPTION
## Purpose

BMP is obsolete. We will use PNG as default.

JIRA issue: N/A

## Proposed changes

- Make `IDS_DEFAULTFILENAME` resource strings PNG extension.
- Choose PNG on `GetSaveFileName`.
- Clear the filename on `GetOpenFileName`.

## TODO

- [x] Do tests.

## Screenshot
![after](https://user-images.githubusercontent.com/2107452/147357031-a28d1068-e387-412c-ba3e-1a3c2c1dce00.png)