### PR TITLE
[NTUSER] Fix UserDestroyInputContext (again)

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1465,8 +1465,10 @@ VOID UserFreeInputContext(PVOID Object)
 BOOLEAN UserDestroyInputContext(PVOID Object)
 {
     PIMC pIMC = Object;
-    if (!pIMC || !UserMarkObjectDestroy(pIMC))
+    if (!pIMC)
         return TRUE;
+
+    UserMarkObjectDestroy(pIMC);
 
     return UserDeleteObject(UserHMGetHandle(pIMC), TYPE_INPUTCONTEXT);
 }

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1465,10 +1465,11 @@ VOID UserFreeInputContext(PVOID Object)
 BOOLEAN UserDestroyInputContext(PVOID Object)
 {
     PIMC pIMC = Object;
-    if (!pIMC || !UserMarkObjectDestroy(pIMC))
+    if (!pIMC)
         return TRUE;
 
-    return UserDeleteObject(UserHMGetHandle(pIMC), TYPE_INPUTCONTEXT);
+    UserDeleteObject(UserHMGetHandle(pIMC), TYPE_INPUTCONTEXT);
+    return TRUE;
 }
 
 // Win: DestroyInputContext

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -596,7 +596,7 @@ UserMarkObjectDestroy(PVOID Object)
 
     entry->flags |= HANDLEENTRY_DESTROY;
 
-    if (ObjHead->cLockObj > 0)
+    if (ObjHead->cLockObj > 1)
     {
         entry->flags &= ~HANDLEENTRY_INDESTROY;
         TRACE("Count %d\n",ObjHead->cLockObj);

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -582,6 +582,7 @@ UserCreateObject( PUSER_HANDLE_TABLE ht,
    return Object;
 }
 
+// Win: HMMarkObjectDestroy
 BOOL
 FASTCALL
 UserMarkObjectDestroy(PVOID Object)
@@ -595,7 +596,7 @@ UserMarkObjectDestroy(PVOID Object)
 
     entry->flags |= HANDLEENTRY_DESTROY;
 
-    if (ObjHead->cLockObj > 1)
+    if (ObjHead->cLockObj > 0)
     {
         entry->flags &= ~HANDLEENTRY_INDESTROY;
         TRACE("Count %d\n",ObjHead->cLockObj);


### PR DESCRIPTION
## Purpose
Fix the `HIMC` handle leak.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- `UserDestroyInputContext` always returns `TRUE`.
- Don't call `UserMarkObjectDestroy` in `UserDestroyInputContext`.

## TODO

- [x] Do tests.