### PR TITLE
[MSPAINT] Define GRIP_SIZE macro and use it

### DIFF
--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -23,3 +23,5 @@ static inline int UnZoomed(int xy)
 {
     return xy * 1000 / toolsModel.GetZoom();
 }
+
+#define GRIP_SIZE 3

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -24,4 +24,4 @@ static inline int UnZoomed(int xy)
     return xy * 1000 / toolsModel.GetZoom();
 }
 
-#define GRIP_SIZE 3
+#define GRIP_SIZE 8

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -24,4 +24,4 @@ static inline int UnZoomed(int xy)
     return xy * 1000 / toolsModel.GetZoom();
 }
 
-#define GRIP_SIZE 4
+#define GRIP_SIZE 3

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -24,4 +24,4 @@ static inline int UnZoomed(int xy)
     return xy * 1000 / toolsModel.GetZoom();
 }
 
-#define GRIP_SIZE 8
+#define GRIP_SIZE 4

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -76,24 +76,24 @@ LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                0,
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterTop.MoveWindow(
-               GRIP_SIZE + Zoomed(imgXRes - GRIP_SIZE) / 2,
+               GRIP_SIZE + (Zoomed(imgXRes) - GRIP_SIZE) / 2,
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightTop.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes),
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftCenter.MoveWindow(
                0,
-               GRIP_SIZE + Zoomed(imgYRes - GRIP_SIZE) / 2,
+               GRIP_SIZE + (Zoomed(imgYRes) - GRIP_SIZE) / 2,
                GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightCenter.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes),
-               GRIP_SIZE + Zoomed(imgYRes - GRIP_SIZE) / 2,
+               GRIP_SIZE + (Zoomed(imgYRes) - GRIP_SIZE) / 2,
                GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftBottom.MoveWindow(
                0,
                GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterBottom.MoveWindow(
-               GRIP_SIZE + Zoomed(imgXRes - GRIP_SIZE) / 2,
+               GRIP_SIZE + (Zoomed(imgXRes) - GRIP_SIZE) / 2,
                GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightBottom.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes),

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -76,26 +76,28 @@ LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                0,
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterTop.MoveWindow(
-               Zoomed(imgXRes) / 2 + 3 * 3 / 4,
+               GRIP_SIZE + Zoomed(imgXRes - GRIP_SIZE) / 2,
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightTop.MoveWindow(
-               Zoomed(imgXRes) + GRIP_SIZE,
+               GRIP_SIZE + Zoomed(imgXRes),
                0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftCenter.MoveWindow(
                0,
-               Zoomed(imgYRes) / 2 + 3 * 3 / 4, GRIP_SIZE, GRIP_SIZE, TRUE);
+               GRIP_SIZE + Zoomed(imgYRes - GRIP_SIZE) / 2,
+               GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightCenter.MoveWindow(
-               Zoomed(imgXRes) + GRIP_SIZE,
-               Zoomed(imgYRes) / 2 + 3 * 3 / 4, GRIP_SIZE, GRIP_SIZE, TRUE);
+               GRIP_SIZE + Zoomed(imgXRes),
+               GRIP_SIZE + Zoomed(imgYRes - GRIP_SIZE) / 2,
+               GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftBottom.MoveWindow(
                0,
                Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterBottom.MoveWindow(
-               Zoomed(imgXRes) / 2 + 3 * 3 / 4,
+               GRIP_SIZE + Zoomed(imgXRes - GRIP_SIZE) / 2,
                Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightBottom.MoveWindow(
-               Zoomed(imgXRes) + GRIP_SIZE,
-               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
+               GRIP_SIZE + Zoomed(imgXRes),
+               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
     UpdateScrollbox();
     return 0;
 }

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -91,10 +91,10 @@ LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftBottom.MoveWindow(
                0,
-               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
+               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterBottom.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes - GRIP_SIZE) / 2,
-               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
+               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightBottom.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes),
                GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -23,7 +23,7 @@ updateCanvasAndScrollbars()
 
     int zoomedWidth = Zoomed(imageModel.GetWidth());
     int zoomedHeight = Zoomed(imageModel.GetHeight());
-    imageArea.MoveWindow(3, 3, zoomedWidth, zoomedHeight, FALSE);
+    imageArea.MoveWindow(GRIP_SIZE, GRIP_SIZE, zoomedWidth, zoomedHeight, FALSE);
 
     scrollboxWindow.Invalidate(TRUE);
     imageArea.Invalidate(FALSE);
@@ -74,28 +74,28 @@ LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
     int imgYRes = imageModel.GetHeight();
     sizeboxLeftTop.MoveWindow(
                0,
-               0, 3, 3, TRUE);
+               0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterTop.MoveWindow(
                Zoomed(imgXRes) / 2 + 3 * 3 / 4,
-               0, 3, 3, TRUE);
+               0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightTop.MoveWindow(
-               Zoomed(imgXRes) + 3,
-               0, 3, 3, TRUE);
+               Zoomed(imgXRes) + GRIP_SIZE,
+               0, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftCenter.MoveWindow(
                0,
-               Zoomed(imgYRes) / 2 + 3 * 3 / 4, 3, 3, TRUE);
+               Zoomed(imgYRes) / 2 + 3 * 3 / 4, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightCenter.MoveWindow(
-               Zoomed(imgXRes) + 3,
-               Zoomed(imgYRes) / 2 + 3 * 3 / 4, 3, 3, TRUE);
+               Zoomed(imgXRes) + GRIP_SIZE,
+               Zoomed(imgYRes) / 2 + 3 * 3 / 4, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxLeftBottom.MoveWindow(
                0,
-               Zoomed(imgYRes) + 3, 3, 3, TRUE);
+               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxCenterBottom.MoveWindow(
                Zoomed(imgXRes) / 2 + 3 * 3 / 4,
-               Zoomed(imgYRes) + 3, 3, 3, TRUE);
+               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
     sizeboxRightBottom.MoveWindow(
-               Zoomed(imgXRes) + 3,
-               Zoomed(imgYRes) + 3, 3, 3, TRUE);
+               Zoomed(imgXRes) + GRIP_SIZE,
+               Zoomed(imgYRes) + GRIP_SIZE, GRIP_SIZE, GRIP_SIZE, TRUE);
     UpdateScrollbox();
     return 0;
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -248,7 +248,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     selectionWindow.Create(scrlClientWindow.m_hWnd, selectionWindowPos, NULL, WS_CHILD | BS_OWNERDRAW);
 
     /* creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn */
-    RECT imageAreaPos = {3, 3, 3 + imageModel.GetWidth(), 3 + imageModel.GetHeight()};
+    RECT imageAreaPos = {GRIP_SIZE, GRIP_SIZE, GRIP_SIZE + imageModel.GetWidth(), GRIP_SIZE + imageModel.GetHeight()};
     imageArea.Create(scrlClientWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
 
     if (__argc >= 2)
@@ -312,7 +312,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     }
 
     /* creating the size boxes */
-    RECT sizeboxPos = {0, 0, 0 + 3, 0 + 3};
+    RECT sizeboxPos = {0, 0, GRIP_SIZE, GRIP_SIZE};
     sizeboxLeftTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
     sizeboxCenterTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
     sizeboxRightTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -322,7 +322,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     sizeboxCenterBottom.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
     sizeboxRightBottom.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
     /* placing the size boxes around the image */
-    imageArea.SendMessage(WM_SIZE, 0, 0);
+    imageArea.PostMessage(WM_SIZE, 0, 0);
 
     /* by moving the window, the things in WM_SIZE are done */
     mainWindow.SetWindowPlacement(&(registrySettings.WindowPlacement));

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -16,7 +16,8 @@ void
 placeSelWin()
 {
     selectionWindow.MoveWindow(Zoomed(selectionModel.GetDestRectLeft()), Zoomed(selectionModel.GetDestRectTop()),
-        Zoomed(selectionModel.GetDestRectWidth()) + 6, Zoomed(selectionModel.GetDestRectHeight()) + 6, TRUE);
+        Zoomed(selectionModel.GetDestRectWidth()) + 2 * GRIP_SIZE,
+        Zoomed(selectionModel.GetDestRectHeight()) + 2 * GRIP_SIZE, TRUE);
     selectionWindow.BringWindowToTop();
     imageArea.InvalidateRect(NULL, FALSE);
 }

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -52,8 +52,6 @@ CONST INT VSCROLL_WIDTH = ::GetSystemMetrics(SM_CXVSCROLL);
 void
 UpdateScrollbox()
 {
-    CONST INT EXTRASIZE = 5; /* 3 px of selection markers + 2 px of border */
-
     CRect tempRect;
     CSize sizeImageArea;
     CSize sizeScrollBox;
@@ -65,7 +63,7 @@ UpdateScrollbox()
 
     imageArea.GetClientRect(&tempRect);
     sizeImageArea = CSize(tempRect.Width(), tempRect.Height());
-    sizeImageArea += CSize(EXTRASIZE * 2, EXTRASIZE * 2);
+    sizeImageArea += CSize(GRIP_SIZE * 2, GRIP_SIZE * 2);
 
     /* show/hide the scrollbars */
     vmode = (sizeScrollBox.cy < sizeImageArea.cy ? 0 :

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -132,8 +132,9 @@ LRESULT CScrollboxWindow::OnHScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         }
         scrollboxWindow.SetScrollInfo(SB_HORZ, &si);
         scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
-                   -scrollboxWindow.GetScrollPos(SB_VERT), Zoomed(imageModel.GetWidth()) + 6,
-                   Zoomed(imageModel.GetHeight()) + 6, TRUE);
+                   -scrollboxWindow.GetScrollPos(SB_VERT),
+                   Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
+                   Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
     }
     return 0;
 }
@@ -167,8 +168,9 @@ LRESULT CScrollboxWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
         }
         scrollboxWindow.SetScrollInfo(SB_VERT, &si);
         scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
-                   -scrollboxWindow.GetScrollPos(SB_VERT), Zoomed(imageModel.GetWidth()) + 6,
-                   Zoomed(imageModel.GetHeight()) + 6, TRUE);
+                   -scrollboxWindow.GetScrollPos(SB_VERT),
+                   Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
+                   Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
     }
     return 0;
 }

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -65,31 +65,24 @@ ForceRefreshSelectionContents()
 
 int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeight)
 {
-    if (iYPos < GRIP_SIZE)
-    {
-        if (iXPos < GRIP_SIZE)
-            return ACTION_RESIZE_TOP_LEFT;
-        if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
-            return ACTION_RESIZE_TOP;
-        if (iWidth - GRIP_SIZE <= iXPos)
-            return ACTION_RESIZE_TOP_RIGHT;
-    }
-    if ((iHeight / 2 - 1 <= iYPos) && (iYPos < iHeight / 2 + 2))
-    {
-        if (iXPos < GRIP_SIZE)
-            return ACTION_RESIZE_LEFT;
-        if (iWidth - GRIP_SIZE <= iXPos)
-            return ACTION_RESIZE_RIGHT;
-    }
-    if (iYPos >= iHeight - GRIP_SIZE)
-    {
-        if (iXPos < GRIP_SIZE)
-            return ACTION_RESIZE_BOTTOM_LEFT;
-        if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
-            return ACTION_RESIZE_BOTTOM;
-        if (iWidth - GRIP_SIZE <= iXPos)
-            return ACTION_RESIZE_BOTTOM_RIGHT;
-    }
+    POINT pt = { iXPos, iYPos };
+    HWND hwndChild = ChildWindowFromPointEx(pt, CWP_SKIPINVISIBLE | CWP_SKIPDISABLED);
+    if (hwndChild == sizeboxLeftTop)
+        return ACTION_RESIZE_TOP_LEFT;
+    if (hwndChild == sizeboxCenterTop)
+        return ACTION_RESIZE_TOP;
+    if (hwndChild == sizeboxRightTop)
+        return ACTION_RESIZE_TOP_RIGHT;
+    if (hwndChild == sizeboxRightCenter)
+        return ACTION_RESIZE_RIGHT;
+    if (hwndChild == sizeboxLeftCenter)
+        return ACTION_RESIZE_LEFT;
+    if (hwndChild == sizeboxCenterBottom)
+        return ACTION_RESIZE_BOTTOM;
+    if (hwndChild == sizeboxRightBottom)
+        return ACTION_RESIZE_BOTTOM_RIGHT;
+    if (hwndChild == sizeboxLeftBottom)
+        return ACTION_RESIZE_BOTTOM_LEFT;
     return 0;
 }
 

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -65,29 +65,29 @@ ForceRefreshSelectionContents()
 
 int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeight)
 {
-    if (iYPos < 3)
+    if (iYPos < GRIP_SIZE)
     {
-        if (iXPos < 3)
+        if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_TOP_LEFT;
         if ((iXPos < iWidth / 2 + 2) && (iXPos >= iWidth / 2 - 1))
             return ACTION_RESIZE_TOP;
-        if (iXPos >= iWidth - 3)
+        if (iXPos >= iWidth - GRIP_SIZE)
             return ACTION_RESIZE_TOP_RIGHT;
     }
     if ((iYPos < iHeight / 2 + 2) && (iYPos >= iHeight / 2 - 1))
     {
-        if (iXPos < 3)
+        if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_LEFT;
-        if (iXPos >= iWidth - 3)
+        if (iXPos >= iWidth - GRIP_SIZE)
             return ACTION_RESIZE_RIGHT;
     }
-    if (iYPos >= iHeight - 3)
+    if (iYPos >= iHeight - GRIP_SIZE)
     {
-        if (iXPos < 3)
+        if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_BOTTOM_LEFT;
         if ((iXPos < iWidth / 2 + 2) && (iXPos >= iWidth / 2 - 1))
             return ACTION_RESIZE_BOTTOM;
-        if (iXPos >= iWidth - 3)
+        if (iXPos >= iWidth - GRIP_SIZE)
             return ACTION_RESIZE_BOTTOM_RIGHT;
     }
     return 0;

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -197,8 +197,8 @@ LRESULT CSelectionWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, B
     }
     else
     {
-        int w = Zoomed(selectionModel.GetDestRectWidth()) + 6;
-        int h = Zoomed(selectionModel.GetDestRectHeight()) + 6;
+        int w = Zoomed(selectionModel.GetDestRectWidth()) + 2 * GRIP_SIZE;
+        int h = Zoomed(selectionModel.GetDestRectHeight()) + 2 * GRIP_SIZE;
         m_ptPos.x = GET_X_LPARAM(lParam);
         m_ptPos.y = GET_Y_LPARAM(lParam);
         SendMessage(hStatusBar, SB_SETTEXT, 2, (LPARAM) NULL);

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -69,12 +69,12 @@ int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeig
     {
         if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_TOP_LEFT;
-        if ((iXPos < iWidth / 2 + 2) && (iXPos >= iWidth / 2 - 1))
+        if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
             return ACTION_RESIZE_TOP;
         if (iXPos >= iWidth - GRIP_SIZE)
             return ACTION_RESIZE_TOP_RIGHT;
     }
-    if ((iYPos < iHeight / 2 + 2) && (iYPos >= iHeight / 2 - 1))
+    if ((iHeight / 2 - 1 <= iYPos) && (iYPos < iHeight / 2 + 2))
     {
         if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_LEFT;
@@ -85,7 +85,7 @@ int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeig
     {
         if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_BOTTOM_LEFT;
-        if ((iXPos < iWidth / 2 + 2) && (iXPos >= iWidth / 2 - 1))
+        if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
             return ACTION_RESIZE_BOTTOM;
         if (iXPos >= iWidth - GRIP_SIZE)
             return ACTION_RESIZE_BOTTOM_RIGHT;

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -71,14 +71,14 @@ int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeig
             return ACTION_RESIZE_TOP_LEFT;
         if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
             return ACTION_RESIZE_TOP;
-        if (iXPos >= iWidth - GRIP_SIZE)
+        if (iWidth - GRIP_SIZE <= iXPos)
             return ACTION_RESIZE_TOP_RIGHT;
     }
     if ((iHeight / 2 - 1 <= iYPos) && (iYPos < iHeight / 2 + 2))
     {
         if (iXPos < GRIP_SIZE)
             return ACTION_RESIZE_LEFT;
-        if (iXPos >= iWidth - GRIP_SIZE)
+        if (iWidth - GRIP_SIZE <= iXPos)
             return ACTION_RESIZE_RIGHT;
     }
     if (iYPos >= iHeight - GRIP_SIZE)
@@ -87,7 +87,7 @@ int CSelectionWindow::IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeig
             return ACTION_RESIZE_BOTTOM_LEFT;
         if ((iWidth / 2 - 1 <= iXPos) && (iXPos < iWidth / 2 + 2))
             return ACTION_RESIZE_BOTTOM;
-        if (iXPos >= iWidth - GRIP_SIZE)
+        if (iWidth - GRIP_SIZE <= iXPos)
             return ACTION_RESIZE_BOTTOM_RIGHT;
     }
     return 0;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -39,7 +39,7 @@ zoomTo(int newZoom, int mouseX, int mouseY)
     toolsModel.SetZoom(newZoom);
 
     selectionWindow.ShowWindow(SW_HIDE);
-    imageArea.MoveWindow(3, 3, Zoomed(imageModel.GetWidth()), Zoomed(imageModel.GetHeight()), FALSE);
+    imageArea.MoveWindow(GRIP_SIZE, GRIP_SIZE, Zoomed(imageModel.GetWidth()), Zoomed(imageModel.GetHeight()), FALSE);
     scrollboxWindow.Invalidate(TRUE);
     imageArea.Invalidate(FALSE);
 


### PR DESCRIPTION
## Purpose
Reduce magic numbers.
JIRA issue: [CORE-17931](https://jira.reactos.org/browse/CORE-17931)

## Proposed changes

- Define `GRIP_SIZE` macro (its value is `3`) in `common.h`.
- Use it.

## Screenshot

![image](https://user-images.githubusercontent.com/2107452/147410398-8b15ed64-c30c-41d0-ab0c-70ee25e6de56.png)