### PR TITLE
[EXPLORER] Crash on backspace while editing folder panel

### DIFF
--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -149,6 +149,7 @@ CExplorerBand::CExplorerBand()
     , m_fVisible(FALSE)
     , m_bNavigating(FALSE)
     , m_dwBandID(0)
+    , m_isEditing(FALSE)
     , m_pidlCurrent(NULL)
 {
 }
@@ -1217,6 +1218,9 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::HasFocusIO()
 
 HRESULT STDMETHODCALLTYPE CExplorerBand::TranslateAcceleratorIO(LPMSG lpMsg)
 {
+    if (m_isEditing)
+        return S_FALSE;
+    
     if (lpMsg->hwnd == m_hWnd)
     {
         TranslateMessage(lpMsg);
@@ -1315,6 +1319,7 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::OnWinEvent(HWND hWnd, UINT uMsg, WPARAM
                 hr = pParent->GetAttributesOf(1, &pChild, &dwAttr);
                 if (SUCCEEDED(hr) && (dwAttr & SFGAO_CANRENAME) && theResult)
                     *theResult = 0;
+                 m_isEditing = TRUE;
                 return S_OK;
             }
             case TVN_ENDLABELEDITW:
@@ -1323,6 +1328,7 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::OnWinEvent(HWND hWnd, UINT uMsg, WPARAM
                 NodeInfo *info = GetNodeInfo(dispInfo->item.hItem);
                 HRESULT hr;
 
+                m_isEditing = FALSE;
                 if (theResult)
                     *theResult = 0;
                 if (dispInfo->item.pszText)

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -149,7 +149,6 @@ CExplorerBand::CExplorerBand()
     , m_fVisible(FALSE)
     , m_bNavigating(FALSE)
     , m_dwBandID(0)
-    , m_isEditing(FALSE)
     , m_pidlCurrent(NULL)
 {
 }
@@ -1218,9 +1217,6 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::HasFocusIO()
 
 HRESULT STDMETHODCALLTYPE CExplorerBand::TranslateAcceleratorIO(LPMSG lpMsg)
 {
-    if (m_isEditing)
-        return S_FALSE;
-    
     if (lpMsg->hwnd == m_hWnd)
     {
         TranslateMessage(lpMsg);
@@ -1319,7 +1315,6 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::OnWinEvent(HWND hWnd, UINT uMsg, WPARAM
                 hr = pParent->GetAttributesOf(1, &pChild, &dwAttr);
                 if (SUCCEEDED(hr) && (dwAttr & SFGAO_CANRENAME) && theResult)
                     *theResult = 0;
-                 m_isEditing = TRUE;
                 return S_OK;
             }
             case TVN_ENDLABELEDITW:
@@ -1328,7 +1323,6 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::OnWinEvent(HWND hWnd, UINT uMsg, WPARAM
                 NodeInfo *info = GetNodeInfo(dispInfo->item.hItem);
                 HRESULT hr;
 
-                m_isEditing = FALSE;
                 if (theResult)
                     *theResult = 0;
                 if (dispInfo->item.pszText)

--- a/dll/win32/browseui/explorerband.cpp
+++ b/dll/win32/browseui/explorerband.cpp
@@ -1220,7 +1220,7 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::TranslateAcceleratorIO(LPMSG lpMsg)
 {
     if (m_isEditing)
         return S_FALSE;
-    
+
     if (lpMsg->hwnd == m_hWnd)
     {
         TranslateMessage(lpMsg);
@@ -1318,8 +1318,10 @@ HRESULT STDMETHODCALLTYPE CExplorerBand::OnWinEvent(HWND hWnd, UINT uMsg, WPARAM
 
                 hr = pParent->GetAttributesOf(1, &pChild, &dwAttr);
                 if (SUCCEEDED(hr) && (dwAttr & SFGAO_CANRENAME) && theResult)
+                {
                     *theResult = 0;
-                 m_isEditing = TRUE;
+                    m_isEditing = TRUE;
+                }
                 return S_OK;
             }
             case TVN_ENDLABELEDITW:

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -60,6 +60,7 @@ private:
     BOOL m_bNavigating;
     BOOL m_bFocused;
     DWORD m_dwBandID;
+    BOOL m_isEditing;
     HIMAGELIST m_hImageList;
     HTREEITEM  m_hRoot;
     HTREEITEM  m_oldSelected;

--- a/dll/win32/browseui/explorerband.h
+++ b/dll/win32/browseui/explorerband.h
@@ -60,7 +60,6 @@ private:
     BOOL m_bNavigating;
     BOOL m_bFocused;
     DWORD m_dwBandID;
-    BOOL m_isEditing;
     HIMAGELIST m_hImageList;
     HTREEITEM  m_hRoot;
     HTREEITEM  m_oldSelected;


### PR DESCRIPTION
JIRA issue: [CORE-18646](https://jira.reactos.org/browse/CORE-18646)
Tested issuing a backspace while editing multiple folder names: No crash

Suspected Duplicates:
[CORE-18504](https://jira.reactos.org/browse/CORE-18504) Tested right clicking on left panel folders: No crash
[CORE-18746](https://jira.reactos.org/browse/CORE-18746) Tried renaming Recycle Bin: No crash

