### PR TITLE
[NTOS:SE] Fix the primary group assignation in TokenPrimaryGroup clas…

### DIFF
--- a/ntoskrnl/se/tokencls.c
+++ b/ntoskrnl/se/tokencls.c
@@ -1227,6 +1227,7 @@ NtSetInformationToken(
                 if (TokenInformationLength >= sizeof(TOKEN_PRIMARY_GROUP))
                 {
                     PTOKEN_PRIMARY_GROUP tpg = (PTOKEN_PRIMARY_GROUP)TokenInformation;
+                    ULONG AclSize;
                     ULONG_PTR PrimaryGroup;
                     PSID InputSid = NULL, CapturedSid;
                     ULONG PrimaryGroupIndex, NewDynamicLength;
@@ -1309,9 +1310,15 @@ NtSetInformationToken(
                                 /* Take away available space from the dynamic area */
                                 Token->DynamicAvailable -= RtlLengthSid(Token->UserAndGroups[PrimaryGroupIndex].Sid);
 
-                                /* And assign the primary group */
-                                PrimaryGroup = (ULONG_PTR)(Token->DynamicPart) + Token->DefaultDacl ?
-                                               Token->DefaultDacl->AclSize : 0;
+                                /*
+                                 * And assign the new primary group. For that
+                                 * we have to make sure where the primary group
+                                 * is going to stay in memory, so if this token
+                                 * has a default DACL then add up its size with
+                                 * the address of the dynamic part.
+                                 */
+                                AclSize = Token->DefaultDacl ? Token->DefaultDacl->AclSize : 0;
+                                PrimaryGroup = (ULONG_PTR)(Token->DynamicPart) + AclSize;
                                 RtlCopySid(RtlLengthSid(Token->UserAndGroups[PrimaryGroupIndex].Sid),
                                            (PVOID)PrimaryGroup,
                                            Token->UserAndGroups[PrimaryGroupIndex].Sid);


### PR DESCRIPTION
…s case

With current master, what happens is that when someone wants to assign a new primary group SID for an access token, it results in an instant page fault because the primary group variable doesn't get assigned the dynamic part's address.

So the primary group variable gets an address which is basically a representation of the ACL size, hence the said address is bogus and it's where the page fault kicks in. This PR fixes this problem where Cygwin installation in ReactOS causes a BSoD.

**JIRA Issue**: [CORE-18249](https://jira.reactos.org/browse/CORE-18249)
