### PR TITLE
[NTOS:IO] Create enum keys for legacy device drivers

### DIFF
--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1143,6 +1143,11 @@ IopCreateLegacyDriverNode(
     _In_ HANDLE ServiceHandle
 );
 
+VOID
+IopDeleteLegacyDriverNode(
+    _In_ PCUNICODE_STRING ServiceName
+);
+
 //
 // File Routines
 //

--- a/ntoskrnl/include/internal/io.h
+++ b/ntoskrnl/include/internal/io.h
@@ -1137,6 +1137,12 @@ IopReinitializeBootDrivers(
     VOID
 );
 
+NTSTATUS
+IopCreateLegacyDriverNode(
+    _In_ PCUNICODE_STRING ServiceName,
+    _In_ HANDLE ServiceHandle
+);
+
 //
 // File Routines
 //


### PR DESCRIPTION
## Purpose

For each legacy device driver an enum key will be created under
HKLM\System\CCS\Enum\Root\LEGACY_<ServiceName>.

JIRA issue: [CORE-17532](https://jira.reactos.org/browse/CORE-17532)
