### PR TITLE
[SHELL32] Fix Assert of OnContextMenu on Right click spamming while cancelling folder copy

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1579,6 +1579,13 @@ LRESULT CDefView::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
 
     m_cidl = m_ListView.GetSelectedCount();
 
+    /* Release cached IContextMenu */
+    if (m_pCM)
+    {
+        IUnknown_SetSite(m_pCM, NULL);
+        m_pCM.Release();
+    }
+
     hResult = GetItemObject( m_cidl ? SVGIO_SELECTION : SVGIO_BACKGROUND, IID_PPV_ARG(IContextMenu, &m_pCM));
     if (FAILED_UNEXPECTEDLY(hResult))
         goto cleanup;


### PR DESCRIPTION
## Purpose

Missinng Release cached IContextMenu

JIRA issue: [CORE-18366](https://jira.reactos.org/browse/CORE-18366)

## Proposed changes

Same design pattern as 
https://github.com/reactos/reactos/pull/4683
https://github.com/reactos/reactos/pull/4683
