### PR TITLE
[SHELL32] Fix of visual glitch problem after CORE-18137 shell32 fix

### DIFF
--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -819,6 +819,7 @@ Control_EnumWinProc(
 static void
 Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
 {
+    HICON hSmallIcon;
     ITaskbarList* pTaskbar = NULL;
 
     /* Try to add a taskbar button only if the applet's parent window is the desktop */
@@ -828,9 +829,22 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
     }
 
     SetWindowTextW(applet->hWnd, applet->info[index].name);
-    if (applet->info[index].icon)
+
+    /* try loading the 16x16 icon for the taskbar button */
+    hSmallIcon = (HICON)LoadImageW(applet->hModule,
+                                   MAKEINTRESOURCEW(applet->info[index].idIcon),
+                                   IMAGE_ICON,
+                                   16, 16, 0);
+    if (hSmallIcon)
     {
-        SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
+        SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)hSmallIcon);
+    }
+    else
+    {
+        if (applet->info[index].icon)
+        {
+            SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
+        }
     }
 
     /* Add button to the taskbar */

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -830,11 +830,13 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
 
     SetWindowTextW(applet->hWnd, applet->info[index].name);
 
-    /* try loading the 16x16 icon for the taskbar button */
+    /* Try loading the small icon for the taskbar button */
     hSmallIcon = (HICON)LoadImageW(applet->hModule,
                                    MAKEINTRESOURCEW(applet->info[index].idIcon),
                                    IMAGE_ICON,
-                                   16, 16, 0);
+                                   GetSystemMetrics(SM_CXSMICON),
+                                   GetSystemMetrics(SM_CYSMICON),
+                                   0);
     if (hSmallIcon)
     {
         SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)hSmallIcon);

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -821,26 +821,29 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
 {
     ITaskbarList* pTaskbar = NULL;
 
-    SetWindowTextW(applet->hWnd, applet->info[index].name);
-    SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
-
-    /* Add button to the taskbar */
-    ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
-
-    /* Activate the corresponding button in the taskbar */
-    CoInitialize(NULL);
-    if (CoCreateInstance(&CLSID_TaskbarList,
-                         NULL, CLSCTX_INPROC_SERVER,
-                         &IID_ITaskbarList,
-                         (LPVOID*)&pTaskbar) == S_OK)
+    if (GetParent(applet->hWnd) == NULL) // Is desktop the parent window?
     {
-        if (ITaskbarList_HrInit(pTaskbar) == S_OK)
+        SetWindowTextW(applet->hWnd, applet->info[index].name);
+        SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
+
+        /* Add button to the taskbar */
+        ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
+
+        /* Activate the corresponding button in the taskbar */
+        CoInitialize(NULL);
+        if (CoCreateInstance(&CLSID_TaskbarList,
+                             NULL, CLSCTX_INPROC_SERVER,
+                             &IID_ITaskbarList,
+                             (LPVOID*)&pTaskbar) == S_OK)
         {
-            ITaskbarList_ActivateTab(pTaskbar, applet->hWnd);
+            if (ITaskbarList_HrInit(pTaskbar) == S_OK)
+            {
+                ITaskbarList_ActivateTab(pTaskbar, applet->hWnd);
+            }
+            ITaskbarList_Release(pTaskbar);
         }
-        ITaskbarList_Release(pTaskbar);
+        CoUninitialize();
     }
-    CoUninitialize();
 }
 
 #endif /* __REACTOS__ */

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -839,9 +839,9 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
     /* Activate the corresponding button in the taskbar */
     CoInitialize(NULL);
     if (CoCreateInstance(&CLSID_TaskbarList,
-                            NULL, CLSCTX_INPROC_SERVER,
-                            &IID_ITaskbarList,
-                            (LPVOID*)&pTaskbar) == S_OK)
+                         NULL, CLSCTX_INPROC_SERVER,
+                         &IID_ITaskbarList,
+                         (LPVOID*)&pTaskbar) == S_OK)
     {
         if (ITaskbarList_HrInit(pTaskbar) == S_OK)
         {

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -821,29 +821,35 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
 {
     ITaskbarList* pTaskbar = NULL;
 
-    if (GetParent(applet->hWnd) == NULL) // Is desktop the parent window?
+    /* Try to add a taskbar button only if the applet's parent window is the desktop */
+    if (GetParent(applet->hWnd) != NULL)
     {
-        SetWindowTextW(applet->hWnd, applet->info[index].name);
-        SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
-
-        /* Add button to the taskbar */
-        ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
-
-        /* Activate the corresponding button in the taskbar */
-        CoInitialize(NULL);
-        if (CoCreateInstance(&CLSID_TaskbarList,
-                             NULL, CLSCTX_INPROC_SERVER,
-                             &IID_ITaskbarList,
-                             (LPVOID*)&pTaskbar) == S_OK)
-        {
-            if (ITaskbarList_HrInit(pTaskbar) == S_OK)
-            {
-                ITaskbarList_ActivateTab(pTaskbar, applet->hWnd);
-            }
-            ITaskbarList_Release(pTaskbar);
-        }
-        CoUninitialize();
+        return;
     }
+
+    SetWindowTextW(applet->hWnd, applet->info[index].name);
+    if (applet->info[index].icon)
+    {
+        SendMessageW(applet->hWnd, WM_SETICON, ICON_SMALL, (LPARAM)applet->info[index].icon);
+    }
+
+    /* Add button to the taskbar */
+    ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
+
+    /* Activate the corresponding button in the taskbar */
+    CoInitialize(NULL);
+    if (CoCreateInstance(&CLSID_TaskbarList,
+                            NULL, CLSCTX_INPROC_SERVER,
+                            &IID_ITaskbarList,
+                            (LPVOID*)&pTaskbar) == S_OK)
+    {
+        if (ITaskbarList_HrInit(pTaskbar) == S_OK)
+        {
+            ITaskbarList_ActivateTab(pTaskbar, applet->hWnd);
+        }
+        ITaskbarList_Release(pTaskbar);
+    }
+    CoUninitialize();
 }
 
 #endif /* __REACTOS__ */


### PR DESCRIPTION
## Purpose

Adding the Control Panel applet to the taskbar caused a visual glitch in the installation wizard via the RunDLL window 

JIRA issue: [CORE-18175](https://jira.reactos.org/browse/CORE-18175)

## Proposed changes

Implemented a check if the parent window of RunDLL is the desktop to add the system control applet to the taskbar only if it is.

In case of a problem, the installer window is the parent window of RunDLL, so now the RunDLL window is not manipulated.
