### PR TITLE
[BOOT][SDK:CMLIB] Compile a CMLIB for FreeLdr / NT bootloader with correct definitions.

### DIFF
--- a/boot/environ/CMakeLists.txt
+++ b/boot/environ/CMakeLists.txt
@@ -101,7 +101,7 @@ endif()
 
 set_entrypoint(bootmgfw EfiEntry)
 
-target_link_libraries(bootmgfw bootlib cportlib cmlib blrtl libcntpr)
+target_link_libraries(bootmgfw bootlib cportlib blcmlib blrtl libcntpr)
 
 # dynamic analysis switches
 if(STACK_PROTECTOR)
@@ -149,7 +149,7 @@ else()
     set_entrypoint(rosload OslMain)
 endif()
 
-target_link_libraries(rosload bootlib cportlib cmlib blrtl libcntpr)
+target_link_libraries(rosload bootlib cportlib blcmlib blrtl libcntpr)
 
 # dynamic analysis switches
 if(STACK_PROTECTOR)

--- a/boot/freeldr/freeldr/CMakeLists.txt
+++ b/boot/freeldr/freeldr/CMakeLists.txt
@@ -293,7 +293,7 @@ if(ARCH STREQUAL "i386")
     target_link_libraries(freeldr_pe mini_hal)
 endif()
 
-target_link_libraries(freeldr_pe freeldr_common cportlib cmlib blrtl libcntpr)
+target_link_libraries(freeldr_pe freeldr_common cportlib blcmlib blrtl libcntpr)
 
 # dynamic analysis switches
 if(STACK_PROTECTOR)

--- a/sdk/lib/cmlib/CMakeLists.txt
+++ b/sdk/lib/cmlib/CMakeLists.txt
@@ -1,6 +1,5 @@
 
 add_definitions(
-    -D_BLDR_
     -D_NTSYSTEM_
     -DNASSERT)
 
@@ -19,10 +18,18 @@ list(APPEND SOURCE
     cmlib.h)
 
 if(CMAKE_CROSSCOMPILING)
+    # CMLIB for NT bootloader
+    add_library(blcmlib ${SOURCE})
+    target_compile_definitions(blcmlib PRIVATE _BLDR_)
+    add_dependencies(blcmlib bugcodes xdk)
+    add_pch(blcmlib cmlib.h SOURCE)
+
+    # CMLIB for NT kernel
     add_library(cmlib ${SOURCE})
     add_dependencies(cmlib bugcodes xdk)
     add_pch(cmlib cmlib.h SOURCE)
 else()
+    # CMLIB for host-tools
     add_definitions(
         -D__NO_CTYPE_INLINES
         -DCMLIB_HOST)


### PR DESCRIPTION
This also allows using the CMLIB with any reduced functionality
that could be required at boot-time.