### PR TITLE
[REACTOS] RtlCreateTagHeap() and HeapCreateTagsW(): Fix types and annotations

### DIFF
--- a/dll/ntdll/def/ntdll.spec
+++ b/dll/ntdll/def/ntdll.spec
@@ -728,7 +728,7 @@
 @ stdcall RtlCreateSecurityDescriptor(ptr long)
 @ stdcall RtlCreateServiceSid(ptr ptr ptr) # Exists in Windows 2003 SP 2
 @ stdcall RtlCreateSystemVolumeInformationFolder(ptr)
-@ stdcall RtlCreateTagHeap(ptr long str str)
+@ stdcall RtlCreateTagHeap(ptr long wstr wstr)
 @ stdcall RtlCreateTimer(ptr ptr ptr ptr long long long)
 @ stdcall RtlCreateTimerQueue(ptr)
 @ stdcall RtlCreateUnicodeString(ptr wstr)

--- a/dll/win32/kernel32/client/heapmem.c
+++ b/dll/win32/kernel32/client/heapmem.c
@@ -166,10 +166,10 @@ HeapValidate(HANDLE hHeap,
  */
 DWORD
 WINAPI
-HeapCreateTagsW(HANDLE hHeap,
-                DWORD dwFlags,
-                PWSTR lpTagName,
-                PWSTR lpTagSubName)
+HeapCreateTagsW(_In_ HANDLE hHeap,
+                _In_ DWORD dwFlags,
+                _In_opt_ PWSTR lpTagName,
+                _In_ PWSTR lpTagSubName)
 {
     /* Call the RTL API */
     return RtlCreateTagHeap(hHeap,

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -688,7 +688,7 @@
 @ stdcall HeapAlloc(long long long) ntdll.RtlAllocateHeap
 @ stdcall HeapCompact(long long)
 @ stdcall HeapCreate(long long long)
-@ stdcall -version=0x351-0x502 HeapCreateTagsW(long long wstr wstr)
+@ stdcall -version=0x351-0x502 HeapCreateTagsW(ptr long wstr wstr)
 @ stdcall HeapDestroy(long)
 @ stdcall -version=0x351-0x502 HeapExtend(long long ptr long)
 @ stdcall HeapFree(long long long) ntdll.RtlFreeHeap

--- a/sdk/include/ndk/rtlfuncs.h
+++ b/sdk/include/ndk/rtlfuncs.h
@@ -861,7 +861,7 @@ NTAPI
 RtlCreateTagHeap(
     _In_ HANDLE HeapHandle,
     _In_ ULONG Flags,
-    _In_ PWSTR TagName,
+    _In_opt_ PWSTR TagName,
     _In_ PWSTR TagSubName
 );
 

--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -4028,10 +4028,10 @@ RtlExtendHeap(IN HANDLE Heap,
 
 ULONG
 NTAPI
-RtlCreateTagHeap(IN HANDLE HeapHandle,
-                 IN ULONG Flags,
-                 IN PWSTR TagName,
-                 IN PWSTR TagSubName)
+RtlCreateTagHeap(_In_ HANDLE HeapHandle,
+                 _In_ ULONG Flags,
+                 _In_opt_ PWSTR TagName,
+                 _In_ PWSTR TagSubName)
 {
     /* TODO */
     UNIMPLEMENTED;


### PR DESCRIPTION
## Purpose

Minor update, to be consistent.

## Proposed changes

- [NDK][NTDLL][RTL] RtlCreateTagHeap(): Fix types and annotations
- [KERNEL32] HeapCreateTagsW(): Sync' types and add annotations