### PR TITLE
[WINDOWSCODECS] Add converter for WICPixelFormat32bppRGBA

### DIFF
--- a/dll/win32/windowscodecs/bmpdecode.c
+++ b/dll/win32/windowscodecs/bmpdecode.c
@@ -744,6 +744,7 @@ static const struct bitfields_format bitfields_formats[] = {
     {16,0xf800,0x7e0,0x1f,0,&GUID_WICPixelFormat16bppBGR565,BmpFrameDecode_ReadUncompressed},
     {32,0xff0000,0xff00,0xff,0,&GUID_WICPixelFormat32bppBGR,BmpFrameDecode_ReadUncompressed},
     {32,0xff0000,0xff00,0xff,0xff000000,&GUID_WICPixelFormat32bppBGRA,BmpFrameDecode_ReadUncompressed},
+    {32,0xff000000,0xff0000,0xff00,0xff,&GUID_WICPixelFormat32bppRGBA,BmpFrameDecode_ReadUncompressed},
     {32,0xff,0xff00,0xff0000,0,&GUID_WICPixelFormat32bppBGR,BmpFrameDecode_ReadRGB8},
     {0}
 };

--- a/dll/win32/windowscodecs/main.c
+++ b/dll/win32/windowscodecs/main.c
@@ -228,6 +228,28 @@ void reverse_bgr8(UINT bytesperpixel, LPBYTE bits, UINT width, UINT height, INT 
     }
 }
 
+void convert_rgba_to_bgra(UINT bytesperpixel, LPBYTE bits, UINT width, UINT height, INT stride)
+{
+    UINT x, y;
+    BYTE *pixel, temp;
+
+    for (y=0; y<height; y++)
+    {
+        pixel = bits + stride * y;
+
+        for (x=0; x<width; x++)
+        {
+            temp = pixel[3];
+            pixel[3] = pixel[0];
+            pixel[0] = pixel[1];
+            pixel[1] = pixel[2];
+//            pixel[2] = pixel[3];
+            pixel[2] = temp;
+            pixel += bytesperpixel;
+        }
+    }
+}
+
 HRESULT get_pixelformat_bpp(const GUID *pixelformat, UINT *bpp)
 {
     HRESULT hr;

--- a/dll/win32/windowscodecs/main.c
+++ b/dll/win32/windowscodecs/main.c
@@ -243,7 +243,6 @@ void convert_rgba_to_bgra(UINT bytesperpixel, LPBYTE bits, UINT width, UINT heig
             pixel[3] = pixel[0];
             pixel[0] = pixel[1];
             pixel[1] = pixel[2];
-//            pixel[2] = pixel[3];
             pixel[2] = temp;
             pixel += bytesperpixel;
         }

--- a/dll/win32/windowscodecs/wincodecs_private.h
+++ b/dll/win32/windowscodecs/wincodecs_private.h
@@ -184,6 +184,7 @@ extern HRESULT write_source(IWICBitmapFrameEncode *iface,
     INT width, INT height) DECLSPEC_HIDDEN;
 
 extern void reverse_bgr8(UINT bytesperpixel, LPBYTE bits, UINT width, UINT height, INT stride) DECLSPEC_HIDDEN;
+extern void convert_rgba_to_bgra(UINT bytesperpixel, LPBYTE bits, UINT width, UINT height, INT stride) DECLSPEC_HIDDEN;
 
 extern HRESULT get_pixelformat_bpp(const GUID *pixelformat, UINT *bpp) DECLSPEC_HIDDEN;
 


### PR DESCRIPTION
## Purpose

This fixes CORE-15708 "PdfSam 3.3.5 setup can not decode bmp"
https://jira.reactos.org/browse/CORE-15708

Wine does not have this issue, but it did not have it back when last sync to
WineStaging-4.18 was done. This commit is as near as possible to actual
wine-7.0-rc3 version. This wine code uses reverse_bgr8 instead of own
convert_rgba_to_bgra, but it leads to wrong colors.

JIRA issue: [CORE-15708](https://jira.reactos.org/browse/CORE-15708)

## Proposed changes

- Add converter for WICPixelFormat32bppRGBA