### PR TITLE
[ATL] CImage::Load() returns E_FAIL without ATLASSERT if failed to load image

### DIFF
--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -382,8 +382,10 @@ public:
         // create a GpBitmap object from file
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        GetCommon().CreateBitmapFromFile(pszNameW, &pBitmap);
-        ATLASSERT(pBitmap);
+        if (GetCommon().CreateBitmapFromFile(pszNameW, &pBitmap) != Ok)
+        {
+            return E_FAIL;
+        }
 
         // TODO & FIXME: get parameters (m_rgbTransColor etc.)
 
@@ -407,8 +409,10 @@ public:
         // create GpBitmap from stream
         using namespace Gdiplus;
         GpBitmap *pBitmap = NULL;
-        GetCommon().CreateBitmapFromStream(pStream, &pBitmap);
-        ATLASSERT(pBitmap);
+        if (GetCommon().CreateBitmapFromStream(pStream, &pBitmap) != Ok)
+        {
+            return E_FAIL;
+        }
 
         // TODO & FIXME: get parameters (m_rgbTransColor etc.)
 


### PR DESCRIPTION
## Purpose

Like MS ATL did, application won't be interrupted by ATLASSERT when failed to load image

JIRA issue: [CORE-18589](https://jira.reactos.org/browse/CORE-18589)

## Proposed changes

- CImage::Load() returns E_FAIL without ASSERT if failed to load image like MS ATL did

![2023-01-14 000536](https://user-images.githubusercontent.com/55521781/212373393-49b9ea89-3764-4636-aefe-915513ade9f5.png)
Open an invalid file in Paint:
Left (After this PR): Paint alerts the image cannot be loaded
Right (Before this PR): Paint interrupted by ATLASSERT

cooperated with KRosUser
