### PR TITLE
[TASKMGR] Don't set "Always On Top" option by default

### DIFF
--- a/base/applications/taskmgr/taskmgr.c
+++ b/base/applications/taskmgr/taskmgr.c
@@ -863,7 +863,7 @@ void LoadSettings(void)
     TaskManagerSettings.ActiveTabPage = 0;
 
     /* Options menu settings */
-    TaskManagerSettings.AlwaysOnTop = TRUE;
+    TaskManagerSettings.AlwaysOnTop = FALSE;
     TaskManagerSettings.MinimizeOnUse = TRUE;
     TaskManagerSettings.HideWhenMinimized = FALSE;
     TaskManagerSettings.Show16BitTasks = TRUE;


### PR DESCRIPTION
## Purpose

- Don't set "Always On Top" option by default, like Windows does.