### PR TITLE
[MMSYS] Minor fixes for FreeSoundFiles

### DIFF
--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -875,7 +875,6 @@ VOID
 FreeSoundFiles(HWND hwndDlg)
 {
     LRESULT lCount, lIndex, lResult;
-    PWCHAR pSoundPath;
     HWND hwndComboBox;
 
     hwndComboBox = GetDlgItem(hwndDlg, IDC_SOUND_LIST);
@@ -891,8 +890,7 @@ FreeSoundFiles(HWND hwndDlg)
             continue;
         }
 
-        pSoundPath = (PWCHAR)lResult;
-        free(pSoundPath);
+        free((PVOID)lResult);
     }
 }
 

--- a/dll/cpl/mmsys/sounds.c
+++ b/dll/cpl/mmsys/sounds.c
@@ -886,7 +886,7 @@ FreeSoundFiles(HWND hwndDlg)
     for (lIndex = 0; lIndex < lCount; lIndex++)
     {
         lResult = ComboBox_GetItemData(hwndComboBox, lIndex);
-        if (lResult == CB_ERR)
+        if (lResult == CB_ERR || lResult == 0)
         {
             continue;
         }


### PR DESCRIPTION
## Purpose
- Addendum to 781c247bd3c5aeee799527db2ce06e15f794b0a4

## Proposed changes
- Skip empty (None) item
- Remove unnecessary `pSoundPath` variable