### PR TITLE
[KERNEL32_VISTA] QueryFullProcessImageName: Don't ignore dwFlags

### DIFF
--- a/dll/win32/kernel32/kernel32_vista/k32_vista.h
+++ b/dll/win32/kernel32/kernel32_vista/k32_vista.h
@@ -17,6 +17,8 @@
 #include <ndk/psfuncs.h>
 #include <ndk/rtlfuncs.h>
 
+#include <ntstrsafe.h>
+
 /* CSRSS Headers */
 #include <win/base.h>
 

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -19,6 +19,95 @@
 #define NDEBUG
 #include <debug.h>
 
+/* INTERNAL FUNCTIONS *********************************************************/
+
+/**
+ * @brief
+ * Maps an NT "\Device\..." path to its Win32 "DOS" equivalent.
+ *
+ * @param[in]   DevicePath
+ * The NT device path to convert.
+ *
+ * @param[out]  DosPath
+ * Pointer to the newly allocated and initialized Unicode string.
+ * Receives the converted Win32 path.
+ *
+ * @return
+ * Returns NTSTATUS error codes.
+ *
+ * @remarks
+ * The caller is responsible for freeing the destination string,
+ * by calling RtlFreeUnicodeString.
+ **/
+static
+NTSTATUS
+DevicePathToDosPathU(
+    _In_ PCUNICODE_STRING DevicePath,
+    _Out_ PUNICODE_STRING DosPath)
+{
+    UNICODE_STRING DevicePathPrefix = RTL_CONSTANT_STRING(L"\\Device\\");
+    LPWSTR pszDevicePath;
+    LPWSTR pszDosPath = NULL;
+    DWORD dwDosPathLength;
+    WCHAR szDrive[3] = L"?:";
+    WCHAR szDeviceName[MAX_PATH];
+    NTSTATUS Status = STATUS_NOT_FOUND;
+
+    /* Check if DevicePath is a device path */
+    if (!RtlPrefixUnicodeString(&DevicePathPrefix, DevicePath, TRUE))
+    {
+        return STATUS_OBJECT_PATH_INVALID;
+    }
+
+    pszDevicePath = RtlAllocateHeap(RtlGetProcessHeap(), 0, DevicePath->Length + sizeof(WCHAR));
+
+    if (!pszDevicePath)
+    {
+        return STATUS_NO_MEMORY;
+    }
+
+    RtlStringCbCopyNW(pszDevicePath, DevicePath->Length + sizeof(WCHAR), DevicePath->Buffer, DevicePath->Length);
+
+    for (szDrive[0] = L'A'; szDrive[0] <= L'`'; szDrive[0]++)
+    {
+        if (QueryDosDeviceW(szDrive, szDeviceName, _countof(szDeviceName)) != 0)
+        {
+            size_t len = wcslen(szDeviceName);
+
+            if (_wcsnicmp(pszDevicePath, szDeviceName, len) == 0)
+            {
+                /* Get required length, including the NULL terminator */
+                dwDosPathLength = _countof(szDrive) + wcslen(pszDevicePath + len);
+
+                pszDosPath = RtlAllocateHeap(RtlGetProcessHeap(), 0, dwDosPathLength * sizeof(WCHAR));
+
+                if (!pszDosPath)
+                {
+                    Status = STATUS_NO_MEMORY;
+                    break;
+                }
+
+                RtlStringCchPrintfW(pszDosPath, dwDosPathLength, L"%s%s",
+                                    szDrive, pszDevicePath + len);
+
+                if (!RtlCreateUnicodeString(DosPath, pszDosPath))
+                {
+                    Status = STATUS_INSUFFICIENT_RESOURCES;
+                    break;
+                }
+
+                Status = STATUS_SUCCESS;
+                break;
+            }
+        }
+    }
+
+    RtlFreeHeap(RtlGetProcessHeap(), 0, pszDosPath);
+    RtlFreeHeap(RtlGetProcessHeap(), 0, pszDevicePath);
+
+    return Status;
+}
+
 /* PUBLIC FUNCTIONS ***********************************************************/
 
 /*
@@ -31,14 +120,43 @@ QueryFullProcessImageNameW(HANDLE hProcess,
                            LPWSTR lpExeName,
                            PDWORD pdwSize)
 {
+    PROCESSINFOCLASS ProcessInfoClass;
     BYTE Buffer[sizeof(UNICODE_STRING) + (MAX_PATH * sizeof(WCHAR))];
-    PUNICODE_STRING DynamicBuffer = NULL;
-    PUNICODE_STRING Result = NULL;
+    PVOID DynamicBuffer = NULL;
+    PUNICODE_STRING Result;
     NTSTATUS Status;
-    DWORD Needed;
+    ULONG Needed;
+
+#if 0
+    if (dwFlags == 0)
+    {
+        /* The name should use the Win32 path format */
+        ProcessInfoClass = ProcessImageFileNameWin32;
+    }
+    else if (dwFlags == PROCESS_NAME_NATIVE)
+    {
+        /* The name should use the native system path format */
+        ProcessInfoClass = ProcessImageFileName;
+    }
+    else
+    {
+        BaseSetLastNTError(STATUS_INVALID_PARAMETER);
+        return FALSE;
+    }
+#else
+    UNICODE_STRING ResultWin32 = { 0 };
+
+    ProcessInfoClass = ProcessImageFileName;
+
+    if (dwFlags != 0 && dwFlags != PROCESS_NAME_NATIVE)
+    {
+        BaseSetLastNTError(STATUS_INVALID_PARAMETER);
+        return FALSE;
+    }
+#endif
 
     Status = NtQueryInformationProcess(hProcess,
-                                       ProcessImageFileName,
+                                       ProcessInfoClass,
                                        Buffer,
                                        sizeof(Buffer) - sizeof(WCHAR),
                                        &Needed);
@@ -52,8 +170,8 @@ QueryFullProcessImageNameW(HANDLE hProcess,
         }
 
         Status = NtQueryInformationProcess(hProcess,
-                                           ProcessImageFileName,
-                                           (LPBYTE)DynamicBuffer,
+                                           ProcessInfoClass,
+                                           DynamicBuffer,
                                            Needed,
                                            &Needed);
         Result = DynamicBuffer;
@@ -68,17 +186,43 @@ QueryFullProcessImageNameW(HANDLE hProcess,
         goto Cleanup;
     }
 
+#if 1
+    /* HACK: Convert device path format into Win32 path format    
+     * Use ProcessImageFileNameWin32 instead if the kernel
+     * supports it */
+    if (dwFlags == 0)
+    {
+        Status = DevicePathToDosPathU(Result, &ResultWin32);
+
+        if (!NT_SUCCESS(Status))
+        {
+            goto Cleanup;
+        }
+
+        Result = &ResultWin32;
+    }
+#endif
+
+    /* Verify that the given buffer size can count a NULL terminator */
     if ((Result->Length / sizeof(WCHAR)) + 1 > *pdwSize)
     {
         Status = STATUS_BUFFER_TOO_SMALL;
         goto Cleanup;
     }
 
+    RtlStringCbCopyNW(lpExeName, (*pdwSize) * sizeof(WCHAR), Result->Buffer, Result->Length);
+    
+    /* Return the written length, not including the NULL terminator */
     *pdwSize = Result->Length / sizeof(WCHAR);
-    memcpy(lpExeName, Result->Buffer, Result->Length);
-    lpExeName[*pdwSize] = UNICODE_NULL;
 
 Cleanup:
+#if 1
+    if (dwFlags == 0)
+    {
+        RtlFreeUnicodeString(&ResultWin32);
+    }
+#endif
+
     RtlFreeHeap(RtlGetProcessHeap(), 0, DynamicBuffer);
 
     if (!NT_SUCCESS(Status))

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -31,9 +31,9 @@ QueryFullProcessImageNameW(HANDLE hProcess,
                            LPWSTR lpExeName,
                            PDWORD pdwSize)
 {
-    BYTE Buffer[sizeof(UNICODE_STRING) + MAX_PATH * sizeof(WCHAR)];
-    UNICODE_STRING *DynamicBuffer = NULL;
-    UNICODE_STRING *Result = NULL;
+    BYTE Buffer[sizeof(UNICODE_STRING) + (MAX_PATH * sizeof(WCHAR))];
+    PUNICODE_STRING DynamicBuffer = NULL;
+    PUNICODE_STRING Result = NULL;
     NTSTATUS Status;
     DWORD Needed;
 
@@ -58,11 +58,17 @@ QueryFullProcessImageNameW(HANDLE hProcess,
                                            &Needed);
         Result = DynamicBuffer;
     }
-    else Result = (PUNICODE_STRING)Buffer;
+    else
+    {
+        Result = (PUNICODE_STRING)Buffer;
+    }
 
-    if (!NT_SUCCESS(Status)) goto Cleanup;
+    if (!NT_SUCCESS(Status))
+    {
+        goto Cleanup;
+    }
 
-    if (Result->Length / sizeof(WCHAR) + 1 > *pdwSize)
+    if ((Result->Length / sizeof(WCHAR)) + 1 > *pdwSize)
     {
         Status = STATUS_BUFFER_TOO_SMALL;
         goto Cleanup;
@@ -70,7 +76,7 @@ QueryFullProcessImageNameW(HANDLE hProcess,
 
     *pdwSize = Result->Length / sizeof(WCHAR);
     memcpy(lpExeName, Result->Buffer, Result->Length);
-    lpExeName[*pdwSize] = 0;
+    lpExeName[*pdwSize] = UNICODE_NULL;
 
 Cleanup:
     RtlFreeHeap(RtlGetProcessHeap(), 0, DynamicBuffer);

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -83,9 +83,7 @@ QueryFullProcessImageNameW(
     }
 
     if (!NT_SUCCESS(Status))
-    {
         goto Cleanup;
-    }
 
     /* Verify that the given buffer size can count a NULL terminator */
     if (Result->Length / sizeof(WCHAR) + 1 > *pdwSize)
@@ -103,9 +101,7 @@ Cleanup:
     RtlFreeHeap(RtlGetProcessHeap(), 0, DynamicBuffer);
 
     if (!NT_SUCCESS(Status))
-    {
         BaseSetLastNTError(Status);
-    }
 
     return !Status;
 }

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -101,9 +101,12 @@ Cleanup:
     RtlFreeHeap(RtlGetProcessHeap(), 0, DynamicBuffer);
 
     if (!NT_SUCCESS(Status))
+    {
         BaseSetLastNTError(Status);
+        return FALSE;
+    }
 
-    return !Status;
+    return TRUE;
 }
 
 

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -52,7 +52,7 @@ QueryFullProcessImageNameW(
     }
     else
     {
-        BaseSetLastNTError(STATUS_INVALID_PARAMETER);
+        BaseSetLastNTError(STATUS_INVALID_PARAMETER_2);
         return FALSE;
     }
 

--- a/dll/win32/kernel32/kernel32_vista/vista.c
+++ b/dll/win32/kernel32/kernel32_vista/vista.c
@@ -115,10 +115,12 @@ DevicePathToDosPathU(
  */
 BOOL
 WINAPI
-QueryFullProcessImageNameW(HANDLE hProcess,
-                           DWORD dwFlags,
-                           LPWSTR lpExeName,
-                           PDWORD pdwSize)
+QueryFullProcessImageNameW(
+    _In_ HANDLE hProcess,
+    _In_ DWORD dwFlags,
+    _Out_z_cap_post_count_(*pdwSize, *pdwSize + 1)
+        LPWSTR lpExeName,
+    _Inout_ PDWORD pdwSize)
 {
     PROCESSINFOCLASS ProcessInfoClass;
     BYTE Buffer[sizeof(UNICODE_STRING) + (MAX_PATH * sizeof(WCHAR))];
@@ -239,10 +241,12 @@ Cleanup:
  */
 BOOL
 WINAPI
-QueryFullProcessImageNameA(HANDLE hProcess,
-                           DWORD dwFlags,
-                           LPSTR lpExeName,
-                           PDWORD pdwSize)
+QueryFullProcessImageNameA(
+    _In_ HANDLE hProcess,
+    _In_ DWORD dwFlags,
+    _Out_z_cap_post_count_(*pdwSize, *pdwSize + 1)
+        LPSTR lpExeName,
+    _Inout_ PDWORD pdwSize)
 {
     DWORD pdwSizeW = *pdwSize;
     BOOL Result;


### PR DESCRIPTION
## Purposed changes
- Correctly handle dwFlags parameter
- Also add SAL annotations and use NT string safe functions

JIRA issue: [CORE-16145](https://jira.reactos.org/browse/CORE-16145)

## TODO
- [x] Do tests