### PR TITLE
[MSPAINT] Add ICC_BAR_CLASSES

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -173,7 +173,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     /* initialize common controls library */
     INITCOMMONCONTROLSEX iccx;
     iccx.dwSize = sizeof(iccx);
-    iccx.dwICC = ICC_STANDARD_CLASSES | ICC_USEREX_CLASSES;
+    iccx.dwICC = ICC_STANDARD_CLASSES | ICC_USEREX_CLASSES | ICC_BAR_CLASSES;
     InitCommonControlsEx(&iccx);
 
     LoadString(hThisInstance, IDS_DEFAULTFILENAME, filepathname, _countof(filepathname));


### PR DESCRIPTION
## Purpose
The Fonts toolbar uses toolbar and tooltips. Thus this flag is needed.
JIRA issue: [CORE-17949](https://jira.reactos.org/browse/CORE-17949)

## Proposed changes

- Add `ICC_BAR_CLASSES` flag to `InitCommonControlsEx` call.