### PR TITLE
[HALX86:ACPI] Use the correct PCH file for compilation.

### DIFF
--- a/hal/halx86/acpi.cmake
+++ b/hal/halx86/acpi.cmake
@@ -14,7 +14,5 @@ if(ARCH STREQUAL "amd64")
 endif()
 
 add_library(lib_hal_acpi OBJECT ${HAL_ACPI_SOURCE})
-add_pch(lib_hal_acpi ${REACTOS_SOURCE_DIR}/drivers/bus/acpi/acpica/include/acpi.h ${HAL_ACPI_SOURCE})
+add_pch(lib_hal_acpi include/hal.h ${HAL_ACPI_SOURCE})
 add_dependencies(lib_hal_acpi bugcodes xdk)
-#add_pch(lib_hal_acpi include/hal.h)
-


### PR DESCRIPTION
## Purpose

This also removes the following warnings, that were present because,
as the ACPICA acpi.h header was used as PCH (instead of none, or the
hal's own main header), it was "included" before any other header
-- and in particular, before hal.h -- and as a result, colliding defines
were still defined even if the #undef tricks were used for them.

```
rosbuilds\sdk\include\reactos\mc\bugcodes.h(1417): warning C4005: 'ACPI_BIOS_ERROR': macro redefinition
reactos\drivers\bus\acpi\acpica\include\acoutput.h(243): note: see previous definition of 'ACPI_BIOS_ERROR'
reactos\hal\halx86\include\hal.h(41): warning C4109: unexpected identifier '_read'
reactos\hal\halx86\include\hal.h(42): warning C4109: unexpected identifier '_read'
```