### PR TITLE
[REGEDIT] Fix issue at Find registry key

### DIFF
--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -160,9 +160,6 @@ BOOL RegFindRecurse(
     if (lResult != ERROR_SUCCESS)
         return FALSE;
 
-    if (pszValueName == NULL)
-        pszValueName = s_empty;
-
     lResult = RegQueryInfoKeyW(hSubKey, NULL, NULL, NULL, NULL, NULL, NULL,
                               &c, NULL, NULL, NULL, NULL);
     if (lResult != ERROR_SUCCESS)
@@ -195,7 +192,7 @@ BOOL RegFindRecurse(
 
     qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
-    if (pszValueName == s_empty)
+    if (pszValueName == NULL)
         pszValueName = ppszNames[0];
 
     for(i = 0; i < c; i++)
@@ -373,7 +370,8 @@ BOOL RegFindWalk(
     LPWSTR *ppszNames = NULL;
 
     hBaseKey = *phKey;
-    if (wcslen(pszSubKey) >= MAX_PATH)
+
+    if (wcslen(pszSubKey) >= _countof(szSubKey))
         return FALSE;
 
     if (RegFindRecurse(hBaseKey, pszSubKey, pszValueName, ppszFoundSubKey,
@@ -690,6 +688,7 @@ BOOL FindNext(HWND hWnd)
     {
         GetKeyName(szFullKey, COUNT_OF(szFullKey), hKeyRoot, pszFoundSubKey);
         SelectNode(g_pChildWnd->hTreeWnd, szFullKey);
+        free(pszFoundSubKey);
 
         if (pszFoundValueName != NULL)
         {
@@ -698,9 +697,9 @@ BOOL FindNext(HWND hWnd)
             SetFocus(g_pChildWnd->hListWnd);
         }
         else
+        {
             SetFocus(g_pChildWnd->hTreeWnd);
-
-        free(pszFoundSubKey);
+        }
     }
     return fSuccess || s_bAbort;
 }

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -690,10 +690,17 @@ BOOL FindNext(HWND hWnd)
     {
         GetKeyName(szFullKey, COUNT_OF(szFullKey), hKeyRoot, pszFoundSubKey);
         SelectNode(g_pChildWnd->hTreeWnd, szFullKey);
-        SetValueName(g_pChildWnd->hListWnd, pszFoundValueName);
+
+        if (pszFoundValueName != NULL)
+        {
+            SetValueName(g_pChildWnd->hListWnd, pszFoundValueName);
+            free(pszFoundValueName);
+            SetFocus(g_pChildWnd->hListWnd);
+        }
+        else
+            SetFocus(g_pChildWnd->hTreeWnd);
+
         free(pszFoundSubKey);
-        free(pszFoundValueName);
-        SetFocus(g_pChildWnd->hListWnd);
     }
     return fSuccess || s_bAbort;
 }

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -195,6 +195,9 @@ BOOL RegFindRecurse(
 
     qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
+    if (pszValueName == s_empty)
+        pszValueName = ppszNames[0];
+
     for(i = 0; i < c; i++)
     {
         if (DoEvents())

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -143,7 +143,6 @@ BOOL RegFindRecurse(
     LONG lResult;
     WCHAR szSubKey[MAX_PATH];
     DWORD i, c, cb, type;
-    BOOL fPast = FALSE;
     LPWSTR *ppszNames = NULL;
     LPBYTE pb = NULL;
 
@@ -199,14 +198,6 @@ BOOL RegFindRecurse(
     {
         if (DoEvents())
             goto err;
-
-        if (!fPast && _wcsicmp(ppszNames[i], pszValueName) == 0)
-        {
-            fPast = TRUE;
-            continue;
-        }
-        if (!fPast)
-            continue;
 
         if ((s_dwFlags & RSF_LOOKATVALUES) &&
                 CompareName(ppszNames[i], s_szFindWhat))
@@ -366,7 +357,6 @@ BOOL RegFindWalk(
     WCHAR szKeyName[MAX_PATH];
     WCHAR szSubKey[MAX_PATH];
     LPWSTR pch;
-    BOOL fPast;
     LPWSTR *ppszNames = NULL;
 
     hBaseKey = *phKey;
@@ -430,19 +420,10 @@ BOOL RegFindWalk(
 
         qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
-        fPast = FALSE;
         for(i = 0; i < c; i++)
         {
             if (DoEvents())
                 goto err;
-
-            if (!fPast && _wcsicmp(ppszNames[i], szKeyName) == 0)
-            {
-                fPast = TRUE;
-                continue;
-            }
-            if (!fPast)
-                continue;
 
             if ((s_dwFlags & RSF_LOOKATKEYS) &&
                     CompareName(ppszNames[i], s_szFindWhat))

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -373,12 +373,12 @@ BOOL RegFindWalk(
     LPWSTR *ppszNames = NULL;
 
     hBaseKey = *phKey;
+    if (wcslen(pszSubKey) >= MAX_PATH)
+        return FALSE;
+
     if (RegFindRecurse(hBaseKey, pszSubKey, pszValueName, ppszFoundSubKey,
                        ppszFoundValueName))
         return TRUE;
-
-    if (wcslen(pszSubKey) >= MAX_PATH)
-        return FALSE;
 
     wcscpy(szSubKey, pszSubKey);
     while(szSubKey[0] != 0)

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -143,6 +143,7 @@ BOOL RegFindRecurse(
     LONG lResult;
     WCHAR szSubKey[MAX_PATH];
     DWORD i, c, cb, type;
+    BOOL fPast = FALSE;
     LPWSTR *ppszNames = NULL;
     LPBYTE pb = NULL;
 
@@ -198,6 +199,14 @@ BOOL RegFindRecurse(
     {
         if (DoEvents())
             goto err;
+
+        if (!fPast && _wcsicmp(ppszNames[i], pszValueName) == 0)
+        {
+            fPast = TRUE;
+            continue;
+        }
+        if (!fPast)
+            continue;
 
         if ((s_dwFlags & RSF_LOOKATVALUES) &&
                 CompareName(ppszNames[i], s_szFindWhat))
@@ -357,6 +366,7 @@ BOOL RegFindWalk(
     WCHAR szKeyName[MAX_PATH];
     WCHAR szSubKey[MAX_PATH];
     LPWSTR pch;
+    BOOL fPast;
     LPWSTR *ppszNames = NULL;
 
     hBaseKey = *phKey;
@@ -420,10 +430,19 @@ BOOL RegFindWalk(
 
         qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
+        fPast = FALSE;
         for(i = 0; i < c; i++)
         {
             if (DoEvents())
                 goto err;
+
+            if (!fPast && _wcsicmp(ppszNames[i], szKeyName) == 0)
+            {
+                fPast = TRUE;
+                continue;
+            }
+            if (!fPast)
+                continue;
 
             if ((s_dwFlags & RSF_LOOKATKEYS) &&
                     CompareName(ppszNames[i], s_szFindWhat))


### PR DESCRIPTION
Searching the registry for a key or value gives no results 

[REGEDIT] Fix issue at Find registry key
If we dont select a value to [pszValueName] as a starting point to search from,  we need set [pszValueName]  to the first item in current subkey

[[REGEDIT] Set focus to subkey when we search for it.

[[REGEDIT] Check pszSubKey length before calling RegFindRecurse.