### PR TITLE
[USER32] Refactoring on LoadKeyboardLayout(W/Ex)

### DIFF
--- a/win32ss/user/user32/misc/stubs.c
+++ b/win32ss/user/user32/misc/stubs.c
@@ -444,15 +444,6 @@ BOOL WINAPI IsServerSideWindow(HWND wnd)
 /*
  * @unimplemented
  */
-HKL WINAPI LoadKeyboardLayoutEx(DWORD unknown,LPCWSTR pwszKLID,UINT Flags) //1st parameter unknown
-{
-  UNIMPLEMENTED;
-  return FALSE;
-}
-
-/*
- * @unimplemented
- */
 VOID WINAPI AllowForegroundActivation(VOID)
 {
   UNIMPLEMENTED;

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -737,7 +737,7 @@ LoadKeyboardLayoutEx(HKL hklUnload,
                      UINT Flags)
 {
     FIXME("(%p, %s, 0x%X)", hklUnload, debugstr_w(pwszKLID), Flags);
-    if (!unknown)
+    if (!hklUnload)
         return NULL;
     return IntLoadKeyboardLayout(hklUnload, pwszKLID, 0, Flags, FALSE);
 }

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -721,6 +721,9 @@ LoadKeyboardLayoutW(LPCWSTR pwszKLID,
     return IntLoadKeyboardLayout(0, pwszKLID, 0, Flags, 0);
 }
 
+/*
+ * @unimplemented
+ */
 HKL WINAPI
 LoadKeyboardLayoutEx(DWORD unknown,
                      LPCWSTR pwszKLID,

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -717,6 +717,7 @@ HKL WINAPI
 LoadKeyboardLayoutW(LPCWSTR pwszKLID,
                     UINT Flags)
 {
+    TRACE("(%s, 0x%X)", debugstr_w(pwszKLID), Flags);
     return IntLoadKeyboardLayout(0, pwszKLID, 0, Flags, 0);
 }
 
@@ -725,6 +726,7 @@ LoadKeyboardLayoutEx(DWORD unknown,
                      LPCWSTR pwszKLID,
                      UINT Flags)
 {
+    TRACE("(0x%X, %s, 0x%X)", unknown, debugstr_w(pwszKLID), Flags);
     if (!unknown)
         return NULL;
     return IntLoadKeyboardLayout(unknown, pwszKLID, 0, Flags, 0);

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -725,7 +725,7 @@ LoadKeyboardLayoutW(LPCWSTR pwszKLID,
                     UINT Flags)
 {
     TRACE("(%s, 0x%X)", debugstr_w(pwszKLID), Flags);
-    return IntLoadKeyboardLayout(NULL, pwszKLID, 0, Flags, 0);
+    return IntLoadKeyboardLayout(NULL, pwszKLID, 0, Flags, FALSE);
 }
 
 /*
@@ -739,7 +739,7 @@ LoadKeyboardLayoutEx(HKL hklUnload,
     FIXME("(%p, %s, 0x%X)", hklUnload, debugstr_w(pwszKLID), Flags);
     if (!unknown)
         return NULL;
-    return IntLoadKeyboardLayout(hklUnload, pwszKLID, 0, Flags, 0);
+    return IntLoadKeyboardLayout(hklUnload, pwszKLID, 0, Flags, FALSE);
 }
 
 /*

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -638,10 +638,17 @@ LoadKeyboardLayoutA(LPCSTR pszKLID,
     return LoadKeyboardLayoutW(wszKLID, Flags);
 }
 
+/*
+ * @unimplemented
+ */
 /* Win: LoadKeyboardLayoutWorker */
 HKL APIENTRY
-IntLoadKeyboardLayout(DWORD unknown1, LPCWSTR pwszKLID, LPCWSTR unknown3, UINT Flags,
-                      DWORD unknown5)
+IntLoadKeyboardLayout(
+    _In_    HKL     hklUnload,
+    _In_z_  LPCWSTR pwszKLID,
+    _In_    LANGID  dwLangID,
+    _In_    UINT    Flags,
+    _In_    BOOL    unknown5)
 {
     DWORD dwhkl, dwType, dwSize;
     UNICODE_STRING ustrKbdName;

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -646,7 +646,7 @@ HKL APIENTRY
 IntLoadKeyboardLayout(
     _In_    HKL     hklUnload,
     _In_z_  LPCWSTR pwszKLID,
-    _In_    LANGID  dwLangID,
+    _In_    LANGID  wLangID,
     _In_    UINT    Flags,
     _In_    BOOL    unknown5)
 {

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -726,7 +726,7 @@ LoadKeyboardLayoutEx(DWORD unknown,
                      LPCWSTR pwszKLID,
                      UINT Flags)
 {
-    TRACE("(0x%X, %s, 0x%X)", unknown, debugstr_w(pwszKLID), Flags);
+    FIXME("(0x%X, %s, 0x%X)", unknown, debugstr_w(pwszKLID), Flags);
     if (!unknown)
         return NULL;
     return IntLoadKeyboardLayout(unknown, pwszKLID, 0, Flags, 0);

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -638,12 +638,10 @@ LoadKeyboardLayoutA(LPCSTR pszKLID,
     return LoadKeyboardLayoutW(wszKLID, Flags);
 }
 
-/*
- * @implemented
- */
-HKL WINAPI
-LoadKeyboardLayoutW(LPCWSTR pwszKLID,
-                    UINT Flags)
+/* Win: LoadKeyboardLayoutWorker */
+HKL APIENTRY
+IntLoadKeyboardLayout(DWORD unknown1, LPCWSTR pwszKLID, LPCWSTR unknown3, UINT Flags,
+                      DWORD unknown5)
 {
     DWORD dwhkl, dwType, dwSize;
     UNICODE_STRING ustrKbdName;
@@ -710,6 +708,26 @@ LoadKeyboardLayoutW(LPCWSTR pwszKLID,
     return NtUserLoadKeyboardLayoutEx(NULL, 0, &ustrKbdName,
                                       NULL, &ustrKLID,
                                       dwhkl, Flags);
+}
+
+/*
+ * @implemented
+ */
+HKL WINAPI
+LoadKeyboardLayoutW(LPCWSTR pwszKLID,
+                    UINT Flags)
+{
+    return IntLoadKeyboardLayout(0, pwszKLID, 0, Flags, 0);
+}
+
+HKL WINAPI
+LoadKeyboardLayoutEx(DWORD unknown,
+                     LPCWSTR pwszKLID,
+                     UINT Flags)
+{
+    if (!unknown)
+        return NULL;
+    return IntLoadKeyboardLayout(unknown, pwszKLID, 0, Flags, 0);
 }
 
 /*

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -725,21 +725,21 @@ LoadKeyboardLayoutW(LPCWSTR pwszKLID,
                     UINT Flags)
 {
     TRACE("(%s, 0x%X)", debugstr_w(pwszKLID), Flags);
-    return IntLoadKeyboardLayout(0, pwszKLID, 0, Flags, 0);
+    return IntLoadKeyboardLayout(NULL, pwszKLID, 0, Flags, 0);
 }
 
 /*
  * @unimplemented
  */
 HKL WINAPI
-LoadKeyboardLayoutEx(DWORD unknown,
+LoadKeyboardLayoutEx(HKL hklUnload,
                      LPCWSTR pwszKLID,
                      UINT Flags)
 {
-    FIXME("(0x%X, %s, 0x%X)", unknown, debugstr_w(pwszKLID), Flags);
+    FIXME("(%p, %s, 0x%X)", hklUnload, debugstr_w(pwszKLID), Flags);
     if (!unknown)
         return NULL;
-    return IntLoadKeyboardLayout(unknown, pwszKLID, 0, Flags, 0);
+    return IntLoadKeyboardLayout(hklUnload, pwszKLID, 0, Flags, 0);
 }
 
 /*


### PR DESCRIPTION
## Purpose
I want to fix the keyboard layout handling, but fixing by one shot is difficult.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `IntLoadKeyboardLayout` (Win: `LoadKeyboardLayoutWorker`) helper function.
- Use it in `LoadKeyboardLayoutW` and `LoadKeyboardLayoutEx` functions.
- Add `TRACE`.
