### PR TITLE
[NTUSER] Check IME-like after WNDS_DESTROYED check

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2980,8 +2980,9 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
    IntSendDestroyMsg(UserHMGetHandle(Window));
 
    // Destroy the default IME window if necessary
-   if (IS_IMM_MODE() && !(ti->TIF_flags & TIF_INCLEANUP) &&
-       ti->spwndDefaultIme && !IS_WND_IMELIKE(Window) && !(Window->state & WNDS_DESTROYED))
+   if (IS_IMM_MODE() && (ti != NULL) && !(ti->TIF_flags & TIF_INCLEANUP) &&
+       ti->spwndDefaultIme && ti->spwndDefaultIme != Window &&
+       !(Window->state & WNDS_DESTROYED) && !IS_WND_IMELIKE(Window))
    {
        if (IS_WND_CHILD(Window))
        {

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2945,7 +2945,7 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
     * Check if this window is the Shell's Desktop Window. If so set hShellWindow to NULL
     */
 
-   if ((ti != NULL) && (ti->pDeskInfo != NULL))
+   if (ti->pDeskInfo != NULL)
    {
       if (ti->pDeskInfo->hShellWindow == hWnd)
       {
@@ -2980,7 +2980,7 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
    IntSendDestroyMsg(UserHMGetHandle(Window));
 
    /* Destroy the default IME window if necessary */
-   if (IS_IMM_MODE() && (ti != NULL) && !(ti->TIF_flags & TIF_INCLEANUP) &&
+   if (IS_IMM_MODE() && !(ti->TIF_flags & TIF_INCLEANUP) &&
        ti->spwndDefaultIme && (ti->spwndDefaultIme != Window) &&
        !(Window->state & WNDS_DESTROYED) && !IS_WND_IMELIKE(Window))
    {

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2979,9 +2979,9 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
    /* Send destroy messages */
    IntSendDestroyMsg(UserHMGetHandle(Window));
 
-   // Destroy the default IME window if necessary
+   /* Destroy the default IME window if necessary */
    if (IS_IMM_MODE() && (ti != NULL) && !(ti->TIF_flags & TIF_INCLEANUP) &&
-       ti->spwndDefaultIme && ti->spwndDefaultIme != Window &&
+       ti->spwndDefaultIme && (ti->spwndDefaultIme != Window) &&
        !(Window->state & WNDS_DESTROYED) && !IS_WND_IMELIKE(Window))
    {
        if (IS_WND_CHILD(Window))


### PR DESCRIPTION
## Purpose

The guilty commit https://github.com/reactos/reactos/commit/a2c6af0da4acbba9c254d003e9d9f4ea6e03ed63 had enabled the IMM mode. So we should take care of the default IME windows. This PR will fix BSoD of `mplay32`.

JIRA issue: [CORE-18777](https://jira.reactos.org/browse/CORE-18777)

## Proposed changes

When the default IME window of the target window is to be destroyed, the target window does:

- Delete `(pti != NULL)` check.
- Check `(ti->spwndDefaultIme != Window)`.
- Check IME-like after `WNDS_DESTROYED` check.

## Screenshots

CORE-18777 BEFORE:
![CORE-18777-before](https://user-images.githubusercontent.com/2107452/213902317-ce6af774-f4b1-4f33-a696-a864d0360c36.png)

CORE-18777 AFTER:
![CORE-18777-after](https://user-images.githubusercontent.com/2107452/213902316-73a9ac2d-3c88-45c2-924e-03287be81f46.png)