### PR TITLE
[NTUSER][USER32] KLF_SETFORPROCESS for ActivateKeyboardLayout

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -720,7 +720,10 @@ co_UserActivateKeyboardLayout(
     pKL->wchDiacritic = 0;
 
     if (pOldKL)
+    {
+        IntReferenceThreadInfo(pti);
         UserRefObjectCo(pOldKL, &Ref1);
+    }
 
     if (pti->TIF_flags & TIF_CSRSSTHREAD)
     {
@@ -788,7 +791,11 @@ co_UserActivateKeyboardLayout(
     }
 
     if (pOldKL)
+    {
         UserDerefObjectCo(pOldKL);
+        IntDereferenceThreadInfo(pti);
+    }
+
     return hOldKL;
 }
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -688,7 +688,6 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
     }
 }
 
-/* Win: xxxInternalActivateKeyboardLayout */
 HKL APIENTRY
 co_UserActivateKeyboardLayout(
     _Inout_ PKL     pKL,

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -657,13 +657,14 @@ IntImmActivateLayout(
 
 static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
 {
-    PTHREADINFO ptiNode;
+    PTHREADINFO ptiNode, ptiNext;
     PCLIENTINFO pClientInfo;
     BOOL bImmMode = IS_IMM_MODE();
 
-    for (ptiNode = ppi->ptiList; ptiNode; ptiNode = ptiNode->ptiSibling)
+    for (ptiNode = ppi->ptiList; ptiNode; ptiNode = ptiNext)
     {
         IntReferenceThreadInfo(ptiNode);
+        ptiNext = ptiNode->ptiSibling;
 
         if (ptiNode->KeyboardLayout == pKL || (ptiNode->TIF_flags & TIF_INCLEANUP))
         {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -701,7 +701,7 @@ co_UserActivateKeyboardLayout(
     HWND hTargetWnd, hImeWnd;
     USER_REFERENCE_ENTRY Ref1, Ref2;
     PCLIENTINFO ClientInfo;
-    BOOL bForProcess = !!(uFlags & KLF_SETFORPROCESS);
+    BOOL bSetForProcess = !!(uFlags & KLF_SETFORPROCESS);
 
     IntReferenceThreadInfo(pti);
     ClientInfo = pti->pClientInfo;
@@ -718,7 +718,7 @@ co_UserActivateKeyboardLayout(
         FIXME("KLF_RESET\n");
     }
 
-    if (!bForProcess && pKL == pti->KeyboardLayout)
+    if (!bSetForProcess && pKL == pti->KeyboardLayout)
     {
         IntDereferenceThreadInfo(pti);
         return hOldKL;
@@ -735,7 +735,7 @@ co_UserActivateKeyboardLayout(
         ClientInfo->CodePage = pKL->CodePage;
         ClientInfo->hKL = pKL->hkl;
     }
-    else if (bForProcess)
+    else if (bSetForProcess)
     {
         co_IntSetKeyboardLayoutForProcess(pti->ppi, pKL);
     }
@@ -787,7 +787,7 @@ co_UserActivateKeyboardLayout(
             {
                 UserRefObjectCo(pImeWnd, &Ref2);
                 hImeWnd = UserHMGetHandle(pImeWnd);
-                co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_SENDNOTIFICATION, bForProcess);
+                co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_SENDNOTIFICATION, bSetForProcess);
                 UserDerefObjectCo(pImeWnd);
             }
         }

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -663,7 +663,7 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
 
     for (ptiNode = ppi->ptiList; ptiNode; ptiNode = ptiNode->ptiSibling)
     {
-        if (ptiNode->KeyboardLayout == pKL && (ptiNode->TIF_flags & TIF_INCLEANUP))
+        if (ptiNode->KeyboardLayout == pKL || (ptiNode->TIF_flags & TIF_INCLEANUP))
             continue;
 
         _SEH2_TRY

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -655,7 +655,7 @@ IntImmActivateLayout(
     pti->pClientInfo->hKL = pKL->hkl;
 }
 
-static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
+static VOID co_IntSetKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
 {
     PTHREADINFO ptiNode, ptiNext;
     PCLIENTINFO pClientInfo;
@@ -737,7 +737,7 @@ co_UserActivateKeyboardLayout(
     }
     else if (bForProcess)
     {
-        co_IntActivateKeyboardLayoutForProcess(pti->ppi, pKL);
+        co_IntSetKeyboardLayoutForProcess(pti->ppi, pKL);
     }
     else
     {

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -654,6 +654,7 @@ IntImmActivateLayout(
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
     pti->pClientInfo->hKL = pKL->hkl;
+    pti->CodePage = pKL->CodePage;
 }
 
 static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
@@ -666,13 +667,13 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
         if (ptiNode->KeyboardLayout == pKL && (ptiNode->TIF_flags & TIF_INCLEANUP))
             continue;
 
-        if (IS_IMM_MODE())
+        _SEH2_TRY
         {
-            IntImmActivateLayout(ptiNode, pKL);
-        }
-        else
-        {
-            _SEH2_TRY
+            if (IS_IMM_MODE())
+            {
+                IntImmActivateLayout(ptiNode, pKL);
+            }
+            else
             {
                 UserAssignmentLock((PVOID*)&ptiNode->KeyboardLayout, pKL);
                 pClientInfo = ptiNode->pClientInfo;
@@ -680,12 +681,12 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
                 pClientInfo->CodePage = pKL->CodePage;
                 pClientInfo->hKL = pKL->hkl;
             }
-            _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
-            {
-                NOTHING;
-            }
-            _SEH2_END;
         }
+        _SEH2_EXCEPT(EXCEPTION_EXECUTE_HANDLER)
+        {
+            NOTHING;
+        }
+        _SEH2_END;
     }
 }
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -666,6 +666,7 @@ static VOID co_IntSetKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
         IntReferenceThreadInfo(ptiNode);
         ptiNext = ptiNode->ptiSibling;
 
+        /* Skip this thread if its keyboard layout is already the correct one, or if it's dying */
         if (ptiNode->KeyboardLayout == pKL || (ptiNode->TIF_flags & TIF_INCLEANUP))
         {
             IntDereferenceThreadInfo(ptiNode);

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -659,6 +659,7 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
 {
     PTHREADINFO ptiNode;
     PCLIENTINFO pClientInfo;
+    BOOL bImmMode = IS_IMM_MODE();
 
     for (ptiNode = ppi->ptiList; ptiNode; ptiNode = ptiNode->ptiSibling)
     {
@@ -667,7 +668,7 @@ static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)
 
         _SEH2_TRY
         {
-            if (IS_IMM_MODE())
+            if (bImmMode)
             {
                 IntImmActivateLayout(ptiNode, pKL);
             }

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -653,7 +653,6 @@ IntImmActivateLayout(
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
     pti->pClientInfo->hKL = pKL->hkl;
-    pti->CodePage = pKL->CodePage;
 }
 
 static VOID co_IntActivateKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -630,7 +630,6 @@ co_UserActivateKbl(PTHREADINFO pti, PKL pKl, UINT Flags)
     return pklPrev;
 }
 
-// Win: xxxImmActivateLayout
 VOID APIENTRY
 IntImmActivateLayout(
     _Inout_ PTHREADINFO pti,

--- a/win32ss/user/user32/windows/defwnd.c
+++ b/win32ss/user/user32/windows/defwnd.c
@@ -561,7 +561,7 @@ User32DefWindowProc(HWND hWnd,
             else if(wParam & INPUTLANGCHANGE_FORWARD) NewHkl = (HKL) HKL_NEXT;
             else NewHkl = (HKL) lParam;
 
-            NtUserActivateKeyboardLayout(NewHkl, 0);
+            NtUserActivateKeyboardLayout(NewHkl, KLF_SETFORPROCESS);
 
             return TRUE;
         }


### PR DESCRIPTION
## Purpose
Supporting `KLF_SETFORPROCESS` flag in `ActivateKeyboardLayout` function.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-10667](https://jira.reactos.org/browse/CORE-10667)

## Proposed changes

- Implement `KLF_SETFORPROCESS` for `co_UserActivateKeyboardLayout`.
- Use `KLF_SETFORPROCESS` flag in `WM_INPUTLANGCHANGEREQUEST` handling.
- Add `co_IntSetKeyboardLayoutForProcess` helper function.

## TODO

- [x] Test keyboard switching.
- [x] Do big tests.
