### PR TITLE
[THEMES] Improve text colors of Modern Dark theme

### DIFF
--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
@@ -1488,7 +1488,7 @@ SizingType = stretch
 Transparent = True
 
 [Window.Caption(Active)]
-TextColor = 42 42 42
+TextColor = 255 255 255
 
 [Window.Caption(Disabled)]
 IconEffect = Alpha

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
@@ -93,10 +93,10 @@ ImageLayout = vertical
 MinSize = 10, 5
 SizingMargins = 8, 8, 9, 9
 SizingType = Stretch
-TextColor = 112 112 112
+TextColor = 200 200 200
 TEXTSHADOWOFFSET = 1,1
 TextShadowType = Single
-TextShadowColor = 221 221 221
+TextShadowColor = 42 42 42
 
 [Button.Pushbutton(Defaulted)]
 AccentColorHint = 0 255 0
@@ -105,13 +105,13 @@ AccentColorHint = 0 255 0
 TextColor = 153 153 153
 
 [Button.Pushbutton(Hot)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Normal)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Pressed)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 ;Checkboxes
 [Button.Checkbox]

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
@@ -1488,7 +1488,7 @@ SizingType = stretch
 Transparent = True
 
 [Window.Caption(Active)]
-TextColor = 42 42 42
+TextColor = 255 255 255
 
 [Window.Caption(Disabled)]
 IconEffect = Alpha

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
@@ -93,10 +93,10 @@ ImageLayout = vertical
 MinSize = 10, 5
 SizingMargins = 8, 8, 9, 9
 SizingType = Stretch
-TextColor = 112 112 112
+TextColor = 200 200 200
 TEXTSHADOWOFFSET = 1,1
 TextShadowType = Single
-TextShadowColor = 221 221 221
+TextShadowColor = 42 42 42
 
 [Button.Pushbutton(Defaulted)]
 AccentColorHint = 0 255 0
@@ -105,13 +105,13 @@ AccentColorHint = 0 255 0
 TextColor = 153 153 153
 
 [Button.Pushbutton(Hot)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Normal)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Pressed)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 ;Checkboxes
 [Button.Checkbox]

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/RegularDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/RegularDark.INI
@@ -93,10 +93,10 @@ ImageLayout = vertical
 MinSize = 10, 5
 SizingMargins = 8, 8, 9, 9
 SizingType = Stretch
-TextColor = 112 112 112
+TextColor = 200 200 200
 TEXTSHADOWOFFSET = 1,1
 TextShadowType = Single
-TextShadowColor = 221 221 221
+TextShadowColor = 42 42 42
 
 [Button.Pushbutton(Defaulted)]
 AccentColorHint = 0 255 0
@@ -105,13 +105,13 @@ AccentColorHint = 0 255 0
 TextColor = 153 153 153
 
 [Button.Pushbutton(Hot)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Normal)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 [Button.Pushbutton(Pressed)]
-TextColor = 75 75 75
+TextColor = 200 200 200
 
 ;Checkboxes
 [Button.Checkbox]
@@ -1488,7 +1488,7 @@ SizingType = stretch
 Transparent = True
 
 [Window.Caption(Active)]
-TextColor = 42 42 42
+TextColor = 255 255 255
 
 [Window.Caption(Disabled)]
 IconEffect = Alpha


### PR DESCRIPTION
## Purpose

Improve readability of text in the Modern dark theme

## Proposed changes

Use lighter text colors and darker text shadow colors

Before:
![image](https://user-images.githubusercontent.com/39295557/188078067-777dea9c-e2dc-4571-bb7c-cfe651d35bcb.png)

After:
![image](https://user-images.githubusercontent.com/39295557/188077824-053b5f66-388f-4163-af1f-f369a0465727.png)

