### PR TITLE
[DOCS] Update contributing rules and PR management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,14 +64,12 @@ Our commit style is defined in a __[commit template]__. Use it as a reference or
 ### Rules and Recommendations
 
 - *Use your __real name__ and __real email__.* We do not accept anonymous code contributions!
-  - Every commit that changes the code or translations should have author's full legal name (in latin letters, diacritics allowed) with real e-mail address.
-  - Same applies to the author's GitHub profile:
-  1. It should have full name set (in the [Name field here][GitHub Profile Settings]) that matches one specified in the commits.
-  1. In the [e-mail settings][GitHub Email Settings] the checkbox "Keep my email addresses private" must be unchecked.
-- There is an exception for media changes, such as changes of the art (wallpapers, themes, icons, sounds) and out-of-code documentation. In these specific cases it's allowed to use a nickname or alias. Few rules still apply here:
-  1. Artist must have an alias set (in the [Name field here][GitHub Profile Settings]) and it should match one specified in the commits.
-  1. Real e-mail address is still required, so the checkbox "Keep my email addresses private" must be unchecked in the [e-mail settings][GitHub Email Settings].
-- In order to *keep your privacy*, select appropriate "Primary email address" that will be applied to your commits in GitHub [e-mail settings][GitHub Email Settings].
+  - Every commit that changes the code or translations should have author's full legal name (in latin letters, diacritics allowed).
+  - Same applies to the author's GitHub profile, it should have full name set (in the [Name field here][GitHub Profile Settings]) that matches one specified in the commits.
+- There is an exception for media changes, such as changes of the art (wallpapers, themes, icons, sounds) and out-of-code documentation.
+  - In these specific cases it's allowed to use a nickname or alias, however the artist name (in the [Name field here][GitHub Profile Settings]) should match one specified in the commits.
+- In any case the author must use a real e-mail address, this includes git commits (`user.email` setting) and GitHub [e-mail settings][GitHub Email Settings] - the checkbox "Keep my email addresses private" must be unchecked there.
+  - In order to *keep your privacy*, select appropriate "Primary email address" that will be applied to your commits in GitHub [e-mail settings][GitHub Email Settings].
 - *Ensure your contribution is properly described.* Include the relevant issue number if applicable.
 - *Put only related changes.* It will make reviewing easier as the reviewer needs to recall less information about the existing source code that is changed.
 - *Search for similar pull requests/patches before submitting.* It may be that a similar pull request or issue was opened previously. Comment and review on that one instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,10 @@ Our commit style is defined in a __[commit template]__. Use it as a reference or
 ### Rules and Recommendations
 
 - *Use your __real name__ and __real email__.* We do not accept anonymous code contributions!
-  - Every commit that changes the code or translations should have author's full legal name (in latin letters, diacritics allowed).
-  - Same applies to the author's GitHub profile, it should have full name set (in the [Name field here][GitHub Profile Settings]) that matches one specified in the commits.
-- There is an exception for media changes, such as changes of the art (wallpapers, themes, icons, sounds) and out-of-code documentation.
-  - In these specific cases it's allowed to use a nickname or alias, however the artist name (in the [Name field here][GitHub Profile Settings]) should match one specified in the commits.
+  - Every commit that changes code or translations should have author's full legal name (in latin letters, diacritics allowed).
+  - It's recommended to have the same full name set in GitHub profile (in the [Name field here][GitHub Profile Settings]) that matches one specified in commits.
+- There is an exception for media changes, such as changes of art (wallpapers, themes, icons, sounds) and out-of-code documentation.
+  - In these specific cases it's allowed to use a nickname or alias as author's name, and it's recommended to have the same name set in GitHub profile (in the [Name field here][GitHub Profile Settings]) matching one specified in commits.
 - In any case the author must use a real e-mail address, this includes git commits (`user.email` setting) and GitHub [e-mail settings][GitHub Email Settings] - the checkbox "Keep my email addresses private" must be unchecked there.
   - In order to *keep your privacy*, select appropriate "Primary email address" that will be applied to your commits in GitHub [e-mail settings][GitHub Email Settings].
 - *Ensure your contribution is properly described.* Include the relevant issue number if applicable.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,12 +64,16 @@ Our commit style is defined in a __[commit template]__. Use it as a reference or
 ### Rules and Recommendations
 
 - *Use your __real name__ and __real email__.* We do not accept anonymous contributions!
+  - Every commit should have author's full legal name (in latin letters, diacritics allowed) with real e-mail address.
+  - Same applies to the author's GitHub profile:
+  1. It should have full name set (in the [Name field here](https://github.com/settings/profile)) that matches one specified in the commits.
+  1. In the [e-mail settings](https://github.com/settings/emails) the checkbox "Keep my email addresses private" must be unchecked.
 - *Ensure your contribution is properly described.* Include the relevant issue number if applicable.
 - *Put only related changes.* It will make reviewing easier as the reviewer needs to recall less information about the existing source code that is changed.
 - *Search for similar pull requests/patches before submitting.* It may be that a similar pull request or issue was opened previously. Comment and review on that one instead.
 - *Keep your contribution small and focused on the topic.* It can be tempting to fix existing issues as you come across them while reading the source code. Resist the temptation and put in a note in the source code instead, or (even better) put the issue in the issue tracking system.
 - *Respect our __[Coding Style]__ and __[Programming Guidelines]__.*
-- *Do not be afraid to ask questions.* Ask our developers on JIRA or [IRC] channel.
+- *Do not be afraid to ask questions.* Ask our developers in the [chat].
 
 To amend your commit with your name and e-mail (in any case you've forgot to set your name/e-mail) please take a look at this [guide](https://reactos.org/wiki/ReactOS_Git_For_Dummies#Amending_your_commit_with_name.2FE-mail). To set your name/e-mail globally for future commits that you push, [read this](https://reactos.org/wiki/ReactOS_Git_For_Dummies#Assign_commits_with_your_name_.26_E-mail_automatically).
 
@@ -79,7 +83,7 @@ Finding a good project to start with can be a challenge, because when starting o
 
 - Find a test that fails, and try to make it succeed: <https://reactos.org/testman/>
 - Look around in JIRA, and if you have problems finding nice projects to start with, there is a label for this: <https://jira.reactos.org/issues/?jql=labels%20%3D%20starter-project>
-- Ask for help on [IRC]
+- Ask for help in the [chat]
 - Additionally, there are some tests that cause crashes/hangs, but these might be slightly harder: <https://jira.reactos.org/browse/ROSTESTS-125>
 
   [clean room reverse engineering]:                              https://en.wikipedia.org/wiki/Clean_room_design
@@ -95,7 +99,7 @@ Finding a good project to start with can be a challenge, because when starting o
   [patch]:                                                       https://git-scm.com/docs/git-format-patch
   [Submitting Patches]:                                          https://reactos.org/wiki/Submitting_Patches
   [Coding Style]:                                                https://reactos.org/wiki/Coding_Style
-  [IRC]:                                                         https://reactos.org/wiki/Connect_to_the_ReactOS_IRC_Channels
+  [chat]:                                                        https://reactos.org/wiki/Mattermost
   [Programming Guidelines]:                                      https://reactos.org/wiki/Programming_Guidelines
   [3rd Party Files.txt]:                                         /media/doc/3rd_Party_Files.txt
   [README.WINE]:                                                 /media/doc/README.WINE

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,11 +63,15 @@ Our commit style is defined in a __[commit template]__. Use it as a reference or
 
 ### Rules and Recommendations
 
-- *Use your __real name__ and __real email__.* We do not accept anonymous contributions!
-  - Every commit should have author's full legal name (in latin letters, diacritics allowed) with real e-mail address.
+- *Use your __real name__ and __real email__.* We do not accept anonymous code contributions!
+  - Every commit that changes the code or translations should have author's full legal name (in latin letters, diacritics allowed) with real e-mail address.
   - Same applies to the author's GitHub profile:
-  1. It should have full name set (in the [Name field here](https://github.com/settings/profile)) that matches one specified in the commits.
-  1. In the [e-mail settings](https://github.com/settings/emails) the checkbox "Keep my email addresses private" must be unchecked.
+  1. It should have full name set (in the [Name field here][GitHub Profile Settings]) that matches one specified in the commits.
+  1. In the [e-mail settings][GitHub Email Settings] the checkbox "Keep my email addresses private" must be unchecked.
+- There is an exception for media changes, such as changes of the art (wallpapers, themes, icons, sounds) and out-of-code documentation. In these specific cases it's allowed to use a nickname or alias. Few rules still apply here:
+  1. Artist must have an alias set (in the [Name field here][GitHub Profile Settings]) and it should match one specified in the commits.
+  1. Real e-mail address is still required, so the checkbox "Keep my email addresses private" must be unchecked in the [e-mail settings][GitHub Email Settings].
+- In order to *keep your privacy*, select appropriate "Primary email address" that will be applied to your commits in GitHub [e-mail settings][GitHub Email Settings].
 - *Ensure your contribution is properly described.* Include the relevant issue number if applicable.
 - *Put only related changes.* It will make reviewing easier as the reviewer needs to recall less information about the existing source code that is changed.
 - *Search for similar pull requests/patches before submitting.* It may be that a similar pull request or issue was opened previously. Comment and review on that one instead.
@@ -94,6 +98,8 @@ Finding a good project to start with can be a challenge, because when starting o
   [migration to GitHub]:                                         https://reactos.org/project-news/reactos-repository-migrated-github/
   [humans are terrible at tracking large amount of information]: https://www.eurekalert.org/pub_releases/2005-03/aps-hmc030805.php
   [Pull requests]:                                               https://help.github.com/articles/about-pull-requests/
+  [GitHub Profile Settings]:                                     https://github.com/settings/profile
+  [GitHub Email Settings]:                                       https://github.com/settings/emails
   [tips for reviewing patches]:                                  https://www.drupal.org/patch/review
   [missing functionality]:                                       https://reactos.org/wiki/Missing_ReactOS_Functionality
   [patch]:                                                       https://git-scm.com/docs/git-format-patch

--- a/PULL_REQUEST_MANAGEMENT.md
+++ b/PULL_REQUEST_MANAGEMENT.md
@@ -17,11 +17,12 @@ In addition, in order to avoid coming off as rude to helpful contributors, pleas
 
 Before merging a PR, make sure it follows the [contributing rules](CONTRIBUTING.md#rules-and-recommendations), but more importantly:
 - If PR contains the code or translations:
-  - Make sure the author does not use a nickname or alias, but a full legal name instead, and have specified a real e-mail in all PR commits
-  - Make sure the author does have full name set in GitHub profile that matches one in commits
+  - Make sure the author have not specified a nickname or alias, but a full legal name in all PR commits
+  - Make sure the author have the same full name set in GitHub profile that matches one in commits
 - If PR contains the media (wallpapers, themes, icons, sounds) or out-of-code documentation:
-  - Make sure the author uses the name or alias, and have specified a real e-mail in all PR commits
-  - Make sure the author does have the same name or alias set in GitHub profile that matches one in commits
+  - Make sure the author have specified the name or alias in all PR commits
+  - Make sure the author have the same name or alias set in GitHub profile that matches one in commits
 - If PR contains mixed code with media changes, handle it as PR with code
+- Make sure the author have specified a real e-mail in all PR commits
 - By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
   under the commit message there will be a text label saying: `This commit will be authored by <address@email.com>`

--- a/PULL_REQUEST_MANAGEMENT.md
+++ b/PULL_REQUEST_MANAGEMENT.md
@@ -14,3 +14,9 @@ In addition, in order to avoid coming off as rude to helpful contributors, pleas
 - Asking the contributor to do unrelated work
 - Closing without providing a reason
 - Merging with the intention to rewrite that code soon after
+
+Before merging a PR, make sure it follows the [contributing rules](CONTRIBUTING.md#rules-and-recommendations), but more importantly:
+- Make sure the author does not use a nickname or alias, but a full legal name instead, and have specified a real e-mail in all PR commits
+- Make sure the author does have full name set in GitHub profile that matches one in commits
+- By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
+  under the commit message there will be a text label saying: `This commit will be authored by <address@email.com>`

--- a/PULL_REQUEST_MANAGEMENT.md
+++ b/PULL_REQUEST_MANAGEMENT.md
@@ -17,12 +17,12 @@ In addition, in order to avoid coming off as rude to helpful contributors, pleas
 
 Before merging a PR, make sure it follows the [contributing rules](CONTRIBUTING.md#rules-and-recommendations), but more importantly:
 - If PR contains the code or translations:
-  - Make sure the author have not specified a nickname or alias, but a full legal name in all PR commits
-  - Make sure the author have the same full name set in GitHub profile that matches one in commits
+  - Make sure the author has not specified a nickname or alias, but a full legal name in all PR commits
+  - Make sure the author has the same full name set in GitHub profile that matches one in commits
 - If PR contains the media (wallpapers, themes, icons, sounds) or out-of-code documentation:
-  - Make sure the author have specified the name or alias in all PR commits
-  - Make sure the author have the same name or alias set in GitHub profile that matches one in commits
+  - Make sure the author has specified the name or alias in all PR commits
+  - Make sure the author has the same name or alias set in GitHub profile that matches one in commits
 - If PR contains mixed code with media changes, handle it as PR with code
-- Make sure the author have specified a real e-mail in all PR commits
+- Make sure the author has specified a real e-mail in all PR commits
 - By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
   under the commit message there will be a text label saying: `This commit will be authored by <address@email.com>`

--- a/PULL_REQUEST_MANAGEMENT.md
+++ b/PULL_REQUEST_MANAGEMENT.md
@@ -16,13 +16,15 @@ In addition, in order to avoid coming off as rude to helpful contributors, pleas
 - Merging with the intention to rewrite that code soon after
 
 Before merging a PR, make sure it follows the [contributing rules](CONTRIBUTING.md#rules-and-recommendations), but more importantly:
-- If PR contains the code or translations:
-  - Make sure the author has not specified a nickname or alias, but a full legal name in all PR commits
-  - Make sure the author has the same full name set in GitHub profile that matches one in commits
-- If PR contains the media (wallpapers, themes, icons, sounds) or out-of-code documentation:
-  - Make sure the author has specified the name or alias in all PR commits
-  - Make sure the author has the same name or alias set in GitHub profile that matches one in commits
-- If PR contains mixed code with media changes, handle it as PR with code
 - Make sure the author has specified a real e-mail in all PR commits
-- By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
+- If PR contains code or translations, make sure the author has not specified a nickname or alias, but a full legal name in all PR commits
+- If PR contains media (wallpapers, themes, icons, sounds) or out-of-code documentation, make sure the author has specified the name or alias in all PR commits
+- If PR contains mixed code with media changes, handle it as PR with code
+- Important notes before using "Squash and merge" strategy on a PR:
+  - Make sure the author's name in GitHub profile matches one in commits. If this is not the case, ask the author to set it accordingly.
+  - If the author does not want to set the name in GitHub profile:
+    - "no squash merge" label needs to be added to a PR.
+	- Make sure every commit message is formatted correctly as in [.gitmessage](https://github.com/reactos/reactos/blob/master/.gitmessage).
+	- Finally in this case a PR has to be merged either using "Rebase and merge" strategy or manually.
+  - By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
   under the commit message there will be a text label saying: `This commit will be authored by <address@email.com>`

--- a/PULL_REQUEST_MANAGEMENT.md
+++ b/PULL_REQUEST_MANAGEMENT.md
@@ -16,7 +16,12 @@ In addition, in order to avoid coming off as rude to helpful contributors, pleas
 - Merging with the intention to rewrite that code soon after
 
 Before merging a PR, make sure it follows the [contributing rules](CONTRIBUTING.md#rules-and-recommendations), but more importantly:
-- Make sure the author does not use a nickname or alias, but a full legal name instead, and have specified a real e-mail in all PR commits
-- Make sure the author does have full name set in GitHub profile that matches one in commits
+- If PR contains the code or translations:
+  - Make sure the author does not use a nickname or alias, but a full legal name instead, and have specified a real e-mail in all PR commits
+  - Make sure the author does have full name set in GitHub profile that matches one in commits
+- If PR contains the media (wallpapers, themes, icons, sounds) or out-of-code documentation:
+  - Make sure the author uses the name or alias, and have specified a real e-mail in all PR commits
+  - Make sure the author does have the same name or alias set in GitHub profile that matches one in commits
+- If PR contains mixed code with media changes, handle it as PR with code
 - By pressing "Squash and merge" button in a PR you can make sure the author does not use no-reply e-mail -
   under the commit message there will be a text label saying: `This commit will be authored by <address@email.com>`


### PR DESCRIPTION
This PR is a result of discussion (links: [one](https://chat.reactos.org/reactos/pl/s1xsp4b1s38o9kx3dc41fy871e), [two](https://chat.reactos.org/reactos/pl/da3ozt58k3bnukpj96ip9n119a)) in the chat with @JoachimHenze and @ThFabba regarding noreply e-mails being used by some GitHub contributors.

It has been experimentally verified that using anonymous GitHub e-mail does not allow to deliver mail to the commit author. GitHub does replace author's real email when `Keep my email addresses private` option is enabled in the account's e-mail settings.

Additionally I have replaced old IRC links with the references to our chat.

Please approve if you are okay with the changes I made in this PR. Suggestions are also welcome.