### PR TITLE
[EXPLORER] 'Show Desktop' button should work on button up

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -324,7 +324,7 @@ public:
         PostMessage(TSDB_CLICK, 0, 0);
     }
 
-    LRESULT OnLButtonDown(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+    LRESULT OnLButtonUp(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
         Click(); // Left-click
         return 0;
@@ -413,7 +413,7 @@ public:
     }
 
     BEGIN_MSG_MAP(CTrayShowDesktopButton)
-        MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
+        MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
         MESSAGE_HANDLER(WM_SETTINGCHANGE, OnSettingChanged)
         MESSAGE_HANDLER(WM_THEMECHANGED, OnSettingChanged)
         MESSAGE_HANDLER(WM_PAINT, OnPaint)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -357,7 +357,7 @@ public:
 
     BOOL PtInButton(POINT pt)
     {
-        if (!m_hWnd)
+        if (!IsWindow())
             return FALSE;
         RECT rc;
         GetWindowRect(&rc);
@@ -2607,7 +2607,7 @@ ChangePos:
     // We have to draw non-client area because the 'Show Desktop' button is beyond client area.
     void DrawShowDesktopButton()
     {
-        if (!m_ShowDesktopButton.m_hWnd)
+        if (!m_ShowDesktopButton.IsWindow())
             return;
         // Get the rectangle in window coordinates
         RECT rcButton, rcWnd;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -377,7 +377,7 @@ public:
         m_bHovering = TRUE;
         SetTimer(SHOW_DESKTOP_TIMER_ID, SHOW_DESKTOP_TIMER_INTERVAL, NULL);
         InvalidateRect(NULL, TRUE);
-        ::SendMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
+        ::PostMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
     }
 
     LRESULT OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
@@ -398,7 +398,7 @@ public:
             m_bHovering = FALSE;
             KillTimer(SHOW_DESKTOP_TIMER_ID);
             InvalidateRect(NULL, TRUE);
-            ::SendMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
+            ::PostMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
         }
 
         return 0;
@@ -2615,7 +2615,7 @@ ChangePos:
         m_ShowDesktopButton.GetWindowRect(&rcButton);
         ::OffsetRect(&rcButton, -rcWnd.left, -rcWnd.top);
 
-        HDC hdc = GetDCEx(NULL, DCX_WINDOW | DCX_CACHE | DCX_NORESETATTRS);
+        HDC hdc = GetDCEx(NULL, DCX_WINDOW | DCX_CACHE);
         m_ShowDesktopButton.OnDraw(hdc, &rcButton); // Draw the button
         ReleaseDC(hdc);
     }
@@ -3236,10 +3236,10 @@ HandleTrayContextMenu:
 
     LRESULT OnNcActivate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
     {
-        DefWindowProc(uMsg, wParam, lParam);
+        LRESULT ret = DefWindowProc(uMsg, wParam, lParam);
         DrawShowDesktopButton(); // We have to draw non-client area
         bHandled = TRUE;
-        return 0;
+        return ret;
     }
 
     LRESULT OnNcCalcSize(INT code, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -357,6 +357,8 @@ public:
 
     BOOL PtInButton(POINT pt)
     {
+        if (!m_hWnd)
+            return FALSE;
         RECT rc;
         GetWindowRect(&rc);
         INT cxEdge = ::GetSystemMetrics(SM_CXEDGE), cyEdge = ::GetSystemMetrics(SM_CYEDGE);
@@ -2605,6 +2607,8 @@ ChangePos:
     // We have to draw non-client area because the 'Show Desktop' button is beyond client area.
     void DrawShowDesktopButton()
     {
+        if (!m_ShowDesktopButton.m_hWnd)
+            return;
         // Get the rectangle in window coordinates
         RECT rcButton, rcWnd;
         GetWindowRect(&rcWnd);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -310,7 +310,7 @@ public:
             return 0;
 
         // Show/Hide Desktop
-        ::SendMessageW(::GetParent(m_hWnd), WM_COMMAND, TRAYCMD_TOGGLE_DESKTOP, 0);
+        GetParent().SendMessage(WM_COMMAND, TRAYCMD_TOGGLE_DESKTOP, 0);
         return 0;
     }
 
@@ -377,7 +377,7 @@ public:
         m_bHovering = TRUE;
         SetTimer(SHOW_DESKTOP_TIMER_ID, SHOW_DESKTOP_TIMER_INTERVAL, NULL);
         InvalidateRect(NULL, TRUE);
-        ::PostMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
+        GetParent().PostMessage(WM_NCPAINT, 0, 0);
     }
 
     LRESULT OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
@@ -398,7 +398,7 @@ public:
             m_bHovering = FALSE;
             KillTimer(SHOW_DESKTOP_TIMER_ID);
             InvalidateRect(NULL, TRUE);
-            ::PostMessageW(::GetParent(m_hWnd), WM_NCPAINT, 0, 0);
+            GetParent().PostMessage(WM_NCPAINT, 0, 0);
         }
 
         return 0;


### PR DESCRIPTION
## Purpose

Follow-up of PR #4715.
JIRA issue: [CORE-15369](https://jira.reactos.org/browse/CORE-15369)

## Proposed changes

- The 'Show Desktop' button of taskbar works on button up instead of button down.
- Add `NULL` checks for `m_ShowDesktopButton`.
- Fix hung-up in rebooting.