### PR TITLE
[SHELL32] Prevent a second call to  Drive Properties Dialog

### DIFF
--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -842,7 +842,7 @@ CDefaultContextMenu::DoProperties(
     HRESULT hr = _DoCallback(DFM_INVOKECOMMAND, DFM_CMD_PROPERTIES, NULL);
 
     // We are asked to run the default property sheet
-    if (hr != S_FALSE)
+    if (hr == S_FALSE)
     {
         return Shell_DefaultContextMenuCallBack(m_psf, m_pDataObj);
     }

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -842,7 +842,7 @@ CDefaultContextMenu::DoProperties(
     HRESULT hr = _DoCallback(DFM_INVOKECOMMAND, DFM_CMD_PROPERTIES, NULL);
 
     // We are asked to run the default property sheet
-    if (hr == S_FALSE)
+    if (hr != S_FALSE)
     {
         return Shell_DefaultContextMenuCallBack(m_psf, m_pDataObj);
     }

--- a/dll/win32/shell32/dialogs/drive.cpp
+++ b/dll/win32/shell32/dialogs/drive.cpp
@@ -175,7 +175,7 @@ SH_ShowDriveProperties(WCHAR *pwszDrive, IDataObject *pDataObj)
 
     CDataObjectHIDA cida(pDataObj);
     if (FAILED_UNEXPECTEDLY(cida.hr()))
-        return cida.hr();
+        return FAILED(cida.hr());
 
     RECT rcPosition = {CW_USEDEFAULT, CW_USEDEFAULT, 0, 0};
     POINT pt;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -345,7 +345,7 @@ HRESULT CALLBACK DrivesContextMenuCallback(IShellFolder *psf,
         {
             // pdtobj should be valid at this point!
             ATLASSERT(pdtobj);
-            hr = SH_ShowDriveProperties(wszBuf, pdtobj);
+            hr = SH_ShowDriveProperties(wszBuf, pdtobj) ? 0 : (HRESULT)-1;
             if (FAILED(hr))
             {
                 dwError = ERROR_CAN_NOT_COMPLETE;

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -345,7 +345,7 @@ HRESULT CALLBACK DrivesContextMenuCallback(IShellFolder *psf,
         {
             // pdtobj should be valid at this point!
             ATLASSERT(pdtobj);
-            hr = SH_ShowDriveProperties(wszBuf, pdtobj) ? 0 : (HRESULT)-1;
+            hr = SH_ShowDriveProperties(wszBuf, pdtobj) ? S_OK : E_UNEXPECTED;
             if (FAILED(hr))
             {
                 dwError = ERROR_CAN_NOT_COMPLETE;


### PR DESCRIPTION
Clicking on the Properties item in the drives context menu will open two Drives Properties dialogs one after the other.

CDefaultContextMenu::DoProperties provides a fallback call to property sheet testing the return value of the _DoCallback method, which is ultimately the return value of SH_ShowDriveProperties(...).
_Do Callback returns 0 (on error) and 1(on success), S_FALSE is defined as 1. 

https://jira.reactos.org/browse/CORE-18613