### PR TITLE
[CMAKE] msvc.cmake: Enable C4090 warning as error

### DIFF
--- a/sdk/cmake/msvc.cmake
+++ b/sdk/cmake/msvc.cmake
@@ -114,7 +114,7 @@ else()
 # - C4022: pointer type mismatch for parameter
 # - C4028: formal parameter different from declaration
 # - C4047: different level of indirection
-# - TODO: C4090: different 'modifier' qualifiers (for C programs only;
+# - C4090: different 'modifier' qualifiers (for C programs only;
 #          for C++ programs, the compiler error C2440 is issued)
 # - C4098: void function returning a value
 # - C4113: parameter lists differ
@@ -130,7 +130,7 @@ else()
 # - C4700: uninitialized variable usage
 # - C4715: 'function': not all control paths return a value
 # - C4716: function must return a value
-add_compile_options(/we4013 /we4020 /we4022 /we4028 /we4047 /we4098 /we4113 /we4129 /we4133 /we4163 /we4229 /we4311 /we4312 /we4313 /we4477 /we4603 /we4700 /we4715 /we4716)
+add_compile_options(/we4013 /we4020 /we4022 /we4028 /we4047 /we4090 /we4098 /we4113 /we4129 /we4133 /we4163 /we4229 /we4311 /we4312 /we4313 /we4477 /we4603 /we4700 /we4715 /we4716)
 
 # - C4101: unreferenced local variable
 # - C4189: local variable initialized but not referenced


### PR DESCRIPTION
C4090: different 'modifier' qualifiers

Follow-up to 42d2d5e (0.4.14-dev-847) and 41bc57d (0.4.15-dev-2952),
which silenced affected modules.

JIRA issue: [CORE-7538](https://jira.reactos.org/browse/CORE-7538)
