### PR TITLE
Fix butterflies screensaver

### DIFF
--- a/modules/rosapps/applications/screensavers/butterflies/butterflies.c
+++ b/modules/rosapps/applications/screensavers/butterflies/butterflies.c
@@ -12,6 +12,7 @@
 HINSTANCE		hInstance;			// Holds The Instance Of The Application
 
 GLuint texture[3];	                //stores texture objects and display list
+HDC hdcOpenGL;
 
 LPCTSTR registryPath = _T("Software\\Microsoft\\ScreenSavers\\Butterflies");
 BOOL dRotate;
@@ -136,7 +137,7 @@ HGLRC InitOGLWindow(HWND hWnd)
 	hRC = wglCreateContext(hDC);
 	wglMakeCurrent(hDC, hRC);
 
-	ReleaseDC(hWnd, hDC);
+	hdcOpenGL = hDC;
 
 	return hRC;
 }
@@ -287,6 +288,7 @@ LRESULT WINAPI ScreenSaverProc(HWND hWnd, UINT message,
 	case WM_DESTROY:
 		wglMakeCurrent(NULL, NULL);
 		wglDeleteContext(hRC);
+		ReleaseDC(hWnd, hdcOpenGL);
 		break;
 	}
 

--- a/win32ss/gdi/gdi32/objects/bitmap.c
+++ b/win32ss/gdi/gdi32/objects/bitmap.c
@@ -756,8 +756,10 @@ SetDIBitsToDevice(
 
     if (!GdiGetHandleUserData(hdc, GDI_OBJECT_TYPE_DC, (PVOID) & pDc_Attr))
     {
+        DPRINT1("SetDIBitsToDevice called on invalid DC %p (not owned?)\n", hdc);
         SetLastError(ERROR_INVALID_PARAMETER);
-        return 0;
+        LinesCopied = 0;
+        goto Exit;
     }
     /*
      if ( !pDc_Attr || // DC is Public
@@ -867,8 +869,10 @@ StretchDIBits(
 
     if (!GdiGetHandleUserData(hdc, GDI_OBJECT_TYPE_DC, (PVOID) & pDc_Attr))
     {
+        DPRINT1("StretchDIBits called on invalid DC %p (not owned?)\n", hdc);
         SetLastError(ERROR_INVALID_PARAMETER);
-        return 0;
+        LinesCopied = 0;
+        goto Exit;
     }
     /*
      if ( !pDc_Attr ||
@@ -894,6 +898,7 @@ StretchDIBits(
                                                   cjBmpScanSize,
                                                   NULL );
     }
+Exit:
     if (pvSafeBits)
         RtlFreeHeap(RtlGetProcessHeap(), 0, pvSafeBits);
     if (lpBitsInfo != pConvertedInfo)


### PR DESCRIPTION
* Fix a memory leak in gdi32
* Fix the butterflies screensaver not to release the DC it passes to OpenGL

The screensaver now works smoothly in ROS, and without blowing up our memory manager.

JIRA issue: [CORE-18498](https://jira.reactos.org/browse/CORE-18498)