### PR TITLE
[NTGDI][FREETYPE] Reduce font size request

### DIFF
--- a/win32ss/gdi/eng/engobjects.h
+++ b/win32ss/gdi/eng/engobjects.h
@@ -161,6 +161,8 @@ typedef struct _FONTGDI {
   LONG          tmInternalLeading;
   LONG          EmHeight;
   LONG          Magic;
+  LONG          lfWidth;
+  LONG          lfHeight;
 } FONTGDI, *PFONTGDI;
 
 /* The initialized 'Magic' value in FONTGDI */

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -1067,9 +1067,6 @@ IntLoadSystemFonts(VOID)
     }
 }
 
-static FT_Error
-IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight);
-
 /* NOTE: If nIndex < 0 then return the number of charsets. */
 UINT FASTCALL IntGetCharSet(INT nIndex, FT_ULong CodePageRange1)
 {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5093,6 +5093,10 @@ FindBestFontFromList(FONTOBJ **FontObj, ULONG *MatchPenalty,
         /* update FontObj if lowest penalty */
         if (Otm)
         {
+            IntLockFreeType();
+            IntRequestFontSize(NULL, FontGDI, LogFont->lfWidth, LogFont->lfHeight);
+            IntUnLockFreeType();
+
             OtmSize = IntGetOutlineTextMetrics(FontGDI, OtmSize, Otm);
             if (!OtmSize)
                 continue;


### PR DESCRIPTION
## Purpose
Optimize for speed.
JIRA issue: [CORE-15554](https://jira.reactos.org/browse/CORE-15554)

## Proposed changes

- Delete some `IntRequestFontSize` function calls.
- Enable cache on font size requests.
- Add two members into `FONTGDI` structure, for font size cache.

## TODO

- [x] Do big tests.