### PR TITLE
Lift the SVCHOST global header and add & complete all the missing definitions.

### DIFF
--- a/base/services/seclogon/precomp.h
+++ b/base/services/seclogon/precomp.h
@@ -28,7 +28,7 @@
 #include <wine/debug.h>
 
 extern HINSTANCE hDllInstance;
-extern SVCHOST_GLOBALS *lpServiceGlobals;
+extern PSVCHOST_GLOBAL_DATA lpServiceGlobals;
 
 DWORD
 StartRpcServer(VOID);

--- a/base/services/seclogon/rpcserver.c
+++ b/base/services/seclogon/rpcserver.c
@@ -31,10 +31,10 @@ void __RPC_USER midl_user_free(void __RPC_FAR * ptr)
 DWORD
 StartRpcServer(VOID)
 {
-    ULONG Status;
+    NTSTATUS Status;
 
-    Status = ((LPSTART_RPC_SERVER)lpServiceGlobals->RpcpStartRpcServer)(L"seclogon", ISeclogon_v1_0_s_ifspec);
-    TRACE("RpcpStartRpcServer returned 0x%08lx\n", Status);
+    Status = lpServiceGlobals->StartRpcServer(L"seclogon", ISeclogon_v1_0_s_ifspec);
+    TRACE("StartRpcServer returned 0x%08lx\n", Status);
 
     return RtlNtStatusToDosError(Status);
 }
@@ -43,10 +43,10 @@ StartRpcServer(VOID)
 DWORD
 StopRpcServer(VOID)
 {
-    ULONG Status;
+    NTSTATUS Status;
 
-    Status = ((LPSTOP_RPC_SERVER)lpServiceGlobals->RpcpStopRpcServer)(ISeclogon_v1_0_s_ifspec);
-    TRACE("RpcpStopRpcServer returned 0x%08lx\n", Status);
+    Status = lpServiceGlobals->StopRpcServer(ISeclogon_v1_0_s_ifspec);
+    TRACE("StopRpcServer returned 0x%08lx\n", Status);
 
     return RtlNtStatusToDosError(Status);
 }

--- a/base/services/seclogon/seclogon.c
+++ b/base/services/seclogon/seclogon.c
@@ -15,7 +15,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(seclogon);
 /* GLOBALS ******************************************************************/
 
 HINSTANCE hDllInstance;
-SVCHOST_GLOBALS *lpServiceGlobals;
+PSVCHOST_GLOBAL_DATA lpServiceGlobals;
 
 static WCHAR ServiceName[] = L"seclogon";
 
@@ -112,7 +112,7 @@ ServiceControlHandlerEx(
 VOID
 WINAPI
 SvchostPushServiceGlobals(
-    _In_ SVCHOST_GLOBALS *lpGlobals)
+    _In_ PSVCHOST_GLOBAL_DATA lpGlobals)
 {
     TRACE("SvchostPushServiceGlobals(%p)\n", lpGlobals);
     lpServiceGlobals = lpGlobals;

--- a/base/services/svchost/globals.c
+++ b/base/services/svchost/globals.c
@@ -47,7 +47,7 @@ DOMAIN_SID_DATA DomainSidData[8] =
     { &AliasBackupOpsSid, DOMAIN_ALIAS_RID_BACKUP_OPS },
 };
 
-PSVCHOST_GLOBALS g_pSvchostSharedGlobals;
+PSVCHOST_GLOBAL_DATA g_pSvchostSharedGlobals;
 DWORD g_SvchostInitFlag;
 HANDLE g_hHeap;
 
@@ -148,13 +148,13 @@ SvchostBuildSharedGlobals (
     g_pSvchostSharedGlobals->AliasBackupOpsSid = AliasBackupOpsSid;
 
     /* Write the pointers to the callbacks */
-    g_pSvchostSharedGlobals->RpcpStartRpcServer = RpcpStartRpcServer;
-    g_pSvchostSharedGlobals->RpcpStopRpcServer = RpcpStopRpcServer;
-    g_pSvchostSharedGlobals->RpcpStopRpcServerEx = RpcpStopRpcServerEx;
-    g_pSvchostSharedGlobals->SvcNetBiosOpen = SvcNetBiosOpen;
-    g_pSvchostSharedGlobals->SvcNetBiosClose = SvcNetBiosClose;
-    g_pSvchostSharedGlobals->SvcNetBiosReset = SvcNetBiosReset;
-    g_pSvchostSharedGlobals->SvcRegisterStopCallback = SvcRegisterStopCallback;
+    g_pSvchostSharedGlobals->StartRpcServer = RpcpStartRpcServer;
+    g_pSvchostSharedGlobals->StopRpcServer = RpcpStopRpcServer;
+    g_pSvchostSharedGlobals->StopRpcServerEx = RpcpStopRpcServerEx;
+    g_pSvchostSharedGlobals->NetBiosOpen = SvcNetBiosOpen;
+    g_pSvchostSharedGlobals->NetBiosClose = SvcNetBiosClose;
+    g_pSvchostSharedGlobals->NetBiosReset = SvcNetBiosReset;
+    g_pSvchostSharedGlobals->RegisterStopCallback = SvcRegisterStopCallback;
 }
 
 VOID

--- a/base/services/svchost/rpcsrv.c
+++ b/base/services/svchost/rpcsrv.c
@@ -81,7 +81,7 @@ RpcpStopRpcServerEx (
 NTSTATUS
 NTAPI
 RpcpAddInterface (
-    _In_ LPCWSTR IfName,
+    _In_ PCWSTR IfName,
     _In_ RPC_IF_HANDLE IfSpec
     )
 {
@@ -129,7 +129,7 @@ RpcpAddInterface (
 NTSTATUS
 NTAPI
 RpcpStartRpcServer (
-    _In_ LPCWSTR IfName,
+    _In_ PCWSTR IfName,
     _In_ RPC_IF_HANDLE IfSpec
     )
 {

--- a/base/services/svchost/svchost.c
+++ b/base/services/svchost/svchost.c
@@ -516,8 +516,8 @@ SvchostStopCallback (
 DWORD
 WINAPI
 SvcRegisterStopCallback (
-    _In_ PHANDLE phNewWaitObject,
-    _In_ LPCWSTR ServiceName,
+    _Out_ PHANDLE phNewWaitObject,
+    _In_ PCWSTR ServiceName,
     _In_ HANDLE hObject,
     _In_ PSVCHOST_STOP_CALLBACK pfnStopCallback,
     _In_ PVOID pContext,

--- a/base/services/svchost/svchost.h
+++ b/base/services/svchost/svchost.h
@@ -39,8 +39,9 @@
 //
 typedef VOID
 (WINAPI *PSVCHOST_INIT_GLOBALS) (
-    _In_ PSVCHOST_GLOBALS Globals
+    _In_ PSVCHOST_GLOBAL_DATA Globals
 );
+
 //
 // Initialization Stages
 //
@@ -139,7 +140,7 @@ RpcpStopRpcServerEx (
 NTSTATUS
 NTAPI
 RpcpStartRpcServer (
-    _In_ LPCWSTR IfName,
+    _In_ PCWSTR IfName,
     _In_ RPC_IF_HANDLE IfSpec
 );
 
@@ -189,7 +190,7 @@ SvcNetBiosInit (
 VOID
 WINAPI
 SvcNetBiosClose (
-VOID
+    VOID
 );
 
 VOID
@@ -243,14 +244,14 @@ RegQueryStringA (
 DWORD
 WINAPI
 SvcRegisterStopCallback (
-    _In_ PHANDLE phNewWaitObject,
-    _In_ LPCWSTR ServiceName,
+    _Out_ PHANDLE phNewWaitObject,
+    _In_ PCWSTR ServiceName,
     _In_ HANDLE hObject,
     _In_ PSVCHOST_STOP_CALLBACK pfnStopCallback,
     _In_ PVOID pContext,
     _In_ ULONG dwFlags
 );
 
-extern PSVCHOST_GLOBALS g_pSvchostSharedGlobals;
+extern PSVCHOST_GLOBAL_DATA g_pSvchostSharedGlobals;
 
 #endif /* _SVCHOST_PCH_ */

--- a/dll/win32/mswsock/stubs.c
+++ b/dll/win32/mswsock/stubs.c
@@ -446,7 +446,7 @@ StopWsdpService()
  */
 VOID
 WINAPI
-SvchostPushServiceGlobals(SVCHOST_GLOBALS *lpGlobals)
+SvchostPushServiceGlobals(PSVCHOST_GLOBAL_DATA lpGlobals)
 {
   OutputDebugStringW(L"mswsock SvchostPushServiceGlobals stub called\n");
 }

--- a/sdk/include/reactos/svc.h
+++ b/sdk/include/reactos/svc.h
@@ -1,68 +1,131 @@
 /*
  * PROJECT:     ReactOS Service Host
  * LICENSE:     BSD - See COPYING.ARM in the top level directory
- * FILE:        sdk/include/reactos/svc.h
  * PURPOSE:     Global Header for Service Host
  * PROGRAMMERS: ReactOS Portable Systems Group
+ *
+ * REFERENCES:
+ * https://www.geoffchappell.com/studies/windows/win32/services/svchost/process/globaldata.htm
  */
-/* See https://www.geoffchappell.com/studies/windows/win32/services/svchost/process/globaldata.htm?tx=78 */
 
 #ifndef __SVC_H
 #define __SVC_H
 
-#ifndef __RPC_H__
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef __RPC_H__ // For RPC_IF_HANDLE
+/* Don't include windows.h if we just need rpc.h */
+#ifndef RPC_NO_WINDOWS_H
+#define RPC_NO_WINDOWS_H
+#endif
 #include <rpc.h>
+#endif // __RPC_H__
+
+#ifndef WINAPI
+#define WINAPI __stdcall
+#endif
+
+/* Ensure NTSTATUS is defined */
+#ifndef _NTDEF_
+typedef _Return_type_success_(return >= 0) LONG NTSTATUS, *PNTSTATUS;
 #endif
 
 
-typedef RPC_STATUS
-(CALLBACK *LPSTART_RPC_SERVER) (
-    _In_ RPC_WSTR PipeName,
+/*
+ * Entrypoints for starting and stopping an RPC server.
+ */
+typedef NTSTATUS
+(WINAPI *PSTART_RPC_SERVER)(
+    _In_ PCWSTR IfName,
     _In_ RPC_IF_HANDLE IfSpec);
 
-typedef RPC_STATUS
-(CALLBACK *LPSTOP_RPC_SERVER) (
+typedef NTSTATUS
+(WINAPI *PSTOP_RPC_SERVER)(
     _In_ RPC_IF_HANDLE IfSpec);
 
-//
-// This is the callback that a hosted service can register for stop notification
-//
+typedef NTSTATUS
+(WINAPI *PSTOP_RPC_SERVER_EX)(
+    _In_ RPC_IF_HANDLE IfSpec);
+
+/*
+ * Entrypoints for NetBIOS service support.
+ */
 typedef VOID
-(CALLBACK *PSVCHOST_STOP_CALLBACK) (
-    _In_ PVOID lpParameter,
-    _In_ BOOLEAN TimerOrWaitFired
-    );
+(WINAPI *PNET_BIOS_OPEN)(VOID);
 
-//
-// Hosted Services and SvcHost Use this Structure
-//
-typedef struct _SVCHOST_GLOBALS
+typedef VOID
+(WINAPI *PNET_BIOS_CLOSE)(VOID);
+
+typedef DWORD
+(WINAPI *PNET_BIOS_RESET)(
+    _In_ UCHAR LanaNum);
+
+/*
+ * Callback that a hosted service can register for stop notification.
+ * Alias to (RTL_)WAITORTIMERCALLBACK(FUNC).
+ */
+/*
+typedef VOID
+(CALLBACK *PSVCHOST_STOP_CALLBACK)(
+    _In_ PVOID lpParameter,
+    _In_ BOOLEAN TimerOrWaitFired);
+*/
+typedef WAITORTIMERCALLBACK PSVCHOST_STOP_CALLBACK;
+
+#if (_WIN32_WINNT == _WIN32_WINNT_WINXP && NTDDI_VERSION >= NTDDI_WINXPSP2) || \
+    (NTDDI_VERSION >= NTDDI_WS03SP1)
+typedef DWORD
+(WINAPI *PREGISTER_STOP_CALLBACK)(
+    _Out_ PHANDLE phNewWaitObject,
+    _In_ PCWSTR pszServiceName,
+    _In_ HANDLE hObject,
+    _In_ PSVCHOST_STOP_CALLBACK Callback,
+    _In_ PVOID Context,
+    _In_ ULONG dwFlags);
+#endif
+
+/*
+ * Hosted Services and SvcHost use this shared global data structure.
+ */
+typedef struct _SVCHOST_GLOBAL_DATA
 {
-    PVOID NullSid;
-    PVOID WorldSid;
-    PVOID LocalSid;
-    PVOID NetworkSid;
-    PVOID LocalSystemSid;
-    PVOID LocalServiceSid;
-    PVOID NetworkServiceSid;
-    PVOID BuiltinDomainSid;
-    PVOID AuthenticatedUserSid;
-    PVOID AnonymousLogonSid;
-    PVOID AliasAdminsSid;
-    PVOID AliasUsersSid;
-    PVOID AliasGuestsSid;
-    PVOID AliasPowerUsersSid;
-    PVOID AliasAccountOpsSid;
-    PVOID AliasSystemOpsSid;
-    PVOID AliasPrintOpsSid;
-    PVOID AliasBackupOpsSid;
-    PVOID RpcpStartRpcServer;
-    PVOID RpcpStopRpcServer;
-    PVOID RpcpStopRpcServerEx;
-    PVOID SvcNetBiosOpen;
-    PVOID SvcNetBiosClose;
-    PVOID SvcNetBiosReset;
-    PVOID SvcRegisterStopCallback;
-} SVCHOST_GLOBALS, *PSVCHOST_GLOBALS;
+    PSID NullSid;
+    PSID WorldSid;
+    PSID LocalSid;
+    PSID NetworkSid;
+    PSID LocalSystemSid;
+    PSID LocalServiceSid;
+    PSID NetworkServiceSid;
+    PSID BuiltinDomainSid;
+    PSID AuthenticatedUserSid;
+    PSID AnonymousLogonSid;
+    PSID AliasAdminsSid;
+    PSID AliasUsersSid;
+    PSID AliasGuestsSid;
+    PSID AliasPowerUsersSid;
+    PSID AliasAccountOpsSid;
+    PSID AliasSystemOpsSid;
+    PSID AliasPrintOpsSid;
+    PSID AliasBackupOpsSid;
+
+    /* SvcHost callbacks for RPC server and NetBIOS service support */
+    PSTART_RPC_SERVER   StartRpcServer;
+    PSTOP_RPC_SERVER    StopRpcServer;
+    PSTOP_RPC_SERVER_EX StopRpcServerEx;
+    PNET_BIOS_OPEN      NetBiosOpen;
+    PNET_BIOS_CLOSE     NetBiosClose;
+    PNET_BIOS_RESET     NetBiosReset;
+
+#if (_WIN32_WINNT == _WIN32_WINNT_WINXP && NTDDI_VERSION >= NTDDI_WINXPSP2) || \
+    (NTDDI_VERSION >= NTDDI_WS03SP1)
+    PREGISTER_STOP_CALLBACK RegisterStopCallback;
+#endif
+} SVCHOST_GLOBAL_DATA, *PSVCHOST_GLOBAL_DATA;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SVC_H */


### PR DESCRIPTION
## Purpose

[SDK:REACTOS][SVCHOST] Following commit 24a727a23, give a lift to the SVCHOST global header and add & complete all the missing definitions.

## Proposed changes

- Based on https://www.geoffchappell.com/studies/windows/win32/services/svchost/process/globaldata.htm
  from public debug symbols (e.g. svchost, mswsock, w32time, wscsvc...),
  adjust some of our symbols' names.

- Make the header C++-compatible.

- Even if the start/stop RPC server functions return an error code whose
  underlying storage type is a 32-bit long, they don't return an RPC
  status error code, but an NT status. Thus, use the adequate type
  instead.

- The PSVCHOST_STOP_CALLBACK is nothing but a WAITORTIMERCALLBACK function.

- Take the opportunity to fix some of these functions' SAL annotations.

- Remark: "LP" for pointers is old-fashioned Windows, avoid this in NT code.

[MSWSOCK][SECLOGON] Do the minor adjustments. Remove unnecessary function casts.
