### PR TITLE
Preparatory work for multidisplay

### DIFF
--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -73,6 +73,7 @@ list(APPEND SOURCE
     gdi/eng/ldevobj.c
     gdi/eng/mapping.c
     gdi/eng/math.c
+    gdi/eng/mdevobj.c
     gdi/eng/mem.c
     gdi/eng/engmisc.c
     gdi/eng/mouse.c

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -77,6 +77,7 @@ list(APPEND SOURCE
     gdi/eng/mem.c
     gdi/eng/engmisc.c
     gdi/eng/mouse.c
+    gdi/eng/multidisp.c
     gdi/eng/paint.c
     gdi/eng/pathobj.c
     gdi/eng/pdevobj.c

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -147,7 +147,7 @@ EngpPopulateDeviceModeList(
     {
         /* Try to load the display driver */
         TRACE("Trying driver: %ls\n", pwsz);
-        pldev = EngLoadImageEx(pwsz, LDEV_DEVICE_DISPLAY);
+        pldev = LDEVOBJ_pLoadDriver(pwsz, LDEV_DEVICE_DISPLAY);
         if (!pldev)
         {
             ERR("Could not load driver: '%ls'\n", pwsz);

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -198,7 +198,7 @@ VideoPortCallout(
             if (CallbackParams->Param == TRUE)
             {
                 /* Re-enable the display */
-                UserRefreshDisplay(gppdevPrimary);
+                UserRefreshDisplay(gpmdev->ppdevGlobal);
             }
             else
             {

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -80,7 +80,7 @@ EngpUpdateGraphicsDeviceList(VOID)
         RtlInitUnicodeString(&ustrDeviceName, awcWinDeviceName);
 
         /* Check if the device exists already */
-        pGraphicsDevice = EngpFindGraphicsDevice(&ustrDeviceName, iDevNum, 0);
+        pGraphicsDevice = EngpFindGraphicsDevice(&ustrDeviceName, iDevNum);
         if (pGraphicsDevice != NULL)
         {
             continue;
@@ -387,14 +387,13 @@ PGRAPHICS_DEVICE
 NTAPI
 EngpFindGraphicsDevice(
     _In_opt_ PUNICODE_STRING pustrDevice,
-    _In_ ULONG iDevNum,
-    _In_ DWORD dwFlags)
+    _In_ ULONG iDevNum)
 {
     UNICODE_STRING ustrCurrent;
     PGRAPHICS_DEVICE pGraphicsDevice;
     ULONG i;
-    TRACE("EngpFindGraphicsDevice('%wZ', %lu, 0x%lx)\n",
-           pustrDevice, iDevNum, dwFlags);
+    TRACE("EngpFindGraphicsDevice('%wZ', %lu)\n",
+           pustrDevice, iDevNum);
 
     /* Lock list */
     EngAcquireSemaphore(ghsemGraphicsDeviceList);

--- a/win32ss/gdi/eng/device.h
+++ b/win32ss/gdi/eng/device.h
@@ -30,13 +30,7 @@ NTAPI
 EngpRegisterGraphicsDevice(
     _In_ PUNICODE_STRING pustrDeviceName,
     _In_ PUNICODE_STRING pustrDiplayDrivers,
-    _In_ PUNICODE_STRING pustrDescription,
-    _In_ PDEVMODEW pdmDefault);
-
-BOOLEAN
-EngpPopulateDeviceModeList(
-    _Inout_ PGRAPHICS_DEVICE pGraphicsDevice,
-    _In_ PDEVMODEW pdmDefault);
+    _In_ PUNICODE_STRING pustrDescription);
 
 NTSTATUS
 EngpUpdateGraphicsDeviceList(VOID);

--- a/win32ss/gdi/eng/device.h
+++ b/win32ss/gdi/eng/device.h
@@ -23,8 +23,7 @@ PGRAPHICS_DEVICE
 NTAPI
 EngpFindGraphicsDevice(
     _In_opt_ PUNICODE_STRING pustrDevice,
-    _In_ ULONG iDevNum,
-    _In_ DWORD dwFlags);
+    _In_ ULONG iDevNum);
 
 PGRAPHICS_DEVICE
 NTAPI

--- a/win32ss/gdi/eng/engbrush.c
+++ b/win32ss/gdi/eng/engbrush.c
@@ -324,7 +324,7 @@ EBRUSHOBJ_bRealizeBrush(EBRUSHOBJ *pebo, BOOL bCallDriver)
 
     ppdev = (PPDEVOBJ)pebo->psurfTrg->SurfObj.hdev;
     if (!ppdev)
-        ppdev = gppdevPrimary;
+        ppdev = gpmdev->ppdevGlobal;
 
     if (bCallDriver)
     {
@@ -458,7 +458,7 @@ EBRUSHOBJ_psoMask(EBRUSHOBJ *pebo)
             /* Get the PDEV */
             ppdev = (PPDEVOBJ)pebo->psurfTrg->SurfObj.hdev;
             if (!ppdev)
-                ppdev = gppdevPrimary;
+                ppdev = gpmdev->ppdevGlobal;
 
             /* Use the hatch bitmap as the mask */
             hbmMask = (HBITMAP)ppdev->ahsurf[pebo->pbrush->iHatch];

--- a/win32ss/gdi/eng/ldevobj.c
+++ b/win32ss/gdi/eng/ldevobj.c
@@ -325,7 +325,7 @@ LDEVOBJ_pvFindImageProcAddress(
 
 PLDEVOBJ
 NTAPI
-EngLoadImageEx(
+LDEVOBJ_pLoadDriver(
     _In_z_ LPWSTR pwszDriverName,
     _In_ ULONG ldevtype)
 {
@@ -336,7 +336,7 @@ EngLoadImageEx(
     SIZE_T cwcLength;
     LPWSTR pwsz;
 
-    TRACE("EngLoadImageEx(%ls, %lu)\n", pwszDriverName, ldevtype);
+    TRACE("LDEVOBJ_pLoadDriver(%ls, %lu)\n", pwszDriverName, ldevtype);
     ASSERT(pwszDriverName);
 
     /* Initialize buffer for the the driver name */
@@ -444,7 +444,7 @@ leave:
     /* Unlock loader */
     EngReleaseSemaphore(ghsemLDEVList);
 
-    TRACE("EngLoadImageEx returning %p\n", pldev);
+    TRACE("LDEVOBJ_pLoadDriver returning %p\n", pldev);
     return pldev;
 }
 
@@ -456,7 +456,7 @@ APIENTRY
 EngLoadImage(
     _In_ LPWSTR pwszDriverName)
 {
-    return (HANDLE)EngLoadImageEx(pwszDriverName, LDEV_IMAGE);
+    return (HANDLE)LDEVOBJ_pLoadDriver(pwszDriverName, LDEV_IMAGE);
 }
 
 

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -42,7 +42,7 @@ LDEVOBJ_pdmiGetModes(
 
 PLDEVOBJ
 APIENTRY
-EngLoadImageEx(
+LDEVOBJ_pLoadDriver(
     _In_z_ LPWSTR pwszDriverName,
     _In_ ULONG ldevtype);
 

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -56,6 +56,14 @@ BOOL
 LDEVOBJ_bBuildDevmodeList(
     _Inout_ PGRAPHICS_DEVICE pGraphicsDevice);
 
+/* This function selects the best available mode corresponding to requested mode */
+BOOL
+LDEVOBJ_bProbeAndCaptureDevmode(
+    _Inout_ PGRAPHICS_DEVICE pGraphicsDevice,
+    _In_ PDEVMODEW RequestedMode,
+    _Out_ PDEVMODEW *pSelectedMode,
+    _In_ BOOL bSearchClosestMode);
+
 PLDEVOBJ
 NTAPI
 EngGetLDEV(

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -52,6 +52,10 @@ LDEVOBJ_pLoadDriver(
     _In_z_ LPWSTR pwszDriverName,
     _In_ ULONG ldevtype);
 
+BOOL
+LDEVOBJ_bBuildDevmodeList(
+    _Inout_ PGRAPHICS_DEVICE pGraphicsDevice);
+
 PLDEVOBJ
 NTAPI
 EngGetLDEV(

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -64,11 +64,6 @@ LDEVOBJ_bProbeAndCaptureDevmode(
     _Out_ PDEVMODEW *pSelectedMode,
     _In_ BOOL bSearchClosestMode);
 
-PLDEVOBJ
-NTAPI
-EngGetLDEV(
-    PDEVMODEW pdm);
-
 CODE_SEG("INIT")
 NTSTATUS
 APIENTRY

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -47,6 +47,11 @@ LDEVOBJ_ulGetDriverModes(
     _Out_ PDEVMODEW *ppdm);
 
 PLDEVOBJ
+LDEVOBJ_pLoadInternal(
+    _In_ PFN_DrvEnableDriver pfnEnableDriver,
+    _In_ ULONG ldevtype);
+
+PLDEVOBJ
 APIENTRY
 LDEVOBJ_pLoadDriver(
     _In_z_ LPWSTR pwszDriverName,

--- a/win32ss/gdi/eng/ldevobj.h
+++ b/win32ss/gdi/eng/ldevobj.h
@@ -34,11 +34,17 @@ NTSTATUS
 NTAPI
 InitLDEVImpl(VOID);
 
-PDEVMODEINFO
-NTAPI
-LDEVOBJ_pdmiGetModes(
-    _In_ PLDEVOBJ pldev,
-    _In_ HANDLE hDriver);
+/* Get all available device modes from a driver
+ * - pwszDriverName: name of the driver
+ * - hDriver: handle of the driver
+ * - ppdm: allocated memory containing driver modes or NULL on error
+ * Return value: number of bytes allocated for *ppdm buffer or 0 on error
+ */
+ULONG
+LDEVOBJ_ulGetDriverModes(
+    _In_ LPWSTR pwszDriverName,
+    _In_ HANDLE hDriver,
+    _Out_ PDEVMODEW *ppdm);
 
 PLDEVOBJ
 APIENTRY

--- a/win32ss/gdi/eng/mdevobj.c
+++ b/win32ss/gdi/eng/mdevobj.c
@@ -1,0 +1,13 @@
+/*
+ * COPYRIGHT:        See COPYING in the top level directory
+ * PROJECT:          ReactOS kernel
+ * PURPOSE:          Support for meta devices
+ * FILE:             win32ss/gdi/eng/mdevobj.c
+ * PROGRAMER:        Hervé Poussineau
+ */
+
+#include <win32k.h>
+#define NDEBUG
+#include <debug.h>
+
+PMDEVOBJ gpmdev = NULL; /* FIXME: should be stored in gpDispInfo->pmdev */

--- a/win32ss/gdi/eng/mdevobj.c
+++ b/win32ss/gdi/eng/mdevobj.c
@@ -64,6 +64,7 @@ MDEVOBJ_Create(
     DEVMODEW dmDefault;
     PDEVMODEW localPdm;
     ULONG iDevNum = 0;
+    ULONG dwAccelerationLevel = 0;
 
     TRACE("MDEVOBJ_Create('%wZ' '%dx%dx%d (%d Hz)')\n",
         pustrDeviceName,
@@ -152,13 +153,14 @@ MDEVOBJ_Create(
             READ(dmDisplayFixedOutput, "DefaultSettings.FixedOutput", DM_DISPLAYFIXEDOUTPUT);
             READ(dmPosition.x, "Attach.RelativeX", DM_POSITION);
             READ(dmPosition.y, "Attach.RelativeY", DM_POSITION);
+            RegReadDWORD(hKey, L"Acceleration.Level", &dwAccelerationLevel);
             ZwClose(hKey);
         }
 
         /* Get or create a PDEV for these settings */
         if (LDEVOBJ_bProbeAndCaptureDevmode(pGraphicsDevice, pdm ? pdm : &dmDefault, &localPdm, !pdm))
         {
-            ppdev = PDEVOBJ_Create(pGraphicsDevice, localPdm, LDEV_DEVICE_DISPLAY);
+            ppdev = PDEVOBJ_Create(pGraphicsDevice, localPdm, dwAccelerationLevel, LDEV_DEVICE_DISPLAY);
         }
         else
         {

--- a/win32ss/gdi/eng/mdevobj.c
+++ b/win32ss/gdi/eng/mdevobj.c
@@ -9,5 +9,200 @@
 #include <win32k.h>
 #define NDEBUG
 #include <debug.h>
+DBG_DEFAULT_CHANNEL(EngMDev);
 
 PMDEVOBJ gpmdev = NULL; /* FIXME: should be stored in gpDispInfo->pmdev */
+
+VOID
+MDEVOBJ_vEnable(
+    _Inout_ PMDEVOBJ pmdev)
+{
+    ULONG i;
+
+    for (i = 0; i < pmdev->cDev; i++)
+    {
+        PDEVOBJ_vEnableDisplay(pmdev->dev[i].ppdev);
+    }
+}
+
+BOOL
+MDEVOBJ_bDisable(
+    _Inout_ PMDEVOBJ pmdev)
+{
+    BOOL bSuccess = TRUE;
+    ULONG i, j;
+
+    for (i = 0; i < pmdev->cDev; i++)
+    {
+        if (!PDEVOBJ_bDisableDisplay(pmdev->dev[i].ppdev))
+        {
+            bSuccess = FALSE;
+            break;
+        }
+    }
+
+    if (!bSuccess)
+    {
+        /* Failed to disable all PDEVs. Reenable those we have disabled */
+        for (j = 0; j < i; j++)
+        {
+            PDEVOBJ_vEnableDisplay(pmdev->dev[i].ppdev);
+        }
+    }
+
+    return bSuccess;
+}
+
+PMDEVOBJ
+MDEVOBJ_Create(
+    _In_opt_ PUNICODE_STRING pustrDeviceName,
+    _In_opt_ PDEVMODEW pdm)
+{
+    PMDEVOBJ pmdev = NULL;
+    PPDEVOBJ ppdev;
+    PGRAPHICS_DEVICE pGraphicsDevice;
+    DEVMODEW dmDefault;
+    PDEVMODEW localPdm;
+    ULONG iDevNum = 0;
+
+    TRACE("MDEVOBJ_Create('%wZ' '%dx%dx%d (%d Hz)')\n",
+        pustrDeviceName,
+        pdm ? pdm->dmPelsWidth : 0,
+        pdm ? pdm->dmPelsHeight : 0,
+        pdm ? pdm->dmBitsPerPel : 0,
+        pdm ? pdm->dmDisplayFrequency : 0);
+
+    pmdev = ExAllocatePoolZero(PagedPool, sizeof(MDEVOBJ), GDITAG_MDEV);
+    if (!pmdev)
+    {
+        ERR("Failed to allocate memory for MDEV\n");
+        return NULL;
+    }
+
+    pmdev->cDev = 0;
+
+    while (TRUE)
+    {
+        /* Get the right graphics devices: either the specified one, or all of them (one after one) */
+        if (pustrDeviceName)
+            pGraphicsDevice = (iDevNum == 0) ? EngpFindGraphicsDevice(pustrDeviceName, 0) : NULL;
+        else
+            pGraphicsDevice = EngpFindGraphicsDevice(NULL, iDevNum);
+        iDevNum++;
+
+        if (!pGraphicsDevice)
+        {
+            TRACE("Done enumeration of graphic devices (DeviceName '%wZ' iDevNum %d)\n", pustrDeviceName, iDevNum);
+            break;
+        }
+
+        if (!pdm)
+        {
+            /* No settings requested. Read default settings from registry to dmDefault */
+            HKEY hKey;
+            WCHAR DeviceKey[128];
+            ULONG cbSize;
+            NTSTATUS Status;
+            DWORD dwValue;
+
+            RtlZeroMemory(&dmDefault, sizeof(dmDefault));
+            dmDefault.dmSize = sizeof(dmDefault);
+
+            Status = RegOpenKey(L"\\Registry\\Machine\\HARDWARE\\DEVICEMAP\\VIDEO", &hKey);
+            if (!NT_SUCCESS(Status))
+            {
+                /* Ignore this device and continue */
+                ERR("Failed to open VIDEO key: status 0x%08x\n", Status);
+                continue;
+            }
+            cbSize = sizeof(DeviceKey);
+            Status = RegQueryValue(hKey,
+                                   pGraphicsDevice->szNtDeviceName,
+                                   REG_SZ,
+                                   DeviceKey,
+                                   &cbSize);
+            ZwClose(hKey);
+            if (!NT_SUCCESS(Status))
+            {
+                /* Ignore this device and continue */
+                ERR("Failed to open get device key for '%S': status 0x%08x\n", pGraphicsDevice->szNtDeviceName, Status);
+                continue;
+            }
+            Status = RegOpenKey(DeviceKey, &hKey);
+            if (!NT_SUCCESS(Status))
+            {
+                /* Ignore this device and continue */
+                ERR("Failed to open open device key '%S' for '%S': status 0x%08x\n", DeviceKey, pGraphicsDevice->szNtDeviceName, Status);
+                continue;
+            }
+#define READ(field, str, flag) \
+    if (RegReadDWORD(hKey, L##str, &dwValue)) \
+    { \
+        dmDefault.field = dwValue; \
+        dmDefault.dmFields |= flag; \
+    }
+            READ(dmBitsPerPel, "DefaultSettings.BitsPerPel", DM_BITSPERPEL);
+            READ(dmPelsWidth, "DefaultSettings.XResolution", DM_PELSWIDTH);
+            READ(dmPelsHeight, "DefaultSettings.YResolution", DM_PELSHEIGHT);
+            READ(dmDisplayFlags, "DefaultSettings.Flags", DM_DISPLAYFLAGS);
+            READ(dmDisplayFrequency, "DefaultSettings.VRefresh", DM_DISPLAYFREQUENCY);
+            READ(dmPanningWidth, "DefaultSettings.XPanning", DM_PANNINGWIDTH);
+            READ(dmPanningHeight, "DefaultSettings.YPanning", DM_PANNINGHEIGHT);
+            READ(dmDisplayOrientation, "DefaultSettings.Orientation", DM_DISPLAYORIENTATION);
+            READ(dmDisplayFixedOutput, "DefaultSettings.FixedOutput", DM_DISPLAYFIXEDOUTPUT);
+            READ(dmPosition.x, "Attach.RelativeX", DM_POSITION);
+            READ(dmPosition.y, "Attach.RelativeY", DM_POSITION);
+            ZwClose(hKey);
+        }
+
+        /* Get or create a PDEV for these settings */
+        if (LDEVOBJ_bProbeAndCaptureDevmode(pGraphicsDevice, pdm ? pdm : &dmDefault, &localPdm, !pdm))
+        {
+            ppdev = PDEVOBJ_Create(pGraphicsDevice, localPdm, LDEV_DEVICE_DISPLAY);
+        }
+        else
+        {
+            ppdev = NULL;
+        }
+
+        if (ppdev)
+        {
+            /* Great. We have a found a matching PDEV. Store it in MDEV */
+            TRACE("Adding '%S' to MDEV %p\n", pGraphicsDevice->szWinDeviceName, pmdev);
+            PDEVOBJ_vReference(ppdev);
+            pmdev->dev[pmdev->cDev].ppdev = ppdev;
+            pmdev->cDev++;
+        }
+        else
+        {
+            WARN("Failed to add '%S' to MDEV %p\n", pGraphicsDevice->szWinDeviceName, pmdev);
+        }
+    }
+
+    if (pmdev->cDev == 0)
+    {
+        TRACE("Failed to add any device to MDEV. Returning NULL\n");
+        MDEVOBJ_vDestroy(pmdev);
+        return NULL;
+    }
+
+    TRACE("Returning new MDEV %p with %d devices\n", pmdev, pmdev->cDev);
+    return pmdev;
+}
+
+VOID
+MDEVOBJ_vDestroy(
+    _Inout_ PMDEVOBJ pmdev)
+{
+    ULONG i;
+
+    for (i = 0; i < pmdev->cDev; i++)
+    {
+        PDEVOBJ_vRelease(pmdev->dev[i].ppdev);
+    }
+
+    if (pmdev->cDev > 1)
+        PDEVOBJ_vRelease(pmdev->ppdevGlobal);
+
+    ExFreePoolWithTag(pmdev, GDITAG_MDEV);
+}

--- a/win32ss/gdi/eng/mdevobj.h
+++ b/win32ss/gdi/eng/mdevobj.h
@@ -1,0 +1,17 @@
+#ifndef __WIN32K_MDEVOBJ_H
+#define __WIN32K_MDEVOBJ_H
+
+/* Type definitions ***********************************************************/
+
+typedef struct _PDEVOBJ *PPDEVOBJ;
+
+typedef struct _MDEVOBJ
+{
+    PPDEVOBJ ppdevGlobal;
+} MDEVOBJ, *PMDEVOBJ;
+
+/* Globals ********************************************************************/
+
+extern PMDEVOBJ gpmdev; /* FIXME: should be stored in gpDispInfo->pmdev */
+
+#endif /* !__WIN32K_MDEVOBJ_H */

--- a/win32ss/gdi/eng/mdevobj.h
+++ b/win32ss/gdi/eng/mdevobj.h
@@ -7,11 +7,40 @@ typedef struct _PDEVOBJ *PPDEVOBJ;
 
 typedef struct _MDEVOBJ
 {
+    ULONG cDev;
     PPDEVOBJ ppdevGlobal;
+    struct
+    {
+        PPDEVOBJ ppdev;
+    } dev[10]; /* FIXME: max number of displays. Needs dynamic allocation */
 } MDEVOBJ, *PMDEVOBJ;
 
 /* Globals ********************************************************************/
 
 extern PMDEVOBJ gpmdev; /* FIXME: should be stored in gpDispInfo->pmdev */
+
+/* Function prototypes ********************************************************/
+
+VOID
+MDEVOBJ_vEnable(
+    _Inout_ PMDEVOBJ pmdev);
+
+BOOL
+MDEVOBJ_bDisable(
+    _Inout_ PMDEVOBJ pmdev);
+
+/* Create a new MDEV:
+ * - pustrDeviceName: name of the device to put in MDEV. If NULL, will put all graphics devices in MDEV
+ * - pdm: settings associated to pustrDeviceName. Unused if pustrDeviceName is NULL.
+ * Return value: the new MDEV (or NULL in case of error)
+ */
+PMDEVOBJ
+MDEVOBJ_Create(
+    _In_opt_ PUNICODE_STRING pustrDeviceName,
+    _In_opt_ PDEVMODEW pdm);
+
+VOID
+MDEVOBJ_vDestroy(
+    _Inout_ PMDEVOBJ pmdev);
 
 #endif /* !__WIN32K_MDEVOBJ_H */

--- a/win32ss/gdi/eng/multidisp.c
+++ b/win32ss/gdi/eng/multidisp.c
@@ -1,0 +1,24 @@
+/*
+* PROJECT:     ReactOS Win32k subsystem
+* LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+* FILE:        win32ss/gdi/eng/multidisp.c
+* PURPOSE:     Multi-Display driver
+* PROGRAMMERS:
+*/
+
+/* INCLUDES *******************************************************************/
+
+#include <win32k.h>
+#define NDEBUG
+#include <debug.h>
+
+BOOL
+APIENTRY
+MultiEnableDriver(
+    _In_ ULONG iEngineVersion,
+    _In_ ULONG cj,
+    _Inout_bytecount_(cj) PDRVENABLEDATA pded)
+{
+    UNIMPLEMENTED;
+    return FALSE;
+}

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -430,9 +430,9 @@ SwitchPointer(
     *ppvPointer2 = pvTemp;
 }
 
-VOID
+BOOL
 NTAPI
-PDEVOBJ_vSwitchPdev(
+PDEVOBJ_bDynamicModeChange(
     PPDEVOBJ ppdev,
     PPDEVOBJ ppdev2)
 {
@@ -481,6 +481,8 @@ PDEVOBJ_vSwitchPdev(
     /* Notify each driver instance of its new HDEV association */
     ppdev->pfn.CompletePDEV(ppdev->dhpdev, (HDEV)ppdev);
     ppdev2->pfn.CompletePDEV(ppdev2->dhpdev, (HDEV)ppdev2);
+
+    return TRUE;
 }
 
 
@@ -536,7 +538,12 @@ PDEVOBJ_bSwitchMode(
     /* 6. Copy old PDEV state to new PDEV instance */
 
     /* 7. Switch the PDEVs */
-    PDEVOBJ_vSwitchPdev(ppdev, ppdevTmp);
+    if (!PDEVOBJ_bDynamicModeChange(ppdev, ppdevTmp))
+    {
+        DPRINT1("PDEVOBJ_bDynamicModeChange() failed\n");
+        PDEVOBJ_vRelease(ppdevTmp);
+        goto leave2;
+    }
 
     /* 8. Disable DirectDraw */
 

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -277,6 +277,45 @@ PDEVOBJ_pSurface(
 }
 
 VOID
+PDEVOBJ_vEnableDisplay(
+    _Inout_ PPDEVOBJ ppdev)
+{
+    BOOL assertVal;
+
+    if (!(ppdev->flFlags & PDEV_DISABLED))
+        return;
+
+    /* Try to enable display until success */
+    do
+    {
+        TRACE("DrvAssertMode(dhpdev %p, TRUE)\n", ppdev->dhpdev);
+        assertVal = ppdev->pfn.AssertMode(ppdev->dhpdev, TRUE);
+        TRACE("DrvAssertMode(dhpdev %p, TRUE) => %d\n", ppdev->dhpdev, assertVal);
+    } while (!assertVal);
+
+    ppdev->flFlags &= ~PDEV_DISABLED;
+}
+
+BOOL
+PDEVOBJ_bDisableDisplay(
+    _Inout_ PPDEVOBJ ppdev)
+{
+    BOOL assertVal;
+
+    if (ppdev->flFlags & PDEV_DISABLED)
+        return TRUE;
+
+    TRACE("DrvAssertMode(dhpdev %p, FALSE)\n", ppdev->dhpdev);
+    assertVal = ppdev->pfn.AssertMode(ppdev->dhpdev, FALSE);
+    TRACE("DrvAssertMode(dhpdev %p, FALSE) => %d\n", ppdev->dhpdev, assertVal);
+
+    if (assertVal)
+        ppdev->flFlags |= PDEV_DISABLED;
+
+    return assertVal;
+}
+
+VOID
 NTAPI
 PDEVOBJ_vRefreshModeList(
     PPDEVOBJ ppdev)
@@ -509,9 +548,9 @@ PDEVOBJ_bSwitchMode(
     // pdm = LDEVOBJ_bProbeAndCaptureDevmode(ppdev, pdm);
 
     /* 1. Temporarily disable the current PDEV and reset video to its default mode */
-    if (!ppdev->pfn.AssertMode(ppdev->dhpdev, FALSE))
+    if (!PDEVOBJ_bDisableDisplay(ppdev))
     {
-        DPRINT1("DrvAssertMode(FALSE) failed\n");
+        DPRINT1("PDEVOBJ_bDisableDisplay() failed\n");
         goto leave;
     }
 
@@ -560,10 +599,7 @@ PDEVOBJ_bSwitchMode(
 
 leave2:
     /* Set the new video mode, or restore the original one in case of failure */
-    if (!ppdev->pfn.AssertMode(ppdev->dhpdev, TRUE))
-    {
-        DPRINT1("DrvAssertMode(TRUE) failed\n");
-    }
+    PDEVOBJ_vEnableDisplay(ppdev);
 
 leave:
     /* Unlock everything else */

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -386,7 +386,7 @@ EngpCreatePDEV(
     }
 
     /* Try to get a diplay driver */
-    ppdev->pldev = EngLoadImageEx(pdm->dmDeviceName, LDEV_DEVICE_DISPLAY);
+    ppdev->pldev = LDEVOBJ_pLoadDriver(pdm->dmDeviceName, LDEV_DEVICE_DISPLAY);
     if (!ppdev->pldev)
     {
         DPRINT1("Could not load display driver '%ls', '%ls'\n",

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -313,7 +313,7 @@ EngpCreatePDEV(
     /* Try to find the GRAPHICS_DEVICE */
     if (pustrDeviceName)
     {
-        pGraphicsDevice = EngpFindGraphicsDevice(pustrDeviceName, 0, 0);
+        pGraphicsDevice = EngpFindGraphicsDevice(pustrDeviceName, 0);
         if (!pGraphicsDevice)
         {
             DPRINT1("No GRAPHICS_DEVICE found for %ls!\n",

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -989,6 +989,33 @@ PDEVOBJ_vGetDeviceCaps(
 
 /** Exported functions ********************************************************/
 
+/*
+ * @implemented
+ */
+BOOL
+APIENTRY
+EngQueryDeviceAttribute(
+    _In_ HDEV hdev,
+    _In_ ENG_DEVICE_ATTRIBUTE devAttr,
+    _In_reads_bytes_(cjInSize) PVOID pvIn,
+    _In_ ULONG cjInSize,
+    _Out_writes_bytes_(cjOutSize) PVOID pvOut,
+    _In_ ULONG cjOutSize)
+{
+    PPDEVOBJ ppdev = (PPDEVOBJ)hdev;
+
+    if (devAttr != QDA_ACCELERATION_LEVEL)
+        return FALSE;
+
+    if (cjOutSize >= sizeof(DWORD))
+    {
+        *(DWORD*)pvOut = ppdev->dwAccelerationLevel;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
 _Must_inspect_result_ _Ret_z_
 LPWSTR
 APIENTRY

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -352,83 +352,88 @@ PDEVOBJ_vRefreshModeList(
     EngReleaseSemaphore(ppdev->hsemDevLock);
 }
 
-static
 PPDEVOBJ
-EngpCreatePDEV(
-    PUNICODE_STRING pustrDeviceName,
-    PDEVMODEW pdm)
+PDEVOBJ_Create(
+    _In_opt_ PGRAPHICS_DEVICE pGraphicsDevice,
+    _In_opt_ PDEVMODEW pdm,
+    _In_ ULONG ldevtype)
 {
-    PGRAPHICS_DEVICE pGraphicsDevice;
-    PPDEVOBJ ppdev;
-    PDEVMODEW newDevMode;
+    PPDEVOBJ ppdev, ppdevMatch = NULL;
+    PLDEVOBJ pldev;
+    PSURFACE pSurface;
 
-    DPRINT("EngpCreatePDEV(%wZ, %p)\n", pustrDeviceName, pdm);
+    TRACE("PDEVOBJ_Create(%p %p %d)\n", pGraphicsDevice, pdm, ldevtype);
 
-    /* Try to find the GRAPHICS_DEVICE */
-    if (pustrDeviceName)
+    if (ldevtype != LDEV_DEVICE_META)
     {
-        pGraphicsDevice = EngpFindGraphicsDevice(pustrDeviceName, 0);
-        if (!pGraphicsDevice)
+        ASSERT(pGraphicsDevice);
+        ASSERT(pdm);
+        /* Search if we already have a PPDEV with the required characteristics.
+         * We will compare the graphics device, the devmode and the desktop
+         */
+        for (ppdev = gppdevList; ppdev; ppdev = ppdev->ppdevNext)
         {
-            DPRINT1("No GRAPHICS_DEVICE found for %ls!\n",
-                    pustrDeviceName ? pustrDeviceName->Buffer : 0);
-            return NULL;
+            if (ppdev->pGraphicsDevice == pGraphicsDevice)
+            {
+                PDEVOBJ_vReference(ppdev);
+
+                if (RtlEqualMemory(pdm, ppdev->pdmwDev, sizeof(DEVMODEW)))
+                {
+                    PDEVOBJ_vReference(ppdev);
+                    ppdevMatch = ppdev;
+                }
+                else
+                {
+                    PDEVOBJ_bDisableDisplay(ppdev);
+                }
+
+                PDEVOBJ_vRelease(ppdev);
+            }
+        }
+
+        if (ppdevMatch)
+        {
+            PDEVOBJ_vEnableDisplay(ppdevMatch);
+
+            return ppdevMatch;
         }
     }
-    else
+
+    /* Try to get a display driver */
+    pldev = LDEVOBJ_pLoadDriver(pdm->dmDeviceName, ldevtype);
+    if (!pldev)
     {
-        ASSERT(gpPrimaryGraphicsDevice);
-        pGraphicsDevice = gpPrimaryGraphicsDevice;
+        ERR("Could not load display driver '%S'\n",
+             (ldevtype == LDEV_DEVICE_META) ? L"" : pdm->dmDeviceName);
+        return NULL;
     }
 
     /* Allocate a new PDEVOBJ */
     ppdev = PDEVOBJ_AllocPDEV();
     if (!ppdev)
     {
-        DPRINT1("failed to allocate a PDEV\n");
+        ERR("failed to allocate a PDEV\n");
         return NULL;
     }
 
-    /* If no DEVMODEW is given, ... */
-    if (!pdm)
+    if (ldevtype != LDEV_DEVICE_META)
     {
-        /* ... use the device's default one */
-        pdm = pGraphicsDevice->pDevModeList[pGraphicsDevice->iDefaultMode].pdm;
-        DPRINT("Using iDefaultMode = %lu\n", pGraphicsDevice->iDefaultMode);
+        ppdev->pGraphicsDevice = pGraphicsDevice;
+
+        // DxEngGetHdevData asks for Graphics DeviceObject in hSpooler field
+        ppdev->hSpooler = ppdev->pGraphicsDevice->DeviceObject;
+
+        /* Keep selected resolution */
+        if (ppdev->pdmwDev)
+            ExFreePoolWithTag(ppdev->pdmwDev, GDITAG_DEVMODE);
+        ppdev->pdmwDev = ExAllocatePoolWithTag(PagedPool, pdm->dmSize + pdm->dmDriverExtra, GDITAG_DEVMODE);
+        if (ppdev->pdmwDev)
+        {
+            RtlCopyMemory(ppdev->pdmwDev, pdm, pdm->dmSize + pdm->dmDriverExtra);
+            /* FIXME: this must be done in a better way */
+            pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_ATTACHED_TO_DESKTOP;
+        }
     }
-
-    /* Try to get a diplay driver */
-    ppdev->pldev = LDEVOBJ_pLoadDriver(pdm->dmDeviceName, LDEV_DEVICE_DISPLAY);
-    if (!ppdev->pldev)
-    {
-        DPRINT1("Could not load display driver '%ls', '%ls'\n",
-                pGraphicsDevice->pDiplayDrivers,
-                pdm->dmDeviceName);
-        PDEVOBJ_vRelease(ppdev);
-        return NULL;
-    }
-
-    /* Copy the function table */
-    ppdev->pfn = ppdev->pldev->pfn;
-
-    /* Set MovePointer function */
-    ppdev->pfnMovePointer = ppdev->pfn.MovePointer;
-    if (!ppdev->pfnMovePointer)
-        ppdev->pfnMovePointer = EngMovePointer;
-
-    ppdev->pGraphicsDevice = pGraphicsDevice;
-
-    // DxEngGetHdevData asks for Graphics DeviceObject in hSpooler field
-    ppdev->hSpooler = ppdev->pGraphicsDevice->DeviceObject;
-
-    // Should we change the ative mode of pGraphicsDevice ?
-    if (!LDEVOBJ_bProbeAndCaptureDevmode(pGraphicsDevice, pdm, &newDevMode, TRUE))
-    {
-        DPRINT1("LDEVOBJ_bProbeAndCaptureDevmode() failed\n");
-        PDEVOBJ_vRelease(ppdev);
-        return NULL;
-    }
-    ppdev->pdmwDev = newDevMode;
 
     /* FIXME! */
     ppdev->flFlags = PDEV_DISPLAY;
@@ -436,19 +441,42 @@ EngpCreatePDEV(
     /* HACK: Don't use the pointer */
     ppdev->Pointer.Exclude.right = -1;
 
+    /* Initialize PDEV */
+    ppdev->pldev = pldev;
+
     /* Call the driver to enable the PDEV */
     if (!PDEVOBJ_bEnablePDEV(ppdev, pdm, NULL))
     {
-        DPRINT1("Failed to enable PDEV!\n");
+        ERR("Failed to enable PDEV!\n");
         PDEVOBJ_vRelease(ppdev);
+        EngUnloadImage(pldev);
         return NULL;
     }
 
-    /* FIXME: this must be done in a better way */
-    pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_ATTACHED_TO_DESKTOP;
+    /* Copy the function table */
+    ppdev->pfn = ppdev->pldev->pfn;
 
     /* Tell the driver that the PDEV is ready */
     PDEVOBJ_vCompletePDEV(ppdev);
+
+    /* Create the initial surface */
+    pSurface = PDEVOBJ_pSurface(ppdev);
+    if (!pSurface)
+    {
+        ERR("Failed to create surface\n");
+        PDEVOBJ_vRelease(ppdev);
+        EngUnloadImage(pldev);
+        return NULL;
+    }
+
+    /* Set MovePointer function */
+    ppdev->pfnMovePointer = ppdev->pfn.MovePointer;
+    if (!ppdev->pfnMovePointer)
+        ppdev->pfnMovePointer = EngMovePointer;
+
+    /* Insert the PDEV into the list */
+    ppdev->ppdevNext = gppdevList;
+    gppdevList = ppdev;
 
     /* Return the PDEV */
     return ppdev;
@@ -531,7 +559,6 @@ PDEVOBJ_bSwitchMode(
     PPDEVOBJ ppdev,
     PDEVMODEW pdm)
 {
-    UNICODE_STRING ustrDevice;
     PPDEVOBJ ppdevTmp;
     PSURFACE pSurface;
     BOOL retval = FALSE;
@@ -555,8 +582,7 @@ PDEVOBJ_bSwitchMode(
     }
 
     /* 2. Create new PDEV */
-    RtlInitUnicodeString(&ustrDevice, ppdev->pGraphicsDevice->szWinDeviceName);
-    ppdevTmp = EngpCreatePDEV(&ustrDevice, pdm);
+    ppdevTmp = PDEVOBJ_Create(ppdev->pGraphicsDevice, pdm, LDEV_DEVICE_DISPLAY);
     if (!ppdevTmp)
     {
         DPRINT1("Failed to create a new PDEV\n");
@@ -657,14 +683,17 @@ EngpGetPDEV(
     }
     else
     {
+        if (pustrDeviceName)
+            pGraphicsDevice = EngpFindGraphicsDevice(pustrDeviceName, 0);
+        if (!pGraphicsDevice)
+            pGraphicsDevice = gpPrimaryGraphicsDevice;
+
         /* No, create a new PDEV for the given device */
-        ppdev = EngpCreatePDEV(pustrDeviceName, NULL);
+        ppdev = PDEVOBJ_Create(pGraphicsDevice,
+                               pGraphicsDevice->pDevModeList[pGraphicsDevice->iDefaultMode].pdm,
+                               LDEV_DEVICE_DISPLAY);
         if (ppdev)
         {
-            /* Insert the PDEV into the list */
-            ppdev->ppdevNext = gppdevList;
-            gppdevList = ppdev;
-
             /* Set as primary PDEV, if we don't have one yet */
             if (!gppdevPrimary)
             {

--- a/win32ss/gdi/eng/pdevobj.c
+++ b/win32ss/gdi/eng/pdevobj.c
@@ -11,8 +11,6 @@
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(EngPDev);
 
-PPDEVOBJ gppdevPrimary = NULL;
-
 static PPDEVOBJ gppdevList = NULL;
 static HSEMAPHORE ghsemPDEV;
 
@@ -150,8 +148,8 @@ PDEVOBJ_vRelease(
         }
 
         /* Is this the primary one ? */
-        if (ppdev == gppdevPrimary)
-            gppdevPrimary = NULL;
+        if (ppdev == gpmdev->ppdevGlobal)
+            gpmdev->ppdevGlobal = NULL;
 
         /* Unload display driver */
         EngUnloadImage(ppdev->pldev);
@@ -615,7 +613,7 @@ PDEVOBJ_bSwitchMode(
     PDEVOBJ_vRelease(ppdevTmp);
 
     /* Update primary display capabilities */
-    if (ppdev == gppdevPrimary)
+    if (ppdev == gpmdev->ppdevGlobal)
     {
         PDEVOBJ_vGetDeviceCaps(ppdev, &GdiHandleTable->DevCaps);
     }
@@ -669,10 +667,10 @@ EngpGetPDEV(
             }
         }
     }
-    else
+    else if (gpmdev)
     {
         /* Otherwise use the primary PDEV */
-        ppdev = gppdevPrimary;
+        ppdev = gpmdev->ppdevGlobal;
     }
 
     /* Did we find one? */
@@ -695,9 +693,9 @@ EngpGetPDEV(
         if (ppdev)
         {
             /* Set as primary PDEV, if we don't have one yet */
-            if (!gppdevPrimary)
+            if (!gpmdev->ppdevGlobal)
             {
-                gppdevPrimary = ppdev;
+                gpmdev->ppdevGlobal = ppdev;
                 ppdev->pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_PRIMARY_DEVICE;
             }
         }

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -213,10 +213,4 @@ PDEVOBJ_bSwitchMode(
     PPDEVOBJ ppdev,
     PDEVMODEW pdm);
 
-PDEVMODEW
-NTAPI
-PDEVOBJ_pdmMatchDevMode(
-    PPDEVOBJ ppdev,
-    PDEVMODEW pdm);
-
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -228,4 +228,20 @@ PDEVOBJ_Create(
     _In_opt_ PDEVMODEW pdm,
     _In_ ULONG ldevtype);
 
+/* Change display settings:
+ * - pustrDeviceName: name of the device to change settings. Can be NULL to specify whole display surface
+ * - RequestedMode: new parameters for device. Ignored if pstrDeviceName is NULL
+ * - pmdevOld: old MDEVOBJ. Can be NULL if we are creating the first one
+ * - ppdevNew: MDEVOBJ created by this function, with the new settings
+ * - bSearchClosestMode: do we need to search exact requested mode, or a mostly similar one
+ * Return value: a DISP_CHANGE_* value
+ */
+LONG
+PDEVOBJ_lChangeDisplaySettings(
+    _In_opt_ PUNICODE_STRING pustrDeviceName,
+    _In_opt_ PDEVMODEW RequestedMode,
+    _In_opt_ PMDEVOBJ pmdevOld,
+    _Out_ PMDEVOBJ *ppmdevNew,
+    _In_ BOOL bSearchClosestMode);
+
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -128,6 +128,7 @@ typedef struct _PDEVOBJ
     PDEVMODEW                 pdmwDev;        /* Ptr->DEVMODEW.dmSize + dmDriverExtra == alloc size. */
 //  DWORD                     Unknown3;
     FLONG                     DxDd_Flags;     /* DxDD active status flags. */
+    DWORD                     dwAccelerationLevel;
 //  LONG                      devAttr;
 //  PVOID                     WatchDogContext;
 //  ULONG                     WatchDogs;
@@ -224,6 +225,7 @@ PPDEVOBJ
 PDEVOBJ_Create(
     _In_opt_ PGRAPHICS_DEVICE pGraphicsDevice,
     _In_opt_ PDEVMODEW pdm,
+    _In_ ULONG dwAccelerationLevel,
     _In_ ULONG ldevtype);
 
 /* Change display settings:

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -219,4 +219,12 @@ PDEVOBJ_bDynamicModeChange(
     _Inout_ PPDEVOBJ ppdev,
     _Inout_ PPDEVOBJ ppdev2);
 
+VOID
+PDEVOBJ_vEnableDisplay(
+    _Inout_ PPDEVOBJ ppdev);
+
+BOOL
+PDEVOBJ_bDisableDisplay(
+    _Inout_ PPDEVOBJ ppdev);
+
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -74,8 +74,6 @@ typedef struct _GRAPHICS_DEVICE
     PVOID            pUnknown;
     PFILE_OBJECT     FileObject;
     DWORD            ProtocolType;
-    ULONG            iDefaultMode;
-    ULONG            iCurrentMode;
 } GRAPHICS_DEVICE, *PGRAPHICS_DEVICE;
 
 typedef struct _PDEVOBJ

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -150,11 +150,6 @@ typedef struct _PDEVOBJ
     struct _EDD_DIRECTDRAW_GLOBAL * pEDDgpl;
 } PDEVOBJ, *PPDEVOBJ;
 
-/* Globals ********************************************************************/
-
-extern PPDEVOBJ gppdevPrimary;
-
-
 /* Function prototypes ********************************************************/
 
 PPDEVOBJ

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -227,4 +227,10 @@ BOOL
 PDEVOBJ_bDisableDisplay(
     _Inout_ PPDEVOBJ ppdev);
 
+PPDEVOBJ
+PDEVOBJ_Create(
+    _In_opt_ PGRAPHICS_DEVICE pGraphicsDevice,
+    _In_opt_ PDEVMODEW pdm,
+    _In_ ULONG ldevtype);
+
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/pdevobj.h
+++ b/win32ss/gdi/eng/pdevobj.h
@@ -213,4 +213,10 @@ PDEVOBJ_bSwitchMode(
     PPDEVOBJ ppdev,
     PDEVMODEW pdm);
 
+BOOL
+NTAPI
+PDEVOBJ_bDynamicModeChange(
+    _Inout_ PPDEVOBJ ppdev,
+    _Inout_ PPDEVOBJ ppdev2);
+
 #endif /* !__WIN32K_PDEVOBJ_H */

--- a/win32ss/gdi/eng/stubs.c
+++ b/win32ss/gdi/eng/stubs.c
@@ -580,34 +580,6 @@ EngPlgBlt(
 /*
  * @unimplemented
  */
-BOOL
-APIENTRY
-EngQueryDeviceAttribute(
-    _In_ HDEV hdev,
-    _In_ ENG_DEVICE_ATTRIBUTE devAttr,
-    _In_reads_bytes_(cjInSize) PVOID pvIn,
-    _In_ ULONG cjInSize,
-    _Out_writes_bytes_(cjOutSize) PVOID pvOut,
-    _In_ ULONG cjOutSize)
-{
-    if (devAttr != QDA_ACCELERATION_LEVEL)
-        return FALSE;
-
-    UNIMPLEMENTED;
-
-    if (cjOutSize >= sizeof(DWORD))
-    {
-        /* Set all accelerations to enabled */
-        *(DWORD*)pvOut = 0;
-        return TRUE;
-    }
-
-    return FALSE;
-}
-
-/*
- * @unimplemented
- */
 LARGE_INTEGER
 APIENTRY
 EngQueryFileTimeStamp(IN LPWSTR FileName)

--- a/win32ss/gdi/ntgdi/dclife.c
+++ b/win32ss/gdi/ntgdi/dclife.c
@@ -144,7 +144,7 @@ DC_vInitDc(
     pdc->pdcattr = &pdc->dcattr;
     pdc->dcattr.pvLDC = NULL;
     pdc->dcattr.ulDirty_ = DIRTY_DEFAULT;
-    if (ppdev == gppdevPrimary)
+    if (ppdev == gpmdev->ppdevGlobal)
         pdc->dcattr.ulDirty_ |= DC_PRIMARY_DISPLAY;
 
     /* Setup the DC size */

--- a/win32ss/gdi/ntgdi/device.c
+++ b/win32ss/gdi/ntgdi/device.c
@@ -29,13 +29,13 @@ BOOL FASTCALL
 IntCreatePrimarySurface(VOID)
 {
     /* Create surface */
-    PDEVOBJ_pSurface(gppdevPrimary);
+    PDEVOBJ_pSurface(gpmdev->ppdevGlobal);
 
-    DPRINT("IntCreatePrimarySurface, gppdevPrimary=%p, gppdevPrimary->pSurface = %p\n",
-        gppdevPrimary, gppdevPrimary->pSurface);
+    DPRINT("IntCreatePrimarySurface, ppdevGlobal=%p, ppdevGlobal->pSurface = %p\n",
+        gpmdev->ppdevGlobal, gpmdev->ppdevGlobal->pSurface);
 
     // Init Primary Displays Device Capabilities.
-    PDEVOBJ_vGetDeviceCaps(gppdevPrimary, &GdiHandleTable->DevCaps);
+    PDEVOBJ_vGetDeviceCaps(gpmdev->ppdevGlobal, &GdiHandleTable->DevCaps);
 
     return TRUE;
 }
@@ -51,7 +51,7 @@ IntEnumHDev(VOID)
 {
 // I guess we will soon have more than one primary surface.
 // This will do for now.
-    return gppdevPrimary;
+    return gpmdev->ppdevGlobal;
 }
 
 

--- a/win32ss/gdi/ntgdi/gdidbg.c
+++ b/win32ss/gdi/ntgdi/gdidbg.c
@@ -32,6 +32,7 @@ DBG_CHANNEL DbgChannels[DbgChCount] = {
     {L"EngLDev", DbgChEngLDev},
     {L"EngLine", DbgChEngLine},
     {L"EngMapping", DbgChEngMapping},
+    {L"EngMDev", DbgChEngMDev},
     {L"EngPDev", DbgChEngPDev},
     {L"EngSurface", DbgChEngSurface},
     {L"EngWnd", DbgChEngWnd},

--- a/win32ss/user/ntuser/display.c
+++ b/win32ss/user/ntuser/display.c
@@ -73,7 +73,6 @@ InitDisplayDriver(
     WCHAR awcBuffer[128];
     ULONG cbSize;
     HKEY hkey;
-    DEVMODEW dmDefault;
     DWORD dwVga;
 
     TRACE("InitDisplayDriver(%S, %S);\n",
@@ -126,9 +125,6 @@ InitDisplayDriver(
         RtlInitUnicodeString(&ustrDescription, L"<unknown>");
     }
 
-    /* Query the default settings */
-    RegReadDisplaySettings(hkey, &dmDefault);
-
     /* Query if this is a VGA compatible driver */
     cbSize = sizeof(DWORD);
     Status = RegQueryValue(hkey, L"VgaCompatible", REG_DWORD, &dwVga, &cbSize);
@@ -141,8 +137,7 @@ InitDisplayDriver(
     RtlInitUnicodeString(&ustrDeviceName, pwszDeviceName);
     pGraphicsDevice = EngpRegisterGraphicsDevice(&ustrDeviceName,
                                                  &ustrDisplayDrivers,
-                                                 &ustrDescription,
-                                                 &dmDefault);
+                                                 &ustrDescription);
     if (pGraphicsDevice && dwVga)
     {
         pGraphicsDevice->StateFlags |= DISPLAY_DEVICE_VGA_COMPATIBLE;

--- a/win32ss/user/ntuser/display.c
+++ b/win32ss/user/ntuser/display.c
@@ -253,7 +253,7 @@ UserEnumDisplayDevices(
     }
 
     /* Ask gdi for the GRAPHICS_DEVICE */
-    pGraphicsDevice = EngpFindGraphicsDevice(pustrDevice, iDevNum, 0);
+    pGraphicsDevice = EngpFindGraphicsDevice(pustrDevice, iDevNum);
     if (!pGraphicsDevice)
     {
         /* No device found */
@@ -423,7 +423,7 @@ UserEnumDisplaySettings(
           pustrDevice, iModeNum);
 
     /* Ask GDI for the GRAPHICS_DEVICE */
-    pGraphicsDevice = EngpFindGraphicsDevice(pustrDevice, 0, 0);
+    pGraphicsDevice = EngpFindGraphicsDevice(pustrDevice, 0);
     ppdev = EngpGetPDEV(pustrDevice);
 
     if (!pGraphicsDevice || !ppdev)

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -47,16 +47,16 @@ InitMetrics(VOID)
         ZwClose(hKey);
     }
 
-    /* FIXME: HACK, due to missing PDEV on first init */
-    if (!gppdevPrimary)
+    /* FIXME: HACK, due to missing MDEV on first init */
+    if (!gpmdev)
     {
         Width = 640;
         Height = 480;
     }
     else
     {
-        Width = gppdevPrimary->gdiinfo.ulHorzRes;
-        Height = gppdevPrimary->gdiinfo.ulVertRes;
+        Width = gpmdev->ppdevGlobal->gdiinfo.ulHorzRes;
+        Height = gpmdev->ppdevGlobal->gdiinfo.ulVertRes;
     }
 
     /* Screen sizes */

--- a/win32ss/user/ntuser/tags.h
+++ b/win32ss/user/ntuser/tags.h
@@ -71,6 +71,7 @@
 #define GDITAG_DC_FREELIST               'fcdG'
 #define GDITAG_DWMSTATE                  'scDG'
 #define GDITAG_DEVMODE                   'vedG'
+#define GDITAG_MDEV                      'vdmG'
 #define GDITAG_PDEV                      'veDG'
 #define GDITAG_HGLYPH_ARRAY              'mfdG'
 #define GDITAG_DRVSUP                    'srdG'

--- a/win32ss/user/ntuser/win32kdebug.h
+++ b/win32ss/user/ntuser/win32kdebug.h
@@ -53,6 +53,7 @@
         DbgChEngLDev,
         DbgChEngLine,
         DbgChEngMapping,
+        DbgChEngMDev,
         DbgChEngPDev,
         DbgChEngSurface,
         DbgChEngWnd,

--- a/win32ss/user/ntuser/windc.c
+++ b/win32ss/user/ntuser/windc.c
@@ -41,7 +41,8 @@ DceCreateDisplayDC(VOID)
 {
   UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"DISPLAY");
 
-  co_IntGraphicsCheck(TRUE);
+  if (!co_IntGraphicsCheck(TRUE))
+    KeBugCheckEx(VIDEO_DRIVER_INIT_FAILURE, 0, 0, 0, USER_VERSION);
 
   return IntGdiCreateDC(&DriverName, NULL, NULL, NULL, FALSE);
 }

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -263,10 +263,9 @@ co_IntInitializeDesktopGraphics(VOID)
     UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"DISPLAY");
     PDESKTOP pdesk;
 
-    gpmdev = ExAllocatePoolZero(PagedPool, sizeof(MDEVOBJ), GDITAG_MDEV);
-    if (!gpmdev)
+    if (PDEVOBJ_lChangeDisplaySettings(NULL, NULL, NULL, &gpmdev, TRUE) != DISP_CHANGE_SUCCESSFUL)
     {
-        ERR("Failed to allocate MDEV.\n");
+        ERR("PDEVOBJ_lChangeDisplaySettings() failed.\n");
         return FALSE;
     }
 

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -335,7 +335,7 @@ co_IntInitializeDesktopGraphics(VOID)
         HDC hdc;
         ULONG iDevNum;
 
-        for (iDevNum = 1; (pGraphicsDevice = EngpFindGraphicsDevice(NULL, iDevNum, 0)) != NULL; iDevNum++)
+        for (iDevNum = 1; (pGraphicsDevice = EngpFindGraphicsDevice(NULL, iDevNum)) != NULL; iDevNum++)
         {
             RtlInitUnicodeString(&DisplayName, pGraphicsDevice->szWinDeviceName);
             hdc = IntGdiCreateDC(&DriverName, &DisplayName, NULL, NULL, FALSE);

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -263,6 +263,13 @@ co_IntInitializeDesktopGraphics(VOID)
     UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"DISPLAY");
     PDESKTOP pdesk;
 
+    gpmdev = ExAllocatePoolZero(PagedPool, sizeof(MDEVOBJ), GDITAG_MDEV);
+    if (!gpmdev)
+    {
+        ERR("Failed to allocate MDEV.\n");
+        return FALSE;
+    }
+
     ScreenDeviceContext = IntGdiCreateDC(&DriverName, NULL, NULL, NULL, FALSE);
     if (NULL == ScreenDeviceContext)
     {
@@ -285,11 +292,11 @@ co_IntInitializeDesktopGraphics(VOID)
     InitMetrics();
 
     /* Set new size of the monitor */
-    UserUpdateMonitorSize((HDEV)gppdevPrimary);
+    UserUpdateMonitorSize((HDEV)gpmdev->ppdevGlobal);
 
     /* Update the SERVERINFO */
-    gpsi->aiSysMet[SM_CXSCREEN] = gppdevPrimary->gdiinfo.ulHorzRes;
-    gpsi->aiSysMet[SM_CYSCREEN] = gppdevPrimary->gdiinfo.ulVertRes;
+    gpsi->aiSysMet[SM_CXSCREEN] = gpmdev->ppdevGlobal->gdiinfo.ulHorzRes;
+    gpsi->aiSysMet[SM_CYSCREEN] = gpmdev->ppdevGlobal->gdiinfo.ulVertRes;
     gpsi->Planes        = NtGdiGetDeviceCaps(ScreenDeviceContext, PLANES);
     gpsi->BitsPixel     = NtGdiGetDeviceCaps(ScreenDeviceContext, BITSPIXEL);
     gpsi->BitCount      = gpsi->Planes * gpsi->BitsPixel;
@@ -311,7 +318,7 @@ co_IntInitializeDesktopGraphics(VOID)
     gpsi->ptCursor.y = gpsi->aiSysMet[SM_CYSCREEN] / 2;
 
     /* Attach monitor */
-    UserAttachMonitor((HDEV)gppdevPrimary);
+    UserAttachMonitor((HDEV)gpmdev->ppdevGlobal);
 
     /* Setup the cursor */
     co_IntLoadDefaultCursors();

--- a/win32ss/win32kp.h
+++ b/win32ss/win32kp.h
@@ -23,6 +23,7 @@ typedef struct _DC *PDC;
 #include "gdi/ntgdi/gdiobj.h"
 #include "gdi/ntgdi/palette.h"
 #include "gdi/eng/surface.h"
+#include "gdi/eng/mdevobj.h"
 #include "gdi/eng/pdevobj.h"
 #include "gdi/eng/ldevobj.h"
 #include "gdi/eng/device.h"


### PR DESCRIPTION
## Purpose

Preparatory work to handle multiple displays.

- rework loading/unloading of graphic display drivers to not tie PDEVOBJ creation and using graphics display driver
- introduce MDEVOBJ structure, to keep a list of currently enable displays
- add a way to load "internal" drivers, ie drivers with entrypoint in win32k
- add a stub for multidisplay driver, which always returns failure
- invoke multidisplay driver when having more than one display

## TODO

- when enumerating display settings (with desk.cpl), the display settings list is refreshed at each mode query. Try to refresh this list only when required?
- UserChangeDisplaySettings needs to call PDEVOBJ_lChangeDisplaySettings
- implement the multidisplay driver