### PR TITLE
[FREELDR][SDK] Use "ReactOS Project" for consistency

### DIFF
--- a/boot/freeldr/freeldr/include/ver.h
+++ b/boot/freeldr/freeldr/include/ver.h
@@ -21,9 +21,9 @@
 
 /* Just some stuff */
 #define VERSION         "FreeLoader v3.0"
-#define COPYRIGHT       "Copyright (C) 1998-" COPYRIGHT_YEAR " ReactOS Team"
+#define COPYRIGHT       "Copyright (C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define AUTHOR_EMAIL    "<www.reactos.org>"
-#define BY_AUTHOR       "by ReactOS Team"
+#define BY_AUTHOR       "by ReactOS Project"
 
 // FreeLoader version defines
 //

--- a/sdk/include/reactos/version.rc
+++ b/sdk/include/reactos/version.rc
@@ -16,10 +16,10 @@
 #include "buildno.h"
 
 /* Define some defaults (shouldn't be overwritten by applications */
-#define REACTOS_DEFAULT_STR_COMPANY_NAME    "ReactOS Development Team"
+#define REACTOS_DEFAULT_STR_COMPANY_NAME    "ReactOS Project"
 #define REACTOS_DEFAULT_STR_DESCRIPTION     "ReactOS Core Component"
 #define REACTOS_DEFAULT_STR_INTERNAL_NAME   ""
-#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "Copyright 1998-" COPYRIGHT_YEAR " ReactOS Team"
+#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "Copyright 1998-" COPYRIGHT_YEAR " ReactOS Project"
 #define REACTOS_DEFAULT_STR_PRODUCT_NAME    "ReactOS Operating System"
 
 /* Set defaults for everything, unless overridden */

--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -58,8 +58,8 @@
 #endif /* WINE_OLESELFREGISTER */
 
 /* Credit the Wine team */
-#define REACTOS_STR_COMPANY_NAME "ReactOS Development Team/Wine Team\0"
-#define REACTOS_STR_LEGAL_COPYRIGHT "Copyright 1998-" COPYRIGHT_YEAR " ReactOS Team, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
+#define REACTOS_STR_COMPANY_NAME "ReactOS Project/Wine Team\0"
+#define REACTOS_STR_LEGAL_COPYRIGHT "Copyright 1998-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
 #define REACTOS_STR_ORIGINAL_COPYRIGHT "Copyright (c) 1993-" COPYRIGHT_YEAR " the Wine project authors " \
                                        "(see the file AUTHORS for a complete list)"
 


### PR DESCRIPTION
Follow up of Colin's idea to use "ReactOS Project" consistently everywhere. This fixes PE version inconsistency that I mentioned in [CORE-18191](https://jira.reactos.org/browse/CORE-18191).

![VirtualBox_ReactOS_27_06_2022_17_24_37](https://user-images.githubusercontent.com/578406/175965429-8f3e2c0a-6c8a-4d3f-9f8f-92301cee8b90.png)

There are some files which also have "ReactOS Development Team", but I doubt whether to update them:
- [drivers/storage/ide/uniata/idedma.rc](https://github.com/reactos/reactos/blob/bbccad0ed60d619e49eb6e5d4e85cf9e0d932e2e/drivers/storage/ide/uniata/idedma.rc#L10)
- [sdk/lib/3rdparty/freetype/freetype.rc](https://github.com/reactos/reactos/blob/bbccad0ed60d619e49eb6e5d4e85cf9e0d932e2e/sdk/lib/3rdparty/freetype/freetype.rc#L5)
- [win32ss/drivers/font/ftfd/freetype.rc](https://github.com/reactos/reactos/blob/bbccad0ed60d619e49eb6e5d4e85cf9e0d932e2e/win32ss/drivers/font/ftfd/freetype.rc#L5)