### PR TITLE
[WIN32K:NTUSER] Assign a security descriptor when parsing the desktop

### DIFF
--- a/base/system/winlogon/security.c
+++ b/base/system/winlogon/security.c
@@ -1446,21 +1446,12 @@ AllowAccessOnSession(
         goto Quit;
     }
 
-/*
- * FIXME: Desktop security management is broken. The application desktop gets created
- * with CreateDesktopW() API call with an initial and defined security  descriptor for it yet
- * when we are giving access to the logged in user, SetUserObjectSecurity() API call fails to set
- * new security because the desktop in question has no prior security  descriptor (when it's
- * been assigned even before!!!). This chunk of code must be enabled when this gets fixed.
- */
-#if 0
     /* Allow application desktop access to this user within this session */
     if (!AllowDesktopAccessToUser(Session->ApplicationDesktop, LogonSid))
     {
         ERR("AllowAccessOnSession(): Failed to allow application desktop access to the logon user!\n");
         goto Quit;
     }
-#endif
 
     /* Get the length of this logon SID */
     SidLength = GetLengthSid(LogonSid);

--- a/win32ss/user/ntuser/desktop.c
+++ b/win32ss/user/ntuser/desktop.c
@@ -128,6 +128,14 @@ IntDesktopObjectParse(IN PVOID ParseObject,
                             (PVOID*)&Desktop);
     if (!NT_SUCCESS(Status)) return Status;
 
+    /* Assign security to the desktop we have created */
+    Status = IntAssignDesktopSecurityOnParse(WinStaObject, Desktop, AccessState);
+    if (!NT_SUCCESS(Status))
+    {
+        ObDereferenceObject(Desktop);
+        return Status;
+    }
+
     /* Initialize the desktop */
     Status = UserInitializeDesktop(Desktop, RemainingName, WinStaObject);
     if (!NT_SUCCESS(Status))

--- a/win32ss/user/ntuser/security.h
+++ b/win32ss/user/ntuser/security.h
@@ -86,6 +86,13 @@ IntQueryUserSecurityIdentification(
 
 NTSTATUS
 NTAPI
+IntAssignDesktopSecurityOnParse(
+    _In_ PWINSTATION_OBJECT WinSta,
+    _In_ PDESKTOP Desktop,
+    _In_ PACCESS_STATE AccessState);
+
+NTSTATUS
+NTAPI
 IntCreateServiceSecurity(
     _Out_ PSECURITY_DESCRIPTOR *ServiceSd);
 


### PR DESCRIPTION
The problem ReactOS currently faces is this -- whenever the desktop is being parsed we aren't assigning a security descriptor to it. As a matter of fact when Winlogon tries to assign new security information to the application desktop when a user logs in, Winlogon fails because no prior descriptor has been created for it even though we already do this when initializing security buffers in Winlogon.

With that said, we must assign a descriptor when parsing the desktop as well. This fixes a hack in Winlogon where security assigning of application desktop during a log in is disabled (which we can now enable such code path back).