### PR TITLE
[CRT] printf/wprintf: Support %zu

### DIFF
--- a/sdk/lib/crt/printf/streamout.c
+++ b/sdk/lib/crt/printf/streamout.c
@@ -432,7 +432,10 @@ streamout(FILE *stream, const TCHAR *format, va_list argptr)
             else if (chr == _T('w')) flags |= FLAG_WIDECHAR;
             else if (chr == _T('L')) flags |= 0; // FIXME: long double
             else if (chr == _T('F')) flags |= 0; // FIXME: what is that?
-            else if (chr == _T('z') && strchr("udxXion", *format)) flags |= FLAG_INTPTR;
+            else if (chr == _T('z') && *format && strchr("udxXion", *format))
+            {
+                flags |= FLAG_INTPTR;
+            }
             else if (chr == _T('l'))
             {
                 /* Check if this is the 2nd 'l' in a row */

--- a/sdk/lib/crt/printf/streamout.c
+++ b/sdk/lib/crt/printf/streamout.c
@@ -432,7 +432,7 @@ streamout(FILE *stream, const TCHAR *format, va_list argptr)
             else if (chr == _T('w')) flags |= FLAG_WIDECHAR;
             else if (chr == _T('L')) flags |= 0; // FIXME: long double
             else if (chr == _T('F')) flags |= 0; // FIXME: what is that?
-            else if (chr == _T('z')) flags |= FLAG_INTPTR;
+            else if (chr == _T('z') && strchr("udxXion", *format)) flags |= FLAG_INTPTR;
             else if (chr == _T('l'))
             {
                 /* Check if this is the 2nd 'l' in a row */

--- a/sdk/lib/crt/printf/streamout.c
+++ b/sdk/lib/crt/printf/streamout.c
@@ -432,6 +432,7 @@ streamout(FILE *stream, const TCHAR *format, va_list argptr)
             else if (chr == _T('w')) flags |= FLAG_WIDECHAR;
             else if (chr == _T('L')) flags |= 0; // FIXME: long double
             else if (chr == _T('F')) flags |= 0; // FIXME: what is that?
+            else if (chr == _T('z')) flags |= FLAG_INTPTR;
             else if (chr == _T('l'))
             {
                 /* Check if this is the 2nd 'l' in a row */


### PR DESCRIPTION
## Purpose

`"%zu"` is a `printf` format specifier for type `size_t`. Some apps assume the implementation of this specifier.

JIRA issue: [CORE-17787](https://jira.reactos.org/browse/CORE-17787)

## TODO

- [x] Do small tests.
- [x] Do big tests.

## Screenshots

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/217737536-c2e4ecd4-447c-491a-b4a2-410a10aca1bf.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/217737522-e95fd7a9-847c-42f0-b2fc-81b20f08d5de.png)