### PR TITLE
[COMDLG32] Fix Font dialog Wrong background in font preview CORE-18588

### DIFF
--- a/dll/win32/comdlg32/fontdlg.c
+++ b/dll/win32/comdlg32/fontdlg.c
@@ -1186,6 +1186,7 @@ static LRESULT CFn_WMPaint(HWND hDlg, WPARAM wParam, LPARAM lParam, const CHOOSE
         /* Draw the sample text itself */
         hOrigFont = SelectObject( hdc, CreateFontIndirectW( &lf ) );
         SetTextColor( hdc, lpcf->rgbColors );
+        SetBkMode( hdc, TRANSPARENT );
 
         DrawTextW( hdc,
                 sample_lang_text[CHARSET_ORDER[lpcf->lpLogFont->lfCharSet]],


### PR DESCRIPTION
by importing Wine commit
https://source.winehq.org/git/wine.git/commit/4273004e65addb70b3f7d91e95eb3d5da31ffa3e

Thanks to @gonzoMD who quickly spotted the needed wine commit for us.

## Purpose
fix JIRA issue: [CORE-18588](https://jira.reactos.org/browse/CORE-18588)
I attached an after-picture for classic theme in the JIRA-report already. It works.
I also tested it successfully for Mizu, Modern, and the Luna theme from rapps.

Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=50034
Signed-off-by: Jeff Smith <whydoubt@gmail.com>
Signed-off-by: Alexandre Julliard <julliard@winehq.org>
