### PR TITLE
[KBSWITCH] Fix GetNextLayout for three or more languages

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -331,6 +331,40 @@ BuildLeftPopupMenu(VOID)
     return hMenu;
 }
 
+static ULONG
+GetMaxLayoutNum(VOID)
+{
+    HKEY hKey;
+    ULONG dwIndex, dwSize, uLayoutNum, uMaxLayoutNum = 0;
+    TCHAR szLayoutNum[CCH_ULONG_DEC + 1], szLayoutID[CCH_LAYOUT_ID + 1];
+
+    /* Add the keyboard layouts to the popup menu */
+    if (RegOpenKeyEx(HKEY_CURRENT_USER, _T("Keyboard Layout\\Preload"), 0,
+                     KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS)
+    {
+        for (dwIndex = 0; ; dwIndex++)
+        {
+            dwSize = sizeof(szLayoutNum);
+            if (RegEnumValue(hKey, dwIndex, szLayoutNum, &dwSize, NULL, NULL,
+                             NULL, NULL) != ERROR_SUCCESS)
+            {
+                break;
+            }
+
+            if (GetLayoutID(szLayoutNum, szLayoutID, ARRAYSIZE(szLayoutID)))
+            {
+                uLayoutNum = _ttoi(szLayoutNum);
+                if (uMaxLayoutNum < uLayoutNum)
+                    uMaxLayoutNum = uLayoutNum;
+            }
+        }
+
+        RegCloseKey(hKey);
+    }
+
+    return uMaxLayoutNum;
+}
+
 BOOL
 SetHooks(VOID)
 {
@@ -362,26 +396,21 @@ ULONG
 GetNextLayout(VOID)
 {
     TCHAR szLayoutNum[3 + 1], szLayoutID[CCH_LAYOUT_ID + 1];
-    ULONG Ret = ulCurrentLayoutNum;
+    ULONG uLayoutNum, uMaxNum = GetMaxLayoutNum();
 
-    _ultot(ulCurrentLayoutNum, szLayoutNum, 10);
-    if (!GetLayoutID(szLayoutNum, szLayoutID, ARRAYSIZE(szLayoutID)))
+    for (uLayoutNum = ulCurrentLayoutNum + 1; ; ++uLayoutNum)
     {
-        return -1;
+        if (uLayoutNum > uMaxNum)
+            uLayoutNum = 1;
+        if (uLayoutNum == ulCurrentLayoutNum)
+            break;
+
+        _ultot(uLayoutNum, szLayoutNum, 10);
+        if (GetLayoutID(szLayoutNum, szLayoutID, ARRAYSIZE(szLayoutID)))
+            return uLayoutNum;
     }
 
-    _ultot(Ret + 1, szLayoutNum, 10);
-
-    if (GetLayoutID(szLayoutNum, szLayoutID, ARRAYSIZE(szLayoutID)))
-    {
-        return (Ret + 1);
-    }
-
-    _ultot(Ret - 1, szLayoutNum, 10);
-    if (GetLayoutID(szLayoutNum, szLayoutID, ARRAYSIZE(szLayoutID)))
-        return (Ret - 1);
-
-    return -1;
+    return ulCurrentLayoutNum;
 }
 
 LRESULT

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -338,7 +338,7 @@ GetMaxLayoutNum(VOID)
     ULONG dwIndex, dwSize, uLayoutNum, uMaxLayoutNum = 0;
     TCHAR szLayoutNum[CCH_ULONG_DEC + 1], szLayoutID[CCH_LAYOUT_ID + 1];
 
-    /* Add the keyboard layouts to the popup menu */
+    /* Get the maximum layout number in the Preload key */
     if (RegOpenKeyEx(HKEY_CURRENT_USER, _T("Keyboard Layout\\Preload"), 0,
                      KEY_QUERY_VALUE, &hKey) == ERROR_SUCCESS)
     {

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -278,7 +278,7 @@ ActivateLayout(HWND hwnd, ULONG uLayoutNum)
     TCHAR szLayoutNum[CCH_ULONG_DEC + 1], szLCID[CCH_LAYOUT_ID + 1], szLangName[MAX_PATH];
     LANGID LangID;
 
-    if (uLayoutNum == (ULONG)-1 || uLayoutNum > 0xFF) /* Invalid */
+    if (uLayoutNum == 0 || uLayoutNum > 0xFF) /* Invalid */
         return;
 
     _ultot(uLayoutNum, szLayoutNum, 10);

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -278,6 +278,7 @@ ActivateLayout(HWND hwnd, ULONG uLayoutNum)
     TCHAR szLayoutNum[CCH_ULONG_DEC + 1], szLCID[CCH_LAYOUT_ID + 1], szLangName[MAX_PATH];
     LANGID LangID;
 
+    /* The layout number starts from one. Zero is invalid */
     if (uLayoutNum == 0 || uLayoutNum > 0xFF) /* Invalid */
         return;
 


### PR DESCRIPTION
## Purpose

Even when the user installed three or more languages into the system, `Shift+Alt` key combination should work correctly.
JIRA issue: [CORE-11737](https://jira.reactos.org/browse/CORE-11737)

![VirtualBox_ReactOS Debug_24_08_2022_14_24_06](https://user-images.githubusercontent.com/2107452/186336198-518d9de5-a123-4ff0-a931-9b13e4aef7da.png)

For example, we assume the user installed three Latin languages (English, French, and German), then typing `Alt+Shift` should work like EN → FR → DE → EN → FR → DE → ... (cyclically).

## Proposed changes

- Add `GetMaxLayoutNum` helper function.
- Fix `GetNextLayout` function to make `Shift+Alt` cyclic.

## TODO

- [x] Do small test.
