### PR TITLE
[AUDIO] Device management code refactoring

### DIFF
--- a/dll/win32/wdmaud.drv/CMakeLists.txt
+++ b/dll/win32/wdmaud.drv/CMakeLists.txt
@@ -8,10 +8,21 @@ include_directories(
 spec2def(wdmaud.drv wdmaud.spec)
 
 list(APPEND SOURCE
-    wdmaud.c
-    mixer.c
-    mmixer.c
     legacy.c
+    mmewrap.c
+    mmixer.c
+    reentrancy.c
+    resample.c
+    result.c
+    wdmaud.c
+    auxiliary/auxMessage.c
+    midi/midMessage.c
+    midi/modMessage.c
+    mixer/mxdMessage.c
+    wave/header.c
+    wave/streaming.c
+    wave/widMessage.c
+    wave/wodMessage.c
     wdmaud.h)
 
 add_library(wdmaud.drv MODULE
@@ -21,7 +32,7 @@ add_library(wdmaud.drv MODULE
 
 set_module_type(wdmaud.drv win32dll UNICODE)
 set_target_properties(wdmaud.drv PROPERTIES SUFFIX "")
-target_link_libraries(wdmaud.drv mmebuddy libsamplerate mmixer)
+target_link_libraries(wdmaud.drv libsamplerate mmixer)
 add_importlibs(wdmaud.drv user32 winmm advapi32 msvcrt setupapi ksuser kernel32 ntdll)
 add_pch(wdmaud.drv wdmaud.h SOURCE)
 add_cd_file(TARGET wdmaud.drv DESTINATION reactos/system32 FOR all)

--- a/dll/win32/wdmaud.drv/auxiliary/auxMessage.c
+++ b/dll/win32/wdmaud.drv/auxiliary/auxMessage.c
@@ -1,0 +1,72 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/auxiliary/auxMessage.c
+ *
+ * PURPOSE:     Provides the auxMessage exported function, as required by
+ *              the MME API, for auxiliary device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Standard MME driver entry-point for messages relating to auxiliary devices.
+*/
+DWORD
+APIENTRY
+auxMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(AUX_DEVICE_TYPE);
+
+    DPRINT("auxMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case AUXM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(AUX_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(AUX_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+
+        case AUXDM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(AUX_DEVICE_TYPE);
+            break;
+        }
+
+        case AUXDM_GETDEVCAPS :
+        {
+            Result = MmeGetSoundDeviceCapabilities(AUX_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+    }
+
+    DPRINT("auxMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(AUX_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/legacy.c
+++ b/dll/win32/wdmaud.drv/legacy.c
@@ -1,89 +1,292 @@
 /*
- * PROJECT:     ReactOS Sound System
- * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        dll/win32/wdmaud.drv/wdmaud.c
- *
- * PURPOSE:     WDM Audio Driver (User-mode part)
- * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
-                Johannes Anderwald
- *
- * NOTES:       Looking for wodMessage & co? You won't find them here. Try
- *              the MME Buddy library, which is where these routines are
- *              actually implemented.
- *
+ * PROJECT:     ReactOS Audio Subsystem
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     WDM Audio Driver Mapper (User-mode part)
+ * COPYRIGHT:   Copyright 2007-2008 Andrew Greenwood (silverblade@reactos.org)
+ *              Copyright 2009-2010 Johannes Anderwald
+ *              Copyright 2022 Oleg Dubinskiy (oleg.dubinskij30@gmail.com)
  */
 
 #include "wdmaud.h"
 
-#define NDEBUG
+#include <mmixer.h>
+
+#define YDEBUG
 #include <debug.h>
-#include <mmebuddy_debug.h>
 
-#define KERNEL_DEVICE_NAME      L"\\\\.\\wdmaud"
-
+extern MIXER_CONTEXT MixerContext;
 HANDLE KernelHandle = INVALID_HANDLE_VALUE;
 DWORD OpenCount = 0;
 
+/*
+    This is a wrapper around DeviceIoControl which provides control over
+    instantiated sound devices. It waits for I/O to complete (since an
+    instantiated sound device is opened _In_ overlapped mode, this is necessary).
+*/
+MMRESULT
+WdmAudIoControl(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_opt_ ULONG BufferSize,
+    _In_opt_ PVOID Buffer,
+    _In_ DWORD IoControlCode)
+{
+    MMRESULT Result = MMSYSERR_NOERROR;
+    OVERLAPPED Overlapped;
+    DWORD Transferred = 0;
+    BOOL IoResult;
+
+    /* Overlapped I/O is done here - this is used for waiting for completion */
+    ZeroMemory(&Overlapped, sizeof(OVERLAPPED));
+    Overlapped.hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
+
+    if ( ! Overlapped.hEvent )
+        return Win32ErrorToMmResult(GetLastError());
+
+    if (DeviceInfo->DeviceType != AUX_DEVICE_TYPE &&
+        DeviceInfo->DeviceType != MIXER_DEVICE_TYPE)
+    {
+        EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+    }
+
+    /* Store input data */
+    DeviceInfo->BufferSize = BufferSize;
+    DeviceInfo->Buffer = Buffer;
+
+    /* Talk to the device */
+    IoResult = DeviceIoControl(KernelHandle,
+                               IoControlCode,
+                               DeviceInfo,
+                               sizeof(WDMAUD_DEVICE_INFO),
+                               DeviceInfo,
+                               sizeof(WDMAUD_DEVICE_INFO),
+                               &Transferred,
+                               &Overlapped);
+
+    /* If failure occurs, make sure it's not just due to the overlapped I/O */
+    if ( ! IoResult )
+    {
+        if (GetLastError() == ERROR_IO_PENDING)
+        {
+            /* Wait for I/O complete */
+            WaitForSingleObject(Overlapped.hEvent, INFINITE);
+        }
+        Result = Win32ErrorToMmResult(GetLastError());
+    }
+
+    if (DeviceInfo->DeviceType != AUX_DEVICE_TYPE &&
+        DeviceInfo->DeviceType != MIXER_DEVICE_TYPE)
+    {
+        LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+    }
+
+    /* Don't need this any more */
+    CloseHandle(Overlapped.hEvent);
+
+    DPRINT("Transferred %d bytes in Sync overlapped I/O\n", Transferred);
+
+    return Result;
+}
+
 DWORD
 WINAPI
-MixerEventThreadRoutine(
+WaveThreadRoutine(
     LPVOID Parameter)
 {
-    HANDLE WaitObjects[2];
-    DWORD dwResult;
+    PWDMAUD_DEVICE_INFO DeviceInfo = (PWDMAUD_DEVICE_INFO)Parameter;
+    PWAVEHDR_EXTENSION HeaderExtension;
+    DWORD dwResult = WAIT_FAILED;
+    PWAVEHDR WaveHeader;
+#ifndef USE_MMIXER_LIB
     MMRESULT Result;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    PSOUND_DEVICE_INSTANCE Instance = (PSOUND_DEVICE_INSTANCE)Parameter;
+#endif
+    HANDLE hEvent;
 
-    /* setup wait objects */
-    WaitObjects[0] = Instance->hNotifyEvent;
-    WaitObjects[1] = Instance->hStopEvent;
-
-    /* zero device info */
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-
-    DeviceInfo.hDevice = Instance->Handle;
-    DeviceInfo.DeviceType = MIXER_DEVICE_TYPE;
-
-    do
+    while (TRUE)
     {
-        dwResult = WaitForMultipleObjects(2, WaitObjects, FALSE, INFINITE);
-
-        if (dwResult == WAIT_OBJECT_0 + 1)
+        DPRINT("WaveQueue %p\n", DeviceInfo->DeviceState->WaveQueue);
+        EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+        WaveHeader = DeviceInfo->DeviceState->WaveQueue;
+        if (WaveHeader && (WaveHeader->dwFlags & (WHDR_BEGINLOOP | WHDR_DONE |
+            WHDR_ENDLOOP | WHDR_INQUEUE | WHDR_PREPARED)) && WaveHeader->reserved)
         {
-            /* stop event was signalled */
+            DPRINT("1\n");
+            HeaderExtension = (PWAVEHDR_EXTENSION)WaveHeader->reserved;
+            if (HeaderExtension && HeaderExtension->Overlapped &&
+                HeaderExtension->Overlapped->hEvent)
+            {
+                hEvent = HeaderExtension->Overlapped->hEvent;
+                DPRINT("2\n");
+
+                LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+                /* Wait for I/O complete */
+                dwResult = WaitForSingleObject(hEvent, INFINITE);
+                DPRINT("dwResult %d\n", dwResult);
+                EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+                DPRINT("3\n");
+                if (DeviceInfo &&
+                    DeviceInfo->DeviceState->hNotifyEvent &&
+                    DeviceInfo->DeviceState->hStopEvent)
+                {
+                    /* Complete current header */
+                    CompleteWaveHeader(DeviceInfo);
+                }
+                else
+                {
+                    DPRINT1("Invalid device info data %p\n", DeviceInfo);
+                    break;
+                }
+            }
+            else
+            {
+                /* Failed, move to the next header */
+                DeviceInfo->DeviceState->WaveQueue = DeviceInfo->DeviceState->WaveQueue->lpNext;
+            }
+            LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+        }
+        else
+        {
+            DPRINT("6\n");
+            if (DeviceInfo->DeviceState->bStart)
+            {
+                DPRINT("7\n");
+#ifdef USE_MMIXER_LIB
+                /* make sure the pin is stopped */
+                MMixerSetWaveStatus(&MixerContext, DeviceInfo->hDevice, KSSTATE_PAUSE);
+                MMixerSetWaveStatus(&MixerContext, DeviceInfo->hDevice, KSSTATE_ACQUIRE);
+                MMixerSetWaveStatus(&MixerContext, DeviceInfo->hDevice, KSSTATE_STOP);
+#else
+                /* Stop streaming if no more data to stream */
+                Result = WdmAudIoControl(DeviceInfo,
+                                         0,
+                                         NULL,
+                                         DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                                         IOCTL_PAUSE_PLAYBACK : IOCTL_PAUSE_CAPTURE);
+                if (!MMSUCCESS(Result))
+                {
+                    DPRINT1("Call to %s failed with %d\n",
+                            DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                            "IOCTL_PAUSE_PLAYBACK" : "IOCTL_PAUSE_CAPTURE",
+                            GetLastError());
+                    break;
+                }
+#endif
+                DeviceInfo->DeviceState->bStart = FALSE;
+            }
+
+            LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+            /* Wait for stop event complete */
+            WaitForSingleObject(DeviceInfo->DeviceState->hNotifyEvent, INFINITE);
+
+            /* Done */
             break;
         }
+    }
 
-        do
-        {
-            Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                                   IOCTL_GET_MIXER_EVENT,
-                                                   (LPVOID) &DeviceInfo,
-                                                   sizeof(WDMAUD_DEVICE_INFO),
-                                                   (LPVOID) &DeviceInfo,
-                                                   sizeof(WDMAUD_DEVICE_INFO),
-                                                   NULL);
+    EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+    CloseHandle(DeviceInfo->DeviceState->hNotifyEvent);
+    DeviceInfo->DeviceState->hNotifyEvent = NULL;
+    DeviceInfo->DeviceState->bStartInThread = FALSE;
+    SetEvent(DeviceInfo->DeviceState->hStopEvent);
+    LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
 
-            if (Result == MMSYSERR_NOERROR)
-            {
-                DriverCallback(Instance->WinMM.ClientCallback,
-                               HIWORD(Instance->WinMM.Flags),
-                               Instance->WinMM.Handle,
-                               DeviceInfo.u.MixerEvent.NotificationType,
-                               Instance->WinMM.ClientCallbackInstanceData,
-                               (DWORD_PTR)DeviceInfo.u.MixerEvent.Value,
-                               0);
-            }
-        }while(Result == MMSYSERR_NOERROR);
-    }while(TRUE);
-
-    /* done */
+    /* Done */
     return 0;
 }
 
 MMRESULT
-WdmAudCleanupByLegacy()
+WdmAudCreateCompletionThread(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo)
+{
+    if (!DeviceInfo->DeviceState->hThread)
+    {
+        if (!DeviceInfo->DeviceState->hNotifyEvent)
+        {
+            DeviceInfo->DeviceState->hNotifyEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
+            if (!DeviceInfo->DeviceState->hNotifyEvent)
+            {
+                DPRINT1("CreateEventW failed with %d\n", GetLastError());
+                DeviceInfo->DeviceState->bStartInThread = FALSE;
+                return Win32ErrorToMmResult(GetLastError());
+            }
+        }
+
+        if (!DeviceInfo->DeviceState->hStopEvent)
+        {
+            DeviceInfo->DeviceState->hStopEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
+            if (!DeviceInfo->DeviceState->hStopEvent)
+            {
+                DPRINT1("CreateEventW failed with %d\n", GetLastError());
+                DeviceInfo->DeviceState->bStartInThread = FALSE;
+                /* Close previous handle */
+                CloseHandle(DeviceInfo->DeviceState->hNotifyEvent);
+                return Win32ErrorToMmResult(GetLastError());
+            }
+        }
+
+        DeviceInfo->DeviceState->hThread = CreateThread(NULL,
+                                                        0,
+                                                        WaveThreadRoutine,
+                                                        DeviceInfo,
+                                                        0,
+                                                        NULL);
+        if (!DeviceInfo->DeviceState->hThread)
+        {
+            DPRINT1("CreateThread failed with %d\n", GetLastError());
+            DeviceInfo->DeviceState->bStartInThread = FALSE;
+            /* Close previous handles */
+            CloseHandle(DeviceInfo->DeviceState->hNotifyEvent);
+            CloseHandle(DeviceInfo->DeviceState->hStopEvent);
+            return Win32ErrorToMmResult(GetLastError());
+        }
+        SetThreadPriority(DeviceInfo->DeviceState->hThread, THREAD_PRIORITY_TIME_CRITICAL);
+    }
+
+    DeviceInfo->DeviceState->bStartInThread = TRUE;
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+WdmAudDestroyCompletionThread(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo)
+{
+    EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+    if (DeviceInfo->DeviceState->hThread)
+    {
+        if (DeviceInfo->DeviceState->hNotifyEvent)
+        {
+            if (DeviceInfo->DeviceState->bStartInThread)
+            {
+                SetEvent(DeviceInfo->DeviceState->hNotifyEvent);
+            }
+        }
+        LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+        if (DeviceInfo->DeviceState->hStopEvent)
+        {
+            WaitForSingleObject(DeviceInfo->DeviceState->hStopEvent, INFINITE);
+        }
+
+        EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+        CloseHandle(DeviceInfo->DeviceState->hThread);
+        DeviceInfo->DeviceState->hThread = NULL;
+
+        if (DeviceInfo->DeviceState->hStopEvent)
+        {
+            CloseHandle(DeviceInfo->DeviceState->hStopEvent);
+            DeviceInfo->DeviceState->hStopEvent = NULL;
+        }
+    }
+    LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+WdmAudCleanupByLegacy(VOID)
 {
     if (KernelHandle != INVALID_HANDLE_VALUE)
     {
@@ -95,167 +298,122 @@ WdmAudCleanupByLegacy()
 }
 
 MMRESULT
-WdmAudGetNumWdmDevsByLegacy(
-    IN  MMDEVICE_TYPE DeviceType,
-    OUT DWORD* DeviceCount)
+WdmAudAddRemoveDeviceNode(
+    _In_ SOUND_DEVICE_TYPE DeviceType,
+    _In_ BOOL bAdd)
 {
     MMRESULT Result;
-    WDMAUD_DEVICE_INFO DeviceInfo;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    VALIDATE_MMSYS_PARAMETER( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
+
+    DPRINT("WDMAUD - AddRemoveDeviceNode DeviceType %u\n", DeviceType);
+
+    DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+    if (!DeviceInfo)
+    {
+        /* No memory */
+        DPRINT1("Failed to allocate WDMAUD_DEVICE_INFO structure\n");
+        return MMSYSERR_NOMEM;
+    }
+
+    DeviceInfo->DeviceType = DeviceType;
+
+    Result = WdmAudIoControl(DeviceInfo,
+                             0,
+                             NULL,
+                             bAdd ?
+                             IOCTL_ADD_DEVNODE :
+                             IOCTL_REMOVE_DEVNODE);
+
+    HeapFree(GetProcessHeap(), 0, DeviceInfo);
+
+    if ( ! MMSUCCESS( Result ) )
+    {
+        DPRINT1("Call to %ls failed with %d\n",
+                bAdd ? L"IOCTL_ADD_DEVNODE" : L"IOCTL_REMOVE_DEVNODE",
+                GetLastError());
+        return TranslateInternalMmResult(Result);
+    }
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+WdmAudGetNumWdmDevsByLegacy(
+    _In_  SOUND_DEVICE_TYPE DeviceType,
+    _Out_ DWORD* DeviceCount)
+{
+    MMRESULT Result;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
 
     VALIDATE_MMSYS_PARAMETER( KernelHandle != INVALID_HANDLE_VALUE );
     VALIDATE_MMSYS_PARAMETER( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
     VALIDATE_MMSYS_PARAMETER( DeviceCount );
 
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.DeviceType = DeviceType;
+    DPRINT("WDMAUD - GetNumWdmDevs DeviceType %u\n", DeviceType);
 
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_GETNUMDEVS_TYPE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
+    DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+    if (!DeviceInfo)
+    {
+        /* No memory */
+        DPRINT1("Failed to allocate WDMAUD_DEVICE_INFO structure\n");
+        return MMSYSERR_NOMEM;
+    }
+
+    DeviceInfo->DeviceType = DeviceType;
+
+    Result = WdmAudIoControl(DeviceInfo,
+                             0,
+                             NULL,
+                             IOCTL_GETNUMDEVS_TYPE);
 
     if ( ! MMSUCCESS( Result ) )
     {
-        SND_ERR(L"Call to IOCTL_GETNUMDEVS_TYPE failed\n");
+        DPRINT1("Call to IOCTL_GETNUMDEVS_TYPE failed with %d\n", GetLastError());
         *DeviceCount = 0;
+        HeapFree(GetProcessHeap(), 0, DeviceInfo);
         return TranslateInternalMmResult(Result);
     }
 
-    *DeviceCount = DeviceInfo.DeviceCount;
+    *DeviceCount = DeviceInfo->DeviceIndex;
+
+    HeapFree(GetProcessHeap(), 0, DeviceInfo);
 
     return MMSYSERR_NOERROR;
 }
 
 MMRESULT
 WdmAudGetCapabilitiesByLegacy(
-    IN  PSOUND_DEVICE SoundDevice,
-    IN  DWORD DeviceId,
-    OUT PVOID Capabilities,
-    IN  DWORD CapabilitiesSize)
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _Out_ PVOID Capabilities,
+    _In_  DWORD CapabilitiesSize)
 {
     MMRESULT Result;
-    MMDEVICE_TYPE DeviceType;
-    WDMAUD_DEVICE_INFO DeviceInfo;
 
-    SND_ASSERT( SoundDevice );
-    SND_ASSERT( Capabilities );
+    ASSERT( Capabilities );
 
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
+    DPRINT("WDMAUD - GetWdmDeviceCapabilities DeviceType %u DeviceId %u\n", DeviceInfo->DeviceType, DeviceInfo->DeviceIndex);
 
-    if ( ! MMSUCCESS(Result) )
-        return Result;
-
-    SND_TRACE(L"WDMAUD - GetWdmDeviceCapabilities DeviceType %u DeviceId %u\n", DeviceType, DeviceId);
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.DeviceType = DeviceType;
-    DeviceInfo.DeviceIndex = DeviceId;
-
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_GETCAPABILITIES,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
+    Result = WdmAudIoControl(DeviceInfo,
+                             CapabilitiesSize,
+                             Capabilities,
+                             IOCTL_GETCAPABILITIES);
 
     if ( ! MMSUCCESS(Result) )
     {
+        DPRINT1("Call to IOCTL_GETCAPABILITIES failed with %d\n", GetLastError());
+        Capabilities = NULL;
         return TranslateInternalMmResult(Result);
-    }
-
-    /* This is pretty much a big hack right now */
-    switch ( DeviceType )
-    {
-        case MIXER_DEVICE_TYPE:
-        {
-            LPMIXERCAPSW MixerCaps = (LPMIXERCAPSW) Capabilities;
-
-            DeviceInfo.u.MixCaps.szPname[MAXPNAMELEN-1] = L'\0';
-            CopyWideString(MixerCaps->szPname, DeviceInfo.u.MixCaps.szPname);
-
-            MixerCaps->cDestinations = DeviceInfo.u.MixCaps.cDestinations;
-            MixerCaps->fdwSupport = DeviceInfo.u.MixCaps.fdwSupport;
-            MixerCaps->vDriverVersion = DeviceInfo.u.MixCaps.vDriverVersion;
-            MixerCaps->wMid = DeviceInfo.u.MixCaps.wMid;
-            MixerCaps->wPid = DeviceInfo.u.MixCaps.wPid;
-            break;
-        }
-        case WAVE_OUT_DEVICE_TYPE :
-        {
-            LPWAVEOUTCAPSW WaveOutCaps = (LPWAVEOUTCAPSW) Capabilities;
-
-            DeviceInfo.u.WaveOutCaps.szPname[MAXPNAMELEN-1] = L'\0';
-            WaveOutCaps->wMid = DeviceInfo.u.WaveOutCaps.wMid;
-            WaveOutCaps->wPid = DeviceInfo.u.WaveOutCaps.wPid;
-
-            WaveOutCaps->vDriverVersion = DeviceInfo.u.WaveOutCaps.vDriverVersion;
-            CopyWideString(WaveOutCaps->szPname, DeviceInfo.u.WaveOutCaps.szPname);
-
-            WaveOutCaps->dwFormats = DeviceInfo.u.WaveOutCaps.dwFormats;
-            WaveOutCaps->wChannels = DeviceInfo.u.WaveOutCaps.wChannels;
-            WaveOutCaps->dwSupport = DeviceInfo.u.WaveOutCaps.dwSupport;
-            break;
-        }
-        case WAVE_IN_DEVICE_TYPE :
-        {
-            LPWAVEINCAPSW WaveInCaps = (LPWAVEINCAPSW) Capabilities;
-
-            DeviceInfo.u.WaveInCaps.szPname[MAXPNAMELEN-1] = L'\0';
-
-            WaveInCaps->wMid = DeviceInfo.u.WaveInCaps.wMid;
-            WaveInCaps->wPid = DeviceInfo.u.WaveInCaps.wPid;
-
-            WaveInCaps->vDriverVersion = DeviceInfo.u.WaveInCaps.vDriverVersion;
-            CopyWideString(WaveInCaps->szPname, DeviceInfo.u.WaveInCaps.szPname);
-
-            WaveInCaps->dwFormats = DeviceInfo.u.WaveInCaps.dwFormats;
-            WaveInCaps->wChannels = DeviceInfo.u.WaveInCaps.wChannels;
-            WaveInCaps->wReserved1 = 0;
-            break;
-        }
-        case MIDI_IN_DEVICE_TYPE :
-        {
-            LPMIDIINCAPSW MidiInCaps = (LPMIDIINCAPSW)Capabilities;
-
-            DeviceInfo.u.MidiInCaps.szPname[MAXPNAMELEN-1] = L'\0';
-
-            MidiInCaps->vDriverVersion = DeviceInfo.u.MidiInCaps.vDriverVersion;
-            MidiInCaps->wMid = DeviceInfo.u.MidiInCaps.wMid;
-            MidiInCaps->wPid = DeviceInfo.u.MidiInCaps.wPid;
-            MidiInCaps->dwSupport = DeviceInfo.u.MidiInCaps.dwSupport;
-
-            CopyWideString(MidiInCaps->szPname, DeviceInfo.u.MidiInCaps.szPname);
-            break;
-        }
-        case MIDI_OUT_DEVICE_TYPE :
-        {
-            LPMIDIOUTCAPSW MidiOutCaps = (LPMIDIOUTCAPSW)Capabilities;
-
-            DeviceInfo.u.MidiOutCaps.szPname[MAXPNAMELEN-1] = L'\0';
-
-            MidiOutCaps->vDriverVersion = DeviceInfo.u.MidiOutCaps.vDriverVersion;
-            MidiOutCaps->wMid = DeviceInfo.u.MidiOutCaps.wMid;
-            MidiOutCaps->wPid = DeviceInfo.u.MidiOutCaps.wPid;
-            MidiOutCaps->dwSupport = DeviceInfo.u.MidiOutCaps.dwSupport;
-
-            CopyWideString(MidiOutCaps->szPname, DeviceInfo.u.MidiOutCaps.szPname);
-            break;
-        }
     }
 
     return MMSYSERR_NOERROR;
 }
 
 MMRESULT
-WdmAudOpenSoundDeviceByLegacy(
-    IN PSOUND_DEVICE SoundDevice,
-    OUT PVOID *Handle)
+WdmAudOpenKernelSoundDeviceByLegacy(VOID)
 {
+    DWORD dwSize;
     HDEVINFO hDevInfo;
     SP_DEVICE_INTERFACE_DATA DeviceInterfaceData;
     GUID SWBusGuid = {STATIC_KSCATEGORY_WDMAUD};
@@ -263,7 +421,7 @@ WdmAudOpenSoundDeviceByLegacy(
 
     if ( KernelHandle == INVALID_HANDLE_VALUE )
     {
-        hDevInfo = SetupDiGetClassDevsW(&SWBusGuid, NULL, NULL,  DIGCF_DEVICEINTERFACE| DIGCF_PRESENT);
+        hDevInfo = SetupDiGetClassDevsW(&SWBusGuid, NULL, NULL,  DIGCF_DEVICEINTERFACE | DIGCF_PRESENT);
         if (!hDevInfo)
         {
             // failed
@@ -278,7 +436,9 @@ WdmAudOpenSoundDeviceByLegacy(
             return MMSYSERR_ERROR;
         }
 
-        DeviceInterfaceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA_W)HeapAlloc(GetProcessHeap(), 0, MAX_PATH * sizeof(WCHAR) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W));
+        SetupDiGetDeviceInterfaceDetailW(hDevInfo,  &DeviceInterfaceData, NULL, 0, &dwSize, NULL);
+
+        DeviceInterfaceDetailData = (PSP_DEVICE_INTERFACE_DETAIL_DATA_W)HeapAlloc(GetProcessHeap(), 0, dwSize);
         if (!DeviceInterfaceDetailData)
         {
             // failed
@@ -287,21 +447,22 @@ WdmAudOpenSoundDeviceByLegacy(
         }
 
         DeviceInterfaceDetailData->cbSize = sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W);
-        if (!SetupDiGetDeviceInterfaceDetailW(hDevInfo,  &DeviceInterfaceData, DeviceInterfaceDetailData,MAX_PATH * sizeof(WCHAR) + sizeof(SP_DEVICE_INTERFACE_DETAIL_DATA_W), NULL, NULL))
+        if (!SetupDiGetDeviceInterfaceDetailW(hDevInfo,  &DeviceInterfaceData, DeviceInterfaceDetailData, dwSize, &dwSize, NULL))
         {
             // failed
             HeapFree(GetProcessHeap(), 0, DeviceInterfaceDetailData);
             SetupDiDestroyDeviceInfoList(hDevInfo);
             return MMSYSERR_ERROR;
         }
-        SND_TRACE(L"Opening wdmaud device '%s'\n",DeviceInterfaceDetailData->DevicePath);
+
+        DPRINT("Opening wdmaud device '%ls'\n", DeviceInterfaceDetailData->DevicePath);
         KernelHandle = CreateFileW(DeviceInterfaceDetailData->DevicePath,
-            GENERIC_READ | GENERIC_WRITE,
-            0,
-            NULL,
-            OPEN_EXISTING,
-            FILE_FLAG_OVERLAPPED,
-            NULL);
+                                   GENERIC_READ | GENERIC_WRITE,
+                                   0,
+                                   NULL,
+                                   OPEN_EXISTING,
+                                   FILE_ATTRIBUTE_NORMAL | FILE_FLAG_OVERLAPPED,
+                                   NULL);
 
         HeapFree(GetProcessHeap(), 0, DeviceInterfaceDetailData);
         SetupDiDestroyDeviceInfoList(hDevInfo);
@@ -317,85 +478,118 @@ WdmAudOpenSoundDeviceByLegacy(
 }
 
 MMRESULT
-WdmAudCloseSoundDeviceByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  PVOID Handle)
+WdmAudOpenSoundDeviceByLegacy(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ PWAVEFORMATEX WaveFormat)
 {
-    WDMAUD_DEVICE_INFO DeviceInfo;
     MMRESULT Result;
-    MMDEVICE_TYPE DeviceType;
-    PSOUND_DEVICE SoundDevice;
-
-    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
 
     if ( OpenCount == 0 )
     {
         return MMSYSERR_NOERROR;
     }
 
-    SND_ASSERT( KernelHandle != INVALID_HANDLE_VALUE );
+    ASSERT( KernelHandle != INVALID_HANDLE_VALUE );
 
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
+    DPRINT("WDMAUD - OpenWdmSoundDevice DeviceType %u\n", DeviceInfo->DeviceType);
 
-    if (SoundDeviceInstance->Handle != (PVOID)KernelHandle)
+    /* Open device handle */
+    Result = WdmAudIoControl(DeviceInfo,
+                             sizeof(WAVEFORMATEX),
+                             WaveFormat,
+                             IOCTL_OPEN_WDMAUD);
+
+    if ( ! MMSUCCESS( Result ) )
     {
-        ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-
-        DeviceInfo.DeviceType = DeviceType;
-        DeviceInfo.hDevice = SoundDeviceInstance->Handle;
-
-         /* First stop the stream */
-         if (DeviceType != MIXER_DEVICE_TYPE)
-         {
-             DeviceInfo.u.State = KSSTATE_PAUSE;
-             SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_SETDEVICE_STATE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                            sizeof(WDMAUD_DEVICE_INFO),
-                                            NULL);
-
-             DeviceInfo.u.State = KSSTATE_ACQUIRE;
-             SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_SETDEVICE_STATE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                            sizeof(WDMAUD_DEVICE_INFO),
-                                            NULL);
-
-
-             DeviceInfo.u.State = KSSTATE_STOP;
-             SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_SETDEVICE_STATE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                            sizeof(WDMAUD_DEVICE_INFO),
-                                            NULL);
-        }
-
-        SyncOverlappedDeviceIoControl(KernelHandle,
-                                      IOCTL_CLOSE_WDMAUD,
-                                      (LPVOID) &DeviceInfo,
-                                      sizeof(WDMAUD_DEVICE_INFO),
-                                      (LPVOID) &DeviceInfo,
-                                      sizeof(WDMAUD_DEVICE_INFO),
-                                      NULL);
+        DPRINT1("Call to IOCTL_OPEN_WDMAUD failed with %d\n", GetLastError());
+        return TranslateInternalMmResult(Result);
     }
 
-    if (DeviceType == MIXER_DEVICE_TYPE)
+    if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE || DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
     {
-        SetEvent(SoundDeviceInstance->hStopEvent);
-        CloseHandle(SoundDeviceInstance->hStopEvent);
-        CloseHandle(SoundDeviceInstance->hNotifyEvent);
+        DeviceInfo->DeviceState->bStart = TRUE;
+
+        /* Start device */
+        Result = WdmAudIoControl(DeviceInfo,
+                                 0,
+                                 NULL,
+                                 DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                                 IOCTL_START_PLAYBACK : IOCTL_START_CAPTURE);
+
+        if ( ! MMSUCCESS( Result ) )
+        {
+            DPRINT1("Call to %s failed with %d\n",
+                    DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                    "IOCTL_START_PLAYBACK" : "IOCTL_START_CAPTURE",
+                    GetLastError());
+            return TranslateInternalMmResult(Result);
+        }
+    }
+
+    DeviceInfo->DeviceState->Samples = WaveFormat->wBitsPerSample * WaveFormat->nChannels;
+
+#ifdef RESAMPLING_ENABLED
+    DeviceInfo->Buffer = WaveFormat;
+    DeviceInfo->BufferSize = sizeof(WAVEFORMATEX);
+#endif
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+WdmAudCloseSoundDeviceByLegacy(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PVOID Handle)
+{
+    MMRESULT Result;
+
+    if ( OpenCount == 0 )
+    {
+        return MMSYSERR_NOERROR;
+    }
+
+    ASSERT( KernelHandle != INVALID_HANDLE_VALUE );
+
+    DPRINT("WDMAUD - CloseWdmSoundDevice DeviceType %u\n", DeviceInfo->DeviceType);
+
+    if (DeviceInfo->hDevice != KernelHandle)
+    {
+        if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE || DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+        {
+            DeviceInfo->DeviceState->bStart = FALSE;
+
+            /* Destroy I/O thread */
+            Result = WdmAudDestroyCompletionThread(DeviceInfo);
+            ASSERT(Result == MMSYSERR_NOERROR);
+
+            /* Stop device */
+            Result = WdmAudIoControl(DeviceInfo,
+                                     0,
+                                     NULL,
+                                     DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                                     IOCTL_PAUSE_PLAYBACK : IOCTL_PAUSE_CAPTURE);
+
+            if ( ! MMSUCCESS( Result ) )
+            {
+                DPRINT1("Call to %s failed with %d\n",
+                        DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                        "IOCTL_PAUSE_PLAYBACK" : "IOCTL_PAUSE_CAPTURE",
+                        GetLastError());
+                return TranslateInternalMmResult(Result);
+            }
+        }
+
+        /* Close device handle */
+        Result = WdmAudIoControl(DeviceInfo,
+                                 0,
+                                 NULL,
+                                 IOCTL_CLOSE_WDMAUD);
+
+        if ( ! MMSUCCESS(Result) )
+        {
+            DPRINT1("Call to IOCTL_CLOSE_WDMAUD failed with %d\n", GetLastError());
+            return TranslateInternalMmResult(Result);
+        }
     }
 
     --OpenCount;
@@ -410,550 +604,274 @@ WdmAudCloseSoundDeviceByLegacy(
 }
 
 MMRESULT
-WdmAudSetMixerDeviceFormatByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize)
+WdmAudSubmitWaveHeaderByLegacy(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ PWAVEHDR WaveHeader)
 {
-    MMRESULT Result;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    HANDLE hThread;
+    PWDMAUD_DEVICE_INFO LocalDeviceInfo;
+    //PWAVEHDR_EXTENSION HeaderExtension;
+    MMRESULT Result = MMSYSERR_NOERROR;
+    OVERLAPPED Overlapped;
+    DWORD Transferred = 0;
+    BOOL IoResult;
+    DWORD IoCtl;
 
-    Instance->hNotifyEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
-    if ( ! Instance->hNotifyEvent )
-        return MMSYSERR_NOMEM;
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
 
-    if (Instance->Handle != NULL)
-    {
-        /* device is already open */
-        return MMSYSERR_NOERROR;
-    }
+    DPRINT("WDMAUD - SubmitWaveHeader DeviceType %u\n", DeviceInfo->DeviceType);
 
-    Instance->hStopEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
-    if ( ! Instance->hStopEvent )
-        return MMSYSERR_NOMEM;
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.DeviceType = MIXER_DEVICE_TYPE;
-    DeviceInfo.DeviceIndex = DeviceId;
-    DeviceInfo.u.hNotifyEvent = Instance->hNotifyEvent;
-
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_OPEN_WDMAUD,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        CloseHandle(Instance->hNotifyEvent);
-        CloseHandle(Instance->hStopEvent);
-        return TranslateInternalMmResult(Result);
-    }
-
-    hThread = CreateThread(NULL, 0, MixerEventThreadRoutine, (LPVOID)Instance, 0, NULL);
-    if (  hThread )
-    {
-        CloseHandle(hThread);
-    }
-
-    /* Store sound device handle instance handle */
-    Instance->Handle = (PVOID)DeviceInfo.hDevice;
-
-    return MMSYSERR_NOERROR;
-}
-
-MMRESULT
-WdmAudSetWaveDeviceFormatByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize)
-{
-    MMRESULT Result;
-    PSOUND_DEVICE SoundDevice;
-    PVOID Identifier;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    MMDEVICE_TYPE DeviceType;
-
-    Result = GetSoundDeviceFromInstance(Instance, &SoundDevice);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    Result = GetSoundDeviceIdentifier(SoundDevice, &Identifier);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    if (Instance->Handle != NULL)
-    {
-        /* device is already open */
-        return MMSYSERR_NOERROR;
-    }
-
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.DeviceType = DeviceType;
-    DeviceInfo.DeviceIndex = DeviceId;
-    DeviceInfo.u.WaveFormatEx.cbSize = sizeof(WAVEFORMATEX); //WaveFormat->cbSize;
-    DeviceInfo.u.WaveFormatEx.wFormatTag = WaveFormat->wFormatTag;
-#ifdef USERMODE_MIXER
-    DeviceInfo.u.WaveFormatEx.nChannels = 2;
-    DeviceInfo.u.WaveFormatEx.nSamplesPerSec = 44100;
-    DeviceInfo.u.WaveFormatEx.nBlockAlign = 4;
-    DeviceInfo.u.WaveFormatEx.nAvgBytesPerSec = 176400;
-    DeviceInfo.u.WaveFormatEx.wBitsPerSample = 16;
-#else
-    DeviceInfo.u.WaveFormatEx.nChannels = WaveFormat->nChannels;
-    DeviceInfo.u.WaveFormatEx.nSamplesPerSec = WaveFormat->nSamplesPerSec;
-    DeviceInfo.u.WaveFormatEx.nBlockAlign = WaveFormat->nBlockAlign;
-    DeviceInfo.u.WaveFormatEx.nAvgBytesPerSec = WaveFormat->nAvgBytesPerSec;
-    DeviceInfo.u.WaveFormatEx.wBitsPerSample = (DeviceInfo.u.WaveFormatEx.nAvgBytesPerSec * 8) / (DeviceInfo.u.WaveFormatEx.nSamplesPerSec * DeviceInfo.u.WaveFormatEx.nChannels);
+#ifdef RESAMPLING_ENABLED
+    /* Resample the stream */
+    Result = WdmAudResampleStream(DeviceInfo, WaveHeader);
+    ASSERT( Result == MMSYSERR_NOERROR );
 #endif
 
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_OPEN_WDMAUD,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
+    ZeroMemory(&Overlapped, sizeof(OVERLAPPED));
+    Overlapped.hEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
 
-    if ( ! MMSUCCESS(Result) )
+    if ( ! Overlapped.hEvent )
+        return Win32ErrorToMmResult(GetLastError());
+
+    LocalDeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+    if (!LocalDeviceInfo)
     {
-        return TranslateInternalMmResult(Result);
+        /* No memory */
+        DPRINT1("Failed to allocate WDMAUD_DEVICE_INFO structure\n");
+        return MMSYSERR_NOMEM;
     }
+#if 0
+    HeaderExtension = (PWAVEHDR_EXTENSION)WaveHeader->reserved;
+    HeaderExtension->DeviceInfo = LocalDeviceInfo;
+#endif
+    LocalDeviceInfo->DeviceType = DeviceInfo->DeviceType;
+    LocalDeviceInfo->DeviceIndex = DeviceInfo->DeviceIndex;
+    LocalDeviceInfo->hDevice = DeviceInfo->hDevice;
+    LocalDeviceInfo->Buffer = WaveHeader;
+    LocalDeviceInfo->BufferSize = sizeof(WAVEHDR);
 
-    if (WaveFormatSize >= sizeof(WAVEFORMAT))
+    if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+        IoCtl = IOCTL_WRITEDATA;
+    else if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
+        IoCtl = IOCTL_READDATA;
+
+    IoResult = DeviceIoControl(KernelHandle,
+                               IoCtl,
+                               LocalDeviceInfo,
+                               sizeof(WDMAUD_DEVICE_INFO),
+                               LocalDeviceInfo,
+                               sizeof(WDMAUD_DEVICE_INFO),
+                               &Transferred,
+                               &Overlapped); // HeaderExtension->Overlapped
+    HeapFree(GetProcessHeap(), 0, LocalDeviceInfo);
+
+    if (!IoResult)
     {
-        /* Store format */
-        Instance->WaveFormatEx.wFormatTag = WaveFormat->wFormatTag;
-        Instance->WaveFormatEx.nChannels = WaveFormat->nChannels;
-        Instance->WaveFormatEx.nSamplesPerSec = WaveFormat->nSamplesPerSec;
-        Instance->WaveFormatEx.nBlockAlign = WaveFormat->nBlockAlign;
-        Instance->WaveFormatEx.nAvgBytesPerSec = WaveFormat->nAvgBytesPerSec;
-    }
-
-    /* store details */
-    Instance->WaveFormatEx.cbSize = sizeof(WAVEFORMATEX);
-    Instance->WaveFormatEx.wBitsPerSample = (DeviceInfo.u.WaveFormatEx.nAvgBytesPerSec * 8) / (DeviceInfo.u.WaveFormatEx.nSamplesPerSec * DeviceInfo.u.WaveFormatEx.nChannels);
-
-    /* Store sound device handle instance handle */
-    Instance->Handle = (PVOID)DeviceInfo.hDevice;
-
-    /* Now determine framing requirements */
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_GETFRAMESIZE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-    if ( MMSUCCESS(Result) )
-    {
-        if (DeviceInfo.u.FrameSize)
+        if (GetLastError() != ERROR_IO_PENDING)
         {
-            Instance->FrameSize = DeviceInfo.u.FrameSize * 2;
-            Instance->BufferCount = WaveFormat->nAvgBytesPerSec / Instance->FrameSize;
-            SND_TRACE(L"FrameSize %u BufferCount %u\n", Instance->FrameSize, Instance->BufferCount);
+            DPRINT1("Call to %s failed with %d\n",
+                    DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                    "IOCTL_WRITEDATA" : "IOCTL_READDATA",
+                    GetLastError());
+        }
+        Result = Win32ErrorToMmResult(GetLastError());
+    }
+    DPRINT("Result %x\n", Result);
+    DPRINT("GetLastError %d\n", GetLastError());
+#if 0
+    if (MMSUCCESS(Result))
+    {
+        /* Create I/O thread */
+        Result = WdmAudCreateCompletionThread(DeviceInfo);
+        if (!MMSUCCESS(Result))
+        {
+            /* Failed */
+            DPRINT1("Failed to create sound thread with error %d\n", GetLastError());
+            return TranslateInternalMmResult(Result);
         }
     }
-    else
-    {
-        // use a default of 100 buffers
-        Instance->BufferCount = 100;
-    }
+#else
+    /* Wait for I/O complete */
+    WaitForSingleObject(Overlapped.hEvent, INFINITE);
 
-    /* Now acquire resources */
-    DeviceInfo.u.State = KSSTATE_ACQUIRE;
-    SyncOverlappedDeviceIoControl(KernelHandle, IOCTL_SETDEVICE_STATE, (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), NULL);
+    /* Complete current header */
+    CompleteWaveHeader(DeviceInfo);
 
-    /* pause the pin */
-    DeviceInfo.u.State = KSSTATE_PAUSE;
-    SyncOverlappedDeviceIoControl(KernelHandle, IOCTL_SETDEVICE_STATE, (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), NULL);
+    /* Don't need this any more */
+    CloseHandle(Overlapped.hEvent);
+#endif
 
-    /* start the pin */
-    DeviceInfo.u.State = KSSTATE_RUN;
-    SyncOverlappedDeviceIoControl(KernelHandle, IOCTL_SETDEVICE_STATE, (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), (LPVOID) &DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), NULL);
+    DPRINT("Transferred %d bytes in Sync overlapped I/O\n", Transferred);
 
-
-    return MMSYSERR_NOERROR;
-}
-
-VOID
-CALLBACK
-LegacyCompletionRoutine(
-    IN  DWORD dwErrorCode,
-    IN  DWORD dwNumberOfBytesTransferred,
-    IN  LPOVERLAPPED lpOverlapped)
-{
-    PSOUND_OVERLAPPED Overlap;
-    PWDMAUD_DEVICE_INFO DeviceInfo;
-
-    Overlap = (PSOUND_OVERLAPPED)lpOverlapped;
-    DeviceInfo = (PWDMAUD_DEVICE_INFO)Overlap->CompletionContext;
-
-    /* Call mmebuddy overlap routine */
-    Overlap->OriginalCompletionRoutine(dwErrorCode, DeviceInfo->Header.DataUsed, lpOverlapped);
-
-    HeapFree(GetProcessHeap(), 0, DeviceInfo);
-}
-
-MMRESULT
-WdmAudCommitWaveBufferByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
-    IN  PVOID OffsetPtr,
-    IN  DWORD Length,
-    IN  PSOUND_OVERLAPPED Overlap,
-    IN  LPOVERLAPPED_COMPLETION_ROUTINE CompletionRoutine)
-{
-    HANDLE Handle;
-    MMRESULT Result;
-    PWDMAUD_DEVICE_INFO DeviceInfo;
-    PSOUND_DEVICE SoundDevice;
-    MMDEVICE_TYPE DeviceType;
-    BOOL Ret;
-
-    VALIDATE_MMSYS_PARAMETER( SoundDeviceInstance );
-    VALIDATE_MMSYS_PARAMETER( OffsetPtr );
-    VALIDATE_MMSYS_PARAMETER( Overlap );
-    VALIDATE_MMSYS_PARAMETER( CompletionRoutine );
-
-    GetSoundDeviceInstanceHandle(SoundDeviceInstance, &Handle);
-    SND_ASSERT(Handle);
-
-    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    DeviceInfo = (PWDMAUD_DEVICE_INFO)HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
-    if (!DeviceInfo)
-    {
-        // no memory
-        return MMSYSERR_NOMEM;
-    }
-
-    DeviceInfo->Header.FrameExtent = Length;
-    if (DeviceType == WAVE_OUT_DEVICE_TYPE)
-    {
-        DeviceInfo->Header.DataUsed = Length;
-    }
-    DeviceInfo->Header.Data = OffsetPtr;
-    DeviceInfo->Header.Size = sizeof(WDMAUD_DEVICE_INFO);
-    DeviceInfo->Header.PresentationTime.Numerator = 1;
-    DeviceInfo->Header.PresentationTime.Denominator = 1;
-    DeviceInfo->hDevice = Handle;
-    DeviceInfo->DeviceType = DeviceType;
-
-
-    // create completion event
-    Overlap->Standard.hEvent = Handle = CreateEventW(NULL, FALSE, FALSE, NULL);
-    if (Overlap->Standard.hEvent == NULL)
-    {
-        // no memory
-        HeapFree(GetProcessHeap(), 0, DeviceInfo);
-        return MMSYSERR_NOMEM;
-    }
-
-    Overlap->OriginalCompletionRoutine = CompletionRoutine;
-    Overlap->CompletionContext = (PVOID)DeviceInfo;
-
-    if (DeviceType == WAVE_OUT_DEVICE_TYPE)
-    {
-        Ret = WriteFileEx(KernelHandle, DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), (LPOVERLAPPED)Overlap, LegacyCompletionRoutine);
-        if (Ret)
-            WaitForSingleObjectEx (KernelHandle, INFINITE, TRUE);
-    }
-    else if (DeviceType == WAVE_IN_DEVICE_TYPE)
-    {
-        Ret = ReadFileEx(KernelHandle, DeviceInfo, sizeof(WDMAUD_DEVICE_INFO), (LPOVERLAPPED)Overlap, LegacyCompletionRoutine);
-        if (Ret)
-            WaitForSingleObjectEx (KernelHandle, INFINITE, TRUE);
-    }
-
-    // close event handle
-    CloseHandle(Handle);
-
-    return MMSYSERR_NOERROR;
+    return Result;
 }
 
 MMRESULT
 WdmAudSetWaveStateByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN BOOL bStart)
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ BOOL bStart)
 {
     MMRESULT Result;
-    PSOUND_DEVICE SoundDevice;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    MMDEVICE_TYPE DeviceType;
-    HANDLE Handle;
+    DWORD IoCtl;
 
-    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
+    DPRINT("WDMAUD - SetWaveState DeviceType %u\n", DeviceInfo->DeviceType);
 
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    Result = GetSoundDeviceInstanceHandle(SoundDeviceInstance, &Handle);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.hDevice = Handle;
-    DeviceInfo.DeviceType = DeviceType;
-
+    DeviceInfo->DeviceState->bStart = bStart;
+#if 0
     if (bStart)
-        DeviceInfo.u.State = KSSTATE_RUN;
-    else
-        DeviceInfo.u.State = KSSTATE_PAUSE;
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_SETDEVICE_STATE,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-    return Result;
-}
-
-MMRESULT
-WdmAudGetDeviceInterfaceStringByLegacy(
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  DWORD DeviceId,
-    IN  LPWSTR Interface,
-    IN  DWORD  InterfaceLength,
-    OUT  DWORD * InterfaceSize)
-{
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    MMRESULT Result;
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.DeviceType = DeviceType;
-    DeviceInfo.DeviceIndex = DeviceId;
-
-
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_QUERYDEVICEINTERFACESTRING,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-
-    if ( ! MMSUCCESS(Result) )
     {
+        Result = WdmAudCreateCompletionThread(DeviceInfo);
+        if (!MMSUCCESS(Result))
+        {
+            /* Failed */
+            return TranslateInternalMmResult(Result);
+        }
+    }
+#endif
+    if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
+    {
+        IoCtl = bStart ? IOCTL_START_CAPTURE : IOCTL_PAUSE_CAPTURE;
+    }
+    else if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+    {
+        IoCtl = bStart ? IOCTL_START_PLAYBACK : IOCTL_PAUSE_PLAYBACK;
+    }
+
+    Result = WdmAudIoControl(DeviceInfo,
+                             0,
+                             NULL,
+                             IoCtl);
+
+    if ( ! MMSUCCESS( Result ) )
+    {
+        DPRINT1("Call to %s failed with %d\n",
+                DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                (bStart ? "IOCTL_START_PLAYBACK" : "IOCTL_PAUSE_PLAYBACK") :
+                (bStart ? "IOCTL_START_CAPTURE" : "IOCTL_PAUSE_CAPTURE"),
+                GetLastError());
         return TranslateInternalMmResult(Result);
     }
-
-
-    if (!Interface)
-    {
-        SND_ASSERT(InterfaceSize);
-
-        *InterfaceSize = DeviceInfo.u.Interface.DeviceInterfaceStringSize;
-        return MMSYSERR_NOERROR;
-    }
-
-    if (InterfaceLength < DeviceInfo.u.Interface.DeviceInterfaceStringSize)
-    {
-        /* buffer is too small */
-        return MMSYSERR_MOREDATA;
-    }
-
-    DeviceInfo.u.Interface.DeviceInterfaceStringSize = InterfaceLength;
-    DeviceInfo.u.Interface.DeviceInterfaceString = Interface;
-
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_QUERYDEVICEINTERFACESTRING,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-    if (  MMSUCCESS(Result) && InterfaceLength > 2)
-    {
-        Interface[1] = L'\\';
-        Interface[InterfaceLength-1] = L'\0';
-    }
-
-    return Result;
-}
-
-MMRESULT
-WdmAudGetWavePositionByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMTIME* Time)
-{
-    MMRESULT Result;
-    PSOUND_DEVICE SoundDevice;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    MMDEVICE_TYPE DeviceType;
-    HANDLE Handle;
-
-    Result = GetSoundDeviceFromInstance(SoundDeviceInstance, &SoundDevice);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    Result = GetSoundDeviceType(SoundDevice, &DeviceType);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    Result = GetSoundDeviceInstanceHandle(SoundDeviceInstance, &Handle);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.hDevice = Handle;
-    DeviceInfo.DeviceType = DeviceType;
-
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_OPEN_WDMAUD,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        return TranslateInternalMmResult(Result);
-    }
-
-    Time->wType = TIME_BYTES;
-    Time->u.cb = (DWORD)DeviceInfo.u.Position;
 
     return MMSYSERR_NOERROR;
 }
 
-
 MMRESULT
 WdmAudResetStreamByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  BOOLEAN bStartReset)
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  BOOL bStartReset)
 {
     MMRESULT Result;
-    HANDLE Handle;
-    WDMAUD_DEVICE_INFO DeviceInfo;
+    DWORD IoCtl;
 
-    Result = GetSoundDeviceInstanceHandle(SoundDeviceInstance, &Handle);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
+    DPRINT("WDMAUD - ResetWaveStream DeviceType %u\n", DeviceInfo->DeviceType);
 
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.hDevice = Handle;
-    DeviceInfo.DeviceType = DeviceType;
-    DeviceInfo.u.ResetStream = (bStartReset ? KSRESET_BEGIN : KSRESET_END);
+    DeviceInfo->DeviceState->bReset = bStartReset;
+    DeviceInfo->DeviceState->bStart = FALSE;
 
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IOCTL_RESET_STREAM,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
-    return Result;
+    IoCtl = DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+            IOCTL_RESET_PLAYBACK : IOCTL_RESET_CAPTURE;
+
+    Result = WdmAudIoControl(DeviceInfo,
+                             0,
+                             NULL,
+                             IoCtl);
+
+    if ( ! MMSUCCESS(Result) )
+    {
+        DPRINT1("Call to %s failed with %d\n",
+                DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                "IOCTL_RESET_PLAYBACK" : "IOCTL_RESET_CAPTURE",
+                GetLastError());
+        return TranslateInternalMmResult(Result);
+    }
+
+    Result = WdmAudDestroyCompletionThread(DeviceInfo);
+    ASSERT(Result == MMSYSERR_NOERROR);
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+WdmAudGetWavePositionByLegacy(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  MMTIME* Time)
+{
+    MMRESULT Result;
+    DWORD Position;
+    DWORD IoCtl;
+
+    DPRINT("WDMAUD - GetWavePosition DeviceType %u\n", DeviceInfo->DeviceType);
+
+    IoCtl = DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+            IOCTL_GETOUTPOS : IOCTL_GETINPOS;
+
+    Result = WdmAudIoControl(DeviceInfo,
+                             sizeof(DWORD),
+                             &Position,
+                             IoCtl);
+
+    if ( ! MMSUCCESS(Result) )
+    {
+        DPRINT1("Call to %s failed with %d\n",
+                DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                "IOCTL_GETOUTPOS" : "IOCTL_GETINPOS",
+                GetLastError());
+        return TranslateInternalMmResult(Result);
+    }
+
+    if (Time->wType == TIME_BYTES)
+        Time->u.cb = Position;
+    else if (Time->wType == TIME_SAMPLES)
+        Time->u.sample = Position * 8 / DeviceInfo->DeviceState->Samples;
+
+    return MMSYSERR_NOERROR;
 }
 
 MMRESULT
 WdmAudQueryMixerInfoByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN DWORD DeviceId,
-    IN UINT uMsg,
-    IN LPVOID Parameter,
-    IN DWORD Flags)
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ DWORD DeviceId,
+    _In_ UINT uMsg,
+    _In_ LPVOID Parameter,
+    _In_ DWORD Flags)
 {
     MMRESULT Result;
-    WDMAUD_DEVICE_INFO DeviceInfo;
-    HANDLE Handle;
     DWORD IoControlCode;
-    LPMIXERLINEW MixLine;
-    LPMIXERLINECONTROLSW MixControls;
-    LPMIXERCONTROLDETAILS MixDetails;
 
-    SND_TRACE(L"uMsg %x Flags %x\n", uMsg, Flags);
+    DPRINT("WDMAUD - QueryMixerInfo: uMsg %x Flags %x\n", uMsg, Flags);
 
-    Result = GetSoundDeviceInstanceHandle(SoundDeviceInstance, &Handle);
-    SND_ASSERT( Result == MMSYSERR_NOERROR );
-
-    ZeroMemory(&DeviceInfo, sizeof(WDMAUD_DEVICE_INFO));
-    DeviceInfo.hDevice = Handle;
-    DeviceInfo.DeviceIndex = DeviceId;
-    DeviceInfo.DeviceType = MIXER_DEVICE_TYPE;
-    DeviceInfo.Flags = Flags;
-
-    MixLine = (LPMIXERLINEW)Parameter;
-    MixControls = (LPMIXERLINECONTROLSW)Parameter;
-    MixDetails = (LPMIXERCONTROLDETAILS)Parameter;
+    DeviceInfo->DeviceIndex = DeviceId;
+    DeviceInfo->DeviceType = MIXER_DEVICE_TYPE;
+    DeviceInfo->Flags = Flags;
 
     switch(uMsg)
     {
         case MXDM_GETLINEINFO:
-            RtlCopyMemory(&DeviceInfo.u.MixLine, MixLine, sizeof(MIXERLINEW));
             IoControlCode = IOCTL_GETLINEINFO;
             break;
         case MXDM_GETLINECONTROLS:
-            RtlCopyMemory(&DeviceInfo.u.MixControls, MixControls, sizeof(MIXERLINECONTROLSW));
             IoControlCode = IOCTL_GETLINECONTROLS;
             break;
-       case MXDM_SETCONTROLDETAILS:
-            RtlCopyMemory(&DeviceInfo.u.MixDetails, MixDetails, sizeof(MIXERCONTROLDETAILS));
+        case MXDM_SETCONTROLDETAILS:
             IoControlCode = IOCTL_SETCONTROLDETAILS;
             break;
-       case MXDM_GETCONTROLDETAILS:
-            RtlCopyMemory(&DeviceInfo.u.MixDetails, MixDetails, sizeof(MIXERCONTROLDETAILS));
+        case MXDM_GETCONTROLDETAILS:
             IoControlCode = IOCTL_GETCONTROLDETAILS;
             break;
-       default:
-           SND_ASSERT(0);
-           return MMSYSERR_NOTSUPPORTED;
+        default:
+            ASSERT(0);
+            break;
     }
 
-    Result = SyncOverlappedDeviceIoControl(KernelHandle,
-                                           IoControlCode,
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           (LPVOID) &DeviceInfo,
-                                           sizeof(WDMAUD_DEVICE_INFO),
-                                           NULL);
+    Result = WdmAudIoControl(DeviceInfo,
+                             sizeof(Parameter),
+                             Parameter,
+                             IoControlCode);
 
     if ( ! MMSUCCESS(Result) )
     {
-        return Result;
+        DPRINT1("Call to 0x%lx failed with %d\n", IoControlCode, GetLastError());
+        return TranslateInternalMmResult(Result);
     }
 
-    switch(uMsg)
-    {
-        case MXDM_GETLINEINFO:
-        {
-            RtlCopyMemory(MixLine, &DeviceInfo.u.MixLine, sizeof(MIXERLINEW));
-            break;
-        }
-    }
-
-    return Result;
+    return MMSYSERR_NOERROR;
 }

--- a/dll/win32/wdmaud.drv/midi/midMessage.c
+++ b/dll/win32/wdmaud.drv/midi/midMessage.c
@@ -1,0 +1,100 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/midi/midMessage.c
+ *
+ * PURPOSE:     Provides the midMessage exported function, as required by
+ *              the MME API, for MIDI input device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Standard MME driver entry-point for messages relating to MIDI input.
+*/
+DWORD
+APIENTRY
+midMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(MIDI_IN_DEVICE_TYPE);
+
+    DPRINT("midMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case MIDM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIDI_IN_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIDI_IN_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+
+        case MIDM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(MIDI_IN_DEVICE_TYPE);
+            break;
+        }
+
+        case MIDM_GETDEVCAPS :
+        {
+            Result = MmeGetSoundDeviceCapabilities(MIDI_IN_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+
+        case MIDM_OPEN :
+        {
+            Result = MmeOpenDevice(MIDI_IN_DEVICE_TYPE,
+                                   DeviceId,
+                                   (LPWAVEOPENDESC) Parameter1,
+                                   Parameter2,
+                                   (DWORD_PTR*) PrivateHandle);
+            break;
+        }
+
+        case MIDM_CLOSE :
+        {
+            Result = MmeCloseDevice(PrivateHandle);
+            break;
+        }
+
+       case MIDM_START :
+        {
+            Result = MmeSetState(PrivateHandle, TRUE);
+            break;
+        }
+
+        case MIDM_STOP :
+        {
+            Result = MmeSetState(PrivateHandle, FALSE);
+            break;
+        }
+    }
+
+    DPRINT("midMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(MIDI_IN_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/midi/modMessage.c
+++ b/dll/win32/wdmaud.drv/midi/modMessage.c
@@ -1,0 +1,90 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/midi/modMessage.c
+ *
+ * PURPOSE:     Provides the modMessage exported function, as required by
+ *              the MME API, for MIDI output device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Standard MME driver entry-point for messages relating to MIDI output.
+*/
+DWORD
+APIENTRY
+modMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(MIDI_OUT_DEVICE_TYPE);
+
+    DPRINT("modMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case MODM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIDI_OUT_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIDI_OUT_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+
+        case MODM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(MIDI_OUT_DEVICE_TYPE);
+            break;
+        }
+
+        case MODM_GETDEVCAPS :
+        {
+            Result = MmeGetSoundDeviceCapabilities(MIDI_OUT_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+
+        case MODM_OPEN :
+        {
+            Result = MmeOpenDevice(MIDI_OUT_DEVICE_TYPE,
+                                   DeviceId,
+                                   (LPWAVEOPENDESC) Parameter1, /* unused */
+                                   Parameter2,
+                                   (DWORD_PTR*)PrivateHandle);
+            break;
+        }
+
+        case MODM_CLOSE :
+        {
+            Result = MmeCloseDevice(PrivateHandle);
+
+            break;
+        }
+
+    }
+
+    DPRINT("modMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(MIDI_OUT_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/mixer/mxdMessage.c
+++ b/dll/win32/wdmaud.drv/mixer/mxdMessage.c
@@ -1,0 +1,158 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/mixer/mxdMessage.c
+ *
+ * PURPOSE:     Provides the mxdMessage exported function, as required by
+ *              the MME API, for mixer device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+MMRESULT
+MmeGetLineInfo(
+    IN UINT DeviceId,
+    IN  UINT Message,
+    IN  DWORD_PTR PrivateHandle,
+    IN  DWORD_PTR Parameter1,
+    IN  DWORD_PTR Parameter2)
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    DPRINT("Getting mixer info %u\n", Message);
+
+    if ( PrivateHandle == 0 )
+    {
+        return FUNC_NAME(WdmAudQueryMixerInfo)(NULL, DeviceId, Message, (LPVOID)Parameter1, Parameter2);
+    }
+
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+    DeviceInfo = (PWDMAUD_DEVICE_INFO) PrivateHandle;
+
+    return FUNC_NAME(WdmAudQueryMixerInfo)(DeviceInfo, DeviceId, Message, (LPVOID)Parameter1, Parameter2);
+}
+
+
+/*
+    Standard MME driver entry-point for messages relating to mixers.
+*/
+DWORD
+APIENTRY
+mxdMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(MIXER_DEVICE_TYPE);
+
+    DPRINT("mxdMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case MXDM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIXER_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(MIXER_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+
+        case MXDM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(MIXER_DEVICE_TYPE);
+            break;
+        }
+
+        case MXDM_GETDEVCAPS :
+        {
+            Result = MmeGetSoundDeviceCapabilities(MIXER_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+
+        case MXDM_OPEN :
+        {
+            Result = MmeOpenDevice(MIXER_DEVICE_TYPE,
+                                   DeviceId,
+                                   (LPWAVEOPENDESC) Parameter1, /* unused */
+                                   Parameter2,
+                                   (DWORD_PTR*) PrivateHandle);
+
+            break;
+        }
+
+        case MXDM_CLOSE :
+        {
+            Result = MmeCloseDevice(PrivateHandle);
+
+            break;
+        }
+
+        case MXDM_GETCONTROLDETAILS :
+        {
+            Result = MmeGetLineInfo(DeviceId,
+                                    Message,
+                                    PrivateHandle,
+                                    Parameter1,
+                                    Parameter2);
+
+            break;
+        }
+
+        case MXDM_SETCONTROLDETAILS :
+        {
+            Result = MmeGetLineInfo(DeviceId,
+                                    Message,
+                                    PrivateHandle,
+                                    Parameter1,
+                                    Parameter2);
+
+            break;
+        }
+
+        case MXDM_GETLINECONTROLS :
+        {
+            Result = MmeGetLineInfo(DeviceId,
+                                    Message,
+                                    PrivateHandle,
+                                    Parameter1,
+                                    Parameter2);
+
+            break;
+        }
+
+        case MXDM_GETLINEINFO :
+        {
+            Result = MmeGetLineInfo(DeviceId,
+                                    Message,
+                                    PrivateHandle,
+                                    Parameter1,
+                                    Parameter2);
+
+            break;
+        }
+    }
+
+    DPRINT("mxdMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(MIXER_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/mmewrap.c
+++ b/dll/win32/wdmaud.drv/mmewrap.c
@@ -1,0 +1,379 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/drivers/sound/mmebuddy/mmewrap.c
+ *
+ * PURPOSE:     Interface between MME functions and MME Buddy's own.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Sets the device into running or stopped state
+*/
+
+MMRESULT
+MmeSetState(
+    IN  DWORD_PTR PrivateHandle,
+    IN  BOOL bStart)
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+    DeviceInfo = (PWDMAUD_DEVICE_INFO)PrivateHandle;
+
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
+
+    /* Try change state */
+    return FUNC_NAME(WdmAudSetWaveState)(DeviceInfo, bStart);
+}
+
+/*
+    Call the client application when something interesting happens (MME API
+    defines "interesting things" as device open, close, and buffer
+    completion.)
+*/
+VOID
+NotifyMmeClient(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN  UINT Message,
+    IN  DWORD_PTR Parameter)
+{
+    ASSERT( DeviceInfo );
+
+    DPRINT("MME client callback - message %d, parameter %d\n",
+              (int) Message,
+              (int) Parameter);
+
+    if ( DeviceInfo->dwCallback )
+    {
+        DriverCallback(DeviceInfo->dwCallback,
+                       HIWORD(DeviceInfo->Flags),
+                       DeviceInfo->hDevice,
+                       Message,
+                       DeviceInfo->dwInstance,
+                       Parameter,
+                       0);
+    }
+}
+
+DWORD
+MmeGetNumDevs(
+    IN SOUND_DEVICE_TYPE DeviceType)
+{
+    MMRESULT Result;
+    DWORD DeviceCount;
+
+    VALIDATE_MMSYS_PARAMETER( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
+
+    Result = FUNC_NAME(WdmAudGetNumWdmDevs)(DeviceType, &DeviceCount);
+
+    if ( ! MMSUCCESS(Result) )
+    {
+        DPRINT1("Error %d while obtaining number of devices\n", GetLastError());
+        return 0;
+    }
+
+    DPRINT("%d devices of type %d found\n", DeviceCount, DeviceType);
+
+    return DeviceCount;
+}
+
+/*
+    Obtains the capabilities of a sound device. This routine ensures that the
+    supplied CapabilitiesSize parameter at least meets the minimum size of the
+    relevant capabilities structure.
+
+    Ultimately, it will call the GetCapabilities function specified in the
+    sound device's function table. Note that there are several of these, in a
+    union. This is simply to avoid manually typecasting when implementing the
+    functions.
+*/
+MMRESULT
+MmeGetSoundDeviceCapabilities(
+    IN  SOUND_DEVICE_TYPE DeviceType,
+    IN  DWORD DeviceId,
+    IN  PVOID Capabilities,
+    IN  DWORD CapabilitiesSize)
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+    BOOL GoodSize = FALSE;
+    MMRESULT Result;
+
+    DPRINT("MME *_GETCAPS for device %d of type %d\n", DeviceId, DeviceType);
+
+    /* FIXME: Validate device ID */
+    VALIDATE_MMSYS_PARAMETER( Capabilities );
+    VALIDATE_MMSYS_PARAMETER( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
+
+    /* Check that the capabilities structure is of a valid size */
+    if ( DeviceType == WAVE_OUT_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(WAVEOUTCAPSW);
+    else if ( DeviceType == WAVE_IN_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(WAVEINCAPSW);
+    else if ( DeviceType == MIDI_OUT_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(MIDIOUTCAPSW);
+    else if ( DeviceType == MIDI_IN_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(MIDIINCAPSW);
+    else if ( DeviceType == AUX_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(AUXCAPSW);
+    else if ( DeviceType == MIXER_DEVICE_TYPE )
+        GoodSize = CapabilitiesSize >= sizeof(MIXERCAPSW);
+
+    if ( ! GoodSize )
+    {
+        DPRINT1("Device capabilities structure too small\n");
+        return MMSYSERR_INVALPARAM;
+    }
+
+    DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+    if (!DeviceInfo)
+    {
+        /* No memory */
+        return MMSYSERR_NOMEM;
+    }
+
+    DeviceInfo->DeviceType = DeviceType;
+    DeviceInfo->DeviceIndex = DeviceId;
+
+    Result = FUNC_NAME(WdmAudGetCapabilities)(DeviceInfo,
+                                              Capabilities,
+                                              CapabilitiesSize);
+
+    HeapFree(GetProcessHeap(), 0, DeviceInfo);
+
+    return Result;
+}
+
+MMRESULT
+MmeOpenDevice(
+    IN  SOUND_DEVICE_TYPE DeviceType,
+    IN  UINT DeviceId,
+    IN  LPWAVEOPENDESC OpenParameters,
+    IN  DWORD Flags,
+    OUT DWORD_PTR* PrivateHandle)
+{
+    MMRESULT Result;
+    UINT Message;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    DPRINT("Opening device\n");
+
+    VALIDATE_MMSYS_PARAMETER( IS_WAVE_DEVICE_TYPE(DeviceType) || IS_MIXER_DEVICE_TYPE(DeviceType) || IS_MIDI_DEVICE_TYPE(DeviceType) );    /* FIXME? wave in too? */
+    VALIDATE_MMSYS_PARAMETER( OpenParameters );
+
+    /* Check that winmm gave us a private handle to fill */
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+
+    /* Allocate a new WDMAUD_DEVICE_INFO structure */
+    DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+    if (!DeviceInfo)
+    {
+        /* No memory */
+        return MMSYSERR_NOMEM;
+    }
+
+    /* Allocate a new WDMAUD_DEVICE_STATE structure */
+    DeviceInfo->DeviceState = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_STATE));
+    if (!DeviceInfo->DeviceState)
+    {
+        /* No memory */
+        HeapFree(GetProcessHeap(), 0, DeviceInfo);
+        return MMSYSERR_NOMEM;
+    }
+
+    if (DeviceType == WAVE_IN_DEVICE_TYPE || DeviceType == WAVE_OUT_DEVICE_TYPE)
+    {
+        /* Check if the caller just wanted to know if a format is supported */
+        if ( Flags & WAVE_FORMAT_QUERY )
+        {
+#if 0
+            DeviceInfo->DeviceType = DeviceType;
+            DeviceInfo->DeviceIndex = DeviceId;
+            DeviceInfo->Flags = Flags;
+
+            Result = FUNC_NAME(WdmAudOpenSoundDevice)(DeviceInfo, OpenParameters->lpFormat);
+            if (!MMSUCCESS(Result))
+            {
+                DPRINT1("Audio format is not supported\n");
+                Result = WAVERR_BADFORMAT;
+            }
+
+            HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState);
+            HeapFree(GetProcessHeap(), 0, DeviceInfo);
+            return Result;
+#else
+            return MMSYSERR_NOERROR;
+#endif
+        }
+    }
+
+    /* Allocate a new queue critical section */
+    DeviceInfo->DeviceState->QueueCriticalSection = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(CRITICAL_SECTION));
+    if (!DeviceInfo->DeviceState->QueueCriticalSection)
+    {
+        /* No memory */
+        HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState);
+        HeapFree(GetProcessHeap(), 0, DeviceInfo);
+        return MMSYSERR_NOMEM;
+    }
+
+    /* Initialize it */
+    InitializeCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+    DeviceInfo->DeviceType = DeviceType;
+    DeviceInfo->DeviceIndex = DeviceId;
+    DeviceInfo->hDevice = OpenParameters->hWave;
+    DeviceInfo->dwCallback = OpenParameters->dwCallback;
+    DeviceInfo->dwInstance = OpenParameters->dwInstance;
+    DeviceInfo->Flags = Flags;
+    DeviceInfo->hMixer = NULL;
+    DeviceInfo->NotificationType = 0;
+    DeviceInfo->Value = 0;
+    DeviceInfo->DeviceState->WaveQueue = NULL;
+    DeviceInfo->DeviceState->bStart = FALSE;
+    DeviceInfo->DeviceState->bStartInThread = FALSE;
+    DeviceInfo->DeviceState->hNotifyEvent = NULL;
+    DeviceInfo->DeviceState->hStopEvent = NULL; 
+    DeviceInfo->DeviceState->hThread = NULL;
+
+    /* Open sound device */
+    Result = FUNC_NAME(WdmAudOpenSoundDevice)(DeviceInfo, OpenParameters->lpFormat);
+    if ( ! MMSUCCESS(Result) )
+    {
+        DeleteCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+        HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState->QueueCriticalSection);
+        HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState);
+        HeapFree(GetProcessHeap(), 0, DeviceInfo);
+        return TranslateInternalMmResult(Result);
+    }
+
+    /* Store the device info pointer in the private handle */
+    *PrivateHandle = (DWORD_PTR)DeviceInfo;
+
+    if (DeviceType == WAVE_OUT_DEVICE_TYPE || DeviceType == WAVE_IN_DEVICE_TYPE ||
+        DeviceType == MIDI_OUT_DEVICE_TYPE || DeviceType == MIDI_IN_DEVICE_TYPE)
+    {
+        /* Let the application know the device is open */
+
+        if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+            Message = WOM_OPEN;
+        else if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
+            Message = WIM_OPEN;
+        else if (DeviceInfo->DeviceType == MIDI_IN_DEVICE_TYPE)
+            Message = MIM_OPEN;
+        else if (DeviceInfo->DeviceType == MIDI_OUT_DEVICE_TYPE)
+            Message = MOM_OPEN;
+
+        ReleaseEntrypointMutex(DeviceType);
+
+        NotifyMmeClient(DeviceInfo,
+                        Message,
+                        0);
+
+        AcquireEntrypointMutex(DeviceType);
+    }
+
+    DPRINT("Device is now opened\n");
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+MmeCloseDevice(
+    IN  DWORD_PTR PrivateHandle)
+{
+    MMRESULT Result;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+    UINT Message = 0;
+
+    DPRINT("Closing wave device (WIDM_CLOSE / WODM_CLOSE)\n");
+
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+    DeviceInfo = (PWDMAUD_DEVICE_INFO)PrivateHandle;
+
+    if ( ! DeviceInfo )
+        return MMSYSERR_INVALHANDLE;
+
+    /* TODO: Check device is stopped! */
+
+    if (DeviceInfo->DeviceType != MIXER_DEVICE_TYPE)
+    {
+        ReleaseEntrypointMutex(DeviceInfo->DeviceType);
+
+        if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+            Message = WOM_CLOSE;
+        else if (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
+            Message = WIM_CLOSE;
+        else if (DeviceInfo->DeviceType == MIDI_IN_DEVICE_TYPE)
+            Message = MIM_CLOSE;
+        else if (DeviceInfo->DeviceType == MIDI_OUT_DEVICE_TYPE)
+            Message = MOM_CLOSE;
+
+        /* TODO: Work with MIDI devices too */
+        NotifyMmeClient(DeviceInfo,
+                        Message,
+                        0);
+
+        AcquireEntrypointMutex(DeviceInfo->DeviceType);
+    }
+
+    /* Clode sound device */
+    Result = FUNC_NAME(WdmAudCloseSoundDevice)(DeviceInfo, DeviceInfo->hDevice);
+
+    /* Delete queue critical section */
+    DeleteCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+    /* Free it */
+    HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState->QueueCriticalSection);
+
+    /* Free device state */
+    HeapFree(GetProcessHeap(), 0, DeviceInfo->DeviceState);
+
+    /* Free device info */
+    HeapFree(GetProcessHeap(), 0, DeviceInfo);
+
+    return Result;
+}
+
+MMRESULT
+MmeResetWavePlayback(
+    IN  DWORD_PTR PrivateHandle)
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    DPRINT("Resetting wave device (WODM_RESET)\n");
+
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+    DeviceInfo = (PWDMAUD_DEVICE_INFO) PrivateHandle;
+
+    return StopStreaming(DeviceInfo);
+}
+
+
+MMRESULT
+MmeGetPosition(
+    IN  DWORD_PTR PrivateHandle,
+    IN  MMTIME* Time,
+    IN  DWORD Size)
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+
+    VALIDATE_MMSYS_PARAMETER( PrivateHandle );
+    DeviceInfo = (PWDMAUD_DEVICE_INFO) PrivateHandle;
+
+    if ( ! DeviceInfo )
+        return MMSYSERR_INVALHANDLE;
+
+    if ( Size != sizeof(MMTIME) )
+        return MMSYSERR_INVALPARAM;
+
+    /* Call the driver */
+    return FUNC_NAME(WdmAudGetWavePosition)(DeviceInfo, Time);
+}
+

--- a/dll/win32/wdmaud.drv/reentrancy.c
+++ b/dll/win32/wdmaud.drv/reentrancy.c
@@ -1,0 +1,106 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/reentrancy.c
+ *
+ * PURPOSE:     Provides entry-point mutex guards.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+HANDLE EntrypointMutexes[SOUND_DEVICE_TYPES];
+
+/*
+    Creates a set of mutexes which are used for the purpose of guarding the
+    device-type specific module entry-points. If any of these fail creation,
+    all of them will be destroyed and the failure reported.
+*/
+MMRESULT
+InitEntrypointMutexes()
+{
+    UCHAR i;
+    MMRESULT Result = MMSYSERR_NOERROR;
+
+    /* Blank all entries ni the table first */
+    for ( i = 0; i < SOUND_DEVICE_TYPES; ++ i )
+    {
+        EntrypointMutexes[i] = NULL;
+    }
+
+    /* Now create the mutexes */
+    for ( i = 0; i < SOUND_DEVICE_TYPES; ++ i )
+    {
+        EntrypointMutexes[i] = CreateMutex(NULL, FALSE, NULL);
+
+        if ( ! EntrypointMutexes[i] )
+        {
+            Result = Win32ErrorToMmResult(GetLastError());
+
+            /* Clean up any mutexes we successfully created */
+            CleanupEntrypointMutexes();
+            break;
+        }
+    }
+
+    return Result;
+}
+
+/*
+    Cleans up any of the entry-point guard mutexes. This will only close the
+    handles of mutexes which have been created, making it safe for use as a
+    cleanup routine even within the InitEntrypointMutexes routine above.
+*/
+VOID
+CleanupEntrypointMutexes()
+{
+    UCHAR i;
+
+    /* Only clean up a mutex if it actually exists */
+    for ( i = 0; i < SOUND_DEVICE_TYPES; ++ i )
+    {
+        if ( EntrypointMutexes[i] )
+        {
+            CloseHandle(EntrypointMutexes[i]);
+            EntrypointMutexes[i] = NULL;
+        }
+    }
+}
+
+/*
+    Grabs an entry-point mutex.
+*/
+VOID
+AcquireEntrypointMutex(
+    IN  SOUND_DEVICE_TYPE DeviceType)
+{
+    UCHAR i;
+
+    ASSERT( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
+    i = SOUND_DEVICE_TYPE_TO_INDEX(DeviceType);
+
+    ASSERT( EntrypointMutexes[i] );
+
+    WaitForSingleObject(EntrypointMutexes[i], INFINITE);
+}
+
+/*
+    Releases an entry-point mutex.
+*/
+VOID
+ReleaseEntrypointMutex(
+    IN  SOUND_DEVICE_TYPE DeviceType)
+{
+    UCHAR i;
+
+    ASSERT( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
+    i = SOUND_DEVICE_TYPE_TO_INDEX(DeviceType);
+
+    ASSERT( EntrypointMutexes[i] );
+
+    ReleaseMutex(EntrypointMutexes[i]);
+}

--- a/dll/win32/wdmaud.drv/result.c
+++ b/dll/win32/wdmaud.drv/result.c
@@ -1,0 +1,74 @@
+/*
+ * PROJECT:     ReactOS Sound Subsystem
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     WDM Audio Driver MMRESULT return code routines
+ * COPYRIGHT:   Copyright 2009-2010 Johannes Anderwald
+ *              Copyright 2022 Oleg Dubinskiy (oleg.dubinskij30@gmail.com)
+ */
+
+#include <wdmaud.h>
+
+/*
+    Translate a Win32 error code into an MMRESULT code.
+*/
+MMRESULT
+Win32ErrorToMmResult(
+    IN  UINT ErrorCode)
+{
+    switch ( ErrorCode )
+    {
+        case NO_ERROR :
+        case ERROR_IO_PENDING :
+            return MMSYSERR_NOERROR;
+
+        case ERROR_BUSY :
+            return MMSYSERR_ALLOCATED;
+
+        case ERROR_NOT_SUPPORTED :
+        case ERROR_INVALID_FUNCTION :
+            return MMSYSERR_NOTSUPPORTED;
+
+        case ERROR_NOT_ENOUGH_MEMORY :
+            return MMSYSERR_NOMEM;
+
+        case ERROR_ACCESS_DENIED :
+            return MMSYSERR_BADDEVICEID;
+
+        case ERROR_INSUFFICIENT_BUFFER :
+            return MMSYSERR_INVALPARAM;
+
+        case ERROR_INVALID_PARAMETER :
+            return MMSYSERR_INVALPARAM;
+
+
+        default :
+            return MMSYSERR_ERROR;
+    }
+}
+
+/*
+    If a function invokes another function, this aids in translating the
+    result code so that it is applicable in the context of the original caller.
+    For example, specifying that an invalid parameter was passed probably does
+    not make much sense if the parameter wasn't passed by the original caller!
+
+    This could potentially highlight internal logic problems.
+
+    However, things like MMSYSERR_NOMEM make sense to return to the caller.
+*/
+MMRESULT
+TranslateInternalMmResult(
+    IN  MMRESULT Result)
+{
+    switch ( Result )
+    {
+        case MMSYSERR_INVALPARAM :
+        case MMSYSERR_INVALFLAG :
+        {
+            return MMSYSERR_ERROR;
+        }
+    }
+
+    return Result;
+}
+

--- a/dll/win32/wdmaud.drv/wave/header.c
+++ b/dll/win32/wdmaud.drv/wave/header.c
@@ -1,0 +1,217 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/drivers/sound/mmebuddy/wave/header.c
+ *
+ * PURPOSE:     Wave header preparation and submission routines
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+
+/*
+    The following routines are basically handlers for:
+    - WODM_PREPARE
+    - WODM_UNPREPARE
+    - WODM_WRITE
+
+    All of these calls are ultimately dealt with in the context of the
+    appropriate sound thread, so the implementation should expect itself to
+    be running in this other thread when any of these operations take place.
+*/
+
+MMRESULT
+PrepareWaveHeader(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN  PWAVEHDR Header)
+{
+    //PWAVEHDR_EXTENSION HeaderExtension;
+
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
+    VALIDATE_MMSYS_PARAMETER( Header );
+
+    DPRINT("Preparing wave header\n");
+#if 0
+    Header->lpNext = NULL;
+    Header->reserved = 0;
+
+    /* Allocate header extension */
+    HeaderExtension = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WAVEHDR_EXTENSION));
+    if (!HeaderExtension)
+    {
+        /* No memory */
+        return MMSYSERR_NOMEM;
+    }
+
+    /* Allocate OVERLAPPED */
+    HeaderExtension->Overlapped = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(OVERLAPPED));
+    if (!HeaderExtension->Overlapped)
+    {
+        /* No memory */
+        HeapFree(GetProcessHeap(), 0, HeaderExtension);
+        return MMSYSERR_NOMEM;
+    }
+
+    /* Create stream event */
+    HeaderExtension->Overlapped->hEvent = CreateEventW(NULL, FALSE, FALSE, NULL);
+    if (!HeaderExtension->Overlapped->hEvent)
+    {
+        /* No memory */
+        HeapFree(GetProcessHeap(), 0, HeaderExtension->Overlapped);
+        HeapFree(GetProcessHeap(), 0, HeaderExtension);
+        return MMSYSERR_NOMEM;
+    }
+
+    Header->reserved = (DWORD_PTR)HeaderExtension;
+#endif
+    /* This is what Windows XP/2003 returns */
+    return MMSYSERR_NOTSUPPORTED;
+}
+
+MMRESULT
+UnprepareWaveHeader(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN  PWAVEHDR Header)
+{
+    //PWAVEHDR_EXTENSION HeaderExtension;
+
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
+    VALIDATE_MMSYS_PARAMETER( Header );
+
+    DPRINT("Un-preparing wave header\n");
+#if 0
+    HeaderExtension = (PWAVEHDR_EXTENSION)Header->reserved;
+
+    Header->reserved = 0;
+
+    /* Destroy stream event */
+    CloseHandle(HeaderExtension->Overlapped->hEvent);
+    HeaderExtension->Overlapped->hEvent = NULL;
+
+    /* Free OVERALPPED */
+    HeapFree(GetProcessHeap(), 0, HeaderExtension->Overlapped);
+    HeaderExtension->Overlapped = NULL;
+
+    /* Free header extension */
+    HeapFree(GetProcessHeap(), 0, HeaderExtension);
+#endif
+    /* This is what Windows XP/2003 returns */
+    return MMSYSERR_NOTSUPPORTED;
+}
+
+MMRESULT
+WriteWaveHeader(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN  PWAVEHDR Header)
+{
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
+    VALIDATE_MMSYS_PARAMETER( Header );
+
+    DPRINT("Submitting wave header\n");
+
+    /*
+        A few minor sanity checks - any custom checks should've been carried
+        out during wave header preparation etc.
+    */
+    VALIDATE_MMSYS_PARAMETER( Header->lpData != NULL );
+    VALIDATE_MMSYS_PARAMETER( Header->dwBufferLength > 0 );
+    VALIDATE_MMSYS_PARAMETER( Header->dwFlags & WHDR_PREPARED );
+    VALIDATE_MMSYS_PARAMETER( ! (Header->dwFlags & WHDR_INQUEUE) );
+
+    return EnqueueWaveHeader(DeviceInfo, Header);
+}
+
+
+/*
+    EnqueueWaveHeader
+        Put the header in the record/playback queue. This is performed within
+        the context of the sound thread, it must NEVER be called from another
+        thread.
+
+    CompleteWaveHeader
+        Set the header information to indicate that it has finished playing,
+        and return it to the client application. This again must be called
+        within the context of the sound thread.
+*/
+
+MMRESULT
+EnqueueWaveHeader(
+    IN PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN PWAVEHDR Header)
+{
+    VALIDATE_MMSYS_PARAMETER( DeviceInfo );
+    VALIDATE_MMSYS_PARAMETER( Header );
+
+    DPRINT("Next header %p\n", Header->lpNext);
+
+    /* Set the "in queue" flag */
+    Header->dwFlags |= WHDR_INQUEUE;
+
+    /* Clear the "done" flag for the buffer */
+    Header->dwFlags &= ~WHDR_DONE;
+
+    /* Store device info */
+    //((PWAVEHDR_EXTENSION)Header->reserved)->DeviceInfo = DeviceInfo;
+
+    EnterCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+    if (!DeviceInfo->DeviceState->WaveQueue)
+    {
+        /* This is the first header in the queue */
+        DPRINT("Enqueued first wave header\n");
+        DeviceInfo->DeviceState->WaveQueue = Header;
+    }
+    else
+    {
+        DPRINT("Enqueued next wave header\n");
+
+        DeviceInfo->DeviceState->WaveQueue = Header;
+        DeviceInfo->DeviceState->WaveQueue->lpNext = Header;
+    }
+    LeaveCriticalSection(DeviceInfo->DeviceState->QueueCriticalSection);
+
+    /* Do wave streaming */
+    return DoWaveStreaming(DeviceInfo, Header);
+}
+
+VOID
+CompleteWaveHeader(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo)
+{
+    PWAVEHDR Header;
+    //PWAVEHDR_EXTENSION HeaderExtension;
+
+    DPRINT("Completing wave header\n");
+
+    Header = DeviceInfo->DeviceState->WaveQueue;
+
+    if ( Header )
+    {
+        /* Move to the next header */
+        DeviceInfo->DeviceState->WaveQueue = DeviceInfo->DeviceState->WaveQueue->lpNext;
+
+        DPRINT("Returning buffer to client...\n");
+#if 0
+        /* Free header's device info */
+        HeaderExtension = (PWAVEHDR_EXTENSION)Header->reserved;
+        if (HeaderExtension->DeviceInfo)
+        {
+            HeapFree(GetProcessHeap(), 0, HeaderExtension->DeviceInfo);
+            HeaderExtension->DeviceInfo = NULL;
+        }
+#endif
+        /* Update the header */
+        Header->lpNext = NULL;
+        Header->dwFlags &= ~WHDR_INQUEUE;
+        Header->dwFlags |= WHDR_DONE;
+
+        /* Safe to do this without thread protection, as we're done with the header */
+        NotifyMmeClient(DeviceInfo,
+                        DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ? WOM_DONE : WIM_DATA,
+                        (DWORD_PTR)Header);
+    }
+}

--- a/dll/win32/wdmaud.drv/wave/streaming.c
+++ b/dll/win32/wdmaud.drv/wave/streaming.c
@@ -1,0 +1,89 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/drivers/sound/mmebuddy/wave/streaming.c
+ *
+ * PURPOSE:     Wave streaming
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+
+/*
+    DoWaveStreaming
+        Check if there is streaming to be done, and if so, do it.
+*/
+
+MMRESULT
+DoWaveStreaming(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
+    IN  PWAVEHDR Header)
+{
+    MMRESULT Result;
+
+    /* Is there any work to do? */
+    if (!Header)
+    {
+        DPRINT("DoWaveStreaming: No work to do - doing nothing\n");
+        return MMSYSERR_NOMEM;
+    }
+
+    /* Sanity checks */
+    ASSERT(Header->dwFlags & WHDR_PREPARED);
+    ASSERT(Header->dwFlags & WHDR_INQUEUE);
+
+    /* Submit wave header */
+    Result = FUNC_NAME(WdmAudSubmitWaveHeader)(DeviceInfo, Header);
+    if (!MMSUCCESS(Result))
+    {
+        DPRINT1("WdmAudSubmitWaveHeader failed with error %d\n", GetLastError());
+        Header->dwFlags &= ~WHDR_INQUEUE;
+        return TranslateInternalMmResult(Result);
+    }
+
+    /* Done */
+    return MMSYSERR_NOERROR;
+}
+
+/*
+    Stream control functions
+    (External/internal thread pairs)
+
+    TODO - Move elsewhere as these shouldn't be wave specific!
+*/
+
+MMRESULT
+StopStreamingInSoundThread(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo)
+{
+    MMRESULT Result;
+
+    /* Reset the stream */
+    Result = FUNC_NAME(WdmAudResetStream)(DeviceInfo, FALSE);
+
+    if ( ! MMSUCCESS(Result) )
+    {
+        /* Failed */
+        return TranslateInternalMmResult(Result);
+    }
+
+    return MMSYSERR_NOERROR;
+}
+
+MMRESULT
+StopStreaming(
+    IN  PWDMAUD_DEVICE_INFO DeviceInfo)
+{
+    if ( ! DeviceInfo )
+        return MMSYSERR_INVALHANDLE;
+
+    if ( DeviceInfo->DeviceType != WAVE_OUT_DEVICE_TYPE && DeviceInfo->DeviceType != WAVE_IN_DEVICE_TYPE )
+        return MMSYSERR_NOTSUPPORTED;
+
+    return StopStreamingInSoundThread(DeviceInfo);
+}

--- a/dll/win32/wdmaud.drv/wave/widMessage.c
+++ b/dll/win32/wdmaud.drv/wave/widMessage.c
@@ -1,0 +1,135 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/sound/mmebuddy/wave/widMessage.c
+ *
+ * PURPOSE:     Provides the widMessage exported function, as required by
+ *              the MME API, for wave input device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Standard MME driver entry-point for messages relating to wave audio
+    input.
+*/
+DWORD
+APIENTRY
+widMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(WAVE_IN_DEVICE_TYPE);
+
+    DPRINT("widMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case WIDM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(WAVE_IN_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(WAVE_IN_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+        case WIDM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(WAVE_IN_DEVICE_TYPE);
+            break;
+        }
+
+        case WIDM_START :
+        {
+            Result = MmeSetState(PrivateHandle, TRUE);
+            break;
+        }
+
+        case WIDM_STOP :
+        {
+            Result = MmeSetState(PrivateHandle, FALSE);
+            break;
+        }
+
+        case WIDM_GETDEVCAPS :
+        {
+
+            Result = MmeGetSoundDeviceCapabilities(WAVE_IN_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+        case WIDM_OPEN :
+        {
+
+            /* Do sanity checks for 'recording' SamplesPerSec value */
+            LPWAVEOPENDESC OpenParameters = (LPWAVEOPENDESC)Parameter1;
+            if (OpenParameters->lpFormat->nSamplesPerSec > 100000)
+                OpenParameters->lpFormat->nSamplesPerSec = 100000;
+            if (OpenParameters->lpFormat->nSamplesPerSec < 5000)
+                OpenParameters->lpFormat->nSamplesPerSec = 5000;
+
+            Result = MmeOpenDevice(WAVE_IN_DEVICE_TYPE,
+                                       DeviceId,
+                                       (LPWAVEOPENDESC) Parameter1,
+                                       Parameter2,
+                                       (DWORD_PTR*) PrivateHandle);
+            break;
+        }
+
+        case WIDM_CLOSE :
+        {
+            Result = MmeCloseDevice(PrivateHandle);
+
+            break;
+        }
+
+        case WIDM_PREPARE :
+        {
+            /* TODO: Do we need to pass 2nd parameter? */
+            Result = MmePrepareWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+
+        case WIDM_UNPREPARE :
+        {
+            Result = MmeUnprepareWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+
+        case WIDM_RESET :
+        {
+            /* Stop playback, reset position to zero */
+            Result = MmeResetWavePlayback(PrivateHandle);
+            break;
+        }
+
+        case WIDM_ADDBUFFER :
+        {
+            Result = MmeWriteWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+    }
+
+    DPRINT("widMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(WAVE_IN_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/wave/wodMessage.c
+++ b/dll/win32/wdmaud.drv/wave/wodMessage.c
@@ -1,0 +1,135 @@
+/*
+ * PROJECT:     ReactOS Sound System "MME Buddy" Library
+ * LICENSE:     GPL - See COPYING in the top level directory
+ * FILE:        lib/drivers/sound/mmebuddy/wave/wodMessage.c
+ *
+ * PURPOSE:     Provides the wodMessage exported function, as required by
+ *              the MME API, for wave output device support.
+ *
+ * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
+*/
+
+#include "wdmaud.h"
+
+#define YDEBUG
+#include <debug.h>
+
+/*
+    Standard MME driver entry-point for messages relating to wave audio
+    output.
+*/
+DWORD
+APIENTRY
+wodMessage(
+    UINT DeviceId,
+    UINT Message,
+    DWORD_PTR PrivateHandle,
+    DWORD_PTR Parameter1,
+    DWORD_PTR Parameter2)
+{
+    MMRESULT Result = MMSYSERR_NOTSUPPORTED;
+
+    AcquireEntrypointMutex(WAVE_OUT_DEVICE_TYPE);
+
+    DPRINT("wodMessage - Message type %d\n", Message);
+
+    switch ( Message )
+    {
+#ifndef USE_MMIXER_LIB
+        case WODM_INIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(WAVE_OUT_DEVICE_TYPE, TRUE);
+            break;
+        }
+
+        case DRVM_EXIT:
+        {
+            Result = WdmAudAddRemoveDeviceNode(WAVE_OUT_DEVICE_TYPE, FALSE);
+            break;
+        }
+#endif
+
+        case WODM_GETNUMDEVS :
+        {
+            Result = MmeGetNumDevs(WAVE_OUT_DEVICE_TYPE);
+            break;
+        }
+
+        case WODM_GETDEVCAPS :
+        {
+            Result = MmeGetSoundDeviceCapabilities(WAVE_OUT_DEVICE_TYPE,
+                                                   DeviceId,
+                                                   (PVOID) Parameter1,
+                                                   Parameter2);
+            break;
+        }
+
+        case WODM_OPEN :
+        {
+            Result = MmeOpenDevice(WAVE_OUT_DEVICE_TYPE,
+                                   DeviceId,
+                                   (LPWAVEOPENDESC) Parameter1,
+                                   Parameter2,
+                                   (DWORD_PTR*)PrivateHandle);
+            break;
+        }
+
+        case WODM_CLOSE :
+        {
+            Result = MmeCloseDevice(PrivateHandle);
+
+            break;
+        }
+
+        case WODM_PREPARE :
+        {
+            /* TODO: Do we need to pass 2nd parameter? */
+            Result = MmePrepareWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+
+        case WODM_UNPREPARE :
+        {
+            Result = MmeUnprepareWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+
+        case WODM_WRITE :
+        {
+            Result = MmeWriteWaveHeader(PrivateHandle, Parameter1);
+            break;
+        }
+
+        case WODM_RESET :
+        {
+            /* Stop playback, reset position to zero */
+            Result = MmeResetWavePlayback(PrivateHandle);
+            break;
+        }
+
+        case WODM_RESTART :
+        {
+            /* Continue playback when paused */
+            Result = MmeSetState(PrivateHandle, TRUE);
+            break;
+        }
+        case WODM_PAUSE :
+        {
+            /* Pause playback */
+            Result = MmeSetState(PrivateHandle, FALSE);
+            break;
+        }
+
+        case WODM_GETPOS :
+        {
+            Result = MmeGetPosition(PrivateHandle, (MMTIME*)Parameter1, Parameter2);
+            break;
+        }
+    }
+
+    DPRINT("wodMessage returning MMRESULT %d\n", Result);
+
+    ReleaseEntrypointMutex(WAVE_OUT_DEVICE_TYPE);
+
+    return Result;
+}

--- a/dll/win32/wdmaud.drv/wdmaud.c
+++ b/dll/win32/wdmaud.drv/wdmaud.c
@@ -5,109 +5,12 @@
  *
  * PURPOSE:     WDM Audio Driver (User-mode part)
  * PROGRAMMERS: Andrew Greenwood (silverblade@reactos.org)
- *
- * NOTES:       Looking for wodMessage & co? You won't find them here. Try
- *              the MME Buddy library, which is where these routines are
- *              actually implemented.
- *
  */
 
 #include "wdmaud.h"
 
-#define NDEBUG
+#define YDEBUG
 #include <debug.h>
-#include <mmebuddy_debug.h>
-
-#define USE_MMIXER_LIB
-#ifndef USE_MMIXER_LIB
-#define FUNC_NAME(x) x##ByLegacy
-#else
-#define FUNC_NAME(x) x##ByMMixer
-#endif
-
-MMRESULT
-QueryWdmWaveDeviceFormatSupport(
-    IN  PSOUND_DEVICE Device,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize)
-{
-    /* Whatever... */
-    return MMSYSERR_NOERROR;
-}
-
-MMRESULT
-PopulateWdmDeviceList(
-    MMDEVICE_TYPE DeviceType)
-{
-    MMRESULT Result;
-    DWORD DeviceCount = 0;
-    PSOUND_DEVICE SoundDevice = NULL;
-    MMFUNCTION_TABLE FuncTable;
-    DWORD i;
-
-    VALIDATE_MMSYS_PARAMETER( IS_VALID_SOUND_DEVICE_TYPE(DeviceType) );
-
-    Result = FUNC_NAME(WdmAudGetNumWdmDevs)(DeviceType, &DeviceCount);
-
-    if ( ! MMSUCCESS(Result) )
-    {
-        SND_ERR(L"Error %d while obtaining number of devices\n", Result);
-        return TranslateInternalMmResult(Result);
-    }
-
-    SND_TRACE(L"%d devices of type %d found\n", DeviceCount, DeviceType);
-
-
-    for ( i = 0; i < DeviceCount; ++ i )
-    {
-        Result = ListSoundDevice(DeviceType, UlongToPtr(i), &SoundDevice);
-
-        if ( ! MMSUCCESS(Result) )
-        {
-            SND_ERR(L"Failed to list sound device - error %d\n", Result);
-            return TranslateInternalMmResult(Result);
-        }
-
-        /* Set up our function table */
-        ZeroMemory(&FuncTable, sizeof(MMFUNCTION_TABLE));
-        FuncTable.GetCapabilities = FUNC_NAME(WdmAudGetCapabilities);
-        FuncTable.QueryWaveFormatSupport = QueryWdmWaveDeviceFormatSupport; //FIXME
-        FuncTable.Open = FUNC_NAME(WdmAudOpenSoundDevice);
-        FuncTable.Close = FUNC_NAME(WdmAudCloseSoundDevice);
-        FuncTable.GetDeviceInterfaceString = FUNC_NAME(WdmAudGetDeviceInterfaceString);
-
-        if (DeviceType == MIXER_DEVICE_TYPE)
-        {
-            FuncTable.SetWaveFormat = FUNC_NAME(WdmAudSetMixerDeviceFormat);
-            FuncTable.QueryMixerInfo = FUNC_NAME(WdmAudQueryMixerInfo);
-        }
-        else if (DeviceType == WAVE_IN_DEVICE_TYPE || DeviceType == WAVE_OUT_DEVICE_TYPE)
-        {
-            FuncTable.SetWaveFormat = FUNC_NAME(WdmAudSetWaveDeviceFormat);
-            FuncTable.SetState = FUNC_NAME(WdmAudSetWaveState);
-            FuncTable.ResetStream = FUNC_NAME(WdmAudResetStream);
-            FuncTable.GetPos = FUNC_NAME(WdmAudGetWavePosition);
-
-#ifndef USERMODE_MIXER
-            FuncTable.CommitWaveBuffer = FUNC_NAME(WdmAudCommitWaveBuffer);
-#else
-            FuncTable.CommitWaveBuffer = WriteFileEx_Remixer;
-#endif
-        }
-        else if (DeviceType == MIDI_IN_DEVICE_TYPE || DeviceType == MIDI_OUT_DEVICE_TYPE)
-        {
-            FuncTable.SetWaveFormat = FUNC_NAME(WdmAudSetMixerDeviceFormat);
-            FuncTable.SetState = FUNC_NAME(WdmAudSetWaveState);
-            FuncTable.GetPos = FUNC_NAME(WdmAudGetWavePosition);
-        }
-
-        SetSoundDeviceFunctionTable(SoundDevice, &FuncTable);
-    }
-
-    return MMSYSERR_NOERROR;
-}
-
-
 
 LONG
 APIENTRY
@@ -122,52 +25,85 @@ DriverProc(
     {
         case DRV_LOAD :
         {
-            HANDLE Handle;
             MMRESULT Result;
-            SND_TRACE(L"DRV_LOAD\n");
+#ifndef USE_MMIXER_LIB
+            PWDMAUD_DEVICE_INFO DeviceInfo;
+#endif
+            DPRINT("DRV_LOAD\n");
 
             Result = InitEntrypointMutexes();
 
             if ( ! MMSUCCESS(Result) )
                 return 0L;
 
-            Result = FUNC_NAME(WdmAudOpenSoundDevice)(NULL, &Handle);
+            Result = FUNC_NAME(WdmAudOpenKernelSoundDevice)();
 
             if ( Result != MMSYSERR_NOERROR )
             {
-                SND_ERR(L"Failed to open \\\\.\\wdmaud\n");
-                //UnlistAllSoundDevices();
+                DPRINT1("Failed to open \\\\.\\wdmaud with %d\n", GetLastError());
 
                 return 0L;
             }
 
-            /* Populate the device lists */
-            SND_TRACE(L"Populating device lists\n");
-            PopulateWdmDeviceList(WAVE_OUT_DEVICE_TYPE);
-            PopulateWdmDeviceList(WAVE_IN_DEVICE_TYPE);
-            PopulateWdmDeviceList(MIDI_OUT_DEVICE_TYPE);
-            PopulateWdmDeviceList(MIDI_IN_DEVICE_TYPE);
-            PopulateWdmDeviceList(AUX_DEVICE_TYPE);
-            PopulateWdmDeviceList(MIXER_DEVICE_TYPE);
+#ifndef USE_MMIXER_LIB
+            DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+            if (!DeviceInfo)
+            {
+                /* No memory */
+                DPRINT1("Failed to allocate WDMAUD_DEVICE_INFO structure\n");
+                return 0L;
+            }
 
-            SND_TRACE(L"Initialisation complete\n");
+            /* Initialize wdmaud.sys */
+            DeviceInfo->DeviceType = AUX_DEVICE_TYPE;
+
+            Result = WdmAudIoControl(DeviceInfo, 0, NULL, IOCTL_INIT_WDMAUD);
+            HeapFree(GetProcessHeap(), 0, DeviceInfo);
+            if ( ! MMSUCCESS( Result ) )
+            {
+                DPRINT1("Call to IOCTL_INIT_WDMAUD failed with %d\n", GetLastError());
+
+                return 0L;
+            }
+#endif
+
+            DPRINT("Initialization completed\n");
 
             return 1L;
         }
 
         case DRV_FREE :
         {
-            SND_TRACE(L"DRV_FREE\n");
+#ifndef USE_MMIXER_LIB
+            MMRESULT Result;
+            PWDMAUD_DEVICE_INFO DeviceInfo;
+#endif
+            DPRINT("DRV_FREE\n");
+#ifndef USE_MMIXER_LIB
+            DeviceInfo = HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, sizeof(WDMAUD_DEVICE_INFO));
+            if (!DeviceInfo)
+            {
+                /* No memory */
+                DPRINT1("Failed to allocate WDMAUD_DEVICE_INFO structure\n");
+                return 0L;
+            }
+
+            /* Unload wdmaud.sys */
+            DeviceInfo->DeviceType = AUX_DEVICE_TYPE;
+
+            Result = WdmAudIoControl(DeviceInfo, 0, NULL, IOCTL_EXIT_WDMAUD);
+            HeapFree(GetProcessHeap(), 0, DeviceInfo);
+            if ( ! MMSUCCESS( Result ) )
+            {
+                DPRINT1("Call to IOCTL_EXIT_WDMAUD failed with %d\n", GetLastError());
+
+                return 0L;
+            }
+#endif
 
             FUNC_NAME(WdmAudCleanup)();
 
-            /* TODO: Clean up the path names! */
-            UnlistAllSoundDevices();
-
             CleanupEntrypointMutexes();
-
-            SND_TRACE(L"Unfreed memory blocks: %d\n",
-                      GetMemoryAllocationCount());
 
             return 1L;
         }
@@ -175,27 +111,27 @@ DriverProc(
         case DRV_ENABLE :
         case DRV_DISABLE :
         {
-            SND_TRACE(L"DRV_ENABLE / DRV_DISABLE\n");
+            DPRINT("DRV_ENABLE / DRV_DISABLE\n");
             return 1L;
         }
 
         case DRV_OPEN :
         case DRV_CLOSE :
         {
-            SND_TRACE(L"DRV_OPEN / DRV_CLOSE\n");
+            DPRINT("DRV_OPEN / DRV_CLOSE\n");
             return 1L;
         }
 
         case DRV_QUERYCONFIGURE :
         {
-            SND_TRACE(L"DRV_QUERYCONFIGURE\n");
+            DPRINT("DRV_QUERYCONFIGURE\n");
             return 0L;
         }
         case DRV_CONFIGURE :
             return DRVCNF_OK;
 
         default :
-            SND_TRACE(L"Unhandled message %d\n", Message);
+            DPRINT("Unhandled message %d\n", Message);
             return DefDriverProc(DriverId,
                                  DriverHandle,
                                  Message,
@@ -213,16 +149,16 @@ BOOL WINAPI DllMain(
     switch ( fdwReason )
     {
         case DLL_PROCESS_ATTACH :
-            SND_TRACE(L"WDMAUD.DRV - Process attached\n");
+            DPRINT("WDMAUD.DRV - Process attached\n");
             break;
         case DLL_PROCESS_DETACH :
-            SND_TRACE(L"WDMAUD.DRV - Process detached\n");
+            DPRINT("WDMAUD.DRV - Process detached\n");
             break;
         case DLL_THREAD_ATTACH :
-            SND_TRACE(L"WDMAUD.DRV - Thread attached\n");
+            DPRINT("WDMAUD.DRV - Thread attached\n");
             break;
         case DLL_THREAD_DETACH :
-            SND_TRACE(L"WDMAUD.DRV - Thread detached\n");
+            DPRINT("WDMAUD.DRV - Thread detached\n");
             break;
     }
 

--- a/dll/win32/wdmaud.drv/wdmaud.h
+++ b/dll/win32/wdmaud.drv/wdmaud.h
@@ -13,12 +13,38 @@
 
 #include <winuser.h>
 #include <mmddk.h>
-#include <mmebuddy.h>
 #include <ks.h>
 #include <ksmedia.h>
 #include <interface.h>
 #include <devioctl.h>
 #include <setupapi.h>
+
+/* 
+ * Enables user-mode stream resampling support.
+ * Resampling is required by some legacy devices
+ * those don't support modern audio formats.
+ * They're only able to use standard 44100 KHz sample rate,
+ * 2 (stereo) channels and 16 BPS quality.
+ * For example, Intel AC97 driver,
+ * which is used in VirtualBox by default.
+ */
+//#define RESAMPLING_ENABLED
+
+#define USE_MMIXER_LIB
+#ifndef USE_MMIXER_LIB
+#define FUNC_NAME(x) x##ByLegacy
+#else
+#define FUNC_NAME(x) x##ByMMixer
+#endif
+
+/* This lives in WAVEHDR.reserved */
+typedef struct
+{
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+    LPOVERLAPPED Overlapped;
+} WAVEHDR_EXTENSION, *PWAVEHDR_EXTENSION;
+
+/* mmixer.c */
 
 BOOL
 WdmAudInitUserModeMixer(VOID);
@@ -32,214 +58,247 @@ WdmAudGetWaveInCount(VOID);
 ULONG
 WdmAudGetMixerCount(VOID);
 
-MMRESULT
-WdmAudGetNumWdmDevsByMMixer(
-    IN  MMDEVICE_TYPE DeviceType,
-    OUT DWORD* DeviceCount);
+/* resample.c */
 
 MMRESULT
-WdmAudCommitWaveBufferByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
-    IN  PVOID OffsetPtr,
-    IN  DWORD Length,
-    IN  PSOUND_OVERLAPPED Overlap,
-    IN  LPOVERLAPPED_COMPLETION_ROUTINE CompletionRoutine);
-
-MMRESULT
-WriteFileEx_Remixer(
-    IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
-    IN  PVOID OffsetPtr,
-    IN  DWORD Length,
-    IN  PSOUND_OVERLAPPED Overlap,
-    IN  LPOVERLAPPED_COMPLETION_ROUTINE CompletionRoutine);
-
-MMRESULT
-WdmAudGetCapabilitiesByMMixer(
-    IN  PSOUND_DEVICE SoundDevice,
-    IN  DWORD DeviceId,
-    OUT PVOID Capabilities,
-    IN  DWORD CapabilitiesSize);
-
-MMRESULT
-WdmAudOpenSoundDeviceByMMixer(
-    IN  struct _SOUND_DEVICE* SoundDevice,
-    OUT PVOID* Handle);
-
-MMRESULT
-WdmAudCloseSoundDeviceByMMixer(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  PVOID Handle);
-
-MMRESULT
-WdmAudGetLineInfo(
-    IN HANDLE hMixer,
-    IN DWORD MixerId,
-    IN LPMIXERLINEW MixLine,
-    IN ULONG Flags);
-
-MMRESULT
-WdmAudGetLineControls(
-    IN HANDLE hMixer,
-    IN DWORD MixerId,
-    IN LPMIXERLINECONTROLSW MixControls,
-    IN ULONG Flags);
-
-MMRESULT
-WdmAudSetControlDetails(
-    IN HANDLE hMixer,
-    IN DWORD MixerId,
-    IN LPMIXERCONTROLDETAILS MixDetails,
-    IN ULONG Flags);
-
-MMRESULT
-WdmAudGetControlDetails(
-    IN HANDLE hMixer,
-    IN DWORD MixerId,
-    IN LPMIXERCONTROLDETAILS MixDetails,
-    IN ULONG Flags);
-
-MMRESULT
-WdmAudSetWaveDeviceFormatByMMixer(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize);
-
-MMRESULT
-WdmAudGetDeviceInterfaceStringByMMixer(
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  DWORD DeviceId,
-    IN  LPWSTR Interface,
-    IN  DWORD  InterfaceLength,
-    OUT  DWORD * InterfaceSize);
-
-MMRESULT
-WdmAudSetMixerDeviceFormatByMMixer(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize);
-
-MMRESULT
-WdmAudQueryMixerInfoByMMixer(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN DWORD DeviceId,
-    IN UINT uMsg,
-    IN LPVOID Parameter,
-    IN DWORD Flags);
-
-MMRESULT
-WdmAudSetWaveStateByMMixer(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN BOOL bStart);
-
-MMRESULT
-WdmAudResetStreamByMMixer(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  BOOLEAN bStartReset);
-
-MMRESULT
-WdmAudGetWavePositionByMMixer(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMTIME* Time);
-
-MMRESULT
-WdmAudCommitWaveBufferByMMixer(
-    IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
-    IN  PVOID OffsetPtr,
-    IN  DWORD Length,
-    IN  PSOUND_OVERLAPPED Overlap,
-    IN  LPOVERLAPPED_COMPLETION_ROUTINE CompletionRoutine);
-
-MMRESULT
-WdmAudCleanupByMMixer(VOID);
+WdmAudResampleStream(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ _Out_ PWAVEHDR WaveHeader);
 
 /* legacy.c */
 
 MMRESULT
-WdmAudCleanupByLegacy(VOID);
+WdmAudIoControl(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_opt_ ULONG DataBufferSize,
+    _In_opt_ PVOID Buffer,
+    _In_  DWORD IoControlCode);
 
 MMRESULT
-WdmAudGetCapabilitiesByLegacy(
-    IN  PSOUND_DEVICE SoundDevice,
-    IN  DWORD DeviceId,
-    OUT PVOID Capabilities,
-    IN  DWORD CapabilitiesSize);
+WdmAudCreateCompletionThread(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo);
 
 MMRESULT
-WdmAudOpenSoundDeviceByLegacy(
-    IN PSOUND_DEVICE SoundDevice,
-    OUT PVOID *Handle
-);
+WdmAudDestroyCompletionThread(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo);
 
 MMRESULT
-WdmAudCloseSoundDeviceByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  PVOID Handle);
+WdmAudAddRemoveDeviceNode(
+    _In_ SOUND_DEVICE_TYPE DeviceType,
+    _In_ BOOL bAdd);
+
+/* Shared functions for legacy.c and mmixer.c */
 
 MMRESULT
-WdmAudGetDeviceInterfaceStringByLegacy(
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  DWORD DeviceId,
-    IN  LPWSTR Interface,
-    IN  DWORD  InterfaceLength,
-    OUT  DWORD * InterfaceSize);
+FUNC_NAME(WdmAudOpenKernelSoundDevice)(VOID);
 
 MMRESULT
-WdmAudSetMixerDeviceFormatByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize);
+FUNC_NAME(WdmAudCleanup)(VOID);
 
 MMRESULT
-WdmAudQueryMixerInfoByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN DWORD DeviceId,
-    IN UINT uMsg,
-    IN LPVOID Parameter,
-    IN DWORD Flags);
+FUNC_NAME(WdmAudGetCapabilities)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _Out_ PVOID Capabilities,
+    _In_  DWORD CapabilitiesSize);
 
 MMRESULT
-WdmAudSetWaveDeviceFormatByLegacy(
-    IN  PSOUND_DEVICE_INSTANCE Instance,
-    IN  DWORD DeviceId,
-    IN  PWAVEFORMATEX WaveFormat,
-    IN  DWORD WaveFormatSize);
+FUNC_NAME(WdmAudOpenSoundDevice)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEFORMATEX WaveFormat);
 
 MMRESULT
-WdmAudSetWaveStateByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN BOOL bStart);
+FUNC_NAME(WdmAudCloseSoundDevice)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PVOID Handle);
 
 MMRESULT
-WdmAudResetStreamByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMDEVICE_TYPE DeviceType,
-    IN  BOOLEAN bStartReset);
+FUNC_NAME(WdmAudQueryMixerInfo)(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ DWORD DeviceId,
+    _In_ UINT uMsg,
+    _In_ LPVOID Parameter,
+    _In_ DWORD Flags);
 
 MMRESULT
-WdmAudGetWavePositionByLegacy(
-    IN  struct _SOUND_DEVICE_INSTANCE* SoundDeviceInstance,
-    IN  MMTIME* Time);
+FUNC_NAME(WdmAudSetWaveState)(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ BOOL bStart);
 
 MMRESULT
-WriteFileEx_Committer2(
-    IN  PSOUND_DEVICE_INSTANCE SoundDeviceInstance,
-    IN  PVOID OffsetPtr,
-    IN  DWORD Length,
-    IN  PSOUND_OVERLAPPED Overlap,
-    IN  LPOVERLAPPED_COMPLETION_ROUTINE CompletionRoutine);
+FUNC_NAME(WdmAudSubmitWaveHeader)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEHDR WaveHeader);
 
 MMRESULT
-WdmAudGetNumWdmDevsByLegacy(
-    IN  MMDEVICE_TYPE DeviceType,
-    OUT DWORD* DeviceCount);
+FUNC_NAME(WdmAudResetStream)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  BOOL bStartReset);
+
+MMRESULT
+FUNC_NAME(WdmAudGetWavePosition)(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  MMTIME* Time);
+
+MMRESULT
+FUNC_NAME(WdmAudGetNumWdmDevs)(
+    _In_  SOUND_DEVICE_TYPE DeviceType,
+    _Out_ DWORD* DeviceCount);
+
+/*
+    reentrancy.c
+*/
+
+MMRESULT
+InitEntrypointMutexes(VOID);
+
+VOID
+CleanupEntrypointMutexes(VOID);
+
+VOID
+AcquireEntrypointMutex(
+    _In_  SOUND_DEVICE_TYPE DeviceType);
+
+VOID
+ReleaseEntrypointMutex(
+    _In_  SOUND_DEVICE_TYPE DeviceType);
+
+/*
+    mmewrap.c
+*/
+
+VOID
+NotifyMmeClient(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  UINT Message,
+    _In_  DWORD_PTR Parameter);
 
 DWORD
-WINAPI
-MixerEventThreadRoutine(
-    LPVOID Parameter);
+MmeGetNumDevs(
+    _In_ SOUND_DEVICE_TYPE DeviceType);
+
+MMRESULT
+MmeGetSoundDeviceCapabilities(
+    _In_  SOUND_DEVICE_TYPE DeviceType,
+    _In_  DWORD DeviceId,
+    _In_  PVOID Capabilities,
+    _In_  DWORD CapabilitiesSize);
+
+MMRESULT
+MmeOpenDevice(
+    _In_  SOUND_DEVICE_TYPE DeviceType,
+    _In_  UINT DeviceId,
+    _In_  LPWAVEOPENDESC OpenParameters,
+    _In_  DWORD Flags,
+    _Out_ DWORD_PTR* PrivateHandle);
+
+MMRESULT
+MmeCloseDevice(
+    _In_  DWORD_PTR PrivateHandle);
+
+MMRESULT
+MmeGetPosition(
+    _In_  DWORD_PTR PrivateHandle,
+    _In_  MMTIME* Time,
+    _In_  DWORD Size);
+
+MMRESULT
+MmeSetState(
+    _In_  DWORD_PTR PrivateHandle,
+    _In_  BOOL bStart);
+
+
+#define MmePrepareWaveHeader(private_handle, header) \
+    PrepareWaveHeader((PWDMAUD_DEVICE_INFO)private_handle, (PWAVEHDR)header)
+
+#define MmeUnprepareWaveHeader(private_handle, header) \
+    UnprepareWaveHeader((PWDMAUD_DEVICE_INFO)private_handle, (PWAVEHDR)header)
+
+#define MmeWriteWaveHeader(private_handle, header) \
+    WriteWaveHeader((PWDMAUD_DEVICE_INFO)private_handle, (PWAVEHDR)header)
+
+MMRESULT
+MmeResetWavePlayback(
+    _In_  DWORD_PTR PrivateHandle);
+
+/*
+    result.c
+*/
+
+MMRESULT
+Win32ErrorToMmResult(
+    _In_  UINT ErrorCode);
+
+MMRESULT
+TranslateInternalMmResult(
+    _In_  MMRESULT Result);
+
+/*
+    header.c
+*/
+
+MMRESULT
+EnqueueWaveHeader(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEHDR Header);
+
+VOID
+CompleteWaveHeader(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo);
+
+MMRESULT
+PrepareWaveHeader(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEHDR Header);
+
+MMRESULT
+UnprepareWaveHeader(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEHDR Header);
+
+MMRESULT
+WriteWaveHeader(
+    _In_  PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_  PWAVEHDR Header);
+
+/*
+    streaming.c
+*/
+
+MMRESULT
+DoWaveStreaming(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo,
+    _In_ PWAVEHDR Header);
+
+MMRESULT
+StopStreaming(
+    _In_ PWDMAUD_DEVICE_INFO DeviceInfo);
+
+
+/*
+    Convert a device type into a zero-based array index
+ */
+
+#define SOUND_DEVICE_TYPE_TO_INDEX(x) \
+    ( x - MIN_SOUND_DEVICE_TYPE )
+
+#define INDEX_TO_SOUND_DEVICE_TYPE(x) \
+    ( x + MIN_SOUND_DEVICE_TYPE )
+
+/*
+    Validation
+*/
+
+#define VALIDATE_MMSYS_PARAMETER(parameter_condition) \
+    { \
+        if ( ! (parameter_condition) ) \
+        { \
+            DPRINT1("FAILED parameter check: %hS at File %S Line %lu\n", #parameter_condition, __FILE__, __LINE__); \
+            return MMSYSERR_INVALPARAM; \
+        } \
+    }
+
+#define MMSUCCESS(result) \
+    ( result == MMSYSERR_NOERROR )
+
 
 #endif /* __WDMAUD_H__ */

--- a/dll/win32/wdmaud.drv/wdmaud.spec
+++ b/dll/win32/wdmaud.drv/wdmaud.spec
@@ -4,3 +4,4 @@
 @ stdcall wodMessage(long long long long long)
 @ stdcall widMessage(long long long long long)
 @ stdcall modMessage(long long long long long)
+@ stdcall midMessage(long long long long long)

--- a/drivers/wdm/audio/backpln/CMakeLists.txt
+++ b/drivers/wdm/audio/backpln/CMakeLists.txt
@@ -1,3 +1,3 @@
 
-add_subdirectory(audio_test)
+#add_subdirectory(audio_test)
 add_subdirectory(portcls)

--- a/drivers/wdm/audio/legacy/wdmaud/control.c
+++ b/drivers/wdm/audio/legacy/wdmaud/control.c
@@ -9,10 +9,39 @@
 
 #include "wdmaud.h"
 
-#define NDEBUG
+#define YDEBUG
 #include <debug.h>
 
 const GUID KSPROPSETID_Sysaudio                 = {0xCBE3FAA0L, 0xCC75, 0x11D0, {0xB4, 0x65, 0x00, 0x00, 0x1A, 0x18, 0x18, 0xE6}};
+
+NTSTATUS
+WdmAudControlInitialize(
+    IN  PDEVICE_OBJECT DeviceObject,
+    IN  PIRP Irp)
+{
+    NTSTATUS Status;
+    LPWSTR SymbolicLinkList;
+    PWDMAUD_DEVICE_EXTENSION DeviceExtension;
+
+    /* Get device extension */
+    DeviceExtension = (PWDMAUD_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
+
+    /* Get SysAudio device interface */
+    Status = GetSysAudioDeviceInterface(&SymbolicLinkList);
+    if (NT_SUCCESS(Status))
+    {
+        /* Wait for initialization finishing */
+        KeWaitForSingleObject(&DeviceExtension->InitializationCompletionEvent,
+                              Executive,
+                              KernelMode,
+                              FALSE,
+                              NULL);
+    }
+
+    ExFreePool(SymbolicLinkList);
+
+    return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
+}
 
 NTSTATUS
 WdmAudControlOpen(
@@ -21,23 +50,31 @@ WdmAudControlOpen(
     IN  PWDMAUD_DEVICE_INFO DeviceInfo,
     IN  PWDMAUD_CLIENT ClientInfo)
 {
+    PWDMAUD_DEVICE_EXTENSION DeviceExtension;
+    NTSTATUS Status;
+
+    DeviceExtension = (PWDMAUD_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
+
+    Status = WdmAudOpenSysAudioDevices(DeviceObject, DeviceExtension);
+    if (!NT_SUCCESS(Status))
+    {
+        return SetIrpIoStatus(Irp, Status, 0);
+    }
+
     if (DeviceInfo->DeviceType == MIXER_DEVICE_TYPE)
     {
-        return WdmAudControlOpenMixer(DeviceObject, Irp, DeviceInfo, ClientInfo);
+        Status = WdmAudControlOpenMixer(DeviceObject, Irp, DeviceInfo, ClientInfo);
     }
-
-    if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE || DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
+    else if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE || DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE)
     {
-        return WdmAudControlOpenWave(DeviceObject, Irp, DeviceInfo, ClientInfo);
+        Status = WdmAudControlOpenWave(DeviceObject, Irp, DeviceInfo, ClientInfo);
     }
-
-    if (DeviceInfo->DeviceType == MIDI_OUT_DEVICE_TYPE || DeviceInfo->DeviceType == MIDI_IN_DEVICE_TYPE)
+    else if (DeviceInfo->DeviceType == MIDI_OUT_DEVICE_TYPE || DeviceInfo->DeviceType == MIDI_IN_DEVICE_TYPE)
     {
-        return WdmAudControlOpenMidi(DeviceObject, Irp, DeviceInfo, ClientInfo);
+        Status = WdmAudControlOpenMidi(DeviceObject, Irp, DeviceInfo, ClientInfo);
     }
 
-
-    return SetIrpIoStatus(Irp, STATUS_NOT_SUPPORTED, sizeof(WDMAUD_DEVICE_INFO));
+    return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
 }
 
 NTSTATUS
@@ -72,46 +109,10 @@ WdmAudControlDeviceType(
 
 
     /* store result count */
-    DeviceInfo->DeviceCount = Result;
+    DeviceInfo->DeviceIndex = Result;
 
-    DPRINT("WdmAudControlDeviceType Devices %u\n", DeviceInfo->DeviceCount);
+    DPRINT("WdmAudControlDeviceType Devices %u\n", DeviceInfo->DeviceIndex);
     return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
-}
-
-NTSTATUS
-WdmAudControlDeviceState(
-    IN  PDEVICE_OBJECT DeviceObject,
-    IN  PIRP Irp,
-    IN  PWDMAUD_DEVICE_INFO DeviceInfo,
-    IN  PWDMAUD_CLIENT ClientInfo)
-{
-    KSPROPERTY Property;
-    KSSTATE State;
-    NTSTATUS Status;
-    ULONG BytesReturned;
-    PFILE_OBJECT FileObject;
-
-    DPRINT("WdmAudControlDeviceState\n");
-
-    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice, GENERIC_READ | GENERIC_WRITE, *IoFileObjectType, KernelMode, (PVOID*)&FileObject, NULL);
-    if (!NT_SUCCESS(Status))
-    {
-        DPRINT1("Error: invalid device handle provided %p Type %x\n", DeviceInfo->hDevice, DeviceInfo->DeviceType);
-        return SetIrpIoStatus(Irp, STATUS_UNSUCCESSFUL, 0);
-    }
-
-    Property.Set = KSPROPSETID_Connection;
-    Property.Id = KSPROPERTY_CONNECTION_STATE;
-    Property.Flags = KSPROPERTY_TYPE_SET;
-
-    State = DeviceInfo->u.State;
-
-    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&State, sizeof(KSSTATE), &BytesReturned);
-
-    ObDereferenceObject(FileObject);
-
-    DPRINT("WdmAudControlDeviceState Status %x\n", Status);
-    return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
 }
 
 NTSTATUS
@@ -160,9 +161,9 @@ WdmAudIoctlClose(
         {
             DPRINT1("Closing device %p\n", DeviceInfo->hDevice);
             ZwClose(DeviceInfo->hDevice);
+            DeviceInfo->hDevice = NULL;
             ClientInfo->hPins[Index].Handle = NULL;
-            SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
-            return STATUS_SUCCESS;
+            return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
         }
         else if (ClientInfo->hPins[Index].Handle == DeviceInfo->hDevice && ClientInfo->hPins[Index].Type == MIXER_DEVICE_TYPE)
         {
@@ -171,97 +172,74 @@ WdmAudIoctlClose(
         }
     }
 
-    SetIrpIoStatus(Irp, STATUS_INVALID_PARAMETER, sizeof(WDMAUD_DEVICE_INFO));
-    return STATUS_INVALID_PARAMETER;
+    return SetIrpIoStatus(Irp, STATUS_INVALID_PARAMETER, sizeof(WDMAUD_DEVICE_INFO));
 }
 
 NTSTATUS
-NTAPI
-WdmAudFrameSize(
+WdmAudSetDeviceState(
     IN  PDEVICE_OBJECT DeviceObject,
     IN  PIRP Irp,
     IN  PWDMAUD_DEVICE_INFO DeviceInfo,
     IN  PWDMAUD_CLIENT ClientInfo)
 {
-    PFILE_OBJECT FileObject;
+    KSSTATE State;
+    NTSTATUS Status;
     KSPROPERTY Property;
     ULONG BytesReturned;
-    KSALLOCATOR_FRAMING Framing;
-    NTSTATUS Status;
+    PFILE_OBJECT FileObject;
 
-    /* Get sysaudio pin file object */
-    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice, GENERIC_WRITE, *IoFileObjectType, KernelMode, (PVOID*)&FileObject, NULL);
+    DPRINT("WdmAudControlDeviceState\n");
+
+    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice, GENERIC_READ | GENERIC_WRITE, *IoFileObjectType, KernelMode, (PVOID*)&FileObject, NULL);
     if (!NT_SUCCESS(Status))
     {
-        DPRINT1("Invalid buffer handle %p\n", DeviceInfo->hDevice);
+        DPRINT1("Error: invalid device handle provided %p Type %x\n", DeviceInfo->hDevice, DeviceInfo->DeviceType);
+        return SetIrpIoStatus(Irp, STATUS_UNSUCCESSFUL, 0);
+    }
+
+    Property.Set = KSPROPSETID_Connection;
+    Property.Id = KSPROPERTY_CONNECTION_STATE;
+    Property.Flags = KSPROPERTY_TYPE_SET;
+
+    State = DeviceInfo->DeviceState->bStart ? KSSTATE_ACQUIRE : KSSTATE_PAUSE;
+    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&State, sizeof(KSSTATE), &BytesReturned);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("%ls failed with status 0x%lx\n",
+                DeviceInfo->DeviceState->bStart ?
+                L"KSSTATE_ACQUIRE" : L"KSSTATE_PAUSE",
+                Status);
+        ObDereferenceObject(FileObject);
         return SetIrpIoStatus(Irp, Status, 0);
     }
 
-    /* Setup get framing request */
-    Property.Id = KSPROPERTY_CONNECTION_ALLOCATORFRAMING;
-    Property.Flags = KSPROPERTY_TYPE_GET;
-    Property.Set = KSPROPSETID_Connection;
-
-    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&Framing, sizeof(KSALLOCATOR_FRAMING), &BytesReturned);
-    /* Did we succeed */
-    if (NT_SUCCESS(Status))
+    State = DeviceInfo->DeviceState->bStart ? KSSTATE_PAUSE : KSSTATE_ACQUIRE;
+    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&State, sizeof(KSSTATE), &BytesReturned);
+    if (!NT_SUCCESS(Status))
     {
-        /* Store framesize */
-        DeviceInfo->u.FrameSize = Framing.FrameSize;
+        DPRINT1("%ls failed with status 0x%lx\n",
+                DeviceInfo->DeviceState->bStart ?
+                L"KSSTATE_PAUSE" : L"KSSTATE_ACQUIRE",
+                Status);
+        ObDereferenceObject(FileObject);
+        return SetIrpIoStatus(Irp, Status, 0);
     }
 
-    /* Release file object */
+    State = DeviceInfo->DeviceState->bStart ? KSSTATE_RUN : KSSTATE_STOP;
+    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&State, sizeof(KSSTATE), &BytesReturned);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("%ls failed with status 0x%lx\n",
+                DeviceInfo->DeviceState->bStart ?
+                L"KSSTATE_RUN" : L"KSSTATE_STOP",
+                Status);
+        ObDereferenceObject(FileObject);
+        return SetIrpIoStatus(Irp, Status, 0);
+    }
+
     ObDereferenceObject(FileObject);
 
-    return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
-
-}
-
-NTSTATUS
-NTAPI
-WdmAudGetDeviceInterface(
-    IN  PDEVICE_OBJECT DeviceObject,
-    IN  PIRP Irp,
-    IN  PWDMAUD_DEVICE_INFO DeviceInfo)
-{
-    NTSTATUS Status;
-    LPWSTR Device;
-    ULONG Size, Length;
-
-    /* get device interface string input length */
-    Size = DeviceInfo->u.Interface.DeviceInterfaceStringSize;
-
-   /* get mixer info */
-   Status = WdmAudGetPnpNameByIndexAndType(DeviceInfo->DeviceIndex, DeviceInfo->DeviceType, &Device);
-
-   /* check for success */
-   if (!NT_SUCCESS(Status))
-   {
-        /* invalid device id */
-        return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
-   }
-
-   /* calculate length */
-   Length = (wcslen(Device)+1) * sizeof(WCHAR);
-
-    if (!Size)
-    {
-        /* store device interface size */
-        DeviceInfo->u.Interface.DeviceInterfaceStringSize = Length;
-    }
-    else if (Size < Length)
-    {
-        /* buffer too small */
-        DeviceInfo->u.Interface.DeviceInterfaceStringSize = Length;
-        return SetIrpIoStatus(Irp, STATUS_BUFFER_OVERFLOW, sizeof(WDMAUD_DEVICE_INFO));
-    }
-    else
-    {
-        //FIXME SEH
-        RtlMoveMemory(DeviceInfo->u.Interface.DeviceInterfaceString, Device, Length);
-    }
-
-    FreeItem(Device);
+    DPRINT("WdmAudControlDeviceState Status 0x%lx BytesReturned %lu\n", Status, BytesReturned);
     return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
 }
 
@@ -272,8 +250,10 @@ WdmAudResetStream(
     IN  PIRP Irp,
     IN  PWDMAUD_DEVICE_INFO DeviceInfo)
 {
-    KSRESET ResetStream;
+    KSSTATE State;
     NTSTATUS Status;
+    KSRESET ResetStream;
+    KSPROPERTY Property;
     ULONG BytesReturned;
     PFILE_OBJECT FileObject;
 
@@ -286,15 +266,307 @@ WdmAudResetStream(
         return SetIrpIoStatus(Irp, STATUS_UNSUCCESSFUL, 0);
     }
 
-    ResetStream = DeviceInfo->u.ResetStream;
-    ASSERT(ResetStream == KSRESET_BEGIN || ResetStream == KSRESET_END);
+    Property.Set = KSPROPSETID_Connection;
+    Property.Id = KSPROPERTY_CONNECTION_STATE;
+    Property.Flags = KSPROPERTY_TYPE_SET;
 
-    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_RESET_STATE, (PVOID)&ResetStream, sizeof(KSRESET), NULL, 0, &BytesReturned);
+    State = DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ? KSSTATE_PAUSE : KSSTATE_STOP;
+
+    Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Property, sizeof(KSPROPERTY), (PVOID)&State, sizeof(KSSTATE), &BytesReturned);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("%ls failed with status 0x%lx\n",
+                DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                L"KSSTATE_PAUSE" : L"KSSTATE_STOP",
+                Status);
+        ObDereferenceObject(FileObject);
+        return SetIrpIoStatus(Irp, Status, 0);
+    }
+
+    if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+    {
+        ResetStream = KSRESET_BEGIN;
+        Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_RESET_STATE, (PVOID)&ResetStream, sizeof(KSRESET), NULL, 0, &BytesReturned);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("KSRESET_BEGIN failed with status 0x%lx\n", Status);
+            ObDereferenceObject(FileObject);
+            return SetIrpIoStatus(Irp, Status, 0);
+        }
+        ResetStream = KSRESET_END;
+        Status = KsSynchronousIoControlDevice(FileObject, KernelMode, IOCTL_KS_RESET_STATE, (PVOID)&ResetStream, sizeof(KSRESET), NULL, 0, &BytesReturned);
+        if (!NT_SUCCESS(Status))
+        {
+            DPRINT1("KSRESET_END failed with status 0x%lx\n", Status);
+            ObDereferenceObject(FileObject);
+            return SetIrpIoStatus(Irp, Status, 0);
+        }
+    }
 
     ObDereferenceObject(FileObject);
 
-    DPRINT("WdmAudResetStream Status %x\n", Status);
-    return SetIrpIoStatus(Irp, Status, sizeof(WDMAUD_DEVICE_INFO));
+    DPRINT("WdmAudResetStream Status 0x%lx BytesReturned %lu\n", Status, BytesReturned);
+    return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
+}
+
+NTSTATUS
+NTAPI
+IoCompletion (
+    PDEVICE_OBJECT DeviceObject,
+    PIRP Irp,
+    PVOID Ctx)
+{
+    PKSSTREAM_HEADER Header;
+    PMDL Mdl, NextMdl;
+    PWDMAUD_COMPLETION_CONTEXT Context = (PWDMAUD_COMPLETION_CONTEXT)Ctx;
+
+    /* Get stream header */
+    Header = (PKSSTREAM_HEADER)Irp->UserBuffer;
+
+    /* Sanity check */
+    ASSERT(Header);
+
+    /* Time to free all allocated mdls */
+    Mdl = Irp->MdlAddress;
+
+    while(Mdl)
+    {
+        /* Get next mdl */
+        NextMdl = Mdl->Next;
+
+        /* Unlock pages */
+        MmUnlockPages(Mdl);
+
+        /* Grab next mdl */
+        Mdl = NextMdl;
+    }
+
+    /* Clear mdl list */
+    Irp->MdlAddress = Context->Mdl;
+
+    DPRINT("IoCompletion Irp %p IoStatus %lx Information %lx\n", Irp, Irp->IoStatus.Status, Irp->IoStatus.Information);
+
+    if (!NT_SUCCESS(Irp->IoStatus.Status))
+    {
+        /* failed */
+        Irp->IoStatus.Information = 0;
+    }
+
+    /* Free context */
+    FreeItem(Context);
+
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+NTAPI
+WdmAudReadWriteInQueue(
+    IN  PDEVICE_OBJECT DeviceObject,
+    IN  PIRP Irp)
+{
+    NTSTATUS Status;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+    PKSSTREAM_HEADER StreamHeader;
+    PFILE_OBJECT FileObject;
+    PIO_STACK_LOCATION IoStack;
+    PWAVEHDR WaveHeader;
+    PMDL Mdl;
+    PWDMAUD_COMPLETION_CONTEXT Context;
+
+    /* get device info */
+    DeviceInfo = (PWDMAUD_DEVICE_INFO)Irp->AssociatedIrp.SystemBuffer;
+    ASSERT(DeviceInfo);
+
+    /* Get queued wave header passed by the caller */
+    WaveHeader = (PWAVEHDR)DeviceInfo->DeviceState->WaveQueue;
+
+    /* Allocate stream header */
+    StreamHeader = AllocateItem(NonPagedPool, sizeof(KSSTREAM_HEADER));
+    if (!StreamHeader)
+    {
+        /* Not enough memory */
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    StreamHeader->Size = sizeof(KSSTREAM_HEADER);
+    StreamHeader->PresentationTime.Numerator = 1;
+    StreamHeader->PresentationTime.Denominator = 1;
+    StreamHeader->Data = WaveHeader->lpData;
+    StreamHeader->FrameExtent = WaveHeader->dwBufferLength;
+
+    if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+    {
+        StreamHeader->DataUsed = WaveHeader->dwBufferLength;
+    }
+    else
+    {
+        StreamHeader->DataUsed = 0;
+    }
+
+    /* allocate completion context */
+    Context = AllocateItem(NonPagedPool, sizeof(WDMAUD_COMPLETION_CONTEXT));
+
+    if (!Context)
+    {
+        /* not enough memory */
+        FreeItem(StreamHeader);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* store the input buffer in UserBuffer */
+    Irp->UserBuffer = StreamHeader;
+
+    /* sanity check */
+    ASSERT(Irp->UserBuffer);
+
+    /* setup context */
+    Context->Length = sizeof(KSSTREAM_HEADER);
+    Context->Function = (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ? IOCTL_KS_WRITE_STREAM : IOCTL_KS_READ_STREAM);
+    Context->Mdl = Irp->MdlAddress;
+
+    /* store mdl address */
+    Mdl = Irp->MdlAddress;
+
+    /* remove mdl address */
+    Irp->MdlAddress = NULL;
+
+    /* now get sysaudio file object */
+    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice,
+                                       DeviceInfo->DeviceType ==
+                                       WAVE_OUT_DEVICE_TYPE ?
+                                       FILE_WRITE_DATA : FILE_READ_DATA,
+                                       NULL,
+                                       KernelMode,
+                                       (PVOID*)&FileObject,
+                                       NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ObReferenceObjectByHandle failed with status 0x%lx for pin handle %p\n", Status, DeviceInfo->hDevice);
+        Irp->MdlAddress = Mdl;
+        FreeItem(Context);
+        FreeItem(StreamHeader);
+        return SetIrpIoStatus(Irp, Status, 0);
+    }
+
+    /* store file object whose reference is released in the completion callback */
+    Context->FileObject = FileObject;
+
+    /* get next stack location */
+    IoStack = IoGetNextIrpStackLocation(Irp);
+
+    /* prepare stack location */
+    IoStack->FileObject = FileObject;
+    IoStack->MajorFunction = IRP_MJ_DEVICE_CONTROL;
+    IoStack->Parameters.DeviceIoControl.OutputBufferLength = sizeof(KSSTREAM_HEADER);
+    IoStack->Parameters.DeviceIoControl.IoControlCode = (DeviceInfo->DeviceType == WAVE_IN_DEVICE_TYPE ? IOCTL_KS_READ_STREAM : IOCTL_KS_WRITE_STREAM);
+    IoSetCompletionRoutine(Irp, IoCompletion, (PVOID)Context, TRUE, TRUE, TRUE);
+
+    /* call the driver */
+    return IoCallDriver(IoGetRelatedDeviceObject(FileObject), Irp);
+}
+
+NTSTATUS
+NTAPI
+WdmAudReadWrite(
+    IN  PDEVICE_OBJECT DeviceObject,
+    IN  PIRP Irp)
+{
+    PKSSTREAM_HEADER StreamHeader;
+    PFILE_OBJECT FileObject;
+    PWAVEHDR WaveHeader;
+    NTSTATUS Status;
+    PWDMAUD_DEVICE_INFO DeviceInfo;
+    PWDMAUD_COMPLETION_CONTEXT Context;
+
+    /* Get device info */
+    DeviceInfo = (PWDMAUD_DEVICE_INFO)Irp->AssociatedIrp.SystemBuffer;
+
+    /* Get wave header passed by the caller */
+    WaveHeader = (PWAVEHDR)DeviceInfo->Buffer;
+
+    /* Allocate stream header */
+    StreamHeader = AllocateItem(NonPagedPool, sizeof(KSSTREAM_HEADER));
+    if (!StreamHeader)
+    {
+        /* Not enough memory */
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    StreamHeader->Size = sizeof(KSSTREAM_HEADER);
+    StreamHeader->PresentationTime.Numerator = 1;
+    StreamHeader->PresentationTime.Denominator = 1;
+    StreamHeader->Data = WaveHeader->lpData;
+    StreamHeader->FrameExtent = WaveHeader->dwBufferLength;
+
+    if (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE)
+    {
+        StreamHeader->DataUsed = WaveHeader->dwBufferLength;
+    }
+    else
+    {
+        StreamHeader->DataUsed = 0;
+    }
+
+    /* Allocate completion context */
+    Context = AllocateItem(NonPagedPool, sizeof(WDMAUD_COMPLETION_CONTEXT));
+    if (!Context)
+    {
+        /* Not enough memory */
+        FreeItem(StreamHeader);
+        return STATUS_INSUFFICIENT_RESOURCES;
+    }
+
+    /* Get sysaudio file object */
+    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice,
+                                       DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                                       FILE_WRITE_DATA : FILE_READ_DATA,
+                                       NULL,
+                                       KernelMode,
+                                       (PVOID*)&FileObject,
+                                       NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("ObReferenceObjectByHandle failed with 0x%lx for %p\n", Status, DeviceInfo->hDevice);
+        FreeItem(Context);
+        FreeItem(StreamHeader);
+        return Status;
+    }
+
+    /* Setup context */
+    Context->Length = sizeof(KSSTREAM_HEADER);
+    Context->Function = (DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ? IOCTL_KS_WRITE_STREAM : IOCTL_KS_READ_STREAM);
+    Context->Mdl = Irp->MdlAddress;
+
+    /* Store file object */
+    Context->FileObject = FileObject;
+
+    /* Clear mdl address */
+    Irp->MdlAddress = NULL;
+
+    /* Do the streaming */
+    Status = KsStreamIo(FileObject,
+                        NULL,
+                        NULL,
+                        IoCompletion,
+                        Context,
+                        KsInvokeOnSuccess | KsInvokeOnError | KsInvokeOnCancel,
+                        Irp->UserIosb,
+                        StreamHeader,
+                        sizeof(KSSTREAM_HEADER),
+                        DeviceInfo->DeviceType == WAVE_OUT_DEVICE_TYPE ?
+                        KSSTREAM_WRITE : KSSTREAM_READ,
+                        KernelMode);
+
+    if (!NT_SUCCESS(Status))
+    {
+        DPRINT1("KsStreamIo failed with Status 0x%lx\n", Status);
+        FreeItem(Context);
+        FreeItem(StreamHeader);
+        return Status;
+    }
+
+    /* Done */
+    return STATUS_SUCCESS;
 }
 
 NTSTATUS
@@ -310,6 +582,7 @@ WdmAudDeviceControl(
     IoStack = IoGetCurrentIrpStackLocation(Irp);
 
     DPRINT("WdmAudDeviceControl entered\n");
+    DPRINT("IOCTL 0x%lx\n", IoStack->Parameters.DeviceIoControl.IoControlCode);
 
     if (IoStack->Parameters.DeviceIoControl.InputBufferLength < sizeof(WDMAUD_DEVICE_INFO))
     {
@@ -335,22 +608,24 @@ WdmAudDeviceControl(
     }
     ClientInfo = (PWDMAUD_CLIENT)IoStack->FileObject->FsContext;
 
-    DPRINT("WdmAudDeviceControl entered\n");
-
     switch(IoStack->Parameters.DeviceIoControl.IoControlCode)
     {
+        case IOCTL_INIT_WDMAUD:
+            return WdmAudControlInitialize(DeviceObject, Irp);
+        case IOCTL_EXIT_WDMAUD:
+            /* No op */
+            return SetIrpIoStatus(Irp, STATUS_SUCCESS, sizeof(WDMAUD_DEVICE_INFO));
         case IOCTL_OPEN_WDMAUD:
+        case IOCTL_OPEN_MIXER:
             return WdmAudControlOpen(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_GETNUMDEVS_TYPE:
             return WdmAudControlDeviceType(DeviceObject, Irp, DeviceInfo, ClientInfo);
-        case IOCTL_SETDEVICE_STATE:
-            return WdmAudControlDeviceState(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_GETCAPABILITIES:
             return WdmAudCapabilities(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_CLOSE_WDMAUD:
             return WdmAudIoctlClose(DeviceObject, Irp, DeviceInfo, ClientInfo);
-        case IOCTL_GETFRAMESIZE:
-            return WdmAudFrameSize(DeviceObject, Irp, DeviceInfo, ClientInfo);
+        case IOCTL_GET_MIXER_EVENT:
+            return WdmAudGetMixerEvent(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_GETLINEINFO:
             return WdmAudGetLineInfo(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_GETLINECONTROLS:
@@ -359,185 +634,29 @@ WdmAudDeviceControl(
             return WdmAudSetControlDetails(DeviceObject, Irp, DeviceInfo, ClientInfo);
         case IOCTL_GETCONTROLDETAILS:
             return WdmAudGetControlDetails(DeviceObject, Irp, DeviceInfo, ClientInfo);
-        case IOCTL_QUERYDEVICEINTERFACESTRING:
-            return WdmAudGetDeviceInterface(DeviceObject, Irp, DeviceInfo);
-        case IOCTL_GET_MIXER_EVENT:
-            return WdmAudGetMixerEvent(DeviceObject, Irp, DeviceInfo, ClientInfo);
-        case IOCTL_RESET_STREAM:
+        case IOCTL_RESET_CAPTURE:
+        case IOCTL_RESET_PLAYBACK:
             return WdmAudResetStream(DeviceObject, Irp, DeviceInfo);
-        case IOCTL_GETPOS:
-        case IOCTL_GETDEVID:
+        case IOCTL_GETINPOS:
+        case IOCTL_GETOUTPOS:
+            return WdmAudGetPosition(DeviceObject, Irp, DeviceInfo);
+        case IOCTL_PAUSE_CAPTURE:
+        case IOCTL_START_CAPTURE:
+        case IOCTL_PAUSE_PLAYBACK:
+        case IOCTL_START_PLAYBACK:
+            return WdmAudSetDeviceState(DeviceObject, Irp, DeviceInfo, ClientInfo);
+        case IOCTL_READDATA:
+        case IOCTL_WRITEDATA:
+            return WdmAudReadWrite(DeviceObject, Irp);
+        case IOCTL_ADD_DEVNODE:
+        case IOCTL_REMOVE_DEVNODE:
         case IOCTL_GETVOLUME:
         case IOCTL_SETVOLUME:
 
-           DPRINT1("Unhandled %x\n", IoStack->Parameters.DeviceIoControl.IoControlCode);
+        default:
+           DPRINT1("Unhandled 0x%x\n", IoStack->Parameters.DeviceIoControl.IoControlCode);
            break;
     }
 
     return SetIrpIoStatus(Irp, STATUS_NOT_IMPLEMENTED, 0);
-}
-
-NTSTATUS
-NTAPI
-IoCompletion (
-    PDEVICE_OBJECT DeviceObject,
-    PIRP Irp,
-    PVOID Ctx)
-{
-    PKSSTREAM_HEADER Header;
-    PMDL Mdl, NextMdl;
-    PWDMAUD_COMPLETION_CONTEXT Context = (PWDMAUD_COMPLETION_CONTEXT)Ctx;
-
-    /* get stream header */
-    Header = (PKSSTREAM_HEADER)Irp->AssociatedIrp.SystemBuffer;
-
-    /* sanity check */
-    ASSERT(Header);
-
-    /* time to free all allocated mdls */
-    Mdl = Irp->MdlAddress;
-
-    while(Mdl)
-    {
-        /* get next mdl */
-        NextMdl = Mdl->Next;
-
-        /* unlock pages */
-        MmUnlockPages(Mdl);
-
-        /* grab next mdl */
-        Mdl = NextMdl;
-    }
-    //IoFreeMdl(Mdl);
-    /* clear mdl list */
-    Irp->MdlAddress = Context->Mdl;
-
-
-
-    DPRINT("IoCompletion Irp %p IoStatus %lx Information %lx\n", Irp, Irp->IoStatus.Status, Irp->IoStatus.Information);
-
-    if (!NT_SUCCESS(Irp->IoStatus.Status))
-    {
-        /* failed */
-        Irp->IoStatus.Information = 0;
-    }
-
-    /* dereference file object */
-    ObDereferenceObject(Context->FileObject);
-
-    /* free context */
-    FreeItem(Context);
-
-    return STATUS_SUCCESS;
-}
-
-NTSTATUS
-NTAPI
-WdmAudReadWrite(
-    IN  PDEVICE_OBJECT DeviceObject,
-    IN  PIRP Irp)
-{
-    NTSTATUS Status;
-    PWDMAUD_DEVICE_INFO DeviceInfo;
-    PFILE_OBJECT FileObject;
-    PIO_STACK_LOCATION IoStack;
-    ULONG Length;
-    PMDL Mdl;
-    BOOLEAN Read = TRUE;
-    PWDMAUD_COMPLETION_CONTEXT Context;
-
-    /* allocate completion context */
-    Context = AllocateItem(NonPagedPool, sizeof(WDMAUD_COMPLETION_CONTEXT));
-
-    if (!Context)
-    {
-        /* not enough memory */
-        Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
-        IoCompleteRequest(Irp, IO_NO_INCREMENT);
-
-        /* done */
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    /* get current irp stack location */
-    IoStack = IoGetCurrentIrpStackLocation(Irp);
-
-    /* store the input buffer in UserBuffer - as KsProbeStreamIrp operates on IRP_MJ_DEVICE_CONTROL */
-    Irp->UserBuffer = MmGetMdlVirtualAddress(Irp->MdlAddress);
-
-    /* sanity check */
-    ASSERT(Irp->UserBuffer);
-
-    /* get the length of the request length */
-    Length = IoStack->Parameters.Write.Length;
-
-    /* store outputbuffer length */
-    IoStack->Parameters.DeviceIoControl.OutputBufferLength = Length;
-
-    /* setup context */
-    Context->Length = Length;
-    Context->Function = (IoStack->MajorFunction == IRP_MJ_WRITE ? IOCTL_KS_WRITE_STREAM : IOCTL_KS_READ_STREAM);
-    Context->Mdl = Irp->MdlAddress;
-
-    /* store mdl address */
-    Mdl = Irp->MdlAddress;
-
-    /* remove mdladdress as KsProbeStreamIrp will interpret it as an already probed audio buffer */
-    Irp->MdlAddress = NULL;
-
-    if (IoStack->MajorFunction == IRP_MJ_WRITE)
-    {
-        /* probe the write stream irp */
-        Read = FALSE;
-        Status = KsProbeStreamIrp(Irp, KSPROBE_STREAMWRITE | KSPROBE_ALLOCATEMDL | KSPROBE_PROBEANDLOCK, Length);
-    }
-    else
-    {
-        /* probe the read stream irp */
-        Status = KsProbeStreamIrp(Irp, KSPROBE_STREAMREAD | KSPROBE_ALLOCATEMDL | KSPROBE_PROBEANDLOCK, Length);
-    }
-
-    if (!NT_SUCCESS(Status))
-    {
-        DPRINT1("KsProbeStreamIrp failed with Status %x Cancel %u\n", Status, Irp->Cancel);
-        Irp->MdlAddress = Mdl;
-        FreeItem(Context);
-        return SetIrpIoStatus(Irp, Status, 0);
-    }
-
-    /* get device info */
-    DeviceInfo = (PWDMAUD_DEVICE_INFO)Irp->AssociatedIrp.SystemBuffer;
-    ASSERT(DeviceInfo);
-
-    /* now get sysaudio file object */
-    Status = ObReferenceObjectByHandle(DeviceInfo->hDevice, GENERIC_WRITE, *IoFileObjectType, KernelMode, (PVOID*)&FileObject, NULL);
-    if (!NT_SUCCESS(Status))
-    {
-        DPRINT1("Invalid pin handle %p\n", DeviceInfo->hDevice);
-        Irp->MdlAddress = Mdl;
-        FreeItem(Context);
-        return SetIrpIoStatus(Irp, Status, 0);
-    }
-
-    /* store file object whose reference is released in the completion callback */
-    Context->FileObject = FileObject;
-
-    /* skip current irp stack location */
-    IoSkipCurrentIrpStackLocation(Irp);
-
-    /* get next stack location */
-    IoStack = IoGetNextIrpStackLocation(Irp);
-
-    /* prepare stack location */
-    IoStack->FileObject = FileObject;
-    IoStack->Parameters.Write.Length = Length;
-    IoStack->MajorFunction = IRP_MJ_WRITE;
-    IoStack->Parameters.DeviceIoControl.IoControlCode = (Read ? IOCTL_KS_READ_STREAM : IOCTL_KS_WRITE_STREAM);
-    IoSetCompletionRoutine(Irp, IoCompletion, (PVOID)Context, TRUE, TRUE, TRUE);
-
-    /* mark irp as pending */
-//    IoMarkIrpPending(Irp);
-    /* call the driver */
-    Status = IoCallDriver(IoGetRelatedDeviceObject(FileObject), Irp);
-    return Status;
 }

--- a/drivers/wdm/audio/legacy/wdmaud/entry.c
+++ b/drivers/wdm/audio/legacy/wdmaud/entry.c
@@ -133,9 +133,6 @@ WdmaudAddDevice(
         return Status;
     }
 
-    /* initialize sysaudio device list */
-    InitializeListHead(&DeviceExtension->SysAudioDeviceList);
-
     /* initialize client context device list */
     InitializeListHead(&DeviceExtension->WdmAudClientList);
 

--- a/drivers/wdm/audio/legacy/wdmaud/interface.h
+++ b/drivers/wdm/audio/legacy/wdmaud/interface.h
@@ -5,110 +5,144 @@
 ///
 /// History: 12/02/2008 Created
 
-// These are now in sndtypes.h
-/*
-typedef enum
-{
-    DEVICE_TYPE_NONE = 0,
-    DEVICE_TYPE_WAVE_OUT,
-    DEVICE_TYPE_WAVE_IN,
-    DEVICE_TYPE_MIDI_IN,
-    DEVICE_TYPE_MIDI_OUT,
-    DEVICE_TYPE_AUX_IN,
-    DEVICE_TYPE_AUX_OUT
-
-}AUDIO_DEVICE_TYPE;
-*/
-
 #include <sndtypes.h>
 
+/* Fixing alignment is needed to make the struct size compatible with MS */
+#pragma pack(1)
+
+/* Contains device state management related stuff */
 typedef struct
 {
-    KSSTREAM_HEADER Header;
-    SOUND_DEVICE_TYPE DeviceType;
-    ULONG_PTR DeviceIndex;
+    DWORD Samples; // Verified to match Windows XP/2003, number of samples passed. Required for TIME_SAMPLES time format.
+    HANDLE hThread; // Verified to match Windows XP/2003, the sound thread handle.
+    DWORD unk2;
 
-    HANDLE hDevice;
-    ULONG DeviceCount;
-    ULONG Flags;
+    LPWAVEHDR WaveQueue; // Verified to match Windows XP/2003, wave queue header.
+    LPMIDIHDR MidiQueue; // Verified to match Windows XP/2003, midi queue header.
 
-    union
-    {
-        MIXERCAPSW    MixCaps;
-        MIXERCONTROLDETAILS MixDetails;
-        MIXERLINECONTROLSW MixControls;
-        MIXERLINEW MixLine;
-        WAVEFORMATEX WaveFormatEx;
-        WAVEOUTCAPSW WaveOutCaps;
-        AUXCAPSW     AuxCaps;
-        WAVEINCAPSW  WaveInCaps;
-        MIDIINCAPSW  MidiInCaps;
-        MIDIOUTCAPSW MidiOutCaps;
-        ULONGLONG    Position;
-        struct
-        {
-            LPWSTR DeviceInterfaceString;
-            ULONG DeviceInterfaceStringSize;
-        }Interface;
+    DWORD unk3;
+    PVOID QueueCriticalSection; // Verified to match Windows XP/2003, queue critical section.
 
-        struct
-        {
-            HANDLE hMixer;
-            ULONG NotificationType;
-            ULONG Value;
-        }MixerEvent;
-        KSSTATE State;
-        KSRESET ResetStream;
-        ULONG Volume;
-        ULONG FrameSize;
-        HANDLE hNotifyEvent;
-    }u;
+    HANDLE hNotifyEvent; // Verified to match Windows XP/2003, queue notification event.
+    HANDLE hStopEvent;   // Verified to match Windows XP/2003, queue stop event.
+
+    BOOL unk5;
+    BOOL bReset; // Verified to match Windows XP/2003, indicates whether device is starting to be reset.
+    BOOL bStart; // Verified to match Windows XP/2003, indicates whether device is to be started.
+    BOOL bStartInThread; // Verified to match Windows XP/2003, indicates whether the sound is started in thread.
+
+    char unk7;
+    char unk8;
+
+}WDMAUD_DEVICE_STATE, *PWDMAUD_DEVICE_STATE;
+
+/* Contains the main information about a sound device */
+typedef struct
+{
+    PVOID unk1;
+    DWORD DeviceIndex; // Verified to match Windows XP/2003, indicates the ordering number of device.
+    SOUND_DEVICE_TYPE DeviceType; // Verified to match Windows XP/2003, indicates the type of the sound device, from 0 to 5.
+    HANDLE hDevice; // Verified to match Windows XP/2003, a handle to an opened audio device.
+
+    DWORD_PTR dwInstance; // Verified to match Windows XP/2003, WinMM client callback's instance from the caller's WAVEOPENDESC structure.
+    DWORD_PTR dwCallback; // Verified to match Windows XP/2003, WinMM client callback from the caller's WAVEOPENDESC structure.
+
+    DWORD unk2;
+
+    DWORD Flags;  // Verified to match Windows XP/2003, wave open flags passed in by the caller.
+
+    PVOID Buffer; // Verified to match Windows XP/2003, optional buffer containing an additional data passed by the caller. It's different for different device management actions.
+    DWORD BufferSize; // Verified to match Windows XP/2003, the size, in bytes, of optional buffer passed by the caller.
+
+    DWORD unk3;
+    DWORD unk4;
+
+    HANDLE hMixer;
+    DWORD NotificationType;
+    DWORD Value;
+
+    DWORD unk5;
+    DWORD unk6;
+    DWORD unk7;
+    INT unk8;
+
+    PWDMAUD_DEVICE_STATE DeviceState; // Verified to match Windows XP/2003, WDMAUD_DEVICE_STATE structure for this device.
+
+    LPCWSTR DeviceInterfaceString; // Verified to match Windows XP/2003, device interface string for this device.
 
 }WDMAUD_DEVICE_INFO, *PWDMAUD_DEVICE_INFO;
 
+#pragma pack()
 
-
-/// IOCTL_OPEN_WDMAUD
+/// IOCTL_INIT_WDMAUD
 ///
-/// Description: This IOCTL informs wdmaud that an application whats to use wdmsys for a waveOut / waveIn / aux operation
+/// Description: This IOCTL does the initialization of wdmaud.sys
 ///
-/// Arguments:   InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///              InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:        DeviceType identifies the device type, DeviceIndex the index, WaveFormatEx the device details
-/// Result:      is returned in hDevice
+/// Arguments:   Buffer is NULL,
+///              BufferSize is zero
 /// Return Code: STATUS_SUCCESS indicates success, otherwise appropriate error code
 /// Prerequisites:  none
 
-#define IOCTL_OPEN_WDMAUD \
+#define IOCTL_INIT_WDMAUD \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             0, \
+             0x0000, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
+/// IOCTL_ADD_DEVNODE
+///
+/// Description: This IOCTL adds a new device node
+///
+/// Arguments:   Buffer is NULL,
+///              BufferSize is zero
+/// Note:        DeviceType identifies the device type, DeviceIndex the index, WaveFormat the device details
+/// Return Code: STATUS_SUCCESS indicates success, otherwise appropriate error code
+/// Prerequisites:  none
 
-/// IOCTL_CLOSE_WDMAUD
+#define IOCTL_ADD_DEVNODE \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0001, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_REMOVE_DEVNODE
 ///
-/// Description: This IOCTL informs that an application has finished with wdmsys and closes the connection
+/// Description: This IOCTL removes an existing device node
 ///
-/// Arguments:   InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///              InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:        DeviceType, DeviceIndex and hDevice must be set
+/// Arguments:   Buffer is NULL,
+///              BufferSize is zero
+/// Note:        DeviceType identifies the device type, DeviceIndex the index, WaveFormat the device details
+/// Return Code: STATUS_SUCCESS indicates success, otherwise appropriate error code
+/// Prerequisites:  none
+
+#define IOCTL_REMOVE_DEVNODE \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0002, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_GETCAPABILITIES
+///
+/// Description: This IOCTL retrieves the capabilities of an specific wave out device
+///
+/// Arguments:  Buffer is a pointer to a capabilities data,
+///             BufferSize is size of capabilities data
+/// Note:       The DeviceType and DeviceIndex must be set
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: openend device
+/// Prerequisites: none
 
-#define IOCTL_CLOSE_WDMAUD \
+#define IOCTL_GETCAPABILITIES \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             1, \
+             0x0003, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS) \
-
+             FILE_WRITE_ACCESS)
 
 /// IOCTL_GETNUMDEVS_TYPE
 ///
-/// Description: This IOCTL queries the number of devices currently present of a specific type. The caller passes a WDMAUD_DEVICE_INFO structure.
+/// Description: This IOCTL queries the number of devices currently present of a specific type.
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
 /// Note:       The DeviceType contains the requested device type.
 /// Result:     The result is returned in DeviceCount
 /// ReturnCode:  STATUS_SUCCESS indicates success
@@ -116,147 +150,287 @@ typedef struct
 
 #define IOCTL_GETNUMDEVS_TYPE \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             2, \
+             0x0004, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
 
-/// IOCTL_SETDEVICE_STATE
+/// IOCTL_OPEN_WDMAUD
 ///
-/// Description: This IOCTL sets an opened waveOut / waveIn / midiIn / midiOut / aux device to specific state
+/// Description: This IOCTL informs wdmaud that an application whats to use wdmsys for a waveOut / waveIn / aux operation
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType, DeviceIndex, hDevice and State member must be set. State determines the new state
-/// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Arguments:   Buffer is a pointer to the WAVEFORMATEX structure,
+///              BufferSize is size of the WAVEFORMATEX structure
+/// Note:        DeviceType identifies the device type, DeviceIndex the index, WaveFormat the device details
+/// Result:      is returned in hDevice
+/// Return Code: STATUS_SUCCESS indicates success, otherwise appropriate error code
+/// Prerequisites:  none
 
-#define IOCTL_SETDEVICE_STATE \
+#define IOCTL_OPEN_WDMAUD \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             3, \
+             0x0005, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
-
-/// IOCTL_GETDEVID
+/// IOCTL_CLOSE_WDMAUD
 ///
-/// Description: This IOCTL returns the device index by its provided handle
+/// Description: This IOCTL informs that an application has finished with wdmsys and closes the connection
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType and hDevice must be set
-/// Result:     The result is returned in DeviceIndex
+/// Arguments:   Buffer is NULL,
+///              BufferSize is zero
+/// Note:        DeviceType, DeviceIndex and hDevice must be set
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Openend device
 
-#define IOCTL_GETDEVID \
+#define IOCTL_CLOSE_WDMAUD \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             4, \
+             0x006, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
-
+             FILE_WRITE_ACCESS)
 
 /// IOCTL_GETVOLUME
 ///
-/// Description: This IOCTL returns the volume a device
+/// Description: This IOCTL returns the volume to a device
 ///
 /// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
 ///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
 /// Note:       The DeviceType and hDevice must be set
-/// Result:     The result is returned in Volume
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_GETVOLUME \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             5, \
+             0x0007, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
 
 /// IOCTL_SETVOLUME
 ///
-/// Description: This IOCTL sets the volume a device
+/// Description: This IOCTL sets the volume for a device
 ///
 /// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
 ///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
 /// Note:       The DeviceType, hDevice and Volume must be set
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_SETVOLUME \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             6, \
+             0x0008, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
 
-/// IOCTL_GETCAPABILITIES
+/// IOCTL_SETVOLUME
 ///
-/// Description: This IOCTL retrieves the capabilities of an specific device
+/// Description: This IOCTL does unloading of wdmaud.sys
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType and DeviceIndex must be set
+/// Arguments:  InputBuffer is NULL,
+///             InputBufferSize is zero
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: none
+/// Prerequisites: Initialized device
 
-#define IOCTL_GETCAPABILITIES \
+#define IOCTL_EXIT_WDMAUD \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             7, \
+             0x0009, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
-
-/// IOCTL_WRITEDATA
+/// IOCTL_PAUSE_PLAYBACK
 ///
-/// Description: This IOCTL writes data to specified device
+/// Description: This IOCTL pauses playback of an opened waveOut device
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType, DeviceIndex, hDevice, BufferSize and Buffer must be set
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
-#define IOCTL_WRITEDATA \
+#define IOCTL_PAUSE_PLAYBACK \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             8, \
+             0x0040, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
-/// IOCTL_GETPOS
+/// IOCTL_START_PLAYBACK
+///
+/// Description: This IOCTL starts playback for an opened waveOut device
+///
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_START_PLAYBACK \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0041, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_RESET_PLAYBACK
+///
+/// Description: This IOCTL resets the stream for an opened waveOut device to default state
+///
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_RESET_PLAYBACK \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0042, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_GETOUTPOS
 ///
 /// Description: This IOCTL retrieves the current playback / write position
 ///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
+/// Arguments:  Buffer is a pointer to a variable that receives playback / write position,
+///             BufferSize is set to size of DWORD
 /// Note:       The DeviceType and hDevice must be set
 /// Result:     The result is returned in Position
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
-#define IOCTL_GETPOS \
+#define IOCTL_GETOUTPOS \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             9, \
+             0x0044, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
 
-/// IOCTL_GETFRAMESIZE
+/// IOCTL_WRITEDATA
 ///
-/// Description: This IOCTL retrieves the frame size requirements for an audio pin
+/// Description: This IOCTL writes data to the specified WaveOut device
+///
+/// Arguments:  Buffer is a pointer to a WAVEHDR structure,
+///             BufferSize is size of WAVEHDR structure
+/// Note:       The DeviceType and hDevice must be set
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_WRITEDATA \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0047, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_PAUSE_CAPTURE
+///
+/// Description: This IOCTL pauses capture of an opened waveIn device
+///
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_PAUSE_CAPTURE \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0050, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_START_CAPTURE
+///
+/// Description: This IOCTL starts capture for an opened waveIn device
+///
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_START_CAPTURE \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0051, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_RESET_CAPTURE
+///
+/// Description: This IOCTL resets the stream for an opened waveIn device to default state
+///
+/// Arguments:  Buffer is NULL,
+///             BufferSize is zero
+/// Note:       The DeviceType and hDevice members must be set. State determines the new state
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_RESET_CAPTURE \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0052, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_GETINPOS
+///
+/// Description: This IOCTL retrieves the current capture / read position
+///
+/// Arguments:  Buffer is a pointer to a variable that receives playback / write position,
+///             BufferSize is set to size of DWORD
+/// Note:       The DeviceType and hDevice must be set
+/// Result:     The result is returned in Position
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_GETINPOS \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0053, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_READDATA
+///
+/// Description: This IOCTL reads data from the specified WaveIn device
+///
+/// Arguments:  Buffer is a pointer to a WAVEHDR structure,
+///             BufferSize is size of WAVEHDR structure
+/// Note:       The DeviceType and hDevice must be set
+/// ReturnCode:  STATUS_SUCCESS indicates success
+/// Prerequisites: Opened device
+
+#define IOCTL_READDATA \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x0054, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_OPEN_MIXER
+///
+/// Description: This IOCTL opens mixer device
 ///
 /// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
 ///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType and hDevice must be set
-/// Result:     The result is returned in FrameSize
+/// Note:       The hDevice member must be set
+/// Result:     The result is returned in MixLine
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
-#define IOCTL_GETFRAMESIZE \
+#define IOCTL_OPEN_MIXER \
     CTL_CODE(FILE_DEVICE_SOUND, \
-             10, \
+             0x00C0, \
              METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
+             FILE_WRITE_ACCESS)
+
+/// IOCTL_GET_MIXER_EVENT
+///
+/// Description: This IOCTL queries for wdmaud driver if there any new kernel streaming events available
+///
+/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
+///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
+/// Note:       The hDevice member must be set
+/// Result:     The result is returned in the struct MixerInfo
+/// ReturnCode:  STATUS_SUCCESS indicates success
+
+#define IOCTL_GET_MIXER_EVENT \
+    CTL_CODE(FILE_DEVICE_SOUND, \
+             0x00C6, \
+             METHOD_BUFFERED, \
+             FILE_WRITE_ACCESS)
 
 /// IOCTL_GETLINEINFO
 ///
@@ -267,7 +441,7 @@ typedef struct
 /// Note:       The hDevice member must be set
 /// Result:     The result is returned in MixLine
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_GETLINEINFO \
     CTL_CODE(FILE_DEVICE_SOUND, \
@@ -285,7 +459,7 @@ typedef struct
 /// Note:       The hDevice member must be set
 /// Result:     The result is returned in MixControls
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_GETLINECONTROLS \
     CTL_CODE(FILE_DEVICE_SOUND, \
@@ -302,7 +476,7 @@ typedef struct
 ///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
 /// Note:       The hDevice member must be set
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_SETCONTROLDETAILS \
     CTL_CODE(FILE_DEVICE_SOUND, \
@@ -320,7 +494,7 @@ typedef struct
 /// Note:       The hDevice member must be set
 /// Result:     The result is returned in MixDetails
 /// ReturnCode:  STATUS_SUCCESS indicates success
-/// Prerequisites: opened device
+/// Prerequisites: Opened device
 
 #define IOCTL_GETCONTROLDETAILS \
     CTL_CODE(FILE_DEVICE_SOUND, \
@@ -328,51 +502,3 @@ typedef struct
              METHOD_BUFFERED, \
              FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
 
-
-/// IOCTL_QUERYDEVICEINTERFACESTRING
-///
-/// Description: This IOCTL queries the mixer / playback / recording device for its device interface string
-///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The DeviceType, DeviceIndex must be set
-/// Result:     The size is returned in Interface.DeviceInterfaceStringSize and if a buffer is supplied in Interface.DeviceInterfaceString
-///             the device interface string is stored
-/// ReturnCode:  STATUS_SUCCESS indicates success
-
-#define IOCTL_QUERYDEVICEINTERFACESTRING \
-    CTL_CODE(FILE_DEVICE_SOUND, \
-             15, \
-             METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
-
-/// IOCTL_GET_MIXER_EVENT
-///
-/// Description: This IOCTL queries for wdmaud driver if there any new kernel streaming events available
-///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The hDevice member must be set
-/// Result:     The result is returned in the struct MixerInfo
-/// ReturnCode:  STATUS_SUCCESS indicates success
-
-#define IOCTL_GET_MIXER_EVENT \
-    CTL_CODE(FILE_DEVICE_SOUND, \
-             16, \
-             METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)
-
-/// IOCTL_RESET_STREAM
-///
-/// Description: This IOCTL instructs wdmaud to reset a stream
-///
-/// Arguments:  InputBuffer is a pointer to a WDMAUD_DEVICE_INFO structure,
-///             InputBufferSize is size of WDMAUD_DEVICE_INFO structure
-/// Note:       The hDevice member must be set and DeviceType
-/// ReturnCode:  STATUS_SUCCESS indicates success
-
-#define IOCTL_RESET_STREAM \
-    CTL_CODE(FILE_DEVICE_SOUND, \
-             17, \
-             METHOD_BUFFERED, \
-             FILE_CREATE_TREE_CONNECTION | FILE_ANY_ACCESS)

--- a/drivers/wdm/audio/legacy/wdmaud/sup.c
+++ b/drivers/wdm/audio/legacy/wdmaud/sup.c
@@ -11,7 +11,7 @@
 
 #include <stdio.h>
 
-#define NDEBUG
+#define YDEBUG
 #include <debug.h>
 
 #define TAG_WDMAUD 'DMDW'
@@ -33,7 +33,7 @@ VOID
 FreeItem(
     IN PVOID Item)
 {
-    ExFreePool(Item);
+    ExFreePoolWithTag(Item, TAG_WDMAUD);
 }
 
 
@@ -62,7 +62,6 @@ GetSysAudioDeviceCount(
     return Count;
 }
 
-
 NTSTATUS
 SetIrpIoStatus(
     IN PIRP Irp,
@@ -73,7 +72,6 @@ SetIrpIoStatus(
     Irp->IoStatus.Status = Status;
     IoCompleteRequest(Irp, IO_NO_INCREMENT);
     return Status;
-
 }
 
 ULONG
@@ -364,17 +362,17 @@ GetSysAudioDevicePnpName(
     NTSTATUS Status;
     PWDMAUD_DEVICE_EXTENSION DeviceExtension;
 
-   /* first check if the device index is within bounds */
-   if (DeviceIndex >= GetSysAudioDeviceCount(DeviceObject))
-       return STATUS_INVALID_PARAMETER;
+    DeviceExtension = (PWDMAUD_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
+
+    /* first check if the device index is within bounds */
+    if (DeviceIndex >= GetSysAudioDeviceCount(DeviceObject))
+        return STATUS_INVALID_PARAMETER;
 
     /* setup the query request */
     Pin.Property.Set = KSPROPSETID_Sysaudio;
     Pin.Property.Id = KSPROPERTY_SYSAUDIO_DEVICE_INTERFACE_NAME;
     Pin.Property.Flags = KSPROPERTY_TYPE_GET;
     Pin.PinId = DeviceIndex;
-
-    DeviceExtension = (PWDMAUD_DEVICE_EXTENSION)DeviceObject->DeviceExtension;
 
     /* query sysaudio for the device path */
     Status = KsSynchronousIoControlDevice(DeviceExtension->FileObject, KernelMode, IOCTL_KS_PROPERTY, (PVOID)&Pin, sizeof(KSPROPERTY) + sizeof(ULONG), NULL, 0, &BytesReturned);

--- a/drivers/wdm/audio/sysaudio/deviface.c
+++ b/drivers/wdm/audio/sysaudio/deviface.c
@@ -8,13 +8,14 @@
 
 #include "sysaudio.h"
 
-#define NDEBUG
+#define YDEBUG
 #include <debug.h>
 
 const GUID GUID_DEVICE_INTERFACE_ARRIVAL       = {0xCB3A4004L, 0x46F0, 0x11D0, {0xB0, 0x8F, 0x00, 0x60, 0x97, 0x13, 0x05, 0x3F}};
 const GUID GUID_DEVICE_INTERFACE_REMOVAL       = {0xCB3A4005L, 0x46F0, 0x11D0, {0xB0, 0x8F, 0x00, 0x60, 0x97, 0x13, 0x05, 0x3F}};
 const GUID KS_CATEGORY_AUDIO                   = {0x6994AD04L, 0x93EF, 0x11D0, {0xA3, 0xCC, 0x00, 0xA0, 0xC9, 0x22, 0x31, 0x96}};
-const GUID KS_CATEGORY_TOPOLOGY                = {0xDDA54A40, 0x1E4C, 0x11D1, {0xA0, 0x50, 0x40, 0x57, 0x05, 0xC1, 0x00, 0x00}};
+const GUID KS_CATEGORY_TOPOLOGY                = {0xDDA54A40L, 0x1E4C, 0x11D1, {0xA0, 0x50, 0x40, 0x57, 0x05, 0xC1, 0x00, 0x00}};
+const GUID KS_CATEGORY_WDMAUD                  = {0x3E227E76L, 0x690D, 0x11D2, {0x81, 0x61, 0x00, 0x00, 0xF8, 0x77, 0x5B, 0xF1}};
 const GUID DMOCATEGORY_ACOUSTIC_ECHO_CANCEL    = {0xBF963D80L, 0xC559, 0x11D0, {0x8A, 0x2B, 0x00, 0xA0, 0xC9, 0x25, 0x5A, 0xC1}};
 
 NTSTATUS
@@ -104,16 +105,6 @@ InsertAudioDevice(
     }
     else
     {
-        /* the device name needs to be prefixed */
-        RtlAppendUnicodeToString(&DeviceEntry->DeviceName, L"\\??\\");
-        RtlAppendUnicodeStringToString(&DeviceEntry->DeviceName, DeviceName);
-
-        /* open device */
-        Status = OpenDevice(&DeviceEntry->DeviceName, &DeviceEntry->Handle, &DeviceEntry->FileObject);
-    }
-
-    if (!NT_SUCCESS(Status))
-    {
         goto cleanup;
     }
 
@@ -124,7 +115,7 @@ InsertAudioDevice(
     InterlockedIncrement((PLONG)&DeviceExtension->NumberOfKsAudioDevices);
 
     DPRINT("Successfully opened audio device %u Device %S\n", DeviceExtension->NumberOfKsAudioDevices, DeviceEntry->DeviceName.Buffer);
-    return Status;
+    return STATUS_SUCCESS;
 
 cleanup:
     if (DeviceEntry)

--- a/sdk/include/reactos/libs/sound/sndtypes.h
+++ b/sdk/include/reactos/libs/sound/sndtypes.h
@@ -25,16 +25,16 @@
 typedef enum
 {
     // The sound device types
-    WAVE_IN_DEVICE_TYPE     = 1,
-    WAVE_OUT_DEVICE_TYPE    = 2,
-    MIDI_IN_DEVICE_TYPE     = 3,
-    MIDI_OUT_DEVICE_TYPE    = 4,
-    AUX_DEVICE_TYPE         = 5,
-    MIXER_DEVICE_TYPE       = 6,
+    WAVE_IN_DEVICE_TYPE    = 0,
+    WAVE_OUT_DEVICE_TYPE   = 1,
+    MIDI_IN_DEVICE_TYPE    = 2,
+    MIDI_OUT_DEVICE_TYPE   = 3,
+    MIXER_DEVICE_TYPE      = 4,
+    AUX_DEVICE_TYPE        = 5,
 
     // Range of valid device type IDs
-    MIN_SOUND_DEVICE_TYPE   = 1,
-    MAX_SOUND_DEVICE_TYPE   = 6,
+    MIN_SOUND_DEVICE_TYPE   = 0,
+    MAX_SOUND_DEVICE_TYPE   = 5,
 
     // Number of sound device types
     SOUND_DEVICE_TYPES      = 6

--- a/sdk/lib/drivers/sound/mmixer/filter.c
+++ b/sdk/lib/drivers/sound/mmixer/filter.c
@@ -180,11 +180,6 @@ MMixerGetControlTypeFromTopologyNode(
         /* mux control */
         return MIXERCONTROL_CONTROLTYPE_MUX;
     }
-    else if (IsEqualGUIDAligned(NodeType, (LPGUID)&KSNODETYPE_MUX))
-    {
-        /* mux control */
-        return MIXERCONTROL_CONTROLTYPE_MUX;
-    }
     else if (IsEqualGUIDAligned(NodeType, (LPGUID)&KSNODETYPE_STEREO_WIDE))
     {
         /* stero wide control */

--- a/sdk/lib/drivers/sound/mmixer/mixer.c
+++ b/sdk/lib/drivers/sound/mmixer/mixer.c
@@ -555,8 +555,22 @@ MMixerSetControlDetails(
         case MIXERCONTROL_CONTROLTYPE_MUX:
             Status = MMixerSetGetMuxControlDetails(MixerContext, MixerInfo, NodeId, TRUE, Flags, MixerControl, MixerControlDetails, MixerLine);
             break;
+        case MIXERCONTROL_CONTROLTYPE_ONOFF:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_ONOFF\n");
+            break;
+        case MIXERCONTROL_CONTROLTYPE_LOUDNESS:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_LOUDNESS\n");
+            break;
+        case MIXERCONTROL_CONTROLTYPE_PEAKMETER:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_PEAKMETER\n");
+            break;
+        case MIXERCONTROL_CONTROLTYPE_FADER:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_FADER\n");
+            break;
+
         default:
             Status = MM_STATUS_NOT_IMPLEMENTED;
+            DPRINT1("ControlType %lx not implemented\n", MixerControl->Control.dwControlType);
     }
 
     return Status;
@@ -601,7 +615,7 @@ MMixerGetControlDetails(
     MixerInfo = (LPMIXER_INFO)MixerHandle;
 
     /* get mixer control */
-     Status = MMixerGetMixerControlById(MixerInfo, MixerControlDetails->dwControlID, &MixerLine, &MixerControl, &NodeId);
+    Status = MMixerGetMixerControlById(MixerInfo, MixerControlDetails->dwControlID, &MixerLine, &MixerControl, &NodeId);
 
     /* check for success */
     if (Status != MM_STATUS_SUCCESS)
@@ -618,11 +632,20 @@ MMixerGetControlDetails(
         case MIXERCONTROL_CONTROLTYPE_VOLUME:
             Status = MMixerSetGetVolumeControlDetails(MixerContext, MixerInfo, NodeId, FALSE, MixerControl, MixerControlDetails, MixerLine);
             break;
+        case MIXERCONTROL_CONTROLTYPE_MUX:
+            Status = MMixerSetGetMuxControlDetails(MixerContext, MixerInfo, NodeId, FALSE, Flags, MixerControl, MixerControlDetails, MixerLine);
+            break;
         case MIXERCONTROL_CONTROLTYPE_ONOFF:
             DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_ONOFF\n");
             break;
-        case MIXERCONTROL_CONTROLTYPE_MUX:
-            Status = MMixerSetGetMuxControlDetails(MixerContext, MixerInfo, NodeId, FALSE, Flags, MixerControl, MixerControlDetails, MixerLine);
+        case MIXERCONTROL_CONTROLTYPE_LOUDNESS:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_LOUDNESS\n");
+            break;
+        case MIXERCONTROL_CONTROLTYPE_PEAKMETER:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_PEAKMETER\n");
+            break;
+        case MIXERCONTROL_CONTROLTYPE_FADER:
+            DPRINT1("Not Implemented MIXERCONTROL_CONTROLTYPE_FADER\n");
             break;
 
         default:

--- a/sdk/lib/drivers/sound/mmixer/mmixer.h
+++ b/sdk/lib/drivers/sound/mmixer/mmixer.h
@@ -208,6 +208,12 @@ MMixerOpenWave(
     OUT PHANDLE PinHandle);
 
 MIXER_STATUS
+MMixerGetWavePosition(
+    IN PMIXER_CONTEXT MixerContext,
+    IN HANDLE PinHandle,
+    OUT DWORD * Position);
+
+MIXER_STATUS
 MMixerSetWaveStatus(
     IN PMIXER_CONTEXT MixerContext,
     IN HANDLE PinHandle,


### PR DESCRIPTION
## Proposed changes
[WDMAUD.DRV]
Completely rewrite Legacy and MMixer routines, to make them more compatible with Windows.
- Make it independent from MMEBuddy library and make it using its own MME routines instead of MMEBuddy's.
- Get rid from SOUND_DEVICE_INSTANCE structure usage, use WDMAUD_DEVICE_INFO instead. SOUND_DEVICE_INSTANCE has the same purpose as WDMAUD_DEVICE_INFO, and Windows does not use multiple structures, so we also don't need that, to be more compatible with MS. Separate all device state related stuff into WDMAUD_DEVICE_STATE structure. Rework them t the look similar to Windows's (based on analysis). Set alignment 1 for both of them, to make it of the same size as in Windows XP/2003. This gets us better compatibility (and therefore ability to work together) between our/MS wdmaud.drv/sys ring. Although it still doesn't work, but the major steps are done.
- Rewrite all Legacy rotines to make them more similar to MS. Add their own WdmAudIoControl, and don't use SyncOverlappedDeviceIoControl from MMEBuddy.
- Don't use separate members for each data buffer in WDMAUD_DEVICE_INFO structure, declare one buffer member, which can store several types of data passed by the caller (as in Windows). Add a second member which indicates the size of passed data.
- Adapt all MMixer routines to other changes. Use WDMAUD_DEVICE_INFO structure for all of them too, instead of SOUND_DEVICE_INSTANCE.
- Implement proper resampling support. Rename WriteFileEx_Remixer to WdmAudResampleStream, and rewrite it to only do the resampling, remove all streaming code from it, which is buggy anyway. Call it in WdmAudSubmitWaveHeader (reworked from WdmAudCommitWaveBuffer), to properly resample wave header data before sending it. Add RESAMPLING_ENABLED define which allows to enable/disable resampling support.
- Don't use MMFUNCTION_TABLE structure from MMEBuddy, extend usage of FUNC_NAME macro instead, which redirects to Legacy or MMixer API appropriatedly, depending on USE_MMIXER_LIB define.
- Remove WdmAudQueryDeviceInterfaceString, since it does not exist in Windows. The device interface string is already received by calling SetupApi routines and is stored in WDMAUD_DEVICE_INFO structure.
- Refactor opening audio device mechanism. Add WdmAudOpenKernelSoundDevice (previously WdmAudOpenSoundDevice), which does the initial initialization of Wdm Audio driver mapper, and WdmAudOpenSoundDevice, which opens the device itself (previously SetWaveDeviceFormat). This is more similar to Windows.
- Implement thread management, represented by WdmAudCreate/DestroyCompletionThread.
- Completely rewrite Wave Header extension management. In Windows, header extension has two members: streaming device info pointer (aka sound private handle), allocated and used by SubmitWaveHeader for I/O operations, and a pointer to OVERLAPPED structure which contains steaming event handle. There is no committed and completed bytes counts.

[WDMAUD]
Fix all kernel-mode routines, whose are used by Legacy APIs. Adapt them to current changes also.
- Fix all IOCTL declarations. Add new/update existing IOCTLs to Windows-compatible state. I investigated them by the following way: 1. Analyze them via debugger, when they are passed to DeviceIoControl. 2. Copy their handle and paste it to any IOCTL decoder (I used OSR online IOCTL Decoder for example: https://www.osronline.com/article.cfm%5Earticle=229.htm). 3. Decode them ang get their actual declarations, those can be used by us.
- Use Buffer member of WDMAUD_DEVICE_INFO when possible for storing user data received from/passed to the caller.
- Implement some more IOCTLs whose exist in Windows. Add initialization code, and rewrite streaming routine. Use KsStreamIo for that, instead of dumb calling the driver via IoCallDriver. That KS routine is buggy, so it also needs a fix, which I will send in a separate PR.
- Extend usage of MMixer library. Implement MMixerGetWavePosition, and use it for both Legacy and MMixer routines (in wdmaud.sys and wdmaud.drv appropriately).

[MMIXER]
- Add support for WAVE_FORMAT_EXTENSIBLE audio format. Don't fail when it is requested. Initialize required structure fields for it. It already is supported properly by us, since it is just and extended representation of WAVE_FORMAT_PCM.
- Handle some more Mixer control types, to fix sndvol32.exe Mixer open failures after my changes. Remove unneeded duplicating of MIXERCONTROL_CONTROLTYPE_MUX handling.
- Implement MMixerGetWavePosition.

[KS]
- Fix bug in KsStreamIo
Properly set output buffer length in IO Stack Location of the current IRP, since it is passed to KsProbeStreamIrp when calling KsStreamIo, so it fails if the length isn't set properly.
Don't set an input buffer length and the buffer itself, since it isn't passed anywhere, so setting it makes no sense. Moreover, MSDN says that for IOCTL_KS_READ/WRITE_STREAM, only output buffer (and its length) is needed to be set, but not an input one. So it indeed is more correct.
It fixes buffer overflow in KsProbeStreamIrp when attempting to perform the streaming via KsStreamIo. I discovered this bug during my audio refactoring from PR https://github.com/reactos/reactos/pull/4660.
- Restore old hack for MS portcls.

## TODO

- [x] Fix remaining bugs in the code, to make it basically working. Currently, sound is not working properly in most of cases.
- [ ] Probably implement MIDI support.
- [x] Fix a bug in our winmm if possible, preventing the proper work of streaming. Currently, the sound works only with MS winmm.dll, so it is badly needed to be replaced. **UPD: it was a mistake. Actually our winmm is OK. As appeared, the problem was caused by my previous changes in wdmaud.drv. After further changes the streaming works properly, both with MS and our winmm.dll.**
- [x] Revert some unnecessary changes.
- [ ] Remove MMEbuddy library and its depending NT4 SoundBlaster driver and MmeNT4 library, since they are unused anyway and are very incomplete. They seem to be not compatible with NT5, and are not used by our wdmaud.drv or anything other anymore. Do it in a separate PR.
- [x] Send a fix in Kernel Streaming driver, which also can be done in a separate PR (done now in #4663).