### PR TITLE
[AFD] ReceiveActivity: Don't return STATUS_FILE_CLOSED in case of FCB overread

### DIFF
--- a/drivers/network/afd/afd/main.c
+++ b/drivers/network/afd/afd/main.c
@@ -751,9 +751,6 @@ AfdDisconnect(PDEVICE_OBJECT DeviceObject, PIRP Irp,
         FCB->Recv.Content = 0;
         FCB->Recv.BytesUsed = 0;
 
-        /* Mark us as overread to complete future reads with an error */
-        FCB->Overread = TRUE;
-
         /* Set a successful receive status to indicate a shutdown on overread */
         FCB->LastReceiveStatus = STATUS_SUCCESS;
 

--- a/drivers/network/afd/afd/read.c
+++ b/drivers/network/afd/afd/read.c
@@ -175,16 +175,8 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
                                     TotalBytesCopied));
             UnlockBuffers( RecvReq->BufferArray,
                            RecvReq->BufferCount, FALSE );
-            if (FCB->Overread && FCB->LastReceiveStatus == STATUS_SUCCESS)
-            {
-                /* Overread after a graceful disconnect */
-                AFD_DbgPrint(MID_TRACE,("FCB overread detected\n"));
-            }
 
-            /* Overread shall not lead to situation of "ECONNRESET" errors
-             * See CORE-18328 and CORE-11650 */
-
-            /* Unexpected disconnect by the remote host or initial read after a graceful disconnect */
+            /* Unexpected disconnect by the remote host or graceful disconnect */
             Status = FCB->LastReceiveStatus;
 
             NextIrp->IoStatus.Status = Status;
@@ -193,7 +185,6 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
             if( NextIrp->MdlAddress ) UnlockRequest( NextIrp, IoGetCurrentIrpStackLocation( NextIrp ) );
             (void)IoSetCancelRoutine(NextIrp, NULL);
             IoCompleteRequest( NextIrp, IO_NETWORK_INCREMENT );
-            FCB->Overread = TRUE;
         }
     } else {
         /* Kick the user that receive would be possible now */

--- a/drivers/network/afd/afd/read.c
+++ b/drivers/network/afd/afd/read.c
@@ -177,14 +177,16 @@ static NTSTATUS ReceiveActivity( PAFD_FCB FCB, PIRP Irp ) {
                            RecvReq->BufferCount, FALSE );
             if (FCB->Overread && FCB->LastReceiveStatus == STATUS_SUCCESS)
             {
-                /* Overread after a graceful disconnect so complete with an error */
-                Status = STATUS_FILE_CLOSED;
+                /* Overread after a graceful disconnect */
+                AFD_DbgPrint(MID_TRACE,("FCB overread detected\n"));
             }
-            else
-            {
-                /* Unexpected disconnect by the remote host or initial read after a graceful disconnect */
-                Status = FCB->LastReceiveStatus;
-            }
+
+            /* Overread shall not lead to situation of "ECONNRESET" errors
+             * See CORE-18328 and CORE-11650 */
+
+            /* Unexpected disconnect by the remote host or initial read after a graceful disconnect */
+            Status = FCB->LastReceiveStatus;
+
             NextIrp->IoStatus.Status = Status;
             NextIrp->IoStatus.Information = 0;
             if( NextIrp == Irp ) RetStatus = Status;

--- a/drivers/network/afd/include/afd.h
+++ b/drivers/network/afd/include/afd.h
@@ -159,7 +159,7 @@ typedef struct _AFD_STORED_DATAGRAM {
 } AFD_STORED_DATAGRAM, *PAFD_STORED_DATAGRAM;
 
 typedef struct _AFD_FCB {
-    BOOLEAN Locked, Critical, Overread, NonBlocking, OobInline, TdiReceiveClosed, SendClosed;
+    BOOLEAN Locked, Critical, NonBlocking, OobInline, TdiReceiveClosed, SendClosed;
     UINT State, Flags, GroupID, GroupType;
     KIRQL OldIrql;
     UINT LockCount;


### PR DESCRIPTION
## Purpose
Fix FileZilla 3.8 `ECONNRESET` error (based on patch by [KRosUser](https://jira.reactos.org/secure/ViewProfile.jspa?name=KRosUser))

JIRA issue: [CORE-18328](https://jira.reactos.org/browse/CORE-18328)
