### PR TITLE
[NETSHELL] Fix "ghost" network activity when opening Network Status page

### DIFF
--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -15,7 +15,6 @@ CLanStatus::CLanStatus() :
 {
 }
 
-BOOL bFirst;
 
 VOID
 UpdateLanStatusUiDlg(
@@ -132,7 +131,7 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
         return;
     }
 
-    if(bFirst)
+    if(pContext->Status == (UINT)-1)
     {
         /*
         On first execution, pContext->dwIn{out}Octets will be null while IF data are already refreshed with non null data so a gap is normal
@@ -140,7 +139,6 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
         */
         pContext->dwInOctets = IfEntry.dwInOctets;
         pContext->dwOutOctets = IfEntry.dwOutOctets;
-        bFirst = FALSE;
     }
 
     hIcon = NULL;
@@ -276,7 +274,6 @@ InitializeLANStatusUiDlg(HWND hwndDlg, LANSTATUSUI_CONTEXT * pContext)
 
     /* update adapter info */
     pContext->Status = -1;
-    bFirst = TRUE;
     UpdateLanStatus(hwndDlg, pContext);
     NcFreeNetconProperties(pProperties);
 }

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -133,8 +133,8 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
     if(pContext->Status == (UINT)-1)
     {
         /*
-        On first execution, pContext->dwIn{out}Octets will be null while IF data are already refreshed with non null data so a gap is normal
-        and does not corresponds to an effective packet tx or rx
+        On first execution, pContext->dwInOctets/dwInOctets will be at 0 while IF data are already refreshed with non null data
+        so a gap is normal and does not corresponds to an effective packet tx or rx
         */
         pContext->dwInOctets = IfEntry.dwInOctets;
         pContext->dwOutOctets = IfEntry.dwOutOctets;

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -130,11 +130,11 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
         return;
     }
 
-    if(pContext->Status == (UINT)-1)
+    if (pContext->Status == (UINT)-1)
     {
         /*
-        On first execution, pContext->dwInOctets/dwInOctets will be at 0 while IF data are already refreshed with non null data
-        so a gap is normal and does not corresponds to an effective packet tx or rx
+        On first execution, pContext->dwInOctets/dwInOctets will be at 0 while interface data is already refreshed with non-null data
+        so a gap is normal and does not correspond to an effective tx or rx packet
         */
         pContext->dwInOctets = IfEntry.dwInOctets;
         pContext->dwOutOctets = IfEntry.dwOutOctets;

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -133,9 +133,10 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
     if (pContext->Status == (UINT)-1)
     {
         /*
-        On first execution, pContext->dwInOctets/dwInOctets will be at 0 while interface data is already refreshed with non-null data
-        so a gap is normal and does not correspond to an effective tx or rx packet
-        */
+         * On first execution, pContext->dw[In|Out]Octets will be zero while
+         * the interface info is already refreshed with non-null data, so a
+         * gap is normal and does not correspond to an effective TX or RX packet.
+         */
         pContext->dwInOctets = IfEntry.dwInOctets;
         pContext->dwOutOctets = IfEntry.dwOutOctets;
     }

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -15,7 +15,6 @@ CLanStatus::CLanStatus() :
 {
 }
 
-
 VOID
 UpdateLanStatusUiDlg(
     HWND hwndDlg,

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -15,6 +15,8 @@ CLanStatus::CLanStatus() :
 {
 }
 
+BOOL bFirst;
+
 VOID
 UpdateLanStatusUiDlg(
     HWND hwndDlg,
@@ -128,6 +130,17 @@ UpdateLanStatus(HWND hwndDlg,  LANSTATUSUI_CONTEXT * pContext)
     if (GetIfEntry(&IfEntry) != NO_ERROR)
     {
         return;
+    }
+
+    if(bFirst)
+    {
+        /*
+        On first execution, pContext->dwIn{out}Octets will be null while IF data are already refreshed with non null data so a gap is normal
+        and does not corresponds to an effective packet tx or rx
+        */
+        pContext->dwInOctets = IfEntry.dwInOctets;
+        pContext->dwOutOctets = IfEntry.dwOutOctets;
+        bFirst = FALSE;
     }
 
     hIcon = NULL;
@@ -263,6 +276,7 @@ InitializeLANStatusUiDlg(HWND hwndDlg, LANSTATUSUI_CONTEXT * pContext)
 
     /* update adapter info */
     pContext->Status = -1;
+    bFirst = TRUE;
     UpdateLanStatus(hwndDlg, pContext);
     NcFreeNetconProperties(pProperties);
 }


### PR DESCRIPTION
## Purpose

Opening Network Status page creates a systematic "ghost" network activity, activating RX+TX activity icon both on property page and tray, while no Rx/Tx.
This is due to pContext->dwIn{out}Octets being initialized to 0 and compared to refreshed interface data.

## Proposed changes

On first Update, copy refreshed interface data to the Context