### PR TITLE
Fix last gdi32:GetObject testcase

### DIFF
--- a/win32ss/gdi/gdi32/objects/gdiobj.c
+++ b/win32ss/gdi/gdi32/objects/gdiobj.c
@@ -206,7 +206,7 @@ GetObjectW(
             break;
 
         case GDI_OBJECT_TYPE_BRUSH:
-            if (!lpBuffer || !cbSize) return sizeof(LOGBRUSH);
+            if (!lpBuffer) return sizeof(LOGBRUSH);
             break;
 
         case GDI_OBJECT_TYPE_BITMAP:


### PR DESCRIPTION
## Purpose

Fix latest gdi32:GetObject:
ok_long(GetObjectA(hBrush, 0, &TestStruct), 0);

https://git.reactos.org/?p=reactos.git;a=blob;hb=680f103f3d52bf46b41eb5249c17d097ac55a3c2;f=modules/rostests/apitests/gdi32/GetObject.c#l162

## Proposed changes

[gdiobj.c]
::GetObjectW::
- When "cbSize" is "0", GetObjectW shouldn't return "sizeof(LOGBRUSH)" but 0.

- Rely in BRUSH::cjGetObject behavior which returns 0 when cjSize is 0.
