### PR TITLE
[EXPLORER] Fix assertion failure on start button

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2687,6 +2687,7 @@ ChangePos:
             {
                 CComPtr<IContextMenu> ctxMenu;
                 CStartMenuBtnCtxMenu_CreateInstance(this, m_hWnd, &ctxMenu);
+                ctxMenu->AddRef();
                 TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this);
             }
         }


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18024](https://jira.reactos.org/browse/CORE-18024)

## Proposed changes

- Add `AddRef` call in `CStartButton::OnContextMenu`.

## Screenshots
BEFORE:
![before](https://user-images.githubusercontent.com/2107452/179517118-ee5e9597-00c8-414f-b9e8-bb755d78eca4.png)
FAILED.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/179517083-59b81c2b-abf5-4704-835c-cd9aa744fa33.png)
Success.