### PR TITLE
mmsys.cpl diverse fixes

### DIFF
--- a/dll/cpl/mmsys/audio.c
+++ b/dll/cpl/mmsys/audio.c
@@ -26,15 +26,15 @@ VOID
 InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
 {
     WAVEOUTCAPSW waveOutputPaps;
-    WAVEINCAPS waveInputPaps;
-    MIDIOUTCAPS midiOutCaps;
-    TCHAR szNoDevices[256];
+    WAVEINCAPSW waveInputPaps;
+    MIDIOUTCAPSW midiOutCaps;
+    WCHAR szNoDevices[256];
     UINT DevsNum;
     UINT uIndex;
     HWND hCB;
     LRESULT Res;
 
-    LoadString(hApplet, IDS_NO_DEVICES, szNoDevices, _countof(szNoDevices));
+    LoadStringW(hApplet, IDS_NO_DEVICES, szNoDevices, _countof(szNoDevices));
 
     // Init sound playback devices list
     hCB = GetDlgItem(hwnd, IDC_DEVICE_PLAY_LIST);
@@ -42,8 +42,8 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     DevsNum = waveOutGetNumDevs();
     if (DevsNum < 1)
     {
-        Res = SendMessage(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
         pGlobalData->bNoAudioOut = TRUE;
     }
     else
@@ -69,12 +69,12 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
 
             if (CB_ERR != Res)
             {
-                SendMessage(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
                 if (!wcsicmp(waveOutputPaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
     }
 
     // Init sound recording devices list
@@ -83,8 +83,8 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     DevsNum = waveInGetNumDevs();
     if (DevsNum < 1)
     {
-        Res = SendMessage(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
         pGlobalData->bNoAudioIn = TRUE;
     }
     else
@@ -104,19 +104,19 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
 
         for (uIndex = 0; uIndex < DevsNum; uIndex++)
         {
-            if (waveInGetDevCaps(uIndex, &waveInputPaps, sizeof(waveInputPaps)))
+            if (waveInGetDevCapsW(uIndex, &waveInputPaps, sizeof(waveInputPaps)))
                 continue;
 
-            Res = SendMessage(hCB, CB_ADDSTRING, 0, (LPARAM) waveInputPaps.szPname);
+            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM) waveInputPaps.szPname);
 
             if (CB_ERR != Res)
             {
-                SendMessage(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
                 if (!wcsicmp(waveInputPaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
     }
 
     // Init MIDI devices list
@@ -125,8 +125,8 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     DevsNum = midiOutGetNumDevs();
     if (DevsNum < 1)
     {
-        Res = SendMessage(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
         pGlobalData->bNoMIDIOut = TRUE;
     }
     else
@@ -145,19 +145,19 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
 
         for (uIndex = 0; uIndex < DevsNum; uIndex++)
         {
-            if (midiOutGetDevCaps(uIndex, &midiOutCaps, sizeof(midiOutCaps)))
+            if (midiOutGetDevCapsW(uIndex, &midiOutCaps, sizeof(midiOutCaps)))
                 continue;
 
-            Res = SendMessage(hCB, CB_ADDSTRING, 0, (LPARAM) midiOutCaps.szPname);
+            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM) midiOutCaps.szPname);
 
             if (CB_ERR != Res)
             {
-                SendMessage(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
                 if (!wcsicmp(midiOutCaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessage(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
     }
 }
 
@@ -165,7 +165,7 @@ VOID
 UpdateRegistryString(HWND hwnd, INT ctrl, LPWSTR key, LPWSTR value)
 {
     HWND hwndCombo = GetDlgItem(hwnd, ctrl);
-    INT CurSel = SendMessage(hwndCombo, CB_GETCURSEL, 0, 0);
+    INT CurSel = SendMessageW(hwndCombo, CB_GETCURSEL, 0, 0);
     UINT TextLen;
     WCHAR SelectedDevice[MAX_PATH] = {0};
     HKEY hKey;
@@ -221,12 +221,12 @@ GetDevNum(HWND hControl, DWORD Id)
     int iCurSel;
     UINT DevNum;
 
-    iCurSel = SendMessage(hControl, CB_GETCURSEL, 0, 0);
+    iCurSel = SendMessageW(hControl, CB_GETCURSEL, 0, 0);
 
     if (iCurSel == CB_ERR)
         return 0;
 
-    DevNum = (UINT) SendMessage(hControl, CB_GETITEMDATA, iCurSel, 0);
+    DevNum = (UINT) SendMessageW(hControl, CB_GETITEMDATA, iCurSel, 0);
     if (DevNum == (UINT) CB_ERR)
         return 0;
 
@@ -245,7 +245,7 @@ AudioDlgProc(HWND hwndDlg,
 {
     PGLOBAL_DATA pGlobalData;
 
-    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
+    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
     switch(uMsg)
     {
@@ -254,7 +254,7 @@ AudioDlgProc(HWND hwndDlg,
             UINT NumWavOut = waveOutGetNumDevs();
 
             pGlobalData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
-            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
+            SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
 
             if (!pGlobalData)
                 break;
@@ -319,7 +319,7 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcess(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
                 }
                 break;
 
@@ -339,7 +339,7 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcess(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
                 }
                 break;
 
@@ -359,7 +359,7 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcess(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
                 }
                 break;
 

--- a/dll/cpl/mmsys/audio.c
+++ b/dll/cpl/mmsys/audio.c
@@ -43,7 +43,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     if (DevsNum < 1)
     {
         Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)Res, 0);
         pGlobalData->bNoAudioOut = TRUE;
     }
     else
@@ -56,7 +56,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
         if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Multimedia\\Sound Mapper", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
         {
             RegQueryValueExW(hKey, L"Playback", NULL, NULL, (LPBYTE)DefaultDevice, &dwSize);
-            DefaultDevice[MAX_PATH-1] = L'\0';
+            DefaultDevice[_countof(DefaultDevice) - 1] = UNICODE_NULL;
             RegCloseKey(hKey);
         }
 
@@ -65,16 +65,16 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
             if (waveOutGetDevCapsW(uIndex, &waveOutputPaps, sizeof(waveOutputPaps)))
                 continue;
 
-            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM) waveOutputPaps.szPname);
+            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)waveOutputPaps.szPname);
 
             if (CB_ERR != Res)
             {
-                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
-                if (!wcsicmp(waveOutputPaps.szPname, DefaultDevice))
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM)uIndex);
+                if (!_wcsicmp(waveOutputPaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)DefaultIndex, 0);
     }
 
     // Init sound recording devices list
@@ -84,7 +84,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     if (DevsNum < 1)
     {
         Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)Res, 0);
         pGlobalData->bNoAudioIn = TRUE;
     }
     else
@@ -97,7 +97,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
         if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Multimedia\\Sound Mapper", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
         {
             RegQueryValueExW(hKey, L"Record", NULL, NULL, (LPBYTE)DefaultDevice, &dwSize);
-            DefaultDevice[MAX_PATH-1] = L'\0';
+            DefaultDevice[_countof(DefaultDevice) - 1] = UNICODE_NULL;
             RegCloseKey(hKey);
         }
 
@@ -107,16 +107,16 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
             if (waveInGetDevCapsW(uIndex, &waveInputPaps, sizeof(waveInputPaps)))
                 continue;
 
-            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM) waveInputPaps.szPname);
+            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)waveInputPaps.szPname);
 
             if (CB_ERR != Res)
             {
-                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
-                if (!wcsicmp(waveInputPaps.szPname, DefaultDevice))
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM)uIndex);
+                if (!_wcsicmp(waveInputPaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)DefaultIndex, 0);
     }
 
     // Init MIDI devices list
@@ -126,7 +126,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
     if (DevsNum < 1)
     {
         Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)szNoDevices);
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) Res, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)Res, 0);
         pGlobalData->bNoMIDIOut = TRUE;
     }
     else
@@ -139,7 +139,7 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
         if (RegOpenKeyExW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Multimedia\\MIDIMap", 0, KEY_READ, &hKey) == ERROR_SUCCESS)
         {
             RegQueryValueExW(hKey, L"szPname", NULL, NULL, (LPBYTE)DefaultDevice, &dwSize);
-            DefaultDevice[MAX_PATH-1] = L'\0';
+            DefaultDevice[_countof(DefaultDevice) - 1] = UNICODE_NULL;
             RegCloseKey(hKey);
         }
 
@@ -148,16 +148,16 @@ InitAudioDlg(HWND hwnd, PGLOBAL_DATA pGlobalData)
             if (midiOutGetDevCapsW(uIndex, &midiOutCaps, sizeof(midiOutCaps)))
                 continue;
 
-            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM) midiOutCaps.szPname);
+            Res = SendMessageW(hCB, CB_ADDSTRING, 0, (LPARAM)midiOutCaps.szPname);
 
             if (CB_ERR != Res)
             {
-                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM) uIndex);
-                if (!wcsicmp(midiOutCaps.szPname, DefaultDevice))
+                SendMessageW(hCB, CB_SETITEMDATA, Res, (LPARAM)uIndex);
+                if (!_wcsicmp(midiOutCaps.szPname, DefaultDevice))
                     DefaultIndex = Res;
             }
         }
-        SendMessageW(hCB, CB_SETCURSEL, (WPARAM) DefaultIndex, 0);
+        SendMessageW(hCB, CB_SETCURSEL, (WPARAM)DefaultIndex, 0);
     }
 }
 
@@ -183,7 +183,7 @@ UpdateRegistryString(HWND hwnd, INT ctrl, LPWSTR key, LPWSTR value)
     if (RegCreateKeyExW(HKEY_CURRENT_USER, key, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_WRITE, NULL, &hKey, NULL) != ERROR_SUCCESS)
         return;
 
-    RegSetValueExW(hKey, value, 0, REG_SZ, (BYTE *)SelectedDevice, (wcslen(SelectedDevice) + 1) * sizeof(WCHAR));
+    RegSetValueExW(hKey, value, 0, REG_SZ, (BYTE*)SelectedDevice, (wcslen(SelectedDevice) + 1) * sizeof(WCHAR));
     RegCloseKey(hKey);
 }
 
@@ -226,7 +226,7 @@ GetDevNum(HWND hControl, DWORD Id)
     if (iCurSel == CB_ERR)
         return 0;
 
-    DevNum = (UINT) SendMessageW(hControl, CB_GETITEMDATA, iCurSel, 0);
+    DevNum = (UINT)SendMessageW(hControl, CB_GETITEMDATA, iCurSel, 0);
     if (DevNum == (UINT) CB_ERR)
         return 0;
 
@@ -247,7 +247,7 @@ AudioDlgProc(HWND hwndDlg,
 
     pGlobalData = (PGLOBAL_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
-    switch(uMsg)
+    switch (uMsg)
     {
         case WM_INITDIALOG:
         {
@@ -300,14 +300,14 @@ AudioDlgProc(HWND hwndDlg,
 
         case WM_COMMAND:
         {
-            STARTUPINFO si;
+            STARTUPINFOW si;
             PROCESS_INFORMATION pi;
             WCHAR szPath[MAX_PATH];
 
             if (!pGlobalData)
                 break;
 
-            switch(LOWORD(wParam))
+            switch (LOWORD(wParam))
             {
                 case IDC_VOLUME1_BTN:
                 {

--- a/dll/cpl/mmsys/audio.c
+++ b/dll/cpl/mmsys/audio.c
@@ -319,7 +319,11 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    if (CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+                    {
+                        CloseHandle(pi.hProcess);
+                        CloseHandle(pi.hThread);
+                    }
                 }
                 break;
 
@@ -339,7 +343,11 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    if (CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+                    {
+                        CloseHandle(pi.hProcess);
+                        CloseHandle(pi.hThread);
+                    }
                 }
                 break;
 
@@ -359,7 +367,11 @@ AudioDlgProc(HWND hwndDlg,
                     si.dwFlags = STARTF_USESHOWWINDOW;
                     si.wShowWindow = SW_SHOW;
 
-                    CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+                    if (CreateProcessW(NULL, szPath, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi))
+                    {
+                        CloseHandle(pi.hProcess);
+                        CloseHandle(pi.hThread);
+                    }
                 }
                 break;
 

--- a/dll/cpl/mmsys/audio.c
+++ b/dll/cpl/mmsys/audio.c
@@ -311,8 +311,8 @@ AudioDlgProc(HWND hwndDlg,
             {
                 case IDC_VOLUME1_BTN:
                 {
-                    wsprintf(szPath, L"sndvol32.exe -d %d",
-                             GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_PLAY_LIST), MIXER_OBJECTF_WAVEOUT));
+                    StringCchPrintfW(szPath, _countof(szPath), L"sndvol32.exe -d %d",
+                                     GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_PLAY_LIST), MIXER_OBJECTF_WAVEOUT));
 
                     ZeroMemory(&si, sizeof(si));
                     si.cb = sizeof(si);
@@ -331,8 +331,8 @@ AudioDlgProc(HWND hwndDlg,
 
                 case IDC_VOLUME2_BTN:
                 {
-                    wsprintf(szPath, L"sndvol32.exe -r -d %d",
-                             GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_REC_LIST), MIXER_OBJECTF_WAVEIN));
+                    StringCchPrintfW(szPath, _countof(szPath), L"sndvol32.exe -r -d %d",
+                                     GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_REC_LIST), MIXER_OBJECTF_WAVEIN));
 
                     ZeroMemory(&si, sizeof(si));
                     si.cb = sizeof(si);
@@ -351,8 +351,8 @@ AudioDlgProc(HWND hwndDlg,
 
                 case IDC_VOLUME3_BTN:
                 {
-                    wsprintf(szPath, L"sndvol32.exe -d %d",
-                             GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_MIDI_LIST), MIXER_OBJECTF_MIDIOUT));
+                    StringCchPrintfW(szPath, _countof(szPath), L"sndvol32.exe -d %d",
+                                     GetDevNum(GetDlgItem(hwndDlg, IDC_DEVICE_MIDI_LIST), MIXER_OBJECTF_MIDIOUT));
 
                     ZeroMemory(&si, sizeof(si));
                     si.cb = sizeof(si);

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -89,11 +89,11 @@ DeviceCreateHardwarePageEx(HWND hWndParent,
                            UINT uNumberOfGuids,
                            HWPAGE_DISPLAYMODE DisplayMode);
 
-typedef BOOL (WINAPI *UpdateDriverForPlugAndPlayDevicesProto)(IN OPTIONAL HWND hwndParent,
-                                                              IN LPCWSTR HardwareId,
-                                                              IN LPCWSTR FullInfPath,
-                                                              IN DWORD InstallFlags,
-                                                              OUT OPTIONAL PBOOL bRebootRequired);
+typedef BOOL (WINAPI *UpdateDriverForPlugAndPlayDevicesProto)(_In_opt_ HWND hwndParent,
+                                                              _In_ LPCWSTR HardwareId,
+                                                              _In_ LPCWSTR FullInfPath,
+                                                              _In_ DWORD InstallFlags,
+                                                              _Out_opt_ PBOOL bRebootRequired);
 
 #define UPDATEDRIVERFORPLUGANDPLAYDEVICES "UpdateDriverForPlugAndPlayDevicesW"
 #define NUM_APPLETS    (1)
@@ -459,7 +459,7 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
         return ERROR_DI_DO_DEFAULT;
 
     Length = GetWindowsDirectoryW(szBuffer, _countof(szBuffer));
-    if (!Length || Length >= _countof(szBuffer) - 14)
+    if (!Length || Length >= _countof(szBuffer) - CONST_STR_LEN(L"\\inf\\audio.inf"))
     {
         return ERROR_GEN_FAILURE;
     }
@@ -509,7 +509,7 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
     if (!IsSoftwareBusPnpEnumeratorInstalled())
     {
         Length = GetWindowsDirectoryW(szBuffer, _countof(szBuffer));
-        if (!Length || Length >= _countof(szBuffer) - 16)
+        if (!Length || Length >= _countof(szBuffer) - CONST_STR_LEN(L"\\inf\\machine.inf"))
         {
             return ERROR_GEN_FAILURE;
         }
@@ -540,7 +540,7 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32", 0, KEY_READ | KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
         Length = GetSystemDirectoryW(szBuffer, _countof(szBuffer));
-        if (!Length || Length >= _countof(szBuffer) - 11)
+        if (!Length || Length >= _countof(szBuffer) - CONST_STR_LEN(L"\\wdmaud.drv"))
         {
             RegCloseKey(hKey);
             return ERROR_DI_DO_DEFAULT;
@@ -648,6 +648,7 @@ HardwareDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
+    
     switch (uMsg)
     {
         case WM_INITDIALOG:
@@ -845,6 +846,7 @@ DllMain(HINSTANCE hinstDLL,
         LPVOID lpReserved)
 {
     UNREFERENCED_PARAMETER(lpReserved);
+    
     switch (dwReason)
     {
         case DLL_PROCESS_ATTACH:

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -649,7 +649,6 @@ HardwareDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
-    
     switch (uMsg)
     {
         case WM_INITDIALOG:
@@ -847,7 +846,6 @@ DllMain(HINSTANCE hinstDLL,
         LPVOID lpReserved)
 {
     UNREFERENCED_PARAMETER(lpReserved);
-    
     switch (dwReason)
     {
         case DLL_PROCESS_ATTACH:

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -33,14 +33,14 @@ typedef struct
     LPWSTR DefaultName;
     UINT LocalizedResId;
     LPWSTR FileName;
-}EVENT_LABEL_ITEM;
+} EVENT_LABEL_ITEM;
 
 typedef struct
 {
     LPWSTR LabelName;
     LPWSTR DefaultName;
     UINT IconId;
-}SYSTEM_SCHEME_ITEM;
+} SYSTEM_SCHEME_ITEM;
 
 static EVENT_LABEL_ITEM EventLabels[] =
 {
@@ -93,8 +93,7 @@ typedef BOOL (WINAPI *UpdateDriverForPlugAndPlayDevicesProto)(IN OPTIONAL HWND h
                                                               IN LPCWSTR HardwareId,
                                                               IN LPCWSTR FullInfPath,
                                                               IN DWORD InstallFlags,
-                                                              OUT OPTIONAL PBOOL bRebootRequired
-                                                         );
+                                                              OUT OPTIONAL PBOOL bRebootRequired);
 
 #define UPDATEDRIVERFORPLUGANDPLAYDEVICES "UpdateDriverForPlugAndPlayDevicesW"
 #define NUM_APPLETS    (1)
@@ -105,7 +104,7 @@ HINSTANCE hApplet = 0;
 /* Applets */
 const APPLET Applets[NUM_APPLETS] =
 {
-  {IDI_CPLICON, IDS_CPLNAME, IDS_CPLDESCRIPTION, MmSysApplet},
+    {IDI_CPLICON, IDS_CPLNAME, IDS_CPLDESCRIPTION, MmSysApplet},
 };
 
 
@@ -208,16 +207,16 @@ InstallSystemSoundLabels(HKEY hKey)
 
     do
     {
-        if (RegCreateKeyExW(hKey, EventLabels[i].LabelName,  0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
+        if (RegCreateKeyExW(hKey, EventLabels[i].LabelName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
         {
-            RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)EventLabels[i].DefaultName, (wcslen(EventLabels[i].DefaultName)+1) * sizeof(WCHAR));
+            RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)EventLabels[i].DefaultName, (wcslen(EventLabels[i].DefaultName) + 1) * sizeof(WCHAR));
             swprintf(Buffer, L"@mmsys.cpl,-%u", EventLabels[i].LocalizedResId);
-            RegSetValueExW(hSubKey, L"DispFileName", 0, REG_SZ, (LPBYTE)Buffer, (wcslen(Buffer)+1) * sizeof(WCHAR));
+            RegSetValueExW(hSubKey, L"DispFileName", 0, REG_SZ, (LPBYTE)Buffer, (wcslen(Buffer) + 1) * sizeof(WCHAR));
 
             RegCloseKey(hSubKey);
         }
         i++;
-    }while(EventLabels[i].LabelName);
+    } while (EventLabels[i].LabelName);
 }
 
 VOID
@@ -228,13 +227,13 @@ InstallSystemSoundSchemeNames(HKEY hKey)
 
     do
     {
-        if (RegCreateKeyExW(hKey, SystemSchemes[i].LabelName,  0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
+        if (RegCreateKeyExW(hKey, SystemSchemes[i].LabelName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
         {
-            RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)SystemSchemes[i].DefaultName, (wcslen(SystemSchemes[i].DefaultName)+1) * sizeof(WCHAR));
+            RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)SystemSchemes[i].DefaultName, (wcslen(SystemSchemes[i].DefaultName) + 1) * sizeof(WCHAR));
             RegCloseKey(hSubKey);
         }
         i++;
-    }while(SystemSchemes[i].LabelName);
+    } while (SystemSchemes[i].LabelName);
 }
 
 VOID
@@ -247,39 +246,39 @@ InstallDefaultSystemSoundScheme(HKEY hRootKey)
     if (RegCreateKeyExW(hRootKey, L".Default", 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hKey, NULL) != ERROR_SUCCESS)
         return;
 
-    RegSetValueExW(hKey, NULL, 0, REG_SZ, (LPBYTE)SystemSchemes[0].DefaultName, (wcslen(SystemSchemes[0].DefaultName)+1) * sizeof(WCHAR));
+    RegSetValueExW(hKey, NULL, 0, REG_SZ, (LPBYTE)SystemSchemes[0].DefaultName, (wcslen(SystemSchemes[0].DefaultName) + 1) * sizeof(WCHAR));
     swprintf(Path, L"@mmsys.cpl,-%u", SystemSchemes[0].IconId);
-    RegSetValueExW(hKey, L"DispFileName", 0, REG_SZ, (LPBYTE)Path, (wcslen(Path)+1) * sizeof(WCHAR));
+    RegSetValueExW(hKey, L"DispFileName", 0, REG_SZ, (LPBYTE)Path, (wcslen(Path) + 1) * sizeof(WCHAR));
 
     do
     {
-        if (RegCreateKeyExW(hKey, EventLabels[i].LabelName,  0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
+        if (RegCreateKeyExW(hKey, EventLabels[i].LabelName, 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hSubKey, NULL) == ERROR_SUCCESS)
         {
             HKEY hScheme;
 
             swprintf(Path, L"%%SystemRoot%%\\media\\%s", EventLabels[i].FileName);
-            if (RegCreateKeyExW(hSubKey, L".Current",  0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hScheme, NULL) == ERROR_SUCCESS)
+            if (RegCreateKeyExW(hSubKey, L".Current", 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hScheme, NULL) == ERROR_SUCCESS)
             {
-                RegSetValueExW(hScheme, NULL, 0, REG_EXPAND_SZ, (LPBYTE)Path, (wcslen(Path)+1) * sizeof(WCHAR));
+                RegSetValueExW(hScheme, NULL, 0, REG_EXPAND_SZ, (LPBYTE)Path, (wcslen(Path) + 1) * sizeof(WCHAR));
                 RegCloseKey(hScheme);
             }
 
-            if (RegCreateKeyExW(hSubKey, L".Default",  0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hScheme, NULL) == ERROR_SUCCESS)
+            if (RegCreateKeyExW(hSubKey, L".Default", 0, NULL, REG_OPTION_NON_VOLATILE, KEY_ALL_ACCESS, NULL, &hScheme, NULL) == ERROR_SUCCESS)
             {
-                RegSetValueExW(hScheme, NULL, 0, REG_EXPAND_SZ, (LPBYTE)Path, (wcslen(Path)+1) * sizeof(WCHAR));
+                RegSetValueExW(hScheme, NULL, 0, REG_EXPAND_SZ, (LPBYTE)Path, (wcslen(Path) + 1) * sizeof(WCHAR));
                 RegCloseKey(hScheme);
             }
             RegCloseKey(hSubKey);
         }
         i++;
-    }while(EventLabels[i].LabelName);
+    } while (EventLabels[i].LabelName);
 
     RegCloseKey(hKey);
 }
 
 
 VOID
-InstallSystemSoundScheme()
+InstallSystemSoundScheme(VOID)
 {
     HKEY hKey, hSubKey;
     DWORD dwDisposition;
@@ -310,7 +309,7 @@ InstallSystemSoundScheme()
             if (dwDisposition & REG_CREATED_NEW_KEY)
             {
                 // FIXME
-                RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)L".Default", (wcslen(L".Default")+1) * sizeof(WCHAR));
+                RegSetValueExW(hSubKey, NULL, 0, REG_SZ, (LPBYTE)L".Default", sizeof(L".Default"));
             }
         }
 
@@ -328,7 +327,7 @@ IsSoftwareBusPnpEnumeratorInstalled()
     GUID SWBusGuid = {STATIC_BUSID_SoftwareDeviceEnumerator};
     PSP_DEVICE_INTERFACE_DETAIL_DATA_W DeviceInterfaceDetailData;
 
-    hDevInfo = SetupDiGetClassDevsW(&SWBusGuid, NULL, NULL,  DIGCF_DEVICEINTERFACE| DIGCF_PRESENT);
+    hDevInfo = SetupDiGetClassDevsW(&SWBusGuid, NULL, NULL, DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);
     if (!hDevInfo)
     {
         // failed
@@ -343,7 +342,7 @@ IsSoftwareBusPnpEnumeratorInstalled()
         return FALSE;
     }
 
-    DeviceInterfaceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA_W)HeapAlloc(GetProcessHeap(), 0, MAX_PATH * sizeof(WCHAR) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W));
+    DeviceInterfaceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA_W)HeapAlloc(GetProcessHeap(), 0, (MAX_PATH * sizeof(WCHAR)) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W));
     if (!DeviceInterfaceDetailData)
     {
         // failed
@@ -352,7 +351,7 @@ IsSoftwareBusPnpEnumeratorInstalled()
     }
 
     DeviceInterfaceDetailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
-    if (!SetupDiGetDeviceInterfaceDetailW(hDevInfo,  &DeviceInterfaceData, DeviceInterfaceDetailData,MAX_PATH * sizeof(WCHAR) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W), NULL, NULL))
+    if (!SetupDiGetDeviceInterfaceDetailW(hDevInfo, &DeviceInterfaceData, DeviceInterfaceDetailData, (MAX_PATH * sizeof(WCHAR)) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W), NULL, NULL))
     {
         // failed
         HeapFree(GetProcessHeap(), 0, DeviceInterfaceDetailData);
@@ -377,25 +376,25 @@ InstallSoftwareBusPnpEnumerator(LPWSTR InfPath, LPCWSTR HardwareIdList)
     BOOL reboot = FALSE;
     DWORD flags = 0;
 
-    if (!SetupDiGetINFClassW(InfPath,&ClassGUID,ClassName,sizeof(ClassName)/sizeof(ClassName[0]),0))
+    if (!SetupDiGetINFClassW(InfPath, &ClassGUID, ClassName, _countof(ClassName), NULL))
     {
         return -1;
     }
 
-    DeviceInfoSet = SetupDiCreateDeviceInfoList(&ClassGUID,0);
-    if(DeviceInfoSet == INVALID_HANDLE_VALUE)
+    DeviceInfoSet = SetupDiCreateDeviceInfoList(&ClassGUID, NULL);
+    if (DeviceInfoSet == INVALID_HANDLE_VALUE)
     {
         return -1;
     }
 
     DeviceInfoData.cbSize = sizeof(SP_DEVINFO_DATA);
-    if (!SetupDiCreateDeviceInfoW(DeviceInfoSet, ClassName, &ClassGUID, NULL, 0, DICD_GENERATE_ID, &DeviceInfoData))
+    if (!SetupDiCreateDeviceInfoW(DeviceInfoSet, ClassName, &ClassGUID, NULL, NULL, DICD_GENERATE_ID, &DeviceInfoData))
     {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         return -1;
     }
 
-    if(!SetupDiSetDeviceRegistryPropertyW(DeviceInfoSet, &DeviceInfoData, SPDRP_HARDWAREID, (LPBYTE)HardwareIdList, (wcslen(HardwareIdList)+1+1)*sizeof(WCHAR)))
+    if (!SetupDiSetDeviceRegistryPropertyW(DeviceInfoSet, &DeviceInfoData, SPDRP_HARDWAREID, (LPBYTE)HardwareIdList, (wcslen(HardwareIdList) + 1 + 1) * sizeof(WCHAR)))
     {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         return -1;
@@ -407,27 +406,29 @@ InstallSoftwareBusPnpEnumerator(LPWSTR InfPath, LPCWSTR HardwareIdList)
         return -1;
     }
 
-    if(GetFileAttributesW(InfPath)==(DWORD)(-1)) {
+    if (GetFileAttributesW(InfPath) == INVALID_FILE_ATTRIBUTES)
+    {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         return -1;
     }
 
     flags |= INSTALLFLAG_FORCE;
     hModule = LoadLibraryW(L"newdev.dll");
-    if(!hModule) {
+    if (!hModule)
+    {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         return -1;
     }
 
-    UpdateProc = (UpdateDriverForPlugAndPlayDevicesProto)GetProcAddress(hModule,UPDATEDRIVERFORPLUGANDPLAYDEVICES);
-    if(!UpdateProc)
+    UpdateProc = (UpdateDriverForPlugAndPlayDevicesProto)GetProcAddress(hModule, UPDATEDRIVERFORPLUGANDPLAYDEVICES);
+    if (!UpdateProc)
     {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         FreeLibrary(hModule);
         return -1;
     }
 
-    if(!UpdateProc(NULL, HardwareIdList, InfPath, flags, &reboot))
+    if (!UpdateProc(NULL, HardwareIdList, InfPath, flags, &reboot))
     {
         SetupDiDestroyDeviceInfoList(DeviceInfoSet);
         FreeLibrary(hModule);
@@ -458,8 +459,8 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
         !IsEqualIID(&pspDevInfoData->ClassGuid, &GUID_DEVCLASS_MEDIA))
         return ERROR_DI_DO_DEFAULT;
 
-    Length = GetWindowsDirectoryW(szBuffer, MAX_PATH);
-    if (!Length || Length >= MAX_PATH - 14)
+    Length = GetWindowsDirectoryW(szBuffer, _countof(szBuffer));
+    if (!Length || Length >= _countof(szBuffer) - 14)
     {
         return ERROR_GEN_FAILURE;
     }
@@ -474,8 +475,8 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
 
     hInf = SetupOpenInfFileW(szBuffer,
                              NULL,
-                            INF_STYLE_WIN4,
-                            NULL);
+                             INF_STYLE_WIN4,
+                             NULL);
 
     if (hInf == INVALID_HANDLE_VALUE)
     {
@@ -513,8 +514,8 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
 
     if (!IsSoftwareBusPnpEnumeratorInstalled())
     {
-        Length = GetWindowsDirectoryW(szBuffer, MAX_PATH);
-        if (!Length || Length >= MAX_PATH - 14)
+        Length = GetWindowsDirectoryW(szBuffer, _countof(szBuffer));
+        if (!Length || Length >= _countof(szBuffer) - 14)
         {
             return ERROR_GEN_FAILURE;
         }
@@ -546,19 +547,19 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
     }
     CloseServiceHandle(hSCManager);
 
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32", 0, GENERIC_READ | GENERIC_WRITE, &hKey) == ERROR_SUCCESS)
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Drivers32", 0, KEY_READ | KEY_WRITE, &hKey) == ERROR_SUCCESS)
     {
-        szBuffer[Length] = '\0';
+        szBuffer[Length] = UNICODE_NULL;
         pBuffer = PathAddBackslashW(szBuffer);
         wcscpy(pBuffer, L"system32\\wdmaud.drv");
 
-        for(Index = 1; Index <= 4; Index++)
+        for (Index = 1; Index <= 4; Index++)
         {
             swprintf(WaveName, L"wave%u", Index);
             if (RegQueryValueExW(hKey, WaveName, 0, NULL, NULL, &BufferSize) != ERROR_MORE_DATA)
             {
                 /* Store new audio driver entry */
-                RegSetValueExW(hKey, WaveName, 0, REG_SZ, (LPBYTE)szBuffer, (wcslen(szBuffer)+1) * sizeof(WCHAR));
+                RegSetValueExW(hKey, WaveName, 0, REG_SZ, (LPBYTE)szBuffer, (wcslen(szBuffer) + 1) * sizeof(WCHAR));
                 break;
             }
             else
@@ -569,9 +570,9 @@ MMSYS_InstallDevice(HDEVINFO hDevInfo, PSP_DEVINFO_DATA pspDevInfoData)
                 if (RegQueryValueExW(hKey, WaveName, 0, NULL, (LPBYTE)Buffer, &BufferSize) == ERROR_SUCCESS)
                 {
                     /* Make sure the buffer is zero terminated */
-                    Buffer[MAX_PATH-1] = L'\0';
+                    Buffer[_countof(Buffer) - 1] = UNICODE_NULL;
 
-                    if (!wcsicmp(Buffer, szBuffer))
+                    if (!_wcsicmp(Buffer, szBuffer))
                     {
                         /* An entry already exists */
                         break;
@@ -651,7 +652,7 @@ HardwareDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
-    switch(uMsg)
+    switch (uMsg)
     {
         case WM_INITDIALOG:
         {
@@ -662,7 +663,7 @@ HardwareDlgProc(HWND hwndDlg,
             /* Create the hardware page */
             DeviceCreateHardwarePageEx(hwndDlg,
                                        Guids,
-                                       sizeof(Guids) / sizeof(Guids[0]),
+                                       _countof(Guids),
                                        HWPD_LARGELIST);
             break;
         }
@@ -698,9 +699,7 @@ MmSysApplet(HWND hwnd,
     PROPSHEETHEADERW psh; // = { 0 };
     INT nPage = 0;
 
-    UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
-    UNREFERENCED_PARAMETER(uMsg);
 
     if (uMsg == CPL_STARTWPARMSW && lParam != 0)
         nPage = _wtoi((PWSTR)lParam);
@@ -711,16 +710,16 @@ MmSysApplet(HWND hwnd,
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
     psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
-    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
+    psh.nPages = _countof(psp);
     psh.nStartPage = 0;
     psh.ppsp = psp;
     psh.pfnCallback = PropSheetProc;
 
-    InitPropSheetPage(&psp[0], IDD_VOLUME,VolumeDlgProc);
-    InitPropSheetPage(&psp[1], IDD_SOUNDS,SoundsDlgProc);
-    InitPropSheetPage(&psp[2], IDD_AUDIO,AudioDlgProc);
-    InitPropSheetPage(&psp[3], IDD_VOICE,VoiceDlgProc);
-    InitPropSheetPage(&psp[4], IDD_HARDWARE,HardwareDlgProc);
+    InitPropSheetPage(&psp[0], IDD_VOLUME, VolumeDlgProc);
+    InitPropSheetPage(&psp[1], IDD_SOUNDS, SoundsDlgProc);
+    InitPropSheetPage(&psp[2], IDD_AUDIO, AudioDlgProc);
+    InitPropSheetPage(&psp[3], IDD_VOICE, VoiceDlgProc);
+    InitPropSheetPage(&psp[4], IDD_HARDWARE, HardwareDlgProc);
 
     if (nPage != 0 && nPage <= psh.nPages)
         psh.nStartPage = nPage;
@@ -749,7 +748,7 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    switch(uMsg)
+    switch (uMsg)
     {
         case CPL_INIT:
             return TRUE;
@@ -798,12 +797,12 @@ ShowAudioPropertySheet(HWND hwnd,
     DPRINT("ShowAudioPropertySheet()\n");
 
     psh.dwSize = sizeof(PROPSHEETHEADERW);
-    psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
+    psh.dwFlags = PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hInstance;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
     psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
-    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
+    psh.nPages = _countof(psp);
     psh.nStartPage = 0;
     psh.ppsp = psp;
     psh.pfnCallback = PropSheetProc;
@@ -825,21 +824,21 @@ ShowFullControlPanel(HWND hwnd,
     DPRINT("ShowFullControlPanel()\n");
 
     psh.dwSize = sizeof(PROPSHEETHEADERW);
-    psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
+    psh.dwFlags = PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hInstance;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
     psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
-    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
+    psh.nPages = _countof(psp);
     psh.nStartPage = 0;
     psh.ppsp = psp;
     psh.pfnCallback = PropSheetProc;
 
-    InitPropSheetPage(&psp[0], IDD_VOLUME,VolumeDlgProc);
-    InitPropSheetPage(&psp[1], IDD_SOUNDS,SoundsDlgProc);
-    InitPropSheetPage(&psp[2], IDD_AUDIO,AudioDlgProc);
-    InitPropSheetPage(&psp[3], IDD_VOICE,VoiceDlgProc);
-    InitPropSheetPage(&psp[4], IDD_HARDWARE,HardwareDlgProc);
+    InitPropSheetPage(&psp[0], IDD_VOLUME, VolumeDlgProc);
+    InitPropSheetPage(&psp[1], IDD_SOUNDS, SoundsDlgProc);
+    InitPropSheetPage(&psp[2], IDD_AUDIO, AudioDlgProc);
+    InitPropSheetPage(&psp[3], IDD_VOICE, VoiceDlgProc);
+    InitPropSheetPage(&psp[4], IDD_HARDWARE, HardwareDlgProc);
 
     PropertySheetW(&psh);
 }
@@ -850,7 +849,7 @@ DllMain(HINSTANCE hinstDLL,
         LPVOID lpReserved)
 {
     UNREFERENCED_PARAMETER(lpReserved);
-    switch(dwReason)
+    switch (dwReason)
     {
         case DLL_PROCESS_ATTACH:
             hApplet = hinstDLL;

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -89,11 +89,12 @@ DeviceCreateHardwarePageEx(HWND hWndParent,
                            UINT uNumberOfGuids,
                            HWPAGE_DISPLAYMODE DisplayMode);
 
-typedef BOOL (WINAPI *UpdateDriverForPlugAndPlayDevicesProto)(_In_opt_ HWND hwndParent,
-                                                              _In_ LPCWSTR HardwareId,
-                                                              _In_ LPCWSTR FullInfPath,
-                                                              _In_ DWORD InstallFlags,
-                                                              _Out_opt_ PBOOL bRebootRequired);
+typedef BOOL (WINAPI *UpdateDriverForPlugAndPlayDevicesProto)(
+    _In_opt_ HWND hwndParent,
+    _In_ LPCWSTR HardwareId,
+    _In_ LPCWSTR FullInfPath,
+    _In_ DWORD InstallFlags,
+    _Out_opt_ PBOOL bRebootRequired);
 
 #define UPDATEDRIVERFORPLUGANDPLAYDEVICES "UpdateDriverForPlugAndPlayDevicesW"
 #define NUM_APPLETS    (1)

--- a/dll/cpl/mmsys/mmsys.h
+++ b/dll/cpl/mmsys/mmsys.h
@@ -14,7 +14,6 @@
 #include <winuser.h>
 #include <mmsystem.h>
 #include <cpl.h>
-#include <tchar.h>
 #include <setupapi.h>
 #include <stdlib.h>
 
@@ -46,7 +45,7 @@ extern HINSTANCE hApplet;
 
 VOID
 InitPropSheetPage(
-    PROPSHEETPAGE *psp,
+    PROPSHEETPAGEW *psp,
     WORD idDlg,
     DLGPROC DlgProc);
 

--- a/dll/cpl/mmsys/mmsys.h
+++ b/dll/cpl/mmsys/mmsys.h
@@ -23,18 +23,18 @@
 
 typedef struct _APPLET
 {
-  UINT idIcon;
-  UINT idName;
-  UINT idDescription;
-  APPLET_PROC AppletProc;
+    UINT idIcon;
+    UINT idName;
+    UINT idDescription;
+    APPLET_PROC AppletProc;
 } APPLET, *PAPPLET;
 
 extern HINSTANCE hApplet;
 
 
 #define DRVM_MAPPER 0x2000
-#define DRVM_MAPPER_PREFERRED_GET (DRVM_MAPPER+21)
-#define DRVM_MAPPER_PREFERRED_SET (DRVM_MAPPER+22)
+#define DRVM_MAPPER_PREFERRED_GET (DRVM_MAPPER + 21)
+#define DRVM_MAPPER_PREFERRED_SET (DRVM_MAPPER + 22)
 
 #define VOLUME_MIN        0
 #define VOLUME_MAX      500
@@ -60,17 +60,17 @@ MmSysApplet(HWND hwnd,
 INT_PTR
 CALLBACK
 SoundsDlgProc(HWND hwndDlg,
-	        UINT uMsg,
-	        WPARAM wParam,
-	        LPARAM lParam);
+	          UINT uMsg,
+	          WPARAM wParam,
+	          LPARAM lParam);
 
 /* volume.c */
 
 INT_PTR CALLBACK
 VolumeDlgProc(HWND hwndDlg,
-	        UINT uMsg,
-	        WPARAM wParam,
-	        LPARAM lParam);
+	          UINT uMsg,
+	          WPARAM wParam,
+	          LPARAM lParam);
 
 /* voice.c */
 

--- a/dll/cpl/mmsys/mmsys.h
+++ b/dll/cpl/mmsys/mmsys.h
@@ -20,6 +20,8 @@
 
 #include "resource.h"
 
+#define CONST_STR_LEN(str) (_countof(str) - 1)
+
 //typedef LONG (CALLBACK *APPLET_PROC)(VOID);
 
 typedef struct _APPLET
@@ -61,17 +63,17 @@ MmSysApplet(HWND hwnd,
 INT_PTR
 CALLBACK
 SoundsDlgProc(HWND hwndDlg,
-	          UINT uMsg,
-	          WPARAM wParam,
-	          LPARAM lParam);
+              UINT uMsg,
+              WPARAM wParam,
+              LPARAM lParam);
 
 /* volume.c */
 
 INT_PTR CALLBACK
 VolumeDlgProc(HWND hwndDlg,
-	          UINT uMsg,
-	          WPARAM wParam,
-	          LPARAM lParam);
+              UINT uMsg,
+              WPARAM wParam,
+              LPARAM lParam);
 
 /* voice.c */
 

--- a/dll/cpl/mmsys/mmsys.h
+++ b/dll/cpl/mmsys/mmsys.h
@@ -16,6 +16,7 @@
 #include <cpl.h>
 #include <setupapi.h>
 #include <stdlib.h>
+#include <strsafe.h>
 
 #include "resource.h"
 

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -892,7 +892,6 @@ FreeSoundFiles(HWND hwndDlg)
         }
 
         pSoundPath = (PWCHAR)lResult;
-        
         free(pSoundPath);
     }
 }

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -79,7 +79,7 @@ LPWSTR MakeFilter(LPWSTR psz)
     return psz;
 }
 
-PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, WCHAR * szName)
+PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, WCHAR *szName)
 {
     PLABEL_MAP pMap = pGlobalData->pLabelMap;
 
@@ -188,7 +188,7 @@ FreeAppMap(PGLOBAL_DATA pGlobalData)
     }
 }
 
-PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, WCHAR * AppName, WCHAR * LabelName)
+PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, WCHAR *AppName, WCHAR *LabelName)
 {
     PLABEL_CONTEXT pLabelContext;
 
@@ -214,7 +214,7 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
     pLabelContext->LabelMap = FindLabel(pGlobalData, pLabelContext->AppMap, LabelName);
     ASSERT(pLabelContext->AppMap);
     ASSERT(pLabelContext->LabelMap);
-    pLabelContext->szValue[0] = L'\0';
+    pLabelContext->szValue[0] = UNICODE_NULL;
     pLabelContext->Next = pSoundScheme->LabelContext;
     pSoundScheme->LabelContext = pLabelContext;
 
@@ -223,7 +223,7 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
 
 
 BOOL
-LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR * szSubKey)
+LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR *szSubKey)
 {
     HKEY hSubKey;
     DWORD cbValue;
@@ -232,21 +232,21 @@ LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR * szSubKey)
     PLABEL_MAP pMap;
 
     if (RegOpenKeyExW(hKey,
-                     szSubKey,
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      szSubKey,
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
 
     cbValue = sizeof(szDesc);
     if (RegQueryValueExW(hSubKey,
-                      NULL,
-                      NULL,
-                      NULL,
-                      (LPBYTE)szDesc,
-                      &cbValue) != ERROR_SUCCESS)
+                         NULL,
+                         NULL,
+                         NULL,
+                         (LPBYTE)szDesc,
+                         &cbValue) != ERROR_SUCCESS)
     {
         RegCloseKey(hSubKey);
         return FALSE;
@@ -254,11 +254,11 @@ LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR * szSubKey)
 
     cbValue = sizeof(szData);
     if (RegQueryValueExW(hSubKey,
-                        L"DispFileName",
-                        NULL,
-                        NULL,
-                        (LPBYTE)szData,
-                        &cbValue) != ERROR_SUCCESS)
+                         L"DispFileName",
+                         NULL,
+                         NULL,
+                         (LPBYTE)szData,
+                         &cbValue) != ERROR_SUCCESS)
     {
         RegCloseKey(hSubKey);
         return FALSE;
@@ -298,10 +298,10 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
     DWORD dwResult;
     DWORD dwCount;
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                     L"AppEvents\\EventLabels",
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      L"AppEvents\\EventLabels",
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -312,13 +312,13 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
     {
         dwName = _countof(szName);
         dwResult = RegEnumKeyExW(hSubKey,
-                                dwCurKey,
-                                szName,
-                                &dwName,
-                                NULL,
-                                NULL,
-                                NULL,
-                                NULL);
+                                 dwCurKey,
+                                 szName,
+                                 &dwName,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL);
 
         if (dwResult == ERROR_SUCCESS)
         {
@@ -337,7 +337,7 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
 
 
 BOOL
-AddSoundProfile(HWND hwndDlg, HKEY hKey, WCHAR * szSubKey, BOOL SetDefault)
+AddSoundProfile(HWND hwndDlg, HKEY hKey, WCHAR *szSubKey, BOOL SetDefault)
 {
     HKEY hSubKey;
     WCHAR szValue[MAX_PATH];
@@ -346,21 +346,21 @@ AddSoundProfile(HWND hwndDlg, HKEY hKey, WCHAR * szSubKey, BOOL SetDefault)
     PSOUND_SCHEME_CONTEXT pScheme;
 
     if (RegOpenKeyExW(hKey,
-                     szSubKey,
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      szSubKey,
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
 
     cbValue = sizeof(szValue);
     dwResult = RegQueryValueExW(hSubKey,
-                               NULL,
-                               NULL,
-                               NULL,
-                               (LPBYTE)szValue,
-                               &cbValue);
+                                NULL,
+                                NULL,
+                                NULL,
+                                (LPBYTE)szValue,
+                                &cbValue);
     RegCloseKey(hSubKey);
 
     if (dwResult != ERROR_SUCCESS)
@@ -406,20 +406,20 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
 
     cbDefault = sizeof(pGlobalData->szDefault);
     if (RegQueryValueExW(hKey,
-                        NULL,
-                        NULL,
-                        NULL,
-                        (LPBYTE)pGlobalData->szDefault,
-                        &cbDefault) != ERROR_SUCCESS)
+                         NULL,
+                         NULL,
+                         NULL,
+                         (LPBYTE)pGlobalData->szDefault,
+                         &cbDefault) != ERROR_SUCCESS)
     {
         return FALSE;
     }
 
     if (RegOpenKeyExW(hKey,
-                     L"Names",
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      L"Names",
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -430,13 +430,13 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     {
         dwName = _countof(szName);
         dwResult = RegEnumKeyExW(hSubKey,
-                                dwCurKey,
-                                szName,
-                                &dwName,
-                                NULL,
-                                NULL,
-                                NULL,
-                                NULL);
+                                 dwCurKey,
+                                 szName,
+                                 &dwName,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL);
 
         if (dwResult == ERROR_SUCCESS)
         {
@@ -454,7 +454,7 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
 }
 
 
-PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, WCHAR * szName)
+PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, WCHAR *szName)
 {
     LRESULT lCount, lIndex, lResult;
     PSOUND_SCHEME_CONTEXT pScheme;
@@ -520,7 +520,7 @@ FreeSoundProfiles(HWND hwndDlg)
 }
 
 BOOL
-ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szProfile, WCHAR * szLabelName, WCHAR * szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
+ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szProfile, WCHAR *szLabelName, WCHAR *szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
 {
     HKEY hSubKey;
     WCHAR szValue[MAX_PATH];
@@ -530,27 +530,25 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szPr
     PLABEL_CONTEXT pLabelContext;
     BOOL bCurrentProfile, bActiveProfile;
 
-    //MessageBoxW(hwndDlg, szProfile, szLabelName, MB_OK);
-
     bCurrentProfile = !_wcsicmp(szProfile, L".Current");
     bActiveProfile = !_wcsicmp(szProfile, pGlobalData->szDefault);
 
     if (RegOpenKeyExW(hKey,
-                     szProfile,
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      szProfile,
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
 
     cbValue = sizeof(szValue);
     if (RegQueryValueExW(hSubKey,
-                        NULL,
-                        NULL,
-                        NULL,
-                        (LPBYTE)szValue,
-                        &cbValue) != ERROR_SUCCESS)
+                         NULL,
+                         NULL,
+                         NULL,
+                         (LPBYTE)szValue,
+                         &cbValue) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -562,7 +560,6 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szPr
 
     if (!pScheme)
     {
-        //MessageBoxW(hwndDlg, szProfile, L"no profile!!", MB_OK);
         return FALSE;
     }
     pLabelContext = FindLabelContext(pGlobalData, pScheme, AppMap->szName, LabelMap->szName);
@@ -584,7 +581,7 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szPr
 
 
 DWORD
-ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szLabelName, WCHAR * szAppName, PAPP_MAP pAppMap)
+ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szLabelName, WCHAR *szAppName, PAPP_MAP pAppMap)
 {
     HKEY hSubKey;
     DWORD dwNumProfiles;
@@ -595,10 +592,10 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szLa
     PLABEL_MAP pLabel;
 
     if (RegOpenKeyExW(hKey,
-                     szLabelName,
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      szLabelName,
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -617,13 +614,13 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szLa
     {
         dwProfile = _countof(szProfile);
         dwResult = RegEnumKeyExW(hSubKey,
-                                dwCurKey,
-                                szProfile,
-                                &dwProfile,
-                                NULL,
-                                NULL,
-                                NULL,
-                                NULL);
+                                 dwCurKey,
+                                 szProfile,
+                                 &dwProfile,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL);
 
         if (dwResult == ERROR_SUCCESS)
         {
@@ -643,7 +640,7 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szLa
 
 
 DWORD
-ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAppName)
+ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szAppName)
 {
     HKEY hSubKey;
     WCHAR szDefault[MAX_PATH];
@@ -656,17 +653,15 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAp
     WCHAR szIcon[MAX_PATH];
     PAPP_MAP AppMap;
 
-    //MessageBoxW(hwndDlg, szAppName, L"Importing...\n", MB_OK);
-
     AppMap = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(APP_MAP));
     if (!AppMap)
         return 0;
 
     if (RegOpenKeyExW(hKey,
-                     szAppName,
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      szAppName,
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         HeapFree(GetProcessHeap(), 0, AppMap);
         return 0;
@@ -674,11 +669,11 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAp
 
     cbValue = sizeof(szDefault);
     if (RegQueryValueExW(hSubKey,
-                        NULL,
-                        NULL,
-                        NULL,
-                        (LPBYTE)szDefault,
-                        &cbValue) != ERROR_SUCCESS)
+                         NULL,
+                         NULL,
+                         NULL,
+                         (LPBYTE)szDefault,
+                         &cbValue) != ERROR_SUCCESS)
     {
         RegCloseKey(hSubKey);
         HeapFree(GetProcessHeap(), 0, AppMap);
@@ -687,13 +682,13 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAp
 
     cbValue = sizeof(szIcon);
     if (RegQueryValueExW(hSubKey,
-                        L"DispFileName",
-                        NULL,
-                        NULL,
-                        (LPBYTE)szIcon,
-                        &cbValue) != ERROR_SUCCESS)
+                         L"DispFileName",
+                         NULL,
+                         NULL,
+                         (LPBYTE)szIcon,
+                         &cbValue) != ERROR_SUCCESS)
     {
-        szIcon[0] = L'\0';
+        szIcon[0] = UNICODE_NULL;
     }
 
     /* initialize app map */
@@ -711,13 +706,13 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAp
     {
         dwName = _countof(szName);
         dwResult = RegEnumKeyExW(hSubKey,
-                              dwCurKey,
-                              szName,
-                              &dwName,
-                              NULL,
-                              NULL,
-                              NULL,
-                              NULL);
+                                 dwCurKey,
+                                 szName,
+                                 &dwName,
+                                 NULL,
+                                 NULL,
+                                 NULL,
+                                 NULL);
         if (dwResult == ERROR_SUCCESS)
         {
             if (ImportSoundEntry(pGlobalData, hwndDlg, hSubKey, szName, szAppName, AppMap))
@@ -743,10 +738,10 @@ ImportSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     HKEY hSubKey;
 
     if (RegOpenKeyExW(hKey,
-                     L"Apps",
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      L"Apps",
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -756,9 +751,9 @@ ImportSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     do
     {
         dwResult = RegEnumKeyW(hSubKey,
-                              dwCurKey,
-                              szName,
-                              _countof(szName));
+                               dwCurKey,
+                               szName,
+                               _countof(szName));
 
         if (dwResult == ERROR_SUCCESS)
         {
@@ -783,10 +778,10 @@ LoadSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
     DWORD dwNumSchemes;
 
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                     L"AppEvents\\Schemes",
-                     0,
-                     KEY_READ,
-                     &hSubKey) != ERROR_SUCCESS)
+                      L"AppEvents\\Schemes",
+                      0,
+                      KEY_READ,
+                      &hSubKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -796,7 +791,6 @@ LoadSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
 
     if (dwNumSchemes)
     {
-        //MessageBoxW(hwndDlg, L"importing sound profiles...", NULL, MB_OK);
         ImportSoundProfiles(pGlobalData, hwndDlg, hSubKey);
     }
 
@@ -810,7 +804,7 @@ LoadSoundFiles(HWND hwndDlg)
 {
     WCHAR szList[256];
     WCHAR szPath[MAX_PATH];
-    WCHAR * ptr;
+    WCHAR *ptr;
     WIN32_FIND_DATAW FileData;
     HANDLE hFile;
     LRESULT lResult;
@@ -819,17 +813,17 @@ LoadSoundFiles(HWND hwndDlg)
     /* Add no sound listview item */
     if (LoadStringW(hApplet, IDS_NO_SOUND, szList, _countof(szList)))
     {
-        szList[_countof(szList) - 1] = L'\0';
+        szList[_countof(szList) - 1] = UNICODE_NULL;
         ComboBox_AddString(GetDlgItem(hwndDlg, IDC_SOUND_LIST), szList);
     }
 
     /* Load sound files */
-    length = GetWindowsDirectoryW(szPath, MAX_PATH);
-    if (length == 0 || length >= MAX_PATH - 9)
+    length = GetWindowsDirectoryW(szPath, _countof(szPath));
+    if (length == 0 || length >= _countof(szPath) - 9)
     {
         return FALSE;
     }
-    if (szPath[length-1] != L'\\')
+    if (szPath[length - 1] != L'\\')
     {
         szPath[length] = L'\\';
         length++;
@@ -857,10 +851,10 @@ LoadSoundFiles(HWND hwndDlg)
         {
             ptr = FileData.cFileName;
         }
-        lResult = SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_ADDSTRING, (WPARAM)0, (LPARAM)ptr);
+        lResult = SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_ADDSTRING, 0, (LPARAM)ptr);
         if (lResult != CB_ERR)
         {
-            wcscpy(&szPath[length-1], FileData.cFileName);
+            wcscpy(&szPath[length - 1], FileData.cFileName);
             SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_SETITEMDATA, (WPARAM)lResult, (LPARAM)_wcsdup(szPath));
         }
     } while (FindNextFileW(hFile, &FileData) != 0);
@@ -890,13 +884,13 @@ ShowSoundScheme(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
         TreeView_SetImageList(hList, pGlobalData->hSoundsImageList, TVSIL_NORMAL);
     }
 
-    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, 0, 0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
 
-    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, 0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
@@ -969,13 +963,13 @@ ApplyChanges(HWND hwndDlg)
 
     hDlgCtrl = GetDlgItem(hwndDlg, IDC_SOUND_SCHEME);
 
-    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, 0, 0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
 
-    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, 0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
@@ -983,22 +977,22 @@ ApplyChanges(HWND hwndDlg)
     pScheme = (PSOUND_SCHEME_CONTEXT)lIndex;
 
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                     L"AppEvents\\Schemes",
-                     0,
-                     KEY_WRITE,
-                     &hKey) != ERROR_SUCCESS)
+                      L"AppEvents\\Schemes",
+                      0,
+                      KEY_WRITE,
+                      &hKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
 
-    RegSetValueExW(hKey, NULL, 0, REG_SZ, (LPBYTE)pScheme->szName, (wcslen(pScheme->szName) +1) * sizeof(WCHAR));
+    RegSetValueExW(hKey, NULL, 0, REG_SZ, (LPBYTE)pScheme->szName, (wcslen(pScheme->szName) + 1) * sizeof(WCHAR));
     RegCloseKey(hKey);
 
     if (RegOpenKeyExW(HKEY_CURRENT_USER,
-                     L"AppEvents\\Schemes\\Apps",
-                     0,
-                     KEY_WRITE,
-                     &hKey) != ERROR_SUCCESS)
+                      L"AppEvents\\Schemes\\Apps",
+                      0,
+                      KEY_WRITE,
+                      &hKey) != ERROR_SUCCESS)
     {
         return FALSE;
     }
@@ -1011,7 +1005,7 @@ ApplyChanges(HWND hwndDlg)
 
         if (RegOpenKeyExW(hKey, Buffer, 0, KEY_WRITE, &hSubKey) == ERROR_SUCCESS)
         {
-            RegSetValueExW(hSubKey, NULL, 0, REG_EXPAND_SZ, (LPBYTE)pLabelContext->szValue, (wcslen(pLabelContext->szValue) +1) * sizeof(WCHAR));
+            RegSetValueExW(hSubKey, NULL, 0, REG_EXPAND_SZ, (LPBYTE)pLabelContext->szValue, (wcslen(pLabelContext->szValue) + 1) * sizeof(WCHAR));
             RegCloseKey(hSubKey);
         }
 
@@ -1113,8 +1107,8 @@ SoundsDlgProc(HWND hwndDlg,
             pGlobalData->NumWavOut = waveOutGetNumDevs();
 
             SendMessageW(GetDlgItem(hwndDlg, IDC_PLAY_SOUND),
-                        BM_SETIMAGE,(WPARAM)IMAGE_ICON,
-                        (LPARAM)(HANDLE)LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_PLAY_ICON)));
+                         BM_SETIMAGE, (WPARAM)IMAGE_ICON,
+                         (LPARAM)(HANDLE)LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_PLAY_ICON)));
 
             pGlobalData->hSoundsImageList = InitImageList(IDI_SOUND_SECTION,
                                                           IDI_SOUND_ASSIGNED,
@@ -1142,7 +1136,7 @@ SoundsDlgProc(HWND hwndDlg,
                     ofn.lStructSize = sizeof(ofn);
                     ofn.hwndOwner = hwndDlg;
                     ofn.lpstrFile = filename;
-                    ofn.lpstrFile[0] = L'\0';
+                    ofn.lpstrFile[0] = UNICODE_NULL;
                     ofn.nMaxFile = _countof(filename);
                     LoadStringW(hApplet, IDS_WAVE_FILES_FILTER, szFilter, _countof(szFilter));
                     ofn.lpstrFilter = MakeFilter(szFilter);
@@ -1152,7 +1146,7 @@ SoundsDlgProc(HWND hwndDlg,
                     ofn.lpstrInitialDir = L"%SystemRoot%\\Media";
                     ofn.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_HIDEREADONLY;
 
-                    if (GetOpenFileNameW(&ofn) != FALSE)
+                    if (GetOpenFileNameW(&ofn))
                     {
                         // FIXME search if list already contains that sound
 
@@ -1162,12 +1156,12 @@ SoundsDlgProc(HWND hwndDlg,
                         pFileName++;
 
                         // add to list
-                        lResult = SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_ADDSTRING, (WPARAM)0, (LPARAM)pFileName);
+                        lResult = SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_ADDSTRING, 0, (LPARAM)pFileName);
                         if (lResult != CB_ERR)
                         {
                             // add path and select item
                             SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_SETITEMDATA, (WPARAM)lResult, (LPARAM)_wcsdup(filename));
-                            SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_SETCURSEL, (WPARAM)lResult, (LPARAM)0);
+                            SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_SETCURSEL, (WPARAM)lResult, 0);
                         }
                     }
                     break;
@@ -1192,7 +1186,7 @@ SoundsDlgProc(HWND hwndDlg,
                 {
                     if (HIWORD(wParam) == CBN_SELENDOK)
                     {
-                        (void)TreeView_DeleteAllItems(GetDlgItem(hwndDlg, IDC_SCHEME_LIST));
+                        TreeView_DeleteAllItems(GetDlgItem(hwndDlg, IDC_SCHEME_LIST));
                         ShowSoundScheme(pGlobalData, hwndDlg);
                         EnableWindow(GetDlgItem(hwndDlg, IDC_SOUND_LIST), FALSE);
                         EnableWindow(GetDlgItem(hwndDlg, IDC_TEXT_SOUND), FALSE);
@@ -1247,7 +1241,7 @@ SoundsDlgProc(HWND hwndDlg,
                                     EnableWindow(GetDlgItem(hwndDlg, IDC_PLAY_SOUND), FALSE);
                                 }
 
-                                pLabelContext->szValue[0] = L'\0';
+                                pLabelContext->szValue[0] = UNICODE_NULL;
 
                                 break;
                             }
@@ -1296,11 +1290,11 @@ SoundsDlgProc(HWND hwndDlg,
         case WM_NOTIFY:
         {
             PLABEL_CONTEXT pLabelContext;
-            WCHAR * ptr;
+            WCHAR *ptr;
 
             LPNMHDR lpnm = (LPNMHDR)lParam;
 
-            switch(lpnm->code)
+            switch (lpnm->code)
             {
                 case PSN_APPLY:
                 {

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -950,6 +950,7 @@ BOOL
 ApplyChanges(HWND hwndDlg)
 {
     HKEY hKey, hSubKey;
+    DWORD dwType;
     LRESULT lIndex;
     PSOUND_SCHEME_CONTEXT pScheme;
     HWND hDlgCtrl;
@@ -1000,7 +1001,8 @@ ApplyChanges(HWND hwndDlg)
 
         if (RegOpenKeyExW(hKey, Buffer, 0, KEY_WRITE, &hSubKey) == ERROR_SUCCESS)
         {
-            RegSetValueExW(hSubKey, NULL, 0, REG_EXPAND_SZ, (LPBYTE)pLabelContext->szValue, (wcslen(pLabelContext->szValue) + 1) * sizeof(WCHAR));
+            dwType = (wcschr(pLabelContext->szValue, L'%') ? REG_EXPAND_SZ : REG_SZ);
+            RegSetValueExW(hSubKey, NULL, 0, dwType, (LPBYTE)pLabelContext->szValue, (wcslen(pLabelContext->szValue) + 1) * sizeof(WCHAR));
             RegCloseKey(hSubKey);
         }
 

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -18,9 +18,9 @@
 
 typedef struct _LABEL_MAP
 {
-    WCHAR *szName;
-    WCHAR *szDesc;
-    WCHAR *szIcon;
+    PWCHAR szName;
+    PWCHAR szDesc;
+    PWCHAR szIcon;
     struct _APP_MAP *AppMap;
     struct _LABEL_MAP *Next;
 } LABEL_MAP, *PLABEL_MAP;
@@ -63,7 +63,7 @@ typedef struct _GLOBAL_DATA
 /* A filter string is a list separated by NULL and ends with double NULLs. */
 LPWSTR MakeFilter(LPWSTR psz)
 {
-    WCHAR *pch;
+    PWCHAR pch;
 
     ASSERT(psz[0] != UNICODE_NULL &&
            psz[wcslen(psz) - 1] == L'|');
@@ -78,7 +78,7 @@ LPWSTR MakeFilter(LPWSTR psz)
     return psz;
 }
 
-PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, WCHAR *szName)
+PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, PWCHAR szName)
 {
     PLABEL_MAP pMap = pGlobalData->pLabelMap;
 
@@ -168,7 +168,7 @@ FreeLabelMap(PGLOBAL_DATA pGlobalData)
     }
 }
 
-PAPP_MAP FindApp(PGLOBAL_DATA pGlobalData, WCHAR *szName)
+PAPP_MAP FindApp(PGLOBAL_DATA pGlobalData, PWCHAR szName)
 {
     PAPP_MAP pMap = pGlobalData->pAppMap;
 
@@ -197,7 +197,7 @@ FreeAppMap(PGLOBAL_DATA pGlobalData)
     }
 }
 
-PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, WCHAR *AppName, WCHAR *LabelName)
+PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, PWCHAR AppName, PWCHAR LabelName)
 {
     PLABEL_CONTEXT pLabelContext;
 
@@ -232,7 +232,7 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
 
 
 BOOL
-LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR *szSubKey)
+LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, PWCHAR szSubKey)
 {
     HKEY hSubKey;
     DWORD cbValue;
@@ -346,7 +346,7 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
 
 
 BOOL
-AddSoundProfile(HWND hwndDlg, HKEY hKey, WCHAR *szSubKey, BOOL SetDefault)
+AddSoundProfile(HWND hwndDlg, HKEY hKey, PWCHAR szSubKey, BOOL SetDefault)
 {
     HKEY hSubKey;
     WCHAR szValue[MAX_PATH];
@@ -463,7 +463,7 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
 }
 
 
-PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, WCHAR *szName)
+PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, PWCHAR szName)
 {
     LRESULT lCount, lIndex, lResult;
     PSOUND_SCHEME_CONTEXT pScheme;
@@ -529,7 +529,7 @@ FreeSoundProfiles(HWND hwndDlg)
 }
 
 BOOL
-ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szProfile, WCHAR *szLabelName, WCHAR *szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
+ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, PWCHAR szProfile, PWCHAR szLabelName, PWCHAR szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
 {
     HKEY hSubKey;
     WCHAR szValue[MAX_PATH];
@@ -590,7 +590,7 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szPro
 
 
 DWORD
-ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szLabelName, WCHAR *szAppName, PAPP_MAP pAppMap)
+ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, PWCHAR szLabelName, PWCHAR szAppName, PAPP_MAP pAppMap)
 {
     HKEY hSubKey;
     DWORD dwNumProfiles;
@@ -649,7 +649,7 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szLab
 
 
 DWORD
-ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR *szAppName)
+ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, PWCHAR szAppName)
 {
     HKEY hSubKey;
     WCHAR szDefault[MAX_PATH];
@@ -813,7 +813,7 @@ LoadSoundFiles(HWND hwndDlg)
 {
     WCHAR szList[256];
     WCHAR szPath[MAX_PATH];
-    WCHAR *ptr;
+    PWCHAR ptr;
     WIN32_FIND_DATAW FileData;
     HANDLE hFile;
     LRESULT lResult;
@@ -828,7 +828,7 @@ LoadSoundFiles(HWND hwndDlg)
 
     /* Load sound files */
     length = GetWindowsDirectoryW(szPath, _countof(szPath));
-    if (length == 0 || length >= _countof(szPath) - 8)
+    if (length == 0 || length >= _countof(szPath) - CONST_STR_LEN(L"\\media\\*"))
     {
         return FALSE;
     }
@@ -859,7 +859,9 @@ LoadSoundFiles(HWND hwndDlg)
         lResult = SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_ADDSTRING, 0, (LPARAM)ptr);
         if (lResult != CB_ERR)
         {
-            StringCchCopyW(szPath + (length + 7), _countof(szPath) - (length + 7), FileData.cFileName);
+            StringCchCopyW(szPath + (length + CONST_STR_LEN(L"\\media\\")),
+                           _countof(szPath) - (length + CONST_STR_LEN(L"\\media\\")),
+                           FileData.cFileName);
             SendDlgItemMessageW(hwndDlg, IDC_SOUND_LIST, CB_SETITEMDATA, (WPARAM)lResult, (LPARAM)_wcsdup(szPath));
         }
     } while (FindNextFileW(hFile, &FileData) != 0);
@@ -873,7 +875,7 @@ VOID
 FreeSoundFiles(HWND hwndDlg)
 {
     LRESULT lCount, lIndex, lResult;
-    WCHAR *pSoundPath;
+    PWCHAR pSoundPath;
     HWND hwndComboBox;
 
     hwndComboBox = GetDlgItem(hwndDlg, IDC_SOUND_LIST);
@@ -889,7 +891,7 @@ FreeSoundFiles(HWND hwndDlg)
             continue;
         }
 
-        pSoundPath = (WCHAR*)lResult;
+        pSoundPath = (PWCHAR)lResult;
         
         free(pSoundPath);
     }
@@ -1211,7 +1213,7 @@ SoundsDlgProc(HWND hwndDlg,
                     lIndex = ComboBox_GetItemData(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex);
                     if (lIndex != CB_ERR)
                     {
-                        PlaySoundW((WCHAR*)lIndex, NULL, SND_FILENAME);
+                        PlaySoundW((PWCHAR)lIndex, NULL, SND_FILENAME);
                     }
                     break;
                 }
@@ -1279,7 +1281,7 @@ SoundsDlgProc(HWND hwndDlg,
                                 break;
                             }
 
-                            if (_wcsicmp(pLabelContext->szValue, (WCHAR*)lResult) || (lIndex != pLabelContext->szValue[0]))
+                            if (_wcsicmp(pLabelContext->szValue, (PWCHAR)lResult) || (lIndex != pLabelContext->szValue[0]))
                             {
                                 /* Update the tree view item image */
                                 item.mask = TVIF_IMAGE | TVIF_SELECTEDIMAGE;
@@ -1292,10 +1294,10 @@ SoundsDlgProc(HWND hwndDlg,
                                 ///
                                 /// Should store in current member
                                 ///
-                                StringCchCopyW(pLabelContext->szValue, _countof(pLabelContext->szValue), (WCHAR*)lResult);
+                                StringCchCopyW(pLabelContext->szValue, _countof(pLabelContext->szValue), (PWCHAR)lResult);
                             }
 
-                            if (wcslen((WCHAR*)lResult) && lIndex != 0 && pGlobalData->NumWavOut != 0)
+                            if (wcslen((PWCHAR)lResult) && lIndex != 0 && pGlobalData->NumWavOut != 0)
                             {
                                 EnableWindow(GetDlgItem(hwndDlg, IDC_PLAY_SOUND), TRUE);
                             }
@@ -1324,7 +1326,7 @@ SoundsDlgProc(HWND hwndDlg,
         case WM_NOTIFY:
         {
             PLABEL_CONTEXT pLabelContext;
-            WCHAR *ptr;
+            PWCHAR ptr;
 
             LPNMHDR lpnm = (LPNMHDR)lParam;
 
@@ -1371,7 +1373,7 @@ SoundsDlgProc(HWND hwndDlg,
                         if (lResult == CB_ERR || lResult == 0)
                             continue;
 
-                        if (!wcscmp((WCHAR*)lResult, pLabelContext->szValue))
+                        if (!wcscmp((PWCHAR)lResult, pLabelContext->szValue))
                         {
                             ComboBox_SetCurSel(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex);
                             return FALSE;

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -19,18 +19,18 @@
 
 typedef struct _LABEL_MAP
 {
-    TCHAR *szName;
-    TCHAR *szDesc;
-    TCHAR *szIcon;
+    WCHAR *szName;
+    WCHAR *szDesc;
+    WCHAR *szIcon;
     struct _APP_MAP *AppMap;
     struct _LABEL_MAP *Next;
 } LABEL_MAP, *PLABEL_MAP;
 
 typedef struct _APP_MAP
 {
-    TCHAR szName[MAX_PATH];
-    TCHAR szDesc[MAX_PATH];
-    TCHAR szIcon[MAX_PATH];
+    WCHAR szName[MAX_PATH];
+    WCHAR szDesc[MAX_PATH];
+    WCHAR szIcon[MAX_PATH];
 
     struct _APP_MAP *Next;
     PLABEL_MAP LabelMap;
@@ -40,20 +40,20 @@ typedef struct _LABEL_CONTEXT
 {
     PLABEL_MAP LabelMap;
     PAPP_MAP AppMap;
-    TCHAR szValue[MAX_PATH];
+    WCHAR szValue[MAX_PATH];
     struct _LABEL_CONTEXT *Next;
 } LABEL_CONTEXT, *PLABEL_CONTEXT;
 
 typedef struct _SOUND_SCHEME_CONTEXT
 {
-    TCHAR szName[MAX_PATH];
-    TCHAR szDesc[MAX_PATH];
+    WCHAR szName[MAX_PATH];
+    WCHAR szDesc[MAX_PATH];
     PLABEL_CONTEXT LabelContext;
 } SOUND_SCHEME_CONTEXT, *PSOUND_SCHEME_CONTEXT;
 
 typedef struct _GLOBAL_DATA
 {
-    TCHAR szDefault[MAX_PATH];
+    WCHAR szDefault[MAX_PATH];
     HIMAGELIST hSoundsImageList;
     PLABEL_MAP pLabelMap;
     PAPP_MAP pAppMap;
@@ -79,7 +79,7 @@ LPWSTR MakeFilter(LPWSTR psz)
     return psz;
 }
 
-PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, TCHAR * szName)
+PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, WCHAR * szName)
 {
     PLABEL_MAP pMap = pGlobalData->pLabelMap;
 
@@ -87,7 +87,7 @@ PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, TCHAR * szName)
     {
         ASSERT(pMap);
         ASSERT(pMap->szName);
-        if (!_tcscmp(pMap->szName, szName))
+        if (!wcscmp(pMap->szName, szName))
             return pMap;
 
         pMap = pMap->Next;
@@ -99,7 +99,7 @@ PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, TCHAR * szName)
     {
         ASSERT(pMap);
         ASSERT(pMap->szName);
-        if (!_tcscmp(pMap->szName, szName))
+        if (!wcscmp(pMap->szName, szName))
             return pMap;
 
         pMap = pMap->Next;
@@ -109,7 +109,7 @@ PLABEL_MAP FindLabel(PGLOBAL_DATA pGlobalData, PAPP_MAP pAppMap, TCHAR * szName)
     if (!pMap)
         return NULL;
 
-    pMap->szName = pMap->szDesc = _tcsdup(szName);
+    pMap->szName = pMap->szDesc = _wcsdup(szName);
     if (!pMap->szName)
     {
         HeapFree(GetProcessHeap(), 0, pMap);
@@ -159,13 +159,13 @@ FreeLabelMap(PGLOBAL_DATA pGlobalData)
     }
 }
 
-PAPP_MAP FindApp(PGLOBAL_DATA pGlobalData, TCHAR *szName)
+PAPP_MAP FindApp(PGLOBAL_DATA pGlobalData, WCHAR *szName)
 {
     PAPP_MAP pMap = pGlobalData->pAppMap;
 
     while (pMap)
     {
-        if (!_tcscmp(pMap->szName, szName))
+        if (!wcscmp(pMap->szName, szName))
             return pMap;
 
         pMap = pMap->Next;
@@ -188,7 +188,7 @@ FreeAppMap(PGLOBAL_DATA pGlobalData)
     }
 }
 
-PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, TCHAR * AppName, TCHAR * LabelName)
+PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT pSoundScheme, WCHAR * AppName, WCHAR * LabelName)
 {
     PLABEL_CONTEXT pLabelContext;
 
@@ -199,7 +199,7 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
         ASSERT(pLabelContext->AppMap);
         ASSERT(pLabelContext->LabelMap);
 
-        if (!_tcsicmp(pLabelContext->AppMap->szName, AppName) && !_tcsicmp(pLabelContext->LabelMap->szName, LabelName))
+        if (!_wcsicmp(pLabelContext->AppMap->szName, AppName) && !_wcsicmp(pLabelContext->LabelMap->szName, LabelName))
         {
             return pLabelContext;
         }
@@ -214,7 +214,7 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
     pLabelContext->LabelMap = FindLabel(pGlobalData, pLabelContext->AppMap, LabelName);
     ASSERT(pLabelContext->AppMap);
     ASSERT(pLabelContext->LabelMap);
-    pLabelContext->szValue[0] = _T('\0');
+    pLabelContext->szValue[0] = L'\0';
     pLabelContext->Next = pSoundScheme->LabelContext;
     pSoundScheme->LabelContext = pLabelContext;
 
@@ -223,15 +223,15 @@ PLABEL_CONTEXT FindLabelContext(PGLOBAL_DATA pGlobalData, PSOUND_SCHEME_CONTEXT 
 
 
 BOOL
-LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, TCHAR * szSubKey)
+LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, WCHAR * szSubKey)
 {
     HKEY hSubKey;
     DWORD cbValue;
-    TCHAR szDesc[MAX_PATH];
-    TCHAR szData[MAX_PATH];
+    WCHAR szDesc[MAX_PATH];
+    WCHAR szData[MAX_PATH];
     PLABEL_MAP pMap;
 
-    if (RegOpenKeyEx(hKey,
+    if (RegOpenKeyExW(hKey,
                      szSubKey,
                      0,
                      KEY_READ,
@@ -241,7 +241,7 @@ LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, TCHAR * szSubKey)
     }
 
     cbValue = sizeof(szDesc);
-    if (RegQueryValueEx(hSubKey,
+    if (RegQueryValueExW(hSubKey,
                       NULL,
                       NULL,
                       NULL,
@@ -253,8 +253,8 @@ LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, TCHAR * szSubKey)
     }
 
     cbValue = sizeof(szData);
-    if (RegQueryValueEx(hSubKey,
-                        _T("DispFileName"),
+    if (RegQueryValueExW(hSubKey,
+                        L"DispFileName",
                         NULL,
                         NULL,
                         (LPBYTE)szData,
@@ -270,9 +270,9 @@ LoadEventLabel(PGLOBAL_DATA pGlobalData, HKEY hKey, TCHAR * szSubKey)
         return FALSE;
     }
 
-    pMap->szName = _tcsdup(szSubKey);
-    pMap->szDesc = _tcsdup(szDesc);
-    pMap->szIcon = _tcsdup(szData);
+    pMap->szName = _wcsdup(szSubKey);
+    pMap->szDesc = _wcsdup(szDesc);
+    pMap->szIcon = _wcsdup(szData);
 
     if (pGlobalData->pLabelMap)
     {
@@ -293,12 +293,12 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
 {
     HKEY hSubKey;
     DWORD dwCurKey;
-    TCHAR szName[MAX_PATH];
+    WCHAR szName[MAX_PATH];
     DWORD dwName;
     DWORD dwResult;
     DWORD dwCount;
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     _T("AppEvents\\EventLabels"),
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                     L"AppEvents\\EventLabels",
                      0,
                      KEY_READ,
                      &hSubKey) != ERROR_SUCCESS)
@@ -311,7 +311,7 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
     do
     {
         dwName = _countof(szName);
-        dwResult = RegEnumKeyEx(hSubKey,
+        dwResult = RegEnumKeyExW(hSubKey,
                                 dwCurKey,
                                 szName,
                                 &dwName,
@@ -337,15 +337,15 @@ LoadEventLabels(PGLOBAL_DATA pGlobalData)
 
 
 BOOL
-AddSoundProfile(HWND hwndDlg, HKEY hKey, TCHAR * szSubKey, BOOL SetDefault)
+AddSoundProfile(HWND hwndDlg, HKEY hKey, WCHAR * szSubKey, BOOL SetDefault)
 {
     HKEY hSubKey;
-    TCHAR szValue[MAX_PATH];
+    WCHAR szValue[MAX_PATH];
     DWORD cbValue, dwResult;
     LRESULT lResult;
     PSOUND_SCHEME_CONTEXT pScheme;
 
-    if (RegOpenKeyEx(hKey,
+    if (RegOpenKeyExW(hKey,
                      szSubKey,
                      0,
                      KEY_READ,
@@ -355,7 +355,7 @@ AddSoundProfile(HWND hwndDlg, HKEY hKey, TCHAR * szSubKey, BOOL SetDefault)
     }
 
     cbValue = sizeof(szValue);
-    dwResult = RegQueryValueEx(hSubKey,
+    dwResult = RegQueryValueExW(hSubKey,
                                NULL,
                                NULL,
                                NULL,
@@ -380,8 +380,8 @@ AddSoundProfile(HWND hwndDlg, HKEY hKey, TCHAR * szSubKey, BOOL SetDefault)
         return FALSE;
     }
 
-    StringCchCopy(pScheme->szDesc, MAX_PATH, szValue);
-    StringCchCopy(pScheme->szName, MAX_PATH, szSubKey);
+    StringCchCopyW(pScheme->szDesc, MAX_PATH, szValue);
+    StringCchCopyW(pScheme->szName, MAX_PATH, szSubKey);
 
     /* Associate the value with the item in the combobox */
     ComboBox_SetItemData(GetDlgItem(hwndDlg, IDC_SOUND_SCHEME), lResult, pScheme);
@@ -402,10 +402,10 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     HKEY hSubKey;
     DWORD dwName, dwCurKey, dwResult, dwNumSchemes;
     DWORD cbDefault;
-    TCHAR szName[MAX_PATH];
+    WCHAR szName[MAX_PATH];
 
     cbDefault = sizeof(pGlobalData->szDefault);
-    if (RegQueryValueEx(hKey,
+    if (RegQueryValueExW(hKey,
                         NULL,
                         NULL,
                         NULL,
@@ -415,8 +415,8 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
         return FALSE;
     }
 
-    if (RegOpenKeyEx(hKey,
-                     _T("Names"),
+    if (RegOpenKeyExW(hKey,
+                     L"Names",
                      0,
                      KEY_READ,
                      &hSubKey) != ERROR_SUCCESS)
@@ -429,7 +429,7 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     do
     {
         dwName = _countof(szName);
-        dwResult = RegEnumKeyEx(hSubKey,
+        dwResult = RegEnumKeyExW(hSubKey,
                                 dwCurKey,
                                 szName,
                                 &dwName,
@@ -440,7 +440,7 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
 
         if (dwResult == ERROR_SUCCESS)
         {
-            if (AddSoundProfile(hwndDlg, hSubKey, szName, (!_tcsicmp(szName, pGlobalData->szDefault))))
+            if (AddSoundProfile(hwndDlg, hSubKey, szName, (!_wcsicmp(szName, pGlobalData->szDefault))))
             {
                 dwNumSchemes++;
             }
@@ -454,7 +454,7 @@ EnumerateSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
 }
 
 
-PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, TCHAR * szName)
+PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, WCHAR * szName)
 {
     LRESULT lCount, lIndex, lResult;
     PSOUND_SCHEME_CONTEXT pScheme;
@@ -476,7 +476,7 @@ PSOUND_SCHEME_CONTEXT FindSoundProfile(HWND hwndDlg, TCHAR * szName)
         }
 
         pScheme = (PSOUND_SCHEME_CONTEXT)lResult;
-        if (!_tcsicmp(pScheme->szName, szName))
+        if (!_wcsicmp(pScheme->szName, szName))
         {
             return pScheme;
         }
@@ -520,22 +520,22 @@ FreeSoundProfiles(HWND hwndDlg)
 }
 
 BOOL
-ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szProfile, TCHAR * szLabelName, TCHAR * szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
+ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szProfile, WCHAR * szLabelName, WCHAR * szAppName, PAPP_MAP AppMap, PLABEL_MAP LabelMap)
 {
     HKEY hSubKey;
-    TCHAR szValue[MAX_PATH];
-    TCHAR szBuffer[MAX_PATH];
+    WCHAR szValue[MAX_PATH];
+    WCHAR szBuffer[MAX_PATH];
     DWORD cbValue, cchLength;
     PSOUND_SCHEME_CONTEXT pScheme;
     PLABEL_CONTEXT pLabelContext;
     BOOL bCurrentProfile, bActiveProfile;
 
-    //MessageBox(hwndDlg, szProfile, szLabelName, MB_OK);
+    //MessageBoxW(hwndDlg, szProfile, szLabelName, MB_OK);
 
-    bCurrentProfile = !_tcsicmp(szProfile, _T(".Current"));
-    bActiveProfile = !_tcsicmp(szProfile, pGlobalData->szDefault);
+    bCurrentProfile = !_wcsicmp(szProfile, L".Current");
+    bActiveProfile = !_wcsicmp(szProfile, pGlobalData->szDefault);
 
-    if (RegOpenKeyEx(hKey,
+    if (RegOpenKeyExW(hKey,
                      szProfile,
                      0,
                      KEY_READ,
@@ -545,7 +545,7 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szPr
     }
 
     cbValue = sizeof(szValue);
-    if (RegQueryValueEx(hSubKey,
+    if (RegQueryValueExW(hSubKey,
                         NULL,
                         NULL,
                         NULL,
@@ -562,12 +562,12 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szPr
 
     if (!pScheme)
     {
-        //MessageBox(hwndDlg, szProfile, _T("no profile!!"), MB_OK);
+        //MessageBoxW(hwndDlg, szProfile, L"no profile!!", MB_OK);
         return FALSE;
     }
     pLabelContext = FindLabelContext(pGlobalData, pScheme, AppMap->szName, LabelMap->szName);
 
-    cchLength = ExpandEnvironmentStrings(szValue, szBuffer, _countof(szBuffer));
+    cchLength = ExpandEnvironmentStringsW(szValue, szBuffer, _countof(szBuffer));
     if (cchLength == 0 || cchLength > _countof(szBuffer))
     {
         /* fixme */
@@ -575,26 +575,26 @@ ImportSoundLabel(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szPr
     }
 
     if (bCurrentProfile)
-        _tcscpy(pLabelContext->szValue, szBuffer);
+        wcscpy(pLabelContext->szValue, szBuffer);
     else if (!bActiveProfile)
-        _tcscpy(pLabelContext->szValue, szBuffer);
+        wcscpy(pLabelContext->szValue, szBuffer);
 
     return TRUE;
 }
 
 
 DWORD
-ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szLabelName, TCHAR * szAppName, PAPP_MAP pAppMap)
+ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szLabelName, WCHAR * szAppName, PAPP_MAP pAppMap)
 {
     HKEY hSubKey;
     DWORD dwNumProfiles;
     DWORD dwCurKey;
     DWORD dwResult;
     DWORD dwProfile;
-    TCHAR szProfile[MAX_PATH];
+    WCHAR szProfile[MAX_PATH];
     PLABEL_MAP pLabel;
 
-    if (RegOpenKeyEx(hKey,
+    if (RegOpenKeyExW(hKey,
                      szLabelName,
                      0,
                      KEY_READ,
@@ -616,7 +616,7 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szLa
     do
     {
         dwProfile = _countof(szProfile);
-        dwResult = RegEnumKeyEx(hSubKey,
+        dwResult = RegEnumKeyExW(hSubKey,
                                 dwCurKey,
                                 szProfile,
                                 &dwProfile,
@@ -643,26 +643,26 @@ ImportSoundEntry(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szLa
 
 
 DWORD
-ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szAppName)
+ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, WCHAR * szAppName)
 {
     HKEY hSubKey;
-    TCHAR szDefault[MAX_PATH];
+    WCHAR szDefault[MAX_PATH];
     DWORD cbValue;
     DWORD dwCurKey;
     DWORD dwResult;
     DWORD dwNumEntry;
     DWORD dwName;
-    TCHAR szName[MAX_PATH];
-    TCHAR szIcon[MAX_PATH];
+    WCHAR szName[MAX_PATH];
+    WCHAR szIcon[MAX_PATH];
     PAPP_MAP AppMap;
 
-    //MessageBox(hwndDlg, szAppName, _T("Importing...\n"), MB_OK);
+    //MessageBoxW(hwndDlg, szAppName, L"Importing...\n", MB_OK);
 
     AppMap = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(APP_MAP));
     if (!AppMap)
         return 0;
 
-    if (RegOpenKeyEx(hKey,
+    if (RegOpenKeyExW(hKey,
                      szAppName,
                      0,
                      KEY_READ,
@@ -673,7 +673,7 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szAp
     }
 
     cbValue = sizeof(szDefault);
-    if (RegQueryValueEx(hSubKey,
+    if (RegQueryValueExW(hSubKey,
                         NULL,
                         NULL,
                         NULL,
@@ -686,20 +686,20 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szAp
     }
 
     cbValue = sizeof(szIcon);
-    if (RegQueryValueEx(hSubKey,
-                        _T("DispFileName"),
+    if (RegQueryValueExW(hSubKey,
+                        L"DispFileName",
                         NULL,
                         NULL,
                         (LPBYTE)szIcon,
                         &cbValue) != ERROR_SUCCESS)
     {
-        szIcon[0] = _T('\0');
+        szIcon[0] = L'\0';
     }
 
     /* initialize app map */
-    _tcscpy(AppMap->szName, szAppName);
-    _tcscpy(AppMap->szDesc, szDefault);
-    _tcscpy(AppMap->szIcon, szIcon);
+    wcscpy(AppMap->szName, szAppName);
+    wcscpy(AppMap->szDesc, szDefault);
+    wcscpy(AppMap->szIcon, szIcon);
 
     AppMap->Next = pGlobalData->pAppMap;
     pGlobalData->pAppMap = AppMap;
@@ -710,7 +710,7 @@ ImportAppProfile(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey, TCHAR * szAp
     do
     {
         dwName = _countof(szName);
-        dwResult = RegEnumKeyEx(hSubKey,
+        dwResult = RegEnumKeyExW(hSubKey,
                               dwCurKey,
                               szName,
                               &dwName,
@@ -739,11 +739,11 @@ ImportSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     DWORD dwCurKey;
     DWORD dwResult;
     DWORD dwNumApps;
-    TCHAR szName[MAX_PATH];
+    WCHAR szName[MAX_PATH];
     HKEY hSubKey;
 
-    if (RegOpenKeyEx(hKey,
-                     _T("Apps"),
+    if (RegOpenKeyExW(hKey,
+                     L"Apps",
                      0,
                      KEY_READ,
                      &hSubKey) != ERROR_SUCCESS)
@@ -755,7 +755,7 @@ ImportSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg, HKEY hKey)
     dwCurKey = 0;
     do
     {
-        dwResult = RegEnumKey(hSubKey,
+        dwResult = RegEnumKeyW(hSubKey,
                               dwCurKey,
                               szName,
                               _countof(szName));
@@ -782,8 +782,8 @@ LoadSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
     HKEY hSubKey;
     DWORD dwNumSchemes;
 
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     _T("AppEvents\\Schemes"),
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                     L"AppEvents\\Schemes",
                      0,
                      KEY_READ,
                      &hSubKey) != ERROR_SUCCESS)
@@ -796,7 +796,7 @@ LoadSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
 
     if (dwNumSchemes)
     {
-        //MessageBox(hwndDlg, _T("importing sound profiles..."), NULL, MB_OK);
+        //MessageBoxW(hwndDlg, L"importing sound profiles...", NULL, MB_OK);
         ImportSoundProfiles(pGlobalData, hwndDlg, hSubKey);
     }
 
@@ -808,7 +808,7 @@ LoadSoundProfiles(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
 BOOL
 LoadSoundFiles(HWND hwndDlg)
 {
-    TCHAR szList[256];
+    WCHAR szList[256];
     WCHAR szPath[MAX_PATH];
     WCHAR * ptr;
     WIN32_FIND_DATAW FileData;
@@ -817,9 +817,9 @@ LoadSoundFiles(HWND hwndDlg)
     UINT length;
 
     /* Add no sound listview item */
-    if (LoadString(hApplet, IDS_NO_SOUND, szList, _countof(szList)))
+    if (LoadStringW(hApplet, IDS_NO_SOUND, szList, _countof(szList)))
     {
-        szList[_countof(szList) - 1] = TEXT('\0');
+        szList[_countof(szList) - 1] = L'\0';
         ComboBox_AddString(GetDlgItem(hwndDlg, IDC_SOUND_LIST), szList);
     }
 
@@ -879,7 +879,7 @@ ShowSoundScheme(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
     PLABEL_MAP pLabelMap;
     PLABEL_CONTEXT pLabelContext;
     HWND hDlgCtrl, hList;
-    TVINSERTSTRUCT tvItem;
+    TVINSERTSTRUCTW tvItem;
     HTREEITEM hTreeItem;
 
     hDlgCtrl = GetDlgItem(hwndDlg, IDC_SOUND_SCHEME);
@@ -890,20 +890,20 @@ ShowSoundScheme(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
         TreeView_SetImageList(hList, pGlobalData->hSoundsImageList, TVSIL_NORMAL);
     }
 
-    lIndex = SendMessage(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
 
-    lIndex = SendMessage(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
     pScheme = (PSOUND_SCHEME_CONTEXT)lIndex;
 
-    _tcscpy(pGlobalData->szDefault, pScheme->szName);
+    wcscpy(pGlobalData->szDefault, pScheme->szName);
 
     pAppMap = pGlobalData->pAppMap;
     while (pAppMap)
@@ -935,7 +935,7 @@ ShowSoundScheme(PGLOBAL_DATA pGlobalData, HWND hwndDlg)
             tvItem.item.state = TVIS_EXPANDED;
             tvItem.item.stateMask = TVIS_EXPANDED;
             tvItem.item.pszText = pLabelMap->szDesc;
-            if (pLabelContext->szValue && _tcslen(pLabelContext->szValue) > 0)
+            if (pLabelContext->szValue && wcslen(pLabelContext->szValue) > 0)
             {
                 tvItem.item.iImage = IMAGE_SOUND_ASSIGNED;
                 tvItem.item.iSelectedImage = IMAGE_SOUND_ASSIGNED;
@@ -965,25 +965,25 @@ ApplyChanges(HWND hwndDlg)
     PSOUND_SCHEME_CONTEXT pScheme;
     HWND hDlgCtrl;
     PLABEL_CONTEXT pLabelContext;
-    TCHAR Buffer[100];
+    WCHAR Buffer[100];
 
     hDlgCtrl = GetDlgItem(hwndDlg, IDC_SOUND_SCHEME);
 
-    lIndex = SendMessage(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETCURSEL, (WPARAM)0, (LPARAM)0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
 
-    lIndex = SendMessage(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
+    lIndex = SendMessageW(hDlgCtrl, CB_GETITEMDATA, (WPARAM)lIndex, (LPARAM)0);
     if (lIndex == CB_ERR)
     {
         return FALSE;
     }
     pScheme = (PSOUND_SCHEME_CONTEXT)lIndex;
 
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     _T("AppEvents\\Schemes"),
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                     L"AppEvents\\Schemes",
                      0,
                      KEY_WRITE,
                      &hKey) != ERROR_SUCCESS)
@@ -991,11 +991,11 @@ ApplyChanges(HWND hwndDlg)
         return FALSE;
     }
 
-    RegSetValueEx(hKey, NULL, 0, REG_SZ, (LPBYTE)pScheme->szName, (_tcslen(pScheme->szName) +1) * sizeof(TCHAR));
+    RegSetValueExW(hKey, NULL, 0, REG_SZ, (LPBYTE)pScheme->szName, (wcslen(pScheme->szName) +1) * sizeof(WCHAR));
     RegCloseKey(hKey);
 
-    if (RegOpenKeyEx(HKEY_CURRENT_USER,
-                     _T("AppEvents\\Schemes\\Apps"),
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                     L"AppEvents\\Schemes\\Apps",
                      0,
                      KEY_WRITE,
                      &hKey) != ERROR_SUCCESS)
@@ -1007,11 +1007,11 @@ ApplyChanges(HWND hwndDlg)
 
     while (pLabelContext)
     {
-        _stprintf(Buffer, _T("%s\\%s\\.Current"), pLabelContext->AppMap->szName, pLabelContext->LabelMap->szName);
+        swprintf(Buffer, L"%s\\%s\\.Current", pLabelContext->AppMap->szName, pLabelContext->LabelMap->szName);
 
-        if (RegOpenKeyEx(hKey, Buffer, 0, KEY_WRITE, &hSubKey) == ERROR_SUCCESS)
+        if (RegOpenKeyExW(hKey, Buffer, 0, KEY_WRITE, &hSubKey) == ERROR_SUCCESS)
         {
-            RegSetValueEx(hSubKey, NULL, 0, REG_EXPAND_SZ, (LPBYTE)pLabelContext->szValue, (_tcslen(pLabelContext->szValue) +1) * sizeof(TCHAR));
+            RegSetValueExW(hSubKey, NULL, 0, REG_EXPAND_SZ, (LPBYTE)pLabelContext->szValue, (wcslen(pLabelContext->szValue) +1) * sizeof(WCHAR));
             RegCloseKey(hSubKey);
         }
 
@@ -1019,7 +1019,7 @@ ApplyChanges(HWND hwndDlg)
     }
     RegCloseKey(hKey);
 
-    SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, (LONG_PTR)PSNRET_NOERROR);
+    SetWindowLongPtrW(hwndDlg, DWLP_MSGRESULT, (LONG_PTR)PSNRET_NOERROR);
     return TRUE;
 }
 
@@ -1101,20 +1101,20 @@ SoundsDlgProc(HWND hwndDlg,
     LPWSTR pFileName;
     LRESULT lResult;
 
-    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
+    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
     switch (uMsg)
     {
         case WM_INITDIALOG:
         {
             pGlobalData = (PGLOBAL_DATA)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
-            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
+            SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
 
             pGlobalData->NumWavOut = waveOutGetNumDevs();
 
-            SendMessage(GetDlgItem(hwndDlg, IDC_PLAY_SOUND),
+            SendMessageW(GetDlgItem(hwndDlg, IDC_PLAY_SOUND),
                         BM_SETIMAGE,(WPARAM)IMAGE_ICON,
-                        (LPARAM)(HANDLE)LoadIcon(hApplet, MAKEINTRESOURCE(IDI_PLAY_ICON)));
+                        (LPARAM)(HANDLE)LoadIconW(hApplet, MAKEINTRESOURCEW(IDI_PLAY_ICON)));
 
             pGlobalData->hSoundsImageList = InitImageList(IDI_SOUND_SECTION,
                                                           IDI_SOUND_ASSIGNED,
@@ -1184,7 +1184,7 @@ SoundsDlgProc(HWND hwndDlg,
                     lIndex = ComboBox_GetItemData(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex);
                     if (lIndex != CB_ERR)
                     {
-                        PlaySound((TCHAR*)lIndex, NULL, SND_FILENAME);
+                        PlaySoundW((WCHAR*)lIndex, NULL, SND_FILENAME);
                     }
                     break;
                 }
@@ -1208,7 +1208,7 @@ SoundsDlgProc(HWND hwndDlg,
                     {
                         PLABEL_CONTEXT pLabelContext;
                         HTREEITEM hItem;
-                        TVITEM item;
+                        TVITEMW item;
                         LRESULT lIndex;
 
                         hItem = TreeView_GetSelection(GetDlgItem(hwndDlg, IDC_SCHEME_LIST));
@@ -1252,7 +1252,7 @@ SoundsDlgProc(HWND hwndDlg,
                                 break;
                             }
 
-                            if (_tcsicmp(pLabelContext->szValue, (TCHAR*)lResult) || (lIndex != pLabelContext->szValue[0]))
+                            if (_wcsicmp(pLabelContext->szValue, (WCHAR*)lResult) || (lIndex != pLabelContext->szValue[0]))
                             {
                                 /* Update the tree view item image */
                                 item.mask = TVIF_IMAGE | TVIF_SELECTEDIMAGE;
@@ -1265,10 +1265,10 @@ SoundsDlgProc(HWND hwndDlg,
                                 ///
                                 /// Should store in current member
                                 ///
-                                _tcscpy(pLabelContext->szValue, (TCHAR*)lResult);
+                                wcscpy(pLabelContext->szValue, (WCHAR*)lResult);
                             }
 
-                            if (_tcslen((TCHAR*)lResult) && lIndex != 0 && pGlobalData->NumWavOut != 0)
+                            if (wcslen((WCHAR*)lResult) && lIndex != 0 && pGlobalData->NumWavOut != 0)
                             {
                                 EnableWindow(GetDlgItem(hwndDlg, IDC_PLAY_SOUND), TRUE);
                             }
@@ -1296,7 +1296,7 @@ SoundsDlgProc(HWND hwndDlg,
         case WM_NOTIFY:
         {
             PLABEL_CONTEXT pLabelContext;
-            TCHAR * ptr;
+            WCHAR * ptr;
 
             LPNMHDR lpnm = (LPNMHDR)lParam;
 
@@ -1309,7 +1309,7 @@ SoundsDlgProc(HWND hwndDlg,
                 }
                 case TVN_SELCHANGED:
                 {
-                    LPNMTREEVIEW nm = (LPNMTREEVIEW)lParam;
+                    LPNMTREEVIEWW nm = (LPNMTREEVIEWW)lParam;
                     LRESULT lCount, lIndex, lResult;
 
                     pLabelContext = (PLABEL_CONTEXT)nm->itemNew.lParam;
@@ -1326,7 +1326,7 @@ SoundsDlgProc(HWND hwndDlg,
                     EnableWindow(GetDlgItem(hwndDlg, IDC_TEXT_SOUND), TRUE);
                     EnableWindow(GetDlgItem(hwndDlg, IDC_BROWSE_SOUND), TRUE);
 
-                    if (_tcslen(pLabelContext->szValue) == 0)
+                    if (wcslen(pLabelContext->szValue) == 0)
                     {
                         lIndex = ComboBox_SetCurSel(GetDlgItem(hwndDlg, IDC_SOUND_LIST), 0);
                         EnableWindow(GetDlgItem(hwndDlg, IDC_PLAY_SOUND), FALSE);
@@ -1343,14 +1343,14 @@ SoundsDlgProc(HWND hwndDlg,
                         if (lResult == CB_ERR || lResult == 0)
                             continue;
 
-                        if (!_tcscmp((TCHAR*)lResult, pLabelContext->szValue))
+                        if (!wcscmp((WCHAR*)lResult, pLabelContext->szValue))
                         {
                             ComboBox_SetCurSel(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex);
                             return FALSE;
                         }
                     }
 
-                    ptr = _tcsrchr(pLabelContext->szValue, _T('\\'));
+                    ptr = wcsrchr(pLabelContext->szValue, L'\\');
                     if (ptr)
                     {
                         ptr++;
@@ -1363,7 +1363,7 @@ SoundsDlgProc(HWND hwndDlg,
                     lIndex = ComboBox_AddString(GetDlgItem(hwndDlg, IDC_SOUND_LIST), ptr);
                     if (lIndex != CB_ERR)
                     {
-                        ComboBox_SetItemData(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex, _tcsdup(pLabelContext->szValue));
+                        ComboBox_SetItemData(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex, _wcsdup(pLabelContext->szValue));
                         ComboBox_SetCurSel(GetDlgItem(hwndDlg, IDC_SOUND_LIST), lIndex);
                     }
                     break;

--- a/dll/cpl/mmsys/speakervolume.c
+++ b/dll/cpl/mmsys/speakervolume.c
@@ -26,38 +26,38 @@ OnInitDialog(
     PPAGE_DATA pPageData,
     HWND hwndDlg)
 {
-    TCHAR szBuffer[256];
-    MIXERLINE mxln;
-    MIXERCONTROL mxc;
-    MIXERLINECONTROLS mxlctrl;
+    WCHAR szBuffer[256];
+    MIXERLINEW mxln;
+    MIXERCONTROLW mxc;
+    MIXERLINECONTROLSW mxlctrl;
     MIXERCONTROLDETAILS mxcd;
     INT i, j;
 
     /* Open the mixer */
     if (mixerOpen(&pPageData->hMixer, 0, PtrToUlong(hwndDlg), 0, MIXER_OBJECTF_MIXER | CALLBACK_WINDOW) != MMSYSERR_NOERROR)
     {
-        MessageBox(hwndDlg, _T("Cannot open mixer"), NULL, MB_OK);
+        MessageBoxW(hwndDlg, L"Cannot open mixer", NULL, MB_OK);
         return FALSE;
     }
 
     /* Retrieve the mixer information */
-    mxln.cbStruct = sizeof(MIXERLINE);
+    mxln.cbStruct = sizeof(MIXERLINEW);
     mxln.dwComponentType = MIXERLINE_COMPONENTTYPE_DST_SPEAKERS;
 
-    if (mixerGetLineInfo((HMIXEROBJ)pPageData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE) != MMSYSERR_NOERROR)
+    if (mixerGetLineInfoW((HMIXEROBJ)pPageData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE) != MMSYSERR_NOERROR)
         return FALSE;
 
     pPageData->volumeChannels = mxln.cChannels;
 
     /* Retrieve the line information */
-    mxlctrl.cbStruct = sizeof(MIXERLINECONTROLS);
+    mxlctrl.cbStruct = sizeof(MIXERLINECONTROLSW);
     mxlctrl.dwLineID = mxln.dwLineID;
     mxlctrl.dwControlType = MIXERCONTROL_CONTROLTYPE_VOLUME;
     mxlctrl.cControls = 1;
-    mxlctrl.cbmxctrl = sizeof(MIXERCONTROL);
+    mxlctrl.cbmxctrl = sizeof(MIXERCONTROLW);
     mxlctrl.pamxctrl = &mxc;
 
-    if (mixerGetLineControls((HMIXEROBJ)pPageData->hMixer, &mxlctrl, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE) != MMSYSERR_NOERROR)
+    if (mixerGetLineControlsW((HMIXEROBJ)pPageData->hMixer, &mxlctrl, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE) != MMSYSERR_NOERROR)
         return FALSE;
 
     pPageData->volumeControlID = mxc.dwControlID;
@@ -80,7 +80,7 @@ OnInitDialog(
     mxcd.cbDetails = sizeof(MIXERCONTROLDETAILS_UNSIGNED);
     mxcd.paDetails = pPageData->volumeValues;
 
-    if (mixerGetControlDetails((HMIXEROBJ)pPageData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE) != MMSYSERR_NOERROR)
+    if (mixerGetControlDetailsW((HMIXEROBJ)pPageData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE) != MMSYSERR_NOERROR)
         return FALSE;
 
     /* Initialize the channels */
@@ -89,14 +89,14 @@ OnInitDialog(
         j = i * 4;
 
         /* Set the channel name */
-        LoadString(hApplet, IDS_SPEAKER_LEFT + i, szBuffer, _countof(szBuffer));
-        SetWindowText(GetDlgItem(hwndDlg, 9472 + j), szBuffer);
+        LoadStringW(hApplet, IDS_SPEAKER_LEFT + i, szBuffer, _countof(szBuffer));
+        SetWindowTextW(GetDlgItem(hwndDlg, 9472 + j), szBuffer);
 
         /* Initialize the channel trackbar */
-        SendDlgItemMessage(hwndDlg, 9475 + j, TBM_SETRANGE, (WPARAM)TRUE, (LPARAM)MAKELONG(VOLUME_MIN, VOLUME_MAX));
-        SendDlgItemMessage(hwndDlg, 9475 + j, TBM_SETTICFREQ, VOLUME_TICFREQ, 0);
-        SendDlgItemMessage(hwndDlg, 9475 + j, TBM_SETPAGESIZE, 0, VOLUME_PAGESIZE);
-        SendDlgItemMessage(hwndDlg, 9475 + j, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pPageData->volumeValues[i].dwValue - pPageData->volumeMinimum) / pPageData->volumeStep);
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETRANGE, (WPARAM)TRUE, (LPARAM)MAKELONG(VOLUME_MIN, VOLUME_MAX));
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETTICFREQ, VOLUME_TICFREQ, 0);
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETPAGESIZE, 0, VOLUME_PAGESIZE);
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pPageData->volumeValues[i].dwValue - pPageData->volumeMinimum) / pPageData->volumeStep);
     }
 
     /* Hide the unused controls */
@@ -130,14 +130,14 @@ OnMixerControlChange(
     mxcd.cbDetails = sizeof(MIXERCONTROLDETAILS_UNSIGNED);
     mxcd.paDetails = pPageData->volumeValues;
 
-    if (mixerGetControlDetails((HMIXEROBJ)pPageData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE) != MMSYSERR_NOERROR)
+    if (mixerGetControlDetailsW((HMIXEROBJ)pPageData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE) != MMSYSERR_NOERROR)
         return;
 
     for (i = 0; i < pPageData->volumeChannels; i++)
     {
         j = i * 4;
 
-        SendDlgItemMessage(hwndDlg, 9475 + j, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pPageData->volumeValues[i].dwValue - pPageData->volumeMinimum) / pPageData->volumeStep);
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pPageData->volumeValues[i].dwValue - pPageData->volumeMinimum) / pPageData->volumeStep);
     }
 }
 
@@ -154,14 +154,14 @@ OnHScroll(
     DWORD dwValue, dwPosition;
     INT id, idx, i, j;
 
-    id = (INT)GetWindowLongPtr((HWND)lParam, GWLP_ID);
+    id = (INT)GetWindowLongPtrW((HWND)lParam, GWLP_ID);
     if (id < 9475 || id > 9503)
         return;
 
     if ((id - 9475) % 4 != 0)
         return;
 
-    dwPosition = (DWORD)SendDlgItemMessage(hwndDlg, id, TBM_GETPOS, 0, 0);
+    dwPosition = (DWORD)SendDlgItemMessageW(hwndDlg, id, TBM_GETPOS, 0, 0);
 
     if (dwPosition == VOLUME_MIN)
         dwValue = pPageData->volumeMinimum;
@@ -176,7 +176,7 @@ OnHScroll(
         {
             j = 9475 + (i * 4);
             if (j != id)
-                SendDlgItemMessage(hwndDlg, j, TBM_SETPOS, (WPARAM)TRUE, dwPosition);
+                SendDlgItemMessageW(hwndDlg, j, TBM_SETPOS, (WPARAM)TRUE, dwPosition);
 
             pPageData->volumeValues[i].dwValue = dwValue;
         }
@@ -237,13 +237,13 @@ SpeakerVolumeDlgProc(
 
     UNREFERENCED_PARAMETER(wParam);
 
-    pPageData = (PPAGE_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
+    pPageData = (PPAGE_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
     switch(uMsg)
     {
         case WM_INITDIALOG:
             pPageData = (PPAGE_DATA)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PAGE_DATA));
-            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pPageData);
+            SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)pPageData);
 
             if (pPageData)
             {
@@ -262,7 +262,7 @@ SpeakerVolumeDlgProc(
 
                 HeapFree(GetProcessHeap(), 0, pPageData);
                 pPageData = NULL;
-                SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)NULL);
+                SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)NULL);
             }
             break;
 
@@ -279,7 +279,7 @@ SpeakerVolumeDlgProc(
             {
                 case 9504:
                     if (HIWORD(wParam) == BN_CLICKED)
-                        pPageData->volumeSync = (SendDlgItemMessage(hwndDlg, 9504, BM_GETCHECK, 0, 0) == BST_CHECKED);
+                        pPageData->volumeSync = (SendDlgItemMessageW(hwndDlg, 9504, BM_GETCHECK, 0, 0) == BST_CHECKED);
                     break;
 
                 case 9505:
@@ -306,16 +306,16 @@ INT_PTR
 SpeakerVolume(
     HWND hwndDlg)
 {
-    PROPSHEETPAGE psp[1];
-    PROPSHEETHEADER psh;
+    PROPSHEETPAGEW psp[1];
+    PROPSHEETHEADERW psh;
 
-    ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
-    psh.dwSize = sizeof(PROPSHEETHEADER);
+    ZeroMemory(&psh, sizeof(PROPSHEETHEADERW));
+    psh.dwSize = sizeof(PROPSHEETHEADERW);
     psh.dwFlags =  PSH_PROPSHEETPAGE;
     psh.hwndParent = hwndDlg;
     psh.hInstance = hApplet;
     psh.pszCaption = MAKEINTRESOURCE(IDS_SPEAKER_VOLUME);
-    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
+    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
     psh.nStartPage = 0;
     psh.ppsp = psp;
 
@@ -324,5 +324,5 @@ SpeakerVolume(
     psp[0].hInstance = hApplet;
     psp[0].pszTitle = MAKEINTRESOURCE(IDS_SPEAKER_VOLUME);
 
-    return (LONG)(PropertySheet(&psh) != -1);
+    return (LONG)(PropertySheetW(&psh) != -1);
 }

--- a/dll/cpl/mmsys/speakervolume.c
+++ b/dll/cpl/mmsys/speakervolume.c
@@ -235,11 +235,9 @@ SpeakerVolumeDlgProc(
 {
     PPAGE_DATA pPageData;
 
-    UNREFERENCED_PARAMETER(wParam);
-
     pPageData = (PPAGE_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
-    switch(uMsg)
+    switch (uMsg)
     {
         case WM_INITDIALOG:
             pPageData = (PPAGE_DATA)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(PAGE_DATA));
@@ -315,7 +313,7 @@ SpeakerVolume(
     psh.hwndParent = hwndDlg;
     psh.hInstance = hApplet;
     psh.pszCaption = MAKEINTRESOURCE(IDS_SPEAKER_VOLUME);
-    psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
+    psh.nPages = _countof(psp);
     psh.nStartPage = 0;
     psh.ppsp = psp;
 

--- a/dll/cpl/mmsys/speakervolume.c
+++ b/dll/cpl/mmsys/speakervolume.c
@@ -93,7 +93,7 @@ OnInitDialog(
         SetWindowTextW(GetDlgItem(hwndDlg, 9472 + j), szBuffer);
 
         /* Initialize the channel trackbar */
-        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETRANGE, (WPARAM)TRUE, (LPARAM)MAKELONG(VOLUME_MIN, VOLUME_MAX));
+        SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETRANGE, (WPARAM)TRUE, MAKELPARAM(VOLUME_MIN, VOLUME_MAX));
         SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETTICFREQ, VOLUME_TICFREQ, 0);
         SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETPAGESIZE, 0, VOLUME_PAGESIZE);
         SendDlgItemMessageW(hwndDlg, 9475 + j, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pPageData->volumeValues[i].dwValue - pPageData->volumeMinimum) / pPageData->volumeStep);

--- a/dll/cpl/mmsys/voice.c
+++ b/dll/cpl/mmsys/voice.c
@@ -19,6 +19,7 @@ VoiceDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
+    
     switch (uMsg)
     {
         case WM_INITDIALOG:

--- a/dll/cpl/mmsys/voice.c
+++ b/dll/cpl/mmsys/voice.c
@@ -19,8 +19,7 @@ VoiceDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
-    UNREFERENCED_PARAMETER(hwndDlg);
-    switch(uMsg)
+    switch (uMsg)
     {
         case WM_INITDIALOG:
         {

--- a/dll/cpl/mmsys/voice.c
+++ b/dll/cpl/mmsys/voice.c
@@ -19,7 +19,6 @@ VoiceDlgProc(HWND hwndDlg,
 {
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
-    
     switch (uMsg)
     {
         case WM_INITDIALOG:

--- a/dll/cpl/mmsys/volume.c
+++ b/dll/cpl/mmsys/volume.c
@@ -170,7 +170,6 @@ GetVolumeControl(PGLOBAL_DATA pGlobalData)
     mxlc.cControls = 1;
     mxlc.cbmxctrl = sizeof(MIXERCONTROLW);
     mxlc.pamxctrl = &mxc;
-    
     if (mixerGetLineControlsW((HMIXEROBJ)pGlobalData->hMixer, &mxlc, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
         != MMSYSERR_NOERROR)
         return;

--- a/dll/cpl/mmsys/volume.c
+++ b/dll/cpl/mmsys/volume.c
@@ -52,11 +52,11 @@ InitImageInfo(PIMGINFO ImgInfo)
     ZeroMemory(ImgInfo, sizeof(*ImgInfo));
 
     ImgInfo->hBitmap = LoadImageW(hApplet,
-                                 MAKEINTRESOURCEW(IDB_SPEAKIMG),
-                                 IMAGE_BITMAP,
-                                 0,
-                                 0,
-                                 LR_DEFAULTCOLOR);
+                                  MAKEINTRESOURCEW(IDB_SPEAKIMG),
+                                  IMAGE_BITMAP,
+                                  0,
+                                  0,
+                                  LR_DEFAULTCOLOR);
 
     if (ImgInfo->hBitmap != NULL)
     {
@@ -82,7 +82,8 @@ GetMuteControl(PGLOBAL_DATA pGlobalData)
     mxln.dwComponentType = MIXERLINE_COMPONENTTYPE_DST_SPEAKERS;
 
     if (mixerGetLineInfoW((HMIXEROBJ)pGlobalData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE)
-        != MMSYSERR_NOERROR) return;
+        != MMSYSERR_NOERROR)
+        return;
 
     mxlctrl.cbStruct = sizeof(MIXERLINECONTROLSW);
     mxlctrl.dwLineID = mxln.dwLineID;
@@ -92,7 +93,8 @@ GetMuteControl(PGLOBAL_DATA pGlobalData)
     mxlctrl.pamxctrl = &mxc;
 
     if (mixerGetLineControlsW((HMIXEROBJ)pGlobalData->hMixer, &mxlctrl, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
-        != MMSYSERR_NOERROR) return;
+        != MMSYSERR_NOERROR)
+        return;
 
     pGlobalData->muteControlID = mxc.dwControlID;
 }
@@ -259,7 +261,7 @@ SetVolumeValue(PGLOBAL_DATA pGlobalData,
         else
         {
             pGlobalData->volumeCurrentValues[i].dwValue =
-                pGlobalData->volumePreviousValues[i].dwValue * dwVolume / pGlobalData-> maxVolume;
+                pGlobalData->volumePreviousValues[i].dwValue * dwVolume / pGlobalData->maxVolume;
         }
     }
 
@@ -377,12 +379,12 @@ InitVolumeControls(HWND hwndDlg, PGLOBAL_DATA pGlobalData)
     GetMuteState(pGlobalData);
     if (pGlobalData->muteVal)
     {
-        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, 0);
         SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
     }
     else
     {
-        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, 0);
         SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
     }
 
@@ -421,24 +423,22 @@ VolumeDlgProc(HWND hwndDlg,
 {
     static IMGINFO ImgInfo;
     PGLOBAL_DATA pGlobalData;
-    UNREFERENCED_PARAMETER(lParam);
-    UNREFERENCED_PARAMETER(wParam);
 
     pGlobalData = (PGLOBAL_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
-    switch(uMsg)
+    switch (uMsg)
     {
         case MM_MIXM_LINE_CHANGE:
         {
             GetMuteState(pGlobalData);
             if (pGlobalData->muteVal)
             {
-                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, 0);
                 SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
             }
             else
             {
-                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, 0);
                 SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
             }
             break;
@@ -451,7 +451,7 @@ VolumeDlgProc(HWND hwndDlg,
         }
         case WM_INITDIALOG:
         {
-            pGlobalData = (GLOBAL_DATA*) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
+            pGlobalData = (PGLOBAL_DATA)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
             SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
 
             pGlobalData->hIconUnMuted = LoadImageW(hApplet, MAKEINTRESOURCEW(IDI_CPLICON), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
@@ -466,8 +466,8 @@ VolumeDlgProc(HWND hwndDlg,
         case WM_DRAWITEM:
         {
             LPDRAWITEMSTRUCT lpDrawItem;
-            lpDrawItem = (LPDRAWITEMSTRUCT) lParam;
-            if(lpDrawItem->CtlID == IDC_SPEAKIMG)
+            lpDrawItem = (LPDRAWITEMSTRUCT)lParam;
+            if (lpDrawItem->CtlID == IDC_SPEAKIMG)
             {
                 HDC hdcMem;
                 LONG left;

--- a/dll/cpl/mmsys/volume.c
+++ b/dll/cpl/mmsys/volume.c
@@ -170,6 +170,7 @@ GetVolumeControl(PGLOBAL_DATA pGlobalData)
     mxlc.cControls = 1;
     mxlc.cbmxctrl = sizeof(MIXERCONTROLW);
     mxlc.pamxctrl = &mxc;
+    
     if (mixerGetLineControlsW((HMIXEROBJ)pGlobalData->hMixer, &mxlc, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
         != MMSYSERR_NOERROR)
         return;

--- a/dll/cpl/mmsys/volume.c
+++ b/dll/cpl/mmsys/volume.c
@@ -51,8 +51,8 @@ InitImageInfo(PIMGINFO ImgInfo)
 
     ZeroMemory(ImgInfo, sizeof(*ImgInfo));
 
-    ImgInfo->hBitmap = LoadImage(hApplet,
-                                 MAKEINTRESOURCE(IDB_SPEAKIMG),
+    ImgInfo->hBitmap = LoadImageW(hApplet,
+                                 MAKEINTRESOURCEW(IDB_SPEAKIMG),
                                  IMAGE_BITMAP,
                                  0,
                                  0,
@@ -60,7 +60,7 @@ InitImageInfo(PIMGINFO ImgInfo)
 
     if (ImgInfo->hBitmap != NULL)
     {
-        GetObject(ImgInfo->hBitmap, sizeof(BITMAP), &bitmap);
+        GetObjectW(ImgInfo->hBitmap, sizeof(BITMAP), &bitmap);
 
         ImgInfo->cxSource = bitmap.bmWidth;
         ImgInfo->cySource = bitmap.bmHeight;
@@ -71,27 +71,27 @@ InitImageInfo(PIMGINFO ImgInfo)
 VOID
 GetMuteControl(PGLOBAL_DATA pGlobalData)
 {
-    MIXERLINE mxln;
-    MIXERCONTROL mxc;
-    MIXERLINECONTROLS mxlctrl;
+    MIXERLINEW mxln;
+    MIXERCONTROLW mxc;
+    MIXERLINECONTROLSW mxlctrl;
 
     if (pGlobalData->hMixer == NULL)
         return;
 
-    mxln.cbStruct = sizeof(MIXERLINE);
+    mxln.cbStruct = sizeof(MIXERLINEW);
     mxln.dwComponentType = MIXERLINE_COMPONENTTYPE_DST_SPEAKERS;
 
-    if (mixerGetLineInfo((HMIXEROBJ)pGlobalData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE)
+    if (mixerGetLineInfoW((HMIXEROBJ)pGlobalData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE)
         != MMSYSERR_NOERROR) return;
 
-    mxlctrl.cbStruct = sizeof(MIXERLINECONTROLS);
+    mxlctrl.cbStruct = sizeof(MIXERLINECONTROLSW);
     mxlctrl.dwLineID = mxln.dwLineID;
     mxlctrl.dwControlType = MIXERCONTROL_CONTROLTYPE_MUTE;
     mxlctrl.cControls = 1;
-    mxlctrl.cbmxctrl = sizeof(MIXERCONTROL);
+    mxlctrl.cbmxctrl = sizeof(MIXERCONTROLW);
     mxlctrl.pamxctrl = &mxc;
 
-    if (mixerGetLineControls((HMIXEROBJ)pGlobalData->hMixer, &mxlctrl, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
+    if (mixerGetLineControlsW((HMIXEROBJ)pGlobalData->hMixer, &mxlctrl, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
         != MMSYSERR_NOERROR) return;
 
     pGlobalData->muteControlID = mxc.dwControlID;
@@ -114,7 +114,7 @@ GetMuteState(PGLOBAL_DATA pGlobalData)
     mxcd.cbDetails = sizeof(MIXERCONTROLDETAILS_BOOLEAN);
     mxcd.paDetails = &mxcdMute;
 
-    if (mixerGetControlDetails((HMIXEROBJ)pGlobalData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE)
+    if (mixerGetControlDetailsW((HMIXEROBJ)pGlobalData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE)
         != MMSYSERR_NOERROR)
         return;
 
@@ -147,28 +147,28 @@ SwitchMuteState(PGLOBAL_DATA pGlobalData)
 VOID
 GetVolumeControl(PGLOBAL_DATA pGlobalData)
 {
-    MIXERLINE mxln;
-    MIXERCONTROL mxc;
-    MIXERLINECONTROLS mxlc;
+    MIXERLINEW mxln;
+    MIXERCONTROLW mxc;
+    MIXERLINECONTROLSW mxlc;
 
     if (pGlobalData->hMixer == NULL)
         return;
 
-    mxln.cbStruct = sizeof(MIXERLINE);
+    mxln.cbStruct = sizeof(MIXERLINEW);
     mxln.dwComponentType = MIXERLINE_COMPONENTTYPE_DST_SPEAKERS;
-    if (mixerGetLineInfo((HMIXEROBJ)pGlobalData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE)
+    if (mixerGetLineInfoW((HMIXEROBJ)pGlobalData->hMixer, &mxln, MIXER_OBJECTF_HMIXER | MIXER_GETLINEINFOF_COMPONENTTYPE)
         != MMSYSERR_NOERROR)
         return;
 
     pGlobalData->volumeChannels = mxln.cChannels;
 
-    mxlc.cbStruct = sizeof(MIXERLINECONTROLS);
+    mxlc.cbStruct = sizeof(MIXERLINECONTROLSW);
     mxlc.dwLineID = mxln.dwLineID;
     mxlc.dwControlType = MIXERCONTROL_CONTROLTYPE_VOLUME;
     mxlc.cControls = 1;
-    mxlc.cbmxctrl = sizeof(MIXERCONTROL);
+    mxlc.cbmxctrl = sizeof(MIXERCONTROLW);
     mxlc.pamxctrl = &mxc;
-    if (mixerGetLineControls((HMIXEROBJ)pGlobalData->hMixer, &mxlc, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
+    if (mixerGetLineControlsW((HMIXEROBJ)pGlobalData->hMixer, &mxlc, MIXER_OBJECTF_HMIXER | MIXER_GETLINECONTROLSF_ONEBYTYPE)
         != MMSYSERR_NOERROR)
         return;
 
@@ -215,7 +215,7 @@ GetVolumeValue(
     mxcd.cbDetails = sizeof(MIXERCONTROLDETAILS_UNSIGNED);
     mxcd.paDetails = pGlobalData->volumePreviousValues;
 
-    if (mixerGetControlDetails((HMIXEROBJ)pGlobalData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE)
+    if (mixerGetControlDetailsW((HMIXEROBJ)pGlobalData->hMixer, &mxcd, MIXER_OBJECTF_HMIXER | MIXER_GETCONTROLDETAILSF_VALUE)
         != MMSYSERR_NOERROR)
         return;
 
@@ -331,14 +331,14 @@ VOID
 InitVolumeControls(HWND hwndDlg, PGLOBAL_DATA pGlobalData)
 {
     UINT NumMixers;
-    MIXERCAPS mxc;
-    TCHAR szNoDevices[256];
+    MIXERCAPSW mxc;
+    WCHAR szNoDevices[256];
 
-    LoadString(hApplet, IDS_NO_DEVICES, szNoDevices, _countof(szNoDevices));
+    LoadStringW(hApplet, IDS_NO_DEVICES, szNoDevices, _countof(szNoDevices));
 
-    SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETRANGE, (WPARAM)TRUE, (LPARAM)MAKELONG(VOLUME_MIN, VOLUME_MAX));
-    SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETTICFREQ, VOLUME_TICFREQ, 0);
-    SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPAGESIZE, 0, VOLUME_PAGESIZE);
+    SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETRANGE, (WPARAM)TRUE, (LPARAM)MAKELONG(VOLUME_MIN, VOLUME_MAX));
+    SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETTICFREQ, VOLUME_TICFREQ, 0);
+    SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPAGESIZE, 0, VOLUME_PAGESIZE);
 
     NumMixers = mixerGetNumDevs();
     if (!NumMixers)
@@ -351,21 +351,21 @@ InitVolumeControls(HWND hwndDlg, PGLOBAL_DATA pGlobalData)
         EnableWindow(GetDlgItem(hwndDlg, IDC_ADVANCED_BTN),    FALSE);
         EnableWindow(GetDlgItem(hwndDlg, IDC_SPEAKER_VOL_BTN), FALSE);
         EnableWindow(GetDlgItem(hwndDlg, IDC_ADVANCED2_BTN),   FALSE);
-        SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconNoHW);
-        SetDlgItemText(hwndDlg, IDC_DEVICE_NAME, szNoDevices);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconNoHW);
+        SetDlgItemTextW(hwndDlg, IDC_DEVICE_NAME, szNoDevices);
         return;
     }
 
     if (mixerOpen(&pGlobalData->hMixer, 0, PtrToUlong(hwndDlg), 0, MIXER_OBJECTF_MIXER | CALLBACK_WINDOW) != MMSYSERR_NOERROR)
     {
-        MessageBox(hwndDlg, _T("Cannot open mixer"), NULL, MB_OK);
+        MessageBoxW(hwndDlg, L"Cannot open mixer", NULL, MB_OK);
         return;
     }
 
-    ZeroMemory(&mxc, sizeof(MIXERCAPS));
-    if (mixerGetDevCaps(PtrToUint(pGlobalData->hMixer), &mxc, sizeof(MIXERCAPS)) != MMSYSERR_NOERROR)
+    ZeroMemory(&mxc, sizeof(MIXERCAPSW));
+    if (mixerGetDevCapsW(PtrToUint(pGlobalData->hMixer), &mxc, sizeof(MIXERCAPSW)) != MMSYSERR_NOERROR)
     {
-        MessageBox(hwndDlg, _T("mixerGetDevCaps failed"), NULL, MB_OK);
+        MessageBoxW(hwndDlg, L"mixerGetDevCaps failed", NULL, MB_OK);
         return;
     }
 
@@ -377,20 +377,20 @@ InitVolumeControls(HWND hwndDlg, PGLOBAL_DATA pGlobalData)
     GetMuteState(pGlobalData);
     if (pGlobalData->muteVal)
     {
-        SendDlgItemMessage(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
-        SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
     }
     else
     {
-        SendDlgItemMessage(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
-        SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
+        SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
     }
 
     GetVolumeControl(pGlobalData);
     GetVolumeValue(pGlobalData, TRUE);
 
-    SendDlgItemMessage(hwndDlg, IDC_DEVICE_NAME, WM_SETTEXT, 0, (LPARAM)mxc.szPname);
-    SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pGlobalData->maxVolume - pGlobalData->volumeMinimum) / pGlobalData->volumeStep);
+    SendDlgItemMessageW(hwndDlg, IDC_DEVICE_NAME, WM_SETTEXT, 0, (LPARAM)mxc.szPname);
+    SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pGlobalData->maxVolume - pGlobalData->volumeMinimum) / pGlobalData->volumeStep);
 }
 
 VOID
@@ -408,7 +408,7 @@ LaunchSoundControl(HWND hwndDlg)
 {
     if ((INT_PTR)ShellExecuteW(NULL, L"open", L"sndvol32.exe", NULL, NULL, SW_SHOWNORMAL) > 32)
         return;
-    MessageBox(hwndDlg, _T("Cannot run sndvol32.exe"), NULL, MB_OK);
+    MessageBoxW(hwndDlg, L"Cannot run sndvol32.exe", NULL, MB_OK);
 }
 
 /* Volume property page dialog callback */
@@ -424,7 +424,7 @@ VolumeDlgProc(HWND hwndDlg,
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
 
-    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtr(hwndDlg, DWLP_USER);
+    pGlobalData = (PGLOBAL_DATA)GetWindowLongPtrW(hwndDlg, DWLP_USER);
 
     switch(uMsg)
     {
@@ -433,30 +433,30 @@ VolumeDlgProc(HWND hwndDlg,
             GetMuteState(pGlobalData);
             if (pGlobalData->muteVal)
             {
-                SendDlgItemMessage(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
-                SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_CHECKED, (LPARAM)0);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
             }
             else
             {
-                SendDlgItemMessage(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
-                SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_CHECKBOX, BM_SETCHECK, (WPARAM)BST_UNCHECKED, (LPARAM)0);
+                SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
             }
             break;
         }
         case MM_MIXM_CONTROL_CHANGE:
         {
             GetVolumeValue(pGlobalData, FALSE);
-            SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pGlobalData->maxVolume - pGlobalData->volumeMinimum) / pGlobalData->volumeStep);
+            SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_SETPOS, (WPARAM)TRUE, (LPARAM)(pGlobalData->maxVolume - pGlobalData->volumeMinimum) / pGlobalData->volumeStep);
             break;
         }
         case WM_INITDIALOG:
         {
             pGlobalData = (GLOBAL_DATA*) HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
-            SetWindowLongPtr(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
+            SetWindowLongPtrW(hwndDlg, DWLP_USER, (LONG_PTR)pGlobalData);
 
-            pGlobalData->hIconUnMuted = LoadImage(hApplet, MAKEINTRESOURCE(IDI_CPLICON), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
-            pGlobalData->hIconMuted = LoadImage(hApplet, MAKEINTRESOURCE(IDI_MUTED_ICON), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
-            pGlobalData->hIconNoHW = LoadImage(hApplet, MAKEINTRESOURCE(IDI_NO_HW), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
+            pGlobalData->hIconUnMuted = LoadImageW(hApplet, MAKEINTRESOURCEW(IDI_CPLICON), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
+            pGlobalData->hIconMuted = LoadImageW(hApplet, MAKEINTRESOURCEW(IDI_MUTED_ICON), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
+            pGlobalData->hIconNoHW = LoadImageW(hApplet, MAKEINTRESOURCEW(IDI_NO_HW), IMAGE_ICON, 32, 32, LR_DEFAULTCOLOR);
 
             InitImageInfo(&ImgInfo);
             InitVolumeControls(hwndDlg, pGlobalData);
@@ -504,11 +504,11 @@ VolumeDlgProc(HWND hwndDlg,
                         SwitchMuteState(pGlobalData);
                         if (pGlobalData->muteVal)
                         {
-                            SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
+                            SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconMuted);
                         }
                         else
                         {
-                            SendDlgItemMessage(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
+                            SendDlgItemMessageW(hwndDlg, IDC_MUTE_ICON, STM_SETIMAGE, IMAGE_ICON, (LPARAM)pGlobalData->hIconUnMuted);
                         }
 
                         PropSheet_Changed(GetParent(hwndDlg), hwndDlg);
@@ -544,12 +544,12 @@ VolumeDlgProc(HWND hwndDlg,
                         break;
 
                     case TB_ENDTRACK:
-                        PlaySound((LPCTSTR)SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID | SND_ASYNC);
+                        PlaySoundW((LPCWSTR)SND_ALIAS_SYSTEMDEFAULT, NULL, SND_ALIAS_ID | SND_ASYNC);
                         break;
 
                     default:
                         SetVolumeValue(pGlobalData,
-                                       (DWORD)SendDlgItemMessage(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_GETPOS, 0, 0));
+                                       (DWORD)SendDlgItemMessageW(hwndDlg, IDC_VOLUME_TRACKBAR, TBM_GETPOS, 0, 0));
                         break;
                 }
             }


### PR DESCRIPTION
## Purpose
Multimedia Control Panel diverse fixes

## Proposed changes
- Use Unicode (WCHAR) instead of TCHAR
- Code formatting
- Use string safe functions
- Close handles after calling `CreateProcess`
- Save sound path as `REG_EXPAND_SZ` only if the path contains '%' character, like Windows does
- Fix `wcsdup` leaks
- ~~Fix incorrect `IDC_SPEAKIMG` control position and size~~ **Next PR**
- ~~Use transparent background for "Speaker settings" bitmap~~ **Next PR**
