### PR TITLE
[IMM32] Renaming: worker functions

### DIFF
--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -146,6 +146,7 @@ CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, D
     return dwBufLen;
 }
 
+// Win: ImmGetCandidateListWorker
 static DWORD APIENTRY
 ImmGetCandidateListAW(HIMC hIMC, DWORD dwIndex, LPCANDIDATELIST lpCandList, DWORD dwBufLen,
                       BOOL bAnsi)
@@ -227,6 +228,7 @@ Quit:
     return ret;
 }
 
+// Win: ImmGetCandidateListCountWorker
 DWORD APIENTRY
 ImmGetCandidateListCountAW(HIMC hIMC, LPDWORD lpdwListCount, BOOL bAnsi)
 {

--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -515,7 +515,7 @@ Imm32GetCompStrW(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
 // Win: ImmSetCompositionStringWorker
 BOOL APIENTRY
 ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLen,
-                            LPVOID pRead, DWORD dwReadLen, BOOL bAnsiAPI)
+                          LPVOID pRead, DWORD dwReadLen, BOOL bAnsiAPI)
 {
     BOOL ret = FALSE, bAnsiClient;
     LPVOID pCompNew = NULL, pReadNew = NULL;

--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -514,7 +514,7 @@ Imm32GetCompStrW(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
 
 // Win: ImmSetCompositionStringWorker
 BOOL APIENTRY
-Imm32SetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLen,
+ImmSetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLen,
                             LPVOID pRead, DWORD dwReadLen, BOOL bAnsiAPI)
 {
     BOOL ret = FALSE, bAnsiClient;
@@ -935,8 +935,8 @@ ImmSetCompositionStringA(HIMC hIMC, DWORD dwIndex, LPVOID lpComp, DWORD dwCompLe
 {
     TRACE("(%p, %lu, %p, %lu, %p, %lu)\n",
           hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen);
-    return Imm32SetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
-                                       lpRead, dwReadLen, TRUE);
+    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
+                                     lpRead, dwReadLen, TRUE);
 }
 
 /***********************************************************************
@@ -948,6 +948,6 @@ ImmSetCompositionStringW(HIMC hIMC, DWORD dwIndex, LPVOID lpComp, DWORD dwCompLe
 {
     TRACE("(%p, %lu, %p, %lu, %p, %lu)\n",
           hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen);
-    return Imm32SetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
-                                       lpRead, dwReadLen, FALSE);
+    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
+                                     lpRead, dwReadLen, FALSE);
 }

--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -512,6 +512,7 @@ Imm32GetCompStrW(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
     return dwBufLen;
 }
 
+// Win: ImmSetCompositionStringWorker
 BOOL APIENTRY
 Imm32SetCompositionStringAW(HIMC hIMC, DWORD dwIndex, LPVOID pComp, DWORD dwCompLen,
                             LPVOID pRead, DWORD dwReadLen, BOOL bAnsiAPI)

--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -935,8 +935,7 @@ ImmSetCompositionStringA(HIMC hIMC, DWORD dwIndex, LPVOID lpComp, DWORD dwCompLe
 {
     TRACE("(%p, %lu, %p, %lu, %p, %lu)\n",
           hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen);
-    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
-                                     lpRead, dwReadLen, TRUE);
+    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen, TRUE);
 }
 
 /***********************************************************************
@@ -948,6 +947,5 @@ ImmSetCompositionStringW(HIMC hIMC, DWORD dwIndex, LPVOID lpComp, DWORD dwCompLe
 {
     TRACE("(%p, %lu, %p, %lu, %p, %lu)\n",
           hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen);
-    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen,
-                                     lpRead, dwReadLen, FALSE);
+    return ImmSetCompositionStringAW(hIMC, dwIndex, lpComp, dwCompLen, lpRead, dwReadLen, FALSE);
 }

--- a/dll/win32/imm32/guideline.c
+++ b/dll/win32/imm32/guideline.c
@@ -9,6 +9,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
+// Win: ImmGetGuideLineWorker
 DWORD APIENTRY
 ImmGetGuideLineAW(HIMC hIMC, DWORD dwIndex, LPVOID lpBuf, DWORD dwBufLen, BOOL bAnsi)
 {

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -1791,8 +1791,7 @@ ImmGetImeMenuItemsA(HIMC hIMC, DWORD dwFlags, DWORD dwType,
 {
     TRACE("(%p, 0x%lX, 0x%lX, %p, %p, 0x%lX)\n",
           hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize);
-    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
-                                dwSize, TRUE);
+    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize, TRUE);
 }
 
 /***********************************************************************
@@ -1805,6 +1804,5 @@ ImmGetImeMenuItemsW(HIMC hIMC, DWORD dwFlags, DWORD dwType,
 {
     TRACE("(%p, 0x%lX, 0x%lX, %p, %p, 0x%lX)\n",
           hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize);
-    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
-                                dwSize, FALSE);
+    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize, FALSE);
 }

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -357,6 +357,7 @@ Imm32GetImeMenuItemWCrossProcess(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID 
     return 0;
 }
 
+// Win: ImmGetImeMenuItemsWorker
 DWORD APIENTRY
 Imm32GetImeMenuItemsAW(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID lpImeParentMenu,
                        LPVOID lpImeMenu, DWORD dwSize, BOOL bTargetIsAnsi)

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -360,7 +360,7 @@ Imm32GetImeMenuItemWCrossProcess(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID 
 // Win: ImmGetImeMenuItemsWorker
 DWORD APIENTRY
 ImmGetImeMenuItemsAW(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID lpImeParentMenu,
-                       LPVOID lpImeMenu, DWORD dwSize, BOOL bTargetIsAnsi)
+                     LPVOID lpImeMenu, DWORD dwSize, BOOL bTargetIsAnsi)
 {
     DWORD ret = 0, cbTotal, dwProcessId, dwThreadId, iItem;
     LPINPUTCONTEXT pIC;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -359,7 +359,7 @@ Imm32GetImeMenuItemWCrossProcess(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID 
 
 // Win: ImmGetImeMenuItemsWorker
 DWORD APIENTRY
-Imm32GetImeMenuItemsAW(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID lpImeParentMenu,
+ImmGetImeMenuItemsAW(HIMC hIMC, DWORD dwFlags, DWORD dwType, LPVOID lpImeParentMenu,
                        LPVOID lpImeMenu, DWORD dwSize, BOOL bTargetIsAnsi)
 {
     DWORD ret = 0, cbTotal, dwProcessId, dwThreadId, iItem;
@@ -1791,8 +1791,8 @@ ImmGetImeMenuItemsA(HIMC hIMC, DWORD dwFlags, DWORD dwType,
 {
     TRACE("(%p, 0x%lX, 0x%lX, %p, %p, 0x%lX)\n",
           hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize);
-    return Imm32GetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
-                                  dwSize, TRUE);
+    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
+                                dwSize, TRUE);
 }
 
 /***********************************************************************
@@ -1805,6 +1805,6 @@ ImmGetImeMenuItemsW(HIMC hIMC, DWORD dwFlags, DWORD dwType,
 {
     TRACE("(%p, 0x%lX, 0x%lX, %p, %p, 0x%lX)\n",
           hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu, dwSize);
-    return Imm32GetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
-                                  dwSize, FALSE);
+    return ImmGetImeMenuItemsAW(hIMC, dwFlags, dwType, lpImeParentMenu, lpImeMenu,
+                                dwSize, FALSE);
 }

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -557,7 +557,7 @@ Quit:
 }
 
 // Win: ImmRequestMessageWorker
-LRESULT APIENTRY Imm32RequestMessageAW(HIMC hIMC, WPARAM wParam, LPARAM lParam, BOOL bAnsi)
+LRESULT APIENTRY ImmRequestMessageAW(HIMC hIMC, WPARAM wParam, LPARAM lParam, BOOL bAnsi)
 {
     LRESULT ret = 0;
     LPINPUTCONTEXT pIC;
@@ -1038,7 +1038,7 @@ Quit:
 LRESULT WINAPI ImmRequestMessageA(HIMC hIMC, WPARAM wParam, LPARAM lParam)
 {
     TRACE("(%p, %p, %p)\n", hIMC, wParam, lParam);
-    return Imm32RequestMessageAW(hIMC, wParam, lParam, TRUE);
+    return ImmRequestMessageAW(hIMC, wParam, lParam, TRUE);
 }
 
 /***********************************************************************
@@ -1047,7 +1047,7 @@ LRESULT WINAPI ImmRequestMessageA(HIMC hIMC, WPARAM wParam, LPARAM lParam)
 LRESULT WINAPI ImmRequestMessageW(HIMC hIMC, WPARAM wParam, LPARAM lParam)
 {
     TRACE("(%p, %p, %p)\n", hIMC, wParam, lParam);
-    return Imm32RequestMessageAW(hIMC, wParam, lParam, FALSE);
+    return ImmRequestMessageAW(hIMC, wParam, lParam, FALSE);
 }
 
 /***********************************************************************

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -235,6 +235,7 @@ BOOL APIENTRY Imm32ProcessHotKey(HWND hWnd, HIMC hIMC, HKL hKL, DWORD dwHotKeyID
     return ret;
 }
 
+// Win: ImmIsUIMessageWorker
 static BOOL APIENTRY
 ImmIsUIMessageAW(HWND hWndIME, UINT msg, WPARAM wParam, LPARAM lParam, BOOL bAnsi)
 {
@@ -555,6 +556,7 @@ Quit:
     return ret;
 }
 
+// Win: ImmRequestMessageWorker
 LRESULT APIENTRY Imm32RequestMessageAW(HIMC hIMC, WPARAM wParam, LPARAM lParam, BOOL bAnsi)
 {
     LRESULT ret = 0;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `Win:` comments for A/W worker functions.
- Renaming: `s/Imm32SetCompositionStringAW/ImmSetCompositionStringAW`
- Renaming: `s/Imm32GetImeMenuItemsAW/ImmGetImeMenuItemsAW/`
- Renaming: `s/Imm32RequestMessageAW/ImmRequestMessageAW/`
- `ImmGetCandidateListAW` --> `Win: ImmGetCandidateListWorker`
- `ImmGetCandidateListCountAW` --> `Win: ImmGetCandidateListCountWorker`
- `ImmGetGuideLineAW` --> `Win: ImmGetGuideLineWorker`
- `ImmGetImeMenuItemsAW` --> `Win: ImmGetImeMenuItemsWorker`
- `ImmIsUIMessageAW` --> `Win: ImmIsUIMessageWorker`
- `ImmSetCompositionStringAW` --> `Win: ImmSetCompositionStringWorker`
- `ImmRequestMessageAW` --> `Win: ImmRequestMessageWorker`
