### PR TITLE
[GDI32] Fix ExtTextOutA with ETO_GLYPH_INDEX

### DIFF
--- a/win32ss/gdi/gdi32/objects/text.c
+++ b/win32ss/gdi/gdi32/objects/text.c
@@ -465,8 +465,15 @@ ExtTextOutA(
     UNICODE_STRING StringU;
     BOOL ret;
 
-    RtlInitAnsiString(&StringA, (LPSTR)lpString);
+    if (fuOptions & ETO_GLYPH_INDEX)
+        return ExtTextOutW(hdc, x, y, fuOptions, lprc, (LPCWSTR)lpString, cch, lpDx);
+
+    StringA.Buffer = (PCHAR)lpString;
+    StringA.Length = StringA.MaximumLength = cch;
     RtlAnsiStringToUnicodeString(&StringU, &StringA, TRUE);
+
+    if (StringU.Length != StringA.Length * sizeof(WCHAR))
+        DPRINT1("ERROR: Should convert lpDx properly!\n");
 
     ret = ExtTextOutW(hdc, x, y, fuOptions, lprc, StringU.Buffer, cch, lpDx);
 


### PR DESCRIPTION
JIRA issue: [CORE-18365](https://jira.reactos.org/browse/CORE-18365)

after fix:
![image](https://user-images.githubusercontent.com/610685/190239168-9ba48b11-e4dd-48a7-95ab-bf4763428ac5.png)
