### PR TITLE
[MSCRT] Implement CONIO CRT Functions:  _getwch() and _getwche()

### DIFF
--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -580,8 +580,8 @@
 @ cdecl _getpid() kernel32.GetCurrentProcessId
 @ cdecl _getsystime(ptr)
 @ cdecl _getw(ptr)
-@ cdecl -stub _getwch()
-@ cdecl -stub _getwche()
+@ cdecl _getwch()
+@ cdecl _getwche()
 @ cdecl _getws(ptr)
 @ cdecl -arch=i386 _global_unwind2(ptr)
 @ cdecl -version=0x600+ _gmtime32(ptr)

--- a/sdk/lib/crt/conio/conio.cmake
+++ b/sdk/lib/crt/conio/conio.cmake
@@ -4,6 +4,8 @@ list(APPEND CRT_CONIO_SOURCE
     conio/cputs.c
     conio/getch.c
     conio/getche.c
+    conio/getwche.c
+    conio/getwch.c
     conio/kbhit.c
     conio/putch.c
     conio/ungetch.c

--- a/sdk/lib/crt/conio/getwch.c
+++ b/sdk/lib/crt/conio/getwch.c
@@ -1,0 +1,123 @@
+/*
+ * COPYRIGHT:   See COPYING in the top level directory
+ * PROJECT:     ReactOS system libraries
+ * FILE:        lib/crt/conio/getch.c
+ * PURPOSE:     Writes a character to stdout
+ * PROGRAMER:   Ariadne
+ *              Lee Schroeder
+ * UPDATE HISTORY:
+ *              28/12/98: Created
+ */
+
+#include <precomp.h>
+
+wint_t _getwch(void)
+{
+    DWORD NumberOfCharsRead = 0;
+    wchar_t c;
+    HANDLE ConsoleHandle;
+    BOOL RestoreMode;
+    DWORD ConsoleMode;
+	INPUT_RECORD InputRecord;
+
+    if (char_avail) {
+        c = ungot_char;
+        char_avail = 0;
+    } else {
+        /*
+         * _getch() is documented to NOT echo characters. Testing shows it
+         * doesn't wait for a CR either. So we need to switch off
+         * ENABLE_ECHO_INPUT and ENABLE_LINE_INPUT if they're currently
+         * switched on.
+         */
+        c = EOF;
+        ConsoleHandle = GetStdHandle(STD_INPUT_HANDLE);
+        RestoreMode = GetConsoleMode(ConsoleHandle, &ConsoleMode) &&
+                      (0 != (ConsoleMode &
+                             (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT)));
+        if (RestoreMode) {
+            SetConsoleMode(ConsoleHandle,
+                           ConsoleMode & (~ (ENABLE_ECHO_INPUT | ENABLE_LINE_INPUT)));
+        }
+        for ( ;; )
+        {
+            if( !ReadConsoleInput(ConsoleHandle,
+                     &InputRecord,
+                     1,
+                     &NumberOfCharsRead) || !NumberOfCharsRead)
+            {
+                break;
+            }
+            if (InputRecord.EventType == KEY_EVENT &&
+                InputRecord.Event.KeyEvent.bKeyDown)
+            {
+                if((c = InputRecord.Event.KeyEvent.uChar.UnicodeChar) != 0)
+                    break;
+
+                if (InputRecord.Event.KeyEvent.wVirtualScanCode == 0x1d || /* Ctrl */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x2a || /* Left Shift */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x36 || /* Right Shift */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x38 || /* Alt */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x3a || /* Caps Lock */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x45 || /* Num Lock */
+                    InputRecord.Event.KeyEvent.wVirtualScanCode == 0x46) /* Scroll Lock */
+                    continue;
+
+                if (InputRecord.Event.KeyEvent.wVirtualKeyCode >= 0x70 && /* F1-F10 */
+                    InputRecord.Event.KeyEvent.wVirtualKeyCode <= 0x79)
+                {
+                    c = 0;
+                    if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_ALT_PRESSED | LEFT_ALT_PRESSED))
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x19 + 20;
+                    else if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED))
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x19 + 10;
+                    else if(InputRecord.Event.KeyEvent.dwControlKeyState & SHIFT_PRESSED)
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x19;
+                    else
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode;
+                    char_avail = 1;
+                }
+                else if (InputRecord.Event.KeyEvent.wVirtualKeyCode == 0x7a || /* F11-F12 */
+                         InputRecord.Event.KeyEvent.wVirtualKeyCode == 0x7b)
+                {
+                    c = 0xe0;
+                    if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_ALT_PRESSED | LEFT_ALT_PRESSED))
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x2E + 6;
+                    else if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED))
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x2E + 4;
+                    else if(InputRecord.Event.KeyEvent.dwControlKeyState & SHIFT_PRESSED)
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x2E + 2;
+                    else
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x2E;
+                    char_avail = 1;
+                }
+                else
+                {
+                    if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_ALT_PRESSED | LEFT_ALT_PRESSED))
+                    {
+                        c = 0;
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x50;
+                    }
+                    else if(InputRecord.Event.KeyEvent.dwControlKeyState & (RIGHT_CTRL_PRESSED | LEFT_CTRL_PRESSED))
+                    {
+                        c = 0xe0;
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode + 0x50;
+                    }
+                    else
+                    {
+                        c = 0xe0;
+                        ungot_char = InputRecord.Event.KeyEvent.wVirtualScanCode;
+                    }
+                    char_avail = 1;
+                }
+                break;
+            }
+        }
+        if (RestoreMode) {
+            SetConsoleMode(ConsoleHandle, ConsoleMode);
+        }
+    }
+    if (c == 10)
+        c = 13;
+    return c;
+}

--- a/sdk/lib/crt/conio/getwch.c
+++ b/sdk/lib/crt/conio/getwch.c
@@ -18,12 +18,15 @@ wint_t _getwch(void)
     HANDLE ConsoleHandle;
     BOOL RestoreMode;
     DWORD ConsoleMode;
-	INPUT_RECORD InputRecord;
+    INPUT_RECORD InputRecord;
 
-    if (char_avail) {
+    if (char_avail)
+    {
         c = ungot_char;
         char_avail = 0;
-    } else {
+    } 
+    else 
+    {
         /*
          * _getch() is documented to NOT echo characters. Testing shows it
          * doesn't wait for a CR either. So we need to switch off
@@ -41,17 +44,18 @@ wint_t _getwch(void)
         }
         for ( ;; )
         {
-            if( !ReadConsoleInput(ConsoleHandle,
+            if ( !ReadConsoleInput(ConsoleHandle,
                      &InputRecord,
                      1,
                      &NumberOfCharsRead) || !NumberOfCharsRead)
             {
                 break;
             }
+
             if (InputRecord.EventType == KEY_EVENT &&
                 InputRecord.Event.KeyEvent.bKeyDown)
             {
-                if((c = InputRecord.Event.KeyEvent.uChar.UnicodeChar) != 0)
+                if ((c = InputRecord.Event.KeyEvent.uChar.UnicodeChar) != 0)
                     break;
 
                 if (InputRecord.Event.KeyEvent.wVirtualScanCode == 0x1d || /* Ctrl */

--- a/sdk/lib/crt/conio/getwche.c
+++ b/sdk/lib/crt/conio/getwche.c
@@ -1,12 +1,12 @@
 /*
  * COPYRIGHT:   See COPYING in the top level directory
- * 		Copyright (C) 1994 DJ Delorie, see COPYING.DJ for details
+ *              Copyright (C) 1994 DJ Delorie, see COPYING.DJ for details
  * PROJECT:     ReactOS system libraries
  * FILE:        lib/msvcrt/conio/getwche.c
  * PURPOSE:     Reads a character from stdin
  * PROGRAMER:   DJ Delorie
-				Ariadne
-				Lee Schroeder
+                Ariadne
+                Lee Schroeder
  * UPDATE HISTORY:
  *              28/12/98: Created
  */
@@ -15,16 +15,19 @@
 
 wint_t _getwche(void)
 {
-  if (char_avail)
-    /*
-     * We don't know, wether the ungot char was already echoed
-     * we assume yes (for example in cscanf, probably the only
-     * place where ungetch is ever called.
-     * There is no way to check for this really, because
-     * ungetch could have been called with a character that
-     * hasn't been got by a conio function.
-     * We don't echo again.
-     */
-    return(_getwch());
-  return (_putwch(_getwch()));
- }
+    if (char_avail) 
+    {
+        /*
+         * We don't know, whether the ungot char was already echoed
+         * we assume yes (for example in cscanf, probably the only
+         * place where ungetch is ever called.
+         * There is no way to check for this really, because
+         * ungetch could have been called with a character that
+         * hasn't been got by a conio function.
+         * We don't echo again.
+         */
+        return(_getwch());
+    }
+
+    return (_putwch(_getwch()));
+}

--- a/sdk/lib/crt/conio/getwche.c
+++ b/sdk/lib/crt/conio/getwche.c
@@ -1,0 +1,30 @@
+/*
+ * COPYRIGHT:   See COPYING in the top level directory
+ * 		Copyright (C) 1994 DJ Delorie, see COPYING.DJ for details
+ * PROJECT:     ReactOS system libraries
+ * FILE:        lib/msvcrt/conio/getwche.c
+ * PURPOSE:     Reads a character from stdin
+ * PROGRAMER:   DJ Delorie
+				Ariadne
+				Lee Schroeder
+ * UPDATE HISTORY:
+ *              28/12/98: Created
+ */
+
+#include <precomp.h>
+
+wint_t _getwche(void)
+{
+  if (char_avail)
+    /*
+     * We don't know, wether the ungot char was already echoed
+     * we assume yes (for example in cscanf, probably the only
+     * place where ungetch is ever called.
+     * There is no way to check for this really, because
+     * ungetch could have been called with a character that
+     * hasn't been got by a conio function.
+     * We don't echo again.
+     */
+    return(_getwch());
+  return (_putwch(_getwch()));
+ }


### PR DESCRIPTION
## Purpose

- This should fix Python MinGW
- FontForge
- Kicad 5.0.0

JIRA issues: [CORE-8028](https://jira.reactos.org/browse/CORE-8028), [CORE-11064](https://jira.reactos.org/browse/CORE-11064), [CORE-14865](https://jira.reactos.org/browse/CORE-14865)

## Proposed changes

- Implement `_getwch` and `_getwche`.
- Implementation comes from a patch of JIRA-8028 from CAv, updated by me. 
- As a reference, this is wine CONIO implementation counterparts and some other extras: https://source.winehq.org/git/wine.git/blob/HEAD:/dlls/msvcrt/console.c#l110