### PR TITLE
[NOTEPAD] Avoid middle status of settings

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -560,6 +560,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     HMONITOR monitor;
     MONITORINFO info;
     INT x, y;
+    RECT rcIntersect;
 
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
@@ -608,10 +609,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
 
     x = Globals.main_rect.left;
     y = Globals.main_rect.top;
-    if (Globals.main_rect.left >= info.rcWork.right ||
-        Globals.main_rect.top >= info.rcWork.bottom ||
-        Globals.main_rect.right < info.rcWork.left ||
-        Globals.main_rect.bottom < info.rcWork.top)
+    if (!IntersectRect(&rcIntersect, &Globals.main_rect, &info.rcWork))
         x = y = CW_USEDEFAULT;
 
     Globals.hMainWnd = CreateWindow(className,

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -96,7 +96,6 @@ BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln);
 BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, EOLN iEoln);
 
 /* from settings.c */
-void NOTEPAD_ResetSettings(void);
 void NOTEPAD_LoadSettingsFromRegistry(void);
 void NOTEPAD_SaveSettingsToRegistry(void);
 

--- a/base/applications/notepad/main.h
+++ b/base/applications/notepad/main.h
@@ -96,6 +96,7 @@ BOOL ReadText(HANDLE hFile, HLOCAL *phLocal, ENCODING *pencFile, EOLN *piEoln);
 BOOL WriteText(HANDLE hFile, LPCWSTR pszText, DWORD dwTextLen, ENCODING encFile, EOLN iEoln);
 
 /* from settings.c */
+void NOTEPAD_ResetSettings(void);
 void NOTEPAD_LoadSettingsFromRegistry(void);
 void NOTEPAD_SaveSettingsToRegistry(void);
 

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -140,7 +140,8 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     /* FIXME: Globals.fSaveWindowPositions = FALSE; */
     /* FIXME: Globals.fMLE_is_broken = FALSE; */
 
-    RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey);
+    if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) != ERROR_SUCCESS)
+        hKey = NULL;
 
     QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
     QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -101,12 +101,12 @@ static BOOL QueryBool(HKEY hKey, LPCTSTR pszValueName, BOOL *pbResult)
     return TRUE;
 }
 
-static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD dwResultLen)
+static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD dwResultLength)
 {
-    if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, dwResultLen * sizeof(TCHAR)))
+    if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, dwResultLength * sizeof(TCHAR)))
         return FALSE;
-    assert(dwResultLen > 0);
-    pszResult[dwResultLen - 1] = 0; /* Avoid buffer overrun */
+    assert(dwResultLength > 0);
+    pszResult[dwResultLength - 1] = 0; /* Avoid buffer overrun */
     return TRUE;
 }
 

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -110,7 +110,7 @@ static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD
     return TRUE;
 }
 
-void NOTEPAD_ResetSettings(void)
+static void NOTEPAD_ResetSettings(void)
 {
     INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
     INT cx = min((cxScreen * 3) / 4, 640), cy = min((cyScreen * 3) / 4, 480);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -113,7 +113,7 @@ static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD
 void NOTEPAD_ResetSettings(void)
 {
     INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    INT cx = min((cxScreen * 2) / 3, 640), cy = min((cyScreen * 2) / 3, 480);
+    INT cx = min((cxScreen * 3) / 4, 640), cy = min((cyScreen * 3) / 4, 480);
 
     Globals.main_rect.left = CW_USEDEFAULT;
     Globals.main_rect.top = CW_USEDEFAULT;

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -144,7 +144,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         hKey = NULL;
 
     /*
-     * Load the settings from registry
+     * Load the values from registry
      */
     QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
     QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -158,15 +158,16 @@ void NOTEPAD_ResetSettings(void)
  */
 void NOTEPAD_LoadSettingsFromRegistry(void)
 {
-    HKEY hKey = NULL;
+    HKEY hKey;
     HFONT hFont;
+    INT dx, dy;
+    DWORD dwPointSize;
 
     NOTEPAD_ResetSettings();
 
     if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) == ERROR_SUCCESS)
     {
-        INT dx, dy;
-        DWORD dwPointSize = 0;
+        dwPointSize = 100;
 
         QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
         QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
@@ -198,10 +199,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         Globals.main_rect.right = Globals.main_rect.left + dx;
         Globals.main_rect.bottom = Globals.main_rect.top + dy;
 
-        if (dwPointSize != 0)
-            Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
-        else
-            Globals.lfFont.lfHeight = HeightFromPointSize(100);
+        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
         RegCloseKey(hKey);
     }

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -113,8 +113,7 @@ static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD
 void NOTEPAD_ResetSettings(void)
 {
     INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    INT cx = min((cxScreen * 2) / 3, 640);
-    INT cy = min((cyScreen * 2) / 3, 480);
+    INT cx = min((cxScreen * 2) / 3, 640), cy = min((cyScreen * 2) / 3, 480);
 
     Globals.main_rect.left = CW_USEDEFAULT;
     Globals.main_rect.top = CW_USEDEFAULT;
@@ -137,6 +136,7 @@ void NOTEPAD_ResetSettings(void)
     Globals.lfFont.lfCharSet = DEFAULT_CHARSET;
     Globals.lfFont.lfHeight = HeightFromPointSize(100);
     Globals.lfFont.lfWeight = FW_NORMAL;
+    Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
     LoadString(Globals.hInstance, STRING_DEFAULTFONT, Globals.lfFont.lfFaceName,
                ARRAY_SIZE(Globals.lfFont.lfFaceName));
 
@@ -147,9 +147,6 @@ void NOTEPAD_ResetSettings(void)
         case LANG_JAPANESE:
         case LANG_KOREAN:
             Globals.lfFont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
-            break;
-        default:
-            Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
             break;
     }
 }

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -112,10 +112,14 @@ static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD
 
 void NOTEPAD_ResetSettings(void)
 {
+    INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
+    INT cx = min((cxScreen * 2) / 3, 640);
+    INT cy = min((cyScreen * 2) / 3, 480);
+
     Globals.main_rect.left = CW_USEDEFAULT;
     Globals.main_rect.top = CW_USEDEFAULT;
-    Globals.main_rect.right = Globals.main_rect.left + CW_USEDEFAULT;
-    Globals.main_rect.bottom = Globals.main_rect.top + CW_USEDEFAULT;
+    Globals.main_rect.right = Globals.main_rect.left + cx;
+    Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
     Globals.bShowStatusBar = TRUE;
     Globals.bWrapLongLines = FALSE;

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -101,7 +101,7 @@ static BOOL QueryBool(HKEY hKey, LPCTSTR pszValueName, BOOL *pbResult)
     return TRUE;
 }
 
-static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD cchResult)
+static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD cchResult)
 {
     if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, cchResult * sizeof(TCHAR)))
         return FALSE;
@@ -161,15 +161,13 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
 {
     HKEY hKey;
     HFONT hFont;
-    INT dx, dy;
     DWORD dwPointSize;
+    INT dx, dy;
 
     NOTEPAD_ResetSettings();
 
     if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) == ERROR_SUCCESS)
     {
-        dwPointSize = 100;
-
         QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
         QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
         QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
@@ -182,7 +180,6 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
         QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
         QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
-        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
         QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
         QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
         QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader));
@@ -192,6 +189,10 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
         QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
 
+        dwPointSize = 100;
+        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
+        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
+
         QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
         QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
         QueryDword(hKey, _T("iWindowPosDX"), (DWORD*)&dx);
@@ -199,8 +200,6 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
 
         Globals.main_rect.right = Globals.main_rect.left + dx;
         Globals.main_rect.bottom = Globals.main_rect.top + dy;
-
-        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
         RegCloseKey(hKey);
     }

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -22,7 +22,6 @@
 
 #include "notepad.h"
 
-#include <assert.h>
 #include <winreg.h>
 
 static LPCTSTR s_szRegistryKey = _T("Software\\Microsoft\\Notepad");
@@ -103,9 +102,10 @@ static BOOL QueryBool(HKEY hKey, LPCTSTR pszValueName, BOOL *pbResult)
 
 static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD dwResultLength)
 {
+    if (dwResultLength == 0)
+        return FALSE;
     if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, dwResultLength * sizeof(TCHAR)))
         return FALSE;
-    assert(dwResultLength > 0);
     pszResult[dwResultLength - 1] = 0; /* Avoid buffer overrun */
     return TRUE;
 }

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -122,7 +122,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     HFONT hFont;
     DWORD dwPointSize;
     INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    INT cx, cy;
+    DWORD cx, cy;
 
     /*
      * Set the default values
@@ -193,8 +193,8 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     cy = min((cyScreen * 3) / 4, 480);
     QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
     QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
-    QueryDword(hKey, _T("iWindowPosDX"), (DWORD*)&cx);
-    QueryDword(hKey, _T("iWindowPosDY"), (DWORD*)&cy);
+    QueryDword(hKey, _T("iWindowPosDX"), &cx);
+    QueryDword(hKey, _T("iWindowPosDY"), &cy);
     Globals.main_rect.right = Globals.main_rect.left + cx;
     Globals.main_rect.bottom = Globals.main_rect.top + cy;
 

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -135,6 +135,10 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     Globals.lfFont.lfHeight = HeightFromPointSize(100);
     Globals.lfFont.lfWeight = FW_NORMAL;
     Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
+    Globals.main_rect.left = CW_USEDEFAULT;
+    Globals.main_rect.top = CW_USEDEFAULT;
+    cx = min((cxScreen * 3) / 4, 640);
+    cy = min((cyScreen * 3) / 4, 480);
 
     /* FIXME: Globals.fSaveWindowPositions = FALSE; */
     /* FIXME: Globals.fMLE_is_broken = FALSE; */
@@ -167,7 +171,15 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
         QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
         QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
+
+        QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
+        QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
+        QueryDword(hKey, _T("iWindowPosDX"), &cx);
+        QueryDword(hKey, _T("iWindowPosDY"), &cy);
     }
+
+    Globals.main_rect.right = Globals.main_rect.left + cx;
+    Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
     if (!hKey || !QueryString(hKey, _T("lfFaceName"),
                               Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName)))
@@ -192,20 +204,6 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     if (hKey)
         QueryDword(hKey, _T("iPointSize"), &dwPointSize);
     Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
-
-    Globals.main_rect.left = CW_USEDEFAULT;
-    Globals.main_rect.top = CW_USEDEFAULT;
-    cx = min((cxScreen * 3) / 4, 640);
-    cy = min((cyScreen * 3) / 4, 480);
-    if (hKey)
-    {
-        QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
-        QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
-        QueryDword(hKey, _T("iWindowPosDX"), &cx);
-        QueryDword(hKey, _T("iWindowPosDY"), &cy);
-    }
-    Globals.main_rect.right = Globals.main_rect.left + cx;
-    Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
     if (hKey)
         RegCloseKey(hKey);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -129,14 +129,13 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
     ZeroMemory(&Globals.lfFont, sizeof(Globals.lfFont));
     Globals.lfFont.lfCharSet = DEFAULT_CHARSET;
-    Globals.lfFont.lfHeight = HeightFromPointSize(100);
+    dwPointSize = 100;
     Globals.lfFont.lfWeight = FW_NORMAL;
     Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
     Globals.main_rect.left = CW_USEDEFAULT;
     Globals.main_rect.top = CW_USEDEFAULT;
     cx = min((cxScreen * 3) / 4, 640);
     cy = min((cyScreen * 3) / 4, 480);
-    dwPointSize = 100;
 
     /* FIXME: Globals.fSaveWindowPositions = FALSE; */
     /* FIXME: Globals.fMLE_is_broken = FALSE; */

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -146,59 +146,69 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     /*
      * Load the values from registry
      */
-    QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
-    QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
-    QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
-    if (!QueryString(hKey, _T("lfFaceName"), Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName)))
+    if (hKey)
+    {
+        QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
+        QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
+        QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
+        QueryByte(hKey, _T("lfItalic"), &Globals.lfFont.lfItalic);
+        QueryDword(hKey, _T("lfOrientation"), (DWORD*)&Globals.lfFont.lfOrientation);
+        QueryByte(hKey, _T("lfOutPrecision"), &Globals.lfFont.lfOutPrecision);
+        QueryByte(hKey, _T("lfPitchAndFamily"), &Globals.lfFont.lfPitchAndFamily);
+        QueryByte(hKey, _T("lfQuality"), &Globals.lfFont.lfQuality);
+        QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
+        QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
+        QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
+
+        QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
+        QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
+
+        QueryDword(hKey, _T("iMarginLeft"), (DWORD*)&Globals.lMargins.left);
+        QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
+        QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
+        QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
+    }
+
+    if (!hKey || !QueryString(hKey, _T("lfFaceName"),
+                              Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName)))
     {
         LoadString(Globals.hInstance, STRING_DEFAULTFONT, Globals.lfFont.lfFaceName,
                    ARRAY_SIZE(Globals.lfFont.lfFaceName));
     }
-    QueryByte(hKey, _T("lfItalic"), &Globals.lfFont.lfItalic);
-    QueryDword(hKey, _T("lfOrientation"), (DWORD*)&Globals.lfFont.lfOrientation);
-    QueryByte(hKey, _T("lfOutPrecision"), &Globals.lfFont.lfOutPrecision);
-    QueryByte(hKey, _T("lfPitchAndFamily"), &Globals.lfFont.lfPitchAndFamily);
-    QueryByte(hKey, _T("lfQuality"), &Globals.lfFont.lfQuality);
-    QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
-    QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
-    QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
 
-    dwPointSize = 100;
-    QueryDword(hKey, _T("iPointSize"), &dwPointSize);
-    Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
-
-    QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
-    QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
-
-    if (!QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader)))
+    if (!hKey || !QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader)))
     {
         LoadString(Globals.hInstance, STRING_PAGESETUP_HEADERVALUE, Globals.szHeader,
                    ARRAY_SIZE(Globals.szHeader));
     }
 
-    if (!QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter)))
+    if (!hKey || !QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter)))
     {
         LoadString(Globals.hInstance, STRING_PAGESETUP_FOOTERVALUE, Globals.szFooter,
                    ARRAY_SIZE(Globals.szFooter));
     }
 
-    QueryDword(hKey, _T("iMarginLeft"), (DWORD*)&Globals.lMargins.left);
-    QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
-    QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
-    QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
+    dwPointSize = 100;
+    if (hKey)
+        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
+    Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
     Globals.main_rect.left = CW_USEDEFAULT;
     Globals.main_rect.top = CW_USEDEFAULT;
     cx = min((cxScreen * 3) / 4, 640);
     cy = min((cyScreen * 3) / 4, 480);
-    QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
-    QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
-    QueryDword(hKey, _T("iWindowPosDX"), &cx);
-    QueryDword(hKey, _T("iWindowPosDY"), &cy);
+    if (hKey)
+    {
+        QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
+        QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
+        QueryDword(hKey, _T("iWindowPosDX"), &cx);
+        QueryDword(hKey, _T("iWindowPosDY"), &cy);
+    }
     Globals.main_rect.right = Globals.main_rect.left + cx;
     Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
-    RegCloseKey(hKey);
+    if (hKey)
+        RegCloseKey(hKey);
 
     /* WORKAROUND: Far East Asian users may not have suitable fixed-pitch fonts. */
     switch (PRIMARYLANGID(GetUserDefaultLangID()))

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -122,15 +122,14 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     HFONT hFont;
     DWORD dwPointSize;
     INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    INT cx = min((cxScreen * 3) / 4, 640), cy = min((cyScreen * 3) / 4, 480);
+    INT cx, cy;
 
-    Globals.main_rect.left = CW_USEDEFAULT;
-    Globals.main_rect.top = CW_USEDEFAULT;
-
+    /*
+     * Set the default values
+     */
     Globals.bShowStatusBar = TRUE;
     Globals.bWrapLongLines = FALSE;
     SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
-
     ZeroMemory(&Globals.lfFont, sizeof(Globals.lfFont));
     Globals.lfFont.lfCharSet = DEFAULT_CHARSET;
     Globals.lfFont.lfHeight = HeightFromPointSize(100);
@@ -140,9 +139,13 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     /* FIXME: Globals.fSaveWindowPositions = FALSE; */
     /* FIXME: Globals.fMLE_is_broken = FALSE; */
 
+    /* Open the target registry key */
     if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) != ERROR_SUCCESS)
         hKey = NULL;
 
+    /*
+     * Load the settings from registry
+     */
     QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
     QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
     QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
@@ -184,6 +187,10 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
     QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
 
+    Globals.main_rect.left = CW_USEDEFAULT;
+    Globals.main_rect.top = CW_USEDEFAULT;
+    cx = min((cxScreen * 3) / 4, 640);
+    cy = min((cyScreen * 3) / 4, 480);
     QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
     QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
     QueryDword(hKey, _T("iWindowPosDX"), (DWORD*)&cx);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -112,10 +112,10 @@ static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD
 
 void NOTEPAD_ResetSettings(void)
 {
-    INT base_length = (GetSystemMetrics(SM_CXSCREEN) > GetSystemMetrics(SM_CYSCREEN)) ?
-                       GetSystemMetrics(SM_CYSCREEN) : GetSystemMetrics(SM_CXSCREEN);
-    INT dx = (INT)(base_length * .95), dy = dx * 3 / 4;
-    SetRect(&Globals.main_rect, 0, 0, dx, dy);
+    Globals.main_rect.left = CW_USEDEFAULT;
+    Globals.main_rect.top = CW_USEDEFAULT;
+    Globals.main_rect.right = Globals.main_rect.left + CW_USEDEFAULT;
+    Globals.main_rect.bottom = Globals.main_rect.top + CW_USEDEFAULT;
 
     Globals.bShowStatusBar = TRUE;
     Globals.bWrapLongLines = FALSE;

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -180,18 +180,20 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
         QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
         QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
+        dwPointSize = 100;
+        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
+        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
+
         QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
         QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
+
         QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader));
         QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter));
+
         QueryDword(hKey, _T("iMarginLeft"), (DWORD*)&Globals.lMargins.left);
         QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
         QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
         QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
-
-        dwPointSize = 100;
-        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
-        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
         QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
         QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -110,47 +110,6 @@ static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD
     return TRUE;
 }
 
-static void NOTEPAD_ResetSettings(void)
-{
-    INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    INT cx = min((cxScreen * 3) / 4, 640), cy = min((cyScreen * 3) / 4, 480);
-
-    Globals.main_rect.left = CW_USEDEFAULT;
-    Globals.main_rect.top = CW_USEDEFAULT;
-    Globals.main_rect.right = Globals.main_rect.left + cx;
-    Globals.main_rect.bottom = Globals.main_rect.top + cy;
-
-    Globals.bShowStatusBar = TRUE;
-    Globals.bWrapLongLines = FALSE;
-    SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
-
-    /* FIXME: Globals.fSaveWindowPositions = FALSE; */
-    /* FIXME: Globals.fMLE_is_broken = FALSE; */
-
-    LoadString(Globals.hInstance, STRING_PAGESETUP_HEADERVALUE, Globals.szHeader,
-               ARRAY_SIZE(Globals.szHeader));
-    LoadString(Globals.hInstance, STRING_PAGESETUP_FOOTERVALUE, Globals.szFooter,
-               ARRAY_SIZE(Globals.szFooter));
-
-    ZeroMemory(&Globals.lfFont, sizeof(Globals.lfFont));
-    Globals.lfFont.lfCharSet = DEFAULT_CHARSET;
-    Globals.lfFont.lfHeight = HeightFromPointSize(100);
-    Globals.lfFont.lfWeight = FW_NORMAL;
-    Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
-    LoadString(Globals.hInstance, STRING_DEFAULTFONT, Globals.lfFont.lfFaceName,
-               ARRAY_SIZE(Globals.lfFont.lfFaceName));
-
-    /* WORKAROUND: Far East Asian users may not have suitable fixed-pitch fonts. */
-    switch (PRIMARYLANGID(GetUserDefaultLangID()))
-    {
-        case LANG_CHINESE:
-        case LANG_JAPANESE:
-        case LANG_KOREAN:
-            Globals.lfFont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
-            break;
-    }
-}
-
 /***********************************************************************
  *
  *           NOTEPAD_LoadSettingsFromRegistry
@@ -162,48 +121,85 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     HKEY hKey;
     HFONT hFont;
     DWORD dwPointSize;
-    INT dx, dy;
+    INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
+    INT cx = min((cxScreen * 3) / 4, 640), cy = min((cyScreen * 3) / 4, 480);
 
-    NOTEPAD_ResetSettings();
+    Globals.main_rect.left = CW_USEDEFAULT;
+    Globals.main_rect.top = CW_USEDEFAULT;
 
-    if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) == ERROR_SUCCESS)
+    Globals.bShowStatusBar = TRUE;
+    Globals.bWrapLongLines = FALSE;
+    SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
+
+    ZeroMemory(&Globals.lfFont, sizeof(Globals.lfFont));
+    Globals.lfFont.lfCharSet = DEFAULT_CHARSET;
+    Globals.lfFont.lfHeight = HeightFromPointSize(100);
+    Globals.lfFont.lfWeight = FW_NORMAL;
+    Globals.lfFont.lfPitchAndFamily = FIXED_PITCH | FF_MODERN;
+
+    /* FIXME: Globals.fSaveWindowPositions = FALSE; */
+    /* FIXME: Globals.fMLE_is_broken = FALSE; */
+
+    RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey);
+
+    QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
+    QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
+    QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
+    if (!QueryString(hKey, _T("lfFaceName"), Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName)))
     {
-        QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
-        QueryByte(hKey, _T("lfClipPrecision"), &Globals.lfFont.lfClipPrecision);
-        QueryDword(hKey, _T("lfEscapement"), (DWORD*)&Globals.lfFont.lfEscapement);
-        QueryString(hKey, _T("lfFaceName"), Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName));
-        QueryByte(hKey, _T("lfItalic"), &Globals.lfFont.lfItalic);
-        QueryDword(hKey, _T("lfOrientation"), (DWORD*)&Globals.lfFont.lfOrientation);
-        QueryByte(hKey, _T("lfOutPrecision"), &Globals.lfFont.lfOutPrecision);
-        QueryByte(hKey, _T("lfPitchAndFamily"), &Globals.lfFont.lfPitchAndFamily);
-        QueryByte(hKey, _T("lfQuality"), &Globals.lfFont.lfQuality);
-        QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
-        QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
-        QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
-        dwPointSize = 100;
-        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
-        Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
+        LoadString(Globals.hInstance, STRING_DEFAULTFONT, Globals.lfFont.lfFaceName,
+                   ARRAY_SIZE(Globals.lfFont.lfFaceName));
+    }
+    QueryByte(hKey, _T("lfItalic"), &Globals.lfFont.lfItalic);
+    QueryDword(hKey, _T("lfOrientation"), (DWORD*)&Globals.lfFont.lfOrientation);
+    QueryByte(hKey, _T("lfOutPrecision"), &Globals.lfFont.lfOutPrecision);
+    QueryByte(hKey, _T("lfPitchAndFamily"), &Globals.lfFont.lfPitchAndFamily);
+    QueryByte(hKey, _T("lfQuality"), &Globals.lfFont.lfQuality);
+    QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
+    QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
+    QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
 
-        QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
-        QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
+    dwPointSize = 100;
+    QueryDword(hKey, _T("iPointSize"), &dwPointSize);
+    Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
-        QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader));
-        QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter));
+    QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
+    QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
 
-        QueryDword(hKey, _T("iMarginLeft"), (DWORD*)&Globals.lMargins.left);
-        QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
-        QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
-        QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
+    if (!QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader)))
+    {
+        LoadString(Globals.hInstance, STRING_PAGESETUP_HEADERVALUE, Globals.szHeader,
+                   ARRAY_SIZE(Globals.szHeader));
+    }
 
-        QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
-        QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
-        QueryDword(hKey, _T("iWindowPosDX"), (DWORD*)&dx);
-        QueryDword(hKey, _T("iWindowPosDY"), (DWORD*)&dy);
+    if (!QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter)))
+    {
+        LoadString(Globals.hInstance, STRING_PAGESETUP_FOOTERVALUE, Globals.szFooter,
+                   ARRAY_SIZE(Globals.szFooter));
+    }
 
-        Globals.main_rect.right = Globals.main_rect.left + dx;
-        Globals.main_rect.bottom = Globals.main_rect.top + dy;
+    QueryDword(hKey, _T("iMarginLeft"), (DWORD*)&Globals.lMargins.left);
+    QueryDword(hKey, _T("iMarginTop"), (DWORD*)&Globals.lMargins.top);
+    QueryDword(hKey, _T("iMarginRight"), (DWORD*)&Globals.lMargins.right);
+    QueryDword(hKey, _T("iMarginBottom"), (DWORD*)&Globals.lMargins.bottom);
 
-        RegCloseKey(hKey);
+    QueryDword(hKey, _T("iWindowPosX"), (DWORD*)&Globals.main_rect.left);
+    QueryDword(hKey, _T("iWindowPosY"), (DWORD*)&Globals.main_rect.top);
+    QueryDword(hKey, _T("iWindowPosDX"), (DWORD*)&cx);
+    QueryDword(hKey, _T("iWindowPosDY"), (DWORD*)&cy);
+    Globals.main_rect.right = Globals.main_rect.left + cx;
+    Globals.main_rect.bottom = Globals.main_rect.top + cy;
+
+    RegCloseKey(hKey);
+
+    /* WORKAROUND: Far East Asian users may not have suitable fixed-pitch fonts. */
+    switch (PRIMARYLANGID(GetUserDefaultLangID()))
+    {
+        case LANG_CHINESE:
+        case LANG_JAPANESE:
+        case LANG_KOREAN:
+            Globals.lfFont.lfPitchAndFamily = DEFAULT_PITCH | FF_DONTCARE;
+            break;
     }
 
     hFont = CreateFontIndirect(&Globals.lfFont);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -120,13 +120,10 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
 {
     HKEY hKey;
     HFONT hFont;
-    DWORD dwPointSize;
-    INT cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
-    DWORD cx, cy;
+    DWORD dwPointSize, cx, cy;
+    DWORD cxScreen = GetSystemMetrics(SM_CXSCREEN), cyScreen = GetSystemMetrics(SM_CYSCREEN);
 
-    /*
-     * Set the default values
-     */
+    /* Set the default values */
     Globals.bShowStatusBar = TRUE;
     Globals.bWrapLongLines = FALSE;
     SetRect(&Globals.lMargins, 750, 1000, 750, 1000);
@@ -139,6 +136,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     Globals.main_rect.top = CW_USEDEFAULT;
     cx = min((cxScreen * 3) / 4, 640);
     cy = min((cyScreen * 3) / 4, 480);
+    dwPointSize = 100;
 
     /* FIXME: Globals.fSaveWindowPositions = FALSE; */
     /* FIXME: Globals.fMLE_is_broken = FALSE; */
@@ -147,9 +145,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     if (RegOpenKey(HKEY_CURRENT_USER, s_szRegistryKey, &hKey) != ERROR_SUCCESS)
         hKey = NULL;
 
-    /*
-     * Load the values from registry
-     */
+    /* Load the values from registry */
     if (hKey)
     {
         QueryByte(hKey, _T("lfCharSet"), &Globals.lfFont.lfCharSet);
@@ -163,6 +159,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryByte(hKey, _T("lfStrikeOut"), &Globals.lfFont.lfStrikeOut);
         QueryByte(hKey, _T("lfUnderline"), &Globals.lfFont.lfUnderline);
         QueryDword(hKey, _T("lfWeight"), (DWORD*)&Globals.lfFont.lfWeight);
+        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
 
         QueryBool(hKey, _T("fWrap"), &Globals.bWrapLongLines);
         QueryBool(hKey, _T("fStatusBar"), &Globals.bShowStatusBar);
@@ -178,6 +175,7 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryDword(hKey, _T("iWindowPosDY"), &cy);
     }
 
+    Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
     Globals.main_rect.right = Globals.main_rect.left + cx;
     Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
@@ -199,11 +197,6 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         LoadString(Globals.hInstance, STRING_PAGESETUP_FOOTERVALUE, Globals.szFooter,
                    ARRAY_SIZE(Globals.szFooter));
     }
-
-    dwPointSize = 100;
-    if (hKey)
-        QueryDword(hKey, _T("iPointSize"), &dwPointSize);
-    Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
 
     if (hKey)
         RegCloseKey(hKey);

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -101,12 +101,12 @@ static BOOL QueryBool(HKEY hKey, LPCTSTR pszValueName, BOOL *pbResult)
     return TRUE;
 }
 
-static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD cchResult)
+static BOOL QueryString(HKEY hKey, LPCTSTR pszValueName, LPTSTR pszResult, DWORD dwResultLen)
 {
-    if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, cchResult * sizeof(TCHAR)))
+    if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, dwResultLen * sizeof(TCHAR)))
         return FALSE;
-    assert(cchResult > 0);
-    pszResult[cchResult - 1] = 0; /* Avoid buffer overrun */
+    assert(dwResultLen > 0);
+    pszResult[dwResultLen - 1] = 0; /* Avoid buffer overrun */
     return TRUE;
 }
 

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -103,13 +103,11 @@ static BOOL QueryBool(HKEY hKey, LPCTSTR pszValueName, BOOL *pbResult)
 
 static BOOL QueryString(HKEY hKey, LPCWSTR pszValueName, LPWSTR pszResult, DWORD cchResult)
 {
-    if (QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, cchResult * sizeof(TCHAR)))
-    {
-        assert(cchResult > 0);
-        pszResult[cchResult - 1] = 0; /* Avoid buffer overrun */
-        return TRUE;
-    }
-    return FALSE;
+    if (!QueryGeneric(hKey, pszValueName, REG_SZ, pszResult, cchResult * sizeof(TCHAR)))
+        return FALSE;
+    assert(cchResult > 0);
+    pszResult[cchResult - 1] = 0; /* Avoid buffer overrun */
+    return TRUE;
 }
 
 void NOTEPAD_ResetSettings(void)


### PR DESCRIPTION
## Purpose
If there is the target registry key and the settings are incomplete, then the settings would become the middle status. This PR will avoid this status.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Avoid buffer overrun in `QueryString` helper function.
- Improve `NOTEPAD_LoadSettingsFromRegistry` function.