### PR TITLE
[WINHTTP] Fix 1 MSVC x86 warning LNK4199

### DIFF
--- a/dll/win32/winhttp/CMakeLists.txt
+++ b/dll/win32/winhttp/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(winhttp MODULE
 
 set_module_type(winhttp win32dll)
 target_link_libraries(winhttp uuid wine)
-add_delay_importlibs(winhttp oleaut32 ole32 crypt32 secur32)
+add_delay_importlibs(winhttp oleaut32 crypt32 secur32)
 add_importlibs(winhttp user32 advapi32 ws2_32 jsproxy kernel32_vista msvcrt kernel32 ntdll)
 add_dependencies(winhttp stdole2)
 add_pch(winhttp precomp.h SOURCE)


### PR DESCRIPTION
JIRA issue: [CORE-18104](https://jira.reactos.org/browse/CORE-18104)


Fixes
   Creating library dll\win32\winhttp\winhttp.lib and object dll\win32\winhttp\winhttp.exp
LINK : warning LNK4199: /DELAYLOAD:ole32.dll ignored; no imports found from ole32.dll

which I could observe all the way from releases/0.4.7 up to releases/0.4.14

would like to have a review of ThFabba, who added that import 10 years ago via:
ae0056953a4926121b2f063e846fc627b6fd691c == SVN r56891

I double-checked with MSDepends: Neither 2k3sp2 nor XPSP3 do have that direct delayedImport of OLE32.