### PR TITLE
[INCLUDE][CMLIB][CABMAN][XML2SDB] Adapt C_ASSERT macro to C++

### DIFF
--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,7 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
+#define C_ASSERT(expr) typedef char __C_ASSERT__[(expr) ? 1 : -1]
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,7 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) EXTERN_C char (*c_assert(void)) [(expr) ? 1 : -1]
+#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,7 +788,11 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+#ifdef __cplusplus
+    #define C_ASSERT(expr) extern "C" char (*c_assert(void)) [(expr) ? 1 : -1]
+#else
+    #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+#endif
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/include/xdk/ntbasedef.h
+++ b/sdk/include/xdk/ntbasedef.h
@@ -788,11 +788,7 @@ $endif(_WINNT_)
 #endif /* _M_AMD64 */
 
 /* C_ASSERT Definition */
-#ifdef __cplusplus
-    #define C_ASSERT(expr) extern "C" char (*c_assert(void)) [(expr) ? 1 : -1]
-#else
-    #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
-#endif
+#define C_ASSERT(expr) EXTERN_C char (*c_assert(void)) [(expr) ? 1 : -1]
 
 /* Eliminate Microsoft C/C++ compiler warning 4715 */
 #if defined(_MSC_VER)

--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -28,7 +28,7 @@
     #define NTDDI_VERSION   NTDDI_WS03SP4 // This is the ReactOS NT kernel version
 
     /* C_ASSERT Definition */
-    #define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
+    #define C_ASSERT(expr) typedef char __C_ASSERT__[(expr) ? 1 : -1]
 
     #ifdef _WIN32
     #define strncasecmp _strnicmp

--- a/sdk/lib/cmlib/cmlib.h
+++ b/sdk/lib/cmlib/cmlib.h
@@ -28,7 +28,7 @@
     #define NTDDI_VERSION   NTDDI_WS03SP4 // This is the ReactOS NT kernel version
 
     /* C_ASSERT Definition */
-    #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+    #define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
 
     #ifdef _WIN32
     #define strncasecmp _strnicmp

--- a/sdk/tools/cabman/cabinet.h
+++ b/sdk/tools/cabman/cabinet.h
@@ -33,7 +33,7 @@
 #endif
 
 #if !defined(C_ASSERT)
-#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
+#define C_ASSERT(expr) typedef char __C_ASSERT__[(expr) ? 1 : -1]
 #endif
 
 #if defined(_WIN32)

--- a/sdk/tools/cabman/cabinet.h
+++ b/sdk/tools/cabman/cabinet.h
@@ -33,7 +33,7 @@
 #endif
 
 #if !defined(C_ASSERT)
-#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
 #endif
 
 #if defined(_WIN32)

--- a/sdk/tools/xml2sdb/xml2sdb.cpp
+++ b/sdk/tools/xml2sdb/xml2sdb.cpp
@@ -17,7 +17,7 @@ static const GUID GUID_NULL = { 0 };
 static const char szCompilerVersion[] = "1.7.0.1";
 
 #if !defined(C_ASSERT)
-#define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
+#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
 #endif
 
 

--- a/sdk/tools/xml2sdb/xml2sdb.cpp
+++ b/sdk/tools/xml2sdb/xml2sdb.cpp
@@ -17,7 +17,7 @@ static const GUID GUID_NULL = { 0 };
 static const char szCompilerVersion[] = "1.7.0.1";
 
 #if !defined(C_ASSERT)
-#define C_ASSERT(expr) int __C_ASSERT__(int c_assert[(expr) ? 1 : -1])
+#define C_ASSERT(expr) typedef char __C_ASSERT__[(expr) ? 1 : -1]
 #endif
 
 


### PR DESCRIPTION
## Purpose

The `C_ASSERT` macro in Win32 is known as the "compile-time assertion" macro. 
Using `C_ASSERT` macro in `mspaint` as below caused some linkage errors:

```txt
C_ASSERT(16 == TOOL_MAX);
```

```txt
sdk/include/psdk/winnt.h:807:38: error: conflicting declaration of 'char (* c_assert())[1]' with 'C' linkage
 #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
                                      ^~~~~~~~
../sdk/include/psdk/wincon.h:251:1: note: in expansion of macro 'C_ASSERT'
 C_ASSERT(FIELD_OFFSET(KEY_EVENT_RECORD, uChar) == 0xA);
 ^~~~~~~~
sdk/include/psdk/winnt.h:807:38: note: previous declaration with 'C++' linkage
 #define C_ASSERT(expr) extern char (*c_assert(void)) [(expr) ? 1 : -1]
                                      ^~~~~~~~
../base/applications/mspaint/toolsmodel.h:31:1: note: in expansion of macro 'C_ASSERT'
 C_ASSERT(16 == TOOL_MAX);
```

Make `C_ASSERT` macro fully available in C++.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Use an array type in a function declaration.

## TODO

- [x] Do tests.