### PR TITLE
Fix ExGetCurrentProcessorCounts

### DIFF
--- a/drivers/network/ndis/include/ndissys.h
+++ b/drivers/network/ndis/include/ndissys.h
@@ -45,8 +45,8 @@
 VOID
 NTAPI
 ExGetCurrentProcessorCounts(
-   PULONG ThreadKernelTime,
-   PULONG TotalCpuTime,
+   PULONG IdleTime,
+   PULONG KernelAndUserTime,
    PULONG ProcessorNumber);
 
 VOID

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -342,17 +342,17 @@ ExGetCurrentProcessorCpuUsage(PULONG CpuUsage)
  */
 VOID
 NTAPI
-ExGetCurrentProcessorCounts(PULONG ThreadKernelTime,
-                            PULONG TotalCpuTime,
+ExGetCurrentProcessorCounts(PULONG IdleTime,
+                            PULONG KernelAndUserTime,
                             PULONG ProcessorNumber)
 {
     PKPRCB Prcb;
 
     Prcb = KeGetCurrentPrcb();
 
-    *ThreadKernelTime = Prcb->KernelTime + Prcb->UserTime;
-    *TotalCpuTime = Prcb->CurrentThread->KernelTime;
-    *ProcessorNumber = KeGetCurrentProcessorNumber();
+    *IdleTime = Prcb->IdleThread->KernelTime;
+    *KernelAndUserTime = Prcb->KernelTime + Prcb->UserTime;
+    *ProcessorNumber = (ULONG)Prcb->Number;
 }
 
 /*


### PR DESCRIPTION
Fix values written to ThreadKernelTime and TotalCpuTime being swapped.