### PR TITLE
[NTUSER] Dereference spDefaultImc at UserCreateInputContext

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1362,6 +1362,8 @@ PIMC FASTCALL UserCreateInputContext(ULONG_PTR dwClientImcData)
     else // First time. It's the default IMC.
     {
         // Add the first one (default) to the list.
+        if (pti->spDefaultImc)
+            UserDereferenceObject(pti->spDefaultImc);
         pti->spDefaultImc = pIMC;
         pIMC->pImcNext = NULL;
     }


### PR DESCRIPTION
## Purpose

`UserCreateInputContext(0);` can be called multiple times in the process because the thread(s) in the process can be multiple.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Dereference `pti->spDefaultImc` by `UserDereferenceObject` if `pti->spDefaultImc` is `NULL` at `UserCreateInputContext` function.

## TODO

- [x] Do tests.