### PR TITLE
[NTUSER] IntVkToVsc should return zero if first parameter is zero

### DIFF
--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -1270,6 +1270,9 @@ IntMapVirtualKeyEx(UINT uCode, UINT Type, PKBDTABLES pKbdTbl)
 {
     UINT uRet = 0;
 
+    if (uCode == 0)
+        return uRet;
+
     switch (Type)
     {
         case MAPVK_VK_TO_VSC:

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -528,14 +528,11 @@ IntVkToVsc(WORD wVk, PKBDTABLES pKbdTbl)
 
     ASSERT(pKbdTbl);
 
-    if (wVk == 0)
-        return 0;
-
     /* Check standard keys first */
     for (i = 0; i < pKbdTbl->bMaxVSCtoVK; i++)
     {
         if ((pKbdTbl->pusVSCtoVK[i] & 0xFF) == wVk)
-            return i;
+            return pKbdTbl->pusVSCtoVK[i] & 0xFF;
     }
 
     /* Check extended keys now */

--- a/win32ss/user/ntuser/keyboard.c
+++ b/win32ss/user/ntuser/keyboard.c
@@ -528,6 +528,9 @@ IntVkToVsc(WORD wVk, PKBDTABLES pKbdTbl)
 
     ASSERT(pKbdTbl);
 
+    if (wVk == 0)
+        return 0;
+
     /* Check standard keys first */
     for (i = 0; i < pKbdTbl->bMaxVSCtoVK; i++)
     {
@@ -1269,9 +1272,6 @@ static UINT
 IntMapVirtualKeyEx(UINT uCode, UINT Type, PKBDTABLES pKbdTbl)
 {
     UINT uRet = 0;
-
-    if (uCode == 0)
-        return uRet;
 
     switch (Type)
     {


### PR DESCRIPTION
## Purpose

Investigated using ApiMonitor, removes the "F17" key shortcut in menu items. Fixes CORE-17906 and should fix CORE-3903 too.

JIRA issue: [CORE-17906](https://jira.reactos.org/browse/CORE-17906)
