### PR TITLE
[KBSWITCH][NTUSER] Realize Shift+Alt language switch

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -14,7 +14,7 @@
 PKBSWITCHSETHOOKS KbSwitchSetHooks    = NULL;
 PKBSWITCHDELETEHOOKS KbSwitchDeleteHooks = NULL;
 UINT ShellHookMessage = 0;
-DWORD dwAltShiftHotKeyId, dwShiftAltHotKeyId;
+DWORD dwAltShiftHotKeyId = 0, dwShiftAltHotKeyId = 0;
 
 static BOOL
 GetLayoutID(LPTSTR szLayoutNum, LPTSTR szLCID, SIZE_T LCIDLength);

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -428,6 +428,9 @@ VOID DoUnregisterAltShiftHotKeys(HWND hwnd)
 {
     UnregisterHotKey(hwnd, dwAltShiftHotKeyId);
     UnregisterHotKey(hwnd, dwShiftAltHotKeyId);
+
+    GlobalDeleteAtom(dwAltShiftHotKeyId);
+    GlobalDeleteAtom(dwShiftAltHotKeyId);
     dwAltShiftHotKeyId = dwShiftAltHotKeyId = 0;
 }
 

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -424,7 +424,7 @@ VOID DoRegisterAltShiftHotKeys(HWND hwnd)
     RegisterHotKey(hwnd, dwShiftAltHotKeyId, MOD_ALT | MOD_SHIFT, VK_MENU);
 }
 
-VOID DoUnuegisterAltShiftHotKeys(HWND hwnd)
+VOID DoUnregisterAltShiftHotKeys(HWND hwnd)
 {
     UnregisterHotKey(hwnd, dwAltShiftHotKeyId);
     UnregisterHotKey(hwnd, dwShiftAltHotKeyId);
@@ -553,7 +553,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
         case WM_DESTROY:
         {
-            DoUnuegisterAltShiftHotKeys(hwnd);
+            DoUnregisterAltShiftHotKeys(hwnd);
             DeleteHooks();
             DestroyMenu(hRightPopupMenu);
             DelTrayIcon(hwnd);

--- a/win32ss/user/ntuser/hotkey.c
+++ b/win32ss/user/ntuser/hotkey.c
@@ -211,7 +211,9 @@ co_UserProcessHotKeys(WORD wVk, BOOL bIsDown)
         if (IsModifier)
         {
             /* Modifier key up -- modifier-only keys are triggered here */
-            pHotKey = IsHotKey(gfsModOnlyCandidate, 0);
+            pHotKey = IsHotKey(gfsModOnlyCandidate, wVk);
+            if (!pHotKey)
+                pHotKey = IsHotKey(gfsModOnlyCandidate, 0);
             gfsModOnlyCandidate = 0;
         }
         else


### PR DESCRIPTION
## Purpose
Improve language switching.
JIRA issue: [CORE-11737](https://jira.reactos.org/browse/CORE-11737)

## Proposed changes

- Fix `co_UserProcessHotKeys` on modifiers-only hot-keys.
- Add `Alt+Shift` hotkeys to `kbswitch` window.

## TODO

- [x] A small test.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/185905421-993faac1-5308-4cfa-947e-a71d6e007f44.png)
Cannot switch languages by `Alt+Shift` key combination.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/185905415-8922f964-6e83-409b-934f-8188a2de34d7.png)
Able to switch languages by `Alt+Shift` key combination.