### PR TITLE
[MSPAINT] Remove extra scrlClientWindow

### DIFF
--- a/base/applications/mspaint/globalvar.h
+++ b/base/applications/mspaint/globalvar.h
@@ -79,7 +79,6 @@ extern CToolBox toolBoxContainer;
 extern CToolSettingsWindow toolSettingsWindow;
 extern CPaletteWindow paletteWindow;
 extern CScrollboxWindow scrollboxWindow;
-extern CScrollboxWindow scrlClientWindow;
 extern CSelectionWindow selectionWindow;
 extern CImgAreaWindow imageArea;
 extern CSizeboxWindow sizeboxLeftTop;

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -98,7 +98,6 @@ LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
     sizeboxRightBottom.MoveWindow(
                GRIP_SIZE + Zoomed(imgXRes),
                GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
-    UpdateScrollbox();
     return 0;
 }
 

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -14,22 +14,6 @@
 
 /* FUNCTIONS ********************************************************/
 
-void
-updateCanvasAndScrollbars()
-{
-    selectionWindow.ShowWindow(SW_HIDE);
-
-    int zoomedWidth = Zoomed(imageModel.GetWidth());
-    int zoomedHeight = Zoomed(imageModel.GetHeight());
-    imageArea.MoveWindow(GRIP_SIZE, GRIP_SIZE, zoomedWidth, zoomedHeight, FALSE);
-
-    scrollboxWindow.Invalidate(TRUE);
-    imageArea.Invalidate(FALSE);
-
-    scrollboxWindow.SetScrollPos(SB_HORZ, 0, TRUE);
-    scrollboxWindow.SetScrollPos(SB_VERT, 0, TRUE);
-}
-
 void CImgAreaWindow::drawZoomFrame(int mouseX, int mouseY)
 {
     HDC hdc;
@@ -68,36 +52,9 @@ void CImgAreaWindow::drawZoomFrame(int mouseX, int mouseY)
 
 LRESULT CImgAreaWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (!IsWindow() || !sizeboxLeftTop.IsWindow())
+    if (!IsWindow())
         return 0;
-    int imgXRes = imageModel.GetWidth();
-    int imgYRes = imageModel.GetHeight();
-    sizeboxLeftTop.MoveWindow(
-               0,
-               0, GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxCenterTop.MoveWindow(
-               GRIP_SIZE + (Zoomed(imgXRes) - GRIP_SIZE) / 2,
-               0, GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxRightTop.MoveWindow(
-               GRIP_SIZE + Zoomed(imgXRes),
-               0, GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxLeftCenter.MoveWindow(
-               0,
-               GRIP_SIZE + (Zoomed(imgYRes) - GRIP_SIZE) / 2,
-               GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxRightCenter.MoveWindow(
-               GRIP_SIZE + Zoomed(imgXRes),
-               GRIP_SIZE + (Zoomed(imgYRes) - GRIP_SIZE) / 2,
-               GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxLeftBottom.MoveWindow(
-               0,
-               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxCenterBottom.MoveWindow(
-               GRIP_SIZE + (Zoomed(imgXRes) - GRIP_SIZE) / 2,
-               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
-    sizeboxRightBottom.MoveWindow(
-               GRIP_SIZE + Zoomed(imgXRes),
-               GRIP_SIZE + Zoomed(imgYRes), GRIP_SIZE, GRIP_SIZE, TRUE);
+    UpdateScrollbox(NULL);
     return 0;
 }
 
@@ -389,7 +346,7 @@ LRESULT CImgAreaWindow::OnMouseLeave(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
 
 LRESULT CImgAreaWindow::OnImageModelDimensionsChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    updateCanvasAndScrollbars();
+    UpdateScrollbox(NULL);
     return 0;
 }
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -249,13 +249,13 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowStatusBar)
         ShowWindow(hStatusBar, SW_SHOWNOACTIVATE);
 
-    /* create selection window (initially hidden) */
-    RECT selectionWindowPos = {350, 0, 350 + 100, 0 + 100};
-    selectionWindow.Create(scrollboxWindow.m_hWnd, selectionWindowPos, NULL, WS_CHILD | BS_OWNERDRAW);
-
     /* creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn */
     RECT imageAreaPos = {GRIP_SIZE, GRIP_SIZE, GRIP_SIZE + imageModel.GetWidth(), GRIP_SIZE + imageModel.GetHeight()};
     imageArea.Create(scrollboxWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
+
+    /* create selection window (initially hidden) */
+    RECT selectionWindowPos = {350, 0, 350 + 100, 0 + 100};
+    selectionWindow.Create(imageArea.m_hWnd, selectionWindowPos, NULL, WS_CHILD | BS_OWNERDRAW);
 
     if (__argc >= 2)
     {

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -249,7 +249,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowStatusBar)
         ShowWindow(hStatusBar, SW_SHOWNOACTIVATE);
 
-    /* creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn */
+    // Creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn
     RECT imageAreaPos = {GRIP_SIZE, GRIP_SIZE, GRIP_SIZE + imageModel.GetWidth(), GRIP_SIZE + imageModel.GetHeight()};
     imageArea.Create(scrollboxWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -249,7 +249,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowStatusBar)
         ShowWindow(hStatusBar, SW_SHOWNOACTIVATE);
 
-    // Creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn
+    // Creating the window inside the scroll box
     RECT imageAreaPos = {GRIP_SIZE, GRIP_SIZE, GRIP_SIZE + imageModel.GetWidth(), GRIP_SIZE + imageModel.GetHeight()};
     imageArea.Create(scrollboxWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -67,7 +67,6 @@ CToolBox toolBoxContainer;
 CToolSettingsWindow toolSettingsWindow;
 CPaletteWindow paletteWindow;
 CScrollboxWindow scrollboxWindow;
-CScrollboxWindow scrlClientWindow;
 CSelectionWindow selectionWindow;
 CImgAreaWindow imageArea;
 CSizeboxWindow sizeboxLeftTop;
@@ -238,7 +237,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     paletteWindow.Create(hwnd, paletteWindowPos, NULL, WS_CHILD | WS_VISIBLE);
 
     /* creating the scroll box */
-    RECT scrollboxWindowPos = {56, 49, 56 + 472, 49 + 248};
+    RECT scrollboxWindowPos = {0, 0, 0 + 500, 0 + 500};
     scrollboxWindow.Create(hwnd, scrollboxWindowPos, NULL,
                            WS_CHILD | WS_GROUP | WS_HSCROLL | WS_VSCROLL | WS_VISIBLE, WS_EX_CLIENTEDGE);
 
@@ -250,16 +249,13 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowStatusBar)
         ShowWindow(hStatusBar, SW_SHOWNOACTIVATE);
 
-    RECT scrlClientWindowPos = {0, 0, 0 + 500, 0 + 500};
-    scrlClientWindow.Create(scrollboxWindow.m_hWnd, scrlClientWindowPos, NULL, WS_CHILD | WS_VISIBLE);
-
     /* create selection window (initially hidden) */
     RECT selectionWindowPos = {350, 0, 350 + 100, 0 + 100};
-    selectionWindow.Create(scrlClientWindow.m_hWnd, selectionWindowPos, NULL, WS_CHILD | BS_OWNERDRAW);
+    selectionWindow.Create(scrollboxWindow.m_hWnd, selectionWindowPos, NULL, WS_CHILD | BS_OWNERDRAW);
 
     /* creating the window inside the scroll box, on which the image in hDrawingDC's bitmap is drawn */
     RECT imageAreaPos = {GRIP_SIZE, GRIP_SIZE, GRIP_SIZE + imageModel.GetWidth(), GRIP_SIZE + imageModel.GetHeight()};
-    imageArea.Create(scrlClientWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
+    imageArea.Create(scrollboxWindow.m_hWnd, imageAreaPos, NULL, WS_CHILD | WS_VISIBLE);
 
     if (__argc >= 2)
     {
@@ -325,14 +321,14 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
 
     /* creating the size boxes */
     RECT sizeboxPos = {0, 0, GRIP_SIZE, GRIP_SIZE};
-    sizeboxLeftTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxCenterTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxRightTop.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxLeftCenter.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxRightCenter.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxLeftBottom.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxCenterBottom.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
-    sizeboxRightBottom.Create(scrlClientWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxLeftTop.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxCenterTop.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxRightTop.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxLeftCenter.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxRightCenter.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxLeftBottom.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxCenterBottom.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
+    sizeboxRightBottom.Create(scrollboxWindow.m_hWnd, sizeboxPos, NULL, WS_CHILD | WS_VISIBLE);
     /* placing the size boxes around the image */
     imageArea.SendMessage(WM_SIZE, 0, 0);
 

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -11,77 +11,40 @@
 #include "precomp.h"
 #include <atltypes.h>
 
-/*
- * Scrollbar functional modes:
- * 0  view < canvas
- * 1  view < canvas + scroll width
- * 2  view >= canvas + scroll width
- *
- * Matrix of scrollbar presence (VERTICAL,HORIZONTAL) given by
- * vertical & horizontal scrollbar modes (view:canvas ratio):
- *
- *           horizontal mode
- *             |      0      |      1      |      2
- * vertical ---+-------------+-------------+------------
- *   mode    0 |  TRUE,TRUE  |  TRUE,TRUE  |  TRUE,FALSE
- *          ---+-------------+-------------+------------
- *           1 |  TRUE,TRUE  | FALSE,FALSE | FALSE,FALSE
- *          ---+-------------+-------------+------------
- *           2 | FALSE,TRUE  | FALSE,FALSE | FALSE,FALSE
- */
-
-struct ScrollbarPresence
-{
-    BOOL bVert;
-    BOOL bHoriz;
-};
-
-CONST ScrollbarPresence sp_mx[3][3] =
-{
-    { {  TRUE,TRUE  }, {  TRUE,TRUE  }, {  TRUE,FALSE } },
-    { {  TRUE,TRUE  }, { FALSE,FALSE }, { FALSE,FALSE } },
-    { { FALSE,TRUE  }, { FALSE,FALSE }, { FALSE,FALSE } }
-};
-
-CONST INT HSCROLL_WIDTH = ::GetSystemMetrics(SM_CYHSCROLL);
-CONST INT VSCROLL_WIDTH = ::GetSystemMetrics(SM_CXVSCROLL);
-
-
 /* FUNCTIONS ********************************************************/
 
 void
 UpdateScrollbox(HWND hwnd)
 {
     CRect tempRect;
-    CSize sizeImageArea;
-    CSize sizeScrollBox;
-    INT vmode, hmode;
+    CSize sizeImageArea, sizeScrollBox;
     SCROLLINFO si;
 
-    scrollboxWindow.GetWindowRect(&tempRect);
+    scrollboxWindow.GetClientRect(&tempRect);
     sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
 
     SIZE sizeZoomed = { Zoomed(imageModel.GetWidth()), Zoomed(imageModel.GetHeight()) };
+    SIZE sizeWhole = { sizeZoomed.cx + (GRIP_SIZE * 2), sizeZoomed.cy + (GRIP_SIZE * 2) };
 
     /* show/hide the scrollbars */
-    vmode = (sizeScrollBox.cy < sizeZoomed.cy ? 0 :
-                (sizeScrollBox.cy < sizeZoomed.cy + HSCROLL_WIDTH ? 1 : 2));
-    hmode = (sizeScrollBox.cx < sizeZoomed.cx ? 0 :
-                (sizeScrollBox.cx < sizeZoomed.cx + VSCROLL_WIDTH ? 1 : 2));
-    scrollboxWindow.ShowScrollBar(SB_VERT, sp_mx[vmode][hmode].bVert);
-    scrollboxWindow.ShowScrollBar(SB_HORZ, sp_mx[vmode][hmode].bHoriz);
+    scrollboxWindow.ShowScrollBar(SB_HORZ, sizeScrollBox.cx < sizeWhole.cx);
+    scrollboxWindow.ShowScrollBar(SB_VERT, sizeScrollBox.cy < sizeWhole.cy);
+
+    if (sizeScrollBox.cx < sizeWhole.cx || sizeScrollBox.cy < sizeWhole.cy)
+    {
+        scrollboxWindow.GetClientRect(&tempRect);
+        sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
+    }
 
     si.cbSize = sizeof(SCROLLINFO);
     si.fMask  = SIF_PAGE | SIF_RANGE;
     si.nMin   = 0;
 
-    si.nMax   = sizeZoomed.cx + (GRIP_SIZE * 2) +
-                (sp_mx[vmode][hmode].bVert ? HSCROLL_WIDTH : 0);
+    si.nMax   = sizeWhole.cx;
     si.nPage  = sizeScrollBox.cx;
     scrollboxWindow.SetScrollInfo(SB_HORZ, &si);
 
-    si.nMax   = sizeZoomed.cy + (GRIP_SIZE * 2) +
-                (sp_mx[vmode][hmode].bHoriz ? VSCROLL_WIDTH : 0);
+    si.nMax   = sizeWhole.cy;
     si.nPage  = sizeScrollBox.cy;
     scrollboxWindow.SetScrollInfo(SB_VERT, &si);
 

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -14,17 +14,14 @@
 /* FUNCTIONS ********************************************************/
 
 void
-UpdateScrollbox(HWND hwnd)
+UpdateScrollbox(HWND hwndFrom)
 {
     CRect tempRect;
-    CSize sizeImageArea, sizeScrollBox;
-    SCROLLINFO si;
-
     scrollboxWindow.GetClientRect(&tempRect);
-    sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
+    CSize sizeScrollBox(tempRect.Width(), tempRect.Height());
 
-    SIZE sizeZoomed = { Zoomed(imageModel.GetWidth()), Zoomed(imageModel.GetHeight()) };
-    SIZE sizeWhole = { sizeZoomed.cx + (GRIP_SIZE * 2), sizeZoomed.cy + (GRIP_SIZE * 2) };
+    CSize sizeZoomed = { Zoomed(imageModel.GetWidth()), Zoomed(imageModel.GetHeight()) };
+    CSize sizeWhole = { sizeZoomed.cx + (GRIP_SIZE * 2), sizeZoomed.cy + (GRIP_SIZE * 2) };
 
     /* show/hide the scrollbars */
     scrollboxWindow.ShowScrollBar(SB_HORZ, sizeScrollBox.cx < sizeWhole.cx);
@@ -36,8 +33,7 @@ UpdateScrollbox(HWND hwnd)
         sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
     }
 
-    si.cbSize = sizeof(SCROLLINFO);
-    si.fMask  = SIF_PAGE | SIF_RANGE;
+    SCROLLINFO si = { sizeof(si), SIF_PAGE | SIF_RANGE };
     si.nMin   = 0;
 
     si.nMax   = sizeWhole.cx;
@@ -77,11 +73,8 @@ UpdateScrollbox(HWND hwnd)
                                       GRIP_SIZE, GRIP_SIZE, TRUE);
     }
 
-    if (imageArea.IsWindow() && hwnd != imageArea.m_hWnd)
-    {
-        imageArea.MoveWindow(GRIP_SIZE + dx, GRIP_SIZE + dy,
-                             sizeZoomed.cx, sizeZoomed.cy, TRUE);
-    }
+    if (imageArea.IsWindow() && hwndFrom != imageArea.m_hWnd)
+        imageArea.MoveWindow(dx + GRIP_SIZE, dy + GRIP_SIZE, sizeZoomed.cx, sizeZoomed.cy, TRUE);
 }
 
 LRESULT CScrollboxWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/scrollbox.cpp
+++ b/base/applications/mspaint/scrollbox.cpp
@@ -61,10 +61,9 @@ UpdateScrollbox()
     scrollboxWindow.GetWindowRect(&tempRect);
     sizeScrollBox = CSize(tempRect.Width(), tempRect.Height());
 
-    if (imageArea.IsWindow())
-        imageArea.GetClientRect(&tempRect);
-    sizeImageArea = CSize(tempRect.Width(), tempRect.Height());
-    sizeImageArea += CSize(GRIP_SIZE * 2, GRIP_SIZE * 2);
+    INT imgXRes = imageModel.GetWidth();
+    INT imgYRes = imageModel.GetHeight();
+    sizeImageArea = { imgXRes, imgYRes };
 
     /* show/hide the scrollbars */
     vmode = (sizeScrollBox.cy < sizeImageArea.cy ? 0 :
@@ -88,17 +87,18 @@ UpdateScrollbox()
     si.nPage  = sizeScrollBox.cy;
     scrollboxWindow.SetScrollInfo(SB_VERT, &si);
 
-    if (scrlClientWindow.IsWindow())
+    if (imageArea.IsWindow())
     {
-        scrlClientWindow.MoveWindow(
-            -scrollboxWindow.GetScrollPos(SB_HORZ), -scrollboxWindow.GetScrollPos(SB_VERT),
+        imageArea.MoveWindow(
+            GRIP_SIZE - scrollboxWindow.GetScrollPos(SB_HORZ),
+            GRIP_SIZE - scrollboxWindow.GetScrollPos(SB_VERT),
             sizeImageArea.cx, sizeImageArea.cy, TRUE);
     }
 }
 
 LRESULT CScrollboxWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (m_hWnd && m_hWnd == scrollboxWindow.m_hWnd)
+    if (m_hWnd)
     {
         UpdateScrollbox();
     }
@@ -107,80 +107,70 @@ LRESULT CScrollboxWindow::OnSize(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& 
 
 LRESULT CScrollboxWindow::OnHScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (m_hWnd == scrollboxWindow.m_hWnd)
+    SCROLLINFO si;
+    si.cbSize = sizeof(SCROLLINFO);
+    si.fMask = SIF_ALL;
+    GetScrollInfo(SB_HORZ, &si);
+    switch (LOWORD(wParam))
     {
-        SCROLLINFO si;
-        si.cbSize = sizeof(SCROLLINFO);
-        si.fMask = SIF_ALL;
-        scrollboxWindow.GetScrollInfo(SB_HORZ, &si);
-        switch (LOWORD(wParam))
-        {
-            case SB_THUMBTRACK:
-            case SB_THUMBPOSITION:
-                si.nPos = HIWORD(wParam);
-                break;
-            case SB_LINELEFT:
-                si.nPos -= 5;
-                break;
-            case SB_LINERIGHT:
-                si.nPos += 5;
-                break;
-            case SB_PAGELEFT:
-                si.nPos -= si.nPage;
-                break;
-            case SB_PAGERIGHT:
-                si.nPos += si.nPage;
-                break;
-        }
-        scrollboxWindow.SetScrollInfo(SB_HORZ, &si);
-        scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
-                   -scrollboxWindow.GetScrollPos(SB_VERT),
-                   Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
-                   Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
+        case SB_THUMBTRACK:
+        case SB_THUMBPOSITION:
+            si.nPos = HIWORD(wParam);
+            break;
+        case SB_LINELEFT:
+            si.nPos -= 5;
+            break;
+        case SB_LINERIGHT:
+            si.nPos += 5;
+            break;
+        case SB_PAGELEFT:
+            si.nPos -= si.nPage;
+            break;
+        case SB_PAGERIGHT:
+            si.nPos += si.nPage;
+            break;
     }
+    SetScrollInfo(SB_HORZ, &si);
+    imageArea.MoveWindow(-GetScrollPos(SB_HORZ), -GetScrollPos(SB_VERT),
+                         Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
+                         Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
     return 0;
 }
 
 LRESULT CScrollboxWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    if (m_hWnd == scrollboxWindow.m_hWnd)
+    SCROLLINFO si;
+    si.cbSize = sizeof(SCROLLINFO);
+    si.fMask = SIF_ALL;
+    GetScrollInfo(SB_VERT, &si);
+    switch (LOWORD(wParam))
     {
-        SCROLLINFO si;
-        si.cbSize = sizeof(SCROLLINFO);
-        si.fMask = SIF_ALL;
-        scrollboxWindow.GetScrollInfo(SB_VERT, &si);
-        switch (LOWORD(wParam))
-        {
-            case SB_THUMBTRACK:
-            case SB_THUMBPOSITION:
-                si.nPos = HIWORD(wParam);
-                break;
-            case SB_LINEUP:
-                si.nPos -= 5;
-                break;
-            case SB_LINEDOWN:
-                si.nPos += 5;
-                break;
-            case SB_PAGEUP:
-                si.nPos -= si.nPage;
-                break;
-            case SB_PAGEDOWN:
-                si.nPos += si.nPage;
-                break;
-        }
-        scrollboxWindow.SetScrollInfo(SB_VERT, &si);
-        scrlClientWindow.MoveWindow(-scrollboxWindow.GetScrollPos(SB_HORZ),
-                   -scrollboxWindow.GetScrollPos(SB_VERT),
-                   Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
-                   Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
+        case SB_THUMBTRACK:
+        case SB_THUMBPOSITION:
+            si.nPos = HIWORD(wParam);
+            break;
+        case SB_LINEUP:
+            si.nPos -= 5;
+            break;
+        case SB_LINEDOWN:
+            si.nPos += 5;
+            break;
+        case SB_PAGEUP:
+            si.nPos -= si.nPage;
+            break;
+        case SB_PAGEDOWN:
+            si.nPos += si.nPage;
+            break;
     }
+    SetScrollInfo(SB_VERT, &si);
+    imageArea.MoveWindow(-GetScrollPos(SB_HORZ), -GetScrollPos(SB_VERT),
+                         Zoomed(imageModel.GetWidth()) + 2 * GRIP_SIZE,
+                         Zoomed(imageModel.GetHeight()) + 2 * GRIP_SIZE, TRUE);
     return 0;
 }
 
 LRESULT CScrollboxWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    selectionWindow.ShowWindow(SW_HIDE);
-
     switch (toolsModel.GetActiveTool())
     {
         case TOOL_BEZIER:

--- a/base/applications/mspaint/scrollbox.h
+++ b/base/applications/mspaint/scrollbox.h
@@ -28,4 +28,4 @@ public:
     LRESULT OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 };
 
-void UpdateScrollbox(HWND hwnd);
+void UpdateScrollbox(HWND hwndFrom);

--- a/base/applications/mspaint/scrollbox.h
+++ b/base/applications/mspaint/scrollbox.h
@@ -27,3 +27,5 @@ public:
     LRESULT OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 };
+
+void UpdateScrollbox(HWND hwnd);

--- a/base/applications/mspaint/scrollbox.h
+++ b/base/applications/mspaint/scrollbox.h
@@ -27,5 +27,3 @@ public:
     LRESULT OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnMouseWheel(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 };
-
-void UpdateScrollbox();

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -107,8 +107,6 @@ LRESULT CSelectionWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam,
     if (m_iAction != ACTION_MOVE)
         SetCursor(LoadCursor(NULL, m_lpszCursorLUT[m_iAction]));
     m_bMoving = TRUE;
-    scrlClientWindow.InvalidateRect(NULL, TRUE);
-    scrlClientWindow.SendMessage(WM_PAINT, 0, 0);
     imageArea.InvalidateRect(NULL, FALSE);
     imageArea.SendMessage(WM_PAINT, 0, 0);
     m_rgbBack = paletteModel.GetBgColor();


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

BEFORE:
![before-edit](https://user-images.githubusercontent.com/2107452/225167557-e1b443dc-bc22-4474-ab7e-8db452e336db.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/225167553-1eaa76c8-ed0d-41e4-b8d7-d63c6ebc3df3.png)

## Proposed changes

- Remove `scrlClientWindow` and simplify.

## TODO

- [x] Image area.
- [x] Selection box.
- [x] Scrolling.
- [x] Tools.
- [x] Zooming.