### PR TITLE
[WINLOGON] Protect function calls to '3rd-party' DLLs by SEH.

### DIFF
--- a/base/system/winlogon/CMakeLists.txt
+++ b/base/system/winlogon/CMakeLists.txt
@@ -21,7 +21,7 @@ list(APPEND SOURCE
 
 add_rc_deps(winlogon.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/winlogon.ico)
 add_executable(winlogon ${SOURCE} winlogon.rc)
-target_link_libraries(winlogon wine)
+target_link_libraries(winlogon wine ${PSEH_LIB})
 set_module_type(winlogon win32gui)
 add_importlibs(winlogon user32 advapi32 userenv secur32 rpcrt4 mpr msvcrt kernel32 ntdll)
 add_pch(winlogon winlogon.h SOURCE)

--- a/base/system/winlogon/winlogon.h
+++ b/base/system/winlogon/winlogon.h
@@ -26,10 +26,12 @@
 #ifndef __WINLOGON_MAIN_H__
 #define __WINLOGON_MAIN_H__
 
-#include <stdarg.h>
-
 #define USE_GETLASTINPUTINFO
 
+
+#include <stdarg.h>
+
+/* PSDK/NDK Headers */
 #define WIN32_NO_STATUS
 #include <windef.h>
 #include <winbase.h>
@@ -40,6 +42,9 @@
 #include <ndk/rtlfuncs.h>
 #include <ndk/exfuncs.h>
 #include <strsafe.h>
+
+/* PSEH for SEH Support */
+#include <pseh/pseh2.h>
 
 #include <reactos/undocuser.h>
 #include <reactos/undocmpr.h>


### PR DESCRIPTION
## Purpose

3rd-party code (e.g. Gina notification handlers DLLs), or related code (e.g. winmm.dll when playing sound events via sound files) can run in the context of WinLogon.exe. If this code crashes (because it contains a bug, or plays a corrupted sound file, etc.), then WinLogon would crash, and since this is a marked system process, this would trigger a BSoD.

Protect calls to this 3rd-party code by SEH.
(Remark: LoadLibrary calls, that run dll's DllMain() functions, don't need to be under SEH, since LoadLibrary already handles that. Thanks to Mark for noticing this.)

## Proposed changes

This includes:
- Notification dll calling in CallNotificationDll().
- winmm.dll API calling (e.g. PlaySound) in PlaySoundRoutine().

Also:
- Fix dwKeyName usage in RegEnumKeyExW() specifying a number of *characters*.
