### PR TITLE
[OLEAUT32] Return proper value from OaBuildVersion

### DIFF
--- a/dll/win32/oleaut32/oleaut.c
+++ b/dll/win32/oleaut32/oleaut.c
@@ -660,6 +660,9 @@ ULONG WINAPI OaBuildVersion(void)
     case 0x00000005:  /* W2K */
 		return MAKELONG(0xffff, 40);
     case 0x00000105:  /* WinXP */
+#ifdef __REACTOS__
+    case 0x00000205:  /* Win2K3 */
+#endif /* __REACTOS__ */
     case 0x00000006:  /* Vista */
     case 0x00000106:  /* Win7 */
 		return MAKELONG(0xffff, 50);


### PR DESCRIPTION
## Purpose
Return proper value from OaBuildVersion 
JIRA issue: [CORE-18419](https://jira.reactos.org/browse/CORE-18419)

## Proposed changes
- Returns MAKELONG(0xffff, 50) for Win2K3 (and ReactOS)
- No useless FIXME output

![OaBuildVersion_On_2K3_W11](https://user-images.githubusercontent.com/55521781/213859895-a08ccca5-da04-4396-8dad-3615f2bd2154.png)
