### PR TITLE
[USER32] Load keyboard layouts on logon correctly

### DIFF
--- a/win32ss/user/user32/include/user32p.h
+++ b/win32ss/user/user32/include/user32p.h
@@ -130,5 +130,6 @@ HANDLE FASTCALL UserGetProp(HWND hWnd, ATOM Atom, BOOLEAN SystemProp);
 BOOL WINAPI InitializeImmEntryTable(VOID);
 HRESULT User32GetImmFileName(_Out_ LPWSTR lpBuffer, _In_ size_t cchBuffer);
 BOOL WINAPI UpdatePerUserImmEnabling(VOID);
+VOID APIENTRY CliImmInitializeHotKeys(DWORD dwAction, HKL hKL);
 
 /* EOF */

--- a/win32ss/user/user32/include/user32p.h
+++ b/win32ss/user/user32/include/user32p.h
@@ -131,5 +131,6 @@ BOOL WINAPI InitializeImmEntryTable(VOID);
 HRESULT User32GetImmFileName(_Out_ LPWSTR lpBuffer, _In_ size_t cchBuffer);
 BOOL WINAPI UpdatePerUserImmEnabling(VOID);
 VOID APIENTRY CliImmInitializeHotKeys(DWORD dwAction, HKL hKL);
+VOID IntLoadPreloadKeyboardLayouts(VOID);
 
 /* EOF */

--- a/win32ss/user/user32/misc/logon.c
+++ b/win32ss/user/user32/misc/logon.c
@@ -7,7 +7,6 @@
  */
 
 #include <user32.h>
-#include <strsafe.h>
 
 WINE_DEFAULT_DEBUG_CHANNEL(user32);
 
@@ -103,7 +102,7 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
 
     for (nNumber = 1; nNumber <= 1000; ++nNumber)
     {
-        StringCchPrintfW(szNumber, _countof(szNumber), L"%u", nNumber);
+        _ultow(nNumber, szNumber, 10);
 
         cbValue = sizeof(szValue);
         if (RegQueryValueExW(hPreloadKey,

--- a/win32ss/user/user32/misc/logon.c
+++ b/win32ss/user/user32/misc/logon.c
@@ -84,20 +84,20 @@ Logon(BOOL IsLogon)
 }
 
 /* Win: LoadPreloadKeyboardLayouts */
-BOOL IntLoadPreloadKeyboardLayouts(VOID)
+VOID IntLoadPreloadKeyboardLayouts(VOID)
 {
     UINT nNumber, uFlags;
     DWORD cbValue, dwType;
     WCHAR szNumber[32], szValue[KL_NAMELENGTH];
     HKEY hPreloadKey;
-    BOOL ret = FALSE;
+    BOOL bOK = FALSE;
     HKL hKL, hDefaultKL = NULL;
 
     if (RegOpenKeyW(HKEY_CURRENT_USER,
                     L"Keyboard Layout\\Preload",
                     &hPreloadKey) != ERROR_SUCCESS)
     {
-        return FALSE;
+        return;
     }
 
     for (nNumber = 1; nNumber <= 1000; ++nNumber)
@@ -126,8 +126,8 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
         hKL = LoadKeyboardLayoutW(szValue, uFlags);
         if (hKL)
         {
-            ret = TRUE;
-            if (nNumber == 1)
+            bOK = TRUE;
+            if (nNumber == 1) /* The first entry */
                 hDefaultKL = hKL;
         }
     }
@@ -137,13 +137,11 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
     if (hDefaultKL)
         SystemParametersInfoW(SPI_SETDEFAULTINPUTLANG, 0, &hDefaultKL, 0);
 
-    if (!ret)
+    if (!bOK)
     {
         /* Default to USA */
         LoadKeyboardLayoutW(L"00000409", KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET);
     }
-
-    return ret;
 }
 
 /*

--- a/win32ss/user/user32/misc/logon.c
+++ b/win32ss/user/user32/misc/logon.c
@@ -141,7 +141,7 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
     if (!ret)
     {
         /* Default to USA */
-        LoadKeyboardLayoutW(L"04090409", KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET);
+        LoadKeyboardLayoutW(L"00000409", KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET);
     }
 
     return ret;

--- a/win32ss/user/user32/misc/logon.c
+++ b/win32ss/user/user32/misc/logon.c
@@ -83,67 +83,6 @@ Logon(BOOL IsLogon)
                          sizeof(*LogonRequest));
 }
 
-/* Win: LoadPreloadKeyboardLayouts */
-VOID IntLoadPreloadKeyboardLayouts(VOID)
-{
-    UINT nNumber, uFlags;
-    DWORD cbValue, dwType;
-    WCHAR szNumber[32], szValue[KL_NAMELENGTH];
-    HKEY hPreloadKey;
-    BOOL bOK = FALSE;
-    HKL hKL, hDefaultKL = NULL;
-
-    if (RegOpenKeyW(HKEY_CURRENT_USER,
-                    L"Keyboard Layout\\Preload",
-                    &hPreloadKey) != ERROR_SUCCESS)
-    {
-        return;
-    }
-
-    for (nNumber = 1; nNumber <= 1000; ++nNumber)
-    {
-        _ultow(nNumber, szNumber, 10);
-
-        cbValue = sizeof(szValue);
-        if (RegQueryValueExW(hPreloadKey,
-                             szNumber,
-                             NULL,
-                             &dwType,
-                             (LPBYTE)szValue,
-                             &cbValue) != ERROR_SUCCESS)
-        {
-            break;
-        }
-
-        if (dwType != REG_SZ)
-            continue;
-
-        if (nNumber == 1) /* The first entry is for default keyboard layout */
-            uFlags = KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET;
-        else
-            uFlags = KLF_SUBSTITUTE_OK | KLF_NOTELLSHELL | KLF_REPLACELANG;
-
-        hKL = LoadKeyboardLayoutW(szValue, uFlags);
-        if (hKL)
-        {
-            bOK = TRUE;
-            if (nNumber == 1) /* The first entry */
-                hDefaultKL = hKL;
-        }
-    }
-
-    RegCloseKey(hPreloadKey);
-
-    if (hDefaultKL)
-        SystemParametersInfoW(SPI_SETDEFAULTINPUTLANG, 0, &hDefaultKL, 0);
-
-    if (!bOK)
-    {
-        /* Default to USA */
-        LoadKeyboardLayoutW(L"00000409", KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET);
-    }
-}
-
 /*
  * @implemented
  */

--- a/win32ss/user/user32/misc/logon.c
+++ b/win32ss/user/user32/misc/logon.c
@@ -89,7 +89,7 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
 {
     UINT nNumber, uFlags;
     DWORD cbValue, dwType;
-    WCHAR szNumber[32], szValue[9];
+    WCHAR szNumber[32], szValue[KL_NAMELENGTH];
     HKEY hPreloadKey;
     BOOL ret = FALSE;
     HKL hKL, hDefaultKL = NULL;
@@ -119,7 +119,7 @@ BOOL IntLoadPreloadKeyboardLayouts(VOID)
         if (dwType != REG_SZ)
             continue;
 
-        if (nNumber == 1)
+        if (nNumber == 1) /* The first entry is for default keyboard layout */
             uFlags = KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET;
         else
             uFlags = KLF_SUBSTITUTE_OK | KLF_NOTELLSHELL | KLF_REPLACELANG;

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -143,6 +143,69 @@ Failure:
     return FALSE;
 }
 
+
+/* Win: LoadPreloadKeyboardLayouts */
+VOID IntLoadPreloadKeyboardLayouts(VOID)
+{
+    UINT nNumber, uFlags;
+    DWORD cbValue, dwType;
+    WCHAR szNumber[32], szValue[KL_NAMELENGTH];
+    HKEY hPreloadKey;
+    BOOL bOK = FALSE;
+    HKL hKL, hDefaultKL = NULL;
+
+    if (RegOpenKeyW(HKEY_CURRENT_USER,
+                    L"Keyboard Layout\\Preload",
+                    &hPreloadKey) != ERROR_SUCCESS)
+    {
+        return;
+    }
+
+    for (nNumber = 1; nNumber <= 1000; ++nNumber)
+    {
+        _ultow(nNumber, szNumber, 10);
+
+        cbValue = sizeof(szValue);
+        if (RegQueryValueExW(hPreloadKey,
+                             szNumber,
+                             NULL,
+                             &dwType,
+                             (LPBYTE)szValue,
+                             &cbValue) != ERROR_SUCCESS)
+        {
+            break;
+        }
+
+        if (dwType != REG_SZ)
+            continue;
+
+        if (nNumber == 1) /* The first entry is for default keyboard layout */
+            uFlags = KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET;
+        else
+            uFlags = KLF_SUBSTITUTE_OK | KLF_NOTELLSHELL | KLF_REPLACELANG;
+
+        hKL = LoadKeyboardLayoutW(szValue, uFlags);
+        if (hKL)
+        {
+            bOK = TRUE;
+            if (nNumber == 1) /* The first entry */
+                hDefaultKL = hKL;
+        }
+    }
+
+    RegCloseKey(hPreloadKey);
+
+    if (hDefaultKL)
+        SystemParametersInfoW(SPI_SETDEFAULTINPUTLANG, 0, &hDefaultKL, 0);
+
+    if (!bOK)
+    {
+        /* Fallback to English (US) */
+        LoadKeyboardLayoutW(L"00000409", KLF_SUBSTITUTE_OK | KLF_ACTIVATE | KLF_RESET);
+    }
+}
+
+
 BOOL APIENTRY
 CliSaveImeHotKey(DWORD dwID, UINT uModifiers, UINT uVirtualKey, HKL hKL, BOOL bDelete)
 {


### PR DESCRIPTION
## Purpose
JIRA issue: [CORE-16600](https://jira.reactos.org/browse/CORE-16600)

## Proposed changes

- Add `IntLoadPreloadKeyboardLayouts` helper function to load the layouts on log-on.
- In `UpdatePerUserSystemParameters` function, call `CliImmInitializeHotKeys` and `IntLoadPreloadKeyboardLayouts` functions.

## TODO

- [x] Do tests.