### PR TITLE
[NOTEPAD] Use _CrtSetDbgFlag to check memory leak

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -661,7 +661,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     DestroyAcceleratorTable(hAccel);
 
 #if defined(_MSC_VER) && !defined(NDEBUG)
-    // For detecting memory leak (MSVC only)
+    /* For detecting memory leak (MSVC only) */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -572,8 +572,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
 
-#if defined(_MSC_VER) && defined(_DEBUG)
-    /* Report any memory leaks at exit */
+#ifdef _DEBUG
+    /* Report any memory leaks on exit */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -27,7 +27,7 @@
 #include <shlobj.h>
 #include <strsafe.h>
 
-#if defined(_MSC_VER) && !defined(NDEBUG)
+#if defined(_MSC_VER) && defined(_DEBUG)
     #include <crtdbg.h> /* For _CrtSetDbgFlag (MSVC only) */
 #endif
 
@@ -660,8 +660,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
 
     DestroyAcceleratorTable(hAccel);
 
-#if defined(_MSC_VER) && !defined(NDEBUG)
-    /* For detecting memory leak (MSVC only) */
+#if defined(_MSC_VER) && defined(_DEBUG)
+    /* Report any memory leaks */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -557,7 +557,10 @@ static BOOL HandleCommandLine(LPTSTR cmdline)
     return TRUE;
 }
 
-static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
+/***********************************************************************
+ *           WinMain
+ */
+int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int show)
 {
     MSG msg;
     HACCEL hAccel;
@@ -579,6 +582,8 @@ static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
     default:
         break;
     }
+
+    UNREFERENCED_PARAMETER(prev);
 
     aFINDMSGSTRING = (ATOM)RegisterWindowMessage(FINDMSGSTRING);
 
@@ -632,6 +637,10 @@ static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
     if (!Globals.hMainWnd)
     {
         ShowLastError();
+#if defined(_MSC_VER) && defined(_DEBUG)
+        /* Report any memory leaks */
+        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
         return 1;
     }
 
@@ -639,7 +648,13 @@ static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
     UpdateWindow(Globals.hMainWnd);
 
     if (!HandleCommandLine(cmdline))
+    {
+#if defined(_MSC_VER) && defined(_DEBUG)
+        /* Report any memory leaks */
+        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
         return 0;
+    }
 
     hAccel = LoadAccelerators(hInstance, MAKEINTRESOURCE(ID_ACCEL));
 
@@ -655,22 +670,10 @@ static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
 
     DestroyAcceleratorTable(hAccel);
 
-    return (INT)msg.wParam;
-}
-
-/***********************************************************************
- *           WinMain
- */
-INT WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, INT show)
-{
-    INT ret = NOTEPAD_Main(hInstance, cmdline, show);
-
-    UNREFERENCED_PARAMETER(prev);
-
 #if defined(_MSC_VER) && defined(_DEBUG)
     /* Report any memory leaks */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
-    return ret;
+    return (int)msg.wParam;
 }

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -573,7 +573,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     static const TCHAR winName[] = _T("Notepad");
 
 #if defined(_MSC_VER) && defined(_DEBUG)
-    /* Report any memory leaks */
+    /* Report any memory leaks at exit */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -557,10 +557,7 @@ static BOOL HandleCommandLine(LPTSTR cmdline)
     return TRUE;
 }
 
-/***********************************************************************
- *           WinMain
- */
-int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int show)
+static INT NOTEPAD_Main(HINSTANCE hInstance, LPTSTR cmdline, INT show)
 {
     MSG msg;
     HACCEL hAccel;
@@ -582,8 +579,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     default:
         break;
     }
-
-    UNREFERENCED_PARAMETER(prev);
 
     aFINDMSGSTRING = (ATOM)RegisterWindowMessage(FINDMSGSTRING);
 
@@ -660,10 +655,22 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
 
     DestroyAcceleratorTable(hAccel);
 
+    return (INT)msg.wParam;
+}
+
+/***********************************************************************
+ *           WinMain
+ */
+INT WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, INT show)
+{
+    INT ret = NOTEPAD_Main(hInstance, cmdline, show);
+
+    UNREFERENCED_PARAMETER(prev);
+
 #if defined(_MSC_VER) && defined(_DEBUG)
     /* Report any memory leaks */
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
-    return (INT)msg.wParam;
+    return ret;
 }

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -675,5 +675,5 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
-    return (int)msg.wParam;
+    return (int) msg.wParam;
 }

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -27,8 +27,8 @@
 #include <shlobj.h>
 #include <strsafe.h>
 
-#if defined(_MSC_VER) && defined(_DEBUG)
-    #include <crtdbg.h> /* For _CrtSetDbgFlag (MSVC only) */
+#ifdef _DEBUG
+#include <crtdbg.h>
 #endif
 
 NOTEPAD_GLOBALS Globals;

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -569,9 +569,13 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     MONITORINFO info;
     INT x, y;
     RECT rcIntersect;
-
     static const TCHAR className[] = _T("Notepad");
     static const TCHAR winName[] = _T("Notepad");
+
+#if defined(_MSC_VER) && defined(_DEBUG)
+    /* Report any memory leaks */
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
 
     switch (GetUserDefaultUILanguage())
     {
@@ -637,10 +641,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     if (!Globals.hMainWnd)
     {
         ShowLastError();
-#if defined(_MSC_VER) && defined(_DEBUG)
-        /* Report any memory leaks */
-        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
         return 1;
     }
 
@@ -648,13 +648,7 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     UpdateWindow(Globals.hMainWnd);
 
     if (!HandleCommandLine(cmdline))
-    {
-#if defined(_MSC_VER) && defined(_DEBUG)
-        /* Report any memory leaks */
-        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
         return 0;
-    }
 
     hAccel = LoadAccelerators(hInstance, MAKEINTRESOURCE(ID_ACCEL));
 
@@ -669,11 +663,6 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
     }
 
     DestroyAcceleratorTable(hAccel);
-
-#if defined(_MSC_VER) && defined(_DEBUG)
-    /* Report any memory leaks */
-    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#endif
 
     return (int) msg.wParam;
 }

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -26,7 +26,8 @@
 
 #include <shlobj.h>
 #include <strsafe.h>
-#ifdef _MSC_VER
+
+#if defined(_MSC_VER) && !defined(NDEBUG)
     #include <crtdbg.h> /* For _CrtSetDbgFlag (MSVC only) */
 #endif
 

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -26,6 +26,9 @@
 
 #include <shlobj.h>
 #include <strsafe.h>
+#ifdef _MSC_VER
+    #include <crtdbg.h> /* For _CrtSetDbgFlag (MSVC only) */
+#endif
 
 NOTEPAD_GLOBALS Globals;
 static ATOM aFINDMSGSTRING;
@@ -656,5 +659,10 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE prev, LPTSTR cmdline, int sh
 
     DestroyAcceleratorTable(hAccel);
 
-    return (int) msg.wParam;
+#if defined(_MSC_VER) && !defined(NDEBUG)
+    // For detecting memory leak (MSVC only)
+    _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#endif
+
+    return (INT)msg.wParam;
 }


### PR DESCRIPTION
## Purpose
We can borrow the power of CRT debug.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

These changes are effective for debug version only.
- Insert `#include <crtdbg.h>` at `main.c`.
- Call `_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF)` at the prologue of `_tWinMain`.

## TODO

- [x] Do tests.

## See also

- `_CrtSetDbgFlag` function: https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/crtsetdbgflag?view=msvc-170