### PR TITLE
[GITHUB] Add a GitHub Action for ChatGPT code review

### DIFF
--- a/.github/workflows/cr.yml
+++ b/.github/workflows/cr.yml
@@ -1,0 +1,18 @@
+name: Code Review
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anc95/ChatGPT-CodeReview@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Purpose
Make ChatGPT do code review for each newly-opened PR.
JIRA issue: N/A

## Proposed changes

- Add `.github/workflow/cr.yml` for GitHub Actions.

## TODO

- [x] Check the cost and the budget.
- [ ] Reach consensus.
- [ ] Add `OPENAI_API_KEY` repository secret.
- [ ] Confirm whether this PR will work.

## Knowledge base

- An ChatGPT API key from OpenAI is necessary.
- The trigger of the GitHub Action is to open or reopen a PR after commit of this PR.
- ChatGPT will read PR changes.
- ChatGPT doesn't reply a PR's comment (yet).
- ChatGPT won't read more than 5000 bytes.
- The `Ada` plan (fastest): $0.0004 / 1K tokens
- The `Davinci` plan (most powerful): $0.0200 / 1K tokens
- For text in English, 1 token is approximately 4 characters or 0.75 words.