### PR TITLE
[NTGDI][FREETYPE] lfWidth for GetTextMetrics and GetCharWidth

### DIFF
--- a/win32ss/gdi/eng/engobjects.h
+++ b/win32ss/gdi/eng/engobjects.h
@@ -164,6 +164,7 @@ typedef struct _FONTGDI {
   LONG          tmInternalLeading;
   LONG          Magic;
   LONG          lfHeight;
+  LONG          lfWidth;
 } FONTGDI, *PFONTGDI;
 
 /* The initialized 'Magic' value in FONTGDI */

--- a/win32ss/gdi/ntgdi/font.h
+++ b/win32ss/gdi/ntgdi/font.h
@@ -42,6 +42,7 @@ typedef struct _FONT_CACHE_HASHED
     INT GlyphIndex;
     FT_Face Face;
     LONG lfHeight;
+    LONG lfWidth;
     _ANONYMOUS_UNION union {
         DWORD AspectValue;
         FONT_ASPECT Aspect;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4585,8 +4585,15 @@ ftGdiGetTextMetricsW(
         Face = FontGDI->SharedFace->Face;
 
         IntLockFreeType();
+
         Error = IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
-        FtMatrixFromMx(&mat, DC_pmxWorldToDevice(dc));
+
+        // NOTE: GetTextMetrics simply ignores lfEscapement and XFORM.
+        if (FT_IS_SCALABLE(Cache.Hashed.Face) && plf->lfWidth != 0)
+            IntWidthMatrix(Cache.Hashed.Face, &mat, plf->lfWidth);
+        else
+            mat = identityMat;
+
         FT_Set_Transform(Face, &mat, 0);
         IntUnLockFreeType();
 
@@ -4597,7 +4604,6 @@ ftGdiGetTextMetricsW(
         }
         else
         {
-            FT_Face Face = FontGDI->SharedFace->Face;
             Status = STATUS_SUCCESS;
 
             IntLockFreeType();

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4590,11 +4590,15 @@ ftGdiGetTextMetricsW(
 
         // NOTE: GetTextMetrics simply ignores lfEscapement and XFORM.
         if (FT_IS_SCALABLE(Face) && plf->lfWidth != 0)
+        {
             IntWidthMatrix(Face, &mat, plf->lfWidth);
+            FT_Set_Transform(Face, &mat, 0);
+        }
         else
-            mat = identityMat;
+        {
+            FT_Set_Transform(Face, &identityMat, 0);
+        }
 
-        FT_Set_Transform(Face, &mat, 0);
         IntUnLockFreeType();
 
         if (0 != Error)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3445,7 +3445,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     TT_OS2 *pOS2;
     TT_HoriHeader *pHori;
     FT_WinFNT_HeaderRec WinFNT;
-    LONG Ascent, Descent, Sum, EmHeight, Width;
+    LONG Ascent, Descent, Sum, EmHeight, Width64;
 
     lfWidth = abs(lfWidth);
     if (lfHeight == 0)
@@ -3553,22 +3553,12 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = min(EmHeight, USHORT_MAX);
 
     if (FT_IS_SCALABLE(face))
-    {
-        FT_Fixed XScale = face->size->metrics.x_scale;
-        LONG tmAveCharWidth = (FT_MulFix(pOS2->xAvgCharWidth, XScale) + 32) >> 6;
-        if (tmAveCharWidth == 0)
-        {
-            tmAveCharWidth = 1;
-        }
-        Width = (lfWidth << 6) / tmAveCharWidth;
-    }
+        Width64 = min(lfWidth, USHORT_MAX) << 6;
     else
-    {
-        Width = 0;
-    }
+        Width64 = 0;
 
     req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
-    req.width          = Width;
+    req.width          = Width64;
     req.height         = (EmHeight << 6);
     req.horiResolution = 0;
     req.vertResolution = 0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3554,16 +3554,10 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = max(EmHeight, 1);
     EmHeight = min(EmHeight, USHORT_MAX);
 
-    if (FT_IS_SCALABLE(face) && lfWidth > 0)
-    {
-        Width64 = (lfWidth * 96) / 72;      /* pixels to points */
-        Width64 <<= 6;                      /* 64 times */
-        Width64 = (Width64 * 167) / 100;    /* ??? FIXME */
-    }
+    if (pOS2 && lfWidth > 0)
+        Width64 = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
     else
-    {
         Width64 = 0;
-    }
 
     req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
     req.width          = Width64;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4284,7 +4284,7 @@ TextIntGetTextExtentPoint(PDC dc,
     Cache.Hashed.Aspect.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
 
     // Check vertical writing (tategaki)
-    nTenthsOfDegrees = IntNormalizeAngle(labs(plf->lfEscapement - plf->lfOrientation));
+    nTenthsOfDegrees = IntNormalizeAngle(plf->lfEscapement - plf->lfOrientation);
     bVerticalWriting = ((nTenthsOfDegrees == 90 * 10) || (nTenthsOfDegrees == 270 * 10));
 
     if (IntIsFontRenderingEnabled())

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3112,6 +3112,7 @@ ftGdiGlyphCacheGet(IN const FONT_CACHE_ENTRY *pCache)
             FontEntry->Hashed.GlyphIndex == pCache->Hashed.GlyphIndex &&
             FontEntry->Hashed.Face == pCache->Hashed.Face &&
             FontEntry->Hashed.lfHeight == pCache->Hashed.lfHeight &&
+            FontEntry->Hashed.lfWidth == pCache->Hashed.lfWidth &&
             FontEntry->Hashed.AspectValue == pCache->Hashed.AspectValue &&
             memcmp(&FontEntry->Hashed.matTransform, &pCache->Hashed.matTransform,
                    sizeof(FT_Matrix)) == 0)
@@ -4269,6 +4270,7 @@ TextIntGetTextExtentPoint(PDC dc,
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     Cache.Hashed.lfHeight = plf->lfHeight;
+    Cache.Hashed.lfWidth = plf->lfWidth;
     Cache.Hashed.Aspect.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Hashed.Aspect.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
 
@@ -4323,7 +4325,7 @@ TextIntGetTextExtentPoint(PDC dc,
         previous = glyph_index;
         String++;
     }
-
+    ASSERT(FontGDI->Magic == FONTGDI_MAGIC);
     ascender = FontGDI->tmAscent; /* Units above baseline */
     descender = FontGDI->tmDescent; /* Units below baseline */
     IntUnLockFreeType();
@@ -6044,6 +6046,7 @@ IntExtTextOutW(
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     Cache.Hashed.lfHeight = plf->lfHeight;
+    Cache.Hashed.lfWidth = plf->lfWidth;
     Cache.Hashed.Aspect.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
     Cache.Hashed.Aspect.Emu.Italic = (plf->lfItalic && !FontGDI->OriginalItalic);
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4589,8 +4589,8 @@ ftGdiGetTextMetricsW(
         Error = IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
 
         // NOTE: GetTextMetrics simply ignores lfEscapement and XFORM.
-        if (FT_IS_SCALABLE(Cache.Hashed.Face) && plf->lfWidth != 0)
-            IntWidthMatrix(Cache.Hashed.Face, &mat, plf->lfWidth);
+        if (FT_IS_SCALABLE(Face) && plf->lfWidth != 0)
+            IntWidthMatrix(Face, &mat, plf->lfWidth);
         else
             mat = identityMat;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3783,7 +3783,7 @@ ftGdiGetGlyphOutline(
     IntLockFreeType();
     TextIntUpdateSize(dc, TextObj, FontGDI, FALSE);
     FtMatrixFromMx(&mat, DC_pmxWorldToDevice(dc));
-    FT_Set_Transform(ft_face, &mat, 0);
+    FT_Set_Transform(ft_face, &mat, NULL);
 
     TEXTOBJ_UnlockText(TextObj);
 
@@ -4267,10 +4267,6 @@ TextIntGetTextExtentPoint(PDC dc,
         *Fit = 0;
     }
 
-    IntLockFreeType();
-
-    TextIntUpdateSize(dc, TextObj, FontGDI, FALSE);
-
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
     Cache.Hashed.lfHeight = plf->lfHeight;
     Cache.Hashed.Aspect.Emu.Bold = EMUBOLD_NEEDED(FontGDI->OriginalWeight, plf->lfWeight);
@@ -4282,6 +4278,8 @@ TextIntGetTextExtentPoint(PDC dc,
         Cache.Hashed.Aspect.RenderMode = (BYTE)FT_RENDER_MODE_MONO;
 
     // NOTE: GetTextExtentPoint32 simply ignores lfEscapement and XFORM.
+    IntLockFreeType();
+    TextIntUpdateSize(dc, TextObj, FontGDI, FALSE);
     Cache.Hashed.matTransform = identityMat;
     FT_Set_Transform(Cache.Hashed.Face, NULL, NULL);
 
@@ -4325,7 +4323,7 @@ TextIntGetTextExtentPoint(PDC dc,
         previous = glyph_index;
         String++;
     }
-    ASSERT(FontGDI->Magic == FONTGDI_MAGIC);
+
     ascender = FontGDI->tmAscent; /* Units above baseline */
     descender = FontGDI->tmDescent; /* Units below baseline */
     IntUnLockFreeType();
@@ -4557,9 +4555,8 @@ ftGdiGetTextMetricsW(
 
         Face = FontGDI->SharedFace->Face;
 
-        IntLockFreeType();
-
         // NOTE: GetTextMetrics simply ignores lfEscapement and XFORM.
+        IntLockFreeType();
         Error = IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
         FT_Set_Transform(Face, NULL, NULL);
 
@@ -6686,9 +6683,9 @@ NtGdiGetCharABCWidthsW(
     }
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
-    IntLockFreeType();
 
     // NOTE: GetCharABCWidths simply ignores lfEscapement and XFORM.
+    IntLockFreeType();
     IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
     FT_Set_Transform(face, NULL, NULL);
 
@@ -6875,9 +6872,9 @@ NtGdiGetCharWidthW(
     }
 
     plf = &TextObj->logfont.elfEnumLogfontEx.elfLogFont;
-    IntLockFreeType();
 
     // NOTE: GetCharWidth simply ignores lfEscapement and XFORM.
+    IntLockFreeType();
     IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
     FT_Set_Transform(face, NULL, NULL);
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -4283,7 +4283,7 @@ TextIntGetTextExtentPoint(PDC dc,
 
     // NOTE: GetTextExtentPoint32 simply ignores lfEscapement and XFORM.
     Cache.Hashed.matTransform = identityMat;
-    FT_Set_Transform(Cache.Hashed.Face, &Cache.Hashed.matTransform, 0);
+    FT_Set_Transform(Cache.Hashed.Face, NULL, NULL);
 
     use_kerning = FT_HAS_KERNING(Cache.Hashed.Face);
     previous = 0;
@@ -4561,7 +4561,7 @@ ftGdiGetTextMetricsW(
 
         // NOTE: GetTextMetrics simply ignores lfEscapement and XFORM.
         Error = IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
-        FT_Set_Transform(Face, (FT_Matrix*)&identityMat, 0);
+        FT_Set_Transform(Face, NULL, NULL);
 
         IntUnLockFreeType();
 
@@ -6067,7 +6067,7 @@ IntExtTextOutW(
     {
         pmxWorldToDevice = DC_pmxWorldToDevice(dc);
         FtMatrixFromMx(&Cache.Hashed.matTransform, pmxWorldToDevice);
-        FT_Set_Transform(face, &Cache.Hashed.matTransform, 0);
+        FT_Set_Transform(face, &Cache.Hashed.matTransform, NULL);
 
         fixAscender = ScaleLong(FontGDI->tmAscent, &pmxWorldToDevice->efM22) << 6;
         fixDescender = ScaleLong(FontGDI->tmDescent, &pmxWorldToDevice->efM22) << 6;
@@ -6076,7 +6076,7 @@ IntExtTextOutW(
     {
         pmxWorldToDevice = (PMATRIX)&gmxWorldToDeviceDefault;
         FtMatrixFromMx(&Cache.Hashed.matTransform, pmxWorldToDevice);
-        FT_Set_Transform(face, &Cache.Hashed.matTransform, 0);
+        FT_Set_Transform(face, &Cache.Hashed.matTransform, NULL);
 
         fixAscender = FontGDI->tmAscent << 6;
         fixDescender = FontGDI->tmDescent << 6;
@@ -6690,7 +6690,7 @@ NtGdiGetCharABCWidthsW(
 
     // NOTE: GetCharABCWidths simply ignores lfEscapement and XFORM.
     IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
-    FT_Set_Transform(face, (FT_Matrix*)&identityMat, 0);
+    FT_Set_Transform(face, NULL, NULL);
 
     for (i = FirstChar; i < FirstChar+Count; i++)
     {
@@ -6879,7 +6879,7 @@ NtGdiGetCharWidthW(
 
     // NOTE: GetCharWidth simply ignores lfEscapement and XFORM.
     IntRequestFontSize(dc, FontGDI, plf->lfWidth, plf->lfHeight);
-    FT_Set_Transform(face, (FT_Matrix*)&identityMat, 0);
+    FT_Set_Transform(face, NULL, NULL);
 
     for (i = FirstChar; i < FirstChar+Count; i++)
     {


### PR DESCRIPTION
## Purpose
Improve text/font rendering and metrics.
JIRA issue: [CORE-11848](https://jira.reactos.org/browse/CORE-11848)

## Proposed changes

- Add `lfWidth` member into `FONTGDI` structure.
- Delete `IntWidthMatrix` function.
- Fix `IntRequestFontSize` behavior for processing `lfWidth` value.
- Apply `lfWidth` in `GetTextMetrics` and `GetCharWidth`.
- Ignore the `XFORM` values in `GetTextMetrics` and `GetCharWidth`.

## TODO

- [x] Do big tests.