### PR TITLE
[COMDLG32] Enable saving files with different extension

### DIFF
--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -3099,7 +3099,7 @@ BOOL FILEDLG95_OnOpen(HWND hwnd)
         /* Attach the file extension with file name*/
         ext = PathFindExtensionW(lpstrPathAndFile);
 #ifdef __REACTOS__
-         if (! *ext)
+        if (*ext == UNICODE_NULL && fodInfos->defext)
         {
             LPWSTR filterExt = NULL, lpstrFilter = NULL, pch, pchNext;
             LPCWSTR the_ext = NULL;

--- a/dll/win32/comdlg32/filedlg.c
+++ b/dll/win32/comdlg32/filedlg.c
@@ -3099,6 +3099,7 @@ BOOL FILEDLG95_OnOpen(HWND hwnd)
         /* Attach the file extension with file name*/
         ext = PathFindExtensionW(lpstrPathAndFile);
 #ifdef __REACTOS__
+         if (! *ext)
         {
             LPWSTR filterExt = NULL, lpstrFilter = NULL, pch, pchNext;
             LPCWSTR the_ext = NULL;


### PR DESCRIPTION
[COMDLG32] Enable saving files with different extension

like on Windows, gives precedence to the user's extension in file names if there is one.
Otherwise appends the selected extension. If not selected, append default extension.