### PR TITLE
[DDRAW] Mute aggressive log-spam in game 'Anno 1602' CORE-18378

### DIFF
--- a/dll/directx/wine/ddraw/utils.c
+++ b/dll/directx/wine/ddraw/utils.c
@@ -580,8 +580,10 @@ unsigned int wined3dmapflags_from_ddrawmapflags(unsigned int flags)
         wined3d_flags |= WINED3D_MAP_NO_DIRTY_UPDATE;
     flags &= ~(handled | DDLOCK_WAIT | DDLOCK_READONLY | DDLOCK_NODIRTYUPDATE);
 
+#ifndef __REACTOS__
     if (flags)
         FIXME("Unhandled flags %#x.\n", flags);
+#endif
 
     return wined3d_flags;
 }

--- a/dll/directx/wine/ddraw/utils.c
+++ b/dll/directx/wine/ddraw/utils.c
@@ -583,6 +583,13 @@ unsigned int wined3dmapflags_from_ddrawmapflags(unsigned int flags)
 #ifndef __REACTOS__
     if (flags)
         FIXME("Unhandled flags %#x.\n", flags);
+#elif defined(__REACTOS__) && defined(DBG)
+    if (flags == 0x20)
+    {
+        static int bWarnedOnce = 0; if (!bWarnedOnce) { bWarnedOnce++; FIXME("Unhandled flag 0x20 once\n"); }
+    }
+    else if (flags)
+        FIXME("Unhandled flags %#x.\n", flags);
 #endif
 
     return wined3d_flags;

--- a/dll/directx/wine/ddraw/utils.c
+++ b/dll/directx/wine/ddraw/utils.c
@@ -570,7 +570,7 @@ unsigned int wined3dmapflags_from_ddrawmapflags(unsigned int flags)
     unsigned int wined3d_flags;
 
     wined3d_flags = flags & handled;
-    if (!(flags & (DDLOCK_NOOVERWRITE | DDLOCK_DISCARDCONTENTS)))
+    if (!(flags & (DDLOCK_NOOVERWRITE | DDLOCK_DISCARDCONTENTS | DDLOCK_WRITEONLY)))
         wined3d_flags |= WINED3D_MAP_READ;
     if (!(flags & DDLOCK_READONLY))
         wined3d_flags |= WINED3D_MAP_WRITE;
@@ -578,19 +578,10 @@ unsigned int wined3dmapflags_from_ddrawmapflags(unsigned int flags)
         wined3d_flags |= WINED3D_MAP_READ | WINED3D_MAP_WRITE;
     if (flags & DDLOCK_NODIRTYUPDATE)
         wined3d_flags |= WINED3D_MAP_NO_DIRTY_UPDATE;
-    flags &= ~(handled | DDLOCK_WAIT | DDLOCK_READONLY | DDLOCK_NODIRTYUPDATE);
+    flags &= ~(handled | DDLOCK_WAIT | DDLOCK_READONLY | DDLOCK_WRITEONLY | DDLOCK_NODIRTYUPDATE);
 
-#ifndef __REACTOS__
     if (flags)
         FIXME("Unhandled flags %#x.\n", flags);
-#elif defined(__REACTOS__) && defined(DBG)
-    if (flags == 0x20)
-    {
-        static int bWarnedOnce = 0; if (!bWarnedOnce) { bWarnedOnce++; FIXME("Unhandled flag 0x20 once\n"); }
-    }
-    else if (flags)
-        FIXME("Unhandled flags %#x.\n", flags);
-#endif
 
     return wined3d_flags;
 }


### PR DESCRIPTION
fixme:(dll/directx/wine/ddraw/utils.c:584) Unhandled flags 0x20.
gets logged many times per second.

It does affect several applications, e.g. the game 'Anno 1602' from 1998, and the 'Diablo 2 demo' from rapps,
For both games it can be observed with both: our VBEMP driver and the VBox4.3.12 3D-accelerated-driver.

Muting may improve performance a bit in such apps.
It gets logged although no missing features can be perceived visually in the rendering.

Fix it by importing Wine-commit [b943c7910b3261c9603343369cd632f7a3b56bba](https://source.winehq.org/git/wine.git/commit/b943c7910b3261c9603343369cd632f7a3b56bba)
 ddraw: Handle DDLOCK_WRITEONLY in wined3dmapflags_from_ddrawmapflags().
 Signed-off-by: Henri Verbeet <hverbeet@codeweavers.com>
 Signed-off-by: Alexandre Julliard <julliard@winehq.org>

I tested it, and got no surprises, it works.


JIRA issue: [CORE-18378](https://jira.reactos.org/browse/CORE-18378)
also contains the log.
