### PR TITLE
[USER32_APITEST] Add tests for MapVirtualKeyW

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -48,6 +48,7 @@ list(APPEND SOURCE
     SwitchToThisWindow.c
     SystemParametersInfo.c
     TrackMouseEvent.c
+    VirtualKey.c
     WndProc.c
     wsprintf.c)
 

--- a/modules/rostests/apitests/user32/VirtualKey.c
+++ b/modules/rostests/apitests/user32/VirtualKey.c
@@ -1,0 +1,63 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for virtual keys
+ * COPYRIGHT:   Copyright 2022 Stanislav Motylkov <x86corez@gmail.com>
+ */
+
+#include "precomp.h"
+
+UINT MapTypes[] = {
+    MAPVK_VK_TO_VSC,
+    MAPVK_VSC_TO_VK,
+    MAPVK_VK_TO_CHAR,
+    MAPVK_VSC_TO_VK_EX,
+#if (NTDDI_VERSION >= NTDDI_VISTA)
+    MAPVK_VK_TO_VSC_EX,
+#endif
+};
+
+struct
+{
+    UINT VirtKey;
+    UINT ScanToVirt;
+    UINT ScanCode;
+} TestCodes[] = {
+    {VK_TAB, 0, 15},
+    {VK_RETURN, 0, 28},
+    {VK_CONTROL, 0, 29},
+    {VK_LCONTROL, VK_CONTROL, 29},
+    {VK_RCONTROL, VK_CONTROL, 29},
+    {VK_MENU, 0, 56},
+    {VK_SPACE, 0, 57},
+};
+
+static void testMapVirtualKey()
+{
+    INT i;
+    UINT vCode, vExpect = 0;
+
+    /* Make sure MapVirtualKeyW returns 0 in all cases when uCode == 0 */
+    for (i = 0; i < _countof(MapTypes); i++)
+    {
+        vCode = MapVirtualKeyW(0, MapTypes[i]);
+        ok(vCode == vExpect, "[%d] Returned %u, expected %u\n", i, vCode, vExpect);
+    }
+
+    /* Test matching between virtual keys and scan codes */
+    for (i = 0; i < _countof(TestCodes); i++)
+    {
+        vCode = MapVirtualKeyW(TestCodes[i].VirtKey, MAPVK_VK_TO_VSC);
+        vExpect = TestCodes[i].ScanCode;
+        ok(vCode == vExpect, "[%d] ScanCode = %u, expected %u\n", i, vCode, vExpect);
+
+        vCode = MapVirtualKeyW(TestCodes[i].ScanCode, MAPVK_VSC_TO_VK);
+        vExpect = (TestCodes[i].ScanToVirt == 0 ? TestCodes[i].VirtKey : TestCodes[i].ScanToVirt);
+        ok(vCode == vExpect, "[%d] VirtKey = %u, expected %u\n", i, vCode, vExpect);
+    }
+}
+
+START_TEST(VirtualKey)
+{
+    testMapVirtualKey();
+}

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -50,6 +50,7 @@ extern void func_ShowWindow(void);
 extern void func_SwitchToThisWindow(void);
 extern void func_SystemParametersInfo(void);
 extern void func_TrackMouseEvent(void);
+extern void func_VirtualKey(void);
 extern void func_WndProc(void);
 extern void func_wsprintf(void);
 
@@ -102,6 +103,7 @@ const struct test winetest_testlist[] =
     { "SwitchToThisWindow", func_SwitchToThisWindow },
     { "SystemParametersInfo", func_SystemParametersInfo },
     { "TrackMouseEvent", func_TrackMouseEvent },
+    { "VirtualKey", func_VirtualKey },
     { "WndProc", func_WndProc },
     { "wsprintfApi", func_wsprintf },
     { 0, 0 }


### PR DESCRIPTION
API tests for @julcar's PR #4730.

JIRA issue: [CORE-17906](https://jira.reactos.org/browse/CORE-17906)

## Test results

#### On Windows XP, 2003, 8.1 (9600), 10 (21H2):
```
VirtualKey: 18 tests executed (0 marked as todo, 0 failures), 0 skipped.
```

#### On ReactOS:
```
VirtualKey.c:44: Test failed: [0] Returned 128, expected 0
VirtualKey.c:52: Test failed: [4] ScanCode = 0, expected 29

VirtualKey: 18 tests executed (0 marked as todo, 2 failures), 0 skipped.
```

Cc @HBelusca to review this, as it covers some of his WIP stuff.