### PR TITLE
[DESK] Set focus to slide bar on PSN_SETACTIVE

### DIFF
--- a/dll/cpl/desk/settings.c
+++ b/dll/cpl/desk/settings.c
@@ -933,6 +933,10 @@ SettingsPageProc(IN HWND hwndDlg, IN UINT uMsg, IN WPARAM wParam, IN LPARAM lPar
                     Current = Current->Flink;
                 OnDisplayDeviceChanged(hwndDlg, pData, Current);
             }
+            else if (lpnm->code == PSN_SETACTIVE)
+            {
+                SetFocus(GetDlgItem(hwndDlg, IDC_SETTINGS_RESOLUTION));
+            }
             break;
         }
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-17939](https://jira.reactos.org/browse/CORE-17939)

## Screenshots

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/179674467-b7b15841-b836-4450-98d0-30c169cd13cf.png)
No focus (EDIT: To be precise, the focus is on the first large control).

AFTER:
![after](https://user-images.githubusercontent.com/2107452/179674463-068aa731-956e-4167-bafc-912f48c7fa17.png)
Got focus.