### PR TITLE
[SHELL32] Fix using the wrong context menu

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1517,7 +1517,7 @@ HRESULT CDefView::InvokeContextMenuCommand(CComPtr<IContextMenu> &pCM, UINT uCom
         cmi.ptInvoke = *pt;
     }
 
-    HRESULT hr = m_pCM->InvokeCommand((LPCMINVOKECOMMANDINFO)&cmi);
+    HRESULT hr = pCM->InvokeCommand((LPCMINVOKECOMMANDINFO)&cmi);
     // Most of our callers will do this, but in case they don't do that (File menu!)
     IUnknown_SetSite(pCM, NULL);
     pCM.Release();


### PR DESCRIPTION
This got broken when when resolving a conflict between two changes in the same function.