### PR TITLE
[BROWSEUI] Add CAddressEditBox::RefreshAddress and use it

### DIFF
--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -106,15 +106,13 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
 
 HRESULT CAddressEditBox::RefreshAddress()
 {
-    HRESULT hr;
-
     if (pidlLastParsed)
         ILFree(pidlLastParsed);
     pidlLastParsed = NULL;
 
     /* Get the current pidl of the browser */
     CComHeapPtr<ITEMIDLIST> absolutePIDL;
-    hr = GetAbsolutePidl(&absolutePIDL);
+    HRESULT hr = GetAbsolutePidl(&absolutePIDL);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -107,8 +107,10 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
 HRESULT CAddressEditBox::RefreshAddress()
 {
     if (pidlLastParsed)
+    {
         ILFree(pidlLastParsed);
-    pidlLastParsed = NULL;
+        pidlLastParsed = NULL;
+    }
 
     /* Get the current pidl of the browser */
     CComHeapPtr<ITEMIDLIST> absolutePIDL;
@@ -116,11 +118,7 @@ HRESULT CAddressEditBox::RefreshAddress()
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    if (!absolutePIDL)
-    {
-        ERR("Got no PIDL, investigate me!\n");
-        return S_OK;
-    }
+    ATLASSERT(absolutePIDL != NULL);
 
     /* Fill the combobox */
     PopulateComboBox(absolutePIDL);
@@ -133,12 +131,11 @@ HRESULT CAddressEditBox::RefreshAddress()
         return hr;
 
     /* Get image list indexes */
-    INT indexClosed, indexOpen;
-    indexClosed = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
+    INT indexOpen;
+    INT indexClosed = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
 
     /* Get ready to set the displayed item */
-    COMBOBOXEXITEMW item = { 0 };
-    item.mask = CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM;
+    COMBOBOXEXITEMW item = { CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM };
     item.iItem = -1; /* -1 to specify the displayed item */
     item.iImage = indexClosed;
     item.iSelectedImage = indexOpen;

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -107,7 +107,6 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
 HRESULT CAddressEditBox::RefreshAddress()
 {
     HRESULT hr;
-    WCHAR szName[4096], szPath[MAX_PATH];
 
     if (pidlLastParsed)
         ILFree(pidlLastParsed);
@@ -158,22 +157,18 @@ HRESULT CAddressEditBox::RefreshAddress()
     item.iSelectedImage = indexOpen;
 
     /* Set the path if filesystem; otherwise use the name */
-    if (SHGetPathFromIDListW(absolutePIDL, szPath))
-    {
-        item.pszText = szPath;
-    }
-    else
+    WCHAR szPathOrName[MAX_PATH];
+    if (!SHGetPathFromIDListW(absolutePIDL, szPathOrName))
     {
         hr = sf->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
 
-        hr = StrRetToBufW(&ret, pidlChild, szName, _countof(szName));
+        hr = StrRetToBufW(&ret, pidlChild, szPathOrName, _countof(szPathOrName));
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
-
-        item.pszText = szName;
     }
+    item.pszText = szPathOrName;
 
     /* Ownership of absolutePIDL will be moved to fCombobox. See CBEN_DELETEITEM */
     item.lParam = reinterpret_cast<LPARAM>(absolutePIDL.Detach());

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -116,9 +116,9 @@ HRESULT CAddressEditBox::RefreshAddress()
     ATLASSERT(absolutePIDL != NULL);
     PopulateComboBox(absolutePIDL);
 
-    /* Add the item that will be visible when the combobox is not expanded */
-    PCITEMID_CHILD pidlChild;
+    /* Get pShellFolder and pidlChild */
     CComPtr<IShellFolder> pShellFolder;
+    PCITEMID_CHILD pidlChild;
     hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &pShellFolder), &pidlChild);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -118,9 +118,8 @@ HRESULT CAddressEditBox::RefreshAddress()
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    ATLASSERT(absolutePIDL != NULL);
-
     /* Fill the combobox */
+    ATLASSERT(absolutePIDL != NULL);
     PopulateComboBox(absolutePIDL);
 
     /* Add the item that will be visible when the combobox is not expanded */

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -106,12 +106,6 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
 
 HRESULT CAddressEditBox::RefreshAddress()
 {
-    if (pidlLastParsed)
-    {
-        ILFree(pidlLastParsed);
-        pidlLastParsed = NULL;
-    }
-
     /* Get the current pidl of the browser */
     CComHeapPtr<ITEMIDLIST> absolutePIDL;
     HRESULT hr = GetAbsolutePidl(&absolutePIDL);
@@ -123,7 +117,7 @@ HRESULT CAddressEditBox::RefreshAddress()
     PopulateComboBox(absolutePIDL);
 
     /* Add the item that will be visible when the combobox is not expanded */
-    LPCITEMIDLIST pidlChild;
+    PCITEMID_CHILD pidlChild;
     CComPtr<IShellFolder> sf;
     hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
     if (FAILED_UNEXPECTEDLY(hr))
@@ -464,7 +458,14 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Invoke(DISPID dispIdMember, REFIID ri
     {
     case DISPID_NAVIGATECOMPLETE2:
     case DISPID_DOCUMENTCOMPLETE:
+        if (pidlLastParsed)
+        {
+            ILFree(pidlLastParsed);
+            pidlLastParsed = NULL;
+        }
+
         RefreshAddress();
+        break;
     }
     return S_OK;
 }

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -118,22 +118,22 @@ HRESULT CAddressEditBox::RefreshAddress()
 
     /* Add the item that will be visible when the combobox is not expanded */
     PCITEMID_CHILD pidlChild;
-    CComPtr<IShellFolder> sf;
-    hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
+    CComPtr<IShellFolder> pShellFolder;
+    hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &pShellFolder), &pidlChild);
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
     /* Get ready to set the displayed item */
     COMBOBOXEXITEMW item = { CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM };
     item.iItem = -1; /* -1 to specify the displayed item */
-    item.iImage = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &item.iSelectedImage);
+    item.iImage = SHMapPIDLToSystemImageListIndex(pShellFolder, pidlChild, &item.iSelectedImage);
 
     /* Set the path if filesystem; otherwise use the name */
     WCHAR szPathOrName[MAX_PATH];
     if (!SHGetPathFromIDListW(absolutePIDL, szPathOrName))
     {
         STRRET ret;
-        hr = sf->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
+        hr = pShellFolder->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -125,17 +125,6 @@ HRESULT CAddressEditBox::RefreshAddress()
     /* Fill the combobox */
     PopulateComboBox(absolutePIDL);
 
-    /* Find the current item in the combobox and select it */
-    CComPtr<IShellFolder> psfDesktop;
-    hr = SHGetDesktopFolder(&psfDesktop);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return S_OK;
-
-    STRRET ret;
-    hr = psfDesktop->GetDisplayNameOf(absolutePIDL, SHGDN_FORADDRESSBAR, &ret);
-    if (FAILED_UNEXPECTEDLY(hr))
-        return S_OK;
-
     /* Add the item that will be visible when the combobox is not expanded */
     LPCITEMIDLIST pidlChild;
     CComPtr<IShellFolder> sf;
@@ -158,6 +147,7 @@ HRESULT CAddressEditBox::RefreshAddress()
     WCHAR szPathOrName[MAX_PATH];
     if (!SHGetPathFromIDListW(absolutePIDL, szPathOrName))
     {
+        STRRET ret;
         hr = sf->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
         if (FAILED_UNEXPECTEDLY(hr))
             return hr;
@@ -172,7 +162,6 @@ HRESULT CAddressEditBox::RefreshAddress()
     item.lParam = reinterpret_cast<LPARAM>(absolutePIDL.Detach());
 
     fCombobox.SendMessage(CBEM_SETITEM, 0, reinterpret_cast<LPARAM>(&item)); /* Set it! */
-
     return S_OK;
 }
 

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -129,15 +129,10 @@ HRESULT CAddressEditBox::RefreshAddress()
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 
-    /* Get image list indexes */
-    INT indexOpen;
-    INT indexClosed = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
-
     /* Get ready to set the displayed item */
     COMBOBOXEXITEMW item = { CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM };
     item.iItem = -1; /* -1 to specify the displayed item */
-    item.iImage = indexClosed;
-    item.iSelectedImage = indexOpen;
+    item.iImage = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &item.iSelectedImage);
 
     /* Set the path if filesystem; otherwise use the name */
     WCHAR szPathOrName[MAX_PATH];

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -213,7 +213,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     PathUnquoteSpacesW(pszCmdLine); /* Unquote the 1st parameter */
 
     /* Get ready for execution */
-    SHELLEXECUTEINFOW info = { sizeof(info), SEE_MASK_FLAG_NO_UI | SEE_MASK_ASYNCOK, m_hWnd };
+    SHELLEXECUTEINFOW info = { sizeof(info), SEE_MASK_FLAG_NO_UI, m_hWnd };
     info.lpFile = pszCmdLine;
     info.lpParameters = args;
     info.nShow = SW_SHOWNORMAL;

--- a/dll/win32/browseui/addresseditbox.cpp
+++ b/dll/win32/browseui/addresseditbox.cpp
@@ -104,6 +104,86 @@ BOOL CAddressEditBox::GetComboBoxText(CComHeapPtr<WCHAR>& pszText)
     return fCombobox.GetWindowText(pszText, cchMax);
 }
 
+HRESULT CAddressEditBox::RefreshAddress()
+{
+    CComPtr<IShellFolder> sf;
+    HRESULT hr;
+    CComHeapPtr<ITEMIDLIST> absolutePIDL;
+    LPCITEMIDLIST pidlChild;
+    STRRET ret;
+    WCHAR szName[4096], szPath[MAX_PATH];
+
+    if (pidlLastParsed)
+        ILFree(pidlLastParsed);
+    pidlLastParsed = NULL;
+
+    /* Get the current pidl of the browser */
+    hr = GetAbsolutePidl(&absolutePIDL);
+    if (FAILED(hr))
+        return hr;
+
+    if (!absolutePIDL)
+    {
+        ERR("Got no PIDL, investigate me!\n");
+        return S_OK;
+    }
+
+    /* Fill the combobox */
+    PopulateComboBox(absolutePIDL);
+
+    /* Find the current item in the combobox and select it */
+    CComPtr<IShellFolder> psfDesktop;
+    hr = SHGetDesktopFolder(&psfDesktop);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return S_OK;
+
+    hr = psfDesktop->GetDisplayNameOf(absolutePIDL, SHGDN_FORADDRESSBAR, &ret);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return S_OK;
+
+    hr = StrRetToBufW(&ret, absolutePIDL, szName, 4095);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return S_OK;
+
+    /* Add the item that will be visible when the combobox is not expanded */
+    hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    hr = sf->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    hr = StrRetToBufW(&ret, pidlChild, szName, _countof(szName));
+    if (FAILED_UNEXPECTEDLY(hr))
+        return hr;
+
+    /* Get image list indexes */
+    INT indexClosed, indexOpen;
+    indexClosed = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
+
+    /* Get ready to set the displayed item */
+    COMBOBOXEXITEMW item = { 0 };
+    item.mask = CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM;
+    item.iItem = -1; /* -1 to specify the displayed item */
+    item.iImage = indexClosed;
+    item.iSelectedImage = indexOpen;
+
+    /* Set the path if filesystem; otherwise use the name */
+    if (SHGetPathFromIDListW(absolutePIDL, szPath))
+        item.pszText = szPath;
+    else
+        item.pszText = szName;
+
+    /* Ownership of absolutePIDL will be moved to fCombobox. See CBEN_DELETEITEM */
+    item.lParam = reinterpret_cast<LPARAM>(absolutePIDL.Detach());
+
+    /* Set it! */
+    fCombobox.SendMessage(CBEM_SETITEM, 0, reinterpret_cast<LPARAM>(&item));
+
+    return S_OK;
+}
+
 HRESULT CAddressEditBox::GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL)
 {
     CComPtr<IBrowserService> isb;
@@ -133,7 +213,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     PathUnquoteSpacesW(pszCmdLine); /* Unquote the 1st parameter */
 
     /* Get ready for execution */
-    SHELLEXECUTEINFOW info = { sizeof(info), SEE_MASK_FLAG_NO_UI, m_hWnd };
+    SHELLEXECUTEINFOW info = { sizeof(info), SEE_MASK_FLAG_NO_UI | SEE_MASK_ASYNCOK, m_hWnd };
     info.lpFile = pszCmdLine;
     info.lpParameters = args;
     info.nShow = SW_SHOWNORMAL;
@@ -150,10 +230,7 @@ BOOL CAddressEditBox::ExecuteCommandLine()
     if (!::ShellExecuteExW(&info)) /* Execute! */
         return FALSE;
 
-    /* Execution succeeded. Reset the combobox. */
-    if (dir[0] != UNICODE_NULL)
-        fCombobox.SetWindowText(dir);
-
+    RefreshAddress();
     return TRUE;
 }
 
@@ -350,6 +427,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::OnWinEvent(
                 else if (endEdit->iWhy == CBENF_ESCAPE)
                 {
                     /* Reset the contents of the combo box */
+                    RefreshAddress();
                 }
             }
             else if (hdr->code == CBEN_DELETEITEM)
@@ -407,13 +485,6 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::GetIDsOfNames(
 HRESULT STDMETHODCALLTYPE CAddressEditBox::Invoke(DISPID dispIdMember, REFIID riid, LCID lcid,
     WORD wFlags, DISPPARAMS *pDispParams, VARIANT *pVarResult, EXCEPINFO *pExcepInfo, UINT *puArgErr)
 {
-    CComPtr<IShellFolder> sf;
-    HRESULT hr;
-    PIDLIST_ABSOLUTE absolutePIDL;
-    LPCITEMIDLIST pidlChild;
-    STRRET ret;
-    WCHAR buf[4096];
-
     if (pDispParams == NULL)
         return E_INVALIDARG;
 
@@ -421,67 +492,7 @@ HRESULT STDMETHODCALLTYPE CAddressEditBox::Invoke(DISPID dispIdMember, REFIID ri
     {
     case DISPID_NAVIGATECOMPLETE2:
     case DISPID_DOCUMENTCOMPLETE:
-
-        if (pidlLastParsed)
-            ILFree(pidlLastParsed);
-        pidlLastParsed = NULL;
-
-        /* Get the current pidl of the browser */
-        hr = GetAbsolutePidl(&absolutePIDL);
-        if (FAILED(hr))
-            return hr;
-
-        if (!absolutePIDL)
-        {
-            ERR("Got no PIDL, investigate me!\n");
-            return S_OK;
-        }
-
-        /* Fill the combobox */
-        PopulateComboBox(absolutePIDL);
-
-        /* Find the current item in the combobox and select it */
-        CComPtr<IShellFolder> psfDesktop;
-        hr = SHGetDesktopFolder(&psfDesktop);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return S_OK;
-
-        hr = psfDesktop->GetDisplayNameOf(absolutePIDL, SHGDN_FORADDRESSBAR, &ret);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return S_OK;
-
-        hr = StrRetToBufW(&ret, absolutePIDL, buf, 4095);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return S_OK;
-
-        int index = SendMessageW(hComboBoxEx, CB_FINDSTRINGEXACT, 0, (LPARAM)buf);
-        if (index != -1)
-            SendMessageW(hComboBoxEx, CB_SETCURSEL, index, 0);
-
-        /* Add the item that will be visible when the combobox is not expanded */
-        hr = SHBindToParent(absolutePIDL, IID_PPV_ARG(IShellFolder, &sf), &pidlChild);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return hr;
-
-        hr = sf->GetDisplayNameOf(pidlChild, SHGDN_FORADDRESSBAR | SHGDN_FORPARSING, &ret);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return hr;
-
-        hr = StrRetToBufW(&ret, pidlChild, buf, 4095);
-        if (FAILED_UNEXPECTEDLY(hr))
-            return hr;
-
-        INT indexClosed, indexOpen;
-        indexClosed = SHMapPIDLToSystemImageListIndex(sf, pidlChild, &indexOpen);
-
-        COMBOBOXEXITEMW item = {0};
-        item.mask = CBEIF_IMAGE | CBEIF_SELECTEDIMAGE | CBEIF_TEXT | CBEIF_LPARAM;
-        item.iItem = -1;
-        item.iImage = indexClosed;
-        item.iSelectedImage = indexOpen;
-        item.pszText = buf;
-        item.lParam = reinterpret_cast<LPARAM>(absolutePIDL);
-        fCombobox.SendMessage(CBEM_SETITEM, 0, reinterpret_cast<LPARAM>(&item));
+        RefreshAddress();
     }
     return S_OK;
 }

--- a/dll/win32/browseui/addresseditbox.h
+++ b/dll/win32/browseui/addresseditbox.h
@@ -51,6 +51,7 @@ private:
     HRESULT GetAbsolutePidl(PIDLIST_ABSOLUTE *pAbsolutePIDL);
     BOOL ExecuteCommandLine();
     BOOL GetComboBoxText(CComHeapPtr<WCHAR>& pszText);
+    HRESULT RefreshAddress();
 public:
     // *** IShellService methods ***
     virtual HRESULT STDMETHODCALLTYPE SetOwner(IUnknown *);


### PR DESCRIPTION
## Purpose

Follow-up of #5026 `[BROWSEUI] Execute command line from address bar`.
Elegantly reset the address bar after command line execution.

JIRA issue: [CORE-15453](https://jira.reactos.org/browse/CORE-15453)

## Proposed changes

- Move the code of `CAddressEditBox::Invoke` into newly-defined `CAddressEditBox::RefreshAddress` function.
- Use `CAddressEditBox::RefreshAddress`.

## TODO

- [x] Do tests