### PR TITLE
[NTOS:OB] Include the security descriptor charge when charging the pa…

### DIFF
--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -447,7 +447,8 @@ ObpChargeQuotaForObject(IN POBJECT_HEADER ObjectHeader,
         if (ObjectQuota)
         {
             /* We have a quota, get the charges */
-            PagedPoolCharge = ObjectQuota->PagedPoolCharge;
+            PagedPoolCharge = ObjectQuota->PagedPoolCharge +
+                              ObjectQuota->SecurityDescriptorCharge;
             NonPagedPoolCharge = ObjectQuota->NonPagedPoolCharge;
         }
         else


### PR DESCRIPTION
…ged pool quota of an object

On `ObpChargeQuotaForObject` function, the kernel will either charge the default object type charges or the specified information charges obtained from `ObCreateObject` API call. What happens is that if a paged pool charge is specified on `ObCreateObject` call the kernel will charge that
but when an object is about to be de-allocated, the amount of quota to return back to the system is the amounting of the paged pool charge specified previously by the **ObCreateObject** call plus the amounting of the security descriptor charge (see oblife.c / line 98).

This will result in a fatal crash with a bugcheck of **QUOTA_UNDERFLOW** because we are returning quota with bits of it that was never charged and that's `SecurityDescriptorCharge`. A **QUOTA_UNDERFLOW** bugcheck occurs in two following scenarios:

-- When installing Virtualbox Guest Additions and prompting the installer to reboot the system for you
-- When logging off and on back to the system and then you restart the system normally

This bug has been discovered whilst working on #4555 PR.