### PR TITLE
[NTUSER] Add ASSERT() on "linking window to itself"

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -946,7 +946,8 @@ IntLinkWindow(
 {
     if (Wnd == WndInsertAfter)
     {
-        ERR("IntLinkWindow -- Trying to link window 0x%p to itself!!\n", Wnd);
+        ERR("Trying to link window 0x%p to itself\n", Wnd);
+        ASSERT(WndInsertAfter != Wnd);
         return;
     }
 
@@ -1049,8 +1050,15 @@ VOID FASTCALL IntLinkHwnd(PWND Wnd, HWND hWndPrev)
         }
 
         if (Wnd == WndInsertAfter)
-            ERR("IntLinkHwnd -- Trying to link window 0x%p to itself!!\n", Wnd);
-        IntLinkWindow(Wnd, WndInsertAfter);
+        {
+            ERR("Trying to link window 0x%p to itself\n", Wnd);
+            ASSERT(WndInsertAfter != Wnd);
+            // FIXME: IntUnlinkWindow(Wnd) was already called. Continuing as is seems wrong!
+        }
+        else
+        {
+            IntLinkWindow(Wnd, WndInsertAfter);
+        }
 
         /* Fix the WS_EX_TOPMOST flag */
         if (!(WndInsertAfter->ExStyle & WS_EX_TOPMOST))


### PR DESCRIPTION
## Purpose

@learn-more wrote 'break on this in debug builds'.
https://jira.reactos.org/browse/CORE-18132?focusedCommentId=133294&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-133294

Addendum to ee0511b (0.4.10-dev-323).
JIRA issue: [CORE-18132](https://jira.reactos.org/browse/CORE-18132)

## Proposed changes

- Add 1 `else`.
- Add 2 `ASSERT()`.
- Add 1 FIXME comment.