### PR TITLE
[NTUSER] Plan B: UserDereferenceObject in ExitThreadCallback

### DIFF
--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -811,6 +811,12 @@ ExitThreadCallback(PETHREAD Thread)
     if (ptiCurrent->KeyboardLayout)
         UserDereferenceObject(ptiCurrent->KeyboardLayout);
 
+    if (ptiCurrent->spDefaultImc)
+    {
+        UserDereferenceObject(ptiCurrent->spDefaultImc);
+        ptiCurrent->spDefaultImc = NULL;
+    }
+
     if (gptiForeground == ptiCurrent)
     {
 //       IntNotifyWinEvent(EVENT_OBJECT_FOCUS, NULL, OBJID_CLIENT, CHILDID_SELF, 0);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `UserDereferenceObject` function in `ExitThreadCallback` function to release the default IMC of the thread.

## TODO

- [ ] Do tests.
