### PR TITLE
[NTUSER][USER32] Make NtUserBuildHwndList exclusive

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1561,9 +1561,9 @@ NtUserBuildHwndList(
     HWND hwndParent,
     BOOLEAN bChildren,
     ULONG dwThreadId,
-    ULONG lParam,
-    HWND *pWnd,
-    ULONG *pBufSize);
+    ULONG cHwnd,
+    HWND *phwndList,
+    ULONG *pcHwndNeeded);
 
 NTSTATUS
 NTAPI

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1560,7 +1560,7 @@ NtUserBuildHwndList(
          {
             if (bGoDown)
             {
-               if(dwCount++ < *pcHwndNeeded && phwndList)
+               if(dwCount++ < cHwnd && phwndList)
                {
                   _SEH2_TRY
                   {
@@ -1638,7 +1638,7 @@ NtUserBuildHwndList(
             Window = ValidateHwndNoErr(List[i]);
             if (Window && Window->head.pti == W32Thread)
             {
-               if (dwCount < *pcHwndNeeded && phwndList)
+               if (dwCount < cHwnd && phwndList)
                {
                   _SEH2_TRY
                   {

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1514,10 +1514,7 @@ NtUserBuildHwndList(
    ULONG dwCount = 0;
 
    if (pcHwndNeeded == NULL)
-   {
-       UserLeave();
        return ERROR_INVALID_PARAMETER;
-   }
 
    UserEnterExclusive();
 

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1560,7 +1560,7 @@ NtUserBuildHwndList(
          {
             if (bGoDown)
             {
-               if(dwCount++ < cHwnd && phwndList)
+               if (dwCount++ < cHwnd && phwndList)
                {
                   _SEH2_TRY
                   {

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -1506,7 +1506,7 @@ NtUserBuildHwndList(
    HWND hwndParent,
    BOOLEAN bChildren,
    ULONG dwThreadId,
-   LPARAM lParam,
+   ULONG lParam,
    HWND* pWnd,
    ULONG* pBufSize)
 {

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -145,7 +145,7 @@ HWND* WIN_ListChildren (HWND hWndparent)
   HANDLE hHeap;
   NTSTATUS Status;
 
-  Status = NtUserBuildHwndList ( NULL, hWndparent, FALSE, 0, 0, NULL, &dwCount );
+  Status = NtUserBuildHwndList(NULL, hWndparent, FALSE, 0, dwCount, NULL, &dwCount);
 
   if ( !NT_SUCCESS( Status ) )
     return 0;
@@ -161,7 +161,7 @@ HWND* WIN_ListChildren (HWND hWndparent)
     }
 
   /* now call kernel again to fill the buffer this time */
-  Status = NtUserBuildHwndList (NULL, hWndparent, FALSE, 0, 0, pHwnd, &dwCount );
+  Status = NtUserBuildHwndList(NULL, hWndparent, FALSE, 0, dwCount, pHwnd, &dwCount);
 
   if ( !NT_SUCCESS( Status ) )
     {

--- a/win32ss/user/user32/windows/window.c
+++ b/win32ss/user/user32/windows/window.c
@@ -701,7 +701,7 @@ User32EnumWindows(HDESK hDesktop,
                                  hWndparent,
                                  bChildren,
                                  dwThreadId,
-                                 lParam,
+                                 dwCount,
                                  NULL,
                                  &dwCount);
     if (!NT_SUCCESS(Status))
@@ -729,7 +729,7 @@ User32EnumWindows(HDESK hDesktop,
                                  hWndparent,
                                  bChildren,
                                  dwThreadId,
-                                 lParam,
+                                 dwCount,
                                  pHwnd,
                                  &dwCount);
     if (!NT_SUCCESS(Status))


### PR DESCRIPTION
## Purpose
Fix hung-up and memory leaks.
JIRA issue: [CORE-18173](https://jira.reactos.org/browse/CORE-18173)

## Proposed changes

- Modify the prototype of `NtUserBuildHwndList` function.
- Wrap the code by `UserEnterExclusive();` and `UserLeave();`.
- Fix calling of `NtUserBuildHwndList` in `user32.dll`.

## TODO

- [x] Do tests.
