### PR TITLE
[CMD][WINSRV] Workaround when Asian fixed-pitch font was absent

### DIFF
--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2311,7 +2311,7 @@ Initialize(VOID)
 
     /* ReactOS extension: Inform if the Asian font is not found */
     hwndConsole = GetConsoleWindow();
-    if (GetPropW(hwndConsole, L"ReactOSCJKFontFallback"))
+    if (GetPropW(hwndConsole, L"ReactOSFontFallback"))
     {
         ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
 
@@ -2320,7 +2320,7 @@ Initialize(VOID)
         SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
 #undef ENGLISH_LANGID
 
-        RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
+        RemovePropW(hwndConsole, L"ReactOSFontFallback");
     }
 
     if (AutoRun)

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2140,6 +2140,7 @@ Initialize(VOID)
     TCHAR option = 0;
     BOOL AutoRun = TRUE;
     TCHAR ModuleName[MAX_PATH + 1];
+    HWND hwndConsole;
 
     /* Get version information */
     InitOSVersion();
@@ -2306,6 +2307,21 @@ Initialize(VOID)
                         _T(KERNEL_VERSION_STR),
                         _T(KERNEL_VERSION_BUILD_STR));
         ConOutPuts(_T("(C) Copyright 1998-") _T(COPYRIGHT_YEAR) _T(" ReactOS Team.\n"));
+    }
+
+    /* ReactOS extension: Inform if the Asian font is not found */
+    hwndConsole = GetConsoleWindow();
+    if (GetPropW(hwndConsole, L"ReactOSCJKFontFallback"))
+    {
+        if (!*ptr)
+        {
+            ConOutPuts(_T("WARNING: The Asian fixed-pitch font was not found. It goes English.\n"));
+        }
+
+        /* Set the thread locale to English */
+#define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)
+        SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
+#undef ENGLISH_LANGID
     }
 
     if (AutoRun)

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2315,7 +2315,7 @@ Initialize(VOID)
     {
         if (!*ptr)
         {
-            ConOutPuts(_T("WARNING: The Asian fixed-pitch font was not found. It goes English.\n"));
+            ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
         }
 
         /* Set the thread locale to English */

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2126,6 +2126,18 @@ GetCmdLineCommand(
     _tcscpy(commandline, ptr);
 }
 
+/* Is the user Chinese, Japanese or Korean? */
+static BOOL IsUserCJK(VOID)
+{
+    switch (PRIMARYLANGID(GetUserDefaultLangID()))
+    {
+        case LANG_CHINESE:
+        case LANG_JAPANESE:
+        case LANG_KOREAN:
+            return TRUE;
+    }
+    return FALSE;
+}
 
 /*
  * Set up global initializations and process parameters.
@@ -2311,7 +2323,7 @@ Initialize(VOID)
 
     /* ReactOS extension: Inform if the Asian font is not found */
     hwndConsole = GetConsoleWindow();
-    if (GetPropW(hwndConsole, L"ReactOSFontFallback"))
+    if (IsUserCJK() && GetPropW(hwndConsole, L"ReactOSFontFallback"))
     {
         ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
 

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2152,7 +2152,6 @@ Initialize(VOID)
     TCHAR option = 0;
     BOOL AutoRun = TRUE;
     TCHAR ModuleName[MAX_PATH + 1];
-    HWND hwndConsole;
 
     /* Get version information */
     InitOSVersion();
@@ -2324,7 +2323,7 @@ Initialize(VOID)
     /* ReactOS extension: Inform if the Asian font is not found */
     if (IsUserCJK())
     {
-        hwndConsole = GetConsoleWindow();
+        HWND hwndConsole = GetConsoleWindow();
         if (GetPropW(hwndConsole, L"ReactOSFontFallback"))
         {
             ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2313,10 +2313,7 @@ Initialize(VOID)
     hwndConsole = GetConsoleWindow();
     if (GetPropW(hwndConsole, L"ReactOSCJKFontFallback"))
     {
-        if (!*ptr)
-        {
-            ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
-        }
+        ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
 
         /* Set the thread locale to English */
 #define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2322,8 +2322,9 @@ Initialize(VOID)
 #define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)
         SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
 #undef ENGLISH_LANGID
+
+        RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
     }
-    RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
 
     if (AutoRun)
     {

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2322,9 +2322,8 @@ Initialize(VOID)
 #define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)
         SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
 #undef ENGLISH_LANGID
-
-        RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
     }
+    RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
 
     if (AutoRun)
     {

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2322,6 +2322,8 @@ Initialize(VOID)
 #define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)
         SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
 #undef ENGLISH_LANGID
+
+        RemovePropW(hwndConsole, L"ReactOSCJKFontFallback");
     }
 
     if (AutoRun)

--- a/base/shell/cmd/cmd.c
+++ b/base/shell/cmd/cmd.c
@@ -2127,7 +2127,7 @@ GetCmdLineCommand(
 }
 
 /* Is the user Chinese, Japanese or Korean? */
-static BOOL IsUserCJK(VOID)
+static inline BOOL IsUserCJK(VOID)
 {
     switch (PRIMARYLANGID(GetUserDefaultLangID()))
     {
@@ -2322,17 +2322,20 @@ Initialize(VOID)
     }
 
     /* ReactOS extension: Inform if the Asian font is not found */
-    hwndConsole = GetConsoleWindow();
-    if (IsUserCJK() && GetPropW(hwndConsole, L"ReactOSFontFallback"))
+    if (IsUserCJK())
     {
-        ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
+        hwndConsole = GetConsoleWindow();
+        if (GetPropW(hwndConsole, L"ReactOSFontFallback"))
+        {
+            ConOutPuts(_T("WARNING: The Asian fixed-pitch font not found. Falling back to English.\n"));
 
-        /* Set the thread locale to English */
+            /* Set the thread locale to English */
 #define ENGLISH_LANGID MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US)
-        SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
+            SetThreadLocale(MAKELCID(ENGLISH_LANGID, SORT_DEFAULT));
 #undef ENGLISH_LANGID
 
-        RemovePropW(hwndConsole, L"ReactOSFontFallback");
+            RemovePropW(hwndConsole, L"ReactOSFontFallback");
+        }
     }
 
     if (AutoRun)

--- a/win32ss/user/winsrv/concfg/font.c
+++ b/win32ss/user/winsrv/concfg/font.c
@@ -40,7 +40,7 @@ CodePageToCharSet(
 }
 
 HFONT
-CreateConsoleFontExEx(
+CreateConsoleFontInternal(
     IN LONG Height,
     IN LONG Width OPTIONAL,
     IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
@@ -97,8 +97,8 @@ CreateConsoleFontEx(
     IN ULONG FontWeight,
     IN UINT  CodePage)
 {
-    return CreateConsoleFontExEx(Height, Width, FaceName, FontFamily, FontWeight,
-                                 CodePage, NULL);
+    return CreateConsoleFontInternal(Height, Width, FaceName, FontFamily, FontWeight,
+                                     CodePage, NULL);
 }
 
 HFONT

--- a/win32ss/user/winsrv/concfg/font.c
+++ b/win32ss/user/winsrv/concfg/font.c
@@ -40,7 +40,7 @@ CodePageToCharSet(
 }
 
 HFONT
-CreateConsoleFontInternal(
+CreateConsoleFontEx(
     IN LONG Height,
     IN LONG Width OPTIONAL,
     IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
@@ -89,19 +89,6 @@ CreateConsoleFontInternal(
 }
 
 HFONT
-CreateConsoleFontEx(
-    IN LONG Height,
-    IN LONG Width OPTIONAL,
-    IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
-    IN ULONG FontFamily,
-    IN ULONG FontWeight,
-    IN UINT  CodePage)
-{
-    return CreateConsoleFontInternal(Height, Width, FaceName, FontFamily, FontWeight,
-                                     CodePage, NULL);
-}
-
-HFONT
 CreateConsoleFont2(
     IN LONG Height,
     IN LONG Width OPTIONAL,
@@ -112,7 +99,8 @@ CreateConsoleFont2(
                                ConsoleInfo->FaceName,
                                ConsoleInfo->FontFamily,
                                ConsoleInfo->FontWeight,
-                               ConsoleInfo->CodePage);
+                               ConsoleInfo->CodePage,
+                               NULL);
 }
 
 HFONT
@@ -130,7 +118,8 @@ CreateConsoleFont(
                                ConsoleInfo->FaceName,
                                ConsoleInfo->FontFamily,
                                ConsoleInfo->FontWeight,
-                               ConsoleInfo->CodePage);
+                               ConsoleInfo->CodePage,
+                               NULL);
 }
 
 BOOL

--- a/win32ss/user/winsrv/concfg/font.c
+++ b/win32ss/user/winsrv/concfg/font.c
@@ -40,15 +40,19 @@ CodePageToCharSet(
 }
 
 HFONT
-CreateConsoleFontEx(
+CreateConsoleFontExEx(
     IN LONG Height,
     IN LONG Width OPTIONAL,
     IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
     IN ULONG FontFamily,
     IN ULONG FontWeight,
-    IN UINT  CodePage)
+    IN UINT  CodePage,
+    OUT LPBOOL pbCJKFontFallback OPTIONAL)
 {
     LOGFONTW lf;
+
+    if (pbCJKFontFallback)
+        *pbCJKFontFallback = FALSE;
 
     RtlZeroMemory(&lf, sizeof(lf));
 
@@ -70,9 +74,10 @@ CreateConsoleFontEx(
 
     if (!IsValidConsoleFont(FaceName, CodePage))
     {
-        StringCchCopyW(FaceName, LF_FACESIZE, L"Terminal");
         if (IsCJKCodePage(CodePage))
         {
+            if (pbCJKFontFallback)
+                *pbCJKFontFallback = TRUE;
             lf.lfCharSet = ANSI_CHARSET;
         }
     }
@@ -81,6 +86,19 @@ CreateConsoleFontEx(
                     FaceName, LF_FACESIZE);
 
     return CreateFontIndirectW(&lf);
+}
+
+HFONT
+CreateConsoleFontEx(
+    IN LONG Height,
+    IN LONG Width OPTIONAL,
+    IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
+    IN ULONG FontFamily,
+    IN ULONG FontWeight,
+    IN UINT  CodePage)
+{
+    return CreateConsoleFontExEx(Height, Width, FaceName, FontFamily, FontWeight,
+                                 CodePage, NULL);
 }
 
 HFONT

--- a/win32ss/user/winsrv/concfg/font.h
+++ b/win32ss/user/winsrv/concfg/font.h
@@ -62,7 +62,7 @@ CodePageToCharSet(
     IN UINT CodePage);
 
 HFONT
-CreateConsoleFontInternal(
+CreateConsoleFontEx(
     IN LONG Height,
     IN LONG Width OPTIONAL,
     IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
@@ -70,15 +70,6 @@ CreateConsoleFontInternal(
     IN ULONG FontWeight,
     IN UINT  CodePage,
     OUT LPBOOL pbCJKFontFallback OPTIONAL);
-
-HFONT
-CreateConsoleFontEx(
-    IN LONG Height,
-    IN LONG Width OPTIONAL,
-    IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
-    IN ULONG FontFamily,
-    IN ULONG FontWeight,
-    IN UINT  CodePage);
 
 HFONT
 CreateConsoleFont2(

--- a/win32ss/user/winsrv/concfg/font.h
+++ b/win32ss/user/winsrv/concfg/font.h
@@ -62,6 +62,16 @@ CodePageToCharSet(
     IN UINT CodePage);
 
 HFONT
+CreateConsoleFontExEx(
+    IN LONG Height,
+    IN LONG Width OPTIONAL,
+    IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements
+    IN ULONG FontFamily,
+    IN ULONG FontWeight,
+    IN UINT  CodePage,
+    OUT LPBOOL pbCJKFontFallback OPTIONAL);
+
+HFONT
 CreateConsoleFontEx(
     IN LONG Height,
     IN LONG Width OPTIONAL,

--- a/win32ss/user/winsrv/concfg/font.h
+++ b/win32ss/user/winsrv/concfg/font.h
@@ -62,7 +62,7 @@ CodePageToCharSet(
     IN UINT CodePage);
 
 HFONT
-CreateConsoleFontExEx(
+CreateConsoleFontInternal(
     IN LONG Height,
     IN LONG Width OPTIONAL,
     IN OUT LPWSTR FaceName, // Points to a WCHAR array of LF_FACESIZE elements

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -532,13 +532,13 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
      * Initialize a new NORMAL font and get its character cell size.
      */
     /* NOTE: FontSize is always in cell height/width units (pixels) */
-    hFont = CreateConsoleFontExEx((LONG)(ULONG)FontSize.Y,
-                                  (LONG)(ULONG)FontSize.X,
-                                  FaceName,
-                                  FontFamily,
-                                  FontWeight,
-                                  GuiData->Console->OutputCodePage,
-                                  &bCJKFontCallBack);
+    hFont = CreateConsoleFontInternal((USHORT)FontSize.Y,
+                                      (USHORT)FontSize.X,
+                                      FaceName,
+                                      FontFamily,
+                                      FontWeight,
+                                      GuiData->Console->OutputCodePage,
+                                      &bCJKFontCallBack);
     if (hFont == NULL)
     {
         DPRINT1("InitFonts: CreateConsoleFontEx failed\n");

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -547,7 +547,7 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
 
     /* ReactOS extension: Remember whether the Asian font was not found */
     if (bCJKFontCallBack)
-        SetPropW(GuiData->hWindow, L"ReactOSCJKFontFallback", (HANDLE)(ULONG_PTR)TRUE);
+        SetPropW(GuiData->hWindow, L"ReactOSFontFallback", (HANDLE)(ULONG_PTR)TRUE);
 
     hDC = GetDC(GuiData->hWindow);
     if (!GetFontCellSize(hDC, hFont, &GuiData->CharHeight, &GuiData->CharWidth))

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -526,7 +526,7 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
 {
     HDC hDC;
     HFONT hFont;
-    BOOL bCJKFontCallBack = FALSE;
+    BOOL bCJKFontCallBack;
 
     /*
      * Initialize a new NORMAL font and get its character cell size.

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -3,7 +3,7 @@
  * PROJECT:         ReactOS Console Server DLL
  * FILE:            win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
  * PURPOSE:         GUI Console Window Class
- * PROGRAMMERS:     Gé van Geldorp
+ * PROGRAMMERS:     GÃ© van Geldorp
  *                  Johannes Anderwald
  *                  Jeffrey Morlan
  *                  Hermes Belusca-Maito (hermes.belusca@sfr.fr)
@@ -545,7 +545,7 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
         return FALSE;
     }
 
-    /* ReactOS extension: Remember whether that the Asian font was not found */
+    /* ReactOS extension: Remember whether the Asian font was not found */
     if (bCJKFontCallBack)
         SetPropW(GuiData->hWindow, L"ReactOSCJKFontFallback", (HANDLE)(ULONG_PTR)TRUE);
 

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -532,8 +532,8 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
      * Initialize a new NORMAL font and get its character cell size.
      */
     /* NOTE: FontSize is always in cell height/width units (pixels) */
-    hFont = CreateConsoleFontEx((USHORT)FontSize.Y,
-                                (USHORT)FontSize.X,
+    hFont = CreateConsoleFontEx((LONG)(ULONG)FontSize.Y,
+                                (LONG)(ULONG)FontSize.X,
                                 FaceName,
                                 FontFamily,
                                 FontWeight,

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -526,22 +526,27 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
 {
     HDC hDC;
     HFONT hFont;
+    BOOL bCJKFontCallBack = FALSE;
 
     /*
      * Initialize a new NORMAL font and get its character cell size.
      */
     /* NOTE: FontSize is always in cell height/width units (pixels) */
-    hFont = CreateConsoleFontEx((LONG)(ULONG)FontSize.Y,
-                                (LONG)(ULONG)FontSize.X,
-                                FaceName,
-                                FontFamily,
-                                FontWeight,
-                                GuiData->Console->OutputCodePage);
+    hFont = CreateConsoleFontExEx((LONG)(ULONG)FontSize.Y,
+                                  (LONG)(ULONG)FontSize.X,
+                                  FaceName,
+                                  FontFamily,
+                                  FontWeight,
+                                  GuiData->Console->OutputCodePage,
+                                  &bCJKFontCallBack);
     if (hFont == NULL)
     {
         DPRINT1("InitFonts: CreateConsoleFontEx failed\n");
         return FALSE;
     }
+
+    /* ReactOS extension: Remember whether that the Asian font was not found */
+    SetPropW(GuiData->hWindow, L"ReactOSCJKFontFallback", (HANDLE)(ULONG_PTR)bCJKFontCallBack);
 
     hDC = GetDC(GuiData->hWindow);
     if (!GetFontCellSize(hDC, hFont, &GuiData->CharHeight, &GuiData->CharWidth))

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -546,7 +546,8 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
     }
 
     /* ReactOS extension: Remember whether that the Asian font was not found */
-    SetPropW(GuiData->hWindow, L"ReactOSCJKFontFallback", (HANDLE)(ULONG_PTR)bCJKFontCallBack);
+    if (bCJKFontCallBack)
+        SetPropW(GuiData->hWindow, L"ReactOSCJKFontFallback", (HANDLE)(ULONG_PTR)TRUE);
 
     hDC = GetDC(GuiData->hWindow);
     if (!GetFontCellSize(hDC, hFont, &GuiData->CharHeight, &GuiData->CharWidth))

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -532,13 +532,13 @@ InitFonts(PGUI_CONSOLE_DATA GuiData,
      * Initialize a new NORMAL font and get its character cell size.
      */
     /* NOTE: FontSize is always in cell height/width units (pixels) */
-    hFont = CreateConsoleFontInternal((USHORT)FontSize.Y,
-                                      (USHORT)FontSize.X,
-                                      FaceName,
-                                      FontFamily,
-                                      FontWeight,
-                                      GuiData->Console->OutputCodePage,
-                                      &bCJKFontCallBack);
+    hFont = CreateConsoleFontEx((USHORT)FontSize.Y,
+                                (USHORT)FontSize.X,
+                                FaceName,
+                                FontFamily,
+                                FontWeight,
+                                GuiData->Console->OutputCodePage,
+                                &bCJKFontCallBack);
     if (hFont == NULL)
     {
         DPRINT1("InitFonts: CreateConsoleFontEx failed\n");


### PR DESCRIPTION
## Purpose
If the user was CJK (Chinese, Japanese, or Korean; Asian), CJK Command Prompt has a readability problem when the CJK fixed-pitch font was absent.

JIRA issue: N/A

## Proposed changes

- Set a property `"ReactOSFontFallback"` to the console window if the CJK fixed-pitch font was not found.
- If the property `"ReactOSFontFallback"` of the console window is set, then show the warning message, and then set the thread locale to English.

## Screenshots
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/149311827-078ca891-13da-4085-80ce-04546f7228cb.png)
AFTER:
![after](https://user-images.githubusercontent.com/2107452/149331021-5184efab-7549-46eb-8739-bc0737103a72.png)