### PR TITLE
[FREELDR] Add support for Physical Address Extension (PAE) paging mode memory management.

### DIFF
--- a/boot/bootdata/livecd.ini
+++ b/boot/bootdata/livecd.ini
@@ -27,6 +27,7 @@ TimeText=Seconds until highlighted choice will be started automatically:
 [Operating Systems]
 LiveCD="LiveCD"
 LiveCD_Debug="LiveCD (Debug)"
+LiveCD_PAE_Debug="LiveCD PAE (Debug)"
 LiveCD_Aacpi="LiveCD ACPI APIC (Debug)"
 LiveCD_VBoxDebug="LiveCD (VBox Debug)"
 LiveCD_Screen="LiveCD (Screen)"
@@ -41,6 +42,11 @@ Options=/MININT
 BootType=Windows2003
 SystemPath=\reactos
 Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /SOS /MININT
+
+[LiveCD_PAE_Debug]
+BootType=Windows2003
+SystemPath=\reactos
+Options=/DEBUG /DEBUGPORT=COM1 /BAUDRATE=115200 /PAE /SOS /MININT
 
 [LiveCD_Aacpi]
 BootType=Windows2003

--- a/boot/freeldr/freeldr/include/arch/i386/i386.h
+++ b/boot/freeldr/freeldr/include/arch/i386/i386.h
@@ -48,6 +48,10 @@
 #define StartupPageTableIndex       (STARTUP_BASE >> 22)
 #define HalPageTableIndex           (HAL_BASE >> 22)
 
+#define APIC_BASE_PTE_IDX   ((APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT)
+#define USER_SHARED_PTE_IDX ((KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT)
+#define PCR0_PTE_IDX        ((KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT)
+
 typedef struct _PAGE_DIRECTORY_X86
 {
     HARDWARE_PTE Pde[1024];

--- a/boot/freeldr/freeldr/include/arch/i386/i386.h
+++ b/boot/freeldr/freeldr/include/arch/i386/i386.h
@@ -29,7 +29,9 @@
 
 /* Bits to shift to convert a Virtual Address into an Offset in the Page Directory */
 #define PDE_SHIFT 22
-#define PDE_SHIFT_PAE 18
+
+#define PDE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PDE_X86)) // 0x400 (1024)
+#define PTE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PTE_X86)) // 0x400 (1024)
 
 /* Converts a Physical Address Pointer into a Page Frame Number */
 #define PaPtrToPfn(p) \
@@ -40,6 +42,7 @@
     ((p) >> PFN_SHIFT)
 
 #define STARTUP_BASE                0xC0000000
+#define SELFMAP_ENTRY               0x300
 
 #define LowMemPageTableIndex        0
 #define StartupPageTableIndex       (STARTUP_BASE >> 22)
@@ -49,6 +52,56 @@ typedef struct _PAGE_DIRECTORY_X86
 {
     HARDWARE_PTE Pde[1024];
 } PAGE_DIRECTORY_X86, *PPAGE_DIRECTORY_X86;
+
+/* PAE specific */
+
+#define PAE_TABLES_START (ULONG_PTR)0xC0000000
+
+#define PAE_PTE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PTE_X86_PAE)) // 0x200 (512)
+#define PAE_PDE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PDE_X86_PAE)) // 0x200 (512)
+
+#define PAE_PTE_MASK     (PAE_PTE_PER_PAGE - 1)
+#define PAE_PDE_MASK     (PAE_PDE_PER_PAGE - 1)
+
+typedef struct _PAGE_DIRECTORY_X86_PAE
+{
+    HARDWARE_PDE_X86_PAE PaePde[PAE_PDE_PER_PAGE];
+} PAGE_DIRECTORY_X86_PAE, *PPAGE_DIRECTORY_X86_PAE;
+C_ASSERT(sizeof(PAGE_DIRECTORY_X86_PAE) == PAGE_SIZE);
+
+/* Number of Page Directories for PAE mode (4)
+   (two most significant bits in the VA)
+*/
+#define PAE_PD_COUNT   (1 << 2)
+#define PAE_PD_PADDING (PAGE_SIZE - (PAE_PD_COUNT * sizeof(HARDWARE_PDPTE_X86_PAE)))
+#define PDPTE_SHIFT    30
+
+#define MAX_PAE_PDE_COUNT (PAE_PD_COUNT * PAE_PDE_PER_PAGE)
+
+/* The size of the virtual memory area that is mapped using a single PDE */
+#define PAE_PDE_MAPPED_VA (PAE_PTE_PER_PAGE * PAGE_SIZE)
+
+/* Count PT and PTE need for HAL range */
+#define HAL_PT_COUNT  ((0xFFFFFFFF - 0xFFC00000 + 1) / PAE_PDE_MAPPED_VA)
+#define HAL_PTE_COUNT (HAL_PT_COUNT * PAE_PTE_PER_PAGE)
+
+/* Page-Directory-Pointer-Table should be aligned on 32-byte boundary
+   Allocating memory is always page-aligned, so this condition will be met.
+*/
+typedef struct _PAE_TABLES
+{
+    HARDWARE_PDPTE_X86_PAE Pdpte[PAE_PD_COUNT];  // PAE Page-Directory-Pointer-Table Entries (should be first)
+    UCHAR Padding[PAE_PD_PADDING];
+    PAGE_DIRECTORY_X86_PAE PaePd[PAE_PD_COUNT];  // PAE Page Directories
+    HARDWARE_PTE_X86_PAE HalPt[HAL_PTE_COUNT];   // PAE Page Tables for HAL
+    HARDWARE_PTE_X86_PAE PaePte[0];              // Start PAE Page Tables
+
+} PAE_TABLES, *PPAE_TABLES;
+C_ASSERT(sizeof(PAE_TABLES) == ((1 + PAE_PD_COUNT + 2) * PAGE_SIZE));
+
+#define KERNEL_PDE_IDX (KSEG0_BASE / PAE_PDE_MAPPED_VA)
+
+/* end PAE specific */
 
 void __cdecl i386DivideByZero(void);
 void __cdecl i386DebugException(void);

--- a/boot/freeldr/freeldr/include/arch/i386/i386.h
+++ b/boot/freeldr/freeldr/include/arch/i386/i386.h
@@ -54,7 +54,7 @@
 
 typedef struct _PAGE_DIRECTORY_X86
 {
-    HARDWARE_PTE Pde[1024];
+    HARDWARE_PTE_X86 Pde[1024];
 } PAGE_DIRECTORY_X86, *PPAGE_DIRECTORY_X86;
 
 void __cdecl i386DivideByZero(void);

--- a/boot/freeldr/freeldr/include/arch/i386/i386.h
+++ b/boot/freeldr/freeldr/include/arch/i386/i386.h
@@ -53,56 +53,6 @@ typedef struct _PAGE_DIRECTORY_X86
     HARDWARE_PTE Pde[1024];
 } PAGE_DIRECTORY_X86, *PPAGE_DIRECTORY_X86;
 
-/* PAE specific */
-
-#define PAE_TABLES_START (ULONG_PTR)0xC0000000
-
-#define PAE_PTE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PTE_X86_PAE)) // 0x200 (512)
-#define PAE_PDE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PDE_X86_PAE)) // 0x200 (512)
-
-#define PAE_PTE_MASK     (PAE_PTE_PER_PAGE - 1)
-#define PAE_PDE_MASK     (PAE_PDE_PER_PAGE - 1)
-
-typedef struct _PAGE_DIRECTORY_X86_PAE
-{
-    HARDWARE_PDE_X86_PAE PaePde[PAE_PDE_PER_PAGE];
-} PAGE_DIRECTORY_X86_PAE, *PPAGE_DIRECTORY_X86_PAE;
-C_ASSERT(sizeof(PAGE_DIRECTORY_X86_PAE) == PAGE_SIZE);
-
-/* Number of Page Directories for PAE mode (4)
-   (two most significant bits in the VA)
-*/
-#define PAE_PD_COUNT   (1 << 2)
-#define PAE_PD_PADDING (PAGE_SIZE - (PAE_PD_COUNT * sizeof(HARDWARE_PDPTE_X86_PAE)))
-#define PDPTE_SHIFT    30
-
-#define MAX_PAE_PDE_COUNT (PAE_PD_COUNT * PAE_PDE_PER_PAGE)
-
-/* The size of the virtual memory area that is mapped using a single PDE */
-#define PAE_PDE_MAPPED_VA (PAE_PTE_PER_PAGE * PAGE_SIZE)
-
-/* Count PT and PTE need for HAL range */
-#define HAL_PT_COUNT  ((0xFFFFFFFF - 0xFFC00000 + 1) / PAE_PDE_MAPPED_VA)
-#define HAL_PTE_COUNT (HAL_PT_COUNT * PAE_PTE_PER_PAGE)
-
-/* Page-Directory-Pointer-Table should be aligned on 32-byte boundary
-   Allocating memory is always page-aligned, so this condition will be met.
-*/
-typedef struct _PAE_TABLES
-{
-    HARDWARE_PDPTE_X86_PAE Pdpte[PAE_PD_COUNT];  // PAE Page-Directory-Pointer-Table Entries (should be first)
-    UCHAR Padding[PAE_PD_PADDING];
-    PAGE_DIRECTORY_X86_PAE PaePd[PAE_PD_COUNT];  // PAE Page Directories
-    HARDWARE_PTE_X86_PAE HalPt[HAL_PTE_COUNT];   // PAE Page Tables for HAL
-    HARDWARE_PTE_X86_PAE PaePte[0];              // Start PAE Page Tables
-
-} PAE_TABLES, *PPAE_TABLES;
-C_ASSERT(sizeof(PAE_TABLES) == ((1 + PAE_PD_COUNT + 2) * PAGE_SIZE));
-
-#define KERNEL_PDE_IDX (KSEG0_BASE / PAE_PDE_MAPPED_VA)
-
-/* end PAE specific */
-
 void __cdecl i386DivideByZero(void);
 void __cdecl i386DebugException(void);
 void __cdecl i386NMIException(void);

--- a/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     FreeLoader
- * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Physical Address Extension (PAE) paging mode definitions.
  * COPYRIGHT:   Copyright 2022 Vadim Galyant <vgal@rambler.ru>
  */
@@ -21,10 +21,8 @@ typedef struct _PAGE_DIRECTORY_X86_PAE
 } PAGE_DIRECTORY_X86_PAE, *PPAGE_DIRECTORY_X86_PAE;
 C_ASSERT(sizeof(PAGE_DIRECTORY_X86_PAE) == PAGE_SIZE);
 
-/* Number of Page Directories for PAE mode (4)
-   (two most significant bits in the VA)
-*/
-#define PAE_PD_COUNT   (1 << 2)
+/* Number of Page Directories for PAE mode (two most significant bits in the VA) */
+#define PAE_PD_COUNT   4
 #define PAE_PD_PADDING (PAGE_SIZE - (PAE_PD_COUNT * sizeof(HARDWARE_PDPTE_X86_PAE)))
 #define PDPTE_SHIFT    30
 

--- a/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#define PAE_TABLES_START (ULONG_PTR)0xC0000000
+#define PAE_TABLES_START ((ULONG_PTR)0xC0000000)
 
 #define PAE_PTE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PTE_X86_PAE)) // 0x200 (512)
 #define PAE_PDE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PDE_X86_PAE)) // 0x200 (512)
@@ -45,7 +45,6 @@ typedef struct _PAE_TABLES
     PAGE_DIRECTORY_X86_PAE PaePd[PAE_PD_COUNT];  // PAE Page Directories
     HARDWARE_PTE_X86_PAE HalPt[HAL_PTE_COUNT];   // PAE Page Tables for HAL
     HARDWARE_PTE_X86_PAE PaePte[0];              // Start PAE Page Tables
-
 } PAE_TABLES, *PPAE_TABLES;
 C_ASSERT(sizeof(PAE_TABLES) == ((1 + PAE_PD_COUNT + 2) * PAGE_SIZE));
 

--- a/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/pae.h
@@ -1,0 +1,56 @@
+/*
+ * PROJECT:     FreeLoader
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     Physical Address Extension (PAE) paging mode definitions.
+ * COPYRIGHT:   Copyright 2022 Vadim Galyant <vgal@rambler.ru>
+ */
+
+#pragma once
+
+#define PAE_TABLES_START (ULONG_PTR)0xC0000000
+
+#define PAE_PTE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PTE_X86_PAE)) // 0x200 (512)
+#define PAE_PDE_PER_PAGE (PAGE_SIZE / sizeof(HARDWARE_PDE_X86_PAE)) // 0x200 (512)
+
+#define PAE_PTE_MASK     (PAE_PTE_PER_PAGE - 1)
+#define PAE_PDE_MASK     (PAE_PDE_PER_PAGE - 1)
+
+typedef struct _PAGE_DIRECTORY_X86_PAE
+{
+    HARDWARE_PDE_X86_PAE PaePde[PAE_PDE_PER_PAGE];
+} PAGE_DIRECTORY_X86_PAE, *PPAGE_DIRECTORY_X86_PAE;
+C_ASSERT(sizeof(PAGE_DIRECTORY_X86_PAE) == PAGE_SIZE);
+
+/* Number of Page Directories for PAE mode (4)
+   (two most significant bits in the VA)
+*/
+#define PAE_PD_COUNT   (1 << 2)
+#define PAE_PD_PADDING (PAGE_SIZE - (PAE_PD_COUNT * sizeof(HARDWARE_PDPTE_X86_PAE)))
+#define PDPTE_SHIFT    30
+
+#define MAX_PAE_PDE_COUNT (PAE_PD_COUNT * PAE_PDE_PER_PAGE)
+
+/* The size of the virtual memory area that is mapped using a single PDE */
+#define PAE_PDE_MAPPED_VA (PAE_PTE_PER_PAGE * PAGE_SIZE)
+
+/* Count PT and PTE need for HAL range */
+#define HAL_PT_COUNT  ((0xFFFFFFFF - 0xFFC00000 + 1) / PAE_PDE_MAPPED_VA)
+#define HAL_PTE_COUNT (HAL_PT_COUNT * PAE_PTE_PER_PAGE)
+
+/* Page-Directory-Pointer-Table should be aligned on 32-byte boundary
+   Allocating memory is always page-aligned, so this condition will be met.
+*/
+typedef struct _PAE_TABLES
+{
+    HARDWARE_PDPTE_X86_PAE Pdpte[PAE_PD_COUNT];  // PAE Page-Directory-Pointer-Table Entries (should be first)
+    UCHAR Padding[PAE_PD_PADDING];
+    PAGE_DIRECTORY_X86_PAE PaePd[PAE_PD_COUNT];  // PAE Page Directories
+    HARDWARE_PTE_X86_PAE HalPt[HAL_PTE_COUNT];   // PAE Page Tables for HAL
+    HARDWARE_PTE_X86_PAE PaePte[0];              // Start PAE Page Tables
+
+} PAE_TABLES, *PPAE_TABLES;
+C_ASSERT(sizeof(PAE_TABLES) == ((1 + PAE_PD_COUNT + 2) * PAGE_SIZE));
+
+#define KERNEL_PDE_IDX (KSEG0_BASE / PAE_PDE_MAPPED_VA)
+
+/* EOF */

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -518,6 +518,7 @@ WinLdrpMapApic(VOID)
     BOOLEAN LocalAPIC;
     LARGE_INTEGER MsrValue;
     ULONG APICAddress, CpuInfo[4];
+    PFN_NUMBER Pfn;
 
     /* Check if we have a local APIC */
     __cpuid((int*)CpuInfo, 1);
@@ -535,21 +536,23 @@ WinLdrpMapApic(VOID)
         APICAddress);
 
     /* Map it */
+    Pfn = (APICAddress >> MM_PAGE_SHIFT);
+
     if (!PaeModeOn)
     {
-        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = APICAddress >> MM_PAGE_SHIFT;
-        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
-        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].WriteThrough = 1;
-        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].CacheDisable = 1;
+        HalPageTable[APIC_BASE_PTE_IDX].PageFrameNumber = Pfn;
+        HalPageTable[APIC_BASE_PTE_IDX].Valid = 1;
+        HalPageTable[APIC_BASE_PTE_IDX].Write = 1;
+        HalPageTable[APIC_BASE_PTE_IDX].WriteThrough = 1;
+        HalPageTable[APIC_BASE_PTE_IDX].CacheDisable = 1;
     }
     else
     {
-        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = APICAddress >> MM_PAGE_SHIFT;
-        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
-        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].WriteThrough = 1;
-        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].CacheDisable = 1;
+        PaeTables->HalPt[APIC_BASE_PTE_IDX].PageFrameNumber = Pfn;
+        PaeTables->HalPt[APIC_BASE_PTE_IDX].Valid = 1;
+        PaeTables->HalPt[APIC_BASE_PTE_IDX].Write = 1;
+        PaeTables->HalPt[APIC_BASE_PTE_IDX].WriteThrough = 1;
+        PaeTables->HalPt[APIC_BASE_PTE_IDX].CacheDisable = 1;
     }
 }
 
@@ -557,31 +560,35 @@ static
 BOOLEAN
 WinLdrMapSpecialPages(void)
 {
+    PFN_NUMBER Pfn;
+
     TRACE("HalPageTable: 0x%X\n", HalPageTable);
 
     /*
      * The Page Tables have been setup, make special handling
      * for the boot processor PCR and KI_USER_SHARED_DATA.
      */
+    Pfn = (PcrBasePage + 1);
+
     if (!PaeModeOn)
     {
-        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage+1;
-        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        HalPageTable[USER_SHARED_PTE_IDX].PageFrameNumber = Pfn;
+        HalPageTable[USER_SHARED_PTE_IDX].Valid = 1;
+        HalPageTable[USER_SHARED_PTE_IDX].Write = 1;
 
-        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage;
-        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        HalPageTable[PCR0_PTE_IDX].PageFrameNumber = PcrBasePage;
+        HalPageTable[PCR0_PTE_IDX].Valid = 1;
+        HalPageTable[PCR0_PTE_IDX].Write = 1;
     }
     else
     {
-        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage+1;
-        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        PaeTables->HalPt[USER_SHARED_PTE_IDX].PageFrameNumber = Pfn;
+        PaeTables->HalPt[USER_SHARED_PTE_IDX].Valid = 1;
+        PaeTables->HalPt[USER_SHARED_PTE_IDX].Write = 1;
 
-        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage;
-        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        PaeTables->HalPt[PCR0_PTE_IDX].PageFrameNumber = PcrBasePage;
+        PaeTables->HalPt[PCR0_PTE_IDX].Valid = 1;
+        PaeTables->HalPt[PCR0_PTE_IDX].Write = 1;
     }
 
     /* Map APIC */

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -11,6 +11,7 @@
 #include <freeldr.h>
 #include <ndk/asm.h>
 #include "../../winldr.h"
+#include "pae.h"
 
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(WINDOWS);

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -161,8 +161,8 @@ DumpGDTEntry(ULONG_PTR Base, ULONG Selector)
 
 /* GLOBALS *******************************************************************/
 
-PHARDWARE_PTE PDE;
-PHARDWARE_PTE HalPageTable;
+PHARDWARE_PTE_X86 PDE;
+PHARDWARE_PTE_X86 HalPageTable;
 PPAE_TABLES PaeTables;
 
 PUCHAR PhysicalPageTablesBuffer;
@@ -238,7 +238,7 @@ MempAllocatePageTables(VOID)
     if (!PaeModeOn)
     {
         /* Set up pointers correctly now */
-        PDE = (PHARDWARE_PTE)Buffer;
+        PDE = (PHARDWARE_PTE_X86)Buffer;
 
         /* Map the page directory at 0xC0000000 (maps itself) */
         PDE[SELFMAP_ENTRY].PageFrameNumber = (ULONG)PDE >> MM_PAGE_SHIFT;
@@ -246,7 +246,7 @@ MempAllocatePageTables(VOID)
         PDE[SELFMAP_ENTRY].Write = 1;
 
         /* The last PDE slot is allocated for HAL's memory mapping (Virtual Addresses 0xFFC00000 - 0xFFFFFFFF) */
-        HalPageTable = (PHARDWARE_PTE)&Buffer[MM_PAGE_SIZE*1];
+        HalPageTable = (PHARDWARE_PTE_X86)&Buffer[MM_PAGE_SIZE*1];
 
         /* Map it */
         PDE[PDE_PER_PAGE - 1].PageFrameNumber = (ULONG)HalPageTable >> MM_PAGE_SHIFT;
@@ -422,8 +422,8 @@ MempSetupPaging(IN PFN_NUMBER StartPage,
             }
             else
             {
-                PhysicalPde = (PHARDWARE_PTE)(PDE[PdeIdx].PageFrameNumber << MM_PAGE_SHIFT);
-                KernelPde = (PHARDWARE_PTE)(PDE[PdeIdx+(KSEG0_BASE >> 22)].PageFrameNumber << MM_PAGE_SHIFT);
+                PhysicalPde = (PHARDWARE_PTE_X86)(PDE[PdeIdx].PageFrameNumber << MM_PAGE_SHIFT);
+                KernelPde = (PHARDWARE_PTE_X86)(PDE[PdeIdx+(KSEG0_BASE >> 22)].PageFrameNumber << MM_PAGE_SHIFT);
             }
 
             PhysicalPde[Page & 0x3ff].PageFrameNumber = Page;
@@ -485,7 +485,7 @@ MempSetupPaging(IN PFN_NUMBER StartPage,
 VOID
 MempUnmapPage(PFN_NUMBER Page)
 {
-    PHARDWARE_PTE KernelPT;
+    PHARDWARE_PTE_X86 KernelPT;
     PFN_NUMBER Entry = (Page >> 10) + (KSEG0_BASE >> 22);
 
     if (PaeModeOn)
@@ -500,7 +500,7 @@ MempUnmapPage(PFN_NUMBER Page)
 
     if (PDE[Entry].Valid)
     {
-        KernelPT = (PHARDWARE_PTE)(PDE[Entry].PageFrameNumber << MM_PAGE_SHIFT);
+        KernelPT = (PHARDWARE_PTE_X86)(PDE[Entry].PageFrameNumber << MM_PAGE_SHIFT);
 
         if (KernelPT)
         {

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -712,15 +712,11 @@ WinLdrSetProcessorContext(void)
     {
         TRACE("WinLdrSetProcessorContext: PaeTables %X, cr0 %X, cr3 %X, cr4 %X\n", PaeTables, __readcr0(), __readcr3(), __readcr4());
 
-        /* Flush TLB */
-        __writecr3(__readcr3());
-
         /* Set the PDPTR */
         __writecr3((ULONG_PTR)PaeTables);
 
         /* Enable PAE */
         __writecr4(__readcr4() | 0x20);
-
     }
 
     /* Enable paging */

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -15,12 +15,6 @@
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(WINDOWS);
 
-// This is needed because headers define wrong one for ReactOS
-#undef KIP0PCRADDRESS
-#define KIP0PCRADDRESS                      0xffdff000
-
-#define SELFMAP_ENTRY       0x300
-
 // This is needed only for SetProcessorContext routine
 #pragma pack(2)
 typedef struct
@@ -168,6 +162,7 @@ DumpGDTEntry(ULONG_PTR Base, ULONG Selector)
 
 PHARDWARE_PTE PDE;
 PHARDWARE_PTE HalPageTable;
+PPAE_TABLES PaeTables;
 
 PUCHAR PhysicalPageTablesBuffer;
 PUCHAR KernelPageTablesBuffer;
@@ -178,6 +173,8 @@ ULONG PcrBasePage;
 ULONG TssBasePage;
 PVOID GdtIdt;
 
+extern BOOLEAN PaeModeOn;
+
 /* FUNCTIONS *****************************************************************/
 
 static
@@ -186,33 +183,46 @@ MempAllocatePageTables(VOID)
 {
     ULONG NumPageTables, TotalSize;
     PUCHAR Buffer;
-    // It's better to allocate PDE + PTEs contiguous
+    ULONG ix;
 
-    // Max number of entries = MaxPageNum >> 10
-    // FIXME: This is a number to describe ALL physical memory
-    // and windows doesn't expect ALL memory mapped...
-    NumPageTables = TotalPagesInLookupTable >> 10;
+    TRACE("MempAllocatePageTables: PaeModeOn %d\n", PaeModeOn);
 
-    TRACE("NumPageTables = %d\n", NumPageTables);
+    /* It's better to allocate PDE + PTEs contiguous.
+       Max number of entries = MaxPageNum >> 10(9 if PAE).
+       FIXME: This is a number to describe ALL physical memory
+       and windows doesn't expect ALL memory mapped...
+    */
 
-    // Allocate memory block for all these things:
-    // PDE, HAL mapping page table, physical mapping, kernel mapping
-    TotalSize = (1 + 1 + NumPageTables * 2) * MM_PAGE_SIZE;
+    /* Allocate memory block for all these things:
+       PDE, HAL mapping page table, physical mapping, kernel mapping.
+    */
+    if (!PaeModeOn)
+    {
+        NumPageTables = (TotalPagesInLookupTable / PTE_PER_PAGE);
+        TotalSize = ((1 + 1 + (NumPageTables * 2)) * MM_PAGE_SIZE);
+        TRACE("MempAllocatePageTables: NumPageTables = %X (%d)\n", NumPageTables, NumPageTables);
+    }
+    else
+    {
+       NumPageTables = (TotalPagesInLookupTable / PAE_PTE_PER_PAGE);
+       TotalSize = (sizeof(PAE_TABLES) + ((NumPageTables * 2) * MM_PAGE_SIZE));
+        TRACE("MempAllocatePageTables: NumPageTables = %X (%d)\n", NumPageTables, NumPageTables);
+    }
 
-    // PDE+HAL+KernelPTEs == MemoryData
+    /* Allocate memory for PD, HAL PT, Kernel PTs with MemoryData type */
     Buffer = MmAllocateMemoryWithType(TotalSize, LoaderMemoryData);
 
-    // Physical PTEs = FirmwareTemporary
-    PhysicalPageTablesBuffer = (PUCHAR)Buffer + TotalSize - NumPageTables*MM_PAGE_SIZE;
+    /* Allocate memory for Physical PTs with FirmwareTemporary type */
+    PhysicalPageTablesBuffer = (PUCHAR)Buffer + TotalSize - (NumPageTables * MM_PAGE_SIZE);
+    TRACE("MempAllocatePageTables: PhysicalPageTablesBuffer %X\n", PhysicalPageTablesBuffer);
     MmSetMemoryType(PhysicalPageTablesBuffer,
-                    NumPageTables*MM_PAGE_SIZE,
+                    (NumPageTables * MM_PAGE_SIZE),
                     LoaderFirmwareTemporary);
 
-    // This check is now redundant
-    if (Buffer + (TotalSize - NumPageTables*MM_PAGE_SIZE) !=
-        PhysicalPageTablesBuffer)
+    /* This check is now redundant */
+    if (Buffer + (TotalSize - (NumPageTables * MM_PAGE_SIZE)) != PhysicalPageTablesBuffer)
     {
-        TRACE("There was a problem allocating two adjacent blocks of memory!");
+        WARN("There was a problem allocating two adjacent blocks of memory!");
     }
 
     if (Buffer == NULL || PhysicalPageTablesBuffer == NULL)
@@ -221,29 +231,86 @@ MempAllocatePageTables(VOID)
         return FALSE;
     }
 
-    // Zero all this memory block
+    /* Zero all this memory block */
     RtlZeroMemory(Buffer, TotalSize);
 
-    // Set up pointers correctly now
-    PDE = (PHARDWARE_PTE)Buffer;
+    if (!PaeModeOn)
+    {
+        /* Set up pointers correctly now */
+        PDE = (PHARDWARE_PTE)Buffer;
 
-    // Map the page directory at 0xC0000000 (maps itself)
-    PDE[SELFMAP_ENTRY].PageFrameNumber = (ULONG)PDE >> MM_PAGE_SHIFT;
-    PDE[SELFMAP_ENTRY].Valid = 1;
-    PDE[SELFMAP_ENTRY].Write = 1;
+        /* Map the page directory at 0xC0000000 (maps itself) */
+        PDE[SELFMAP_ENTRY].PageFrameNumber = (ULONG)PDE >> MM_PAGE_SHIFT;
+        PDE[SELFMAP_ENTRY].Valid = 1;
+        PDE[SELFMAP_ENTRY].Write = 1;
 
-    // The last PDE slot is allocated for HAL's memory mapping (Virtual Addresses 0xFFC00000 - 0xFFFFFFFF)
-    HalPageTable = (PHARDWARE_PTE)&Buffer[MM_PAGE_SIZE*1];
+        /* The last PDE slot is allocated for HAL's memory mapping (Virtual Addresses 0xFFC00000 - 0xFFFFFFFF) */
+        HalPageTable = (PHARDWARE_PTE)&Buffer[MM_PAGE_SIZE*1];
 
-    // Map it
-    PDE[1023].PageFrameNumber = (ULONG)HalPageTable >> MM_PAGE_SHIFT;
-    PDE[1023].Valid = 1;
-    PDE[1023].Write = 1;
+        /* Map it */
+        PDE[PDE_PER_PAGE - 1].PageFrameNumber = (ULONG)HalPageTable >> MM_PAGE_SHIFT;
+        PDE[PDE_PER_PAGE - 1].Valid = 1;
+        PDE[PDE_PER_PAGE - 1].Write = 1;
 
-    // Store pointer to the table for easier access
-    KernelPageTablesBuffer = &Buffer[MM_PAGE_SIZE*2];
+        /* Store pointer to the table for easier access */
+        KernelPageTablesBuffer = &Buffer[MM_PAGE_SIZE*2];
+    }
+    else
+    {
+        PPAGE_DIRECTORY_X86_PAE PaePd;
+        PFN_NUMBER PaeHalPages;
+        PHARDWARE_PDPTE_X86_PAE Pdpte;
+        PHARDWARE_PDE_X86_PAE PaePde;
 
-    // Zero counters of page tables used
+        PaeTables = (PPAE_TABLES)Buffer;
+        PaePd = (PPAGE_DIRECTORY_X86_PAE)PaeTables->PaePd;
+        TRACE("MempAllocatePageTables: PaeTables %X, PaePd %X\n", PaeTables, PaePd);
+
+        /* Fill the page-directory-pointer-table */
+        for (ix = 0; ix < PAE_PD_COUNT; ix++)
+        {
+            Pdpte = &PaeTables->Pdpte[ix];
+
+            Pdpte->PageFrameNumber = ((ULONG)Buffer >> MM_PAGE_SHIFT) + (ix + 1);
+            Pdpte->Valid = 1;
+            Pdpte->Write = 1;
+            TRACE("MempAllocatePageTables: [%X] Pdpte->PageFrameNumber %X\n", ix, (ULONG)Pdpte->PageFrameNumber);
+        }
+
+        /* Map the page directories at PAE_TABLES_START (maps itself) */
+        for (ix = 0; ix < PAE_PD_COUNT; ix++)
+        {
+            Pdpte = &PaeTables->Pdpte[ix];
+            PaePde = &PaePd[PAE_TABLES_START >> PDPTE_SHIFT].PaePde[ix];
+
+            PaePde->PageFrameNumber = Pdpte->PageFrameNumber;
+            PaePde->Valid = 1;
+            PaePde->Write = 1;
+        }
+
+        /* The last Pde slots is allocated for HAL's memory mapping (Virtual Addresses 0xFFC00000 - 0xFFFFFFFF) */
+        PaeHalPages = ((ULONG_PTR)PaeTables->HalPt >> MM_PAGE_SHIFT);
+        TRACE("MempAllocatePageTables: PaeHalPages %X\n", PaeHalPages);
+
+        /* Map it at end page directories */
+        ix = (PAE_TABLES_START >> PDPTE_SHIFT);
+
+        PaePde = &PaePd[ix].PaePde[PAE_PDE_PER_PAGE - 2];
+        PaePde->PageFrameNumber = (PaeHalPages + 0);
+        PaePde->Valid = 1;
+        PaePde->Write = 1;
+
+        PaePde = &PaePd[ix].PaePde[PAE_PDE_PER_PAGE - 1];
+        PaePde->PageFrameNumber = (PaeHalPages + 1);
+        PaePde->Valid = 1;
+        PaePde->Write = 1;
+
+        /* Store pointer to the table for easier access */
+        KernelPageTablesBuffer = (PUCHAR)PaeTables->PaePte;
+        TRACE("MempAllocatePageTables: KernelPageTablesBuffer %X\n", KernelPageTablesBuffer);
+    }
+
+    /* Zero counters of page tables used */
     PhysicalPageTables = 0;
     KernelPageTables = 0;
 
@@ -252,12 +319,12 @@ MempAllocatePageTables(VOID)
 
 static
 VOID
-MempAllocatePTE(ULONG Entry, PHARDWARE_PTE *PhysicalPT, PHARDWARE_PTE *KernelPT)
+MempAllocatePde(ULONG Entry, PHARDWARE_PDE_X86 * PhysicalPT, PHARDWARE_PDE_X86 * KernelPT)
 {
     //Print(L"Creating PDE Entry %X\n", Entry);
 
     // Identity mapping
-    *PhysicalPT = (PHARDWARE_PTE)&PhysicalPageTablesBuffer[PhysicalPageTables*MM_PAGE_SIZE];
+    *PhysicalPT = (PHARDWARE_PDE_X86)&PhysicalPageTablesBuffer[PhysicalPageTables*MM_PAGE_SIZE];
     PhysicalPageTables++;
 
     PDE[Entry].PageFrameNumber = (ULONG)*PhysicalPT >> MM_PAGE_SHIFT;
@@ -270,7 +337,7 @@ MempAllocatePTE(ULONG Entry, PHARDWARE_PTE *PhysicalPT, PHARDWARE_PTE *KernelPT)
     }
 
     // Kernel-mode mapping
-    *KernelPT = (PHARDWARE_PTE)&KernelPageTablesBuffer[KernelPageTables*MM_PAGE_SIZE];
+    *KernelPT = (PHARDWARE_PDE_X86)&KernelPageTablesBuffer[KernelPageTables*MM_PAGE_SIZE];
     KernelPageTables++;
 
     PDE[Entry+(KSEG0_BASE >> 22)].PageFrameNumber = ((ULONG)*KernelPT >> MM_PAGE_SHIFT);
@@ -278,56 +345,135 @@ MempAllocatePTE(ULONG Entry, PHARDWARE_PTE *PhysicalPT, PHARDWARE_PTE *KernelPT)
     PDE[Entry+(KSEG0_BASE >> 22)].Write = 1;
 }
 
+static
+VOID
+MempAllocatePaePde(ULONG PdeIdx, PHARDWARE_PDE_X86_PAE * PhysicalPde, PHARDWARE_PDE_X86_PAE * KernelPde)
+{
+    PHARDWARE_PDE_X86_PAE Pde;
+    ULONG PdIdx;
+
+    /* Identity mapping */
+    *PhysicalPde = (PHARDWARE_PDE_X86_PAE)&PhysicalPageTablesBuffer[PhysicalPageTables * MM_PAGE_SIZE];
+    PhysicalPageTables++;
+
+    PdIdx = (PdeIdx / PAE_PDE_PER_PAGE);
+
+    Pde = &PaeTables->PaePd[PdIdx].PaePde[PdeIdx & PAE_PDE_MASK];
+    Pde->PageFrameNumber = (ULONG)*PhysicalPde >> MM_PAGE_SHIFT;
+    Pde->Valid = 1;
+    Pde->Write = 1;
+
+
+    if ((PdeIdx + KERNEL_PDE_IDX) > (MAX_PAE_PDE_COUNT - 1))
+    {
+        ERR("WARNING! PdeIdx %X > %X\n", (PdeIdx + KERNEL_PDE_IDX, (MAX_PAE_PDE_COUNT - 1)));
+    }
+
+    /* Kernel-mode mapping */
+    *KernelPde = (PHARDWARE_PDE_X86_PAE)&KernelPageTablesBuffer[KernelPageTables * MM_PAGE_SIZE];
+    KernelPageTables++;
+
+    PdIdx = ((PdeIdx + KERNEL_PDE_IDX) / PAE_PDE_PER_PAGE);
+
+    Pde = &PaeTables->PaePd[PdIdx].PaePde[PdeIdx & PAE_PDE_MASK];
+    Pde->PageFrameNumber = (ULONG)*PhysicalPde >> MM_PAGE_SHIFT;
+    Pde->Valid = 1;
+    Pde->Write = 1;
+}
+
 BOOLEAN
 MempSetupPaging(IN PFN_NUMBER StartPage,
                 IN PFN_COUNT NumberOfPages,
                 IN BOOLEAN KernelMapping)
 {
-    PHARDWARE_PTE PhysicalPT;
-    PHARDWARE_PTE KernelPT;
-    PFN_COUNT Entry, Page;
+    PFN_COUNT Page;
+    PFN_COUNT PdeIdx;
+    PFN_COUNT PhysicalPdIdx;
+    PFN_COUNT KernelPdIdx;
 
-    TRACE("MempSetupPaging: SP 0x%X, Number: 0x%X, Kernel: %s\n",
-       StartPage, NumberOfPages, KernelMapping ? "yes" : "no");
-
-    // HACK
-    if (StartPage+NumberOfPages >= 0x80000)
+    /* HACK */
+    if ((StartPage + NumberOfPages) >= 0x80000)
     {
-        //
-        // We cannot map this as it requires more than 1 PDE
-        // and in fact it's not possible at all ;)
-        //
-        //Print(L"skipping...\n");
+        /* We cannot map this as it requires more than 1 PDE
+           and in fact it's not possible at all ;)
+        */
+        ERR("MempSetupPaging: skipping... StartPage %X, Pages %X, Kernel: %s\n",
+            StartPage, NumberOfPages, KernelMapping ? "yes" : "no");
+
         return TRUE;
     }
 
-    //
-    // Now actually set up the page tables for identity mapping
-    //
-    for (Page = StartPage; Page < StartPage + NumberOfPages; Page++)
-    {
-        Entry = Page >> 10;
+    TRACE("MempSetupPaging: StartPage %X, Pages %X, Kernel: %s\n", StartPage, NumberOfPages, KernelMapping ? "yes" : "no");
 
-        if (((PULONG)PDE)[Entry] == 0)
+    /* Now actually set up the page tables for identity mapping */
+    for (Page = StartPage; Page < (StartPage + NumberOfPages); Page++)
+    {
+        if (!PaeModeOn)
         {
-            MempAllocatePTE(Entry, &PhysicalPT, &KernelPT);
+            PHARDWARE_PDE_X86 PhysicalPde;
+            PHARDWARE_PDE_X86 KernelPde;
+
+            PdeIdx = (Page >> 10);
+
+            if (((PULONG)PDE)[PdeIdx] == 0)
+            {
+                MempAllocatePde(PdeIdx, &PhysicalPde, &KernelPde);
+            }
+            else
+            {
+                PhysicalPde = (PHARDWARE_PTE)(PDE[PdeIdx].PageFrameNumber << MM_PAGE_SHIFT);
+                KernelPde = (PHARDWARE_PTE)(PDE[PdeIdx+(KSEG0_BASE >> 22)].PageFrameNumber << MM_PAGE_SHIFT);
+            }
+
+            PhysicalPde[Page & 0x3ff].PageFrameNumber = Page;
+            PhysicalPde[Page & 0x3ff].Valid = (Page != 0);
+            PhysicalPde[Page & 0x3ff].Write = (Page != 0);
+
+            if (KernelMapping)
+            {
+                if (KernelPde[Page & 0x3ff].Valid) WARN("KernelPde already mapped\n");
+
+                KernelPde[Page & 0x3ff].PageFrameNumber = Page;
+                KernelPde[Page & 0x3ff].Valid = (Page != 0);
+                KernelPde[Page & 0x3ff].Write = (Page != 0);
+            }
         }
         else
         {
-            PhysicalPT = (PHARDWARE_PTE)(PDE[Entry].PageFrameNumber << MM_PAGE_SHIFT);
-            KernelPT = (PHARDWARE_PTE)(PDE[Entry+(KSEG0_BASE >> 22)].PageFrameNumber << MM_PAGE_SHIFT);
-        }
+            PHARDWARE_PDE_X86_PAE PhysicalPde;
+            PHARDWARE_PDE_X86_PAE KernelPde;
 
-        PhysicalPT[Page & 0x3ff].PageFrameNumber = Page;
-        PhysicalPT[Page & 0x3ff].Valid = (Page != 0);
-        PhysicalPT[Page & 0x3ff].Write = (Page != 0);
+            PdeIdx = (Page / PAE_PTE_PER_PAGE);
 
-        if (KernelMapping)
-        {
-            if (KernelPT[Page & 0x3ff].Valid) WARN("KernelPT already mapped\n");
-            KernelPT[Page & 0x3ff].PageFrameNumber = Page;
-            KernelPT[Page & 0x3ff].Valid = (Page != 0);
-            KernelPT[Page & 0x3ff].Write = (Page != 0);
+            PhysicalPdIdx = (PdeIdx / PAE_PDE_PER_PAGE);
+            KernelPdIdx = ((PdeIdx + KERNEL_PDE_IDX) / PAE_PDE_PER_PAGE);
+
+            //TRACE("MempSetupPaging: Page %X, PdeIdx %X, PhysicalPdIdx %X, KernelPdIdx %X\n", Page, PdeIdx, PhysicalPdIdx, KernelPdIdx);
+
+            if (PaeTables->PaePd[PhysicalPdIdx].PaePde[PdeIdx].LowPart == 0)
+            {
+                MempAllocatePaePde(PdeIdx, &PhysicalPde, &KernelPde);
+            }
+            else
+            {
+                PhysicalPde = (PHARDWARE_PDE_X86_PAE)(PaeTables->PaePd[PhysicalPdIdx].PaePde[PdeIdx & PAE_PDE_MASK].PageFrameNumber << MM_PAGE_SHIFT);
+                KernelPde   = (PHARDWARE_PDE_X86_PAE)(PaeTables->PaePd[KernelPdIdx].PaePde[PdeIdx & PAE_PDE_MASK].PageFrameNumber << MM_PAGE_SHIFT);
+            }
+
+            //TRACE("MempSetupPaging: PhysicalPde %X, KernelPde %X\n", PhysicalPde, KernelPde);
+
+            PhysicalPde[Page & PAE_PDE_MASK].PageFrameNumber = Page;
+            PhysicalPde[Page & PAE_PDE_MASK].Valid = (Page != 0);
+            PhysicalPde[Page & PAE_PDE_MASK].Write = (Page != 0);
+
+            if (KernelMapping)
+            {
+                if (KernelPde[Page & PAE_PDE_MASK].Valid) WARN("KernelPde already mapped\n");
+
+                KernelPde[Page & PAE_PDE_MASK].PageFrameNumber = Page;
+                KernelPde[Page & PAE_PDE_MASK].Valid = (Page != 0);
+                KernelPde[Page & PAE_PDE_MASK].Write = (Page != 0);
+            }
         }
     }
 
@@ -339,6 +485,12 @@ MempUnmapPage(PFN_NUMBER Page)
 {
     PHARDWARE_PTE KernelPT;
     PFN_NUMBER Entry = (Page >> 10) + (KSEG0_BASE >> 22);
+
+    if (PaeModeOn)
+    {
+        UNIMPLEMENTED;
+        return;
+    }
 
     /* Don't unmap page directory or HAL entries */
     if (Entry == SELFMAP_ENTRY || Entry == 1023)
@@ -381,12 +533,22 @@ WinLdrpMapApic(VOID)
         APICAddress);
 
     /* Map it */
-    HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber
-        = APICAddress >> MM_PAGE_SHIFT;
-    HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-    HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
-    HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].WriteThrough = 1;
-    HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].CacheDisable = 1;
+    if (!PaeModeOn)
+    {
+        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = APICAddress >> MM_PAGE_SHIFT;
+        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].WriteThrough = 1;
+        HalPageTable[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].CacheDisable = 1;
+    }
+    else
+    {
+        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = APICAddress >> MM_PAGE_SHIFT;
+        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].WriteThrough = 1;
+        PaeTables->HalPt[(APIC_BASE - 0xFFC00000) >> MM_PAGE_SHIFT].CacheDisable = 1;
+    }
 }
 
 static
@@ -399,13 +561,26 @@ WinLdrMapSpecialPages(void)
      * The Page Tables have been setup, make special handling
      * for the boot processor PCR and KI_USER_SHARED_DATA.
      */
-    HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage+1;
-    HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-    HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+    if (!PaeModeOn)
+    {
+        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage+1;
+        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        HalPageTable[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
 
-    HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage;
-    HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
-    HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage;
+        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        HalPageTable[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+    }
+    else
+    {
+        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage+1;
+        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        PaeTables->HalPt[(KI_USER_SHARED_DATA - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+
+        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].PageFrameNumber = PcrBasePage;
+        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Valid = 1;
+        PaeTables->HalPt[(KIP0PCRADDRESS - 0xFFC00000) >> MM_PAGE_SHIFT].Write = 1;
+    }
 
     /* Map APIC */
     WinLdrpMapApic();
@@ -501,7 +676,6 @@ void WinLdrSetupMachineDependent(PLOADER_PARAMETER_BLOCK LoaderBlock)
     WinLdrSetupSpecialDataPointers();
 }
 
-
 VOID
 WinLdrSetProcessorContext(void)
 {
@@ -528,11 +702,32 @@ WinLdrSetProcessorContext(void)
     /* Re-initialize EFLAGS */
     __writeeflags(0);
 
-    /* Set the PDBR */
-    __writecr3((ULONG_PTR)PDE);
+    if (!PaeModeOn)
+    {
+        /* Set the PDBR */
+        __writecr3((ULONG_PTR)PDE);
 
-    /* Enable paging by modifying CR0 */
-    __writecr0(__readcr0() | CR0_PG);
+        /* Enable paging by modifying CR0 */
+        __writecr0(__readcr0() | CR0_PG);
+    }
+    else
+    {
+        TRACE("WinLdrSetProcessorContext: PaeTables %X, cr0 %X, cr3 %X, cr4 %X\n", PaeTables, __readcr0(), __readcr3(), __readcr4());
+
+        /* Flush TLB */
+        __writecr3(__readcr3());
+
+        /* Set the PDPTR */
+        __writecr3((ULONG_PTR)PaeTables);
+
+        /* Enable PAE */
+        __writecr4(__readcr4() | 0x20);
+
+        /* Enable paging */
+        __writecr0(__readcr0() | CR0_PG);
+    }
+
+    TRACE("WinLdrSetProcessorContext: cr0 %X, cr3 %X, cr4 %X\n", __readcr0(), __readcr3(), __readcr4());
 
     /* The Kernel expects the boot processor PCR to be zero-filled on startup */
     RtlZeroMemory((PVOID)Pcr, MM_PAGE_SIZE);

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -201,14 +201,14 @@ MempAllocatePageTables(VOID)
     {
         NumPageTables = (TotalPagesInLookupTable / PTE_PER_PAGE);
         TotalSize = ((1 + 1 + (NumPageTables * 2)) * MM_PAGE_SIZE);
-        TRACE("MempAllocatePageTables: NumPageTables = %X (%d)\n", NumPageTables, NumPageTables);
     }
     else
     {
-       NumPageTables = (TotalPagesInLookupTable / PAE_PTE_PER_PAGE);
-       TotalSize = (sizeof(PAE_TABLES) + ((NumPageTables * 2) * MM_PAGE_SIZE));
-        TRACE("MempAllocatePageTables: NumPageTables = %X (%d)\n", NumPageTables, NumPageTables);
+        NumPageTables = (TotalPagesInLookupTable / PAE_PTE_PER_PAGE);
+        TotalSize = (sizeof(PAE_TABLES) + ((NumPageTables * 2) * MM_PAGE_SIZE));
     }
+
+    TRACE("MempAllocatePageTables: NumPageTables = %X (%d)\n", NumPageTables, NumPageTables);
 
     /* Allocate memory for PD, HAL PT, Kernel PTs with MemoryData type */
     Buffer = MmAllocateMemoryWithType(TotalSize, LoaderMemoryData);
@@ -320,7 +320,7 @@ MempAllocatePageTables(VOID)
 
 static
 VOID
-MempAllocatePde(ULONG Entry, PHARDWARE_PDE_X86 * PhysicalPT, PHARDWARE_PDE_X86 * KernelPT)
+MempAllocatePde(ULONG Entry, PHARDWARE_PDE_X86* PhysicalPT, PHARDWARE_PDE_X86* KernelPT)
 {
     //Print(L"Creating PDE Entry %X\n", Entry);
 
@@ -348,7 +348,7 @@ MempAllocatePde(ULONG Entry, PHARDWARE_PDE_X86 * PhysicalPT, PHARDWARE_PDE_X86 *
 
 static
 VOID
-MempAllocatePaePde(ULONG PdeIdx, PHARDWARE_PDE_X86_PAE * PhysicalPde, PHARDWARE_PDE_X86_PAE * KernelPde)
+MempAllocatePaePde(ULONG PdeIdx, PHARDWARE_PDE_X86_PAE* PhysicalPde, PHARDWARE_PDE_X86_PAE* KernelPde)
 {
     PHARDWARE_PDE_X86_PAE Pde;
     ULONG PdIdx;
@@ -363,7 +363,6 @@ MempAllocatePaePde(ULONG PdeIdx, PHARDWARE_PDE_X86_PAE * PhysicalPde, PHARDWARE_
     Pde->PageFrameNumber = (ULONG)*PhysicalPde >> MM_PAGE_SHIFT;
     Pde->Valid = 1;
     Pde->Write = 1;
-
 
     if ((PdeIdx + KERNEL_PDE_IDX) > (MAX_PAE_PDE_COUNT - 1))
     {

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -469,7 +469,8 @@ MempSetupPaging(IN PFN_NUMBER StartPage,
 
             if (KernelMapping)
             {
-                if (KernelPde[Page & PAE_PDE_MASK].Valid) WARN("KernelPde already mapped\n");
+                if (KernelPde[Page & PAE_PDE_MASK].Valid)
+                    WARN("KernelPde already mapped\n");
 
                 KernelPde[Page & PAE_PDE_MASK].PageFrameNumber = Page;
                 KernelPde[Page & PAE_PDE_MASK].Valid = (Page != 0);
@@ -716,7 +717,7 @@ WinLdrSetProcessorContext(void)
         __writecr3((ULONG_PTR)PaeTables);
 
         /* Enable PAE */
-        __writecr4(__readcr4() | 0x20);
+        __writecr4(__readcr4() | CR4_PAE);
     }
 
     /* Enable paging */

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -706,9 +706,6 @@ WinLdrSetProcessorContext(void)
     {
         /* Set the PDBR */
         __writecr3((ULONG_PTR)PDE);
-
-        /* Enable paging by modifying CR0 */
-        __writecr0(__readcr0() | CR0_PG);
     }
     else
     {
@@ -723,9 +720,10 @@ WinLdrSetProcessorContext(void)
         /* Enable PAE */
         __writecr4(__readcr4() | 0x20);
 
-        /* Enable paging */
-        __writecr0(__readcr0() | CR0_PG);
     }
+
+    /* Enable paging */
+    __writecr0(__readcr0() | CR0_PG);
 
     TRACE("WinLdrSetProcessorContext: cr0 %X, cr3 %X, cr4 %X\n", __readcr0(), __readcr3(), __readcr4());
 

--- a/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/arch/i386/winldr.c
@@ -174,8 +174,6 @@ ULONG PcrBasePage;
 ULONG TssBasePage;
 PVOID GdtIdt;
 
-extern BOOLEAN PaeModeOn;
-
 /* FUNCTIONS *****************************************************************/
 
 static

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -1052,7 +1052,7 @@ LoadAndBootWindowsCommon(
 
     if (PaeModeOn)
     {
-        /*"No PAE support for kernel (no ntkrnlpa.exe) */
+        /* No PAE support for kernel (no ntkrnlpa.exe) */
         FIXME("Hello from PAE paged mode! KiSystemStartup %p, LoaderBlockVA %p\n", KiSystemStartup, LoaderBlockVA);
         BugCheck("No PAE support for kernel!\n");
     }

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -513,39 +513,25 @@ WinLdrIsPaeSupported(IN PLOADER_PARAMETER_BLOCK LoaderBlock,
         NtLdrGetOption(BootOptions, "PAE"))
     {
         /* We found the PAE option. */
-        FIXME("LoadWindowsCore: PAE - TRUE (not implemented)\n");
         PaeEnabled = TRUE;
     }
+
+    Result = PaeEnabled;
 
     if (OperatingSystemVersion > _WIN32_WINNT_WIN2K)
     {
         if (NtLdrGetOption(BootOptions, "NOPAE"))
-        {
-            /* We found the NOPAE option. */
-            FIXME("LoadWindowsCore: NOPAE - TRUE (not implemented)\n");
             PaeDisabled = TRUE;
-        }
 
         if (!LoaderBlock->SetupLdrBlock)
         {
-            if (NtLdrGetOption(BootOptions, "EXECUTE"))
-            {
-                /* We found the EXECUTE option. */
-                FIXME("LoadWindowsCore: EXECUTE - TRUE (not implemented)\n");
-                NoexecuteDisabled = TRUE;
-            }
             if (NtLdrGetOption(BootOptions, "NOEXECUTE=ALWAYSOFF"))
-            {
-                /* We found the NOEXECUTE=ALWAYSOFF option. */
-                FIXME("LoadWindowsCore: NOEXECUTE=ALWAYSOFF - TRUE (not implemented)\n");
                 NoexecuteDisabled = TRUE;
-            }
-            if (NtLdrGetOption(BootOptions, "NOEXECUTE"))
-            {
-                /* We found the NOEXECUTE option. */
-                FIXME("LoadWindowsCore: NOEXECUTE - TRUE (not implemented)\n");
+            else if (NtLdrGetOption(BootOptions, "NOEXECUTE"))
                 NoexecuteEnabled = TRUE;
-            }
+
+            if (NtLdrGetOption(BootOptions, "EXECUTE") && !NoexecuteEnabled)
+                NoexecuteDisabled = TRUE;
         }
     }
 
@@ -555,13 +541,18 @@ WinLdrIsPaeSupported(IN PLOADER_PARAMETER_BLOCK LoaderBlock,
         NoexecuteDisabled = TRUE;
     }
 
-    TRACE("NoexecuteDisabled %X, NoexecuteEnabled %X\n", NoexecuteDisabled, NoexecuteEnabled);
+    TRACE("NoexecuteDisabled %X\n", NoexecuteDisabled);
     TRACE("PaeEnabled %X, PaeDisabled %X\n", PaeEnabled, PaeDisabled);
+
+    if (PaeDisabled)
+        Result = FALSE;
+
+    if (NoexecuteDisabled == FALSE)
+        Result = TRUE;
 
     // FIXME checks for CPU support, hotplug memory support .. other tests
     // FIXME select kernel name ("ntkrnlpa.exe" or ntoskrnl.exe")
 
-    Result = PaeEnabled;
     return Result;
 }
 

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -499,7 +499,6 @@ LoadModule(
 
 static
 BOOLEAN
-NTAPI
 WinLdrIsPaeSupported(IN PCHAR KernelFileName,
                      IN PCHAR HalFileName)
 {

--- a/boot/freeldr/freeldr/ntldr/winldr.h
+++ b/boot/freeldr/freeldr/ntldr/winldr.h
@@ -73,6 +73,8 @@ VOID ConvertConfigToVA(PCONFIGURATION_COMPONENT_DATA Start);
 
 
 // winldr.c
+extern BOOLEAN PaeModeOn;
+
 PVOID WinLdrLoadModule(PCSTR ModuleName, PULONG Size,
                        TYPE_OF_MEMORY MemoryType);
 

--- a/sdk/include/ndk/i386/mmtypes.h
+++ b/sdk/include/ndk/i386/mmtypes.h
@@ -65,8 +65,6 @@ C_ASSERT(MM_ALLOCATION_GRANULARITY >= PAGE_SIZE);
 //
 // Page Table Entry Definitions
 //
-#if !defined(_X86PAE_)
-
 typedef struct _HARDWARE_PTE_X86
 {
     ULONG Valid:1;
@@ -82,7 +80,42 @@ typedef struct _HARDWARE_PTE_X86
     ULONG Prototype: 1;
     ULONG reserved: 1;
     ULONG PageFrameNumber:20;
-} HARDWARE_PTE_X86, *PHARDWARE_PTE_X86;
+} HARDWARE_PTE_X86, *PHARDWARE_PTE_X86,
+  HARDWARE_PDE_X86, *PHARDWARE_PDE_X86;
+
+typedef struct _HARDWARE_PTE_X86_PAE
+{
+    union
+    {
+        struct
+        {
+            ULONGLONG Valid:1;
+            ULONGLONG Write:1;
+            ULONGLONG Owner:1;
+            ULONGLONG WriteThrough:1;
+            ULONGLONG CacheDisable:1;
+            ULONGLONG Accessed:1;
+            ULONGLONG Dirty:1;
+            ULONGLONG LargePage:1;
+            ULONGLONG Global:1;
+            ULONGLONG CopyOnWrite:1;
+            ULONGLONG Prototype:1;
+            ULONGLONG reserved0:1;
+            ULONGLONG PageFrameNumber:26;
+            ULONGLONG reserved1:25;
+            ULONGLONG NoExecute:1;
+        };
+        struct
+        {
+            ULONG LowPart;
+            ULONG HighPart;
+        };
+    };
+} HARDWARE_PTE_X86_PAE, *PHARDWARE_PTE_X86_PAE,
+  HARDWARE_PDE_X86_PAE, *PHARDWARE_PDE_X86_PAE,
+  HARDWARE_PDPTE_X86_PAE, *PHARDWARE_PDPTE_X86_PAE;
+
+#if !defined(_X86PAE_)
 
 typedef struct _MMPTE_SOFTWARE
 {
@@ -163,36 +196,6 @@ typedef struct _MMPTE_HARDWARE
 } MMPTE_HARDWARE, *PMMPTE_HARDWARE;
 
 #else
-
-typedef struct _HARDWARE_PTE_X86
-{
-    union
-    {
-        struct
-        {
-            ULONGLONG Valid:1;
-            ULONGLONG Write:1;
-            ULONGLONG Owner:1;
-            ULONGLONG WriteThrough:1;
-            ULONGLONG CacheDisable:1;
-            ULONGLONG Accessed:1;
-            ULONGLONG Dirty:1;
-            ULONGLONG LargePage:1;
-            ULONGLONG Global:1;
-            ULONGLONG CopyOnWrite:1;
-            ULONGLONG Prototype:1;
-            ULONGLONG reserved0:1;
-            ULONGLONG PageFrameNumber:26;
-            ULONGLONG reserved1:25;
-            ULONGLONG NoExecute:1;
-        };
-        struct
-        {
-            ULONG LowPart;
-            ULONG HighPart;
-        };
-    };
-} HARDWARE_PTE_X86, *PHARDWARE_PTE_X86;
 
 typedef struct _MMPTE_SOFTWARE
 {
@@ -282,8 +285,13 @@ typedef struct _MMPTE_HARDWARE
 //
 // Use the right PTE structure
 //
+#if !defined(_X86PAE_)
 #define HARDWARE_PTE        HARDWARE_PTE_X86
 #define PHARDWARE_PTE       PHARDWARE_PTE_X86
+#else
+#define HARDWARE_PTE        HARDWARE_PTE_X86_PAE
+#define PHARDWARE_PTE       PHARDWARE_PTE_X86_PAE
+#endif
 
 typedef struct _MMPTE
 {


### PR DESCRIPTION
## Purpose

[FREELDR] Add support for Physical Address Extension (PAE) paging mode memory management.

JIRA issue: [CORE-17986](https://jira.reactos.org/browse/CORE-17986)

## Proposed changes

- Added "LiveCD PAE (Debug)" in livecd.ini.
- Changes have been made to "ndk/i386/mmtypes.h" so that PAE\Non-PAE structures are visible at the same time.
- Added defines for PAE in "boot/freeldr/freeldr/include/arch/i386/i386.h"
- Added WinLdrIsPaeSupported() - a stub for checking compatibility and enabling PAE mode.
- Add support for PAE in "boot/freeldr/freeldr/ntldr/arch/i386/winldr.c".
