### PR TITLE
[MCIAVI32] Add ifdef guards to prevent regression

### DIFF
--- a/dll/win32/mciavi32/mmoutput.c
+++ b/dll/win32/mciavi32/mmoutput.c
@@ -399,11 +399,13 @@ BOOL MCIAVI_GetInfo(WINE_MCIAVI* wma)
 	mmioAscend(wma->hFile, &mmckInfo, 0);
     }
 
+#ifdef __REACTOS__
     /* Empty file */
     if (alb.numVideoFrames == 0) {
         WARN("NumVideoFrames: %u, Empty or possibly corrupt video file");
         return FALSE;
     }
+#endif
 
     if (alb.numVideoFrames != wma->dwPlayableVideoFrames) {
 	WARN("AVI header says %d frames, we found %d video frames, reducing playable frames\n",
@@ -620,10 +622,12 @@ double MCIAVI_PaintFrame(WINE_MCIAVI* wma, HDC hDC)
 
     if (wma->dwCurrVideoFrame != wma->dwCachedFrame)
     {
+#ifdef __REACTOS__
         if (wma->dwCurrVideoFrame >= wma->dwPlayableVideoFrames) {
             ERR("Invalid frame requested. Current : %u Total Playable %u\n", wma->dwCurrVideoFrame, wma->dwPlayableVideoFrames);
             return 0;
         }
+#endif
 
         if (!wma->lpVideoIndex[wma->dwCurrVideoFrame].dwOffset)
 	    return 0;


### PR DESCRIPTION
`#ifdef` guard was missed as part of the previous (PR)(https://github.com/reactos/reactos/pull/5063)
