### PR TITLE
[NOTEPAD] Move '#include <crtdbg.h>' and add _CRTDBG_MAP_ALLOC

### DIFF
--- a/base/applications/notepad/main.c
+++ b/base/applications/notepad/main.c
@@ -14,10 +14,6 @@
 #include <shlobj.h>
 #include <strsafe.h>
 
-#ifdef _DEBUG
-#include <crtdbg.h>
-#endif
-
 NOTEPAD_GLOBALS Globals;
 static ATOM aFINDMSGSTRING;
 

--- a/base/applications/notepad/notepad.h
+++ b/base/applications/notepad/notepad.h
@@ -23,7 +23,12 @@
 #include <shellapi.h>
 #include <commdlg.h>
 #include <tchar.h>
+#include <stdlib.h>
 #include <malloc.h>
+#ifdef _DEBUG
+    #define _CRTDBG_MAP_ALLOC
+    #include <crtdbg.h>
+#endif
 
 #include "dialog.h"
 #include "notepad_res.h"


### PR DESCRIPTION
## Purpose

Get the full power of CRT debug.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed changes

- Add `#include <stdlib.h>` for `<crtdbg.h>`.
- Move `"#include <crtdbg.h>"` into `"notepad.h"`.
- Insert `#define _CRTDBG_MAP_ALLOC` just before `"#include <crtdbg.h>"`.

## TODO

- [x] Can build?