### PR TITLE
[SHELL32] Fix detailed list views in control panel

### DIFF
--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -54,6 +54,12 @@ static const shvheader ControlPanelSFHeader[] = {
 
 #define CONROLPANELSHELLVIEWCOLUMNS 2
 
+enum controlpanel_columns
+{
+    CONTROLPANEL_COL_NAME,
+    CONTROLPANEL_COL_COMMENT,
+};
+
 CControlPanelEnum::CControlPanelEnum()
 {
 }
@@ -330,10 +336,10 @@ HRESULT WINAPI CControlPanelFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE
     int result;
     switch(LOWORD(lParam))
     {
-        case 0:        /* name */
+        case CONTROLPANEL_COL_NAME:
             result = wcsicmp(pData1->szName + pData1->offsDispName, pData2->szName + pData2->offsDispName);
             break;
-        case 1:        /* comment */
+        case CONTROLPANEL_COL_COMMENT:
             result = wcsicmp(pData1->szName + pData1->offsComment, pData2->szName + pData2->offsComment);
             break;
         default:
@@ -579,9 +585,9 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iCol
 
         switch(iColumn)
         {
-            case 0:        /* name */
+            case CONTROLPANEL_COL_NAME:
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsDispName);
-            case 1:        /* comment */
+            case CONTROLPANEL_COL_COMMENT:
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsComment);
         }
     }

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -52,12 +52,11 @@ static const shvheader ControlPanelSFHeader[] = {
     {IDS_SHV_COLUMN_COMMENTS, SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT, LVCFMT_LEFT, 80},/*FIXME*/
 };
 
-#define CONROLPANELSHELLVIEWCOLUMNS 2
-
 enum controlpanel_columns
 {
     CONTROLPANEL_COL_NAME,
     CONTROLPANEL_COL_COMMENT,
+    CONTROLPANEL_COL_COUNT,
 };
 
 CControlPanelEnum::CControlPanelEnum()
@@ -330,7 +329,7 @@ HRESULT WINAPI CControlPanelFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE
     PIDLCPanelStruct *pData1 = _ILGetCPanelPointer(pidl1);
     PIDLCPanelStruct *pData2 = _ILGetCPanelPointer(pidl2);
 
-    if (!pData1 || !pData2 || LOWORD(lParam)>= CONROLPANELSHELLVIEWCOLUMNS)
+    if (!pData1 || !pData2 || LOWORD(lParam) >= CONTROLPANEL_COL_COUNT)
         return E_INVALIDARG;
 
     int result;
@@ -550,7 +549,8 @@ HRESULT WINAPI CControlPanelFolder::GetDefaultColumnState(UINT iColumn, DWORD *p
 {
     TRACE("(%p)\n", this);
 
-    if (!pcsFlags || iColumn >= CONROLPANELSHELLVIEWCOLUMNS) return E_INVALIDARG;
+    if (!pcsFlags || iColumn >= CONTROLPANEL_COL_COUNT)
+        return E_INVALIDARG;
     *pcsFlags = ControlPanelSFHeader[iColumn].pcsFlags;
     return S_OK;
 }
@@ -563,7 +563,7 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsEx(PCUITEMID_CHILD pidl, const SHC
 
 HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHELLDETAILS *psd)
 {
-    if (!psd || iColumn >= CONROLPANELSHELLVIEWCOLUMNS)
+    if (!psd || iColumn >= CONTROLPANEL_COL_COUNT)
         return E_INVALIDARG;
 
     if (!pidl)

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -333,7 +333,7 @@ HRESULT WINAPI CControlPanelFolder::CompareIDs(LPARAM lParam, PCUIDLIST_RELATIVE
         case 0:        /* name */
             result = wcsicmp(pData1->szName + pData1->offsDispName, pData2->szName + pData2->offsDispName);
             break;
-        case 4:        /* comment */
+        case 1:        /* comment */
             result = wcsicmp(pData1->szName + pData1->offsComment, pData2->szName + pData2->offsComment);
             break;
         default:
@@ -581,12 +581,12 @@ HRESULT WINAPI CControlPanelFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iCol
         {
             case 0:        /* name */
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsDispName);
-            case 4:        /* comment */
+            case 1:        /* comment */
                 return SHSetStrRet(&psd->str, pCPanel->szName + pCPanel->offsComment);
         }
     }
 
-    return S_OK;
+    return E_FAIL;
 }
 
 HRESULT WINAPI CControlPanelFolder::MapColumnToSCID(UINT column, SHCOLUMNID *pscid)

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -212,6 +212,15 @@ class CRegFolderEnum :
         END_COM_MAP()
 };
 
+#define REGISTRYSHELLVIEWCOLUMNS 2
+
+enum registry_columns
+{
+    REGISTRY_COL_NAME,
+    REGISTRY_COL_TYPE,
+    REGISTRY_COL_VALUE,
+};
+
 CRegFolderEnum::CRegFolderEnum()
 {
 }
@@ -723,7 +732,7 @@ HRESULT WINAPI CRegFolder::GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pD
 
 HRESULT WINAPI CRegFolder::GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags)
 {
-    if (iColumn >= 2)
+    if (iColumn > REGISTRYSHELLVIEWCOLUMNS)
         return E_INVALIDARG;
     *pcsFlags = SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT;
     return S_OK;
@@ -749,11 +758,11 @@ HRESULT WINAPI CRegFolder::GetDetailsOf(PCUITEMID_CHILD pidl, UINT iColumn, SHEL
 
     switch(iColumn)
     {
-        case 0:        /* name */
+        case REGISTRY_COL_NAME:
             return GetDisplayNameOf(pidl, SHGDN_NORMAL | SHGDN_INFOLDER, &psd->str);
-        case 1:        /* type */
+        case REGISTRY_COL_TYPE:
             return SHSetStrRet(&psd->str, IDS_SYSTEMFOLDER);
-        case 4:        /* comments */
+        case REGISTRY_COL_VALUE:
             HKEY hKey;
             if (!HCR_RegOpenClassIDKey(*clsid, &hKey))
                 return SHSetStrRet(&psd->str, "");

--- a/dll/win32/shell32/folders/CRegFolder.cpp
+++ b/dll/win32/shell32/folders/CRegFolder.cpp
@@ -212,13 +212,12 @@ class CRegFolderEnum :
         END_COM_MAP()
 };
 
-#define REGISTRYSHELLVIEWCOLUMNS 2
-
 enum registry_columns
 {
     REGISTRY_COL_NAME,
     REGISTRY_COL_TYPE,
     REGISTRY_COL_VALUE,
+    REGISTRY_COL_COUNT,
 };
 
 CRegFolderEnum::CRegFolderEnum()
@@ -732,7 +731,7 @@ HRESULT WINAPI CRegFolder::GetDefaultColumn(DWORD dwRes, ULONG *pSort, ULONG *pD
 
 HRESULT WINAPI CRegFolder::GetDefaultColumnState(UINT iColumn, DWORD *pcsFlags)
 {
-    if (iColumn > REGISTRYSHELLVIEWCOLUMNS)
+    if (iColumn >= REGISTRY_COL_COUNT)
         return E_INVALIDARG;
     *pcsFlags = SHCOLSTATE_TYPE_STR | SHCOLSTATE_ONBYDEFAULT;
     return S_OK;


### PR DESCRIPTION
## Purpose

Current CControlPanelFolder::CompareIDs was using wrong lparam column index. Actual column index should be 1 instead of 4. Because of this the comment column next to name in details view was not being displayed in correct way. Please see below JIRA issues to see the bug in detail.

JIRA issue: 
[CORE-18743](https://jira.reactos.org/browse/CORE-18743)
[CORE-18501](https://jira.reactos.org/browse/CORE-18501)
