### PR TITLE
[BTRFS][UBTRFS][SHELLBTRFS] Upgrade to 1.8.1

### DIFF
--- a/dll/shellext/shellbtrfs/propsheet.cpp
+++ b/dll/shellext/shellbtrfs/propsheet.cpp
@@ -597,6 +597,16 @@ void BtrfsPropSheet::change_inode_flag(HWND hDlg, uint64_t flag, UINT state) {
         flags_set = ~flag;
     }
 
+    if (flags & BTRFS_INODE_NODATACOW && flags_set & BTRFS_INODE_NODATACOW) {
+        EnableWindow(GetDlgItem(hDlg, IDC_COMPRESS), false);
+        EnableWindow(GetDlgItem(hDlg, IDC_COMPRESS_TYPE), false);
+    } else {
+        EnableWindow(GetDlgItem(hDlg, IDC_COMPRESS), true);
+        EnableWindow(GetDlgItem(hDlg, IDC_COMPRESS_TYPE), flags & BTRFS_INODE_COMPRESS && flags_set & BTRFS_INODE_COMPRESS);
+    }
+
+    EnableWindow(GetDlgItem(hDlg, IDC_NODATACOW), !(flags & BTRFS_INODE_COMPRESS) || !(flags_set & BTRFS_INODE_COMPRESS));
+
     flags_changed = true;
 
     SendMessageW(GetParent(hDlg), PSM_CHANGED, (WPARAM)hDlg, 0);
@@ -994,6 +1004,11 @@ void BtrfsPropSheet::init_propsheet(HWND hwndDlg) {
 
     set_check_box(hwndDlg, IDC_NODATACOW, min_flags & BTRFS_INODE_NODATACOW, max_flags & BTRFS_INODE_NODATACOW);
     set_check_box(hwndDlg, IDC_COMPRESS, min_flags & BTRFS_INODE_COMPRESS, max_flags & BTRFS_INODE_COMPRESS);
+
+    if (min_flags & BTRFS_INODE_NODATACOW || max_flags & BTRFS_INODE_NODATACOW)
+        EnableWindow(GetDlgItem(hwndDlg, IDC_COMPRESS), false);
+    else if (min_flags & BTRFS_INODE_COMPRESS || max_flags & BTRFS_INODE_COMPRESS)
+        EnableWindow(GetDlgItem(hwndDlg, IDC_NODATACOW), false);
 
     comptype = GetDlgItem(hwndDlg, IDC_COMPRESS_TYPE);
 

--- a/dll/shellext/shellbtrfs/shellbtrfs.rc
+++ b/dll/shellext/shellbtrfs/shellbtrfs.rc
@@ -61,8 +61,8 @@ IDI_ICON1               ICON                    "subvol.ico"
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,0,0
- PRODUCTVERSION 1,8,0,0
+ FILEVERSION 1,8,1,0
+ PRODUCTVERSION 1,8,1,0
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -78,12 +78,12 @@ BEGIN
         BLOCK "080904b0"
         BEGIN
             VALUE "FileDescription", "WinBtrfs shell extension"
-            VALUE "FileVersion", "1.8.0"
+            VALUE "FileVersion", "1.8.1"
             VALUE "InternalName", "btrfs"
             VALUE "LegalCopyright", "Copyright (c) Mark Harmstone 2016-22"
             VALUE "OriginalFilename", "shellbtrfs.dll"
             VALUE "ProductName", "WinBtrfs"
-            VALUE "ProductVersion", "1.8.0"
+            VALUE "ProductVersion", "1.8.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/dll/win32/ubtrfs/ubtrfs.rc
+++ b/dll/win32/ubtrfs/ubtrfs.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,0,0
- PRODUCTVERSION 1,8,0,0
+ FILEVERSION 1,8,1,0
+ PRODUCTVERSION 1,8,1,0
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "080904b0"
         BEGIN
             VALUE "FileDescription", "Btrfs utility DLL"
-            VALUE "FileVersion", "1.8.0"
+            VALUE "FileVersion", "1.8.1"
             VALUE "InternalName", "ubtrfs"
             VALUE "LegalCopyright", "Copyright (c) Mark Harmstone 2016-22"
             VALUE "OriginalFilename", "ubtrfs.dll"
             VALUE "ProductName", "WinBtrfs"
-            VALUE "ProductVersion", "1.8.0"
+            VALUE "ProductVersion", "1.8.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/drivers/filesystems/btrfs/btrfs.inf
+++ b/drivers/filesystems/btrfs/btrfs.inf
@@ -10,7 +10,7 @@ Signature   = "$Windows NT$"
 Class       = Volume
 ClassGuid   = {71a27cdd-812a-11d0-bec7-08002be2092f}
 Provider    = %Me%
-DriverVer   = 03/12/2022,1.8.0
+DriverVer   = 08/23/2022,1.8.1
 CatalogFile = btrfs.cat
 
 [DestinationDirs]

--- a/drivers/filesystems/btrfs/btrfs.rc
+++ b/drivers/filesystems/btrfs/btrfs.rc
@@ -51,8 +51,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 1,8,0,0
- PRODUCTVERSION 1,8,0,0
+ FILEVERSION 1,8,1,0
+ PRODUCTVERSION 1,8,1,0
  FILEFLAGSMASK 0x17L
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -68,12 +68,12 @@ BEGIN
         BLOCK "080904b0"
         BEGIN
             VALUE "FileDescription", "WinBtrfs"
-            VALUE "FileVersion", "1.8.0"
+            VALUE "FileVersion", "1.8.1"
             VALUE "InternalName", "btrfs"
             VALUE "LegalCopyright", "Copyright (c) Mark Harmstone 2016-22"
             VALUE "OriginalFilename", "btrfs.sys"
             VALUE "ProductName", "WinBtrfs"
-            VALUE "ProductVersion", "1.8.0"
+            VALUE "ProductVersion", "1.8.1"
         END
     END
     BLOCK "VarFileInfo"

--- a/drivers/filesystems/btrfs/btrfs_drv.h
+++ b/drivers/filesystems/btrfs/btrfs_drv.h
@@ -492,8 +492,15 @@ typedef struct {
 } batch_item;
 
 typedef struct {
-    root* r;
+    KEY key;
     LIST_ENTRY items;
+    unsigned int num_items;
+    LIST_ENTRY list_entry;
+} batch_item_ind;
+
+typedef struct {
+    root* r;
+    LIST_ENTRY items_ind;
     LIST_ENTRY list_entry;
 } batch_root;
 
@@ -674,6 +681,7 @@ typedef struct {
     bool clear_cache;
     bool allow_degraded;
     bool no_root_dir;
+    bool nodatacow;
 } mount_options;
 
 #define VCB_TYPE_FS         1
@@ -1182,6 +1190,7 @@ extern uint32_t mount_clear_cache;
 extern uint32_t mount_allow_degraded;
 extern uint32_t mount_readonly;
 extern uint32_t mount_no_root_dir;
+extern uint32_t mount_nodatacow;
 extern uint32_t no_pnp;
 
 #ifndef __GNUC__
@@ -1468,8 +1477,6 @@ NTSTATUS do_tree_writes(device_extension* Vcb, LIST_ENTRY* tree_writes, bool no_
 void add_checksum_entry(device_extension* Vcb, uint64_t address, ULONG length, void* csum, PIRP Irp);
 bool find_metadata_address_in_chunk(device_extension* Vcb, chunk* c, uint64_t* address);
 void add_trim_entry_avoid_sb(device_extension* Vcb, device* dev, uint64_t address, uint64_t size);
-NTSTATUS insert_tree_item_batch(LIST_ENTRY* batchlist, device_extension* Vcb, root* r, uint64_t objid, uint8_t objtype, uint64_t offset,
-                                _In_opt_ _When_(return >= 0, __drv_aliasesMem) void* data, uint16_t datalen, enum batch_operation operation);
 NTSTATUS flush_partial_stripe(device_extension* Vcb, chunk* c, partial_stripe* ps);
 NTSTATUS update_dev_item(device_extension* Vcb, device* device, PIRP Irp);
 void calc_tree_checksum(device_extension* Vcb, tree_header* th);
@@ -1697,6 +1704,9 @@ static __inline void print_open_trees(device_extension* Vcb) {
 }
 
 static __inline bool write_fcb_compressed(fcb* fcb) {
+    if (fcb->inode_item.flags & BTRFS_INODE_NODATACOW)
+        return false;
+
     // make sure we don't accidentally write the cache inodes or pagefile compressed
     if (fcb->subvol->id == BTRFS_ROOT_ROOT || fcb->Header.Flags2 & FSRTL_FLAG2_IS_PAGING_FILE)
         return false;

--- a/drivers/filesystems/btrfs/free-space.c
+++ b/drivers/filesystems/btrfs/free-space.c
@@ -1892,16 +1892,16 @@ static NTSTATUS update_chunk_cache_tree(device_extension* Vcb, chunk* c, PIRP Ir
 
                 fsi_count++;
 
-                ExFreePool(s);
                 RemoveHeadList(&space_list);
+                ExFreePool(s);
                 continue;
             } else if (s->address == tp.item->key.obj_id && s->size == tp.item->key.offset) {
                 // unchanged entry
 
                 fsi_count++;
 
-                ExFreePool(s);
                 RemoveHeadList(&space_list);
+                ExFreePool(s);
             } else {
                 // remove entry
 

--- a/drivers/filesystems/btrfs/fsctl.c
+++ b/drivers/filesystems/btrfs/fsctl.c
@@ -1363,6 +1363,10 @@ static NTSTATUS set_inode_info(PFILE_OBJECT FileObject, void* data, ULONG length
         return STATUS_ACCESS_DENIED;
     }
 
+    // nocow and compression are mutually exclusive
+    if (bsii->flags_changed && bsii->flags & BTRFS_INODE_NODATACOW && bsii->flags & BTRFS_INODE_COMPRESS)
+        return STATUS_INVALID_PARAMETER;
+
     ExAcquireResourceExclusiveLite(fcb->Header.Resource, true);
 
     if (bsii->flags_changed) {


### PR DESCRIPTION
v1.8.1 (2022-08-23):
- Fixed use-after-free when flushing
- Fixed crash when opening volume when AppLocker installed
- Compression now disabled for no-COW files, as on Linux
- Flushing now scales better on very fast drives
- Fixed small files getting padded to 4,096 bytes by lazy writer
- Added NoDataCOW registry option

JIRA issue: [CORE-18322](https://jira.reactos.org/browse/CORE-18322)