### PR TITLE
[USERENV_WINETEST] Compare variable case insensitive

### DIFF
--- a/modules/rostests/winetests/userenv/userenv.c
+++ b/modules/rostests/winetests/userenv/userenv.c
@@ -152,7 +152,11 @@ static void test_create_env(void)
     for(i=0; i<4; i++)
     {
         r = get_env(env[i], "SystemRoot", &st);
+#ifdef __REACTOS__
+        ok(!stricmp(st, "SystemRoot=overwrite"), "%s\n", st);
+#else
         ok(!strcmp(st, "SystemRoot=overwrite"), "%s\n", st);
+#endif
         expect(TRUE, r);
         HeapFree(GetProcessHeap(), 0, st);
     }


### PR DESCRIPTION
This fixes a test for TestWHS
