### PR TITLE
[IMM32] Many renamings and 'Win:' info

### DIFF
--- a/dll/win32/imm32/candidate.c
+++ b/dll/win32/imm32/candidate.c
@@ -9,6 +9,7 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
+// Win: InternalGetCandidateListWtoA
 DWORD APIENTRY
 CandidateListWideToAnsi(const CANDIDATELIST *pWideCL, LPCANDIDATELIST pAnsiCL, DWORD dwBufLen,
                         UINT uCodePage)
@@ -78,6 +79,7 @@ CandidateListWideToAnsi(const CANDIDATELIST *pWideCL, LPCANDIDATELIST pAnsiCL, D
     return dwBufLen;
 }
 
+// Win: InternalGetCandidateListAtoW
 DWORD APIENTRY
 CandidateListAnsiToWide(const CANDIDATELIST *pAnsiCL, LPCANDIDATELIST pWideCL, DWORD dwBufLen,
                         UINT uCodePage)

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -308,7 +308,7 @@ ImeDpi_Escape(PIMEDPI pImeDpi, HIMC hIMC, UINT uSubFunc, LPVOID lpData, HKL hKL)
 }
 
 // Win: ImmUnloadIME
-BOOL APIENTRY ImmUnloadIME(HKL hKL)
+BOOL APIENTRY Imm32ReleaseIME(HKL hKL)
 {
     BOOL ret = TRUE;
     PIMEDPI pImeDpi0, pImeDpi1;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -16,7 +16,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 RTL_CRITICAL_SECTION gcsImeDpi; // Win: gcsImeDpi
 PIMEDPI gpImeDpiList = NULL; // Win: gpImeDpi
 
-// Win: GetImeDpi
+// Win: ImmGetImeDpi
 PIMEDPI APIENTRY Imm32FindImeDpi(HKL hKL)
 {
     PIMEDPI pImeDpi;

--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -17,7 +17,7 @@ RTL_CRITICAL_SECTION gcsImeDpi; // Win: gcsImeDpi
 PIMEDPI gpImeDpiList = NULL; // Win: gpImeDpi
 
 // Win: GetImeDpi
-PIMEDPI APIENTRY Imm32GetImeDpi(HKL hKL)
+PIMEDPI APIENTRY Imm32FindImeDpi(HKL hKL)
 {
     PIMEDPI pImeDpi;
 
@@ -254,7 +254,7 @@ PIMEDPI APIENTRY Ime32LoadImeDpi(HKL hKL, BOOL bLock)
 
     RtlEnterCriticalSection(&gcsImeDpi);
 
-    pImeDpiFound = Imm32GetImeDpi(hKL);
+    pImeDpiFound = Imm32FindImeDpi(hKL);
     if (pImeDpiFound)
     {
         if (!bLock)
@@ -809,7 +809,7 @@ BOOL WINAPI ImmLoadIME(HKL hKL)
     if (!IS_IME_HKL(hKL) && (!Imm32IsCiceroMode() || Imm32Is16BitMode()))
         return FALSE;
 
-    pImeDpi = Imm32GetImeDpi(hKL);
+    pImeDpi = Imm32FindImeDpi(hKL);
     if (pImeDpi == NULL)
         pImeDpi = Ime32LoadImeDpi(hKL, FALSE);
     return (pImeDpi != NULL);

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -13,10 +13,10 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
-HMODULE g_hImm32Inst = NULL;
-PSERVERINFO gpsi = NULL;
-SHAREDINFO gSharedInfo = { NULL };
-BYTE g_bClientRegd = FALSE;
+HMODULE ghImm32Inst = NULL; // Win: ghInst
+PSERVERINFO gpsi = NULL; // Win: gpsi
+SHAREDINFO gSharedInfo = { NULL }; // Win: gSharedInfo
+BYTE gfImmInitialized = FALSE; // Win: gfInitialized
 
 // Win: ImmInitializeGlobals
 static BOOL APIENTRY ImmInitializeGlobals(HMODULE hMod)
@@ -24,16 +24,16 @@ static BOOL APIENTRY ImmInitializeGlobals(HMODULE hMod)
     NTSTATUS status;
 
     if (hMod)
-        g_hImm32Inst = hMod;
+        ghImm32Inst = hMod;
 
-    if (g_bClientRegd)
+    if (gfImmInitialized)
         return TRUE;
 
     status = RtlInitializeCriticalSection(&gcsImeDpi);
     if (NT_ERROR(status))
         return FALSE;
 
-    g_bClientRegd = TRUE;
+    gfImmInitialized = TRUE;
     return TRUE;
 }
 
@@ -163,7 +163,7 @@ BOOL WINAPI ImmFreeLayout(DWORD dwUnknown)
 Retry:
         for (pImeDpi = gpImeDpiList; pImeDpi; pImeDpi = pImeDpi->pNext)
         {
-            if (Imm32ReleaseIME(pImeDpi->hKL))
+            if (ImmUnloadIME(pImeDpi->hKL))
                 goto Retry;
         }
         RtlLeaveCriticalSection(&gcsImeDpi);
@@ -172,13 +172,14 @@ Retry:
     {
         hNewKL = (HKL)(DWORD_PTR)dwUnknown;
         if (IS_IME_HKL(hNewKL) && hNewKL != hOldKL)
-            Imm32ReleaseIME(hNewKL);
+            ImmUnloadIME(hNewKL);
     }
 
     return TRUE;
 }
 
-VOID APIENTRY Imm32SelectLayout(HKL hNewKL, HKL hOldKL, HIMC hIMC)
+// Win: SelectInputContext
+VOID APIENTRY Imm32SelectInputContext(HKL hNewKL, HKL hOldKL, HIMC hIMC)
 {
     PCLIENTIMC pClientImc;
     LPINPUTCONTEXTDX pIC;
@@ -424,14 +425,16 @@ typedef struct SELECT_LAYOUT
     HKL hOldKL;
 } SELECT_LAYOUT, *LPSELECT_LAYOUT;
 
-static BOOL CALLBACK Imm32SelectLayoutProc(HIMC hIMC, LPARAM lParam)
+// Win: SelectContextProc
+static BOOL CALLBACK Imm32SelectContextProc(HIMC hIMC, LPARAM lParam)
 {
     LPSELECT_LAYOUT pSelect = (LPSELECT_LAYOUT)lParam;
-    Imm32SelectLayout(pSelect->hNewKL, pSelect->hOldKL, hIMC);
+    Imm32SelectInputContext(pSelect->hNewKL, pSelect->hOldKL, hIMC);
     return TRUE;
 }
 
-static BOOL CALLBACK Imm32NotifyCompStrProc(HIMC hIMC, LPARAM lParam)
+// Win: NotifyIMEProc
+static BOOL CALLBACK Imm32NotifyIMEProc(HIMC hIMC, LPARAM lParam)
 {
     ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, (DWORD)lParam, 0);
     return TRUE;
@@ -466,7 +469,7 @@ BOOL WINAPI ImmActivateLayout(HKL hKL)
                 lParam = CPS_CANCEL;
             ImmUnlockImeDpi(pImeDpi);
 
-            ImmEnumInputContext(0, Imm32NotifyCompStrProc, lParam);
+            ImmEnumInputContext(0, Imm32NotifyIMEProc, lParam);
         }
 
         hwndDefIME = ImmGetDefaultIMEWnd(NULL);
@@ -478,7 +481,7 @@ BOOL WINAPI ImmActivateLayout(HKL hKL)
 
     SelectLayout.hNewKL = hKL;
     SelectLayout.hOldKL = hOldKL;
-    ImmEnumInputContext(0, Imm32SelectLayoutProc, (LPARAM)&SelectLayout);
+    ImmEnumInputContext(0, Imm32SelectContextProc, (LPARAM)&SelectLayout);
 
     if (IsWindow(hwndDefIME))
         SendMessageW(hwndDefIME, WM_IME_SELECT, TRUE, (LPARAM)hKL);
@@ -1099,7 +1102,7 @@ BOOL WINAPI ImmEnumInputContext(DWORD dwThreadId, IMCENUMPROC lpfn, LPARAM lPara
 
     TRACE("(%lu, %p, %p)\n", dwThreadId, lpfn, lParam);
 
-    dwCount = Imm32AllocAndBuildHimcList(dwThreadId, &phList);
+    dwCount = Imm32BuildHimcList(dwThreadId, &phList);
     if (!dwCount)
         return FALSE;
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -163,7 +163,7 @@ BOOL WINAPI ImmFreeLayout(DWORD dwUnknown)
 Retry:
         for (pImeDpi = gpImeDpiList; pImeDpi; pImeDpi = pImeDpi->pNext)
         {
-            if (ImmUnloadIME(pImeDpi->hKL))
+            if (Imm32ReleaseIME(pImeDpi->hKL))
                 goto Retry;
         }
         RtlLeaveCriticalSection(&gcsImeDpi);
@@ -172,7 +172,7 @@ Retry:
     {
         hNewKL = (HKL)(DWORD_PTR)dwUnknown;
         if (IS_IME_HKL(hNewKL) && hNewKL != hOldKL)
-            ImmUnloadIME(hNewKL);
+            Imm32ReleaseIME(hNewKL);
     }
 
     return TRUE;

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -69,12 +69,11 @@ typedef struct REG_IME
     WCHAR szFileName[80];   /* The IME module filename */
 } REG_IME, *PREG_IME;
 
-extern HMODULE g_hImm32Inst;
+extern HMODULE ghImm32Inst;
 extern RTL_CRITICAL_SECTION gcsImeDpi;
 extern PIMEDPI gpImeDpiList;
 extern PSERVERINFO gpsi;
 extern SHAREDINFO gSharedInfo;
-extern BYTE g_bClientRegd;
 extern HANDLE ghImmHeap;
 
 BOOL Imm32GetSystemLibraryPath(LPWSTR pszPath, DWORD cchPath, LPCWSTR pszFileName);
@@ -93,7 +92,7 @@ LONG APIENTRY IchWideFromAnsi(LONG cchAnsi, LPCSTR pchAnsi, UINT uCodePage);
 LONG APIENTRY IchAnsiFromWide(LONG cchWide, LPCWSTR pchWide, UINT uCodePage);
 PIMEDPI APIENTRY Imm32FindOrLoadImeDpi(HKL hKL);
 LPINPUTCONTEXT APIENTRY Imm32InternalLockIMC(HIMC hIMC, BOOL fSelect);
-BOOL APIENTRY Imm32ReleaseIME(HKL hKL);
+BOOL APIENTRY ImmUnloadIME(HKL hKL);
 BOOL APIENTRY Imm32IsSystemJapaneseOrKorean(VOID);
 
 static inline BOOL Imm32IsCrossThreadAccess(HIMC hIMC)
@@ -127,7 +126,7 @@ BOOL APIENTRY
 Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWORD_PTR dwValue,
                    DWORD_PTR dwCommand, DWORD_PTR dwData);
 
-DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList);
+DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList);
 
 INT APIENTRY
 Imm32ImeMenuAnsiToWide(const IMEMENUITEMINFOA *pItemA, LPIMEMENUITEMINFOW pItemW,

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -92,7 +92,7 @@ LONG APIENTRY IchWideFromAnsi(LONG cchAnsi, LPCSTR pchAnsi, UINT uCodePage);
 LONG APIENTRY IchAnsiFromWide(LONG cchWide, LPCWSTR pchWide, UINT uCodePage);
 PIMEDPI APIENTRY Imm32FindOrLoadImeDpi(HKL hKL);
 LPINPUTCONTEXT APIENTRY Imm32InternalLockIMC(HIMC hIMC, BOOL fSelect);
-BOOL APIENTRY ImmUnloadIME(HKL hKL);
+BOOL APIENTRY Imm32ReleaseIME(HKL hKL);
 BOOL APIENTRY Imm32IsSystemJapaneseOrKorean(VOID);
 
 static inline BOOL Imm32IsCrossThreadAccess(HIMC hIMC)

--- a/dll/win32/imm32/utils.c
+++ b/dll/win32/imm32/utils.c
@@ -15,6 +15,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 HANDLE ghImmHeap = NULL; // Win: pImmHeap
 
+// Win: StrToUInt
 HRESULT APIENTRY
 Imm32StrToUInt(LPCWSTR pszText, LPDWORD pdwValue, ULONG nBase)
 {
@@ -266,7 +267,8 @@ Imm32MakeIMENotify(HIMC hIMC, HWND hwnd, DWORD dwAction, DWORD_PTR dwIndex, DWOR
     return TRUE;
 }
 
-DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList)
+// Win: BuildHimcList
+DWORD APIENTRY Imm32BuildHimcList(DWORD dwThreadId, HIMC **pphList)
 {
 #define INITIAL_COUNT 0x40
 #define MAX_RETRY 10
@@ -304,6 +306,7 @@ DWORD APIENTRY Imm32AllocAndBuildHimcList(DWORD dwThreadId, HIMC **pphList)
 #undef MAX_RETRY
 }
 
+// Win: ConvertImeMenuItemInfoAtoW
 INT APIENTRY
 Imm32ImeMenuAnsiToWide(const IMEMENUITEMINFOA *pItemA, LPIMEMENUITEMINFOW pItemW,
                        UINT uCodePage, BOOL bBitmap)
@@ -330,6 +333,7 @@ Imm32ImeMenuAnsiToWide(const IMEMENUITEMINFOA *pItemA, LPIMEMENUITEMINFOW pItemW
     return ret;
 }
 
+// Win: ConvertImeMenuItemInfoWtoA
 INT APIENTRY
 Imm32ImeMenuWideToAnsi(const IMEMENUITEMINFOW *pItemW, LPIMEMENUITEMINFOA pItemA,
                        UINT uCodePage)
@@ -353,6 +357,7 @@ Imm32ImeMenuWideToAnsi(const IMEMENUITEMINFOW *pItemW, LPIMEMENUITEMINFOA pItemA
     return ret;
 }
 
+// Win: GetImeModeSaver
 PIME_STATE APIENTRY
 Imm32FetchImeState(LPINPUTCONTEXTDX pIC, HKL hKL)
 {
@@ -376,6 +381,7 @@ Imm32FetchImeState(LPINPUTCONTEXTDX pIC, HKL hKL)
     return pState;
 }
 
+// Win: GetImePrivateModeSaver
 PIME_SUBSTATE APIENTRY
 Imm32FetchImeSubState(PIME_STATE pState, HKL hKL)
 {
@@ -395,6 +401,7 @@ Imm32FetchImeSubState(PIME_STATE pState, HKL hKL)
     return pSubState;
 }
 
+// Win: RestorePrivateMode
 BOOL APIENTRY
 Imm32LoadImeStateSentence(LPINPUTCONTEXTDX pIC, PIME_STATE pState, HKL hKL)
 {
@@ -407,6 +414,7 @@ Imm32LoadImeStateSentence(LPINPUTCONTEXTDX pIC, PIME_STATE pState, HKL hKL)
     return FALSE;
 }
 
+// Win: SavePrivateMode
 BOOL APIENTRY
 Imm32SaveImeStateSentence(LPINPUTCONTEXTDX pIC, PIME_STATE pState, HKL hKL)
 {
@@ -550,6 +558,7 @@ static FN_GetFileVersionInfoW s_fnGetFileVersionInfoW = NULL;
 static FN_GetFileVersionInfoSizeW s_fnGetFileVersionInfoSizeW = NULL;
 static FN_VerQueryValueW s_fnVerQueryValueW = NULL;
 
+// Win: LoadFixVersionInfo
 static BOOL APIENTRY Imm32LoadImeFixedInfo(PIMEINFOEX pInfoEx, LPCVOID pVerInfo)
 {
     UINT cbFixed = 0;
@@ -566,6 +575,7 @@ static BOOL APIENTRY Imm32LoadImeFixedInfo(PIMEINFOEX pInfoEx, LPCVOID pVerInfo)
     return TRUE;
 }
 
+// Win: GetVersionDatum
 static LPWSTR APIENTRY
 Imm32GetVerInfoValue(LPCVOID pVerInfo, LPWSTR pszKey, DWORD cchKey, LPCWSTR pszName)
 {
@@ -582,6 +592,7 @@ Imm32GetVerInfoValue(LPCVOID pVerInfo, LPWSTR pszKey, DWORD cchKey, LPCWSTR pszN
     return (cbValue ? pszValue : NULL);
 }
 
+// Win: LoadVarVersionInfo
 BOOL APIENTRY Imm32LoadImeLangAndDesc(PIMEINFOEX pInfoEx, LPCVOID pVerInfo)
 {
     BOOL ret;


### PR DESCRIPTION
## Purpose
Improve debuggability.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add many `Win:` comments.
- `s/Imm32UnloadIME/Imm32FreeIME/`
- `s/Imm32LoadImeInfo/Imm32LoadIME/`
- `s/g_hImm32Inst/ghImm32Inst/`
- `s/g_bClientRegd/gfImmInitialized/`
- `s/Imm32AllocAndBuildHimcList/Imm32BuildHimcList/`
- `s/Imm32SelectLayout/Imm32SelectInputContext/`
- `s/Imm32NotifyCompStrProc/Imm32NotifyIMEProc/`
