### PR TITLE
[MSPAINT] Add NUM_COLORS and enum PAL_TYPE

### DIFF
--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -54,17 +54,17 @@ void PaletteModel::SelectPalette(PAL_TYPE nPalette)
     NotifyPaletteChanged();
 }
 
-COLORREF PaletteModel::GetColor(int nIndex) const
+COLORREF PaletteModel::GetColor(UINT nIndex) const
 {
-    if (0 <= nIndex && nIndex < NUM_COLORS)
+    if (nIndex < NUM_COLORS)
         return m_colors[nIndex];
     else
         return 0;
 }
 
-void PaletteModel::SetColor(int nIndex, COLORREF newColor)
+void PaletteModel::SetColor(UINT nIndex, COLORREF newColor)
 {
-    if (0 <= nIndex && nIndex < NUM_COLORS)
+    if (nIndex < NUM_COLORS)
     {
         m_colors[nIndex] = newColor;
         NotifyPaletteChanged();

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -20,12 +20,12 @@ PaletteModel::PaletteModel()
     SelectPalette(1);
 }
 
-int PaletteModel::SelectedPalette()
+PAL_TYPE PaletteModel::SelectedPalette()
 {
     return m_nSelectedPalette;
 }
 
-void PaletteModel::SelectPalette(int nPalette)
+void PaletteModel::SelectPalette(PAL_TYPE nPalette)
 {
     static const COLORREF modernColors[NUM_COLORS] =
     {
@@ -41,12 +41,14 @@ void PaletteModel::SelectPalette(int nPalette)
         0xffffff, 0xc0c0c0, 0x0000ff, 0x00ffff, 0x00ff00, 0xffff00, 0xff0000,
         0xff00ff, 0x80ffff, 0x80ff00, 0xffff80, 0xff8080, 0x8000ff, 0x4080ff
     };
-    if (nPalette == 1)
-        CopyMemory(m_colors, modernColors, sizeof(m_colors));
-    else if (nPalette == 2)
-        CopyMemory(m_colors, oldColors, sizeof(m_colors));
-    else
-        return;
+    switch (nPalette)
+    {
+        case PAL_MODERN:
+            CopyMemory(m_colors, modernColors, sizeof(m_colors));
+            break;
+        case PAL_OLDTYPE:
+            CopyMemory(m_colors, oldColors, sizeof(m_colors));
+    }
     m_nSelectedPalette = nPalette;
     NotifyPaletteChanged();
 }

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -17,7 +17,7 @@ PaletteModel::PaletteModel()
 {
     m_fgColor = 0x00000000;
     m_bgColor = 0x00ffffff;
-    SelectPalette(1);
+    SelectPalette(PAL_MODERN);
 }
 
 PAL_TYPE PaletteModel::SelectedPalette()

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -48,6 +48,7 @@ void PaletteModel::SelectPalette(PAL_TYPE nPalette)
             break;
         case PAL_OLDTYPE:
             CopyMemory(m_colors, oldColors, sizeof(m_colors));
+            break;
     }
     m_nSelectedPalette = nPalette;
     NotifyPaletteChanged();

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -4,6 +4,7 @@
  * FILE:        base/applications/mspaint/palettemodel.cpp
  * PURPOSE:     Keep track of palette data, notify listeners
  * PROGRAMMERS: Benedikt Freisen
+ *              Katayama Hirofumi MZ
  */
 
 /* INCLUDES *********************************************************/
@@ -26,13 +27,15 @@ int PaletteModel::SelectedPalette()
 
 void PaletteModel::SelectPalette(int nPalette)
 {
-    int modernColors[28] = {
+    static const int modernColors[NUM_COLORS] =
+    {
         0x000000, 0x464646, 0x787878, 0x300099, 0x241ced, 0x0078ff, 0x0ec2ff,
         0x00f2ff, 0x1de6a8, 0x4cb122, 0xefb700, 0xf36d4d, 0x99362f, 0x98316f,
         0xffffff, 0xdcdcdc, 0xb4b4b4, 0x3c5a9c, 0xb1a3ff, 0x7aaae5, 0x9ce4f5,
         0xbdf9ff, 0xbcf9d3, 0x61bb9d, 0xead999, 0xd19a70, 0x8e6d54, 0xd5a5b5
     };
-    int oldColors[28] = {
+    static const int oldColors[NUM_COLORS] =
+    {
         0x000000, 0x808080, 0x000080, 0x008080, 0x008000, 0x808000, 0x800000,
         0x800080, 0x408080, 0x404000, 0xff8000, 0x804000, 0xff0040, 0x004080,
         0xffffff, 0xc0c0c0, 0x0000ff, 0x00ffff, 0x00ff00, 0xffff00, 0xff0000,
@@ -50,7 +53,7 @@ void PaletteModel::SelectPalette(int nPalette)
 
 int PaletteModel::GetColor(int nIndex) const
 {
-    if (nIndex < 28)
+    if (nIndex < NUM_COLORS)
         return m_colors[nIndex];
     else
         return 0;
@@ -58,7 +61,7 @@ int PaletteModel::GetColor(int nIndex) const
 
 void PaletteModel::SetColor(int nIndex, int newColor)
 {
-    if (nIndex < 28)
+    if (nIndex < NUM_COLORS)
     {
         m_colors[nIndex] = newColor;
         NotifyPaletteChanged();

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -27,14 +27,14 @@ int PaletteModel::SelectedPalette()
 
 void PaletteModel::SelectPalette(int nPalette)
 {
-    static const int modernColors[NUM_COLORS] =
+    static const COLORREF modernColors[NUM_COLORS] =
     {
         0x000000, 0x464646, 0x787878, 0x300099, 0x241ced, 0x0078ff, 0x0ec2ff,
         0x00f2ff, 0x1de6a8, 0x4cb122, 0xefb700, 0xf36d4d, 0x99362f, 0x98316f,
         0xffffff, 0xdcdcdc, 0xb4b4b4, 0x3c5a9c, 0xb1a3ff, 0x7aaae5, 0x9ce4f5,
         0xbdf9ff, 0xbcf9d3, 0x61bb9d, 0xead999, 0xd19a70, 0x8e6d54, 0xd5a5b5
     };
-    static const int oldColors[NUM_COLORS] =
+    static const COLORREF oldColors[NUM_COLORS] =
     {
         0x000000, 0x808080, 0x000080, 0x008080, 0x008000, 0x808000, 0x800000,
         0x800080, 0x408080, 0x404000, 0xff8000, 0x804000, 0xff0040, 0x004080,
@@ -51,7 +51,7 @@ void PaletteModel::SelectPalette(int nPalette)
     NotifyPaletteChanged();
 }
 
-int PaletteModel::GetColor(int nIndex) const
+COLORREF PaletteModel::GetColor(int nIndex) const
 {
     if (nIndex < NUM_COLORS)
         return m_colors[nIndex];
@@ -59,7 +59,7 @@ int PaletteModel::GetColor(int nIndex) const
         return 0;
 }
 
-void PaletteModel::SetColor(int nIndex, int newColor)
+void PaletteModel::SetColor(int nIndex, COLORREF newColor)
 {
     if (nIndex < NUM_COLORS)
     {
@@ -68,23 +68,23 @@ void PaletteModel::SetColor(int nIndex, int newColor)
     }
 }
 
-int PaletteModel::GetFgColor() const
+COLORREF PaletteModel::GetFgColor() const
 {
     return m_fgColor;
 }
 
-void PaletteModel::SetFgColor(int newColor)
+void PaletteModel::SetFgColor(COLORREF newColor)
 {
     m_fgColor = newColor;
     NotifyColorChanged();
 }
 
-int PaletteModel::GetBgColor() const
+COLORREF PaletteModel::GetBgColor() const
 {
     return m_bgColor;
 }
 
-void PaletteModel::SetBgColor(int newColor)
+void PaletteModel::SetBgColor(COLORREF newColor)
 {
     m_bgColor = newColor;
     NotifyColorChanged();

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -56,7 +56,7 @@ void PaletteModel::SelectPalette(PAL_TYPE nPalette)
 
 COLORREF PaletteModel::GetColor(int nIndex) const
 {
-    if (nIndex < NUM_COLORS)
+    if (0 <= nIndex && nIndex < NUM_COLORS)
         return m_colors[nIndex];
     else
         return 0;
@@ -64,7 +64,7 @@ COLORREF PaletteModel::GetColor(int nIndex) const
 
 void PaletteModel::SetColor(int nIndex, COLORREF newColor)
 {
-    if (nIndex < NUM_COLORS)
+    if (0 <= nIndex && nIndex < NUM_COLORS)
     {
         m_colors[nIndex] = newColor;
         NotifyPaletteChanged();

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -8,12 +8,14 @@
 
 #pragma once
 
+#define NUM_COLORS 28
+
 /* CLASSES **********************************************************/
 
 class PaletteModel
 {
 private:
-    int m_colors[28];
+    int m_colors[NUM_COLORS];
     int m_nSelectedPalette;
     int m_fgColor;
     int m_bgColor;

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -10,23 +10,29 @@
 
 #define NUM_COLORS 28
 
+enum PAL_TYPE
+{
+    PAL_MODERN = 1,
+    PAL_OLDTYPE = 2,
+};
+
 /* CLASSES **********************************************************/
 
 class PaletteModel
 {
 private:
     COLORREF m_colors[NUM_COLORS];
-    int m_nSelectedPalette;
-    int m_fgColor;
-    int m_bgColor;
+    PAL_TYPE m_nSelectedPalette;
+    COLORREF m_fgColor;
+    COLORREF m_bgColor;
 
     void NotifyColorChanged();
     void NotifyPaletteChanged();
 
 public:
     PaletteModel();
-    int SelectedPalette();
-    void SelectPalette(int nPalette);
+    PAL_TYPE SelectedPalette();
+    void SelectPalette(PAL_TYPE nPalette);
     COLORREF GetColor(int nIndex) const;
     void SetColor(int nIndex, COLORREF newColor);
     COLORREF GetFgColor() const;

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -33,8 +33,8 @@ public:
     PaletteModel();
     PAL_TYPE SelectedPalette();
     void SelectPalette(PAL_TYPE nPalette);
-    COLORREF GetColor(int nIndex) const;
-    void SetColor(int nIndex, COLORREF newColor);
+    COLORREF GetColor(UINT nIndex) const;
+    void SetColor(UINT nIndex, COLORREF newColor);
     COLORREF GetFgColor() const;
     void SetFgColor(COLORREF newColor);
     COLORREF GetBgColor() const;

--- a/base/applications/mspaint/palettemodel.h
+++ b/base/applications/mspaint/palettemodel.h
@@ -15,7 +15,7 @@
 class PaletteModel
 {
 private:
-    int m_colors[NUM_COLORS];
+    COLORREF m_colors[NUM_COLORS];
     int m_nSelectedPalette;
     int m_fgColor;
     int m_bgColor;
@@ -27,10 +27,10 @@ public:
     PaletteModel();
     int SelectedPalette();
     void SelectPalette(int nPalette);
-    int GetColor(int nIndex) const;
-    void SetColor(int nIndex, int newColor);
-    int GetFgColor() const;
-    void SetFgColor(int newColor);
-    int GetBgColor() const;
-    void SetBgColor(int newColor);
+    COLORREF GetColor(int nIndex) const;
+    void SetColor(int nIndex, COLORREF newColor);
+    COLORREF GetFgColor() const;
+    void SetFgColor(COLORREF newColor);
+    COLORREF GetBgColor() const;
+    void SetBgColor(COLORREF newColor);
 };

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -346,8 +346,8 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     CheckMenuItem(menu, IDM_VIEWZOOM400, CHECKED_IF(toolsModel.GetZoom() == 4000));
     CheckMenuItem(menu, IDM_VIEWZOOM800, CHECKED_IF(toolsModel.GetZoom() == 8000));
 
-    CheckMenuItem(menu, IDM_COLORSMODERNPALETTE, CHECKED_IF(paletteModel.SelectedPalette() == 1));
-    CheckMenuItem(menu, IDM_COLORSOLDPALETTE,    CHECKED_IF(paletteModel.SelectedPalette() == 2));
+    CheckMenuItem(menu, IDM_COLORSMODERNPALETTE, CHECKED_IF(paletteModel.SelectedPalette() == PAL_MODERN));
+    CheckMenuItem(menu, IDM_COLORSOLDPALETTE,    CHECKED_IF(paletteModel.SelectedPalette() == PAL_OLDTYPE));
     return 0;
 }
 
@@ -586,10 +586,10 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 paletteModel.SetFgColor(choosecolor.rgbResult);
             break;
         case IDM_COLORSMODERNPALETTE:
-            paletteModel.SelectPalette(1);
+            paletteModel.SelectPalette(PAL_MODERN);
             break;
         case IDM_COLORSOLDPALETTE:
-            paletteModel.SelectPalette(2);
+            paletteModel.SelectPalette(PAL_OLDTYPE);
             break;
         case IDM_IMAGEINVERTCOLORS:
         {


### PR DESCRIPTION
## Purpose
Reduce magic numbers and improve debuggability.
JIRA issue: [CORE-17931](https://jira.reactos.org/browse/CORE-17931)

## Proposed changes

- Define `NUM_COLORS` macro and `enum PAL_TYPE` in `palettemodel.h`.
- Use them.
- Add `static const` to `modernColors` and `oldColors` in `PaletteModel::SelectPalette`.
- Use `COLORREF` for some color values.