### PR TITLE
[NTOS:SE] Implement token sandbox inert querying

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -443,6 +443,11 @@ SeCopyClientToken(
     _In_ KPROCESSOR_MODE PreviousMode,
     _Out_ PACCESS_TOKEN* NewToken);
 
+BOOLEAN
+NTAPI
+SeTokenIsInert(
+    _In_ PTOKEN Token);
+
 ULONG
 RtlLengthSidAndAttributes(
     _In_ ULONG Count,

--- a/ntoskrnl/se/token.c
+++ b/ntoskrnl/se/token.c
@@ -1182,6 +1182,27 @@ SeCopyClientToken(
 
 /**
  * @brief
+ * Determines if a token is a sandbox inert token or not,
+ * based upon the token flags.
+ *
+ * @param[in] Token
+ * A valid access token to determine if such token is inert.
+ *
+ * @return
+ * Returns TRUE if the token is inert, FALSE otherwise.
+ */
+BOOLEAN
+NTAPI
+SeTokenIsInert(
+    _In_ PTOKEN Token)
+{
+    PAGED_CODE();
+
+    return (((PTOKEN)Token)->TokenFlags & TOKEN_SANDBOX_INERT) != 0;
+}
+
+/**
+ * @brief
  * Internal function that deals with access token object destruction and deletion.
  * The function is used solely by the object manager mechanism that handles the life
  * management of a token object.

--- a/ntoskrnl/se/tokencls.c
+++ b/ntoskrnl/se/tokencls.c
@@ -984,9 +984,26 @@ NtQueryInformationToken(
             }
 
             case TokenSandBoxInert:
-                DPRINT1("NtQueryInformationToken(TokenSandboxInert) not implemented\n");
-                Status = STATUS_NOT_IMPLEMENTED;
+            {
+                ULONG IsTokenSandBoxInert;
+
+                DPRINT("NtQueryInformationToken(TokenSandBoxInert)\n");
+
+                IsTokenSandBoxInert = SeTokenIsInert(Token);
+                _SEH2_TRY
+                {
+                    /* Buffer size was already verified, no need to check here again */
+                    *(PULONG)TokenInformation = IsTokenSandBoxInert;
+                    *ReturnLength = sizeof(ULONG);
+                }
+                _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+                {
+                    Status = _SEH2_GetExceptionCode();
+                }
+                _SEH2_END;
+
                 break;
+            }
 
             case TokenSessionId:
             {


### PR DESCRIPTION
Since there's support for restricted tokens in the kernel which also supports for sandbox inert tokens as well, just implement the querying part outright, aka `TokenSandBoxInert` class.