### PR TITLE
[REGEDIT] Fix ListView selection and finding

### DIFF
--- a/base/applications/regedit/childwnd.c
+++ b/base/applications/regedit/childwnd.c
@@ -229,7 +229,7 @@ LRESULT CALLBACK AddressBarProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 }
 
 VOID
-UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
+UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath, BOOL bSelectNone)
 {
     LPCWSTR keyPath, rootName;
     LPWSTR fullPath;
@@ -251,7 +251,7 @@ UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath)
 
     if (keyPath)
     {
-        RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath);
+        RefreshListView(g_pChildWnd->hListWnd, hRootKey, keyPath, bSelectNone);
         rootName = get_root_key_name(hRootKey);
         cbFullPath = (wcslen(rootName) + 1 + wcslen(keyPath) + 1) * sizeof(WCHAR);
         fullPath = malloc(cbFullPath);

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -108,7 +108,7 @@ static BOOL MatchString(LPCWCH pch1, INT cch1, LPCWCH pch2, INT cch2)
     return FALSE;
 }
 
-static BOOL MatchData(DWORD dwType, LPCVOID pv1, size_t cb1)
+static BOOL MatchData(DWORD dwType, LPCVOID pv1, DWORD cb1)
 {
     if (dwType == REG_SZ || dwType == REG_EXPAND_SZ || dwType == REG_MULTI_SZ)
         return MatchString(pv1, (INT)(cb1 / sizeof(WCHAR)), s_szFindWhat, lstrlenW(s_szFindWhat));

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -88,9 +88,9 @@ static BOOL CompareName(LPCWSTR pszName1, LPCWSTR pszName2)
 }
 
 /* We don't assume that pch1 is UNICODE_NULL-terminated */
-static BOOL MatchString(LPCWCH pch1, size_t cch1, LPCWCH pch2, size_t cch2)
+static BOOL MatchString(LPCWCH pch1, INT cch1, LPCWCH pch2, INT cch2)
 {
-    size_t i;
+    INT i;
     DWORD dwNorm = ((s_dwFlags & RSF_MATCHCASE) ? NORM_IGNORECASE : 0);
 
     if (s_dwFlags & RSF_WHOLESTRING)
@@ -111,7 +111,7 @@ static BOOL MatchString(LPCWCH pch1, size_t cch1, LPCWCH pch2, size_t cch2)
 static BOOL MatchData(DWORD dwType, LPCVOID pv1, size_t cb1)
 {
     if (dwType == REG_SZ || dwType == REG_EXPAND_SZ || dwType == REG_MULTI_SZ)
-        return MatchString(pv1, cb1 / sizeof(WCHAR), s_szFindWhat, wcslen(s_szFindWhat));
+        return MatchString(pv1, (INT)(cb1 / sizeof(WCHAR)), s_szFindWhat, lstrlenW(s_szFindWhat));
 
     return FALSE;
 }

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -88,8 +88,7 @@ static BOOL CompareName(LPCWSTR pszName1, LPCWSTR pszName2)
 }
 
 /* We don't assume that pch1 is UNICODE_NULL-terminated */
-static BOOL
-MatchString(LPCWCH pch1, size_t cch1, LPCWCH pch2, size_t cch2)
+static BOOL MatchString(LPCWCH pch1, size_t cch1, LPCWCH pch2, size_t cch2)
 {
     size_t i;
     DWORD dwNorm = ((s_dwFlags & RSF_MATCHCASE) ? NORM_IGNORECASE : 0);
@@ -109,8 +108,7 @@ MatchString(LPCWCH pch1, size_t cch1, LPCWCH pch2, size_t cch2)
     return FALSE;
 }
 
-static BOOL
-MatchData(DWORD dwType, LPCVOID pv1, size_t cb1)
+static BOOL MatchData(DWORD dwType, LPCVOID pv1, size_t cb1)
 {
     if (dwType == REG_SZ || dwType == REG_EXPAND_SZ || dwType == REG_MULTI_SZ)
         return MatchString(pv1, cb1 / sizeof(WCHAR), s_szFindWhat, wcslen(s_szFindWhat));

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -160,7 +160,7 @@ BOOL RegFindRecurse(
         goto err;
     ZeroMemory(ppszNames, c * sizeof(LPWSTR));
 
-    /* Get the value names of the current key */
+    /* Retrieve the value names associated with the current key */
     for(i = 0; i < c; i++)
     {
         if (DoEvents())
@@ -184,10 +184,10 @@ BOOL RegFindRecurse(
 
     qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
-    /* If pszValueName is not specified, then search the values entirely in the key */
+    /* If pszValueName is NULL, the function will search for all values within the key */
     fPast = (pszValueName == NULL);
 
-    /* Search in the value entries */
+    /* Search within the values */
     for (i = 0; i < c; i++)
     {
         if (DoEvents())
@@ -239,7 +239,7 @@ BOOL RegFindRecurse(
     }
     ppszNames = NULL;
 
-    /* Get the count of the sub-keys */
+    /* Retrieve the number of sub-keys */
     lResult = RegQueryInfoKeyW(hSubKey, NULL, NULL, NULL, &c, NULL, NULL,
                               NULL, NULL, NULL, NULL, NULL);
     if (lResult != ERROR_SUCCESS)
@@ -249,7 +249,7 @@ BOOL RegFindRecurse(
         goto err;
     ZeroMemory(ppszNames, c * sizeof(LPWSTR));
 
-    /* Get the the sub-key names */
+    /* Retrieve the names of the sub-keys */
     for(i = 0; i < c; i++)
     {
         if (DoEvents())
@@ -273,7 +273,7 @@ BOOL RegFindRecurse(
 
     qsort(ppszNames, c, sizeof(LPWSTR), compare);
 
-    /* Search in the sub-keys */
+    /* Search within the sub-keys */
     for(i = 0; i < c; i++)
     {
         if (DoEvents())
@@ -299,7 +299,7 @@ BOOL RegFindRecurse(
             goto success;
         }
 
-        /* Search in the value entries of the sub-key */
+        /* Search within the value entries of the sub-key */
         if (RegFindRecurse(hSubKey, ppszNames[i], NULL, ppszFoundSubKey,
                            ppszFoundValueName))
         {

--- a/base/applications/regedit/find.c
+++ b/base/applications/regedit/find.c
@@ -87,7 +87,7 @@ static BOOL CompareName(LPCWSTR pszName1, LPCWSTR pszName2)
     }
 }
 
-/* We don't assume that pch1 is UNICODE_NULL-terminated */
+/* Do not assume that pch1 is terminated with UNICODE_NULL */
 static BOOL MatchString(LPCWCH pch1, INT cch1, LPCWCH pch2, INT cch2)
 {
     INT i;

--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -383,7 +383,7 @@ static BOOL LoadHive(HWND hWnd)
                 /* refresh tree and list views */
                 RefreshTreeView(g_pChildWnd->hTreeWnd);
                 pszKeyPath = GetItemPath(g_pChildWnd->hTreeWnd, 0, &hRootKey);
-                RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath);
+                RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath, TRUE);
             }
             else
             {
@@ -421,7 +421,7 @@ static BOOL UnloadHive(HWND hWnd)
         /* refresh tree and list views */
         RefreshTreeView(g_pChildWnd->hTreeWnd);
         pszKeyPath = GetItemPath(g_pChildWnd->hTreeWnd, 0, &hRootKey);
-        RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath);
+        RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath, TRUE);
     }
     else
     {
@@ -518,7 +518,7 @@ static BOOL ImportRegistryFile(HWND hWnd)
     /* refresh tree and list views */
     RefreshTreeView(g_pChildWnd->hTreeWnd);
     pszKeyPath = GetItemPath(g_pChildWnd->hTreeWnd, 0, &hKeyRoot);
-    RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, pszKeyPath);
+    RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, pszKeyPath, TRUE);
 
     return bRet;
 }
@@ -877,7 +877,7 @@ static BOOL CreateNewValue(HKEY hRootKey, LPCWSTR pszKeyPath, DWORD dwType)
         return FALSE;
     }
 
-    RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath);
+    RefreshListView(g_pChildWnd->hListWnd, hRootKey, pszKeyPath, TRUE);
 
     /* locate the newly added value, and get ready to rename it */
     memset(&lvfi, 0, sizeof(lvfi));
@@ -885,7 +885,12 @@ static BOOL CreateNewValue(HKEY hRootKey, LPCWSTR pszKeyPath, DWORD dwType)
     lvfi.psz = szNewValue;
     iIndex = ListView_FindItem(g_pChildWnd->hListWnd, -1, &lvfi);
     if (iIndex >= 0)
+    {
+        ListView_SetItemState(g_pChildWnd->hListWnd, iIndex,
+                              LVIS_SELECTED | LVIS_FOCUSED, LVIS_SELECTED | LVIS_FOCUSED);
+        ListView_EnsureVisible(g_pChildWnd->hListWnd, iIndex, FALSE);
         (void)ListView_EditLabel(g_pChildWnd->hListWnd, iIndex);
+    }
 
     return TRUE;
 }
@@ -1128,11 +1133,11 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     {
     case ID_EDIT_MODIFY:
         if (valueName && ModifyValue(hWnd, hKey, valueName, FALSE))
-            RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath);
+            RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, FALSE);
         break;
     case ID_EDIT_MODIFY_BIN:
         if (valueName && ModifyValue(hWnd, hKey, valueName, TRUE))
-            RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath);
+            RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, FALSE);
         break;
     case ID_EDIT_RENAME:
         if (GetFocus() == g_pChildWnd->hListWnd)
@@ -1180,7 +1185,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
                         item = ni;
                     }
 
-                    RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath);
+                    RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, FALSE);
                     if(errs > 0)
                     {
                         LoadStringW(hInst, IDS_ERR_DELVAL_CAPTION, caption, ARRAY_SIZE(caption));
@@ -1243,7 +1248,7 @@ static BOOL _CmdWndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     case ID_VIEW_REFRESH:
         RefreshTreeView(g_pChildWnd->hTreeWnd);
         keyPath = GetItemPath(g_pChildWnd->hTreeWnd, 0, &hKeyRoot);
-        RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath);
+        RefreshListView(g_pChildWnd->hListWnd, hKeyRoot, keyPath, TRUE);
         break;
         /*case ID_OPTIONS_TOOLBAR:*/
         /*	toggle_child(hWnd, LOWORD(wParam), hToolBar);*/

--- a/base/applications/regedit/listview.c
+++ b/base/applications/regedit/listview.c
@@ -91,7 +91,7 @@ VOID SetValueName(HWND hwndLV, LPCWSTR pszValueName)
     {
         ListView_SetItemState(hwndLV, i, 0, LVIS_FOCUSED | LVIS_SELECTED);
     }
-    if (pszValueName == NULL)
+    if (pszValueName == NULL || pszValueName[0] == 0)
         i = 0;
     else
     {
@@ -101,6 +101,7 @@ VOID SetValueName(HWND hwndLV, LPCWSTR pszValueName)
     }
     ListView_SetItemState(hwndLV, i, LVIS_FOCUSED | LVIS_SELECTED,
                           LVIS_FOCUSED | LVIS_SELECTED);
+    ListView_EnsureVisible(hwndLV, i, FALSE);
     iListViewSelect = i;
 }
 
@@ -668,7 +669,7 @@ void DestroyListView(HWND hwndLV)
 
 }
 
-BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath)
+BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath, BOOL bSelectNone)
 {
     DWORD max_sub_key_len;
     DWORD max_val_name_len;
@@ -738,6 +739,9 @@ BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath)
     {
         ListView_SetItemState(hwndLV, i, 0, LVIS_FOCUSED | LVIS_SELECTED);
     }
+
+    if (bSelectNone)
+        iListViewSelect = -1;
     ListView_SetItemState(hwndLV, iListViewSelect,
                           LVIS_FOCUSED | LVIS_SELECTED,
                           LVIS_FOCUSED | LVIS_SELECTED);

--- a/base/applications/regedit/main.h
+++ b/base/applications/regedit/main.h
@@ -97,7 +97,7 @@ void ShowAboutBox(HWND hWnd);
 LRESULT CALLBACK ChildWndProc(HWND, UINT, WPARAM, LPARAM);
 void ResizeWnd(int cx, int cy);
 LPCWSTR get_root_key_name(HKEY hRootKey);
-VOID UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath);
+VOID UpdateAddress(HTREEITEM hItem, HKEY hRootKey, LPCWSTR pszPath, BOOL bSelectNone);
 
 /* edit.c */
 BOOL ModifyValue(HWND hwnd, HKEY hKey, LPCWSTR valueName, BOOL EditBin);
@@ -125,7 +125,7 @@ BOOL ExportRegistryFile(HWND hWnd);
 
 /* listview.c */
 HWND CreateListView(HWND hwndParent, HMENU id, INT cx);
-BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath);
+BOOL RefreshListView(HWND hwndLV, HKEY hKey, LPCWSTR keyPath, BOOL bSelectNone);
 WCHAR *GetValueName(HWND hwndLV, int iStartAt);
 BOOL ListWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result);
 BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result);

--- a/base/applications/regedit/treeview.c
+++ b/base/applications/regedit/treeview.c
@@ -643,7 +643,7 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
             /* Get the parent of the current item */
             HTREEITEM hParentItem = TreeView_GetParent(g_pChildWnd->hTreeWnd, pnmtv->itemNew.hItem);
 
-            UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL);
+            UpdateAddress(pnmtv->itemNew.hItem, NULL, NULL, TRUE);
 
             /* Disable the Permissions menu item for 'My Computer' */
             EnableMenuItem(hMenuFrame, ID_EDIT_PERMISSIONS, MF_BYCOMMAND | (hParentItem ? MF_ENABLED : MF_GRAYED));
@@ -722,7 +722,7 @@ BOOL TreeWndNotifyProc(HWND hWnd, WPARAM wParam, LPARAM lParam, BOOL *Result)
                         lResult = FALSE;
                     }
                     else
-                        UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer);
+                        UpdateAddress(ptvdi->item.hItem, hRootKey, szBuffer, FALSE);
                 }
                 *Result = lResult;
             }


### PR DESCRIPTION
## Purpose

Follow up to #5146.

- Fix ListView Selection.
- Search a value correctly.

The `wcslen` call against non-`UNICODE_NULL`-terminated data had caused buffer overrun. We will check the data size correctly, instead of 3 `NUL` byte appending hack.

JIRA issue: [CORE-15986](https://jira.reactos.org/browse/CORE-15986), [CORE-18230](https://jira.reactos.org/browse/CORE-18230)

## Proposed changes

- Add `bSelectNone` parameter to `UpdateAddress` and `RefreshListView` functions.
- If `bSelectNone` is `TRUE`, then select nothing of ListView.
- Fix item selection of ListView.
- Rename `CompareData` helper function as `MatchData` and improve it.
- Improve the search algorithm.
- If the item selection of ListView changed, scroll down to the item.

## Screenshots

`ReportAs`:
![after-ReportAs](https://user-images.githubusercontent.com/2107452/224478217-e8d3f5b8-86e4-426a-a50c-264fd2661b37.png)

`DisplayVersion`:
![after-DisplayVersion](https://user-images.githubusercontent.com/2107452/224478221-6bdbb88d-549b-469a-beb6-2f8810ddeee1.png)

## TODO

- [x] Do tests.