### PR TITLE
[FREELDR] Allow to boot from FATX volume using vfatfs driver

### DIFF
--- a/boot/bootdata/txtsetup.sif
+++ b/boot/bootdata/txtsetup.sif
@@ -124,6 +124,7 @@ pci.sys      = 1,,,,,,x,4,,,,1,4
 scsiport.sys = 1,,,,,,,4,,,,1,4
 storport.sys = 1,,,,,,,4,,,,1,4
 fastfat.sys  = 1,,,,,,x,4,,,,1,4
+vfatfs.sys   = 1,,,,,,,4,,,,1,4
 btrfs.sys    = 1,,,,,,x,4,,,,1,4
 ramdisk.sys  = 1,,,,,,x,4,,,,1,4
 pciide.sys   = 1,,,,,,,4,,,,1,4

--- a/boot/freeldr/freeldr/lib/fs/fat.c
+++ b/boot/freeldr/freeldr/lib/fs/fat.c
@@ -1547,6 +1547,16 @@ const DEVVTBL FatFuncTable =
     L"fastfat",
 };
 
+const DEVVTBL FatXFuncTable =
+{
+    FatClose,
+    FatGetFileInformation,
+    FatOpen,
+    FatRead,
+    FatSeek,
+    L"vfatfs",
+};
+
 const DEVVTBL* FatMount(ULONG DeviceId)
 {
     PFAT_VOLUME_INFO Volume;
@@ -1634,5 +1644,5 @@ const DEVVTBL* FatMount(ULONG DeviceId)
     // Return success
     //
     TRACE("FatMount(%lu) success\n", DeviceId);
-    return &FatFuncTable;
+    return (ISFATX(Volume->FatType) ? &FatXFuncTable : &FatFuncTable);
 }


### PR DESCRIPTION
This fixes JIRA issue: [CORE-16329](https://jira.reactos.org/browse/CORE-16329)

Creating a PR to run on testbots, to make sure 1st stage setup passes on non-Xbox.