### PR TITLE
[MSPAINT] Treat as a file even if the bitmap is empty

### DIFF
--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -118,7 +118,6 @@ HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, DWORD dwFileSize, BOOL i
 
         fileHPPM = fileVPPM = 2834;
         ZeroMemory(&fileTime, sizeof(fileTime));
-        isFile = FALSE;
     }
     else
     {


### PR DESCRIPTION
JIRA issue: [CORE-18508](https://jira.reactos.org/browse/CORE-18508)

Currently if a file is empty, while loading the file the global variable isAFile is set as FALSE.
This leads to a save as dialogue while saving thinking that no file is loaded
