### PR TITLE
[NTUSER] Destroy the default IME window

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1811,8 +1811,8 @@ Quit:
     return ret;
 }
 
-// Returns TRUE if there is no IME-related window of the same thread of
-// pwndTarget, that is other than pwndTarget, around pwndParent.
+// Returns TRUE if there is any different-thread owner, or any same-thread
+// non-IME-related window of pwndTarget, that is other than pwndTarget, around pwndParent.
 //
 // Win: IsChildSameThread
 BOOL IntNoImeRelatedWindowOfSameThread(PWND pwndParent, PWND pwndTarget)
@@ -1839,14 +1839,14 @@ BOOL IntNoImeRelatedWindowOfSameThread(PWND pwndParent, PWND pwndTarget)
                 }
             }
             if (bFoundImeLikeOwner)
-                continue; // Skip IME-related windows.
+                continue; // Skip if any IME-like owner.
         }
 
         pwndNode = pwnd;
 
         if (IS_WND_CHILD(pwndNode))
         {
-            // Check if any IME-like ancestor of the same thread.
+            // Check if any different-thread child ancestor or any same-thread IME-like ancestor.
             bFoundImeLikeAncestor = FALSE;
             for (; IS_WND_CHILD(pwndNode); pwndNode = pwndNode->spwndParent)
             {
@@ -1860,13 +1860,13 @@ BOOL IntNoImeRelatedWindowOfSameThread(PWND pwndParent, PWND pwndTarget)
                 }
             }
             if (bFoundImeLikeAncestor)
-                continue; // Skip if the IME-like ancestor is found.
-            // Now, pwndNode is the non-child ancestor of the same thread.
+                continue;
+            // Now, pwndNode is non-child or non-same-thread window.
         }
 
-        if (!IS_WND_CHILD(pwndNode))
+        if (!IS_WND_CHILD(pwndNode)) // pwndNode is non-child
         {
-            // Check if any IME-like owner from the current pwndNode.
+            // Check if any different-thread owner or any same-thread IME-like owner.
             bFoundImeLikeOwner = FALSE;
             for (; pwndNode; pwndNode = pwndNode->spwndOwner)
             {
@@ -1880,7 +1880,7 @@ BOOL IntNoImeRelatedWindowOfSameThread(PWND pwndParent, PWND pwndTarget)
                 }
             }
             if (!bFoundImeLikeOwner)
-                return TRUE; // The IME-like ancestor of the same thread is not found.
+                return TRUE;
         }
     }
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1816,7 +1816,7 @@ BOOL IntIsChildSameThread(PWND pwndParent, PWND pwndChild)
 {
     PWND pwnd, pwndOwner, pwndNode;
     PTHREADINFO ptiChild = pwndChild->head.pti;
-    BOOL bFoundImeLikeOwner, bFoundImeLikeAncestor, bFoundImeLike;
+    BOOL bFoundImeLikeOwner, bFoundImeLikeAncestor;
 
     for (pwnd = pwndParent->spwndChild; pwnd; pwnd = pwnd->spwndNext)
     {

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1901,6 +1901,7 @@ BOOL FASTCALL IntImeCanDestroyDefIMEforChild(PWND pImeWnd, PWND pwndTarget)
     if (!pimeui || (LONG_PTR)pimeui == (LONG_PTR)-1)
         return FALSE;
 
+    // Check IMEUI.fChildThreadDef
     _SEH2_TRY
     {
         ProbeForRead(pimeui, sizeof(IMEUI), 1);
@@ -1914,6 +1915,7 @@ BOOL FASTCALL IntImeCanDestroyDefIMEforChild(PWND pImeWnd, PWND pwndTarget)
     }
     _SEH2_END;
 
+    // The parent of pwndTarget is NULL or of the same thread of pwndTarget?
     if (pwndTarget->spwndParent == NULL ||
         pwndTarget->head.pti == pwndTarget->spwndParent->head.pti)
     {
@@ -1946,6 +1948,7 @@ BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
     if (!pimeui || (LONG_PTR)pimeui == (LONG_PTR)-1)
         return FALSE;
 
+    // Check IMEUI.fDestroy
     _SEH2_TRY
     {
         ProbeForRead(pimeui, sizeof(IMEUI), 1);
@@ -1959,6 +1962,7 @@ BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
     }
     _SEH2_END;
 
+    // Any ancestor of pImeWnd has pwndTarget?
     if (pImeWnd->spwndOwner)
     {
         for (pwndNode = pImeWnd->spwndOwner; pwndNode; pwndNode = pwndNode->spwndOwner)
@@ -1971,23 +1975,24 @@ BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
             return FALSE;
     }
 
+    // Any ancestor of pwndTarget is IME-like?
     for (pwndNode = pwndTarget; pwndNode; pwndNode = pwndNode->spwndOwner)
     {
         if (IS_WND_IMELIKE(pwndNode))
             return FALSE;
     }
 
+    // Adjust the ordering and top-mode status
     IntImeSetFutureOwner(pImeWnd, pwndTarget);
-
     for (pwndNode = pImeWnd->spwndOwner; pwndNode; pwndNode = pwndNode->spwndNext)
     {
         if (pwndNode == pImeWnd)
             break;
     }
-
     if (pwndNode == pImeWnd)
         IntImeCheckTopmost(pImeWnd);
 
+    // Is the owner of pImeWnd NULL or pwndTarget?
     if (pImeWnd->spwndOwner && pwndTarget != pImeWnd->spwndOwner)
         return FALSE;
 

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1811,8 +1811,8 @@ Quit:
     return ret;
 }
 
-// Returns TRUE if there is no IME-related window of the same thread of pwndTarget,
-// around pwndParent.
+// Returns TRUE if there is no IME-related window of the same thread of
+// pwndTarget, that is other than pwndTarget, around pwndParent.
 //
 // Win: IsChildSameThread
 BOOL IntNoImeRelatedWindowOfSameThread(PWND pwndParent, PWND pwndTarget)

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1944,7 +1944,6 @@ BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
     IMEUI SafeImeUI;
 
     pimeui = ((PIMEWND)pImeWnd)->pimeui;
-
     if (!pimeui || (LONG_PTR)pimeui == (LONG_PTR)-1)
         return FALSE;
 
@@ -1962,7 +1961,7 @@ BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
     }
     _SEH2_END;
 
-    // Any ancestor of pImeWnd has pwndTarget?
+    // Any ancestor of pImeWnd is pwndTarget?
     if (pImeWnd->spwndOwner)
     {
         for (pwndNode = pImeWnd->spwndOwner; pwndNode; pwndNode = pwndNode->spwndOwner)

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1851,11 +1851,14 @@ BOOL IntIsChildSameThread(PWND pwndParent, PWND pwndChild)
                     break;
 
                 if (IS_WND_IMELIKE(pwndNode))
+                {
                     bFoundImeLikeAncestor = TRUE;
+                    break;
+                }
             }
             if (bFoundImeLikeAncestor)
-                continue;
-            // Now, pwndNode is the non-child ancestor.
+                continue; // The IME-like ancestor is found.
+            // Now, pwndNode is the non-child ancestor of the same thread.
         }
 
         if (!IS_WND_CHILD(pwndNode))

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -21,15 +21,6 @@ DBG_DEFAULT_CHANNEL(UserMisc);
 #define LANGID_CHINESE_TRADITIONAL  MAKELANGID(LANG_CHINESE,  SUBLANG_CHINESE_TRADITIONAL)
 #define LANGID_NEUTRAL              MAKELANGID(LANG_NEUTRAL,  SUBLANG_NEUTRAL)
 
-// The IME-like windows are the IME windows and the IME UI windows.
-// The IME window's class name is "IME".
-// The IME UI window behaves the User Interface of IME for the user.
-#define IS_WND_IMELIKE(pwnd) \
-    (((pwnd)->pcls->style & CS_IME) || \
-     ((pwnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_IME]))
-#define IS_WND_MENU(pWnd) \
-    ((pWnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_MENU])
-
 // The special virtual keys for Japanese: Used for key states.
 // https://www.kthree.co.jp/kihelp/index.html?page=app/vkey&type=html
 #define VK_DBE_ALPHANUMERIC 0xF0
@@ -1818,6 +1809,181 @@ NtUserQueryInputContext(HIMC hIMC, DWORD dwType)
 Quit:
     UserLeave();
     return ret;
+}
+
+// Win: IsChildSameThread
+BOOL IntIsChildSameThread(PWND pwndParent, PWND pwndChild)
+{
+    PWND pwnd, pwndOwner, pwndNode;
+    PTHREADINFO pti = pwndChild->head.pti;
+    BOOL bFoundOwner, bFoundImeLike;
+
+    for (pwnd = pwndParent->spwndChild; pwnd; pwnd = pwnd->spwndNext)
+    {
+        if (!IS_WND_CHILD(pwnd))
+        {
+            if (IS_WND_MENU(pwnd))
+                continue;
+
+            bFoundOwner = FALSE;
+            for (pwndOwner = pwnd; pwndOwner; pwndOwner = pwndOwner->spwndOwner)
+            {
+                if (IS_WND_IMELIKE(pwndOwner))
+                {
+                    bFoundOwner = TRUE;
+                    break;
+                }
+            }
+
+            if (bFoundOwner)
+                continue;
+        }
+
+        if (pwnd == pwndChild || pwnd->head.pti != pti)
+            continue;
+
+        bFoundImeLike = FALSE;
+
+        for (pwndNode = pwnd; IS_WND_CHILD(pwndNode); pwndNode = pwndNode->spwndParent)
+        {
+            if (pwndNode->head.pti != pti)
+                break;
+
+            if (IS_WND_IMELIKE(pwndNode))
+            {
+                bFoundImeLike = TRUE;
+                break;
+            }
+        }
+
+        if (bFoundImeLike)
+            continue;
+
+        if (!IS_WND_CHILD(pwndNode))
+        {
+            for (; pwndNode; pwndNode = pwndNode->spwndOwner)
+            {
+                if (pwndNode->head.pti != pti)
+                    break;
+
+                if (IS_WND_IMELIKE(pwndNode))
+                {
+                    bFoundImeLike = TRUE;
+                    break;
+                }
+            }
+        }
+
+        if (!bFoundImeLike)
+            return TRUE;
+    }
+
+    return FALSE;
+}
+
+// Can we destroy the default IME window for the target child window?
+// Win: ImeCanDestroyDefIMEforChild
+BOOL FASTCALL IntImeCanDestroyDefIMEforChild(PWND pImeWnd, PWND pwndTarget)
+{
+    PWND pwndNode;
+    PIMEUI pimeui;
+    IMEUI SafeImeUI;
+
+    pimeui = ((PIMEWND)pImeWnd)->pimeui;
+    if (!pimeui || (LONG_PTR)pimeui == (LONG_PTR)-1)
+        return FALSE;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pimeui, sizeof(IMEUI), 1);
+        SafeImeUI = *pimeui;
+        if (!SafeImeUI.fChildThreadDef)
+            return FALSE;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ;
+    }
+    _SEH2_END;
+
+    if (pwndTarget->spwndParent == NULL ||
+        pwndTarget->head.pti == pwndTarget->spwndParent->head.pti)
+    {
+        return FALSE;
+    }
+
+    for (pwndNode = pwndTarget; pwndNode; pwndNode = pwndNode->spwndParent)
+    {
+        if (pwndNode == pwndNode->head.rpdesk->pDeskInfo->spwnd)
+            break;
+
+        if (IntIsChildSameThread(pwndNode->spwndParent, pwndTarget))
+            return FALSE;
+    }
+
+    return TRUE;
+}
+
+// Can we destroy the default IME window for the non-child target window?
+// Win: ImeCanDestroyDefIME
+BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget)
+{
+    PWND pwndNode;
+    PIMEUI pimeui;
+    IMEUI SafeImeUI;
+
+    pimeui = ((PIMEWND)pImeWnd)->pimeui;
+
+    if (!pimeui || (LONG_PTR)pimeui == (LONG_PTR)-1)
+        return FALSE;
+
+    _SEH2_TRY
+    {
+        ProbeForRead(pimeui, sizeof(IMEUI), 1);
+        SafeImeUI = *pimeui;
+        if (SafeImeUI.fDestroy)
+            return FALSE;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ;
+    }
+    _SEH2_END;
+
+    if (pImeWnd->spwndOwner)
+    {
+        for (pwndNode = pImeWnd->spwndOwner; pwndNode; pwndNode = pwndNode->spwndOwner)
+        {
+            if (pwndNode == pwndTarget)
+                break;
+        }
+
+        if (!pwndNode)
+            return FALSE;
+    }
+
+    for (pwndNode = pwndTarget; pwndNode; pwndNode = pwndNode->spwndOwner)
+    {
+        if (IS_WND_IMELIKE(pwndNode))
+            return FALSE;
+    }
+
+    IntImeSetFutureOwner(pImeWnd, pwndTarget);
+
+    for (pwndNode = pImeWnd->spwndOwner; pwndNode; pwndNode = pwndNode->spwndNext)
+    {
+        if (pwndNode == pImeWnd)
+            break;
+    }
+
+    if (pwndNode == pImeWnd)
+        IntImeCheckTopmost(pImeWnd);
+
+    if (pImeWnd->spwndOwner && pwndTarget != pImeWnd->spwndOwner)
+        return FALSE;
+
+    pImeWnd->spwndOwner = NULL;
+    return TRUE;
 }
 
 /* EOF */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -658,7 +658,7 @@ LRESULT co_UserFreeWindow(PWND Window,
          ThreadData->rpdesk->rpwinstaParent->ShellListView = NULL;
    }
 
-  if (IS_IMM_MODE() && Window == ThreadData->spwndDefaultIme)
+   if (IS_IMM_MODE() && Window == ThreadData->spwndDefaultIme)
       UserAssignmentUnlock((PVOID*)&(ThreadData->spwndDefaultIme));
 
    /* Fixes dialog test_focus breakage due to r66237. */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -658,6 +658,9 @@ LRESULT co_UserFreeWindow(PWND Window,
          ThreadData->rpdesk->rpwinstaParent->ShellListView = NULL;
    }
 
+  if (IS_IMM_MODE() && Window == ThreadData->spwndDefaultIme)
+      UserAssignmentUnlock((PVOID*)&(ThreadData->spwndDefaultIme));
+
    /* Fixes dialog test_focus breakage due to r66237. */
    if (ThreadData->MessageQueue->spwndFocus == Window)
       ThreadData->MessageQueue->spwndFocus = NULL;
@@ -2762,7 +2765,7 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
    TRACE("co_UserDestroyWindow(Window = 0x%p, hWnd = 0x%p)\n", Window, hWnd);
 
    /* Check for owner thread */
-   if ( Window->head.pti != PsGetCurrentThreadWin32Thread())
+   if (Window->head.pti != ti)
    {
        /* Check if we are destroying the desktop window */
        if (! ((Window->head.rpdesk->dwDTFlags & DF_DESTROYED) && Window == Window->head.rpdesk->pDeskInfo->spwnd))
@@ -2917,6 +2920,22 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
 
    /* Send destroy messages */
    IntSendDestroyMsg(UserHMGetHandle(Window));
+
+   // Destroy the default IME window if necessary
+   if (IS_IMM_MODE() && !(ti->TIF_flags & TIF_INCLEANUP) &&
+       ti->spwndDefaultIme && !IS_WND_IMELIKE(Window) && !(Window->state & WNDS_DESTROYED))
+   {
+       if (IS_WND_CHILD(Window))
+       {
+           if (IntImeCanDestroyDefIMEforChild(ti->spwndDefaultIme, Window))
+               co_UserDestroyWindow(ti->spwndDefaultIme);
+       }
+       else
+       {
+           if (IntImeCanDestroyDefIME(ti->spwndDefaultIme, Window))
+               co_UserDestroyWindow(ti->spwndDefaultIme);
+       }
+   }
 
    if (!IntIsWindow(UserHMGetHandle(Window)))
    {

--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -102,17 +102,15 @@ VOID FASTCALL IntFreeHwndList(PWINDOWLIST pwlTarget);
 /* Undocumented dwFlags for IntBuildHwndList */
 #define IACE_LIST  0x0002
 
-#define IS_WND_MENU(pWnd) \
-    ((pWnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_MENU])
-
 #define IS_WND_CHILD(pWnd) ((pWnd)->style & WS_CHILD)
+#define IS_WND_MENU(pWnd) ((pWnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_MENU])
 
 // The IME-like windows are the IME windows and the IME UI windows.
 // The IME window's class name is "IME".
 // The IME UI window behaves the User Interface of IME for the user.
-#define IS_WND_IMELIKE(pwnd) \
-    (((pwnd)->pcls->style & CS_IME) || \
-     ((pwnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_IME]))
+#define IS_WND_IMELIKE(pWnd) \
+    (((pWnd)->pcls->style & CS_IME) || \
+     ((pWnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_IME]))
 
 BOOL FASTCALL IntImeCanDestroyDefIMEforChild(PWND pImeWnd, PWND pwndTarget);
 BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget);

--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -102,4 +102,19 @@ VOID FASTCALL IntFreeHwndList(PWINDOWLIST pwlTarget);
 /* Undocumented dwFlags for IntBuildHwndList */
 #define IACE_LIST  0x0002
 
+#define IS_WND_MENU(pWnd) \
+    ((pWnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_MENU])
+
+#define IS_WND_CHILD(pWnd) ((pWnd)->style & WS_CHILD)
+
+// The IME-like windows are the IME windows and the IME UI windows.
+// The IME window's class name is "IME".
+// The IME UI window behaves the User Interface of IME for the user.
+#define IS_WND_IMELIKE(pwnd) \
+    (((pwnd)->pcls->style & CS_IME) || \
+     ((pwnd)->pcls->atomClassName == gpsi->atomSysClass[ICLS_IME]))
+
+BOOL FASTCALL IntImeCanDestroyDefIMEforChild(PWND pImeWnd, PWND pwndTarget);
+BOOL FASTCALL IntImeCanDestroyDefIME(PWND pImeWnd, PWND pwndTarget);
+
 /* EOF */


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `IntFindNonImeRelatedWndOfSameThread`, `IntImeCanDestroyDefIMEforChild`, and `IntImeCanDestroyDefIME` helper functions.
- Do assignment unlock `spwndDefaultIme` at `co_UserFreeWindow` function.
- Destroy the default IME window of the specified window if necessary at `co_UserDestroyWindow` function.