### PR TITLE
[MSPAINT] Fix the size of settings if too large

### DIFF
--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -104,12 +104,11 @@ void RegistrySettings::Load()
         ReadFileHistory(files, _T("File4"), strFile4);
     }
 
-    if (BMPWidth > 4096 || BMPHeight > 2304)
-    {
-        // Too large. Fix it.
-        BMPWidth = 400;
-        BMPHeight = 300;
-    }
+    // Fix the bitmap size if too large
+    if (BMPHeight > 5000)
+        BMPHeight = 460;
+    if (BMPWidth > 5000)
+        BMPWidth = 819;
 }
 
 void RegistrySettings::Store()

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -103,6 +103,13 @@ void RegistrySettings::Load()
         ReadFileHistory(files, _T("File3"), strFile3);
         ReadFileHistory(files, _T("File4"), strFile4);
     }
+
+    if (BMPWidth > 4096 || BMPHeight > 2304)
+    {
+        // Too large. Fix it.
+        BMPWidth = 400;
+        BMPHeight = 300;
+    }
 }
 
 void RegistrySettings::Store()

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -50,8 +50,8 @@ void RegistrySettings::SetWallpaper(LPCTSTR szFileName, RegistrySettings::Wallpa
 
 void RegistrySettings::LoadPresets()
 {
-    BMPHeight = 300;
-    BMPWidth = 400;
+    BMPHeight = GetSystemMetrics(SM_CYSCREEN) / 2
+    BMPWidth = GetSystemMetrics(SM_CXSCREEN) / 2;
     GridExtent = 1;
     NoStretching = 0;
     ShowThumbnail = 0;
@@ -105,10 +105,10 @@ void RegistrySettings::Load()
     }
 
     // Fix the bitmap size if too large
-    if (BMPHeight > 5000)
-        BMPHeight = 460;
     if (BMPWidth > 5000)
-        BMPWidth = 819;
+        BMPWidth = (GetSystemMetrics(SM_CXSCREEN) * 6) / 10;
+    if (BMPHeight > 5000)
+        BMPHeight = (GetSystemMetrics(SM_CYSCREEN) * 6) / 10;
 }
 
 void RegistrySettings::Store()

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -50,7 +50,7 @@ void RegistrySettings::SetWallpaper(LPCTSTR szFileName, RegistrySettings::Wallpa
 
 void RegistrySettings::LoadPresets()
 {
-    BMPHeight = GetSystemMetrics(SM_CYSCREEN) / 2
+    BMPHeight = GetSystemMetrics(SM_CYSCREEN) / 2;
     BMPWidth = GetSystemMetrics(SM_CXSCREEN) / 2;
     GridExtent = 1;
     NoStretching = 0;


### PR DESCRIPTION
## Purpose

If the bitmap size from the registry settings is too large, we should fix it.
JIRA issue: N/A

## Proposed changes

- Fix the initial values of `BMPHeight` and `BMPWidth`.
- Fix the values of `BMPHeight` and `BMPWidth` if too large.