### PR TITLE
[NTUSER] co_UserDestroyWindow: Check Window->pcls is not NULL

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2881,7 +2881,7 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
       }
    }
 
-   if (Window->pcls->atomClassName != gpsi->atomSysClass[ICLS_IME])
+   if (Window->pcls && (Window->pcls->atomClassName != gpsi->atomSysClass[ICLS_IME]))
    {
       if ((Window->style & (WS_POPUP|WS_CHILD)) != WS_CHILD)
       {


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18821](https://jira.reactos.org/browse/CORE-18821)