### PR TITLE
[SHELL32] Fix Assertion when opening "File" menu in MyComputer twice

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1310,6 +1310,13 @@ HRESULT CDefView::FillFileMenu()
     if (!hFileMenu)
         return E_FAIL;
 
+    /* Release cached IContextMenu */
+    if (m_pCM)
+    {
+        IUnknown_SetSite(m_pCM, NULL);
+        m_pCM.Release();
+    }
+
     /* Cleanup the items added previously */
     for (int i = GetMenuItemCount(hFileMenu) - 1; i >= 0; i--)
     {


### PR DESCRIPTION
## Purpose

_ ReactOS asserts when opening File menu in MyComputer for the second time
![image](https://user-images.githubusercontent.com/112266950/189473867-913f8412-7bf0-4ca9-94c0-0a295a3e6c83.png)
_ This is due to the cached copy of IContextMenu not being released before attempting to cache it again.

JIRA issue: [CORE-18353](https://jira.reactos.org/browse/CORE-18353)

## Proposed changes

_ Fix based on the patch proposed by user https://jira.reactos.org/secure/ViewProfile.jspa?name=I_Kill_Bugs