### PR TITLE
[PORTCLS] Fix crashes because of zero initialization weirdness

### DIFF
--- a/drivers/wdm/audio/backpln/portcls/dma_slave.cpp
+++ b/drivers/wdm/audio/backpln/portcls/dma_slave.cpp
@@ -17,19 +17,6 @@
 class CDmaChannelInit : public IDmaChannelInit
 {
 public:
-    inline
-    PVOID
-    operator new(
-        size_t Size,
-        POOL_TYPE PoolType,
-        ULONG Tag)
-    {
-        PVOID P = ExAllocatePoolWithTag(PoolType, Size, Tag);
-        if (P)
-            RtlZeroMemory(P, Size);
-        return P;
-    }
-
     STDMETHODIMP QueryInterface( REFIID InterfaceId, PVOID* Interface);
 
     STDMETHODIMP_(ULONG) AddRef()


### PR DESCRIPTION
## Purpose

This fixes BSODs on startup and when running programs that play audio when using the AC’97 Audio Driver that is available at https://github.com/reactos/reactos/pull/4246. This fix was done by Michael Stamper (aka TheDeadFish).
