### PR TITLE
[WINLOGON] Make PC Speaker "beep" similar to Windows 2003 one

### DIFF
--- a/base/system/winlogon/sas.c
+++ b/base/system/winlogon/sas.c
@@ -261,7 +261,7 @@ PlaySoundRoutine(
             {
                 if (!bLogon)
                 {
-                    Beep(500, 500);
+                    Beep(440, 125);
                 }
                 FreeLibrary(hLibrary);
                 return FALSE;


### PR DESCRIPTION
Changing this because the current beep might be annoying, specifically on real hardware with loud PC speaker and mostly because it's just too long. Win2k3 one is much shorter and a bit easier on ears (in my opinion).