### PR TITLE
[NTFS] Add a few casts to ULONGLONG from ULONG/LONGLONG

### DIFF
--- a/drivers/filesystems/ntfs/mft.c
+++ b/drivers/filesystems/ntfs/mft.c
@@ -249,9 +249,9 @@ ULONGLONG
 AttributeAllocatedLength(PNTFS_ATTR_RECORD AttrRecord)
 {
     if (AttrRecord->IsNonResident)
-        return AttrRecord->NonResident.AllocatedSize;
+        return (ULONGLONG)AttrRecord->NonResident.AllocatedSize; // From LONGLONG.
     else
-        return ALIGN_UP_BY(AttrRecord->Resident.ValueLength, ATTR_RECORD_ALIGNMENT);
+        return ALIGN_UP_BY(AttrRecord->Resident.ValueLength, ATTR_RECORD_ALIGNMENT); // From ULONG.
 }
 
 
@@ -259,9 +259,9 @@ ULONGLONG
 AttributeDataLength(PNTFS_ATTR_RECORD AttrRecord)
 {
     if (AttrRecord->IsNonResident)
-        return AttrRecord->NonResident.DataSize;
+        return (ULONGLONG)AttrRecord->NonResident.DataSize; // From LONGLONG.
     else
-        return AttrRecord->Resident.ValueLength;
+        return AttrRecord->Resident.ValueLength; // From ULONG.
 }
 
 /**

--- a/drivers/filesystems/ntfs/rw.c
+++ b/drivers/filesystems/ntfs/rw.c
@@ -134,7 +134,7 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
     }
 
     StreamSize = AttributeDataLength(DataContext->pRecord);
-    if (ReadOffset >= StreamSize)
+    if ((ULONGLONG)ReadOffset >= StreamSize)
     {
         DPRINT1("Reading beyond stream end!\n");
         ReleaseAttributeContext(DataContext);
@@ -143,8 +143,8 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
     }
 
     ToRead = Length;
-    if (ReadOffset + Length > StreamSize)
-        ToRead = StreamSize - ReadOffset;
+    if ((ULONGLONG)ReadOffset + Length > StreamSize)
+        ToRead = (ULONG)(StreamSize - ReadOffset);
 
     RealReadOffset = ReadOffset;
     RealLength = ToRead;
@@ -154,9 +154,9 @@ NtfsReadFile(PDEVICE_EXTENSION DeviceExt,
         RealReadOffset = ROUND_DOWN(ReadOffset, DeviceExt->NtfsInfo.BytesPerSector);
         RealLength = ROUND_UP(ToRead, DeviceExt->NtfsInfo.BytesPerSector);
         /* do we need to extend RealLength by one sector? */
-        if (RealLength + RealReadOffset < ReadOffset + Length)
+        if ((ULONGLONG)RealReadOffset + RealLength < (ULONGLONG)ReadOffset + Length)
         {
-            if (RealReadOffset + RealLength + DeviceExt->NtfsInfo.BytesPerSector <= AttributeAllocatedLength(DataContext->pRecord))
+            if ((ULONGLONG)RealReadOffset + RealLength + DeviceExt->NtfsInfo.BytesPerSector <= AttributeAllocatedLength(DataContext->pRecord))
                 RealLength += DeviceExt->NtfsInfo.BytesPerSector;
         }
 
@@ -425,7 +425,7 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
     DPRINT("WriteOffset: %lu\tStreamSize: %I64u\n", WriteOffset, StreamSize);
 
     // Are we trying to write beyond the end of the stream?
-    if (WriteOffset + Length > StreamSize)
+    if ((ULONGLONG)WriteOffset + Length > StreamSize)
     {
         // is increasing the stream size allowed?
         if (!(Fcb->Flags & FCB_IS_VOLUME) &&
@@ -437,7 +437,7 @@ NTSTATUS NtfsWriteFile(PDEVICE_EXTENSION DeviceExt,
             ULONGLONG ParentMFTId;
             UNICODE_STRING filename;
 
-            DataSize.QuadPart = WriteOffset + Length;
+            DataSize.QuadPart = (ULONGLONG)WriteOffset + Length;
 
             // set the attribute data length
             Status = SetAttributeDataLength(FileObject, Fcb, DataContext, AttributeOffset, FileRecord, &DataSize);


### PR DESCRIPTION
## Purpose

This is probably not a fix for this very ticket, yet a small step.

JIRA issue: [CORE-12101](https://jira.reactos.org/browse/CORE-12101)

## Proposed changes

in
AttributeAllocatedLength() and AttributeDataLength(),
NtfsReadFile() and NtfsWriteFile().

- Be explicit about 32/64 bits and signs..