### PR TITLE
[CPL][INTL] Realize automatic Japanese IME installation

### DIFF
--- a/dll/cpl/intl/languages.c
+++ b/dll/cpl/intl/languages.c
@@ -1,13 +1,14 @@
 #include "intl.h"
 
 #include <shellapi.h>
+#include <strsafe.h>
 
 /* Is there any Japanese input method? */
 BOOL HasJapaneseIME(VOID)
 {
     WCHAR szImePath[MAX_PATH];
     GetSystemDirectoryW(szImePath, _countof(szImePath));
-    lstrcatW(szImePath, L"\\mzimeja.ime");
+    StringCchCatW(szImePath, _countof(szImePath), L"\\mzimeja.ime");
     return GetFileAttributesW(szImePath) != INVALID_FILE_ATTRIBUTES;
 }
 

--- a/dll/cpl/intl/languages.c
+++ b/dll/cpl/intl/languages.c
@@ -1,14 +1,13 @@
 #include "intl.h"
 
 #include <shellapi.h>
-#include <shlobj.h>
 
 /* Is there any Japanese input method? */
 BOOL HasJapaneseIME(VOID)
 {
     WCHAR szImePath[MAX_PATH];
-    SHGetSpecialFolderPathW(NULL, szImePath, CSIDL_PROGRAM_FILES, FALSE);
-    lstrcatW(szImePath, L"\\mzimeja\\mzimeja.ime");
+    GetSystemDirectoryW(szImePath, _countof(szImePath));
+    lstrcatW(szImePath, L"\\mzimeja.ime");
     return GetFileAttributesW(szImePath) != INVALID_FILE_ATTRIBUTES;
 }
 

--- a/dll/cpl/intl/languages.c
+++ b/dll/cpl/intl/languages.c
@@ -98,7 +98,7 @@ LanguagesPageProc(HWND hwndDlg,
                             }
                             else
                             {
-                                ShellExecuteW(hwndDlg, NULL, L"rapps.com", L"/INSTALL mzimeja",
+                                ShellExecuteW(hwndDlg, NULL, L"rapps.exe", L"/INSTALL mzimeja",
                                               NULL, SW_SHOWNORMAL);
                             }
                             break;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- In `intl.cpl`, realize automatic Japanese IME installation by checkbox `Install files for East Asian languages` by using `rapps.exe`.
- Disable checkbox `Install files for East Asian languages` if Japanese IME is not installable.

## TODO

- [x] Do small tests.

## Screenshots

![1](https://user-images.githubusercontent.com/2107452/190827473-71903110-4271-4409-af0e-7a8241ab4967.png)

![2](https://user-images.githubusercontent.com/2107452/190827482-da73112c-9196-41a5-af68-1403cebbe8d9.png)

![3](https://user-images.githubusercontent.com/2107452/190827690-977b10ba-ff70-4b91-97f9-1aa4bf25e557.png)