### PR TITLE
[MSAFD] Handle option levels properly in WSPGetSockOpt(), following WSPSetSockOpt()

### DIFF
--- a/base/setup/usetup/lang/pt-PT.h
+++ b/base/setup/usetup/lang/pt-PT.h
@@ -1493,35 +1493,35 @@ static MUI_ENTRY ptPTBootLoaderEntries[] =
     {
         6,
         8,
-        "O instalador ir\240 configurar o gestor de inicializa\207\306o",
+        "O instalador ir\240 configurar o gestor de arranque.",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         12,
-        "Instalar o gestor de inicializa\207\306o no disco r\241gido (MBR e VBR)",
+        "Instalar o gestor de arranque no disco r\241gido (MBR e VBR)",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         13,
-        "Instalar o gestor de inicializa\207\306o no disco r\241gido (apenas VBR)",
+        "Instalar o gestor de arranque no disco r\241gido (apenas VBR)",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         14,
-        "Instalar o gestor de inicializa\207\306o numa disquete",
+        "Instalar o gestor de arranque numa disquete",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },
     {
         8,
         15,
-        "Saltar a instala\207\306o do gestor de inicializa\207\306o",
+        "Saltar a instala\207\306o do gestor de arranque",
         TEXT_STYLE_NORMAL,
         TEXT_ID_STATIC
     },

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2745,13 +2745,15 @@ WSPGetSockOpt(IN SOCKET Handle,
 
             if (*OptionLength < BufferSize)
             {
-                if (lpErrno) *lpErrno = WSAEFAULT;
+                if (lpErrno) 
+                    *lpErrno = WSAEFAULT;
                 *OptionLength = BufferSize;
                 return SOCKET_ERROR;
             }
             RtlCopyMemory(OptionValue, Buffer, BufferSize);
 
             return 0;
+
         /* These are handled at a lower level */
         case IPPROTO_IP:
         case IPPROTO_IPV6:
@@ -2979,8 +2981,8 @@ WSPSetSockOpt(
             DbgPrint("Invalid option level (%x)\n", level);
             if (lpErrno) *lpErrno = WSAEINVAL;
             return SOCKET_ERROR;
-         }
         }
+        
     }
 
 SendToHelper:


### PR DESCRIPTION
:: WSPGetSockOpt()

-Handle option levels properly in WSPGetSockOpt following the WSPSetSockOpt

## Purpose

I've reviewed all the patches in this following JIRA:

JIRA issue: [CORE-12104](https://jira.reactos.org/browse/CORE-12104)

In order to see if everything is already in master and close the Jira report if so.

I detected a patch which seems to be missing in master being the counterpart of the WSPSetSockOpt.
The creator is "tambre", according to the Jira History, 2 years later, and whom shares same location as the author Peter Hater.

I've recreated the patch for Git and current master. All the other patches seems to be included in master.

## Proposed changes

This seems to properly manage option levels in the Get counterpart. Now Get and Set shares the same structure, and lets lower options to be properly handled with a default case which can help to understand which other options could be used.


