### PR TITLE
[NTUSER][IMM32_APITEST] Associate HIMC to WND

### DIFF
--- a/modules/rostests/apitests/imm32/himc.c
+++ b/modules/rostests/apitests/imm32/himc.c
@@ -7,7 +7,7 @@
 
 #include "precomp.h"
 
-START_TEST(himc)
+static void Test1(void)
 {
     DWORD style;
     HWND hwndEdit, hwndStatic;
@@ -151,4 +151,45 @@ START_TEST(himc)
 
     DestroyWindow(hwndEdit);
     DestroyWindow(hwndStatic);
+}
+
+static void Test2(void)
+{
+    static const LPCSTR apszClasses[] =
+    {
+        "BUTTON",
+        "COMBOBOX",
+        "EDIT",
+        "LISTBOX",
+        "SCROLLBAR",
+        "STATIC"
+    };
+    size_t i;
+    HIMC hIMC;
+    HWND hwnd;
+
+    for (i = 0; i < _countof(apszClasses); ++i)
+    {
+        LPCSTR pszClass = apszClasses[i];
+        hwnd = CreateWindowA(pszClass, NULL, WS_VISIBLE, 0, 0, 0, 0, NULL, NULL,
+                             GetModuleHandle(NULL), NULL);
+        ok(hwnd != NULL, "CreateWindow failed\n");
+
+        hIMC = ImmGetContext(hwnd);
+
+        if (lstrcmpiA(pszClass, "BUTTON") == 0)
+            ok(hIMC == NULL, "hIMC was %p\n", hIMC);
+        else
+            ok(hIMC != NULL, "hIMC was NULL\n");
+
+        ImmReleaseContext(hwnd, hIMC);
+
+        DestroyWindow(hwnd);
+    }
+}
+
+START_TEST(himc)
+{
+    Test1();
+    Test2();
 }

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1866,6 +1866,10 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
    pWnd->ExStyle = Cs->dwExStyle;
    pWnd->cbwndExtra = pWnd->pcls->cbwndExtra;
    pWnd->pActCtx = acbiBuffer;
+
+   if (pti->spDefaultImc && Class->atomClassName != gpsi->atomSysClass[ICLS_BUTTON])
+      pWnd->hImc = UserHMGetHandle(pti->spDefaultImc);
+
    pWnd->InternalPos.MaxPos.x  = pWnd->InternalPos.MaxPos.y  = -1;
    pWnd->InternalPos.IconPos.x = pWnd->InternalPos.IconPos.y = -1;
 


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Set the default input context to `WND` at `IntCreateWindow` function.
- Add more tests to the `himc` testcase of `imm32_apitest`.