### PR TITLE
[LIBWINE] Fix GCC build warning.

### DIFF
--- a/sdk/lib/3rdparty/libwine/debug.c
+++ b/sdk/lib/3rdparty/libwine/debug.c
@@ -336,9 +336,9 @@ int ros_dbg_log( enum __wine_debug_class cls, struct __wine_debug_channel *chann
 static char *get_temp_buffer( size_t size )
 {
     static char *list[32];
-    static int pos;
+    static long pos = 0;
     char *ret;
-    int idx;
+    long idx;
 
     idx = interlocked_xchg_add( &pos, 1 ) % (sizeof(list)/sizeof(list[0]));
     if ((ret = realloc( list[idx], size ))) list[idx] = ret;


### PR DESCRIPTION
Cf. comment https://jira.reactos.org/browse/CORE-18707?focusedCommentId=137342&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-137342
```
In file included from ../sdk/lib/3rdparty/libwine/debug_ros.c:9:
../sdk/lib/3rdparty/libwine/debug.c: In function 'get_temp_buffer':
../sdk/lib/3rdparty/libwine/debug.c:343:33: warning: passing argument 1 of '_InterlockedExchangeAdd' from incompatible pointer type [-Wincompatible-pointer-types]
     idx = interlocked_xchg_add( &pos, 1 ) % (sizeof(list)/sizeof(list[0]));
                                 ^~~~
In file included from ../sdk/include/crt/mingw32/intrin.h:98,
                 from ../sdk/include/crt/intrin.h:1017,
                 from sdk/include/psdk/winnt.h:48,
                 from ../sdk/include/psdk/windef.h:202,
                 from ../sdk/include/reactos/wine/debug.h:26,
                 from ../sdk/lib/3rdparty/libwine/debug.c:32,
                 from ../sdk/lib/3rdparty/libwine/debug_ros.c:9:
../sdk/include/crt/mingw32/intrin_x86.h:215:70: note: expected 'volatile long int *' but argument is of type 'int *'
 __INTRIN_INLINE long __cdecl _InterlockedExchangeAdd(volatile long * Addend, long Value)
                                                      ~~~~~~~~~~~~~~~~^~~~~~
```