### PR TITLE
[SHELL32] Handle double click on focus manager

### DIFF
--- a/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuFocusManager.cpp
@@ -577,6 +577,7 @@ LRESULT CMenuFocusManager::GetMsgHook(INT nCode, WPARAM hookWParam, LPARAM hookL
             break;
 
         case WM_NCLBUTTONDOWN:
+        case WM_LBUTTONDBLCLK:
         case WM_LBUTTONDOWN:
             isLButton = TRUE;
             TRACE("LB\n");


### PR DESCRIPTION
## Purpose

_Focus manager doesn't handle double click_

JIRA issue: [CORE-9943](https://jira.reactos.org/browse/CORE-9943)

## Proposed changes

_Just pretend that double click is a normal click button_