### PR TITLE
[WINMM] Winmm fixes for system sound

### DIFF
--- a/dll/win32/winmm/midimap/midimap.c
+++ b/dll/win32/winmm/midimap/midimap.c
@@ -202,11 +202,21 @@ static BOOL	MIDIMAP_LoadSettingsScheme(MIDIMAPDATA* mom, const WCHAR* scheme)
 
 static BOOL	MIDIMAP_LoadSettings(MIDIMAPDATA* mom)
 {
-    HKEY 	hKey;
+    HKEY 	hUserKey, hKey;
+    DWORD   err;
     BOOL	ret;
 
-    if (RegOpenKeyA(HKEY_CURRENT_USER,
-		    "Software\\Microsoft\\Windows\\CurrentVersion\\Multimedia\\MIDIMap", &hKey))
+    err = RegOpenCurrentUser(KEY_READ, &hUserKey);
+    if (err == ERROR_SUCCESS)
+    {
+        err = RegOpenKeyW(hUserKey,
+                          L"Software\\Microsoft\\Windows\\CurrentVersion\\Multimedia\\MIDIMap",
+                          &hKey);
+
+        RegCloseKey(hUserKey);
+    }
+
+    if (err != ERROR_SUCCESS)
     {
 	ret = MIDIMAP_LoadSettingsDefault(mom, NULL);
     }

--- a/dll/win32/winmm/midimap/midimap.c
+++ b/dll/win32/winmm/midimap/midimap.c
@@ -212,7 +212,6 @@ static BOOL	MIDIMAP_LoadSettings(MIDIMAPDATA* mom)
         err = RegOpenKeyW(hUserKey,
                           L"Software\\Microsoft\\Windows\\CurrentVersion\\Multimedia\\MIDIMap",
                           &hKey);
-
         RegCloseKey(hUserKey);
     }
 

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -121,15 +121,16 @@ static HMMIO	get_mmioFromProfile(UINT uFlags, LPCWSTR lpszName)
     err = RegOpenKeyW(hRegApp, lpszName, &hScheme);
     RegCloseKey(hRegApp);
     if (err != 0) goto none;
-    /* what's the difference between .Current and .Default ? */
-    err = RegOpenKeyW(hScheme, wszDotDefault, &hSnd);
-    if (err != 0)
+    
+    err = RegOpenKeyW(hScheme, wszDotCurrent, &hSnd);
+
+    RegCloseKey(hScheme);
+
+    if (err != ERROR_SUCCESS)
     {
-        err = RegOpenKeyW(hScheme, wszDotCurrent, &hSnd);
-        RegCloseKey(hScheme);
-        if (err != 0)
-            goto none;
+        goto none;
     }
+
     count = sizeof(str);
     err = RegQueryValueExW(hSnd, NULL, 0, &type, (LPBYTE)str, &count);
     RegCloseKey(hSnd);

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -63,7 +63,7 @@ static HMMIO	get_mmioFromProfile(UINT uFlags, LPCWSTR lpszName)
     WCHAR	str[128];
     LPWSTR	ptr, pszSnd;
     HMMIO  	hmmio;
-    HKEY        hRegSnd, hRegApp, hScheme, hSnd;
+    HKEY        hUserKey, hRegSnd, hRegApp, hScheme, hSnd;
     DWORD       err, type, count;
 
     static const WCHAR  wszSounds[] = {'S','o','u','n','d','s',0};
@@ -92,7 +92,19 @@ static HMMIO	get_mmioFromProfile(UINT uFlags, LPCWSTR lpszName)
      *      HKCU\AppEvents\Schemes\Apps\.Default
      *      HKCU\AppEvents\Schemes\Apps\<AppName>
      */
-    if (RegOpenKeyW(HKEY_CURRENT_USER, wszKey, &hRegSnd) != 0) goto none;
+    err = RegOpenCurrentUser(KEY_READ, &hUserKey);
+    if (err == ERROR_SUCCESS)
+    {
+        err = RegOpenKeyW(hUserKey, wszKey, &hRegSnd);
+        
+        RegCloseKey(hUserKey);
+    }
+
+    if (err != ERROR_SUCCESS)
+    {
+        goto none;
+    }
+
     if (uFlags & SND_APPLICATION)
     {
         DWORD len;

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -328,15 +328,23 @@ static BOOL PlaySound_IsString(DWORD fdwSound, const void* psz)
     /* SND_RESOURCE is 0x40004 while
      * SND_MEMORY is 0x00004
      */
-    switch (fdwSound & (SND_RESOURCE|SND_ALIAS_ID|SND_FILENAME))
+    switch (fdwSound & (SND_RESOURCE | SND_ALIAS_ID | SND_FILENAME))
     {
-    case SND_RESOURCE:  return HIWORD(psz) != 0; /* by name or by ID ? */
-    case SND_ALIAS_ID:
-    case SND_MEMORY:    return FALSE;
-    case SND_ALIAS:
-    case SND_FILENAME:
-    case 0:             return TRUE;
-    default:            FIXME("WTF\n"); return FALSE;
+        case SND_RESOURCE:
+            return HIWORD(psz) != 0; /* by name or by ID ? */
+
+        case SND_ALIAS_ID:
+        case SND_MEMORY:
+            return FALSE;
+
+        case SND_ALIAS:
+        case SND_FILENAME:
+        case 0:
+            return TRUE;
+
+        default:
+            FIXME("WTF\n");
+            return FALSE;
     }
 }
 

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -46,7 +46,7 @@ static HMMIO	get_mmioFromFile(LPCWSTR lpszName)
     ret = mmioOpenW((LPWSTR)lpszName, NULL,
                     MMIO_ALLOCBUF | MMIO_READ | MMIO_DENYWRITE);
     if (ret != 0) return ret;
-    if (SearchPathW(NULL, lpszName, NULL, sizeof(buf)/sizeof(buf[0]), buf, &dummy))
+    if (SearchPathW(NULL, lpszName, NULL, ARRAY_SIZE(buf), buf, &dummy))
     {
         return mmioOpenW(buf, NULL,
                          MMIO_ALLOCBUF | MMIO_READ | MMIO_DENYWRITE);
@@ -71,7 +71,7 @@ static HMMIO get_mmioFromProfile(UINT uFlags, LPCWSTR lpszName)
                       bIsDefault ? L"Default" : lpszName,
                       L"",
                       str,
-                      _countof(str));
+                      ARRAY_SIZE(str));
     if (lstrlenW(str) == 0)
         goto Next;
 
@@ -105,8 +105,8 @@ Next:
         DWORD len;
 
         err = ERROR_FILE_NOT_FOUND; /* error */
-        len = GetModuleFileNameW(NULL, str, _countof(str));
-        if (len > 0 && len < _countof(str))
+        len = GetModuleFileNameW(NULL, str, ARRAY_SIZE(str));
+        if (len > 0 && len < ARRAY_SIZE(str))
         {
             for (ptr = str + lstrlenW(str) - 1; ptr >= str; ptr--)
             {

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -93,7 +93,6 @@ Next:
     if (err == ERROR_SUCCESS)
     {
         err = RegOpenKeyW(hUserKey, L"AppEvents\\Schemes\\Apps", &hRegSnd);
-
         RegCloseKey(hUserKey);
     }
 
@@ -216,18 +215,12 @@ static HMMIO PlaySound_GetMMIO(LPCWSTR pszSound, HMODULE hMod, DWORD fdwSound)
             hRes = FindResourceW(hMod, pszSound, L"WAVE");
             hGlob = LoadResource(hMod, hRes);
             if (!hRes || !hGlob)
-            {
                 goto Quit;
-            }
 
             data = LockResource(hGlob);
-            if (!data)
-            {
-                FreeResource(hGlob);
-                goto Quit;
-            }
-
             FreeResource(hGlob);
+            if (!data)
+                goto Quit;
         }
         else
         {
@@ -285,9 +278,7 @@ static HMMIO PlaySound_GetMMIO(LPCWSTR pszSound, HMODULE hMod, DWORD fdwSound)
     {
         hmmio = get_mmioFromProfile(fdwSound, pszSound);
         if (!hmmio)
-        {
             hmmio = get_mmioFromFile(pszSound);
-        }
     }
 
 Quit:
@@ -306,12 +297,9 @@ Quit:
             /* Find system default sound */
             hmmio = get_mmioFromProfile(fdwSound & ~SND_APPLICATION, L"SystemDefault");
         }
-        else
+        else if (!bIsDefault)
         {
-            if (!bIsDefault)
-            {
-                hmmio = get_mmioFromProfile(fdwSound, L"SystemDefault");
-            }
+            hmmio = get_mmioFromProfile(fdwSound, L"SystemDefault");
         }
     }
 

--- a/dll/win32/winmm/playsound.c
+++ b/dll/win32/winmm/playsound.c
@@ -245,7 +245,7 @@ static HMMIO PlaySound_GetMMIO(LPCWSTR pszSound, HMODULE hMod, DWORD fdwSound)
     }
     else if (fdwSound & SND_ALIAS)
     {
-        LPWSTR pszName;
+        LPCWSTR pszName;
 
         /* NOTE: SND_ALIAS_ID has the SND_ALIAS bit set */
         if ((fdwSound & SND_ALIAS_ID) == SND_ALIAS_ID)
@@ -271,7 +271,7 @@ static HMMIO PlaySound_GetMMIO(LPCWSTR pszSound, HMODULE hMod, DWORD fdwSound)
         }
         else
         {
-            pszName = (LPWSTR)pszSound;
+            pszName = pszSound;
         }
 
         bIsDefault = (_wcsicmp(pszName, L"SystemDefault") == 0);
@@ -397,7 +397,7 @@ static WINE_PLAYSOUND* PlaySound_AllocAndGetMMIO(const void* pszSound, HMODULE h
                                                  DWORD fdwSound, BOOL bUnicode)
 {
     BOOL bIsString;
-    LPWSTR pszSoundW;
+    LPCWSTR pszSoundW;
     UNICODE_STRING usBuffer;
     WINE_PLAYSOUND* wps;
 
@@ -413,7 +413,7 @@ static WINE_PLAYSOUND* PlaySound_AllocAndGetMMIO(const void* pszSound, HMODULE h
     }
     else
     {
-        pszSoundW = (LPWSTR)pszSound;
+        pszSoundW = pszSound;
     }
 
     wps = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(*wps));


### PR DESCRIPTION
## Proposed changes
- Fix incorrect registry key in `get_mmioFromProfile`
- `get_mmioFromProfile` : Expand environment strings if registry value type is `REG_EXPAND_SZ`
- Use `RegOpenCurrentUser` to access the appropriate `HKEY_CURRENT_USER` key. This allows functions that use `HKEY_CURRENT_USER` to be called from system processes while impersonating, for example: winlogon
- Fix `SystemDefault` event and `SND_NODEFAULT` flag

#### Also:
- `get_mmioFromProfile` code formatting
- `PlaySound_IsString` code formatting
