### PR TITLE
[PCIX] Add 2 OBJ_KERNEL_HANDLE

### DIFF
--- a/drivers/bus/pcix/init.c
+++ b/drivers/bus/pcix/init.c
@@ -733,7 +733,7 @@ DriverEntry(IN PDRIVER_OBJECT DriverObject,
         /* Open the PCI key */
         InitializeObjectAttributes(&ObjectAttributes,
                                    RegistryPath,
-                                   OBJ_CASE_INSENSITIVE,
+                                   OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                    NULL,
                                    NULL);
         Status = ZwOpenKey(&KeyHandle, KEY_QUERY_VALUE, &ObjectAttributes);

--- a/drivers/bus/pcix/utils.c
+++ b/drivers/bus/pcix/utils.c
@@ -177,7 +177,7 @@ PciOpenKey(IN PWCHAR KeyName,
     RtlInitUnicodeString(&KeyString, KeyName);
     InitializeObjectAttributes(&ObjectAttributes,
                                &KeyString,
-                               OBJ_CASE_INSENSITIVE,
+                               OBJ_CASE_INSENSITIVE | OBJ_KERNEL_HANDLE,
                                RootKey,
                                NULL);
 


### PR DESCRIPTION
Match `Zw*()` uses.

JIRA issue: [CORE-10207](https://jira.reactos.org/browse/CORE-10207)