### PR TITLE
[IMM32] Renaming: s/pImmHeap/ghImmHeap/

### DIFF
--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -75,7 +75,7 @@ extern PIMEDPI g_pImeDpiList;
 extern PSERVERINFO gpsi;
 extern SHAREDINFO g_SharedInfo;
 extern BYTE g_bClientRegd;
-extern HANDLE ghImmHeap;
+extern HANDLE ghImmHeap; // Win: pImmHeap
 
 BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileName);
 VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW);

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -75,7 +75,7 @@ extern PIMEDPI g_pImeDpiList;
 extern PSERVERINFO gpsi;
 extern SHAREDINFO g_SharedInfo;
 extern BYTE g_bClientRegd;
-extern HANDLE pImmHeap;
+extern HANDLE ghImmHeap;
 
 BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileName);
 VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW);
@@ -85,7 +85,7 @@ LPVOID FASTCALL ValidateHandleNoErr(HANDLE hObject, UINT uType);
 BOOL APIENTRY Imm32CheckImcProcess(PIMC pIMC);
 
 LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes);
-#define ImmLocalFree(lpData) HeapFree(pImmHeap, 0, (lpData))
+#define ImmLocalFree(lpData) HeapFree(ghImmHeap, 0, (lpData))
 
 LPWSTR APIENTRY Imm32WideFromAnsi(LPCSTR pszA);
 LPSTR APIENTRY Imm32AnsiFromWide(LPCWSTR pszW);

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -75,7 +75,7 @@ extern PIMEDPI g_pImeDpiList;
 extern PSERVERINFO gpsi;
 extern SHAREDINFO g_SharedInfo;
 extern BYTE g_bClientRegd;
-extern HANDLE ghImmHeap; // Win: pImmHeap
+extern HANDLE ghImmHeap;
 
 BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileName);
 VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW);

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -14,7 +14,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
-HANDLE ghImmHeap = NULL;
+HANDLE ghImmHeap = NULL; // Win: pImmHeap
 
 HRESULT APIENTRY
 Imm32StrToUInt(LPCWSTR pszText, LPDWORD pdwValue, ULONG nBase)

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -14,7 +14,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
-HANDLE pImmHeap = NULL;
+HANDLE ghImmHeap = NULL;
 
 HRESULT APIENTRY
 Imm32StrToUInt(LPCWSTR pszText, LPDWORD pdwValue, ULONG nBase)
@@ -221,13 +221,13 @@ BOOL APIENTRY Imm32CheckImcProcess(PIMC pIMC)
 
 LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
 {
-    if (!pImmHeap)
+    if (!ghImmHeap)
     {
-        pImmHeap = RtlGetProcessHeap();
-        if (pImmHeap == NULL)
+        ghImmHeap = RtlGetProcessHeap();
+        if (ghImmHeap == NULL)
             return NULL;
     }
-    return HeapAlloc(pImmHeap, dwFlags, dwBytes);
+    return HeapAlloc(ghImmHeap, dwFlags, dwBytes);
 }
 
 BOOL APIENTRY


### PR DESCRIPTION
## Purpose

I had confirmed the name of `pImmHeap` on WinDBG, but @HBelusca thinks it's bad name. Renaming correctly...

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Rename `pImmHeap` as `ghImmHeap`.
