### PR TITLE
[TASKMGR] Fix UI on SwitchTo for multiple application

### DIFF
--- a/base/applications/taskmgr/applpage.c
+++ b/base/applications/taskmgr/applpage.c
@@ -512,14 +512,14 @@ void ApplicationPageUpdate(void)
     {
         EnableWindow(hApplicationPageEndTaskButton, FALSE);
     }
-    /* Enable "Switch To" button only if one app is selected */
-    if (ListView_GetSelectedCount(hApplicationPageListCtrl) == 1 )
+    /* Enable "Switch To" button only if at least one app is selected */
+    if (ListView_GetSelectedCount(hApplicationPageListCtrl))
     {
         EnableWindow(hApplicationPageSwitchToButton, TRUE);
     }
     else
     {
-    EnableWindow(hApplicationPageSwitchToButton, FALSE);
+        EnableWindow(hApplicationPageSwitchToButton, FALSE);
     }
 
     /* If we are on the applications tab the windows menu will be */

--- a/base/applications/taskmgr/applpage.c
+++ b/base/applications/taskmgr/applpage.c
@@ -512,8 +512,8 @@ void ApplicationPageUpdate(void)
     {
         EnableWindow(hApplicationPageEndTaskButton, FALSE);
     }
-    /* Enable "Switch To" button only if at least one app is selected */
-    if (ListView_GetSelectedCount(hApplicationPageListCtrl))
+    /* Enable "Switch To" button only if only one app is selected */
+    if (ListView_GetSelectedCount(hApplicationPageListCtrl) == 1 )
     {
         EnableWindow(hApplicationPageSwitchToButton, TRUE);
     }
@@ -693,6 +693,7 @@ void ApplicationPageShowContextMenu2(void)
 
     if (ListView_GetSelectedCount(hApplicationPageListCtrl) == 1)
     {
+        EnableMenuItem(hSubMenu, ID_APPLICATION_PAGE_SWITCHTO, MF_BYCOMMAND|MF_ENABLED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEHORIZONTALLY, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEVERTICALLY, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_MINIMIZE, MF_BYCOMMAND|MF_ENABLED);
@@ -702,6 +703,7 @@ void ApplicationPageShowContextMenu2(void)
     }
     else if (ListView_GetSelectedCount(hApplicationPageListCtrl) > 1)
     {
+        EnableMenuItem(hSubMenu, ID_APPLICATION_PAGE_SWITCHTO, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEHORIZONTALLY, MF_BYCOMMAND|MF_ENABLED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEVERTICALLY, MF_BYCOMMAND|MF_ENABLED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_MINIMIZE, MF_BYCOMMAND|MF_ENABLED);
@@ -711,6 +713,7 @@ void ApplicationPageShowContextMenu2(void)
     }
     else
     {
+        EnableMenuItem(hSubMenu, ID_APPLICATION_PAGE_SWITCHTO, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEHORIZONTALLY, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_TILEVERTICALLY, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);
         EnableMenuItem(hSubMenu, ID_WINDOWS_MINIMIZE, MF_BYCOMMAND|MF_DISABLED|MF_GRAYED);

--- a/base/applications/taskmgr/applpage.c
+++ b/base/applications/taskmgr/applpage.c
@@ -513,14 +513,7 @@ void ApplicationPageUpdate(void)
         EnableWindow(hApplicationPageEndTaskButton, FALSE);
     }
     /* Enable "Switch To" button only if only one app is selected */
-    if (ListView_GetSelectedCount(hApplicationPageListCtrl) == 1 )
-    {
-        EnableWindow(hApplicationPageSwitchToButton, TRUE);
-    }
-    else
-    {
-        EnableWindow(hApplicationPageSwitchToButton, FALSE);
-    }
+    EnableWindow(hApplicationPageSwitchToButton, (ListView_GetSelectedCount(hApplicationPageListCtrl) == 1));
 
     /* If we are on the applications tab the windows menu will be */
     /* present on the menu bar so enable & disable the menu items */


### PR DESCRIPTION
Fix discrepancy on "Switch To" action when multiple applications are selected
![image](https://user-images.githubusercontent.com/112266950/187959618-fe15a26a-d08f-42de-96aa-67d1a49299e2.png)

Menu is available (and only Switch to one of the selected apps) but button is disabled.
WinXPSP3 : both active and behaves like ReactOS menu (only Switch to one of the selected apps)
![image](https://user-images.githubusercontent.com/112266950/187959668-0b5beb95-28f4-4fc2-843c-75a79c8bba20.png)

Proposed changes : Make button and menu consistent