### PR TITLE
[WIN32SS][NTUSER] Load DirectX graphics driver at system startup

### DIFF
--- a/win32ss/gdi/ntgdi/init.c
+++ b/win32ss/gdi/ntgdi/init.c
@@ -7,10 +7,9 @@
  */
 
 #include <win32k.h>
+DBG_DEFAULT_CHANNEL(UserMisc);
 
-#define NDEBUG
-#include <debug.h>
-#include <kdros.h>
+USHORT gusLanguageID;
 
 BOOL NTAPI GDI_CleanupForProcess(struct _EPROCESS *Process);
 
@@ -76,6 +75,29 @@ GdiThreadDestroy(PETHREAD Thread)
     return STATUS_SUCCESS;
 }
 
+
+BOOL
+InitializeGreCSRSS(VOID)
+{
+    /* Initialize DirectX graphics driver */
+    if (DxDdStartupDxGraphics(0, NULL, 0, NULL, NULL, gpepCSRSS) != STATUS_SUCCESS)
+    {
+        ERR("Unable to initialize DirectX graphics\n");
+        return FALSE;
+    }
+
+    /* Get global language ID */
+    gusLanguageID = UserGetLanguageID();
+
+    /* Initialize FreeType library */
+    if (!InitFontSupport())
+    {
+        ERR("Unable to initialize font support\n");
+        return FALSE;
+    }
+
+    return TRUE;
+}
 
 /*
  * @implemented

--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -23,7 +23,9 @@ extern BOOL APIENTRY IntEngLeave(PINTENG_ENTER_LEAVE EnterLeave);
 extern HGDIOBJ StockObjects[];
 extern USHORT gusLanguageID;
 
+BOOL InitializeGreCSRSS(VOID);
 USHORT FASTCALL UserGetLanguageID(VOID);
+
 PVOID APIENTRY HackSecureVirtualMemory(IN PVOID,IN SIZE_T,IN ULONG,OUT PVOID *);
 VOID APIENTRY HackUnsecureVirtualMemory(IN PVOID);
 

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -26,7 +26,6 @@ NTSTATUS GdiThreadDestroy(PETHREAD Thread);
 
 PSERVERINFO gpsi = NULL; // Global User Server Information.
 
-USHORT gusLanguageID;
 PPROCESSINFO ppiScrnSaver;
 PPROCESSINFO gppiList = NULL;
 
@@ -1050,15 +1049,6 @@ DriverEntry(
     NT_ROF(MsqInitializeImpl());
     NT_ROF(InitTimerImpl());
     NT_ROF(InitDCEImpl());
-
-    gusLanguageID = UserGetLanguageID();
-
-    /* Initialize FreeType library */
-    if (!InitFontSupport())
-    {
-        DPRINT1("Unable to initialize font support\n");
-        return Status;
-    }
 
     return STATUS_SUCCESS;
 }

--- a/win32ss/user/ntuser/ntuser.c
+++ b/win32ss/user/ntuser/ntuser.c
@@ -198,12 +198,9 @@ NtUserInitialize(
 // Initialize Power Request List (use hPowerRequestEvent).
 // Initialize Media Change (use hMediaRequestEvent).
 
-// InitializeGreCSRSS();
-// {
-//    Startup DxGraphics.
-//    calls ** UserGetLanguageID() and sets it **.
-//    Enables Fonts drivers, Initialize Font table & Stock Fonts.
-// }
+    /* Initialize various GDI stuff (DirectX, fonts, language ID etc.) */
+    if (!InitializeGreCSRSS())
+        return STATUS_UNSUCCESSFUL;
 
     /* Initialize USER */
     Status = UserInitialize();


### PR DESCRIPTION
## Purpose

Load DirectX graphics kernel driver (dxg.sys) by our win32k when the system starts up. Keep it always loaded in memory, like done in Windows, instead of loading only by DirectX dlls. It fixes the problem with accessing to this driver, so then we need only call `DxDdEnableDirectDraw` and do other stuff when DirectDraw/Direct3D is required by anything. In other cases, it is called from win32k PDEV* functions when changing display mode (as in Windows). Since it's used by other things too, it needs to be always loaded.
Otherwise, if it's not loaded, its APIs are not accessible when needed, and then execution fails.
It fixes display mode change problem in VMWare, when a new mode fails to be applied, because when it manages DirectDraw stuff, it calls DXG routines, and therefore fails if dxg.sys isn't loaded in memory at the moment.

JIRA issue: [CORE-18221](https://jira.reactos.org/browse/CORE-18221)

## Proposed changes

- Implement `InitializeGreCSRSS()` initialization routine. Call win32k!`DxDdStartupDxGraphics` inside it, which loads dxg.sys.
Additionally, move fonts and language ID initialization into `InitializeGreCSRSS()` from win32k!`DriverEntry`, as it is implemented in Windows. My analysis confirms that `DriverEntry()` does not initialize fonts stuff and language ID. It's done in `IntitializeGreCSRSS()` instead.
- Call `InitializeGreCSRSS()` in `NtUserInitialize()` main initialization routine. My analysis confirms that this is correct, regarding the Windows implementation. :slightly_smiling_face: 

**NOTE 2: To see the bug, #4519 PR should also be applied.**