### PR TITLE
[SHELL32] Fix context menu command ids

### DIFF
--- a/dll/shellext/netshell/shfldr_netconnect.cpp
+++ b/dll/shellext/netshell/shfldr_netconnect.cpp
@@ -400,7 +400,8 @@ HRESULT WINAPI CNetworkConnections::MapColumnToSCID(UINT column, SHCOLUMNID *psc
 */
 
 CNetConUiObject::CNetConUiObject()
-    : m_pidl(NULL)
+    : m_pidl(NULL),
+      m_iIdCmdFirst(0)
 {
 }
 
@@ -513,6 +514,7 @@ HRESULT WINAPI CNetConUiObject::QueryContextMenu(
     else
         _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst + 7, MFT_STRING, MAKEINTRESOURCEW(IDS_NET_PROPERTIES),  MFS_DEFAULT);
 
+    m_iIdCmdFirst = idCmdFirst;
     return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 9);
 }
 
@@ -633,13 +635,15 @@ HRESULT WINAPI CNetConUiObject::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
     if (HIWORD(lpcmi->lpVerb) && !strcmp(lpcmi->lpVerb, "rename"))
         lpcmi->lpVerb = MAKEINTRESOURCEA(IDS_NET_RENAME);
 
-    if (HIWORD(lpcmi->lpVerb) || LOWORD(lpcmi->lpVerb) > 7)
+    if (HIWORD(lpcmi->lpVerb)
+        || LOWORD(lpcmi->lpVerb) < m_iIdCmdFirst
+        || LOWORD(lpcmi->lpVerb) > (m_iIdCmdFirst + 7))
     {
-        FIXME("Got invalid command\n");
+        FIXME("Got invalid command 0x%x with idCmdFirst 0x%x\n", lpcmi->lpVerb, m_iIdCmdFirst);
         return E_NOTIMPL;
     }
 
-    CmdId = LOWORD(lpcmi->lpVerb) + IDS_NET_ACTIVATE;
+    CmdId = LOWORD(lpcmi->lpVerb) - m_iIdCmdFirst + IDS_NET_ACTIVATE;
 
     switch(CmdId)
     {

--- a/dll/shellext/netshell/shfldr_netconnect.h
+++ b/dll/shellext/netshell/shfldr_netconnect.h
@@ -96,6 +96,7 @@ class CNetConUiObject:
         PCUITEMID_CHILD m_pidl;
         CComPtr<IUnknown> m_pUnknown;
         CComPtr<IOleCommandTarget> m_lpOleCmd;
+        UINT m_iIdCmdFirst;
 
     public:
         CNetConUiObject();

--- a/dll/shellext/zipfldr/CZipFolder.hpp
+++ b/dll/shellext/zipfldr/CZipFolder.hpp
@@ -40,10 +40,12 @@ class CZipFolder :
     CStringA m_ZipDir;
     CComHeapPtr<ITEMIDLIST> m_CurDir;
     unzFile m_UnzipFile;
+    UINT m_iIdCmdFirst;
 
 public:
     CZipFolder()
-        :m_UnzipFile(NULL)
+        :m_UnzipFile(NULL),
+         m_iIdCmdFirst(0)
     {
     }
 
@@ -502,7 +504,8 @@ public:
         if (!pici || (pici->cbSize != sizeof(CMINVOKECOMMANDINFO) && pici->cbSize != sizeof(CMINVOKECOMMANDINFOEX)))
             return E_INVALIDARG;
 
-        if (pici->lpVerb == MAKEINTRESOURCEA(0) || (HIWORD(pici->lpVerb) && !strcmp(pici->lpVerb, EXTRACT_VERBA)))
+        if (pici->lpVerb == MAKEINTRESOURCEA(m_iIdCmdFirst + 0)
+            || (HIWORD(pici->lpVerb) && !strcmp(pici->lpVerb, EXTRACT_VERBA)))
         {
             BSTR ZipFile = m_ZipFile.AllocSysString();
             InterlockedIncrement(&g_ModuleRefCnt);
@@ -520,6 +523,7 @@ public:
     STDMETHODIMP QueryContextMenu(HMENU hmenu, UINT indexMenu, UINT idCmdFirst, UINT idCmdLast, UINT uFlags)
     {
         UINT idCmd = idCmdFirst;
+        m_iIdCmdFirst = idCmdFirst;
 
         if (!(uFlags & CMF_DEFAULTONLY))
         {

--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1292,7 +1292,7 @@ LRESULT CDefView::OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandl
 
     /* A folder is special if it is the Desktop folder,
      * a network folder, or a Control Panel folder. */
-    m_isParentFolderSpecial = _ILIsDesktop(m_pidlParent) || _ILIsNetHood(m_pidlParent) 
+    m_isParentFolderSpecial = _ILIsDesktop(m_pidlParent) || _ILIsNetHood(m_pidlParent)
         || _ILIsControlPanel(ILFindLastID(m_pidlParent));
 
     /* Only force StatusBar part refresh if the state
@@ -1657,7 +1657,7 @@ LRESULT CDefView::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
         m_ListView.ClientToScreen(&pt);
     }
 
-    // This runs the message loop, calling back to us with f.e. WM_INITPOPUP (hence why m_hContextMenu and m_pCM exist) 
+    // This runs the message loop, calling back to us with f.e. WM_INITPOPUP (hence why m_hContextMenu and m_pCM exist)
     uCommand = TrackPopupMenu(m_hContextMenu,
                               TPM_LEFTALIGN | TPM_RETURNCMD | TPM_LEFTBUTTON | TPM_RIGHTBUTTON,
                               pt.x, pt.y, 0, m_hWnd, NULL);
@@ -1667,7 +1667,7 @@ LRESULT CDefView::OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &b
     if (uCommand == FCIDM_SHVIEW_OPEN && OnDefaultCommand() == S_OK)
         return 0;
 
-    InvokeContextMenuCommand(m_pCM, uCommand - CONTEXT_MENU_BASE_ID, &pt);
+    InvokeContextMenuCommand(m_pCM, uCommand, &pt);
 
     return 0;
 }
@@ -2399,7 +2399,7 @@ LRESULT CDefView::OnCustomItem(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bH
     UINT CmdID;
     HRESULT hres = SHGetMenuIdFromMenuMsg(uMsg, lParam, &CmdID);
     if (SUCCEEDED(hres))
-        SHSetMenuIdInMenuMsg(uMsg, lParam, CmdID - CONTEXT_MENU_BASE_ID);
+        SHSetMenuIdInMenuMsg(uMsg, lParam, CmdID);
 
     /* Forward the message to the IContextMenu2 */
     LRESULT result;
@@ -3617,14 +3617,14 @@ void CDefView::_HandleStatusBarResize(int nWidth)
     const int nLocationPartLength = 150;
     const int nRightPartsLength = nFileSizePartLength + nLocationPartLength;
     int nObjectsPartLength = nWidth - nRightPartsLength;
-    
+
     /* If the window is small enough just divide each part into thirds
      * This is the behavior of Windows Server 2003. */
     if (nObjectsPartLength <= nLocationPartLength)
         nObjectsPartLength = nFileSizePartLength = nWidth / 3;
 
     int nPartArray[] = {nObjectsPartLength, nObjectsPartLength + nFileSizePartLength, -1};
-    
+
     m_pShellBrowser->SendControlMsg(FCW_STATUS, SB_SETPARTS, _countof(nPartArray), (LPARAM)nPartArray, &lResult);
 }
 

--- a/dll/win32/shell32/CShellLink.cpp
+++ b/dll/win32/shell32/CShellLink.cpp
@@ -2577,9 +2577,15 @@ HRESULT STDMETHODCALLTYPE CShellLink::InvokeCommand(LPCMINVOKECOMMANDINFO lpici)
     }
 
     UINT idCmd = LOWORD(lpici->lpVerb);
-    TRACE("idCmd: %d\n", idCmd);
 
-    switch (idCmd)
+    TRACE("idCmd: %d first: %d\n", idCmd, m_idCmdFirst);
+
+    if (idCmd < m_idCmdFirst || idCmd > m_idCmdFirst + IDCMD_OPENFILELOCATION) {
+      // Not in our range; fail so that more handlers can be called.
+      return E_FAIL;
+    }
+
+    switch (idCmd - m_idCmdFirst)
     {
     case IDCMD_OPEN:
         return DoOpen(lpici);

--- a/dll/win32/shell32/folders/CControlPanelFolder.cpp
+++ b/dll/win32/shell32/folders/CControlPanelFolder.cpp
@@ -657,6 +657,7 @@ CCPLItemMenu::CCPLItemMenu()
 {
     m_apidl = NULL;
     m_cidl = 0;
+    m_iIdCmdFirst = 0;
 }
 
 HRESULT WINAPI CCPLItemMenu::Initialize(UINT cidl, PCUITEMID_CHILD_ARRAY apidl)
@@ -685,6 +686,7 @@ HRESULT WINAPI CCPLItemMenu::QueryContextMenu(
     _InsertMenuItemW(hMenu, indexMenu++, TRUE, IDC_STATIC, MFT_SEPARATOR, NULL, MFS_ENABLED);
     _InsertMenuItemW(hMenu, indexMenu++, TRUE, idCmdFirst + 1, MFT_STRING, MAKEINTRESOURCEW(IDS_CREATELINK), MFS_ENABLED);
 
+    m_iIdCmdFirst = idCmdFirst;
     return MAKE_HRESULT(SEVERITY_SUCCESS, 0, 2);
 }
 
@@ -704,7 +706,7 @@ HRESULT WINAPI CCPLItemMenu::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
 
     TRACE("(%p)->(invcom=%p verb=%p wnd=%p)\n", this, lpcmi, lpcmi->lpVerb, lpcmi->hwnd);
 
-    if (lpcmi->lpVerb == MAKEINTRESOURCEA(0))
+    if (lpcmi->lpVerb == MAKEINTRESOURCEA(m_iIdCmdFirst + 0))
     {
         /* Hardcode the command here; Executing a cpl file would be fine but we also need to run things like console.dll */
         WCHAR wszParams[MAX_PATH];
@@ -716,7 +718,7 @@ HRESULT WINAPI CCPLItemMenu::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
         /* Note: we pass the applet name to Control_RunDLL to distinguish between multiple applets in one .cpl file */
         ShellExecuteW(NULL, NULL, wszFile, wszParams, NULL, 0);
     }
-    else if (lpcmi->lpVerb == MAKEINTRESOURCEA(1)) //FIXME
+    else if (lpcmi->lpVerb == MAKEINTRESOURCEA(m_iIdCmdFirst + 1)) //FIXME
     {
         CComPtr<IDataObject> pDataObj;
         LPITEMIDLIST pidl = _ILCreateControlPanel();

--- a/dll/win32/shell32/folders/CControlPanelFolder.h
+++ b/dll/win32/shell32/folders/CControlPanelFolder.h
@@ -91,6 +91,7 @@ class CCPLItemMenu:
 private:
     PITEMID_CHILD *m_apidl;
     UINT m_cidl;
+    UINT m_iIdCmdFirst;
 
 public:
     CCPLItemMenu();

--- a/dll/win32/shell32/folders/CFSFolder.cpp
+++ b/dll/win32/shell32/folders/CFSFolder.cpp
@@ -1811,13 +1811,15 @@ HRESULT WINAPI CFSFolder::CallBack(IShellFolder *psf, HWND hwndOwner, IDataObjec
     {
         if (uMsg == DFM_INVOKECOMMAND && wParam == 0)
         {
-            // Create an data object
+            // Create a data object
             CComHeapPtr<ITEMID_CHILD> pidlChild(ILClone(ILFindLastID(m_pidlRoot)));
             CComHeapPtr<ITEMIDLIST> pidlParent(ILClone(m_pidlRoot));
             ILRemoveLastID(pidlParent);
 
+            ITEMIDLIST* arrChildren[] = {pidlChild};
             CComPtr<IDataObject> pDataObj;
-            HRESULT hr = SHCreateDataObject(pidlParent, 1, &pidlChild, NULL, IID_PPV_ARG(IDataObject, &pDataObj));
+
+            HRESULT hr = SHCreateDataObject(pidlParent, 1, arrChildren, NULL, IID_PPV_ARG(IDataObject, &pDataObj));
             if (!FAILED_UNEXPECTEDLY(hr))
             {
                 // Ask for a title to display

--- a/dll/win32/shell32/folders/CRecycleBin.cpp
+++ b/dll/win32/shell32/folders/CRecycleBin.cpp
@@ -415,7 +415,7 @@ HRESULT WINAPI CRecycleBinItemContextMenu::InvokeCommand(LPCMINVOKECOMMANDINFO l
         BOOL ret = TRUE;
 
         /* restore file */
-        if (lpcmi->lpVerb == MAKEINTRESOURCEA(1)) 
+        if (lpcmi->lpVerb == MAKEINTRESOURCEA(1))
             ret = RestoreFile(Context.hDeletedFile);
         /* delete file */
         else
@@ -850,7 +850,7 @@ HRESULT WINAPI CRecycleBin::QueryContextMenu(HMENU hMenu, UINT indexMenu, UINT i
     mii.cch = wcslen(mii.dwTypeData);
     mii.wID = idCmdFirst + id++;
     mii.fType = MFT_STRING;
-    iIdEmpty = 1;
+    iIdEmpty = idCmdFirst + 1;
 
     if (!InsertMenuItemW(hMenu, indexMenu, TRUE, &mii))
         return E_FAIL;
@@ -867,7 +867,7 @@ HRESULT WINAPI CRecycleBin::InvokeCommand(LPCMINVOKECOMMANDINFO lpcmi)
 
     TRACE("%p %p verb %p\n", this, lpcmi, lpcmi->lpVerb);
 
-    if (LOWORD(lpcmi->lpVerb) == iIdEmpty)
+    if (IS_INTRESOURCE(lpcmi->lpVerb) && LOWORD(lpcmi->lpVerb) == iIdEmpty)
     {
         if (!GetEnvironmentVariableW(L"SystemDrive", szDrive, _countof(szDrive) - 1))
         {


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18585](https://jira.reactos.org/browse/CORE-18585)

Right clicking & selecting "Properties" from background context menus now works.

## Proposed changes

We're mainly cleaning up how CDefaultContextMenu merges menus, with some random minor fixes.

The bug itself seems to have been caused by multiple things:

- CDefView was applying an offset of -1 on the command ids; context menu implementations assume that what they return in QueryContextMenu stays the same. We're no longer doing this.
- it was (to me?) not entirely obvious whether the "last" command id fields represent actual last ids or the next ids after (as per the checks, it was the latter); I renamed them to "end" to follow the STL convention of "end means a non-inclusive upper bound"
- these bounds are also always set now, even if the ranges are empty (e.g. "ids 7 to 7"); this allows the removal of some extra checks (for equality)
- it also wasn't super easy to see how we were supposed to know what ids the callback in CDefaultContextMenu added (which we would then need to skip) as it doesn't really return anything; this got replaced with just giving them 48 (0x30) ids to pick from.
- there is also a minor fix in CDefView: we were using the & operator to produce a pointer to a list of children, but the ATL class implements "&" in a way where we go from holding a NULL pointer to holding something else, so in debug builds it'll fail an assertion. Now we're handing out an actual separate list.

## TODO

- [x] more detailed testing? I haven't found any automated tests yet (are there any) & there might be some corner cases?
