### PR TITLE
[EVENTVWR] Fix settings loading. Remove usage of Rtl functions. Use Win32 CRT assert.

### DIFF
--- a/base/applications/mscutils/eventvwr/eventvwr.h
+++ b/base/applications/mscutils/eventvwr/eventvwr.h
@@ -10,13 +10,17 @@
 #ifndef _EVENTVWR_PCH_
 #define _EVENTVWR_PCH_
 
-// #pragma once
+#pragma once
 
+/* C Headers */
 #include <stdio.h>
 #include <stdlib.h>
 
-#define WIN32_NO_STATUS
+#include <assert.h>
+#define ASSERT(x) assert(x)
 
+/* PSDK Headers */
+#define WIN32_NO_STATUS
 #include <windef.h>
 #include <winbase.h>
 #include <wingdi.h>
@@ -24,7 +28,7 @@
 #include <winnls.h>
 #include <winreg.h>
 
-#include <ndk/rtlfuncs.h>
+#include <ndk/rtlfuncs.h> // For linked-lists.
 
 #define ROUND_DOWN(n, align) (((ULONG)n) & ~((align) - 1l))
 #define ROUND_UP(n, align) ROUND_DOWN(((ULONG)n) + (align) - 1, (align))


### PR DESCRIPTION
## Purpose

Exactly what's written in the title.

## Proposed changes

- Don't create the settings registry key when trying to load them.
  Defer its creation when saving the settings.

- Use more restricted access rights when opening/creating the key.

- Ensure read and written string settings are NULL-terminated.

- Use the Win32 CRT assert so that if an assertion fails we get a
  message on the screen, not via the kernel debugger.