### PR TITLE
[KBDJA] Enable VK_CONVERT/VK_NONCONVERT keys

### DIFF
--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -102,8 +102,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* One more f-key */
   VK_F24,
   /* - 77 - */
-  VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_EMPTY, VK_EMPTY, VK_OEM_5, VK_EMPTY, /* PA1 */
+  VK_EMPTY, VK_EMPTY, VK_CONVERT, VK_EMPTY,
+  VK_NONCONVERT, VK_EMPTY, VK_OEM_5, VK_EMPTY, /* PA1 */
   VK_EMPTY,
   /* - 80 - */
   0


### PR DESCRIPTION
## Purpose

The ReactOS Japanese keyboard could not use `VK_CONVERT`/`VK_NONCONVERT` keys. This PR will enable these two keys.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

![keyboard](https://user-images.githubusercontent.com/2107452/167987129-23db9a15-b1cb-4bd7-9e94-08bbf21b3431.png)

## Proposed changes

- ScanCode 121 (`0x79`) --> `VK_CONVERT`.
- ScanCode 123 (`0x7B`) --> `VK_NONCONVERT`.