### PR TITLE
[NTUSER][IMM32] Fix ValidateHandleNoErr

### DIFF
--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -149,7 +149,7 @@ VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
     plfA->lfFaceName[cch] = 0;
 }
 
-PVOID DesktopPtrToUser(PVOID ptr)
+static PVOID FASTCALL DesktopPtrToUser(PVOID ptr)
 {
     PCLIENTINFO pci = GetWin32ClientInfo();
     PDESKTOPINFO pdi = pci->pDeskInfo;
@@ -157,13 +157,9 @@ PVOID DesktopPtrToUser(PVOID ptr)
     ASSERT(ptr != NULL);
     ASSERT(pdi != NULL);
     if (pdi->pvDesktopBase <= ptr && ptr < pdi->pvDesktopLimit)
-    {
         return (PVOID)((ULONG_PTR)ptr - pci->ulClientDelta);
-    }
     else
-    {
         return (PVOID)NtUserCallOneParam((DWORD_PTR)ptr, ONEPARAM_ROUTINE_GETDESKTOPMAPPING);
-    }
 }
 
 LPVOID FASTCALL ValidateHandleNoErr(HANDLE hObject, UINT uType)

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -168,7 +168,7 @@ PVOID DesktopPtrToUser(PVOID ptr)
 
 LPVOID FASTCALL ValidateHandleNoErr(HANDLE hObject, UINT uType)
 {
-    INT index;
+    UINT index;
     PUSER_HANDLE_TABLE ht;
     PUSER_HANDLE_ENTRY he;
     WORD generation;
@@ -184,7 +184,10 @@ LPVOID FASTCALL ValidateHandleNoErr(HANDLE hObject, UINT uType)
     he = (PUSER_HANDLE_ENTRY)((ULONG_PTR)ht->handles - g_SharedInfo.ulSharedDelta);
 
     index = (LOWORD(hObject) - FIRST_USER_HANDLE) >> 1;
-    if (index < 0 || ht->nb_handles <= index || he[index].type != uType)
+    if ((INT)index < 0 || ht->nb_handles <= index || he[index].type != uType)
+        return NULL;
+
+    if (he[index].flags & HANDLEENTRY_DESTROY)
         return NULL;
 
     generation = HIWORD(hObject);


### PR DESCRIPTION
## Purpose
`imm32.ValidateHandleNoErr` is an important function to get the object pointer from a handle. It was not working.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-18049](https://jira.reactos.org/browse/CORE-18049)

## Proposed changes

- Add `DesktopPtrToUser` helper function.
- Fix `imm32.ValidateHandleNoErr` function.
- Use `DesktopHeapAlloc` to allocate the IMC, instead of `ExAllocatePoolWithTag`.
- Use `DesktopHeapFree` to free the IMC, instead of `ExFreePoolWithTag`.

## TODO

- [x] Do tests.