### PR TITLE
[TASKMGR] Application Page: Fix "Go To Process" item selection

### DIFF
--- a/base/applications/taskmgr/applpage.c
+++ b/base/applications/taskmgr/applpage.c
@@ -944,6 +944,8 @@ void ApplicationPage_OnGotoProcess(void)
         i = ProcGetIndexByProcessId(dwProcessId);
         if (i != -1)
         {
+            ListView_SetSelectionMark(hProcessPageListCtrl, i);
+
             ListView_SetItemState(hProcessPageListCtrl,
                                   i,
                                   LVIS_SELECTED | LVIS_FOCUSED,


### PR DESCRIPTION
## Purpose

Fix "Go To Process" selecting wrong process in the process page
