### PR TITLE
[SYSSETUP] Adjust Status Window if Asian

### DIFF
--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -566,7 +566,7 @@ cleanup:
 }
 
 static VOID
-AdjustStatusMessageWindowPos(HWND hwndDlg, PDLG_DATA pDlgData)
+AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
 {
     INT xOld, yOld, cxOld, cyOld;
     INT xNew, yNew, cxNew, cyNew;
@@ -685,7 +685,7 @@ StatusMessageWindowProc(
                 return FALSE;
             SetDlgItemTextW(hwndDlg, IDC_STATUSLABEL, szMsg);
 
-            AdjustStatusMessageWindowPos(hwndDlg, pDlgData);
+            AdjustStatusMessageWindow(hwndDlg, pDlgData);
             return TRUE;
         }
 

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -570,7 +570,7 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
 {
     INT xOld, yOld, cxOld, cyOld;
     INT xNew, yNew, cxNew, cyNew;
-    INT dy, xLabel, yLabel;
+    INT xLabel, yLabel, cxLabel, cyLabel, dyLabel;
     RECT rc, rcWnd;
     BITMAP bmLogo, bmBar;
     DWORD style, exstyle;
@@ -578,7 +578,7 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
     HWND hwndBar = GetDlgItem(hwndDlg, IDC_BAR);
     HWND hwndLabel = GetDlgItem(hwndDlg, IDC_STATUSLABEL);
 
-    /* Adjustment is for Chinese, Japanese and Korean only */
+    /* This adjustment is for CJK only */
     switch (PRIMARYLANGID(GetUserDefaultLangID()))
     {
         case LANG_CHINESE:
@@ -592,16 +592,20 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
 
     if (!GetObject(pDlgData->hLogoBitmap, sizeof(BITMAP), &bmLogo) ||
         !GetObject(pDlgData->hBarBitmap, sizeof(BITMAP), &bmBar))
+    {
         return;
+    }
 
     GetWindowRect(hwndBar, &rc);
     MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rc, 2);
-    dy = bmLogo.bmHeight - rc.top;
+    dyLabel = bmLogo.bmHeight - rc.top;
 
     GetWindowRect(hwndLabel, &rc);
     MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rc, 2);
     xLabel = rc.left;
-    yLabel = rc.top;
+    yLabel = rc.top + dyLabel;
+    cxLabel = rc.right - rc.left;
+    cyLabel = rc.bottom - rc.top;
 
     GetWindowRect(hwndDlg, &rcWnd);
     xOld = rcWnd.left;
@@ -618,11 +622,10 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
 
     MoveWindow(hwndLogo, 0, 0, bmLogo.bmWidth, bmLogo.bmHeight, TRUE);
     MoveWindow(hwndBar, 0, bmLogo.bmHeight, bmLogo.bmWidth, bmBar.bmHeight, TRUE);
-    SetWindowPos(hwndLabel, NULL, xLabel, yLabel + dy, 0, 0,
-                 SWP_NOSIZE | SWP_NOACTIVATE | SWP_NOZORDER);
+    MoveWindow(hwndLabel, xLabel, yLabel, cxLabel, cyLabel, TRUE);
 
     cxNew = rc.right - rc.left;
-    cyNew = (rc.bottom - rc.top) + dy;
+    cyNew = (rc.bottom - rc.top) + dyLabel;
     xNew = xOld - (cxNew - cxOld) / 2;
     yNew = yOld - (cyNew - cyOld) / 2;
     MoveWindow(hwndDlg, xNew, yNew, cxNew, cyNew, TRUE);

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -570,8 +570,8 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
 {
     INT xOld, yOld, cxOld, cyOld;
     INT xNew, yNew, cxNew, cyNew;
-    INT xLabel, yLabel, cxLabel, cyLabel, dyLabel;
-    RECT rc, rcWnd;
+    INT cxLabel, cyLabel, dyLabel;
+    RECT rc, rcBar, rcLabel, rcWnd;
     BITMAP bmLogo, bmBar;
     DWORD style, exstyle;
     HWND hwndLogo = GetDlgItem(hwndDlg, IDC_ROSLOGO);
@@ -596,16 +596,18 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
         return;
     }
 
-    GetWindowRect(hwndBar, &rc);
-    MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rc, 2);
-    dyLabel = bmLogo.bmHeight - rc.top;
+    GetWindowRect(hwndBar, &rcBar);
+    MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rcBar, 2);
+    dyLabel = bmLogo.bmHeight - rcBar.top;
 
-    GetWindowRect(hwndLabel, &rc);
-    MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rc, 2);
-    xLabel = rc.left;
-    yLabel = rc.top + dyLabel;
-    cxLabel = rc.right - rc.left;
-    cyLabel = rc.bottom - rc.top;
+    GetWindowRect(hwndLabel, &rcLabel);
+    MapWindowPoints(NULL, hwndDlg, (LPPOINT)&rcLabel, 2);
+    cxLabel = rcLabel.right - rcLabel.left;
+    cyLabel = rcLabel.bottom - rcLabel.top;
+
+    MoveWindow(hwndLogo, 0, 0, bmLogo.bmWidth, bmLogo.bmHeight, TRUE);
+    MoveWindow(hwndBar, 0, bmLogo.bmHeight, bmLogo.bmWidth, bmBar.bmHeight, TRUE);
+    MoveWindow(hwndLabel, rcLabel.left, rcLabel.top + dyLabel, cxLabel, cyLabel, TRUE);
 
     GetWindowRect(hwndDlg, &rcWnd);
     xOld = rcWnd.left;
@@ -619,10 +621,6 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
     style = (DWORD)GetWindowLongPtr(hwndDlg, GWL_STYLE);
     exstyle = (DWORD)GetWindowLongPtr(hwndDlg, GWL_EXSTYLE);
     AdjustWindowRectEx(&rc, style, FALSE, exstyle);
-
-    MoveWindow(hwndLogo, 0, 0, bmLogo.bmWidth, bmLogo.bmHeight, TRUE);
-    MoveWindow(hwndBar, 0, bmLogo.bmHeight, bmLogo.bmWidth, bmBar.bmHeight, TRUE);
-    MoveWindow(hwndLabel, xLabel, yLabel, cxLabel, cyLabel, TRUE);
 
     cxNew = rc.right - rc.left;
     cyNew = (rc.bottom - rc.top) + dyLabel;

--- a/dll/win32/syssetup/install.c
+++ b/dll/win32/syssetup/install.c
@@ -590,8 +590,8 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
             return;
     }
 
-    if (!GetObject(pDlgData->hLogoBitmap, sizeof(BITMAP), &bmLogo) ||
-        !GetObject(pDlgData->hBarBitmap, sizeof(BITMAP), &bmBar))
+    if (!GetObjectW(pDlgData->hLogoBitmap, sizeof(BITMAP), &bmLogo) ||
+        !GetObjectW(pDlgData->hBarBitmap, sizeof(BITMAP), &bmBar))
     {
         return;
     }
@@ -618,8 +618,8 @@ AdjustStatusMessageWindow(HWND hwndDlg, PDLG_DATA pDlgData)
     GetClientRect(hwndDlg, &rc);
     SetRect(&rc, 0, 0, bmLogo.bmWidth, rc.bottom - rc.top); /* new client size */
 
-    style = (DWORD)GetWindowLongPtr(hwndDlg, GWL_STYLE);
-    exstyle = (DWORD)GetWindowLongPtr(hwndDlg, GWL_EXSTYLE);
+    style = (DWORD)GetWindowLongPtrW(hwndDlg, GWL_STYLE);
+    exstyle = (DWORD)GetWindowLongPtrW(hwndDlg, GWL_EXSTYLE);
     AdjustWindowRectEx(&rc, style, FALSE, exstyle);
 
     cxNew = rc.right - rc.left;


### PR DESCRIPTION
## Purpose
The CJK (Chinese, Japanese and Korean; Asian) dialog uses the different font. So, the logo and bar positions of CJK are different from English positions. We will add adjustment to the CJK dialog.

JIRA issue: N/A

## Proposed changes

- Add positional adjustment to `IDD_STATUSWINDOW_DLG` if CJK.

## Screenshots

BEFORE:
![VirtualBox_ReactOS_13_01_2022_12_08_41](https://user-images.githubusercontent.com/2107452/149262670-6066d51b-5630-47cb-823d-f86930e194da.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/149262653-5ba78336-80c3-445e-b427-623fdfcb05c3.png)