### PR TITLE
[NTOS:SE] Do not allocate memory pool just for the access rights

### DIFF
--- a/ntoskrnl/include/internal/se.h
+++ b/ntoskrnl/include/internal/se.h
@@ -1,9 +1,9 @@
 /*
- * PROJECT:         ReactOS Kernel
- * LICENSE:         GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
- * PURPOSE:         Internal header for the Security Manager
- * COPYRIGHT:       Copyright Eric Kohl
- *                  Copyright 2022 George Bișoc <george.bisoc@reactos.org>
+ * PROJECT:     ReactOS Kernel
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Internal header for the Security Manager
+ * COPYRIGHT:   Copyright Eric Kohl
+ *              Copyright 2022 George Bișoc <george.bisoc@reactos.org>
  */
 
 #pragma once
@@ -303,7 +303,7 @@ SepDumpTokenDebugInfo(
 
 VOID
 SepDumpAccessRightsStats(
-    _In_opt_ PACCESS_CHECK_RIGHTS AccessRights);
+    _In_ PACCESS_CHECK_RIGHTS AccessRights);
 #endif // DBG
 
 //

--- a/ntoskrnl/include/internal/tag.h
+++ b/ntoskrnl/include/internal/tag.h
@@ -164,7 +164,6 @@
 #define TAG_LOGON_NOTIFICATION  'nLeS'
 #define TAG_SID_AND_ATTRIBUTES  'aSeS'
 #define TAG_SID_VALIDATE        'vSeS'
-#define TAG_ACCESS_CHECK_RIGHT  'rCeS'
 #define TAG_DACL                'lcaD'
 
 /* LPC Tags */

--- a/ntoskrnl/se/debug.c
+++ b/ntoskrnl/se/debug.c
@@ -323,10 +323,15 @@ SepDumpTokenDebugInfo(
  */
 VOID
 SepDumpAccessRightsStats(
-    _In_opt_ PACCESS_CHECK_RIGHTS AccessRights)
+    _In_ PACCESS_CHECK_RIGHTS AccessRights)
 {
-    /* Don't dump anything if no access check rights list was provided */
-    if (!AccessRights)
+    /*
+     * Dump the access rights only if we have remaining rights
+     * to dump in the first place. RemainingAccessRights can be 0
+     * if access check procedure has failed prematurely and this
+     * member hasn't been filled yet.
+     */
+    if (!AccessRights->RemainingAccessRights)
     {
         return;
     }


### PR DESCRIPTION
Access check is an expensive operation, that is, whenever an access to an object is performed an access check has to be done to ensure the access can be allowed to the calling thread who attempts to access such object.

Currently `SepAnalyzeAcesFromDacl` allocates a block of pool memory for access check rights, nagging the Memory Manager like a desperate naughty creep. So instead initialize the access rights as a simple variable in `SepAccessCheck` and pass it out as an address to `SepAnalyzeAcesFromDacl `so that the function will fill it up with access rights. This helps with performance, avoiding wasting a few bits of memory just to hold these access rights.

In addition to that, add a few asserts and fix the copyright header on both `se.h` and `accesschk.c,` to reflect the Coding Style rules.
