### PR TITLE
[SHELL32] Improve StartButton context menu

### DIFF
--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1120,8 +1120,7 @@ public:
         IN POINT *ppt OPTIONAL,
         IN HWND hwndExclude OPTIONAL,
         IN BOOL TrackUp,
-        IN PVOID Context OPTIONAL,
-        IN UINT uFlags = CMF_NORMAL)
+        IN PVOID Context OPTIONAL)
     {
         POINT pt;
         TPMPARAMS params;
@@ -1145,7 +1144,7 @@ public:
         }
 
         TRACE("Before Query\n");
-        hr = contextMenu->QueryContextMenu(popup, 0, 0, UINT_MAX, uFlags);
+        hr = contextMenu->QueryContextMenu(popup, 0, 0, UINT_MAX, CMF_NORMAL);
         if (FAILED_UNEXPECTEDLY(hr))
         {
             TRACE("Query failed\n");
@@ -3008,7 +3007,7 @@ ChangePos:
             {
                 CComPtr<IContextMenu> ctxMenu;
                 CStartMenuBtnCtxMenu_CreateInstance(this, m_hWnd, &ctxMenu);
-                TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this, CMF_VERBSONLY);
+                TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this);
             }
         }
         else
@@ -3044,7 +3043,7 @@ ChangePos:
             {
 HandleTrayContextMenu:
                 /* Tray the default tray window context menu */
-                TrackCtxMenu(this, ppt, NULL, FALSE, this, CMF_NORMAL);
+                TrackCtxMenu(this, ppt, NULL, FALSE, this);
             }
         }
         return Ret;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -1120,7 +1120,8 @@ public:
         IN POINT *ppt OPTIONAL,
         IN HWND hwndExclude OPTIONAL,
         IN BOOL TrackUp,
-        IN PVOID Context OPTIONAL)
+        IN PVOID Context OPTIONAL,
+        IN UINT uFlags = CMF_NORMAL)
     {
         POINT pt;
         TPMPARAMS params;
@@ -1144,7 +1145,7 @@ public:
         }
 
         TRACE("Before Query\n");
-        hr = contextMenu->QueryContextMenu(popup, 0, 0, UINT_MAX, CMF_NORMAL);
+        hr = contextMenu->QueryContextMenu(popup, 0, 0, UINT_MAX, uFlags);
         if (FAILED_UNEXPECTEDLY(hr))
         {
             TRACE("Query failed\n");
@@ -3007,7 +3008,7 @@ ChangePos:
             {
                 CComPtr<IContextMenu> ctxMenu;
                 CStartMenuBtnCtxMenu_CreateInstance(this, m_hWnd, &ctxMenu);
-                TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this);
+                TrackCtxMenu(ctxMenu, ppt, hWndExclude, m_Position == ABE_BOTTOM, this, CMF_VERBSONLY);
             }
         }
         else
@@ -3043,7 +3044,7 @@ ChangePos:
             {
 HandleTrayContextMenu:
                 /* Tray the default tray window context menu */
-                TrackCtxMenu(this, ppt, NULL, FALSE, this);
+                TrackCtxMenu(this, ppt, NULL, FALSE, this, CMF_NORMAL);
             }
         }
         return Ret;

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -271,6 +271,11 @@ CCopyToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("CCopyToMenu::QueryContextMenu(%p, %u, %u, %u, %u)\n",
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
+    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
+    {
+        return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
+    }
+
     m_idCmdFirst = m_idCmdLast = idCmdFirst;
 
     // insert separator if necessary

--- a/dll/win32/shell32/CCopyToMenu.cpp
+++ b/dll/win32/shell32/CCopyToMenu.cpp
@@ -271,10 +271,8 @@ CCopyToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("CCopyToMenu::QueryContextMenu(%p, %u, %u, %u, %u)\n",
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
-    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
-    {
+    if (uFlags & (CMF_NOVERBS | CMF_VERBSONLY))
         return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
-    }
 
     m_idCmdFirst = m_idCmdLast = idCmdFirst;
 

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -84,7 +84,7 @@ class CDefaultContextMenu :
         BOOL IsShellExtensionAlreadyLoaded(REFCLSID clsid);
         HRESULT LoadDynamicContextMenuHandler(HKEY hKey, REFCLSID clsid);
         BOOL EnumerateDynamicContextHandlerForKey(HKEY hRootKey);
-        UINT AddShellExtensionsToMenu(HMENU hMenu, UINT* pIndexMenu, UINT idCmdFirst, UINT idCmdLast);
+        UINT AddShellExtensionsToMenu(HMENU hMenu, UINT* pIndexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags);
         UINT AddStaticContextMenusToMenu(HMENU hMenu, UINT* IndexMenu, UINT iIdCmdFirst, UINT iIdCmdLast);
         HRESULT DoPaste(LPCMINVOKECOMMANDINFOEX lpcmi, BOOL bLink);
         HRESULT DoOpenOrExplore(LPCMINVOKECOMMANDINFOEX lpcmi);
@@ -417,7 +417,7 @@ CDefaultContextMenu::EnumerateDynamicContextHandlerForKey(HKEY hRootKey)
 }
 
 UINT
-CDefaultContextMenu::AddShellExtensionsToMenu(HMENU hMenu, UINT* pIndexMenu, UINT idCmdFirst, UINT idCmdLast)
+CDefaultContextMenu::AddShellExtensionsToMenu(HMENU hMenu, UINT* pIndexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
 {
     UINT cIds = 0;
 
@@ -429,7 +429,7 @@ CDefaultContextMenu::AddShellExtensionsToMenu(HMENU hMenu, UINT* pIndexMenu, UIN
     {
         DynamicShellEntry& info = m_DynamicEntries.GetNext(it);
 
-        HRESULT hr = info.pCM->QueryContextMenu(hMenu, *pIndexMenu, idCmdFirst + cIds, idCmdLast, CMF_NORMAL);
+        HRESULT hr = info.pCM->QueryContextMenu(hMenu, *pIndexMenu, idCmdFirst + cIds, idCmdLast, uFlags);
         if (SUCCEEDED(hr))
         {
             info.iIdCmdFirst = cIds;
@@ -636,7 +636,7 @@ CDefaultContextMenu::QueryContextMenu(
     idCmdNext = idCmdFirst + cIds;
 
     /* Add dynamic context menu handlers */
-    cIds += AddShellExtensionsToMenu(hMenu, &IndexMenu, idCmdNext, idCmdLast);
+    cIds += AddShellExtensionsToMenu(hMenu, &IndexMenu, idCmdNext, idCmdLast, uFlags);
     m_iIdSHEFirst = m_iIdSCMLast;
     m_iIdSHELast = cIds;
     idCmdNext = idCmdFirst + cIds;

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -270,10 +270,8 @@ CMoveToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("CMoveToMenu::QueryContextMenu(%p, %u, %u, %u, %u)\n",
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
-    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
-    {
+    if (uFlags & (CMF_NOVERBS | CMF_VERBSONLY))
         return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
-    }
 
     m_idCmdFirst = m_idCmdLast = idCmdFirst;
 

--- a/dll/win32/shell32/CMoveToMenu.cpp
+++ b/dll/win32/shell32/CMoveToMenu.cpp
@@ -270,6 +270,11 @@ CMoveToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("CMoveToMenu::QueryContextMenu(%p, %u, %u, %u, %u)\n",
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
+    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
+    {
+        return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
+    }
+
     m_idCmdFirst = m_idCmdLast = idCmdFirst;
 
     // insert separator if necessary

--- a/dll/win32/shell32/CSendToMenu.cpp
+++ b/dll/win32/shell32/CSendToMenu.cpp
@@ -295,6 +295,11 @@ CSendToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("%p %p %u %u %u %u\n", this,
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
+    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
+    {
+        return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
+    }
+
     HMENU hSubMenu = CreateMenu();
     if (!hSubMenu)
     {

--- a/dll/win32/shell32/CSendToMenu.cpp
+++ b/dll/win32/shell32/CSendToMenu.cpp
@@ -295,10 +295,8 @@ CSendToMenu::QueryContextMenu(HMENU hMenu,
     TRACE("%p %p %u %u %u %u\n", this,
           hMenu, indexMenu, idCmdFirst, idCmdLast, uFlags);
 
-    if ((uFlags & (CMF_NOVERBS | CMF_VERBSONLY)) != 0) // CORE-16544
-    {
+    if (uFlags & (CMF_NOVERBS | CMF_VERBSONLY))
         return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 0);
-    }
 
     HMENU hSubMenu = CreateMenu();
     if (!hSubMenu)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-16544](https://jira.reactos.org/browse/CORE-16544)

## Proposed changes

- Add `uFlags` argument to `CDefaultContextMenu::AddShellExtensionsToMenu`.
- `CCopyToMenu`, `CMoveToMenu`, and `CSendToMenu` check the `uFlags` against `(CMF_NOVERBS | CMF_VERBSONLY)`.

## TODO

- [x] Do tests.

## Screenshots

BEFORE:
![before-1](https://user-images.githubusercontent.com/2107452/214014222-7e8b7a9b-3a16-4db5-a6f3-86c5f62f47e9.png)

AFTER:
![after-1](https://user-images.githubusercontent.com/2107452/214014105-f7c68a43-808a-4f7a-ae66-42bdca373daf.png)