### PR TITLE
[SHELLEXT] Sync' 3 error logs about CreateEmptyFile()

### DIFF
--- a/dll/shellext/mydocs/mydocs.cpp
+++ b/dll/shellext/mydocs/mydocs.cpp
@@ -43,7 +43,7 @@ CreateSendToMyDocuments(LPCWSTR pszSendTo)
 
     if (!CreateEmptyFile(szSendToFile))
     {
-        ERR("CreateEmptyFile(%S, %S) failed!\n", szSendToFile, szTarget);
+        ERR("CreateEmptyFile('%S') failed\n", szSendToFile);
         return E_FAIL;
     }
 

--- a/dll/shellext/sendmail/sendmail.cpp
+++ b/dll/shellext/sendmail/sendmail.cpp
@@ -44,7 +44,7 @@ CreateSendToDeskLink(LPCWSTR pszSendTo)
 
     if (!CreateEmptyFile(szSendToFile))
     {
-        ERR("CreateEmptyFile('%ls')\n", szSendToFile);
+        ERR("CreateEmptyFile('%S') failed\n", szSendToFile);
         return E_FAIL;
     }
     return S_OK;

--- a/dll/shellext/zipfldr/zipfldr.cpp
+++ b/dll/shellext/zipfldr/zipfldr.cpp
@@ -73,7 +73,7 @@ CreateSendToZip(LPCWSTR pszSendTo)
     StringCbCatW(szSendToFile, sizeof(szSendToFile), L".ZFSendToTarget");
     if (!CreateEmptyFile(szSendToFile))
     {
-        DPRINT1("CreateEmptyFile('%ls')\n", szSendToFile);
+        DPRINT1("CreateEmptyFile('%S') failed\n", szSendToFile);
         return E_FAIL;
     }
     return S_OK;


### PR DESCRIPTION
Be explicit/consistent.

Before: (reactos-livecd-0.4.15-dev-3778-gf80de47-x86-gcc-lin-dbg)
```
err:(/dll/shellext/mydocs/mydocs.cpp:46) CreateEmptyFile(X:\Profiles\Default User\SendTo\My Documents.mydocs, X:\Profiles\Default User\My Documents) failed!
err:(/dll/shellext/sendmail/sendmail.cpp:47) CreateEmptyFile('X:\Profiles\Default User\SendTo\Desktop (Create shortcut).DeskLink')
zipfldr.cpp:76: (/dll/shellext/zipfldr/zipfldr.cpp:76) CreateEmptyFile('X:\Profiles\Default User\SendTo\Compressed (zipped) Folder.ZFSendToTarget')
```

After:
```
err:(/dll/shellext/mydocs/mydocs.cpp:46) CreateEmptyFile('X:\Profiles\Default User\SendTo\My Documents.mydocs') failed
err:(/dll/shellext/sendmail/sendmail.cpp:47) CreateEmptyFile('X:\Profiles\Default User\SendTo\Desktop (Create shortcut).DeskLink') failed
zipfldr.cpp:76: (/dll/shellext/zipfldr/zipfldr.cpp:76) CreateEmptyFile('X:\Profiles\Default User\SendTo\Compressed (zipped) Folder.ZFSendToTarget') failed
```