### PR TITLE
[MSPAINT] Save paletteWindow visibility

### DIFF
--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -219,7 +219,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     /* creating the palette child window */
     RECT paletteWindowPos = {56, 9, 56 + 255, 9 + 32};
     paletteWindow.Create(hwnd, paletteWindowPos, NULL, WS_CHILD, WS_EX_STATICEDGE);
-    if (registrySettings.ShowColorBox)
+    if (registrySettings.ShowPalette)
         paletteWindow.ShowWindow(SW_SHOWNOACTIVATE);
 
     // creating the canvas

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -218,7 +218,9 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
 
     /* creating the palette child window */
     RECT paletteWindowPos = {56, 9, 56 + 255, 9 + 32};
-    paletteWindow.Create(hwnd, paletteWindowPos, NULL, WS_CHILD | WS_VISIBLE, WS_EX_STATICEDGE);
+    paletteWindow.Create(hwnd, paletteWindowPos, NULL, WS_CHILD, WS_EX_STATICEDGE);
+    if (registrySettings.ShowColorBox)
+        paletteWindow.ShowWindow(SW_SHOWNOACTIVATE);
 
     // creating the canvas
     RECT canvasWindowPos = {0, 0, 0 + 500, 0 + 500};

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -72,7 +72,7 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
     FontsPositionY = 0;
     ShowTextTool = TRUE;
     ShowStatusBar = TRUE;
-    ShowColorBox = TRUE;
+    ShowPalette = TRUE;
 
     LOGFONT lf;
     GetObject(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
@@ -142,7 +142,7 @@ void RegistrySettings::Load(INT nCmdShow)
     CRegKey bar4;
     if (bar4.Open(paint, _T("General-Bar4"), KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar4, _T("Visible"), ShowColorBox);
+        ReadDWORD(bar4, _T("Visible"), ShowPalette);
     }
 
     // Fix the bitmap size if too large
@@ -205,7 +205,7 @@ void RegistrySettings::Store()
     CRegKey bar4;
     if (bar4.Create(paint, _T("General-Bar4")) == ERROR_SUCCESS)
     {
-        bar4.SetDWORDValue(_T("Visible"), ShowColorBox);
+        bar4.SetDWORDValue(_T("Visible"), ShowPalette);
     }
 }
 

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -41,6 +41,7 @@ public:
     DWORD FontsPositionY;
     DWORD ShowTextTool;
     DWORD ShowStatusBar;
+    DWORD ShowColorBox;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -41,7 +41,7 @@ public:
     DWORD FontsPositionY;
     DWORD ShowTextTool;
     DWORD ShowStatusBar;
-    DWORD ShowColorBox;
+    DWORD ShowPalette;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -753,8 +753,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWCOLORPALETTE:
-            registrySettings.ShowColorBox = !paletteWindow.IsWindowVisible();
-            paletteWindow.ShowWindow(registrySettings.ShowColorBox ? SW_SHOWNOACTIVATE : SW_HIDE);
+            registrySettings.ShowPalette = !paletteWindow.IsWindowVisible();
+            paletteWindow.ShowWindow(registrySettings.ShowPalette ? SW_SHOWNOACTIVATE : SW_HIDE);
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWSTATUSBAR:

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -753,7 +753,8 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWCOLORPALETTE:
-            paletteWindow.ShowWindow(::IsWindowVisible(paletteWindow) ? SW_HIDE : SW_SHOW);
+            registrySettings.ShowColorBox = !paletteWindow.IsWindowVisible();
+            paletteWindow.ShowWindow(registrySettings.ShowColorBox ? SW_SHOWNOACTIVATE : SW_HIDE);
             alignChildrenToMainWindow();
             break;
         case IDM_VIEWSTATUSBAR:


### PR DESCRIPTION
## Purpose

Allow the user to save the showing/hiding status of the palette window.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

According to my registry analysis, `HKCU\Software\Microsoft\Windows\CurrentVersion\Applets\Paint\General-Bar4:Visible` is the target value.

- Improve `ReadDWORD` helper function.
- Add `ShowPalette` registry setting.
- Save the visibility on exit, and load the visibility on startup.
- Simplify `RegistrySettings::Load` and `RegistrySettings::Store`.

## TODO

- [x] Do tests.
