### PR TITLE
Remove references to ReactOS Foundation

### DIFF
--- a/boot/boot_images.cmake
+++ b/boot/boot_images.cmake
@@ -56,8 +56,8 @@ ${_efisys_file} 1
 ")
 
 # ISO image identifier names
-set(ISO_MANUFACTURER "ReactOS Foundation")  # For both the publisher and the preparer
-set(ISO_VOLNAME      "ReactOS")             # For both the Volume ID and the Volume set ID
+set(ISO_MANUFACTURER "ReactOS Project") # For both the publisher and the preparer
+set(ISO_VOLNAME      "ReactOS")         # For both the Volume ID and the Volume set ID
 
 
 # Create user profile directories in the LiveImage

--- a/drivers/processor/processr/cpu.inf
+++ b/drivers/processor/processr/cpu.inf
@@ -120,7 +120,7 @@ LoadOrderGroup = Extended Base
 ;-------------------------------- STRINGS -------------------------------
 
 [Strings]
-ReactOS = "ReactOS Foundation"
+ReactOS = "ReactOS Team"
 ProcessorClassName = "Processors"
 
 CyrixMfg = "Cyrix"

--- a/media/themes/Blackshade/blackshade.msstyles/lang/de-DE.rc
+++ b/media/themes/Blackshade/blackshade.msstyles/lang/de-DE.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Black Shade"
 5001, "Visueller Stil"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Grafiken erstellt durch David Quintana <gigaherz@gmail.com>"
 5004, "Grafiken veröffentlicht unter CC-BY-SA 4.0"
 5005, "https://reactos.org/"

--- a/media/themes/Blackshade/blackshade.msstyles/lang/en-US.rc
+++ b/media/themes/Blackshade/blackshade.msstyles/lang/en-US.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Black Shade"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Images by David Quintana <gigaherz@gmail.com>"
 5004, "Images released under CC-BY-SA 4.0"
 5005, "https://reactos.org/"

--- a/media/themes/Blackshade/blackshade.msstyles/lang/it-IT.rc
+++ b/media/themes/Blackshade/blackshade.msstyles/lang/it-IT.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Black Shade"
 5001, "Stile di visualizzazione"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Immagini di David Quintana <gigaherz@gmail.com>"
 5004, "Immagini rilasciate sotto licenza CC-BY-SA 4.0"
 5005, "https://reactos.org/"

--- a/media/themes/Blackshade/blackshade.msstyles/lang/zh-HK.rc
+++ b/media/themes/Blackshade/blackshade.msstyles/lang/zh-HK.rc
@@ -35,7 +35,7 @@ STRINGTABLE
 {
 5000, "Black Shade"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "圖像由 David Quintana <gigaherz@gmail.com> 提供"
 5004, "圖像以 CC-BY-SA 4.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Blackshade/blackshade.msstyles/lang/zh-TW.rc
+++ b/media/themes/Blackshade/blackshade.msstyles/lang/zh-TW.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Black Shade"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "圖像由 David Quintana <gigaherz@gmail.com> 提供"
 5004, "圖像以 CC-BY-SA 4.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Lautus/lautus.msstyles/lang/de-DE.rc
+++ b/media/themes/Lautus/lautus.msstyles/lang/de-DE.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lautus"
 5001, "Visueller Stil"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Pisarz, basierend auf Luna Inspirat"
 5004, "Veröffentlicht unter GNU/GPL 2.0, 2011"
 5005, "https://reactos.org/"

--- a/media/themes/Lautus/lautus.msstyles/lang/en-US.rc
+++ b/media/themes/Lautus/lautus.msstyles/lang/en-US.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lautus"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Pisarz, based on Luna Inspirat"
 5004, "Released under GNU/GPL 2.0, 2011"
 5005, "https://reactos.org/"

--- a/media/themes/Lautus/lautus.msstyles/lang/it-IT.rc
+++ b/media/themes/Lautus/lautus.msstyles/lang/it-IT.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lautus"
 5001, "Stile di visualizzazione"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Pisarz, basato on Luna Inspirat"
 5004, "Distribuito sotto licenza GNU/GPL 2.0, 2011"
 5005, "https://reactos.org/"

--- a/media/themes/Lautus/lautus.msstyles/lang/zh-HK.rc
+++ b/media/themes/Lautus/lautus.msstyles/lang/zh-HK.rc
@@ -35,7 +35,7 @@ STRINGTABLE
 {
 5000, "Lautus"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Pisarz, 基於 Luna Inspirat"
 5004, "於 2011 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Lautus/lautus.msstyles/lang/zh-TW.rc
+++ b/media/themes/Lautus/lautus.msstyles/lang/zh-TW.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Lautus"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Pisarz, 基於 Luna Inspirat"
 5004, "於 2011 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/cs-CZ.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/cs-CZ.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "Vizuální styl"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, založeno na stylu Lautus"
 5004, "Vydáno pod licencí GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/de-DE.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/de-DE.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "Visueller Stil"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, basierend auf Lautus"
 5004, "Veröffentlicht unter GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/en-US.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/en-US.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, built on top of Lautus"
 5004, "Released under GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/it-IT.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/it-IT.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "Stile di visualizzazione"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, basato su Lautus"
 5004, "Distribuito sotto licenza GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/zh-HK.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/zh-HK.rc
@@ -35,7 +35,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, built on top of Lautus"
 5004, "於 2019 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Lunar/lunar.msstyles/lang/zh-TW.rc
+++ b/media/themes/Lunar/lunar.msstyles/lang/zh-TW.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Lunar"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Cernodile & Illen, built on top of Lautus"
 5004, "於 2019 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Mizu/mizu.msstyles/lang/de-DE.rc
+++ b/media/themes/Mizu/mizu.msstyles/lang/de-DE.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Mizu"
 5001, "Visueller Stil"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Foxlet, basierend auf Lautus"
 5004, "Veröffentlicht unter GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Mizu/mizu.msstyles/lang/en-US.rc
+++ b/media/themes/Mizu/mizu.msstyles/lang/en-US.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Mizu"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Foxlet, based on Lautus"
 5004, "Released under GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Mizu/mizu.msstyles/lang/it-IT.rc
+++ b/media/themes/Mizu/mizu.msstyles/lang/it-IT.rc
@@ -28,7 +28,7 @@ STRINGTABLE
 {
 5000, "Mizu"
 5001, "Stile di visualizzazione"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Foxlet, basato on Lautus"
 5004, "Distribuito sotto licenza GNU/GPL 2.0, 2019"
 5005, "https://reactos.org/"

--- a/media/themes/Mizu/mizu.msstyles/lang/zh-HK.rc
+++ b/media/themes/Mizu/mizu.msstyles/lang/zh-HK.rc
@@ -35,7 +35,7 @@ STRINGTABLE
 {
 5000, "Mizu"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Foxlet, 基於 Lautus"
 5004, "於 2019 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Mizu/mizu.msstyles/lang/zh-TW.rc
+++ b/media/themes/Mizu/mizu.msstyles/lang/zh-TW.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Mizu"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Foxlet, 基於 Lautus"
 5004, "於 2019 年以 GNU/GPL 2.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/de-DE.rc
+++ b/media/themes/Modern/modern.msstyles/lang/de-DE.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "Visueller Stil"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, basierend auf win10"
 5004, "Veröffentlicht unter GNU/GPL 3.0, 2018"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/en-GB.rc
+++ b/media/themes/Modern/modern.msstyles/lang/en-GB.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, based on win10"
 5004, "Released under GNU/GPL 3.0, 2018"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/en-US.rc
+++ b/media/themes/Modern/modern.msstyles/lang/en-US.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "Visual Style"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, based on win10"
 5004, "Released under GNU/GPL 3.0, 2018"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/it-IT.rc
+++ b/media/themes/Modern/modern.msstyles/lang/it-IT.rc
@@ -30,7 +30,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "Stile di visualizzazione"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, basato on win10"
 5004, "Distribuito sotto licenza GNU/GPL 3.0, 2018"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/zh-HK.rc
+++ b/media/themes/Modern/modern.msstyles/lang/zh-HK.rc
@@ -37,7 +37,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, 基於 win10 預設樣式"
 5004, "於 2018 年以 GNU/GPL 3.0 條款發行"
 5005, "https://reactos.org/"

--- a/media/themes/Modern/modern.msstyles/lang/zh-TW.rc
+++ b/media/themes/Modern/modern.msstyles/lang/zh-TW.rc
@@ -32,7 +32,7 @@ STRINGTABLE
 {
 5000, "Modern"
 5001, "視覺樣式"
-5002, "ReactOS Foundation"
+5002, "ReactOS Project"
 5003, "Polar, 基於 win10 預設樣式"
 5004, "於 2018 年以 GNU/GPL 3.0 條款發行"
 5005, "https://reactos.org/"

--- a/sdk/include/psdk/common.ver
+++ b/sdk/include/psdk/common.ver
@@ -18,9 +18,9 @@
 //
 #ifndef VER_LEGALCOPYRIGHT_STR
 #if defined(RC_INVOKED) && !defined(WIN16)
-#define VER_LEGALCOPYRIGHT_STR L"\251 ReactOS Foundation. All rights reserved."
+#define VER_LEGALCOPYRIGHT_STR L"\251 ReactOS Project. All rights reserved."
 #else
-#define VER_LEGALCOPYRIGHT_STR "Copyright (c) ReactOS Foundation. All rights reserved."
+#define VER_LEGALCOPYRIGHT_STR "Copyright (c) ReactOS Project. All rights reserved."
 #endif
 #endif
 
@@ -29,9 +29,9 @@
 //
 #ifndef VER_PRODUCTNAME_STR
 #ifdef RC_INVOKED
-#define VER_PRODUCTNAME_STR L"ReactOS\256 Operating System"
+#define VER_PRODUCTNAME_STR L"ReactOS Operating System"
 #else
-#define VER_PRODUCTNAME_STR "ReactOS (R) Operating System"
+#define VER_PRODUCTNAME_STR "ReactOS Operating System"
 #endif
 #endif
 

--- a/sdk/include/psdk/ntverp.h
+++ b/sdk/include/psdk/ntverp.h
@@ -144,8 +144,8 @@
 // Company and Trademarks
 //
 #define VER_COMPANYNAME_STR                 \
-    "ReactOS(R) Foundation"
+    "ReactOS Project"
 #define VER_PRODUCTNAME_STR                 \
-    "ReactOS(R) Operating System"
+    "ReactOS Operating System"
 #define VER_LEGALTRADEMARKS_STR             \
-    "ReactOS(R) is a registered trademark of the ReactOS Foundation."
+    "ReactOS is a registered trademark of ReactOS Deutschland e.V."


### PR DESCRIPTION
## Purpose

Remove leftover references to "ReactOS Foundation"

JIRA issue: [CORE-18191](https://jira.reactos.org/browse/CORE-18191)

## Proposed changes

Changed references to "ReactOS Foundation" to "ReactOS Project"

## TODO

Some files use "ReactOS Foundation" in reference to legal trademarks, like "ReactOS(R) is a registered trademark of the ReactOS Foundation." I didn't change those yet, I will ask in IRC.
