### PR TITLE
[HALX86] HalpQueryInterface(): Debug log InterfaceType param

### DIFF
--- a/hal/halx86/acpi/halpnpdd.c
+++ b/hal/halx86/acpi/halpnpdd.c
@@ -9,6 +9,10 @@
 /* INCLUDES *******************************************************************/
 
 #include <hal.h>
+
+#include <initguid.h>
+#include <wdmguid.h>
+
 #define NDEBUG
 #include <debug.h>
 
@@ -153,7 +157,23 @@ HalpQueryInterface(IN PDEVICE_OBJECT DeviceObject,
                    IN PINTERFACE Interface,
                    OUT PULONG Length)
 {
-    UNIMPLEMENTED;
+    if (IsEqualIID(InterfaceType, &GUID_ACPI_REGS_INTERFACE_STANDARD))
+    {
+        DPRINT1("HalpQueryInterface(GUID_ACPI_REGS_INTERFACE_STANDARD) is UNIMPLEMENTED\n");
+    }
+    else if (IsEqualIID(InterfaceType, &GUID_ACPI_PORT_RANGES_INTERFACE_STANDARD))
+    {
+        DPRINT1("HalpQueryInterface(GUID_ACPI_PORT_RANGES_INTERFACE_STANDARD) is UNIMPLEMENTED\n");
+    }
+    else
+    {
+        DPRINT1("HalpQueryInterface({%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}) is UNIMPLEMENTED\n",
+                InterfaceType->Data1, InterfaceType->Data2, InterfaceType->Data3,
+                InterfaceType->Data4[0], InterfaceType->Data4[1],
+                InterfaceType->Data4[2], InterfaceType->Data4[3],
+                InterfaceType->Data4[4], InterfaceType->Data4[5],
+                InterfaceType->Data4[6], InterfaceType->Data4[7]);
+    }
     return STATUS_NOT_SUPPORTED;
 }
 

--- a/hal/halx86/legacy/halpnpdd.c
+++ b/hal/halx86/legacy/halpnpdd.c
@@ -145,7 +145,12 @@ HalpQueryInterface(IN PDEVICE_OBJECT DeviceObject,
                    IN PINTERFACE Interface,
                    OUT PULONG Length)
 {
-    UNIMPLEMENTED;
+    DPRINT1("HalpQueryInterface({%08X-%04X-%04X-%02X%02X-%02X%02X%02X%02X%02X%02X}) is UNIMPLEMENTED\n",
+            InterfaceType->Data1, InterfaceType->Data2, InterfaceType->Data3,
+            InterfaceType->Data4[0], InterfaceType->Data4[1],
+            InterfaceType->Data4[2], InterfaceType->Data4[3],
+            InterfaceType->Data4[4], InterfaceType->Data4[5],
+            InterfaceType->Data4[6], InterfaceType->Data4[7]);
     return STATUS_NOT_SUPPORTED;
 }
 


### PR DESCRIPTION
Help find out which GUIDs are actually wanted.

Note:
I guess the 2 ACPI GUIDs are only used for the ACPI HAL. Correct?

Based on CircularTriangle06's patch.
JIRA issue: [CORE-11632](https://jira.reactos.org/browse/CORE-11632)