### PR TITLE
[MSPAINT] Improve Undo/Redo and finishing tool

### DIFF
--- a/base/applications/mspaint/history.h
+++ b/base/applications/mspaint/history.h
@@ -26,7 +26,7 @@ private:
 public:
     ImageModel();
     void CopyPrevious(void);
-    void Undo(void);
+    void Undo(BOOL bClearRedo = FALSE);
     void Redo(void);
     void ResetToPrevious(void);
     void ClearHistory(void);
@@ -45,4 +45,7 @@ public:
     void FlipHorizontally();
     void FlipVertically();
     void RotateNTimes90Degrees(int iN);
+    void DrawSelectionBackground(COLORREF rgbBG);
+    void DeleteSelection();
+    void Bound(POINT& pt);
 };

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -259,7 +259,7 @@ LRESULT CImgAreaWindow::OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL&
         }
         else
         {
-            if (drawing || ToolBase::pointSP != 0)
+            if (drawing || ToolBase::pointSP != 0 || selectionWindow.IsWindowVisible())
                 cancelDrawing();
         }
     }
@@ -410,4 +410,11 @@ LRESULT CImgAreaWindow::OnCtlColorEdit(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     HDC hdc = (HDC)wParam;
     SetBkMode(hdc, TRANSPARENT);
     return (LRESULT)GetStockObject(NULL_BRUSH);
+}
+
+void CImgAreaWindow::finishDrawing()
+{
+    toolsModel.OnFinishDraw();
+    drawing = FALSE;
+    Invalidate(FALSE);
 }

--- a/base/applications/mspaint/imgarea.h
+++ b/base/applications/mspaint/imgarea.h
@@ -17,6 +17,10 @@ public:
     {
     }
 
+    BOOL drawing;
+    void cancelDrawing();
+    void finishDrawing();
+
     DECLARE_WND_CLASS_EX(_T("ImgAreaWindow"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CImgAreaWindow)
@@ -40,8 +44,6 @@ public:
         MESSAGE_HANDLER(WM_CTLCOLOREDIT, OnCtlColorEdit)
     END_MSG_MAP()
 
-    BOOL drawing;
-
 private:
     LRESULT OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnEraseBkGnd(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
@@ -63,5 +65,4 @@ private:
     LRESULT OnCtlColorEdit(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
     void drawZoomFrame(int mouseX, int mouseY);
-    void cancelDrawing();
 };

--- a/base/applications/mspaint/mouse.cpp
+++ b/base/applications/mspaint/mouse.cpp
@@ -76,9 +76,18 @@ void updateLast(LONG x, LONG y)
 void ToolBase::reset()
 {
     pointSP = 0;
+    start.x = start.y = last.x = last.y = -1;
+    selectionModel.ResetPtStack();
+    if (selectionWindow.IsWindow())
+        selectionWindow.ShowWindow(SW_HIDE);
 }
 
 void ToolBase::OnCancelDraw()
+{
+    reset();
+}
+
+void ToolBase::OnFinishDraw()
 {
     reset();
 }
@@ -100,48 +109,75 @@ void ToolBase::endEvent()
 // TOOL_FREESEL
 struct FreeSelTool : ToolBase
 {
-    FreeSelTool() : ToolBase(TOOL_FREESEL)
+    BOOL m_bLeftButton;
+
+    FreeSelTool() : ToolBase(TOOL_FREESEL), m_bLeftButton(FALSE)
     {
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
     {
-        imageModel.CopyPrevious();
-        selectionWindow.ShowWindow(SW_HIDE);
-        selectionModel.ResetPtStack();
-        selectionModel.PushToPtStack(x, y);
+        if (bLeftButton)
+        {
+            imageModel.CopyPrevious();
+            selectionWindow.ShowWindow(SW_HIDE);
+            selectionModel.ResetPtStack();
+            selectionModel.PushToPtStack(x, y);
+        }
+        m_bLeftButton = bLeftButton;
     }
 
     void OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
     {
-        if (selectionModel.PtStackSize() == 1)
-            imageModel.CopyPrevious();
-        selectionModel.PushToPtStack(max(0, min(x, imageModel.GetWidth())), max(0, min(y, imageModel.GetHeight())));
-        imageModel.ResetToPrevious();
-        selectionModel.DrawFramePoly(m_hdc);
+        if (bLeftButton)
+        {
+            POINT pt = { x, y };
+            imageModel.Bound(pt);
+            selectionModel.PushToPtStack(pt.x, pt.y);
+            imageModel.ResetToPrevious();
+            selectionModel.DrawFramePoly(m_hdc);
+        }
     }
 
     void OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
     {
-        selectionModel.CalculateBoundingBoxAndContents(m_hdc);
-        if (selectionModel.PtStackSize() > 1)
+        if (bLeftButton)
         {
-            selectionModel.DrawBackgroundPoly(m_hdc, m_bg);
-            imageModel.CopyPrevious();
-
-            selectionModel.DrawSelection(m_hdc);
-
-            placeSelWin();
-            selectionWindow.ShowWindow(SW_SHOW);
-            ForceRefreshSelectionContents();
+            imageModel.ResetToPrevious();
+            if (selectionModel.PtStackSize() > 2)
+            {
+                selectionModel.CalculateBoundingBoxAndContents(m_hdc);
+                placeSelWin();
+                selectionWindow.IsMoved(FALSE);
+                selectionWindow.ShowWindow(SW_SHOWNOACTIVATE);
+            }
+            else
+            {
+                imageModel.Undo(TRUE);
+                selectionWindow.IsMoved(FALSE);
+                selectionModel.ResetPtStack();
+                selectionWindow.ShowWindow(SW_HIDE);
+            }
         }
-        selectionModel.ResetPtStack();
+    }
+
+    void OnFinishDraw()
+    {
+        if (m_bLeftButton)
+        {
+            selectionWindow.IsMoved(FALSE);
+            selectionWindow.ForceRefreshSelectionContents();
+        }
+        m_bLeftButton = FALSE;
+        ToolBase::OnFinishDraw();
     }
 
     void OnCancelDraw()
     {
-        imageModel.ResetToPrevious();
-        selectionModel.ResetPtStack();
+        if (m_bLeftButton)
+            imageModel.Undo(TRUE);
+        m_bLeftButton = FALSE;
+        selectionWindow.IsMoved(FALSE);
         ToolBase::OnCancelDraw();
     }
 };
@@ -149,31 +185,32 @@ struct FreeSelTool : ToolBase
 // TOOL_RECTSEL
 struct RectSelTool : ToolBase
 {
-    RectSelTool() : ToolBase(TOOL_RECTSEL)
+    BOOL m_bLeftButton;
+
+    RectSelTool() : ToolBase(TOOL_RECTSEL), m_bLeftButton(FALSE)
     {
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
     {
-        imageModel.CopyPrevious();
         if (bLeftButton)
         {
             imageModel.CopyPrevious();
             selectionWindow.ShowWindow(SW_HIDE);
             selectionModel.SetSrcRectSizeToZero();
         }
+        m_bLeftButton = bLeftButton;
     }
 
     void OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
     {
-        POINT temp;
         if (bLeftButton)
         {
             imageModel.ResetToPrevious();
-            temp.x = max(0, min(x, imageModel.GetWidth()));
-            temp.y = max(0, min(y, imageModel.GetHeight()));
-            selectionModel.SetSrcAndDestRectFromPoints(start, temp);
-            RectSel(m_hdc, start.x, start.y, temp.x, temp.y);
+            POINT pt = { x, y };
+            imageModel.Bound(pt);
+            selectionModel.SetSrcAndDestRectFromPoints(start, pt);
+            RectSel(m_hdc, start.x, start.y, pt.x, pt.y);
         }
     }
 
@@ -182,25 +219,35 @@ struct RectSelTool : ToolBase
         if (bLeftButton)
         {
             imageModel.ResetToPrevious();
+            if (start.x == x && start.y == y)
+                imageModel.Undo(TRUE);
+            selectionModel.CalculateContents(m_hdc);
+            placeSelWin();
+            selectionWindow.IsMoved(FALSE);
             if (selectionModel.IsSrcRectSizeNonzero())
-            {
-                selectionModel.CalculateContents(m_hdc);
-                selectionModel.DrawBackgroundRect(m_hdc, m_bg);
-                imageModel.CopyPrevious();
-
-                selectionModel.DrawSelection(m_hdc);
-
-                placeSelWin();
-                selectionWindow.ShowWindow(SW_SHOW);
-                ForceRefreshSelectionContents();
-            }
+                selectionWindow.ShowWindow(SW_SHOWNOACTIVATE);
+            else
+                selectionWindow.ShowWindow(SW_HIDE);
         }
+    }
+
+    void OnFinishDraw()
+    {
+        if (m_bLeftButton)
+        {
+            selectionWindow.IsMoved(FALSE);
+            selectionWindow.ForceRefreshSelectionContents();
+        }
+        m_bLeftButton = FALSE;
+        ToolBase::OnFinishDraw();
     }
 
     void OnCancelDraw()
     {
-        imageModel.ResetToPrevious();
-        selectionModel.ResetPtStack();
+        if (m_bLeftButton)
+            imageModel.Undo(TRUE);
+        m_bLeftButton = FALSE;
+        selectionWindow.IsMoved(FALSE);
         ToolBase::OnCancelDraw();
     }
 };
@@ -232,8 +279,7 @@ struct GenericDrawTool : ToolBase
     void OnCancelDraw()
     {
         OnButtonUp(FALSE, 0, 0);
-        imageModel.Undo();
-        selectionModel.ResetPtStack();
+        imageModel.Undo(TRUE);
         ToolBase::OnCancelDraw();
     }
 };
@@ -275,20 +321,29 @@ struct ColorTool : ToolBase
     {
     }
 
-    void OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
+    void fetchColor(BOOL bLeftButton, LONG x, LONG y)
     {
-        COLORREF tempColor;
+        COLORREF rgbColor;
 
         if (0 <= x && x < imageModel.GetWidth() && 0 <= y && y < imageModel.GetHeight())
-            tempColor = GetPixel(m_hdc, x, y);
+            rgbColor = GetPixel(m_hdc, x, y);
         else
-            tempColor = RGB(255, 255, 255); // Outside is white
+            rgbColor = RGB(255, 255, 255); // Outside is white
 
         if (bLeftButton)
-            paletteModel.SetFgColor(tempColor);
+            paletteModel.SetFgColor(rgbColor);
         else
-            paletteModel.SetBgColor(tempColor);
+            paletteModel.SetBgColor(rgbColor);
+    }
 
+    void OnMouseMove(BOOL bLeftButton, LONG x, LONG y)
+    {
+        fetchColor(bLeftButton, x, y);
+    }
+
+    void OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
+    {
+        fetchColor(bLeftButton, x, y);
         toolsModel.SetActiveTool(toolsModel.GetOldActiveTool());
     }
 };
@@ -368,12 +423,11 @@ struct TextTool : ToolBase
 
     void UpdatePoint(LONG x, LONG y)
     {
-        POINT temp;
         imageModel.ResetToPrevious();
-        temp.x = max(0, min(x, imageModel.GetWidth()));
-        temp.y = max(0, min(y, imageModel.GetHeight()));
-        selectionModel.SetSrcAndDestRectFromPoints(start, temp);
-        RectSel(m_hdc, start.x, start.y, temp.x, temp.y);
+        POINT pt = { x, y };
+        imageModel.Bound(pt);
+        selectionModel.SetSrcAndDestRectFromPoints(start, pt);
+        RectSel(m_hdc, start.x, start.y, pt.x, pt.y);
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
@@ -392,7 +446,7 @@ struct TextTool : ToolBase
 
     void OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
     {
-        imageModel.ResetToPrevious();
+        imageModel.Undo(TRUE);
 
         BOOL bTextBoxShown = ::IsWindowVisible(textEditWindow);
         if (bTextBoxShown && textEditWindow.GetWindowTextLength() > 0)
@@ -405,6 +459,7 @@ struct TextTool : ToolBase
             textEditWindow.GetEditRect(&rc);
 
             INT style = (toolsModel.IsBackgroundTransparent() ? 0 : 1);
+            imageModel.CopyPrevious();
             Text(m_hdc, rc.left, rc.top, rc.right, rc.bottom, m_fg, m_bg, szText,
                  textEditWindow.GetFont(), style);
         }
@@ -451,13 +506,12 @@ struct TextTool : ToolBase
         }
     }
 
-    void OnCancelDraw()
+    void OnFinishDraw()
     {
-        imageModel.ResetToPrevious();
-        selectionModel.ResetPtStack();
-        textEditWindow.SetWindowText(NULL);
-        textEditWindow.ShowWindow(SW_HIDE);
-        ToolBase::OnCancelDraw();
+        toolsModel.OnButtonDown(TRUE, -1, -1, TRUE);
+        toolsModel.OnButtonUp(TRUE, -1, -1);
+        selectionWindow.IsMoved(FALSE);
+        ToolBase::OnFinishDraw();
     }
 };
 
@@ -481,7 +535,9 @@ struct LineTool : GenericDrawTool
 // TOOL_BEZIER
 struct BezierTool : ToolBase
 {
-    BezierTool() : ToolBase(TOOL_BEZIER)
+    BOOL m_bLeftButton;
+
+    BezierTool() : ToolBase(TOOL_BEZIER), m_bLeftButton(FALSE)
     {
     }
 
@@ -501,6 +557,7 @@ struct BezierTool : ToolBase
                 Bezier(m_hdc, pointStack[0], pointStack[2], pointStack[3], pointStack[1], rgb, toolsModel.GetLineWidth());
                 break;
         }
+        m_bLeftButton = bLeftButton;
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
@@ -535,9 +592,19 @@ struct BezierTool : ToolBase
     void OnCancelDraw()
     {
         OnButtonUp(FALSE, 0, 0);
-        imageModel.Undo();
-        selectionModel.ResetPtStack();
+        imageModel.Undo(TRUE);
         ToolBase::OnCancelDraw();
+    }
+
+    void OnFinishDraw()
+    {
+        if (pointSP)
+        {
+            imageModel.ResetToPrevious();
+            --pointSP;
+            draw(m_bLeftButton);
+        }
+        ToolBase::OnFinishDraw();
     }
 };
 
@@ -563,7 +630,9 @@ struct RectTool : GenericDrawTool
 // TOOL_SHAPE
 struct ShapeTool : ToolBase
 {
-    ShapeTool() : ToolBase(TOOL_SHAPE)
+    BOOL m_bLeftButton;
+
+    ShapeTool() : ToolBase(TOOL_SHAPE), m_bLeftButton(FALSE)
     {
     }
 
@@ -576,6 +645,7 @@ struct ShapeTool : ToolBase
             else
                 Poly(m_hdc, pointStack, pointSP + 1, m_bg, m_fg, toolsModel.GetLineWidth(), toolsModel.GetShapeStyle(), bClosed, FALSE);
         }
+        m_bLeftButton = bLeftButton;
     }
 
     void OnButtonDown(BOOL bLeftButton, LONG x, LONG y, BOOL bDoubleClick)
@@ -631,9 +701,24 @@ struct ShapeTool : ToolBase
 
     void OnCancelDraw()
     {
-        imageModel.ResetToPrevious();
-        selectionModel.ResetPtStack();
+        imageModel.Undo(TRUE);
         ToolBase::OnCancelDraw();
+    }
+
+    void OnFinishDraw()
+    {
+        if (pointSP)
+        {
+            imageModel.ResetToPrevious();
+            --pointSP;
+            draw(m_bLeftButton, -1, -1, TRUE);
+            pointSP = 0;
+        }
+        else
+        {
+            imageModel.Undo(TRUE);
+        }
+        ToolBase::OnFinishDraw();
     }
 };
 

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -19,9 +19,9 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
     HBRUSH oldBrush;
     int i, a, b;
 
-    DefWindowProc(WM_PAINT, wParam, lParam);
+    PAINTSTRUCT ps;
+    HDC hDC = BeginPaint(&ps);
 
-    HDC hDC = GetDC();
     for(b = 2; b < 30; b++)
         for(a = 2; a < 29; a++)
             if ((a + b) % 2 == 1)
@@ -54,7 +54,7 @@ LRESULT CPaletteWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& b
         DeleteObject(SelectObject(hDC, oldBrush));
         DeleteObject(SelectObject(hDC, oldPen));
     }
-    ReleaseDC(hDC);
+    EndPaint(&ps);
     return 0;
 }
 

--- a/base/applications/mspaint/selection.h
+++ b/base/applications/mspaint/selection.h
@@ -12,6 +12,15 @@
 class CSelectionWindow : public CWindowImpl<CSelectionWindow>
 {
 public:
+    CSelectionWindow() : m_bMoved(FALSE)
+    {
+    }
+
+    BOOL IsMoved() const        { return m_bMoved; }
+    void IsMoved(BOOL bMoved)   { m_bMoved = bMoved; }
+
+    void ForceRefreshSelectionContents();
+
     DECLARE_WND_CLASS_EX(_T("Selection"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CSelectionWindow)
@@ -24,6 +33,7 @@ public:
         MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
         MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel)
         MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
+        MESSAGE_HANDLER(WM_MOVE, OnMove)
         MESSAGE_HANDLER(WM_PALETTEMODELCOLORCHANGED, OnPaletteModelColorChanged)
         MESSAGE_HANDLER(WM_TOOLSMODELSETTINGSCHANGED, OnToolsModelSettingsChanged)
         MESSAGE_HANDLER(WM_TOOLSMODELZOOMCHANGED, OnToolsModelZoomChanged)
@@ -47,14 +57,17 @@ public:
     LRESULT OnSelectionModelRefreshNeeded(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnCaptureChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnKeyDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 
 private:
     static const LPCTSTR m_lpszCursorLUT[9];
+    BOOL m_bMoved;
     BOOL m_bMoving;
     int m_iAction;
     POINT m_ptPos;
     POINT m_ptFrac;
     POINT m_ptDelta;
+    COLORREF m_rgbBack;
 
     int IdentifyCorner(int iXPos, int iYPos, int iWidth, int iHeight);
 };

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -337,11 +337,6 @@ LONG SelectionModel::GetDestRectTop() const
     return m_rcDest.top;
 }
 
-void SelectionModel::DrawTextToolText(HDC hDCImage, COLORREF crFg, COLORREF crBg, BOOL bBgTransparent)
-{
-    Text(hDCImage, m_rcDest.left, m_rcDest.top, m_rcDest.right, m_rcDest.bottom, crFg, crBg, textToolText, hfontTextFont, bBgTransparent);
-}
-
 void SelectionModel::NotifyRefreshNeeded()
 {
     selectionWindow.SendMessage(WM_SELECTIONMODELREFRESHNEEDED);

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -66,7 +66,6 @@ public:
     LONG GetDestRectLeft() const;
     LONG GetDestRectTop() const;
     void GetRect(LPRECT prc) const;
-    void DrawTextToolText(HDC hDCImage, COLORREF crFg, COLORREF crBg, BOOL bBgTransparent = FALSE);
 
 private:
     SelectionModel(const SelectionModel&);

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -33,12 +33,11 @@ LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, 
 
 LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    PAINTSTRUCT ps;
     RECT rect1 = { 0, 0, 42, 66 };
     RECT rect2 = { 0, 70, 42, 136 };
 
-    DefWindowProc(WM_PAINT, wParam, lParam);
-
-    HDC hdc = GetDC();
+    HDC hdc = BeginPaint(&ps);
     DrawEdge(hdc, &rect1, BDR_SUNKENOUTER, (toolsModel.GetActiveTool() == TOOL_ZOOM) ? BF_RECT : BF_RECT | BF_MIDDLE);
     DrawEdge(hdc, &rect2, (toolsModel.GetActiveTool() >= TOOL_RECT) ? BDR_SUNKENOUTER : 0, BF_RECT | BF_MIDDLE);
     switch (toolsModel.GetActiveTool())
@@ -181,7 +180,7 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
         case TOOL_PEN:
             break;
     }
-    ReleaseDC(hdc);
+    EndPaint(&ps);
     return 0;
 }
 

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -85,6 +85,11 @@ TOOLTYPE ToolsModel::GetOldActiveTool() const
 
 void ToolsModel::SetActiveTool(TOOLTYPE nActiveTool)
 {
+    OnFinishDraw();
+
+    if (m_activeTool == nActiveTool)
+        return;
+
     switch (m_activeTool)
     {
         case TOOL_FREESEL:
@@ -92,15 +97,7 @@ void ToolsModel::SetActiveTool(TOOLTYPE nActiveTool)
         case TOOL_RUBBER:
         case TOOL_COLOR:
         case TOOL_ZOOM:
-            break;
-
         case TOOL_TEXT:
-            if (nActiveTool != TOOL_TEXT)
-            {
-                // Finish the text
-                OnButtonDown(TRUE, -1, -1, TRUE);
-                OnButtonUp(TRUE, -1, -1);
-            }
             break;
 
         default:
@@ -171,15 +168,18 @@ void ToolsModel::NotifyToolChanged()
 
 void ToolsModel::NotifyToolSettingsChanged()
 {
-    toolSettingsWindow.SendMessage(WM_TOOLSMODELSETTINGSCHANGED);
-    selectionWindow.SendMessage(WM_TOOLSMODELSETTINGSCHANGED);
+    if (toolSettingsWindow.IsWindow())
+        toolSettingsWindow.SendMessage(WM_TOOLSMODELSETTINGSCHANGED);
+    if (selectionWindow.IsWindow())
+        selectionWindow.SendMessage(WM_TOOLSMODELSETTINGSCHANGED);
     if (textEditWindow.IsWindow())
         textEditWindow.SendMessage(WM_TOOLSMODELSETTINGSCHANGED);
 }
 
 void ToolsModel::NotifyZoomChanged()
 {
-    toolSettingsWindow.SendMessage(WM_TOOLSMODELZOOMCHANGED);
+    if (toolSettingsWindow.IsWindow())
+        toolSettingsWindow.SendMessage(WM_TOOLSMODELZOOMCHANGED);
     if (textEditWindow.IsWindow())
         textEditWindow.SendMessage(WM_TOOLSMODELZOOMCHANGED);
     if (selectionWindow.IsWindow())
@@ -212,8 +212,17 @@ void ToolsModel::OnButtonUp(BOOL bLeftButton, LONG x, LONG y)
 
 void ToolsModel::OnCancelDraw()
 {
+    ATLTRACE("ToolsModel::OnCancelDraw()\n");
     m_pToolObject->beginEvent();
     m_pToolObject->OnCancelDraw();
+    m_pToolObject->endEvent();
+}
+
+void ToolsModel::OnFinishDraw()
+{
+    ATLTRACE("ToolsModel::OnFinishDraw()\n");
+    m_pToolObject->beginEvent();
+    m_pToolObject->OnFinishDraw();
     m_pToolObject->endEvent();
 }
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -60,6 +60,7 @@ struct ToolBase
     }
 
     virtual void OnCancelDraw();
+    virtual void OnFinishDraw();
 
     void beginEvent();
     void endEvent();
@@ -110,6 +111,7 @@ public:
     void OnMouseMove(BOOL bLeftButton, LONG x, LONG y);
     void OnButtonUp(BOOL bLeftButton, LONG x, LONG y);
     void OnCancelDraw();
+    void OnFinishDraw();
 
     void resetTool();
     void selectAll();

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -89,6 +89,8 @@ void CMainWindow::alignChildrenToMainWindow()
 
 void CMainWindow::saveImage(BOOL overwrite)
 {
+    imageArea.finishDrawing();
+
     if (isAFile && overwrite)
     {
         imageModel.SaveImage(filepathname);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -240,6 +240,8 @@ LRESULT CMainWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
 
 BOOL CMainWindow::ConfirmSave()
 {
+    imageArea.finishDrawing();
+
     if (imageModel.IsImageSaved())
         return TRUE;
 


### PR DESCRIPTION
## Purpose
Fix and improve mspaint UI/UX.
JIRA issue: [CORE-17969](https://jira.reactos.org/browse/CORE-17969)

## Proposed changes

- Fix Undo/Redo mechanism.
- Finish drawing when the tool is to be chanaged and when the file is to be saved.
- Add `ToolBase::OnFinishDraw` to virtualize finishing drawing.
- Extend `bClearRedo` parameter to `ImageModel::Undo`.
- Add `ImageModel::DrawSelectionBackground` and `ImageModel::DeleteSelection` methods.
- Fix some `WM_PAINT` message handling.

## TODO

- [x] Do tests.
