### PR TITLE
[NTOS:SE] Properly handle dynamic counters in token

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -390,6 +390,17 @@ SepRemoveUserGroupToken(
     _Inout_ PTOKEN Token,
     _In_ ULONG Index);
 
+ULONG
+SepComputeAvailableDynamicSpace(
+    _In_ ULONG DynamicCharged,
+    _In_ PSID PrimaryGroup,
+    _In_opt_ PACL DefaultDacl);
+
+NTSTATUS
+SepRebuildDynamicPartOfToken(
+    _In_ PTOKEN Token,
+    _In_ ULONG NewDynamicPartSize);
+
 BOOLEAN
 NTAPI
 SeTokenCanImpersonate(


### PR DESCRIPTION
On current master, ReactOS faces these problems:

- ObCreateObject charges both paged and non paged pool a size of TOKEN structure, not the actual dynamic contents of WHAT IS inside a token. For paged pool charge the size is that of the dynamic area (primary group + default DACL if any). This is basically what DynamicCharged is for.
For the non paged pool charge, the actual charge is that of TOKEN structure upon creation. On duplication and filtering however, the paged pool charge size is that of the inherited dynamic charged space from an existing token whereas the non paged pool size is that of the calculated token body
length for the new duplicated/filtered token. On current master, we're literally cheating the kernel by charging the wrong amount of quota not taking into account the dynamic contents which they come from UM.

- Both DynamicCharged and DynamicAvailable are not fully handled (DynamicAvailable is pretty much poorly handled with some cases still to be taking into account). DynamicCharged is barely handled, like at all.

- As a result of these two points above, NtSetInformationToken doesn't check when the caller wants to set up a new default token DACL or primary group if the newly DACL or the said group exceeds the dynamic charged boundary. So what happens is that I'm going to act like a smug bastard fat politician and whack the primary group and DACL of an token however I want to, because why in the hell not? In reality no, the kernel has to punish whoever attempts to do that, although we currently don't.

- The dynamic area (aka DynamicPart) only picks up the default DACL but not the primary group as well. Generally the dynamic part is composed of primary group and default DACL, if provided.

In addition to that, we aren't returning the dynamic charged and available area in token statistics. SepComputeAvailableDynamicSpace helper is here to accommodate that. Apparently Windows is calculating the dynamic available area rather than just querying the DynamicAvailable field directly from the token.
My theory regarding this is like the following: on Windows both TokenDefaultDacl and TokenPrimaryGroup classes are barely used by the system components during startup (LSASS provides both a DACL and primary group when calling NtCreateToken anyway). In fact DynamicAvailable is 0 during token creation, duplication and filtering when inspecting a token with WinDBG. So
if an application wants to query token statistics that application will face a dynamic available space of 0.
## TODO

- [x] Rewrite the `DynamicPart` management code
- [x] Expand the `DynamicPart` field on `TokenPrimaryGroup` if needed
- [x] Fully handle `DynamicAvailable`
- [x] Investigate `QUOTA_UNDERFLOW` scenario when restarting ROS after a complete Vbox Guest Additions install (rebased on top of #4562)