### PR TITLE
[RICHED20] Fix word break procedure for punct

### DIFF
--- a/dll/win32/riched20/string.c
+++ b/dll/win32/riched20/string.c
@@ -161,7 +161,9 @@ void ME_StrDeleteV(ME_String *s, int nVChar, int nChars)
 static int
 ME_WordBreakProc(LPWSTR s, INT start, INT len, INT code)
 {
+#ifndef __REACTOS__
   /* FIXME: Native also knows about punctuation */
+#endif
   TRACE("s==%s, start==%d, len==%d, code==%d\n",
         debugstr_wn(s, len), start, len, code);
 
@@ -173,13 +175,23 @@ ME_WordBreakProc(LPWSTR s, INT start, INT len, INT code)
     case WB_MOVEWORDLEFT:
       while (start && ME_IsWSpace(s[start - 1]))
         start--;
+#ifdef __REACTOS__
+      while (start && !ME_IsWSpace(s[start - 1]) && !iswpunct(s[start - 1]))
+        start--;
+#else
       while (start && !ME_IsWSpace(s[start - 1]))
         start--;
+#endif
       return start;
     case WB_RIGHT:
     case WB_MOVEWORDRIGHT:
+#ifdef __REACTOS__
+      while (start < len && !ME_IsWSpace(s[start]) && !iswpunct(s[start]))
+        start++;
+#else
       while (start < len && !ME_IsWSpace(s[start]))
         start++;
+#endif
       while (start < len && ME_IsWSpace(s[start]))
         start++;
       return start;


### PR DESCRIPTION
## Purpose

Fix the hyperlink on Chinese Rapps.
JIRA issue: [CORE-17091](https://jira.reactos.org/browse/CORE-17091)

## Proposed changes

- Check punctuation in the word break procedure by using `iswpunct` function.

## TODO

- [x] Do big tests.
- [x] Do small tests.

## Screenshots

BEFORE:
![before1](https://user-images.githubusercontent.com/2107452/215613725-80b1cd4c-3553-44bf-ad0a-f109ffbee6ee.png)
Hyperlink was wrong.
AFTER:
![after1](https://user-images.githubusercontent.com/2107452/215383896-b7addfc5-8934-4f96-9252-37af022b0462.png)
Fixed.

BEFORE:
![before2](https://user-images.githubusercontent.com/2107452/215613779-69a10cda-5d02-4344-b166-8a8be98ed6a4.png)
Hyperlink is wrong.
AFTER:
![after2](https://user-images.githubusercontent.com/2107452/215383892-4147c0b8-da6a-4f45-abd7-ee694fc55da5.png)
Fixed.