### PR TITLE
[NTOS:KE] Fully implement FPU state Save/Restore mechanism

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -74,6 +74,7 @@ list(APPEND KMTEST_DRV_SOURCE
     ntos_ke/KeDevQueue.c
     ntos_ke/KeDpc.c
     ntos_ke/KeEvent.c
+    ntos_ke/KeFloatPointState.c
     ntos_ke/KeGuardedMutex.c
     ntos_ke/KeIrql.c
     ntos_ke/KeMutex.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -39,6 +39,7 @@ KMT_TESTFUNC Test_KeApc;
 KMT_TESTFUNC Test_KeDeviceQueue;
 KMT_TESTFUNC Test_KeDpc;
 KMT_TESTFUNC Test_KeEvent;
+KMT_TESTFUNC Test_KeFloatPointState;
 KMT_TESTFUNC Test_KeGuardedMutex;
 KMT_TESTFUNC Test_KeIrql;
 KMT_TESTFUNC Test_KeMutex;
@@ -119,6 +120,7 @@ const KMT_TEST TestList[] =
     { "KeDeviceQueue",                      Test_KeDeviceQueue },
     { "KeDpc",                              Test_KeDpc },
     { "KeEvent",                            Test_KeEvent },
+    { "KeFloatPointState",                  Test_KeFloatPointState },
     { "KeGuardedMutex",                     Test_KeGuardedMutex },
     { "KeIrql",                             Test_KeIrql },
     { "KeMutex",                            Test_KeMutex },

--- a/modules/rostests/kmtests/ntos_ke/KeFloatPointState.c
+++ b/modules/rostests/kmtests/ntos_ke/KeFloatPointState.c
@@ -1,0 +1,47 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Kernel mode tests for Save/Restore FPU state API kernel support
+ * COPYRIGHT:   Copyright 2022 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include <kmt_test.h>
+
+START_TEST(KeFloatPointState)
+{
+    NTSTATUS Status;
+    KFLOATING_SAVE FloatSave;
+    KIRQL Irql;
+
+    /* Save the state under normal conditions */
+    Status = KeSaveFloatingPointState(&FloatSave);
+    ok_irql(PASSIVE_LEVEL);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    /* Restore the FPU state back */
+    KeRestoreFloatingPointState(&FloatSave);
+
+    /* Try to raise the IRQL to APC and do some operations again */
+    KeRaiseIrql(APC_LEVEL, &Irql);
+
+    /* Save the state under APC_LEVEL interrupt */
+    Status = KeSaveFloatingPointState(&FloatSave);
+    ok_irql(APC_LEVEL);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    /* Restore the FPU state back */
+    KeRestoreFloatingPointState(&FloatSave);
+
+    /* Try to raise the IRQL to dispatch this time */
+    KeLowerIrql(Irql);
+    KeRaiseIrql(DISPATCH_LEVEL, &Irql);
+
+    /* Save the state under DISPATCH_LEVEL interrupt */
+    Status = KeSaveFloatingPointState(&FloatSave);
+    ok_irql(DISPATCH_LEVEL);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    /* We're done */
+    KeRestoreFloatingPointState(&FloatSave);
+    KeLowerIrql(Irql);
+}

--- a/ntoskrnl/include/internal/i386/ke.h
+++ b/ntoskrnl/include/internal/i386/ke.h
@@ -235,6 +235,17 @@ typedef struct _LARGE_IDENTITY_MAP
     PVOID PagesList[30];
 } LARGE_IDENTITY_MAP, *PLARGE_IDENTITY_MAP;
 
+//
+// Floating Point Internal Context Structure
+//
+typedef struct _FLOATING_SAVE_CONTEXT
+{
+    PKTHREAD CurrentThread;
+    KIRQL OldNpxIrql;
+    PFX_SAVE_AREA Buffer;
+    PFX_SAVE_AREA PfxSaveArea;
+} FLOATING_SAVE_CONTEXT, *PFLOATING_SAVE_CONTEXT;
+
 /* Diable interrupts and return whether they were enabled before */
 FORCEINLINE
 BOOLEAN

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -38,8 +38,10 @@
 #define TAG_KDBG 'GBDK'
 
 /* Kernel Tags */
-#define TAG_KNMI    'IMNK'
-#define TAG_KERNEL  '  eK'
+#define TAG_KNMI                    'IMNK'
+#define TAG_KERNEL                  '  eK'
+#define TAG_FLOATING_POINT_FX       'xFpF'
+#define TAG_FLOATING_POINT_CONTEXT  'oCpF'
 
 /* File-System Run-Time Library Tags */
 #define TAG_UNC    'nuSF'

--- a/ntoskrnl/ke/i386/cpu.c
+++ b/ntoskrnl/ke/i386/cpu.c
@@ -12,6 +12,8 @@
 #define NDEBUG
 #include <debug.h>
 
+#include <xmmintrin.h>
+
 /* GLOBALS *******************************************************************/
 
 /* The TSS to use for Double Fault Traps (INT 0x9) */
@@ -75,6 +77,9 @@ typedef union _CPU_SIGNATURE
     ULONG AsULONG;
 } CPU_SIGNATURE;
 
+/* FX area alignment size */
+#define FXSAVE_ALIGN 15
+
 /* SUPPORT ROUTINES FOR MSVC COMPATIBILITY ***********************************/
 
 /* NSC/Cyrix CPU configuration register index */
@@ -96,7 +101,6 @@ setCx86(UCHAR reg, UCHAR data)
     WRITE_PORT_UCHAR((PUCHAR)(ULONG_PTR)0x22, reg);
     WRITE_PORT_UCHAR((PUCHAR)(ULONG_PTR)0x23, data);
 }
-
 
 /* FUNCTIONS *****************************************************************/
 
@@ -1306,59 +1310,230 @@ KiCoprocessorError(VOID)
     __writecr0(__readcr0() | CR0_TS);
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Saves the current floating point unit state
+ * context of the current calling thread.
+ *
+ * @param[out] Save
+ * The saved floating point context given to the
+ * caller at the end of function's operations.
+ * The structure whose data contents are opaque
+ * to the calling thread.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the function has
+ * successfully completed its operations.
+ * STATUS_INSUFFICIENT_RESOURCES is returned
+ * if the function couldn't allocate memory
+ * for FPU state information.
+ *
+ * @remarks
+ * The function performs a FPU state save
+ * in two ways. A normal FPU save (FNSAVE)
+ * is performed if the system doesn't have
+ * SSE/SSE2, otherwise the function performs
+ * a save of FPU, MMX and SSE states save (FXSAVE).
  */
+#if defined(__clang__)
+__attribute__((__target__("sse")))
+#endif
 NTSTATUS
 NTAPI
-KeSaveFloatingPointState(OUT PKFLOATING_SAVE Save)
+KeSaveFloatingPointState(
+    _Out_ PKFLOATING_SAVE Save)
 {
-    PFNSAVE_FORMAT FpState;
+    PFLOATING_SAVE_CONTEXT FsContext;
+    PFX_SAVE_AREA FxSaveAreaFrame;
+    PKPRCB CurrentPrcb;
+
+    /* Sanity checks */
+    ASSERT(Save);
     ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
-    UNIMPLEMENTED_ONCE;
+    ASSERT(KeI386NpxPresent);
 
-    FpState = ExAllocatePool(NonPagedPool, sizeof (FNSAVE_FORMAT));
-    if (!FpState) return STATUS_INSUFFICIENT_RESOURCES;
-
-    *((PVOID *) Save) = FpState;
-#ifdef __GNUC__
-    asm volatile("fnsave %0\n\t" : "=m" (*FpState));
-#else
-    __asm
+    /* Initialize the floating point context */
+    FsContext = ExAllocatePoolWithTag(NonPagedPool,
+                                      sizeof(FLOATING_SAVE_CONTEXT),
+                                      TAG_FLOATING_POINT_CONTEXT);
+    if (!FsContext)
     {
-        mov eax, [FpState]
-        fnsave [eax]
-    };
-#endif
+        /* Bail out if we failed */
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
 
-    KeGetCurrentThread()->Header.NpxIrql = KeGetCurrentIrql();
+    /*
+     * Allocate some memory pool for the buffer. The size
+     * of this allocated buffer is the FX area plus the
+     * alignment requirement needed for FXSAVE as a 16-byte
+     * aligned pointer is compulsory in order to save the
+     * FPU state.
+     */
+    FsContext->Buffer = ExAllocatePoolWithTag(NonPagedPool,
+                                              sizeof(FX_SAVE_AREA) + FXSAVE_ALIGN,
+                                              TAG_FLOATING_POINT_FX);
+    if (!FsContext->Buffer)
+    {
+        /* Bail out if we failed */
+        ExFreePoolWithTag(FsContext, TAG_FLOATING_POINT_CONTEXT);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /*
+     * Now cache the allocated buffer into the save area
+     * and align the said area to a 16-byte boundary. Why
+     * do we have to do this is because of ExAllocate function.
+     * We gave the necessary alignment requirement in the pool
+     * allocation size although the function will always return
+     * a 8-byte aligned pointer. Aligning the given pointer directly
+     * can cause issues when freeing it from memory afterwards. With
+     * that said, we have to cache the buffer to the area so that we
+     * do not touch or mess the allocated buffer any further.
+     */
+    FsContext->PfxSaveArea = ALIGN_UP_POINTER_BY(FsContext->Buffer, 16);
+
+    /* Disable interrupts and get the current processor control region */
+    _disable();
+    CurrentPrcb = KeGetCurrentPrcb();
+
+    /* Store the current thread to context */
+    FsContext->CurrentThread = KeGetCurrentThread();
+
+    /*
+     * Save the previous NPX thread state registers (aka Numeric
+     * Processor eXtension) into the current context so that
+     * we are informing the scheduler the current FPU state
+     * belongs to this thread.
+     */
+    if (FsContext->CurrentThread != CurrentPrcb->NpxThread)
+    {
+        if ((CurrentPrcb->NpxThread != NULL) &&
+            (CurrentPrcb->NpxThread->NpxState == NPX_STATE_LOADED))
+        {
+            /* Get the FX frame */
+            FxSaveAreaFrame = KiGetThreadNpxArea(CurrentPrcb->NpxThread);
+
+            /* Save the FPU state */
+            Ke386SaveFpuState(FxSaveAreaFrame);
+
+            /* NPX thread has lost its state */
+            CurrentPrcb->NpxThread->NpxState = NPX_STATE_NOT_LOADED;
+            FxSaveAreaFrame->NpxSavedCpu = 0;
+        }
+
+        /* The new NPX thread is the current thread */
+        CurrentPrcb->NpxThread = FsContext->CurrentThread;
+    }
+
+    /* Perform the save */
+    Ke386SaveFpuState(FsContext->PfxSaveArea);
+
+    /* Store the NPX IRQL */
+    FsContext->OldNpxIrql = FsContext->CurrentThread->Header.NpxIrql;
+
+    /* Set the current IRQL to NPX */
+    FsContext->CurrentThread->Header.NpxIrql = KeGetCurrentIrql();
+
+    /* Initialize the FPU */
+    Ke386FnInit();
+
+    /* Enable interrupts back */
+    _enable();
+
+    /* Give the saved FPU context to the caller */
+    *((PVOID *) Save) = FsContext;
     return STATUS_SUCCESS;
 }
 
-/*
- * @implemented
+/**
+ * @brief
+ * Restores the original FPU state context that has
+ * been saved by a API call of KeSaveFloatingPointState.
+ * Callers are expected to restore the floating point
+ * state by calling this function when they've finished
+ * doing FPU operations.
+ *
+ * @param[in] Save
+ * The saved floating point context that is to be given
+ * to the function to restore the FPU state.
+ *
+ * @return
+ * Returns STATUS_SUCCESS indicating the function
+ * has fully completed its operations.
  */
+#if defined(__clang__)
+__attribute__((__target__("sse")))
+#endif
 NTSTATUS
 NTAPI
-KeRestoreFloatingPointState(IN PKFLOATING_SAVE Save)
+KeRestoreFloatingPointState(
+    _In_ PKFLOATING_SAVE Save)
 {
-    PFNSAVE_FORMAT FpState = *((PVOID *) Save);
-    ASSERT(KeGetCurrentThread()->Header.NpxIrql == KeGetCurrentIrql());
-    UNIMPLEMENTED_ONCE;
+    PFLOATING_SAVE_CONTEXT FsContext;
 
-#ifdef __GNUC__
-    asm volatile("fnclex\n\t");
-    asm volatile("frstor %0\n\t" : "=m" (*FpState));
-#else
-    __asm
+    /* Sanity checks */
+    ASSERT(Save);
+    ASSERT(KeGetCurrentIrql() <= DISPATCH_LEVEL);
+    ASSERT(KeI386NpxPresent);
+
+    /* Cache the saved FS context */
+    FsContext = *((PVOID *) Save);
+
+    /*
+     * We have to restore the regular saved FPU
+     * state. For this we must first do some
+     * validation checks so that we are sure
+     * ourselves the state context is saved
+     * properly. Check if we are in the same
+     * calling thread.
+     */
+    if (FsContext->CurrentThread != KeGetCurrentThread())
     {
-        fnclex
-        mov eax, [FpState]
-        frstor [eax]
-    };
-#endif
+        /*
+         * This isn't the thread that saved the
+         * FPU state context, crash the system!
+         */
+        KeBugCheckEx(INVALID_FLOATING_POINT_STATE,
+                     0x2,
+                     (ULONG_PTR)FsContext->CurrentThread,
+                     (ULONG_PTR)KeGetCurrentThread(),
+                     0);
+    }
 
-    ExFreePool(FpState);
+    /* Are we under the same NPX interrupt level? */
+    if (FsContext->CurrentThread->Header.NpxIrql != KeGetCurrentIrql())
+    {
+        /* The interrupt level has changed, crash the system! */
+        KeBugCheckEx(INVALID_FLOATING_POINT_STATE,
+                     0x1,
+                     (ULONG_PTR)FsContext->CurrentThread->Header.NpxIrql,
+                     (ULONG_PTR)KeGetCurrentIrql(),
+                     0);
+    }
+
+    /* Disable interrupts */
+    _disable();
+
+    /*
+     * The saved FPU state context is valid,
+     * it's time to restore the state. First,
+     * clear FPU exceptions now.
+     */
+    Ke386ClearFpExceptions();
+
+    /* Restore the state */
+    Ke386RestoreFpuState(FsContext->PfxSaveArea);
+
+    /* Give the saved NPX IRQL back to the NPX thread */
+    FsContext->CurrentThread->Header.NpxIrql = FsContext->OldNpxIrql;
+
+    /* Enable interrupts back */
+    _enable();
+
+    /* We're done, free the allocated area and context */
+    ExFreePoolWithTag(FsContext->Buffer, TAG_FLOATING_POINT_FX);
+    ExFreePoolWithTag(FsContext, TAG_FLOATING_POINT_CONTEXT);
+
     return STATUS_SUCCESS;
 }
 

--- a/sdk/include/reactos/mc/bugcodes.mc
+++ b/sdk/include/reactos/mc/bugcodes.mc
@@ -1598,6 +1598,14 @@ Language=English
 POWER_FAILURE_SIMULATE
 .
 
+MessageId=0xE7
+Severity=Success
+Facility=System
+SymbolicName=INVALID_FLOATING_POINT_STATE
+Language=English
+INVALID_FLOATING_POINT_STATE
+.
+
 MessageId=0xE8
 Severity=Success
 Facility=System


### PR DESCRIPTION
On ReactOS we are merely doing a **FNSAVE** when saving the non-volatile data of floating point unit state, while on Windows it does a lot more than that.

FPU state saving is done thorough this rule -- check the NPX state of the current thread. If NPX is loaded then the mechanism grabs the NPX registers, otherwise the non-volatile data is obtained from NPX frame. Windows performs a `FNSAVE` or `FXSAVE` only if NPX state is loaded and that the FPU state context is being held in a pool allocation.

If the NPX interrupt level is no longer equal to the current interrupt level of the calling thread, it checks if the level in question is APC_LEVEL and if that's the case then from that moment memory pool is allocated to hold the FX save area, otherwise the said area is obtained from the current processor control region.

When restoring the FPU state back, we aren't checking if the calling thread is right the same as the one that performed a save FPU state context. We're only checking on an ASSERT if the NPX interrupt level is the same as the current one but on release builds that's a NOP, which is pretty useless. There's `INVALID_FLOATING_POINT_STATE` bugcheck for this kind of stuff. If it's deemed that the saved FPU state context is not valid, ReactOS will crash.

**JIRA Issue:** [CORE-12904](https://jira.reactos.org/browse/CORE-12904)

## TODO

- [x] ~~Investigate why `IRQL_NOT_LESS_OR_EQUAL` occurs when the KMTEST has finished~~

