### PR TITLE
[COMCTL32][USER32] EDIT: Do default on WM_IME_SELECT/CONTROL

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -4997,9 +4997,15 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
         break;
 
     case WM_IME_SELECT:
+#ifdef __REACTOS__
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         break;
 
     case WM_IME_CONTROL:
+#ifdef __REACTOS__
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         break;
 
     case WM_IME_REQUEST:

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5310,9 +5310,15 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		break;
 
 	case WM_IME_SELECT:
+#ifdef __REACTOS__
+		result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+#endif
 		break;
 
 	case WM_IME_CONTROL:
+#ifdef __REACTOS__
+		result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+#endif
 		break;
 
 	case WM_IME_REQUEST:


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-15289](https://jira.reactos.org/browse/CORE-15289)

## Proposed changes

- Do default processing on `WM_IME_SELECT` and `WM_IME_CONTROL` messages in `EDIT` controls.

## TODO

- [x] Do small tests.
- [x] Do big tests.