### PR TITLE
[NTUSER] Fix KVM and VBox tests

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -226,7 +226,10 @@ VOID UserFreeInputContext(PVOID Object)
     PIMC pIMC = Object, pImc0;
     PTHREADINFO pti = pIMC->head.pti;
 
-    UserMarkObjectDestroy(Object);
+    if (!pIMC)
+        return;
+
+    UserMarkObjectDestroy(pIMC);
 
     for (pImc0 = pti->spDefaultImc; pImc0; pImc0 = pImc0->pImcNext)
     {
@@ -237,7 +240,7 @@ VOID UserFreeInputContext(PVOID Object)
         }
     }
 
-    UserHeapFree(Object);
+    UserHeapFree(pIMC);
 
     pti->ppi->UserHandleCount--;
     IntDereferenceThreadInfo(pti);

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -250,7 +250,8 @@ VOID UserFreeInputContext(PVOID Object)
 BOOLEAN UserDestroyInputContext(PVOID Object)
 {
     PIMC pIMC = Object;
-    UserDeleteObject(pIMC->head.h, TYPE_INPUTCONTEXT);
+    if (pIMC)
+        UserDeleteObject(pIMC->head.h, TYPE_INPUTCONTEXT);
     return TRUE;
 }
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -231,6 +231,7 @@ VOID UserFreeInputContext(PVOID Object)
 
     pti = pIMC->head.pti;
 
+    /* Find the IMC in the list and remove it */
     for (pImc0 = pti->spDefaultImc; pImc0; pImc0 = pImc0->pImcNext)
     {
         if (pImc0->pImcNext == pIMC)

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -230,7 +230,6 @@ VOID UserFreeInputContext(PVOID Object)
         return;
 
     pti = pIMC->head.pti;
-    UserMarkObjectDestroy(pIMC);
 
     for (pImc0 = pti->spDefaultImc; pImc0; pImc0 = pImc0->pImcNext)
     {
@@ -251,7 +250,10 @@ BOOLEAN UserDestroyInputContext(PVOID Object)
 {
     PIMC pIMC = Object;
     if (pIMC)
+    {
+        UserMarkObjectDestroy(pIMC);
         UserDeleteObject(pIMC->head.h, TYPE_INPUTCONTEXT);
+    }
     return TRUE;
 }
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -224,11 +224,12 @@ AllocInputContextObject(PDESKTOP pDesk,
 VOID UserFreeInputContext(PVOID Object)
 {
     PIMC pIMC = Object, pImc0;
-    PTHREADINFO pti = pIMC->head.pti;
+    PTHREADINFO pti;
 
     if (!pIMC)
         return;
 
+    pti = pIMC->head.pti;
     UserMarkObjectDestroy(pIMC);
 
     for (pImc0 = pti->spDefaultImc; pImc0; pImc0 = pImc0->pImcNext)


### PR DESCRIPTION
## Purpose

KVM and VBox tests was failing since https://github.com/reactos/reactos/commit/d5deacd90305a83d413af18dca8fa41fe03e61b3

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Check `NULL` at `UserFreeInputContext` and `UserDestroyInputContext` functions.
- Move `UserMarkObjectDestroy` into the `UserDestroyInputContext` function.
## TODO

- [x] Do tests.
