### PR TITLE
[MCIAVI32] Media Player: Don't open empty files

### DIFF
--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -401,6 +401,7 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 
     /* Empty file */
     if (alb.numVideoFrames == 0) {
+        WARN("NumVideoFrames: %u, Empty or possibly corrupt video file");
         return FALSE;
     }
 
@@ -619,8 +620,10 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
 
     if (wma->dwCurrVideoFrame != wma->dwCachedFrame)
     {
-        if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames)
+        if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames) {
+            ERR("Invalid frame requested. Current : %u Total Playable %u\n", wma->dwCurrVideoFrame, wma->dwPlayableVideoFrames);
             return 0;
+        }
 
         if (!wma->lpVideoIndex[wma->dwCurrVideoFrame].dwOffset)
 	    return 0;

--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -619,6 +619,9 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
 
     if (wma->dwCurrVideoFrame != wma->dwCachedFrame)
     {
+        if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames)
+            return 0;
+
         if (!wma->lpVideoIndex[wma->dwCurrVideoFrame].dwOffset)
 	    return 0;
 

--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -399,7 +399,7 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 	mmioAscend(wma->hFile, &mmckInfo, 0);
     }
 
-    /* Empty file*/
+    /* Empty file */
     if (alb.numVideoFrames == 0) {
         return FALSE;
     }

--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -398,6 +398,12 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 
 	mmioAscend(wma->hFile, &mmckInfo, 0);
     }
+
+    /* Empty file*/
+    if (alb.numVideoFrames == 0) {
+        return FALSE;
+    }
+
     if (alb.numVideoFrames != wma->dwPlayableVideoFrames) {
 	WARN("AVI header says %d frames, we found %d video frames, reducing playable frames\n",
 	     wma->dwPlayableVideoFrames, alb.numVideoFrames);


### PR DESCRIPTION
Opening Empty files in Mediaplayer leads to a crash
JIRA issue: [CORE-18669](https://jira.reactos.org/browse/CORE-18669)

