### PR TITLE
[DNSAPI] DNSRSLVR_HANDLE_bind(): Demote 1 DPRINT1()

### DIFF
--- a/dll/win32/dnsapi/rpc.c
+++ b/dll/win32/dnsapi/rpc.c
@@ -16,7 +16,7 @@ DNSRSLVR_HANDLE_bind(DNSRSLVR_HANDLE pszMachineName)
     LPWSTR pszStringBinding;
     RPC_STATUS Status;
 
-    DPRINT1("DNSRSLVR_HANDLE_bind(%S)\n", pszMachineName);
+    DPRINT("DNSRSLVR_HANDLE_bind(%S)\n", pszMachineName);
 
     Status = RpcStringBindingComposeW(NULL,
                                       L"ncalrpc",


### PR DESCRIPTION
Code has been unchanged for 3 years.

Addendum to b79246c (0.4.14-dev-174).
JIRA issue: [CORE-18384](https://jira.reactos.org/browse/CORE-18384)