### PR TITLE
[BTRFS] btrfs.inf: Comment out mkbtrfs.exe

### DIFF
--- a/drivers/filesystems/btrfs/btrfs.inf
+++ b/drivers/filesystems/btrfs/btrfs.inf
@@ -95,13 +95,13 @@ LoadOrderGroup   = "File System"
 [Btrfs.DllFiles]
 shellbtrfs.dll
 ubtrfs.dll
-mkbtrfs.exe
+; mkbtrfs.exe ; Not imported into ReactOS.
 
 [SourceDisksFiles]
 btrfs.sys = 1,,
 shellbtrfs.dll = 1,,
 ubtrfs.dll = 1,,
-mkbtrfs.exe = 1,,
+; mkbtrfs.exe = 1,, ; Not imported into ReactOS.
 
 [SourceDisksNames.x86]
 1 = %DiskId1%,,,\x86


### PR DESCRIPTION
## Purpose

It is not imported into ReactOS.

Addendum to c8875c1 (0.4.13-dev-788) and 194ea90 (0.4.14-dev-1535).

## Proposed changes

- Comment out mkbtrfs.exe
