### PR TITLE
[NTOS:KD][KDBG] Rework the BootPhase >= 2 initialization of the KD/KDBG kernel debugger.

### DIFF
--- a/ntoskrnl/include/internal/kd.h
+++ b/ntoskrnl/include/internal/kd.h
@@ -39,7 +39,7 @@ typedef enum _KD_CONTINUE_TYPE
 } KD_CONTINUE_TYPE;
 
 typedef
-VOID
+NTSTATUS
 (NTAPI *PKDP_INIT_ROUTINE)(
     _In_ struct _KD_DISPATCH_TABLE *DispatchTable,
     _In_ ULONG BootPhase);
@@ -70,19 +70,19 @@ KdpScreenAcquire(VOID);
 VOID
 KdpScreenRelease(VOID);
 
-VOID
+NTSTATUS
 NTAPI
 KdpScreenInit(
     _In_ struct _KD_DISPATCH_TABLE *DispatchTable,
     _In_ ULONG BootPhase);
 
-VOID
+NTSTATUS
 NTAPI
 KdpSerialInit(
     _In_ struct _KD_DISPATCH_TABLE *DispatchTable,
     _In_ ULONG BootPhase);
 
-VOID
+NTSTATUS
 NTAPI
 KdpDebugLogInit(
     _In_ struct _KD_DISPATCH_TABLE *DispatchTable,
@@ -168,6 +168,7 @@ typedef struct _KD_DISPATCH_TABLE
     LIST_ENTRY KdProvidersList;
     PKDP_INIT_ROUTINE KdpInitRoutine;
     PKDP_PRINT_ROUTINE KdpPrintRoutine;
+    NTSTATUS InitStatus;
 } KD_DISPATCH_TABLE, *PKD_DISPATCH_TABLE;
 
 /* The current Debugging Mode */

--- a/ntoskrnl/io/iomgr/iomgr.c
+++ b/ntoskrnl/io/iomgr/iomgr.c
@@ -588,14 +588,6 @@ IoInitSystem(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
      * We can finally load other drivers from the boot volume. */
     PnPBootDriversInitialized = TRUE;
 
-#if !defined(_WINKD_) && defined(KDBG)
-    /* Read KDB Data */
-    KdbpCliInit();
-
-    /* I/O is now setup for disk access, so phase 3 */
-    KdInitSystem(3, LoaderBlock);
-#endif
-
     /* Load system start drivers */
     IopInitializeSystemDrivers();
     PnpSystemInit = TRUE;

--- a/ntoskrnl/kd/kdmain.c
+++ b/ntoskrnl/kd/kdmain.c
@@ -1,10 +1,10 @@
 /*
- * COPYRIGHT:       See COPYING in the top level directory
- * PROJECT:         ReactOS Kernel
- * FILE:            ntoskrnl/kd/kdmain.c
- * PURPOSE:         Kernel Debugger Initialization
- *
- * PROGRAMMERS:     Alex Ionescu (alex@relsoft.net)
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Kernel Debugger Initialization
+ * COPYRIGHT:   Copyright 2005 Alex Ionescu <alex.ionescu@reactos.org>
+ *              Copyright 2020 Hervé Poussineau <hpoussin@reactos.org>
+ *              Copyright 2023 Hermès Bélusca-Maïto <hermes.belusca-maito@reactos.org>
  */
 
 #include <ntoskrnl.h>
@@ -12,8 +12,6 @@
 #include <debug.h>
 
 /* VARIABLES ***************************************************************/
-
-VOID NTAPI PspDumpThreads(BOOLEAN SystemThreads);
 
 extern ANSI_STRING KdpLogFileName;
 
@@ -86,8 +84,9 @@ NTAPI
 KdDebuggerInitialize0(
     _In_opt_ PLOADER_PARAMETER_BLOCK LoaderBlock)
 {
-    ULONG i;
     PCHAR CommandLine, Port = NULL;
+    ULONG i;
+    BOOLEAN Success = FALSE;
 
     if (LoaderBlock)
     {
@@ -127,13 +126,172 @@ KdDebuggerInitialize0(
     if (KdpDebugMode.Value == 0)
         KdpDebugMode.Serial = TRUE;
 
-    /* Call Providers at Phase 0 */
-    for (i = 0; i < KdMax; i++)
+    /* Call the providers at Phase 0 */
+    for (i = 0; i < RTL_NUMBER_OF(DispatchTable); i++)
     {
-        InitRoutines[i](&DispatchTable[i], 0);
+        DispatchTable[i].InitStatus = InitRoutines[i](&DispatchTable[i], 0);
+        Success = (Success || NT_SUCCESS(DispatchTable[i].InitStatus));
     }
 
+    /* Return success if at least one of the providers succeeded */
+    return (Success ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL);
+}
+
+
+/**
+ * @brief   Reinitialization routine.
+ * DRIVER_REINITIALIZE
+ *
+ * Calls each registered provider for reinitialization at Phase >= 2.
+ * I/O is now set up for disk access, at different phases.
+ **/
+static VOID
+NTAPI
+KdpDriverReinit(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_opt_ PVOID Context,
+    _In_ ULONG Count)
+{
+    PLIST_ENTRY CurrentEntry;
+    PKD_DISPATCH_TABLE CurrentTable;
+    PKDP_INIT_ROUTINE KdpInitRoutine;
+    ULONG BootPhase = (Count + 1); // Do BootPhase >= 2
+    BOOLEAN ScheduleReinit = FALSE;
+
+    ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    DPRINT("*** KD %sREINITIALIZATION - Phase %d ***\n",
+           Context ? "" : "BOOT ", BootPhase);
+
+    /* Call the registered providers */
+    for (CurrentEntry = KdProviders.Flink;
+         CurrentEntry != &KdProviders; NOTHING)
+    {
+        /* Get the provider */
+        CurrentTable = CONTAINING_RECORD(CurrentEntry,
+                                         KD_DISPATCH_TABLE,
+                                         KdProvidersList);
+        /* Go to the next entry (the Init routine may unlink us) */
+        CurrentEntry = CurrentEntry->Flink;
+
+        /* Call it if it requires a reinitialization */
+        if (CurrentTable->KdpInitRoutine)
+        {
+            /* Get the initialization routine and reset it */
+            KdpInitRoutine = CurrentTable->KdpInitRoutine;
+            CurrentTable->KdpInitRoutine = NULL;
+            CurrentTable->InitStatus = KdpInitRoutine(CurrentTable, BootPhase);
+            DPRINT("KdpInitRoutine(%p) returned 0x%08lx\n",
+                   CurrentTable, CurrentTable->InitStatus);
+
+            /* Check whether it needs to be reinitialized again */
+            ScheduleReinit = (ScheduleReinit || CurrentTable->KdpInitRoutine);
+        }
+    }
+
+    DPRINT("ScheduleReinit: %s\n", ScheduleReinit ? "TRUE" : "FALSE");
+    if (ScheduleReinit)
+    {
+        /*
+         * Determine when to reinitialize.
+         * If Context == NULL, we are doing a boot-driver reinitialization.
+         * It is initially done once (Count == 1), and is rescheduled once
+         * after all other boot drivers get loaded (Count == 2).
+         * If further reinitialization is needed, switch to system-driver
+         * reinitialization and do it again, not more than twice.
+         */
+        if (Count <= 1)
+        {
+            IoRegisterBootDriverReinitialization(DriverObject,
+                                                 KdpDriverReinit,
+                                                 (PVOID)FALSE);
+        }
+        else if (Count <= 3)
+        {
+            IoRegisterDriverReinitialization(DriverObject,
+                                             KdpDriverReinit,
+                                             (PVOID)TRUE);
+        }
+        else
+        {
+            /* Too late, no more reinitializations! */
+            DPRINT("Cannot reinitialize anymore!\n");
+            ScheduleReinit = FALSE;
+        }
+    }
+
+    if (!ScheduleReinit)
+    {
+        /* All the necessary reinitializations are done,
+         * the driver object is not needed anymore. */
+        ObMakeTemporaryObject(DriverObject);
+        IoDeleteDriver(DriverObject);
+    }
+}
+
+/**
+ * @brief   Entry point for the auxiliary driver.
+ * DRIVER_INITIALIZE
+ **/
+static NTSTATUS
+NTAPI
+KdpDriverEntry(
+    _In_ PDRIVER_OBJECT DriverObject,
+    _In_ PUNICODE_STRING RegistryPath)
+{
+    UNREFERENCED_PARAMETER(RegistryPath);
+
+    /* Register for reinitialization after the other drivers are loaded */
+    IoRegisterBootDriverReinitialization(DriverObject,
+                                         KdpDriverReinit,
+                                         (PVOID)FALSE);
+
+    /* Set the driver as initialized */
+    DriverObject->Flags |= DRVO_INITIALIZED;
     return STATUS_SUCCESS;
+}
+
+/**
+ * @brief   Hooked HalInitPnpDriver() callback.
+ * It is initially set by the HAL when HalInitSystem(0, ...)
+ * is called earlier on.
+ **/
+static pHalInitPnpDriver orgHalInitPnpDriver = NULL;
+
+/**
+ * @brief
+ * HalInitPnpDriver() callback hook installed by KdDebuggerInitialize1().
+ *
+ * It is called during initialization of the I/O manager and is where
+ * the auxiliary driver is created. This driver is needed for receiving
+ * reinitialization callbacks in KdpDriverReinit() later.
+ * This hook must *always* call the original HalInitPnpDriver() function
+ * and return its returned value, or return STATUS_SUCCESS.
+ **/
+static NTSTATUS
+NTAPI
+KdpInitDriver(VOID)
+{
+    static BOOLEAN InitCalled = FALSE;
+    NTSTATUS Status;
+    UNICODE_STRING DriverName = RTL_CONSTANT_STRING(L"\\Driver\\KdDriver");
+
+    ASSERT(KeGetCurrentIrql() == PASSIVE_LEVEL);
+
+    /* Ensure we are not called more than once */
+    if (_InterlockedCompareExchange8((char*)&InitCalled, TRUE, FALSE) != FALSE)
+        return STATUS_SUCCESS;
+
+    /* Create the driver */
+    Status = IoCreateDriver(&DriverName, KdpDriverEntry);
+    if (!NT_SUCCESS(Status))
+        DPRINT1("IoCreateDriver failed: 0x%08lx\n", Status);
+    /* Ignore any failure from IoCreateDriver(). If it fails, no I/O-related
+     * initialization will happen (no file log debugging, etc.). */
+
+    /* Finally, restore and call the original HalInitPnpDriver() */
+    InterlockedExchangePointer((PVOID*)&HalInitPnpDriver, orgHalInitPnpDriver);
+    return (HalInitPnpDriver ? HalInitPnpDriver() : STATUS_SUCCESS);
 }
 
 NTSTATUS
@@ -143,26 +301,119 @@ KdDebuggerInitialize1(
 {
     PLIST_ENTRY CurrentEntry;
     PKD_DISPATCH_TABLE CurrentTable;
+    PKDP_INIT_ROUTINE KdpInitRoutine;
+    BOOLEAN Success = FALSE;
+    BOOLEAN ReinitForPhase2 = FALSE;
 
-    /* Call the registered handlers */
-    CurrentEntry = KdProviders.Flink;
-    while (CurrentEntry != &KdProviders)
+    /* Call the registered providers */
+    for (CurrentEntry = KdProviders.Flink;
+         CurrentEntry != &KdProviders; NOTHING)
     {
-        /* Get the current table */
+        /* Get the provider */
         CurrentTable = CONTAINING_RECORD(CurrentEntry,
                                          KD_DISPATCH_TABLE,
                                          KdProvidersList);
+        /* Go to the next entry (the Init routine may unlink us) */
+        CurrentEntry = CurrentEntry->Flink;
+
+        /* Get the initialization routine and reset it */
+        ASSERT(CurrentTable->KdpInitRoutine);
+        KdpInitRoutine = CurrentTable->KdpInitRoutine;
+        CurrentTable->KdpInitRoutine = NULL;
 
         /* Call it */
-        CurrentTable->KdpInitRoutine(CurrentTable, 1);
+        CurrentTable->InitStatus = KdpInitRoutine(CurrentTable, 1);
 
-        /* Next Table */
-        CurrentEntry = CurrentEntry->Flink;
+        /* Check whether it needs to be reinitialized for Phase 2 */
+        Success = (Success || NT_SUCCESS(CurrentTable->InitStatus));
+        ReinitForPhase2 = (ReinitForPhase2 || CurrentTable->KdpInitRoutine);
     }
 
     NtGlobalFlag |= FLG_STOP_ON_EXCEPTION;
 
+    /* If we don't need to reinitialize providers for Phase 2, we are done */
+    if (!ReinitForPhase2)
+    {
+        /* Return success if at least one of them succeeded */
+        return (Success ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL);
+    }
+
+    /**
+     * We want to be able to perform I/O-related initialization (starting a
+     * logger thread for file log debugging, loading KDBinit file for KDBG,
+     * etc.). A good place for this would be as early as possible, once the
+     * I/O Manager has started the storage and the boot filesystem drivers.
+     *
+     * Here is an overview of the initialization steps of the NT Kernel and
+     * Executive:
+     * ----
+     * KiSystemStartup(KeLoaderBlock)
+     *     if (Cpu == 0) KdInitSystem(0, KeLoaderBlock);
+     *     KiSwitchToBootStack() -> KiSystemStartupBootStack()
+     *     -> KiInitializeKernel() -> ExpInitializeExecutive(Cpu, KeLoaderBlock)
+     *
+     * (NOTE: Any unexpected debugger break will call KdInitSystem(0, NULL); )
+     * KdInitSystem(0, LoaderBlock) -> KdDebuggerInitialize0(LoaderBlock);
+     *
+     * ExpInitializeExecutive(Cpu == 0):    ExpInitializationPhase = 0;
+     *     HalInitSystem(0, KeLoaderBlock); <-- Sets HalInitPnpDriver callback.
+     *     ...
+     *     PsInitSystem(LoaderBlock)
+     *         PsCreateSystemThread(Phase1Initialization)
+     *
+     * Phase1Initialization(Discard):       ExpInitializationPhase = 1;
+     *     HalInitSystem(1, KeLoaderBlock);
+     *     ...
+     *     Early initialization of Ob, Ex, Ke.
+     *     KdInitSystem(1, KeLoaderBlock);
+     *     ...
+     *     KdDebuggerInitialize1(LoaderBlock);
+     *     ...
+     *     IoInitSystem(LoaderBlock);
+     *     ...
+     * ----
+     * As we can see, KdDebuggerInitialize1() is the last KD initialization
+     * routine the kernel calls, and is called *before* the I/O Manager starts.
+     * Thus, direct Nt/ZwCreateFile ... calls done there would fail. Also,
+     * we want to do the I/O initialization as soon as possible. There does
+     * not seem to be any exported way to be notified about the I/O manager
+     * initialization steps... that is, unless we somehow become a driver and
+     * insert ourselves in the flow!
+     *
+     * Since we are not a regular driver, we need to invoke IoCreateDriver()
+     * to create one. However, remember that we are currently running *before*
+     * IoInitSystem(), the I/O subsystem is not initialized yet. Due to this,
+     * calling IoCreateDriver(), much like any other IO functions, would lead
+     * to a crash, because it calls
+     * ObCreateObject(..., IoDriverObjectType, ...), and IoDriverObjectType
+     * is non-initialized yet (it's NULL).
+     *
+     * The chosen solution is to hook a "known" exported callback: namely, the
+     * HalInitPnpDriver() callback (it initializes the "HAL Root Bus Driver").
+     * It is set very early on by the HAL via the HalInitSystem(0, ...) call,
+     * and is called early on by IoInitSystem() before any driver is loaded,
+     * but after the I/O Manager has been minimally set up so that new drivers
+     * can be created.
+     * When the hook: KdpInitDriver() is called, we create our driver with
+     * IoCreateDriver(), specifying its entrypoint KdpDriverEntry(), then
+     * restore and call the original HalInitPnpDriver() callback.
+     *
+     * Another possible unexplored alternative, could be to insert ourselves
+     * in the KeLoaderBlock->LoadOrderListHead boot modules list, or in the
+     * KeLoaderBlock->BootDriverListHead boot-driver list. (Note that while
+     * we may be able to do this, because boot-drivers are resident in memory,
+     * much like we are, we cannot insert ourselves in the system-driver list
+     * however, since those drivers are expected to come from PE image files.)
+     *
+     * Once the KdpDriverEntry() driver entrypoint is called, we register
+     * KdpDriverReinit() for re-initialization with the I/O Manager, in order
+     * to provide more initialization points. KdpDriverReinit() calls the KD
+     * providers at BootPhase >= 2, and schedules further reinitializations
+     * (at most 3 more) if any of the providers request so.
+     **/
+    orgHalInitPnpDriver =
+        InterlockedExchangePointer((PVOID*)&HalInitPnpDriver, KdpInitDriver);
     return STATUS_SUCCESS;
 }
 
- /* EOF */
+/* EOF */

--- a/ntoskrnl/kdbg/kdb.h
+++ b/ntoskrnl/kdbg/kdb.h
@@ -82,7 +82,7 @@ KdbpStackSwitchAndCall(
 
 extern PCHAR KdbInitFileBuffer;
 
-VOID
+NTSTATUS
 NTAPI
 KdbInitialize(
     _In_ PKD_DISPATCH_TABLE DispatchTable,
@@ -94,7 +94,7 @@ KdbRegisterCliCallback(
     PVOID Callback,
     BOOLEAN Deregister);
 
-VOID
+NTSTATUS
 KdbpCliInit(VOID);
 
 VOID


### PR DESCRIPTION
## Purpose

Fix the way how (and when) we initialize KD(BG) functionality that depends on the NT I/O Manager to be up & running.
This includes, creating the debug log file + its thread, and for KDBG, loading the KDBinit file.

JIRA issue: [CORE-17470](https://jira.reactos.org/browse/CORE-17470)

## Proposed changes

**_NOTE: A hack for fixing FILE_APPEND_DATA support appears to be needed, because ReactOS doesn't fully honour it (files get overwritten instead). This will potentially be fixed in a separate PR, see [CORE-18789](https://jira.reactos.org/browse/CORE-18789)_**

Remove the ReactOS-specific (NT-incompatible) callback we do in the middle of IoInitSystem(), for a runtime mechanism that should work on Windows as well.

The idea of the new mechanism is loosely inspired by the TDL4 rootkit :sunglasses:
http://blog.w4kfu.com/public/tdl4_article/draft_tdl4article.html
but contrary to it (which uses [IoRegisterPlugPlayNotification](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-ioregisterplugplaynotification) which is not reliable to detect when the storage stack is up)
we use instead a specific hook and the technique of driver reinitialization:
https://web.archive.org/web/20211021050515/https://driverentry.com.br/en/blog/?p=261
```
We want to be able to perform I/O-related initialization (starting a
logger thread for file log debugging, loading KDBinit file for KDBG,
etc.). A good place for this would be as early as possible, once the
I/O Manager has started the disk drivers and the boot filesystem driver.

Here is an overview of the initialization steps of the NT Kernel and
Executive:

KiSystemStartup(KeLoaderBlock)
    if (Cpu == 0) KdInitSystem(0, KeLoaderBlock);
    KiSwitchToBootStack() -> KiSystemStartupBootStack()
    -> KiInitializeKernel() -> ExpInitializeExecutive(Cpu, KeLoaderBlock)

(NOTE: Any unexpected debugger break will call KdInitSystem(0, NULL); )
KdInitSystem(0, LoaderBlock) -> KdDebuggerInitialize0(LoaderBlock);

ExpInitializeExecutive(Cpu == 0):    ExpInitializationPhase = 0;
    HalInitSystem(0, KeLoaderBlock); <-- Sets HalInitPnpDriver callback.
    ...
    PsInitSystem(LoaderBlock)
        PsCreateSystemThread(Phase1Initialization)

Phase1Initialization(Discard):       ExpInitializationPhase = 1;
    HalInitSystem(1, KeLoaderBlock);
    ...
    Early initialization of Ob, Ex, Ke.
    KdInitSystem(1, KeLoaderBlock);
    ...
    KdDebuggerInitialize1(LoaderBlock);
    ...
    IoInitSystem(LoaderBlock);
    ...

As we can see, KdDebuggerInitialize1() is the last KD initialization
routine the kernel calls, and is called *before* the I/O Manager starts.
Thus, direct Nt/ZwCreateFile ... calls done there would fail. Also,
we want to do our I/O initialization as soon as possible. There does
not seem to be any exported way to be notified about the I/O manager
initialization steps... that is, unless we somehow become a driver and
insert ourselves in the flow!

Since we are not a natural driver, we need to invoke IoCreateDriver()
to create one. However, remember that we are currently running *before*
IoInitSystem(), the I/O subsystem is not initialized yet. Due to this,
calling IoCreateDriver(), much like any other IO functions, would lead
to a crash, because it calls
ObCreateObject(..., IoDriverObjectType, ...), and IoDriverObjectType
is non-initialized yet (it's NULL).

The chosen solution here is to hook a "known" exported callback: namely,
the HalInitPnpDriver() callback (initializes the HAL Root Bus Driver).
It is set very early on by the HAL via the HalInitSystem(0, ...) call,
and is called early on by IoInitSystem() before any driver is loaded,
but after the I/O Manager has been minimally set up so that new drivers
can be created.
When our hooked HalInitPnpDriver() is called, we create our driver with
IoCreateDriver(), specifying its entrypoint KdpDriverEntry, then restore
and call the original HalInitPnpDriver() callback.

Another possible unexplored alternative, could be to insert ourselves
in the KeLoaderBlock->LoadOrderListHead boot modules list, or in the
KeLoaderBlock->BootDriverListHead boot-driver list. (Note that while
we may be able to do this, because boot-drivers are resident in memory,
much like we are, we cannot insert ourselves in the system-driver list
however, since those drivers are expected to come from PE image files.)

Once our "driver" KdpDriverEntry() entrypoint is called, we register
KdpDriverReinit() for re-initialization with the I/O Manager, in order
to provide more initialization points. KdpDriverReinit() calls the KD
providers at BootPhase >= 2, and reschedule further reinitializations
if any of those fail with either STATUS_OBJECT_NAME_NOT_FOUND or
STATUS_OBJECT_PATH_NOT_FOUND.
```

## TODO

- [x] More testing in cooperation with @binarymaster, @julenuri, @DarkFire01 and others who have also encountered the problem.