### PR TITLE
Minor cleanup of deprecated things in CSRSRV/SMSS/NTOS:MM

### DIFF
--- a/base/system/smss/smss.c
+++ b/base/system/smss/smss.c
@@ -25,18 +25,6 @@ HANDLE SmpInitialCommandProcessId;
 
 /* FUNCTIONS ******************************************************************/
 
-/* GCC's incompetence strikes again */
-VOID
-sprintf_nt(IN PCHAR Buffer,
-           IN PCHAR Format,
-           IN ...)
-{
-    va_list ap;
-    va_start(ap, Format);
-    sprintf(Buffer, Format, ap);
-    va_end(ap);
-}
-
 NTSTATUS
 NTAPI
 SmpExecuteImage(IN PUNICODE_STRING FileName,
@@ -176,9 +164,10 @@ SmpInvokeAutoChk(IN PUNICODE_STRING FileName,
     if (Flags & SMP_INVALID_PATH)
     {
         /* It wasn't, so create an error message to print on the screen */
-        sprintf_nt(MessageBuffer,
-                   "%wZ program not found - skipping AUTOCHECK\r\n",
-                   FileName);
+        RtlStringCbPrintfA(MessageBuffer,
+                           sizeof(MessageBuffer),
+                           "%wZ program not found - skipping AUTOCHECK\r\n",
+                           FileName);
         RtlInitAnsiString(&MessageString, MessageBuffer);
         if (NT_SUCCESS(RtlAnsiStringToUnicodeString(&Destination,
                                                     &MessageString,

--- a/subsystems/win32/csrsrv/CMakeLists.txt
+++ b/subsystems/win32/csrsrv/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(csrsrv MODULE
 
 set_module_type(csrsrv nativedll)
 target_link_libraries(csrsrv ${PSEH_LIB} smlib)
-add_importlibs(csrsrv smdll ntdll)
+add_importlibs(csrsrv ntdll)
 add_pch(csrsrv srv.h SOURCE)
 add_dependencies(csrsrv psdk bugcodes)
 add_cd_file(TARGET csrsrv DESTINATION reactos/system32 FOR all)


### PR DESCRIPTION
## Purpose

`[CSRSRV] Remove deprecated dependency on smdll.`
`[SMSS][NTOS:MM] Get rid of the remaining sprintf_nt hacks.`
