### PR TITLE
[RAPPS] Centralize the names of the RAPPS' registry setting sub-key, and user local settings & offline apps database sub-directories.

### DIFF
--- a/base/applications/rapps/README.ENG
+++ b/base/applications/rapps/README.ENG
@@ -85,16 +85,18 @@ and synced every time RAPPS is launched for the first time.
 
 NOTE: You can find the most current URL in rapps.h, defined as APPLICATION_DATABASE_URL.
 
-To generate a RAPPS database (usually a rappmgr.cab archive), use the included scripts:
+To generate a RAPPS database (usually a rappmgr.cab/rappmgr2.cab archive), use
+the included scripts:
 
 For Windows & other NT-derived: CreateCabFile.bat
 For Linux & other UNIX flavors: CreateCabFile.sh
 
 
-Once the rappmgr.cab is downloaded to %appdata%\rapps, RAPPS extracts it using cabinet.dll
-inside %appdata%\rapps\rapps, after that, it will parse all the *.txt files contained therein.
+Once the rappmgr.cab is downloaded to the user's local %AppData%\RApps, RAPPS extracts it
+using cabinet.dll inside %AppData%\RApps\appdb. After that, it will parse all the *.txt
+files contained therein.
 
-Every subsequent time the program tries to access the local .txt files
+Every subsequent time, the program tries to access the local .txt files
 until a database update is manually triggered by the user.
 
 If the rappmgr.cab file is moved or just missing, RAPPS will download it again.

--- a/base/applications/rapps/appdb.cpp
+++ b/base/applications/rapps/appdb.cpp
@@ -74,7 +74,7 @@ CAppDB::EnumerateFiles()
     ClearList(m_Available);
 
     CPathW AppsPath = m_BasePath;
-    AppsPath += L"rapps";
+    AppsPath += RAPPS_DATABASE_SUBDIR;
     CPathW WildcardPath = AppsPath;
     WildcardPath += L"*.txt";
 
@@ -95,7 +95,7 @@ CAppDB::EnumerateFiles()
         ATLASSERT(Info == NULL);
         if (!Info)
         {
-            CConfigParser *Parser = new CConfigParser(FindFileData.cFileName);
+            CConfigParser *Parser = new CConfigParser(CPathW(AppsPath) += FindFileData.cFileName);
             int Cat;
             if (!Parser->GetInt(L"Category", Cat))
                 Cat = ENUM_INVALID;
@@ -130,7 +130,7 @@ CAppDB::UpdateAvailable()
         SettingsInfo.bUseSource ? SettingsInfo.szSourceURL : APPLICATION_DATABASE_URL, !SettingsInfo.bUseSource);
 
     CPathW AppsPath = m_BasePath;
-    AppsPath += L"rapps";
+    AppsPath += RAPPS_DATABASE_SUBDIR;
     if (!ExtractFilesFromCab(APPLICATION_DATABASE_NAME, m_BasePath, AppsPath))
         return;
 
@@ -243,7 +243,7 @@ CAppDB::RemoveCached()
 {
     // Delete icons
     CPathW AppsPath = m_BasePath;
-    AppsPath += L"rapps";
+    AppsPath += RAPPS_DATABASE_SUBDIR;
     CPathW IconPath = AppsPath;
     IconPath += L"icons";
     DeleteWithWildcard(IconPath, L"*.ico");

--- a/base/applications/rapps/configparser.cpp
+++ b/base/applications/rapps/configparser.cpp
@@ -7,6 +7,7 @@
  *              Copyright 2017 Alexander Shaposhnikov (sanchaez@reactos.org)
  *              Copyright 2021 Mark Jansen <mark.jansen@reactos.org>
  */
+
 #include "rapps.h"
 #include <debug.h>
 
@@ -24,19 +25,7 @@ struct CSectionNames
 };
 static CSectionNames g_Names;
 
-static CStringW
-GetINIFullPath(const CStringW &FileName)
-{
-    CStringW szDir;
-    CStringW szBuffer;
-
-    GetStorageDirectory(szDir);
-    szBuffer.Format(L"%ls\\rapps\\%ls", szDir.GetString(), FileName.GetString());
-
-    return szBuffer;
-}
-
-CConfigParser::CConfigParser(const CStringW &FileName) : szConfigPath(GetINIFullPath(FileName))
+CConfigParser::CConfigParser(const CStringW &FilePath) : szConfigPath(FilePath)
 {
     CacheINI();
 }

--- a/base/applications/rapps/include/configparser.h
+++ b/base/applications/rapps/include/configparser.h
@@ -13,7 +13,7 @@ class CConfigParser
     ReadSection(CStringW &Buffer, const CStringW &Section, BOOL isArch);
 
   public:
-    CConfigParser(const CStringW &FileName);
+    CConfigParser(const CStringW &FilePath);
 
     BOOL
     GetString(const CStringW &KeyName, CStringW &ResultString);

--- a/base/applications/rapps/include/defines.h
+++ b/base/applications/rapps/include/defines.h
@@ -29,6 +29,15 @@
 #include "resource.h"
 #include "winmain.h"
 
-#define APPLICATION_DATABASE_URL L"https://rapps.reactos.org/rappmgr2.cab"
-#define APPLICATION_DATABASE_NAME L"rappmgr2.cab"
+/* Name of the registry sub-key where RAPPS settings are stored, and
+ * of the local AppData sub-directory where the RAPPS files are stored. */
+#define RAPPS_NAME                  L"RApps"
+
+/* Name of the RAPPS sub-directory where the offline RAPPS database is stored */
+#define RAPPS_DATABASE_SUBDIR       L"appdb"
+
+/* URL and filename of the online RAPPS database */
+#define APPLICATION_DATABASE_URL    L"https://rapps.reactos.org/rappmgr2.cab"
+#define APPLICATION_DATABASE_NAME   L"rappmgr2.cab"
+
 #define MAX_STR_LEN 256

--- a/base/applications/rapps/misc.cpp
+++ b/base/applications/rapps/misc.cpp
@@ -153,7 +153,7 @@ GetStorageDirectory(CStringW &Directory)
         BOOL bHasPath = SHGetSpecialFolderPathW(NULL, DirectoryStr, CSIDL_LOCAL_APPDATA, TRUE);
         if (bHasPath)
         {
-            PathAppendW(DirectoryStr, L"rapps");
+            PathAppendW(DirectoryStr, RAPPS_NAME);
         }
         CachedDirectory.ReleaseBuffer();
 

--- a/base/applications/rapps/settings.cpp
+++ b/base/applications/rapps/settings.cpp
@@ -218,7 +218,7 @@ BOOL
 LoadSettings(PSETTINGS_INFO pSettingsInfo)
 {
     ATL::CRegKey RegKey;
-    if (RegKey.Open(HKEY_CURRENT_USER, L"Software\\ReactOS\\rapps", KEY_READ) != ERROR_SUCCESS)
+    if (RegKey.Open(HKEY_CURRENT_USER, L"Software\\ReactOS\\" RAPPS_NAME, KEY_READ) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -245,9 +245,8 @@ SaveSettings(HWND hwnd, PSETTINGS_INFO pSettingsInfo)
             (wp.showCmd == SW_MAXIMIZE || (wp.showCmd == SW_SHOWMINIMIZED && (wp.flags & WPF_RESTORETOMAXIMIZED)));
     }
 
-    if (RegKey.Create(
-            HKEY_CURRENT_USER, L"Software\\ReactOS\\rapps", NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, NULL) !=
-        ERROR_SUCCESS)
+    if (RegKey.Create(HKEY_CURRENT_USER, L"Software\\ReactOS\\" RAPPS_NAME, NULL,
+                      REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, NULL) != ERROR_SUCCESS)
     {
         return FALSE;
     }

--- a/base/applications/rapps/settingsdlg.cpp
+++ b/base/applications/rapps/settingsdlg.cpp
@@ -246,7 +246,7 @@ SettingsDlgProc(HWND hDlg, UINT Msg, WPARAM wParam, LPARAM lParam)
                         CStringW szMsgText;
                         szMsgText.LoadStringW(IDS_URL_INVALID);
 
-                        MessageBoxW(hDlg, szMsgText, NULL, 0);
+                        MessageBoxW(hDlg, szMsgText, NULL, MB_OK);
                         SetFocus(GetDlgItem(hDlg, IDC_SOURCE_URL));
                         break;
                     }

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -241,13 +241,13 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 
     if (argc == 1) // RAPPS is launched without options
     {
-        // Check for if rapps MainWindow is already launched in another process
+        // Check whether the RAPPS MainWindow is already launched in another process
         HANDLE hMutex;
 
         hMutex = CreateMutexW(NULL, FALSE, szWindowClass);
         if ((!hMutex) || (GetLastError() == ERROR_ALREADY_EXISTS))
         {
-            /* If already started, it is found its window */
+            /* If already started, find its window */
             HWND hWindow = FindWindowW(szWindowClass, NULL);
 
             /* Activate window */


### PR DESCRIPTION
## Purpose

The primary goal is the replace (in user's local AppData) `rapps\rapps`, which looks a bit ridiculous and could appear as a bug of RAPPS (why creating two subdirectories with the same name??), by instead `RAPPS\AppsDb`, which (to my opinion) looks more decent and tells exactly what it is for -- the offline apps database. This would also allow for future sub-directories into the `RAPPS` settings folder.

And also I take the opportunity to consolidate in one single place the defines for these directory names.

## Proposed changes

- Change the name of the application database sub-directory from "rapps\rapps" to "RApps\appdb".
- Adjust the documentation to reflect this.
- Simplify CConfigParser constructor by removing GetINIFullPath().

NOTE: In case this is accepted, https://reactos.org/wiki/RAPPS will need minor adjustments as well (following the README update).