### PR TITLE
[NTOS:MM] Support image prefixing in MmLoadSystemImage

### DIFF
--- a/ntoskrnl/mm/ARM3/sysldr.c
+++ b/ntoskrnl/mm/ARM3/sysldr.c
@@ -2900,7 +2900,7 @@ MmLoadSystemImage(IN PUNICODE_STRING FileName,
     ULONG EntrySize, DriverSize;
     PLOAD_IMPORTS LoadedImports = MM_SYSLDR_NO_IMPORTS;
     PCHAR MissingApiName, Buffer;
-    PWCHAR MissingDriverName;
+    PWCHAR MissingDriverName, PrefixedBuffer = NULL;
     HANDLE SectionHandle;
     ACCESS_MASK DesiredAccess;
     PSECTION Section = NULL;
@@ -2964,7 +2964,52 @@ MmLoadSystemImage(IN PUNICODE_STRING FileName,
     PrefixName = *FileName;
 
     /* Check if we have a prefix */
-    if (NamePrefix) DPRINT1("Prefixed images are not yet supported!\n");
+    if (NamePrefix)
+    {
+        /* Check if "directory + prefix" is too long for the string */
+        Status = RtlUShortAdd(BaseDirectory.Length,
+                              NamePrefix->Length,
+                              &PrefixName.MaximumLength);
+        if (!NT_SUCCESS(Status))
+        {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Quickie;
+        }
+
+        /* Check if "directory + prefix + basename" is too long for the string */
+        Status = RtlUShortAdd(PrefixName.MaximumLength,
+                              BaseName.Length,
+                              &PrefixName.MaximumLength);
+        if (!NT_SUCCESS(Status))
+        {
+            Status = STATUS_INVALID_PARAMETER;
+            goto Quickie;
+        }
+
+        /* Allocate the buffer exclusively used for prefixed name */
+        PrefixedBuffer = ExAllocatePoolWithTag(PagedPool,
+                                               PrefixName.MaximumLength,
+                                               TAG_LDR_WSTR);
+        if (!PrefixedBuffer)
+        {
+            Status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Quickie;
+        }
+
+        /* Clear out the prefixed name string */
+        PrefixName.Buffer = PrefixedBuffer;
+        PrefixName.Length = 0;
+
+        /* Concatenate the strings */
+        RtlAppendUnicodeStringToString(&PrefixName, &BaseDirectory);
+        RtlAppendUnicodeStringToString(&PrefixName, NamePrefix);
+        RtlAppendUnicodeStringToString(&PrefixName, &BaseName);
+
+        /* Now the base name of the image becomes the prefixed version */
+        BaseName.Buffer = &(PrefixName.Buffer[BaseDirectory.Length / sizeof(WCHAR)]);
+        BaseName.Length += NamePrefix->Length;
+        BaseName.MaximumLength = (PrefixName.MaximumLength - BaseDirectory.Length);
+    }
 
     /* Check if we already have a name, use it instead */
     if (LoadedName) BaseName = *LoadedName;
@@ -3406,8 +3451,8 @@ Quickie:
     /* If we have a file handle, close it */
     if (FileHandle) ZwClose(FileHandle);
 
-    /* Check if we had a prefix (not supported yet - PrefixName == *FileName now) */
-    /* if (NamePrefix) ExFreePool(PrefixName.Buffer); */
+    /* If we have allocated a prefixed name buffer, free it */
+    if (PrefixedBuffer) ExFreePoolWithTag(PrefixedBuffer, TAG_LDR_WSTR);
 
     /* Free the name buffer and return status */
     ExFreePoolWithTag(Buffer, TAG_LDR_WSTR);


### PR DESCRIPTION
## Purpose

The `MmLoadSystemImage` function has a parameter called `IN PUNICODE_STRING NamePrefix OPTIONAL`. In the current ReactOS codebase, there's nowhere that this parameter is used. In Windows, this parameter is used in crash dump storage stack, where the special "crash mode" drivers would be loaded by kernel directly through MmLoadSystemImage, with a "dump_"(for crash dump)/"hiber_"(for hibernation) (see [reference post on OSR](https://community.osr.com/discussion/comment/97932/)).

When this parameter is specified, the actual driver's image to be loaded would be loaded under the prefixed name. The driver would appear in module list when running `lm` in WinDbg.

This isn't a urgently needed feature but I think it's better to have a solid foundation for my experiments on crash dump mechanism. And I should also begin with smaller kernel patches.

Jira ticket: [CORE-376](https://jira.reactos.org/browse/CORE-376)

In Windows XP (5.1.2600): 
![图片](https://user-images.githubusercontent.com/49363666/211505160-838ece38-7028-413f-9804-6268de51f516.png)
![图片](https://user-images.githubusercontent.com/49363666/211506209-c7ee0a59-d88d-4b18-b0b8-0be513c33ea1.png)

This PR (with my experiments on crash dump):
![图片](https://user-images.githubusercontent.com/49363666/211506261-db84ca06-a7d6-4ede-8410-26f1dae00952.png)
![图片](https://user-images.githubusercontent.com/49363666/211506318-7996d4f3-efe7-4239-83d2-16530ec99591.png)



## Proposed changes

- Added image prefix support in MmLoadSystemImage.