### PR TITLE
[USER32] Implement WM_IME_COMPOSITION of IME window

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1200,7 +1200,7 @@ typedef struct tagIMEUI
     HWND hwndIMC;
     HKL hKL;
     HWND hwndUI;
-    INT nCntInIMEProc;
+    LONG nCntInIMEProc;
     struct {
         UINT fShowStatus:1;
         UINT fActivate:1;

--- a/win32ss/user/user32/misc/imm.c
+++ b/win32ss/user/user32/misc/imm.c
@@ -183,7 +183,7 @@ static void ImeWnd_OnDestroy(PIMEUI pimeui)
 }
 
 static LRESULT
-SendImeUIMessage(PIMEUI pimeui, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL unicode)
+User32SendImeUIMessage(PIMEUI pimeui, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL unicode)
 {
     LRESULT ret = 0;
     HWND hwndUI = pimeui->hwndUI;
@@ -306,7 +306,7 @@ LRESULT WINAPI ImeWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lPa
         case WM_IME_STARTCOMPOSITION:
         case WM_IME_COMPOSITION:
         case WM_IME_ENDCOMPOSITION:
-            return SendImeUIMessage(pimeui, msg, wParam, lParam, unicode);
+            return User32SendImeUIMessage(pimeui, msg, wParam, lParam, unicode);
 
         case WM_IME_CONTROL:
             // TODO:


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `User32SendImeUIMessage` helper function.
- Implement `WM_IME_STARTCOMPOSITION`, `WM_IME_COMPOSITION`, `WM_IME_ENDCOMPOSITION` message handling of the IME window.