### PR TITLE
[WIN32SS][NTGDI] Remove useless assert

### DIFF
--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -1064,7 +1064,6 @@ IntGdiCreateDisplayDC(HDEV hDev, ULONG DcType, BOOL EmptyDC)
 {
     HDC hDC;
     UNIMPLEMENTED;
-    ASSERT(FALSE);
 
     if (DcType == DC_TYPE_MEMORY)
         hDC = NtGdiCreateCompatibleDC(NULL); // OH~ Yuck! I think I taste vomit in my mouth!


### PR DESCRIPTION
## Purpose

Remove useless `ASSERT(FALSE);` in `IntGdiCreateDisplayDC`, because it actually does not check anything useful. It only asserts each time when the function is called from `DxEngCreateMemoryDC` by MS DirectDraw stack (ddraw.dll & dxg.sys).
`UNIMPLEMENTED` debug print is enough a lot to see that this function is not implemented properly.
**This function does not play the major role for DirectDraw and Direct3D at least. It does properly the main thing which it should do - DC is creating successfully. So its current implementation is enough for this case. The bug with running in fullscreen mode is caused by another code.**

JIRA issue: [CORE-17561](https://jira.reactos.org/browse/CORE-17561)

## Result

As result, the DirectDraw and Direct3D acceleration is now working properly with MS ddraw.dll, d3d8.dll, d3d9.dll and dxg.sys replacement, at least in windowed mode. :smiley:  So this is really the last fix for that.
**But please note that my #3638 PR is also badly required to be applied/merged.** I think it makes sense to merge that together with merging this fix.