### PR TITLE
[KBDJA][NTUSER] Improve scancode_to_vk data

### DIFF
--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -59,8 +59,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* Bottom Row */
   VK_MULTIPLY | KBDMULTIVK,
                 VK_LMENU,     VK_SPACE,
-                                            /* FIXME: This value should be (VK_OEM_ATTN | KBDSPECIAL).
-                                                      Please fix the caps state in special handling. */
+                                            /* FIXME: This should be (VK_OEM_ATTN | KBDSPECIAL).
+                                                      Please fix the caps in special handling. */
                                             VK_CAPITAL | KBDSPECIAL,
 
   /* - 3b - */

--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -58,7 +58,7 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 37 - */
   /* Bottom Row */
   VK_MULTIPLY | KBDMULTIVK,
-                VK_LMENU,     VK_SPACE,     VK_OEM_ATTN | KBDSPECIAL,
+                VK_LMENU,     VK_SPACE,     VK_CAPITAL | KBDSPECIAL,
 
   /* - 3b - */
   /* F-Keys */

--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -58,7 +58,10 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 37 - */
   /* Bottom Row */
   VK_MULTIPLY | KBDMULTIVK,
-                VK_LMENU,     VK_SPACE,     VK_CAPITAL | KBDSPECIAL,
+                VK_LMENU,     VK_SPACE,
+                                            /* FIXME: This value should be (VK_OEM_ATTN | KBDSPECIAL).
+                                                      Please fix the caps state in special handling. */
+                                            VK_CAPITAL | KBDSPECIAL,
 
   /* - 3b - */
   /* F-Keys */

--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -48,16 +48,17 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_LCONTROL,
   'A',          'S',          'D',          'F',
   'G',          'H',          'J',          'K',
-  'L',          VK_OEM_PLUS,  VK_OEM_1,     VK_PROCESSKEY,
+  'L',          VK_OEM_PLUS,  VK_OEM_1,     VK_KANJI | KBDSPECIAL,
   VK_LSHIFT,    VK_OEM_6,
   /* - 2c - */
   /* Third letters row */
   'Z',          'X',          'C',          'V',
   'B',          'N',          'M',          VK_OEM_COMMA,
-  VK_OEM_PERIOD,VK_OEM_2, VK_RSHIFT,
+  VK_OEM_PERIOD,VK_OEM_2,     VK_RSHIFT | KBDEXT,
   /* - 37 - */
   /* Bottom Row */
-  VK_MULTIPLY,  VK_LMENU,     VK_SPACE,     VK_CAPITAL,
+  VK_MULTIPLY | KBDMULTIVK,
+                VK_LMENU,     VK_SPACE,     VK_OEM_ATTN | KBDSPECIAL,
 
   /* - 3b - */
   /* F-Keys */
@@ -88,16 +89,15 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F13, VK_F14, VK_F15, VK_F16, VK_F17, VK_F18, VK_F19, VK_F20,
   VK_F21, VK_F22, VK_F23,
   /* - 6f - */
-  /* Not sure who uses these codes */
-  VK_EMPTY, VK_EMPTY, VK_EMPTY,
+  VK_EMPTY, VK_OEM_COPY | KBDSPECIAL, VK_EMPTY,
   /* - 72 - */
   VK_EMPTY, VK_OEM_102, VK_EMPTY, VK_EMPTY,
   /* - 76 - */
   /* One more f-key */
   VK_F24,
   /* - 77 - */
-  VK_EMPTY, VK_EMPTY, VK_CONVERT, VK_EMPTY,
-  VK_NONCONVERT, VK_EMPTY, VK_OEM_5, VK_EMPTY, /* PA1 */
+  VK_EMPTY, VK_EMPTY, VK_CONVERT | KBDSPECIAL, VK_EMPTY,
+  VK_NONCONVERT | KBDSPECIAL, VK_EMPTY, VK_OEM_5, VK_EMPTY, /* PA1 */
   VK_EMPTY,
   /* - 80 - */
   0
@@ -205,7 +205,7 @@ ROSDATA VK_TO_WCHARS2 key_to_chars_2mod[] = {
   { '7',         0, {'7', '\''} },
   { '8',         0, {'8', '('} },
   { '9',         0, {'9', ')'} },
-  { '0',         0, {'0',  0 } },
+  { '0',         0, {'0', WCH_NONE} },
 
   /*Japanese Keys*/
   { VK_OEM_7,     0, { '^','~'} },

--- a/dll/keyboard/kbdja/kbdja.c
+++ b/dll/keyboard/kbdja/kbdja.c
@@ -58,10 +58,7 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 37 - */
   /* Bottom Row */
   VK_MULTIPLY | KBDMULTIVK,
-                VK_LMENU,     VK_SPACE,
-                                            /* FIXME: This should be (VK_OEM_ATTN | KBDSPECIAL).
-                                                      Please fix the caps in special handling. */
-                                            VK_CAPITAL | KBDSPECIAL,
+                VK_LMENU,     VK_SPACE,     VK_OEM_ATTN | KBDSPECIAL,
 
   /* - 3b - */
   /* F-Keys */

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -812,12 +812,16 @@ ProcessKeyEvent(WORD wVk, WORD wScanCode, DWORD dwFlags, BOOL bInjected, DWORD d
     /* Get virtual key without shifts (VK_(L|R)* -> VK_*) */
     wSimpleVk = IntSimplifyVk(wVk);
 
-    if (wSimpleVk == VK_OEM_ATTN &&
-        PRIMARYLANGID(gusLanguageID) == LANG_JAPANESE &&
-        IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
+    if (PRIMARYLANGID(gusLanguageID) == LANG_JAPANESE)
     {
         /* Japanese special! */
-        wSimpleVk = VK_CAPITAL;
+        if (IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
+        {
+            if (wSimpleVk == VK_OEM_ATTN)
+                wSimpleVk = VK_CAPITAL;
+            else if (wSimpleVk == VK_OEM_COPY)
+                wSimpleVk = VK_OEM_FINISH;
+        }
     }
 
     bWasSimpleDown = IS_KEY_DOWN(gafAsyncKeyState, wSimpleVk);

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -811,6 +811,15 @@ ProcessKeyEvent(WORD wVk, WORD wScanCode, DWORD dwFlags, BOOL bInjected, DWORD d
 
     /* Get virtual key without shifts (VK_(L|R)* -> VK_*) */
     wSimpleVk = IntSimplifyVk(wVk);
+
+    if (wSimpleVk == VK_OEM_ATTN &&
+        PRIMARYLANGID(gusLanguageID) == LANG_JAPANESE &&
+        IS_KEY_DOWN(gafAsyncKeyState, VK_SHIFT))
+    {
+        /* Japanese special! */
+        wSimpleVk = VK_CAPITAL;
+    }
+
     bWasSimpleDown = IS_KEY_DOWN(gafAsyncKeyState, wSimpleVk);
 
     /* Update key without shifts */


### PR DESCRIPTION
## Purpose
Improve Japanese keyboard.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Fix `scancode_to_vk` variable.
- Add special handling to `win32k!ProcessKeyEvent` function for Japanese.