### PR TITLE
Fix SEH in Cc

### DIFF
--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -139,6 +139,7 @@ CcPerformReadAhead(
     ULONG Length;
     PPRIVATE_CACHE_MAP PrivateCacheMap;
     BOOLEAN Locked;
+    BOOLEAN Success;
 
     SharedCacheMap = FileObject->SectionObjectPointer->SharedCacheMap;
 
@@ -206,9 +207,18 @@ CcPerformReadAhead(
             goto Clear;
         }
 
-        Status = CcRosEnsureVacbResident(Vacb, TRUE, FALSE,
-                CurrentOffset % VACB_MAPPING_GRANULARITY, PartialLength);
-        if (!NT_SUCCESS(Status))
+        _SEH2_TRY
+        {
+            Success = CcRosEnsureVacbResident(Vacb, TRUE, FALSE,
+                    CurrentOffset % VACB_MAPPING_GRANULARITY, PartialLength);
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            Success = FALSE;
+        }
+        _SEH2_END
+
+        if (!Success)
         {
             CcRosReleaseVacb(SharedCacheMap, Vacb, FALSE, FALSE);
             DPRINT1("Failed to read data: %lx!\n", Status);
@@ -234,8 +244,17 @@ CcPerformReadAhead(
             goto Clear;
         }
 
-        Status = CcRosEnsureVacbResident(Vacb, TRUE, FALSE, 0, PartialLength);
-        if (!NT_SUCCESS(Status))
+        _SEH2_TRY
+        {
+            Success = CcRosEnsureVacbResident(Vacb, TRUE, FALSE, 0, PartialLength);
+        }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            Success = FALSE;
+        }
+        _SEH2_END
+
+        if (!Success)
         {
             CcRosReleaseVacb(SharedCacheMap, Vacb, FALSE, FALSE);
             DPRINT1("Failed to read data: %lx!\n", Status);


### PR DESCRIPTION
## Purpose

This PR fixes broken usage of _SEH2_FINALLY.
1. While variable assignment is handled properly with MSVC, GCC/PSEH does not know anything about exceptions and does not guarantee that your variables are set where you think they are set, because the compiler will happily remove any assignments that it considers redundant or move them to a different place. If you need to check a variable within a finally or except block, which is set in a try block, you must mark that variable with _SEH2_VOLATILE.
2. Finally handlers are - unlike except blocks - not part of the function they are in, but separate functions, which are called during unwind. PSEH implements them on GCC using nested functions. While "return" from a finally handler is allowed with native SEH, it's handled by the compiler through an extra unwinding operation using _local_unwind, WHICH IS NOT SUPPORTED BY PSEH! With PSEH, returning from a finally handler does not return from the function, instead it will only return from the finally handler and the function will continue below the finally handler as if there was no return at all. To work around this issue, _SEH2_EXCEPT can be used together with a variable that is set in the try and the except block and checked after it.
3. Since there is no point in raising an exception from CcRosEnsureVacbResident in combination with returning a BOOLEAN result, and it simply makes everything more complicated and prone to errors, remove all SEH entirely and simply use the returned BOOLEAN value.

Also change PSEH to make return from finally handler a compile error.

## TODO

- [x] Run on testbot; https://reactos.org/testman/compare.php?ids=85480,85482,85484,85486,85497 (rightmost is this PR)
