### PR TITLE
[NTUSER] Missing "X" on "Folder" pane when Right Click > Explore from Desktop icons & Rapps toolbar errors

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2101,7 +2101,11 @@ co_WinPosSetWindowPos(
 
       /* We need to redraw what wasn't visible before or force a redraw */
       if ((WinPos.flags & (SWP_FRAMECHANGED | SWP_SHOWWINDOW)) ||
-          (((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) && VisAfter != NULL))
+          ((((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) ||
+          /* This fixes CORE-18830 */
+          ((Window->style & (WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN)) ==
+          (WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN)))
+          && VisAfter != NULL))
       {
          PREGION DirtyRgn = IntSysCreateRectpRgn(0, 0, 0, 0);
          if (DirtyRgn)

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1979,7 +1979,7 @@ co_WinPosSetWindowPos(
       Window->state |= WNDS_SENDNCPAINT;
    }
 
-   if (!(WinPos.flags & SWP_NOREDRAW))
+   if (!(WinPos.flags & SWP_NOREDRAW) && ((WinPos.flags & SWP_AGG_STATUSFLAGS) != SWP_AGG_NOPOSCHANGE))
    {
       /* Determine the new visible region */
       VisAfter = VIS_ComputeVisibleRegion(Window, FALSE, FALSE,
@@ -2100,12 +2100,7 @@ co_WinPosSetWindowPos(
       }
 
       /* We need to redraw what wasn't visible before or force a redraw */
-      if ((WinPos.flags & (SWP_FRAMECHANGED | SWP_SHOWWINDOW)) ||
-          ((((WinPos.flags & SWP_AGG_NOGEOMETRYCHANGE) != SWP_AGG_NOGEOMETRYCHANGE) ||
-          /* This fixes CORE-18830 */
-          ((Window->style & (WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN)) ==
-          (WS_CHILD | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN)))
-          && VisAfter != NULL))
+      if (VisAfter != NULL)
       {
          PREGION DirtyRgn = IntSysCreateRectpRgn(0, 0, 0, 0);
          if (DirtyRgn)


### PR DESCRIPTION
## Purpose

_Fix for right-clicking on 'My Computer' and selecting 'explore' and there is no 'X' for the title bar in the Folders pane_
_Also fixes Rapps missing toolbar combo box and edit box controls that were not displayed._

JIRA issue: [CORE-18830](https://jira.reactos.org/browse/CORE-18830)
                  [CORE-18817](https://jira.reactos.org/browse/CORE-18817)

## Proposed changes

_This is a new patch from User I_Kill_Bugs as provided in https://jira.reactos.org/browse/CORE-18817_

This is a complete revert of https://github.com/reactos/reactos/pull/4995 and still retains its fixes.
