### PR TITLE
[USER32] Fix ICO_ExtractIconExW causing explorer to crash on bad PE header icon display

### DIFF
--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -616,6 +616,15 @@ static UINT ICO_ExtractIconExW(
             goto end;
         }
 
+#ifdef __REACTOS__
+        /* Check for boundary limit (and overflow) */
+        if (((ULONG_PTR)(rootresdir + 1) < (ULONG_PTR)rootresdir) ||
+            ((ULONG_PTR)(rootresdir + 1) > (ULONG_PTR)peimage + fsizel))
+        {
+            goto end;
+        }
+#endif
+
 	  /* search for the group icon directory */
 	  if (!(icongroupresdir = find_entry_by_id(rootresdir, LOWORD(RT_GROUP_ICON), rootresdir)))
 	  {


### PR DESCRIPTION
## Purpose

_Fix explorer crashing when trying to display icon for file with bad EXE with a bad PE header._

JIRA issue: [CORE-15879](https://jira.reactos.org/browse/CORE-15879)

## Proposed changes

_Modify ICO_ExtractIsonExW to check for trying to read data past end of file and exit._

Crredit: @ThFabba in ReactOS chat 
