### PR TITLE
[ATL][MSPAINT] Add ATLTRACE and fix assertion failures

### DIFF
--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -44,7 +44,7 @@ ImageModel::ImageModel()
 
 void ImageModel::CopyPrevious()
 {
-    DPRINT("%s: %d\n", __FUNCTION__, currInd);
+    ATLTRACE("%s: %d\n", __FUNCTION__, currInd);
     DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
     hBms[(currInd + 1) % HISTORYSIZE] = CopyDIBImage(hBms[currInd]);
     currInd = (currInd + 1) % HISTORYSIZE;
@@ -57,7 +57,7 @@ void ImageModel::CopyPrevious()
 
 void ImageModel::Undo()
 {
-    DPRINT("%s: %d\n", __FUNCTION__, undoSteps);
+    ATLTRACE("%s: %d\n", __FUNCTION__, undoSteps);
     if (undoSteps > 0)
     {
         int oldWidth = GetWidth();
@@ -76,7 +76,7 @@ void ImageModel::Undo()
 
 void ImageModel::Redo()
 {
-    DPRINT("%s: %d\n", __FUNCTION__, redoSteps);
+    ATLTRACE("%s: %d\n", __FUNCTION__, redoSteps);
     if (redoSteps > 0)
     {
         int oldWidth = GetWidth();
@@ -95,7 +95,7 @@ void ImageModel::Redo()
 
 void ImageModel::ResetToPrevious()
 {
-    DPRINT("%s: %d\n", __FUNCTION__, currInd);
+    ATLTRACE("%s: %d\n", __FUNCTION__, currInd);
     DeleteObject(hBms[currInd]);
     hBms[currInd] = CopyDIBImage(hBms[(currInd + HISTORYSIZE - 1) % HISTORYSIZE]);
     SelectObject(hDrawingDC, hBms[currInd]);

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -14,12 +14,14 @@
 
 void ImageModel::NotifyDimensionsChanged()
 {
-    imageArea.SendMessage(WM_IMAGEMODELDIMENSIONSCHANGED);
+    if (imageArea.IsWindow())
+        imageArea.SendMessage(WM_IMAGEMODELDIMENSIONSCHANGED);
 }
 
 void ImageModel::NotifyImageChanged()
 {
-    imageArea.SendMessage(WM_IMAGEMODELIMAGECHANGED);
+    if (imageArea.IsWindow())
+        imageArea.SendMessage(WM_IMAGEMODELIMAGECHANGED);
 }
 
 ImageModel::ImageModel()

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -68,6 +68,8 @@ void CImgAreaWindow::drawZoomFrame(int mouseX, int mouseY)
 
 LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    if (!IsWindow() || !sizeboxLeftTop.IsWindow())
+        return 0;
     int imgXRes = imageModel.GetWidth();
     int imgYRes = imageModel.GetHeight();
     sizeboxLeftTop.MoveWindow(
@@ -143,11 +145,11 @@ LRESULT CImgAreaWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
         DeleteObject(SelectObject(hdc, oldPen));
     }
     EndPaint(&ps);
-    if (selectionWindow.IsWindowVisible())
+    if (selectionWindow.IsWindow())
         selectionWindow.Invalidate(FALSE);
-    if (miniature.IsWindowVisible())
+    if (miniature.IsWindow())
         miniature.Invalidate(FALSE);
-    if (textEditWindow.IsWindowVisible())
+    if (textEditWindow.IsWindow())
         textEditWindow.Invalidate(FALSE);
     return 0;
 }

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -107,7 +107,7 @@ LRESULT CImgAreaWindow::OnEraseBkGnd(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     HDC hdc = (HDC)wParam;
 
     if (toolsModel.GetActiveTool() == TOOL_TEXT && !toolsModel.IsBackgroundTransparent() &&
-        textEditWindow.IsWindowVisible())
+        ::IsWindowVisible(textEditWindow))
     {
         // Do clipping
         HWND hChild = textEditWindow;

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -394,7 +394,7 @@ struct TextTool : ToolBase
     {
         imageModel.ResetToPrevious();
 
-        BOOL bTextBoxShown = textEditWindow.IsWindowVisible();
+        BOOL bTextBoxShown = ::IsWindowVisible(textEditWindow);
         if (bTextBoxShown && textEditWindow.GetWindowTextLength() > 0)
         {
             CString szText;

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -95,7 +95,9 @@ void PaletteModel::SetBgColor(COLORREF newColor)
 
 void PaletteModel::NotifyColorChanged()
 {
-    paletteWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
+    if (paletteWindow.IsWindow())
+        paletteWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
+    if (selectionWindow.IsWindow())
     selectionWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
     if (textEditWindow.IsWindow())
         textEditWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
@@ -103,5 +105,6 @@ void PaletteModel::NotifyColorChanged()
 
 void PaletteModel::NotifyPaletteChanged()
 {
-    paletteWindow.SendMessage(WM_PALETTEMODELPALETTECHANGED);
+    if (paletteWindow.IsWindow())
+        paletteWindow.SendMessage(WM_PALETTEMODELPALETTECHANGED);
 }

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -98,7 +98,7 @@ void PaletteModel::NotifyColorChanged()
     if (paletteWindow.IsWindow())
         paletteWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
     if (selectionWindow.IsWindow())
-    selectionWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
+        selectionWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
     if (textEditWindow.IsWindow())
         textEditWindow.SendMessage(WM_PALETTEMODELCOLORCHANGED);
 }

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -1,6 +1,15 @@
 #ifndef _MSPAINT_H
 #define _MSPAINT_H
 
+#ifdef NDEBUG
+    #undef DBG
+    #undef _DEBUG
+#endif
+
+#if DBG && !defined(_DEBUG)
+    #define _DEBUG
+#endif
+
 #include <stdarg.h>
 
 #include <windef.h>

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -61,7 +61,8 @@ UpdateScrollbox()
     scrollboxWindow.GetWindowRect(&tempRect);
     sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
 
-    imageArea.GetClientRect(&tempRect);
+    if (imageArea.IsWindow())
+        imageArea.GetClientRect(&tempRect);
     sizeImageArea = CSize(tempRect.Width(), tempRect.Height());
     sizeImageArea += CSize(GRIP_SIZE * 2, GRIP_SIZE * 2);
 
@@ -87,14 +88,17 @@ UpdateScrollbox()
     si.nPage  = sizeScrollBox.cy;
     scrollboxWindow.SetScrollInfo(SB_VERT, &si);
 
-    scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
-                                -scrollboxWindow.GetScrollPos(SB_VERT),
-                                sizeImageArea.cx, sizeImageArea.cy, TRUE);
+    if (scrlClientWindow.IsWindow())
+    {
+        scrlClientWindow.MoveWindow(
+            -scrollboxWindow.GetScrollPos(SB_HORZ), -scrollboxWindow.GetScrollPos(SB_VERT),
+            sizeImageArea.cx, sizeImageArea.cy, TRUE);
+    }
 }
 
 LRESULT CScrollboxWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (m_hWnd == scrollboxWindow.m_hWnd)
+    if (m_hWnd && m_hWnd == scrollboxWindow.m_hWnd)
     {
         UpdateScrollbox();
     }

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -57,7 +57,7 @@ ColorKeyedMaskBlt(HDC hdcDest, int nXDest, int nYDest, int nWidth, int nHeight,
 void
 ForceRefreshSelectionContents()
 {
-    if (selectionWindow.IsWindowVisible())
+    if (::IsWindowVisible(selectionWindow))
     {
         selectionWindow.SendMessage(WM_LBUTTONDOWN, 0, MAKELPARAM(0, 0));
         selectionWindow.SendMessage(WM_MOUSEMOVE,   0, MAKELPARAM(0, 0));

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -300,12 +300,12 @@ HWND CTextEditWindow::Create(HWND hwndParent)
 
     const DWORD style = ES_LEFT | ES_MULTILINE | ES_WANTRETURN | ES_AUTOVSCROLL |
                         WS_CHILD | WS_THICKFRAME;
-    m_hWnd = ::CreateWindowEx(0, WC_EDIT, NULL, style, 0, 0, 0, 0,
-                              hwndParent, NULL, hProgInstance, NULL);
-    if (m_hWnd)
+    HWND hwnd = ::CreateWindowEx(0, WC_EDIT, NULL, style, 0, 0, 0, 0,
+                                 hwndParent, NULL, hProgInstance, NULL);
+    if (hwnd)
     {
 #undef SubclassWindow // Don't use this macro
-        SubclassWindow(m_hWnd);
+        SubclassWindow(hwnd);
 
         UpdateFont();
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -159,13 +159,14 @@ void ToolsModel::SetZoom(int nZoom)
 
 void ToolsModel::NotifyToolChanged()
 {
-    toolBoxContainer.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
-    toolSettingsWindow.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
-
+    if (toolBoxContainer.IsWindow())
+        toolBoxContainer.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
+    if (toolSettingsWindow.IsWindow())
+        toolSettingsWindow.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
     if (fontsDialog.IsWindow())
         fontsDialog.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
-
-    textEditWindow.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
+    if (textEditWindow.IsWindow())
+        textEditWindow.SendMessage(WM_TOOLSMODELTOOLCHANGED, m_activeTool);
 }
 
 void ToolsModel::NotifyToolSettingsChanged()

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -51,7 +51,7 @@ void CMainWindow::alignChildrenToMainWindow()
     RECT clientRect;
     GetClientRect(&clientRect);
 
-    if (toolBoxContainer.IsWindow() && toolBoxContainer.IsWindowVisible())
+    if (::IsWindowVisible(toolBoxContainer))
     {
         x = 56;
         w = clientRect.right - 56;
@@ -61,7 +61,7 @@ void CMainWindow::alignChildrenToMainWindow()
         x = 0;
         w = clientRect.right;
     }
-    if (paletteWindow.IsWindow() && paletteWindow.IsWindowVisible())
+    if (::IsWindowVisible(paletteWindow))
     {
         y = 49;
         h = clientRect.bottom - 49;
@@ -273,7 +273,9 @@ LRESULT CMainWindow::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHan
 LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     HMENU menu = GetMenu();
-    BOOL trueSelection = (selectionWindow.IsWindowVisible() && ((toolsModel.GetActiveTool() == TOOL_FREESEL) || (toolsModel.GetActiveTool() == TOOL_RECTSEL)));
+    BOOL trueSelection =
+        (::IsWindowVisible(selectionWindow) &&
+         ((toolsModel.GetActiveTool() == TOOL_FREESEL) || (toolsModel.GetActiveTool() == TOOL_RECTSEL)));
     switch (lParam)
     {
         case 0: /* File menu */
@@ -325,17 +327,17 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
             CloseClipboard();
             break;
         case 2: /* View menu */
-                CheckMenuItem(menu, IDM_VIEWTOOLBOX,      CHECKED_IF(toolBoxContainer.IsWindowVisible()));
-                CheckMenuItem(menu, IDM_VIEWCOLORPALETTE, CHECKED_IF(paletteWindow.IsWindowVisible()));
-                CheckMenuItem(menu, IDM_VIEWSTATUSBAR,    CHECKED_IF(::IsWindowVisible(hStatusBar)));
-                CheckMenuItem(menu, IDM_FORMATICONBAR,    CHECKED_IF(fontsDialog.IsWindowVisible()));
-                EnableMenuItem(menu, IDM_FORMATICONBAR, ENABLED_IF(toolsModel.GetActiveTool() == TOOL_TEXT));
+            CheckMenuItem(menu, IDM_VIEWTOOLBOX, CHECKED_IF(::IsWindowVisible(toolBoxContainer)));
+            CheckMenuItem(menu, IDM_VIEWCOLORPALETTE, CHECKED_IF(::IsWindowVisible(paletteWindow)));
+            CheckMenuItem(menu, IDM_VIEWSTATUSBAR,    CHECKED_IF(::IsWindowVisible(hStatusBar)));
+            CheckMenuItem(menu, IDM_FORMATICONBAR, CHECKED_IF(::IsWindowVisible(fontsDialog)));
+            EnableMenuItem(menu, IDM_FORMATICONBAR, ENABLED_IF(toolsModel.GetActiveTool() == TOOL_TEXT));
 
-                CheckMenuItem(menu, IDM_VIEWSHOWGRID,      CHECKED_IF(showGrid));
-                CheckMenuItem(menu, IDM_VIEWSHOWMINIATURE, CHECKED_IF(showMiniature));
+            CheckMenuItem(menu, IDM_VIEWSHOWGRID,      CHECKED_IF(showGrid));
+            CheckMenuItem(menu, IDM_VIEWSHOWMINIATURE, CHECKED_IF(showMiniature));
             break;
         case 3: /* Image menu */
-            EnableMenuItem(menu, IDM_IMAGECROP, ENABLED_IF(selectionWindow.IsWindowVisible()));
+            EnableMenuItem(menu, IDM_IMAGECROP, ENABLED_IF(::IsWindowVisible(selectionWindow)));
             CheckMenuItem(menu, IDM_IMAGEDRAWOPAQUE, CHECKED_IF(!toolsModel.IsBackgroundTransparent()));
             break;
     }
@@ -527,13 +529,13 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         }
         case IDM_EDITUNDO:
-            if (toolsModel.GetActiveTool() == TOOL_TEXT && textEditWindow.IsWindowVisible())
+            if (toolsModel.GetActiveTool() == TOOL_TEXT && ::IsWindowVisible(textEditWindow))
                 break;
             imageModel.Undo();
             imageArea.Invalidate(FALSE);
             break;
         case IDM_EDITREDO:
-            if (toolsModel.GetActiveTool() == TOOL_TEXT && textEditWindow.IsWindowVisible())
+            if (toolsModel.GetActiveTool() == TOOL_TEXT && ::IsWindowVisible(textEditWindow))
                 break;
             imageModel.Redo();
             imageArea.Invalidate(FALSE);
@@ -566,7 +568,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITSELECTALL:
         {
-            if (toolsModel.GetActiveTool() == TOOL_TEXT && textEditWindow.IsWindowVisible())
+            if (toolsModel.GetActiveTool() == TOOL_TEXT && ::IsWindowVisible(textEditWindow))
             {
                 textEditWindow.SendMessage(EM_SETSEL, 0, -1);
                 break;
@@ -616,13 +618,13 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             switch (mirrorRotateDialog.DoModal(mainWindow.m_hWnd))
             {
                 case 1: /* flip horizontally */
-                    if (selectionWindow.IsWindowVisible())
+                    if (::IsWindowVisible(selectionWindow))
                         selectionModel.FlipHorizontally();
                     else
                         imageModel.FlipHorizontally();
                     break;
                 case 2: /* flip vertically */
-                    if (selectionWindow.IsWindowVisible())
+                    if (::IsWindowVisible(selectionWindow))
                         selectionModel.FlipVertically();
                     else
                         imageModel.FlipVertically();
@@ -630,7 +632,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 case 3: /* rotate 90 degrees */
                     break;
                 case 4: /* rotate 180 degrees */
-                    if (selectionWindow.IsWindowVisible())
+                    if (::IsWindowVisible(selectionWindow))
                         selectionModel.RotateNTimes90Degrees(2);
                     else
                         imageModel.RotateNTimes90Degrees(2);
@@ -664,11 +666,11 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
 
         case IDM_VIEWTOOLBOX:
-            toolBoxContainer.ShowWindow(toolBoxContainer.IsWindowVisible() ? SW_HIDE : SW_SHOW);
+            toolBoxContainer.ShowWindow(::IsWindowVisible(toolBoxContainer) ? SW_HIDE : SW_SHOW);
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWCOLORPALETTE:
-            paletteWindow.ShowWindow(paletteWindow.IsWindowVisible() ? SW_HIDE : SW_SHOW);
+            paletteWindow.ShowWindow(::IsWindowVisible(paletteWindow) ? SW_HIDE : SW_SHOW);
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWSTATUSBAR:
@@ -682,7 +684,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                 {
                     fontsDialog.Create(mainWindow);
                 }
-                registrySettings.ShowTextTool = !fontsDialog.IsWindowVisible();
+                registrySettings.ShowTextTool = !::IsWindowVisible(fontsDialog);
                 fontsDialog.ShowWindow(registrySettings.ShowTextTool ? SW_SHOW : SW_HIDE);
                 fontsDialog.SendMessage(DM_REPOSITION, 0, 0);
             }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -51,7 +51,7 @@ void CMainWindow::alignChildrenToMainWindow()
     RECT clientRect;
     GetClientRect(&clientRect);
 
-    if (toolBoxContainer.IsWindowVisible())
+    if (toolBoxContainer.IsWindow() && toolBoxContainer.IsWindowVisible())
     {
         x = 56;
         w = clientRect.right - 56;
@@ -61,7 +61,7 @@ void CMainWindow::alignChildrenToMainWindow()
         x = 0;
         w = clientRect.right;
     }
-    if (paletteWindow.IsWindowVisible())
+    if (paletteWindow.IsWindow() && paletteWindow.IsWindowVisible())
     {
         y = 49;
         h = clientRect.bottom - 49;
@@ -73,13 +73,18 @@ void CMainWindow::alignChildrenToMainWindow()
     }
 
     RECT statusBarRect0;
-    SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&statusBarRect0);
     int statusBarBorders[3];
-    SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&statusBarBorders);
+    if (::IsWindow(hStatusBar))
+    {
+        ::SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&statusBarRect0);
+        ::SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&statusBarBorders);
+    }
     int statusBarHeight = statusBarRect0.bottom - statusBarRect0.top + statusBarBorders[1];
 
-    scrollboxWindow.MoveWindow(x, y, w, ::IsWindowVisible(hStatusBar) ? h - statusBarHeight : h, TRUE);
-    paletteWindow.MoveWindow(x, 9, 255, 32, TRUE);
+    if (scrollboxWindow.IsWindow())
+        scrollboxWindow.MoveWindow(x, y, w, ::IsWindowVisible(hStatusBar) ? h - statusBarHeight : h, TRUE);
+    if (paletteWindow.IsWindow())
+        paletteWindow.MoveWindow(x, 9, 255, 32, TRUE);
 }
 
 void CMainWindow::saveImage(BOOL overwrite)
@@ -351,8 +356,11 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
 LRESULT CMainWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     int test[] = { LOWORD(lParam) - 260, LOWORD(lParam) - 140, LOWORD(lParam) - 20 };
-    SendMessage(hStatusBar, WM_SIZE, wParam, lParam);
-    SendMessage(hStatusBar, SB_SETPARTS, 3, (LPARAM)&test);
+    if (::IsWindow(hStatusBar))
+    {
+        ::SendMessage(hStatusBar, WM_SIZE, wParam, lParam);
+        ::SendMessage(hStatusBar, SB_SETPARTS, 3, (LPARAM)&test);
+    }
     alignChildrenToMainWindow();
     Invalidate(TRUE);
     return 0;

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1862,7 +1862,7 @@ inline HRESULT WINAPI AtlComModuleRevokeClassObjects(_ATL_COM_MODULE *module)
 #if DBG
 
 inline VOID __stdcall
-AtlVTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
+AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
 {
     char szBuff[512];
     size_t cch;
@@ -1884,7 +1884,7 @@ AtlVTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, v
 }
 
 inline VOID __cdecl
-AtlTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
+AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
 {
     va_list va;
     va_start(va, format);
@@ -1892,7 +1892,7 @@ AtlTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ..
     va_end(va);
 }
 
-inline VOID __cdecl AtlTraceEx(LPCSTR file, INT line, HRESULT hr)
+inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, HRESULT hr)
 {
     AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
 }

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -26,11 +26,9 @@
 #include "atlcomcli.h"
 #include "atlalloc.h"
 #include "atlexcept.h"
+#include "atltrace.h"
 #include "comcat.h"
 #include "tchar.h"
-#if DBG
-    #include <stdio.h>
-#endif
 
 #ifdef _MSC_VER
 // It is common to use this in ATL constructors. They only store this for later use, so the usage is safe.
@@ -1858,62 +1856,6 @@ inline HRESULT WINAPI AtlComModuleRevokeClassObjects(_ATL_COM_MODULE *module)
 
     return S_OK;
 }
-
-#if DBG
-
-inline VOID __stdcall
-AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
-{
-    char szBuff[512];
-    size_t cch;
-
-    if (!IsDebuggerPresent())
-        return;
-
-#ifdef _STRSAFE_H_INCLUDED_
-    StringCchPrintfA(szBuff, _countof(szBuff), "%s (%d): ", file, line);
-    StringCchLengthA(szBuff, _countof(szBuff), &cch);
-    StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
-#else
-    cch = _snprintf(szBuff, _countof(szBuff), "%s (%d): ", file, line);
-    _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
-#endif
-
-    OutputDebugStringA(szBuff);
-    va_end(va);
-}
-
-inline VOID __cdecl
-AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
-{
-    va_list va;
-    va_start(va, format);
-    AtlVTraceEx(file, line, format, va);
-    va_end(va);
-}
-
-inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, HRESULT hr)
-{
-    AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
-}
-
-inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
-{
-    va_list va;
-    va_start(va, format);
-    AtlVTraceEx("(null)", -1, format, va);
-    va_end(va);
-}
-
-#endif // DBG
-
-#ifndef ATLTRACE
-    #if DBG
-        #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
-    #else
-        #define ATLTRACE(format, ...)
-    #endif
-#endif
 
 }; // namespace ATL
 

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -28,6 +28,9 @@
 #include "atlexcept.h"
 #include "comcat.h"
 #include "tchar.h"
+#if DBG
+    #include <stdio.h>
+#endif
 
 #ifdef _MSC_VER
 // It is common to use this in ATL constructors. They only store this for later use, so the usage is safe.
@@ -1856,6 +1859,67 @@ inline HRESULT WINAPI AtlComModuleRevokeClassObjects(_ATL_COM_MODULE *module)
     return S_OK;
 }
 
+#if DBG
+
+#ifndef ATLDEBUG_BUFSIZE
+    #define ATLDEBUG_BUFSIZE 512
+#endif
+
+inline VOID __stdcall
+AtlVTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
+{
+    char szBuff[ATLDEBUG_BUFSIZE];
+    size_t cch = 0;
+
+    if (!IsDebuggerPresent())
+        return;
+
+#ifdef _STRSAFE_H_INCLUDED_
+    StringCchPrintfA(szBuff, _countof(szBuff), "%s (%d): ", file, line);
+    StringCchLengthA(szBuff, _countof(szBuff), &cch);
+    StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
+#else
+    cch = _snprintf(szBuff, _countof(szBuff), "%s (%d): ", file, line);
+    _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
+#endif
+
+    OutputDebugStringA(szBuff);
+    va_end(va);
+}
+
+inline VOID __cdecl
+AtlTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    AtlVTraceEx(file, line, format, va);
+    va_end(va);
+}
+
+inline VOID __cdecl
+AtlTraceEx(LPCSTR file, INT line, HRESULT hr)
+{
+    AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
+}
+
+inline VOID __cdecl
+AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    AtlVTraceEx("(null)", -1, format, va);
+    va_end(va);
+}
+
+#endif // DBG
+
+#ifndef ATLTRACE
+    #if DBG
+        #define ATLTRACE(format, ...) AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+    #else
+        #define ATLTRACE(format, ...)
+    #endif
+#endif
 
 }; // namespace ATL
 

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1909,7 +1909,7 @@ inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
 
 #ifndef ATLTRACE
     #if DBG
-        #define ATLTRACE(format, ...) AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+        #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
     #else
         #define ATLTRACE(format, ...)
     #endif

--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -1861,15 +1861,11 @@ inline HRESULT WINAPI AtlComModuleRevokeClassObjects(_ATL_COM_MODULE *module)
 
 #if DBG
 
-#ifndef ATLDEBUG_BUFSIZE
-    #define ATLDEBUG_BUFSIZE 512
-#endif
-
 inline VOID __stdcall
 AtlVTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
 {
-    char szBuff[ATLDEBUG_BUFSIZE];
-    size_t cch = 0;
+    char szBuff[512];
+    size_t cch;
 
     if (!IsDebuggerPresent())
         return;
@@ -1896,14 +1892,12 @@ AtlTraceEx(LPCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ..
     va_end(va);
 }
 
-inline VOID __cdecl
-AtlTraceEx(LPCSTR file, INT line, HRESULT hr)
+inline VOID __cdecl AtlTraceEx(LPCSTR file, INT line, HRESULT hr)
 {
     AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
 }
 
-inline VOID __cdecl
-AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
+inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
 {
     va_list va;
     va_start(va, format);

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -101,7 +101,6 @@ AtlTraceV(_In_z_                         PCSTR   file,
 #endif
 
     OutputDebugStringA(szBuff);
-    va_end(va);
 }
 
 inline VOID __stdcall
@@ -128,7 +127,6 @@ AtlTraceV(_In_z_                         PCSTR   file,
 #endif
 
     OutputDebugStringW(szBuff);
-    va_end(va);
 }
 
 template <typename T_CHAR>

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -30,39 +30,39 @@ class CTraceCategoryEx
 public:
     enum
     {
-        TraceGeneral = (1 << 0),
-        TraceCom = (1 << 1),
-        TraceQI = (1 << 2),
-        TraceRegistrar = (1 << 3),
-        TraceRefcount = (1 << 4),
-        TraceWindowing = (1 << 5),
-        TraceControls = (1 << 6),
-        TraceHosting = (1 << 7),
-        TraceDBClient = (1 << 8),
+        TraceGeneral    = (1 << 0),
+        TraceCom        = (1 << 1),
+        TraceQI         = (1 << 2),
+        TraceRegistrar  = (1 << 3),
+        TraceRefcount   = (1 << 4),
+        TraceWindowing  = (1 << 5),
+        TraceControls   = (1 << 6),
+        TraceHosting    = (1 << 7),
+        TraceDBClient   = (1 << 8),
         TraceDBProvider = (1 << 9),
-        TraceSnapin = (1 << 10),
-        TraceNotImpl = (1 << 11),
+        TraceSnapin     = (1 << 10),
+        TraceNotImpl    = (1 << 11),
         TraceAllocation = (1 << 12),
-        TraceException = (1 << 13),
-        TraceTime = (1 << 14),
-        TraceCache = (1 << 15),
-        TraceStencil = (1 << 16),
-        TraceString = (1 << 17),
-        TraceMap = (1 << 18),
-        TraceUtil = (1 << 19),
-        TraceSecurity = (1 << 20),
-        TraceSync = (1 << 21),
-        TraceISAPI = (1 << 22),
-        TraceUser = TraceUtil
+        TraceException  = (1 << 13),
+        TraceTime       = (1 << 14),
+        TraceCache      = (1 << 15),
+        TraceStencil    = (1 << 16),
+        TraceString     = (1 << 17),
+        TraceMap        = (1 << 18),
+        TraceUtil       = (1 << 19),
+        TraceSecurity   = (1 << 20),
+        TraceSync       = (1 << 21),
+        TraceISAPI      = (1 << 22),
+        TraceUser       = TraceUtil
     };
 
     CTraceCategoryEx(LPCTSTR name = NULL) : m_name(name)
     {
     }
 
-    static UINT GetLevel()      { return t_level; }
-    static UINT GetCategory()   { return t_category; }
-    operator UINT() const       { return GetCategory(); }
+    static UINT GetLevel()          { return t_level; }
+    static UINT GetCategory()       { return t_category; }
+    operator UINT() const           { return GetCategory(); }
     LPCTSTR GetCategoryName() const { return m_name; }
 
 protected:

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -48,9 +48,9 @@ AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...
     va_end(va);
 }
 
-inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, HRESULT hr)
+inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, DWORD value)
 {
-    AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
+    AtlTraceEx(file, line, "%ld (0x%lX)\n", value, value);
 }
 
 inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -64,9 +64,7 @@ struct CTrace
 
     static bool IsTracingEnabled(UINT category, UINT level)
     {
-        if (s_level == DisableTracing || s_level < level || !(s_categories & category))
-            return false;
-        return ::IsDebuggerPresent();
+        return (s_level != DisableTracing && s_level >= level && (s_categories & category));
     }
 
 protected:

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -32,7 +32,7 @@ struct CTraceCategory
     operator UINT() const { return (1 << 15); }
 };
 
-#define DEFINE_TRACE_CATEGORY(name, cat) DECLSPEC_SELECTANY UINT name = cat
+#define DEFINE_TRACE_CATEGORY(name, cat) DECLSPEC_SELECTANY const UINT name = cat
 DEFINE_TRACE_CATEGORY(atlTraceGeneral,    (1 << 0));
 DEFINE_TRACE_CATEGORY(atlTraceCOM,        (1 << 1));
 DEFINE_TRACE_CATEGORY(atlTraceQI,         (1 << 2));

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -25,6 +25,13 @@
 namespace ATL
 {
 
+struct CTraceCategory
+{
+    explicit CTraceCategory(LPCSTR name, UINT level = 0) { }
+
+    operator UINT() const { return (1 << 15); }
+};
+
 #define DEFINE_TRACE_CATEGORY(name, cat) DECLSPEC_SELECTANY UINT name = cat
 DEFINE_TRACE_CATEGORY(atlTraceGeneral,    (1 << 0));
 DEFINE_TRACE_CATEGORY(atlTraceCOM,        (1 << 1));

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -18,7 +18,10 @@ namespace ATL
 {
 
 inline VOID __stdcall
-AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
+AtlVTraceEx(_In_z_                 PCSTR   file,
+            _In_                   INT     line,
+            _Printf_format_string_ PCSTR   format,
+            _In_                   va_list va)
 {
     char szBuff[512];
     size_t cch;
@@ -40,7 +43,10 @@ AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va
 }
 
 inline VOID __cdecl
-AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
+AtlTraceEx(_In_z_                 PCSTR file,
+           _In_                   INT line,
+           _Printf_format_string_ PCSTR format,
+           ...)
 {
     va_list va;
     va_start(va, format);
@@ -48,12 +54,7 @@ AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...
     va_end(va);
 }
 
-inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, DWORD value)
-{
-    AtlTraceEx(file, line, "%ld (0x%lX)\n", value, value);
-}
-
-inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
+inline VOID __cdecl AtlTrace(_Printf_format_string_ PCSTR format, ...)
 {
     va_list va;
     va_start(va, format);
@@ -61,17 +62,27 @@ inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
     va_end(va);
 }
 
+inline VOID __stdcall
+AtlTraceEx(_In_z_ PCSTR file,
+           _In_   INT   line,
+           _In_   DWORD value)
+{
+    AtlTraceEx(file, line, "%ld (0x%lX)\n", value, value);
+}
+
 } // namespace ATL
 
 #endif // DBG
 
-#ifndef ATLTRACE
-    #if DBG
-        #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
-    #else
-        #define ATLTRACE(format, ...)
-    #endif
+#if DBG
+    #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+#else
+    #define ATLTRACE(format, ...) ((void)0)
 #endif
+
+#define ATLTRACE2 ATLTRACE
+
+#define ATLTRACENOTIMPL(funcname) ATLTRACE(#funcname " is not implemented.\n")
 
 #ifndef _ATL_NO_AUTOMATIC_NAMESPACE
 using namespace ATL;

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -1,0 +1,77 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
+ * PURPOSE:     Providing ATLTRACE macro
+ * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+#pragma once
+
+#include "atldef.h"
+#if DBG
+    #include <stdio.h>
+#endif
+
+namespace ATL
+{
+
+#if DBG
+
+inline VOID __stdcall
+AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
+{
+    char szBuff[512];
+    size_t cch;
+
+    if (!IsDebuggerPresent())
+        return;
+
+#ifdef _STRSAFE_H_INCLUDED_
+    StringCchPrintfA(szBuff, _countof(szBuff), "%s (%d): ", file, line);
+    StringCchLengthA(szBuff, _countof(szBuff), &cch);
+    StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
+#else
+    cch = _snprintf(szBuff, _countof(szBuff), "%s (%d): ", file, line);
+    _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
+#endif
+
+    OutputDebugStringA(szBuff);
+    va_end(va);
+}
+
+inline VOID __cdecl
+AtlTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    AtlVTraceEx(file, line, format, va);
+    va_end(va);
+}
+
+inline VOID __stdcall AtlTraceEx(PCSTR file, INT line, HRESULT hr)
+{
+    AtlTraceEx(file, line, "%ld (0x%lX)\n", hr, hr);
+}
+
+inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
+{
+    va_list va;
+    va_start(va, format);
+    AtlVTraceEx("(null)", -1, format, va);
+    va_end(va);
+}
+
+#endif // DBG
+
+} // namespace ATL
+
+#ifndef ATLTRACE
+    #if DBG
+        #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+    #else
+        #define ATLTRACE(format, ...)
+    #endif
+#endif
+
+#ifndef _ATL_NO_AUTOMATIC_NAMESPACE
+using namespace ATL;
+#endif //!_ATL_NO_AUTOMATIC_NAMESPACE

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -32,7 +32,7 @@ struct CTraceCategory
     operator UINT() const { return (1 << 15); }
 };
 
-#define DEFINE_TRACE_CATEGORY(name, cat) DECLSPEC_SELECTANY const UINT name = cat
+#define DEFINE_TRACE_CATEGORY(name, cat) extern const DECLSPEC_SELECTANY UINT name = cat
 DEFINE_TRACE_CATEGORY(atlTraceGeneral,    (1 << 0));
 DEFINE_TRACE_CATEGORY(atlTraceCOM,        (1 << 1));
 DEFINE_TRACE_CATEGORY(atlTraceQI,         (1 << 2));

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -1,5 +1,5 @@
 /*
- * PROJECT:     ReactOS Kernel
+ * PROJECT:     ReactOS ATL
  * LICENSE:     LGPL-2.0-or-later (https://spdx.org/licenses/LGPL-2.0-or-later)
  * PURPOSE:     Providing ATLTRACE macro
  * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -25,28 +25,100 @@
 namespace ATL
 {
 
-struct CTraceCategory
+template <UINT t_category = (1 << 19), UINT t_level = 0>
+class CTraceCategoryEx
 {
-    explicit CTraceCategory(LPCSTR name, UINT level = 0) { }
+public:
+    enum
+    {
+        TraceGeneral = (1 << 0),
+        TraceCom = (1 << 1),
+        TraceQI = (1 << 2),
+        TraceRegistrar = (1 << 3),
+        TraceRefcount = (1 << 4),
+        TraceWindowing = (1 << 5),
+        TraceControls = (1 << 6),
+        TraceHosting = (1 << 7),
+        TraceDBClient = (1 << 8),
+        TraceDBProvider = (1 << 9),
+        TraceSnapin = (1 << 10),
+        TraceNotImpl = (1 << 11),
+        TraceAllocation = (1 << 12),
+        TraceException = (1 << 13),
+        TraceTime = (1 << 14),
+        TraceCache = (1 << 15),
+        TraceStencil = (1 << 16),
+        TraceString = (1 << 17),
+        TraceMap = (1 << 18),
+        TraceUtil = (1 << 19),
+        TraceSecurity = (1 << 20),
+        TraceSync = (1 << 21),
+        TraceISAPI = (1 << 22),
+        TraceUser = TraceUtil
+    };
 
-    operator UINT() const { return (1 << 15); }
+    CTraceCategoryEx(LPCTSTR name = NULL) : m_name(name)
+    {
+    }
+
+    static UINT GetLevel()      { return t_level; }
+    static UINT GetCategory()   { return t_category; }
+    operator UINT() const       { return GetCategory(); }
+    LPCTSTR GetCategoryName() const { return m_name; }
+
+protected:
+    LPCTSTR m_name;
 };
 
-#define DEFINE_TRACE_CATEGORY(name, cat) extern const DECLSPEC_SELECTANY UINT name = cat
-DEFINE_TRACE_CATEGORY(atlTraceGeneral,    (1 << 0));
-DEFINE_TRACE_CATEGORY(atlTraceCOM,        (1 << 1));
-DEFINE_TRACE_CATEGORY(atlTraceQI,         (1 << 2));
-DEFINE_TRACE_CATEGORY(atlTraceRegistrar,  (1 << 3));
-DEFINE_TRACE_CATEGORY(atlTraceRefcount,   (1 << 4));
-DEFINE_TRACE_CATEGORY(atlTraceWindowing,  (1 << 5));
-DEFINE_TRACE_CATEGORY(atlTraceControls,   (1 << 6));
-DEFINE_TRACE_CATEGORY(atlTraceHosting,    (1 << 7));
-DEFINE_TRACE_CATEGORY(atlTraceDBClient,   (1 << 8));
-DEFINE_TRACE_CATEGORY(atlTraceDBProvider, (1 << 9));
-DEFINE_TRACE_CATEGORY(atlTraceSnapin,     (1 << 10));
-DEFINE_TRACE_CATEGORY(atlTraceNotImpl,    (1 << 11));
-DEFINE_TRACE_CATEGORY(atlTraceAllocation, (1 << 12));
+class CTraceCategory : public CTraceCategoryEx<>
+{
+    CTraceCategory(LPCTSTR name = NULL) : CTraceCategoryEx<>(name)
+    {
+    }
+};
+
+#define DEFINE_TRACE_CATEGORY(name, cat) extern const DECLSPEC_SELECTANY CTraceCategoryEx<cat, 0> name(TEXT(#name))
+DEFINE_TRACE_CATEGORY(atlTraceGeneral,    CTraceCategoryEx<>::TraceGeneral);
+DEFINE_TRACE_CATEGORY(atlTraceCOM,        CTraceCategoryEx<>::TraceCom);
+DEFINE_TRACE_CATEGORY(atlTraceQI,         CTraceCategoryEx<>::TraceQI);
+DEFINE_TRACE_CATEGORY(atlTraceRegistrar,  CTraceCategoryEx<>::TraceRegistrar);
+DEFINE_TRACE_CATEGORY(atlTraceRefcount,   CTraceCategoryEx<>::TraceRefcount);
+DEFINE_TRACE_CATEGORY(atlTraceWindowing,  CTraceCategoryEx<>::TraceWindowing);
+DEFINE_TRACE_CATEGORY(atlTraceControls,   CTraceCategoryEx<>::TraceControls);
+DEFINE_TRACE_CATEGORY(atlTraceHosting,    CTraceCategoryEx<>::TraceHosting);
+DEFINE_TRACE_CATEGORY(atlTraceDBClient,   CTraceCategoryEx<>::TraceDBClient);
+DEFINE_TRACE_CATEGORY(atlTraceDBProvider, CTraceCategoryEx<>::TraceDBProvider);
+DEFINE_TRACE_CATEGORY(atlTraceSnapin,     CTraceCategoryEx<>::TraceSnapin);
+DEFINE_TRACE_CATEGORY(atlTraceNotImpl,    CTraceCategoryEx<>::TraceNotImpl);
+DEFINE_TRACE_CATEGORY(atlTraceAllocation, CTraceCategoryEx<>::TraceAllocation);
+DEFINE_TRACE_CATEGORY(atlTraceException,  CTraceCategoryEx<>::TraceException);
+DEFINE_TRACE_CATEGORY(atlTraceTime,       CTraceCategoryEx<>::TraceTime);
+DEFINE_TRACE_CATEGORY(atlTraceCache,      CTraceCategoryEx<>::TraceCache);
+DEFINE_TRACE_CATEGORY(atlTraceStencil,    CTraceCategoryEx<>::TraceStencil);
+DEFINE_TRACE_CATEGORY(atlTraceString,     CTraceCategoryEx<>::TraceString);
+DEFINE_TRACE_CATEGORY(atlTraceMap,        CTraceCategoryEx<>::TraceMap);
+DEFINE_TRACE_CATEGORY(atlTraceUtil,       CTraceCategoryEx<>::TraceUtil);
+DEFINE_TRACE_CATEGORY(atlTraceSecurity,   CTraceCategoryEx<>::TraceSecurity);
+DEFINE_TRACE_CATEGORY(atlTraceSync,       CTraceCategoryEx<>::TraceSync);
+DEFINE_TRACE_CATEGORY(atlTraceISAPI,      CTraceCategoryEx<>::TraceISAPI);
 #undef DEFINE_TRACE_CATEGORY
+
+struct CTraceCategoryEasy
+{
+    UINT m_category;
+    UINT m_level;
+    LPCTSTR m_name;
+
+    template <UINT t_category, UINT t_level>
+    CTraceCategoryEasy(const CTraceCategoryEx<t_category, t_level>& cat)
+    {
+        m_category = t_category;
+        m_level = t_level;
+        m_name = cat.GetCategoryName();
+    }
+
+    operator UINT() const { return m_category; }
+};
 
 struct CTrace
 {
@@ -57,8 +129,8 @@ struct CTrace
         EnableAllCategories = 0xFFFFFFFF
     };
 
-    static UINT GetLevel()      { return s_level; }
-    static UINT GetCategories() { return s_categories; }
+    static UINT GetLevel()                     { return s_level; }
+    static UINT GetCategories()                { return s_categories; }
     static void SetLevel(UINT level)           { s_level = level; }
     static void SetCategories(UINT categories) { s_categories = categories; }
 
@@ -76,12 +148,12 @@ DECLSPEC_SELECTANY UINT CTrace::s_categories = CTrace::EnableAllCategories;
 DECLSPEC_SELECTANY UINT CTrace::s_level      = CTrace::DefaultTraceLevel;
 
 inline VOID __stdcall
-AtlTraceV(_In_opt_z_                     PCSTR   file,
-          _In_                           INT     line,
-          _In_                           UINT    cat,
-          _In_                           UINT    level,
-          _In_z_ _Printf_format_string_  PCSTR   format,
-          _In_                           va_list va)
+AtlTraceV(_In_opt_z_                     PCSTR                     file,
+          _In_                           INT                       line,
+          _In_                           const CTraceCategoryEasy& cat,
+          _In_                           UINT                      level,
+          _In_z_ _Printf_format_string_  PCSTR                     format,
+          _In_                           va_list                   va)
 {
     char szBuff[1024];
     size_t cch;
@@ -90,11 +162,19 @@ AtlTraceV(_In_opt_z_                     PCSTR   file,
         return;
 
 #ifdef _STRSAFE_H_INCLUDED_
-    StringCchPrintfA(szBuff, _countof(szBuff), "%s(%d) : ", file, line);
+    #ifdef UNICODE
+        StringCchPrintfA(szBuff, _countof(szBuff), "%s(%d) : %ls - ", file, line, cat.m_name);
+    #else
+        StringCchPrintfA(szBuff, _countof(szBuff), "%s(%d) : %hs - ", file, line, cat.m_name);
+    #endif
     StringCchLengthA(szBuff, _countof(szBuff), &cch);
     StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
-    cch = _snprintf(szBuff, _countof(szBuff), "%s(%d) : ", file, line);
+    #ifdef UNICODE
+        cch = _snprintf(szBuff, _countof(szBuff), "%s(%d) : %ls - ", file, line, cat.m_name);
+    #else
+        cch = _snprintf(szBuff, _countof(szBuff), "%s(%d) : %hs - ", file, line, cat.m_name);
+    #endif
     _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif
 
@@ -102,12 +182,12 @@ AtlTraceV(_In_opt_z_                     PCSTR   file,
 }
 
 inline VOID __stdcall
-AtlTraceV(_In_opt_z_                     PCSTR   file,
-          _In_                           INT     line,
-          _In_                           UINT    cat,
-          _In_                           UINT    level,
-          _In_z_ _Printf_format_string_  PCWSTR  format,
-          _In_                           va_list va)
+AtlTraceV(_In_opt_z_                     PCSTR                     file,
+          _In_                           INT                       line,
+          _In_                           const CTraceCategoryEasy& cat,
+          _In_                           UINT                      level,
+          _In_z_ _Printf_format_string_  PCWSTR                    format,
+          _In_                           va_list                   va)
 {
     WCHAR szBuff[1024];
     size_t cch;
@@ -116,11 +196,19 @@ AtlTraceV(_In_opt_z_                     PCSTR   file,
         return;
 
 #ifdef _STRSAFE_H_INCLUDED_
-    StringCchPrintfW(szBuff, _countof(szBuff), L"%hs(%d) : ", file, line);
+    #ifdef UNICODE
+        StringCchPrintfW(szBuff, _countof(szBuff), L"%hs(%d) : %ls - ", file, line, cat.m_name);
+    #else
+        StringCchPrintfW(szBuff, _countof(szBuff), L"%hs(%d) : %hs - ", file, line, cat.m_name);
+    #endif
     StringCchLengthW(szBuff, _countof(szBuff), &cch);
     StringCchVPrintfW(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
-    cch = _snwprintf(szBuff, _countof(szBuff), L"%hs(%d) : ", file, line);
+    #ifdef UNICODE
+        cch = _snwprintf(szBuff, _countof(szBuff), L"%hs(%d) : %ls - ", file, line, cat.m_name);
+    #else
+        cch = _snwprintf(szBuff, _countof(szBuff), L"%hs(%d) : %hs - ", file, line, cat.m_name);
+    #endif
     _vsnwprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif
 
@@ -129,11 +217,11 @@ AtlTraceV(_In_opt_z_                     PCSTR   file,
 
 template <typename T_CHAR>
 inline VOID __cdecl
-AtlTraceEx(_In_opt_z_                    PCSTR         file,
-           _In_                          INT           line,
-           _In_                          UINT          cat,
-           _In_                          UINT          level,
-           _In_z_ _Printf_format_string_ const T_CHAR *format,
+AtlTraceEx(_In_opt_z_                    PCSTR                     file,
+           _In_                          INT                       line,
+           _In_                          const CTraceCategoryEasy& cat,
+           _In_                          UINT                      level,
+           _In_z_ _Printf_format_string_ const T_CHAR *            format,
            ...)
 {
     va_list va;

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -161,7 +161,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
           _In_                           va_list                   va)
 {
     char szBuff[1024], szFile[MAX_PATH];
-    size_t cch;
+    size_t cch = 0;
     const BOOL bUnicode = (sizeof(TCHAR) == 2);
 
     if (!CTrace::IsTracingEnabled(cat, level))
@@ -169,11 +169,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
 
 #ifdef _STRSAFE_H_INCLUDED_
     StringCchPrintfA(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? "%ls" : "%hs"), file);
-    if (cat.IsGeneral())
-    {
-        cch = 0;
-    }
-    else
+    if (!cat.IsGeneral())
     {
         StringCchPrintfA(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
         StringCchLengthA(szBuff, _countof(szBuff), &cch);
@@ -181,9 +177,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
     StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
     _snprintf(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? "%ls" : "%hs"), file);
-    if (cat.IsGeneral())
-        cch = 0;
-    else
+    if (!cat.IsGeneral())
         cch = _snprintf(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
     _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif
@@ -201,7 +195,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
           _In_                           va_list                   va)
 {
     WCHAR szBuff[1024], szFile[MAX_PATH];
-    size_t cch;
+    size_t cch = 0;
     const BOOL bUnicode = (sizeof(TCHAR) == 2);
 
     if (!CTrace::IsTracingEnabled(cat, level))
@@ -209,11 +203,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
 
 #ifdef _STRSAFE_H_INCLUDED_
     StringCchPrintfW(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? L"%ls" : L"%hs"), file);
-    if (cat.IsGeneral())
-    {
-        cch = 0;
-    }
-    else
+    if (!cat.IsGeneral())
     {
         StringCchPrintfW(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
         StringCchLengthW(szBuff, _countof(szBuff), &cch);
@@ -221,9 +211,7 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
     StringCchVPrintfW(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
     _snwprintf(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? L"%ls" : L"%hs"), file);
-    if (cat.IsGeneral())
-        cch = 0;
-    else
+    if (!cat.IsGeneral())
         cch = _snwprintf(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
     _vsnwprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -4,6 +4,7 @@
  * PURPOSE:     Providing ATLTRACE macro
  * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
+ 
 #pragma once
 
 #include "atldef.h"
@@ -11,10 +12,10 @@
     #include <stdio.h>
 #endif
 
+#if DBG
+
 namespace ATL
 {
-
-#if DBG
 
 inline VOID __stdcall
 AtlVTraceEx(PCSTR file, INT line, _In_z_ _Printf_format_string_ PCSTR format, va_list va)
@@ -60,9 +61,9 @@ inline VOID __cdecl AtlTrace(_In_z_ _Printf_format_string_ PCSTR format, ...)
     va_end(va);
 }
 
-#endif // DBG
-
 } // namespace ATL
+
+#endif // DBG
 
 #ifndef ATLTRACE
     #if DBG

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -75,14 +75,14 @@ AtlTraceEx(_In_z_ PCSTR file,
 #endif // DBG
 
 #if DBG
-    #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+    #define ATLTRACE(format, ...)      ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
+    #define ATLTRACENOTIMPL(funcname)  (ATLTRACE(#funcname " is not implemented.\n"), E_NOTIMPL)
 #else
-    #define ATLTRACE(format, ...) ((void)0)
+    #define ATLTRACE(format, ...)      ((void)0)
+    #define ATLTRACENOTIMPL(funcname)  E_NOTIMPL
 #endif
 
 #define ATLTRACE2 ATLTRACE
-
-#define ATLTRACENOTIMPL(funcname) ATLTRACE(#funcname " is not implemented.\n")
 
 #ifndef _ATL_NO_AUTOMATIC_NAMESPACE
 using namespace ATL;

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -9,14 +9,14 @@
 
 #include "atldef.h"
 
-#if DBG
+#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
 
 #include <stdio.h>
 #include <crtdbg.h>
 
 extern "C"
 {
-// FIXME: Enabling _DEBUG at top level causes assertion failures...
+// FIXME: Enabling _DEBUG at top level causes assertion failures... CORE-17505
 int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, ...);
 int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, ...);
 }
@@ -270,7 +270,7 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 #endif // DBG
 
 #ifndef ATLTRACE
-    #if DBG
+    #if DBG  // FIXME: We should use _DEBUG instead of DBG. CORE-17505
         #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
     #else
         #define ATLTRACE(format, ...) ((void)0)
@@ -279,7 +279,7 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 
 #define ATLTRACE2 ATLTRACE
 
-#if DBG
+#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
     #define ATLTRACENOTIMPL(funcname) do { \
         ATLTRACE(atlTraceNotImpl, 0, #funcname " is not implemented.\n"); \
         return E_NOTIMPL; \

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -78,7 +78,7 @@ DECLSPEC_SELECTANY UINT CTrace::s_categories = CTrace::EnableAllCategories;
 DECLSPEC_SELECTANY UINT CTrace::s_level      = CTrace::DefaultTraceLevel;
 
 inline VOID __stdcall
-AtlTraceV(_In_z_                         PCSTR   file,
+AtlTraceV(_In_opt_z_                     PCSTR   file,
           _In_                           INT     line,
           _In_                           UINT    cat,
           _In_                           UINT    level,
@@ -104,7 +104,7 @@ AtlTraceV(_In_z_                         PCSTR   file,
 }
 
 inline VOID __stdcall
-AtlTraceV(_In_z_                         PCSTR   file,
+AtlTraceV(_In_opt_z_                     PCSTR   file,
           _In_                           INT     line,
           _In_                           UINT    cat,
           _In_                           UINT    level,
@@ -131,7 +131,7 @@ AtlTraceV(_In_z_                         PCSTR   file,
 
 template <typename T_CHAR>
 inline VOID __cdecl
-AtlTraceEx(_In_z_                        PCSTR         file,
+AtlTraceEx(_In_opt_z_                    PCSTR         file,
            _In_                          INT           line,
            _In_                          UINT          cat,
            _In_                          UINT          level,
@@ -146,7 +146,7 @@ AtlTraceEx(_In_z_                        PCSTR         file,
 
 template <typename T_CHAR>
 inline VOID __cdecl
-AtlTraceEx(_In_z_                        PCSTR         file,
+AtlTraceEx(_In_opt_z_                    PCSTR         file,
            _In_                          INT           line,
            _In_z_ _Printf_format_string_ const T_CHAR *format,
            ...)
@@ -158,9 +158,9 @@ AtlTraceEx(_In_z_                        PCSTR         file,
 }
 
 inline VOID __stdcall
-AtlTraceEx(_In_z_ PCSTR file,
-           _In_   INT   line,
-           _In_   DWORD value)
+AtlTraceEx(_In_opt_z_ PCSTR file,
+           _In_       INT   line,
+           _In_       DWORD value)
 {
     AtlTraceEx(file, line, "%ld (0x%lX)\n", value, value);
 }

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -117,6 +117,11 @@ struct CTraceCategoryEasy
     }
 
     operator UINT() const { return m_category; }
+
+    BOOL IsGeneral() const
+    {
+        return lstrcmp(m_name, TEXT("atlTraceGeneral")) == 0;
+    }
 };
 
 struct CTrace
@@ -164,12 +169,22 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
 
 #ifdef _STRSAFE_H_INCLUDED_
     StringCchPrintfA(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? "%ls" : "%hs"), file);
-    StringCchPrintfA(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
-    StringCchLengthA(szBuff, _countof(szBuff), &cch);
+    if (cat.IsGeneral())
+    {
+        cch = 0;
+    }
+    else
+    {
+        StringCchPrintfA(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
+        StringCchLengthA(szBuff, _countof(szBuff), &cch);
+    }
     StringCchVPrintfA(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
     _snprintf(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? "%ls" : "%hs"), file);
-    cch = _snprintf(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
+    if (cat.IsGeneral())
+        cch = 0;
+    else
+        cch = _snprintf(szBuff, _countof(szBuff), (bUnicode ? "%ls - " : "%hs - "), cat.m_name);
     _vsnprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif
 
@@ -194,12 +209,22 @@ AtlTraceV(_In_opt_z_                     const X_CHAR *            file,
 
 #ifdef _STRSAFE_H_INCLUDED_
     StringCchPrintfW(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? L"%ls" : L"%hs"), file);
-    StringCchPrintfW(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
-    StringCchLengthW(szBuff, _countof(szBuff), &cch);
+    if (cat.IsGeneral())
+    {
+        cch = 0;
+    }
+    else
+    {
+        StringCchPrintfW(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
+        StringCchLengthW(szBuff, _countof(szBuff), &cch);
+    }
     StringCchVPrintfW(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #else
     _snwprintf(szFile, _countof(szFile), ((sizeof(X_CHAR) == 2) ? L"%ls" : L"%hs"), file);
-    cch = _snwprintf(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
+    if (cat.IsGeneral())
+        cch = 0;
+    else
+        cch = _snwprintf(szBuff, _countof(szBuff), (bUnicode ? L"%ls - " : L"%hs - "), cat.m_name);
     _vsnwprintf(&szBuff[cch], _countof(szBuff) - cch, format, va);
 #endif
 


### PR DESCRIPTION
## Purpose
Improve traceability of ATL applications.
JIRA issue: [CORE-17969](https://jira.reactos.org/browse/CORE-17969), [CORE-18012](https://jira.reactos.org/browse/CORE-18012)

## Proposed changes

- Implement `ATLTRACE` and `AtlTrace` in `atlbase.h`.
- Fix assertion failures in `mspaint`.

## Screenshot
![無題](https://user-images.githubusercontent.com/2107452/150622479-ae94283a-4248-478e-82e0-438b63147f14.png)