### PR TITLE
[ADVAPI32] RegCreateKeyExW(): Log parameters

### DIFF
--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -1110,8 +1110,23 @@ RegCreateKeyExW(
           hKey, debugstr_w(lpSubKey), Reserved, debugstr_w(lpClass), dwOptions,
           samDesired, lpSecurityAttributes, phkResult, lpdwDisposition);
 
-    if (lpSecurityAttributes && lpSecurityAttributes->nLength != sizeof(SECURITY_ATTRIBUTES))
+    if (lpSecurityAttributes && lpSecurityAttributes->nLength != sizeof(*lpSecurityAttributes))
+    {
+        /**/ ASSERT(lpSecurityAttributes->nLength == sizeof(*lpSecurityAttributes));
+        WARN("lpSecurityAttributes: %lu != %Iu\n",
+             lpSecurityAttributes->nLength, sizeof(*lpSecurityAttributes));
+        /**/ ASSERT(lpSecurityAttributes->nLength == sizeof(*lpSecurityAttributes));
+        WARN("lpSecurityAttributes: %lu != %Iu, %p\n",
+             lpSecurityAttributes->nLength, sizeof(*lpSecurityAttributes),
+             lpSecurityAttributes->lpSecurityDescriptor);
+        /**/ ASSERT(lpSecurityAttributes->nLength == sizeof(*lpSecurityAttributes));
+        WARN("lpSecurityAttributes: %lu != %Iu, %p, %d\n",
+             lpSecurityAttributes->nLength, sizeof(*lpSecurityAttributes),
+             lpSecurityAttributes->lpSecurityDescriptor,
+             lpSecurityAttributes->bInheritHandle);
+        /**/ ASSERT(lpSecurityAttributes->nLength == sizeof(*lpSecurityAttributes));
         return ERROR_INVALID_USER_BUFFER;
+    }
 
     /* get the real parent key */
     Status = MapDefaultKey(&ParentKey,

--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -1106,7 +1106,9 @@ RegCreateKeyExW(
     ULONG Attributes = OBJ_CASE_INSENSITIVE;
     NTSTATUS Status;
 
-    TRACE("RegCreateKeyExW() called\n");
+    TRACE("RegCreateKeyExW(%p, %s, %lu, %s, %08x, %08x, %p, %p, %p)\n",
+          hKey, debugstr_w(lpSubKey), Reserved, debugstr_w(lpClass), dwOptions,
+          samDesired, lpSecurityAttributes, phkResult, lpdwDisposition);
 
     if (lpSecurityAttributes && lpSecurityAttributes->nLength != sizeof(SECURITY_ATTRIBUTES))
         return ERROR_INVALID_USER_BUFFER;
@@ -1116,6 +1118,7 @@ RegCreateKeyExW(
                            hKey);
     if (!NT_SUCCESS(Status))
     {
+        WARN("MapDefaultKey(%p) failed (Status %x)\n", hKey, Status);
         return RtlNtStatusToDosError(Status);
     }
 

--- a/sdk/include/psdk/wtypes.idl
+++ b/sdk/include/psdk/wtypes.idl
@@ -146,7 +146,7 @@ typedef struct _SECURITY_DESCRIPTOR {
 typedef struct _SECURITY_ATTRIBUTES
 {
     DWORD nLength;
-    [size_is(nLength)] LPVOID lpSecurityDescriptor;
+    LPVOID lpSecurityDescriptor;
     BOOL bInheritHandle;
 } SECURITY_ATTRIBUTES, *PSECURITY_ATTRIBUTES, *LPSECURITY_ATTRIBUTES;
 


### PR DESCRIPTION
## Purpose

Give clues about failures.

JIRA issue: [CORE-15471](https://jira.reactos.org/browse/CORE-15471)

## Proposed changes

- Enhance a `TRACE()`.
- Add a `WARN()`.