### PR TITLE
[NTUSER] KLF_UNLOAD flag of NtUserGetKeyboardLayoutList

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -60,13 +60,13 @@ IntGetKeyboardLayoutList(
         {
             if (!(pKL->dwKL_Flags & KLF_UNLOAD))
             {
-                if (nBuff == 0)
-                    break;
-
                 *pHklBuff = pKL->hkl;
                 ++pHklBuff;
                 ++ret;
                 --nBuff;
+
+                if (nBuff == 0)
+                    break;
             }
             pKL = pKL->pklNext;
         } while (pKL != pFirstKL);

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -18,7 +18,7 @@
 
 DBG_DEFAULT_CHANNEL(UserKbdLayout);
 
-PKL gspklBaseLayout = NULL; // FIXME: Please move this to pWinSta->spklList
+PKL gspklBaseLayout = NULL; /* FIXME: Please move this to pWinSta->spklList */
 PKBDFILE gpkfList = NULL;
 DWORD gSystemFS = 0;
 UINT gSystemCPCharSet = 0;
@@ -37,7 +37,7 @@ IntGetKeyboardLayoutList(
     UINT ret = 0;
     PKL pKL, pFirstKL;
 
-    pFirstKL = gspklBaseLayout; // FIXME: Use pWinSta->spklList instead
+    pFirstKL = gspklBaseLayout; /* FIXME: Use pWinSta->spklList instead */
     if (!pWinSta || !pFirstKL)
         return 0;
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -42,7 +42,7 @@ IntGetKeyboardLayoutList(PWINSTATION_OBJECT pWinSta, ULONG nBuff, HKL *pHklBuff)
 
     if (nBuff == 0)
     {
-        // Count the effective PKLs
+        /* Count the effective PKLs */
         do
         {
             if (!(pKL->dwKL_Flags & KLF_UNLOAD))
@@ -52,7 +52,7 @@ IntGetKeyboardLayoutList(PWINSTATION_OBJECT pWinSta, ULONG nBuff, HKL *pHklBuff)
     }
     else
     {
-        // Copy the effective HKLs to pHklBuff
+        /* Copy the effective HKLs to pHklBuff */
         do
         {
             if (!(pKL->dwKL_Flags & KLF_UNLOAD))

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -615,7 +615,6 @@ NtUserGetKeyboardLayoutList(
     _SEH2_TRY
     {
         ProbeForWrite(pHklBuff, nBuff * sizeof(HKL), 1);
-        pWinSta = IntGetProcessWindowStation(NULL);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -624,7 +623,18 @@ NtUserGetKeyboardLayoutList(
     }
     _SEH2_END;
 
-    ret = IntGetKeyboardLayoutList(pWinSta, nBuff, pHklBuff);
+    pWinSta = IntGetProcessWindowStation(NULL);
+
+    _SEH2_TRY
+    {
+        ret = IntGetKeyboardLayoutList(pWinSta, nBuff, pHklBuff);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        SetLastNtError(_SEH2_GetExceptionCode());
+        goto Quit;
+    }
+    _SEH2_END;
 
 Quit:
     UserLeave();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -29,7 +29,10 @@ typedef PVOID (*PFN_KBDLAYERDESCRIPTOR)(VOID);
 
 // Win: _GetKeyboardLayoutList
 static UINT APIENTRY
-IntGetKeyboardLayoutList(PWINSTATION_OBJECT pWinSta, ULONG nBuff, HKL *pHklBuff)
+IntGetKeyboardLayoutList(
+    _Inout_ PWINSTATION_OBJECT pWinSta,
+    _In_ ULONG nBuff,
+    _Out_ HKL *pHklBuff)
 {
     UINT ret = 0;
     PKL pKL, pFirstKL;

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -393,6 +393,18 @@ CheckWinstaAttributeAccess(ACCESS_MASK DesiredAccess)
     return TRUE;
 }
 
+// Win: _GetProcessWindowStation
+PWINSTATION_OBJECT FASTCALL
+IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL)
+{
+    PWINSTATION_OBJECT pWinSta;
+    PPROCESSINFO ppi = GetW32ProcessInfo();
+    HWINSTA hWinSta = ppi->hwinsta;
+    if (phWinSta)
+        *phWinSta = hWinSta;
+    IntValidateWindowStationHandle(hWinSta, UserMode, 0, &pWinSta, 0);
+    return pWinSta;
+}
 
 /* PUBLIC FUNCTIONS ***********************************************************/
 

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -112,17 +112,6 @@ BOOL FASTCALL co_IntInitializeDesktopGraphics(VOID);
 VOID FASTCALL IntEndDesktopGraphics(VOID);
 BOOL FASTCALL CheckWinstaAttributeAccess(ACCESS_MASK);
 
-// Win: _GetProcessWindowStation
-static inline PWINSTATION_OBJECT
-IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL)
-{
-    PWINSTATION_OBJECT pWinSta;
-    PPROCESSINFO ppi = GetW32ProcessInfo();
-    HWINSTA hWinSta = ppi->hwinsta;
-    if (phWinSta)
-        *phWinSta = hWinSta;
-    IntValidateWindowStationHandle(hWinSta, UserMode, 0, &pWinSta, 0);
-    return pWinSta;
-}
+PWINSTATION_OBJECT FASTCALL IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL);
 
 /* EOF */

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -112,4 +112,17 @@ BOOL FASTCALL co_IntInitializeDesktopGraphics(VOID);
 VOID FASTCALL IntEndDesktopGraphics(VOID);
 BOOL FASTCALL CheckWinstaAttributeAccess(ACCESS_MASK);
 
+// Win: _GetProcessWindowStation
+static inline PWINSTATION_OBJECT
+IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL)
+{
+    PWINSTATION_OBJECT pWinSta;
+    PPROCESSINFO ppi = GetW32ProcessInfo();
+    HWINSTA hWinSta = ppi->hwinsta;
+    if (phWinSta)
+        *phWinSta = hWinSta;
+    IntValidateWindowStationHandle(hWinSta, UserMode, 0, &pWinSta, 0);
+    return pWinSta;
+}
+
 /* EOF */

--- a/win32ss/user/ntuser/winsta.h
+++ b/win32ss/user/ntuser/winsta.h
@@ -106,12 +106,11 @@ IntCreateWindowStation(
     DWORD Unknown5,
     DWORD Unknown6);
 
+PWINSTATION_OBJECT FASTCALL IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL);
 BOOL FASTCALL UserSetProcessWindowStation(HWINSTA hWindowStation);
 
 BOOL FASTCALL co_IntInitializeDesktopGraphics(VOID);
 VOID FASTCALL IntEndDesktopGraphics(VOID);
 BOOL FASTCALL CheckWinstaAttributeAccess(ACCESS_MASK);
-
-PWINSTATION_OBJECT FASTCALL IntGetProcessWindowStation(HWINSTA *phWinSta OPTIONAL);
 
 /* EOF */


### PR DESCRIPTION
## Purpose

This PR's implementation enables `KLF_UNLOAD` flag awareness on listing the KLs.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `IntGetProcessWindowStation` helper function to `winsta.c`.
- Add `IntGetKeyboardLayoutList` helper function to `kbdlayout.c`.
- Implement `NtUserGetKeyboardLayoutList` function in `kbdlayout.c`, using `IntGetKeyboardLayoutList` and `IntGetProcessWindowStation`.

## TODO

- [x] Do a test about keyboard input.