### PR TITLE
[USETUP] Speed up CONSOLE_SetStatusTextXV +17%

### DIFF
--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -82,6 +82,7 @@ CONSOLE_Init(VOID)
         for (i = 0; i < 10000; ++i)
         {
             va_list va;
+            *(int*)&va = 0;
             CONSOLE_SetStatusTextXV(0, "TESTTESTTEST", va);
         }
         GetSystemTimeAsFileTime(&ft1);
@@ -94,6 +95,7 @@ CONSOLE_Init(VOID)
         for (i = 0; i < 10000; ++i)
         {
             va_list va;
+            *(int*)&va = 0;
             CONSOLE_SetStatusTextXV_Improved(0, "TESTTESTTEST", va);
         }
         GetSystemTimeAsFileTime(&ft1);

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -449,7 +449,7 @@ CONSOLE_SetStatusTextXV(
                                &Written);
     WriteConsoleOutputCharacterA(StdOutput,
                                  Buffer,
-                                 xScreen,
+                                 min(sizeof(Buffer), xScreen),
                                  coPos,
                                  &Written);
 }

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -434,7 +434,6 @@ CONSOLE_SetStatusTextXV(
     DWORD Written;
     CHAR Buffer[128];
 
-    ASSERT(xScreen <= sizeof(Buffer));
     memset(Buffer, ' ', min(sizeof(Buffer), xScreen));
     nLength = vsprintf(&Buffer[x], fmt, args);
     ASSERT(x + nLength < sizeof(Buffer));

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -512,7 +512,7 @@ CONSOLE_SetStatusTextXV_Improved(
     CHAR Buffer[128];
     INT nLength;
 
-    RtlFillMemory(Buffer, xScreen, ' ');
+    memset(Buffer, ' ', xScreen);
     nLength = vsprintf(&Buffer[x], fmt, args);
     Buffer[x + nLength] = ' ';
 

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -41,6 +41,7 @@ SHORT yScreen = 0;
 
 /* FUNCTIONS *****************************************************************/
 
+/* TODO: Replace CONSOLE_SetStatusTextXV with CONSOLE_SetStatusTextXV_Improved */
 VOID
 CONSOLE_SetStatusTextXV(
     IN SHORT x,
@@ -74,7 +75,7 @@ CONSOLE_Init(VOID)
     xScreen = csbi.dwSize.X;
     yScreen = csbi.dwSize.Y;
 
-    /* Test */
+    /* TODO: Delete this test code later */
     {
         DWORD i;
         FILETIME ft0, ft1;

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -41,18 +41,6 @@ SHORT yScreen = 0;
 
 /* FUNCTIONS *****************************************************************/
 
-/* TODO: Replace CONSOLE_SetStatusTextXV with CONSOLE_SetStatusTextXV_Improved */
-VOID
-CONSOLE_SetStatusTextXV(
-    IN SHORT x,
-    IN LPCSTR fmt,
-    IN va_list args);
-VOID
-CONSOLE_SetStatusTextXV_Improved(
-    IN SHORT x,
-    IN LPCSTR fmt,
-    IN va_list args);
-
 BOOLEAN
 CONSOLE_Init(VOID)
 {
@@ -74,34 +62,6 @@ CONSOLE_Init(VOID)
     }
     xScreen = csbi.dwSize.X;
     yScreen = csbi.dwSize.Y;
-
-    /* TODO: Delete this test code later */
-    {
-        DWORD i;
-        FILETIME ft0, ft1;
-        GetSystemTimeAsFileTime(&ft0);
-        for (i = 0; i < 10000; ++i)
-        {
-            va_list va;
-            *(int*)&va = 0;
-            CONSOLE_SetStatusTextXV(0, "TESTTESTTEST", va);
-        }
-        GetSystemTimeAsFileTime(&ft1);
-        DPRINT1("CONSOLE_SetStatusTextXV: %d\n", ft1.dwLowDateTime - ft0.dwLowDateTime);
-    }
-    {
-        DWORD i;
-        FILETIME ft0, ft1;
-        GetSystemTimeAsFileTime(&ft0);
-        for (i = 0; i < 10000; ++i)
-        {
-            va_list va;
-            *(int*)&va = 0;
-            CONSOLE_SetStatusTextXV_Improved(0, "TESTTESTTEST", va);
-        }
-        GetSystemTimeAsFileTime(&ft1);
-        DPRINT1("CONSOLE_SetStatusTextXV_Improved: %d\n", ft1.dwLowDateTime - ft0.dwLowDateTime);
-    }
 
     return TRUE;
 }
@@ -463,7 +423,6 @@ CONSOLE_SetUnderlinedTextXY(
                                 &Written);
 }
 
-/* This is the target function */
 VOID
 CONSOLE_SetStatusTextXV(
     IN SHORT x,
@@ -473,45 +432,9 @@ CONSOLE_SetStatusTextXV(
     COORD coPos;
     DWORD Written;
     CHAR Buffer[128];
-
-    vsprintf(Buffer, fmt, args);
-
-    coPos.X = 0;
-    coPos.Y = yScreen - 1;
-
-    FillConsoleOutputAttribute(StdOutput,
-                               BACKGROUND_WHITE,
-                               xScreen,
-                               coPos,
-                               &Written);
-
-    /* This function call causes blinking */
-    FillConsoleOutputCharacterA(StdOutput,
-                                ' ',
-                                xScreen,
-                                coPos,
-                                &Written);
-
-    coPos.X = x;
-
-    WriteConsoleOutputCharacterA(StdOutput,
-                                 Buffer,
-                                 (ULONG)strlen(Buffer),
-                                 coPos,
-                                 &Written);
-}
-
-VOID
-CONSOLE_SetStatusTextXV_Improved(
-    IN SHORT x,
-    IN LPCSTR fmt,
-    IN va_list args)
-{
-    COORD coPos;
-    DWORD Written;
-    CHAR Buffer[128];
     INT nLength;
 
+    ASSERT(xScreen <= sizeof(Buffer));
     memset(Buffer, ' ', xScreen);
     nLength = vsprintf(&Buffer[x], fmt, args);
     Buffer[x + nLength] = ' ';

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -509,7 +509,7 @@ CONSOLE_SetStatusTextXV_Improved(
     CHAR Buffer[128];
     INT nLength;
 
-    RtlFillMemory(Buffer, sizeof(Buffer), ' ');
+    RtlFillMemory(Buffer, xScreen, ' ');
     nLength = vsprintf(&Buffer[x], fmt, args);
     Buffer[nLength] = ' ';
 

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -511,7 +511,7 @@ CONSOLE_SetStatusTextXV_Improved(
 
     RtlFillMemory(Buffer, xScreen, ' ');
     nLength = vsprintf(&Buffer[x], fmt, args);
-    Buffer[nLength] = ' ';
+    Buffer[x + nLength] = ' ';
 
     coPos.X = 0;
     coPos.Y = yScreen - 1;

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -523,7 +523,6 @@ CONSOLE_SetStatusTextXV_Improved(
                                xScreen,
                                coPos,
                                &Written);
-    coPos.X = 0;
     WriteConsoleOutputCharacterA(StdOutput,
                                  Buffer,
                                  xScreen,

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -462,6 +462,7 @@ CONSOLE_SetUnderlinedTextXY(
                                 &Written);
 }
 
+/* This is the target function */
 VOID
 CONSOLE_SetStatusTextXV(
     IN SHORT x,
@@ -483,6 +484,7 @@ CONSOLE_SetStatusTextXV(
                                coPos,
                                &Written);
 
+    /* This function call causes blinking */
     FillConsoleOutputCharacterA(StdOutput,
                                 ' ',
                                 xScreen,

--- a/base/setup/usetup/consup.c
+++ b/base/setup/usetup/consup.c
@@ -429,14 +429,15 @@ CONSOLE_SetStatusTextXV(
     IN LPCSTR fmt,
     IN va_list args)
 {
+    INT nLength;
     COORD coPos;
     DWORD Written;
     CHAR Buffer[128];
-    INT nLength;
 
     ASSERT(xScreen <= sizeof(Buffer));
-    memset(Buffer, ' ', xScreen);
+    memset(Buffer, ' ', min(sizeof(Buffer), xScreen));
     nLength = vsprintf(&Buffer[x], fmt, args);
+    ASSERT(x + nLength < sizeof(Buffer));
     Buffer[x + nLength] = ' ';
 
     coPos.X = 0;


### PR DESCRIPTION
## Purpose
When watching ReactOS Setup, I found the status text appeared to be flickering.
JIRA issue: [CORE-18838](https://jira.reactos.org/browse/CORE-18838)
## Proposed changes

- Get more speed by omitting erasing and overwriting whole line.

```txt
(base/setup/usetup/consup.c:90) CONSOLE_SetStatusTextXV: 52333248
(base/setup/usetup/consup.c:103) CONSOLE_SetStatusTextXV_Improved: 43486080
```
+17% speed up in `CONSOLE_SetStatusTextXV`.

## TODO

- [x] Do tests.

## Screenshot

![VirtualBox_ReactOS_18_02_2023_18_23_57](https://user-images.githubusercontent.com/2107452/219853493-8272d7ea-cc2c-4de0-a8a0-cfdaa11368b2.png)