### PR TITLE
[NTOS:PNP][SDK:LIB] Build assignment ordering for arbiters

### DIFF
--- a/ntoskrnl/io/pnpmgr/arbiters.c
+++ b/ntoskrnl/io/pnpmgr/arbiters.c
@@ -413,6 +413,7 @@ IopGenericUnpackRequirement(
     if (IoDescriptor->u.Generic.Alignment == 0)
         *OutAlignment = 1;
 
+    /* Fixup memory requirements for devices which support only 24bit addresses. */
     if (IoDescriptor->Type == CmResourceTypeMemory &&
         IoDescriptor->Flags & CM_RESOURCE_MEMORY_24 &&
         IoDescriptor->u.Generic.MaximumAddress.QuadPart > 0xFFFFFF) // 16 Mb

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -308,43 +308,36 @@ ArbPruneOrdering(
     Current = TmpOrderings;
     Orderings = OrderList->Orderings;
 
-    for (ix = 0; ix < OrderList->Count; ix++)
+    for (ix = 0; ix < OrderList->Count; ix++, Orderings++)
     {
-        if (MaximumAddress < Orderings[0].Start ||
-            MinimumAddress > Orderings[0].End)
+        if (MaximumAddress < Orderings->Start ||
+            MinimumAddress > Orderings->End)
         {
-            Current->Start = Orderings[0].Start;
-            Current->End = Orderings[0].End;
+            Current->Start = Orderings->Start;
+            Current->End = Orderings->End;
         }
-        else if (MinimumAddress <= Orderings[0].Start)
+        else if (MinimumAddress <= Orderings->Start)
         {
-            if (MaximumAddress >= Orderings[0].End)
-            {
+            if (MaximumAddress >= Orderings->End)
                 continue;
-            }
-            else
-            {
-                Current->Start = (MaximumAddress + 1);
-                Current->End = Orderings[0].End;
-            }
+
+            Current->Start = (MaximumAddress + 1);
+            Current->End = Orderings->End;
+        }
+        else if (MaximumAddress >= Orderings->End)
+        {
+            Current->Start = Orderings->Start;
+            Current->End = (MinimumAddress - 1);
         }
         else
         {
-            if (MaximumAddress >= Orderings[0].End)
-            {
-                Current->Start = Orderings[0].Start;
-                Current->End = (MinimumAddress - 1);
-            }
-            else
-            {
-                Current->Start = (MaximumAddress + 1);
-                Current->End = Orderings[0].End;
+            Current->Start = (MaximumAddress + 1);
+            Current->End = Orderings->End;
 
-                Current++;
+            Current++;
 
-                Current->Start = Orderings[0].Start;
-                Current->End = (MinimumAddress - 1);
-            }
+            Current->Start = Orderings->Start;
+            Current->End = (MinimumAddress - 1);
         }
 
         Current++;

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -272,7 +272,7 @@ CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
 ArbPruneOrdering(
-    _Out_ PARBITER_ORDERING_LIST OrderingList,
+    _Out_ PARBITER_ORDERING_LIST OrderList,
     _In_ UINT64 MinimumAddress,
     _In_ UINT64 MaximumAddress)
 {
@@ -434,6 +434,62 @@ ArbFreeOrderingList(
 }
 
 CODE_SEG("PAGE")
+static
+NTSTATUS
+ArbpGetRegistryValue(
+    _In_ HANDLE KeyHandle,
+    _In_ PCWSTR NameString,
+    _Out_ PKEY_VALUE_FULL_INFORMATION * OutValueInfo)
+{
+    PKEY_VALUE_FULL_INFORMATION ValueInfo;
+    UNICODE_STRING ValueName;
+    ULONG ResultLength;
+    NTSTATUS Status;
+
+    PAGED_CODE();
+
+    DPRINT("ArbpGetRegistryValue: NameString '%S'\n", NameString);
+    RtlInitUnicodeString(&ValueName, NameString);
+
+    Status = ZwQueryValueKey(KeyHandle,
+                             &ValueName,
+                             KeyFullInformation | KeyNodeInformation,
+                             NULL,
+                             0,
+                             &ResultLength);
+
+    if (Status != STATUS_BUFFER_OVERFLOW && Status != STATUS_BUFFER_TOO_SMALL)
+    {
+        DPRINT1("ArbpGetRegistryValue: Status %X\n", Status);
+        return Status;
+    }
+
+    ValueInfo = ExAllocatePoolWithTag(PagedPool, ResultLength, TAG_ARBITER);
+    if (!ValueInfo)
+    {
+        DPRINT1("ArbpGetRegistryValue: STATUS_INSUFFICIENT_RESOURCES\n");
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    Status = ZwQueryValueKey(KeyHandle,
+                             &ValueName,
+                             KeyFullInformation|KeyNodeInformation,
+                             ValueInfo,
+                             ResultLength,
+                             &ResultLength);
+    if (NT_SUCCESS(Status))
+    {
+        *OutValueInfo = ValueInfo;
+        return STATUS_SUCCESS;
+    }
+
+    DPRINT1("ArbpGetRegistryValue: Status %X\n", Status);
+
+    ExFreePoolWithTag(ValueInfo, TAG_ARBITER);
+    return Status;
+}
+
+CODE_SEG("PAGE")
 NTSTATUS
 NTAPI
 ArbBuildAssignmentOrdering(
@@ -442,10 +498,244 @@ ArbBuildAssignmentOrdering(
     _In_ PCWSTR ReservedOrderName,
     _In_ PARB_TRANSLATE_ORDERING TranslateOrderingFunction)
 {
+    UNICODE_STRING ReservedResourcesName = RTL_CONSTANT_STRING(L"ReservedResources");
+    UNICODE_STRING AllocationOrderName = RTL_CONSTANT_STRING(L"AllocationOrder");
+    UNICODE_STRING ArbitersKeyName = RTL_CONSTANT_STRING(IO_REG_KEY_ARBITERS);
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    PKEY_VALUE_FULL_INFORMATION ReservedValueInfo = NULL;
+    PKEY_VALUE_FULL_INFORMATION ValueInfo = NULL;
+    PIO_RESOURCE_REQUIREMENTS_LIST IoResources;
+    PIO_RESOURCE_DESCRIPTOR IoDescriptor;
+    IO_RESOURCE_DESCRIPTOR TranslatedIoDesc;
+    HANDLE ArbitersKeyHandle = NULL;
+    HANDLE OrderingKeyHandle = NULL;
+    PCWSTR CurrentOrderName;
+    PCWSTR ValueName;
+    UINT32 ix;
+    NTSTATUS Status;
+  #if DBG
+    PARBITER_ORDERING Orderings;
+  #endif
+
     PAGED_CODE();
 
-    UNIMPLEMENTED;
+    DPRINT("[%p] OrderName '%S', ReservedOrderName '%S'\n", ArbInstance, OrderName, ReservedOrderName);
+
+    KeWaitForSingleObject(ArbInstance->MutexEvent,
+                          Executive,
+                          KernelMode,
+                          FALSE,
+                          NULL);
+
+    ArbFreeOrderingList(&ArbInstance->OrderingList);
+    ArbFreeOrderingList(&ArbInstance->ReservedList);
+
+    Status = ArbInitializeOrderingList(&ArbInstance->OrderingList);
+    if (!NT_SUCCESS(Status))
+        goto ErrorExit;
+
+    Status = ArbInitializeOrderingList(&ArbInstance->ReservedList);
+    if (!NT_SUCCESS(Status))
+        goto ErrorExit;
+
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &ArbitersKeyName,
+                               OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                               NULL,
+                               NULL);
+
+    Status = ZwOpenKey(&ArbitersKeyHandle, KEY_READ, &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+        goto ErrorExit;
+
+    /* First loop for AllocationOrder, next for ReservedResources */
+    for (ix = 0; ix <= 1; ix++)
+    {
+        ValueInfo = NULL;
+
+        if (ix == 0)
+        {
+            CurrentOrderName = OrderName;
+
+            InitializeObjectAttributes(&ObjectAttributes,
+                                       &AllocationOrderName,
+                                       OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                       ArbitersKeyHandle,
+                                       NULL);
+
+            Status = ZwOpenKey(&OrderingKeyHandle, KEY_READ, &ObjectAttributes);
+        }
+        else
+        {
+            CurrentOrderName = ReservedOrderName;
+
+            InitializeObjectAttributes(&ObjectAttributes,
+                                       &ReservedResourcesName,
+                                       OBJ_KERNEL_HANDLE | OBJ_CASE_INSENSITIVE,
+                                       ArbitersKeyHandle,
+                                       NULL);
+
+            Status = ZwCreateKey(&OrderingKeyHandle,
+                                 KEY_READ,
+                                 &ObjectAttributes,
+                                 0,
+                                 NULL,
+                                 REG_OPTION_NON_VOLATILE,
+                                 NULL);
+        }
+
+        if (!NT_SUCCESS(Status))
+            goto ErrorExit;
+
+        Status = ArbpGetRegistryValue(OrderingKeyHandle, CurrentOrderName, &ValueInfo);
+        if (!NT_SUCCESS(Status) || !ValueInfo)
+            goto ErrorExit;
+
+        if (ix == 1 && ValueInfo->Type == REG_SZ)
+        {
+            /* ReservedResources case */
+
+            ValueName = (PCWSTR)((ULONG_PTR)ValueInfo + ValueInfo->DataOffset);
+            DPRINT("ArbBuildAssignmentOrdering: ValueName '%S'\n", ValueName);
+
+            if (ValueName[(ValueInfo->DataLength / sizeof(WCHAR)) - 1])
+                goto ErrorExit;
+
+            Status = ArbpGetRegistryValue(OrderingKeyHandle, ValueName, &ReservedValueInfo);
+            if (!NT_SUCCESS(Status))
+                goto ErrorExit;
+
+            ExFreePoolWithTag(ValueInfo, TAG_ARBITER);
+            ValueInfo = ReservedValueInfo;
+        }
+
+        ZwClose(OrderingKeyHandle);
+
+        if (ValueInfo->Type != REG_RESOURCE_REQUIREMENTS_LIST)
+        {
+            DPRINT1("ArbBuildAssignmentOrdering: STATUS_INVALID_PARAMETER\n");
+            Status = STATUS_INVALID_PARAMETER;
+            goto ErrorExit;
+        }
+
+        IoResources = (PIO_RESOURCE_REQUIREMENTS_LIST)((ULONG_PTR)ValueInfo + ValueInfo->DataOffset);
+        ASSERT(IoResources->AlternativeLists == 1);
+
+        for (IoDescriptor = &IoResources->List[0].Descriptors[0];
+             IoDescriptor < (&IoResources->List[0].Descriptors[0] + IoResources->List[0].Count);
+             IoDescriptor++)
+        {
+            UINT64 MinimumAddress;
+            UINT64 MaximumAddress;
+            UINT32 Dummy1;
+            UINT32 Dummy2;
+
+            if (TranslateOrderingFunction)
+            {
+                Status = TranslateOrderingFunction(&TranslatedIoDesc, IoDescriptor);
+                if (!NT_SUCCESS(Status))
+                    goto ErrorExit;
+            }
+            else
+            {
+                RtlCopyMemory(&TranslatedIoDesc, IoDescriptor, sizeof(TranslatedIoDesc));
+            }
+
+            if (TranslatedIoDesc.Type != ArbInstance->ResourceType)
+                continue;
+
+            Status = ArbInstance->UnpackRequirement(&TranslatedIoDesc,
+                                                    &MinimumAddress,
+                                                    &MaximumAddress,
+                                                    &Dummy1,
+                                                    &Dummy2);
+            if (!NT_SUCCESS(Status))
+                goto ErrorExit;
+
+            if (ix == 0)
+            {
+                /* AllocationOrder */
+                Status = ArbAddOrdering(&ArbInstance->OrderingList, MinimumAddress, MaximumAddress);
+                if (!NT_SUCCESS(Status))
+                    goto ErrorExit;
+            }
+            else
+            {
+                /* ReservedResources */
+                Status = ArbAddOrdering(&ArbInstance->ReservedList, MinimumAddress, MaximumAddress);
+                if (!NT_SUCCESS(Status))
+                    goto ErrorExit;
+
+                /* Prune AllocationOrder */
+                Status = ArbPruneOrdering(&ArbInstance->OrderingList, MinimumAddress, MaximumAddress);
+                if (!NT_SUCCESS(Status))
+                    goto ErrorExit;
+            }
+        }
+    }
+
+    ZwClose(ArbitersKeyHandle);
+
+#if DBG
+
+    Orderings = ArbInstance->OrderingList.Orderings;
+
+    for (Orderings = &ArbInstance->OrderingList.Orderings[0];
+         Orderings < &ArbInstance->OrderingList.Orderings[ArbInstance->OrderingList.Count];
+         Orderings++)
+    {
+        DPRINT("ArbBuildAssignmentOrdering: OrderingList(%I64X-%I64X)\n",
+               Orderings->Start, Orderings->End);
+    }
+
+    Orderings = ArbInstance->ReservedList.Orderings;
+
+    for (Orderings = &ArbInstance->ReservedList.Orderings[0];
+         Orderings < &ArbInstance->ReservedList.Orderings[ArbInstance->ReservedList.Count];
+         Orderings++)
+    {
+        DPRINT("ArbBuildAssignmentOrdering: ReservedList(%I64X-%I64X)\n",
+               Orderings->Start, Orderings->End);
+    }
+
+#endif
+
+    KeSetEvent(ArbInstance->MutexEvent, IO_NO_INCREMENT, FALSE);
     return STATUS_SUCCESS;
+
+ErrorExit:
+
+    DPRINT1("ArbBuildAssignmentOrdering: ErrorExit. Status %X\n", Status);
+
+    if (ArbitersKeyHandle)
+        ZwClose(ArbitersKeyHandle);
+
+    if (OrderingKeyHandle)
+        ZwClose(OrderingKeyHandle);
+
+    if (ValueInfo)
+        ExFreePoolWithTag(ValueInfo, TAG_ARBITER);
+
+    if (ReservedValueInfo)
+        ExFreePoolWithTag(ReservedValueInfo, TAG_ARBITER);
+
+    if (ArbInstance->OrderingList.Orderings)
+    {
+        ExFreePoolWithTag(ArbInstance->OrderingList.Orderings, TAG_ARB_ORDERING);
+        ArbInstance->OrderingList.Count = 0;
+        ArbInstance->OrderingList.Maximum = 0;
+    }
+
+    if (ArbInstance->ReservedList.Orderings)
+    {
+        ExFreePoolWithTag(ArbInstance->ReservedList.Orderings, TAG_ARB_ORDERING);
+        ArbInstance->ReservedList.Count = 0;
+        ArbInstance->ReservedList.Maximum = 0;
+    }
+
+    KeSetEvent(ArbInstance->MutexEvent, IO_NO_INCREMENT, FALSE);
+
+    return Status;
 }
 
 CODE_SEG("PAGE")
@@ -568,9 +858,7 @@ ArbInitializeArbiterInstance(
 
     Status = ArbBuildAssignmentOrdering(Arbiter, OrderName, OrderName, TranslateOrderingFunction);
     if (NT_SUCCESS(Status))
-    {
         return STATUS_SUCCESS;
-    }
 
     DPRINT1("ArbInitializeArbiterInstance: Status %X\n", Status);
 

--- a/sdk/lib/drivers/arbiter/arbiter.c
+++ b/sdk/lib/drivers/arbiter/arbiter.c
@@ -223,12 +223,11 @@ ArbAddOrdering(
 
     PAGED_CODE();
 
-    DPRINT("ArbAddOrdering: OrderList %p, MinimumAddress - %I64X, MaximumAddress - %I64X\n",
-           OrderList, MinimumAddress, MaximumAddress);
+    DPRINT("ArbAddOrdering: [%p] %I64X-%I64X\n", OrderList, MinimumAddress, MaximumAddress);
 
     if (MaximumAddress < MinimumAddress)
     {
-        DPRINT1("ArbAddOrdering: STATUS_INVALID_PARAMETER. [%p] %I64X : %I64X\n", OrderList, MinimumAddress, MaximumAddress);
+        DPRINT1("ArbAddOrdering: STATUS_INVALID_PARAMETER. [%p] %I64X-%I64X\n", OrderList, MinimumAddress, MaximumAddress);
         return STATUS_INVALID_PARAMETER;
     }
 
@@ -286,14 +285,14 @@ ArbPruneOrdering(
 
     PAGED_CODE();
 
-    DPRINT("ArbPruneOrdering: %X, %I64X, %I64X\n", OrderList->Count, MinimumAddress, MaximumAddress);
+    DPRINT("ArbPruneOrdering: %X, %I64X-%I64X\n", OrderList->Count, MinimumAddress, MaximumAddress);
 
     ASSERT(OrderList);
     ASSERT(OrderList->Orderings);
 
     if (MaximumAddress < MinimumAddress)
     {
-        DPRINT1("ArbPruneOrdering: STATUS_INVALID_PARAMETER. [%p] %I64X : %I64X\n", OrderList, MinimumAddress, MaximumAddress);
+        DPRINT1("ArbPruneOrdering: STATUS_INVALID_PARAMETER. [%p] %I64X-%I64X\n", OrderList, MinimumAddress, MaximumAddress);
         return STATUS_INVALID_PARAMETER;
     }
 

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -11,6 +11,7 @@
 #define TAG_ARBITER        'MbrA'
 #define TAG_ARB_ALLOCATION 'AbrA'
 #define TAG_ARB_RANGE      'RbrA'
+#define TAG_ARB_ORDERING   'LbrA'
 
 #define ARB_ORDERING_LIST_DEFAULT_COUNT  16
 #define ARB_ORDERING_LIST_ADD_COUNT      8

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Kernel&Driver SDK
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Hardware Resources Arbiter Library
- * COPYRIGHT:   Copyright 2020 Vadim Galyant <vgal@rambler.ru>
+ * COPYRIGHT:   Copyright 2020-2022 Vadim Galyant <vgal@rambler.ru>
  */
 
 #pragma once
@@ -12,6 +12,8 @@
 #define TAG_ARB_ALLOCATION 'AbrA'
 #define TAG_ARB_RANGE      'RbrA'
 #define TAG_ARB_ORDERING   'LbrA'
+
+#define IO_REG_KEY_ARBITERS L"\\REGISTRY\\MACHINE\\SYSTEM\\CURRENTCONTROLSET\\CONTROL\\ARBITERS"
 
 #define ARB_ORDERING_LIST_DEFAULT_COUNT  16
 #define ARB_ORDERING_LIST_ADD_COUNT      8

--- a/sdk/lib/drivers/arbiter/arbiter.h
+++ b/sdk/lib/drivers/arbiter/arbiter.h
@@ -12,6 +12,9 @@
 #define TAG_ARB_ALLOCATION 'AbrA'
 #define TAG_ARB_RANGE      'RbrA'
 
+#define ARB_ORDERING_LIST_DEFAULT_COUNT  16
+#define ARB_ORDERING_LIST_ADD_COUNT      8
+
 typedef struct _ARBITER_ORDERING
 {
     UINT64 Start;


### PR DESCRIPTION
## Purpose

Implement ArbBuildassignmentOrdering() and dependent functions for the arbiter library and PnP arbiters.

## Proposed changes

- [LIB:ARBITER] Implemented:
   ArbInitializeOrderingList(),
   ArbFreeOrderingList(),
   ArbAddOrdering(),
   ArbPruneOrdering(),
   ArbBuildAssignmentOrdering().

- [LIB:ARBITER] Added ArbpGetRegistryValue().

- [NTOS:PNP] Implemented:
   IopIrqUnpackRequirement(),
   IopDmaUnpackRequirement(),
   IopGenericUnpackRequirement(),
   IopIrqTranslateOrdering(),
   IopGenericTranslateOrdering().
