### PR TITLE
[SHELL32] Fix French message for "Overwrite Folder" confirmation message

### DIFF
--- a/dll/win32/shell32/lang/fr-FR.rc
+++ b/dll/win32/shell32/lang/fr-FR.rc
@@ -821,7 +821,7 @@ BEGIN
     IDS_CANTTRASH_TEXT "L'élément '%1' ne peut être envoyé à la Corbeille. Voulez-vous le supprimer ?"
     IDS_OVERWRITEFILE_TEXT "Ce dossier contient déjà un fichier nommé '%1'.\n\nVoulez-vous le remplacer ?"
     IDS_OVERWRITEFILE_CAPTION "Confirmer l'écrasement du fichier"
-    IDS_OVERWRITEFOLDER_TEXT "Ce dossier contient déjà un dossier nommé '%1'.\n\nSi les fichiers dans le dossier de destination ont les mêmes noms que ceux dans le\ndossier sélectionné, ils seront remplacés. Voulez-vous toujours déplacer ou copier\nle dossier?"
+    IDS_OVERWRITEFOLDER_TEXT "Ce dossier contient déjà un dossier nommé '%1'.\n\nSi les fichiers dans le dossier de destination ont les mêmes noms que ceux dans le dossier sélectionné, ils seront remplacés.\nVoulez-vous toujours déplacer ou copier le dossier?"
 
     IDS_FILEOOP_COPYING "Copie..."
     IDS_FILEOOP_MOVING "Déplacement..."


### PR DESCRIPTION
[SHELL32] Fix French message for "Overwrite Folder" confirmation message

Before
![image](https://user-images.githubusercontent.com/112266950/190246004-ed79b3c7-cc00-43e0-9dc7-49e963ad01d0.png)

After
![image](https://user-images.githubusercontent.com/112266950/190245959-c3bdff0e-6166-4a17-87d7-a41daa323cc3.png)
