### PR TITLE
[NOTEPAD] Use _countof macro from <stdlib.h>

### DIFF
--- a/base/applications/notepad/dialog.c
+++ b/base/applications/notepad/dialog.c
@@ -50,7 +50,7 @@ VOID ShowLastError(VOID)
         LPTSTR lpMsgBuf = NULL;
         TCHAR szTitle[MAX_STRING_LEN];
 
-        LoadString(Globals.hInstance, STRING_ERROR, szTitle, ARRAY_SIZE(szTitle));
+        LoadString(Globals.hInstance, STRING_ERROR, szTitle, _countof(szTitle));
 
         FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM,
                       NULL,
@@ -96,13 +96,13 @@ void UpdateWindowCaption(BOOL clearModifyAlert)
     Globals.bWasModified = isModified;
 
     /* Load the name of the application */
-    LoadString(Globals.hInstance, STRING_NOTEPAD, szNotepad, ARRAY_SIZE(szNotepad));
+    LoadString(Globals.hInstance, STRING_NOTEPAD, szNotepad, _countof(szNotepad));
 
     /* Determine if the file has been saved or if this is a new file */
     if (Globals.szFileTitle[0] != 0)
-        StringCchCopy(szFilename, ARRAY_SIZE(szFilename), Globals.szFileTitle);
+        StringCchCopy(szFilename, _countof(szFilename), Globals.szFileTitle);
     else
-        LoadString(Globals.hInstance, STRING_UNTITLED, szFilename, ARRAY_SIZE(szFilename));
+        LoadString(Globals.hInstance, STRING_UNTITLED, szFilename, _countof(szFilename));
 
     /* Update the window caption based upon whether the user has modified the file or not */
     StringCbPrintf(szCaption, sizeof(szCaption), _T("%s%s - %s"),
@@ -126,14 +126,14 @@ VOID DIALOG_StatusBarAlignParts(VOID)
     parts[0] = max(parts[0], defaultWidths[0]);
     parts[1] = max(parts[1], defaultWidths[0] + defaultWidths[1]);
 
-    SendMessageW(Globals.hStatusBar, SB_SETPARTS, ARRAY_SIZE(parts), (LPARAM)parts);
+    SendMessageW(Globals.hStatusBar, SB_SETPARTS, _countof(parts), (LPARAM)parts);
 }
 
 static VOID DIALOG_StatusBarUpdateLineEndings(VOID)
 {
     WCHAR szText[128];
 
-    LoadStringW(Globals.hInstance, EolnToStrId[Globals.iEoln], szText, ARRAY_SIZE(szText));
+    LoadStringW(Globals.hInstance, EolnToStrId[Globals.iEoln], szText, _countof(szText));
 
     SendMessageW(Globals.hStatusBar, SB_SETTEXTW, SBPART_EOLN, (LPARAM)szText);
 }
@@ -144,7 +144,7 @@ static VOID DIALOG_StatusBarUpdateEncoding(VOID)
 
     if (Globals.encFile != ENCODING_AUTO)
     {
-        LoadStringW(Globals.hInstance, EncToStrId[Globals.encFile], szText, ARRAY_SIZE(szText));
+        LoadStringW(Globals.hInstance, EncToStrId[Globals.encFile], szText, _countof(szText));
     }
 
     SendMessageW(Globals.hStatusBar, SB_SETTEXTW, SBPART_ENCODING, (LPARAM)szText);
@@ -163,14 +163,14 @@ int DIALOG_StringMsgBox(HWND hParent, int formatId, LPCTSTR szString, DWORD dwFl
     TCHAR szResource[MAX_STRING_LEN];
 
     /* Load and format szMessage */
-    LoadString(Globals.hInstance, formatId, szResource, ARRAY_SIZE(szResource));
-    _sntprintf(szMessage, ARRAY_SIZE(szMessage), szResource, szString);
+    LoadString(Globals.hInstance, formatId, szResource, _countof(szResource));
+    _sntprintf(szMessage, _countof(szMessage), szResource, szString);
 
     /* Load szCaption */
     if ((dwFlags & MB_ICONMASK) == MB_ICONEXCLAMATION)
-        LoadString(Globals.hInstance, STRING_ERROR, szResource, ARRAY_SIZE(szResource));
+        LoadString(Globals.hInstance, STRING_ERROR, szResource, _countof(szResource));
     else
-        LoadString(Globals.hInstance, STRING_NOTEPAD, szResource, ARRAY_SIZE(szResource));
+        LoadString(Globals.hInstance, STRING_NOTEPAD, szResource, _countof(szResource));
 
     /* Display Modal Dialog */
     // if (hParent == NULL)
@@ -187,7 +187,7 @@ static int AlertFileNotSaved(LPCTSTR szFileName)
 {
     TCHAR szUntitled[MAX_STRING_LEN];
 
-    LoadString(Globals.hInstance, STRING_UNTITLED, szUntitled, ARRAY_SIZE(szUntitled));
+    LoadString(Globals.hInstance, STRING_UNTITLED, szUntitled, _countof(szUntitled));
 
     return DIALOG_StringMsgBox(Globals.hMainWnd, STRING_NOTSAVED,
                                szFileName[0] ? szFileName : szUntitled,
@@ -330,7 +330,7 @@ VOID DoOpenFile(LPCTSTR szFileName)
     /*  If the file starts with .LOG, add a time/date at the end and set cursor after
      *  See http://web.archive.org/web/20090627165105/http://support.microsoft.com/kb/260563
      */
-    if (GetWindowText(Globals.hEdit, log, ARRAY_SIZE(log)) && !_tcscmp(log, _T(".LOG")))
+    if (GetWindowText(Globals.hEdit, log, _countof(log)) && !_tcscmp(log, _T(".LOG")))
     {
         static const TCHAR lf[] = _T("\r\n");
         SendMessage(Globals.hEdit, EM_SETSEL, GetWindowTextLength(Globals.hEdit), -1);
@@ -367,7 +367,7 @@ VOID DIALOG_FileNew(VOID)
 VOID DIALOG_FileNewWindow(VOID)
 {
     TCHAR pszNotepadExe[MAX_PATH];
-    GetModuleFileName(NULL, pszNotepadExe, ARRAYSIZE(pszNotepadExe));
+    GetModuleFileName(NULL, pszNotepadExe, _countof(pszNotepadExe));
     ShellExecute(NULL, NULL, pszNotepadExe, NULL, NULL, SW_SHOWNORMAL);
 }
 
@@ -388,7 +388,7 @@ VOID DIALOG_FileOpen(VOID)
     openfilename.hInstance = Globals.hInstance;
     openfilename.lpstrFilter = Globals.szFilter;
     openfilename.lpstrFile = szPath;
-    openfilename.nMaxFile = ARRAY_SIZE(szPath);
+    openfilename.nMaxFile = _countof(szPath);
     openfilename.Flags = OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_HIDEREADONLY;
     openfilename.lpstrDefExt = szDefaultExt;
 
@@ -428,32 +428,32 @@ DIALOG_FileSaveAs_Hook(HWND hDlg, UINT msg, WPARAM wParam, LPARAM lParam)
         case WM_INITDIALOG:
             hCombo = GetDlgItem(hDlg, ID_ENCODING);
 
-            LoadString(Globals.hInstance, STRING_ANSI, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_ANSI, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_UNICODE, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_UNICODE, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_UNICODE_BE, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_UNICODE_BE, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_UTF8, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_UTF8, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_UTF8_BOM, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_UTF8_BOM, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
             SendMessage(hCombo, CB_SETCURSEL, Globals.encFile, 0);
 
             hCombo = GetDlgItem(hDlg, ID_EOLN);
 
-            LoadString(Globals.hInstance, STRING_CRLF, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_CRLF, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_LF, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_LF, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
-            LoadString(Globals.hInstance, STRING_CR, szText, ARRAY_SIZE(szText));
+            LoadString(Globals.hInstance, STRING_CR, szText, _countof(szText));
             SendMessage(hCombo, CB_ADDSTRING, 0, (LPARAM) szText);
 
             SendMessage(hCombo, CB_SETCURSEL, Globals.iEoln, 0);
@@ -492,7 +492,7 @@ BOOL DIALOG_FileSaveAs(VOID)
     saveas.hInstance = Globals.hInstance;
     saveas.lpstrFilter = Globals.szFilter;
     saveas.lpstrFile = szPath;
-    saveas.nMaxFile = ARRAY_SIZE(szPath);
+    saveas.nMaxFile = _countof(szPath);
     saveas.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY |
                    OFN_EXPLORER | OFN_ENABLETEMPLATE | OFN_ENABLEHOOK;
     saveas.lpstrDefExt = szDefaultExt;
@@ -748,9 +748,9 @@ static VOID DIALOG_SearchDialog(FINDPROC pfnProc)
         Globals.find.lStructSize = sizeof(Globals.find);
         Globals.find.hwndOwner = Globals.hMainWnd;
         Globals.find.lpstrFindWhat = Globals.szFindText;
-        Globals.find.wFindWhatLen = ARRAY_SIZE(Globals.szFindText);
+        Globals.find.wFindWhatLen = _countof(Globals.szFindText);
         Globals.find.lpstrReplaceWith = Globals.szReplaceText;
-        Globals.find.wReplaceWithLen = ARRAY_SIZE(Globals.szReplaceText);
+        Globals.find.wReplaceWithLen = _countof(Globals.szReplaceText);
         Globals.find.Flags = FR_DOWN;
     }
 
@@ -812,8 +812,8 @@ DIALOG_GoTo_DialogProc(HWND hwndDialog, UINT uMsg, WPARAM wParam, LPARAM lParam)
                 {
                     /* Show error message */
                     WCHAR title[128], text[256];
-                    LoadStringW(Globals.hInstance, STRING_NOTEPAD, title, ARRAY_SIZE(title));
-                    LoadStringW(Globals.hInstance, STRING_LINE_NUMBER_OUT_OF_RANGE, text, ARRAY_SIZE(text));
+                    LoadStringW(Globals.hInstance, STRING_NOTEPAD, title, _countof(title));
+                    LoadStringW(Globals.hInstance, STRING_LINE_NUMBER_OUT_OF_RANGE, text, _countof(text));
                     MessageBoxW(hwndDialog, text, title, MB_OK);
 
                     SendDlgItemMessageW(hwndDialog, ID_LINENUMBER, EM_SETSEL, 0, -1);
@@ -900,8 +900,8 @@ VOID DIALOG_HelpAboutNotepad(VOID)
     TCHAR szNotepad[MAX_STRING_LEN];
     TCHAR szNotepadAuthors[MAX_STRING_LEN];
 
-    LoadString(Globals.hInstance, STRING_NOTEPAD, szNotepad, ARRAY_SIZE(szNotepad));
-    LoadString(Globals.hInstance, STRING_NOTEPAD_AUTHORS, szNotepadAuthors, ARRAY_SIZE(szNotepadAuthors));
+    LoadString(Globals.hInstance, STRING_NOTEPAD, szNotepad, _countof(szNotepad));
+    LoadString(Globals.hInstance, STRING_NOTEPAD_AUTHORS, szNotepadAuthors, _countof(szNotepadAuthors));
 
     ShellAbout(Globals.hMainWnd, szNotepad, szNotepadAuthors,
                LoadIcon(Globals.hInstance, MAKEINTRESOURCE(IDI_NPICON)));

--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -33,9 +33,9 @@ VOID NOTEPAD_EnableSearchMenu()
  */
 VOID SetFileName(LPCTSTR szFileName)
 {
-    StringCchCopy(Globals.szFileName, ARRAY_SIZE(Globals.szFileName), szFileName);
+    StringCchCopy(Globals.szFileName, _countof(Globals.szFileName), szFileName);
     Globals.szFileTitle[0] = 0;
-    GetFileTitle(szFileName, Globals.szFileTitle, ARRAY_SIZE(Globals.szFileTitle));
+    GetFileTitle(szFileName, Globals.szFileTitle, _countof(Globals.szFileTitle));
 
     if (szFileName && szFileName[0])
         SHAddToRecentDocs(SHARD_PATHW, szFileName);
@@ -201,9 +201,9 @@ BOOL NOTEPAD_FindNext(FINDREPLACE *pFindReplace, BOOL bReplace, BOOL bShowAlert)
         /* Can't find target */
         if (bShowAlert)
         {
-            LoadString(Globals.hInstance, STRING_CANNOTFIND, szResource, ARRAY_SIZE(szResource));
-            _sntprintf(szText, ARRAY_SIZE(szText), szResource, pFindReplace->lpstrFindWhat);
-            LoadString(Globals.hInstance, STRING_NOTEPAD, szResource, ARRAY_SIZE(szResource));
+            LoadString(Globals.hInstance, STRING_CANNOTFIND, szResource, _countof(szResource));
+            _sntprintf(szText, _countof(szText), szResource, pFindReplace->lpstrFindWhat);
+            LoadString(Globals.hInstance, STRING_NOTEPAD, szResource, _countof(szResource));
             MessageBox(Globals.hFindReplaceDlg, szText, szResource, MB_OK);
         }
         bSuccess = FALSE;
@@ -253,11 +253,11 @@ static VOID NOTEPAD_InitData(HINSTANCE hInstance)
     p = Globals.szFilter;
     p += LoadString(Globals.hInstance, STRING_TEXT_FILES_TXT, p, MAX_STRING_LEN) + 1;
     _tcscpy(p, txt_files);
-    p += ARRAY_SIZE(txt_files);
+    p += _countof(txt_files);
 
     p += LoadString(Globals.hInstance, STRING_ALL_FILES, p, MAX_STRING_LEN) + 1;
     _tcscpy(p, all_files);
-    p += ARRAY_SIZE(all_files);
+    p += _countof(all_files);
     *p = '\0';
     Globals.find.lpstrFindWhat = NULL;
 
@@ -416,7 +416,7 @@ NOTEPAD_WndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
         TCHAR szFileName[MAX_PATH];
         HDROP hDrop = (HDROP) wParam;
 
-        DragQueryFile(hDrop, 0, szFileName, ARRAY_SIZE(szFileName));
+        DragQueryFile(hDrop, 0, szFileName, _countof(szFileName));
         DragFinish(hDrop);
         DoOpenFile(szFileName);
         break;
@@ -515,7 +515,7 @@ static BOOL HandleCommandLine(LPTSTR cmdline)
             }
         }
 
-        GetFullPathName(file_name, ARRAY_SIZE(szPath), szPath, NULL);
+        GetFullPathName(file_name, _countof(szPath), szPath, NULL);
 
         if (file_exists)
         {

--- a/base/applications/notepad/notepad.h
+++ b/base/applications/notepad/notepad.h
@@ -33,8 +33,6 @@
 #include "dialog.h"
 #include "notepad_res.h"
 
-#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
-
 #define EDIT_STYLE_WRAP (WS_CHILD | WS_VSCROLL | ES_AUTOVSCROLL | ES_MULTILINE | ES_NOHIDESEL)
 #define EDIT_STYLE      (EDIT_STYLE_WRAP | WS_HSCROLL | ES_AUTOHSCROLL)
 #define EDIT_CLASS      _T("EDIT")

--- a/base/applications/notepad/printing.c
+++ b/base/applications/notepad/printing.c
@@ -17,7 +17,7 @@ static VOID AlertPrintError(VOID)
 {
     TCHAR szUntitled[MAX_STRING_LEN];
 
-    LoadString(Globals.hInstance, STRING_UNTITLED, szUntitled, ARRAY_SIZE(szUntitled));
+    LoadString(Globals.hInstance, STRING_UNTITLED, szUntitled, _countof(szUntitled));
 
     DIALOG_StringMsgBox(Globals.hMainWnd, STRING_PRINTERROR,
                         Globals.szFileName[0] ? Globals.szFileName : szUntitled,
@@ -143,7 +143,7 @@ DrawHeaderOrFooter(HDC hDC, LPRECT pRect, LPCTSTR pszFormat, INT nPageNo, const 
     {
         if (*pchFormat != _T('&'))
         {
-            StringCchCatN(szText, ARRAY_SIZE(szText), pchFormat, 1);
+            StringCchCatN(szText, _countof(szText), pchFormat, 1);
             continue;
         }
 
@@ -154,7 +154,7 @@ DrawHeaderOrFooter(HDC hDC, LPRECT pRect, LPCTSTR pszFormat, INT nPageNo, const 
         switch (_totupper(*pchFormat)) /* Make it uppercase */
         {
             case _T('&'): /* Found double ampersand */
-                StringCchCat(szText, ARRAY_SIZE(szText), TEXT("&"));
+                StringCchCat(szText, _countof(szText), TEXT("&"));
                 break;
 
             case _T('L'): /* Left */
@@ -177,30 +177,30 @@ DrawHeaderOrFooter(HDC hDC, LPRECT pRect, LPCTSTR pszFormat, INT nPageNo, const 
 
             case _T('D'): /* Date */
                 GetDateFormat(LOCALE_USER_DEFAULT, 0, pstNow, NULL,
-                              szField, (INT)ARRAY_SIZE(szField));
-                StringCchCat(szText, ARRAY_SIZE(szText), szField);
+                              szField, (INT)_countof(szField));
+                StringCchCat(szText, _countof(szText), szField);
                 break;
 
             case _T('T'): /* Time */
                 GetTimeFormat(LOCALE_USER_DEFAULT, 0, pstNow, NULL,
-                              szField, (INT)ARRAY_SIZE(szField));
-                StringCchCat(szText, ARRAY_SIZE(szText), szField);
+                              szField, (INT)_countof(szField));
+                StringCchCat(szText, _countof(szText), szField);
                 break;
 
             case _T('F'): /* Filename */
-                StringCchCat(szText, ARRAY_SIZE(szText), Globals.szFileTitle);
+                StringCchCat(szText, _countof(szText), Globals.szFileTitle);
                 break;
 
             case _T('P'): /* Page number */
-                StringCchPrintf(szField, ARRAY_SIZE(szField), TEXT("%u"), nPageNo);
-                StringCchCat(szText, ARRAY_SIZE(szText), szField);
+                StringCchPrintf(szField, _countof(szField), TEXT("%u"), nPageNo);
+                StringCchCat(szText, _countof(szText), szField);
                 break;
 
             default: /* Otherwise */
                 szField[0] = _T('&');
                 szField[1] = *pchFormat;
                 szField[2] = 0;
-                StringCchCat(szText, ARRAY_SIZE(szText), szField);
+                StringCchCat(szText, _countof(szText), szField);
                 break;
         }
     }
@@ -503,7 +503,7 @@ DIALOG_Printing_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             s_pData = (PPRINT_DATA)lParam;
             s_pData->hwndDlg = hwnd;
             SetDlgItemText(hwnd, IDC_PRINTING_FILENAME, Globals.szFileTitle);
-            GetDlgItemText(hwnd, IDC_PRINTING_PAGE, s_szPage, ARRAY_SIZE(s_szPage));
+            GetDlgItemText(hwnd, IDC_PRINTING_PAGE, s_szPage, _countof(s_szPage));
             SetDlgItemText(hwnd, IDC_PRINTING_PAGE, NULL);
 
             s_hThread = CreateThread(NULL, 0, PrintThreadFunc, s_pData, 0, NULL);
@@ -519,17 +519,17 @@ DIALOG_Printing_DialogProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 case STRING_NOWPRINTING:
                 case STRING_PRINTCANCELING:
-                    StringCchPrintf(szText, ARRAY_SIZE(szText), s_szPage, s_pData->currentPage);
+                    StringCchPrintf(szText, _countof(szText), s_szPage, s_pData->currentPage);
                     SetDlgItemText(hwnd, IDC_PRINTING_PAGE, szText);
 
-                    LoadString(Globals.hInstance, s_pData->status, szText, ARRAY_SIZE(szText));
+                    LoadString(Globals.hInstance, s_pData->status, szText, _countof(szText));
                     SetDlgItemText(hwnd, IDC_PRINTING_STATUS, szText);
                     break;
 
                 case STRING_PRINTCOMPLETE:
                 case STRING_PRINTCANCELED:
                 case STRING_PRINTFAILED:
-                    LoadString(Globals.hInstance, s_pData->status, szText, ARRAY_SIZE(szText));
+                    LoadString(Globals.hInstance, s_pData->status, szText, _countof(szText));
                     SetDlgItemText(hwnd, IDC_PRINTING_STATUS, szText);
 
                     if (s_pData->status == STRING_PRINTCOMPLETE)
@@ -636,8 +636,8 @@ static UINT_PTR CALLBACK DIALOG_PAGESETUP_Hook(HWND hDlg, UINT uMsg, WPARAM wPar
                 {
                 case IDOK:
                     /* save user input and close dialog */
-                    GetDlgItemText(hDlg, 0x141, Globals.szHeader, ARRAY_SIZE(Globals.szHeader));
-                    GetDlgItemText(hDlg, 0x143, Globals.szFooter, ARRAY_SIZE(Globals.szFooter));
+                    GetDlgItemText(hDlg, 0x141, Globals.szHeader, _countof(Globals.szHeader));
+                    GetDlgItemText(hDlg, 0x143, Globals.szFooter, _countof(Globals.szFooter));
                     return FALSE;
 
                 case IDCANCEL:

--- a/base/applications/notepad/settings.c
+++ b/base/applications/notepad/settings.c
@@ -159,8 +159,8 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
         QueryDword(hKey, _T("iWindowPosDX"), &cx);
         QueryDword(hKey, _T("iWindowPosDY"), &cy);
 
-        QueryString(hKey, _T("searchString"), Globals.szFindText, ARRAY_SIZE(Globals.szFindText));
-        QueryString(hKey, _T("replaceString"), Globals.szReplaceText, ARRAY_SIZE(Globals.szReplaceText));
+        QueryString(hKey, _T("searchString"), Globals.szFindText, _countof(Globals.szFindText));
+        QueryString(hKey, _T("replaceString"), Globals.szReplaceText, _countof(Globals.szReplaceText));
     }
 
     Globals.lfFont.lfHeight = HeightFromPointSize(dwPointSize);
@@ -168,22 +168,22 @@ void NOTEPAD_LoadSettingsFromRegistry(void)
     Globals.main_rect.bottom = Globals.main_rect.top + cy;
 
     if (!hKey || !QueryString(hKey, _T("lfFaceName"),
-                              Globals.lfFont.lfFaceName, ARRAY_SIZE(Globals.lfFont.lfFaceName)))
+                              Globals.lfFont.lfFaceName, _countof(Globals.lfFont.lfFaceName)))
     {
         LoadString(Globals.hInstance, STRING_DEFAULTFONT, Globals.lfFont.lfFaceName,
-                   ARRAY_SIZE(Globals.lfFont.lfFaceName));
+                   _countof(Globals.lfFont.lfFaceName));
     }
 
-    if (!hKey || !QueryString(hKey, _T("szHeader"), Globals.szHeader, ARRAY_SIZE(Globals.szHeader)))
+    if (!hKey || !QueryString(hKey, _T("szHeader"), Globals.szHeader, _countof(Globals.szHeader)))
     {
         LoadString(Globals.hInstance, STRING_PAGESETUP_HEADERVALUE, Globals.szHeader,
-                   ARRAY_SIZE(Globals.szHeader));
+                   _countof(Globals.szHeader));
     }
 
-    if (!hKey || !QueryString(hKey, _T("szTrailer"), Globals.szFooter, ARRAY_SIZE(Globals.szFooter)))
+    if (!hKey || !QueryString(hKey, _T("szTrailer"), Globals.szFooter, _countof(Globals.szFooter)))
     {
         LoadString(Globals.hInstance, STRING_PAGESETUP_FOOTERVALUE, Globals.szFooter,
-                   ARRAY_SIZE(Globals.szFooter));
+                   _countof(Globals.szFooter));
     }
 
     if (hKey)


### PR DESCRIPTION
## Purpose

Standardization.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Remove the definition of `ARRAY_SIZE` macro.
- Replace `ARRAY_SIZE` and `ARRAYSIZE` with `_countof`.

## TODO

- [x] Did build.