### PR TITLE
[SHELL32] Show system control applet in taskbar

### DIFF
--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -804,6 +804,21 @@ Control_EnumWinProc(
     }
     return TRUE; // continue enumeration
 }
+
+/**
+ * This function makes the system control applet accessible via the taskbar.
+ * 
+ * @param applet Pointer of system control applet
+ * @param index Number of applet in a system control library
+ */
+static void 
+Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
+{
+    SetWindowTextW(applet->hWnd, applet->info[index].name);
+    SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
+    ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
+}
+
 #endif /* __REACTOS__ */
 
 static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
@@ -956,6 +971,7 @@ static	void	Control_DoLaunch(CPanel* panel, HWND hWnd, LPCWSTR wszCmd)
         {
             SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLName), (HANDLE)MAKEINTATOM(aCPLPath));
             SetPropW(applet->hWnd, (LPTSTR)MAKEINTATOM(aCPLFlags), UlongToHandle(sp + 1));
+            Control_ShowAppletInTaskbar(applet, sp);
 #endif
 
         if (!applet->proc(applet->hWnd, CPL_STARTWPARMSW, sp, (LPARAM)extraPmts))


### PR DESCRIPTION
## Purpose

Display the control panel applet in the taskbar to allow better navigation between programs.

JIRA issue: [CORE-18137](https://jira.reactos.org/browse/CORE-18137)

## Proposed changes

Manipulate the window of the current instance of 'rundll32.exe'.

- Set title text
- Set icon
- Show window (minimal)