### PR TITLE
[HALX86] Print the correct size of the BAR in HalpDebugPciDumpBus()

### DIFF
--- a/hal/halx86/include/halp.h
+++ b/hal/halx86/include/halp.h
@@ -516,6 +516,8 @@ CODE_SEG("INIT")
 VOID
 NTAPI
 HalpDebugPciDumpBus(
+    IN PBUS_HANDLER BusHandler,
+    IN PCI_SLOT_NUMBER PciSlot,
     IN ULONG i,
     IN ULONG j,
     IN ULONG k,


### PR DESCRIPTION
## Purpose

BEFORE:
```
00:01.1 IDE interface [0101]: Intel Corporation 82371AB/EB/MB PIIX4 IDE [8086:7111] (rev 01)
        Subsystem: Unknown [0000:0000]
        Flags: bus master, fast devsel, latency 0
        I/O ports at d000 [size=4K]
```
AFTER:
```
00:01.1 IDE interface [0101]: Intel Corporation 82371AB/EB/MB PIIX4 IDE [8086:7111] (rev 01)
        Subsystem: Unknown [0000:0000]
        Flags: bus master, fast devsel, latency 0
        I/O ports at d000 [size=16]
```
Note: 64-bit BARs are not supported yet.