### PR TITLE
[DISKPART] Fix help for multi-word command crashing.

### DIFF
--- a/base/system/diskpart/help.c
+++ b/base/system/diskpart/help.c
@@ -60,7 +60,7 @@ HelpCommand(
     {
         if (pCommand->cmd1 != NULL && pCommand->cmd2 == NULL && pCommand->cmd3 == NULL)
         {
-            if ((wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
+            if ((cmdptr->cmd1 != NULL && wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
                 (cmdptr->cmd2 != NULL) &&
                 (cmdptr->cmd3 == NULL) &&
                 (cmdptr->help != IDS_NONE))
@@ -72,8 +72,8 @@ HelpCommand(
         }
         else if (pCommand->cmd1 != NULL && pCommand->cmd2 != NULL && pCommand->cmd3 == NULL)
         {
-            if ((wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
-                (wcsicmp(pCommand->cmd2, cmdptr->cmd2) == 0) &&
+            if ((cmdptr->cmd1 != NULL && wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
+                (cmdptr->cmd2 != NULL && wcsicmp(pCommand->cmd2, cmdptr->cmd2) == 0) &&
                 (cmdptr->cmd3 != NULL) &&
                 (cmdptr->help != IDS_NONE))
             {
@@ -84,9 +84,9 @@ HelpCommand(
         }
         else if (pCommand->cmd1 != NULL && pCommand->cmd2 != NULL && pCommand->cmd3 != NULL)
         {
-            if ((wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
-                (wcsicmp(pCommand->cmd2, cmdptr->cmd2) == 0) &&
-                (wcsicmp(pCommand->cmd3, cmdptr->cmd3) == 0) &&
+            if ((cmdptr->cmd1 != NULL && wcsicmp(pCommand->cmd1, cmdptr->cmd1) == 0) &&
+                (cmdptr->cmd2 != NULL && wcsicmp(pCommand->cmd2, cmdptr->cmd2) == 0) &&
+                (cmdptr->cmd3 != NULL && wcsicmp(pCommand->cmd3, cmdptr->cmd3) == 0) &&
                 (cmdptr->help_detail != MSG_NONE))
             {
                 ConMsgPuts(StdOut,
@@ -133,22 +133,30 @@ BOOL help_main(INT argc, LPWSTR *argv)
     /* Scan internal command table */
     for (cmdptr = cmds; cmdptr->cmd1; cmdptr++)
     {
+    
+    
         if ((cmdptr1 == NULL) &&
-            (wcsicmp(argv[1], cmdptr->cmd1) == 0))
+            (cmdptr->cmd1 != NULL && wcsicmp(argv[1], cmdptr->cmd1) == 0))
+        {
             cmdptr1 = cmdptr;
+        }
 
         if ((cmdptr2 == NULL) &&
             (argc >= 3) &&
-            (wcsicmp(argv[1], cmdptr->cmd1) == 0) &&
-            (wcsicmp(argv[2], cmdptr->cmd2) == 0))
+            (cmdptr->cmd1 != NULL && wcsicmp(argv[1], cmdptr->cmd1) == 0) &&
+            (cmdptr->cmd2 != NULL && wcsicmp(argv[2], cmdptr->cmd2) == 0))
+        {
             cmdptr2 = cmdptr;
-
+        }
+        
         if ((cmdptr3 == NULL) &&
             (argc >= 4) &&
-            (wcsicmp(argv[1], cmdptr->cmd1) == 0) &&
-            (wcsicmp(argv[2], cmdptr->cmd2) == 0) &&
-            (wcsicmp(argv[3], cmdptr->cmd3) == 0))
+            (cmdptr->cmd1 != NULL && wcsicmp(argv[1], cmdptr->cmd1) == 0) &&
+            (cmdptr->cmd2 != NULL && wcsicmp(argv[2], cmdptr->cmd2) == 0) &&
+            (cmdptr->cmd3 != NULL && wcsicmp(argv[3], cmdptr->cmd3) == 0))
+        {
             cmdptr3 = cmdptr;
+        }
     }
 
     if (cmdptr3 != NULL)

--- a/base/system/diskpart/help.c
+++ b/base/system/diskpart/help.c
@@ -133,8 +133,6 @@ BOOL help_main(INT argc, LPWSTR *argv)
     /* Scan internal command table */
     for (cmdptr = cmds; cmdptr->cmd1; cmdptr++)
     {
-    
-    
         if ((cmdptr1 == NULL) &&
             (cmdptr->cmd1 != NULL && wcsicmp(argv[1], cmdptr->cmd1) == 0))
         {


### PR DESCRIPTION
## Purpose

When the HELP command is executed for a multi-word command, for example "HELP CREATE PARTITION PRIMARY", diskpart crashes. This happens because before the desired form of the command is encountered, its single word form is found (in case of this example - "CREATE") - since the first word of the command matches the one HELP is looking for, it tries to compare the second word of the input command with the second (nonexistent) word of the encountered single word command, which is NULL. This results in diskpart crashing.

## Proposed changes

This fix makes HELP check if the to-be-compared word is not NULL before calling wcsicmp.


