### PR TITLE
[NTGDI][FREETYPE] lfEscapement for TextOut

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3564,7 +3564,7 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = min(EmHeight, USHORT_MAX);
 
     if (lfWidth != 0)
-        Width64 = ((lfWidth * 96 / 72 * 5 / 3) << 6); /* ??? FIXME */
+        Width64 = (FT_MulDiv(lfWidth, 96 * 5, 72 * 3) << 6); /* ??? FIXME */
     else
         Width64 = 0;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6379,6 +6379,8 @@ IntExtTextOutW(
         /* Calculate the position and the thickness */
         INT i, underline_position, thickness;
 
+        DeltaY64 = Y64 - RealYStart64;
+
         if (!face->units_per_EM)
         {
             underline_position = 0;
@@ -6402,7 +6404,10 @@ IntExtTextOutW(
                 EngLineTo(SurfObj,
                           (CLIPOBJ *)&dc->co,
                           &dc->eboText.BrushObject,
-                          ((RealXStart64 + 32) >> 6), Y, ((X64 + 32) >> 6), Y,
+                          ((RealXStart64 + 32) >> 6),
+                          Y,
+                          ((X64 + 32) >> 6),
+                          Y + ((DeltaY64 + 32) >> 6),
                           NULL,
                           ROP2_TO_MIX(R2_COPYPEN));
             }
@@ -6416,7 +6421,10 @@ IntExtTextOutW(
                 EngLineTo(SurfObj,
                           (CLIPOBJ *)&dc->co,
                           &dc->eboText.BrushObject,
-                          ((RealXStart64 + 32) >> 6), Y, ((X64 + 32) >> 6), Y,
+                          ((RealXStart64 + 32) >> 6),
+                          Y,
+                          ((X64 + 32) >> 6),
+                          Y + ((DeltaY64 + 32) >> 6),
                           NULL,
                           ROP2_TO_MIX(R2_COPYPEN));
             }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5893,7 +5893,7 @@ IntGetTextDisposition(
         {
             FT_Get_Kerning(face, previous, glyph_index, 0, &delta);
             X64 += delta.x;
-            Y64 += delta.y;
+            Y64 -= delta.y;
         }
 
         if (NULL == Dx)
@@ -6242,7 +6242,7 @@ IntExtTextOutW(
         {
             FT_Get_Kerning(face, previous, glyph_index, 0, &delta);
             X64 += delta.x;
-            Y64 += delta.y;
+            Y64 -= delta.y;
         }
 
         DPRINT("X64, Y64: %I64d, %I64d\n", X64, Y64);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6357,9 +6357,6 @@ IntExtTextOutW(
                 }
             }
 
-            if (dc->dctype == DCTYPE_DIRECT)
-                MouseSafetyOnDrawStart(dc->ppdev, DestRect.left, DestRect.top, DestRect.right, DestRect.bottom);
-
             if (!IntEngMaskBlt(SurfObj,
                                SourceGlyphSurf,
                                (CLIPOBJ *)&dc->co,
@@ -6372,9 +6369,6 @@ IntExtTextOutW(
             {
                 DPRINT1("Failed to MaskBlt a glyph!\n");
             }
-
-            if (dc->dctype == DCTYPE_DIRECT)
-                MouseSafetyOnDrawEnd(dc->ppdev) ;
 
             EngUnlockSurface(SourceGlyphSurf);
             EngDeleteSurface((HSURF)HSourceGlyph);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5855,7 +5855,10 @@ ScaleLong(LONG lValue, PFLOATOBJ pef)
     return lValue;
 }
 
-/* Calculate width of the text. */
+/*
+ * Calculate X and Y disposition of the text.
+ * NOTE: The disposition can be negative.
+ */
 static BOOL
 ftGdiGetTextDisposition(
     LONGLONG *pX64,

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5964,7 +5964,6 @@ IntExtTextOutW(
     PTEXTOBJ TextObj;
     EXLATEOBJ exloRGB2Dst, exloDst2RGB;
     POINT Start;
-    USHORT DxShift;
     PMATRIX pmxWorldToDevice;
     FT_Vector delta, vecAscent64, vecDescent64;
     LOGFONTW *plf;
@@ -6225,7 +6224,6 @@ IntExtTextOutW(
      */
     X64 = RealXStart64;
     Y64 = RealYStart64;
-    DxShift = (fuOptions & ETO_PDY) ? 1 : 0;
     previous = 0;
     DoBreak = FALSE;
     for (i = 0; i < Count; ++i)
@@ -6366,11 +6364,6 @@ IntExtTextOutW(
         }
 
         DPRINT("New X64: %I64d, New Y64: %I64d\n", X64, Y64);
-
-        if (DxShift)
-        {
-            Y64 -= Dx[2 * i + 1];
-        }
 
         previous = glyph_index;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6117,21 +6117,18 @@ IntExtTextOutW(
 
     if (lprc && (fuOptions & ETO_OPAQUE))
     {
-        RtlCopyMemory(&DestRect, lprc, sizeof(DestRect));
-
         if (FLOATOBJ_Equal0(&pmxWorldToDevice->efM12) &&
             FLOATOBJ_Equal0(&pmxWorldToDevice->efM21))
         {
-            IntLPtoDP(dc, (POINT*)&DestRect, 2);
-
-            DestRect.left   += dc->ptlDCOrig.x;
-            DestRect.right  += dc->ptlDCOrig.x;
-            DestRect.top    += dc->ptlDCOrig.y;
-            DestRect.bottom += dc->ptlDCOrig.y;
+            IntLPtoDP(dc, (POINT*)lprc, 2);
+            lprc->left   += dc->ptlDCOrig.x;
+            lprc->right  += dc->ptlDCOrig.x;
+            lprc->top    += dc->ptlDCOrig.y;
+            lprc->bottom += dc->ptlDCOrig.y;
 
             IntEngFillBox(dc,
-                          DestRect.left, DestRect.top,
-                          DestRect.right - DestRect.left, DestRect.bottom - DestRect.top,
+                          lprc->left, lprc->top,
+                          lprc->right - lprc->left, lprc->bottom - lprc->top,
                           &dc->eboBackground.BrushObject);
         }
         else
@@ -6139,10 +6136,10 @@ IntExtTextOutW(
             UINT i;
             POINT pts[4] =
             {
-                { DestRect.left, DestRect.top },
-                { DestRect.right, DestRect.top },
-                { DestRect.right, DestRect.bottom },
-                { DestRect.left, DestRect.bottom },
+                { lprc->left, lprc->top },
+                { lprc->right, lprc->top },
+                { lprc->right, lprc->bottom },
+                { lprc->left, lprc->bottom },
             };
 
             IntLPtoDP(dc, pts, 4);

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6245,9 +6245,8 @@ IntExtTextOutW(
             Y64 += delta.y;
         }
 
-        DPRINT("X64: %I64d\n", X64);
-        DPRINT("Y64: %I64d\n", Y64);
-        DPRINT("Advance: %d\n", realglyph->root.advance.x);
+        DPRINT("X64, Y64: %I64d, %I64d\n", X64, Y64);
+        DPRINT("Advance: %d, %d\n", realglyph->root.advance.x, realglyph->root.advance.y);
 
         bitSize.cx = realglyph->bitmap.width;
         bitSize.cy = realglyph->bitmap.rows;
@@ -6362,7 +6361,7 @@ IntExtTextOutW(
             Y64 -= vec.y;
         }
 
-        DPRINT("New X64: %I64d, New Y64: %I64d\n", X64, Y64);
+        DPRINT("New X64, New Y64: %I64d, %I64d\n", X64, Y64);
 
         previous = glyph_index;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6037,7 +6037,6 @@ IntExtTextOutW(
     LONGLONG X64, Y64, RealXStart64, RealYStart64, DeltaX64, DeltaY64;
     ULONG previous;
     RECTL DestRect, MaskRect;
-    POINTL BrushOrigin;
     HBITMAP HSourceGlyph;
     SIZEL bitSize;
     FONTOBJ *FontObj;
@@ -6101,8 +6100,6 @@ IntExtTextOutW(
 
     MaskRect.left = 0;
     MaskRect.top = 0;
-    BrushOrigin.x = 0;
-    BrushOrigin.y = 0;
 
     psurf = dc->dclevel.pSurface;
     SurfObj = &psurf->SurfObj;
@@ -6398,7 +6395,7 @@ IntExtTextOutW(
                                &DestRect,
                                (PPOINTL)&MaskRect,
                                &dc->eboText.BrushObject,
-                               &BrushOrigin))
+                               &PointZero))
             {
                 DPRINT1("Failed to MaskBlt a glyph!\n");
             }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6450,6 +6450,7 @@ IntExtTextOutW(
     {
         /* Calculate the position and the thickness */
         INT underline_position, thickness;
+        FT_Vector vecA64, vecB64;
 
         DeltaX64 = X64 - RealXStart64;
         DeltaY64 = Y64 - RealYStart64;
@@ -6471,7 +6472,6 @@ IntExtTextOutW(
 
         if (plf->lfUnderline) /* Draw underline */
         {
-            FT_Vector vecA64, vecB64;
             vecA64.x = 0;
             vecA64.y = (-underline_position - thickness / 2) << 6;
             vecB64.x = 0;
@@ -6506,27 +6506,26 @@ IntExtTextOutW(
 
         if (plf->lfStrikeOut) /* Draw strike-out */
         {
-            FT_Vector vecC64, vecD64;
-            vecC64.x = 0;
-            vecC64.y = -(FontGDI->tmAscent << 6) / 3;
-            vecD64.x = 0;
-            vecD64.y = vecC64.y + (thickness << 6);
-            FT_Vector_Transform(&vecC64, &Cache.Hashed.matTransform);
-            FT_Vector_Transform(&vecD64, &Cache.Hashed.matTransform);
+            vecA64.x = 0;
+            vecA64.y = -(FontGDI->tmAscent << 6) / 3;
+            vecB64.x = 0;
+            vecB64.y = vecA64.y + (thickness << 6);
+            FT_Vector_Transform(&vecA64, &Cache.Hashed.matTransform);
+            FT_Vector_Transform(&vecB64, &Cache.Hashed.matTransform);
             {
-                INT X0 = (RealXStart64 - vecC64.x + 32) >> 6;
-                INT Y0 = (RealYStart64 + vecC64.y + 32) >> 6;
+                INT X0 = (RealXStart64 - vecA64.x + 32) >> 6;
+                INT Y0 = (RealYStart64 + vecA64.y + 32) >> 6;
                 INT DX = (DeltaX64 >> 6);
                 if (Cache.Hashed.matTransform.xy == 0 && Cache.Hashed.matTransform.yx == 0)
                 {
-                    INT CY = (vecD64.y - vecC64.y + 32) >> 6;
+                    INT CY = (vecB64.y - vecA64.y + 32) >> 6;
                     IntEngFillBox(dc, X0, Y0, DX, CY, &dc->eboText.BrushObject);
                 }
                 else
                 {
                     INT DY = (DeltaY64 >> 6);
-                    INT X1 = X0 + ((vecC64.x - vecD64.x + 32) >> 6);
-                    INT Y1 = Y0 + ((vecD64.y - vecC64.y + 32) >> 6);
+                    INT X1 = X0 + ((vecA64.x - vecB64.x + 32) >> 6);
+                    INT Y1 = Y0 + ((vecB64.y - vecA64.y + 32) >> 6);
                     POINT pts[4] =
                     {
                         { X0,       Y0      },

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6259,19 +6259,18 @@ IntExtTextOutW(
         {
             INT X0 = (RealXStart64 - vecAscent64.x + 32) >> 6;
             INT Y0 = (RealYStart64 + vecAscent64.y + 32) >> 6;
+            INT DX = (DeltaX64 >> 6);
             if (Cache.Hashed.matTransform.xy == 0 &&
                 Cache.Hashed.matTransform.yx == 0)
             {
                 INT CY = (vecDescent64.y - vecAscent64.y + 32) >> 6;
-                INT DX = (DeltaX64 >> 6);
                 IntEngFillBox(dc, X0, Y0, DX, CY, &dc->eboBackground.BrushObject);
             }
             else
             {
+                INT DY = (DeltaY64 >> 6);
                 INT X1 = X0 + (vecAscent64.x - vecDescent64.x + 32) >> 6;
                 INT Y1 = Y0 + (vecDescent64.y - vecAscent64.y + 32) >> 6;
-                INT DX = (DeltaX64 >> 6);
-                INT DY = (DeltaY64 >> 6);
                 POINT pts[4];
                 pts[0].x = X0;
                 pts[0].y = Y0;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3563,8 +3563,8 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = max(EmHeight, 1);
     EmHeight = min(EmHeight, USHORT_MAX);
 
-    if (pOS2 && lfWidth > 0)
-        Width64 = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
+    if (lfWidth != 0)
+        Width64 = ((lfWidth * 96 / 72 * 5 / 3) << 6); /* ??? FIXME */
     else
         Width64 = 0;
 

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3563,10 +3563,17 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = max(EmHeight, 1);
     EmHeight = min(EmHeight, USHORT_MAX);
 
+#if 1
+    if (lfWidth != 0)
+        Width64 = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
+    else
+        Width64 = 0;
+#else
     if (lfWidth != 0)
         Width64 = (FT_MulDiv(lfWidth, 96 * 5, 72 * 3) << 6); /* ??? FIXME */
     else
         Width64 = 0;
+#endif
 
     req.type           = FT_SIZE_REQUEST_TYPE_NOMINAL;
     req.width          = Width64;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6143,9 +6143,15 @@ IntExtTextOutW(
 
         /* Adjust the horizontal position by horizontal alignment */
         if ((pdcattr->flTextAlign & TA_CENTER) == TA_CENTER)
+        {
             RealXStart64 -= DeltaX64 / 2;
+            RealYStart64 -= DeltaY64 / 2;
+        }
         else if ((pdcattr->flTextAlign & TA_RIGHT) == TA_RIGHT)
+        {
             RealXStart64 -= DeltaX64;
+            RealYStart64 -= DeltaY64;
+        }
 
         /* Fill background */
         if (fuOptions & ETO_OPAQUE)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6273,15 +6273,13 @@ IntExtTextOutW(
                 INT DY = (DeltaY64 >> 6);
                 INT X1 = X0 + ((vecAscent64.x - vecDescent64.x + 32) >> 6);
                 INT Y1 = Y0 + ((vecDescent64.y - vecAscent64.y + 32) >> 6);
-                POINT pts[4];
-                pts[0].x = X0;
-                pts[0].y = Y0;
-                pts[1].x = X0 + DX;
-                pts[1].y = Y0 + DY;
-                pts[2].x = X1 + DX;
-                pts[2].y = Y1 + DY;
-                pts[3].x = X1;
-                pts[3].y = Y1;
+                POINT pts[4] =
+                {
+                    { X0,       Y0      },
+                    { X0 + DX,  Y0 + DY },
+                    { X1 + DX,  Y1 + DY },
+                    { X1,       Y1      },
+                };
                 IntEngFillPolygon(dc, pts, 4, &dc->eboBackground.BrushObject);
             }
         }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -3564,11 +3564,14 @@ IntRequestFontSize(PDC dc, PFONTGDI FontGDI, LONG lfWidth, LONG lfHeight)
     EmHeight = min(EmHeight, USHORT_MAX);
 
 #if 1
+    /* I think this is wrong implementation but its test result is better. */
     if (lfWidth != 0)
         Width64 = FT_MulDiv(lfWidth, face->units_per_EM, pOS2->xAvgCharWidth) << 6;
     else
         Width64 = 0;
 #else
+    /* I think this is correct implementation but it is mismatching to the
+       other metric functions. The test result is bad. */
     if (lfWidth != 0)
         Width64 = (FT_MulDiv(lfWidth, 96 * 5, 72 * 3) << 6); /* ??? FIXME */
     else

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -6205,10 +6205,10 @@ IntExtTextOutW(
 
     /* Calculate the ascent point and the descent point */
     vecAscent64.x = 0;
-    vecAscent64.y = -(FontGDI->tmAscent << 6);
+    vecAscent64.y = (FontGDI->tmAscent << 6);
     FT_Vector_Transform(&vecAscent64, &Cache.Hashed.matTransform);
     vecDescent64.x = 0;
-    vecDescent64.y = (FontGDI->tmDescent << 6);
+    vecDescent64.y = -(FontGDI->tmDescent << 6);
     FT_Vector_Transform(&vecDescent64, &Cache.Hashed.matTransform);
 
     /* Process the vertical alignment and fix the real starting point. */
@@ -6219,13 +6219,13 @@ IntExtTextOutW(
     }
     else if ((pdcattr->flTextAlign & VALIGN_MASK) == TA_BOTTOM)
     {
-        RealXStart64 += vecDescent64.x;
-        RealYStart64 -= vecDescent64.y;
+        RealXStart64 -= vecDescent64.x;
+        RealYStart64 += vecDescent64.y;
     }
     else /* TA_TOP */
     {
-        RealXStart64 += vecAscent64.x;
-        RealYStart64 -= vecAscent64.y;
+        RealXStart64 -= vecAscent64.x;
+        RealYStart64 += vecAscent64.y;
     }
 #undef VALIGN_MASK
 
@@ -6256,19 +6256,19 @@ IntExtTextOutW(
         /* Fill background */
         if (fuOptions & ETO_OPAQUE)
         {
-            INT X0 = (RealXStart64 - vecAscent64.x + 32) >> 6;
-            INT Y0 = (RealYStart64 + vecAscent64.y + 32) >> 6;
+            INT X0 = (RealXStart64 + vecAscent64.x + 32) >> 6;
+            INT Y0 = (RealYStart64 - vecAscent64.y + 32) >> 6;
             INT DX = (DeltaX64 >> 6);
             if (Cache.Hashed.matTransform.xy == 0 && Cache.Hashed.matTransform.yx == 0)
             {
-                INT CY = (vecDescent64.y - vecAscent64.y + 32) >> 6;
+                INT CY = (vecAscent64.y - vecDescent64.y + 32) >> 6;
                 IntEngFillBox(dc, X0, Y0, DX, CY, &dc->eboBackground.BrushObject);
             }
             else
             {
                 INT DY = (DeltaY64 >> 6);
-                INT X1 = X0 + ((vecAscent64.x - vecDescent64.x + 32) >> 6);
-                INT Y1 = Y0 + ((vecDescent64.y - vecAscent64.y + 32) >> 6);
+                INT X1 = ((RealXStart64 + vecDescent64.x + 32) >> 6);
+                INT Y1 = ((RealYStart64 - vecDescent64.y + 32) >> 6);
                 POINT pts[4] =
                 {
                     { X0,       Y0      },


### PR DESCRIPTION
## Purpose
Realize font/text transformation in correct and quick implementation. Retrial of PR #1207.
JIRA issue: [CORE-11848](https://jira.reactos.org/browse/CORE-11848)

## Proposed changes

- Rename `ftGdiGetTextWidth` as `IntGetTextDisposition` and add a Y parameter.
- Add `RealYStart64` variable.
- Apply `lfEscapement` values (by multiplying matrices).
- Add `IntEngFillPolygon` and `IntEngFillBox` helper functions.

## TODO

- [x] Background fill.
- [x] `lfWidth`.
- [x] `lfEscapement`.
- [x] `XFORM`.
- [x] Underline.
- [x] StrikeOut.
- [x] The `testcase` program.
- [ ] Vertical tabs.
- [ ] Photivo.
- [x] Do big tests.