### PR TITLE
[NTOS] Add some sanity checks when synchronizing PDEs

### DIFF
--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1261,13 +1261,13 @@ NTSTATUS
 NTAPI
 MmGetExecuteOptions(IN PULONG ExecuteOptions);
 
-VOID
-NTAPI
+_Success_(return)
+BOOLEAN
 MmDeleteVirtualMapping(
-    struct _EPROCESS *Process,
-    PVOID Address,
-    BOOLEAN* WasDirty,
-    PPFN_NUMBER Page
+    _In_opt_ PEPROCESS Process,
+    _In_ PVOID Address,
+    _Out_opt_ BOOLEAN* WasDirty,
+    _Out_opt_ PPFN_NUMBER Page
 );
 
 /* arch/procsup.c ************************************************************/

--- a/ntoskrnl/mm/ARM3/miarm.h
+++ b/ntoskrnl/mm/ARM3/miarm.h
@@ -2428,21 +2428,29 @@ FORCEINLINE
 BOOLEAN
 MiSynchronizeSystemPde(PMMPDE PointerPde)
 {
-    MMPDE SystemPde;
     ULONG Index;
 
     /* Get the Index from the PDE */
     Index = ((ULONG_PTR)PointerPde & (SYSTEM_PD_SIZE - 1)) / sizeof(MMPTE);
+    if (PointerPde->u.Hard.Valid != 0)
+    {
+        NT_ASSERT(PointerPde->u.Long == MmSystemPagePtes[Index].u.Long);
+        return TRUE;
+    }
+
+    if (MmSystemPagePtes[Index].u.Hard.Valid == 0)
+    {
+        return FALSE;
+    }
 
     /* Copy the PDE from the double-mapped system page directory */
-    SystemPde = MmSystemPagePtes[Index];
-    *PointerPde = SystemPde;
+    MI_WRITE_VALID_PDE(PointerPde, MmSystemPagePtes[Index]);
 
     /* Make sure we re-read the PDE and PTE */
     KeMemoryBarrierWithoutFence();
 
-    /* Return, if we had success */
-    return SystemPde.u.Hard.Valid != 0;
+    /* Return success */
+    return TRUE;
 }
 #endif
 

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -314,16 +314,19 @@ MmFreeMemoryArea(
             BOOLEAN Dirty = FALSE;
             SWAPENTRY SwapEntry = 0;
             PFN_NUMBER Page = 0;
+            BOOLEAN DoFree;
 
             if (MmIsPageSwapEntry(Process, (PVOID)Address))
             {
                 MmDeletePageFileMapping(Process, (PVOID)Address, &SwapEntry);
+                /* We'll have to do some cleanup when we're on the page file */
+                DoFree = TRUE;
             }
             else
             {
-                MmDeleteVirtualMapping(Process, (PVOID)Address, &Dirty, &Page);
+                DoFree = MmDeleteVirtualMapping(Process, (PVOID)Address, &Dirty, &Page);
             }
-            if (FreePage != NULL)
+            if (DoFree && (FreePage != NULL))
             {
                 FreePage(FreePageContext, MemoryArea, (PVOID)Address,
                          Page, SwapEntry, (BOOLEAN)Dirty);

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -1897,6 +1897,7 @@ MmAccessFaultSectionView(PMMSUPPORT AddressSpace,
     PMM_SECTION_SEGMENT Segment;
     PFN_NUMBER OldPage;
     PFN_NUMBER NewPage;
+    PFN_NUMBER UnmappedPage;
     PVOID PAddress;
     LARGE_INTEGER Offset;
     PMM_REGION Region;
@@ -1904,6 +1905,7 @@ MmAccessFaultSectionView(PMMSUPPORT AddressSpace,
     PEPROCESS Process = MmGetAddressSpaceOwner(AddressSpace);
     BOOLEAN Cow = FALSE;
     ULONG NewProtect;
+    BOOLEAN Unmapped;
 
     DPRINT("MmAccessFaultSectionView(%p, %p, %p)\n", AddressSpace, MemoryArea, Address);
 
@@ -2003,7 +2005,17 @@ MmAccessFaultSectionView(PMMSUPPORT AddressSpace,
      * Unshare the old page.
      */
     DPRINT("Swapping page (Old %x New %x)\n", OldPage, NewPage);
-    MmDeleteVirtualMapping(Process, PAddress, NULL, NULL);
+    Unmapped = MmDeleteVirtualMapping(Process, PAddress, NULL, &UnmappedPage);
+    if (!Unmapped || (UnmappedPage != OldPage))
+    {
+        /* Uh , we had a page just before, but suddenly it changes. Someone corrupted us. */
+        KeBugCheckEx(MEMORY_MANAGEMENT,
+                    (ULONG_PTR)Process,
+                    (ULONG_PTR)PAddress,
+                    (ULONG_PTR)__FILE__,
+                    __LINE__);
+    }
+
     if (Process)
         MmDeleteRmap(OldPage, Process, PAddress);
     MmUnsharePageEntrySectionSegment(MemoryArea, Segment, &Offset, FALSE, FALSE, NULL);


### PR DESCRIPTION
## Purpose

In one of the revert patch for CORE-17595, I noticed there's a slight difference in checks that are done in the way PDEs are checked. Let's see f that matters. Those are sanity checks which are worth having anyway.

## Proposed changes

 - Check that PDE double mapping is always in sync
 - Check the user-mode PDEs are consistent with their share count.

