### PR TITLE
[SHELL32] Add 3 missing accelerators for IDM_DRAGFILE MENU in de-DE.rc

### DIFF
--- a/dll/win32/shell32/lang/de-DE.rc
+++ b/dll/win32/shell32/lang/de-DE.rc
@@ -80,9 +80,9 @@ IDM_DRAGFILE MENU
 BEGIN
     POPUP ""
     BEGIN
-        MENUITEM "Hierher kopieren", IDM_COPYHERE
-        MENUITEM "Hierher verschieben", IDM_MOVEHERE
-        MENUITEM "Verknüpfung hier erstellen", IDM_LINKHERE
+        MENUITEM "Hierher &kopieren", IDM_COPYHERE
+        MENUITEM "Hierher &verschieben", IDM_MOVEHERE
+        MENUITEM "Verknüpfung hier &erstellen", IDM_LINKHERE
         MENUITEM SEPARATOR
         MENUITEM "Abbrechen", 0
     END


### PR DESCRIPTION
## Purpose

English translation has its accelerators, the german ones were stripped
erroneously when this dlg was translated during 0.4.9-dev'ing.

I used the accelerators from my german WinXPSP3.