### PR TITLE
[NTUSER] Don't redraw scrollbar if it is hidden

### DIFF
--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -668,13 +668,13 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
       switch (nBar)
       {
          case SB_HORZ:
-            bVisible = !!(Window->style & WS_HSCROLL);
+            bVisible = (Window->style & WS_HSCROLL);
             break;
          case SB_VERT:
-            bVisible = !!(Window->style & WS_VSCROLL);
+            bVisible = (Window->style & WS_VSCROLL);
             break;
          case SB_CTL:
-            bVisible = !!(Window->style & WS_VISIBLE);
+            bVisible = (Window->style & WS_VISIBLE);
             break;
          default:
             bVisible = FALSE;

--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -497,6 +497,7 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    static DWORD PrevPos[3] = { 0 };
    static DWORD PrevMax[3] = { 0 };
    static INT PrevAction[3] = { 0 };
+   BOOL bVisible;
 
    ASSERT_REFS_CO(Window);
 
@@ -663,7 +664,24 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
       if ( action & SA_SSI_SHOW )
          if ( co_UserShowScrollBar(Window, nBar, TRUE, TRUE) )
             return lpsi->fMask & SIF_PREVIOUSPOS ? OldPos : pSBData->pos; /* SetWindowPos() already did the painting */
-      if (bRedraw)
+
+      switch (nBar)
+      {
+         case SB_HORZ:
+            bVisible = !!(Window->style & WS_HSCROLL);
+            break;
+         case SB_VERT:
+            bVisible = !!(Window->style & WS_VSCROLL);
+            break;
+         case SB_CTL:
+            bVisible = !!(Window->style & WS_VISIBLE);
+            break;
+         default:
+            bVisible = FALSE;
+            break;
+      }
+
+      if (bRedraw && bVisible)
       {
          if (!(Info->fMask & SIF_THEMED)) /* Not Using Themes */
          {

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -1393,8 +1393,9 @@ OnTimer(PGUI_CONSOLE_DATA GuiData)
                                SW_INVALIDATE);
                 if (NewScrollX >= 0)
                 {
+                    BOOL bRedraw = (Buff->ScreenBufferSize.X > Buff->ViewSize.X);
                     sInfo.nPos = NewScrollX;
-                    SetScrollInfo(GuiData->hWindow, SB_HORZ, &sInfo, TRUE);
+                    SetScrollInfo(GuiData->hWindow, SB_HORZ, &sInfo, bRedraw);
                 }
                 if (NewScrollY >= 0)
                 {

--- a/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
+++ b/win32ss/user/winsrv/consrv/frontends/gui/conwnd.c
@@ -1393,9 +1393,8 @@ OnTimer(PGUI_CONSOLE_DATA GuiData)
                                SW_INVALIDATE);
                 if (NewScrollX >= 0)
                 {
-                    BOOL bRedraw = (Buff->ScreenBufferSize.X > Buff->ViewSize.X);
                     sInfo.nPos = NewScrollX;
-                    SetScrollInfo(GuiData->hWindow, SB_HORZ, &sInfo, bRedraw);
+                    SetScrollInfo(GuiData->hWindow, SB_HORZ, &sInfo, TRUE);
                 }
                 if (NewScrollY >= 0)
                 {


### PR DESCRIPTION
## Purpose

Fix redrawing bug on Command Prompt.
JIRA issue: [CORE-18593](https://jira.reactos.org/browse/CORE-18593)

## Bug reproduction steps

- Open Command Prompt.
- Type `Enter` key 30 times.
- The bottom edge of Command Prompt becomes dirty.

## Proposed changes

- Do not redraw the scrollbar if the scrollbar is hidden.

## Comparison

BEFORE (retested):
![before](https://user-images.githubusercontent.com/2107452/200095255-d1423859-1f81-401a-8f05-7a370b508877.png)
The bottom edge of Command Prompt is dirty.

AFTER (retested):
![after](https://user-images.githubusercontent.com/2107452/200095256-5fb86cb7-86e2-4599-b888-8317be95a12f.png)
The bottom edge of Command Prompt is fixed.

BEFORE:
![before2](https://user-images.githubusercontent.com/2107452/200095254-2a98d913-5eee-4d78-84aa-4e5bec388a68.png)

AFTER:
![after2](https://user-images.githubusercontent.com/2107452/200095258-0025e8b4-1a3b-4992-9ea3-6bbc423e9932.png)