### PR TITLE
[REACTOS] Enforce 'Biosinfo' reg key name exact case

### DIFF
--- a/boot/freeldr/freeldr/ntldr/setupldr.c
+++ b/boot/freeldr/freeldr/ntldr/setupldr.c
@@ -92,9 +92,9 @@ SetupLdrInitErrataInf(
     CHAR ErrataFilePath[MAX_PATH];
 
     /* Retrieve the INF file name value */
-    if (!InfFindFirstLine(InfHandle, "BiosInfo", "InfName", &InfContext))
+    if (!InfFindFirstLine(InfHandle, "Biosinfo", "InfName", &InfContext))
     {
-        WARN("Failed to find 'BiosInfo/InfName'\n");
+        WARN("Failed to find 'Biosinfo/InfName'\n");
         return FALSE;
     }
     if (!InfGetDataField(&InfContext, 1, &FileName))

--- a/boot/freeldr/freeldr/ntldr/winldr.c
+++ b/boot/freeldr/freeldr/ntldr/winldr.c
@@ -715,7 +715,7 @@ WinLdrInitErrataInf(
     WCHAR szFileName[80];
     CHAR ErrataFilePath[MAX_PATH];
 
-    /* Open either the 'BiosInfo' (Windows <= 2003) or the 'Errata' (Vista+) key */
+    /* Open either the 'Biosinfo' (Windows <= 2003) or the 'Errata' (Vista+) key */
     if (OperatingSystemVersion >= _WIN32_WINNT_VISTA)
     {
         rc = RegOpenKey(NULL,
@@ -725,12 +725,12 @@ WinLdrInitErrataInf(
     else // (OperatingSystemVersion <= _WIN32_WINNT_WS03)
     {
         rc = RegOpenKey(NULL,
-                        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\BiosInfo",
+                        L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\Control\\Biosinfo",
                         &hKey);
     }
     if (rc != ERROR_SUCCESS)
     {
-        WARN("Could not open the BiosInfo/Errata registry key (Error %u)\n", (int)rc);
+        WARN("Could not open the Biosinfo/Errata registry key (Error %u)\n", (int)rc);
         return FALSE;
     }
 

--- a/drivers/bus/pcix/init.c
+++ b/drivers/bus/pcix/init.c
@@ -804,7 +804,7 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
 
         /* The PCILOCK feature can also be enabled per-system in the registry */
         Status = PciGetRegistryValue(L"PCILock",
-                                     L"Control\\BiosInfo\\PCI",
+                                     L"Control\\Biosinfo\\PCI",
                                      ControlSetKey,
                                      REG_DWORD,
                                      (PVOID*)&Value,

--- a/ntoskrnl/config/i386/cmhardwr.c
+++ b/ntoskrnl/config/i386/cmhardwr.c
@@ -294,7 +294,7 @@ CmpInitializeMachineDependentConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBloc
     /* Create the BIOS Information key */
     RtlInitUnicodeString(&KeyName,
                          L"\\Registry\\Machine\\SYSTEM\\CurrentControlSet\\"
-                         L"Control\\BIOSINFO");
+                         L"Control\\Biosinfo");
     InitializeObjectAttributes(&ObjectAttributes,
                                &KeyName,
                                OBJ_CASE_INSENSITIVE,


### PR DESCRIPTION
Use 1 consistent case, instead of 3 different ones.
No functional change, yet helps reading/searching code.
https://git.reactos.org/?p=reactos.git&a=search&h=HEAD&st=grep&s=Biosinfo&sr=1

Noticed while looking into [CORE-18040](https://jira.reactos.org/browse/CORE-18040).