### PR TITLE
[ATL] Prohibit the use of AddRef/Release on objects inside CComPtr

### DIFF
--- a/base/shell/explorer/startctxmnu.cpp
+++ b/base/shell/explorer/startctxmnu.cpp
@@ -242,8 +242,5 @@ public:
 
 HRESULT CStartMenuBtnCtxMenu_CreateInstance(ITrayWindow * m_TrayWnd, IN HWND m_Owner, IContextMenu ** ppCtxMenu)
 {
-    CStartMenuBtnCtxMenu * mnu = new CComObject<CStartMenuBtnCtxMenu>();
-    mnu->Initialize(m_TrayWnd, m_Owner);
-    *ppCtxMenu = mnu;
-    return S_OK;
+    return ShellObjectCreatorInit<CStartMenuBtnCtxMenu>(m_TrayWnd, m_Owner, IID_PPV_ARG(IContextMenu, ppCtxMenu));
 }

--- a/base/shell/explorer/tbsite.cpp
+++ b/base/shell/explorer/tbsite.cpp
@@ -301,8 +301,8 @@ public:
 
         if (ppcm != NULL)
         {
-            m_ContextMenu->AddRef();
             *ppcm = m_ContextMenu;
+            (*ppcm)->AddRef();
         }
 
         /* Add the menu items */

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2943,7 +2943,6 @@ ChangePos:
             {
                 CComPtr<IContextMenu> ctxMenu;
                 CStartMenuBtnCtxMenu_CreateInstance(this, m_hWnd, &ctxMenu);
-                ctxMenu->AddRef();
                 TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this);
             }
         }

--- a/dll/shellext/netshell/lanstatusui.cpp
+++ b/dll/shellext/netshell/lanstatusui.cpp
@@ -953,7 +953,7 @@ CLanStatus::InitializeNetTaskbarNotifications()
         pItem->uID = Index;
         pItem->pNext = NULL;
         pItem->pNet = pNetCon;
-        pNetCon->AddRef();
+        pItem->pNet->AddRef();
         hwndDlg = CreateDialogParamW(netshell_hInstance, MAKEINTRESOURCEW(IDD_STATUS), NULL, LANStatusDlg, (LPARAM)pContext);
         if (!hwndDlg)
         {

--- a/dll/win32/browseui/CAutoComplete.cpp
+++ b/dll/win32/browseui/CAutoComplete.cpp
@@ -1126,18 +1126,12 @@ CAutoComplete::Init(HWND hwndEdit, IUnknown *punkACL,
     ::GetWindowRect(m_hwndEdit, &m_rcEdit);
 
     // get an IEnumString
-    ATLASSERT(!m_pEnum);
     punkACL->QueryInterface(IID_IEnumString, (VOID **)&m_pEnum);
     TRACE("m_pEnum: %p\n", static_cast<void *>(m_pEnum));
-    if (m_pEnum)
-        m_pEnum->AddRef(); // hold not to be freed
 
     // get an IACList
-    ATLASSERT(!m_pACList);
     punkACL->QueryInterface(IID_IACList, (VOID **)&m_pACList);
     TRACE("m_pACList: %p\n", static_cast<void *>(m_pACList));
-    if (m_pACList)
-        m_pACList->AddRef(); // hold not to be freed
 
     UpdateDropDownState(); // create/hide the drop-down window if necessary
 

--- a/dll/win32/browseui/internettoolbar.cpp
+++ b/dll/win32/browseui/internettoolbar.cpp
@@ -614,8 +614,6 @@ CInternetToolbar::CInternetToolbar()
     fMenuCallback = new CComObject<CMenuCallback>();
     fToolbarWindow = NULL;
     fAdviseCookie = 0;
-
-    fMenuCallback->AddRef();
 }
 
 CInternetToolbar::~CInternetToolbar()

--- a/dll/win32/browseui/shellbrowser.cpp
+++ b/dll/win32/browseui/shellbrowser.cpp
@@ -1121,7 +1121,7 @@ HRESULT CShellBrowser::GetBaseBar(bool vertical, REFIID riid, void **theBaseBar)
 
         // we have to store our basebar into cache now
         *cache = newBaseBar;
-        newBaseBar->AddRef();
+        (*cache)->AddRef();
 
         // tell the new base bar about the shell browser
         hResult = IUnknown_SetSite(newBaseBar, static_cast<IDropTarget *>(this));

--- a/dll/win32/shell32/CFolderItems.cpp
+++ b/dll/win32/shell32/CFolderItems.cpp
@@ -38,7 +38,7 @@ HRESULT STDMETHODCALLTYPE CFolderItem::get_Parent(IDispatch **ppid)
     if (ppid)
     {
         *ppid = m_Folder;
-        m_Folder->AddRef();
+        (*ppid)->AddRef();
     }
     return E_NOTIMPL;
 }

--- a/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
+++ b/dll/win32/shell32/shelldesktop/CDesktopBrowser.cpp
@@ -321,8 +321,8 @@ HRESULT STDMETHODCALLTYPE CDesktopBrowser::QueryActiveShellView(IShellView **pps
     if (ppshv == NULL)
         return E_POINTER;
     *ppshv = m_ShellView;
-    if (m_ShellView != NULL)
-        m_ShellView->AddRef();
+    if (*ppshv != NULL)
+        (*ppshv)->AddRef();
 
     return S_OK;
 }

--- a/dll/win32/shell32/shellmenu/CMenuBand.cpp
+++ b/dll/win32/shell32/shellmenu/CMenuBand.cpp
@@ -99,9 +99,9 @@ HRESULT STDMETHODCALLTYPE  CMenuBand::GetMenuInfo(
 
     if (ppsmc)
     {
-        if (m_psmc)
-            m_psmc->AddRef();
         *ppsmc = m_psmc;
+        if (*ppsmc)
+            (*ppsmc)->AddRef();
     }
 
     if (puId)
@@ -655,8 +655,8 @@ HRESULT STDMETHODCALLTYPE CMenuBand::GetClient(IUnknown **ppunkClient)
 
     if (m_subMenuChild)
     {
-        m_subMenuChild->AddRef();
         *ppunkClient = m_subMenuChild;
+        (*ppunkClient)->AddRef();
     }
 
     return S_OK;

--- a/sdk/include/reactos/browseui_undoc.h
+++ b/sdk/include/reactos/browseui_undoc.h
@@ -60,7 +60,7 @@ typedef struct IEThreadParamBlock
     UCHAR gap108[24];
     DWORD dword120;
     DWORD dword124;
-    IUnknown*                       offsetF8; // 0x128 instance explorer
+    IUnknown*                       pExplorerInstance; // 0x128 instance explorer
     UCHAR byteflags_130;
 } IE_THREAD_PARAM_BLOCK, * PIE_THREAD_PARAM_BLOCK;
 #else
@@ -90,7 +90,7 @@ typedef struct IEThreadParamBlock
     char                            offsetA4[0xD8-0xA4];    // unknown contents -- 0xA4..0xD8
     LONG                            offsetD8;
     char                            offsetDC[0xF8-0xDC];    // unknown contents -- 0xDC..0xF8
-    IUnknown                      * offsetF8;        // instance explorer
+    IUnknown                      * pExplorerInstance;        // instance explorer
     LONG                            offsetFC;        // unknown contents
 } IE_THREAD_PARAM_BLOCK, *PIE_THREAD_PARAM_BLOCK;
 #endif

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -226,7 +226,8 @@ void ReleaseCComPtrExpectZero(CComPtr<T>& cptr, BOOL forceRelease = FALSE)
 {
     if (cptr.p != NULL)
     {
-        int nrc = cptr->Release();
+        T *raw = cptr.Detach();
+        int nrc = raw->Release();
         if (nrc > 0)
         {
             DbgPrint("WARNING: Unexpected RefCount > 0 (%d)!\n", nrc);
@@ -234,11 +235,10 @@ void ReleaseCComPtrExpectZero(CComPtr<T>& cptr, BOOL forceRelease = FALSE)
             {
                 while (nrc > 0)
                 {
-                    nrc = cptr->Release();
+                    nrc = raw->Release();
                 }
             }
         }
-        cptr.Detach();
     }
 }
 

--- a/sdk/lib/atl/atlcomcli.h
+++ b/sdk/lib/atl/atlcomcli.h
@@ -59,6 +59,13 @@ inline HRESULT AtlHresultFromLastError() throw()
     return HRESULT_FROM_WIN32(dwError);
 }
 
+template <class T>
+class _NoAddRefReleaseOnCComPtr : public T
+{
+  private:
+    virtual ULONG STDMETHODCALLTYPE AddRef() = 0;
+    virtual ULONG STDMETHODCALLTYPE Release() = 0;
+};
 
 template<class T>
 class CComPtr
@@ -173,10 +180,10 @@ public:
         return p;
     }
 
-    T *operator -> ()
+    _NoAddRefReleaseOnCComPtr<T> *operator -> () const
     {
         ATLASSERT(p != NULL);
-        return p;
+        return (_NoAddRefReleaseOnCComPtr<T> *)p;
     }
 };
 


### PR DESCRIPTION
## Purpose

This mimics what MS's CComPtr is doing:
https://learn.microsoft.com/en-us/cpp/atl/reference/ccomptrbase-class?view=msvc-170#operator_ptr
The reasoning behind this is that AddRef/Release is handled by the CComPtr,
so anyone calling that is most likely not using the CComPtr correct.

