### PR TITLE
[CONSOLE] Use translated resource rather than hardcoded text

### DIFF
--- a/dll/cpl/console/console.c
+++ b/dll/cpl/console/console.c
@@ -237,10 +237,12 @@ InitApplet(HANDLE hSectionOrWnd)
     psh.dwFlags = PSH_PROPSHEETPAGE | PSH_PROPTITLE | /* PSH_USEHICON | */ PSH_USEICONID | PSH_NOAPPLYNOW | PSH_USECALLBACK;
 
     if (ConInfo->ConsoleTitle[0] != UNICODE_NULL)
+    {
         StringCchPrintfW(szTitle, ARRAYSIZE(szTitle), L"\"%s\"", ConInfo->ConsoleTitle);
+        psh.pszCaption = szTitle;
+    }
     else
-        StringCchCopyW(szTitle, ARRAYSIZE(szTitle), L"ReactOS Console");
-    psh.pszCaption = szTitle;
+        psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
 
     if (pSharedInfo != NULL)
     {

--- a/dll/cpl/console/console.c
+++ b/dll/cpl/console/console.c
@@ -242,7 +242,9 @@ InitApplet(HANDLE hSectionOrWnd)
         psh.pszCaption = szTitle;
     }
     else
+    {
         psh.pszCaption = MAKEINTRESOURCEW(IDS_CPLNAME);
+    }
 
     if (pSharedInfo != NULL)
     {


### PR DESCRIPTION
## Purpose

- Current implementation use hardcoded text for "Default" title and does not use the translated ressource to be used as CPL name

## Proposed changes

- Load the localized CPL name as title, similarly to [4631](https://github.com/KRosUser/reactos/issues/4631)

Post change :
![image](https://user-images.githubusercontent.com/112266950/187549422-54b3e2c2-8299-411b-8685-a903a337a234.png)

