### PR TITLE
[XDK] MmBadPointer: Exists on NT6+ only

### DIFF
--- a/sdk/include/xdk/mmtypes.h
+++ b/sdk/include/xdk/mmtypes.h
@@ -151,7 +151,11 @@ typedef enum _MM_SYSTEM_SIZE {
 __CREATE_NTOS_DATA_IMPORT_ALIAS(Mm64BitPhysicalAddress)
 extern PBOOLEAN Mm64BitPhysicalAddress;
 #endif
+
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+// On NT6.3+, MmBadPointer is deprecated. Use MM_BAD_POINTER macro instead.
 extern NTKERNELAPI PVOID MmBadPointer;
+#endif
 
 $endif (_WDMDDK_)
 $if (_NTDDK_)


### PR DESCRIPTION
Add an `#ifdef`, plus a comment.

JIRA issue: [CORE-15443](https://jira.reactos.org/browse/CORE-15443)