### PR TITLE
[SHELL32] Fix Assert when hitting DEL or F2 in Recycle Bin (or copying files)

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1656,14 +1656,21 @@ LRESULT CDefView::OnExplorerCommand(UINT uCommand, BOOL bUseSelection)
     HRESULT hResult;
     HMENU hMenu = NULL;
 
+    if (m_pCM)
+    {
+        IUnknown_SetSite(m_pCM, NULL);
+        m_pCM.Release();
+    }
+
     hResult = GetItemObject( bUseSelection ? SVGIO_SELECTION : SVGIO_BACKGROUND, IID_PPV_ARG(IContextMenu, &m_pCM));
     if (FAILED_UNEXPECTEDLY( hResult))
         goto cleanup;
+
     if ((uCommand != FCIDM_SHVIEW_DELETE) && (uCommand != FCIDM_SHVIEW_RENAME))
     {
         hMenu = CreatePopupMenu();
         if (!hMenu)
-            return 0;
+            goto cleanup;
 
         hResult = m_pCM->QueryContextMenu(hMenu, 0, FCIDM_SHVIEWFIRST, FCIDM_SHVIEWLAST, CMF_NORMAL);
         if (FAILED_UNEXPECTEDLY(hResult))
@@ -1676,18 +1683,18 @@ LRESULT CDefView::OnExplorerCommand(UINT uCommand, BOOL bUseSelection)
         SFGAOF rfg = SFGAO_BROWSABLE | SFGAO_CANCOPY | SFGAO_CANLINK | SFGAO_CANMOVE | SFGAO_CANDELETE | SFGAO_CANRENAME | SFGAO_HASPROPSHEET | SFGAO_FILESYSTEM | SFGAO_FOLDER;
         hResult = m_pSFParent->GetAttributesOf(m_cidl, m_apidl, &rfg);
         if (FAILED_UNEXPECTEDLY(hResult))
-            return 0;
+            goto cleanup;
 
         if (!(rfg & SFGAO_CANMOVE) && uCommand == FCIDM_SHVIEW_CUT)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANCOPY) && uCommand == FCIDM_SHVIEW_COPY)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANDELETE) && uCommand == FCIDM_SHVIEW_DELETE)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANRENAME) && uCommand == FCIDM_SHVIEW_RENAME)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_HASPROPSHEET) && uCommand == FCIDM_SHVIEW_PROPERTIES)
-            return 0;
+            goto cleanup;
     }
 
     InvokeContextMenuCommand(uCommand);


### PR DESCRIPTION
Due to improper return without calling "cleanup" code

## Purpose

_ Remplace incorrect "return" call to call for "cleanup" section

JIRA issue: [CORE-18361](https://jira.reactos.org/browse/CORE-18361)
JIRA issue: [CORE-18345](https://jira.reactos.org/browse/CORE-18345)
JIRA issue: [CORE-18321](https://jira.reactos.org/browse/CORE-18321)

Next steps will be to implement Delete (and fix CM Deleted action on multiple files as per CORE-18359) action using keyboard "del" key which is not supported (currently asserts without action) in **another** PR.