### PR TITLE
[NTOSKRNL] Fix a bug in MiDeleteVirtualAddresses

### DIFF
--- a/ntoskrnl/mm/ARM3/virtual.c
+++ b/ntoskrnl/mm/ARM3/virtual.c
@@ -714,10 +714,15 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
                 if (MiDecrementPageTableReferences((PVOID)Va) == 0)
                 {
                     ASSERT(PointerPde->u.Long != 0);
+
                     /* Delete the PDE proper */
                     MiDeletePde(PointerPde, CurrentProcess);
-                    /* Jump */
+
+                    /* Continue with the next PDE */
                     Va = (ULONG_PTR)MiPdeToAddress(PointerPde + 1);
+
+                    /* Use this to detect address gaps */
+                    PointerPte++;
                     break;
                 }
             }
@@ -733,8 +738,8 @@ MiDeleteVirtualAddresses(IN ULONG_PTR Va,
 
         if (Va > EndingAddress) return;
 
-        /* Otherwise, we exited because we hit a new PDE boundary, so start over */
-        AddressGap = FALSE;
+        /* Check if we exited the loop regularly */
+        AddressGap = (PointerPte != MiAddressToPte(Va));
     }
 }
 


### PR DESCRIPTION
When a PDE gets empty, we skip the address to the next PDE boundary, which might introduce an AddressGap, which wasn't handled before.
