### PR TITLE
[RPCRT4] Fix MASM version of _call_stubless_func asm wrapper

### DIFF
--- a/dll/win32/rpcrt4/msvc.S
+++ b/dll/win32/rpcrt4/msvc.S
@@ -17,16 +17,17 @@ _call_stubless_func:
     mov ecx,[ecx]          /* This->lpVtbl */
     mov ecx,[ecx-8]        /* MIDL_STUBLESS_PROXY_INFO */
     mov edx,[ecx+8]        /* Info->FormatStringOffset */
-    mov edx,[edx+eax*2]    /* FormatStringOffset[index] */
-    and edx, 0000FFFFh
+    movzx edx, word ptr [edx+eax*2]   /* FormatStringOffset[index] */
     add edx,[ecx+4]        /* info->ProcFormatString + offset */
-    mov eax, [edx+8]       /* arguments size */
-    and eax, 0000FFFFh
+    movzx eax, byte ptr [edx+1] /* Oi_flags */
+    and eax, 8             /* Oi_HAS_RPCFLAGS */
+    shr eax, 1
+    movzx eax, word ptr [edx+eax+4] /* arguments size */
     push eax
     lea eax, [esp+8]       /* &This */
     push eax
     push edx               /* format string */
-    push [ecx]             /* info->pstubdesc */
+    push dword ptr [ecx]   /* info->pstubdesc */
     call _ndr_client_call
     lea esp, [esp+12]
     pop edx                /* arguments size */


### PR DESCRIPTION
## Purpose

Attempt to fix MSVC specific asm wrapper after wine sync.

JIRA issue: [CORE-18505](https://jira.reactos.org/browse/CORE-18505)

## Proposed changes

Replace the instructions with the identical instructions from the GCC inline asm.

## TODO
- [ ] Test, if it fixes the issue

