### PR TITLE
[IMM32] Renaming about IME layout

### DIFF
--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -401,6 +401,6 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCANDIDATEPOS,
-                      IMN_SETCANDIDATEPOS, (1 << (BYTE)lpCandidate->dwIndex));
+                       IMN_SETCANDIDATEPOS, (1 << (BYTE)lpCandidate->dwIndex));
     return TRUE;
 }

--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -400,7 +400,7 @@ BOOL WINAPI ImmSetCandidateWindow(HIMC hIMC, LPCANDIDATEFORM lpCandidate)
 
     ImmUnlockIMC(hIMC);
 
-    Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCANDIDATEPOS,
+    Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCANDIDATEPOS,
                       IMN_SETCANDIDATEPOS, (1 << (BYTE)lpCandidate->dwIndex));
     return TRUE;
 }

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -549,11 +549,11 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
         return NULL;
 
     /* Get the IME layouts from registry */
-    cLayouts = Imm32GetRegImes(NULL, 0);
+    cLayouts = Imm32GetImeLayout(NULL, 0);
     if (cLayouts)
     {
         pLayouts = ImmLocalAlloc(0, cLayouts * sizeof(REG_IME));
-        if (!pLayouts || !Imm32GetRegImes(pLayouts, cLayouts))
+        if (!pLayouts || !Imm32GetImeLayout(pLayouts, cLayouts))
         {
             ImmLocalFree(pLayouts);
             return NULL;
@@ -585,19 +585,19 @@ HKL WINAPI ImmInstallIMEW(LPCWSTR lpszIMEFileName, LPCWSTR lpszLayoutText)
 
     /* If the source and the destination pathnames were different, then copy the IME file */
     if (lstrcmpiW(szImeFileName, szImeDestPath) != 0 &&
-        !Imm32CopyFile(szImeFileName, szImeDestPath))
+        !Imm32CopyImeFile(szImeFileName, szImeDestPath))
     {
         hNewKL = NULL;
         goto Quit;
     }
 
     if (hNewKL == NULL)
-        hNewKL = Imm32GetNextHKL(cLayouts, pLayouts, wLangID);
+        hNewKL = Imm32AssignNewLayout(cLayouts, pLayouts, wLangID);
 
     if (hNewKL)
     {
         /* Write the IME layout to registry */
-        if (Imm32WriteRegIme(hNewKL, pchFilePart, lpszLayoutText))
+        if (Imm32WriteImeLayout(hNewKL, pchFilePart, lpszLayoutText))
         {
             /* Load the keyboard layout */
             Imm32UIntToStr((DWORD)(DWORD_PTR)hNewKL, 16, szImeKey, _countof(szImeKey));
@@ -1184,7 +1184,7 @@ BOOL WINAPI ImmSetOpenStatus(HIMC hIMC, BOOL fOpen)
 
     if (bHasChange)
     {
-        Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
+        Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
                           IMC_SETOPENSTATUS, IMN_SETOPENSTATUS, 0);
         NtUserNotifyIMEStatus(hWnd, fOpen, dwConversion);
     }
@@ -1237,7 +1237,7 @@ BOOL WINAPI ImmSetStatusWindowPos(HIMC hIMC, LPPOINT lpptPos)
 
     ImmUnlockIMC(hIMC);
 
-    Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
+    Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
                       IMC_SETSTATUSWINDOWPOS, IMN_SETSTATUSWINDOWPOS, 0);
     return TRUE;
 }
@@ -1288,7 +1288,7 @@ BOOL WINAPI ImmSetCompositionWindow(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm)
 
     ImmUnlockIMC(hIMC);
 
-    Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
+    Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
                       IMC_SETCOMPOSITIONWINDOW, IMN_SETCOMPOSITIONWINDOW, 0);
     return TRUE;
 }
@@ -1418,7 +1418,7 @@ BOOL WINAPI ImmSetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
 
     ImmUnlockIMC(hIMC);
 
-    Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
+    Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
                       IMN_SETCOMPOSITIONFONT, 0);
     return TRUE;
 }
@@ -1476,7 +1476,7 @@ BOOL WINAPI ImmSetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
 
     ImmUnlockIMC(hIMC);
 
-    Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
+    Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
                       IMN_SETCOMPOSITIONFONT, 0);
     return TRUE;
 }
@@ -1657,7 +1657,7 @@ BOOL WINAPI ImmSetConversionStatus(HIMC hIMC, DWORD fdwConversion, DWORD fdwSent
 
     if (fConversionChange || fUseCicero)
     {
-        Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldConversion,
+        Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldConversion,
                           IMC_SETCONVERSIONMODE, IMN_SETCONVERSIONMODE, 0);
         if (fConversionChange)
             NtUserNotifyIMEStatus(hWnd, fOpen, fdwConversion);
@@ -1665,7 +1665,7 @@ BOOL WINAPI ImmSetConversionStatus(HIMC hIMC, DWORD fdwConversion, DWORD fdwSent
 
     if (fSentenceChange || fUseCicero)
     {
-        Imm32NotifyAction(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldSentence,
+        Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldSentence,
                           IMC_SETSENTENCEMODE, IMN_SETSENTENCEMODE, 0);
     }
 

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -1185,7 +1185,7 @@ BOOL WINAPI ImmSetOpenStatus(HIMC hIMC, BOOL fOpen)
     if (bHasChange)
     {
         Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
-                          IMC_SETOPENSTATUS, IMN_SETOPENSTATUS, 0);
+                           IMC_SETOPENSTATUS, IMN_SETOPENSTATUS, 0);
         NtUserNotifyIMEStatus(hWnd, fOpen, dwConversion);
     }
 
@@ -1238,7 +1238,7 @@ BOOL WINAPI ImmSetStatusWindowPos(HIMC hIMC, LPPOINT lpptPos)
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
-                      IMC_SETSTATUSWINDOWPOS, IMN_SETSTATUSWINDOWPOS, 0);
+                       IMC_SETSTATUSWINDOWPOS, IMN_SETSTATUSWINDOWPOS, 0);
     return TRUE;
 }
 
@@ -1289,7 +1289,7 @@ BOOL WINAPI ImmSetCompositionWindow(HIMC hIMC, LPCOMPOSITIONFORM lpCompForm)
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0,
-                      IMC_SETCOMPOSITIONWINDOW, IMN_SETCOMPOSITIONWINDOW, 0);
+                       IMC_SETCOMPOSITIONWINDOW, IMN_SETCOMPOSITIONWINDOW, 0);
     return TRUE;
 }
 
@@ -1419,7 +1419,7 @@ BOOL WINAPI ImmSetCompositionFontA(HIMC hIMC, LPLOGFONTA lplf)
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
-                      IMN_SETCOMPOSITIONFONT, 0);
+                       IMN_SETCOMPOSITIONFONT, 0);
     return TRUE;
 }
 
@@ -1477,7 +1477,7 @@ BOOL WINAPI ImmSetCompositionFontW(HIMC hIMC, LPLOGFONTW lplf)
     ImmUnlockIMC(hIMC);
 
     Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, 0, IMC_SETCOMPOSITIONFONT,
-                      IMN_SETCOMPOSITIONFONT, 0);
+                       IMN_SETCOMPOSITIONFONT, 0);
     return TRUE;
 }
 
@@ -1658,7 +1658,7 @@ BOOL WINAPI ImmSetConversionStatus(HIMC hIMC, DWORD fdwConversion, DWORD fdwSent
     if (fConversionChange || fUseCicero)
     {
         Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldConversion,
-                          IMC_SETCONVERSIONMODE, IMN_SETCONVERSIONMODE, 0);
+                           IMC_SETCONVERSIONMODE, IMN_SETCONVERSIONMODE, 0);
         if (fConversionChange)
             NtUserNotifyIMEStatus(hWnd, fOpen, fdwConversion);
     }
@@ -1666,7 +1666,7 @@ BOOL WINAPI ImmSetConversionStatus(HIMC hIMC, DWORD fdwConversion, DWORD fdwSent
     if (fSentenceChange || fUseCicero)
     {
         Imm32MakeIMENotify(hIMC, hWnd, NI_CONTEXTUPDATED, dwOldSentence,
-                          IMC_SETSENTENCEMODE, IMN_SETSENTENCEMODE, 0);
+                           IMC_SETSENTENCEMODE, IMN_SETSENTENCEMODE, 0);
     }
 
     return TRUE;

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -125,7 +125,7 @@ CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, D
 
 BOOL APIENTRY
 Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
-                  DWORD_PTR dwCommand, DWORD_PTR dwData);
+                   DWORD_PTR dwCommand, DWORD_PTR dwData);
 
 DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList);
 

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -124,7 +124,7 @@ CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, D
                         UINT uCodePage);
 
 BOOL APIENTRY
-Imm32NotifyAction(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
+Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
                   DWORD_PTR dwCommand, DWORD_PTR dwData);
 
 DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList);
@@ -152,10 +152,10 @@ Imm32ReconvertWideFromAnsi(LPRECONVERTSTRING pDest, const RECONVERTSTRING *pSrc,
 HRESULT APIENTRY Imm32StrToUInt(LPCWSTR pszText, LPDWORD pdwValue, ULONG nBase);
 HRESULT APIENTRY Imm32UIntToStr(DWORD dwValue, ULONG nBase, LPWSTR pszBuff, USHORT cchBuff);
 BOOL APIENTRY Imm32LoadImeVerInfo(PIMEINFOEX pImeInfoEx);
-UINT APIENTRY Imm32GetRegImes(PREG_IME pLayouts, UINT cLayouts);
-BOOL APIENTRY Imm32WriteRegIme(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayout);
-HKL APIENTRY Imm32GetNextHKL(UINT cKLs, const REG_IME *pLayouts, WORD wLangID);
-BOOL APIENTRY Imm32CopyFile(LPWSTR pszOldFile, LPCWSTR pszNewFile);
+UINT APIENTRY Imm32GetImeLayout(PREG_IME pLayouts, UINT cLayouts);
+BOOL APIENTRY Imm32WriteImeLayout(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayout);
+HKL APIENTRY Imm32AssignNewLayout(UINT cKLs, const REG_IME *pLayouts, WORD wLangID);
+BOOL APIENTRY Imm32CopyImeFile(LPWSTR pszOldFile, LPCWSTR pszNewFile);
 
 static inline PTHREADINFO FASTCALL Imm32CurrentPti(VOID)
 {

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -232,7 +232,7 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
 // Win: MakeIMENotify
 BOOL APIENTRY
 Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
-                  DWORD_PTR dwCommand, DWORD_PTR dwData)
+                   DWORD_PTR dwCommand, DWORD_PTR dwData)
 {
     DWORD dwThreadId;
     HKL hKL;

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -229,8 +229,9 @@ LPVOID APIENTRY ImmLocalAlloc(DWORD dwFlags, DWORD dwBytes)
     return HeapAlloc(ghImmHeap, dwFlags, dwBytes);
 }
 
+// Win: MakeIMENotify
 BOOL APIENTRY
-Imm32NotifyAction(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
+Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
                   DWORD_PTR dwCommand, DWORD_PTR dwData)
 {
     DWORD dwThreadId;
@@ -668,7 +669,8 @@ Quit:
     return ret;
 }
 
-HKL APIENTRY Imm32GetNextHKL(UINT cKLs, const REG_IME *pLayouts, WORD wLangID)
+// Win: AssignNewLayout
+HKL APIENTRY Imm32AssignNewLayout(UINT cKLs, const REG_IME *pLayouts, WORD wLangID)
 {
     UINT iKL, wID, wLow = 0xE0FF, wHigh = 0xE01F, wNextID = 0;
 
@@ -713,7 +715,8 @@ HKL APIENTRY Imm32GetNextHKL(UINT cKLs, const REG_IME *pLayouts, WORD wLangID)
     return (HKL)(DWORD_PTR)MAKELONG(wLangID, wNextID);
 }
 
-UINT APIENTRY Imm32GetRegImes(PREG_IME pLayouts, UINT cLayouts)
+// Win: GetImeLayout
+UINT APIENTRY Imm32GetImeLayout(PREG_IME pLayouts, UINT cLayouts)
 {
     HKEY hkeyLayouts, hkeyIME;
     WCHAR szImeFileName[80], szImeKey[20];
@@ -780,7 +783,8 @@ UINT APIENTRY Imm32GetRegImes(PREG_IME pLayouts, UINT cLayouts)
     return nCount;
 }
 
-BOOL APIENTRY Imm32WriteRegIme(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayout)
+// Win: WriteImeLayout
+BOOL APIENTRY Imm32WriteImeLayout(HKL hKL, LPCWSTR pchFilePart, LPCWSTR pszLayout)
 {
     UINT iPreload;
     HKEY hkeyLayouts, hkeyIME, hkeyPreload;
@@ -876,7 +880,8 @@ typedef INT (WINAPI *FN_LZOpenFileW)(LPWSTR, LPOFSTRUCT, WORD);
 typedef LONG (WINAPI *FN_LZCopy)(INT, INT);
 typedef VOID (WINAPI *FN_LZClose)(INT);
 
-BOOL APIENTRY Imm32CopyFile(LPWSTR pszOldFile, LPCWSTR pszNewFile)
+// Win: CopyImeFile
+BOOL APIENTRY Imm32CopyImeFile(LPWSTR pszOldFile, LPCWSTR pszNewFile)
 {
     BOOL ret = FALSE, bLoaded = FALSE;
     HMODULE hinstLZ32;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- `s/Imm32WriteRegIme/Imm32WriteImeLayout/` --> `Win: WriteImeLayout`
- `s/Imm32GetRegImes/Imm32GetImeLayout/` --> `Win: GetImeLayout`
- `s/Imm32GetNextHKL/Imm32AssignNewLayout/` --> `Win: AssignNewLayout`
- `s/Imm32NotifyAction/Imm32MakeIMENotify/` --> `Win: MakeIMENotify`
- `s/Imm32CopyFile/Imm32CopyImeFile/` --> `Win: CopyImeFile`
