### PR TITLE
[NTOS:KE/x64] Detect CPU vendor properly and store value in PRCB

### DIFF
--- a/drivers/processor/processr/cpu.inf
+++ b/drivers/processor/processr/cpu.inf
@@ -62,6 +62,9 @@ HKR, , Icon,           0, "-28"
 %IntelP4Processor.DeviceDesc%     = Processr_Inst,ACPI\GenuineIntel_-_x86_Family_15
 %IntelProcessor.DeviceDesc%       = Processr_Inst,ACPI\GenuineIntel_-_x86
 
+[Intel.NTAMD64]
+%IntelProcessor.DeviceDesc%       = Processr_Inst,ACPI\GenuineIntel_-_EM64T
+
 [AMD]
 %AMDK6Processor.DeviceDesc%   = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_5_Model_7
 %AMDK62Processor.DeviceDesc%  = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_5_Model_8
@@ -74,6 +77,10 @@ HKR, , Icon,           0, "-28"
 %AMDQProcessor.DeviceDesc%    = Processr_Inst,ACPI\AuthenticAMD_-_x86_Family_17
 %AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_x86
 
+[AMD.NTAMD64]
+%AMDK8Processor.DeviceDesc%   = Processr_Inst,ACPI\AuthenticAMD_-_AMD64_Family_15
+%AMDProcessor.DeviceDesc%     = Processr_Inst,ACPI\AuthenticAMD_-_AMD64
+
 [Transmeta]
 %TransmetaProcessor.DeviceDesc% = Processr_Inst,ACPI\GenuineTMx86_-_x86
 
@@ -83,6 +90,9 @@ HKR, , Icon,           0, "-28"
 %ViaC7Processor.DeviceDesc%   = Processr_Inst,ACPI\CentaurHauls_-_x86_Family_6_Model_13
 %ViaNANOProcessor.DeviceDesc% = Processr_Inst,ACPI\CentaurHauls_-_x86_Family_6_Model_15
 %ViaProcessor.DeviceDesc%     = Processr_Inst,ACPI\CentaurHauls_-_x86
+
+[VIA.NTAMD64]
+%ViaProcessor.DeviceDesc%     = Processr_Inst,ACPI\CentaurHauls_-_VIA64
 
 ;---------------------------- Processr Driver ---------------------------
 

--- a/ntoskrnl/config/i386/cmhardwr.c
+++ b/ntoskrnl/config/i386/cmhardwr.c
@@ -14,14 +14,7 @@
 
 /* GLOBALS *******************************************************************/
 
-#ifdef _M_IX86
-PCHAR CmpID1 = "80%u86-%c%x";
-PCHAR CmpID2 = "x86 Family %u Model %u Stepping %u";
-#else
-PCHAR CmpID1 = "EM64T Family %u Model %u Stepping %u";
-PCHAR CmpID2 = "AMD64 Family %u Model %u Stepping %u";
-PCHAR CmpID3 = "VIA64 Family %u Model %u Stepping %u";
-#endif
+PCHAR CmpFullCpuID = "%s Family %u Model %u Stepping %u";
 PCHAR CmpBiosStrings[] =
 {
     "Ver",
@@ -353,7 +346,7 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
         for (i = 0; i < KeNumberProcessors; i++)
         {
 #ifdef _M_AMD64
-            PCHAR CmpID;
+            PCHAR FamilyId;
 #endif
             /* Get the PRCB */
             Prcb = KiProcessorBlock[i];
@@ -370,18 +363,19 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
             /* Check if the CPU doesn't support CPUID */
             if (!Prcb->CpuID)
             {
-                /* Build ID1-style string for older CPUs */
+                /* Build 80x86-style string for older CPUs */
                 sprintf(Buffer,
-                        CmpID1,
+                        "80%u86-%c%x",
                         Prcb->CpuType,
                         (Prcb->CpuStep >> 8) + 'A',
                         Prcb->CpuStep & 0xff);
             }
             else
             {
-                /* Build ID2-style string for newer CPUs */
+                /* Build full ID string for newer CPUs */
                 sprintf(Buffer,
-                        CmpID2,
+                        CmpFullCpuID,
+                        "x86",
                         Prcb->CpuType,
                         (Prcb->CpuStep >> 8),
                         Prcb->CpuStep & 0xff);
@@ -390,22 +384,23 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
             if (Prcb->CpuVendor == CPU_VIA)
             {
                 /* This is VIA64 family */
-                CmpID = CmpID3;
+                FamilyId = "VIA64";
             }
             else if (Prcb->CpuVendor == CPU_AMD)
             {
                 /* This is AMD64 family */
-                CmpID = CmpID2;
+                FamilyId = "AMD64";
             }
             else
             {
                 /* This is generic EM64T family */
-                CmpID = CmpID1;
+                FamilyId = "EM64T";
             }
 
             /* ID string has the same style for all 64-bit CPUs */
             sprintf(Buffer,
-                    CmpID,
+                    CmpFullCpuID,
+                    FamilyId,
                     Prcb->CpuType,
                     (Prcb->CpuStep >> 8),
                     Prcb->CpuStep & 0xff);

--- a/ntoskrnl/ke/amd64/cpu.c
+++ b/ntoskrnl/ke/amd64/cpu.c
@@ -33,10 +33,7 @@ volatile LONG KiTbFlushTimeStamp;
 /* CPU Signatures */
 static const CHAR CmpIntelID[]       = "GenuineIntel";
 static const CHAR CmpAmdID[]         = "AuthenticAMD";
-static const CHAR CmpCyrixID[]       = "CyrixInstead";
-static const CHAR CmpTransmetaID[]   = "GenuineTMx86";
 static const CHAR CmpCentaurID[]     = "CentaurHauls";
-static const CHAR CmpRiseID[]        = "RiseRiseRise";
 
 /* FUNCTIONS *****************************************************************/
 
@@ -89,25 +86,25 @@ KiGetCpuVendor(VOID)
     /* Now check the CPU Type */
     if (!strcmp((PCHAR)Prcb->VendorString, CmpIntelID))
     {
-        return CPU_INTEL;
+        Prcb->CpuVendor = CPU_INTEL;
     }
     else if (!strcmp((PCHAR)Prcb->VendorString, CmpAmdID))
     {
-        return CPU_AMD;
+        Prcb->CpuVendor = CPU_AMD;
     }
     else if (!strcmp((PCHAR)Prcb->VendorString, CmpCentaurID))
     {
         DPRINT1("VIA CPUs not fully supported\n");
-        return CPU_VIA;
+        Prcb->CpuVendor = CPU_VIA;
     }
-    else if (!strcmp((PCHAR)Prcb->VendorString, CmpRiseID))
+    else
     {
-        DPRINT1("Rise CPUs not fully supported\n");
-        return 0;
+        /* Invalid CPU */
+        DPRINT1("%s CPU support not fully tested!\n", Prcb->VendorString);
+        Prcb->CpuVendor = CPU_UNKNOWN;
     }
 
-    /* Invalid CPU */
-    return CPU_UNKNOWN;
+    return Prcb->CpuVendor;
 }
 
 ULONG


### PR DESCRIPTION
Also generate processor identifier properly based on this value
on the Configuration Manager machine-dependent initialization.

Update processor driver INF file accordingly.

JIRA issue: [CORE-17970](https://jira.reactos.org/browse/CORE-17970)