### PR TITLE
[NTUSER] Initialize correctly CaretWidth value.

### DIFF
--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -73,6 +73,7 @@ static const WCHAR* VAL_SCRLLLINES = L"WheelScrollLines";
 static const WCHAR* VAL_CLICKLOCKTIME = L"ClickLockTime";
 static const WCHAR* VAL_PAINTDESKVER = L"PaintDesktopVersion";
 static const WCHAR* VAL_CARETRATE = L"CursorBlinkRate";
+static const WCHAR* VAL_CARETWIDTH = L"CaretWidth";
 #if (_WIN32_WINNT >= 0x0600)
 static const WCHAR* VAL_SCRLLCHARS = L"WheelScrollChars";
 #endif
@@ -288,6 +289,7 @@ SpiUpdatePerUserSystemParameters(VOID)
     gspv.iWheelScrollLines = SpiLoadInt(KEY_DESKTOP, VAL_SCRLLLINES, 3);
     gspv.dwMouseClickLockTime = SpiLoadDWord(KEY_DESKTOP, VAL_CLICKLOCKTIME, 1200);
     gpsi->dtCaretBlink = SpiLoadInt(KEY_DESKTOP, VAL_CARETRATE, 530);
+    gspv.dwCaretWidth = SpiLoadDWord(KEY_DESKTOP, VAL_CARETWIDTH, 1);
     gspv.dwUserPrefMask = SpiLoadUserPrefMask(UPM_DEFAULT);
     gspv.bMouseClickLock = (gspv.dwUserPrefMask & UPM_CLICKLOCK) != 0;
     gspv.bMouseCursorShadow = (gspv.dwUserPrefMask & UPM_CURSORSHADOW) != 0;


### PR DESCRIPTION
Fixes CORE-14359

## Purpose

dwCaretWidth is not initialized in NtUser, this causes that when calling SystemParametersInfo() with SPI_GETCARETWIDTH flag, the DWord pointer passed as 3rd parameter always returns zero, the visible effect of this is that carets are created with 0 width and cannot be seen in text inputs.

JIRA issue: [CORE-13984](https://jira.reactos.org/browse/CORE-13984)  [CORE-14359](https://jira.reactos.org/browse/CORE-14359)  [CORE-16624](https://jira.reactos.org/browse/CORE-16624) 
