### PR TITLE
[TASKMGR] Prevent context menu on idle process CORE-18640

### DIFF
--- a/base/applications/taskmgr/procpage.c
+++ b/base/applications/taskmgr/procpage.c
@@ -400,6 +400,10 @@ void ProcessPageShowContextMenu(DWORD dwProcessId)
     DWORD        dwDebuggerSize;
     HKEY         hKey;
 
+    if (dwProcessId == 0)
+    {
+        return;
+    }
     memset(&si, 0, sizeof(SYSTEM_INFO));
 
     GetCursorPos(&pt);

--- a/base/applications/taskmgr/procpage.c
+++ b/base/applications/taskmgr/procpage.c
@@ -401,9 +401,8 @@ void ProcessPageShowContextMenu(DWORD dwProcessId)
     HKEY         hKey;
 
     if (dwProcessId == 0)
-    {
         return;
-    }
+
     memset(&si, 0, sizeof(SYSTEM_INFO));
 
     GetCursorPos(&pt);


### PR DESCRIPTION
TaskMgr show context menu for all processes

In Win2K3, there is no context menu  on System Idle Process

JIRA issue: [CORE-18640](https://jira.reactos.org/browse/CORE-18640)