### PR TITLE
Kddata fix clang

### DIFF
--- a/ntoskrnl/kd64/kddata.c
+++ b/ntoskrnl/kd64/kddata.c
@@ -529,7 +529,7 @@ KDDEBUGGER_DATA64 KdDebuggerDataBlock =
 {
     {{0}},
     0,
-    PtrToUL64(RtlpBreakWithStatusInstruction),
+    PtrToUL64(&RtlpBreakWithStatusInstruction),
     0,
     FIELD_OFFSET(KTHREAD, CallbackStack),
 #if defined(_M_ARM) || defined(_M_AMD64)


### PR DESCRIPTION
## Purpose

OK it would appear that Clang, even in MSVC mode, behaves as stubbornly as GCC regarding 32-bit pointer extension to 64 bits...