### PR TITLE
[SHELL32] shlexec: Initial support of App Paths

### DIFF
--- a/dll/win32/shell32/wine/shellreg.c
+++ b/dll/win32/shell32/wine/shellreg.c
@@ -28,6 +28,7 @@
 #include <windef.h>
 #include <winbase.h>
 #include <shlobj.h>
+#include <shlwapi.h>
 
 #include <wine/debug.h>
 
@@ -73,16 +74,16 @@ HRESULT WINAPI SHRegQueryValueA(HKEY hkey, LPSTR lpSubKey, LPSTR lpValue, LPDWOR
  * SHRegQueryValueExA   [SHELL32.509]
  *
  */
-HRESULT WINAPI SHRegQueryValueExA(
+LONG WINAPI SHRegQueryValueExA(
 	HKEY hkey,
-	LPSTR lpValueName,
+	LPCSTR lpValueName,
 	LPDWORD lpReserved,
 	LPDWORD lpType,
 	LPBYTE lpData,
 	LPDWORD lpcbData)
 {
 	TRACE("%p %s %p %p %p %p\n", hkey, lpValueName, lpReserved, lpType, lpData, lpcbData);
-	return RegQueryValueExA (hkey, lpValueName, lpReserved, lpType, lpData, lpcbData);
+	return SHQueryValueExA(hkey, lpValueName, lpReserved, lpType, lpData, lpcbData);
 }
 
 /*************************************************************************
@@ -102,24 +103,18 @@ HRESULT WINAPI SHRegQueryValueW(
 
 /*************************************************************************
  * SHRegQueryValueExW	[SHELL32.511] NT4.0
- *
- * FIXME
- *  if the datatype REG_EXPAND_SZ then expand the string and change
- *  *pdwType to REG_SZ.
  */
-HRESULT WINAPI SHRegQueryValueExW (
+LONG WINAPI SHRegQueryValueExW(
 	HKEY hkey,
-	LPWSTR pszValue,
+	LPCWSTR pszValue,
 	LPDWORD pdwReserved,
 	LPDWORD pdwType,
 	LPVOID pvData,
 	LPDWORD pcbData)
 {
-	DWORD ret;
-	WARN("%p %s %p %p %p %p semi-stub\n",
+	TRACE("%p %s %p %p %p %p\n",
 		hkey, debugstr_w(pszValue), pdwReserved, pdwType, pvData, pcbData);
-	ret = RegQueryValueExW ( hkey, pszValue, pdwReserved, pdwType, pvData, pcbData);
-	return ret;
+	return SHQueryValueExW(hkey, pszValue, pdwReserved, pdwType, pvData, pcbData);
 }
 
 /*************************************************************************

--- a/sdk/include/reactos/undocshell.h
+++ b/sdk/include/reactos/undocshell.h
@@ -721,6 +721,26 @@ IStream* WINAPI SHGetViewStream(LPCITEMIDLIST, DWORD, LPCTSTR, LPCTSTR, LPCTSTR)
 
 EXTERN_C HRESULT WINAPI SHCreateSessionKey(REGSAM samDesired, PHKEY phKey);
 
+LONG WINAPI SHRegQueryValueExA(
+    HKEY hkey,
+    LPCSTR lpValueName,
+    LPDWORD lpReserved,
+    LPDWORD lpType,
+    LPBYTE lpData,
+    LPDWORD lpcbData);
+LONG WINAPI SHRegQueryValueExW(
+    HKEY hkey,
+    LPCWSTR pszValue,
+    LPDWORD pdwReserved,
+    LPDWORD pdwType,
+    LPVOID pvData,
+    LPDWORD pcbData);
+#ifdef UNICODE
+    #define SHRegQueryValueEx SHRegQueryValueExW
+#else
+    #define SHRegQueryValueEx SHRegQueryValueExA
+#endif
+
 /*****************************************************************************
  * INVALID_FILETITLE_CHARACTERS
  */


### PR DESCRIPTION
## Purpose

Windows `"App Paths"` is a mechanism that realizes the command line execution with a single filename that is registered at a registry key. This PR will partially fix our broken `App Paths` mechanism.

JIRA issue: [CORE-11335](https://jira.reactos.org/browse/CORE-11335)

## Proposed changes

- Fix `SHELL_TryAppPathW` helper function using `SHRegQueryValueExW` function.
- Fix `SHRegQueryValueExA/W` functions.

## Comparison
Executing `"pbrush"` on the `Run` dialog

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/200116572-ab2fa692-0142-493a-891a-3eaa32b69879.png)
Error.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/200116571-a2b687dd-2114-4b56-8bad-3efe83255605.png)
Successful.

## TODO

- [x] Do the big test.