### PR TITLE
Random fixes

### DIFF
--- a/dll/win32/kernel32/client/file/mntpoint.c
+++ b/dll/win32/kernel32/client/file/mntpoint.c
@@ -206,7 +206,7 @@ GetVolumeNameForRoot(IN LPCWSTR lpszRootPath,
             /* Make a string of it, to easy the checks */
             SymbolicLink.Length = MountPoints->MountPoints[CurrentMntPt].SymbolicLinkNameLength;
             SymbolicLink.MaximumLength = SymbolicLink.Length;
-            SymbolicLink.Buffer = (PVOID)((ULONG_PTR)&MountPoints->MountPoints[CurrentMntPt] + MountPoints->MountPoints[CurrentMntPt].SymbolicLinkNameOffset);
+            SymbolicLink.Buffer = (PVOID)((ULONG_PTR)MountPoints + MountPoints->MountPoints[CurrentMntPt].SymbolicLinkNameOffset);
             /* If that's a NT volume name (GUID form), keep it! */
             if (MOUNTMGR_IS_NT_VOLUME_NAME(&SymbolicLink))
             {

--- a/modules/rostests/apitests/crt/strlen.c
+++ b/modules/rostests/apitests/crt/strlen.c
@@ -48,8 +48,8 @@ Test_strlen(PFN_STRLEN pstrlen)
     eflags = __readeflags();
     __writeeflags(eflags | EFLAGS_DF);
     len = pstrlen(teststr + 4);
-    eflags = __readeflags();
-    ok((eflags & EFLAGS_DF) != 0, "Direction flag in ELFAGS was changed.");
+    ok((__readeflags() & EFLAGS_DF) != 0, "Direction flag in ELFAGS was changed.");
+    __writeeflags(eflags);
 
     /* Only test this for the exported versions, intrinsics might do it
        differently. It's up to us to not do fishy stuff! Also crtdll does

--- a/modules/rostests/apitests/ws2_32/bind.c
+++ b/modules/rostests/apitests/ws2_32/bind.c
@@ -133,7 +133,7 @@ START_TEST(bind)
     int Error;
     CHAR LocalHostName[128];
     struct hostent *Hostent;
-    IN_ADDR Address;
+    IN_ADDR Address = { 0 };
     SOCKET Socket;
     struct sockaddr_in Addr = { AF_INET };
 

--- a/ntoskrnl/ex/init.c
+++ b/ntoskrnl/ex/init.c
@@ -649,6 +649,7 @@ ExpInitSystemPhase0(VOID)
     /* Initialize the Firmware Table resource and listhead */
     InitializeListHead(&ExpFirmwareTableProviderListHead);
     ExInitializeResourceLite(&ExpFirmwareTableResource);
+    ExInitializeResourceLite(&ExpTimeRefreshLock);
 
     /* Set the suite mask to maximum and return */
     ExSuiteMask = 0xFFFFFFFF;

--- a/ntoskrnl/include/internal/ex.h
+++ b/ntoskrnl/include/internal/ex.h
@@ -16,6 +16,7 @@ extern POBJECT_TYPE ExEventPairObjectType;
 extern POBJECT_TYPE _ExEventObjectType, _ExSemaphoreObjectType;
 extern FAST_MUTEX ExpEnvironmentLock;
 extern ERESOURCE ExpFirmwareTableResource;
+extern ERESOURCE ExpTimeRefreshLock;
 extern LIST_ENTRY ExpFirmwareTableProviderListHead;
 extern BOOLEAN ExpIsWinPEMode;
 extern LIST_ENTRY ExpSystemResourcesList;

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1270,11 +1270,16 @@ MmCleanProcessAddressSpace(IN PEPROCESS Process)
     PMM_AVL_TABLE VadTree;
     PETHREAD Thread = PsGetCurrentThread();
 
-    /* Only support this */
-    ASSERT(Process->AddressSpaceInitialized == 2);
-
     /* Remove from the session */
     MiSessionRemoveProcess();
+
+    /* Abort early, when the address space wasn't fully initialized */
+    if (Process->AddressSpaceInitialized < 2)
+    {
+        DPRINT1("Incomplete address space for Process %p. Might leak resources.\n",
+                Process);
+        return;
+    }
 
     /* Lock the process address space from changes */
     MmLockAddressSpace(&Process->Vm);

--- a/ntoskrnl/mm/ARM3/procsup.c
+++ b/ntoskrnl/mm/ARM3/procsup.c
@@ -1379,7 +1379,8 @@ MmDeleteProcessAddressSpace(IN PEPROCESS Process)
 
     /* Remove us from the list */
     OldIrql = MiAcquireExpansionLock();
-    RemoveEntryList(&Process->Vm.WorkingSetExpansionLinks);
+    if (Process->Vm.WorkingSetExpansionLinks.Flink != NULL)
+        RemoveEntryList(&Process->Vm.WorkingSetExpansionLinks);
     MiReleaseExpansionLock(OldIrql);
 
     /* Acquire the PFN lock */
@@ -1421,8 +1422,8 @@ MmDeleteProcessAddressSpace(IN PEPROCESS Process)
     }
     else
     {
-        /* A partly-initialized process should never exit through here */
-        ASSERT(FALSE);
+        DPRINT1("Deleting partially initialized address space of Process %p. Might leak resources.\n",
+                Process);
     }
 
     /* Release the PFN lock */

--- a/ntoskrnl/ob/oblife.c
+++ b/ntoskrnl/ob/oblife.c
@@ -1035,6 +1035,7 @@ ObCreateObject(IN KPROCESSOR_MODE ProbeMode OPTIONAL,
         /* Release the Capture Info, we don't need it */
         ObpFreeObjectCreateInformation(ObjectCreateInfo);
         if (ObjectName.Buffer) ObpFreeObjectNameBuffer(&ObjectName);
+        return Status;
     }
 
     /* We failed, so release the Buffer */

--- a/win32ss/gdi/ntgdi/dibobj.c
+++ b/win32ss/gdi/ntgdi/dibobj.c
@@ -1578,7 +1578,13 @@ IntCreateDIBitmap(
             Surface = SURFACE_ShareLockSurface(handle);
             ASSERT(Surface);
             Palette = CreateDIBPalette(data, Dc, coloruse);
-            ASSERT(Palette);
+            if (Palette == NULL)
+            {
+                SURFACE_ShareUnlockSurface(Surface);
+                GreDeleteObject(handle);
+                return NULL;
+            }
+
             SURFACE_vSetPalette(Surface, Palette);
 
             PALETTE_ShareUnlockPalette(Palette);

--- a/win32ss/printing/base/spoolss/main.c
+++ b/win32ss/printing/base/spoolss/main.c
@@ -253,12 +253,12 @@ SpoolerInit(VOID)
 }
 
 BOOL WINAPI
-BuildOtherNamesFromMachineName(LPVOID * ptr1, LPVOID * ptr2)
+BuildOtherNamesFromMachineName(LPVOID * ptr1, ULONG * ptr2)
 {
     FIXME("(%p, %p) stub\n", ptr1, ptr2);
 
     *ptr1 = NULL;
-    *ptr2 = NULL;
+    *ptr2 = 0;
     return FALSE;
 }
 


### PR DESCRIPTION
## Purpose

A bunch of random fixes that impact test runs for x64, but are also valid for x86.

## Proposed changes

- [CRT_APITEST] Restore direction flag to avoid false RTC break
- [WS2_32_APITEST] Fix uninitialized variable
- [KERNEL32] Fix a bug in GetVolumeNameForRoot
- [NTOS:EX] Initialize ExpTimeRefreshLock
- [WIN32K] Fix missing NULL check in IntCreateDIBitmap
- [NTOS] Improve MmCleanProcessAddressSpace
- [NTOS] Improve MmDeleteProcessAddressSpace
- [SPOOLSS] Fix prototype of BuildOtherNamesFromMachineName
- [NTOS] Fix double free on allocation failure in ObCreateObject

## Test results
KVM: https://reactos.org/testman/compare.php?ids=85079,85082,85084,85087,85092
VBox: https://reactos.org/testman/compare.php?ids=85081,85083,85085,85088,85091
- gdi32:TextTransform: Difference due to updated test
- kernel32:QueueUserAPC: looks random
- kernel32:volume: fixed 21 tests

