### PR TITLE
Reduce diff of wine crt code to wine-5.0-rc5

### DIFF
--- a/sdk/lib/crt/wine/except_i386.c
+++ b/sdk/lib/crt/wine/except_i386.c
@@ -651,8 +651,8 @@ DWORD CDECL cxx_frame_handler( PEXCEPTION_RECORD rec, cxx_exception_frame* frame
 /*********************************************************************
  *		__CxxFrameHandler (MSVCRT.@)
  */
-extern DWORD CDECL __CxxFrameHandler(PEXCEPTION_RECORD rec, EXCEPTION_REGISTRATION_RECORD* frame,
-                                     PCONTEXT context, EXCEPTION_REGISTRATION_RECORD** dispatch);
+extern DWORD CDECL __CxxFrameHandler( PEXCEPTION_RECORD rec, EXCEPTION_REGISTRATION_RECORD* frame,
+                                      PCONTEXT context, EXCEPTION_REGISTRATION_RECORD** dispatch );
 #ifdef _MSC_VER
 DWORD _declspec(naked) __CxxFrameHandler(PEXCEPTION_RECORD rec, EXCEPTION_REGISTRATION_RECORD* frame,
                                          PCONTEXT context, EXCEPTION_REGISTRATION_RECORD** dispatch)
@@ -672,25 +672,25 @@ DWORD _declspec(naked) __CxxFrameHandler(PEXCEPTION_RECORD rec, EXCEPTION_REGIST
     }
 }
 #else
-__ASM_GLOBAL_FUNC(__CxxFrameHandler,
-                  "pushl $0\n\t"        /* nested_trylevel */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl $0\n\t"        /* nested_frame */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl %eax\n\t"      /* descr */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl 28(%esp)\n\t"  /* dispatch */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl 28(%esp)\n\t"  /* context */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl 28(%esp)\n\t"  /* frame */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "pushl 28(%esp)\n\t"  /* rec */
-                  __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
-                  "call " __ASM_NAME("cxx_frame_handler") "\n\t"
-                  "add $28,%esp\n\t"
-                  __ASM_CFI(".cfi_adjust_cfa_offset -28\n\t")
-                  "ret")
+__ASM_GLOBAL_FUNC( __CxxFrameHandler,
+                   "pushl $0\n\t"        /* nested_trylevel */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl $0\n\t"        /* nested_frame */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl %eax\n\t"      /* descr */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl 28(%esp)\n\t"  /* dispatch */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl 28(%esp)\n\t"  /* context */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl 28(%esp)\n\t"  /* frame */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "pushl 28(%esp)\n\t"  /* rec */
+                   __ASM_CFI(".cfi_adjust_cfa_offset 4\n\t")
+                   "call " __ASM_NAME("cxx_frame_handler") "\n\t"
+                   "add $28,%esp\n\t"
+                   __ASM_CFI(".cfi_adjust_cfa_offset -28\n\t")
+                   "ret" )
 #endif
 
 

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -175,7 +175,7 @@ void* CDECL MSVCRT_operator_new(MSVCRT_size_t size)
 
   TRACE("(%ld) out of memory\n", size);
 #if _MSVCR_VER >= 80
-  throw_bad_alloc("bad allocation");
+  throw_exception(EXCEPTION_BAD_ALLOC, 0, "bad allocation");
 #endif
   return NULL;
 }

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -418,7 +418,15 @@ size_t CDECL _aligned_msize(void *p, MSVCRT_size_t alignment, MSVCRT_size_t offs
  */
 void* CDECL MSVCRT_calloc(MSVCRT_size_t count, MSVCRT_size_t size)
 {
-  return msvcrt_heap_alloc(HEAP_ZERO_MEMORY, count*size);
+  MSVCRT_size_t bytes = count*size;
+
+  if (size && bytes / size != count)
+  {
+    *MSVCRT__errno() = MSVCRT_ENOMEM;
+    return NULL;
+  }
+
+  return msvcrt_heap_alloc(HEAP_ZERO_MEMORY, bytes);
 }
 
 /*********************************************************************

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -149,7 +149,7 @@ static MSVCRT_size_t msvcrt_heap_size(void *ptr)
 /*********************************************************************
  *		??2@YAPAXI@Z (MSVCRT.@)
  */
-void* CDECL MSVCRT_operator_new(MSVCRT_size_t size)
+void* CDECL DECLSPEC_HOTPATCH MSVCRT_operator_new(MSVCRT_size_t size)
 {
   void *retval;
   int freed;
@@ -193,7 +193,7 @@ void* CDECL MSVCRT_operator_new_dbg(MSVCRT_size_t size, int type, const char *fi
 /*********************************************************************
  *		??3@YAXPAX@Z (MSVCRT.@)
  */
-void CDECL MSVCRT_operator_delete(void *mem)
+void CDECL DECLSPEC_HOTPATCH MSVCRT_operator_delete(void *mem)
 {
   TRACE("(%p)\n", mem);
   msvcrt_heap_free(mem);
@@ -418,7 +418,7 @@ size_t CDECL _aligned_msize(void *p, MSVCRT_size_t alignment, MSVCRT_size_t offs
 /*********************************************************************
  *		calloc (MSVCRT.@)
  */
-void* CDECL MSVCRT_calloc(MSVCRT_size_t count, MSVCRT_size_t size)
+void* CDECL DECLSPEC_HOTPATCH MSVCRT_calloc(MSVCRT_size_t count, MSVCRT_size_t size)
 {
   MSVCRT_size_t bytes = count*size;
 
@@ -444,7 +444,7 @@ void* CDECL _calloc_base(MSVCRT_size_t count, MSVCRT_size_t size)
 /*********************************************************************
  *		free (MSVCRT.@)
  */
-void CDECL MSVCRT_free(void* ptr)
+void CDECL DECLSPEC_HOTPATCH MSVCRT_free(void* ptr)
 {
   msvcrt_heap_free(ptr);
 }
@@ -483,7 +483,7 @@ void* CDECL _malloc_base(MSVCRT_size_t size)
 /*********************************************************************
  *		realloc (MSVCRT.@)
  */
-void* CDECL MSVCRT_realloc(void* ptr, MSVCRT_size_t size)
+void* CDECL DECLSPEC_HOTPATCH MSVCRT_realloc(void* ptr, MSVCRT_size_t size)
 {
   if (!ptr) return MSVCRT_malloc(size);
   if (size) return msvcrt_heap_realloc(0, ptr, size);

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -484,6 +484,14 @@ void* CDECL MSVCRT_realloc(void* ptr, MSVCRT_size_t size)
 }
 
 /*********************************************************************
+ *		_realloc_base (UCRTBASE.@)
+ */
+void* CDECL _realloc_base(void* ptr, MSVCRT_size_t size)
+{
+  return MSVCRT_realloc(ptr, size);
+}
+
+/*********************************************************************
  * _recalloc (MSVCR100.@)
  */
 void* CDECL _recalloc(void *mem, MSVCRT_size_t num, MSVCRT_size_t size)

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -849,7 +849,7 @@ int CDECL wmemcpy_s(MSVCRT_wchar_t *dest, MSVCRT_size_t numberOfElements,
         return MSVCRT_ERANGE;
     }
 
-    memcpy(dest, src, sizeof(MSVCRT_wchar_t)*count);
+    memmove(dest, src, sizeof(MSVCRT_wchar_t)*count);
     return 0;
 }
 #endif

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -822,7 +822,7 @@ int CDECL MSVCRT_memcpy_s(void *dest, MSVCRT_size_t numberOfElements, const void
         return MSVCRT_ERANGE;
     }
 
-    memcpy(dest, src, count);
+    memmove(dest, src, count);
     return 0;
 }
 

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -397,8 +397,9 @@ MSVCRT_size_t CDECL _msize(void* mem)
   return size;
 }
 
+#if _MSVCR_VER>=80
 /*********************************************************************
- * _aligned_msize (MSVCR100.@)
+ * _aligned_msize (MSVCR80.@)
  */
 size_t CDECL _aligned_msize(void *p, MSVCRT_size_t alignment, MSVCRT_size_t offset)
 {
@@ -412,6 +413,7 @@ size_t CDECL _aligned_msize(void *p, MSVCRT_size_t alignment, MSVCRT_size_t offs
     alloc_ptr = SAVED_PTR(p);
     return _msize(*alloc_ptr)-alignment-sizeof(void*);
 }
+#endif
 
 /*********************************************************************
  *		calloc (MSVCRT.@)
@@ -429,6 +431,7 @@ void* CDECL MSVCRT_calloc(MSVCRT_size_t count, MSVCRT_size_t size)
   return msvcrt_heap_alloc(HEAP_ZERO_MEMORY, bytes);
 }
 
+#if _MSVCR_VER>=140
 /*********************************************************************
  *		_calloc_base (UCRTBASE.@)
  */
@@ -436,6 +439,7 @@ void* CDECL _calloc_base(MSVCRT_size_t count, MSVCRT_size_t size)
 {
   return MSVCRT_calloc(count, size);
 }
+#endif
 
 /*********************************************************************
  *		free (MSVCRT.@)
@@ -445,6 +449,7 @@ void CDECL MSVCRT_free(void* ptr)
   msvcrt_heap_free(ptr);
 }
 
+#if _MSVCR_VER>=140
 /*********************************************************************
  *		_free_base (UCRTBASE.@)
  */
@@ -452,6 +457,7 @@ void CDECL _free_base(void* ptr)
 {
   msvcrt_heap_free(ptr);
 }
+#endif
 
 /*********************************************************************
  *                  malloc (MSVCRT.@)
@@ -464,6 +470,7 @@ void* CDECL MSVCRT_malloc(MSVCRT_size_t size)
   return ret;
 }
 
+#if _MSVCR_VER>=140
 /*********************************************************************
  *                  _malloc_base (UCRTBASE.@)
  */
@@ -471,6 +478,7 @@ void* CDECL _malloc_base(MSVCRT_size_t size)
 {
   return MSVCRT_malloc(size);
 }
+#endif
 
 /*********************************************************************
  *		realloc (MSVCRT.@)
@@ -483,6 +491,7 @@ void* CDECL MSVCRT_realloc(void* ptr, MSVCRT_size_t size)
   return NULL;
 }
 
+#if _MSVCR_VER>=140
 /*********************************************************************
  *		_realloc_base (UCRTBASE.@)
  */
@@ -490,9 +499,11 @@ void* CDECL _realloc_base(void* ptr, MSVCRT_size_t size)
 {
   return MSVCRT_realloc(ptr, size);
 }
+#endif
 
+#if _MSVCR_VER>=80
 /*********************************************************************
- * _recalloc (MSVCR100.@)
+ * _recalloc (MSVCR80.@)
  */
 void* CDECL _recalloc(void *mem, MSVCRT_size_t num, MSVCRT_size_t size)
 {
@@ -515,6 +526,7 @@ void* CDECL _recalloc(void *mem, MSVCRT_size_t num, MSVCRT_size_t size)
         memset((BYTE*)ret+old_size, 0, size-old_size);
     return ret;
 }
+#endif
 
 /*********************************************************************
  *		__p__amblksiz (MSVCRT.@)
@@ -763,6 +775,7 @@ int CDECL MSVCRT_memmove_s(void *dest, MSVCRT_size_t numberOfElements, const voi
     return 0;
 }
 
+#if _MSVCR_VER>=100
 /*********************************************************************
  *              wmemmove_s (MSVCR100.@)
  */
@@ -785,6 +798,7 @@ int CDECL wmemmove_s(MSVCRT_wchar_t *dest, MSVCRT_size_t numberOfElements,
     memmove(dest, src, sizeof(MSVCRT_wchar_t)*count);
     return 0;
 }
+#endif
 
 /*********************************************************************
  *		memcpy_s (MSVCRT.@)
@@ -812,6 +826,7 @@ int CDECL MSVCRT_memcpy_s(void *dest, MSVCRT_size_t numberOfElements, const void
     return 0;
 }
 
+#if _MSVCR_VER>=100
 /*********************************************************************
  *              wmemcpy_s (MSVCR100.@)
  */
@@ -837,6 +852,7 @@ int CDECL wmemcpy_s(MSVCRT_wchar_t *dest, MSVCRT_size_t numberOfElements,
     memcpy(dest, src, sizeof(MSVCRT_wchar_t)*count);
     return 0;
 }
+#endif
 
 /*********************************************************************
  *		strncpy_s (MSVCRT.@)

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -715,20 +715,9 @@ int CDECL MSVCRT_memmove_s(void *dest, MSVCRT_size_t numberOfElements, const voi
     if(!count)
         return 0;
 
-    if(!dest || !src) {
-        if(dest)
-            memset(dest, 0, numberOfElements);
-
-        *_errno() = EINVAL;
-        return EINVAL;
-    }
-
-    if(count > numberOfElements) {
-        memset(dest, 0, numberOfElements);
-
-        *_errno() = ERANGE;
-        return ERANGE;
-    }
+    if (!MSVCRT_CHECK_PMT(dest != NULL)) return MSVCRT_EINVAL;
+    if (!MSVCRT_CHECK_PMT(src != NULL)) return MSVCRT_EINVAL;
+    if (!MSVCRT_CHECK_PMT_ERR( count <= numberOfElements, MSVCRT_ERANGE )) return MSVCRT_ERANGE;
 
     memmove(dest, src, count);
     return 0;

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -430,6 +430,14 @@ void* CDECL MSVCRT_calloc(MSVCRT_size_t count, MSVCRT_size_t size)
 }
 
 /*********************************************************************
+ *		_calloc_base (UCRTBASE.@)
+ */
+void* CDECL _calloc_base(MSVCRT_size_t count, MSVCRT_size_t size)
+{
+  return MSVCRT_calloc(count, size);
+}
+
+/*********************************************************************
  *		free (MSVCRT.@)
  */
 void CDECL MSVCRT_free(void* ptr)

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -446,6 +446,14 @@ void CDECL MSVCRT_free(void* ptr)
 }
 
 /*********************************************************************
+ *		_free_base (UCRTBASE.@)
+ */
+void CDECL _free_base(void* ptr)
+{
+  msvcrt_heap_free(ptr);
+}
+
+/*********************************************************************
  *                  malloc (MSVCRT.@)
  */
 void* CDECL MSVCRT_malloc(MSVCRT_size_t size)

--- a/sdk/lib/crt/wine/heap.c
+++ b/sdk/lib/crt/wine/heap.c
@@ -457,6 +457,14 @@ void* CDECL MSVCRT_malloc(MSVCRT_size_t size)
 }
 
 /*********************************************************************
+ *                  _malloc_base (UCRTBASE.@)
+ */
+void* CDECL _malloc_base(MSVCRT_size_t size)
+{
+  return MSVCRT_malloc(size);
+}
+
+/*********************************************************************
  *		realloc (MSVCRT.@)
  */
 void* CDECL MSVCRT_realloc(void* ptr, MSVCRT_size_t size)

--- a/sdk/lib/crt/wine/msvcrt.h
+++ b/sdk/lib/crt/wine/msvcrt.h
@@ -26,7 +26,7 @@
  *   Other conventions
  *      - To avoid conflicts with the standard C library,
  *        no msvcrt headers are included in the implementation.
- *      - Instead, symbols are duplicated here, prefixed with
+ *      - Instead, symbols are duplicated here, prefixed with 
  *        MSVCRT_, as explained above.
  *      - To avoid inconsistencies, a test for each symbol is
  *        added into tests/headers.c. Please always add a

--- a/sdk/lib/crt/wine/undname.c
+++ b/sdk/lib/crt/wine/undname.c
@@ -34,7 +34,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
  */
 
 /* How data types modifiers are stored:
- * M (in the following definitions) is defined for
+ * M (in the following definitions) is defined for 
  * 'A', 'B', 'C' and 'D' as follows
  *      {<A>}:  ""
  *      {<B>}:  "const "
@@ -48,7 +48,7 @@ WINE_DEFAULT_DEBUG_CHANNEL(msvcrt);
  *      in data fields:
  *              same as for arguments and also the following
  *              ?<M>x   {<M>}x
- *
+ *              
  */
 
 struct array
@@ -110,7 +110,7 @@ static void*    und_alloc(struct parsed_symbol* sym, unsigned int len)
         sym->avail_in_first = 0;
         ptr = (char*)sym->alloc_list + sizeof(void*);
     }
-    else
+    else 
     {
         if (len > sym->avail_in_first)
         {
@@ -188,7 +188,7 @@ static BOOL str_array_push(struct parsed_symbol* sym, const char* ptr, int len,
     a->elts[a->num] = und_alloc(sym, len + 1);
     assert(a->elts[a->num]);
     memcpy(a->elts[a->num], ptr, len);
-    a->elts[a->num][len] = '\0';
+    a->elts[a->num][len] = '\0'; 
     if (++a->num >= a->max) a->max = a->num;
     {
         int i;
@@ -217,18 +217,18 @@ static char* str_array_get_ref(struct array* cref, unsigned idx)
     assert(cref);
     if (cref->start + idx >= cref->max)
     {
-        WARN("Out of bounds: %p %d + %d >= %d\n",
+        WARN("Out of bounds: %p %d + %d >= %d\n", 
               cref, cref->start, idx, cref->max);
         return NULL;
     }
-    TRACE("Returning %p[%d] => %s\n",
+    TRACE("Returning %p[%d] => %s\n", 
           cref, idx, debugstr_a(cref->elts[cref->start + idx]));
     return cref->elts[cref->start + idx];
 }
 
 /******************************************************************
  *		str_printf
- * Helper for printf type of command (only %s and %c are implemented)
+ * Helper for printf type of command (only %s and %c are implemented) 
  * while dynamically allocating the buffer
  */
 static char* str_printf(struct parsed_symbol* sym, const char* format, ...)
@@ -341,7 +341,7 @@ static const char* get_number(struct parsed_symbol* sym)
  * Parses a list of function/method arguments, creates a string corresponding
  * to the arguments' list.
  */
-static char* get_args(struct parsed_symbol* sym, struct array* pmt_ref, BOOL z_term,
+static char* get_args(struct parsed_symbol* sym, struct array* pmt_ref, BOOL z_term, 
                       char open_char, char close_char)
 
 {
@@ -376,8 +376,8 @@ static char* get_args(struct parsed_symbol* sym, struct array* pmt_ref, BOOL z_t
      */
     if (z_term && *sym->current++ != 'Z') return NULL;
 
-    if (arg_collect.num == 0 ||
-        (arg_collect.num == 1 && !strcmp(arg_collect.elts[0], "void")))
+    if (arg_collect.num == 0 || 
+        (arg_collect.num == 1 && !strcmp(arg_collect.elts[0], "void")))        
         return str_printf(sym, "%cvoid%c", open_char, close_char);
     for (i = 1; i < arg_collect.num; i++)
     {
@@ -386,12 +386,12 @@ static char* get_args(struct parsed_symbol* sym, struct array* pmt_ref, BOOL z_t
 
     last = args_str ? args_str : arg_collect.elts[0];
     if (close_char == '>' && last[strlen(last) - 1] == '>')
-        args_str = str_printf(sym, "%c%s%s %c",
+        args_str = str_printf(sym, "%c%s%s %c", 
                               open_char, arg_collect.elts[0], args_str, close_char);
     else
-        args_str = str_printf(sym, "%c%s%s%c",
+        args_str = str_printf(sym, "%c%s%s%c", 
                               open_char, arg_collect.elts[0], args_str, close_char);
-
+    
     return args_str;
 }
 
@@ -730,7 +730,7 @@ static BOOL get_calling_convention(char ch, const char** call_conv,
 static const char* get_simple_type(char c)
 {
     const char* type_string;
-
+    
     switch (c)
     {
     case 'C': type_string = "signed char"; break;
@@ -759,7 +759,7 @@ static const char* get_simple_type(char c)
 static const char* get_extended_type(char c)
 {
     const char* type_string;
-
+    
     switch (c)
     {
     case 'D': type_string = "__int8"; break;
@@ -794,7 +794,7 @@ static BOOL demangle_datatype(struct parsed_symbol* sym, struct datatype_t* ct,
 
     assert(ct);
     ct->left = ct->right = NULL;
-
+    
     switch (dt = *sym->current++)
     {
     case '_':
@@ -819,7 +819,7 @@ static BOOL demangle_datatype(struct parsed_symbol* sym, struct datatype_t* ct,
 
             if (!(struct_name = get_class_name(sym)))
                 goto done;
-            if (!(sym->flags & UNDNAME_NO_COMPLEX_TYPE))
+            if (!(sym->flags & UNDNAME_NO_COMPLEX_TYPE)) 
             {
                 switch (dt)
                 {
@@ -908,7 +908,7 @@ static BOOL demangle_datatype(struct parsed_symbol* sym, struct datatype_t* ct,
                 sym->current++;
 
                 if (!get_calling_convention(*sym->current++,
-                                            &call_conv, &exported,
+                                            &call_conv, &exported, 
                                             sym->flags & ~UNDNAME_NO_ALLOCATION_LANGUAGE) ||
                     !demangle_datatype(sym, &sub_ct, pmt_ref, FALSE))
                     goto done;
@@ -917,7 +917,7 @@ static BOOL demangle_datatype(struct parsed_symbol* sym, struct datatype_t* ct,
                 if (!args) goto done;
                 sym->stack.num = mark;
 
-                ct->left  = str_printf(sym, "%s%s (%s*",
+                ct->left  = str_printf(sym, "%s%s (%s*", 
                                        sub_ct.left, sub_ct.right, call_conv);
                 ct->right = str_printf(sym, ")%s", args);
             }
@@ -1044,7 +1044,7 @@ static BOOL demangle_datatype(struct parsed_symbol* sym, struct datatype_t* ct,
             return FALSE;
     }
 done:
-
+    
     return ct->left != NULL;
 }
 
@@ -1081,7 +1081,7 @@ static BOOL handle_data(struct parsed_symbol* sym)
         case '0': access = "private: "; break;
         case '1': access = "protected: "; break;
         case '2': access = "public: "; break;
-        }
+        } 
     }
 
     if (!(sym->flags & UNDNAME_NO_MEMBER_TYPE))
@@ -1131,8 +1131,8 @@ static BOOL handle_data(struct parsed_symbol* sym)
     if (sym->flags & UNDNAME_NAME_ONLY) ct.left = ct.right = modifier = NULL;
 
     sym->result = str_printf(sym, "%s%s%s%s%s%s%s%s", access,
-                             member_type, ct.left,
-                             modifier && ct.left ? " " : NULL, modifier,
+                             member_type, ct.left, 
+                             modifier && ct.left ? " " : NULL, modifier, 
                              modifier || ct.left ? " " : NULL, name, ct.right);
     ret = TRUE;
 done:
@@ -1604,7 +1604,7 @@ char* CDECL __unDNameEx(char* buffer, const char* mangled, int buflen,
 
     TRACE("(%p,%s,%d,%p,%p,%p,%x)\n",
           buffer, debugstr_a(mangled), buflen, memget, memfree, unknown, flags);
-
+    
     /* The flags details is not documented by MS. However, it looks exactly
      * like the UNDNAME_ manifest constants from imagehlp.h and dbghelp.h
      * So, we copied those (on top of the file)


### PR DESCRIPTION
## Purpose

Reduce diff between crt wine code and wine-5.0-rc5

## Proposed changes

- Remove white space changes
- Merge a number of missing commits

## Tests
Rightmost 2 are this PR
KVM: https://reactos.org/testman/compare.php?ids=85666,85673,85682,85678,85681
VBox: https://reactos.org/testman/compare.php?ids=85667,85671,85683,85679,85680

