### PR TITLE
[Scsiport] Return correct status for IOCTL FT_BALANCED_READ_MODE

### DIFF
--- a/drivers/storage/port/scsiport/ioctl.c
+++ b/drivers/storage/port/scsiport/ioctl.c
@@ -8,6 +8,7 @@
  */
 
 #include "scsiport.h"
+#include "ntddft.h" // FT_BALANCED_READ_MODE
 
 #define NDEBUG
 #include <debug.h>
@@ -538,6 +539,11 @@ ScsiPortDeviceControl(
             status = STATUS_NOT_IMPLEMENTED;
             break;
 
+        case FT_BALANCED_READ_MODE:
+            DPRINT1("FT_BALANCED_READ_MODE unimplemented!\n");
+            status = STATUS_NOT_IMPLEMENTED;
+            break;
+        
         default:
             DPRINT1("unknown ioctl code: 0x%lX\n", Stack->Parameters.DeviceIoControl.IoControlCode);
             status = STATUS_NOT_SUPPORTED;


### PR DESCRIPTION
JIRA issue: [CORE-18820](https://jira.reactos.org/browse/CORE-18820)
Add support for IOCTL FT_BALANCED_READ_MODE and return STATUS_NOT_IMPLEMENTED
