### PR TITLE
[MSPAINT][EXPLORER][SHELL32] Enable ATL asserts in CMake

### DIFF
--- a/base/applications/mspaint/CMakeLists.txt
+++ b/base/applications/mspaint/CMakeLists.txt
@@ -2,6 +2,10 @@ project(MSPAINT)
 
 add_definitions(-DINITGUID)
 
+if(DBG)
+    add_definitions(-D_DEBUG=1) # CORE-17505
+endif()
+
 list(APPEND SOURCE
     dialogs.cpp
     dib.cpp

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -6,10 +6,6 @@
     #undef _DEBUG
 #endif
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG
-#endif
-
 #include <stdarg.h>
 
 #include <windef.h>

--- a/base/shell/explorer/CMakeLists.txt
+++ b/base/shell/explorer/CMakeLists.txt
@@ -1,5 +1,9 @@
 PROJECT(SHELL)
 
+if(DBG)
+    add_definitions(-D_DEBUG=1) # CORE-17505
+endif()
+
 list(APPEND SOURCE
     appbar.cpp
     desktop.cpp

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -9,10 +9,6 @@
 #define WIN7_COMPAT_MODE 1
 #endif
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG     // CORE-17505
-#endif
-
 #include <stdio.h>
 #include <tchar.h>
 

--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -13,6 +13,10 @@ add_definitions(
     -D_SHELL32_
     -D_WINE)
 
+if(DBG)
+    add_definitions(-D_DEBUG=1) # CORE-17505
+endif()
+
 list(APPEND SOURCE
     CActiveDesktop.cpp
     CActiveDesktop.h

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -1,10 +1,6 @@
 #ifndef _PRECOMP_H__
 #define _PRECOMP_H__
 
-#if DBG && !defined(_DEBUG)
-    #define _DEBUG  // CORE-17505
-#endif
-
 #include <stdarg.h>
 #include <assert.h>
 

--- a/dll/win32/shell32/shellmenu/CMakeLists.txt
+++ b/dll/win32/shell32/shellmenu/CMakeLists.txt
@@ -4,6 +4,10 @@ add_definitions(
     -DUNICODE
     -D_UNICODE)
 
+if(DBG)
+    add_definitions(-D_DEBUG=1) # CORE-17505
+endif()
+
 list(APPEND SOURCE
     CMenuBand.cpp
     CMenuDeskBar.cpp


### PR DESCRIPTION


In MSVC builds they would not work reliably when enabled in the precompiled header


JIRA issue: [CORE-17505](https://jira.reactos.org/browse/CORE-17505)
