### PR TITLE
[NOTEPAD] Arabic also uses Right-to-Left (RTL) layout

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -573,6 +573,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
+    /* Arabic and Hebrew are Right-to-Left */
     switch (PRIMARYLANGID(GetUserDefaultUILanguage()))
     {
         case LANG_ARABIC:

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -573,14 +573,12 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
-    switch (GetUserDefaultUILanguage())
+    switch (PRIMARYLANGID(GetUserDefaultUILanguage()))
     {
-    case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-        SetProcessDefaultLayout(LAYOUT_RTL);
-        break;
-
-    default:
-        break;
+        case LANG_ARABIC:
+        case LANG_HEBREW:
+            SetProcessDefaultLayout(LAYOUT_RTL);
+            break;
     }
 
     UNREFERENCED_PARAMETER(prev);

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -573,7 +573,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
-    /* Arabic and Hebrew are Right-to-Left */
+    /* Arabic and Hebrew use Right-to-Left layout */
     switch (PRIMARYLANGID(GetUserDefaultUILanguage()))
     {
         case LANG_ARABIC:


### PR DESCRIPTION
## Purpose
The Arabic user uses Right-to-Left (RTL) layout. Notepad should support RTL.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Use `PRIMARYLANGID` macro to get the primary language ID.
- Add Arabic case.