### PR TITLE
[NTUSER] Move TL structure definition to ntuser.h

### DIFF
--- a/win32ss/user/ntuser/ntuser.h
+++ b/win32ss/user/ntuser/ntuser.h
@@ -9,6 +9,15 @@
 #define UserEnterCo UserEnterExclusive
 #define UserLeaveCo UserLeave
 
+typedef VOID (*TL_FN_FREE)(PVOID);
+
+typedef struct _TL
+{
+    struct _TL* next;
+    PVOID pobj;
+    TL_FN_FREE pfnFree;
+} TL, *PTL;
+
 extern PSERVERINFO gpsi;
 extern PTHREADINFO gptiCurrent;
 extern PPROCESSINFO gppiList;
@@ -20,15 +29,6 @@ extern ATOM AtomDDETrack;
 extern ATOM AtomQOS;
 extern ATOM AtomImeLevel;
 extern ERESOURCE UserLock;
-
-typedef VOID (*TL_FN_FREE)(PVOID);
-
-typedef struct _TL
-{
-    struct _TL* next;
-    PVOID pobj;
-    TL_FN_FREE pfnFree;
-} TL, *PTL;
 
 CODE_SEG("INIT") NTSTATUS NTAPI InitUserImpl(VOID);
 VOID FASTCALL CleanupUserImpl(VOID);

--- a/win32ss/user/ntuser/ntuser.h
+++ b/win32ss/user/ntuser/ntuser.h
@@ -21,6 +21,15 @@ extern ATOM AtomQOS;
 extern ATOM AtomImeLevel;
 extern ERESOURCE UserLock;
 
+typedef VOID (*TL_FN_FREE)(PVOID);
+
+typedef struct _TL
+{
+    struct _TL* next;
+    PVOID pobj;
+    TL_FN_FREE pfnFree;
+} TL, *PTL;
+
 CODE_SEG("INIT") NTSTATUS NTAPI InitUserImpl(VOID);
 VOID FASTCALL CleanupUserImpl(VOID);
 VOID FASTCALL UserEnterShared(VOID);

--- a/win32ss/user/ntuser/win32.h
+++ b/win32ss/user/ntuser/win32.h
@@ -53,13 +53,8 @@ extern HANDLE hModuleWin;    // This Win32k Instance.
 extern struct _CLS *SystemClassList;
 extern BOOL RegisteredSysClasses;
 
-// FIXME: Move to ntuser.h
-typedef struct _TL
-{
-    struct _TL* next;
-    PVOID pobj;
-    PVOID pfnFree;
-} TL, *PTL;
+struct _TL;
+typedef struct _TL *PTL;
 
 typedef struct _W32THREAD
 {


### PR DESCRIPTION
## Purpose
Define type in proper place.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

# Proposed changes

- Move `struct _TL` and `TL` definitions from `win32.h` to `ntuser.h`.
- Modify the type of `TL.pfnFree` as newly-defined `TL_FN_FREE` function pointer.