### PR TITLE
[NTOSKRNL] Regroup the pool allocation tags in one dedicated place

### DIFF
--- a/ntoskrnl/dbgk/dbgkobj.c
+++ b/ntoskrnl/dbgk/dbgkobj.c
@@ -59,7 +59,7 @@ DbgkpQueueMessage(IN PEPROCESS Process,
         /* Allocate it */
         DebugEvent = ExAllocatePoolWithTag(NonPagedPool,
                                            sizeof(DEBUG_EVENT),
-                                           'EgbD');
+                                           TAG_DEBUG_EVENT);
         if (!DebugEvent) return STATUS_INSUFFICIENT_RESOURCES;
 
         /* Set flags */
@@ -192,7 +192,7 @@ DbgkpQueueMessage(IN PEPROCESS Process,
             ObDereferenceObject(Process);
 
             /* Free the debug event */
-            ExFreePoolWithTag(DebugEvent, 'EgbD');
+            ExFreePoolWithTag(DebugEvent, TAG_DEBUG_EVENT);
         }
     }
 
@@ -418,7 +418,7 @@ DbgkpFreeDebugEvent(IN PDEBUG_EVENT DebugEvent)
     /* Dereference process and thread and free the event */
     ObDereferenceObject(DebugEvent->Process);
     ObDereferenceObject(DebugEvent->Thread);
-    ExFreePoolWithTag(DebugEvent, 'EgbD');
+    ExFreePoolWithTag(DebugEvent, TAG_DEBUG_EVENT);
 }
 
 VOID

--- a/ntoskrnl/ex/atom.c
+++ b/ntoskrnl/ex/atom.c
@@ -13,8 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define TAG_ATOM 'motA'
-
 /* GLOBALS ****************************************************************/
 
 /*

--- a/ntoskrnl/ex/harderr.c
+++ b/ntoskrnl/ex/harderr.c
@@ -12,8 +12,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define TAG_ERR ' rrE'
-
 /* GLOBALS ******************************************************************/
 
 BOOLEAN ExReadyForErrors = FALSE;

--- a/ntoskrnl/ex/profile.c
+++ b/ntoskrnl/ex/profile.c
@@ -13,8 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define TAG_PROFILE 'forP'
-
 /* GLOBALS *******************************************************************/
 
 POBJECT_TYPE ExProfileObjectType = NULL;

--- a/ntoskrnl/fsrtl/filelock.c
+++ b/ntoskrnl/fsrtl/filelock.c
@@ -51,10 +51,6 @@ typedef struct _LOCK_SHARED_RANGE
 }
     LOCK_SHARED_RANGE, *PLOCK_SHARED_RANGE;
 
-#define TAG_TABLE 'BATL'
-#define TAG_RANGE 'ARSF'
-#define TAG_FLOCK 'KCLF'
-
 /* PRIVATE FUNCTIONS *********************************************************/
 
 VOID

--- a/ntoskrnl/fsrtl/oplock.c
+++ b/ntoskrnl/fsrtl/oplock.c
@@ -27,8 +27,6 @@
 #define BROKEN_TO_CLOSE_PENDING     0x800
 #define BROKEN_ANY                  (BROKEN_TO_LEVEL_2 | BROKEN_TO_NONE  | BROKEN_TO_NONE_FROM_LEVEL_2 | BROKEN_TO_CLOSE_PENDING)
 
-#define TAG_OPLOCK 'orSF'
-
 typedef struct _INTERNAL_OPLOCK
 {
     /* Level I IRP */

--- a/ntoskrnl/inbv/inbv.c
+++ b/ntoskrnl/inbv/inbv.c
@@ -11,10 +11,6 @@
 #define MM_READONLY     1   // PAGE_READONLY
 #define MM_READWRITE    4   // PAGE_WRITECOPY
 
-#ifndef TAG_OSTR
-#define TAG_OSTR    'RTSO'
-#endif
-
 /* GLOBALS *******************************************************************/
 
 /*

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -1,3 +1,13 @@
+/*
+ * PROJECT:         ReactOS Kernel
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         ReactOS NT kernel pool allocation tags
+ * COPYRIGHT:       Copyright 2005 Steven Edwards <sedwards@reactos.com>
+ *                  Copyright 2006 Alex Ionescu <alex.ionescu@reactos.org>
+ *                  Copyright 2015 Thomas Faber <thomas.faber@reactos.org>
+ *                  Copyright 2021 George Bișoc <george.bisoc@reactos.org>
+ */
+
 #pragma once
 
 /* Cache Manager Tags */
@@ -7,167 +17,128 @@
 #define TAG_PRIVATE_CACHE_MAP   'cPcC'
 #define TAG_BCB                 'cBcC'
 
-/* Executive Callbacks */
+/* Executive Tags */
 #define TAG_CALLBACK_ROUTINE_BLOCK 'brbC'
 #define TAG_CALLBACK_REGISTRATION  'eRBC'
+#define TAG_RESOURCE_TABLE         'aTeR'
+#define TAG_RESOURCE_EVENT         'aTeR'
+#define TAG_RESOURCE_SEMAPHORE     'aTeR'
+#define TAG_OBJECT_TABLE           'btbO'
+#define TAG_INIT                   'tinI'
+#define TAG_RTLI                   'iltR'
+#define TAG_ATOM                   'motA'
+#define TAG_PROFILE                'forP'
+#define TAG_ERR                    ' rrE'
 
-/* formely located in dbg/dbgkobj.c */
-#define TAG_DEBUG_EVENT     'EgbD'
+/* User Mode Debugging Manager Tag */
+#define TAG_DEBUG_EVENT 'EgbD'
 
-/* formerly located in ex/resource.c */
-#define TAG_RESOURCE_TABLE      'aTeR'
-#define TAG_RESOURCE_EVENT      'aTeR'
-#define TAG_RESOURCE_SEMAPHORE  'aTeR'
+/* Kernel Debugger Tags */
+#define TAG_KDBS 'SBDK'
+#define TAG_KDBG 'GBDK'
 
-/* formerly located in ex/handle.c */
-#define TAG_OBJECT_TABLE 'btbO'
+/* Kernel Tags */
+#define TAG_KNMI    'IMNK'
+#define TAG_KERNEL  '  eK'
 
-/* formerly located in ex/init.c */
-#define TAG_INIT 'tinI'
-#define TAG_RTLI 'iltR'
+/* File-System Run-Time Library Tags */
+#define TAG_UNC    'nuSF'
+#define TAG_TABLE  'BATL'
+#define TAG_RANGE  'ARSF'
+#define TAG_FLOCK  'KCLF'
+#define TAG_OPLOCK 'orSF'
 
-/* formerly located in fs/notify.c */
-#define FSRTL_NOTIFY_TAG 'ITON'
-
-/* formerly located in fsrtl/unc.c */
-#define TAG_UNC 'nuSF'
-
-/* formerly located in io/device.c */
+/* I/O Manager Tags */
 #define TAG_DEVICE_EXTENSION   'TXED'
-#define TAG_SHUTDOWN_ENTRY    'TUHS'
-#define TAG_IO_TIMER      'MTOI'
-
-/* formerly located in io/driver.c */
+#define TAG_SHUTDOWN_ENTRY     'TUHS'
+#define TAG_IO_TIMER           'MTOI'
 #define TAG_DRIVER             'RVRD'
 #define TAG_DRIVER_EXTENSION   'EVRD'
+#define TAG_SYSB               'BSYS'
+#define TAG_LOCK               'kclF'
+#define TAG_FILE_NAME          'MANF'
+#define TAG_FILE_SYSTEM        'SYSF'
+#define TAG_FS_CHANGE_NOTIFY   'NCSF'
+#define IFS_POOL_TAG           'trSF'
+#define TAG_FS_NOTIFICATIONS   'NrSF'
+#define IOC_TAG                'TCOI'
+#define TAG_DEVICE_TYPE        'TVED'
+#define TAG_FILE_TYPE          'ELIF'
+#define TAG_ADAPTER_TYPE       'TPDA'
+#define IO_LARGEIRP            'lprI'
+#define IO_SMALLIRP            'sprI'
+#define IO_LARGEIRP_CPU        'LprI'
+#define IO_SMALLIRP_CPU        'SprI'
+#define IOC_TAG1               ' cpI'
+#define IOC_CPU                'PcpI'
+#define TAG_APC                'CPAK'
+#define TAG_IO                 '  oI'
+#define TAG_ERROR_LOG          'rEoI'
+#define TAG_EA                 'aEoI'
+#define TAG_IO_NAME            'mNoI'
+#define TAG_REINIT             'iRoI'
+#define TAG_IOWI               'IWOI'
+#define TAG_IRP                ' prI'
+#define TAG_SYS_BUF            'BSYS'
+#define TAG_KINTERRUPT         'RSIK'
+#define TAG_MDL                ' LDM'
+#define TAG_IO_DEVNODE         'donD'
+#define TAG_PNP_NOTIFY         'NPnP'
+#define TAG_PNP_ROOT           'RPnP'
+#define TAG_IO_RESOURCE        'CRSR'
+#define TAG_IO_TIMER           'MTOI'
+#define TAG_VPB                ' BPV'
+#define TAG_SYSB               'BSYS'
+#define TAG_RTLREGISTRY        'vrqR'
+#define TAG_PNP_DEVACTION      'aDpP'
 
-/* formerly located in io/file.c */
-#define TAG_SYSB        'BSYS'
-#define TAG_LOCK        'kclF'
-#define TAG_FILE_NAME   'MANF'
-
-/* formerly located in io/fs.c */
-#define TAG_FILE_SYSTEM       'SYSF'
-#define TAG_FS_CHANGE_NOTIFY  'NCSF'
-#define IFS_POOL_TAG          'trSF'
-#define TAG_FS_NOTIFICATIONS  'NrSF'
-
-/* formerly located in io/iocomp.c */
-#define IOC_TAG   'TCOI'
-
-/* formerly located in io/iomgr.c */
-#define TAG_DEVICE_TYPE     'TVED'
-#define TAG_FILE_TYPE       'ELIF'
-#define TAG_ADAPTER_TYPE    'TPDA'
-#define IO_LARGEIRP         'lprI'
-#define IO_SMALLIRP         'sprI'
-#define IO_LARGEIRP_CPU     'LprI'
-#define IO_SMALLIRP_CPU     'SprI'
-#define IOC_TAG1            ' cpI'
-#define IOC_CPU             'PcpI'
-#define TAG_APC             'CPAK'
-#define TAG_IO              '  oI'
-#define TAG_ERROR_LOG       'rEoI'
-#define TAG_EA              'aEoI'
-#define TAG_IO_NAME         'mNoI'
-#define TAG_REINIT          'iRoI'
-
-/* formerly located in io/work.c */
-#define TAG_IOWI 'IWOI'
-
-/* formerly located in io/irp.c */
-#define TAG_IRP      ' prI'
-#define TAG_SYS_BUF  'BSYS'
-
-/* formerly located in io/irq.c */
-#define TAG_KINTERRUPT   'RSIK'
-
-/* formerly located in io/mdl.c */
-#define TAG_MDL    ' LDM'
-
-/* formerly located in io/pnpmgr.c */
-#define TAG_IO_DEVNODE 'donD'
-
-/* formerly located in io/pnpnotify.c */
-#define TAG_PNP_NOTIFY  'NPnP'
-
-/* for io/pnproot.c */
-#define TAG_PNP_ROOT    'RPnP'
-
-/* formerly located in io/resource.c */
-#define TAG_IO_RESOURCE    'CRSR'
-
-/* formerly located in io/timer.c */
-#define TAG_IO_TIMER      'MTOI'
-
-/* formerly located in io/vpb.c */
-#define TAG_VPB    ' BPV'
-#define TAG_SYSB   'BSYS'
-
-/* formerly located in ldr/loader.c */
-#define TAG_DRIVER_MEM  'MVRD' /* drvm */
+/* Loader Related Tags */
 #define TAG_MODULE_OBJECT 'omlk' /* klmo - kernel ldr module object */
-#define TAG_LDR_WSTR 'swlk' /* klws - kernel ldr wide string */
-#define TAG_LDR_IMPORTS 'milk' /* klim - kernel ldr imports */
+#define TAG_LDR_WSTR      'swlk' /* klws - kernel ldr wide string */
+#define TAG_LDR_IMPORTS   'milk' /* klim - kernel ldr imports */
 
-/* formerly located in lpc/connect */
-#define TAG_LPC_CONNECT_MESSAGE   'CCPL'
-
-/* formerly located in mm/aspace.c */
-#define TAG_PTRC      'CRTP'
-
-/* formerly located in mm/marea.c */
-#define TAG_MAREA   'ERAM'
-#define TAG_MVAD    'VADM'
-
-/* formerly located in mm/pageop.c */
-#define TAG_MM_PAGEOP   'POPM'
-
-/* formerly located in mm/pool.c */
-#define TAG_NONE 'enoN'
-
-/* formerly located in mm/region.c */
-#define TAG_MM_REGION    'NGRM'
-
-/* formerly located in mm/rmap.c */
-#define TAG_RMAP    'PAMR'
-
-/* formerly located in mm/ARM3/section.c */
-#define TAG_MM      '  mM'
-
-/* formerly located in mm/section.c */
+/* Memory Manager Tags */
+#define TAG_PTRC                 'CRTP'
+#define TAG_MAREA                'ERAM'
+#define TAG_MVAD                 'VADM'
+#define TAG_MM_PAGEOP            'POPM'
+#define TAG_NONE                 'enoN'
+#define TAG_MM_REGION            'NGRM'
+#define TAG_RMAP                 'PAMR'
+#define TAG_MM                   '  mM'
 #define TAG_MM_SECTION_SEGMENT   'SSMM'
 #define TAG_SECTION_PAGE_TABLE   'TPSM'
-
-/* formerly located in ob/symlink.c */
-#define TAG_OBJECT_TYPE         'TjbO'
-#define TAG_SYMLINK_TTARGET     'TTYS'
-#define TAG_SYMLINK_TARGET      'TMYS'
-
-/* formerly located in ob/obsdcach.c */
-#define TAG_OB_SD_CACHE         'cSbO'
 
 /* Object Manager Tags */
 #define OB_NAME_TAG             'mNbO'
 #define OB_DIR_TAG              'iDbO'
+#define TAG_WAIT                'tiaW'
+#define TAG_SEC_QUERY           'qSbO'
+#define TAG_OBJECT_TYPE         'TjbO'
+#define TAG_SYMLINK_TTARGET     'TTYS'
+#define TAG_SYMLINK_TARGET      'TMYS'
+#define TAG_OB_SD_CACHE         'cSbO'
+#define TAG_OB_HANDLE           'dHbO'
 
+/* Power Manager Tag */
+#define TAG_PO_DOPE 'EPOD'
 
-/* formerly located in ps/cid.c */
-#define TAG_CIDOBJECT 'ODIC'
+/* Process Manager Tags */
+#define TAG_CIDOBJECT           'ODIC'
 #define TAG_PS_IMPERSONATION    'mIsP'
+#define TAG_EJOB                'BOJE' /* EJOB */
+#define TAG_TERMINATE_APC       'CPAT'
+#define TAG_KAPC                'papk' /* kpap - kernel ps apc */
+#define TAG_PS_APC              'pasP' /* Psap - Ps APC */
+#define TAG_SHIM                'MIHS'
 
-/* formerly located in ps/job.c */
-#define TAG_EJOB 'BOJE' /* EJOB */
-
-/* formerly located in ps/kill.c */
-#define TAG_TERMINATE_APC   'CPAT'
-
-/* formerly located in ps/notify.c */
-#define TAG_KAPC 'papk' /* kpap - kernel ps apc */
-#define TAG_PS_APC 'pasP' /* Psap - Ps APC */
-
-/* formerly located in rtl/handle.c */
+/* Run-Time Library Tags */
 #define TAG_HDTB  'BTDH'
+#define TAG_ATMT  'TotA' /* Atom table */
+#define TAG_RTHL  'LHtR' /* Heap Lock */
+#define TAG_USTR  'RTSU'
+#define TAG_ASTR  'RTSA'
+#define TAG_OSTR  'RTSO'
 
 /* Security Manager Tags */
 #define TAG_SE                 '  eS'
@@ -189,11 +160,9 @@
 #define TAG_SID_VALIDATE       'vSeS'
 
 /* LPC Tags */
-#define TAG_LPC_MESSAGE   'McpL'
-#define TAG_LPC_ZONE      'ZcpL'
+#define TAG_LPC_MESSAGE           'McpL'
+#define TAG_LPC_ZONE              'ZcpL'
+#define TAG_LPC_CONNECT_MESSAGE   'CCPL'
 
-#define TAG_WAIT            'tiaW'
-#define TAG_SEC_QUERY       'qSbO'
-
-/* FSTUB */
+/* FSTUB Tag */
 #define TAG_FSTUB 'BtsF'

--- a/ntoskrnl/io/iomgr/driver.c
+++ b/ntoskrnl/io/iomgr/driver.c
@@ -32,8 +32,6 @@ static const WCHAR ServicesKeyName[] = L"\\Registry\\Machine\\System\\CurrentCon
 
 POBJECT_TYPE IoDriverObjectType = NULL;
 
-#define TAG_RTLREGISTRY 'vrqR'
-
 extern BOOLEAN ExpInTextModeSetup;
 extern BOOLEAN PnpSystemInit;
 extern BOOLEAN PnPBootDriversLoaded;

--- a/ntoskrnl/io/pnpmgr/devaction.c
+++ b/ntoskrnl/io/pnpmgr/devaction.c
@@ -50,8 +50,6 @@ KSPIN_LOCK IopDeviceActionLock;
 KEVENT PiEnumerationFinished;
 static const WCHAR ServicesKeyName[] = L"\\Registry\\Machine\\System\\CurrentControlSet\\Services\\";
 
-#define TAG_PNP_DEVACTION 'aDpP'
-
 /* TYPES *********************************************************************/
 
 typedef struct _DEVICE_ACTION_REQUEST

--- a/ntoskrnl/kdbg/kdb.h
+++ b/ntoskrnl/kdbg/kdb.h
@@ -1,12 +1,6 @@
 #pragma once
 #include "internal/kd.h"
 
-/* DEFINES *******************************************************************/
-
-/* formerly located in kdbg/kdb_symbols.c */
-#define TAG_KDBS 'SBDK'
-#define TAG_KDBG 'GBDK'
-
 /* TYPES *********************************************************************/
 
 /* from kdb.c */

--- a/ntoskrnl/ke/bug.c
+++ b/ntoskrnl/ke/bug.c
@@ -28,7 +28,6 @@ ULONG_PTR KiBugCheckData[5];
 
 PKNMI_HANDLER_CALLBACK KiNmiCallbackListHead = NULL;
 KSPIN_LOCK KiNmiCallbackListLock;
-#define TAG_KNMI 'IMNK'
 
 /* Bugzilla Reporting */
 UNICODE_STRING KeRosProcessorName, KeRosBiosDate, KeRosBiosVersion;

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -591,7 +591,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
         /* Allocate the IOPM save area */
         Ki386IopmSaveArea = ExAllocatePoolWithTag(PagedPool,
                                                   IOPM_SIZE,
-                                                  '  eK');
+                                                  TAG_KERNEL);
         if (!Ki386IopmSaveArea)
         {
             /* Bugcheck. We need this for V86/VDM support. */

--- a/ntoskrnl/ke/i386/v86vdm.c
+++ b/ntoskrnl/ke/i386/v86vdm.c
@@ -655,7 +655,7 @@ Ke386CallBios(IN ULONG Int,
     /* Allocate VDM structure */
     VdmProcessObjects = ExAllocatePoolWithTag(NonPagedPool,
                                               sizeof(VDM_PROCESS_OBJECTS),
-                                              '  eK');
+                                              TAG_KERNEL);
     if (!VdmProcessObjects) return STATUS_NO_MEMORY;
 
     /* Set it up */
@@ -694,7 +694,7 @@ Ke386CallBios(IN ULONG Int,
     Context->ContextFlags = CONTEXT_FULL;
 
     /* Free VDM objects */
-    ExFreePoolWithTag(PsGetCurrentProcess()->VdmObjects, '  eK');
+    ExFreePoolWithTag(PsGetCurrentProcess()->VdmObjects, TAG_KERNEL);
     PsGetCurrentProcess()->VdmObjects = NULL;
 
     /* Return status */

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -19,8 +19,6 @@
 
 PHANDLE_TABLE ObpKernelHandleTable = NULL;
 
-#define TAG_OB_HANDLE 'dHbO'
-
 /* PRIVATE FUNCTIONS *********************************************************/
 
 PHANDLE_TABLE

--- a/ntoskrnl/po/povolume.c
+++ b/ntoskrnl/po/povolume.c
@@ -27,8 +27,6 @@ KGUARDED_MUTEX PopVolumeLock;
 LIST_ENTRY PopVolumeDevices;
 KSPIN_LOCK PopDopeGlobalLock;
 
-#define TAG_PO_DOPE 'EPOD'
-
 /* PRIVATE FUNCTIONS *********************************************************/
 
 PDEVICE_OBJECT_POWER_EXTENSION

--- a/ntoskrnl/ps/apphelp.c
+++ b/ntoskrnl/ps/apphelp.c
@@ -39,7 +39,6 @@ static UNICODE_STRING AppCompatCacheValue = RTL_CONSTANT_STRING(L"AppCompatCache
 
 #define EMPTY_SHIM_ENTRY    { { 0 }, { { 0 } }, 0 }
 #define MAX_SHIM_ENTRIES    0x200
-#define TAG_SHIM            'MIHS'
 
 #ifndef INVALID_HANDLE_VALUE
 #define INVALID_HANDLE_VALUE (HANDLE)(-1)

--- a/ntoskrnl/ps/i386/psldt.c
+++ b/ntoskrnl/ps/i386/psldt.c
@@ -34,7 +34,7 @@ PspDeleteVdmObjects(PEPROCESS Process)
     UNIMPLEMENTED;
 
     /* Free VDM objects */
-    ExFreePoolWithTag(Process->VdmObjects, '  eK');
+    ExFreePoolWithTag(Process->VdmObjects, TAG_KERNEL);
     Process->VdmObjects = NULL;
 }
 

--- a/ntoskrnl/rtl/libsupp.c
+++ b/ntoskrnl/rtl/libsupp.c
@@ -13,9 +13,6 @@
 #define NDEBUG
 #include <debug.h>
 
-#define TAG_ATMT 'TotA' /* Atom table */
-#define TAG_RTHL 'LHtR' /* Heap Lock */
-
 extern ULONG NtGlobalFlag;
 
 typedef struct _RTL_RANGE_ENTRY
@@ -114,10 +111,6 @@ RtlpAllocateMemory(ULONG Bytes,
                                  Tag);
 }
 
-
-#define TAG_USTR        'RTSU'
-#define TAG_ASTR        'RTSA'
-#define TAG_OSTR        'RTSO'
 VOID
 NTAPI
 RtlpFreeMemory(PVOID Mem,


### PR DESCRIPTION
We already have a dedicated header file where we store pool allocation tags that are used in NT, called `tag.h`, and yet I still see some tags around the kernel which is annoying and confusing. Everyone who discovers a new pool tag or whatever has to use `tag.h` from now on.