### PR TITLE
[NTUSER] Use assignment-lock against THREADINFO.KeyboardLayout

### DIFF
--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -517,7 +517,6 @@ NtUserSetThreadLayoutHandles(HKL hNewKL, HKL hOldKL)
 {
     PTHREADINFO pti;
     PKL pOldKL, pNewKL;
-    PCLIENTINFO ClientInfo;
 
     UserEnterExclusive();
 
@@ -534,9 +533,7 @@ NtUserSetThreadLayoutHandles(HKL hNewKL, HKL hOldKL)
         pti->hklPrev = hOldKL;
 
     UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pNewKL);
-
-    ClientInfo = pti->pClientInfo;
-    ClientInfo->hKL = pNewKL->hkl;
+    pti->pClientInfo->hKL = pNewKL->hkl;
 
 Quit:
     UserLeave();

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -517,6 +517,7 @@ NtUserSetThreadLayoutHandles(HKL hNewKL, HKL hOldKL)
 {
     PTHREADINFO pti;
     PKL pOldKL, pNewKL;
+    PCLIENTINFO ClientInfo;
 
     UserEnterExclusive();
 
@@ -533,6 +534,9 @@ NtUserSetThreadLayoutHandles(HKL hNewKL, HKL hOldKL)
         pti->hklPrev = hOldKL;
 
     UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pNewKL);
+
+    ClientInfo = pti->pClientInfo;
+    ClientInfo->hKL = pNewKL->hkl;
 
 Quit:
     UserLeave();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -670,11 +670,16 @@ co_UserActivateKeyboardLayout(
     if (pti->TIF_flags & TIF_CSRSSTHREAD)
     {
         UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pKL);
-        ClientInfo->CodePage = pKL->CodePage;
+
+        if (!(pti->TIF_flags & TIF_INCLEANUP))
+        {
+            ClientInfo->CodePage = pKL->CodePage;
+            ClientInfo->hKL = pKL->hkl;
+        }
     }
     else if (uFlags & KLF_SETFORPROCESS)
     {
-        /* FIXME */
+        FIXME("KLF_SETFORPROCESS\n");
     }
     else
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -585,12 +585,11 @@ co_UserActivateKbl(PTHREADINFO pti, PKL pKl, UINT Flags)
     pklPrev = pti->KeyboardLayout;
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKl);
-
     pti->pClientInfo->hKL = pKl->hkl;
 
     if (Flags & KLF_SETFORPROCESS)
     {
-        // FIXME
+        FIXME("KLF_SETFORPROCESS\n");
     }
 
     if (!(pWnd = pti->MessageQueue->spwndFocus))
@@ -657,7 +656,7 @@ co_UserActivateKeyboardLayout(
 
     if (uFlags & KLF_RESET)
     {
-        /* FIXME */
+        FIXME("KLF_RESET\n");
     }
 
     if (!(uFlags & KLF_SETFORPROCESS) && pKL == pti->KeyboardLayout)
@@ -671,12 +670,8 @@ co_UserActivateKeyboardLayout(
     if (pti->TIF_flags & TIF_CSRSSTHREAD)
     {
         UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pKL);
-
-        if (!(pti->TIF_flags & TIF_INCLEANUP))
-        {
-            ClientInfo->CodePage = pKL->CodePage;
-            ClientInfo->hKL = pKL->hkl;
-        }
+        ClientInfo->CodePage = pKL->CodePage;
+        ClientInfo->hKL = pKL->hkl;
     }
     else if (uFlags & KLF_SETFORPROCESS)
     {
@@ -689,11 +684,8 @@ co_UserActivateKeyboardLayout(
         else
             UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pKL);
 
-        if (!(pti->TIF_flags & TIF_INCLEANUP))
-        {
-            ClientInfo->CodePage = pKL->CodePage;
-            ClientInfo->hKL = pKL->hkl;
-        }
+        ClientInfo->CodePage = pKL->CodePage;
+        ClientInfo->hKL = pKL->hkl;
     }
 
     if (gptiForeground && (gptiForeground->ppi == pti->ppi))

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -583,12 +583,10 @@ co_UserActivateKbl(PTHREADINFO pti, PKL pKl, UINT Flags)
     PWND pWnd;
 
     pklPrev = pti->KeyboardLayout;
-    if (pklPrev)
-        UserDereferenceObject(pklPrev);
 
-    pti->KeyboardLayout = pKl;
+    UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKl);
+
     pti->pClientInfo->hKL = pKl->hkl;
-    UserReferenceObject(pKl);
 
     if (Flags & KLF_SETFORPROCESS)
     {
@@ -631,7 +629,7 @@ IntImmActivateLayout(
         UserDerefObjectCo(pImeWnd);
     }
 
-    UserAssignmentLock((PVOID*)&pti->KeyboardLayout, pKL);
+    UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
 }
 
 /* Win: xxxInternalActivateKeyboardLayout */

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -630,6 +630,7 @@ IntImmActivateLayout(
     }
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
+    pti->pClientInfo->hKL = pKL->hkl;
 }
 
 /* Win: xxxInternalActivateKeyboardLayout */

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1174,9 +1174,17 @@ IntTranslateKbdMessage(LPMSG lpMsg,
 
     if (!pti->KeyboardLayout)
     {
-       pti->KeyboardLayout = W32kGetDefaultKeyLayout();
-       pti->pClientInfo->hKL = pti->KeyboardLayout ? pti->KeyboardLayout->hkl : NULL;
-       pKbdTbl = pti->KeyboardLayout ? pti->KeyboardLayout->spkf->pKbdTbl : NULL;
+        UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), W32kGetDefaultKeyLayout());
+        if (pti->KeyboardLayout)
+        {
+            pti->pClientInfo->hKL = pti->KeyboardLayout->hkl;
+            pKbdTbl = pti->KeyboardLayout->spkf->pKbdTbl;
+        }
+        else
+        {
+            pti->pClientInfo->hKL = NULL;
+            pKbdTbl = NULL;
+        }
     }
     else
        pKbdTbl = pti->KeyboardLayout->spkf->pKbdTbl;

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1174,11 +1174,12 @@ IntTranslateKbdMessage(LPMSG lpMsg,
 
     if (!pti->KeyboardLayout)
     {
-        UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), W32kGetDefaultKeyLayout());
-        if (pti->KeyboardLayout)
+        PKL pDefKL = W32kGetDefaultKeyLayout();
+        UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pDefKL);
+        if (pDefKL)
         {
-            pti->pClientInfo->hKL = pti->KeyboardLayout->hkl;
-            pKbdTbl = pti->KeyboardLayout->spkf->pKbdTbl;
+            pti->pClientInfo->hKL = pDefKL->hkl;
+            pKbdTbl = pDefKL->spkf->pKbdTbl;
         }
         else
         {

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -462,6 +462,7 @@ InitThreadCallback(PETHREAD Thread)
     NTSTATUS Status = STATUS_SUCCESS;
     PTEB pTeb;
     PRTL_USER_PROCESS_PARAMETERS ProcessParams;
+    PKL pDefKL;
 
     Process = Thread->ThreadsProcess;
 
@@ -532,7 +533,8 @@ InitThreadCallback(PETHREAD Thread)
         goto error;
     }
 
-    UserAssignmentLock((PVOID*)&(ptiCurrent->KeyboardLayout), W32kGetDefaultKeyLayout());
+    pDefKL = W32kGetDefaultKeyLayout();
+    UserAssignmentLock((PVOID*)&(ptiCurrent->KeyboardLayout), pDefKL);
 
     ptiCurrent->TIF_flags &= ~TIF_INCLEANUP;
 
@@ -548,10 +550,10 @@ InitThreadCallback(PETHREAD Thread)
     pci->ppi = ptiCurrent->ppi;
     pci->fsHooks = ptiCurrent->fsHooks;
     pci->dwTIFlags = ptiCurrent->TIF_flags;
-    if (ptiCurrent->KeyboardLayout)
+    if (pDefKL)
     {
-        pci->hKL = ptiCurrent->KeyboardLayout->hkl;
-        pci->CodePage = ptiCurrent->KeyboardLayout->CodePage;
+        pci->hKL = pDefKL->hkl;
+        pci->CodePage = pDefKL->CodePage;
     }
 
     /* Need to pass the user Startup Information to the current process. */

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -532,9 +532,7 @@ InitThreadCallback(PETHREAD Thread)
         goto error;
     }
 
-    ptiCurrent->KeyboardLayout = W32kGetDefaultKeyLayout();
-    if (ptiCurrent->KeyboardLayout)
-        UserReferenceObject(ptiCurrent->KeyboardLayout);
+    UserAssignmentLock((PVOID*)&(ptiCurrent->KeyboardLayout), W32kGetDefaultKeyLayout());
 
     ptiCurrent->TIF_flags &= ~TIF_INCLEANUP;
 
@@ -829,8 +827,7 @@ ExitThreadCallback(PETHREAD Thread)
     /* Remove it from the list */
     *ppti = ptiCurrent->ptiSibling;
 
-    if (ptiCurrent->KeyboardLayout)
-        UserDereferenceObject(ptiCurrent->KeyboardLayout);
+    UserAssignmentUnlock((PVOID*)&(ptiCurrent->KeyboardLayout));
 
     if (gptiForeground == ptiCurrent)
     {

--- a/win32ss/user/ntuser/main.c
+++ b/win32ss/user/ntuser/main.c
@@ -829,7 +829,8 @@ ExitThreadCallback(PETHREAD Thread)
     /* Remove it from the list */
     *ppti = ptiCurrent->ptiSibling;
 
-    UserAssignmentUnlock((PVOID*)&(ptiCurrent->KeyboardLayout));
+    if (!UserAssignmentUnlock((PVOID*)&(ptiCurrent->KeyboardLayout)))
+        ptiCurrent->pClientInfo->hKL = NULL;
 
     if (gptiForeground == ptiCurrent)
     {


### PR DESCRIPTION
## Purpose
Improve stability when switching languages.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-18317](https://jira.reactos.org/browse/CORE-18317)

## Proposed changes

- When the system is to assign a pointer to `THREADINFO.KeyboardLayout`, it uses `UserAssignmentLock`.
- When the system is to detach a pointer from `THREADINFO.KeyboardLayout`, it uses `UserAssignmentUnlock`.
- Synchronize `ClientInfo->hKL` with `pti->KeyboardLayout->hkl`.

## TODO

- [x] A small test.