### PR TITLE
[SYSDM] General page: Implement auto-updating for system uptime

### DIFF
--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -610,7 +610,7 @@ static VOID GetSystemVersion(HWND hwnd)
  *
  * @return
  * The number of milliseconds that have elapsed since the system was started.
- **/
+ */
 static ULONGLONG GetTickCountQPC(VOID)
 {
     LARGE_INTEGER Counter, Frequency;

--- a/dll/cpl/sysdm/general.c
+++ b/dll/cpl/sysdm/general.c
@@ -694,6 +694,7 @@ INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
     switch (uMsg)
     {
         case WM_INITDIALOG:
+        {
             pImgInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(IMGINFO));
             if (pImgInfo == NULL)
             {
@@ -707,8 +708,10 @@ INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
             GetSystemVersion(hwndDlg);
             InitSystemUptime(hwndDlg);
             break;
+        }
 
         case WM_DESTROY:
+        {
             KillTimer(hwndDlg, ID_SYSUPTIME_UPDATE_TIMER);
 
             if (hKernel32Vista)
@@ -718,6 +721,7 @@ INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
 
             HeapFree(GetProcessHeap(), 0, pImgInfo);
             break;
+        }
 
         case WM_TIMER:
         {
@@ -731,6 +735,7 @@ INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
         }
 
         case WM_COMMAND:
+        {
             if (LOWORD(wParam) == IDC_LICENCE)
             {
                 DialogBox(hApplet, MAKEINTRESOURCE(IDD_LICENCE), hwndDlg, LicenceDlgProc);
@@ -738,6 +743,7 @@ INT_PTR CALLBACK GeneralPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM 
                 return TRUE;
             }
             break;
+        }
 
         case WM_DRAWITEM:
         {

--- a/dll/cpl/sysdm/lang/bg-BG.rc
+++ b/dll/cpl/sysdm/lang/bg-BG.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "ПБ памет"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Променлива"
     IDS_VALUE "Стойност"
     IDS_NO_DUMP "(Няма)"

--- a/dll/cpl/sysdm/lang/cs-CZ.rc
+++ b/dll/cpl/sysdm/lang/cs-CZ.rc
@@ -338,7 +338,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Proměnná"
     IDS_VALUE "Hodnota"
     IDS_NO_DUMP "(Není)"

--- a/dll/cpl/sysdm/lang/da-DK.rc
+++ b/dll/cpl/sysdm/lang/da-DK.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB of RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Value"
     IDS_NO_DUMP "(None)"

--- a/dll/cpl/sysdm/lang/de-DE.rc
+++ b/dll/cpl/sysdm/lang/de-DE.rc
@@ -342,7 +342,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Tage, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Tage, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Wert"
     IDS_NO_DUMP "(Keine)"

--- a/dll/cpl/sysdm/lang/el-GR.rc
+++ b/dll/cpl/sysdm/lang/el-GR.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB μνήμης RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Μεταβλητή"
     IDS_VALUE "Τιμή"
     IDS_NO_DUMP "(Κανένα)"

--- a/dll/cpl/sysdm/lang/en-US.rc
+++ b/dll/cpl/sysdm/lang/en-US.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB of RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Value"
     IDS_NO_DUMP "(None)"

--- a/dll/cpl/sysdm/lang/es-ES.rc
+++ b/dll/cpl/sysdm/lang/es-ES.rc
@@ -335,7 +335,7 @@ BEGIN
     IDS_PETABYTE "PB de RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Valor"
     IDS_NO_DUMP "(Ninguno)"

--- a/dll/cpl/sysdm/lang/fr-FR.rc
+++ b/dll/cpl/sysdm/lang/fr-FR.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "Po de RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u jours, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu jours, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Valeur"
     IDS_NO_DUMP "(Aucun)"

--- a/dll/cpl/sysdm/lang/he-IL.rc
+++ b/dll/cpl/sysdm/lang/he-IL.rc
@@ -335,7 +335,7 @@ BEGIN
     IDS_PETABYTE "PB זיכרון פיזי"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "משתנה"
     IDS_VALUE "ערך"
     IDS_NO_DUMP "(ללא)"

--- a/dll/cpl/sysdm/lang/hu-HU.rc
+++ b/dll/cpl/sysdm/lang/hu-HU.rc
@@ -335,7 +335,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u nap, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu nap, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Változó"
     IDS_VALUE "Érték"
     IDS_NO_DUMP "(nincs)"

--- a/dll/cpl/sysdm/lang/id-ID.rc
+++ b/dll/cpl/sysdm/lang/id-ID.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Hari, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Hari, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variabel"
     IDS_VALUE "Nilai"
     IDS_NO_DUMP "(Tidak ada)"

--- a/dll/cpl/sysdm/lang/it-IT.rc
+++ b/dll/cpl/sysdm/lang/it-IT.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB di RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Giorno, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Giorno, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variabile"
     IDS_VALUE "Valore"
     IDS_NO_DUMP "(None)"

--- a/dll/cpl/sysdm/lang/ja-JP.rc
+++ b/dll/cpl/sysdm/lang/ja-JP.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "可変"
     IDS_VALUE "値"
     IDS_NO_DUMP "(なし)"

--- a/dll/cpl/sysdm/lang/nl-NL.rc
+++ b/dll/cpl/sysdm/lang/nl-NL.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB of RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variable"
     IDS_VALUE "Value"
     IDS_NO_DUMP "(None)"

--- a/dll/cpl/sysdm/lang/no-NO.rc
+++ b/dll/cpl/sysdm/lang/no-NO.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB Systemminne"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variabel"
     IDS_VALUE "Verdi"
     IDS_NO_DUMP "(Ingen)"

--- a/dll/cpl/sysdm/lang/pl-PL.rc
+++ b/dll/cpl/sysdm/lang/pl-PL.rc
@@ -342,7 +342,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u dni, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu dni, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Zmienna"
     IDS_VALUE "Wartość"
     IDS_NO_DUMP "(Brak)"

--- a/dll/cpl/sysdm/lang/pt-PT.rc
+++ b/dll/cpl/sysdm/lang/pt-PT.rc
@@ -337,7 +337,7 @@ BEGIN
     IDS_PETABYTE "PB de RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Dias, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Dias, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variável"
     IDS_VALUE "Valor"
     IDS_NO_DUMP "(Nenhum)"

--- a/dll/cpl/sysdm/lang/ro-RO.rc
+++ b/dll/cpl/sysdm/lang/ro-RO.rc
@@ -342,7 +342,7 @@ BEGIN
     IDS_PETABYTE "Po de memorie"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u zile, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu zile, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variabilă"
     IDS_VALUE "Valoare"
     IDS_NO_DUMP "(Fără fișier de depanare)"

--- a/dll/cpl/sysdm/lang/ru-RU.rc
+++ b/dll/cpl/sysdm/lang/ru-RU.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "Пб ОЗУ"
     IDS_MEGAHERTZ "МГц"
     IDS_GIGAHERTZ "ГГц"
-    IDS_UPTIME_FORMAT "%u дней, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu дней, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Переменная"
     IDS_VALUE "Значение"
     IDS_NO_DUMP "(Нет)"

--- a/dll/cpl/sysdm/lang/sk-SK.rc
+++ b/dll/cpl/sysdm/lang/sk-SK.rc
@@ -341,7 +341,7 @@ BEGIN
     IDS_PETABYTE "PB pamäte RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Premenná"
     IDS_VALUE "Hodnota"
     IDS_NO_DUMP "(Žiadne)"

--- a/dll/cpl/sysdm/lang/sq-AL.rc
+++ b/dll/cpl/sysdm/lang/sq-AL.rc
@@ -333,7 +333,7 @@ BEGIN
     IDS_PETABYTE "PB e RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variablë"
     IDS_VALUE "Vlera"
     IDS_NO_DUMP "(Asnjë)"

--- a/dll/cpl/sysdm/lang/sv-SE.rc
+++ b/dll/cpl/sysdm/lang/sv-SE.rc
@@ -335,7 +335,7 @@ BEGIN
     IDS_PETABYTE "PB RAM"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Variabel"
     IDS_VALUE "Värde"
     IDS_NO_DUMP "(None)"

--- a/dll/cpl/sysdm/lang/tr-TR.rc
+++ b/dll/cpl/sysdm/lang/tr-TR.rc
@@ -335,7 +335,7 @@ BEGIN
     IDS_PETABYTE "PB Bellek"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u Gün, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Gün, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Değişken"
     IDS_VALUE "Değer"
     IDS_NO_DUMP "(Yok)"

--- a/dll/cpl/sysdm/lang/uk-UA.rc
+++ b/dll/cpl/sysdm/lang/uk-UA.rc
@@ -341,7 +341,7 @@ BEGIN
     IDS_PETABYTE "Пб ОЗП"
     IDS_MEGAHERTZ "МГц"
     IDS_GIGAHERTZ "ГГц"
-    IDS_UPTIME_FORMAT "%u Days, %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu Days, %02lu:%02lu:%02lu"
     IDS_VARIABLE "Змінна"
     IDS_VALUE "Значення"
     IDS_NO_DUMP "(Немає)"

--- a/dll/cpl/sysdm/lang/zh-CN.rc
+++ b/dll/cpl/sysdm/lang/zh-CN.rc
@@ -342,7 +342,7 @@ BEGIN
     IDS_PETABYTE "PB 内存"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u 天，%02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu 天，%02lu:%02lu:%02lu"
     IDS_VARIABLE "变量"
     IDS_VALUE "值"
     IDS_NO_DUMP "（无）"

--- a/dll/cpl/sysdm/lang/zh-HK.rc
+++ b/dll/cpl/sysdm/lang/zh-HK.rc
@@ -341,7 +341,7 @@ BEGIN
     IDS_PETABYTE "PB 記憶體"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u 日， %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu 日， %02lu:%02lu:%02lu"
     IDS_VARIABLE "變量"
     IDS_VALUE "值"
     IDS_NO_DUMP "（無）"

--- a/dll/cpl/sysdm/lang/zh-TW.rc
+++ b/dll/cpl/sysdm/lang/zh-TW.rc
@@ -342,7 +342,7 @@ BEGIN
     IDS_PETABYTE "PB 記憶體"
     IDS_MEGAHERTZ "MHz"
     IDS_GIGAHERTZ "GHz"
-    IDS_UPTIME_FORMAT "%u 天， %02u:%02u:%02u"
+    IDS_UPTIME_FORMAT "%lu 天， %02lu:%02lu:%02lu"
     IDS_VARIABLE "變量"
     IDS_VALUE "值"
     IDS_NO_DUMP "（無）"


### PR DESCRIPTION
## Purpose

Implement auto-updating for system uptime

https://user-images.githubusercontent.com/86486978/185762489-13a95f6e-5740-4854-bf90-418b4bc7ed96.mp4

This change helps testing ROS uptime more accurate.

> Done, but the system uptime doesn’t seem to auto-update. So it’s a bit misleading actually.

[https://www.reddit.com/r/reactos/comments/wl68g8/ive_set_up_a_web_server_running_on_reactos_today/](https://www.reddit.com/r/reactos/comments/wl68g8/ive_set_up_a_web_server_running_on_reactos_today/)