### PR TITLE
[WIN32K:ENG] EngAlphaBlend(): Release EnterLeaveSource on error

### DIFF
--- a/win32ss/gdi/eng/alphablend.c
+++ b/win32ss/gdi/eng/alphablend.c
@@ -111,6 +111,7 @@ EngAlphaBlend(
 
     if (!IntEngEnter(&EnterLeaveDest, psoDest, &OutputRect, FALSE, &Translate, &OutputObj))
     {
+        IntEngLeave(&EnterLeaveSource);
         return FALSE;
     }
     OutputRect.left += Translate.x;


### PR DESCRIPTION
Part of
JIRA issue: [CORE-11156](https://jira.reactos.org/browse/CORE-11156)

Co-authored-by: Carlo Bramini <...>