### PR TITLE
[REACTOS] Always check HalGetBusDataByOffset() return code

### DIFF
--- a/boot/freeldr/freeldr/disk/scsiport.c
+++ b/boot/freeldr/freeldr/disk/scsiport.c
@@ -1065,16 +1065,20 @@ SpiGetPciConfigData(
                 SlotNumber.u.AsULONG,
                 &PciConfig,
                 0,
-                sizeof(ULONG));
+                RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, DeviceID));
 
-            /* If result of HalGetBusData is 0, then the bus is wrong */
-            if (DataSize == 0)
+            /* If result size is too small, then the bus is wrong or something failed */
+            if (DataSize < RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, VendorID))
                 return FALSE;
 
             /* If result is PCI_INVALID_VENDORID, then this device has no more
                "Functions" */
             if (PciConfig.VendorID == PCI_INVALID_VENDORID)
                 break;
+
+            /* If result size does not match, then something failed */
+            if (DataSize != RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, DeviceID))
+                return FALSE;
 
             sprintf(VendorIdString, "%04hx", PciConfig.VendorID);
             sprintf(DeviceIdString, "%04hx", PciConfig.DeviceID);

--- a/drivers/bus/acpi/osl.c
+++ b/drivers/bus/acpi/osl.c
@@ -826,6 +826,7 @@ AcpiOsWritePciConfiguration (
     UINT64                   Value,
     UINT32                   Width)
 {
+    /* FIXME: ULONG != UINT64... */
     ULONG buf = Value;
     PCI_SLOT_NUMBER slot;
     ULONG Size;

--- a/drivers/bus/pci/pdo.c
+++ b/drivers/bus/pci/pdo.c
@@ -1390,6 +1390,7 @@ PdoStartDevice(
         DBGPRINT("None\n");
     }
 
+    /* FIXME: Should this fail if some HalSetBusDataByOffset() failed, for example? */
     return STATUS_SUCCESS;
 }
 

--- a/drivers/bus/pci/pdo.c
+++ b/drivers/bus/pci/pdo.c
@@ -209,12 +209,9 @@ PdoReadPciBar(PPDO_DEVICE_EXTENSION DeviceExtension,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  OriginalValue,
                                  Offset,
-                                 sizeof(ULONG));
-    if (Size != sizeof(ULONG))
-    {
-        DPRINT1("Wrong size %lu\n", Size);
+                                 sizeof(*OriginalValue));
+    if (Size != sizeof(*OriginalValue))
         return FALSE;
-    }
 
     /* Write all ones to determine which bits are held to zero */
     AllOnes = MAXULONG;
@@ -223,12 +220,9 @@ PdoReadPciBar(PPDO_DEVICE_EXTENSION DeviceExtension,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  &AllOnes,
                                  Offset,
-                                 sizeof(ULONG));
-    if (Size != sizeof(ULONG))
-    {
-        DPRINT1("Wrong size %lu\n", Size);
+                                 sizeof(AllOnes));
+    if (Size != sizeof(AllOnes))
         return FALSE;
-    }
 
     /* Get the range length */
     Size = HalGetBusDataByOffset(PCIConfiguration,
@@ -236,12 +230,9 @@ PdoReadPciBar(PPDO_DEVICE_EXTENSION DeviceExtension,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  NewValue,
                                  Offset,
-                                 sizeof(ULONG));
-    if (Size != sizeof(ULONG))
-    {
-        DPRINT1("Wrong size %lu\n", Size);
+                                 sizeof(*NewValue));
+    if (Size != sizeof(*NewValue))
         return FALSE;
-    }
 
     /* Restore original value */
     Size = HalSetBusDataByOffset(PCIConfiguration,
@@ -249,12 +240,9 @@ PdoReadPciBar(PPDO_DEVICE_EXTENSION DeviceExtension,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  OriginalValue,
                                  Offset,
-                                 sizeof(ULONG));
-    if (Size != sizeof(ULONG))
-    {
-        DPRINT1("Wrong size %lu\n", Size);
+                                 sizeof(*OriginalValue));
+    if (Size != sizeof(*OriginalValue))
         return FALSE;
-    }
 
     return TRUE;
 }
@@ -1031,7 +1019,6 @@ InterfaceBusSetBusData(
     IN ULONG Length)
 {
     PPDO_DEVICE_EXTENSION DeviceExtension;
-    ULONG Size;
 
     DPRINT("InterfaceBusSetBusData(%p 0x%lx %p 0x%lx 0x%lx)\n",
            Context, DataType, Buffer, Offset, Length);
@@ -1045,13 +1032,12 @@ InterfaceBusSetBusData(
     DeviceExtension = (PPDO_DEVICE_EXTENSION)((PDEVICE_OBJECT)Context)->DeviceExtension;
 
     /* Get PCI configuration space */
-    Size = HalSetBusDataByOffset(PCIConfiguration,
+    return HalSetBusDataByOffset(PCIConfiguration,
                                  DeviceExtension->PciDevice->BusNumber,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  Buffer,
                                  Offset,
                                  Length);
-    return Size;
 }
 
 static GET_SET_DEVICE_DATA InterfaceBusGetBusData;
@@ -1067,7 +1053,6 @@ InterfaceBusGetBusData(
     IN ULONG Length)
 {
     PPDO_DEVICE_EXTENSION DeviceExtension;
-    ULONG Size;
 
     DPRINT("InterfaceBusGetBusData(%p 0x%lx %p 0x%lx 0x%lx) called\n",
            Context, DataType, Buffer, Offset, Length);
@@ -1081,13 +1066,12 @@ InterfaceBusGetBusData(
     DeviceExtension = (PPDO_DEVICE_EXTENSION)((PDEVICE_OBJECT)Context)->DeviceExtension;
 
     /* Get PCI configuration space */
-    Size = HalGetBusDataByOffset(PCIConfiguration,
+    return HalGetBusDataByOffset(PCIConfiguration,
                                  DeviceExtension->PciDevice->BusNumber,
                                  DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
                                  Buffer,
                                  Offset,
                                  Length);
-    return Size;
 }
 
 
@@ -1354,12 +1338,12 @@ PdoStartDevice(
                         DeviceExtension->PciDevice->BusNumber);
 
                 Irq = (UCHAR)RawPartialDesc->u.Interrupt.Vector;
-                HalSetBusDataByOffset(PCIConfiguration,
-                                      DeviceExtension->PciDevice->BusNumber,
-                                      DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
-                                      &Irq,
-                                      0x3c /* PCI_INTERRUPT_LINE */,
-                                      sizeof(UCHAR));
+                (VOID)HalSetBusDataByOffset(PCIConfiguration,
+                                            DeviceExtension->PciDevice->BusNumber,
+                                            DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
+                                            &Irq,
+                                            0x3c /* PCI_INTERRUPT_LINE */,
+                                            sizeof(Irq));
             }
         }
     }
@@ -1394,12 +1378,12 @@ PdoStartDevice(
         /* OR with the previous value */
         Command |= DeviceExtension->PciDevice->PciConfig.Command;
 
-        HalSetBusDataByOffset(PCIConfiguration,
-                              DeviceExtension->PciDevice->BusNumber,
-                              DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
-                              &Command,
-                              FIELD_OFFSET(PCI_COMMON_CONFIG, Command),
-                              sizeof(USHORT));
+        (VOID)HalSetBusDataByOffset(PCIConfiguration,
+                                    DeviceExtension->PciDevice->BusNumber,
+                                    DeviceExtension->PciDevice->SlotNumber.u.AsULONG,
+                                    &Command,
+                                    FIELD_OFFSET(PCI_COMMON_CONFIG, Command),
+                                    sizeof(Command));
     }
     else
     {

--- a/drivers/bus/pcix/pci/config.c
+++ b/drivers/bus/pcix/pci/config.c
@@ -36,8 +36,9 @@ PciGetAdjustedInterruptLine(IN PPCI_PDO_EXTENSION PdoExtension)
                                        &PciInterruptLine,
                                        FIELD_OFFSET(PCI_COMMON_HEADER,
                                                     u.type0.InterruptLine),
-                                       sizeof(UCHAR));
-        if (Length) InterruptLine = PciInterruptLine;
+                                       sizeof(PciInterruptLine));
+        if (Length == sizeof(PciInterruptLine))
+            InterruptLine = PciInterruptLine;
     }
 
     /* Either keep the original interrupt line, or the one on the master bus */

--- a/drivers/bus/pcix/pci/config.c
+++ b/drivers/bus/pcix/pci/config.c
@@ -23,6 +23,7 @@ UCHAR
 NTAPI
 PciGetAdjustedInterruptLine(IN PPCI_PDO_EXTENSION PdoExtension)
 {
+    /* TODO: InterruptLine is superfluous. (See FIXME below, first) */
     UCHAR InterruptLine = 0, PciInterruptLine;
     ULONG Length;
 
@@ -42,6 +43,7 @@ PciGetAdjustedInterruptLine(IN PPCI_PDO_EXTENSION PdoExtension)
     }
 
     /* Either keep the original interrupt line, or the one on the master bus */
+    /* FIXME: Are these values swapped? */
     return InterruptLine ? PdoExtension->RawInterruptLine : InterruptLine;
 }
 

--- a/hal/halx86/acpi/busemul.c
+++ b/hal/halx86/acpi/busemul.c
@@ -223,6 +223,7 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                               Offset,
                               Length);
     }
+    /* TODO: No default handling? */
 
     /* Log unexpected size. 0 (no bus) and PCI_INVALID_VENDORID (no data) are valid results */
     /* TODO: EisaConfiguration is excluded, until its case is implemented */
@@ -315,6 +316,7 @@ HalSetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                               Offset,
                               Length);
     }
+    /* TODO: No default handling? */
 
     /* Log unexpected size */
     if (Size != Length)

--- a/hal/halx86/legacy/bussupp.c
+++ b/hal/halx86/legacy/bussupp.c
@@ -1561,6 +1561,17 @@ HalGetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                                  Offset,
                                  Length);
 
+    /* Log unexpected size. 0 (no bus) and PCI_INVALID_VENDORID (no data) are valid results */
+    if (Status != Length &&
+        Status != 0 &&
+        (BusDataType != PCIConfiguration ||
+         Status != RTL_SIZEOF_THROUGH_FIELD(PCI_COMMON_CONFIG, VendorID) ||
+         ((PPCI_COMMON_CONFIG)Buffer)->VendorID != PCI_INVALID_VENDORID))
+    {
+       DPRINT1("HalGetBusDataByOffset(%d, %lu, 0x%lX) failed (%lu != %lu)\n",
+               BusDataType, BusNumber, SlotNumber, Status, Length);
+    }
+
     /* Dereference the handler and return */
     HalDereferenceBusHandler(Handler);
     return Status;
@@ -1659,6 +1670,13 @@ HalSetBusDataByOffset(IN BUS_DATA_TYPE BusDataType,
                                  Buffer,
                                  Offset,
                                  Length);
+
+    /* Log unexpected size */
+    if (Status != Length)
+    {
+       DPRINT1("HalSetBusDataByOffset(%d, %lu, 0x%lX) failed (%lu != %lu)\n",
+               BusDataType, BusNumber, SlotNumber, Status, Length);
+    }
 
     /* Dereference the handler and return */
     HalDereferenceBusHandler(Handler);

--- a/hal/halx86/mp/ioapic.c
+++ b/hal/halx86/mp/ioapic.c
@@ -647,13 +647,12 @@ HaliReconfigurePciInterrupts(VOID)
 	        i, IRQMap[i].IrqType, IRQMap[i].IrqFlag, IRQMap[i].SrcBusId,
 	        IRQMap[i].SrcBusIrq, IRQMap[i].DstApicId, IRQMap[i].DstApicInt);
 
-	 HalSetBusDataByOffset(PCIConfiguration,
-	                               IRQMap[i].SrcBusId,
-				       (IRQMap[i].SrcBusIrq >> 2) & 0x1f,
-				       &IRQMap[i].DstApicInt,
-				       0x3c /*PCI_INTERRUPT_LINE*/,
-				       1);
-
+         (VOID)HalSetBusDataByOffset(PCIConfiguration,
+                                     IRQMap[i].SrcBusId,
+                                     (IRQMap[i].SrcBusIrq >> 2) & 0x1f,
+                                     &IRQMap[i].DstApicInt,
+                                     0x3c /* PCI_INTERRUPT_LINE */,
+                                     sizeof(IRQMap[i].DstApicInt));
       }
    }
 }


### PR DESCRIPTION
## Purpose

HalSetBusDataByOffset() too.

JIRA issue: [CORE-12422](https://jira.reactos.org/browse/CORE-12422)

Note:
I noticed this related part on CORE 15545.
This does not implement the EISA case.

## Proposed changes

- Add debug log.
- Return error where it applies.

Note:
I did not touch UniATA.