### PR TITLE
[KDGDB] Fix compilation following commit de81021ba

### DIFF
--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -259,8 +259,8 @@ GetVersionSendHandler(
     RtlCopyMemory(&KdVersion, &State->u.GetVersion64, sizeof(KdVersion));
     DebuggerDataList = (LIST_ENTRY*)(ULONG_PTR)KdVersion.DebuggerDataList;
     KdDebuggerDataBlock = CONTAINING_RECORD(DebuggerDataList->Flink, KDDEBUGGER_DATA64, Header.List);
-    ProcessListHead = (LIST_ENTRY*)KdDebuggerDataBlock->PsActiveProcessHead.Pointer;
-    ModuleListHead = (LIST_ENTRY*)KdDebuggerDataBlock->PsLoadedModuleList.Pointer;
+    ProcessListHead = (LIST_ENTRY*)(ULONG_PTR)KdDebuggerDataBlock->PsActiveProcessHead;
+    ModuleListHead = (LIST_ENTRY*)(ULONG_PTR)KdDebuggerDataBlock->PsLoadedModuleList;
 
     /* Now we can get the context for the current state */
     KdpSendPacketHandler = NULL;


### PR DESCRIPTION
Use cast to be compatible with "public" structure definition. (By "public" I understand that code could use MS PSDK wdbgexts.h definitions instead of our hacked version.)
Caught by @hpoussin :+1: