### PR TITLE
[NTGDI] Check if face->charmap is not zero before accessing its encoding

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4501,6 +4501,8 @@ ftGetFontUnicodeRanges(PFONTGDI Font, PGLYPHSET glyphset)
     DWORD num_ranges = 0;
     FT_Face face = Font->SharedFace->Face;
 
+    if (!(face->charmap)) return 0;
+
     if (face->charmap->encoding == FT_ENCODING_UNICODE)
     {
         FT_UInt glyph_code = 0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4501,7 +4501,11 @@ ftGetFontUnicodeRanges(PFONTGDI Font, PGLYPHSET glyphset)
     DWORD num_ranges = 0;
     FT_Face face = Font->SharedFace->Face;
 
-    if (!(face->charmap)) return 0;
+    if (face->charmap == NULL)
+    {
+        DPRINT1("FIXME: No charmap selected! This is a BUG!\n");
+        return 0;
+    }
 
     if (face->charmap->encoding == FT_ENCODING_UNICODE)
     {


### PR DESCRIPTION
## Purpose

Attempting to start DevExpress Ribbon Notepad makes crash ReactOS due to null pointer access, after some investigation, I found that `(face->charmap)` might return 0 sometimes, and we are not making this check.

This allows DevExpress Ribbon Notepad sample to start.

JIRA issue: [CORE-18091](https://jira.reactos.org/browse/CORE-18091) [CORE-18558](https://jira.reactos.org/browse/CORE-18558)