### PR TITLE
[NTOSKRNL] Fix returned number of handles for Idle System Process

### DIFF
--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1031,9 +1031,11 @@ QSI_DEF(SystemProcessInformation)
                 SpiCurrent->BasePriority = Process->Pcb.BasePriority;
                 SpiCurrent->UniqueProcessId = Process->UniqueProcessId;
                 SpiCurrent->InheritedFromUniqueProcessId = Process->InheritedFromUniqueProcessId;
-                /* Idle Process shares the HandleTable with PsInitialSystemProcess so let's return these
-                Handle count for System only, not Idle.	*/
-                SpiCurrent->HandleCount = (Process == PsIdleProcess)?0:ObGetProcessHandleCount(Process);
+
+                /* PsIdleProcess shares its handle table with PsInitialSystemProcess,
+                 * so return the handle count for System only, not Idle one. */
+                SpiCurrent->HandleCount = (Process == PsIdleProcess) ? 0 : ObGetProcessHandleCount(Process);
+
                 SpiCurrent->PeakVirtualSize = Process->PeakVirtualSize;
                 SpiCurrent->VirtualSize = Process->VirtualSize;
                 SpiCurrent->PageFaultCount = Process->Vm.PageFaultCount;

--- a/ntoskrnl/ex/sysinfo.c
+++ b/ntoskrnl/ex/sysinfo.c
@@ -1031,7 +1031,9 @@ QSI_DEF(SystemProcessInformation)
                 SpiCurrent->BasePriority = Process->Pcb.BasePriority;
                 SpiCurrent->UniqueProcessId = Process->UniqueProcessId;
                 SpiCurrent->InheritedFromUniqueProcessId = Process->InheritedFromUniqueProcessId;
-                SpiCurrent->HandleCount = ObGetProcessHandleCount(Process);
+                /* Idle Process shares the HandleTable with PsInitialSystemProcess so let's return these
+                Handle count for System only, not Idle.	*/
+                SpiCurrent->HandleCount = (Process == PsIdleProcess)?0:ObGetProcessHandleCount(Process);
                 SpiCurrent->PeakVirtualSize = Process->PeakVirtualSize;
                 SpiCurrent->VirtualSize = Process->VirtualSize;
                 SpiCurrent->PageFaultCount = Process->Vm.PageFaultCount;

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -60,11 +60,6 @@ ObGetProcessHandleCount(IN PEPROCESS Process)
 
     ASSERT(Process);
 
-    /* Idle Process shares the HandleTable with PsInitialSystemProcess so let's return these
-    Handle count for System only, not Idle.	*/
-    if(Process == PsIdleProcess )
-        return 0;
-
     /* Ensure the handle table doesn't go away while we use it */
     HandleTable = ObReferenceProcessHandleTable(Process);
 

--- a/ntoskrnl/ob/obhandle.c
+++ b/ntoskrnl/ob/obhandle.c
@@ -60,6 +60,11 @@ ObGetProcessHandleCount(IN PEPROCESS Process)
 
     ASSERT(Process);
 
+    /* Idle Process shares the HandleTable with PsInitialSystemProcess so let's return these
+    Handle count for System only, not Idle.	*/
+    if(Process == PsIdleProcess )
+        return 0;
+
     /* Ensure the handle table doesn't go away while we use it */
     HandleTable = ObReferenceProcessHandleTable(Process);
 


### PR DESCRIPTION
## Purpose

As explained by @HBelusca in the Jira ticket, PsIdleProcess and PsInitialSystemProcess share the same HandleTable. This leads to the same number of Handles to be reported by ObGetProcessHandleCount then feeding the SYSTEM_PROCESS_INFORMATION structure?

JIRA issue: [CORE-16577](https://jira.reactos.org/browse/CORE-16577)

## Proposed changes

Proposed change is to force the HandleCount to 0 for the Idle process in SystemProcessInformation handling instead of calling ObGetProcessHandleCount.

## After change :

![image](https://user-images.githubusercontent.com/112266950/188259306-8eb59be1-551b-4d37-9291-ba5a7e5cb1d8.png)

