### PR TITLE
[NTOS:MM] Fix MiInsertSharedUserPageVad preventing boot on x64

### DIFF
--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -901,12 +901,15 @@ MiInsertSharedUserPageVad(
         return Status;
     }
 
-    Status = PsChargeProcessNonPagedPoolQuota(Process, sizeof(MMVAD_LONG));
-    if (!NT_SUCCESS(Status))
+    if (Process->QuotaBlock != NULL)
     {
-        DPRINT1("Ran out of quota.\n");
-        ExFreePoolWithTag(Vad, 'ldaV');
-        return Status;
+        Status = PsChargeProcessNonPagedPoolQuota(Process, sizeof(MMVAD_LONG));
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("Ran out of quota.\n");
+            ExFreePoolWithTag(Vad, 'ldaV');
+            return Status;
+        }
     }
 
 


### PR DESCRIPTION
Fix MiInsertSharedUserPageVad to not charge the system process pool quota.
Even though PsChargeProcessNonPagedPoolQuota itself checks if the process specified is the system process, this doesn't work here as we're too early into boot for the kernel to know what the system process is.