### PR TITLE
[MSAFD] Allow SIO_UDP_CONNRESET and SIO_UDP_NETRESET in WSPIoctl.

### DIFF
--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2559,6 +2559,13 @@ WSPIoctl(IN  SOCKET Handle,
             Errno = NO_ERROR;
             Ret = NO_ERROR;
             break;
+        case SIO_UDP_NETRESET:
+            /* FIXME: It's a fix not to fail with unimplemented
+               This code forces NET_UNREACHABLE messages to be ignored.
+            */
+            Errno = NO_ERROR;
+            Ret = NO_ERROR;
+            break;
         default:
             Errno = Socket->HelperData->WSHIoctl(Socket->HelperContext,
                                                  Handle,

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2552,6 +2552,14 @@ WSPIoctl(IN  SOCKET Handle,
             Errno = NO_ERROR;
             Ret = NO_ERROR;
             break;
+        case SIO_UDP_CONNRESET:
+            /* FIXME: It's a fix not to fail with unimplemented
+               This control code shoute controls whether UDP 
+               PORT_UNREACHABLE messages are reported.
+            */
+            Errno = NO_ERROR;
+            Ret = NO_ERROR;
+            break;
         default:
             Errno = Socket->HelperData->WSHIoctl(Socket->HelperContext,
                                                  Handle,

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2553,7 +2553,7 @@ WSPIoctl(IN  SOCKET Handle,
             Ret = NO_ERROR;
             break;
         case SIO_UDP_CONNRESET:
-            /* FIXME: It's a fix not to fail with unimplemented
+            /* FIXME: It's a hack to prevent failing with unimplemented
                This code forces UDP PORT_UNREACHABLE messages to be ignored.
             */
             FIXME("SIO_UDP_CONNRESET stub\n");
@@ -2561,7 +2561,7 @@ WSPIoctl(IN  SOCKET Handle,
             Ret = NO_ERROR;
             break;
         case SIO_UDP_NETRESET:
-            /* FIXME: It's a fix not to fail with unimplemented
+            /* FIXME: It's a hack to prevent failing with unimplemented
                This code forces NET_UNREACHABLE messages to be ignored.
             */
             FIXME("SIO_UDP_NETRESET stub\n");

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2556,6 +2556,7 @@ WSPIoctl(IN  SOCKET Handle,
             /* FIXME: It's a fix not to fail with unimplemented
                This code forces UDP PORT_UNREACHABLE messages to be ignored.
             */
+            FIXME("SIO_UDP_CONNRESET stub\n");
             Errno = NO_ERROR;
             Ret = NO_ERROR;
             break;
@@ -2563,6 +2564,7 @@ WSPIoctl(IN  SOCKET Handle,
             /* FIXME: It's a fix not to fail with unimplemented
                This code forces NET_UNREACHABLE messages to be ignored.
             */
+            FIXME("SIO_UDP_NETRESET stub\n");
             Errno = NO_ERROR;
             Ret = NO_ERROR;
             break;

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2554,8 +2554,7 @@ WSPIoctl(IN  SOCKET Handle,
             break;
         case SIO_UDP_CONNRESET:
             /* FIXME: It's a fix not to fail with unimplemented
-               This control code shoute controls whether UDP 
-               PORT_UNREACHABLE messages are reported.
+               This code forces UDP PORT_UNREACHABLE messages to be ignored.
             */
             Errno = NO_ERROR;
             Ret = NO_ERROR;


### PR DESCRIPTION
## Purpose
Don't fail with unimplemented on calling `WSPIoctl` with control codes `SIO_UDP_CONNRESET` and `SIO_UDP_NETRESET`.
JIRA issue: [CORE-18808](https://jira.reactos.org/browse/CORE-18808)

## Proposed changes
Made calling `WSPIoctl` with `SIO_UDP_CONNRESET` or `SIO_UDP_NETRESET` control code do nothing instead of failing with unimplemented.

`SIO_UDP_CONNRESET` should control UDP PORT_UNREACHABLE messages. 
`SIO_UDP_NETRESET` should control NET_UNREACHABLE messages. 
This hack should be ok.
