### PR TITLE
[NTUSER][USER32] Classic Theme: disabled "checked" checkboxes should be grey

### DIFF
--- a/win32ss/user/ntuser/draw.c
+++ b/win32ss/user/ntuser/draw.c
@@ -743,7 +743,7 @@ BOOL FASTCALL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL
     {
         WCHAR Check = (Radio) ? 'i' : 'b';
 
-        IntGdiSetTextColor(dc, IntGetSysColor(COLOR_WINDOWTEXT));
+        IntGdiSetTextColor(dc, IntGetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
         GreTextOutW(dc, myr.left, myr.top, &Check, 1);
     }
 

--- a/win32ss/user/ntuser/draw.c
+++ b/win32ss/user/ntuser/draw.c
@@ -743,7 +743,7 @@ BOOL FASTCALL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL
     {
         WCHAR Check = (Radio) ? 'i' : 'b';
 
-        IntGdiSetTextColor(dc, IntGetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_GRAYTEXT : COLOR_WINDOWTEXT));
+        IntGdiSetTextColor(dc, IntGetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
         GreTextOutW(dc, myr.left, myr.top, &Check, 1);
     }
 

--- a/win32ss/user/ntuser/draw.c
+++ b/win32ss/user/ntuser/draw.c
@@ -743,7 +743,7 @@ BOOL FASTCALL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL
     {
         WCHAR Check = (Radio) ? 'i' : 'b';
 
-        IntGdiSetTextColor(dc, IntGetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
+        IntGdiSetTextColor(dc, IntGetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_GRAYTEXT : COLOR_WINDOWTEXT));
         GreTextOutW(dc, myr.left, myr.top, &Check, 1);
     }
 

--- a/win32ss/user/user32/windows/draw.c
+++ b/win32ss/user/user32/windows/draw.c
@@ -759,7 +759,7 @@ static BOOL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL R
         {
             TCHAR Check = (Radio) ? 'i' : 'b';
 
-            SetTextColor(dc, GetSysColor(COLOR_WINDOWTEXT));
+            SetTextColor(dc, GetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
             TextOut(dc, X, Y, &Check, 1);
         }
     }

--- a/win32ss/user/user32/windows/draw.c
+++ b/win32ss/user/user32/windows/draw.c
@@ -759,7 +759,7 @@ static BOOL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL R
         {
             TCHAR Check = (Radio) ? 'i' : 'b';
 
-            SetTextColor(dc, GetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_GRAYTEXT : COLOR_WINDOWTEXT));
+            SetTextColor(dc, GetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
             TextOut(dc, X, Y, &Check, 1);
         }
     }

--- a/win32ss/user/user32/windows/draw.c
+++ b/win32ss/user/user32/windows/draw.c
@@ -759,7 +759,7 @@ static BOOL UITOOLS95_DFC_ButtonCheckRadio(HDC dc, LPRECT r, UINT uFlags, BOOL R
         {
             TCHAR Check = (Radio) ? 'i' : 'b';
 
-            SetTextColor(dc, GetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_BTNSHADOW : COLOR_WINDOWTEXT));
+            SetTextColor(dc, GetSysColor((uFlags & DFCS_INACTIVE) ? COLOR_GRAYTEXT : COLOR_WINDOWTEXT));
             TextOut(dc, X, Y, &Check, 1);
         }
     }


### PR DESCRIPTION
… CORE-18609

and not black, like they erroneously were.
This patch does not seem to have any impact on how they are rendered for themed ros.

patch by @Krosuser2
JIRA issue: [CORE-18609](https://jira.reactos.org/browse/CORE-18609)

see screenshots of my own tests before + after for themed and unthemed here:
https://jira.reactos.org/browse/CORE-18609?focusedCommentId=136705&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-136705
Also ran a botrun upfront, results linked in there as well.