### PR TITLE
[EXPLORER] Fix lazy Clock Tray (CORE-12987)

### DIFF
--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -426,8 +426,6 @@ UINT CTrayClockWnd::CalculateDueTime()
 
     GetLocalTime(&LocalTime);
     uiDueTime = 1000 - (UINT) LocalTime.wMilliseconds;
-    if (!g_TaskbarSettings.bShowSeconds)
-        uiDueTime += (59 - (UINT) LocalTime.wSecond) * 1000;
 
     return uiDueTime;
 }
@@ -469,16 +467,8 @@ VOID CTrayClockWnd::CalibrateTimer()
 
     uiDueTime = CalculateDueTime();
 
-    if (g_TaskbarSettings.bShowSeconds)
-    {
-        uiWait1 = 1000 - 200;
-        uiWait2 = 1000;
-    }
-    else
-    {
-        uiWait1 = 60 * 1000 - 200;
-        uiWait2 = 60 * 1000;
-    }
+    uiWait1 = 1000 - 200;
+    uiWait2 = 1000;
 
     if (uiDueTime > uiWait1)
     {

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -414,10 +414,32 @@ VOID CTrayClockWnd::UpdateWnd()
     delete[] szDate;
 }
 
+BOOL SameTime(SYSTEMTIME a, SYSTEMTIME b)
+{
+    /*
+    no need to look for other members
+    only consequence is only at worst a single extra redraw
+    for corner cases (best performance option)
+    */
+    if(a.wHour != b.wHour)
+        return FALSE;
+    if(a.wMinute != b.wMinute)
+        return FALSE;
+    if(a.wSecond != b.wSecond)
+        return FALSE;
+    return TRUE;
+}
+
 VOID CTrayClockWnd::Update()
 {
+    static SYSTEMTIME LocalTime_old;
+    
     GetLocalTime(&LocalTime);
+    if (SameTime(LocalTime, LocalTime_old) && !g_TaskbarSettings.bShowSeconds)
+        return;
+
     UpdateWnd();
+    LocalTime_old = LocalTime;
 }
 
 UINT CTrayClockWnd::CalculateDueTime()

--- a/base/shell/explorer/trayclock.cpp
+++ b/base/shell/explorer/trayclock.cpp
@@ -417,29 +417,31 @@ VOID CTrayClockWnd::UpdateWnd()
 BOOL SameTime(SYSTEMTIME a, SYSTEMTIME b)
 {
     /*
-    no need to look for other members
-    only consequence is only at worst a single extra redraw
-    for corner cases (best performance option)
+    no need to look for milliseconds nor seconds (only used if second not displayed)
     */
-    if(a.wHour != b.wHour)
-        return FALSE;
-    if(a.wMinute != b.wMinute)
-        return FALSE;
-    if(a.wSecond != b.wSecond)
-        return FALSE;
-    return TRUE;
+    
+    return (a.wMinute == b.wMinute) &&
+           (a.wHour == b.wHour) &&
+           (a.wDay == b.wDay) &&
+           (a.wMonth == b.wMonth) &&
+           (a.wYear == b.wYear);
 }
 
 VOID CTrayClockWnd::Update()
 {
     static SYSTEMTIME LocalTime_old;
+    static BOOL bShowSeconds_old;
     
     GetLocalTime(&LocalTime);
-    if (SameTime(LocalTime, LocalTime_old) && !g_TaskbarSettings.bShowSeconds)
+    
+    /* if seconds not displayed and time (w/o secs) and date unchanged, no need to update
+    but force update if switching from hh:mm:ss to hh:mm*/
+    if (SameTime(LocalTime, LocalTime_old) && !g_TaskbarSettings.bShowSeconds && !bShowSeconds_old)
         return;
-
+    
     UpdateWnd();
     LocalTime_old = LocalTime;
+    bShowSeconds_old = g_TaskbarSettings.bShowSeconds;
 }
 
 UINT CTrayClockWnd::CalculateDueTime()


### PR DESCRIPTION
Implement fix to cover 4 cases refered in CORE-12987

## Purpose

Clock tray time indication, when displaying hh:mm (not second) is not updated at the right pace.

It "calibrates" a 60sec timer based on init and therefore gets out of sync if time (in particular seconds) is modified by NTP, API, user (from cpl), ...

This calibrated timer is overcomplex and not robust compared to a basic 1 Hz timer.

JIRA issue: [CORE-12987](https://jira.reactos.org/browse/CORE-12987)
JIRA issue: [CORE-11443](https://jira.reactos.org/browse/CORE-11443)

## Proposed changes

Simplify and always stick to a 1 Hz pace regardless of seconds being displayed or not
but optimize the condition of the UpdateWnd call to get the save performance saving (no unnecessary redraw of the clock tray area)