### PR TITLE
[NTUSER] Delete temporary workarounds in co_IntSetScrollInfo()

### DIFF
--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -488,20 +488,15 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    UINT new_flags;
    INT action = 0;
    PSBDATA pSBData;
-   DWORD OldPos = 0, CurrentPos = 0;
+   DWORD OldPos = 0;
    BOOL bChangeParams = FALSE; /* Don't show/hide scrollbar if params don't change */
    UINT MaxPage;
    int MaxPos;
-   /* [0] = SB_HORZ, [1] = SB_VERT, [2] = SB_CTL */
-   static PWND PrevHwnd[3] = { 0 };
-   static DWORD PrevPos[3] = { 0 };
-   static DWORD PrevMax[3] = { 0 };
-   static INT PrevAction[3] = { 0 };
    BOOL bVisible;
 
    ASSERT_REFS_CO(Window);
 
-   if(!SBID_IS_VALID(nBar)) /* Assures nBar is 0, 1, or 2 */
+   if(!SBID_IS_VALID(nBar))
    {
       EngSetLastError(ERROR_INVALID_PARAMETER);
       ERR("Trying to set scrollinfo for unknown scrollbar type %d\n", nBar);
@@ -645,16 +640,6 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    }
 
 //done:
-   if ((Window != PrevHwnd[nBar]) || (action != PrevAction[nBar]))
-   {
-      if ((action == SA_SSI_SHOW) && (PrevAction[nBar] == SA_SSI_HIDE))
-      {
-         co_UserShowScrollBar(Window, nBar, TRUE, TRUE);
-      }
-   }
-   if ((action != PrevAction[nBar]) && action != 0)
-      PrevAction[nBar] = action;
-
    if ( action & SA_SSI_HIDE )
    {
       co_UserShowScrollBar(Window, nBar, FALSE, FALSE);
@@ -685,7 +670,6 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
       {
          if (!(Info->fMask & SIF_THEMED)) /* Not Using Themes */
          {
-            TRACE("Not using themes.\n");
             if (action & SA_SSI_REPAINT_ARROWS)
             {
                // Redraw the entire bar.
@@ -705,47 +689,14 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
          else  /* Using Themes */
          {
             RECTL UpdateRect = psbi->rcScrollBar;
-            TRACE("Using themes.\n");
             UpdateRect.left -= Window->rcClient.left - Window->rcWindow.left;
             UpdateRect.right -= Window->rcClient.left - Window->rcWindow.left;
             UpdateRect.top -= Window->rcClient.top - Window->rcWindow.top;
             UpdateRect.bottom -= Window->rcClient.top - Window->rcWindow.top;
-            /* Just paint the interior and not the arrows. */
-            if (!(action & SA_SSI_REPAINT_ARROWS))
-            {
-               if (nBar == SB_HORZ)
-               {
-                  UpdateRect.left += psbi->dxyLineButton;
-                  UpdateRect.right -= psbi->dxyLineButton;
-               }
-               if (nBar == SB_VERT)
-               {
-                  UpdateRect.top += psbi->dxyLineButton;
-                  UpdateRect.bottom -= psbi->dxyLineButton;
-               }
-            }
-            CurrentPos = lpsi->fMask & SIF_PREVIOUSPOS ? OldPos : pSBData->pos;
-            /* Check for changes to Window or CurrentPos or lpsi->nMax */
-            if ((Window != PrevHwnd[nBar]) || (CurrentPos != PrevPos[nBar]) ||
-               (lpsi->nMax != PrevMax[nBar]))
-            {
-                co_UserRedrawWindow(Window, &UpdateRect, 0, RDW_INVALIDATE | RDW_FRAME);
-                PrevHwnd[nBar] = Window;
-                PrevPos[nBar] = CurrentPos;
-                PrevMax[nBar] = lpsi->nMax;
-            }
+            co_UserRedrawWindow(Window, &UpdateRect, 0, RDW_INVALIDATE | RDW_FRAME);
          }
-      } // FIXME: Arrows
-/*      else if( action & SA_SSI_REPAINT_ARROWS )
-      {
-         RECTL UpdateRect = psbi->rcScrollBar;
-         UpdateRect.left -= Window->rcClient.left - Window->rcWindow.left;
-         UpdateRect.right -= Window->rcClient.left - Window->rcWindow.left;
-         UpdateRect.top -= Window->rcClient.top - Window->rcWindow.top;
-         UpdateRect.bottom -= Window->rcClient.top - Window->rcWindow.top;
-         co_UserRedrawWindow(Window, &UpdateRect, 0, RDW_INVALIDATE | RDW_FRAME);
       }
-*/   }
+   }
 
    if (bChangeParams && (nBar == SB_HORZ || nBar == SB_VERT) && (lpsi->fMask & SIF_DISABLENOSCROLL))
    {

--- a/win32ss/user/ntuser/scrollbar.c
+++ b/win32ss/user/ntuser/scrollbar.c
@@ -543,9 +543,9 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
    /* Set the scroll pos */
    if (lpsi->fMask & SIF_POS)
    {
+      OldPos = Info->nPos;
       if (Info->nPos != lpsi->nPos)
       {
-         OldPos = Info->nPos;
          Info->nPos = lpsi->nPos;
          pSBData->pos = lpsi->nPos;
       }
@@ -686,14 +686,15 @@ co_IntSetScrollInfo(PWND Window, INT nBar, LPCSCROLLINFO lpsi, BOOL bRedraw)
                IntRefeshScrollInterior(Window, nBar, psbi);
             }
          }
-         else  /* Using Themes */
+         else /* Using Themes */
          {
             RECTL UpdateRect = psbi->rcScrollBar;
             UpdateRect.left -= Window->rcClient.left - Window->rcWindow.left;
             UpdateRect.right -= Window->rcClient.left - Window->rcWindow.left;
             UpdateRect.top -= Window->rcClient.top - Window->rcWindow.top;
             UpdateRect.bottom -= Window->rcClient.top - Window->rcWindow.top;
-            co_UserRedrawWindow(Window, &UpdateRect, 0, RDW_INVALIDATE | RDW_FRAME);
+            if (bChangeParams || (OldPos != pSBData->pos))
+                co_UserRedrawWindow(Window, &UpdateRect, 0, RDW_INVALIDATE | RDW_FRAME);
          }
       }
    }


### PR DESCRIPTION
## Purpose

* fixes JIRA issue: [CORE-18050](https://jira.reactos.org/browse/CORE-18050)
* improves the code by removing ancient hacks
* reduces testbot failures
VBox: https://reactos.org/testman/compare.php?ids=85831,85832 LGTM (-2 failures in user32:scroll for both bots)
KVM: https://reactos.org/testman/compare.php?ids=85829,85833 LGTM (-2 failures in user32:scroll for both bots)

* co-authored by @Doug-Lyons . Many thanks for his contributions in the 2nd commit. Extremely valuable addition!

## A bit of history
Back when we committed
0.4.14-dev-1134-g 00adb1a3f967ac7f5cd56b4c39df72a7b3814603
we massively improved for the unthemed painting of scrollbars. Unfortunately that introduced a few glitches with themed scrollbars, so we had to commit some follow-ups, beginning with the good idea:
0.4.15-dev-3086-g 236649c626f97c68a9d0a6709a1bb342681b2aa0
which brought the initial solution to allow splitting the themed from the unthemed drawing paths.

But also some very unelegant temporary workarounds like:
0.4.15-dev-3147-g 3bf7e3ac13c5c9df373827c102b763b5b9822204
0.4.15-dev-3174-g dda9c3979e87223b66e61f0f936f46920221e509
0.4.15-dev-3175-g 222acf5a3ed11f74adbe0d1bdee527447fd81bbf
Those were not very elegant, especially those static variables.

Luckily we later found better solutions for the cases where we needed those former workarounds:
0.4.15-dev-3875-g 977c129f331cd5b92e0c7a4925e85fc14e147ec9

So we can get rid of the unelegant stuff with the static variables now.

-------------
## TODO
0.4.15-dev-3849-g fd28a69de63f1a801384e3d6c5675189aa82455e
was a workaround as well, and that one also got obsolete by the better
0.4.15-dev-3875-g 977c129f331cd5b92e0c7a4925e85fc14e147ec9
I do intend to revert that 2nd workaround with a later PR. I don't want to see that revert squashed with the changes in here (for better bisectability). But I do consider the static variables to be more wrong/ugly than that other small workaround, so I want to see them gone first.