### PR TITLE
[MSHTML] Wine internet explorer print crash fix

### DIFF
--- a/dll/win32/mshtml/olecmd.c
+++ b/dll/win32/mshtml/olecmd.c
@@ -241,6 +241,13 @@ static HRESULT exec_print(HTMLDocument *This, DWORD nCmdexecopt, VARIANT *pvaIn,
         return S_OK;
     }
 
+#ifdef __REACTOS__
+    // returning here fixes CORE-16884. Maybe use this until printing works.
+    ERR("Aborting print, to work around CORE-16884\n");
+    nsIWebBrowserPrint_Release(nsprint);
+    return S_OK;
+#endif
+
     nsres = nsIWebBrowserPrint_GetGlobalPrintSettings(nsprint, &settings);
     if(NS_FAILED(nsres))
         ERR("GetCurrentPrintSettings failed: %08x\n", nsres);


### PR DESCRIPTION
## Purpose

When using wine internet explorer it crashes if you click print even if you click cancel, this fixes that issue.
nsIWebBrowserPrint_Print apparently causes issues for unknown reasons.

JIRA issue: [CORE-16884](https://jira.reactos.org/browse/CORE-16884)

## Proposed changes

By returning S_OK print doesn't cause a crash.

Use ERR and S_OK return before hitting nsIWebBrowserPrint_Print

Created to replace https://github.com/reactos/reactos/pull/4967 which seems to be abandoned.
