### PR TITLE
[GIT] Add .DS_Store files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ modules/3rdparty
 modules/[Aa][Hh][Kk]_[Tt]ests
 .cache
 .cproject
+.DS_Store
 .project
 .settings
 .vscode


### PR DESCRIPTION
## Purpose

When working on macOS, the system creates a .DS_Store file in every accessed directory. They are marked as new files
in git, which is very annoying. This change will exclude these files.

## Proposed changes

- Add .DS_Store files to .gitignore
