### PR TITLE
[MSPAINT] Don't allow to set image as wallpaper if it has the wrong format

### DIFF
--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -280,14 +280,18 @@ LRESULT CMainWindow::OnInitMenuPopup(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     BOOL trueSelection =
         (::IsWindowVisible(selectionWindow) &&
          ((toolsModel.GetActiveTool() == TOOL_FREESEL) || (toolsModel.GetActiveTool() == TOOL_RECTSEL)));
+    BOOL isBMP;
     switch (lParam)
     {
         case 0: /* File menu */
             if ((HMENU)wParam != GetSubMenu(menu, 0))
                 break;
-            EnableMenuItem(menu, IDM_FILEASWALLPAPERPLANE,     ENABLED_IF(isAFile));
-            EnableMenuItem(menu, IDM_FILEASWALLPAPERCENTERED,  ENABLED_IF(isAFile));
-            EnableMenuItem(menu, IDM_FILEASWALLPAPERSTRETCHED, ENABLED_IF(isAFile));
+
+            isBMP = _wcsicmp(PathFindExtensionW(filepathname), L".bmp") == 0;
+            EnableMenuItem(menu, IDM_FILEASWALLPAPERPLANE,     ENABLED_IF(isAFile && isBMP));
+            EnableMenuItem(menu, IDM_FILEASWALLPAPERCENTERED,  ENABLED_IF(isAFile && isBMP));
+            EnableMenuItem(menu, IDM_FILEASWALLPAPERSTRETCHED, ENABLED_IF(isAFile && isBMP));
+
             RemoveMenu(menu, IDM_FILE1, MF_BYCOMMAND);
             RemoveMenu(menu, IDM_FILE2, MF_BYCOMMAND);
             RemoveMenu(menu, IDM_FILE3, MF_BYCOMMAND);


### PR DESCRIPTION
## Purpose

Our Paint allows user to try to set a .ico file as a wallpaper, which isn't possible. Different Windows versions have different behaviour, so it was decided that the simplest fix would be to just grey out "Set as wallpaper" buttons as in 2K3 (See the Jira ticket).

JIRA issue: [CORE-18661](https://jira.reactos.org/browse/CORE-18661)

## Proposed changes

Check the file extension and deactivate the buttons if needed.

![image](https://user-images.githubusercontent.com/30466983/205428283-7205424b-31d7-4dbc-9593-64353b09c245.png)

