### PR TITLE
[WLANCONF] Fix getting the interface GUID value

### DIFF
--- a/base/applications/network/wlanconf/wlanconf.c
+++ b/base/applications/network/wlanconf/wlanconf.c
@@ -1,9 +1,8 @@
 /*
  * PROJECT:     ReactOS WLAN command-line configuration utility
- * LICENSE:     GPL - See COPYING in the top level directory
- * FILE:        base/applications/network/wlanconf/wlanconf.c
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Allows WLAN configuration via the command prompt
- * COPYRIGHT:   Copyright 2012 Cameron Gutman (cameron.gutman@reactos.org)
+ * COPYRIGHT:   Copyright 2012 Cameron Gutman <cameron.gutman@reactos.org>
  */
 
 #include <stdio.h>
@@ -183,8 +182,13 @@ OpenAdapterHandle(DWORD Index, HANDLE *hAdapter, IP_ADAPTER_INDEX_MAP *IpInfo)
 
     for (i = 0; i < InterfaceInfo->NumAdapters; i++)
     {
+        PWCHAR InterfaceGuid = wcschr(InterfaceInfo->Adapter[i].Name, L'{');
+
+        if (InterfaceGuid == NULL)
+            continue;
+
         if (wcsstr((PWCHAR)((PUCHAR)QueryBinding + QueryBinding->DeviceNameOffset),
-                   InterfaceInfo->Adapter[i].Name))
+                   InterfaceGuid))
         {
             *IpInfo = InterfaceInfo->Adapter[i];
             *hAdapter = hDriver;


### PR DESCRIPTION
**JIRA issue:** [**CORE-18032**](https://jira.reactos.org/browse/CORE-18032)

## Description

GetInterfaceInfo returns interface name in Windows XP and 2003 in this format: `\DEVICE\TCPIP_{GUID}`.

MSDN says that the `Name` member of the `IP_ADAPTER_INDEX_MAP` may start with '{' character on Windows Vista and later.

https://docs.microsoft.com/en-us/windows/win32/api/ipexport/ns-ipexport-ip_adapter_index_map

Change the code to support both cases.

## Result

Tested with RTL8187-based USB adapter:

![VirtualBox_ReactOS_28_09_2022_19_47_09](https://user-images.githubusercontent.com/578406/193408595-88a8c1f0-28bc-4970-baf5-31a4ccf64856.png)