### PR TITLE
[KERNEL32][BASESRV] Fix interoperability with Win2k3 regarding NLS section security.

### DIFF
--- a/sdk/include/reactos/subsys/win/base.h
+++ b/sdk/include/reactos/subsys/win/base.h
@@ -23,6 +23,14 @@ VOID
 NTAPI
 BaseSetProcessCreateNotify(IN BASE_PROCESS_CREATE_NOTIFY_ROUTINE ProcessCreateNotifyProc);
 
+#define NLS_SIZEOF_ACE_AND_SIDS(n) \
+    (FIELD_OFFSET(ACCESS_ALLOWED_ACE, SidStart) + \
+     FIELD_OFFSET(SID, SubAuthority) + (n)*RTL_FIELD_SIZE(SID, SubAuthority))
+
+/* Minimal size for the security descriptors of the "\NLS\NlsSection*" sections */
+#define NLS_SECTION_SECURITY_DESCRIPTOR_SIZE \
+    (sizeof(SECURITY_DESCRIPTOR) + sizeof(ACL) + NLS_SIZEOF_ACE_AND_SIDS(1))
+
 typedef struct _NLS_USER_INFO
 {
     WCHAR sLanguage[80];

--- a/subsystems/win/basesrv/basesrv.h
+++ b/subsystems/win/basesrv/basesrv.h
@@ -58,9 +58,6 @@ typedef BOOL (WINAPI *PGET_NLS_SECTION_NAME)(UINT   CodePage,
                                              ULONG  ResultSize);
 
 typedef BOOL (WINAPI *PVALIDATE_LOCALE)(IN ULONG LocaleId);
-typedef NTSTATUS (WINAPI *PCREATE_NLS_SECURTY_DESCRIPTOR)(_Out_ PVOID *SecurityDescriptorBuffer,
-                                                          _In_ ULONG DescriptorSize,
-                                                          _In_ ULONG AccessMask);
 
 /* Globals */
 extern HANDLE BaseSrvHeap;


### PR DESCRIPTION
## Purpose and Proposed changes

Partially revert some aspects of commits 5696e4ba4 and bf40c7a31. (See PR #4340.)

In order for Win2k3 kernel32.dll to operate with our basesrv.dll (or our kernel32.dll to operate with Win2k3 basesrv.dll), we need in particular to have the CreateNlsSecurityDescriptor() helper to exactly take the expected parameters. Namely, a pointer to a **user-allocated** SECURITY_DESCRIPTOR buffer, its size (and an access mask).

The function expects its caller to provide all this, and the caller expects the function to initialize the security descriptor buffer. Note that the function does *NOT* allocate a new descriptor buffer to be returned!

Indeed, with the way it currently is in master, using Win2k3 kernel32 with our basesrv is now failing with the errors:
```
NLSAPI: Could NOT Create ACL - c0000023.
(subsystems/win/basesrv/nls.c:279) NLS: CreateNlsSecurityDescriptor FAILED!: c0000023
NLSAPI: Could NOT initialize Server - c0000023.
(dll/ntdll/ldr/ldrinit.c:867) LDR: DLL_PROCESS_ATTACH for dll "kernel32.dll" (InitRoutine: 77E40D95) failed
```
(and, if we ever attempted to increase the so-claimed "dummy parameter" descriptor size in the basesrv call, we would end up with its stack corrupted and a crash).
Conversely, using our kernel32 with Win2k3 basesrv, would end up with basesrv receiving a wrongly-initialized descriptor that would not work (the buffer not being initialized with the contents of a descriptor, but instead receiving some address to a descriptor allocated somewhere else).
