### PR TITLE
[NTUSER] Rewrite NtUserUnloadKeyboardLayout

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -23,6 +23,7 @@ PKL gspklBaseLayout = NULL; /* FIXME: Please move this to pWinSta->spklList */
 PKBDFILE gpkfList = NULL;
 DWORD gSystemFS = 0;
 UINT gSystemCPCharSet = 0;
+DWORD gLCIDSentToShell = 0; /* Win: gLCIDSentToShell */
 
 typedef PVOID (*PFN_KBDLAYERDESCRIPTOR)(VOID);
 
@@ -816,8 +817,7 @@ co_IntUnloadKeyboardLayoutEx(
     if (pti->pDeskInfo->fsHooks)
     {
         co_IntShellHookNotify(HSHELL_LANGUAGE, 0, 0);
-
-        /* FIXME */
+        gLCIDSentToShell = 0;
     }
 
     return TRUE;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -23,7 +23,7 @@ PKL gspklBaseLayout = NULL; /* FIXME: Please move this to pWinSta->spklList */
 PKBDFILE gpkfList = NULL;
 DWORD gSystemFS = 0;
 UINT gSystemCPCharSet = 0;
-DWORD gLCIDSentToShell = 0; /* Win: gLCIDSentToShell */
+DWORD gLCIDSentToShell = 0;
 
 typedef PVOID (*PFN_KBDLAYERDESCRIPTOR)(VOID);
 


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `co_IntUnloadKeyboardLayoutEx` (Win: `xxxInternalUnloadKeyboardLayout`), `IntUnloadKeyboardLayout` (Win: `xxxUnloadKeyboardLayout`) helper functions.
- Rewrite `NtUserUnloadKeyboardLayout` function.

## TODO

- [x] Do a small test.
- [x] Do a big test.
