### PR TITLE
[NTOS:OB] Implement name information querying on ObjectInformation case

### DIFF
--- a/modules/rostests/kmtests/CMakeLists.txt
+++ b/modules/rostests/kmtests/CMakeLists.txt
@@ -88,6 +88,7 @@ list(APPEND KMTEST_DRV_SOURCE
     ntos_mm/ZwCreateSection.c
     ntos_mm/ZwMapViewOfSection.c
     ntos_ob/ObHandle.c
+    ntos_ob/ObQuery.c
     ntos_ob/ObReference.c
     ntos_ob/ObSecurity.c
     ntos_ob/ObSymbolicLink.c

--- a/modules/rostests/kmtests/kmtest_drv/testlist.c
+++ b/modules/rostests/kmtests/kmtest_drv/testlist.c
@@ -56,6 +56,7 @@ KMT_TESTFUNC Test_NpfsFileInfo;
 KMT_TESTFUNC Test_NpfsReadWrite;
 KMT_TESTFUNC Test_NpfsVolumeInfo;
 KMT_TESTFUNC Test_ObHandle;
+KMT_TESTFUNC Test_ObQuery;
 KMT_TESTFUNC Test_ObReference;
 KMT_TESTFUNC Test_ObSecurity;
 KMT_TESTFUNC Test_ObSymbolicLink;
@@ -137,6 +138,7 @@ const KMT_TEST TestList[] =
     { "NpfsReadWrite",                      Test_NpfsReadWrite },
     { "NpfsVolumeInfo",                     Test_NpfsVolumeInfo },
     { "ObHandle",                           Test_ObHandle },
+    { "ObQuery",                            Test_ObQuery },
     { "ObReference",                        Test_ObReference },
     { "ObSecurity",                         Test_ObSecurity },
     { "ObSymbolicLink",                     Test_ObSymbolicLink },

--- a/modules/rostests/kmtests/ntos_ob/ObQuery.c
+++ b/modules/rostests/kmtests/ntos_ob/ObQuery.c
@@ -1,0 +1,71 @@
+/*
+ * PROJECT:     ReactOS kernel-mode tests
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Kernel mode tests for object information querying
+ * COPYRIGHT:   Copyright 2023 George Bișoc <george.bisoc@reactos.org>
+ */
+
+#include <kmt_test.h>
+
+#define OBJ_WINSTA_DIRECTORY_NAME_INFO_SIZE (sizeof(UNICODE_STRING) + sizeof(L"\\Windows"))
+#define OBJ_DIRECTORY_TYPE_INFO_SIZE (sizeof(OBJECT_TYPE_INFORMATION) + (wcslen(L"\\Directory") * sizeof(WCHAR)))
+
+static
+VOID
+ObjectBasicInformationTests(VOID)
+{
+    NTSTATUS Status;
+    HANDLE WinStaDirHandle;
+    OBJECT_BASIC_INFORMATION BasicInfo;
+    ULONG ReturnLength;
+    OBJECT_ATTRIBUTES ObjectAttributes;
+    static UNICODE_STRING WinStaDir = RTL_CONSTANT_STRING(L"\\Windows");
+
+    /* We must be in PASSIVE_LEVEL to do all of this stuff */
+    ok_irql(PASSIVE_LEVEL);
+
+    /* Create a path to \Windows directory */
+    InitializeObjectAttributes(&ObjectAttributes,
+                               &WinStaDir,
+                               OBJ_CASE_INSENSITIVE | OBJ_OPENIF | OBJ_KERNEL_HANDLE,
+                               NULL,
+                               NULL);
+    Status = ZwOpenDirectoryObject(&WinStaDirHandle,
+                                   DIRECTORY_QUERY | DIRECTORY_TRAVERSE,
+                                   &ObjectAttributes);
+    if (!NT_SUCCESS(Status))
+    {
+        ok(FALSE, "Failed to open \\Windows directory (Status 0x%lx)\n", Status);
+        return;
+    }
+
+    /* Give 0 as information length, this must fail */
+    Status = ZwQueryObject(WinStaDirHandle,
+                           ObjectBasicInformation,
+                           &BasicInfo,
+                           0,
+                           &ReturnLength);
+    ok_eq_hex(Status, STATUS_INFO_LENGTH_MISMATCH);
+
+    /* Do a proper query now */
+    Status = ZwQueryObject(WinStaDirHandle,
+                           ObjectBasicInformation,
+                           &BasicInfo,
+                           sizeof(BasicInfo),
+                           &ReturnLength);
+    ok_eq_hex(Status, STATUS_SUCCESS);
+
+    /* \Windows is currently used */
+    ok(BasicInfo.HandleCount != 0, "\\Windows is in use but HandleCount is 0!\n");
+    ok(BasicInfo.PointerCount != 0, "\\Windows is in use but PointerCount is 0!\n");
+
+    ok_eq_ulong(BasicInfo.NameInfoSize, OBJ_WINSTA_DIRECTORY_NAME_INFO_SIZE);
+    ok_eq_ulong(BasicInfo.TypeInfoSize, OBJ_DIRECTORY_TYPE_INFO_SIZE);
+
+    ZwClose(WinStaDirHandle);
+}
+
+START_TEST(ObQuery)
+{
+    ObjectBasicInformationTests();
+}


### PR DESCRIPTION
Currently there is no implementation support for object name information querying when someone queries information about an object with `ObjectBasicInformation` class case. Some device drivers may take use of such information.

`NameInfoSize` is a size that is the sum of all name directories of an object, including path separators. `TypeInfoSize` is a size that is pointed by the size of a type object itself, therefore this size remains pretty much fixed depending on the kind of an object.

https://www.geoffchappell.com/studies/windows/km/ntoskrnl/inc/api/ntobapi/object_basic_information.htm
http://undocumented.ntinternals.net/index.html?page=UserMode%2FUndocumented%20Functions%2FNT%20Objects%2FType%20independed%2FNtQueryObject.html