### PR TITLE
[IMM32] Introduce 'security' code

### DIFF
--- a/dll/win32/imm32/ime.c
+++ b/dll/win32/imm32/ime.c
@@ -266,7 +266,7 @@ Failed:
 // Win: LoadImeDpi
 PIMEDPI APIENTRY Imm32LoadImeDpi(HKL hKL, BOOL bLock)
 {
-    IMM_SECURITY_BEGIN();
+    STACK_CHECK_BEGIN();
     IMEINFOEX ImeInfoEx;
     CHARSETINFO ci;
     PIMEDPI pImeDpiNew, pImeDpiFound;
@@ -341,7 +341,7 @@ PIMEDPI APIENTRY Imm32LoadImeDpi(HKL hKL, BOOL bLock)
     }
 
 Finish:
-    IMM_SECURITY_END();
+    STACK_CHECK_END();
     return ret;
 }
 
@@ -885,14 +885,14 @@ Quit:
  */
 BOOL WINAPI ImmIsIME(HKL hKL)
 {
-    IMM_SECURITY_BEGIN();
+    STACK_CHECK_BEGIN();
     BOOL ret;
     IMEINFOEX info;
 
     TRACE("(%p)\n", hKL);
     ret = !!ImmGetImeInfoEx(&info, ImeInfoExKeyboardLayoutTFS, &hKL);
 
-    IMM_SECURITY_END();
+    STACK_CHECK_END();
     return ret;
 }
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1350,7 +1350,7 @@ VOID FASTCALL __security_check_cookie(DWORD_PTR ecx)
 #ifndef NDEBUG
     DebugBreak();
 #endif
-    TerminateProcess(GetCurrentProcess(), 0xC0000409); // STATUS_STACK_BUFFER_OVERRUN
+    TerminateProcess(GetCurrentProcess(), STATUS_STACK_BUFFER_OVERRUN);
 }
 #endif /* def IMM_SECURITY */
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1310,9 +1310,9 @@ BOOL WINAPI ImmSetActiveContextConsoleIME(HWND hwnd, BOOL fFlag)
 }
 
 /************************************************************************/
-/* IMM_SECURITY */
+/* STACK_CHECK */
 
-#ifdef IMM_SECURITY
+#ifdef STACK_CHECK
 
 DWORD_PTR __security_cookie = 0x0000BB40;
 DWORD_PTR __security_cookie_complement = 0xFFFF44BF;
@@ -1371,7 +1371,7 @@ VOID FASTCALL __security_check_cookie(DWORD_PTR ecx)
 #endif
     TerminateProcess(GetCurrentProcess(), STATUS_STACK_BUFFER_OVERRUN);
 }
-#endif /* def IMM_SECURITY */
+#endif /* def STACK_CHECK */
 
 /************************************************************************/
 /* Unit test */
@@ -1417,7 +1417,7 @@ ImmDllInitialize(
     switch (dwReason)
     {
         case DLL_PROCESS_ATTACH:
-#ifdef IMM_SECURITY
+#ifdef STACK_CHECK
             Imm32InitSecurity(hDll, TRUE);
 #endif
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -67,7 +67,7 @@ BOOL WINAPI ImmRegisterClient(PSHAREDINFO ptr, HINSTANCE hMod)
  */
 BOOL WINAPI ImmLoadLayout(HKL hKL, PIMEINFOEX pImeInfoEx)
 {
-    IMM_SECURITY_BEGIN();
+    STACK_CHECK_BEGIN();
     DWORD cbData, dwType;
     HKEY hLayoutKey;
     LONG error;
@@ -116,7 +116,7 @@ BOOL WINAPI ImmLoadLayout(HKL hKL, PIMEINFOEX pImeInfoEx)
     ret = Imm32LoadImeVerInfo(pImeInfoEx);
 
 Finish:
-    IMM_SECURITY_END();
+    STACK_CHECK_END();
     return ret;
 }
 
@@ -125,7 +125,7 @@ Finish:
  */
 BOOL WINAPI ImmFreeLayout(DWORD dwUnknown)
 {
-    IMM_SECURITY_BEGIN();
+    STACK_CHECK_BEGIN();
     WCHAR szKBD[KL_NAMELENGTH];
     UINT iKL, cKLs;
     HKL hOldKL, hNewKL, *pList;
@@ -193,7 +193,7 @@ Retry:
     }
 
 Finish:
-    IMM_SECURITY_END();
+    STACK_CHECK_END();
     return ret;
 }
 

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1342,6 +1342,11 @@ static VOID Imm32InitSecurity(HINSTANCE hDll, BOOL bInitCookie)
         Imm32GenerateSecurityCookie();
 }
 
+DWORD_PTR FASTCALL __security_check_cookie(DWORD_PTR eax)
+{
+    /* FIXME */
+    return eax;
+}
 #endif /* def IMM_SECURITY */
 
 /************************************************************************/

--- a/dll/win32/imm32/imm.c
+++ b/dll/win32/imm32/imm.c
@@ -1342,6 +1342,12 @@ static VOID Imm32InitSecurity(HINSTANCE hDll, BOOL bInitCookie)
         Imm32GenerateSecurityCookie();
 }
 
+/*
+ * This function detects stack corruption.
+ *
+ * The parameter of this function must be a variable that saved the __security_cookie value
+ * in caller's prologue.
+ */
 VOID FASTCALL __security_check_cookie(DWORD_PTR ecx)
 {
     if (ecx == __security_cookie && (ecx & 0xFFFF0000) == 0)

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -12,8 +12,6 @@
 
 #pragma once
 
-#undef IMM_SECURITY
-
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -192,7 +190,9 @@ PTHREADINFO FASTCALL Imm32CurrentPti(VOID);
 HBITMAP Imm32LoadBitmapFromBytes(const BYTE *pb);
 BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
 
-#ifdef IMM_SECURITY
+#undef STACK_CHECK
+
+#ifdef STACK_CHECK
     extern DWORD_PTR __security_cookie;
     VOID FASTCALL __security_check_cookie(DWORD_PTR ecx);
 

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -194,8 +194,12 @@ BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
 
 #ifdef IMM_SECURITY
 extern DWORD_PTR __security_cookie;
-extern DWORD_PTR __security_cookie_complement;
 VOID FASTCALL __security_check_cookie(DWORD_PTR ecx);
+#define IMM_SECURITY_BEGIN()    DWORD_PTR SecurityCookieSaved = __security_cookie
+#define IMM_SECURITY_END()      __security_check_cookie(SecurityCookieSaved)
+#else
+#define IMM_SECURITY_BEGIN()    /* empty */
+#define IMM_SECURITY_END()      /* empty */
 #endif
 
 #ifndef NDEBUG

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -193,9 +193,9 @@ HBITMAP Imm32LoadBitmapFromBytes(const BYTE *pb);
 BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
 
 #ifdef IMM_SECURITY
-extern DWORD __security_cookie;
-extern DWORD __security_cookie_complement;
-DWORD_PTR FASTCALL __security_check_cookie(DWORD_PTR eax);
+extern DWORD_PTR __security_cookie;
+extern DWORD_PTR __security_cookie_complement;
+VOID FASTCALL __security_check_cookie(DWORD_PTR ecx);
 #endif
 
 #ifndef NDEBUG

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -195,6 +195,7 @@ BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
 #ifdef IMM_SECURITY
 extern DWORD __security_cookie;
 extern DWORD __security_cookie_complement;
+DWORD_PTR FASTCALL __security_check_cookie(DWORD_PTR eax);
 #endif
 
 #ifndef NDEBUG

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -193,17 +193,18 @@ HBITMAP Imm32LoadBitmapFromBytes(const BYTE *pb);
 BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
 
 #ifdef IMM_SECURITY
-extern DWORD_PTR __security_cookie;
-VOID FASTCALL __security_check_cookie(DWORD_PTR ecx);
-#define IMM_SECURITY_BEGIN()    DWORD_PTR SecurityCookieSaved = __security_cookie
-#define IMM_SECURITY_END()      __security_check_cookie(SecurityCookieSaved)
+    extern DWORD_PTR __security_cookie;
+    VOID FASTCALL __security_check_cookie(DWORD_PTR ecx);
+
+    #define STACK_CHECK_BEGIN()     DWORD_PTR SecurityCookieSaved = __security_cookie
+    #define STACK_CHECK_END()       __security_check_cookie(SecurityCookieSaved)
 #else
-#define IMM_SECURITY_BEGIN()    /* empty */
-#define IMM_SECURITY_END()      /* empty */
+    #define STACK_CHECK_BEGIN()     /* empty */
+    #define STACK_CHECK_END()       /* empty */
 #endif
 
 #ifndef NDEBUG
-VOID APIENTRY Imm32UnitTest(VOID);
+    VOID APIENTRY Imm32UnitTest(VOID);
 #else
-#define Imm32UnitTest() /* empty */
+    #define Imm32UnitTest() /* empty */
 #endif

--- a/dll/win32/imm32/precomp.h
+++ b/dll/win32/imm32/precomp.h
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#undef IMM_SECURITY
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -189,3 +191,14 @@ PTHREADINFO FASTCALL Imm32CurrentPti(VOID);
 
 HBITMAP Imm32LoadBitmapFromBytes(const BYTE *pb);
 BOOL Imm32StoreBitmapToBytes(HBITMAP hbm, LPBYTE pbData, DWORD cbDataMax);
+
+#ifdef IMM_SECURITY
+extern DWORD __security_cookie;
+extern DWORD __security_cookie_complement;
+#endif
+
+#ifndef NDEBUG
+VOID APIENTRY Imm32UnitTest(VOID);
+#else
+#define Imm32UnitTest() /* empty */
+#endif


### PR DESCRIPTION
## Purpose
Add 'security' code for future use.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `Imm32InitSecurity` and `Imm32GenerateSecurityCookie` helper functions.
- Add `__security_cookie` and `__security_cookie_complement` global variables.
- Add `__security_check_cookie` function to detect stack corruption.

## TODO

- [x] Do small tests.
