### PR TITLE
[PSDK][SHELL32][SHELLEXT] Add SHCreateFileExtractIconW() to the PSDK headers, and SAL-annotate it.

### DIFF
--- a/dll/shellext/fontext/CFontExt.cpp
+++ b/dll/shellext/fontext/CFontExt.cpp
@@ -42,11 +42,6 @@ static FolderViewColumns g_ColumnDefs[] =
 };
 
 
-
-// Should fix our headers..
-EXTERN_C HRESULT WINAPI SHCreateFileExtractIconW(LPCWSTR pszPath, DWORD dwFileAttributes, REFIID riid, void **ppv);
-
-
 // Helper functions to translate a guid to a readable name
 bool GetInterfaceName(const WCHAR* InterfaceString, WCHAR* buf, size_t size)
 {

--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -5,10 +5,6 @@
  * COPYRIGHT:   Copyright 2017 Mark Jansen (mark.jansen@reactos.org)
  */
 
-
-EXTERN_C HRESULT WINAPI SHCreateFileExtractIconW(LPCWSTR pszPath, DWORD dwFileAttributes, REFIID riid, void **ppv);
-
-
 struct FolderViewColumns
 {
     int iResource;

--- a/dll/win32/shell32/CExtractIcon.cpp
+++ b/dll/win32/shell32/CExtractIcon.cpp
@@ -345,15 +345,17 @@ HRESULT WINAPI SHCreateDefaultExtractIcon(REFIID riid, void **ppv)
  * Currently (march 2018) our shell does not handle IExtractIconW with an invalid path,
  * so this (wrong) implementation actually works better for us.
  */
-EXTERN_C HRESULT
+EXTERN_C
+HRESULT
 WINAPI
-SHCreateFileExtractIconW(LPCWSTR pszPath,
-                         DWORD dwFileAttributes,
-                         REFIID riid,
-                         void **ppv)
+SHCreateFileExtractIconW(
+    _In_ LPCWSTR pszFile,
+    _In_ DWORD dwFileAttributes,
+    _In_ REFIID riid,
+    _Outptr_ void **ppv)
 {
     SHFILEINFOW shfi;
-    ULONG_PTR firet = SHGetFileInfoW(pszPath, dwFileAttributes, &shfi, sizeof(shfi), SHGFI_USEFILEATTRIBUTES | SHGFI_ICONLOCATION);
+    ULONG_PTR firet = SHGetFileInfoW(pszFile, dwFileAttributes, &shfi, sizeof(shfi), SHGFI_USEFILEATTRIBUTES | SHGFI_ICONLOCATION);
     HRESULT hr = E_FAIL;
     if (firet)
     {
@@ -373,4 +375,3 @@ SHCreateFileExtractIconW(LPCWSTR pszPath,
 
     return hr;
 }
-

--- a/sdk/include/psdk/shlobj.h
+++ b/sdk/include/psdk/shlobj.h
@@ -2092,6 +2092,28 @@ SHBindToParent(
   _Outptr_opt_ PCUITEMID_CHILD *ppidlLast);
 
 /****************************************************************************
+ * SHCreateFileExtractIcon API
+ */
+#if (NTDDI_VERSION >= NTDDI_WINXP)
+
+// NOTE: Even if documented on MSDN, the SHCreateFileExtractIconA()
+// ANSI function never existed on Windows!
+
+HRESULT
+WINAPI
+SHCreateFileExtractIconW(
+    _In_ LPCWSTR pszFile,
+    _In_ DWORD dwFileAttributes,
+    _In_ REFIID riid,
+    _Outptr_ void **ppv);
+
+#ifdef UNICODE
+#define SHCreateFileExtractIcon  SHCreateFileExtractIconW
+#endif
+
+#endif /* (NTDDI_VERSION >= NTDDI_WINXP) */
+
+/****************************************************************************
 * SHDefExtractIcon API
 */
 HRESULT


### PR DESCRIPTION
Note that even if the MS PSDK and MSDN documents an hypothetical
ANSI version SHCreateFileExtractIconA(), this one never existed
exported in any Windows version!