### PR TITLE
[SHELL32_APITEST] ShellExecCmdLine: Do **NOT** use TerminateProcess to close the opened windows.

### DIFF
--- a/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecCmdLine.cpp
@@ -609,13 +609,7 @@ static void CleanupNewlyCreatedWindows(void)
             }
         }
         if (!bFound)
-        {
-            DWORD dwPID;
-            GetWindowThreadProcessId(s_wi1.phwnd[i1], &dwPID);
-            HANDLE hProcess = OpenProcess(PROCESS_TERMINATE, TRUE, dwPID);
-            TerminateProcess(hProcess, -1);
-            CloseHandle(hProcess);
-        }
+            PostMessageW(s_wi1.phwnd[i1], WM_CLOSE, 0, 0);
     }
     free(s_wi1.phwnd);
     ZeroMemory(&s_wi1, sizeof(s_wi1));

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -67,6 +67,7 @@ TestShellExecuteEx(const WCHAR* Name, BOOL ExpectedResult)
 {
     SHELLEXECUTEINFOW ShellExecInfo;
     BOOL Result;
+
     ZeroMemory(&ShellExecInfo, sizeof(ShellExecInfo));
     ShellExecInfo.cbSize = sizeof(ShellExecInfo);
     ShellExecInfo.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_FLAG_NO_UI;
@@ -74,6 +75,7 @@ TestShellExecuteEx(const WCHAR* Name, BOOL ExpectedResult)
     ShellExecInfo.nShow = SW_SHOWNORMAL;
     ShellExecInfo.lpFile = Name;
     ShellExecInfo.lpDirectory = NULL;
+
     Result = ShellExecuteExW(&ShellExecInfo);
     ok(Result == ExpectedResult, "ShellExecuteEx lpFile %s failed. Error: %lu\n", wine_dbgstr_w(Name), GetLastError());
     if (ShellExecInfo.hProcess)
@@ -209,6 +211,27 @@ static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
     return TRUE;
 }
 
+static void CleanupNewlyCreatedWindows(void)
+{
+    EnumWindows(EnumWindowsProc, (LPARAM)&s_wi1);
+    for (UINT i1 = 0; i1 < s_wi1.count; ++i1)
+    {
+        BOOL bFound = FALSE;
+        for (UINT i0 = 0; i0 < s_wi0.count; ++i0)
+        {
+            if (s_wi1.phwnd[i1] == s_wi0.phwnd[i0])
+            {
+                bFound = TRUE;
+                break;
+            }
+        }
+        if (!bFound)
+            PostMessageW(s_wi1.phwnd[i1], WM_CLOSE, 0, 0);
+    }
+    free(s_wi1.phwnd);
+    ZeroMemory(&s_wi1, sizeof(s_wi1));
+}
+
 static VOID DoTestEntry(const TEST_ENTRY *pEntry)
 {
     SHELLEXECUTEINFOA info = { sizeof(info) };
@@ -238,24 +261,7 @@ static VOID DoTestEntry(const TEST_ENTRY *pEntry)
 
     WaitForInputIdle(info.hProcess, INFINITE);
 
-    // close newly opened windows
-    EnumWindows(EnumWindowsProc, (LPARAM)&s_wi1);
-    for (UINT i1 = 0; i1 < s_wi1.count; ++i1)
-    {
-        BOOL bFound = FALSE;
-        for (UINT i0 = 0; i0 < s_wi0.count; ++i0)
-        {
-            if (s_wi1.phwnd[i1] == s_wi0.phwnd[i0])
-            {
-                bFound = TRUE;
-                break;
-            }
-        }
-        if (!bFound)
-            PostMessageW(s_wi1.phwnd[i1], WM_CLOSE, 0, 0);
-    }
-    free(s_wi1.phwnd);
-    ZeroMemory(&s_wi1, sizeof(s_wi1));
+    CleanupNewlyCreatedWindows();
 
     if (WaitForSingleObject(info.hProcess, 10 * 1000) == WAIT_TIMEOUT)
     {


### PR DESCRIPTION
## Purpose

This design, introduced in 418edcd2b, is fundamentally flawed as it
can also close windows unrelated to the running test (e.g. windows
of programs that the user can start, while the test is running).

But since we cannot do much better, mitigate instead the other main
problem of this design: Just use PostMessageW(WM_CLOSE), as it used
to be, instead of TerminateProcess().

Indeed, using TerminateProcess() otherwise could kill unrelated
processes the test hasn't created. In particular it could kill the
csrss.exe system process if, during the testing procedure, a hard-error
popup shows up.
And this is precisely the case when this test runs with limited memory,
and a hard-error
  "Insufficient system resources exist to complete the requested service."
arises.

## Proposed changes

Effectively partly revert commit 418edcd2b.