### PR TITLE
[DDRAW] Resize the window after setting the new display mode

### DIFF
--- a/dll/directx/wine/ddraw/ddraw.c
+++ b/dll/directx/wine/ddraw/ddraw.c
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 1997-2000 Marcus Meissner
  * Copyright 1998-2000 Lionel Ulmer
  * Copyright 2000-2001 TransGaming Technologies Inc.
@@ -1146,13 +1146,13 @@ static HRESULT WINAPI ddraw7_SetDisplayMode(IDirectDraw7 *iface, DWORD width, DW
                 ddrawformat_from_wined3dformat(&ddraw->primary->surface_desc.u4.ddpfPixelFormat, mode.format_id);
         }
         ddraw->flags |= DDRAW_RESTORE_MODE;
+		
+		if (ddraw->cooperative_level & DDSCL_EXCLUSIVE)
+            SetWindowPos(ddraw->dest_window, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE);
+            TRACE("DirectDraw window has been resized\n");
     }
 
     InterlockedCompareExchange(&ddraw->device_state, DDRAW_DEVICE_STATE_NOT_RESTORED, DDRAW_DEVICE_STATE_OK);
-
-    if (ddraw->cooperative_level & DDSCL_EXCLUSIVE)
-       SetWindowPos(ddraw->dest_window, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE);
-       TRACE("DirectDraw window has been resized\n");
 
     wined3d_mutex_unlock();
 

--- a/dll/directx/wine/ddraw/ddraw.c
+++ b/dll/directx/wine/ddraw/ddraw.c
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 1997-2000 Marcus Meissner
  * Copyright 1998-2000 Lionel Ulmer
  * Copyright 2000-2001 TransGaming Technologies Inc.
@@ -1132,6 +1132,7 @@ static HRESULT WINAPI ddraw7_SetDisplayMode(IDirectDraw7 *iface, DWORD width, DW
 
     /* TODO: The possible return values from msdn suggest that the screen mode
      * can't be changed if a surface is locked or some drawing is in progress. */
+
     if (SUCCEEDED(hr = wined3d_set_adapter_display_mode(ddraw->wined3d, WINED3DADAPTER_DEFAULT, &mode)))
     {
         if (ddraw->primary)
@@ -1148,6 +1149,10 @@ static HRESULT WINAPI ddraw7_SetDisplayMode(IDirectDraw7 *iface, DWORD width, DW
     }
 
     InterlockedCompareExchange(&ddraw->device_state, DDRAW_DEVICE_STATE_NOT_RESTORED, DDRAW_DEVICE_STATE_OK);
+
+    if (ddraw->cooperative_level & DDSCL_EXCLUSIVE)
+       SetWindowPos(ddraw->dest_window, HWND_TOP, 0, 0, width, height, SWP_SHOWWINDOW | SWP_NOACTIVATE);
+       TRACE("DirectDraw window has been resized\n");
 
     wined3d_mutex_unlock();
 


### PR DESCRIPTION
## Purpose

This gets the taskbar to not show when running a DirectDraw based program in Full-Screen Mode.

JIRA issues: [CORE-16321](https://jira.reactos.org/browse/CORE-16321), [CORE-16130](https://jira.reactos.org/browse/CORE-16130), [CORE-16233](https://jira.reactos.org/browse/CORE-16233), [CORE-16189](https://jira.reactos.org/browse/CORE-16189), [CORE-16140](https://jira.reactos.org/browse/CORE-16140), [CORE-17799](https://jira.reactos.org/browse/CORE-17799), [CORE-17919](https://jira.reactos.org/browse/CORE-17919)

This fix is taken from code found in https://source.winehq.org/git/wine.git/commitdiff/84413298de371a9e9b9ecfe0dd01f580b7521222

The following link shows how all those programs, mentioned with the linked tickets, no longer show the taskbar when displayed in Full-Screen Mode:
https://www.youtube.com/watch?v=WOdhlshVkSo 

Supersedes #4727 and #4724.