### PR TITLE
[BOOTDATA] Use the standard "Helv" -> "MS Sans Serif"

### DIFF
--- a/boot/bootdata/livecd.inf
+++ b/boot/bootdata/livecd.inf
@@ -44,7 +44,7 @@ HKLM,"SYSTEM\CurrentControlSet\Control\Session Manager\Memory Management","Pagin
 ; Font Substitution
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Courier",0x00000000,"Courier New"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Fixedsys",0x00000000,"Fixedsys Excelsior 3.01-L2"
-HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Helv",0x00000000,"Tahoma"
+HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Helv",0x00000000,"MS Sans Serif"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","Helvetica",0x00000000,"Arial"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","MS Sans Serif",0x00000000,"Tahoma"
 HKLM,"SOFTWARE\Microsoft\Windows NT\CurrentVersion\FontSubstitutes","MS Shell Dlg",0x00000000,"Tahoma"


### PR DESCRIPTION
## Purpose

This is what Windows does. And we forgot this location here. This is an addendum to
0.4.15-dev-5365-g 9bb5627df60392b90039266f277ff668b574b4cd [SETUP][INF] Use the standard "Helv" -> "MS Sans Serif" substitution... (#4864)
