### PR TITLE
[MSHTML] Wine internet explorer print crash fix (Credit: DougLyons)

### DIFF
--- a/dll/win32/mshtml/olecmd.c
+++ b/dll/win32/mshtml/olecmd.c
@@ -241,11 +241,13 @@ static HRESULT exec_print(HTMLDocument *This, DWORD nCmdexecopt, VARIANT *pvaIn,
         return S_OK;
     }
 
+#ifndef __REACTOS__
     // returning here fixes CORE-16884. Maybe use this until printing works.
     ERR("Sorry, ReactOS does not support printing yet.\n");
     return S_OK;
 
     // For now if this is executed we get internal corruptions for unknown reasons. 
+#endif
     nsres = nsIWebBrowserPrint_GetGlobalPrintSettings(nsprint, &settings);
     if(NS_FAILED(nsres))
         ERR("GetCurrentPrintSettings failed: %08x\n", nsres);

--- a/dll/win32/mshtml/olecmd.c
+++ b/dll/win32/mshtml/olecmd.c
@@ -241,6 +241,11 @@ static HRESULT exec_print(HTMLDocument *This, DWORD nCmdexecopt, VARIANT *pvaIn,
         return S_OK;
     }
 
+    // returning here fixes CORE-16884. Maybe use this until printing works.
+    ERR("Sorry, ReactOS does not support printing yet.\n");
+    return S_OK;
+
+    // For now if this is executed we get internal corruptions for unknown reasons. 
     nsres = nsIWebBrowserPrint_GetGlobalPrintSettings(nsprint, &settings);
     if(NS_FAILED(nsres))
         ERR("GetCurrentPrintSettings failed: %08x\n", nsres);

--- a/dll/win32/mshtml/olecmd.c
+++ b/dll/win32/mshtml/olecmd.c
@@ -243,7 +243,7 @@ static HRESULT exec_print(HTMLDocument *This, DWORD nCmdexecopt, VARIANT *pvaIn,
 
 #ifdef __REACTOS__
     // returning here fixes CORE-16884. Maybe use this until printing works.
-    ERR("Sorry, ReactOS does not support printing yet.\n");
+    ERR("Aborting print, to work around CORE-16884\n");
     return S_OK;
 
     // For now if this is executed we get internal corruptions for unknown reasons. 

--- a/dll/win32/mshtml/olecmd.c
+++ b/dll/win32/mshtml/olecmd.c
@@ -241,7 +241,7 @@ static HRESULT exec_print(HTMLDocument *This, DWORD nCmdexecopt, VARIANT *pvaIn,
         return S_OK;
     }
 
-#ifndef __REACTOS__
+#ifdef __REACTOS__
     // returning here fixes CORE-16884. Maybe use this until printing works.
     ERR("Sorry, ReactOS does not support printing yet.\n");
     return S_OK;


### PR DESCRIPTION
This issue was fixed by [DougLyons](https://jira.reactos.org/secure/ViewProfile.jspa?name=DougLyons)

## Purpose

When using wine internet explorer it crashes if you click print even if you click cancel, this fixes that issue.
nsIWebBrowserPrint_Print apparently causes issues for unknown reasons.

JIRA issue: [CORE-16884](https://jira.reactos.org/browse/CORE-16884)

## Proposed changes

By returning S_OK print doesnt cause a crash

- ERR and S_OK return before nsIWebBrowserPrint_Print
