### PR TITLE
[SHELL32] Support CSIDL_FLAG_NO_ALIAS

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -2888,6 +2888,9 @@ HRESULT WINAPI SHGetFolderLocation(
 	LPITEMIDLIST *ppidl)
 {
     HRESULT hr = E_INVALIDARG;
+#ifdef __REACTOS__
+    WCHAR szPath[MAX_PATH];
+#endif
 
     TRACE("%p 0x%08x %p 0x%08x %p\n",
      hwndOwner, nFolder, hToken, dwReserved, ppidl);
@@ -2897,6 +2900,15 @@ HRESULT WINAPI SHGetFolderLocation(
     if (dwReserved)
         return E_INVALIDARG;
 
+#ifdef __REACTOS__
+    if ((nFolder & CSIDL_FLAG_NO_ALIAS) &&
+        SHGetSpecialFolderPathW(hwndOwner, szPath, (nFolder & CSIDL_FOLDER_MASK), FALSE))
+    {
+        *ppidl = ILCreateFromPathW(szPath);
+        if (*ppidl)
+            return S_OK;
+    }
+#endif
     /* The virtual folders' locations are not user-dependent */
     *ppidl = NULL;
     switch (nFolder & CSIDL_FOLDER_MASK)


### PR DESCRIPTION
## Purpose
Adding the `CSIDL_FLAG_NO_ALIAS` flag to `SHGetSpecialFolderLocation` should return the physical PIDL.
JIRA issue: [CORE-18079](https://jira.reactos.org/browse/CORE-18079)

## TODO

- [x] Do tests.

## Comparison
BEFORE:
![PidlTest-0 4 15-dev-3878-gd9f156e-FAILED](https://user-images.githubusercontent.com/2107452/156910096-4e4ad49f-1d43-4313-bfc3-1b2d8999175e.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/156910094-e0bcb672-cc71-4c6c-9c84-15e6b9ecc6a2.png)