### PR TITLE
Further improvements for KDBG

### DIFF
--- a/ntoskrnl/kd64/kdtrap.c
+++ b/ntoskrnl/kd64/kdtrap.c
@@ -147,7 +147,7 @@ KdpTrap(IN PKTRAP_FRAME TrapFrame,
 
     /*
      * Check if we got a STATUS_BREAKPOINT with a SubID for Print, Prompt or
-     * Load/Unload symbols. Make sure it isn't a software breakpoints as those
+     * Load/Unload symbols. Make sure it isn't a software breakpoint as those
      * are handled by KdpReport.
      */
     if ((ExceptionRecord->ExceptionCode == STATUS_BREAKPOINT) &&

--- a/ntoskrnl/kdbg/kdb.c
+++ b/ntoskrnl/kdbg/kdb.c
@@ -1176,7 +1176,8 @@ KdbpInternalEnter(VOID)
     Thread->Tcb.StackLimit = (ULONG_PTR)KdbStack;
     Thread->Tcb.KernelStack = (char*)KdbStack + KDB_STACK_SIZE;
 
-    // KdbPrintf("Switching to KDB stack 0x%08x-0x%08x (Current Stack is 0x%08x)\n", Thread->Tcb.StackLimit, Thread->Tcb.StackBase, Esp);
+    // KdbPrintf("Switching to KDB stack 0x%08x-0x%08x (Current Stack is 0x%08x)\n",
+    //           Thread->Tcb.StackLimit, Thread->Tcb.StackBase, Esp);
 
     KdbpStackSwitchAndCall(KdbStack + KDB_STACK_SIZE - KDB_STACK_RESERVE, KdbpCallMainLoop);
 
@@ -1333,7 +1334,6 @@ KdbEnterDebuggerException(
         {
             Resume = TRUE; /* Set the resume flag when continuing execution */
         }
-
         /*
          * When a temporary breakpoint is hit we have to make sure that we are
          * in the same context in which it was set, otherwise it could happen
@@ -1360,7 +1360,6 @@ KdbEnterDebuggerException(
 
             KdbEnteredOnSingleStep = TRUE;
         }
-
         /*
          * If we hit a breakpoint set by the debugger we set the single step flag,
          * ignore the next single step and reenable the breakpoint.

--- a/ntoskrnl/kdbg/kdb.h
+++ b/ntoskrnl/kdbg/kdb.h
@@ -61,7 +61,7 @@ typedef enum _KD_CONTINUE_TYPE
 
 /* GLOBALS *******************************************************************/
 
-extern PCHAR KdbInitFileBuffer;
+extern volatile PCHAR KdbInitFileBuffer;
 
 extern PEPROCESS KdbCurrentProcess;
 extern PETHREAD KdbCurrentThread;

--- a/ntoskrnl/kdbg/kdb_cli.c
+++ b/ntoskrnl/kdbg/kdb_cli.c
@@ -3341,23 +3341,20 @@ VOID
 KdbpCliInterpretInitFile(VOID)
 {
     PCHAR p1, p2;
-    INT_PTR i;
-    CHAR c;
 
     /* Execute the commands in the init file */
     DPRINT("KDB: Executing KDBinit file...\n");
     p1 = KdbInitFileBuffer;
     while (p1[0] != '\0')
     {
-        i = strcspn(p1, "\r\n");
+        size_t i = strcspn(p1, "\r\n");
         if (i > 0)
         {
-            c = p1[i];
+            CHAR c = p1[i];
             p1[i] = '\0';
 
             /* Look for "break" command and comments */
             p2 = p1;
-
             while (isspace(p2[0]))
                 p2++;
 


### PR DESCRIPTION
## Purpose

The main purpose of this PR is to reintroduce the capability from KdbpCliInit() to interpret the KDBinit file.
(Addendum to commit baa47fa5e.)

Additional improvements are also added, see below.

## Proposed changes

### `[NTOS:KDBG] Small improvements for KdbpCliMainLoop() and KdbpDoCommand()`

  - Move the printing pager state reset code (setting the number of
    printed rows and columns to zero, and the output aborted flag)
    to KdbpDoCommand(). This allows to keep the original behaviour,
    while also inheriting it whenever KdbpDoCommand() is invoked
    elsewhere (for example, from KdbpCliInterpretInitFile()).

  - Use KdbPuts/Printf() instead of KdbpPrint() for the entry banners,
    so that they aren't subject to the current printing pager state.
    Do the same for the "command unknown" error in KdbpDoCommand().

  - Add a "Type 'help' for a list of commands" banner, for the users.

  - Replace the do-while-loop with a simple while-loop.

### `[NTOS:KDBG] Reintroduce the capability of KdbpCliInit() to interpret the KDBinit file`

  Similarly to what was originally done, have KdbpCliInterpretInitFile()
  parse the KDBinit file by breaking back into the debugger.
  But contrary to before, replace the deprecated call to KdbEnter() by
  a standard DbgBreakPointWithStatus(DBG_STATUS_CONTROL_C) . This allows
  KdbEnterDebuggerException() to do the KdbpCliInterpretInitFile() call.

  Additional fixes and improvements:

  - Run KdbpCliInterpretInitFile() in full KDBG environment (interrupts
    disabled, modified IRQL, own stack), like the usual interactive loop.

  - The KDBinit data buffer must be in non-paged pool.

  - Demote the "Could not open KDBinit" error to a DPRINT, so that it
    doesn't pollute the debug log when the KDBG init function is called
    early (before the storage stack is initialized), or if the file
    doesn't exist -- since this is an optional feature.
