### PR TITLE
[CRT] Fix MinGW-arm intrin minor bug

### DIFF
--- a/sdk/include/crt/mingw32/intrin_arm.h
+++ b/sdk/include/crt/mingw32/intrin_arm.h
@@ -41,7 +41,7 @@ __INTRIN_INLINE void __break(unsigned int value) { __asm__ __volatile__("bkpt %0
 
 __INTRIN_INLINE unsigned short _byteswap_ushort(unsigned short value)
 {
-	return (value >> 8) || (value << 8);
+	return (value >> 8) | (value << 8);
 }
 
 __INTRIN_INLINE unsigned _CountLeadingZeros(long Mask)


### PR DESCRIPTION
## Purpose
Fix a little bug present on the CRT, located with a cegcc compiler under ReactOS Build Environment (for more info, visit http://max.kellermann.name/projects/cegcc/ ), little MinGW intrin_arm.h that is making an error, thanks to @HBelusca.
``` ../sdk/include/crt/mingw32/intrin_arm.h:44:32: error: '<<' in boolean context, did you mean '<' ? [-Werror=int-in-bool-context] ```

## TO-DO
- Well, it's cegcc and arm... So surely more bugs will be encountered.