### PR TITLE
Move the RTL UTF8 functions to the main RTL library, to be linked in the rtl_vista target.

### DIFF
--- a/sdk/lib/drivers/ntoskrnl_vista/CMakeLists.txt
+++ b/sdk/lib/drivers/ntoskrnl_vista/CMakeLists.txt
@@ -4,14 +4,14 @@ add_definitions(-D_WIN32_WINNT=0x600)
 add_definitions(-DUNICODE -D_UNICODE -D__NTOSKRNL__ -D_NTOSKRNL_ -D_NTSYSTEM_)
 
 list(APPEND SOURCE
-	etw.c
+    etw.c
     fsrtl.c
     io.c
     po.c
-    ke.c
-    rtl.c)
+    ke.c)
 
 add_library(ntoskrnl_vista ${SOURCE})
+target_link_libraries(ntoskrnl_vista PRIVATE rtl_vista)
 add_dependencies(ntoskrnl_vista bugcodes xdk)
 
 target_compile_definitions(ntoskrnl_vista PUBLIC NTKRNLVISTA)

--- a/sdk/lib/rtl/CMakeLists.txt
+++ b/sdk/lib/rtl/CMakeLists.txt
@@ -116,7 +116,7 @@ list(APPEND SOURCE_VISTA
     condvar.c
     runonce.c
     srw.c
-)
+    utf8.c)
 
 add_library(rtl_vista ${SOURCE_VISTA})
 add_pch(rtl_vista rtl_vista.h SOURCE_VISTA)

--- a/sdk/lib/rtl/runonce.c
+++ b/sdk/lib/rtl/runonce.c
@@ -1,7 +1,7 @@
 
 /* Taken from Wine ntdll/sync.c */
 
-#include "rtl_vista.h"
+#include <rtl_vista.h>
 #include <wine/config.h>
 #include <wine/port.h>
 

--- a/sdk/lib/rtl/utf8.c
+++ b/sdk/lib/rtl/utf8.c
@@ -1,15 +1,18 @@
 /*
- * PROJECT:         ReactOS Kernel - Vista+ APIs
- * LICENSE:         GPL v2 - See COPYING in the top level directory
- * FILE:            lib/drivers/ntoskrnl_vista/rtl.c
- * PURPOSE:         Rtl functions of Vista+
- * PROGRAMMERS:     Thomas Faber <thomas.faber@reactos.org>
+ * PROJECT:     ReactOS Kernel - Vista+ APIs
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Rtl functions of Vista+
+ * COPYRIGHT:   2016 Thomas Faber <thomas.faber@reactos.org>
  */
 
-#include <ntdef.h>
-#include <ntifs.h>
+/* INCLUDES ******************************************************************/
 
-typedef UCHAR BYTE;
+#include <rtl_vista.h>
+
+#define NDEBUG
+#include <debug.h>
+
+/* FUNCTIONS *****************************************************************/
 
 /******************************************************************************
  * RtlUnicodeToUTF8N [NTDLL.@]


### PR DESCRIPTION
## Purpose

The reason is that both RtlUTF8ToUnicodeN() and RtlUnicodeToUTF8N() are
exported in both kernel and user-mode (ntdll) in Windows 7+. They are not
limited to the kernel only.

References:
https://www.geoffchappell.com/studies/windows/km/ntoskrnl/history/names61.htm
https://www.geoffchappell.com/studies/windows/win32/ntdll/history/names61.htm

Conversion from and to UTF8 are fundamental enough that they indeed
deserve to be in a separate file.
