### PR TITLE
[IMM32] Add CtfImmIsGuidMapEnable and CtfImmGetGuidAtom

### DIFF
--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -1,7 +1,7 @@
 /*
  * PROJECT:     ReactOS IMM32
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
- * PURPOSE:     Implementing IMM32 Cicero (modern input method)
+ * PURPOSE:     Implementing the IMM32 Cicero-aware Text Framework (CTF)
  * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -10,8 +10,8 @@
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 /*
- * NOTE: Microsoft CTF protocol (ctfmon.exe and CTF clients) has massive vulnerability.
- *       We don't follow the design of some parts of Microsoft's CTF protocol if insecure.
+ * NOTE: Microsoft CTF protocol has vulnerability.
+ *       If insecure, we don't follow the design of some Microsoft's CTF components.
  *
  * See also:
  * https://www.zdnet.com/article/vulnerability-in-microsoft-ctf-protocol-goes-back-to-windows-xp/

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -13,7 +13,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
  * NOTE: Microsoft CTF protocol has vulnerability.
  *       If insecure, we don't follow the dangerous design.
  *
- * See also:
  * https://www.zdnet.com/article/vulnerability-in-microsoft-ctf-protocol-goes-back-to-windows-xp/
  */
 

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -9,6 +9,14 @@
 
 WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
+/*
+ * NOTE: Microsoft CTF protocol (ctfmon.exe and CTF clients) has massive vulnerability.
+ *       We don't follow the design of some parts of Microsoft's CTF protocol if insecure.
+ *
+ * See also:
+ * https://www.zdnet.com/article/vulnerability-in-microsoft-ctf-protocol-goes-back-to-windows-xp/
+ */
+
 // Win: LoadCtfIme
 HMODULE APIENTRY Imm32LoadCtfIme(VOID)
 {

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -108,7 +108,7 @@ BOOL WINAPI CtfImmIsGuidMapEnable(HIMC hIMC)
 
     TRACE("(%p)\n", hIMC);
 
-    if (!Imm32IsCiceroMode() || Imm32Is16BitMode()))
+    if (!Imm32IsCiceroMode() || Imm32Is16BitMode())
         return ret;
 
     dwThreadId = (DWORD)NtUserQueryInputContext(hIMC, QIC_INPUTTHREADID);
@@ -142,7 +142,7 @@ HRESULT WINAPI CtfImmGetGuidAtom(HIMC hIMC, DWORD dwUnknown, LPDWORD pdwGuidAtom
 
     *pdwGuidAtom = 0;
 
-    if (!Imm32IsCiceroMode() || Imm32Is16BitMode()))
+    if (!Imm32IsCiceroMode() || Imm32Is16BitMode())
         return hr;
 
     dwThreadId = (DWORD)NtUserQueryInputContext(hIMC, QIC_INPUTTHREADID);

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -11,7 +11,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
 
 /*
  * NOTE: Microsoft CTF protocol has vulnerability.
- *       If insecure, we don't follow the design of some Microsoft's CTF components.
+ *       If insecure, we don't follow the dangerous design.
  *
  * See also:
  * https://www.zdnet.com/article/vulnerability-in-microsoft-ctf-protocol-goes-back-to-windows-xp/

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -95,3 +95,68 @@ LRESULT WINAPI CtfImmDispatchDefImeMessage(HWND hWnd, UINT uMsg, WPARAM wParam, 
     FIXME("(%p, %u, %p, %p)\n", hWnd, uMsg, wParam, lParam);
     return 0;
 }
+
+/***********************************************************************
+ *		CtfImmIsGuidMapEnable(IMM32.@)
+ */
+BOOL WINAPI CtfImmIsGuidMapEnable(HIMC hIMC)
+{
+    DWORD dwThreadId;
+    HKL hKL;
+    PIMEDPI pImeDpi;
+    BOOL ret = FALSE;
+
+    TRACE("(%p)\n", hIMC);
+
+    if (!Imm32IsCiceroMode() || Imm32Is16BitMode()))
+        return ret;
+
+    dwThreadId = (DWORD)NtUserQueryInputContext(hIMC, QIC_INPUTTHREADID);
+    hKL = GetKeyboardLayout(dwThreadId);
+
+    if (IS_IME_HKL(hKL))
+        return ret;
+
+    pImeDpi = Imm32FindOrLoadImeDpi(hKL);
+    if (!pImeDpi)
+        return ret;
+
+    if (pImeDpi->CtfImeIsGuidMapEnable)
+        ret = pImeDpi->CtfImeIsGuidMapEnable(hIMC);
+
+    ImmUnlockImeDpi(pImeDpi);
+    return ret;
+}
+
+/***********************************************************************
+ *		CtfImmGetGuidAtom(IMM32.@)
+ */
+HRESULT WINAPI CtfImmGetGuidAtom(HIMC hIMC, DWORD dwUnknown, LPDWORD pdwGuidAtom)
+{
+    HRESULT hr = E_FAIL;
+    PIMEDPI pImeDpi;
+    DWORD dwThreadId;
+    HKL hKL;
+
+    TRACE("(%p, 0x%08lX, %p)\n", hIMC, dwUnknown, pdwGuidAtom);
+
+    *pdwGuidAtom = 0;
+
+    if (!Imm32IsCiceroMode() || Imm32Is16BitMode()))
+        return hr;
+
+    dwThreadId = (DWORD)NtUserQueryInputContext(hIMC, QIC_INPUTTHREADID);
+    hKL = GetKeyboardLayout(dwThreadId);
+    if (IS_IME_HKL(hKL))
+        return S_OK;
+
+    pImeDpi = Imm32FindOrLoadImeDpi(hKL);
+    if (!pImeDpi)
+        return hr;
+
+    if (pImeDpi->CtfImeGetGuidAtom)
+        hr = pImeDpi->CtfImeGetGuidAtom(hIMC, dwUnknown, pdwGuidAtom);
+
+    ImmUnlockImeDpi(pImeDpi);
+    return hr;
+}

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -14,6 +14,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(imm);
  *       If insecure, we don't follow the dangerous design.
  *
  * https://www.zdnet.com/article/vulnerability-in-microsoft-ctf-protocol-goes-back-to-windows-xp/
+ * https://googleprojectzero.blogspot.com/2019/08/down-rabbit-hole.html
  */
 
 // Win: LoadCtfIme

--- a/dll/win32/imm32/ctf.c
+++ b/dll/win32/imm32/ctf.c
@@ -138,7 +138,7 @@ HRESULT WINAPI CtfImmGetGuidAtom(HIMC hIMC, DWORD dwUnknown, LPDWORD pdwGuidAtom
     DWORD dwThreadId;
     HKL hKL;
 
-    TRACE("(%p, 0x%08lX, %p)\n", hIMC, dwUnknown, pdwGuidAtom);
+    TRACE("(%p, 0xlX, %p)\n", hIMC, dwUnknown, pdwGuidAtom);
 
     *pdwGuidAtom = 0;
 

--- a/dll/win32/imm32/imm32.spec
+++ b/dll/win32/imm32/imm32.spec
@@ -4,6 +4,8 @@
 @ stdcall CtfImmRestoreToolbarWnd(long)
 @ stdcall CtfImmHideToolbarWnd()
 @ stdcall CtfImmDispatchDefImeMessage(ptr long ptr ptr)
+@ stdcall CtfImmIsGuidMapEnable(ptr)
+@ stdcall CtfImmGetGuidAtom(ptr long ptr)
 @ stdcall ImmActivateLayout(ptr)
 @ stdcall ImmAssociateContext(ptr ptr)
 @ stdcall ImmAssociateContextEx(ptr ptr long)

--- a/win32ss/include/imetable.h
+++ b/win32ss/include/imetable.h
@@ -18,5 +18,5 @@ DEFINE_IME_ENTRY(DWORD, ImeGetImeMenuItems, (HIMC hIMC, DWORD dwFlags, DWORD dwT
 DEFINE_IME_ENTRY(BOOL, CtfImeInquireExW, (LPIMEINFO lpIMEInfo, LPVOID lpszWndClass, DWORD dwSystemInfoFlags, HKL hKL), TRUE)
 DEFINE_IME_ENTRY(BOOL, CtfImeSelectEx, (HIMC hIMC, BOOL fSelect, HKL hKL), TRUE)
 DEFINE_IME_ENTRY(LRESULT, CtfImeEscapeEx, (HIMC hIMC, UINT uSubFunc, LPVOID lpData, HKL hKL), TRUE)
-DEFINE_IME_ENTRY(DWORD, CtfImeGetGuidAtom, (VOID /* FIXME: unknown */), TRUE)
-DEFINE_IME_ENTRY(DWORD, CtfImeIsGuidMapEnable, (VOID /* FIXME: unknown */), TRUE)
+DEFINE_IME_ENTRY(HRESULT, CtfImeGetGuidAtom, (HIMC hIMC, DWORD dwUnknown, LPDWORD pdwGuidAtom), TRUE)
+DEFINE_IME_ENTRY(BOOL, CtfImeIsGuidMapEnable, (HIMC hIMC), TRUE)


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `CtfImmIsGuidMapEnable` and `CtfImmGetGuidAtom` functions.
- Modify `imetable.h` and `imm32.spec`.