### PR TITLE
[COMCTL32] Invalidate LVIS_CUT selected items too

### DIFF
--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -2276,7 +2276,7 @@ static void LISTVIEW_InvalidateSelectedItems(const LISTVIEW_INFO *infoPtr)
     iterator_frameditems(&i, infoPtr, &infoPtr->rcList); 
     while(iterator_next(&i))
     {
-	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED))
+	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED | LVIS_CUT))
 	    LISTVIEW_InvalidateItem(infoPtr, i.nItem);
     }
     iterator_destroy(&i);

--- a/dll/win32/comctl32/listview.c
+++ b/dll/win32/comctl32/listview.c
@@ -2276,7 +2276,11 @@ static void LISTVIEW_InvalidateSelectedItems(const LISTVIEW_INFO *infoPtr)
     iterator_frameditems(&i, infoPtr, &infoPtr->rcList); 
     while(iterator_next(&i))
     {
+#ifdef __REACTOS__
 	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED | LVIS_CUT))
+#else
+	if (LISTVIEW_GetItemState(infoPtr, i.nItem, LVIS_SELECTED))
+#endif
 	    LISTVIEW_InvalidateItem(infoPtr, i.nItem);
     }
     iterator_destroy(&i);


### PR DESCRIPTION
## Purpose

_Hidden folders are not drawn with transparent icon until the filebrowser window is resized_

JIRA issue: [CORE-16722](https://jira.reactos.org/browse/CORE-16722)

## Proposed changes

_Seems that window doesn't send a setfocus event until the icon list are displayed so no transparent icon is displayed because the cut property is not applied to non focused listview, so the change proposed is to redraw the LVIS_CUT istead of just LVIS_SELECTED when window is focused_
