### PR TITLE
[CMAKE] Do not use the dwarf baseaddress file for GCC Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -335,7 +335,7 @@ Enable this if the module uses typeid or dynamic_cast. You will probably need to
     add_subdirectory(sdk/include/reactos/mc)
     add_subdirectory(sdk/include/asm)
 
-    if(NO_ROSSYM)
+    if(DEFINED NO_ROSSYM AND NOT CMAKE_BUILD_TYPE STREQUAL "Release")
         include(sdk/cmake/baseaddress_dwarf.cmake)
     elseif(MSVC)
         if (ARCH STREQUAL "amd64")

--- a/sdk/cmake/gcc.cmake
+++ b/sdk/cmake/gcc.cmake
@@ -220,8 +220,12 @@ if(SEPARATE_DBG)
         "${CMAKE_STRIP} --only-keep-debug <TARGET> -o ${REACTOS_BINARY_DIR}/symbols/${SYMBOL_FILE}"
         ${strip_debug})
 elseif(NO_ROSSYM)
-    # Dwarf-based build
-    message(STATUS "Generating a dwarf-based build (no rsym)")
+    # Either a GCC Dwarf-based build, or a GCC build in release config
+    if(CMAKE_BUILD_TYPE STREQUAL "Release")
+        message(STATUS "Generating a Release build (no rsym)")
+    else()
+        message(STATUS "Generating a dwarf-based build (no rsym)")
+    endif()
     set(CMAKE_C_LINK_EXECUTABLE "<CMAKE_C_COMPILER> ${CMAKE_C_FLAGS} <CMAKE_C_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
     set(CMAKE_CXX_LINK_EXECUTABLE "<CMAKE_CXX_COMPILER> ${CMAKE_CXX_FLAGS} <CMAKE_CXX_LINK_FLAGS> <LINK_FLAGS> <OBJECTS> -o <TARGET> <LINK_LIBRARIES>")
     set(CMAKE_C_CREATE_SHARED_LIBRARY "<CMAKE_C_COMPILER> ${CMAKE_C_FLAGS} <CMAKE_SHARED_LIBRARY_C_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")


### PR DESCRIPTION
Explanation:
There are currently two seperate cases where we do use the baseaddress_**dwarf**.cmake file:
1.) When configuring a GCC dbg build with -DNO_ROSSYM:BOOL=TRUE
2.) When configuring a GCC rls build with -DCMAKE_BUILD_TYPE=Release

The first one makes sense, large binaries will be the result, and therefore the standard baseaddress.cmake file is not giving sufficient space for those binaries.
But for the 2nd case it does not make sense to use the dwarf baseaddress file. The generated binaries can be expected to be even smaller than the regular debug buillds with RSYM. The dwarf baseaddress file being used here as well is an unintended side effect of the ancient commit SVN r68147 == git 74c80a51dd88d30d346928c04d98382319131507 

This is a late addendum to SVN r68147 == git 74c80a51dd88d30d346928c04d98382319131507

Back then we set NO_ROSSYM to TRUE for the release builds, that did lead us to unintentionally always using the baseaddress_dwarf.cmake file for our release builds, which is not optimal. Neither from the perspective of efficiency (the base addresses are too sparse for them, since dwarf generates much bigger binaries) nor from a testing perspective: We want the base addresses used for our releases to be tested frequently and not only very rarely. So it is good to use then what is frequently tested. And that are the addresses from the 'regular' debug build.

As discussed with @ThFabba and others in chat https://chat.reactos.org/reactos/pl/f1nafrgagjb1tm8a8ihzow6t9r