### PR TITLE
[NTOSKRNL] Fix KDBG compilation on MSVC amd64

### DIFF
--- a/ntoskrnl/kdbg/i386/i386-dis.c
+++ b/ntoskrnl/kdbg/i386/i386-dis.c
@@ -63,14 +63,13 @@ KdbpNopPrintDisasm(void* Ignored, const char* fmt, ...)
 
 static int
 KdbpReadMemory(uintptr_t Addr, unsigned char* Data, unsigned int Length,
-	       struct disassemble_info * Ignored)
+               struct disassemble_info * Ignored)
 {
   return KdbpSafeReadMemory(Data, (void *)Addr, Length); /* 0 means no error */
 }
 
 static void
-KdbpMemoryError(int Status, uintptr_t Addr,
-	        struct disassemble_info * Ignored)
+KdbpMemoryError(int Status, uintptr_t Addr, struct disassemble_info * Ignored)
 {
 }
 
@@ -79,7 +78,7 @@ KdbpPrintAddressInCode(uintptr_t Addr, struct disassemble_info * Ignored)
 {
     if (!KdbSymPrintAddress((void*)Addr, NULL))
     {
-      KdbPrintf("<%08x>", Addr);
+        KdbPrintf("<%p>", (void*)Addr);
     }
 }
 

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -1453,7 +1453,7 @@ KdbpCmdBreakPointList(
     BOOLEAN Global = FALSE;
     PEPROCESS Process = NULL;
     PCHAR str1, str2, ConditionExpr, GlobalOrLocal;
-    CHAR Buffer[20];
+    CHAR Buffer[8 + 2 * sizeof(DWORD) + 1];
 
     l = KdbpGetNextBreakPointNr(0);
     if (l < 0)
@@ -1489,8 +1489,10 @@ KdbpCmdBreakPointList(
         else
         {
             GlobalOrLocal = Buffer;
-            sprintf(Buffer, "  PID 0x%Ix",
-                    (ULONG_PTR)(Process ? Process->UniqueProcessId : INVALID_HANDLE_VALUE));
+#define PID_NO_PROCESS ((DWORD) -1)
+            sprintf(Buffer, "  PID 0x%08lx",
+                    (Process ? HandleToUlong(Process->UniqueProcessId) : PID_NO_PROCESS));
+#undef PID_NO_PROCESS
         }
 
         if (Type == KdbBreakPointSoftware || Type == KdbBreakPointTemporary)
@@ -1949,9 +1951,9 @@ KdbpCmdProc(
             State = ((Process->Pcb.State == ProcessInMemory) ? "In Memory" :
                     ((Process->Pcb.State == ProcessOutOfMemory) ? "Out of Memory" : "In Transition"));
 
-            KdbpPrint(" %s0x%08x  %-10s  %s%s\n",
+            KdbpPrint(" %s0x%08lx  %-10s  %s%s\n",
                       str1,
-                      Process->UniqueProcessId,
+                      HandleToUlong(Process->UniqueProcessId),
                       State,
                       Process->ImageFileName,
                       str2);
@@ -2009,11 +2011,11 @@ KdbpCmdProc(
         State = ((Process->Pcb.State == ProcessInMemory) ? "In Memory" :
                 ((Process->Pcb.State == ProcessOutOfMemory) ? "Out of Memory" : "In Transition"));
         KdbpPrint("%s"
-                  "  PID:             0x%08x\n"
+                  "  PID:             0x%08lx\n"
                   "  State:           %s (0x%x)\n"
                   "  Image Filename:  %s\n",
                   (Argc < 2) ? "Current process:\n" : "",
-                  Process->UniqueProcessId,
+                  HandleToUlong(Process->UniqueProcessId),
                   State, Process->Pcb.State,
                   Process->ImageFileName);
 

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -104,16 +104,11 @@ static BOOLEAN KdbpCmdPrintStruct(ULONG Argc, PCHAR Argv[]);
 #endif
 
 /* Portability */
-FORCEINLINE
-ULONG_PTR
-strtoulptr(const char* nptr, char** endptr, int base)
-{
-#ifdef _M_IX86
-    return strtoul(nptr, endptr, base);
+#ifdef _WIN64
+#define strtoulptr strtoull
 #else
-    return strtoull(nptr, endptr, base);
+#define strtoulptr strtoul
 #endif
-}
 
 /* GLOBALS *******************************************************************/
 
@@ -457,7 +452,7 @@ KdbpGetHexNumber(
         pszNum += 2;
 
     /* Make a number from the string (hex) */
-    *pulValue = strtoul(pszNum, &endptr, 16);
+    *pulValue = strtoulptr(pszNum, &endptr, 16);
 
     return (*endptr == '\0');
 }

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -892,7 +892,7 @@ KdbpCmdDisassembleX(
         while (Count-- > 0)
         {
             if (!KdbSymPrintAddress((PVOID)Address, NULL))
-                KdbpPrint("<%08x>: ", Address);
+                KdbpPrint("<%p>: ", (PVOID)Address);
             else
                 KdbpPrint(": ");
 
@@ -999,14 +999,18 @@ KdbpCmdRegs(
     else /* dregs */
     {
         ASSERT(Argv[0][0] == 'd');
-        KdbpPrint("DR0  0x%08x\n"
-                  "DR1  0x%08x\n"
-                  "DR2  0x%08x\n"
-                  "DR3  0x%08x\n"
-                  "DR6  0x%08x\n"
-                  "DR7  0x%08x\n",
-                  Context->Dr0, Context->Dr1, Context->Dr2, Context->Dr3,
-                  Context->Dr6, Context->Dr7);
+        KdbpPrint("DR0  0x%p\n"
+                  "DR1  0x%p\n"
+                  "DR2  0x%p\n"
+                  "DR3  0x%p\n"
+                  "DR6  0x%p\n"
+                  "DR7  0x%p\n",
+                  (PVOID)Context->Dr0,
+                  (PVOID)Context->Dr1,
+                  (PVOID)Context->Dr2,
+                  (PVOID)Context->Dr3,
+                  (PVOID)Context->Dr6,
+                  (PVOID)Context->Dr7);
     }
 
     return TRUE;
@@ -1338,7 +1342,7 @@ KdbpCmdBackTrace(
 
         /* Print the location of the call instruction (assumed 5 bytes length) */
         if (!KdbSymPrintAddress((PVOID)(Address - 5), &Context))
-            KdbpPrint("<%08x>\n", Address);
+            KdbpPrint("<%p>\n", (PVOID)Address);
         else
             KdbpPrint("\n");
 
@@ -1379,7 +1383,7 @@ CheckForParentTSS:
         KdbpPrint("[Parent TSS 0x%04x @ 0x%p]\n", TssSelector, Tss);
 
         if (!KdbSymPrintAddress((PVOID)Address, &Context))
-            KdbpPrint("<%08x>\n", Address);
+            KdbpPrint("<%p>\n", (PVOID)Address);
         else
             KdbpPrint("\n");
 #endif
@@ -1492,8 +1496,10 @@ KdbpCmdBreakPointList(
 
         if (Type == KdbBreakPointSoftware || Type == KdbBreakPointTemporary)
         {
-            KdbpPrint(" %s%03d  BPX  0x%08x%s%s%s%s%s\n",
-                      str1, l, Address,
+            KdbpPrint(" %s%03d  BPX  0x%p%s%s%s%s%s\n",
+                      str1,
+                      l,
+                      (PVOID)Address,
                       Enabled ? "" : "  disabled",
                       GlobalOrLocal,
                       ConditionExpr ? "  IF " : "",
@@ -1504,7 +1510,10 @@ KdbpCmdBreakPointList(
         {
             if (!Enabled)
             {
-                KdbpPrint(" %s%03d  BPM  0x%08x  %-5s %-5s  disabled%s%s%s%s\n", str1, l, Address,
+                KdbpPrint(" %s%03d  BPM  0x%p  %-5s %-5s  disabled%s%s%s%s\n",
+                          str1,
+                          l,
+                          (PVOID)Address,
                           KDB_ACCESS_TYPE_TO_STRING(AccessType),
                           Size == 1 ? "byte" : (Size == 2 ? "word" : "dword"),
                           GlobalOrLocal,
@@ -1514,7 +1523,10 @@ KdbpCmdBreakPointList(
             }
             else
             {
-                KdbpPrint(" %s%03d  BPM  0x%08x  %-5s %-5s  DR%d%s%s%s%s\n", str1, l, Address,
+                KdbpPrint(" %s%03d  BPM  0x%p  %-5s %-5s  DR%d%s%s%s%s\n",
+                          str1,
+                          l,
+                          (PVOID)Address,
                           KDB_ACCESS_TYPE_TO_STRING(AccessType),
                           Size == 1 ? "byte" : (Size == 2 ? "word" : "dword"),
                           DebugReg,
@@ -1747,7 +1759,7 @@ KdbpCmdThread(
         if (Entry == &Process->ThreadListHead)
         {
             if (Argc >= 3)
-                KdbpPrint("No threads in process 0x%px!\n", (PVOID)ul);
+                KdbpPrint("No threads in process 0x%p!\n", (PVOID)ul);
             else
                 KdbpPrint("No threads in current process!\n");
 
@@ -1800,14 +1812,14 @@ KdbpCmdThread(
             else
                 State = "Unknown";
 
-            KdbpPrint(" %s0x%08x  %-11s  %3d     0x%08x  0x%08x  0x%08x%s\n",
+            KdbpPrint(" %s0x%p  %-11s  %3d     0x%p  0x%p  0x%p%s\n",
                       str1,
                       Thread->Cid.UniqueThread,
                       State,
                       Thread->Tcb.Priority,
-                      Thread->Tcb.Affinity,
+                      (PVOID)Thread->Tcb.Affinity,
                       Frame,
-                      Pc,
+                      (PVOID)Pc,
                       str2);
 
             Entry = Entry->Flink;
@@ -1838,7 +1850,7 @@ KdbpCmdThread(
             return TRUE;
         }
 
-        KdbpPrint("Attached to thread 0x%08x.\n", ul);
+        KdbpPrint("Attached to thread 0x%p.\n", (PVOID)ul);
     }
     else
     {
@@ -1869,15 +1881,15 @@ KdbpCmdThread(
             State = "Unknown";
 
         KdbpPrint("%s"
-                  "  TID:            0x%08x\n"
+                  "  TID:            0x%p\n"
                   "  State:          %s (0x%x)\n"
                   "  Priority:       %d\n"
-                  "  Affinity:       0x%08x\n"
-                  "  Initial Stack:  0x%08x\n"
-                  "  Stack Limit:    0x%08x\n"
-                  "  Stack Base:     0x%08x\n"
-                  "  Kernel Stack:   0x%08x\n"
-                  "  Trap Frame:     0x%08x\n"
+                  "  Affinity:       0x%p\n"
+                  "  Initial Stack:  0x%p\n"
+                  "  Stack Limit:    0x%p\n"
+                  "  Stack Base:     0x%p\n"
+                  "  Kernel Stack:   0x%p\n"
+                  "  Trap Frame:     0x%p\n"
 #ifndef _M_AMD64
                   "  NPX State:      %s (0x%x)\n"
 #endif
@@ -1885,9 +1897,9 @@ KdbpCmdThread(
                   , Thread->Cid.UniqueThread
                   , State, Thread->Tcb.State
                   , Thread->Tcb.Priority
-                  , Thread->Tcb.Affinity
+                  , (PVOID)Thread->Tcb.Affinity
                   , Thread->Tcb.InitialStack
-                  , Thread->Tcb.StackLimit
+                  , (PVOID)Thread->Tcb.StackLimit
                   , Thread->Tcb.StackBase
                   , Thread->Tcb.KernelStack
                   , Thread->Tcb.TrapFrame
@@ -2116,7 +2128,7 @@ KdbpCmdGdtLdtIdt(
             return TRUE;
         }
 
-        KdbpPrint("IDT Base: 0x%08x  Limit: 0x%04x\n", Reg.Base, Reg.Limit);
+        KdbpPrint("IDT Base: 0x%p  Limit: 0x%04x\n", Reg.Base, Reg.Limit);
         KdbpPrint("  Idx  Type        Seg. Sel.  Offset      DPL\n");
 
         for (i = 0; (i + sizeof(SegDesc) - 1) <= Reg.Limit; i += 8)
@@ -2189,7 +2201,7 @@ KdbpCmdGdtLdtIdt(
             return TRUE;
         }
 
-        KdbpPrint("%cDT Base: 0x%08x  Limit: 0x%04x\n",
+        KdbpPrint("%cDT Base: 0x%p  Limit: 0x%04x\n",
                   Argv[0][0] == 'g' ? 'G' : 'L', Reg.Base, Reg.Limit);
         KdbpPrint("  Idx  Sel.    Type         Base        Limit       DPL  Attribs\n");
 
@@ -2197,7 +2209,7 @@ KdbpCmdGdtLdtIdt(
         {
             if (!NT_SUCCESS(KdbpSafeReadMemory(SegDesc, (PVOID)((ULONG_PTR)Reg.Base + i), sizeof(SegDesc))))
             {
-                KdbpPrint("Couldn't access memory at 0x%p!\n", (ULONG_PTR)Reg.Base + i);
+                KdbpPrint("Couldn't access memory at 0x%p!\n", (PVOID)((ULONG_PTR)Reg.Base + i));
                 return TRUE;
             }
 

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -517,6 +517,7 @@ MiDumpPoolConsumers(BOOLEAN CalledFromDbg, ULONG Tag, ULONG Mask, ULONG Flags)
     // Remember whether we'll have to be verbose
     // This is the only supported flag!
     //
+    ASSERT((Flags & 0xFFFFFFFE) == 0);
     Verbose = BooleanFlagOn(Flags, 1);
 
     //

--- a/ntoskrnl/mm/ARM3/kdbg.c
+++ b/ntoskrnl/mm/ARM3/kdbg.c
@@ -75,6 +75,11 @@ ExpKdbgExtPool(
             KdbpPrint("Invalid parameter: %s\n", Argv[2]);
             return TRUE;
         }
+
+#ifdef _WIN64
+        ASSERT(Flags <= 0xFFFFFFFFULL);
+#endif
+        ASSERT((Flags & 0x7FFFFFFE) == 0);
     }
 
     /* Check if we got an address */
@@ -211,7 +216,10 @@ ExpKdbgExtPoolUsed(
     }
 
     /* Call the dumper */
-    MiDumpPoolConsumers(TRUE, Tag, Mask, Flags);
+#ifdef _WIN64
+    ASSERT(Flags <= 0xFFFFFFFFULL);
+#endif
+    MiDumpPoolConsumers(TRUE, Tag, Mask, (ULONG)Flags);
 
     return TRUE;
 }


### PR DESCRIPTION
And fix some features.

JIRA issue: [CORE-17995](https://jira.reactos.org/browse/CORE-17995)

NB:
I used VS 2022.
Obviously, KDBG `_WIN64` support is far from complete.