### PR TITLE
[NTUSER] Fix zombie window created by CTRL+ALT+DEL

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1945,9 +1945,12 @@ co_WinPosSetWindowPos(
           (!(Window->ExStyle & WS_EX_TOOLWINDOW) && !Window->spwndOwner &&
            (!Window->spwndParent || UserIsDesktopWindow(Window->spwndParent))))
       {
-         co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
-         if (!(WinPos.flags & SWP_NOACTIVATE))
-            UpdateShellHook(Window);
+         if (!UserIsDesktopWindow(Window))
+         {
+            co_IntShellHookNotify(HSHELL_WINDOWCREATED, (WPARAM)Window->head.h, 0);
+            if (!(WinPos.flags & SWP_NOACTIVATE))
+               UpdateShellHook(Window);
+         }
       }
 
       Window->style |= WS_VISIBLE; //IntSetStyle( Window, WS_VISIBLE, 0 );


### PR DESCRIPTION
## Purpose
Fix zombie window created by CTRL+ALT+DEL (Based on patch by [I_Kill_Bugs](https://jira.reactos.org/secure/ViewProfile.jspa?name=I_Kill_Bugs))

JIRA issue: [CORE-18258](https://jira.reactos.org/browse/CORE-18258)

## Purposed changes
- Don't send a HSHELL_WINDOWCREATED if the window is the desktop