### PR TITLE
[NTUSER][IMM32] Implement NtUserGetImeInfoEx

### DIFF
--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -679,42 +679,25 @@ BOOL WINAPI ImmDisableLegacyIME(void)
 BOOL WINAPI
 ImmGetImeInfoEx(PIMEINFOEX pImeInfoEx, IMEINFOEXCLASS SearchType, PVOID pvSearchKey)
 {
-    BOOL bDisabled = FALSE;
     HKL hKL;
-
-    /* FIXME: broken */
-    switch (SearchType)
+    if (SearchType == ImeInfoExKeyboardLayout)
     {
-        case ImeInfoExKeyboardLayout:
-            break;
+        hKL = *(HKL*)pvSearchKey;
+        if (!IS_IME_HKL(hKL))
+            return FALSE;
 
-        case ImeInfoExImeWindow:
-            bDisabled = CtfImmIsTextFrameServiceDisabled();
-            SearchType = ImeInfoExKeyboardLayout;
-            break;
-
-        case ImeInfoExImeFileName:
-            StringCchCopyW(pImeInfoEx->wszImeFile, _countof(pImeInfoEx->wszImeFile),
-                           pvSearchKey);
-            goto Quit;
+        pImeInfoEx->hkl = hKL;
     }
-
-    hKL = *(HKL*)pvSearchKey;
-    pImeInfoEx->hkl = hKL;
-
-    if (!IS_IME_HKL(hKL))
+    else if (SearchType == ImeInfoExImeFileName)
     {
-        if (Imm32IsCiceroMode())
-        {
-            if (Imm32Is16BitMode())
-                return FALSE;
-            if (!bDisabled)
-                goto Quit;
-        }
+        StringCchCopyW(pImeInfoEx->wszImeFile, _countof(pImeInfoEx->wszImeFile),
+                       pvSearchKey);
+    }
+    else
+    {
         return FALSE;
     }
 
-Quit:
     return NtUserGetImeInfoEx(pImeInfoEx, SearchType);
 }
 

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -574,8 +574,7 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
     }
 
     /* If the IME for the specified filename is valid, then unload it now */
-    /* FIXME: ImmGetImeInfoEx is broken */
-    if (ImmGetImeInfoEx(&InfoEx, 3, pchFilePart) &&
+    if (ImmGetImeInfoEx(&InfoEx, ImeInfoExImeFileName, pchFilePart) &&
         !UnloadKeyboardLayout(InfoEx.hkl))
     {
         hNewKL = NULL;
@@ -623,8 +622,7 @@ BOOL WINAPI ImmIsIME(HKL hKL)
 {
     IMEINFOEX info;
     TRACE("(%p)\n", hKL);
-    /* FIXME: ImmGetImeInfoEx is broken */
-    return !!ImmGetImeInfoEx(&info, 1, &hKL);
+    return !!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayout, &hKL);
 }
 
 /***********************************************************************

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1183,9 +1183,12 @@ typedef struct tagIMEINFOEX
     };
 } IMEINFOEX, *PIMEINFOEX;
 
-typedef enum IMEINFOEXCLASS /* unconfirmed: buggy */
+typedef enum IMEINFOEXCLASS
 {
     ImeInfoExKeyboardLayout,
+#if 0
+    ImeInfoExKeyboardUnknown,
+#endif
     ImeInfoExImeWindow,
     ImeInfoExImeFileName
 } IMEINFOEXCLASS;

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1186,8 +1186,8 @@ typedef struct tagIMEINFOEX
 typedef enum IMEINFOEXCLASS
 {
     ImeInfoExKeyboardLayout,
-#if 0
-    ImeInfoExKeyboardUnknown,
+#if 1
+    ImeInfoExKeyboardLayoutTFS,
 #endif
     ImeInfoExImeWindow,
     ImeInfoExImeFileName

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -166,17 +166,18 @@ BOOL FASTCALL UserGetImeInfoEx(LPVOID pUnknown, PIMEINFOEX pInfoEx, IMEINFOEXCLA
 
     pkl = pklHead = gspklBaseLayout;
 
+    /* Find the matching entry from the list and get info */
     if (SearchType == ImeInfoExKeyboardLayout)
     {
         do
         {
-            if (pInfoEx->hkl == pkl->hkl)
+            if (pInfoEx->hkl == pkl->hkl) /* Matched */
             {
                 if (!pkl->piiex)
                     break;
 
-                *pInfoEx = *pkl->piiex;
-                return TRUE;
+                *pInfoEx = *pkl->piiex; /* Get */
+                return TRUE; /* Found */
             }
 
             pkl = pkl->pklNext;
@@ -186,14 +187,12 @@ BOOL FASTCALL UserGetImeInfoEx(LPVOID pUnknown, PIMEINFOEX pInfoEx, IMEINFOEXCLA
     {
         do
         {
-            if (pkl->piiex)
+            if (pkl->piiex &&
+                _wcsnicmp(pkl->piiex->wszImeFile, pInfoEx->wszImeFile,
+                          RTL_NUMBER_OF(pkl->piiex->wszImeFile)) == 0) /* Matched */
             {
-                if (!_wcsnicmp(pkl->piiex->wszImeFile, pInfoEx->wszImeFile,
-                               RTL_NUMBER_OF(pkl->piiex->wszImeFile)))
-                {
-                    *pInfoEx = *pkl->piiex;
-                    return TRUE;
-                }
+                *pInfoEx = *pkl->piiex; /* Get */
+                return TRUE; /* Found */
             }
 
             pkl = pkl->pklNext;
@@ -204,7 +203,7 @@ BOOL FASTCALL UserGetImeInfoEx(LPVOID pUnknown, PIMEINFOEX pInfoEx, IMEINFOEXCLA
         /* Do nothing */
     }
 
-    return FALSE;
+    return FALSE; /* Not found */
 }
 
 BOOL

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -157,16 +157,97 @@ NtUserGetAppImeLevel(HWND hWnd)
     return 0;
 }
 
+BOOL FASTCALL UserGetImeInfoEx(LPVOID pUnknown, PIMEINFOEX pInfoEx, IMEINFOEXCLASS SearchType)
+{
+    PKL pkl, pklHead;
+
+    if (!gspklBaseLayout)
+        return FALSE;
+
+    pkl = pklHead = gspklBaseLayout;
+
+    if (SearchType == ImeInfoExKeyboardLayout)
+    {
+        do
+        {
+            if (pInfoEx->hkl == pkl->hkl)
+            {
+                if (!pkl->piiex)
+                    break;
+
+                *pInfoEx = *pkl->piiex;
+                return TRUE;
+            }
+
+            pkl = pkl->pklNext;
+        } while (pkl != pklHead);
+    }
+    else if (SearchType == ImeInfoExImeFileName)
+    {
+        do
+        {
+            if (pkl->piiex)
+            {
+                if (!_wcsnicmp(pkl->piiex->wszImeFile, pInfoEx->wszImeFile,
+                               RTL_NUMBER_OF(pkl->piiex->wszImeFile)))
+                {
+                    *pInfoEx = *pkl->piiex;
+                    return TRUE;
+                }
+            }
+
+            pkl = pkl->pklNext;
+        } while (pkl != pklHead);
+    }
+    else
+    {
+        /* Do nothing */
+    }
+
+    return FALSE;
+}
+
 BOOL
 APIENTRY
 NtUserGetImeInfoEx(
     PIMEINFOEX pImeInfoEx,
     IMEINFOEXCLASS SearchType)
 {
-    STUB;
-    return FALSE;
-}
+    IMEINFOEX ImeInfoEx;
+    BOOL ret = FALSE;
 
+    UserEnterShared();
+
+    if (!IS_IMM_MODE())
+        goto Quit;
+
+    _SEH2_TRY
+    {
+        ProbeForWrite(pImeInfoEx, sizeof(*pImeInfoEx), 1);
+        ImeInfoEx = *pImeInfoEx;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        goto Quit;
+    }
+    _SEH2_END;
+
+    ret = UserGetImeInfoEx(NULL, &ImeInfoEx, SearchType);
+
+    _SEH2_TRY
+    {
+        *pImeInfoEx = ImeInfoEx;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ret = FALSE;
+    }
+    _SEH2_END;
+
+Quit:
+    UserLeave();
+    return ret;
+}
 
 DWORD
 APIENTRY

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -232,16 +232,18 @@ NtUserGetImeInfoEx(
     _SEH2_END;
 
     ret = UserGetImeInfoEx(NULL, &ImeInfoEx, SearchType);
-
-    _SEH2_TRY
+    if (ret)
     {
-        *pImeInfoEx = ImeInfoEx;
+        _SEH2_TRY
+        {
+            *pImeInfoEx = ImeInfoEx;
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            ret = FALSE;
+        }
+        _SEH2_END;
     }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        ret = FALSE;
-    }
-    _SEH2_END;
 
 Quit:
     UserLeave();


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `UserGetImeInfoEx` helper function.
- Implement `NtUserGetImeInfoEx` function by using `UserGetImeInfoEx`.
- Fix `imm32.ImmGetImeInfoEx`.
- Modify `enum IMEINFOEXCLASS`.

## TODO

- [x] Do tests