### PR TITLE
[NTOSKRNL] Flush file to disk when deleting file mappings

### DIFF
--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3684,6 +3684,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         FsRtlReleaseFile(FileObject);
         MmDereferenceSegment(Segment);
     }
+
     /* Notify debugger */
     if (ImageBaseAddress && !SkipDebuggerNotify) DbgkUnMapViewOfSection(ImageBaseAddress);
 

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3636,6 +3636,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
     {
         PMM_SECTION_SEGMENT Segment = MemoryArea->SectionData.Segment;
         PMMVAD Vad = &MemoryArea->VadNode;
+        PFILE_OBJECT FileObject;
         SIZE_T ViewSize = PAGE_SIZE + ((Vad->EndingVpn - Vad->StartingVpn) << PAGE_SHIFT);
         LARGE_INTEGER ViewOffset;
         ViewOffset.QuadPart = MemoryArea->SectionData.ViewOffset;

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3659,7 +3659,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         }
         ASSERT(FlagOn(*Segment->Flags, MM_DATAFILE_SEGMENT));
 
-        PFILE_OBJECT FileObject = Segment->FileObject;
+        FileObject = Segment->FileObject;
         FsRtlAcquireFileExclusive(FileObject);
 
         /* Don't bother for auto-delete closed file. */

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3637,7 +3637,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         PMM_SECTION_SEGMENT Segment = MemoryArea->SectionData.Segment;
         PMMVAD Vad = &MemoryArea->VadNode;
         PFILE_OBJECT FileObject;
-        SIZE_T ViewSize = PAGE_SIZE + ((Vad->EndingVpn - Vad->StartingVpn) << PAGE_SHIFT);
+        SIZE_T ViewSize;
         LARGE_INTEGER ViewOffset;
         ViewOffset.QuadPart = MemoryArea->SectionData.ViewOffset;
         

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3672,9 +3672,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         /* FIXME: We should likely flush only when last mapping is deleted */
         while (ViewSize > 0)
         {
-            ULONG FlushSize = ViewSize > (PAGE_ROUND_DOWN(MAXULONG)) ? 
-                                PAGE_ROUND_DOWN(MAXULONG) :
-                                ViewSize;
+            ULONG FlushSize = min(ViewSize, PAGE_ROUND_DOWN(MAXULONG));
             MmFlushSegment(FileObject->SectionObjectPointer,
                            &ViewOffset,
                            FlushSize,

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -3671,6 +3671,7 @@ MiRosUnmapViewOfSection(IN PEPROCESS Process,
         }
 
         /* FIXME: We should likely flush only when last mapping is deleted */
+        ViewSize = PAGE_SIZE + ((Vad->EndingVpn - Vad->StartingVpn) << PAGE_SHIFT);
         while (ViewSize > 0)
         {
             ULONG FlushSize = min(ViewSize, PAGE_ROUND_DOWN(MAXULONG));


### PR DESCRIPTION
[CORE-17627](https://jira.reactos.org/browse/CORE-17627)

## Purpose

When closing a file, fastfat zeroes it out from ValidDataLength up to the end of the file.
The ValidDataLength field is updated when the file content is actually written to disk.
There is currently a race between the file-close path and the page out path, leading to potential file corruptions when the zeroing happens after the memory has been flushed to disk.

Fix this by actually flushing the file to disk when unmapping files, with file lock acquired. This way, the FS driver cannot zero out the tail of the file while we're actually flushing it to disk.