### PR TITLE
[USERENV] SetUserEnvironmentVariable(): Remove use of uninit' ShortName

### DIFF
--- a/dll/win32/userenv/environment.c
+++ b/dll/win32/userenv/environment.c
@@ -88,8 +88,6 @@ SetUserEnvironmentVariable(PWSTR* Environment,
         {
             DPRINT("GetShortPathNameW() failed for %S (Error %lu)\n", DstValue.Buffer, GetLastError());
         }
-
-        DPRINT("Buffer: %S\n", ShortName);
     }
 
     RtlInitUnicodeString(&Name, lpName);


### PR DESCRIPTION
Split off of #4349.

Addendum to 96fe018 (r72066).