### PR TITLE
[BCRYPT] Add ECDSA P384 to known algorithms

### DIFF
--- a/dll/win32/bcrypt/bcrypt_main.c
+++ b/dll/win32/bcrypt/bcrypt_main.c
@@ -268,6 +268,7 @@ enum alg_id
     ALG_ID_SHA384,
     ALG_ID_SHA512,
     ALG_ID_ECDSA_P256,
+    ALG_ID_ECDSA_P384,
 };
 
 static const struct {
@@ -281,6 +282,7 @@ static const struct {
     /* ALG_ID_SHA384 */ { 48, BCRYPT_SHA384_ALGORITHM },
     /* ALG_ID_SHA512 */ { 64, BCRYPT_SHA512_ALGORITHM },
     /* ALG_ID_ECDSA_P256 */ { 0, BCRYPT_ECDSA_P256_ALGORITHM },
+    /* ALG_ID_ECDSA_P384 */ { 0, BCRYPT_ECDSA_P384_ALGORITHM },
 };
 
 struct algorithm
@@ -354,6 +356,7 @@ NTSTATUS WINAPI BCryptOpenAlgorithmProvider( BCRYPT_ALG_HANDLE *handle, LPCWSTR 
     else if (!strcmpW( id, BCRYPT_SHA384_ALGORITHM )) alg_id = ALG_ID_SHA384;
     else if (!strcmpW( id, BCRYPT_SHA512_ALGORITHM )) alg_id = ALG_ID_SHA512;
     else if (!strcmpW( id, BCRYPT_ECDSA_P256_ALGORITHM )) alg_id = ALG_ID_ECDSA_P256;
+    else if (!strcmpW( id, BCRYPT_ECDSA_P384_ALGORITHM )) alg_id = ALG_ID_ECDSA_P384;
     else
     {
         FIXME( "algorithm %s not supported\n", debugstr_w(id) );


### PR DESCRIPTION
Add missing structs and handler in BCryptOpenAlgorithmProvider().

Cherry-pick a part of Michael Müller's
https://source.winehq.org/git/wine.git/commit/76b6c360fa7f3d6a0a14ed935075f5eb10f2f719

Follow-up to e0a47b7 (0.4.15-dev-3603).
JIRA issue: [CORE-14198](https://jira.reactos.org/browse/CORE-14198)