### PR TITLE
[USER32] Implement WM_IME_SELECT and WM_IME_COMPOSITION of IME window

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1200,7 +1200,7 @@ typedef struct tagIMEUI
     HWND hwndIMC;
     HKL hKL;
     HWND hwndUI;
-    INT nCntInIMEProc;
+    LONG nCntInIMEProc;
     struct {
         UINT fShowStatus:1;
         UINT fActivate:1;


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `User32CreateImeUIWindow`, `User32GetImeShowStatus`, `User32SendImeUIMessage`, `User32UpdateImcOfImeUI`, `User32SetImeWindowOfImc` and `User32NotifyOpenStatus` helper functions.
- Add `WM_IME_SELECT`, `WM_IME_COMPOSITION`, `WM_IME_STARTCOMPOSITION` and `WM_IME_ENDCOMPOSITION` message handling of the IME window.
- Rename `ImeWnd_OnDestroy` as `User32DestroyImeUIWindow`.
- Rename `CheckIMCForWindow` as `User32CanSetImeWindowToImc`.
- Improve `ImeWnd_OnCreate` function.