### PR TITLE
[IP] Allow 0xFFFF as Valid Network Port Number

### DIFF
--- a/drivers/network/tcpip/ip/transport/tcp/accept.c
+++ b/drivers/network/tcpip/ip/transport/tcp/accept.c
@@ -77,10 +77,10 @@ NTSTATUS TCPListen(PCONNECTION_ENDPOINT Connection, UINT Backlog)
             if (NT_SUCCESS(Status))
             {
                 /* Allocate the port in the port bitmap */
-                Connection->AddressFile->Port = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
-
-                /* This should never fail */
-                ASSERT(Connection->AddressFile->Port != 0xFFFF);
+                UINT AllocatedPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
+                /* This should never fail unless all ports are in use */
+                ASSERT(AllocatedPort != (UINT)-1);
+                Connection->AddressFile->Port = AllocatedPort;
             }
         }
     }

--- a/drivers/network/tcpip/ip/transport/tcp/accept.c
+++ b/drivers/network/tcpip/ip/transport/tcp/accept.c
@@ -81,7 +81,7 @@ NTSTATUS TCPListen(PCONNECTION_ENDPOINT Connection, UINT Backlog)
                 /* This should never fail unless all ports are in use */
                 if (AllocatedPort == (UINT) -1)
                 {
-                    ERR("No more ports available.\n");
+                    DbgPrint("ERR: No more ports available.\n");
                     return STATUS_TOO_MANY_ADDRESSES;
                 }
                 Connection->AddressFile->Port = AllocatedPort;

--- a/drivers/network/tcpip/ip/transport/tcp/accept.c
+++ b/drivers/network/tcpip/ip/transport/tcp/accept.c
@@ -79,7 +79,11 @@ NTSTATUS TCPListen(PCONNECTION_ENDPOINT Connection, UINT Backlog)
                 /* Allocate the port in the port bitmap */
                 UINT AllocatedPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
                 /* This should never fail unless all ports are in use */
-                ASSERT(AllocatedPort != (UINT)-1);
+                if (AllocatedPort == (UINT) -1)
+                {
+                    ERR("No more ports available.\n");
+                    return STATUS_TOO_MANY_ADDRESSES;
+                }
                 Connection->AddressFile->Port = AllocatedPort;
             }
         }

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -383,7 +383,11 @@ NTSTATUS TCPConnect
         /* Allocate the port in the port bitmap */
         AllocatedPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
         /* This should never fail unless all ports are in use */
-        ASSERT(AllocatedPort != (UINT)-1);
+        if (AllocatedPort == (UINT) -1)
+        {
+            ERR("No more ports available.\n");
+            return STATUS_TOO_MANY_ADDRESSES;
+        }
         Connection->AddressFile->Port = AllocatedPort;
     }
 

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -385,7 +385,7 @@ NTSTATUS TCPConnect
         /* This should never fail unless all ports are in use */
         if (AllocatedPort == (UINT) -1)
         {
-            ERR("No more ports available.\n");
+            DbgPrint("ERR: No more ports available.\n");
             return STATUS_TOO_MANY_ADDRESSES;
         }
         Connection->AddressFile->Port = AllocatedPort;

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -214,7 +214,7 @@ NTSTATUS TCPStartup(VOID)
 {
     NTSTATUS Status;
 
-    Status = PortsStartup( &TCPPorts, 1, 0xfffe );
+    Status = PortsStartup(&TCPPorts, 1, 0xffff);
     if (!NT_SUCCESS(Status))
     {
         return Status;
@@ -370,6 +370,8 @@ NTSTATUS TCPConnect
     /* Check if we had an unspecified port */
     if (!Connection->AddressFile->Port)
     {
+        UINT AllocatedPort;
+
         /* We did, so we need to copy back the port */
         Status = TCPGetSockAddress(Connection, (PTRANSPORT_ADDRESS)&LocalAddress, FALSE);
         if (!NT_SUCCESS(Status))
@@ -379,10 +381,10 @@ NTSTATUS TCPConnect
         }
 
         /* Allocate the port in the port bitmap */
-        Connection->AddressFile->Port = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
-
+        AllocatedPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
         /* This should never fail */
-        ASSERT(Connection->AddressFile->Port != 0xFFFF);
+        ASSERT(AllocatedPort != (UINT)-1);
+        Connection->AddressFile->Port = AllocatedPort;
     }
 
     connaddr.addr = RemoteAddress.Address.IPv4Address;

--- a/drivers/network/tcpip/ip/transport/tcp/tcp.c
+++ b/drivers/network/tcpip/ip/transport/tcp/tcp.c
@@ -382,7 +382,7 @@ NTSTATUS TCPConnect
 
         /* Allocate the port in the port bitmap */
         AllocatedPort = TCPAllocatePort(LocalAddress.Address[0].Address[0].sin_port);
-        /* This should never fail */
+        /* This should never fail unless all ports are in use */
         ASSERT(AllocatedPort != (UINT)-1);
         Connection->AddressFile->Port = AllocatedPort;
     }

--- a/drivers/network/tcpip/tcpip/fileobjs.c
+++ b/drivers/network/tcpip/tcpip/fileobjs.c
@@ -404,6 +404,7 @@ NTSTATUS FileOpenAddress(
   PVOID Options)
 {
   PADDRESS_FILE AddrFile;
+  UINT AllocatedPort;
 
   TI_DbgPrint(MID_TRACE, ("Called (Proto %d).\n", Protocol));
 
@@ -472,14 +473,15 @@ NTSTATUS FileOpenAddress(
       if (Address->Address[0].Address[0].sin_port)
       {
           /* The client specified an explicit port so we force a bind to this */
-          AddrFile->Port = TCPAllocatePort(Address->Address[0].Address[0].sin_port);
+          AllocatedPort = TCPAllocatePort(Address->Address[0].Address[0].sin_port);
 
           /* Check for bind success */
-          if (AddrFile->Port == 0xffff)
+          if (AllocatedPort == (UINT)-1)
           {
               ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
               return STATUS_ADDRESS_ALREADY_EXISTS;
           }
+          AddrFile->Port = AllocatedPort;
 
           /* Sanity check */
           ASSERT(Address->Address[0].Address[0].sin_port == AddrFile->Port);
@@ -487,14 +489,15 @@ NTSTATUS FileOpenAddress(
       else if (!AddrIsUnspecified(&AddrFile->Address))
       {
           /* The client is trying to bind to a local address so allocate a port now too */
-          AddrFile->Port = TCPAllocatePort(0);
+          AllocatedPort = TCPAllocatePort(0);
 
           /* Check for bind success */
-          if (AddrFile->Port == 0xffff)
+          if (AllocatedPort == (UINT)-1)
           {
               ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
               return STATUS_ADDRESS_ALREADY_EXISTS;
           }
+          AddrFile->Port = AllocatedPort;
       }
       else
       {
@@ -509,16 +512,16 @@ NTSTATUS FileOpenAddress(
 
   case IPPROTO_UDP:
       TI_DbgPrint(MID_TRACE,("Allocating udp port\n"));
-      AddrFile->Port =
-	  UDPAllocatePort(Address->Address[0].Address[0].sin_port);
+      AllocatedPort = UDPAllocatePort(Address->Address[0].Address[0].sin_port);
 
       if ((Address->Address[0].Address[0].sin_port &&
-           AddrFile->Port != Address->Address[0].Address[0].sin_port) ||
-           AddrFile->Port == 0xffff)
+           AllocatedPort != Address->Address[0].Address[0].sin_port) ||
+           AllocatedPort == (UINT)-1)
       {
           ExFreePoolWithTag(AddrFile, ADDR_FILE_TAG);
           return STATUS_ADDRESS_ALREADY_EXISTS;
       }
+      AddrFile->Port = AllocatedPort;
 
       TI_DbgPrint(MID_TRACE,("Setting port %d (wanted %d)\n",
                              AddrFile->Port,


### PR DESCRIPTION
## Purpose

Do not declare 0XFFFF as invalid in ReactOS. Applications should be able to use 0XFFFF as it is valid. Thanks to @KRosUser for detailed analysis.

JIRA issue:
[CORE-18371](https://jira.reactos.org/browse/CORE-18371)
[CORE-18764](https://jira.reactos.org/browse/CORE-18764)

## Proposed changes

The proposed fix is similar to what is already implemented in ReactOS for existing TCPAlloc failure in [FileOpenAddress](https://git.reactos.org/?p=reactos.git;a=blob;f=drivers/network/tcpip/tcpip/fileobjs.c#l475)

This PR replaces https://github.com/reactos/reactos/pull/4968 for which the creator has been inactive for over a month.