### PR TITLE
[USER32] Call CliImmInitializeHotKeys in IntLoadKeyboardLayout

### DIFF
--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -656,6 +656,7 @@ IntLoadKeyboardLayout(
     WCHAR wszRegKey[256] = L"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\";
     WCHAR wszLayoutId[10], wszNewKLID[10];
     HKEY hKey;
+    HKL hNewKL;
 
     /* LOWORD of dwhkl is Locale Identifier */
     dwhkl = LOWORD(wcstoul(pwszKLID, NULL, 16));
@@ -712,9 +713,11 @@ IntLoadKeyboardLayout(
 
     ZeroMemory(&ustrKbdName, sizeof(ustrKbdName));
     RtlInitUnicodeString(&ustrKLID, pwszKLID);
-    return NtUserLoadKeyboardLayoutEx(NULL, 0, &ustrKbdName,
-                                      NULL, &ustrKLID,
-                                      dwhkl, Flags);
+    hNewKL = NtUserLoadKeyboardLayoutEx(NULL, 0, &ustrKbdName,
+                                        NULL, &ustrKLID,
+                                        dwhkl, Flags);
+    CliImmInitializeHotKeys(SETIMEHOTKEY_ADD, hNewKL);
+    return hNewKL;
 }
 
 /*


### PR DESCRIPTION
## Purpose
Implementing Far-East-Asian input... Enable the IME hotkeys.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `CliImmInitializeHotKeys.SETIMEHOTKEY_ADD` on `IntLoadKeyboardLayout` epilogue.