### PR TITLE
[NTUSER] Move IME window creation code

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2050,33 +2050,6 @@ PWND FASTCALL IntCreateWindow(CREATESTRUCTW* Cs,
       pWnd->strName.MaximumLength = WindowName->Length + sizeof(UNICODE_NULL);
    }
 
-   /* Create the IME window for pWnd */
-   if (IS_IMM_MODE() && !(pti->spwndDefaultIme) && IntWantImeWindow(pWnd))
-   {
-      PWND pwndDefaultIme = co_IntCreateDefaultImeWindow(pWnd, pWnd->hModule);
-      UserAssignmentLock((PVOID*)&(pti->spwndDefaultIme), pwndDefaultIme);
-
-      if (pwndDefaultIme)
-      {
-         HWND hImeWnd;
-         USER_REFERENCE_ENTRY Ref;
-         UserRefObjectCo(pwndDefaultIme, &Ref);
-
-         hImeWnd = UserHMGetHandle(pwndDefaultIme);
-
-         co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_LOADTHREADLAYOUT, 0);
-
-         if (pti->pClientInfo->CI_flags & CI_IMMACTIVATE)
-         {
-            HKL hKL = pti->KeyboardLayout->hkl;
-            co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_ACTIVATELAYOUT, (LPARAM)hKL);
-            pti->pClientInfo->CI_flags &= ~CI_IMMACTIVATE;
-         }
-
-         UserDerefObjectCo(pwndDefaultIme);
-      }
-   }
-
    /* Correct the window style. */
    if ((pWnd->style & (WS_CHILD | WS_POPUP)) != WS_CHILD)
    {
@@ -2463,6 +2436,33 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
 
    RECTL_vOffsetRect(&Window->rcWindow, MaxPos.x - Window->rcWindow.left,
                                      MaxPos.y - Window->rcWindow.top);
+   }
+
+   /* Create the IME window for pWnd */
+   if (IS_IMM_MODE() && !(pti->spwndDefaultIme) && IntWantImeWindow(Window))
+   {
+      PWND pwndDefaultIme = co_IntCreateDefaultImeWindow(Window, Window->hModule);
+      UserAssignmentLock((PVOID*)&(pti->spwndDefaultIme), pwndDefaultIme);
+
+      if (pwndDefaultIme)
+      {
+         HWND hImeWnd;
+         USER_REFERENCE_ENTRY Ref;
+         UserRefObjectCo(pwndDefaultIme, &Ref);
+
+         hImeWnd = UserHMGetHandle(pwndDefaultIme);
+
+         co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_LOADTHREADLAYOUT, 0);
+
+         if (pti->pClientInfo->CI_flags & CI_IMMACTIVATE)
+         {
+            HKL hKL = pti->KeyboardLayout->hkl;
+            co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_ACTIVATELAYOUT, (LPARAM)hKL);
+            pti->pClientInfo->CI_flags &= ~CI_IMMACTIVATE;
+         }
+
+         UserDerefObjectCo(pwndDefaultIme);
+      }
    }
 
    /* Send the WM_CREATE message. */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2423,21 +2423,6 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
           IntLinkHwnd(Window, hwndInsertAfter);
    }
 
-   /* Send the WM_NCCALCSIZE message */
-   {
-  // RECT rc;
-   MaxPos.x = Window->rcWindow.left;
-   MaxPos.y = Window->rcWindow.top;
-
-   Result = co_WinPosGetNonClientSize(Window, &Window->rcWindow, &Window->rcClient);
-   //rc = Window->rcWindow;
-   //Result = co_IntSendMessageNoWait(Window->head.h, WM_NCCALCSIZE, FALSE, (LPARAM)&rc);
-   //Window->rcClient = rc;
-
-   RECTL_vOffsetRect(&Window->rcWindow, MaxPos.x - Window->rcWindow.left,
-                                     MaxPos.y - Window->rcWindow.top);
-   }
-
    /* Create the IME window for pWnd */
    if (IS_IMM_MODE() && !(pti->spwndDefaultIme) && IntWantImeWindow(Window))
    {
@@ -2463,6 +2448,21 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
 
          UserDerefObjectCo(pwndDefaultIme);
       }
+   }
+
+   /* Send the WM_NCCALCSIZE message */
+   {
+  // RECT rc;
+   MaxPos.x = Window->rcWindow.left;
+   MaxPos.y = Window->rcWindow.top;
+
+   Result = co_WinPosGetNonClientSize(Window, &Window->rcWindow, &Window->rcClient);
+   //rc = Window->rcWindow;
+   //Result = co_IntSendMessageNoWait(Window->head.h, WM_NCCALCSIZE, FALSE, (LPARAM)&rc);
+   //Window->rcClient = rc;
+
+   RECTL_vOffsetRect(&Window->rcWindow, MaxPos.x - Window->rcWindow.left,
+                                     MaxPos.y - Window->rcWindow.top);
    }
 
    /* Send the WM_CREATE message. */

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2424,10 +2424,10 @@ co_UserCreateWindowEx(CREATESTRUCTW* Cs,
    }
 
    /* Create the IME window for pWnd */
-   if (IS_IMM_MODE() && !(pti->spwndDefaultIme) && IntWantImeWindow(Window))
+   if (IS_IMM_MODE() && !pti->spwndDefaultIme && IntWantImeWindow(Window))
    {
       PWND pwndDefaultIme = co_IntCreateDefaultImeWindow(Window, Window->hModule);
-      UserAssignmentLock((PVOID*)&(pti->spwndDefaultIme), pwndDefaultIme);
+      UserAssignmentLock((PVOID*)&pti->spwndDefaultIme, pwndDefaultIme);
 
       if (pwndDefaultIme)
       {


### PR DESCRIPTION
## Purpose

Fix hung-up in some applications on IME window creation.

JIRA issue:
[CORE-18723](https://jira.reactos.org/browse/CORE-18723)
[CORE-18754](https://jira.reactos.org/browse/CORE-18754)
[CORE-18773](https://jira.reactos.org/browse/CORE-18773)
[CORE-18785](https://jira.reactos.org/browse/CORE-18785)
[CORE-18802](https://jira.reactos.org/browse/CORE-18802)
[CORE-18803](https://jira.reactos.org/browse/CORE-18803)

## Proposed changes

- Move the code that creates the default IME window, from `IntCreateWindow` to `co_UserCreateWindowEx`, just before sending `WM_NCCALCSIZE` message.

## TODO

- [x] Do big tests.
- [x] Do small tests.