### PR TITLE
[CPL] Use MAKEINTRESOURCE instead of LoadString

### DIFF
--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -189,14 +189,11 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     PGLOBAL_DATA pGlobalData;
     PROPSHEETPAGE psp[5];
     PROPSHEETHEADER psh;
-    TCHAR Caption[1024];
     INT nPage = 0;
     INT ret;
 
     if (uMsg == CPL_STARTWPARMSW && lParam != 0)
         nPage = _wtoi((PWSTR)lParam);
-
-    LoadString(hApplet, IDS_CPLSYSTEMNAME, Caption, sizeof(Caption) / sizeof(TCHAR));
 
     pGlobalData = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(GLOBAL_DATA));
     if (pGlobalData == NULL)
@@ -214,7 +211,7 @@ SystemApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLACCESS);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLSYSTEMNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;

--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -144,7 +144,6 @@ DisplayApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     HPROPSHEETPAGE hpsp[MAX_DESK_PAGES];
     PROPSHEETHEADER psh;
     HPSXA hpsxa = NULL;
-    TCHAR Caption[1024];
     UINT i;
     LPWSTR *argv = NULL;
     LPCWSTR pwszSelectedTab = NULL;
@@ -198,15 +197,13 @@ DisplayApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     g_GlobalData.pwszAction = pwszAction;
     g_GlobalData.desktop_color = GetSysColor(COLOR_DESKTOP);
 
-    LoadString(hApplet, IDS_CPLNAME, Caption, sizeof(Caption) / sizeof(TCHAR));
-
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags = PSH_USECALLBACK | PSH_PROPTITLE | PSH_USEICONID;
     psh.hwndParent = hCPLWindow;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDC_DESK_ICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = 0;
     psh.nStartPage = 0;
     psh.phpage = hpsp;

--- a/dll/cpl/intl/generalp.c
+++ b/dll/cpl/intl/generalp.c
@@ -1349,9 +1349,6 @@ CustomizeLocalePropertySheet(
 {
     PROPSHEETPAGEW PsPage[NUM_SHEETS + 1];
     PROPSHEETHEADERW psh;
-    WCHAR Caption[MAX_STR_SIZE];
-
-    LoadStringW(hApplet, IDS_CUSTOMIZE_TITLE, Caption, sizeof(Caption) / sizeof(TCHAR));
 
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
@@ -1359,7 +1356,7 @@ CustomizeLocalePropertySheet(
     psh.hwndParent = hwndDlg;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCE(IDC_CPLICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCE(IDS_CUSTOMIZE_TITLE);
     psh.nPages = (sizeof(PsPage) / sizeof(PROPSHEETPAGE)) - 1;
     psh.nStartPage = 0;
     psh.ppsp = PsPage;

--- a/dll/cpl/intl/intl.c
+++ b/dll/cpl/intl/intl.c
@@ -168,7 +168,6 @@ PropSheetProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
 static LONG APIENTRY
 Applet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
 {
-    TCHAR Caption[BUFFERSIZE];
     PROPSHEETPAGE psp[3];
     PROPSHEETHEADER psh;
     PGLOBALDATA pGlobalData;
@@ -190,15 +189,13 @@ Applet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     pGlobalData->SystemLCID = GetSystemDefaultLCID();
     pGlobalData->bIsUserAdmin = IsUserAdmin();
 
-    LoadString(hApplet, IDS_CPLNAME, Caption, sizeof(Caption) / sizeof(TCHAR));
-
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDC_CPLICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = 0;
     psh.nStartPage = 0;
     psh.ppsp = psp;

--- a/dll/cpl/main/keyboard.c
+++ b/dll/cpl/main/keyboard.c
@@ -305,7 +305,6 @@ KeyboardApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     HPROPSHEETPAGE hpsp[MAX_CPL_PAGES];
     PROPSHEETHEADER psh;
     HPSXA hpsxa;
-    TCHAR szCaption[256];
     INT nPage = 0;
     LONG ret;
 
@@ -317,15 +316,13 @@ KeyboardApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     if (uMsg == CPL_STARTWPARMSW && lParam != 0)
         nPage = _wtoi((PWSTR)lParam);
 
-    LoadString(hApplet, IDS_CPLNAME_2, szCaption, sizeof(szCaption) / sizeof(TCHAR));
-
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCE(IDC_CPLICON_2);
-    psh.pszCaption = szCaption;
+    psh.pszCaption = MAKEINTRESOURCE(IDS_CPLNAME_2);
     psh.nStartPage = 0;
     psh.phpage = hpsp;
     psh.pfnCallback = PropSheetProc;

--- a/dll/cpl/main/mouse.c
+++ b/dll/cpl/main/mouse.c
@@ -1831,7 +1831,6 @@ MouseApplet(HWND hwnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     HPROPSHEETPAGE hpsp[MAX_CPL_PAGES];
     PROPSHEETHEADER psh;
     HPSXA hpsxa;
-    TCHAR Caption[256];
     UINT i;
     INT nPage = 0;
     LONG ret;
@@ -1844,15 +1843,13 @@ MouseApplet(HWND hwnd, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
     if (uMsg == CPL_STARTWPARMSW && lParam2 != 0)
         nPage = _wtoi((PWSTR)lParam2);
 
-    LoadString(hApplet, IDS_CPLNAME_1, Caption, sizeof(Caption) / sizeof(TCHAR));
-
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags = PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDC_CPLICON_1);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME_1);
     psh.nStartPage = 0;
     psh.phpage = hpsp;
     psh.pfnCallback = PropSheetProc;

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -696,7 +696,6 @@ MmSysApplet(HWND hwnd,
 {
     PROPSHEETPAGE psp[5];
     PROPSHEETHEADER psh; // = { 0 };
-    TCHAR Caption[256];
     INT nPage = 0;
 
     UNREFERENCED_PARAMETER(lParam);
@@ -706,14 +705,12 @@ MmSysApplet(HWND hwnd,
     if (uMsg == CPL_STARTWPARMSW && lParam != 0)
         nPage = _wtoi((PWSTR)lParam);
 
-    LoadString(hApplet, IDS_CPLNAME, Caption, _countof(Caption));
-
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;
@@ -797,18 +794,15 @@ ShowAudioPropertySheet(HWND hwnd,
 {
     PROPSHEETPAGE psp[1];
     PROPSHEETHEADER psh;
-    TCHAR Caption[256];
 
     DPRINT("ShowAudioPropertySheet()\n");
-
-    LoadString(hApplet, IDS_CPLNAME, Caption, _countof(Caption));
 
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hInstance;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;
@@ -827,18 +821,15 @@ ShowFullControlPanel(HWND hwnd,
 {
     PROPSHEETPAGE psp[5];
     PROPSHEETHEADER psh;
-    TCHAR Caption[256];
 
     DPRINT("ShowFullControlPanel()\n");
-
-    LoadString(hApplet, IDS_CPLNAME, Caption, _countof(Caption));
 
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hInstance;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;

--- a/dll/cpl/mmsys/speakervolume.c
+++ b/dll/cpl/mmsys/speakervolume.c
@@ -308,23 +308,21 @@ SpeakerVolume(
 {
     PROPSHEETPAGE psp[1];
     PROPSHEETHEADER psh;
-    TCHAR Caption[256];
-
-    LoadString(hApplet, IDS_SPEAKER_VOLUME, Caption, _countof(Caption));
 
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags =  PSH_PROPSHEETPAGE;
     psh.hwndParent = hwndDlg;
     psh.hInstance = hApplet;
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCE(IDS_SPEAKER_VOLUME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;
 
     InitPropSheetPage(&psp[0], IDD_MULTICHANNEL, SpeakerVolumeDlgProc);
     psp[0].dwFlags |= PSP_USETITLE;
-    psp[0].pszTitle = Caption;
+    psp[0].hInstance = hApplet;
+    psp[0].pszTitle = MAKEINTRESOURCE(IDS_SPEAKER_VOLUME);
 
     return (LONG)(PropertySheet(&psh) != -1);
 }

--- a/dll/cpl/openglcfg/openglcfg.c
+++ b/dll/cpl/openglcfg/openglcfg.c
@@ -25,9 +25,6 @@ LONG CALLBACK AppletInit(HWND hWnd)
 {
     PROPSHEETPAGEW psp;
     PROPSHEETHEADERW psh;
-    WCHAR szCaption[1024];
-
-    LoadStringW(hApplet, IDS_CPLNAME, szCaption, sizeof(szCaption) / sizeof(WCHAR));
 
     ZeroMemory(&psp, sizeof(PROPSHEETPAGE));
     psp.dwSize = sizeof(PROPSHEETPAGE);
@@ -42,7 +39,7 @@ LONG CALLBACK AppletInit(HWND hWnd)
     psh.hwndParent = hWnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
-    psh.pszCaption = szCaption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = &psp;

--- a/dll/cpl/powercfg/powercfg.c
+++ b/dll/cpl/powercfg/powercfg.c
@@ -92,7 +92,6 @@ Applet1(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     HPROPSHEETPAGE hpsp[MAX_POWER_PAGES];
     PROPSHEETHEADER psh;
     HPSXA hpsxa = NULL;
-    TCHAR Caption[1024];
     SYSTEM_POWER_CAPABILITIES spc;
     LONG ret;
 
@@ -100,16 +99,13 @@ Applet1(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     UNREFERENCED_PARAMETER(wParam);
     UNREFERENCED_PARAMETER(lParam);
 
-    memset(Caption, 0x0, sizeof(Caption));
-    LoadString(hApplet, IDS_CPLNAME_1, Caption, sizeof(Caption) / sizeof(TCHAR));
-
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
     psh.dwFlags = PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDC_CPLICON_1);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME_1);
     psh.nPages = 0;
     psh.nStartPage = 0;
     psh.phpage = hpsp;

--- a/dll/cpl/timedate/timedate.c
+++ b/dll/cpl/timedate/timedate.c
@@ -89,7 +89,6 @@ Applet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
 {
     PROPSHEETHEADER psh;
     PROPSHEETPAGEW psp[3];
-    WCHAR Caption[256];
     LONG Ret = 0;
 
     UNREFERENCED_PARAMETER(uMsg);
@@ -99,15 +98,13 @@ Applet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     if (RegisterMonthCalControl(hApplet) &&
         RegisterClockControl())
     {
-        LoadStringW(hApplet, IDS_CPLNAME, Caption, sizeof(Caption) / sizeof(WCHAR));
-
         ZeroMemory(&psh, sizeof(PROPSHEETHEADERW));
         psh.dwSize = sizeof(PROPSHEETHEADERW);
         psh.dwFlags =  PSH_PROPSHEETPAGE | PSH_PROPTITLE | PSH_USEICONID | PSH_USECALLBACK;
         psh.hwndParent = hwnd;
         psh.hInstance = hApplet;
         psh.pszIcon = MAKEINTRESOURCEW(IDC_CPLICON);
-        psh.pszCaption = Caption;
+        psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
         psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGEW);
         psh.nStartPage = 0;
         psh.ppsp = psp;

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -61,13 +61,10 @@ UsrmgrApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
 {
     PROPSHEETPAGE psp[2];
     PROPSHEETHEADER psh;
-    TCHAR Caption[1024];
 
     UNREFERENCED_PARAMETER(lParam);
     UNREFERENCED_PARAMETER(wParam);
     UNREFERENCED_PARAMETER(uMsg);
-
-    LoadString(hApplet, IDS_CPLNAME, Caption, sizeof(Caption) / sizeof(TCHAR));
 
     ZeroMemory(&psh, sizeof(PROPSHEETHEADER));
     psh.dwSize = sizeof(PROPSHEETHEADER);
@@ -75,7 +72,7 @@ UsrmgrApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
     psh.hwndParent = hwnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_USRMGR_ICON);
-    psh.pszCaption = Caption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = psp;

--- a/dll/cpl/wined3dcfg/wined3dcfg.c
+++ b/dll/cpl/wined3dcfg/wined3dcfg.c
@@ -25,9 +25,6 @@ LONG CALLBACK AppletInit(HWND hWnd)
 {
     PROPSHEETPAGEW psp;
     PROPSHEETHEADERW psh;
-    WCHAR szCaption[1024];
-
-    LoadStringW(hApplet, IDS_CPLNAME, szCaption, sizeof(szCaption) / sizeof(WCHAR));
 
     ZeroMemory(&psp, sizeof(PROPSHEETPAGE));
     psp.dwSize = sizeof(PROPSHEETPAGE);
@@ -42,7 +39,7 @@ LONG CALLBACK AppletInit(HWND hWnd)
     psh.hwndParent = hWnd;
     psh.hInstance = hApplet;
     psh.pszIcon = MAKEINTRESOURCEW(IDI_CPLICON);
-    psh.pszCaption = szCaption;
+    psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
     psh.nPages = sizeof(psp) / sizeof(PROPSHEETPAGE);
     psh.nStartPage = 0;
     psh.ppsp = &psp;


### PR DESCRIPTION
## Purpose
- Follow-up of [0ed302e](https://github.com/reactos/reactos/commit/0ed302ef656ed39c932e084508ffa506b47c463b)

## Proposed changes
- Replace unnecessary `LoadString` calls with `MAKEINTRESOURCE`
