### PR TITLE
[USER32][NTUSER] Fill by white in DrawFrameControl:DFC_MENU

### DIFF
--- a/win32ss/user/ntuser/draw.c
+++ b/win32ss/user/ntuser/draw.c
@@ -959,6 +959,7 @@ BOOL FASTCALL UITOOLS95_DrawFrameMenu(HDC dc, LPRECT r, UINT uFlags)
     WCHAR Symbol;
     RECT myr;
     INT cxy;
+    FillRect(dc, r, (HBRUSH)NtGdiGetStockObject(WHITE_BRUSH));
     cxy = UITOOLS_MakeSquareRect(r, &myr);
     switch(uFlags & 0x1f)
     {

--- a/win32ss/user/user32/windows/draw.c
+++ b/win32ss/user/user32/windows/draw.c
@@ -978,6 +978,7 @@ static BOOL UITOOLS95_DrawFrameMenu(HDC dc, LPRECT r, UINT uFlags)
     TCHAR Symbol;
     RECT myr;
     INT cxy;
+    FillRect(dc, r, (HBRUSH)GetStockObject(WHITE_BRUSH));
     cxy = UITOOLS_MakeSquareRect(r, &myr);
     switch(uFlags & 0x1f)
     {


### PR DESCRIPTION
## Purpose

`DrawFrameControl:DFC_MENU` draws the monochrome image of menu arrow or checkmark. However, the function didn't draw the entire rectangle correctly when the rectangle was not a square.
`DrawFrameControl:DFC_MENU` should fill the background rectangle by white.

JIRA issue: [CORE-18417](https://jira.reactos.org/browse/CORE-18417)

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/195962116-4a0b5a40-db4e-4ac9-a14a-11cbc4bd0d93.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/195962111-c1fff79a-4a2d-41f7-9220-424400dc792a.png)

## TODO

- [x] Do tests.
