### PR TITLE
[SDK][CRT] Add _CRT_NON_CONFORMING_SWPRINTFS support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,11 @@ include(sdk/cmake/config.cmake)
 # Compiler flags handling
 include(sdk/cmake/compilerflags.cmake)
 
-add_definitions(-D__REACTOS__)
+add_definitions(
+    -D__REACTOS__
+    # swprintf without count argument is used in most of the codebase
+    -D_CRT_NON_CONFORMING_SWPRINTFS
+)
 
 # There doesn't seem to be a standard for __FILE__ being relative or absolute, so detect it at runtime.
 file(RELATIVE_PATH _PATH_PREFIX ${REACTOS_BINARY_DIR} ${REACTOS_SOURCE_DIR})

--- a/modules/rostests/winetests/msvcrt/printf.c
+++ b/modules/rostests/winetests/msvcrt/printf.c
@@ -23,7 +23,9 @@
 /* With Visual Studio >= 2005,  swprintf() takes an extra parameter unless
  * the following macro is defined.
  */
+#ifndef _CRT_NON_CONFORMING_SWPRINTFS
 #define _CRT_NON_CONFORMING_SWPRINTFS
+#endif
 
 #include <stdio.h>
 #include <errno.h>

--- a/sdk/include/crt/stdio.h
+++ b/sdk/include/crt/stdio.h
@@ -885,6 +885,7 @@ extern _CRTIMP int _commode;
     _In_z_ _Printf_format_string_ const wchar_t *_Format,
     va_list _ArgList);
 
+#if defined __cplusplus || defined _CRT_NON_CONFORMING_SWPRINTFS
   _Check_return_opt_
   _CRTIMP
   int
@@ -901,6 +902,7 @@ extern _CRTIMP int _commode;
     _Out_ wchar_t*,
     const wchar_t*,
     va_list);
+#endif
 
   _Check_return_opt_
   _CRTIMP
@@ -948,15 +950,38 @@ extern _CRTIMP int _commode;
 #include <vadefs.h>
 #endif
 
-#if 0 //this is for MSVCRT80 and higher, which we don't use nor implement
-#ifdef _CRT_NON_CONFORMING_SWPRINTFS
-#ifndef __cplusplus
-#define swprintf _swprintf
-#define vswprintf _vswprintf
-#define _swprintf_l __swprintf_l
-#define _vswprintf_l __vswprintf_l
-#endif
-#endif
+#ifndef _CRT_NON_CONFORMING_SWPRINTFS
+  _Check_return_opt_
+  static inline
+  int
+  __cdecl
+  swprintf(
+      _Out_writes_z_(_SizeInWords) wchar_t* _DstBuf,
+      _In_ size_t _SizeInWords,
+      _In_z_ _Printf_format_string_ const wchar_t* _Format,
+      ...)
+  {
+      int ret;
+      va_list args;
+
+      va_start(args, _Format);
+      ret = _vsnwprintf(_DstBuf, _SizeInWords, _Format, args);
+      va_end(args);
+      return ret;
+  }
+
+  _Check_return_opt_
+  static inline
+  int
+  __cdecl
+  vswprintf(
+      _Out_writes_z_(_SizeInWords) wchar_t* _DstBuf,
+      _In_ size_t _SizeInWords,
+      _In_z_ _Printf_format_string_ const wchar_t* _Format,
+      va_list _ArgList)
+  {
+      return _vsnwprintf(_DstBuf, _SizeInWords, _Format, _ArgList);
+  }
 #endif
 
   _Check_return_

--- a/sdk/include/crt/wchar.h
+++ b/sdk/include/crt/wchar.h
@@ -1072,6 +1072,7 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
     _In_z_ _Printf_format_string_ const wchar_t *_Format,
     va_list _ArgList);
 
+#if defined __cplusplus || defined _CRT_NON_CONFORMING_SWPRINTFS
   _CRTIMP
   int
   __cdecl
@@ -1087,6 +1088,7 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
     _Out_ wchar_t*,
     const wchar_t*,
     va_list);
+#endif
 
   _Check_return_opt_
   _CRTIMP
@@ -1378,15 +1380,38 @@ _CRTIMP int __cdecl iswblank(wint_t _C);
   _CRTIMP int __cdecl __swprintf_l(wchar_t *_Dest,const wchar_t *_Format,_locale_t _Plocinfo,...);
   _CRTIMP int __cdecl __vswprintf_l(wchar_t *_Dest,const wchar_t *_Format,_locale_t _Plocinfo,va_list _Args);
 
-#if 0 //this is for MSVCRT80 and higher, which we don't use nor implement
-#ifdef _CRT_NON_CONFORMING_SWPRINTFS
-#ifndef __cplusplus
-#define swprintf _swprintf
-#define vswprintf _vswprintf
-#define _swprintf_l __swprintf_l
-#define _vswprintf_l __vswprintf_l
-#endif
-#endif
+#ifndef _CRT_NON_CONFORMING_SWPRINTFS
+  _Check_return_opt_
+  static inline
+  int
+  __cdecl
+  swprintf(
+      _Out_writes_z_(_SizeInWords) wchar_t* _DstBuf,
+      _In_ size_t _SizeInWords,
+      _In_z_ _Printf_format_string_ const wchar_t* _Format,
+      ...)
+  {
+      int ret;
+      va_list args;
+
+      va_start(args, _Format);
+      ret = _vsnwprintf(_DstBuf, _SizeInWords, _Format, args);
+      va_end(args);
+      return ret;
+  }
+
+  _Check_return_opt_
+  static inline
+  int
+  __cdecl
+  vswprintf(
+      _Out_writes_z_(_SizeInWords) wchar_t* _DstBuf,
+      _In_ size_t _SizeInWords,
+      _In_z_ _Printf_format_string_ const wchar_t* _Format,
+      va_list _ArgList)
+  {
+      return _vsnwprintf(_DstBuf, _SizeInWords, _Format, _ArgList);
+  }
 #endif
 
   _Check_return_


### PR DESCRIPTION
This allows us to easier port wine changes, where swprintf with a size is used a lot

