### PR TITLE
[WIN32SS] Do not use both VGA and graphic card driver at the same time

### DIFF
--- a/win32ss/drivers/displays/vga/objects/screen.c
+++ b/win32ss/drivers/displays/vga/objects/screen.c
@@ -139,7 +139,7 @@ BOOL InitVGA(PPDEV ppdev, BOOL bFirst)
 
     ppdev->sizeSurf.cx = 640;
     ppdev->sizeSurf.cy = 480;
-    ppdev->ModeNum = 12;
+    ppdev->ModeNum = 2;
 
     /* Set the mode that was requested */
     if (EngDeviceIoControl(ppdev->KMDriver,

--- a/win32ss/drivers/miniport/vga/vgamp.c
+++ b/win32ss/drivers/miniport/vga/vgamp.c
@@ -545,7 +545,7 @@ BOOLEAN  VGASetColorRegisters(IN PVIDEO_CLUT  ColorLookUpTable,
 BOOLEAN  VGASetCurrentMode(IN PVIDEO_MODE  RequestedMode,
                         OUT PSTATUS_BLOCK  StatusBlock)
 {
-  if(RequestedMode->RequestedMode == 12)
+  if(RequestedMode->RequestedMode == 2)
   {
     InitVGAMode();
     return TRUE;

--- a/win32ss/gdi/eng/device.c
+++ b/win32ss/gdi/eng/device.c
@@ -465,9 +465,9 @@ EngpRegisterGraphicsDevice(
     TRACE("EngpRegisterGraphicsDevice(%wZ)\n", pustrDeviceName);
 
     /* Allocate a GRAPHICS_DEVICE structure */
-    pGraphicsDevice = ExAllocatePoolWithTag(PagedPool,
-                                            sizeof(GRAPHICS_DEVICE),
-                                            GDITAG_GDEVICE);
+    pGraphicsDevice = ExAllocatePoolZero(PagedPool,
+                                         sizeof(GRAPHICS_DEVICE),
+                                         GDITAG_GDEVICE);
     if (!pGraphicsDevice)
     {
         ERR("ExAllocatePoolWithTag failed\n");
@@ -562,15 +562,6 @@ EngpRegisterGraphicsDevice(
                   pustrDescription->Buffer,
                   pustrDescription->Length);
     pGraphicsDevice->pwszDescription[pustrDescription->Length/sizeof(WCHAR)] = 0;
-
-    /* Initialize the pdevmodeInfo list */
-    pGraphicsDevice->pdevmodeInfo = NULL;
-
-    // FIXME: initialize state flags
-    pGraphicsDevice->StateFlags = 0;
-
-    /* Create the mode list */
-    pGraphicsDevice->pDevModeList = NULL;
 
     /* Lock loader */
     EngAcquireSemaphore(ghsemGraphicsDeviceList);

--- a/win32ss/user/ntuser/display.h
+++ b/win32ss/user/ntuser/display.h
@@ -1,0 +1,7 @@
+#pragma once
+
+extern BOOL gbBaseVideo;
+
+NTSTATUS
+NTAPI
+InitVideo(VOID);

--- a/win32ss/user/ntuser/ntuser.c
+++ b/win32ss/user/ntuser/ntuser.c
@@ -113,10 +113,6 @@ InitUserImpl(VOID)
 
 NTSTATUS
 NTAPI
-InitVideo(VOID);
-
-NTSTATUS
-NTAPI
 UserInitialize(VOID)
 {
     static const DWORD wPattern55AA[] = /* 32 bit aligned */

--- a/win32ss/win32kp.h
+++ b/win32ss/win32kp.h
@@ -67,6 +67,7 @@ typedef struct _DC *PDC;
 #include "user/ntuser/accelerator.h"
 #include "user/ntuser/hook.h"
 #include "user/ntuser/clipboard.h"
+#include "user/ntuser/display.h"
 #include "user/ntuser/winsta.h"
 #include "user/ntuser/msgqueue.h"
 #include "user/ntuser/desktop.h"


### PR DESCRIPTION
## Purpose

Prevent using both VGA driver and graphic card driver (vmx_svga.sys/bochsmp.sys/...) at the same time on the same card.
This will also prevent seeing two graphic cards (VGA + graphic card driver) in desk.cpl settings page.

JIRA issue: [CORE-18522](https://jira.reactos.org/browse/CORE-18522)

## Proposed changes

- When choosing the primary device, try to not select the VGA driver
- When using a graphic card driver, remove VGA driver from available drivers list so it is not used 
- When selecting VGA mode in freeldr, remove all drivers from available drivers list, except VGA one.

Also harmonize 640x480 mode index in VGA driver to 2, so it is the same value as in vga_new.