### PR TITLE
[WIN32K] Conditionally enable IMM32

### DIFF
--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -124,7 +124,16 @@ NtUserCallNoParam(DWORD Routine)
             break;
 
         case NOPARAM_ROUTINE_UPDATEPERUSERIMMENABLING:
-            gpsi->dwSRVIFlags |= SRVINFO_IMM32; // Always set.
+            // TODO: This should also check the registry!
+            // see https://www.pctipsbox.com/fix-available-for-ie7-memory-leaks-on-xp-sp3/ for more information
+            if (NLS_MB_CODE_PAGE_TAG)
+            {
+                gpsi->dwSRVIFlags |= SRVINFO_IMM32;
+            }
+            else
+            {
+                gpsi->dwSRVIFlags &= ~SRVINFO_IMM32;
+            }
             Result = TRUE; // Always return TRUE.
             break;
 


### PR DESCRIPTION
MFC42 applications only expect an IME window when on a DBCS system,
so they will capture this IME window as their 'main' window on non-DBCS systems.

JIRA issue: [CORE-18212](https://jira.reactos.org/browse/CORE-18212)
