### PR TITLE
[RTL] RtlReAllocateHeap(): Promote a DPRINT1() to ASSERTMSG()

### DIFF
--- a/sdk/lib/rtl/heap.c
+++ b/sdk/lib/rtl/heap.c
@@ -2973,7 +2973,7 @@ RtlReAllocateHeap(HANDLE HeapPtr,
             /* Growing in place failed, so growing out of place */
             if (Flags & HEAP_REALLOC_IN_PLACE_ONLY)
             {
-                DPRINT1("Realloc in place failed, but it was the only option\n");
+                ASSERTMSG("Realloc in place failed, but it was the only option\n", FALSE);
                 Ptr = NULL;
             }
             else


### PR DESCRIPTION
for "Realloc in place failed, but it was the only option"

to help notice/investigate this case.

JIRA issues: https://jira.reactos.org/browse/CORE-15840?jql=resolution%20is%20EMPTY%20AND%20text%20~%20%22Realloc%20in%20place%20failed%22
6 open out of 11 total. (It could be unnoticed on some other tickets...)