### PR TITLE
[DEVMGR] Ensure clicking on item when opening property sheet

### DIFF
--- a/dll/win32/devmgr/devmgmt/DeviceView.cpp
+++ b/dll/win32/devmgr/devmgmt/DeviceView.cpp
@@ -125,6 +125,27 @@ CDeviceView::OnSize(
 }
 
 LRESULT
+CDeviceView::OnDoubleClick(
+    _In_ LPNMHDR NmHdr
+    )
+{
+    TVHITTESTINFO hitInfo;
+    HTREEITEM hItem;
+
+    GetCursorPos(&hitInfo.pt);
+    ScreenToClient(m_hTreeView, &hitInfo.pt);
+
+    // Check if we are trying to double click an item
+    hItem = TreeView_HitTest(m_hTreeView, &hitInfo);
+    if (hItem != NULL && (hitInfo.flags & (TVHT_ONITEM | TVHT_ONITEMICON)))
+    {
+        DisplayPropertySheet();
+    }
+
+    return 0;
+}
+
+LRESULT
 CDeviceView::OnRightClick(
     _In_ LPNMHDR NmHdr
     )

--- a/dll/win32/devmgr/devmgmt/DeviceView.h
+++ b/dll/win32/devmgr/devmgmt/DeviceView.h
@@ -45,6 +45,10 @@ public:
         _In_ int cy
         );
 
+    LRESULT OnDoubleClick(
+        _In_ LPNMHDR NmHdr
+        );
+
     LRESULT OnRightClick(
         _In_ LPNMHDR NmHdr
         );

--- a/dll/win32/devmgr/devmgmt/MainWindow.cpp
+++ b/dll/win32/devmgr/devmgmt/MainWindow.cpp
@@ -515,7 +515,7 @@ CDeviceManager::OnNotify(_In_ LPARAM lParam)
 
         case NM_DBLCLK:
         {
-            m_DeviceView->DisplayPropertySheet();
+            Ret = m_DeviceView->OnDoubleClick(NmHdr);
             break;
         }
 


### PR DESCRIPTION
## Purpose

_Fix a bug related to the device manager where double clicking anywhere when you have selected an item opens the property sheet_

JIRA issue: [CORE-17207](https://jira.reactos.org/browse/CORE-17207)

## Proposed changes

_Ensure that you are clicking an item when opening the property sheet_
