### PR TITLE
[USETUP][INFLIB] Don't use HEAP_ZERO_MEMORY for malloc

### DIFF
--- a/base/setup/usetup/spapisup/cabinet.c
+++ b/base/setup/usetup/spapisup/cabinet.c
@@ -140,7 +140,7 @@ typedef struct _CFDATA
 void *__cdecl
 malloc(size_t size)
 {
-    return RtlAllocateHeap(ProcessHeap, HEAP_ZERO_MEMORY, size);
+    return RtlAllocateHeap(ProcessHeap, 0, size);
 }
 
 void __cdecl

--- a/sdk/lib/inflib/infget.c
+++ b/sdk/lib/inflib/infget.c
@@ -212,6 +212,7 @@ InfpFindFirstLine(PINFCACHE Cache,
       DPRINT1("MALLOC() failed\n");
       return INF_STATUS_NO_MEMORY;
     }
+  ZEROMEMORY(*Context, sizeof(INFCONTEXT));
   (*Context)->Inf = (PVOID)Cache;
   (*Context)->Section = CacheSection->Id;
   (*Context)->Line = CacheLine->Id;

--- a/sdk/lib/inflib/infput.c
+++ b/sdk/lib/inflib/infput.c
@@ -55,6 +55,7 @@ Output(POUTPUTBUFFER OutBuf, PCWSTR Text)
           OutBuf->Status = INF_STATUS_NO_MEMORY;
           return;
         }
+      ZEROMEMORY(NewBuf, NewSize);
 
       /* Need to copy old contents? */
       if (NULL != OutBuf->Buffer)
@@ -200,6 +201,7 @@ InfpFindOrAddSection(PINFCACHE Cache,
       DPRINT1("MALLOC() failed\n");
       return INF_STATUS_NO_MEMORY;
     }
+  ZEROMEMORY(*Context, sizeof(INFCONTEXT));
 
   (*Context)->Inf = Cache;
   (*Context)->Line = 0;


### PR DESCRIPTION
## Purpose

The `malloc` function doesn't need `HEAP_ZERO_MEMORY` flag.
JIRA issue: [CORE-18838](https://jira.reactos.org/browse/CORE-18838)

## TODO

- [x] Do tests.
