### PR TITLE
[NTUSER] Release WinSta->spklList at IntWinStaObjectDelete

### DIFF
--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -128,6 +128,8 @@ IntWinStaObjectDelete(
 
     RtlDestroyAtomTable(WinSta->AtomTable);
 
+    UserAssignmentUnlock((PVOID*)&WinSta->spklList);
+
     return STATUS_SUCCESS;
 }
 


### PR DESCRIPTION
## Purpose
This PR allows that the window station's keyboard layout can be assignment-locked. Currently no effect.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `UserAssignmentUnlock((PVOID*)&WinSta->spklList);` in `IntWinStaObjectDelete` function.