### PR TITLE
[CPL:INTL] Use Japanese package for Far-East files

### DIFF
--- a/dll/cpl/intl/CMakeLists.txt
+++ b/dll/cpl/intl/CMakeLists.txt
@@ -24,6 +24,6 @@ add_library(intl MODULE
     ${CMAKE_CURRENT_BINARY_DIR}/intl.def)
 
 set_module_type(intl cpl UNICODE)
-add_importlibs(intl user32 comctl32 advapi32 setupapi shell32 msvcrt kernel32 ntdll)
+add_importlibs(intl user32 comctl32 advapi32 setupapi shlwapi shell32 msvcrt kernel32 ntdll)
 add_pch(intl intl.h SOURCE)
 add_cd_file(TARGET intl DESTINATION reactos/system32 FOR all)

--- a/dll/cpl/intl/languages.c
+++ b/dll/cpl/intl/languages.c
@@ -137,7 +137,9 @@ LanguagesPageProc(HWND hwndDlg,
                                 if (pchArgs && *pchArgs)
                                 {
                                     --pchArgs;
-                                    *pchArgs = UNICODE_NULL; /* Cut the C string */
+                                    /* pchArgs pointer is inside szUninstall,
+                                     * so we have to split both strings */
+                                    *pchArgs = UNICODE_NULL;
                                     ++pchArgs;
                                 }
                                 PathUnquoteSpacesW(szUninstall);


### PR DESCRIPTION
## Purpose

This PR will implement `IDC_INST_FILES_FOR_ASIAN` checkbox action. It will install/uninstall `"ReactOS JPN Package"` in Japanese ReactOS.
JIRA issue: [CORE-12748](https://jira.reactos.org/browse/CORE-12748)

## Proposed changes

- Detect `"ReactOS JPN Package"` installation.
- Use `"ReactOS JPN Package"` instead of "mzimeja".
- Implement installation/uninstallation of `"ReactOS JPN Package"` as the action of `IDC_INST_FILES_FOR_ASIAN` checkbox.