### PR TITLE
[IP][TCPIP] Update TCP and UDP dynamic port ranges

### DIFF
--- a/drivers/network/tcpip/include/udp.h
+++ b/drivers/network/tcpip/include/udp.h
@@ -7,8 +7,9 @@
 
 #pragma once
 
-#define UDP_STARTING_PORT 0x8000
-#define UDP_DYNAMIC_PORTS 0x8000
+// TODO: Support MaxUserPort registry key.
+#define UDP_STARTING_PORT 49152
+#define UDP_DYNAMIC_PORTS (65535 - UDP_STARTING_PORT + 1)
 
 /* UDPv4 header structure */
 #include <pshpack1.h>

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -638,8 +638,9 @@ UINT TCPAllocatePort(const UINT HintPort)
             return (UINT)-1;
         }
     }
-    else
-        return AllocatePortFromRange( &TCPPorts, 1024, 5000 );
+
+    // TODO: Support MaxUserPort registry key.
+    return AllocatePortFromRange(&TCPPorts, 49152, 65535);
 }
 
 VOID TCPFreePort(const UINT Port)


### PR DESCRIPTION
## Purpose

Use higher ports, as updated Windows S2003 does.

JIRA issue: [CORE-18766](https://jira.reactos.org/browse/CORE-18766)

## Proposed changes

- Use IANA range (49152-65535), only.
- Add TODOs about `MaxUserPort` registry key.