### PR TITLE
[NTUSER] Use UserAssignmentLock for gspklBaseLayout

### DIFF
--- a/win32ss/user/ntuser/input.h
+++ b/win32ss/user/ntuser/input.h
@@ -75,6 +75,9 @@ VOID NTAPI UserProcessKeyboardInput(PKEYBOARD_INPUT_DATA pKeyInput);
 BOOL NTAPI UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected);
 PKL NTAPI UserHklToKbl(HKL hKl);
 BOOL NTAPI UserSetDefaultInputLang(HKL hKl);
+BOOLEAN UserKbdFileCleanup(PVOID Object);
+BOOLEAN UserKbdLayoutCleanup(PVOID Object);
+
 extern int gLanguageToggleKeyState;
 extern DWORD gdwLanguageToggleKey;
 

--- a/win32ss/user/ntuser/input.h
+++ b/win32ss/user/ntuser/input.h
@@ -75,8 +75,8 @@ VOID NTAPI UserProcessKeyboardInput(PKEYBOARD_INPUT_DATA pKeyInput);
 BOOL NTAPI UserSendKeyboardInput(KEYBDINPUT *pKbdInput, BOOL bInjected);
 PKL NTAPI UserHklToKbl(HKL hKl);
 BOOL NTAPI UserSetDefaultInputLang(HKL hKl);
-BOOLEAN UserKbdFileCleanup(PVOID Object);
-BOOLEAN UserKbdLayoutCleanup(PVOID Object);
+VOID FreeKbdFile(PVOID Object);
+VOID FreeKbdLayout(PVOID Object);
 
 extern int gLanguageToggleKeyState;
 extern DWORD gdwLanguageToggleKey;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -436,24 +436,6 @@ co_UserLoadKbdLayout(PUNICODE_STRING pustrKLID, HKL hKL)
     return pKl;
 }
 
-BOOLEAN UserKbdLayoutCleanup(PVOID Object)
-{
-    PKL pKL = Object;
-    NT_ASSERT(pKL != NULL);
-
-    if (!pKL)
-        return TRUE;
-
-    if (pKL->piiex)
-        ExFreePoolWithTag(pKL->piiex, USERTAG_IME);
-
-    if (pKL->spkf)
-        UserDeleteObject(pKL->spkf->head.h, TYPE_KBDFILE);
-
-    UserHeapFree(Object);
-    return TRUE;
-}
-
 /*
  * UserKbdFileCleanup
  *
@@ -478,6 +460,24 @@ BOOLEAN UserKbdFileCleanup(PVOID Object)
     }
 
     EngUnloadImage(pkf->hBase);
+    UserHeapFree(Object);
+    return TRUE;
+}
+
+BOOLEAN UserKbdLayoutCleanup(PVOID Object)
+{
+    PKL pKL = Object;
+    NT_ASSERT(pKL != NULL);
+
+    if (!pKL)
+        return TRUE;
+
+    if (pKL->piiex)
+        ExFreePoolWithTag(pKL->piiex, USERTAG_IME);
+
+    if (pKL->spkf)
+        UserDeleteObject(pKL->spkf->head.h, TYPE_KBDFILE);
+
     UserHeapFree(Object);
     return TRUE;
 }

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -461,24 +461,20 @@ BOOLEAN UserKbdLayoutCleanup(PVOID Object)
  */
 BOOLEAN UserKbdFileCleanup(PVOID Object)
 {
-    PKBDFILE pkf = Object;
-    PKBDFILE *ppkfLink = &gpkfList;
+    PKBDFILE pkf = Object, *ppkfLink;
     NT_ASSERT(pkf != NULL);
 
     if (!pkf)
         return FALSE;
 
-    /* Find previous object */
-    while (*ppkfLink)
+    for (ppkfLink = &gpkfList; *ppkfLink; ppkfLink = &(*ppkfLink)->pkfNext)
     {
         if (*ppkfLink == pkf)
+        {
+            *ppkfLink = pkf->pkfNext;
             break;
-
-        ppkfLink = &(*ppkfLink)->pkfNext;
+        }
     }
-
-    if (*ppkfLink == pkf)
-        *ppkfLink = pkf->pkfNext;
 
     EngUnloadImage(pkf->hBase);
     UserHeapFree(Object);

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -359,8 +359,6 @@ UserLoadKbdFile(PUNICODE_STRING pwszKLID)
 cleanup:
     if (hKey)
         ZwClose(hKey);
-    if (pkf)
-        UserDereferenceObject(pkf); // we dont need ptr anymore
     if (!pRet)
     {
         /* We have failed - destroy created object */

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -442,7 +442,7 @@ co_UserLoadKbdLayout(PUNICODE_STRING pustrKLID, HKL hKL)
  *
  * Clean up specified Keyboard File object
  */
-BOOLEAN UserKbdFileCleanup(PVOID Object)
+VOID FreeKbdFile(PVOID Object)
 {
     PKBDFILE pkf = Object, *ppkfLink;
 
@@ -459,11 +459,10 @@ BOOLEAN UserKbdFileCleanup(PVOID Object)
     }
 
     EngUnloadImage(pkf->hBase);
-    UserDeleteObject(UserHMGetHandle(pkf), TYPE_KBDFILE);
-    return TRUE;
+    UserHeapFree(Object);
 }
 
-BOOLEAN UserKbdLayoutCleanup(PVOID Object)
+VOID FreeKbdLayout(PVOID Object)
 {
     PKL pKL = Object;
 
@@ -482,8 +481,7 @@ BOOLEAN UserKbdLayoutCleanup(PVOID Object)
     if (gspklBaseLayout == pKL)
         gspklBaseLayout = NULL;
 
-    UserDeleteObject(UserHMGetHandle(pKL), TYPE_KBDLAYOUT);
-    return TRUE;
+    UserHeapFree(Object);
 }
 
 /*

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -313,6 +313,9 @@ UserLoadKbdFile(PUNICODE_STRING pwszKLID)
         return NULL;
     }
 
+    /* Release the extra reference (UserCreateObject added 2 references) */
+    UserDereferenceObject(pkf);
+
     /* Set keyboard layout name */
     swprintf(pkf->awchKF, L"%wZ", pwszKLID);
 
@@ -391,7 +394,7 @@ co_UserLoadKbdLayout(PUNICODE_STRING pustrKLID, HKL hKL)
     pKl->hkl = hKL;
     pKl->spkf = UserLoadKbdFile(pustrKLID);
 
-    /* Dereference keyboard layout */
+    /* Release the extra reference (UserCreateObject added 2 references) */
     UserDereferenceObject(pKl);
 
     /* If we failed, remove KL object */

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -442,7 +442,7 @@ BOOLEAN UserKbdLayoutCleanup(PVOID Object)
     NT_ASSERT(pKL != NULL);
 
     if (!pKL)
-        return FALSE;
+        return TRUE;
 
     if (pKL->piiex)
         ExFreePoolWithTag(pKL->piiex, USERTAG_IME);
@@ -465,7 +465,7 @@ BOOLEAN UserKbdFileCleanup(PVOID Object)
     NT_ASSERT(pkf != NULL);
 
     if (!pkf)
-        return FALSE;
+        return TRUE;
 
     /* Remove pkf from gpkfList */
     for (ppkfLink = &gpkfList; *ppkfLink; ppkfLink = &(*ppkfLink)->pkfNext)

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -477,6 +477,7 @@ BOOLEAN UserKbdLayoutCleanup(PVOID Object)
     if (!pKL)
         return TRUE;
 
+    /* Remove pKL from the list */
     pKL->pklPrev->pklNext = pKL->pklNext;
     pKL->pklNext->pklPrev = pKL->pklPrev;
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -446,11 +446,7 @@ BOOLEAN UserKbdFileCleanup(PVOID Object)
 {
     PKBDFILE pkf = Object, *ppkfLink;
 
-    NT_ASSERT(pkf != NULL);
     NT_ASSERT(UserIsEnteredExclusive());
-
-    if (!pkf)
-        return TRUE;
 
     /* Remove pkf from gpkfList */
     for (ppkfLink = &gpkfList; *ppkfLink; ppkfLink = &(*ppkfLink)->pkfNext)
@@ -471,11 +467,7 @@ BOOLEAN UserKbdLayoutCleanup(PVOID Object)
 {
     PKL pKL = Object;
 
-    NT_ASSERT(pKL != NULL);
     NT_ASSERT(UserIsEnteredExclusive());
-
-    if (!pKL)
-        return TRUE;
 
     /* Remove pKL from the list */
     pKL->pklPrev->pklNext = pKL->pklNext;

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -467,6 +467,7 @@ BOOLEAN UserKbdFileCleanup(PVOID Object)
     if (!pkf)
         return FALSE;
 
+    /* Remove pkf from gpkfList */
     for (ppkfLink = &gpkfList; *ppkfLink; ppkfLink = &(*ppkfLink)->pkfNext)
     {
         if (*ppkfLink == pkf)

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -266,8 +266,8 @@ static const struct
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDECONV */
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDEXACT */
     { AllocSysObject,           /*UserMonitorCleanup*/NULL, FreeSysObject },        /* TYPE_MONITOR */
-    { AllocSysObject,           UserKbdLayoutCleanup,       FreeSysObject },        /* TYPE_KBDLAYOUT */
-    { AllocSysObject,           UserKbdFileCleanup,         FreeSysObject },        /* TYPE_KBDFILE */
+    { AllocSysObject,           UserKbdLayoutCleanup,       FreeSysObject },       /* TYPE_KBDLAYOUT */
+    { AllocSysObject,           UserKbdFileCleanup,         FreeSysObject },       /* TYPE_KBDFILE */
     { AllocThreadObject,        IntRemoveEvent,             FreeThreadObject },     /* TYPE_WINEVENTHOOK */
     { AllocSysObject,           /*UserTimerCleanup*/NULL,   FreeSysObject },        /* TYPE_TIMER */
     { AllocInputContextObject,  UserDestroyInputContext,    UserFreeInputContext }, /* TYPE_INPUTCONTEXT */

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -266,8 +266,8 @@ static const struct
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDECONV */
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDEXACT */
     { AllocSysObject,           /*UserMonitorCleanup*/NULL, FreeSysObject },        /* TYPE_MONITOR */
-    { AllocSysObject,           /*UserKbdLayoutCleanup*/NULL,FreeSysObject },       /* TYPE_KBDLAYOUT */
-    { AllocSysObject,           /*UserKbdFileCleanup*/NULL, FreeSysObject },        /* TYPE_KBDFILE */
+    { AllocSysObject,           UserKbdLayoutCleanup,       FreeSysObject },        /* TYPE_KBDLAYOUT */
+    { AllocSysObject,           UserKbdFileCleanup,         FreeSysObject },        /* TYPE_KBDFILE */
     { AllocThreadObject,        IntRemoveEvent,             FreeThreadObject },     /* TYPE_WINEVENTHOOK */
     { AllocSysObject,           /*UserTimerCleanup*/NULL,   FreeSysObject },        /* TYPE_TIMER */
     { AllocInputContextObject,  UserDestroyInputContext,    UserFreeInputContext }, /* TYPE_INPUTCONTEXT */

--- a/win32ss/user/ntuser/object.c
+++ b/win32ss/user/ntuser/object.c
@@ -266,8 +266,8 @@ static const struct
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDECONV */
     { NULL,                     NULL,                       NULL },                 /* TYPE_DDEXACT */
     { AllocSysObject,           /*UserMonitorCleanup*/NULL, FreeSysObject },        /* TYPE_MONITOR */
-    { AllocSysObject,           UserKbdLayoutCleanup,       FreeSysObject },       /* TYPE_KBDLAYOUT */
-    { AllocSysObject,           UserKbdFileCleanup,         FreeSysObject },       /* TYPE_KBDFILE */
+    { AllocSysObject,           NULL,                       FreeKbdLayout },        /* TYPE_KBDLAYOUT */
+    { AllocSysObject,           NULL,                       FreeKbdFile },          /* TYPE_KBDFILE */
     { AllocThreadObject,        IntRemoveEvent,             FreeThreadObject },     /* TYPE_WINEVENTHOOK */
     { AllocSysObject,           /*UserTimerCleanup*/NULL,   FreeSysObject },        /* TYPE_TIMER */
     { AllocInputContextObject,  UserDestroyInputContext,    UserFreeInputContext }, /* TYPE_INPUTCONTEXT */

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -128,8 +128,7 @@ IntWinStaObjectDelete(
 
     RtlDestroyAtomTable(WinSta->AtomTable);
 
-    /* FIXME: Please move gspklBaseLayout to WinSta->spklList */
-    UserAssignmentUnlock((PVOID*)&gspklBaseLayout);
+    UserAssignmentUnlock((PVOID*)&WinSta->spklList);
 
     return STATUS_SUCCESS;
 }

--- a/win32ss/user/ntuser/winsta.c
+++ b/win32ss/user/ntuser/winsta.c
@@ -128,7 +128,8 @@ IntWinStaObjectDelete(
 
     RtlDestroyAtomTable(WinSta->AtomTable);
 
-    UserAssignmentUnlock((PVOID*)&WinSta->spklList);
+    /* FIXME: Please move gspklBaseLayout to WinSta->spklList */
+    UserAssignmentUnlock((PVOID*)&gspklBaseLayout);
 
     return STATUS_SUCCESS;
 }


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `UserKbdFileCleanup` and `UserKbdLayoutCleanup` functions to clean up the keyboard layout objects.
- Delete `UnloadKbdFile` function.
- Use `UserAssignmentLock` / `UserAssignmentUnlock` against `gspklBaseLayout` assignments.
- Half-implement `KLF_RESET` in `co_IntLoadKeyboardLayoutEx`.

## TODO

- [x] Keyboard is working.
- [x] Confirm keyboard switching.
- [ ] Confirm keyboard cleanup.
- [ ] Free `gspklBaseLayout`.
- [x] Do small tests.
- [ ] Do big tests.