### PR TITLE
[SETUP][INF][MEDIA] Get rid of the last Ubuntu references CORE-18607

### DIFF
--- a/base/setup/lib/muifonts.h
+++ b/base/setup/lib/muifonts.h
@@ -122,7 +122,6 @@ MUI_SUBFONT HebrewFonts[] =
     { L"Times New Roman Greek,161",    L"Times New Roman,161" },
     { L"Times New Roman TUR,162",      L"Times New Roman,162" },
     { L"Tms Rmn",                L"Times New Roman" },
-    { L"Ubuntu",                 L"Tahoma" },
     { NULL, NULL }
 };
 
@@ -169,7 +168,6 @@ MUI_SUBFONT ChineseSimplifiedFonts[] =
     { L"Times New Roman TUR,162",      L"Times New Roman,162" },
     { L"Tms Rmn",                L"Times New Roman" },
     { L"Trebuchet MS",           L"Droid Sans Fallback" },
-    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { CSF_LocalName0,            L"Droid Sans Fallback" },
     { CSF_LocalName1,            L"Droid Sans Fallback" },
@@ -222,7 +220,6 @@ MUI_SUBFONT ChineseTraditionalFonts[] =
     { L"Times New Roman TUR,162",      L"Times New Roman,162" },
     { L"Tms Rmn",         L"Times New Roman" },
     { L"Trebuchet MS",    L"Droid Sans Fallback" },
-    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { CTF_LocalName0,     L"Droid Sans Fallback" },
     { CTF_LocalName1,     L"Droid Sans Fallback" },
@@ -273,7 +270,6 @@ MUI_SUBFONT JapaneseFonts[] =
     { L"Times New Roman TUR,162",      L"Times New Roman,162" },
     { L"Tms Rmn",         L"Times New Roman" },
     { L"Trebuchet MS",    L"Droid Sans Fallback" },
-    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { JF_LocalName0,      L"Droid Sans Fallback" },
     { JF_LocalName1,      L"Droid Sans Fallback" },
@@ -328,7 +324,6 @@ MUI_SUBFONT KoreanFonts[] =
     { L"Times New Roman TUR,162",      L"Times New Roman,162" },
     { L"Tms Rmn",         L"Times New Roman" },
     { L"Trebuchet MS",    L"Droid Sans Fallback" },
-    { L"Ubuntu",                 L"Droid Sans Fallback" },
     /* localized names */
     { KF_LocalName0,      L"Droid Sans Fallback" },
     { KF_LocalName1,      L"Droid Sans Fallback" },

--- a/media/inf/font.inf
+++ b/media/inf/font.inf
@@ -70,7 +70,6 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","MS Shell Dl
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Terminal",0x00000000,"Courier New"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Times",0x00000000,"Times New Roman"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Tms Rmn",0x00000000,"Times New Roman"
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Ubuntu",0x00000000,"Tahoma"
 
 [Font.CJK.Reg]
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Courier",0x00000000,"Courier New"
@@ -89,7 +88,6 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Terminal",0
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Times",0x00000000,"Times New Roman"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Tms Rmn",0x00000000,"Times New Roman"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Trebuchet MS",0x00000000,"Droid Sans Fallback"
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Ubuntu",0x00000000,"Droid Sans Fallback"
 
 [Font.Unicode.Reg]
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Courier",0x00000000,"Courier New"

--- a/media/themes/Blackshade/blackshade.msstyles/textfiles/LargeFontsNormal.INI
+++ b/media/themes/Blackshade/blackshade.msstyles/textfiles/LargeFontsNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Ubuntu, 9, Bold
+CaptionFont = Tahoma, 9, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Ubuntu, 9
+IconTitleFont = Tahoma, 9
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Ubuntu, 9
+MenuFont = Tahoma, 9
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Ubuntu, 9
+MsgBoxFont = Tahoma, 9
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Ubuntu, 9, Bold
+SmallCaptionFont = Tahoma, 9, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Ubuntu, 9
+StatusFont = Tahoma, 9
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -206,7 +206,7 @@ GradientRatio2 = 255
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 94 135 217
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\ExplorerBarHeaderBackground.bmp
 SizingMargins = 17, 1, 0, 0
 SizingType = Stretch
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -286,7 +286,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 240 243 251
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\NormalGroupHead.bmp
 SizingMargins = 3, 15, 3, 1
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -331,7 +331,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColor = 2 72 178
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\SpecialGroupHead.bmp
 SizingMargins = 3, 6, 5, 16
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -683,7 +683,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = ImageFile
 ContentMargins = 11, 2, 0, 5
 DefaultPaneSize = 0, 0, 178, 30
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 HotTracking = 48 112 208
 Imagecount = 1
 ImageFile = Normal\StartPanelMoreProgBackGround.BMP
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1011,7 +1011,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 TextColor = 255 255 255
 
 [TaskBar.BackgroundBottom]
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Blackshade/blackshade.msstyles/textfiles/NormalNormal.INI
+++ b/media/themes/Blackshade/blackshade.msstyles/textfiles/NormalNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Ubuntu, 8, Bold
+CaptionFont = Tahoma, 8, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Ubuntu, 8
+IconTitleFont = Tahoma, 8
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Ubuntu, 8
+MenuFont = Tahoma, 8
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Ubuntu, 8
+MsgBoxFont = Tahoma, 8
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Ubuntu, 8, Bold
+SmallCaptionFont = Tahoma, 8, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Ubuntu, 8
+StatusFont = Tahoma, 8
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Lautus/lautus.msstyles/textfiles/LargeFontsNormal.INI
+++ b/media/themes/Lautus/lautus.msstyles/textfiles/LargeFontsNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Ubuntu, 9, Bold
+CaptionFont = Tahoma, 9, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Ubuntu, 9
+IconTitleFont = Tahoma, 9
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Ubuntu, 9
+MenuFont = Tahoma, 9
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Ubuntu, 9
+MsgBoxFont = Tahoma, 9
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Ubuntu, 9, Bold
+SmallCaptionFont = Tahoma, 9, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Ubuntu, 9
+StatusFont = Tahoma, 9
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -206,7 +206,7 @@ GradientRatio2 = 255
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 94 135 217
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\ExplorerBarHeaderBackground.bmp
 SizingMargins = 17, 1, 0, 0
 SizingType = Stretch
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -286,7 +286,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 240 243 251
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\NormalGroupHead.bmp
 SizingMargins = 3, 15, 3, 1
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -331,7 +331,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColor = 2 72 178
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 ImageFile = Normal\SpecialGroupHead.bmp
 SizingMargins = 3, 6, 5, 16
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -683,7 +683,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = ImageFile
 ContentMargins = 11, 2, 0, 5
 DefaultPaneSize = 0, 0, 178, 30
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 HotTracking = 48 112 208
 Imagecount = 1
 ImageFile = Normal\StartPanelMoreProgBackGround.BMP
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 9
+FONT = Tahoma, 9
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1011,7 +1011,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 9, Bold
+Font = Tahoma, 9, Bold
 TextColor = 255 255 255
 
 [TaskBar.BackgroundBottom]
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Ubuntu, 9
+Font = Tahoma, 9
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 9
+Font = Tahoma, 9
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Lautus/lautus.msstyles/textfiles/NormalNormal.INI
+++ b/media/themes/Lautus/lautus.msstyles/textfiles/NormalNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Ubuntu, 8, Bold
+CaptionFont = Tahoma, 8, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Ubuntu, 8
+IconTitleFont = Tahoma, 8
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Ubuntu, 8
+MenuFont = Tahoma, 8
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Ubuntu, 8
+MsgBoxFont = Tahoma, 8
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Ubuntu, 8, Bold
+SmallCaptionFont = Tahoma, 8, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Ubuntu, 8
+StatusFont = Tahoma, 8
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/ExtraLargeDark.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 12
+MenuFont = Tahoma, 12
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 12, Bold
+CaptionFont = Tahoma, 12, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 12
-IconTitleFont = Ubuntu, 12
-SmallCaptionFont = Ubuntu, 12, Bold
+MsgBoxFont = Tahoma, 12
+IconTitleFont = Tahoma, 12
+SmallCaptionFont = Tahoma, 12, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 12
+StatusFont = Tahoma, 12
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 12, Bold
+Font = Tahoma, 12, Bold
 Imagecount = 1
 ImageFile = Dark\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Dark\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 12, Bold
+Font = Tahoma, 12, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Dark\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/LargeFontsDark.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 10
+MenuFont = Tahoma, 10
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 10, Bold
+CaptionFont = Tahoma, 10, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 10
-IconTitleFont = Ubuntu, 10
-SmallCaptionFont = Ubuntu, 10, Bold
+MsgBoxFont = Tahoma, 10
+IconTitleFont = Tahoma, 10
+SmallCaptionFont = Tahoma, 10, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 10
+StatusFont = Tahoma, 10
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 10, Bold
+Font = Tahoma, 10, Bold
 Imagecount = 1
 ImageFile = Dark\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Dark\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 10, Bold
+Font = Tahoma, 10, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Dark\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Dark/RegularDark.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Dark/RegularDark.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 8
+MenuFont = Tahoma, 8
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 8, Bold
+CaptionFont = Tahoma, 8, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 8
-IconTitleFont = Ubuntu, 8
-SmallCaptionFont = Ubuntu, 8, Bold
+MsgBoxFont = Tahoma, 8
+IconTitleFont = Tahoma, 8
+SmallCaptionFont = Tahoma, 8, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 8
+StatusFont = Tahoma, 8
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 Imagecount = 1
 ImageFile = Dark\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Dark\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Dark\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Light/ExtraLargeLight.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Light/ExtraLargeLight.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 12
+MenuFont = Tahoma, 12
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 12, Bold
+CaptionFont = Tahoma, 12, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 12
-IconTitleFont = Ubuntu, 12
-SmallCaptionFont = Ubuntu, 12, Bold
+MsgBoxFont = Tahoma, 12
+IconTitleFont = Tahoma, 12
+SmallCaptionFont = Tahoma, 12, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 12
+StatusFont = Tahoma, 12
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 12, Bold
+Font = Tahoma, 12, Bold
 Imagecount = 1
 ImageFile = Light\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Light\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 12, Bold
+Font = Tahoma, 12, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 12
+Font = Tahoma, 12
 ImageFile = Light\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 12
+Font = Tahoma, 12
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Light/LargeFontsLight.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Light/LargeFontsLight.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 10
+MenuFont = Tahoma, 10
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 10, Bold
+CaptionFont = Tahoma, 10, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 10
-IconTitleFont = Ubuntu, 10
-SmallCaptionFont = Ubuntu, 10, Bold
+MsgBoxFont = Tahoma, 10
+IconTitleFont = Tahoma, 10
+SmallCaptionFont = Tahoma, 10, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 10
+StatusFont = Tahoma, 10
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 10, Bold
+Font = Tahoma, 10, Bold
 Imagecount = 1
 ImageFile = Light\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Light\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 10, Bold
+Font = Tahoma, 10, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 10
+Font = Tahoma, 10
 ImageFile = Light\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 10
+Font = Tahoma, 10
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Modern/modern.msstyles/textfiles/Light/RegularLight.INI
+++ b/media/themes/Modern/modern.msstyles/textfiles/Light/RegularLight.INI
@@ -40,7 +40,7 @@ Light3d = 241 239 226
 
 Menu = 255 255 255
 MenuBar = 220 220 220
-MenuFont = Ubuntu, 8
+MenuFont = Tahoma, 8
 MenuHilight = 151 169 227
 MenuText = 75 75 75
 
@@ -51,14 +51,14 @@ Window = 255 255 255
 
 ; DONT REMOVE THESE FONTS (must specify to be localizable)
 CaptionBarHeight = 25
-CaptionFont = Ubuntu, 8, Bold
+CaptionFont = Tahoma, 8, Bold
 CaptionText = 28 28 28
-MsgBoxFont = Ubuntu, 8
-IconTitleFont = Ubuntu, 8
-SmallCaptionFont = Ubuntu, 8, Bold
+MsgBoxFont = Tahoma, 8
+IconTitleFont = Tahoma, 8
+SmallCaptionFont = Tahoma, 8, Bold
 SMCaptionBarHeight = 17
 SMCaptionBarWidth = 17
-StatusFont = Ubuntu, 8
+StatusFont = Tahoma, 8
 
 ;The FlatMenus option allows the author to
 ;turn of the 3d border on menus
@@ -86,7 +86,7 @@ BorderColorHint = 0 60 116; Edge color
 Bgtype = imagefile
 ContentMargins = 3, 3, 3, 3; Average fill color
 FillColorHint = 243 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\button.bmp
 ImageCount = 5
 ImageLayout = vertical
@@ -300,7 +300,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -345,7 +345,7 @@ Transparent = True
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -478,7 +478,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -840,7 +840,7 @@ TransparentColor = 255 0 255
 BgType = none
 DefaultPaneSize = 0, 0, 380, 64
 FillColorHint = 31 113 216
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 Imagecount = 1
 ImageFile = Light\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -929,7 +929,7 @@ MinDpi2 = 164
 StockImageFile = Light\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 
 ;The content area of a tab page
@@ -954,7 +954,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -972,7 +972,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -990,7 +990,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1008,7 +1008,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1026,7 +1026,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1044,7 +1044,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1066,7 +1066,7 @@ TextShadowType = Single
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
 TextColor = 112 112 112
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60; Rollover hilite color
@@ -1080,7 +1080,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 Transparent = True
 TransparentColor = 255 0 255
-FONT = Ubuntu, 8
+FONT = Tahoma, 8
 TextColor = 112 112 112
 TextShadowColor =255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1116,7 +1116,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Ubuntu, 8, Bold
+Font = Tahoma, 8, Bold
 TextColor =255 255 255
 
 ; taskbar background (bottom)
@@ -1825,7 +1825,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -2031,7 +2031,7 @@ AccentColorHint = 48 127 229; Left edge of More Programs menu
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255; Background of More Programs menu
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -2144,7 +2144,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 42 42 42
 TextShadowType = Single
 
@@ -2194,7 +2194,7 @@ AccentColorHint = 255 199 60; Menu top highlight color
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213; Average background color
-Font = Ubuntu, 8
+Font = Tahoma, 8
 ImageFile = Light\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2215,7 +2215,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 28 28 28
 
 [TaskBandVert::Toolbar.Button]
@@ -2242,7 +2242,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2301,7 +2301,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 28 28 28
 
 [TaskBar::Toolbar.Button]
@@ -2328,7 +2328,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2363,7 +2363,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Ubuntu, 8
+Font = Tahoma, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]


### PR DESCRIPTION
An addendum to 0.4.14-dev-20-g 2f4fb903b46207ab380365908401ded63752a108 because since then we don't have the Ubuntu font anymore.

The substitutes are also not needed any longer.
We can use Tahoma here without causing any change in the current rendering, because for all languages the former
Ubuntu substitutions did point either to Tahoma,
or to the same thing, that Tahoma atm points to
(for those language that do require additional glyphs).

This way we do not only get the substitutions closer to 2k3sp2, but will also simplify our maintenance and testing, because the same font is guaranteed to be used then for all themes: Classic, Blackshade, Modern and Lautus: The font which has the needed glyphs for that specific language.

E.g.
"FreeSans" for Hindi,
"Tahoma" for most Western languages, and
"Droid Sans Fallback" for Chinese and Japanese language.

JIRA issue: [CORE-18607](https://jira.reactos.org/browse/CORE-18607)
