### PR TITLE
[NTUSER] Fix UserDestroyInputContext (again and again)

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -1468,6 +1468,7 @@ BOOLEAN UserDestroyInputContext(PVOID Object)
     if (!pIMC)
         return TRUE;
 
+    UserMarkObjectDestroy(pIMC);
     UserDeleteObject(UserHMGetHandle(pIMC), TYPE_INPUTCONTEXT);
     return TRUE;
 }


### PR DESCRIPTION
## Purpose
Fix hung-up.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add call of `UserMarkObjectDestroy`.

## TODO

- [x] Do tests.
