### PR TITLE
[REGEDIT] Fix missing translation for Favorites menu

### DIFF
--- a/base/applications/regedit/lang/pt-BR.rc
+++ b/base/applications/regedit/lang/pt-BR.rc
@@ -128,7 +128,7 @@ BEGIN
         MENUITEM SEPARATOR
         MENUITEM "Atuali&zar\tF5", ID_VIEW_REFRESH
     END
-    POPUP "&Favorites"
+    POPUP "&Favoritos"
     BEGIN
         MENUITEM "&Adicionar a favoritos", ID_FAVOURITES_ADDTOFAVOURITES, GRAYED
         MENUITEM "&Remover favorito", ID_FAVOURITES_REMOVEFAVOURITE, GRAYED


### PR DESCRIPTION
Improve translation for Favorites menu

## Purpose

Translation is missing for Favorites button

JIRA issue: None

## Proposed changes

Replace the English word "Favorites" by the Portuguese word "Favoritos"