### PR TITLE
[NTUSER] Implement NtUserCreateInputContext

### DIFF
--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -597,7 +597,7 @@ HIMC WINAPI ImmCreateContext(void)
     if (pClientImc == NULL)
         return NULL;
 
-    hIMC = NtUserCreateInputContext(pClientImc);
+    hIMC = NtUserCreateInputContext((ULONG_PTR)pClientImc);
     if (hIMC == NULL)
     {
         Imm32HeapFree(pClientImc);

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1937,7 +1937,7 @@ NtUserCreateDesktop(
 
 HIMC
 NTAPI
-NtUserCreateInputContext(PCLIENTIMC pClientImc);
+NtUserCreateInputContext(ULONG_PTR dwClientImcData);
 
 NTSTATUS
 NTAPI

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -651,6 +651,12 @@ InitThreadCallback(PETHREAD Thread)
     }
     ptiCurrent->pClientInfo->dwTIFlags = ptiCurrent->TIF_flags;
 
+    /* Create the default input context */
+    if (IS_IMM_MODE())
+    {
+        UserCreateInputContext(0);
+    }
+
     /* Last things to do only if we are not a SYSTEM or CSRSS thread */
     if (!(ptiCurrent->TIF_flags & (TIF_SYSTEMTHREAD | TIF_CSRSSTHREAD)))
     {

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -422,28 +422,35 @@ PIMC APIENTRY UserCreateInputContext(ULONG_PTR dwClientImcData)
     PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
     PDESKTOP pdesk = pti->rpdesk;
 
-    if (!IS_IMM_MODE() || (pti->TIF_flags & TIF_DISABLEIME) || !pdesk)
+    if (!IS_IMM_MODE() || (pti->TIF_flags & TIF_DISABLEIME)) // Disabled?
         return NULL;
 
+    if (!pdesk) // No desktop?
+        return NULL;
+
+    // pti->spDefaultImc should be already set if non-first time.
     if (dwClientImcData && !pti->spDefaultImc)
         return NULL;
 
+    // Create an input context user object.
     pIMC = UserCreateObject(gHandleTable, pdesk, pti, NULL, TYPE_INPUTCONTEXT, sizeof(IMC));
     if (!pIMC)
         return NULL;
 
-    if (dwClientImcData)
+    if (dwClientImcData) // Non-first time.
     {
+        // Insert pIMC to the second position (non-default) of the list.
         pIMC->pImcNext = pti->spDefaultImc->pImcNext;
         pti->spDefaultImc->pImcNext = pIMC;
     }
-    else
+    else // First time. It's the default IMC.
     {
+        // Add the first one (default) to the list.
         pti->spDefaultImc = pIMC;
         pIMC->pImcNext = NULL;
     }
 
-    pIMC->dwClientImcData = dwClientImcData;
+    pIMC->dwClientImcData = dwClientImcData; // Set it.
     return pIMC;
 }
 

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -416,7 +416,7 @@ NtUserYieldTask(VOID)
    return 0;
 }
 
-PIMC APIENTRY UserCreateInputContext(ULONG_PTR dwClientImcData)
+PIMC FASTCALL UserCreateInputContext(ULONG_PTR dwClientImcData)
 {
     PIMC pIMC;
     PTHREADINFO pti = PsGetCurrentThreadWin32Thread();

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -165,6 +165,7 @@ BOOL FASTCALL GetLayeredStatus(PWND pWnd);
 
 /************** INPUT CONTEXT **************/
 
+PIMC FASTCALL UserCreateInputContext(ULONG_PTR dwClientImcData);
 VOID UserFreeInputContext(PVOID Object);
 BOOLEAN UserDestroyInputContext(PVOID Object);
 PVOID AllocInputContextObject(PDESKTOP pDesk, PTHREADINFO pti, SIZE_T Size, PVOID* HandleOwner);


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Modify `NtUserCreateInputContext` prototype.
- Add `UserCreateInputContext` helper function.
- Implement `NtUserCreateInputContext` function by using `UserCreateInputContext`.
- Call `UserCreateInputContext(0)` in `InitThreadCallback` function to create the default input context.