### PR TITLE
[NTOS:IO] Properly zero-initialize file object extension on file object creation

### DIFF
--- a/ntoskrnl/io/iomgr/file.c
+++ b/ntoskrnl/io/iomgr/file.c
@@ -857,7 +857,7 @@ IopParseDevice(IN PVOID ParseObject,
             }
 
             /* Clear the file object */
-            RtlZeroMemory(FileObject, sizeof(FILE_OBJECT));
+            RtlZeroMemory(FileObject, ObjectSize);
 
             /* Check if this is Synch I/O */
             if (OpenPacket->CreateOptions &
@@ -917,6 +917,7 @@ IopParseDevice(IN PVOID ParseObject,
                 /* Make sure the file object knows it has an extension */
                 FileObject->Flags |= FO_FILE_OBJECT_HAS_EXTENSION;
 
+                /* Initialize file object extension */
                 FileObjectExtension = (PFILE_OBJECT_EXTENSION)(FileObject + 1);
                 FileObject->FileObjectExtension = FileObjectExtension;
 


### PR DESCRIPTION
## Purpose

Zero-initialize `FileObjectExtension` member of `FileObject` in `IopParseDevice` by passing the actual `ObjectSize` to `RtlZeroMemory` call, instead of `sizeof(FILE_OBJECT)` only. It allows to initialize `FileObjectExtension` members properly, such as `FilterContext` and `TopDeviceObjectHint`. Since they are deleted on file object deletion (in case it has an extension), they should also be initialized correctly on creation to avoid any failure(s).
It fixes an assert in `FsRtlPTeardownPerFileObjectContexts` and BAD_POOL_CALLER bugcheck for the apps which manage file object with an extension. For example, Kaspersky Anti-Virus 2012 installer. Now that installer fails with another issue.

JIRA issue: [CORE-18711](https://jira.reactos.org/browse/CORE-18711)