### PR TITLE
[NTGDI][FREETYPE] Optimize MatchFontNames

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5150,22 +5150,17 @@ IntFontType(PFONTGDI Font)
 }
 
 static BOOL
-MatchFontName(PSHARED_FACE SharedFace, LPCWSTR lfFaceName, FT_UShort NameID, FT_UShort LangID)
+MatchFontName(PSHARED_FACE SharedFace, PUNICODE_STRING Name1, FT_UShort NameID, FT_UShort LangID)
 {
     NTSTATUS Status;
-    UNICODE_STRING Name1, Name2;
-
-    if (lfFaceName[0] == UNICODE_NULL)
-        return FALSE;
-
-    RtlInitUnicodeString(&Name1, lfFaceName);
+    UNICODE_STRING Name2;
 
     RtlInitUnicodeString(&Name2, NULL);
     Status = IntGetFontLocalizedName(&Name2, SharedFace, NameID, LangID);
 
     if (NT_SUCCESS(Status))
     {
-        if (RtlCompareUnicodeString(&Name1, &Name2, TRUE) == 0)
+        if (RtlCompareUnicodeString(Name1, &Name2, TRUE) == 0)
         {
             RtlFreeUnicodeString(&Name2);
             return TRUE;
@@ -5180,15 +5175,22 @@ MatchFontName(PSHARED_FACE SharedFace, LPCWSTR lfFaceName, FT_UShort NameID, FT_
 static BOOL
 MatchFontNames(PSHARED_FACE SharedFace, LPCWSTR lfFaceName)
 {
-    if (MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FONT_FAMILY, LANG_ENGLISH) ||
-        MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FULL_NAME, LANG_ENGLISH))
+    UNICODE_STRING Name1;
+
+    if (lfFaceName[0] == UNICODE_NULL)
+        return FALSE;
+
+    RtlInitUnicodeString(&Name1, lfFaceName);
+
+    if (MatchFontName(SharedFace, &Name1, TT_NAME_ID_FONT_FAMILY, LANG_ENGLISH) ||
+        MatchFontName(SharedFace, &Name1, TT_NAME_ID_FULL_NAME, LANG_ENGLISH))
     {
         return TRUE;
     }
     if (PRIMARYLANGID(gusLanguageID) != LANG_ENGLISH)
     {
-        if (MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FONT_FAMILY, gusLanguageID) ||
-            MatchFontName(SharedFace, lfFaceName, TT_NAME_ID_FULL_NAME, gusLanguageID))
+        if (MatchFontName(SharedFace, &Name1, TT_NAME_ID_FONT_FAMILY, gusLanguageID) ||
+            MatchFontName(SharedFace, &Name1, TT_NAME_ID_FULL_NAME, gusLanguageID))
         {
             return TRUE;
         }


### PR DESCRIPTION
## Purpose

Optimize for speed.

JIRA issue: [CORE-15554](https://jira.reactos.org/browse/CORE-15554)

## Proposed changes

- Optimize `MatchFontNames` helper function for speed.

## TODO

- [x] Do big tests.