### PR TITLE
[NTFS] PrintAllVCNs(): Fix a typo in an ASSERT()

### DIFF
--- a/drivers/filesystems/ntfs/btree.c
+++ b/drivers/filesystems/ntfs/btree.c
@@ -56,7 +56,7 @@ PrintAllVCNs(PDEVICE_EXTENSION Vcb,
 
     BytesRead = ReadAttribute(Vcb, IndexAllocationContext, 0, (PCHAR)Buffer, BufferSize);
 
-    ASSERT(BytesRead = BufferSize);
+    ASSERT(BytesRead == BufferSize);
 
     CurrentNode = Buffer;
 


### PR DESCRIPTION
Obvious typo.