### PR TITLE
[ZIPFLDR] Set large icon correctly

### DIFF
--- a/dll/shellext/zipfldr/CZipExtract.cpp
+++ b/dll/shellext/zipfldr/CZipExtract.cpp
@@ -331,10 +331,23 @@ public:
     };
 
 
+    /* NOTE: This callback is needed to set large icon correctly. */
+    static INT CALLBACK s_PropSheetCallbackProc(HWND hwndDlg, UINT uMsg, LPARAM lParam)
+    {
+        if (uMsg == PSCB_INITIALIZED)
+        {
+            HICON hIcon = LoadIconW(_AtlBaseModule.GetResourceInstance(), MAKEINTRESOURCEW(IDI_ZIPFLDR));
+            CWindow dlg(hwndDlg);
+            dlg.SetIcon(hIcon, TRUE);
+        }
+
+        return 0;
+    }
+
     void runWizard()
     {
         PROPSHEETHEADERW psh = { sizeof(psh), 0 };
-        psh.dwFlags = PSH_WIZARD97 | PSH_HEADER | PSH_USEICONID;
+        psh.dwFlags = PSH_WIZARD97 | PSH_HEADER | PSH_USEICONID | PSH_USECALLBACK;
         psh.hInstance = _AtlBaseModule.GetResourceInstance();
 
         CExtractSettingsPage extractPage(this, &m_Password);
@@ -350,6 +363,7 @@ public:
         psh.pszIcon = MAKEINTRESOURCE(IDI_ZIPFLDR);
         psh.pszbmWatermark = MAKEINTRESOURCE(IDB_WATERMARK);
         psh.pszbmHeader = MAKEINTRESOURCE(IDB_HEADER);
+        psh.pfnCallback = s_PropSheetCallbackProc;
 
         PropertySheetW(&psh);
     }


### PR DESCRIPTION
## Proposed changes
- Set large icon correctly

Alt + Tab Before:
![ROS_zipfldr_before](https://user-images.githubusercontent.com/86486978/190667181-d5f0e5fb-9a38-45af-8bf3-336742127cc9.png)

Alt + Tab After:
![ROS_zipfldr_after](https://user-images.githubusercontent.com/86486978/190667288-ac8ee62b-0fbc-4ae4-9420-1f4a4d84b16a.png)
