### PR TITLE
[TASKMGR]: Fixing the pool corruption bug

### DIFF
--- a/base/applications/taskmgr/graphctl.c
+++ b/base/applications/taskmgr/graphctl.c
@@ -150,7 +150,7 @@ GraphCtrl_AddPoint(PTM_GRAPH_CONTROL inst, BYTE val0, BYTE val1)
     t = inst->PointBuffer;
     Prev0 = *(t + inst->CurrIndex);
     Prev1 = *(t + inst->CurrIndex + inst->NumberOfPoints);
-    if (inst->CurrIndex < inst->NumberOfPoints)
+    if (inst->CurrIndex < inst->NumberOfPoints - 1)
     {
         inst->CurrIndex++;
     }


### PR DESCRIPTION
 * improper adjustment of the array index in graphctl.c, introduced in PR #4141 lead to an off-by-one pool corruption. fixing this.

JIRA issue: [CORE-18015](https://jira.reactos.org/browse/CORE-18015)