### PR TITLE
[NOTEPAD] Fix NOTEPAD_FindTextAt

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -111,30 +111,30 @@ NOTEPAD_FindTextAt(FINDREPLACE *pFindReplace, LPCTSTR pszText, INT iTextLength, 
 {
     BOOL bMatches;
     size_t iTargetLength;
-    LPCTSTR pch;
+    LPCTSTR pchPosition;
 
     if (!pFindReplace || !pszText)
         return FALSE;
 
     iTargetLength = _tcslen(pFindReplace->lpstrFindWhat);
-    pch = &pszText[dwPosition];
+    pchPosition = &pszText[dwPosition];
 
     /* Make proper comparison */
     if (pFindReplace->Flags & FR_MATCHCASE)
-        bMatches = !_tcsncmp(pch, pFindReplace->lpstrFindWhat, iTargetLength);
+        bMatches = !_tcsncmp(pchPosition, pFindReplace->lpstrFindWhat, iTargetLength);
     else
-        bMatches = !_tcsnicmp(pch, pFindReplace->lpstrFindWhat, iTargetLength);
+        bMatches = !_tcsnicmp(pchPosition, pFindReplace->lpstrFindWhat, iTargetLength);
 
     if (bMatches && (pFindReplace->Flags & FR_WHOLEWORD))
     {
         if (dwPosition > 0)
         {
-            if (_istalnum(*(pch - 1)) || *(pch - 1) == _T('_'))
+            if (_istalnum(*(pchPosition - 1)) || *(pchPosition - 1) == _T('_'))
                bMatches = FALSE;
         }
         if ((INT)dwPosition + iTargetLength < iTextLength)
         {
-            if (_istalnum(pch[iTargetLength]) || pch[iTargetLength] == _T('_'))
+            if (_istalnum(pchPosition[iTargetLength]) || pchPosition[iTargetLength] == _T('_'))
                 bMatches = FALSE;
         }
     }

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -107,30 +107,36 @@ static int NOTEPAD_MenuCommand(WPARAM wParam)
  */
 
 static BOOL
-NOTEPAD_FindTextAt(FINDREPLACE *pFindReplace, LPCTSTR pszText, int iTextLength, DWORD dwPosition)
+NOTEPAD_FindTextAt(FINDREPLACE *pFindReplace, LPCTSTR pszText, INT iTextLength, DWORD dwPosition)
 {
     BOOL bMatches;
     size_t iTargetLength;
+    LPCTSTR pch;
 
-    if ((!pFindReplace) || (!pszText))
-    {
+    if (!pFindReplace || !pszText)
         return FALSE;
-    }
 
     iTargetLength = _tcslen(pFindReplace->lpstrFindWhat);
+    pch = &pszText[dwPosition];
 
     /* Make proper comparison */
     if (pFindReplace->Flags & FR_MATCHCASE)
-        bMatches = !_tcsncmp(&pszText[dwPosition], pFindReplace->lpstrFindWhat, iTargetLength);
+        bMatches = !_tcsncmp(pch, pFindReplace->lpstrFindWhat, iTargetLength);
     else
-        bMatches = !_tcsnicmp(&pszText[dwPosition], pFindReplace->lpstrFindWhat, iTargetLength);
+        bMatches = !_tcsnicmp(pch, pFindReplace->lpstrFindWhat, iTargetLength);
 
-    if (bMatches && pFindReplace->Flags & FR_WHOLEWORD)
+    if (bMatches && (pFindReplace->Flags & FR_WHOLEWORD))
     {
-        if ((dwPosition > 0) && !_istspace(pszText[dwPosition-1]))
-            bMatches = FALSE;
-        if ((dwPosition < (DWORD) iTextLength - 1) && !_istspace(pszText[dwPosition+1]))
-            bMatches = FALSE;
+        if (dwPosition > 0)
+        {
+            if (_istalnum(*(pch - 1)) || *(pch - 1) == _T('_'))
+               bMatches = FALSE;
+        }
+        if ((INT)dwPosition + iTargetLength < iTextLength)
+        {
+            if (_istalnum(pch[iTargetLength]) || pch[iTargetLength] == _T('_'))
+                bMatches = FALSE;
+        }
     }
 
     return bMatches;

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -130,7 +130,7 @@ NOTEPAD_FindTextAt(FINDREPLACE *pFindReplace, LPCTSTR pszText, INT iTextLength, 
         if (dwPosition > 0)
         {
             if (_istalnum(*(pchPosition - 1)) || *(pchPosition - 1) == _T('_'))
-               bMatches = FALSE;
+                bMatches = FALSE;
         }
         if ((INT)dwPosition + iTargetLength < iTextLength)
         {


### PR DESCRIPTION
## Purpose
The whole-word search of Notepad had a bug around punctuation. For example, the text `"Windows"` didn't match in the text `"MS-DOS,Windows,ReactOS"`.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Use `_istalnum` instead of `_istspace`.
- Fix the position to check.

`_istalnum` matches an alphabet letter or numeric digit.

## TODO

- [x] Do tests.