### PR TITLE
[NTUSER][USER32] Refactor NtUserLoadKeyboardLayoutEx

### DIFF
--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2740,7 +2740,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable,
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING puszKLID,
+    IN PUNICODE_STRING pustrKLID,
     IN DWORD dwNewKL,
     IN UINT Flags);
 

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2740,7 +2740,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable,
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING puzKLID,
+    IN PUNICODE_STRING puszKLID,
     IN DWORD dwNewKL,
     IN UINT Flags);
 

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2740,7 +2740,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable,
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING pustrKLID,
+    IN PUNICODE_STRING puzKLID,
     IN DWORD dwNewKL,
     IN UINT Flags);
 

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2734,14 +2734,14 @@ NtUserKillTimer(
     UINT_PTR uIDEvent);
 
 HKL
-NTAPI
+APIENTRY
 NtUserLoadKeyboardLayoutEx(
-    IN HANDLE Handle,
+    IN HANDLE hFile,
     IN DWORD offTable,
-    IN PUNICODE_STRING puszKeyboardName,
-    IN HKL hKL,
-    IN PUNICODE_STRING puszKLID,
-    IN DWORD dwKLID,
+    IN PVOID pUnknown,
+    IN HKL hOldKL,
+    IN PUNICODE_STRING pustrKLID,
+    IN DWORD dwNewKL,
     IN UINT Flags);
 
 BOOL

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2738,7 +2738,7 @@ NTAPI
 NtUserLoadKeyboardLayoutEx(
     IN HANDLE hFile,
     IN DWORD offTable,
-    IN PVOID pUnknown,
+    IN PVOID pTables,
     IN HKL hOldKL,
     IN PUNICODE_STRING puszKLID,
     IN DWORD dwNewKL,

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2734,7 +2734,7 @@ NtUserKillTimer(
     UINT_PTR uIDEvent);
 
 HKL
-APIENTRY
+NTAPI
 NtUserLoadKeyboardLayoutEx(
     IN HANDLE hFile,
     IN DWORD offTable,

--- a/win32ss/include/ntuser.h
+++ b/win32ss/include/ntuser.h
@@ -2740,7 +2740,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable,
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING pustrKLID,
+    IN PUNICODE_STRING puszKLID,
     IN DWORD dwNewKL,
     IN UINT Flags);
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1178,7 +1178,7 @@ NtUserLoadKeyboardLayoutEx(
                                         hSafeFile,
                                         hOldKL,
                                         offTable,
-                                        pTables, /* This must be a safe table */
+                                        pTables, /* FIXME: This must be a safe table */
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -873,7 +873,7 @@ co_IntLoadKeyboardLayoutEx(
     HKL hOldKL,
     DWORD offTable,
     PVOID pUnknown,
-    PUNICODE_STRING pustrSafeKLID,
+    PUNICODE_STRING puszSafeKLID,
     HKL hNewKL,
     UINT Flags)
 {
@@ -897,7 +897,7 @@ co_IntLoadKeyboardLayoutEx(
     if (!pNewKL)
     {
         /* It wasn't, so load it. */
-        pNewKL = UserLoadKbdLayout(pustrSafeKLID, hNewKL);
+        pNewKL = UserLoadKbdLayout(puszSafeKLID, hNewKL);
         if (!pNewKL)
             return NULL;
 
@@ -1131,7 +1131,7 @@ NtUserLoadKeyboardLayoutEx(
 {
     HKL hRetKL, hNewKL = (HKL)(DWORD_PTR)dwNewKL;
     WCHAR Buffer[KL_NAMELENGTH];
-    UNICODE_STRING ustrSafeKLID;
+    UNICODE_STRING uszSafeKLID;
     PWINSTATION_OBJECT pWinSta;
 
     if (Flags & ~(KLF_ACTIVATE|KLF_NOTELLSHELL|KLF_REORDER|KLF_REPLACELANG|
@@ -1143,12 +1143,12 @@ NtUserLoadKeyboardLayoutEx(
         return NULL;
     }
 
-    RtlInitEmptyUnicodeString(&ustrSafeKLID, Buffer, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&uszSafeKLID, Buffer, sizeof(Buffer));
     _SEH2_TRY
     {
         ProbeForRead(puzKLID, sizeof(*puzKLID), 1);
         ProbeForRead(puzKLID->Buffer, sizeof(puzKLID->Length), 1);
-        RtlCopyUnicodeString(&ustrSafeKLID, puzKLID);
+        RtlCopyUnicodeString(&uszSafeKLID, puzKLID);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -1164,7 +1164,7 @@ NtUserLoadKeyboardLayoutEx(
                                         hOldKL,
                                         offTable,
                                         pUnknown,
-                                        &ustrSafeKLID,
+                                        &uszSafeKLID,
                                         hNewKL,
                                         Flags);
     UserLeave();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1125,7 +1125,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable, // Offset to KbdTables
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING pustrKLID,
+    IN PUNICODE_STRING puzKLID,
     IN DWORD dwNewKL,
     IN UINT Flags)
 {
@@ -1146,9 +1146,9 @@ NtUserLoadKeyboardLayoutEx(
     RtlInitEmptyUnicodeString(&ustrSafeKLID, Buffer, sizeof(Buffer));
     _SEH2_TRY
     {
-        ProbeForRead(pustrKLID, sizeof(*pustrKLID), 1);
-        ProbeForRead(pustrKLID->Buffer, sizeof(pustrKLID->Length), 1);
-        RtlCopyUnicodeString(&ustrSafeKLID, pustrKLID);
+        ProbeForRead(puzKLID, sizeof(*puzKLID), 1);
+        ProbeForRead(puzKLID->Buffer, sizeof(puzKLID->Length), 1);
+        RtlCopyUnicodeString(&ustrSafeKLID, puzKLID);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1123,7 +1123,7 @@ NTAPI
 NtUserLoadKeyboardLayoutEx(
     IN HANDLE hFile, // See https://bugtraq.securityfocus.com/detail/50056B96.6040306
     IN DWORD offTable, // Offset to KbdTables
-    IN PVOID pUnknown,
+    IN PVOID pUnknown, // Not used?
     IN HKL hOldKL,
     IN PUNICODE_STRING pustrKLID,
     IN DWORD dwNewKL,

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -958,7 +958,8 @@ HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
 
     /* FIXME: Is the file in the system directory? */
 
-    ObDereferenceObject(FileObject);
+    if (FileObject)
+        ObDereferenceObject(FileObject);
     return hFile;
 }
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -956,7 +956,7 @@ HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
         return NULL;
     }
 
-    /* FIXME: Is the file in Windows directory? */
+    /* FIXME: Is the file in the system directory? */
 
     ObDereferenceObject(FileObject);
     return hFile;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -948,8 +948,13 @@ co_IntLoadKeyboardLayoutEx(
 HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
 {
     PFILE_OBJECT FileObject;
-    NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, UserMode,
-                                                (PVOID*)&FileObject, NULL);
+    NTSTATUS Status;
+
+    if (hFile == INVALID_HANDLE_VALUE)
+        return NULL;
+
+    Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, UserMode,
+                                       (PVOID*)&FileObject, NULL);
     if (!NT_SUCCESS(Status))
     {
         ERR("0x%08X\n", Status);
@@ -960,6 +965,7 @@ HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
 
     if (FileObject)
         ObDereferenceObject(FileObject);
+
     return hFile;
 }
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1126,7 +1126,9 @@ cleanup:
 }
 
 /*
- * NtUserLoadKeyboardLayoutEx - Loads keyboard layout with given locale id
+ * NtUserLoadKeyboardLayoutEx
+ *
+ * Loads keyboard layout with given locale id
  */
 HKL
 NTAPI
@@ -1181,7 +1183,7 @@ NtUserLoadKeyboardLayoutEx(
                                         hSafeFile,
                                         hOldKL,
                                         offTable,
-                                        pTables, /* FIXME: This must be a safe table */
+                                        pTables, /* FIXME: This must be safe */
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -869,12 +869,15 @@ PIMEINFOEX FASTCALL co_UserImmLoadLayout(_In_ HKL hKL)
 HKL APIENTRY
 co_IntLoadKeyboardLayoutEx(
     IN OUT PWINSTATION_OBJECT pWinSta,
+    IN HANDLE hSafeFile,
     IN HKL hOldKL,
     IN PUNICODE_STRING puszSafeKLID,
     IN HKL hNewKL,
     IN UINT Flags)
 {
     PKL pOldKL, pNewKL;
+
+    UNREFERENCED_PARAMETER(hSafeFile);
 
     if (hNewKL == NULL || (pWinSta->Flags & WSS_NOIO))
         return NULL;
@@ -940,6 +943,23 @@ co_IntLoadKeyboardLayoutEx(
     /* FIXME: KLF_REPLACELANG */
 
     return hNewKL;
+}
+
+HANDLE FASTCALL IntVerifySystemFileHandle(HANDLE hFile)
+{
+    PFILE_OBJECT FileObject;
+    NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, KernelMode,
+                                                (PVOID*)&FileObject, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("0x%08X\n", Status);
+        return NULL;
+    }
+
+    /* FIXME: Is the file in Windows directory? */
+
+    ObDereferenceObject(FileObject);
+    return hFile;
 }
 
 /* EXPORTS *******************************************************************/
@@ -1111,7 +1131,7 @@ cleanup:
  * Loads keyboard layout with given locale id
  *
  * NOTE: We adopt a different design from Microsoft's one for security reason.
- *       We don't use the 1st and 3rd parameters of NtUserLoadKeyboardLayoutEx.
+ *       We don't use the 3rd parameter pTables of NtUserLoadKeyboardLayoutEx.
  *       See https://bugtraq.securityfocus.com/detail/50056B96.6040306
  */
 HKL
@@ -1129,8 +1149,8 @@ NtUserLoadKeyboardLayoutEx(
     WCHAR Buffer[KL_NAMELENGTH];
     UNICODE_STRING uszSafeKLID;
     PWINSTATION_OBJECT pWinSta;
+    HANDLE hSafeFile;
 
-    UNREFERENCED_PARAMETER(hFile);
     UNREFERENCED_PARAMETER(offTable);
     UNREFERENCED_PARAMETER(pTables);
 
@@ -1159,12 +1179,17 @@ NtUserLoadKeyboardLayoutEx(
 
     UserEnterExclusive();
 
+    hSafeFile = (hFile ? IntVerifySystemFileHandle(hFile) : NULL);
     pWinSta = IntGetProcessWindowStation(NULL);
     hRetKL = co_IntLoadKeyboardLayoutEx(pWinSta,
+                                        hSafeFile,
                                         hOldKL,
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);
+    if (hSafeFile)
+        ZwClose(hSafeFile);
+
     UserLeave();
     return hRetKL;
 }

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1119,7 +1119,7 @@ cleanup:
 HKL
 NTAPI
 NtUserLoadKeyboardLayoutEx(
-    IN HANDLE hFile, // hFile (See downloads.securityfocus.com/vulnerabilities/exploits/43774.c)
+    IN HANDLE hFile, // See downloads.securityfocus.com/vulnerabilities/exploits/43774.c
     IN DWORD offTable, // Offset to KbdTables
     IN PVOID pUnknown,
     IN HKL hOldKL,

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -877,7 +877,7 @@ co_IntLoadKeyboardLayoutEx(
     HKL hNewKL,
     UINT Flags)
 {
-    PKL pOldKL, pNewKL, pLastKL;
+    PKL pOldKL, pNewKL;
 
     if (hNewKL == NULL || (pWinSta->Flags & WSS_NOIO))
         return NULL;
@@ -904,8 +904,8 @@ co_IntLoadKeyboardLayoutEx(
         if (gspklBaseLayout)
         {
             /* Find last not unloaded layout */
-            pLastKL = gspklBaseLayout->pklPrev;
-            while (pLastKL != gspklBaseLayout && pLastKL->dwKL_Flags & KLF_UNLOAD)
+            PKL pLastKL = gspklBaseLayout->pklPrev;
+            while (pLastKL != gspklBaseLayout && (pLastKL->dwKL_Flags & KLF_UNLOAD))
                 pLastKL = pLastKL->pklPrev;
 
             /* Add new layout to the list */

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -868,14 +868,14 @@ PIMEINFOEX FASTCALL co_UserImmLoadLayout(_In_ HKL hKL)
 
 HKL APIENTRY
 co_IntLoadKeyboardLayoutEx(
-    PWINSTATION_OBJECT pWinSta,
-    HANDLE hFile,
-    HKL hOldKL,
-    DWORD offTable,
-    PVOID pTables,
-    PUNICODE_STRING puszSafeKLID,
-    HKL hNewKL,
-    UINT Flags)
+    IN OUT PWINSTATION_OBJECT pWinSta,
+    IN HANDLE hFile,
+    IN HKL hOldKL,
+    IN DWORD offTable,
+    IN OUT PVOID pSafeTables,
+    IN PUNICODE_STRING puszSafeKLID,
+    IN HKL hNewKL,
+    IN UINT Flags)
 {
     PKL pOldKL, pNewKL;
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1130,7 +1130,7 @@ cleanup:
  *
  * Loads keyboard layout with given locale id
  *
- * NOTE: We adopt a different design from Microsoft's one for security reason.
+ * NOTE: We adopt a different design from Microsoft's one due to security reason.
  *       We don't use the 3rd parameter pTables of NtUserLoadKeyboardLayoutEx.
  *       See https://bugtraq.securityfocus.com/detail/50056B96.6040306
  */

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -945,7 +945,7 @@ co_IntLoadKeyboardLayoutEx(
     return hNewKL;
 }
 
-HANDLE FASTCALL IntVerifySystemFileHandle(HANDLE hFile)
+HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
 {
     PFILE_OBJECT FileObject;
     NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, KernelMode,
@@ -1179,7 +1179,7 @@ NtUserLoadKeyboardLayoutEx(
 
     UserEnterExclusive();
 
-    hSafeFile = (hFile ? IntVerifySystemFileHandle(hFile) : NULL);
+    hSafeFile = (hFile ? IntVerifyKeyboardFileHandle(hFile) : NULL);
     pWinSta = IntGetProcessWindowStation(NULL);
     hRetKL = co_IntLoadKeyboardLayoutEx(pWinSta,
                                         hSafeFile,

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1161,7 +1161,7 @@ NtUserLoadKeyboardLayoutEx(
         ProbeForRead(puszKLID->Buffer, sizeof(puszKLID->Length), 1);
         RtlCopyUnicodeString(&uszSafeKLID, puszKLID);
 
-        // FIXME: pTables
+        /* FIXME: pTables */
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1131,7 +1131,7 @@ NtUserLoadKeyboardLayoutEx(
 {
     HKL hRetKL, hNewKL = (HKL)(DWORD_PTR)dwNewKL;
     WCHAR Buffer[KL_NAMELENGTH];
-    UNICODE_STRING uszSafeKLID;
+    UNICODE_STRING ustrSafeKLID;
     PWINSTATION_OBJECT pWinSta;
 
     if (Flags & ~(KLF_ACTIVATE|KLF_NOTELLSHELL|KLF_REORDER|KLF_REPLACELANG|
@@ -1143,12 +1143,12 @@ NtUserLoadKeyboardLayoutEx(
         return NULL;
     }
 
-    RtlInitEmptyUnicodeString(&uszSafeKLID, Buffer, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&ustrSafeKLID, Buffer, sizeof(Buffer));
     _SEH2_TRY
     {
         ProbeForRead(puzKLID, sizeof(*puzKLID), 1);
         ProbeForRead(puzKLID->Buffer, sizeof(puzKLID->Length), 1);
-        RtlCopyUnicodeString(&uszSafeKLID, puzKLID);
+        RtlCopyUnicodeString(&ustrSafeKLID, puzKLID);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -1164,7 +1164,7 @@ NtUserLoadKeyboardLayoutEx(
                                         hOldKL,
                                         offTable,
                                         pUnknown,
-                                        &uszSafeKLID,
+                                        &ustrSafeKLID,
                                         hNewKL,
                                         Flags);
     UserLeave();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1126,14 +1126,7 @@ cleanup:
 }
 
 /*
- * NtUserLoadKeyboardLayoutEx
- *
- * Loads keyboard layout with given locale id
- *
- * NOTE: We adopt a different design from Microsoft's one for security reason.
- *       We don't use 3rd parameter of NtUserLoadKeyboardLayoutEx.
- *
- * https://www.infosecmatter.com/metasploit-module-library/?mm=post/windows/escalate/ms10_073_kbdlayout
+ * NtUserLoadKeyboardLayoutEx - Loads keyboard layout with given locale id
  */
 HKL
 NTAPI
@@ -1180,13 +1173,12 @@ NtUserLoadKeyboardLayoutEx(
     UserEnterExclusive();
 
     hSafeFile = (hFile ? IntVerifySystemFileHandle(hFile) : NULL);
-
     pWinSta = IntGetProcessWindowStation(NULL);
     hRetKL = co_IntLoadKeyboardLayoutEx(pWinSta,
                                         hSafeFile,
                                         hOldKL,
                                         offTable,
-                                        pTables,
+                                        pTables, /* This must be a safe table */
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);
@@ -1194,7 +1186,7 @@ NtUserLoadKeyboardLayoutEx(
     {
         ZwClose(hSafeFile);
 
-        // FIXME: pTables
+        /* FIXME: pTables */
     }
 
     UserLeave();

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1115,6 +1115,8 @@ cleanup:
  *
  * NOTE: We adopt a different design from Microsoft's one for security reason.
  *       We don't use the 1st and 3rd parameters of NtUserLoadKeyboardLayoutEx.
+ *
+ * https://www.infosecmatter.com/metasploit-module-library/?mm=post/windows/escalate/ms10_073_kbdlayout
  */
 HKL
 NTAPI

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1125,7 +1125,7 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable, // Offset to KbdTables
     IN PVOID pUnknown,
     IN HKL hOldKL,
-    IN PUNICODE_STRING puzKLID,
+    IN PUNICODE_STRING pustrKLID,
     IN DWORD dwNewKL,
     IN UINT Flags)
 {
@@ -1146,9 +1146,9 @@ NtUserLoadKeyboardLayoutEx(
     RtlInitEmptyUnicodeString(&ustrSafeKLID, Buffer, sizeof(Buffer));
     _SEH2_TRY
     {
-        ProbeForRead(puzKLID, sizeof(*puzKLID), 1);
-        ProbeForRead(puzKLID->Buffer, sizeof(puzKLID->Length), 1);
-        RtlCopyUnicodeString(&ustrSafeKLID, puzKLID);
+        ProbeForRead(pustrKLID, sizeof(*pustrKLID), 1);
+        ProbeForRead(pustrKLID->Buffer, sizeof(pustrKLID->Length), 1);
+        RtlCopyUnicodeString(&ustrSafeKLID, pustrKLID);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1117,7 +1117,7 @@ cleanup:
  *       We don't use the 1st and 3rd parameters of NtUserLoadKeyboardLayoutEx.
  */
 HKL
-APIENTRY
+NTAPI
 NtUserLoadKeyboardLayoutEx(
     IN HANDLE hFile, // hFile (See downloads.securityfocus.com/vulnerabilities/exploits/43774.c)
     IN DWORD offTable, // Offset to KbdTables

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1125,13 +1125,13 @@ NtUserLoadKeyboardLayoutEx(
     IN DWORD offTable, // Offset to KbdTables
     IN PVOID pUnknown, // Not used?
     IN HKL hOldKL,
-    IN PUNICODE_STRING pustrKLID,
+    IN PUNICODE_STRING puszKLID,
     IN DWORD dwNewKL,
     IN UINT Flags)
 {
-    HKL hRetKL, hNewKL = (HKL)(DWORD_PTR)dwNewKL;
+    HKL hRetKL;
     WCHAR Buffer[KL_NAMELENGTH];
-    UNICODE_STRING ustrSafeKLID;
+    UNICODE_STRING uszSafeKLID;
     PWINSTATION_OBJECT pWinSta;
 
     if (Flags & ~(KLF_ACTIVATE|KLF_NOTELLSHELL|KLF_REORDER|KLF_REPLACELANG|
@@ -1143,12 +1143,12 @@ NtUserLoadKeyboardLayoutEx(
         return NULL;
     }
 
-    RtlInitEmptyUnicodeString(&ustrSafeKLID, Buffer, sizeof(Buffer));
+    RtlInitEmptyUnicodeString(&uszSafeKLID, Buffer, sizeof(Buffer));
     _SEH2_TRY
     {
-        ProbeForRead(pustrKLID, sizeof(*pustrKLID), 1);
-        ProbeForRead(pustrKLID->Buffer, sizeof(pustrKLID->Length), 1);
-        RtlCopyUnicodeString(&ustrSafeKLID, pustrKLID);
+        ProbeForRead(puszKLID, sizeof(*puszKLID), 1);
+        ProbeForRead(puszKLID->Buffer, sizeof(puszKLID->Length), 1);
+        RtlCopyUnicodeString(&uszSafeKLID, puszKLID);
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -1164,8 +1164,8 @@ NtUserLoadKeyboardLayoutEx(
                                         hOldKL,
                                         offTable,
                                         pUnknown,
-                                        &ustrSafeKLID,
-                                        hNewKL,
+                                        &uszSafeKLID,
+                                        (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);
     UserLeave();
     return hRetKL;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1119,7 +1119,7 @@ cleanup:
 HKL
 NTAPI
 NtUserLoadKeyboardLayoutEx(
-    IN HANDLE hFile, // See downloads.securityfocus.com/vulnerabilities/exploits/43774.c
+    IN HANDLE hFile, // See https://bugtraq.securityfocus.com/detail/50056B96.6040306
     IN DWORD offTable, // Offset to KbdTables
     IN PVOID pUnknown,
     IN HKL hOldKL,

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -948,7 +948,7 @@ co_IntLoadKeyboardLayoutEx(
 HANDLE FASTCALL IntVerifyKeyboardFileHandle(HANDLE hFile)
 {
     PFILE_OBJECT FileObject;
-    NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, KernelMode,
+    NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, UserMode,
                                                 (PVOID*)&FileObject, NULL);
     if (!NT_SUCCESS(Status))
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -869,12 +869,15 @@ PIMEINFOEX FASTCALL co_UserImmLoadLayout(_In_ HKL hKL)
 HKL APIENTRY
 co_IntLoadKeyboardLayoutEx(
     IN OUT PWINSTATION_OBJECT pWinSta,
+    IN HANDLE hSafeFile,
     IN HKL hOldKL,
     IN PUNICODE_STRING puszSafeKLID,
     IN HKL hNewKL,
     IN UINT Flags)
 {
     PKL pOldKL, pNewKL;
+
+    UNREFERENCED_PARAMETER(hSafeFile);
 
     if (hNewKL == NULL || (pWinSta->Flags & WSS_NOIO))
         return NULL;
@@ -940,6 +943,23 @@ co_IntLoadKeyboardLayoutEx(
     /* FIXME: KLF_REPLACELANG */
 
     return hNewKL;
+}
+
+HANDLE FASTCALL IntVerifySystemFileHandle(HANDLE hFile)
+{
+    PFILE_OBJECT FileObject;
+    NTSTATUS Status = ObReferenceObjectByHandle(hFile, FILE_READ_DATA, NULL, KernelMode,
+                                                (PVOID*)&FileObject, NULL);
+    if (!NT_SUCCESS(Status))
+    {
+        ERR("0x%08X\n", Status);
+        return NULL;
+    }
+
+    /* FIXME: Is the file in Windows directory? */
+
+    ObDereferenceObject(FileObject);
+    return hFile;
 }
 
 /* EXPORTS *******************************************************************/
@@ -1111,7 +1131,7 @@ cleanup:
  * Loads keyboard layout with given locale id
  *
  * NOTE: We adopt a different design from Microsoft's one due to security reason.
- *       We don't use the 1st and 3rd parameters of NtUserLoadKeyboardLayoutEx.
+ *       We don't use the 3rd parameter of NtUserLoadKeyboardLayoutEx.
  *       See https://bugtraq.securityfocus.com/detail/50056B96.6040306
  */
 HKL
@@ -1129,8 +1149,8 @@ NtUserLoadKeyboardLayoutEx(
     WCHAR Buffer[KL_NAMELENGTH];
     UNICODE_STRING uszSafeKLID;
     PWINSTATION_OBJECT pWinSta;
+    HANDLE hSafeFile;
 
-    UNREFERENCED_PARAMETER(hFile);
     UNREFERENCED_PARAMETER(offTable);
     UNREFERENCED_PARAMETER(pTables);
 
@@ -1159,12 +1179,16 @@ NtUserLoadKeyboardLayoutEx(
 
     UserEnterExclusive();
 
+    hSafeFile = (hFile ? IntVerifySystemFileHandle(hFile) : NULL);
     pWinSta = IntGetProcessWindowStation(NULL);
     hRetKL = co_IntLoadKeyboardLayoutEx(pWinSta,
+                                        hSafeFile,
                                         hOldKL,
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);
+    if (hSafeFile)
+        ZwClose(hSafeFile);
 
     UserLeave();
     return hRetKL;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -1161,7 +1161,10 @@ NtUserLoadKeyboardLayoutEx(
         ProbeForRead(puszKLID->Buffer, sizeof(puszKLID->Length), 1);
         RtlCopyUnicodeString(&uszSafeKLID, puszKLID);
 
-        /* FIXME: pTables */
+        if (pTables)
+        {
+            /* FIXME: pTables */
+        }
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -369,12 +369,12 @@ cleanup:
 }
 
 /*
- * UserLoadKbdLayout
+ * co_UserLoadKbdLayout
  *
  * Loads keyboard layout and creates KL object
  */
 static PKL
-UserLoadKbdLayout(PUNICODE_STRING pustrKLID, HKL hKL)
+co_UserLoadKbdLayout(PUNICODE_STRING pustrKLID, HKL hKL)
 {
     LCID lCid;
     CHARSETINFO cs;
@@ -896,7 +896,7 @@ co_IntLoadKeyboardLayoutEx(
     if (!pNewKL)
     {
         /* It wasn't, so load it. */
-        pNewKL = UserLoadKbdLayout(puszSafeKLID, hNewKL);
+        pNewKL = co_UserLoadKbdLayout(puszSafeKLID, hNewKL);
         if (!pNewKL)
             return NULL;
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -872,7 +872,6 @@ co_IntLoadKeyboardLayoutEx(
     IN HANDLE hFile,
     IN HKL hOldKL,
     IN DWORD offTable,
-    IN OUT PVOID pSafeTables,
     IN PUNICODE_STRING puszSafeKLID,
     IN HKL hNewKL,
     IN UINT Flags)
@@ -1162,11 +1161,6 @@ NtUserLoadKeyboardLayoutEx(
         ProbeForRead(puszKLID, sizeof(*puszKLID), 1);
         ProbeForRead(puszKLID->Buffer, sizeof(puszKLID->Length), 1);
         RtlCopyUnicodeString(&uszSafeKLID, puszKLID);
-
-        if (pTables)
-        {
-            /* FIXME: pTables */
-        }
     }
     _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
     {
@@ -1183,15 +1177,12 @@ NtUserLoadKeyboardLayoutEx(
                                         hSafeFile,
                                         hOldKL,
                                         offTable,
-                                        pTables, /* FIXME: This must be safe */
                                         &uszSafeKLID,
                                         (HKL)(DWORD_PTR)dwNewKL,
                                         Flags);
     if (hSafeFile)
     {
         ZwClose(hSafeFile);
-
-        /* FIXME: pTables */
     }
 
     UserLeave();

--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -125,6 +125,14 @@ BOOL FASTCALL IntBroadcastImeShowStatusChange(PWND pImeWnd, BOOL bShow);
 VOID FASTCALL IntNotifyImeShowStatus(PWND pImeWnd);
 VOID FASTCALL IntCheckImeShowStatusInThread(PWND pImeWnd);
 
+PVOID FASTCALL
+IntReAllocatePoolWithTag(
+    POOL_TYPE PoolType,
+    PVOID pOld,
+    SIZE_T cbOld,
+    SIZE_T cbNew,
+    ULONG Tag);
+
 static inline
 VOID
 WndSetOwner(_Inout_ PWND pwnd, _In_opt_ PWND pwndOwner)

--- a/win32ss/user/ntuser/window.h
+++ b/win32ss/user/ntuser/window.h
@@ -125,14 +125,6 @@ BOOL FASTCALL IntBroadcastImeShowStatusChange(PWND pImeWnd, BOOL bShow);
 VOID FASTCALL IntNotifyImeShowStatus(PWND pImeWnd);
 VOID FASTCALL IntCheckImeShowStatusInThread(PWND pImeWnd);
 
-PVOID FASTCALL
-IntReAllocatePoolWithTag(
-    POOL_TYPE PoolType,
-    PVOID pOld,
-    SIZE_T cbOld,
-    SIZE_T cbNew,
-    ULONG Tag);
-
 static inline
 VOID
 WndSetOwner(_Inout_ PWND pwnd, _In_opt_ PWND pwndOwner)

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -722,6 +722,7 @@ VOID GetSystemLibraryPath(LPWSTR pszPath, INT cchPath, LPCWSTR pszFileName)
  * @unimplemented
  *
  * NOTE: We adopt a different design from Microsoft's one due to security reason.
+ *       See NtUserLoadKeyboardLayoutEx.
  */
 HKL APIENTRY
 IntLoadKeyboardLayout(

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -721,9 +721,8 @@ VOID GetSystemLibraryPath(LPWSTR pszPath, INT cchPath, LPCWSTR pszFileName)
 /*
  * @unimplemented
  *
- * NOTE: We adopt a different design from Microsoft's one for security reason.
+ * NOTE: We adopt a different design from Microsoft's one due to security reason.
  */
-/* Win: LoadKeyboardLayoutWorker */
 HKL APIENTRY
 IntLoadKeyboardLayout(
     _In_    HKL     hklUnload,
@@ -733,7 +732,6 @@ IntLoadKeyboardLayout(
     _In_    BOOL    unknown5)
 {
     DWORD dwKLID, dwHKL, dwType, dwSize;
-    UNICODE_STRING ustrKbdName;
     UNICODE_STRING ustrKLID;
     WCHAR wszRegKey[256] = L"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\";
     WCHAR wszLayoutId[10], wszNewKLID[KL_NAMELENGTH], szImeFileName[80];
@@ -833,9 +831,8 @@ IntLoadKeyboardLayout(
 
     dwHKL = MAKELONG(wLow, wHigh);
 
-    ZeroMemory(&ustrKbdName, sizeof(ustrKbdName));
     RtlInitUnicodeString(&ustrKLID, pwszKLID);
-    hNewKL = NtUserLoadKeyboardLayoutEx(NULL, 0, &ustrKbdName, NULL, &ustrKLID, dwHKL, Flags);
+    hNewKL = NtUserLoadKeyboardLayoutEx(NULL, 0, NULL, hklUnload, &ustrKLID, dwHKL, Flags);
     CliImmInitializeHotKeys(SETIMEHOTKEY_ADD, hNewKL);
     return hNewKL;
 }

--- a/win32ss/user/user32/windows/input.c
+++ b/win32ss/user/user32/windows/input.c
@@ -806,7 +806,7 @@ IntLoadKeyboardLayout(
                 szImeFileName[_countof(szImeFileName) - 1] = UNICODE_NULL;
                 GetSystemLibraryPath(szPath, _countof(szPath), szImeFileName);
 
-                /* We don't allow the invalid "IME File" values for security reason */
+                /* We don't allow the invalid "IME File" values due to security reason */
                 if (dwType != REG_SZ || szImeFileName[0] == 0 ||
                     wcscspn(szImeFileName, L":\\/") != wcslen(szImeFileName) ||
                     GetFileAttributesW(szPath) == INVALID_FILE_ATTRIBUTES) /* Does not exist? */


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Split some code of `NtUserLoadKeyboardLayoutEx` to newly-added `co_IntLoadKeyboardLayoutEx` helper function.
- Modify `NtUserLoadKeyboardLayoutEx` prototype.
- Move `co_UserImmLoadLayout` code.
- Implement `KLF_REORDER`.
- Rename `UserLoadKbdLayout` as `co_UserLoadKbdLayout`.
- Improve `LoadKeyboardLayoutEx`.

## TODO

- [x] Do big tests.