### PR TITLE
[IMM32_APITEST] himc: Show class on CreateWindow failure

### DIFF
--- a/modules/rostests/apitests/imm32/himc.c
+++ b/modules/rostests/apitests/imm32/himc.c
@@ -173,7 +173,7 @@ static void Test2(void)
         LPCSTR pszClass = apszClasses[i];
         hwnd = CreateWindowA(pszClass, NULL, WS_VISIBLE, 0, 0, 0, 0, NULL, NULL,
                              GetModuleHandle(NULL), NULL);
-        ok(hwnd != NULL, "CreateWindow failed\n");
+        ok(hwnd != NULL, "CreateWindow(%s) failed\n", pszClass);
 
         hIMC = ImmGetContext(hwnd);
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Display the window class name on failure of `CreateWindow` function call.