### PR TITLE
[BROWSEUI] Execute command line from address bar

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -181,10 +181,10 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
     if (!GetComboBoxText(input))
         return E_FAIL;
 
-    INT addressLength = (wcschr(input, L'%') ? ::ExpandEnvironmentStrings(input, NULL, 0) : 0);
+    INT addressLength = (wcschr(input, L'%') ? ::SHExpandEnvironmentStringsW(input, NULL, 0) : 0);
     if (addressLength <= 0 ||
         !address.Allocate(addressLength + 1) ||
-        !::ExpandEnvironmentStrings(input, address, addressLength))
+        !::SHExpandEnvironmentStringsW(input, address, addressLength))
     {
         address.Free();
         address.Attach(input.Detach());

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -94,14 +94,20 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::SetCurrentDir(long paramC)
     return E_NOTIMPL;
 }
 
+BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& strText)
+{
+    INT cchMax = fCombobox.GetWindowTextLength() + sizeof(UNICODE_NULL);
+    strText.Allocate(cchMax);
+    fCombobox.GetWindowText(strText, cchMax);
+    return TRUE;
+}
+
 // Execute command line from address bar
 HRESULT CAddressEditBox::ExecuteCommandLine()
 {
     /* Get command line */
     CComHeapPtr<WCHAR> pszCmdLine;
-    INT cchCmdLine = fCombobox.GetWindowTextLength() + sizeof(UNICODE_NULL);
-    pszCmdLine.Allocate(cchCmdLine);
-    fCombobox.GetWindowText(pszCmdLine, cchCmdLine);
+    GetComboBoxText(pszCmdLine);
 
     /* Split 1st parameter and trailing arguments */
     PWCHAR args = PathGetArgsW(pszCmdLine);
@@ -158,11 +164,8 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
         return hr;
 
     /* Get the path to browse and expand it if needed */
-    LPWSTR input;
-    int inputLength = fCombobox.GetWindowTextLength() + 2;
-
-    input = new WCHAR[inputLength];
-    fCombobox.GetWindowText(input, inputLength);
+    CComHeapPtr<WCHAR> input;
+    GetComboBoxText(input);
 
     LPWSTR address;
     int addressLength = ExpandEnvironmentStrings(input, NULL, 0);
@@ -221,10 +224,7 @@ cleanup:
 HRESULT STDMETHODCALLTYPE CAddressEditBox::ShowFileNotFoundError(HRESULT hRet)
 {
     CComHeapPtr<WCHAR> input;
-    int inputLength = fCombobox.GetWindowTextLength() + 2;
-
-    input.Allocate(inputLength);
-    fCombobox.GetWindowText(input, inputLength);
+    GetComboBoxText(input);
 
     ShellMessageBoxW(_AtlBaseModule.GetResourceInstance(), fCombobox.m_hWnd, MAKEINTRESOURCEW(IDS_PARSE_ADDR_ERR_TEXT), MAKEINTRESOURCEW(IDS_PARSE_ADDR_ERR_TITLE), MB_OK | MB_ICONERROR, input.m_pData);
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -128,12 +128,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
 
     /* Split 1st parameter from trailing arguments */
     PWCHAR args = PathGetArgsW(pszCmdLine);
-    if (args && *args)
-    {
-        --args;
-        *args = UNICODE_NULL;
-        ++args;
-    }
+    PathRemoveArgsW(pszCmdLine);
 
     PathUnquoteSpacesW(pszCmdLine); /* Unquote the 1st parameter */
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -118,7 +118,7 @@ HRESULT CAddressEditBox::GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL)
     return S_OK;
 }
 
-// Execute command line from address bar
+/* Execute command line from address bar */
 BOOL CAddressEditBox::ExecuteCommandLine()
 {
     /* Get command line */

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -144,12 +144,11 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     info.nShow = SW_SHOWNORMAL;
 
     WCHAR dir[MAX_PATH] = L"";
-    PIDLIST_ABSOLUTE pidl;
+    CComHeapPtr<ITEMIDLIST> pidl;
     if (SUCCEEDED(GetAbsolutePidl(&pidl)))
     {
         if (SHGetPathFromIDListW(pidl, dir) && PathIsDirectoryW(dir))
             info.lpDirectory = dir; /* Set current directory */
-        ILFree(pidl);
     }
 
     if (!::ShellExecuteExW(&info)) /* Execute! */
@@ -188,7 +187,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
 
     INT addressLength = (wcschr(input, L'%') ? ::ExpandEnvironmentStrings(input, NULL, 0) : 0);
     if (addressLength <= 0 ||
-        !address.Allocate(addressLength + 2) ||
+        !address.Allocate(addressLength + 1) ||
         !::ExpandEnvironmentStrings(input, address, addressLength))
     {
         address.Free();

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -186,8 +186,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
     if (!GetComboBoxText(input))
         return E_FAIL;
 
-    /* Expand the text */
-    int addressLength = ExpandEnvironmentStrings(input, NULL, 0);
+    INT addressLength = (wcschr(input, L'%') ? ::ExpandEnvironmentStrings(input, NULL, 0) : 0);
     if (addressLength <= 0 ||
         !address.Allocate(addressLength + 2) ||
         !::ExpandEnvironmentStrings(input, address, addressLength))

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -105,6 +105,22 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
     return fCombobox.GetWindowText(pszText, cchMax);
 }
 
+HRESULT CAddressEditBox::GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL)
+{
+    CComPtr<IBrowserService> isb;
+    HRESULT hr;
+
+    hr = IUnknown_QueryService(fSite, SID_STopLevelBrowser, IID_PPV_ARG(IBrowserService, &isb));
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    hr = isb->GetPidl(pAbsolutePIDL);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    return S_OK;
+}
+
 // Execute command line from address bar
 BOOL CAddressEditBox::ExecuteCommandLine()
 {
@@ -113,7 +129,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     if (!GetComboBoxText(pszCmdLine))
         return FALSE;
 
-    /* Split 1st parameter and trailing arguments */
+    /* Split 1st parameter from trailing arguments */
     PWCHAR args = PathGetArgsW(pszCmdLine);
     if (args && *args)
     {
@@ -122,7 +138,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
         ++args;
     }
 
-    PathUnquoteSpacesW(pszCmdLine);
+    PathUnquoteSpacesW(pszCmdLine); /* Unquote the 1st parameter */
 
     /* Get ready for execution */
     SHELLEXECUTEINFOW info = { sizeof(info), SEE_MASK_FLAG_NO_UI, m_hWnd };
@@ -139,7 +155,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
         ILFree(pidl);
     }
 
-    if (!::ShellExecuteExW(&info))
+    if (!::ShellExecuteExW(&info)) /* Execute! */
         return FALSE;
 
     /* Execution succeeded. Reset the combobox. */
@@ -410,22 +426,6 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::GetIDsOfNames(
     REFIID riid, LPOLESTR *rgszNames, UINT cNames, LCID lcid, DISPID *rgDispId)
 {
     return E_NOTIMPL;
-}
-
-HRESULT CAddressEditBox::GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL)
-{
-    CComPtr<IBrowserService> isb;
-    HRESULT hr;
-
-    hr = IUnknown_QueryService(fSite, SID_STopLevelBrowser, IID_PPV_ARG(IBrowserService, &isb));
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    hr = isb->GetPidl(pAbsolutePIDL);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return hr;
-
-    return S_OK;
 }
 
 HRESULT STDMETHODCALLTYPE CAddressEditBox::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -186,19 +186,14 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::ParseNow(long paramC)
     if (!GetComboBoxText(input))
         return E_FAIL;
 
-    INT addressLength = ::ExpandEnvironmentStrings(input, NULL, 0);
-    if (addressLength <= 0)
+    /* Expand the text */
+    int addressLength = ExpandEnvironmentStrings(input, NULL, 0);
+    if (addressLength <= 0 ||
+        !address.Allocate(addressLength + 2) ||
+        !::ExpandEnvironmentStrings(input, address, addressLength))
     {
+        address.Free();
         address.Attach(input.Detach());
-    }
-    else
-    {
-        if (!address.Allocate(addressLength + 2) ||
-            !::ExpandEnvironmentStrings(input, address, addressLength))
-        {
-            address.Free();
-            address.Attach(input.Detach());
-        }
     }
 
     /* Try to parse a relative path and if it fails, try to browse an absolute path */

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -101,16 +101,13 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
     INT cchMax = fCombobox.GetWindowTextLength() + sizeof(UNICODE_NULL);
     if (!pszText.Allocate(cchMax))
         return FALSE;
-
     return fCombobox.GetWindowText(pszText, cchMax);
 }
 
 HRESULT CAddressEditBox::GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL)
 {
     CComPtr<IBrowserService> isb;
-    HRESULT hr;
-
-    hr = IUnknown_QueryService(fSite, SID_STopLevelBrowser, IID_PPV_ARG(IBrowserService, &isb));
+    HRESULT hr = IUnknown_QueryService(fSite, SID_STopLevelBrowser, IID_PPV_ARG(IBrowserService, &isb));
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -138,12 +138,13 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     info.lpParameters = args;
     info.nShow = SW_SHOWNORMAL;
 
+    /* Set current directory */
     WCHAR dir[MAX_PATH] = L"";
     CComHeapPtr<ITEMIDLIST> pidl;
     if (SUCCEEDED(GetAbsolutePidl(&pidl)))
     {
         if (SHGetPathFromIDListW(pidl, dir) && PathIsDirectoryW(dir))
-            info.lpDirectory = dir; /* Set current directory */
+            info.lpDirectory = dir;
     }
 
     if (!::ShellExecuteExW(&info)) /* Execute! */

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -48,6 +48,7 @@ private:
     void FillOneLevel(int index, int levelIndent, int indent);
     LPITEMIDLIST GetItemData(int index);
     HRESULT STDMETHODCALLTYPE ShowFileNotFoundError(HRESULT hRet);
+    BOOL ExecuteCommandLine();
 public:
     // *** IShellService methods ***
     virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -48,7 +48,8 @@ private:
     void FillOneLevel(int index, int levelIndent, int indent);
     LPITEMIDLIST GetItemData(int index);
     HRESULT STDMETHODCALLTYPE ShowFileNotFoundError(HRESULT hRet);
-    BOOL ExecuteCommandLine();
+    HRESULT ExecuteCommandLine();
+    HRESULT GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL);
 public:
     // *** IShellService methods ***
     virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -48,9 +48,9 @@ private:
     void FillOneLevel(int index, int levelIndent, int indent);
     LPITEMIDLIST GetItemData(int index);
     HRESULT STDMETHODCALLTYPE ShowFileNotFoundError(HRESULT hRet);
-    HRESULT ExecuteCommandLine();
     HRESULT GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL);
-    BOOL GetComboBoxText(CComHeapPtr<WCHAR>& strText);
+    BOOL ExecuteCommandLine();
+    BOOL GetComboBoxText(CComHeapPtr<WCHAR>& pszText);
 public:
     // *** IShellService methods ***
     virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -50,6 +50,7 @@ private:
     HRESULT STDMETHODCALLTYPE ShowFileNotFoundError(HRESULT hRet);
     HRESULT ExecuteCommandLine();
     HRESULT GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL);
+    BOOL GetComboBoxText(CComHeapPtr<WCHAR>& strText);
 public:
     // *** IShellService methods ***
     virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);


### PR DESCRIPTION
## Purpose
If the user could execute a command line from address bar, usability will improve.
JIRA issue: [CORE-15453](https://jira.reactos.org/browse/CORE-15453)

## Proposed changes

- Add `CAddressEditBox::GetAbsolutePidl` and `CAddressEditBox::GetComboBoxText` helper functions.
- Add `CAddressEditBox::ExecuteCommandLine` function to execute the command line.
- And use them.

## TODO

- [x] Set current directory.
- [ ] Reset the combobox after execution.

## Screenshots

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/215639272-5b1d115a-4399-4303-993f-24a54f127bc6.png)
Cannot execute from address bar.

![after](https://user-images.githubusercontent.com/2107452/215664399-53d7a2b4-2c5f-4e9a-91e6-b96242e9bfa5.png)
Able to execute a command line from address bar.