### PR TITLE
[EVENTVWR] Improve behaviour on event item selection.

### DIFF
--- a/base/applications/mscutils/eventvwr/evtdetctl.h
+++ b/base/applications/mscutils/eventvwr/evtdetctl.h
@@ -10,6 +10,14 @@
 #ifndef _EVTDETCTL_H_
 #define _EVTDETCTL_H_
 
+/* Optional structure passed by pointer
+ * as LPARAM to CreateEventDetailsCtrl() */
+typedef struct _EVENTDETAIL_INFO
+{
+    PEVENTLOGFILTER EventLogFilter;
+    INT iEventItem;
+} EVENTDETAIL_INFO, *PEVENTDETAIL_INFO;
+
 #define EVT_SETFILTER   (WM_APP + 2)
 #define EVT_DISPLAY     (WM_APP + 3)
 


### PR DESCRIPTION
## Purpose

When clicking outside a selected event item in the list, or right clicking on a non-selected line,
we used to get "No Items in ListView" error.
This error came from a check for code paths that should, in principle, be not taken if no event item is selected.

JIRA issue: [CORE-18438](https://jira.reactos.org/browse/CORE-18438)

## Proposed changes

Rework how some aspects of item selection retrieval is done.

- Each event detail control stores its own "current" item index, so
  that there can be different event detail dialogs showing different
  events concurrently (half-plemented; this is a Win7-like feature).
  As such, give the index of the selected event item when sending
  the EVT_DISPLAY message, instead of having the details dialog
  retrieve everytime by itself the current selected item (that may
  change in-between calls, and can trigger the "No Items in ListView"
  error).

- When pressing "Prev"/"Next" buttons, detect whether we already are
  at the top/bottom of the event log, and if so, prompt the user to
  continue around.
  Clear up any selected event in the list, before selecting the new
  one. (Note: the event list supports multiple selection, for future
  functionality.)
