### PR TITLE
[SHLWAPI] No need extension to execute '.bat' files CORE-17612

### DIFF
--- a/dll/win32/kernel32/client/path.c
+++ b/dll/win32/kernel32/client/path.c
@@ -2321,7 +2321,7 @@ GetSystemDirectoryW(OUT LPWSTR lpBuffer,
         RtlCopyMemory(lpBuffer,
                       BaseWindowsSystemDirectory.Buffer,
                       BaseWindowsSystemDirectory.Length);
-        lpBuffer[BaseWindowsSystemDirectory.Length / sizeof(WCHAR)] = ANSI_NULL;
+        lpBuffer[BaseWindowsSystemDirectory.Length / sizeof(WCHAR)] = UNICODE_NULL;
 
         ReturnLength = BaseWindowsSystemDirectory.Length;
     }
@@ -2405,7 +2405,7 @@ GetSystemWindowsDirectoryW(OUT LPWSTR lpBuffer,
         RtlCopyMemory(lpBuffer,
                       BaseWindowsDirectory.Buffer,
                       BaseWindowsDirectory.Length);
-        lpBuffer[BaseWindowsDirectory.Length / sizeof(WCHAR)] = ANSI_NULL;
+        lpBuffer[BaseWindowsDirectory.Length / sizeof(WCHAR)] = UNICODE_NULL;
 
         ReturnLength = BaseWindowsDirectory.Length;
     }

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2531,6 +2531,8 @@ HRESULT WINAPI ShellExecCmdLine(
     }
     else
     {
+        PCWSTR apPathList[2];
+
         pchParams = SplitParams(lpCommand, szFile, _countof(szFile));
         if (szFile[0] != UNICODE_NULL && szFile[1] == L':' &&
             szFile[2] == UNICODE_NULL)
@@ -2551,30 +2553,10 @@ HRESULT WINAPI ShellExecCmdLine(
         {
             StringCchCopyW(szFile, _countof(szFile), szFile2);
         }
-        else if (SearchPathW(NULL, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, szFile, L".exe", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, szFile, L".com", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, szFile, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, szFile, L".exe", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, szFile, L".com", _countof(szFile2), szFile2, NULL))
-        {
-            StringCchCopyW(szFile, _countof(szFile), szFile2);
-        }
-        else if (SearchPathW(NULL, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, lpCommand, L".exe", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(NULL, lpCommand, L".com", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, lpCommand, NULL, _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, lpCommand, L".exe", _countof(szFile2), szFile2, NULL) ||
-                 SearchPathW(pwszStartDir, lpCommand, L".com", _countof(szFile2), szFile2, NULL))
-        {
-            StringCchCopyW(szFile, _countof(szFile), szFile2);
-            pchParams = NULL;
-        }
 
-        if (pwszStartDir)
-        {
-            SetCurrentDirectoryW(szCurDir);
-        }
+        apPathList[0] = pwszStartDir;
+        apPathList[1] = NULL;
+        PathFindOnPathExW(szFile, apPathList, WHICH_DEFAULT);
 
         if (!(dwSeclFlags & SECL_ALLOW_NONEXE))
         {

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1151,6 +1151,7 @@ BOOL WINAPI PathFileExistsDefExtW(LPWSTR lpszPath,DWORD dwWhich)
 #ifdef __REACTOS__
         if (dwWhich & 0x1)
         {
+        if (GetFileAttributes(lpszPath) != FILE_ATTRIBUTE_DIRECTORY)
 #endif
         lstrcpyW(lpszPath + iLen, pszExts[iChoose]);
         if (PathFileExistsW(lpszPath))

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1353,7 +1353,7 @@ BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile,LPCWSTR *lppszOtherDirs,DWORD dwWh
 
   TRACE("(%s,%p,%08x)\n", debugstr_w(lpszFile), lppszOtherDirs, dwWhich);
 
-  if (!lpszFile || !PathIsFileSpecW(lpszFile))
+  if (!PathIsFileSpecW(lpszFile) || !lpszFile)
     return FALSE;
 
   /* Search provided directories first */

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1353,7 +1353,7 @@ BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile,LPCWSTR *lppszOtherDirs,DWORD dwWh
 
   TRACE("(%s,%p,%08x)\n", debugstr_w(lpszFile), lppszOtherDirs, dwWhich);
 
-  if (!(lpszFile && PathIsFileSpecW(lpszFile)))
+  if (!PathIsFileSpecW(lpszFile) || !lpszFile)
     return FALSE;
 
   /* Search provided directories first */

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1353,7 +1353,7 @@ BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile,LPCWSTR *lppszOtherDirs,DWORD dwWh
 
   TRACE("(%s,%p,%08x)\n", debugstr_w(lpszFile), lppszOtherDirs, dwWhich);
 
-  if (!PathIsFileSpecW(lpszFile) || !lpszFile)
+  if (!(lpszFile && PathIsFileSpecW(lpszFile)))
     return FALSE;
 
   /* Search provided directories first */

--- a/dll/win32/shlwapi/path.c
+++ b/dll/win32/shlwapi/path.c
@@ -1353,7 +1353,7 @@ BOOL WINAPI PathFindOnPathExW(LPWSTR lpszFile,LPCWSTR *lppszOtherDirs,DWORD dwWh
 
   TRACE("(%s,%p,%08x)\n", debugstr_w(lpszFile), lppszOtherDirs, dwWhich);
 
-  if (!PathIsFileSpecW(lpszFile) || !lpszFile)
+  if (!lpszFile || !PathIsFileSpecW(lpszFile))
     return FALSE;
 
   /* Search provided directories first */


### PR DESCRIPTION
When no extension is provided, add default extension with correct precedence
using PathFileExistsDefExtW.

Use PathFindOnPathExW when searching in current directory and PATH environment variable
Fix Width String terminator to UNICODE_NULL
Fix all failed tests on PathFindPathExW KVM test


JIRA issue: [CORE-17612](https://jira.reactos.org/browse/CORE-17612)
