### PR TITLE
[SHELL32][PRINTER] Pointer check implemented.

### DIFF
--- a/dll/win32/shell32/folders/CPrinterFolder.cpp
+++ b/dll/win32/shell32/folders/CPrinterFolder.cpp
@@ -102,10 +102,13 @@ static LPITEMIDLIST _ILCreatePrinterItem(PRINTER_INFO_4W *pi)
     PIDLPrinterStruct * p;
     int size0 = (char*)&tmp.u.cprinter.szName - (char*)&tmp.u.cprinter;
     int size = size0;
-    SIZE_T cchPrinterName, cchServerName;
+    SIZE_T cchPrinterName = 0;
+    SIZE_T cchServerName = 0;
 
-    cchPrinterName = wcslen(pi->pPrinterName);
-    cchServerName = wcslen(pi->pServerName);
+    if (pi->pPrinterName)
+        cchPrinterName = wcslen(pi->pPrinterName);
+    if (pi->pServerName)
+        cchServerName = wcslen(pi->pServerName);
     if ((cchPrinterName + cchServerName) > (MAXUSHORT - 2))
     {
         return NULL;


### PR DESCRIPTION
## Purpose

To fix the exception error issue when opening the printer folder.

JIRA issue: [CORE-18174](https://jira.reactos.org/browse/CORE-18174)

## Proposed changes

Check string pointers before determining the length of strings.