### PR TITLE
[NTUSER] co_UserDestroyWindow: Validate window before destroying it

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -2855,6 +2855,15 @@ BOOLEAN co_UserDestroyWindow(PVOID Object)
 
    ASSERT_REFS_CO(Window); // FIXME: Temp HACK?
 
+   /* NtUserDestroyWindow does check if the window has already been destroyed
+      but co_UserDestroyWindow can be called from more paths which means
+      that it can also be called for a window that has already been destroyed. */
+   if (!IntIsWindow(UserHMGetHandle(Window)))
+   {
+      TRACE("Tried to destroy a window twice\n");
+      return TRUE;
+   }
+
    hWnd = Window->head.h;
    ti = PsGetCurrentThreadWin32Thread();
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18821](https://jira.reactos.org/browse/CORE-18821)

## Proposed changes
Do window validation for some functions in win32k that call co_UserDestroyWindow directly.

Thanks @sdever and @yagoulas for the help.