### PR TITLE
[MSAFD] Work around regression of CORE-18848 from 0.4.12-dev-693-g2b1f6c8

### DIFF
--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2499,7 +2499,11 @@ WSPIoctl(IN  SOCKET Handle,
                     *((PVOID *)lpvOutBuffer) = WSPConnectEx;
                     cbRet = sizeof(PVOID);
                     Errno = NO_ERROR;
-                    Ret = NO_ERROR;
+                    /* See CORE-14966 and associated commits.
+                     * Original line below was 'Ret = NO_ERROR:'.
+                     * This caused winetest ws2_32:sock to hang.
+                     * This new Ret value allows the test to complete. */
+                    Ret = SOCKET_ERROR;
                 }
                 else if (IsEqualGUID(&DisconnectExGUID, lpvInBuffer))
                 {
@@ -2513,7 +2517,11 @@ WSPIoctl(IN  SOCKET Handle,
                     *((PVOID *)lpvOutBuffer) = WSPGetAcceptExSockaddrs;
                     cbRet = sizeof(PVOID);
                     Errno = NO_ERROR;
-                    Ret = NO_ERROR;
+                    /* See CORE-14966 and associated commits.
+                     * Original line below was 'Ret = NO_ERROR:'.
+                     * This caused winetest ws2_32:sock to hang.
+                     * This new Ret value allows the test to complete. */
+                    Ret = SOCKET_ERROR;
                 }
                 else
                 {

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2499,12 +2499,7 @@ WSPIoctl(IN  SOCKET Handle,
                     *((PVOID *)lpvOutBuffer) = WSPConnectEx;
                     cbRet = sizeof(PVOID);
                     Errno = NO_ERROR;
-                    /* See CORE-14966 and associated commits.
-                     * Original line below was 'Ret = NO_ERROR:'.
-                     * This caused winetest ws2_32:sock to hang.
-                     * This new Ret value allows the test to complete. */
-                    ERR("SIO_GET_EXTENSION_FUNCTION_POINTER UNIMPLEMENTED!\n");
-                    Ret = SOCKET_ERROR;
+                    Ret = NO_ERROR;
                 }
                 else if (IsEqualGUID(&DisconnectExGUID, lpvInBuffer))
                 {

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2517,7 +2517,7 @@ WSPIoctl(IN  SOCKET Handle,
                      * Original line below was 'Ret = NO_ERROR:'.
                      * This caused winetest ws2_32:sock to hang.
                      * This new Ret value allows the test to complete. */
-                    ERR("SIO_GET_EXTENSION_FUNCTION_POINTER UNIMPLEMENTED!\n");
+                    ERR("SIO_GET_EXTENSION_FUNCTION_POINTER UNIMPLEMENTED\n");
                     Ret = SOCKET_ERROR;
                 }
                 else

--- a/dll/win32/msafd/misc/dllmain.c
+++ b/dll/win32/msafd/misc/dllmain.c
@@ -2503,6 +2503,7 @@ WSPIoctl(IN  SOCKET Handle,
                      * Original line below was 'Ret = NO_ERROR:'.
                      * This caused winetest ws2_32:sock to hang.
                      * This new Ret value allows the test to complete. */
+                    ERR("SIO_GET_EXTENSION_FUNCTION_POINTER UNIMPLEMENTED!\n");
                     Ret = SOCKET_ERROR;
                 }
                 else if (IsEqualGUID(&DisconnectExGUID, lpvInBuffer))
@@ -2521,6 +2522,7 @@ WSPIoctl(IN  SOCKET Handle,
                      * Original line below was 'Ret = NO_ERROR:'.
                      * This caused winetest ws2_32:sock to hang.
                      * This new Ret value allows the test to complete. */
+                    ERR("SIO_GET_EXTENSION_FUNCTION_POINTER UNIMPLEMENTED!\n");
                     Ret = SOCKET_ERROR;
                 }
                 else


### PR DESCRIPTION
## Purpose

_Fix hang of winetest ws2_32:sock caused by revision 0.4.12-dev-693-g2b1f6c8._

JIRA issue: [CORE-18848](https://jira.reactos.org/browse/CORE-18848)

## Proposed changes

_Revert some minor return value changes by Pierre Schweitzer for CORE-14966 which affects msafd.dll._

It appears that he attempted to improve Steam installs, but was unsuccessful to make the install run with this commit:
https://github.com/reactos/reactos/commit/2b1f6c8b0d73b80c9aeaf8808c66c0c52eb1f320
This seemed intended to only stub some functions, but the new return values caused the ws2_32:sock test to hang.
Therefore, it should not be too dangerous to revert the return values of his changes.

My intent is to reduce the test errors by reverting to the original return values when the 'sock' test worked.
This way a minimum of the current ws2_32:sock tests can be bypassed to allow successful completion of this test.
Currently it is necessary to bypass three (3) of the sub-tests.
With these changes, it will be necessary to only bypass two (2) of the sub-tests.
This test currently always hangs with no summary output because of the timeout.
I intend to create another PR after this one is merged to allow the sock tests successful completion.
This will be done by temporarily bypassing two (2) of the sub-tests.

The testbot results are shown in the referenced JIRA issue here:  https://jira.reactos.org/browse/CORE-18848
From what I can tell, they look good. I enabled the ws2_32:sock tests by including an additional patch for it.
This allows us to see that the test runs and completes successfully with the two sub-tests bypassed.