### PR TITLE
[MSPAINT] Fix use of uninitialized variable on startup

### DIFF
--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -72,18 +72,18 @@ void CMainWindow::alignChildrenToMainWindow()
         h = clientRect.bottom - 3;
     }
 
-    RECT statusBarRect0;
-    int statusBarBorders[3];
-    int statusBarHeight = 0;
-    if (::IsWindow(hStatusBar))
+    INT statusBarHeight = 0;
+    if (::IsWindowVisible(hStatusBar))
     {
+        RECT statusBarRect0;
+        INT statusBarBorders[3];
         ::SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&statusBarRect0);
         ::SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&statusBarBorders);
         statusBarHeight = statusBarRect0.bottom - statusBarRect0.top + statusBarBorders[1];
     }
 
     if (scrollboxWindow.IsWindow())
-        scrollboxWindow.MoveWindow(x, y, w, ::IsWindowVisible(hStatusBar) ? h - statusBarHeight : h, TRUE);
+        scrollboxWindow.MoveWindow(x, y, w, h - statusBarHeight, TRUE);
     if (paletteWindow.IsWindow())
         paletteWindow.MoveWindow(x, 9, 255, 32, TRUE);
 }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -74,12 +74,13 @@ void CMainWindow::alignChildrenToMainWindow()
 
     RECT statusBarRect0;
     int statusBarBorders[3];
+    int statusBarHeight = 0;
     if (::IsWindow(hStatusBar))
     {
         ::SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&statusBarRect0);
         ::SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&statusBarBorders);
+        statusBarHeight = statusBarRect0.bottom - statusBarRect0.top + statusBarBorders[1];
     }
-    int statusBarHeight = statusBarRect0.bottom - statusBarRect0.top + statusBarBorders[1];
 
     if (scrollboxWindow.IsWindow())
         scrollboxWindow.MoveWindow(x, y, w, ::IsWindowVisible(hStatusBar) ? h - statusBarHeight : h, TRUE);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -75,11 +75,11 @@ void CMainWindow::alignChildrenToMainWindow()
     INT statusBarHeight = 0;
     if (::IsWindowVisible(hStatusBar))
     {
-        RECT statusBarRect0;
-        INT statusBarBorders[3];
-        ::SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&statusBarRect0);
-        ::SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&statusBarBorders);
-        statusBarHeight = statusBarRect0.bottom - statusBarRect0.top + statusBarBorders[1];
+        RECT Rect;
+        INT borders[3];
+        ::SendMessage(hStatusBar, SB_GETRECT, 0, (LPARAM)&Rect);
+        ::SendMessage(hStatusBar, SB_GETBORDERS, 0, (LPARAM)&borders);
+        statusBarHeight = Rect.bottom - Rect.top + borders[1];
     }
 
     if (scrollboxWindow.IsWindow())


### PR DESCRIPTION
## Purpose
There was an exception in starting up of `mspaint` of Visual Studio 2019 build.
JIRA issue: [CORE-18594](https://jira.reactos.org/browse/CORE-18594), [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

![image](https://user-images.githubusercontent.com/2107452/223897744-38b2ed83-326a-4ab3-a278-7eba050e9d52.png)

## Proposed changes

- Fix `"Use of uninitialized variable statusBarRect0"` exception in `CMainWindow::alignChildrenToMainWindow`.

## TODO

- [x] Do tests.