### PR TITLE
[NTUSER][KBSWITCH] Realize Alt+Shift keyboard switch (retry)

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -546,6 +546,12 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
                     break;
                 }
 
+                case ID_NEXTLAYOUT:
+                {
+                    ActivateLayout(hwnd, GetNextLayout());
+                    break;
+                }
+
                 default:
                 {
                     ActivateLayout(hwnd, LOWORD(wParam));

--- a/base/applications/kbswitch/resource.h
+++ b/base/applications/kbswitch/resource.h
@@ -9,3 +9,4 @@
 /* Menu items */
 #define ID_EXIT        10001
 #define ID_PREFERENCES 10002
+#define ID_NEXTLAYOUT  10003

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -945,6 +945,25 @@ IntDefWindowProc(
                    wParamTmp = UserGetKeyState(VK_SHIFT) & 0x8000 ? SC_PREVWINDOW : SC_NEXTWINDOW;
                    co_IntSendMessage( Active, WM_SYSCOMMAND, wParamTmp, wParam );
                 }
+                else if (wParam == VK_SHIFT) // Alt+Shift
+                {
+                    RTL_ATOM ClassAtom = 0;
+                    UNICODE_STRING ustrClass, ustrWindow;
+                    HWND hwndSwitch;
+
+                    RtlInitUnicodeString(&ustrClass, L"kbswitcher");
+                    RtlInitUnicodeString(&ustrWindow, L"");
+
+                    IntGetAtomFromStringOrAtom(&ustrClass, &ClassAtom);
+
+                    hwndSwitch = IntFindWindow(UserGetDesktopWindow(), NULL, ClassAtom, &ustrWindow);
+                    if (hwndSwitch)
+                    {
+#define ID_NEXTLAYOUT 10003
+                        UserPostMessage(hwndSwitch, WM_COMMAND, ID_NEXTLAYOUT, 0);
+                    }
+                    pti->MessageQueue->QF_flags &= ~QF_FF10STATUS; //iF10Key = 0;
+                }
             }
             else if( wParam == VK_F10 )
             {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -962,7 +962,6 @@ IntDefWindowProc(
 #define ID_NEXTLAYOUT 10003
                         UserPostMessage(hwndSwitch, WM_COMMAND, ID_NEXTLAYOUT, 0);
                     }
-                    pti->MessageQueue->QF_flags &= ~QF_FF10STATUS; //iF10Key = 0;
                 }
             }
             else if( wParam == VK_F10 )

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -3040,7 +3040,7 @@ CLEANUP:
 }
 
 
-static HWND FASTCALL
+HWND FASTCALL
 IntFindWindow(PWND Parent,
               PWND ChildAfter,
               RTL_ATOM ClassAtom,

--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -98,6 +98,8 @@ extern PWINDOWLIST gpwlCache;
 
 PWINDOWLIST FASTCALL IntBuildHwndList(PWND pwnd, DWORD dwFlags, PTHREADINFO pti);
 VOID FASTCALL IntFreeHwndList(PWINDOWLIST pwlTarget);
+HWND FASTCALL IntFindWindow(PWND Parent, PWND ChildAfter, RTL_ATOM ClassAtom,
+                            PUNICODE_STRING WindowName);
 
 /* Undocumented dwFlags for IntBuildHwndList */
 #define IACE_LIST  0x0002


### PR DESCRIPTION
## Purpose

`Alt+Shift` is a useful key combination to switch the current keyboard layout.

JIRA issue: [CORE-11737](https://jira.reactos.org/browse/CORE-11737)

![VirtualBox_ReactOS_23_09_2022_13_00_09](https://user-images.githubusercontent.com/2107452/191890381-85b8fa6f-4df7-4885-8432-4a90dd6bcdcf.png)

## Proposed changes

- Add `ID_NEXTLAYOUT` command to `kbswitch`.
- Send command `ID_NEXTLAYOUT` to `kbswitch` on `Alt+Shift` key combination in `WM_SYSKEYDOWN` handling of `IntDefWindowProc` function.
- Make `IntFindWindow` a non-static function.

## TODO

- [x] Do tests.

Hopefully, it works.