### PR TITLE
[MSPAINT] Tool settings: Reduce magic numbers

### DIFF
--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -184,8 +184,11 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style)
             break;
         case 3:
             for(a = 0; a <= b; a++)
-                Rectangle(hdc, (x1 * (b - a) + x2 * a) / b - 4, (y1 * (b - a) + y2 * a) / b - 4,
-                          (x1 * (b - a) + x2 * a) / b + 4, (y1 * (b - a) + y2 * a) / b + 4);
+                Rectangle(hdc,
+                          (x1 * (b - a) + x2 * a) / b - 4,
+                          (y1 * (b - a) + y2 * a) / b - 4,
+                          (x1 * (b - a) + x2 * a) / b + 4,
+                          (y1 * (b - a) + y2 * a) / b + 4);
             break;
         case 4:
             for(a = 0; a <= b; a++)

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -174,8 +174,11 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style)
             break;
         case 1:
             for(a = 0; a <= b; a++)
-                Ellipse(hdc, (x1 * (b - a) + x2 * a) / b - 1, (y1 * (b - a) + y2 * a) / b - 1,
-                        (x1 * (b - a) + x2 * a) / b + 3, (y1 * (b - a) + y2 * a) / b + 3);
+                Ellipse(hdc,
+                        (x1 * (b - a) + x2 * a) / b - 2,
+                        (y1 * (b - a) + y2 * a) / b - 2,
+                        (x1 * (b - a) + x2 * a) / b + 2,
+                        (y1 * (b - a) + y2 * a) / b + 2);
             break;
         case 2:
             MoveToEx(hdc, x1, y1, NULL);

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -182,8 +182,8 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style)
             break;
         case 3:
             for(a = 0; a <= b; a++)
-                Rectangle(hdc, (x1 * (b - a) + x2 * a) / b - 3, (y1 * (b - a) + y2 * a) / b - 3,
-                          (x1 * (b - a) + x2 * a) / b + 5, (y1 * (b - a) + y2 * a) / b + 5);
+                Rectangle(hdc, (x1 * (b - a) + x2 * a) / b - 4, (y1 * (b - a) + y2 * a) / b - 4,
+                          (x1 * (b - a) + x2 * a) / b + 4, (y1 * (b - a) + y2 * a) / b + 4);
             break;
         case 4:
             for(a = 0; a <= b; a++)
@@ -202,10 +202,10 @@ Brush(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG style)
         case 10:
         case 11:
         {
-            POINT offsTop[] = {{4, -3}, {2, -2}, {0, 0},
-                               {-3, -3}, {-2, -2}, {-1, 0}};
-            POINT offsBtm[] = {{-3, 4}, {-2, 2}, {-1, 1},
-                               {4, 4}, {2, 2}, {0, 1}};
+            POINT offsTop[] = {{3, -3}, {2, -2}, {0, 0},
+                               {-4, -4}, {-2, -2}, {-1, 0}};
+            POINT offsBtm[] = {{-3, 3}, {-2, 2}, {-1, 1},
+                               {3, 3}, {2, 2}, {0, 1}};
             LONG idx = style - 6;
             POINT pts[4];
             pts[0].x = x1 + offsTop[idx].x;

--- a/base/applications/mspaint/drawing.cpp
+++ b/base/applications/mspaint/drawing.cpp
@@ -123,9 +123,11 @@ Erase(HDC hdc, LONG x1, LONG y1, LONG x2, LONG y2, COLORREF color, LONG radius)
     b = max(1, max(abs(x2 - x1), abs(y2 - y1)));
     oldPen = (HPEN) SelectObject(hdc, CreatePen(PS_SOLID, 1, color));
     for(a = 0; a <= b; a++)
-        Rectangle(hdc, (x1 * (b - a) + x2 * a) / b - radius + 1,
-                  (y1 * (b - a) + y2 * a) / b - radius + 1, (x1 * (b - a) + x2 * a) / b + radius + 1,
-                  (y1 * (b - a) + y2 * a) / b + radius + 1);
+        Rectangle(hdc,
+                  (x1 * (b - a) + x2 * a) / b - radius,
+                  (y1 * (b - a) + y2 * a) / b - radius,
+                  (x1 * (b - a) + x2 * a) / b + radius,
+                  (y1 * (b - a) + y2 * a) / b + radius);
     DeleteObject(SelectObject(hdc, oldBrush));
     DeleteObject(SelectObject(hdc, oldPen));
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -185,7 +185,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowToolBox)
         toolBoxContainer.ShowWindow(SW_SHOWNOACTIVATE);
     /* creating the tool settings child window */
-    RECT toolSettingsWindowPos = {5, 208, 5 + 42, 208 + 140};
+    RECT toolSettingsWindowPos = {3, CY_TOOLBAR + 3, CX_TOOLBAR - 3, 208 + 140};
     toolSettingsWindow.Create(toolBoxContainer.m_hWnd, toolSettingsWindowPos, NULL, WS_CHILD | WS_VISIBLE);
 
     /* creating the palette child window */

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -180,13 +180,8 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     SetMenu(hwnd, menu);
     haccel = LoadAccelerators(hThisInstance, MAKEINTRESOURCE(800));
 
-    RECT toolBoxContainerPos = {2, 2, 2 + 52, 2 + 350};
-    toolBoxContainer.Create(hwnd, toolBoxContainerPos, NULL, WS_CHILD);
-    if (registrySettings.ShowToolBox)
-        toolBoxContainer.ShowWindow(SW_SHOWNOACTIVATE);
-    /* creating the tool settings child window */
-    RECT toolSettingsWindowPos = {3, CY_TOOLBAR + 3, CX_TOOLBAR - 3, CY_TOOLBAR + 3 + 140};
-    toolSettingsWindow.Create(toolBoxContainer.m_hWnd, toolSettingsWindowPos, NULL, WS_CHILD | WS_VISIBLE);
+    /* Create ToolBox */
+    toolBoxContainer.DoCreate(hwnd);
 
     /* creating the palette child window */
     RECT paletteWindowPos = {56, 9, 56 + 255, 9 + 32};

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -185,7 +185,7 @@ _tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument
     if (registrySettings.ShowToolBox)
         toolBoxContainer.ShowWindow(SW_SHOWNOACTIVATE);
     /* creating the tool settings child window */
-    RECT toolSettingsWindowPos = {3, CY_TOOLBAR + 3, CX_TOOLBAR - 3, 208 + 140};
+    RECT toolSettingsWindowPos = {3, CY_TOOLBAR + 3, CX_TOOLBAR - 3, CY_TOOLBAR + 3 + 140};
     toolSettingsWindow.Create(toolBoxContainer.m_hWnd, toolSettingsWindowPos, NULL, WS_CHILD | WS_VISIBLE);
 
     /* creating the palette child window */

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -16,7 +16,8 @@
 BOOL CToolBox::DoCreate(HWND hwndParent)
 {
     RECT toolBoxContainerPos = { 0, 0, 0, 0 };
-    return !!Create(hwndParent, toolBoxContainerPos, NULL, WS_CHILD | WS_VISIBLE);
+    DWORD style = WS_CHILD | (registrySettings.ShowToolBox ? WS_VISIBLE : 0);
+    return !!Create(hwndParent, toolBoxContainerPos, NULL, style);
 }
 
 LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -13,12 +13,20 @@
 
 /* FUNCTIONS ********************************************************/
 
+BOOL CToolBox::DoCreate(HWND hwndParent)
+{
+    RECT toolBoxContainerPos = { 0, 0, 0, 0 };
+    return !!Create(hwndParent, toolBoxContainerPos, NULL, WS_CHILD | WS_VISIBLE);
+}
+
 LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     HIMAGELIST hImageList;
     HBITMAP tempBm;
     int i;
     TCHAR tooltips[NUM_TOOLS][30];
+
+    toolSettingsWindow.DoCreate(m_hWnd);
 
     /* NOTE: The horizontal line above the toolbar is hidden by CCS_NODIVIDER style. */
     RECT toolbarPos = {0, 0, CX_TOOLBAR, CY_TOOLBAR};

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -12,8 +12,8 @@
 #define TOOLBAR_ROWS        8
 #define TOOLBAR_COLUMNS     2
 #define CXY_TB_BUTTON       25
-#define CX_TOOLBAR          ((TOOLBAR_COLUMNS * CXY_TB_BUTTON) + 2)
-#define CY_TOOLBAR          ((TOOLBAR_ROWS * CXY_TB_BUTTON) + 2)
+#define CX_TOOLBAR          (TOOLBAR_COLUMNS * CXY_TB_BUTTON)
+#define CY_TOOLBAR          (TOOLBAR_ROWS * CXY_TB_BUTTON)
 
 class CToolBox : public CWindowImpl<CToolBox>
 {
@@ -27,6 +27,9 @@ public:
         MESSAGE_HANDLER(WM_TOOLSMODELTOOLCHANGED, OnToolsModelToolChanged)
     END_MSG_MAP()
 
+    BOOL DoCreate(HWND hwndParent);
+
+private:
     CWindow toolbar;
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -226,8 +226,8 @@ VOID CToolSettingsWindow::drawBox(HDC hdc, LPCRECT prc)
                 hOldBrush = ::SelectObject(hdc, ::GetSysColorBrush(COLOR_APPWORKSPACE));
             HGDIOBJ hOldPen = ::SelectObject(hdc, ::CreatePen(PS_SOLID, 1, rgbPen));
             ::Rectangle(hdc, rcItem.left, rcItem.top, rcItem.right, rcItem.bottom);
-            ::SelectObject(hdc, hOldBrush);
             ::DeleteObject(::SelectObject(hdc, hOldPen));
+            ::SelectObject(hdc, hOldBrush);
         }
         else
         {

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -33,7 +33,7 @@ getSplitRects(RECT *arc, INT cColumns, INT cRows, LPCRECT prc, LPPOINT ppt)
             rc.top = prc->top + (iRow * cy / cRows);
             rc.right = prc->left + ((iColumn + 1) * cx / cColumns);
             rc.bottom = prc->top + ((iRow + 1) * cy / cRows);
-            if (ppt && ::PtInRect(&rc, pt))
+            if (ppt && ::PtInRect(&rc, *ppt))
                 return i;
             ++i;
         }
@@ -144,7 +144,7 @@ VOID CToolSettingsWindow::drawLine(HDC hdc, LPCRECT prc)
     }
 }
 
-static VOID getAirBrushRects(RECT arc[4], LPCRECT prc)
+static INT getAirBrushRects(RECT arc[4], LPCRECT prc, LPPOINT ppt = NULL)
 {
     INT cx = (prc->right - prc->left), cy = (prc->bottom - prc->top);
 
@@ -155,6 +155,16 @@ static VOID getAirBrushRects(RECT arc[4], LPCRECT prc)
 
     arc[2].top = arc[3].top = prc->top + cy / 2;
     arc[2].right = arc[3].left = prc->left + cx * 2 / 8;
+
+    if (ppt)
+    {
+        for (INT i = 0; i < 4; ++i)
+        {
+            if (::PtInRect(&arc[i], *ppt))
+                return i;
+        }
+    }
+    return -1;
 }
 
 VOID CToolSettingsWindow::drawAirBrush(HDC hdc, LPCRECT prc)
@@ -335,28 +345,28 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
         case TOOL_FREESEL:
         case TOOL_RECTSEL:
         case TOOL_TEXT:
-            iItem = getTransRects(arc, &rect1);
+            iItem = getTransRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetBackgroundTransparent(iItem);
             break;
         case TOOL_RUBBER:
-            iItem = getRubberRects(arc, &rect1);
+            iItem = getRubberRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetRubberRadius(iItem + 2);
             break;
         case TOOL_BRUSH:
-            iItem = getBrushRects(arc, &rect1);
+            iItem = getBrushRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetBrushStyle(iItem);
             break;
         case TOOL_AIRBRUSH:
-            iItem = getAirBrushRects(arc, &rect1);
+            iItem = getAirBrushRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetAirBrushWidth(s_AirRadius[iItem]);
             break;
         case TOOL_LINE:
         case TOOL_BEZIER:
-            iItem = getLineRects(arc, &rect1);
+            iItem = getLineRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetLineWidth(iItem + 1);
             break;
@@ -364,13 +374,13 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
         case TOOL_SHAPE:
         case TOOL_ELLIPSE:
         case TOOL_RRECT:
-            iItem = getBoxRects(arc, &rect1);
+            iItem = getBoxRects(arc, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetShapeStyle(iItem);
 
-            iItem = getLineRects(arc, &rect2);
+            iItem = getLineRects(arc, &rect2, &pt);
             if (iItem != -1)
-                toolsModel.SetLineWidth(i + 1);
+                toolsModel.SetLineWidth(iItem + 1);
             break;
         case TOOL_FILL:
         case TOOL_COLOR:

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -124,7 +124,7 @@ VOID CToolSettingsWindow::drawLine(HDC hdc, LPCRECT prc)
     for (INT i = 0; i < 5; i++)
     {
         INT penWidth = i + 1;
-        RECT& rcLine = arc[i];
+        RECT rcLine = arc[i];
         ::InflateRect(&rcLine, -2, 0);
         rcLine.top = (rcLine.top + rcLine.bottom - penWidth) / 2;
         rcLine.bottom = rcLine.top + penWidth;

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -12,6 +12,11 @@
 
 #include "precomp.h"
 
+#define X_TOOLSETTINGS  0
+#define Y_TOOLSETTINGS  (CY_TOOLBAR + 3)
+#define CX_TOOLSETTINGS CX_TOOLBAR
+#define CY_TOOLSETTINGS 140
+
 #define CX_TRANS_ICON 40
 #define CY_TRANS_ICON 30
 #define MARGIN1 3

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -282,15 +282,24 @@ LRESULT CToolSettingsWindow::OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, 
     return 0;
 }
 
-LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+VOID CToolSettingsWindow::calculateTwoBoxes(RECT& rect1, RECT& rect2)
 {
     RECT rcClient;
     GetClientRect(&rcClient);
     ::InflateRect(&rcClient, -MARGIN1, -MARGIN1);
 
     INT yCenter = (rcClient.top + rcClient.bottom) / 2;
-    RECT rect1 = { rcClient.left, rcClient.top, rcClient.right, yCenter };
-    RECT rect2 = { rcClient.left, yCenter, rcClient.right, rcClient.bottom };
+    ::SetRect(&rect1, rcClient.left, rcClient.top, rcClient.right, yCenter);
+    ::SetRect(&rect2, rcClient.left, yCenter, rcClient.right, rcClient.bottom);
+
+    ::InflateRect(&rect1, -MARGIN2, -MARGIN2);
+    ::InflateRect(&rect2, -MARGIN2, -MARGIN2);
+}
+
+LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    RECT rect1, rect2;
+    calculateTwoBoxes(rect1, rect2);
 
     PAINTSTRUCT ps;
     HDC hdc = BeginPaint(&ps);
@@ -346,15 +355,9 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
 {
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
 
-    RECT rcClient, rects[12];
-    GetClientRect(&rcClient);
-    ::InflateRect(&rcClient, -MARGIN1, -MARGIN1);
-
-    INT yCenter = (rcClient.top + rcClient.bottom) / 2;
-    RECT rect1 = { rcClient.left, rcClient.top, rcClient.right, yCenter };
-    RECT rect2 = { rcClient.left, yCenter, rcClient.right, rcClient.bottom };
-    ::InflateRect(&rect1, -MARGIN2 * 2, -MARGIN2 * 2);
-    ::InflateRect(&rect2, -MARGIN2 * 2, -MARGIN2 * 2);
+    RECT rect1, rect2;
+    calculateTwoBoxes(rect1, rect2);
+    RECT rects[12];
 
     INT iItem;
     switch (toolsModel.GetActiveTool())

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -51,7 +51,8 @@ VOID CToolSettingsWindow::drawTrans(HDC hdc, LPCRECT prc)
     RECT rc[2];
     getTransRects(rc, prc);
 
-    ::FillRect(hdc, &rc[toolsModel.IsBackgroundTransparent()], ::GetSysColorBrush(COLOR_HIGHLIGHT));
+    HBRUSH hbrHigh = ::GetSysColorBrush(COLOR_HIGHLIGHT);
+    ::FillRect(hdc, &rc[toolsModel.IsBackgroundTransparent()], hbrHigh);
     ::DrawIconEx(hdc, rc[0].left, rc[0].top, m_hNontranspIcon,
                  CX_TRANS_ICON, CY_TRANS_ICON, 0, NULL, DI_NORMAL);
     ::DrawIconEx(hdc, rc[1].left, rc[1].top, m_hTranspIcon,
@@ -100,7 +101,8 @@ VOID CToolSettingsWindow::drawBrush(HDC hdc, LPCRECT prc)
     RECT rects[12];
     getBrushRects(rects, prc);
 
-    ::FillRect(hdc, &rects[toolsModel.GetBrushStyle()], ::GetSysColorBrush(COLOR_HIGHLIGHT));
+    HBRUSH hbrHigh = ::GetSysColorBrush(COLOR_HIGHLIGHT);
+    ::FillRect(hdc, &rects[toolsModel.GetBrushStyle()], hbrHigh);
 
     for (INT i = 0; i < 12; i++)
     {
@@ -212,17 +214,17 @@ VOID CToolSettingsWindow::drawBox(HDC hdc, LPCRECT prc)
 
         if (iItem <= 1)
         {
-            INT iPenColor;
+            COLORREF rgbPen;
             if (toolsModel.GetShapeStyle() == iItem)
-                iPenColor = COLOR_HIGHLIGHTTEXT;
+                rgbPen = ::GetSysColor(COLOR_HIGHLIGHTTEXT);
             else
-                iPenColor = COLOR_WINDOWTEXT;
+                rgbPen = ::GetSysColor(COLOR_WINDOWTEXT);
             HGDIOBJ hOldBrush;
             if (iItem == 0)
                 hOldBrush = ::SelectObject(hdc, ::GetStockObject(NULL_BRUSH));
             else
                 hOldBrush = ::SelectObject(hdc, ::GetSysColorBrush(COLOR_APPWORKSPACE));
-            HGDIOBJ hOldPen = ::SelectObject(hdc, ::CreatePen(PS_SOLID, 1, GetSysColor(iPenColor)));
+            HGDIOBJ hOldPen = ::SelectObject(hdc, ::CreatePen(PS_SOLID, 1, rgbPen));
             ::Rectangle(hdc, rcItem.left, rcItem.top, rcItem.right, rcItem.bottom);
             ::SelectObject(hdc, hOldBrush);
             ::DeleteObject(::SelectObject(hdc, hOldPen));

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -16,19 +16,19 @@
 #define CY_TRANS_ICON 30
 #define BOX_MARGIN 2
 
-static const INT s_AirRadius[4] = { 5, 8, 3, 12 };
+static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
 
 /* FUNCTIONS ********************************************************/
 
 static INT
-getSplitRects(RECT *arc, INT cColumns, INT cRows, LPCRECT prc, LPPOINT ppt)
+getSplitRects(RECT *rects, INT cColumns, INT cRows, LPCRECT prc, LPPOINT ppt)
 {
     INT cx = prc->right - prc->left, cy = prc->bottom - prc->top;
     for (INT i = 0, iRow = 0; iRow < cRows; ++iRow)
     {
         for (INT iColumn = 0; iColumn < cColumns; ++iColumn)
         {
-            RECT& rc = arc[i];
+            RECT& rc = rects[i];
             rc.left = prc->left + (iColumn * cx / cColumns);
             rc.top = prc->top + (iRow * cy / cRows);
             rc.right = prc->left + ((iColumn + 1) * cx / cColumns);
@@ -41,9 +41,9 @@ getSplitRects(RECT *arc, INT cColumns, INT cRows, LPCRECT prc, LPPOINT ppt)
     return -1;
 }
 
-static inline INT getTransRects(RECT arc[2], LPCRECT prc, LPPOINT ppt = NULL)
+static inline INT getTransRects(RECT rects[2], LPCRECT prc, LPPOINT ppt = NULL)
 {
-    return getSplitRects(arc, 1, 2, prc, ppt);
+    return getSplitRects(rects, 1, 2, prc, ppt);
 }
 
 VOID CToolSettingsWindow::drawTrans(HDC hdc, LPCRECT prc)
@@ -58,22 +58,22 @@ VOID CToolSettingsWindow::drawTrans(HDC hdc, LPCRECT prc)
                  CX_TRANS_ICON, CY_TRANS_ICON, 0, NULL, DI_NORMAL);
 }
 
-static inline INT getRubberRects(RECT arc[4], LPCRECT prc, LPPOINT ppt = NULL)
+static inline INT getRubberRects(RECT rects[4], LPCRECT prc, LPPOINT ppt = NULL)
 {
-    return getSplitRects(arc, 1, 4, prc, ppt);
+    return getSplitRects(rects, 1, 4, prc, ppt);
 }
 
 VOID CToolSettingsWindow::drawRubber(HDC hdc, LPCRECT prc)
 {
-    RECT arc[4], rcRubber;
-    getRubberRects(arc, prc);
+    RECT rects[4], rcRubber;
+    getRubberRects(rects, prc);
     INT xCenter = (prc->left + prc->right) / 2;
     for (INT i = 0; i < 4; i++)
     {
         INT iColor, radius = i + 2;
         if (toolsModel.GetRubberRadius() == radius)
         {
-            ::FillRect(hdc, &arc[i], ::GetSysColorBrush(COLOR_HIGHLIGHT));
+            ::FillRect(hdc, &rects[i], ::GetSysColorBrush(COLOR_HIGHLIGHT));
             iColor = COLOR_HIGHLIGHTTEXT;
         }
         else
@@ -81,7 +81,7 @@ VOID CToolSettingsWindow::drawRubber(HDC hdc, LPCRECT prc)
             iColor = COLOR_WINDOWTEXT;
         }
 
-        INT yCenter = (arc[i].top + arc[i].bottom) / 2;
+        INT yCenter = (rects[i].top + rects[i].bottom) / 2;
         rcRubber.left = xCenter - radius;
         rcRubber.top = yCenter - radius;
         rcRubber.right = rcRubber.left + radius * 2;
@@ -90,21 +90,21 @@ VOID CToolSettingsWindow::drawRubber(HDC hdc, LPCRECT prc)
     }
 }
 
-static inline INT getBrushRects(RECT arc[12], LPCRECT prc, LPPOINT ppt = NULL)
+static inline INT getBrushRects(RECT rects[12], LPCRECT prc, LPPOINT ppt = NULL)
 {
-    return getSplitRects(arc, 3, 4, prc, ppt);
+    return getSplitRects(rects, 3, 4, prc, ppt);
 }
 
 VOID CToolSettingsWindow::drawBrush(HDC hdc, LPCRECT prc)
 {
-    RECT arc[12];
-    getBrushRects(arc, prc);
+    RECT rects[12];
+    getBrushRects(rects, prc);
 
-    ::FillRect(hdc, &arc[toolsModel.GetBrushStyle()], ::GetSysColorBrush(COLOR_HIGHLIGHT));
+    ::FillRect(hdc, &rects[toolsModel.GetBrushStyle()], ::GetSysColorBrush(COLOR_HIGHLIGHT));
 
     for (INT i = 0; i < 12; i++)
     {
-        RECT rcItem = arc[i];
+        RECT rcItem = rects[i];
         INT x = (rcItem.left + rcItem.right) / 2, y = (rcItem.top + rcItem.bottom) / 2;
         INT iColor;
         if (i == toolsModel.GetBrushStyle())
@@ -115,26 +115,26 @@ VOID CToolSettingsWindow::drawBrush(HDC hdc, LPCRECT prc)
     }
 }
 
-static inline INT getLineRects(RECT arc[5], LPCRECT prc, LPPOINT ppt = NULL)
+static inline INT getLineRects(RECT rects[5], LPCRECT prc, LPPOINT ppt = NULL)
 {
-    return getSplitRects(arc, 1, 5, prc, ppt);
+    return getSplitRects(rects, 1, 5, prc, ppt);
 }
 
 VOID CToolSettingsWindow::drawLine(HDC hdc, LPCRECT prc)
 {
-    RECT arc[5];
-    getLineRects(arc, prc);
+    RECT rects[5];
+    getLineRects(rects, prc);
 
     for (INT i = 0; i < 5; i++)
     {
         INT penWidth = i + 1;
-        RECT rcLine = arc[i];
+        RECT rcLine = rects[i];
         ::InflateRect(&rcLine, -2, 0);
         rcLine.top = (rcLine.top + rcLine.bottom - penWidth) / 2;
         rcLine.bottom = rcLine.top + penWidth;
         if (toolsModel.GetLineWidth() == penWidth)
         {
-            ::FillRect(hdc, &arc[i], ::GetSysColorBrush(COLOR_HIGHLIGHT));
+            ::FillRect(hdc, &rects[i], ::GetSysColorBrush(COLOR_HIGHLIGHT));
             ::FillRect(hdc, &rcLine, ::GetSysColorBrush(COLOR_HIGHLIGHTTEXT));
         }
         else
@@ -144,23 +144,23 @@ VOID CToolSettingsWindow::drawLine(HDC hdc, LPCRECT prc)
     }
 }
 
-static INT getAirBrushRects(RECT arc[4], LPCRECT prc, LPPOINT ppt = NULL)
+static INT getAirBrushRects(RECT rects[4], LPCRECT prc, LPPOINT ppt = NULL)
 {
     INT cx = (prc->right - prc->left), cy = (prc->bottom - prc->top);
 
-    arc[0] = arc[1] = arc[2] = arc[3] = *prc;
+    rects[0] = rects[1] = rects[2] = rects[3] = *prc;
 
-    arc[0].right = arc[1].left = prc->left + cx * 3 / 8;
-    arc[0].bottom = arc[1].bottom = prc->top + cy / 2;
+    rects[0].right = rects[1].left = prc->left + cx * 3 / 8;
+    rects[0].bottom = rects[1].bottom = prc->top + cy / 2;
 
-    arc[2].top = arc[3].top = prc->top + cy / 2;
-    arc[2].right = arc[3].left = prc->left + cx * 2 / 8;
+    rects[2].top = rects[3].top = prc->top + cy / 2;
+    rects[2].right = rects[3].left = prc->left + cx * 2 / 8;
 
     if (ppt)
     {
         for (INT i = 0; i < 4; ++i)
         {
-            if (::PtInRect(&arc[i], *ppt))
+            if (::PtInRect(&rects[i], *ppt))
                 return i;
         }
     }
@@ -169,13 +169,13 @@ static INT getAirBrushRects(RECT arc[4], LPCRECT prc, LPPOINT ppt = NULL)
 
 VOID CToolSettingsWindow::drawAirBrush(HDC hdc, LPCRECT prc)
 {
-    RECT arc[4];
-    getAirBrushRects(arc, prc);
+    RECT rects[4];
+    getAirBrushRects(rects, prc);
 
     srand(0);
-    for (INT i = 0; i < 4; ++i)
+    for (size_t i = 0; i < 4; ++i)
     {
-        RECT& rc = arc[i];
+        RECT& rc = rects[i];
         INT x = (rc.left + rc.right) / 2;
         INT y = (rc.top + rc.bottom) / 2;
         BOOL bHigh = (s_AirRadius[i] == toolsModel.GetAirBrushWidth());
@@ -191,19 +191,19 @@ VOID CToolSettingsWindow::drawAirBrush(HDC hdc, LPCRECT prc)
     }
 }
 
-static inline INT getBoxRects(RECT arc[3], LPCRECT prc, LPPOINT ppt = NULL)
+static inline INT getBoxRects(RECT rects[3], LPCRECT prc, LPPOINT ppt = NULL)
 {
-    return getSplitRects(arc, 1, 3, prc, ppt);
+    return getSplitRects(rects, 1, 3, prc, ppt);
 }
 
 VOID CToolSettingsWindow::drawBox(HDC hdc, LPCRECT prc)
 {
-    RECT arc[3];
-    getBoxRects(arc, prc);
+    RECT rects[3];
+    getBoxRects(rects, prc);
 
     for (INT iItem = 0; iItem < 3; ++iItem)
     {
-        RECT& rcItem = arc[iItem];
+        RECT& rcItem = rects[iItem];
 
         if (toolsModel.GetShapeStyle() == iItem)
             ::FillRect(hdc, &rcItem, ::GetSysColorBrush(COLOR_HIGHLIGHT));
@@ -331,7 +331,7 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
 {
     POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
 
-    RECT rcClient, arc[12];
+    RECT rcClient, rects[12];
     GetClientRect(&rcClient);
 
     RECT rect1 = { 0, 0, rcClient.right, rcClient.bottom / 2 };
@@ -345,28 +345,28 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
         case TOOL_FREESEL:
         case TOOL_RECTSEL:
         case TOOL_TEXT:
-            iItem = getTransRects(arc, &rect1, &pt);
+            iItem = getTransRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetBackgroundTransparent(iItem);
             break;
         case TOOL_RUBBER:
-            iItem = getRubberRects(arc, &rect1, &pt);
+            iItem = getRubberRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetRubberRadius(iItem + 2);
             break;
         case TOOL_BRUSH:
-            iItem = getBrushRects(arc, &rect1, &pt);
+            iItem = getBrushRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetBrushStyle(iItem);
             break;
         case TOOL_AIRBRUSH:
-            iItem = getAirBrushRects(arc, &rect1, &pt);
+            iItem = getAirBrushRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetAirBrushWidth(s_AirRadius[iItem]);
             break;
         case TOOL_LINE:
         case TOOL_BEZIER:
-            iItem = getLineRects(arc, &rect1, &pt);
+            iItem = getLineRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetLineWidth(iItem + 1);
             break;
@@ -374,11 +374,11 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
         case TOOL_SHAPE:
         case TOOL_ELLIPSE:
         case TOOL_RRECT:
-            iItem = getBoxRects(arc, &rect1, &pt);
+            iItem = getBoxRects(rects, &rect1, &pt);
             if (iItem != -1)
                 toolsModel.SetShapeStyle(iItem);
 
-            iItem = getLineRects(arc, &rect2, &pt);
+            iItem = getLineRects(rects, &rect2, &pt);
             if (iItem != -1)
                 toolsModel.SetLineWidth(iItem + 1);
             break;

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -14,11 +14,23 @@
 
 #define CX_TRANS_ICON 40
 #define CY_TRANS_ICON 30
-#define BOX_MARGIN 2
+#define MARGIN1 3
+#define MARGIN2 2
 
 static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
 
 /* FUNCTIONS ********************************************************/
+
+BOOL CToolSettingsWindow::DoCreate(HWND hwndParent)
+{
+    /* creating the tool settings child window */
+    RECT toolSettingsWindowPos =
+    {
+        X_TOOLSETTINGS, Y_TOOLSETTINGS,
+        X_TOOLSETTINGS + CX_TOOLSETTINGS, Y_TOOLSETTINGS + CY_TOOLSETTINGS
+    };
+    return !!Create(toolBoxContainer, toolSettingsWindowPos, NULL, WS_CHILD | WS_VISIBLE);
+}
 
 static INT
 getSplitRects(RECT *rects, INT cColumns, INT cRows, LPCRECT prc, LPPOINT ppt)
@@ -274,10 +286,11 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
 {
     RECT rcClient;
     GetClientRect(&rcClient);
-    RECT rect1 = { 0, 0, rcClient.right, rcClient.bottom / 2 };
-    RECT rect2 = { 0, rcClient.bottom / 2, rcClient.right, rcClient.bottom };
-    ::InflateRect(&rect1, -BOX_MARGIN, -BOX_MARGIN);
-    ::InflateRect(&rect2, -BOX_MARGIN, -BOX_MARGIN);
+    ::InflateRect(&rcClient, -MARGIN1, -MARGIN1);
+
+    INT yCenter = (rcClient.top + rcClient.bottom) / 2;
+    RECT rect1 = { rcClient.left, rcClient.top, rcClient.right, yCenter };
+    RECT rect2 = { rcClient.left, yCenter, rcClient.right, rcClient.bottom };
 
     PAINTSTRUCT ps;
     HDC hdc = BeginPaint(&ps);
@@ -290,8 +303,8 @@ LRESULT CToolSettingsWindow::OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
     if (toolsModel.GetActiveTool() >= TOOL_RECT)
         ::DrawEdge(hdc, &rect2, BDR_SUNKENOUTER, BF_RECT | BF_MIDDLE);
 
-    ::InflateRect(&rect1, -BOX_MARGIN, -BOX_MARGIN);
-    ::InflateRect(&rect2, -BOX_MARGIN, -BOX_MARGIN);
+    ::InflateRect(&rect1, -MARGIN2, -MARGIN2);
+    ::InflateRect(&rect2, -MARGIN2, -MARGIN2);
     switch (toolsModel.GetActiveTool())
     {
         case TOOL_FREESEL:
@@ -335,11 +348,13 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
 
     RECT rcClient, rects[12];
     GetClientRect(&rcClient);
+    ::InflateRect(&rcClient, -MARGIN1, -MARGIN1);
 
-    RECT rect1 = { 0, 0, rcClient.right, rcClient.bottom / 2 };
-    RECT rect2 = { 0, rcClient.bottom / 2, rcClient.right, rcClient.bottom };
-    ::InflateRect(&rect1, -BOX_MARGIN * 2, -BOX_MARGIN * 2);
-    ::InflateRect(&rect2, -BOX_MARGIN * 2, -BOX_MARGIN * 2);
+    INT yCenter = (rcClient.top + rcClient.bottom) / 2;
+    RECT rect1 = { rcClient.left, rcClient.top, rcClient.right, yCenter };
+    RECT rect2 = { rcClient.left, yCenter, rcClient.right, rcClient.bottom };
+    ::InflateRect(&rect1, -MARGIN2 * 2, -MARGIN2 * 2);
+    ::InflateRect(&rect2, -MARGIN2 * 2, -MARGIN2 * 2);
 
     INT iItem;
     switch (toolsModel.GetActiveTool())

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -8,11 +8,6 @@
 
 #pragma once
 
-#define X_TOOLSETTINGS  0
-#define Y_TOOLSETTINGS  (CY_TOOLBAR + 3)
-#define CX_TOOLSETTINGS CX_TOOLBAR
-#define CY_TOOLSETTINGS 140
-
 class CToolSettingsWindow : public CWindowImpl<CToolSettingsWindow>
 {
 public:

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -24,9 +24,18 @@ public:
         MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
     END_MSG_MAP()
 
+private:
     CWindow trackbarZoom;
     HICON m_hNontranspIcon;
     HICON m_hTranspIcon;
+
+    VOID drawTrans(HDC hdc, LPCRECT prc);
+    VOID drawRubber(HDC hdc, LPCRECT prc);
+    VOID drawBrush(HDC hdc, LPCRECT prc);
+    VOID drawLine(HDC hdc, LPCRECT prc);
+    VOID drawBox(HDC hdc, LPCRECT prc);
+    VOID drawAirBrush(HDC hdc, LPCRECT prc);
+
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -42,6 +42,7 @@ private:
     VOID drawLine(HDC hdc, LPCRECT prc);
     VOID drawBox(HDC hdc, LPCRECT prc);
     VOID drawAirBrush(HDC hdc, LPCRECT prc);
+    VOID calculateTwoBoxes(RECT& rect1, RECT& rect2);
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -8,6 +8,11 @@
 
 #pragma once
 
+#define X_TOOLSETTINGS  0
+#define Y_TOOLSETTINGS  (CY_TOOLBAR + 3)
+#define CX_TOOLSETTINGS CX_TOOLBAR
+#define CY_TOOLSETTINGS 140
+
 class CToolSettingsWindow : public CWindowImpl<CToolSettingsWindow>
 {
 public:
@@ -23,6 +28,8 @@ public:
         MESSAGE_HANDLER(WM_TOOLSMODELZOOMCHANGED, OnToolsModelZoomChanged)
         MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
     END_MSG_MAP()
+
+    BOOL DoCreate(HWND hwndParent);
 
 private:
     CWindow trackbarZoom;

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -36,7 +36,6 @@ private:
     VOID drawBox(HDC hdc, LPCRECT prc);
     VOID drawAirBrush(HDC hdc, LPCRECT prc);
 
-
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnVScroll(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -426,7 +426,7 @@ LRESULT CMainWindow::OnGetMinMaxInfo(UINT nMsg, WPARAM wParam, LPARAM lParam, BO
 {
     MINMAXINFO *mm = (LPMINMAXINFO) lParam;
     mm->ptMinTrackSize.x = 330;
-    mm->ptMinTrackSize.y = 430;
+    mm->ptMinTrackSize.y = 360;
     return 0;
 }
 


### PR DESCRIPTION
## Purpose
Improve human readability and code flexibility.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

Many coordinates are dynamically calculated.
It is adjustable against client area change.

- Fix some brush/eraser shapes for pixel perfection.
- Reduce magic numbers in `toolssettings.cpp`.
- Refactoring.

## TODO

- [x] Do tests.

## Screenshots

![image](https://user-images.githubusercontent.com/2107452/226498115-1e3045e5-95bb-49cc-befd-476e023111dc.png)

![image](https://user-images.githubusercontent.com/2107452/226500817-e9756245-def3-4e22-80ef-e57f61717174.png)
