### PR TITLE
[WIN32SS][SDK][WIN32NT_APITEST] Move INPUTCONTEXTDX to ntuser.h

### DIFF
--- a/modules/rostests/apitests/win32nt/win32nt.h
+++ b/modules/rostests/apitests/win32nt/win32nt.h
@@ -14,6 +14,7 @@
 #include <wingdi.h>
 #include <objbase.h>
 #include <imm.h>
+#include <immdev.h>
 
 #include <winddi.h>
 #include <prntfont.h>

--- a/sdk/include/ddk/immdev.h
+++ b/sdk/include/ddk/immdev.h
@@ -115,36 +115,6 @@ C_ASSERT(offsetof(INPUTCONTEXT, dwReserve) == 0x134);
 C_ASSERT(sizeof(INPUTCONTEXT) == 0x140);
 #endif
 
-struct IME_STATE;
-
-/* unconfirmed */
-#ifdef __cplusplus
-typedef struct INPUTCONTEXTDX : INPUTCONTEXT
-{
-#else
-typedef struct INPUTCONTEXTDX
-{
-    INPUTCONTEXT;
-#endif
-    UINT nVKey;
-    BOOL bNeedsTrans;
-    DWORD dwUnknown1;
-    DWORD dwUIFlags;
-    DWORD dwUnknown2;
-    struct IME_STATE *pState;
-    DWORD dwChange;
-    DWORD dwUnknown5;
-} INPUTCONTEXTDX, *PINPUTCONTEXTDX, *LPINPUTCONTEXTDX;
-
-#ifndef _WIN64
-C_ASSERT(offsetof(INPUTCONTEXTDX, nVKey) == 0x140);
-C_ASSERT(offsetof(INPUTCONTEXTDX, bNeedsTrans) == 0x144);
-C_ASSERT(offsetof(INPUTCONTEXTDX, dwUIFlags) == 0x14c);
-C_ASSERT(offsetof(INPUTCONTEXTDX, pState) == 0x154);
-C_ASSERT(offsetof(INPUTCONTEXTDX, dwChange) == 0x158);
-C_ASSERT(sizeof(INPUTCONTEXTDX) == 0x160);
-#endif
-
 // bits of fdwInit of INPUTCONTEXT
 #define INIT_STATUSWNDPOS               0x00000001
 #define INIT_CONVERSION                 0x00000002
@@ -152,12 +122,6 @@ C_ASSERT(sizeof(INPUTCONTEXTDX) == 0x160);
 #define INIT_LOGFONT                    0x00000008
 #define INIT_COMPFORM                   0x00000010
 #define INIT_SOFTKBDPOS                 0x00000020
-
-// bits for INPUTCONTEXTDX.dwChange
-#define INPUTCONTEXTDX_CHANGE_OPEN          0x1
-#define INPUTCONTEXTDX_CHANGE_CONVERSION    0x2
-#define INPUTCONTEXTDX_CHANGE_SENTENCE      0x4
-#define INPUTCONTEXTDX_CHANGE_FORCE_OPEN    0x100
 
 #ifndef WM_IME_REPORT
     #define WM_IME_REPORT 0x280

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -1244,6 +1244,41 @@ typedef struct tagTRANSMSGLIST
     TRANSMSG TransMsg[ANYSIZE_ARRAY];
 } TRANSMSGLIST, *PTRANSMSGLIST, *LPTRANSMSGLIST;
 
+struct IME_STATE;
+
+#ifdef __cplusplus
+typedef struct INPUTCONTEXTDX : INPUTCONTEXT
+{
+#else
+typedef struct INPUTCONTEXTDX
+{
+    INPUTCONTEXT;
+#endif
+    UINT nVKey;
+    BOOL bNeedsTrans;
+    DWORD dwUnknown1;
+    DWORD dwUIFlags;
+    DWORD dwUnknown2;
+    struct IME_STATE *pState;
+    DWORD dwChange;
+    DWORD dwUnknown5;
+} INPUTCONTEXTDX, *PINPUTCONTEXTDX, *LPINPUTCONTEXTDX;
+
+#ifndef _WIN64
+C_ASSERT(offsetof(INPUTCONTEXTDX, nVKey) == 0x140);
+C_ASSERT(offsetof(INPUTCONTEXTDX, bNeedsTrans) == 0x144);
+C_ASSERT(offsetof(INPUTCONTEXTDX, dwUIFlags) == 0x14c);
+C_ASSERT(offsetof(INPUTCONTEXTDX, pState) == 0x154);
+C_ASSERT(offsetof(INPUTCONTEXTDX, dwChange) == 0x158);
+C_ASSERT(sizeof(INPUTCONTEXTDX) == 0x160);
+#endif
+
+// bits for INPUTCONTEXTDX.dwChange
+#define INPUTCONTEXTDX_CHANGE_OPEN          0x1
+#define INPUTCONTEXTDX_CHANGE_CONVERSION    0x2
+#define INPUTCONTEXTDX_CHANGE_SENTENCE      0x4
+#define INPUTCONTEXTDX_CHANGE_FORCE_OPEN    0x100
+
 #define DEFINE_IME_ENTRY(type, name, params, extended) typedef type (WINAPI *FN_##name) params;
 #include "imetable.h"
 #undef DEFINE_IME_ENTRY

--- a/win32ss/pch.h
+++ b/win32ss/pch.h
@@ -68,6 +68,7 @@ typedef struct _SECURITY_ATTRIBUTES SECURITY_ATTRIBUTES, *LPSECURITY_ATTRIBUTES;
 #define _NOCSECT_TYPE
 #include <ddrawi.h>
 #include <imm.h>
+#include <immdev.h>
 #include <dbt.h>
 #include <ntddvdeo.h>
 

--- a/win32ss/user/user32/include/user32.h
+++ b/win32ss/user/user32/include/user32.h
@@ -28,6 +28,7 @@
 #include <winreg.h>
 #include <winuser.h>
 #include <imm.h>
+#include <immdev.h>
 #include <ddeml.h>
 #include <dde.h>
 #include <windowsx.h>

--- a/win32ss/user/winsrv/winsrv.h
+++ b/win32ss/user/winsrv/winsrv.h
@@ -23,6 +23,7 @@
 #include <winreg.h>
 #include <winuser.h>
 #include <imm.h>
+#include <immdev.h>
 
 /* Undocumented user definitions */
 #include <undocuser.h>


### PR DESCRIPTION
## Purpose

JIRA issue: N/A
https://github.com/reactos/reactos/commit/26caef23362f33ef753a444696ef6e41c7146ee7#r86886940

## Proposed changes

- Move `INPUTCONTEXTDX` structure from `<immdev.h>` into `<include/ntuser.h>`
- Add some `#include <immdev.h>` to resolve dependencies.
