### PR TITLE
[KS] Fix bug in KsStreamIo

### DIFF
--- a/drivers/ksfilter/ks/irp.c
+++ b/drivers/ksfilter/ks/irp.c
@@ -634,8 +634,7 @@ KsStreamIo(
     IoStack = IoGetNextIrpStackLocation(Irp);
     /* setup stack parameters */
     IoStack->FileObject = FileObject;
-    IoStack->Parameters.DeviceIoControl.InputBufferLength = Length;
-    IoStack->Parameters.DeviceIoControl.Type3InputBuffer = StreamHeaders;
+    IoStack->Parameters.DeviceIoControl.OutputBufferLength = Length;
     IoStack->Parameters.DeviceIoControl.IoControlCode = (Flags == KSSTREAM_READ ? IOCTL_KS_READ_STREAM : IOCTL_KS_WRITE_STREAM);
 
     if (CompletionRoutine)


### PR DESCRIPTION
## Purpose

Properly set output buffer length in IO Stack Location of the current IRP, since it is passed to KsProbeStreamIrp when calling KsStreamIo, so it fails if the length isn't set properly.
Don't set an input buffer length and the buffer itself, since it isn't passed anywhere, so setting it makes no sense. Moreover, MSDN says that for IOCTL_KS_READ/WRITE_STREAM, only output buffer (and its length) is needed to be set, but not an input one. So it indeed is more correct.
It fixes buffer overflow in KsProbeStreamIrp when attempting to perform the streaming via KsStreamIo. I discovered this bug during my audio refactoring from PR #4660.

JIRA issue: None.