### PR TITLE
[USER32_WINETEST] Change module type to win32cui

### DIFF
--- a/modules/rostests/winetests/user32/CMakeLists.txt
+++ b/modules/rostests/winetests/user32/CMakeLists.txt
@@ -47,7 +47,6 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 endif()
 
 add_pch(user32_winetest precomp.h "${PCH_SKIP_SOURCE}")
-# some tests need to be run from an app compiled as GUI
-set_module_type(user32_winetest win32gui)
+set_module_type(user32_winetest win32cui)
 add_importlibs(user32_winetest user32 gdi32 advapi32 msvcrt kernel32)
 add_rostests_file(TARGET user32_winetest)


### PR DESCRIPTION
## Purpose

Change module type to win32cui to be able to see the test results.

## Tests
Test WHS: https://reactos.org/testman/compare.php?ids=85895,85896,85897,85899,85900
