### PR TITLE
Control Panel applets should be started in single instance

### DIFF
--- a/dll/cpl/access/CMakeLists.txt
+++ b/dll/cpl/access/CMakeLists.txt
@@ -8,7 +8,9 @@ list(APPEND SOURCE
     keyboard.c
     mouse.c
     sound.c
-    access.h)
+    access.h
+    ../common/cpl_common.c
+)
 
 add_rc_deps(access.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/applet.ico)
 

--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -5,9 +5,11 @@
  * PURPOSE:         Main control panel code
  * COPYRIGHT:       Copyright 2004 Johannes Anderwald (johannes.anderwald@reactos.org)
  *                  Copyright 2007 Eric Kohl
+ *                  Copyright 2022 Raymond Czerny
  */
 
 #include "access.h"
+#include "../common/cpl_common.h"
 
 #include <cpl.h>
 
@@ -247,8 +249,16 @@ CPlApplet(HWND hwndCPl,
 
     switch (uMsg)
     {
-        case CPL_INIT:
+       case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLSYSTEMNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/common/common.c
+++ b/dll/cpl/common/common.c
@@ -1,0 +1,72 @@
+/**
+ * @file common.c
+ * @brief Auxiliary functions for the realization
+ *        of a one-instance cpl applet
+ *
+ * Copyright 2022 Raymond Czerny
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#include "common.h"
+
+/** Structure for in and out data when
+ *  search for the cpl dialog of first instance
+ */
+typedef struct tagUserData
+{
+    const WCHAR*    Title;
+    HWND            Result;
+} UserData;
+
+static BOOL CALLBACK enumWinProc(
+  _In_ HWND   hwnd,
+  _In_ LPARAM lParam
+)
+{
+    WCHAR szClassName[51];
+    if(GetClassNameW(hwnd, szClassName, 50))
+    {
+        if(0 == wcscmp(L"#32770", szClassName))
+        {
+            WCHAR szCaption[255];
+            ZeroMemory(szCaption, sizeof(szCaption));
+            if(GetWindowTextW(hwnd, szCaption, sizeof(szCaption)))
+            {
+                UserData* pData = (UserData*)lParam;
+                if(NULL != wcsstr(szCaption, pData->Title))
+                {
+                    pData->Result = hwnd;
+                }
+            }
+        }
+    }
+    return TRUE;
+}
+
+HWND CPL_GetHWndByCaption(const WCHAR* Caption)
+{
+    UserData data = {Caption, NULL};
+    EnumWindows(enumWinProc, (LPARAM)&data);
+    return data.Result;
+}
+
+HWND CPL_GetHWndByResource(HINSTANCE hInstance, UINT uID)
+{
+    WCHAR szCaption[255];
+    ZeroMemory(szCaption, sizeof(szCaption));
+    LoadStringW(hInstance, uID, szCaption, 255);
+    return CPL_GetHWndByCaption(szCaption);
+}

--- a/dll/cpl/common/common.h
+++ b/dll/cpl/common/common.h
@@ -1,0 +1,31 @@
+/**
+ * @file common.h
+ * @brief Auxiliary functions for the realization
+ *        of a one-instance cpl applet
+ *
+ * Copyright 2022 Raymond Czerny
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ */
+
+#ifndef _CPL_COMMON_H_
+#define _CPL_COMMON_H_
+
+#include <windows.h>
+
+HWND CPL_GetHWndByCaption(const WCHAR* Caption);
+HWND CPL_GetHWndByResource(HINSTANCE hInstance, UINT uID);
+
+#endif

--- a/dll/cpl/common/cpl_common.c
+++ b/dll/cpl/common/cpl_common.c
@@ -1,5 +1,5 @@
 /**
- * @file common.c
+ * @file cpl_common.c
  * @brief Auxiliary functions for the realization
  *        of a one-instance cpl applet
  *
@@ -20,7 +20,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
  */
 
-#include "common.h"
+#include "cpl_common.h"
 
 /** Structure for in and out data when
  *  search for the cpl dialog of first instance

--- a/dll/cpl/common/cpl_common.h
+++ b/dll/cpl/common/cpl_common.h
@@ -1,5 +1,5 @@
 /**
- * @file common.h
+ * @file cpl_common.h
  * @brief Auxiliary functions for the realization
  *        of a one-instance cpl applet
  *

--- a/dll/cpl/desk/CMakeLists.txt
+++ b/dll/cpl/desk/CMakeLists.txt
@@ -20,7 +20,9 @@ list(APPEND SOURCE
     general.c
     draw.c
     theme.c
-    muireg.c)
+    muireg.c
+    ../common/cpl_common.c
+)
 
 list(APPEND PCH_SKIP_SOURCE
     guid.c)

--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -5,9 +5,12 @@
  * PURPOSE:         ReactOS Display Control Panel
  *
  * PROGRAMMERS:     Trevor McCort (lycan359@gmail.com)
+ *                  Raymond Czerny
  */
 
 #include "desk.h"
+#include "../common/cpl_common.h"
+
 #include <shellapi.h>
 #include <cplext.h>
 #include <debug.h>
@@ -260,7 +263,15 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/inetcpl/CMakeLists.txt
+++ b/dll/cpl/inetcpl/CMakeLists.txt
@@ -9,7 +9,9 @@ list(APPEND SOURCE
     general.c
     inetcpl.c
     security.c
-    precomp.h)
+    precomp.h
+    ../common/cpl_common.c
+)
 
 file(GLOB inetcpl_rc_deps resources/*.*)
 add_rc_deps(inetcpl.rc ${inetcpl_rc_deps})

--- a/dll/cpl/inetcpl/inetcpl.c
+++ b/dll/cpl/inetcpl/inetcpl.c
@@ -35,6 +35,7 @@
 #include "wine/debug.h"
 
 #include "inetcpl.h"
+#include "../common/cpl_common.h"
 
 
 WINE_DEFAULT_DEBUG_CHANNEL(inetcpl);
@@ -185,7 +186,15 @@ LONG CALLBACK CPlApplet(HWND hWnd, UINT command, LPARAM lParam1, LPARAM lParam2)
     switch (command)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hcpl, IDS_CPL_NAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return 1;

--- a/dll/cpl/intl/CMakeLists.txt
+++ b/dll/cpl/intl/CMakeLists.txt
@@ -14,7 +14,9 @@ list(APPEND SOURCE
     languages.c
     advanced.c
     sort.c
-    intl.h)
+    intl.h
+    ../common/cpl_common.c
+)
 
 add_rc_deps(intl.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/applet.ico)
 

--- a/dll/cpl/intl/intl.c
+++ b/dll/cpl/intl/intl.c
@@ -21,9 +21,11 @@
  * FILE:            dll/cpl/intl/intl.c
  * PURPOSE:         Property sheet code
  * PROGRAMMER:      Eric Kohl
+ *                  Raymond Czerny
  */
 
 #include "intl.h"
+#include "../common/cpl_common.h"
 
 #include <debug.h>
 
@@ -238,7 +240,15 @@ CPlApplet(HWND hwndCpl,
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/joy/CMakeLists.txt
+++ b/dll/cpl/joy/CMakeLists.txt
@@ -5,6 +5,7 @@ add_rc_deps(joy.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/applet.ico)
 add_library(joy MODULE
     joy.c
     joy.rc
+    ../common/cpl_common.c
     ${CMAKE_CURRENT_BINARY_DIR}/joy.def)
 
 set_module_type(joy cpl UNICODE)

--- a/dll/cpl/joy/joy.c
+++ b/dll/cpl/joy/joy.c
@@ -22,12 +22,14 @@
  * FILE:            dll/cpl/joy/joy.c
  * PURPOSE:         ReactOS Software Control Panel
  * PROGRAMMER:      Dmitry Chapyshev (lentind@yandex.ru)
+ *                  Raymond Czerny (chip@raymisoft.de)
  * UPDATE HISTORY:
  *    10-18-2007  Created
  *    05-18-2020  Updated (init of dialog and combobox)
  */
 
 #include "joy.h"
+#include "../common/cpl_common.h"
 
 #define NUM_APPLETS    (1)
 
@@ -327,7 +329,15 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLSYSTEMNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/main/CMakeLists.txt
+++ b/dll/cpl/main/CMakeLists.txt
@@ -5,7 +5,9 @@ list(APPEND SOURCE
     keyboard.c
     main.c
     mouse.c
-    main.h)
+    main.h
+    ../common/cpl_common.c
+)
 
 file(GLOB main_rc_deps resources/*.*)
 add_rc_deps(main.rc ${main_rc_deps})

--- a/dll/cpl/main/main.c
+++ b/dll/cpl/main/main.c
@@ -21,11 +21,13 @@
  * FILE:            dll/cpl/main/main.c
  * PURPOSE:         ReactOS Main Control Panel
  * PROGRAMMER:      Eric Kohl
+ *                  Raymond Czerny
  * UPDATE HISTORY:
  *      05-01-2004  Created
  */
 
 #include "main.h"
+#include "../common/cpl_common.h"
 
 #define NUM_APPLETS	(2)
 
@@ -90,7 +92,15 @@ CPlApplet(HWND hwndCpl,
     switch(uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME_1);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/mmsys/CMakeLists.txt
+++ b/dll/cpl/mmsys/CMakeLists.txt
@@ -8,7 +8,9 @@ list(APPEND SOURCE
     volume.c
     audio.c
     voice.c
-    mmsys.h)
+    mmsys.h
+    ../common/cpl_common.c
+)
 
 file(GLOB mmsys_rc_deps resources/*.*)
 add_rc_deps(mmsys.rc ${mmsys_rc_deps})

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -10,6 +10,7 @@
  */
 
 #include "mmsys.h"
+#include "../common/cpl_common.h"
 
 #include <winsvc.h>
 #include <shlwapi.h>
@@ -755,6 +756,15 @@ CPlApplet(HWND hwndCpl,
     switch(uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
+            return TRUE;
+        }
             return TRUE;
 
         case CPL_GETCOUNT:

--- a/dll/cpl/openglcfg/CMakeLists.txt
+++ b/dll/cpl/openglcfg/CMakeLists.txt
@@ -4,7 +4,9 @@ spec2def(openglcfg.cpl openglcfg.spec)
 list(APPEND SOURCE
     openglcfg.c
     general.c
-    openglcfg.h)
+    openglcfg.h
+    ../common/cpl_common.c
+)
 
 add_rc_deps(openglcfg.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/openglcfg.ico)
 

--- a/dll/cpl/openglcfg/openglcfg.c
+++ b/dll/cpl/openglcfg/openglcfg.c
@@ -1,4 +1,5 @@
 #include "openglcfg.h"
+#include "../common/cpl_common.h"
 
 #include <cpl.h>
 
@@ -56,7 +57,15 @@ LONG CALLBACK CPlApplet(HWND hWnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return 1;

--- a/dll/cpl/sysdm/CMakeLists.txt
+++ b/dll/cpl/sysdm/CMakeLists.txt
@@ -16,7 +16,9 @@ list(APPEND SOURCE
     sysdm.c
     userprofile.c
     virtmem.c
-    precomp.h)
+    precomp.h
+    ../common/cpl_common.c
+)
 
 file(GLOB sysdm_rc_deps resources/*.*)
 add_rc_deps(sysdm.rc ${sysdm_rc_deps})

--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -8,6 +8,7 @@
  */
 
 #include "precomp.h"
+#include "../common/cpl_common.h"
 
 #include <regstr.h>
 
@@ -210,8 +211,15 @@ CPlApplet(HWND hwndCPl,
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLSYSTEMNAME);
+            if(hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
-
+        }
         case CPL_GETCOUNT:
             return NUM_APPLETS;
 

--- a/dll/cpl/timedate/CMakeLists.txt
+++ b/dll/cpl/timedate/CMakeLists.txt
@@ -10,7 +10,9 @@ list(APPEND SOURCE
     monthcal.c
     timedate.c
     timezone.c
-    timedate.h)
+    timedate.h
+    ../common/cpl_common.c
+)
 
 file(GLOB timedate_rc_deps resources/*.*)
 add_rc_deps(timedate.rc ${timedate_rc_deps})

--- a/dll/cpl/timedate/timedate.c
+++ b/dll/cpl/timedate/timedate.c
@@ -5,10 +5,12 @@
  * PURPOSE:     ReactOS Timedate Control Panel
  * COPYRIGHT:   Copyright 2004-2005 Eric Kohl
  *              Copyright 2006 Ged Murphy <gedmurphy@gmail.com>
+ *              Copyright 2022 Raymond Czerny <chip@raymisoft.de>
  *
  */
 
 #include "timedate.h"
+#include "../common/cpl_common.h"
 
 #define NUM_APPLETS 1
 
@@ -139,7 +141,15 @@ CPlApplet(HWND hwndCpl,
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if (hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/usrmgr/CMakeLists.txt
+++ b/dll/cpl/usrmgr/CMakeLists.txt
@@ -10,7 +10,9 @@ list(APPEND SOURCE
     userprops.c
     users.c
     usrmgr.c
-    usrmgr.h)
+    usrmgr.h
+    ../common/cpl_common.c
+)
 
 file(GLOB usrmgr_rc_deps resources/*.*)
 add_rc_deps(usrmgr.rc ${usrmgr_rc_deps})

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -5,9 +5,11 @@
  * PURPOSE:         Main functions
  *
  * PROGRAMMERS:     Eric Kohl
+ *                  Raymond Czerny <chip@raymisoft.de>
  */
 
 #include "usrmgr.h"
+#include "../common/cpl_common.h"
 
 #define NUM_APPLETS 1
 
@@ -98,7 +100,15 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if (hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return NUM_APPLETS;

--- a/dll/cpl/wined3dcfg/CMakeLists.txt
+++ b/dll/cpl/wined3dcfg/CMakeLists.txt
@@ -4,7 +4,9 @@ spec2def(wined3dcfg.cpl wined3dcfg.spec)
 list(APPEND SOURCE
     wined3dcfg.c
     general.c
-    wined3dcfg.h)
+    wined3dcfg.h
+    ../common/cpl_common.c
+)
 
 add_rc_deps(wined3dcfg.rc ${CMAKE_CURRENT_SOURCE_DIR}/resources/wined3dcfg.ico)
 

--- a/dll/cpl/wined3dcfg/wined3dcfg.c
+++ b/dll/cpl/wined3dcfg/wined3dcfg.c
@@ -1,4 +1,5 @@
 #include "wined3dcfg.h"
+#include "../common/cpl_common.h"
 
 #include <cpl.h>
 
@@ -56,7 +57,15 @@ LONG CALLBACK CPlApplet(HWND hWnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     switch (uMsg)
     {
         case CPL_INIT:
+        {
+            HWND hwnd = CPL_GetHWndByResource(hApplet, IDS_CPLNAME);
+            if (hwnd)
+            {
+                BringWindowToTop(hwnd);
+                return FALSE;
+            }
             return TRUE;
+        }
 
         case CPL_GETCOUNT:
             return 1;


### PR DESCRIPTION
## Purpose

In MS Windows all control panel applets are single instance applications. This prevents the collision of multiple accesses to the configuration data.

## Proposed changes

In the initialization phase of the applets, a preinstance is now searched for after the dialog window. If the search is successful, this dialog is brought to the foreground and the second instance is aborted.