### PR TITLE
[NTGDI][FREETYPE] Skip TAB/CR/LF in font/text rendering

### DIFF
--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5910,10 +5910,7 @@ IntGetTextDisposition(
         else
         {
             if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
-            {
-                previous = 0;
                 continue;
-            }
             glyph_index = get_glyph_index(face, *String);
         }
         Cache->Hashed.GlyphIndex = glyph_index;
@@ -6314,10 +6311,7 @@ IntExtTextOutW(
         else
         {
             if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
-            {
-                previous = 0;
                 continue;
-            }
             glyph_index = get_glyph_index(face, *String);
         }
         Cache.Hashed.GlyphIndex = glyph_index;

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -46,9 +46,9 @@
     (((request) != FW_DONTCARE) && ((request) - (original) >= FW_BOLD - FW_MEDIUM))
 
 /* Special characters */
-#define TAB  (L'\t')
-#define CR   (L'\r')
-#define LF   (L'\n')
+#define TAB  L'\t'
+#define CR   L'\r'
+#define LF   L'\n'
 
 extern const MATRIX gmxWorldToDeviceDefault;
 extern const MATRIX gmxWorldToPageDefault;
@@ -5895,7 +5895,7 @@ IntGetTextDisposition(
     INT i, glyph_index;
     FT_BitmapGlyph realglyph;
     FT_Face face = Cache->Hashed.Face;
-    BOOL use_kerning = FT_HAS_KERNING(face), indexed = (ETO_GLYPH_INDEX & fuOptions);
+    BOOL use_kerning = FT_HAS_KERNING(face), indexed = (fuOptions & ETO_GLYPH_INDEX);
     ULONG previous = 0;
     FT_Vector delta;
 
@@ -6301,7 +6301,7 @@ IntExtTextOutW(
     Y64 = RealYStart64;
     previous = 0;
     DoBreak = FALSE;
-    indexed = (ETO_GLYPH_INDEX & fuOptions);
+    indexed = (fuOptions & ETO_GLYPH_INDEX);
     for (i = 0; i < Count; ++i, ++String)
     {
         if (indexed)

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -49,6 +49,8 @@
 #define TAB  L'\t'
 #define CR   L'\r'
 #define LF   L'\n'
+C_ASSERT(TAB < CR);
+C_ASSERT(LF < CR);
 
 extern const MATRIX gmxWorldToDeviceDefault;
 extern const MATRIX gmxWorldToPageDefault;
@@ -5909,7 +5911,8 @@ IntGetTextDisposition(
         }
         else
         {
-            if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
+            /* Ignore special characters */
+            if (*String <= CR && (*String == TAB || *String == LF || *String == CR))
                 continue;
             glyph_index = get_glyph_index(face, *String);
         }
@@ -6310,7 +6313,8 @@ IntExtTextOutW(
         }
         else
         {
-            if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
+            /* Ignore special characters */
+            if (*String <= CR && (*String == TAB || *String == LF || *String == CR))
                 continue;
             glyph_index = get_glyph_index(face, *String);
         }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5912,7 +5912,7 @@ IntGetTextDisposition(
         else
         {
             /* Ignore special characters */
-            if (*String <= CR && (*String == TAB || *String == LF || *String == CR))
+            if (*String <= CR && (*String == CR || *String == TAB || *String == LF))
                 continue;
             glyph_index = get_glyph_index(face, *String);
         }
@@ -6314,7 +6314,7 @@ IntExtTextOutW(
         else
         {
             /* Ignore special characters */
-            if (*String <= CR && (*String == TAB || *String == LF || *String == CR))
+            if (*String <= CR && (*String == CR || *String == TAB || *String == LF))
                 continue;
             glyph_index = get_glyph_index(face, *String);
         }

--- a/win32ss/gdi/ntgdi/freetype.c
+++ b/win32ss/gdi/ntgdi/freetype.c
@@ -5909,10 +5909,11 @@ IntGetTextDisposition(
         }
         else
         {
-            /* Ignore special characters */
-            if (*String == TAB || *String == LF || *String == CR)
+            if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
+            {
+                previous = 0;
                 continue;
-
+            }
             glyph_index = get_glyph_index(face, *String);
         }
         Cache->Hashed.GlyphIndex = glyph_index;
@@ -6312,10 +6313,11 @@ IntExtTextOutW(
         }
         else
         {
-            /* Ignore special characters */
-            if (*String == TAB || *String == LF || *String == CR)
+            if (*String == TAB || *String == LF || *String == CR) /* Ignore special characters */
+            {
+                previous = 0;
                 continue;
-
+            }
             glyph_index = get_glyph_index(face, *String);
         }
         Cache.Hashed.GlyphIndex = glyph_index;


### PR DESCRIPTION
## Purpose

Avoid rendering tofu blocks in `TextOut` function.
JIRA issue: [CORE-18804](https://jira.reactos.org/browse/CORE-18804)

## Proposed changes

- Skip `TAB`, `CR`, and `LF` special characters.

## TODO

- [x] Do big tests.

## Screenshots

BEFORE:
![before-2](https://user-images.githubusercontent.com/2107452/214250172-291d1b02-b728-417a-8ecb-4acac6b1dc8e.png)

AFTER:
![after-2](https://user-images.githubusercontent.com/2107452/214250215-804744ec-aab4-4303-affd-9c2a4ab97a68.png)