### PR TITLE
[SHELL32] Fix "Fonts" and "Administrative Tools" control panel icon incorrectly displayed after 8d520f3

### DIFF
--- a/dll/win32/shell32/res/rgs/adminfoldershortcut.rgs
+++ b/dll/win32/shell32/res/rgs/adminfoldershortcut.rgs
@@ -7,7 +7,7 @@ HKCR
 			val '{305CA226-D286-468e-B848-2B2E8E697B74} 2' = d '5'
 			val InfoTip = e '@%%SystemRoot%%\system32\SHELL32.dll,-22921'
 			val LocalizedString = e '@%%SystemRoot%%\system32\SHELL32.dll,-22982'
-			DefaultIcon = e '%%SystemRoot%%\system32\main.cpl,10'
+			DefaultIcon = e '%%SystemRoot%%\system32\main.cpl,-500'
 			InprocServer32 = s '%MODULE%'
 			{
 				val ThreadingModel = s 'Apartment'

--- a/dll/win32/shell32/res/rgs/fontsfoldershortcut.rgs
+++ b/dll/win32/shell32/res/rgs/fontsfoldershortcut.rgs
@@ -7,7 +7,7 @@ HKCR
 			val '{305CA226-D286-468e-B848-2B2E8E697B74} 2' = d '&Hffffffff'
 			val InfoTip = e '@%%SystemRoot%%\system32\SHELL32.dll,-22920'
 			val LocalizedString = e '@%%SystemRoot%%\system32\SHELL32.dll,-22981'
-			DefaultIcon = e '%%SystemRoot%%\system32\main.cpl,9'
+			DefaultIcon = e '%%SystemRoot%%\system32\main.cpl,-400'
 			InprocServer32 = s '%MODULE%'
 			{
 				val ThreadingModel = s 'Apartment'


### PR DESCRIPTION
JIRA issue: [CORE-18251](https://jira.reactos.org/browse/CORE-18251)

![VirtualBox_ReactOS_06_08_2022_17_25_48](https://user-images.githubusercontent.com/86486978/183245699-67db1592-ff2e-410e-ae44-c8c140283fd7.png)
