### PR TITLE
[KEYBOARD] Fix failing tests added in 6aacfa93 and c1c12793

### DIFF
--- a/dll/keyboard/kbda1/kbda1.c
+++ b/dll/keyboard/kbda1/kbda1.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -366,7 +364,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbda2/kbda2.c
+++ b/dll/keyboard/kbda2/kbda2.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -383,7 +381,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbda3/kbda3.c
+++ b/dll/keyboard/kbda3/kbda3.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -383,7 +381,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdal/kbdal.c
+++ b/dll/keyboard/kbdal/kbdal.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -380,7 +378,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdarme/kbdarme.c
+++ b/dll/keyboard/kbdarme/kbdarme.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -353,7 +351,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdarmw/kbdarmw.c
+++ b/dll/keyboard/kbdarmw/kbdarmw.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -341,7 +339,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdaze/kbdaze.c
+++ b/dll/keyboard/kbdaze/kbdaze.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdazel/kbdazel.c
+++ b/dll/keyboard/kbdazel/kbdazel.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -353,7 +351,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbe/kbdbe.c
+++ b/dll/keyboard/kbdbe/kbdbe.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -460,7 +457,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbga/kbdbga.c
+++ b/dll/keyboard/kbdbga/kbdbga.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -381,7 +379,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbgt/kbdbgt.c
+++ b/dll/keyboard/kbdbgt/kbdbgt.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -398,7 +396,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdblr/kbdblr.c
+++ b/dll/keyboard/kbdblr/kbdblr.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbr/kbdbr.c
+++ b/dll/keyboard/kbdbr/kbdbr.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -441,7 +439,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbu/kbdbu.c
+++ b/dll/keyboard/kbdbu/kbdbu.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -382,7 +380,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdbur/kbdbur.c
+++ b/dll/keyboard/kbdbur/kbdbur.c
@@ -95,10 +95,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -360,7 +358,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdcan/kbdcan.c
+++ b/dll/keyboard/kbdcan/kbdcan.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -574,7 +572,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdcr/kbdcr.c
+++ b/dll/keyboard/kbdcr/kbdcr.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -488,7 +486,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdcz/kbdcz.c
+++ b/dll/keyboard/kbdcz/kbdcz.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -458,7 +455,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdcz1/kbdcz1.c
+++ b/dll/keyboard/kbdcz1/kbdcz1.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -451,7 +448,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdda/kbdda.c
+++ b/dll/keyboard/kbdda/kbdda.c
@@ -93,9 +93,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -460,7 +457,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbddv/kbddv.c
+++ b/dll/keyboard/kbddv/kbddv.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -371,7 +368,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdeo/kbdeo.c
+++ b/dll/keyboard/kbdeo/kbdeo.c
@@ -100,9 +100,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -393,7 +390,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdest/kbdest.c
+++ b/dll/keyboard/kbdest/kbdest.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -372,7 +369,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdfc/kbdfc.c
+++ b/dll/keyboard/kbdfc/kbdfc.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -452,7 +450,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdfi/kbdfi.c
+++ b/dll/keyboard/kbdfi/kbdfi.c
@@ -96,9 +96,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -451,7 +448,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdfr/kbdfr.c
+++ b/dll/keyboard/kbdfr/kbdfr.c
@@ -103,9 +103,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -451,7 +448,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdgeo/kbdgeo.c
+++ b/dll/keyboard/kbdgeo/kbdgeo.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdgerg/kbdgerg.c
+++ b/dll/keyboard/kbdgerg/kbdgerg.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -430,7 +427,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdgneo/kbdgneo.c
+++ b/dll/keyboard/kbdgneo/kbdgneo.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -430,7 +427,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdgr/kbdgr.c
+++ b/dll/keyboard/kbdgr/kbdgr.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -430,7 +427,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdgr1/kbdgr1.c
+++ b/dll/keyboard/kbdgr1/kbdgr1.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -430,7 +427,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdhe/kbdhe.c
+++ b/dll/keyboard/kbdhe/kbdhe.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -402,7 +399,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdheb/kbdheb.c
+++ b/dll/keyboard/kbdheb/kbdheb.c
@@ -214,9 +214,6 @@ ROSDATA USHORT scancode_to_vk[] =
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -494,7 +491,7 @@ ROSDATA KBDTABLES keyboard_layout_table =
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdhu/kbdhu.c
+++ b/dll/keyboard/kbdhu/kbdhu.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -377,7 +374,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdic/kbdic.c
+++ b/dll/keyboard/kbdic/kbdic.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -442,7 +440,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdinasa/kbdinasa.c
+++ b/dll/keyboard/kbdinasa/kbdinasa.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -379,7 +377,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdinben/kbdinben.c
+++ b/dll/keyboard/kbdinben/kbdinben.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -374,7 +372,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdindev/kbdindev.c
+++ b/dll/keyboard/kbdindev/kbdindev.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -379,7 +377,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdinguj/kbdinguj.c
+++ b/dll/keyboard/kbdinguj/kbdinguj.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -379,7 +377,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdinmal/kbdinmal.c
+++ b/dll/keyboard/kbdinmal/kbdinmal.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -375,7 +373,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdir/kbdir.c
+++ b/dll/keyboard/kbdir/kbdir.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -407,7 +405,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdit/kbdit.c
+++ b/dll/keyboard/kbdit/kbdit.c
@@ -155,9 +155,6 @@ ROSDATA USHORT scancode_to_vk[] = {
 /* 7c */  VK_EMPTY,
 /* 7d */  VK_EMPTY,
 /* 7e */  VK_EMPTY,
-/* 7f */  VK_EMPTY,
-/* 80 */  VK_EMPTY,
-/* 00 */  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -432,7 +429,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdjpn/kbdjpn.c
+++ b/dll/keyboard/kbdjpn/kbdjpn.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_CONVERT | KBDSPECIAL, VK_EMPTY,
   VK_NONCONVERT | KBDSPECIAL, VK_EMPTY, VK_OEM_5, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -378,7 +375,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdkaz/kbdkaz.c
+++ b/dll/keyboard/kbdkaz/kbdkaz.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdkor/kbdkor.c
+++ b/dll/keyboard/kbdkor/kbdkor.c
@@ -104,9 +104,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -377,7 +374,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdla/kbdla.c
+++ b/dll/keyboard/kbdla/kbdla.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -428,7 +426,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdlt1/kbdlt1.c
+++ b/dll/keyboard/kbdlt1/kbdlt1.c
@@ -100,9 +100,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -369,7 +366,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdlv/kbdlv.c
+++ b/dll/keyboard/kbdlv/kbdlv.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -373,7 +370,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdmac/kbdmac.c
+++ b/dll/keyboard/kbdmac/kbdmac.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -364,7 +362,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdne/kbdne.c
+++ b/dll/keyboard/kbdne/kbdne.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -446,7 +444,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdno/kbdno.c
+++ b/dll/keyboard/kbdno/kbdno.c
@@ -93,9 +93,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -460,7 +457,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdpl/kbdpl.c
+++ b/dll/keyboard/kbdpl/kbdpl.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -397,7 +394,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdpl1/kbdpl1.c
+++ b/dll/keyboard/kbdpl1/kbdpl1.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -413,7 +410,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdpo/kbdpo.c
+++ b/dll/keyboard/kbdpo/kbdpo.c
@@ -165,9 +165,6 @@ ROSDATA USHORT scancode_to_vk[] = {
 /* 7c */  VK_EMPTY,
 /* 7d */  VK_EMPTY,
 /* 7e */  VK_EMPTY,
-/* 7f */  VK_EMPTY,
-/* 80 */  VK_EMPTY,
-/* 00 */  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -553,7 +550,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdro/kbdro.c
+++ b/dll/keyboard/kbdro/kbdro.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -363,7 +361,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdrost/kbdrost.c
+++ b/dll/keyboard/kbdrost/kbdrost.c
@@ -134,10 +134,6 @@ ROSDATA USHORT scancode_to_vk[] =
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] =
@@ -461,7 +457,7 @@ ROSDATA KBDTABLES keyboard_layout_table =
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdru/kbdru.c
+++ b/dll/keyboard/kbdru/kbdru.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -371,7 +369,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdru1/kbdru1.c
+++ b/dll/keyboard/kbdru1/kbdru1.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -371,7 +369,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsf/kbdsf.c
+++ b/dll/keyboard/kbdsf/kbdsf.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -461,7 +458,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsg/kbdsg.c
+++ b/dll/keyboard/kbdsg/kbdsg.c
@@ -99,9 +99,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -458,7 +455,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsl/kbdsl.c
+++ b/dll/keyboard/kbdsl/kbdsl.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -445,7 +442,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsl1/kbdsl1.c
+++ b/dll/keyboard/kbdsl1/kbdsl1.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -445,7 +442,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsp/kbdsp.c
+++ b/dll/keyboard/kbdsp/kbdsp.c
@@ -165,9 +165,6 @@ ROSDATA USHORT scancode_to_vk[] =
   /* 7c */  VK_EMPTY,
   /* 7d */  VK_EMPTY,
   /* 7e */  VK_EMPTY,
-  /* 7f */  VK_EMPTY,
-  /* 80 */  VK_EMPTY,
-  /* 00 */  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] =
@@ -534,7 +531,7 @@ ROSDATA KBDTABLES keyboard_layout_table =
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdsw/kbdsw.c
+++ b/dll/keyboard/kbdsw/kbdsw.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -456,7 +453,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdtat/kbdtat.c
+++ b/dll/keyboard/kbdtat/kbdtat.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -368,7 +366,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdth0/kbdth0.c
+++ b/dll/keyboard/kbdth0/kbdth0.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdth1/kbdth1.c
+++ b/dll/keyboard/kbdth1/kbdth1.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdth2/kbdth2.c
+++ b/dll/keyboard/kbdth2/kbdth2.c
@@ -95,10 +95,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -359,7 +357,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdth3/kbdth3.c
+++ b/dll/keyboard/kbdth3/kbdth3.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdtuf/kbdtuf.c
+++ b/dll/keyboard/kbdtuf/kbdtuf.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -453,7 +451,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdtuq/kbdtuq.c
+++ b/dll/keyboard/kbdtuq/kbdtuq.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -453,7 +451,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbduk/kbduk.c
+++ b/dll/keyboard/kbduk/kbduk.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -383,7 +380,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdur/kbdur.c
+++ b/dll/keyboard/kbdur/kbdur.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -372,7 +370,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdurs/kbdurs.c
+++ b/dll/keyboard/kbdurs/kbdurs.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -364,7 +362,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdus/kbdus.c
+++ b/dll/keyboard/kbdus/kbdus.c
@@ -98,9 +98,6 @@ ROSDATA USHORT scancode_to_vk[] = {
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY, /* PA1 */
-  VK_EMPTY,
-  /* - 80 - */
-  0
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -378,7 +375,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdusa/kbdusa.c
+++ b/dll/keyboard/kbdusa/kbdusa.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -363,7 +361,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdusl/kbdusl.c
+++ b/dll/keyboard/kbdusl/kbdusl.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdusr/kbdusr.c
+++ b/dll/keyboard/kbdusr/kbdusr.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdusx/kbdusx.c
+++ b/dll/keyboard/kbdusx/kbdusx.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -447,7 +445,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbduzb/kbduzb.c
+++ b/dll/keyboard/kbduzb/kbduzb.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -358,7 +356,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdvntc/kbdvntc.c
+++ b/dll/keyboard/kbdvntc/kbdvntc.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -363,7 +361,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdycc/kbdycc.c
+++ b/dll/keyboard/kbdycc/kbdycc.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -379,7 +377,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 

--- a/dll/keyboard/kbdycl/kbdycl.c
+++ b/dll/keyboard/kbdycl/kbdycl.c
@@ -98,10 +98,8 @@ ROSDATA USHORT scancode_to_vk[] = {
   VK_F24,
   /* - 77 - */
   VK_EMPTY, VK_EMPTY, VK_EMPTY, VK_EMPTY,
-  VK_OEM_PA1, VK_TAB, 0xc2, 0, /* PA1 */
-  0,
-  /* - 80 - */
-  0
+  VK_OEM_PA1, VK_TAB, 0xc2, VK_EMPTY, /* PA1 */
+  VK_EMPTY,
 };
 
 ROSDATA VSC_VK extcode0_to_vk[] = {
@@ -499,7 +497,7 @@ ROSDATA KBDTABLES keyboard_layout_table = {
 
   /* scan code to virtual key maps */
   scancode_to_vk,
-  sizeof(scancode_to_vk) / sizeof(scancode_to_vk[0]),
+  RTL_NUMBER_OF(scancode_to_vk),
   extcode0_to_vk,
   extcode1_to_vk,
 


### PR DESCRIPTION
This also should fix related problems with "F17" shortcut key in the menu items of some programs.

Dedicated to @julcar. This PR effectively supersedes #4730.

JIRA issues: [CORE-17906](https://jira.reactos.org/browse/CORE-17906) and [CORE-3903](https://jira.reactos.org/browse/CORE-3903)

Note there are also misleading comments about the offsets in `scancode_to_vk` array, but I will probably fix that later (and not by hand).

## Test results

- **VirtualKey**: one failure less
- **KbdLayout**: all failures fixed
 
```sh
VirtualKey.c:52: Test failed: [4] ScanCode = 0, expected 29

VirtualKey: 18 tests executed (0 marked as todo, 1 failure), 0 skipped.

KbdLayout.c:23: Testing 'kbda1.dll'...
KbdLayout.c:23: Testing 'kbda2.dll'...
KbdLayout.c:23: Testing 'kbda3.dll'...
KbdLayout.c:23: Testing 'kbdal.dll'...
KbdLayout.c:23: Testing 'kbdarme.dll'...
KbdLayout.c:23: Testing 'kbdarmw.dll'...
KbdLayout.c:23: Testing 'kbdaze.dll'...
KbdLayout.c:23: Testing 'kbdazel.dll'...
KbdLayout.c:23: Testing 'kbdbe.dll'...
KbdLayout.c:23: Testing 'kbdbga.dll'...
KbdLayout.c:23: Testing 'kbdbgt.dll'...
KbdLayout.c:23: Testing 'kbdblr.dll'...
KbdLayout.c:23: Testing 'kbdbr.dll'...
KbdLayout.c:23: Testing 'kbdbu.dll'...
KbdLayout.c:23: Testing 'kbdbur.dll'...
KbdLayout.c:23: Testing 'kbdcan.dll'...
KbdLayout.c:23: Testing 'kbdcr.dll'...
KbdLayout.c:23: Testing 'kbdcz.dll'...
KbdLayout.c:23: Testing 'kbdcz1.dll'...
KbdLayout.c:23: Testing 'kbdda.dll'...
KbdLayout.c:23: Testing 'kbddv.dll'...
KbdLayout.c:23: Testing 'kbdeo.dll'...
KbdLayout.c:23: Testing 'kbdest.dll'...
KbdLayout.c:23: Testing 'kbdfc.dll'...
KbdLayout.c:23: Testing 'kbdfi.dll'...
KbdLayout.c:23: Testing 'kbdfr.dll'...
KbdLayout.c:23: Testing 'kbdgeo.dll'...
KbdLayout.c:23: Testing 'kbdgerg.dll'...
KbdLayout.c:23: Testing 'kbdgneo.dll'...
KbdLayout.c:23: Testing 'kbdgr.dll'...
KbdLayout.c:23: Testing 'kbdgr1.dll'...
KbdLayout.c:23: Testing 'kbdhe.dll'...
KbdLayout.c:23: Testing 'kbdheb.dll'...
KbdLayout.c:23: Testing 'kbdhu.dll'...
KbdLayout.c:23: Testing 'kbdic.dll'...
KbdLayout.c:23: Testing 'kbdinasa.dll'...
KbdLayout.c:23: Testing 'kbdinben.dll'...
KbdLayout.c:23: Testing 'kbdindev.dll'...
KbdLayout.c:23: Testing 'kbdinguj.dll'...
KbdLayout.c:23: Testing 'kbdinmal.dll'...
KbdLayout.c:23: Testing 'kbdir.dll'...
KbdLayout.c:23: Testing 'kbdit.dll'...
KbdLayout.c:23: Testing 'kbdjpn.dll'...
KbdLayout.c:23: Testing 'kbdkaz.dll'...
KbdLayout.c:23: Testing 'kbdkor.dll'...
KbdLayout.c:23: Testing 'kbdla.dll'...
KbdLayout.c:23: Testing 'kbdlt1.dll'...
KbdLayout.c:23: Testing 'kbdlv.dll'...
KbdLayout.c:23: Testing 'kbdmac.dll'...
KbdLayout.c:23: Testing 'kbdne.dll'...
KbdLayout.c:23: Testing 'kbdno.dll'...
KbdLayout.c:23: Testing 'kbdpl.dll'...
KbdLayout.c:23: Testing 'kbdpl1.dll'...
KbdLayout.c:23: Testing 'kbdpo.dll'...
KbdLayout.c:23: Testing 'kbdro.dll'...
KbdLayout.c:23: Testing 'kbdrost.dll'...
KbdLayout.c:23: Testing 'kbdru.dll'...
KbdLayout.c:23: Testing 'kbdru1.dll'...
KbdLayout.c:23: Testing 'kbdsf.dll'...
KbdLayout.c:23: Testing 'kbdsg.dll'...
KbdLayout.c:23: Testing 'kbdsl.dll'...
KbdLayout.c:23: Testing 'kbdsl1.dll'...
KbdLayout.c:23: Testing 'kbdsp.dll'...
KbdLayout.c:23: Testing 'kbdsw.dll'...
KbdLayout.c:23: Testing 'kbdtat.dll'...
KbdLayout.c:23: Testing 'kbdth0.dll'...
KbdLayout.c:23: Testing 'kbdth1.dll'...
KbdLayout.c:23: Testing 'kbdth2.dll'...
KbdLayout.c:23: Testing 'kbdth3.dll'...
KbdLayout.c:23: Testing 'kbdtuf.dll'...
KbdLayout.c:23: Testing 'kbdtuq.dll'...
KbdLayout.c:23: Testing 'kbduk.dll'...
KbdLayout.c:23: Testing 'kbdur.dll'...
KbdLayout.c:23: Testing 'kbdurs.dll'...
KbdLayout.c:23: Testing 'kbdus.dll'...
KbdLayout.c:23: Testing 'kbdusa.dll'...
KbdLayout.c:23: Testing 'kbdusl.dll'...
KbdLayout.c:23: Testing 'kbdusr.dll'...
KbdLayout.c:23: Testing 'kbdusx.dll'...
KbdLayout.c:23: Testing 'kbduzb.dll'...
KbdLayout.c:23: Testing 'kbdvntc.dll'...
KbdLayout.c:23: Testing 'kbdycc.dll'...
KbdLayout.c:23: Testing 'kbdycl.dll'...

KbdLayout: 83 tests executed (0 marked as todo, 0 failures), 0 skipped.
```