### PR TITLE
[BOOT] HybridCD: Add 'Temp' dir

### DIFF
--- a/boot/boot_images.cmake
+++ b/boot/boot_images.cmake
@@ -142,7 +142,7 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
 # Create TEMP dir
-file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "reactos/TEMP=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "reactos/Temp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
 # Create user profile directories
 add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/livecd.cmake.lst "Profiles")
@@ -162,6 +162,9 @@ add_custom_target(livecd
 # Create the file list
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "${CMAKE_CURRENT_BINARY_DIR}/empty\n")
+
+# Create TEMP dir
+file(APPEND ${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/reactos/Temp=${CMAKE_CURRENT_BINARY_DIR}/empty\n")
 
 # Create user profile directories
 add_allusers_profile_dirs(${CMAKE_CURRENT_BINARY_DIR}/hybridcd.cmake.lst "livecd/Profiles")


### PR DESCRIPTION
## Purpose

Fix wrong behaviour and add missing dir.

## Proposed changes

- [USERENV] SetUserEnvironmentVariable(): Fix use of uninit' ShortName
- [BOOT] LiveCD: Add 'Temp' dir