### PR TITLE
[MSPAINT] Restore the main window saved show state

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -143,7 +143,7 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 /* entry point */
 
 int WINAPI
-_tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument, int nFunsterStil)
+_tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument, INT nShowCmd)
 {
     HWND hwnd;               /* This is the handle for our window */
     MSG messages;            /* Here messages to the application are saved */

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -194,7 +194,9 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     imageModel.Crop(registrySettings.BMPWidth, registrySettings.BMPHeight);
 
     /* create main window */
-    RECT mainWindowPos = {0, 0, 544, 375};	// FIXME: use equivalent of CW_USEDEFAULT for position
+    RECT mainWindowPos = { CW_USEDEFAULT, CW_USEDEFAULT };
+    mainWindowPos.right = mainWindowPos.left + 544;
+    mainWindowPos.bottom = mainWindowPos.top + 375;
     hwnd = mainWindow.Create(HWND_DESKTOP, mainWindowPos, strTitle, WS_OVERLAPPEDWINDOW);
 
     RECT fullscreenWindowPos = {0, 0, 100, 100};
@@ -337,10 +339,19 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     imageArea.SendMessage(WM_SIZE, 0, 0);
 
     /* by moving the window, the things in WM_SIZE are done */
-    mainWindow.SetWindowPlacement(&(registrySettings.WindowPlacement));
+    if (registrySettings.WindowPlacement.length)
+    {
+        RECT rc = registrySettings.WindowPlacement.rcNormalPosition;
+        mainWindow.MoveWindow(rc.left, rc.top,
+                              rc.right - rc.left, rc.bottom - rc.top,
+                              TRUE);
+    }
 
     /* Make the window visible on the screen */
-    ShowWindow(hwnd, registrySettings.WindowPlacement.showCmd);
+    if (registrySettings.WindowPlacement.showCmd == SW_MAXIMIZE)
+        ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+    else
+        ShowWindow(hwnd, SW_SHOWNORMAL);
 
     /* inform the system, that the main window accepts dropped files */
     DragAcceptFiles(hwnd, TRUE);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -340,7 +340,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     mainWindow.SetWindowPlacement(&(registrySettings.WindowPlacement));
 
     /* Make the window visible on the screen */
-    ShowWindow (hwnd, nFunsterStil);
+    ShowWindow(hwnd, registrySettings.WindowPlacement.showCmd);
 
     /* inform the system, that the main window accepts dropped files */
     DragAcceptFiles(hwnd, TRUE);

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -143,7 +143,7 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 /* entry point */
 
 int WINAPI
-_tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument, INT nShowCmd)
+_tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument, INT nCmdShow)
 {
     HWND hwnd;               /* This is the handle for our window */
     MSG messages;            /* Here messages to the application are saved */

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -189,14 +189,12 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     LoadString(hThisInstance, IDS_MINIATURETITLE, miniaturetitle, _countof(miniaturetitle));
 
     /* load settings from registry */
-    registrySettings.Load();
+    registrySettings.Load(nCmdShow);
     showMiniature = registrySettings.ShowThumbnail;
     imageModel.Crop(registrySettings.BMPWidth, registrySettings.BMPHeight);
 
     /* create main window */
-    RECT mainWindowPos = { CW_USEDEFAULT, CW_USEDEFAULT };
-    mainWindowPos.right = mainWindowPos.left + 544;
-    mainWindowPos.bottom = mainWindowPos.top + 375;
+    RECT mainWindowPos = registrySettings.WindowPlacement.rcNormalPosition;
     hwnd = mainWindow.Create(HWND_DESKTOP, mainWindowPos, strTitle, WS_OVERLAPPEDWINDOW);
 
     RECT fullscreenWindowPos = {0, 0, 100, 100};
@@ -338,20 +336,8 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     /* placing the size boxes around the image */
     imageArea.SendMessage(WM_SIZE, 0, 0);
 
-    /* by moving the window, the things in WM_SIZE are done */
-    if (registrySettings.WindowPlacement.length)
-    {
-        RECT rc = registrySettings.WindowPlacement.rcNormalPosition;
-        mainWindow.MoveWindow(rc.left, rc.top,
-                              rc.right - rc.left, rc.bottom - rc.top,
-                              TRUE);
-    }
-
     /* Make the window visible on the screen */
-    if (registrySettings.WindowPlacement.showCmd == SW_MAXIMIZE)
-        ShowWindow(hwnd, SW_SHOWMAXIMIZED);
-    else
-        ShowWindow(hwnd, SW_SHOWNORMAL);
+    ShowWindow(hwnd, registrySettings.WindowPlacement.showCmd);
 
     /* inform the system, that the main window accepts dropped files */
     DragAcceptFiles(hwnd, TRUE);

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -81,7 +81,6 @@ void RegistrySettings::LoadPresets()
     strFontName = lf.lfFaceName;
 
     ZeroMemory(&WindowPlacement, sizeof(WindowPlacement));
-    WindowPlacement.showCmd = SW_SHOWNORMAL;
 }
 
 void RegistrySettings::Load()

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -81,6 +81,7 @@ void RegistrySettings::LoadPresets()
     strFontName = lf.lfFaceName;
 
     ZeroMemory(&WindowPlacement, sizeof(WindowPlacement));
+    WindowPlacement.showCmd = SW_SHOWNORMAL;
 }
 
 void RegistrySettings::Load()

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -82,8 +82,7 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
 
     ZeroMemory(&WindowPlacement, sizeof(WindowPlacement));
     RECT& rc = WindowPlacement.rcNormalPosition;
-    rc.left = CW_USEDEFAULT;
-    rc.top = CW_USEDEFAULT;
+    rc.left = rc.top = CW_USEDEFAULT;
     rc.right = rc.left + 544;
     rc.bottom = rc.top + 375;
     WindowPlacement.showCmd = nCmdShow;

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -53,7 +53,7 @@ void RegistrySettings::SetWallpaper(LPCTSTR szFileName, RegistrySettings::Wallpa
     SystemParametersInfo(SPI_SETDESKWALLPAPER, 0, (PVOID) szFileName, SPIF_UPDATEINIFILE | SPIF_SENDCHANGE);
 }
 
-void RegistrySettings::LoadPresets()
+void RegistrySettings::LoadPresets(INT nCmdShow)
 {
     BMPHeight = GetSystemMetrics(SM_CYSCREEN) / 2;
     BMPWidth = GetSystemMetrics(SM_CXSCREEN) / 2;
@@ -81,11 +81,17 @@ void RegistrySettings::LoadPresets()
     strFontName = lf.lfFaceName;
 
     ZeroMemory(&WindowPlacement, sizeof(WindowPlacement));
+    RECT& rc = WindowPlacement.rcNormalPosition;
+    rc.left = CW_USEDEFAULT;
+    rc.top = CW_USEDEFAULT;
+    rc.right = rc.left + 544;
+    rc.bottom = rc.top + 375;
+    WindowPlacement.showCmd = nCmdShow;
 }
 
-void RegistrySettings::Load()
+void RegistrySettings::Load(INT nCmdShow)
 {
-    LoadPresets();
+    LoadPresets(nCmdShow);
 
     CRegKey view;
     if (view.Open(HKEY_CURRENT_USER, _T("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint\\View"), KEY_READ) == ERROR_SUCCESS)

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -11,7 +11,7 @@
 class RegistrySettings
 {
 private:
-    void LoadPresets();
+    void LoadPresets(INT nCmdShow);
 
 public:
     DWORD BMPHeight;
@@ -51,7 +51,7 @@ public:
 
     static void SetWallpaper(LPCTSTR szFileName, WallpaperStyle style);
 
-    void Load();
+    void Load(INT nCmdShow);
     void Store();
     void SetMostRecentFile(LPCTSTR szPathName);
 };

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -234,6 +234,7 @@ LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
 
 LRESULT CMainWindow::OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
+    registrySettings.WindowPlacement.length = sizeof(WINDOWPLACEMENT);
     GetWindowPlacement(&(registrySettings.WindowPlacement));
     PostQuitMessage(0); /* send a WM_QUIT to the message queue */
     return 0;


### PR DESCRIPTION
## Purpose
Our `mspaint` didn't remember the maximized status of the main window.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Initialize `RegistrySettings::WindowPlacement` correctly.
- Fix `mainWindowPos` values.
- Add `nCmdShow` parameter to `RegistrySettings::Load` and `RegistrySettings::LoadPresets`.
- Use `registrySettings.WindowPlacement.showCmd` for `ShowWindow` call.

## TODO

- [x] Do tests.
