### PR TITLE
[NTOBJSHEX] Return early from GetInfoFromPidl when pcidl is null in LPCITEMIDLIST

### DIFF
--- a/dll/shellext/ntobjshex/ntobjfolder.cpp
+++ b/dll/shellext/ntobjshex/ntobjfolder.cpp
@@ -489,12 +489,6 @@ HRESULT CNtObjectFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const NtPidlEntry 
     }
 
     NtPidlEntry * entry = (NtPidlEntry*) &(pcidl->mkid);
-    if (!entry)
-    {
-        DbgPrint("PCIDL with NULL mkid\n");
-        return E_INVALIDARG;
-    }
-
     if (entry->cb < sizeof(NtPidlEntry))
     {
         DbgPrint("PCIDL too small %l (required %l)\n", entry->cb, sizeof(NtPidlEntry));

--- a/dll/shellext/ntobjshex/ntobjfolder.cpp
+++ b/dll/shellext/ntobjshex/ntobjfolder.cpp
@@ -482,8 +482,13 @@ BOOL CNtObjectFolder::IsFolder(const NtPidlEntry * info)
 
 HRESULT CNtObjectFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const NtPidlEntry ** pentry)
 {
-    NtPidlEntry * entry = (NtPidlEntry*) &(pcidl->mkid);
+    if (!pcidl)
+    {
+        DbgPrint("PCIDL is NULL\n");
+        return E_INVALIDARG;
+    }
 
+    NtPidlEntry * entry = (NtPidlEntry*) &(pcidl->mkid);
     if (!entry)
     {
         DbgPrint("PCIDL with NULL mkid\n");

--- a/dll/shellext/ntobjshex/ntobjfolder.cpp
+++ b/dll/shellext/ntobjshex/ntobjfolder.cpp
@@ -484,6 +484,12 @@ HRESULT CNtObjectFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const NtPidlEntry 
 {
     NtPidlEntry * entry = (NtPidlEntry*) &(pcidl->mkid);
 
+    if (!entry)
+    {
+        DbgPrint("PCIDL with NULL mkid\n");
+        return E_INVALIDARG;
+    }
+
     if (entry->cb < sizeof(NtPidlEntry))
     {
         DbgPrint("PCIDL too small %l (required %l)\n", entry->cb, sizeof(NtPidlEntry));

--- a/dll/shellext/ntobjshex/regfolder.cpp
+++ b/dll/shellext/ntobjshex/regfolder.cpp
@@ -433,12 +433,6 @@ HRESULT CRegistryFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const RegPidlEntry
     }
 
     RegPidlEntry * entry = (RegPidlEntry*) &(pcidl->mkid);
-    if (!entry)
-    {
-        DbgPrint("PCIDL with NULL mkid\n");
-        return E_INVALIDARG;
-    }
-
     if (entry->cb < sizeof(RegPidlEntry))
     {
         DbgPrint("PCIDL too small %l (required %l)\n", entry->cb, sizeof(RegPidlEntry));

--- a/dll/shellext/ntobjshex/regfolder.cpp
+++ b/dll/shellext/ntobjshex/regfolder.cpp
@@ -428,6 +428,12 @@ HRESULT CRegistryFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const RegPidlEntry
 {
     RegPidlEntry * entry = (RegPidlEntry*) &(pcidl->mkid);
 
+    if (!entry)
+    {
+        DbgPrint("PCIDL with NULL mkid\n");
+        return E_INVALIDARG;
+    }
+
     if (entry->cb < sizeof(RegPidlEntry))
     {
         DbgPrint("PCIDL too small %l (required %l)\n", entry->cb, sizeof(RegPidlEntry));

--- a/dll/shellext/ntobjshex/regfolder.cpp
+++ b/dll/shellext/ntobjshex/regfolder.cpp
@@ -426,8 +426,13 @@ BOOL CRegistryFolder::IsFolder(const RegPidlEntry * info)
 
 HRESULT CRegistryFolder::GetInfoFromPidl(LPCITEMIDLIST pcidl, const RegPidlEntry ** pentry)
 {
-    RegPidlEntry * entry = (RegPidlEntry*) &(pcidl->mkid);
+    if (!pcidl)
+    {
+        DbgPrint("PCIDL is NULL\n");
+        return E_INVALIDARG;
+    }
 
+    RegPidlEntry * entry = (RegPidlEntry*) &(pcidl->mkid);
     if (!entry)
     {
         DbgPrint("PCIDL with NULL mkid\n");


### PR DESCRIPTION
## Purpose
This fixes crash when attempting to drag n drop items from NTObject Namespace and System Registry.

_Do a quick recap of your work here._

JIRA issues: [CORE-18480](https://jira.reactos.org/browse/CORE-18480), [CORE-18481](https://jira.reactos.org/browse/CORE-18481)

## Proposed changes
Perform a null check in GetInfoFromPidel on mkid in LPCITEMIDLIST

https://user-images.githubusercontent.com/120612254/208288691-a1cd6d4d-3afa-433c-9721-c3b3d9e1d7a1.mp4

(refer video, no more crash)
