### PR TITLE
[CPL] Boundary check of Control Panel applets

### DIFF
--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -240,7 +240,7 @@ CPlApplet(HWND hwndCPl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -251,7 +251,7 @@ CPlApplet(HWND hwndCPl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -266,7 +266,7 @@ CPlApplet(HWND hwndCPl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             }
@@ -277,10 +277,8 @@ CPlApplet(HWND hwndCPl,
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
-            {
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
             break;
     }
 

--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -267,13 +267,9 @@ CPlApplet(HWND hwndCPl,
 
         case CPL_DBLCLK:
             if (i < NUM_APPLETS)
-            {
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
             else
-            {
                 return TRUE;
-            }
             break;
 
         case CPL_STARTWPARMSW:

--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -251,6 +251,7 @@ CPlApplet(HWND hwndCPl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
+            if (0 <= i && i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -258,14 +259,33 @@ CPlApplet(HWND hwndCPl,
                 CPlInfo->idName = Applets[i].idName;
                 CPlInfo->idInfo = Applets[i].idDescription;
             }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_STARTWPARMSW:
-            return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            else
+            {
+                return FALSE;
+            }
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/access/access.c
+++ b/dll/cpl/access/access.c
@@ -281,10 +281,6 @@ CPlApplet(HWND hwndCPl,
             {
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             }
-            else
-            {
-                return FALSE;
-            }
             break;
     }
 

--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -252,7 +252,7 @@ cleanup:
 LONG CALLBACK
 CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
-    int i = (int)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -263,7 +263,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -278,14 +278,14 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -279,24 +279,14 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 
         case CPL_DBLCLK:
             if (0 <= i && i < NUM_APPLETS)
-            {
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
             else
-            {
                 return TRUE;
-            }
             break;
 
         case CPL_STARTWPARMSW:
             if (0 <= i && i < NUM_APPLETS)
-            {
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
-            else
-            {
-                return FALSE;
-            }
             break;
     }
 

--- a/dll/cpl/desk/desk.c
+++ b/dll/cpl/desk/desk.c
@@ -263,6 +263,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
+            if (0 <= i && i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -270,14 +271,33 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
                 CPlInfo->idName = Applets[i].idName;
                 CPlInfo->idInfo = Applets[i].idDescription;
             }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_STARTWPARMSW:
-            return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            else
+            {
+                return FALSE;
+            }
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/hotplug/hotplug.c
+++ b/dll/cpl/hotplug/hotplug.c
@@ -548,6 +548,7 @@ CPlApplet(
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
+            if (0 <= i && i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -555,14 +556,29 @@ CPlApplet(
                 CPlInfo->idName = Applets[i].idName;
                 CPlInfo->idInfo = Applets[i].idDescription;
             }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_STARTWPARMSW:
-            return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            }
+            return FALSE;
     }
     return FALSE;
 }

--- a/dll/cpl/hotplug/hotplug.c
+++ b/dll/cpl/hotplug/hotplug.c
@@ -548,7 +548,7 @@ CPlApplet(
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -563,14 +563,14 @@ CPlApplet(
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/hotplug/hotplug.c
+++ b/dll/cpl/hotplug/hotplug.c
@@ -564,21 +564,15 @@ CPlApplet(
 
         case CPL_DBLCLK:
             if (0 <= i && i < NUM_APPLETS)
-            {
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
             else
-            {
                 return TRUE;
-            }
             break;
 
         case CPL_STARTWPARMSW:
             if (0 <= i && i < NUM_APPLETS)
-            {
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-            }
-            return FALSE;
+            break;
     }
     return FALSE;
 }

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -100,15 +100,23 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            CPlInfo = (CPLINFO*)lParam2;
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[i].idIcon;
-            CPlInfo->idName = Applets[i].idName;
-            CPlInfo->idInfo = Applets[i].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             break;
     }
 

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -115,6 +115,8 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
         case CPL_DBLCLK:
             if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
     }
 

--- a/dll/cpl/input/input.c
+++ b/dll/cpl/input/input.c
@@ -87,9 +87,7 @@ LONG CALLBACK
 CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
     CPLINFO *CPlInfo;
-    int i;
-
-    i = (int)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -100,7 +98,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -115,7 +113,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/intl/intl.c
+++ b/dll/cpl/intl/intl.c
@@ -232,6 +232,8 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
+    INT i = (INT)lParam1;
+
     switch (uMsg)
     {
         case CPL_INIT:
@@ -241,23 +243,30 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-        {
-            CPLINFO *CPlInfo = (CPLINFO*)lParam2;
-            UINT uAppIndex = (UINT)lParam1;
-
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[uAppIndex].idIcon;
-            CPlInfo->idName = Applets[uAppIndex].idName;
-            CPlInfo->idInfo = Applets[uAppIndex].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPLINFO *CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
-        }
 
         case CPL_DBLCLK:
-            Applets[(UINT)lParam1].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            return Applets[(UINT)lParam1].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
     }
 
     return FALSE;

--- a/dll/cpl/intl/intl.c
+++ b/dll/cpl/intl/intl.c
@@ -232,7 +232,7 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -243,7 +243,7 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -258,15 +258,16 @@ CPlApplet(HWND hwndCpl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             else
                 return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/joy/joy.c
+++ b/dll/cpl/joy/joy.c
@@ -319,11 +319,11 @@ LONG CALLBACK
 CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
     CPLINFO *CPlInfo;
-    DWORD i;
+    INT i;
 
     UNREFERENCED_PARAMETER(hwndCPl);
 
-    i = (DWORD)lParam1;
+    i = (INT)lParam1;
     switch (uMsg)
     {
         case CPL_INIT:
@@ -333,15 +333,25 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            CPlInfo = (CPLINFO*)lParam2;
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[i].idIcon;
-            CPlInfo->idName = Applets[i].idName;
-            CPlInfo->idInfo = Applets[i].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
     }
 

--- a/dll/cpl/joy/joy.c
+++ b/dll/cpl/joy/joy.c
@@ -319,11 +319,9 @@ LONG CALLBACK
 CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
     CPLINFO *CPlInfo;
-    INT i;
-
+    UINT i = (UINT)lParam1;
     UNREFERENCED_PARAMETER(hwndCPl);
 
-    i = (INT)lParam1;
     switch (uMsg)
     {
         case CPL_INIT:
@@ -333,7 +331,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -348,7 +346,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;

--- a/dll/cpl/main/main.c
+++ b/dll/cpl/main/main.c
@@ -87,6 +87,8 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
+    INT i = (INT)lParam1;
+
     switch(uMsg)
     {
         case CPL_INIT:
@@ -96,26 +98,31 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-        {
-            CPLINFO *CPlInfo = (CPLINFO*)lParam2;
-            UINT uAppIndex = (UINT)lParam1;
-
-            CPlInfo->lData = lParam1;
-            CPlInfo->idIcon = Applets[uAppIndex].idIcon;
-            CPlInfo->idName = Applets[uAppIndex].idName;
-            CPlInfo->idInfo = Applets[uAppIndex].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPLINFO *CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = lParam1;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
-        }
 
         case CPL_DBLCLK:
-        {
-            UINT uAppIndex = (UINT)lParam1;
-            Applets[uAppIndex].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
-        }
 
         case CPL_STARTWPARMSW:
-            return Applets[(UINT)lParam1].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/main/main.c
+++ b/dll/cpl/main/main.c
@@ -87,7 +87,7 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch(uMsg)
     {
@@ -98,7 +98,7 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = lParam1;
@@ -113,14 +113,14 @@ CPlApplet(HWND hwndCpl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             else
                 return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -745,7 +745,7 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -756,7 +756,7 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -771,7 +771,7 @@ CPlApplet(HWND hwndCpl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 Applets[i].AppletProc(hwndCpl,
                                       uMsg,
@@ -785,7 +785,7 @@ CPlApplet(HWND hwndCpl,
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -745,6 +745,8 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
+    INT i = (INT)lParam1;
+
     switch (uMsg)
     {
         case CPL_INIT:
@@ -754,29 +756,38 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-        {
-            CPLINFO *CPlInfo = (CPLINFO*)lParam2;
-            UINT uAppIndex = (UINT)lParam1;
-
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[uAppIndex].idIcon;
-            CPlInfo->idName = Applets[uAppIndex].idName;
-            CPlInfo->idInfo = Applets[uAppIndex].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPLINFO *CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
-        }
 
         case CPL_DBLCLK:
-        {
-            UINT uAppIndex = (UINT)lParam1;
-            Applets[uAppIndex].AppletProc(hwndCpl,
-                                          uMsg,
-                                          lParam1,
-                                          lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                Applets[i].AppletProc(hwndCpl,
+                                      uMsg,
+                                      lParam1,
+                                      lParam2);
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
-        }
 
         case CPL_STARTWPARMSW:
-            return Applets[(UINT)lParam1].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                return Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/mmsys/mmsys.c
+++ b/dll/cpl/mmsys/mmsys.c
@@ -772,16 +772,9 @@ CPlApplet(HWND hwndCpl,
 
         case CPL_DBLCLK:
             if (i < NUM_APPLETS)
-            {
-                Applets[i].AppletProc(hwndCpl,
-                                      uMsg,
-                                      lParam1,
-                                      lParam2);
-            }
+                Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             else
-            {
                 return TRUE;
-            }
             break;
 
         case CPL_STARTWPARMSW:

--- a/dll/cpl/powercfg/powercfg.c
+++ b/dll/cpl/powercfg/powercfg.c
@@ -170,20 +170,26 @@ CPlApplet(HWND hwndCPl,
         }
 
         case CPL_INQUIRE:
-        {
-            CPLINFO *CPlInfo = (CPLINFO*)lParam2;
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[i].idIcon;
-            CPlInfo->idName = Applets[i].idName;
-            CPlInfo->idInfo = Applets[i].idDescription;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPLINFO *CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
             break;
-        }
 
         case CPL_DBLCLK:
-        {
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
-        }
     }
 
     return FALSE;

--- a/dll/cpl/powercfg/powercfg.c
+++ b/dll/cpl/powercfg/powercfg.c
@@ -155,7 +155,7 @@ CPlApplet(HWND hwndCPl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    int i = (int)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -170,7 +170,7 @@ CPlApplet(HWND hwndCPl,
         }
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -185,7 +185,7 @@ CPlApplet(HWND hwndCPl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;

--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -203,7 +203,7 @@ CPlApplet(HWND hwndCPl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     UNREFERENCED_PARAMETER(hwndCPl);
 
@@ -216,7 +216,7 @@ CPlApplet(HWND hwndCPl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                  CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                  CPlInfo->lData = 0;
@@ -231,14 +231,14 @@ CPlApplet(HWND hwndCPl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             break;
     }

--- a/dll/cpl/sysdm/sysdm.c
+++ b/dll/cpl/sysdm/sysdm.c
@@ -216,6 +216,7 @@ CPlApplet(HWND hwndCPl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
+            if (0 <= i && i < NUM_APPLETS)
             {
                  CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                  CPlInfo->lData = 0;
@@ -223,15 +224,23 @@ CPlApplet(HWND hwndCPl,
                  CPlInfo->idName = Applets[i].idName;
                  CPlInfo->idInfo = Applets[i].idDescription;
             }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
 
         case CPL_STARTWPARMSW:
-            return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
-
+            if (0 <= i && i < NUM_APPLETS)
+                return Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            break;
     }
 
     return FALSE;

--- a/dll/cpl/timedate/timedate.c
+++ b/dll/cpl/timedate/timedate.c
@@ -131,7 +131,7 @@ CPlApplet(HWND hwndCpl,
           LPARAM lParam1,
           LPARAM lParam2)
 {
-    INT i = (INT)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -142,7 +142,7 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -157,7 +157,7 @@ CPlApplet(HWND hwndCpl,
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
             else
                 return TRUE;

--- a/dll/cpl/timedate/timedate.c
+++ b/dll/cpl/timedate/timedate.c
@@ -142,20 +142,26 @@ CPlApplet(HWND hwndCpl,
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-        {
-            CPLINFO *CPlInfo = (CPLINFO*)lParam2;
-            CPlInfo->lData = 0;
-            CPlInfo->idIcon = Applets[i].idIcon;
-            CPlInfo->idName = Applets[i].idName;
-            CPlInfo->idInfo = Applets[i].idDescription;
-        }
-        break;
+            if (0 <= i && i < NUM_APPLETS)
+            {
+                CPLINFO *CPlInfo = (CPLINFO*)lParam2;
+                CPlInfo->lData = 0;
+                CPlInfo->idIcon = Applets[i].idIcon;
+                CPlInfo->idName = Applets[i].idName;
+                CPlInfo->idInfo = Applets[i].idDescription;
+            }
+            else
+            {
+                return TRUE;
+            }
+            break;
 
         case CPL_DBLCLK:
-        {
-            Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
-        }
-        break;
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCpl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
+            break;
     }
     return FALSE;
 }

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -101,6 +101,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
+            if (0 <= i && i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -108,10 +109,17 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
                 CPlInfo->idName = Applets[i].idName;
                 CPlInfo->idInfo = Applets[i].idDescription;
             }
+            else
+            {
+                return TRUE;
+            }
             break;
 
         case CPL_DBLCLK:
-            Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            if (0 <= i && i < NUM_APPLETS)
+                Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
+            else
+                return TRUE;
             break;
     }
 

--- a/dll/cpl/usrmgr/usrmgr.c
+++ b/dll/cpl/usrmgr/usrmgr.c
@@ -90,7 +90,7 @@ UsrmgrApplet(HWND hwnd, UINT uMsg, LPARAM wParam, LPARAM lParam)
 LONG CALLBACK
 CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
 {
-    int i = (int)lParam1;
+    UINT i = (UINT)lParam1;
 
     switch (uMsg)
     {
@@ -101,7 +101,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             return NUM_APPLETS;
 
         case CPL_INQUIRE:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
             {
                 CPLINFO *CPlInfo = (CPLINFO*)lParam2;
                 CPlInfo->lData = 0;
@@ -116,7 +116,7 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             break;
 
         case CPL_DBLCLK:
-            if (0 <= i && i < NUM_APPLETS)
+            if (i < NUM_APPLETS)
                 Applets[i].AppletProc(hwndCPl, uMsg, lParam1, lParam2);
             else
                 return TRUE;


### PR DESCRIPTION
## Purpose

Improve stability of the system.

## Proposed changes

- Check the boundary `(i < NUM_APPLETS)` of the variable `i` in `CPlApplet` functions.
- Use `UINT` type for the variable `i`.