### PR TITLE
[NTOS:SE] Fill the access check rights array with zeros

### DIFF
--- a/ntoskrnl/se/accesschk.c
+++ b/ntoskrnl/se/accesschk.c
@@ -394,12 +394,15 @@ SepAccessCheck(
     BOOLEAN Defaulted;
     NTSTATUS Status;
     PACCESS_TOKEN Token = NULL;
-    ACCESS_CHECK_RIGHTS AccessCheckRights = {0};
+    ACCESS_CHECK_RIGHTS AccessCheckRights;
 
     PAGED_CODE();
 
     /* A security descriptor must be expected for access checks */
     ASSERT(SecurityDescriptor);
+
+    /* Fill the whole access rights array with zeros */
+    RtlZeroMemory(&AccessCheckRights, sizeof(ACCESS_CHECK_RIGHTS));
 
     /* Check for no access desired */
     if (!DesiredAccess)


### PR DESCRIPTION
GCC optimizes the code for the sake of performance purposes, by adding padding to structures so that the access of the member fields are memory aligned. However, this padding is not zero'd out which means we can leak critical kernel data into the stack to UM, which is the access check mask rights.

Probably MSVC doesn't zero out the padding either, if they ever add padding to begin with. Whatever that is, we have to zero out the padding ourselves by filling the access check rights array with zeros, as it fills the whole memory range that holds the array with zeros.

This bug was originally spotted by @learn-more, so kudos to him.
For more information -> https://research.nccgroup.com/2019/10/30/padding-the-struct-how-a-compiler-optimization-can-disclose-stack-memory/