### PR TITLE
[NOTEPAD] Use DestroyIcon instead of DeleteObject to destroy icon

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -1413,7 +1413,7 @@ VOID DIALOG_HelpAboutNotepad(VOID)
     LoadString(Globals.hInstance, STRING_NOTEPAD_AUTHORS, szNotepadAuthors, ARRAY_SIZE(szNotepadAuthors));
 
     ShellAbout(Globals.hMainWnd, szNotepad, szNotepadAuthors, notepadIcon);
-    DeleteObject(notepadIcon);
+    DestroyIcon(notepadIcon);
 }
 
 /***********************************************************************


### PR DESCRIPTION
## Purpose

Fix handle leak.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Use `DestroyIcon` function instead of `DeleteObject` to destroy `notepadIcon` at `DIALOG_HelpAboutNotepad`.
