### PR TITLE
[NTOS:LPC] Ensure debug-traced user-mode data passed by pointers is captured.

### DIFF
--- a/ntoskrnl/lpc/complete.c
+++ b/ntoskrnl/lpc/complete.c
@@ -59,6 +59,7 @@ NtAcceptConnectPort(OUT PHANDLE PortHandle,
     LARGE_INTEGER SectionOffset;
 
     PAGED_CODE();
+
     LPCTRACE(LPC_COMPLETE_DEBUG,
              "Context: %p. Message: %p. Accept: %lx. Views: %p/%p\n",
              PortContext,
@@ -306,10 +307,11 @@ NtAcceptConnectPort(OUT PHANDLE PortHandle,
             /* Otherwise, quit */
             ObDereferenceObject(ServerPort);
             DPRINT1("Client section mapping failed: %lx\n", Status);
-            DPRINT1("View base, offset, size: %p %lx %p\n",
-                    ServerPort->ClientSectionBase,
-                    ConnectMessage->ClientView.ViewSize,
-                    SectionOffset);
+            LPCTRACE(LPC_COMPLETE_DEBUG,
+                     "View base, offset, size: %p %lx %p\n",
+                     ServerPort->ClientSectionBase,
+                     ConnectMessage->ClientView.ViewSize,
+                     SectionOffset);
             goto Cleanup;
         }
     }

--- a/ntoskrnl/lpc/create.c
+++ b/ntoskrnl/lpc/create.c
@@ -50,11 +50,13 @@ LpcpCreatePort(OUT PHANDLE PortHandle,
     NTSTATUS Status;
     KPROCESSOR_MODE PreviousMode = KeGetPreviousMode();
     UNICODE_STRING CapturedObjectName, *ObjectName;
+#if DBG
+    UNICODE_STRING CapturedPortName;
+#endif
     PLPCP_PORT_OBJECT Port;
     HANDLE Handle;
 
     PAGED_CODE();
-    LPCTRACE(LPC_CREATE_DEBUG, "Name: %wZ\n", ObjectAttributes->ObjectName);
 
     RtlInitEmptyUnicodeString(&CapturedObjectName, NULL, 0);
 
@@ -70,10 +72,7 @@ LpcpCreatePort(OUT PHANDLE PortHandle,
             ProbeForRead(ObjectAttributes, sizeof(*ObjectAttributes), sizeof(ULONG));
             ObjectName = ((volatile OBJECT_ATTRIBUTES*)ObjectAttributes)->ObjectName;
             if (ObjectName)
-            {
-                ProbeForRead(ObjectName, sizeof(*ObjectName), 1);
-                CapturedObjectName = *(volatile UNICODE_STRING*)ObjectName;
-            }
+                CapturedObjectName = ProbeForReadUnicodeString(ObjectName);
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
@@ -88,9 +87,19 @@ LpcpCreatePort(OUT PHANDLE PortHandle,
             CapturedObjectName = *(ObjectAttributes->ObjectName);
     }
 
-    /* Normalize the buffer pointer in case we don't have a name */
+    /* Normalize the buffer pointer in case we don't have
+     * a name, for initializing an unconnected port. */
     if (CapturedObjectName.Length == 0)
         CapturedObjectName.Buffer = NULL;
+
+#if DBG
+    /* Capture the port name for DPRINT only - ObCreateObject does its
+     * own capture. As it is used only for debugging, ignore any failure;
+     * the string is zeroed out in such case. */
+    ProbeAndCaptureUnicodeString(&CapturedPortName, PreviousMode, &CapturedObjectName);
+    LPCTRACE(LPC_CREATE_DEBUG, "Name: %wZ\n", &CapturedPortName);
+    ReleaseCapturedUnicodeString(&CapturedPortName, PreviousMode);
+#endif
 
     /* Create the Object */
     Status = ObCreateObject(PreviousMode,

--- a/ntoskrnl/lpc/send.c
+++ b/ntoskrnl/lpc/send.c
@@ -449,11 +449,6 @@ NtRequestPort(IN HANDLE PortHandle,
     PLPCP_MESSAGE Message;
 
     PAGED_CODE();
-    LPCTRACE(LPC_SEND_DEBUG,
-             "Handle: %p. Message: %p. Type: %lx\n",
-             PortHandle,
-             LpcRequest,
-             LpcpGetMessageType(LpcRequest));
 
     /* Check if the call comes from user mode */
     if (PreviousMode != KernelMode)
@@ -475,6 +470,12 @@ NtRequestPort(IN HANDLE PortHandle,
         /* Access the LpcRequest directly */
         CapturedLpcRequest = *LpcRequest;
     }
+
+    LPCTRACE(LPC_SEND_DEBUG,
+             "Handle: %p. Message: %p. Type: %lx\n",
+             PortHandle,
+             LpcRequest,
+             LpcpGetMessageType(&CapturedLpcRequest));
 
     /* Get the message type */
     MessageType = CapturedLpcRequest.u2.s2.Type | LPC_DATAGRAM;
@@ -709,15 +710,10 @@ NtRequestWaitReplyPort(IN HANDLE PortHandle,
     PLPCP_DATA_INFO DataInfo;
 
     PAGED_CODE();
-    LPCTRACE(LPC_SEND_DEBUG,
-             "Handle: %p. Messages: %p/%p. Type: %lx\n",
-             PortHandle,
-             LpcRequest,
-             LpcReply,
-             LpcpGetMessageType(LpcRequest));
 
     /* Check if the thread is dying */
-    if (Thread->LpcExitThreadCalled) return STATUS_THREAD_IS_TERMINATING;
+    if (Thread->LpcExitThreadCalled)
+        return STATUS_THREAD_IS_TERMINATING;
 
     /* Check for user mode access */
     if (PreviousMode != KernelMode)
@@ -756,6 +752,13 @@ NtRequestWaitReplyPort(IN HANDLE PortHandle,
             return Status;
         }
     }
+
+    LPCTRACE(LPC_SEND_DEBUG,
+             "Handle: %p. Messages: %p/%p. Type: %lx\n",
+             PortHandle,
+             LpcRequest,
+             LpcReply,
+             LpcpGetMessageType(&CapturedLpcRequest));
 
     /* This flag is undocumented. Remove it before continuing */
     CapturedLpcRequest.u2.s2.Type &= ~0x4000;


### PR DESCRIPTION
## Purpose

Ensure debug-traced user-mode data passed by pointers is captured.

JIRA issue: [CORE-18098](https://jira.reactos.org/browse/CORE-18098)
