### PR TITLE
[SHELL32] Implement IsLFNDriveA/W and improve PathResolve

### DIFF
--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -625,11 +625,13 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
 
 #define MSDOS_8DOT3_LEN 12 /* MS-DOS 8.3 == length 12 */
 
-    /* I don't want to return FALSE if GetVolumeInformationW fails. See below */
-    cchMaxFileName = MSDOS_8DOT3_LEN + 1;
-
     /* GetVolumeInformation requires a root path */
-    GetVolumeInformationW(szRoot, NULL, 0, NULL, &cchMaxFileName, NULL, NULL, 0);
+    if (!GetVolumeInformationW(szRoot, NULL, 0, NULL, &cchMaxFileName, NULL, NULL, 0))
+    {
+        /* I don't want to return FALSE if GetVolumeInformationW fails. See below */
+        cchMaxFileName = MSDOS_8DOT3_LEN + 1;
+    }
+
     return cchMaxFileName > MSDOS_8DOT3_LEN;
 }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -260,14 +260,14 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
 
             if (pchSlash)
             {
-                *(pchSlash + 1) = UNICODE_NULL;
+                *(pchSlash + 1) = UNICODE_NULL; /* Cut off */
                 pchTemp += pchSlash - pszPath;
                 cchPathLeft -= (INT)(SIZE_T)(pchSlash - pszPath) + 1;
             }
             else
             {
                 bLFN = TRUE;
-                pszPath[2] = UNICODE_NULL;
+                pszPath[2] = UNICODE_NULL; /* Cut off */
                 cchPathLeft -= 2;
                 pchTemp += 2;
             }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -268,7 +268,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
             {
                 bLFN = TRUE;
                 pszPath[2] = UNICODE_NULL;
-                cchPathLeft -= 3;
+                cchPathLeft -= 2;
                 pchTemp += 2;
             }
         }

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -538,9 +538,14 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
         }
     }
 
-    cchMaxFileName = 13;
+#define MSDOS_8DOT3_LEN 12 /* MS-DOS 8.3 == length 12 */
+
+    /* I don't want to return FALSE if GetVolumeInformationW fails. See below */
+    cchMaxFileName = MSDOS_8DOT3_LEN + 1;
+
+    /* GetVolumeInformation requires a root path */
     GetVolumeInformationW(szRoot, NULL, 0, NULL, &cchMaxFileName, NULL, NULL, 0);
-    return cchMaxFileName > 12; /* MS-DOS 8.3 == length 12 */
+    return cchMaxFileName > MSDOS_8DOT3_LEN;
 }
 
 /*************************************************************************

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -632,8 +632,8 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
     /* GetVolumeInformation requires a root path */
     if (!GetVolumeInformationW(szRoot, NULL, 0, NULL, &cchMaxFileName, NULL, NULL, 0))
     {
-        /* I don't want to return FALSE if GetVolumeInformationW fails. See below */
-        cchMaxFileName = MSDOS_8DOT3_LEN + 1;
+        /* Don't return FALSE when GetVolumeInformationW fails. */
+        return TRUE;
     }
 
     return cchMaxFileName > MSDOS_8DOT3_LEN;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -40,6 +40,7 @@
 #include <strsafe.h>
 #include <wine/debug.h>
 #include <wine/unicode.h>
+#include <assert.h>
 
 #include <shlwapi_undoc.h>
 #include <shellutils.h>
@@ -106,6 +107,7 @@ DoGetProductType(PNT_PRODUCT_TYPE ProductType)
 BOOL APIENTRY IsRemovableDrive(DWORD iDrive)
 {
     WCHAR szRoot[] = L"C:\\";
+    assert(L'A' + iDrive <= L'Z');
     szRoot[0] = (WCHAR)(L'A' + iDrive);
     return GetDriveTypeW(szRoot) == DRIVE_REMOVABLE;
 }
@@ -612,8 +614,10 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
 
         StringCchCatW(szRoot, _countof(szRoot), L"\\"); /* Add a backslash */
     }
-    else /* Assuming absolute path... */
+    else
     {
+        assert(!PathIsRelativeW(lpszPath)); /* Assuming absolute path... */
+
         iDrive = ((lpszPath[0] - L'A') & 0x1F);
         PathBuildRootW(szRoot, iDrive);
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -623,7 +623,7 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
         }
     }
 
-#define MSDOS_8DOT3_LEN 12 /* MS-DOS 8.3 == length 12 */
+#define MSDOS_8DOT3_LEN 12 /* MS-DOS 8.3 filename == length 12 */
 
     /* GetVolumeInformation requires a root path */
     if (!GetVolumeInformationW(szRoot, NULL, 0, NULL, &cchMaxFileName, NULL, NULL, 0))

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -334,7 +334,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
             {
                 if (*pchTemp == L'.')
                 {
-                    pchDot = pchTemp;
+                    pchDot = pchTemp; /* Remember the last position */
 
                     /* Clear szDotExtension */
                     cchDotExtension = 0;
@@ -345,8 +345,6 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                 {
                     if (cchDotExtension < 1 + 3)
                         szDotExtension[cchDotExtension++] = *pchTemp;
-                    else
-                        break;
                 }
                 else
                 {
@@ -354,7 +352,6 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
                         szTitle[cchTitle++] = *pchTemp;
                 }
 
-                ++cchTitle;
                 ++pchTemp;
             }
 

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -252,7 +252,7 @@ PathQualifyExW(_Inout_ LPWSTR pszPath, _Inout_opt_ LPCWSTR pszDir, _In_ DWORD dw
         }
         else
         {
-            PWCHAR pchSlash = StrChrW(&pszPath[2], L'\\');
+            PWCHAR pchSlash = StrChrW(pszPath + 2, L'\\');
             if (pchSlash)
                 pchSlash = StrChrW(pchSlash + 1, L'\\');
 
@@ -607,7 +607,7 @@ BOOL WINAPI IsLFNDriveW(LPCWSTR lpszPath)
         StringCchCopyW(szRoot, _countof(szRoot), lpszPath);
         PathStripToRootW(szRoot);
 
-        if (StrChrW(&szRoot[2], TEXT('\\')) == NULL)
+        if (StrChrW(szRoot + 2, L'\\') == NULL)
             return TRUE; /* LFN */
 
         StringCchCatW(szRoot, _countof(szRoot), L"\\"); /* Add a backslash */


### PR DESCRIPTION
## Purpose

#4850 had implemented `PathResolve` function. Actually, Windows `PathResolve` uses `IsLFNDriveW` function. Now `IsLFNDriveW` is fixed.
JIRA issue: [CORE-11335](https://jira.reactos.org/browse/CORE-11335)

## Proposed changes

- Fix `IsLFNDriveA` and `IsLFNDriveW` functions.
- Add `IsRemovableDrive` helper function.
- Fix `PathQualifyExW` by using `IsLFNDriveW`.

## TODO

- [x] Do small tests.