### PR TITLE
[HIDCLASS] Implement proper ping-pong read and other improvements

### DIFF
--- a/drivers/hid/hidclass/CMakeLists.txt
+++ b/drivers/hid/hidclass/CMakeLists.txt
@@ -4,7 +4,8 @@ spec2def(hidclass.sys hidclass.spec ADD_IMPORTLIB)
 list(APPEND SOURCE
     fdo.c
     hidclass.c
-    pdo.c)
+    pdo.c
+    cyclicbuffer.c)
 
 list(APPEND PCH_SKIP_SOURCE
     guid.c)

--- a/drivers/hid/hidclass/cyclicbuffer.c
+++ b/drivers/hid/hidclass/cyclicbuffer.c
@@ -1,0 +1,70 @@
+/*
+ * PROJECT:     ReactOS Universal Serial Bus Human Interface Device Driver
+ * LICENSE:     GPL-3.0-or-later (https://spdx.org/licenses/GPL-3.0-or-later)
+ * PURPOSE:     Ring buffer
+ * COPYRIGHT:   Copyright 2022 Roman Masanin <36927roma@gmail.com>
+ */
+
+#include "precomp.h"
+
+NTSTATUS HidClass_CyclicBufferUpdateSize(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN UINT32 elementCount)
+{
+    buffer->elementCount = elementCount + 1;
+    if (buffer->buffer != NULL)
+    {
+        buffer->endIndex = 0;
+        buffer->startIndex = 0;
+        ExFreePool(buffer->buffer);
+        buffer->buffer = NULL;
+    }
+    buffer->buffer = ExAllocatePoolWithTag(NonPagedPool, buffer->elementSize * buffer->elementCount, HIDCLASS_TAG);
+
+    // FIXME: HANDLE ERROR
+    return STATUS_SUCCESS;
+}
+
+void HidClass_CyclicBufferInitialize(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN UINT32 elementSize)
+{
+    buffer->elementSize = elementSize;
+    buffer->endIndex = 0;
+    buffer->startIndex = 0;
+    buffer->buffer = NULL;
+
+    HidClass_CyclicBufferUpdateSize(buffer, 16);
+}
+
+void HidClass_CyclicBufferPut(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN PVOID item)
+{
+    PUCHAR currentItem;
+
+    currentItem = buffer->buffer;
+    currentItem += buffer->elementSize * buffer->endIndex;
+    RtlCopyMemory(currentItem, item, buffer->elementSize);
+    buffer->endIndex = (buffer->endIndex + 1) % buffer->elementCount;
+    if (buffer->endIndex == buffer->startIndex)
+    {
+        buffer->startIndex = (buffer->startIndex + 1) % buffer->elementCount;
+    }
+}
+
+BOOLEAN HidClass_CyclicBufferIsEmpty(IN PHIDCHASS_CYCLIC_BUFFER buffer)
+{
+    return buffer->startIndex == buffer->endIndex;
+}
+
+BOOLEAN HidClass_CyclicBufferGet(IN PHIDCHASS_CYCLIC_BUFFER buffer, OUT PVOID item)
+{
+    PUCHAR currentItem;
+    BOOLEAN result = FALSE;
+
+    if (buffer->startIndex != buffer->endIndex)
+    {
+        currentItem = buffer->buffer;
+        currentItem += buffer->elementSize * buffer->startIndex;
+        RtlCopyMemory(item, currentItem, buffer->elementSize);
+        buffer->startIndex = (buffer->startIndex + 1) % buffer->elementCount;
+        result = TRUE;
+    }
+
+    return result;
+}

--- a/drivers/hid/hidclass/cyclicbuffer.h
+++ b/drivers/hid/hidclass/cyclicbuffer.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "wdm.h"
+
+typedef struct _HIDCHASS_CYCLIC_BUFFER
+{
+    UINT32 elementCount;
+    UINT32 elementSize;
+    UINT32 startIndex;
+    UINT32 endIndex;
+
+    PVOID buffer;
+} HIDCHASS_CYCLIC_BUFFER, *PHIDCHASS_CYCLIC_BUFFER;
+
+NTSTATUS HidClass_CyclicBufferUpdateSize(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN UINT32 elementCount);
+
+void HidClass_CyclicBufferInitialize(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN UINT32 elementSize);
+
+void HidClass_CyclicBufferPut(IN PHIDCHASS_CYCLIC_BUFFER buffer, IN PVOID item);
+
+BOOLEAN HidClass_CyclicBufferIsEmpty(IN PHIDCHASS_CYCLIC_BUFFER buffer);
+
+BOOLEAN HidClass_CyclicBufferGet(IN PHIDCHASS_CYCLIC_BUFFER buffer, OUT PVOID item);

--- a/drivers/hid/hidclass/fdo.c
+++ b/drivers/hid/hidclass/fdo.c
@@ -1,11 +1,10 @@
 /*
  * PROJECT:     ReactOS Universal Serial Bus Human Interface Device Driver
- * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        drivers/hid/hidclass/fdo.c
+ * LICENSE:     GPL-3.0-or-later (https://spdx.org/licenses/GPL-3.0-or-later)
  * PURPOSE:     HID Class Driver
- * PROGRAMMERS:
- *              Michael Martin (michael.martin@reactos.org)
- *              Johannes Anderwald (johannes.anderwald@reactos.org)
+ * COPYRIGHT:   Copyright  Michael Martin <michael.martin@reactos.org>
+ *              Copyright  Johannes Anderwald <johannes.anderwald@reactos.org>
+ *              Copyright 2022 Roman Masanin <36927roma@gmail.com>
  */
 
 #include "precomp.h"
@@ -388,6 +387,212 @@ HidClassFDO_GetDescriptors(
     return STATUS_SUCCESS;
 }
 
+PIRP HidClass_DequeueIrp(PHIDCLASS_PDO_DEVICE_EXTENSION deviceContext)
+{
+    PIRP nextIrp = NULL;
+    PDRIVER_CANCEL oldCancelRoutine;
+    PLIST_ENTRY listEntry;
+
+    while (nextIrp == NULL && IsListEmpty(&deviceContext->PendingIRPList) == FALSE)
+    {
+        listEntry = RemoveHeadList(&deviceContext->PendingIRPList);
+        nextIrp = CONTAINING_RECORD(listEntry, IRP, Tail.Overlay.ListEntry);
+
+        oldCancelRoutine = IoSetCancelRoutine(nextIrp, NULL);
+        if (oldCancelRoutine != NULL)
+        {
+            // Cancel routine not called for this IRP. Return this IRP.
+            ASSERT(oldCancelRoutine == HidClassPDO_IrpCancelRoutine);
+        }
+        else
+        {
+            // IRP is canceled
+            ASSERT(nextIrp->Cancel);
+            InitializeListHead(&nextIrp->Tail.Overlay.ListEntry);
+            nextIrp = NULL;
+        }
+    }
+
+    return nextIrp;
+}
+
+NTSTATUS
+NTAPI
+HidClassFDO_ReadCompletion(
+    IN PDEVICE_OBJECT DeviceObject,
+    IN PIRP Irp,
+    IN PVOID Context)
+{
+    PHIDCLASS_FDO_EXTENSION DeviceExtension;
+    PHIDCLASS_PDO_DEVICE_EXTENSION PDODeviceExtension = NULL;
+    ULONG CollectionNumber;
+    KIRQL CurrentIRQL;
+    LIST_ENTRY completeIRP;
+    PUCHAR address = NULL;
+    PIRP tempIRP = NULL;
+
+    UNREFERENCED_PARAMETER(DeviceObject);
+
+    /* get device extension */
+    DeviceExtension = Context;
+    ASSERT(DeviceExtension != NULL);
+
+    if (Irp->IoStatus.Status == STATUS_PRIVILEGE_NOT_HELD ||
+        Irp->IoStatus.Status == STATUS_DEVICE_NOT_CONNECTED ||
+        Irp->IoStatus.Status == STATUS_CANCELLED)
+    {
+        /* failed to read or should be stopped*/
+        DPRINT1("[HIDCLASS] ReadCompletion terminating read Status %x\n", Irp->IoStatus.Status);
+
+        return STATUS_MORE_PROCESSING_REQUIRED;
+    }
+
+    if (Irp->IoStatus.Information > 0)
+    {
+        if (DeviceExtension->DeviceRelations->Count > 0)
+        {
+            // find PDO related to the reportID
+            {
+                CollectionNumber = HidClassPDO_GetReportDescriptionByReportID(&DeviceExtension->Common.DeviceDescription, DeviceExtension->InputBuffer[0])->CollectionNumber;
+
+                for (int i = 0; i < DeviceExtension->DeviceRelations->Count; i++)
+                {
+                    PDODeviceExtension = DeviceExtension->DeviceRelations->Objects[i]->DeviceExtension;
+                    ASSERT(PDODeviceExtension->Common.IsFDO == FALSE);
+
+                    if (PDODeviceExtension->CollectionNumber == CollectionNumber)
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        PDODeviceExtension = NULL;
+                    }
+                }
+            }
+
+            ASSERT(PDODeviceExtension != NULL);
+
+
+            InitializeListHead(&completeIRP);
+
+            KeAcquireSpinLock(&PDODeviceExtension->ReadLock, &CurrentIRQL);
+
+            // check if any IRP waiting data
+            while (!IsListEmpty(&PDODeviceExtension->PendingIRPList))
+            {
+                tempIRP = HidClass_DequeueIrp(PDODeviceExtension);
+                if (tempIRP != NULL)
+                {
+                    if (tempIRP->MdlAddress != NULL)
+                    {
+                        address = MmGetSystemAddressForMdlSafe(tempIRP->MdlAddress, LowPagePriority);
+                        if (address != NULL)
+                        {
+                            tempIRP->IoStatus.Information = HidClassPDO_GetCollectionDescription(&PDODeviceExtension->Common.DeviceDescription, PDODeviceExtension->CollectionNumber)->InputLength;
+                            RtlCopyMemory(address, DeviceExtension->InputBuffer, tempIRP->IoStatus.Information);
+                            tempIRP->IoStatus.Status = STATUS_SUCCESS;
+                        }
+                        else
+                        {
+                            tempIRP->IoStatus.Status = STATUS_INVALID_USER_BUFFER;
+                            tempIRP->IoStatus.Information = 0;
+                        }
+                    }
+
+                    // Mark this IRP to be cenceled after exiting spinLock
+                    InsertHeadList(&completeIRP, &tempIRP->Tail.Overlay.ListEntry);
+                }
+            }
+
+            // No IRP waiting data, put it into the buffer
+            if (IsListEmpty(&completeIRP) == TRUE)
+            {
+                HidClass_CyclicBufferPut(&PDODeviceExtension->InputBuffer, DeviceExtension->InputBuffer);
+            }
+
+            KeReleaseSpinLock(&PDODeviceExtension->ReadLock, CurrentIRQL);
+
+            // complete waiting IRPs
+            {
+                PIRP nextIrp;
+                PLIST_ENTRY listEntry;
+                while (IsListEmpty(&completeIRP) == FALSE)
+                {
+                    listEntry = RemoveHeadList(&completeIRP);
+                    nextIrp = CONTAINING_RECORD(listEntry, IRP, Tail.Overlay.ListEntry);
+
+                    IoCompleteRequest(nextIrp, IO_NO_INCREMENT);
+                }
+            }
+        }
+    }
+
+    // re-init read
+    HidClassFDO_SubmitRead(DeviceExtension);
+
+    /* stop completion */
+    return STATUS_MORE_PROCESSING_REQUIRED;
+}
+
+NTSTATUS
+HidClassFDO_SubmitRead(IN PHIDCLASS_FDO_EXTENSION DeviceExtension)
+{
+    PIO_STACK_LOCATION IoStack;
+    NTSTATUS Status;
+
+    /* re-use irp */
+    IoReuseIrp(DeviceExtension->InputIRP, STATUS_SUCCESS);
+
+    /* init irp */
+    DeviceExtension->InputIRP->UserBuffer = DeviceExtension->InputWriteAddress;
+
+    /* get next stack location */
+    IoStack = IoGetNextIrpStackLocation(DeviceExtension->InputIRP);
+
+    /* init stack location */
+    IoStack->MajorFunction = IRP_MJ_INTERNAL_DEVICE_CONTROL;
+    IoStack->Parameters.DeviceIoControl.IoControlCode = IOCTL_HID_READ_REPORT;
+    IoStack->Parameters.DeviceIoControl.OutputBufferLength = DeviceExtension->InputBufferSize;
+    IoStack->Parameters.DeviceIoControl.InputBufferLength = 0;
+    IoStack->Parameters.DeviceIoControl.Type3InputBuffer = NULL;
+    IoStack->DeviceObject = ((PHIDCLASS_PDO_DEVICE_EXTENSION)DeviceExtension->DeviceRelations->Objects[0]->DeviceExtension)->FDODeviceObject;
+    //IoStack->DeviceObject = DeviceExtension->DeviceRelations->Objects[0];
+
+    /* set completion routine */
+    IoSetCompletionRoutine(DeviceExtension->InputIRP, HidClassFDO_ReadCompletion, DeviceExtension, TRUE, TRUE, TRUE);
+
+    // TODO: create function for this.
+    // let's dispatch the request
+    IoSetNextIrpStackLocation(DeviceExtension->InputIRP);
+    Status = DeviceExtension->Common.DriverExtension->MajorFunction[IRP_MJ_INTERNAL_DEVICE_CONTROL](((PHIDCLASS_PDO_DEVICE_EXTENSION)DeviceExtension->DeviceRelations->Objects[0]->DeviceExtension)->FDODeviceObject, DeviceExtension->InputIRP);
+
+    /* done */
+    return Status;
+}
+
+NTSTATUS
+HidClassFDO_InitiateRead(IN PHIDCLASS_FDO_EXTENSION DeviceExtension)
+{
+    if (DeviceExtension->IsReadLoopStarted == FALSE)
+    {
+        DeviceExtension->IsReadLoopStarted = TRUE;
+
+        DeviceExtension->InputWriteAddress = DeviceExtension->InputBuffer;
+        if (DeviceExtension->Common.DeviceDescription.ReportIDsLength == 1 && DeviceExtension->Common.DeviceDescription.ReportIDs[0].ReportID == 0)
+        {
+            DeviceExtension->InputWriteAddress[0] = 0;
+            DeviceExtension->InputWriteAddress++;
+            DeviceExtension->InputBufferSize--;
+        }
+
+        DPRINT1("[HIDCLASS] HidClassFDO_InitiateRead for address %p and size %x\n", DeviceExtension->InputWriteAddress, DeviceExtension->InputBufferSize);
+
+        HidClassFDO_SubmitRead(DeviceExtension);
+    }
+
+    return STATUS_SUCCESS;
+}
 
 NTSTATUS
 HidClassFDO_StartDevice(
@@ -451,6 +656,22 @@ HidClassFDO_StartDevice(
         IoCompleteRequest(Irp, IO_NO_INCREMENT);
         return Status;
     }
+
+    USHORT maxInputLen = 0;
+    for (int i = 0; i < FDODeviceExtension->Common.DeviceDescription.CollectionDescLength; i++)
+    {
+        if (FDODeviceExtension->Common.DeviceDescription.CollectionDesc[i].InputLength > maxInputLen)
+        {
+            maxInputLen = FDODeviceExtension->Common.DeviceDescription.CollectionDesc[i].InputLength;
+        }
+    }
+    FDODeviceExtension->InputBufferSize = maxInputLen;
+    FDODeviceExtension->InputBuffer = ExAllocatePoolWithTag(NonPagedPool, FDODeviceExtension->InputBufferSize + 1, HIDCLASS_TAG);
+
+    FDODeviceExtension->InputIRP = IoAllocateIrp(DeviceObject->StackSize, FALSE);
+
+    // trigger the IRP_MN_QUERY_DEVICE_RELATIONS
+    IoInvalidateDeviceRelations(FDODeviceExtension->Common.HidDeviceExtension.PhysicalDeviceObject, BusRelations);
 
     //
     // complete request

--- a/drivers/hid/hidclass/fdo.c
+++ b/drivers/hid/hidclass/fdo.c
@@ -12,6 +12,11 @@
 #define NDEBUG
 #include <debug.h>
 
+// driver verifier
+IO_COMPLETION_ROUTINE HidClassFDO_QueryCapabilitiesCompletionRoutine;
+IO_COMPLETION_ROUTINE HidClassFDO_DispatchRequestSynchronousCompletion;
+IO_COMPLETION_ROUTINE HidClassFDO_ReadCompletion;
+
 NTSTATUS
 NTAPI
 HidClassFDO_QueryCapabilitiesCompletionRoutine(
@@ -19,9 +24,10 @@ HidClassFDO_QueryCapabilitiesCompletionRoutine(
     IN PIRP Irp,
     IN PVOID Context)
 {
-    //
-    // set event
-    //
+    UNREFERENCED_PARAMETER(DeviceObject);
+    UNREFERENCED_PARAMETER(Irp);
+    ASSERT(Context != NULL);
+
     KeSetEvent(Context, 0, FALSE);
 
     //
@@ -130,14 +136,12 @@ HidClassFDO_DispatchRequestSynchronousCompletion(
     IN PIRP Irp,
     IN PVOID Context)
 {
-    //
-    // signal event
-    //
+    UNREFERENCED_PARAMETER(DeviceObject);
+    UNREFERENCED_PARAMETER(Irp);
+    ASSERT(Context != NULL);
+
     KeSetEvent(Context, 0, FALSE);
 
-    //
-    // done
-    //
     return STATUS_MORE_PROCESSING_REQUIRED;
 }
 

--- a/drivers/hid/hidclass/hidclass.c
+++ b/drivers/hid/hidclass/hidclass.c
@@ -13,13 +13,19 @@
 #include <debug.h>
 
 static LPWSTR ClientIdentificationAddress = L"HIDCLASS";
-static ULONG HidClassDeviceNumber = 0;
+static LONG HidClassDeviceNumber = 0;
+
+DRIVER_DISPATCH HidClassDispatch;
+DRIVER_UNLOAD HidClassDriverUnload;
+DRIVER_ADD_DEVICE HidClassAddDevice;
 
 NTSTATUS
 NTAPI
 DllInitialize(
     IN PUNICODE_STRING RegistryPath)
 {
+    UNREFERENCED_PARAMETER(RegistryPath);
+
     return STATUS_SUCCESS;
 }
 
@@ -45,10 +51,10 @@ HidClassAddDevice(
     PHIDCLASS_DRIVER_EXTENSION DriverExtension;
 
     /* increment device number */
-    InterlockedIncrement((PLONG)&HidClassDeviceNumber);
+    UINT32 hidclassDevNum = InterlockedIncrement(&HidClassDeviceNumber) & 0xFFFFFFFF;
 
     /* construct device name */
-    swprintf(CharDeviceName, L"\\Device\\_HID%08x", HidClassDeviceNumber);
+    swprintf(CharDeviceName, L"\\Device\\_HID%08x", hidclassDevNum);
 
     /* initialize device name */
     RtlInitUnicodeString(&DeviceName, CharDeviceName);
@@ -136,8 +142,8 @@ HidClass_Create(
 {
     PIO_STACK_LOCATION IoStack;
     PHIDCLASS_COMMON_DEVICE_EXTENSION CommonDeviceExtension;
-    PHIDCLASS_PDO_DEVICE_EXTENSION PDODeviceExtension;
-    PHIDCLASS_FILEOP_CONTEXT Context;
+
+    DPRINT("[HIDCLASS] HidClass_Create\n");
 
     //
     // get device extension
@@ -145,23 +151,19 @@ HidClass_Create(
     CommonDeviceExtension = DeviceObject->DeviceExtension;
     if (CommonDeviceExtension->IsFDO)
     {
-        //
-        // only supported for PDO
-        //
-        Irp->IoStatus.Status = STATUS_UNSUCCESSFUL;
-        IoCompleteRequest(Irp, IO_NO_INCREMENT);
-        return STATUS_UNSUCCESSFUL;
+        DPRINT("[HIDCLASS] HidClass_Create fdo\n");
+         //
+         // only supported for PDO
+         //
+         Irp->IoStatus.Status = STATUS_UNSUCCESSFUL;
+         IoCompleteRequest(Irp, IO_NO_INCREMENT);
+         return STATUS_UNSUCCESSFUL;
     }
 
     //
     // must be a PDO
     //
     ASSERT(CommonDeviceExtension->IsFDO == FALSE);
-
-    //
-    // get device extension
-    //
-    PDODeviceExtension = DeviceObject->DeviceExtension;
 
     //
     // get stack location
@@ -171,36 +173,6 @@ HidClass_Create(
     DPRINT("ShareAccess %x\n", IoStack->Parameters.Create.ShareAccess);
     DPRINT("Options %x\n", IoStack->Parameters.Create.Options);
     DPRINT("DesiredAccess %x\n", IoStack->Parameters.Create.SecurityContext->DesiredAccess);
-
-    //
-    // allocate context
-    //
-    Context = ExAllocatePoolWithTag(NonPagedPool, sizeof(HIDCLASS_FILEOP_CONTEXT), HIDCLASS_TAG);
-    if (!Context)
-    {
-        //
-        // no memory
-        //
-        Irp->IoStatus.Status = STATUS_INSUFFICIENT_RESOURCES;
-        IoCompleteRequest(Irp, IO_NO_INCREMENT);
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    //
-    // init context
-    //
-    RtlZeroMemory(Context, sizeof(HIDCLASS_FILEOP_CONTEXT));
-    Context->DeviceExtension = PDODeviceExtension;
-    KeInitializeSpinLock(&Context->Lock);
-    InitializeListHead(&Context->ReadPendingIrpListHead);
-    InitializeListHead(&Context->IrpCompletedListHead);
-    KeInitializeEvent(&Context->IrpReadComplete, NotificationEvent, FALSE);
-
-    //
-    // store context
-    //
-    ASSERT(IoStack->FileObject);
-    IoStack->FileObject->FsContext = Context;
 
     //
     // done
@@ -216,13 +188,7 @@ HidClass_Close(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp)
 {
-    PIO_STACK_LOCATION IoStack;
     PHIDCLASS_COMMON_DEVICE_EXTENSION CommonDeviceExtension;
-    PHIDCLASS_FILEOP_CONTEXT IrpContext;
-    BOOLEAN IsRequestPending = FALSE;
-    KIRQL OldLevel;
-    PLIST_ENTRY Entry;
-    PIRP ListIrp;
 
     //
     // get device extension
@@ -243,101 +209,6 @@ HidClass_Close(
     }
 
     //
-    // get stack location
-    //
-    IoStack = IoGetCurrentIrpStackLocation(Irp);
-
-    //
-    // sanity checks
-    //
-    ASSERT(IoStack->FileObject);
-    ASSERT(IoStack->FileObject->FsContext);
-
-    //
-    // get irp context
-    //
-    IrpContext = IoStack->FileObject->FsContext;
-    ASSERT(IrpContext);
-
-    //
-    // acquire lock
-    //
-    KeAcquireSpinLock(&IrpContext->Lock, &OldLevel);
-
-    if (!IsListEmpty(&IrpContext->ReadPendingIrpListHead))
-    {
-        //
-        // FIXME cancel irp
-        //
-        IsRequestPending = TRUE;
-    }
-
-    //
-    // signal stop
-    //
-    IrpContext->StopInProgress = TRUE;
-
-    //
-    // release lock
-    //
-    KeReleaseSpinLock(&IrpContext->Lock, OldLevel);
-
-    if (IsRequestPending)
-    {
-        //
-        // wait for request to complete
-        //
-        DPRINT1("[HIDCLASS] Waiting for read irp completion...\n");
-        KeWaitForSingleObject(&IrpContext->IrpReadComplete, Executive, KernelMode, FALSE, NULL);
-    }
-
-    //
-    // acquire lock
-    //
-    KeAcquireSpinLock(&IrpContext->Lock, &OldLevel);
-
-    //
-    // sanity check
-    //
-    ASSERT(IsListEmpty(&IrpContext->ReadPendingIrpListHead));
-
-    //
-    // now free all irps
-    //
-    while (!IsListEmpty(&IrpContext->IrpCompletedListHead))
-    {
-        //
-        // remove head irp
-        //
-        Entry = RemoveHeadList(&IrpContext->IrpCompletedListHead);
-
-        //
-        // get irp
-        //
-        ListIrp = CONTAINING_RECORD(Entry, IRP, Tail.Overlay.ListEntry);
-
-        //
-        // free the irp
-        //
-        IoFreeIrp(ListIrp);
-    }
-
-    //
-    // release lock
-    //
-    KeReleaseSpinLock(&IrpContext->Lock, OldLevel);
-
-    //
-    // remove context
-    //
-    IoStack->FileObject->FsContext = NULL;
-
-    //
-    // free context
-    //
-    ExFreePoolWithTag(IrpContext, HIDCLASS_TAG);
-
-    //
     // complete request
     //
     Irp->IoStatus.Status = STATUS_SUCCESS;
@@ -345,337 +216,59 @@ HidClass_Close(
     return STATUS_SUCCESS;
 }
 
-NTSTATUS
-NTAPI
-HidClass_ReadCompleteIrp(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP Irp,
-    IN PVOID Ctx)
+BOOLEAN HidClass_QueueIrp(PHIDCLASS_PDO_DEVICE_EXTENSION deviceContext, PIRP Irp)
 {
-    PHIDCLASS_IRP_CONTEXT IrpContext;
-    KIRQL OldLevel;
-    PUCHAR Address;
-    ULONG Offset;
-    PHIDP_COLLECTION_DESC CollectionDescription;
-    PHIDP_REPORT_IDS ReportDescription;
-    BOOLEAN IsEmpty;
+    PDRIVER_CANCEL oldCancelRoutine;
 
-    //
-    // get irp context
-    //
-    IrpContext = Ctx;
+    IoMarkIrpPending(Irp);
 
-    DPRINT("HidClass_ReadCompleteIrp Irql %lu\n", KeGetCurrentIrql());
-    DPRINT("HidClass_ReadCompleteIrp Status %lx\n", Irp->IoStatus.Status);
-    DPRINT("HidClass_ReadCompleteIrp Length %lu\n", Irp->IoStatus.Information);
-    DPRINT("HidClass_ReadCompleteIrp Irp %p\n", Irp);
-    DPRINT("HidClass_ReadCompleteIrp InputReportBuffer %p\n", IrpContext->InputReportBuffer);
-    DPRINT("HidClass_ReadCompleteIrp InputReportBufferLength %li\n", IrpContext->InputReportBufferLength);
-    DPRINT("HidClass_ReadCompleteIrp OriginalIrp %p\n", IrpContext->OriginalIrp);
+    // check if canceled
+    oldCancelRoutine = IoSetCancelRoutine(Irp, HidClassPDO_IrpCancelRoutine);
+    ASSERT(oldCancelRoutine == NULL);
 
-    //
-    // copy result
-    //
-    if (Irp->IoStatus.Information)
+    if (Irp->Cancel == TRUE)
     {
-        //
-        // get address
-        //
-        Address = MmGetSystemAddressForMdlSafe(IrpContext->OriginalIrp->MdlAddress, NormalPagePriority);
-        if (Address)
+        // Is cancel routine called?
+        oldCancelRoutine = IoSetCancelRoutine(Irp, NULL);
+        if (oldCancelRoutine != NULL)
         {
-            //
-            // reports may have a report id prepended
-            //
-            Offset = 0;
-
-            //
-            // get collection description
-            //
-            CollectionDescription = HidClassPDO_GetCollectionDescription(&IrpContext->FileOp->DeviceExtension->Common.DeviceDescription,
-                                                                         IrpContext->FileOp->DeviceExtension->CollectionNumber);
-            ASSERT(CollectionDescription);
-
-            //
-            // get report description
-            //
-            ReportDescription = HidClassPDO_GetReportDescription(&IrpContext->FileOp->DeviceExtension->Common.DeviceDescription,
-                                                                 IrpContext->FileOp->DeviceExtension->CollectionNumber);
-            ASSERT(ReportDescription);
-
-            if (CollectionDescription && ReportDescription)
-            {
-                //
-                // calculate offset
-                //
-                ASSERT(CollectionDescription->InputLength >= ReportDescription->InputLength);
-                Offset = CollectionDescription->InputLength - ReportDescription->InputLength;
-            }
-
-            //
-            // copy result
-            //
-            RtlCopyMemory(&Address[Offset], IrpContext->InputReportBuffer, IrpContext->InputReportBufferLength);
+            // cancel routine not called
+            // IRP must be completed
+            return FALSE;
         }
-    }
-
-    //
-    // copy result status
-    //
-    IrpContext->OriginalIrp->IoStatus.Status = Irp->IoStatus.Status;
-    IrpContext->OriginalIrp->IoStatus.Information = Irp->IoStatus.Information;
-
-    //
-    // free input report buffer
-    //
-    ExFreePoolWithTag(IrpContext->InputReportBuffer, HIDCLASS_TAG);
-
-    //
-    // remove us from pending list
-    //
-    KeAcquireSpinLock(&IrpContext->FileOp->Lock, &OldLevel);
-
-    //
-    // remove from pending list
-    //
-    RemoveEntryList(&Irp->Tail.Overlay.ListEntry);
-
-    //
-    // is list empty
-    //
-    IsEmpty = IsListEmpty(&IrpContext->FileOp->ReadPendingIrpListHead);
-
-    //
-    // insert into completed list
-    //
-    InsertTailList(&IrpContext->FileOp->IrpCompletedListHead, &Irp->Tail.Overlay.ListEntry);
-
-    //
-    // release lock
-    //
-    KeReleaseSpinLock(&IrpContext->FileOp->Lock, OldLevel);
-
-    //
-    // complete original request
-    //
-    IoCompleteRequest(IrpContext->OriginalIrp, IO_NO_INCREMENT);
-
-
-    DPRINT("StopInProgress %x IsEmpty %x\n", IrpContext->FileOp->StopInProgress, IsEmpty);
-    if (IrpContext->FileOp->StopInProgress && IsEmpty)
-    {
-        //
-        // last pending irp
-        //
-        DPRINT1("[HIDCLASS] LastPendingTransfer Signalling\n");
-        KeSetEvent(&IrpContext->FileOp->IrpReadComplete, 0, FALSE);
-    }
-
-    if (IrpContext->FileOp->StopInProgress && IsEmpty)
-    {
-        //
-        // last pending irp
-        //
-        DPRINT1("[HIDCLASS] LastPendingTransfer Signalling\n");
-        KeSetEvent(&IrpContext->FileOp->IrpReadComplete, 0, FALSE);
-    }
-
-    //
-    // free irp context
-    //
-    ExFreePoolWithTag(IrpContext, HIDCLASS_TAG);
-
-    //
-    // done
-    //
-    return STATUS_MORE_PROCESSING_REQUIRED;
-}
-
-PIRP
-HidClass_GetIrp(
-    IN PHIDCLASS_FILEOP_CONTEXT Context)
-{
-    KIRQL OldLevel;
-    PIRP Irp = NULL;
-    PLIST_ENTRY ListEntry;
-
-    //
-    // acquire lock
-    //
-    KeAcquireSpinLock(&Context->Lock, &OldLevel);
-
-    //
-    // is list empty?
-    //
-    if (!IsListEmpty(&Context->IrpCompletedListHead))
-    {
-        //
-        // grab first entry
-        //
-        ListEntry = RemoveHeadList(&Context->IrpCompletedListHead);
-
-        //
-        // get irp
-        //
-        Irp = CONTAINING_RECORD(ListEntry, IRP, Tail.Overlay.ListEntry);
-    }
-
-    //
-    // release lock
-    //
-    KeReleaseSpinLock(&Context->Lock, OldLevel);
-
-    //
-    // done
-    //
-    return Irp;
-}
-
-NTSTATUS
-HidClass_BuildIrp(
-    IN PDEVICE_OBJECT DeviceObject,
-    IN PIRP RequestIrp,
-    IN PHIDCLASS_FILEOP_CONTEXT Context,
-    IN ULONG DeviceIoControlCode,
-    IN ULONG BufferLength,
-    OUT PIRP *OutIrp,
-    OUT PHIDCLASS_IRP_CONTEXT *OutIrpContext)
-{
-    PIRP Irp;
-    PIO_STACK_LOCATION IoStack;
-    PHIDCLASS_IRP_CONTEXT IrpContext;
-    PHIDCLASS_PDO_DEVICE_EXTENSION PDODeviceExtension;
-    PHIDP_COLLECTION_DESC CollectionDescription;
-    PHIDP_REPORT_IDS ReportDescription;
-
-    //
-    // get an irp from fresh list
-    //
-    Irp = HidClass_GetIrp(Context);
-    if (!Irp)
-    {
-        //
-        // build new irp
-        //
-        Irp = IoAllocateIrp(DeviceObject->StackSize, FALSE);
-        if (!Irp)
+        else
         {
-            //
-            // no memory
-            //
-            return STATUS_INSUFFICIENT_RESOURCES;
+            // cancel routine is called
+            // IRP will be closed by it
+            return TRUE;
         }
     }
     else
     {
-        //
-        // re-use irp
-        //
-        IoReuseIrp(Irp, STATUS_SUCCESS);
+        InsertTailList(&deviceContext->PendingIRPList, &Irp->Tail.Overlay.ListEntry);
     }
 
-    //
-    // allocate completion context
-    //
-    IrpContext = ExAllocatePoolWithTag(NonPagedPool, sizeof(HIDCLASS_IRP_CONTEXT), HIDCLASS_TAG);
-    if (!IrpContext)
-    {
-        //
-        // no memory
-        //
-        IoFreeIrp(Irp);
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
+    return TRUE;
+}
 
-    //
-    // get device extension
-    //
-    PDODeviceExtension = DeviceObject->DeviceExtension;
-    ASSERT(PDODeviceExtension->Common.IsFDO == FALSE);
+VOID
+NTAPI
+HidClassPDO_IrpCancelRoutine(IN PDEVICE_OBJECT DeviceObject, IN PIRP Irp)
+{
+    PHIDCLASS_PDO_DEVICE_EXTENSION deviceContext = DeviceObject->DeviceExtension;
+    KIRQL  oldIrql;
 
-    //
-    // init irp context
-    //
-    RtlZeroMemory(IrpContext, sizeof(HIDCLASS_IRP_CONTEXT));
-    IrpContext->OriginalIrp = RequestIrp;
-    IrpContext->FileOp = Context;
+    IoReleaseCancelSpinLock(Irp->CancelIrql);
 
-    //
-    // get collection description
-    //
-    CollectionDescription = HidClassPDO_GetCollectionDescription(&IrpContext->FileOp->DeviceExtension->Common.DeviceDescription,
-                                                                 IrpContext->FileOp->DeviceExtension->CollectionNumber);
-    ASSERT(CollectionDescription);
+    KeAcquireSpinLock(&deviceContext->ReadLock, &oldIrql);
 
-    //
-    // get report description
-    //
-    ReportDescription = HidClassPDO_GetReportDescription(&IrpContext->FileOp->DeviceExtension->Common.DeviceDescription,
-                                                         IrpContext->FileOp->DeviceExtension->CollectionNumber);
-    ASSERT(ReportDescription);
+    RemoveEntryList(&Irp->Tail.Overlay.ListEntry);
 
-    //
-    // sanity check
-    //
-    ASSERT(CollectionDescription->InputLength >= ReportDescription->InputLength);
+    KeReleaseSpinLock(&deviceContext->ReadLock, oldIrql);
 
-    if (Context->StopInProgress)
-    {
-        //
-        // stop in progress
-        //
-        DPRINT1("[HIDCLASS] Stop In Progress\n");
-        Irp->IoStatus.Status = STATUS_CANCELLED;
-        IoCompleteRequest(Irp, IO_NO_INCREMENT);
-        return STATUS_CANCELLED;
-
-    }
-
-    //
-    // store report length
-    //
-    IrpContext->InputReportBufferLength = ReportDescription->InputLength;
-
-    //
-    // allocate buffer
-    //
-    IrpContext->InputReportBuffer = ExAllocatePoolWithTag(NonPagedPool, IrpContext->InputReportBufferLength, HIDCLASS_TAG);
-    if (!IrpContext->InputReportBuffer)
-    {
-        //
-        // no memory
-        //
-        IoFreeIrp(Irp);
-        ExFreePoolWithTag(IrpContext, HIDCLASS_TAG);
-        return STATUS_INSUFFICIENT_RESOURCES;
-    }
-
-    //
-    // get stack location
-    //
-    IoStack = IoGetNextIrpStackLocation(Irp);
-
-    //
-    // init stack location
-    //
-    IoStack->MajorFunction = IRP_MJ_INTERNAL_DEVICE_CONTROL;
-    IoStack->Parameters.DeviceIoControl.IoControlCode = DeviceIoControlCode;
-    IoStack->Parameters.DeviceIoControl.OutputBufferLength = IrpContext->InputReportBufferLength;
-    IoStack->Parameters.DeviceIoControl.InputBufferLength = 0;
-    IoStack->Parameters.DeviceIoControl.Type3InputBuffer = NULL;
-    Irp->UserBuffer = IrpContext->InputReportBuffer;
-    IoStack->DeviceObject = DeviceObject;
-
-    //
-    // store result
-    //
-    *OutIrp = Irp;
-    *OutIrpContext = IrpContext;
-
-    //
-    // done
-    //
-    return STATUS_SUCCESS;
+    Irp->IoStatus.Status = STATUS_CANCELLED;
+    IoCompleteRequest(Irp, IO_NO_INCREMENT);
+    return;
 }
 
 NTSTATUS
@@ -684,114 +277,53 @@ HidClass_Read(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp)
 {
-    PIO_STACK_LOCATION IoStack;
-    PHIDCLASS_FILEOP_CONTEXT Context;
-    KIRQL OldLevel;
-    NTSTATUS Status;
-    PIRP NewIrp;
-    PHIDCLASS_IRP_CONTEXT NewIrpContext;
-    PHIDCLASS_COMMON_DEVICE_EXTENSION CommonDeviceExtension;
+    NTSTATUS status = STATUS_SUCCESS;
+    BOOLEAN isCompletionRequired = TRUE;
+    PHIDCLASS_PDO_DEVICE_EXTENSION PDODeviceExtension;
+    PUCHAR Address;
+    KIRQL CurrentIRQL;
 
-    //
-    // get current stack location
-    //
-    IoStack = IoGetCurrentIrpStackLocation(Irp);
+    //DPRINT("[HIDCLASS] HidClass_Read\n");
 
     //
     // get device extension
     //
-    CommonDeviceExtension = DeviceObject->DeviceExtension;
-    ASSERT(CommonDeviceExtension->IsFDO == FALSE);
+    PDODeviceExtension = DeviceObject->DeviceExtension;
+    ASSERT(PDODeviceExtension->Common.IsFDO == FALSE);
 
-    //
-    // sanity check
-    //
-    ASSERT(IoStack->FileObject);
-    ASSERT(IoStack->FileObject->FsContext);
-
-    //
-    // get context
-    //
-    Context = IoStack->FileObject->FsContext;
-    ASSERT(Context);
-
-    //
-    // FIXME support polled devices
-    //
-    ASSERT(Context->DeviceExtension->Common.DriverExtension->DevicesArePolled == FALSE);
-
-    if (Context->StopInProgress)
+    KeAcquireSpinLock(&PDODeviceExtension->ReadLock, &CurrentIRQL);
+    Address = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+    if (HidClass_CyclicBufferGet(&PDODeviceExtension->InputBuffer, Address) == TRUE)
     {
-        //
-        // stop in progress
-        //
-        DPRINT1("[HIDCLASS] Stop In Progress\n");
-        Irp->IoStatus.Status = STATUS_CANCELLED;
+        Irp->IoStatus.Information = HidClassPDO_GetCollectionDescription(&PDODeviceExtension->Common.DeviceDescription, PDODeviceExtension->CollectionNumber)->InputLength;
+        Irp->IoStatus.Status = STATUS_SUCCESS;
+        status = STATUS_SUCCESS;
+        isCompletionRequired = TRUE;
+    }
+    else
+    {
+        if (HidClass_QueueIrp(PDODeviceExtension, Irp) == TRUE)
+        {
+            status = STATUS_PENDING;
+            isCompletionRequired = FALSE;
+        }
+        else
+        {
+            Irp->IoStatus.Information = 0;
+            Irp->IoStatus.Status = STATUS_CANCELLED;
+            status = STATUS_PENDING;
+            isCompletionRequired = TRUE;
+        }
+    }
+    KeReleaseSpinLock(&PDODeviceExtension->ReadLock, CurrentIRQL);
+
+    // complete request outside spinLock, if required
+    if (isCompletionRequired == TRUE)
+    {
         IoCompleteRequest(Irp, IO_NO_INCREMENT);
-        return STATUS_CANCELLED;
     }
 
-    //
-    // build irp request
-    //
-    Status = HidClass_BuildIrp(DeviceObject,
-                               Irp,
-                               Context,
-                               IOCTL_HID_READ_REPORT,
-                               IoStack->Parameters.Read.Length,
-                               &NewIrp,
-                               &NewIrpContext);
-    if (!NT_SUCCESS(Status))
-    {
-        //
-        // failed
-        //
-        DPRINT1("HidClass_BuildIrp failed with %x\n", Status);
-        Irp->IoStatus.Status = Status;
-        IoCompleteRequest(Irp, IO_NO_INCREMENT);
-        return Status;
-    }
-
-    //
-    // acquire lock
-    //
-    KeAcquireSpinLock(&Context->Lock, &OldLevel);
-
-    //
-    // insert irp into pending list
-    //
-    InsertTailList(&Context->ReadPendingIrpListHead, &NewIrp->Tail.Overlay.ListEntry);
-
-    //
-    // set completion routine
-    //
-    IoSetCompletionRoutine(NewIrp, HidClass_ReadCompleteIrp, NewIrpContext, TRUE, TRUE, TRUE);
-
-    //
-    // make next location current
-    //
-    IoSetNextIrpStackLocation(NewIrp);
-
-    //
-    // release spin lock
-    //
-    KeReleaseSpinLock(&Context->Lock, OldLevel);
-
-    //
-    // mark irp pending
-    //
-    IoMarkIrpPending(Irp);
-
-    //
-    // let's dispatch the request
-    //
-    ASSERT(Context->DeviceExtension);
-    Status = Context->DeviceExtension->Common.DriverExtension->MajorFunction[IRP_MJ_INTERNAL_DEVICE_CONTROL](Context->DeviceExtension->FDODeviceObject, NewIrp);
-
-    //
-    // complete
-    //
-    return STATUS_PENDING;
+    return status;
 }
 NTSTATUS
 NTAPI

--- a/drivers/hid/hidclass/hidclass.c
+++ b/drivers/hid/hidclass/hidclass.c
@@ -131,6 +131,8 @@ NTAPI
 HidClassDriverUnload(
     IN PDRIVER_OBJECT DriverObject)
 {
+    UNREFERENCED_PARAMETER(DriverObject);
+
     UNIMPLEMENTED;
 }
 
@@ -355,6 +357,7 @@ HidClass_Write(
     XferPacket.reportId = XferPacket.reportBuffer[0];
 
     CommonDeviceExtension = DeviceObject->DeviceExtension;
+    KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
     SubIrp = IoBuildDeviceIoControlRequest(
         IOCTL_HID_WRITE_REPORT,
         CommonDeviceExtension->HidDeviceExtension.NextDeviceObject,
@@ -370,7 +373,6 @@ HidClass_Write(
         return STATUS_NOT_IMPLEMENTED;
     }
     SubIrp->UserBuffer = &XferPacket;
-    KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
     Status = IoCallDriver(CommonDeviceExtension->HidDeviceExtension.NextDeviceObject, SubIrp);
     if (Status == STATUS_PENDING)
     {
@@ -542,6 +544,7 @@ HidClass_DeviceControl(
                 return STATUS_INSUFFICIENT_RESOURCES;
             }
 
+            KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
             SubIrp = IoBuildDeviceIoControlRequest(
                 IOCTL_HID_GET_FEATURE,
                 CommonDeviceExtension->HidDeviceExtension.NextDeviceObject,
@@ -557,7 +560,6 @@ HidClass_DeviceControl(
                 return STATUS_NOT_IMPLEMENTED;
             }
             SubIrp->UserBuffer = &XferPacket;
-            KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
             Status = IoCallDriver(CommonDeviceExtension->HidDeviceExtension.NextDeviceObject, SubIrp);
             if (Status == STATUS_PENDING)
             {
@@ -596,6 +598,7 @@ HidClass_DeviceControl(
             XferPacket.reportBuffer = Irp->AssociatedIrp.SystemBuffer;
             XferPacket.reportId = XferPacket.reportBuffer[0];
 
+            KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
             SubIrp = IoBuildDeviceIoControlRequest(
                 IOCTL_HID_SET_FEATURE,
                 CommonDeviceExtension->HidDeviceExtension.NextDeviceObject,
@@ -611,7 +614,6 @@ HidClass_DeviceControl(
                 return STATUS_NOT_IMPLEMENTED;
             }
             SubIrp->UserBuffer = &XferPacket;
-            KeInitializeEvent(&Event, SynchronizationEvent, FALSE);
             Status = IoCallDriver(CommonDeviceExtension->HidDeviceExtension.NextDeviceObject, SubIrp);
             if (Status == STATUS_PENDING)
             {
@@ -695,6 +697,8 @@ HidClass_InternalDeviceControl(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp)
 {
+    UNREFERENCED_PARAMETER(DeviceObject);
+
     UNIMPLEMENTED;
     ASSERT(FALSE);
     Irp->IoStatus.Status = STATUS_NOT_IMPLEMENTED;

--- a/drivers/hid/hidclass/pdo.c
+++ b/drivers/hid/hidclass/pdo.c
@@ -1,16 +1,16 @@
 /*
  * PROJECT:     ReactOS Universal Serial Bus Human Interface Device Driver
- * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        drivers/hid/hidclass/fdo.c
+ * LICENSE:     GPL-3.0-or-later (https://spdx.org/licenses/GPL-3.0-or-later)
  * PURPOSE:     HID Class Driver
- * PROGRAMMERS:
- *              Michael Martin (michael.martin@reactos.org)
- *              Johannes Anderwald (johannes.anderwald@reactos.org)
+ * COPYRIGHT:   Copyright  Michael Martin <michael.martin@reactos.org>
+ *              Copyright  Johannes Anderwald <johannes.anderwald@reactos.org>
+ *              Copyright 2022 Roman Masanin <36927roma@gmail.com>
  */
 
 #include "precomp.h"
 
 #include <wdmguid.h>
+#include "cyclicbuffer.h"
 
 #define NDEBUG
 #include <debug.h>
@@ -98,6 +98,7 @@ HidClassPDO_HandleQueryDeviceId(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp)
 {
+    const WCHAR HidBusName[] = L"HID\\";
     NTSTATUS Status;
     LPWSTR Buffer;
     LPWSTR NewBuffer, Ptr;
@@ -124,12 +125,18 @@ HidClassPDO_HandleQueryDeviceId(
     // get buffer
     //
     Buffer = (LPWSTR)Irp->IoStatus.Information;
-    Length = wcslen(Buffer);
+    Length = wcslen(Buffer) + 1;
+
+    // Make sure busName fit
+    Length *= sizeof(WCHAR);
+    Length += sizeof(HidBusName);
+
+    ASSERT(Length > 10);
 
     //
     // allocate new buffer
     //
-    NewBuffer = ExAllocatePoolWithTag(NonPagedPool, (Length + 1) * sizeof(WCHAR), HIDCLASS_TAG);
+    NewBuffer = ExAllocatePoolWithTag(NonPagedPool, Length, HIDCLASS_TAG);
     if (!NewBuffer)
     {
         //
@@ -141,7 +148,7 @@ HidClassPDO_HandleQueryDeviceId(
     //
     // replace bus
     //
-    wcscpy(NewBuffer, L"HID\\");
+    wcscpy(NewBuffer, HidBusName);
 
     //
     // get offset to first '\\'
@@ -337,7 +344,7 @@ HidClassPDO_HandleQueryInstanceId(
     //
     // write device id
     //
-    swprintf(Buffer, L"%04x", PDODeviceExtension->CollectionNumber);
+    swprintf(Buffer, L"%04x", (UINT16)(PDODeviceExtension->CollectionNumber & 0xFFFF));
     Irp->IoStatus.Information = (ULONG_PTR)Buffer;
 
     //
@@ -453,6 +460,21 @@ HidClassPDO_PnP(
                 Status = STATUS_DEVICE_CONFIGURATION_ERROR;
                 break;
             }
+            PHIDP_COLLECTION_DESC ColDesc;
+            ColDesc = HidClassPDO_GetCollectionDescription(&PDODeviceExtension->Common.DeviceDescription,
+                                                           PDODeviceExtension->CollectionNumber);
+            if (ColDesc->UsagePage == HID_USAGE_PAGE_GENERIC &&
+                (ColDesc->Usage == HID_USAGE_GENERIC_MOUSE ||
+                 ColDesc->Usage == HID_USAGE_GENERIC_KEYBOARD))
+            {
+                // Disable raw access for mouses and keybords
+                PDODeviceExtension->Capabilities.RawDeviceOK = FALSE;
+            }
+            else
+            {
+                // And enable for others
+                PDODeviceExtension->Capabilities.RawDeviceOK = TRUE;
+            }
 
             //
             // copy capabilities
@@ -469,6 +491,8 @@ HidClassPDO_PnP(
             //
             //
             BusInformation = ExAllocatePoolWithTag(NonPagedPool, sizeof(PNP_BUS_INFORMATION), HIDCLASS_TAG);
+            // TODO: handle error
+            ASSERT(BusInformation != NULL);
 
             //
             // fill in result
@@ -537,37 +561,39 @@ HidClassPDO_PnP(
         {
             //
             // FIXME: support polled devices
+            // FIXME: START LOOPS
             //
+            HidClassFDO_InitiateRead(PDODeviceExtension->FDODeviceExtension);
+
             ASSERT(PDODeviceExtension->Common.DriverExtension->DevicesArePolled == FALSE);
 
             //
             // now register the device interface
             //
-            Status = IoRegisterDeviceInterface(PDODeviceExtension->Common.HidDeviceExtension.PhysicalDeviceObject,
+            Status = IoRegisterDeviceInterface(
+                                               DeviceObject,
                                                &GUID_DEVINTERFACE_HID,
                                                NULL,
                                                &PDODeviceExtension->DeviceInterface);
-            DPRINT("[HIDCLASS] IoRegisterDeviceInterfaceState Status %x\n", Status);
+            DPRINT("[HIDCLASS] IRP_MN_START_DEVICE IoRegisterDeviceInterfaceState Status %x\n", Status);
             if (NT_SUCCESS(Status))
             {
                 //
                 // enable device interface
                 //
                 Status = IoSetDeviceInterfaceState(&PDODeviceExtension->DeviceInterface, TRUE);
-                DPRINT("[HIDCLASS] IoSetDeviceInterFaceState %x\n", Status);
+                DPRINT("[HIDCLASS] IRP_MN_START_DEVICE IoSetDeviceInterFaceState %x\n", Status);
             }
-
-            //
-            // done
-            //
-            Status = STATUS_SUCCESS;
             break;
         }
         case IRP_MN_REMOVE_DEVICE:
         {
             /* Disable the device interface */
             if (PDODeviceExtension->DeviceInterface.Length != 0)
-                IoSetDeviceInterfaceState(&PDODeviceExtension->DeviceInterface, FALSE);
+            {
+                Status = IoSetDeviceInterfaceState(&PDODeviceExtension->DeviceInterface, FALSE);
+                DPRINT("[HIDCLASS] IRP_MN_REMOVE_DEVICE IoSetDeviceInterFaceState %x\n", Status);
+            }
 
             //
             // remove us from the fdo's pdo list
@@ -740,6 +766,10 @@ HidClassPDO_CreatePDO(
         PDODeviceExtension->Common.DriverExtension = FDODeviceExtension->Common.DriverExtension;
         PDODeviceExtension->CollectionNumber = FDODeviceExtension->Common.DeviceDescription.CollectionDesc[Index].CollectionNumber;
 
+        HidClass_CyclicBufferInitialize(&PDODeviceExtension->InputBuffer, FDODeviceExtension->Common.DeviceDescription.CollectionDesc[Index].InputLength);
+        InitializeListHead(&PDODeviceExtension->PendingIRPList);
+        KeInitializeSpinLock(&PDODeviceExtension->ReadLock);
+
         //
         // copy device data
         //
@@ -750,7 +780,8 @@ HidClassPDO_CreatePDO(
         //
         // set device flags
         //
-        PDODeviceObject->Flags |= DO_MAP_IO_BUFFER;
+        PDODeviceObject->Flags |= DO_DIRECT_IO;
+
 
         //
         // device is initialized

--- a/drivers/hid/hidclass/pdo.c
+++ b/drivers/hid/hidclass/pdo.c
@@ -360,6 +360,8 @@ HidClassPDO_HandleQueryCompatibleId(
 {
     LPWSTR Buffer;
 
+    UNREFERENCED_PARAMETER(DeviceObject);
+
     Buffer = ExAllocatePoolWithTag(NonPagedPool, 2 * sizeof(WCHAR), HIDCLASS_TAG);
     if (!Buffer)
     {
@@ -567,9 +569,7 @@ HidClassPDO_PnP(
 
             ASSERT(PDODeviceExtension->Common.DriverExtension->DevicesArePolled == FALSE);
 
-            //
             // now register the device interface
-            //
             Status = IoRegisterDeviceInterface(
                                                DeviceObject,
                                                &GUID_DEVINTERFACE_HID,
@@ -578,9 +578,7 @@ HidClassPDO_PnP(
             DPRINT("[HIDCLASS] IRP_MN_START_DEVICE IoRegisterDeviceInterfaceState Status %x\n", Status);
             if (NT_SUCCESS(Status))
             {
-                //
                 // enable device interface
-                //
                 Status = IoSetDeviceInterfaceState(&PDODeviceExtension->DeviceInterface, TRUE);
                 DPRINT("[HIDCLASS] IRP_MN_START_DEVICE IoSetDeviceInterFaceState %x\n", Status);
             }

--- a/drivers/hid/hidclass/precomp.h
+++ b/drivers/hid/hidclass/precomp.h
@@ -6,6 +6,7 @@
 #include <hidpddi.h>
 #include <stdio.h>
 #include <hidport.h>
+#include "cyclicbuffer.h"
 
 #define HIDCLASS_TAG 'CdiH'
 
@@ -77,6 +78,11 @@ typedef struct
     //
     PDEVICE_RELATIONS DeviceRelations;
 
+    BOOLEAN IsReadLoopStarted;
+    PUCHAR InputBuffer;
+    USHORT InputBufferSize;
+    PUCHAR InputWriteAddress;
+    PIRP InputIRP;
 } HIDCLASS_FDO_EXTENSION, *PHIDCLASS_FDO_EXTENSION;
 
 typedef struct
@@ -111,70 +117,16 @@ typedef struct
     //
     PHIDCLASS_FDO_EXTENSION FDODeviceExtension;
 
+
+
+    HIDCHASS_CYCLIC_BUFFER InputBuffer;
+
+    LIST_ENTRY PendingIRPList;
+
+    KSPIN_LOCK ReadLock;
 } HIDCLASS_PDO_DEVICE_EXTENSION, *PHIDCLASS_PDO_DEVICE_EXTENSION;
 
-typedef struct __HIDCLASS_FILEOP_CONTEXT__
-{
-    //
-    // device extension
-    //
-    PHIDCLASS_PDO_DEVICE_EXTENSION DeviceExtension;
-
-    //
-    // spin lock
-    //
-    KSPIN_LOCK Lock;
-
-    //
-    // read irp pending list
-    //
-    LIST_ENTRY ReadPendingIrpListHead;
-
-    //
-    // completed irp list
-    //
-    LIST_ENTRY IrpCompletedListHead;
-
-    //
-    // stop in progress indicator
-    //
-    BOOLEAN StopInProgress;
-
-    //
-    // read complete event
-    //
-    KEVENT IrpReadComplete;
-
-} HIDCLASS_FILEOP_CONTEXT, *PHIDCLASS_FILEOP_CONTEXT;
-
-typedef struct
-{
-    //
-    // original request
-    //
-    PIRP OriginalIrp;
-
-    //
-    // file op
-    //
-    PHIDCLASS_FILEOP_CONTEXT FileOp;
-
-    //
-    // buffer for reading report
-    //
-    PVOID InputReportBuffer;
-
-    //
-    // buffer length
-    //
-    ULONG InputReportBufferLength;
-
-    //
-    // work item
-    //
-    PIO_WORKITEM CompletionWorkItem;
-
-} HIDCLASS_IRP_CONTEXT, *PHIDCLASS_IRP_CONTEXT;
+DRIVER_CANCEL HidClassPDO_IrpCancelRoutine;
 
 /* fdo.c */
 NTSTATUS
@@ -191,6 +143,19 @@ NTSTATUS
 HidClassFDO_DispatchRequestSynchronous(
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp);
+
+NTSTATUS
+NTAPI
+HidClassFDO_ReadCompletion(
+    IN PDEVICE_OBJECT  DeviceObject,
+    IN PIRP  Irp,
+    IN PVOID  Context);
+
+NTSTATUS
+HidClassFDO_SubmitRead(IN PHIDCLASS_FDO_EXTENSION DeviceExtension);
+
+NTSTATUS
+HidClassFDO_InitiateRead(IN PHIDCLASS_FDO_EXTENSION DeviceExtension);
 
 /* pdo.c */
 NTSTATUS

--- a/drivers/hid/hidclass/precomp.h
+++ b/drivers/hid/hidclass/precomp.h
@@ -2,6 +2,7 @@
 #define _HIDCLASS_PCH_
 
 #define _HIDPI_NO_FUNCTION_MACROS_
+
 #include <wdm.h>
 #include <hidpddi.h>
 #include <stdio.h>
@@ -48,7 +49,6 @@ typedef struct
     // hid attributes
     //
     HID_DEVICE_ATTRIBUTES Attributes;
-
 } HIDCLASS_COMMON_DEVICE_EXTENSION, *PHIDCLASS_COMMON_DEVICE_EXTENSION;
 
 typedef struct

--- a/drivers/hid/mouhid/mouhid.h
+++ b/drivers/hid/mouhid/mouhid.h
@@ -129,6 +129,8 @@ typedef struct
     //
     HIDP_VALUE_CAPS ValueCapsY;
 
+    volatile LONG ReferenceCount;
+
 } MOUHID_DEVICE_EXTENSION, *PMOUHID_DEVICE_EXTENSION;
 
 #define WHEEL_DELTA 120


### PR DESCRIPTION
## Purpose
Fixed hidclass read routine architecture, now hidclass start ping-pong IRP loop for proper reading.
Fixed issue in MOUHID_Close, now the device will not stop while in use.
Added HidUsb_GetStringDescriptor implementation


## Proposed changes
Improve ROS HID stack 

## TODO
-WANRNING, this version allows raw access to mouse and keyboard devices, this is serious security flow, but it can be fixed much easier after refactoring.
-REFACTORING (separate commit\PR)
