### PR TITLE
[SHELL32] Ignore unused flag SEE_MASK_UNICODE

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -1823,7 +1823,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
     static const DWORD unsupportedFlags =
         SEE_MASK_ICON         | SEE_MASK_HOTKEY |
         SEE_MASK_CONNECTNETDRV | SEE_MASK_FLAG_DDEWAIT |
-        SEE_MASK_UNICODE       | SEE_MASK_ASYNCOK      | SEE_MASK_HMONITOR;
+        SEE_MASK_ASYNCOK      | SEE_MASK_HMONITOR;
 
     WCHAR parametersBuffer[1024], dirBuffer[MAX_PATH], wcmdBuffer[1024];
     WCHAR *wszApplicationName, *wszParameters, *wszDir, *wcmd;


### PR DESCRIPTION
## Purpose

`SEE_MASK_UNICODE` (0x00004000) does nothing, so we needn't mark it as "unsupported flag" and output FIXME

- `SEE_MASK_UNICODE` does nothing, see MS DevBlogs: [What does the SEE_MASK_UNICODE flag in ShellExecuteEx actually do?](https://devblogs.microsoft.com/oldnewthing/20140227-00/?p=1643)
- Corresponding FIXME output can be found in [CORE-18050](https://jira.reactos.org/browse/CORE-18050), the first line of log: `fixme:(dll/win32/shell32/shlexec.cpp:1934) flags ignored: 0x00004000`. **This PR is not for this ticket, but the FIXME output can be found in this ticket**

## Proposed changes
- No `fixme:(dll/win32/shell32/shlexec.cpp:1934) flags ignored: 0x00004000` output