### PR TITLE
[NTOS:SE] Add extra sanitization and fix some bugs in token filtering.

### DIFF
--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -4518,7 +4518,7 @@ NtSetInformationToken(
                     {
                         PACL CapturedAcl;
 
-                        /* Capture and copy the dacl */
+                        /* Capture, validate, and copy the DACL */
                         Status = SepCaptureAcl(InputAcl,
                                                PreviousMode,
                                                PagedPool,

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -1047,8 +1047,7 @@ SepDuplicateToken(
     }
 
     /* Copy the immutable fields */
-    RtlCopyLuid(&AccessToken->TokenSource.SourceIdentifier,
-                &Token->TokenSource.SourceIdentifier);
+    AccessToken->TokenSource.SourceIdentifier = Token->TokenSource.SourceIdentifier;
     RtlCopyMemory(AccessToken->TokenSource.SourceName,
                   Token->TokenSource.SourceName,
                   sizeof(Token->TokenSource.SourceName));
@@ -1062,7 +1061,7 @@ SepDuplicateToken(
     SepAcquireTokenLockShared(Token);
 
     AccessToken->SessionId = Token->SessionId;
-    RtlCopyLuid(&AccessToken->ModifiedId, &Token->ModifiedId);
+    AccessToken->ModifiedId = Token->ModifiedId;
 
     AccessToken->TokenFlags = Token->TokenFlags & ~TOKEN_SESSION_NOT_REFERENCED;
 
@@ -1097,7 +1096,7 @@ SepDuplicateToken(
     AccessToken->CreateMethod = TOKEN_DUPLICATE_METHOD;
 #endif
 
-    /* Assign the data that reside in the TOKEN's variable information area */
+    /* Assign the data that reside in the token's variable information area */
     AccessToken->VariableLength = VariableLength;
     EndMem = (PVOID)&AccessToken->VariablePart;
 
@@ -1264,7 +1263,7 @@ SepDuplicateToken(
     // other data, the code will require adaptations.
     //
 
-    /* Now allocate the TOKEN's dynamic information area and set the data */
+    /* Now allocate the token's dynamic information area and set the data */
     AccessToken->DynamicAvailable = 0; // Unused memory in the dynamic area.
     AccessToken->DynamicPart = NULL;
     if (Token->DynamicPart && Token->DefaultDacl)
@@ -1810,8 +1809,7 @@ SepCreateToken(
     /* Zero out the buffer and initialize the token */
     RtlZeroMemory(AccessToken, TotalSize);
 
-    RtlCopyLuid(&AccessToken->TokenId, &TokenId);
-
+    AccessToken->TokenId = TokenId;
     AccessToken->TokenType = TokenType;
     AccessToken->ImpersonationLevel = ImpersonationLevel;
 
@@ -1820,19 +1818,18 @@ SepCreateToken(
     if (!NT_SUCCESS(Status))
         goto Quit;
 
-    RtlCopyLuid(&AccessToken->TokenSource.SourceIdentifier,
-                &TokenSource->SourceIdentifier);
+    AccessToken->TokenSource.SourceIdentifier = TokenSource->SourceIdentifier;
     RtlCopyMemory(AccessToken->TokenSource.SourceName,
                   TokenSource->SourceName,
                   sizeof(TokenSource->SourceName));
 
     AccessToken->ExpirationTime = *ExpirationTime;
-    RtlCopyLuid(&AccessToken->ModifiedId, &ModifiedId);
+    AccessToken->ModifiedId = ModifiedId;
 
     AccessToken->TokenFlags = TokenFlags & ~TOKEN_SESSION_NOT_REFERENCED;
 
     /* Copy and reference the logon session */
-    RtlCopyLuid(&AccessToken->AuthenticationId, AuthenticationId);
+    AccessToken->AuthenticationId = *AuthenticationId;
     Status = SepRmReferenceLogonSession(&AccessToken->AuthenticationId);
     if (!NT_SUCCESS(Status))
     {
@@ -1878,7 +1875,7 @@ SepCreateToken(
     AccessToken->CreateMethod = TOKEN_CREATE_METHOD;
 #endif
 
-    /* Assign the data that reside in the TOKEN's variable information area */
+    /* Assign the data that reside in the token's variable information area */
     AccessToken->VariableLength = VariableLength;
     EndMem = (PVOID)&AccessToken->VariablePart;
 
@@ -1960,7 +1957,7 @@ SepCreateToken(
     AccessToken->PrimaryGroup = AccessToken->UserAndGroups[PrimaryGroupIndex].Sid;
     AccessToken->DefaultOwnerIndex = DefaultOwnerIndex;
 
-    /* Now allocate the TOKEN's dynamic information area and set the data */
+    /* Now allocate the token's dynamic information area and set the data */
     AccessToken->DynamicAvailable = 0; // Unused memory in the dynamic area.
     AccessToken->DynamicPart = NULL;
     if (DefaultDacl != NULL)
@@ -2181,16 +2178,14 @@ SepPerformTokenFiltering(
     AccessToken->ImpersonationLevel = Token->ImpersonationLevel;
 
     /* Copy the immutable fields */
-    RtlCopyLuid(&AccessToken->TokenSource.SourceIdentifier,
-                &Token->TokenSource.SourceIdentifier);
+    AccessToken->TokenSource.SourceIdentifier = Token->TokenSource.SourceIdentifier;
     RtlCopyMemory(AccessToken->TokenSource.SourceName,
                   Token->TokenSource.SourceName,
                   sizeof(Token->TokenSource.SourceName));
 
-    RtlCopyLuid(&AccessToken->AuthenticationId, &Token->AuthenticationId);
-    RtlCopyLuid(&AccessToken->ParentTokenId, &Token->TokenId);
-    RtlCopyLuid(&AccessToken->OriginatingLogonSession,
-                &Token->OriginatingLogonSession);
+    AccessToken->AuthenticationId = Token->AuthenticationId;
+    AccessToken->ParentTokenId = Token->TokenId;
+    AccessToken->OriginatingLogonSession = Token->OriginatingLogonSession;
 
     AccessToken->ExpirationTime = Token->ExpirationTime;
 
@@ -4100,8 +4095,7 @@ NtQueryInformationToken(
                 {
                     if (TokenInformationLength >= RequiredLength)
                     {
-                        RtlCopyLuid(&to->OriginatingLogonSession,
-                                    &Token->AuthenticationId);
+                        to->OriginatingLogonSession = Token->AuthenticationId;
                     }
                     else
                     {
@@ -5436,9 +5430,7 @@ NtAdjustGroupsToken(
 Quit:
     /* Allocate a new ID for the token as we made changes */
     if (ChangesMade)
-    {
         ExAllocateLocallyUniqueId(&Token->ModifiedId);
-    }
 
     /* Unlock and dereference the token */
     SepReleaseTokenLock(Token);

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -2254,27 +2254,9 @@ SepPerformTokenFiltering(
         EndMem = (PVOID)((ULONG_PTR)EndMem + PrivilegesLength);
         VariableLength -= PrivilegesLength;
 
-        if (PreviousMode != KernelMode)
-        {
-            _SEH2_TRY
-            {
-                RtlCopyMemory(AccessToken->Privileges,
-                              Token->Privileges,
-                              AccessToken->PrivilegeCount * sizeof(LUID_AND_ATTRIBUTES));
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = _SEH2_GetExceptionCode();
-                _SEH2_YIELD(goto Quit);
-            }
-            _SEH2_END;
-        }
-        else
-        {
-            RtlCopyMemory(AccessToken->Privileges,
-                          Token->Privileges,
-                          AccessToken->PrivilegeCount * sizeof(LUID_AND_ATTRIBUTES));
-        }
+        RtlCopyMemory(AccessToken->Privileges,
+                      Token->Privileges,
+                      AccessToken->PrivilegeCount * sizeof(LUID_AND_ATTRIBUTES));
     }
 
     /* Copy the user and groups */
@@ -2287,39 +2269,17 @@ SepPerformTokenFiltering(
         EndMem = &AccessToken->UserAndGroups[AccessToken->UserAndGroupCount];
         VariableLength -= ((ULONG_PTR)EndMem - (ULONG_PTR)AccessToken->UserAndGroups);
 
-        if (PreviousMode != KernelMode)
+        Status = RtlCopySidAndAttributesArray(AccessToken->UserAndGroupCount,
+                                              Token->UserAndGroups,
+                                              VariableLength,
+                                              AccessToken->UserAndGroups,
+                                              EndMem,
+                                              &EndMem,
+                                              &VariableLength);
+        if (!NT_SUCCESS(Status))
         {
-            _SEH2_TRY
-            {
-                Status = RtlCopySidAndAttributesArray(AccessToken->UserAndGroupCount,
-                                                      Token->UserAndGroups,
-                                                      VariableLength,
-                                                      AccessToken->UserAndGroups,
-                                                      EndMem,
-                                                      &EndMem,
-                                                      &VariableLength);
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = _SEH2_GetExceptionCode();
-                _SEH2_YIELD(goto Quit);
-            }
-            _SEH2_END;
-        }
-        else
-        {
-            Status = RtlCopySidAndAttributesArray(AccessToken->UserAndGroupCount,
-                                                  Token->UserAndGroups,
-                                                  VariableLength,
-                                                  AccessToken->UserAndGroups,
-                                                  EndMem,
-                                                  &EndMem,
-                                                  &VariableLength);
-            if (!NT_SUCCESS(Status))
-            {
-                DPRINT1("SepPerformTokenFiltering(): Failed to copy the groups into token (Status 0x%lx)\n", Status);
-                goto Quit;
-            }
+            DPRINT1("SepPerformTokenFiltering(): Failed to copy the groups into token (Status 0x%lx)\n", Status);
+            goto Quit;
         }
     }
 
@@ -2333,39 +2293,17 @@ SepPerformTokenFiltering(
         EndMem = &AccessToken->RestrictedSids[AccessToken->RestrictedSidCount];
         VariableLength -= ((ULONG_PTR)EndMem - (ULONG_PTR)AccessToken->RestrictedSids);
 
-        if (PreviousMode != KernelMode)
+        Status = RtlCopySidAndAttributesArray(AccessToken->RestrictedSidCount,
+                                              Token->RestrictedSids,
+                                              VariableLength,
+                                              AccessToken->RestrictedSids,
+                                              EndMem,
+                                              &EndMem,
+                                              &VariableLength);
+        if (!NT_SUCCESS(Status))
         {
-            _SEH2_TRY
-            {
-                Status = RtlCopySidAndAttributesArray(AccessToken->RestrictedSidCount,
-                                                      Token->RestrictedSids,
-                                                      VariableLength,
-                                                      AccessToken->RestrictedSids,
-                                                      EndMem,
-                                                      &EndMem,
-                                                      &VariableLength);
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = _SEH2_GetExceptionCode();
-                _SEH2_YIELD(goto Quit);
-            }
-            _SEH2_END;
-        }
-        else
-        {
-            Status = RtlCopySidAndAttributesArray(AccessToken->RestrictedSidCount,
-                                                  Token->RestrictedSids,
-                                                  VariableLength,
-                                                  AccessToken->RestrictedSids,
-                                                  EndMem,
-                                                  &EndMem,
-                                                  &VariableLength);
-            if (!NT_SUCCESS(Status))
-            {
-                DPRINT1("SepPerformTokenFiltering(): Failed to copy the restricted SIDs into token (Status 0x%lx)\n", Status);
-                goto Quit;
-            }
+            DPRINT1("SepPerformTokenFiltering(): Failed to copy the restricted SIDs into token (Status 0x%lx)\n", Status);
+            goto Quit;
         }
     }
 
@@ -2614,27 +2552,9 @@ SepPerformTokenFiltering(
         EndMem = (PVOID)((ULONG_PTR)EndMem + RestrictedSidsLength);
         VariableLength -= RestrictedSidsLength;
 
-        if (PreviousMode != KernelMode)
-        {
-            _SEH2_TRY
-            {
-                RtlCopyMemory(AccessToken->RestrictedSids,
-                              RestrictedSidsIntoToken,
-                              AccessToken->RestrictedSidCount * sizeof(SID_AND_ATTRIBUTES));
-            }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                Status = _SEH2_GetExceptionCode();
-                _SEH2_YIELD(goto Quit);
-            }
-            _SEH2_END;
-        }
-        else
-        {
-            RtlCopyMemory(AccessToken->RestrictedSids,
-                          RestrictedSidsIntoToken,
-                          AccessToken->RestrictedSidCount * sizeof(SID_AND_ATTRIBUTES));
-        }
+        RtlCopyMemory(AccessToken->RestrictedSids,
+                      RestrictedSidsIntoToken,
+                      AccessToken->RestrictedSidCount * sizeof(SID_AND_ATTRIBUTES));
 
         /*
          * As we've copied the restricted SIDs into


### PR DESCRIPTION
## Purpose

Noticed by @JohnyTheCarrot while testing Google Chrome installation on ReactOS, where the contents of a `TOKEN`'s `DefaultDacl` gets corrupted.
The problem resides in the `SepPerformTokenFiltering()` helper function, where the `EndMem` pointer is changed to point to the dynamic part, before being used again later on on data that reside instead in the variable part of the token.

Example:
```
kd> ?? Token
struct _TOKEN * 0xe18cb8e0
   +0x000 TokenSource      : _TOKEN_SOURCE
   +0x010 TokenId          : _LUID
   +0x018 AuthenticationId : _LUID
   +0x020 ParentTokenId    : _LUID
   +0x028 ExpirationTime   : _LARGE_INTEGER 0x7fffffff`ffffffff
   +0x030 TokenLock        : 0xb85de878 _ERESOURCE
   +0x038 AuditPolicy      : _SEP_AUDIT_POLICY
   +0x040 ModifiedId       : _LUID
   +0x048 SessionId        : 0
   +0x04c UserAndGroupCount : 9
   +0x050 RestrictedSidCount : 1
   +0x054 PrivilegeCount   : 0
   +0x058 VariableLength   : 0x2b0
   +0x05c DynamicCharged   : 0
   +0x060 DynamicAvailable : 0
   +0x064 DefaultOwnerIndex : 7
   +0x068 UserAndGroups    : 0xe18cba90 _SID_AND_ATTRIBUTES
   +0x06c RestrictedSids   : 0xe18cbd98 _SID_AND_ATTRIBUTES
   +0x070 PrimaryGroup     : 0xe18cbaf4 Void
   +0x074 Privileges       : 0xe18cb9a0 _LUID_AND_ATTRIBUTES
   +0x078 DynamicPart      : 0xe18cbd98  -> 0xe192c4a0
   +0x07c DefaultDacl      : 0xe18cbd98 _ACL
   +0x080 TokenType        : 1 ( TokenPrimary )
   +0x084 ImpersonationLevel : 0 ( SecurityAnonymous )
   +0x088 TokenFlags       : 0x58
   +0x08c TokenInUse       : 0 ''
   +0x090 ProxyData        : (null) 
   +0x094 AuditData        : (null) 
   +0x098 LogonSession     : 0xe18aa2c0 _SEP_LOGON_SESSION_REFERENCES
   +0x09c OriginatingLogonSession : _LUID
   +0x0a4 ImageFileName    : [16]  "chrome.exe"
   +0x0b4 ProcessCid       : 0x00000684 Void
   +0x0b8 ThreadCid        : 0x00000718 Void
   +0x0bc CreateMethod     : 0xf
   +0x0c0 VariablePart     : 0x19
 
<** THE CORRUPTED DefaultDacl **>

kd> ?? Token->DefaultDacl
struct _ACL * 0xe18cbd98
   +0x000 AclRevision      : 0xa0 ''
   +0x001 Sbz1             : 0xc4 ''
   +0x002 AclSize          : 0xe192
   +0x004 AceCount         : 7
   +0x006 Sbz2             : 0
```

(_Side note:_ `SepPerformTokenFiltering()` has other potential problems:
For example, the decreasing of the for-loop indices (e.g. `PrivsInToken--;`)
while such indices are still == 0 are prone to hidden bugs.)

## Proposed changes

Just see the commits.

## Debugging aids

```
bp nt!SepDuplicateToken+0xa42 ".echo AccessToken->DynamicPart; ?? AccessToken->DynamicPart; .echo AccessToken->DefaultDacl; ??AccessToken->DefaultDacl; g;"
bp nt!SepCreateToken+0x7ff ".echo AccessToken->DynamicPart; ?? AccessToken->DynamicPart; .echo AccessToken->DefaultDacl; ??AccessToken->DefaultDacl; g;"
bp nt!SepCaptureAcl+0x1ca
bp nt!SeQueryInformationToken+0x3b3
bp nt!NtQueryInformationToken+0x548
bp nt!NtSetInformationToken+0x664
bp nt!SepPerformTokenFiltering+0xb79 ".echo AccessToken->DynamicPart; ?? AccessToken->DynamicPart; .echo AccessToken->DefaultDacl; ??AccessToken->DefaultDacl; g;"
bp nt!NtFreeVirtualMemory+0x573
```