### PR TITLE
[NTOS:SE] Access Check Overhaul -- Deny access to the caller if not permitted

### DIFF
--- a/base/system/services/database.c
+++ b/base/system/services/database.c
@@ -370,7 +370,7 @@ ScmLogonService(
     DPRINT("ScmLogonService(%p %p)\n", pService, pImage);
     DPRINT("Service %S\n", pService->lpServiceName);
 
-    if (ScmIsLocalSystemAccount(pImage->pszAccountName) || ScmLiveSetup)
+    if (ScmIsLocalSystemAccount(pImage->pszAccountName) || ScmLiveSetup || ScmSetupInProgress)
         return ERROR_SUCCESS;
 
     /* Get the user and domain names */

--- a/base/system/services/security.c
+++ b/base/system/services/security.c
@@ -55,6 +55,7 @@ DWORD
 ScmCreateSids(VOID)
 {
     SID_IDENTIFIER_AUTHORITY NullAuthority = {SECURITY_NULL_SID_AUTHORITY};
+    SID_IDENTIFIER_AUTHORITY WorldAuthority = {SECURITY_WORLD_SID_AUTHORITY};
     SID_IDENTIFIER_AUTHORITY NtAuthority = {SECURITY_NT_AUTHORITY};
     PULONG pSubAuthority;
     ULONG ulLength1 = RtlLengthRequiredSid(1);
@@ -78,7 +79,7 @@ ScmCreateSids(VOID)
         return ERROR_OUTOFMEMORY;
     }
 
-    RtlInitializeSid(pWorldSid, &NullAuthority, 1);
+    RtlInitializeSid(pWorldSid, &WorldAuthority, 1);
     pSubAuthority = RtlSubAuthoritySid(pWorldSid, 0);
     *pSubAuthority = SECURITY_WORLD_RID;
 

--- a/base/system/services/services.c
+++ b/base/system/services/services.c
@@ -28,6 +28,7 @@ int WINAPI RegisterServicesProcess(DWORD ServicesProcessId);
 BOOL ScmInitialize = FALSE;
 BOOL ScmShutdown = FALSE;
 BOOL ScmLiveSetup = FALSE;
+BOOL ScmSetupInProgress = FALSE;
 static HANDLE hScmShutdownEvent = NULL;
 static HANDLE hScmSecurityServicesEvent = NULL;
 
@@ -55,6 +56,7 @@ CheckForLiveCD(VOID)
     WCHAR CommandLine[MAX_PATH];
     HKEY hSetupKey;
     DWORD dwSetupType;
+    DWORD dwSetupInProgress;
     DWORD dwType;
     DWORD dwSize;
     DWORD dwError;
@@ -105,6 +107,28 @@ CheckForLiveCD(VOID)
     {
         DPRINT1("Running on LiveCD\n");
         ScmLiveSetup = TRUE;
+    }
+
+    /* Read the SystemSetupInProgress value */
+    dwSize = sizeof(DWORD);
+    dwError = RegQueryValueExW(hSetupKey,
+                               L"SystemSetupInProgress",
+                               NULL,
+                               &dwType,
+                               (LPBYTE)&dwSetupInProgress,
+                               &dwSize);
+    if (dwError != ERROR_SUCCESS ||
+        dwType != REG_DWORD ||
+        dwSize != sizeof(DWORD) ||
+        dwSetupType == 0)
+    {
+        goto done;
+    }
+
+    if (dwSetupInProgress == 1)
+    {
+        DPRINT1("ReactOS Setup currently in progress!\n");
+        ScmSetupInProgress = TRUE;
     }
 
 done:

--- a/base/system/services/services.h
+++ b/base/system/services/services.h
@@ -102,6 +102,7 @@ extern LIST_ENTRY ImageListHead;
 extern BOOL ScmInitialize;
 extern BOOL ScmShutdown;
 extern BOOL ScmLiveSetup;
+extern BOOL ScmSetupInProgress;
 extern PSECURITY_DESCRIPTOR pPipeSD;
 
 

--- a/base/system/winlogon/CMakeLists.txt
+++ b/base/system/winlogon/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND SOURCE
     rpcserver.c
     sas.c
     screensaver.c
+    security.c
     setup.c
     shutdown.c
     winlogon.c

--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -428,87 +428,6 @@ PlayLogonSound(
         CloseHandle(hThread);
 }
 
-static BOOL
-AllowWinstaAccess(PWLSESSION Session)
-{
-    BOOL bSuccess = FALSE;
-    DWORD dwIndex;
-    DWORD dwLength = 0;
-    PTOKEN_GROUPS ptg = NULL;
-    PSID psid;
-    TOKEN_STATISTICS Stats;
-    DWORD cbStats;
-    DWORD ret;
-
-    // Get required buffer size and allocate the TOKEN_GROUPS buffer.
-
-    if (!GetTokenInformation(Session->UserToken,
-                             TokenGroups,
-                             ptg,
-                             0,
-                             &dwLength))
-    {
-        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
-            return FALSE;
-
-        ptg = (PTOKEN_GROUPS)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, dwLength);
-        if (ptg == NULL)
-            return FALSE;
-    }
-
-    // Get the token group information from the access token.
-    if (!GetTokenInformation(Session->UserToken,
-                             TokenGroups,
-                             ptg,
-                             dwLength,
-                             &dwLength))
-    {
-        goto Cleanup;
-    }
-
-    // Loop through the groups to find the logon SID.
-
-    for (dwIndex = 0; dwIndex < ptg->GroupCount; dwIndex++)
-    {
-        if ((ptg->Groups[dwIndex].Attributes & SE_GROUP_LOGON_ID)
-            == SE_GROUP_LOGON_ID)
-        {
-            psid = ptg->Groups[dwIndex].Sid;
-            break;
-        }
-    }
-
-    dwLength = GetLengthSid(psid);
-
-    if (!GetTokenInformation(Session->UserToken,
-                             TokenStatistics,
-                             &Stats,
-                             sizeof(TOKEN_STATISTICS),
-                             &cbStats))
-    {
-        WARN("Couldn't get Authentication id from user token!\n");
-        goto Cleanup;
-    }
-
-    AddAceToWindowStation(Session->InteractiveWindowStation, psid);
-
-    ret = SetWindowStationUser(Session->InteractiveWindowStation,
-                               &Stats.AuthenticationId,
-                               psid,
-                               dwLength);
-    TRACE("SetWindowStationUser returned 0x%x\n", ret);
-
-    bSuccess = TRUE;
-
-Cleanup:
-
-    // Free the buffer for the token groups.
-    if (ptg != NULL)
-        HeapFree(GetProcessHeap(), 0, (LPVOID)ptg);
-
-    return bSuccess;
-}
-
 static
 VOID
 RestoreAllConnections(PWLSESSION Session)
@@ -633,7 +552,12 @@ HandleLogon(
         goto cleanup;
     }
 
-    AllowWinstaAccess(Session);
+    /* Allow winsta and desktop access for this session */
+    if (!AllowAccessOnSession(Session))
+    {
+        WARN("WL: AllowAccessOnSession() failed to give winsta & desktop access for this session\n");
+        goto cleanup;
+    }
 
     /* Connect remote resources */
     RestoreAllConnections(Session);

--- a/base/system/winlogon/security.c
+++ b/base/system/winlogon/security.c
@@ -1,0 +1,1314 @@
+/*
+ * PROJECT:         ReactOS Winlogon
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security utility infrastructure implementation of Winlogon
+ * COPYRIGHT:       Copyright 2022 George Bișoc <george.bisoc@reactos.org>
+ */
+
+/* INCLUDES *****************************************************************/
+
+#include "winlogon.h"
+
+/* DEFINES ******************************************************************/
+
+#define DESKTOP_ALL (DESKTOP_READOBJECTS | DESKTOP_CREATEWINDOW | \
+    DESKTOP_CREATEMENU | DESKTOP_HOOKCONTROL | DESKTOP_JOURNALRECORD | \
+    DESKTOP_JOURNALPLAYBACK | DESKTOP_ENUMERATE | DESKTOP_WRITEOBJECTS | \
+    DESKTOP_SWITCHDESKTOP | STANDARD_RIGHTS_REQUIRED)
+
+#define DESKTOP_ADMINS_LIMITED (DESKTOP_WRITEOBJECTS | DESKTOP_READOBJECTS | \
+    DESKTOP_CREATEWINDOW | DESKTOP_CREATEMENU | DESKTOP_ENUMERATE)
+
+#define DESKTOP_INTERACTIVE_LIMITED (STANDARD_RIGHTS_READ | DESKTOP_ENUMERATE | \
+    DESKTOP_READOBJECTS | DESKTOP_CREATEWINDOW)
+
+#define DESKTOP_WINLOGON_ADMINS_LIMITED (STANDARD_RIGHTS_REQUIRED | DESKTOP_ENUMERATE)
+
+#define WINSTA_ALL (WINSTA_ENUMDESKTOPS | WINSTA_READATTRIBUTES | \
+    WINSTA_ACCESSCLIPBOARD | WINSTA_CREATEDESKTOP | \
+    WINSTA_WRITEATTRIBUTES | WINSTA_ACCESSGLOBALATOMS | \
+    WINSTA_EXITWINDOWS | WINSTA_ENUMERATE | WINSTA_READSCREEN | \
+    STANDARD_RIGHTS_REQUIRED)
+
+#define WINSTA_ADMINS_LIMITED (WINSTA_READATTRIBUTES | WINSTA_ENUMERATE)
+
+#define GENERIC_ACCESS (GENERIC_READ | GENERIC_WRITE | \
+    GENERIC_EXECUTE | GENERIC_ALL)
+
+/* GLOBALS ******************************************************************/
+
+static SID_IDENTIFIER_AUTHORITY NtAuthority = {SECURITY_NT_AUTHORITY};
+
+/* FUNCTIONS ****************************************************************/
+
+/**
+ * @brief
+ * Converts an absolute security descriptor to a self-relative
+ * format.
+ *
+ * @param[in] AbsoluteSd
+ * A pointer to an absolute security descriptor to be
+ * converted.
+ *
+ * @return
+ * Returns a pointer to a converted security descriptor in
+ * self-relative format. If the function fails, NULL is returned
+ * otherwise.
+ *
+ * @remarks
+ * The function allocates the security descriptor buffer in memory
+ * heap, the caller is entirely responsible for freeing such buffer
+ * from when it's no longer needed.
+ */
+PSECURITY_DESCRIPTOR
+ConvertToSelfRelative(
+    _In_ PSECURITY_DESCRIPTOR AbsoluteSd)
+{
+    PSECURITY_DESCRIPTOR RelativeSd;
+    DWORD DescriptorLength = 0;
+
+    /* Determine the size for our buffer to allocate */
+    if (!MakeSelfRelativeSD(AbsoluteSd, NULL, &DescriptorLength) && GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+    {
+        ERR("ConvertToSelfRelative(): Unexpected error code (error code %lu -- must be ERROR_INSUFFICIENT_BUFFER)\n", GetLastError());
+        return NULL;
+    }
+
+    /* Allocate the buffer now */
+    RelativeSd = RtlAllocateHeap(RtlGetProcessHeap(),
+                                 HEAP_ZERO_MEMORY,
+                                 DescriptorLength);
+    if (RelativeSd == NULL)
+    {
+        ERR("ConvertToSelfRelative(): Failed to allocate buffer for relative SD!\n");
+        return NULL;
+    }
+
+    /* Convert the security descriptor now */
+    if (!MakeSelfRelativeSD(AbsoluteSd, RelativeSd, &DescriptorLength))
+    {
+        ERR("ConvertToSelfRelative(): Failed to convert the security descriptor to a self relative format (error code %lu)\n", GetLastError());
+        RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        return NULL;
+    }
+
+    return RelativeSd;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for the default
+ * window station upon its creation.
+ *
+ * @param[out] WinstaSd
+ * A pointer to a created security descriptor for
+ * the window station.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * created the security descriptor, FALSE otherwise.
+ */
+BOOL
+CreateWinstaSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *WinstaSd)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of four ACEs of two different SIDs. The first two
+     * ACEs give both window station and generic access
+     * to Winlogon, the last two give limited window station
+     * and desktop access to admins.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("CreateWinstaSecurity(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("CreateWinstaSecurity(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- give full winsta access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ALL,
+                               WinlogonSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- give full generic access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               GENERIC_ACCESS,
+                               WinlogonSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Third ACE -- give limited winsta access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Fourth ACE -- give limited desktop access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               DESKTOP_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("CreateWinstaSecurity(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("CreateWinstaSecurity(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to the descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("CreateWinstaSecurity(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Convert it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("CreateWinstaSecurity(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Give the descriptor to the caller */
+    *WinstaSd = RelativeSd;
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (Success == FALSE)
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for the default
+ * application desktop upon its creation.
+ *
+ * @param[out] ApplicationDesktopSd
+ * A pointer to a created security descriptor for
+ * the application desktop.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * created the security descriptor, FALSE otherwise.
+ */
+BOOL
+CreateApplicationDesktopSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ApplicationDesktopSd)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of two ACEs of two different SIDs. The first ACE
+     * gives full access to Winlogon, the last one gives
+     * limited desktop access to admins.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- Give full desktop power to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               WinlogonSid))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- Give limited desktop power to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to the descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Conver it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("CreateApplicationDesktopSecurity(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Give the descriptor to the caller */
+    *ApplicationDesktopSd = RelativeSd;
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (Success == FALSE)
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for the default
+ * Winlogon desktop. This descriptor serves as a
+ * security measure for the winlogon desktop so
+ * that only Winlogon itself (and admins) can
+ * interact with it.
+ *
+ * @param[out] WinlogonDesktopSd
+ * A pointer to a created security descriptor for
+ * the Winlogon desktop.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * created the security descriptor, FALSE otherwise.
+ */
+BOOL
+CreateWinlogonDesktopSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *WinlogonDesktopSd)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of two ACEs of two different SIDs. The first ACE
+     * gives full access to Winlogon, the last one gives
+     * limited desktop access to admins.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- Give full desktop access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               WinlogonSid))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- Give limited desktop access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_WINLOGON_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to the descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Conver it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("CreateWinlogonDesktopSecurity(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Give the descriptor to the caller */
+    *WinlogonDesktopSd = RelativeSd;
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (Success == FALSE)
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for the screen
+ * saver desktop.
+ *
+ * @param[out] ScreenSaverDesktopSd
+ * A pointer to a created security descriptor for
+ * the screen-saver desktop.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * created the security descriptor, FALSE otherwise.
+ */
+BOOL
+CreateScreenSaverSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ScreenSaverDesktopSd)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL, InteractiveSid = NULL;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Create the interactive logon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_INTERACTIVE_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &InteractiveSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to create the interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of three ACEs of three different SIDs. The first ACE
+     * gives full access to Winlogon, the second one gives
+     * limited desktop access to admins and the last one
+     * gives full desktop access to users who have logged in
+     * interactively.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(InteractiveSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- Give full desktop access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               WinlogonSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- Give limited desktop access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               DESKTOP_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Third ACE -- Give full desktop access to interactive logon users */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               DESKTOP_INTERACTIVE_LIMITED,
+                               InteractiveSid))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to set ACE for interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to the descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Conver it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("CreateScreenSaverSecurity(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Give the descriptor to the caller */
+    *ScreenSaverDesktopSd = RelativeSd;
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (InteractiveSid != NULL)
+    {
+        FreeSid(InteractiveSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (Success == FALSE)
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Assigns access to the specific logon user to
+ * the default window station. Such access is
+ * given to the user when it has logged in.
+ *
+ * @param[in] WinSta
+ * A handle to a window station where the
+ * user is given access to it.
+ *
+ * @param[in] LogonSid
+ * A pointer to a logon SID that represents
+ * the logged in user in question.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * assigned access to the user, FALSE otherwise.
+ */
+BOOL
+AllowWinstaAccessToUser(
+    _In_ HWINSTA WinSta,
+    _In_ PSID LogonSid)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL, InteractiveSid = NULL;
+    SECURITY_INFORMATION SecurityInformation;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Create the interactive logon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_INTERACTIVE_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &InteractiveSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to create the interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of eight ACEs of four different SIDs. The first ACE
+     * gives full winsta access to Winlogon, the second one gives
+     * generic access to Winlogon. Such approach is the same
+     * for both interactive logon users and logon user as well.
+     * Only admins are given limited powers.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(InteractiveSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(InteractiveSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(LogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(LogonSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- Give full winsta access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ALL,
+                               WinlogonSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- Give generic access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               GENERIC_ACCESS,
+                               WinlogonSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Third ACE -- Give limited winsta access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Fourth ACE -- Give limited desktop access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               DESKTOP_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Fifth ACE -- Give full winsta access to interactive logon users */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ALL,
+                               InteractiveSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Sixth ACE -- Give generic access to interactive logon users */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               GENERIC_ACCESS,
+                               InteractiveSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Seventh ACE -- Give full winsta access to logon user */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               NO_PROPAGATE_INHERIT_ACE,
+                               WINSTA_ALL,
+                               LogonSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for logon user SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Eighth ACE -- Give generic access to logon user */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               INHERIT_ONLY_ACE | OBJECT_INHERIT_ACE | CONTAINER_INHERIT_ACE,
+                               GENERIC_ACCESS,
+                               LogonSid))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set ACE for logon user SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Convert it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Set new winsta security based on this descriptor */
+    SecurityInformation = DACL_SECURITY_INFORMATION;
+    if (!SetUserObjectSecurity(WinSta, &SecurityInformation, RelativeSd))
+    {
+        ERR("AllowWinstaAccessToUser(): Failed to set window station security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (InteractiveSid != NULL)
+    {
+        FreeSid(InteractiveSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (RelativeSd != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Assigns access to the specific logon user to
+ * the default desktop. Such access is given to
+ * the user when it has logged in.
+ *
+ * @param[in] Desktop
+ * A handle to a desktop where the user
+ * is given access to it.
+ *
+ * @param[in] LogonSid
+ * A pointer to a logon SID that represents
+ * the logged in user in question.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * assigned access to the user, FALSE otherwise.
+ */
+BOOL
+AllowDesktopAccessToUser(
+    _In_ HDESK Desktop,
+    _In_ PSID LogonSid)
+{
+    BOOL Success = FALSE;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    PSID WinlogonSid = NULL, AdminsSid = NULL, InteractiveSid = NULL;
+    SECURITY_INFORMATION SecurityInformation;
+    DWORD DaclSize;
+    PACL Dacl;
+
+    /* Create the Winlogon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_LOCAL_SYSTEM_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &WinlogonSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to create the Winlogon SID (error code %lu)\n", GetLastError());
+        return FALSE;
+    }
+
+    /* Create the admins SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  2,
+                                  SECURITY_BUILTIN_DOMAIN_RID,
+                                  DOMAIN_ALIAS_RID_ADMINS,
+                                  0, 0, 0, 0, 0, 0,
+                                  &AdminsSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to create the admins SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Create the interactive logon SID */
+    if (!AllocateAndInitializeSid(&NtAuthority,
+                                  1,
+                                  SECURITY_INTERACTIVE_RID,
+                                  0, 0, 0, 0, 0, 0, 0,
+                                  &InteractiveSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to create the interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /*
+     * Build up the DACL size. This includes a number
+     * of four ACEs of four different SIDs. The first ACE
+     * gives full desktop access to Winlogon, the second one gives
+     * generic limited desktop access to admins. The last two give
+     * full power to both interactive logon users and logon user as
+     * well.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(WinlogonSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(AdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(InteractiveSid) +
+               sizeof(ACCESS_ALLOWED_ACE) - sizeof(DWORD) + GetLengthSid(LogonSid);
+
+    /* Allocate the DACL now */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to allocate memory buffer for DACL!\n");
+        goto Quit;
+    }
+
+    /* Initialize it */
+    if (!InitializeAcl(Dacl, DaclSize, ACL_REVISION))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to initialize DACL (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* First ACE -- Give full desktop access to Winlogon */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               WinlogonSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set ACE for Winlogon (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Second ACE -- Give limited desktop access to admins */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ADMINS_LIMITED,
+                               AdminsSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set ACE for admins (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Third ACE -- Give full desktop access to interactive logon users */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               InteractiveSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set ACE for interactive SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Fourth ACE -- Give full desktop access to logon user */
+    if (!AddAccessAllowedAceEx(Dacl,
+                               ACL_REVISION,
+                               0,
+                               DESKTOP_ALL,
+                               LogonSid))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set ACE for logon user SID (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    if (!InitializeSecurityDescriptor(&AbsoluteSd, SECURITY_DESCRIPTOR_REVISION))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to initialize absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Set the DACL to the descriptor */
+    if (!SetSecurityDescriptorDacl(&AbsoluteSd, TRUE, Dacl, FALSE))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set up DACL to absolute security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Conver it to self-relative format */
+    RelativeSd = ConvertToSelfRelative(&AbsoluteSd);
+    if (RelativeSd == NULL)
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to convert security descriptor to self relative format!\n");
+        goto Quit;
+    }
+
+    /* Assign new security to desktop based on this descriptor */
+    SecurityInformation = DACL_SECURITY_INFORMATION;
+    if (!SetUserObjectSecurity(Desktop, &SecurityInformation, RelativeSd))
+    {
+        ERR("AllowDesktopAccessToUser(): Failed to set desktop security descriptor (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    Success = TRUE;
+
+Quit:
+    if (WinlogonSid != NULL)
+    {
+        FreeSid(WinlogonSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        FreeSid(AdminsSid);
+    }
+
+    if (InteractiveSid != NULL)
+    {
+        FreeSid(InteractiveSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (RelativeSd != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+    }
+
+    return Success;
+}
+
+/**
+ * @brief
+ * Assigns both window station and desktop access
+ * to the specific session currently active on the
+ * system.
+ *
+ * @param[in] Session
+ * A pointer to an active session.
+ *
+ * @return
+ * Returns TRUE if the function has successfully
+ * assigned access to the current session, FALSE otherwise.
+ */
+BOOL
+AllowAccessOnSession(
+    _In_ PWLSESSION Session)
+{
+    BOOL Success = FALSE;
+    DWORD Index, SidLength, GroupsLength = 0;
+    PTOKEN_GROUPS TokenGroup = NULL;
+    PSID LogonSid;
+
+    /* Get required buffer size and allocate the TOKEN_GROUPS buffer */
+    if (!GetTokenInformation(Session->UserToken,
+                             TokenGroups,
+                             TokenGroup,
+                             0,
+                             &GroupsLength))
+    {
+        if (GetLastError() != ERROR_INSUFFICIENT_BUFFER)
+        {
+            ERR("AllowAccessOnSession(): Unexpected error code returned, must be ERROR_INSUFFICIENT_BUFFER (error code %lu)\n", GetLastError());
+            return FALSE;
+        }
+
+        TokenGroup = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, GroupsLength);
+        if (TokenGroup == NULL)
+        {
+            ERR("AllowAccessOnSession(): Failed to allocate memory buffer for token group!\n");
+            return FALSE;
+        }
+    }
+
+    /* Get the token group information from the access token */
+    if (!GetTokenInformation(Session->UserToken,
+                             TokenGroups,
+                             TokenGroup,
+                             GroupsLength,
+                             &GroupsLength))
+    {
+        ERR("AllowAccessOnSession(): Failed to retrieve the token group information (error code %lu)\n", GetLastError());
+        goto Quit;
+    }
+
+    /* Loop through the groups to find the logon SID */
+    for (Index = 0; Index < TokenGroup->GroupCount; Index++)
+    {
+        if ((TokenGroup->Groups[Index].Attributes & SE_GROUP_LOGON_ID)
+            == SE_GROUP_LOGON_ID)
+        {
+            LogonSid = TokenGroup->Groups[Index].Sid;
+            break;
+        }
+    }
+
+    /* Allow window station access to this user within this session */
+    if (!AllowWinstaAccessToUser(Session->InteractiveWindowStation, LogonSid))
+    {
+        ERR("AllowAccessOnSession(): Failed to allow winsta access to the logon user!\n");
+        goto Quit;
+    }
+
+/*
+ * FIXME: Desktop security management is broken. The application desktop gets created
+ * with CreateDesktopW() API call with an initial and defined security  descriptor for it yet
+ * when we are giving access to the logged in user, SetUserObjectSecurity() API call fails to set
+ * new security because the desktop in question has no prior security  descriptor (when it's
+ * been assigned even before!!!). This chunk of code must be enabled when this gets fixed.
+ */
+#if 0
+    /* Allow application desktop access to this user within this session */
+    if (!AllowDesktopAccessToUser(Session->ApplicationDesktop, LogonSid))
+    {
+        ERR("AllowAccessOnSession(): Failed to allow application desktop access to the logon user!\n");
+        goto Quit;
+    }
+#endif
+
+    /* Get the length of this logon SID */
+    SidLength = GetLengthSid(LogonSid);
+
+    /* Assign the window station to this logged in user */
+    if (!SetWindowStationUser(Session->InteractiveWindowStation,
+                              &Session->LogonId,
+                              LogonSid,
+                              SidLength))
+    {
+        ERR("AllowAccessOnSession(): Failed to assign the window station to the logon user!\n");
+        goto Quit;
+    }
+
+    Success = TRUE;
+
+Quit:
+    if (TokenGroup != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, TokenGroup);
+    }
+
+    return Success;
+}
+
+/* EOF */

--- a/base/system/winlogon/winlogon.h
+++ b/base/system/winlogon/winlogon.h
@@ -320,6 +320,41 @@ InitializeScreenSaver(IN OUT PWLSESSION Session);
 VOID
 StartScreenSaver(IN PWLSESSION Session);
 
+/* security.c */
+PSECURITY_DESCRIPTOR
+ConvertToSelfRelative(
+    _In_ PSECURITY_DESCRIPTOR AbsoluteSd);
+
+BOOL
+CreateWinstaSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *WinstaSd);
+
+BOOL
+CreateApplicationDesktopSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ApplicationDesktopSd);
+
+BOOL
+CreateWinlogonDesktopSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *WinlogonDesktopSd);
+
+BOOL
+CreateScreenSaverSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ScreenSaverDesktopSd);
+
+BOOL
+AllowWinstaAccessToUser(
+    _In_ HWINSTA WinSta,
+    _In_ PSID LogonSid);
+
+BOOL
+AllowDesktopAccessToUser(
+    _In_ HDESK Desktop,
+    _In_ PSID LogonSid);
+
+BOOL
+AllowAccessOnSession(
+    _In_ PWLSESSION Session);
+
 /* setup.c */
 DWORD
 GetSetupType(VOID);
@@ -364,12 +399,8 @@ BOOL
 GinaInit(IN OUT PWLSESSION Session);
 
 BOOL
-AddAceToWindowStation(
-    IN HWINSTA WinSta,
-    IN PSID Sid);
-
-BOOL
-CreateWindowStationAndDesktops(IN OUT PWLSESSION Session);
+CreateWindowStationAndDesktops(
+    _Inout_ PWLSESSION Session);
 
 
 VOID WINAPI WlxUseCtrlAltDel(HANDLE hWlx);

--- a/dll/win32/kernel32/winnls/string/nls.c
+++ b/dll/win32/kernel32/winnls/string/nls.c
@@ -56,6 +56,9 @@ GetNlsSectionName(UINT CodePage, UINT Base, ULONG Unknown,
 BOOL WINAPI
 GetCPFileNameFromRegistry(UINT CodePage, LPWSTR FileName, ULONG FileNameSize);
 
+NTSTATUS
+CreateNlsDirectorySecurity(_Out_ PSECURITY_DESCRIPTOR *NlsSecurityDescriptor);
+
 /* PRIVATE FUNCTIONS **********************************************************/
 
 /**
@@ -70,7 +73,9 @@ NlsInit(VOID)
 {
     UNICODE_STRING DirName;
     OBJECT_ATTRIBUTES ObjectAttributes;
+    PSECURITY_DESCRIPTOR NlsDirSd;
     HANDLE Handle;
+    NTSTATUS Status;
 
     InitializeListHead(&CodePageListHead);
     RtlInitializeCriticalSection(&CodePageListLock);
@@ -82,13 +87,21 @@ NlsInit(VOID)
      */
     RtlInitUnicodeString(&DirName, L"\\Nls");
 
+    /* Create a security descriptor for NLS directory */
+    Status = CreateNlsDirectorySecurity(&NlsDirSd);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("Failed to create NLS directory security (Status 0x%08x)\n", Status);
+        return FALSE;
+    }
+
     InitializeObjectAttributes(&ObjectAttributes,
                                &DirName,
                                OBJ_CASE_INSENSITIVE | OBJ_PERMANENT,
                                NULL,
-                               NULL);
+                               NlsDirSd);
 
-    if (NT_SUCCESS(NtCreateDirectoryObject(&Handle, DIRECTORY_ALL_ACCESS, &ObjectAttributes)))
+    if (NT_SUCCESS(NtCreateDirectoryObject(&Handle, DIRECTORY_TRAVERSE | DIRECTORY_CREATE_OBJECT, &ObjectAttributes)))
     {
         NtClose(Handle);
     }
@@ -112,6 +125,7 @@ NlsInit(VOID)
     OemCodePage.CodePage = OemCodePage.CodePageTable.CodePage;
     InsertTailList(&CodePageListHead, &OemCodePage.Entry);
 
+    RtlFreeHeap(RtlGetProcessHeap(), 0, NlsDirSd);
     return TRUE;
 }
 
@@ -2237,13 +2251,343 @@ IsDBCSLeadByte(BYTE TestByte)
     return IntIsLeadByte(&AnsiCodePage.CodePageTable, TestByte);
 }
 
-/*
- * @unimplemented
+/**
+ * @brief
+ * Creates a security descriptor for the NLS object directory
+ * name.
+ *
+ * @param[out] SecurityDescriptor
+ * A pointer to an allocated and created security descriptor
+ * that is given to the caller.
+ *
+ * @return
+ * STATUS_SUCCESS is returned if the function has successfully
+ * created a security descriptor for a NLS section name. Otherwise
+ * a NTSTATUS failure code is returned.
+ *
+ * @remarks
+ * Everyone (aka World SID) is given read access to the NLS directory
+ * whereas admins are given full power.
  */
-NTSTATUS WINAPI CreateNlsSecurityDescriptor(PSECURITY_DESCRIPTOR SecurityDescriptor,ULONG Size,ULONG AccessMask)
+NTSTATUS
+CreateNlsDirectorySecurity(_Out_ PSECURITY_DESCRIPTOR *NlsSecurityDescriptor)
 {
-    STUB;
-    return 0;
+    NTSTATUS Status;
+    PACL Dacl;
+    PSID WorldSid = NULL, AdminsSid = NULL;
+    ULONG DaclSize, RelSdSize = 0;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    static SID_IDENTIFIER_AUTHORITY WorldAuthority = {SECURITY_WORLD_SID_AUTHORITY};
+    static SID_IDENTIFIER_AUTHORITY NtAuthority = {SECURITY_NT_AUTHORITY};
+
+    /* Create the World SID */
+    Status = RtlAllocateAndInitializeSid(&WorldAuthority,
+                                         1,
+                                         SECURITY_WORLD_RID,
+                                         0, 0, 0, 0, 0, 0, 0,
+                                         &WorldSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to create world SID (Status 0x%08x)\n", Status);
+        return Status;
+    }
+
+    /* Create the admins SID */
+    Status = RtlAllocateAndInitializeSid(&NtAuthority,
+                                         2,
+                                         SECURITY_BUILTIN_DOMAIN_RID,
+                                         DOMAIN_ALIAS_RID_ADMINS,
+                                         0, 0, 0, 0, 0, 0,
+                                         &AdminsSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to create admins SID (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Build up the size of our DACL, including the World and admins SIDs */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(WorldSid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(AdminsSid);
+
+    /* Allocate memory for our DACL */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, DaclSize);
+    if (Dacl == NULL)
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Could not allocate memory for DACL, not enough memory!\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Quit;
+    }
+
+    /* Create the DACL */
+    Status = RtlCreateAcl(Dacl, DaclSize, ACL_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to create the DACL (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Give everyone basic directory access */
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    DIRECTORY_TRAVERSE | DIRECTORY_CREATE_OBJECT,
+                                    WorldSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to insert allowed access ACE to DACL for World SID (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Give admins full power */
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    DIRECTORY_ALL_ACCESS,
+                                    AdminsSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to insert allowed access ACE to DACL for admins SID (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    Status = RtlCreateSecurityDescriptor(&AbsoluteSd,
+                                         SECURITY_DESCRIPTOR_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to initialize the security descriptor (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Set the DACL to descriptor */
+    Status = RtlSetDaclSecurityDescriptor(&AbsoluteSd,
+                                          TRUE,
+                                          Dacl,
+                                          FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to insert DACL into the descriptor (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Determine how much size is needed to convert the absolute SD into self-relative one */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         NULL,
+                                         &RelSdSize);
+    if (Status != STATUS_BUFFER_TOO_SMALL)
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Unexpected status code, must be STATUS_BUFFER_TOO_SMALL (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Allocate buffer for relative SD */
+    RelativeSd = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, RelSdSize);
+    if (RelativeSd == NULL)
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Could not allocate memory for relative SD, not enough memory!\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Quit;
+    }
+
+    /* Convert it now */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         RelativeSd,
+                                         &RelSdSize);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsDirectorySecurity(): Failed to convert absolute SD to self-relative format (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Give the security descriptor to the caller */
+    *NlsSecurityDescriptor = RelativeSd;
+
+Quit:
+    if (WorldSid != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, WorldSid);
+    }
+
+    if (AdminsSid != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, AdminsSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Status;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for each NLS section
+ * name.
+ *
+ * @param[in] AccessMask
+ * An access mask bit to supply to the function. This
+ * access mask grants everyone access specific to that
+ * bit mask.
+ *
+ * @param[out] SecurityDescriptor
+ * A pointer to an allocated and created security descriptor
+ * that is given to the caller.
+ *
+ * @return
+ * STATUS_SUCCESS is returned if the function has successfully
+ * created a security descriptor for a NLS section name. Otherwise
+ * a NTSTATUS failure code is returned.
+ *
+ * @remarks
+ * The implementation of CreateNlsSecurityDescriptor on Windows Server
+ * 2003 is slightly different compared to ours. The second parameter
+ * takes the size of a security descriptor, in bytes. This is implied
+ * that on Windows the caller is responsible to submit the exact
+ * size of the descriptor. On ReactOS we're going to do it different,
+ * let the function be responsible for security descriptor creation
+ * and its size. DescriptorSize will act like a dummy parameter for us
+ * in this case. Everyone (aka World SID) is given read access to each
+ * NLS section name.
+ */
+NTSTATUS WINAPI CreateNlsSecurityDescriptor(_Out_ PSECURITY_DESCRIPTOR *SecurityDescriptor, _In_ SIZE_T DescriptorSize, _In_ ULONG AccessMask)
+{
+    NTSTATUS Status;
+    PACL Dacl;
+    PSID WorldSid = NULL;
+    ULONG DaclSize, RelSdSize = 0;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    static SID_IDENTIFIER_AUTHORITY WorldAuthority = {SECURITY_WORLD_SID_AUTHORITY};
+
+    /* DescriptorSize is just a dummy parameter */
+    UNREFERENCED_PARAMETER(DescriptorSize);
+
+    /* Create the World SID */
+    Status = RtlAllocateAndInitializeSid(&WorldAuthority,
+                                         1,
+                                         SECURITY_WORLD_RID,
+                                         0, 0, 0, 0, 0, 0, 0,
+                                         &WorldSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to create world SID (Status 0x%08x)\n", Status);
+        return Status;
+    }
+
+    /* Build up the size of our DACL, including the World SID */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(WorldSid);
+
+    /* Allocate memory for our DACL */
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, DaclSize);
+    if (Dacl == NULL)
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Could not allocate memory for DACL, not enough memory!\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Quit;
+    }
+
+    /* Create the DACL */
+    Status = RtlCreateAcl(Dacl, DaclSize, ACL_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to create the DACL (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Add a ACE with allow access to the World SID */
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    AccessMask,
+                                    WorldSid);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to insert allowed access ACE to DACL for World SID (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Initialize the security descriptor */
+    Status = RtlCreateSecurityDescriptor(&AbsoluteSd,
+                                         SECURITY_DESCRIPTOR_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to insert allowed access ACE to DACL for World SID (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Set the DACL to descriptor */
+    Status = RtlSetDaclSecurityDescriptor(&AbsoluteSd,
+                                          TRUE,
+                                          Dacl,
+                                          FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to insert DACL into the descriptor (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Determine how much size is needed to convert the absolute SD into self-relative one */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         NULL,
+                                         &RelSdSize);
+    if (Status != STATUS_BUFFER_TOO_SMALL)
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Unexpected status code, must be STATUS_BUFFER_TOO_SMALL (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Allocate buffer for relative SD */
+    RelativeSd = RtlAllocateHeap(RtlGetProcessHeap(), HEAP_ZERO_MEMORY, RelSdSize);
+    if (RelativeSd == NULL)
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Could not allocate memory for relative SD, not enough memory!\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto Quit;
+    }
+
+    /* Convert it now */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         RelativeSd,
+                                         &RelSdSize);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("CreateNlsSecurityDescriptor(): Failed to convert absolute SD to self-relative format (Status 0x%08x)\n", Status);
+        goto Quit;
+    }
+
+    /* Give the security descriptor to the caller */
+    *SecurityDescriptor = RelativeSd;
+
+Quit:
+    if (WorldSid != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, WorldSid);
+    }
+
+    if (Dacl != NULL)
+    {
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (RelativeSd != NULL)
+        {
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+        }
+    }
+
+    return Status;
 }
 
 /*

--- a/dll/win32/lsasrv/lsasrv.h
+++ b/dll/win32/lsasrv/lsasrv.h
@@ -436,6 +436,12 @@ NTSTATUS
 LsapCreateSecretSd(PSECURITY_DESCRIPTOR *SecretSd,
                    PULONG SecretSdSize);
 
+NTSTATUS
+LsapCreateTokenSd(
+    _In_ const TOKEN_USER *User,
+    _Outptr_ PSECURITY_DESCRIPTOR *TokenSd,
+    _Out_ PULONG TokenSdSize);
+
 /* session.c */
 VOID
 LsapInitLogonSessions(VOID);

--- a/dll/win32/lsasrv/security.c
+++ b/dll/win32/lsasrv/security.c
@@ -599,4 +599,180 @@ done:
     return Status;
 }
 
+
+/**
+ * @brief
+ * Creates a security descriptor for the token
+ * object.
+ *
+ * @param[in] User
+ * A primary user to be given to the function.
+ * This user represents the owner that is in
+ * charge of this object.
+ *
+ * @param[out] TokenSd
+ * A pointer to an allocated security descriptor
+ * for the token object.
+ *
+ * @param[out] TokenSdSize
+ * A pointer to a returned size of the descriptor.
+ *
+ * @return
+ * STATUS_SUCCESS is returned if the function has
+ * successfully created the security descriptor.
+ * STATUS_INVALID_PARAMETER is returned if one of the
+ * parameters are not valid. STATUS_INSUFFICIENT_RESOURCES
+ * is returned if memory heap allocation for specific
+ * security buffers couldn't be done. A NTSTATUS status
+ * code is returned otherwise.
+ *
+ * @remarks
+ * Bot the local system and user are given full access rights
+ * for the token (they can open it, read and write into it, etc.)
+ * whereas admins can only read from the token. This security
+ * descriptor is TO NOT BE confused with the default DACL of the
+ * token which is another thing that serves different purpose.
+ */
+NTSTATUS
+LsapCreateTokenSd(
+    _In_ const TOKEN_USER *User,
+    _Outptr_ PSECURITY_DESCRIPTOR *TokenSd,
+    _Out_ PULONG TokenSdSize)
+{
+    SECURITY_DESCRIPTOR AbsoluteSd;
+    PSECURITY_DESCRIPTOR RelativeSd = NULL;
+    ULONG RelativeSdSize = 0;
+    PSID AdministratorsSid = NULL;
+    PSID LocalSystemSid = NULL;
+    PACL Dacl = NULL;
+    ULONG DaclSize;
+    NTSTATUS Status;
+
+    if (TokenSd == NULL || TokenSdSize == NULL)
+        return STATUS_INVALID_PARAMETER;
+
+    *TokenSd = NULL;
+    *TokenSdSize = 0;
+
+    /* Initialize the SD */
+    Status = RtlCreateSecurityDescriptor(&AbsoluteSd,
+                                         SECURITY_DESCRIPTOR_REVISION);
+    if (!NT_SUCCESS(Status))
+        return Status;
+
+    Status = RtlAllocateAndInitializeSid(&NtAuthority,
+                                         1,
+                                         SECURITY_LOCAL_SYSTEM_RID,
+                                         0, 0, 0, 0, 0, 0, 0,
+                                         &LocalSystemSid);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlAllocateAndInitializeSid(&NtAuthority,
+                                         2,
+                                         SECURITY_BUILTIN_DOMAIN_RID,
+                                         DOMAIN_ALIAS_RID_ADMINS,
+                                         0, 0, 0, 0, 0, 0,
+                                         &AdministratorsSid);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    /* Allocate and initialize the DACL */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(LocalSystemSid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(AdministratorsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(User->User.Sid);
+
+    Dacl = RtlAllocateHeap(RtlGetProcessHeap(),
+                           HEAP_ZERO_MEMORY,
+                           DaclSize);
+    if (Dacl == NULL)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto done;
+    }
+
+    Status = RtlCreateAcl(Dacl,
+                          DaclSize,
+                          ACL_REVISION);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    TOKEN_ALL_ACCESS,
+                                    LocalSystemSid);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    TOKEN_READ,
+                                    AdministratorsSid);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlAddAccessAllowedAce(Dacl,
+                                    ACL_REVISION,
+                                    TOKEN_ALL_ACCESS,
+                                    User->User.Sid);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlSetDaclSecurityDescriptor(&AbsoluteSd,
+                                          TRUE,
+                                          Dacl,
+                                          FALSE);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlSetOwnerSecurityDescriptor(&AbsoluteSd,
+                                           AdministratorsSid,
+                                           FALSE);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         RelativeSd,
+                                         &RelativeSdSize);
+    if (Status != STATUS_BUFFER_TOO_SMALL)
+        goto done;
+
+    RelativeSd = RtlAllocateHeap(RtlGetProcessHeap(),
+                                 HEAP_ZERO_MEMORY,
+                                 RelativeSdSize);
+    if (RelativeSd == NULL)
+    {
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        goto done;
+    }
+
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsoluteSd,
+                                         RelativeSd,
+                                         &RelativeSdSize);
+    if (!NT_SUCCESS(Status))
+        goto done;
+
+    *TokenSd = RelativeSd;
+    *TokenSdSize = RelativeSdSize;
+
+done:
+    if (Dacl != NULL)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, Dacl);
+
+    if (AdministratorsSid != NULL)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, AdministratorsSid);
+
+    if (LocalSystemSid != NULL)
+        RtlFreeHeap(RtlGetProcessHeap(), 0, LocalSystemSid);
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (RelativeSd != NULL)
+            RtlFreeHeap(RtlGetProcessHeap(), 0, RelativeSd);
+    }
+
+    return Status;
+}
+
 /* EOF */

--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -24,6 +24,19 @@ typedef struct _KNOWN_COMPOUND_ACE
     ULONG SidStart;
 } KNOWN_COMPOUND_ACE, *PKNOWN_COMPOUND_ACE;
 
+typedef struct _ACCESS_CHECK_RIGHTS
+{
+    ACCESS_MASK RemainingAccessRights;
+    ACCESS_MASK GrantedAccessRights;
+    ACCESS_MASK DeniedAccessRights;
+} ACCESS_CHECK_RIGHTS, *PACCESS_CHECK_RIGHTS;
+
+typedef enum _ACCESS_CHECK_RIGHT_TYPE
+{
+    AccessCheckMaximum,
+    AccessCheckRegular
+} ACCESS_CHECK_RIGHT_TYPE;
+
 typedef struct _TOKEN_AUDIT_POLICY_INFORMATION
 {
     ULONG PolicyCount;
@@ -500,6 +513,12 @@ SepReleaseSid(
     _In_ PSID CapturedSid,
     _In_ KPROCESSOR_MODE AccessMode,
     _In_ BOOLEAN CaptureIfKernel);
+
+PSID
+NTAPI
+SepGetSidFromAce(
+    _In_ UCHAR AceType,
+    _In_ PACE Ace);
 
 NTSTATUS
 NTAPI

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -159,6 +159,7 @@
 #define TAG_LOGON_NOTIFICATION 'nLeS'
 #define TAG_SID_AND_ATTRIBUTES 'aSeS'
 #define TAG_SID_VALIDATE       'vSeS'
+#define TAG_ACCESS_CHECK_RIGHT 'rCeS'
 
 /* LPC Tags */
 #define TAG_LPC_MESSAGE           'McpL'

--- a/ntoskrnl/se/accesschk.c
+++ b/ntoskrnl/se/accesschk.c
@@ -2,8 +2,9 @@
  * PROJECT:         ReactOS Kernel
  * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:         Security access check control implementation
- * COPYRIGHT:       Copyright Timo Kreuzer <timo.kreuzer@reactos.org>
- *                  Copyright Eric Kohl
+ * COPYRIGHT:       Copyright 2014 Timo Kreuzer <timo.kreuzer@reactos.org>
+ *                  Copyright 2014 Eric Kohl
+ *                  Copyright 2022 George Bișoc <george.bisoc@reactos.org>
  */
 
 /* INCLUDES *******************************************************************/
@@ -12,89 +13,488 @@
 #define NDEBUG
 #include <debug.h>
 
-/* GLOBALS ********************************************************************/
-
-
 /* PRIVATE FUNCTIONS **********************************************************/
 
 /**
  * @brief
- * Private function that determines whether security access rights can be given
- * to an object depending on the security descriptor and other security context
- * entities, such as an owner.
+ * Allocates memory for the internal access check rights
+ * data structure and initializes it for use for the kernel.
+ * The purpose of this piece of data is to track down the
+ * remaining, granted and denied access rights whilst we
+ * are doing an access check procedure.
  *
- * @param[in] SecurityDescriptor
- * Security descriptor of the object that is being accessed.
+ * @return
+ * Returns a pointer to allocated and initialized access
+ * check rights, otherwise NULL is returned.
+ */
+PACCESS_CHECK_RIGHTS
+SepInitAccessCheckRights(VOID)
+{
+    PACCESS_CHECK_RIGHTS AccessRights;
+
+    PAGED_CODE();
+
+    /* Allocate some pool for access check rights */
+    AccessRights = ExAllocatePoolWithTag(PagedPool,
+                                         sizeof(ACCESS_CHECK_RIGHTS),
+                                         TAG_ACCESS_CHECK_RIGHT);
+
+    /* Bail out if we failed */
+    if (!AccessRights)
+    {
+        return NULL;
+    }
+
+    /* Initialize the structure */
+    AccessRights->RemainingAccessRights = 0;
+    AccessRights->GrantedAccessRights = 0;
+    AccessRights->DeniedAccessRights = 0;
+
+    return AccessRights;
+}
+
+/**
+ * @brief
+ * Frees an allocated access check rights from
+ * memory space after access check procedures
+ * have finished.
  *
- * @param[in] SubjectSecurityContext
- * The captured subject security context.
+ * @param[in] AccessRights
+ * A pointer to access check rights of which is
+ * to be freed from memory.
  *
- * @param[in] DesiredAccess
- * Access right bitmask that the calling thread wants to acquire.
+ * @return
+ * Nothing.
+ */
+VOID
+SepFreeAccessCheckRights(
+    _In_ PACCESS_CHECK_RIGHTS AccessRights)
+{
+    PAGED_CODE();
+
+    if (AccessRights)
+    {
+        ExFreePoolWithTag(AccessRights, TAG_ACCESS_CHECK_RIGHT);
+    }
+}
+
+/**
+ * @brief
+ * Analyzes an access control entry that is present in a discretionary
+ * access control list (DACL) for access right masks of each entry with
+ * the purpose to judge whether the calling thread can be warranted
+ * access check to a certain object or not.
  *
- * @param[in] ObjectTypeListLength
- * The length of a object type list.
+ * @param[in] ActionType
+ * The type of analysis to be done against an access entry. This type
+ * influences how access rights are gathered. This can either be AccessCheckMaximum
+ * which means the algorithm will perform analysis against ACEs on behalf of the
+ * requestor that gave us the acknowledgement that he desires MAXIMUM_ALLOWED access
+ * right or AccessCheckRegular if the requestor wants a subset of access rights.
  *
- * @param[in] PreviouslyGrantedAccess
- * The access rights previously acquired in the past.
+ * @param[in] Dacl
+ * The discretionary access control list to be given to this function. This DACL
+ * must have at least one ACE currently present in the list.
  *
- * @param[out] Privileges
- * The returned set of privileges.
+ * @param[in] AccessToken
+ * A pointer to an access token, where an equality comparison check is performed if
+ * the security identifier (SID) from a ACE of a certain object is present in this
+ * token. This token represents the effective (calling thread) token of the caller.
+ *
+ * @param[in] PrimaryAccessToken
+ * A pointer to an access token, represented as an access token associated with the
+ * primary calling process. This token describes the primary security context of the
+ * main process.
+ *
+ * @param[in] IsTokenRestricted
+ * If this parameter is set to TRUE, the function considers the token pointed by
+ * AccessToken parameter argument as restricted. That is, the token has restricted
+ * SIDs therefore the function will act accordingly against that token by checking
+ * for restricted SIDs only when doing an equaility comparison check between the
+ * two identifiers.
+ *
+ * @param[in] AccessRightsAllocated
+ * If this parameter is set to TRUE, the function will not allocate the access
+ * check rights again. This is typical when we have to do additional analysis
+ * of ACEs because a token has restricted SIDs (see IsTokenRestricted parameter)
+ * of which we already initialized the access check rights pointer before.
+ *
+ * @param[in] PrincipalSelfSid
+ * A pointer to a security identifier that represents a principal. A principal
+ * identifies a user object which is associated with its own security descriptor.
  *
  * @param[in] GenericMapping
- * The generic mapping of access rights of an object type.
+ * A pointer to a generic mapping that is associated with the object in question
+ * being checked for access. If certain set of desired access rights have
+ * a generic access right, this parameter is needed to map generic rights.
+ *
+ * @param[in] ObjectTypeList
+ * A pointer to a list array of object types. If such array is provided to the
+ * function, the algorithm will perform a different approach by doing analysis
+ * against ACEs each sub-object of an object of primary level (level 0) or sub-objects
+ * of a sub-object of an object. If this parameter is NULL, the function will normally
+ * analyze the ACEs of a DACL of the target object itself.
+ *
+ * @param[in] ObjectTypeListLength
+ * The length of the object type list array, pointed by ObjectTypeList. This length in
+ * question represents the number of elements in such array. This parameter must be 0
+ * if no array list is provided.
+ *
+ * @param[in] RemainingAccess
+ * The remaining access rights that have yet to be granted to the calling thread
+ * whomst requests access to a certain object. This parameter mustn't be 0 as
+ * the remaining rights are left to be addressed. This is the case if we have
+ * to address the remaining rights on a regular subset basis (the requestor
+ * didn't ask for MAXIMUM_ALLOWED). Otherwise this parameter can be 0.
+ *
+ * @return
+ * Returns a pointer to initialized access check rights after ACE analysis
+ * has finished. This pointer contains the rights that have been acquired
+ * in order to determine if access can be granted to the calling thread.
+ * Typically this pointer contains the remaining, denied and granted rights.
+ *
+ * Otherwise NULL is returned and thus access check procedure can't any longer
+ * continue further. We have prematurely failed this access check operation
+ * at this point.
+ */
+PACCESS_CHECK_RIGHTS
+SepAnalyzeAcesFromDacl(
+    _In_ ACCESS_CHECK_RIGHT_TYPE ActionType,
+    _In_ PACL Dacl,
+    _In_ PACCESS_TOKEN AccessToken,
+    _In_ PACCESS_TOKEN PrimaryAccessToken,
+    _In_ BOOLEAN IsTokenRestricted,
+    _In_ BOOLEAN AccessRightsAllocated,
+    _In_opt_ PSID PrincipalSelfSid,
+    _In_ PGENERIC_MAPPING GenericMapping,
+    _In_opt_ POBJECT_TYPE_LIST ObjectTypeList,
+    _In_ ULONG ObjectTypeListLength,
+    _In_ ACCESS_MASK RemainingAccess)
+{
+    NTSTATUS Status;
+    PACE CurrentAce;
+    ULONG AceIndex;
+    PSID Sid;
+    ACCESS_MASK Access;
+    PACCESS_CHECK_RIGHTS AccessRights;
+
+    PAGED_CODE();
+
+    /* These parameters are really needed */
+    ASSERT(Dacl);
+    ASSERT(AccessToken);
+
+    /* TODO: To be removed once we support object type handling in Se */
+    DBG_UNREFERENCED_PARAMETER(ObjectTypeList);
+    DBG_UNREFERENCED_PARAMETER(ObjectTypeListLength);
+
+    /* TODO: To be removed once we support compound ACEs handling in Se */
+    DBG_UNREFERENCED_PARAMETER(PrimaryAccessToken);
+
+    /*
+     * Allocate memory for access check rights if
+     * we have not done it so. Otherwise just use
+     * the already allocated pointer. This is
+     * typically when we have to do additional
+     * ACEs analysis because the token has
+     * restricted SIDs so we have allocated this
+     * pointer before.
+     */
+    if (!AccessRightsAllocated)
+    {
+        AccessRights = SepInitAccessCheckRights();
+        if (!AccessRights)
+        {
+            DPRINT1("SepAnalyzeAcesFromDacl(): Failed to initialize the access check rights!\n");
+            return NULL;
+        }
+    }
+
+    /* Determine how we should analyze the ACEs */
+    switch (ActionType)
+    {
+        /*
+         * We got the acknowledgement the calling thread desires
+         * maximum rights (as according to MAXIMUM_ALLOWED access
+         * mask). Analyze the ACE of the given DACL.
+         */
+        case AccessCheckMaximum:
+        {
+            /* Loop over the DACL to retrieve ACEs */
+            for (AceIndex = 0; AceIndex < Dacl->AceCount; AceIndex++)
+            {
+                /* Obtain a ACE now */
+                Status = RtlGetAce(Dacl, AceIndex, (PVOID*)&CurrentAce);
+
+                /* Getting this ACE is important, otherwise something is seriously wrong */
+                ASSERT(NT_SUCCESS(Status));
+
+                /*
+                 * Now it's time to analyze it based upon the
+                 * type of this ACE we're being given.
+                 */
+                if (!(CurrentAce->Header.AceFlags & INHERIT_ONLY_ACE))
+                {
+                    if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
+                    {
+                        /* Get the SID from this ACE */
+                        Sid = SepGetSidFromAce(ACCESS_DENIED_ACE_TYPE, CurrentAce);
+
+                        if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, TRUE, IsTokenRestricted))
+                        {
+                            /* Get this access right from the ACE */
+                            Access = CurrentAce->AccessMask;
+
+                            /* Map this access right if it has a generic mask right */
+                            if ((Access & GENERIC_ACCESS) && GenericMapping)
+                            {
+                                RtlMapGenericMask(&Access, GenericMapping);
+                            }
+
+                            /* Deny access rights that have not been granted yet */
+                            AccessRights->DeniedAccessRights |= (Access & ~AccessRights->GrantedAccessRights);
+                            DPRINT("SepAnalyzeAcesFromDacl(): DeniedAccessRights 0x%08lx\n", AccessRights->DeniedAccessRights);
+                        }
+                    }
+                    else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
+                    {
+                        /* Get the SID from this ACE */
+                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_ACE_TYPE, CurrentAce);
+
+                        if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, FALSE, IsTokenRestricted))
+                        {
+                            /* Get this access right from the ACE */
+                            Access = CurrentAce->AccessMask;
+
+                            /* Map this access right if it has a generic mask right */
+                            if ((Access & GENERIC_ACCESS) && GenericMapping)
+                            {
+                                RtlMapGenericMask(&Access, GenericMapping);
+                            }
+
+                            /* Grant access rights that have not been denied yet */
+                            AccessRights->GrantedAccessRights |= (Access & ~AccessRights->DeniedAccessRights);
+                            DPRINT("SepAnalyzeAcesFromDacl(): GrantedAccessRights 0x%08lx\n", AccessRights->GrantedAccessRights);
+                        }
+                    }
+                    else
+                    {
+                        DPRINT1("SepAnalyzeAcesFromDacl(): Unsupported ACE type 0x%lx\n", CurrentAce->Header.AceType);
+                    }
+                }
+            }
+
+            /* We're done here */
+            break;
+        }
+
+        /*
+         * We got the acknowledgement the calling thread desires
+         * only a subset of rights therefore we have to act a little
+         * different here.
+         */
+        case AccessCheckRegular:
+        {
+            /* Cache the remaining access rights to be addressed */
+            AccessRights->RemainingAccessRights = RemainingAccess;
+
+            /* Loop over the DACL to retrieve ACEs */
+            for (AceIndex = 0; AceIndex < Dacl->AceCount; AceIndex++)
+            {
+                /* Obtain a ACE now */
+                Status = RtlGetAce(Dacl, AceIndex, (PVOID*)&CurrentAce);
+
+                /* Getting this ACE is important, otherwise something is seriously wrong */
+                ASSERT(NT_SUCCESS(Status));
+
+                /*
+                 * Now it's time to analyze it based upon the
+                 * type of this ACE we're being given.
+                 */
+                if (!(CurrentAce->Header.AceFlags & INHERIT_ONLY_ACE))
+                {
+                    if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
+                    {
+                        /* Get the SID from this ACE */
+                        Sid = SepGetSidFromAce(ACCESS_DENIED_ACE_TYPE, CurrentAce);
+
+                        if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, TRUE, IsTokenRestricted))
+                        {
+                            /* Get this access right from the ACE */
+                            Access = CurrentAce->AccessMask;
+
+                            /* Map this access right if it has a generic mask right */
+                            if ((Access & GENERIC_ACCESS) && GenericMapping)
+                            {
+                                RtlMapGenericMask(&Access, GenericMapping);
+                            }
+
+                            /*
+                             * The caller requests a right that cannot be
+                             * granted. Access is implicitly denied for
+                             * the calling thread. Track this access right.
+                             */
+                            if (AccessRights->RemainingAccessRights & Access)
+                            {
+                                DPRINT("SepAnalyzeAcesFromDacl(): Refuted access 0x%08lx\n", Access);
+                                AccessRights->DeniedAccessRights |= Access;
+                                break;
+                            }
+                        }
+                    }
+                    else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
+                    {
+                        /* Get the SID from this ACE */
+                        Sid = SepGetSidFromAce(ACCESS_ALLOWED_ACE_TYPE, CurrentAce);
+
+                        if (SepSidInTokenEx(AccessToken, PrincipalSelfSid, Sid, FALSE, IsTokenRestricted))
+                        {
+                            /* Get this access right from the ACE */
+                            Access = CurrentAce->AccessMask;
+
+                            /* Map this access right if it has a generic mask right */
+                            if ((Access & GENERIC_ACCESS) && GenericMapping)
+                            {
+                                RtlMapGenericMask(&Access, GenericMapping);
+                            }
+
+                            /* Remove granted rights */
+                            DPRINT("SepAnalyzeAcesFromDacl(): RemainingAccessRights 0x%08lx  Access 0x%08lx\n", AccessRights->RemainingAccessRights, Access);
+                            AccessRights->RemainingAccessRights &= ~Access;
+                            DPRINT("SepAnalyzeAcesFromDacl(): RemainingAccessRights 0x%08lx\n", AccessRights->RemainingAccessRights);
+
+                            /* Track the granted access right */
+                            AccessRights->GrantedAccessRights |= Access;
+                        }
+                    }
+                    else
+                    {
+                        DPRINT1("SepAnalyzeAcesFromDacl(): Unsupported ACE type 0x%lx\n", CurrentAce->Header.AceType);
+                    }
+                }
+            }
+
+            /* We're done here */
+            break;
+        }
+
+        /* We shouldn't reach here */
+        DEFAULT_UNREACHABLE;
+    }
+
+    /* Return the access rights that we've got */
+    return AccessRights;
+}
+
+/**
+ * @brief
+ * Private function that determines whether security access rights can be given
+ * to the calling thread in order to access an object depending on the security
+ * descriptor and other security context entities, such as an owner. This
+ * function is the heart and brain of the whole access check algorithm in
+ * the kernel.
+ *
+ * @param[in] ClientAccessToken
+ * A pointer to a client (thread) access token that requests access rights
+ * of an object or subset of multiple objects.
+ *
+ * @param[in] PrimaryAccessToken
+ * A pointer to a primary access token that describes the primary security
+ * context of the main calling process.
+ *
+ * @param[in] PrincipalSelfSid
+ * A pointer to a security identifier that represents a security principal,
+ * that is, a user object associated with its security descriptor.
+ *
+ * @param[in] DesiredAccess
+ * The access rights desired by the calling thread to acquire in order to
+ * access an object.
+ *
+ * @param[in] ObjectTypeList
+ * An array list of object types to be checked against for access. The function
+ * will act accordingly in this case by checking each sub-object of an object
+ * of primary level and such. If this parameter is NULL, the function will
+ * perform a normal access check against the target object itself.
+ *
+ * @param[in] ObjectTypeListLength
+ * The length of a object type list. Such length represents the number of
+ * elements in this list.
+ *
+ * @param[in] PreviouslyGrantedAccess
+ * The access rights previously acquired in the past. If this parameter is 0,
+ * it is deemed that the calling thread hasn't acquired any rights. Access checks
+ * are more tighten in this case.
+ *
+ * @param[in] GenericMapping
+ * A pointer to a generic mapping of access rights of the target object.
  *
  * @param[in] AccessMode
  * The processor request level mode.
  *
+ * @param[in] UseResultList
+ * If set to TRUE, the function will return a list of granted access rights
+ * of each sub-object as well as status code for each. If this parameter is
+ * set to FALSE, then the function will just return only the granted access
+ * rights and status code for single object that's been target for access
+ * checks.
+ *
+ * @param[out] Privileges
+ * A pointer to a definite set of privileges that have been audited
+ * whilst doing access check procedures. Such set of privileges are
+ * optionally returned to the caller. This can be set to NULL if
+ * the caller doesn't want to obtain a set of privileges.
+ *
  * @param[out] GrantedAccessList
- * A list of granted access rights.
+ * A list of granted access rights returned to the caller. This list
+ * can comprehend multiple elements which represent the sub-objects
+ * that have been checked or a single element which is the target
+ * object itself.
  *
  * @param[out] AccessStatusList
- * The returned status code specifying why access cannot be made
- * onto an object (if said access is denied in the first place).
- *
- * @param[in] UseResultList
- * If set to TRUE, the function will return complete lists of
- * access status codes and granted access rights.
+ * A list of access status codes returned to the caller. This list
+ * can comprehend multiple elements which represent the sub-objects
+ * that have been checked or a single element which is the target
+ * object itself.
  *
  * @return
  * Returns TRUE if access onto the specific object is allowed, FALSE
  * otherwise.
- *
- * @remarks
- * The function is currently incomplete!
  */
-BOOLEAN NTAPI
+BOOLEAN
+NTAPI
 SepAccessCheck(
     _In_ PSECURITY_DESCRIPTOR SecurityDescriptor,
-    _In_ PSECURITY_SUBJECT_CONTEXT SubjectSecurityContext,
+    _In_opt_ PACCESS_TOKEN ClientAccessToken,
+    _In_ PACCESS_TOKEN PrimaryAccessToken,
+    _In_opt_ PSID PrincipalSelfSid,
     _In_ ACCESS_MASK DesiredAccess,
-    _In_ POBJECT_TYPE_LIST ObjectTypeList,
+    _In_opt_ POBJECT_TYPE_LIST ObjectTypeList,
     _In_ ULONG ObjectTypeListLength,
     _In_ ACCESS_MASK PreviouslyGrantedAccess,
-    _Out_ PPRIVILEGE_SET* Privileges,
     _In_ PGENERIC_MAPPING GenericMapping,
     _In_ KPROCESSOR_MODE AccessMode,
+    _In_ BOOLEAN UseResultList,
+    _Out_opt_ PPRIVILEGE_SET* Privileges,
     _Out_ PACCESS_MASK GrantedAccessList,
-    _Out_ PNTSTATUS AccessStatusList,
-    _In_ BOOLEAN UseResultList)
+    _Out_ PNTSTATUS AccessStatusList)
 {
     ACCESS_MASK RemainingAccess;
-    ACCESS_MASK TempAccess;
-    ACCESS_MASK TempGrantedAccess = 0;
-    ACCESS_MASK TempDeniedAccess = 0;
+    PACCESS_CHECK_RIGHTS AccessCheckRights;
     PACCESS_TOKEN Token;
-    ULONG i, ResultListLength;
+    ULONG ResultListLength;
+    ULONG ResultListIndex;
     PACL Dacl;
     BOOLEAN Present;
     BOOLEAN Defaulted;
-    PACE CurrentAce;
-    PSID Sid;
     NTSTATUS Status;
+
     PAGED_CODE();
 
-    DPRINT("SepAccessCheck()\n");
+    /* A security descriptor must be expected for access checks */
+    ASSERT(SecurityDescriptor);
+
+    /* Assume no access check rights first */
+    AccessCheckRights = NULL;
 
     /* Check for no access desired */
     if (!DesiredAccess)
@@ -103,6 +503,7 @@ SepAccessCheck(
         if (!PreviouslyGrantedAccess)
         {
             /* Then there's nothing to give */
+            DPRINT1("SepAccessCheck(): The caller has no previously granted access gained!\n");
             Status = STATUS_ACCESS_DENIED;
             goto ReturnCommonStatus;
         }
@@ -121,16 +522,35 @@ SepAccessCheck(
     /* Initialize remaining access rights */
     RemainingAccess = DesiredAccess;
 
-    Token = SubjectSecurityContext->ClientToken ?
-        SubjectSecurityContext->ClientToken : SubjectSecurityContext->PrimaryToken;
+    /*
+     * Obtain the token provided by the caller. Client (or also
+     * called impersonation or thread) token takes precedence over
+     * the primary token which is the token associated with the security
+     * context of the main calling process. This is because it is the
+     * client itself that requests access of an object or subset of
+     * multiple objects. Otherwise obtain the security context of the
+     * main process (the actual primary token).
+     */
+    Token = ClientAccessToken ? ClientAccessToken : PrimaryAccessToken;
 
-    /* Check for ACCESS_SYSTEM_SECURITY and WRITE_OWNER access */
+    /*
+     * We should at least expect a primary token
+     * to be present if client token is not
+     * available.
+     */
+    ASSERT(Token);
+
+    /*
+     * Check for ACCESS_SYSTEM_SECURITY and WRITE_OWNER access.
+     * Write down a set of privileges that have been checked
+     * if the caller wants it.
+     */
     Status = SePrivilegePolicyCheck(&RemainingAccess,
                                     &PreviouslyGrantedAccess,
                                     NULL,
                                     Token,
-                                    NULL,
-                                    UserMode);
+                                    Privileges,
+                                    AccessMode);
     if (!NT_SUCCESS(Status))
     {
         goto ReturnCommonStatus;
@@ -153,7 +573,7 @@ SepAccessCheck(
         goto ReturnCommonStatus;
     }
 
-    /* RULE 1: Grant desired access if the object is unprotected */
+    /* Grant desired access if the object is unprotected */
     if (Present == FALSE || Dacl == NULL)
     {
         PreviouslyGrantedAccess |= RemainingAccess;
@@ -176,6 +596,7 @@ SepAccessCheck(
         }
         else
         {
+            DPRINT1("SepAccessCheck(): The DACL has no ACEs and the caller has no previously granted access!\n");
             PreviouslyGrantedAccess = 0;
             Status = STATUS_ACCESS_DENIED;
         }
@@ -185,125 +606,140 @@ SepAccessCheck(
     /* Determine the MAXIMUM_ALLOWED access rights according to the DACL */
     if (DesiredAccess & MAXIMUM_ALLOWED)
     {
-        CurrentAce = (PACE)(Dacl + 1);
-        for (i = 0; i < Dacl->AceCount; i++)
+        /* Perform access checks against ACEs from this DACL */
+        AccessCheckRights = SepAnalyzeAcesFromDacl(AccessCheckMaximum,
+                                                   Dacl,
+                                                   Token,
+                                                   PrimaryAccessToken,
+                                                   FALSE,
+                                                   FALSE,
+                                                   PrincipalSelfSid,
+                                                   GenericMapping,
+                                                   ObjectTypeList,
+                                                   ObjectTypeListLength,
+                                                   0);
+
+        /*
+         * Getting the access check rights is very
+         * important as we have to do access checks
+         * depending on the kind of rights we get.
+         * Fail prematurely if we can't...
+         */
+        if (!AccessCheckRights)
         {
-            if (!(CurrentAce->Header.AceFlags & INHERIT_ONLY_ACE))
-            {
-                Sid = (PSID)(CurrentAce + 1);
-                if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
-                {
-                    if (SepSidInToken(Token, Sid))
-                    {
-                        /* Map access rights from the ACE */
-                        TempAccess = CurrentAce->AccessMask;
-                        RtlMapGenericMask(&TempAccess, GenericMapping);
+            DPRINT1("SepAccessCheck(): Failed to obtain access check rights!\n");
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            PreviouslyGrantedAccess = 0;
+            goto ReturnCommonStatus;
+        }
 
-                        /* Deny access rights that have not been granted yet */
-                        TempDeniedAccess |= (TempAccess & ~TempGrantedAccess);
-                    }
-                }
-                else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
-                {
-                    if (SepSidInToken(Token, Sid))
-                    {
-                        /* Map access rights from the ACE */
-                        TempAccess = CurrentAce->AccessMask;
-                        RtlMapGenericMask(&TempAccess, GenericMapping);
-
-                        /* Grant access rights that have not been denied yet */
-                        TempGrantedAccess |= (TempAccess & ~TempDeniedAccess);
-                    }
-                }
-                else
-                {
-                    DPRINT1("Unsupported ACE type 0x%lx\n", CurrentAce->Header.AceType);
-                }
-            }
-
-            /* Get the next ACE */
-            CurrentAce = (PACE)((ULONG_PTR)CurrentAce + CurrentAce->Header.AceSize);
+        /*
+         * Perform further access checks if this token
+         * has restricted SIDs.
+         */
+        if (SeTokenIsRestricted(Token))
+        {
+            AccessCheckRights = SepAnalyzeAcesFromDacl(AccessCheckMaximum,
+                                                       Dacl,
+                                                       Token,
+                                                       PrimaryAccessToken,
+                                                       TRUE,
+                                                       TRUE,
+                                                       PrincipalSelfSid,
+                                                       GenericMapping,
+                                                       ObjectTypeList,
+                                                       ObjectTypeListLength,
+                                                       0);
         }
 
         /* Fail if some rights have not been granted */
-        RemainingAccess &= ~(MAXIMUM_ALLOWED | TempGrantedAccess);
+        RemainingAccess &= ~(MAXIMUM_ALLOWED | AccessCheckRights->GrantedAccessRights);
         if (RemainingAccess != 0)
         {
+            DPRINT1("SepAccessCheck(): Failed to grant access rights. RemainingAccess = 0x%08lx  DesiredAccess = 0x%08lx\n", RemainingAccess, DesiredAccess);
             PreviouslyGrantedAccess = 0;
             Status = STATUS_ACCESS_DENIED;
             goto ReturnCommonStatus;
         }
 
         /* Set granted access right and access status */
-        PreviouslyGrantedAccess |= TempGrantedAccess;
+        PreviouslyGrantedAccess |= AccessCheckRights->GrantedAccessRights;
         if (PreviouslyGrantedAccess != 0)
         {
             Status = STATUS_SUCCESS;
         }
         else
         {
+            DPRINT1("SepAccessCheck(): Failed to grant access rights. PreviouslyGrantedAccess == 0  DesiredAccess = %08lx\n", DesiredAccess);
             Status = STATUS_ACCESS_DENIED;
         }
+
+        /* We have successfully granted all the rights */
         goto ReturnCommonStatus;
     }
 
-    /* RULE 4: Grant rights according to the DACL */
-    CurrentAce = (PACE)(Dacl + 1);
-    for (i = 0; i < Dacl->AceCount; i++)
+    /* Grant rights according to the DACL */
+    AccessCheckRights = SepAnalyzeAcesFromDacl(AccessCheckRegular,
+                                               Dacl,
+                                               Token,
+                                               PrimaryAccessToken,
+                                               FALSE,
+                                               FALSE,
+                                               PrincipalSelfSid,
+                                               GenericMapping,
+                                               ObjectTypeList,
+                                               ObjectTypeListLength,
+                                               RemainingAccess);
+
+    /*
+     * Getting the access check rights is very
+     * important as we have to do access checks
+     * depending on the kind of rights we get.
+     * Fail prematurely if we can't...
+     */
+    if (!AccessCheckRights)
     {
-        if (!(CurrentAce->Header.AceFlags & INHERIT_ONLY_ACE))
-        {
-            Sid = (PSID)(CurrentAce + 1);
-            if (CurrentAce->Header.AceType == ACCESS_DENIED_ACE_TYPE)
-            {
-                if (SepSidInToken(Token, Sid))
-                {
-                    /* Map access rights from the ACE */
-                    TempAccess = CurrentAce->AccessMask;
-                    RtlMapGenericMask(&TempAccess, GenericMapping);
-
-                    /* Leave if a remaining right must be denied */
-                    if (RemainingAccess & TempAccess)
-                        break;
-                }
-            }
-            else if (CurrentAce->Header.AceType == ACCESS_ALLOWED_ACE_TYPE)
-            {
-                if (SepSidInToken(Token, Sid))
-                {
-                    /* Map access rights from the ACE */
-                    TempAccess = CurrentAce->AccessMask;
-                    DPRINT("TempAccess 0x%08lx\n", TempAccess);
-                    RtlMapGenericMask(&TempAccess, GenericMapping);
-
-                    /* Remove granted rights */
-                    DPRINT("RemainingAccess 0x%08lx  TempAccess 0x%08lx\n", RemainingAccess, TempAccess);
-                    RemainingAccess &= ~TempAccess;
-                    DPRINT("RemainingAccess 0x%08lx\n", RemainingAccess);
-                }
-            }
-            else
-            {
-                DPRINT1("Unsupported ACE type 0x%lx\n", CurrentAce->Header.AceType);
-            }
-        }
-
-        /* Get the next ACE */
-        CurrentAce = (PACE)((ULONG_PTR)CurrentAce + CurrentAce->Header.AceSize);
+        DPRINT1("SepAccessCheck(): Failed to obtain access check rights!\n");
+        Status = STATUS_INSUFFICIENT_RESOURCES;
+        PreviouslyGrantedAccess = 0;
+        goto ReturnCommonStatus;
     }
-
-    DPRINT("DesiredAccess %08lx\nPreviouslyGrantedAccess %08lx\nRemainingAccess %08lx\n",
-           DesiredAccess, PreviouslyGrantedAccess, RemainingAccess);
 
     /* Fail if some rights have not been granted */
-    if (RemainingAccess != 0)
+    if (AccessCheckRights->RemainingAccessRights != 0)
     {
-        DPRINT("HACK: RemainingAccess = 0x%08lx  DesiredAccess = 0x%08lx\n", RemainingAccess, DesiredAccess);
-#if 0
-        /* HACK HACK HACK */
+        DPRINT1("SepAccessCheck(): Failed to grant access rights. RemainingAccess = 0x%08lx  DesiredAccess = 0x%08lx\n", AccessCheckRights->RemainingAccessRights, DesiredAccess);
+        PreviouslyGrantedAccess = 0;
         Status = STATUS_ACCESS_DENIED;
         goto ReturnCommonStatus;
-#endif
+    }
+
+    /*
+     * Perform further access checks if this token
+     * has restricted SIDs.
+     */
+    if (SeTokenIsRestricted(Token))
+    {
+        AccessCheckRights = SepAnalyzeAcesFromDacl(AccessCheckRegular,
+                                                   Dacl,
+                                                   Token,
+                                                   PrimaryAccessToken,
+                                                   TRUE,
+                                                   TRUE,
+                                                   PrincipalSelfSid,
+                                                   GenericMapping,
+                                                   ObjectTypeList,
+                                                   ObjectTypeListLength,
+                                                   RemainingAccess);
+
+        /* Fail if some rights have not been granted */
+        if (AccessCheckRights->RemainingAccessRights != 0)
+        {
+            DPRINT1("SepAccessCheck(): Failed to grant access rights. RemainingAccess = 0x%08lx  DesiredAccess = 0x%08lx\n", AccessCheckRights->RemainingAccessRights, DesiredAccess);
+            PreviouslyGrantedAccess = 0;
+            Status = STATUS_ACCESS_DENIED;
+            goto ReturnCommonStatus;
+        }
     }
 
     /* Set granted access rights */
@@ -312,21 +748,28 @@ SepAccessCheck(
     /* Fail if no rights have been granted */
     if (PreviouslyGrantedAccess == 0)
     {
-        DPRINT1("PreviouslyGrantedAccess == 0  DesiredAccess = %08lx\n", DesiredAccess);
+        DPRINT1("SepAccessCheck(): Failed to grant access rights. PreviouslyGrantedAccess == 0  DesiredAccess = %08lx\n", DesiredAccess);
         Status = STATUS_ACCESS_DENIED;
         goto ReturnCommonStatus;
     }
 
+    /*
+     * If we're here then we granted all the desired
+     * access rights the caller wanted.
+     */
     Status = STATUS_SUCCESS;
-    goto ReturnCommonStatus;
 
 ReturnCommonStatus:
     ResultListLength = UseResultList ? ObjectTypeListLength : 1;
-    for (i = 0; i < ResultListLength; i++)
+    for (ResultListIndex = 0; ResultListIndex < ResultListLength; ResultListIndex++)
     {
-        GrantedAccessList[i] = PreviouslyGrantedAccess;
-        AccessStatusList[i] = Status;
+        GrantedAccessList[ResultListIndex] = PreviouslyGrantedAccess;
+        AccessStatusList[ResultListIndex] = Status;
     }
+
+    /* Free the allocated access check rights */
+    SepFreeAccessCheckRights(AccessCheckRights);
+    AccessCheckRights = NULL;
 
     return NT_SUCCESS(Status);
 }
@@ -425,8 +868,9 @@ SepGetPrivilegeSetLength(
  * The captured subject security context.
  *
  * @param[in] SubjectContextLocked
- * If set to TRUE, a lock must be acquired for the security subject
- * context.
+ * If set to TRUE, the caller acknowledges that the subject context
+ * has already been locked by the caller himself. If set to FALSE,
+ * the function locks the subject context.
  *
  * @param[in] DesiredAccess
  * Access right bitmask that the calling thread wants to acquire.
@@ -552,17 +996,19 @@ SeAccessCheck(
     {
         /* Call the internal function */
         ret = SepAccessCheck(SecurityDescriptor,
-                             SubjectSecurityContext,
+                             SubjectSecurityContext->ClientToken,
+                             SubjectSecurityContext->PrimaryToken,
+                             NULL,
                              DesiredAccess,
                              NULL,
                              0,
                              PreviouslyGrantedAccess,
-                             Privileges,
                              GenericMapping,
                              AccessMode,
+                             FALSE,
+                             Privileges,
                              GrantedAccess,
-                             AccessStatus,
-                             FALSE);
+                             AccessStatus);
     }
 
     /* Release the lock if needed */
@@ -726,6 +1172,7 @@ NtAccessCheck(
     ULONG CapturedPrivilegeSetLength, RequiredPrivilegeSetLength;
     PTOKEN Token;
     NTSTATUS Status;
+
     PAGED_CODE();
 
     /* Check if this is kernel mode */
@@ -922,17 +1369,19 @@ NtAccessCheck(
     {
         /* Now perform the access check */
         SepAccessCheck(CapturedSecurityDescriptor,
-                       &SubjectSecurityContext,
+                       Token,
+                       &SubjectSecurityContext.PrimaryToken,
+                       NULL,
                        DesiredAccess,
                        NULL,
                        0,
                        PreviouslyGrantedAccess,
-                       &PrivilegeSet, //FIXME
                        GenericMapping,
                        PreviousMode,
+                       FALSE,
+                       NULL,
                        GrantedAccess,
-                       AccessStatus,
-                       FALSE);
+                       AccessStatus);
     }
 
     /* Release subject context and unlock the token */

--- a/ntoskrnl/se/sid.c
+++ b/ntoskrnl/se/sid.c
@@ -414,6 +414,77 @@ SepReleaseSid(
 
 /**
  * @brief
+ * Captures a security identifier from a
+ * given access control entry. This identifier
+ * is valid for the whole of its lifetime.
+ *
+ * @param[in] AceType
+ * The type of an access control entry. This
+ * type that is given by the calling thread
+ * must coincide with the actual ACE that is
+ * given in the second parameter otherwise this
+ * can potentially lead to UNDEFINED behavior!
+ *
+ * @param[in] Ace
+ * A pointer to an access control entry, which
+ * can be obtained from a DACL.
+ *
+ * @return
+ * Returns a pointer to a security identifier (SID),
+ * otherwise NULL is returned if an unsupported ACE
+ * type was given to the function.
+ */
+PSID
+NTAPI
+SepGetSidFromAce(
+    _In_ UCHAR AceType,
+    _In_ PACE Ace)
+{
+    PSID Sid;
+    PAGED_CODE();
+
+    /* Sanity check */
+    ASSERT(Ace);
+
+    /* Initialize the SID */
+    Sid = NULL;
+
+    /* Obtain the SID based upon ACE type */
+    switch (AceType)
+    {
+        case ACCESS_DENIED_ACE_TYPE:
+        {
+            Sid = (PSID)&((PACCESS_DENIED_ACE)Ace)->SidStart;
+            break;
+        }
+
+        case ACCESS_ALLOWED_ACE_TYPE:
+        {
+            Sid = (PSID)&((PACCESS_ALLOWED_ACE)Ace)->SidStart;
+            break;
+        }
+
+        case ACCESS_DENIED_OBJECT_ACE_TYPE:
+        {
+            Sid = (PSID)&((PACCESS_DENIED_OBJECT_ACE)Ace)->SidStart;
+            break;
+        }
+
+        case ACCESS_ALLOWED_OBJECT_ACE_TYPE:
+        {
+            Sid = (PSID)&((PACCESS_ALLOWED_OBJECT_ACE)Ace)->SidStart;
+            break;
+        }
+
+        default:
+            break;
+    }
+
+    return Sid;
+}
+
+/**
+ * @brief
  * Captures a SID with attributes.
  *
  * @param[in] SrcSidAndAttributes

--- a/sdk/include/xdk/setypes.h
+++ b/sdk/include/xdk/setypes.h
@@ -765,6 +765,24 @@ typedef struct _ACCESS_DENIED_ACE {
   $ULONG SidStart;
 } ACCESS_DENIED_ACE, *PACCESS_DENIED_ACE;
 
+typedef struct _ACCESS_ALLOWED_OBJECT_ACE {
+  ACE_HEADER Header;
+  ACCESS_MASK Mask;
+  $ULONG Flags;
+  GUID ObjectType;
+  GUID InheritedObjectType;
+  $ULONG SidStart;
+} ACCESS_ALLOWED_OBJECT_ACE, *PACCESS_ALLOWED_OBJECT_ACE;
+
+typedef struct _ACCESS_DENIED_OBJECT_ACE {
+  ACE_HEADER  Header;
+  ACCESS_MASK Mask;
+  $ULONG Flags;
+  GUID ObjectType;
+  GUID InheritedObjectType;
+  $ULONG SidStart;
+} ACCESS_DENIED_OBJECT_ACE, *PACCESS_DENIED_OBJECT_ACE;
+
 typedef struct _SYSTEM_AUDIT_ACE {
   ACE_HEADER Header;
   ACCESS_MASK Mask;

--- a/sdk/include/xdk/winnt_old.h
+++ b/sdk/include/xdk/winnt_old.h
@@ -2426,24 +2426,6 @@ typedef struct _SECURITY_ATTRIBUTES {
 
 $include(setypes.h)
 
-typedef struct _ACCESS_ALLOWED_OBJECT_ACE {
-  ACE_HEADER Header;
-  ACCESS_MASK Mask;
-  DWORD Flags;
-  GUID ObjectType;
-  GUID InheritedObjectType;
-  DWORD SidStart;
-} ACCESS_ALLOWED_OBJECT_ACE,*PACCESS_ALLOWED_OBJECT_ACE;
-
-typedef struct _ACCESS_DENIED_OBJECT_ACE {
-  ACE_HEADER Header;
-  ACCESS_MASK Mask;
-  DWORD Flags;
-  GUID ObjectType;
-  GUID InheritedObjectType;
-  DWORD SidStart;
-} ACCESS_DENIED_OBJECT_ACE,*PACCESS_DENIED_OBJECT_ACE;
-
 typedef struct _SYSTEM_AUDIT_OBJECT_ACE {
   ACE_HEADER Header;
   ACCESS_MASK Mask;

--- a/subsystems/win/basesrv/basesrv.h
+++ b/subsystems/win/basesrv/basesrv.h
@@ -58,9 +58,9 @@ typedef BOOL (WINAPI *PGET_NLS_SECTION_NAME)(UINT   CodePage,
                                              ULONG  ResultSize);
 
 typedef BOOL (WINAPI *PVALIDATE_LOCALE)(IN ULONG LocaleId);
-typedef NTSTATUS (WINAPI *PCREATE_NLS_SECURTY_DESCRIPTOR)(IN PVOID Buffer,
-                                                          IN ULONG BufferSize,
-                                                          IN ULONG AceType);
+typedef NTSTATUS (WINAPI *PCREATE_NLS_SECURTY_DESCRIPTOR)(_Out_ PVOID *SecurityDescriptorBuffer,
+                                                          _In_ ULONG DescriptorSize,
+                                                          _In_ ULONG AccessMask);
 
 /* Globals */
 extern HANDLE BaseSrvHeap;

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -144,6 +144,7 @@ list(APPEND SOURCE
     user/ntuser/prop.c
     user/ntuser/scrollbar.c
     user/ntuser/scrollex.c
+    user/ntuser/security.c
     user/ntuser/session.c
     user/ntuser/shutdown.c
     user/ntuser/simplecall.c

--- a/win32ss/gdi/ntgdi/gdidbg.c
+++ b/win32ss/gdi/ntgdi/gdidbg.c
@@ -87,6 +87,7 @@ DBG_CHANNEL DbgChannels[DbgChCount] = {
     {L"UserProcess", DbgChUserProcess},
     {L"UserProp", DbgChUserProp},
     {L"UserScrollbar", DbgChUserScrollbar},
+    {L"UserSecurity", DbgChUserSecurity},
     {L"UserShutdown", DbgChUserShutdown},
     {L"UserSysparams", DbgChUserSysparams},
     {L"UserTimer", DbgChUserTimer},

--- a/win32ss/pch.h
+++ b/win32ss/pch.h
@@ -25,6 +25,7 @@
 #include <ndk/mmfuncs.h>
 #include <ndk/obfuncs.h>
 #include <ndk/psfuncs.h>
+#include <ndk/sefuncs.h>
 #include <ndk/rtlfuncs.h>
 #include <ntstrsafe.h>
 #include <ntintsafe.h>

--- a/win32ss/user/ntuser/desktop.h
+++ b/win32ss/user/ntuser/desktop.h
@@ -55,32 +55,6 @@ typedef struct _DESKTOP
 #define DT_GWL_PROCESSID 0
 #define DT_GWL_THREADID  4
 
-#define DESKTOP_READ       STANDARD_RIGHTS_READ      | \
-                           DESKTOP_ENUMERATE         | \
-                           DESKTOP_READOBJECTS
-
-#define DESKTOP_WRITE       STANDARD_RIGHTS_WRITE    | \
-                            DESKTOP_CREATEMENU       | \
-                            DESKTOP_CREATEWINDOW     | \
-                            DESKTOP_HOOKCONTROL      | \
-                            DESKTOP_JOURNALPLAYBACK  | \
-                            DESKTOP_JOURNALRECORD    | \
-                            DESKTOP_WRITEOBJECTS
-
-#define DESKTOP_EXECUTE     STANDARD_RIGHTS_EXECUTE  | \
-                            DESKTOP_SWITCHDESKTOP
-
-#define DESKTOP_ALL_ACCESS  STANDARD_RIGHTS_REQUIRED | \
-                            DESKTOP_CREATEMENU       | \
-                            DESKTOP_CREATEWINDOW     | \
-                            DESKTOP_ENUMERATE        | \
-                            DESKTOP_HOOKCONTROL      | \
-                            DESKTOP_JOURNALPLAYBACK  | \
-                            DESKTOP_JOURNALRECORD    | \
-                            DESKTOP_READOBJECTS      | \
-                            DESKTOP_SWITCHDESKTOP    | \
-                            DESKTOP_WRITEOBJECTS
-
 extern PDESKTOP gpdeskInputDesktop;
 extern PCLS DesktopWindowClass;
 extern HDC ScreenDeviceContext;

--- a/win32ss/user/ntuser/security.c
+++ b/win32ss/user/ntuser/security.c
@@ -1,0 +1,493 @@
+/*
+ * PROJECT:         ReactOS Win32k subsystem
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security infrastructure of NTUSER component of Win32k
+ * COPYRIGHT:       Copyright 2022 George Bișoc <george.bisoc@reactos.org>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <win32k.h>
+DBG_DEFAULT_CHANNEL(UserSecurity);
+
+/* FUNCTIONS *****************************************************************/
+
+/**
+ * @brief
+ * Opens an access token that represents the effective security
+ * context of the caller. The purpose of this function is to query
+ * the authenticated user that is associated with the security
+ * context.
+ *
+ * @return
+ * Returns a handle to an opened access token that represents the
+ * security context of the authenticated user, otherwise NULL.
+ */
+HANDLE
+IntGetCurrentAccessToken(VOID)
+{
+    NTSTATUS Status;
+    HANDLE TokenHandle;
+
+    /*
+     * Try acquiring the security context by opening
+     * the current thread (or so called impersonation)
+     * token. Such token represents the effective caller.
+     * Otherwise if the current thread does not have a
+     * token (hence no impersonation occurs) then open
+     * the token of main calling process instead.
+     */
+    Status = ZwOpenThreadToken(ZwCurrentThread(),
+                               TOKEN_QUERY,
+                               FALSE,
+                               &TokenHandle);
+    if (!NT_SUCCESS(Status))
+    {
+        /*
+         * We might likely fail to open the thread
+         * token if the process isn't impersonating
+         * a client. In scenarios where the server
+         * isn't impersonating, open the main process
+         * token.
+         */
+        if (Status == STATUS_NO_TOKEN)
+        {
+            TRACE("IntGetCurrentAccessToken(): The thread doesn't have a token, trying to open the process one...\n");
+            Status = ZwOpenProcessToken(ZwCurrentProcess(),
+                                        TOKEN_QUERY,
+                                        &TokenHandle);
+            if (!NT_SUCCESS(Status))
+            {
+                /* We failed opening process token as well, bail out... */
+                ERR("IntGetCurrentAccessToken(): Failed to capture security context, couldn't open the process token (Status 0x%08lx)\n", Status);
+                return NULL;
+            }
+
+            /* Return the opened token handle */
+            return TokenHandle;
+        }
+
+        /* There's a thread token but we couldn't open it so bail out */
+        ERR("IntGetCurrentAccessToken(): Failed to capture security context, couldn't open the thread token (Status 0x%08lx)\n", Status);
+        return NULL;
+    }
+
+    /* Return the opened token handle */
+    return TokenHandle;
+}
+
+/**
+ * @brief
+ * Allocates a buffer within UM (user mode) address
+ * space area. Such buffer is reserved for security
+ * purposes, such as allocating a buffer for a DACL
+ * or a security descriptor.
+ *
+ * @param[in] Length
+ * The length of the buffer that has to be allocated,
+ * in bytes.
+ *
+ * @return
+ * Returns a pointer to an allocated buffer whose
+ * contents are arbitrary. If the function fails,
+ * it means no pages are available to reserve for
+ * memory allocation for this buffer.
+ */
+PVOID
+IntAllocateSecurityBuffer(
+    _In_ SIZE_T Length)
+{
+    NTSTATUS Status;
+    PVOID Buffer = NULL;
+
+    /* Allocate the buffer in UM memory space */
+    Status = ZwAllocateVirtualMemory(ZwCurrentProcess(),
+                                     &Buffer,
+                                     0,
+                                     &Length,
+                                     MEM_COMMIT,
+                                     PAGE_READWRITE);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntAllocateSecurityBuffer(): Failed to allocate the buffer (Status 0x%08lx)\n", Status);
+        return NULL;
+    }
+
+    return Buffer;
+}
+
+/**
+ * @brief
+ * Frees an allocated security buffer from UM
+ * memory that is been previously allocated by
+ * IntAllocateSecurityBuffer function.
+ *
+ * @param[in] Buffer
+ * A pointer to a buffer whose contents are
+ * arbitrary, to be freed from UM memory space.
+ *
+ * @return
+ * Nothing.
+ */
+VOID
+IntFreeSecurityBuffer(
+    _In_ PVOID Buffer)
+{
+    SIZE_T Size = 0;
+
+    ZwFreeVirtualMemory(ZwCurrentProcess(),
+                        &Buffer,
+                        &Size,
+                        MEM_RELEASE);
+}
+
+/**
+ * @brief
+ * Queries the authenticated user security identifier
+ * (SID) that is associated with the security context
+ * of the access token that is being opened.
+ *
+ * @param[out] User
+ * A pointer to the token user that contains the security
+ * identifier of the authenticated user.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the function has successfully
+ * queried the token user. STATUS_UNSUCCESSFUL is returned
+ * if the effective token of the caller couldn't be opened.
+ * STATUS_NO_MEMORY is returned if memory allocation for
+ * token user buffer has failed because of lack of necessary
+ * pages reserved for such allocation. A failure NTSTATUS
+ * code is returned otherwise.
+ *
+ * @remarks
+ * !!!WARNING!!! -- THE CALLER WHO QUERIES THE TOKEN USER IS
+ * RESPONSIBLE TO FREE THE ALLOCATED TOKEN USER BUFFER THAT IS
+ * BEING GIVEN.
+ */
+NTSTATUS
+IntQueryUserSecurityIdentification(
+    _Out_ PTOKEN_USER *User)
+{
+    NTSTATUS Status;
+    PTOKEN_USER UserToken;
+    HANDLE Token;
+    ULONG BufferLength;
+
+    /* Initialize the parameter */
+    *User = NULL;
+
+    /* Open the current token of the caller */
+    Token = IntGetCurrentAccessToken();
+    if (!Token)
+    {
+        ERR("IntQueryUserSecurityIdentification(): Couldn't capture the token!\n");
+        return STATUS_UNSUCCESSFUL;
+    }
+
+    /*
+     * Since we do not know what the length
+     * of the buffer size should be exactly to
+     * hold the user data, let the function
+     * tell us the size.
+     */
+    Status = ZwQueryInformationToken(Token,
+                                     TokenUser,
+                                     NULL,
+                                     0,
+                                     &BufferLength);
+    if (!NT_SUCCESS(Status) && Status == STATUS_BUFFER_TOO_SMALL)
+    {
+        /*
+         * Allocate some memory for the buffer
+         * based on the size that the function
+         * gave us.
+         */
+        UserToken = IntAllocateSecurityBuffer(BufferLength);
+        if (!UserToken)
+        {
+            /* Bail out if we failed */
+            ERR("IntQueryUserSecurityIdentification(): Couldn't allocate memory for the token user!\n");
+            ZwClose(Token);
+            return STATUS_NO_MEMORY;
+        }
+    }
+
+    /* Query the user now as we have plenty of space to hold it */
+    Status = ZwQueryInformationToken(Token,
+                                     TokenUser,
+                                     UserToken,
+                                     BufferLength,
+                                     &BufferLength);
+    if (!NT_SUCCESS(Status))
+    {
+        /* We failed, bail out */
+        ERR("IntQueryUserSecurityIdentification(): Failed to query token user (Status 0x%08lx)\n", Status);
+        IntFreeSecurityBuffer(UserToken);
+        ZwClose(Token);
+        return Status;
+    }
+
+    /* All good, give the buffer to the caller and close the captured token */
+    *User = UserToken;
+    ZwClose(Token);
+
+    return STATUS_SUCCESS;
+}
+
+/**
+ * @brief
+ * Creates a security descriptor for the service.
+ *
+ * @param[out] ServiceSd
+ * A pointer to a newly allocated and created security
+ * descriptor for the service.
+ *
+ * @return
+ * Returns STATUS_SUCCESS if the function has successfully
+ * queried created the security descriptor. STATUS_NO_MEMORY
+ * is returned if memory allocation for security buffers because
+ * of a lack of needed pages to reserve for such allocation. A
+ * failure NTSTATUS code is returned otherwise.
+ */
+NTSTATUS
+NTAPI
+IntCreateServiceSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ServiceSd)
+{
+    NTSTATUS Status;
+    PACL ServiceDacl;
+    ULONG DaclSize;
+    ULONG RelSDSize;
+    SECURITY_DESCRIPTOR AbsSD;
+    PSECURITY_DESCRIPTOR RelSD;
+    PTOKEN_USER TokenUser;
+
+    /* Initialize our local variables */
+    RelSDSize = 0;
+    TokenUser = NULL;
+    RelSD = NULL;
+    ServiceDacl = NULL;
+
+    /* Query the logged in user of the current security context (aka token) */
+    Status = IntQueryUserSecurityIdentification(&TokenUser);
+    if (!TokenUser)
+    {
+        ERR("IntCreateServiceSecurity(): Failed to query the token user (Status 0x%08lx)\n", Status);
+        return Status;
+    }
+
+    /* Initialize the absolute security descriptor */
+    Status = RtlCreateSecurityDescriptor(&AbsSD, SECURITY_DESCRIPTOR_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to initialize absolute SD (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * Build up the size of access control
+     * list (the DACL) necessary to initialize
+     * our ACL. The first two entry members
+     * of ACL field are the authenticated user
+     * that is associated with the security
+     * context of the token. Then here come
+     * the last two entries which are admins.
+     * Why the ACL contains two ACEs of the
+     * same SID is because of service access
+     * rights and ACE inheritance.
+     *
+     * A service is composed of a default
+     * desktop and window station upon
+     * booting the system. On Windows connection
+     * to such service is being made if no
+     * default window station and desktop handles
+     * were created before. The desktop and winsta
+     * objects grant access on a separate type basis.
+     * The user is granted full access to the window
+     * station first and then full access to the desktop.
+     * After that admins are granted specific rights
+     * separately, just like the user. Ultimately the
+     * ACEs that handle desktop rights management are
+     * inherited to the default desktop object so
+     * that there's no need to have a separate security
+     * descriptor for the desktop object alone.
+     */
+    DaclSize = sizeof(ACL) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(TokenUser->User.Sid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(TokenUser->User.Sid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(SeExports->SeAliasAdminsSid) +
+               sizeof(ACCESS_ALLOWED_ACE) + RtlLengthSid(SeExports->SeAliasAdminsSid);
+
+    /* Allocate memory for service DACL */
+    ServiceDacl = IntAllocateSecurityBuffer(DaclSize);
+    if (!ServiceDacl)
+    {
+        ERR("IntCreateServiceSecurity(): Failed to allocate memory for service DACL!\n");
+        Status = STATUS_NO_MEMORY;
+        goto Quit;
+    }
+
+    /* Now create the DACL */
+    Status = RtlCreateAcl(ServiceDacl,
+                          DaclSize,
+                          ACL_REVISION);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to create service DACL (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * The authenticated user is the ultimate and absolute
+     * king in charge of the created (or opened, whatever that is)
+     * window station object.
+     */
+    Status = RtlAddAccessAllowedAceEx(ServiceDacl,
+                                      ACL_REVISION,
+                                      0,
+                                      WINSTA_ACCESS_ALL,
+                                      TokenUser->User.Sid);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to set up window station ACE for authenticated user (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * The authenticated user also has the ultimate power
+     * over the desktop object as well. This ACE cannot
+     * be propagated but inherited. See the comment
+     * above regarding ACL size for further explanation.
+     */
+    Status = RtlAddAccessAllowedAceEx(ServiceDacl,
+                                      ACL_REVISION,
+                                      INHERIT_ONLY_ACE | NO_PROPAGATE_INHERIT_ACE | OBJECT_INHERIT_ACE,
+                                      DESKTOP_ALL_ACCESS,
+                                      TokenUser->User.Sid);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to set up desktop ACE for authenticated user (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * Administrators can only enumerate window
+     * stations within a desktop.
+     */
+    Status = RtlAddAccessAllowedAceEx(ServiceDacl,
+                                      ACL_REVISION,
+                                      0,
+                                      WINSTA_ENUMERATE,
+                                      SeExports->SeAliasAdminsSid);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to set up window station ACE for admins (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * Administrators have some share of power over
+     * the desktop object. They can enumerate desktops,
+     * write and read upon the object itself.
+     */
+    Status = RtlAddAccessAllowedAceEx(ServiceDacl,
+                                      ACL_REVISION,
+                                      INHERIT_ONLY_ACE | NO_PROPAGATE_INHERIT_ACE | OBJECT_INHERIT_ACE,
+                                      DESKTOP_ENUMERATE | DESKTOP_READOBJECTS | DESKTOP_WRITEOBJECTS,
+                                      SeExports->SeAliasAdminsSid);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to set up desktop ACE for admins (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /* Set the DACL to absolute SD */
+    Status = RtlSetDaclSecurityDescriptor(&AbsSD,
+                                          TRUE,
+                                          ServiceDacl,
+                                          FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to set up service DACL to absolute SD (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /* This descriptor is ownerless */
+    Status = RtlSetOwnerSecurityDescriptor(&AbsSD,
+                                           NULL,
+                                           FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to make the absolute SD as ownerless (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /* This descriptor has no primary group */
+    Status = RtlSetGroupSecurityDescriptor(&AbsSD,
+                                           NULL,
+                                           FALSE);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to make the absolute SD as having no primary group (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /*
+     * Determine how much size is needed to allocate
+     * memory space for our relative security descriptor.
+     */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsSD,
+                                         NULL,
+                                         &RelSDSize);
+    if (Status != STATUS_BUFFER_TOO_SMALL)
+    {
+        ERR("IntCreateServiceSecurity(): Unexpected status code, must be STATUS_BUFFER_TOO_SMALL (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /* Allocate memory for this */
+    RelSD = IntAllocateSecurityBuffer(RelSDSize);
+    if (!RelSD)
+    {
+        ERR("IntCreateServiceSecurity(): Failed to allocate memory pool for relative SD!\n");
+        Status = STATUS_NO_MEMORY;
+        goto Quit;
+    }
+
+    /* Convert the absolute SD into a relative one now */
+    Status = RtlAbsoluteToSelfRelativeSD(&AbsSD,
+                                         RelSD,
+                                         &RelSDSize);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("IntCreateServiceSecurity(): Failed to convert absolute SD to a relative one (Status 0x%08lx)\n", Status);
+        goto Quit;
+    }
+
+    /* All good, give the SD to the caller */
+    *ServiceSd = RelSD;
+
+Quit:
+    if (ServiceDacl)
+    {
+        IntFreeSecurityBuffer(ServiceDacl);
+    }
+
+    if (TokenUser)
+    {
+        IntFreeSecurityBuffer(TokenUser);
+    }
+
+    if (!NT_SUCCESS(Status))
+    {
+        if (RelSD)
+        {
+            IntFreeSecurityBuffer(RelSD);
+        }
+    }
+
+    return Status;
+}
+
+/* EOF */

--- a/win32ss/user/ntuser/security.h
+++ b/win32ss/user/ntuser/security.h
@@ -1,0 +1,92 @@
+/*
+ * PROJECT:         ReactOS Win32k subsystem
+ * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:         Security infrastructure of NTUSER component of Win32k
+ * COPYRIGHT:       Copyright 2022 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#pragma once
+
+//
+// USER objects security rights
+//
+
+/* Desktop access rights */
+#define DESKTOP_READ (STANDARD_RIGHTS_READ      | \
+                      DESKTOP_ENUMERATE         | \
+                      DESKTOP_READOBJECTS)
+
+#define DESKTOP_WRITE (STANDARD_RIGHTS_WRITE    | \
+                       DESKTOP_CREATEMENU       | \
+                       DESKTOP_CREATEWINDOW     | \
+                       DESKTOP_HOOKCONTROL      | \
+                       DESKTOP_JOURNALPLAYBACK  | \
+                       DESKTOP_JOURNALRECORD    | \
+                       DESKTOP_WRITEOBJECTS)
+
+#define DESKTOP_EXECUTE (STANDARD_RIGHTS_EXECUTE  | \
+                         DESKTOP_SWITCHDESKTOP)
+
+#define DESKTOP_ALL_ACCESS (STANDARD_RIGHTS_REQUIRED | \
+                            DESKTOP_CREATEMENU       | \
+                            DESKTOP_CREATEWINDOW     | \
+                            DESKTOP_ENUMERATE        | \
+                            DESKTOP_HOOKCONTROL      | \
+                            DESKTOP_JOURNALPLAYBACK  | \
+                            DESKTOP_JOURNALRECORD    | \
+                            DESKTOP_READOBJECTS      | \
+                            DESKTOP_SWITCHDESKTOP    | \
+                            DESKTOP_WRITEOBJECTS)
+
+/* Window Station access rights */
+#define WINSTA_READ (STANDARD_RIGHTS_READ     | \
+                     WINSTA_ENUMDESKTOPS      | \
+                     WINSTA_ENUMERATE         | \
+                     WINSTA_READATTRIBUTES    | \
+                     WINSTA_READSCREEN)
+
+#define WINSTA_WRITE (STANDARD_RIGHTS_WRITE    | \
+                      WINSTA_ACCESSCLIPBOARD   | \
+                      WINSTA_CREATEDESKTOP     | \
+                      WINSTA_WRITEATTRIBUTES)
+
+#define WINSTA_EXECUTE (STANDARD_RIGHTS_EXECUTE  | \
+                        WINSTA_ACCESSGLOBALATOMS | \
+                        WINSTA_EXITWINDOWS)
+
+#define WINSTA_ACCESS_ALL (STANDARD_RIGHTS_REQUIRED | \
+                           WINSTA_ACCESSCLIPBOARD   | \
+                           WINSTA_ACCESSGLOBALATOMS | \
+                           WINSTA_CREATEDESKTOP     | \
+                           WINSTA_ENUMDESKTOPS      | \
+                           WINSTA_ENUMERATE         | \
+                           WINSTA_EXITWINDOWS       | \
+                           WINSTA_READATTRIBUTES    | \
+                           WINSTA_READSCREEN        | \
+                           WINSTA_WRITEATTRIBUTES)
+
+//
+// Function prototypes
+//
+
+HANDLE
+IntCaptureCurrentAccessToken(VOID);
+
+PVOID
+IntAllocateSecurityBuffer(
+    _In_ SIZE_T Length);
+
+VOID
+IntFreeSecurityBuffer(
+    _In_ PVOID Buffer);
+
+NTSTATUS
+IntQueryUserSecurityIdentification(
+    _Out_ PTOKEN_USER *User);
+
+NTSTATUS
+NTAPI
+IntCreateServiceSecurity(
+    _Out_ PSECURITY_DESCRIPTOR *ServiceSd);
+
+/* EOF */

--- a/win32ss/user/ntuser/win32kdebug.h
+++ b/win32ss/user/ntuser/win32kdebug.h
@@ -108,6 +108,7 @@
         DbgChUserProcess,
         DbgChUserProp,
         DbgChUserScrollbar,
+        DbgChUserSecurity,
         DbgChUserShutdown,
         DbgChUserSysparams,
         DbgChUserThread,

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -47,32 +47,6 @@ extern HANDLE gpidLogon;
 extern HWND hwndSAS;
 extern UNICODE_STRING gustrWindowStationsDir;
 
-#define WINSTA_READ       STANDARD_RIGHTS_READ     | \
-                          WINSTA_ENUMDESKTOPS      | \
-                          WINSTA_ENUMERATE         | \
-                          WINSTA_READATTRIBUTES    | \
-                          WINSTA_READSCREEN
-
-#define WINSTA_WRITE      STANDARD_RIGHTS_WRITE    | \
-                          WINSTA_ACCESSCLIPBOARD   | \
-                          WINSTA_CREATEDESKTOP     | \
-                          WINSTA_WRITEATTRIBUTES
-
-#define WINSTA_EXECUTE    STANDARD_RIGHTS_EXECUTE  | \
-                          WINSTA_ACCESSGLOBALATOMS | \
-                          WINSTA_EXITWINDOWS
-
-#define WINSTA_ACCESS_ALL STANDARD_RIGHTS_REQUIRED | \
-                          WINSTA_ACCESSCLIPBOARD   | \
-                          WINSTA_ACCESSGLOBALATOMS | \
-                          WINSTA_CREATEDESKTOP     | \
-                          WINSTA_ENUMDESKTOPS      | \
-                          WINSTA_ENUMERATE         | \
-                          WINSTA_EXITWINDOWS       | \
-                          WINSTA_READATTRIBUTES    | \
-                          WINSTA_READSCREEN        | \
-                          WINSTA_WRITEATTRIBUTES
-
 CODE_SEG("INIT")
 NTSTATUS
 NTAPI
@@ -125,4 +99,5 @@ BOOL FASTCALL UserSetProcessWindowStation(HWINSTA hWindowStation);
 BOOL FASTCALL co_IntInitializeDesktopGraphics(VOID);
 VOID FASTCALL IntEndDesktopGraphics(VOID);
 BOOL FASTCALL CheckWinstaAttributeAccess(ACCESS_MASK);
+
 /* EOF */

--- a/win32ss/user/user32/misc/winsta.c
+++ b/win32ss/user/user32/misc/winsta.c
@@ -104,7 +104,7 @@ CreateWindowStationW(
                                lpwinsta ? &WindowStationName : NULL,
                                OBJ_CASE_INSENSITIVE | OBJ_OPENIF,
                                hWindowStationsDir,
-                               NULL);
+                               lpsa ? lpsa->lpSecurityDescriptor : NULL);
 
     /* Check if the handle should be inheritable */
     if (lpsa && lpsa->bInheritHandle)

--- a/win32ss/win32kp.h
+++ b/win32ss/win32kp.h
@@ -81,6 +81,7 @@ typedef struct _DC *PDC;
 #include "user/ntuser/painting.h"
 #include "user/ntuser/class.h"
 #include "user/ntuser/window.h"
+#include "user/ntuser/security.h"
 #include "user/ntuser/sysparams.h"
 #include "user/ntuser/prop.h"
 #include "user/ntuser/guicheck.h"


### PR DESCRIPTION
There are two fundamental problems when it comes to access checks in ReactOS. First, the internal function `SepAccessCheck` which is the heart and brain of the whole access checks logic of the kernel warrants access to the calling thread of a process to an object even though access could not be given. 

This can potentially leave security issues as we literally leave objects to be touched indiscriminately by anyone regardless of their ACEs in the DACL of a security descriptor. Second, the current access check code doesn't take into account the fact that an access token can have restricted SIDs. In such scenario we must perform additional access checks by iterating over the restricted SIDs of the primary token by comparing the SID equality and see if the group can be granted certain rights based on the ACE policy that represents the same SID.

Part of `SepAccessCheck`'s code logic will be split for a separate private kernel routine, `SepAnalyzeAcesFromDacl`. The reasons for this are primarily two -- such code is subject to grow eventually as we'll support different type ACEs and handle them accordingly -- and we avoid further code duplicates. On Windows Server 2003 there are 5 different type of ACEs that are supported for access checks:

- **ACCESS_DENIED_ACE_TYPE** (supported by ReactOS)
- **ACCESS_ALLOWED_ACE_TYPE** (supported by ReactOS)
- **ACCESS_DENIED_OBJECT_ACE_TYPE**
- **ACCESS_ALLOWED_OBJECT_ACE_TYPE**
- **ACCESS_ALLOWED_COMPOUND_ACE_TYPE**

Once the foundation of access checks is properly solid by getting rid of the ugly hack present in the code, this allows for more opportunity to continue further on implementing object type access checks, compound ACE handling, and whatnot. For now we'll live by the basics.
## TODO

- [x] Make ReactOS bootable again
- [x] Investigate most of the "failed to grant access rights" occurrences on ReactOS

**JIRA Issue:** [CORE-9184](https://jira.reactos.org/browse/CORE-9184)