### PR TITLE
[CRT] _mbsstr should return NULL if the substring is longer than source string

### DIFF
--- a/sdk/lib/crt/mbstring/mbsstr.c
+++ b/sdk/lib/crt/mbstring/mbsstr.c
@@ -8,6 +8,9 @@ unsigned char *_mbsstr(const unsigned char *src1,const unsigned char *src2)
 {
   size_t len;
 
+  if (_mbslen(src2) > _mbslen(src1))
+    return NULL;
+
   if (src2 == NULL || *src2 == 0)
     return (unsigned char *)src1;
 

--- a/sdk/lib/crt/mbstring/mbsstr.c
+++ b/sdk/lib/crt/mbstring/mbsstr.c
@@ -8,16 +8,17 @@ unsigned char *_mbsstr(const unsigned char *src1,const unsigned char *src2)
 {
   size_t len;
 
-  if (src2 ==NULL || *src2 == 0)
+  if (src2 == NULL || *src2 == 0)
     return (unsigned char *)src1;
 
   len = _mbslen(src2);
 
   while(*src1)
-    {
-      if ((*src1 == *src2) && (_mbsncmp(src1,src2,len) == 0))
-	return (unsigned char *)src1;
-      src1 = (unsigned char *)_mbsinc(src1);
-    }
+  {
+    if ((*src1 == *src2) && (_mbsncmp(src1,src2,len) == 0))
+      return (unsigned char *)src1;
+
+    src1 = (unsigned char *)_mbsinc(src1);
+  }
   return NULL;
 }


### PR DESCRIPTION
## Purpose

_mbsstr should return NULL when is requested to compare a substring whose length is greater than the source string, until now it tries to return a pointer and this leads to heap corruption

JIRA issue: [Core 16933](https://jira.reactos.org/browse/Core 16933)

Software affected: BabyWeb Server