### PR TITLE
[IMM32] Add more 'Win:' comments

### DIFF
--- a/dll/win32/imm32/compstr.c
+++ b/dll/win32/imm32/compstr.c
@@ -214,6 +214,7 @@ Imm32CompClauseWideToAnsi(const DWORD *source, INT slen, LPCWSTR text,
 #define CS_DoAttr CS_DoStrA
 #define CS_DoClause CS_DoStrA
 
+// Win: InternalGetCompositionStringA
 LONG APIENTRY
 Imm32GetCompStrA(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
                  LPVOID lpBuf, DWORD dwBufLen, BOOL bAnsiClient, UINT uCodePage)
@@ -364,6 +365,7 @@ Imm32GetCompStrA(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
     return dwBufLen;
 }
 
+// Win: InternalGetCompositionStringW
 LONG APIENTRY
 Imm32GetCompStrW(HIMC hIMC, const COMPOSITIONSTRING *pCS, DWORD dwIndex,
                  LPVOID lpBuf, DWORD dwBufLen, BOOL bAnsiClient, UINT uCodePage)

--- a/dll/win32/imm32/keymsg.c
+++ b/dll/win32/imm32/keymsg.c
@@ -179,6 +179,7 @@ BOOL APIENTRY Imm32KEnglish(HIMC hIMC)
     return TRUE;
 }
 
+// Win: HotKeyIDDispatcher
 BOOL APIENTRY Imm32ProcessHotKey(HWND hWnd, HIMC hIMC, HKL hKL, DWORD dwHotKeyID)
 {
     PIMEDPI pImeDpi;

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -27,6 +27,7 @@ Imm32StrToUInt(LPCWSTR pszText, LPDWORD pdwValue, ULONG nBase)
     return S_OK;
 }
 
+// Win: UIntToStr
 HRESULT APIENTRY
 Imm32UIntToStr(DWORD dwValue, ULONG nBase, LPWSTR pszBuff, USHORT cchBuff)
 {
@@ -115,6 +116,7 @@ LONG APIENTRY IchAnsiFromWide(LONG cchWide, LPCWSTR pchWide, UINT uCodePage)
     return cchAnsi;
 }
 
+// Win: InternalGetSystemPathName
 BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileName)
 {
     if (!pszFileName[0] || !GetSystemDirectoryW(pszPath, cchPath))
@@ -124,6 +126,7 @@ BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileNam
     return TRUE;
 }
 
+// Win: LFontAtoLFontW
 VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
 {
     size_t cch;
@@ -136,6 +139,7 @@ VOID APIENTRY LogFontAnsiToWide(const LOGFONTA *plfA, LPLOGFONTW plfW)
     plfW->lfFaceName[cch] = 0;
 }
 
+// Win: LFontWtoLFontA
 VOID APIENTRY LogFontWideToAnsi(const LOGFONTW *plfW, LPLOGFONTA plfA)
 {
     size_t cch;
@@ -615,6 +619,7 @@ BOOL APIENTRY Imm32LoadImeLangAndDesc(PIMEINFOEX pInfoEx, LPCVOID pVerInfo)
     return TRUE;
 }
 
+// Win: LoadVersionInfo
 BOOL APIENTRY Imm32LoadImeVerInfo(PIMEINFOEX pImeInfoEx)
 {
     HINSTANCE hinstVersion;


### PR DESCRIPTION
## Purpose

Improve debuggability by adding Windows-side information.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- `LogFontWideToAnsi` --> `Win: LFontWtoLFontA`
- `LogFontAnsiToWide` --> `Win: LFontAtoLFontW`
- `Imm32GetCompStrA` --> `Win: InternalGetCompositionStringA`
- `Imm32GetCompStrW` --> `Win: InternalGetCompositionStringW`
- `Imm32LoadImeVerInfo` --> `Win: LoadVersionInfo`
- `Imm32GetSystemLibraryPath` --> `Win: InternalGetSystemPathName`
- `Imm32UIntToStr` --> `Win: UIntToStr`
- `Imm32ProcessHotKey` --> `Win: HotKeyIDDispatcher`