### PR TITLE
[EXPLORER] Fix Start Menu context menu actions

### DIFF
--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -185,7 +185,7 @@ public:
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (uiCmdId != 0)
         {
-            if ((uiCmdId >= ID_SHELL_CMD_FIRST) && (uiCmdId <= ID_SHELL_CMD_LAST))
+            if ((uiCmdId < ID_SHELL_CMD_PROPERTIES ) || (uiCmdId > ID_SHELL_CMD_RESTORE_ALL))
             {
                 CMINVOKECOMMANDINFO cmici = { 0 };
                 CHAR szDir[MAX_PATH];

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -151,7 +151,6 @@ public:
         HRESULT hRet;
 
         psfDesktop = NULL;
-        m_Inner = NULL;
 
         pidlStart = SHCloneSpecialIDList(m_Owner, CSIDL_STARTMENU, TRUE);
 
@@ -169,7 +168,15 @@ public:
                     if (SUCCEEDED(hRet))
                     {
                         CreateContextMenuFromShellFolderPidl(hPopup);
-                        m_idCmdCmLast = ID_SHELL_CMD_FIRST + GetMenuItemCount(hPopup);
+
+                        m_idCmdCmLast = m_Inner->QueryContextMenu(
+                            hPopup,
+                            0,
+                            ID_SHELL_CMD_FIRST,
+                            ID_SHELL_CMD_LAST,
+                            CMF_VERBSONLY);
+                        if(!SUCCEEDED(m_idCmdCmLast))
+                            m_idCmdCmLast = ID_SHELL_CMD_LAST;
                         AddStartContextMenuItems(hPopup);
                     }
                 }

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -136,7 +136,6 @@ public:
     {
         m_TrayWnd = pTrayWnd;
         m_Owner = hWndOwner;
-        m_idCmdCmLast = ID_SHELL_CMD_LAST;
         return S_OK;
     }
 
@@ -227,6 +226,7 @@ public:
 
     CStartMenuBtnCtxMenu()
     {
+        m_idCmdCmLast = ID_SHELL_CMD_LAST;
     }
 
     virtual ~CStartMenuBtnCtxMenu()

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -151,6 +151,7 @@ public:
         HRESULT hRet;
 
         psfDesktop = NULL;
+        m_Inner = NULL;
 
         pidlStart = SHCloneSpecialIDList(m_Owner, CSIDL_STARTMENU, TRUE);
 
@@ -167,16 +168,8 @@ public:
                     hRet = psfDesktop->BindToObject(pidlStart, NULL, IID_PPV_ARG(IShellFolder, &m_Folder));
                     if (SUCCEEDED(hRet))
                     {
-                        CreateContextMenuFromShellFolderPidl(hPopup);
-
-                        m_idCmdCmLast = m_Inner->QueryContextMenu(
-                            hPopup,
-                            0,
-                            ID_SHELL_CMD_FIRST,
-                            ID_SHELL_CMD_LAST,
-                            CMF_VERBSONLY);
-                        if(!SUCCEEDED(m_idCmdCmLast))
-                            m_idCmdCmLast = ID_SHELL_CMD_LAST;
+                        hRet = CreateContextMenuFromShellFolderPidl(hPopup);
+                        m_idCmdCmLast = (SUCCEEDED(hRet)) ? HRESULT_CODE(hRet) : ID_SHELL_CMD_LAST;
                         AddStartContextMenuItems(hPopup);
                     }
                 }

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -32,7 +32,7 @@ class CStartMenuBtnCtxMenu :
     CComPtr<ITrayWindow>  m_TrayWnd;
     CComPtr<IContextMenu> m_Inner;
     CComPtr<IShellFolder> m_Folder;
-    UINT m_idCmdCmFirst;
+    UINT m_idCmdCmLast;
 
     HWND m_Owner;
     LPITEMIDLIST m_FolderPidl;

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -32,6 +32,7 @@ class CStartMenuBtnCtxMenu :
     CComPtr<ITrayWindow>  m_TrayWnd;
     CComPtr<IContextMenu> m_Inner;
     CComPtr<IShellFolder> m_Folder;
+    UINT m_idCmdCmFirst;
 
     HWND m_Owner;
     LPITEMIDLIST m_FolderPidl;
@@ -135,6 +136,7 @@ public:
     {
         m_TrayWnd = pTrayWnd;
         m_Owner = hWndOwner;
+        m_idCmdCmLast = ID_SHELL_CMD_LAST;
         return S_OK;
     }
 
@@ -168,6 +170,7 @@ public:
                     if (SUCCEEDED(hRet))
                     {
                         CreateContextMenuFromShellFolderPidl(hPopup);
+                        m_idCmdCmLast = ID_SHELL_CMD_FIRST + GetMenuItemCount(hPopup);
                         AddStartContextMenuItems(hPopup);
                     }
                 }
@@ -185,8 +188,7 @@ public:
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (uiCmdId != 0)
         {
-            if (((uiCmdId >= ID_SHELL_CMD_FIRST) && (uiCmdId <= ID_SHELL_CMD_LAST)) &&
-                ((uiCmdId < ID_SHELL_CMD_PROPERTIES ) || (uiCmdId > ID_SHELL_CMD_RESTORE_ALL)))
+            if ((uiCmdId >= ID_SHELL_CMD_FIRST) && (uiCmdId < m_idCmdCmLast))
             {
                 CMINVOKECOMMANDINFO cmici = { 0 };
                 CHAR szDir[MAX_PATH];

--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -185,7 +185,8 @@ public:
         UINT uiCmdId = PtrToUlong(lpici->lpVerb);
         if (uiCmdId != 0)
         {
-            if ((uiCmdId < ID_SHELL_CMD_PROPERTIES ) || (uiCmdId > ID_SHELL_CMD_RESTORE_ALL))
+            if (((uiCmdId >= ID_SHELL_CMD_FIRST) && (uiCmdId <= ID_SHELL_CMD_LAST)) &&
+                ((uiCmdId < ID_SHELL_CMD_PROPERTIES ) || (uiCmdId > ID_SHELL_CMD_RESTORE_ALL)))
             {
                 CMINVOKECOMMANDINFO cmici = { 0 };
                 CHAR szDir[MAX_PATH];


### PR DESCRIPTION
## Purpose

_ Current design is not processing actions verbs correctly for some Start Menu context menu actions (Properties, Open all users, Explore all users) despite associated code being implemented
_ This bug is cased by an incorrect actions id filtering not routing to the appropriate processing

JIRA issue: [CORE-18336](https://jira.reactos.org/browse/CORE-18336)

_ before : Properties, Open all users, Explore all users have no effect
_ after : Properties, Open all users, Explore all users open the appropriate windows