### PR TITLE
[HDAUDBUS][KS] Remove a redundant ASSERT()

### DIFF
--- a/drivers/ksfilter/ks/swenum.c
+++ b/drivers/ksfilter/ks/swenum.c
@@ -2165,7 +2165,6 @@ KsServiceBusEnumPnpRequest(
         else if (IoStack->MinorFunction == IRP_MN_QUERY_DEVICE_RELATIONS && IoStack->Parameters.QueryDeviceRelations.Type == TargetDeviceRelation)
         {
             /* handle target device relations */
-            ASSERT(IoStack->Parameters.QueryDeviceRelations.Type == TargetDeviceRelation);
             ASSERT(Irp->IoStatus.Information == 0);
 
             /* allocate device relation */

--- a/drivers/wdm/audio/hdaudbus/hdaudbus.cpp
+++ b/drivers/wdm/audio/hdaudbus/hdaudbus.cpp
@@ -131,7 +131,6 @@ HDA_PdoPnp(
         if (IoStack->Parameters.QueryDeviceRelations.Type == TargetDeviceRelation)
         {
             /* handle target device relations */
-            ASSERT(IoStack->Parameters.QueryDeviceRelations.Type == TargetDeviceRelation);
             ASSERT(Irp->IoStatus.Information == 0);
 
             /* allocate device relation */


### PR DESCRIPTION
Redundant with previous `if()`.
Added as is.
I don't know if different conditions were intended.