### PR TITLE
[ATL] Fix window position to fit in screen area CORE-17089

### DIFF
--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -325,27 +325,27 @@ public:
 
         if (!(::GetWindowLong(hWndCenter, GWL_STYLE) & WS_CHILD))
         {
-            MONITORINFO m_MonInfo;
-            m_MonInfo.cbSize = sizeof(m_MonInfo);
+            MONITORINFO mi;
+            mi.cbSize = sizeof(mi);
             HMONITOR hMonitor = MonitorFromWindow(hWndCenter, MONITOR_DEFAULTTOPRIMARY);
-            GetMonitorInfo(hMonitor, &m_MonInfo);
+            GetMonitorInfo(hMonitor, &mi);
 
-            if (xPos + wndWidth > m_MonInfo.rcWork.right)
+            if (xPos + wndWidth > mi.rcWork.right)
             {
-                xPos = m_MonInfo.rcWork.right - wndWidth;
+                xPos = mi.rcWork.right - wndWidth;
             }
-            else if (xPos < m_MonInfo.rcWork.left)
+            else if (xPos < mi.rcWork.left)
             {
-                xPos = m_MonInfo.rcWork.left;
+                xPos = mi.rcWork.left;
             }
 
-            if (yPos + wndHeight > m_MonInfo.rcWork.bottom)
+            if (yPos + wndHeight > mi.rcWork.bottom)
             {
-                yPos = m_MonInfo.rcWork.bottom - wndHeight;
+                yPos = mi.rcWork.bottom - wndHeight;
             }
-            if (yPos < m_MonInfo.rcWork.top)
+            if (yPos < mi.rcWork.top)
             {
-                yPos = m_MonInfo.rcWork.top;
+                yPos = mi.rcWork.top;
             }
         }
         return ::MoveWindow(m_hWnd,

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -320,9 +320,32 @@ public:
         int wndCenterHeight = wndCenterRect.bottom - wndCenterRect.top;
         int wndWidth = wndRect.right - wndRect.left;
         int wndHeight = wndRect.bottom - wndRect.top;
+        int xPos = wndCenterRect.left + ((wndCenterWidth - wndWidth + 1) >> 1);
+        int yPos = wndCenterRect.top + ((wndCenterHeight - wndHeight + 1) >> 1);
+        RECT rcWork;
+        SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
+
+        if (xPos + wndWidth > rcWork.right)
+        {
+            xPos = rcWork.right - wndWidth;
+        }
+        else if (xPos < 0)
+        {
+            xPos = 0;
+        }
+
+        if (yPos + wndHeight > rcWork.bottom)
+        {
+            yPos = rcWork.bottom - wndHeight;
+        }
+        else if (yPos < 0)
+        {
+            yPos = 0;
+        }
+        
         return ::MoveWindow(m_hWnd,
-                            wndCenterRect.left + ((wndCenterWidth - wndWidth + 1) >> 1),
-                            wndCenterRect.top + ((wndCenterHeight - wndHeight + 1) >> 1),
+                            xPos,
+                            yPos,
                             wndWidth, wndHeight, TRUE);
     }
 

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -322,27 +322,32 @@ public:
         int wndHeight = wndRect.bottom - wndRect.top;
         int xPos = wndCenterRect.left + ((wndCenterWidth - wndWidth + 1) >> 1);
         int yPos = wndCenterRect.top + ((wndCenterHeight - wndHeight + 1) >> 1);
-        RECT rcWork;
-        SystemParametersInfo(SPI_GETWORKAREA, 0, &rcWork, 0);
 
-        if (xPos + wndWidth > rcWork.right)
+        if (!(::GetWindowLong(hWndCenter, GWL_STYLE) & WS_CHILD))
         {
-            xPos = rcWork.right - wndWidth;
-        }
-        else if (xPos < 0)
-        {
-            xPos = 0;
-        }
+            MONITORINFO m_MonInfo;
+            m_MonInfo.cbSize = sizeof(MONITORINFO);
+            HMONITOR hMonitor = MonitorFromWindow(hWndCenter, MONITOR_DEFAULTTOPRIMARY);
+            GetMonitorInfo(hMonitor, &m_MonInfo);
 
-        if (yPos + wndHeight > rcWork.bottom)
-        {
-            yPos = rcWork.bottom - wndHeight;
+            if (xPos + wndWidth > m_MonInfo.rcWork.right)
+            {
+                xPos = m_MonInfo.rcWork.right - wndWidth;
+            }
+            else if (xPos < m_MonInfo.rcWork.left)
+            {
+                xPos = m_MonInfo.rcWork.left;
+            }
+
+            if (yPos + wndHeight > m_MonInfo.rcWork.bottom)
+            {
+                yPos = m_MonInfo.rcWork.bottom - wndHeight;
+            }
+            if (yPos < m_MonInfo.rcWork.top)
+            {
+                yPos = m_MonInfo.rcWork.top;
+            }
         }
-        else if (yPos < 0)
-        {
-            yPos = 0;
-        }
-        
         return ::MoveWindow(m_hWnd,
                             xPos,
                             yPos,

--- a/sdk/lib/atl/atlwin.h
+++ b/sdk/lib/atl/atlwin.h
@@ -326,7 +326,7 @@ public:
         if (!(::GetWindowLong(hWndCenter, GWL_STYLE) & WS_CHILD))
         {
             MONITORINFO m_MonInfo;
-            m_MonInfo.cbSize = sizeof(MONITORINFO);
+            m_MonInfo.cbSize = sizeof(m_MonInfo);
             HMONITOR hMonitor = MonitorFromWindow(hWndCenter, MONITOR_DEFAULTTOPRIMARY);
             GetMonitorInfo(hMonitor, &m_MonInfo);
 


### PR DESCRIPTION
By right-click on a Desktop icon, "Properties" menu, "Compatibility" tab and the "Edit compatibility modes" button, this opens a window centered on the parent window.
If we moved the parent window to one of the sides, (left or right) and then click on the "Edit modes" button, this window will appear cut off because it exceeds the width of the screen.

[ CORE-17089](https://jira.reactos.org/browse/CORE-17089)

Expected behavior:

The window should be completely visible

