### PR TITLE
[CRT/arm64] Build wine/except_arm64.c

### DIFF
--- a/sdk/lib/crt/wine/wine.cmake
+++ b/sdk/lib/crt/wine/wine.cmake
@@ -18,6 +18,10 @@ elseif(ARCH STREQUAL "arm")
     list(APPEND CRT_WINE_SOURCE
         wine/except_arm.c
     )
+elseif(ARCH STREQUAL "arm64")
+    list(APPEND CRT_WINE_SOURCE
+        wine/except_arm64.c
+    )
 endif()
 
 # includes for wine code


### PR DESCRIPTION
Another small step...

Follow-up to 9efafd6 (0.4.14-dev-934).
JIRA issue: [CORE-17518](https://jira.reactos.org/browse/CORE-17518)