### PR TITLE
[IP] Avoid declaring 0xFFFF as invalid port in ReactOS

### DIFF
--- a/drivers/network/tcpip/tcpip/fileobjs.c
+++ b/drivers/network/tcpip/tcpip/fileobjs.c
@@ -404,6 +404,7 @@ NTSTATUS FileOpenAddress(
   PVOID Options)
 {
   PADDRESS_FILE AddrFile;
+  UINT nPort;
 
   TI_DbgPrint(MID_TRACE, ("Called (Proto %d).\n", Protocol));
 
@@ -472,14 +473,15 @@ NTSTATUS FileOpenAddress(
       if (Address->Address[0].Address[0].sin_port)
       {
           /* The client specified an explicit port so we force a bind to this */
-          AddrFile->Port = TCPAllocatePort(Address->Address[0].Address[0].sin_port);
+          nPort = TCPAllocatePort(Address->Address[0].Address[0].sin_port);
 
           /* Check for bind success */
-          if (AddrFile->Port == 0xffff)
+          if (nPort == (UINT)-1)
           {
               ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
               return STATUS_ADDRESS_ALREADY_EXISTS;
           }
+          AddrFile->Port = nPort;
 
           /* Sanity check */
           ASSERT(Address->Address[0].Address[0].sin_port == AddrFile->Port);
@@ -487,14 +489,15 @@ NTSTATUS FileOpenAddress(
       else if (!AddrIsUnspecified(&AddrFile->Address))
       {
           /* The client is trying to bind to a local address so allocate a port now too */
-          AddrFile->Port = TCPAllocatePort(0);
+          nPort = TCPAllocatePort(0);
 
           /* Check for bind success */
-          if (AddrFile->Port == 0xffff)
+          if (nPort == (UINT)-1)
           {
               ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
               return STATUS_ADDRESS_ALREADY_EXISTS;
           }
+          AddrFile->Port = nPort;
       }
       else
       {
@@ -509,16 +512,16 @@ NTSTATUS FileOpenAddress(
 
   case IPPROTO_UDP:
       TI_DbgPrint(MID_TRACE,("Allocating udp port\n"));
-      AddrFile->Port =
-	  UDPAllocatePort(Address->Address[0].Address[0].sin_port);
+      nPort = UDPAllocatePort(Address->Address[0].Address[0].sin_port);
 
       if ((Address->Address[0].Address[0].sin_port &&
-           AddrFile->Port != Address->Address[0].Address[0].sin_port) ||
-           AddrFile->Port == 0xffff)
+           nPort != Address->Address[0].Address[0].sin_port) ||
+           nPort == (UINT)-1)
       {
           ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
           return STATUS_ADDRESS_ALREADY_EXISTS;
       }
+      AddrFile->Port = nPort;
 
       TI_DbgPrint(MID_TRACE,("Setting port %d (wanted %d)\n",
                              AddrFile->Port,

--- a/sdk/lib/drivers/ip/network/ports.c
+++ b/sdk/lib/drivers/ip/network/ports.c
@@ -39,6 +39,12 @@ VOID DeallocatePort( PPORT_SET PortSet, ULONG Port ) {
     ASSERT(Port >= PortSet->StartingPort);
     ASSERT(Port < PortSet->StartingPort + PortSet->PortsToOversee);
 
+    if ((Port < PortSet->StartingPort) ||
+        (Port >= PortSet->StartingPort + PortSet->PortsToOversee))
+    {
+       return;
+    }
+
     KeAcquireSpinLock( &PortSet->Lock, &OldIrql );
     RtlClearBits( &PortSet->ProtoBitmap, Port - PortSet->StartingPort, 1 );
     KeReleaseSpinLock( &PortSet->Lock, OldIrql );

--- a/sdk/lib/drivers/ip/transport/tcp/accept.c
+++ b/sdk/lib/drivers/ip/transport/tcp/accept.c
@@ -77,10 +77,10 @@ NTSTATUS TCPListen(PCONNECTION_ENDPOINT Connection, UINT Backlog)
             if (NT_SUCCESS(Status))
             {
                 /* Allocate the port in the port bitmap */
-                Connection->AddressFile->Port = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
-
+                UINT nPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
                 /* This should never fail */
-                ASSERT(Connection->AddressFile->Port != 0xFFFF);
+                ASSERT(nPort != (UINT)-1);
+                Connection->AddressFile->Port = nPort;
             }
         }
     }

--- a/sdk/lib/drivers/ip/transport/tcp/tcp.c
+++ b/sdk/lib/drivers/ip/transport/tcp/tcp.c
@@ -214,7 +214,7 @@ NTSTATUS TCPStartup(VOID)
 {
     NTSTATUS Status;
 
-    Status = PortsStartup( &TCPPorts, 1, 0xfffe );
+    Status = PortsStartup(&TCPPorts, 1, 0xffff);
     if (!NT_SUCCESS(Status))
     {
         return Status;
@@ -370,6 +370,8 @@ NTSTATUS TCPConnect
     /* Check if we had an unspecified port */
     if (!Connection->AddressFile->Port)
     {
+        UINT nPort;
+
         /* We did, so we need to copy back the port */
         Status = TCPGetSockAddress(Connection, (PTRANSPORT_ADDRESS)&LocalAddress, FALSE);
         if (!NT_SUCCESS(Status))
@@ -379,10 +381,10 @@ NTSTATUS TCPConnect
         }
 
         /* Allocate the port in the port bitmap */
-        Connection->AddressFile->Port = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
-
+        nPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
         /* This should never fail */
-        ASSERT(Connection->AddressFile->Port != 0xFFFF);
+        ASSERT(nPort != (UINT)-1);
+        Connection->AddressFile->Port = nPort;
     }
 
     connaddr.addr = RemoteAddress.Address.IPv4Address;


### PR DESCRIPTION
## Purpose

Do not declare 0XFFFF as invalid in ReactOS. Applications should be able to use 0XFFFF as it is valid. Thanks to @KRosUser for detailed analysis.

JIRA issue: 
[CORE-18371](https://jira.reactos.org/browse/CORE-18371)
[CORE-18764](https://jira.reactos.org/browse/CORE-18764)

## Proposed changes

The proposed fix is similar to what is already implemented in ReactOS for existing TCPAlloc failure in [FileOpenAddress](https://git.reactos.org/?p=reactos.git;a=blob;f=drivers/network/tcpip/tcpip/fileobjs.c#l475 )

