### PR TITLE
[SENDMAIL] Fix Send To -> Desktop (create shortcut) behavior

### DIFF
--- a/dll/shellext/sendmail/CDeskLinkDropHandler.cpp
+++ b/dll/shellext/sendmail/CDeskLinkDropHandler.cpp
@@ -87,13 +87,27 @@ CDeskLinkDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
         if (SHGetPathFromIDListW(pidl, szSrc))
         {
             CStringW strTitle;
+            LPCWSTR pszSourceExt;
+
             strTitle.Format(IDS_SHORTCUT, PathFindFileNameW(szSrc));
 
             PathAppendW(szDest, strTitle);
             PathRemoveExtensionW(szDest);
             StringCbCatW(szDest, sizeof(szDest), L".lnk");
 
-            hr = CreateShellLink(szDest, szSrc, NULL, NULL, NULL, NULL, -1, NULL);
+            pszSourceExt = PathFindExtensionW(szSrc);
+            if (PathIsDirectoryW(szSrc) || (_wcsicmp(pszSourceExt, L".zip") == 0))
+            {
+                hr = CreateShellLink(szDest, szSrc, NULL, NULL, NULL, NULL, -1, NULL);
+            }
+            else
+            {
+                /* Set default working directory for the shortcut */
+                CStringW strWorkingDir(szSrc);
+                PathRemoveFileSpecW(strWorkingDir.GetBuffer());
+
+                hr = CreateShellLink(szDest, szSrc, NULL, NULL, strWorkingDir, NULL, -1, NULL);
+            }
         }
         else
         {

--- a/dll/shellext/sendmail/CDeskLinkDropHandler.cpp
+++ b/dll/shellext/sendmail/CDeskLinkDropHandler.cpp
@@ -95,6 +95,12 @@ CDeskLinkDropHandler::Drop(IDataObject *pDataObject, DWORD dwKeyState,
             PathRemoveExtensionW(szDest);
             StringCbCatW(szDest, sizeof(szDest), L".lnk");
 
+            if (PathFileExistsW(szDest))
+            {
+                CStringW strName(PathFindFileNameW(szDest));
+                PathYetAnotherMakeUniqueName(szDest, szDir, NULL, strName);
+            }
+
             pszSourceExt = PathFindExtensionW(szSrc);
             if (PathIsDirectoryW(szSrc) || (_wcsicmp(pszSourceExt, L".zip") == 0))
             {


### PR DESCRIPTION
## Proposed changes
- Set default working directory for shortcuts (except folders and zip files)
- Copy existing shortcut to the desktop if the source file is a shortcut
- Prevent destination file name collision

Notes: Verified on Windows XP SP3 and Windows 7 SP1.

Shortcut to EXE file (Before):
[ReactOS-sendto-before.webm](https://user-images.githubusercontent.com/86486978/204141743-0c683da0-04fc-4c5c-8aa5-6dc7bc5444ae.webm)

Shortcut to EXE file (After):
[ReactOS-sendto-after.webm](https://user-images.githubusercontent.com/86486978/204141767-8c38c888-2037-4f89-b38c-d3de0cd04874.webm)
