### PR TITLE
[SDK:NTOS_VISTA] Fix GCC AMD64 build. Addendum for commit 6f559e9c5.

### DIFF
--- a/sdk/lib/drivers/ntoskrnl_vista/CMakeLists.txt
+++ b/sdk/lib/drivers/ntoskrnl_vista/CMakeLists.txt
@@ -3,15 +3,18 @@ add_definitions(-D_WIN32_WINNT=0x600)
 
 add_definitions(-DUNICODE -D_UNICODE -D__NTOSKRNL__ -D_NTOSKRNL_ -D_NTSYSTEM_)
 
+include_directories(${REACTOS_SOURCE_DIR}/sdk/lib/rtl)
+
 list(APPEND SOURCE
     etw.c
     fsrtl.c
     io.c
     po.c
-    ke.c)
+    ke.c
+    ${REACTOS_SOURCE_DIR}/sdk/lib/rtl/utf8.c)
 
 add_library(ntoskrnl_vista ${SOURCE})
-target_link_libraries(ntoskrnl_vista PRIVATE rtl_vista)
+target_link_libraries(ntoskrnl_vista PRIVATE pseh) # rtl_vista)
 add_dependencies(ntoskrnl_vista bugcodes xdk)
 
 target_compile_definitions(ntoskrnl_vista PUBLIC NTKRNLVISTA)


### PR DESCRIPTION
## Purpose

Fix GCC AMD64 build, following commit 6f559e9c5.

## Observations

Problem only arises on GCC AMD64 build bot and is:
```
FAILED: drivers/filesystems/nfs/nfs41_driver.sys 
: && /home/runner/work/reactos/reactos/RosBE-CI/amd64/bin/x86_64-w64-mingw32-gcc   -nostdlib
<-- stripped -->
 && /home/runner/work/reactos/reactos/build/host-tools/bin/pefixup --kernelmodedriver /home/runner/work/reactos/reactos/build/drivers/filesystems/nfs/nfs41_driver.sys
/home/runner/work/reactos/reactos/RosBE-CI/amd64/lib/gcc/x86_64-w64-mingw32/8.4.0/../../../../x86_64-w64-mingw32/bin/ld:
sdk/lib/rtl/CMakeFiles/rtl_vista.dir/utf8.c.obj: in function `RtlUnicodeToUTF8N':
/sdk/include/crt/mingw32/intrin_x86.h:76: undefined reference to `memcpy'
collect2: error: ld returned 1 exit status
```
Notice the rtl_vista library is included at the very end.

GCC x86 and MSVC x86/x64 build fine however:

GCC x86:
```CMAKE:
cmake version 3.17.2-ReactOS

CMake suite maintained and supported by Kitware (kitware.com/cmake).

NINJA:
1.10.0

D:\rosbuilds\x86_MinGW_FLDR_PC>ninja -v nfs41_driver -k 0
[1/168] cmd.exe /C "cd /D D:\rosbuilds\x86_MinGW_FLDR_PC\host-tools\bin && C:\RosBE\bin\cmake.exe --build ."
ninja: no work to do.
[2/2] cmd.exe /C "cd . && C:\RosBE\i386\bin\gcc.exe   -nostdlib
<-- stripped -->
drivers/filesystems/nfs/CMakeFiles/nfs41_driver.dir/nfs.rc.obj  sdk/lib/drivers/ntoskrnl_vista/libntoskrnl_vista.a  sdk/lib/drivers/rdbsslib/librdbsslib.a  sdk/lib/drivers/rxce/librxce.a  sdk/lib/drivers/copysup/libcopysup.a  sdk/lib/crt/libmemcmp.a  sdk/lib/pseh/libpseh.a  ntoskrnl/libntoskrnl.a  hal/halx86/libhal.a  sdk/lib/rtl/librtl_vista.a  sdk/lib/pseh/libpseh.a  sdk/lib/crt/libchkstk.a  -lgcc
&& D:/rosbuilds/x86_MinGW_FLDR_PC/host-tools/bin/rsym.exe -s D:/reactos drivers\filesystems\nfs\nfs41_driver.sys drivers\filesystems\nfs\nfs41_driver.sys && cmd.exe /C "cd /D D:\rosbuilds\x86_MinGW_FLDR_PC\drivers\filesystems\nfs && D:\rosbuilds\x86_MinGW_FLDR_PC\host-tools\bin\pefixup.exe --kernelmodedriver D:/rosbuilds/x86_MinGW_FLDR_PC/drivers/filesystems/nfs/nfs41_driver.sys""
```

MSVC x86:
```
CMAKE:
cmake version 3.17.2-ReactOS

CMake suite maintained and supported by Kitware (kitware.com/cmake).

NINJA:
1.10.0

D:\rosbuilds\x86_MSVC19_FLDR_PC>ninja -v nfs41_driver -k 0
<-- stripped -->
[2/2] cmd.exe /C "cd . && C:\RosBE\bin\cmake.exe -E vs_link_dll --intdir=drivers\filesystems\nfs\CMakeFiles\nfs41_driver.dir --rc=rc --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100190~1.0\x86\mt.exe --manifests  -- C:\PROGRA~2\MICROS~2\2019\COMMUN~1\VC\Tools\MSVC\1429~1.301\bin\Hostx86\x86\link.exe
<-- stripped -->
/DRIVER  sdk\lib\runtmchk\runtmchk.lib  sdk\lib\drivers\ntoskrnl_vista\ntoskrnl_vista.lib  sdk\lib\drivers\rdbsslib\rdbsslib.lib  sdk\lib\drivers\rxce\rxce.lib  sdk\lib\drivers\copysup\copysup.lib  sdk\lib\crt\memcmp.lib  sdk\lib\pseh\pseh.lib  ntoskrnl\libntoskrnl.lib  hal\halx86\libhal.lib  sdk\lib\rtl\rtl_vista.lib  sdk\lib\pseh\pseh.lib  && cd ."
```

(MSVC x64 builders are green as well).

We will observe that in all cases, rtl_vista is quite at the end; however it is always followed by the PSEH library (and chkstk). This may explain why it still builds OK there...