### PR TITLE
[NTOS:MM] Fix memory leak in MiMapViewOfDataSection

### DIFF
--- a/ntoskrnl/mm/ARM3/section.c
+++ b/ntoskrnl/mm/ARM3/section.c
@@ -1494,6 +1494,11 @@ MiMapViewOfDataSection(IN PCONTROL_AREA ControlArea,
     if (!NT_SUCCESS(Status))
     {
         ExFreePoolWithTag(Vad, 'ldaV');
+        MiDereferenceControlArea(ControlArea);
+
+        KeAcquireGuardedMutex(&MmSectionCommitMutex);
+        Segment->NumberOfCommittedPages -= QuotaCharge;
+        KeReleaseGuardedMutex(&MmSectionCommitMutex);
         return Status;
     }
 
@@ -1506,6 +1511,13 @@ MiMapViewOfDataSection(IN PCONTROL_AREA ControlArea,
                            AllocationType);
     if (!NT_SUCCESS(Status))
     {
+        ExFreePoolWithTag(Vad, 'ldaV');
+        MiDereferenceControlArea(ControlArea);
+
+        KeAcquireGuardedMutex(&MmSectionCommitMutex);
+        Segment->NumberOfCommittedPages -= QuotaCharge;
+        KeReleaseGuardedMutex(&MmSectionCommitMutex);
+
         PsReturnProcessNonPagedPoolQuota(PsGetCurrentProcess(), sizeof(MMVAD_LONG));
         return Status;
     }


### PR DESCRIPTION
## Purpose

If inserting the allocated VAD fails, MiMapViewOfDataSection will make no attempt to free the allocated VAD.
This PR should fix the leaking of memory in such situations.
