### PR TITLE
[COMCTL32] Fix issue at BUTTON_CheckAutoRadioButton"

### DIFF
--- a/dll/win32/comctl32/button.c
+++ b/dll/win32/comctl32/button.c
@@ -1667,7 +1667,8 @@ static void BUTTON_CheckAutoRadioButton( HWND hwnd )
     {
         if (!sibling) break;
 #ifdef __REACTOS__
-        if (SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
+        DWORD Mask = DLGC_BUTTON | DLGC_RADIOBUTTON;
+        if ((SendMessageW( sibling, WM_GETDLGCODE, 0, 0 ) & Mask) == (DLGC_BUTTON | DLGC_RADIOBUTTON))
             SendMessageW( sibling, BM_SETCHECK, sibling == hwnd ? BST_CHECKED : BST_UNCHECKED, 0 );
 #else
         if ((hwnd != sibling) &&


### PR DESCRIPTION
[COMCTL32] Fix issue at BUTTON_CheckAutoRadioButton

     When we modify the selection in a group of AutoRadioButton  objects, the new button is not selected.

This happen when the WM_GETDLGCODE message returns bits other than (DLGC_BUTTON|DLGC_RADIOBUTTON) such DLGC_WANTARROWS, wich is quite common.

Adopted Solution: The comparison must be done using a mask that rejects the non-mandatory bits


Affected objects:
    Accessibility/Mouse Keys Settings/(On/off).
    Properties for Console/Options/(Cursor Size)
                                                       (Display Options)
