### PR TITLE
[HDAUDBUS] Add support for GUID_HDAUDIO_BUS_INTERFACE_BDL

### DIFF
--- a/drivers/wdm/audio/hdaudbus/businterface.cpp
+++ b/drivers/wdm/audio/hdaudbus/businterface.cpp
@@ -294,6 +294,48 @@ HDA_UnregisterNotificationEvent(
 	return STATUS_NOT_IMPLEMENTED;
 }
 
+NTSTATUS
+NTAPI
+HDA_AllocateContiguousDmaBuffer(
+    IN PVOID _context,
+    IN HANDLE Handle,
+    ULONG RequestedBufferSize,
+    OUT PVOID *DataBuffer,
+    OUT PHDAUDIO_BUFFER_DESCRIPTOR *BdlBuffer)
+{
+	UNIMPLEMENTED;
+	ASSERT(FALSE);
+	return STATUS_NOT_IMPLEMENTED;
+}
+
+NTSTATUS
+NTAPI
+HDA_FreeContiguousDmaBuffer(
+    IN PVOID _context,
+    IN HANDLE Handle)
+{
+	UNIMPLEMENTED;
+	ASSERT(FALSE);
+	return STATUS_NOT_IMPLEMENTED;
+}
+
+NTSTATUS
+NTAPI
+HDA_SetupDmaEngineWithBdl(
+    IN PVOID _context,
+    IN HANDLE Handle,
+    ULONG BufferLength,
+    IN ULONG Lvi,
+    IN PHDAUDIO_BDL_ISR Isr,
+    PVOID Context,
+    OUT PUCHAR StreamId,
+    OUT PULONG FifoSize)
+{
+	UNIMPLEMENTED;
+	ASSERT(FALSE);
+	return STATUS_NOT_IMPLEMENTED;
+}
+
 
 NTSTATUS
 HDA_PDOHandleQueryInterface(
@@ -302,6 +344,7 @@ HDA_PDOHandleQueryInterface(
 {
     PIO_STACK_LOCATION IoStack;
     PHDAUDIO_BUS_INTERFACE_V2 InterfaceHDA;
+    PHDAUDIO_BUS_INTERFACE_BDL InterfaceBDL;
     PHDA_PDO_DEVICE_EXTENSION DeviceExtension;
 
     /* get device extension */
@@ -363,10 +406,36 @@ HDA_PDOHandleQueryInterface(
         InterfaceHDA->FreeDmaBufferWithNotification = HDA_FreeDmaBufferWithNotification;
         InterfaceHDA->RegisterNotificationEvent = HDA_RegisterNotificationEvent;
         InterfaceHDA->UnregisterNotificationEvent = HDA_UnregisterNotificationEvent;
+        return STATUS_SUCCESS;
+    }
+    else if (IsEqualGUIDAligned(*IoStack->Parameters.QueryInterface.InterfaceType, GUID_HDAUDIO_BUS_INTERFACE_BDL))
+    {
+        InterfaceBDL = (PHDAUDIO_BUS_INTERFACE_BDL)IoStack->Parameters.QueryInterface.Interface;
+        InterfaceBDL->Version = IoStack->Parameters.QueryInterface.Version;
+        InterfaceBDL->Size = sizeof(HDAUDIO_BUS_INTERFACE_BDL);
+        InterfaceBDL->Context = DeviceExtension;
+        InterfaceBDL->InterfaceReference = HDA_InterfaceReference;
+        InterfaceBDL->InterfaceDereference = HDA_InterfaceDereference;
+
+        InterfaceBDL->TransferCodecVerbs = HDA_TransferCodecVerbs;
+        InterfaceBDL->AllocateCaptureDmaEngine = HDA_AllocateCaptureDmaEngine;
+        InterfaceBDL->AllocateRenderDmaEngine = HDA_AllocateRenderDmaEngine;
+        InterfaceBDL->ChangeBandwidthAllocation = HDA_ChangeBandwidthAllocation;
+        InterfaceBDL->FreeDmaEngine = HDA_FreeDmaEngine;
+        InterfaceBDL->SetDmaEngineState = HDA_SetDmaEngineState;
+        InterfaceBDL->GetWallClockRegister = HDA_GetWallClockRegister;
+        InterfaceBDL->GetLinkPositionRegister = HDA_GetLinkPositionRegister;
+        InterfaceBDL->RegisterEventCallback = HDA_RegisterEventCallback;
+        InterfaceBDL->UnregisterEventCallback = HDA_UnregisterEventCallback;
+        InterfaceBDL->GetDeviceInformation = HDA_GetDeviceInformation;
+        InterfaceBDL->GetResourceInformation = HDA_GetResourceInformation;
+
+        InterfaceBDL->AllocateContiguousDmaBuffer = HDA_AllocateContiguousDmaBuffer;
+        InterfaceBDL->FreeContiguousDmaBuffer = HDA_FreeContiguousDmaBuffer;
+        InterfaceBDL->SetupDmaEngineWithBdl = HDA_SetupDmaEngineWithBdl;
+        return STATUS_SUCCESS;
     }
 
-    // FIXME
-    // implement support for GUID_HDAUDIO_BUS_INTERFACE_BDL
-    UNIMPLEMENTED;
+    DPRINT1("Unsupported HDAUDIO GUID requested\n");
     return STATUS_NOT_SUPPORTED;
 }

--- a/drivers/wdm/audio/hdaudbus/fdo.cpp
+++ b/drivers/wdm/audio/hdaudbus/fdo.cpp
@@ -120,7 +120,7 @@ HDA_DpcForIsr(
         if (Codec->ResponseCount >= MAX_CODEC_RESPONSES)
         {
             DPRINT1("too many responses for codec %x Response %x ResponseFlags %x\n", Cad, Response, ResponseFlags);
-            continue;
+            break;
         }
 
         // FIXME handle unsolicited responses


### PR DESCRIPTION
## Purpose

FIX 1: Handle `GUID_HDAUDIO_BUS_INTERFACE_BDL` in `HDA_PDOHandleQueryInterface`.
This HD audio version is used by Realtek High Definition audio driver as well.

FIX 2: Break out from the device enumeration loop when max codec responses number is reached.
Stop the execution of device enumeration in `HDA_DpcForIsr` DPC routine if `ResponseCount` is equal or more of `MAX_CODEC_RESPONSES` definition.
Since the maximal number of items in Responses array is declared with this constant, it definitely makes no any sense to store more items there.
Simply switching to next loop iteration causes endless loop execution until the timeout is reached and bugcheck is occured. So just break when the array is full.
Don't dumbly repeat Haiku OS behaviour.

The Intel HDA specification (to which MSDN references), declares 3 possible amounts of Responses for RIRB: 2, 16 and 256. It's available at https://www.intel.com/content/dam/www/public/us/en/documents/product-specifications/high-definition-audio-specification.pdf.

It should fix bugcheck 0x7e when installing Realtek HD audio driver via Device Manager. Although another timer assert is still here, but after ignoring it, the installation should finish successfully at least.

JIRA issue: [CORE-18776](https://jira.reactos.org/browse/CORE-18776)

## Proposed changes

- Handle `GUID_HDAUDIO_BUS_INTERFACE_BDL` in `HDA_PDOHandleQueryInterface`.
- Properly return success for `GUID_HDAUDIO_BUS_INTERFACE_V2`, to avoid executing failure case upon finishing.
- Add some stubs for `HDAUDIO_BUS_INTERFACE_BDL` specific routines: `AllocateContiguousDmaBuffer`, `FreeContiguousDmaBuffer` and `SetupDmaEngineWithBdl`. Set them together with other ones in `HDA_PDOHandleQueryInterface`.
- Break out from the device enumeration loop when max codec responses number is reached. **TODO: make sure this fix is correct.**

## TODO

- [ ] Perhaps implement the HDA routines as much as possible. The driver seems to call them, so it needs the correct implementation of them.
- [ ] Test it on a compatible hardware (cc @julenuri). Unfortunately, I have no compatible controller(s) right now.