### PR TITLE
[RAPPS] Fix view mode error management

### DIFF
--- a/base/applications/rapps/appview.cpp
+++ b/base/applications/rapps/appview.cpp
@@ -1868,13 +1868,19 @@ VOID CApplicationView::OnCommand(WPARAM wParam, LPARAM lParam)
             switch (NotifyCode)
             {
             case CBN_SELCHANGE:
+                static int PrevSelection = 0;
                 int CurrSelection = m_ComboBox->SendMessageW(CB_GETCURSEL);
 
                 int ViewModeList[] = { LV_VIEW_DETAILS, LV_VIEW_LIST, LV_VIEW_TILE };
                 ATLASSERT(CurrSelection < (int)_countof(ViewModeList));
                 if (!m_ListView->SetViewMode(ViewModeList[CurrSelection]))
                 {
-                    MessageBoxW(L"View mode invalid or unimplemented");
+                    MessageBoxW(MAKEINTRESOURCEW(IDS_APP_DISPLAY_ERROR));
+                    m_ComboBox->SendMessageW(CB_SETCURSEL, PrevSelection);
+                }
+                else
+                {
+                    PrevSelection = CurrSelection;
                 }
                 break;
             }

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -124,6 +124,7 @@
 #define IDS_APP_DISPLAY_LIST     134
 #define IDS_APP_DISPLAY_TILE     135
 #define IDS_NO_SEARCH_RESULTS    136
+#define IDS_APP_DISPLAY_ERROR    137
 
 /* Tooltips */
 #define IDS_TOOLTIP_INSTALL      200

--- a/base/applications/rapps/lang/bg-BG.rc
+++ b/base/applications/rapps/lang/bg-BG.rc
@@ -219,6 +219,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/cs-CZ.rc
+++ b/base/applications/rapps/lang/cs-CZ.rc
@@ -220,6 +220,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/de-DE.rc
+++ b/base/applications/rapps/lang/de-DE.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Liste"
     IDS_APP_DISPLAY_TILE "Kacheln"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/en-US.rc
+++ b/base/applications/rapps/lang/en-US.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/es-ES.rc
+++ b/base/applications/rapps/lang/es-ES.rc
@@ -218,6 +218,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Lista"
     IDS_APP_DISPLAY_TILE "Título"
     IDS_NO_SEARCH_RESULTS "Búsqueda sin resultados."
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/et-EE.rc
+++ b/base/applications/rapps/lang/et-EE.rc
@@ -223,6 +223,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/fr-FR.rc
+++ b/base/applications/rapps/lang/fr-FR.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Liste"
     IDS_APP_DISPLAY_TILE "Tuile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "Mode d'affiche non disponible"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/hu-HU.rc
+++ b/base/applications/rapps/lang/hu-HU.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Lista"
     IDS_APP_DISPLAY_TILE "Csempe"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/id-ID.rc
+++ b/base/applications/rapps/lang/id-ID.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/it-IT.rc
+++ b/base/applications/rapps/lang/it-IT.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ja-JP.rc
+++ b/base/applications/rapps/lang/ja-JP.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/no-NO.rc
+++ b/base/applications/rapps/lang/no-NO.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pl-PL.rc
+++ b/base/applications/rapps/lang/pl-PL.rc
@@ -224,6 +224,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Lista"
     IDS_APP_DISPLAY_TILE "Kafelki"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pt-BR.rc
+++ b/base/applications/rapps/lang/pt-BR.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/pt-PT.rc
+++ b/base/applications/rapps/lang/pt-PT.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ro-RO.rc
+++ b/base/applications/rapps/lang/ro-RO.rc
@@ -224,6 +224,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/ru-RU.rc
+++ b/base/applications/rapps/lang/ru-RU.rc
@@ -215,6 +215,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sk-SK.rc
+++ b/base/applications/rapps/lang/sk-SK.rc
@@ -220,6 +220,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sq-AL.rc
+++ b/base/applications/rapps/lang/sq-AL.rc
@@ -219,6 +219,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/sv-SE.rc
+++ b/base/applications/rapps/lang/sv-SE.rc
@@ -222,6 +222,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/tr-TR.rc
+++ b/base/applications/rapps/lang/tr-TR.rc
@@ -217,6 +217,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "Liste"
     IDS_APP_DISPLAY_TILE "Karo"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/uk-UA.rc
+++ b/base/applications/rapps/lang/uk-UA.rc
@@ -223,6 +223,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "List"
     IDS_APP_DISPLAY_TILE "Tile"
     IDS_NO_SEARCH_RESULTS "No search results"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/zh-CN.rc
+++ b/base/applications/rapps/lang/zh-CN.rc
@@ -226,6 +226,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "列表"
     IDS_APP_DISPLAY_TILE "卡片"
     IDS_NO_SEARCH_RESULTS "无搜索结果"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/zh-HK.rc
+++ b/base/applications/rapps/lang/zh-HK.rc
@@ -223,6 +223,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "列表"
     IDS_APP_DISPLAY_TILE "並排"
     IDS_NO_SEARCH_RESULTS "沒有搜尋結果"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE

--- a/base/applications/rapps/lang/zh-TW.rc
+++ b/base/applications/rapps/lang/zh-TW.rc
@@ -223,6 +223,7 @@ BEGIN
     IDS_APP_DISPLAY_LIST "列表"
     IDS_APP_DISPLAY_TILE "並排"
     IDS_NO_SEARCH_RESULTS "沒有搜尋結果"
+    IDS_APP_DISPLAY_ERROR "View mode invalid or unimplemented"
 END
 
 STRINGTABLE


### PR DESCRIPTION
## Purpose

When unable to change view mode, current design :
- show an error message
- but switch the view mode indication to the mode that just failed

Expected design would be to revert the view mode to the last mode that was successfully activated.

JIRA issue: [CORE-17274](https://jira.reactos.org/browse/CORE-17274)

Error message proposed to be localized as it may be required even after tiled mode gets implements (eg : SetViewMode may fail for whatever reason)