### PR TITLE
[SCSIPORT] Improved PnP support

### DIFF
--- a/drivers/storage/port/scsiport/scsiport.c
+++ b/drivers/storage/port/scsiport/scsiport.c
@@ -857,7 +857,7 @@ SpiCreatePortDevice(IN PDRIVER_OBJECT DriverObject,
     RtlZeroMemory(DeviceExtension, DeviceExtensionSize);
     DeviceExtension->Common.DeviceObject = PortDeviceObject;
     DeviceExtension->Common.IsFDO = TRUE;
-    DeviceExtension->Common.PnpState = SpcsNeverStarted;
+    DeviceExtension->Common.PnpState = SppsNeverStarted;
     DeviceExtension->Length = DeviceExtensionSize;
     DeviceExtension->PortNumber = SystemConfig->ScsiPortCount;
     DeviceExtension->DeviceName = DeviceName;

--- a/drivers/storage/port/scsiport/scsiport.h
+++ b/drivers/storage/port/scsiport/scsiport.h
@@ -76,6 +76,17 @@ typedef enum _SCSI_PORT_TIMER_STATES
     IDETimerResetWaitForDrdyAssert
 } SCSI_PORT_TIMER_STATES;
 
+typedef enum _SCSI_PORT_PNP_STATES
+{
+    SpcsNeverStarted = 0,
+    SpcsStarted,
+    SpcsPendingRemoval,
+    SpcsPendingStop,
+    SpcsSurpriseRemoved,
+    SpcsRemoved,
+    SpcsStopped
+} SCSI_PORT_PNP_STATES;
+
 typedef struct _CONFIGURATION_INFO
 {
     /* Identify info */
@@ -138,6 +149,8 @@ typedef struct _SCSI_PORT_COMMON_EXTENSION
     PDEVICE_OBJECT DeviceObject;
     PDEVICE_OBJECT LowerDevice;
     BOOLEAN IsFDO;
+    SCSI_PORT_PNP_STATES PnpState;
+    IO_REMOVE_LOCK RemoveLock;
 } SCSI_PORT_COMMON_EXTENSION, *PSCSI_PORT_COMMON_EXTENSION;
 
 // PDO device

--- a/drivers/storage/port/scsiport/scsiport.h
+++ b/drivers/storage/port/scsiport/scsiport.h
@@ -78,13 +78,13 @@ typedef enum _SCSI_PORT_TIMER_STATES
 
 typedef enum _SCSI_PORT_PNP_STATES
 {
-    SpcsNeverStarted = 0,
-    SpcsStarted,
-    SpcsPendingRemoval,
-    SpcsPendingStop,
-    SpcsSurpriseRemoved,
-    SpcsRemoved,
-    SpcsStopped
+    SppsNeverStarted = 0,
+    SppsStarted,
+    SppsPendingRemoval,
+    SppsPendingStop,
+    SppsSurpriseRemoved,
+    SppsRemoved,
+    SppsStopped
 } SCSI_PORT_PNP_STATES;
 
 typedef struct _CONFIGURATION_INFO


### PR DESCRIPTION
## Purpose
Right now, the PnP support in ScsiPort is partial and locked behind an `ASSERT`.
Finishing the implementation will provide better compatibility with existing windows drivers, and it will also allow us to write fully PnP-aware SCSI miniports in the future.

## TODO
- [ ] Move functionality out of ScsiPortInitialize to reuse in PnP device creation
- [ ] Defer creation of PnP device FDOs to ScsiPortAddDevice()
- [ ] Finish handler for IRP_MN_START_DEVICE
- [ ] Handle IRP_MN_SURPRISE_REMOVAL
- [ ] Handle IRP_MN_REMOVE_DEVICE
- [ ] Handle IRP_MN_QUERY_REMOVE_DEVICE
- [ ] Handle IRP_MN_CANCEL_REMOVE_DEVICE
- [ ] Handle IRP_MN_STOP_DEVICE
- [ ] Handle IRP_MN_QUERY_STOP_DEVICE
- [ ] Handle IRP_MN_CANCEL_STOP_DEVICE
- [ ] Make existing code PnP state aware

## End Goals
- [ ] Being able to confidently remove the `ASSERT(driverExtension->IsLegacyDriver)` from ScsiPortInitialize