### PR TITLE
[NTUSER] Plan A: UserDereferenceObject in UserCreateInputContext

### DIFF
--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -654,11 +654,7 @@ InitThreadCallback(PETHREAD Thread)
     /* Create the default input context */
     if (IS_IMM_MODE())
     {
-        PIMC pIMC = UserCreateInputContext(0);
-        if (pIMC)
-        {
-            UserDereferenceObject(pIMC);
-        }
+        UserCreateInputContext(0);
     }
 
     /* Last things to do only if we are not a SYSTEM or CSRSS thread */

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -654,7 +654,7 @@ InitThreadCallback(PETHREAD Thread)
     /* Create the default input context */
     if (IS_IMM_MODE())
     {
-        UserCreateInputContext(0);
+        (VOID)UserCreateInputContext(0);
     }
 
     /* Last things to do only if we are not a SYSTEM or CSRSS thread */

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -509,9 +509,12 @@ NtUserCreateInputContext(ULONG_PTR dwClientImcData)
     PIMC pIMC;
     HIMC ret = NULL;
 
+    if (!dwClientImcData)
+        return NULL;
+
     UserEnterExclusive();
 
-    if (!IS_IMM_MODE() || !dwClientImcData)
+    if (!IS_IMM_MODE())
         goto Quit;
 
     pIMC = UserCreateInputContext(dwClientImcData);

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -482,6 +482,8 @@ PIMC FASTCALL UserCreateInputContext(ULONG_PTR dwClientImcData)
     if (!pIMC)
         return NULL;
 
+    UserDereferenceObject(pIMC);
+
     if (dwClientImcData) // Non-first time.
     {
         // Insert pIMC to the second position (non-default) of the list.
@@ -513,10 +515,7 @@ NtUserCreateInputContext(ULONG_PTR dwClientImcData)
 
     pIMC = UserCreateInputContext(dwClientImcData);
     if (pIMC)
-    {
         ret = UserHMGetHandle(pIMC);
-        UserDereferenceObject(pIMC);
-    }
 
 Quit:
     UserLeave();

--- a/win32ss/user/ntuser/ntstubs.c
+++ b/win32ss/user/ntuser/ntstubs.c
@@ -482,6 +482,7 @@ PIMC FASTCALL UserCreateInputContext(ULONG_PTR dwClientImcData)
     if (!pIMC)
         return NULL;
 
+    // Release the extra reference (UserCreateObject added 2 references).
     UserDereferenceObject(pIMC);
 
     if (dwClientImcData) // Non-first time.


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `UserDereferenceObject` function in `UserCreateInputContext`.
- Don't call `UserDereferenceObject` against input context at the other places.

## TODO

- [x] Do tests.
