### PR TITLE
[USER32] Use UINT as parameter for Drawtext()

### DIFF
--- a/win32ss/user/user32/controls/static.c
+++ b/win32ss/user/user32/controls/static.c
@@ -158,7 +158,7 @@ static HBITMAP STATIC_SetBitmap( HWND hwnd, HBITMAP hBitmap, DWORD style )
             SetWindowPos( hwnd, 0, 0, 0, bm.bmWidth, bm.bmHeight,
                           SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOZORDER );
         }
-	
+
     }
     return hOldBitmap;
 }
@@ -327,7 +327,7 @@ static BOOL hasTextStyle( DWORD style )
         case SS_OWNERDRAW:
             return TRUE;
     }
-    
+
     return FALSE;
 }
 
@@ -616,7 +616,7 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     RECT rc;
     HBRUSH hBrush;
     HFONT hFont, hOldFont = NULL;
-    WORD wFormat;
+    UINT format;
     INT len, buf_size;
     WCHAR *text;
 
@@ -625,23 +625,23 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     switch (style & SS_TYPEMASK)
     {
     case SS_LEFT:
-	wFormat = DT_LEFT | DT_EXPANDTABS | DT_WORDBREAK;
+	format = DT_LEFT | DT_EXPANDTABS | DT_WORDBREAK;
 	break;
 
     case SS_CENTER:
-	wFormat = DT_CENTER | DT_EXPANDTABS | DT_WORDBREAK;
+	format = DT_CENTER | DT_EXPANDTABS | DT_WORDBREAK;
 	break;
 
     case SS_RIGHT:
-	wFormat = DT_RIGHT | DT_EXPANDTABS | DT_WORDBREAK;
+	format = DT_RIGHT | DT_EXPANDTABS | DT_WORDBREAK;
 	break;
 
     case SS_SIMPLE:
-        wFormat = DT_LEFT | DT_SINGLELINE;
+        format = DT_LEFT | DT_SINGLELINE;
 	break;
 
     case SS_LEFTNOWORDWRAP:
-        wFormat = DT_LEFT | DT_EXPANDTABS;
+        format = DT_LEFT | DT_EXPANDTABS;
 	break;
 
     default:
@@ -649,25 +649,25 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     }
 
     if (GetWindowLongW( hwnd, GWL_EXSTYLE ) & WS_EX_RIGHT)
-        wFormat = DT_RIGHT | (wFormat & ~(DT_LEFT | DT_CENTER));
+        format = DT_RIGHT | (format & ~(DT_LEFT | DT_CENTER));
 
     if (style & SS_NOPREFIX)
-        wFormat |= DT_NOPREFIX;
+        format |= DT_NOPREFIX;
     else if (GetWindowLongW(hwnd, UISTATE_GWL_OFFSET) & UISF_HIDEACCEL) // ReactOS r30727
-        wFormat |= DT_HIDEPREFIX;
+        format |= DT_HIDEPREFIX;
 
     if ((style & SS_TYPEMASK) != SS_SIMPLE)
     {
         if (style & SS_CENTERIMAGE)
-            wFormat |= DT_SINGLELINE | DT_VCENTER;
+            format |= DT_SINGLELINE | DT_VCENTER;
         if (style & SS_EDITCONTROL)
-            wFormat |= DT_EDITCONTROL;
+            format |= DT_EDITCONTROL;
         if (style & SS_ENDELLIPSIS)
-            wFormat |= DT_SINGLELINE | DT_END_ELLIPSIS;
+            format |= DT_SINGLELINE | DT_END_ELLIPSIS;
         if (style & SS_PATHELLIPSIS)
-            wFormat |= DT_SINGLELINE | DT_PATH_ELLIPSIS;
+            format |= DT_SINGLELINE | DT_PATH_ELLIPSIS;
         if (style & SS_WORDELLIPSIS)
-            wFormat |= DT_SINGLELINE | DT_WORD_ELLIPSIS;
+            format |= DT_SINGLELINE | DT_WORD_ELLIPSIS;
     }
 
     if ((hFont = (HFONT)GetWindowLongPtrW( hwnd, HFONT_GWL_OFFSET )))
@@ -706,7 +706,7 @@ static void STATIC_PaintTextfn( HWND hwnd, HDC hdc, DWORD style )
     }
     else
     {
-        DrawTextW( hdc, text, -1, &rc, wFormat );
+        DrawTextW( hdc, text, -1, &rc, format );
     }
 
 no_TextOut:


### PR DESCRIPTION

## Purpose

JIRA issue: [CORE-17315](https://jira.reactos.org/browse/CORE-17315)

## Proposed changes

Import Wine Commit 0ba1bfb0624d5e95f15499d6cfc9af1910c7c5be by Marcus
Meissner: user32: DrawText gets a 32bit flag, not a 16bit flag.

Fixes CORE-17315 - spottted by I_Kill_Bugs
