### PR TITLE
[SHELL32] Fix multiple Asserts related to Context Menu

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1678,18 +1678,18 @@ LRESULT CDefView::OnExplorerCommand(UINT uCommand, BOOL bUseSelection)
         SFGAOF rfg = SFGAO_BROWSABLE | SFGAO_CANCOPY | SFGAO_CANLINK | SFGAO_CANMOVE | SFGAO_CANDELETE | SFGAO_CANRENAME | SFGAO_HASPROPSHEET | SFGAO_FILESYSTEM | SFGAO_FOLDER;
         hResult = m_pSFParent->GetAttributesOf(m_cidl, m_apidl, &rfg);
         if (FAILED_UNEXPECTEDLY(hResult))
-            return 0;
+            goto cleanup;
 
         if (!(rfg & SFGAO_CANMOVE) && uCommand == FCIDM_SHVIEW_CUT)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANCOPY) && uCommand == FCIDM_SHVIEW_COPY)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANDELETE) && uCommand == FCIDM_SHVIEW_DELETE)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_CANRENAME) && uCommand == FCIDM_SHVIEW_RENAME)
-            return 0;
+            goto cleanup;
         if (!(rfg & SFGAO_HASPROPSHEET) && uCommand == FCIDM_SHVIEW_PROPERTIES)
-            return 0;
+            goto cleanup;
     }
 
     InvokeContextMenuCommand(uCommand);

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1579,6 +1579,13 @@ LRESULT CDefView::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
 
     m_cidl = m_ListView.GetSelectedCount();
 
+    /* Release cached IContextMenu */
+    if (m_pCM)
+    {
+        IUnknown_SetSite(m_pCM, NULL);
+        m_pCM.Release();
+    }
+
     hResult = GetItemObject( m_cidl ? SVGIO_SELECTION : SVGIO_BACKGROUND, IID_PPV_ARG(IContextMenu, &m_pCM));
     if (FAILED_UNEXPECTEDLY(hResult))
         goto cleanup;


### PR DESCRIPTION
## Purpose

Fix Assert of OnContextMenu on Right click spamming while cancelling folder copy
Fix Assert when hitting DEL or F2 in Recycle Bin (or copying files)

Missinng Release cached IContextMenu

JIRA issue: [CORE-18366](https://jira.reactos.org/browse/CORE-18366)
JIRA issue: [CORE-18361](https://jira.reactos.org/browse/CORE-18361)
JIRA issue: [CORE-18345](https://jira.reactos.org/browse/CORE-18345)
JIRA issue: [CORE-18321](https://jira.reactos.org/browse/CORE-18321)

Proposed change using a helper function as suggested by Learn-more and pattern used in https://github.com/reactos/reactos/pull/4675 (now generallized)

Fully superseedes https://github.com/reactos/reactos/pull/4683 (closed)