### PR TITLE
Amd64/misc kernel fixes

### DIFF
--- a/dll/win32/kernel32/client/except.c
+++ b/dll/win32/kernel32/client/except.c
@@ -104,7 +104,7 @@ PrintStackTrace(IN PEXCEPTION_POINTERS ExceptionInfo)
     if (ExceptionRecord->ExceptionCode == STATUS_ACCESS_VIOLATION &&
         ExceptionRecord->NumberParameters == 2)
     {
-        DbgPrint("Faulting Address: %8x\n", ExceptionRecord->ExceptionInformation[1]);
+        DbgPrint("Faulting Address: %p\n", (PVOID)ExceptionRecord->ExceptionInformation[1]);
     }
 
     /* Trace the wine special error and show the modulename and functionname */

--- a/hal/halx86/amd64/x86bios.c
+++ b/hal/halx86/amd64/x86bios.c
@@ -321,9 +321,15 @@ ValidatePort(
         case 0x3C9: return (Size == 1);
         case 0x3DA: return (Size == 1) && !IsWrite;
 
-        // CHECKME!
+        // OVMF debug messages used by VBox / QEMU
+        // https://www.virtualbox.org/svn/vbox/trunk/src/VBox/Devices/EFI/Firmware/OvmfPkg/README
+        case 0x402: return (Size == 1) && IsWrite;
+
+        // BOCHS VBE: https://forum.osdev.org/viewtopic.php?f=1&t=14639
         case 0x1CE: return (Size == 1) && IsWrite;
         case 0x1CF: return (Size == 1);
+
+        // CHECKME!
         case 0x3B6: return (Size <= 2);
     }
 

--- a/ntoskrnl/ke/amd64/except.c
+++ b/ntoskrnl/ke/amd64/except.c
@@ -119,6 +119,9 @@ KiDispatchExceptionToUser(
     /* Get pointer to the usermode context, exception record and machine frame */
     UserStack = (PKUSER_EXCEPTION_STACK)UserRsp;
 
+    /* Enable interrupts */
+    _enable();
+
     /* Set up the user-stack */
     _SEH2_TRY
     {
@@ -143,6 +146,7 @@ KiDispatchExceptionToUser(
         // FIXME: handle stack overflow
 
         /* Nothing we can do here */
+        _disable();
         _SEH2_YIELD(return);
     }
     _SEH2_END;
@@ -164,6 +168,8 @@ KiDispatchExceptionToUser(
 
     /* Set RIP to the User-mode Dispatcher */
     TrapFrame->Rip = (ULONG64)KeUserExceptionDispatcher;
+
+    _disable();
 
     /* Exit to usermode */
     KiServiceExit2(TrapFrame);
@@ -202,6 +208,9 @@ KiPrepareUserDebugData(void)
     Teb = KeGetCurrentThread()->Teb;
     if (!Teb) return;
 
+    /* Enable interrupts */
+    _enable();
+
     _SEH2_TRY
     {
         /* Get a pointer to the loader data */
@@ -230,6 +239,8 @@ KiPrepareUserDebugData(void)
     {
     }
     _SEH2_END;
+
+    _disable();
 }
 
 VOID

--- a/ntoskrnl/ke/amd64/except.c
+++ b/ntoskrnl/ke/amd64/except.c
@@ -361,9 +361,10 @@ KiDispatchException(IN PEXCEPTION_RECORD ExceptionRecord,
             /* Forward exception to user mode debugger */
             if (DbgkForwardException(ExceptionRecord, TRUE, FALSE)) return;
 
-            /* Forward exception to user mode (does not return) */
+            /* Forward exception to user mode (does not return, if successful) */
             KiDispatchExceptionToUser(TrapFrame, &Context, ExceptionRecord);
-            NT_ASSERT(FALSE);
+
+            /* Failed to dispatch, fall through for second chance handling */
         }
 
         /* Try second chance */

--- a/ntoskrnl/ke/amd64/stubs.c
+++ b/ntoskrnl/ke/amd64/stubs.c
@@ -115,6 +115,7 @@ KiSwitchKernelStack(PVOID StackBase, PVOID StackLimit)
     LONG_PTR StackOffset;
     SIZE_T StackSize;
     PKIPCR Pcr;
+    ULONG Eflags;
 
     /* Get the current thread */
     CurrentThread = KeGetCurrentThread();
@@ -135,6 +136,7 @@ KiSwitchKernelStack(PVOID StackBase, PVOID StackLimit)
     StackOffset = (PUCHAR)StackBase - (PUCHAR)CurrentThread->StackBase;
 
     /* Disable interrupts while messing with the stack */
+    Eflags = __readeflags();
     _disable();
 
     /* Set the new trap frame */
@@ -156,6 +158,9 @@ KiSwitchKernelStack(PVOID StackBase, PVOID StackLimit)
 
     /* Adjust Rsp0 in the TSS */
     Pcr->TssBase->Rsp0 += StackOffset;
+
+    /* Restore interrupts */
+    __writeeflags(Eflags);
 
     return OldStackBase;
 }

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -316,6 +316,10 @@ ENDFUNC
 
 PUBLIC KiDoubleFaultAbort
 FUNC KiDoubleFaultAbort
+
+    /* Hack for VBox, which "forgets" to push an error code on the stack! */
+    and rsp, HEX(FFFFFFFFFFFFFFF0)
+
     /* A zero error code is pushed */
     EnterTrap (TF_HAS_ERROR_CODE OR TF_SAVE_ALL)
 

--- a/ntoskrnl/ke/amd64/trap.S
+++ b/ntoskrnl/ke/amd64/trap.S
@@ -428,6 +428,10 @@ FUNC KiPageFault
     /* Save page fault address */
     mov rdx, cr2
     mov [rbp  + KTRAP_FRAME_FaultAddress], rdx
+    
+    /* If interrupts are off, treat this as an access violation */
+    test dword ptr [rbp + KTRAP_FRAME_EFlags], EFLAGS_IF_MASK
+    jz AccessViolation
 
     /* Enable interrupts for the page fault handler */
     sti

--- a/win32ss/gdi/ntgdi/bitmaps.c
+++ b/win32ss/gdi/ntgdi/bitmaps.c
@@ -333,6 +333,11 @@ IntCreateCompatibleBitmap(
                           Planes ? Planes : 1,
                           Bpp ? Bpp : dibs.dsBm.bmBitsPixel,
                           NULL);
+            if (Bmp == NULL)
+            {
+                DPRINT1("Failed to allocate a bitmap!\n");
+                return NULL;
+            }
             psurfBmp = SURFACE_ShareLockSurface(Bmp);
             ASSERT(psurfBmp);
 
@@ -342,7 +347,7 @@ IntCreateCompatibleBitmap(
             /* Set flags */
             psurfBmp->flags = API_BITMAP;
             psurfBmp->hdc = NULL; // FIXME:
-            psurf->SurfObj.hdev = (HDEV)Dc->ppdev;
+            psurfBmp->SurfObj.hdev = (HDEV)Dc->ppdev;
             SURFACE_ShareUnlockSurface(psurfBmp);
         }
         else if (Count == sizeof(DIBSECTION))

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -69,6 +69,11 @@ CreateDIBPalette(
                                     0,
                                     0,
                                     0);
+        if (ppal == NULL)
+        {
+            DPRINT1("Failed to allocate palette.\n");
+            return NULL;
+        }
 
         /* Check if the BITMAPINFO specifies how many colors to use */
         if ((pbmi->bmiHeader.biSize >= sizeof(BITMAPINFOHEADER)) &&


### PR DESCRIPTION
## Purpose

Misc kernel fixes

## Proposed changes

- [WIN32K] Add missing NULL checks
- [NTOS:KDBG] Improve x64 stack trace printing
- [HAL] Add missing I/O port to int 10 BIOS emulator
- [KERNEL32] Fix printing exception address
- [NTOS] Add a hack for VBox
- [NTOS:KE] Restore interrupts in KiSwitchKernelStack
- [NTOS:KE/X64] Enable interrupts when accessing user mode memory
- [NTOS] Treat page faults with interrupts disabled as access violation
- [NTOS] Don't assert, when dispatching an exception to user mode fails
