### PR TITLE
[NOTEPAD] Use Globals.hMainWnd in ShowLastError

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -75,7 +75,7 @@ VOID ShowLastError(VOID)
                       0,
                       NULL);
 
-        MessageBox(NULL, lpMsgBuf, szTitle, MB_OK | MB_ICONERROR);
+        MessageBox(Globals.hMainWnd, lpMsgBuf, szTitle, MB_OK | MB_ICONERROR);
         LocalFree(lpMsgBuf);
     }
 }


### PR DESCRIPTION
## Purpose
Improving UI/UX by making `Globals.hMainWnd` the owner of the message box.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Use `Globals.hMainWnd` variable in `ShowLastError` function.

## Comparison
BEFORE: Try to open a folder by dragging & dropping.
![image](https://user-images.githubusercontent.com/2107452/223913360-4a23a6cb-24d7-4ae5-8c32-fb5ff172b2f6.png)
Since the owner of the messsage box was `NULL`, the message box could be overlapped by the main window.