### PR TITLE
[NTUSER] VerifyWnd: Remove pointless SEH and simplify the function

### DIFF
--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -85,33 +85,12 @@ PWND FASTCALL IntGetWindowObject(HWND hWnd)
 
 PWND FASTCALL VerifyWnd(PWND pWnd)
 {
-   HWND hWnd;
-   UINT State, State2;
-   ULONG Error;
+   if (!pWnd ||
+       UserObjectInDestroy(UserHMGetHandle(pWnd)) ||
+       pWnd->state & WNDS_DESTROYED ||
+       pWnd->state2 & WNDS2_INDESTROY)
+      return NULL;
 
-   if (!pWnd) return NULL;
-
-   Error = EngGetLastError();
-
-   _SEH2_TRY
-   {
-      hWnd = UserHMGetHandle(pWnd);
-      State = pWnd->state;
-      State2 = pWnd->state2;
-   }
-   _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-   {
-      EngSetLastError(Error);
-      _SEH2_YIELD(return NULL);
-   }
-   _SEH2_END
-
-   if ( UserObjectInDestroy(hWnd) ||
-        State & WNDS_DESTROYED ||
-        State2 & WNDS2_INDESTROY )
-      pWnd = NULL;
-
-   EngSetLastError(Error);
    return pWnd;
 }
 


### PR DESCRIPTION
## Purpose
The NULL check has been done before calling `UserHMGetHandle` already. I don't see the point of using SEH here.