### PR TITLE
[SHELL32] Canonicalize path in CShellLink

### DIFF
--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2224,8 +2224,12 @@ HRESULT CShellLink::SetTargetFromPIDLOrPath(LPCITEMIDLIST pidl, LPCWSTR pszFile)
             }
             else
             {
+                /* It might contain double backslashes (CORE-18080). Canonicalize the path. */
+                WCHAR szFullPath[MAX_PATH];
+                GetFullPathNameW(szPath, _countof(szFullPath), szFullPath, NULL);
+
                 hr = S_OK;
-                pidlNew = SHSimpleIDListFromPathW(szPath);
+                pidlNew = SHSimpleIDListFromPathW(szFullPath);
                 // NOTE: Don't make it failed here even if pidlNew was NULL.
                 // We don't fail on purpose even if SHSimpleIDListFromPathW returns NULL.
                 // This behaviour has been verified with tests.


### PR DESCRIPTION
## Purpose

Fix LibreOffice icon.
JIRA issue: [CORE-18080](https://jira.reactos.org/browse/CORE-18080)

## Proposed changes

- Use `GetFullPathName` to canonicalize the path in `CShellLink::SetTargetFromPIDLOrPath`.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/198857981-4c578150-85e2-4b6c-baf8-b8f482794bd7.png)
The icon was blank.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/198857982-064f4ab3-4857-42d7-a755-75c1f3513141.png)
Successful.