### PR TITLE
[NTUSER] Fix 'Trying to link windows to itself' with Patch by I_Kill_Bugs

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1400,12 +1400,14 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
                      {
                         /* Do not allow hWndInsertAfter to become equal to
                          * Window->head.h. This would cause the window to
-                         * reference itself. */
+                         * reference itself. This changes the passed in
+                         * hWndInsertAfter which will be handled below. */
                         hWndInsertAfter = List[i - 1];
                      }
                      else
                      {
-                        /* If hWndInsertAfter is equal to Window->head.h */
+                        /* If we cannot do 'hWndInsertAfter = List[i - 1]' then
+                         * exit here returning hWndInsertAfter as passed in. */
                         return hWndInsertAfter;
                      }
                   }

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1396,18 +1396,24 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
                   /* We found its Owner, so we must handle it here. */
                   if (i > 0)
                   {
-                     if (List[i - 1] != Window->head.h)
+                     if (List[i - 1] != UserHMGetHandle(Window))
                      {
-                        /* Do not allow hWndInsertAfter to become equal to
-                         * Window->head.h. This would cause the window to
-                         * reference itself. This changes the passed in
-                         * hWndInsertAfter which will be handled below. */
+                        /*
+                         * If the popup to be inserted is not already just
+                         * before the Owner, insert it there. The modified
+                         * hWndInsertAfter will be handled below.
+                         *
+                         * (NOTE: Do not allow hWndInsertAfter to become equal
+                         * to the popup's window handle, as this would cause
+                         * the popup to link to itself).
+                         */
                         hWndInsertAfter = List[i - 1];
                      }
                      else
                      {
-                        /* If we cannot do 'hWndInsertAfter = List[i - 1]' then
-                         * exit here returning hWndInsertAfter as passed in. */
+                        /* If the popup to be inserted is already
+                         * before the Owner, we are done. */
+                        ExFreePoolWithTag(List, USERTAG_WINDOWLIST);
                         return hWndInsertAfter;
                      }
                   }

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1393,16 +1393,27 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
 
                if (List[i] == Owner)
                {
-                   if (i > 0)
-                   {
-                       if (List[i - 1] != Window->head.h)  
-                           hWndInsertAfter = List[i - 1];
-                   }
-                   else
-                   {
-                       hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
-                   }
-                   break;
+                  /* We found its Owner, so we must handle it here. */
+                  if (i > 0)
+                  {
+                     if (List[i-1] != Window->head.h)
+                     {
+                     /* Do not allow hWndInsertAfter to become equal to
+                      * Window->head.h. This would cause the window to
+                      * reference itself. */
+                         hWndInsertAfter = List[i-1];
+                     }
+                     else
+                     {
+                     /* If hWndInsertAfter is equal to Window->head.h */
+                         return hWndInsertAfter;
+                     }
+                  }
+                  else
+                  {
+                     hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
+                  }
+                  break;
                }
 
                if (hWndInsertAfter == HWND_TOP || hWndInsertAfter ==  HWND_NOTOPMOST)

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1393,9 +1393,13 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
 
                if (List[i] == Owner)
                {
-                  if (i > 0) hWndInsertAfter = List[i-1];
-                  else hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
-                  break;
+                   if (i > 0)
+                   {
+                       if (List[i-1] != Window->head.h)  
+                           hWndInsertAfter = List[i-1];
+                   }
+                   else hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
+                   break;
                }
 
                if (hWndInsertAfter == HWND_TOP || hWndInsertAfter ==  HWND_NOTOPMOST)

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1395,10 +1395,13 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
                {
                    if (i > 0)
                    {
-                       if (List[i-1] != Window->head.h)  
-                           hWndInsertAfter = List[i-1];
+                       if (List[i - 1] != Window->head.h)  
+                           hWndInsertAfter = List[i - 1];
                    }
-                   else hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
+                   else
+                   {
+                       hWndInsertAfter = topmost ? HWND_TOPMOST : HWND_TOP;
+                   }
                    break;
                }
 

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1396,17 +1396,17 @@ WinPosDoOwnedPopups(PWND Window, HWND hWndInsertAfter)
                   /* We found its Owner, so we must handle it here. */
                   if (i > 0)
                   {
-                     if (List[i-1] != Window->head.h)
+                     if (List[i - 1] != Window->head.h)
                      {
-                     /* Do not allow hWndInsertAfter to become equal to
-                      * Window->head.h. This would cause the window to
-                      * reference itself. */
-                         hWndInsertAfter = List[i-1];
+                        /* Do not allow hWndInsertAfter to become equal to
+                         * Window->head.h. This would cause the window to
+                         * reference itself. */
+                        hWndInsertAfter = List[i - 1];
                      }
                      else
                      {
-                     /* If hWndInsertAfter is equal to Window->head.h */
-                         return hWndInsertAfter;
+                        /* If hWndInsertAfter is equal to Window->head.h */
+                        return hWndInsertAfter;
                      }
                   }
                   else


### PR DESCRIPTION
## Fix Crash on cxLocalizerEditor when selecting pull-down and then clicking out of the pull-down box.

_Change how Windows Hierarchy is changed when creating pop-up windows as owned._

JIRA issue: [CORE-18132](https://jira.reactos.org/browse/CORE-18132)

## Revise winpos.c to change how window owner/owned relationship is done when creating pop-ups as owned.
