### PR TITLE
[USER32] Don't delay-load-link to imm32.dll

### DIFF
--- a/win32ss/user/user32/CMakeLists.txt
+++ b/win32ss/user/user32/CMakeLists.txt
@@ -87,7 +87,7 @@ if(MSVC AND (ARCH STREQUAL "i386"))
     target_sources(user32 PRIVATE $<TARGET_OBJECTS:ftol2_sse>)
 endif()
 
-add_delay_importlibs(user32 imm32 usp10)
+add_delay_importlibs(user32 usp10)
 add_importlibs(user32 gdi32 advapi32 kernel32 ntdll)
 add_pch(user32 include/user32.h SOURCE)
 add_cd_file(TARGET user32 DESTINATION reactos/system32 FOR all)

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -45,6 +45,11 @@
 #include <user32.h>
 #define WIN32_LEAN_AND_MEAN
 #include <usp10.h>
+#ifdef __REACTOS__
+#define ImmGetContext               IMM_FN(ImmGetContext)
+#define ImmGetCompositionStringW    IMM_FN(ImmGetCompositionStringW)
+#define ImmReleaseContext           IMM_FN(ImmReleaseContext)
+#endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(edit);
 WINE_DECLARE_DEBUG_CHANNEL(combo);

--- a/win32ss/user/user32/windows/defwnd.c
+++ b/win32ss/user/user32/windows/defwnd.c
@@ -951,16 +951,16 @@ RealDefWindowProcA(HWND hWnd,
             LONG size, i;
             unsigned char lead = 0;
             char *buf = NULL;
-            HIMC himc = ImmGetContext( hWnd );
+            HIMC himc = IMM_FN(ImmGetContext)( hWnd );
 
             if (himc)
             {
-                if ((size = ImmGetCompositionStringA( himc, GCS_RESULTSTR, NULL, 0 )))
+                if ((size = IMM_FN(ImmGetCompositionStringA)( himc, GCS_RESULTSTR, NULL, 0 )))
                 {
                     if (!(buf = HeapAlloc( GetProcessHeap(), 0, size ))) size = 0;
-                    else size = ImmGetCompositionStringA( himc, GCS_RESULTSTR, buf, size );
+                    else size = IMM_FN(ImmGetCompositionStringA)( himc, GCS_RESULTSTR, buf, size );
                 }
-                ImmReleaseContext( hWnd, himc );
+                IMM_FN(ImmReleaseContext)( hWnd, himc );
 
                 for (i = 0; i < size; i++)
                 {
@@ -990,7 +990,7 @@ RealDefWindowProcA(HWND hWnd,
         {
             HWND hwndIME;
 
-            hwndIME = ImmGetDefaultIMEWnd(hWnd);
+            hwndIME = IMM_FN(ImmGetDefaultIMEWnd)(hWnd);
             if (hwndIME)
                 Result = SendMessageA(hwndIME, Msg, wParam, lParam);
             break;
@@ -1000,9 +1000,9 @@ RealDefWindowProcA(HWND hWnd,
         {
             HWND hwndIME;
 
-            hwndIME = ImmGetDefaultIMEWnd(hWnd);
+            hwndIME = IMM_FN(ImmGetDefaultIMEWnd)(hWnd);
             if (hwndIME)
-                Result = ImmIsUIMessageA(hwndIME, Msg, wParam, lParam);
+                Result = SendMessageA(hwndIME, Msg, wParam, lParam);
             break;
         }
 
@@ -1150,16 +1150,16 @@ RealDefWindowProcW(HWND hWnd,
         {
             LONG size, i;
             WCHAR *buf = NULL;
-            HIMC himc = ImmGetContext( hWnd );
+            HIMC himc = IMM_FN(ImmGetContext)( hWnd );
 
             if (himc)
             {
-                if ((size = ImmGetCompositionStringW( himc, GCS_RESULTSTR, NULL, 0 )))
+                if ((size = IMM_FN(ImmGetCompositionStringW)( himc, GCS_RESULTSTR, NULL, 0 )))
                 {
                     if (!(buf = HeapAlloc( GetProcessHeap(), 0, size * sizeof(WCHAR) ))) size = 0;
-                    else size = ImmGetCompositionStringW( himc, GCS_RESULTSTR, buf, size * sizeof(WCHAR) );
+                    else size = IMM_FN(ImmGetCompositionStringW)( himc, GCS_RESULTSTR, buf, size * sizeof(WCHAR) );
                 }
-                ImmReleaseContext( hWnd, himc );
+                IMM_FN(ImmReleaseContext)( hWnd, himc );
 
                 for (i = 0; i < size / sizeof(WCHAR); i++)
                     SendMessageW( hWnd, WM_IME_CHAR, buf[i], 1 );
@@ -1175,7 +1175,7 @@ RealDefWindowProcW(HWND hWnd,
         {
             HWND hwndIME;
 
-            hwndIME = ImmGetDefaultIMEWnd(hWnd);
+            hwndIME = IMM_FN(ImmGetDefaultIMEWnd)(hWnd);
             if (hwndIME)
                 Result = SendMessageW(hwndIME, Msg, wParam, lParam);
             break;
@@ -1185,9 +1185,9 @@ RealDefWindowProcW(HWND hWnd,
         {
             HWND hwndIME;
 
-            hwndIME = ImmGetDefaultIMEWnd(hWnd);
+            hwndIME = IMM_FN(ImmGetDefaultIMEWnd)(hWnd);
             if (hwndIME)
-                Result = ImmIsUIMessageW(hwndIME, Msg, wParam, lParam);
+                Result = SendMessageW(hwndIME, Msg, wParam, lParam);
             break;
         }
 


### PR DESCRIPTION
## Purpose
Reduce binary size.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Don't directly call the `IMM32` functions. Use `IMM_FN` instead.
- Modify `CMakeLists.txt` to unlink `imm32.dll`.

## Comparison
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/151722622-ffe98434-d03f-4642-9c23-f65b937297e4.png)
1,553,920 bytes.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/151722598-5adfb70a-f7f7-40cf-be47-e1bfc1a2ff06.png)
1,552,384 bytes.

`1,552,384 - 1,553,920 == -1536 bytes.`