### PR TITLE
[BCRYPT] Add ECDSA P256 to known algorithms

### DIFF
--- a/dll/win32/bcrypt/bcrypt_main.c
+++ b/dll/win32/bcrypt/bcrypt_main.c
@@ -266,7 +266,8 @@ enum alg_id
     ALG_ID_SHA1,
     ALG_ID_SHA256,
     ALG_ID_SHA384,
-    ALG_ID_SHA512
+    ALG_ID_SHA512,
+    ALG_ID_ECDSA_P256,
 };
 
 static const struct {
@@ -278,7 +279,8 @@ static const struct {
     /* ALG_ID_SHA1   */ { 20, BCRYPT_SHA1_ALGORITHM },
     /* ALG_ID_SHA256 */ { 32, BCRYPT_SHA256_ALGORITHM },
     /* ALG_ID_SHA384 */ { 48, BCRYPT_SHA384_ALGORITHM },
-    /* ALG_ID_SHA512 */ { 64, BCRYPT_SHA512_ALGORITHM }
+    /* ALG_ID_SHA512 */ { 64, BCRYPT_SHA512_ALGORITHM },
+    /* ALG_ID_ECDSA_P256 */ { 0, BCRYPT_ECDSA_P256_ALGORITHM },
 };
 
 struct algorithm
@@ -351,6 +353,7 @@ NTSTATUS WINAPI BCryptOpenAlgorithmProvider( BCRYPT_ALG_HANDLE *handle, LPCWSTR 
     else if (!strcmpW( id, BCRYPT_SHA256_ALGORITHM )) alg_id = ALG_ID_SHA256;
     else if (!strcmpW( id, BCRYPT_SHA384_ALGORITHM )) alg_id = ALG_ID_SHA384;
     else if (!strcmpW( id, BCRYPT_SHA512_ALGORITHM )) alg_id = ALG_ID_SHA512;
+    else if (!strcmpW( id, BCRYPT_ECDSA_P256_ALGORITHM )) alg_id = ALG_ID_ECDSA_P256;
     else
     {
         FIXME( "algorithm %s not supported\n", debugstr_w(id) );


### PR DESCRIPTION
Add ECDSA P256 to known algorithms.

## Purpose
Fix download problems for notepad++ with RAPPS

I started syncing bcrypt from WINE to ReactOS to support ECDSA algorithm.
At the point that i had to adjust the code to mbedtls, i tried to debug where
i have to do more adjustments. To my surprise the code work at this point already.
Therefor i check what is the minimal change to fix the reported issue.
This PR is the result.
See [video](https://jira.reactos.org/secure/attachment/61351/61351_reactos-bcrypt-2021-12-30T20-58-06-726618000Z.webm) for proof. Tested on an linux host under QEMU
and  Virtualbox.

JIRA issue: [CORE-16741](https://jira.reactos.org/browse/CORE-16741)

## Proposed changes
Add ECSDA P256 algorithm structs and BCryptOpenAlgorithmProvider function.

- Fix download problems for notepad++ with RAPPS
