### PR TITLE
[NTGDI][FREETYPE] lfWidth for GetTextExtentPoint32

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4280,7 +4280,6 @@ TextIntGetTextExtentPoint(PDC dc,
     BOOL use_kerning;
     LONG ascender, descender;
     FONT_CACHE_ENTRY Cache;
-    FT_Matrix mat;
 
     FontGDI = ObjToGDI(TextObj->Font, FONT);
 


### PR DESCRIPTION
## Purpose

Implement `LOGFONT.lfWidth` for `GetTextExtentPoint32`.
JIRA issue: [CORE-11848](https://jira.reactos.org/browse/CORE-11848)

## Proposed changes

- Apply `LOGFONT.lfWidth` in `TextIntGetTextExtentPoint` function.
- Delete `XFORM` transformation in `TextIntGetTextExtentPoint` (to be simply ignored).

## TODO

- [x] Do big tests.
