### PR TITLE
[THEMES] "Open Sans" -> "Trebuchet MS"

### DIFF
--- a/media/doc/3rd Party Files.txt
+++ b/media/doc/3rd Party Files.txt
@@ -178,7 +178,7 @@ License: media/fonts/doc/DejaVu/LICENSE.txt
 URL: http://dejavu.sourceforge.net
 
 Title: Open Sans Fonts
-Path: media/fonts
+Path: media/fonts/trebuc*.ttf
 Used Version: 1.10
 License: Apache-2.0 (https://spdx.org/licenses/Apache-2.0.html)
 URL: http://www.google.com/fonts/specimen/Open+Sans

--- a/media/themes/Blackshade/blackshade.msstyles/textfiles/ExtraLargeNormal.INI
+++ b/media/themes/Blackshade/blackshade.msstyles/textfiles/ExtraLargeNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Open Sans, 8, Bold
+CaptionFont = Trebuchet MS, 8, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Open Sans, 8
+IconTitleFont = Trebuchet MS, 8
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Open Sans, 8
+MenuFont = Trebuchet MS, 8
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Open Sans, 8
+MsgBoxFont = Trebuchet MS, 8
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Open Sans, 8, Bold
+SmallCaptionFont = Trebuchet MS, 8, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Open Sans, 8
+StatusFont = Trebuchet MS, 8
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -206,7 +206,7 @@ GradientRatio2 = 255
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 94 135 217
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\ExplorerBarHeaderBackground.bmp
 SizingMargins = 17, 1, 0, 0
 SizingType = Stretch
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -286,7 +286,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 240 243 251
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\NormalGroupHead.bmp
 SizingMargins = 3, 15, 3, 1
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -331,7 +331,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColor = 2 72 178
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\SpecialGroupHead.bmp
 SizingMargins = 3, 6, 5, 16
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -683,7 +683,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = ImageFile
 ContentMargins = 11, 2, 0, 5
 DefaultPaneSize = 0, 0, 178, 30
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 HotTracking = 48 112 208
 Imagecount = 1
 ImageFile = Normal\StartPanelMoreProgBackGround.BMP
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1011,7 +1011,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 TextColor = 255 255 255
 
 [TaskBar.BackgroundBottom]
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]

--- a/media/themes/Lautus/lautus.msstyles/textfiles/ExtraLargeNormal.INI
+++ b/media/themes/Lautus/lautus.msstyles/textfiles/ExtraLargeNormal.INI
@@ -13,7 +13,7 @@ Btnface = 239 238 243
 BtnHighlight = 255 255 255
 BtnShadow = 162 162 162
 CaptionBarHeight = 24
-CaptionFont = Open Sans, 8, Bold
+CaptionFont = Trebuchet MS, 8, Bold
 CaptionText = 255 255 255
 CssName = cpwebvw.css
 DkShadow3d = 162 162 162
@@ -24,23 +24,23 @@ GrayText = 172 168 153
 Highlight = 75 75 75
 HighlightText = 255 255 255
 HotTracking = 0 0 128
-IconTitleFont = Open Sans, 8
+IconTitleFont = Trebuchet MS, 8
 InactiveCaption = 65 65 65
 InactiveCaptionText = 180 180 180
 Light3d = 241 239 226
 Menu = 255 255 255
 MenuBar = 239 238 243
-MenuFont = Open Sans, 8
+MenuFont = Trebuchet MS, 8
 MenuHilight = 100 100 100
 MenuText = 75 75 75
 MinColorDepth = 15
-MsgBoxFont = Open Sans, 8
+MsgBoxFont = Trebuchet MS, 8
 ScrollbarHeight = 15
 ScrollbarWidth = 15
-SmallCaptionFont = Open Sans, 8, Bold
+SmallCaptionFont = Trebuchet MS, 8, Bold
 SMCaptionBarHeight = 19
 SMCaptionBarWidth = 21
-StatusFont = Open Sans, 8
+StatusFont = Trebuchet MS, 8
 Window = 255 255 255
 XmlName = default.xml
 
@@ -101,7 +101,7 @@ SizingType = Stretch
 TextColor = 112 112 112
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTSHADOWOFFSET = 1,1
 TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 221 221 221
@@ -206,7 +206,7 @@ GradientRatio2 = 255
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 94 135 217
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\ExplorerBarHeaderBackground.bmp
 SizingMargins = 17, 1, 0, 0
 SizingType = Stretch
@@ -252,7 +252,7 @@ BgType = ImageFile
 BorderColor = 255 255 255
 ContentMargins = 8, 8, 7, 7
 FillColor = 214 223 247
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\NormalGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -286,7 +286,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 240 243 251
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\NormalGroupHead.bmp
 SizingMargins = 3, 15, 3, 1
 SizingType = Stretch
@@ -297,7 +297,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColorHint = 239 243 255
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\SpecialGroupBackground.bmp
 SizingMargins = 3, 3, 3, 3
 SizingType = Stretch
@@ -331,7 +331,7 @@ Transparent = true
 BgType = ImageFile
 ContentMargins = 8, 8, 7, 7
 FillColor = 2 72 178
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 ImageFile = Normal\SpecialGroupHead.bmp
 SizingMargins = 3, 6, 5, 16
 SizingType = Stretch
@@ -416,7 +416,7 @@ SizingType = Stretch
 [Rebar]
 Bgtype = imagefile
 FillColorHint = 241 243 239
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\ToolbarBackground.bmp
 Sizingmargins = 1, 1, 1, 2
 Sizingtype = stretch
@@ -683,7 +683,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = ImageFile
 ContentMargins = 11, 2, 0, 5
 DefaultPaneSize = 0, 0, 178, 30
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 HotTracking = 48 112 208
 Imagecount = 1
 ImageFile = Normal\StartPanelMoreProgBackGround.BMP
@@ -749,7 +749,7 @@ TRANSPARENTCOLOR = 255 0 255
 BgType = None
 DefaultPaneSize = 0, 0, 357, 28
 FillColorHint = 31 113 216
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 Imagecount = 1
 ImageFile = Normal\StartUserPanel.bmp
 ImageLayout = Horizontal
@@ -825,7 +825,7 @@ MinDpi2 = 164
 StockImageFile = Normal\TabBackground.bmp
 TrueSizeScalingType = Dpi
 TrueSizeStretchMark = 50
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 
 [Tab.Pane]
@@ -849,7 +849,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -867,7 +867,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -885,7 +885,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -903,7 +903,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -921,7 +921,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -939,7 +939,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -961,7 +961,7 @@ TEXTSHADOWTYPE = Single
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
 TEXTCOLOR = 112 112 112
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 
 [Tab.TopTabItemRightEdge]
 AccentColorHint = 255 200 60
@@ -975,7 +975,7 @@ Imagelayout = vertical
 SizingMargins = 6, 6, 6, 6
 TRANSPARENT = true
 TRANSPARENTCOLOR = 255 0 255
-FONT = Open Sans, 8
+FONT = Trebuchet MS, 8
 TEXTCOLOR = 112 112 112
 TEXTSHADOWCOLOR = 255 255 255
 TEXTSHADOWOFFSET = 1,1
@@ -1011,7 +1011,7 @@ Transparent = True
 TransparentColor = 255 0 255
 
 [TaskBand.GroupCount]
-Font = Open Sans, 8, Bold
+Font = Trebuchet MS, 8, Bold
 TextColor = 255 255 255
 
 [TaskBar.BackgroundBottom]
@@ -1663,7 +1663,7 @@ OffsetType = TopLeft
 [ExplorerBar::Rebar]
 Bgtype = imagefile
 FillColorHint = 243 247 253
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\ExplorerBarToolbarBackground.bmp
 Sizingmargins = 0, 0, 34, 0
 Sizingtype = stretch
@@ -1869,7 +1869,7 @@ AccentColorHint = 48 127 229
 BgType = ImageFile
 ContentMargins = 0, 0, 0, 0
 FillColorHint = 255 255 255
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\StartGroupBackground.bmp
 SizingMargins = 24, 3, 3, 4
 SizingType = Stretch
@@ -1975,7 +1975,7 @@ SizingMargins = 1, 1, 0, 0
 
 [TaskBand::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 TEXTSHADOWCOLOR = 0 0 0
 TEXTSHADOWOFFSET = 1,1
@@ -2035,7 +2035,7 @@ AccentColorHint = 255 199 60
 BgType = ImageFile
 ContentMargins = 6, 11, 6, 6
 FillColorHint = 33 87 213
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 ImageFile = Normal\TaskBandBackground.bmp
 SizingMargins = 6, 6, 6, 6
 SizingType = Stretch
@@ -2056,7 +2056,7 @@ Transparent = True
 
 [TaskBandVert::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBandVert::Toolbar.Button]
@@ -2083,7 +2083,7 @@ Transparent = True
 
 [TaskBar::Rebar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 123 182 232
 
 [TaskBar::Rebar.Band]
@@ -2142,7 +2142,7 @@ TransparentColor = 255 0 255
 
 [TaskBar::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBar::Toolbar.Button]
@@ -2169,7 +2169,7 @@ Transparent = True
 
 [TaskBarVert::Toolbar]
 BgType = None
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TaskBarVert::Toolbar(Checked)]
@@ -2204,7 +2204,7 @@ SizingType = Stretch
 Transparent = True
 
 [TrayNotify::Clock]
-Font = Open Sans, 8
+Font = Trebuchet MS, 8
 TextColor = 255 255 255
 
 [TrayNotify::Toolbar]


### PR DESCRIPTION
## Purpose

Eliminates the last references to "Open Sans" font.

This is an addendum to ( 0.4.13-dev-765-g 04a361d091095a96bb3af376e46daf4c5fe81c63 )
and 0.4.14-dev-20-g 2f4fb903b46207ab380365908401ded63752a108
"Open Sans" has been replaced by "Trebuchet MS" back then.
