### PR TITLE
[NTUSER][USER32] NtUserGetKeyboardLayoutName and GetKeyboardLayoutNameW

### DIFF
--- a/modules/rostests/apitests/win32u/win32u_2k3sp2/win32u_2k3sp2.spec
+++ b/modules/rostests/apitests/win32u/win32u_2k3sp2/win32u_2k3sp2.spec
@@ -417,7 +417,7 @@
 @ stdcall NtUserGetImeInfoEx(long long)
 @ stdcall NtUserGetInternalWindowPos(ptr ptr ptr)
 @ stdcall NtUserGetKeyboardLayoutList(long ptr)
-@ stdcall NtUserGetKeyboardLayoutName(str)
+@ stdcall NtUserGetKeyboardLayoutName(ptr)
 @ stdcall NtUserGetKeyboardState(ptr)
 @ stdcall NtUserGetKeyNameText(long wstr long)
 @ stdcall NtUserGetKeyState(long)

--- a/modules/rostests/apitests/win32u/win32u_ros/win32u_ros.spec
+++ b/modules/rostests/apitests/win32u/win32u_ros/win32u_ros.spec
@@ -418,7 +418,7 @@
 @ stdcall NtUserGetImeInfoEx(long long)
 @ stdcall NtUserGetInternalWindowPos(ptr ptr ptr)
 @ stdcall NtUserGetKeyboardLayoutList(long ptr)
-@ stdcall NtUserGetKeyboardLayoutName(str)
+@ stdcall NtUserGetKeyboardLayoutName(ptr)
 @ stdcall NtUserGetKeyboardState(ptr)
 @ stdcall NtUserGetKeyNameText(long wstr long)
 @ stdcall NtUserGetKeyState(long)

--- a/modules/rostests/apitests/win32u/win32u_vista/win32u_vista.spec
+++ b/modules/rostests/apitests/win32u/win32u_vista/win32u_vista.spec
@@ -431,7 +431,7 @@
 @ stdcall NtUserGetImeInfoEx(long long)
 @ stdcall NtUserGetInternalWindowPos(ptr ptr ptr)
 @ stdcall NtUserGetKeyboardLayoutList(long ptr)
-@ stdcall NtUserGetKeyboardLayoutName(str)
+@ stdcall NtUserGetKeyboardLayoutName(ptr)
 @ stdcall NtUserGetKeyboardState(ptr)
 @ stdcall NtUserGetKeyNameText(long wstr long)
 @ stdcall NtUserGetKeyState(long)

--- a/modules/rostests/apitests/win32u/win32u_xpsp2/win32u_xpsp2.spec
+++ b/modules/rostests/apitests/win32u/win32u_xpsp2/win32u_xpsp2.spec
@@ -417,7 +417,7 @@
 @ stdcall NtUserGetImeInfoEx(long long)
 @ stdcall NtUserGetInternalWindowPos(ptr ptr ptr)
 @ stdcall NtUserGetKeyboardLayoutList(long ptr)
-@ stdcall NtUserGetKeyboardLayoutName(str)
+@ stdcall NtUserGetKeyboardLayoutName(ptr)
 @ stdcall NtUserGetKeyboardState(ptr)
 @ stdcall NtUserGetKeyNameText(long wstr long)
 @ stdcall NtUserGetKeyState(long)

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2431,7 +2431,7 @@ NtUserGetKeyboardLayoutList(
 BOOL
 NTAPI
 NtUserGetKeyboardLayoutName(
-    _Out_ PUNICODE_STRING pustrName);
+    _Inout_ PUNICODE_STRING pustrName);
 
 DWORD
 NTAPI

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2431,7 +2431,7 @@ NtUserGetKeyboardLayoutList(
 BOOL
 NTAPI
 NtUserGetKeyboardLayoutName(
-    LPWSTR lpszName);
+    PUNICODE_STRING pustrName);
 
 DWORD
 NTAPI

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2431,7 +2431,7 @@ NtUserGetKeyboardLayoutList(
 BOOL
 NTAPI
 NtUserGetKeyboardLayoutName(
-    PUNICODE_STRING pustrName);
+    _Out_ PUNICODE_STRING pustrName);
 
 DWORD
 NTAPI

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -641,7 +641,6 @@ NtUserGetKeyboardLayoutName(
                 EngSetLastError(ERROR_INVALID_PARAMETER);
                 goto cleanup;
             }
-#if 1
             RtlInitUnicodeString(&ustrTemp, pKl->spkf->awchKF); /* FIXME: Do not use awchKF */
             RtlCopyUnicodeString(pustrName, &ustrTemp);
         }

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -644,14 +644,6 @@ NtUserGetKeyboardLayoutName(
 #if 1
             RtlInitUnicodeString(&ustrTemp, pKl->spkf->awchKF); /* FIXME: Do not use awchKF */
             RtlCopyUnicodeString(pustrName, &ustrTemp);
-#else
-            Status = RtlIntegerToUnicodeString(/* pKl->(offset 64) */, 16, pustrName);
-            if (!NT_SUCCESS(Status))
-            {
-                EngSetLastError(ERROR_INVALID_PARAMETER);
-                goto cleanup;
-            }
-#endif
         }
 
         bRet = TRUE;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -609,7 +609,7 @@ NtUserGetKeyboardLayoutList(
 BOOL
 APIENTRY
 NtUserGetKeyboardLayoutName(
-    PUNICODE_STRING pustrName)
+    _Out_ PUNICODE_STRING pustrName)
 {
     BOOL bRet = FALSE;
     PKL pKl;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -615,7 +615,6 @@ NtUserGetKeyboardLayoutName(
     PKL pKl;
     PTHREADINFO pti;
     UNICODE_STRING ustrTemp;
-    /*NTSTATUS Status;*/
 
     UserEnterShared();
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -6,7 +6,6 @@
  * COPYRIGHT:       Copyright 2007 Saveliy Tretiakov
  *                  Copyright 2008 Colin Finck
  *                  Copyright 2011 Rafal Harabien
- *                  Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include <win32k.h>

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -609,7 +609,7 @@ NtUserGetKeyboardLayoutList(
 BOOL
 APIENTRY
 NtUserGetKeyboardLayoutName(
-    _Out_ PUNICODE_STRING pustrName)
+    _Inout_ PUNICODE_STRING pustrName)
 {
     BOOL bRet = FALSE;
     PKL pKl;

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -585,9 +585,11 @@ BOOL WINAPI
 GetKeyboardLayoutNameW(LPWSTR pwszKLID)
 {
     UNICODE_STRING Name;
-    Name.Buffer = pwszKLID;
-    Name.Length = 0;
-    Name.MaximumLength = KL_NAMELENGTH * sizeof(WCHAR);
+
+    RtlInitEmptyUnicodeString(&Name,
+                              pwszKLID,
+                              KL_NAMELENGTH * sizeof(WCHAR));
+
     return NtUserGetKeyboardLayoutName(&Name);
 }
 

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -584,7 +584,11 @@ GetKeyboardLayoutNameA(LPSTR pwszKLID)
 BOOL WINAPI
 GetKeyboardLayoutNameW(LPWSTR pwszKLID)
 {
-    return NtUserGetKeyboardLayoutName(pwszKLID);
+    UNICODE_STRING Name;
+    Name.Buffer = pwszKLID;
+    Name.Length = 0;
+    Name.MaximumLength = KL_NAMELENGTH * sizeof(WCHAR);
+    return NtUserGetKeyboardLayoutName(&Name);
 }
 
 /*


### PR DESCRIPTION
## Purpose

#4594 has proved that the 1st argument of `NtUserGetKeyboardLayoutName` has type `PUNICODE_STRING`.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Modify `NtUserGetKeyboardLayoutName` prototype.
- Adjust `GetKeyboardLayoutNameW` for this modification.
- If an `HKL` was an IME keyboard layout, then use the `HKL` for layout name.