### PR TITLE
[MAIN.CPL] Fix Cursor/Caret blinking CORE-17929

### DIFF
--- a/dll/cpl/access/display.c
+++ b/dll/cpl/access/display.c
@@ -209,7 +209,6 @@ DisplayPageProc(HWND hwndDlg,
                         HDC hDC = GetDC(hwndDlg);
                         HBRUSH hBrush = GetSysColorBrush(COLOR_BTNTEXT);
                         FillRect(hDC, &pGlobalData->rcCaret, hBrush);
-                        DeleteObject(hBrush);
                         ReleaseDC(hwndDlg, hDC);
                     }
                     else
@@ -229,7 +228,6 @@ DisplayPageProc(HWND hwndDlg,
                     HDC hDC = GetDC(hwndDlg);
                     HBRUSH hBrush = GetSysColorBrush(COLOR_BTNTEXT);
                     FillRect(hDC, &pGlobalData->rcCaret, hBrush);
-                    DeleteObject(hBrush);
                     ReleaseDC(hwndDlg, hDC);
                 }
                 else

--- a/dll/cpl/main/keyboard.c
+++ b/dll/cpl/main/keyboard.c
@@ -196,7 +196,6 @@ KeyboardSpeedProc(IN HWND hwndDlg,
                     HDC hDC = GetDC(hwndDlg);
                     HBRUSH hBrush = GetSysColorBrush(COLOR_BTNTEXT);
                     FillRect(hDC, &pSpeedData->rcCursor, hBrush);
-                    DeleteObject(hBrush);
                     ReleaseDC(hwndDlg, hDC);
                 }
                 else


### PR DESCRIPTION
[MAIN.CPL] Fix Cursor/Caret blinking [CORE-17929](https://jira.reactos.org/browse/CORE-17929)
[MAIN.CPL] Do not delete system stock object
[MAIN.CPL] Save uCaretBlinkTime to CursorBlinkRate key
Cursor/Caret blinking rate never  reaching None
[NTUSER] Fix issue when caret is static


When caret is static (not blinking) it is not shown and hiden correctly when moved in a one line edit box or combobox.