### PR TITLE
[NTOS] A list of Misc Changes needed to boot ReactOS with SMP

### DIFF
--- a/ntoskrnl/ex/lookas.c
+++ b/ntoskrnl/ex/lookas.c
@@ -20,8 +20,8 @@ LIST_ENTRY ExpPagedLookasideListHead;
 KSPIN_LOCK ExpPagedLookasideListLock;
 LIST_ENTRY ExSystemLookasideListHead;
 LIST_ENTRY ExPoolLookasideListHead;
-GENERAL_LOOKASIDE ExpSmallNPagedPoolLookasideLists[MAXIMUM_PROCESSORS];
-GENERAL_LOOKASIDE ExpSmallPagedPoolLookasideLists[MAXIMUM_PROCESSORS];
+GENERAL_LOOKASIDE ExpSmallNPagedPoolLookasideLists[NUMBER_POOL_LOOKASIDE_LISTS];
+GENERAL_LOOKASIDE ExpSmallPagedPoolLookasideLists[NUMBER_POOL_LOOKASIDE_LISTS];
 
 /* PRIVATE FUNCTIONS *********************************************************/
 
@@ -99,7 +99,7 @@ ExpInitLookasideLists(VOID)
     KeInitializeSpinLock(&ExpPagedLookasideListLock);
 
     /* Initialize the system lookaside lists */
-    for (i = 0; i < MAXIMUM_PROCESSORS; i++)
+    for (i = 0; i < NUMBER_POOL_LOOKASIDE_LISTS; i++)
     {
         /* Initialize the non-paged list */
         ExInitializeSystemLookasideList(&ExpSmallNPagedPoolLookasideLists[i],

--- a/ntoskrnl/ke/i386/kiinit.c
+++ b/ntoskrnl/ke/i386/kiinit.c
@@ -547,7 +547,7 @@ KiInitializeKernel(IN PKPROCESS InitProcess,
     InitThread->State = Running;
     InitThread->Affinity = 1 << Number;
     InitThread->WaitIrql = DISPATCH_LEVEL;
-    InitProcess->ActiveProcessors = 1 << Number;
+    InitProcess->ActiveProcessors |= 1 << Number;
 
     /* HACK for MmUpdatePageDir */
     ((PETHREAD)InitThread)->ThreadsProcess = (PEPROCESS)InitProcess;

--- a/ntoskrnl/ke/i386/thrdini.c
+++ b/ntoskrnl/ke/i386/thrdini.c
@@ -427,6 +427,9 @@ KiSwapContextEntry(IN PKSWITCHFRAME SwitchFrame,
     /* Get the old thread and set its kernel stack */
     OldThread->KernelStack = SwitchFrame;
 
+    /* Set swapbusy to false for the new thread */
+    NewThread->SwapBusy = FALSE;
+
     /* ISRs can change FPU state, so disable interrupts while checking */
     _disable();
 


### PR DESCRIPTION
## Purpose

This PR is mostly to get conversation going about all the small changes me and  @HBelusca 
discovered while using ReactOS with SMP support.
This is a draft as I may add more to it the coming days.

However:
This isn't every problem with the multiprocessor kernel it's only the small stuff that kills the BSP when its called by the other CPUs


## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- [NTOS] Swap MAXIMUM_PROCESSORS with NUMBER_POOL_LOOKASIDE_LISTS
- [NTOS] fix timer lock data and hardcode
- [NTOS] Increment ActiveProcessors accurately
- [NTOS] Set SwapBusy properly for i386
