### PR TITLE
[DXDIAG] Fix Portuguese (pt-BR) translation

### DIFF
--- a/base/applications/dxdiag/lang/pt-BR.rc
+++ b/base/applications/dxdiag/lang/pt-BR.rc
@@ -24,7 +24,7 @@ BEGIN
     GROUPBOX "Informações do sistema", IDC_STATIC, 5, 35, 452, 150, SS_RIGHT
     LTEXT "Data/hora atual:", IDC_STATIC, 70, 50, 80, 10, SS_RIGHT
     LTEXT "Nome do computador:", IDC_STATIC, 70, 60, 80, 10, SS_RIGHT
-    LTEXT "Sistema pperacional:", IDC_STATIC, 70, 70, 80, 10, SS_RIGHT
+    LTEXT "Sistema operacional:", IDC_STATIC, 70, 70, 80, 10, SS_RIGHT
     LTEXT "Idioma:", IDC_STATIC, 70, 80, 80, 10, SS_RIGHT
     LTEXT "Fabricante do sistema:", IDC_STATIC, 70, 90, 80, 10, SS_RIGHT
     LTEXT "Modelo do sistema:", IDC_STATIC, 70, 100, 80, 10, SS_RIGHT


### PR DESCRIPTION
## Purpose

Fix minor translation error.

JIRA issue: No IRA bug report

## Proposed changes

Replace the word "pperacional" (this doesn't exist in Portuguese language) by "operacional" .

Operating system in PT_BR is sistema operacional, not sistema ppracional.