### PR TITLE
KD/KDBG: Fix/improve KdbpReadCommand() and KdReceivePacket() for DBGKD_DEBUG_IO

### DIFF
--- a/dll/win32/kernel32/client/proc.c
+++ b/dll/win32/kernel32/client/proc.c
@@ -1625,14 +1625,13 @@ FatalExit(IN int ExitCode)
 {
 #if DBG
     /* On Checked builds, Windows gives the user a nice little debugger UI */
-    CHAR ch[2];
-    DbgPrint("FatalExit...\n");
-    DbgPrint("\n");
+    CHAR Action[2];
+    DbgPrint("FatalExit...\n\n");
 
     while (TRUE)
     {
-        DbgPrompt( "A (Abort), B (Break), I (Ignore)? ", ch, sizeof(ch));
-        switch (ch[0])
+        DbgPrompt("A (Abort), B (Break), I (Ignore)? ", Action, sizeof(Action));
+        switch (Action[0])
         {
             case 'B': case 'b':
                  DbgBreakPoint();

--- a/ntoskrnl/kdbg/kdb.h
+++ b/ntoskrnl/kdbg/kdb.h
@@ -98,6 +98,11 @@ KdbpCliMainLoop(
 VOID
 KdbpCliInterpretInitFile(VOID);
 
+SIZE_T
+KdbpReadCommand(
+    _Out_ PCHAR Buffer,
+    _In_ SIZE_T Size);
+
 VOID
 KdbpPager(
     _In_ PCHAR Buffer,

--- a/ntoskrnl/kdbg/kdb_keyboard.c
+++ b/ntoskrnl/kdbg/kdb_keyboard.c
@@ -90,12 +90,12 @@ KbdSendCommandToMouse(UCHAR Command)
     return;
 }
 
-VOID KbdEnableMouse()
+VOID KbdEnableMouse(VOID)
 {
     KbdSendCommandToMouse(MOU_ENAB);
 }
 
-VOID KbdDisableMouse()
+VOID KbdDisableMouse(VOID)
 {
     KbdSendCommandToMouse(MOU_DISAB);
 }

--- a/ntoskrnl/ps/kill.c
+++ b/ntoskrnl/ps/kill.c
@@ -42,23 +42,20 @@ PspCatchCriticalBreak(IN PCHAR Message,
             /* If a debugger isn't present, don't prompt */
             if (KdDebuggerNotPresent) break;
 
-            /* A debuger is active, prompt for action */
-            DbgPrompt("Break, or Ignore (bi)?", Action, sizeof(Action));
+            /* A debugger is active, prompt for action */
+            DbgPrompt("Break, or Ignore (bi)? ", Action, sizeof(Action));
             switch (Action[0])
             {
                 /* Break */
                 case 'B': case 'b':
-
-                    /* Do a breakpoint */
                     DbgBreakPoint();
+                    /* Fall through */
 
-                /* Ignore */
+                /* Ignore: Handle it */
                 case 'I': case 'i':
-
-                    /* Handle it */
                     Handled = TRUE;
 
-                /* Unrecognized */
+                /* Unrecognized: Prompt again */
                 default:
                     break;
             }

--- a/sdk/lib/rtl/assert.c
+++ b/sdk/lib/rtl/assert.c
@@ -43,52 +43,38 @@ RtlAssert(IN PVOID FailedAssertion,
                  LineNumber);
 
         /* Prompt for action */
-        DbgPrompt("Break repeatedly, break Once, Ignore,"
-                  " terminate Process or terminate Thread (boipt)? ",
+        DbgPrompt("Break repeatedly, break Once, Ignore, "
+                  "terminate Process or terminate Thread (boipt)? ",
                   Action,
                   sizeof(Action));
         switch (Action[0])
         {
-            /* Break repeatedly */
+            /* Break repeatedly / Break once */
             case 'B': case 'b':
-
-                /* Do a breakpoint, then prompt again */
-                DbgPrint("Execute '.cxr %p' to dump context\n", &Context);
-                DbgBreakPoint();
-                break;
-
-            /* Ignore */
-            case 'I': case 'i':
-
-                /* Return to caller */
-                return;
-
-            /* Break once */
             case 'O': case 'o':
-
-                /* Do a breakpoint and return */
                 DbgPrint("Execute '.cxr %p' to dump context\n", &Context);
+                /* Do a breakpoint, then prompt again or return */
                 DbgBreakPoint();
+                if ((Action[0] == 'B') || (Action[0] == 'b'))
+                    break;
+                /* else ('O','o'): fall through */
+
+            /* Ignore: Return to caller */
+            case 'I': case 'i':
                 return;
 
-            /* Terminate process*/
+            /* Terminate current process */
             case 'P': case 'p':
-
-                /* Terminate us */
                 ZwTerminateProcess(ZwCurrentProcess(), STATUS_UNSUCCESSFUL);
                 break;
 
-            /* Terminate thread */
+            /* Terminate current thread */
             case 'T': case 't':
-
-                /* Terminate us */
                 ZwTerminateThread(ZwCurrentThread(), STATUS_UNSUCCESSFUL);
                 break;
 
-            /* Unrecognized */
+            /* Unrecognized: Prompt again */
             default:
-
-                /* Prompt again */
                 break;
         }
     }


### PR DESCRIPTION
## Purpose

@julenuri noticed that debugger input is a bit "raw" when KD handles input for DbgPrompt() calls, and e.g. shows squares if backspaces are used, etc.:
![image](https://user-images.githubusercontent.com/1969829/204155476-164a2bcf-bb1a-4908-8790-a78a94427a3d.png)

Take also the opportunity to add other fixes.

## Proposed changes

- Validate DEBUG_IO API call.

- Take the LengthOfStringRead into account; use KdbpReadCommand() to read
  the input, so that correct line edition is available (backspace, etc.)

For KdbpReadCommand():
- Don't read anything and return immediately if the buffer size is zero.

- Allow the controlling keys (up/down arrows, backspace) even if the
  buffer is full! (especially backspace if too much has been written).

- Return the number of characters stored, not counting the NULL terminator.