### PR TITLE
[NTUSER][USER32] Define NtUserSetWindowLongPtr for non-Win64

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3366,11 +3366,7 @@ NtUserSetWindowLongPtr(
     LONG_PTR NewValue,
     BOOL Ansi);
 #else
-static inline LONG_PTR NTAPI
-NtUserSetWindowLongPtr(HWND hWnd, DWORD Index, LONG_PTR NewValue, BOOL Ansi)
-{
-    return NtUserSetWindowLong(hWnd, Index, (LONG)NewValue, Ansi);
-}
+#define NtUserSetWindowLongPtr NtUserSetWindowLong
 #endif // _WIN64
 
 BOOL

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3366,8 +3366,11 @@ NtUserSetWindowLongPtr(
     LONG_PTR NewValue,
     BOOL Ansi);
 #else
-#define NtUserSetWindowLongPtr(hWnd, Index, NewValue, Ansi) \
-    ((LONG_PTR)NtUserSetWindowLong((hWnd), (Index), (LONG)(NewValue), (Ansi)))
+static inline LONG_PTR NTAPI
+NtUserSetWindowLongPtr(HWND hWnd, DWORD Index, LONG_PTR NewValue, BOOL Ansi)
+{
+    return NtUserSetWindowLong(hWnd, Index, (LONG)NewValue, Ansi);
+}
 #endif // _WIN64
 
 BOOL

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -3365,6 +3365,9 @@ NtUserSetWindowLongPtr(
     DWORD Index,
     LONG_PTR NewValue,
     BOOL Ansi);
+#else
+#define NtUserSetWindowLongPtr(hWnd, Index, NewValue, Ansi) \
+    ((LONG_PTR)NtUserSetWindowLong((hWnd), (Index), (LONG)(NewValue), (Ansi)))
 #endif // _WIN64
 
 BOOL

--- a/win32ss/user/user32/misc/imm.c
+++ b/win32ss/user/user32/misc/imm.c
@@ -331,7 +331,7 @@ static HWND User32CreateImeUIWindow(PIMEUI pimeui, HKL hKL)
     }
 
     if (hwndUI)
-        NtUserSetWindowLong(hwndUI, IMMGWLP_IMC, (LONG_PTR)pimeui->hIMC, FALSE);
+        NtUserSetWindowLongPtr(hwndUI, IMMGWLP_IMC, (LONG_PTR)pimeui->hIMC, FALSE);
 
 Quit:
     IMM_FN(ImmUnlockImeDpi)(pImeDpi);

--- a/win32ss/user/user32/windows/class.c
+++ b/win32ss/user/user32/windows/class.c
@@ -1829,7 +1829,7 @@ SetWindowWord ( HWND hWnd,int nIndex,WORD wNewWord )
         }
         break;
     }
-    return NtUserSetWindowLong( hWnd, nIndex, wNewWord, FALSE );
+    return (WORD)NtUserSetWindowLongPtr(hWnd, nIndex, wNewWord, FALSE);
 }
 
 /*
@@ -1843,7 +1843,7 @@ SetWindowLongA(
   int nIndex,
   LONG dwNewLong)
 {
-    return NtUserSetWindowLong(hWnd, nIndex, dwNewLong, TRUE);
+    return (LONG)NtUserSetWindowLongPtr(hWnd, nIndex, dwNewLong, TRUE);
 }
 
 /*
@@ -1856,7 +1856,7 @@ SetWindowLongW(
   int nIndex,
   LONG dwNewLong)
 {
-    return NtUserSetWindowLong(hWnd, nIndex, dwNewLong, FALSE);
+    return (LONG)NtUserSetWindowLongPtr(hWnd, nIndex, dwNewLong, FALSE);
 }
 
 #ifdef _WIN64


### PR DESCRIPTION
## Purpose
Improve code uniformity and backward compatibility of `NtUserSetWindowLongPtr`.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `NtUserSetWindowLongPtr` macro on non-Win64.
- Use `NtUserSetWindowLongPtr` instead of `NtUserSetWindowLong`.