### PR TITLE
GCC 9+ support draft [for futureproofing]

### DIFF
--- a/base/applications/atactl/CMakeLists.txt
+++ b/base/applications/atactl/CMakeLists.txt
@@ -4,4 +4,9 @@ include_directories(${REACTOS_SOURCE_DIR}/drivers/storage/ide/uniata)
 add_executable(atactl atactl.cpp atactl.rc)
 set_module_type(atactl win32cui)
 add_importlibs(atactl advapi32 msvcrt kernel32 ntdll)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
+    target_compile_options(atactl PRIVATE -Wno-format)
+endif()
+
 add_cd_file(TARGET atactl DESTINATION reactos/system32 FOR all)

--- a/base/applications/network/ftp/CMakeLists.txt
+++ b/base/applications/network/ftp/CMakeLists.txt
@@ -17,6 +17,10 @@ add_importlibs(ftp ws2_32 iphlpapi msvcrt kernel32)
 target_link_libraries(ftp oldnames)
 add_pch(ftp precomp.h SOURCE)
 
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
+   target_compile_options(ftp PRIVATE -Wno-free-nonheap-object)
+endif()
+
 if(MSVC)
     add_importlibs(ftp ntdll)
 endif()

--- a/base/applications/network/telnet/src/tnconfig.cpp
+++ b/base/applications/network/telnet/src/tnconfig.cpp
@@ -547,7 +547,7 @@ void TConfig::keyfile_init() {
 		// if there is no environment variable
 		GetPrivateProfileString("Keyboard", "Keyfile", "", keyfile,
 			sizeof(keyfile), inifile);
-		if(keyfile == 0 || *keyfile == 0) {
+		if(*keyfile == 0) {
 			// and there is no profile string
 			strcpy(keyfile, startdir);
 			if (sizeof(keyfile) >= strlen(keyfile)+strlen("telnet.cfg")) {

--- a/base/shell/cmd/del.c
+++ b/base/shell/cmd/del.c
@@ -332,8 +332,9 @@ ProcessDirectory(LPTSTR FileName, DWORD* dwFlags, DWORD dwAttrFlags)
             {
                 if (!(f.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) ||
                         !_tcscmp(f.cFileName, _T(".")) ||
-                        !_tcscmp(f.cFileName, _T("..")))
-                    continue;
+                        !_tcscmp(f.cFileName, _T(".."))) {
+                        continue;
+                    }
 
                     _tcscpy(pFilePart, f.cFileName);
                     _tcscat(pFilePart, _T("\\"));

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -214,6 +214,9 @@ if(USE_CLANG_CL)
     # We need to reduce the binary size
     target_compile_options(freeldr_common PRIVATE "/Os")
 endif()
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
+    target_compile_options(freeldr_common PRIVATE -Wno-format)
+endif()
 if(NOT MSVC AND ARCH STREQUAL "i386" AND SARCH STREQUAL "xbox")
   # Prevent a warning when doing a memcmp with address 0
   set_source_files_properties(arch/i386/xbox/xboxmem.c PROPERTIES COMPILE_FLAGS "-Wno-nonnull")

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -935,7 +935,7 @@ ShowSoundScheme(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
             tvItem.item.state = TVIS_EXPANDED;
             tvItem.item.stateMask = TVIS_EXPANDED;
             tvItem.item.pszText = pLabelMap->szDesc;
-            if (pLabelContext->szValue && _tcslen(pLabelContext->szValue) > 0)
+            if (pLabelContext->szValue[0] && _tcslen(pLabelContext->szValue) > 0)
             {
                 tvItem.item.iImage = IMAGE_SOUND_ASSIGNED;
                 tvItem.item.iSelectedImage = IMAGE_SOUND_ASSIGNED;

--- a/dll/opengl/glu32/CMakeLists.txt
+++ b/dll/opengl/glu32/CMakeLists.txt
@@ -121,7 +121,7 @@ target_link_libraries(glu32 cpprt)
 set_module_type(glu32 win32dll)
 
 if(NOT MSVC)
-    target_compile_options(glu32 PRIVATE -Wno-write-strings)
+    target_compile_options(glu32 PRIVATE -Wno-write-strings -Wno-uninitialized)
 elseif(USE_CLANG_CL)
     target_compile_options(glu32 PRIVATE -Wno-self-assign -Wno-unused-function -Wno-microsoft-include)
     target_compile_options(glu32 PRIVATE -Wno-deprecated-register -Wno-tautological-undefined-compare)

--- a/dll/opengl/mesa/clip.c
+++ b/dll/opengl/mesa/clip.c
@@ -479,6 +479,11 @@ GLuint gl_viewclip_polygon( GLcontext* ctx, GLuint n, GLuint vlist[] )
  *              from v[in] to v[out] with the clipping plane and store
  *              the result in v[new]
  */
+#ifdef __REACTOS__
+#define OUTLIST_IS_VLIST2 (&OUTLIST[0]==&vlist2[0])
+#else
+#define OUTLIST_IS_VLIST2 (OUTLIST==vlist2)
+#endif
 
 #define GENERAL_CLIP                                                    \
    if (INCOUNT<3)  return 0;						\
@@ -538,7 +543,7 @@ GLuint gl_viewclip_polygon( GLcontext* ctx, GLuint n, GLuint vlist[] )
       /* check for overflowing vertex buffer */				\
       if (OUTCOUNT>=VB_SIZE-1) {					\
 	 /* Too many vertices */					\
-         if (&OUTLIST[0]==&vlist2[0]) {						\
+         if (OUTLIST_IS_VLIST2) {					\
 	    /* copy OUTLIST[] to vlist[] */				\
 	    int i;							\
 	    for (i=0;i<VB_SIZE;i++) {					\

--- a/dll/opengl/mesa/clip.c
+++ b/dll/opengl/mesa/clip.c
@@ -538,7 +538,7 @@ GLuint gl_viewclip_polygon( GLcontext* ctx, GLuint n, GLuint vlist[] )
       /* check for overflowing vertex buffer */				\
       if (OUTCOUNT>=VB_SIZE-1) {					\
 	 /* Too many vertices */					\
-         if (OUTLIST==vlist2) {						\
+         if (&OUTLIST[0]==&vlist2[0]) {						\
 	    /* copy OUTLIST[] to vlist[] */				\
 	    int i;							\
 	    for (i=0;i<VB_SIZE;i++) {					\

--- a/dll/opengl/mesa/eval.c
+++ b/dll/opengl/mesa/eval.c
@@ -2026,7 +2026,7 @@ void gl_EvalCoord1f(GLcontext* ctx, GLfloat u)
      colorptr = icolor;
   }
   else {
-     GLubyte col[4];
+     static GLubyte col[4];
      COPY_4V(col, ctx->Current.ByteColor );
      colorptr = col;
   }
@@ -2164,7 +2164,7 @@ void gl_EvalCoord2f( GLcontext* ctx, GLfloat u, GLfloat v )
       colorptr = icolor;
    }
    else {
-     GLubyte col[4];
+     static GLubyte col[4];
      COPY_4V(col, ctx->Current.ByteColor );
      colorptr = col;
    }

--- a/dll/opengl/mesa/eval.c
+++ b/dll/opengl/mesa/eval.c
@@ -2026,7 +2026,10 @@ void gl_EvalCoord1f(GLcontext* ctx, GLfloat u)
      colorptr = icolor;
   }
   else {
-     static GLubyte col[4];
+#ifdef __REACTOS__ // fix -Wdangling-pointer
+     static
+#endif
+     GLubyte col[4];
      COPY_4V(col, ctx->Current.ByteColor );
      colorptr = col;
   }
@@ -2164,7 +2167,10 @@ void gl_EvalCoord2f( GLcontext* ctx, GLfloat u, GLfloat v )
       colorptr = icolor;
    }
    else {
-     static GLubyte col[4];
+#ifdef __REACTOS__ // fix -Wdangling-pointer
+     static
+#endif
+     GLubyte col[4];
      COPY_4V(col, ctx->Current.ByteColor );
      colorptr = col;
    }

--- a/dll/shellext/shellbtrfs/reactos.cpp
+++ b/dll/shellext/shellbtrfs/reactos.cpp
@@ -17,6 +17,17 @@ extern "C" {
 /* So that we can link */
 DEFINE_GUID(CLSID_WICImagingFactory, 0xcacaf262,0x9370,0x4615,0xa1,0x3b,0x9f,0x55,0x39,0xda,0x4c,0x0a);
 
+#if __GNUC__ >= 9
+// Evil hack to bypass compile, temporary until further notice
+// TODO: import rand_s into msvcex? Even more evil, but also more consistent
+int CDECL hack_rand_s(unsigned int *pval)
+{
+    return rand();
+}
+
+const void* _imp__rand_s = (const void*)&hack_rand_s;
+#endif
+
 /* Copied from ntoskrnl_vista */
 NTSTATUS WINAPI RtlUTF8ToUnicodeN(PWSTR uni_dest, ULONG uni_bytes_max,
                                   PULONG uni_bytes_written,

--- a/dll/win32/crypt32/store.c
+++ b/dll/win32/crypt32/store.c
@@ -1269,7 +1269,7 @@ static LONG CRYPT_OpenParentStore(DWORD dwFlags,
     void *pvSystemStoreLocationPara, HKEY *key)
 {
     HKEY root;
-    LPCWSTR base;
+    static LPCWSTR base;
 
     TRACE("(%08x, %p)\n", dwFlags, pvSystemStoreLocationPara);
 

--- a/dll/win32/devmgr/properties/hwpage.cpp
+++ b/dll/win32/devmgr/properties/hwpage.cpp
@@ -1030,8 +1030,8 @@ DeviceCreateHardwarePageEx(IN HWND hWndParent,
        failure cases! */
     hpd = (PHARDWARE_PAGE_DATA)HeapAlloc(GetProcessHeap(),
                                          HEAP_ZERO_MEMORY,
-                                         FIELD_OFFSET(HARDWARE_PAGE_DATA,
-                                                      ClassDevInfo[uNumberOfGuids]));
+                                         FIELD_OFFSET(HARDWARE_PAGE_DATA, ClassDevInfo)
+                                         + (uNumberOfGuids * sizeof(HWCLASSDEVINFO)));
     if (hpd != NULL)
     {
         HWND hWnd;

--- a/dll/win32/oleaut32/vartype.c
+++ b/dll/win32/oleaut32/vartype.c
@@ -152,15 +152,15 @@ static HRESULT VARIANT_FromDisp(IDispatch* pdispIn, LCID lcid, void* pOut,
 
 /* Compiler cast where input cannot be negative */
 #define NEGTST(dest, src, func) RETTYP _##func(src in, dest* out) { \
-  if (in < 0) return DISP_E_OVERFLOW; *out = in; return S_OK; }
+  if (in < 0) { return DISP_E_OVERFLOW; } *out = in; return S_OK; }
 
 /* Compiler cast where input cannot be > some number */
 #define POSTST(dest, src, func, tst) RETTYP _##func(src in, dest* out) { \
-  if (in > (dest)tst) return DISP_E_OVERFLOW; *out = in; return S_OK; }
+  if (in > (dest)tst) { return DISP_E_OVERFLOW; } *out = in; return S_OK; }
 
 /* Compiler cast where input cannot be < some number or >= some other number */
 #define BOTHTST(dest, src, func, lo, hi) RETTYP _##func(src in, dest* out) { \
-  if (in < (dest)lo || in > hi) return DISP_E_OVERFLOW; *out = in; return S_OK; }
+  if (in < (dest)lo || in > hi) { return DISP_E_OVERFLOW; } *out = in; return S_OK; }
 
 /* I1 */
 POSTST(signed char, BYTE, VarI1FromUI1, I1_MAX)

--- a/dll/win32/shell32/wine/classes.c
+++ b/dll/win32/shell32/wine/classes.c
@@ -326,10 +326,10 @@ BOOL HCR_GetIconA(LPCSTR szClass, LPSTR szDest, LPCSTR szName, DWORD len, int* p
 	  RegCloseKey(hkey);
 	}
 
-    if (ret)
-        TRACE("-- %s %i\n", szDest, *picon_idx);
-    else
-        TRACE("-- not found\n");
+        if (ret)
+            TRACE("-- %s %i\n", szDest, *picon_idx);
+        else
+            TRACE("-- not found\n");
 
 	return ret;
 }

--- a/dll/win32/shell32/wine/shellord.c
+++ b/dll/win32/shell32/wine/shellord.c
@@ -2205,9 +2205,9 @@ HRESULT WINAPI SHCreateStdEnumFmtEtc(
 	HRESULT hRes;
 	TRACE("cf=%d fe=%p pef=%p\n", cFormats, lpFormats, ppenumFormatetc);
 
-    hRes = IEnumFORMATETC_Constructor(cFormats, lpFormats, &pef);
-    if (FAILED(hRes))
-        return hRes;
+	hRes = IEnumFORMATETC_Constructor(cFormats, lpFormats, &pef);
+	if (FAILED(hRes))
+	    return hRes;
 
 	IEnumFORMATETC_AddRef(pef);
 	hRes = IEnumFORMATETC_QueryInterface(pef, &IID_IEnumFORMATETC, (LPVOID*)ppenumFormatetc);

--- a/dll/win32/wininet/internet.c
+++ b/dll/win32/wininet/internet.c
@@ -2880,9 +2880,10 @@ BOOL WINAPI InternetSetOptionW(HINTERNET hInternet, DWORD dwOption,
         } else if(dwBufferLength != sizeof(ULONG)) {
             SetLastError(ERROR_INTERNET_BAD_OPTION_LENGTH);
             ret = FALSE;
-        } else
+        } else {
             TRACE("INTERNET_OPTION_ERROR_MASK: %x\n", *(ULONG*)lpBuffer);
             lpwhh->ErrorMask = *(ULONG*)lpBuffer;
+        }
       }
       break;
     case INTERNET_OPTION_PROXY:

--- a/drivers/bus/acpi/busmgr/utils.c
+++ b/drivers/bus/acpi/busmgr/utils.c
@@ -364,8 +364,9 @@ end:
 		//ExFreePool(list->handles);
 	}
 
-    if (buffer.Pointer)
-        AcpiOsFree(buffer.Pointer);
+	if (buffer.Pointer) {
+		AcpiOsFree(buffer.Pointer);
+	}
 
 	return_ACPI_STATUS(status);
 }

--- a/drivers/filesystems/ext2/CMakeLists.txt
+++ b/drivers/filesystems/ext2/CMakeLists.txt
@@ -102,6 +102,9 @@ else()
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+        target_compile_options(ext2fs PRIVATE -Wno-address-of-packed-member)
+    endif()
     target_compile_options(ext2fs PRIVATE -Wno-unused-but-set-variable)
 endif()
 

--- a/drivers/ksfilter/ks/filter.c
+++ b/drivers/ksfilter/ks/filter.c
@@ -168,7 +168,7 @@ IKsProcessingObject_fnProcessingObjectWork(
     {
 
         /* check if the and-gate has been enabled again */
-        if (&This->Gate.Count != 0)
+        if (This->Gate.Count != 0)
         {
             /* gate is open */
             DPRINT1("processing object gate open\n");

--- a/drivers/storage/ide/uniata/CMakeLists.txt
+++ b/drivers/storage/ide/uniata/CMakeLists.txt
@@ -35,6 +35,9 @@ if(MSVC)
 endif()
 
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+        target_compile_options(uniata PRIVATE -Wno-misleading-indentation)
+    endif()
     target_compile_options(uniata PRIVATE -Wno-unused-but-set-variable)
 endif()
 

--- a/drivers/storage/ide/uniata/id_init.cpp
+++ b/drivers/storage/ide/uniata/id_init.cpp
@@ -108,7 +108,7 @@ UniataChipDetectChannels(
         AtapiRegCheckDevValue(deviceExtension, CHAN_NOT_SPECIFIED, DEVNUM_NOT_SPECIFIED, L"PortMask", (ULONG)0xffffffff >> (32-deviceExtension->NumberChannels) );
     KdPrint2((PRINT_PREFIX "Force PortMask %#x\n", deviceExtension->AHCI_PI_mask));
 
-    for(i=deviceExtension->AHCI_PI_mask, n=0; i; i=i>>1) {++n;}
+    for(i=deviceExtension->AHCI_PI_mask, n=0; i; n++, i=i>>1);
     KdPrint2((PRINT_PREFIX "mask -> %d chans\n", n));
 
     switch(VendorID) {

--- a/drivers/storage/ide/uniata/id_init.cpp
+++ b/drivers/storage/ide/uniata/id_init.cpp
@@ -108,7 +108,7 @@ UniataChipDetectChannels(
         AtapiRegCheckDevValue(deviceExtension, CHAN_NOT_SPECIFIED, DEVNUM_NOT_SPECIFIED, L"PortMask", (ULONG)0xffffffff >> (32-deviceExtension->NumberChannels) );
     KdPrint2((PRINT_PREFIX "Force PortMask %#x\n", deviceExtension->AHCI_PI_mask));
 
-    for(i=deviceExtension->AHCI_PI_mask, n=0; i; n++, i=i>>1);
+    for(i=deviceExtension->AHCI_PI_mask, n=0; i; i=i>>1) {++n;}
     KdPrint2((PRINT_PREFIX "mask -> %d chans\n", n));
 
     switch(VendorID) {

--- a/drivers/usb/usbohci/usbohci.c
+++ b/drivers/usb/usbohci/usbohci.c
@@ -50,30 +50,30 @@ OHCI_DumpHcdTD(POHCI_HCD_TD TD)
 {
     DPRINT("TD                - %p\n", TD);
     DPRINT("gTD.Control       - %08X\n", TD->HwTD.gTD.Control.AsULONG);
-if (TD->HwTD.gTD.CurrentBuffer)
-    DPRINT("gTD.CurrentBuffer - %08X\n", TD->HwTD.gTD.CurrentBuffer);
-if (TD->HwTD.gTD.NextTD)
-    DPRINT("gTD.NextTD        - %08X\n", TD->HwTD.gTD.NextTD);
-if (TD->HwTD.gTD.BufferEnd)
-    DPRINT("gTD.BufferEnd     - %08X\n", TD->HwTD.gTD.BufferEnd);
+if (TD->HwTD.gTD.CurrentBuffer) {
+    DPRINT("gTD.CurrentBuffer - %08X\n", TD->HwTD.gTD.CurrentBuffer); }
+if (TD->HwTD.gTD.NextTD) {
+    DPRINT("gTD.NextTD        - %08X\n", TD->HwTD.gTD.NextTD); }
+if (TD->HwTD.gTD.BufferEnd) {
+    DPRINT("gTD.BufferEnd     - %08X\n", TD->HwTD.gTD.BufferEnd); }
 
-if (TD->HwTD.SetupPacket.bmRequestType.B)
-    DPRINT("bmRequestType     - %02X\n", TD->HwTD.SetupPacket.bmRequestType.B);
-if (TD->HwTD.SetupPacket.bRequest)
-    DPRINT("bRequest          - %02X\n", TD->HwTD.SetupPacket.bRequest);
-if (TD->HwTD.SetupPacket.wValue.W)
-    DPRINT("wValue            - %04X\n", TD->HwTD.SetupPacket.wValue.W);
-if (TD->HwTD.SetupPacket.wIndex.W)
-    DPRINT("wIndex            - %04X\n", TD->HwTD.SetupPacket.wIndex.W);
-if (TD->HwTD.SetupPacket.wLength)
-    DPRINT("wLength           - %04X\n", TD->HwTD.SetupPacket.wLength);
+if (TD->HwTD.SetupPacket.bmRequestType.B) {
+    DPRINT("bmRequestType     - %02X\n", TD->HwTD.SetupPacket.bmRequestType.B); }
+if (TD->HwTD.SetupPacket.bRequest) {
+    DPRINT("bRequest          - %02X\n", TD->HwTD.SetupPacket.bRequest); }
+if (TD->HwTD.SetupPacket.wValue.W) {
+    DPRINT("wValue            - %04X\n", TD->HwTD.SetupPacket.wValue.W); }
+if (TD->HwTD.SetupPacket.wIndex.W) {
+    DPRINT("wIndex            - %04X\n", TD->HwTD.SetupPacket.wIndex.W); }
+if (TD->HwTD.SetupPacket.wLength) {
+    DPRINT("wLength           - %04X\n", TD->HwTD.SetupPacket.wLength); }
 
     DPRINT("PhysicalAddress   - %p\n", TD->PhysicalAddress);
     DPRINT("Flags             - %X\n", TD->Flags);
     DPRINT("OhciTransfer      - %08X\n", TD->OhciTransfer);
     DPRINT("NextTDVa          - %08X\n", TD->NextTDVa);
-if (TD->TransferLen)
-    DPRINT("TransferLen       - %X\n", TD->TransferLen);
+if (TD->TransferLen) {
+    DPRINT("TransferLen       - %X\n", TD->TransferLen); }
 }
 
 VOID

--- a/drivers/usb/usbuhci/usbuhci.c
+++ b/drivers/usb/usbuhci/usbuhci.c
@@ -39,19 +39,19 @@ UhciDumpHcdTD(PUHCI_HCD_TD TD)
     DPRINT("NextElement     - %p\n", TD->HwTD.NextElement);
     DPRINT("ControlStatus   - %08X\n", TD->HwTD.ControlStatus.AsULONG);
     DPRINT("Token           - %p\n", TD->HwTD.Token.AsULONG);
-if (TD->HwTD.Buffer)
-    DPRINT("Buffer          - %p\n", TD->HwTD.Buffer);
+if (TD->HwTD.Buffer) {
+    DPRINT("Buffer          - %p\n", TD->HwTD.Buffer); }
 
-if (TD->SetupPacket.bmRequestType.B)
-    DPRINT("bmRequestType   - %02X\n", TD->SetupPacket.bmRequestType.B);
-if (TD->SetupPacket.bRequest)
-    DPRINT("bRequest        - %02X\n", TD->SetupPacket.bRequest);
-if (TD->SetupPacket.wValue.W)
-    DPRINT("wValue          - %04X\n", TD->SetupPacket.wValue.W);
-if (TD->SetupPacket.wIndex.W)
-    DPRINT("wIndex          - %04X\n", TD->SetupPacket.wIndex.W);
-if (TD->SetupPacket.wLength)
-    DPRINT("wLength         - %04X\n", TD->SetupPacket.wLength);
+if (TD->SetupPacket.bmRequestType.B) {
+    DPRINT("bmRequestType   - %02X\n", TD->SetupPacket.bmRequestType.B); }
+if (TD->SetupPacket.bRequest) {
+    DPRINT("bRequest        - %02X\n", TD->SetupPacket.bRequest); }
+if (TD->SetupPacket.wValue.W) {
+    DPRINT("wValue          - %04X\n", TD->SetupPacket.wValue.W); }
+if (TD->SetupPacket.wIndex.W) {
+    DPRINT("wIndex          - %04X\n", TD->SetupPacket.wIndex.W); }
+if (TD->SetupPacket.wLength) {
+    DPRINT("wLength         - %04X\n", TD->SetupPacket.wLength); }
 
     DPRINT("PhysicalAddress - %p\n", TD->PhysicalAddress);
     DPRINT("Flags           - %X\n", TD->Flags);

--- a/modules/rosapps/applications/cmdutils/touch/touch.c
+++ b/modules/rosapps/applications/cmdutils/touch/touch.c
@@ -194,7 +194,7 @@ main(int argc, char *argv[])
 	return rval;
 }
 
-#define	ATOI2(ar)	((ar)[0] - '0') * 10 + ((ar)[1] - '0'); (ar) += 2;
+#define	ATOI2(ar)	((ar)[0] - '0') * 10 + ((ar)[1] - '0'), (ar) += 2;
 
 void
 stime_arg1(char *arg, time_t *tvp)

--- a/modules/rosapps/applications/explorer-old/CMakeLists.txt
+++ b/modules/rosapps/applications/explorer-old/CMakeLists.txt
@@ -57,5 +57,10 @@ set_module_type(explorer_old win32gui UNICODE)
 add_importlibs(explorer_old advapi32 gdi32 user32 ws2_32 msimg32 comctl32 ole32 oleaut32 shell32 shlwapi notifyhook msvcrt kernel32 ntdll)
 add_pch(explorer_old precomp.h "${PCH_SKIP_SOURCE}")
 add_dependencies(explorer_old psdk)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
+    target_compile_options(explorer_old PRIVATE -Wno-dangling-pointer -Wno-free-nonheap-object)
+endif()
+
 add_cd_file(TARGET explorer_old DESTINATION reactos FOR all)
 add_cd_file(FILE ${CMAKE_CURRENT_SOURCE_DIR}/explorer-cfg-template.xml DESTINATION reactos FOR all)

--- a/modules/rosapps/applications/sysutils/regexpl/ShellCommandSACL.cpp
+++ b/modules/rosapps/applications/sysutils/regexpl/ShellCommandSACL.cpp
@@ -427,14 +427,14 @@ CheckSACLArgument:
 
 AbortDumpSACL:
   ASSERT(pSecurityDescriptor);
-  delete pSecurityDescriptor;
+  delete[] pSecurityDescriptor;
 
   VERIFY(CloseHandle(hThreadToken));
 
 	return 0;
 Error:
   if (pSecurityDescriptor)
-    delete pSecurityDescriptor;
+    delete[] pSecurityDescriptor;
 
   if (hThreadToken != INVALID_HANDLE_VALUE)
     VERIFY(CloseHandle(hThreadToken));

--- a/modules/rosapps/drivers/green/pnp.c
+++ b/modules/rosapps/drivers/green/pnp.c
@@ -206,13 +206,19 @@ GreenAddDevice(
 
 		GreenDeviceExtension = (PGREEN_DEVICE_EXTENSION)DriverExtension->GreenMainDO->DeviceExtension;
 		if (Pdo == GreenDeviceExtension->KeyboardPdo)
+		{
 			return KeyboardAddDevice(DriverObject, Pdo);
+		}
 		else if (Pdo == GreenDeviceExtension->ScreenPdo)
+		{
 			return ScreenAddDevice(DriverObject, Pdo);
+		}
 		else
+		{
 			/* Strange PDO. We don't know it */
 			ASSERT(FALSE);
 			return STATUS_UNSUCCESSFUL;
+		}
 	}
 }
 

--- a/modules/rostests/apitests/crt/crtdata.c
+++ b/modules/rostests/apitests/crt/crtdata.c
@@ -58,7 +58,7 @@ void Test___badioinfo(void)
 {
     typedef struct _ioinfo ioinfo;
     _CRTIMP extern ioinfo* __badioinfo[];
-    ok(__badioinfo != NULL, "__badioinfo is NULL\n");
+    //ok(__badioinfo != NULL, "__badioinfo is NULL\n");
     ok(__badioinfo[0] != NULL, "__badioinfo is NULL\n");
 }
 

--- a/modules/rostests/apitests/iphlpapi/GetNetworkParams.c
+++ b/modules/rostests/apitests/iphlpapi/GetNetworkParams.c
@@ -168,12 +168,12 @@ test_GetNetworkParams(VOID)
         HeapFree(GetProcessHeap(), 0, FixedInfo);
         skip("GetNetworkParams failed. Can't proceed\n");
     }
-    ok(FixedInfo->HostName != NULL, "FixedInfo->HostName is NULL\n");
-    if (FixedInfo->HostName == NULL)
-    {
-        HeapFree(GetProcessHeap(), 0, FixedInfo);
-        skip("FixedInfo->HostName is NULL. Can't proceed\n");
-    }
+    //ok(FixedInfo->HostName != NULL, "FixedInfo->HostName is NULL\n");
+    //if (FixedInfo->HostName == NULL)
+    //{
+    //    HeapFree(GetProcessHeap(), 0, FixedInfo);
+    //    skip("FixedInfo->HostName is NULL. Can't proceed\n");
+    //}
     if (OrigDhcpHostnameExists)
     {
         /* Windows doesn't honor DHCP option 12 even if RFC requires it if it is returned by DHCP server! */
@@ -181,12 +181,12 @@ test_GetNetworkParams(VOID)
     }
     else
         ok(strcmp(FixedInfo->HostName, OrigHostname) == 0, "FixedInfo->HostName is wrong '%s' != '%s'\n", FixedInfo->HostName, OrigHostname);
-    ok(FixedInfo->DomainName != NULL, "FixedInfo->DomainName is NULL\n");
-    if (FixedInfo->DomainName == NULL)
-    {
-        HeapFree(GetProcessHeap(), 0, FixedInfo);
-        skip("FixedInfo->DomainName is NULL. Can't proceed\n");
-    }
+    //ok(FixedInfo->DomainName != NULL, "FixedInfo->DomainName is NULL\n");
+    //if (FixedInfo->DomainName == NULL)
+    //{
+    //    HeapFree(GetProcessHeap(), 0, FixedInfo);
+    //    skip("FixedInfo->DomainName is NULL. Can't proceed\n");
+    //}
     if(OrigDhcpDomainNameExists)
         ok(strcmp(FixedInfo->DomainName, OrigDhcpDomainName) == 0, "FixedInfo->DomainName is wrong '%s' != '%s'\n", FixedInfo->DomainName, OrigDhcpDomainName);
     else
@@ -248,9 +248,9 @@ test_GetNetworkParams(VOID)
     ok(ApiReturn == NO_ERROR,
         "GetNetworkParams(buf, &dwSize) returned %ld, expected NO_ERROR\n",
         ApiReturn);
-    ok(FixedInfo->HostName != NULL, "FixedInfo->HostName is NULL\n");
-    if (FixedInfo->HostName == NULL)
-        skip("FixedInfo->HostName is NULL. Can't proceed\n");
+    //ok(FixedInfo->HostName != NULL, "FixedInfo->HostName is NULL\n");
+    //if (FixedInfo->HostName == NULL)
+    //    skip("FixedInfo->HostName is NULL. Can't proceed\n");
     if (!OrigDhcpHostnameExists)
     {
         /* Windows doesn't honor DHCP option 12 even if RFC requires it if it is returned by DHCP server! */
@@ -258,9 +258,9 @@ test_GetNetworkParams(VOID)
     }
     else
         ok(strcmp(FixedInfo->HostName, OrigHostname) == 0, "FixedInfo->HostName is wrong '%s' != '%s'\n", FixedInfo->HostName, OrigHostname);
-    ok(FixedInfo->DomainName != NULL, "FixedInfo->DomainName is NULL\n");
-    if (FixedInfo->DomainName == NULL)
-        skip("FixedInfo->DomainName is NULL. Can't proceed\n");
+    //ok(FixedInfo->DomainName != NULL, "FixedInfo->DomainName is NULL\n");
+    //if (FixedInfo->DomainName == NULL)
+    //    skip("FixedInfo->DomainName is NULL. Can't proceed\n");
     if (!OrigDhcpDomainNameExists)
         ok(strcmp(FixedInfo->DomainName, ROSTESTDHCPDOMAIN) == 0, "FixedInfo->DomainName is wrong '%s' != '%s'\n", FixedInfo->DomainName, ROSTESTDHCPDOMAIN);
     else

--- a/modules/rostests/apitests/ntdll/StackOverflow.c
+++ b/modules/rostests/apitests/ntdll/StackOverflow.c
@@ -9,8 +9,11 @@
 
 #include <pseh/pseh2.h>
 
-#ifdef _MSC_VER
-#pragma warning(disable : 4717) // disable warning about recursive function
+// disable warning about recursive functions
+#if defined(_MSC_VER)
+#pragma warning(disable : 4717)
+#elif defined(__GNUC__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
 #endif
 
 static int iteration = 0;

--- a/modules/rostests/rosautotest/tools.cpp
+++ b/modules/rostests/rosautotest/tools.cpp
@@ -228,7 +228,7 @@ AsciiToUnicode(const char* AsciiString)
     UnicodeString = new WCHAR[Length];
     MultiByteToWideChar(CP_ACP, 0, AsciiString, -1, UnicodeString, Length);
     ReturnString = UnicodeString;
-    delete UnicodeString;
+    delete[] UnicodeString;
 
     return ReturnString;
 }
@@ -269,7 +269,7 @@ UnicodeToAscii(PCWSTR UnicodeString)
     AsciiString = new char[Length];
     WideCharToMultiByte(CP_ACP, 0, UnicodeString, -1, AsciiString, Length, NULL, NULL);
     ReturnString = AsciiString;
-    delete AsciiString;
+    delete[] AsciiString;
 
     return ReturnString;
 }

--- a/modules/rostests/winetests/advapi32/cred.c
+++ b/modules/rostests/winetests/advapi32/cred.c
@@ -809,7 +809,7 @@ START_TEST(cred)
     else
         test_generic();
 
-        trace("domain password:\n");
+    trace("domain password:\n");
     if (persists[CRED_TYPE_DOMAIN_PASSWORD] == CRED_PERSIST_NONE)
         skip("CRED_TYPE_DOMAIN_PASSWORD credentials are not supported or are disabled. Skipping\n");
     else

--- a/modules/rostests/winetests/advapi32/registry.c
+++ b/modules/rostests/winetests/advapi32/registry.c
@@ -3622,25 +3622,25 @@ static void test_RegQueryValueExPerformanceData(void)
 
         cbData = 0xdeadbeef;
         dwret = RegQueryValueExA(HKEY_PERFORMANCE_TEXT, names[i], NULL, NULL, NULL, &cbData);
-todo_wine
+        todo_wine
         ok(dwret == ERROR_MORE_DATA, "%u/%s: got %u\n", i, names[i], dwret);
         ok(cbData == 0, "got %u\n", cbData);
 
         cbData = 0;
         dwret = RegQueryValueExA(HKEY_PERFORMANCE_TEXT, names[i], NULL, NULL, NULL, &cbData);
-todo_wine
+        todo_wine
         ok(dwret == ERROR_MORE_DATA, "%u/%s: got %u\n", i, names[i], dwret);
         ok(cbData == 0, "got %u\n", cbData);
 
         cbData = 0xdeadbeef;
         dwret = RegQueryValueExA(HKEY_PERFORMANCE_NLSTEXT, names[i], NULL, NULL, NULL, &cbData);
-todo_wine
+        todo_wine
         ok(dwret == ERROR_MORE_DATA, "%u/%s: got %u\n", i, names[i], dwret);
         ok(cbData == 0, "got %u\n", cbData);
 
         cbData = 0;
         dwret = RegQueryValueExA(HKEY_PERFORMANCE_NLSTEXT, names[i], NULL, NULL, NULL, &cbData);
-todo_wine
+        todo_wine
         ok(dwret == ERROR_MORE_DATA, "%u/%s: got %u\n", i, names[i], dwret);
         ok(cbData == 0, "got %u\n", cbData);
     }
@@ -3679,7 +3679,7 @@ todo_wine
         ok(pdb->TotalByteLength == len, "got %u vs %u\n", pdb->TotalByteLength, len);
         ok(pdb->HeaderLength == pdb->TotalByteLength, "got %u\n", pdb->HeaderLength);
         ok(pdb->NumObjectTypes == 0, "got %u\n", pdb->NumObjectTypes);
-todo_wine
+        todo_wine
         ok(pdb->DefaultObject != 0, "got %u\n", pdb->DefaultObject);
         ok(pdb->SystemTime.wYear == st.wYear, "got %u\n", pdb->SystemTime.wYear);
         ok(pdb->SystemTime.wMonth == st.wMonth, "got %u\n", pdb->SystemTime.wMonth);
@@ -3708,39 +3708,39 @@ todo_wine
     }
 
     dwret = RegOpenKeyA(HKEY_PERFORMANCE_DATA, NULL, &hkey);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     dwret = RegOpenKeyA(HKEY_PERFORMANCE_DATA, "Global", &hkey);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     dwret = RegOpenKeyExA(HKEY_PERFORMANCE_DATA, "Global", 0, KEY_READ, &hkey);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     dwret = RegQueryValueA(HKEY_PERFORMANCE_DATA, "Global", NULL, (LONG *)&cbData);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     dwret = RegSetValueA(HKEY_PERFORMANCE_DATA, "Global", REG_SZ, "dummy", 4);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     dwret = RegSetValueExA(HKEY_PERFORMANCE_DATA, "Global", 0, REG_SZ, (const BYTE *)"dummy", 40);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     cbData = sizeof(buf);
     dwret = RegEnumKeyA(HKEY_PERFORMANCE_DATA, 0, (LPSTR)buf, cbData);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
 
     cbData = sizeof(buf);
     dwret = RegEnumValueA(HKEY_PERFORMANCE_DATA, 0, (LPSTR)buf, &cbData, NULL, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(dwret == ERROR_MORE_DATA, "got %u\n", dwret);
-todo_wine
+    todo_wine
     ok(cbData == sizeof(buf), "got %u\n", cbData);
 
     dwret = RegEnumValueA(HKEY_PERFORMANCE_DATA, 0, NULL, &cbData, NULL, NULL, NULL, NULL);
@@ -3749,7 +3749,7 @@ todo_wine
     if (pRegSetKeyValueW)
     {
         dwret = pRegSetKeyValueW(HKEY_PERFORMANCE_DATA, NULL, globalW, REG_SZ, dummyW, sizeof(dummyW));
-todo_wine
+        todo_wine
         ok(dwret == ERROR_INVALID_HANDLE, "got %u\n", dwret);
     }
 

--- a/modules/rostests/winetests/advapi32/security.c
+++ b/modules/rostests/winetests/advapi32/security.c
@@ -1114,7 +1114,7 @@ cleanup:
 
     rc = GetFileAttributesA(file);
     rc &= ~(FILE_ATTRIBUTE_NOT_CONTENT_INDEXED|FILE_ATTRIBUTE_COMPRESSED);
-todo_wine
+    todo_wine
     ok(rc == (FILE_ATTRIBUTE_ARCHIVE|FILE_ATTRIBUTE_READONLY),
        "expected FILE_ATTRIBUTE_ARCHIVE|FILE_ATTRIBUTE_READONLY got %#x\n", rc);
 
@@ -1561,10 +1561,10 @@ static void test_AccessCheck(void)
     ret = AccessCheck(SecurityDescriptor, Token, KEY_READ, &Mapping,
                       PrivSet, &PrivSetLen, &Access, &AccessStatus);
     err = GetLastError();
-todo_wine
+    todo_wine
     ok(!ret && err == ERROR_INSUFFICIENT_BUFFER, "AccessCheck should have "
        "failed with ERROR_INSUFFICIENT_BUFFER, instead of %d\n", err);
-todo_wine
+    todo_wine
     ok(PrivSetLen == sizeof(PRIVILEGE_SET), "PrivSetLen returns %d\n", PrivSetLen);
     ok(Access == 0x1abe11ed && AccessStatus == 0x1abe11ed,
        "Access and/or AccessStatus were changed!\n");
@@ -1576,12 +1576,12 @@ todo_wine
     ret = AccessCheck(SecurityDescriptor, Token, KEY_READ, &Mapping,
                       PrivSet, &PrivSetLen, &Access, &AccessStatus);
     err = GetLastError();
-todo_wine
+    todo_wine
     ok(!ret && err == ERROR_INSUFFICIENT_BUFFER, "AccessCheck should have "
        "failed with ERROR_INSUFFICIENT_BUFFER, instead of %d\n", err);
-todo_wine
+    todo_wine
     ok(PrivSetLen == sizeof(PRIVILEGE_SET), "PrivSetLen returns %d\n", PrivSetLen);
-todo_wine
+    todo_wine
     ok(Access == 0x1abe11ed && AccessStatus == 0x1abe11ed,
        "Access and/or AccessStatus were changed!\n");
 
@@ -1594,7 +1594,7 @@ todo_wine
                       PrivSet, &PrivSetLen, &Access, &AccessStatus);
     err = GetLastError();
     ok(ret, "AccessCheck failed with error %d\n", GetLastError());
-todo_wine
+    todo_wine
     ok(PrivSetLen == sizeof(PRIVILEGE_SET), "PrivSetLen returns %d\n", PrivSetLen);
     ok(AccessStatus && (Access == KEY_READ),
         "AccessCheck failed to grant access with error %d\n", GetLastError());
@@ -1610,7 +1610,7 @@ todo_wine
                       PrivSet, &PrivSetLen, &Access, &AccessStatus);
     err = GetLastError();
     ok(ret, "AccessCheck failed with error %d\n", GetLastError());
-todo_wine
+    todo_wine
     ok(PrivSetLen == sizeof(PRIVILEGE_SET) + 1, "PrivSetLen returns %d\n", PrivSetLen);
     ok(AccessStatus && (Access == KEY_READ),
         "AccessCheck failed to grant access with error %d\n", GetLastError());
@@ -1674,12 +1674,12 @@ todo_wine
         ret = AccessCheck(SecurityDescriptor, Token, KEY_READ, &Mapping,
                           PrivSet, &PrivSetLen, &Access, &AccessStatus);
         err = GetLastError();
-    todo_wine
+        todo_wine
         ok(!ret && err == ERROR_INSUFFICIENT_BUFFER, "AccessCheck should have "
            "failed with ERROR_INSUFFICIENT_BUFFER, instead of %d\n", err);
-    todo_wine
+        todo_wine
         ok(PrivSetLen == sizeof(PRIVILEGE_SET), "PrivSetLen returns %d\n", PrivSetLen);
-    todo_wine
+        todo_wine
         ok(Access == 0x1abe11ed && AccessStatus == 0x1abe11ed,
            "Access and/or AccessStatus were changed!\n");
 
@@ -5589,9 +5589,9 @@ static void validate_default_security_descriptor(SECURITY_DESCRIPTOR *sd)
     SetLastError(0xdeadbeef);
     ret = GetSecurityDescriptorDacl(sd, &present, &acl, &defaulted);
     ok(ret, "GetSecurityDescriptorDacl error %d\n", GetLastError());
-todo_wine
+    todo_wine
     ok(present == 1, "acl is not present\n");
-todo_wine
+    todo_wine
     ok(acl != (void *)0xdeadbeef && acl != NULL, "acl pointer is not set\n");
     ok(defaulted == 0, "defaulted is set to TRUE\n");
 
@@ -5600,7 +5600,7 @@ todo_wine
     SetLastError(0xdeadbeef);
     ret = GetSecurityDescriptorOwner(sd, &sid, &defaulted);
     ok(ret, "GetSecurityDescriptorOwner error %d\n", GetLastError());
-todo_wine
+    todo_wine
     ok(sid != (void *)0xdeadbeef && sid != NULL, "sid pointer is not set\n");
     ok(defaulted == 0, "defaulted is set to TRUE\n");
 
@@ -5609,7 +5609,7 @@ todo_wine
     SetLastError(0xdeadbeef);
     ret = GetSecurityDescriptorGroup(sd, &sid, &defaulted);
     ok(ret, "GetSecurityDescriptorGroup error %d\n", GetLastError());
-todo_wine
+    todo_wine
     ok(sid != (void *)0xdeadbeef && sid != NULL, "sid pointer is not set\n");
     ok(defaulted == 0, "defaulted is set to TRUE\n");
 }
@@ -5746,9 +5746,9 @@ static void test_mutex_security(HANDLE token)
 
         SetLastError(0xdeadbeef);
         dup = OpenMutexA(0, FALSE, "WineTestMutex");
-todo_wine
+        todo_wine
         ok(!dup, "OpenMutex should fail\n");
-todo_wine
+        todo_wine
         ok(GetLastError() == ERROR_ACCESS_DENIED, "wrong error %u\n", GetLastError());
     }
 
@@ -5803,9 +5803,9 @@ static void test_event_security(HANDLE token)
 
         SetLastError(0xdeadbeef);
         dup = OpenEventA(0, FALSE, "WineTestEvent");
-todo_wine
+        todo_wine
         ok(!dup, "OpenEvent should fail\n");
-todo_wine
+        todo_wine
         ok(GetLastError() == ERROR_ACCESS_DENIED, "wrong error %u\n", GetLastError());
     }
 
@@ -6022,7 +6022,7 @@ static void test_file_security(HANDLE token)
     ok(file != INVALID_HANDLE_VALUE, "CreateFile error %d\n", GetLastError());
 
     access = get_obj_access(file);
-todo_wine
+    todo_wine
     ok(access == (FILE_READ_ATTRIBUTES | SYNCHRONIZE), "expected FILE_READ_ATTRIBUTES | SYNCHRONIZE, got %#x\n", access);
 
     bytes = 0xdeadbeef;
@@ -6039,7 +6039,7 @@ todo_wine
     ok(file != INVALID_HANDLE_VALUE, "CreateFile error %d\n", GetLastError());
 
     access = get_obj_access(file);
-todo_wine
+    todo_wine
     ok(access == (FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES), "expected FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES, got %#x\n", access);
 
     bytes = 0xdeadbeef;
@@ -6080,7 +6080,7 @@ todo_wine
     ok(file != INVALID_HANDLE_VALUE, "CreateFile error %d\n", GetLastError());
 
     access = get_obj_access(file);
-todo_wine
+    todo_wine
     ok(access == (FILE_READ_ATTRIBUTES | SYNCHRONIZE), "expected FILE_READ_ATTRIBUTES | SYNCHRONIZE, got %#x\n", access);
 
     CloseHandle(file);
@@ -6090,7 +6090,7 @@ todo_wine
     ok(file != INVALID_HANDLE_VALUE, "CreateFile error %d\n", GetLastError());
 
     access = get_obj_access(file);
-todo_wine
+    todo_wine
     ok(access == (FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES), "expected FILE_GENERIC_WRITE | FILE_READ_ATTRIBUTES, got %#x\n", access);
 
     CloseHandle(file);
@@ -6271,7 +6271,7 @@ static void test_thread_security(void)
                "%d: expected %#x, got %#x\n", i, map[i].mapped, access);
             break;
         case GENERIC_WRITE:
-todo_wine
+            todo_wine
             ok(access == map[i].mapped ||
                access == (map[i].mapped | THREAD_SET_LIMITED_INFORMATION) /* Vista+ */ ||
                access == (map[i].mapped | THREAD_SET_LIMITED_INFORMATION | THREAD_RESUME) /* win8 */,

--- a/modules/rostests/winetests/comctl32/edit.c
+++ b/modules/rostests/winetests/comctl32/edit.c
@@ -1400,7 +1400,7 @@ static void test_edit_control_6(void)
 
     buf[0] = 0;
     ret = SendMessageA(hWnd, WM_DESTROY, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == 1, "Unexpected return value %d\n", ret);
     ret = SendMessageA(hWnd, WM_GETTEXT, MAXLEN, (LPARAM)buf);
     ok(ret == strlen(str), "Expected %s, got len %d\n", str, ret);

--- a/modules/rostests/winetests/comctl32/listbox.c
+++ b/modules/rostests/winetests/comctl32/listbox.c
@@ -2551,7 +2551,7 @@ static void test_LBS_NODATA(void)
         ret = SendMessageA(listbox, LB_SETITEMDATA, valid_idx[i], 42);
         ok(ret == TRUE, "Unexpected return value %d.\n", ret);
         ret = SendMessageA(listbox, LB_GETTEXTLEN, valid_idx[i], 0);
-    todo_wine_if(is_wow64)
+        todo_wine_if(is_wow64)
         ok(ret == text_len, "Unexpected return value %d.\n", ret);
 
         memset(&data, 0xee, sizeof(data));

--- a/modules/rostests/winetests/comctl32/listview.c
+++ b/modules/rostests/winetests/comctl32/listview.c
@@ -1679,7 +1679,7 @@ static void test_create(BOOL is_version_6)
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
     hHeader = (HWND)SendMessageA(hList, LVM_GETHEADER, 0, 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
 
     /* insert column */
@@ -1694,7 +1694,7 @@ todo_wine_if(is_version_6)
     /* LVS_REPORT without WS_VISIBLE, try to show it */
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
 
     ShowWindow(hList, SW_SHOW);
@@ -1713,7 +1713,7 @@ todo_wine_if(is_version_6)
     /* setting LVS_EX_HEADERDRAGDROP creates header */
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
 
     SendMessageA(hList, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, LVS_EX_HEADERDRAGDROP);
@@ -1723,7 +1723,7 @@ todo_wine_if(is_version_6)
     /* setting LVS_EX_GRIDLINES creates header */
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
 
     SendMessageA(hList, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, LVS_EX_GRIDLINES);
@@ -1733,7 +1733,7 @@ todo_wine_if(is_version_6)
     /* setting LVS_EX_FULLROWSELECT creates header */
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
     SendMessageA(hList, LVM_SETEXTENDEDLISTVIEWSTYLE, 0, LVS_EX_FULLROWSELECT);
     TEST_HEADER_EXPECTED(hList);
@@ -1749,7 +1749,7 @@ todo_wine_if(is_version_6)
     /* requesting header info with LVM_GETSUBITEMRECT doesn't create it */
     hList = CreateWindowA(WC_LISTVIEWA, "Test", LVS_REPORT, 0, 0, 100, 100, NULL, NULL,
                           GetModuleHandleA(NULL), 0);
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
 
     SetRect(&rect, LVIR_BOUNDS, 1, -10, -10);
@@ -1758,7 +1758,7 @@ todo_wine_if(is_version_6)
     /* right value contains garbage, probably because header columns are not set up */
     ok(rect.bottom >= 0, "Unexpected rectangle.\n");
 
-todo_wine_if(is_version_6)
+    todo_wine_if(is_version_6)
     TEST_NO_HEADER2(hList, is_version_6);
     DestroyWindow(hList);
 
@@ -4000,7 +4000,7 @@ static void test_getitemrect(void)
     expect(0, rect.left);
     expect(0, rect.top);
     /* estimate it as width / height ratio */
-todo_wine
+    todo_wine
     ok((rect.right / rect.bottom) >= 5, "got right %d, bottom %d\n", rect.right, rect.bottom);
     DestroyWindow(hwnd);
 
@@ -5105,20 +5105,20 @@ static void test_approximate_viewrect(void)
 
     /* Empty control without columns */
     ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, 0, MAKELPARAM(100, 100));
-todo_wine
+    todo_wine
     ok(LOWORD(ret) == 0, "Unexpected width %d.\n", LOWORD(ret));
     ok(HIWORD(ret) != 0, "Unexpected height %d.\n", HIWORD(ret));
 
     ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, 0, 0);
     ok(LOWORD(ret) == 0, "Unexpected width %d.\n", LOWORD(ret));
-todo_wine
+    todo_wine
     ok(HIWORD(ret) != 0, "Unexpected height %d.\n", HIWORD(ret));
 
     header_height = HIWORD(ret);
 
     ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, 1, 0);
     ok(LOWORD(ret) == 0, "Unexpected width %d.\n", LOWORD(ret));
-todo_wine
+    todo_wine
     ok(HIWORD(ret) > header_height, "Unexpected height %d.\n", HIWORD(ret));
 
     item_height = HIWORD(ret) - header_height;
@@ -5152,7 +5152,7 @@ todo_wine {
 
     ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, 1, 0);
     ok(LOWORD(ret) == item_width, "Unexpected width %d.\n", LOWORD(ret));
-todo_wine
+    todo_wine
     ok(HIWORD(ret) > header_height, "Unexpected height %d.\n", HIWORD(ret));
 
     item_height = HIWORD(ret) - header_height;
@@ -5180,7 +5180,7 @@ todo_wine
 
         ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, 0, 0);
         ok(LOWORD(ret) >= column_width, "Unexpected width %d.\n", LOWORD(ret));
-    todo_wine
+        todo_wine
         ok(HIWORD(ret) != 0, "Unexpected height %d.\n", HIWORD(ret));
 
         header_height = HIWORD(ret);
@@ -5194,7 +5194,7 @@ todo_wine
 
         ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, -2, 0);
         ok(LOWORD(ret) == item_width, "Unexpected width %d.\n", LOWORD(ret));
-    todo_wine
+        todo_wine
         ok(HIWORD(ret) == header_height - 2 * item_height, "Unexpected height %d.\n", HIWORD(ret));
 
         ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, -1, 0);
@@ -5211,12 +5211,12 @@ todo_wine
 
         ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, -2, MAKELONG(item_width * 2, 0));
         ok(LOWORD(ret) == item_width, "Unexpected width %d.\n", LOWORD(ret));
-    todo_wine
+        todo_wine
         ok(HIWORD(ret) == header_height - 2 * item_height, "Unexpected height %d.\n", HIWORD(ret));
 
         ret = SendMessageA(hwnd, LVM_APPROXIMATEVIEWRECT, -2, MAKELONG(-1, -1));
         ok(LOWORD(ret) == item_width, "Unexpected width %d.\n", LOWORD(ret));
-    todo_wine
+        todo_wine
         ok(HIWORD(ret) == header_height - 2 * item_height, "Unexpected height %d.\n", HIWORD(ret));
     }
 
@@ -6109,11 +6109,11 @@ static void test_callback_mask(void)
     flush_sequences(sequences, NUM_MSG_SEQUENCES);
 
     ret = SendMessageA(hwnd, LVM_GETNEXTITEM, -1, LVNI_FOCUSED);
-todo_wine
+    todo_wine
     ok(ret == 0, "Unexpected focused item, ret %d\n", ret);
 
     ret = SendMessageA(hwnd, LVM_GETSELECTIONMARK, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == 0, "Unexpected selection mark, %d\n", ret);
 
     ret = SendMessageA(hwnd, LVM_SETITEMCOUNT, 0, 0);
@@ -6163,7 +6163,7 @@ todo_wine
     ok(ret == -1, "Unexpected focused item, ret %d\n", ret);
 
     ret = SendMessageA(hwnd, LVM_GETSELECTIONMARK, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == -1, "Unexpected selection mark, %d\n", ret);
 
     ret = SendMessageA(hwnd, LVM_SETITEMCOUNT, 1, 0);
@@ -6294,7 +6294,7 @@ static void test_state_image(void)
         item.iSubItem = 2;
         r = SendMessageA(hwnd, LVM_GETITEMA, 0, (LPARAM)&item);
         ok(r, "Failed to get subitem state.\n");
-    todo_wine
+        todo_wine
         ok(item.state == 0, "Unexpected state %#x.\n", item.state);
 
         item.mask = LVIF_TEXT;

--- a/modules/rostests/winetests/comctl32/misc.c
+++ b/modules/rostests/winetests/comctl32/misc.c
@@ -351,14 +351,14 @@ static void check_class( const char *name, int must_exist, UINT style, UINT igno
         char buff[64];
         HWND hwnd;
 
-todo_wine_if(!strcmp(name, "SysLink") && !must_exist && !v6)
+        todo_wine_if(!strcmp(name, "SysLink") && !must_exist && !v6)
         ok( must_exist, "System class %s should %sexist\n", name, must_exist ? "" : "NOT " );
         if (!must_exist) return;
 
-todo_wine_if(!strcmp(name, "ScrollBar") || (!strcmp(name, "tooltips_class32") && v6))
+        todo_wine_if(!strcmp(name, "ScrollBar") || (!strcmp(name, "tooltips_class32") && v6))
         ok( !(~wc.style & style & ~ignore), "System class %s is missing bits %x (%08x/%08x)\n",
             name, ~wc.style & style, wc.style, style );
-todo_wine_if((!strcmp(name, "tooltips_class32") && v6) || !strcmp(name, "SysLink"))
+        todo_wine_if((!strcmp(name, "tooltips_class32") && v6) || !strcmp(name, "SysLink"))
         ok( !(wc.style & ~style), "System class %s has extra bits %x (%08x/%08x)\n",
             name, wc.style & ~style, wc.style, style );
         ok( !wc.hInstance, "System class %s has hInstance %p\n", name, wc.hInstance );

--- a/modules/rostests/winetests/comctl32/static.c
+++ b/modules/rostests/winetests/comctl32/static.c
@@ -100,7 +100,7 @@ static void test_updates(int style, int flags)
     {
         HDC hdc = GetDC(hStatic);
         COLORREF colour = GetPixel(hdc, 10, 10);
-    todo_wine
+        todo_wine
         ok(colour == 0, "Unexpected pixel color.\n");
         ReleaseDC(hStatic, hdc);
     }
@@ -111,7 +111,7 @@ static void test_updates(int style, int flags)
         exp = 1; /* SS_ETCHED* seems to send WM_CTLCOLORSTATIC only sometimes */
 
     if (flags & TODO_COUNT)
-    todo_wine
+        todo_wine
         ok(g_nReceivedColorStatic == exp, "Unexpected WM_CTLCOLORSTATIC value %d\n", g_nReceivedColorStatic);
     else if ((style & SS_TYPEMASK) == SS_ICON || (style & SS_TYPEMASK) == SS_BITMAP)
         ok(g_nReceivedColorStatic == exp, "Unexpected %u got %u\n", exp, g_nReceivedColorStatic);

--- a/modules/rostests/winetests/comctl32/tab.c
+++ b/modules/rostests/winetests/comctl32/tab.c
@@ -648,18 +648,18 @@ static void test_curfocus(void)
     ret = SendMessageA(hTab, TCM_SETCURFOCUS, -10, 0);
     ok(ret == 0, "Unexpected ret value %d.\n", ret);
     ret = SendMessageA(hTab, TCM_GETCURFOCUS, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == nTabs - 1, "Unexpected focus index %d.\n", ret);
 
     /* Testing CurFocus with value larger than number of tabs */
     ret = SendMessageA(hTab, TCM_SETCURSEL, 1, 0);
-todo_wine
+    todo_wine
     ok(ret == 0, "Unexpected focus index %d.\n", ret);
 
     ret = SendMessageA(hTab, TCM_SETCURFOCUS, nTabs + 1, 0);
     ok(ret == 0, "Unexpected ret value %d.\n", ret);
     ret = SendMessageA(hTab, TCM_GETCURFOCUS, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == nTabs - 1, "Unexpected focus index %d.\n", ret);
 
     ok_sequence(sequences, TAB_SEQ_INDEX, getset_cur_focus_seq, "TCS_BUTTONS: set focused tab sequence", FALSE);
@@ -1437,10 +1437,10 @@ static void test_TCN_SELCHANGING(void)
     ok_sequence(sequences, PARENT_SEQ_INDEX, selchanging_parent_seq, "Focus change disallowed sequence", FALSE);
 
     ret = SendMessageA(hTab, TCM_GETCURFOCUS, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == nTabs - 1, "Unexpected focused tab %d.\n", ret);
     ret = SendMessageA(hTab, TCM_GETCURSEL, 0, 0);
-todo_wine
+    todo_wine
     ok(ret == nTabs - 1, "Unexpected selected tab %d.\n", ret);
 
     /* Removing focus sends only TCN_SELCHANGE */

--- a/modules/rostests/winetests/comctl32/toolbar.c
+++ b/modules/rostests/winetests/comctl32/toolbar.c
@@ -2065,7 +2065,7 @@ static void test_get_set_style(void)
 
     style = SendMessageA(hToolbar, TB_GETSTYLE, 0, 0);
     style2 = GetWindowLongA(hToolbar, GWL_STYLE);
-todo_wine
+    todo_wine
     ok(style == style2, "got 0x%08x, expected 0x%08x\n", style, style2);
 
     /* try to alter common window bits */
@@ -2295,7 +2295,7 @@ static void test_TB_GET_SET_EXTENDEDSTYLE(void)
     style = SendMessageA(hwnd, TB_GETEXTENDEDSTYLE, 0, 0);
     ok(style == TBSTYLE_EX_VERTICAL, "got style 0x%08x, expected 0x%08x\n", style, TBSTYLE_EX_VERTICAL);
     style = SendMessageA(hwnd, TB_GETSTYLE, 0, 0);
- todo_wine
+    todo_wine
     ok(style == CCS_VERT, "got style 0x%08x, expected CCS_VERT\n", style);
 
     DestroyWindow(hwnd);
@@ -2460,33 +2460,33 @@ static void test_drawtext_flags(void)
     rebuild_toolbar(&hwnd);
 
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, 0, 0);
-todo_wine
+    todo_wine
     ok(flags == 0, "Unexpected draw text flags %#x\n", flags);
 
     /* zero mask, flags are retained */
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, 0, DT_BOTTOM);
-todo_wine
+    todo_wine
     ok(flags == 0, "Unexpected draw text flags %#x\n", flags);
     ok(!(flags & DT_BOTTOM), "Unexpected DT_BOTTOM style\n");
 
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, 0, 0);
-todo_wine
+    todo_wine
     ok(flags == 0, "Unexpected draw text flags %#x\n", flags);
     ok(!(flags & DT_BOTTOM), "Unexpected DT_BOTTOM style\n");
 
     /* set/remove */
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, DT_BOTTOM, DT_BOTTOM);
-todo_wine
+    todo_wine
     ok(flags == 0, "Unexpected draw text flags %#x\n", flags);
     ok(!(flags & DT_BOTTOM), "Unexpected DT_BOTTOM style\n");
 
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, DT_BOTTOM, 0);
-todo_wine
+    todo_wine
     ok(flags == DT_BOTTOM, "Unexpected draw text flags %#x\n", flags);
     ok(flags & DT_BOTTOM, "Expected DT_BOTTOM style, %#x\n", flags);
 
     flags = SendMessageA(hwnd, TB_SETDRAWTEXTFLAGS, DT_BOTTOM, 0);
-todo_wine
+    todo_wine
     ok(flags == 0, "Unexpected draw text flags %#x\n", flags);
     ok(!(flags & DT_BOTTOM), "Unexpected DT_BOTTOM style\n");
 

--- a/modules/rostests/winetests/comctl32/tooltips.c
+++ b/modules/rostests/winetests/comctl32/tooltips.c
@@ -69,7 +69,7 @@ static void test_create_tooltip(BOOL is_v6)
     exp_style = WS_POPUP | WS_CLIPSIBLINGS;
     if (!is_v6)
         exp_style |= WS_BORDER;
-todo_wine_if(is_v6)
+    todo_wine_if(is_v6)
     ok(style == exp_style || broken(style == (exp_style | WS_BORDER)) /* XP */,
         "Unexpected window style %#x.\n", style);
 
@@ -391,7 +391,7 @@ static void test_gettext(void)
 
     toolinfoA.lpszText = bufA;
     r = SendMessageA(hwnd, TTM_GETTOOLINFOA, 0, (LPARAM)&toolinfoA);
-todo_wine
+    todo_wine
     ok(!r, "got %ld\n", r);
     ok(toolinfoA.lpszText == NULL, "expected NULL, got %p\n", toolinfoA.lpszText);
 
@@ -416,7 +416,7 @@ todo_wine
 
     toolinfoA.hinst = (HINSTANCE)0xdeadbee;
     r = SendMessageA(hwnd, TTM_GETTOOLINFOA, 0, (LPARAM)&toolinfoA);
-todo_wine
+    todo_wine
     ok(!r, "got %ld\n", r);
     ok(toolinfoA.hinst == NULL, "expected NULL, got %p\n", toolinfoA.hinst);
 
@@ -449,7 +449,7 @@ todo_wine
     memset(bufA, 0x1f, sizeof(bufA));
     toolinfoA.lpszText = bufA;
     r = SendMessageA(hwnd, TTM_GETTOOLINFOA, 0, (LPARAM)&toolinfoA);
-todo_wine
+    todo_wine
     ok(!r, "got %ld\n", r);
     ok(!strcmp(toolinfoA.lpszText, testtipA), "expected %s, got %p\n", testtipA, toolinfoA.lpszText);
 
@@ -477,7 +477,7 @@ todo_wine
 
     toolinfoA.lpszText = bufA;
     r = SendMessageA(hwnd, TTM_GETTOOLINFOA, 0, (LPARAM)&toolinfoA);
-todo_wine
+    todo_wine
     ok(!r, "got %ld\n", r);
     ok(toolinfoA.lpszText == LPSTR_TEXTCALLBACKA, "expected LPSTR_TEXTCALLBACKA, got %p\n", toolinfoA.lpszText);
 
@@ -500,7 +500,7 @@ todo_wine
     r = SendMessageW(hwnd, TTM_ADDTOOLW, 0, (LPARAM)&toolinfoW);
     /* Wine currently checks for V3 structure size, which matches what V6 control does.
        Older implementation was never updated to support lpReserved field. */
-todo_wine
+    todo_wine
     ok(!r, "Adding the tool to the tooltip succeeded!\n");
 
     if (0)  /* crashes on NT4 */
@@ -1158,7 +1158,7 @@ static void test_TTM_ADDTOOL(BOOL is_v6)
         GetClientRect(hwnd, &tiW.rect);
 
         ret = SendMessageA(hwnd, TTM_ADDTOOLW, 0, (LPARAM)&tiW);
-    todo_wine_if(!is_v6 && size > max_size)
+        todo_wine_if(!is_v6 && size > max_size)
         ok(size <= max_size ? ret : !ret, "%d: Unexpected ret value %d, size %d, max size %d.\n", is_v6, ret, size, max_size);
         if (ret)
         {

--- a/modules/rostests/winetests/comctl32/treeview.c
+++ b/modules/rostests/winetests/comctl32/treeview.c
@@ -2164,7 +2164,7 @@ static void test_cchildren(void)
     /* check cChildren */
     ret = SendMessageA(hTree, TVM_GETITEMA, 0, (LPARAM)&item);
     expect(TRUE, ret);
-todo_wine
+    todo_wine
     expect(1, item.cChildren);
 
     DestroyWindow(hTree);
@@ -2224,7 +2224,7 @@ static void _check_item(HWND hwnd, HTREEITEM item, BOOL is_version_6, int line)
         }
         else
             width = data->width;
-    todo_wine
+        todo_wine
         ok_(__FILE__, line)(width == (rect.right - rect.left) || broken(is_version_6 && width == 0) /* XP */,
                 "Width %d, rect width %d.\n", width, rect.right - rect.left);
     }
@@ -2728,7 +2728,7 @@ static void test_TVM_SORTCHILDREN(void)
     /* with NULL item nothing is sorted */
     fill_treeview_sort_test(hwnd);
     ret = SendMessageA(hwnd, TVM_SORTCHILDREN, 0, 0);
-todo_wine
+    todo_wine
     ok(ret, "Unexpected ret value %d\n", ret);
     get_item_names_string(hwnd, NULL, buff);
     ok(!strcmp(buff, initial_order), "Wrong sorted order %s, expected %s\n", buff, initial_order);
@@ -2736,7 +2736,7 @@ todo_wine
     /* TVI_ROOT as item */
     fill_treeview_sort_test(hwnd);
     ret = SendMessageA(hwnd, TVM_SORTCHILDREN, 0, (LPARAM)TVI_ROOT);
-todo_wine
+    todo_wine
     ok(ret, "Unexpected ret value %d\n", ret);
     get_item_names_string(hwnd, NULL, buff);
     ok(!strcmp(buff, initial_order), "Wrong sorted order %s, expected %s\n", buff, initial_order);
@@ -2753,7 +2753,7 @@ todo_wine
     /* non-zero WPARAM, NULL item */
     fill_treeview_sort_test(hwnd);
     ret = SendMessageA(hwnd, TVM_SORTCHILDREN, TRUE, 0);
-todo_wine
+    todo_wine
     ok(ret, "Unexpected ret value %d\n", ret);
     get_item_names_string(hwnd, NULL, buff);
     ok(!strcmp(buff, initial_order), "Wrong sorted order %s, expected %s\n", buff, sorted_order);
@@ -2761,7 +2761,7 @@ todo_wine
     /* TVI_ROOT as item */
     fill_treeview_sort_test(hwnd);
     ret = SendMessageA(hwnd, TVM_SORTCHILDREN, TRUE, (LPARAM)TVI_ROOT);
-todo_wine
+    todo_wine
     ok(ret, "Unexpected ret value %d\n", ret);
     get_item_names_string(hwnd, NULL, buff);
     ok(!strcmp(buff, initial_order), "Wrong sorted order %s, expected %s\n", buff, sorted_order);

--- a/modules/rostests/winetests/comctl32/updown.c
+++ b/modules/rostests/winetests/comctl32/updown.c
@@ -670,7 +670,7 @@ static void test_updown_buddy(void)
     buddyReturn = (HWND)SendMessageA(updown, UDM_SETBUDDY, 0, 0);
     ok(buddyReturn == g_edit, "Unexpected buddy window.\n");
     GetClientRect(updown, &rect2);
-todo_wine
+    todo_wine
     ok(EqualRect(&rect, &rect2), "Unexpected window rect.\n");
 
     DestroyWindow(updown);

--- a/modules/rostests/winetests/comdlg32/filedlg.c
+++ b/modules/rostests/winetests/comdlg32/filedlg.c
@@ -471,7 +471,7 @@ static UINT_PTR WINAPI resize_template_hook(HWND dlg, UINT msg, WPARAM wParam, L
                                 break;
                             /* todo_wine: non moving non sizing controls */
                             case lst1:
-todo_wine
+                                todo_wine
                                 ok( TESTRECTS( rc, ctrlrcs[i], 0, 0, 0, 0),
                                     "control id %03x was moved/resized, before %s after %s\n",
                                     ctrlids[i], wine_dbgstr_rect( &ctrlrcs[i] ),

--- a/modules/rostests/winetests/crypt32/base64.c
+++ b/modules/rostests/winetests/crypt32/base64.c
@@ -134,7 +134,7 @@ static void encodeAndCompareBase64_A(const BYTE *toEncode, DWORD toEncodeLen,
     strLen2 = strLen - 1;
     str[0] = 0x12;
     ret = CryptBinaryToStringA(toEncode, toEncodeLen, format, str, &strLen2);
-todo_wine
+    todo_wine
     ok((!ret && GetLastError() == ERROR_MORE_DATA) || broken(ret) /* XP */, "CryptBinaryToStringA failed %d, error %d.\n",
         ret, GetLastError());
     ok(strLen2 == strLen || broken(strLen2 == strLen - 1), "Expected length %d, got %d\n", strLen - 1, strLen);
@@ -207,7 +207,7 @@ static void encode_compare_base64_W(const BYTE *toEncode, DWORD toEncodeLen, DWO
     strLen2 = strLen - 1;
     strW[0] = 0x1234;
     ret = CryptBinaryToStringW(toEncode, toEncodeLen, format, strW, &strLen2);
-todo_wine
+    todo_wine
     ok((!ret && GetLastError() == ERROR_MORE_DATA) || broken(ret) /* XP */, "CryptBinaryToStringW failed, %d, error %d\n",
         ret, GetLastError());
     if (headerW)

--- a/modules/rostests/winetests/crypt32/cert.c
+++ b/modules/rostests/winetests/crypt32/cert.c
@@ -2829,7 +2829,7 @@ static void testGetValidUsages(void)
     ret = pCertGetValidUsages(0, NULL, NULL, NULL, &size);
      */
     contexts[0] = NULL;
-    numOIDs = size = 0xdeadbeef;
+    size = numOIDs = 0xdeadbeef;
     SetLastError(0xdeadbeef);
     ret = pCertGetValidUsages(1, &contexts[0], &numOIDs, NULL, &size);
     ok(ret, "CertGetValidUsages failed: %d\n", GetLastError());
@@ -2841,12 +2841,12 @@ static void testGetValidUsages(void)
      sizeof(certWithUsage));
     contexts[2] = CertCreateCertificateContext(X509_ASN_ENCODING,
      cert2WithUsage, sizeof(cert2WithUsage));
-    numOIDs = size = 0xdeadbeef;
+    size = numOIDs = 0xdeadbeef;
     ret = pCertGetValidUsages(0, NULL, &numOIDs, NULL, &size);
     ok(ret, "CertGetValidUsages failed: %08x\n", GetLastError());
     ok(numOIDs == -1, "Expected -1, got %d\n", numOIDs);
     ok(size == 0, "Expected size 0, got %d\n", size);
-    numOIDs = size = 0xdeadbeef;
+    size = numOIDs = 0xdeadbeef;
     ret = pCertGetValidUsages(1, contexts, &numOIDs, NULL, &size);
     ok(ret, "CertGetValidUsages failed: %08x\n", GetLastError());
     ok(numOIDs == -1, "Expected -1, got %d\n", numOIDs);

--- a/modules/rostests/winetests/crypt32/main.c
+++ b/modules/rostests/winetests/crypt32/main.c
@@ -357,7 +357,7 @@ static void test_getDefaultCryptProv(void)
         prov = pI_CryptGetDefaultCryptProv(test_prov[i].algid);
         if (!prov)
         {
-todo_wine_if(test_prov[i].algid == CALG_DSS_SIGN || test_prov[i].algid == CALG_NO_SIGN)
+            todo_wine_if(test_prov[i].algid == CALG_DSS_SIGN || test_prov[i].algid == CALG_NO_SIGN)
             ok(test_prov[i].optional, "%u: I_CryptGetDefaultCryptProv(%#x) failed\n", i, test_prov[i].algid);
             continue;
         }

--- a/modules/rostests/winetests/gdi32/bitmap.c
+++ b/modules/rostests/winetests/gdi32/bitmap.c
@@ -2796,7 +2796,7 @@ static void test_CreateBitmap(void)
        "0: %p, 1: %p, 4: %p, 5: %p, curObj1 %p, old1 %p\n",
        bm, bm1, bm4, bm5, curObj1, old1);
     ok(bm != bm2 && bm != bm3, "0: %p, 2: %p, 3: %p\n", bm, bm2, bm3);
-todo_wine
+    todo_wine
     ok(bm != curObj2, "0: %p, curObj2 %p\n", bm, curObj2);
     ok(old2 == 0, "old2 %p\n", old2);
 

--- a/modules/rostests/winetests/gdi32/font.c
+++ b/modules/rostests/winetests/gdi32/font.c
@@ -1819,15 +1819,15 @@ static void test_GetKerningPairs(void)
            kd[i].otmMacDescent, otm.otmMacDescent);
         ok(near_match(kd[i].otmMacAscent, otm.otmMacAscent), "expected %d, got %d\n",
            kd[i].otmMacAscent, otm.otmMacAscent);
-todo_wine
+        todo_wine
         ok(kd[i].otmsCapEmHeight == otm.otmsCapEmHeight, "expected %u, got %u\n",
            kd[i].otmsCapEmHeight, otm.otmsCapEmHeight);
-todo_wine
+        todo_wine
         ok(kd[i].otmsXHeight == otm.otmsXHeight, "expected %u, got %u\n",
            kd[i].otmsXHeight, otm.otmsXHeight);
         ok(kd[i].otmMacLineGap == otm.otmMacLineGap, "expected %u, got %u\n",
            kd[i].otmMacLineGap, otm.otmMacLineGap);
-todo_wine
+        todo_wine
         ok(kd[i].otmusMinimumPPEM == otm.otmusMinimumPPEM, "expected %u, got %u\n",
            kd[i].otmusMinimumPPEM, otm.otmusMinimumPPEM);
 
@@ -4167,7 +4167,7 @@ static void test_nonexistent_font(void)
     hfont = CreateFontIndirectA(&lf);
     hfont = SelectObject(hdc, hfont);
     GetTextFaceA(hdc, sizeof(buf), buf);
-todo_wine /* Wine uses Arial for all substitutions */
+    todo_wine /* Wine uses Arial for all substitutions */
     ok(!lstrcmpiA(buf, "Nonexistent font") /* XP, Vista */ ||
        !lstrcmpiA(buf, "MS Serif") || /* Win9x */
        !lstrcmpiA(buf, "MS Sans Serif"), /* win2k3 */
@@ -4204,11 +4204,11 @@ todo_wine /* Wine uses Arial for all substitutions */
     for (i = 0; i < sizeof(font_subst)/sizeof(font_subst[0]); i++)
     {
         ret = is_font_installed(font_subst[i].name);
-todo_wine
+        todo_wine
         ok(ret || broken(!ret && !i) /* win2000 doesn't have Times New Roman Baltic substitution */,
            "%s should be enumerated\n", font_subst[i].name);
         ret = is_truetype_font_installed(font_subst[i].name);
-todo_wine
+        todo_wine
         ok(ret || broken(!ret && !i) /* win2000 doesn't have Times New Roman Baltic substitution */,
            "%s should be enumerated\n", font_subst[i].name);
 
@@ -4559,7 +4559,7 @@ static void test_oemcharset(void)
     hfont = CreateFontIndirectA(&lf);
     old_hfont = SelectObject(hdc, hfont);
     charset = GetTextCharset(hdc);
-todo_wine
+    todo_wine
     ok(charset == OEM_CHARSET, "expected %d charset, got %d\n", OEM_CHARSET, charset);
     hfont = SelectObject(hdc, old_hfont);
     GetObjectA(hfont, sizeof(clf), &clf);
@@ -5295,9 +5295,9 @@ static INT CALLBACK enum_ms_shell_dlg_proc(const LOGFONTA *lf, const TEXTMETRICA
 {
     struct enum_fullname_data *efnd = (struct enum_fullname_data *)lParam;
 
-if (0) /* Disabled to limit console spam */
-    trace("enumed font \"%s\", charset %d, height %d, weight %d, italic %d\n",
-          lf->lfFaceName, lf->lfCharSet, lf->lfHeight, lf->lfWeight, lf->lfItalic);
+    if (0) /* Disabled to limit console spam */
+        trace("enumed font \"%s\", charset %d, height %d, weight %d, italic %d\n",
+              lf->lfFaceName, lf->lfCharSet, lf->lfHeight, lf->lfWeight, lf->lfItalic);
 
     if (type != TRUETYPE_FONTTYPE) return 1;
     if (strcmp(lf->lfFaceName, "MS Shell Dlg") != 0) return 1;
@@ -5316,9 +5316,9 @@ static INT CALLBACK enum_ms_shell_dlg2_proc(const LOGFONTA *lf, const TEXTMETRIC
 {
     struct enum_fullname_data *efnd = (struct enum_fullname_data *)lParam;
 
-if (0) /* Disabled to limit console spam */
-    trace("enumed font \"%s\", charset %d, height %d, weight %d, italic %d\n",
-          lf->lfFaceName, lf->lfCharSet, lf->lfHeight, lf->lfWeight, lf->lfItalic);
+    if (0) /* Disabled to limit console spam */
+        trace("enumed font \"%s\", charset %d, height %d, weight %d, italic %d\n",
+              lf->lfFaceName, lf->lfCharSet, lf->lfHeight, lf->lfWeight, lf->lfItalic);
 
     if (type != TRUETYPE_FONTTYPE) return 1;
     if (strcmp(lf->lfFaceName, "MS Shell Dlg 2") != 0) return 1;
@@ -5706,7 +5706,7 @@ static void test_GetGlyphOutline_metric_clipping(void)
 
     /* Test tmLastChar - wine_test has code points fffb-fffe mapped to glyph 0 */
     GetTextMetricsW(hdc, &tmW);
-todo_wine
+    todo_wine
     ok( tmW.tmLastChar == 0xfffe, "got %04x\n", tmW.tmLastChar);
 
     SelectObject(hdc, hfont_prev);

--- a/modules/rostests/winetests/gdiplus/customlinecap.c
+++ b/modules/rostests/winetests/gdiplus/customlinecap.c
@@ -283,12 +283,12 @@ static void test_create_adjustable_cap(void)
     ok(base == LineCapTriangle, "Unexpected base cap %d\n", base);
 
     stat = GdipSetCustomLineCapBaseCap((GpCustomLineCap*)cap, LineCapSquare);
-todo_wine
+    todo_wine
     ok(stat == Ok, "Unexpected return code, %d\n", stat);
 
     stat = GdipGetCustomLineCapBaseCap((GpCustomLineCap*)cap, &base);
     ok(stat == Ok, "Unexpected return code, %d\n", stat);
-todo_wine
+    todo_wine
     ok(base == LineCapSquare, "Unexpected base cap %d\n", base);
 
     /* Base inset */

--- a/modules/rostests/winetests/gdiplus/font.c
+++ b/modules/rostests/winetests/gdiplus/font.c
@@ -889,7 +889,7 @@ static void test_font_substitution(void)
     lstrcpyA(lf.lfFaceName, "ThisFontShouldNotExist");
     font = NULL;
     status = GdipCreateFontFromLogfontA(hdc, &lf, &font);
-todo_wine
+    todo_wine
     ok(status == NotTrueTypeFont || broken(status == FileNotFound), /* before XP */
        "expected NotTrueTypeFont, got %d\n", status);
     /* FIXME: remove when wine is fixed */
@@ -899,7 +899,7 @@ todo_wine
     lf.lfFaceName[0] = 0;
     font = NULL;
     status = GdipCreateFontFromLogfontA(hdc, &lf, &font);
-todo_wine
+    todo_wine
     ok(status == NotTrueTypeFont || broken(status == FileNotFound), /* before XP */
        "expected NotTrueTypeFont, got %d\n", status);
     /* FIXME: remove when wine is fixed */
@@ -964,7 +964,7 @@ static void test_font_transform(void)
     expect(Ok, status);
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
-todo_wine
+    todo_wine
     expectf(height + margin_y, bounds.Height);
     set_rect_empty(&rect);
     set_rect_empty(&bounds);
@@ -1008,7 +1008,7 @@ todo_wine
     expect(Ok, status);
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
-todo_wine
+    todo_wine
     expectf(height + margin_y, bounds.Height);
     set_rect_empty(&rect);
     set_rect_empty(&bounds);
@@ -1029,9 +1029,9 @@ todo_wine
                                      DriverStringOptionsCmapLookup, matrix, &bounds);
     expect(Ok, status);
     expectf(0.0, bounds.X);
-todo_wine
+    todo_wine
     expectf_(-300.0, bounds.Y, 0.15);
-todo_wine
+    todo_wine
     expectf(height * 3.0, bounds.Height);
 
     /* scale + ratate matrix */
@@ -1054,7 +1054,7 @@ todo_wine
     expect(Ok, status);
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
-todo_wine
+    todo_wine
     expectf(height + margin_y, bounds.Height);
     set_rect_empty(&rect);
     set_rect_empty(&bounds);
@@ -1074,11 +1074,11 @@ todo_wine
     status = GdipMeasureDriverString(graphics, (const UINT16 *)string, -1, font, pos,
                                      DriverStringOptionsCmapLookup, matrix, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(-43.814377, bounds.X, 0.05);
-todo_wine
+    todo_wine
     expectf_(-212.235611, bounds.Y, 0.05);
-todo_wine
+    todo_wine
     expectf_(340.847534, bounds.Height, 0.05);
 
     /* scale + ratate + shear matrix */
@@ -1088,7 +1088,7 @@ todo_wine
     expect(Ok, status);
     status = GdipGetLogFontA(font, graphics, &lf);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(1032, lf.lfHeight);
     expect(0, lf.lfWidth);
     expect_(3099, lf.lfEscapement, 1);
@@ -1102,7 +1102,7 @@ todo_wine
     expect(Ok, status);
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
-todo_wine
+    todo_wine
     expectf(height + margin_y, bounds.Height);
     set_rect_empty(&rect);
     set_rect_empty(&bounds);
@@ -1122,11 +1122,11 @@ todo_wine
     status = GdipMeasureDriverString(graphics, (const UINT16 *)string, -1, font, pos,
                                      DriverStringOptionsCmapLookup, matrix, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(-636.706848, bounds.X, 0.05);
-todo_wine
+    todo_wine
     expectf_(-175.257523, bounds.Y, 0.05);
-todo_wine
+    todo_wine
     expectf_(1532.984985, bounds.Height, 0.05);
 
     /* scale + ratate + shear + translate matrix */
@@ -1136,7 +1136,7 @@ todo_wine
     expect(Ok, status);
     status = GdipGetLogFontA(font, graphics, &lf);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(1032, lf.lfHeight);
     expect(0, lf.lfWidth);
     expect_(3099, lf.lfEscapement, 1);
@@ -1150,7 +1150,7 @@ todo_wine
     expect(Ok, status);
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
-todo_wine
+    todo_wine
     expectf(height + margin_y, bounds.Height);
     set_rect_empty(&rect);
     set_rect_empty(&bounds);
@@ -1170,11 +1170,11 @@ todo_wine
     status = GdipMeasureDriverString(graphics, (const UINT16 *)string, -1, font, pos,
                                      DriverStringOptionsCmapLookup, matrix, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(-626.706848, bounds.X, 0.05);
-todo_wine
+    todo_wine
     expectf_(-155.257523, bounds.Y, 0.05);
-todo_wine
+    todo_wine
     expectf_(1532.984985, bounds.Height, 0.05);
 
     GdipDeleteMatrix(matrix);

--- a/modules/rostests/winetests/gdiplus/graphics.c
+++ b/modules/rostests/winetests/gdiplus/graphics.c
@@ -3804,7 +3804,7 @@ static void test_GdipMeasureString(void)
 
         expectf(0.0, bounds.X);
         expectf(0.0, bounds.Y);
-todo_wine
+        todo_wine
         expectf_(height, bounds.Height, height / 100.0);
         expectf_(bounds.Height / base_cy, bounds.Width / base_cx, 0.1);
         expect(7, chars);
@@ -3821,7 +3821,7 @@ todo_wine
         expect(Ok, status);
         expectf(50.0, bounds.X);
         expectf(50.0, bounds.Y);
-todo_wine
+        todo_wine
         expectf_(height, bounds.Height, height / 100.0);
         expectf_(bounds.Height / base_cy, bounds.Width / base_cx, 0.1);
         expect(7, chars);
@@ -3893,7 +3893,7 @@ todo_wine
 
             expectf(0.0, bounds.X);
             expectf(0.0, bounds.Y);
-todo_wine
+            todo_wine
             expectf_(height, bounds.Height, height / 85.0);
             expectf_(bounds.Height / base_cy, bounds.Width / base_cx, 0.1);
             expect(7, chars);
@@ -3910,7 +3910,7 @@ todo_wine
             expect(Ok, status);
             expectf(50.0, bounds.X);
             expectf(50.0, bounds.Y);
-todo_wine
+            todo_wine
             expectf_(height, bounds.Height, height / 85.0);
             expectf_(bounds.Height / base_cy, bounds.Width / base_cx, 0.1);
             expect(7, chars);
@@ -3922,7 +3922,7 @@ todo_wine
                 height *= td[i].page_scale;
             /*trace("%u: unit %u, %.1fx%.1f dpi, scale %.1f, height %f, pixels %f\n",
                   i, td[i].unit, td[i].res_x, td[i].res_y, td[i].page_scale, bounds.Height, height);*/
-todo_wine
+            todo_wine
             expectf_(100.0, height, 1.1);
 
             status = GdipDeleteGraphics(graphics);
@@ -4379,7 +4379,7 @@ static void test_font_height_scaling(void)
             status = GdipMeasureString(graphics, string, -1, font, &rect, format, &bounds, NULL, NULL);
             expect(Ok, status);
             /*trace("bounds: %f,%f,%f,%f\n", bounds.X, bounds.Y, bounds.Width, bounds.Height);*/
-todo_wine
+            todo_wine
             expectf_(font_height + margin_y, bounds.Height, 0.005);
 
             ptf.X = 0;
@@ -4387,14 +4387,14 @@ todo_wine
             status = GdipTransformPoints(graphics, CoordinateSpaceDevice, CoordinateSpaceWorld, &ptf, 1);
             expect(Ok, status);
             match = fabs(100.0 - ptf.Y) <= 1.0;
-todo_wine
+            todo_wine
             ok(match, "Expected 100.0, got %f\n", ptf.Y);
 
             /* verify the result */
             ptf.Y = units_to_pixels(bounds.Height, gfx_unit, dpi);
             ptf.Y /= 100.0;
             match = fabs(100.0 - ptf.Y) <= 1.0;
-todo_wine
+            todo_wine
             ok(match, "Expected 100.0, got %f\n", ptf.Y);
 
             /* bounds.width of 1 glyph: [margin]+[width]+[margin] */
@@ -4502,7 +4502,7 @@ static void test_measure_string(void)
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
     expectf(width, bounds.Width);
-todo_wine
+    todo_wine
     expectf(height / 2.0, bounds.Height);
 
     range.First = 0;
@@ -4522,7 +4522,7 @@ todo_wine
     expectf_(5.0 + margin_x, bounds.X, 1.0);
     expectf(5.0, bounds.Y);
     expectf_(width - margin_x*2.0, bounds.Width, 1.0);
-todo_wine
+    todo_wine
     expectf_(height - margin_y, bounds.Height, 1.0);
 
     width_rgn = bounds.Width;
@@ -4578,7 +4578,7 @@ todo_wine
     expectf_(5.0 + margin_x, bounds.X, 1.0);
     expectf(5.0, bounds.Y);
     expectf_(width_1, bounds.Width, 1.0);
-todo_wine
+    todo_wine
     expectf_(height - margin_y, bounds.Height, 1.0);
 
     status = GdipSetStringFormatFlags(format, StringFormatFlagsNoWrap | StringFormatFlagsNoClip);
@@ -4621,7 +4621,7 @@ todo_wine
     expectf(0.0, bounds.X);
     expectf(0.0, bounds.Y);
     expectf_(width, bounds.Width, 0.01);
-todo_wine
+    todo_wine
     expectf(height, bounds.Height);
 
     set_rect_empty(&rect);
@@ -4714,7 +4714,7 @@ todo_wine
     expectf_(5.0 + margin_x, bounds.X, 1.0);
     expectf(5.0, bounds.Y);
     expectf_(width - margin_x*2.0, bounds.Width, 1.0);
-todo_wine
+    todo_wine
     expectf_(height - margin_y, bounds.Height, 1.0);
 
     width_rgn = bounds.Width;
@@ -4733,9 +4733,9 @@ todo_wine
     expect(Ok, status);
     expect(3, glyphs);
     expect(1, lines);
-todo_wine
+    todo_wine
     expectf_(5.0 + width/2.0, bounds.X, 0.01);
-todo_wine
+    todo_wine
     expectf(5.0 + height/2.0, bounds.Y);
     expectf_(width, bounds.Width, 0.01);
     expectf(height, bounds.Height);
@@ -4749,9 +4749,9 @@ todo_wine
     expect(Ok, status);
     expect(3, glyphs);
     expect(1, lines);
-todo_wine
+    todo_wine
     expectf_(5.0 - width/2.0, bounds.X, 0.01);
-todo_wine
+    todo_wine
     expectf(5.0 - height/2.0, bounds.Y);
     expectf_(width, bounds.Width, 0.01);
     expectf(height, bounds.Height);
@@ -4765,9 +4765,9 @@ todo_wine
     set_rect_empty(&bounds);
     status = GdipGetRegionBounds(region, graphics, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(5.0 + width_rgn/2.0, bounds.X, 1.0);
-todo_wine
+    todo_wine
     expectf_(5.0 + height_rgn/2.0, bounds.Y, 1.0);
     expectf_(width_rgn, bounds.Width, 1.0);
     expectf_(height_rgn, bounds.Height, 1.0);
@@ -4781,9 +4781,9 @@ todo_wine
     set_rect_empty(&bounds);
     status = GdipGetRegionBounds(region, graphics, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(5.0 - width_rgn/2.0, bounds.X, 1.0);
-todo_wine
+    todo_wine
     expectf_(5.0 - height_rgn/2.0, bounds.Y, 1.0);
     expectf_(width_rgn, bounds.Width, 1.0);
     expectf_(height_rgn, bounds.Height, 1.0);
@@ -4801,9 +4801,9 @@ todo_wine
     expect(Ok, status);
     expect(3, glyphs);
     expect(1, lines);
-todo_wine
+    todo_wine
     expectf_(5.0 + width, bounds.X, 0.01);
-todo_wine
+    todo_wine
     expectf(5.0 + height, bounds.Y);
     expectf_(width, bounds.Width, 0.01);
     expectf(height, bounds.Height);
@@ -4817,9 +4817,9 @@ todo_wine
     expect(Ok, status);
     expect(3, glyphs);
     expect(1, lines);
-todo_wine
+    todo_wine
     expectf_(5.0 - width, bounds.X, 0.01);
-todo_wine
+    todo_wine
     expectf(5.0 - height, bounds.Y);
     expectf_(width, bounds.Width, 0.01);
     expectf(height, bounds.Height);
@@ -4833,9 +4833,9 @@ todo_wine
     set_rect_empty(&bounds);
     status = GdipGetRegionBounds(region, graphics, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(5.0 + width_rgn, bounds.X, 2.0);
-todo_wine
+    todo_wine
     expectf_(5.0 + height_rgn, bounds.Y, 1.0);
     expectf_(width_rgn, bounds.Width, 1.0);
     expectf_(height_rgn, bounds.Height, 1.0);
@@ -4849,9 +4849,9 @@ todo_wine
     set_rect_empty(&bounds);
     status = GdipGetRegionBounds(region, graphics, &bounds);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expectf_(5.0 - width_rgn, bounds.X, 2.0);
-todo_wine
+    todo_wine
     expectf_(5.0 - height_rgn, bounds.Y, 1.0);
     expectf_(width_rgn, bounds.Width, 1.0);
     expectf_(height_rgn, bounds.Height, 1.0);

--- a/modules/rostests/winetests/gdiplus/image.c
+++ b/modules/rostests/winetests/gdiplus/image.c
@@ -5432,7 +5432,7 @@ static void test_GdipInitializePalette(void)
     palette->Count = 256;
     status = pGdipInitializePalette(palette, PaletteTypeFixedBW, 0, FALSE, bitmap);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(0x200, palette->Flags);
     expect(2, palette->Count);
     expect(0xff000000, palette->Entries[0]);
@@ -5443,7 +5443,7 @@ todo_wine
     palette->Count = 256;
     status = pGdipInitializePalette(palette, PaletteTypeFixedHalftone8, 1, FALSE, NULL);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(0x300, palette->Flags);
     expect(16, palette->Count);
     expect(0xff000000, palette->Entries[0]);
@@ -5455,7 +5455,7 @@ todo_wine
     palette->Count = 256;
     status = pGdipInitializePalette(palette, PaletteTypeFixedHalftone8, 1, FALSE, bitmap);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(0x300, palette->Flags);
     expect(16, palette->Count);
     expect(0xff000000, palette->Entries[0]);
@@ -5467,7 +5467,7 @@ todo_wine
     palette->Count = 256;
     status = pGdipInitializePalette(palette, PaletteTypeFixedHalftone252, 1, FALSE, bitmap);
     expect(Ok, status);
-todo_wine
+    todo_wine
     expect(0x800, palette->Flags);
     expect(252, palette->Count);
     expect(0xff000000, palette->Entries[0]);

--- a/modules/rostests/winetests/hlink/hlink.c
+++ b/modules/rostests/winetests/hlink/hlink.c
@@ -2364,9 +2364,9 @@ if (0) {    /* these currently open a browser window on wine */
     CHECK_CALLED(IsSystemMoniker);
     CHECK_CALLED(GetDisplayName);
     CHECK_CALLED(HBC_GetObject);
-todo_wine
+    todo_wine
     CHECK_CALLED(BindStatusCallback_GetBindInfo);
-todo_wine
+    todo_wine
     CHECK_CALLED(Reduce);
     CHECK_CALLED(BindToObject);
 todo_wine {
@@ -2374,15 +2374,15 @@ todo_wine {
     CHECK_CALLED(BindStatusCallback_OnObjectAvailable);
 }
     CHECK_CALLED(HT_QueryInterface_IHlinkTarget);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetBrowseContext);
     CHECK_CALLED(HT_SetBrowseContext);
-todo_wine
+    todo_wine
     CHECK_CALLED(HBC_QueryInterface_IHlinkHistory);
     CHECK_CALLED(HT_Navigate);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetFriendlyName);
-todo_wine
+    todo_wine
     CHECK_CALLED(BindStatusCallback_OnStopBinding);
 
     ok(bind_callback_refs == 1, "Got unexpected refcount %d.\n", bind_callback_refs);
@@ -2400,7 +2400,7 @@ todo_wine
     CHECK_CALLED(IsSystemMoniker);
     CHECK_CALLED(GetDisplayName);
     CHECK_CALLED(HBC_GetObject);
-todo_wine
+    todo_wine
     CHECK_CALLED(Reduce);
     CHECK_CALLED(BindToObject);
 
@@ -2425,13 +2425,13 @@ todo_wine
             (IUnknown *)&HlinkTarget);
     ok(hres == S_OK, "Got hr %#x.\n", hres);
     CHECK_CALLED(HT_QueryInterface_IHlinkTarget);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetBrowseContext);
     CHECK_CALLED(HT_SetBrowseContext);
-todo_wine
+    todo_wine
     CHECK_CALLED(HBC_QueryInterface_IHlinkHistory);
     CHECK_CALLED(HT_Navigate);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetFriendlyName);
 
     hres = IHlink_Navigate(hlink, 0, pbc, NULL, &HlinkBrowseContext);
@@ -2456,10 +2456,10 @@ todo_wine
     ok(hres == MK_S_ASYNCHRONOUS, "Navigate failed: %#x\n", hres);
     CHECK_CALLED(IsSystemMoniker);
     CHECK_CALLED(GetDisplayName);
-todo_wine
+    todo_wine
     CHECK_CALLED(BindStatusCallback_GetBindInfo);
     CHECK_CALLED(HBC_GetObject);
-todo_wine
+    todo_wine
     CHECK_CALLED(Reduce);
     CHECK_CALLED(BindToObject);
 
@@ -2491,13 +2491,13 @@ todo_wine
     ok(hres == S_OK, "Got hr %#x.\n", hres);
     CHECK_CALLED(BindStatusCallback_OnObjectAvailable);
     CHECK_CALLED(HT_QueryInterface_IHlinkTarget);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetBrowseContext);
     CHECK_CALLED(HT_SetBrowseContext);
-todo_wine
+    todo_wine
     CHECK_CALLED(HBC_QueryInterface_IHlinkHistory);
     CHECK_CALLED(HT_Navigate);
-todo_wine
+    todo_wine
     CHECK_CALLED(HT_GetFriendlyName);
 
     hres = IHlink_Navigate(hlink, 0, pbc, NULL, &HlinkBrowseContext);

--- a/modules/rostests/winetests/iphlpapi/iphlpapi.c
+++ b/modules/rostests/winetests/iphlpapi/iphlpapi.c
@@ -936,7 +936,7 @@ static void testIcmpSendEcho(void)
     ret = pIcmpSendEcho(INVALID_HANDLE_VALUE, address, senddata, sizeof(senddata), NULL, replydata, replysz, 1000);
     error = GetLastError();
     ok (!ret, "IcmpSendEcho succeeded unexpectedly\n");
-todo_wine
+    todo_wine
     ok (error == ERROR_INVALID_PARAMETER
         || broken(error == ERROR_INVALID_HANDLE) /* <= 2003 */,
         "expected 87, got %d\n", error);
@@ -992,7 +992,7 @@ todo_wine
     ret = pIcmpSendEcho(icmp, address, senddata, sizeof(senddata), NULL, replydata, 0, 1000);
     error = GetLastError();
     ok (!ret, "IcmpSendEcho succeeded unexpectedly\n");
-todo_wine
+    todo_wine
     ok (error == ERROR_INVALID_PARAMETER
         || broken(error == ERROR_INSUFFICIENT_BUFFER) /* <= 2003 */,
         "expected 87, got %d\n", error);
@@ -1001,7 +1001,7 @@ todo_wine
     ret = pIcmpSendEcho(icmp, address, senddata, sizeof(senddata), NULL, NULL, 0, 1000);
     error = GetLastError();
     ok (!ret, "IcmpSendEcho succeeded unexpectedly\n");
-todo_wine
+    todo_wine
     ok (error == ERROR_INVALID_PARAMETER
         || broken(error == ERROR_INSUFFICIENT_BUFFER) /* <= 2003 */,
         "expected 87, got %d\n", error);
@@ -1021,7 +1021,7 @@ todo_wine
     replysz = sizeof(ICMP_ECHO_REPLY);
     ret = pIcmpSendEcho(icmp, address, senddata, 0, NULL, replydata, replysz, 1000);
     error = GetLastError();
-todo_wine
+    todo_wine
     ok (ret, "IcmpSendEcho failed unexpectedly with error %d\n", error);
 
     SetLastError(0xdeadbeef);
@@ -1034,9 +1034,9 @@ todo_wine
     replysz = sizeof(ICMP_ECHO_REPLY) + ICMP_MINLEN;
     ret = pIcmpSendEcho(icmp, address, senddata, ICMP_MINLEN + 1, NULL, replydata, replysz, 1000);
     error = GetLastError();
-todo_wine
+    todo_wine
     ok (!ret, "IcmpSendEcho succeeded unexpectedly\n");
-todo_wine
+    todo_wine
     ok (error == IP_GENERAL_FAILURE
         || broken(error == IP_BUF_TOO_SMALL) /* <= 2003 */,
         "expected 11050, got %d\n", error);
@@ -1045,7 +1045,7 @@ todo_wine
     ret = pIcmpSendEcho(icmp, address, senddata, ICMP_MINLEN, NULL, replydata, replysz - 1, 1000);
     error = GetLastError();
     ok (!ret, "IcmpSendEcho succeeded unexpectedly\n");
-todo_wine
+    todo_wine
     ok (error == IP_GENERAL_FAILURE
         || broken(error == IP_BUF_TOO_SMALL) /* <= 2003 */,
         "expected 11050, got %d\n", error);

--- a/modules/rostests/winetests/kernel32/actctx.c
+++ b/modules/rostests/winetests/kernel32/actctx.c
@@ -2571,7 +2571,7 @@ todo_wine {
     SetLastError(0xdeadbeef);
     handle = pCreateActCtxA(&actctx);
     ok(handle == INVALID_HANDLE_VALUE, "got handle %p\n", handle);
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_SXS_CANT_GEN_ACTCTX || broken(GetLastError() == ERROR_NOT_ENOUGH_MEMORY) /* XP, win2k3 */,
         "got error %d\n", GetLastError());
 
@@ -2684,7 +2684,7 @@ static void test_ZombifyActCtx(void)
 
     SetLastError(0xdeadbeef);
     ret = pZombifyActCtx(NULL);
-todo_wine
+    todo_wine
     ok(!ret && GetLastError() == ERROR_INVALID_PARAMETER, "got %d, error %d\n", ret, GetLastError());
 
     handle = create_manifest("test.manifest", testdep_manifest3, __LINE__);
@@ -2715,7 +2715,7 @@ todo_wine
     ok(basicinfo.dwFlags == 0, "got %x\n", basicinfo.dwFlags);
 
     ret = pZombifyActCtx(handle);
-todo_wine
+    todo_wine
     ok(ret, "got %d\n", ret);
 
     memset(&basicinfo, 0xff, sizeof(basicinfo));
@@ -2738,7 +2738,7 @@ todo_wine
 
     /* one more time */
     ret = pZombifyActCtx(handle);
-todo_wine
+    todo_wine
     ok(ret, "got %d\n", ret);
 
     ret = pDeactivateActCtx(0, cookie);

--- a/modules/rostests/winetests/kernel32/file.c
+++ b/modules/rostests/winetests/kernel32/file.c
@@ -3940,14 +3940,14 @@ static void test_CreateFile(void)
         ok(hfile == INVALID_HANDLE_VALUE, "CreateFile should fail\n");
         if (i == 0 || i == 5)
         {
-/* FIXME: remove once Wine is fixed */
-todo_wine_if (i == 5)
+            /* FIXME: remove once Wine is fixed */
+            todo_wine_if (i == 5)
             ok(GetLastError() == ERROR_INVALID_PARAMETER, "%d: expected ERROR_INVALID_PARAMETER, got %d\n", i, GetLastError());
         }
         else
         {
-/* FIXME: remove once Wine is fixed */
-todo_wine_if (i == 1)
+            /* FIXME: remove once Wine is fixed */
+            todo_wine_if (i == 1)
             ok(GetLastError() == ERROR_ACCESS_DENIED, "%d: expected ERROR_ACCESS_DENIED, got %d\n", i, GetLastError());
         }
 
@@ -3958,8 +3958,8 @@ todo_wine_if (i == 1)
             ok(GetLastError() == ERROR_INVALID_PARAMETER, "%d: expected ERROR_INVALID_PARAMETER, got %d\n", i, GetLastError());
         else
         {
-/* FIXME: remove once Wine is fixed */
-todo_wine_if (i == 1)
+            /* FIXME: remove once Wine is fixed */
+            todo_wine_if (i == 1)
             ok(GetLastError() == ERROR_ACCESS_DENIED, "%d: expected ERROR_ACCESS_DENIED, got %d\n", i, GetLastError());
         }
     }
@@ -4869,7 +4869,7 @@ static void test_SetFileInformationByHandle(void)
     /* test FileDispositionInfo, additional details already covered by ntdll tests */
     SetLastError(0xdeadbeef);
     ret = pSetFileInformationByHandle(file, FileDispositionInfo, &dispinfo, 0);
-todo_wine
+    todo_wine
     ok(!ret && GetLastError() == ERROR_BAD_LENGTH, "got %d, error %d\n", ret, GetLastError());
 
     dispinfo.DeleteFile = TRUE;

--- a/modules/rostests/winetests/kernel32/loader.c
+++ b/modules/rostests/winetests/kernel32/loader.c
@@ -2490,7 +2490,7 @@ static BOOL WINAPI dll_entry_point(HINSTANCE hinst, DWORD reason, LPVOID param)
         SetLastError(0xdeadbeef);
         ret = WaitForDebugEvent(&de, 0);
         ok(!ret, "WaitForDebugEvent should fail\n");
-todo_wine
+        todo_wine
         ok(GetLastError() == ERROR_INVALID_HANDLE, "expected ERROR_INVALID_HANDLE, got %d\n", GetLastError());
 
         SetLastError(0xdeadbeef);

--- a/modules/rostests/winetests/kernel32/mailslot.c
+++ b/modules/rostests/winetests/kernel32/mailslot.c
@@ -88,7 +88,7 @@ static int mailslot_test(void)
     SetLastError(0xdeadbeef);
     ret = ReadFile(hSlot, buffer, 0, &count, NULL);
     ok(!ret, "ReadFile should fail\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_SEM_TIMEOUT, "wrong error %u\n", GetLastError());
     ok(count == 0, "expected 0, got %u\n", count);
 

--- a/modules/rostests/winetests/kernel32/process.c
+++ b/modules/rostests/winetests/kernel32/process.c
@@ -3733,7 +3733,7 @@ static void test_process_info(void)
         case ProcessDebugPort:
         case ProcessDebugFlags:
         case ProcessCookie:
-todo_wine
+            todo_wine
             ok(status == STATUS_ACCESS_DENIED, "for info %u expected STATUS_ACCESS_DENIED, got %08x (ret_len %u)\n", i, status, ret_len);
             break;
 

--- a/modules/rostests/winetests/kernel32/sync.c
+++ b/modules/rostests/winetests/kernel32/sync.c
@@ -203,9 +203,9 @@ static void test_mutex(void)
 
     SetLastError(0xdeadbeef);
     hOpened = OpenMutexA(0, FALSE, "WineTestMutex");
-todo_wine
+    todo_wine
     ok(hOpened == NULL, "OpenMutex succeeded\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_ACCESS_DENIED, "wrong error %u\n", GetLastError());
 
     SetLastError(0xdeadbeef);
@@ -250,7 +250,7 @@ todo_wine
         }
     }
 
-todo_wine
+    todo_wine
     ok( failed == 0x0de0fffe, "open succeeded when it shouldn't: %x\n", failed);
 
     SetLastError(0xdeadbeef);

--- a/modules/rostests/winetests/kernel32/thread.c
+++ b/modules/rostests/winetests/kernel32/thread.c
@@ -2040,14 +2040,14 @@ static void test_thread_info(void)
 #endif
 
         case ThreadTimes:
-todo_wine
+            todo_wine
             ok(status == STATUS_SUCCESS, "for info %u expected STATUS_SUCCESS, got %08x (ret_len %u)\n", i, status, ret_len);
             break;
 
         case ThreadAffinityMask:
         case ThreadQuerySetWin32StartAddress:
         case ThreadIsIoPending:
-todo_wine
+            todo_wine
             ok(status == STATUS_ACCESS_DENIED, "for info %u expected STATUS_ACCESS_DENIED, got %08x (ret_len %u)\n", i, status, ret_len);
             break;
 

--- a/modules/rostests/winetests/kernel32/virtual.c
+++ b/modules/rostests/winetests/kernel32/virtual.c
@@ -4012,7 +4012,7 @@ static void test_NtQuerySection(void)
     ok(info.image.ImageCharacteristics == nt->FileHeader.Characteristics, "expected %#x, got %#x\n", nt->FileHeader.Characteristics, info.image.ImageCharacteristics);
     ok(info.image.DllCharacteristics == nt->OptionalHeader.DllCharacteristics, "expected %#x, got %#x\n", nt->OptionalHeader.DllCharacteristics, info.image.DllCharacteristics);
     ok(info.image.Machine == nt->FileHeader.Machine, "expected %#x, got %#x\n", nt->FileHeader.Machine, info.image.Machine);
-todo_wine
+    todo_wine
     ok(info.image.ImageContainsCode == TRUE, "expected 1, got %#x\n", info.image.ImageContainsCode);
 
     memset(&info, 0x55, sizeof(info));
@@ -4037,7 +4037,7 @@ todo_wine
     ok(status == STATUS_SUCCESS, "NtQuerySection error %#x\n", status);
     ok(ret == sizeof(info.basic), "wrong returned size %u\n", ret);
     ok(info.basic.BaseAddress == NULL, "expected NULL, got %p\n", info.basic.BaseAddress);
-todo_wine
+    todo_wine
     ok(info.basic.Attributes == SEC_FILE, "expected SEC_FILE, got %#x\n", info.basic.Attributes);
     ok(info.basic.Size.QuadPart == fsize, "expected %#lx, got %#x/%08x\n", fsize, info.basic.Size.HighPart, info.basic.Size.LowPart);
 

--- a/modules/rostests/winetests/mlang/mlang.c
+++ b/modules/rostests/winetests/mlang/mlang.c
@@ -2272,7 +2272,7 @@ static void test_IMLangConvertCharset(IMultiLanguage *ml)
     HRESULT hr;
 
     hr = IMultiLanguage_CreateConvertCharset(ml, CP_ACP, CP_UTF8, 0, &convert);
-todo_wine
+    todo_wine
     ok(hr == S_FALSE, "expected S_FALSE got 0x%08x\n", hr);
 
     hr = IMLangConvertCharset_GetSourceCodePage(convert, NULL);

--- a/modules/rostests/winetests/msacm32/msacm.c
+++ b/modules/rostests/winetests/msacm32/msacm.c
@@ -952,7 +952,7 @@ static void test_prepareheader(void)
     ok(mr == MMSYSERR_NOERROR, "convert failed: 0x%x\n", mr);
     ok(hdr.fdwStatus & ACMSTREAMHEADER_STATUSF_DONE, "conversion was not done: 0x%x\n", hdr.fdwStatus);
     ok(hdr.cbSrcLengthUsed == hdr.cbSrcLength, "expected %d, got %d\n", hdr.cbSrcLength, hdr.cbSrcLengthUsed);
-todo_wine
+    todo_wine
     ok(hdr.cbDstLengthUsed == 1010, "expected 1010, got %d\n", hdr.cbDstLengthUsed);
 
     mr = acmStreamUnprepareHeader(has, &hdr, 0);
@@ -980,7 +980,7 @@ todo_wine
         ok(mr == MMSYSERR_NOERROR, "convert failed: 0x%x\n", mr);
         ok(hdr.fdwStatus & ACMSTREAMHEADER_STATUSF_DONE, "conversion was not done: 0x%x\n", hdr.fdwStatus);
         ok(hdr.cbSrcLengthUsed == hdr.cbSrcLength, "expected %d, got %d\n", hdr.cbSrcLength, hdr.cbSrcLengthUsed);
-todo_wine
+        todo_wine
         ok(hdr.cbDstLengthUsed == 1010, "expected 1010, got %d\n", hdr.cbDstLengthUsed);
 
         mr = acmStreamUnprepareHeader(has, &hdr, 0);
@@ -988,7 +988,7 @@ todo_wine
         ok(hdr.fdwStatus == ACMSTREAMHEADER_STATUSF_DONE, "header wasn't unprepared: 0x%x\n", hdr.fdwStatus);
     }
     else
-todo_wine
+        todo_wine
         ok(mr == MMSYSERR_INVALPARAM, "expected 0x0b, got 0x%x\n", mr);
 
     memset(&hdr, 0, sizeof(hdr));
@@ -1029,9 +1029,9 @@ todo_wine
     mr = acmStreamConvert(has, &hdr, ACM_STREAMCONVERTF_BLOCKALIGN);
     ok(mr == MMSYSERR_NOERROR, "convert failed: 0x%x\n", mr);
     ok(hdr.fdwStatus & ACMSTREAMHEADER_STATUSF_DONE, "conversion was not done: 0x%x\n", hdr.fdwStatus);
-todo_wine
+    todo_wine
     ok(hdr.cbSrcLengthUsed == hdr.cbSrcLength, "expected %d, got %d\n", hdr.cbSrcLength, hdr.cbSrcLengthUsed);
-todo_wine
+    todo_wine
     ok(hdr.cbDstLengthUsed == hdr.cbDstLength, "expected %d, got %d\n", hdr.cbDstLength, hdr.cbDstLengthUsed);
 
     mr = acmStreamUnprepareHeader(has, &hdr, 0);
@@ -1128,7 +1128,7 @@ static void test_convert(void)
         ok(hdr.fdwStatus & ACMSTREAMHEADER_STATUSF_DONE, "#%d: conversion was not done: 0x%x\n", i, hdr.fdwStatus);
         ok(hdr.cbSrcLengthUsed == hdr.cbSrcLength, "#%d: expected %d, got %d\n", i, hdr.cbSrcLength, hdr.cbSrcLengthUsed);
         ok(hdr.cbDstLengthUsed == expected_output[i].dst_used, "#%d: expected %d, got %d\n", i, expected_output[i].dst_used, hdr.cbDstLengthUsed);
-todo_wine_if(expected_output[i].todo)
+        todo_wine_if(expected_output[i].todo)
         ok(!memcmp(expected_output[i].output, output, hdr.cbDstLengthUsed), "#%d: output does not match\n", i);
 
         mmr = acmStreamUnprepareHeader(has, &hdr, 0);
@@ -1502,7 +1502,7 @@ static void test_acmDriverAdd(void)
 
     res = acmDriverAddA(&drvid, GetModuleHandleA(NULL), (LPARAM)acm_driver_func, 0, ACM_DRIVERADDF_FUNCTION);
     ok(res == MMSYSERR_NOERROR, "Expected 0, got %d\n", res);
-todo_wine
+    todo_wine
     ok(driver_calls.driver.open == 1, "Expected 1, got %d\n", driver_calls.driver.open);
     ok(driver_calls.driver.details == 1, "Expected 1, got %d\n", driver_calls.driver.details);
 
@@ -1513,10 +1513,10 @@ todo_wine
     acm.drv_details.cbStruct = sizeof(acm.drv_details);
     res = acmDriverDetailsA(drvid, &acm.drv_details, 0);
     ok(res == MMSYSERR_NOERROR, "Expected 0, got %d\n", res);
-todo_wine
+    todo_wine
     ok(driver_calls.driver.open == 1, "Expected 1, got %d\n", driver_calls.driver.open);
     ok(driver_calls.driver.details == 2, "Expected 2, got %d\n", driver_calls.driver.details);
-todo_wine
+    todo_wine
     ok(driver_calls.driver.close == 0, "Expected 0, got %d\n", driver_calls.driver.close);
 }
 

--- a/modules/rostests/winetests/msi/install.c
+++ b/modules/rostests/winetests/msi/install.c
@@ -6076,7 +6076,7 @@ static void test_deferred_action(void)
     }
     ok(r == ERROR_SUCCESS, "Expected ERROR_SUCCESS, got %u\n", r);
 
-todo_wine
+    todo_wine
     check_file_matches(file, "onetwo");
 
     ok(DeleteFileA(file), "Directory not created\n");

--- a/modules/rostests/winetests/msvfw32/msvfw.c
+++ b/modules/rostests/winetests/msvfw32/msvfw.c
@@ -478,7 +478,7 @@ static void test_ICInfo(void)
         ok(!lstrcmpW(info.szDriver, bogusW), "Got unexpected driver %s.\n", wine_dbgstr_w(info.szDriver));
 
         /* Drivers installed after msvfw32 is loaded are not enumerated. */
-todo_wine
+        todo_wine
         ok(!ICInfo(test_type, 0, &info), "Expected failure.\n");
 
         ret = ICRemove(test_type, test_handler, 0);
@@ -506,7 +506,7 @@ todo_wine
         ok(!lstrcmpW(info.szDriver, bogusW), "Got unexpected driver %s.\n", wine_dbgstr_w(info.szDriver));
 
         /* Drivers installed after msvfw32 is loaded are not enumerated. */
-todo_wine
+        todo_wine
         ok(!ICInfo(test_type, 0, &info), "Expected failure.\n");
 
         ret = WritePrivateProfileStringA("drivers32", "wine.test", NULL, "system.ini");

--- a/modules/rostests/winetests/msxml3/domdoc.c
+++ b/modules/rostests/winetests/msxml3/domdoc.c
@@ -7417,7 +7417,7 @@ static void test_XSLPattern(void)
         if (len) {
             if (ptr->todo) {
                 char *str = list_to_string(list);
-            todo_wine
+                todo_wine
                 ok(!strcmp(str, ptr->list), "Invalid node list: %s, expected %s\n", str, ptr->list);
                 IXMLDOMNodeList_Release(list);
             }
@@ -10497,7 +10497,7 @@ static void test_mxnamespacemanager(void)
     EXPECT_REF(mgr2, 2);
     prefixes = NULL;
     hr = IVBMXNamespaceManager_getDeclaredPrefixes(mgr2, &prefixes);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "got 0x%08x\n", hr);
     if (hr == S_OK)
     {
@@ -11068,7 +11068,7 @@ static void test_dispex(void)
     hr = IDispatchEx_Invoke(dispex, DISPID_VALUE, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
     ok(hr == DISP_E_BADPARAMCOUNT, "got 0x%08x\n", hr);
     ok(V_VT(&ret) == VT_EMPTY, "got %d\n", V_VT(&ret));
-todo_wine
+    todo_wine
     ok(broken(V_DISPATCH(&ret) == (void*)0x1) || (V_DISPATCH(&ret) == NULL), "got %p\n", V_DISPATCH(&ret));
 
     V_VT(&arg) = VT_I4;
@@ -11083,7 +11083,7 @@ todo_wine
     hr = IDispatchEx_Invoke(dispex, DISPID_VALUE, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
     ok(hr == DISP_E_BADPARAMCOUNT, "got 0x%08x\n", hr);
     ok(V_VT(&ret) == VT_EMPTY, "got %d\n", V_VT(&ret));
-todo_wine
+    todo_wine
     ok(broken(V_DISPATCH(&ret) == (void*)0x1) || (V_DISPATCH(&ret) == NULL), "got %p\n", V_DISPATCH(&ret));
 
     V_VT(&arg) = VT_I4;
@@ -11136,7 +11136,7 @@ todo_wine
     hr = IDispatchEx_Invoke(dispex, DISPID_DOM_NODELIST_LENGTH, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
     ok(hr == DISP_E_MEMBERNOTFOUND, "got 0x%08x\n", hr);
     ok(V_VT(&ret) == VT_EMPTY, "got %d\n", V_VT(&ret));
-todo_wine
+    todo_wine
     ok(broken(V_I4(&ret) == 1) || (V_I4(&ret) == 0), "got %d\n", V_I4(&ret));
 
     IXMLDOMNodeList_Release(node_list);
@@ -11162,7 +11162,7 @@ todo_wine
     hr = IDispatchEx_Invoke(dispex, DISPID_VALUE, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
     ok(hr == DISP_E_MEMBERNOTFOUND, "got 0x%08x\n", hr);
     ok(V_VT(&ret) == VT_EMPTY, "got %d\n", V_VT(&ret));
-todo_wine
+    todo_wine
     ok(broken(V_DISPATCH(&ret) == (void*)0x1) || (V_DISPATCH(&ret) == NULL), "got %p\n", V_DISPATCH(&ret));
 
     IDispatchEx_Release(dispex);
@@ -11267,7 +11267,7 @@ todo_wine {
     V_VT(&ret) = VT_EMPTY;
     V_DISPATCH(&ret) = (void*)0x1;
     hr = IDispatchEx_Invoke(dispex, DISPID_VALUE, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "got 0x%08x\n", hr);
     ok(V_VT(&ret) == VT_DISPATCH, "got %d\n", V_VT(&ret));
     ok(V_DISPATCH(&ret) == NULL, "got %p\n", V_DISPATCH(&ret));
@@ -11307,7 +11307,7 @@ todo_wine
     V_I4(&ret) = 1;
     hr = IDispatchEx_Invoke(dispex, DISPID_DOM_NODELIST_LENGTH, &IID_NULL, 0, DISPATCH_METHOD, &dispparams, &ret, NULL, NULL);
     ok(hr == DISP_E_MEMBERNOTFOUND, "got 0x%08x\n", hr);
-todo_wine
+    todo_wine
     ok(V_VT(&ret) == VT_EMPTY, "got %d\n", V_VT(&ret));
     ok(broken(V_I4(&ret) == 1) || (V_I4(&ret) == 0), "got %d\n", V_I4(&ret));
 
@@ -12303,7 +12303,7 @@ static void test_newline_normalization(void)
         if (IsEqualGUID(table->clsid, &CLSID_DOMDocument60))
         {
             /* DOMDocument60 does the newline normalization but does not insert line breaks around the root node */
-todo_wine
+            todo_wine
             ok(!lstrcmpW(s, _bstr_("<?xml version=\"1.0\"?><root>foo\r\n\r\n\r\n\r\nbar</root>")),
                "got %s\n", wine_dbgstr_w(s));
         }
@@ -12761,8 +12761,8 @@ static HRESULT WINAPI transformdest_QueryInterface(IUnknown *iface, REFIID riid,
         IsEqualIID(riid, &IID_ISequentialStream) ||
         IsEqualIID(riid, &IID_IRequestDictionary);
 
-todo_wine_if(IsEqualIID(riid, &IID_IXMLDOMDocument))
-    ok(known_iid, "Unexpected riid %s\n", wine_dbgstr_guid(riid));
+    todo_wine_if(IsEqualIID(riid, &IID_IXMLDOMDocument))
+        ok(known_iid, "Unexpected riid %s\n", wine_dbgstr_guid(riid));
 
     return E_NOINTERFACE;
 }

--- a/modules/rostests/winetests/msxml3/httpreq.c
+++ b/modules/rostests/winetests/msxml3/httpreq.c
@@ -1403,11 +1403,11 @@ static void set_xhr_site(IXMLHttpRequest *xhr)
     EXPECT_HR(hr, S_OK);
 
     CHECK_CALLED(site_qi_IServiceProvider);
-todo_wine
+    todo_wine
     CHECK_CALLED(sp_queryservice_SID_SBindHost);
     CHECK_CALLED(sp_queryservice_SID_SContainerDispatch_htmldoc2);
     CHECK_CALLED(sp_queryservice_SID_secmgr_htmldoc2);
-todo_wine
+    todo_wine
     CHECK_CALLED(sp_queryservice_SID_secmgr_xmldomdoc);
     /* this one isn't very reliable
     CHECK_CALLED(sp_queryservice_SID_secmgr_secmgr); */

--- a/modules/rostests/winetests/ntdll/file.c
+++ b/modules/rostests/winetests/ntdll/file.c
@@ -3524,7 +3524,7 @@ static void test_NtCreateFile(void)
             /* FIXME: leave only 'else' case below once Wine is fixed */
             if (ret != td[i].attrib_out)
             {
-            todo_wine
+                todo_wine
                 ok(ret == td[i].attrib_out, "%d: expected %#x got %#x\n", i, td[i].attrib_out, ret);
                 SetFileAttributesW(path, td[i].attrib_out);
             }

--- a/modules/rostests/winetests/ntdll/reg.c
+++ b/modules/rostests/winetests/ntdll/reg.c
@@ -366,9 +366,9 @@ static void test_NtOpenKey(void)
     attr.Length = sizeof(attr);
     key = (HANDLE)0xdeadbeef;
     status = pNtOpenKey(&key, 0, &attr);
-todo_wine
+    todo_wine
     ok(status == STATUS_ACCESS_DENIED, "Expected STATUS_ACCESS_DENIED, got: 0x%08x\n", status);
-todo_wine
+    todo_wine
     ok(!key, "key = %p\n", key);
     if (status == STATUS_SUCCESS) NtClose(key);
 
@@ -378,7 +378,7 @@ todo_wine
     key = (HANDLE)0xdeadbeef;
     status = pNtOpenKey(&key, KEY_READ, &attr);
     todo_wine ok(status == STATUS_OBJECT_PATH_SYNTAX_BAD, "NtOpenKey Failed: 0x%08x\n", status);
-todo_wine
+    todo_wine
     ok(!key, "key = %p\n", key);
     pRtlFreeUnicodeString( &str );
 

--- a/modules/rostests/winetests/ole32/compobj.c
+++ b/modules/rostests/winetests/ole32/compobj.c
@@ -1534,7 +1534,7 @@ static void test_CoRegisterClassObject(void)
     if ((handle = activate_context(actctx_manifest, &ctxcookie)))
     {
         hr = CoGetClassObject(&CLSID_WineOOPTest, CLSCTX_INPROC_SERVER, NULL, &IID_IClassFactory, (void**)&pcf);
-todo_wine
+        todo_wine
         ok(hr == HRESULT_FROM_WIN32(ERROR_MOD_NOT_FOUND), "got 0x%08x\n", hr);
 
         pDeactivateActCtx(0, ctxcookie);
@@ -3649,7 +3649,7 @@ static void test_CoGetInstanceFromFile(void)
     mqi[0].pItf = NULL;
     mqi[0].hr = E_NOTIMPL;
     hr = CoGetInstanceFromFile(NULL, NULL, NULL, CLSCTX_INPROC_SERVER, STGM_READ, (OLECHAR*)filenameW, 1, mqi);
-todo_wine
+    todo_wine
     ok(hr == MK_E_CANTOPENFILE, "got 0x%08x\n", hr);
     ok(mqi[0].pItf == NULL, "got %p\n", mqi[0].pItf);
     ok(mqi[0].hr == E_NOINTERFACE, "got 0x%08x\n", mqi[0].hr);

--- a/modules/rostests/winetests/ole32/defaulthandler.c
+++ b/modules/rostests/winetests/ole32/defaulthandler.c
@@ -286,7 +286,7 @@ static void test_default_handler_run(void)
     SET_EXPECT(CF_QueryInterface_ClassFactory);
     SET_EXPECT(CF_CreateInstance);
     hres = IRunnableObject_Run(ro, NULL);
-todo_wine
+    todo_wine
     ok(hres == S_OK, "Run failed: %x\n", hres);
     CHECK_CALLED(CF_QueryInterface_ClassFactory);
     CHECK_CALLED(CF_CreateInstance);
@@ -296,11 +296,11 @@ todo_wine
     SET_EXPECT(CF_CreateInstance);
     hres = CoCreateInstance(&test_server_clsid, NULL, CLSCTX_LOCAL_SERVER,
                             &IID_IOleObject, (void**)&oleobj);
-todo_wine
+    todo_wine
     ok(hres == REGDB_E_CLASSNOTREG, "expected REGDB_E_CLASSNOTREG, got %x\n", hres);
-todo_wine
+    todo_wine
     CHECK_NOT_CALLED(CF_QueryInterface_ClassFactory);
-todo_wine
+    todo_wine
     CHECK_NOT_CALLED(CF_CreateInstance);
 
     SET_EXPECT(CF_QueryInterface_IMarshal);

--- a/modules/rostests/winetests/ole32/marshal.c
+++ b/modules/rostests/winetests/ole32/marshal.c
@@ -1353,7 +1353,7 @@ static void test_marshal_channel_buffer(void)
 
     SET_EXPECT(Disconnect);
     IUnknown_Release(proxy);
-todo_wine
+    todo_wine
     CHECK_CALLED(Disconnect);
 
     hr = CoRevokeClassObject(registration_key);

--- a/modules/rostests/winetests/ole32/ole2.c
+++ b/modules/rostests/winetests/ole32/ole2.c
@@ -1353,7 +1353,7 @@ static void test_OleLoad(IStorage *pStorage)
             if (fmt == CF_METAFILEPICT)
                 ok(hr == S_OK, "OleDraw error %#x: cfFormat = %u, advf = %#x\n", hr, fmt, header.advf);
             else if (fmt == CF_ENHMETAFILE)
-todo_wine
+                todo_wine
                 ok(hr == S_OK, "OleDraw error %#x: cfFormat = %u, advf = %#x\n", hr, fmt, header.advf);
             else
                 ok(hr == OLE_E_BLANK || hr == OLE_E_NOTRUNNING || hr == E_FAIL, "OleDraw should fail: %#x, cfFormat = %u, advf = %#x\n", hr, fmt, header.advf);
@@ -3349,7 +3349,7 @@ static HRESULT WINAPI Storage_CreateStream(IStorage *iface, LPCOLESTR pwcsName, 
     }
     else
     {
-todo_wine
+        todo_wine
         ok(0, "unexpected stream name %s\n", wine_dbgstr_w(pwcsName));
 #if 0   /* FIXME: return NULL once Wine is fixed */
         *ppstm = NULL;
@@ -3818,11 +3818,11 @@ static void test_data_cache_save(void)
     hr = IPersistStorage_Save(stg, &Storage, FALSE);
     ok(hr == S_OK, "unexpected %#x\n", hr);
     CHECK_CALLED(Storage_CreateStream_OlePres);
-todo_wine
+    todo_wine
     CHECK_CALLED(Storage_OpenStream_OlePres);
-todo_wine
+    todo_wine
     CHECK_CALLED(Storage_OpenStream_Ole);
-todo_wine
+    todo_wine
     CHECK_CALLED(Storage_DestroyElement);
 
     IStream_Release(olepres_stream);
@@ -4599,10 +4599,10 @@ static void test_data_cache_contents(void)
 
         enumerated_streams = matched_streams = -1;
         check_storage_contents(doc2, test_data[i].out, &enumerated_streams, &matched_streams);
-todo_wine_if(!(test_data[i].in == &stg_def_0 || test_data[i].in == &stg_def_1 || test_data[i].in == &stg_def_2))
+        todo_wine_if(!(test_data[i].in == &stg_def_0 || test_data[i].in == &stg_def_1 || test_data[i].in == &stg_def_2))
         ok(enumerated_streams == matched_streams, "%d out: enumerated %d != matched %d\n", i,
            enumerated_streams, matched_streams);
-todo_wine_if(!(test_data[i].in == &stg_def_0 || test_data[i].in == &stg_def_4 || test_data[i].in == &stg_def_5
+        todo_wine_if(!(test_data[i].in == &stg_def_0 || test_data[i].in == &stg_def_4 || test_data[i].in == &stg_def_5
                  || test_data[i].in == &stg_def_6))
         ok(enumerated_streams == test_data[i].out->stream_count, "%d: saved streams %d != def streams %d\n", i,
             enumerated_streams, test_data[i].out->stream_count);

--- a/modules/rostests/winetests/ole32/ole_server.c
+++ b/modules/rostests/winetests/ole32/ole_server.c
@@ -472,11 +472,11 @@ START_TEST(ole_server)
     trace("call OleRun\n");
     hr = OleRun(unknown);
     trace("ret OleRun\n");
-todo_wine
+    todo_wine
     ok(hr == S_OK, "OleRun error %#x\n", hr);
 
     ret = IRunnableObject_IsRunning(runobj);
-todo_wine
+    todo_wine
     ok(ret == 1, "expected 1, got %d\n", ret);
 
     trace("call IRunnableObject_Release\n");

--- a/modules/rostests/winetests/ole32/usrmarshal.c
+++ b/modules/rostests/winetests/ole32/usrmarshal.c
@@ -720,7 +720,7 @@ static void marshal_WdtpInterfacePointer(DWORD umcb_ctx, DWORD ctx, BOOL client,
     IStream_Seek(stm, zero, STREAM_SEEK_CUR, &pos);
     marshal_size = pos.u.LowPart;
     marshal_data = GlobalLock(h);
-todo_wine
+    todo_wine
     ok(Test_Unknown.refs == 2, "got %d\n", Test_Unknown.refs);
 
     init_user_marshal_cb(&umcb, &stub_msg, &rpc_msg, NULL, 0, umcb_ctx);
@@ -729,7 +729,7 @@ todo_wine
     buffer = HeapAlloc(GetProcessHeap(), 0, size);
     init_user_marshal_cb(&umcb, &stub_msg, &rpc_msg, buffer, size, umcb_ctx);
     buffer_end = WdtpInterfacePointer_UserMarshal(&umcb.Flags, ctx, buffer, unk, &IID_IUnknown);
-todo_wine
+    todo_wine
     ok(Test_Unknown.refs == 2, "got %d\n", Test_Unknown.refs);
     wireip = buffer;
 

--- a/modules/rostests/winetests/oleaut32/olefont.c
+++ b/modules/rostests/winetests/oleaut32/olefont.c
@@ -1146,12 +1146,12 @@ static void test_hfont_lifetime(void)
     EXPECT_HR(hr, S_OK);
     hr = IFont_get_hFont(font2, &first_hfont);
     EXPECT_HR(hr, S_OK);
-todo_wine
+    todo_wine
     ok(hfont == first_hfont, "fonts differ\n");
     hr = IFont_ReleaseHfont(font, hfont);
     EXPECT_HR(hr, S_OK);
     hr = IFont_ReleaseHfont(font, hfont);
-todo_wine
+    todo_wine
     EXPECT_HR(hr, S_OK);
     hr = IFont_ReleaseHfont(font, hfont);
     EXPECT_HR(hr, S_FALSE);

--- a/modules/rostests/winetests/oleaut32/olepicture.c
+++ b/modules/rostests/winetests/oleaut32/olepicture.c
@@ -1313,7 +1313,7 @@ static void test_load_save_icon(void)
     size = -1;
     hr = IPicture_SaveAsFile(pic, dst_stream, TRUE, &size);
     ok(hr == S_OK, "IPicture_SaveasFile error %#x\n", hr);
-todo_wine
+    todo_wine
     ok(size == 766, "expected 766, got %d\n", size);
     mem = GlobalLock(hmem);
     ok(mem[0] == 0x00010000, "got wrong icon header %04x\n", mem[0]);
@@ -1339,7 +1339,7 @@ todo_wine
 
     mem = GlobalLock(hmem);
     ok(!memcmp(mem, "lt\0\0", 4), "got wrong stream header %04x\n", mem[0]);
-todo_wine
+    todo_wine
     ok(mem[1] == 766, "expected stream size 766, got %u\n", mem[1]);
     ok(mem[2] == 0x00010000, "got wrong icon header %04x\n", mem[2]);
 

--- a/modules/rostests/winetests/oleaut32/safearray.c
+++ b/modules/rostests/winetests/oleaut32/safearray.c
@@ -2016,9 +2016,9 @@ static void test_SafeArrayDestroyData (void)
   ok(sa->pvData != NULL, "got %p\n", sa->pvData);
   hres = SafeArrayDestroyData(sa);
   ok(hres == S_OK, "got 0x%08x\n", hres);
-todo_wine
+  todo_wine
   ok(sa->fFeatures == FADF_HAVEVARTYPE, "got 0x%x\n", sa->fFeatures);
-todo_wine
+  todo_wine
   ok(sa->pvData == NULL || broken(sa->pvData != NULL), "got %p\n", sa->pvData);
   /* There was a bug on windows, especially visible on 64bit systems,
      probably double-free or similar issue. */

--- a/modules/rostests/winetests/oleaut32/tmarshal.c
+++ b/modules/rostests/winetests/oleaut32/tmarshal.c
@@ -2284,7 +2284,7 @@ static void test_marshal_iface(IWidget *widget, IDispatch *disp)
     V_VT(&arg[0]) = VT_UNKNOWN|VT_BYREF;  V_UNKNOWNREF(&arg[0]) = &proxy_unk2;
     hr = IDispatch_Invoke(disp, DISPID_TM_IFACE_OUT, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
 if (hr == S_OK) {
     hr = IUnknown_QueryInterface(proxy_unk2, &IID_ISomethingFromDispatch, (void **)&proxy_sfd);
@@ -2301,7 +2301,7 @@ if (hr == S_OK) {
     proxy_disp = NULL;
     hr = IDispatch_Invoke(disp, DISPID_TM_IFACE_OUT, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
     ok(!proxy_unk, "Got unexpected proxy %p.\n", proxy_unk);
     ok(!proxy_disp, "Got unexpected proxy %p.\n", proxy_disp);
@@ -2318,7 +2318,7 @@ todo_wine
     V_VT(&arg[0]) = VT_UNKNOWN|VT_BYREF; V_UNKNOWNREF(&arg[0]) = &unk_in_out;
     hr = IDispatch_Invoke(disp, DISPID_TM_IFACE_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
     ok(unk_in == (IUnknown *)sfd1, "[in] parameter should not have changed.\n");
     ok(!unk_out, "[out] parameter should have been cleared.\n");
@@ -2335,7 +2335,7 @@ todo_wine
     IUnknown_AddRef(unk_in_out);
     hr = IDispatch_Invoke(disp, DISPID_TM_IFACE_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
 
 if (hr == S_OK) {
@@ -2356,14 +2356,14 @@ if (hr == S_OK) {
     release_iface(unk_in_out);
 }
     release_iface(sfd1);
-todo_wine
+    todo_wine
     release_iface(sfd3);
 
     testmode = 2;
     unk_in = unk_out = unk_in_out = NULL;
     hr = IDispatch_Invoke(disp, DISPID_TM_IFACE_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
 
     ok(!unk_out, "[out] parameter should not have been set.\n");
@@ -2750,7 +2750,7 @@ static void test_marshal_coclass(IWidget *widget, IDispatch *disp)
     V_VT(&arg[0]) = VT_UNKNOWN|VT_BYREF;    V_UNKNOWNREF(&arg[0]) = &unk_in_out;
     hr = IDispatch_Invoke(disp, DISPID_TM_COCLASS_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
     ok(unk_in == (IUnknown *)&class1->ICoclass1_iface, "[in] parameter should not have changed.\n");
     ok(!unk_out, "[out] parameter should have been cleared.\n");
@@ -2767,7 +2767,7 @@ todo_wine
     IUnknown_AddRef(unk_in_out);
     hr = IDispatch_Invoke(disp, DISPID_TM_COCLASS_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
 
 if (hr == S_OK) {
@@ -2788,14 +2788,14 @@ if (hr == S_OK) {
     release_iface(unk_in_out);
 }
     release_iface(&class1->ICoclass1_iface);
-todo_wine
+    todo_wine
     release_iface(&class3->ICoclass1_iface);
 
     testmode = 2;
     unk_in = unk_out = unk_in_out = NULL;
     hr = IDispatch_Invoke(disp, DISPID_TM_COCLASS_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
 
     ok(!unk_out, "[out] parameter should not have been set.\n");
@@ -2816,12 +2816,12 @@ if (hr == S_OK) {
     IUnknown_AddRef(unk_in_out);
     hr = IDispatch_Invoke(disp, DISPID_TM_COCLASS_PTR, &IID_NULL, LOCALE_NEUTRAL,
             DISPATCH_METHOD, &dispparams, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Got hr %#x.\n", hr);
-todo_wine
+    todo_wine
     ok(!unk_in_out, "[in, out] parameter should have been cleared.\n");
 
-todo_wine
+    todo_wine
     release_iface(&class3->ICoclass1_iface);
 }
 

--- a/modules/rostests/winetests/oleaut32/usrmarshal.c
+++ b/modules/rostests/winetests/oleaut32/usrmarshal.c
@@ -1484,7 +1484,7 @@ static void test_marshal_VARIANT(void)
     stubMsg.BufferEnd = stubMsg.Buffer + stubMsg.BufferLength;
     memset(buffer, 0xcc, stubMsg.BufferLength);
     next = VARIANT_UserMarshal(&umcb.Flags, buffer, &v);
-todo_wine
+    todo_wine
     ok(heap_unknown->refs == 2, "got refcount %d\n", heap_unknown->refs);
     wirev = (DWORD*)buffer;
     wirev = check_variant_header(wirev, &v, next - buffer);
@@ -1502,7 +1502,7 @@ todo_wine
     V_UNKNOWN(&v3) = &heap_unknown->IUnknown_iface;
     IUnknown_AddRef(V_UNKNOWN(&v3));
     stubMsg.Buffer = buffer;
-todo_wine
+    todo_wine
     ok(heap_unknown->refs == 3, "got refcount %d\n", heap_unknown->refs);
     next = VARIANT_UserUnmarshal(&umcb.Flags, buffer, &v3);
     ok(V_VT(&v) == V_VT(&v3), "got vt %d expect %d\n", V_VT(&v), V_VT(&v3));
@@ -1551,7 +1551,7 @@ todo_wine
     memset(buffer, 0xcc, stubMsg.BufferLength);
     ok(heap_unknown->refs == 1, "got refcount %d\n", heap_unknown->refs);
     next = VARIANT_UserMarshal(&umcb.Flags, buffer, &v);
-todo_wine
+    todo_wine
     ok(heap_unknown->refs == 2, "got refcount %d\n", heap_unknown->refs);
     wirev = (DWORD*)buffer;
     wirev = check_variant_header(wirev, &v, next - buffer);

--- a/modules/rostests/winetests/propsys/propsys.c
+++ b/modules/rostests/winetests/propsys/propsys.c
@@ -817,7 +817,7 @@ static void test_PropVariantCompare(void)
 
     /* VT_R4/VT_R8 */
     res = PropVariantCompareEx(&r4_0, &r8_0, 0, 0);
-todo_wine
+    todo_wine
     ok(res == 0, "res=%i\n", res);
 
     res = PropVariantCompareEx(&r4_0, &r4_0, 0, 0);

--- a/modules/rostests/winetests/psapi/psapi_main.c
+++ b/modules/rostests/winetests/psapi/psapi_main.c
@@ -159,7 +159,7 @@ static void test_EnumProcessModules(void)
 
         ret = GetModuleFileNameExA(pi.hProcess, hMod, name, sizeof(name));
         ok(ret, "got error %u\n", GetLastError());
-todo_wine
+        todo_wine
         ok(!strcmp(name, buffer), "got %s\n", name);
 
         ret = GetModuleInformation(pi.hProcess, hMod, &info, sizeof(info));
@@ -183,7 +183,7 @@ todo_wine
         SetLastError(0xdeadbeef);
         ret = EnumProcessModules(pi.hProcess, &hMod, sizeof(HMODULE), &cbNeeded);
         ok(!ret, "got %d\n", ret);
-todo_wine
+        todo_wine
         ok(GetLastError() == ERROR_PARTIAL_COPY, "got error %u\n", GetLastError());
 
         TerminateProcess(pi.hProcess, 0);
@@ -527,7 +527,7 @@ todo_wine {
     SetLastError(0xdeadbeef);
     ret = GetMappedFileNameA(GetCurrentProcess(), NULL, map_name, sizeof(map_name));
     ok(!ret, "GetMappedFileName should fail\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_UNEXP_NET_ERR, "expected ERROR_UNEXP_NET_ERR, got %d\n", GetLastError());
 
     SetLastError(0xdeadbeef);

--- a/modules/rostests/winetests/quartz/filtergraph.c
+++ b/modules/rostests/winetests/quartz/filtergraph.c
@@ -473,7 +473,7 @@ static void test_media_event(IFilterGraph2 *graph)
 
     hr = IMediaSeeking_GetCurrentPosition(seeking, &current);
     ok(hr == S_OK, "GetCurrentPosition() failed: %#x\n", hr);
-todo_wine
+    todo_wine
     ok(current == stop, "expected %s, got %s\n", wine_dbgstr_longlong(stop), wine_dbgstr_longlong(current));
 
     hr = IMediaControl_Stop(control);
@@ -569,7 +569,7 @@ static void test_render_run(const WCHAR *file)
         ok(!refs, "Graph has %u references\n", refs);
 
         hr = test_graph_builder_connect(filename);
-todo_wine
+        todo_wine
         ok(hr == VFW_E_CANNOT_CONNECT, "got %#x\n", hr);
     }
     else
@@ -599,7 +599,7 @@ static DWORD WINAPI call_RenderFile_multithread(LPVOID lParam)
     HRESULT hr;
 
     hr = IFilterGraph2_RenderFile(graph, filename, NULL);
-todo_wine
+    todo_wine
     ok(SUCCEEDED(hr), "RenderFile failed: %x\n", hr);
 
     if (SUCCEEDED(hr))

--- a/modules/rostests/winetests/riched20/editor.c
+++ b/modules/rostests/winetests/riched20/editor.c
@@ -8979,11 +8979,11 @@ static void test_window_classes(void)
     {
         SetLastError(0xdeadbeef);
         hwnd = CreateWindowExA(0, test[i].class, NULL, WS_POPUP, 0, 0, 0, 0, 0, 0, 0, NULL);
-todo_wine_if(!strcmp(test[i].class, "RichEdit50A") || !strcmp(test[i].class, "RichEdit50W"))
+        todo_wine_if(!strcmp(test[i].class, "RichEdit50A") || !strcmp(test[i].class, "RichEdit50W"))
         ok(!hwnd == !test[i].success, "CreateWindow(%s) should %s\n",
            test[i].class, test[i].success ? "succeed" : "fail");
         if (!hwnd)
-todo_wine
+            todo_wine
             ok(GetLastError() == ERROR_CANNOT_FIND_WND_CLASS, "got %d\n", GetLastError());
         else
             DestroyWindow(hwnd);

--- a/modules/rostests/winetests/riched20/richole.c
+++ b/modules/rostests/winetests/riched20/richole.c
@@ -422,7 +422,7 @@ todo_wine {
   touch_file(filename);
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   hres = ITextDocument_Open(txtDoc, &testfile, tomShareDenyRead, CP_ACP);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   SetLastError(0xdeadbeef);
   hFile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
@@ -435,7 +435,7 @@ todo_wine
   touch_file(filename);
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   hres = ITextDocument_Open(txtDoc, &testfile, tomShareDenyWrite, CP_ACP);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   SetLastError(0xdeadbeef);
   hFile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
@@ -449,7 +449,7 @@ todo_wine
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   SetLastError(0xdeadbeef);
   hres = ITextDocument_Open(txtDoc, &testfile, tomShareDenyWrite|tomShareDenyRead, CP_ACP);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   hFile = CreateFileW(filename, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING,
                           FILE_ATTRIBUTE_NORMAL, NULL);
@@ -465,7 +465,7 @@ todo_wine
   CloseHandle(hFile);
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   hres = ITextDocument_Open(txtDoc, &testfile, tomReadOnly, CP_ACP);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   result = SendMessageA(w, WM_GETTEXT, 1024, (LPARAM)bufACP);
   todo_wine ok(result == 12, "ITextDocument_Open: Test ASCII returned %d, expected 12\n", result);
@@ -480,7 +480,7 @@ todo_wine
   CloseHandle(hFile);
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   hres = ITextDocument_Open(txtDoc, &testfile, tomReadOnly, CP_UTF8);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   result = SendMessageA(w, WM_GETTEXT, 1024, (LPARAM)bufACP);
   todo_wine ok(result == 15, "ITextDocument_Open: Test UTF-8 returned %d, expected 15\n", result);
@@ -495,7 +495,7 @@ todo_wine
   CloseHandle(hFile);
   create_interfaces(&w, &reOle, &txtDoc, &txtSel);
   hres = ITextDocument_Open(txtDoc, &testfile, tomReadOnly, 1200);
-todo_wine
+  todo_wine
   ok(hres == S_OK, "got 0x%08x\n", hres);
   result = SendMessageW(w, WM_GETTEXT, 1024, (LPARAM)bufUnicode);
   todo_wine ok(result == 12, "ITextDocument_Open: Test UTF-16 returned %d, expected 12\n", result);
@@ -671,13 +671,13 @@ static void test_GetText(void)
     bstr = (void*)0xdeadbeef;
     hres = ITextSelection_GetText(txtSel, &bstr);
     ok(hres == CO_E_RELEASED, "got 0x%08x\n", hres);
-todo_wine
+    todo_wine
     ok(bstr == NULL, "got %p\n", bstr);
 
     bstr = (void*)0xdeadbeef;
     hres = ITextRange_GetText(range, &bstr);
     ok(hres == CO_E_RELEASED, "got 0x%08x\n", hres);
-todo_wine
+    todo_wine
     ok(bstr == NULL, "got %p\n", bstr);
   }
   else {
@@ -2670,7 +2670,7 @@ todo_wine {
 }
   hr = ITextRange_GetEnd(range, &value);
   ok(hr == S_OK, "got 0x%08x\n", hr);
-todo_wine
+  todo_wine
   ok(value == 3, "got %d\n", value);
 
   hr = ITextRange_GetStart(range2, &value);
@@ -2679,7 +2679,7 @@ todo_wine
 
   hr = ITextRange_GetEnd(range2, &value);
   ok(hr == S_OK, "got 0x%08x\n", hr);
-todo_wine
+  todo_wine
   ok(value == 1, "got %d\n", value);
 
   ITextRange_Release(range);

--- a/modules/rostests/winetests/rpcrt4/ndr_marshall.c
+++ b/modules/rostests/winetests/rpcrt4/ndr_marshall.c
@@ -1843,7 +1843,7 @@ static void test_server_init(void)
     ok(stubMsg.Buffer == buffer, "stubMsg.Buffer should have been %p instead of %p\n", buffer, stubMsg.Buffer);
     ok(stubMsg.BufferStart == buffer, "stubMsg.BufferStart should have been %p instead of %p\n", buffer, stubMsg.BufferStart);
     ok(stubMsg.BufferEnd == buffer + sizeof(buffer), "stubMsg.BufferEnd should have been %p instead of %p\n", buffer + sizeof(buffer), stubMsg.BufferEnd);
-todo_wine
+    todo_wine
     ok(stubMsg.BufferLength == 0, "stubMsg.BufferLength should have been 0 instead of %u\n", stubMsg.BufferLength);
     ok(stubMsg.IsClient == 0, "stubMsg.IsClient should have been 0 instead of %u\n", stubMsg.IsClient);
     ok(stubMsg.ReuseBuffer == 0 ||
@@ -2649,7 +2649,7 @@ static void test_ndr_buffer(void)
     ok(StubMsg.Buffer != NULL, "Buffer should not have been NULL\n");
     ok(!StubMsg.BufferStart, "BufferStart should have been NULL instead of %p\n", StubMsg.BufferStart);
     ok(!StubMsg.BufferEnd, "BufferEnd should have been NULL instead of %p\n", StubMsg.BufferEnd);
-todo_wine
+    todo_wine
     ok(StubMsg.BufferLength == 0, "BufferLength should have left as 0 instead of being set to %d\n", StubMsg.BufferLength);
     old_buffer_valid_location = !StubMsg.fBufferValid;
     if (old_buffer_valid_location)
@@ -2942,7 +2942,7 @@ static void test_MesEncodeFixedBufferHandleCreate(void)
     ok(status == RPC_S_INVALID_ARG, "got %d\n", status);
 
     status = MesEncodeFixedBufferHandleCreate(buffer, 0, &encoded_size, &handle);
-todo_wine
+    todo_wine
     ok(status == RPC_S_INVALID_ARG, "got %d\n", status);
 if (status == RPC_S_OK) {
     MesHandleFree(handle);

--- a/modules/rostests/winetests/rpcrt4/server.c
+++ b/modules/rostests/winetests/rpcrt4/server.c
@@ -1051,7 +1051,7 @@ void __cdecl s_stop_autolisten(void)
 {
     RPC_STATUS status;
     status = RpcServerUnregisterIf(NULL, NULL, FALSE);
-todo_wine
+    todo_wine
     ok(status == RPC_S_UNKNOWN_MGR_TYPE, "got %u\n", status);
 }
 
@@ -1954,7 +1954,7 @@ client(const char *test)
 
     run_tests();
     authinfo_test(RPC_PROTSEQ_LRPC, 0);
-todo_wine
+    todo_wine
     test_is_server_listening(IMixedServer_IfHandle, RPC_S_NOT_LISTENING);
 
     stop_autolisten();

--- a/modules/rostests/winetests/scrrun/dictionary.c
+++ b/modules/rostests/winetests/scrrun/dictionary.c
@@ -774,8 +774,8 @@ static void test_Exists(void)
             &IID_IDictionary, (void**)&dict);
     ok(hr == S_OK, "got 0x%08x\n", hr);
 
-if (0) /* crashes on native */
-    hr = IDictionary_Exists(dict, NULL, NULL);
+    if (0) /* crashes on native */
+        hr = IDictionary_Exists(dict, NULL, NULL);
 
     V_VT(&key) = VT_I2;
     V_I2(&key) = 0;
@@ -880,8 +880,8 @@ static void test_Remove(void)
             &IID_IDictionary, (void**)&dict);
     ok(hr == S_OK, "got 0x%08x\n", hr);
 
-if (0)
-    hr = IDictionary_Remove(dict, NULL);
+    if (0)
+        hr = IDictionary_Remove(dict, NULL);
 
     /* nothing added yet */
     V_VT(&key) = VT_R4;

--- a/modules/rostests/winetests/scrrun/filesystem.c
+++ b/modules/rostests/winetests/scrrun/filesystem.c
@@ -1743,7 +1743,7 @@ todo_wine {
     str = NULL;
     hr = ITextStream_ReadAll(stream, &str);
     ok(hr == S_FALSE || broken(hr == S_OK) /* win2k */, "got 0x%08x\n", hr);
-todo_wine
+    todo_wine
     ok(!lstrcmpW(buffW, str), "got %s\n", wine_dbgstr_w(str));
     SysFreeString(str);
     ITextStream_Release(stream);
@@ -1891,7 +1891,7 @@ todo_wine {
     str = NULL;
     hr = ITextStream_Read(stream, 100, &str);
     ok(hr == S_FALSE || broken(hr == S_OK) /* win2k */, "got 0x%08x\n", hr);
-todo_wine
+    todo_wine
     ok(!lstrcmpW(buffW, str), "got %s\n", wine_dbgstr_w(str));
     SysFreeString(str);
     ITextStream_Release(stream);

--- a/modules/rostests/winetests/secur32/schannel.c
+++ b/modules/rostests/winetests/secur32/schannel.c
@@ -763,9 +763,9 @@ static void test_communication(void)
     status = InitializeSecurityContextA(&cred_handle, &context, (SEC_CHAR *)"localhost",
             ISC_REQ_CONFIDENTIALITY|ISC_REQ_STREAM,
             0, 0, &buffers[1], 0, NULL, &buffers[0], &attrs, NULL);
-todo_wine
+    todo_wine
     ok(status == SEC_E_INVALID_TOKEN, "Expected SEC_E_INVALID_TOKEN, got %08x\n", status);
-todo_wine
+    todo_wine
     ok(buffers[0].pBuffers[0].cbBuffer == 0, "Output buffer size was not set to 0.\n");
 
     buffers[1].cBuffers = 1;
@@ -782,7 +782,7 @@ todo_wine
     status = InitializeSecurityContextA(&cred_handle, &context, (SEC_CHAR *)"localhost",
             ISC_REQ_CONFIDENTIALITY|ISC_REQ_STREAM,
             0, 0, &buffers[1], 0, NULL, &buffers[0], &attrs, NULL);
-todo_wine
+    todo_wine
     ok(status == SEC_E_INSUFFICIENT_MEMORY || status == SEC_E_INVALID_TOKEN,
        "Expected SEC_E_INSUFFICIENT_MEMORY or SEC_E_INVALID_TOKEN, got %08x\n", status);
     ok(buffers[0].pBuffers[0].cbBuffer == 0, "Output buffer size was not set to 0.\n");
@@ -790,7 +790,7 @@ todo_wine
     status = InitializeSecurityContextA(&cred_handle, NULL, (SEC_CHAR *)"localhost",
             ISC_REQ_CONFIDENTIALITY|ISC_REQ_STREAM,
             0, 0, NULL, 0, &context, NULL, &attrs, NULL);
-todo_wine
+    todo_wine
     ok(status == SEC_E_INVALID_TOKEN, "Expected SEC_E_INVALID_TOKEN, got %08x\n", status);
 
     buffers[0].pBuffers[0].cbBuffer = buf_size;

--- a/modules/rostests/winetests/setupapi/devinst.c
+++ b/modules/rostests/winetests/setupapi/devinst.c
@@ -150,7 +150,7 @@ static void test_open_class_key(void)
     SetLastError(0xdeadbeef);
     class_key = SetupDiOpenClassRegKeyExA(&guid, KEY_ALL_ACCESS, DIOCR_INSTALLER, NULL, NULL);
     ok(class_key == INVALID_HANDLE_VALUE, "Expected failure.\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_CLASS, "Got unexpected error %#x.\n", GetLastError());
 
     root_key = SetupDiOpenClassRegKey(NULL, KEY_ALL_ACCESS);
@@ -842,7 +842,7 @@ static void test_device_key(void)
 
     SetLastError(0xdeadbeef);
     res = RegOpenKeyW(HKEY_LOCAL_MACHINE, classKey, &key);
-todo_wine
+    todo_wine
     ok(res == ERROR_FILE_NOT_FOUND, "Key should not exist.\n");
     RegCloseKey(key);
 
@@ -960,7 +960,7 @@ static void test_registry_property_a(void)
     SetLastError(0xdeadbeef);
     ret = SetupDiSetDeviceRegistryPropertyA(set, &device, -1, NULL, 0);
     ok(!ret, "Expected failure.\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_REG_PROPERTY, "Got unexpected error %#x.\n", GetLastError());
 
     ret = SetupDiSetDeviceRegistryPropertyA(set, &device, SPDRP_FRIENDLYNAME, NULL, 0);
@@ -985,7 +985,7 @@ todo_wine
     SetLastError(0xdeadbeef);
     ret = SetupDiGetDeviceRegistryPropertyA(set, &device, -1, NULL, NULL, 0, NULL);
     ok(!ret, "Expected failure.\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_REG_PROPERTY, "Got unexpected error %#x.\n", GetLastError());
 
     ret = SetupDiGetDeviceRegistryPropertyA(set, &device, SPDRP_FRIENDLYNAME, NULL, NULL, sizeof("Bogus"), NULL);
@@ -1064,7 +1064,7 @@ static void test_registry_property_w(void)
     SetLastError(0xdeadbeef);
     ret = SetupDiSetDeviceRegistryPropertyW(set, &device, -1, NULL, 0);
     ok(!ret, "Expected failure.\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_REG_PROPERTY, "Got unexpected error %#x.\n", GetLastError());
 
     ret = SetupDiSetDeviceRegistryPropertyW(set, &device, SPDRP_FRIENDLYNAME, NULL, 0);
@@ -1089,7 +1089,7 @@ todo_wine
     SetLastError(0xdeadbeef);
     ret = SetupDiGetDeviceRegistryPropertyW(set, &device, -1, NULL, NULL, 0, NULL);
     ok(!ret, "Expected failure.\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_REG_PROPERTY, "Got unexpected error %#x.\n", GetLastError());
 
     ret = SetupDiGetDeviceRegistryPropertyW(set, &device, SPDRP_FRIENDLYNAME, NULL, NULL, sizeof(buf), NULL);

--- a/modules/rostests/winetests/shell32/appbar.c
+++ b/modules/rostests/winetests/shell32/appbar.c
@@ -428,7 +428,7 @@ static void test_GetCurrentProcessExplicitAppUserModelID(void)
 
     appid = (void*)0xdeadbeef;
     hr = pGetCurrentProcessExplicitAppUserModelID(&appid);
-todo_wine
+    todo_wine
     ok(hr == E_FAIL, "got 0x%08x\n", hr);
     ok(appid == NULL, "got %p\n", appid);
 }

--- a/modules/rostests/winetests/shell32/shelldispatch.c
+++ b/modules/rostests/winetests/shell32/shelldispatch.c
@@ -168,7 +168,7 @@ static void test_namespace(void)
         folder = (void*)0xdeadbeef;
         r = IShellDispatch_NameSpace(sd, var, &folder);
         if (special_folders[i] == ssfALTSTARTUP || special_folders[i] == ssfCOMMONALTSTARTUP)
-        todo_wine
+            todo_wine
             ok(r == S_OK || broken(r == S_FALSE) /* winxp */, "Failed to get folder for index %#x, got %08x\n", special_folders[i], r);
         else
             ok(r == S_OK, "Failed to get folder for index %#x, got %08x\n", special_folders[i], r);
@@ -702,10 +702,10 @@ static void test_items(void)
             variant_set_string(&str_index2, cstr);
             item2 = (FolderItem*)0xdeadbeef;
             r = FolderItems_Item(items, str_index2, &item2);
-       todo_wine {
-            ok(r == S_FALSE, "file_defs[%d]: expected S_FALSE, got %08x\n", i, r);
-            ok(!item2, "file_defs[%d]: item is not null\n", i);
-       }
+            todo_wine {
+                 ok(r == S_FALSE, "file_defs[%d]: expected S_FALSE, got %08x\n", i, r);
+                 ok(!item2, "file_defs[%d]: item is not null\n", i);
+            }
             if (item2) FolderItem_Release(item2);
             VariantClear(&str_index2);
 
@@ -784,16 +784,16 @@ static void test_items(void)
     }
 
     r = FolderItems__NewEnum(items, &unk);
-todo_wine
+    todo_wine
     ok(r == S_OK, "FolderItems::_NewEnum failed: %08x\n", r);
-todo_wine
+    todo_wine
     ok(!!unk, "unk is null\n");
     if (unk) IUnknown_Release(unk);
 
     if (items3)
     {
         r = FolderItems3_Filter(items3, 0, NULL);
-todo_wine
+        todo_wine
         ok(r == S_OK, "expected S_OK, got %08x\n", r);
 
         if (0) /* crashes on xp */
@@ -803,7 +803,7 @@ todo_wine
         }
 
         r = FolderItems3_get_Verbs(items3, &verbs);
-todo_wine
+        todo_wine
         ok(r == S_FALSE, "expected S_FALSE, got %08x\n", r);
         ok(!verbs, "verbs is not null\n");
     }
@@ -1034,15 +1034,15 @@ static void test_ShellWindows(void)
     ok(hr == HRESULT_FROM_WIN32(RPC_X_NULL_REF_POINTER), "got 0x%08x\n", hr);
 
     hr = IShellWindows_Register(shellwindows, NULL, 0, SWC_EXPLORER, &cookie);
-todo_wine
+    todo_wine
     ok(hr == E_POINTER, "got 0x%08x\n", hr);
 
     hr = IShellWindows_Register(shellwindows, (IDispatch*)shellwindows, 0, SWC_EXPLORER, &cookie);
-todo_wine
+    todo_wine
     ok(hr == E_POINTER, "got 0x%08x\n", hr);
 
     hr = IShellWindows_Register(shellwindows, (IDispatch*)shellwindows, 0, SWC_EXPLORER, &cookie);
-todo_wine
+    todo_wine
     ok(hr == E_POINTER, "got 0x%08x\n", hr);
 
     hwnd = CreateWindowExA(0, "button", "test", BS_CHECKBOX | WS_VISIBLE | WS_POPUP,
@@ -1062,14 +1062,14 @@ todo_wine {
     ok(cookie2 != 0 && cookie2 != cookie, "got %d\n", cookie2);
 }
     hr = IShellWindows_Revoke(shellwindows, cookie);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "got 0x%08x\n", hr);
     hr = IShellWindows_Revoke(shellwindows, cookie2);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "got 0x%08x\n", hr);
 
     hr = IShellWindows_Revoke(shellwindows, 0);
-todo_wine
+    todo_wine
     ok(hr == S_FALSE, "got 0x%08x\n", hr);
 
     /* we can register ourselves as desktop, but FindWindowSW still returns real desktop window */
@@ -1120,7 +1120,7 @@ todo_wine {
         ok(hr == S_OK, "got 0x%08x\n", hr);
 
         hr = IWebBrowser2_Refresh(wb);
-todo_wine
+        todo_wine
         ok(hr == S_OK, "got 0x%08x\n", hr);
 
         hr = IWebBrowser2_get_Application(wb, &app);
@@ -1129,7 +1129,7 @@ todo_wine
         IDispatch_Release(app);
 
         hr = IWebBrowser2_get_Document(wb, &doc);
-todo_wine
+        todo_wine
         ok(hr == S_OK, "got 0x%08x\n", hr);
 if (hr == S_OK) {
         test_dispatch_typeinfo(doc, viewdual_riids);
@@ -1202,13 +1202,13 @@ if (hr == S_OK) {
     V_I4(&v) = cookie;
     VariantInit(&v2);
     hr = IShellWindows_FindWindowSW(shellwindows, &v, &v2, SWC_BROWSER, &ret, SWFO_COOKIEPASSED, &disp);
-todo_wine
+    todo_wine
     ok(hr == S_FALSE, "got 0x%08x\n", hr);
     ok(disp == NULL, "got %p\n", disp);
     ok(ret == 0, "got %d\n", ret);
 
     hr = IShellWindows_Revoke(shellwindows, cookie);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "got 0x%08x\n", hr);
     DestroyWindow(hwnd);
     IShellWindows_Release(shellwindows);

--- a/modules/rostests/winetests/shell32/shelllink.c
+++ b/modules/rostests/winetests/shell32/shelllink.c
@@ -1266,7 +1266,7 @@ static void test_ExtractIcon(void)
 
     /* specified instance handle */
     hicon = ExtractIconA(GetModuleHandleA("shell32.dll"), NULL, 0);
-todo_wine
+    todo_wine
     ok(hicon == NULL, "Got icon %p\n", hicon);
     hicon2 = ExtractIconA(GetModuleHandleA("shell32.dll"), "shell32.dll", -1);
     ok(hicon2 != NULL, "Got icon %p\n", hicon2);
@@ -1292,14 +1292,14 @@ todo_wine
     CloseHandle(file);
 
     hicon = ExtractIconA(NULL, path, 0);
-todo_wine
+    todo_wine
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     hicon = ExtractIconA(NULL, path, -1);
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     hicon = ExtractIconA(NULL, path, 1);
-todo_wine
+    todo_wine
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     r = DeleteFileA(path);
@@ -1340,14 +1340,14 @@ if (0)
     CloseHandle(file);
 
     hicon = ExtractIconW(NULL, pathW, 0);
-todo_wine
+    todo_wine
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     hicon = ExtractIconW(NULL, pathW, -1);
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     hicon = ExtractIconW(NULL, pathW, 1);
-todo_wine
+    todo_wine
     ok(hicon == NULL, "Got icon %p\n", hicon);
 
     r = DeleteFileW(pathW);

--- a/modules/rostests/winetests/shell32/shlfolder.c
+++ b/modules/rostests/winetests/shell32/shlfolder.c
@@ -224,7 +224,7 @@ static void test_ParseDisplayName(void)
     for (i = 0; i < ARRAY_SIZE(parse_tests); i++)
     {
         hr = IShellFolder_ParseDisplayName(desktop, NULL, NULL, parse_tests[i].path, NULL, &pidl, NULL);
-todo_wine_if(parse_tests[i].todo)
+        todo_wine_if(parse_tests[i].todo)
         ok(hr == parse_tests[i].hr, "%s: expected %#x, got %#x\n",
             wine_dbgstr_w(parse_tests[i].path), parse_tests[i].hr, hr);
         if (SUCCEEDED(hr))
@@ -4384,16 +4384,16 @@ static void test_contextmenu_qi(IContextMenu *menu, BOOL todo)
     HRESULT hr;
 
     hr = IContextMenu_QueryInterface(menu, &IID_IShellExtInit, (void **)&unk);
-todo_wine_if(todo)
+    todo_wine_if(todo)
     ok(hr == S_OK, "Failed to get IShellExtInit, hr %#x.\n", hr);
-if (hr == S_OK)
-    IUnknown_Release(unk);
+    if (hr == S_OK)
+        IUnknown_Release(unk);
 
     hr = IContextMenu_QueryInterface(menu, &IID_IObjectWithSite, (void **)&unk);
-todo_wine_if(todo)
+    todo_wine_if(todo)
     ok(hr == S_OK, "Failed to get IShellExtInit, hr %#x.\n", hr);
-if (hr == S_OK)
-    IUnknown_Release(unk);
+    if (hr == S_OK)
+        IUnknown_Release(unk);
 }
 
 static void test_contextmenu(IContextMenu *menu, BOOL background)
@@ -4436,7 +4436,7 @@ static void test_contextmenu(IContextMenu *menu, BOOL background)
         {
             max_id_check = (mii.wID > max_id_check) ? mii.wID : max_id_check;
             hr = IContextMenu_GetCommandString(menu, mii.wID - baseItem, GCS_VERBA, 0, buf, sizeof(buf));
-        todo_wine_if(background)
+            todo_wine_if(background)
             ok(SUCCEEDED(hr) || hr == E_NOTIMPL, "for id 0x%x got 0x%08x (menustr: %s)\n", mii.wID - baseItem, hr, mii.dwTypeData);
             if (SUCCEEDED(hr))
                 trace("for id 0x%x got string %s (menu string: %s)\n", mii.wID - baseItem, buf, mii.dwTypeData);
@@ -4461,12 +4461,12 @@ static void test_contextmenu(IContextMenu *menu, BOOL background)
         /* Attempt to execute a nonexistent command */
         cmi.lpVerb = MAKEINTRESOURCEA(9999);
         hr = IContextMenu_InvokeCommand(menu, &cmi);
-    todo_wine_if(background)
+        todo_wine_if(background)
         ok(hr == E_INVALIDARG, "Got 0x%08x\n", hr);
 
         cmi.lpVerb = "foobar_wine_test";
         hr = IContextMenu_InvokeCommand(menu, &cmi);
-    todo_wine_if(background)
+        todo_wine_if(background)
         ok((hr == E_INVALIDARG) || (hr == E_FAIL /* Win7 */) ||
            (hr == HRESULT_FROM_WIN32(ERROR_NO_ASSOCIATION) /* Vista */),
             "Unexpected hr %#x.\n", hr);
@@ -5267,18 +5267,18 @@ static void test_SHLimitInputEdit(void)
     ok(hr == S_OK, "Failed to get desktop folder, hr %#x.\n", hr);
 
     hr = SHLimitInputEdit(NULL, desktop);
-todo_wine
+    todo_wine
     ok(hr == E_FAIL, "Unexpected hr %#x.\n", hr);
 
     hwnd = CreateWindowA("EDIT", NULL, WS_VISIBLE, 0, 0, 100, 30, NULL, NULL, NULL, NULL);
     ok(hwnd != NULL, "Failed to create Edit control.\n");
 
     hr = SHLimitInputEdit(hwnd, desktop);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Failed to set input limits, hr %#x.\n", hr);
 
     hr = SHLimitInputEdit(hwnd, desktop);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Failed to set input limits, hr %#x.\n", hr);
 
     DestroyWindow(hwnd);

--- a/modules/rostests/winetests/shlwapi/istream.c
+++ b/modules/rostests/winetests/shlwapi/istream.c
@@ -270,7 +270,7 @@ static void test_stream_qi(IStream *stream)
 
     unk = NULL;
     hr = IStream_QueryInterface(stream, &IID_ISequentialStream, (void **)&unk);
-todo_wine
+    todo_wine
     ok(SUCCEEDED(hr) || broken(hr == E_NOINTERFACE) /* XP */, "Failed to get ISequentialStream interface, hr %#x.\n", hr);
     if (unk)
         IUnknown_Release(unk);
@@ -753,17 +753,17 @@ static void test_SHCreateMemStream(void)
     ok(stream != NULL, "Failed to create a stream.\n");
 
     hr = IStream_QueryInterface(stream, &IID_ISequentialStream, (void **)&unk);
-todo_wine
+    todo_wine
     ok(hr == S_OK || broken(hr == E_NOINTERFACE) /* WinXP */, "Failed to QI, hr %#x.\n", hr);
     if (unk)
         IUnknown_Release(unk);
 
     hr = IStream_Read(stream, buff, sizeof(buff), NULL);
-todo_wine
+    todo_wine
     ok(hr == S_FALSE || broken(hr == S_OK) /* WinXP */, "Unexpected hr %#x.\n", hr);
 
     hr = IStream_Clone(stream, &stream2);
-todo_wine
+    todo_wine
     ok(hr == S_OK || broken(hr == E_NOTIMPL) /* < Win8 */, "Failed to clone a stream, hr %#x.\n", hr);
     if (hr == S_OK)
         IStream_Release(stream2);

--- a/modules/rostests/winetests/user32/dde.c
+++ b/modules/rostests/winetests/user32/dde.c
@@ -336,7 +336,7 @@ static void test_ddeml_client(void)
     ret = DdeGetLastError(client_pid);
     ok(res == DDE_FNOTPROCESSED || broken(res == 0xdeadbeef), /* win9x */
        "Expected DDE_FNOTPROCESSED, got %x\n", res);
-todo_wine
+    todo_wine
     ok(ret == DMLERR_MEMORY_ERROR || broken(ret == 0), /* win9x */
        "Expected DMLERR_MEMORY_ERROR, got %d\n", ret);
     ok( hdata != NULL, "hdata is NULL\n" );
@@ -1771,7 +1771,7 @@ static void test_initialisation(void)
     hdata = DdeClientTransaction(NULL, 0, conversation, item, CF_TEXT, XTYP_REQUEST, default_timeout, &res);
     ok(hdata == NULL, "Expected NULL, got %p\n", hdata);
     ret = DdeGetLastError(client_pid);
-todo_wine
+    todo_wine
     ok(ret == DMLERR_INVALIDPARAMETER, "Expected DMLERR_INVALIDPARAMETER, got %d\n", ret);
     ok(res == 0xdeadbeef, "Expected 0xdeadbeef, got %08x\n", res);
 

--- a/modules/rostests/winetests/user32/dialog.c
+++ b/modules/rostests/winetests/user32/dialog.c
@@ -1556,12 +1556,12 @@ static INT_PTR CALLBACK test_aw_conversion_dlgproc(HWND hdlg, UINT msg, WPARAM w
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTA));
         ret = SetWindowTextA(hdlg, testtext);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTW));
         ret = SetWindowTextW(hdlg, testtextW);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         memset(buff, 'A', sizeof(buff));
@@ -1592,12 +1592,12 @@ static INT_PTR CALLBACK test_aw_conversion_dlgproc(HWND hdlg, UINT msg, WPARAM w
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTA));
         ret = SetWindowTextA(hdlg, testtext);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTW));
         ret = SetWindowTextW(hdlg, testtextW);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         memset(buff, 'A', sizeof(buff));
@@ -1663,12 +1663,12 @@ static INT_PTR CALLBACK test_aw_conversion_dlgproc2(HWND hdlg, UINT msg, WPARAM 
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTA));
         ret = SetWindowTextA(hdlg, testtext);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTW));
         ret = SetWindowTextW(hdlg, testtextW);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         memset(buff, 'A', sizeof(buff));
@@ -1699,12 +1699,12 @@ static INT_PTR CALLBACK test_aw_conversion_dlgproc2(HWND hdlg, UINT msg, WPARAM 
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTA));
         ret = SetWindowTextA(hdlg, testtext);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         SetPropA(hdlg, "test_mode", ULongToHandle(DLGPROCTEXT_SETTEXTW));
         ret = SetWindowTextW(hdlg, testtextW);
-    todo_wine
+        todo_wine
         ok(ret, "Failed to set window text.\n");
 
         memset(buff, 'A', sizeof(buff));

--- a/modules/rostests/winetests/user32/listbox.c
+++ b/modules/rostests/winetests/user32/listbox.c
@@ -1952,7 +1952,7 @@ static void test_GetListBoxInfo(void)
     lb_getlistboxinfo = 0;
     ret = pGetListBoxInfo(listbox);
     ok(ret > 0, "got %d\n", ret);
-todo_wine
+    todo_wine
     ok(lb_getlistboxinfo == 0, "got %d\n", lb_getlistboxinfo);
 
     DestroyWindow(listbox);

--- a/modules/rostests/winetests/user32/msg.c
+++ b/modules/rostests/winetests/user32/msg.c
@@ -7053,8 +7053,8 @@ static void test_autoradio_kbd_move(void)
     ret = IsDialogMessageA(parent, &msg);
     ok(ret, "IsDialogMessage should return TRUE\n");
     while (PeekMessageA(&msg, 0, 0, 0, PM_REMOVE)) DispatchMessageA(&msg);
-if (0) /* actual message sequence is different on every run in some Windows setups */
-    ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #1", FALSE);
+    if (0) /* actual message sequence is different on every run in some Windows setups */
+        ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #1", FALSE);
     /* what really matters is that nothing has changed */
     test_radio(radio1, 1, radio2, 1, radio3, 1);
 
@@ -7067,8 +7067,8 @@ if (0) /* actual message sequence is different on every run in some Windows setu
     ret = IsDialogMessageA(parent, &msg);
     ok(ret, "IsDialogMessage should return TRUE\n");
     while (PeekMessageA(&msg, 0, 0, 0, PM_REMOVE)) DispatchMessageA(&msg);
-if (0) /* actual message sequence is different on every run in some Windows setups */
-    ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #2", FALSE);
+    if (0) /* actual message sequence is different on every run in some Windows setups */
+        ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #2", FALSE);
     /* what really matters is that nothing has changed */
     test_radio(radio1, 0, radio2, 1, radio3, 1);
 
@@ -7143,8 +7143,8 @@ if (0) /* actual message sequence is different on every run in some Windows setu
     ret = IsDialogMessageA(parent, &msg);
     ok(ret, "IsDialogMessage should return TRUE\n");
     while (PeekMessageA(&msg, 0, 0, 0, PM_REMOVE)) DispatchMessageA(&msg);
-if (0) /* actual message sequence is different on every run in some Windows setups */
-    ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #3", FALSE);
+    if (0) /* actual message sequence is different on every run in some Windows setups */
+        ok_sequence(auto_radio_button_VK_UP_dialog, "IsDialogMessage(VK_UP) #3", FALSE);
     /* what really matters is that nothing has changed */
     test_radio(radio1, 1, radio2, 0, radio3, 0);
 
@@ -10284,8 +10284,8 @@ static void test_timers(void)
     start = GetTickCount();
     while (GetTickCount()-start < 1001 && GetMessageA(&msg, info.hWnd, 0, 0))
         DispatchMessageA(&msg);
-ros_skip_flaky
-todo_wine
+    ros_skip_flaky
+    todo_wine
     ok(abs(count-TIMER_COUNT_EXPECTED) < TIMER_COUNT_TOLERANCE /* xp */
        || broken(abs(count-64) < TIMER_COUNT_TOLERANCE) /* most common */
        || broken(abs(count-43) < TIMER_COUNT_TOLERANCE) /* w2k3, win8 */,
@@ -10356,7 +10356,7 @@ static void test_timers_no_wnd(void)
     start = GetTickCount();
     while (GetTickCount()-start < 1001 && GetMessageA(&msg, NULL, 0, 0))
         DispatchMessageA(&msg);
-todo_wine
+    todo_wine
     ok(abs(count-TIMER_COUNT_EXPECTED) < TIMER_COUNT_TOLERANCE /* xp */
        || broken(abs(count-64) < TIMER_COUNT_TOLERANCE) /* most common */,
        "did not get expected count for minimum timeout (%d != ~%d).\n",
@@ -17038,7 +17038,7 @@ static void test_SetFocus(void)
 
     SetLastError(0xdeadbeef);
     old_active = SetActiveWindow(GetDesktopWindow());
-todo_wine
+    todo_wine
     ok(GetLastError() == 0xdeadbeef, "expected 0xdeadbeef, got %d\n", GetLastError());
     while (PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE)) DispatchMessageA(&msg);
     ok_sequence(WmEmptySeq, "SetActiveWindow on a desktop window", TRUE);
@@ -17048,7 +17048,7 @@ todo_wine
 
     SetLastError(0xdeadbeef);
     old_active = SetActiveWindow(wnd_event.hwnd);
-todo_wine
+    todo_wine
     ok(GetLastError() == 0xdeadbeef, "expected 0xdeadbeef, got %d\n", GetLastError());
     while (PeekMessageA(&msg, NULL, 0, 0, PM_REMOVE)) DispatchMessageA(&msg);
     ok_sequence(WmEmptySeq, "SetActiveWindow on another thread window", TRUE);
@@ -17111,7 +17111,7 @@ todo_wine
 
     SetLastError(0xdeadbeef);
     old_focus = SetFocus(child);
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_INVALID_PARAMETER /* Vista+ */ ||
        broken(GetLastError() == 0) /* XP */ ||
        broken(GetLastError() == 0xdeadbeef), "expected ERROR_INVALID_PARAMETER, got %d\n", GetLastError());
@@ -17561,7 +17561,7 @@ static void test_SendMessage_other_thread(int thread_n)
 
     ret = GetQueueStatus(QS_SENDMESSAGE|QS_POSTMESSAGE);
     /* FIXME: remove once Wine is fixed */
-todo_wine_if (thread_n == 2)
+    todo_wine_if (thread_n == 2)
     ok(ret == 0, "wrong status %08x\n", ret);
 
     trace("main: call PeekMessage\n");

--- a/modules/rostests/winetests/user32/win.c
+++ b/modules/rostests/winetests/user32/win.c
@@ -2248,7 +2248,7 @@ static void test_mdi(void)
         if (style[i] & (WS_HSCROLL | WS_VSCROLL))
         {
             ok(ret, "style %#x: GetScrollInfo(SB_HORZ) failed\n", style[i]);
-todo_wine
+            todo_wine
             ok(si.nPage != 0, "expected !0\n");
             ok(si.nPos == 0, "expected 0\n");
             ok(si.nTrackPos == 0, "expected 0\n");
@@ -2262,7 +2262,7 @@ todo_wine
         if (style[i] & (WS_HSCROLL | WS_VSCROLL))
         {
             ok(ret, "style %#x: GetScrollInfo(SB_VERT) failed\n", style[i]);
-todo_wine
+            todo_wine
             ok(si.nPage != 0, "expected !0\n");
             ok(si.nPos == 0, "expected 0\n");
             ok(si.nTrackPos == 0, "expected 0\n");
@@ -3031,7 +3031,7 @@ static void test_SetFocus(HWND hwnd)
     ok( GetActiveWindow() == hwnd, "parent window %p should be active\n", hwnd);
     ShowWindow(hwnd, SW_SHOWMINIMIZED);
     ok( GetActiveWindow() == hwnd, "parent window %p should be active\n", hwnd);
-todo_wine
+    todo_wine
     ok( GetFocus() != child, "Focus should not be on child %p\n", child );
     ok( GetFocus() != hwnd, "Focus should not be on parent %p\n", hwnd );
     ShowWindow(hwnd, SW_RESTORE);
@@ -3040,12 +3040,12 @@ todo_wine
     ShowWindow(hwnd, SW_SHOWMINIMIZED);
     ok( GetActiveWindow() == hwnd, "parent window %p should be active\n", hwnd);
     ok( GetFocus() != child, "Focus should not be on child %p\n", child );
-todo_wine
+    todo_wine
     ok( GetFocus() != hwnd, "Focus should not be on parent %p\n", hwnd );
     old_wnd_proc = (WNDPROC)SetWindowLongPtrA(hwnd, GWLP_WNDPROC, (LONG_PTR)set_focus_on_activate_proc);
     ShowWindow(hwnd, SW_RESTORE);
     ok( GetActiveWindow() == hwnd, "parent window %p should be active\n", hwnd);
-todo_wine
+    todo_wine
     ok( GetFocus() == child, "Focus should be on child %p, not %p\n", child, GetFocus() );
     SetWindowLongPtrA(hwnd, GWLP_WNDPROC, (LONG_PTR)old_wnd_proc);
 
@@ -8290,10 +8290,10 @@ static void test_child_window_from_point(void)
 
     ok(!found_invisible, "found %d invisible windows\n", found_invisible);
     ok(found_disabled, "found %d disabled windows\n", found_disabled);
-todo_wine
+    todo_wine
     ok(found_groupbox == 4, "found %d groupbox windows\n", found_groupbox);
     ok(found_httransparent, "found %d httransparent windows\n", found_httransparent);
-todo_wine
+    todo_wine
     ok(found_extransparent, "found %d extransparent windows\n", found_extransparent);
 
     ret = UnregisterClassA("my_button", cls.hInstance);
@@ -8734,7 +8734,7 @@ static void test_update_region(void)
             rc.right + wnd_orig.x, rc.bottom + wnd_orig.y);
     CombineRgn(rgn1, rgn1, rgn2, RGN_OR);
     GetUpdateRgn(parent, rgn2, FALSE);
-todo_wine
+    todo_wine
     ok(EqualRgn(rgn1, rgn2), "wrong update region\n");
 
     /* hwnd has the same invalid region as before moving */
@@ -8746,7 +8746,7 @@ todo_wine
     SetRectRgn(rgn1, rc.left - child_orig.x , rc.top - child_orig.y,
             rc.right - child_orig.x, rc.bottom - child_orig.y);
     GetUpdateRgn(child, rgn2, FALSE);
-todo_wine
+    todo_wine
     ok(EqualRgn(rgn1, rgn2), "wrong update region\n");
 
     DeleteObject(rgn1);
@@ -9380,12 +9380,12 @@ static void test_deferwindowpos(void)
     ok(!ret, "got %d\n", ret);
 
     hdwp2 = DeferWindowPos(NULL, NULL, NULL, 0, 0, 10, 10, 0);
-todo_wine
+    todo_wine
     ok(hdwp2 == NULL && ((GetLastError() == ERROR_INVALID_DWP_HANDLE) ||
         broken(GetLastError() == ERROR_INVALID_WINDOW_HANDLE) /* before win8 */), "got %p, error %d\n", hdwp2, GetLastError());
 
     hdwp2 = DeferWindowPos((HDWP)0xdead, GetDesktopWindow(), NULL, 0, 0, 10, 10, 0);
-todo_wine
+    todo_wine
     ok(hdwp2 == NULL && ((GetLastError() == ERROR_INVALID_DWP_HANDLE) ||
         broken(GetLastError() == ERROR_INVALID_WINDOW_HANDLE) /* before win8 */), "got %p, error %d\n", hdwp2, GetLastError());
 

--- a/modules/rostests/winetests/user32/winstation.c
+++ b/modules/rostests/winetests/user32/winstation.c
@@ -623,7 +623,7 @@ static void test_inputdesktop(void)
         win_skip("Skip tests on NT4\n");
         return;
     }
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_ACCESS_DENIED, "unexpected last error %08x\n", GetLastError());
     ok(ret == 1 || broken(ret == 0) /* Win64 */, "unexpected return count %d\n", ret);
 
@@ -664,14 +664,14 @@ todo_wine
     memset(name, 0, sizeof(name));
     ret = GetUserObjectInformationA(input_desk, UOI_NAME, name, 1024, NULL);
     ok(ret, "GetUserObjectInformation failed!\n");
-todo_wine
+    todo_wine
     ok(!strcmp(name, "new_desk"), "unexpected desktop %s\n", name);
     ret = CloseDesktop(input_desk);
     ok(ret, "CloseDesktop failed!\n");
 
     SetLastError(0xdeadbeef);
     ret = SendInput(1, inputs, sizeof(INPUT));
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_ACCESS_DENIED, "unexpected last error %08x\n", GetLastError());
     ok(ret == 1 || broken(ret == 0) /* Win64 */, "unexpected return count %d\n", ret);
 
@@ -769,16 +769,16 @@ static void test_inputdesktop2(void)
     ok(hdesk != NULL, "OpenDesktop failed!\n");
     SetLastError(0xdeadbeef);
     ret = SwitchDesktop(hdesk);
-todo_wine
+    todo_wine
     ok(!ret, "Switch to desktop belong to non default winstation should fail!\n");
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_ACCESS_DENIED || broken(GetLastError() == 0xdeadbeef), "last error %08x\n", GetLastError());
     ret = SetThreadDesktop(hdesk);
     ok(ret, "SetThreadDesktop failed!\n");
 
     /* clean side effect */
     ret = SetThreadDesktop(thread_desk);
-todo_wine
+    todo_wine
     ok(ret, "SetThreadDesktop should success even desktop is not belong to process winstation!\n");
     ret = SetProcessWindowStation(w1);
     ok(ret, "SetProcessWindowStation failed!\n");

--- a/modules/rostests/winetests/uxtheme/system.c
+++ b/modules/rostests/winetests/uxtheme/system.c
@@ -106,7 +106,7 @@ static void test_SetWindowTheme(void)
     HWND    hWnd;
 
     hRes = SetWindowTheme(NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok( hRes == E_HANDLE, "Expected E_HANDLE, got 0x%08x\n", hRes);
 
     /* Only do the bare minimum to get a valid hwnd */
@@ -619,11 +619,11 @@ static void test_buffered_paint(void)
 
     /* clearing */
     hr = pBufferedPaintClear(NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == E_FAIL, "Unexpected return code %#x\n", hr);
 
     hr = pBufferedPaintClear(buffer, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "Unexpected return code %#x\n", hr);
 
     /* access buffer attributes */

--- a/modules/rostests/winetests/wbemprox/query.c
+++ b/modules/rostests/winetests/wbemprox/query.c
@@ -1061,7 +1061,7 @@ static void test_query_semisync( IWbemServices *services )
     count = 1;
     obj = (void *)0xdeadbeef;
     hr = IEnumWbemClassObject_Next( result, -1, 1, &obj, &count );
-todo_wine
+    todo_wine
     ok( hr == WBEM_E_INVALID_CLASS, "Unexpected hr %#x.\n", hr );
     ok( count == 0, "Unexpected count %u.\n", count );
     ok( obj == (void *)0xdeadbeef, "Got object %p\n", obj );

--- a/modules/rostests/winetests/windowscodecs/bitmap.c
+++ b/modules/rostests/winetests/windowscodecs/bitmap.c
@@ -869,7 +869,7 @@ static void test_CreateBitmapFromHBITMAP(void)
     ok(hr == S_OK, "CreateBitmapFromHBITMAP error %#x\n", hr);
 
     IWICBitmap_GetPixelFormat(bitmap, &format);
-todo_wine
+    todo_wine
     ok(IsEqualGUID(&format, &GUID_WICPixelFormat4bppIndexed),
        "unexpected pixel format %s\n", wine_dbgstr_guid(&format));
 
@@ -889,7 +889,7 @@ todo_wine
 
     hr = IWICPalette_GetColorCount(palette, &count);
     ok(hr == S_OK, "GetColorCount error %#x\n", hr);
-todo_wine
+    todo_wine
     ok(count == 16, "expected 16, got %u\n", count);
 
     IWICPalette_Release(palette);

--- a/modules/rostests/winetests/windowscodecs/converter.c
+++ b/modules/rostests/winetests/windowscodecs/converter.c
@@ -1213,7 +1213,7 @@ static void test_set_frame_palette(IWICBitmapFrameEncode *frameencode)
     ok(hr == S_OK, "CreatePalette failed, hr=%x\n", hr);
 
     hr = IWICBitmapFrameEncode_SetPalette(frameencode, palette);
-todo_wine
+    todo_wine
     ok(hr == WINCODEC_ERR_NOTINITIALIZED, "Unexpected hr=%x\n", hr);
 
     hr = IWICPalette_InitializePredefined(palette, WICBitmapPaletteTypeFixedHalftone256, FALSE);

--- a/modules/rostests/winetests/windowscodecs/icoformat.c
+++ b/modules/rostests/winetests/windowscodecs/icoformat.c
@@ -164,7 +164,7 @@ static void test_ico_data_(void *data, DWORD data_size, HRESULT init_hr, int tod
         {
             hr = IWICBitmapDecoder_Initialize(decoder, (IStream*)icostream,
                 WICDecodeMetadataCacheOnDemand);
-        todo_wine_if(todo)
+            todo_wine_if(todo)
             ok_(__FILE__, line)(hr == init_hr, "Initialize failed, hr=%x\n", hr);
 
             if (SUCCEEDED(hr))

--- a/modules/rostests/winetests/windowscodecs/info.c
+++ b/modules/rostests/winetests/windowscodecs/info.c
@@ -171,7 +171,7 @@ static void test_decoder_info(void)
         len = 0;
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, 1, NULL, &len);
         ok(hr == E_INVALIDARG, "GetMimeType failed, hr=%x\n", hr);
-    todo_wine_if(test->todo)
+        todo_wine_if(test->todo)
         ok(len == lstrlenW(mimetypeW) + 1, "GetMimeType returned wrong len %i\n", len);
 
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, len, value, NULL);
@@ -180,27 +180,27 @@ static void test_decoder_info(void)
         len = 0;
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, 0, NULL, &len);
         ok(hr == S_OK, "GetMimeType failed, hr=%x\n", hr);
-    todo_wine_if(test->todo)
+        todo_wine_if(test->todo)
         ok(len == lstrlenW(mimetypeW) + 1, "GetMimeType returned wrong len %i\n", len);
 
         value[0] = 0;
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, len, value, &len);
         ok(hr == S_OK, "GetMimeType failed, hr=%x\n", hr);
-    todo_wine_if(test->todo) {
+        todo_wine_if(test->todo) {
         ok(lstrcmpW(value, mimetypeW) == 0, "GetMimeType returned wrong value %s\n", wine_dbgstr_w(value));
         ok(len == lstrlenW(mimetypeW) + 1, "GetMimeType returned wrong len %i\n", len);
-    }
+        }
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, 1, value, &len);
         ok(hr == WINCODEC_ERR_INSUFFICIENTBUFFER, "GetMimeType failed, hr=%x\n", hr);
-    todo_wine_if(test->todo)
+        todo_wine_if(test->todo)
         ok(len == lstrlenW(mimetypeW) + 1, "GetMimeType returned wrong len %i\n", len);
 
         hr = IWICBitmapDecoderInfo_GetMimeTypes(decoder_info, 256, value, &len);
         ok(hr == S_OK, "GetMimeType failed, hr=%x\n", hr);
-    todo_wine_if(test->todo) {
+        todo_wine_if(test->todo) {
         ok(lstrcmpW(value, mimetypeW) == 0, "GetMimeType returned wrong value %s\n", wine_dbgstr_w(value));
         ok(len == lstrlenW(mimetypeW) + 1, "GetMimeType returned wrong len %i\n", len);
-    }
+        }
         num_formats = 0xdeadbeef;
         hr = IWICBitmapDecoderInfo_GetPixelFormats(decoder_info, 0, NULL, &num_formats);
         ok(hr == S_OK, "GetPixelFormats failed, hr=%x\n", hr);
@@ -244,7 +244,7 @@ static void test_decoder_info(void)
 
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, 1, NULL, &len);
         ok(hr == E_INVALIDARG, "GetFileExtensions failed, hr=%x\n", hr);
-    todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
+        todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
         ok(len == lstrlenW(extensionsW) + 1, "%u: GetFileExtensions returned wrong len %i\n", i, len);
 
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, len, value, NULL);
@@ -252,27 +252,27 @@ static void test_decoder_info(void)
 
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, 0, NULL, &len);
         ok(hr == S_OK, "GetFileExtensions failed, hr=%x\n", hr);
-    todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
+        todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
         ok(len == lstrlenW(extensionsW) + 1, "GetFileExtensions returned wrong len %i\n", len);
 
         value[0] = 0;
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, len, value, &len);
         ok(hr == S_OK, "GetFileExtensions failed, hr=%x\n", hr);
-    todo_wine_if(test->todo)
+        todo_wine_if(test->todo)
         ok(lstrcmpW(value, extensionsW) == 0, "GetFileExtensions returned wrong value %s\n", wine_dbgstr_w(value));
-    todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
+        todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
         ok(len == lstrlenW(extensionsW) + 1, "GetFileExtensions returned wrong len %i\n", len);
 
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, 1, value, &len);
         ok(hr == WINCODEC_ERR_INSUFFICIENTBUFFER, "GetFileExtensions failed, hr=%x\n", hr);
-    todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
+        todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
         ok(len == lstrlenW(extensionsW) + 1, "GetFileExtensions returned wrong len %i\n", len);
 
         hr = IWICBitmapDecoderInfo_GetFileExtensions(decoder_info, 256, value, &len);
         ok(hr == S_OK, "GetFileExtensions failed, hr=%x\n", hr);
-    todo_wine_if(test->todo)
+        todo_wine_if(test->todo)
         ok(lstrcmpW(value, extensionsW) == 0, "GetFileExtensions returned wrong value %s\n", wine_dbgstr_w(value));
-    todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
+        todo_wine_if(test->todo && !IsEqualCLSID(test->clsid, &CLSID_WICTiffDecoder))
         ok(len == lstrlenW(extensionsW) + 1, "GetFileExtensions returned wrong len %i\n", len);
 
         IWICBitmapDecoderInfo_Release(decoder_info);
@@ -553,7 +553,7 @@ static void test_reader_info(void)
     IWICComponentInfo_Release(info);
 
     hr = IWICImagingFactory_CreateComponentInfo(factory, &CLSID_WICXMPStructMetadataReader, &info);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "CreateComponentInfo failed, hr=%x\n", hr);
 
     if (FAILED(hr))

--- a/modules/rostests/winetests/windowscodecs/pngformat.c
+++ b/modules/rostests/winetests/windowscodecs/pngformat.c
@@ -815,7 +815,7 @@ static void test_color_formats(void)
         if (!is_valid_png_type_depth(td[i].color_type, td[i].bit_depth, TRUE))
             ok(hr == WINCODEC_ERR_UNKNOWNIMAGEFORMAT, "%d: wrong error %#x\n", i, hr);
         else
-todo_wine_if(td[i].todo_load)
+            todo_wine_if(td[i].todo_load)
             ok(hr == S_OK, "%d: Failed to load PNG image data (type %d, bpp %d) %#x\n", i, td[i].color_type, td[i].bit_depth, hr);
         if (hr != S_OK) goto next_1;
 
@@ -824,7 +824,7 @@ todo_wine_if(td[i].todo_load)
 
         hr = IWICBitmapFrameDecode_GetPixelFormat(frame, &format);
         ok(hr == S_OK, "GetPixelFormat error %#x\n", hr);
-todo_wine_if(td[i].todo)
+        todo_wine_if(td[i].todo)
         ok(IsEqualGUID(&format, td[i].format_PLTE_tRNS),
            "PLTE+tRNS: expected %s, got %s (type %d, bpp %d)\n",
             wine_dbgstr_guid(td[i].format_PLTE_tRNS), wine_dbgstr_guid(&format), td[i].color_type, td[i].bit_depth);
@@ -843,7 +843,7 @@ next_1:
         if (!is_valid_png_type_depth(td[i].color_type, td[i].bit_depth, TRUE))
             ok(hr == WINCODEC_ERR_UNKNOWNIMAGEFORMAT, "%d: wrong error %#x\n", i, hr);
         else
-todo_wine_if(td[i].todo_load)
+            todo_wine_if(td[i].todo_load)
             ok(hr == S_OK, "%d: Failed to load PNG image data (type %d, bpp %d) %#x\n", i, td[i].color_type, td[i].bit_depth, hr);
         if (hr != S_OK) goto next_2;
 
@@ -871,7 +871,7 @@ next_2:
         if (!is_valid_png_type_depth(td[i].color_type, td[i].bit_depth, FALSE))
             ok(hr == WINCODEC_ERR_UNKNOWNIMAGEFORMAT, "%d: wrong error %#x\n", i, hr);
         else
-todo_wine_if(td[i].todo_load)
+            todo_wine_if(td[i].todo_load)
             ok(hr == S_OK, "%d: Failed to load PNG image data (type %d, bpp %d) %#x\n", i, td[i].color_type, td[i].bit_depth, hr);
         if (hr != S_OK) goto next_3;
 
@@ -898,7 +898,7 @@ next_3:
         if (!is_valid_png_type_depth(td[i].color_type, td[i].bit_depth, FALSE))
             ok(hr == WINCODEC_ERR_UNKNOWNIMAGEFORMAT, "%d: wrong error %#x\n", i, hr);
         else
-todo_wine_if(td[i].todo_load)
+            todo_wine_if(td[i].todo_load)
             ok(hr == S_OK, "%d: Failed to load PNG image data (type %d, bpp %d) %#x\n", i, td[i].color_type, td[i].bit_depth, hr);
         if (hr != S_OK) continue;
 
@@ -907,7 +907,7 @@ todo_wine_if(td[i].todo_load)
 
         hr = IWICBitmapFrameDecode_GetPixelFormat(frame, &format);
         ok(hr == S_OK, "GetPixelFormat error %#x\n", hr);
-todo_wine_if(td[i].todo)
+        todo_wine_if(td[i].todo)
         ok(IsEqualGUID(&format, td[i].format_PLTE_tRNS),
            "tRNS: expected %s, got %s (type %d, bpp %d)\n",
             wine_dbgstr_guid(td[i].format_PLTE_tRNS), wine_dbgstr_guid(&format), td[i].color_type, td[i].bit_depth);

--- a/modules/rostests/winetests/windowscodecs/tiffformat.c
+++ b/modules/rostests/winetests/windowscodecs/tiffformat.c
@@ -553,7 +553,7 @@ static void test_QueryCapability(void)
     IWICBitmapDecoder_Release(decoder);
 
     hr = IWICImagingFactory_CreateDecoderFromStream(factory, stream, NULL, 0, &decoder);
-todo_wine
+    todo_wine
     ok(hr == WINCODEC_ERR_COMPONENTNOTFOUND, "expected WINCODEC_ERR_COMPONENTNOTFOUND, got %#x\n", hr);
 
     if (SUCCEEDED(hr))

--- a/modules/rostests/winetests/winhttp/winhttp.c
+++ b/modules/rostests/winetests/winhttp/winhttp.c
@@ -4487,7 +4487,7 @@ static void test_IWinHttpRequest_Invoke(void)
     VariantInit(&arg[2]);
     params.cArgs = 3;
     hr = IWinHttpRequest_Invoke(request, DISPID_HTTPREQUEST_OPTION, &IID_NULL, 0, DISPATCH_PROPERTYPUT, &params, &ret, NULL, &err);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "error %#x\n", hr);
 
     VariantInit(&arg[0]);
@@ -4532,7 +4532,7 @@ todo_wine
 
     params.cArgs = 2;
     hr = IWinHttpRequest_Invoke(request, DISPID_HTTPREQUEST_OPTION, &IID_NULL, 0, DISPATCH_PROPERTYGET, &params, NULL, NULL, NULL);
-todo_wine
+    todo_wine
     ok(hr == S_OK, "error %#x\n", hr);
 
     params.cArgs = 0;

--- a/modules/rostests/winetests/wininet/internet.c
+++ b/modules/rostests/winetests/wininet/internet.c
@@ -1610,7 +1610,7 @@ static void test_InternetGetConnectedStateExA(void)
     buffer[0] = 0;
     res = pInternetGetConnectedStateExA(&flags, buffer, sizeof(buffer), 0);
     trace("Internet Connection: Flags 0x%02x - Name '%s'\n", flags, buffer);
-todo_wine
+    todo_wine
     ok (flags & INTERNET_RAS_INSTALLED, "Missing RAS flag\n");
     if(!res) {
         win_skip("InternetGetConnectedStateExA tests require a valid connection\n");
@@ -1712,7 +1712,7 @@ static void test_InternetGetConnectedStateExW(void)
     buffer[0] = 0;
     res = pInternetGetConnectedStateExW(&flags, buffer, ARRAY_SIZE(buffer), 0);
     trace("Internet Connection: Flags 0x%02x - Name '%s'\n", flags, wine_dbgstr_w(buffer));
-todo_wine
+    todo_wine
     ok (flags & INTERNET_RAS_INSTALLED, "Missing RAS flag\n");
     if(!res) {
         win_skip("InternetGetConnectedStateExW tests require a valid connection\n");

--- a/modules/rostests/winetests/ws2_32/sock.c
+++ b/modules/rostests/winetests/ws2_32/sock.c
@@ -1544,7 +1544,7 @@ static void test_set_getsockopt(void)
     SetLastError(0xdeadbeef);
     i = 1234;
     err = setsockopt(s, SOL_SOCKET, SO_ERROR, (char *) &i, size);
-todo_wine
+    todo_wine
     ok( !err && !WSAGetLastError(),
         "got %d with %d (expected 0 with 0)\n",
         err, WSAGetLastError());
@@ -1552,18 +1552,18 @@ todo_wine
     SetLastError(0xdeadbeef);
     i = 4321;
     err = getsockopt(s, SOL_SOCKET, SO_ERROR, (char *) &i, &size);
-todo_wine
+    todo_wine
     ok( !err && !WSAGetLastError(),
         "got %d with %d (expected 0 with 0)\n",
         err, WSAGetLastError());
-todo_wine
+    todo_wine
     ok (i == 1234, "got %d (expected 1234)\n", i);
 
     /* Test invalid optlen */
     SetLastError(0xdeadbeef);
     size = 1;
     err = getsockopt(s, SOL_SOCKET, SO_ERROR, (char *) &i, &size);
-todo_wine
+    todo_wine
     ok( (err == SOCKET_ERROR) && (WSAGetLastError() == WSAEFAULT),
         "got %d with %d (expected SOCKET_ERROR with WSAEFAULT)\n",
         err, WSAGetLastError());
@@ -1574,7 +1574,7 @@ todo_wine
     size = sizeof(i);
     i = 1234;
     err = getsockopt(s, SOL_SOCKET, SO_ERROR, (char *) &i, &size);
-todo_wine
+    todo_wine
     ok( (err == SOCKET_ERROR) && (WSAGetLastError() == WSAENOTSOCK),
         "got %d with %d (expected SOCKET_ERROR with WSAENOTSOCK)\n",
         err, WSAGetLastError());
@@ -4105,7 +4105,7 @@ static void test_select(void)
     SetLastError(0xdeadbeef);
     ret = select(0, &readfds, NULL, &exceptfds, &select_timeout);
     ok(ret == SOCKET_ERROR, "expected -1, got %d\n", ret);
-todo_wine
+    todo_wine
     ok(GetLastError() == WSAENOTSOCK, "expected 10038, got %d\n", GetLastError());
     /* descriptor sets are unchanged */
     ok(readfds.fd_count == 2, "expected 2, got %d\n", readfds.fd_count);
@@ -4133,9 +4133,9 @@ todo_wine
     FD_SET(fdWrite, &exceptfds);
     SetLastError(0xdeadbeef);
     ret = select(0, NULL, NULL, &exceptfds, &select_timeout);
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "expected -1, got %d\n", ret);
-todo_wine
+    todo_wine
     ok(GetLastError() == WSAENOTSOCK, "expected 10038, got %d\n", GetLastError());
     WaitForSingleObject (thread_handle, 1000);
     closesocket(fdRead);
@@ -6674,7 +6674,7 @@ todo_wine {
     ret = pWSASendMsg(sock, &msg, 0, &bytesSent, NULL, NULL);
     ok(ret == SOCKET_ERROR, "WSASendMsg should have failed\n");
     err = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(err == WSAEINVAL, "expected 10014, got %d instead\n", err);
     closesocket(sock);
 }
@@ -7276,7 +7276,7 @@ static void test_WSAPoll(void)
     POLL_SET(fdWrite, POLLIN | POLLOUT);
     poll_timeout = 2000;
     ret = pWSAPoll(fds, ix, poll_timeout);
-todo_wine
+    todo_wine
     ok(ret == 0, "expected 0, got %d\n", ret);
     len = sizeof(id);
     id = 0xdeadbeef;
@@ -7298,7 +7298,7 @@ todo_wine
     POLL_SET(fdWrite, POLLIN | POLLOUT);
     ret = pWSAPoll(fds, ix, poll_timeout);
     ok(ret == 1, "expected 1, got %d\n", ret);
-todo_wine
+    todo_wine
     ok(POLL_ISSET(fdWrite, POLLWRNORM | POLLHUP) || broken(POLL_ISSET(fdWrite, POLLWRNORM)) /* <= 2008 */,
        "fdWrite socket events incorrect\n");
     closesocket(fdWrite);
@@ -8307,7 +8307,7 @@ static void test_AcceptEx(void)
     bret = pAcceptEx(listener, acceptor, buffer, sizeof(buffer) - 2*(sizeof(struct sockaddr_in) + 16),
         sizeof(struct sockaddr_in) + 16, sizeof(struct sockaddr_in) + 16,
         &bytesReturned, &overlapped);
-todo_wine
+    todo_wine
     ok(bret == FALSE && WSAGetLastError() == WSAEINVAL, "AcceptEx on a non-listening socket "
         "returned %d + errno %d\n", bret, WSAGetLastError());
 
@@ -9443,7 +9443,7 @@ static void test_sioAddressListChange(void)
     ok(ret == WAIT_OBJECT_0, "failed to get overlapped event %u\n", ret);
 
     ret = WaitForSingleObject(event2, 500);
-todo_wine
+    todo_wine
     ok(ret == WAIT_OBJECT_0, "failed to get change event %u\n", ret);
 
     ret = WaitForSingleObject(event3, 500);
@@ -10606,19 +10606,19 @@ static void test_WSALookupService(void)
     ret = pWSALookupServiceBeginW(NULL, 0, &hnd);
     error = WSAGetLastError();
     ok(ret == SOCKET_ERROR, "WSALookupServiceBeginW should have failed\n");
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "expected 10014, got %d\n", error);
 
     ret = pWSALookupServiceBeginW(qs, 0, NULL);
     error = WSAGetLastError();
     ok(ret == SOCKET_ERROR, "WSALookupServiceBeginW should have failed\n");
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "expected 10014, got %d\n", error);
 
     ret = pWSALookupServiceBeginW(qs, 0, &hnd);
     error = WSAGetLastError();
     ok(ret == SOCKET_ERROR, "WSALookupServiceBeginW should have failed\n");
-todo_wine
+    todo_wine
     ok(error == WSAEINVAL
        || broken(error == ERROR_INVALID_PARAMETER) /* == XP */
        || broken(error == WSAEFAULT) /* == NT */
@@ -10627,9 +10627,9 @@ todo_wine
 
     ret = pWSALookupServiceEnd(NULL);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "WSALookupServiceEnd should have failed\n");
-todo_wine
+    todo_wine
     ok(error == ERROR_INVALID_HANDLE, "expected 6, got %d\n", error);
 
     /* standard network list query */
@@ -10643,9 +10643,9 @@ todo_wine
         return;
     }
 
-todo_wine
+    todo_wine
     ok(!ret, "WSALookupServiceBeginW failed unexpectedly with error %d\n", error);
-todo_wine
+    todo_wine
     ok(hnd != (HANDLE)0xdeadbeef, "Handle was not filled\n");
 
     offset = 0;
@@ -10758,34 +10758,34 @@ static void test_WSAEnumNameSpaceProvidersA(void)
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersA(&blen, name);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     /* Invalid parameter tests */
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersA(NULL, name);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersA(NULL, NULL);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersA(&blen, NULL);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
 #ifdef __REACTOS__ /* ROSTESTS-233 */
@@ -10804,7 +10804,7 @@ todo_wine
     }
 
     ret = pWSAEnumNameSpaceProvidersA(&blen, name);
-todo_wine
+    todo_wine
     ok(ret > 0, "Expected more than zero name space providers\n");
 
     for (i = 0;i < ret; i++)
@@ -10843,34 +10843,34 @@ static void test_WSAEnumNameSpaceProvidersW(void)
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersW(&blen, name);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     /* Invalid parameter tests */
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersW(NULL, name);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersW(NULL, NULL);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
     SetLastError(0xdeadbeef);
     ret = pWSAEnumNameSpaceProvidersW(&blen, NULL);
     error = WSAGetLastError();
-todo_wine
+    todo_wine
     ok(ret == SOCKET_ERROR, "Expected failure, got %u\n", ret);
-todo_wine
+    todo_wine
     ok(error == WSAEFAULT, "Expected 10014, got %u\n", error);
 
 #ifdef __REACTOS__ /* ROSTESTS-233 */
@@ -10889,7 +10889,7 @@ todo_wine
     }
 
     ret = pWSAEnumNameSpaceProvidersW(&blen, name);
-todo_wine
+    todo_wine
     ok(ret > 0, "Expected more than zero name space providers\n");
 
     for (i = 0;i < ret; i++)
@@ -11112,7 +11112,7 @@ todo_wine
     SetLastError(0xdeadbeef);
     ret = GetQueuedCompletionStatus(port, &bytes, &key, &ovl_iocp, 100);
     ok(!ret, "got %d\n", ret);
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_CONNECTION_ABORTED || GetLastError() == ERROR_NETNAME_DELETED /* XP */, "got %u\n", GetLastError());
     ok(!bytes, "got bytes %u\n", bytes);
     ok(key == 0x12345678, "got key %#lx\n", key);
@@ -11120,7 +11120,7 @@ todo_wine
     if (ovl_iocp)
     {
         ok(!ovl_iocp->InternalHigh, "got %#lx\n", ovl_iocp->InternalHigh);
-todo_wine
+        todo_wine
         ok(ovl_iocp->Internal == (ULONG)STATUS_CONNECTION_ABORTED || ovl_iocp->Internal == (ULONG)STATUS_LOCAL_DISCONNECT /* XP */, "got %#lx\n", ovl_iocp->Internal);
     }
 
@@ -11351,7 +11351,7 @@ static void iocp_async_read_thread_closesocket(SOCKET src)
     SetLastError(0xdeadbeef);
     ret = GetQueuedCompletionStatus(port, &bytes, &key, &ovl_iocp, 100);
     ok(!ret, "got %d\n", ret);
-todo_wine
+    todo_wine
     ok(GetLastError() == ERROR_CONNECTION_ABORTED || GetLastError() == ERROR_NETNAME_DELETED /* XP */, "got %u\n", GetLastError());
     ok(!bytes, "got bytes %u\n", bytes);
     ok(key == 0x12345678, "got key %#lx\n", key);
@@ -11359,7 +11359,7 @@ todo_wine
     if (ovl_iocp)
     {
         ok(!ovl_iocp->InternalHigh, "got %#lx\n", ovl_iocp->InternalHigh);
-todo_wine
+        todo_wine
         ok(ovl_iocp->Internal == (ULONG)STATUS_CONNECTION_ABORTED || ovl_iocp->Internal == (ULONG)STATUS_LOCAL_DISCONNECT /* XP */, "got %#lx\n", ovl_iocp->Internal);
     }
 

--- a/modules/rostests/winetests/xmllite/reader.c
+++ b/modules/rostests/winetests/xmllite/reader.c
@@ -818,16 +818,16 @@ if (0)
 
     nodetype = XmlNodeType_Element;
     hr = IXmlReader_Read(reader, &nodetype);
-todo_wine
+    todo_wine
     ok(FAILED(hr), "got %08x\n", hr);
     ok(nodetype == XmlNodeType_None, "Unexpected node type %d\n", nodetype);
 
-todo_wine
+    todo_wine
     TEST_READER_STATE(reader, XmlReadState_Error);
 
     nodetype = XmlNodeType_Element;
     hr = IXmlReader_Read(reader, &nodetype);
-todo_wine
+    todo_wine
     ok(FAILED(hr), "got %08x\n", hr);
     ok(nodetype == XmlNodeType_None, "Unexpected node type %d\n", nodetype);
 
@@ -1027,11 +1027,11 @@ todo_wine {
 
     type = -1;
     hr = IXmlReader_Read(reader, &type);
-todo_wine
+    todo_wine
     ok(hr == WC_E_SYNTAX || hr == WC_E_XMLCHARACTER /* XP */, "expected WC_E_SYNTAX, got %08x\n", hr);
     ok(type == XmlNodeType_None, "expected XmlNodeType_None, got %s\n", type_to_str(type));
     TEST_READER_POSITION(reader, 1, 41);
-todo_wine
+    todo_wine
     TEST_READER_STATE(reader, XmlReadState_Error);
 
     IStream_Release(stream);
@@ -1579,7 +1579,7 @@ static void test_read_pending(void)
     ok(hr == S_OK || broken(hr == E_PENDING), "got 0x%08x\n", hr);
     /* newer versions are happy when it's enough data to detect node type,
        older versions keep reading until it fails to read more */
-todo_wine
+    todo_wine
     ok(stream_readcall == 1 || broken(stream_readcall > 1), "got %d\n", stream_readcall);
     ok(type == XmlNodeType_Comment || broken(type == XmlNodeType_None), "got %d\n", type);
 

--- a/modules/rostests/winetests/xmllite/writer.c
+++ b/modules/rostests/winetests/xmllite/writer.c
@@ -439,7 +439,7 @@ static void test_writeroutput(void)
     unk = NULL;
     hr = IUnknown_QueryInterface(output, &IID_IXmlWriterOutput, (void**)&unk);
     ok(hr == S_OK, "got %08x\n", hr);
-todo_wine
+    todo_wine
     ok(unk != NULL && unk != output, "got %p, output %p\n", unk, output);
     EXPECT_REF(output, 2);
     /* releasing 'unk' crashes on native */
@@ -1699,8 +1699,8 @@ static void test_WriteAttributeString(void)
 
         hr = write_attribute_string(writer, attribute_tests[i].prefix, attribute_tests[i].local,
                 attribute_tests[i].uri, attribute_tests[i].value);
-    todo_wine_if(attribute_tests[i].todo_hr)
-        ok(hr == attribute_tests[i].hr, "%u: unexpected hr %#x, expected %#x.\n", i, hr, attribute_tests[i].hr);
+        todo_wine_if(attribute_tests[i].todo_hr)
+            ok(hr == attribute_tests[i].hr, "%u: unexpected hr %#x, expected %#x.\n", i, hr, attribute_tests[i].hr);
 
         hr = IXmlWriter_Flush(writer);
         ok(hr == S_OK, "Failed to flush, hr %#x.\n", hr);
@@ -1739,7 +1739,7 @@ static void test_WriteAttributeString(void)
     ok(hr == S_OK, "Failed to write attribute string, hr %#x.\n", hr);
 
     hr = write_attribute_string(writer, "prefix", "local", NULL, "b");
-todo_wine
+    todo_wine
     ok(hr == WR_E_DUPLICATEATTRIBUTE, "got 0x%08x\n", hr);
 
     hr = write_start_element(writer, NULL, "b", NULL);

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -45,8 +45,34 @@ add_compile_options(-pipe -fms-extensions -fno-strict-aliasing)
 # The case for C++ is handled through the reactos_c++ INTERFACE library
 add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:CXX>>:-nostdinc>")
 
+# GCC/CLang and above defaults to fno-common from version 10/11 onward. We are not ready for this now
+add_compile_options(-fcommon)
+
 if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-fno-aggressive-loop-optimizations)
+
+    if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9)
+        add_compile_options(-fno-builtin-floor)
+        add_compile_options(-fno-builtin-floorf)
+        add_compile_options(-fno-builtin-ceil)
+        add_compile_options(-fno-builtin-ceilf)
+        add_compile_options(-fno-builtin-sqrt)
+        add_compile_options(-fno-builtin-sqrtf)
+
+        add_compile_options(-fno-builtin-sin)
+        add_compile_options(-fno-builtin-cos)
+        add_compile_options(-fno-builtin-sinf)
+        add_compile_options(-fno-builtin-cosf)
+        add_compile_options(-fno-builtin-sincos)
+        add_compile_options(-fno-builtin-sincosf)
+
+        add_compile_options(-Wno-stringop-overread)
+        add_compile_options(-Wno-stringop-overflow)
+        add_compile_options(-Wno-array-bounds)
+        add_compile_options(-Wno-array-parameter)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-class-memaccess>)
+        add_compile_options($<$<COMPILE_LANGUAGE:CXX>:-Wno-class-conversion>)
+    endif()
     if (DBG)
         add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wold-style-declaration>")
     endif()
@@ -54,7 +80,6 @@ elseif(CMAKE_C_COMPILER_ID STREQUAL "Clang")
     add_compile_options("$<$<COMPILE_LANGUAGE:C>:-Wno-microsoft>")
     add_compile_options(-Wno-pragma-pack)
     add_compile_options(-fno-associative-math)
-    add_compile_options(-fcommon)
 
     if(CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0)
         # disable "libcall optimization"

--- a/sdk/lib/3rdparty/freetype/src/truetype/ttgload.c
+++ b/sdk/lib/3rdparty/freetype/src/truetype/ttgload.c
@@ -1512,17 +1512,17 @@
                        FT_UInt    recurse_count,
                        FT_Bool    header_only )
   {
-    FT_Error        error        = FT_Err_Ok;
-    FT_Fixed        x_scale, y_scale;
-    FT_ULong        offset;
-    TT_Face         face         = loader->face;
-    FT_GlyphLoader  gloader      = loader->gloader;
-    FT_Bool         opened_frame = 0;
+    FT_Error             error        = FT_Err_Ok;
+    FT_Fixed             x_scale, y_scale;
+    FT_ULong             offset;
+    TT_Face              face         = loader->face;
+    FT_GlyphLoader       gloader      = loader->gloader;
+    FT_Bool              opened_frame = 0;
 
 #ifdef FT_CONFIG_OPTION_INCREMENTAL
-    FT_StreamRec    inc_stream;
-    FT_Data         glyph_data;
-    FT_Bool         glyph_data_loaded = 0;
+    static FT_StreamRec  inc_stream;
+    FT_Data              glyph_data;
+    FT_Bool              glyph_data_loaded = 0;
 #endif
 
 

--- a/sdk/lib/3rdparty/freetype/src/truetype/ttgload.c
+++ b/sdk/lib/3rdparty/freetype/src/truetype/ttgload.c
@@ -1512,17 +1512,20 @@
                        FT_UInt    recurse_count,
                        FT_Bool    header_only )
   {
-    FT_Error             error        = FT_Err_Ok;
-    FT_Fixed             x_scale, y_scale;
-    FT_ULong             offset;
-    TT_Face              face         = loader->face;
-    FT_GlyphLoader       gloader      = loader->gloader;
-    FT_Bool              opened_frame = 0;
+    FT_Error        error        = FT_Err_Ok;
+    FT_Fixed        x_scale, y_scale;
+    FT_ULong        offset;
+    TT_Face         face         = loader->face;
+    FT_GlyphLoader  gloader      = loader->gloader;
+    FT_Bool         opened_frame = 0;
 
 #ifdef FT_CONFIG_OPTION_INCREMENTAL
-    static FT_StreamRec  inc_stream;
-    FT_Data              glyph_data;
-    FT_Bool              glyph_data_loaded = 0;
+#ifdef __REACTOS__ // fix -Wdangling-pointer
+    static
+#endif
+    FT_StreamRec    inc_stream;
+    FT_Data         glyph_data;
+    FT_Bool         glyph_data_loaded = 0;
 #endif
 
 

--- a/sdk/lib/crt/string/tcsnlen.h
+++ b/sdk/lib/crt/string/tcsnlen.h
@@ -4,11 +4,11 @@
 
 size_t __cdecl _tcsnlen(const _TCHAR * str, size_t count)
 {
- const _TCHAR * s;
+ const _TCHAR * s = str;
 
- if(str == 0) return 0;
+ if(s == 0) return 0;
 
- for(s = str; *s && count; ++ s, -- count);
+ while ( *s && count ) { ++ s, -- count; };
 
  return s - str;
 }

--- a/sdk/lib/fslib/vfatlib/CMakeLists.txt
+++ b/sdk/lib/fslib/vfatlib/CMakeLists.txt
@@ -17,3 +17,7 @@ list(APPEND SOURCE
 add_library(vfatlib ${SOURCE})
 add_dependencies(vfatlib xdk)
 add_pch(vfatlib vfatlib.h SOURCE)
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND (CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 9))
+    target_compile_options(vfatlib PRIVATE -Wno-address-of-packed-member)
+endif()


### PR DESCRIPTION
## Purpose

Futureproofing for migrations to future GCC versions. Not done yet, will need to fix a plethora of class, overflow, and etc. warnings ~~(p.s.: freeldr needs fixes from hbelusca)~~. Some changes I'm unsure about (dll/win32/crypt/store.c needs a static declaration in CRYPT_OpenParentStore for variable "base" to prevent -Wdangling-pointer, samething with MesaGL and FreeType), and the BTRFS/rosglue change is a temporary evil hack because GCC 11+ be damned for thinking that rand_s exists in XP.

D3D test fixes are merged from https://github.com/wine-mirror/wine/commit/3660176e09bc02e71586b4cf42f58c9498481af6, https://github.com/wine-mirror/wine/commit/71c6f5b1ca3f2528aabedf216e525c4526a3c337, https://github.com/wine-mirror/wine/commit/cee2d4c4c90887faa862f5d0dfc61e16312e9799, and https://github.com/wine-mirror/wine/commit/70c51f89bdcecd6119345038b8f33785aa465865.