### PR TITLE
[NTUSER] Improve SPI_(GET/SET)NONCLIENTMETRICS

### DIFF
--- a/modules/rostests/apitests/user32/SystemParametersInfo.c
+++ b/modules/rostests/apitests/user32/SystemParametersInfo.c
@@ -106,10 +106,129 @@ MSG_ENTRY CaptionHeight_chain[]={
 static void Test_NonClientMetrics()
 {
     NONCLIENTMETRICS NonClientMetrics;
+    NONCLIENTMETRICSA ncmA;
+    NONCLIENTMETRICSW ncmW;
+    BOOL ret;
 
     /* WARNING: this test requires themes and dwm to be disabled */
 
     SetCursorPos(0,0);
+
+    ncmA.cbSize = 0;
+    ret = SystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 1, &ncmA, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    /* ncmA */
+    ncmA.cbSize = 0;
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 1, &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = 0;
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmA.cbSize = sizeof(ncmA);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    /* ncmW */
+    ncmW.cbSize = 0;
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 1, &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = 0;
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = 0;
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 1, &ncmW, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = 0;
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
+    ok_int(ret, 0);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
+
+    ncmW.cbSize = sizeof(ncmW);
+    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
+    ok_int(ret, 1);
+    FlushMessages();
+    COMPARE_CACHE(empty_chain);
 
     /* Retrieve th non client metrics */
     NonClientMetrics.cbSize = sizeof(NONCLIENTMETRICS);

--- a/modules/rostests/apitests/user32/SystemParametersInfo.c
+++ b/modules/rostests/apitests/user32/SystemParametersInfo.c
@@ -109,42 +109,51 @@ typedef struct _NCM_TESTENRY
     BOOL ret;
     UINT cbSize;
     UINT uiParam;
+    UINT cbSizeNew;
 } NCM_TESTENRY;
 
 static const NCM_TESTENRY s_entriesAA[] =
 {
-    { __LINE__, 0, 0, 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, 0, 0, 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
 };
 
 static const NCM_TESTENRY s_entriesAW[] =
 {
-    { __LINE__, 0, 0, 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, 0, 0, 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA)  },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
 };
 
 static const NCM_TESTENRY s_entriesWA[] =
 {
-    { __LINE__, 0, 0, 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, 0, 0, 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
 };
 
 static const NCM_TESTENRY s_entriesWW[] =
 {
-    { __LINE__, 0, 0, 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, 0, 0, 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
 };
 
 static void Test_NonClientMetrics()
@@ -165,6 +174,7 @@ static void Test_NonClientMetrics()
         ncmA.cbSize = pEntry->cbSize;
         ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        ok(ncmA.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmA.cbSize, pEntry->cbSizeNew);
         FlushMessages();
         COMPARE_CACHE(empty_chain);
     }
@@ -174,6 +184,7 @@ static void Test_NonClientMetrics()
         ncmA.cbSize = pEntry->cbSize;
         ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        ok(ncmA.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmA.cbSize, pEntry->cbSizeNew);
         FlushMessages();
         COMPARE_CACHE(empty_chain);
     }
@@ -185,6 +196,7 @@ static void Test_NonClientMetrics()
         ncmW.cbSize = pEntry->cbSize;
         ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        ok(ncmW.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmW.cbSize, pEntry->cbSizeNew);
         FlushMessages();
         COMPARE_CACHE(empty_chain);
     }
@@ -194,6 +206,7 @@ static void Test_NonClientMetrics()
         ncmW.cbSize = pEntry->cbSize;
         ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        ok(ncmW.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmW.cbSize, pEntry->cbSizeNew);
         FlushMessages();
         COMPARE_CACHE(empty_chain);
     }

--- a/modules/rostests/apitests/user32/SystemParametersInfo.c
+++ b/modules/rostests/apitests/user32/SystemParametersInfo.c
@@ -107,53 +107,46 @@ typedef struct _NCM_TESTENRY
 {
     INT line;
     BOOL ret;
+    BOOL bAnsi;
     UINT cbSize;
     UINT uiParam;
     UINT cbSizeNew;
 } NCM_TESTENRY;
 
-static const NCM_TESTENRY s_entriesAA[] =
+static const NCM_TESTENRY s_entriesA[] =
 {
-    { __LINE__, 0, 0, 0, 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA), 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
+    { __LINE__, 0, TRUE, 0, 0, 0 },
+    { __LINE__, 1, TRUE, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 1, TRUE, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
+    { __LINE__, 0, TRUE, 0, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 1, TRUE, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
+    { __LINE__, 0, FALSE, 0, 0, 0 },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
+    { __LINE__, 0, FALSE, 0, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA)  },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
 };
 
-static const NCM_TESTENRY s_entriesAW[] =
+static const NCM_TESTENRY s_entriesW[] =
 {
-    { __LINE__, 0, 0, 0, 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 0, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 1, sizeof(NONCLIENTMETRICSA) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 1, 1, sizeof(NONCLIENTMETRICSA) + 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA), 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA)  },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSA) + 100, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) + 100 },
-};
-
-static const NCM_TESTENRY s_entriesWA[] =
-{
-    { __LINE__, 0, 0, 0, 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW), 0 },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
-};
-
-static const NCM_TESTENRY s_entriesWW[] =
-{
-    { __LINE__, 0, 0, 0, 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
-    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW), 0 },
-    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
-    { __LINE__, 0, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
+    { __LINE__, 0, TRUE, 0, 0, 0 },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
+    { __LINE__, 0, TRUE, 0, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, TRUE, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
+    { __LINE__, 0, FALSE, 0, 0, 0 },
+    { __LINE__, 1, FALSE, sizeof(NONCLIENTMETRICSW), 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 1, FALSE, sizeof(NONCLIENTMETRICSW), 1, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSW) + 1, 1, sizeof(NONCLIENTMETRICSW) + 1 },
+    { __LINE__, 0, FALSE, 0, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 1, FALSE, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, FALSE, sizeof(NONCLIENTMETRICSW) + 100, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) + 100 },
 };
 
 static void Test_NonClientMetrics()
@@ -168,21 +161,14 @@ static void Test_NonClientMetrics()
     SetCursorPos(0,0);
 
     /* ncmA */
-    for (i = 0; i < _countof(s_entriesAA); ++i)
+    for (i = 0; i < _countof(s_entriesA); ++i)
     {
-        const NCM_TESTENRY *pEntry = &s_entriesAA[i];
+        const NCM_TESTENRY *pEntry = &s_entriesA[i];
         ncmA.cbSize = pEntry->cbSize;
-        ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
-        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
-        ok(ncmA.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmA.cbSize, pEntry->cbSizeNew);
-        FlushMessages();
-        COMPARE_CACHE(empty_chain);
-    }
-    for (i = 0; i < _countof(s_entriesAW); ++i)
-    {
-        const NCM_TESTENRY *pEntry = &s_entriesAW[i];
-        ncmA.cbSize = pEntry->cbSize;
-        ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
+        if (pEntry->bAnsi)
+            ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
+        else
+            ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
         ok(ncmA.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmA.cbSize, pEntry->cbSizeNew);
         FlushMessages();
@@ -190,21 +176,14 @@ static void Test_NonClientMetrics()
     }
 
     /* ncmW */
-    for (i = 0; i < _countof(s_entriesWA); ++i)
+    for (i = 0; i < _countof(s_entriesW); ++i)
     {
-        const NCM_TESTENRY *pEntry = &s_entriesWA[i];
+        const NCM_TESTENRY *pEntry = &s_entriesW[i];
         ncmW.cbSize = pEntry->cbSize;
-        ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
-        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
-        ok(ncmW.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmW.cbSize, pEntry->cbSizeNew);
-        FlushMessages();
-        COMPARE_CACHE(empty_chain);
-    }
-    for (i = 0; i < _countof(s_entriesWW); ++i)
-    {
-        const NCM_TESTENRY *pEntry = &s_entriesWW[i];
-        ncmW.cbSize = pEntry->cbSize;
-        ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
+        if (pEntry->bAnsi)
+            ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
+        else
+            ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
         ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
         ok(ncmW.cbSize == pEntry->cbSizeNew, "Line %d: cbSize %d vs. %d\n", pEntry->line, ncmW.cbSize, pEntry->cbSizeNew);
         FlushMessages();

--- a/modules/rostests/apitests/user32/SystemParametersInfo.c
+++ b/modules/rostests/apitests/user32/SystemParametersInfo.c
@@ -103,158 +103,126 @@ MSG_ENTRY CaptionHeight_chain[]={
     {1,WM_MOVE},
     {0,0}};
 
+typedef struct _NCM_TESTENRY
+{
+    INT line;
+    BOOL ret;
+    UINT cbSize;
+    UINT uiParam;
+} NCM_TESTENRY;
+
+static const NCM_TESTENRY s_entriesAA[] =
+{
+    { __LINE__, 0, 0, 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+};
+
+static const NCM_TESTENRY s_entriesAW[] =
+{
+    { __LINE__, 0, 0, 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSA) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSA), sizeof(NONCLIENTMETRICSA) },
+};
+
+static const NCM_TESTENRY s_entriesWA[] =
+{
+    { __LINE__, 0, 0, 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 0, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+};
+
+static const NCM_TESTENRY s_entriesWW[] =
+{
+    { __LINE__, 0, 0, 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 0 },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), 1 },
+    { __LINE__, 0, 0, sizeof(NONCLIENTMETRICSW) },
+    { __LINE__, 1, sizeof(NONCLIENTMETRICSW), sizeof(NONCLIENTMETRICSW) },
+};
+
 static void Test_NonClientMetrics()
 {
-    NONCLIENTMETRICS NonClientMetrics;
     NONCLIENTMETRICSA ncmA;
     NONCLIENTMETRICSW ncmW;
     BOOL ret;
+    SIZE_T i;
 
     /* WARNING: this test requires themes and dwm to be disabled */
 
     SetCursorPos(0,0);
 
     /* ncmA */
-    ncmA.cbSize = 0;
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 1, &ncmA, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = 0;
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 1, &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = 0;
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmA.cbSize = sizeof(ncmA);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
+    for (i = 0; i < _countof(s_entriesAA); ++i)
+    {
+        const NCM_TESTENRY *pEntry = &s_entriesAA[i];
+        ncmA.cbSize = pEntry->cbSize;
+        ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
+        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        FlushMessages();
+        COMPARE_CACHE(empty_chain);
+    }
+    for (i = 0; i < _countof(s_entriesAW); ++i)
+    {
+        const NCM_TESTENRY *pEntry = &s_entriesAW[i];
+        ncmA.cbSize = pEntry->cbSize;
+        ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmA, 0);
+        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        FlushMessages();
+        COMPARE_CACHE(empty_chain);
+    }
 
     /* ncmW */
-    ncmW.cbSize = 0;
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 1, &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = 0;
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = 0;
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 0, &ncmW, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, 1, &ncmW, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = 0;
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
-    ok_int(ret, 0);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
-
-    ncmW.cbSize = sizeof(ncmW);
-    ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
-    ok_int(ret, 1);
-    FlushMessages();
-    COMPARE_CACHE(empty_chain);
+    for (i = 0; i < _countof(s_entriesWA); ++i)
+    {
+        const NCM_TESTENRY *pEntry = &s_entriesWA[i];
+        ncmW.cbSize = pEntry->cbSize;
+        ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
+        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        FlushMessages();
+        COMPARE_CACHE(empty_chain);
+    }
+    for (i = 0; i < _countof(s_entriesWW); ++i)
+    {
+        const NCM_TESTENRY *pEntry = &s_entriesWW[i];
+        ncmW.cbSize = pEntry->cbSize;
+        ret = SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, pEntry->uiParam, &ncmW, 0);
+        ok(ret == pEntry->ret, "Line %d: ret %d vs. %d\n", pEntry->line, ret, pEntry->ret);
+        FlushMessages();
+        COMPARE_CACHE(empty_chain);
+    }
 
     /* Retrieve th non client metrics */
-    NonClientMetrics.cbSize = sizeof(NONCLIENTMETRICS);
-    SystemParametersInfo(SPI_GETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &NonClientMetrics, 0);
+    ncmW.cbSize = sizeof(ncmW);
+    SystemParametersInfoW(SPI_GETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
     FlushMessages();
     COMPARE_CACHE(empty_chain);
 
     /* Set the non client metric without making any change */
-    SystemParametersInfo(SPI_SETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &NonClientMetrics, 0);
+    SystemParametersInfoW(SPI_SETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
     FlushMessages();
     COMPARE_CACHE(NcMetricsChange_chain);
 
     /* Set the same metrics again with the SPIF_SENDCHANGE param */
-    SystemParametersInfo(SPI_SETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &NonClientMetrics, SPIF_SENDCHANGE|SPIF_UPDATEINIFILE );
+    SystemParametersInfoW(SPI_SETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, SPIF_SENDCHANGE|SPIF_UPDATEINIFILE );
     FlushMessages();
     COMPARE_CACHE(NcMetricsChange1_chain);
 
     /* Slightly change the caption height */
-    NonClientMetrics.iCaptionHeight += 1;
-    SystemParametersInfo(SPI_SETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &NonClientMetrics, 0);
+    ncmW.iCaptionHeight += 1;
+    SystemParametersInfoW(SPI_SETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
     FlushMessages();
     COMPARE_CACHE(CaptionHeight_chain);
 
     /* Restore the original caption height */
-    NonClientMetrics.iCaptionHeight -= 1;
-    SystemParametersInfo(SPI_SETNONCLIENTMETRICS, sizeof(NONCLIENTMETRICS), &NonClientMetrics, 0);
+    ncmW.iCaptionHeight -= 1;
+    SystemParametersInfoW(SPI_SETNONCLIENTMETRICS, sizeof(ncmW), &ncmW, 0);
     FlushMessages();
     COMPARE_CACHE(CaptionHeight_chain);
 }

--- a/modules/rostests/apitests/user32/SystemParametersInfo.c
+++ b/modules/rostests/apitests/user32/SystemParametersInfo.c
@@ -114,8 +114,9 @@ static void Test_NonClientMetrics()
 
     SetCursorPos(0,0);
 
+    /* ncmA */
     ncmA.cbSize = 0;
-    ret = SystemParametersInfo(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
+    ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, 0, &ncmA, 0);
     ok_int(ret, 0);
     FlushMessages();
     COMPARE_CACHE(empty_chain);
@@ -132,7 +133,6 @@ static void Test_NonClientMetrics()
     FlushMessages();
     COMPARE_CACHE(empty_chain);
 
-    /* ncmA */
     ncmA.cbSize = 0;
     ret = SystemParametersInfoA(SPI_GETNONCLIENTMETRICS, sizeof(ncmA), &ncmA, 0);
     ok_int(ret, 0);

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1999,10 +1999,8 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_GETNONCLIENTMETRICS:
-            if (uiParam == sizeof(NONCLIENTMETRICSA))
-                cbSize = sizeof(NONCLIENTMETRICSA);
-            else if (uiParam == sizeof(NONCLIENTMETRICSW))
-                cbSize = sizeof(NONCLIENTMETRICSW);
+            if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
+                cbSize = uiParam;
             break;
 
         case SPI_GETMINIMIZEDMETRICS:
@@ -2074,10 +2072,8 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_SETNONCLIENTMETRICS:
-            if (uiParam == sizeof(NONCLIENTMETRICSA))
-                cbSize = sizeof(NONCLIENTMETRICSA);
-            else if (uiParam == sizeof(NONCLIENTMETRICSW))
-                cbSize = sizeof(NONCLIENTMETRICSW);
+            if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
+                cbSize = uiParam;
             bToUser = FALSE;
             break;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -942,8 +942,8 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
 
         case SPI_GETNONCLIENTMETRICS:
         {
-            UINT cbSize = 0;
-            if (!SpiGetInt(pvParam, &cbSize, fl))
+            UINT cbSize;
+            if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
 
             if (
@@ -961,8 +961,8 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
 
         case SPI_SETNONCLIENTMETRICS:
         {
-            UINT cbSize = 0;
-            if (!SpiGetInt(pvParam, &cbSize, fl))
+            UINT cbSize;
+            if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
 
             if (

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1049,7 +1049,7 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             }
             else if (uiParam == sizeof(NONCLIENTMETRICSW))
             {
-                RtlCopyMemory(&ncmW, pvParam, sizeof(ncmW));
+                SpiGet(&ncmW, pvParam, uiParam, fl);
 
                 /* Fixup user's structure size */
                 ncmW.cbSize = sizeof(NONCLIENTMETRICSW);

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1999,7 +1999,10 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_GETNONCLIENTMETRICS:
-            cbSize = sizeof(NONCLIENTMETRICSA);
+            if (uiParam == sizeof(NONCLIENTMETRICSA))
+                cbSize = sizeof(NONCLIENTMETRICSA);
+            else if (uiParam == sizeof(NONCLIENTMETRICSW))
+                cbSize = sizeof(NONCLIENTMETRICSW);
             break;
 
         case SPI_GETMINIMIZEDMETRICS:
@@ -2071,7 +2074,10 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_SETNONCLIENTMETRICS:
-            cbSize = sizeof(NONCLIENTMETRICSA);
+            if (uiParam == sizeof(NONCLIENTMETRICSA))
+                cbSize = sizeof(NONCLIENTMETRICSA);
+            else if (uiParam == sizeof(NONCLIENTMETRICSW))
+                cbSize = sizeof(NONCLIENTMETRICSW);
             bToUser = FALSE;
             break;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -816,41 +816,57 @@ SpiLogFontWideToAnsi(const LOGFONTW *pLFW, LPLOGFONTA pLFA)
 static void
 SpiNonClientMetricsAnsiToWide(const NONCLIENTMETRICSA *pNCMA, LPNONCLIENTMETRICSW pNCMW)
 {
-    pNCMW->cbSize = sizeof(NONCLIENTMETRICSW);
-    pNCMW->iBorderWidth = pNCMA->iBorderWidth;
-    pNCMW->iScrollWidth = pNCMA->iScrollWidth;
-    pNCMW->iScrollHeight = pNCMA->iScrollHeight;
-    pNCMW->iCaptionWidth = pNCMA->iCaptionWidth;
-    pNCMW->iCaptionHeight = pNCMA->iCaptionHeight;
-    SpiLogFontAnsiToWide(&pNCMA->lfCaptionFont, &pNCMW->lfCaptionFont);
-    pNCMW->iSmCaptionWidth = pNCMA->iSmCaptionWidth;
-    pNCMW->iSmCaptionHeight = pNCMA->iSmCaptionHeight;
-    SpiLogFontAnsiToWide(&pNCMA->lfSmCaptionFont, &pNCMW->lfSmCaptionFont);
-    pNCMW->iMenuWidth = pNCMA->iMenuWidth;
-    pNCMW->iMenuHeight = pNCMA->iMenuHeight;
-    SpiLogFontAnsiToWide(&pNCMA->lfMenuFont, &pNCMW->lfMenuFont);
-    SpiLogFontAnsiToWide(&pNCMA->lfStatusFont, &pNCMW->lfStatusFont);
-    SpiLogFontAnsiToWide(&pNCMA->lfMessageFont, &pNCMW->lfMessageFont);
+    _SEH2_TRY
+    {
+        pNCMW->cbSize = sizeof(NONCLIENTMETRICSW);
+        pNCMW->iBorderWidth = pNCMA->iBorderWidth;
+        pNCMW->iScrollWidth = pNCMA->iScrollWidth;
+        pNCMW->iScrollHeight = pNCMA->iScrollHeight;
+        pNCMW->iCaptionWidth = pNCMA->iCaptionWidth;
+        pNCMW->iCaptionHeight = pNCMA->iCaptionHeight;
+        SpiLogFontAnsiToWide(&pNCMA->lfCaptionFont, &pNCMW->lfCaptionFont);
+        pNCMW->iSmCaptionWidth = pNCMA->iSmCaptionWidth;
+        pNCMW->iSmCaptionHeight = pNCMA->iSmCaptionHeight;
+        SpiLogFontAnsiToWide(&pNCMA->lfSmCaptionFont, &pNCMW->lfSmCaptionFont);
+        pNCMW->iMenuWidth = pNCMA->iMenuWidth;
+        pNCMW->iMenuHeight = pNCMA->iMenuHeight;
+        SpiLogFontAnsiToWide(&pNCMA->lfMenuFont, &pNCMW->lfMenuFont);
+        SpiLogFontAnsiToWide(&pNCMA->lfStatusFont, &pNCMW->lfStatusFont);
+        SpiLogFontAnsiToWide(&pNCMA->lfMessageFont, &pNCMW->lfMessageFont);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ;
+    }
+    _SEH2_END;
 }
 
 static void
 SpiNonClientMetricsWideToAnsi(const NONCLIENTMETRICSW *pNCMW, LPNONCLIENTMETRICSA pNCMA)
 {
-    pNCMA->cbSize = sizeof(NONCLIENTMETRICSA);
-    pNCMA->iBorderWidth = pNCMW->iBorderWidth;
-    pNCMA->iScrollWidth = pNCMW->iScrollWidth;
-    pNCMA->iScrollHeight = pNCMW->iScrollHeight;
-    pNCMA->iCaptionWidth = pNCMW->iCaptionWidth;
-    pNCMA->iCaptionHeight = pNCMW->iCaptionHeight;
-    SpiLogFontWideToAnsi(&pNCMW->lfCaptionFont, &pNCMA->lfCaptionFont);
-    pNCMA->iSmCaptionWidth = pNCMW->iSmCaptionWidth;
-    pNCMA->iSmCaptionHeight = pNCMW->iSmCaptionHeight;
-    SpiLogFontWideToAnsi(&pNCMW->lfSmCaptionFont, &pNCMA->lfSmCaptionFont);
-    pNCMA->iMenuWidth = pNCMW->iMenuWidth;
-    pNCMA->iMenuHeight = pNCMW->iMenuHeight;
-    SpiLogFontWideToAnsi(&pNCMW->lfMenuFont, &pNCMA->lfMenuFont);
-    SpiLogFontWideToAnsi(&pNCMW->lfStatusFont, &pNCMA->lfStatusFont);
-    SpiLogFontWideToAnsi(&pNCMW->lfMessageFont, &pNCMA->lfMessageFont);
+    _SEH2_TRY
+    {
+        pNCMA->cbSize = sizeof(NONCLIENTMETRICSA);
+        pNCMA->iBorderWidth = pNCMW->iBorderWidth;
+        pNCMA->iScrollWidth = pNCMW->iScrollWidth;
+        pNCMA->iScrollHeight = pNCMW->iScrollHeight;
+        pNCMA->iCaptionWidth = pNCMW->iCaptionWidth;
+        pNCMA->iCaptionHeight = pNCMW->iCaptionHeight;
+        SpiLogFontWideToAnsi(&pNCMW->lfCaptionFont, &pNCMA->lfCaptionFont);
+        pNCMA->iSmCaptionWidth = pNCMW->iSmCaptionWidth;
+        pNCMA->iSmCaptionHeight = pNCMW->iSmCaptionHeight;
+        SpiLogFontWideToAnsi(&pNCMW->lfSmCaptionFont, &pNCMA->lfSmCaptionFont);
+        pNCMA->iMenuWidth = pNCMW->iMenuWidth;
+        pNCMA->iMenuHeight = pNCMW->iMenuHeight;
+        SpiLogFontWideToAnsi(&pNCMW->lfMenuFont, &pNCMA->lfMenuFont);
+        SpiLogFontWideToAnsi(&pNCMW->lfStatusFont, &pNCMA->lfStatusFont);
+        SpiLogFontWideToAnsi(&pNCMW->lfMessageFont, &pNCMA->lfMessageFont);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ;
+    }
+    _SEH2_END;
 }
 
 static
@@ -998,6 +1014,9 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
 
         case SPI_GETNONCLIENTMETRICS:
         {
+            if (uiParam == 0)
+                SpiGetInt(pvParam, &uiParam, fl);
+
             if (uiParam == sizeof(NONCLIENTMETRICSA))
             {
                 NONCLIENTMETRICSA ncmA;
@@ -1010,7 +1029,6 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             }
             else
             {
-                EngSetLastError(ERROR_INVALID_PARAMETER);
                 return 0;
             }
         }
@@ -1018,6 +1036,10 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
         case SPI_SETNONCLIENTMETRICS:
         {
             NONCLIENTMETRICSW ncmW;
+
+            if (uiParam == 0)
+                SpiGetInt(pvParam, &uiParam, fl);
+
             if (uiParam == sizeof(NONCLIENTMETRICSA))
             {
                 SpiNonClientMetricsAnsiToWide(pvParam, &ncmW);
@@ -1037,7 +1059,6 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             }
             else
             {
-                EngSetLastError(ERROR_INVALID_PARAMETER);
                 return 0;
             }
 
@@ -2003,6 +2024,8 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
         case SPI_GETNONCLIENTMETRICS:
             if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
                 cbSize = uiParam;
+            else if (uiParam == 0)
+                SpiGetInt(pvParam, &cbSize, 0);
             break;
 
         case SPI_GETMINIMIZEDMETRICS:
@@ -2076,6 +2099,8 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
         case SPI_SETNONCLIENTMETRICS:
             if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
                 cbSize = uiParam;
+            else if (uiParam == 0)
+                SpiGetInt(pvParam, &cbSize, 0);
             bToUser = FALSE;
             break;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -946,9 +946,6 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
 
-            if (cbSize > sizeof(NONCLIENTMETRICSW))
-                cbSize = sizeof(NONCLIENTMETRICSW);
-
             if (
 #if (WINVER >= 0x0600)
                 cbSize != offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth) &&
@@ -970,9 +967,6 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             UINT cbSize;
             if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
-
-            if (cbSize > sizeof(NONCLIENTMETRICSW))
-                cbSize = sizeof(NONCLIENTMETRICSW);
 
             if (
 #if (WINVER >= 0x0600)

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -2036,10 +2036,7 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
         case SPI_GETNONCLIENTMETRICS:
             if (uiParam == 0)
                 SpiGetInt(pvParam, &uiParam, 0);
-            if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
-                cbSize = uiParam;
-            else
-                cbSize = 0;
+            cbSize = uiParam;
             break;
 
         case SPI_GETMINIMIZEDMETRICS:
@@ -2113,10 +2110,7 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
         case SPI_SETNONCLIENTMETRICS:
             if (uiParam == 0)
                 SpiGetInt(pvParam, &uiParam, 0);
-            if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
-                cbSize = uiParam;
-            else
-                cbSize = 0;
+            cbSize = uiParam;
             bToUser = FALSE;
             break;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -2034,10 +2034,12 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_GETNONCLIENTMETRICS:
+            if (uiParam == 0)
+                SpiGetInt(pvParam, &uiParam, 0);
             if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
                 cbSize = uiParam;
-            else if (uiParam == 0)
-                SpiGetInt(pvParam, &cbSize, 0);
+            else
+                cbSize = 0;
             break;
 
         case SPI_GETMINIMIZEDMETRICS:
@@ -2109,10 +2111,12 @@ SpiGetSetProbeBuffer(UINT uiAction, UINT uiParam, PVOID pvParam)
             break;
 
         case SPI_SETNONCLIENTMETRICS:
+            if (uiParam == 0)
+                SpiGetInt(pvParam, &uiParam, 0);
             if (uiParam == sizeof(NONCLIENTMETRICSA) || uiParam == sizeof(NONCLIENTMETRICSW))
                 cbSize = uiParam;
-            else if (uiParam == 0)
-                SpiGetInt(pvParam, &cbSize, 0);
+            else
+                cbSize = 0;
             bToUser = FALSE;
             break;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1008,9 +1008,11 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             {
                 return SpiGet(pvParam, &gspv.ncm, sizeof(NONCLIENTMETRICSW), fl);
             }
-
-            SetLastError(ERROR_INVALID_PARAMETER);
-            return 0;
+            else
+            {
+                EngSetLastError(ERROR_INVALID_PARAMETER);
+                return 0;
+            }
         }
 
         case SPI_SETNONCLIENTMETRICS:
@@ -1035,7 +1037,7 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             }
             else
             {
-                SetLastError(ERROR_INVALID_PARAMETER);
+                EngSetLastError(ERROR_INVALID_PARAMETER);
                 return 0;
             }
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -1002,11 +1002,11 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             {
                 NONCLIENTMETRICSA ncmA;
                 SpiNonClientMetricsWideToAnsi(&gspv.ncm, &ncmA);
-                return SpiGet(pvParam, &ncmA, sizeof(NONCLIENTMETRICSA), fl);
+                return SpiGet(pvParam, &ncmA, uiParam, fl);
             }
             else if (uiParam == sizeof(NONCLIENTMETRICSW))
             {
-                return SpiGet(pvParam, &gspv.ncm, sizeof(NONCLIENTMETRICSW), fl);
+                return SpiGet(pvParam, &gspv.ncm, uiParam, fl);
             }
             else
             {
@@ -1022,7 +1022,7 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             {
                 SpiNonClientMetricsAnsiToWide(pvParam, &ncmW);
 
-                if (!SpiSet(&gspv.ncm, &ncmW, sizeof(NONCLIENTMETRICSA), fl))
+                if (!SpiSet(&gspv.ncm, &ncmW, sizeof(NONCLIENTMETRICSW), fl))
                     return 0;
             }
             else if (uiParam == sizeof(NONCLIENTMETRICSW))

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -942,19 +942,11 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
 
         case SPI_GETNONCLIENTMETRICS:
         {
-            INT cbSize = 0;
-            if (!SpiGetInt(pvParam, &cbSize, fl) || cbSize != sizeof(NONCLIENTMETRICSW))
-                return 0;
-
-            return SpiGet(pvParam, &gspv.ncm, cbSize, fl);
+            return SpiGet(pvParam, &gspv.ncm, sizeof(NONCLIENTMETRICSW), fl);
         }
 
         case SPI_SETNONCLIENTMETRICS:
         {
-            INT cbSize = 0;
-            if (!SpiGetInt(pvParam, &cbSize, fl) || cbSize != sizeof(NONCLIENTMETRICSW))
-                return 0;
-
             if (!SpiSet(&gspv.ncm, pvParam, sizeof(NONCLIENTMETRICSW), fl))
                 return 0;
 

--- a/win32ss/user/ntuser/sysparams.c
+++ b/win32ss/user/ntuser/sysparams.c
@@ -946,6 +946,9 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
 
+            if (cbSize > sizeof(NONCLIENTMETRICSW))
+                cbSize = sizeof(NONCLIENTMETRICSW);
+
             if (
 #if (WINVER >= 0x0600)
                 cbSize != offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth) &&
@@ -956,7 +959,10 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             }
 
             if (SpiGet(pvParam, &gspv.ncm, cbSize, fl))
+            {
+                SpiGetInt(pvParam, &cbSize, fl);
                 return 1;
+            }
         }
 
         case SPI_SETNONCLIENTMETRICS:
@@ -964,6 +970,9 @@ SpiGetSet(UINT uiAction, UINT uiParam, PVOID pvParam, FLONG fl)
             UINT cbSize;
             if (!SpiGetInt(&cbSize, pvParam, fl))
                 return 0;
+
+            if (cbSize > sizeof(NONCLIENTMETRICSW))
+                cbSize = sizeof(NONCLIENTMETRICSW);
 
             if (
 #if (WINVER >= 0x0600)

--- a/win32ss/user/user32/misc/desktop.c
+++ b/win32ss/user/user32/misc/desktop.c
@@ -189,7 +189,7 @@ RealSystemParametersInfoA(UINT uiAction,
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if (pnclma->cbSize < sizeof(NONCLIENTMETRICSA))
+           if (pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;
@@ -221,7 +221,7 @@ RealSystemParametersInfoA(UINT uiAction,
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if (pnclma->cbSize < sizeof(NONCLIENTMETRICSA))
+           if (pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;

--- a/win32ss/user/user32/misc/desktop.c
+++ b/win32ss/user/user32/misc/desktop.c
@@ -207,7 +207,6 @@ RealSystemParametersInfoA(UINT uiAction,
            if (!SystemParametersInfoW(uiAction, sizeof(NONCLIENTMETRICSW), &nclmw, fWinIni))
                return FALSE;
 
-           pnclma->cbSize = sizeof(NONCLIENTMETRICSA);
            pnclma->iBorderWidth = nclmw.iBorderWidth;
            pnclma->iScrollWidth = nclmw.iScrollWidth;
            pnclma->iScrollHeight = nclmw.iScrollHeight;

--- a/win32ss/user/user32/misc/desktop.c
+++ b/win32ss/user/user32/misc/desktop.c
@@ -189,7 +189,7 @@ RealSystemParametersInfoA(UINT uiAction,
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if(pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
+           if (pnclma->cbSize < sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;
@@ -200,6 +200,7 @@ RealSystemParametersInfoA(UINT uiAction,
                                       &nclmw, fWinIni))
              return FALSE;
 
+           pnclma->cbSize = sizeof(NONCLIENTMETRICSA);
            pnclma->iBorderWidth = nclmw.iBorderWidth;
            pnclma->iScrollWidth = nclmw.iScrollWidth;
            pnclma->iScrollHeight = nclmw.iScrollHeight;
@@ -220,7 +221,7 @@ RealSystemParametersInfoA(UINT uiAction,
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if(pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
+           if (pnclma->cbSize < sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;

--- a/win32ss/user/user32/misc/desktop.c
+++ b/win32ss/user/user32/misc/desktop.c
@@ -189,16 +189,19 @@ RealSystemParametersInfoA(UINT uiAction,
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if (pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
+           if (
+#if (WINVER >= 0x0600)
+               pnclma->cbSize != offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth) &&
+#endif
+               pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;
            }
-           nclmw.cbSize = sizeof(NONCLIENTMETRICSW);
 
-           if (!SystemParametersInfoW(uiAction, sizeof(NONCLIENTMETRICSW),
-                                      &nclmw, fWinIni))
-             return FALSE;
+           nclmw.cbSize = sizeof(NONCLIENTMETRICSW);
+           if (!SystemParametersInfoW(uiAction, sizeof(NONCLIENTMETRICSW), &nclmw, fWinIni))
+               return FALSE;
 
            pnclma->cbSize = sizeof(NONCLIENTMETRICSA);
            pnclma->iBorderWidth = nclmw.iBorderWidth;
@@ -215,17 +218,26 @@ RealSystemParametersInfoA(UINT uiAction,
            LogFontW2A(&(pnclma->lfMenuFont), &(nclmw.lfMenuFont));
            LogFontW2A(&(pnclma->lfStatusFont), &(nclmw.lfStatusFont));
            LogFontW2A(&(pnclma->lfMessageFont), &(nclmw.lfMessageFont));
+#if (WINVER >= 0x0600)
+           if (pnclma->cbSize == sizeof(NONCLIENTMETRICSA))
+               pnclma->iPaddedBorderWidth = nclmw.iPaddedBorderWidth;
+#endif
            return TRUE;
         }
       case SPI_SETNONCLIENTMETRICS:
         {
            LPNONCLIENTMETRICSA pnclma = (LPNONCLIENTMETRICSA)pvParam;
            NONCLIENTMETRICSW nclmw;
-           if (pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
+           if (
+#if (WINVER >= 0x0600)
+               pnclma->cbSize != offsetof(NONCLIENTMETRICSW, iPaddedBorderWidth) &&
+#endif
+               pnclma->cbSize != sizeof(NONCLIENTMETRICSA))
            {
                SetLastError(ERROR_INVALID_PARAMETER);
                return FALSE;
            }
+
            nclmw.cbSize = sizeof(NONCLIENTMETRICSW);
            nclmw.iBorderWidth = pnclma->iBorderWidth;
            nclmw.iScrollWidth = pnclma->iScrollWidth;
@@ -241,9 +253,11 @@ RealSystemParametersInfoA(UINT uiAction,
            LogFontA2W(&(nclmw.lfMenuFont), &(pnclma->lfMenuFont));
            LogFontA2W(&(nclmw.lfStatusFont), &(pnclma->lfStatusFont));
            LogFontA2W(&(nclmw.lfMessageFont), &(pnclma->lfMessageFont));
-
-           return SystemParametersInfoW(uiAction, sizeof(NONCLIENTMETRICSW),
-                                        &nclmw, fWinIni);
+#if (WINVER >= 0x0600)
+           if (pnclma->cbSize == sizeof(NONCLIENTMETRICSA))
+               nclmw.iPaddedBorderWidth = pnclma->iPaddedBorderWidth;
+#endif
+           return SystemParametersInfoW(uiAction, sizeof(NONCLIENTMETRICSW), &nclmw, fWinIni);
         }
       case SPI_GETICONMETRICS:
           {


### PR DESCRIPTION
## Purpose

`SystemParametersInfo` function didn't check in the cases of `SPI_GETNONCLIENTMETRICS` and `SPI_SETNONCLIENTMETRICS` correctly.

JIRA issue: [CORE-18022](https://jira.reactos.org/browse/CORE-18022)

## Proposed changes

- Strengthen `user32_apitest` `SystemParametersInfo` testcase.
- Return `1` if `SPI_GETNONCLIENTMETRICS` is successful.
- Consider Vista-sized `NONCLIENTMETRICS`.

## TODO

- [x] Do tests.

## Screenshots
WinXP (with disabling theme):
![WinXP](https://user-images.githubusercontent.com/2107452/150784993-338fb0cf-867f-4f44-ba0f-3f41a30a209e.png)
Successful.

Win2k3:
![Win2k3](https://user-images.githubusercontent.com/2107452/150784990-416a7906-4430-47e8-97d3-9bf3526fede0.png)
Successful.

REACTOS BEFORE:
![before](https://user-images.githubusercontent.com/2107452/150788057-906beaf1-2740-411a-8f05-09c432395cd4.png)
17 failures.

REACTOS AFTER:
![after](https://user-images.githubusercontent.com/2107452/150792772-3ee921af-5ceb-43fa-991b-105c8cc90517.png)
17 failures. No change.