### PR TITLE
[CRT/arm64] Fix handling of intrinsics

### DIFF
--- a/sdk/include/crt/math.h
+++ b/sdk/include/crt/math.h
@@ -202,9 +202,9 @@ _Check_return_ float __cdecl tanhf(_In_ float x);
 
 #if defined(_MSC_VER)
 /* Make sure intrinsics don't get in our way */
-#if defined(_M_AMD64) || defined(_M_ARM)
+#if defined(_M_AMD64) || defined(_M_ARM) || defined(_M_ARM64)
 #pragma function(acosf,asinf,atanf,atan2f,ceilf,cosf,coshf,expf,floorf,fmodf,logf,log10f,powf,sinf,sinhf,sqrtf,tanf,tanhf)
-#endif /* defined(_M_AMD64) || defined(_M_ARM) */
+#endif /* defined(_M_AMD64) || defined(_M_ARM) || defined(_M_ARM64) */
 #if (_MSC_VER >= 1920)
 #pragma function(_hypotf)
 #endif


### PR DESCRIPTION
Fix msvc14.1-arm64-Release build. (And 14.2. Did not try 14.3.)

Follow-up to db41787 (0.4.15-dev-2914).
JIRA issue: [CORE-17518](https://jira.reactos.org/browse/CORE-17518)

```
...\math.h(217): error C2169: 'acosf': intrinsic function, cannot be defined
...\math.h(218): error C2169: 'asinf': intrinsic function, cannot be defined
...\math.h(219): error C2169: 'atanf': intrinsic function, cannot be defined
...\math.h(220): error C2169: 'atan2f': intrinsic function, cannot be defined
...\math.h(221): error C2169: 'ceilf': intrinsic function, cannot be defined
...\math.h(222): error C2169: 'cosf': intrinsic function, cannot be defined
...\math.h(223): error C2169: 'coshf': intrinsic function, cannot be defined
...\math.h(224): error C2169: 'expf': intrinsic function, cannot be defined
...\math.h(225): error C2169: 'floorf': intrinsic function, cannot be defined
...\math.h(226): error C2169: 'fmodf': intrinsic function, cannot be defined
...\math.h(227): error C2169: 'logf': intrinsic function, cannot be defined
...\math.h(228): error C2169: 'log10f': intrinsic function, cannot be defined
...\math.h(230): error C2169: 'powf': intrinsic function, cannot be defined
...\math.h(231): error C2169: 'sinf': intrinsic function, cannot be defined
...\math.h(232): error C2169: 'sinhf': intrinsic function, cannot be defined
...\math.h(233): error C2169: 'sqrtf': intrinsic function, cannot be defined
...\math.h(234): error C2169: 'tanf': intrinsic function, cannot be defined
...\math.h(235): error C2169: 'tanhf': intrinsic function, cannot be defined
```