### PR TITLE
[NTOS:IO] IoRegisterDeviceInterface: create non-volatile keys for new device interfaces

### DIFF
--- a/ntoskrnl/io/iomgr/deviface.c
+++ b/ntoskrnl/io/iomgr/deviface.c
@@ -1060,7 +1060,7 @@ IoRegisterDeviceInterface(IN PDEVICE_OBJECT PhysicalDeviceObject,
         &ObjectAttributes,
         0, /* TileIndex */
         NULL, /* Class */
-        REG_OPTION_VOLATILE,
+        REG_OPTION_NON_VOLATILE,
         NULL); /* Disposition */
 
     if (!NT_SUCCESS(Status))
@@ -1111,7 +1111,7 @@ IoRegisterDeviceInterface(IN PDEVICE_OBJECT PhysicalDeviceObject,
         &ObjectAttributes,
         0, /* TileIndex */
         NULL, /* Class */
-        REG_OPTION_VOLATILE,
+        REG_OPTION_NON_VOLATILE,
         NULL); /* Disposition */
 
     if (!NT_SUCCESS(Status))
@@ -1175,7 +1175,7 @@ IoRegisterDeviceInterface(IN PDEVICE_OBJECT PhysicalDeviceObject,
         &ObjectAttributes,
         0, /* TileIndex */
         NULL, /* Class */
-        REG_OPTION_VOLATILE,
+        REG_OPTION_NON_VOLATILE,
         NULL); /* Disposition */
 
     if (!NT_SUCCESS(Status))


### PR DESCRIPTION
## Purpose

Always create only non-volatile (sub)keys when registering a new device interface, so then they are saved after reboot.
On Windows, nearly all device interface keys are non-volatile, except the "Control" subkey, which is managed by `IoSetDeviceInterfaceState` instead.
In particular, it fixes MS sysaudio loading failure with MS audio drivers replacement (ks, portcls, swenum, sysaudio, wdmaud). My `IoGetDeviceInterfaceAlias` implementation from #3510 is also required to be applied. MS sysaudio implementation(s) except that those keys are non-volatile (but we're creating them volatile instead), and trying to create a subkey(s) there (via other IoDeviceInterface* routines), to read/write some needed data. But then they fail to do that with `STATUS_CHILD_MUST_BE_VOLATILE` (`0xc0000181`), obviously because our keys are volatile.
**The volatile keys can never have non-volatile subkeys.** :point_up: 

JIRA issue: [CORE-17361](https://jira.reactos.org/browse/CORE-17361)

## Proof

To check this, it's not necessarily to do a complicated analysis. After simple checking it via registry editor, it becomes obvious. :slightly_smiling_face: 
Steps which we need to do:
1. Open Regedit.
2. Go to `HKLM\SYSTEM\CurrentCotnrolSet\Control\DeviceClasses\{CLASS_GUID}`.
3. Try to create a new empty keys in this GUID key and in the all its subkeys.

In GUID, device and instance keys, subkeys are created successfully. Same as in "Device Parameters" key. Only in "Control" subkey, they fail to be created. MS Regedit just shows a messagebox that it failed to be created. But our Regedit additionally shows an error code `1021`, which appears to be `ERROR_CHILD_MUST_BE_VOLATILE`, that is translated from kernel mode's `STATUS_CHILD_MUST_BE_VOLATILE`, as visible on screenshot:
![deviface_keys](https://user-images.githubusercontent.com/26385117/149673353-fb61dede-11d0-43ef-80ae-58a4d08f09fa.png)