### PR TITLE
[MSVCRT] Enable _wfindfirst64 and _wfindnext64 in msvcrt.spec

### DIFF
--- a/dll/win32/msvcrt/msvcrt.spec
+++ b/dll/win32/msvcrt/msvcrt.spec
@@ -1197,10 +1197,10 @@
 @ cdecl _wexecvpe(wstr ptr ptr)
 @ cdecl _wfdopen(long wstr)
 @ cdecl _wfindfirst(wstr ptr)
-# stub _wfindfirst64
+@ cdecl _wfindfirst64(wstr ptr)
 @ cdecl _wfindfirsti64(wstr ptr)
 @ cdecl _wfindnext(long ptr)
-# stub _wfindnext64
+@ cdecl _wfindnext64(long ptr)
 @ cdecl _wfindnexti64(long ptr)
 @ cdecl _wfopen(wstr wstr)
 @ cdecl -version=0x600+ _wfopen_s(ptr wstr wstr)


### PR DESCRIPTION
## Purpose

Allows to enable software such like VLC under ReactOS 64 bits.

JIRA issue: [CORE-17666](https://jira.reactos.org/browse/CORE-17666)

![VLC](https://user-images.githubusercontent.com/27921286/164554693-861c78c6-11fd-47a5-881b-c8612caf6214.jpeg)


## Proposed changes

- Activate them. Check if work as they should.

## TODO
- Not in this pull request, but [CORE-17666](https://jira.reactos.org/browse/CORE-17666) needs the MSI to finish the install, that surely will need something else.
- Not in this PR, but  [CORE-18158](https://jira.reactos.org/browse/CORE-18158) msvcrt needs some fixes to go on.