### PR TITLE
[SYSDM] Fix fancy edit Environment dialog box

### DIFF
--- a/dll/cpl/sysdm/environment.c
+++ b/dll/cpl/sysdm/environment.c
@@ -155,7 +155,9 @@ GatherDataFromListView(HWND hwndListView,
             return 0;
     }
 
-    /* Copy the variable values while seperating them with a semi-colon except for the last value */
+    /* First reinitialize the value buffer then copy the variable values while
+       seperating them with a semi-colon except for the last value */
+    VarData->lpRawValue[0] = _T('\0');
     for (i = 0; i < NumberOfItems; i++)
     {
         if (i > 0)

--- a/dll/cpl/sysdm/environment.c
+++ b/dll/cpl/sysdm/environment.c
@@ -155,8 +155,8 @@ GatherDataFromListView(HWND hwndListView,
             return 0;
     }
 
-    /* First reinitialize the value buffer then copy the variable values while
-       seperating them with a semi-colon except for the last value */
+    /* First reinitialize the value buffer, then copy the variable values while
+     * separating them with a semi-colon, except for the last value. */
     VarData->lpRawValue[0] = _T('\0');
     for (i = 0; i < NumberOfItems; i++)
     {


### PR DESCRIPTION
## Purpose

Fix the issue of the changes of the environment values not being set sometimes through fancy dialog box.

## Proposed changes

- Make sure the environment value buffer is always reallocated before taking the values.