### PR TITLE
[ATL][GLOBAL] Enable _DEBUG globally if debugging!!!

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,7 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
 
 
     if(DBG)
-        add_definitions(-DDBG=1 -D_SEH_ENABLE_TRACE)
+        add_definitions(-DDBG=1 -D_DEBUG=1 -D_SEH_ENABLE_TRACE)
     else()
         add_definitions(-DDBG=0)
     endif()

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -1,15 +1,6 @@
 #ifndef _MSPAINT_H
 #define _MSPAINT_H
 
-#ifdef NDEBUG
-    #undef DBG
-    #undef _DEBUG
-#endif
-
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG
-#endif
-
 #include <stdarg.h>
 
 #include <windef.h>

--- a/base/applications/rapps/include/rapps.h
+++ b/base/applications/rapps/include/rapps.h
@@ -1,10 +1,6 @@
 #ifndef _RAPPS_H
 #define _RAPPS_H
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG  // CORE-17505
-#endif
-
 #include "defines.h"
 
 #include "dialogs.h"

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -9,10 +9,6 @@
 #define WIN7_COMPAT_MODE 1
 #endif
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG     // CORE-17505
-#endif
-
 #include <stdio.h>
 #include <tchar.h>
 

--- a/dll/win32/msvcrt/CMakeLists.txt
+++ b/dll/win32/msvcrt/CMakeLists.txt
@@ -14,6 +14,7 @@ if (STACK_PROTECTOR)
 endif()
 
 add_definitions(
+    -U_DEBUG
     -DUSE_MSVCRT_PREFIX
     -D_MSVCRT_
     -D_MSVCRT_LIB_

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -1,10 +1,6 @@
 #ifndef _PRECOMP_H__
 #define _PRECOMP_H__
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG  // CORE-17505
-#endif
-
 #include <stdarg.h>
 #include <assert.h>
 

--- a/drivers/CMakeLists.txt
+++ b/drivers/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 PROJECT(Drivers)
 
+add_definitions(-U_DEBUG)
+
 add_subdirectory(base)
 add_subdirectory(battery)
 add_subdirectory(bluetooth)

--- a/drivers/filesystems/btrfs/CMakeLists.txt
+++ b/drivers/filesystems/btrfs/CMakeLists.txt
@@ -70,7 +70,7 @@ if(MSVC)
     target_compile_options(btrfs PRIVATE /wd4267)
 endif()
 
-add_definitions(-D__KERNEL__ -U_DEBUG)
+add_definitions(-D__KERNEL__)
 set_module_type(btrfs kernelmodedriver)
 target_link_libraries(btrfs rtlver zlib_solo chkstk wdmguid ${PSEH_LIB})
 add_importlibs(btrfs ntoskrnl hal)

--- a/drivers/filesystems/btrfs/CMakeLists.txt
+++ b/drivers/filesystems/btrfs/CMakeLists.txt
@@ -70,7 +70,7 @@ if(MSVC)
     target_compile_options(btrfs PRIVATE /wd4267)
 endif()
 
-add_definitions(-D__KERNEL__)
+add_definitions(-D__KERNEL__ -U_DEBUG)
 set_module_type(btrfs kernelmodedriver)
 target_link_libraries(btrfs rtlver zlib_solo chkstk wdmguid ${PSEH_LIB})
 add_importlibs(btrfs ntoskrnl hal)

--- a/modules/rosapps/applications/explorer-old/CMakeLists.txt
+++ b/modules/rosapps/applications/explorer-old/CMakeLists.txt
@@ -2,6 +2,7 @@
 add_subdirectory(notifyhook)
 
 add_definitions(
+    -U_DEBUG
     -DWIN32
     -D__WINDRES__)
 

--- a/modules/rosapps/applications/sysutils/regexpl/ph.h
+++ b/modules/rosapps/applications/sysutils/regexpl/ph.h
@@ -13,10 +13,6 @@
 //#define UNICODE
 //#define _UNICODE
 
-#if DBG
-#define _DEBUG
-#endif
-
 #include <stdarg.h>
 
 #include <windef.h>

--- a/modules/rosapps/templates/dialog/trace.c
+++ b/modules/rosapps/templates/dialog/trace.c
@@ -11,9 +11,6 @@
 
 #ifdef _DEBUG
 
-#undef THIS_FILE
-static char THIS_FILE[] = __FILE__;
-
 void _DebugBreak(void)
 {
     DebugBreak();
@@ -33,14 +30,14 @@ void Trace(TCHAR* lpszFormat, ...)
     va_end(args);
 }
 
-void Assert(void* assert, TCHAR* file, int line, void* msg)
+void Assert(void* assert_, TCHAR* file, int line, void* msg)
 {
     if (msg == NULL) {
         printf("ASSERT -- %s occured on line %u of file %s.\n",
-               assert, line, file);
+               (char *)assert_, line, file);
     } else {
         printf("ASSERT -- %s occured on line %u of file %s: Message = %s.\n",
-               assert, line, file, msg);
+               (char *)assert_, line, file, (char *)msg);
     }
 }
 

--- a/modules/rostests/apitests/atl/CMakeLists.txt
+++ b/modules/rostests/apitests/atl/CMakeLists.txt
@@ -12,9 +12,6 @@ list(APPEND SOURCE
     CComQIPtr.cpp
     CComVariant.cpp
     CHeapPtrList.cpp
-    CImage.cpp
-    CPath.cpp
-    CPath.inl
     CRegKey.cpp
     CSimpleArray.cpp
     CSimpleMap.cpp
@@ -23,6 +20,8 @@ list(APPEND SOURCE
     SubclassWindow.cpp)
 
 list(APPEND PCH_SKIP_SOURCE
+    CImage.cpp
+    CPath.cpp
     testlist.c)
 
 add_executable(atl_apitest

--- a/sdk/lib/atl/atlcore.h
+++ b/sdk/lib/atl/atlcore.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <malloc.h>
-
 #ifdef __REACTOS__
     #define WIN32_NO_STATUS
     #define _INC_WINDOWS
@@ -34,9 +32,10 @@
 #else
     #include <windows.h>
 #endif
+#include <atldef.h>
 #include <ole2.h>
 #include <olectl.h>
-#include <crtdbg.h>
+#include <malloc.h>
 
 #ifndef ATLASSERT
 #define ATLASSERT(expr) _ASSERTE(expr)

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -11,11 +11,6 @@
     #error Please don't #include <crtdbg.h> before #include <atl***.h>.
 #endif
 
-#ifdef NDEBUG
-    #undef DBG
-    #undef _DEBUG
-#endif
-
 #if DBG && !defined(_DEBUG)
     #define _DEBUG
 #endif

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -7,20 +7,12 @@
 
 #pragma once
 
-#ifdef _INC_CRTDBG
-    #error Please don't #include <crtdbg.h> before #include <atl***.h>.
-#endif
-
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG
-#endif
-
-#include <crtdbg.h> // for _CrtDbgReport
-
 #ifndef __REACTOS__
     #include <cstddef>
     #include <pseh/pseh2.h>
 #endif
+
+#include <crtdbg.h>
 
 #define _ATL_PACKING 8
 

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -7,6 +7,15 @@
 
 #pragma once
 
+#ifdef NDEBUG
+    #undef DBG
+    #undef _DEBUG
+#endif
+
+#if DBG && !defined(_DEBUG)
+    #define _DEBUG
+#endif
+
 #ifndef __REACTOS__
     #include <cstddef>
     #include <pseh/pseh2.h>

--- a/sdk/lib/atl/atldef.h
+++ b/sdk/lib/atl/atldef.h
@@ -7,6 +7,10 @@
 
 #pragma once
 
+#ifdef _INC_CRTDBG
+    #error Please don't #include <crtdbg.h> before #include <atl***.h>.
+#endif
+
 #ifdef NDEBUG
     #undef DBG
     #undef _DEBUG
@@ -15,6 +19,8 @@
 #if DBG && !defined(_DEBUG)
     #define _DEBUG
 #endif
+
+#include <crtdbg.h> // for _CrtDbgReport
 
 #ifndef __REACTOS__
     #include <cstddef>

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -9,17 +9,10 @@
 
 #include "atldef.h"
 
-#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+#ifdef _DEBUG
 
 #include <stdio.h>
 #include <crtdbg.h>
-
-extern "C"
-{
-// FIXME: Enabling _DEBUG at top level causes assertion failures... CORE-17505
-int __cdecl _CrtDbgReport(int reportType, const char *filename, int linenumber, const char *moduleName, const char *format, ...);
-int __cdecl _CrtDbgReportW(int reportType, const wchar_t *filename, int linenumber, const wchar_t *moduleName, const wchar_t *format, ...);
-}
 
 namespace ATL
 {
@@ -267,10 +260,10 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 
 } // namespace ATL
 
-#endif // DBG
+#endif // def _DEBUG
 
 #ifndef ATLTRACE
-    #if DBG  // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+    #ifdef _DEBUG
         #define ATLTRACE(format, ...) ATL::AtlTraceEx(__FILE__, __LINE__, format, ##__VA_ARGS__)
     #else
         #define ATLTRACE(format, ...) ((void)0)
@@ -279,7 +272,7 @@ AtlTrace(_In_z_ _Printf_format_string_ const X_CHAR *format, ...)
 
 #define ATLTRACE2 ATLTRACE
 
-#if DBG // FIXME: We should use _DEBUG instead of DBG. CORE-17505
+#ifdef _DEBUG
     #define ATLTRACENOTIMPL(funcname) do { \
         ATLTRACE(atlTraceNotImpl, 0, #funcname " is not implemented.\n"); \
         return E_NOTIMPL; \

--- a/sdk/lib/atl/atltrace.h
+++ b/sdk/lib/atl/atltrace.h
@@ -12,7 +12,6 @@
 #ifdef _DEBUG
 
 #include <stdio.h>
-#include <crtdbg.h>
 
 namespace ATL
 {

--- a/sdk/lib/crt/CMakeLists.txt
+++ b/sdk/lib/crt/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories(include)
 #include_directories(.)
 
-add_definitions(-D_CRTBLD)
+add_definitions(-D_CRTBLD -U_DEBUG)
 
 include(conio/conio.cmake)
 include(direct/direct.cmake)


### PR DESCRIPTION
## Purpose
Improve debuggability.
JIRA issue: [CORE-17505](https://jira.reactos.org/browse/CORE-17505)

## Proposed changes

- Define `_DEBUG` globally if debugging!!!
- ATL sees `_DEBUG` and treats it correctly.
- Delete `_DEBUG` hacks.
- Undefine `_DEBUG` in `drivers`, CRT, and `explorer_old`.

## TODO

- [ ] Fix build.
- [ ] Do tests carefully.