### PR TITLE
[BOOTDATA][NTUSER] Add UserIsIMMEnabled and use it

### DIFF
--- a/boot/bootdata/hivesft.inf
+++ b/boot/bootdata/hivesft.inf
@@ -512,7 +512,7 @@ HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontMapper",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\HotFix",,0x00000012
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IME Compatibility",,0x00000012
 
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,0
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadIMM",0x00010003,1
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\IMM","LoadCTFIME",0x00010003,0
 
 ; DOS Device ports

--- a/win32ss/gdi/ntgdi/misc.h
+++ b/win32ss/gdi/ntgdi/misc.h
@@ -54,6 +54,10 @@ BOOL
 NTAPI
 RegReadDWORD(HKEY hkey, PWSTR pwszValue, PDWORD pdwData);
 
+DWORD
+NTAPI
+RegGetSectionDWORD(LPCWSTR pszSection, LPWSTR pszValue, DWORD dwDefault);
+
 VOID FASTCALL
 SetLastNtError(
   NTSTATUS Status);

--- a/win32ss/user/ntuser/ime.c
+++ b/win32ss/user/ntuser/ime.c
@@ -562,7 +562,7 @@ DWORD FASTCALL UserBuildHimcList(PTHREADINFO pti, DWORD dwCount, HIMC *phList)
     }
     else
     {
-        for (pti = GetW32ThreadInfo()->ppi->ptiList; pti; pti = pti->ptiSibling)
+        for (pti = gptiCurrent->ppi->ptiList; pti; pti = pti->ptiSibling)
         {
             for (pIMC = pti->spDefaultImc; pIMC; pIMC = pIMC->pImcNext)
             {
@@ -716,7 +716,7 @@ NtUserBuildHimcList(DWORD dwThreadId, DWORD dwCount, HIMC *phList, LPDWORD pdwCo
 
     if (dwThreadId == 0)
     {
-        pti = GetW32ThreadInfo();
+        pti = gptiCurrent;
     }
     else if (dwThreadId == INVALID_THREAD_ID)
     {

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -14,6 +14,16 @@ static BOOL Setup = FALSE;
 
 /* FUNCTIONS *****************************************************************/
 
+BOOL UserIsIMMEnabled(VOID)
+{
+    WCHAR szLoadIMM[] = L"LoadIMM";
+
+    if (NLS_MB_CODE_PAGE_TAG)
+        return TRUE;
+
+    return !!RegGetSectionDWORD(L"IMM", szLoadIMM, TRUE);
+}
+
 BOOL
 NTAPI
 InitMetrics(VOID)
@@ -169,12 +179,13 @@ InitMetrics(VOID)
     piSysMet[90] = 0;
 #endif
 
-    /*gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED;*/ /* Cicero is not supported yet */
-
     if (NLS_MB_CODE_PAGE_TAG) /* Is the system multi-byte codepage? */
-    {
-        gpsi->dwSRVIFlags |= (SRVINFO_DBCSENABLED | SRVINFO_IMM32); /* DBCS+IME Support */
-    }
+        gpsi->dwSRVIFlags |= SRVINFO_DBCSENABLED; /* DBCS Support */
+
+    if (UserIsIMMEnabled())
+        gpsi->dwSRVIFlags |= SRVINFO_IMM32; /* IME Support */
+
+    /*gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED;*/ /* Cicero is not supported yet */
 
     Setup = TRUE;
 

--- a/win32ss/user/ntuser/metric.c
+++ b/win32ss/user/ntuser/metric.c
@@ -14,14 +14,24 @@ static BOOL Setup = FALSE;
 
 /* FUNCTIONS *****************************************************************/
 
-BOOL UserIsIMMEnabled(VOID)
+BOOL FASTCALL UserIsDBCSEnabled(VOID)
 {
-    WCHAR szLoadIMM[] = L"LoadIMM";
+    return NLS_MB_CODE_PAGE_TAG;
+}
+
+BOOL FASTCALL UserIsIMMEnabled(VOID)
+{
+    static WCHAR s_szLoadIMM[] = L"LoadIMM";
 
     if (NLS_MB_CODE_PAGE_TAG)
         return TRUE;
 
-    return !!RegGetSectionDWORD(L"IMM", szLoadIMM, TRUE);
+    return !!RegGetSectionDWORD(L"IMM", s_szLoadIMM, TRUE);
+}
+
+BOOL FASTCALL UserIsCiceroEnabled(VOID)
+{
+    return FALSE; /* FIXME: Cicero is not supported yet */
 }
 
 BOOL
@@ -179,13 +189,14 @@ InitMetrics(VOID)
     piSysMet[90] = 0;
 #endif
 
-    if (NLS_MB_CODE_PAGE_TAG) /* Is the system multi-byte codepage? */
+    if (UserIsDBCSEnabled())
         gpsi->dwSRVIFlags |= SRVINFO_DBCSENABLED; /* DBCS Support */
 
     if (UserIsIMMEnabled())
         gpsi->dwSRVIFlags |= SRVINFO_IMM32; /* IME Support */
 
-    /*gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED;*/ /* Cicero is not supported yet */
+    if (UserIsCiceroEnabled())
+        gpsi->dwSRVIFlags |= SRVINFO_CICERO_ENABLED; /* Cicero support */
 
     Setup = TRUE;
 

--- a/win32ss/user/ntuser/misc/registry.c
+++ b/win32ss/user/ntuser/misc/registry.c
@@ -155,6 +155,36 @@ RegReadDWORD(HKEY hkey, PWSTR pwszValue, PDWORD pdwData)
     return NT_SUCCESS(Status);
 }
 
+NTSTATUS
+NTAPI
+RegOpenSectionKey(
+    LPCWSTR pszSection,
+    PHKEY phkey)
+{
+    WCHAR szKey[MAX_PATH] =
+        L"\\Registry\\Machine\\Software\\Microsoft\\Windows NT\\CurrentVersion\\";
+
+    RtlStringCchCatW(szKey, _countof(szKey), pszSection);
+    return RegOpenKey(szKey, phkey);
+}
+
+DWORD
+NTAPI
+RegGetSectionDWORD(LPCWSTR pszSection, LPWSTR pszValue, DWORD dwDefault)
+{
+    HKEY hKey;
+    DWORD dwValue;
+
+    if (NT_ERROR(RegOpenSectionKey(pszSection, &hKey)))
+        return dwDefault;
+
+    if (!RegReadDWORD(hKey, pszValue, &dwValue))
+        dwValue = dwDefault;
+
+    ZwClose(hKey);
+    return dwValue;
+}
+
 _Success_(return!=FALSE)
 BOOL
 NTAPI

--- a/win32ss/user/ntuser/simplecall.c
+++ b/win32ss/user/ntuser/simplecall.c
@@ -124,16 +124,11 @@ NtUserCallNoParam(DWORD Routine)
             break;
 
         case NOPARAM_ROUTINE_UPDATEPERUSERIMMENABLING:
-            // TODO: This should also check the registry!
-            // see https://www.pctipsbox.com/fix-available-for-ie7-memory-leaks-on-xp-sp3/ for more information
-            if (NLS_MB_CODE_PAGE_TAG)
-            {
+            if (UserIsIMMEnabled())
                 gpsi->dwSRVIFlags |= SRVINFO_IMM32;
-            }
             else
-            {
                 gpsi->dwSRVIFlags &= ~SRVINFO_IMM32;
-            }
+
             Result = TRUE; // Always return TRUE.
             break;
 

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -83,7 +83,9 @@ NTSTATUS FASTCALL InitSessionImpl(VOID);
 
 BOOL NTAPI InitMetrics(VOID);
 LONG NTAPI UserGetSystemMetrics(ULONG Index);
-BOOL UserIsIMMEnabled(VOID);
+BOOL FASTCALL UserIsDBCSEnabled(VOID);
+BOOL FASTCALL UserIsIMMEnabled(VOID);
+BOOL FASTCALL UserIsCiceroEnabled(VOID);
 
 /*************** KEYBOARD.C ***************/
 

--- a/win32ss/user/ntuser/userfuncs.h
+++ b/win32ss/user/ntuser/userfuncs.h
@@ -83,6 +83,7 @@ NTSTATUS FASTCALL InitSessionImpl(VOID);
 
 BOOL NTAPI InitMetrics(VOID);
 LONG NTAPI UserGetSystemMetrics(ULONG Index);
+BOOL UserIsIMMEnabled(VOID);
 
 /*************** KEYBOARD.C ***************/
 


### PR DESCRIPTION
## Purpose
PR #4876 revealed the bug in `ImmEnumInputContext`. 
Fix `SRVINFO_IMM32` flag and `ImmEnumInputContext` testcase's results.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## NOTE 

This PR enables `SRVINFO_IMM32` also for non-CJK. You can disable this flag by setting zero to  the `LoadIMM` registry value if you're non-CJK.

## Proposed changes

- Fix the `LoadIMM` registry value.
- Add `RegOpenSectionKey` and `RegGetSectionDWORD` helper functions.
- Add `UserIsIMMEnabled` function by using helper funtions.
- Fix `SRVINFO_IMM32` flag status by using `UserIsIMMEnabled`.
- Fix `NOPARAM_ROUTINE_UPDATEPERUSERIMMENABLING` action by using `UserIsIMMEnabled`.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/201835852-0fb42e9b-eab6-4ab5-9987-f913f34007d3.png)
Failing.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/201835857-cc416256-710a-4ffd-bf0f-4124c4a67140.png)
Successful.