### PR TITLE
[USER32] Improve icon extraction to handle RIFF formats and Fix crash

### DIFF
--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -331,7 +331,7 @@ static UINT ICO_ExtractIconExW(
         ULONG   uSize = 0;
 
         /* Get size of the animation data */
-        uSize = peimage[4] + (peimage[5] << 8);
+        uSize = MAKEWORD(peimage[4], peimage[5]);
 
         /* Search for 'anih' indicating animation header */
         for (anihOffset = 0; anihOffset < uSize; anihOffset++)

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -331,21 +331,19 @@ static UINT ICO_ExtractIconExW(
         ULONG   uSize = 0;
 
         /* Get size of the animation data */
-        uSize = (WORD)peimage[4] +
-                256 * (WORD)peimage[5];
+        uSize = peimage[4] + (peimage[5] << 8);
 
         /* Search for 'anih' indicating animation header */
         for (anihOffset = 0; anihOffset < uSize; anihOffset++)
         {
-           if (((WORD)peimage[anihOffset] == 0x61) &&     // a
-               ((WORD)peimage[anihOffset+1] == 0x6e) &&   // n
-               ((WORD)peimage[anihOffset+2] == 0x69) &&   // i
-               ((WORD)peimage[anihOffset+3] == 0x68))     // h
+           if ((peimage[anihOffset] == 0x61) &&     // a
+               (peimage[anihOffset+1] == 0x6e) &&   // n
+               (peimage[anihOffset+2] == 0x69) &&   // i
+               (peimage[anihOffset+3] == 0x68))     // h
                break;
         }
         /* Get count of images for return value */
-        ret = (WORD)peimage[anihOffset + 12] +
-              256 * (WORD)peimage[anihOffset + 13];
+        ret = MAKEWORD(peimage[anihOffset + 12], peimage[anihOffset + 13]);
 
         TRACE("RIFF File with '%d' images at Offset '%d'.\n", ret, anihOffset);
 
@@ -505,7 +503,8 @@ static UINT ICO_ExtractIconExW(
                           * A dummy 0 can be given for BI_RGB bitmaps.
                           * https://en.wikipedia.org/wiki/BMP_file_format */
                          if ((bmih.biCompression == BI_RGB) &&
-                             (bmih.biSizeImage == 0))
+                             (bmih.biSizeImage == 0) &&
+                             (bmih.biClrUsed == 0))
                          {
                              bmih.biSizeImage = bmih.biWidth *
                                  bmih.biHeight / 2 * bmih.biBitCount / 8;

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -330,6 +330,7 @@ static UINT ICO_ExtractIconExW(
     if ((fsizel >= 52) && !memcmp(peimage, "RIFF", 4))
     {
         UINT anihOffset;
+        UINT anihMax;
         /* Get size of the animation data */
         ULONG uSize = MAKEWORD(peimage[4], peimage[5]);
 
@@ -337,12 +338,18 @@ static UINT ICO_ExtractIconExW(
         if (uSize > fsizel)
             goto end;
 
+        /* Maximum of 200 chars to search for anih */
+        anihMax = min(uSize, 200); 
         /* Search for 'anih' indicating animation header */
-        for (anihOffset = 0; anihOffset < uSize; anihOffset++)
+        for (anihOffset = 0; anihOffset < anihMax; anihOffset++)
         {
             if (memcmp(&peimage[anihOffset], "anih", 4) == 0)
                 break;
         }
+
+        if (anihOffset >= anihMax)
+            goto end;
+
         /* Get count of images for return value */
         ret = MAKEWORD(peimage[anihOffset + 12], peimage[anihOffset + 13]);
 

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -71,6 +71,21 @@ typedef struct
     DWORD resloader;
 } NE_TYPEINFO;
 
+//  From: James Houghtaling
+//  https://www.moon-soft.com/program/FORMAT/windows/ani.htm
+typedef struct taganiheader
+{
+    DWORD cbsizeof;  // num bytes in aniheader (36 bytes)
+    DWORD cframes;   // number of unique icons in this cursor
+    DWORD csteps;    // number of blits before the animation cycles
+    DWORD cx;        // reserved, must be zero.
+    DWORD cy;        // reserved, must be zero.
+    DWORD cbitcount; // reserved, must be zero.
+    DWORD cplanes;   // reserved, must be zero.
+    DWORD jifrate;   // default jiffies (1/60th sec) if rate chunk not present.
+    DWORD flags;     // animation flag
+} aniheader;
+
 #define NE_RSCTYPE_ICON        0x8003
 #define NE_RSCTYPE_GROUP_ICON  0x800e
 
@@ -338,8 +353,8 @@ static UINT ICO_ExtractIconExW(
         if (uSize > fsizel)
             goto end;
 
-        /* Maximum of 200 chars to search for anih */
-        anihMax = min(uSize, 200); 
+        /* Look though the reported size less search string length */
+        anihMax = uSize - strlen("anih"); 
         /* Search for 'anih' indicating animation header */
         for (anihOffset = 0; anihOffset < anihMax; anihOffset++)
         {
@@ -347,7 +362,7 @@ static UINT ICO_ExtractIconExW(
                 break;
         }
 
-        if (anihOffset >= anihMax)
+        if (anihOffset + sizeof(aniheader) > fsizel)
             goto end;
 
         /* Get count of images for return value */

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -324,8 +324,10 @@ static UINT ICO_ExtractIconExW(
 	CloseHandle(fmapping);
 
 #ifdef __REACTOS__
-    /* Check if the resource is an animated icon/cursor */
-    if (!memcmp(peimage, "RIFF", 4))
+    /* Check if we have a min size of 2 headers RIFF & 'icon'
+     * at 8 chars each plus an anih header of 36 byptes.
+     * Also, is this resource an animjated icon/cursor (RIFF) */
+    if ((fsizel >= 52) && !memcmp(peimage, "RIFF", 4))
     {
         UINT anihOffset;
         /* Get size of the animation data */

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -350,7 +350,7 @@ static UINT ICO_ExtractIconExW(
         ULONG uSize = MAKEWORD(peimage[4], peimage[5]);
 
         /* Check if uSize is reasonable with respect to fsizel */
-        if (uSize > fsizel)
+        if ((uSize < strlen("anih")) || (uSize > fsizel))
             goto end;
 
         /* Look though the reported size less search string length */

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2452,7 +2452,7 @@ HICON WINAPI CreateIconFromResourceEx(
         int wResId = LookupIconIdFromDirectoryEx(pbIconBits, fIcon, cxDesired, cyDesired, uFlags);
         HANDLE ResHandle = NULL;
 #ifdef __REACTOS__
-        if ((wResId) && (pbIconBits[4] != sizeof(BITMAPINFOHEADER)))
+        if (wResId && (pbIconBits[4] != sizeof(BITMAPINFOHEADER)))
 #else
         if(wResId)
 #endif

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2452,7 +2452,7 @@ HICON WINAPI CreateIconFromResourceEx(
         int wResId = LookupIconIdFromDirectoryEx(pbIconBits, fIcon, cxDesired, cyDesired, uFlags);
         HANDLE ResHandle = NULL;
 #ifdef __REACTOS__
-        if ((wResId) && ((DWORD)pbIconBits[4] != sizeof(BITMAPINFOHEADER)))
+        if ((wResId) && (pbIconBits[4] != sizeof(BITMAPINFOHEADER)))
 #else
         if(wResId)
 #endif

--- a/win32ss/user/user32/windows/cursoricon.c
+++ b/win32ss/user/user32/windows/cursoricon.c
@@ -2451,7 +2451,11 @@ HICON WINAPI CreateIconFromResourceEx(
         /* It is possible to pass Icon Directories to this API */
         int wResId = LookupIconIdFromDirectoryEx(pbIconBits, fIcon, cxDesired, cyDesired, uFlags);
         HANDLE ResHandle = NULL;
+#ifdef __REACTOS__
+        if ((wResId) && ((DWORD)pbIconBits[4] != sizeof(BITMAPINFOHEADER)))
+#else
         if(wResId)
+#endif
         {
             HINSTANCE hinst;
             HRSRC hrsrc;


### PR DESCRIPTION
## Improve Displaying Icons and Cursors and Fix crash.

_Add handling for 'RIFF' formats._

JIRA issue: [CORE-16287](https://jira.reactos.org/browse/CORE-16287)

## Add code to fix crash and show icons with RIFF format

Before:
![icons_before](https://user-images.githubusercontent.com/32620577/148668409-5bb54fb2-e969-43f3-9cc5-1a3d8857ef56.png)

After:
![icons_after](https://user-images.githubusercontent.com/32620577/148668419-c81a2501-34f0-4248-b5a1-c4bf7099ed98.png)

