### PR TITLE
[NTOS:MM] MmPurgeSegment: Fix wrong return value

### DIFF
--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -4739,7 +4739,7 @@ MmPurgeSegment(
     if (!Segment)
     {
         /* Nothing to purge */
-        return STATUS_SUCCESS;
+        return TRUE;
     }
 
     PurgeStart.QuadPart = Offset ? Offset->QuadPart : 0LL;


### PR DESCRIPTION
Return TRUE instead of NTSTATUS code which has a value of FALSE and may confuse caller. Fixes sporadic 0x7B bugcheck when booting from corrupted NTFS volume using WinXP ntfs.sys.