### PR TITLE
[NTUSER] Fix winpos bug hyperlink&images loop redrawing (CORE-7652)

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2100,7 +2100,8 @@ co_WinPosSetWindowPos(
       }
 
       /* We need to redraw what wasn't visible before or force a redraw */
-      if ((WinPos.flags & (SWP_FRAMECHANGED | SWP_SHOWWINDOW)) || (((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) && VisAfter != NULL))
+      if ((WinPos.flags & (SWP_FRAMECHANGED | SWP_SHOWWINDOW)) ||
+          (((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) && VisAfter != NULL))
       {
          PREGION DirtyRgn = IntSysCreateRectpRgn(0, 0, 0, 0);
          if (DirtyRgn)

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2100,7 +2100,7 @@ co_WinPosSetWindowPos(
       }
 
       /* We need to redraw what wasn't visible before or force a redraw */
-      if (VisAfter != NULL)
+      if ((WinPos.flags & (SWP_FRAMECHANGED | SWP_SHOWWINDOW)) || (((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) && VisAfter != NULL))
       {
          PREGION DirtyRgn = IntSysCreateRectpRgn(0, 0, 0, 0);
          if (DirtyRgn)


### PR DESCRIPTION
## Purpose

Thanks to the hard work of I_Kill_Bugs and Simone, I would like to propose this fix or workaround for the bugs that appears in elements rendered that include hyperlinks and images at the same time. I'm not skilled enough to call them preciselly, but after some investigations, I take 3 conclusions: 

1st, the elements are rendered once and again fighting with other rendered elements, that cause that flickering. 
2nd, that rendering causes malfunction in the whole software rendering, causing a near 99% of CPU use.
3rd, some of them are being rendered over other windows, and if we minimize it, the GUI of the software will become responsible.

Fails detected:
(SWP_NOMOVE | SWP_NOZORDER | SWP_NOACTIVATE) is from VC2008
(SWP_NOZORDER) is from CPUZ
(SWP_NOZORDER and SWP_NOSIZE) from API Monitor

## JIRA issues:

-[CORE-7652](https://jira.reactos.org/browse/CORE-7652)
-[CORE-7753](https://jira.reactos.org/browse/CORE-7753)
-[CORE-10741](https://jira.reactos.org/browse/CORE-10741)
-[CORE-15300](https://jira.reactos.org/browse/CORE-15300)
-[CORE-15756](https://jira.reactos.org/browse/CORE-15756)
-[CORE-16325](https://jira.reactos.org/browse/CORE-16325)
-[CORE-18434](https://jira.reactos.org/browse/CORE-18434)
-[CORE-18553](https://jira.reactos.org/browse/CORE-18553)


## Proposed changes

- I_Kill_Bugs propose this fix. Avoiding the redrawing under the situations that affects that software.

## TODO

- [ ] Check if the testbots are happy with this patch. 
- [x] Check if the avoid of this redraw affects other pieces of software. *Yes it does*, at least, rapps when first open or de-minimize, some comboboxes are not drawn at first. 
![Captura desde 2023-01-16 02-35-30](https://user-images.githubusercontent.com/27921286/212580773-b95cd861-b90a-4042-875c-10c1fc2dad61.png)
Also, the Performance tab from Task manager is not redrawing some elements after getting it off the screen correcly. 

- [ ] Check if this is the best fix (or it's simply a hack).
