### PR TITLE
[NTUSER] Implement NtUserCheckImeHotKey

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1846,8 +1846,8 @@ NtUserCheckWindowThreadDesktop(
 DWORD
 NTAPI
 NtUserCheckImeHotKey(
-    DWORD dwUnknown1,
-    LPARAM dwUnknown2);
+    UINT uVirtualKey,
+    LPARAM lParam);
 
 HWND NTAPI
 NtUserChildWindowFromPointEx(

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -58,7 +58,7 @@ typedef struct tagIMEHOTKEY
 PIMEHOTKEY gpImeHotKeyList = NULL;
 LCID glcid = 0;
 
-INT FASTCALL IntGetImeHotKeyScore(HKL hKL, LANGID HotKeyLangId)
+INT FASTCALL IntGetImeHotKeyLanguageScore(HKL hKL, LANGID HotKeyLangId)
 {
     LCID lcid;
 
@@ -75,13 +75,13 @@ INT FASTCALL IntGetImeHotKeyScore(HKL hKL, LANGID HotKeyLangId)
     }
     _SEH2_END;
 
-    if (LANGIDFROMLCID(lcid) == HotKeyLangId)
+    if (HotKeyLangId == LANGIDFROMLCID(lcid))
         return 2;
 
     if (glcid == 0)
         ZwQueryDefaultLocale(FALSE, &glcid);
 
-    if (LANGIDFROMLCID(glcid) == HotKeyLangId)
+    if (HotKeyLangId == LANGIDFROMLCID(glcid))
         return 1;
 
     return 0;
@@ -244,7 +244,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
         }
 
         LangId = IntGetImeHotKeyLangId(pNode->dwHotKeyId);
-        nScore = IntGetImeHotKeyScore(hKL, LangId);
+        nScore = IntGetImeHotKeyLanguageScore(hKL, LangId);
         if (nScore == 3)
             return pNode;
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -11,6 +11,7 @@
 DBG_DEFAULT_CHANNEL(UserMisc);
 
 #define INVALID_THREAD_ID  ((ULONG)-1)
+#define INVALID_HOTKEY     ((UINT)-1)
 #define MOD_KEYS           (MOD_CONTROL | MOD_SHIFT | MOD_ALT | MOD_WIN)
 #define MOD_LEFT_RIGHT     (MOD_LEFT | MOD_RIGHT)
 
@@ -55,6 +56,50 @@ typedef struct tagIMEHOTKEY
 } IMEHOTKEY, *PIMEHOTKEY;
 
 PIMEHOTKEY gpImeHotKeyList = NULL;
+LCID glcid = 0;
+
+INT FASTCALL IntGetKeyboardLayoutScore(HKL hkl, LANGID LangId)
+{
+    LCID lcid;
+
+    if (LangId == LANGID_NEUTRAL || LOWORD(hkl) == LangId)
+        return 3;
+
+    _SEH2_TRY
+    {
+        lcid = NtCurrentTeb()->CurrentLocale;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        lcid = MAKELCID(LANGID_NEUTRAL, SORT_DEFAULT);
+    }
+    _SEH2_END;
+
+    if (LANGIDFROMLCID(lcid) == LangId)
+        return 2;
+
+    if (glcid == 0)
+        ZwQueryDefaultLocale(FALSE, &glcid);
+
+    if (LANGIDFROMLCID(glcid) == LangId)
+        return 1;
+
+    return 0;
+}
+
+HKL FASTCALL IntGetActiveKeyboardLayout(VOID)
+{
+    PTHREADINFO pti;
+
+    if (gpqForeground && gpqForeground->spwndActive)
+    {
+        pti = gpqForeground->spwndActive->head.pti;
+        if (pti && pti->KeyboardLayout)
+            return pti->KeyboardLayout->hkl;
+    }
+
+    return UserGetKeyboardLayout(0);
+}
 
 static LANGID FASTCALL IntGetImeHotKeyLangId(DWORD dwHotKeyId)
 {
@@ -163,6 +208,114 @@ static VOID FASTCALL IntDeleteImeHotKey(PIMEHOTKEY *ppList, PIMEHOTKEY pHotKey)
             return;
         }
     }
+}
+
+PIMEHOTKEY
+IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVirtualKey)
+{
+    PIMEHOTKEY pNode, ret = NULL;
+    PTHREADINFO pti = GetW32ThreadInfo();
+    LANGID LangId;
+    HKL hKL = IntGetActiveKeyboardLayout();
+    BOOL fKorean = (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN);
+    INT nScore, nMaxScore = 0;
+
+    for (pNode = pList; pNode != NULL; pNode = pNode->pNext)
+    {
+        if (pNode->uVirtualKey != uVirtualKey)
+            continue;
+
+        if ((pNode->uModifiers & MOD_IGNORE_ALL_MODIFIER))
+        {
+            ;
+        }
+        else if ((pNode->uModifiers & MOD_KEYS) != uModKeys)
+        {
+            continue;
+        }
+        else if ((pNode->uModifiers & uLeftRight) ||
+                 (pNode->uModifiers & MOD_LEFT_RIGHT) == uLeftRight)
+        {
+            ;
+        }
+        else
+        {
+            continue;
+        }
+
+        LangId = IntGetImeHotKeyLangId(pNode->dwHotKeyId);
+        nScore = IntGetKeyboardLayoutScore(hKL, LangId);
+        if (nScore == 3)
+            return pNode;
+
+        if (fKorean)
+            continue;
+
+        if (nScore == 0)
+        {
+            if (pNode->dwHotKeyId == IME_CHOTKEY_IME_NONIME_TOGGLE ||
+                pNode->dwHotKeyId == IME_THOTKEY_IME_NONIME_TOGGLE)
+            {
+                if (LOWORD(pti->hklPrev) == LangId)
+                    return pNode;
+            }
+        }
+
+        if (nScore > nMaxScore)
+        {
+            nMaxScore = nScore;
+            ret = pNode;
+        }
+    }
+
+    return ret;
+}
+
+PIMEHOTKEY IntCheckImeHotKey(PUSER_MESSAGE_QUEUE MessageQueue, UINT uVirtualKey, LPARAM lParam)
+{
+    PIMEHOTKEY pHotKey;
+    UINT uModifiers;
+    BOOL bKeyUp = (lParam & 0x80000000);
+    LPBYTE KeyState = MessageQueue->afKeyState;
+    static UINT s_uOldVirtualKey = 0;
+
+    if (bKeyUp)
+    {
+        if (s_uOldVirtualKey != uVirtualKey)
+            return NULL;
+
+        s_uOldVirtualKey = 0;
+    }
+
+    uModifiers = 0;
+    if (IS_KEY_DOWN(KeyState, VK_LSHIFT))   uModifiers |= (MOD_SHIFT | MOD_LEFT);
+    if (IS_KEY_DOWN(KeyState, VK_RSHIFT))   uModifiers |= (MOD_SHIFT | MOD_RIGHT);
+    if (IS_KEY_DOWN(KeyState, VK_LCONTROL)) uModifiers |= (MOD_CONTROL | MOD_LEFT);
+    if (IS_KEY_DOWN(KeyState, VK_RCONTROL)) uModifiers |= (MOD_CONTROL | MOD_RIGHT);
+    if (IS_KEY_DOWN(KeyState, VK_LMENU))    uModifiers |= (MOD_ALT | MOD_LEFT);
+    if (IS_KEY_DOWN(KeyState, VK_RMENU))    uModifiers |= (MOD_ALT | MOD_RIGHT);
+
+    pHotKey = IntGetImeHotKeyByKey(gpImeHotKeyList,
+                                   (uModifiers & MOD_KEYS),
+                                   (uModifiers & MOD_LEFT_RIGHT),
+                                   uVirtualKey);
+    if (pHotKey)
+    {
+        if (bKeyUp)
+        {
+            if (pHotKey->uModifiers & MOD_ON_KEYUP)
+                return pHotKey;
+        }
+        else
+        {
+            if (pHotKey->uModifiers & MOD_ON_KEYUP)
+                s_uOldVirtualKey = uVirtualKey;
+            else
+                return pHotKey;
+        }
+    }
+
+    return NULL;
 }
 
 VOID FASTCALL IntFreeImeHotKeys(VOID)
@@ -290,6 +443,27 @@ NtUserSetImeHotKey(
     BOOL ret;
     UserEnterExclusive();
     ret = IntSetImeHotKey(dwHotKeyId, uModifiers, uVirtualKey, hKL, dwAction);
+    UserLeave();
+    return ret;
+}
+
+DWORD
+NTAPI
+NtUserCheckImeHotKey(UINT uVirtualKey, LPARAM lParam)
+{
+    PIMEHOTKEY pNode;
+    DWORD ret = INVALID_HOTKEY;
+
+    UserEnterExclusive();
+
+    if (!gpqForeground || !IS_IMM_MODE())
+        goto Quit;
+
+    pNode = IntCheckImeHotKey(gpqForeground, uVirtualKey, lParam);
+    if (pNode)
+        ret = pNode->dwHotKeyId;
+
+Quit:
     UserLeave();
     return ret;
 }
@@ -548,16 +722,6 @@ NtUserNotifyIMEStatus(HWND hwnd, BOOL fOpen, DWORD dwConversion)
 
 Quit:
     UserLeave();
-    return 0;
-}
-
-DWORD
-NTAPI
-NtUserCheckImeHotKey(
-    DWORD  VirtualKey,
-    LPARAM lParam)
-{
-    STUB;
     return 0;
 }
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -58,7 +58,7 @@ typedef struct tagIMEHOTKEY
 PIMEHOTKEY gpImeHotKeyList = NULL;
 LCID glcid = 0;
 
-INT FASTCALL IntGetImeHotKeyLanguageScore(HKL hKL, LANGID HotKeyLangId)
+UINT FASTCALL IntGetImeHotKeyLanguageScore(HKL hKL, LANGID HotKeyLangId)
 {
     LCID lcid;
 
@@ -218,7 +218,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
     LANGID LangId;
     HKL hKL = IntGetActiveKeyboardLayout();
     BOOL fKorean = (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN);
-    INT nScore, nMaxScore = 0;
+    UINT nScore, nMaxScore = 0;
 
     for (pNode = pList; pNode; pNode = pNode->pNext)
     {
@@ -245,7 +245,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
 
         LangId = IntGetImeHotKeyLangId(pNode->dwHotKeyId);
         nScore = IntGetImeHotKeyLanguageScore(hKL, LangId);
-        if (nScore == 3)
+        if (nScore >= 3)
             return pNode;
 
         if (fKorean)
@@ -261,7 +261,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
             }
         }
 
-        if (nScore > nMaxScore)
+        if (nMaxScore < nScore)
         {
             nMaxScore = nScore;
             ret = pNode;

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -276,15 +276,18 @@ PIMEHOTKEY IntCheckImeHotKey(PUSER_MESSAGE_QUEUE MessageQueue, UINT uVirtualKey,
     PIMEHOTKEY pHotKey;
     UINT uModifiers;
     BOOL bKeyUp = (lParam & 0x80000000);
-    LPBYTE KeyState = MessageQueue->afKeyState;
-    static UINT s_uOldVirtualKey = 0;
+    const BYTE *KeyState = MessageQueue->afKeyState;
+    static UINT s_uKeyUpVKey = 0;
 
     if (bKeyUp)
     {
-        if (s_uOldVirtualKey != uVirtualKey)
+        if (s_uKeyUpVKey != uVirtualKey)
+        {
+            s_uKeyUpVKey = 0;
             return NULL;
+        }
 
-        s_uOldVirtualKey = 0;
+        s_uKeyUpVKey = 0;
     }
 
     uModifiers = 0;
@@ -309,7 +312,7 @@ PIMEHOTKEY IntCheckImeHotKey(PUSER_MESSAGE_QUEUE MessageQueue, UINT uVirtualKey,
         else
         {
             if (pHotKey->uModifiers & MOD_ON_KEYUP)
-                s_uOldVirtualKey = uVirtualKey;
+                s_uKeyUpVKey = uVirtualKey;
             else
                 return pHotKey;
         }

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -58,11 +58,11 @@ typedef struct tagIMEHOTKEY
 PIMEHOTKEY gpImeHotKeyList = NULL;
 LCID glcid = 0;
 
-INT FASTCALL IntGetKeyboardLayoutScore(HKL hkl, LANGID LangId)
+INT FASTCALL IntGetImeHotKeyScore(HKL hKL, LANGID HotKeyLangId)
 {
     LCID lcid;
 
-    if (LangId == LANGID_NEUTRAL || LOWORD(hkl) == LangId)
+    if (HotKeyLangId == LANGID_NEUTRAL || HotKeyLangId == LOWORD(hKL))
         return 3;
 
     _SEH2_TRY
@@ -75,13 +75,13 @@ INT FASTCALL IntGetKeyboardLayoutScore(HKL hkl, LANGID LangId)
     }
     _SEH2_END;
 
-    if (LANGIDFROMLCID(lcid) == LangId)
+    if (LANGIDFROMLCID(lcid) == HotKeyLangId)
         return 2;
 
     if (glcid == 0)
         ZwQueryDefaultLocale(FALSE, &glcid);
 
-    if (LANGIDFROMLCID(glcid) == LangId)
+    if (LANGIDFROMLCID(glcid) == HotKeyLangId)
         return 1;
 
     return 0;
@@ -220,7 +220,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
     BOOL fKorean = (PRIMARYLANGID(LOWORD(hKL)) == LANG_KOREAN);
     INT nScore, nMaxScore = 0;
 
-    for (pNode = pList; pNode != NULL; pNode = pNode->pNext)
+    for (pNode = pList; pNode; pNode = pNode->pNext)
     {
         if (pNode->uVirtualKey != uVirtualKey)
             continue;
@@ -244,7 +244,7 @@ IntGetImeHotKeyByKey(PIMEHOTKEY pList, UINT uModKeys, UINT uLeftRight, UINT uVir
         }
 
         LangId = IntGetImeHotKeyLangId(pNode->dwHotKeyId);
-        nScore = IntGetKeyboardLayoutScore(hKL, LangId);
+        nScore = IntGetImeHotKeyScore(hKL, LangId);
         if (nScore == 3)
             return pNode;
 


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Modify `NtUserCheckImeHotKey` prototype.
- Add `IntGetImeHotKeyLanguageScore`, `IntGetActiveKeyboardLayout`, `IntGetImeHotKeyByKey`, and `IntCheckImeHotKey` helper functions.
- Implement `NtUserCheckImeHotKey` function.