### PR TITLE
[USER32] Rewrite CharPrev(Ex)A functions and fix tests

### DIFF
--- a/win32ss/user/user32/windows/text.c
+++ b/win32ss/user/user32/windows/text.c
@@ -148,13 +148,25 @@ LPSTR
 WINAPI
 CharPrevA(LPCSTR start, LPCSTR ptr)
 {
-    while (*start && (start < ptr))
+    if (ptr > start)
     {
-        LPCSTR next = CharNextA(start);
-        if (next >= ptr) break;
-        start = next;
+        --ptr;
+        if (gpsi->dwSRVIFlags & SRVINFO_DBCSENABLED)
+        {
+            LPCSTR ch;
+            BOOL dbl = FALSE;
+
+            for (ch = ptr - 1; ch >= start; --ch)
+            {
+                if (!IsDBCSLeadByte(*ch))
+                    break;
+
+                dbl = !dbl;
+            }
+            if (dbl) --ptr;
+        }
     }
-    return (LPSTR)start;
+    return (LPSTR)ptr;
 }
 
 /*
@@ -164,13 +176,22 @@ LPSTR
 WINAPI
 CharPrevExA(WORD codepage, LPCSTR start, LPCSTR ptr, DWORD flags)
 {
-    while (*start && (start < ptr))
+    if (ptr > start)
     {
-        LPCSTR next = CharNextExA(codepage, start, flags);
-        if (next >= ptr) break;
-        start = next;
+        LPCSTR ch;
+        BOOL dbl = FALSE;
+
+        --ptr;
+        for (ch = ptr - 1; ch >= start; --ch)
+        {
+            if (!IsDBCSLeadByteEx(codepage, *ch))
+                break;
+
+            dbl = !dbl;
+        }
+        if (dbl) --ptr;
     }
-    return (LPSTR)start;
+    return (LPSTR)ptr;
 }
 
 /*


### PR DESCRIPTION
Fixes 48 failing tests of `user32:CharFuncs`. Only 12 minor failing tests are left! :tada: 

JIRA issue: [CORE-18452](https://jira.reactos.org/browse/CORE-18452)

<details>
  <summary>BEFORE :x:</summary>
  
  ```
  CharFuncs.c:529: Test failed: [4] CharPrevA: pchA (0x00233988) is expected to be within szCurrent (0x00233808)
  CharFuncs.c:532: Test failed: [4] CharPrevA: pchA is 0x00233988 (offset 384)
  CharFuncs.c:532: Test failed: [5] CharPrevA: pchA is 0x00233993 (offset -7893)
  CharFuncs.c:529: Test failed: [6] CharPrevA: pchA (0x00233988) is expected to be within szCurrent (0x00233808)
  CharFuncs.c:532: Test failed: [6] CharPrevA: pchA is 0x00233988 (offset 384)
  CharFuncs.c:568: Test failed: [5] CharPrevA: pchA is 0x00473EAA (expected 0x00473EA8)
  CharFuncs.c:571: Test failed: [5] CharPrevExA: pchA is 0x00473EAA (expected 0x00473EA8)
  CharFuncs.c:568: Test failed: [6] CharPrevA: pchA is 0x00473EAA (expected 0x00473EA9)
  CharFuncs.c:571: Test failed: [6] CharPrevExA: pchA is 0x00473EAA (expected 0x00473EA9)
  CharFuncs.c:568: Test failed: [10] CharPrevA: pchA is 0x00473E5C (expected 0x00473E5F)
  CharFuncs.c:571: Test failed: [10] CharPrevExA: pchA is 0x00473E5C (expected 0x00473E5F)
  CharFuncs.c:568: Test failed: [11] CharPrevA: pchA is 0x00473E5C (expected 0x00473E64)
  CharFuncs.c:571: Test failed: [11] CharPrevExA: pchA is 0x00473E5C (expected 0x00473E64)
  CharFuncs.c:568: Test failed: [12] CharPrevA: pchA is 0x00473E5C (expected 0x00473E68)
  CharFuncs.c:571: Test failed: [12] CharPrevExA: pchA is 0x00473E5C (expected 0x00473E68)
  CharFuncs.c:568: Test failed: [13] CharPrevA: pchA is 0x00473E5C (expected 0x00473E69)
  CharFuncs.c:571: Test failed: [13] CharPrevExA: pchA is 0x00473E5C (expected 0x00473E69)
  CharFuncs.c:704: Test failed: [0] CharPrevA: pchA is 0x00473EA8, expected 0x00000000
  CharFuncs.c:717: Test failed: [0] CharPrevExA: pchA is 0x00473EA8, expected 0x00000000
  CharFuncs.c:703: Test failed: [1] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:716: Test failed: [1] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:703: Test failed: [2] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:704: Test failed: [2] CharPrevA: pchA is 0x00000000, expected 0x00473EA7
  CharFuncs.c:716: Test failed: [2] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:717: Test failed: [2] CharPrevExA: pchA is 0x00000000, expected 0x00473EA7
  CharFuncs.c:703: Test failed: [3] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:716: Test failed: [3] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:703: Test failed: [4] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:716: Test failed: [4] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:689: Test failed: [5] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [5] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:704: Test failed: [5] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEE
  CharFuncs.c:689: Test failed: [6] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [6] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:703: Test failed: [6] CharPrevA: Status is 0x0, expected 0xC0000005
  CharFuncs.c:704: Test failed: [6] CharPrevA: pchA is 0x00473EB2, expected 0xDEADBEEE
  CharFuncs.c:716: Test failed: [6] CharPrevExA: Status is 0x0, expected 0xC0000005
  CharFuncs.c:717: Test failed: [6] CharPrevExA: pchA is 0x00473EB2, expected 0x00000000
  CharFuncs.c:703: Test failed: [7] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:704: Test failed: [7] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEF
  CharFuncs.c:716: Test failed: [7] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:717: Test failed: [7] CharPrevExA: pchA is 0x00000000, expected 0xDEADBEEF
  CharFuncs.c:703: Test failed: [8] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:704: Test failed: [8] CharPrevA: pchA is 0x00000000, expected 0x00473EA8
  CharFuncs.c:716: Test failed: [8] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:717: Test failed: [8] CharPrevExA: pchA is 0x00000000, expected 0x00473EA8
  CharFuncs.c:689: Test failed: [9] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [9] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:704: Test failed: [9] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEE
  CharFuncs.c:689: Test failed: [10] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [10] CharPrevW: pchW is 0xDEADBEEF, expected 0x00000000
  CharFuncs.c:704: Test failed: [10] CharPrevA: pchA is 0x00000000, expected 0xDEADBEF0
  CharFuncs.c:703: Test failed: [11] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:704: Test failed: [11] CharPrevA: pchA is 0x00000000, expected 0xDEADBEED
  CharFuncs.c:716: Test failed: [11] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:717: Test failed: [11] CharPrevExA: pchA is 0x00000000, expected 0xDEADBEED
  CharFuncs.c:703: Test failed: [12] CharPrevA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:704: Test failed: [12] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEF
  CharFuncs.c:716: Test failed: [12] CharPrevExA: Status is 0xC0000005, expected 0x0
  CharFuncs.c:717: Test failed: [12] CharPrevExA: pchA is 0x00000000, expected 0xDEADBEEF
  
  CharFuncs: 259 tests executed (0 marked as todo, 60 failures), 0 skipped.
  ```
  
</details>

<details>
  <summary>AFTER :heavy_check_mark:</summary>
  
  ```
  CharFuncs.c:689: Test failed: [5] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [5] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:704: Test failed: [5] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEE
  CharFuncs.c:689: Test failed: [6] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [6] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:704: Test failed: [6] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEE
  CharFuncs.c:689: Test failed: [9] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [9] CharPrevW: pchW is 0xDEADBEED, expected 0x00000000
  CharFuncs.c:704: Test failed: [9] CharPrevA: pchA is 0x00000000, expected 0xDEADBEEE
  CharFuncs.c:689: Test failed: [10] CharPrevW: Status is 0x0, expected 0xC0000005
  CharFuncs.c:690: Test failed: [10] CharPrevW: pchW is 0xDEADBEEF, expected 0x00000000
  CharFuncs.c:704: Test failed: [10] CharPrevA: pchA is 0x00000000, expected 0xDEADBEF0
  
  CharFuncs: 259 tests executed (0 marked as todo, 12 failures), 0 skipped.
  ```
  
</details>