### PR TITLE
[SHELL32] Fix property sheets that can't be closed due to failed init

### DIFF
--- a/dll/win32/shell32/dialogs/fprop.cpp
+++ b/dll/win32/shell32/dialogs/fprop.cpp
@@ -137,8 +137,12 @@ SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CH
                 hr = pFileDefExt->AddPages(AddPropSheetPageCallback, (LPARAM)&Header);
                 if (FAILED(hr))
                     ERR("AddPages failed\n");
-            } else
+            }
+            else
+            {
                 ERR("Initialize failed\n");
+                return FALSE;
+            }
         }
 
         LoadPropSheetHandlers(wszPath, &Header, MAX_PROPERTY_SHEET_PAGE - 1, hpsxa, pDataObj);

--- a/dll/win32/shell32/dialogs/fprop.cpp
+++ b/dll/win32/shell32/dialogs/fprop.cpp
@@ -132,11 +132,14 @@ SH_ShowPropertiesDialog(LPCWSTR pwszPath, LPCITEMIDLIST pidlFolder, PCUITEMID_CH
         {
             pFileDefExt->AddRef(); // CreateInstance returns object with 0 ref count
             hr = pFileDefExt->Initialize(pidlFolder, pDataObj, NULL);
-            if (SUCCEEDED(hr))
+            if (!FAILED_UNEXPECTEDLY(hr))
             {
                 hr = pFileDefExt->AddPages(AddPropSheetPageCallback, (LPARAM)&Header);
-                if (FAILED(hr))
+                if (FAILED_UNEXPECTEDLY(hr))
+                {
                     ERR("AddPages failed\n");
+                    return FALSE;
+                }
             }
             else
             {


### PR DESCRIPTION
[SHELL32] Fix property sheets that can't be closed due to failed init

## Purpose

- When a PropertySheet fails to init, log and ERR but is displayed with no page and can't be closed.

JIRA issue: [CORE-18333](https://jira.reactos.org/browse/CORE-18333)

## Before 

![image](https://user-images.githubusercontent.com/112266950/190828965-564ba82a-90e3-4abd-b136-25b5429434c9.png)

## Proposed changes

- In such error case, do not open PropertySheet.