### PR TITLE
[APPLICATIONS] Enable mirroring for right-to-left languages from resources.

### DIFF
--- a/base/applications/charmap/charmap.c
+++ b/base/applications/charmap/charmap.c
@@ -680,17 +680,6 @@ wWinMain(HINSTANCE hInst,
 
     hInstance = hInst;
 
-    /* Mirroring code for the titlebar */
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     iccx.dwSize = sizeof(INITCOMMONCONTROLSEX);
     iccx.dwICC = ICC_TAB_CLASSES;
     InitCommonControlsEx(&iccx);

--- a/base/applications/charmap/lang/he-IL.rc
+++ b/base/applications/charmap/lang/he-IL.rc
@@ -1,6 +1,14 @@
 /* Translated by Baruch Rutman */
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Character Map"
+#include <reactos/version.rc>
+
 IDD_CHARMAP DIALOGEX 6, 6, 292, 224
 FONT 8, "MS Shell Dlg", 0, 0
 STYLE DS_SHELLFONT | WS_CHILD | WS_VISIBLE

--- a/base/applications/clipbrd/clipbrd.c
+++ b/base/applications/clipbrd/clipbrd.c
@@ -675,16 +675,6 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLi
         return 0;
     }
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     ZeroMemory(&Globals, sizeof(Globals));
     Globals.hInstance = hInstance;
 

--- a/base/applications/clipbrd/clipbrd.rc
+++ b/base/applications/clipbrd/clipbrd.rc
@@ -10,6 +10,8 @@
 
 #include "resources.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION    "ReactOS Clipboard Viewer"
 #define REACTOS_STR_INTERNAL_NAME       "clipbrd"
 #define REACTOS_STR_ORIGINAL_FILENAME   "clipbrd.exe"

--- a/base/applications/clipbrd/lang/he-IL.rc
+++ b/base/applications/clipbrd/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Clipboard Viewer"
+#include <reactos/version.rc>
+
 ID_ACCEL ACCELERATORS
 BEGIN
     VK_DELETE, CMD_DELETE, VIRTKEY

--- a/base/applications/fontview/fontview.c
+++ b/base/applications/fontview/fontview.c
@@ -108,16 +108,6 @@ wWinMain(HINSTANCE hThisInstance,
 	WNDCLASSEXW wincl;
 	LPCWSTR fileName;
 
-    switch (GetUserDefaultUILanguage())
-    {
-    case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-      SetProcessDefaultLayout(LAYOUT_RTL);
-      break;
-
-    default:
-      break;
-    }
-
 	g_hInstance = hThisInstance;
 
 	/* Get unicode command line */

--- a/base/applications/fontview/lang/he-IL.rc
+++ b/base/applications/fontview/lang/he-IL.rc
@@ -2,6 +2,14 @@
 
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Font Viewer"
+#include <reactos/version.rc>
+
 STRINGTABLE
 BEGIN
     IDS_INSTALL "התקן"

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -888,15 +888,6 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInst, LPTSTR lpCmdLine, INT nCmdSh
     HANDLE hMutex;
     HWND hwnd;
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-        default:
-            break;
-    }
-
     hMutex = CreateMutex(NULL, FALSE, szKbSwitcherName);
     if (!hMutex)
         return 1;

--- a/base/applications/kbswitch/lang/he-IL.rc
+++ b/base/applications/kbswitch/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Keyboard Layout Switcher"
+#include <reactos/version.rc>
+
 IDR_POPUP MENU
 BEGIN
     POPUP "popup"

--- a/base/applications/magnify/lang/he-IL.rc
+++ b/base/applications/magnify/lang/he-IL.rc
@@ -2,6 +2,14 @@
 
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Magnifier"
+#include <reactos/version.rc>
+
 IDC_MAGNIFIER MENU
 BEGIN
     POPUP "&קובץ"

--- a/base/applications/magnify/magnifier.c
+++ b/base/applications/magnify/magnifier.c
@@ -81,16 +81,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
     UNREFERENCED_PARAMETER(hPrevInstance);
     UNREFERENCED_PARAMETER(lpCmdLine);
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     /* Initialize global strings */
     LoadString(hInstance, IDS_APP_TITLE, szTitle, MAX_LOADSTRING);
     MyRegisterClass(hInstance);

--- a/base/applications/mplay32/lang/he-IL.rc
+++ b/base/applications/mplay32/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Multimedia Player"
+#include <reactos/version.rc>
+
 IDR_MAINMENU MENU
 BEGIN
     POPUP "&קובץ"

--- a/base/applications/mplay32/mplay32.c
+++ b/base/applications/mplay32/mplay32.c
@@ -1473,16 +1473,6 @@ _tWinMain(HINSTANCE hInst, HINSTANCE hPrevInst, LPTSTR lpCmdLine, INT nCmdShow)
 
     hInstance = hInst;
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     LoadString(hInstance, IDS_APPTITLE, szAppTitle, ARRAYSIZE(szAppTitle));
 
     WndClass.cbSize            = sizeof(WndClass);

--- a/base/applications/mplay32/mplay32.rc
+++ b/base/applications/mplay32/mplay32.rc
@@ -3,12 +3,12 @@
 
 #include "resource.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Multimedia Player"
 #define REACTOS_STR_INTERNAL_NAME     "mplay32"
 #define REACTOS_STR_ORIGINAL_FILENAME "mplay32.exe"
 #include <reactos/version.rc>
-
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 /* Icons */
 IDI_MAIN ICON "resources/mplay32.ico"

--- a/base/applications/mscutils/servman/lang/he-IL.rc
+++ b/base/applications/mscutils/servman/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Service Manager"
+#include <reactos/version.rc>
+
 IDR_MAINMENU MENU
 BEGIN
     POPUP "קובץ"

--- a/base/applications/mscutils/servman/servman.c
+++ b/base/applications/mscutils/servman/servman.c
@@ -28,16 +28,6 @@ wWinMain(HINSTANCE hThisInstance,
     int Ret = 1;
     INITCOMMONCONTROLSEX icex;
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     hInstance = hThisInstance;
     ProcessHeap = GetProcessHeap();
 

--- a/base/applications/mscutils/servman/servman.rc
+++ b/base/applications/mscutils/servman/servman.rc
@@ -4,14 +4,14 @@
 
 #include "resource.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Service Manager"
 #define REACTOS_STR_INTERNAL_NAME     "services"
 #define REACTOS_STR_ORIGINAL_FILENAME "servman.exe"
 #include <reactos/version.rc>
 
 #include <reactos/manifest_exe.rc>
-
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 IDI_SM_ICON ICON "res/system.ico"
 

--- a/base/applications/notepad/lang/he-IL.rc
+++ b/base/applications/notepad/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Notepad"
+#include <reactos/version.rc>
+
 ID_ACCEL ACCELERATORS
 BEGIN
     "^A", CMD_SELECT_ALL

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -560,16 +560,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
-    switch (GetUserDefaultUILanguage())
-    {
-    case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-        SetProcessDefaultLayout(LAYOUT_RTL);
-        break;
-
-    default:
-        break;
-    }
-
     UNREFERENCED_PARAMETER(prev);
 
     aFINDMSGSTRING = (ATOM)RegisterWindowMessage(FINDMSGSTRING);

--- a/base/applications/notepad/rsrc.rc
+++ b/base/applications/notepad/rsrc.rc
@@ -23,6 +23,8 @@
 
 #include "notepad_res.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Notepad"
 #define REACTOS_STR_INTERNAL_NAME     "notepad"
 #define REACTOS_STR_ORIGINAL_FILENAME "notepad.exe"

--- a/base/applications/rapps/lang/he-IL.rc
+++ b/base/applications/rapps/lang/he-IL.rc
@@ -9,6 +9,14 @@
 
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Applications Manager"
+#include <reactos/version.rc>
+
 IDR_MAINMENU MENU
 BEGIN
     POPUP "&קובץ"

--- a/base/applications/rapps/rapps.rc
+++ b/base/applications/rapps/rapps.rc
@@ -4,12 +4,12 @@
 
 #include "resource.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Applications Manager"
 #define REACTOS_STR_INTERNAL_NAME     "rapps"
 #define REACTOS_STR_ORIGINAL_FILENAME "rapps.exe"
 #include <reactos/version.rc>
-
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 IDI_MAIN ICON "res/main.ico"
 IDI_EXIT ICON "res/exit.ico"

--- a/base/applications/rapps/winmain.cpp
+++ b/base/applications/rapps/winmain.cpp
@@ -34,11 +34,6 @@ wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPWSTR lpCmdLine, INT nSh
     gModule.Init(ObjectMap, hInstance, NULL);
     Gdiplus::GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
 
-    if (GetUserDefaultUILanguage() == MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT))
-    {
-        SetProcessDefaultLayout(LAYOUT_RTL);
-    }
-
     hInst = hInstance;
 
     BOOL bIsFirstLaunch = !LoadSettings(&SettingsInfo);

--- a/base/applications/regedit/lang/he-IL.rc
+++ b/base/applications/regedit/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Registry Explorer"
+#include <reactos/version.rc>
+
 ID_ACCEL ACCELERATORS
 BEGIN
     "D", ID_ADDRESS_FOCUS, VIRTKEY, ALT

--- a/base/applications/regedit/main.c
+++ b/base/applications/regedit/main.c
@@ -215,15 +215,6 @@ int WINAPI wWinMain(HINSTANCE hInstance,
         return 0;
     }
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
     /* Store instance handle in our global variable */
     hInst = hInstance;
 

--- a/base/applications/regedit/regedit.rc
+++ b/base/applications/regedit/regedit.rc
@@ -24,14 +24,14 @@
 
 #include "resource.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Registry Explorer"
 #define REACTOS_STR_INTERNAL_NAME     "regedit"
 #define REACTOS_STR_ORIGINAL_FILENAME "regedit.exe"
 #include <reactos/version.rc>
 
 #include <reactos/manifest_exe.rc>
-
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 IDI_STRING ICON "res/string.ico"
 IDI_BIN ICON "res/bin.ico"

--- a/base/applications/sndrec32/lang/he-IL.rc
+++ b/base/applications/sndrec32/lang/he-IL.rc
@@ -1,5 +1,13 @@
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS Sound Recorder"
+#include <reactos/version.rc>
+
 IDC_REACTOS_SNDREC32 ACCELERATORS
 BEGIN
     "?", IDM_ABOUT, ASCII, ALT

--- a/base/applications/sndrec32/rsrc.rc
+++ b/base/applications/sndrec32/rsrc.rc
@@ -5,6 +5,13 @@
 
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
+#define REACTOS_STR_FILE_DESCRIPTION  "ReactOS Sound Recorder"
+#define REACTOS_STR_INTERNAL_NAME     "sndrec32"
+#define REACTOS_STR_ORIGINAL_FILENAME "sndrec32.exe"
+#include <reactos/version.rc>
+
+#include <reactos/manifest_exe.rc>
+
 IDI_SNDREC32 ICON "resources/record-app.ico"
 
 IDB_BITMAP2_START BITMAP "resources/but_start.bmp"
@@ -17,8 +24,6 @@ IDB_BITMAP2_PLAY_DIS BITMAP "resources/but_play_dis.bmp"
 IDB_BITMAP2_REC_DIS BITMAP "resources/but_rec_dis.bmp"
 IDB_BITMAP2_START_DIS BITMAP "resources/but_start_dis.bmp"
 IDB_BITMAP2_STOP_DIS BITMAP "resources/but_stop_dis.bmp"
-
-#include <reactos/manifest_exe.rc>
 
 /* UTF-8 */
 #pragma code_page(65001)

--- a/base/applications/wordpad/lang/he-IL.rc
+++ b/base/applications/wordpad/lang/he-IL.rc
@@ -23,6 +23,14 @@
 
 LANGUAGE LANG_HEBREW, SUBLANG_DEFAULT
 
+/*
+ * Enable RTL mirroring by adding two left-to-right marks (LRMs)
+ * in front of the FileDescription value of the version stamping.
+ */
+#undef REACTOS_STR_FILE_DESCRIPTION
+#define REACTOS_STR_FILE_DESCRIPTION    L"\x200e\x200e" L"ReactOS WordPad"
+#include <reactos/version.rc>
+
 IDM_MAINMENU MENU
 BEGIN
     POPUP "&קובץ"

--- a/base/applications/wordpad/rsrc.rc
+++ b/base/applications/wordpad/rsrc.rc
@@ -22,6 +22,8 @@
 
 #include "wordpad.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION  "ReactOS WordPad"
 #define REACTOS_STR_INTERNAL_NAME     "wordpad"
 #define REACTOS_STR_ORIGINAL_FILENAME "wordpad.exe"

--- a/base/applications/wordpad/wordpad.c
+++ b/base/applications/wordpad/wordpad.c
@@ -2663,16 +2663,6 @@ int CALLBACK WinMain(HINSTANCE hInstance, HINSTANCE hOldInstance, LPSTR szCmdPar
 
     InitCommonControlsEx(&classes);
 
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-
     hAccel = LoadAcceleratorsW(hInstance, wszAccelTable);
 
     wc.cbSize = sizeof(wc);

--- a/base/setup/welcome/welcome.c
+++ b/base/setup/welcome/welcome.c
@@ -790,19 +790,6 @@ _tWinMain(HINSTANCE hInst,
         return 0;
     }
 
-#if 0
-    /* Mirroring is enabled from within the resources */
-    switch (GetUserDefaultUILanguage())
-    {
-        case MAKELANGID(LANG_HEBREW, SUBLANG_DEFAULT):
-            SetProcessDefaultLayout(LAYOUT_RTL);
-            break;
-
-        default:
-            break;
-    }
-#endif
-
     hInstance = hInst;
 
     /* Load icons */

--- a/base/setup/welcome/welcome.rc
+++ b/base/setup/welcome/welcome.rc
@@ -2,12 +2,12 @@
 
 #include "resource.h"
 
+LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
+
 #define REACTOS_STR_FILE_DESCRIPTION    "ReactOS-Welcome"
 #define REACTOS_STR_INTERNAL_NAME       "welcome"
 #define REACTOS_STR_ORIGINAL_FILENAME   "welcome.exe"
 #include <reactos/version.rc>
-
-LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 
 /* Icons */
 IDI_MAIN ICON "res/welcome.ico"


### PR DESCRIPTION
Currently done only for Hebrew, since ReactOS doesn't have the other ones (e.g. Arabic, Persian, etc.)

Supersedes PR #5129