### PR TITLE
[WIN32K:NTUSER] ValidateHwndNoErr: Fix window handle validation

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -117,8 +117,16 @@ PWND FASTCALL VerifyWnd(PWND pWnd)
 
 PWND FASTCALL ValidateHwndNoErr(HWND hWnd)
 {
-   if (hWnd) return (PWND)UserGetObjectNoErr(gHandleTable, hWnd, TYPE_WINDOW);
-   return NULL;
+    PWND Window;
+
+    if (!hWnd)
+        return NULL;
+
+    Window = (PWND)UserGetObjectNoErr(gHandleTable, hWnd, TYPE_WINDOW);
+    if (!Window || (Window->state & WNDS_DESTROYED))
+        return NULL;
+
+    return Window;
 }
 
 /* Temp HACK */


### PR DESCRIPTION
## Purposed changes
- Also check window state against `WNDS_DESTROYED`

See also: commit [https://github.com/reactos/reactos/commit/4d48b88bfbfcb6845e8742f78154156e984f6363](https://github.com/reactos/reactos/commit/4d48b88bfbfcb6845e8742f78154156e984f6363)