### PR TITLE
[NOTEPAD] Don't reset Find/Replace if lpstrFindWhat is set

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -1053,7 +1053,6 @@ static VOID DIALOG_SearchDialog(FINDPROC pfnProc)
         ZeroMemory(&Globals.find, sizeof(Globals.find));
         Globals.find.lStructSize = sizeof(Globals.find);
         Globals.find.hwndOwner = Globals.hMainWnd;
-        Globals.find.hInstance = Globals.hInstance;
         Globals.find.lpstrFindWhat = Globals.szFindText;
         Globals.find.wFindWhatLen = ARRAY_SIZE(Globals.szFindText);
         Globals.find.lpstrReplaceWith = Globals.szReplaceText;

--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -1048,15 +1048,18 @@ static VOID DIALOG_SearchDialog(FINDPROC pfnProc)
         return;
     }
 
-    ZeroMemory(&Globals.find, sizeof(Globals.find));
-    Globals.find.lStructSize = sizeof(Globals.find);
-    Globals.find.hwndOwner = Globals.hMainWnd;
-    Globals.find.hInstance = Globals.hInstance;
-    Globals.find.lpstrFindWhat = Globals.szFindText;
-    Globals.find.wFindWhatLen = ARRAY_SIZE(Globals.szFindText);
-    Globals.find.lpstrReplaceWith = Globals.szReplaceText;
-    Globals.find.wReplaceWithLen = ARRAY_SIZE(Globals.szReplaceText);
-    Globals.find.Flags = FR_DOWN;
+    if (!Globals.find.lpstrFindWhat)
+    {
+        ZeroMemory(&Globals.find, sizeof(Globals.find));
+        Globals.find.lStructSize = sizeof(Globals.find);
+        Globals.find.hwndOwner = Globals.hMainWnd;
+        Globals.find.hInstance = Globals.hInstance;
+        Globals.find.lpstrFindWhat = Globals.szFindText;
+        Globals.find.wFindWhatLen = ARRAY_SIZE(Globals.szFindText);
+        Globals.find.lpstrReplaceWith = Globals.szReplaceText;
+        Globals.find.wReplaceWithLen = ARRAY_SIZE(Globals.szReplaceText);
+        Globals.find.Flags = FR_DOWN;
+    }
 
     /* We only need to create the modal FindReplace dialog which will */
     /* notify us of incoming events using hMainWnd Window Messages    */


### PR DESCRIPTION
## Purpose

We don't want to reset the status of the checkboxes even if the Find/Replace dialog was closed.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- If `lpstrFindWhat` is set, do not reset the Find/Replace settings at `DIALOG_SearchDialog`.

## TODO

- [x] Do tests.