### PR TITLE
[COMCTL32] Remove a rosdiff TOOLBAR_EraseBackground()

### DIFF
--- a/dll/win32/comctl32/toolbar.c
+++ b/dll/win32/comctl32/toolbar.c
@@ -6603,10 +6603,6 @@ TOOLBAR_Paint (TOOLBAR_INFO *infoPtr, WPARAM wParam)
 
     TRACE("psrect=(%s)\n", wine_dbgstr_rect(&ps.rcPaint));
 
-#ifdef __REACTOS__
-    TOOLBAR_EraseBackground(infoPtr, (WPARAM)hdc, (LPARAM) 0);
-#endif
-
     TOOLBAR_Refresh (infoPtr, hdc, &ps);
     if (!wParam) EndPaint (infoPtr->hwndSelf, &ps);
 


### PR DESCRIPTION
This fixes the toolbar in FileZilla 3.8 being drawn wrong (grey) It regressed by 0.4.15-dev-1603-g 232c45fcd71b12a0d726b47f4a72e9a16f87432a

And todays fix is a partial revert of that guilty rev. The reverted part is not even necessarily needed for what we had in mind back then, it was just a first tiny step with the aim to get rid of the comctl32.h changes of that commit. But that goal was and even is far out of reach for many other reasons also. Actually we should have reverted the toolbar.c change back then already, before committing the "flipfix9".

Many thanks to JIRA user "julenuri" and "KrosUser" for their extensive testing.

JIRA issue: [CORE-18263](https://jira.reactos.org/browse/CORE-18263)

I could reproduce the issue with VBox4.3.12 with VBEMP graphics driver.
And do confirm the fixes effectiveness.
More retests in the wider context of the ancient flipfix9 were done by
Julenuri https://jira.reactos.org/browse/CORE-18263?focusedCommentId=136784&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-136784
and
KRosUser https://jira.reactos.org/browse/CORE-18263?focusedCommentId=136703&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-136703

We all 3 were very happy with the results.