### PR TITLE
[NTUSER] Implement GetSystemMetrics.SM_DBCSENABLED

### DIFF
--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -197,6 +197,9 @@ UserGetSystemMetrics(ULONG Index)
     ASSERT(Setup);
     TRACE("UserGetSystemMetrics(%lu)\n", Index);
 
+    if (Index == SM_DBCSENABLED)
+        return UserIsDBCSEnabled();
+
     /* Get metrics from array */
     if (Index < SM_CMETRICS)
     {
@@ -219,6 +222,5 @@ UserGetSystemMetrics(ULONG Index)
     ERR("UserGetSystemMetrics() called with invalid index %lu\n", Index);
     return 0;
 }
-
 
 /* EOF */

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -14,6 +14,20 @@ static BOOL Setup = FALSE;
 
 /* FUNCTIONS *****************************************************************/
 
+BOOL APIENTRY UserIsDBCSEnabled(VOID)
+{
+    switch (PRIMARYLANGID(gusLanguageID))
+    {
+        case LANG_CHINESE:
+        case LANG_JAPANESE:
+        case LANG_KOREAN:
+            return TRUE;
+
+        default:
+            return FALSE;
+    }
+}
+
 BOOL
 NTAPI
 InitMetrics(VOID)
@@ -150,7 +164,7 @@ InitMetrics(VOID)
     piSysMet[SM_NETWORK] = 3;
     piSysMet[SM_SLOWMACHINE] = 0;
     piSysMet[SM_SECURE] = 0;
-    piSysMet[SM_DBCSENABLED] = 0;
+    piSysMet[SM_DBCSENABLED] = UserIsDBCSEnabled();
     piSysMet[SM_SHOWSOUNDS] = gspv.bShowSounds;
     piSysMet[SM_MIDEASTENABLED] = 0;
     piSysMet[SM_CMONITORS] = 1;

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -21,6 +21,7 @@ BOOL APIENTRY UserIsDBCSEnabled(VOID)
         case LANG_CHINESE:
         case LANG_JAPANESE:
         case LANG_KOREAN:
+        //case LANG_VIETNAMESE: // Are you using double-byte character strings?
             return TRUE;
 
         default:


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `UserIsDBCSEnabled` helper function.
- Support `SM_DBCSENABLED` value of `GetSystemMetrics` function.

## Screenshots

WinXP (Japanese):
![WinXP](https://user-images.githubusercontent.com/2107452/151284417-590fad8d-315f-4385-9b85-5d327d4c772c.png)

Win2k3 (English):
![Win2k3](https://user-images.githubusercontent.com/2107452/151284423-6d7a799f-8899-4295-8e94-7548de4ddf15.png)

ReactOS (English):
![SBCS](https://user-images.githubusercontent.com/2107452/151284414-f271cbcd-c6d9-4833-b1ca-6d5ea97608ba.png)

ReactOS (Japanese):
![DBCS](https://user-images.githubusercontent.com/2107452/151284426-2373b464-9ed6-44c3-b5a6-8ec28609748c.png)