### PR TITLE
[WIN32K:DIB] USE_DIBLIB: Use new DIB_16BPP_AlphaBlend()

### DIFF
--- a/win32ss/gdi/dib/alphablend.c
+++ b/win32ss/gdi/dib/alphablend.c
@@ -43,7 +43,7 @@ DIB_XXBPP_AlphaBlend(SURFOBJ* Dest, SURFOBJ* Source, RECTL* DestRect,
   EXLATEOBJ exloSrcRGB, exloDstRGB, exloRGBSrc;
   PFN_DIB_PutPixel pfnDibPutPixel = DibFunctionsForBitmapFormat[Dest->iBitmapFormat].DIB_PutPixel;
 
-  DPRINT("DIB_16BPP_AlphaBlend: srcRect: (%d,%d)-(%d,%d), dstRect: (%d,%d)-(%d,%d)\n",
+  DPRINT("DIB_XXBPP_AlphaBlend: srcRect: (%d,%d)-(%d,%d), dstRect: (%d,%d)-(%d,%d)\n",
     SourceRect->left, SourceRect->top, SourceRect->right, SourceRect->bottom,
     DestRect->left, DestRect->top, DestRect->right, DestRect->bottom);
 

--- a/win32ss/gdi/dib/dib_new.c
+++ b/win32ss/gdi/dib/dib_new.c
@@ -51,7 +51,7 @@ DIB_FUNCTIONS DibFunctionsForBitmapFormat[] =
   {
     DIB_16BPP_PutPixel, DIB_16BPP_GetPixel, DIB_16BPP_HLine, DIB_16BPP_VLine,
     0, 0, DIB_XXBPP_StretchBlt,
-    DIB_16BPP_TransparentBlt, 0, DIB_XXBPP_AlphaBlend
+    DIB_16BPP_TransparentBlt, 0, DIB_16BPP_AlphaBlend
   },
   /* BMF_24BPP */
   {


### PR DESCRIPTION
Match/Use `DIB_16BPP_AlphaBlend` and `DIB_XXBPP_AlphaBlend` where they apply.

- TestKVM x86: https://reactos.org/testman/compare.php?ids=101186,101194,101196,101203
- Test KVM x64: https://reactos.org/testman/compare.php?ids=101188,101195,101197,101204