### PR TITLE
[UNIATA] Fix packing for port configuration information structures

### DIFF
--- a/drivers/storage/ide/uniata/srb.h
+++ b/drivers/storage/ide/uniata/srb.h
@@ -43,6 +43,10 @@ typedef struct _ACCESS_RANGE {
     BOOLEAN RangeInMemory;
 }ACCESS_RANGE, *PACCESS_RANGE;
 
+#ifdef __REACTOS__
+#pragma pack(push, 4)
+#endif
+
 //
 // Configuration information structure.  Contains the information necessary
 // to initialize the adapter. NOTE: This structure's must be a multiple of
@@ -124,6 +128,10 @@ typedef struct _PORT_CONFIGURATION_INFORMATION_2K {
     // Supports WMI?
     BOOLEAN WmiDataProvider;
 } PORT_CONFIGURATION_INFORMATION_2K, *PPORT_CONFIGURATION_INFORMATION_2K;
+
+#ifdef __REACTOS__
+#pragma pack(pop)
+#endif
 
 typedef struct _PORT_CONFIGURATION_INFORMATION_COMMON {
     PORT_CONFIGURATION_INFORMATION     comm;


### PR DESCRIPTION
Now it's consistent with our structure in `sdk/include/ddk/srb.h`.
Thanks to Hervé Poussineau for help with problem analysis.

JIRA issue: [CORE-17966](https://jira.reactos.org/browse/CORE-17966)