### PR TITLE
[MSPAINT] There were two "main" windows

### DIFF
--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -9,7 +9,7 @@
 
 #pragma once
 
-class CToolBox : public CWindowImpl<CMainWindow>
+class CToolBox : public CWindowImpl<CToolBox>
 {
 public:
     DECLARE_WND_CLASS_EX(_T("ToolBox"), CS_DBLCLKS, COLOR_BTNFACE)


### PR DESCRIPTION
## Purpose

There were two "main" windows in our `mspaint`.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Comparison

BEFORE:
![TwoMainWindow](https://user-images.githubusercontent.com/2107452/224260982-bd6673ca-b062-4721-8829-7d7c6ffb4471.png)
Our `mspaint` had two windows of window class `"MainWindow"`.

AFTER:
![after](https://user-images.githubusercontent.com/2107452/224260967-0247ff73-faae-4dfb-9b60-a1db010cdccf.png)
One has been fixed as window class `"ToolBox"`.

## Proposed changes

- class `CToolBox` should inherit `CWindowImpl<CToolBox>` instead of `CWindowImpl<CMainWindow>`.

## TODO

- [x] Do tests.