### PR TITLE
[USER32] Fix CascadeWindows()

### DIFF
--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2386,7 +2386,7 @@ TileWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         ++ret;
     }
 
-    NtUserEndDeferWindowPosEx(hDWP, TRUE);
+    EndDeferWindowPos(hDWP);
 
     if (hwndPrev)
         SetForegroundWindow(hwndPrev);

--- a/win32ss/user/user32/windows/mdi.c
+++ b/win32ss/user/user32/windows/mdi.c
@@ -2192,7 +2192,7 @@ CascadeWindows(HWND hwndParent, UINT wFlags, LPCRECT lpRect,
         ++ret;
     }
 
-    NtUserEndDeferWindowPosEx(hDWP, TRUE);
+    EndDeferWindowPos(hDWP);
 
     if (hwndPrev)
         SetForegroundWindow(hwndPrev);


### PR DESCRIPTION
## Purpose

- Current implementation of CascadeWindows is broken, the sequence of Z-Order is not correct when finally rendered

JIRA issue: [CORE-18343](https://jira.reactos.org/browse/CORE-18343)

## Proposed changes

- The root cause is about the use of NtUserEndDeferWindowPosEx(hDWP, TRUE) which does an ASYNC processing of the defered positionning. 

## Before

![image](https://user-images.githubusercontent.com/112266950/188070823-80006c9a-b0e5-4fff-bec5-4493e43f6d4d.png)

## After

TBD