### PR TITLE
[SHELL32] Folders: Adjust column sequence in details view

### DIFF
--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -333,7 +333,7 @@ HRESULT WINAPI CControlPanelFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE
         case 0:        /* name */
             result = wcsicmp(pData1->szName + pData1->offsDispName, pData2->szName + pData2->offsDispName);
             break;
-        case 1:        /* comment */
+        case 4:        /* comment */
             result = wcsicmp(pData1->szName + pData1->offsComment, pData2->szName + pData2->offsComment);
             break;
         default:
@@ -581,7 +581,7 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iCol
         {
             case 0:        /* name */
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsDispName);
-            case 1:        /* comment */
+            case 4:        /* comment */
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsComment);
         }
     }

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -528,10 +528,10 @@ class CDrivesFolderEnum :
 
 static const shvheader MyComputerSFHeader[] = {
     {IDS_SHV_COLUMN_NAME, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 15},
-    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 10},
     {IDS_SHV_COLUMN_TYPE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10},
     {IDS_SHV_COLUMN_DISK_CAPACITY, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_RIGHT, 10},
     {IDS_SHV_COLUMN_DISK_AVAILABLE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_RIGHT, 10},
+    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 10},
 };
 
 #define MYCOMPUTERSHELLVIEWCOLUMNS 5
@@ -729,16 +729,13 @@ HRESULT WINAPI CDrivesFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1
             hres = MAKE_COMPARE_HRESULT(result);
             break;
         }
-        case 1:        /* comments */
-            hres = MAKE_COMPARE_HRESULT(0);
-            break;
-        case 2:        /* Type */
+        case 1:        /* Type */
         {
             /* We want to return immediately because SHELL32_CompareDetails also compares children. */
             return SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
         }
-        case 3:       /* Size */
-        case 4:       /* Size Available */
+        case 2:       /* Size */
+        case 3:       /* Size Available */
         {
             ULARGE_INTEGER Drive1Available, Drive1Total, Drive2Available, Drive2Total;
 
@@ -761,6 +758,9 @@ HRESULT WINAPI CDrivesFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE pidl1
             hres = MAKE_COMPARE_HRESULT(Diff.QuadPart);
             break;
         }
+        case 4:        /* comments */
+            hres = MAKE_COMPARE_HRESULT(0);
+            break;
         default:
             return E_INVALIDARG;
     }
@@ -1126,28 +1126,28 @@ HRESULT WINAPI CDrivesFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, S
             case 0:        /* name */
                 hr = GetDisplayNameOf(pidl, SHGDN_NORMAL | SHGDN_INFOLDER, &psd->str);
                 break;
-            case 1:                /* FIXME: comments */
-                hr = SHSetStrRet(&psd->str, "");
-                break;
-            case 2:        /* type */
+            case 1:        /* type */
                 if (DriveType == DRIVE_REMOVABLE && !IsDriveFloppyA(pszDrive))
                     hr = SHSetStrRet(&psd->str, IDS_DRIVE_REMOVABLE);
                 else
                     hr = SHSetStrRet(&psd->str, iDriveTypeIds[DriveType]);
                 break;
-            case 3:        /* total size */
-            case 4:        /* free size */
+            case 2:        /* total size */
+            case 3:        /* free size */
                 psd->str.cStr[0] = 0x00;
                 psd->str.uType = STRRET_CSTR;
                 if (GetVolumeInformationA(pszDrive, NULL, 0, NULL, NULL, NULL, NULL, 0))
                 {
                     GetDiskFreeSpaceExA(pszDrive, &ulFreeBytes, &ulTotalBytes, NULL);
-                    if (iColumn == 3)
+                    if (iColumn == 2)
                         StrFormatByteSize64A(ulTotalBytes.QuadPart, psd->str.cStr, MAX_PATH);
                     else
                         StrFormatByteSize64A(ulFreeBytes.QuadPart, psd->str.cStr, MAX_PATH);
                 }
                 hr = S_OK;
+                break;
+            case 4:                /* FIXME: comments */
+                hr = SHSetStrRet(&psd->str, "");
                 break;
         }
     }

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -527,10 +527,10 @@ CFSFolder::~CFSFolder()
 
 static const shvheader GenericSFHeader[] = {
     {IDS_SHV_COLUMN_NAME, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 15},
-    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 0},
     {IDS_SHV_COLUMN_TYPE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10},
     {IDS_SHV_COLUMN_SIZE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_RIGHT, 10},
     {IDS_SHV_COLUMN_MODIFIED, SHCOLSTATE_TYPE_DATE | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 12},
+    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 0},
     {IDS_SHV_COLUMN_ATTRIBUTES, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10}
 };
 
@@ -969,15 +969,12 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
         case 0: /* Name */
             result = wcsicmp(pDataW1->wszName, pDataW2->wszName);
             break;
-        case 1: /* Comments */
-            result = 0;
-            break;
-        case 2: /* Type */
+        case 1: /* Type */
             pExtension1 = PathFindExtensionW(pDataW1->wszName);
             pExtension2 = PathFindExtensionW(pDataW2->wszName);
             result = wcsicmp(pExtension1, pExtension2);
             break;
-        case 3: /* Size */
+        case 2: /* Size */
             if (pData1->u.file.dwFileSize > pData2->u.file.dwFileSize)
                 result = 1;
             else if (pData1->u.file.dwFileSize < pData2->u.file.dwFileSize)
@@ -985,10 +982,13 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
             else
                 result = 0;
             break;
-        case 4: /* Modified */
+        case 3: /* Modified */
             result = pData1->u.file.uFileDate - pData2->u.file.uFileDate;
             if (result == 0)
                 result = pData1->u.file.uFileTime - pData2->u.file.uFileTime;
+            break;
+        case 4: /* Comments */
+            result = 0;
             break;
         case 5: /* Attributes */
             return SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
@@ -1531,17 +1531,17 @@ HRESULT WINAPI CFSFolder::GetDetailsOf(PCUITEMID_CHILD pidl,
             case 0:                /* name */
                 hr = GetDisplayNameOf (pidl, SHGDN_NORMAL | SHGDN_INFOLDER, &psd->str);
                 break;
-            case 1:                /* FIXME: comments */
-                psd->str.cStr[0] = 0;
-                break;
-            case 2:                /* type */
+            case 1:                /* type */
                 _ILGetFileType(pidl, psd->str.cStr, MAX_PATH);
                 break;
-            case 3:                /* size */
+            case 2:                /* size */
                 _ILGetFileSize(pidl, psd->str.cStr, MAX_PATH);
                 break;
-            case 4:                /* date */
+            case 3:                /* date */
                 _ILGetFileDate(pidl, psd->str.cStr, MAX_PATH);
+                break;
+            case 4:                /* FIXME: comments */
+                psd->str.cStr[0] = 0;
                 break;
             case 5:                /* attributes */
                 _ILGetFileAttributes(pidl, psd->str.cStr, MAX_PATH);

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -742,19 +742,13 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
         return E_INVALIDARG;
     }
 
-    if (iColumn >= 3)
-    {
-        /* Return an empty string when we area asked for a column we don't support.
-           Only  the regfolder is supposed to do this as it supports less columns compared to other folder
-           and its contents are supposed to be presented alongside items that support more columns. */
-        return SHSetStrRet(&psd->str, "");
-    }
-
     switch(iColumn)
     {
         case 0:        /* name */
             return GetDisplayNameOf(pidl, SHGDN_NORMAL | SHGDN_INFOLDER, &psd->str);
-        case 1:        /* comments */
+        case 1:        /* type */
+            return SHSetStrRet(&psd->str, IDS_SYSTEMFOLDER);
+        case 4:        /* comments */
             HKEY hKey;
             if (!HCR_RegOpenClassIDKey(*clsid, &hKey))
                 return SHSetStrRet(&psd->str, "");
@@ -764,8 +758,11 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
             RegLoadMUIStringA(hKey, "InfoTip", psd->str.cStr, MAX_PATH, NULL, 0, NULL);
             RegCloseKey(hKey);
             return S_OK;
-        case 2:        /* type */
-            return SHSetStrRet(&psd->str, IDS_SYSTEMFOLDER);
+        default:
+            /* Return an empty string when we area asked for a column we don't support.
+               Only  the regfolder is supposed to do this as it supports less columns compared to other folder
+               and its contents are supposed to be presented alongside items that support more columns. */
+            return SHSetStrRet(&psd->str, "");
     }
     return E_FAIL;
 }


### PR DESCRIPTION
## Purpose

Adjust column sequence in folder view to match WinXP and Win2k3 order.

JIRA issue: [CORE-11846](https://jira.reactos.org/browse/CORE-11846)

**Before:**
![image](https://user-images.githubusercontent.com/46087964/149223177-5a872160-1cab-41c8-80dd-13fcd07c5f4e.png)

**After:**
![image](https://user-images.githubusercontent.com/46087964/149222046-d3c5642b-5f23-4955-921c-4bc446dde291.png)

**Win2k3:**
![image](https://user-images.githubusercontent.com/46087964/149223438-6f4671df-2cab-48c8-855a-de24d8063460.png)

**WinXP:**
![image](https://user-images.githubusercontent.com/46087964/149223365-fbd0495a-ad7d-4dd7-a03e-6be789974261.png)

## ToDo

- [ ] Do not use magic numbers for column sequence number. **Does any dev have preference or statement, which header file should be used?**