### PR TITLE
[EXT2FS] Ext2Read(): Complete request on VCB_VOLUME_LOCKED case

### DIFF
--- a/drivers/filesystems/ext2/src/read.c
+++ b/drivers/filesystems/ext2/src/read.c
@@ -905,6 +905,9 @@ Ext2Read (IN PEXT2_IRP_CONTEXT IrpContext)
             if (FlagOn(Vcb->Flags, VCB_VOLUME_LOCKED) &&
                 Vcb->LockFile != FileObject ) {
                 Status = STATUS_ACCESS_DENIED;
+#ifdef __REACTOS__
+                bCompleteRequest = TRUE;
+#endif
                 _SEH2_LEAVE;
             }
 


### PR DESCRIPTION
I checked Read and Write: this is the only case where it is missing.

JIRA issue: [CORE-10645](https://jira.reactos.org/browse/CORE-10645)

Co-authored-by: Victor Martinez Calvo <vicmarcal@...>