### PR TITLE
[WIN32K] Remove incorrect packing specification around _TL, _WIN32THREAD and _THREADINFO structures.

### DIFF
--- a/win32ss/user/ntuser/win32.h
+++ b/win32ss/user/ntuser/win32.h
@@ -53,7 +53,6 @@ extern HANDLE hModuleWin;    // This Win32k Instance.
 extern struct _CLS *SystemClassList;
 extern BOOL RegisteredSysClasses;
 
-#include <pshpack1.h>
 // FIXME: Move to ntuser.h
 typedef struct _TL
 {
@@ -163,8 +162,6 @@ typedef struct _THREADINFO
 #endif
 #endif // __cplusplus
 } THREADINFO;
-
-#include <poppack.h>
 
 
 #define IntReferenceThreadInfo(pti) \


### PR DESCRIPTION
## Purpose

Remove incorrect packing specification around _TL, _WIN32THREAD and _THREADINFO structures.

JIRA issue: [CORE-18140](https://jira.reactos.org/browse/CORE-18140)

This was introduced historically in commit 583de66b3 (r7460) to
workaround some compiler problems (or replace already existing
GCC-specific `__attribute__((packed))` annotations); however these
structures are in-memory-only, do not describe any on-disk data
format and don't describe hardware-specific data. So they should
have the "natural" alignment of the target platform.

They also have to match the documented layouts at:
https://reactos.org/wiki/Techwiki:Win32k/THREADINFO
https://www.geoffchappell.com/studies/windows/km/win32k/structs/threadinfo/index.htm
at least for the compatible parts that ReactOS shares.
