### PR TITLE
[NTGDI][FREETYPE] Add Sanitizer and check memory

### DIFF
--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2930,50 +2930,11 @@ NTAPI
 ExQueryPoolBlockSize(IN PVOID PoolBlock,
                      OUT PBOOLEAN QuotaCharged)
 {
-    SIZE_T BlockSize;
-    PPOOL_HEADER Entry;
-    ULONG i;
-    KIRQL OldIrql;
-
-    if (QuotaCharged)
-        *QuotaCharged = FALSE; /* FIXME */
-
-    if (PoolBlock == NULL)
-        return 0;
-
-    /* Get the pool header */
-    Entry = POOL_ENTRY(PoolBlock);
-
-    /* Check if this is a large allocation */
-    if (PAGE_ALIGN(PoolBlock) == PoolBlock)
-    {
-        /* Lock the pool table */
-        KeAcquireSpinLock(&ExpLargePoolTableLock, &OldIrql);
-
-        /* Find the pool tag */
-        for (i = 0; i < PoolBigPageTableSize; i++)
-        {
-            /* Check if this is our allocation */
-            if (PoolBigPageTable[i].Va == PoolBlock)
-                break;
-        }
-
-        /* Release the lock */
-        KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
-
-        ASSERT(i != PoolBigPageTableSize);
-
-        BlockSize = 0; /* FIXME: ??? */
-    }
-    else
-    {
-        /* Check the rest of the header */
-        ExpCheckPoolHeader(Entry);
-
-        BlockSize = Entry->BlockSize;
-    }
-
-    return BlockSize;
+    //
+    // Not implemented
+    //
+    UNIMPLEMENTED;
+    return FALSE;
 }
 
 /*

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2930,7 +2930,7 @@ NTAPI
 ExQueryPoolBlockSize(IN PVOID PoolBlock,
                      OUT PBOOLEAN QuotaCharged)
 {
-    SIZE_T Size;
+    SIZE_T BlockSize;
     PPOOL_HEADER Entry;
     ULONG i;
     KIRQL OldIrql;
@@ -2964,17 +2964,17 @@ ExQueryPoolBlockSize(IN PVOID PoolBlock,
 
         ASSERT(i != PoolBigPageTableSize);
 
-        Size = 0; /* FIXME: ??? */
+        BlockSize = 0; /* FIXME: ??? */
     }
     else
     {
         /* Check the rest of the header */
         ExpCheckPoolHeader(Entry);
 
-        Size = Entry->BlockSize;
+        BlockSize = Entry->BlockSize;
     }
 
-    return Size;
+    return BlockSize;
 }
 
 /*

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2934,7 +2934,6 @@ ExQueryPoolBlockSize(IN PVOID PoolBlock,
     PPOOL_HEADER Entry;
     ULONG i;
     KIRQL OldIrql;
-    POOL_TYPE RealPoolType;
 
     if (QuotaCharged)
         *QuotaCharged = FALSE; /* FIXME */

--- a/ntoskrnl/mm/ARM3/expool.c
+++ b/ntoskrnl/mm/ARM3/expool.c
@@ -2923,13 +2923,14 @@ ExFreePool(PVOID P)
 }
 
 /*
- * @half-implemented
+ * @unimplemented
  */
 SIZE_T
 NTAPI
 ExQueryPoolBlockSize(IN PVOID PoolBlock,
                      OUT PBOOLEAN QuotaCharged)
 {
+    SIZE_T Size;
     PPOOL_HEADER Entry;
     ULONG i;
     KIRQL OldIrql;
@@ -2955,27 +2956,25 @@ ExQueryPoolBlockSize(IN PVOID PoolBlock,
         {
             /* Check if this is our allocation */
             if (PoolBigPageTable[i].Va == PoolBlock)
-            {
                 break;
-            }
         }
 
         /* Release the lock */
         KeReleaseSpinLock(&ExpLargePoolTableLock, OldIrql);
 
-        if (i == PoolBigPageTableSize)
-        {
-            ASSERT(FALSE);
-            return 0;
-        }
+        ASSERT(i != PoolBigPageTableSize);
+
+        Size = 0; /* FIXME: ??? */
     }
     else
     {
         /* Check the rest of the header */
         ExpCheckPoolHeader(Entry);
+
+        Size = Entry->BlockSize;
     }
 
-    return Entry->BlockSize;
+    return Size;
 }
 
 /*

--- a/win32ss/CMakeLists.txt
+++ b/win32ss/CMakeLists.txt
@@ -192,6 +192,7 @@ list(APPEND SOURCE
     gdi/ntgdi/print.c
     gdi/ntgdi/rect.c
     gdi/ntgdi/region.c
+    gdi/ntgdi/sanitizer.c
     gdi/ntgdi/stockobj.c
     gdi/ntgdi/text.c
     gdi/ntgdi/wingl.c

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -12,9 +12,6 @@
 
 #include <win32k.h>
 
-#define SANITIZER_ENABLED
-#include "sanitizer.h"
-
 #include FT_GLYPH_H
 #include FT_TYPE1_TABLES_H
 #include FT_TRUETYPE_TABLES_H
@@ -38,6 +35,9 @@
 
 #define NDEBUG
 #include <debug.h>
+
+#define SANITIZER_ENABLED
+#include "sanitizer.h"
 
 /* TPMF_FIXED_PITCH is confusing; brain-dead api */
 #ifndef _TMPF_VARIABLE_PITCH

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -205,17 +205,23 @@ VOID SanitizeFace(FT_Face Face)
     // ...
 }
 
-VOID SanitizeFaceCache(PSHARED_FACE_CACHE pFaceCache)
+VOID SanitizeBitmapGlyph(FT_BitmapGlyph BitmapGlyph)
 {
     // ...
+}
+
+VOID SanitizeSharedFaceCache(PSHARED_FACE_CACHE pFaceCache)
+{
+    SanitizeUnicodeString(&pFaceCache->FontFamily);
+    SanitizeUnicodeString(&pFaceCache->FullName);
 }
 
 VOID SanitizeSharedFace(PSHARED_FACE SharedFace)
 {
     SanitizeFace(SharedFace->Face);
     SanitizeSharedMem(SharedFace->Memory);
-    SanitizeFaceCache(SharedFace->EnglishUS);
-    SanitizeFaceCache(SharedFace->UserLanguage);
+    SanitizeSharedFaceCache(SharedFace->EnglishUS);
+    SanitizeSharedFaceCache(SharedFace->UserLanguage);
 }
 
 VOID SanitizeFontEntry(PFONT_ENTRY FontEntry)
@@ -228,7 +234,7 @@ VOID SanitizeFontEntry(PFONT_ENTRY FontEntry)
 
     if (FontGDI->SharedFace)
     {
-        SanitizeSharedFace(SharedFace);
+        SanitizeSharedFace(FontGDI->SharedFace);
     }
 }
 
@@ -273,6 +279,7 @@ VOID SanitizePrivateFontList(BOOL bDoLock)
 VOID SanitizeFontCacheEntry(PFONT_CACHE_ENTRY FontEntry)
 {
     SanitizeFace(FontEntry->Face);
+    SanitizeBitmapGlyph(FontEntry->BitmapGlyph);
 }
 
 VOID SanitizeFontCacheList(BOOL bDoLock)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -255,37 +255,47 @@ struct FT_MemoryRec_ g_FreeTypeMemory =
 
 VOID SanitizeFace(FT_Face Face)
 {
-    SanitizeReadPtr(Face, sizeof(*Face), TRUE);
+    SanitizeReadPtr(Face, sizeof(FT_FaceRec), FALSE);
     SanitizeStringPtrA(Face->family_name, TRUE);
     SanitizeStringPtrA(Face->style_name, TRUE);
-    // ...
+    SanitizeReadPtr(Face->available_sizes, sizeof(FT_Bitmap_Size), FALSE);
+    SanitizeReadPtr(Face->charmaps, Face->num_charmaps * sizeof(FT_CharMap), TRUE);
+    SanitizeReadPtr(Face->charmap, sizeof(FT_CharMap), TRUE);
+    // FIXME: ...
+}
+
+VOID SanitizeGlyph(FT_Glyph Glyph)
+{
+    SanitizeReadPtr(Glyph, sizeof(FT_GlyphRec), FALSE);
+    // FIXME: ...
 }
 
 VOID SanitizeBitmapGlyph(FT_BitmapGlyph BitmapGlyph)
 {
-    // ...
+    SanitizeReadPtr(BitmapGlyph, sizeof(FT_BitmapGlyphRec), FALSE);
+    ASSERT(BitmapGlyph->bitmap.buffer != NULL);
 }
 
 VOID SanitizeSharedMem(PSHARED_MEM pSharedMem)
 {
-    SanitizePoolMemory(pSharedMem, TAG_FONT);
+    SanitizePoolMemory(pSharedMem, TAG_FONT, FALSE);
     if (!pSharedMem->IsMapping)
     {
-        SanitizePoolMemory(pSharedMem->Buffer, TAG_FONT);
+        SanitizePoolMemory(pSharedMem->Buffer, TAG_FONT, FALSE);
     }
-    // ...
+    // FIXME: ...
 }
 
 VOID SanitizeSharedFaceCache(PSHARED_FACE_CACHE pFaceCache)
 {
-    SanitizePoolMemory(pFaceCache, TAG_FONT);
-    SanitizeUnicodeString(&pFaceCache->FontFamily);
-    SanitizeUnicodeString(&pFaceCache->FullName);
+    SanitizePoolMemory(pFaceCache, TAG_FONT, FALSE);
+    SanitizeUnicodeString(&pFaceCache->FontFamily, FALSE);
+    SanitizeUnicodeString(&pFaceCache->FullName, FALSE);
 }
 
 VOID SanitizeSharedFace(PSHARED_FACE SharedFace)
 {
-    SanitizePoolMemory(SharedFace, TAG_FONT);
+    SanitizePoolMemory(SharedFace, TAG_FONT, FALSE);
     SanitizeFace(SharedFace->Face);
     SanitizeSharedMem(SharedFace->Memory);
     SanitizeSharedFaceCache(&SharedFace->EnglishUS);
@@ -294,9 +304,9 @@ VOID SanitizeSharedFace(PSHARED_FACE SharedFace)
 
 VOID SanitizeFontSubstEntry(PFONTSUBST_ENTRY pEntry)
 {
-    SanitizePoolMemory(pEntry, TAG_FONT);
-    SanitizeUnicodeString(&pEntry->FontNames[0]);
-    SanitizeUnicodeString(&pEntry->FontNames[1]);
+    SanitizePoolMemory(pEntry, TAG_FONT, FALSE);
+    SanitizeUnicodeString(&pEntry->FontNames[0], FALSE);
+    SanitizeUnicodeString(&pEntry->FontNames[1], FALSE);
 }
 
 VOID SanitizeFontSubstList(VOID)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -231,7 +231,7 @@ ft_custom_realloc(FT_Memory memory,
         return NULL;
     }
 
-    if (!block)
+    if (block == NULL)
         return ft_custom_malloc(memory, new_size);
 
     if (new_size <= cur_size)
@@ -245,6 +245,7 @@ ft_custom_realloc(FT_Memory memory,
         return NULL;
 
     RtlCopyMemory(new_block, block, cur_size);
+    ft_custom_free(memory, block);
     return new_block;
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -11,8 +11,9 @@
 /** Includes ******************************************************************/
 
 #include <win32k.h>
-#include "sanitizer.h"
+
 #define SANITIZER_ENABLED
+#include "sanitizer.h"
 
 #include FT_GLYPH_H
 #include FT_TYPE1_TABLES_H

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -200,7 +200,7 @@ static RTL_STATIC_LIST_HEAD(g_FontSubstListHead);
 
 VOID SanitizeFace(FT_Face Face)
 {
-    SanitizeReadPtr(Face, sizeof(*FT_Face), FALSE);
+    SanitizeReadPtr(Face, sizeof(*Face), FALSE);
     SanitizeStringPtrA(Face->family_name, TRUE);
     SanitizeStringPtrA(Face->style_name, TRUE);
     // ...
@@ -263,7 +263,6 @@ VOID SanitizeFontSubstList(VOID)
 
 VOID SanitizeFontEntry(PFONT_ENTRY FontEntry)
 {
-    FT_Face Face;
     PFONTGDI FontGDI = FontEntry->Font;
 
     if (!FontGDI || !FontGDI->SharedFace)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -416,9 +416,9 @@ VOID DumpFontEntry(PFONT_ENTRY FontEntry)
 #ifdef SANITIZER_ENABLED
     {
         if (Face->family_name)
-            ValidateStringPtrA(Face->family_name);
+            SanitizeStringPtrA(Face->family_name);
         if (Face->style_name)
-            ValidateStringPtrA(Face->style_name);
+            SanitizeStringPtrA(Face->style_name);
         // ...
     }
 #endif

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -56,7 +56,6 @@ static const FT_Matrix identityMat = {(1 << 16), 0, 0, (1 << 16)};
 /* HACK!! Fix XFORMOBJ then use 1:16 / 16:1 */
 #define gmxWorldToDeviceDefault gmxWorldToPageDefault
 
-struct FT_MemoryRec_ g_FreeTypeMemory = { NULL };
 FT_Library  g_FreeTypeLibrary;
 
 /* registry */
@@ -248,6 +247,11 @@ ft_custom_realloc(FT_Memory memory,
     ft_custom_free(memory, block);
     return new_block;
 }
+
+struct FT_MemoryRec_ g_FreeTypeMemory =
+{
+    NULL, ft_custom_malloc, ft_custom_free, ft_custom_realloc
+};
 
 VOID SanitizeFace(FT_Face Face)
 {
@@ -923,10 +927,6 @@ InitFontSupport(VOID)
 
     /* Initialize FreeType */
 #ifdef SANITIZER_ENABLED
-    g_FreeTypeMemory.user    = NULL;
-    g_FreeTypeMemory.alloc   = ft_custom_malloc;
-    g_FreeTypeMemory.realloc = ft_custom_realloc;
-    g_FreeTypeMemory.free    = ft_custom_free;
     ulError = FT_New_Library(&g_FreeTypeMemory, &g_FreeTypeLibrary);
     if (!ulError)
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -200,7 +200,7 @@ static RTL_STATIC_LIST_HEAD(g_FontSubstListHead);
 
 VOID SanitizeFace(FT_Face Face)
 {
-    SanitizeReadPtr(Face, sizeof(*Face), FALSE);
+    SanitizeReadPtr(Face, sizeof(*Face), TRUE);
     SanitizeStringPtrA(Face->family_name, TRUE);
     SanitizeStringPtrA(Face->style_name, TRUE);
     // ...

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -892,6 +892,10 @@ InitFontSupport(VOID)
     DumpFontInfo(TRUE);
 #endif
 
+#ifdef SANITIZER_ENABLED
+    SanitizeFontInfo(TRUE);
+#endif
+
     return TRUE;
 }
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -415,8 +415,10 @@ VOID DumpFontEntry(PFONT_ENTRY FontEntry)
 
 #ifdef SANITIZER_ENABLED
     {
-        ASSERT(!Face->family_name || IsBadStringPtrA(Face->family_name, 256));
-        ASSERT(!Face->style_name || IsBadStringPtrA(Face->style_name, 256));
+        if (Face->family_name)
+            ValidateStringPtrA(Face->family_name);
+        if (Face->style_name)
+            ValidateStringPtrA(Face->style_name);
         // ...
     }
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -80,14 +80,14 @@ SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag)
 
     if (P == NULL)
     {
-        ASSERT(0);
+        ASSERT(FALSE);
         return 0;
     }
 
     if (P == FREED_POINTER || P == UNINIT_POINTER)
     {
         DPRINT1("%p is bad pointer\n", P);
-        ASSERT(0);
+        ASSERT(FALSE);
         return 0;
     }
 
@@ -127,7 +127,7 @@ static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULO
     {
         DPRINT1("%p is double-free suspicious\n", P);
 #ifdef PUNISH_SUSPECTED
-        ASSERT(0);
+        ASSERT(FALSE);
 #endif
     }
 

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -27,6 +27,9 @@
     #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
 #endif
 
+#undef ExAllocatePoolWithTag
+#undef ExFreePoolWithTag
+
 /* FUNCTIONS ******************************************************************/
 
 VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bNullOK)
@@ -96,8 +99,6 @@ SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag)
     return ExQueryPoolBlockSize(P, &QuotaCharged); // FIXME: Implement
 }
 
-#undef ExAllocatePoolWithTag
-
 PVOID FASTCALL
 SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
                               SIZE_T NumberOfBytes,
@@ -137,8 +138,6 @@ VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, ULONG TagToFree)
 
     RtlFillMemory(P, NumberOfBytes, FREED_BYTE);
 }
-
-#undef ExFreePoolWithTag
 
 VOID FASTCALL SanitizeExFreePoolWithTag(PVOID P, ULONG TagToFree)
 {

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -158,17 +158,15 @@ SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag, BOOL bNullOK)
     ASSERT(P != UNINIT_POINTER);
     ASSERT(P != FREED_POINTER);
 
+    real = P;
+    Size = 0;
+
     _SEH2_TRY
     {
         if (IS_FAKE(P))
         {
             real = FAKE2REAL(P);
-            Size = REAL2DATA(real);
-        }
-        else
-        {
-            real = P;
-            Size = 0;
+            Size = (REAL2DATA(real) & DATA_MASK);
         }
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -139,7 +139,7 @@ ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
     if (P)
     {
         NumberOfBytes = SanitizeGetExPoolSize(P);
-        SanitizeCheckSuspicious(P, NumberOfBytes);
+        SanitizeDoubleFreeSuspicious(P, NumberOfBytes);
         memset(P, 0xEE, NumberOfBytes);
     }
 

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -27,11 +27,11 @@
 
 /* FUNCTIONS ******************************************************************/
 
-VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
+VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bNullOK)
 {
     volatile const BYTE *pb;
 
-    if (bCanBeNull && !ptr)
+    if (bNullOK && !ptr)
         return;
 
     for (pb = ptr; cb-- > 0; ++pb)
@@ -45,11 +45,11 @@ VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
     }
 }
 
-VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
+VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK)
 {
     volatile const BYTE *pb;
 
-    if (bCanBeNull && !ptr)
+    if (bNullOK && !ptr)
         return;
 
     for (pb = ptr; cb-- > 0; ++pb)
@@ -58,11 +58,11 @@ VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
     }
 }
 
-VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bCanBeNull)
+VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK)
 {
     volatile const CHAR *pch;
 
-    if (bCanBeNull && !psz)
+    if (bNullOK && !psz)
         return;
 
     for (pch = psz; *pch; ++pch)
@@ -72,11 +72,11 @@ VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bCanBeNull)
     *pch = *pch;
 }
 
-VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bCanBeNull)
+VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK)
 {
     volatile const WCHAR *pch;
 
-    if (bCanBeNull && !psz)
+    if (bNullOK && !psz)
         return;
 
     for (pch = psz; *pch; ++pch)

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -12,6 +12,7 @@
 #include <debug.h>
 #include "sanitizer.h"
 
+/* #define DO_HEAVY_CHECK */
 /* #define PUNISH_SUSPECTED */
 
 #define UNINIT_BYTE 0xDD
@@ -119,13 +120,17 @@ ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
 {
     PVOID ret;
 
+#ifdef DO_HEAVY_CHECK
     SanitizeHeapSystem();
+#endif
 
     ret = ExAllocatePoolWithTag(PoolType, NumberOfBytes, Tag);
     if (ret)
         RtlFillMemory(ret, NumberOfBytes, UNINIT_BYTE);
 
+#ifdef DO_HEAVY_CHECK
     SanitizeHeapSystem();
+#endif
 
     return ret;
 }
@@ -158,12 +163,16 @@ static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULO
 
 VOID FASTCALL ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
 {
+#ifdef DO_HEAVY_CHECK
     SanitizeHeapSystem();
+#endif
 
     if (P)
         SanitizeBeforeExFreePool(P, TagToFree);
 
     ExFreePoolWithTag(P, TagToFree);
 
+#ifdef DO_HEAVY_CHECK
     SanitizeHeapSystem();
+#endif
 }

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -83,7 +83,7 @@ VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag)
     // FIXME
 }
 
-SIZE_T FASTCALL SanitizeGetExPoolSize(LPCVOID pv)
+static SIZE_T FASTCALL SanitizeGetExPoolSize(LPCVOID pv)
 {
     return 0; // FIXME
 }
@@ -129,8 +129,7 @@ VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes)
     }
 }
 
-VOID FASTCALL
-ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
+VOID FASTCALL ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
 {
     SIZE_T NumberOfBytes;
 

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -94,8 +94,10 @@ SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag)
     return ExQueryPoolBlockSize(P, &QuotaCharged); // FIXME: Implement
 }
 
+#undef ExAllocatePoolWithTag
+
 PVOID FASTCALL
-ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
+SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
                               SIZE_T NumberOfBytes,
                               ULONG Tag)
 {
@@ -108,7 +110,7 @@ ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
     return ret;
 }
 
-static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULONG TagToFree)
+VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULONG TagToFree)
 {
     volatile BYTE *pb = P;
     SIZE_T NumberOfBytes, cb, cbFreed;
@@ -134,7 +136,9 @@ static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULO
     RtlFillMemory(P, NumberOfBytes, FREED_BYTE);
 }
 
-VOID FASTCALL ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
+#undef ExFreePoolWithTag
+
+VOID FASTCALL SanitizeExFreePoolWithTag(PVOID P, ULONG TagToFree)
 {
     if (P)
         SanitizeBeforeExFreePool(P, TagToFree);

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -10,6 +10,8 @@
 
 #include <win32k.h>
 #include <debug.h>
+
+#define SANITIZER_ENABLED
 #include "sanitizer.h"
 
 /* #define PUNISH_SUSPECTED */
@@ -65,7 +67,7 @@ VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK)
     ProbeForWrite(psz, cch * sizeof(WCHAR), 1);
 }
 
-VOID FASTCALL SanitizeUnicodeString(const UNICODE_STRING *pustr)
+VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr)
 {
     ASSERT(pustr != NULL);
     ASSERT(pustr->Buffer != UNINIT_POINTER);
@@ -110,7 +112,7 @@ SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
     return ret;
 }
 
-VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULONG TagToFree)
+VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, ULONG TagToFree)
 {
     volatile BYTE *pb = P;
     SIZE_T NumberOfBytes, cb, cbFreed;

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -1,9 +1,8 @@
 /*
- * PROJECT:         ReactOS win32 kernel mode subsystem
- * LICENSE:         GPL - See COPYING in the top level directory
- * FILE:            win32ss/gdi/ntgdi/sanitizer.c
- * PURPOSE:         Address/heap sanitizer
- * PROGRAMMERS:     Copyright 2022 Katayama Hirofumi MZ.
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Sanitizing address, memory and heap
+ * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 /** Includes ******************************************************************/

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -1,0 +1,214 @@
+/*
+ * PROJECT:         ReactOS win32 kernel mode subsystem
+ * LICENSE:         GPL - See COPYING in the top level directory
+ * FILE:            win32ss/gdi/ntgdi/sanitizer.c
+ * PURPOSE:         Address sanitizer
+ * PROGRAMMERS:     Copyright 2022 Katayama Hirofumi MZ.
+ */
+
+/** Includes ******************************************************************/
+
+#include <win32k.h>
+
+/* FUNCTIONS ******************************************************************/
+
+/* The following code is borrowed from kernel32.dll */
+
+/*
+ * @implemented
+ */
+BOOL
+WINAPI
+IsBadReadPtr(IN LPCVOID lp,
+             IN UINT_PTR ucb)
+{
+    ULONG PageSize;
+    BOOLEAN Result = FALSE;
+    volatile CHAR *Current;
+    PCHAR Last;
+
+    /* Quick cases */
+    if (!ucb) return FALSE;
+    if (!lp) return TRUE;
+
+    /* Get the page size */
+    PageSize = BaseStaticServerData->SysInfo.PageSize;
+
+    /* Calculate start and end */
+    Current = (volatile CHAR*)lp;
+    Last = (PCHAR)((ULONG_PTR)lp + ucb - 1);
+
+    /* Another quick failure case */
+    if (Last < Current) return TRUE;
+
+    /* Enter SEH */
+    _SEH2_TRY
+    {
+        /* Do an initial probe */
+        *Current;
+
+        /* Align the addresses */
+        Current = (volatile CHAR *)ALIGN_DOWN_POINTER_BY(Current, PageSize);
+        Last = (PCHAR)ALIGN_DOWN_POINTER_BY(Last, PageSize);
+
+        /* Probe the entire range */
+        while (Current != Last)
+        {
+            Current += PageSize;
+            *Current;
+        }
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        /* We hit an exception, so return true */
+        Result = TRUE;
+    }
+    _SEH2_END
+
+    /* Return exception status */
+    return Result;
+}
+
+/*
+ * @implemented
+ */
+BOOL
+NTAPI
+IsBadCodePtr(FARPROC lpfn)
+{
+    /* Executing has the same privileges as reading */
+    return IsBadReadPtr((LPVOID)lpfn, 1);
+}
+
+/*
+ * @implemented
+ */
+BOOL
+NTAPI
+IsBadWritePtr(IN LPVOID lp,
+              IN UINT_PTR ucb)
+{
+    ULONG PageSize;
+    BOOLEAN Result = FALSE;
+    volatile CHAR *Current;
+    PCHAR Last;
+
+    /* Quick cases */
+    if (!ucb) return FALSE;
+    if (!lp) return TRUE;
+
+    /* Get the page size */
+    PageSize = BaseStaticServerData->SysInfo.PageSize;
+
+    /* Calculate start and end */
+    Current = (volatile CHAR*)lp;
+    Last = (PCHAR)((ULONG_PTR)lp + ucb - 1);
+
+    /* Another quick failure case */
+    if (Last < Current) return TRUE;
+
+    /* Enter SEH */
+    _SEH2_TRY
+    {
+        /* Do an initial probe */
+        *Current = *Current;
+
+        /* Align the addresses */
+        Current = (volatile CHAR *)ALIGN_DOWN_POINTER_BY(Current, PageSize);
+        Last = (PCHAR)ALIGN_DOWN_POINTER_BY(Last, PageSize);
+
+        /* Probe the entire range */
+        while (Current != Last)
+        {
+            Current += PageSize;
+            *Current = *Current;
+        }
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        /* We hit an exception, so return true */
+        Result = TRUE;
+    }
+    _SEH2_END
+
+    /* Return exception status */
+    return Result;
+}
+
+/*
+ * @implemented
+ */
+BOOL
+NTAPI
+IsBadStringPtrW(IN LPCWSTR lpsz,
+                IN UINT_PTR ucchMax)
+{
+    BOOLEAN Result = FALSE;
+    volatile WCHAR *Current;
+    PWCHAR Last;
+    WCHAR Char;
+
+    /* Quick cases */
+    if (!ucchMax) return FALSE;
+    if (!lpsz) return TRUE;
+
+    /* Calculate start and end */
+    Current = (volatile WCHAR*)lpsz;
+    Last = (PWCHAR)((ULONG_PTR)lpsz + (ucchMax * 2) - 2);
+
+    /* Enter SEH */
+    _SEH2_TRY
+    {
+        /* Probe the entire range */
+        Char = *Current++;
+        while ((Char) && (Current != Last)) Char = *Current++;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        /* We hit an exception, so return true */
+        Result = TRUE;
+    }
+    _SEH2_END
+
+    /* Return exception status */
+    return Result;
+}
+
+/*
+ * @implemented
+ */
+BOOL
+NTAPI
+IsBadStringPtrA(IN LPCSTR lpsz,
+                IN UINT_PTR ucchMax)
+{
+    BOOLEAN Result = FALSE;
+    volatile CHAR *Current;
+    PCHAR Last;
+    CHAR Char;
+
+    /* Quick cases */
+    if (!ucchMax) return FALSE;
+    if (!lpsz) return TRUE;
+
+    /* Calculate start and end */
+    Current = (volatile CHAR*)lpsz;
+    Last = (PCHAR)((ULONG_PTR)lpsz + ucchMax - 1);
+
+    /* Enter SEH */
+    _SEH2_TRY
+    {
+        /* Probe the entire range */
+        Char = *Current++;
+        while ((Char) && (Current != Last)) Char = *Current++;
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        /* We hit an exception, so return true */
+        Result = TRUE;
+    }
+    _SEH2_END
+
+    /* Return exception status */
+    return Result;
+}

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -15,17 +15,6 @@
 
 /* #define PUNISH_SUSPECTED */
 
-#define UNINIT_BYTE 0xDD
-#define FREED_BYTE 0xEE
-
-#ifdef _WIN64
-    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDDDDDDDDDD)
-    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEEEEEEEEEE)
-#else
-    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDD)
-    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
-#endif
-
 #undef ExAllocatePoolWithTag
 #undef ExFreePoolWithTag
 

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -231,6 +231,9 @@ VOID FASTCALL SanitizeExFreePoolWithTag(PVOID P, ULONG TagToFree)
     if (!P)
         return;
 
+    ASSERT(P != UNINIT_POINTER);
+    ASSERT(P != FREED_POINTER);
+
     SanitizeBeforeExFreePool(P, TagToFree);
 
     _SEH2_TRY

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -86,6 +86,11 @@ VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK)
     *pch = *pch;
 }
 
+VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr)
+{
+    // FIXME
+}
+
 VOID FASTCALL SanitizeHeapSystem(VOID)
 {
     // FIXME

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -2,7 +2,7 @@
  * PROJECT:         ReactOS win32 kernel mode subsystem
  * LICENSE:         GPL - See COPYING in the top level directory
  * FILE:            win32ss/gdi/ntgdi/sanitizer.c
- * PURPOSE:         Address sanitizer
+ * PURPOSE:         Address/heap sanitizer
  * PROGRAMMERS:     Copyright 2022 Katayama Hirofumi MZ.
  */
 
@@ -12,30 +12,112 @@
 
 /* FUNCTIONS ******************************************************************/
 
-VOID FASTCALL ValidateReadPtr(IN LPCVOID lp, IN UINT_PTR ucb)
+DWORD FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
 {
-    memcmp(lp, lp, ucb);
-}
+    volatile const BYTE *pb;
+    DWORD ret;
 
-VOID FASTCALL ValidateWritePtr(IN LPVOID lp, IN UINT_PTR ucb)
-{
-    memcpy(lp, lp, ucb);
-}
+    if (bCanBeNull && !lp)
+        return 0;
 
-VOID FASTCALL ValidateStringPtrA(IN LPCSTR lpsz)
-{
-    while (*lpsz)
+    pb = lp;
+    ret = 0;
+    while (ucb-- > 0)
     {
-        *lpsz = *lpsz;
-        ++lpsz;
+        ret += *pb;
+        ++pb;
+    }
+    return ret;
+}
+
+VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
+{
+    volatile const BYTE *pb;
+
+    if (bCanBeNull && !lp)
+        return 0;
+
+    pb = lp;
+    while (ucb-- > 0)
+    {
+        *pb = *pb;
+        ++pb;
     }
 }
 
-VOID FASTCALL ValidateStringPtrW(IN LPCWSTR lpsz)
+VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull)
 {
-    while (*lpsz)
+    volatile const CHAR *pch = lpsz;
+    if (bCanBeNull && !lpsz)
+        return;
+    while (*pch)
     {
-        *lpsz = *lpsz;
-        ++lpsz;
+        *pch = *pch;
+        ++pch;
     }
+}
+
+VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull)
+{
+    volatile const WCHAR *pch = lpsz;
+    if (bCanBeNull && !lpsz)
+        return;
+    while (*pch)
+    {
+        *pch = *pch;
+        ++pch;
+    }
+}
+
+VOID FASTCALL SanitizeHeapSystem(VOID)
+{
+    // FIXME
+}
+
+VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag)
+{
+    // FIXME
+}
+
+SIZE_T FASTCALL SanitizeGetExPoolSize(LPCVOID pv)
+{
+    return 0; // FIXME
+}
+
+PVOID FASTCALL
+ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
+                              SIZE_T NumberOfBytes,
+                              ULONG Tag)
+{
+    PVOID ret;
+
+    SanitizeHeapSystem();
+
+    ret = ExAllocatePoolWithTag(PoolType, NumberOfBytes, Tag);
+    if (ret)
+    {
+        memset(ret, 0xDD, NumberOfBytes);
+    }
+
+    SanitizeHeapSystem();
+
+    return ret;
+}
+
+VOID FASTCALL
+ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree)
+{
+    SIZE_T NumberOfBytes;
+
+    SanitizeHeapSystem();
+
+    if (P)
+    {
+        NumberOfBytes = SanitizeGetExPoolSize(P);
+        memset(P, 0xEE, NumberOfBytes);
+    }
+
+    ExFreePoolWithTag(P, TagToFree);
+
+    SanitizeHeapSystem();
 }

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -9,8 +9,8 @@
 /** Includes ******************************************************************/
 
 #include <win32k.h>
-
-/* FUNCTIONS ******************************************************************/
+#include <debug.h>
+#include "sanitizer.h"
 
 /* #define PUNISH_SUSPECTED */
 
@@ -24,6 +24,8 @@
     #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDD)
     #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
 #endif
+
+/* FUNCTIONS ******************************************************************/
 
 VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
 {
@@ -96,6 +98,7 @@ SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag)
 
     if (P == FREED_POINTER || P == UNINIT_POINTER)
     {
+        DPRINT1("%p is bad pointer\n", P);
         ASSERT(0);
         return 0;
     }
@@ -139,7 +142,7 @@ static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULO
 
     if (cbSuspicous >= 4)
     {
-        DPRINT1("%p is double-free suspicous\n", P);
+        DPRINT1("%p is double-free suspicious\n", P);
 #ifdef PUNISH_SUSPECTED
         ASSERT(0);
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -36,7 +36,15 @@ VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bNullOK)
     if (bNullOK && ptr == NULL)
         return;
 
-    ProbeForRead(ptr, cb, 1);
+    _SEH2_TRY
+    {
+        ProbeForRead(ptr, cb, 1);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ASSERT(FALSE);
+    }
+    _SEH2_END;
 }
 
 VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK)
@@ -44,7 +52,15 @@ VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK)
     if (bNullOK && ptr == NULL)
         return;
 
-    ProbeForWrite(ptr, cb, 1);
+    _SEH2_TRY
+    {
+        ProbeForWrite(ptr, cb, 1);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ASSERT(FALSE);
+    }
+    _SEH2_END;
 }
 
 VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK)
@@ -54,8 +70,16 @@ VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK)
     if (bNullOK && psz == NULL)
         return;
 
-    cch = strlen(psz) + 1;
-    ProbeForWrite(psz, cch * sizeof(CHAR), 1);
+    _SEH2_TRY
+    {
+        cch = strlen(psz) + 1;
+        ProbeForWrite(psz, cch * sizeof(CHAR), 1);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ASSERT(FALSE);
+    }
+    _SEH2_END;
 }
 
 VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK)
@@ -65,17 +89,33 @@ VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK)
     if (bNullOK && psz == NULL)
         return;
 
-    cch = wcslen(psz) + 1;
-    ProbeForWrite(psz, cch * sizeof(WCHAR), 1);
+    _SEH2_TRY
+    {
+        cch = wcslen(psz) + 1;
+        ProbeForWrite(psz, cch * sizeof(WCHAR), 1);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ASSERT(FALSE);
+    }
+    _SEH2_END;
 }
 
 VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr)
 {
-    ASSERT(pustr != NULL);
-    ASSERT(pustr->Buffer != UNINIT_POINTER);
-    ASSERT(pustr->Buffer != FREED_POINTER);
-    ProbeForReadUnicodeString(pustr);
-    // FIXME: pustr->Buffer
+    _SEH2_TRY
+    {
+        // FIXME: pustr->Buffer
+        ASSERT(pustr != NULL);
+        ASSERT(pustr->Buffer != UNINIT_POINTER);
+        ASSERT(pustr->Buffer != FREED_POINTER);
+        ProbeForReadUnicodeString(pustr);
+    }
+    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+    {
+        ASSERT(FALSE);
+    }
+    _SEH2_END;
 }
 
 SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag)

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -25,14 +25,14 @@
     #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
 #endif
 
-VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
+VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
 {
     volatile const BYTE *pb;
 
-    if (bCanBeNull && !lp)
+    if (bCanBeNull && !ptr)
         return;
 
-    for (pb = lp; ucb-- > 0; ++pb)
+    for (pb = ptr; cb-- > 0; ++pb)
     {
         if (*pb != *pb)
         {
@@ -43,41 +43,41 @@ VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
     }
 }
 
-VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
+VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bCanBeNull)
 {
     volatile const BYTE *pb;
 
-    if (bCanBeNull && !lp)
+    if (bCanBeNull && !ptr)
         return;
 
-    for (pb = lp; ucb-- > 0; ++pb)
+    for (pb = ptr; cb-- > 0; ++pb)
     {
         *pb = *pb;
     }
 }
 
-VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull)
+VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bCanBeNull)
 {
     volatile const CHAR *pch;
 
-    if (bCanBeNull && !lpsz)
+    if (bCanBeNull && !psz)
         return;
 
-    for (pch = lpsz; *pch; ++pch)
+    for (pch = psz; *pch; ++pch)
     {
         *pch = *pch;
     }
     *pch = *pch;
 }
 
-VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull)
+VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bCanBeNull)
 {
     volatile const WCHAR *pch;
 
-    if (bCanBeNull && !lpsz)
+    if (bCanBeNull && !psz)
         return;
 
-    for (pch = lpsz; *pch; ++pch)
+    for (pch = psz; *pch; ++pch)
     {
         *pch = *pch;
     }

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -12,6 +12,8 @@
 
 /* FUNCTIONS ******************************************************************/
 
+#define PUNISH_SUSPECTED
+
 VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull)
 {
     volatile const BYTE *pb;
@@ -121,6 +123,9 @@ VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes)
     if (cbSuspicous >= 4)
     {
         DPRINT1("%p is double-free suspicous\n", P);
+#ifdef PUNISH_SUSPECTED
+        ASSERT(0);
+#endif
     }
 }
 

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -12,203 +12,30 @@
 
 /* FUNCTIONS ******************************************************************/
 
-/* The following code is borrowed from kernel32.dll */
-
-/*
- * @implemented
- */
-BOOL
-WINAPI
-IsBadReadPtr(IN LPCVOID lp,
-             IN UINT_PTR ucb)
+VOID FASTCALL ValidateReadPtr(IN LPCVOID lp, IN UINT_PTR ucb)
 {
-    ULONG PageSize;
-    BOOLEAN Result = FALSE;
-    volatile CHAR *Current;
-    PCHAR Last;
-
-    /* Quick cases */
-    if (!ucb) return FALSE;
-    if (!lp) return TRUE;
-
-    /* Get the page size */
-    PageSize = BaseStaticServerData->SysInfo.PageSize;
-
-    /* Calculate start and end */
-    Current = (volatile CHAR*)lp;
-    Last = (PCHAR)((ULONG_PTR)lp + ucb - 1);
-
-    /* Another quick failure case */
-    if (Last < Current) return TRUE;
-
-    /* Enter SEH */
-    _SEH2_TRY
-    {
-        /* Do an initial probe */
-        *Current;
-
-        /* Align the addresses */
-        Current = (volatile CHAR *)ALIGN_DOWN_POINTER_BY(Current, PageSize);
-        Last = (PCHAR)ALIGN_DOWN_POINTER_BY(Last, PageSize);
-
-        /* Probe the entire range */
-        while (Current != Last)
-        {
-            Current += PageSize;
-            *Current;
-        }
-    }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        /* We hit an exception, so return true */
-        Result = TRUE;
-    }
-    _SEH2_END
-
-    /* Return exception status */
-    return Result;
+    memcmp(lp, lp, ucb);
 }
 
-/*
- * @implemented
- */
-BOOL
-NTAPI
-IsBadCodePtr(FARPROC lpfn)
+VOID FASTCALL ValidateWritePtr(IN LPVOID lp, IN UINT_PTR ucb)
 {
-    /* Executing has the same privileges as reading */
-    return IsBadReadPtr((LPVOID)lpfn, 1);
+    memcpy(lp, lp, ucb);
 }
 
-/*
- * @implemented
- */
-BOOL
-NTAPI
-IsBadWritePtr(IN LPVOID lp,
-              IN UINT_PTR ucb)
+VOID FASTCALL ValidateStringPtrA(IN LPCSTR lpsz)
 {
-    ULONG PageSize;
-    BOOLEAN Result = FALSE;
-    volatile CHAR *Current;
-    PCHAR Last;
-
-    /* Quick cases */
-    if (!ucb) return FALSE;
-    if (!lp) return TRUE;
-
-    /* Get the page size */
-    PageSize = BaseStaticServerData->SysInfo.PageSize;
-
-    /* Calculate start and end */
-    Current = (volatile CHAR*)lp;
-    Last = (PCHAR)((ULONG_PTR)lp + ucb - 1);
-
-    /* Another quick failure case */
-    if (Last < Current) return TRUE;
-
-    /* Enter SEH */
-    _SEH2_TRY
+    while (*lpsz)
     {
-        /* Do an initial probe */
-        *Current = *Current;
-
-        /* Align the addresses */
-        Current = (volatile CHAR *)ALIGN_DOWN_POINTER_BY(Current, PageSize);
-        Last = (PCHAR)ALIGN_DOWN_POINTER_BY(Last, PageSize);
-
-        /* Probe the entire range */
-        while (Current != Last)
-        {
-            Current += PageSize;
-            *Current = *Current;
-        }
+        *lpsz = *lpsz;
+        ++lpsz;
     }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        /* We hit an exception, so return true */
-        Result = TRUE;
-    }
-    _SEH2_END
-
-    /* Return exception status */
-    return Result;
 }
 
-/*
- * @implemented
- */
-BOOL
-NTAPI
-IsBadStringPtrW(IN LPCWSTR lpsz,
-                IN UINT_PTR ucchMax)
+VOID FASTCALL ValidateStringPtrW(IN LPCWSTR lpsz)
 {
-    BOOLEAN Result = FALSE;
-    volatile WCHAR *Current;
-    PWCHAR Last;
-    WCHAR Char;
-
-    /* Quick cases */
-    if (!ucchMax) return FALSE;
-    if (!lpsz) return TRUE;
-
-    /* Calculate start and end */
-    Current = (volatile WCHAR*)lpsz;
-    Last = (PWCHAR)((ULONG_PTR)lpsz + (ucchMax * 2) - 2);
-
-    /* Enter SEH */
-    _SEH2_TRY
+    while (*lpsz)
     {
-        /* Probe the entire range */
-        Char = *Current++;
-        while ((Char) && (Current != Last)) Char = *Current++;
+        *lpsz = *lpsz;
+        ++lpsz;
     }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        /* We hit an exception, so return true */
-        Result = TRUE;
-    }
-    _SEH2_END
-
-    /* Return exception status */
-    return Result;
-}
-
-/*
- * @implemented
- */
-BOOL
-NTAPI
-IsBadStringPtrA(IN LPCSTR lpsz,
-                IN UINT_PTR ucchMax)
-{
-    BOOLEAN Result = FALSE;
-    volatile CHAR *Current;
-    PCHAR Last;
-    CHAR Char;
-
-    /* Quick cases */
-    if (!ucchMax) return FALSE;
-    if (!lpsz) return TRUE;
-
-    /* Calculate start and end */
-    Current = (volatile CHAR*)lpsz;
-    Last = (PCHAR)((ULONG_PTR)lpsz + ucchMax - 1);
-
-    /* Enter SEH */
-    _SEH2_TRY
-    {
-        /* Probe the entire range */
-        Char = *Current++;
-        while ((Char) && (Current != Last)) Char = *Current++;
-    }
-    _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-    {
-        /* We hit an exception, so return true */
-        Result = TRUE;
-    }
-    _SEH2_END
-
-    /* Return exception status */
-    return Result;
 }

--- a/win32ss/gdi/ntgdi/sanitizer.c
+++ b/win32ss/gdi/ntgdi/sanitizer.c
@@ -91,7 +91,7 @@ VOID FASTCALL SanitizeHeapSystem(VOID)
     // FIXME
 }
 
-SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag)
+SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag)
 {
     if (!P)
         return 0;
@@ -130,7 +130,7 @@ static VOID FASTCALL SanitizeBeforeExFreePool(PVOID P, SIZE_T NumberOfBytes, ULO
     volatile BYTE *pb = P;
     SIZE_T NumberOfBytes, cb, cbSuspicous;
 
-    NumberOfBytes = SanitizeHeapMemory(P, TagToFree);
+    NumberOfBytes = SanitizePoolMemory(P, TagToFree);
     if (!NumberOfBytes)
         return;
 

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -13,13 +13,9 @@
     ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
                                   SIZE_T NumberOfBytes,
                                   ULONG Tag);
-    VOID FASTCALL
-    ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
+    VOID FASTCALL ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
 
-    #undef ExAllocatePoolWithTag
     #define ExAllocatePoolWithTag ExAllocatePoolWithTagSanitize
-
-    #undef ExFreePoolWithTag
     #define ExFreePoolWithTag ExFreePoolWithTagSanitize
 #else
     #define SanitizeReadPtr(ptr, cb, bNullOK)
@@ -28,6 +24,4 @@
     #define SanitizeStringPtrW(psz, bNullOK)
     #define SanitizeHeapSystem()
     #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
-    #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag
-    #define ExFreePoolWithTagSanitize ExFreePoolWithTag
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -15,6 +15,12 @@
                                   ULONG Tag);
     VOID FASTCALL
     ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
+
+    #undef ExAllocatePoolWithTag
+    #define ExAllocatePoolWithTag ExAllocatePoolWithTagSanitize
+
+    #undef ExFreePoolWithTag
+    #define ExFreePoolWithTag ExFreePoolWithTagSanitize
 #else
     #define SanitizeReadPtr(ptr, cb, bCanBeNull)
     #define SanitizeWritePtr(ptr, cb, bCanBeNull)

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -7,9 +7,6 @@
     VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
     VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr);
 
-    VOID FASTCALL SanitizeHeapSystem(VOID);
-    SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag);
-
     PVOID FASTCALL
     ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
                                   SIZE_T NumberOfBytes,
@@ -24,6 +21,4 @@
     #define SanitizeStringPtrA(psz, bNullOK)
     #define SanitizeStringPtrW(psz, bNullOK)
     #define SanitizeUnicodeString(pustr)
-    #define SanitizeHeapSystem()
-    #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,20 +1,29 @@
 #pragma once
 
-VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
-VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
-VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull);
-VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull);
+#ifdef SANITIZER_ENABLED
+    VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull);
 
-VOID FASTCALL SanitizeHeapSystem(VOID);
-VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag);
-SIZE_T FASTCALL SanitizeGetExPoolSize(LPCVOID pv);
+    VOID FASTCALL SanitizeHeapSystem(VOID);
+    VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag);
 
-PVOID FASTCALL
-ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
-                              SIZE_T NumberOfBytes,
-                              ULONG Tag);
-VOID FASTCALL
-ExFreePoolWithTagSanitize(PVOID P,
-                          ULONG TagToFree);
+    PVOID FASTCALL
+    ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
+                                  SIZE_T NumberOfBytes,
+                                  ULONG Tag);
+    VOID FASTCALL
+    ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
 
-VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes);
+    VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes);
+#else
+    #define SanitizeReadPtr(lp, ucb, bCanBeNull)
+    #define SanitizeWritePtr(lp, ucb, bCanBeNull)
+    #define SanitizeStringPtrA(lpsz, bCanBeNull)
+    #define SanitizeStringPtrW(lpsz, bCanBeNull)
+    #define SanitizeHeapSystem()
+    #define SanitizeHeapMemory(P, PoolType, Tag)
+    #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag
+    #define ExFreePoolWithTagSanitize ExFreePoolWithTag
+#endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -6,6 +6,7 @@
     VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK);
     VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
     VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr);
+    SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag);
 
     PVOID FASTCALL
     SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
@@ -22,4 +23,5 @@
     #define SanitizeStringPtrA(psz, bNullOK)
     #define SanitizeStringPtrW(psz, bNullOK)
     #define SanitizeUnicodeString(pustr)
+    #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -16,3 +16,5 @@ ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
 VOID FASTCALL
 ExFreePoolWithTagSanitize(PVOID P,
                           ULONG TagToFree);
+
+VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes);

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,0 +1,7 @@
+#pragma once
+
+BOOL WINAPI IsBadReadPtr(IN LPCVOID lp, IN UINT_PTR ucb);
+BOOL NTAPI IsBadWritePtr(IN LPVOID lp, IN UINT_PTR ucb);
+BOOL NTAPI IsBadCodePtr(FARPROC lpfn);
+BOOL NTAPI IsBadStringPtrA(IN LPCSTR lpsz, IN UINT_PTR ucchMax);
+BOOL NTAPI IsBadStringPtrW(IN LPCWSTR lpsz, IN UINT_PTR ucchMax);

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,7 +1,6 @@
 #pragma once
 
-BOOL WINAPI IsBadReadPtr(IN LPCVOID lp, IN UINT_PTR ucb);
-BOOL NTAPI IsBadWritePtr(IN LPVOID lp, IN UINT_PTR ucb);
-BOOL NTAPI IsBadCodePtr(FARPROC lpfn);
-BOOL NTAPI IsBadStringPtrA(IN LPCSTR lpsz, IN UINT_PTR ucchMax);
-BOOL NTAPI IsBadStringPtrW(IN LPCWSTR lpsz, IN UINT_PTR ucchMax);
+VOID FASTCALL ValidateReadPtr(IN LPCVOID lp, IN UINT_PTR ucb);
+VOID FASTCALL ValidateWritePtr(IN LPVOID lp, IN UINT_PTR ucb);
+VOID FASTCALL ValidateStringPtrA(IN LPCSTR lpsz);
+VOID FASTCALL ValidateStringPtrW(IN LPCWSTR lpsz);

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -23,8 +23,8 @@
     VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK);
     VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK);
     VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
-    VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr);
-    SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag);
+    VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr, BOOL bNullOK);
+    SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag, BOOL bNullOK);
 
     PVOID FASTCALL
     SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
@@ -40,6 +40,6 @@
     #define SanitizeWritePtr(ptr, cb, bNullOK)
     #define SanitizeStringPtrA(psz, bNullOK)
     #define SanitizeStringPtrW(psz, bNullOK)
-    #define SanitizeUnicodeString(pustr)
-    #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
+    #define SanitizeUnicodeString(pustr, bNullOK)
+    #define SanitizePoolMemory(P, Tag, bNullOK) ((SIZE_T)0)
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -7,6 +7,17 @@
 
 #pragma once
 
+#define UNINIT_BYTE 0xDD
+#define FREED_BYTE 0xEE
+
+#ifdef _WIN64
+    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDDDDDDDDDD)
+    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEEEEEEEEEE)
+#else
+    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDD)
+    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
+#endif
+
 #ifdef SANITIZER_ENABLED
     VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bNullOK);
     VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK);

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,3 +1,10 @@
+/*
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Sanitizing address, memory and heap
+ * COPYRIGHT:   Copyright 2022 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
 #pragma once
 
 #ifdef SANITIZER_ENABLED

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #ifdef SANITIZER_ENABLED
-    VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bCanBeNull);
 
     VOID FASTCALL SanitizeHeapSystem(VOID);
     SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag);
@@ -16,10 +16,10 @@
     VOID FASTCALL
     ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
 #else
-    #define SanitizeReadPtr(lp, ucb, bCanBeNull)
-    #define SanitizeWritePtr(lp, ucb, bCanBeNull)
-    #define SanitizeStringPtrA(lpsz, bCanBeNull)
-    #define SanitizeStringPtrW(lpsz, bCanBeNull)
+    #define SanitizeReadPtr(ptr, cb, bCanBeNull)
+    #define SanitizeWritePtr(ptr, cb, bCanBeNull)
+    #define SanitizeStringPtrA(psz, bCanBeNull)
+    #define SanitizeStringPtrW(psz, bCanBeNull)
     #define SanitizeHeapSystem()
     #define SanitizeHeapMemory(P, Tag) ((SIZE_T)0)
     #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,6 +1,18 @@
 #pragma once
 
-VOID FASTCALL ValidateReadPtr(IN LPCVOID lp, IN UINT_PTR ucb);
-VOID FASTCALL ValidateWritePtr(IN LPVOID lp, IN UINT_PTR ucb);
-VOID FASTCALL ValidateStringPtrA(IN LPCSTR lpsz);
-VOID FASTCALL ValidateStringPtrW(IN LPCWSTR lpsz);
+VOID FASTCALL SanitizeReadPtr(LPCVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
+VOID FASTCALL SanitizeWritePtr(LPVOID lp, UINT_PTR ucb, BOOL bCanBeNull);
+VOID FASTCALL SanitizeStringPtrA(LPSTR lpsz, BOOL bCanBeNull);
+VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull);
+
+VOID FASTCALL SanitizeHeapSystem(VOID);
+VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag);
+SIZE_T FASTCALL SanitizeGetExPoolSize(LPCVOID pv);
+
+PVOID FASTCALL
+ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
+                              SIZE_T NumberOfBytes,
+                              ULONG Tag);
+VOID FASTCALL
+ExFreePoolWithTagSanitize(PVOID P,
+                          ULONG TagToFree);

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -7,15 +7,15 @@
 
 #pragma once
 
-#define UNINIT_BYTE 0xDD
-#define FREED_BYTE 0xEE
+#define UNINIT_BYTE 0xCD
+#define FREED_BYTE 0xFD
 
 #ifdef _WIN64
-    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDDDDDDDDDD)
-    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEEEEEEEEEE)
+    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xCDCDCDCDCDCDCDCD)
+    #define FREED_POINTER ((PVOID)(UINT_PTR)0xFDFDFDFDFDFDFDFD)
 #else
-    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xDDDDDDDD)
-    #define FREED_POINTER ((PVOID)(UINT_PTR)0xEEEEEEEE)
+    #define UNINIT_POINTER ((PVOID)(UINT_PTR)0xCDCDCDCD)
+    #define FREED_POINTER ((PVOID)(UINT_PTR)0xFDFDFDFD)
 #endif
 
 #ifdef SANITIZER_ENABLED
@@ -34,7 +34,10 @@
     VOID FASTCALL SanitizeExFreePoolWithTag(PVOID P, ULONG TagToFree);
 
     #define ExAllocatePoolWithTag SanitizeExAllocatePoolWithTag
-    #define ExFreePoolWithTag SanitizeExFreePoolWithTag
+    #define ExFreePoolWithTag(P, TagToFree) do { \
+        SanitizeExFreePoolWithTag((P), (TagToFree)); \
+        (P) = FREED_POINTER; \
+    } while (0)
 #else
     #define SanitizeReadPtr(ptr, cb, bNullOK)
     #define SanitizeWritePtr(ptr, cb, bNullOK)

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -5,6 +5,7 @@
     VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK);
     VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK);
     VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
+    VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr);
 
     VOID FASTCALL SanitizeHeapSystem(VOID);
     SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag);
@@ -22,6 +23,7 @@
     #define SanitizeWritePtr(ptr, cb, bNullOK)
     #define SanitizeStringPtrA(psz, bNullOK)
     #define SanitizeStringPtrW(psz, bNullOK)
+    #define SanitizeUnicodeString(pustr)
     #define SanitizeHeapSystem()
     #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -1,10 +1,10 @@
 #pragma once
 
 #ifdef SANITIZER_ENABLED
-    VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bCanBeNull);
-    VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bCanBeNull);
+    VOID FASTCALL SanitizeReadPtr(LPCVOID ptr, UINT_PTR cb, BOOL bNullOK);
+    VOID FASTCALL SanitizeWritePtr(LPVOID ptr, UINT_PTR cb, BOOL bNullOK);
+    VOID FASTCALL SanitizeStringPtrA(LPSTR psz, BOOL bNullOK);
+    VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
 
     VOID FASTCALL SanitizeHeapSystem(VOID);
     SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag);
@@ -22,10 +22,10 @@
     #undef ExFreePoolWithTag
     #define ExFreePoolWithTag ExFreePoolWithTagSanitize
 #else
-    #define SanitizeReadPtr(ptr, cb, bCanBeNull)
-    #define SanitizeWritePtr(ptr, cb, bCanBeNull)
-    #define SanitizeStringPtrA(psz, bCanBeNull)
-    #define SanitizeStringPtrW(psz, bCanBeNull)
+    #define SanitizeReadPtr(ptr, cb, bNullOK)
+    #define SanitizeWritePtr(ptr, cb, bNullOK)
+    #define SanitizeStringPtrA(psz, bNullOK)
+    #define SanitizeStringPtrW(psz, bNullOK)
     #define SanitizeHeapSystem()
     #define SanitizeHeapMemory(P, Tag) ((SIZE_T)0)
     #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -7,7 +7,7 @@
     VOID FASTCALL SanitizeStringPtrW(LPWSTR lpsz, BOOL bCanBeNull);
 
     VOID FASTCALL SanitizeHeapSystem(VOID);
-    VOID FASTCALL SanitizeHeapMemory(PVOID P, POOL_TYPE PoolType, ULONG Tag);
+    SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag);
 
     PVOID FASTCALL
     ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
@@ -15,15 +15,13 @@
                                   ULONG Tag);
     VOID FASTCALL
     ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
-
-    VOID FASTCALL SanitizeDoubleFreeSuspicious(PVOID P, SIZE_T NumberOfBytes);
 #else
     #define SanitizeReadPtr(lp, ucb, bCanBeNull)
     #define SanitizeWritePtr(lp, ucb, bCanBeNull)
     #define SanitizeStringPtrA(lpsz, bCanBeNull)
     #define SanitizeStringPtrW(lpsz, bCanBeNull)
     #define SanitizeHeapSystem()
-    #define SanitizeHeapMemory(P, PoolType, Tag)
+    #define SanitizeHeapMemory(P, Tag) ((SIZE_T)0)
     #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag
     #define ExFreePoolWithTagSanitize ExFreePoolWithTag
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -7,7 +7,7 @@
     VOID FASTCALL SanitizeStringPtrW(LPWSTR psz, BOOL bNullOK);
 
     VOID FASTCALL SanitizeHeapSystem(VOID);
-    SIZE_T FASTCALL SanitizeHeapMemory(PVOID P, ULONG Tag);
+    SIZE_T FASTCALL SanitizePoolMemory(PVOID P, ULONG Tag);
 
     PVOID FASTCALL
     ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
@@ -27,7 +27,7 @@
     #define SanitizeStringPtrA(psz, bNullOK)
     #define SanitizeStringPtrW(psz, bNullOK)
     #define SanitizeHeapSystem()
-    #define SanitizeHeapMemory(P, Tag) ((SIZE_T)0)
+    #define SanitizePoolMemory(P, Tag) ((SIZE_T)0)
     #define ExAllocatePoolWithTagSanitize ExAllocatePoolWithTag
     #define ExFreePoolWithTagSanitize ExFreePoolWithTag
 #endif

--- a/win32ss/gdi/ntgdi/sanitizer.h
+++ b/win32ss/gdi/ntgdi/sanitizer.h
@@ -8,13 +8,14 @@
     VOID FASTCALL SanitizeUnicodeString(PUNICODE_STRING pustr);
 
     PVOID FASTCALL
-    ExAllocatePoolWithTagSanitize(POOL_TYPE PoolType,
+    SanitizeExAllocatePoolWithTag(POOL_TYPE PoolType,
                                   SIZE_T NumberOfBytes,
                                   ULONG Tag);
-    VOID FASTCALL ExFreePoolWithTagSanitize(PVOID P, ULONG TagToFree);
 
-    #define ExAllocatePoolWithTag ExAllocatePoolWithTagSanitize
-    #define ExFreePoolWithTag ExFreePoolWithTagSanitize
+    VOID FASTCALL SanitizeExFreePoolWithTag(PVOID P, ULONG TagToFree);
+
+    #define ExAllocatePoolWithTag SanitizeExAllocatePoolWithTag
+    #define ExFreePoolWithTag SanitizeExFreePoolWithTag
 #else
     #define SanitizeReadPtr(ptr, cb, bNullOK)
     #define SanitizeWritePtr(ptr, cb, bNullOK)


### PR DESCRIPTION
## Purpose

Investigate the cause of memory destruction.
JIRA issue: [CORE-17324](https://jira.reactos.org/browse/CORE-17324)

- Detect double free.
- Detect uninitialized variable use.
- Detect heap collapse.

## Proposed changes

- Half-implement `ExQueryPoolBlockSize`.
- Add files `sanitizer.h` and `sanitizer.c`.
- Check memory in file `freetype.c`.
- Fill memory for check in `SanitizeExAllocatePoolWithTag`.
- Fill memory for check in `SanitizeExFreePoolWithTag`.
- Replace `ExAllocatePoolWithTag` with `SanitizeExAllocatePoolWithTag` in `freetype.c`.
- Replace `ExFreePoolWithTag` with `SanitizeExFreePoolWithTag` in `freetype.c`.