### PR TITLE
[NTUSER] Implement NtUserGetAppImeLevel and NtUserSetAppImeLevel

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3084,11 +3084,11 @@ NTAPI
 NtUserSetActiveWindow(
     HWND Wnd);
 
-DWORD
+BOOL
 NTAPI
 NtUserSetAppImeLevel(
-    DWORD dwUnknown1,
-    DWORD dwUnknown2);
+    HWND hWnd,
+    DWORD dwLevel);
 
 HWND
 NTAPI

--- a/win32ss/user/ntuser/ntuser.c
+++ b/win32ss/user/ntuser/ntuser.c
@@ -25,6 +25,7 @@ ATOM AtomQOS;           // Window DDE Quality of Service atom.
 HINSTANCE hModClient = NULL;
 BOOL ClientPfnInit = FALSE;
 ATOM gaGuiConsoleWndClass;
+ATOM AtomImeLevel;
 
 /* PRIVATE FUNCTIONS **********************************************************/
 
@@ -55,6 +56,7 @@ InitUserAtoms(VOID)
 
     AtomDDETrack = IntAddGlobalAtom(L"SysDT", TRUE);
     AtomQOS      = IntAddGlobalAtom(L"SysQOS", TRUE);
+    AtomImeLevel = IntAddGlobalAtom(L"SysIMEL", TRUE);
 
     /*
      * FIXME: AddPropW uses the global kernel atom table, thus leading to conflicts if we use

--- a/win32ss/user/ntuser/ntuser.h
+++ b/win32ss/user/ntuser/ntuser.h
@@ -18,6 +18,7 @@ extern BOOL g_AlwaysDisplayVersion;
 extern ATOM gaGuiConsoleWndClass;
 extern ATOM AtomDDETrack;
 extern ATOM AtomQOS;
+extern ATOM AtomImeLevel;
 extern ERESOURCE UserLock;
 
 CODE_SEG("INIT") NTSTATUS NTAPI InitUserImpl(VOID);


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `AtomImeLevel` atom.
- Modify `NtUserSetAppImeLevel` prototype.
- Implement `NtUserGetAppImeLevel` and `NtUserSetAppImeLevel` functions.
