### PR TITLE
[NTUSER] Do assignment lock at NtUserSetThreadLayoutHandles

### DIFF
--- a/win32ss/user/ntuser/callback.c
+++ b/win32ss/user/ntuser/callback.c
@@ -1247,6 +1247,7 @@ co_UserCBClientPrinterThunk( PVOID pkt, INT InSize, PVOID pvOutData, INT OutSize
    return 0;
 }
 
+// Win: ClientImmProcessKey
 DWORD
 APIENTRY
 co_IntImmProcessKey(HWND hWnd, HKL hKL, UINT vKey, LPARAM lParam, DWORD dwHotKeyID)


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Use `UserAssignmentLock` in `NtUserSetThreadLayoutHandles`.
- Add `Win:` comments to many functions.
- Rename `glcid` as `glcidSystem`.
