### PR TITLE
[WINMM] MMIO_ParseExtA: Don't parse extension if the file name is empty

### DIFF
--- a/dll/win32/winmm/mmio.c
+++ b/dll/win32/winmm/mmio.c
@@ -374,6 +374,12 @@ static FOURCC MMIO_ParseExtA(LPCSTR szFileName)
     if (!szFileName)
 	return ret;
 
+#ifdef __REACTOS__
+    /* Check if the file name is empty (CORE-18810) */
+    if (!*szFileName)
+        return ret;
+#endif
+
     /* Find the last '.' */
     extStart = strrchr(szFileName,'.');
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18810](https://jira.reactos.org/browse/CORE-18810)