### PR TITLE
[SHELL32] Fix recycle bin handle reference leaking

### DIFF
--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -380,19 +380,18 @@ HRESULT WINAPI CRecycleBinItemContextMenu::InvokeCommand(LPCMINVOKECOMMANDINFO l
         if (!Context.bFound)
             return E_FAIL;
 
-        if (lpcmi->lpVerb == MAKEINTRESOURCEA(1))
-        {
-            /* restore file */
-            if (RestoreFile(Context.hDeletedFile))
-                return S_OK;
-            else
-                return E_FAIL;
-        }
+        BOOL ret = TRUE;
+
+        /* restore file */
+        if (lpcmi->lpVerb == MAKEINTRESOURCEA(1)) 
+            ret = RestoreFile(Context.hDeletedFile);
+        /* delete file */
         else
-        {
             DeleteFileHandleToRecycleBin(Context.hDeletedFile);
-            return E_NOTIMPL;
-        }
+
+        CloseRecycleBinHandle(Context.hDeletedFile);
+
+        return (ret ? S_OK : E_FAIL);
     }
     else if (lpcmi->lpVerb == MAKEINTRESOURCEA(3))
     {

--- a/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
@@ -3,7 +3,7 @@
  * LICENSE:     GPL v2 - See COPYING in the top level directory
  * FILE:        lib/recyclebin/recyclebin_v5.c
  * PURPOSE:     Deals with recycle bins of Windows 2000/XP/2003
- * PROGRAMMERS: Copyright 2006-2007 Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS: Copyright 2006-2007 HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "recyclebin_private.h"
@@ -500,7 +500,7 @@ RecycleBin5_RecycleBin5_Restore(
         {
             /* Restore file */
             ZeroMemory(&op, sizeof(op));
-            op.wFunc = FO_COPY;
+            op.wFunc = FO_MOVE;
             op.pFrom = pDeletedFileName;
             op.pTo = pDeletedFile->FileNameW;
 


### PR DESCRIPTION
## Purpose

_There was a handle reference leak in the recycler bin and the bin wasn't removing the copied file after restoring it_

JIRA issue: [CORE-13730](https://jira.reactos.org/browse/CORE-13730)

## Proposed changes

_Close the handle were the memory leak was and delete the file when restoring it_