### PR TITLE
[SHELL32][SDK] Check drop target for allowed effects

### DIFF
--- a/dll/win32/shell32/CIDLDataObj.cpp
+++ b/dll/win32/shell32/CIDLDataObj.cpp
@@ -3,7 +3,7 @@
  * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
  * PURPOSE:     IEnumFORMATETC, IDataObject implementation
  * COPYRIGHT:   Copyright 1998, 1999 <juergen.schmied@metronet.de>
- *              Copyright 2019 Mark Jansen (mark.jansen@reactos.org)
+ *              Copyright 2019-2022 Mark Jansen <mark.jansen@reactos.org>
  */
 
 #include "precomp.h"

--- a/dll/win32/shell32/CMakeLists.txt
+++ b/dll/win32/shell32/CMakeLists.txt
@@ -40,6 +40,7 @@ list(APPEND SOURCE
     folders.cpp
     iconcache.cpp
     shell32.cpp
+    shell32_private.cpp
     CShellItem.cpp
     CShellLink.cpp
     CFolderOptions.cpp

--- a/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
+++ b/dll/win32/shell32/droptargets/CRecyclerDropTarget.cpp
@@ -114,7 +114,7 @@ class CRecyclerDropTarget :
             /* The recycle bin accepts pretty much everything, and sets a CSIDL flag. */
             fAcceptFmt = TRUE;
 
-            *pdwEffect = DROPEFFECT_MOVE;
+            *pdwEffect &= DROPEFFECT_MOVE;
             return S_OK;
         }
 
@@ -125,7 +125,7 @@ class CRecyclerDropTarget :
             if (!pdwEffect)
                 return E_INVALIDARG;
 
-            *pdwEffect = DROPEFFECT_MOVE;
+            *pdwEffect &= DROPEFFECT_MOVE;
 
             return S_OK;
         }
@@ -164,6 +164,7 @@ class CRecyclerDropTarget :
                  * TODO call SetData on the data object with format CFSTR_TARGETCLSID
                  * set to the Recycle Bin's class identifier CLSID_RecycleBin.
                  */
+                UNIMPLEMENTED_DBGBREAK;
             }
             return S_OK;
         }

--- a/dll/win32/shell32/precomp.h
+++ b/dll/win32/shell32/precomp.h
@@ -107,50 +107,9 @@
 #include "CUserNotification.h"
 #include "dialogs/folder_options.h"
 #include "shelldesktop/CChangeNotifyServer.h"
+#include "shell32_private.h"
 
 #include <wine/debug.h>
 #include <wine/unicode.h>
-
-extern const GUID CLSID_AdminFolderShortcut;
-extern const GUID CLSID_FontsFolderShortcut;
-extern const GUID CLSID_StartMenu;
-extern const GUID CLSID_MenuBandSite;
-extern const GUID CLSID_OpenWith;
-extern const GUID CLSID_UnixFolder;
-extern const GUID CLSID_UnixDosFolder;
-extern const GUID SHELL32_AdvtShortcutProduct;
-extern const GUID SHELL32_AdvtShortcutComponent;
-
-#define MAX_PROPERTY_SHEET_PAGE 32
-
-extern inline
-BOOL
-CALLBACK
-AddPropSheetPageCallback(HPROPSHEETPAGE hPage, LPARAM lParam)
-{
-    PROPSHEETHEADERW *pHeader = (PROPSHEETHEADERW *)lParam;
-
-    if (pHeader->nPages < MAX_PROPERTY_SHEET_PAGE)
-    {
-        pHeader->phpage[pHeader->nPages++] = hPage;
-        return TRUE;
-    }
-
-    return FALSE;
-}
-
-HRESULT WINAPI
-Shell_DefaultContextMenuCallBack(IShellFolder *psf, IDataObject *pdtobj);
-
-// CStubWindow32 --- The owner window of file property sheets.
-// This window hides taskbar button of property sheet.
-class CStubWindow32 : public CWindowImpl<CStubWindow32>
-{
-public:
-    DECLARE_WND_CLASS_EX(_T("StubWindow32"), 0, COLOR_WINDOWTEXT)
-
-    BEGIN_MSG_MAP(CStubWindow32)
-    END_MSG_MAP()
-};
 
 #endif /* _PRECOMP_H__ */

--- a/dll/win32/shell32/shell32_private.cpp
+++ b/dll/win32/shell32/shell32_private.cpp
@@ -1,0 +1,76 @@
+/*
+ * PROJECT:     shell32
+ * LICENSE:     LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:     Shell32 private helpers
+ * COPYRIGHT:   Copyright 2022 Mark Jansen <mark.jansen@reactos.org>
+ */
+
+#include "precomp.h"
+
+WINE_DEFAULT_DEBUG_CHANNEL(shell);
+
+
+// Share this with CDefaultContextMenu!!
+DWORD
+Clipboard_GetDropEffect(IShellFolder *pShellFolder)
+{
+    /* If the folder doesn't have a drop target we can't paste */
+    CComPtr<IDropTarget> pdt;
+    HRESULT hr = pShellFolder->CreateViewObject(NULL, IID_PPV_ARG(IDropTarget, &pdt));
+    if (FAILED(hr))
+        return FALSE;
+
+    CComPtr<IDataObject> pDataObj;
+    hr = OleGetClipboard(&pDataObj);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return FALSE;
+
+    STGMEDIUM medium;
+    FORMATETC formatetc;
+
+    /* We can only paste if CFSTR_SHELLIDLIST is present in the clipboard */
+    InitFormatEtc(formatetc, RegisterClipboardFormatW(CFSTR_SHELLIDLIST), TYMED_HGLOBAL);
+    hr = pDataObj->GetData(&formatetc, &medium);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return FALSE;
+
+    ReleaseStgMedium(&medium);
+
+    /* Check what we were asked to do */
+    DWORD dwDropEffect;
+    if (FAILED_UNEXPECTEDLY(DataObject_GetPreferredDropEffect(pDataObj, &dwDropEffect)))
+    {
+        dwDropEffect = DROPEFFECT_COPY | DROPEFFECT_LINK;
+    }
+    /* Let's see what the drop target is allowing us to do */
+    if (!FAILED_UNEXPECTEDLY(pdt->DragEnter(pDataObj, MK_RBUTTON, {0}, &dwDropEffect)))
+    {
+        FAILED_UNEXPECTEDLY(pdt->DragLeave());
+    }
+    else
+    {
+        dwDropEffect = DROPEFFECT_NONE;
+    }
+
+    return dwDropEffect;
+}
+
+// Adapted from https://devblogs.microsoft.com/oldnewthing/20041007-00/?p=37633
+HRESULT
+IContextMenu_HandleMenuMsg2(IContextMenu *pcm, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult)
+{
+    CComPtr<IContextMenu2> pcm2;
+    CComPtr<IContextMenu3> pcm3;
+    HRESULT hr;
+    if (SUCCEEDED(hr = pcm->QueryInterface(IID_PPV_ARG(IContextMenu3, &pcm3))))
+    {
+        hr = pcm3->HandleMenuMsg2(uMsg, wParam, lParam, plResult);
+    }
+    else if (SUCCEEDED(hr = pcm->QueryInterface(IID_PPV_ARG(IContextMenu2, &pcm2))))
+    {
+        if (plResult)
+            *plResult = 0;
+        hr = pcm2->HandleMenuMsg(uMsg, wParam, lParam);
+    }
+    return hr;
+}

--- a/dll/win32/shell32/shell32_private.h
+++ b/dll/win32/shell32/shell32_private.h
@@ -1,0 +1,54 @@
+#ifndef SHELL32_PRIVATE_H
+#define SHELL32_PRIVATE_H
+
+extern const GUID CLSID_AdminFolderShortcut;
+extern const GUID CLSID_FontsFolderShortcut;
+extern const GUID CLSID_StartMenu;
+extern const GUID CLSID_MenuBandSite;
+extern const GUID CLSID_OpenWith;
+extern const GUID CLSID_UnixFolder;
+extern const GUID CLSID_UnixDosFolder;
+extern const GUID SHELL32_AdvtShortcutProduct;
+extern const GUID SHELL32_AdvtShortcutComponent;
+
+#define MAX_PROPERTY_SHEET_PAGE 32
+
+extern inline
+BOOL
+CALLBACK
+AddPropSheetPageCallback(HPROPSHEETPAGE hPage, LPARAM lParam)
+{
+    PROPSHEETHEADERW *pHeader = (PROPSHEETHEADERW *)lParam;
+
+    if (pHeader->nPages < MAX_PROPERTY_SHEET_PAGE)
+    {
+        pHeader->phpage[pHeader->nPages++] = hPage;
+        return TRUE;
+    }
+
+    return FALSE;
+}
+
+HRESULT WINAPI
+Shell_DefaultContextMenuCallBack(IShellFolder *psf, IDataObject *pdtobj);
+
+// CStubWindow32 --- The owner window of file property sheets.
+// This window hides taskbar button of property sheet.
+class CStubWindow32 : public CWindowImpl<CStubWindow32>
+{
+public:
+    DECLARE_WND_CLASS_EX(_T("StubWindow32"), 0, COLOR_WINDOWTEXT)
+
+    BEGIN_MSG_MAP(CStubWindow32)
+    END_MSG_MAP()
+};
+
+
+DWORD
+Clipboard_GetDropEffect(IShellFolder *pShellFolder);
+
+HRESULT
+IContextMenu_HandleMenuMsg2(IContextMenu *pcm, UINT uMsg, WPARAM wParam, LPARAM lParam, LRESULT *plResult);
+
+
+#endif /* SHELL32_PRIVATE_H */

--- a/sdk/include/reactos/shellutils.h
+++ b/sdk/include/reactos/shellutils.h
@@ -576,6 +576,7 @@ static inline PCUIDLIST_RELATIVE HIDA_GetPIDLItem(CIDA const* pida, SIZE_T i)
 
 DECLSPEC_SELECTANY CLIPFORMAT g_cfHIDA = NULL;
 DECLSPEC_SELECTANY CLIPFORMAT g_cfShellIdListOffsets = NULL;
+DECLSPEC_SELECTANY CLIPFORMAT g_cfPreferredDropEffect = NULL;
 
 // Allow to use the HIDA from an IDataObject without copying it
 struct CDataObjectHIDA
@@ -723,6 +724,30 @@ DataObject_SetOffset(IDataObject* pDataObject, POINT* point)
     }
 
     return DataObject_SetData(pDataObject, g_cfShellIdListOffsets, point, sizeof(point[0]));
+}
+
+inline HRESULT
+DataObject_GetPreferredDropEffect(IDataObject *pDataObject, DWORD* dwPreferredEffect)
+{
+    if (g_cfPreferredDropEffect == NULL)
+    {
+        g_cfPreferredDropEffect = (CLIPFORMAT)RegisterClipboardFormatW(CFSTR_PREFERREDDROPEFFECTW);
+    }
+
+    *dwPreferredEffect = 0;
+
+    return DataObject_GetData(pDataObject, g_cfPreferredDropEffect, dwPreferredEffect, sizeof(dwPreferredEffect[0]));
+}
+
+inline HRESULT
+DataObject_SetPreferredDropEffect(IDataObject *pDataObject, DWORD dwPreferredEffect)
+{
+    if (g_cfPreferredDropEffect == NULL)
+    {
+        g_cfPreferredDropEffect = (CLIPFORMAT)RegisterClipboardFormatW(CFSTR_PREFERREDDROPEFFECTW);
+    }
+
+    return DataObject_SetData(pDataObject, g_cfPreferredDropEffect, &dwPreferredEffect, sizeof(dwPreferredEffect));
 }
 
 #endif

--- a/sdk/include/reactos/wine/debug.h
+++ b/sdk/include/reactos/wine/debug.h
@@ -64,6 +64,12 @@ struct __wine_debug_channel
 };
 
 #define UNIMPLEMENTED WINE_FIXME("%s is UNIMPLEMENTED!\n", __FUNCTION__)
+#define UNIMPLEMENTED_DBGBREAK                                                                                         \
+    do                                                                                                                 \
+    {                                                                                                                  \
+        UNIMPLEMENTED;                                                                                                 \
+        DbgBreakPoint();                                                                                               \
+    } while (0)
 
 #ifndef WINE_NO_TRACE_MSGS
 # define __WINE_GET_DEBUGGING_TRACE(dbch) ((dbch)->flags & (1 << __WINE_DBCL_TRACE))


### PR DESCRIPTION
This fixes 'paste as link' being enabled in the recycler

JIRA issue: [CORE-16811](https://jira.reactos.org/browse/CORE-16811)
