### PR TITLE
[CSRSRV] Acquire the necessary SE_INC_BASE_PRIORITY_PRIVILEGE at shutdown

### DIFF
--- a/subsystems/win32/csrsrv/procsup.c
+++ b/subsystems/win32/csrsrv/procsup.c
@@ -64,8 +64,8 @@ CsrSetToNormalPriority(VOID)
  * @name CsrSetToShutdownPriority
  *
  * The CsrSetToShutdownPriority routine sets the current NT Process'
- * priority to the boosted priority for CSR Processes doing shutdown.
- * Additonally, it acquires the Shutdown Privilege required for shutdown.
+ * priority to the boosted priority for CSR Processes doing shutdown,
+ * acquiring also the required Increase Base Priority privilege.
  *
  * @param None.
  *
@@ -82,8 +82,8 @@ CsrSetToShutdownPriority(VOID)
     KPRIORITY BasePriority = PROCESS_PRIORITY_NORMAL_FOREGROUND + 6;
     BOOLEAN Old;
 
-    /* Get the shutdown privilege */
-    if (NT_SUCCESS(RtlAdjustPrivilege(SE_SHUTDOWN_PRIVILEGE,
+    /* Get the Increase Base Priority privilege */
+    if (NT_SUCCESS(RtlAdjustPrivilege(SE_INC_BASE_PRIORITY_PRIVILEGE,
                                       TRUE,
                                       FALSE,
                                       &Old)))


### PR DESCRIPTION
## Purpose

When increasing the base priority at shutdown, acquire the necessary
SE_INC_BASE_PRIORITY_PRIVILEGE in CsrSetToShutdownPriority(),
called by CsrShutdownProcesses(), which is necessary due to the increase
of process base priority (i.e. increase of scheduling) being done.

Dedicated to George Bișoc :)

## Explanation

The Shutdown privilege is however unnecessary (or unwanted) since this
has been already dealt with by the shutdown caller. Also, it will be
needed only by the caller of NtShutdownSystem() -- that we don't call
at all here.
