### PR TITLE
[SHLWAPI][SHLWAPI_APITEST] Expand string in SHLoadIndirectString

### DIFF
--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4131,6 +4131,14 @@ HRESULT WINAPI SHLoadRegUIStringW(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD si
     if(RegQueryValueExW(hkey, value, NULL, &type, (LPBYTE)buf, &sz) != ERROR_SUCCESS)
         return E_FAIL;
 
+#ifdef __REACTOS__
+    if (wcschr(buf, L'%') != NULL)
+    {
+        WCHAR szExpanded[MAX_PATH];
+        ExpandEnvironmentStrings(buf, szExpanded, ARRAY_SIZE(szExpanded));
+        lstrcpynW(buf, szExpanded, size);
+    }
+#endif
     return SHLoadIndirectString(buf, buf, size, NULL);
 }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4131,14 +4131,6 @@ HRESULT WINAPI SHLoadRegUIStringW(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD si
     if(RegQueryValueExW(hkey, value, NULL, &type, (LPBYTE)buf, &sz) != ERROR_SUCCESS)
         return E_FAIL;
 
-#ifdef __REACTOS__
-    if (wcschr(buf, L'%') != NULL)
-    {
-        WCHAR szExpanded[MAX_PATH];
-        ExpandEnvironmentStrings(buf, szExpanded, ARRAY_SIZE(szExpanded));
-        lstrcpynW(buf, szExpanded, size);
-    }
-#endif
     return SHLoadIndirectString(buf, buf, size, NULL);
 }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4142,7 +4142,8 @@ HRESULT WINAPI SHLoadRegUIStringA(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size
         return hr;
 
     WideCharToMultiByte(CP_ACP, 0, bufferW, -1, buf, size, NULL, NULL);
-    buf[size - 1] = 0; /* Avoid buffer overrun */
+    if (size > 0)
+        buf[size - 1] = 0; /* Avoid buffer overrun */
     return S_OK;
 }
 

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4121,6 +4121,32 @@ BOOL WINAPI IsOS(DWORD feature)
     return FALSE;
 }
 
+#ifdef __REACTOS__
+/*************************************************************************
+ * @  [SHLWAPI.438]
+ */
+HRESULT WINAPI SHLoadRegUIStringA(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size)
+{
+    WCHAR valueW[MAX_PATH], bufferW[MAX_PATH];
+    DWORD sz = ARRAY_SIZE(bufferW) * sizeof(CHAR);
+    HRESULT hr;
+
+    MultiByteToWideChar(CP_ACP, 0, value, -1, valueW, ARRAY_SIZE(valueW));
+    valueW[ARRAY_SIZE(valueW) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
+
+    if (RegQueryValueExW(hkey, valueW, NULL, NULL, (LPBYTE)bufferW, &sz) != ERROR_SUCCESS)
+        return E_FAIL;
+
+    hr = SHLoadIndirectString(bufferW, bufferW, ARRAY_SIZE(bufferW), NULL);
+    if (FAILED(hr))
+        return hr;
+
+    WideCharToMultiByte(CP_ACP, 0, bufferW, -1, buf, size, NULL, NULL);
+    buf[size - 1] = 0; /* Avoid buffer overrun */
+    return S_OK;
+}
+
+#endif
 /*************************************************************************
  * @  [SHLWAPI.439]
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4146,8 +4146,8 @@ HRESULT WINAPI SHLoadRegUIStringA(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size
         buf[size - 1] = ANSI_NULL; /* Avoid buffer overrun */
     return S_OK;
 }
-
 #endif
+
 /*************************************************************************
  * @  [SHLWAPI.439]
  */

--- a/dll/win32/shlwapi/ordinal.c
+++ b/dll/win32/shlwapi/ordinal.c
@@ -4128,13 +4128,13 @@ BOOL WINAPI IsOS(DWORD feature)
 HRESULT WINAPI SHLoadRegUIStringA(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size)
 {
     WCHAR valueW[MAX_PATH], bufferW[MAX_PATH];
-    DWORD sz = ARRAY_SIZE(bufferW) * sizeof(CHAR);
+    DWORD dwSize = ARRAY_SIZE(bufferW) * sizeof(CHAR);
     HRESULT hr;
 
     MultiByteToWideChar(CP_ACP, 0, value, -1, valueW, ARRAY_SIZE(valueW));
     valueW[ARRAY_SIZE(valueW) - 1] = UNICODE_NULL; /* Avoid buffer overrun */
 
-    if (RegQueryValueExW(hkey, valueW, NULL, NULL, (LPBYTE)bufferW, &sz) != ERROR_SUCCESS)
+    if (RegQueryValueExW(hkey, valueW, NULL, NULL, (LPBYTE)bufferW, &dwSize) != ERROR_SUCCESS)
         return E_FAIL;
 
     hr = SHLoadIndirectString(bufferW, bufferW, ARRAY_SIZE(bufferW), NULL);
@@ -4143,7 +4143,7 @@ HRESULT WINAPI SHLoadRegUIStringA(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size
 
     WideCharToMultiByte(CP_ACP, 0, bufferW, -1, buf, size, NULL, NULL);
     if (size > 0)
-        buf[size - 1] = 0; /* Avoid buffer overrun */
+        buf[size - 1] = ANSI_NULL; /* Avoid buffer overrun */
     return S_OK;
 }
 

--- a/dll/win32/shlwapi/shlwapi.spec
+++ b/dll/win32/shlwapi/shlwapi.spec
@@ -435,7 +435,7 @@
 435 stdcall -noname CLSIDFromProgIDWrap(wstr ptr) ole32.CLSIDFromProgID
 436 stdcall -noname CLSIDFromStringWrap(wstr ptr)
 437 stdcall -noname IsOS(long)
-438 stub -noname SHLoadRegUIStringA
+438 stdcall -noname SHLoadRegUIStringA(ptr str ptr long)
 439 stdcall -noname SHLoadRegUIStringW(ptr wstr ptr long)
 440 stdcall -noname SHGetWebFolderFilePathA(str ptr long)
 441 stdcall -noname SHGetWebFolderFilePathW(wstr ptr long)

--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -2879,7 +2879,7 @@ HRESULT WINAPI SHLoadIndirectString(LPCWSTR src, LPWSTR dst, UINT dst_len, void 
     HMODULE hmod = NULL;
     HRESULT hr = E_FAIL;
 #ifdef __REACTOS__
-    WCHAR szExpanded[MAX_PATH];
+    WCHAR szExpanded[512];
 #endif
 
     TRACE("(%s %p %08x %p)\n", debugstr_w(src), dst, dst_len, reserved);

--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -2878,6 +2878,9 @@ HRESULT WINAPI SHLoadIndirectString(LPCWSTR src, LPWSTR dst, UINT dst_len, void 
     WCHAR *dllname = NULL;
     HMODULE hmod = NULL;
     HRESULT hr = E_FAIL;
+#ifdef __REACTOS__
+    WCHAR szExpanded[MAX_PATH];
+#endif
 
     TRACE("(%s %p %08x %p)\n", debugstr_w(src), dst, dst_len, reserved);
 
@@ -2886,6 +2889,13 @@ HRESULT WINAPI SHLoadIndirectString(LPCWSTR src, LPWSTR dst, UINT dst_len, void 
         WCHAR *index_str;
         int index;
 
+#ifdef __REACTOS__
+        if (wcschr(src, '%') != NULL)
+        {
+            ExpandEnvironmentStrings(src, szExpanded, ARRAYSIZE(szExpanded));
+            src = szExpanded;
+        }
+#endif
         dst[0] = 0;
         dllname = StrDupW(src + 1);
         index_str = strchrW(dllname, ',');

--- a/dll/win32/shlwapi/string.c
+++ b/dll/win32/shlwapi/string.c
@@ -2892,7 +2892,7 @@ HRESULT WINAPI SHLoadIndirectString(LPCWSTR src, LPWSTR dst, UINT dst_len, void 
 #ifdef __REACTOS__
         if (wcschr(src, '%') != NULL)
         {
-            ExpandEnvironmentStrings(src, szExpanded, ARRAYSIZE(szExpanded));
+            ExpandEnvironmentStringsW(src, szExpanded, ARRAY_SIZE(szExpanded));
             src = szExpanded;
         }
 #endif

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -13,6 +13,7 @@ list(APPEND SOURCE
     PathUnExpandEnvStringsForUser.c
     SHAreIconsEqual.c
     SHLoadIndirectString.c
+    SHLoadRegUIString.c
     StrFormatByteSizeW.c
     testdata.rc
     testlist.c)
@@ -23,6 +24,6 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
 target_link_libraries(shlwapi_apitest ${PSEH_LIB})
-add_importlibs(shlwapi_apitest shlwapi user32 msvcrt kernel32)
+add_importlibs(shlwapi_apitest shlwapi user32 msvcrt advapi32 kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/CMakeLists.txt
+++ b/modules/rostests/apitests/shlwapi/CMakeLists.txt
@@ -24,6 +24,6 @@ add_rc_deps(testdata.rc ${CMAKE_CURRENT_BINARY_DIR}/shlwapi_resource_dll/shlwapi
 add_executable(shlwapi_apitest ${SOURCE})
 set_module_type(shlwapi_apitest win32cui)
 target_link_libraries(shlwapi_apitest ${PSEH_LIB})
-add_importlibs(shlwapi_apitest shlwapi user32 msvcrt advapi32 kernel32)
+add_importlibs(shlwapi_apitest shlwapi user32 advapi32 msvcrt kernel32)
 add_dependencies(shlwapi_apitest shlwapi_resource_dll)
 add_rostests_file(TARGET shlwapi_apitest)

--- a/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
+++ b/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
@@ -51,6 +51,12 @@ START_TEST(SHLoadRegUIString)
     static const WCHAR s_szTestValue2[] = L"@shlwapi_resource_dll.dll%EmptyEnvVar%,-3";
     HMODULE hSHLWAPI;
 
+    if (!PathFileExistsW(L"shlwapi_resource_dll.dll"))
+    {
+        skip("File 'shlwapi_resource_dll.dll' does not exist\n");
+        return;
+    }
+
     SetEnvironmentVariableW(L"EmptyEnvVar", L"");
 
     /* Get procedures */

--- a/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
+++ b/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
@@ -17,15 +17,11 @@ static FN_SHLoadRegUIStringW pSHLoadRegUIStringW = NULL;
 static void test_SHLoadRegUIStringA(HKEY hKey)
 {
     HRESULT hr;
-    CHAR szTestValue[MAX_PATH];
     CHAR szBuff[MAX_PATH];
-
-    GetWindowsDirectoryA(szTestValue, _countof(szTestValue));
-    lstrcatA(szTestValue, "\\TEST");
 
     hr = pSHLoadRegUIStringA(hKey, "TestValue1", szBuff, _countof(szBuff));
     ok_long(hr, S_OK);
-    ok_str(szBuff, szTestValue);
+    ok_str(szBuff, "%WINDIR%\\TEST");
 
     hr = pSHLoadRegUIStringA(hKey, "TestValue2", szBuff, _countof(szBuff));
     ok_long(hr, S_OK);
@@ -35,11 +31,7 @@ static void test_SHLoadRegUIStringA(HKEY hKey)
 static void test_SHLoadRegUIStringW(HKEY hKey)
 {
     HRESULT hr;
-    WCHAR szTestValue[MAX_PATH];
     WCHAR szBuff[MAX_PATH];
-
-    GetWindowsDirectoryW(szTestValue, _countof(szTestValue));
-    lstrcatW(szTestValue, L"\\TEST");
 
     hr = pSHLoadRegUIStringW(hKey, L"TestValue1", szBuff, _countof(szBuff));
     ok_long(hr, S_OK);

--- a/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
+++ b/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
@@ -42,20 +42,16 @@ static void test_SHLoadRegUIStringW(HKEY hKey)
     ok_wstr(szBuff, L"Test string one.");
 }
 
+BOOL extract_resource(const WCHAR* Filename, LPCWSTR ResourceName);
+
 START_TEST(SHLoadRegUIString)
 {
     LONG error;
     HKEY hKey;
     DWORD cbValue;
     static const WCHAR s_szTestValue1[] = L"%WINDIR%\\TEST";
-    static const WCHAR s_szTestValue2[] = L"@shlwapi_resource_dll.dll%EmptyEnvVar%,-3";
+    static const WCHAR s_szTestValue2[] = L"@SHLoadRegUIString.dll%EmptyEnvVar%,-3";
     HMODULE hSHLWAPI;
-
-    if (!PathFileExistsW(L"shlwapi_resource_dll.dll"))
-    {
-        skip("File 'shlwapi_resource_dll.dll' does not exist\n");
-        return;
-    }
 
     SetEnvironmentVariableW(L"EmptyEnvVar", L"");
 
@@ -66,6 +62,12 @@ START_TEST(SHLoadRegUIString)
     if (!pSHLoadRegUIStringA || !pSHLoadRegUIStringW)
     {
         skip("No procedure found\n");
+        return;
+    }
+
+    if (!extract_resource(L"SHLoadRegUIString.dll", MAKEINTRESOURCEW(101)))
+    {
+        skip("File 'SHLoadRegUIString.dll' cannot be extracted\n");
         return;
     }
 
@@ -87,5 +89,8 @@ START_TEST(SHLoadRegUIString)
 
     /* Delete the test values and close the key */
     RegDeleteValueW(hKey, L"TestValue1");
+    RegDeleteValueW(hKey, L"TestValue2");
     RegCloseKey(hKey);
+
+    DeleteFileW(L"SHLoadRegUIString.dll");
 }

--- a/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
+++ b/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
@@ -1,0 +1,93 @@
+/*
+ * PROJECT:     ReactOS api tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Tests for SHLoadRegUIStringA/W
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ */
+
+#include <apitest.h>
+#include <shlwapi.h>
+
+typedef HRESULT (WINAPI *FN_SHLoadRegUIStringA)(HKEY hkey, LPCSTR value, LPSTR buf, DWORD size);
+typedef HRESULT (WINAPI *FN_SHLoadRegUIStringW)(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD size);
+
+static FN_SHLoadRegUIStringA pSHLoadRegUIStringA = NULL;
+static FN_SHLoadRegUIStringW pSHLoadRegUIStringW = NULL;
+
+static void test_SHLoadRegUIStringA(HKEY hKey)
+{
+    HRESULT hr;
+    CHAR szTestValue[MAX_PATH];
+    CHAR szBuff[MAX_PATH];
+
+    GetWindowsDirectoryA(szTestValue, _countof(szTestValue));
+    lstrcatA(szTestValue, "\\TEST");
+
+    hr = pSHLoadRegUIStringA(hKey, "TestValue1", szBuff, _countof(szBuff));
+    ok_long(hr, S_OK);
+    ok_str(szBuff, szTestValue);
+
+    hr = pSHLoadRegUIStringA(hKey, "TestValue2", szBuff, _countof(szBuff));
+    ok_long(hr, S_OK);
+    ok_str(szBuff, "Test string one.");
+}
+
+static void test_SHLoadRegUIStringW(HKEY hKey)
+{
+    HRESULT hr;
+    WCHAR szTestValue[MAX_PATH];
+    WCHAR szBuff[MAX_PATH];
+
+    GetWindowsDirectoryW(szTestValue, _countof(szTestValue));
+    lstrcatW(szTestValue, L"\\TEST");
+
+    hr = pSHLoadRegUIStringW(hKey, L"TestValue1", szBuff, _countof(szBuff));
+    ok_long(hr, S_OK);
+    ok_wstr(szBuff, L"%WINDIR%\\TEST");
+
+    hr = pSHLoadRegUIStringW(hKey, L"TestValue2", szBuff, _countof(szBuff));
+    ok_long(hr, S_OK);
+    ok_wstr(szBuff, L"Test string one.");
+}
+
+START_TEST(SHLoadRegUIString)
+{
+    LONG error;
+    HKEY hKey;
+    DWORD cbValue;
+    static const WCHAR s_szTestValue1[] = L"%WINDIR%\\TEST";
+    static const WCHAR s_szTestValue2[] = L"@shlwapi_resource_dll.dll%EmptyEnvVar%,-3";
+    HMODULE hSHLWAPI;
+
+    SetEnvironmentVariableW(L"EmptyEnvVar", L"");
+
+    /* Get procedures */
+    hSHLWAPI = GetModuleHandleW(L"shlwapi");
+    pSHLoadRegUIStringA = (FN_SHLoadRegUIStringA)GetProcAddress(hSHLWAPI, (LPCSTR)438);
+    pSHLoadRegUIStringW = (FN_SHLoadRegUIStringW)GetProcAddress(hSHLWAPI, (LPCSTR)439);
+    if (!pSHLoadRegUIStringA || !pSHLoadRegUIStringW)
+    {
+        skip("No procedure found\n");
+        return;
+    }
+
+    /* Open registry key and write some test values */
+    error = RegOpenKeyExW(HKEY_CURRENT_USER, L"Software", 0, KEY_READ | KEY_WRITE, &hKey);
+    ok_long(error, ERROR_SUCCESS);
+
+    cbValue = (lstrlenW(s_szTestValue1) + 1) * sizeof(WCHAR);
+    error = RegSetValueExW(hKey, L"TestValue1", 0, REG_SZ, (LPBYTE)s_szTestValue1, cbValue);
+    ok_long(error, ERROR_SUCCESS);
+
+    cbValue = (lstrlenW(s_szTestValue2) + 1) * sizeof(WCHAR);
+    error = RegSetValueExW(hKey, L"TestValue2", 0, REG_SZ, (LPBYTE)s_szTestValue2, cbValue);
+    ok_long(error, ERROR_SUCCESS);
+
+    /* The main dish */
+    test_SHLoadRegUIStringA(hKey);
+    test_SHLoadRegUIStringW(hKey);
+
+    /* Delete the test values and close the key */
+    RegDeleteValueW(hKey, L"TestValue1");
+    RegCloseKey(hKey);
+}

--- a/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
+++ b/modules/rostests/apitests/shlwapi/SHLoadRegUIString.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS api tests
  * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
  * PURPOSE:     Tests for SHLoadRegUIStringA/W
- * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ (katayama.hirofumi.mz@gmail.com)
+ * COPYRIGHT:   Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
  */
 
 #include <apitest.h>

--- a/modules/rostests/apitests/shlwapi/testlist.c
+++ b/modules/rostests/apitests/shlwapi/testlist.c
@@ -9,6 +9,7 @@ extern void func_PathUnExpandEnvStrings(void);
 extern void func_PathUnExpandEnvStringsForUser(void);
 extern void func_SHAreIconsEqual(void);
 extern void func_SHLoadIndirectString(void);
+extern void func_SHLoadRegUIString(void);
 extern void func_StrFormatByteSizeW(void);
 
 const struct test winetest_testlist[] =
@@ -21,6 +22,7 @@ const struct test winetest_testlist[] =
     { "PathUnExpandEnvStringsForUser", func_PathUnExpandEnvStringsForUser },
     { "SHAreIconsEqual", func_SHAreIconsEqual },
     { "SHLoadIndirectString", func_SHLoadIndirectString },
+    { "SHLoadRegUIString", func_SHLoadRegUIString },
     { "StrFormatByteSizeW", func_StrFormatByteSizeW },
     { 0, 0 }
 };


### PR DESCRIPTION
## Purpose

`shlwapi!SHLoadIndirectString` function seems expanding the environment variable strings.
Split from https://github.com/reactos/reactos/pull/4929.

JIRA issue: [CORE-10667](https://jira.reactos.org/browse/CORE-10667)

## Proposed changes

- `shlwapi!SHLoadIndirectString` expands the environmental strings if the first character was `'@'`.
- Implement `SHLoadRegUIStringA` function.

## TODO

- [x] Do tests.