### PR TITLE
[NTOS:PNP] Fix GCC build (ignoring return value)

### DIFF
--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -195,7 +195,7 @@ IopInitializeDevice(
     UNICODE_STRING DeviceInstance;
     PDEVICE_OBJECT DeviceObject;
     PDEVICE_NODE DeviceNode;
-    NTSTATUS Status = STATUS_SUCCESS, StatusUnused;
+    NTSTATUS Status = STATUS_SUCCESS;
 
     DPRINT("IopInitializeDevice(%p)\n", ControlData);
 

--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -195,7 +195,7 @@ IopInitializeDevice(
     UNICODE_STRING DeviceInstance;
     PDEVICE_OBJECT DeviceObject;
     PDEVICE_NODE DeviceNode;
-    NTSTATUS Status = STATUS_SUCCESS;
+    NTSTATUS Status = STATUS_SUCCESS, StatusUnused;
 
     DPRINT("IopInitializeDevice(%p)\n", ControlData);
 
@@ -245,8 +245,8 @@ IopInitializeDevice(
     }
 
     /* Set the device instance of the device node */
-    RtlDuplicateUnicodeString(0, &DeviceInstance, &DeviceNode->InstancePath);
-
+    StatusUnused = RtlDuplicateUnicodeString(0, &DeviceInstance, &DeviceNode->InstancePath);
+    UNREFERENCED_PARAMETER(StatusUnused);
 
     /* Insert as a root enumerated device node */
     PiInsertDevNode(DeviceNode, IopRootDeviceNode);

--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -245,8 +245,14 @@ IopInitializeDevice(
     }
 
     /* Set the device instance of the device node */
-    StatusUnused = RtlDuplicateUnicodeString(0, &DeviceInstance, &DeviceNode->InstancePath);
-    UNREFERENCED_PARAMETER(StatusUnused);
+    Status = RtlDuplicateUnicodeString(0, &DeviceInstance, &DeviceNode->InstancePath);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("RtlDuplicateUnicodeString() failed (Status 0x%08lx)\n", Status);
+        IopFreeDeviceNode(DeviceNode);
+        IoDeleteDevice(DeviceObject);
+        goto done;
+    }
 
     /* Insert as a root enumerated device node */
     PiInsertDevNode(DeviceNode, IopRootDeviceNode);


### PR DESCRIPTION
## Purpose

JIRA issue: N/A

```txt
/srv/buildbot/worker_data/Build_GCCLin_x86/build/ntoskrnl/io/pnpmgr/plugplay.c: In function 'IopInitializeDevice':
/srv/buildbot/worker_data/Build_GCCLin_x86/build/ntoskrnl/io/pnpmgr/plugplay.c:248:5: error: ignoring return value of 'RtlDuplicateUnicodeString', declared with attribute warn_unused_result [-Werror=unused-result]
     RtlDuplicateUnicodeString(0, &DeviceInstance, &DeviceNode->InstancePath);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

## Proposed changes

- Get the return value of `RtlDuplicateUnicodeString` function call as `Status`.
- Output the error message if failed.

## TODO

- [x] Build.
- [x] Get consensus.