### PR TITLE
[INBV] Omit black screen fill at epilogue of boot

### DIFF
--- a/ntoskrnl/inbv/bootanim.c
+++ b/ntoskrnl/inbv/bootanim.c
@@ -755,12 +755,6 @@ FinalizeBootLogo(VOID)
 {
     /* Acquire lock and check the display state */
     InbvAcquireLock();
-    if (InbvGetDisplayState() == INBV_DISPLAY_STATE_OWNED)
-    {
-        /* Clear the screen */
-        VidSolidColorFill(0, 0, SCREEN_WIDTH-1, SCREEN_HEIGHT-1, BV_COLOR_BLACK);
-    }
-
     /* Reset progress bar and lock */
 #ifdef INBV_ROTBAR_IMPLEMENTED
     PltRotBarStatus = RBS_STOP_ANIMATE;


### PR DESCRIPTION
## Purpose

Speed up!
JIRA issue: N/A

## Proposed changes

- Do not fill the screen by black at `FinalizeBootLogo` function.

## TODO

- [x] Do tests.