### PR TITLE
[COMCTL32] Do not start tracking mouse input in combobox on the opening click

### DIFF
--- a/dll/win32/comctl32/combo.c
+++ b/dll/win32/comctl32/combo.c
@@ -1610,8 +1610,6 @@ static void COMBO_LButtonDown( LPHEADCOMBO lphc, LPARAM lParam )
        else
        {
 	   /* drop down the listbox and start tracking */
-
-           lphc->wState |= CBF_CAPTURE;
            SetCapture( hWnd );
            CBDropDown( lphc );
        }
@@ -1642,6 +1640,11 @@ static void COMBO_LButtonUp( LPHEADCOMBO lphc )
        }
        ReleaseCapture();
        SetCapture(lphc->hWndLBox);
+   }
+   else
+   {
+        if (lphc->wState & CBF_DROPPED)
+            lphc->wState |= CBF_CAPTURE;
    }
 
    if( lphc->wState & CBF_BUTTONDOWN )


### PR DESCRIPTION
## Purpose

On small screens there is a problem that a big combobox closes itself as if it was clicked.
Fix this issue by enabling mouse capture only after the opening click is complete.

JIRA issue: [CORE-18769](https://jira.reactos.org/browse/CORE-18769)