### PR TITLE
[PCI] Fix I/O range size of the resource descriptors

### DIFF
--- a/drivers/bus/pci/pdo.c
+++ b/drivers/bus/pci/pdo.c
@@ -283,6 +283,7 @@ PdoGetRangeLength(PPDO_DEVICE_EXTENSION DeviceExtension,
         ULONGLONG Bar;
     } NewValue;
     ULONG Offset;
+    ULONGLONG Size;
 
     /* Compute the offset of this BAR in PCI config space */
     Offset = 0x10 + Bar * 4;
@@ -359,9 +360,10 @@ PdoGetRangeLength(PPDO_DEVICE_EXTENSION DeviceExtension,
              ? (OriginalValue.Bar & PCI_ADDRESS_IO_ADDRESS_MASK_64)
              : (OriginalValue.Bar & PCI_ADDRESS_MEMORY_ADDRESS_MASK_64));
 
-    *Length = ~((NewValue.Bar & PCI_ADDRESS_IO_SPACE)
-                ? (NewValue.Bar & PCI_ADDRESS_IO_ADDRESS_MASK_64)
-                : (NewValue.Bar & PCI_ADDRESS_MEMORY_ADDRESS_MASK_64)) + 1;
+    Size = (NewValue.Bar & PCI_ADDRESS_IO_SPACE)
+           ? (NewValue.Bar & PCI_ADDRESS_IO_ADDRESS_MASK_64)
+           : (NewValue.Bar & PCI_ADDRESS_MEMORY_ADDRESS_MASK_64);
+    *Length = Size & ~(Size - 1);
 
     *Flags = (NewValue.Bar & PCI_ADDRESS_IO_SPACE)
              ? (NewValue.Bar & ~PCI_ADDRESS_IO_ADDRESS_MASK_64)


### PR DESCRIPTION

## Purpose

Fixes incorrect PCI IDE resources in VPC 2007.

Before:
```
[E1002948:1:1] IO: Min 0:FFA0, Max FFFFFFFF:FFFFFFAF, Align 1 Len FFFF0010
[E1002968:8:1] IO: Min 0:0, Max 0:FFFFFFFF, Align FFFF0010 Len FFFF0010
...
[E10563A0:1:1] MEM: Min 0:F8000000, Max FFFFFFFF:FBFFFFFF, Align 1 Len 4000000
[E10563C0:8:1] MEM: Min 0:0, Max 0:FFFFFFFF, Align 4000000 Len 4000000
```
After:
```
[E1002948:1:1] IO: Min 0:FFA0, Max 0:FFAF, Align 1 Len 10
[E1002968:8:1] IO: Min 0:0, Max 0:FFFFFFFF, Align 10 Len 10
...
[E10563A0:1:1] MEM: Min 0:F8000000, Max 0:FBFFFFFF, Align 1 Len 4000000
[E10563C0:8:1] MEM: Min 0:0, Max 0:FFFFFFFF, Align 4000000 Len 4000000
```

JIRA issue: [CORE-17256](https://jira.reactos.org/browse/CORE-17256)
