### PR TITLE
[SHELL32] Fix folders on recycle bin and adjust the column size

### DIFF
--- a/dll/win32/shell32/shellrecyclebin/recyclebin.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin.c
@@ -3,7 +3,7 @@
  * LICENSE:     GPL v2 - See COPYING in the top level directory
  * FILE:        lib/recyclebin/recyclebin.c
  * PURPOSE:     Public interface
- * PROGRAMMERS: Copyright 2006-2007 Hervé Poussineau (hpoussin@reactos.org)
+ * PROGRAMMERS: Copyright 2006-2007 HervÃ© Poussineau (hpoussin@reactos.org)
  */
 
 #include "recyclebin_private.h"
@@ -245,6 +245,32 @@ cleanup:
         IRecycleBinEnumList_Release(prbel);
     if (SUCCEEDED(hr))
         return TRUE;
+    if (HRESULT_FACILITY(hr) == FACILITY_WIN32)
+        SetLastError(HRESULT_CODE(hr));
+    else
+        SetLastError(ERROR_GEN_FAILURE);
+    return FALSE;
+}
+
+BOOL WINAPI
+GetDeletedFileTypeNameW(
+    IN HANDLE hDeletedFile,
+    OUT LPWSTR pTypeName,
+    IN DWORD BufferSize,
+    OUT LPDWORD RequiredSize OPTIONAL)
+{
+    IRecycleBinFile *prbf = (IRecycleBinFile *)hDeletedFile;
+    SIZE_T FinalSize;
+
+    HRESULT hr = IRecycleBinFile_GetTypeName(prbf, BufferSize, pTypeName, &FinalSize);
+
+    if (SUCCEEDED(hr))
+    {
+        if (RequiredSize)
+            *RequiredSize = (DWORD)FinalSize;
+
+        return TRUE;
+    }
     if (HRESULT_FACILITY(hr) == FACILITY_WIN32)
         SetLastError(HRESULT_CODE(hr));
     else

--- a/dll/win32/shell32/shellrecyclebin/recyclebin.h
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin.h
@@ -131,6 +131,13 @@ EnumerateRecycleBinW(
 #define EnumerateRecycleBin EnumerateRecycleBinA
 #endif
 
+BOOL WINAPI
+GetDeletedFileTypeNameW(
+    IN HANDLE hDeletedFile,
+    OUT LPWSTR pTypeName,
+    IN DWORD BufferSize,
+    OUT LPDWORD RequiredSize OPTIONAL);
+
 /* Gets details about a deleted file
  * hDeletedFile: handle of the deleted file to get details about
  * BufferSize: size of the 'FileDetails' buffer, in bytes
@@ -198,6 +205,7 @@ DECLARE_INTERFACE_(IRecycleBinFile, IUnknown)
     STDMETHOD(GetPhysicalFileSize)(THIS_ ULARGE_INTEGER *pPhysicalFileSize) PURE;
     STDMETHOD(GetAttributes)(THIS_ DWORD *pAttributes) PURE;
     STDMETHOD(GetFileName)(THIS_ SIZE_T BufferSize, LPWSTR Buffer, SIZE_T *RequiredSize) PURE;
+    STDMETHOD(GetTypeName)(THIS_ SIZE_T BufferSize, LPWSTR Buffer, SIZE_T *RequiredSize) PURE;
     STDMETHOD(Delete)(THIS) PURE;
     STDMETHOD(Restore)(THIS) PURE;
 
@@ -267,6 +275,8 @@ EXTERN_C const IID IID_IRecycleBin;
     (This)->lpVtbl->GetAttributes(This, pAttributes)
 #define IRecycleBinFile_GetFileName(This, BufferSize, Buffer, RequiredSize) \
     (This)->lpVtbl->GetFileName(This, BufferSize, Buffer, RequiredSize)
+#define IRecycleBinFile_GetTypeName(This, BufferSize, Buffer, RequiredSize) \
+    (This)->lpVtbl->GetTypeName(This, BufferSize, Buffer, RequiredSize)
 #define IRecycleBinFile_Delete(This) \
     (This)->lpVtbl->Delete(This)
 #define IRecycleBinFile_Restore(This) \

--- a/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
+++ b/dll/win32/shell32/shellrecyclebin/recyclebin_v5.c
@@ -234,7 +234,7 @@ RecycleBin5_RecycleBin5_DeleteFile(
         return HRESULT_FROM_WIN32(ERROR_INVALID_NAME);
     }
 
-    hFile = CreateFileW(szFullName, 0, 0, NULL, OPEN_EXISTING, 0, NULL);
+    hFile = CreateFileW(szFullName, 0, 0, NULL, OPEN_EXISTING, (dwAttributes & FILE_ATTRIBUTE_DIRECTORY) ? FILE_FLAG_BACKUP_SEMANTICS : 0, NULL);
     if (hFile == INVALID_HANDLE_VALUE)
     {
         hr = HRESULT_FROM_WIN32(GetLastError());


### PR DESCRIPTION
## Purpose

- Folders cannot be sent to recycle bin by a bug inside the implementation.
- Adjust column size of the RecycleBin virtual folder in details mode (sugested by hbelusca).

JIRA issue: [CORE-11000](https://jira.reactos.org/browse/CORE-11000)

## Proposed changes

Ensure folders can be opened on the function, this partially fix the bug, but my other PR that's still in review fix the other part of the bug, as this bug is related to it by the handle leak bug.