### PR TITLE
Sync thread's language/locale with console's preferred language

### DIFF
--- a/dll/win32/kernel32/client/console/init.c
+++ b/dll/win32/kernel32/client/console/init.c
@@ -342,14 +342,13 @@ ConDllInitialize(IN ULONG Reason,
     PRTL_USER_PROCESS_PARAMETERS Parameters = NtCurrentPeb()->ProcessParameters;
     BOOLEAN InServerProcess = FALSE;
     CONSRV_API_CONNECTINFO ConnectInfo;
-    LCID lcid;
 
     if (Reason != DLL_PROCESS_ATTACH)
     {
         if ((Reason == DLL_THREAD_ATTACH) && IsConsoleApp())
         {
-            /* Sets the current console locale for the new thread */
-            SetTEBLangID(lcid);
+            /* Sync the new thread's LangId with the console's one */
+            SetTEBLangID();
         }
         else if (Reason == DLL_PROCESS_DETACH)
         {
@@ -522,8 +521,8 @@ ConDllInitialize(IN ULONG Reason,
 
         InputWaitHandle = ConnectInfo.ConsoleStartInfo.InputWaitHandle;
 
-        /* Sets the current console locale for this thread */
-        SetTEBLangID(lcid);
+        /* Sync the current thread's LangId with the console's one */
+        SetTEBLangID();
     }
 
     DPRINT("Console setup: 0x%p, 0x%p, 0x%p, 0x%p\n",

--- a/dll/win32/kernel32/client/thread.c
+++ b/dll/win32/kernel32/client/thread.c
@@ -935,8 +935,19 @@ LANGID
 WINAPI
 SetThreadUILanguage(IN LANGID LangId)
 {
+#if (NTDDI_VERSION < NTDDI_LONGHORN)
+    /* We only support LangId == 0, for selecting a language
+     * identifier that best supports the NT Console. */
+    if (LangId != 0)
+    {
+        BaseSetLastNTError(STATUS_NOT_SUPPORTED);
+        return 0;
+    }
+#endif
+
     UNIMPLEMENTED;
-    return (LANGID)NtCurrentTeb()->CurrentLocale;
+
+    return LANGIDFROMLCID(NtCurrentTeb()->CurrentLocale);
 }
 
 /*

--- a/dll/win32/kernel32/include/console.h
+++ b/dll/win32/kernel32/include/console.h
@@ -60,7 +60,8 @@ GetConsoleInputWaitHandle(VOID);
 HANDLE
 TranslateStdHandle(HANDLE hHandle);
 
-#define SetTEBLangID(p) (p)
+VOID
+SetTEBLangID(VOID);
 
 VOID
 SetUpConsoleInfo(IN BOOLEAN CaptureTitle,

--- a/sdk/include/reactos/subsys/win/conmsg.h
+++ b/sdk/include/reactos/subsys/win/conmsg.h
@@ -859,6 +859,12 @@ typedef struct _CONSOLE_SETINPUTOUTPUTCP
     HANDLE EventHandle;
 } CONSOLE_SETINPUTOUTPUTCP, *PCONSOLE_SETINPUTOUTPUTCP;
 
+typedef struct _CONSOLE_GETLANGID
+{
+    HANDLE ConsoleHandle;
+    LANGID LangId;
+} CONSOLE_GETLANGID, *PCONSOLE_GETLANGID;
+
 typedef struct _CONSOLE_GETKBDLAYOUTNAME
 {
     HANDLE ConsoleHandle;
@@ -991,6 +997,7 @@ typedef struct _CONSOLE_API_MESSAGE
         /* Input and Output Code Pages; keyboard */
         CONSOLE_GETINPUTOUTPUTCP GetConsoleCPRequest;
         CONSOLE_SETINPUTOUTPUTCP SetConsoleCPRequest;
+        CONSOLE_GETLANGID LangIdRequest;
         CONSOLE_GETKBDLAYOUTNAME GetKbdLayoutNameRequest;
 
         /* Virtual DOS Machine */

--- a/win32ss/user/winsrv/concfg/font.h
+++ b/win32ss/user/winsrv/concfg/font.h
@@ -19,6 +19,15 @@
 #define CP_GB2312   936  // Chinese Simplified (GB2312)
 #define CP_BIG5     950  // Chinese Traditional (Big5)
 
+/*
+ * "Human-understandable" names for the previous standard code pages.
+ * Taken from https://github.com/microsoft/terminal/blob/main/src/inc/unicode.hpp
+ */
+#define CP_JAPANESE             CP_SHIFTJIS
+#define CP_KOREAN               CP_HANGUL
+#define CP_CHINESE_SIMPLIFIED   CP_GB2312
+#define CP_CHINESE_TRADITIONAL  CP_BIG5
+
 /* IsFarEastCP(CodePage) */
 #define IsCJKCodePage(CodePage) \
     ((CodePage) == CP_SHIFTJIS || (CodePage) == CP_HANGUL || \


### PR DESCRIPTION
## Purpose

For a given non-unicode display code page, the console may not support showing the characters of the corresponding character set, if no suitable monospace font is available.
(For example, this is especially true in CJK ReactOS installations where no default _monospace_ font with CJK characters is installed; one needs an external fonts pack. But this observation is not limited to ReactOS.)

In this case, the console may change the code page to a default one. Or it may not, and might instead keep the code page, even if the selected font does not fully support displaying the corresponding characters.
On the other hand, a suitable font may exist and the console would keep the output code page.

In any of these cases, it is advisable that the console also tells which language it advises to be used for output.
On Windows, this is done whenever a program creates/attaches to a console, and when it sets a new output code page, and is mostly used in CJK installations. The calling thread's locale (in Windows <= 2003, since there was no concept of a separate thread UI language) is then modified with the corresponding language.

JIRA issue: [CORE-17601](https://jira.reactos.org/browse/CORE-17601), [CORE-17803](https://jira.reactos.org/browse/CORE-17803)
Replaces PR #4281

### NOTE
This PR should be tested together with PR #4337

## Proposed changes

```
[KERNEL32][CONSRV] Implement retrieving the best-suited language ID corresponding to the active console output code page.

Implement SrvGetConsoleLangId() (server-side) to retrieve the console's preferred language ID,
and (client-side) set the new current thread's locale after connecting to a console, or changing its output code page.

Based on comments gathered, and code, from: https://github.com/microsoft/terminal
```
```
[KERNEL32] SetThreadUILanguage(): Check for parameter (we and Win2k3 only support '0'). Use LANGIDFROMLCID() macro.
```

## TODO

- [x] Write tests.
- [x] Show the matrix of test results.
- [x] What about Windows 10 CJK? (ask @katahiromz)

## Test results matrix

**How to test:** Add a pause (like a `Sleep` or an infinite loop `while (1);`) just after the `test_CP_ThreadLang()` test in `modules/rostests/apitests/kernel32/ConsoleCP.c`, so that you can have time to see the test results (that appear in the separate spanned console window, that would otherwise just vanish quickly).

### Non-CJK systems

_**OBSERVATIONS:**_
- *(Cases A,E):* Both unfixed ReactOS and Windows 10 switch to a console CJK codepage (second test line), irrespectively of whether the system is CJK or not (and has or hasn't suitable fonts).
- *(Cases B,D):* Both ReactOS with this PR + PR #4337 and Windows 2003 will refuse to switch the console to a (otherwise valid) CJK codepage. _**BUT:**_ Windows 2003 will always do that, while ReactOS will do it only if there is no suitable CJK font present *(Case B, compare with Case C)*.
- *(Cases C,E)* Fixed ReactOS will switch to a console CJK codepage (even when the system is non-CJK) when it has the CJK fonts, and thus will behave similarly to Windows 10.

| Test OS      | Results |
| :-----:      | :-----: |
| _**A:**_ ReactOS _(No fixes or just this PR)_ | <img src="https://user-images.githubusercontent.com/1969829/152661640-1cae0368-781a-4461-a779-0758a29289fe.png" alt="reactos_nofixes_or_withfixes_USACP" width="75%" height="75%"/> |
| _**B:**_ ReactOS _(This PR + PR #4337, No CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152661648-427c746f-c08c-48c6-b728-33784200c58b.png" alt="reactos_withfixes_and_PR4337_NoCJKFonts_USACP" width="75%" height="75%"/> |
| _**C:**_ ReactOS _(This PR + PR #4337, With CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152661649-24605aa9-4c53-45c5-b1ba-04df859be358.png" alt="reactos_withfixes_and_PR4337_USACP" width="75%" height="75%"/> |
| _**D:**_ Windows 2003 | <img src="https://user-images.githubusercontent.com/1969829/152661652-9d8ec7ac-e9d9-46d9-afe4-161171c0bbf0.png" alt="win2k3_USACP" width="75%" height="75%"/> |
| _**E:**_ Windows 10   | <img src="https://user-images.githubusercontent.com/1969829/152661654-eadff88e-3596-4ff4-94c6-1053e6cb7096.png" alt="win10_USACP" width="75%" height="75%"/>  |


### CJK systems

_**OBSERVATIONS:**_
- *(Case C):* ReactOS with this PR + PR #4337 _*but without CJK fonts*_ will refuse to change to a console CJK codepage and therefore will behave similarly to the case of a non-CJK system.
- *(Cases B/D/E/F vs. A):* This PR allows ReactOS to sync a console program's thread lang ID to the one suitable for the console, as on Windows 2003+.
- *(Cases D,E,F):* Both ReactOS with this PR + PR #4337 with CJK fonts, and Windows 2003/Windows 10 behave correctly.

| Test OS      | Results |
| :-----:      | :-----: |
| _**A:**_ ReactOS _(No fixes, with or without CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152658993-ba65ba64-234f-4432-a011-1d826bf526e0.png" alt="reactos_nofixes_CJK" width="75%" height="75%"/> |
| _**B:**_ ReactOS _(This PR only, with or without CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152659000-4d9a9f47-6a04-4318-8c2d-9258b3216c45.png" alt="reactos_withfixes_CJK" width="75%" height="75%"/> |
| _**C:**_ ReactOS _(This PR + PR #4337, No CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152659007-9407caed-00ae-4bb6-b1f0-7a0709abbe5f.png" alt="reactos_withfixes_and_PR4337_CJK_1" width="75%" height="75%"/> |
| _**D:**_ ReactOS _(This PR + PR #4337, With CJK fonts)_ | <img src="https://user-images.githubusercontent.com/1969829/152659008-8bb2e2e0-66ad-48e9-9d48-c5e8a55234a6.png" alt="reactos_withfixes_and_PR4337_CJK_2" width="75%" height="75%"/> |
| _**E:**_ Windows 2003 | <img src="https://user-images.githubusercontent.com/1969829/152659013-28b52216-14bc-46b9-82aa-49ac06a4b5a9.png" alt="win2k3_CJK_system" width="75%" height="75%"/> |
| _**F:**_ Windows 10 | <pre><br>ConsoleCP.c:1531: Running on CJK system (codepage 932)<br>ConsoleCP.c:152: Thread LangId 1041, expecting 1041...<br>ConsoleCP.c:157: Thread LangId 1033, expecting 1033...<br>ConsoleCP.c:161: Thread LangId 1041, expecting 1041...</pre> |
