### PR TITLE
[NTOS:MM] Fix memory leak in NtAllocateVirtualMemory

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -4787,6 +4787,7 @@ NtAllocateVirtualMemory(IN HANDLE ProcessHandle,
         if (!NT_SUCCESS(Status))
         {
             DPRINT1("Failed to insert the VAD!\n");
+            ExFreePoolWithTag(Vad, 'SdaV');
             goto FailPathNoLock;
         }
 


### PR DESCRIPTION
When an allocated VAD's insertion fails, the VAD is not freed. This commit attempts to fix this behaviour.