### PR TITLE
[NTOS:CM] Implement registry cache lookup & enforce cache consistency

### DIFF
--- a/modules/rostests/winetests/ntdll/reg.c
+++ b/modules/rostests/winetests/ntdll/reg.c
@@ -1797,23 +1797,18 @@ static void test_NtQueryKey(void)
     ok( status == STATUS_SUCCESS, "NtSetValueKey failed: 0x%08x\n", status );
     pRtlFreeUnicodeString(&str);
 
-    if (!winetest_interactive)
-        skip("ROSTESTS-198: Causes an assert in Cm.\n");
-    else
-    {
-        status = pNtQueryKey(subkey, KeyCachedInformation, &cached_info, sizeof(cached_info), &len);
-        ok(status == STATUS_SUCCESS, "NtQueryKey Failed: 0x%08x\n", status);
+    status = pNtQueryKey(subkey, KeyCachedInformation, &cached_info, sizeof(cached_info), &len);
+    ok(status == STATUS_SUCCESS, "NtQueryKey Failed: 0x%08x\n", status);
 
-        if (status == STATUS_SUCCESS)
-        {
-            ok(len == sizeof(cached_info), "got unexpected length %d\n", len);
-            ok(cached_info.SubKeys == 1, "cached_info.SubKeys = %u\n", cached_info.SubKeys);
-            ok(cached_info.MaxNameLen == 24, "cached_info.MaxNameLen = %u\n", cached_info.MaxNameLen);
-            ok(cached_info.Values == 1, "cached_info.Values = %u\n", cached_info.Values);
-            ok(cached_info.MaxValueNameLen == 6, "cached_info.MaxValueNameLen = %u\n", cached_info.MaxValueNameLen);
-            ok(cached_info.MaxValueDataLen == 4, "cached_info.MaxValueDataLen = %u\n", cached_info.MaxValueDataLen);
-            ok(cached_info.NameLength == 22, "cached_info.NameLength = %u\n", cached_info.NameLength);
-        }
+    if (status == STATUS_SUCCESS)
+    {
+        ok(len == sizeof(cached_info), "got unexpected length %d\n", len);
+        ok(cached_info.SubKeys == 1, "cached_info.SubKeys = %u\n", cached_info.SubKeys);
+        ok(cached_info.MaxNameLen == 24, "cached_info.MaxNameLen = %u\n", cached_info.MaxNameLen);
+        ok(cached_info.Values == 1, "cached_info.Values = %u\n", cached_info.Values);
+        ok(cached_info.MaxValueNameLen == 6, "cached_info.MaxValueNameLen = %u\n", cached_info.MaxValueNameLen);
+        ok(cached_info.MaxValueDataLen == 4, "cached_info.MaxValueDataLen = %u\n", cached_info.MaxValueDataLen);
+        ok(cached_info.NameLength == 22, "cached_info.NameLength = %u\n", cached_info.NameLength);
     }
 
     status = pNtDeleteKey(subkey2);

--- a/ntoskrnl/config/cmkcbncb.c
+++ b/ntoskrnl/config/cmkcbncb.c
@@ -1135,6 +1135,154 @@ DelistKeyBodyFromKCB(IN PCM_KEY_BODY KeyBody,
 }
 
 VOID
+CmpUnLockKcbArray(
+    _In_ PULONG KcbArray)
+{
+    ULONG i;
+
+    /* Release the locked KCBs in reverse order */
+    for (i = KcbArray[0]; i > 0; i--)
+    {
+        CmpReleaseKcbLockByIndex(KcbArray[i]);
+    }
+}
+
+static
+VOID
+CmpLockKcbArray(
+    _In_ PULONG KcbArray,
+    _In_ ULONG KcbLockFlags)
+{
+    ULONG i;
+
+    /* Lock the KCBs */
+    for (i = 1; i <= KcbArray[0]; i++)
+    {
+        if (KcbLockFlags & CMP_LOCK_KCB_ARRAY_EXCLUSIVE)
+        {
+            CmpAcquireKcbLockExclusiveByIndex(KcbArray[i]);
+        }
+        else // CMP_LOCK_KCB_ARRAY_SHARED
+        {
+            CmpAcquireKcbLockSharedByIndex(KcbArray[i]);
+        }
+    }
+}
+
+static
+VOID
+CmpSortKcbArray(
+    _Inout_ PULONG KcbArray)
+{
+    ULONG i, j, k, KcbCount;
+
+    /* Ensure we don't go above the limit of KCBs we can hold */
+    KcbCount = KcbArray[0];
+    ASSERT(KcbCount < CMP_KCBS_IN_ARRAY_LIMIT);
+
+    /* Exchange-Sort the array in ascending order. Complexity: O[n^2] */
+    for (i = 1; i <= KcbCount; i++)
+    {
+        for (j = i + 1; j <= KcbCount; j++)
+        {
+            if (KcbArray[i] > KcbArray[j])
+            {
+                ULONG Temp = KcbArray[i];
+                KcbArray[i] = KcbArray[j];
+                KcbArray[j] = Temp;
+            }
+        }
+    }
+
+    /* Now remove any duplicated indices on the sorted array if any */
+    for (i = 1; i <= KcbCount; i++)
+    {
+        for (j = i + 1; j <= KcbCount; j++)
+        {
+            if (KcbArray[i] == KcbArray[j])
+            {
+                for (k = j; k <= KcbCount; k++)
+                {
+                    KcbArray[k - 1] = KcbArray[k];
+                }
+
+                j--;
+                KcbCount--;
+            }
+        }
+    }
+
+    /* Update the KCB count */
+    KcbArray[0] = KcbCount;
+}
+
+PULONG
+NTAPI
+CmpBuildAndLockKcbArray(
+    _In_ PCM_HASH_CACHE_STACK HashCacheStack,
+    _In_ ULONG KcbLockFlags,
+    _In_ PCM_KEY_CONTROL_BLOCK Kcb,
+    _Inout_ PULONG OuterStackArray,
+    _In_ ULONG TotalRemainingSubkeys,
+    _In_ ULONG MatchRemainSubkeyLevel)
+{
+    ULONG KcbIndex = 1, HashStackIndex, TotalRemaining;
+    PULONG LockedKcbs = NULL;
+    PCM_KEY_CONTROL_BLOCK ParentKcb = Kcb->ParentKcb;;
+
+    /* These parameters are expected */
+    ASSERT(HashCacheStack != NULL);
+    ASSERT(Kcb != NULL);
+    ASSERT(OuterStackArray != NULL);
+
+    /*
+     * Ensure when we build an array of KCBs to lock, that
+     * we don't go beyond the boundary the limit allows us
+     * to. 1 is the current KCB we would want to lock
+     * alongside with the remaining key levels in the formula.
+     */
+    TotalRemaining = (1 + TotalRemainingSubkeys) - MatchRemainSubkeyLevel;
+    ASSERT(TotalRemaining <= CMP_KCBS_IN_ARRAY_LIMIT);
+
+    /* Count the parent if we have one */
+    if (ParentKcb)
+    {
+        /* Ensure we are still below the limit and add the parent to KCBs to lock */
+        if (TotalRemainingSubkeys == MatchRemainSubkeyLevel)
+        {
+            TotalRemaining++;
+            ASSERT(TotalRemaining <= CMP_KCBS_IN_ARRAY_LIMIT);
+            OuterStackArray[KcbIndex++] = GET_HASH_INDEX(ParentKcb->ConvKey);
+        }
+    }
+
+    /* Add the current KCB */
+    OuterStackArray[KcbIndex++] = GET_HASH_INDEX(Kcb->ConvKey);
+
+    /* Loop over the hash stack and grab the hashes for locking (they will be converted to indices) */
+    for (HashStackIndex = 0;
+         HashStackIndex < TotalRemainingSubkeys;
+         HashStackIndex++)
+    {
+        OuterStackArray[KcbIndex++] = GET_HASH_INDEX(HashCacheStack[HashStackIndex].ConvKey);
+    }
+
+    /*
+     * Store how many KCBs we need to lock and sort the array.
+     * Remove any duplicated indices from the array if any.
+     */
+    OuterStackArray[0] = KcbIndex - 1;
+    CmpSortKcbArray(OuterStackArray);
+
+    /* Lock them */
+    CmpLockKcbArray(OuterStackArray, KcbLockFlags);
+
+    /* Give the locked KCBs to caller now */
+    LockedKcbs = OuterStackArray;
+    return LockedKcbs;
+}
+
+VOID
 NTAPI
 CmpFlushNotifiesOnKeyBodyList(IN PCM_KEY_CONTROL_BLOCK Kcb,
                               IN BOOLEAN LockHeld)

--- a/ntoskrnl/config/cmparse.c
+++ b/ntoskrnl/config/cmparse.c
@@ -367,14 +367,14 @@ CmpDoCreateChild(IN PHHIVE Hive,
                               CmpKeyObjectType->TypeInfo.PoolType);
     if (NT_SUCCESS(Status))
     {
-        Status = CmpSecurityMethod(*Object,
-                                   AssignSecurityDescriptor,
-                                   NULL,
-                                   NewDescriptor,
-                                   NULL,
-                                   NULL,
-                                   CmpKeyObjectType->TypeInfo.PoolType,
-                                   &CmpKeyObjectType->TypeInfo.GenericMapping);
+        /*
+         * FIXME: We must acquire a security lock when assigning
+         * a security descriptor to this hive but since the
+         * CmpAssignSecurityDescriptor function does nothing
+         * (we lack the necessary security management implementations
+         * anyway), do not do anything for now.
+         */
+        Status = CmpAssignSecurityDescriptor(Kcb, NewDescriptor);
     }
 
     /* Now that the security descriptor is copied in the hive, we can free the original */

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -138,7 +138,7 @@ CmpDeleteKeyObject(PVOID DeletedObject)
         if (Kcb)
         {
             /* Delist the key */
-            DelistKeyBodyFromKCB(KeyBody, FALSE);
+            DelistKeyBodyFromKCB(KeyBody, KeyBody->KcbLocked);
 
             /* Dereference the KCB */
             CmpDelayDerefKeyControlBlock(Kcb);

--- a/ntoskrnl/config/cmsysini.c
+++ b/ntoskrnl/config/cmsysini.c
@@ -1126,6 +1126,7 @@ CmpCreateRegistryRoot(VOID)
     RootKey->Type = CM_KEY_BODY_TYPE;
     RootKey->NotifyBlock = NULL;
     RootKey->ProcessID = PsGetCurrentProcessId();
+    RootKey->KcbLocked = FALSE;
 
     /* Link with KCB */
     EnlistKeyBodyWithKCB(RootKey, 0);

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -511,6 +511,15 @@ CmpDestroyHiveViewList(
 );
 
 //
+// Security Management Functions
+//
+NTSTATUS
+CmpAssignSecurityDescriptor(
+    IN PCM_KEY_CONTROL_BLOCK Kcb,
+    IN PSECURITY_DESCRIPTOR SecurityDescriptor
+);
+
+//
 // Security Cache Functions
 //
 VOID

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -96,6 +96,12 @@
 #define CMP_ENLIST_KCB_LOCKED_EXCLUSIVE                 0x2
 
 //
+// CmpBuildAndLockKcbArray & CmpLockKcbArray Flags
+//
+#define CMP_LOCK_KCB_ARRAY_EXCLUSIVE                    0x1
+#define CMP_LOCK_KCB_ARRAY_SHARED                       0x2
+
+//
 // Unload Flags
 //
 #define CMP_UNLOCK_KCB_LOCKED                    0x1
@@ -118,6 +124,12 @@
     ((PAGE_SIZE - FIELD_OFFSET(CM_ALLOC_PAGE, AllocPage)) / sizeof(CM_KEY_CONTROL_BLOCK))
 #define CM_DELAYS_PER_PAGE                              \
     ((PAGE_SIZE - FIELD_OFFSET(CM_ALLOC_PAGE, AllocPage)) / sizeof(CM_DELAY_ALLOC))
+
+//
+// Cache Lookup & KCB Array constructs
+//
+#define CMP_SUBKEY_LEVELS_DEPTH_LIMIT   32
+#define CMP_KCBS_IN_ARRAY_LIMIT         (CMP_SUBKEY_LEVELS_DEPTH_LIMIT + 2)
 
 //
 // Value Search Results
@@ -401,6 +413,15 @@ typedef struct _HIVE_LIST_ENTRY
     BOOLEAN ThreadStarted;
     BOOLEAN Allocate;
 } HIVE_LIST_ENTRY, *PHIVE_LIST_ENTRY;
+
+//
+// Hash Cache Stack
+//
+typedef struct _CM_HASH_CACHE_STACK
+{
+    UNICODE_STRING NameOfKey;
+    ULONG ConvKey;
+} CM_HASH_CACHE_STACK, *PCM_HASH_CACHE_STACK;
 
 //
 // Parse context for Key Object
@@ -995,6 +1016,23 @@ DelistKeyBodyFromKCB(
 
 VOID
 NTAPI
+CmpUnLockKcbArray(
+    _In_ PULONG LockedKcbs
+);
+
+PULONG
+NTAPI
+CmpBuildAndLockKcbArray(
+    _In_ PCM_HASH_CACHE_STACK HashCacheStack,
+    _In_ ULONG KcbLockFlags,
+    _In_ PCM_KEY_CONTROL_BLOCK Kcb,
+    _Inout_ PULONG OuterStackArray,
+    _In_ ULONG TotalRemainingSubkeys,
+    _In_ ULONG MatchRemainSubkeyLevel
+);
+
+VOID
+NTAPI
 CmpAcquireTwoKcbLocksExclusiveByKey(
     IN ULONG ConvKey1,
     IN ULONG ConvKey2
@@ -1084,6 +1122,7 @@ CmpCreateLinkNode(
     IN PHHIVE Hive,
     IN HCELL_INDEX Cell,
     IN PACCESS_STATE AccessState,
+    IN PULONG KcbsLocked,
     IN UNICODE_STRING Name,
     IN KPROCESSOR_MODE AccessMode,
     IN ULONG CreateOptions,

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -235,6 +235,9 @@ typedef struct _CM_KEY_BODY
     struct _CM_NOTIFY_BLOCK *NotifyBlock;
     HANDLE ProcessID;
     LIST_ENTRY KeyBodyList;
+
+    /* ReactOS specific -- boolean flag to avoid recursive locking of the KCB */
+    BOOLEAN KcbLocked;
 } CM_KEY_BODY, *PCM_KEY_BODY;
 
 //

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -1015,7 +1015,6 @@ DelistKeyBodyFromKCB(
 );
 
 VOID
-NTAPI
 CmpUnLockKcbArray(
     _In_ PULONG LockedKcbs
 );

--- a/ntoskrnl/include/internal/cm.h
+++ b/ntoskrnl/include/internal/cm.h
@@ -1133,12 +1133,12 @@ CmpCreateLinkNode(
     IN PHHIVE Hive,
     IN HCELL_INDEX Cell,
     IN PACCESS_STATE AccessState,
-    IN PULONG KcbsLocked,
     IN UNICODE_STRING Name,
     IN KPROCESSOR_MODE AccessMode,
     IN ULONG CreateOptions,
     IN PCM_PARSE_CONTEXT Context,
     IN PCM_KEY_CONTROL_BLOCK ParentKcb,
+    IN PULONG KcbsLocked,
     OUT PVOID *Object
 );
 

--- a/ntoskrnl/include/internal/cm_x.h
+++ b/ntoskrnl/include/internal/cm_x.h
@@ -16,7 +16,7 @@
 // Returns the index into the hash table, or the entry itself
 //
 #define GET_HASH_INDEX(ConvKey)                                     \
-    GET_HASH_KEY(ConvKey) % CmpHashTableSize
+    (GET_HASH_KEY(ConvKey) % CmpHashTableSize)
 #define GET_HASH_ENTRY(Table, ConvKey)                              \
     (&Table[GET_HASH_INDEX(ConvKey)])
 #define ASSERT_VALID_HASH(h)                                        \

--- a/ntoskrnl/include/internal/cm_x.h
+++ b/ntoskrnl/include/internal/cm_x.h
@@ -90,6 +90,14 @@
                     (k)->ConvKey)->Owner == KeGetCurrentThread())
 
 //
+// Shared acquires a KCB by index
+//
+#define CmpAcquireKcbLockSharedByIndex(i)                           \
+{                                                                   \
+    ExAcquirePushLockShared(&CmpCacheTable[(i)].Lock);              \
+}
+
+//
 // Exclusively acquires a KCB by index
 //
 FORCEINLINE
@@ -120,6 +128,16 @@ CmpAcquireKcbLockExclusiveByKey(IN ULONG ConvKey)
     CmpAcquireKcbLockExclusiveByIndex(GET_HASH_INDEX(ConvKey));
 }
 
+//
+// Shared acquires a KCB by key
+//
+FORCEINLINE
+VOID
+CmpAcquireKcbLockSharedByKey(
+    _In_ ULONG ConvKey)
+{
+    CmpAcquireKcbLockSharedByIndex(GET_HASH_INDEX(ConvKey));
+}
 
 //
 // Shared acquires a KCB
@@ -128,14 +146,6 @@ CmpAcquireKcbLockExclusiveByKey(IN ULONG ConvKey)
 {                                                                   \
     ExAcquirePushLockShared(&GET_HASH_ENTRY(CmpCacheTable,          \
                                             (k)->ConvKey)->Lock);    \
-}
-
-//
-// Shared acquires a KCB by index
-//
-#define CmpAcquireKcbLockSharedByIndex(i)                           \
-{                                                                   \
-    ExAcquirePushLockShared(&CmpCacheTable[(i)].Lock);              \
 }
 
 //

--- a/ntoskrnl/include/internal/cm_x.h
+++ b/ntoskrnl/include/internal/cm_x.h
@@ -13,6 +13,12 @@
     ((CMP_HASH_IRRATIONAL * (ConvKey)) % CMP_HASH_PRIME)
 
 //
+// Computes the hashkey of a character
+//
+#define COMPUTE_HASH_CHAR(ConvKey, Char)                            \
+    (37 * ConvKey + RtlUpcaseUnicodeChar(Char))
+
+//
 // Returns the index into the hash table, or the entry itself
 //
 #define GET_HASH_INDEX(ConvKey)                                     \


### PR DESCRIPTION
## Purpose
ReactOS implements a cache feature for the registry thanks to `CmpCacheTable` and various functions that handle it. With this, registry data can be cached on respective key control blocks (KCBs) so that such data can be acquired quickly. Except that the cached data isn't quite consistent.

The reason why the cache can become inconsistent is because we don't properly clean the subkey's information, such as when we are creating a link node or a new key. As a result the cached data can get out of sync and such data in a KCB might not reflect with the actual data of the subkey itself. Moreover, we barely do any cache lookup which means if a key path component is already in cache we will not ever acknowledge that. This PR, together with #4571, it embodies the "registry data integrity" goal which is what I'm trying to achieve.
## Proposed Changes
* Implement `CmpLookInCache`, the heart and brains of cache lookup;
* Implement `CmpBuildAndLockKcbArray` and `CmpComputeHashValue`. Together with these two, we can compute the hash values of each path name component of a registry key and lock the KCBs of each key component by their hash CONVKEY;
* Implement `CmpBuildHashStackAndLookupCache`;
* Don't touch read-only KCBs when creating a link node or just a mere key;
* Do a soft rewrite of `CmpDoOpen`, when using a KCB from cache we would want to expect a shared lock here. Also don't touch the registry node when we already have a KCB. Otherwise the passed KCB must be held with lock exclusively on new KCB creation;
* Add missing `CmpCleanUpSubKeyInfo` calls when performing a `create` procedure of a registry key object (key or link node);
* Add missing cleanup code paths in `CmpDoCreate`;
* Lock the hive flusher where appropriate, in `create` procedure, we don't want the lazy flusher to kick in when we are creating something on the target hive;
* Add missing KCB lock assertions;
* Fix a push lock acquiring recursion in `CmpSecurityMethod`, where it can happen that we might acquire a push lock (whether exclusive or shared) twice which it hangs the calling thread due to the nature of push locks;
* Document the code.
## TODO (for future PRs)
* Currently we don't handle `CM_KCB_SYM_LINK_FOUND`, a flag that indicates a symbolic link has been found (or resolved, whatever that is) which is necessary if a KCB is cached but such block is also a symbolic link. Perhaps `CmpGetSymbolicLink` might need some improvements.
* The registry parser of ReactOS doesn't handle fake keys. We are good because we don't create them anywhere anyway but when the time comes, `CmpParseKey` must require code adaptations to handle fake keys differently than the usual keys. FIXME comments have been added as reminders.
## JIRA Issues
[CORE-10581](https://jira.reactos.org/browse/CORE-10581)
[ROSTESTS-198](https://jira.reactos.org/browse/ROSTESTS-198)
## TODO
- [x] Fix a recursive lock in `CmpBuildAndLockKcbArray` (and other potential bugs I may find)
- [x] Run a testbot