### PR TITLE
[HALX86] Parse the MADT tables and make then usable across the APIC/SMP Hal(s)

### DIFF
--- a/hal/halx86/CMakeLists.txt
+++ b/hal/halx86/CMakeLists.txt
@@ -66,7 +66,8 @@ if(ARCH STREQUAL "i386")
     add_hal(halxbox SOURCES xbox/halxbox.rc COMPONENTS xbox up)
     add_hal(halpc98 SOURCES pc98/halpc98.rc COMPONENTS pc98 up)
 
-    #add_hal(halmacpi SOURCES acpi/halacpi.rc COMPONENTS generic acpi smp pic)
+    #add_hal(halmacpi SOURCES smp/halmacpi.rc COMPONENTS generic acpi smp apic)
+    #add_hal(halmp SOURCES mp/halmp.rc COMPONENTS generic legacy smp apic)
 
 elseif(ARCH STREQUAL "amd64")
 

--- a/hal/halx86/acpi.cmake
+++ b/hal/halx86/acpi.cmake
@@ -1,11 +1,20 @@
 
+include_directories(include ${REACTOS_SOURCE_DIR}/drivers/bus/acpi/acpica/include)
+
 list(APPEND HAL_ACPI_SOURCE
     acpi/halacpi.c
     acpi/halpnpdd.c
     acpi/busemul.c
+    acpi/madt.c
     legacy/bus/pcibus.c)
 
+# Needed to compile while using ACPICA
+if(ARCH STREQUAL "amd64")
+    add_definitions(-DWIN64)
+endif()
+
 add_library(lib_hal_acpi OBJECT ${HAL_ACPI_SOURCE})
+add_pch(lib_hal_acpi ${REACTOS_SOURCE_DIR}/drivers/bus/acpi/acpica/include/acpi.h ${HAL_ACPI_SOURCE})
 add_dependencies(lib_hal_acpi bugcodes xdk)
 #add_pch(lib_hal_acpi include/hal.h)
 

--- a/hal/halx86/acpi/madt.c
+++ b/hal/halx86/acpi/madt.c
@@ -1,0 +1,30 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Source File for MADT Table parsing
+ * COPYRIGHT:   Copyright 2021 Justin Miller <justinmiller100@gmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <hal.h>
+#include <acpi.h>
+/* ACPI_BIOS_ERROR defined in acoutput.h and bugcodes.h */
+#undef ACPI_BIOS_ERROR
+#include <smp.h>
+#define NDEBUG
+#include <debug.h>
+
+/* GLOBALS ********************************************************************/
+
+PROCESSOR_IDENTITY HalpStaticProcessorIdentity[MAXIMUM_PROCESSORS] = {{0}};
+PPROCESSOR_IDENTITY HalpProcessorIdentity = NULL;
+
+/* FUNCTIONS ******************************************************************/
+
+VOID
+HalpParseApicTables(
+    _In_ PLOADER_PARAMETER_BLOCK LoaderBlock)
+{
+    UNIMPLEMENTED;
+}

--- a/hal/halx86/acpi/madt.c
+++ b/hal/halx86/acpi/madt.c
@@ -19,6 +19,10 @@
 
 PROCESSOR_IDENTITY HalpStaticProcessorIdentity[MAXIMUM_PROCESSORS] = {{0}};
 PPROCESSOR_IDENTITY HalpProcessorIdentity = NULL;
+HALP_APIC_INFO_TABLE HalpApicInfoTable;
+ACPI_TABLE_MADT *MadtTable;
+ACPI_SUBTABLE_HEADER *AcpiHeader;
+ACPI_MADT_LOCAL_APIC *LocalApic;
 
 /* FUNCTIONS ******************************************************************/
 
@@ -26,7 +30,46 @@ VOID
 HalpParseApicTables(
     _In_ PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-    UNIMPLEMENTED;
+    ULONG_PTR TableEnd;
+    ULONG ValidProcessorCount;
+
+    /* We only support legacy APIC for now, this will be updated in the future */
+    HalpApicInfoTable.ApicMode = 0x10;
+    MadtTable = HalAcpiGetTable(LoaderBlock, 'CIPA');
+
+    AcpiHeader = (ACPI_SUBTABLE_HEADER*)MadtTable;
+    AcpiHeader->Length = sizeof(ACPI_TABLE_MADT);
+    TableEnd = (ULONG_PTR)MadtTable + MadtTable->Header.Length;
+
+    HalpApicInfoTable.ProcessorCount = 0;
+    HalpProcessorIdentity = HalpStaticProcessorIdentity;
+
+    AcpiHeader = (ACPI_SUBTABLE_HEADER*)MadtTable;
+    AcpiHeader->Length = sizeof(ACPI_TABLE_MADT);
+    TableEnd = (ULONG_PTR)MadtTable + MadtTable->Header.Length;
+
+    while ((ULONG_PTR)AcpiHeader <= TableEnd)
+    {
+        LocalApic = (ACPI_MADT_LOCAL_APIC*)AcpiHeader;
+
+        if (LocalApic->Header.Type == ACPI_MADT_TYPE_LOCAL_APIC &&
+            LocalApic->Header.Length == sizeof(ACPI_MADT_LOCAL_APIC))
+        {
+            ValidProcessorCount = HalpApicInfoTable.ProcessorCount;
+
+            HalpProcessorIdentity[ValidProcessorCount].LapicId = LocalApic->Id;
+            HalpProcessorIdentity[ValidProcessorCount].ProcessorId = LocalApic->ProcessorId;
+
+            HalpApicInfoTable.ProcessorCount++;
+
+            AcpiHeader = (ACPI_SUBTABLE_HEADER*)((ULONG_PTR)AcpiHeader + AcpiHeader->Length);
+        }
+        else
+        {
+            /* End the parsing early if we don't use the currently selected table */
+            AcpiHeader = (ACPI_SUBTABLE_HEADER*)((ULONG_PTR)AcpiHeader + 1);
+        }
+    }
 }
 
 VOID

--- a/hal/halx86/acpi/madt.c
+++ b/hal/halx86/acpi/madt.c
@@ -28,3 +28,18 @@ HalpParseApicTables(
 {
     UNIMPLEMENTED;
 }
+
+VOID
+HalpPrintApicTables(VOID)
+{ 
+    UINT32 i;
+
+    DPRINT1("HAL has detected a physical processor count of: %d\n", HalpApicInfoTable.ProcessorCount);
+    for (i = 0; i < HalpApicInfoTable.ProcessorCount; i++)
+    {
+        DPRINT1("Information about the following processor is for processors number: %d\n"
+                "   The BSPCheck is set to: %X\n"
+                "   The LapicID is set to: %X\n",
+                i, HalpProcessorIdentity[i].BSPCheck, HalpProcessorIdentity[i].LapicId);
+    }
+}

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -25,13 +25,14 @@ HalpInitProcessor(
     IN ULONG ProcessorNumber,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
+#ifdef CONFIG_SMP
     if (ProcessorNumber == 0)
     {
-        /* APIC tables should always be parsed once before touching APIC */
+#endif
         HalpParseApicTables(LoaderBlock);
+#ifdef CONFIG_SMP
     }
 
-#ifdef CONFIG_SMP
     HalpSetupProcessorsTable(ProcessorNumber);
 #endif
 
@@ -52,6 +53,8 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
             (HalpBuildType & PRCB_BUILD_UNIPROCESSOR) ? "UP" : "SMP",
             (HalpBuildType & PRCB_BUILD_DEBUG) ? "DBG" : "REL");
 
+    HalpPrintApicTables();
+
     /* Enable clock interrupt handler */
     HalpEnableInterruptHandler(IDT_INTERNAL,
                                0,
@@ -59,9 +62,6 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                                CLOCK2_LEVEL,
                                HalpClockInterrupt,
                                Latched);
-#if DBG
-    HalpPrintApicTables();
-#endif
 }
 
 VOID

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -59,6 +59,9 @@ HalpInitPhase0(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
                                CLOCK2_LEVEL,
                                HalpClockInterrupt,
                                Latched);
+#if DBG
+    HalpPrintApicTables();
+#endif
 }
 
 VOID

--- a/hal/halx86/apic/halinit.c
+++ b/hal/halx86/apic/halinit.c
@@ -9,6 +9,7 @@
 
 #include <hal.h>
 #include "apicp.h"
+#include <smp.h>
 #define NDEBUG
 #include <debug.h>
 
@@ -24,6 +25,16 @@ HalpInitProcessor(
     IN ULONG ProcessorNumber,
     IN PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
+    if (ProcessorNumber == 0)
+    {
+        /* APIC tables should always be parsed once before touching APIC */
+        HalpParseApicTables(LoaderBlock);
+    }
+
+#ifdef CONFIG_SMP
+    HalpSetupProcessorsTable(ProcessorNumber);
+#endif
+
     /* Initialize the local APIC for this cpu */
     ApicInitializeLocalApic(ProcessorNumber);
 

--- a/hal/halx86/include/smp.h
+++ b/hal/halx86/include/smp.h
@@ -1,0 +1,27 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Header File for SMP support
+ * COPYRIGHT:   Copyright 2021 Justin Miller <justinmiller100@gmail.com>
+ */
+
+#pragma once
+
+/* This table is filled for each physical processor on system */
+typedef struct _PROCESSOR_IDENTITY
+{
+    UCHAR ProcessorId;
+    UCHAR LapicId;
+    BOOLEAN ProcessorStarted;
+    BOOLEAN BSPCheck;
+    PKPRCB ProcessorPrcb;
+
+} PROCESSOR_IDENTITY, *PPROCESSOR_IDENTITY;
+
+VOID
+HalpParseApicTables(
+    _In_ PLOADER_PARAMETER_BLOCK LoaderBlock);
+
+VOID
+HalpSetupProcessorsTable(
+    _In_ UINT32 NTProcessorNumber);

--- a/hal/halx86/include/smp.h
+++ b/hal/halx86/include/smp.h
@@ -25,3 +25,6 @@ HalpParseApicTables(
 VOID
 HalpSetupProcessorsTable(
     _In_ UINT32 NTProcessorNumber);
+
+VOID
+HalpPrintApicTables(VOID);

--- a/hal/halx86/include/smp.h
+++ b/hal/halx86/include/smp.h
@@ -18,6 +18,19 @@ typedef struct _PROCESSOR_IDENTITY
 
 } PROCESSOR_IDENTITY, *PPROCESSOR_IDENTITY;
 
+/* This table is counter of the overall APIC constants acquired from madt */
+typedef struct _HALP_APIC_INFO_TABLE
+{
+    ULONG ApicMode;
+    ULONG ProcessorCount; /* Count of all physical cores, This includes BSP */
+    ULONG IOAPICCount;
+    ULONG LocalApicPA;                // The 32-bit physical address at which each processor can access its local interrupt controller
+    ULONG IoApicVA[256];
+    ULONG IoApicPA[256];
+    ULONG IoApicIrqBase[256]; // Global system interrupt base
+
+} HALP_APIC_INFO_TABLE, *PHALP_APIC_INFO_TABLE;
+
 VOID
 HalpParseApicTables(
     _In_ PLOADER_PARAMETER_BLOCK LoaderBlock);

--- a/hal/halx86/legacy.cmake
+++ b/hal/halx86/legacy.cmake
@@ -9,7 +9,8 @@ list(APPEND HAL_LEGACY_SOURCE
     legacy/bus/sysbus.c
     legacy/bussupp.c
     legacy/halpnpdd.c
-    legacy/halpcat.c)
+    legacy/halpcat.c
+    smp/mps/mps.c)
 
 add_library(lib_hal_legacy OBJECT ${HAL_LEGACY_SOURCE})
 add_dependencies(lib_hal_legacy bugcodes xdk)

--- a/hal/halx86/smp.cmake
+++ b/hal/halx86/smp.cmake
@@ -1,7 +1,8 @@
 
 list(APPEND HAL_SMP_SOURCE
     generic/buildtype.c
-    generic/spinlock.c)
+    generic/spinlock.c
+    smp/smp.c)
 
 add_library(lib_hal_smp OBJECT ${HAL_SMP_SOURCE})
 add_dependencies(lib_hal_smp bugcodes xdk)

--- a/hal/halx86/smp/mps/mps.c
+++ b/hal/halx86/smp/mps/mps.c
@@ -1,0 +1,22 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Source File for MPS specific functions
+ * COPYRIGHT:   Copyright 2021 Justin Miller <justinmiller100@gmail.com>
+ */
+
+/* INCLUDES *******************************************************************/
+
+#include <hal.h>
+#include <smp.h>
+#define NDEBUG
+#include <debug.h>
+
+/* FUNCTIONS ******************************************************************/
+
+VOID
+HalpParseApicTables(
+    _In_ PLOADER_PARAMETER_BLOCK LoaderBlock)
+{
+    UNIMPLEMENTED;
+}

--- a/hal/halx86/smp/mps/mps.c
+++ b/hal/halx86/smp/mps/mps.c
@@ -12,6 +12,12 @@
 #define NDEBUG
 #include <debug.h>
 
+/* GLOBALS ********************************************************************/
+
+PROCESSOR_IDENTITY HalpStaticProcessorIdentity[MAXIMUM_PROCESSORS] = {{0}};
+PPROCESSOR_IDENTITY HalpProcessorIdentity = NULL;
+UINT32 PhysicalProcessorCount = 0;
+
 /* FUNCTIONS ******************************************************************/
 
 VOID
@@ -19,4 +25,19 @@ HalpParseApicTables(
     _In_ PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
     UNIMPLEMENTED;
+}
+
+VOID
+HalpPrintApicTables(VOID)
+{
+    UINT32 i;
+
+    DPRINT1("HAL has detected a physical processor count of: %d\n", PhysicalProcessorCount);
+    for (i = 0; i < PhysicalProcessorCount; i++)
+    {
+        DPRINT1("Information about the following processor is for processors number: %d\n"
+                "   The BSPCheck is set to: %X\n"
+                "   The LapicID is set to: %X\n",
+                i, HalpProcessorIdentity[i].BSPCheck, HalpProcessorIdentity[i].LapicId);
+    }
 }

--- a/hal/halx86/smp/smp.c
+++ b/hal/halx86/smp/smp.c
@@ -1,0 +1,24 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Core source file for SMP management
+ * COPYRIGHT:   Copyright 2021 Justin Miller <justinmiller100@gmail.com>
+ */
+
+/* INCLUDES ******************************************************************/
+
+#include <hal.h>
+#include <smp.h>
+#define NDEBUG
+#include <debug.h>
+
+/* GLOBALS *******************************************************************/
+
+/* FUNCTIONS *****************************************************************/
+
+VOID
+HalpSetupProcessorsTable(
+    _In_ UINT32 NTProcessorNumber)
+{
+    UNIMPLEMENTED;
+}

--- a/hal/halx86/smp/smp.c
+++ b/hal/halx86/smp/smp.c
@@ -14,11 +14,20 @@
 
 /* GLOBALS *******************************************************************/
 
+extern PPROCESSOR_IDENTITY HalpProcessorIdentity;
+
 /* FUNCTIONS *****************************************************************/
 
 VOID
 HalpSetupProcessorsTable(
     _In_ UINT32 NTProcessorNumber)
 {
-    UNIMPLEMENTED;
+    PKPRCB CurrentPrcb;
+
+    /*
+     * Link the Prcb of the current CPU to
+     * the current CPUs entry in the global ProcessorIdentity
+     */
+    CurrentPrcb = KeGetCurrentPrcb();
+    HalpProcessorIdentity[NTProcessorNumber].ProcessorPrcb = CurrentPrcb;
 }


### PR DESCRIPTION
## Purpose

Parse the MADT tables and make then usable across the APIC/SMP Hal(s).

## Proposed changes

- Parse the MADT tables for the number of Local APICs in the system and those IDs.
- Use the ACPICA headers to gather the information.
- Give all the APIC Hals the ability to use the information in a custom structure.
- Add a helper function for getting a pointer to the PRCB of every processor in the system and assign it to the struct above
- Make this work in a way that can be easily integrated with the MPS Hal(s).
