### PR TITLE
[NTOS:MM] MI_IS_*(): Upgrade documentation

### DIFF
--- a/ntoskrnl/include/internal/amd64/mm.h
+++ b/ntoskrnl/include/internal/amd64/mm.h
@@ -125,7 +125,8 @@
 #define MI_IS_INSTRUCTION_FETCH(FaultCode)   BooleanFlagOn(FaultCode, 0x00000010)
 // 0x00000020: protection-key violation.
 // 0x00000040: shadow-stack access.
-// Bits 7-14: reserved.
+// 0x00000080: HLAT paging.
+// Bits 8-14: reserved.
 // 0x00008000: violation of SGX-specific access-control requirements.
 // Bits 16-31: reserved.
 

--- a/ntoskrnl/include/internal/i386/mm.h
+++ b/ntoskrnl/include/internal/i386/mm.h
@@ -117,7 +117,8 @@
 #define MI_IS_INSTRUCTION_FETCH(FaultCode)   BooleanFlagOn(FaultCode, 0x00000010)
 // 0x00000020: protection-key violation.
 // 0x00000040: shadow-stack access.
-// Bits 7-14: reserved.
+// 0x00000080: HLAT paging.
+// Bits 8-14: reserved.
 // 0x00008000: violation of SGX-specific access-control requirements.
 // Bits 16-31: reserved.
 


### PR DESCRIPTION
Intel 64 and IA-32 Architectures Software Developer’s Manual
version 076 (December 2021)
4.7 PAGE-FAULT EXCEPTIONS