### PR TITLE
[NTUSER] Improve WINSTATION_OBJECT compatibility

### DIFF
--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -20,7 +20,7 @@ typedef struct _WINSTATION_OBJECT
     PRTL_ATOM_TABLE AtomTable;
 
     ULONG          Flags;
-    struct tagKL  *spklList;
+    struct tagKL*  spklList;
     PTHREADINFO    ptiClipLock;
     PTHREADINFO    ptiDrawingClipboard;
     PWND           spwndClipOpen;

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -11,18 +11,16 @@
 #define WSS_DYING         (16)
 #define WSS_REALSHUTDOWN  (32)
 
+// See also: https://reactos.org/wiki/Techwiki:Win32k/WINDOWSTATION
 typedef struct _WINSTATION_OBJECT
 {
     DWORD dwSessionId;
 
     LIST_ENTRY DesktopListHead;
     PRTL_ATOM_TABLE AtomTable;
-    HANDLE ShellWindow;
-    HANDLE ShellListView;
 
-    ULONG Flags;
-    struct _DESKTOP* ActiveDesktop;
-
+    ULONG          Flags;
+    struct tagKL  *spklList;
     PTHREADINFO    ptiClipLock;
     PTHREADINFO    ptiDrawingClipboard;
     PWND           spwndClipOpen;
@@ -40,7 +38,20 @@ typedef struct _WINSTATION_OBJECT
     LUID           luidUser;
     PVOID          psidUser;
 
+    struct _DESKTOP* ActiveDesktop;
+    HANDLE         ShellWindow;
+    HANDLE         ShellListView;
 } WINSTATION_OBJECT, *PWINSTATION_OBJECT;
+
+#ifndef _WIN64
+C_ASSERT(offsetof(WINSTATION_OBJECT, Flags) == 0x10);
+C_ASSERT(offsetof(WINSTATION_OBJECT, spklList) == 0x14);
+C_ASSERT(offsetof(WINSTATION_OBJECT, ptiClipLock) == 0x18);
+C_ASSERT(offsetof(WINSTATION_OBJECT, ptiDrawingClipboard) == 0x1c);
+C_ASSERT(offsetof(WINSTATION_OBJECT, spwndClipOpen) == 0x20);
+C_ASSERT(offsetof(WINSTATION_OBJECT, spwndClipViewer) == 0x24);
+C_ASSERT(offsetof(WINSTATION_OBJECT, spwndClipOwner) == 0x28);
+#endif
 
 extern WINSTATION_OBJECT *InputWindowStation;
 extern HANDLE gpidLogon;

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -38,6 +38,7 @@ typedef struct _WINSTATION_OBJECT
     LUID           luidUser;
     PVOID          psidUser;
 
+    /* ReactOS-specific */
     struct _DESKTOP* ActiveDesktop;
     HANDLE         ShellWindow;
     HANDLE         ShellListView;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18252](https://jira.reactos.org/browse/CORE-18252)

## Proposed changes

- Add a comment for `WINSTATION_OBJECT` structure.
- Modify `WINSTATION_OBJECT` structure with inserting `struct tagKL *spklList` member.
- Add some `C_ASSERT(offsetof(WINSTATION_OBJECT, ...) == ...);`.