### PR TITLE
[REGEDIT] Fix crashes in regedit-find affecting CORE-15986 and CORE-18230

### DIFF
--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -223,13 +223,18 @@ BOOL RegFindRecurse(
                                   NULL, &cb);
         if (lResult != ERROR_SUCCESS)
             goto err;
-        pb = malloc(cb);
+        pb = malloc(cb + 3); /* To avoid buffer overrun, append 3 NULs */
         if (pb == NULL)
             goto err;
         lResult = RegQueryValueExW(hSubKey, ppszNames[i], NULL, &type,
                                   pb, &cb);
         if (lResult != ERROR_SUCCESS)
             goto err;
+
+        /* To avoid buffer overrun, append 3 NUL bytes.
+           NOTE: cb can be an odd number although UNICODE_NULL is two bytes.
+           Two bytes at odd position is not enough to avoid buffer overrun. */
+        pb[cb] = pb[cb + 1] = pb[cb + 2] = 0;
 
         if ((s_dwFlags & RSF_LOOKATDATA) &&
                 CompareData(type, (LPWSTR) pb, s_szFindWhat))


### PR DESCRIPTION
## Purpose

_Fix crashes in regedit-find._

JIRA issue: [CORE-15986](https://jira.reactos.org/browse/CORE-15986)
JIRA issue: [CORE-18230](https://jira.reactos.org/browse/CORE-18230)

## Proposed changes

_After possible RegQueryValueExW append 3 zero bytes to guarantee that we will end with a UNICODE NULL._