### PR TITLE
[NEWDEV] Fix Update Driver Wizard Dialog position

### DIFF
--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -25,32 +25,8 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 
+
 HANDLE hThread;
-
-static VOID
-CenterWindow(
-    IN HWND hWnd)
-{
-    HWND hWndParent;
-    RECT rcParent;
-    RECT rcWindow;
-
-    hWndParent = GetParent(hWnd);
-    if (hWndParent == NULL)
-        hWndParent = GetDesktopWindow();
-
-    GetWindowRect(hWndParent, &rcParent);
-    GetWindowRect(hWnd, &rcWindow);
-
-    SetWindowPos(
-        hWnd,
-        HWND_TOP,
-        ((rcParent.right - rcParent.left) - (rcWindow.right - rcWindow.left)) / 2,
-        ((rcParent.bottom - rcParent.top) - (rcWindow.bottom - rcWindow.top)) / 2,
-        0,
-        0,
-        SWP_NOSIZE);
-}
 
 static BOOL
 SetFailedInstall(
@@ -482,9 +458,6 @@ WelcomeDlgProc(
 
             hwndControl = GetParent(hwndDlg);
 
-            /* Center the wizard window */
-            CenterWindow(hwndControl);
-
             /* Hide the system menu */
             dwStyle = GetWindowLongPtr(hwndControl, GWL_STYLE);
             SetWindowLongPtr(hwndControl, GWL_STYLE, dwStyle & ~WS_SYSMENU);
@@ -592,9 +565,6 @@ CHSourceDlgProc(
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
             hwndControl = GetParent(hwndDlg);
-
-            /* Center the wizard window */
-            CenterWindow(hwndControl);
 
             /* Hide the system menu */
             dwStyle = GetWindowLongPtr(hwndControl, GWL_STYLE);
@@ -747,9 +717,6 @@ SearchDrvDlgProc(
             DevInstData->hDialog = hwndDlg;
             hwndControl = GetParent(hwndDlg);
 
-            /* Center the wizard window */
-            CenterWindow(hwndControl);
-
             SendDlgItemMessage(
                 hwndDlg,
                 IDC_DEVICE,
@@ -841,9 +808,6 @@ InstallDrvDlgProc(
 
             DevInstData->hDialog = hwndDlg;
             hwndControl = GetParent(hwndDlg);
-
-            /* Center the wizard window */
-            CenterWindow(hwndControl);
 
             SendDlgItemMessage(
                 hwndDlg,
@@ -950,9 +914,6 @@ NoDriverDlgProc(
             /* Get pointer to the global setup data */
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
-
-            /* Center the wizard window */
-            CenterWindow(GetParent(hwndDlg));
 
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
@@ -1070,9 +1031,6 @@ InstallFailedDlgProc(
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
-            /* Center the wizard window */
-            CenterWindow(GetParent(hwndDlg));
-
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
             EnableWindow(hwndControl, FALSE);
@@ -1149,9 +1107,6 @@ NeedRebootDlgProc(
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
-            /* Center the wizard window */
-            CenterWindow(GetParent(hwndDlg));
-
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
             EnableWindow(hwndControl, FALSE);
@@ -1227,9 +1182,6 @@ FinishDlgProc(
             /* Get pointer to the global setup data */
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
-
-            /* Center the wizard window */
-            CenterWindow(GetParent(hwndDlg));
 
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -1,7 +1,7 @@
 /*
  * New device installer (newdev.dll)
  *
- * Copyright 2006 Hervé Poussineau (hpoussin@reactos.org)
+ * Copyright 2006 HervÃ© Poussineau (hpoussin@reactos.org)
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -41,6 +41,11 @@ CenterWindow(
 
     GetWindowRect(hWndParent, &rcParent);
     GetWindowRect(hWnd, &rcWindow);
+
+    /// Check if the child window fits inside the parent window
+    if (rcWindow.left < rcParent.left || rcWindow.top < rcParent.top ||
+        rcWindow.right > rcParent.right || rcWindow.bottom > rcParent.bottom)
+        return;
 
     SetWindowPos(
         hWnd,

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -42,10 +42,12 @@ CenterWindow(
     GetWindowRect(hWndParent, &rcParent);
     GetWindowRect(hWnd, &rcWindow);
 
-    /// Check if the child window fits inside the parent window
+    /* Check if the child window fits inside the parent window */
     if (rcWindow.left < rcParent.left || rcWindow.top < rcParent.top ||
         rcWindow.right > rcParent.right || rcWindow.bottom > rcParent.bottom)
+    {
         return;
+    }
 
     SetWindowPos(
         hWnd,

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -25,8 +25,32 @@
 #include <shlobj.h>
 #include <shlwapi.h>
 
-
 HANDLE hThread;
+
+static VOID
+CenterWindow(
+    IN HWND hWnd)
+{
+    HWND hWndParent;
+    RECT rcParent;
+    RECT rcWindow;
+
+    hWndParent = GetParent(hWnd);
+    if (hWndParent == NULL)
+        hWndParent = GetDesktopWindow();
+
+    GetWindowRect(hWndParent, &rcParent);
+    GetWindowRect(hWnd, &rcWindow);
+
+    SetWindowPos(
+        hWnd,
+        HWND_TOP,
+        ((rcParent.right - rcParent.left) - (rcWindow.right - rcWindow.left)) / 2,
+        ((rcParent.bottom - rcParent.top) - (rcWindow.bottom - rcWindow.top)) / 2,
+        0,
+        0,
+        SWP_NOSIZE);
+}
 
 static BOOL
 SetFailedInstall(
@@ -458,6 +482,9 @@ WelcomeDlgProc(
 
             hwndControl = GetParent(hwndDlg);
 
+            /* Center the wizard window */
+            CenterWindow(hwndControl);
+
             /* Hide the system menu */
             dwStyle = GetWindowLongPtr(hwndControl, GWL_STYLE);
             SetWindowLongPtr(hwndControl, GWL_STYLE, dwStyle & ~WS_SYSMENU);
@@ -565,6 +592,9 @@ CHSourceDlgProc(
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
             hwndControl = GetParent(hwndDlg);
+
+            /* Center the wizard window */
+            CenterWindow(hwndControl);
 
             /* Hide the system menu */
             dwStyle = GetWindowLongPtr(hwndControl, GWL_STYLE);
@@ -717,6 +747,9 @@ SearchDrvDlgProc(
             DevInstData->hDialog = hwndDlg;
             hwndControl = GetParent(hwndDlg);
 
+            /* Center the wizard window */
+            CenterWindow(hwndControl);
+
             SendDlgItemMessage(
                 hwndDlg,
                 IDC_DEVICE,
@@ -808,6 +841,9 @@ InstallDrvDlgProc(
 
             DevInstData->hDialog = hwndDlg;
             hwndControl = GetParent(hwndDlg);
+
+            /* Center the wizard window */
+            CenterWindow(hwndControl);
 
             SendDlgItemMessage(
                 hwndDlg,
@@ -914,6 +950,9 @@ NoDriverDlgProc(
             /* Get pointer to the global setup data */
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
+
+            /* Center the wizard window */
+            CenterWindow(GetParent(hwndDlg));
 
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
@@ -1031,6 +1070,9 @@ InstallFailedDlgProc(
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
+            /* Center the wizard window */
+            CenterWindow(GetParent(hwndDlg));
+
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
             EnableWindow(hwndControl, FALSE);
@@ -1107,6 +1149,9 @@ NeedRebootDlgProc(
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
 
+            /* Center the wizard window */
+            CenterWindow(GetParent(hwndDlg));
+
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);
             EnableWindow(hwndControl, FALSE);
@@ -1182,6 +1227,9 @@ FinishDlgProc(
             /* Get pointer to the global setup data */
             DevInstData = (PDEVINSTDATA)((LPPROPSHEETPAGE)lParam)->lParam;
             SetWindowLongPtr(hwndDlg, GWLP_USERDATA, (DWORD_PTR)DevInstData);
+
+            /* Center the wizard window */
+            CenterWindow(GetParent(hwndDlg));
 
             hwndControl = GetDlgItem(GetParent(hwndDlg), IDCANCEL);
             ShowWindow(hwndControl, SW_HIDE);


### PR DESCRIPTION
Observed behavior:
        The Update Driver Wizard Dialog is not completely visible.
		Part of the window is off the screen.

Expected behavior:
        As in Windows XP the dialog box is positioned slightly below
		and to the right of the parent window (Z order).

