### PR TITLE
[RUNDLL32] Add comctl32 manifest to rundll32 (CORE-16669)

### DIFF
--- a/base/system/rundll32/rundll32.rc
+++ b/base/system/rundll32/rundll32.rc
@@ -1,4 +1,5 @@
 #include <windef.h>
+#include <winuser.h>
 
 #include "resource.h"
 
@@ -6,6 +7,8 @@
 #define REACTOS_STR_INTERNAL_NAME     "rundll32"
 #define REACTOS_STR_ORIGINAL_FILENAME "rundll32.exe"
 #include <reactos/version.rc>
+
+#include <reactos/manifest_exe.rc>
 
 IDI_MAIN ICON "res/main.ico"
 


### PR DESCRIPTION
## Purpose

Support `Ctrl+A` (Select All) on `appwiz` (`Create Shortcut`) wizard.

JIRA issue: [CORE-16669](https://jira.reactos.org/browse/CORE-16669)

## Proposed changes

- Add exe manifest to `rundll32.exe`.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/195847800-cc22078f-2963-4ec7-92a2-ed88a9ab6612.png)
`Ctrl+A` won't work.

![after](https://user-images.githubusercontent.com/2107452/195847797-1c0526c4-7c36-479b-b8b3-ab0661f92cba.png)
`Ctrl+A` works well.