### PR TITLE
[USER32_APITEST] Add tests for Keyboard Layouts

### DIFF
--- a/modules/rostests/apitests/user32/CMakeLists.txt
+++ b/modules/rostests/apitests/user32/CMakeLists.txt
@@ -23,6 +23,7 @@ list(APPEND SOURCE
     GetUserObjectInformation.c
     GetWindowPlacement.c
     InitializeLpkHooks.c
+    KbdLayout.c
     keybd_event.c
     LoadImage.c
     LookupIconIdFromDirectoryEx.c

--- a/modules/rostests/apitests/user32/KbdLayout.c
+++ b/modules/rostests/apitests/user32/KbdLayout.c
@@ -1,0 +1,113 @@
+/*
+ * PROJECT:     ReactOS API tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for Keyboard Layouts DLL files
+ * COPYRIGHT:   Copyright 2022 Stanislav Motylkov <x86corez@gmail.com>
+ */
+
+#include "precomp.h"
+#include <ndk/kbd.h>
+#include <strsafe.h>
+
+typedef PVOID (*PFN_KBDLAYERDESCRIPTOR)(VOID);
+
+static void testLayout(
+    _In_ LPWSTR szFileName,
+    _In_ LPWSTR szFilePath)
+{
+    HMODULE hModule;
+    PFN_KBDLAYERDESCRIPTOR pfnKbdLayerDescriptor;
+    PKBDTABLES pKbdTbl;
+    USHORT i, uTableSize;
+
+    trace("Testing '%ls'...\n", szFileName);
+
+    hModule = LoadLibraryW(szFilePath);
+    if (!hModule)
+    {
+        ok(FALSE, "LoadLibraryW failed with code %ld\n", GetLastError());
+        return;
+    }
+
+    pfnKbdLayerDescriptor = (PFN_KBDLAYERDESCRIPTOR)GetProcAddress(hModule, "KbdLayerDescriptor");
+    if (!pfnKbdLayerDescriptor)
+    {
+        ok(FALSE, "KbdLayerDescriptor not found!\n");
+        goto Cleanup;
+    }
+
+    pKbdTbl = pfnKbdLayerDescriptor();
+    if (!pKbdTbl)
+    {
+        ok(FALSE, "PKBDTABLES is NULL!\n");
+        goto Cleanup;
+    }
+
+    if (!pKbdTbl->pusVSCtoVK)
+    {
+        ok(FALSE, "pusVSCtoVK table is NULL!\n");
+        goto Cleanup;
+    }
+
+    if (wcscmp(szFileName, L"kbdnec.dll") == 0)
+        uTableSize = 128; /* Only NEC PC-9800 Japanese keyboard layout has 128 entries. */
+    else
+        uTableSize = 127;
+
+    /* Validate number of entries in pusVSCtoVK array. */
+    ok(pKbdTbl->bMaxVSCtoVK == uTableSize, "pKbdTbl->bMaxVSCtoVK = %u\n", pKbdTbl->bMaxVSCtoVK);
+
+    for (i = 0; i < pKbdTbl->bMaxVSCtoVK; ++i)
+    {
+        /* Make sure there are no Virtual Keys with zero value. */
+        if (pKbdTbl->pusVSCtoVK[i] == 0)
+            ok(FALSE, "Scan Code %u => Virtual Key %u\n", i, pKbdTbl->pusVSCtoVK[i]);
+    }
+
+Cleanup:
+    if (hModule)
+        FreeLibrary(hModule);
+}
+
+static void testKeyboardLayouts(void)
+{
+    DWORD dwRet;
+    WCHAR szSysPath[MAX_PATH],
+          szPattern[MAX_PATH],
+          szFilePath[MAX_PATH];
+    HANDLE hFindFile = INVALID_HANDLE_VALUE;
+    WIN32_FIND_DATAW wfd;
+    BOOL bFound = TRUE;
+
+    dwRet = GetSystemDirectoryW(szSysPath, ARRAYSIZE(szSysPath));
+    if (!dwRet)
+    {
+        skip("GetSystemDirectoryW failed with code %ld\n", GetLastError());
+        return;
+    }
+
+    StringCchCopyW(szPattern, ARRAYSIZE(szPattern), szSysPath);
+    StringCchCatW(szPattern, ARRAYSIZE(szPattern), L"\\kbd*.dll");
+
+    for (hFindFile = FindFirstFileW(szPattern, &wfd);
+         bFound && (hFindFile != INVALID_HANDLE_VALUE);
+         bFound = FindNextFileW(hFindFile, &wfd))
+    {
+        if (wfd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+            continue;
+
+        StringCchCopyW(szFilePath, ARRAYSIZE(szFilePath), szSysPath);
+        StringCchCatW(szFilePath, ARRAYSIZE(szFilePath), L"\\");
+        StringCchCatW(szFilePath, ARRAYSIZE(szFilePath), wfd.cFileName);
+
+        testLayout(wfd.cFileName, szFilePath);
+    }
+
+    if (hFindFile != INVALID_HANDLE_VALUE)
+        FindClose(hFindFile);
+}
+
+START_TEST(KbdLayout)
+{
+    testKeyboardLayouts();
+}

--- a/modules/rostests/apitests/user32/testlist.c
+++ b/modules/rostests/apitests/user32/testlist.c
@@ -25,6 +25,7 @@ extern void func_GetSystemMetrics(void);
 extern void func_GetUserObjectInformation(void);
 extern void func_GetWindowPlacement(void);
 extern void func_InitializeLpkHooks(void);
+extern void func_KbdLayout(void);
 extern void func_keybd_event(void);
 extern void func_LoadImage(void);
 extern void func_LookupIconIdFromDirectoryEx(void);
@@ -78,6 +79,7 @@ const struct test winetest_testlist[] =
     { "GetUserObjectInformation", func_GetUserObjectInformation },
     { "GetWindowPlacement", func_GetWindowPlacement },
     { "InitializeLpkHooks", func_InitializeLpkHooks },
+    { "KbdLayout", func_KbdLayout },
     { "keybd_event", func_keybd_event },
     { "LoadImage", func_LoadImage },
     { "LookupIconIdFromDirectoryEx", func_LookupIconIdFromDirectoryEx },


### PR DESCRIPTION
JIRA issue: [CORE-17906](https://jira.reactos.org/browse/CORE-17906)

For @julcar. See PR #4730 for details.

## Test results

<details>
  <summary>Windows Server 2003, also ReactOS with replaced kbd*.dll files</summary>
  
  ```sh
  KbdLayout.c:21: Testing 'KBDAL.DLL'...
  KbdLayout.c:21: Testing 'kbdaze.dll'...
  KbdLayout.c:21: Testing 'kbdazel.dll'...
  KbdLayout.c:21: Testing 'kbdbe.dll'...
  KbdLayout.c:21: Testing 'kbdbene.dll'...
  KbdLayout.c:21: Testing 'kbdbhc.dll'...
  KbdLayout.c:21: Testing 'kbdblr.dll'...
  KbdLayout.c:21: Testing 'kbdbr.dll'...
  KbdLayout.c:21: Testing 'kbdbu.dll'...
  KbdLayout.c:21: Testing 'kbdca.dll'...
  KbdLayout.c:21: Testing 'kbdcan.dll'...
  KbdLayout.c:21: Testing 'kbdcr.dll'...
  KbdLayout.c:21: Testing 'kbdcz.dll'...
  KbdLayout.c:21: Testing 'kbdcz1.dll'...
  KbdLayout.c:21: Testing 'kbdcz2.dll'...
  KbdLayout.c:21: Testing 'kbdda.dll'...
  KbdLayout.c:21: Testing 'kbddv.dll'...
  KbdLayout.c:21: Testing 'kbdes.dll'...
  KbdLayout.c:21: Testing 'kbdest.dll'...
  KbdLayout.c:21: Testing 'kbdfc.dll'...
  KbdLayout.c:21: Testing 'kbdfi.dll'...
  KbdLayout.c:21: Testing 'kbdfi1.dll'...
  KbdLayout.c:21: Testing 'kbdfo.dll'...
  KbdLayout.c:21: Testing 'kbdfr.dll'...
  KbdLayout.c:21: Testing 'kbdgae.dll'...
  KbdLayout.c:21: Testing 'kbdgkl.dll'...
  KbdLayout.c:21: Testing 'kbdgr.dll'...
  KbdLayout.c:21: Testing 'kbdgr1.dll'...
  KbdLayout.c:21: Testing 'kbdhe.dll'...
  KbdLayout.c:21: Testing 'kbdhe220.dll'...
  KbdLayout.c:21: Testing 'kbdhe319.dll'...
  KbdLayout.c:21: Testing 'kbdhela2.dll'...
  KbdLayout.c:21: Testing 'kbdhela3.dll'...
  KbdLayout.c:21: Testing 'kbdhept.dll'...
  KbdLayout.c:21: Testing 'kbdhu.dll'...
  KbdLayout.c:21: Testing 'kbdhu1.dll'...
  KbdLayout.c:21: Testing 'kbdic.dll'...
  KbdLayout.c:21: Testing 'kbdir.dll'...
  KbdLayout.c:21: Testing 'kbdit.dll'...
  KbdLayout.c:21: Testing 'kbdit142.dll'...
  KbdLayout.c:21: Testing 'kbdiultn.dll'...
  KbdLayout.c:21: Testing 'kbdkaz.dll'...
  KbdLayout.c:21: Testing 'kbdkyr.dll'...
  KbdLayout.c:21: Testing 'kbdla.dll'...
  KbdLayout.c:21: Testing 'kbdlt.dll'...
  KbdLayout.c:21: Testing 'kbdlt1.dll'...
  KbdLayout.c:21: Testing 'kbdlv.dll'...
  KbdLayout.c:21: Testing 'kbdlv1.dll'...
  KbdLayout.c:21: Testing 'kbdmac.dll'...
  KbdLayout.c:21: Testing 'kbdmaori.dll'...
  KbdLayout.c:21: Testing 'kbdmlt47.dll'...
  KbdLayout.c:21: Testing 'kbdmlt48.dll'...
  KbdLayout.c:21: Testing 'kbdmon.dll'...
  KbdLayout.c:21: Testing 'kbdne.dll'...
  KbdLayout.c:21: Testing 'kbdnec.dll'...
  KbdLayout.c:21: Testing 'kbdnepr.dll'...
  KbdLayout.c:21: Testing 'kbdno.dll'...
  KbdLayout.c:21: Testing 'kbdno1.dll'...
  KbdLayout.c:21: Testing 'kbdpash.dll'...
  KbdLayout.c:21: Testing 'kbdpl.dll'...
  KbdLayout.c:21: Testing 'kbdpl1.dll'...
  KbdLayout.c:21: Testing 'kbdpo.dll'...
  KbdLayout.c:21: Testing 'kbdro.dll'...
  KbdLayout.c:21: Testing 'kbdru.dll'...
  KbdLayout.c:21: Testing 'kbdru1.dll'...
  KbdLayout.c:21: Testing 'kbdsf.dll'...
  KbdLayout.c:21: Testing 'kbdsg.dll'...
  KbdLayout.c:21: Testing 'kbdsl.dll'...
  KbdLayout.c:21: Testing 'kbdsl1.dll'...
  KbdLayout.c:21: Testing 'kbdsmsfi.dll'...
  KbdLayout.c:21: Testing 'kbdsmsno.dll'...
  KbdLayout.c:21: Testing 'kbdsp.dll'...
  KbdLayout.c:21: Testing 'kbdsw.dll'...
  KbdLayout.c:21: Testing 'kbdtat.dll'...
  KbdLayout.c:21: Testing 'kbdtuf.dll'...
  KbdLayout.c:21: Testing 'kbdtuq.dll'...
  KbdLayout.c:21: Testing 'kbduk.dll'...
  KbdLayout.c:21: Testing 'kbdukx.dll'...
  KbdLayout.c:21: Testing 'kbdur.dll'...
  KbdLayout.c:21: Testing 'kbdus.dll'...
  KbdLayout.c:21: Testing 'kbdusl.dll'...
  KbdLayout.c:21: Testing 'kbdusr.dll'...
  KbdLayout.c:21: Testing 'kbdusx.dll'...
  KbdLayout.c:21: Testing 'kbduzb.dll'...
  KbdLayout.c:21: Testing 'kbdycc.dll'...
  KbdLayout.c:21: Testing 'kbdycl.dll'...
  
  KbdLayout: 86 tests executed (0 marked as todo, 0 failures), 0 skipped.
  ```
  
</details>

<details>
  <summary>Windows XP SP3</summary>
  
  ```sh
  KbdLayout.c:21: Testing 'KBDAL.DLL'...
  KbdLayout.c:21: Testing 'kbdaze.dll'...
  KbdLayout.c:21: Testing 'kbdazel.dll'...
  KbdLayout.c:21: Testing 'kbdbe.dll'...
  KbdLayout.c:21: Testing 'kbdbene.dll'...
  KbdLayout.c:21: Testing 'kbdbhc.dll'...
  KbdLayout.c:21: Testing 'kbdblr.dll'...
  KbdLayout.c:21: Testing 'kbdbr.dll'...
  KbdLayout.c:21: Testing 'kbdbu.dll'...
  KbdLayout.c:21: Testing 'kbdca.dll'...
  KbdLayout.c:21: Testing 'kbdcan.dll'...
  KbdLayout.c:21: Testing 'kbdcr.dll'...
  KbdLayout.c:21: Testing 'kbdcz.dll'...
  KbdLayout.c:21: Testing 'kbdcz1.dll'...
  KbdLayout.c:21: Testing 'kbdcz2.dll'...
  KbdLayout.c:21: Testing 'kbdda.dll'...
  KbdLayout.c:21: Testing 'kbddv.dll'...
  KbdLayout.c:21: Testing 'kbdes.dll'...
  KbdLayout.c:21: Testing 'kbdest.dll'...
  KbdLayout.c:21: Testing 'kbdfc.dll'...
  KbdLayout.c:21: Testing 'kbdfi.dll'...
  KbdLayout.c:21: Testing 'kbdfi1.dll'...
  KbdLayout.c:21: Testing 'kbdfo.dll'...
  KbdLayout.c:21: Testing 'kbdfr.dll'...
  KbdLayout.c:21: Testing 'kbdgae.dll'...
  KbdLayout.c:21: Testing 'kbdgkl.dll'...
  KbdLayout.c:21: Testing 'kbdgr.dll'...
  KbdLayout.c:21: Testing 'kbdgr1.dll'...
  KbdLayout.c:21: Testing 'kbdhe.dll'...
  KbdLayout.c:21: Testing 'kbdhe220.dll'...
  KbdLayout.c:21: Testing 'kbdhe319.dll'...
  KbdLayout.c:21: Testing 'kbdhela2.dll'...
  KbdLayout.c:21: Testing 'kbdhela3.dll'...
  KbdLayout.c:21: Testing 'kbdhept.dll'...
  KbdLayout.c:21: Testing 'kbdhu.dll'...
  KbdLayout.c:21: Testing 'kbdhu1.dll'...
  KbdLayout.c:21: Testing 'kbdic.dll'...
  KbdLayout.c:21: Testing 'kbdinbe1.dll'...
  KbdLayout.c:21: Testing 'kbdinben.dll'...
  KbdLayout.c:21: Testing 'kbdinmal.dll'...
  KbdLayout.c:21: Testing 'kbdir.dll'...
  KbdLayout.c:21: Testing 'kbdit.dll'...
  KbdLayout.c:21: Testing 'kbdit142.dll'...
  KbdLayout.c:21: Testing 'kbdiultn.dll'...
  KbdLayout.c:21: Testing 'kbdkaz.dll'...
  KbdLayout.c:21: Testing 'kbdkyr.dll'...
  KbdLayout.c:21: Testing 'kbdla.dll'...
  KbdLayout.c:21: Testing 'kbdlt.dll'...
  KbdLayout.c:21: Testing 'kbdlt1.dll'...
  KbdLayout.c:21: Testing 'kbdlv.dll'...
  KbdLayout.c:21: Testing 'kbdlv1.dll'...
  KbdLayout.c:21: Testing 'kbdmac.dll'...
  KbdLayout.c:21: Testing 'kbdmaori.dll'...
  KbdLayout.c:21: Testing 'kbdmlt47.dll'...
  KbdLayout.c:21: Testing 'kbdmlt48.dll'...
  KbdLayout.c:21: Testing 'kbdmon.dll'...
  KbdLayout.c:21: Testing 'kbdne.dll'...
  KbdLayout.c:21: Testing 'kbdnec.dll'...
  KbdLayout.c:21: Testing 'kbdnepr.dll'...
  KbdLayout.c:21: Testing 'kbdno.dll'...
  KbdLayout.c:21: Testing 'kbdno1.dll'...
  KbdLayout.c:21: Testing 'kbdpash.dll'...
  KbdLayout.c:21: Testing 'kbdpl.dll'...
  KbdLayout.c:21: Testing 'kbdpl1.dll'...
  KbdLayout.c:21: Testing 'kbdpo.dll'...
  KbdLayout.c:21: Testing 'kbdro.dll'...
  KbdLayout.c:21: Testing 'kbdru.dll'...
  KbdLayout.c:21: Testing 'kbdru1.dll'...
  KbdLayout.c:21: Testing 'kbdsf.dll'...
  KbdLayout.c:21: Testing 'kbdsg.dll'...
  KbdLayout.c:21: Testing 'kbdsl.dll'...
  KbdLayout.c:21: Testing 'kbdsl1.dll'...
  KbdLayout.c:21: Testing 'kbdsmsfi.dll'...
  KbdLayout.c:21: Testing 'kbdsmsno.dll'...
  KbdLayout.c:21: Testing 'kbdsp.dll'...
  KbdLayout.c:21: Testing 'kbdsw.dll'...
  KbdLayout.c:21: Testing 'kbdtat.dll'...
  KbdLayout.c:21: Testing 'kbdtuf.dll'...
  KbdLayout.c:21: Testing 'kbdtuq.dll'...
  KbdLayout.c:21: Testing 'kbduk.dll'...
  KbdLayout.c:21: Testing 'kbdukx.dll'...
  KbdLayout.c:21: Testing 'kbdur.dll'...
  KbdLayout.c:21: Testing 'kbdus.dll'...
  KbdLayout.c:21: Testing 'kbdusl.dll'...
  KbdLayout.c:21: Testing 'kbdusr.dll'...
  KbdLayout.c:21: Testing 'kbdusx.dll'...
  KbdLayout.c:21: Testing 'kbduzb.dll'...
  KbdLayout.c:21: Testing 'kbdycc.dll'...
  KbdLayout.c:21: Testing 'kbdycl.dll'...
  
  KbdLayout: 89 tests executed (0 marked as todo, 0 failures), 0 skipped.
  ```
  
</details>

<details>
  <summary>ReactOS 0.4.15-dev-5142-g967f5b98983 - spoiler alert: many failures :eyes:</summary>
  
  ```sh
  KbdLayout.c:21: Testing 'kbda1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbda2.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbda3.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdal.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdarme.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdarmw.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdaze.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdazel.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbe.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbga.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbgt.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdblr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbu.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdbur.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdcan.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdcr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdcz.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdcz1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdda.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbddv.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdeo.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdest.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdfc.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdfi.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdfr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdgeo.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdgerg.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdgneo.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdgr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdgr1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdhe.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdheb.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdhu.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdic.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdinasa.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdinben.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdindev.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdinguj.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdinmal.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdir.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdit.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 130
  KbdLayout.c:62: Test failed: Scan Code 129 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdjpn.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdkaz.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdkor.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdla.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdlt1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdlv.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdmac.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdne.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdno.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdpl.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdpl1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdpo.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 130
  KbdLayout.c:62: Test failed: Scan Code 129 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdro.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdrost.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdru.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdru1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsf.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsg.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsl.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsl1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsp.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 130
  KbdLayout.c:62: Test failed: Scan Code 129 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdsw.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdtat.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdth0.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdth1.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdth2.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdth3.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdtuf.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdtuq.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbduk.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdur.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdurs.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdus.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 129
  KbdLayout.c:62: Test failed: Scan Code 128 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdusa.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdusl.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdusr.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdusx.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbduzb.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdvntc.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdycc.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  KbdLayout.c:21: Testing 'kbdycl.dll'...
  KbdLayout.c:56: Test failed: pKbdTbl->bMaxVSCtoVK = 128
  KbdLayout.c:62: Test failed: Scan Code 125 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 126 => Virtual Key 0
  KbdLayout.c:62: Test failed: Scan Code 127 => Virtual Key 0
  
  KbdLayout: 264 tests executed (0 marked as todo, 264 failures), 0 skipped.
  ```
  
</details>