### PR TITLE
[NTOS:CM] Set alternative system architecture field on PC-98

### DIFF
--- a/ntoskrnl/config/cmconfig.c
+++ b/ntoskrnl/config/cmconfig.c
@@ -333,6 +333,11 @@ CmpInitializeHardwareConfiguration(IN PLOADER_PARAMETER_BLOCK LoaderBlock)
     ULONG Disposition;
     UNICODE_STRING KeyName;
 
+    /* Set the alternative system architecture information */
+#if defined(SARCH_PC98)
+    SharedUserData->AlternativeArchitecture = NEC98x86;
+#endif
+
     /* Setup the key name */
     RtlInitUnicodeString(&KeyName,
                          L"\\Registry\\Machine\\Hardware\\DeviceMap");


### PR DESCRIPTION
## Purpose

This is needed by some 3rd party drivers.

## Proposed changes

- Initialize the alternative system architecture field
