### PR TITLE
[KBSWITCH] Fix keyboard indicator text and font

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -155,6 +155,7 @@ CreateTrayIcon(LPTSTR szLCID)
     ICONINFO IconInfo;
     HICON hIcon;
     LOGFONT lf;
+    BITMAPINFO bmi;
 
     /* Getting "EN", "FR", etc. from English, French, ... */
     LangID = LOWORD(_tcstoul(szLCID, NULL, 16));
@@ -165,9 +166,16 @@ CreateTrayIcon(LPTSTR szLCID)
     }
     szBuf[2] = 0; /* "ENG" --> "EN" etc. */
 
+    ZeroMemory(&bmi, sizeof(bmi));
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = CX_ICON;
+    bmi.bmiHeader.biHeight = CY_ICON;
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 24;
+
     /* Create hdc, hbmColor and hbmMono */
     hdc = CreateCompatibleDC(NULL);
-    hbmColor = CreateCompatibleBitmap(hdc, CX_ICON, CY_ICON);
+    hbmColor = CreateDIBSection(hdc, &bmi, DIB_RGB_COLORS, NULL, NULL, 0);
     hbmMono = CreateBitmap(CX_ICON, CY_ICON, 1, 1, NULL);
 
     /* Create a font */

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -147,7 +147,7 @@ static HICON
 CreateTrayIcon(LPTSTR szLCID)
 {
     LANGID LangID;
-    TCHAR szBuf[3];
+    TCHAR szBuf[4];
     HDC hdc;
     HBITMAP hbmColor, hbmMono, hBmpOld;
     RECT rect;
@@ -157,11 +157,13 @@ CreateTrayIcon(LPTSTR szLCID)
     LOGFONT lf;
 
     /* Getting "EN", "FR", etc. from English, French, ... */
-    LangID = (LANGID)_tcstoul(szLCID, NULL, 16);
-    if (!GetLocaleInfo(LangID, LOCALE_SISO639LANGNAME, szBuf, ARRAYSIZE(szBuf)))
+    LangID = LOWORD(_tcstoul(szLCID, NULL, 16));
+    if (!GetLocaleInfo(LangID, LOCALE_SABBREVLANGNAME | LOCALE_NOUSEROVERRIDE,
+                       szBuf, ARRAYSIZE(szBuf)))
     {
         StringCchCopy(szBuf, ARRAYSIZE(szBuf), _T("??"));
     }
+    szBuf[2] = 0; /* "ENG" --> "EN" etc. */
     CharUpper(szBuf);
 
     /* Create hdc, hbmColor and hbmMono */
@@ -170,11 +172,7 @@ CreateTrayIcon(LPTSTR szLCID)
     hbmMono = CreateBitmap(CX_ICON, CY_ICON, 1, 1, NULL);
 
     /* Create a font */
-    ZeroMemory(&lf, sizeof(lf));
-    lf.lfHeight = -11;
-    lf.lfCharSet = ANSI_CHARSET;
-    lf.lfWeight = FW_NORMAL;
-    StringCchCopy(lf.lfFaceName, ARRAYSIZE(lf.lfFaceName), _T("Tahoma"));
+    SystemParametersInfo(SPI_GETICONTITLELOGFONT, sizeof(lf), &lf, 0);
     hFont = CreateFontIndirect(&lf);
 
     /* Checking NULL */

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -164,11 +164,11 @@ CreateTrayIcon(LPTSTR szLCID)
     {
         StringCchCopy(szBuf, ARRAYSIZE(szBuf), _T("??"));
     }
-    szBuf[2] = 0; /* "ENG" --> "EN" etc. */
+    szBuf[2] = 0; /* Truncate the identifiers to two characters: "ENG" --> "EN" etc. */
 
     /* Prepare for DIB (device-independent bitmap) */
     ZeroMemory(&bmi, sizeof(bmi));
-    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biSize = sizeof(bmi.bmiHeader);
     bmi.bmiHeader.biWidth = CX_ICON;
     bmi.bmiHeader.biHeight = CY_ICON;
     bmi.bmiHeader.biPlanes = 1;

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -166,6 +166,7 @@ CreateTrayIcon(LPTSTR szLCID)
     }
     szBuf[2] = 0; /* "ENG" --> "EN" etc. */
 
+    /* Prepare for DIB (device-independent bitmap) */
     ZeroMemory(&bmi, sizeof(bmi));
     bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
     bmi.bmiHeader.biWidth = CX_ICON;
@@ -179,8 +180,10 @@ CreateTrayIcon(LPTSTR szLCID)
     hbmMono = CreateBitmap(CX_ICON, CY_ICON, 1, 1, NULL);
 
     /* Create a font */
-    SystemParametersInfo(SPI_GETICONTITLELOGFONT, sizeof(lf), &lf, 0);
-    hFont = CreateFontIndirect(&lf);
+    if (SystemParametersInfo(SPI_GETICONTITLELOGFONT, sizeof(lf), &lf, 0))
+        hFont = CreateFontIndirect(&lf);
+    else
+        hFont = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
 
     /* Checking NULL */
     if (!hdc || !hbmColor || !hbmMono || !hFont)

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -164,7 +164,6 @@ CreateTrayIcon(LPTSTR szLCID)
         StringCchCopy(szBuf, ARRAYSIZE(szBuf), _T("??"));
     }
     szBuf[2] = 0; /* "ENG" --> "EN" etc. */
-    CharUpper(szBuf);
 
     /* Create hdc, hbmColor and hbmMono */
     hdc = CreateCompatibleDC(NULL);


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-10667](https://jira.reactos.org/browse/CORE-10667)

## Comparison

WinXP Japanese:
![xp](https://user-images.githubusercontent.com/2107452/192074220-0f383c38-df89-4a02-86f1-8f44ab1b0652.png)

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/192074227-efb710d3-9531-4a20-9fd8-e43acd0d504e.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/192074823-9a94aa21-d771-46d1-8fae-dff24c3d81d4.png)

## Proposed changes

- Do the same behaviour as `input.dll` in getting indicator text.
- Use full color DIB (device-independent bitmap) to improve icon.
- Use `SPI_GETICONTITLELOGFONT` for font.