### PR TITLE
[FREELDR:PC98] Don't do the HighRes check everytime a character is written with writechr.

### DIFF
--- a/boot/freeldr/bootsect/pc98/fat12fdd.S
+++ b/boot/freeldr/bootsect/pc98/fat12fdd.S
@@ -145,11 +145,9 @@ relocated:
     mov ds, ax
 
     test byte ptr ds:[HEX(501)], HEX(08)        // High-resolution mode check
-    jz VideoTestNormalMode
-    mov ax, HEX(0E000)
-    jmp short VideoTestDone
-VideoTestNormalMode:
-    mov ax, HEX(0A000)
+    mov ax, HEX(0A000)                          // Suppose normal mode
+    jz short VideoTestDone
+    mov ah, HEX(E0)                             // Change 0xA000 to 0xE000, use hi-res mode
 VideoTestDone:
     mov word ptr BP_REL(VramSegment), ax
 
@@ -360,14 +358,11 @@ PutChar:
     push di
     push es
 
-    push word ptr BP_REL(VramSegment)
-    pop es
-    mov di, word ptr BP_REL(VramOffset)         // ES:DI = VramSegment:VramOffset
+    les di, dword ptr BP_REL(VramSegOff)        // Load the VRAM segment and offset (ES:DI)
     .PutCharWrite:
-        xor ah, ah
-        stosw                                   // Write ASCII directly to the VRAM
-
-        mov word ptr BP_REL(VramOffset), di
+        xor ah, ah                              // Write ASCII directly to the VRAM
+        stosw                                   //   (two bytes per character)
+        mov word ptr BP_REL(VramOffset), di     // Update the start position
     pop es
     pop di
 
@@ -470,10 +465,12 @@ Reboot:
 Halt:
     jmp short Halt                              // Spin
 
-VramSegment:
-    .word 0
+VramSegOff:
 VramOffset:
     .word 0
+VramSegment:
+    .word 0
+
 msgDiskError:
     .ascii "ERR", CR, LF, NUL
 msgNotFoundError:

--- a/boot/freeldr/freeldr/arch/realmode/helpers_pc98.inc
+++ b/boot/freeldr/freeldr/arch/realmode/helpers_pc98.inc
@@ -56,12 +56,12 @@ writestr:
     jmp short .writestr_loop
 
 .writestr_cr:
-    mov ax, word ptr VramOffset
+    mov ax, word ptr ds:[VramOffset]
     mov dl, 80 * 2
     div dl
     inc ax
     mul dl
-    mov word ptr VramOffset, ax
+    mov word ptr ds:[VramOffset], ax
 
     /* Skip the next LF character */
     inc si
@@ -80,26 +80,38 @@ writechr:
     pushf
     pusha
 
+    /* Check if the VRAM segment was initialized */
+    mov dx, word ptr ds:[VramSegment]
+    test dx, dx
+    jnz short .writechr_write
+
     /* High-resolution mode check */
     test byte ptr ds:[HEX(501)], HEX(08)
-    jz .writechr_normal
-    push HEX(0E000)
-    jmp short .writechr_test_done
-.writechr_normal:
-    push HEX(0A000)
-
+    mov dx, HEX(0A000) // Suppose normal mode
+    jz short .writechr_test_done
+    mov dh, HEX(E0)    // Change 0xA000 to 0xE000, use hi-res mode
 .writechr_test_done:
-    pop es
-    mov di, word ptr VramOffset
+    mov word ptr ds:[VramSegment], dx
+
+.writechr_write:
+    /* Load the VRAM segment and offset (ES:DI) */
+    les di, dword ptr ds:[VramSegOff]
+
+    /* Write ASCII directly to the VRAM (two bytes per character) */
     xor ah, ah
     stosw
-    mov word ptr VramOffset, di
+
+    /* Update the start position */
+    mov word ptr ds:[VramOffset], di
 
     popa
     popf
     ret
 
+VramSegOff:
 VramOffset:
+    .word 0
+VramSegment:
     .word 0
 
 /*


### PR DESCRIPTION
## Purpose

See this PR's title. I suppose that this setting won't change between calls (when e.g. done from the other `writestr` helpers).

## Proposed changes

Do the HighRes check and cache the computed value of `VramSegment` only once, then reuse that latter one.

## TODO

- [x] Retest again once other blocker PR #4358 gets fixed.