### PR TITLE
[MSPAINT] Remember status bar visibility

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -239,9 +239,11 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
 
     /* creating the status bar */
     hStatusBar =
-        CreateWindowEx(0, STATUSCLASSNAME, NULL, SBARS_SIZEGRIP | WS_CHILD | WS_VISIBLE, 0, 0, 0, 0, hwnd,
+        CreateWindowEx(0, STATUSCLASSNAME, NULL, SBARS_SIZEGRIP | WS_CHILD, 0, 0, 0, 0, hwnd,
                        NULL, hThisInstance, NULL);
     SendMessage(hStatusBar, SB_SETMINHEIGHT, 21, 0);
+    if (registrySettings.ShowStatusBar)
+        ShowWindow(hStatusBar, SW_SHOWNOACTIVATE);
 
     RECT scrlClientWindowPos = {0, 0, 0 + 500, 0 + 500};
     scrlClientWindow.Create(scrollboxWindow.m_hWnd, scrlClientWindowPos, NULL, WS_CHILD | WS_VISIBLE);

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -74,6 +74,7 @@ void RegistrySettings::LoadPresets()
     FontsPositionX = 0;
     FontsPositionY = 0;
     ShowTextTool = TRUE;
+    ShowStatusBar = TRUE;
 
     LOGFONT lf;
     GetObject(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
@@ -100,6 +101,7 @@ void RegistrySettings::Load()
         ReadDWORD(view, _T("ThumbXPos"),     ThumbXPos,     TRUE);
         ReadDWORD(view, _T("ThumbYPos"),     ThumbYPos,     TRUE);
         ReadDWORD(view, _T("UnitSetting"),   UnitSetting,   FALSE);
+        ReadDWORD(view, _T("ShowStatusBar"), ShowStatusBar, FALSE);
 
         ULONG pnBytes = sizeof(WINDOWPLACEMENT);
         view.QueryBinaryValue(_T("WindowPlacement"), &WindowPlacement, &pnBytes);
@@ -152,6 +154,7 @@ void RegistrySettings::Store()
         view.SetDWORDValue(_T("ThumbXPos"),     ThumbXPos);
         view.SetDWORDValue(_T("ThumbYPos"),     ThumbYPos);
         view.SetDWORDValue(_T("UnitSetting"),   UnitSetting);
+        view.SetDWORDValue(_T("ShowStatusBar"), ShowStatusBar);
 
         view.SetBinaryValue(_T("WindowPlacement"), &WindowPlacement, sizeof(WINDOWPLACEMENT));
     }

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -101,7 +101,7 @@ void RegistrySettings::Load()
         ReadDWORD(view, _T("ThumbXPos"),     ThumbXPos,     TRUE);
         ReadDWORD(view, _T("ThumbYPos"),     ThumbYPos,     TRUE);
         ReadDWORD(view, _T("UnitSetting"),   UnitSetting,   FALSE);
-        ReadDWORD(view, _T("ShowStatusBar"), ShowStatusBar, FALSE);
+        ReadDWORD(view, _T("ShowStatusBar"), (DWORD&)ShowStatusBar, FALSE);
 
         ULONG pnBytes = sizeof(WINDOWPLACEMENT);
         view.QueryBinaryValue(_T("WindowPlacement"), &WindowPlacement, &pnBytes);
@@ -126,7 +126,7 @@ void RegistrySettings::Load()
         ReadDWORD(text, _T("PointSize"),    PointSize,      FALSE);
         ReadDWORD(text, _T("PositionX"),    FontsPositionX, FALSE);
         ReadDWORD(text, _T("PositionY"),    FontsPositionY, FALSE);
-        ReadDWORD(text, _T("ShowTextTool"), ShowTextTool,   FALSE);
+        ReadDWORD(text, _T("ShowTextTool"), (DWORD&)ShowTextTool, FALSE);
         ReadString(text, _T("TypeFaceName"), strFontName, strFontName);
     }
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -101,7 +101,7 @@ void RegistrySettings::Load()
         ReadDWORD(view, _T("ThumbXPos"),     ThumbXPos,     TRUE);
         ReadDWORD(view, _T("ThumbYPos"),     ThumbYPos,     TRUE);
         ReadDWORD(view, _T("UnitSetting"),   UnitSetting,   FALSE);
-        ReadDWORD(view, _T("ShowStatusBar"), (DWORD&)ShowStatusBar, FALSE);
+        ReadDWORD(view, _T("ShowStatusBar"), ShowStatusBar, FALSE);
 
         ULONG pnBytes = sizeof(WINDOWPLACEMENT);
         view.QueryBinaryValue(_T("WindowPlacement"), &WindowPlacement, &pnBytes);
@@ -126,7 +126,7 @@ void RegistrySettings::Load()
         ReadDWORD(text, _T("PointSize"),    PointSize,      FALSE);
         ReadDWORD(text, _T("PositionX"),    FontsPositionX, FALSE);
         ReadDWORD(text, _T("PositionY"),    FontsPositionY, FALSE);
-        ReadDWORD(text, _T("ShowTextTool"), (DWORD&)ShowTextTool, FALSE);
+        ReadDWORD(text, _T("ShowTextTool"), ShowTextTool,   FALSE);
         ReadString(text, _T("TypeFaceName"), strFontName, strFontName);
     }
 

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -41,6 +41,7 @@ public:
     DWORD FontsPositionX;
     DWORD FontsPositionY;
     DWORD ShowTextTool;
+    DWORD ShowStatusBar;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -40,8 +40,8 @@ public:
     DWORD CharSet;
     DWORD FontsPositionX;
     DWORD FontsPositionY;
-    DWORD ShowTextTool;
-    DWORD ShowStatusBar;
+    BOOL ShowTextTool;
+    BOOL ShowStatusBar;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -40,8 +40,8 @@ public:
     DWORD CharSet;
     DWORD FontsPositionX;
     DWORD FontsPositionY;
-    BOOL ShowTextTool;
-    BOOL ShowStatusBar;
+    DWORD ShowTextTool;
+    DWORD ShowStatusBar;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -729,8 +729,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWSTATUSBAR:
-            ::ShowWindow(hStatusBar, ::IsWindowVisible(hStatusBar) ? SW_HIDE : SW_SHOW);
-            registrySettings.ShowStatusBar = ::IsWindowVisible(hStatusBar);
+            registrySettings.ShowStatusBar = !::IsWindowVisible(hStatusBar);
+            ::ShowWindow(hStatusBar, (registrySettings.ShowStatusBar ? SW_SHOWNOACTIVATE : SW_HIDE));
             alignChildrenToMainWindow();
             break;
         case IDM_FORMATICONBAR:

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -730,6 +730,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_VIEWSTATUSBAR:
             ::ShowWindow(hStatusBar, ::IsWindowVisible(hStatusBar) ? SW_HIDE : SW_SHOW);
+            registrySettings.ShowStatusBar = ::IsWindowVisible(hStatusBar);
             alignChildrenToMainWindow();
             break;
         case IDM_FORMATICONBAR:


### PR DESCRIPTION
## Purpose
Some users might want to keep the status bar hidden.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Add `ShowStatusBar` registry setting.
- Save `ShowStatusBar` status and restore the status on startup.

## TODO

- [x] Do tests.