### PR TITLE
[NTFS] NtfsCreateFCB(): Check allocation result

### DIFF
--- a/drivers/filesystems/ntfs/fcb.c
+++ b/drivers/filesystems/ntfs/fcb.c
@@ -74,6 +74,11 @@ NtfsCreateFCB(PCWSTR FileName,
     ASSERT(Vcb->Identifier.Type == NTFS_TYPE_VCB);
 
     Fcb = ExAllocateFromNPagedLookasideList(&NtfsGlobalData->FcbLookasideList);
+    if (Fcb == NULL)
+    {
+        return NULL;
+    }
+
     RtlZeroMemory(Fcb, sizeof(NTFS_FCB));
 
     Fcb->Identifier.Type = NTFS_TYPE_FCB;


### PR DESCRIPTION
Abort if `NULL` pointer.