### PR TITLE
Remove '.html' from spdx.org license page URLs.

### DIFF
--- a/drivers/network/dd/e1000/send.c
+++ b/drivers/network/dd/e1000/send.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS Intel PRO/1000 Driver
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Sending packets
  * COPYRIGHT:   Copyright 2018 Mark Jansen <mark.jansen@reactos.org>
  *              Copyright 2019 Victor Perevertkin <victor.perevertkin@reactos.org>

--- a/modules/rostests/apitests/ntdll/RtlGenerate8dot3Name.c
+++ b/modules/rostests/apitests/ntdll/RtlGenerate8dot3Name.c
@@ -3,7 +3,7 @@
 // To revert conversion, please execute "code7bit -r <file>".
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Test for RtlGenerate8dot3Name
  * COPYRIGHT:   Copyright 2015-2016 Pierre Schweitzer <pierre@reactos.org>
  *              Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>

--- a/modules/rostests/apitests/ntdll/RtlUnicodeStringToCountedOemString.c
+++ b/modules/rostests/apitests/ntdll/RtlUnicodeStringToCountedOemString.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later.html)
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     Test for RtlUnicodeStringToCountedOemString
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
  */

--- a/modules/rostests/apitests/ntdll/RtlUnicodeToOemN.c
+++ b/modules/rostests/apitests/ntdll/RtlUnicodeToOemN.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     0BSD (https://spdx.org/licenses/0BSD.html)
+ * LICENSE:     0BSD (https://spdx.org/licenses/0BSD)
  * PURPOSE:     Test for RtlUnicodeToOemN
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
  */

--- a/modules/rostests/apitests/ntdll/RtlxUnicodeStringToAnsiSize.c
+++ b/modules/rostests/apitests/ntdll/RtlxUnicodeStringToAnsiSize.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     0BSD (https://spdx.org/licenses/0BSD.html)
+ * LICENSE:     0BSD (https://spdx.org/licenses/0BSD)
  * PURPOSE:     Test for RtlxUnicodeStringToAnsiSize
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
  */

--- a/modules/rostests/apitests/ntdll/RtlxUnicodeStringToOemSize.c
+++ b/modules/rostests/apitests/ntdll/RtlxUnicodeStringToOemSize.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     0BSD (https://spdx.org/licenses/0BSD.html)
+ * LICENSE:     0BSD (https://spdx.org/licenses/0BSD)
  * PURPOSE:     Test for RtlxUnicodeStringToOemSize
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
  */

--- a/modules/rostests/apitests/ntdll/locale.c
+++ b/modules/rostests/apitests/ntdll/locale.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS API tests
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     RTL locale support
  * COPYRIGHT:   Copyright 2016 Mark Jansen <mark.jansen@reactos.org>
  *              Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>

--- a/ntoskrnl/mm/ARM3/wslist.cpp
+++ b/ntoskrnl/mm/ARM3/wslist.cpp
@@ -1,6 +1,6 @@
 /*
  * PROJECT:         ReactOS Kernel
- * LICENSE:         BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause.html)
+ * LICENSE:         BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause)
  * FILE:            ntoskrnl/mm/ARM3/wslist.cpp
  * PURPOSE:         Working set list management
  * PROGRAMMERS:     Jérôme Gardou

--- a/ntoskrnl/mm/i386/procsup.c
+++ b/ntoskrnl/mm/i386/procsup.c
@@ -1,6 +1,6 @@
 /*
  * PROJECT:         ReactOS Kernel
- * LICENSE:         BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause.html)
+ * LICENSE:         BSD-3-Clause (https://spdx.org/licenses/BSD-3-Clause)
  * FILE:            ntoskrnl/mm/i386/procsup.c
  * PURPOSE:         Process handling for i386 architecture
  * PROGRAMMERS:     Jérôme Gardou

--- a/sdk/include/reactos/msgdump.h
+++ b/sdk/include/reactos/msgdump.h
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS header files
- * LICENSE:     CC-BY-4.0 (https://spdx.org/licenses/CC-BY-4.0.html)
+ * LICENSE:     CC-BY-4.0 (https://spdx.org/licenses/CC-BY-4.0)
  * PURPOSE:     Win32API message dumping
  * COPYRIGHT:   Copyright 2018-2021 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */

--- a/sdk/include/reactos/winxx.h
+++ b/sdk/include/reactos/winxx.h
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS header files
- * LICENSE:     CC-BY-4.0 (https://spdx.org/licenses/CC-BY-4.0.html)
+ * LICENSE:     CC-BY-4.0 (https://spdx.org/licenses/CC-BY-4.0)
  * PURPOSE:     An unofficial extension of <windowsx.h>
  * COPYRIGHT:   Copyright 2017-2019 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
  */

--- a/sdk/tools/gcc_plugin_seh/main.cpp
+++ b/sdk/tools/gcc_plugin_seh/main.cpp
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS SDK
- * LICENSE:     BSD Zero Clause License (https://spdx.org/licenses/0BSD.html)
+ * LICENSE:     BSD Zero Clause License (https://spdx.org/licenses/0BSD)
  * PURPOSE:     Helper pragma implementation for pseh library (amd64)
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou
  */

--- a/sdk/tools/txt2nls/main.cpp
+++ b/sdk/tools/txt2nls/main.cpp
@@ -1,6 +1,6 @@
 /*
  * PROJECT:     ReactOS TXT to NLS Converter
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later.html)
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * FILE:        sdk/tools/txt2nls/main.c
  * COPYRIGHT:   Copyright 2021 Jérôme Gardou <jerome.gardou@reactos.org>
  */


### PR DESCRIPTION
## Purpose

Remove '.html' from spdx.org license page URLs, only in source code files (not in the media/doc/3rd Party Files.txt)