### PR TITLE
[DOC] 3rd Party Files.txt: Fix Buslogic driver version

### DIFF
--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -147,7 +147,7 @@ URL: http://alter.org.ua/soft/win/uni_ata/
 
 Title: Miniport driver for the Buslogic BT 958 SCSI Controller
 Path: drivers/storage/port/buslogic
-Used Version: v1.2.0.2 (2005-08-17)
+Used Version: 1.2.0.4 (2005-08-17)
 License: GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
 URL: https://customerconnect.vmware.com/downloads/details?productId=23&downloadGroup=SERVER-SCSI-OS
 


### PR DESCRIPTION
Rather use version from active line in .rc than from comment in .c.

Addendum to 5ee633f (0.4.15-dev-4556).
JIRA issue: [CORE-18180](https://jira.reactos.org/browse/CORE-18180)

(Split off from #4642.)