### PR TITLE
[SYSSETUP] Changed credit link for qemu.

### DIFF
--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -33,7 +33,7 @@ IDI_ICON5 ICON "resources/5.ico"
 
 STRINGTABLE
 BEGIN
-    IDS_ACKPROJECTS "Wine - http://www.winehq.org\nFreeType - http://www.freetype.org\nSYSLINUX - http://syslinux.zytor.com\nMinGW - http://www.mingw.org\nBochs - http://bochs.sourceforge.net\nQEMU - http://fabrice.bellard.free.fr/qemu\nMesa3D - http://www.mesa3d.org\nadns - http://www.gnu.org/software/adns\nICU - http://www.icu-project.org/\nGraphApp - http://enchantia.com/software/graphapp/\nExt2 - http://www.ext2fsd.com/\nGNU FreeFont - http://savannah.gnu.org/projects/freefont/\nDejaVu Fonts - http://dejavu.sourceforge.net\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts/\nBtrfs - https://github.com/maharmstone/btrfs\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project"
+    IDS_ACKPROJECTS "Wine - http://www.winehq.org\nFreeType - http://www.freetype.org\nSYSLINUX - http://syslinux.zytor.com\nMinGW - http://www.mingw.org\nBochs - http://bochs.sourceforge.net\nQEMU - http://www.qemu.org\nMesa3D - http://www.mesa3d.org\nadns - http://www.gnu.org/software/adns\nICU - http://www.icu-project.org/\nGraphApp - http://enchantia.com/software/graphapp/\nExt2 - http://www.ext2fsd.com/\nGNU FreeFont - http://savannah.gnu.org/projects/freefont/\nDejaVu Fonts - http://dejavu.sourceforge.net\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts/\nBtrfs - https://github.com/maharmstone/btrfs\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project"
 END
 
 IDR_GPL RT_TEXT "COPYING"

--- a/dll/win32/syssetup/syssetup.rc
+++ b/dll/win32/syssetup/syssetup.rc
@@ -33,7 +33,7 @@ IDI_ICON5 ICON "resources/5.ico"
 
 STRINGTABLE
 BEGIN
-    IDS_ACKPROJECTS "Wine - http://www.winehq.org\nFreeType - http://www.freetype.org\nSYSLINUX - http://syslinux.zytor.com\nMinGW - http://www.mingw.org\nBochs - http://bochs.sourceforge.net\nQEMU - http://www.qemu.org\nMesa3D - http://www.mesa3d.org\nadns - http://www.gnu.org/software/adns\nICU - http://www.icu-project.org/\nGraphApp - http://enchantia.com/software/graphapp/\nExt2 - http://www.ext2fsd.com/\nGNU FreeFont - http://savannah.gnu.org/projects/freefont/\nDejaVu Fonts - http://dejavu.sourceforge.net\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts/\nBtrfs - https://github.com/maharmstone/btrfs\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project"
+    IDS_ACKPROJECTS "Wine - http://www.winehq.org\nFreeType - http://www.freetype.org\nSYSLINUX - http://syslinux.zytor.com\nMinGW - http://www.mingw.org\nBochs - http://bochs.sourceforge.net\nMesa3D - http://www.mesa3d.org\nadns - http://www.gnu.org/software/adns\nICU - http://www.icu-project.org/\nGraphApp - http://enchantia.com/software/graphapp/\nExt2 - http://www.ext2fsd.com/\nGNU FreeFont - http://savannah.gnu.org/projects/freefont/\nDejaVu Fonts - http://dejavu.sourceforge.net\nLiberation(tm) Fonts - https://fedorahosted.org/liberation-fonts/\nBtrfs - https://github.com/maharmstone/btrfs\nTango Desktop Project - http://tango.freedesktop.org/Tango_Desktop_Project"
 END
 
 IDR_GPL RT_TEXT "COPYING"


### PR DESCRIPTION
## Purpose

The url was outdated and redirected to the new qemu website.
Should it be kept in credits?

JIRA issue: [CORE-18495](https://jira.reactos.org/browse/CORE-18495)

## Proposed changes

- Change url for QEMU credits
