### PR TITLE
[MSPAINT] Implement canvas rotation

### DIFF
--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -208,3 +208,38 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile)
 
     return hBitmap;
 }
+
+HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight)
+{
+    HBITMAP hbm2 = CreateDIBWithProperties(cy, cx);
+    if (!hbm2)
+        return NULL;
+
+    HDC hDC2 = CreateCompatibleDC(NULL);
+    HGDIOBJ hbm2Old = SelectObject(hDC2, hbm2);
+    if (bRight)
+    {
+        for (INT y = 0; y < cy; ++y)
+        {
+            for (INT x = 0; x < cx; ++x)
+            {
+                COLORREF rgb = GetPixel(hDC1, x, y);
+                SetPixelV(hDC2, cy - (y + 1), x, rgb);
+            }
+        }
+    }
+    else
+    {
+        for (INT y = 0; y < cy; ++y)
+        {
+            for (INT x = 0; x < cx; ++x)
+            {
+                COLORREF rgb = GetPixel(hDC1, x, y);
+                SetPixelV(hDC2, y, cx - (x + 1), rgb);
+            }
+        }
+    }
+    SelectObject(hDC2, hbm2Old);
+    DeleteDC(hDC2);
+    return hbm2;
+}

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -27,3 +27,5 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile);
 void ShowFileLoadError(LPCTSTR name);
 
 HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, DWORD dwFileSize, BOOL isFile);
+
+HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight);

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -248,7 +248,6 @@ void ImageModel::RotateNTimes90Degrees(int iN)
     switch (iN)
     {
     case 1:
-        CopyPrevious();
         DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
         hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), TRUE);
         currInd = (currInd + 1) % HISTORYSIZE;
@@ -265,7 +264,6 @@ void ImageModel::RotateNTimes90Degrees(int iN)
                    0, 0, GetWidth(), GetHeight(), SRCCOPY);
         break;
     case 3:
-        CopyPrevious();
         DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
         hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), FALSE);
         currInd = (currInd + 1) % HISTORYSIZE;

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -248,8 +248,9 @@ void ImageModel::RotateNTimes90Degrees(int iN)
     switch (iN)
     {
     case 1:
+    case 3:
         DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
-        hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), TRUE);
+        hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), iN == 1);
         currInd = (currInd + 1) % HISTORYSIZE;
         if (undoSteps < HISTORYSIZE - 1)
             undoSteps++;
@@ -262,17 +263,6 @@ void ImageModel::RotateNTimes90Degrees(int iN)
         CopyPrevious();
         StretchBlt(hDrawingDC, GetWidth() - 1, GetHeight() - 1, -GetWidth(), -GetHeight(), GetDC(),
                    0, 0, GetWidth(), GetHeight(), SRCCOPY);
-        break;
-    case 3:
-        DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
-        hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), FALSE);
-        currInd = (currInd + 1) % HISTORYSIZE;
-        if (undoSteps < HISTORYSIZE - 1)
-            undoSteps++;
-        redoSteps = 0;
-        SelectObject(hDrawingDC, hBms[currInd]);
-        imageSaved = FALSE;
-        NotifyDimensionsChanged();
         break;
     }
     NotifyImageChanged();

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -245,11 +245,37 @@ void ImageModel::FlipVertically()
 
 void ImageModel::RotateNTimes90Degrees(int iN)
 {
-    if (iN == 2)
+    switch (iN)
     {
+    case 1:
+        CopyPrevious();
+        DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
+        hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), TRUE);
+        currInd = (currInd + 1) % HISTORYSIZE;
+        if (undoSteps < HISTORYSIZE - 1)
+            undoSteps++;
+        redoSteps = 0;
+        SelectObject(hDrawingDC, hBms[currInd]);
+        imageSaved = FALSE;
+        NotifyDimensionsChanged();
+        break;
+    case 2:
         CopyPrevious();
         StretchBlt(hDrawingDC, GetWidth() - 1, GetHeight() - 1, -GetWidth(), -GetHeight(), GetDC(),
                    0, 0, GetWidth(), GetHeight(), SRCCOPY);
+        break;
+    case 3:
+        CopyPrevious();
+        DeleteObject(hBms[(currInd + 1) % HISTORYSIZE]);
+        hBms[(currInd + 1) % HISTORYSIZE] = Rotate90DegreeBlt(hDrawingDC, GetWidth(), GetHeight(), FALSE);
+        currInd = (currInd + 1) % HISTORYSIZE;
+        if (undoSteps < HISTORYSIZE - 1)
+            undoSteps++;
+        redoSteps = 0;
+        SelectObject(hDrawingDC, hBms[currInd]);
+        imageSaved = FALSE;
+        NotifyDimensionsChanged();
+        break;
     }
     NotifyImageChanged();
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -344,7 +344,8 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
         if (fontsDialog.IsWindow() && IsDialogMessage(fontsDialog, &messages))
             continue;
 
-        TranslateAccelerator(hwnd, haccel, &messages);
+        if (TranslateAccelerator(hwnd, haccel, &messages))
+            continue;
 
         /* Translate virtual-key messages into character messages */
         TranslateMessage(&messages);

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -266,6 +266,7 @@ LRESULT CSelectionWindow::OnToolsModelSettingsChanged(UINT nMsg, WPARAM wParam, 
 
 LRESULT CSelectionWindow::OnSelectionModelRefreshNeeded(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    ForceRefreshSelectionContents();
     return 0;
 }
 

--- a/base/applications/mspaint/selectionmodel.h
+++ b/base/applications/mspaint/selectionmodel.h
@@ -50,7 +50,7 @@ public:
     void DrawSelection(HDC hDCImage, COLORREF crBg = 0, BOOL bBgTransparent = FALSE);
     void DrawSelectionStretched(HDC hDCImage);
     void ScaleContentsToFit();
-    void InsertFromHBITMAP(HBITMAP hBm);
+    void InsertFromHBITMAP(HBITMAP hBm, INT x = 0, INT y = 0);
     void FlipHorizontally();
     void FlipVertically();
     void RotateNTimes90Degrees(int iN);

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -141,6 +141,8 @@ void ToolsModel::SetBackgroundTransparent(BOOL bTransparent)
 {
     m_transpBg = bTransparent;
     NotifyToolSettingsChanged();
+    if (selectionWindow.IsWindow())
+        selectionWindow.ForceRefreshSelectionContents();
 }
 
 int ToolsModel::GetZoom() const

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -664,6 +664,10 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                         imageModel.FlipVertically();
                     break;
                 case 3: /* rotate 90 degrees */
+                    if (::IsWindowVisible(selectionWindow))
+                        selectionModel.RotateNTimes90Degrees(1);
+                    else
+                        imageModel.RotateNTimes90Degrees(1);
                     break;
                 case 4: /* rotate 180 degrees */
                     if (::IsWindowVisible(selectionWindow))
@@ -672,6 +676,10 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
                         imageModel.RotateNTimes90Degrees(2);
                     break;
                 case 5: /* rotate 270 degrees */
+                    if (::IsWindowVisible(selectionWindow))
+                        selectionModel.RotateNTimes90Degrees(3);
+                    else
+                        imageModel.RotateNTimes90Degrees(3);
                     break;
             }
             break;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16634](https://jira.reactos.org/browse/CORE-16634)

## Proposed changes

- Add `Rotate90DegreeBlt` function to `dib.cpp`.
- Implement `ImageModel::RotateNTimes90Degrees` and `SelectionModel::RotateNTimes90Degrees`.
- Improve `ToolsModel::SetBackgroundTransparent`.
- Extend and improve `SelectionModel::InsertFromHBITMAP`.

## Screenshots

![1](https://user-images.githubusercontent.com/2107452/153755120-f049c1a2-f920-429e-88d2-3b832cf786fd.png)
![2](https://user-images.githubusercontent.com/2107452/153755119-c357296d-706a-41bf-85c6-09ca9c200c72.png)

## NOTE

Always selecting the bitmap object is bad design. Our source is cursed. Two DCs can't select the same bitmap at once.