### PR TITLE
[WIN32SS] Store the scrollbar theming enabled flag in the scrollbar

### DIFF
--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -528,6 +528,11 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    Info = IntGetScrollInfoFromWindow(Window, nBar);
    pSBData = IntGetSBData(Window, nBar);
 
+   if (lpsi->fMask & SIF_THEMED && !(Info->fMask & SIF_THEMED))
+   {
+       Info->fMask |= SIF_THEMED;
+   }
+
    /* Set the page size */
    if (lpsi->fMask & SIF_PAGE)
    {
@@ -660,7 +665,7 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
             return lpsi->fMask & SIF_PREVIOUSPOS ? OldPos : pSBData->pos; /* SetWindowPos() already did the painting */
       if (bRedraw)
       {
-         if (!(lpsi->fMask & SIF_THEMED)) /* Not Using Themes */
+         if (!(Info->fMask & SIF_THEMED)) /* Not Using Themes */
          {
             TRACE("Not using themes.\n");
             if (action & SA_SSI_REPAINT_ARROWS)


### PR DESCRIPTION
This ensure we do not rely on usermode for always passing this flag in,
which is a ReactOS specific flag.
Thanks to Doug Lyons for finding the source of the problem.

JIRA issue: [CORE-17780](https://jira.reactos.org/browse/CORE-17780)
