### PR TITLE
[SHELL32] Show 'comments' column for folders, make it rightmost CORE-18615

### DIFF
--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -530,8 +530,8 @@ static const shvheader GenericSFHeader[] = {
     {IDS_SHV_COLUMN_TYPE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10},
     {IDS_SHV_COLUMN_SIZE, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_RIGHT, 10},
     {IDS_SHV_COLUMN_MODIFIED, SHCOLSTATE_TYPE_DATE | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 12},
-    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 0},
-    {IDS_SHV_COLUMN_ATTRIBUTES, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10}
+    {IDS_SHV_COLUMN_ATTRIBUTES, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 10},
+    {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR, LVCFMT_LEFT, 10}
 };
 
 #define GENERICSHELLVIEWCOLUMNS 6
@@ -987,11 +987,11 @@ HRESULT WINAPI CFSFolder::CompareIDs(LPARAM lParam,
             if (result == 0)
                 result = pData1->u.file.uFileTime - pData2->u.file.uFileTime;
             break;
-        case 4: /* Comments */
+        case 4: /* Attributes */
+            return SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
+        case 5: /* Comments */
             result = 0;
             break;
-        case 5: /* Attributes */
-            return SHELL32_CompareDetails(this, lParam, pidl1, pidl2);
     }
 
     if (result == 0)
@@ -1541,11 +1541,11 @@ HRESULT WINAPI CFSFolder::GetDetailsOf(PCUITEMID_CHILD pidl,
             case 3:                /* date */
                 _ILGetFileDate(pidl, psd->str.cStr, MAX_PATH);
                 break;
-            case 4:                /* FIXME: comments */
-                psd->str.cStr[0] = 0;
-                break;
-            case 5:                /* attributes */
+            case 4:                /* attributes */
                 _ILGetFileAttributes(pidl, psd->str.cStr, MAX_PATH);
+                break;
+            case 5:                /* FIXME: comments */
+                psd->str.cStr[0] = 0;
                 break;
         }
     }


### PR DESCRIPTION

In explorer filebrowser 'details' view
the column 'comments' had invalid length of zero, and therefore was hidden under the 'attributes' column.

I guess even after this patch, it will not display any sane contents in there yet.
Therefore I chose a small width of 10 only, to reduce the chance for it to trigger an undesired horizontal scrollbar.

JIRA issue: [CORE-18615](https://jira.reactos.org/browse/CORE-18615)

As far as I see we don't support manual showing and hiding of additional columns.
By default my Windows does not show this column. But when activated manually, it is always
shown on the right hand side of the Atributes column.

For a video of the patched state, check the JIRA ticket.