### PR TITLE
[KERNEL32] Fix reading SafeDllSearchMode

### DIFF
--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -424,7 +424,7 @@ BaseComputeProcessDllPath(IN LPWSTR FullPath,
     UNICODE_STRING KeyName = RTL_CONSTANT_STRING(L"\\Registry\\MACHINE\\System\\CurrentControlSet\\Control\\Session Manager");
     UNICODE_STRING ValueName = RTL_CONSTANT_STRING(L"SafeDllSearchMode");
     OBJECT_ATTRIBUTES ObjectAttributes = RTL_CONSTANT_OBJECT_ATTRIBUTES(&KeyName, OBJ_CASE_INSENSITIVE);
-    KEY_VALUE_PARTIAL_INFORMATION PartialInfo;
+    CHAR PartialInfoBuffer[FIELD_OFFSET(KEY_VALUE_PARTIAL_INFORMATION, Data) + sizeof(ULONG)];
     HANDLE KeyHandle;
     NTSTATUS Status;
     ULONG ResultLength;
@@ -461,15 +461,16 @@ BaseComputeProcessDllPath(IN LPWSTR FullPath,
             Status = NtQueryValueKey(KeyHandle,
                                      &ValueName,
                                      KeyValuePartialInformation,
-                                     &PartialInfo,
-                                     sizeof(PartialInfo),
+                                     PartialInfoBuffer,
+                                     sizeof(PartialInfoBuffer),
                                      &ResultLength);
             if (NT_SUCCESS(Status))
             {
                 /* Read the value if the size is OK */
-                if (ResultLength == sizeof(PartialInfo))
+                if (ResultLength == sizeof(PartialInfoBuffer))
                 {
-                    CurrentDirPlacement = *(PULONG)PartialInfo.Data;
+                    PKEY_VALUE_PARTIAL_INFORMATION PartialInfo = (PKEY_VALUE_PARTIAL_INFORMATION)PartialInfoBuffer;
+                    CurrentDirPlacement = *(PULONG)PartialInfo->Data;
                 }
             }
 


### PR DESCRIPTION
Previously there was no room reserved for the ULONG, only for a BYTE