### PR TITLE
[NTGDI][FREETYPE] Font cache: Use hash

### DIFF
--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -26,12 +26,13 @@ typedef struct _FONT_ENTRY_COLL_MEM
 typedef struct _FONT_CACHE_ENTRY
 {
     LIST_ENTRY ListEntry;
-    int GlyphIndex;
-    FT_Face Face;
     FT_BitmapGlyph BitmapGlyph;
-    int Height;
-    int Width;
-    int Escapement;
+    DWORD dwHash;
+
+    /* The following members are hashed */
+    INT GlyphIndex;
+    FT_Face Face;
+    LONG lfHeight;
     FT_Render_Mode RenderMode;
     FT_Matrix matTransform;
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -23,13 +23,23 @@ typedef struct _FONT_ENTRY_COLL_MEM
     FONT_ENTRY_MEM *Entry;
 } FONT_ENTRY_COLL_MEM, *PFONT_ENTRY_COLL_MEM;
 
+#include <pshpack1.h> /* We don't like padding for these structures */
+
 typedef struct _EMULATION_BOLD_ITALIC
 {
     BYTE Bold;
     BYTE Italic;
 } EMULATION_BOLD_ITALIC, *PEMULATION_BOLD_ITALIC;
 
-#include <pshpack1.h> /* We don't like padding for this structure */
+typedef struct _FONT_ASPECT
+{
+    _ANONYMOUS_UNION union {
+        EMULATION_BOLD_ITALIC Emu;
+        WORD EmuBoldItalic;
+    } DUMMYUNIONNAME;
+    WORD RenderMode;
+} FONT_ASPECT, *PFONT_ASPECT;
+
 typedef struct _FONT_CACHE_ENTRY
 {
     LIST_ENTRY ListEntry;
@@ -41,12 +51,12 @@ typedef struct _FONT_CACHE_ENTRY
     FT_Face Face;
     LONG lfHeight;
     _ANONYMOUS_UNION union {
-        EMULATION_BOLD_ITALIC Emu;
-        WORD EmuBoldItalic;
+        FONT_ASPECT Aspect;
+        DWORD AspectValue;
     } DUMMYUNIONNAME;
-    WORD RenderMode;
     FT_Matrix matTransform;
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;
+
 #include <poppack.h>
 
 C_ASSERT(offsetof(FONT_CACHE_ENTRY, GlyphIndex) % sizeof(DWORD) == 0);

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -39,6 +39,7 @@ typedef struct _FONT_CACHE_ENTRY
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;
 #include <poppack.h>
 
+C_ASSERT(offsetof(FONT_CACHE_ENTRY, GlyphIndex) % sizeof(DWORD) == 0);
 C_ASSERT(sizeof(FONT_CACHE_ENTRY) % sizeof(DWORD) == 0);
 
 /*

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -23,6 +23,12 @@ typedef struct _FONT_ENTRY_COLL_MEM
     FONT_ENTRY_MEM *Entry;
 } FONT_ENTRY_COLL_MEM, *PFONT_ENTRY_COLL_MEM;
 
+typedef struct _EMULATION_BOLD_ITALIC
+{
+    BOOLEAN Bold;
+    BOOLEAN Italic;
+} EMULATION_BOLD_ITALIC, *PEMULATION_BOLD_ITALIC;
+
 #include <pshpack1.h> /* We don't like padding for this structure */
 typedef struct _FONT_CACHE_ENTRY
 {
@@ -34,8 +40,10 @@ typedef struct _FONT_CACHE_ENTRY
     INT GlyphIndex;
     FT_Face Face;
     LONG lfHeight;
-    BOOLEAN EmuBold;
-    BOOLEAN EmuItalic;
+    _ANONYMOUS_UNION union {
+        EMULATION_BOLD_ITALIC Emu;
+        WORD EmuBoldItalic;
+    } DUMMYUNIONNAME;
     WORD RenderMode;
     FT_Matrix matTransform;
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -34,7 +34,9 @@ typedef struct _FONT_CACHE_ENTRY
     INT GlyphIndex;
     FT_Face Face;
     LONG lfHeight;
-    FT_Render_Mode RenderMode;
+    BOOLEAN EmuBold;
+    BOOLEAN EmuItalic;
+    WORD RenderMode;
     FT_Matrix matTransform;
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;
 #include <poppack.h>

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -25,8 +25,8 @@ typedef struct _FONT_ENTRY_COLL_MEM
 
 typedef struct _EMULATION_BOLD_ITALIC
 {
-    BOOLEAN Bold;
-    BOOLEAN Italic;
+    BYTE Bold;
+    BYTE Italic;
 } EMULATION_BOLD_ITALIC, *PEMULATION_BOLD_ITALIC;
 
 #include <pshpack1.h> /* We don't like padding for this structure */

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -23,6 +23,7 @@ typedef struct _FONT_ENTRY_COLL_MEM
     FONT_ENTRY_MEM *Entry;
 } FONT_ENTRY_COLL_MEM, *PFONT_ENTRY_COLL_MEM;
 
+#include <pshpack1.h> /* We don't like padding for this structure */
 typedef struct _FONT_CACHE_ENTRY
 {
     LIST_ENTRY ListEntry;
@@ -36,7 +37,9 @@ typedef struct _FONT_CACHE_ENTRY
     FT_Render_Mode RenderMode;
     FT_Matrix matTransform;
 } FONT_CACHE_ENTRY, *PFONT_CACHE_ENTRY;
+#include <poppack.h>
 
+C_ASSERT(sizeof(FONT_CACHE_ENTRY) % sizeof(DWORD) == 0);
 
 /*
  * FONTSUBST_... --- constants for font substitutes

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4211,7 +4211,7 @@ ftGdiGetRealGlyph(
     INT glyph_index,
     LONG lfHeight,
     FT_Render_Mode RenderMode,
-    const FT_Matrix *pmat,
+    const FT_Matrix *pmatTransform,
     BOOL EmuBold,
     BOOL EmuItalic)
 {
@@ -4244,7 +4244,7 @@ ftGdiGetRealGlyph(
         CacheEntry.Face = face;
         CacheEntry.lfHeight = lfHeight;
         CacheEntry.RenderMode = RenderMode;
-        CacheEntry.matTransform = *pmat;
+        CacheEntry.matTransform = *pmatTransform;
 
         cdw = (sizeof(FONT_CACHE_ENTRY) - offsetof(FONT_CACHE_ENTRY, GlyphIndex)) / sizeof(DWORD);
         CacheEntry.dwHash = IntGetHash(&CacheEntry.GlyphIndex, cdw);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4298,9 +4298,11 @@ TextIntGetTextExtentPoint(PDC dc,
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     Cache.lfHeight = plf->lfHeight;
+
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
-    Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
     ASSERT(Cache.Emu.Bold <= 1);
+
+    Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
     ASSERT(Cache.Emu.Italic <= 1);
 
     if (IntIsFontRenderingEnabled())
@@ -6076,9 +6078,11 @@ IntExtTextOutW(
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     Cache.lfHeight = plf->lfHeight;
+
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
-    Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
     ASSERT(Cache.Emu.Bold <= 1);
+
+    Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
     ASSERT(Cache.Emu.Italic <= 1);
 
     if (IntIsFontRenderingEnabled())

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4314,7 +4314,6 @@ TextIntGetTextExtentPoint(PDC dc,
     for (i = 0; i < Count; i++)
     {
         glyph_index = get_glyph_index_flagged(Cache.Face, *String, GTEF_INDICES, fl);
-
         Cache.GlyphIndex = glyph_index;
 
         realglyph = ftGdiGetRealGlyph(&Cache, EmuBold, EmuItalic);
@@ -6194,7 +6193,6 @@ IntExtTextOutW(
     DxShift = (fuOptions & ETO_PDY) ? 1 : 0;
     previous = 0;
     DoBreak = FALSE;
-
     for (i = 0; i < Count; ++i)
     {
         glyph_index = get_glyph_index_flagged(face, *String++, ETO_GLYPH_INDEX, fuOptions);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4300,8 +4300,8 @@ TextIntGetTextExtentPoint(PDC dc,
     Cache.lfHeight = plf->lfHeight;
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
-    ASSERT(Cache.Emu.Bold == 0 || Cache.Emu.Bold == 1);
-    ASSERT(Cache.Emu.Italic == 0 || Cache.Emu.Italic == 1);
+    ASSERT(Cache.Emu.Bold <= 1);
+    ASSERT(Cache.Emu.Italic <= 1);
 
     if (IntIsFontRenderingEnabled())
         Cache.RenderMode = (BYTE)IntGetFontRenderMode(plf);
@@ -6078,8 +6078,8 @@ IntExtTextOutW(
     Cache.lfHeight = plf->lfHeight;
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
-    ASSERT(Cache.Emu.Bold == 0 || Cache.Emu.Bold == 1);
-    ASSERT(Cache.Emu.Italic == 0 || Cache.Emu.Italic == 1);
+    ASSERT(Cache.Emu.Bold <= 1);
+    ASSERT(Cache.Emu.Italic <= 1);
 
     if (IntIsFontRenderingEnabled())
         Cache.RenderMode = (BYTE)IntGetFontRenderMode(plf);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3174,6 +3174,8 @@ ftGdiGlyphSet(
     FT_Bitmap AlignedBitmap;
     FT_BitmapGlyph BitmapGlyph;
 
+    ASSERT_FREETYPE_LOCK_HELD();
+
     error = FT_Get_Glyph(GlyphSlot, &Glyph);
     if (error)
     {
@@ -4215,6 +4217,8 @@ ftGdiGetRealGlyph(
     FT_GlyphSlot glyph;
     FT_BitmapGlyph realglyph;
     DWORD cdw;
+
+    ASSERT_FREETYPE_LOCK_HELD();
 
     if (EmuBold || EmuItalic)
     {

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3121,7 +3121,7 @@ IntGetHash(LPCVOID pv, DWORD cdw)
     while (cdw-- > 0)
     {
         dwHash ^= *pdw++;
-        dwHash *= 5;
+        dwHash *= 3;
     }
 
     return dwHash;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3112,7 +3112,7 @@ ftGdiGetRasterizerCaps(LPRASTERIZER_STATUS lprs)
     return FALSE;
 }
 
-static DWORD FASTCALL
+static DWORD APIENTRY
 IntGetHash(LPCVOID pv, DWORD cdw)
 {
     DWORD dwHash = cdw;
@@ -3120,15 +3120,15 @@ IntGetHash(LPCVOID pv, DWORD cdw)
 
     while (cdw-- > 0)
     {
-        dwHash ^= *pdw++;
         dwHash *= 3;
+        dwHash ^= *pdw++;
     }
 
     return dwHash;
 }
 
 FT_BitmapGlyph APIENTRY
-ftGdiGlyphCacheGet(PFONT_CACHE_ENTRY pCache)
+ftGdiGlyphCacheGet(const FONT_CACHE_ENTRY *pCache)
 {
     PLIST_ENTRY CurrentEntry;
     PFONT_CACHE_ENTRY FontEntry;
@@ -3204,7 +3204,7 @@ ftGdiGlyphSet(
     return BitmapGlyph;
 }
 
-FT_BitmapGlyph FASTCALL
+FT_BitmapGlyph APIENTRY
 ftGdiGlyphCacheSet(
     PFONT_CACHE_ENTRY Cache,
     FT_GlyphSlot GlyphSlot)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5949,7 +5949,7 @@ IntExtTextOutW(
     POINT Start;
     USHORT DxShift;
     PMATRIX pmxWorldToDevice;
-    LONG lfHeight, fixAscender, fixDescender;
+    LONG fixAscender, fixDescender;
     FLOATOBJ Scale;
     LOGFONTW *plf;
     BOOL use_kerning, EmuBold, EmuItalic, bResult, DoBreak;
@@ -6074,7 +6074,7 @@ IntExtTextOutW(
     Cache.Face = face = FontGDI->SharedFace->Face;
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
-    Cache.lfHeight = lfHeight = plf->lfHeight;
+    Cache.lfHeight = plf->lfHeight;
     EmuBold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     EmuItalic = (plf->lfItalic && !FontGDI->OriginalItalic);
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4297,9 +4297,11 @@ TextIntGetTextExtentPoint(PDC dc,
     TextIntUpdateSize(dc, TextObj, FontGDI, FALSE);
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
+    Cache.lfHeight = plf->lfHeight;
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
-    Cache.lfHeight = plf->lfHeight;
+    ASSERT(Cache.Emu.Bold == 0 || Cache.Emu.Bold == 1);
+    ASSERT(Cache.Emu.Italic == 0 || Cache.Emu.Italic == 1);
 
     if (IntIsFontRenderingEnabled())
         Cache.RenderMode = (BYTE)IntGetFontRenderMode(plf);
@@ -6076,6 +6078,8 @@ IntExtTextOutW(
     Cache.lfHeight = plf->lfHeight;
     Cache.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
+    ASSERT(Cache.Emu.Bold == 0 || Cache.Emu.Bold == 1);
+    ASSERT(Cache.Emu.Italic == 0 || Cache.Emu.Italic == 1);
 
     if (IntIsFontRenderingEnabled())
         Cache.RenderMode = (BYTE)IntGetFontRenderMode(plf);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4272,7 +4272,6 @@ TextIntGetTextExtentPoint(PDC dc,
                           FLONG fl)
 {
     PFONTGDI FontGDI;
-    FT_Face face;
     FT_BitmapGlyph realglyph;
     INT glyph_index, i, previous;
     ULONGLONG TotalWidth64 = 0;
@@ -4284,7 +4283,7 @@ TextIntGetTextExtentPoint(PDC dc,
 
     FontGDI = ObjToGDI(TextObj->Font, FONT);
 
-    Cache.Face = face = FontGDI->SharedFace->Face;
+    Cache.Face = FontGDI->SharedFace->Face;
     if (NULL != Fit)
     {
         *Fit = 0;
@@ -4307,14 +4306,14 @@ TextIntGetTextExtentPoint(PDC dc,
     /* Get the DC's world-to-device transformation matrix */
     pmxWorldToDevice = DC_pmxWorldToDevice(dc);
     FtMatrixFromMx(&Cache.matTransform, pmxWorldToDevice);
-    FT_Set_Transform(face, &Cache.matTransform, 0);
+    FT_Set_Transform(Cache.Face, &Cache.matTransform, 0);
 
-    use_kerning = FT_HAS_KERNING(face);
+    use_kerning = FT_HAS_KERNING(Cache.Face);
     previous = 0;
 
     for (i = 0; i < Count; i++)
     {
-        glyph_index = get_glyph_index_flagged(face, *String, GTEF_INDICES, fl);
+        glyph_index = get_glyph_index_flagged(Cache.Face, *String, GTEF_INDICES, fl);
 
         Cache.GlyphIndex = glyph_index;
 
@@ -4326,7 +4325,7 @@ TextIntGetTextExtentPoint(PDC dc,
         if (use_kerning && previous && glyph_index)
         {
             FT_Vector delta;
-            FT_Get_Kerning(face, previous, glyph_index, 0, &delta);
+            FT_Get_Kerning(Cache.Face, previous, glyph_index, 0, &delta);
             TotalWidth64 += delta.x;
         }
 


### PR DESCRIPTION
## Purpose
Optimize the font rendering for speed.
JIRA issue: [CORE-11848](https://jira.reactos.org/browse/CORE-11848)

## Proposed changes

- Modify `FONT_CACHE_ENTRY` structure to use hash.
- Add `IntGetHash` to calculate the hash of `FONT_CACHE_ENTRY`.
- Use hash in `ftGdiGlyphCacheGet` and `ftGdiGlyphCacheSet` functions.
- Reduce function call overheads by using `FONT_CACHE_ENTRY`, in getting glyph.

## TODO

- [x] Do small tests.
- [x] Do big tests.