### PR TITLE
[SHELL32] Give opportunity to rename file/folder on its creation

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -990,7 +990,6 @@ BOOLEAN CDefView::LV_ProdItem(PCUITEMID_CHILD pidl)
         lvItem.iImage = SHMapPIDLToSystemImageListIndex(m_pSFParent, pidl, 0);
         m_ListView.SetItem(&lvItem);
         m_ListView.Update(nItem);
-        m_ListView.EditLabel(nItem);
         return TRUE;
     }
 

--- a/dll/win32/shell32/CDefaultContextMenu.cpp
+++ b/dll/win32/shell32/CDefaultContextMenu.cpp
@@ -926,7 +926,7 @@ CDefaultContextMenu::DoCreateNewFolder(
     CComPtr<IShellView> psv;
 
     /* Notify the view object about the new item */
-    SHChangeNotify(SHCNE_MKDIR, SHCNF_PATHW, (LPCVOID)wszName, NULL);
+    SHChangeNotify(SHCNE_MKDIR, SHCNF_PATHW | SHCNF_FLUSH, (LPCVOID)wszName, NULL);
 
     if (!m_site)
         return S_OK;

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -418,7 +418,7 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
         dwSelectFlags |= SVSI_EDIT;
 
     /* Notify the view object about the new item */
-    SHChangeNotify(wEventId, uFlags | SHCNF_FLUSH, (LPCVOID) pszName, NULL);
+    SHChangeNotify(wEventId, uFlags | SHCNF_FLUSH, (LPCVOID)pszName, NULL);
 
     if (!m_pSite)
         return S_OK;

--- a/dll/win32/shell32/CNewMenu.cpp
+++ b/dll/win32/shell32/CNewMenu.cpp
@@ -418,7 +418,7 @@ HRESULT CNewMenu::SelectNewItem(LONG wEventId, UINT uFlags, LPWSTR pszName, BOOL
         dwSelectFlags |= SVSI_EDIT;
 
     /* Notify the view object about the new item */
-    SHChangeNotify(wEventId, uFlags, (LPCVOID) pszName, NULL);
+    SHChangeNotify(wEventId, uFlags | SHCNF_FLUSH, (LPCVOID) pszName, NULL);
 
     if (!m_pSite)
         return S_OK;


### PR DESCRIPTION
Revert the hack from commit ed4b16b7f (PR #4950).
Real fix to this issue.

The CNewMenu::SelectNewItem method starts with a request to notify the View object about a new item by calling SHChangeNotify. After creating and obtaining the new PIDL by calling ILFindLastID, the CDefView::SelectItem method is called. This method fails right from the start when calling LV_FindItemByPidl which returns -1, thus preventing the user from being given the opportunity to change the name displayed by default.

This failure is due to the fact that this object has not yet been added to the CDefView::m_ListView. For some reason the call to SHChangeNotify did not call CDefView::OnChangeNotify with eventID SHCNE_CREATE.

Thanks to @yagoulas  by the big help.
