### PR TITLE
[NOTEPAD] Fix and simplify Status Bar handling

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -911,10 +911,10 @@ VOID DIALOG_EditTimeDate(VOID)
     SendMessage(Globals.hEdit, EM_REPLACESEL, TRUE, (LPARAM)szText);
 }
 
-VOID DoShowStatusBar(BOOL bShow)
+VOID DoShowHideStatusBar(VOID)
 {
     /* Check if status bar object already exists. */
-    if (bShow && Globals.hStatusBar == NULL)
+    if (Globals.bShowStatusBar && Globals.hStatusBar == NULL)
     {
         /* Try to create the status bar */
         Globals.hStatusBar = CreateStatusWindow(WS_CHILD | CCS_BOTTOM | SBARS_SIZEGRIP,
@@ -933,8 +933,7 @@ VOID DoShowStatusBar(BOOL bShow)
     }
 
     /* Update visibility of status bar */
-    ShowWindowAsync(Globals.hStatusBar, (bShow ? SW_SHOWNOACTIVATE : SW_HIDE));
-    Globals.bShowStatusBar = bShow;
+    ShowWindowAsync(Globals.hStatusBar, (Globals.bShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
 
     /* Update layout of controls */
     PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
@@ -1055,7 +1054,7 @@ VOID DIALOG_EditWrap(VOID)
         EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_ENABLED);
 
     DoCreateEditWindow();
-    DoShowStatusBar(Globals.bShowStatusBar);
+    DoShowHideStatusBar();
 }
 
 VOID DIALOG_SelectFont(VOID)
@@ -1220,7 +1219,8 @@ VOID DIALOG_StatusBarUpdateCaretPos(VOID)
 
 VOID DIALOG_ViewStatusBar(VOID)
 {
-    DoShowStatusBar(!Globals.bShowStatusBar);
+    Globals.bShowStatusBar = !Globals.bShowStatusBar;
+    DoShowHideStatusBar();
 }
 
 VOID DIALOG_HelpContents(VOID)

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -938,9 +938,6 @@ VOID DoShowHideStatusBar(VOID)
     /* Update layout of controls */
     PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
 
-    /* Update menu mar with the previous changes */
-    DrawMenuBar(Globals.hMainWnd);
-
     /* Set the status bar for multiple-text output */
     DIALOG_StatusBarAlignParts();
 

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -1048,10 +1048,7 @@ VOID DIALOG_EditWrap(VOID)
 {
     Globals.bWrapLongLines = !Globals.bWrapLongLines;
 
-    if (Globals.bWrapLongLines)
-        EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_GRAYED);
-    else
-        EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_ENABLED);
+    EnableMenuItem(Globals.hMenu, CMD_GOTO, (Globals.bWrapLongLines ? MF_GRAYED : MF_ENABLED));
 
     DoCreateEditWindow();
     DoShowHideStatusBar();

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -990,9 +990,6 @@ VOID DoCreateEditWindow(VOID)
     /* Update wrap status into the main menu and recover style flags */
     dwStyle = (Globals.bWrapLongLines ? EDIT_STYLE_WRAP : EDIT_STYLE);
 
-    /* Update previous changes */
-    DrawMenuBar(Globals.hMainWnd);
-
     /* Create the new edit control */
     Globals.hEdit = CreateWindowEx(WS_EX_CLIENTEDGE,
                                    EDIT_CLASS,
@@ -1006,7 +1003,6 @@ VOID DoCreateEditWindow(VOID)
                                    NULL,
                                    Globals.hInstance,
                                    NULL);
-
     if (Globals.hEdit == NULL)
     {
         if (pTemp)
@@ -1039,6 +1035,9 @@ VOID DoCreateEditWindow(VOID)
     /* Finally shows new edit control and set focus into it. */
     ShowWindow(Globals.hEdit, SW_SHOW);
     SetFocus(Globals.hEdit);
+
+    /* Re-arrange controls */
+    PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
 }
 
 VOID DIALOG_EditWrap(VOID)

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -938,12 +938,9 @@ VOID DoShowHideStatusBar(VOID)
     /* Update layout of controls */
     PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
 
-    /* Set the status bar for multiple-text output */
-    DIALOG_StatusBarAlignParts();
-
     /* Update content with current row/column text */
     DIALOG_StatusBarUpdateCaretPos();
-    
+
     /* Update line endings and encoding on the status bar */
     DIALOG_StatusBarUpdateLineEndings();
     DIALOG_StatusBarUpdateEncoding();

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -939,7 +939,7 @@ VOID DoShowHideStatusBar(VOID)
         return;
 
     /* Update visibility of status bar */
-    ShowWindowAsync(Globals.hStatusBar, (Globals.bShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
+    ShowWindow(Globals.hStatusBar, (Globals.bShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
 
     /* Update status bar contents */
     DIALOG_StatusBarUpdateCaretPos();

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -992,10 +992,7 @@ VOID DoCreateEditWindow(VOID)
     }
 
     /* Update wrap status into the main menu and recover style flags */
-    if (Globals.bWrapLongLines)
-        dwStyle = EDIT_STYLE_WRAP;
-    else
-        dwStyle = EDIT_STYLE;
+    dwStyle = (Globals.bWrapLongLines ? EDIT_STYLE_WRAP : EDIT_STYLE);
 
     /* Update previous changes */
     DrawMenuBar(Globals.hMainWnd);
@@ -1053,13 +1050,9 @@ VOID DIALOG_EditWrap(VOID)
     Globals.bWrapLongLines = !Globals.bWrapLongLines;
 
     if (Globals.bWrapLongLines)
-    {
-        EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_DISABLED | MF_GRAYED);
-    }
+        EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_GRAYED);
     else
-    {
         EnableMenuItem(Globals.hMenu, CMD_GOTO, MF_BYCOMMAND | MF_ENABLED);
-    }
 
     DoCreateEditWindow();
     DoShowStatusBar(Globals.bShowStatusBar);

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -932,16 +932,17 @@ VOID DoShowHideStatusBar(VOID)
         LoadString(Globals.hInstance, STRING_LINE_COLUMN, Globals.szStatusBarLineCol, MAX_PATH - 1);
     }
 
-    /* Update visibility of status bar */
-    ShowWindowAsync(Globals.hStatusBar, (Globals.bShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
-
     /* Update layout of controls */
     PostMessageW(Globals.hMainWnd, WM_SIZE, 0, 0);
 
-    /* Update content with current row/column text */
-    DIALOG_StatusBarUpdateCaretPos();
+    if (Globals.hStatusBar == NULL)
+        return;
 
-    /* Update line endings and encoding on the status bar */
+    /* Update visibility of status bar */
+    ShowWindowAsync(Globals.hStatusBar, (Globals.bShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
+
+    /* Update status bar contents */
+    DIALOG_StatusBarUpdateCaretPos();
     DIALOG_StatusBarUpdateLineEndings();
     DIALOG_StatusBarUpdateEncoding();
 }

--- a/base/applications/notepad/dialog.h
+++ b/base/applications/notepad/dialog.h
@@ -67,5 +67,5 @@ BOOL FileExists(LPCTSTR szFilename);
 BOOL HasFileExtension(LPCTSTR szFilename);
 BOOL DoCloseFile(VOID);
 VOID DoOpenFile(LPCTSTR szFileName);
-VOID DoShowStatusBar(BOOL bShow);
+VOID DoShowHideStatusBar(VOID);
 VOID DoCreateEditWindow(VOID);

--- a/base/applications/notepad/dialog.h
+++ b/base/applications/notepad/dialog.h
@@ -67,5 +67,5 @@ BOOL FileExists(LPCTSTR szFilename);
 BOOL HasFileExtension(LPCTSTR szFilename);
 BOOL DoCloseFile(VOID);
 VOID DoOpenFile(LPCTSTR szFileName);
-VOID DoCreateStatusBar(VOID);
+VOID DoShowStatusBar(BOOL bShow);
 VOID DoCreateEditWindow(VOID);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -641,8 +641,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     UpdateWindow(Globals.hMainWnd);
     DragAcceptFiles(Globals.hMainWnd, TRUE);
 
-    DIALOG_ViewStatusBar();
-
     if (!HandleCommandLine(cmdline))
     {
         return 0;

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -436,10 +436,11 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         DoOpenFile(szFileName);
         break;
     }
-    case WM_CHAR:
+
     case WM_INITMENUPOPUP:
         NOTEPAD_InitMenuPopup((HMENU)wParam, lParam);
         break;
+
     default:
         if (msg == aFINDMSGSTRING)
         {

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -279,33 +279,31 @@ static VOID NOTEPAD_InitData(VOID)
 /***********************************************************************
  * Enable/disable items on the menu based on control state
  */
-static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
+static VOID NOTEPAD_InitMenuPopup(HMENU hMenu, LPARAM index)
 {
-    int enable;
+    DWORD dwRange;
+    UINT uEnable;
+    BOOL bCanUndo, bCanPaste, bCanSelectAll;
 
     UNREFERENCED_PARAMETER(index);
 
-    CheckMenuItem(menu, CMD_WRAP,
-        MF_BYCOMMAND | (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
+    CheckMenuItem(hMenu, CMD_WRAP, (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
+    CheckMenuItem(hMenu, CMD_STATUSBAR, (Globals.bShowStatusBar ? MF_CHECKED : MF_UNCHECKED));
 
-    if (Globals.bShowStatusBar)
-        CheckMenuItem(menu, CMD_STATUSBAR, MF_BYCOMMAND | MF_CHECKED);
-    else
-        CheckMenuItem(menu, CMD_STATUSBAR, MF_BYCOMMAND | MF_UNCHECKED);
+    bCanUndo = (BOOL)SendMessageW(Globals.hEdit, EM_CANUNDO, 0, 0);
+    EnableMenuItem(hMenu, CMD_UNDO, (bCanUndo ? MF_ENABLED : MF_GRAYED));
 
-    EnableMenuItem(menu, CMD_UNDO,
-        SendMessage(Globals.hEdit, EM_CANUNDO, 0, 0) ? MF_ENABLED : MF_GRAYED);
-    EnableMenuItem(menu, CMD_PASTE,
-        IsClipboardFormatAvailable(CF_TEXT) ? MF_ENABLED : MF_GRAYED);
-    enable = (int) SendMessage(Globals.hEdit, EM_GETSEL, 0, 0);
-    enable = (HIWORD(enable) == LOWORD(enable)) ? MF_GRAYED : MF_ENABLED;
-    EnableMenuItem(menu, CMD_CUT, enable);
-    EnableMenuItem(menu, CMD_COPY, enable);
-    EnableMenuItem(menu, CMD_DELETE, enable);
-    EnableMenuItem(menu, CMD_SELECT_ALL,
-        GetWindowTextLength(Globals.hEdit) ? MF_ENABLED : MF_GRAYED);
+    bCanPaste = IsClipboardFormatAvailable(CF_TEXT);
+    EnableMenuItem(hMenu, CMD_PASTE, (bCanPaste ? MF_ENABLED : MF_GRAYED));
 
-    DrawMenuBar(Globals.hMainWnd);
+    dwRange = (DWORD)SendMessageW(Globals.hEdit, EM_GETSEL, 0, 0);
+    uEnable = (HIWORD(dwRange) == LOWORD(dwRange)) ? MF_GRAYED : MF_ENABLED;
+    EnableMenuItem(hMenu, CMD_CUT, uEnable);
+    EnableMenuItem(hMenu, CMD_COPY, uEnable);
+    EnableMenuItem(hMenu, CMD_DELETE, uEnable);
+
+    bCanSelectAll = (GetWindowTextLengthW(Globals.hEdit) != 0);
+    EnableMenuItem(hMenu, CMD_SELECT_ALL, (bCanSelectAll ? MF_ENABLED : MF_GRAYED));
 }
 
 LRESULT CALLBACK EDIT_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -635,7 +635,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     }
 
     DoCreateEditWindow();
-    DoShowStatusBar(Globals.bShowStatusBar);
+    DoShowHideStatusBar();
 
     NOTEPAD_InitData();
     DIALOG_FileNew();

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -279,31 +279,26 @@ static VOID NOTEPAD_InitData(VOID)
 /***********************************************************************
  * Enable/disable items on the menu based on control state
  */
-static VOID NOTEPAD_InitMenuPopup(HMENU hMenu, LPARAM index)
+static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
 {
-    DWORD dwRange;
-    UINT uEnable;
-    BOOL bCanUndo, bCanPaste, bCanSelectAll;
+    int enable;
 
     UNREFERENCED_PARAMETER(index);
 
-    CheckMenuItem(hMenu, CMD_WRAP, (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
-    CheckMenuItem(hMenu, CMD_STATUSBAR, (Globals.bShowStatusBar ? MF_CHECKED : MF_UNCHECKED));
+    CheckMenuItem(menu, CMD_WRAP, (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
+    CheckMenuItem(menu, CMD_STATUSBAR, (Globals.bShowStatusBar ? MF_CHECKED : MF_UNCHECKED));
+    EnableMenuItem(menu, CMD_UNDO,
+        SendMessage(Globals.hEdit, EM_CANUNDO, 0, 0) ? MF_ENABLED : MF_GRAYED);
+    EnableMenuItem(menu, CMD_PASTE,
+        IsClipboardFormatAvailable(CF_TEXT) ? MF_ENABLED : MF_GRAYED);
+    enable = (int) SendMessage(Globals.hEdit, EM_GETSEL, 0, 0);
+    enable = (HIWORD(enable) == LOWORD(enable)) ? MF_GRAYED : MF_ENABLED;
+    EnableMenuItem(menu, CMD_CUT, enable);
+    EnableMenuItem(menu, CMD_COPY, enable);
+    EnableMenuItem(menu, CMD_DELETE, enable);
 
-    bCanUndo = (BOOL)SendMessageW(Globals.hEdit, EM_CANUNDO, 0, 0);
-    EnableMenuItem(hMenu, CMD_UNDO, (bCanUndo ? MF_ENABLED : MF_GRAYED));
-
-    bCanPaste = IsClipboardFormatAvailable(CF_TEXT);
-    EnableMenuItem(hMenu, CMD_PASTE, (bCanPaste ? MF_ENABLED : MF_GRAYED));
-
-    dwRange = (DWORD)SendMessageW(Globals.hEdit, EM_GETSEL, 0, 0);
-    uEnable = (HIWORD(dwRange) == LOWORD(dwRange)) ? MF_GRAYED : MF_ENABLED;
-    EnableMenuItem(hMenu, CMD_CUT, uEnable);
-    EnableMenuItem(hMenu, CMD_COPY, uEnable);
-    EnableMenuItem(hMenu, CMD_DELETE, uEnable);
-
-    bCanSelectAll = (GetWindowTextLengthW(Globals.hEdit) != 0);
-    EnableMenuItem(hMenu, CMD_SELECT_ALL, (bCanSelectAll ? MF_ENABLED : MF_GRAYED));
+    EnableMenuItem(menu, CMD_SELECT_ALL,
+        GetWindowTextLength(Globals.hEdit) ? MF_ENABLED : MF_GRAYED);
 }
 
 LRESULT CALLBACK EDIT_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -285,13 +285,13 @@ static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
 
     UNREFERENCED_PARAMETER(index);
 
-    CheckMenuItem(GetMenu(Globals.hMainWnd), CMD_WRAP,
+    CheckMenuItem(menu, CMD_WRAP,
         MF_BYCOMMAND | (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
 
     if (Globals.bShowStatusBar)
-        CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_CHECKED);
+        CheckMenuItem(menu, CMD_STATUSBAR, MF_BYCOMMAND | MF_CHECKED);
     else
-        CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_UNCHECKED);
+        CheckMenuItem(menu, CMD_STATUSBAR, MF_BYCOMMAND | MF_UNCHECKED);
 
     EnableMenuItem(menu, CMD_UNDO,
         SendMessage(Globals.hEdit, EM_CANUNDO, 0, 0) ? MF_ENABLED : MF_GRAYED);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -288,7 +288,7 @@ static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
     CheckMenuItem(GetMenu(Globals.hMainWnd), CMD_WRAP,
         MF_BYCOMMAND | (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
 
-    if (IsWindowVisible(Globals.hStatusBar))
+    if (Globals.bShowStatusBar)
         CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_CHECKED);
     else
         CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_UNCHECKED);
@@ -408,8 +408,11 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
         MoveWindow(Globals.hEdit, 0, 0, rc.right, rc.bottom, TRUE);
 
-        /* Align status bar parts, only if the status bar resize operation succeeds */
-        DIALOG_StatusBarAlignParts();
+        if (Globals.bShowStatusBar)
+        {
+            /* Align status bar parts, only if the status bar resize operation succeeds */
+            DIALOG_StatusBarAlignParts();
+        }
         break;
     }
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -287,11 +287,12 @@ static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
 
     CheckMenuItem(GetMenu(Globals.hMainWnd), CMD_WRAP,
         MF_BYCOMMAND | (Globals.bWrapLongLines ? MF_CHECKED : MF_UNCHECKED));
-    if (!Globals.bWrapLongLines)
-    {
-        CheckMenuItem(GetMenu(Globals.hMainWnd), CMD_STATUSBAR,
-            MF_BYCOMMAND | (Globals.bShowStatusBar ? MF_CHECKED : MF_UNCHECKED));
-    }
+
+    if (IsWindowVisible(Globals.hStatusBar))
+        CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_CHECKED);
+    else
+        CheckMenuItem(Globals.hMenu, CMD_STATUSBAR, MF_BYCOMMAND | MF_UNCHECKED);
+
     EnableMenuItem(menu, CMD_UNDO,
         SendMessage(Globals.hEdit, EM_CANUNDO, 0, 0) ? MF_ENABLED : MF_GRAYED);
     EnableMenuItem(menu, CMD_PASTE,
@@ -301,9 +302,9 @@ static VOID NOTEPAD_InitMenuPopup(HMENU menu, LPARAM index)
     EnableMenuItem(menu, CMD_CUT, enable);
     EnableMenuItem(menu, CMD_COPY, enable);
     EnableMenuItem(menu, CMD_DELETE, enable);
-
     EnableMenuItem(menu, CMD_SELECT_ALL,
         GetWindowTextLength(Globals.hEdit) ? MF_ENABLED : MF_GRAYED);
+
     DrawMenuBar(Globals.hMainWnd);
 }
 
@@ -394,56 +395,21 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 
     case WM_SIZE:
     {
-        if ((Globals.bShowStatusBar != FALSE) && (Globals.bWrapLongLines == FALSE))
+        RECT rc;
+        GetClientRect(hWnd, &rc);
+
+        if (Globals.bShowStatusBar)
         {
-            RECT rcStatusBar;
-            HDWP hdwp;
-
-            if (!GetWindowRect(Globals.hStatusBar, &rcStatusBar))
-                break;
-
-            hdwp = BeginDeferWindowPos(2);
-            if (hdwp == NULL)
-                break;
-
-            hdwp = DeferWindowPos(hdwp,
-                                  Globals.hEdit,
-                                  NULL,
-                                  0,
-                                  0,
-                                  LOWORD(lParam),
-                                  HIWORD(lParam) - (rcStatusBar.bottom - rcStatusBar.top),
-                                  SWP_NOZORDER | SWP_NOMOVE);
-
-            if (hdwp == NULL)
-                break;
-
-            hdwp = DeferWindowPos(hdwp,
-                                  Globals.hStatusBar,
-                                  NULL,
-                                  0,
-                                  0,
-                                  LOWORD(lParam),
-                                  LOWORD(wParam),
-                                  SWP_NOZORDER);
-
-            if (hdwp == NULL)
-                break;
-                
-            EndDeferWindowPos(hdwp);
-
-            /* Align status bar parts, only if the status bar resize operation succeeds */
-            DIALOG_StatusBarAlignParts();
+            RECT rcStatus;
+            SendMessageW(Globals.hStatusBar, WM_SIZE, 0, 0);
+            GetWindowRect(Globals.hStatusBar, &rcStatus);
+            rc.bottom -= rcStatus.bottom - rcStatus.top;
         }
-        else
-            SetWindowPos(Globals.hEdit,
-                         NULL,
-                         0,
-                         0,
-                         LOWORD(lParam),
-                         HIWORD(lParam),
-                         SWP_NOZORDER | SWP_NOMOVE);
 
+        MoveWindow(Globals.hEdit, 0, 0, rc.right, rc.bottom, TRUE);
+
+        /* Align status bar parts, only if the status bar resize operation succeeds */
+        DIALOG_StatusBarAlignParts();
         break;
     }
 
@@ -669,6 +635,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     }
 
     DoCreateEditWindow();
+    DoShowStatusBar(Globals.bShowStatusBar);
 
     NOTEPAD_InitData();
     DIALOG_FileNew();

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -157,9 +157,6 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         Globals.main_rect.right = Globals.main_rect.left + dx;
         Globals.main_rect.bottom = Globals.main_rect.top + dy;
 
-        /* invert value because DIALOG_ViewStatusBar will be called to show it */
-        Globals.bShowStatusBar = !Globals.bShowStatusBar;
-
         if (dwPointSize != 0)
             Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
         else

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -167,7 +167,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     else
     {
         /* If no settings are found in the registry, then use default values */
-        Globals.bShowStatusBar = FALSE;
+        Globals.bShowStatusBar = TRUE;
         Globals.bWrapLongLines = FALSE;
         SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
 


### PR DESCRIPTION
## Purpose
Notepad's status bar was not working by some reasons. And I want to simplify Notepad code.
JIRA issue: N/A

## Proposed changes

- Rename `DoCreateStatusBar` as `DoShowHideStatusBar`.
- The code re-arranging the controls is moved to `WM_SIZE` handler. This makes the code much simpler.
- Improve `WM_SIZE` handler.
- Enable/disable `CMD_STATUSBAR` menu item correctly.
- Make `DoShowHideStatusBar` independent from `DoCreateEditWindow`.

## TODO

- [x] Do tests. 
