### PR TITLE
[NEWDEV][SHELL32][SYSSETUP] Enable Browser Dlg OK button, when driver is found

### DIFF
--- a/dll/win32/newdev/newdev.c
+++ b/dll/win32/newdev/newdev.c
@@ -409,6 +409,14 @@ SearchDriverRecursive(
 }
 
 BOOL
+CheckBestDriver(
+    IN PDEVINSTDATA DevInstData,
+    PWCHAR szDir)
+{
+    return SearchDriverRecursive(DevInstData, szDir);
+}
+
+BOOL
 ScanFoldersForDriver(
     IN PDEVINSTDATA DevInstData)
 {

--- a/dll/win32/newdev/newdev.c
+++ b/dll/win32/newdev/newdev.c
@@ -410,10 +410,10 @@ SearchDriverRecursive(
 
 BOOL
 CheckBestDriver(
-    IN PDEVINSTDATA DevInstData,
-    PWCHAR szDir)
+    _In_ PDEVINSTDATA DevInstData,
+    _In_ PCWSTR pszDir)
 {
-    return SearchDriverRecursive(DevInstData, szDir);
+    return SearchDriverRecursive(DevInstData, pszDir);
 }
 
 BOOL

--- a/dll/win32/newdev/newdev.c
+++ b/dll/win32/newdev/newdev.c
@@ -359,7 +359,7 @@ SearchDriverRecursive(
         wcscat(DirPath, L"\\");
 
     wcscpy(PathWithPattern, DirPath);
-    wcscat(PathWithPattern, L"\\*");
+    wcscat(PathWithPattern, L"*");
 
     for (hFindFile = FindFirstFileW(PathWithPattern, &wfd);
         ok && hFindFile != INVALID_HANDLE_VALUE;

--- a/dll/win32/newdev/newdev_private.h
+++ b/dll/win32/newdev/newdev_private.h
@@ -63,8 +63,8 @@ InstallCurrentDriver(
 
 BOOL
 CheckBestDriver(
-    IN PDEVINSTDATA DevInstData,
-    PWCHAR szDir);
+    _In_ PDEVINSTDATA DevInstData,
+    _In_ PCWSTR pszDir);
 
 /* wizard.c */
 BOOL

--- a/dll/win32/newdev/newdev_private.h
+++ b/dll/win32/newdev/newdev_private.h
@@ -61,6 +61,11 @@ BOOL
 InstallCurrentDriver(
 	IN PDEVINSTDATA DevInstData);
 
+BOOL
+CheckBestDriver(
+    IN PDEVINSTDATA DevInstData,
+    PWCHAR szDir);
+
 /* wizard.c */
 BOOL
 DisplayWizard(

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -598,11 +598,7 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
             if (SHGetPathFromIDListW((LPITEMIDLIST)lParam, szDir))
             {
                 PDEVINSTDATA DevInstData = (PDEVINSTDATA)lpData;
-                SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver(DevInstData, szDir));
-            }
-            else
-            {
-                SendMessageW(hwnd, BFFM_ENABLEOK, 0, FALSE);
+                return CheckBestDriver(DevInstData, szDir);
             }
             break;
         }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -586,7 +586,9 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
     {
         case BFFM_INITIALIZED:
         {
-            SendMessageW(hwnd, BFFM_ENABLEOK, 0, FALSE);
+            LPCWSTR pszPath = ((PDEVINSTDATA)lpData)->CustomSearchPath;
+            SendMessageW(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM) pszPath);
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver(NULL, (LPWSTR)pszPath));
             break;
         }
 
@@ -683,7 +685,11 @@ CHSourceDlgProc(
                     BROWSEINFO bi = { 0 };
                     LPITEMIDLIST pidl;
                     WCHAR Title[MAX_PATH];
+                    WCHAR CustomSearchPath[MAX_PATH];
+                    INT idx = SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETCURSEL, 0, 0);
                     LoadStringW(hDllInstance, IDS_BROWSE_FOR_FOLDER_TITLE, Title, _countof(Title));
+                    SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETLBTEXT, idx, (LPARAM)CustomSearchPath);
+                    DevInstData->CustomSearchPath = CustomSearchPath;
 
                     bi.hwndOwner = hwndDlg;
                     bi.ulFlags = BIF_USENEWUI | BIF_RETURNONLYFSDIRS | BIF_STATUSTEXT | BIF_NONEWFOLDERBUTTON;

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -586,7 +586,7 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
     {
         case BFFM_INITIALIZED:
         {
-            SendMessage(hwnd, BFFM_ENABLEOK, 0, FALSE);
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, FALSE);
             break;
         }
 
@@ -596,11 +596,11 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
             if (SHGetPathFromIDListW((LPITEMIDLIST)lParam, szDir))
             {
                 PDEVINSTDATA DevInstData = (PDEVINSTDATA)lpData;
-                SendMessage(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver(DevInstData, szDir));
+                SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver(DevInstData, szDir));
             }
             else
             {
-                SendMessage(hwnd, BFFM_ENABLEOK, 0, FALSE);
+                SendMessageW(hwnd, BFFM_ENABLEOK, 0, FALSE);
             }
             break;
         }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -586,9 +586,9 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
     {
         case BFFM_INITIALIZED:
         {
-            LPCWSTR pszPath = ((PDEVINSTDATA)lpData)->CustomSearchPath;
+            PCWSTR pszPath = ((PDEVINSTDATA)lpData)->CustomSearchPath;
             SendMessageW(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM)pszPath);
-            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver((PDEVINSTDATA)lpData, (LPWSTR)pszPath));
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver((PDEVINSTDATA)lpData, pszPath));
             break;
         }
 

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -582,23 +582,29 @@ AutoDriver(HWND Dlg, BOOL Enabled)
 static INT CALLBACK
 BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
 {
+    BOOL bValid = FALSE;
+
     switch (uMsg)
     {
         case BFFM_INITIALIZED:
         {
             PCWSTR pszPath = ((PDEVINSTDATA)lpData)->CustomSearchPath;
+
+            bValid = CheckBestDriver((PDEVINSTDATA)lpData, pszPath);
             SendMessageW(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM)pszPath);
-            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver((PDEVINSTDATA)lpData, pszPath));
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, bValid);
             break;
         }
 
         case BFFM_SELCHANGED:
         {
             WCHAR szDir[MAX_PATH];
+
             if (SHGetPathFromIDListW((LPITEMIDLIST)lParam, szDir))
             {
-                return CheckBestDriver((PDEVINSTDATA)lpData, szDir);
+                bValid = CheckBestDriver((PDEVINSTDATA)lpData, szDir);
             }
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, bValid);
             break;
         }
     }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -686,10 +686,22 @@ CHSourceDlgProc(
                     BROWSEINFOW bi = { 0 };
                     LPITEMIDLIST pidl;
                     WCHAR Title[MAX_PATH];
-                    WCHAR CustomSearchPath[MAX_PATH];
-                    INT idx = SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETCURSEL, 0, 0);
+                    WCHAR CustomSearchPath[MAX_PATH] = { 0 };
+                    INT len, idx = (INT)SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETCURSEL, 0, 0);
                     LoadStringW(hDllInstance, IDS_BROWSE_FOR_FOLDER_TITLE, Title, _countof(Title));
-                    SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETLBTEXT, idx, (LPARAM)CustomSearchPath);
+
+                    if (idx == CB_ERR)
+                        len = GetWindowTextLengthW(GetDlgItem(hwndDlg, IDC_COMBO_PATH));
+                    else
+                        len = (INT)SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETLBTEXTLEN, idx, 0);
+
+                    if (len < _countof(CustomSearchPath))
+                    {
+                        if (idx == CB_ERR)
+                            GetWindowTextW(GetDlgItem(hwndDlg, IDC_COMBO_PATH), CustomSearchPath, _countof(CustomSearchPath));
+                        else
+                            SendDlgItemMessageW(hwndDlg, IDC_COMBO_PATH, CB_GETLBTEXT, idx, (LPARAM)CustomSearchPath);
+                    }
                     DevInstData->CustomSearchPath = CustomSearchPath;
 
                     bi.hwndOwner = hwndDlg;

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -604,7 +604,7 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
             {
                 bValid = CheckBestDriver((PDEVINSTDATA)lpData, szDir);
             }
-            SendMessageW(hwnd, BFFM_ENABLEOK, 0, bValid);
+            PostMessageW(hwnd, BFFM_ENABLEOK, 0, bValid);
             break;
         }
     }

--- a/dll/win32/newdev/wizard.c
+++ b/dll/win32/newdev/wizard.c
@@ -587,8 +587,8 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
         case BFFM_INITIALIZED:
         {
             LPCWSTR pszPath = ((PDEVINSTDATA)lpData)->CustomSearchPath;
-            SendMessageW(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM) pszPath);
-            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver(NULL, (LPWSTR)pszPath));
+            SendMessageW(hwnd, BFFM_SETSELECTION, TRUE, (LPARAM)pszPath);
+            SendMessageW(hwnd, BFFM_ENABLEOK, 0, CheckBestDriver((PDEVINSTDATA)lpData, (LPWSTR)pszPath));
             break;
         }
 
@@ -597,8 +597,7 @@ BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
             WCHAR szDir[MAX_PATH];
             if (SHGetPathFromIDListW((LPITEMIDLIST)lParam, szDir))
             {
-                PDEVINSTDATA DevInstData = (PDEVINSTDATA)lpData;
-                return CheckBestDriver(DevInstData, szDir);
+                return CheckBestDriver((PDEVINSTDATA)lpData, szDir);
             }
             break;
         }
@@ -678,7 +677,7 @@ CHSourceDlgProc(
 
                 case IDC_BROWSE:
                 {
-                    BROWSEINFO bi = { 0 };
+                    BROWSEINFOW bi = { 0 };
                     LPITEMIDLIST pidl;
                     WCHAR Title[MAX_PATH];
                     WCHAR CustomSearchPath[MAX_PATH];
@@ -692,7 +691,7 @@ CHSourceDlgProc(
                     bi.lpszTitle = Title;
                     bi.lpfn = BrowseCallbackProc;
                     bi.lParam = (LPARAM)DevInstData;
-                    pidl = SHBrowseForFolder(&bi);
+                    pidl = SHBrowseForFolderW(&bi);
                     if (pidl)
                     {
                         WCHAR Directory[MAX_PATH];

--- a/dll/win32/shell32/wine/brsfolder.c
+++ b/dll/win32/shell32/wine/brsfolder.c
@@ -465,7 +465,7 @@ static void FillTreeView( browse_info *info, IShellFolder * lpsf,
                 }
 	    }
 #ifdef __REACTOS__
-        if (ulAttrs != SFGAO_FOLDER)
+        if (ulAttrs != (ulAttrs & SFGAO_FOLDER))
         {
 	        if (!InsertTreeViewItem(info, lpsf, pidlTemp, pidl, pEnumIL, hParent))
 	            goto done;

--- a/dll/win32/shell32/wine/brsfolder.c
+++ b/dll/win32/shell32/wine/brsfolder.c
@@ -464,9 +464,17 @@ static void FillTreeView( browse_info *info, IShellFolder * lpsf,
                     IShellFolder_Release(pSFChild);
                 }
 	    }
+#ifdef __REACTOS__
+        if (ulAttrs != SFGAO_FOLDER)
+        {
+	        if (!InsertTreeViewItem(info, lpsf, pidlTemp, pidl, pEnumIL, hParent))
+	            goto done;
+	    }
+#else
 
 	    if (!InsertTreeViewItem(info, lpsf, pidlTemp, pidl, pEnumIL, hParent))
 	        goto done;
+#endif
 	    SHFree(pidlTemp);  /* Finally, free the pidl that the shell gave us... */
 	    pidlTemp=NULL;
 	}

--- a/dll/win32/shell32/wine/brsfolder.c
+++ b/dll/win32/shell32/wine/brsfolder.c
@@ -611,10 +611,10 @@ static HRESULT BrsFolder_Treeview_Changed( browse_info *info, NMTREEVIEWW *pnmtv
 
     if (GetName(lptvid->lpsfParent, lptvid->lpi, SHGDN_NORMAL, name))
             SetWindowTextW( GetDlgItem(info->hWnd, IDC_BROWSE_FOR_FOLDER_FOLDER_TEXT), name );
+
 #ifndef __REACTOS__
     browsefolder_callback( info->lpBrowseInfo, info->hWnd, BFFM_SELCHANGED,
                            (LPARAM)info->pidlRet );
-
     BrsFolder_CheckValidSelection( info, lptvid );
 #else
     bBtnState = browsefolder_callback( info->lpBrowseInfo, info->hWnd, BFFM_SELCHANGED,

--- a/dll/win32/shell32/wine/brsfolder.c
+++ b/dll/win32/shell32/wine/brsfolder.c
@@ -122,23 +122,12 @@ static inline DWORD BrowseFlagsToSHCONTF(UINT ulFlags)
     return SHCONTF_FOLDERS | (ulFlags & BIF_BROWSEINCLUDEFILES ? SHCONTF_NONFOLDERS : 0);
 }
 
-#ifndef __REACTOS__
 static void browsefolder_callback( LPBROWSEINFOW lpBrowseInfo, HWND hWnd,
                                    UINT msg, LPARAM param )
-#else
-static BOOL browsefolder_callback( LPBROWSEINFOW lpBrowseInfo, HWND hWnd,
-                                   UINT msg, LPARAM param )
-#endif
 {
-#ifndef __REACTOS__
     if (!lpBrowseInfo->lpfn)
         return;
     lpBrowseInfo->lpfn( hWnd, msg, param, lpBrowseInfo->lParam );
-#else
-    if (!lpBrowseInfo->lpfn)
-        return FALSE;
-    return lpBrowseInfo->lpfn( hWnd, msg, param, lpBrowseInfo->lParam );
-#endif
 }
 
 #ifndef __REACTOS__ /* Defined in "layout.h" */
@@ -504,19 +493,11 @@ static inline BOOL PIDLIsType(LPCITEMIDLIST pidl, PIDLTYPE type)
     return (data->type == type);
 }
 
-#ifndef __REACTOS__
 static void BrsFolder_CheckValidSelection( browse_info *info, LPTV_ITEMDATA lptvid )
-#else
-static void BrsFolder_CheckValidSelection( browse_info *info, LPTV_ITEMDATA lptvid, BOOL bDirValid)
-#endif
 {
     LPBROWSEINFOW lpBrowseInfo = info->lpBrowseInfo;
     LPCITEMIDLIST pidl = lptvid->lpi;
-#ifndef __REACTOS__
     BOOL bEnabled = TRUE;
-#else
-    BOOL bEnabled = bDirValid;
-#endif
     DWORD dwAttributes;
     HRESULT r;
 
@@ -603,25 +584,15 @@ static HRESULT BrsFolder_Treeview_Changed( browse_info *info, NMTREEVIEWW *pnmtv
     LPTV_ITEMDATA lptvid = (LPTV_ITEMDATA) pnmtv->itemNew.lParam;
     WCHAR name[MAX_PATH];
 
-#ifdef __REACTOS__
-    BOOL bBtnState;
-#endif
     ILFree(info->pidlRet);
     info->pidlRet = ILClone(lptvid->lpifq);
 
     if (GetName(lptvid->lpsfParent, lptvid->lpi, SHGDN_NORMAL, name))
             SetWindowTextW( GetDlgItem(info->hWnd, IDC_BROWSE_FOR_FOLDER_FOLDER_TEXT), name );
 
-#ifndef __REACTOS__
     browsefolder_callback( info->lpBrowseInfo, info->hWnd, BFFM_SELCHANGED,
                            (LPARAM)info->pidlRet );
     BrsFolder_CheckValidSelection( info, lptvid );
-#else
-    bBtnState = browsefolder_callback( info->lpBrowseInfo, info->hWnd, BFFM_SELCHANGED,
-                           (LPARAM)info->pidlRet );
-
-    BrsFolder_CheckValidSelection( info, lptvid, bBtnState);
-#endif
     return S_OK;
 }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2992,6 +2992,22 @@ ProcessSetupInf(
                              (LPBYTE)pSetupData->SourcePath,
                              (wcslen(pSetupData->SourcePath) + 1) * sizeof(WCHAR));
 
+        WCHAR szData[MAX_PATH];
+        LPWSTR pData = szData;
+        ZeroMemory(szData, _countof(szData) * sizeof(WCHAR));
+        GetWindowsDirectoryW(szData, _countof(szData));
+        wcscat(szData, L"\\inf");
+        pData = szData + (wcslen(szData) + 1) ;
+        wcscpy(pData, pSetupData->SourcePath);
+        pData += (wcslen(pData) + 1) ;
+        *pData = UNICODE_NULL;
+
+        res = RegSetValueExW(hKey,
+                             L"Installation Sources",
+                             0,
+                             REG_MULTI_SZ,
+                            (LPBYTE)szData,
+                            ((DWORD)(pData - szData) * sizeof(WCHAR)));
         RegCloseKey(hKey);
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2884,7 +2884,7 @@ ProcessUnattendSection(
 static BOOL
 PathIsEqual(
     IN LPCWSTR lpPath1,
-    IN LPWSTR lpPath2)
+    IN LPCWSTR lpPath2)
 {
     WCHAR szPath1[MAX_PATH];
     WCHAR szPath2[MAX_PATH];

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2968,6 +2968,26 @@ ProcessSetupInf(
     }
 #endif
 
+    WCHAR szData[MAX_PATH] = L"";
+    LPWSTR pData = szData;
+    size_t pcchLength;
+
+    GetWindowsDirectoryW(szData, ARRAYSIZE(szData));
+    StringCchCatW(szData, ARRAYSIZE(szData), L"\\inf");
+    if (FAILED(StringCchLengthW(szData, ARRAYSIZE(szData), &pcchLength)))
+    {
+        return;
+    }
+    pData += pcchLength + 1;
+    pcchLength = (ARRAYSIZE(szData) - pcchLength - 1);
+    StringCchCopyW(pData, pcchLength, pSetupData->SourcePath);
+    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szData), &pcchLength)))
+    {
+        return;
+    }
+    pData += pcchLength + 1;
+    *pData = UNICODE_NULL;
+
     res = RegCreateKeyExW(HKEY_LOCAL_MACHINE,
                           L"Software\\Microsoft\\Windows\\CurrentVersion\\Setup",
                           0, NULL,
@@ -2978,10 +2998,6 @@ ProcessSetupInf(
                           NULL);
     if (res == ERROR_SUCCESS)
     {
-        WCHAR szData[MAX_PATH] = L"";
-        LPWSTR pData = szData;
-        size_t pcchLength;
-
         res = RegSetValueExW(hKey,
                              L"SourcePath",
                              0,
@@ -2996,28 +3012,12 @@ ProcessSetupInf(
                              (LPBYTE)pSetupData->SourcePath,
                              (wcslen(pSetupData->SourcePath) + 1) * sizeof(WCHAR));
 
-        GetWindowsDirectoryW(szData, ARRAYSIZE(szData));
-        StringCchCatW(szData, ARRAYSIZE(szData), L"\\inf");
-        if (FAILED(StringCchLengthW(szData, ARRAYSIZE(szData), &pcchLength)))
-        {
-            return;
-        }
-        pData += pcchLength + 1;
-        pcchLength = (ARRAYSIZE(szData) - pcchLength - 1);
-        StringCchCopyW(pData, pcchLength, pSetupData->SourcePath);
-        if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szData), &pcchLength)))
-        {
-            return;
-        }
-        pData += pcchLength + 1;
-        *pData = UNICODE_NULL;
-
         res = RegSetValueExW(hKey,
                              L"Installation Sources",
                              0,
                              REG_MULTI_SZ,
                              (LPBYTE)szData,
-                             ((DWORD)(pData - szData) * sizeof(WCHAR)));
+                             (DWORD)((pData - szData) * sizeof(WCHAR)));
         RegCloseKey(hKey);
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2985,7 +2985,7 @@ ProcessSetupInf(
     cchLength = (ARRAYSIZE(szValue) - cchLength - 1);
     StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
 
-    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szValue), &cchLength)))
+    if (FAILED(StringCchLengthW(pData, cchLength, &cchLength)))
     {
         return;
     }

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2977,9 +2977,9 @@ ProcessSetupInf(
     GetWindowsDirectoryW(szValue, ARRAYSIZE(szValue));
     hr = StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
 
-    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength))
-        || FAILED(hr))
+    if (FAILED(hr) || FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength)))
     {
+        DPRINT1("Failed to initialize installation sources path!\n");
         return;
     }
 
@@ -2987,9 +2987,9 @@ ProcessSetupInf(
     cchLength = (ARRAYSIZE(szValue) - cchLength - 1);
     hr = StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
 
-    if (FAILED(StringCchLengthW(pData, cchLength, &cchLength))
-        || FAILED(hr))
+    if (FAILED(hr) || FAILED(StringCchLengthW(pData, cchLength, &cchLength)))
     {
+        DPRINT1("Failed to initialize installation sources path!\n");
         return;
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -3025,7 +3025,7 @@ ProcessSetupInf(
                              0,
                              REG_MULTI_SZ,
                              (LPBYTE)szValue,
-                             (DWORD)((pData - szValue) * sizeof(WCHAR)));
+                             (DWORD)((pData - szValue + 1) * sizeof(WCHAR)));
         RegCloseKey(hKey);
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2890,6 +2890,8 @@ ProcessSetupInf(
     DWORD LineLength;
     HKEY hKey;
     LONG res;
+    LPWSTR pData;
+    size_t pcchLength;
 
     pSetupData->hSetupInf = INVALID_HANDLE_VALUE;
 
@@ -2968,23 +2970,26 @@ ProcessSetupInf(
     }
 #endif
 
-    WCHAR szData[MAX_PATH] = L"";
-    LPWSTR pData = szData;
-    size_t pcchLength;
+    *szValue = UNICODE_NULL;
+    pData = szValue;
 
-    GetWindowsDirectoryW(szData, ARRAYSIZE(szData));
-    StringCchCatW(szData, ARRAYSIZE(szData), L"\\inf");
-    if (FAILED(StringCchLengthW(szData, ARRAYSIZE(szData), &pcchLength)))
+    GetWindowsDirectoryW(szValue, ARRAYSIZE(szValue));
+    StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
+
+    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &pcchLength)))
     {
         return;
     }
+
     pData += pcchLength + 1;
-    pcchLength = (ARRAYSIZE(szData) - pcchLength - 1);
+    pcchLength = (ARRAYSIZE(szValue) - pcchLength - 1);
     StringCchCopyW(pData, pcchLength, pSetupData->SourcePath);
-    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szData), &pcchLength)))
+
+    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szValue), &pcchLength)))
     {
         return;
     }
+
     pData += pcchLength + 1;
     *pData = UNICODE_NULL;
 
@@ -3016,8 +3021,8 @@ ProcessSetupInf(
                              L"Installation Sources",
                              0,
                              REG_MULTI_SZ,
-                             (LPBYTE)szData,
-                             (DWORD)((pData - szData) * sizeof(WCHAR)));
+                             (LPBYTE)szValue,
+                             (DWORD)((pData - szValue) * sizeof(WCHAR)));
         RegCloseKey(hKey);
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -20,6 +20,7 @@
 #include <windowsx.h>
 #include <wincon.h>
 #include <shlobj.h>
+#include <shlwapi.h>
 #include <tzlib.h>
 #include <strsafe.h>
 
@@ -2880,6 +2881,97 @@ ProcessUnattendSection(
     }
 }
 
+static VOID
+AddInstallationSource(
+    IN HKEY hKey,
+    IN LPWSTR lpPath)
+{
+    LONG res;
+    DWORD dwRegType;
+    DWORD dwPathLength = 0;
+    DWORD dwNewLength = 0;
+    LPWSTR Buffer = NULL;
+    LPWSTR Path;
+
+    res = RegQueryValueExW(
+        hKey,
+        L"Installation Sources",
+        NULL,
+        &dwRegType,
+        NULL,
+        &dwPathLength);
+
+    if (res != ERROR_SUCCESS ||
+        dwRegType != REG_MULTI_SZ ||
+        dwPathLength == 0 ||
+        dwPathLength % sizeof(WCHAR) != 0)
+    {
+        dwPathLength = 0;
+        goto set;
+    }
+
+    /* Reserve space for existing data + new string */
+    dwNewLength = dwPathLength + (wcslen(lpPath) + 1) * sizeof(WCHAR);
+    Buffer = HeapAlloc(GetProcessHeap(), 0, dwNewLength);
+    if (!Buffer)
+        return;
+
+    ZeroMemory(Buffer, dwNewLength);
+
+    res = RegQueryValueExW(
+        hKey,
+        L"Installation Sources",
+        NULL,
+        NULL,
+        (LPBYTE)Buffer,
+        &dwPathLength);
+
+    if (res != ERROR_SUCCESS)
+    {
+        HeapFree(GetProcessHeap(), 0, Buffer);
+        dwPathLength = 0;
+        goto set;
+    }
+
+    /* Sanity check, these should already be zeros */
+    Buffer[dwPathLength / sizeof(WCHAR) - 2] = UNICODE_NULL;
+    Buffer[dwPathLength / sizeof(WCHAR) - 1] = UNICODE_NULL;
+
+    for (Path = Buffer; *Path; Path += wcslen(Path) + 1)
+    {
+        /* Check if path is already added */
+        if (PathIsSameRootW(Path, lpPath) && wcslen(Path) == wcslen(lpPath))
+            goto cleanup;
+    }
+
+    Path = Buffer + dwPathLength / sizeof(WCHAR) - 1;
+
+set:
+    if (dwPathLength == 0)
+    {
+        dwNewLength = (wcslen(lpPath) + 1 + 1) * sizeof(WCHAR);
+        Buffer = HeapAlloc(GetProcessHeap(), 0, dwNewLength);
+        if (!Buffer)
+            return;
+
+        Path = Buffer;
+    }
+
+    StringCbCopyW(Path, dwNewLength - (Path - Buffer) * sizeof(WCHAR), lpPath);
+    Buffer[dwNewLength / sizeof(WCHAR) - 1] = UNICODE_NULL;
+
+    RegSetValueExW(
+        hKey,
+        L"Installation Sources",
+        0,
+        REG_MULTI_SZ,
+        (LPBYTE)Buffer,
+        dwNewLength);
+
+cleanup:
+    HeapFree(GetProcessHeap(), 0, Buffer);
+}
+
 VOID
 ProcessSetupInf(
     IN OUT PSETUPDATA pSetupData)
@@ -2890,9 +2982,6 @@ ProcessSetupInf(
     DWORD LineLength;
     HKEY hKey;
     LONG res;
-    LPWSTR pData;
-    size_t cchLength;
-    HRESULT hr;
 
     pSetupData->hSetupInf = INVALID_HANDLE_VALUE;
 
@@ -2971,31 +3060,6 @@ ProcessSetupInf(
     }
 #endif
 
-    *szValue = UNICODE_NULL;
-    pData = szValue;
-
-    GetWindowsDirectoryW(szValue, ARRAYSIZE(szValue));
-    hr = StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
-
-    if (FAILED(hr) || FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength)))
-    {
-        DPRINT1("Failed to initialize installation sources path!\n");
-        return;
-    }
-
-    pData += cchLength + 1;
-    cchLength = (ARRAYSIZE(szValue) - cchLength - 1);
-    hr = StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
-
-    if (FAILED(hr) || FAILED(StringCchLengthW(pData, cchLength, &cchLength)))
-    {
-        DPRINT1("Failed to initialize installation sources path!\n");
-        return;
-    }
-
-    pData += cchLength + 1;
-    *pData = UNICODE_NULL;
-
     res = RegCreateKeyExW(HKEY_LOCAL_MACHINE,
                           L"Software\\Microsoft\\Windows\\CurrentVersion\\Setup",
                           0, NULL,
@@ -3006,6 +3070,8 @@ ProcessSetupInf(
                           NULL);
     if (res == ERROR_SUCCESS)
     {
+        AddInstallationSource(hKey, pSetupData->SourcePath);
+
         res = RegSetValueExW(hKey,
                              L"SourcePath",
                              0,
@@ -3020,12 +3086,6 @@ ProcessSetupInf(
                              (LPBYTE)pSetupData->SourcePath,
                              (wcslen(pSetupData->SourcePath) + 1) * sizeof(WCHAR));
 
-        res = RegSetValueExW(hKey,
-                             L"Installation Sources",
-                             0,
-                             REG_MULTI_SZ,
-                             (LPBYTE)szValue,
-                             (DWORD)((pData - szValue + 1) * sizeof(WCHAR)));
         RegCloseKey(hKey);
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2881,6 +2881,32 @@ ProcessUnattendSection(
     }
 }
 
+static BOOL
+PathIsEqual(
+    IN LPWSTR lpPath1,
+    IN LPWSTR lpPath2)
+{
+    WCHAR szPath1[MAX_PATH];
+    WCHAR szPath2[MAX_PATH];
+
+    /* If something goes wrong, better return TRUE,
+     * so the calling function returns early.
+     */
+    if (!PathCanonicalizeW(szPath1, lpPath1))
+        return TRUE;
+
+    if (!PathAddBackslashW(szPath1))
+        return TRUE;
+
+    if (!PathCanonicalizeW(szPath2, lpPath2))
+        return TRUE;
+
+    if (!PathAddBackslashW(szPath2))
+        return TRUE;
+
+    return (_wcsicmp(szPath1, szPath2) == 0);
+}
+
 static VOID
 AddInstallationSource(
     IN HKEY hKey,
@@ -2940,7 +2966,7 @@ AddInstallationSource(
     for (Path = Buffer; *Path; Path += wcslen(Path) + 1)
     {
         /* Check if path is already added */
-        if (PathIsSameRootW(Path, lpPath) && wcslen(Path) == wcslen(lpPath))
+        if (PathIsEqual(Path, lpPath))
             goto cleanup;
     }
 

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2891,7 +2891,7 @@ ProcessSetupInf(
     HKEY hKey;
     LONG res;
     LPWSTR pData;
-    size_t pcchLength;
+    size_t cchLength;
 
     pSetupData->hSetupInf = INVALID_HANDLE_VALUE;
 
@@ -2976,21 +2976,21 @@ ProcessSetupInf(
     GetWindowsDirectoryW(szValue, ARRAYSIZE(szValue));
     StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
 
-    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &pcchLength)))
+    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength)))
     {
         return;
     }
 
-    pData += pcchLength + 1;
-    pcchLength = (ARRAYSIZE(szValue) - pcchLength - 1);
-    StringCchCopyW(pData, pcchLength, pSetupData->SourcePath);
+    pData += cchLength + 1;
+    cchLength = (ARRAYSIZE(szValue) - cchLength - 1);
+    StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
 
-    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szValue), &pcchLength)))
+    if (FAILED(StringCchLengthW(pData, ARRAYSIZE(szValue), &cchLength)))
     {
         return;
     }
 
-    pData += pcchLength + 1;
+    pData += cchLength + 1;
     *pData = UNICODE_NULL;
 
     res = RegCreateKeyExW(HKEY_LOCAL_MACHINE,

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2883,7 +2883,7 @@ ProcessUnattendSection(
 
 static BOOL
 PathIsEqual(
-    IN LPWSTR lpPath1,
+    IN LPCWSTR lpPath1,
     IN LPWSTR lpPath2)
 {
     WCHAR szPath1[MAX_PATH];

--- a/dll/win32/syssetup/wizard.c
+++ b/dll/win32/syssetup/wizard.c
@@ -2892,6 +2892,7 @@ ProcessSetupInf(
     LONG res;
     LPWSTR pData;
     size_t cchLength;
+    HRESULT hr;
 
     pSetupData->hSetupInf = INVALID_HANDLE_VALUE;
 
@@ -2974,18 +2975,20 @@ ProcessSetupInf(
     pData = szValue;
 
     GetWindowsDirectoryW(szValue, ARRAYSIZE(szValue));
-    StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
+    hr = StringCchCatW(szValue, ARRAYSIZE(szValue), L"\\inf");
 
-    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength)))
+    if (FAILED(StringCchLengthW(szValue, ARRAYSIZE(szValue), &cchLength))
+        || FAILED(hr))
     {
         return;
     }
 
     pData += cchLength + 1;
     cchLength = (ARRAYSIZE(szValue) - cchLength - 1);
-    StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
+    hr = StringCchCopyW(pData, cchLength, pSetupData->SourcePath);
 
-    if (FAILED(StringCchLengthW(pData, cchLength, &cchLength)))
+    if (FAILED(StringCchLengthW(pData, cchLength, &cchLength))
+        || FAILED(hr))
     {
         return;
     }


### PR DESCRIPTION
[NEWDEV] Enable Browser Dlg OK button, when driver is found

expected behavior:
When selecting a directory that contains a driver to update, the "OK" button in the browser dialog is activated when the requested driver is found. otherwise the "OK" button is disabled.