### PR TITLE
[SHELL32] Read the label for a CD from autorun.inf

### DIFF
--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -463,6 +463,28 @@ getIconLocationForDrive(IShellFolder *psf, PCITEMID_CHILD pidl, UINT uFlags,
     return E_FAIL;
 }
 
+static HRESULT
+getLabelForDrive(LPWSTR wszPath, LPWSTR wszLabel)
+{
+    WCHAR wszAutoRunInfPath[MAX_PATH];
+    WCHAR wszTemp[MAX_PATH];
+
+    if (!PathIsDirectoryW(wszPath))
+        return E_FAIL;
+
+    StringCchCopyW(wszAutoRunInfPath, _countof(wszAutoRunInfPath), wszPath);
+    PathAppendW(wszAutoRunInfPath, L"autorun.inf");
+
+    if (GetPrivateProfileStringW(L"autorun", L"label", NULL, wszTemp, _countof(wszTemp),
+                                 wszAutoRunInfPath) && wszTemp[0] != 0)
+    {
+        StringCchCopyW(wszLabel, _countof(wszTemp), wszTemp);
+        return S_OK;
+    }
+
+    return E_FAIL;
+}
+
 BOOL IsDriveFloppyA(LPCSTR pszDriveRoot);
 
 HRESULT CDrivesExtractIcon_CreateInstance(IShellFolder * psf, LPCITEMIDLIST pidl, REFIID riid, LPVOID * ppvOut)
@@ -979,38 +1001,43 @@ HRESULT WINAPI CDrivesFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFla
     if (!(dwFlags & SHGDN_FORPARSING))
     {
         WCHAR wszDrive[18] = {0};
-        DWORD dwVolumeSerialNumber, dwMaximumComponentLength, dwFileSystemFlags;
 
         lstrcpynW(wszDrive, pszPath, 4);
         pszPath[0] = L'\0';
-        GetVolumeInformationW(wszDrive, pszPath,
-                                MAX_PATH - 7,
-                                &dwVolumeSerialNumber,
-                                &dwMaximumComponentLength, &dwFileSystemFlags, NULL, 0);
-        pszPath[MAX_PATH-1] = L'\0';
-        if (!wcslen(pszPath))
+
+        if (!SUCCEEDED(getLabelForDrive(wszDrive, pszPath)))
         {
-            UINT DriveType, ResourceId;
-            DriveType = GetDriveTypeW(wszDrive);
-            switch(DriveType)
+            DWORD dwVolumeSerialNumber, dwMaximumComponentLength, dwFileSystemFlags;
+
+            GetVolumeInformationW(wszDrive, pszPath,
+                                    MAX_PATH - 7,
+                                    &dwVolumeSerialNumber,
+                                    &dwMaximumComponentLength, &dwFileSystemFlags, NULL, 0);
+            pszPath[MAX_PATH-1] = L'\0';
+            if (!wcslen(pszPath))
             {
-                case DRIVE_FIXED:
-                    ResourceId = IDS_DRIVE_FIXED;
-                    break;
-                case DRIVE_REMOTE:
-                    ResourceId = IDS_DRIVE_NETWORK;
-                    break;
-                case DRIVE_CDROM:
-                    ResourceId = IDS_DRIVE_CDROM;
-                    break;
-                default:
-                    ResourceId = 0;
-            }
-            if (ResourceId)
-            {
-                dwFileSystemFlags = LoadStringW(shell32_hInstance, ResourceId, pszPath, MAX_PATH);
-                if (dwFileSystemFlags > MAX_PATH - 7)
-                    pszPath[MAX_PATH-7] = L'\0';
+                UINT DriveType, ResourceId;
+                DriveType = GetDriveTypeW(wszDrive);
+                switch(DriveType)
+                {
+                    case DRIVE_FIXED:
+                        ResourceId = IDS_DRIVE_FIXED;
+                        break;
+                    case DRIVE_REMOTE:
+                        ResourceId = IDS_DRIVE_NETWORK;
+                        break;
+                    case DRIVE_CDROM:
+                        ResourceId = IDS_DRIVE_CDROM;
+                        break;
+                    default:
+                        ResourceId = 0;
+                }
+                if (ResourceId)
+                {
+                    dwFileSystemFlags = LoadStringW(shell32_hInstance, ResourceId, pszPath, MAX_PATH);
+                    if (dwFileSystemFlags > MAX_PATH - 7)
+                        pszPath[MAX_PATH-7] = L'\0';
+                }
             }
         }
         wcscat (pszPath, L" (");

--- a/dll/win32/shell32/folders/CDrivesFolder.cpp
+++ b/dll/win32/shell32/folders/CDrivesFolder.cpp
@@ -1014,11 +1014,13 @@ HRESULT WINAPI CDrivesFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFla
                                     &dwVolumeSerialNumber,
                                     &dwMaximumComponentLength, &dwFileSystemFlags, NULL, 0);
             pszPath[MAX_PATH-1] = L'\0';
+
             if (!wcslen(pszPath))
             {
                 UINT DriveType, ResourceId;
                 DriveType = GetDriveTypeW(wszDrive);
-                switch(DriveType)
+
+                switch (DriveType)
                 {
                     case DRIVE_FIXED:
                         ResourceId = IDS_DRIVE_FIXED;
@@ -1032,6 +1034,7 @@ HRESULT WINAPI CDrivesFolder::GetDisplayNameOf(PCUITEMID_CHILD pidl, DWORD dwFla
                     default:
                         ResourceId = 0;
                 }
+
                 if (ResourceId)
                 {
                     dwFileSystemFlags = LoadStringW(shell32_hInstance, ResourceId, pszPath, MAX_PATH);


### PR DESCRIPTION
## Purpose

Some CDs may set a custom label using autorun.inf. Read the label from the file, and if it succeeds, show it to the user.

JIRA issue: [CORE-18567](https://jira.reactos.org/browse/CORE-18567)

## Proposed changes

Add a function to read the `label` variable from autorun.inf and use it.

![image](https://user-images.githubusercontent.com/30466983/208254081-843cbc30-94a8-4ca1-87ac-f3d5586cbc75.png)

