### PR TITLE
[PSDK] SECURITY_ATTRIBUTES: Remove size_is(nLength)

### DIFF
--- a/sdk/include/psdk/wtypes.idl
+++ b/sdk/include/psdk/wtypes.idl
@@ -146,7 +146,7 @@ typedef struct _SECURITY_DESCRIPTOR {
 typedef struct _SECURITY_ATTRIBUTES
 {
     DWORD nLength;
-    [size_is(nLength)] LPVOID lpSecurityDescriptor;
+    LPVOID lpSecurityDescriptor;
     BOOL bInheritHandle;
 } SECURITY_ATTRIBUTES, *PSECURITY_ATTRIBUTES, *LPSECURITY_ATTRIBUTES;
 


### PR DESCRIPTION
nLength is the size of the struct itself,
not a number of descriptors.

Addendum to 1f12113 (r26428).
JIRA issue: noticed while investigating CORE 15471.
