### PR TITLE
[USER32] Adjust the threshold in CascadeWindows

### DIFF
--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2149,7 +2149,7 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         if (IsZoomed(hwnd))
         {
             if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
-                                     SMTO_ABORTIFHUNG, 100, NULL))
+                                     SMTO_ABORTIFHUNG, 300, NULL))
             {
                 continue;
             }
@@ -2338,7 +2338,7 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         if (IsZoomed(hwnd))
         {
             if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
-                                     SMTO_ABORTIFHUNG, 100, NULL))
+                                     SMTO_ABORTIFHUNG, 300, NULL))
             {
                 continue;
             }

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2163,10 +2163,12 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         if (info.chwnd != 1 && (GetWindowLongPtrW(hwnd, GWL_STYLE) & WS_THICKFRAME))
         {
             /* check the size */
-#define THRESHOLD(xy) (((xy) * 5) / 7)      /* in the rate 5/7 */
-            cxNew = min(cxNew, THRESHOLD(cxWork));
-            cyNew = min(cyNew, THRESHOLD(cyWork));
-#undef THRESHOLD
+#define MIN_THRESHOLD(xy) (((xy) * 4) / 7)      /* in the rate 4/7 */
+#define MAX_THRESHOLD(xy) (((xy) * 5) / 7)      /* in the rate 5/7 */
+            cxNew = max(min(cxNew, MAX_THRESHOLD(cxWork)), MIN_THRESHOLD(cxWork));
+            cyNew = max(min(cyNew, MAX_THRESHOLD(cyWork)), MIN_THRESHOLD(cyWork));
+#undef MIN_THRESHOLD
+#undef MAX_THRESHOLD
             if (cx != cxNew || cy != cyNew)
             {
                 /* too large. shrink if we can */

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2147,7 +2147,7 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
             continue;
 
         if (IsZoomed(hwnd))
-            ShowWindow(hwnd, SW_RESTORE | SW_SHOWNA);
+            ShowWindowAsync(hwnd, SW_RESTORE | SW_SHOWNA);
 
         GetWindowRect(hwnd, &rcWnd);
         cxNew = cx = rcWnd.right - rcWnd.left;
@@ -2330,7 +2330,7 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         hwnd = info.ahwnd[i];
 
         if (IsZoomed(hwnd))
-            ShowWindow(hwnd, SW_RESTORE | SW_SHOWNA);
+            ShowWindowAsync(hwnd, SW_RESTORE | SW_SHOWNA);
 
         GetWindowRect(hwnd, &rcWnd);
         cx = rcWnd.right - rcWnd.left;

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2147,13 +2147,7 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
             continue;
 
         if (IsZoomed(hwnd))
-        {
-            if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
-                                     SMTO_ABORTIFHUNG, 300, NULL))
-            {
-                continue;
-            }
-        }
+            ShowWindow(hwnd, SW_RESTORE | SW_SHOWNA);
 
         GetWindowRect(hwnd, &rcWnd);
         cxNew = cx = rcWnd.right - rcWnd.left;
@@ -2338,13 +2332,7 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         hwnd = info.ahwnd[i];
 
         if (IsZoomed(hwnd))
-        {
-            if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
-                                     SMTO_ABORTIFHUNG, 300, NULL))
-            {
-                continue;
-            }
-        }
+            ShowWindow(hwnd, SW_RESTORE | SW_SHOWNA);
 
         GetWindowRect(hwnd, &rcWnd);
         cx = rcWnd.right - rcWnd.left;

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2147,7 +2147,13 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
             continue;
 
         if (IsZoomed(hwnd))
-            ShowWindowAsync(hwnd, SW_RESTORE | SW_SHOWNA);
+        {
+            if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
+                                     SMTO_ABORTIFHUNG, 100, NULL))
+            {
+                continue;
+            }
+        }
 
         GetWindowRect(hwnd, &rcWnd);
         cxNew = cx = rcWnd.right - rcWnd.left;
@@ -2330,7 +2336,13 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         hwnd = info.ahwnd[i];
 
         if (IsZoomed(hwnd))
-            ShowWindowAsync(hwnd, SW_RESTORE | SW_SHOWNA);
+        {
+            if (!SendMessageTimeoutW(hwnd, WM_SYSCOMMAND, SC_RESTORE, 0,
+                                     SMTO_ABORTIFHUNG, 100, NULL))
+            {
+                continue;
+            }
+        }
 
         GetWindowRect(hwnd, &rcWnd);
         cx = rcWnd.right - rcWnd.left;


### PR DESCRIPTION
## Purpose
Not to make the windows too small.
JIRA issue: N/A

## Proposed changes

- Improve the threshold of `CascadeWindows` function not to make the windows too small.

## TODO

- [x] Do tests.

## Screenshots

![VirtualBox_ReactOS_14_01_2022_21_04_47](https://user-images.githubusercontent.com/2107452/149512884-11514fbf-ba52-454c-ba1a-917b94819210.png)
![VirtualBox_ReactOS_14_01_2022_21_00_53](https://user-images.githubusercontent.com/2107452/149512891-11a7b984-5c93-4535-af57-583228d05550.png)
Still working.