### PR TITLE
[NTUSER][USER32] Set WM_CONTEXTMENU's wParam to the child window's handle

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -738,7 +738,7 @@ IntDefWindowProc(
       {
             if (Wnd->style & WS_CHILD)
             {
-                co_IntSendMessage(UserHMGetHandle(IntGetParent(Wnd)), Msg, wParam, lParam);
+                co_IntSendMessage(UserHMGetHandle(IntGetParent(Wnd)), Msg, (WPARAM)UserHMGetHandle(Wnd), lParam);
             }
             else
             {

--- a/win32ss/user/user32/windows/defwnd.c
+++ b/win32ss/user/user32/windows/defwnd.c
@@ -390,11 +390,11 @@ User32DefWindowProc(HWND hWnd,
             {
                 if (bUnicode)
                 {
-                    SendMessageW(GetParent(hWnd), Msg, wParam, lParam);
+                    SendMessageW(GetParent(hWnd), Msg, (WPARAM)hWnd, lParam);
                 }
                 else
                 {
-                    SendMessageA(GetParent(hWnd), WM_CONTEXTMENU, wParam, lParam);
+                    SendMessageA(GetParent(hWnd), Msg, (WPARAM)hWnd, lParam);
                 }
             }
             else


### PR DESCRIPTION
## Purpose

Set WM_CONTEXTMENU's wParam to the child window's handle

JIRA issue: [CORE-18801](https://jira.reactos.org/browse/CORE-18801)

## Proposed changes

Cherry-picked from https://github.com/wine-mirror/wine/commit/3af8415ca9dc50e6c394c1001aad97db5f514069
