### PR TITLE
[NTUSER] Optimize Window Snap Disabling

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -792,25 +792,20 @@ IntDefWindowProc(
          if (g_bWindowSnapEnabled && (IS_KEY_DOWN(gafAsyncKeyState, VK_LWIN) || IS_KEY_DOWN(gafAsyncKeyState, VK_RWIN)))
          {
             BOOL IsTaskBar;
-            DWORD Style;
-            DWORD ExStyle;
+            DWORD StyleTB;
+            DWORD ExStyleTB;
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
 
-            /* Test for typical TaskBar ExStyle Values */
-            ExStyle = (topWnd->ExStyle & WS_EX_TOOLWINDOW);
-            TRACE("ExStyle=%x\n", ExStyle);
+            // We want to forbid snapping operations on the TaskBar
+            // We use a heuristic for detecting the TaskBar Wnd by its typical Style & ExStyle Values
+            ExStyleTB = (topWnd->ExStyle & WS_EX_TOOLWINDOW);
+            StyleTB = (topWnd->style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
+            IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
+                        && (ExStyleTB == WS_EX_TOOLWINDOW);
+            TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", StyleTB, ExStyleTB, IsTaskBar);
 
-            /* Test for typical TaskBar Style Values */
-            Style = (topWnd->style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
-            TRACE("Style=%x\n", Style);
-
-            /* Test for masked typical TaskBar Style and ExStyles to detect TaskBar */
-            IsTaskBar = (Style == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
-                        && (ExStyle == WS_EX_TOOLWINDOW);
-            TRACE("IsTaskBar=%d\n", IsTaskBar);
-
-            if (topWnd && !IsTaskBar)  /* Second test is so we are not touching the Taskbar */
+            if (topWnd && !IsTaskBar)
             {
                if ((topWnd->style & WS_THICKFRAME) == 0)
                   return 0;

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -408,7 +408,7 @@ UserPaintCaption(PWND pWnd, INT Flags)
      * When themes are not enabled we can go on and paint the non client area.
      * However if we do that with themes enabled we will draw a classic frame.
      * This is solved by sending a themes specific message to notify the themes
-     * engine that the caption needs to be redrawn
+     * engine that the caption needs to be redrawn.
      */
       if (gpsi->dwSRVIFlags & SRVINFO_APIHOOK)
       {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -792,7 +792,7 @@ IntDefWindowProc(
                co_IntSendMessage(UserHMGetHandle(Wnd), WM_CONTEXTMENU, (WPARAM)UserHMGetHandle(Wnd), MAKELPARAM(-1, -1));
             }
          }
-         if (IS_KEY_DOWN(gafAsyncKeyState, VK_LWIN) || IS_KEY_DOWN(gafAsyncKeyState, VK_RWIN))
+         if (g_bWindowSnapEnabled && (IS_KEY_DOWN(gafAsyncKeyState, VK_LWIN) || IS_KEY_DOWN(gafAsyncKeyState, VK_RWIN)))
          {
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
@@ -813,7 +813,7 @@ IntDefWindowProc(
 
             if (topWnd && !IsTaskBar)  /* Second test is so we are not touching the Taskbar */
             {
-               if ((topWnd->style & WS_THICKFRAME) == 0 || !g_bWindowSnapEnabled)
+               if ((topWnd->style & WS_THICKFRAME) == 0)
                {
                   return 0;
                }

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -544,9 +544,6 @@ IntDefWindowProc(
    PTHREADINFO pti = PsGetCurrentThreadWin32Thread();
    LRESULT lResult = 0;
    USER_REFERENCE_ENTRY Ref;
-   BOOL IsTaskBar;
-   DWORD Style;
-   DWORD ExStyle;
 
    if (Msg > WM_USER) return 0;
 
@@ -794,6 +791,9 @@ IntDefWindowProc(
          }
          if (g_bWindowSnapEnabled && (IS_KEY_DOWN(gafAsyncKeyState, VK_LWIN) || IS_KEY_DOWN(gafAsyncKeyState, VK_RWIN)))
          {
+            BOOL IsTaskBar;
+            DWORD Style;
+            DWORD ExStyle;
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
 

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -803,7 +803,7 @@ IntDefWindowProc(
             StyleTB = (topWnd->style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
             IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
                         && (ExStyleTB == WS_EX_TOOLWINDOW);
-            TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", StyleTB, ExStyleTB, IsTaskBar);
+            TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", ExStyleTB, StyleTB, IsTaskBar);
 
             if (topWnd && !IsTaskBar)
             {

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -415,7 +415,7 @@ UserPaintCaption(PWND pWnd, INT Flags)
         /*
          * This will cause uxtheme to either paint the themed caption or call
          * RealUserDrawCaption in order to draw the classic caption when themes
-         * are disabled but the themes service is enabled
+         * are disabled but the themes service is enabled.
          */
          TRACE("UDCB Flags %08x\n", Flags);
          co_IntSendMessage(UserHMGetHandle(pWnd), WM_NCUAHDRAWCAPTION, Flags, 0);

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -404,15 +404,15 @@ UserPaintCaption(PWND pWnd, INT Flags)
   {
       if (pWnd->state & WNDS_HASCAPTION && pWnd->head.pti->MessageQueue == gpqForeground)
          Flags |= DC_ACTIVE;
-    /* 
+    /*
      * When themes are not enabled we can go on and paint the non client area.
      * However if we do that with themes enabled we will draw a classic frame.
      * This is solved by sending a themes specific message to notify the themes
-     * engine that the caption needs to be redrawn 
+     * engine that the caption needs to be redrawn
      */
       if (gpsi->dwSRVIFlags & SRVINFO_APIHOOK)
       {
-        /* 
+        /*
          * This will cause uxtheme to either paint the themed caption or call
          * RealUserDrawCaption in order to draw the classic caption when themes
          * are disabled but the themes service is enabled
@@ -440,7 +440,7 @@ DefWndSetIcon(PWND pWnd, WPARAM wParam, LPARAM lParam)
     HICON hIcon, hIconSmall, hIconOld;
 
     if ( wParam > ICON_SMALL2 )
-    {  
+    {
         EngSetLastError(ERROR_INVALID_PARAMETER);
         return 0;
     }
@@ -799,25 +799,22 @@ IntDefWindowProc(
 
             /* Test for typical TaskBar ExStyle Values */
             ExStyle = (topWnd->ExStyle & WS_EX_TOOLWINDOW);
-            TRACE("ExStyle is '%x'.\n", ExStyle);
+            TRACE("ExStyle=%x\n", ExStyle);
 
             /* Test for typical TaskBar Style Values */
-            Style = (topWnd->style & (WS_POPUP | WS_VISIBLE |
-                        WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
-            TRACE("Style is '%x'.\n", Style);
+            Style = (topWnd->style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
+            TRACE("Style=%x\n", Style);
 
             /* Test for masked typical TaskBar Style and ExStyles to detect TaskBar */
             IsTaskBar = (Style == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
                         && (ExStyle == WS_EX_TOOLWINDOW);
-            TRACE("This %s the TaskBar.\n", IsTaskBar ? "is" : "is not");
+            TRACE("IsTaskBar=%d\n", IsTaskBar);
 
             if (topWnd && !IsTaskBar)  /* Second test is so we are not touching the Taskbar */
             {
                if ((topWnd->style & WS_THICKFRAME) == 0)
-               {
                   return 0;
-               }
-               
+
                if (wParam == VK_DOWN)
                {
                    if (topWnd->style & WS_MAXIMIZE)
@@ -835,7 +832,7 @@ IntDefWindowProc(
                else if (wParam == VK_UP)
                {
                   RECT currentRect;
-                  if ((topWnd->InternalPos.NormalRect.right == topWnd->InternalPos.NormalRect.left) || 
+                  if ((topWnd->InternalPos.NormalRect.right == topWnd->InternalPos.NormalRect.left) ||
                       (topWnd->InternalPos.NormalRect.top == topWnd->InternalPos.NormalRect.bottom))
                   {
                       currentRect = topWnd->rcWindow;

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -403,17 +403,16 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
       {
          /* Test for typical TaskBar ExStyle Values */
          ExStyleTB = (ExStyle & WS_EX_TOOLWINDOW);
-         TRACE("ExStyle is '%x'.\n", ExStyleTB);
+         TRACE("ExStyle=%x\n", ExStyleTB);
 
          /* Test for typical TaskBar Style Values */
-         StyleTB = (Style & (WS_POPUP | WS_VISIBLE |
-                        WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
-         TRACE("Style is '%x'.\n", StyleTB);
+         StyleTB = (Style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
+         TRACE("Style=%x\n", StyleTB);
 
          /* Test for masked typical TaskBar Style and ExStyles to detect TaskBar */
          IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
                      && (ExStyleTB == WS_EX_TOOLWINDOW);
-         TRACE("This %s the TaskBar.\n", IsTaskBar ? "is" : "is not");
+         TRACE("IsTaskBar=%d\n", IsTaskBar);
 
          // check for snapping if was moved by caption
          if (hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)
@@ -424,9 +423,8 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
 
             /* if this is the taskbar, then we want to just exit */
             if (IsTaskBar)
-            {
                break;
-            }
+
             // snap to left
             if (pt.x <= snapRect.left)
             {
@@ -439,7 +437,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
                snapRect.left = (snapRect.right - snapRect.left) / 2 + snapRect.left;
                doSideSnap = TRUE;
             }
-            
+
             if (doSideSnap)
             {
                co_WinPosSetWindowPos(pwnd,
@@ -463,7 +461,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
          }
          break;
       }
-      
+
       /* Exit on Return or Esc */
       if (msg.message == WM_KEYDOWN &&
           (msg.wParam == VK_RETURN || msg.wParam == VK_ESCAPE))
@@ -1290,7 +1288,7 @@ LRESULT NC_HandleNCCalcSize( PWND Wnd, WPARAM wparam, RECTL *Rect, BOOL Suspende
    SIZE WindowBorders;
    RECT OrigRect;
    LONG Style = Wnd->style;
-   LONG  exStyle = Wnd->ExStyle; 
+   LONG exStyle = Wnd->ExStyle;
 
    if (Rect == NULL)
    {
@@ -1667,7 +1665,7 @@ NC_HandleNCLButtonDblClk(PWND pWnd, WPARAM wParam, LPARAM lParam)
     {
       PMENU SysMenu = IntGetSystemMenu(pWnd, FALSE);
       UINT state = IntGetMenuState(SysMenu ? UserHMGetHandle(SysMenu) : NULL, SC_CLOSE, MF_BYCOMMAND);
-                  
+
       /* If the close item of the sysmenu is disabled or not present do nothing */
       if ((state & (MF_DISABLED | MF_GRAYED)) || (state == 0xFFFFFFFF))
           break;
@@ -1679,12 +1677,12 @@ NC_HandleNCLButtonDblClk(PWND pWnd, WPARAM wParam, LPARAM lParam)
     case HTBOTTOM:
     {
       RECT sizingRect = pWnd->rcWindow, mouseRect;
-      
+
       if (pWnd->ExStyle & WS_EX_MDICHILD)
           break;
-      
+
       UserSystemParametersInfo(SPI_GETWORKAREA, 0, &mouseRect, 0);
-        
+
       co_WinPosSetWindowPos(pWnd,
                             NULL,
                             sizingRect.left,
@@ -1705,7 +1703,7 @@ NC_HandleNCLButtonDblClk(PWND pWnd, WPARAM wParam, LPARAM lParam)
  *
  * Handle a WM_NCRBUTTONDOWN message. Called from DefWindowProc().
  */
-LRESULT NC_HandleNCRButtonDown( PWND pwnd, WPARAM wParam, LPARAM lParam ) 
+LRESULT NC_HandleNCRButtonDown(PWND pwnd, WPARAM wParam, LPARAM lParam)
 {
   MSG msg;
   INT hittest = wParam;

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -393,8 +393,13 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
       if (!co_IntGetPeekMessage(&msg, 0, 0, 0, PM_REMOVE, TRUE)) break;
       if (IntCallMsgFilter( &msg, MSGF_SIZE )) continue;
 
-      /* Exit on button-up */
-      if (msg.message == WM_LBUTTONUP)
+      if (!g_bWindowSnapEnabled) /* If no WindowSnapEnabled: Exit on button-up, Return, or Esc */
+      {
+         if((msg.message == WM_LBUTTONUP) ||
+           ((msg.message == WM_KEYDOWN) &&
+           ((msg.wParam == VK_RETURN) || (msg.wParam == VK_ESCAPE)))) break;
+      }
+      else if (msg.message == WM_LBUTTONUP) /* If WindowSnapEnabled: Exit on button-up */
       {
          /* Test for typical TaskBar ExStyle Values */
          ExStyleTB = (ExStyle & WS_EX_TOOLWINDOW);
@@ -418,7 +423,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
             UserSystemParametersInfo(SPI_GETWORKAREA, 0, &snapRect, 0);
 
             /* if this is the taskbar, then we want to just exit */
-            if (IsTaskBar || !g_bWindowSnapEnabled)
+            if (IsTaskBar)
             {
                break;
             }

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -411,7 +411,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
                      && (ExStyleTB == WS_EX_TOOLWINDOW);
          TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", StyleTB, ExStyleTB, IsTaskBar);
 
-          // check for snapping if was moved by caption
+         // check for snapping if was moved by caption
          if (!IsTaskBar && hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)
          {
             RECT snapRect;

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -409,7 +409,7 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
          StyleTB = (Style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
          IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
                      && (ExStyleTB == WS_EX_TOOLWINDOW);
-         TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", StyleTB, ExStyleTB, IsTaskBar);
+         TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", ExStyleTB, StyleTB, IsTaskBar);
 
          // check for snapping if was moved by caption
          if (!IsTaskBar && hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)

--- a/win32ss/user/ntuser/nonclient.c
+++ b/win32ss/user/ntuser/nonclient.c
@@ -403,20 +403,15 @@ DefWndDoSizeMove(PWND pwnd, WORD wParam)
          DWORD ExStyleTB, StyleTB;
          BOOL IsTaskBar;
 
-         /* Test for typical TaskBar ExStyle Values */
+         // We want to forbid snapping operations on the TaskBar
+         // We use a heuristic for detecting the TaskBar Wnd by its typical Style & ExStyle Values
          ExStyleTB = (ExStyle & WS_EX_TOOLWINDOW);
-         TRACE("ExStyle=%x\n", ExStyleTB);
-
-         /* Test for typical TaskBar Style Values */
          StyleTB = (Style & (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN));
-         TRACE("Style=%x\n", StyleTB);
-
-         /* Test for masked typical TaskBar Style and ExStyles to detect TaskBar */
          IsTaskBar = (StyleTB == (WS_POPUP | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN))
                      && (ExStyleTB == WS_EX_TOOLWINDOW);
-         TRACE("IsTaskBar=%d\n", IsTaskBar);
+         TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", StyleTB, ExStyleTB, IsTaskBar);
 
-         // check for snapping if was moved by caption
+          // check for snapping if was moved by caption
          if (!IsTaskBar && hittest == HTCAPTION && thickframe && (ExStyle & WS_EX_MDICHILD) == 0)
          {
             RECT snapRect;


### PR DESCRIPTION
## Purpose

I experimented with porting back the code-changes of (#5014) locally and while doing so,
I saw that it can be optimized a lot for the case that Window Snapping is turned off:

In defwnd.c we can save a call to UserGetForegroundWindow(), a call to UserGetWindowObject(hwndTop), assignments, ifs, traces.
In nonclient.c we can save a call to UserSystemParametersInfo(), assignments, ifs, traces.
In nonclient.c we are within a tight for(;;) even!

And I also think the code is much more readable like that,
as it separates the Window-Snapped-paths much leaner from the non-Window-Snapped-paths.

That gets very obvious when having a look again at the initial commit that introduced Window-Snapping:
https://github.com/reactos/reactos/commit/7e396787ed00a3939031447725f79697a41878e1
We can see that its code begins much further upwards than where Katayama decided to check his new flag.

**All relevant code changes are in the first commit, the 2nd commit is only non-functional formatting improvements**

JIRA issue: [CORE-16379](https://jira.reactos.org/browse/CORE-16379)
