### PR TITLE
[NTUSER] Cleanup window lists on thread/process exit

### DIFF
--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -90,6 +90,9 @@ typedef struct tagWINDOWLIST
     HWND ahwnd[ANYSIZE_ARRAY]; /* Terminated by HWND_TERMINATOR */
 } WINDOWLIST, *PWINDOWLIST;
 
+extern PWINDOWLIST gpwlList;
+extern PWINDOWLIST gpwlCache;
+
 #define WL_IS_BAD(pwl)   ((pwl)->phwndEnd <= (pwl)->phwndLast)
 #define WL_CAPACITY(pwl) ((pwl)->phwndEnd - &((pwl)->ahwnd[0]))
 


### PR DESCRIPTION
## Purpose

PR #4334 introduced Window List. This PR deletes the window lists that are no longer needed at the end of the thread / process.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Cleanup the window lists that are no longer needed at the thread / process termination.
