### PR TITLE
[NOTEPAD] Speed up notepad loading

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -442,10 +442,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
         ShowLastError();
         goto done;
     }
-
     SendMessageW(Globals.hEdit, EM_SETHANDLE, (WPARAM)hLocal, 0);
-    SendMessage(Globals.hEdit, EM_SETMODIFY, FALSE, 0);
-    SendMessage(Globals.hEdit, EM_EMPTYUNDOBUFFER, 0, 0);
     SetFocus(Globals.hEdit);
 
     /*  If the file starts with .LOG, add a time/date at the end and set cursor after
@@ -588,7 +585,7 @@ DIALOG_FileSaveAs_Hook(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
 
                 hCombo = GetDlgItem(hDlg, ID_EOLN);
                 if (hCombo)
-                    Globals.iEoln = (int) SendMessage(hCombo, CB_GETCURSEL, 0, 0);
+                    Globals.iEoln = (EOLN)SendMessage(hCombo, CB_GETCURSEL, 0, 0);
             }
             break;
     }

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -421,9 +421,8 @@ VOID DoOpenFile(LPCTSTR szFileName)
 {
     static const TCHAR dotlog[] = _T(".LOG");
     HANDLE hFile;
-    LPTSTR pszText = NULL;
-    DWORD dwTextLen;
     TCHAR log[5];
+    HLOCAL hLocal;
 
     /* Close any files and prompt to save changes */
     if (!DoCloseFile())
@@ -437,13 +436,14 @@ VOID DoOpenFile(LPCTSTR szFileName)
         goto done;
     }
 
-    if (!ReadText(hFile, (LPWSTR *)&pszText, &dwTextLen, &Globals.encFile, &Globals.iEoln))
+    hLocal = (HLOCAL)SendMessageW(Globals.hEdit, EM_GETHANDLE, 0, 0);
+    if (!ReadText(hFile, &hLocal, &Globals.encFile, &Globals.iEoln))
     {
         ShowLastError();
         goto done;
     }
-    SetWindowText(Globals.hEdit, pszText);
 
+    SendMessageW(Globals.hEdit, EM_SETHANDLE, (WPARAM)hLocal, 0);
     SendMessage(Globals.hEdit, EM_SETMODIFY, FALSE, 0);
     SendMessage(Globals.hEdit, EM_EMPTYUNDOBUFFER, 0, 0);
     SetFocus(Globals.hEdit);
@@ -471,8 +471,6 @@ VOID DoOpenFile(LPCTSTR szFileName)
 done:
     if (hFile != INVALID_HANDLE_VALUE)
         CloseHandle(hFile);
-    if (pszText)
-        HeapFree(GetProcessHeap(), 0, pszText);
 }
 
 VOID DIALOG_FileNew(VOID)

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -448,7 +448,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
     SetFocus(Globals.hEdit);
 
     /*  If the file starts with .LOG, add a time/date at the end and set cursor after
-     *  See http://support.microsoft.com/?kbid=260563
+     *  See http://web.archive.org/web/20090627165105/http://support.microsoft.com/kb/260563
      */
     if (GetWindowText(Globals.hEdit, log, ARRAY_SIZE(log)) && !_tcscmp(log, _T(".LOG")))
     {

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -419,7 +419,6 @@ BOOL DoCloseFile(VOID)
 
 VOID DoOpenFile(LPCTSTR szFileName)
 {
-    static const TCHAR dotlog[] = _T(".LOG");
     HANDLE hFile;
     TCHAR log[5];
     HLOCAL hLocal;
@@ -436,6 +435,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
         goto done;
     }
 
+    /* To make loading file quicker, we use the internal handle of EDIT control */
     hLocal = (HLOCAL)SendMessageW(Globals.hEdit, EM_GETHANDLE, 0, 0);
     if (!ReadText(hFile, &hLocal, &Globals.encFile, &Globals.iEoln))
     {
@@ -448,7 +448,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
     /*  If the file starts with .LOG, add a time/date at the end and set cursor after
      *  See http://support.microsoft.com/?kbid=260563
      */
-    if (GetWindowText(Globals.hEdit, log, ARRAY_SIZE(log)) && !_tcscmp(log, dotlog))
+    if (GetWindowText(Globals.hEdit, log, ARRAY_SIZE(log)) && !_tcscmp(log, _T(".LOG")))
     {
         static const TCHAR lf[] = _T("\r\n");
         SendMessage(Globals.hEdit, EM_SETSEL, GetWindowTextLength(Globals.hEdit), -1);

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -443,6 +443,8 @@ VOID DoOpenFile(LPCTSTR szFileName)
         goto done;
     }
     SendMessageW(Globals.hEdit, EM_SETHANDLE, (WPARAM)hLocal, 0);
+    /* No need of EM_SETMODIFY and EM_EMPTYUNDOBUFFER here. EM_SETHANDLE does instead. */
+
     SetFocus(Globals.hEdit);
 
     /*  If the file starts with .LOG, add a time/date at the end and set cursor after

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -47,12 +47,12 @@ typedef enum
 // #define MIN_ENCODING   0
 // #define MAX_ENCODING   3
 
-/* NewLine code */
-typedef enum {
+typedef enum
+{
     EOLN_CRLF = 0,
     EOLN_LF   = 1,
     EOLN_CR   = 2
-} EOLN;
+} EOLN; /* NewLine code */
 
 typedef struct
 {

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -47,6 +47,7 @@ typedef enum
 // #define MIN_ENCODING   0
 // #define MAX_ENCODING   3
 
+/* NewLine code */
 typedef enum {
     EOLN_CRLF = 0,
     EOLN_LF   = 1,

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -52,7 +52,7 @@ typedef enum
     EOLN_CRLF = 0,
     EOLN_LF   = 1,
     EOLN_CR   = 2
-} EOLN; /* NewLine code */
+} EOLN; /* End of line (NewLine) type */
 
 typedef struct
 {

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -89,7 +89,7 @@ extern NOTEPAD_GLOBALS Globals;
 VOID SetFileName(LPCTSTR szFileName);
 
 /* from text.c */
-BOOL ReadText(HANDLE hFile, LPWSTR *ppszText, DWORD *pdwTextLen, ENCODING *pencFile, int *piEoln);
+BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, int *piEoln);
 BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, int iEoln);
 
 /* from settings.c */

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -47,9 +47,11 @@ typedef enum
 // #define MIN_ENCODING   0
 // #define MAX_ENCODING   3
 
-#define EOLN_CRLF           0
-#define EOLN_LF             1
-#define EOLN_CR             2
+typedef enum {
+    EOLN_CRLF = 0,
+    EOLN_LF   = 1,
+    EOLN_CR   = 2
+} EOLN;
 
 typedef struct
 {
@@ -76,7 +78,7 @@ typedef struct
     TCHAR szStatusBarLineCol[MAX_PATH];
 
     ENCODING encFile;
-    int iEoln;
+    EOLN iEoln;
 
     FINDREPLACE find;
     WNDPROC EditProc;
@@ -89,8 +91,8 @@ extern NOTEPAD_GLOBALS Globals;
 VOID SetFileName(LPCTSTR szFileName);
 
 /* from text.c */
-BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, int *piEoln);
-BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, int iEoln);
+BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln);
+BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, EOLN iEoln);
 
 /* from settings.c */
 void NOTEPAD_LoadSettingsFromRegistry(void);

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -49,9 +49,9 @@ typedef enum
 
 typedef enum
 {
-    EOLN_CRLF = 0,
-    EOLN_LF   = 1,
-    EOLN_CR   = 2
+    EOLN_CRLF = 0, /* "\r\n" */
+    EOLN_LF   = 1, /* "\n" */
+    EOLN_CR   = 2  /* "\r" */
 } EOLN; /* End of line (NewLine) type */
 
 typedef struct

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -86,25 +86,27 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOL
 {
     DWORD cchNew, ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 };
     LPWSTR pszText = *ppszText, pszNew;
-    BOOL bCR = FALSE;
     EOLN iEoln;
     HLOCAL hLocal;
+    BOOL bPrevCR = FALSE;
 
-    /* Replace '\0' with SPACE. Count new lines. */
+    /* Replace '\0' with SPACE. Count newlines. */
     for (ich = 0; ich < cchText; ++ich)
     {
         WCHAR ch = pszText[ich];
         if (ch == UNICODE_NULL)
             pszText[ich] = L' ';
 
-        if (bCR && ch == '\n')
-            adwEolnCount[EOLN_CRLF]++;
-
-        bCR = (ch == L'\r');
-        if (bCR)
-            adwEolnCount[EOLN_CR]++;
-        if (ch == L'\n')
+        if (ch == '\n')
+        {
             adwEolnCount[EOLN_LF]++;
+            if (bPrevCR)
+                adwEolnCount[EOLN_CRLF]++;
+        }
+
+        bPrevCR = (ch == L'\r');
+        if (bPrevCR)
+            adwEolnCount[EOLN_CR]++;
     }
 
     /* Choose the newline code */

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -255,6 +255,8 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
                 goto done;
         }
         break;
+    }
+
     DEFAULT_UNREACHABLE;
     }
 

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -252,7 +252,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
         cchText = 0;
         if (cbContent > 0)
         {
-            cchText = MultiByteToWideChar(iCodePage, 0, &pBytes[dwPos], (DWORD)cbContent, NULL, 0);
+            cchText = MultiByteToWideChar(iCodePage, 0, &pBytes[dwPos], (INT)cbContent, NULL, 0);
             if (cchText == 0)
                 goto done;
         }
@@ -268,8 +268,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
         if (cbContent > 0)
         {
             if (!MultiByteToWideChar(iCodePage, 0,
-                                     &pBytes[dwPos], (DWORD)cbContent,
-                                     pszNewText, (DWORD)cchText))
+                                     &pBytes[dwPos], (INT)cbContent, pszNewText, (INT)cchText))
             {
                 goto done;
             }

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -82,7 +82,7 @@ ReplaceNewLines(LPWSTR pszNew, DWORD cchNew, LPCWSTR pszOld, DWORD cchOld, WCHAR
 }
 
 static BOOL
-ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOLN *piEoln)
+ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOLN *piEoln)
 {
     DWORD cchNew, ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 };
     LPWSTR pszText = *ppszText, pszNew;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -71,7 +71,6 @@ static VOID
 ReplaceNewLines(LPWSTR pszNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
 {
     DWORD ichNew, ichOld;
-
     for (ichOld = ichNew = 0; ichOld < cchOld; ++ichOld)
     {
         WCHAR ch = pszOld[ichOld];
@@ -95,14 +94,13 @@ ProcessNewLines(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, DWORD adwEo
     DWORD ich, cchText = *pcchText, cchNew;
     LPWSTR pszText = *ppszText, pszNew;
     BOOL bCR = FALSE;
-    INT iEoln;
+    EOLN iEoln;
     HLOCAL hLocal;
 
-    /* Count new lines. Replace '\0' with SPACE. */
+    /* Replace '\0' with SPACE. Count new lines. */
     for (ich = 0; ich < cchText; ++ich)
     {
         WCHAR ch = pszText[ich];
-
         if (ch == UNICODE_NULL)
             pszText[ich] = L' ';
 
@@ -146,16 +144,13 @@ ProcessNewLines(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, DWORD adwEo
             *ppszText = pszNew;
             *pcchText = cchNew;
             break;
-
-        default:
-            return FALSE;
     }
 
     return TRUE;
 }
 
 BOOL
-ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, int *piEoln)
+ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
 {
     LPBYTE pBytes = NULL;
     LPWSTR pszText, pszAllocText = NULL;
@@ -382,7 +377,7 @@ done:
     return bSuccess;
 }
 
-BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, int iEoln)
+BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, EOLN iEoln)
 {
     WCHAR wcBom;
     LPCWSTR pszLF = L"\n";

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -61,10 +61,10 @@ ENCODING AnalyzeEncoding(const char *pBytes, DWORD dwSize)
 }
 
 static VOID
-ReplaceNewLines(LPWSTR pszNew, DWORD cchNew, LPCWSTR pszOld, DWORD cchOld)
+ReplaceNewLines(LPWSTR pszNew, SIZE_T cchNew, LPCWSTR pszOld, SIZE_T cchOld)
 {
     BOOL bPrevCR = FALSE;
-    DWORD ichNew, ichOld;
+    SIZE_T ichNew, ichOld;
     for (ichOld = ichNew = 0; ichOld < cchOld; ++ichOld)
     {
         WCHAR ch = pszOld[ichOld];

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -98,9 +98,10 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOL
 
         if (ch == '\n')
         {
-            adwEolnCount[EOLN_LF]++;
             if (bPrevCR)
                 adwEolnCount[EOLN_CRLF]++;
+            else
+                adwEolnCount[EOLN_LF]++;
         }
 
         bPrevCR = (ch == L'\r');

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -144,7 +144,9 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOL
             *ppszText = pszNew;
             *pcchText = cchNew;
             break;
-    DEFAULT_UNREACHABLE;
+        }
+
+        DEFAULT_UNREACHABLE;
     }
 
     *piEoln = iEoln;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -80,7 +80,7 @@ ReplaceNewLines(LPWSTR pszNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
 }
 
 static BOOL
-ProcessNewLines(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOLN *piEoln)
+ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOLN *piEoln)
 {
     DWORD adwEolnCount[3] = { 0, 0, 0 };
     DWORD ich, cchText = *pcchText, cchNew;
@@ -251,7 +251,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
 
     pszAllocText[dwCharCount] = UNICODE_NULL;
 
-    if (!ProcessNewLines(phLocal, &pszAllocText, &dwCharCount, piEoln))
+    if (!ProcessNewLinesAndNulls(phLocal, &pszAllocText, &dwCharCount, piEoln))
         goto done;
 
     *pencFile = encFile;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -84,10 +84,9 @@ ReplaceNewLines(LPWSTR pszNew, DWORD cchNew, LPCWSTR pszOld, DWORD cchOld, WCHAR
 static BOOL
 ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOLN *piEoln)
 {
-    DWORD cchNew, ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 };
-    LPWSTR pszText = *ppszText, pszNew;
+    DWORD ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 };
+    LPWSTR pszText = *ppszText;
     EOLN iEoln;
-    HLOCAL hLocal;
     BOOL bPrevCR = FALSE;
 
     /* Replace '\0' with SPACE. Count newlines. */
@@ -126,9 +125,9 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOL
         case EOLN_CR:
         {
             /* Allocate a buffer for EM_SETHANDLE */
-            cchNew = cchText + adwEolnCount[iEoln];
-            hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));
-            pszNew = LocalLock(hLocal);
+            DWORD cchNew = cchText + adwEolnCount[iEoln];
+            HLOCAL hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));
+            LPWSTR pszNew = LocalLock(hLocal);
             if (!pszNew)
             {
                 LocalFree(hLocal);

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -22,6 +22,7 @@
  */
 
 #include "notepad.h"
+#include <assert.h>
 
 BOOL IsTextNonZeroASCII(const void *pText, DWORD dwSize)
 {
@@ -60,7 +61,7 @@ ENCODING AnalyzeEncoding(const char *pBytes, DWORD dwSize)
 }
 
 static VOID
-ReplaceNewLines(LPWSTR pszNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
+ReplaceNewLines(LPWSTR pszNew, DWORD cchNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
 {
     DWORD ichNew, ichOld;
     for (ichOld = ichNew = 0; ichOld < cchOld; ++ichOld)
@@ -77,6 +78,7 @@ ReplaceNewLines(LPWSTR pszNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
         }
     }
     pszNew[ichNew] = UNICODE_NULL;
+    assert(ichNew == cchNew);
 }
 
 static BOOL
@@ -130,7 +132,7 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOL
                 return FALSE; /* Failure */
             }
 
-            ReplaceNewLines(pszNew, pszText, cchText, (iEoln == EOLN_LF) ? L'\n' : L'\r');
+            ReplaceNewLines(pszNew, cchNew, pszText, cchText, (iEoln == EOLN_LF) ? L'\n' : L'\r');
 
             /* Replace with new data */
             LocalUnlock(*phLocal);

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -82,8 +82,7 @@ ReplaceNewLines(LPWSTR pszNew, LPCWSTR pszOld, DWORD cchOld, WCHAR chTarget)
 static BOOL
 ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR* ppszText, LPDWORD pcchText, EOLN *piEoln)
 {
-    DWORD adwEolnCount[3] = { 0, 0, 0 };
-    DWORD ich, cchText = *pcchText, cchNew;
+    DWORD cchNew, ich, cchText = *pcchText, adwEolnCount[3] = { 0, 0, 0 };
     LPWSTR pszText = *ppszText, pszNew;
     BOOL bCR = FALSE;
     EOLN iEoln;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -124,6 +124,7 @@ ProcessNewLinesAndNulls(HLOCAL *phLocal, LPWSTR *ppszText, LPDWORD pcchText, EOL
 
         case EOLN_LF:
         case EOLN_CR:
+        {
             /* Allocate a buffer for EM_SETHANDLE */
             cchNew = cchText + adwEolnCount[iEoln];
             hLocal = LocalAlloc(LMEM_MOVEABLE, (cchNew + 1) * sizeof(WCHAR));

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -226,6 +226,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
             }
         }
         break;
+    }
 
     case ENCODING_ANSI:
     case ENCODING_UTF8:

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -203,6 +203,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
     {
     case ENCODING_UTF16BE:
     case ENCODING_UTF16LE:
+    {
         /* Re-allocate the buffer for EM_SETHANDLE */
         pszText = (LPWSTR) &pBytes[dwPos];
         dwCharCount = (dwSize - dwPos) / sizeof(WCHAR);

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -38,31 +38,23 @@ BOOL IsTextNonZeroASCII(const void *pText, DWORD dwSize)
 
 ENCODING AnalyzeEncoding(const char *pBytes, DWORD dwSize)
 {
-    INT flags = IS_TEXT_UNICODE_STATISTICS;
+    INT flags = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
 
     if (dwSize <= 1)
         return ENCODING_ANSI;
 
     if (IsTextNonZeroASCII(pBytes, dwSize))
-    {
         return ENCODING_ANSI;
-    }
 
     if (IsTextUnicode(pBytes, dwSize, &flags))
-    {
         return ENCODING_UTF16LE;
-    }
 
     if ((flags & IS_TEXT_UNICODE_REVERSE_MASK) && !(flags & IS_TEXT_UNICODE_ILLEGAL_CHARS))
-    {
         return ENCODING_UTF16BE;
-    }
 
     /* is it UTF-8? */
     if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, pBytes, dwSize, NULL, 0))
-    {
         return ENCODING_UTF8;
-    }
 
     return ENCODING_ANSI;
 }

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -231,6 +231,7 @@ ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln)
     case ENCODING_ANSI:
     case ENCODING_UTF8:
     case ENCODING_UTF8BOM:
+    {
         iCodePage = ((encFile == ENCODING_UTF8 || encFile == ENCODING_UTF8BOM) ? CP_UTF8 : CP_ACP);
 
         dwCharCount = 0;

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -71,13 +71,7 @@ ReplaceNewLines(LPWSTR pszNew, DWORD cchNew, LPCWSTR pszOld, DWORD cchOld)
 
         if (ch == L'\n')
         {
-            if (bPrevCR)
-            {
-                ichNew -= 2;
-                pszNew[ichNew++] = L'\r';
-                pszNew[ichNew++] = L'\n';
-            }
-            else
+            if (!bPrevCR)
             {
                 pszNew[ichNew++] = L'\r';
                 pszNew[ichNew++] = L'\n';

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -4,7 +4,7 @@
  *  Copyright 1998,99 Marcel Baur <mbaur@g26.ethz.ch>
  *  Copyright 2002 Sylvain Petreolle <spetreolle@yahoo.fr>
  *  Copyright 2002 Andriy Palamarchuk
- *  Copyright 2019 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ *  Copyright 2019-2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public

--- a/base/applications/notepad/text.c
+++ b/base/applications/notepad/text.c
@@ -41,10 +41,7 @@ ENCODING AnalyzeEncoding(const char *pBytes, DWORD dwSize)
 {
     INT flags = IS_TEXT_UNICODE_STATISTICS | IS_TEXT_UNICODE_REVERSE_STATISTICS;
 
-    if (dwSize <= 1)
-        return ENCODING_ANSI;
-
-    if (IsTextNonZeroASCII(pBytes, dwSize))
+    if (dwSize <= 1 || IsTextNonZeroASCII(pBytes, dwSize))
         return ENCODING_ANSI;
 
     if (IsTextUnicode(pBytes, dwSize, &flags))


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-14641](https://jira.reactos.org/browse/CORE-14641)

## Proposed changes

- Use `EM_GETHANDLE`/`EM_SETHANDLE` message to get/set the internal buffer handle.
- Use `LocalReAlloc` to re-allocate the buffer.
- Use file mapping to speed up loading.
- Use also `IS_TEXT_UNICODE_REVERSE_STATISTICS` for `IsTextUnicode`.

## TODO

- [x] Do small tests.
