### PR TITLE
[NTUSER] Fix Toolbar re-painting when Rebar parent has been altered.

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2103,10 +2103,7 @@ co_WinPosSetWindowPos(
                    IntInvalidateWindows( Parent, DirtyRgn, RDW_ERASE | RDW_INVALIDATE);
                    co_IntPaintWindows(Parent, RDW_NOCHILDREN, FALSE);
                 }
-                else
-                {
-                   IntInvalidateWindows( Window, DirtyRgn, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
-                }
+                IntInvalidateWindows(Window, DirtyRgn, RDW_ERASE | RDW_FRAME | RDW_INVALIDATE | RDW_ALLCHILDREN);
              }
              else if ( RgnType != ERROR && RgnType == NULLREGION ) // Must be the same. See CORE-7166 & CORE-15934, NC HACK fix.
              {


### PR DESCRIPTION
## Purpose

If a Rebar window is altered by calling either ShowWindow() or UpdateWindow()
then we were only updating the parent and omitting their children windows.

This is closer to the behavior of the very very old SVN r27394 == git f1a7f30887ac02e9a6c6605d0409af2618771154 .
And therefore intentionally excludes parts of SVN r27403 == git e2651a0dbc4d98dbda0d87746b87bd9575fb4f4c .

The bots have no complaints about it:
KVM https://reactos.org/testman/compare.php?ids=81266,81290
VBox https://reactos.org/testman/compare.php?ids=81267,81291

JIRA issue: [CORE-12342](https://jira.reactos.org/browse/CORE-12342)
