### PR TITLE
[MSPAINT] Define enum TOOLTYPE and use it

### DIFF
--- a/base/applications/mspaint/definitions.h
+++ b/base/applications/mspaint/definitions.h
@@ -131,24 +131,6 @@
 #define ID_ELLIPSE  614
 #define ID_RRECT    615
 
-/* the following 16 numbers need to be in order, increasing by 1 */
-#define TOOL_FREESEL  1
-#define TOOL_RECTSEL  2
-#define TOOL_RUBBER   3
-#define TOOL_FILL     4
-#define TOOL_COLOR    5
-#define TOOL_ZOOM     6
-#define TOOL_PEN      7
-#define TOOL_BRUSH    8
-#define TOOL_AIRBRUSH 9
-#define TOOL_TEXT     10
-#define TOOL_LINE     11
-#define TOOL_BEZIER   12
-#define TOOL_RECT     13
-#define TOOL_SHAPE    14
-#define TOOL_ELLIPSE  15
-#define TOOL_RRECT    16
-
 #define ID_ACCELERATORS 800
 
 #define IDD_MIRRORROTATE      700

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -275,6 +275,8 @@ LRESULT CImgAreaWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
                 case TOOL_SHAPE: case TOOL_BEZIER:
                     cancelDrawing();
                     break;
+                default:
+                    break;
             }
         }
     }
@@ -369,6 +371,8 @@ LRESULT CImgAreaWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOO
                 SendMessage(hStatusBar, SB_SETTEXT, 1, (LPARAM) (LPCTSTR) strCoord);
                 break;
             }
+            default:
+                break;
         }
         if ((wParam & MK_LBUTTON) != 0)
         {

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -127,6 +127,9 @@ startPaintingL(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
                 pointSP++;
             }
             break;
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+            break;
     }
 }
 
@@ -216,6 +219,10 @@ whilePaintingL(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
             if (GetAsyncKeyState(VK_SHIFT) < 0)
                 regularize(start.x, start.y, x, y);
             RRect(hdc, start.x, start.y, x, y, fg, bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            break;
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
             break;
     }
 
@@ -330,6 +337,12 @@ endPaintingL(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
                 regularize(start.x, start.y, x, y);
             RRect(hdc, start.x, start.y, x, y, fg, bg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
             break;
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+        case TOOL_BRUSH:
+        case TOOL_AIRBRUSH:
+            break;
     }
 }
 
@@ -389,6 +402,10 @@ startPaintingR(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
                 imageModel.CopyPrevious();
                 pointSP++;
             }
+            break;
+        case TOOL_RECTSEL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
             break;
     }
 }
@@ -462,6 +479,13 @@ whilePaintingR(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
                 regularize(start.x, start.y, x, y);
             RRect(hdc, start.x, start.y, x, y, bg, fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
             break;
+        case TOOL_FREESEL:
+        case TOOL_RECTSEL:
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+        case TOOL_TEXT:
+            break;
     }
 
     last.x = x;
@@ -531,6 +555,15 @@ endPaintingR(HDC hdc, LONG x, LONG y, COLORREF fg, COLORREF bg)
             if (GetAsyncKeyState(VK_SHIFT) < 0)
                 regularize(start.x, start.y, x, y);
             RRect(hdc, start.x, start.y, x, y, bg, fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle());
+            break;
+        case TOOL_FREESEL:
+        case TOOL_RECTSEL:
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+        case TOOL_BRUSH:
+        case TOOL_AIRBRUSH:
+        case TOOL_TEXT:
             break;
     }
 }

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -76,52 +76,52 @@ LRESULT CToolBox::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
     switch (LOWORD(wParam))
     {
         case ID_FREESEL:
-            toolsModel.SetActiveTool(1);
+            toolsModel.SetActiveTool(TOOL_FREESEL);
             break;
         case ID_RECTSEL:
-            toolsModel.SetActiveTool(2);
+            toolsModel.SetActiveTool(TOOL_RECTSEL);
             break;
         case ID_RUBBER:
-            toolsModel.SetActiveTool(3);
+            toolsModel.SetActiveTool(TOOL_RUBBER);
             break;
         case ID_FILL:
-            toolsModel.SetActiveTool(4);
+            toolsModel.SetActiveTool(TOOL_FILL);
             break;
         case ID_COLOR:
-            toolsModel.SetActiveTool(5);
+            toolsModel.SetActiveTool(TOOL_COLOR);
             break;
         case ID_ZOOM:
-            toolsModel.SetActiveTool(6);
+            toolsModel.SetActiveTool(TOOL_ZOOM);
             break;
         case ID_PEN:
-            toolsModel.SetActiveTool(7);
+            toolsModel.SetActiveTool(TOOL_PEN);
             break;
         case ID_BRUSH:
-            toolsModel.SetActiveTool(8);
+            toolsModel.SetActiveTool(TOOL_BRUSH);
             break;
         case ID_AIRBRUSH:
-            toolsModel.SetActiveTool(9);
+            toolsModel.SetActiveTool(TOOL_AIRBRUSH);
             break;
         case ID_TEXT:
-            toolsModel.SetActiveTool(10);
+            toolsModel.SetActiveTool(TOOL_TEXT);
             break;
         case ID_LINE:
-            toolsModel.SetActiveTool(11);
+            toolsModel.SetActiveTool(TOOL_LINE);
             break;
         case ID_BEZIER:
-            toolsModel.SetActiveTool(12);
+            toolsModel.SetActiveTool(TOOL_BEZIER);
             break;
         case ID_RECT:
-            toolsModel.SetActiveTool(13);
+            toolsModel.SetActiveTool(TOOL_RECT);
             break;
         case ID_SHAPE:
-            toolsModel.SetActiveTool(14);
+            toolsModel.SetActiveTool(TOOL_SHAPE);
             break;
         case ID_ELLIPSE:
-            toolsModel.SetActiveTool(15);
+            toolsModel.SetActiveTool(TOOL_ELLIPSE);
             break;
         case ID_RRECT:
-            toolsModel.SetActiveTool(16);
+            toolsModel.SetActiveTool(TOOL_RRECT);
             break;
     }
     return 0;

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -175,6 +175,11 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
             DeleteObject(SelectObject(hdc, oldPen));
             break;
         }
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+        case TOOL_PEN:
+            break;
     }
     ReleaseDC(hdc);
     return 0;
@@ -232,6 +237,11 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
                 toolsModel.SetShapeStyle((y - 2) / 20);
             if ((y >= 70) && (y <= 132))
                 toolsModel.SetLineWidth((y - 72) / 12 + 1);
+            break;
+        case TOOL_FILL:
+        case TOOL_COLOR:
+        case TOOL_ZOOM:
+        case TOOL_PEN:
             break;
     }
     return 0;

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -57,12 +57,12 @@ void ToolsModel::SetBrushStyle(int nBrushStyle)
     NotifyToolSettingsChanged();
 }
 
-int ToolsModel::GetActiveTool() const
+TOOLTYPE ToolsModel::GetActiveTool() const
 {
     return m_activeTool;
 }
 
-void ToolsModel::SetActiveTool(int nActiveTool)
+void ToolsModel::SetActiveTool(TOOLTYPE nActiveTool)
 {
     m_activeTool = nActiveTool;
     NotifyToolChanged();

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -8,6 +8,26 @@
 
 #pragma once
 
+enum TOOLTYPE
+{
+    TOOL_FREESEL  =  1,
+    TOOL_RECTSEL  =  2,
+    TOOL_RUBBER   =  3,
+    TOOL_FILL     =  4,
+    TOOL_COLOR    =  5,
+    TOOL_ZOOM     =  6,
+    TOOL_PEN      =  7,
+    TOOL_BRUSH    =  8,
+    TOOL_AIRBRUSH =  9,
+    TOOL_TEXT     = 10,
+    TOOL_LINE     = 11,
+    TOOL_BEZIER   = 12,
+    TOOL_RECT     = 13,
+    TOOL_SHAPE    = 14,
+    TOOL_ELLIPSE  = 15,
+    TOOL_RRECT    = 16,
+};
+
 /* CLASSES **********************************************************/
 
 class ToolsModel
@@ -16,7 +36,7 @@ private:
     int m_lineWidth;
     int m_shapeStyle;
     int m_brushStyle;
-    int m_activeTool;
+    TOOLTYPE m_activeTool;
     int m_airBrushWidth;
     int m_rubberRadius;
     BOOL m_transpBg;
@@ -34,8 +54,8 @@ public:
     void SetShapeStyle(int nShapeStyle);
     int GetBrushStyle() const;
     void SetBrushStyle(int nBrushStyle);
-    int GetActiveTool() const;
-    void SetActiveTool(int nActiveTool);
+    TOOLTYPE GetActiveTool() const;
+    void SetActiveTool(TOOLTYPE nActiveTool);
     int GetAirBrushWidth() const;
     void SetAirBrushWidth(int nAirBrushWidth);
     int GetRubberRadius() const;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -405,6 +405,8 @@ LRESULT CMainWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 case TOOL_SHAPE: case TOOL_BEZIER:
                     imageArea.SendMessage(nMsg, wParam, lParam);
                     break;
+                default:
+                    break;
             }
         }
     }


### PR DESCRIPTION
## Purpose

Improve code quality and debuggability.
JIRA issue: [CORE-17931](https://jira.reactos.org/browse/CORE-17931)

## Proposed changes

- Define `enum TOOLTYPE` in `toolsmodel.h`.
- Use it.
- Add the missing cases in the `switch` statements.