### PR TITLE
[NTUSER] Send WM_IME_SYSTEM:IMS_UPDATEIMEUI

### DIFF
--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3135,7 +3135,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         {
             continue;
         }
-        /* Now pwnd is an IME window or an IME UI window of the current thread */
+        /* Now pwnd is an IME window of the current thread */
 
         /* Get hImeWnd from pwnd */
         _SEH2_TRY
@@ -3155,7 +3155,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         if (!hImeWnd)
             continue;
 
-        /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME window / the IME UI window  */
+        /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME window */
         UserReferenceObject(pwnd);
         for (pwndNode = ValidateHwndNoErr(hImeWnd);
              pwndNode && pwndNode != pwndDesktop;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3107,7 +3107,7 @@ END:
 
 static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
 {
-    PWND pwnd, pwndDesktop;
+    PWND pwnd, pwndDesktop, pwndImeFocus;
     PWINDOWLIST pWL;
     HWND hwnd, *phwnd, hwndImeFocus;
     PIMEWND pImeWnd;
@@ -3157,12 +3157,12 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         _SEH2_END;
 
         /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME focus window */
-        pwnd = ValidateHwndNoErr(hwndImeFocus);
-        if (pwnd)
+        pwndImeFocus = ValidateHwndNoErr(hwndImeFocus);
+        if (pwndImeFocus)
         {
-            UserReferenceObject(pwnd);
+            UserReferenceObject(pwndImeFocus);
             co_IntSendMessage(hwndImeFocus, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
-            UserDereferenceObject(pwnd);
+            UserDereferenceObject(pwndImeFocus);
         }
     }
 

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1765,7 +1765,7 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
         if (gptiCurrent->TIF_flags & TIF_INCLEANUP)
             break;
 
-        pwndNode = ValidateHwndNoErr(hwndNode);
+        pwndNode = ValidateHwndNoErr(*phwnd);
         if (pwndNode == NULL ||
             pwndNode->head.pti != gptiCurrent ||
             pwndNode->pcls->atomClassName != gpsi->atomSysClass[ICLS_IME])

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3157,7 +3157,6 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         _SEH2_END;
 
         /* Scan hwndImeFocus and its ancestors */
-        UserReferenceObject(pwnd);
         for (pwndNode = ValidateHwndNoErr(hwndImeFocus);
              pwndNode && pwndNode != pwndDesktop;
              pwndNode = pwndNode->spwndParent)
@@ -3181,7 +3180,6 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
             if (icvr < ccvr)
                 break; /* Found a position change and the task is done, so get out of here */
         }
-        UserDereferenceObject(pwnd);
     }
 
     IntFreeHwndList(pWL);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3137,7 +3137,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         }
         /* Now pwnd is an IME window of the current thread */
 
-        /* Get hwndIMC from pwnd */
+        /* Get the IME focus window from pwnd */
         _SEH2_TRY
         {
             ProbeForRead(pwnd, sizeof(IMEWND), 1);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3105,7 +3105,6 @@ END:
     return retvalue;
 }
 
-/* Win: xxxImeWindowPosChanged */
 static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
 {
     PWND pwnd, pwndDesktop, pwndNode;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3164,13 +3164,13 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         {
             /* Find whether the pwndNode is changed its position */
             HWND hwndNode = UserHMGetHandle(pwndNode);
-            PCVR pcvr = psmwp->acvr;
+            PCVR winpos = psmwp->acvr;
             INT icvr, ccvr = psmwp->ccvr;
-            for (icvr = 0; icvr < ccvr; ++icvr, ++pcvr)
+            for (icvr = 0; icvr < ccvr; ++icvr, ++winpos)
             {
-                if (hwndNode != pcvr->pos.hwnd)
+                if (hwndNode != winpos->pos.hwnd)
                     continue; /* Not matched */
-                if ((pcvr->pos.flags & (SWP_NOSIZE | SWP_NOMOVE)) == (SWP_NOSIZE | SWP_NOMOVE))
+                if ((winpos->pos.flags & (SWP_NOSIZE | SWP_NOMOVE)) == (SWP_NOSIZE | SWP_NOMOVE))
                     continue; /* No change */
 
                 /* Now found a position change of hwndImeFocus or its ancestor.
@@ -3179,7 +3179,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
                 break;
             }
             if (icvr < ccvr)
-                break; /* Found a position change, so get out of here */
+                break; /* Found a position change and the task is done, so get out of here */
         }
         UserDereferenceObject(pwnd);
     }

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3152,7 +3152,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            FIXME("Exception! 0x%08X\n", _SEH2_GetExceptionCode());
+            ERR("Exception! 0x%08X\n", _SEH2_GetExceptionCode());
             hwndImeFocus = NULL;
         }
         _SEH2_END;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1770,8 +1770,8 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
         {
             continue;
         }
-        /* Now hwndNode is an IME window of the current thread */
 
+        /* Now hwndNode is an IME window of the current thread */
         UserRefObjectCo(pwndNode, &Ref);
         co_IntSendMessage(hwndNode, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
         UserDerefObjectCo(pwndNode);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3108,7 +3108,6 @@ END:
 static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
 {
     PWND pwnd, pwndDesktop, pwndNode;
-    PTHREADINFO pti;
     PWINDOWLIST pWL;
     HWND hwnd, hImeWnd, *phwnd;
     PIMEWND pImeWnd;
@@ -3118,8 +3117,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
     if (!pwndDesktop)
         return;
 
-    pti = gptiCurrent;
-    pWL = IntBuildHwndList(pwndDesktop->spwndChild, IACE_LIST, pti);
+    pWL = IntBuildHwndList(pwndDesktop->spwndChild, IACE_LIST, gptiCurrent);
     if (!pWL)
         return;
 
@@ -3127,12 +3125,12 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
     phwnd = pWL->ahwnd;
     for (hwnd = *phwnd; hwnd != HWND_TERMINATOR; hwnd = *phwnd++)
     {
-        if (pti->TIF_flags & TIF_INCLEANUP)
+        if (gptiCurrent->TIF_flags & TIF_INCLEANUP)
             break;
 
         pwnd = ValidateHwndNoErr(hwnd);
         if (!pwnd ||
-            pwnd->head.pti != pti ||
+            pwnd->head.pti != gptiCurrent ||
             pwnd->pcls->atomClassName != gpsi->atomSysClass[ICLS_IME])
         {
             continue;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1747,7 +1747,7 @@ ForceNCPaintErase(PWND Wnd, HRGN hRgn, PREGION pRgn)
 
 static VOID FASTCALL IntImeWindowPosChanged(VOID)
 {
-    HWND hwndNode, *phwnd;
+    HWND *phwnd;
     PWND pwndNode, pwndDesktop = UserGetDesktopWindow();
     PWINDOWLIST pWL;
     USER_REFERENCE_ENTRY Ref;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3160,6 +3160,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         pwndImeFocus = ValidateHwndNoErr(hwndImeFocus);
         if (pwndImeFocus)
         {
+            /* FIXME: Use psmwp to check if the position is changed */
             UserReferenceObject(pwndImeFocus);
             co_IntSendMessage(hwndImeFocus, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
             UserDereferenceObject(pwndImeFocus);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3152,7 +3152,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            FIXME("Exception!\n");
+            FIXME("Exception! 0x%08X\n", _SEH2_GetExceptionCode());
             hwndImeFocus = NULL;
         }
         _SEH2_END;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3152,6 +3152,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
+            ERR("Exception!\n");
             hwndImeFocus = NULL;
         }
         _SEH2_END;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1750,6 +1750,7 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
     HWND hwndNode, *phwnd;
     PWND pwndNode, pwndDesktop = UserGetDesktopWindow();
     PWINDOWLIST pWL;
+    USER_REFERENCE_ENTRY Ref;
 
     if (!pwndDesktop)
         return;
@@ -1769,9 +1770,11 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
         {
             continue;
         }
-
         /* Now hwndNode is an IME window of the current thread */
+
+        UserRefObjectCo(pwndNode, &Ref);
         co_IntSendMessage(hwndNode, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
+        UserDerefObjectCo(pwndNode);
     }
 
     IntFreeHwndList(pWL);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3109,7 +3109,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
 {
     PWND pwnd, pwndDesktop;
     PWINDOWLIST pWL;
-    HWND hwnd, *phwnd, hwndFocus;
+    HWND hwnd, *phwnd, hwndImeFocus;
     PIMEWND pImeWnd;
     PIMEUI pimeui;
 
@@ -3145,19 +3145,19 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
             pimeui = pImeWnd->pimeui;
 
             ProbeForRead(pimeui, sizeof(IMEUI), 1);
-            hwndFocus = pimeui->hwndIMC;
+            hwndImeFocus = pimeui->hwndIMC;
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            hwndFocus = NULL;
+            hwndImeFocus = NULL;
         }
         _SEH2_END;
 
-        if (!hwndFocus)
+        if (!hwndImeFocus)
             continue;
 
-        /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the focus window */
-        pwnd = ValidateHwndNoErr(hwndFocus);
+        /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME focus window */
+        pwnd = ValidateHwndNoErr(hwndImeFocus);
         if (pwnd)
         {
             UserReferenceObject(pwnd);

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1775,7 +1775,7 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
 
         /* Now hwndNode is an IME window of the current thread */
         UserRefObjectCo(pwndNode, &Ref);
-        co_IntSendMessage(hwndNode, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
+        co_IntSendMessage(*phwnd, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
         UserDerefObjectCo(pwndNode);
     }
 

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3162,7 +3162,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
              pwndNode && pwndNode != pwndDesktop;
              pwndNode = pwndNode->spwndParent)
         {
-            /* Find whether the pwndNode is changed its position */
+            /* Check whether pwndNode is changed its position */
             HWND hwndNode = UserHMGetHandle(pwndNode);
             PCVR winpos = psmwp->acvr;
             INT icvr, ccvr = psmwp->ccvr;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3173,13 +3173,13 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
                 if ((pcvr->pos.flags & (SWP_NOSIZE | SWP_NOMOVE)) == (SWP_NOSIZE | SWP_NOMOVE))
                     continue; /* No change */
 
-                /* Now found position change of hwndImeFocus or its ancestor.
+                /* Now found a position change of hwndImeFocus or its ancestor.
                    Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME window */
                 co_IntSendMessage(hwnd, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
                 break;
             }
             if (icvr < ccvr)
-                break; /* Found position change, so get out of here */
+                break; /* Found a position change, so get out of here */
         }
         UserDereferenceObject(pwnd);
     }

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -2337,7 +2337,7 @@ co_WinPosSetWindowPos(
          IntNotifyWinEvent(EVENT_OBJECT_LOCATIONCHANGE, pWnd, OBJID_WINDOW, CHILDID_SELF, WEF_SETBYWNDPTI);
    }
 
-   /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI if necessary */
+   /* Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME windows if necessary */
    if ((WinPos.flags & (SWP_NOMOVE | SWP_NOSIZE)) != (SWP_NOMOVE | SWP_NOSIZE))
    {
       if (IS_IMM_MODE())

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1760,8 +1760,7 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
     if (!pWL)
         return;
 
-    phwnd = pWL->ahwnd;
-    for (hwndNode = *phwnd; hwndNode != HWND_TERMINATOR; hwndNode = *phwnd++)
+    for (phwnd = pWL->ahwnd; *phwnd != HWND_TERMINATOR; ++phwnd)
     {
         if (gptiCurrent->TIF_flags & TIF_INCLEANUP)
             break;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -1763,6 +1763,9 @@ static VOID FASTCALL IntImeWindowPosChanged(VOID)
     phwnd = pWL->ahwnd;
     for (hwndNode = *phwnd; hwndNode != HWND_TERMINATOR; hwndNode = *phwnd++)
     {
+        if (gptiCurrent->TIF_flags & TIF_INCLEANUP)
+            break;
+
         pwndNode = ValidateHwndNoErr(hwndNode);
         if (pwndNode == NULL ||
             pwndNode->head.pti != gptiCurrent ||

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3152,7 +3152,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
         }
         _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
         {
-            ERR("Exception!\n");
+            FIXME("Exception!\n");
             hwndImeFocus = NULL;
         }
         _SEH2_END;

--- a/win32ss/user/ntuser/winpos.c
+++ b/win32ss/user/ntuser/winpos.c
@@ -3175,7 +3175,7 @@ static VOID FASTCALL IntImeWindowPosChanged(PSMWP psmwp)
 
                 /* Now found position change of hwndImeFocus or its ancestor.
                    Send WM_IME_SYSTEM:IMS_UPDATEIMEUI to the IME window */
-                co_IntSendMessage(UserHMGetHandle(pwnd), WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
+                co_IntSendMessage(hwnd, WM_IME_SYSTEM, IMS_UPDATEIMEUI, 0);
                 break;
             }
             if (icvr < ccvr)


### PR DESCRIPTION
## Purpose
Send `WM_IME_SYSTEM:IMS_UPDATEIMEUI` message after window position change to improve IME UI sync.

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-15289](https://jira.reactos.org/browse/CORE-15289)

- `WM_IME_SYSTEM == 0x287`.
- `IMS_UPDATEIMEUI == 0x6`.

## Proposed changes

- Add `IntImeWindowPosChanged` helper function.
- Use `IntImeWindowPosChanged` on IMM mode after window position change.

## TODO

- [x] Fix exception.
- [x] Do big tests.

## Screenshots

WinXP Japanese:
![VirtualBox_Windows XP_18_02_2023_11_46_13](https://user-images.githubusercontent.com/2107452/219827782-ac633082-03d5-46c9-a499-a2e2222ce644.png)
`WM_IME_SYSTEM:IMS_UPDATEIMEUI` is correctly sent to the Default IME window of Notepad on moving the main window (`WM_647 == WM_IME_SYSTEM`).

Win10 x64 Japanse:
![image](https://user-images.githubusercontent.com/2107452/219827977-d73ad03e-50c9-432e-bf9c-d1010d53c0bf.png)
`WM_IME_SYSTEM:IMS_UPDATEIMEUI` is correctly sent to the Default IME window of Notepad on moving the main window.

Win2k3 English:
![win2k3](https://user-images.githubusercontent.com/2107452/219830550-1e94fd48-5a5a-4330-89d4-c0072e755d39.png)
`WM_IME_SYSTEM:IMS_UPDATEIMEUI` is correctly sent to the Default IME window of Notepad on moving the main window.
