### PR TITLE
[I8042PRT] Add Dell Latitude D820 to the hack list

### DIFF
--- a/drivers/input/i8042prt/hwhacks.c
+++ b/drivers/input/i8042prt/hwhacks.c
@@ -49,6 +49,7 @@ const HARDWARE_TABLE i8042HardwareTable[] =
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D620                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D630                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D810                   "}}, FL_INITHACK },
+    { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D820                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude E4300                  "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude E4310                  "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude E6400                  "}}, FL_INITHACK },


### PR DESCRIPTION
## Purpose

Fixes the Dell Latitude D820 TouchPad not working

## Proposed changes

Add the Dell Latitude D820 string to `i8042HardwareTable`