### PR TITLE
[SHELL32][INCLUDE] Fix PathResolve for double-backslash

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -185,7 +185,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
             if (*pchTemp == L'\\')
                 ++pchTemp;
         }
-        else /* Drive is not specified */
+        else
         {
             if (!pszDir || FAILED(StringCchCopyW(szRoot, _countof(szRoot), pszDir)))
             {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -187,6 +187,11 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         }
         else
         {
+            /*
+             * No drive was specified in the path. Try to find one from the
+             * optional directory (if this fails, fall back to the one of the
+             * Windows directory).
+             */
             if (!pszDir || FAILED(StringCchCopyW(szRoot, _countof(szRoot), pszDir)))
             {
                 /* pszDir was invalid or NULL. Fall back to the

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -785,16 +785,16 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
         if (!PathFileExistsAndAttributesW(path, NULL)) /* Check the existence */
             return FALSE; /* Not found */
-    }
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
-    if ((flags & PRF_REQUIREABSOLUTE) && !PathIsAbsoluteW(path))
-    {
-        if (!PathMakeAbsoluteW(path))
-            return FALSE;
-        return PathFileExistsAndAttributesW(path, NULL);
-    }
+        if ((flags & PRF_REQUIREABSOLUTE) && !PathIsAbsoluteW(path))
+        {
+            if (!PathMakeAbsoluteW(path))
+                return FALSE;
+            return PathFileExistsAndAttributesW(path, NULL);
+        }
 #endif
+    }
 
     return TRUE; /* Done */
 }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -154,8 +154,6 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     WCHAR szTemp[MAX_PATH], szRoot[MAX_PATH];
     PWCHAR pchTemp, pchPath, pchPathEnd;
 
-    /* FIXME: Short pathname */
-
     /* Save pszPath path into szTemp for rebuilding the path later */
     if (FAILED(StringCchCopyW(szTemp, _countof(szTemp), pszPath)))
         return;
@@ -166,6 +164,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     /* Build the root-like path on pszPath, and set pchTemp */
     if (PathIsUNCW(szTemp)) /* UNC path: Begins with double backslash */
     {
+        /* FIXME: Short pathname */
         pszPath[2] = UNICODE_NULL; /* Cut off */
         pchTemp = &szTemp[2];
     }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -218,13 +218,10 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 pchPath = &pszPath[lstrlenW(pszPath)];
                 bDots = TRUE;
             }
-            else
+            else if (pchTemp[1] == UNICODE_NULL || pchTemp[1] == L'\\')
             {
                 /* Component '.' */
-                if (pchTemp[1] == UNICODE_NULL || pchTemp[1] == L'\\')
-                {
-                    bDots = TRUE;
-                }
+                bDots = TRUE;
             }
 
             if (bDots) /* '..' or '.' ? */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -267,7 +267,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     if (pchPath < pchPathEnd)
         *pchPath = UNICODE_NULL; /* Keep null-terminated */
 
-    PathRemoveBackslashW(pszPath); /* The trailing backslash should be removed */
+    /* Remove any trailing backslash */
+    PathRemoveBackslashW(pszPath);
 
     if (!(dwFlags & 1)) /* Remove the trailing dot? */
     {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -123,7 +123,7 @@ PathSearchOnExtensionsW(
         return PathFileExistsDefExtW(pszPath, dwWhich);
 }
 
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
 static BOOL WINAPI PathIsAbsoluteW(_In_ LPCWSTR path)
 {
     return PathIsUNCW(path) || (PathGetDriveNumberW(path) != -1 && path[2] == L'\\');

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -754,7 +754,11 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
                 return TRUE;
 
             if (!PathIsAbsoluteW(path))
-                return PathMakeAbsoluteW(path) && PathFileExistsAndAttributesW(path, NULL);
+            {
+                if (!PathMakeAbsoluteW(path))
+                    return FALSE;
+                return PathFileExistsAndAttributesW(path, NULL);
+            }
 #else
             return TRUE; /* Found */
 #endif

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -175,7 +175,12 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         iDrive = PathGetDriveNumberW(szTemp);
         if (iDrive != -1) /* Drive is specified */
         {
-            PathBuildRootW(pszPath, iDrive); /* 'C:\' */
+            /*
+             * A drive is specified in the path, that can be either of the
+             * form 'C:\xxx' or of the form 'C:xxx' (relative path). Isolate
+             * the root part 'C:' and the rest of the path 'xxx' in pchTemp.
+             */
+            PathBuildRootW(pszPath, iDrive);
             pchTemp = &szTemp[2];
 
             if (*pchTemp == L'\\')

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -150,6 +150,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     WCHAR szTemp[MAX_PATH], szRoot[MAX_PATH];
     PWCHAR pchTemp, pchPath, pchPathEnd;
 
+    TRACE("(%s,%s,0x%08x)\n", debugstr_w(pszPath), debugstr_w(pszDir), dwFlags);
+
     /* Save pszPath path into szTemp for rebuilding the path later */
     if (FAILED(StringCchCopyW(szTemp, _countof(szTemp), pszPath)))
         return;
@@ -673,7 +675,7 @@ BOOL WINAPI PathResolveA(LPSTR path, LPCSTR *dirs, DWORD flags)
     DWORD iDir, cDirs, cbDirs;
     WCHAR pathW[MAX_PATH];
 
-    TRACE("PathResolveA(%s,%p,0x%08x)\n", debugstr_a(path), dirs, flags);
+    TRACE("(%s,%p,0x%08x)\n", debugstr_a(path), dirs, flags);
 
     if (dirs)
     {
@@ -716,7 +718,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 {
     DWORD dwWhich = WHICH_DEFAULT; /* The extensions to be searched */
 
-    TRACE("PathResolveW(%s,%p,0x%08x)\n", debugstr_w(path), dirs, flags);
+    TRACE("(%s,%p,0x%08x)\n", debugstr_w(path), dirs, flags);
 
     if (flags & PRF_DONTFINDLNK)
         dwWhich &= ~WHICH_LNK; /* Don't search '.LNK' (shortcut) */
@@ -766,6 +768,8 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
     /* Qualify the path */
     PathQualifyExW(path, ((flags & PRF_FIRSTDIRDEF) ? *dirs : NULL), 1);
+
+    TRACE("(%s)\n", debugstr_w(path));
 
     if (flags & PRF_VERIFYEXISTS) /* Verify the existence? */
     {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -207,7 +207,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     /* Start appending the path components of szTemp to pszPath. */
     while (*pchTemp && pchPath < pchPathEnd)
     {
-        if (pchTemp[0] == L'.') /* Dot? */
+        /* Collapse any .\ and ..\ parts in the path */
+        if (pchTemp[0] == L'.')
         {
             BOOL bDots = FALSE; /* '..' or '.' ? */
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -199,7 +199,7 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
             StringCchCopyW(pszPath, MAX_PATH, szRoot);
         }
     }
-    /* Now pszPath is a root path or an empty string. */
+    /* Now pszPath is a root path-like or an empty string. */
 
     pchPath = &pszPath[lstrlenW(pszPath)];
     pchPathEnd = pszPath + MAX_PATH;
@@ -231,9 +231,15 @@ static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
             {
                 /* Go to next component */
                 while (*pchTemp && *pchTemp != L'\\')
+                {
                     ++pchTemp;
+                }
+
                 if (*pchTemp == L'\\')
+                {
                     ++pchTemp;
+                }
+
                 continue;
             }
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -152,7 +152,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
 {
     INT iDrive;
     WCHAR szTemp[MAX_PATH], szRoot[MAX_PATH];
-    LPWSTR pchTemp, pchPath, pchPathEnd;
+    PWCHAR pchTemp, pchPath, pchPathEnd;
 
     /* FIXME: Short pathname */
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -749,7 +749,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
         if (PathFindOnPathW(path, dirs)) /* Try to find the filename in the directories */
         {
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
             if (!(flags & PRF_REQUIREABSOLUTE))
                 return TRUE;
 
@@ -787,7 +787,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
             return FALSE; /* Not found */
     }
 
-#if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
+#if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
     if ((flags & PRF_REQUIREABSOLUTE) && !PathIsAbsoluteW(path))
     {
         if (!PathMakeAbsoluteW(path))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -3,7 +3,7 @@
  *
  * Copyright 1998, 1999, 2000 Juergen Schmied
  * Copyright 2004 Juan Lang
- * Copyright 2018-2021 Katayama Hirofumi MZ
+ * Copyright 2018-2022 Katayama Hirofumi MZ
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -57,8 +57,6 @@ WINE_DEFAULT_DEBUG_CHANNEL(shell);
 
 static const BOOL is_win64 = sizeof(void *) > sizeof(int);
 
-#ifdef __REACTOS__
-
 /* FIXME: Remove this */
 typedef enum _NT_PRODUCT_TYPE
 {
@@ -104,8 +102,6 @@ DoGetProductType(PNT_PRODUCT_TYPE ProductType)
     RegCloseKey(hKey);
     return TRUE;
 }
-
-#endif // __REACTOS__
 
 /*
 	########## Combining and Constructing paths ##########

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -226,7 +226,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 bDots = TRUE;
             }
 
-            /* If a '..' or '.' was encountered, skip to next component */
+            /* If a '..' or '.' was encountered, skip to the next component */
             if (bDots)
             {
                 while (*pchTemp && *pchTemp != L'\\')

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -111,9 +111,12 @@ DoGetProductType(PNT_PRODUCT_TYPE ProductType)
 	########## Combining and Constructing paths ##########
 */
 
-/* @implemented */
 static BOOL WINAPI
-PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD dwWhich)
+PathSearchOnExtensionsW(
+    _Inout_ LPWSTR pszPath,
+    _In_ LPCWSTR *ppszDirs,
+    _In_ BOOL bDoSearch,
+    _In_ DWORD dwWhich)
 {
     if (*PathFindExtensionW(pszPath) != 0)
         return FALSE;
@@ -125,14 +128,12 @@ PathSearchOnExtensionsW(LPWSTR pszPath, LPCWSTR *ppszDirs, BOOL bDoSearch, DWORD
 }
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
-/* @implemented */
-static BOOL WINAPI PathIsAbsoluteW(LPCWSTR path)
+static BOOL WINAPI PathIsAbsoluteW(_In_ LPCWSTR path)
 {
     return PathIsUNCW(path) || (PathGetDriveNumberW(path) != -1 && path[2] == L'\\');
 }
 
-/* @implemented */
-static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
+static BOOL WINAPI PathMakeAbsoluteW(_Inout_ LPWSTR path)
 {
     WCHAR path1[MAX_PATH];
     DWORD cch;
@@ -146,8 +147,8 @@ static BOOL WINAPI PathMakeAbsoluteW(LPWSTR path)
 }
 #endif
 
-/* @implemented */
-static VOID WINAPI PathQualifyExW(LPWSTR pszPath, LPCWSTR pszDir, DWORD dwFlags)
+static VOID WINAPI
+PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dwFlags)
 {
     INT iDrive;
     WCHAR szTemp[MAX_PATH], szRoot[MAX_PATH];
@@ -719,7 +720,7 @@ Cleanup:
     return ret;
 }
 
-BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
+BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DWORD flags)
 {
     DWORD dwWhich = WHICH_DEFAULT; /* The extensions to be searched */
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -768,19 +768,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
         /* Try to find the filename in the directories */
         if (PathFindOnPathW(path, dirs))
-        {
-#if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
-            if (!(flags & PRF_REQUIREABSOLUTE) || PathIsAbsoluteW(path))
-                return TRUE;
-
-            if (!PathMakeAbsoluteW(path))
-                return FALSE;
-
-            return PathFileExistsAndAttributesW(path, NULL);
-#else
-            return TRUE; /* Found */
-#endif
-        }
+            goto CheckAbsoluteAndFinish;
 
         return FALSE; /* Not found */
     }
@@ -804,6 +792,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
             return FALSE; /* Not found */
     }
 
+CheckAbsoluteAndFinish:
 #if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
     if (!(flags & PRF_REQUIREABSOLUTE) || PathIsAbsoluteW(path))
         return TRUE;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -114,7 +114,7 @@ DoGetProductType(PNT_PRODUCT_TYPE ProductType)
 static BOOL WINAPI
 PathSearchOnExtensionsW(
     _Inout_ LPWSTR pszPath,
-    _In_ LPCWSTR *ppszDirs,
+    _In_opt_ LPCWSTR *ppszDirs,
     _In_ BOOL bDoSearch,
     _In_ DWORD dwWhich)
 {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -209,6 +209,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
 
             StringCchCopyW(pszPath, MAX_PATH, szRoot);
         }
+
+        /* FIXME: Support non-LFN */
     }
     /* Now pszPath is a root-like path or an empty string. */
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -189,9 +189,10 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         {
             if (!pszDir || FAILED(StringCchCopyW(szRoot, _countof(szRoot), pszDir)))
             {
-                /* pszDir was invalid or NULL */
-                szRoot[0] = 0;
-                GetWindowsDirectoryW(szRoot, _countof(szRoot)); /* fallback to Windows directory */
+                /* pszDir was invalid or NULL. Fall back to the
+                 * Windows directory and find its root. */
+                szRoot[0] = UNICODE_NULL;
+                GetWindowsDirectoryW(szRoot, _countof(szRoot));
                 iDrive = PathGetDriveNumberW(szRoot);
                 if (iDrive != -1)
                     PathBuildRootW(szRoot, iDrive);

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -173,7 +173,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
          * Determine and normalize the root drive.
          */
         iDrive = PathGetDriveNumberW(szTemp);
-        if (iDrive != -1) /* Drive is specified */
+        if (iDrive != -1)
         {
             /*
              * A drive is specified in the path, that can be either of the

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -156,7 +156,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
 
     /* FIXME: Short pathname */
 
-    /* Copy path to szTemp */
+    /* Save pszPath path into szTemp for rebuilding the path later */
     if (FAILED(StringCchCopyW(szTemp, _countof(szTemp), pszPath)))
         return;
 
@@ -729,7 +729,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
     if (flags & PRF_VERIFYEXISTS)
         SetLastError(ERROR_FILE_NOT_FOUND); /* We set this error code at first in verification */
 
-    PathUnquoteSpacesW(path); /* Unquote the path */
+    PathUnquoteSpacesW(path);
 
     if (PathIsRootW(path)) /* Root path */
     {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -263,7 +263,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
 
     PathRemoveBackslashW(pszPath); /* The trailing backslash should be removed */
 
-    if (!(dwFlags & 1)) /* Remove the last dot? */
+    if (!(dwFlags & 1)) /* Remove the trailing dot? */
     {
         pchPath = CharPrevW(pszPath, pszPath + lstrlenW(pszPath));
         if (*pchPath == L'.')

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -194,7 +194,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 GetWindowsDirectoryW(szRoot, _countof(szRoot)); /* fallback to Windows directory */
                 iDrive = PathGetDriveNumberW(szRoot);
                 if (iDrive != -1)
-                    PathBuildRootW(szRoot, iDrive); /* 'C:\' */
+                    PathBuildRootW(szRoot, iDrive);
             }
 
             pchTemp = szTemp;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -796,8 +796,9 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
     if (flags & PRF_VERIFYEXISTS) /* Verify the existence? */
     {
-        if ((flags & PRF_TRYPROGRAMEXTENSIONS) && /* Try to find a program? */
-            PathSearchOnExtensionsW(path, dirs, FALSE, dwWhich)) /* Search it */
+        /* Try to find the path with program extensions applied? */
+        if ((flags & PRF_TRYPROGRAMEXTENSIONS) &&
+            PathSearchOnExtensionsW(path, dirs, FALSE, dwWhich))
         {
             return TRUE; /* Found */
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -759,8 +759,9 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
     if (PathIsFileSpecW(path)) /* Filename only */
     {
-        if ((flags & PRF_TRYPROGRAMEXTENSIONS) && /* Try to find a program? */
-            PathSearchOnExtensionsW(path, dirs, TRUE, dwWhich)) /* Search it */
+        /* Try to find the path with program extensions applied? */
+        if ((flags & PRF_TRYPROGRAMEXTENSIONS) &&
+            PathSearchOnExtensionsW(path, dirs, TRUE, dwWhich))
         {
             return TRUE; /* Found */
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -789,7 +789,11 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
 
 #if (_WIN32_WINNT >= _WIN32_WINNT_VISTA)
     if ((flags & PRF_REQUIREABSOLUTE) && !PathIsAbsoluteW(path))
-        return PathMakeAbsoluteW(path) && PathFileExistsAndAttributesW(path, NULL);
+    {
+        if (!PathMakeAbsoluteW(path))
+            return FALSE;
+        return PathFileExistsAndAttributesW(path, NULL);
+    }
 #endif
 
     return TRUE; /* Done */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -760,7 +760,7 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
     if (PathIsURLW(path)) /* URL? */
         return FALSE;
 
-    /* Quialify the path */
+    /* Qualify the path */
     PathQualifyExW(path, ((flags & PRF_FIRSTDIRDEF) ? *dirs : NULL), 1);
 
     if (flags & PRF_VERIFYEXISTS) /* Verify the existence? */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -766,7 +766,8 @@ BOOL WINAPI PathResolveW(_Inout_ LPWSTR path, _Inout_opt_ LPCWSTR *dirs, _In_ DW
             return TRUE; /* Found */
         }
 
-        if (PathFindOnPathW(path, dirs)) /* Try to find the filename in the directories */
+        /* Try to find the filename in the directories */
+        if (PathFindOnPathW(path, dirs))
         {
 #if (_WIN32_WINNT >= _WIN32_WINNT_WS03)
             if (!(flags & PRF_REQUIREABSOLUTE))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -224,9 +224,9 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 bDots = TRUE;
             }
 
-            if (bDots) /* '..' or '.' ? */
+            /* If a '..' or '.' was encountered, skip to next component */
+            if (bDots)
             {
-                /* Go to next component */
                 while (*pchTemp && *pchTemp != L'\\')
                 {
                     ++pchTemp;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -168,6 +168,10 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     }
     else
     {
+        /*
+         * Non-UNC path.
+         * Determine and normalize the root drive.
+         */
         iDrive = PathGetDriveNumberW(szTemp);
         if (iDrive != -1) /* Drive is specified */
         {

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -246,7 +246,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         if (!PathAddBackslashW(pszPath)) /* Append a backslash at the end */
             break;
 
-        while (*pchPath == L'\\') /* Backslash is added. Go forward */
+        /* Backslash is added. Skip any consecutive ones. */
+        while (*pchPath == L'\\')
         {
             ++pchPath;
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -735,15 +735,11 @@ BOOL WINAPI PathResolveW(LPWSTR path, LPCWSTR *dirs, DWORD flags)
 
     if (PathIsRootW(path)) /* Root path */
     {
-        if (path[0] == L'\\' && path[1] == UNICODE_NULL &&
-            !PathIsUNCServerW(path) &&
-            !PathIsUNCServerShareW(path))
-        {
-            PathQualifyExW(path, ((flags & PRF_FIRSTDIRDEF) ? *dirs : NULL), 0);
-        }
+        if (path[0] == L'\\' && path[1] == UNICODE_NULL) /* '\' only? */
+            PathQualifyExW(path, ((flags & PRF_FIRSTDIRDEF) ? *dirs : NULL), 0); /* Qualify */
 
         if (flags & PRF_VERIFYEXISTS)
-            return PathFileExistsAndAttributesW(path, NULL);
+            return PathFileExistsAndAttributesW(path, NULL); /* Check the existence */
 
         return TRUE;
     }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -164,7 +164,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     /* Build the root-like path on pszPath, and set pchTemp */
     if (PathIsUNCW(szTemp)) /* UNC path: Begins with double backslash */
     {
-        /* FIXME: Short pathname */
+        /* FIXME: Support non-LFN */
         pszPath[2] = UNICODE_NULL; /* Cut off */
         pchTemp = &szTemp[2];
     }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -166,7 +166,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         pszPath[2] = UNICODE_NULL; /* Cut off */
         pchTemp = &szTemp[2];
     }
-    else /* Non-UNC path */
+    else
     {
         iDrive = PathGetDriveNumberW(szTemp);
         if (iDrive != -1) /* Drive is specified */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -182,7 +182,6 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
              */
             PathBuildRootW(pszPath, iDrive);
             pchTemp = &szTemp[2];
-
             if (*pchTemp == L'\\')
                 ++pchTemp;
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -160,7 +160,8 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
     if (FAILED(StringCchCopyW(szTemp, _countof(szTemp), pszPath)))
         return;
 
-    FixSlashesAndColonW(szTemp); /* every '/' --> '\' */
+    /* Replace every '/' by '\' */
+    FixSlashesAndColonW(szTemp);
 
     /* Build the root-like path on pszPath, and set pchTemp */
     if (PathIsUNCW(szTemp)) /* UNC path: Begins with double backslash */

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -233,9 +233,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 }
 
                 if (*pchTemp == L'\\')
-                {
                     ++pchTemp;
-                }
 
                 continue;
             }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -252,7 +252,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
             ++pchPath;
         }
 
-        /* Copy the component upto backslash */
+        /* Copy the component up to the next separator */
         while (*pchTemp && *pchTemp != L'\\' && pchPath < pchPathEnd)
         {
             *pchPath++ = *pchTemp++;

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -168,6 +168,7 @@ ShellMessageBoxWrapW(
 BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath, DWORD dwWhich);
 BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
+BOOL WINAPI PathIsValidCharW(WCHAR, DWORD);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -168,7 +168,7 @@ ShellMessageBoxWrapW(
 BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath, DWORD dwWhich);
 BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile, LPCWSTR *lppszOtherDirs, DWORD dwWhich);
 VOID WINAPI FixSlashesAndColonW(LPWSTR);
-BOOL WINAPI PathIsValidCharW(WCHAR, DWORD);
+BOOL WINAPI PathIsValidCharW(WCHAR c, DWORD dwClass);
 
 #ifdef __cplusplus
 } /* extern "C" */


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18080](https://jira.reactos.org/browse/CORE-18080), [CORE-15204](https://jira.reactos.org/browse/CORE-15204)

## Proposed changes

- Fix `shell32!PathResolve` and `shell32!PathQualifyExW` functions for double-backslash.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/199160383-fb4d7a1a-218f-4b5f-9584-cb9fa0d5d3ff.png)
There were some failures.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/199160385-d9942313-13ee-40e1-a759-9039381718c8.png)
Successful.

AFTER:
![after2](https://user-images.githubusercontent.com/2107452/199160381-af36f2ce-d740-4447-b1f1-618f7b546cf4.png)
The icon is fixed.