### PR TITLE
[CRT] Implement mmintrin.h and xmmintrin.h

### DIFF
--- a/sdk/include/crt/_mingw.h
+++ b/sdk/include/crt/_mingw.h
@@ -244,6 +244,18 @@ allow GCC to optimize away some EH unwind code, at least in DW2 case.  */
 #endif
 #endif /* DECLSPEC_HOTPATCH */
 
+#ifndef __INTRIN_INLINE
+#  define __INTRIN_INLINE extern __inline__ __attribute__((__always_inline__,__gnu_inline__,artificial))
+#endif
+
+#ifndef HAS_BUILTIN
+#  ifdef __clang__
+#    define HAS_BUILTIN(x) __has_builtin(x)
+#  else
+#    define HAS_BUILTIN(x) 0
+#  endif
+#endif
+
 #ifdef __cplusplus
 #  define __mingw_ovr  inline __cdecl
 #elif defined (__GNUC__)

--- a/sdk/include/crt/mingw32/intrin.h
+++ b/sdk/include/crt/mingw32/intrin.h
@@ -30,23 +30,6 @@
 
 #ifndef RC_INVOKED
 
-#ifndef __INTRIN_INLINE
-#  ifdef __clang__
-#    define __ATTRIBUTE_ARTIFICIAL
-#  else
-#    define __ATTRIBUTE_ARTIFICIAL __attribute__((artificial))
-#  endif
-#  define __INTRIN_INLINE extern __inline__ __attribute__((__always_inline__,__gnu_inline__)) __ATTRIBUTE_ARTIFICIAL
-#endif
-
-#ifndef HAS_BUILTIN
-#  ifdef __clang__
-#    define HAS_BUILTIN(x) __has_builtin(x)
-#  else
-#    define HAS_BUILTIN(x) 0
-#  endif
-#endif
-
 #ifndef _SIZE_T_DEFINED
 #define _SIZE_T_DEFINED
 #ifdef _WIN64

--- a/sdk/include/crt/mingw32/intrin_x86.h
+++ b/sdk/include/crt/mingw32/intrin_x86.h
@@ -111,15 +111,6 @@ __INTRIN_INLINE void _mm_lfence(void)
 }
 #endif
 
-#if !HAS_BUILTIN(_mm_sfence)
-__INTRIN_INLINE void _mm_sfence(void)
-{
-	_WriteBarrier();
-	__asm__ __volatile__("sfence");
-	_WriteBarrier();
-}
-#endif
-
 #if defined(__x86_64__) && !HAS_BUILTIN(__faststorefence)
 __INTRIN_INLINE void __faststorefence(void)
 {

--- a/sdk/include/crt/mmintrin.h
+++ b/sdk/include/crt/mmintrin.h
@@ -1,7 +1,21 @@
-/**
- * This file has no copyright assigned and is placed in the Public Domain.
- * This file is part of the w64 mingw-runtime package.
- * No warranty is given; refer to the file DISCLAIMER within this package.
+/*
+ * mmintrin.h
+ *
+ * This file is part of the ReactOS CRT package.
+ *
+ * Contributors:
+ *   Timo Kreuzer (timo.kreuzer@reactos.org)
+ *
+ * THIS SOFTWARE IS NOT COPYRIGHTED
+ *
+ * This source code is offered for use in the public domain. You may
+ * use, modify or distribute it freely.
+ *
+ * This code is distributed in the hope that it will be useful but
+ * WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
+ * DISCLAIMED. This includes but is not limited to warranties of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  */
 
 #pragma once
@@ -10,6 +24,639 @@
 
 #include <crtdefs.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+#ifdef _MSC_VER
+#define DECLSPEC_INTRINTYPE __declspec(intrin_type)
+#else
+#define DECLSPEC_INTRINTYPE
+#endif
+
+#if defined(_MSC_VER) && !defined(__clang__)
+
+    typedef union DECLSPEC_INTRINTYPE _CRT_ALIGN(8) __m64
+    {
+        unsigned __int64 m64_u64;
+        float m64_f32[2];
+        __int8 m64_i8[8];
+        __int16 m64_i16[4];
+        __int32 m64_i32[2];    
+        __int64 m64_i64;
+        unsigned __int8 m64_u8[8];
+        unsigned __int16 m64_u16[4];
+        unsigned __int32 m64_u32[2];
+    } __m64;
+
+#else /* _MSC_VER */
+
+    typedef long long __v1di __attribute__((__vector_size__(8)));
+    typedef int __v2si __attribute__((__vector_size__(8)));
+    typedef short __v4hi __attribute__((__vector_size__(8)));
+    typedef char __v8qi __attribute__((__vector_size__(8)));
+
+    typedef float __m64 __attribute__((__vector_size__(8), __aligned__(16)));
+
+#ifdef __clang__
+#define __INTRIN_INLINE_MMX __INTRIN_INLINE __attribute__((__target__("mmx"),__min_vector_width__(64)))
+#else
+#define __INTRIN_INLINE_MMX __INTRIN_INLINE __attribute__((__target__("mmx")))
+#endif
+
+#endif /* _MSC_VER */
+
+#ifdef _M_IX86
+
+void  _m_empty(void);
+__m64 _m_from_int(int i);
+int   _m_to_int(__m64 m);
+__m64 _m_packsswb(__m64 a, __m64 b);
+__m64 _m_packssdw(__m64 a, __m64 b);
+__m64 _m_packuswb(__m64 a, __m64 b);
+__m64 _m_punpckhbw(__m64 a, __m64 b);
+__m64 _m_punpckhwd(__m64 a, __m64 b);
+__m64 _m_punpckhdq(__m64 a, __m64 b);
+__m64 _m_punpcklbw(__m64 a, __m64 b);
+__m64 _m_punpcklwd(__m64 a, __m64 b);
+__m64 _m_punpckldq(__m64 a, __m64 b);
+__m64 _m_paddb(__m64 a, __m64 b);
+__m64 _m_paddw(__m64 a, __m64 b);
+__m64 _m_paddd(__m64 a, __m64 b);
+__m64 _m_paddsb(__m64 a, __m64 b);
+__m64 _m_paddsw(__m64 a, __m64 b);
+__m64 _m_paddusb(__m64 a, __m64 b);
+__m64 _m_paddusw(__m64 a, __m64 b);
+__m64 _m_psubb(__m64 a, __m64 b);
+__m64 _m_psubw(__m64 a, __m64 b);
+__m64 _m_psubd(__m64 a, __m64 b);
+__m64 _m_psubsb(__m64 a, __m64 b);
+__m64 _m_psubsw(__m64 a, __m64 b);
+__m64 _m_psubusb(__m64 a, __m64 b);
+__m64 _m_psubusw(__m64 a, __m64 b);
+__m64 _m_pmaddwd(__m64 a, __m64 b);
+__m64 _m_pmulhw(__m64 a, __m64 b);
+__m64 _m_pmullw(__m64 a, __m64 b);
+__m64 _m_psllw(__m64 a, __m64 count);
+__m64 _m_psllwi(__m64 a, int imm8);
+__m64 _m_pslld(__m64 a, __m64 count);
+__m64 _m_pslldi(__m64 a, int imm8);
+__m64 _m_psllq(__m64 a, __m64 count);
+__m64 _m_psllqi(__m64 a, int imm8);
+__m64 _m_psraw(__m64 a, __m64 count);
+__m64 _m_psrawi(__m64 a, int imm8);
+__m64 _m_psrad(__m64 a, __m64 count);
+__m64 _m_psradi(__m64 a, int imm8);
+__m64 _m_psrlw(__m64 a, __m64 count);
+__m64 _m_psrlwi(__m64 a, int imm8);
+__m64 _m_psrld(__m64 a, __m64 count);
+__m64 _m_psrldi(__m64 a, int imm8);
+__m64 _m_psrlq(__m64 a, __m64 count);
+__m64 _m_psrlqi(__m64 a, int imm8);
+__m64 _m_pand(__m64 a, __m64 b);
+__m64 _m_pandn(__m64 a, __m64 b);
+__m64 _m_por(__m64 a, __m64 b);
+__m64 _m_pxor(__m64 a, __m64 b);
+__m64 _m_pcmpeqb(__m64 a, __m64 b);
+__m64 _m_pcmpgtb(__m64 a, __m64 b);
+__m64 _m_pcmpeqw(__m64 a, __m64 b);
+__m64 _m_pcmpgtw(__m64 a, __m64 b);
+__m64 _m_pcmpeqd(__m64 a, __m64 b);
+__m64 _m_pcmpgtd(__m64 a, __m64 b);
+__m64 _mm_setzero_si64(void);
+__m64 _mm_set_pi32(int i1, int i0);
+__m64 _mm_set_pi16(short s3, short s2, short s1, short s0);
+__m64 _mm_set_pi8(char b7, char b6, char b5, char b4,
+                  char b3, char b2, char b1, char b0);
+__m64 _mm_setr_pi32(int i1, int i0);
+__m64 _mm_setr_pi16(short s3, short s2, short s1, short s0);
+__m64 _mm_setr_pi8(char b7, char b6, char b5, char b4,
+                   char b3, char b2, char b1, char b0);
+__m64 _mm_set1_pi32(int i);
+__m64 _mm_set1_pi16(short s);
+__m64 _mm_set1_pi8(char b);
+
+/* Alternate names */
+#define _mm_empty _m_empty
+#define _mm_cvtsi32_si64 _m_from_int
+#define _mm_cvtsi64_si32 _m_to_int
+#define _mm_packs_pi16 _m_packsswb
+#define _mm_packs_pi32 _m_packssdw
+#define _mm_packs_pu16 _m_packuswb
+#define _mm_unpackhi_pi8 _m_punpckhbw
+#define _mm_unpackhi_pi16 _m_punpckhwd
+#define _mm_unpackhi_pi32 _m_punpckhdq
+#define _mm_unpacklo_pi8 _m_punpcklbw
+#define _mm_unpacklo_pi16 _m_punpcklwd
+#define _mm_unpacklo_pi32 _m_punpckldq
+#define _mm_add_pi8 _m_paddb
+#define _mm_add_pi16 _m_paddw
+#define _mm_add_pi32 _m_paddd
+#define _mm_adds_pi8 _m_paddsb
+#define _mm_adds_pi16 _m_paddsw
+#define _mm_adds_pu8 _m_paddusb
+#define _mm_adds_pu16 _m_paddusw
+#define _mm_sub_pi8 _m_psubb
+#define _mm_sub_pi16 _m_psubw
+#define _mm_sub_pi32 _m_psubd
+#define _mm_subs_pi8 _m_psubsb
+#define _mm_subs_pi16 _m_psubsw
+#define _mm_subs_pu8 _m_psubusb
+#define _mm_subs_pu16 _m_psubusw
+#define _mm_madd_pi16 _m_pmaddwd
+#define _mm_mulhi_pi16 _m_pmulhw
+#define _mm_mullo_pi16 _m_pmullw
+#define _mm_sll_pi16 _m_psllw
+#define _mm_slli_pi16 _m_psllwi
+#define _mm_sll_pi32 _m_pslld
+#define _mm_slli_pi32 _m_pslldi
+#define _mm_sll_si64 _m_psllq
+#define _mm_slli_si64 _m_psllqi
+#define _mm_sra_pi16 _m_psraw
+#define _mm_srai_pi16 _m_psrawi
+#define _mm_sra_pi32 _m_psrad
+#define _mm_srai_pi32 _m_psradi
+#define _mm_srl_pi16 _m_psrlw
+#define _mm_srli_pi16 _m_psrlwi
+#define _mm_srl_pi32 _m_psrld
+#define _mm_srli_pi32 _m_psrldi
+#define _mm_srl_si64 _m_psrlq
+#define _mm_srli_si64 _m_psrlqi
+#define _mm_and_si64 _m_pand
+#define _mm_andnot_si64 _m_pandn
+#define _mm_or_si64 _m_por
+#define _mm_xor_si64 _m_pxor
+#define _mm_cmpeq_pi8 _m_pcmpeqb
+#define _mm_cmpgt_pi8 _m_pcmpgtb
+#define _mm_cmpeq_pi16 _m_pcmpeqw
+#define _mm_cmpgt_pi16 _m_pcmpgtw
+#define _mm_cmpeq_pi32 _m_pcmpeqd
+#define _mm_cmpgt_pi32 _m_pcmpgtd
+
+/* Use intrinsics on MSVC */
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma intrinsic(_m_empty)
+#pragma intrinsic(_m_from_int)
+#pragma intrinsic(_m_to_int)
+#pragma intrinsic(_m_packsswb)
+#pragma intrinsic(_m_packssdw)
+#pragma intrinsic(_m_packuswb)
+#pragma intrinsic(_m_punpckhbw)
+#pragma intrinsic(_m_punpckhwd)
+#pragma intrinsic(_m_punpckhdq)
+#pragma intrinsic(_m_punpcklbw)
+#pragma intrinsic(_m_punpcklwd)
+#pragma intrinsic(_m_punpckldq)
+#pragma intrinsic(_m_paddb)
+#pragma intrinsic(_m_paddw)
+#pragma intrinsic(_m_paddd)
+#pragma intrinsic(_m_paddsb)
+#pragma intrinsic(_m_paddsw)
+#pragma intrinsic(_m_paddusb)
+#pragma intrinsic(_m_paddusw)
+#pragma intrinsic(_m_psubb)
+#pragma intrinsic(_m_psubw)
+#pragma intrinsic(_m_psubd)
+#pragma intrinsic(_m_psubsb)
+#pragma intrinsic(_m_psubsw)
+#pragma intrinsic(_m_psubusb)
+#pragma intrinsic(_m_psubusw)
+#pragma intrinsic(_m_pmaddwd)
+#pragma intrinsic(_m_pmulhw)
+#pragma intrinsic(_m_pmullw)
+#pragma intrinsic(_m_psllw)
+#pragma intrinsic(_m_psllwi)
+#pragma intrinsic(_m_pslld)
+#pragma intrinsic(_m_pslldi)
+#pragma intrinsic(_m_psllq)
+#pragma intrinsic(_m_psllqi)
+#pragma intrinsic(_m_psraw)
+#pragma intrinsic(_m_psrawi)
+#pragma intrinsic(_m_psrad)
+#pragma intrinsic(_m_psradi)
+#pragma intrinsic(_m_psrlw)
+#pragma intrinsic(_m_psrlwi)
+#pragma intrinsic(_m_psrld)
+#pragma intrinsic(_m_psrldi)
+#pragma intrinsic(_m_psrlq)
+#pragma intrinsic(_m_psrlqi)
+#pragma intrinsic(_m_pand)
+#pragma intrinsic(_m_pandn)
+#pragma intrinsic(_m_por)
+#pragma intrinsic(_m_pxor)
+#pragma intrinsic(_m_pcmpeqb)
+#pragma intrinsic(_m_pcmpgtb)
+#pragma intrinsic(_m_pcmpeqw)
+#pragma intrinsic(_m_pcmpgtw)
+#pragma intrinsic(_m_pcmpeqd)
+#pragma intrinsic(_m_pcmpgtd)
+#pragma intrinsic(_mm_setzero_si64)
+#pragma intrinsic(_mm_set_pi32)
+#pragma intrinsic(_mm_set_pi16)
+#pragma intrinsic(_mm_set_pi8)
+#pragma intrinsic(_mm_setr_pi32)
+#pragma intrinsic(_mm_setr_pi16)
+#pragma intrinsic(_mm_setr_pi8)
+#pragma intrinsic(_mm_set1_pi32)
+#pragma intrinsic(_mm_set1_pi16)
+#pragma intrinsic(_mm_set1_pi8)
+
+/* Use inline functions on GCC/Clang */
+#else // GCC / Clang  Clang-CL
+
+/*
+- GCC: https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/mmintrin.h
+- Clang: https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/mmintrin.h
+*/
+
+// _m_empty
+__INTRIN_INLINE_MMX void _mm_empty(void)
+{
+    __builtin_ia32_emms();
+}
+
+// _m_from_int
+__INTRIN_INLINE_MMX __m64 _mm_cvtsi32_si64(int i)
+{
+    return (__m64)__builtin_ia32_vec_init_v2si(i, 0);
+}
+
+// _m_to_int
+__INTRIN_INLINE_MMX int _mm_cvtsi64_si32(__m64 m)
+{
+    return __builtin_ia32_vec_ext_v2si((__v2si)m, 0);
+}
+
+// _m_packsswb
+__INTRIN_INLINE_MMX __m64 _mm_packs_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_packsswb((__v4hi)a, (__v4hi)b);
+}
+
+// _m_packssdw
+__INTRIN_INLINE_MMX __m64 _mm_packs_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_packssdw((__v2si)a, (__v2si)b);
+}
+
+// _m_packuswb
+__INTRIN_INLINE_MMX __m64 _mm_packs_pu16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_packuswb((__v4hi)a, (__v4hi)b);
+}
+
+// _m_punpckhbw
+__INTRIN_INLINE_MMX __m64 _mm_unpackhi_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpckhbw((__v8qi)a, (__v8qi)b);
+}
+
+// _m_punpckhwd
+__INTRIN_INLINE_MMX __m64 _mm_unpackhi_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpckhwd((__v4hi)a, (__v4hi)b);
+}
+
+// _m_punpckhdq
+__INTRIN_INLINE_MMX __m64 _mm_unpackhi_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpckhdq((__v2si)a, (__v2si)b);
+}
+
+// _m_punpcklbw
+__INTRIN_INLINE_MMX __m64 _mm_unpacklo_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpcklbw((__v8qi)a, (__v8qi)b);
+}
+
+// _m_punpcklwd
+__INTRIN_INLINE_MMX __m64 _mm_unpacklo_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpcklwd((__v4hi)a, (__v4hi)b);
+}
+
+// _m_punpckldq
+__INTRIN_INLINE_MMX __m64 _mm_unpacklo_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_punpckldq((__v2si)a, (__v2si)b);
+}
+
+// _m_paddb
+__INTRIN_INLINE_MMX __m64 _mm_add_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_paddw
+__INTRIN_INLINE_MMX __m64 _mm_add_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_paddd
+__INTRIN_INLINE_MMX __m64 _mm_add_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddd((__v2si)a, (__v2si)b);
+}
+
+// _m_paddsb
+__INTRIN_INLINE_MMX __m64 _mm_adds_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddsb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_paddsw
+__INTRIN_INLINE_MMX __m64 _mm_adds_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddsw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_paddusb
+__INTRIN_INLINE_MMX __m64 _mm_adds_pu8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddusb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_paddusw
+__INTRIN_INLINE_MMX __m64 _mm_adds_pu16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_paddusw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_psubb
+__INTRIN_INLINE_MMX __m64 _mm_sub_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_psubw
+__INTRIN_INLINE_MMX __m64 _mm_sub_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_psubd
+__INTRIN_INLINE_MMX __m64 _mm_sub_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubd((__v2si)a, (__v2si)b);
+}
+
+// _m_psubsb
+__INTRIN_INLINE_MMX __m64 _mm_subs_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubsb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_psubsw
+__INTRIN_INLINE_MMX __m64 _mm_subs_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubsw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_psubusb
+__INTRIN_INLINE_MMX __m64 _mm_subs_pu8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubusb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_psubusw
+__INTRIN_INLINE_MMX __m64 _mm_subs_pu16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_psubusw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_pmaddwd
+__INTRIN_INLINE_MMX __m64 _mm_madd_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pmaddwd((__v4hi)a, (__v4hi)b);
+}
+
+// _m_pmulhw
+__INTRIN_INLINE_MMX __m64 _mm_mulhi_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pmulhw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_pmullw
+__INTRIN_INLINE_MMX __m64 _mm_mullo_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pmullw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_psllw
+__INTRIN_INLINE_MMX __m64 _mm_sll_pi16(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psllw((__v4hi)a, (__v4hi)count);
+}
+
+// _m_psllwi
+__INTRIN_INLINE_MMX __m64 _mm_slli_pi16(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psllwi((__v4hi)a, imm8);
+}
+
+// _m_pslld
+__INTRIN_INLINE_MMX __m64 _mm_sll_pi32(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_pslld((__v2si)a, (__v2si)count);
+}
+
+// _m_pslldi
+__INTRIN_INLINE_MMX __m64 _mm_slli_pi32(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_pslldi((__v2si)a, imm8);
+}
+
+// _m_psllq
+__INTRIN_INLINE_MMX __m64 _mm_sll_si64(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psllq((__v1di)a, (__v1di)count);
+}
+
+// _m_psllqi
+__INTRIN_INLINE_MMX __m64 _mm_slli_si64(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psllqi((__v1di)a, imm8);
+}
+
+// _m_psraw
+__INTRIN_INLINE_MMX __m64 _mm_sra_pi16(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psraw((__v4hi)a, (__v4hi)count);
+}
+
+// _m_psrawi
+__INTRIN_INLINE_MMX __m64 _mm_srai_pi16(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psrawi((__v4hi)a, imm8);
+}
+
+// _m_psrad
+__INTRIN_INLINE_MMX __m64 _mm_sra_pi32(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psrad((__v2si)a, (__v2si)count);
+}
+
+// _m_psradi
+__INTRIN_INLINE_MMX __m64 _mm_srai_pi32(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psradi((__v2si)a, imm8);
+}
+
+// _m_psrlw
+__INTRIN_INLINE_MMX __m64 _mm_srl_pi16(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psrlw((__v4hi)a, (__v4hi)count);
+}
+
+// _m_psrlwi
+__INTRIN_INLINE_MMX __m64 _mm_srli_pi16(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psrlwi((__v4hi)a, imm8);
+}
+
+// _m_psrld
+__INTRIN_INLINE_MMX __m64 _mm_srl_pi32(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psrld((__v2si)a, (__v2si)count);
+}
+
+// _m_psrldi
+__INTRIN_INLINE_MMX __m64 _mm_srli_pi32(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psrldi((__v2si)a, imm8);
+}
+
+// _m_psrlq
+__INTRIN_INLINE_MMX __m64 _mm_srl_si64(__m64 a, __m64 count)
+{
+    return (__m64)__builtin_ia32_psrlq((__v1di)a, (__v1di)count);
+}
+
+// _m_psrlqi
+__INTRIN_INLINE_MMX __m64 _mm_srli_si64(__m64 a, int imm8)
+{
+    return (__m64)__builtin_ia32_psrlqi((__v1di)a, imm8);
+}
+
+// _m_pand
+__INTRIN_INLINE_MMX __m64 _mm_and_si64(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pand((__v2si)a, (__v2si)b);
+}
+
+// _m_pandn
+__INTRIN_INLINE_MMX __m64 _mm_andnot_si64(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pandn((__v2si)a, (__v2si)b);
+}
+
+// _m_por
+__INTRIN_INLINE_MMX __m64 _mm_or_si64(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_por((__v2si)a, (__v2si)b);
+}
+
+// _m_pxor
+__INTRIN_INLINE_MMX __m64 _mm_xor_si64(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pxor((__v2si)a, (__v2si)b);
+}
+
+// _m_pcmpeqb
+__INTRIN_INLINE_MMX __m64 _mm_cmpeq_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpeqb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_pcmpgtb
+__INTRIN_INLINE_MMX __m64 _mm_cmpgt_pi8(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpgtb((__v8qi)a, (__v8qi)b);
+}
+
+// _m_pcmpeqw
+__INTRIN_INLINE_MMX __m64 _mm_cmpeq_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpeqw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_pcmpgtw
+__INTRIN_INLINE_MMX __m64 _mm_cmpgt_pi16(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpgtw((__v4hi)a, (__v4hi)b);
+}
+
+// _m_pcmpeqd
+__INTRIN_INLINE_MMX __m64 _mm_cmpeq_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpeqd((__v2si)a, (__v2si)b);
+}
+
+// _m_pcmpgtd
+__INTRIN_INLINE_MMX __m64 _mm_cmpgt_pi32(__m64 a, __m64 b)
+{
+    return (__m64)__builtin_ia32_pcmpgtd((__v2si)a, (__v2si)b);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_setzero_si64(void)
+{
+    return (__m64) { 0 };
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set_pi32(int i1, int i0)
+{
+    return (__m64)__builtin_ia32_vec_init_v2si(i0, i1);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set_pi16(short s3, short s2, short s1, short s0)
+{
+    return (__m64)__builtin_ia32_vec_init_v4hi(s0, s1, s2, s3);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set_pi8(char b7, char b6, char b5, char b4,
+                                  char b3, char b2, char b1, char b0)
+{
+    return (__m64)__builtin_ia32_vec_init_v8qi(b0, b1, b2, b3, b4, b5, b6, b7);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_setr_pi32(int i1, int i0)
+{
+    return _mm_set_pi32(i0, i1);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_setr_pi16(short s3, short s2, short s1, short s0)
+{
+    return _mm_set_pi16(s0, s1, s2, s3);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_setr_pi8(char b7, char b6, char b5, char b4,
+                                   char b3, char b2, char b1, char b0)
+{
+    return _mm_set_pi8(b7, b6, b5, b4, b3, b2, b1, b0);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set1_pi32(int i)
+{
+    return _mm_set_pi32(i, i);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set1_pi16(short s)
+{
+    return _mm_set_pi16(s, s, s, s);
+}
+
+__INTRIN_INLINE_MMX __m64 _mm_set1_pi8(char b)
+{
+    return _mm_set_pi8(b, b, b, b, b, b, b, b);
+}
+
+#endif /* __GNUC__ */
+
+#endif /* _M_IX86 */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _MMINTRIN_H_INCLUDED */

--- a/sdk/include/crt/xmmintrin.h
+++ b/sdk/include/crt/xmmintrin.h
@@ -1,25 +1,42 @@
-/**
- * This file has no copyright assigned and is placed in the Public Domain.
- * This file is part of the w64 mingw-runtime package.
- * No warranty is given; refer to the file DISCLAIMER within this package.
+/*
+ * xmmintrin.h
+ *
+ * This file is part of the ReactOS CRT package.
+ *
+ * Contributors:
+ *   Timo Kreuzer (timo.kreuzer@reactos.org)
+ *
+ * THIS SOFTWARE IS NOT COPYRIGHTED
+ *
+ * This source code is offered for use in the public domain. You may
+ * use, modify or distribute it freely.
+ *
+ * This code is distributed in the hope that it will be useful but
+ * WITHOUT ANY WARRANTY. ALL WARRANTIES, EXPRESS OR IMPLIED ARE HEREBY
+ * DISCLAIMED. This includes but is not limited to warranties of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
  */
 
 #pragma once
 #ifndef _INCLUDED_MM2
 #define _INCLUDED_MM2
 
-#include <crtdefs.h>
 #include <mmintrin.h>
 
-#ifdef __clang__
+#if defined(_MM2_FUNCTIONALITY) && !defined(_MM_FUNCTIONALITY)
+#define _MM_FUNCTIONALITY
+#endif
 
-typedef        float __v4sf __attribute__((__vector_size__(16)));
-typedef   signed int __v4si __attribute__((__vector_size__(16)));
-typedef unsigned int __v4su __attribute__((__vector_size__(16)));
+#if !defined _VCRT_BUILD && !defined _INC_MALLOC
+//#include <malloc.h> // FIXME: This breaks build
+#endif
 
-typedef        float __m128 __attribute__((__vector_size__(16), __aligned__(16)));
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-#else /* __clang__ */
+#if defined(_MSC_VER) && !defined(__clang__)
 
 typedef union _DECLSPEC_INTRIN_TYPE _CRT_ALIGN(16) __m128
 {
@@ -34,96 +51,1194 @@ typedef union _DECLSPEC_INTRIN_TYPE _CRT_ALIGN(16) __m128
     unsigned __int32 m128_u32[4];
 } __m128;
 
-#endif /* __clang__ */
-
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-extern __m128 _mm_load_ss(float const*);
-extern int _mm_cvt_ss2si(__m128);
-__m128 _mm_xor_ps(__m128 a, __m128 b);
-__m128 _mm_div_ps(__m128 a, __m128 b);
-
-#ifdef _MSC_VER
-unsigned int _mm_getcsr(void);
-#pragma intrinsic(_mm_getcsr)
-void _mm_setcsr(unsigned int);
-#pragma intrinsic(_mm_setcsr)
-
-#ifndef __clang__
-#pragma intrinsic(_mm_xor_ps)
-#pragma intrinsic(_mm_div_ps)
-#else
-
-/*
- * Clang implements these as inline functions in the header instead of real builtins
- */
-__forceinline __m128 _mm_xor_ps(__m128 a, __m128 b)
-{
-    return (__m128)((__v4su)a ^ (__v4su)b);
-}
-
-__forceinline __m128 _mm_div_ps(__m128 a, __m128 b)
-{
-    return (__m128)((__v4sf)a / (__v4sf)b);
-}
-#endif /* __clang__ */
+#define __ATTRIBUTE_SSE__
 
 #else /* _MSC_VER */
 
-#if !defined(__INTRIN_INLINE)
-# ifdef __clang__
-#  define __ATTRIBUTE_ARTIFICIAL
-# else
-#  define __ATTRIBUTE_ARTIFICIAL __attribute__((artificial))
-# endif
-# define __INTRIN_INLINE extern __inline__ __attribute__((__always_inline__,__gnu_inline__)) __ATTRIBUTE_ARTIFICIAL
-#endif /* !__INTRIN_INLINE */
+    typedef        float __v4sf __attribute__((__vector_size__(16)));
+    typedef   signed int __v4si __attribute__((__vector_size__(16)));
+    typedef unsigned int __v4su __attribute__((__vector_size__(16)));
+    typedef float __m128_u __attribute__((__vector_size__(16), __aligned__(1)));
 
-#ifndef HAS_BUILTIN
+    typedef        float __m128 __attribute__((__vector_size__(16), __aligned__(16)));
+
 #ifdef __clang__
-#define HAS_BUILTIN(x) __has_builtin(x)
+#define __ATTRIBUTE_SSE__ __attribute__((__target__("sse"),__min_vector_width__(128)))
 #else
-#define HAS_BUILTIN(x) 0
+#define __ATTRIBUTE_SSE__ __attribute__((__target__("sse")))
 #endif
+#define __INTRIN_INLINE_SSE __INTRIN_INLINE __ATTRIBUTE_SSE__ 
+
+#endif /* _MSC_VER */
+
+#define _MM_ALIGN16 _VCRT_ALIGN(16)
+
+/* Constants for use with _mm_prefetch.  */
+#define _MM_HINT_NTA  0
+#define _MM_HINT_T0   1
+#define _MM_HINT_T1   2
+#define _MM_HINT_T2   3
+#define _MM_HINT_ENTA 4
+#if 0 // Not supported yet
+#define _MM_HINT_ET0  5
+#define _MM_HINT_ET1  6
+#define _MM_HINT_ET2  7
 #endif
+
+/* Create a selector for use with the SHUFPS instruction.  */
+#define _MM_SHUFFLE(fp3, fp2, fp1, fp0) \
+    (((fp3) << 6) | ((fp2) << 4) | ((fp1) << 2) | (fp0))
+
+/* Bits in the MXCSR.  */
+#define _MM_EXCEPT_MASK       0x003f
+#define _MM_EXCEPT_INVALID    0x0001
+#define _MM_EXCEPT_DENORM     0x0002
+#define _MM_EXCEPT_DIV_ZERO   0x0004
+#define _MM_EXCEPT_OVERFLOW   0x0008
+#define _MM_EXCEPT_UNDERFLOW  0x0010
+#define _MM_EXCEPT_INEXACT    0x0020
+
+#define _MM_MASK_MASK         0x1f80
+#define _MM_MASK_INVALID      0x0080
+#define _MM_MASK_DENORM       0x0100
+#define _MM_MASK_DIV_ZERO     0x0200
+#define _MM_MASK_OVERFLOW     0x0400
+#define _MM_MASK_UNDERFLOW    0x0800
+#define _MM_MASK_INEXACT      0x1000
+
+#define _MM_ROUND_MASK        0x6000
+#define _MM_ROUND_NEAREST     0x0000
+#define _MM_ROUND_DOWN        0x2000
+#define _MM_ROUND_UP          0x4000
+#define _MM_ROUND_TOWARD_ZERO 0x6000
+
+#define _MM_FLUSH_ZERO_MASK   0x8000
+#define _MM_FLUSH_ZERO_ON     0x8000
+#define _MM_FLUSH_ZERO_OFF    0x0000
+
+#ifdef __ICL
+void* __cdecl _mm_malloc(size_t Size, size_t Al);
+void __cdecl _mm_free(void* P);
+#endif
+
+void _mm_prefetch(_In_ char const* p, _In_ int i);
+__m128 _mm_setzero_ps(void);
+__m128 _mm_add_ss(__m128 a, __m128 b);
+__m128 _mm_sub_ss(__m128 a, __m128 b);
+__m128 _mm_mul_ss(__m128 a, __m128 b);
+__m128 _mm_div_ss(__m128 a, __m128 b);
+__m128 _mm_sqrt_ss(__m128 a);
+__m128 _mm_rcp_ss(__m128 a);
+__m128 _mm_rsqrt_ss(__m128 a);
+__m128 _mm_min_ss(__m128 a, __m128 b);
+__m128 _mm_max_ss(__m128 a, __m128 b);
+__m128 _mm_add_ps(__m128 a, __m128 b);
+__m128 _mm_sub_ps(__m128 a, __m128 b);
+__m128 _mm_mul_ps(__m128 a, __m128 b);
+__m128 _mm_div_ps(__m128 a, __m128 b);
+__m128 _mm_sqrt_ps(__m128 a);
+__m128 _mm_rcp_ps(__m128 a);
+__m128 _mm_rsqrt_ps(__m128 a);
+__m128 _mm_min_ps(__m128 a, __m128 b);
+__m128 _mm_max_ps(__m128 a, __m128 b);
+__m128 _mm_and_ps(__m128 a, __m128 b);
+__m128 _mm_andnot_ps(__m128 a, __m128 b);
+__m128 _mm_or_ps(__m128 a, __m128 b);
+__m128 _mm_xor_ps(__m128 a, __m128 b);
+__m128 _mm_cmpeq_ss(__m128 a, __m128 b);
+__m128 _mm_cmplt_ss(__m128 a, __m128 b);
+__m128 _mm_cmple_ss(__m128 a, __m128 b);
+__m128 _mm_cmpgt_ss(__m128 a, __m128 b);
+__m128 _mm_cmpge_ss(__m128 a, __m128 b);
+__m128 _mm_cmpneq_ss(__m128 a, __m128 b);
+__m128 _mm_cmpnlt_ss(__m128 a, __m128 b);
+__m128 _mm_cmpnle_ss(__m128 a, __m128 b);
+__m128 _mm_cmpngt_ss(__m128 a, __m128 b);
+__m128 _mm_cmpnge_ss(__m128 a, __m128 b);
+__m128 _mm_cmpord_ss(__m128 a, __m128 b);
+__m128 _mm_cmpunord_ss(__m128 a, __m128 b);
+__m128 _mm_cmpeq_ps(__m128 a, __m128 b);
+__m128 _mm_cmplt_ps(__m128 a, __m128 b);
+__m128 _mm_cmple_ps(__m128 a, __m128 b);
+__m128 _mm_cmpgt_ps(__m128 a, __m128 b);
+__m128 _mm_cmpge_ps(__m128 a, __m128 b);
+__m128 _mm_cmpneq_ps(__m128 a, __m128 b);
+__m128 _mm_cmpnlt_ps(__m128 a, __m128 b);
+__m128 _mm_cmpnle_ps(__m128 a, __m128 b);
+__m128 _mm_cmpngt_ps(__m128 a, __m128 b);
+__m128 _mm_cmpnge_ps(__m128 a, __m128 b);
+__m128 _mm_cmpord_ps(__m128 a, __m128 b);
+__m128 _mm_cmpunord_ps(__m128 a, __m128 b);
+int _mm_comieq_ss(__m128 a, __m128 b);
+int _mm_comilt_ss(__m128 a, __m128 b);
+int _mm_comile_ss(__m128 a, __m128 b);
+int _mm_comigt_ss(__m128 a, __m128 b);
+int _mm_comige_ss(__m128 a, __m128 b);
+int _mm_comineq_ss(__m128 a, __m128 b);
+int _mm_ucomieq_ss(__m128 a, __m128 b);
+int _mm_ucomilt_ss(__m128 a, __m128 b);
+int _mm_ucomile_ss(__m128 a, __m128 b);
+int _mm_ucomigt_ss(__m128 a, __m128 b);
+int _mm_ucomige_ss(__m128 a, __m128 b);
+int _mm_ucomineq_ss(__m128 a, __m128 b);
+int _mm_cvt_ss2si(__m128 a);
+int _mm_cvtt_ss2si(__m128 a);
+__m128 _mm_cvt_si2ss(__m128 a, int b);
+#ifdef _M_IX86
+__m64 _mm_cvt_ps2pi(__m128 a);
+__m64 _mm_cvtt_ps2pi(__m128 a);
+__m128 _mm_cvt_pi2ps(__m128 a, __m64 b);
+#endif
+__m128 _mm_shuffle_ps(__m128 a, __m128 b, unsigned int imm8);
+__m128 _mm_unpackhi_ps(__m128 a, __m128 b);
+__m128 _mm_unpacklo_ps(__m128 a, __m128 b);
+__m128 _mm_loadh_pi(__m128 a, __m64 const* p);
+void _mm_storeh_pi(__m64* p, __m128 a);
+__m128 _mm_movehl_ps(__m128 a, __m128 b);
+__m128 _mm_movelh_ps(__m128 a, __m128 b);
+__m128 _mm_loadl_pi(__m128 a, __m64 const* p);
+void _mm_storel_pi(__m64* p, __m128 a);
+int _mm_movemask_ps(__m128 a);
+unsigned int _mm_getcsr(void);
+void _mm_setcsr(unsigned int a);
+__m128 _mm_set_ss(float a);
+__m128 _mm_set_ps1(float a);
+__m128 _mm_load_ss(float const* p);
+__m128 _mm_load_ps1(float const* p);
+__m128 _mm_load_ps(float const* p);
+__m128 _mm_loadu_ps(float const* p);
+__m128 _mm_loadr_ps(float const* p);
+__m128 _mm_set_ps(float e3, float e2, float e1, float e0);
+__m128 _mm_setr_ps(float e3, float e2, float e1, float e0);
+void _mm_store_ss(float* p, __m128 a);
+float _mm_cvtss_f32(__m128 a);
+void _mm_store_ps(float* p, __m128 a);
+void _mm_storeu_ps(float* p, __m128 a);
+void _mm_store_ps1(float* p, __m128 a);
+void _mm_storer_ps(float* p, __m128 a);
+__m128 _mm_move_ss(__m128 a, __m128 b);
+#ifdef _M_IX86
+int _m_pextrw(__m64 a, int imm8);
+__m64 _m_pinsrw(__m64 a, int i, int imm8);
+__m64 _m_pmaxsw(__m64 a, __m64 b);
+__m64 _m_pmaxub(__m64 a, __m64 b);
+__m64 _m_pminsw(__m64 a, __m64 b);
+__m64 _m_pminub(__m64 a, __m64 b);
+int _m_pmovmskb(__m64 a);
+__m64 _m_pmulhuw(__m64 a, __m64 b);
+__m64 _m_pshufw(__m64 a, int imm8);
+void _m_maskmovq(__m64 a, __m64 b, char*);
+__m64 _m_pavgb(__m64 a, __m64 b);
+__m64 _m_pavgw(__m64 a, __m64 b);
+__m64 _m_psadbw(__m64 a, __m64 b);
+void _mm_stream_pi(__m64* p, __m64 a);
+#endif
+void _mm_stream_ps(float* p, __m128 a);
+void _mm_sfence(void);
+#ifdef _M_AMD64
+__int64 _mm_cvtss_si64(__m128 a);
+__int64 _mm_cvttss_si64(__m128 a);
+__m128  _mm_cvtsi64_ss(__m128 a, __int64 b);
+#endif
+
+/* Alternate names */
+#define _mm_cvtss_si32 _mm_cvt_ss2si
+#define _mm_cvttss_si32 _mm_cvtt_ss2si
+#define _mm_cvtsi32_ss _mm_cvt_si2ss
+#define _mm_set1_ps _mm_set_ps1
+#define _mm_load1_ps _mm_load_ps1f
+#define _mm_store1_ps _mm_store_ps1
+#define _mm_cvtps_pi32    _mm_cvt_ps2pi
+#define _mm_cvttps_pi32   _mm_cvtt_ps2pi
+#define _mm_cvtpi32_ps    _mm_cvt_pi2ps
+#define _mm_extract_pi16  _m_pextrw
+#define _mm_insert_pi16   _m_pinsrw
+#define _mm_max_pi16      _m_pmaxsw
+#define _mm_max_pu8       _m_pmaxub
+#define _mm_min_pi16      _m_pminsw
+#define _mm_min_pu8       _m_pminub
+#define _mm_movemask_pi8  _m_pmovmskb
+#define _mm_mulhi_pu16    _m_pmulhuw
+#define _mm_shuffle_pi16  _m_pshufw
+#define _mm_maskmove_si64 _m_maskmovq
+#define _mm_avg_pu8       _m_pavgb
+#define _mm_avg_pu16      _m_pavgw
+#define _mm_sad_pu8       _m_psadbw
+
+#ifdef _M_IX86
+/* Inline functions from Clang: https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/xmmintrin.h */
+
+__ATTRIBUTE_SSE__
+static __inline __m128 _mm_cvtpi16_ps(__m64 __a)
+{
+    __m64 __b, __c;
+    __m128 __r;
+
+    __b = _mm_setzero_si64();
+    __b = _mm_cmpgt_pi16(__b, __a);
+    __c = _mm_unpackhi_pi16(__a, __b);
+    __r = _mm_setzero_ps();
+    __r = _mm_cvtpi32_ps(__r, __c);
+    __r = _mm_movelh_ps(__r, __r);
+    __c = _mm_unpacklo_pi16(__a, __b);
+    __r = _mm_cvtpi32_ps(__r, __c);
+
+    return __r;
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m128 _mm_cvtpu16_ps(__m64 __a)
+{
+    __m64 __b, __c;
+    __m128 __r;
+
+    __b = _mm_setzero_si64();
+    __c = _mm_unpackhi_pi16(__a, __b);
+    __r = _mm_setzero_ps();
+    __r = _mm_cvtpi32_ps(__r, __c);
+    __r = _mm_movelh_ps(__r, __r);
+    __c = _mm_unpacklo_pi16(__a, __b);
+    __r = _mm_cvtpi32_ps(__r, __c);
+
+    return __r;
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m128 _mm_cvtpi8_ps(__m64 __a)
+{
+    __m64 __b;
+
+    __b = _mm_setzero_si64();
+    __b = _mm_cmpgt_pi8(__b, __a);
+    __b = _mm_unpacklo_pi8(__a, __b);
+
+    return _mm_cvtpi16_ps(__b);
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m128 _mm_cvtpu8_ps(__m64 __a)
+{
+    __m64 __b;
+
+    __b = _mm_setzero_si64();
+    __b = _mm_unpacklo_pi8(__a, __b);
+
+    return _mm_cvtpi16_ps(__b);
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m128 _mm_cvtpi32x2_ps(__m64 __a, __m64 __b)
+{
+    __m128 __c;
+
+    __c = _mm_setzero_ps();
+    __c = _mm_cvtpi32_ps(__c, __b);
+    __c = _mm_movelh_ps(__c, __c);
+
+    return _mm_cvtpi32_ps(__c, __a);
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m64 _mm_cvtps_pi16(__m128 __a)
+{
+    __m64 __b, __c;
+
+    __b = _mm_cvtps_pi32(__a);
+    __a = _mm_movehl_ps(__a, __a);
+    __c = _mm_cvtps_pi32(__a);
+
+    return _mm_packs_pi32(__b, __c);
+}
+
+__ATTRIBUTE_SSE__
+static __inline __m64 _mm_cvtps_pi8(__m128 __a)
+{
+    __m64 __b, __c;
+
+    __b = _mm_cvtps_pi16(__a);
+    __c = _mm_setzero_si64();
+
+    return _mm_packs_pi16(__b, __c);
+}
+
+#endif /* _M_IX86 */
+
+/* Transpose the 4x4 matrix composed of row[0-3].  */
+#define _MM_TRANSPOSE4_PS(row0, row1, row2, row3) \
+do {                                              \
+    __m128 t0 = _mm_unpacklo_ps(row0, row1);      \
+    __m128 t1 = _mm_unpacklo_ps(row2, row3);      \
+    __m128 t2 = _mm_unpackhi_ps(row0, row1);      \
+    __m128 t3 = _mm_unpackhi_ps(row2, row3);      \
+    (row0) = _mm_movelh_ps(t0, t1);               \
+    (row1) = _mm_movehl_ps(t1, t0);               \
+    (row2) = _mm_movelh_ps(t2, t3);               \
+    (row3) = _mm_movehl_ps(t3, t2);               \
+} while (0)
+
+#define _MM_GET_EXCEPTION_STATE() \
+    (_mm_getcsr() & _MM_EXCEPT_MASK)
+
+#define _MM_GET_EXCEPTION_MASK() \
+    (_mm_getcsr() & _MM_MASK_MASK)
+
+#define _MM_GET_ROUNDING_MODE() \
+    (_mm_getcsr() & _MM_ROUND_MASK)
+
+#define _MM_GET_FLUSH_ZERO_MODE() \
+    (_mm_getcsr() & _MM_FLUSH_ZERO_MASK)
+
+#define _MM_SET_EXCEPTION_STATE(__mask) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_EXCEPT_MASK) | (__mask))
+
+#define _MM_SET_EXCEPTION_MASK(__mask) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_MASK_MASK) | (__mask))
+
+#define _MM_SET_ROUNDING_MODE(__mode) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_ROUND_MASK) | (__mode))
+
+#define _MM_SET_FLUSH_ZERO_MODE(__mode) \
+    _mm_setcsr((_mm_getcsr() & ~_MM_FLUSH_ZERO_MASK) | (__mode))
+
+/* Use intrinsics on MSVC */
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma intrinsic(_mm_prefetch)
+#pragma intrinsic(_mm_setzero_ps)
+#pragma intrinsic(_mm_add_ss)
+#pragma intrinsic(_mm_sub_ss)
+#pragma intrinsic(_mm_mul_ss)
+#pragma intrinsic(_mm_div_ss)
+#pragma intrinsic(_mm_sqrt_ss)
+#pragma intrinsic(_mm_rcp_ss)
+#pragma intrinsic(_mm_rsqrt_ss)
+#pragma intrinsic(_mm_min_ss)
+#pragma intrinsic(_mm_max_ss)
+#pragma intrinsic(_mm_add_ps)
+#pragma intrinsic(_mm_sub_ps)
+#pragma intrinsic(_mm_mul_ps)
+#pragma intrinsic(_mm_div_ps)
+#pragma intrinsic(_mm_sqrt_ps)
+#pragma intrinsic(_mm_rcp_ps)
+#pragma intrinsic(_mm_rsqrt_ps)
+#pragma intrinsic(_mm_min_ps)
+#pragma intrinsic(_mm_max_ps)
+#pragma intrinsic(_mm_and_ps)
+#pragma intrinsic(_mm_andnot_ps)
+#pragma intrinsic(_mm_or_ps)
+#pragma intrinsic(_mm_xor_ps)
+#pragma intrinsic(_mm_cmpeq_ss)
+#pragma intrinsic(_mm_cmplt_ss)
+#pragma intrinsic(_mm_cmple_ss)
+#pragma intrinsic(_mm_cmpgt_ss)
+#pragma intrinsic(_mm_cmpge_ss)
+#pragma intrinsic(_mm_cmpneq_ss)
+#pragma intrinsic(_mm_cmpnlt_ss)
+#pragma intrinsic(_mm_cmpnle_ss)
+#pragma intrinsic(_mm_cmpngt_ss)
+#pragma intrinsic(_mm_cmpnge_ss)
+#pragma intrinsic(_mm_cmpord_ss)
+#pragma intrinsic(_mm_cmpunord_ss)
+#pragma intrinsic(_mm_cmpeq_ps)
+#pragma intrinsic(_mm_cmplt_ps)
+#pragma intrinsic(_mm_cmple_ps)
+#pragma intrinsic(_mm_cmpgt_ps)
+#pragma intrinsic(_mm_cmpge_ps)
+#pragma intrinsic(_mm_cmpneq_ps)
+#pragma intrinsic(_mm_cmpnlt_ps)
+#pragma intrinsic(_mm_cmpnle_ps)
+#pragma intrinsic(_mm_cmpngt_ps)
+#pragma intrinsic(_mm_cmpnge_ps)
+#pragma intrinsic(_mm_cmpord_ps)
+#pragma intrinsic(_mm_cmpunord_ps)
+#pragma intrinsic(_mm_comieq_ss)
+#pragma intrinsic(_mm_comilt_ss)
+#pragma intrinsic(_mm_comile_ss)
+#pragma intrinsic(_mm_comigt_ss)
+#pragma intrinsic(_mm_comige_ss)
+#pragma intrinsic(_mm_comineq_ss)
+#pragma intrinsic(_mm_ucomieq_ss)
+#pragma intrinsic(_mm_ucomilt_ss)
+#pragma intrinsic(_mm_ucomile_ss)
+#pragma intrinsic(_mm_ucomigt_ss)
+#pragma intrinsic(_mm_ucomige_ss)
+#pragma intrinsic(_mm_ucomineq_ss)
+#pragma intrinsic(_mm_cvt_ss2si)
+#pragma intrinsic(_mm_cvtt_ss2si)
+#pragma intrinsic(_mm_cvt_si2ss)
+#ifdef _M_IX86
+#pragma intrinsic(_mm_cvt_ps2pi)
+#pragma intrinsic(_mm_cvtt_ps2pi)
+#pragma intrinsic(_mm_cvt_pi2ps)
+#endif // _M_IX86
+#pragma intrinsic(_mm_shuffle_ps)
+#pragma intrinsic(_mm_unpackhi_ps)
+#pragma intrinsic(_mm_unpacklo_ps)
+#pragma intrinsic(_mm_loadh_pi)
+#pragma intrinsic(_mm_storeh_pi)
+#pragma intrinsic(_mm_movehl_ps)
+#pragma intrinsic(_mm_movelh_ps)
+#pragma intrinsic(_mm_loadl_pi)
+#pragma intrinsic(_mm_storel_pi)
+#pragma intrinsic(_mm_movemask_ps)
+#pragma intrinsic(_mm_getcsr)
+#pragma intrinsic(_mm_setcsr)
+#pragma intrinsic(_mm_set_ss)
+#pragma intrinsic(_mm_set_ps1)
+#pragma intrinsic(_mm_load_ss)
+#pragma intrinsic(_mm_load_ps1)
+#pragma intrinsic(_mm_load_ps)
+#pragma intrinsic(_mm_loadu_ps)
+#pragma intrinsic(_mm_loadr_ps)
+#pragma intrinsic(_mm_set_ps)
+#pragma intrinsic(_mm_setr_ps)
+#pragma intrinsic(_mm_store_ss)
+#pragma intrinsic(_mm_cvtss_f32)
+#pragma intrinsic(_mm_store_ps)
+#pragma intrinsic(_mm_storeu_ps)
+#pragma intrinsic(_mm_store_ps1)
+#pragma intrinsic(_mm_storer_ps)
+#pragma intrinsic(_mm_move_ss)
+#ifdef _M_IX86
+#pragma intrinsic(_m_pextrw)
+#pragma intrinsic(_m_pinsrw)
+#pragma intrinsic(_m_pmaxsw)
+#pragma intrinsic(_m_pmaxub)
+#pragma intrinsic(_m_pminsw)
+#pragma intrinsic(_m_pminub)
+#pragma intrinsic(_m_pmovmskb)
+#pragma intrinsic(_m_pmulhuw)
+#pragma intrinsic(_m_pshufw)
+#pragma intrinsic(_m_maskmovq)
+#pragma intrinsic(_m_pavgb)
+#pragma intrinsic(_m_pavgw)
+#pragma intrinsic(_m_psadbw)
+#pragma intrinsic(_mm_stream_pi)
+#endif // _M_IX86
+#pragma intrinsic(_mm_stream_ps)
+#pragma intrinsic(_mm_sfence)
+#ifdef _M_AMD64
+#pragma intrinsic(_mm_cvtss_si64)
+#pragma intrinsic(_mm_cvttss_si64)
+#pragma intrinsic(_mm_cvtsi64_ss)
+#endif // _M_AMD64
+
+#else /* _MSC_VER */
 
 /*
- * We can't use __builtin_ia32_* functions,
- * are they are only available with the -msse2 compiler switch
- */
+  GCC: https://github.com/gcc-mirror/gcc/blob/master/gcc/config/i386/xmmintrin.h
+  Clang: https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/xmmintrin.h
+*/
+
+/* Use inline functions on GCC/Clang */
+
 #if !HAS_BUILTIN(_mm_getcsr)
-__INTRIN_INLINE unsigned int _mm_getcsr(void)
+__INTRIN_INLINE_SSE unsigned int _mm_getcsr(void)
 {
-    unsigned int retval;
-    __asm__ __volatile__("stmxcsr %0" : "=m"(retval));
-    return retval;
+    return __builtin_ia32_stmxcsr();
 }
 #endif
 
 #if !HAS_BUILTIN(_mm_setcsr)
-__INTRIN_INLINE void _mm_setcsr(unsigned int val)
+__INTRIN_INLINE_SSE void _mm_setcsr(unsigned int a)
 {
-    __asm__ __volatile__("ldmxcsr %0" : : "m"(val));
+    __builtin_ia32_ldmxcsr(a);
 }
 #endif
+
+__INTRIN_INLINE_SSE __m128 _mm_add_ss(__m128 __a, __m128 __b)
+{
+    __a[0] += __b[0];
+    return __a;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_add_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4sf)__a + (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_sub_ss(__m128 __a, __m128 __b)
+{
+    __a[0] -= __b[0];
+    return __a;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_sub_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4sf)__a - (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_mul_ss(__m128 __a, __m128 __b)
+{
+    __a[0] *= __b[0];
+    return __a;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_mul_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4sf)__a * (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_div_ss(__m128 __a, __m128 __b)
+{
+    __a[0] /= __b[0];
+    return __a;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_div_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4sf)__a / (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_sqrt_ss(__m128 __a)
+{
+    return (__m128)__builtin_ia32_sqrtss((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_sqrt_ps(__m128 __a)
+{
+    return __builtin_ia32_sqrtps((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_rcp_ss(__m128 __a)
+{
+    return (__m128)__builtin_ia32_rcpss((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_rcp_ps(__m128 __a)
+{
+    return (__m128)__builtin_ia32_rcpps((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_rsqrt_ss(__m128 __a)
+{
+    return __builtin_ia32_rsqrtss((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_rsqrt_ps(__m128 __a)
+{
+    return __builtin_ia32_rsqrtps((__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_min_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_minss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_min_ps(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_minps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_max_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_maxss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_max_ps(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_maxps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_and_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4su)__a & (__v4su)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_andnot_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)(~(__v4su)__a & (__v4su)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_or_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4su)__a | (__v4su)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_xor_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)((__v4su)__a ^ (__v4su)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpeq_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpeqss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpeq_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpeqps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmplt_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpltss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmplt_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpltps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmple_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpless((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmple_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpleps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpgt_ss(__m128 __a, __m128 __b)
+{
+    __v4sf temp = __builtin_ia32_cmpltss((__v4sf)__b, (__v4sf)__a);
+#ifdef __clang__
+    return (__m128)__builtin_shufflevector((__v4sf)__a, temp, 4, 1, 2, 3);
+#else
+    return (__m128)__builtin_ia32_movss((__v4sf)__a, temp);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpgt_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpltps((__v4sf)__b, (__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpge_ss(__m128 __a, __m128 __b)
+{
+    __v4sf temp = __builtin_ia32_cmpless((__v4sf)__b, (__v4sf)__a);
+#ifdef __clang__
+    return (__m128)__builtin_shufflevector((__v4sf)__a, temp, 4, 1, 2, 3);
+#else
+    return (__m128)__builtin_ia32_movss((__v4sf)__a, temp);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpge_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpleps((__v4sf)__b, (__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpneq_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpneqss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpneq_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpneqps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnlt_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnltss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnlt_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnltps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnle_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnless((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnle_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnleps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpngt_ss(__m128 __a, __m128 __b)
+{
+    __v4sf temp = __builtin_ia32_cmpnltss((__v4sf)__b, (__v4sf)__a);
+#ifdef  __clang__
+    return (__m128)__builtin_shufflevector((__v4sf)__a, temp, 4, 1, 2, 3);
+#else
+    return (__m128)__builtin_ia32_movss((__v4sf)__a, temp);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpngt_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnltps((__v4sf)__b, (__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnge_ss(__m128 __a, __m128 __b)
+{
+    __v4sf temp = (__v4sf)__builtin_ia32_cmpnless((__v4sf)__b, (__v4sf)__a);
+#ifdef  __clang__
+    return (__m128)__builtin_shufflevector((__v4sf)__a, temp, 4, 1, 2, 3);
+#else
+    return (__m128)__builtin_ia32_movss((__v4sf)__a, temp);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpnge_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpnleps((__v4sf)__b, (__v4sf)__a);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpord_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpordss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpord_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpordps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpunord_ss(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpunordss((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_cmpunord_ps(__m128 __a, __m128 __b)
+{
+    return (__m128)__builtin_ia32_cmpunordps((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comieq_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comieq((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comilt_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comilt((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comile_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comile((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comigt_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comigt((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comige_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comige((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_comineq_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_comineq((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomieq_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomieq((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomilt_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomilt((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomile_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomile((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomigt_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomigt((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomige_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomige((__v4sf)__a, (__v4sf)__b);
+}
+
+__INTRIN_INLINE_SSE int _mm_ucomineq_ss(__m128 __a, __m128 __b)
+{
+    return __builtin_ia32_ucomineq((__v4sf)__a, (__v4sf)__b);
+}
+
+// _mm_cvt_ss2si
+__INTRIN_INLINE_SSE int _mm_cvtss_si32(__m128 __a)
+{
+    return __builtin_ia32_cvtss2si((__v4sf)__a);
+}
+
+#ifdef _M_AMD64
+__INTRIN_INLINE_SSE long long _mm_cvtss_si64(__m128 __a)
+{
+    return __builtin_ia32_cvtss2si64((__v4sf)__a);
+}
+#endif
+
+// _mm_cvt_ps2pi
+__INTRIN_INLINE_SSE __m64 _mm_cvtps_pi32(__m128 __a)
+{
+    return (__m64)__builtin_ia32_cvtps2pi((__v4sf)__a);
+}
+
+// _mm_cvtt_ss2si
+__INTRIN_INLINE_SSE int _mm_cvttss_si32(__m128 __a)
+{
+    return __builtin_ia32_cvttss2si((__v4sf)__a);
+}
+
+#ifdef _M_AMD64
+__INTRIN_INLINE_SSE long long _mm_cvttss_si64(__m128 __a)
+{
+    return __builtin_ia32_cvttss2si64((__v4sf)__a);
+}
+#endif
+
+// _mm_cvtt_ps2pi
+__INTRIN_INLINE_SSE __m64 _mm_cvttps_pi32(__m128 __a)
+{
+    return (__m64)__builtin_ia32_cvttps2pi((__v4sf)__a);
+}
+
+// _mm_cvt_si2ss
+__INTRIN_INLINE_SSE __m128 _mm_cvtsi32_ss(__m128 __a, int __b)
+{
+    __a[0] = __b;
+    return __a;
+}
+
+#ifdef _M_AMD64
+__INTRIN_INLINE_SSE __m128 _mm_cvtsi64_ss(__m128 __a, long long __b)
+{
+    __a[0] = __b;
+    return __a;
+}
+#endif
+
+// _mm_cvt_pi2ps
+__INTRIN_INLINE_SSE __m128 _mm_cvtpi32_ps(__m128 __a, __m64 __b)
+{
+    return __builtin_ia32_cvtpi2ps((__v4sf)__a, (__v2si)__b);
+}
+
+__INTRIN_INLINE_SSE float _mm_cvtss_f32(__m128 __a)
+{
+    return __a[0];
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_loadh_pi(__m128 __a, const __m64 *__p)
+{
+#ifdef  __clang__
+    typedef float __mm_loadh_pi_v2f32 __attribute__((__vector_size__(8)));
+    struct __mm_loadh_pi_struct {
+        __mm_loadh_pi_v2f32 __u;
+    } __attribute__((__packed__, __may_alias__));
+    __mm_loadh_pi_v2f32 __b = ((const struct __mm_loadh_pi_struct*)__p)->__u;
+    __m128 __bb = __builtin_shufflevector(__b, __b, 0, 1, 0, 1);
+    return __builtin_shufflevector(__a, __bb, 0, 1, 4, 5);
+#else
+    return (__m128)__builtin_ia32_loadhps(__a, __p);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_loadl_pi(__m128 __a, const __m64 *__p)
+{
+#ifdef  __clang__
+    typedef float __mm_loadl_pi_v2f32 __attribute__((__vector_size__(8)));
+    struct __mm_loadl_pi_struct {
+        __mm_loadl_pi_v2f32 __u;
+    } __attribute__((__packed__, __may_alias__));
+    __mm_loadl_pi_v2f32 __b = ((const struct __mm_loadl_pi_struct*)__p)->__u;
+    __m128 __bb = __builtin_shufflevector(__b, __b, 0, 1, 0, 1);
+    return __builtin_shufflevector(__a, __bb, 4, 5, 2, 3);
+#else
+    return (__m128)__builtin_ia32_loadlps(__a, __p);
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_load_ss(const float *__p)
+{
+    return _mm_set_ss(*__p);
+}
+
+// _mm_load_ps1
+__INTRIN_INLINE_SSE __m128 _mm_load1_ps(const float *__p)
+{
+    return _mm_set1_ps(*__p);
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_load_ps(const float *__p)
+{
+    return *(const __m128*)__p;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_loadu_ps(const float *__p)
+{
+    struct __loadu_ps {
+        __m128_u __v;
+    } __attribute__((__packed__, __may_alias__));
+    return ((const struct __loadu_ps*)__p)->__v;
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_loadr_ps(const float *__p)
+{
+    __m128 __a = _mm_load_ps(__p);
+#ifdef  __clang__
+    return __builtin_shufflevector((__v4sf)__a, (__v4sf)__a, 3, 2, 1, 0);
+#else
+    return (__m128)__builtin_ia32_shufps(__a, __a, _MM_SHUFFLE(0,1,2,3));
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_undefined_ps(void)
+{
+#ifdef __clang__
+    return (__m128)__builtin_ia32_undef128();
+#else
+    __m128 undef = undef;
+    return undef;
+#endif
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_set_ss(float __w)
+{
+    return __extension__ (__m128){ __w, 0, 0, 0 };
+}
+
+// _mm_set_ps1
+__INTRIN_INLINE_SSE __m128 _mm_set1_ps(float __w)
+{
+    return __extension__ (__m128){ __w, __w, __w, __w };
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_set_ps(float __z, float __y, float __x, float __w)
+{
+    return __extension__ (__m128){ __w, __x, __y, __z };
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_setr_ps(float __z, float __y, float __x, float __w)
+{
+    return __extension__ (__m128){ __z, __y, __x, __w };
+}
+
+__INTRIN_INLINE_SSE __m128 _mm_setzero_ps(void)
+{
+    return __extension__ (__m128){ 0, 0, 0, 0 };
+}
+
+__INTRIN_INLINE_SSE void _mm_storeh_pi(__m64 *__p, __m128 __a)
+{
+#ifdef __clang__
+    typedef float __mm_storeh_pi_v2f32 __attribute__((__vector_size__(8)));
+    struct __mm_storeh_pi_struct {
+        __mm_storeh_pi_v2f32 __u;
+    } __attribute__((__packed__, __may_alias__));
+    ((struct __mm_storeh_pi_struct*)__p)->__u = __builtin_shufflevector(__a, __a, 2, 3);
+#else
+    __builtin_ia32_storehps(__p, __a);
+#endif
+}
+
+__INTRIN_INLINE_SSE void _mm_storel_pi(__m64 *__p, __m128 __a)
+{
+#ifdef __clang__
+    typedef float __mm_storeh_pi_v2f32 __attribute__((__vector_size__(8)));
+    struct __mm_storeh_pi_struct {
+        __mm_storeh_pi_v2f32 __u;
+    } __attribute__((__packed__, __may_alias__));
+    ((struct __mm_storeh_pi_struct*)__p)->__u = __builtin_shufflevector(__a, __a, 0, 1);
+#else
+    __builtin_ia32_storelps(__p, __a);
+#endif
+}
+
+__INTRIN_INLINE_SSE void _mm_store_ss(float *__p, __m128 __a)
+{
+    *__p = ((__v4sf)__a)[0];
+}
+
+__INTRIN_INLINE_SSE void _mm_storeu_ps(float *__p, __m128 __a)
+{
+    *(__m128_u *)__p = __a;
+}
+
+__INTRIN_INLINE_SSE void _mm_store_ps(float *__p, __m128 __a)
+{
+    *(__m128*)__p = __a;
+}
+
+// _mm_store_ps1
+__INTRIN_INLINE_SSE void _mm_store1_ps(float *__p, __m128 __a)
+{
+    // FIXME: Should we use a temp instead?
+#ifdef __clang__
+     __a = __builtin_shufflevector((__v4sf)__a, (__v4sf)__a, 0, 0, 0, 0);
+#else
+    __a = __builtin_ia32_shufps(__a, __a, _MM_SHUFFLE(0,0,0,0));
+#endif
+    _mm_store_ps(__p, __a);
+}
+
+__INTRIN_INLINE_SSE void _mm_storer_ps(float *__p, __m128 __a)
+{
+#ifdef  __clang__
+    __m128 __tmp = __builtin_shufflevector((__v4sf)__a, (__v4sf)__a, 3, 2, 1, 0);
+#else
+    __m128 __tmp = __builtin_ia32_shufps(__a, __a, _MM_SHUFFLE(0,1,2,3));
+#endif
+    _mm_store_ps(__p, __tmp);
+}
+
+/* GCC / Clang specific consants */
+#define _MM_HINT_NTA_ALT 0
+#define _MM_HINT_T0_ALT  3
+#define _MM_HINT_T1_ALT  2
+#define _MM_HINT_T2_ALT  1
+#define _MM_HINT_ENTA_ALT 4
+
+// These are not supported yet
+//#define _MM_HINT_ET0_ALT 7
+//#define _MM_HINT_ET1_ALT 6
+//#define _MM_HINT_ET2_ALT 5
+
+#define _MM_HINT_MS_TO_ALT(sel) \
+   (((sel) == _MM_HINT_NTA) ? _MM_HINT_NTA_ALT : \
+    ((sel) == _MM_HINT_T0) ? _MM_HINT_T0_ALT : \
+    ((sel) == _MM_HINT_T1) ? _MM_HINT_T1_ALT : \
+    ((sel) == _MM_HINT_T2) ? _MM_HINT_T2_ALT : \
+    ((sel) == _MM_HINT_ENTA) ? _MM_HINT_ENTA_ALT : 0)
+
+#ifdef _MSC_VER1
+
+/* On clang-cl we have an intrinsic, but the constants are different */
+#pragma intrinsic(_mm_prefetch)
+#define _mm_prefetch(p, sel) _mm_prefetch(p, _MM_HINT_MS_TO_ALT(sel))
+
+#else /* _MSC_VER */
+
+#define _mm_prefetch(p, sel) \
+    __builtin_prefetch((const void *)(p), (_MM_HINT_MS_TO_ALT(sel) >> 2) & 1, _MM_HINT_MS_TO_ALT(sel) & 0x3)
+
 #endif /* _MSC_VER */
 
-/* Alternate names */
-#define _mm_cvtss_si32 _mm_cvt_ss2si
+__INTRIN_INLINE_SSE void _mm_stream_pi(__m64 *__p, __m64 __a)
+{
+#ifdef __clang__
+    __builtin_ia32_movntq((__v1di*)__p, __a);
+#else
+    __builtin_ia32_movntq((long long unsigned int *)__p, (long long unsigned int)__a);
+#endif
+}
+
+__INTRIN_INLINE_SSE void _mm_stream_ps(float *__p, __m128 __a)
+{
+#ifdef __clang__
+    __builtin_nontemporal_store((__v4sf)__a, (__v4sf*)__p);
+#else
+    __builtin_ia32_movntps(__p, (__v4sf)__a);
+#endif
+}
+
+#if !HAS_BUILTIN(_mm_sfence)
+__INTRIN_INLINE_SSE void _mm_sfence(void)
+{
+    __builtin_ia32_sfence();
+}
+#endif
+
+#ifdef __clang__
+#define _m_pextrw(a, n) \
+    ((int)__builtin_ia32_vec_ext_v4hi((__v4hi)a, (int)n))
+
+#define _m_pinsrw(a, d, n) \
+    ((__m64)__builtin_ia32_vec_set_v4hi((__v4hi)a, (int)d, (int)n))
+#else
+// _m_pextrw
+__INTRIN_INLINE_SSE int _mm_extract_pi16(__m64 const __a, int const __n)
+{
+    return (unsigned short)__builtin_ia32_vec_ext_v4hi((__v4hi)__a, __n);
+}
+
+// _m_pinsrw
+__INTRIN_INLINE_SSE __m64 _mm_insert_pi16 (__m64 const __a, int const __d, int const __n)
+{
+    return (__m64)__builtin_ia32_vec_set_v4hi ((__v4hi)__a, __d, __n);
+}
+
+#endif
+
+// _m_pmaxsw
+__INTRIN_INLINE_SSE __m64 _mm_max_pi16(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pmaxsw((__v4hi)__a, (__v4hi)__b);
+}
+
+// _m_pmaxub
+__INTRIN_INLINE_SSE __m64 _mm_max_pu8(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pmaxub((__v8qi)__a, (__v8qi)__b);
+}
+
+// _m_pminsw
+__INTRIN_INLINE_SSE __m64 _mm_min_pi16(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pminsw((__v4hi)__a, (__v4hi)__b);
+}
+
+// _m_pminub
+__INTRIN_INLINE_SSE __m64 _mm_min_pu8(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pminub((__v8qi)__a, (__v8qi)__b);
+}
+
+// _m_pmovmskb
+__INTRIN_INLINE_SSE int _mm_movemask_pi8(__m64 __a)
+{
+    return __builtin_ia32_pmovmskb((__v8qi)__a);
+}
+
+// _m_pmulhuw
+__INTRIN_INLINE_SSE __m64 _mm_mulhi_pu16(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pmulhuw((__v4hi)__a, (__v4hi)__b);
+}
+
+#ifdef __clang__
+#define _m_pshufw(a, n) \
+    ((__m64)__builtin_ia32_pshufw((__v4hi)(__m64)(a), (n)))
+#else
+// _m_pshufw
+__INTRIN_INLINE_MMX __m64 _mm_shuffle_pi16 (__m64 __a, int const __n)
+{
+    return (__m64) __builtin_ia32_pshufw ((__v4hi)__a, __n);
+}
+#endif
+
+// _m_maskmovq
+__INTRIN_INLINE_SSE void _mm_maskmove_si64(__m64 __d, __m64 __n, char *__p)
+{
+    __builtin_ia32_maskmovq((__v8qi)__d, (__v8qi)__n, __p);
+}
+
+// _m_pavgb
+__INTRIN_INLINE_SSE __m64 _mm_avg_pu8(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pavgb((__v8qi)__a, (__v8qi)__b);
+}
+
+// _m_pavgw
+__INTRIN_INLINE_SSE __m64 _mm_avg_pu16(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_pavgw((__v4hi)__a, (__v4hi)__b);
+}
+
+// _m_psadbw
+__INTRIN_INLINE_SSE __m64 _mm_sad_pu8(__m64 __a, __m64 __b)
+{
+    return (__m64)__builtin_ia32_psadbw((__v8qi)__a, (__v8qi)__b);
+}
+
+#endif // __GNUC__
 
 #ifdef __cplusplus
 }
-#endif
-
-/* _mm_prefetch constants */
-#define _MM_HINT_T0 1
-#define _MM_HINT_T1 2
-#define _MM_HINT_T2 3
-#define _MM_HINT_NTA 0
-#define _MM_HINT_ET1 6
-
+#endif // __cplusplus
 
 #endif /* _INCLUDED_MM2 */


### PR DESCRIPTION
## Purpose

This change implements all intrinsics in mmintrin.h (MMX) and xmmintrin.h (SSE)
Note: the previous GCC definition of __m128 was broken and didn't work.
It's preparation work for importing some SSE math functions for x64

## Proposed changes

* Implement all mmintrin.h/xmmintrin.h functions as inline wrappers around GCC/Clang builtins
* Move __INTRIN_INLINE definition to mingw32.h, which is always included
* Allow attribute artificial for Clang, too

## TODO

- [ ] Find someone to write tests
