### PR TITLE
[MSPAINT][ATL] Encapsulation: mainWindow

### DIFF
--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -40,11 +40,6 @@ public:
 
     BOOL SetResolution(Gdiplus::GpBitmap *pBitmap, float xDpi, float yDpi) const
     {
-        if (xDpi <= 0)
-            xDpi = 96;
-        if (yDpi <= 0)
-            yDpi = 96;
-
         if (BitmapSetResolution == NULL)
             BitmapSetResolution = AddrOf<BITMAPSETRESOLUTION>("GdipBitmapSetResolution");
 

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -10,7 +10,7 @@ public:
         BitmapSetResolution = NULL;
     }
 
-    BOOL GetResolution(Gdiplus::GpBitmap *pBitmap, float *pxDpi, float *pyDpi)
+    BOOL GetResolution(Gdiplus::GpImage *pImage, float *pxDpi, float *pyDpi)
     {
         *pxDpi = 96;
         *pyDpi = 96;
@@ -24,8 +24,8 @@ public:
         if (GetImageHorizontalResolution == NULL || GetImageVerticalResolution == NULL)
             return FALSE;
 
-        GetImageHorizontalResolution((Gdiplus::GpImage*)pBitmap, pxDpi);
-        GetImageVerticalResolution((Gdiplus::GpImage*)pBitmap, pyDpi);
+        GetImageHorizontalResolution(pImage, pxDpi);
+        GetImageVerticalResolution(pImage, pyDpi);
         return TRUE;
     }
 
@@ -66,7 +66,7 @@ public:
         status = GetCommon().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // get the resolution
-        GetResolution(pBitmap, pxDpi, pyDpi);
+        GetResolution((Gdiplus::GpImage*)pBitmap, pxDpi, pyDpi);
 
         // delete GpBitmap
         GetCommon().DisposeImage(pBitmap);

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -24,8 +24,10 @@ public:
 
         if (GetImageHorizontalResolution == NULL || GetImageVerticalResolution == NULL)
         {
-            GetImageHorizontalResolution = AddrOf<GETIMAGEHORIZONTALRESOLUTION>("GdipGetImageHorizontalResolution");
-            GetImageVerticalResolution = AddrOf<GETIMAGEVERTICALRESOLUTION>("GdipGetImageVerticalResolution");
+            GetImageHorizontalResolution =
+                AddrOf<GETIMAGEHORIZONTALRESOLUTION>("GdipGetImageHorizontalResolution");
+            GetImageVerticalResolution =
+                AddrOf<GETIMAGEVERTICALRESOLUTION>("GdipGetImageVerticalResolution");
         }
 
         if (GetImageHorizontalResolution == NULL || GetImageVerticalResolution == NULL)

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -3,7 +3,7 @@
 class CImageDx : public CImage
 {
 public:
-    CImageDx()
+    CImageDx() : CImage()
     {
         GetImageHorizontalResolution = NULL;
         GetImageVerticalResolution = NULL;
@@ -29,7 +29,7 @@ public:
         return TRUE;
     }
 
-    BOOL SetResolution(Gdiplus::GpBitmap *pBitmap, float xDpi, float yDpi)
+    BOOL SetResolution(Gdiplus::GpBitmap *pBitmap, float xDpi, float yDpi) const
     {
         if (xDpi <= 0)
             xDpi = 96;
@@ -63,8 +63,7 @@ public:
         HBITMAP hbm = NULL;
         Color color(0xFF, 0xFF, 0xFF);
         Gdiplus::Status status;
-        status = GetCommon().CreateHBITMAPFromBitmap(
-            pBitmap, &hbm, color.GetValue());
+        status = GetCommon().CreateHBITMAPFromBitmap(pBitmap, &hbm, color.GetValue());
 
         // get the resolution
         GetResolution(pBitmap, pxDpi, pyDpi);
@@ -107,7 +106,7 @@ public:
         GetCommon().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
 
         // set the resolution
-        BitmapSetResolution(pBitmap, xDpi, yDpi);
+        SetResolution(pBitmap, xDpi, yDpi);
 
         // save to file
         Status status;
@@ -122,7 +121,7 @@ public:
 protected:
     // get procedure address of the DLL
     template <typename TYPE>
-    TYPE AddrOf(const char *name)
+    TYPE AddrOf(const char *name) const
     {
         FARPROC proc = ::GetProcAddress(GetCommon().hinstGdiPlus, name);
         return reinterpret_cast<TYPE>(proc);
@@ -140,5 +139,5 @@ protected:
 
     GETIMAGEHORIZONTALRESOLUTION    GetImageHorizontalResolution;
     GETIMAGEVERTICALRESOLUTION      GetImageVerticalResolution;
-    BITMAPSETRESOLUTION             BitmapSetResolution;
+    mutable BITMAPSETRESOLUTION     BitmapSetResolution;
 };

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -1,3 +1,10 @@
+/*
+ * PROJECT:    PAINT for ReactOS
+ * LICENSE:    LGPL-2.1-or-later (https://spdx.org/licenses/LGPL-2.1-or-later)
+ * PURPOSE:    Loading/Saving an image file with getting/setting resolution
+ * COPYRIGHT:  Copyright 2023 Katayama Hirofumi MZ <katayama.hirofumi.mz@gmail.com>
+ */
+
 #pragma once
 
 class CImageDx : public CImage

--- a/base/applications/mspaint/atlimagedx.h
+++ b/base/applications/mspaint/atlimagedx.h
@@ -127,15 +127,9 @@ protected:
         return reinterpret_cast<TYPE>(proc);
     }
 
-#undef API
-#undef CST
-#define API WINGDIPAPI
-#define CST GDIPCONST
-    typedef St (API *GETIMAGEHORIZONTALRESOLUTION)(Im *, float*);
-    typedef St (API *GETIMAGEVERTICALRESOLUTION)(Im *, float*);
-    typedef St (API *BITMAPSETRESOLUTION)(Bm *, float, float);
-#undef API
-#undef CST
+    typedef St (WINGDIPAPI *GETIMAGEHORIZONTALRESOLUTION)(Im *, float*);
+    typedef St (WINGDIPAPI *GETIMAGEVERTICALRESOLUTION)(Im *, float*);
+    typedef St (WINGDIPAPI *BITMAPSETRESOLUTION)(Bm *, float, float);
 
     GETIMAGEHORIZONTALRESOLUTION    GetImageHorizontalResolution;
     GETIMAGEVERTICALRESOLUTION      GetImageVerticalResolution;

--- a/base/applications/mspaint/canvas.cpp
+++ b/base/applications/mspaint/canvas.cpp
@@ -6,9 +6,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+CCanvasWindow canvasWindow;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/common.h
+++ b/base/applications/mspaint/common.h
@@ -14,6 +14,17 @@
 #define MIN_ZOOM    125
 #define MAX_ZOOM    8000
 
+#define MAX_LONG_PATH 512
+
+#define WM_TOOLSMODELTOOLCHANGED         (WM_APP + 0)
+#define WM_TOOLSMODELSETTINGSCHANGED     (WM_APP + 1)
+#define WM_TOOLSMODELZOOMCHANGED         (WM_APP + 2)
+#define WM_PALETTEMODELCOLORCHANGED      (WM_APP + 3)
+#define WM_PALETTEMODELPALETTECHANGED    (WM_APP + 4)
+#define WM_IMAGEMODELDIMENSIONSCHANGED   (WM_APP + 5)
+#define WM_IMAGEMODELIMAGECHANGED        (WM_APP + 6)
+#define WM_SELECTIONMODELREFRESHNEEDED   (WM_APP + 7)
+
 /* width of the rectangle defined by a RECT structure */
 #define RECT_WIDTH(a)  ((a).right - (a).left)
 
@@ -26,6 +37,21 @@
 /* this simplifies enabling or graying menu items */
 #define ENABLED_IF(a) ((a) ? (MF_ENABLED | MF_BYCOMMAND) : (MF_GRAYED | MF_BYCOMMAND))
 
+enum CANVAS_HITTEST // hit
+{
+    HIT_NONE = 0, // Nothing hit or outside
+    HIT_UPPER_LEFT,
+    HIT_UPPER_CENTER,
+    HIT_UPPER_RIGHT,
+    HIT_MIDDLE_LEFT,
+    HIT_MIDDLE_RIGHT,
+    HIT_LOWER_LEFT,
+    HIT_LOWER_CENTER,
+    HIT_LOWER_RIGHT,
+    HIT_BORDER,
+    HIT_INNER,
+};
+
 /* FUNCTIONS ********************************************************/
 
 BOOL zoomTo(int newZoom, int mouseX, int mouseY);
@@ -33,13 +59,3 @@ BOOL nearlyEqualPoints(INT x0, INT y0, INT x1, INT y1);
 void placeSelWin(void);
 void updateStartAndLast(LONG x, LONG y);
 void updateLast(LONG x, LONG y);
-
-static inline int Zoomed(int xy)
-{
-    return xy * toolsModel.GetZoom() / 1000;
-}
-
-static inline int UnZoomed(int xy)
-{
-    return xy * 1000 / toolsModel.GetZoom();
-}

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -135,7 +135,6 @@ LRESULT CAttributesDialog::OnDefault(WORD wNotifyCode, WORD wID, HWND hWndCtl, B
 
 LRESULT CAttributesDialog::OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    FixDpi();
     CString strNum;
     strNum.Format(_T("%.3lf"), newWidth / g_xDpi);
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
@@ -146,11 +145,10 @@ LRESULT CAttributesDialog::OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndC
 
 LRESULT CAttributesDialog::OnRadioButton2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    FixDpi();
     CString strNum;
-    strNum.Format(_T("%.3lf"), newWidth / (PpmFromDpi(g_xDpi) / 100));
+    strNum.Format(_T("%.3lf"), newWidth * 100 / PpmFromDpi(g_xDpi));
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
-    strNum.Format(_T("%.3lf"), newHeight / (PpmFromDpi(g_yDpi) / 100));
+    strNum.Format(_T("%.3lf"), newHeight * 100 / PpmFromDpi(g_yDpi));
     SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
     return 0;
 }
@@ -164,7 +162,6 @@ LRESULT CAttributesDialog::OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndC
 
 LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    FixDpi();
     if (Edit_GetModify(hWndCtl))
     {
         TCHAR tempS[100];
@@ -176,7 +173,7 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (_tcstod(tempS, NULL) * (PpmFromDpi(g_xDpi) / 100)));
+            newWidth = max(1, (int) (_tcstod(tempS, NULL) * PpmFromDpi(g_xDpi) / 100));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
@@ -190,7 +187,6 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
 
 LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
-    FixDpi();
     if (Edit_GetModify(hWndCtl))
     {
         TCHAR tempS[100];
@@ -202,7 +198,7 @@ LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (_tcstod(tempS, NULL) * (PpmFromDpi(g_yDpi) / 100)));
+            newHeight = max(1, (int) (_tcstod(tempS, NULL) * PpmFromDpi(g_yDpi) / 100));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {

--- a/base/applications/mspaint/dialogs.cpp
+++ b/base/applications/mspaint/dialogs.cpp
@@ -99,7 +99,7 @@ LRESULT CAttributesDialog::OnInitDialog(UINT nMsg, WPARAM wParam, LPARAM lParam,
         SetDlgItemText(IDD_ATTRIBUTESTEXT7, strSize);
     }
     CString strRes;
-    strRes.Format(IDS_PRINTRES, fileHPPM, fileVPPM);
+    strRes.Format(IDS_PRINTRES, (INT)PpmFromDpi(g_xDpi), (INT)PpmFromDpi(g_yDpi));
     SetDlgItemText(IDD_ATTRIBUTESTEXT8, strRes);
     return 0;
 }
@@ -135,20 +135,22 @@ LRESULT CAttributesDialog::OnDefault(WORD wNotifyCode, WORD wID, HWND hWndCtl, B
 
 LRESULT CAttributesDialog::OnRadioButton1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
+    FixDpi();
     CString strNum;
-    strNum.Format(_T("%.3lf"), newWidth / (0.0254 * fileHPPM));
+    strNum.Format(_T("%.3lf"), newWidth / g_xDpi);
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
-    strNum.Format(_T("%.3lf"), newHeight / (0.0254 * fileVPPM));
+    strNum.Format(_T("%.3lf"), newHeight / g_yDpi);
     SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
     return 0;
 }
 
 LRESULT CAttributesDialog::OnRadioButton2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
+    FixDpi();
     CString strNum;
-    strNum.Format(_T("%.3lf"), newWidth * 100.0 / fileHPPM);
+    strNum.Format(_T("%.3lf"), newWidth / (PpmFromDpi(g_xDpi) / 100));
     SetDlgItemText(IDD_ATTRIBUTESEDIT1, strNum);
-    strNum.Format(_T("%.3lf"), newHeight * 100.0 / fileVPPM);
+    strNum.Format(_T("%.3lf"), newHeight / (PpmFromDpi(g_yDpi) / 100));
     SetDlgItemText(IDD_ATTRIBUTESEDIT2, strNum);
     return 0;
 }
@@ -162,18 +164,19 @@ LRESULT CAttributesDialog::OnRadioButton3(WORD wNotifyCode, WORD wID, HWND hWndC
 
 LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
+    FixDpi();
     if (Edit_GetModify(hWndCtl))
     {
         TCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM * 0.0254));
+            newWidth = max(1, (int) (_tcstod(tempS, NULL) * g_xDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT1, tempS, _countof(tempS));
-            newWidth = max(1, (int) (_tcstod(tempS, NULL) * fileHPPM / 100));
+            newWidth = max(1, (int) (_tcstod(tempS, NULL) * (PpmFromDpi(g_xDpi) / 100)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {
@@ -187,18 +190,19 @@ LRESULT CAttributesDialog::OnEdit1(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOO
 
 LRESULT CAttributesDialog::OnEdit2(WORD wNotifyCode, WORD wID, HWND hWndCtl, BOOL& bHandled)
 {
+    FixDpi();
     if (Edit_GetModify(hWndCtl))
     {
         TCHAR tempS[100];
         if (IsDlgButtonChecked(IDD_ATTRIBUTESRB1))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM * 0.0254));
+            newHeight = max(1, (int) (_tcstod(tempS, NULL) * g_yDpi));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB2))
         {
             GetDlgItemText(IDD_ATTRIBUTESEDIT2, tempS, _countof(tempS));
-            newHeight = max(1, (int) (_tcstod(tempS, NULL) * fileVPPM / 100));
+            newHeight = max(1, (int) (_tcstod(tempS, NULL) * (PpmFromDpi(g_yDpi) / 100)));
         }
         else if (IsDlgButtonChecked(IDD_ATTRIBUTESRB3))
         {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -16,14 +16,6 @@ SYSTEMTIME fileTime;
 
 /* FUNCTIONS ********************************************************/
 
-VOID FixDpi(VOID)
-{
-    if (g_xDpi <= 0)
-        g_xDpi = 96;
-    if (g_yDpi <= 0)
-        g_yDpi = 96;
-}
-
 // Convert DPI (dots per inch) into PPM (pixels per meter)
 float PpmFromDpi(float dpi)
 {
@@ -85,8 +77,6 @@ GetDIBHeight(HBITMAP hBitmap)
 
 BOOL SaveDIBToFile(HBITMAP hBitmap, LPTSTR FileName, HDC hDC)
 {
-    FixDpi();
-
     CImageDx img;
     img.Attach(hBitmap);
     img.SaveDx(FileName, GUID_NULL, g_xDpi, g_yDpi); // TODO: error handling
@@ -202,6 +192,12 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile)
     // load the image
     CImageDx img;
     img.LoadDx(name, &g_xDpi, &g_yDpi);
+
+    if (g_xDpi <= 0)
+        g_xDpi = 96;
+    if (g_yDpi <= 0)
+        g_yDpi = 96;
+
     HBITMAP hBitmap = img.Detach();
 
     if (hBitmap == NULL)

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -87,9 +87,9 @@ BOOL SaveDIBToFile(HBITMAP hBitmap, LPTSTR FileName, HDC hDC)
 {
     FixDpi();
 
-    CImage img;
+    CImageDx img;
     img.Attach(hBitmap);
-    img.Save(FileName, GUID_NULL, &g_xDpi, &g_yDpi);  // TODO: error handling
+    img.SaveDx(FileName, GUID_NULL, g_xDpi, g_yDpi); // TODO: error handling
     img.Detach();
 
     WIN32_FIND_DATA find;
@@ -200,8 +200,8 @@ HBITMAP DoLoadImageFile(HWND hwnd, LPCTSTR name, BOOL fIsMainFile)
     }
 
     // load the image
-    CImage img;
-    img.Load(name, &g_xDpi, &g_yDpi);
+    CImageDx img;
+    img.LoadDx(name, &g_xDpi, &g_yDpi);
     HBITMAP hBitmap = img.Detach();
 
     if (hBitmap == NULL)

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -30,12 +30,6 @@ float PpmFromDpi(float dpi)
     return dpi / 0.0254; // 1 DPI is 0.0254 meter.
 }
 
-// Convert PPM (pixels per meter) into DPI (dots per inch)
-float DpiFromPpm(float ppm)
-{
-    return ppm * 0.0254; // 1 DPI is 0.0254 meter.
-}
-
 HBITMAP
 CreateDIBWithProperties(int width, int height)
 {

--- a/base/applications/mspaint/dib.cpp
+++ b/base/applications/mspaint/dib.cpp
@@ -6,10 +6,13 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
 #include <math.h>
+
+INT fileSize = 0;
+INT fileHPPM = 2834; // horizontal pixels per millimeter (PPM)
+INT fileVPPM = 2834; // vertical pixels per millimeter (PPM)
+SYSTEMTIME fileTime;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -33,4 +33,3 @@ HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight);
 HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
 
 float PpmFromDpi(float dpi);
-VOID FixDpi(VOID);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -31,3 +31,7 @@ HBITMAP SetBitmapAndInfo(HBITMAP hBitmap, LPCTSTR name, DWORD dwFileSize, BOOL i
 HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight);
 
 HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
+
+float PpmFromDpi(float dpi);
+float DpiFromPpm(float ppm);
+VOID FixDpi(VOID);

--- a/base/applications/mspaint/dib.h
+++ b/base/applications/mspaint/dib.h
@@ -33,5 +33,4 @@ HBITMAP Rotate90DegreeBlt(HDC hDC1, INT cx, INT cy, BOOL bRight);
 HBITMAP SkewDIB(HDC hDC1, HBITMAP hbm, INT nDegree, BOOL bVertical);
 
 float PpmFromDpi(float dpi);
-float DpiFromPpm(float ppm);
 VOID FixDpi(VOID);

--- a/base/applications/mspaint/fullscreen.cpp
+++ b/base/applications/mspaint/fullscreen.cpp
@@ -12,6 +12,15 @@
 
 /* FUNCTIONS ********************************************************/
 
+HWND CFullscreenWindow::DoCreate()
+{
+    if (m_hWnd)
+        return m_hWnd;
+
+    RECT rc = {0, 0, 0, 0}; // Rely on SW_SHOWMAXIMIZED
+    return fullscreenWindow.Create(HWND_DESKTOP, rc, NULL, WS_POPUPWINDOW);
+}
+
 LRESULT CFullscreenWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     SendMessage(WM_SETICON, ICON_BIG, (LPARAM) LoadIcon(hProgInstance, MAKEINTRESOURCE(IDI_APPICON)));

--- a/base/applications/mspaint/fullscreen.cpp
+++ b/base/applications/mspaint/fullscreen.cpp
@@ -6,9 +6,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+CFullscreenWindow fullscreenWindow;
 
 /* FUNCTIONS ********************************************************/
 
@@ -18,7 +18,7 @@ HWND CFullscreenWindow::DoCreate()
         return m_hWnd;
 
     RECT rc = {0, 0, 0, 0}; // Rely on SW_SHOWMAXIMIZED
-    return fullscreenWindow.Create(HWND_DESKTOP, rc, NULL, WS_POPUPWINDOW);
+    return Create(HWND_DESKTOP, rc, NULL, WS_POPUPWINDOW, WS_EX_TOPMOST);
 }
 
 LRESULT CFullscreenWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/fullscreen.h
+++ b/base/applications/mspaint/fullscreen.h
@@ -23,6 +23,9 @@ public:
         MESSAGE_HANDLER(WM_GETTEXT, OnGetText)
     END_MSG_MAP()
 
+    HWND DoCreate();
+
+private:
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnCloseOrKeyDownOrLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/globalvar.h
+++ b/base/applications/mspaint/globalvar.h
@@ -41,8 +41,8 @@ extern SelectionModel selectionModel;
 extern PaletteModel paletteModel;
 
 extern HWND hStatusBar;
-extern INT fileHPPM;
-extern INT fileVPPM;
+extern float g_xDpi;
+extern float g_yDpi;
 extern INT fileSize;
 extern SYSTEMTIME fileTime;
 

--- a/base/applications/mspaint/globalvar.h
+++ b/base/applications/mspaint/globalvar.h
@@ -10,58 +10,42 @@
 
 /* VARIABLES declared in main.cpp ***********************************/
 
-class RegistrySettings;
-extern RegistrySettings registrySettings;
-
-class ImageModel;
-extern ImageModel imageModel;
 extern BOOL askBeforeEnlarging;
 
 extern POINT start;
 extern POINT last;
 
-class ToolsModel;
+extern HINSTANCE hProgInstance;
+
+extern TCHAR filepathname[MAX_LONG_PATH];
+extern BOOL isAFile;
+extern BOOL imageSaved;
+
+extern BOOL showGrid;
+
+extern CMainWindow mainWindow;
+
+/* VARIABLES declared in dialogs.cpp ********************************/
+
+extern CMirrorRotateDialog mirrorRotateDialog;
+extern CAttributesDialog attributesDialog;
+extern CStretchSkewDialog stretchSkewDialog;
+extern CFontsDialog fontsDialog;
+
+/* VARIABLES declared in the other places ***************************/
+
+extern RegistrySettings registrySettings;
+extern ImageModel imageModel;
 extern ToolsModel toolsModel;
-
-class SelectionModel;
 extern SelectionModel selectionModel;
-
-class PaletteModel;
 extern PaletteModel paletteModel;
 
 extern HWND hStatusBar;
-extern CHOOSECOLOR choosecolor;
-extern OPENFILENAME ofn;
-extern OPENFILENAME sfn;
-extern HICON hNontranspIcon;
-extern HICON hTranspIcon;
-
-extern HINSTANCE hProgInstance;
-
-extern TCHAR filepathname[1000];
-extern BOOL isAFile;
-extern BOOL imageSaved;
-extern int fileSize;
-extern int fileHPPM;
-extern int fileVPPM;
+extern INT fileHPPM;
+extern INT fileVPPM;
+extern INT fileSize;
 extern SYSTEMTIME fileTime;
 
-extern BOOL showGrid;
-extern BOOL showMiniature;
-
-class CMainWindow;
-class CFullscreenWindow;
-class CMiniatureWindow;
-class CToolBox;
-class CToolSettingsWindow;
-class CPaletteWindow;
-class CCanvasWindow;
-class CSelectionWindow;
-class CImgAreaWindow;
-class CSizeboxWindow;
-class CTextEditWindow;
-
-extern CMainWindow mainWindow;
 extern CFullscreenWindow fullscreenWindow;
 extern CMiniatureWindow miniature;
 extern CToolBox toolBoxContainer;
@@ -71,15 +55,3 @@ extern CCanvasWindow canvasWindow;
 extern CSelectionWindow selectionWindow;
 extern CImgAreaWindow imageArea;
 extern CTextEditWindow textEditWindow;
-
-/* VARIABLES declared in dialogs.cpp ********************************/
-
-class CMirrorRotateDialog;
-class CAttributesDialog;
-class CStretchSkewDialog;
-class CFontsDialog;
-
-extern CMirrorRotateDialog mirrorRotateDialog;
-extern CAttributesDialog attributesDialog;
-extern CStretchSkewDialog stretchSkewDialog;
-extern CFontsDialog fontsDialog;

--- a/base/applications/mspaint/history.cpp
+++ b/base/applications/mspaint/history.cpp
@@ -6,9 +6,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+ImageModel imageModel;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -10,18 +10,9 @@
 
 #include "precomp.h"
 
-/* FUNCTIONS ********************************************************/
+CImgAreaWindow imageArea;
 
-HWND CImgAreaWindow::DoCreate(HWND hwndParent)
-{
-    RECT rc =
-    {
-        GRIP_SIZE, GRIP_SIZE,
-        GRIP_SIZE + imageModel.GetWidth(),
-        GRIP_SIZE + imageModel.GetHeight()
-    };
-    return imageArea.Create(hwndParent, rc, NULL, WS_CHILD | WS_VISIBLE);
-}
+/* FUNCTIONS ********************************************************/
 
 LRESULT CImgAreaWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {

--- a/base/applications/mspaint/imgarea.cpp
+++ b/base/applications/mspaint/imgarea.cpp
@@ -12,6 +12,17 @@
 
 /* FUNCTIONS ********************************************************/
 
+HWND CImgAreaWindow::DoCreate(HWND hwndParent)
+{
+    RECT rc =
+    {
+        GRIP_SIZE, GRIP_SIZE,
+        GRIP_SIZE + imageModel.GetWidth(),
+        GRIP_SIZE + imageModel.GetHeight()
+    };
+    return imageArea.Create(hwndParent, rc, NULL, WS_CHILD | WS_VISIBLE);
+}
+
 LRESULT CImgAreaWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     m_hCurFill     = LoadIcon(hProgInstance, MAKEINTRESOURCE(IDC_FILL));

--- a/base/applications/mspaint/imgarea.h
+++ b/base/applications/mspaint/imgarea.h
@@ -17,6 +17,8 @@ public:
     {
     }
 
+    HWND DoCreate(HWND hwndParent);
+
     BOOL drawing;
     void cancelDrawing();
     void finishDrawing();

--- a/base/applications/mspaint/imgarea.h
+++ b/base/applications/mspaint/imgarea.h
@@ -13,11 +13,7 @@
 class CImgAreaWindow : public CWindowImpl<CImgAreaWindow>
 {
 public:
-    CImgAreaWindow() : drawing(FALSE)
-    {
-    }
-
-    HWND DoCreate(HWND hwndParent);
+    CImgAreaWindow() : drawing(FALSE) { }
 
     BOOL drawing;
     void cancelDrawing();

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -215,6 +215,12 @@ _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nC
         return 1;
     }
 
+    // Initialize imageModel
+    imageModel.Crop(registrySettings.BMPWidth, registrySettings.BMPHeight);
+    if (__argc >= 2)
+        DoLoadImageFile(mainWindow, __targv[1], TRUE);
+    imageModel.ClearHistory();
+
     // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -100,12 +100,12 @@ BOOL CMainWindow::DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
 
         // Initializing the OPENFILENAME structure for GetOpenFileName
         ZeroMemory(&ofn, sizeof(ofn));
-        ofn.lStructSize    = sizeof(ofn);
-        ofn.hwndOwner      = m_hWnd;
-        ofn.hInstance      = hProgInstance;
-        ofn.lpstrFilter    = strFilter;
-        ofn.Flags          = OFN_EXPLORER | OFN_HIDEREADONLY;
-        ofn.lpstrDefExt    = L"png";
+        ofn.lStructSize = sizeof(ofn);
+        ofn.hwndOwner   = m_hWnd;
+        ofn.hInstance   = hProgInstance;
+        ofn.lpstrFilter = strFilter;
+        ofn.Flags       = OFN_EXPLORER | OFN_HIDEREADONLY;
+        ofn.lpstrDefExt = L"png";
     }
 
     ofn.lpstrFile = pszFile;
@@ -127,13 +127,13 @@ BOOL CMainWindow::DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
 
         // Initializing the OPENFILENAME structure for GetSaveFileName
         ZeroMemory(&sfn, sizeof(sfn));
-        sfn.lStructSize    = sizeof(sfn);
-        sfn.hwndOwner      = m_hWnd;
-        sfn.hInstance      = hProgInstance;
-        sfn.lpstrFilter    = strFilter;
-        sfn.Flags          = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_ENABLEHOOK;
-        sfn.lpfnHook       = OFNHookProc;
-        sfn.lpstrDefExt    = L"png";
+        sfn.lStructSize = sizeof(sfn);
+        sfn.hwndOwner   = m_hWnd;
+        sfn.hInstance   = hProgInstance;
+        sfn.lpstrFilter = strFilter;
+        sfn.Flags       = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_ENABLEHOOK;
+        sfn.lpfnHook    = OFNHookProc;
+        sfn.lpstrDefExt = L"png";
 
         // Choose PNG
         for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
@@ -164,9 +164,9 @@ BOOL CMainWindow::DoChooseColor(IN OUT COLORREF *prgbColor)
     {
         // Initializing the CHOOSECOLOR structure for ChooseColor
         ZeroMemory(&choosecolor, sizeof(choosecolor));
-        choosecolor.lStructSize    = sizeof(choosecolor);
-        choosecolor.hwndOwner      = m_hWnd;
-        choosecolor.lpCustColors   = custColors;
+        choosecolor.lStructSize  = sizeof(choosecolor);
+        choosecolor.hwndOwner    = m_hWnd;
+        choosecolor.lpCustColors = custColors;
     }
 
     choosecolor.rgbResult = *prgbColor;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -8,52 +8,22 @@
 
 #include "precomp.h"
 
-/* FUNCTIONS ********************************************************/
-
 POINT start;
 POINT last;
 
-ToolsModel toolsModel;
-
-SelectionModel selectionModel;
-
-PaletteModel paletteModel;
-
-RegistrySettings registrySettings;
-
-ImageModel imageModel;
 BOOL askBeforeEnlarging = FALSE;  // TODO: initialize from registry
-
-HWND hStatusBar;
-CHOOSECOLOR choosecolor;
-OPENFILENAME ofn;
-OPENFILENAME sfn;
-HICON hNontranspIcon;
-HICON hTranspIcon;
 
 HINSTANCE hProgInstance;
 
-TCHAR filepathname[1000];
+TCHAR filepathname[MAX_LONG_PATH];
 BOOL isAFile = FALSE;
 BOOL imageSaved = FALSE;
-int fileSize;
-int fileHPPM = 2834;
-int fileVPPM = 2834;
-SYSTEMTIME fileTime;
 
 BOOL showGrid = FALSE;
-BOOL showMiniature = FALSE;
 
 CMainWindow mainWindow;
-CFullscreenWindow fullscreenWindow;
-CMiniatureWindow miniature;
-CToolBox toolBoxContainer;
-CToolSettingsWindow toolSettingsWindow;
-CPaletteWindow paletteWindow;
-CCanvasWindow canvasWindow;
-CSelectionWindow selectionWindow;
-CImgAreaWindow imageArea;
-CTextEditWindow textEditWindow;
+
+/* FUNCTIONS ********************************************************/
 
 // get file name extension from filter string
 static BOOL
@@ -115,134 +85,165 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return 0;
 }
 
-/* entry point */
-
-int WINAPI
-_tWinMain (HINSTANCE hThisInstance, HINSTANCE hPrevInstance, LPTSTR lpszArgument, INT nCmdShow)
+BOOL CMainWindow::DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
 {
-    MSG messages;            /* Here messages to the application are saved */
+    static OPENFILENAME ofn = { 0 };
+    static CString strFilter;
 
-    HMENU menu;
-    HACCEL haccel;
+    if (ofn.lStructSize == 0)
+    {
+        // The "All Files" item text
+        CString strAllPictureFiles;
+        strAllPictureFiles.LoadString(hProgInstance, IDS_ALLPICTUREFILES);
 
-    TCHAR sfnFilename[1000];
-    TCHAR sfnFiletitle[256];
-    TCHAR ofnFilename[1000];
-    TCHAR ofnFiletitle[256];
-    static COLORREF custColors[16] = {
+        // Get the import filter
+        CSimpleArray<GUID> aguidFileTypesI;
+        CImage::GetImporterFilterString(strFilter, aguidFileTypesI, strAllPictureFiles,
+                                        CImage::excludeDefaultLoad, _T('\0'));
+
+        // Initializing the OPENFILENAME structure for GetOpenFileName
+        ZeroMemory(&ofn, sizeof(OPENFILENAME));
+        ofn.lStructSize    = sizeof(OPENFILENAME);
+        ofn.hwndOwner      = m_hWnd;
+        ofn.hInstance      = hProgInstance;
+        ofn.lpstrFilter    = strFilter;
+        ofn.Flags          = OFN_EXPLORER | OFN_HIDEREADONLY;
+        ofn.lpstrDefExt    = L"png";
+    }
+
+    ofn.lpstrFile = pszFile;
+    ofn.nMaxFile  = cchMaxFile;
+    return ::GetOpenFileName(&ofn);
+}
+
+BOOL CMainWindow::DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
+{
+    static OPENFILENAME sfn = { 0 };
+    static CString strFilter;
+
+    if (sfn.lStructSize == 0)
+    {
+        // Get the export filter
+        CSimpleArray<GUID> aguidFileTypesE;
+        CImage::GetExporterFilterString(strFilter, aguidFileTypesE, NULL,
+                                        CImage::excludeDefaultSave, _T('\0'));
+
+        // Initializing the OPENFILENAME structure for GetSaveFileName
+        ZeroMemory(&sfn, sizeof(OPENFILENAME));
+        sfn.lStructSize    = sizeof(OPENFILENAME);
+        sfn.hwndOwner      = m_hWnd;
+        sfn.hInstance      = hProgInstance;
+        sfn.lpstrFilter    = strFilter;
+        sfn.Flags          = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_ENABLEHOOK;
+        sfn.lpfnHook       = OFNHookProc;
+        sfn.lpstrDefExt    = L"png";
+
+        // Choose PNG
+        for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
+        {
+            if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)
+            {
+                sfn.nFilterIndex = i + 1;
+                break;
+            }
+        }
+    }
+
+    sfn.lpstrFile = pszFile;
+    sfn.nMaxFile  = cchMaxFile;
+    return ::GetSaveFileName(&sfn);
+}
+
+BOOL CMainWindow::DoChooseColor(IN OUT COLORREF *prgbColor)
+{
+    static CHOOSECOLOR choosecolor = { 0 };
+    static COLORREF custColors[16] =
+    {
         0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff,
         0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff, 0xffffff
     };
 
+    if (choosecolor.lStructSize == 0)
+    {
+        // Initializing the CHOOSECOLOR structure for ChooseColor
+        ZeroMemory(&choosecolor, sizeof(choosecolor));
+        choosecolor.lStructSize    = sizeof(CHOOSECOLOR);
+        choosecolor.hwndOwner      = m_hWnd;
+        choosecolor.lpCustColors   = custColors;
+    }
+
+    choosecolor.rgbResult = *prgbColor;
+    if (!::ChooseColor(&choosecolor))
+        return FALSE;
+
+    *prgbColor = choosecolor.rgbResult;
+    return TRUE;
+}
+
+HWND CMainWindow::DoCreate()
+{
+    ::LoadString(hProgInstance, IDS_DEFAULTFILENAME, filepathname, _countof(filepathname));
+
+    CString strTitle;
+    strTitle.Format(IDS_WINDOWTITLE, PathFindFileName(filepathname));
+
+    RECT& rc = registrySettings.WindowPlacement.rcNormalPosition;
+    return Create(HWND_DESKTOP, rc, strTitle, WS_OVERLAPPEDWINDOW, WS_EX_ACCEPTFILES);
+}
+
+// entry point
+INT WINAPI
+_tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdLine, INT nCmdShow)
+{
 #ifdef _DEBUG
-    /* Report any memory leaks on exit */
+    // Report any memory leaks on exit
     _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
 #endif
 
-    hProgInstance = hThisInstance;
+    hProgInstance = hInstance;
 
-    /* initialize common controls library */
+    // Initialize common controls library
     INITCOMMONCONTROLSEX iccx;
     iccx.dwSize = sizeof(iccx);
     iccx.dwICC = ICC_STANDARD_CLASSES | ICC_USEREX_CLASSES | ICC_BAR_CLASSES;
     InitCommonControlsEx(&iccx);
 
-    /* load settings from registry */
+    // Load settings from registry
     registrySettings.Load(nCmdShow);
-    showMiniature = registrySettings.ShowThumbnail;
-    ::LoadString(hThisInstance, IDS_DEFAULTFILENAME, filepathname, _countof(filepathname));
 
     // Create the main window
-    mainWindow.DoCreate();
-
-    /* loading and setting the window menu from resource */
-    menu = LoadMenu(hThisInstance, MAKEINTRESOURCE(ID_MENU));
-    mainWindow.SetMenu(menu);
-
-    // Load the access keys
-    haccel = ::LoadAccelerators(hThisInstance, MAKEINTRESOURCE(800));
-
-    /* initializing the CHOOSECOLOR structure for use with ChooseColor */
-    ZeroMemory(&choosecolor, sizeof(choosecolor));
-    choosecolor.lStructSize    = sizeof(CHOOSECOLOR);
-    choosecolor.hwndOwner      = mainWindow;
-    choosecolor.rgbResult      = 0x00ffffff;
-    choosecolor.lpCustColors   = custColors;
-
-    /* initializing the OPENFILENAME structure for use with GetOpenFileName and GetSaveFileName */
-    ofnFilename[0] = 0;
-    CString strImporters;
-    CSimpleArray<GUID> aguidFileTypesI;
-    CString strAllPictureFiles;
-    strAllPictureFiles.LoadString(hThisInstance, IDS_ALLPICTUREFILES);
-    CImage::GetImporterFilterString(strImporters, aguidFileTypesI, strAllPictureFiles, CImage::excludeDefaultLoad, _T('\0'));
-//     CAtlStringW strAllFiles;
-//     strAllFiles.LoadString(hThisInstance, IDS_ALLFILES);
-//     strImporters = strAllFiles + CAtlStringW(_T("|*.*|")).Replace('|', '\0') + strImporters;
-    ZeroMemory(&ofn, sizeof(OPENFILENAME));
-    ofn.lStructSize    = sizeof(OPENFILENAME);
-    ofn.hwndOwner      = mainWindow;
-    ofn.hInstance      = hThisInstance;
-    ofn.lpstrFilter    = strImporters;
-    ofn.lpstrFile      = ofnFilename;
-    ofn.nMaxFile       = _countof(ofnFilename);
-    ofn.lpstrFileTitle = ofnFiletitle;
-    ofn.nMaxFileTitle  = _countof(ofnFiletitle);
-    ofn.Flags          = OFN_EXPLORER | OFN_HIDEREADONLY;
-    ofn.lpstrDefExt    = L"png";
-
-    CopyMemory(sfnFilename, filepathname, sizeof(filepathname));
-    CString strExporters;
-    CSimpleArray<GUID> aguidFileTypesE;
-    CImage::GetExporterFilterString(strExporters, aguidFileTypesE, NULL, CImage::excludeDefaultSave, _T('\0'));
-    ZeroMemory(&sfn, sizeof(OPENFILENAME));
-    sfn.lStructSize    = sizeof(OPENFILENAME);
-    sfn.hwndOwner      = mainWindow;
-    sfn.hInstance      = hThisInstance;
-    sfn.lpstrFilter    = strExporters;
-    sfn.lpstrFile      = sfnFilename;
-    sfn.nMaxFile       = _countof(sfnFilename);
-    sfn.lpstrFileTitle = sfnFiletitle;
-    sfn.nMaxFileTitle  = _countof(sfnFiletitle);
-    sfn.Flags          = OFN_EXPLORER | OFN_OVERWRITEPROMPT | OFN_HIDEREADONLY | OFN_EXPLORER | OFN_ENABLEHOOK;
-    sfn.lpfnHook       = OFNHookProc;
-    sfn.lpstrDefExt    = L"png";
-    // Choose PNG
-    for (INT i = 0; i < aguidFileTypesE.GetSize(); ++i)
+    if (!mainWindow.DoCreate())
     {
-        if (aguidFileTypesE[i] == Gdiplus::ImageFormatPNG)
-        {
-            sfn.nFilterIndex = i + 1;
-            break;
-        }
+        MessageBox(NULL, TEXT("Failed to create main window."), NULL, MB_ICONERROR);
+        return 1;
     }
 
-    /* placing the size boxes around the image */
-    imageArea.SendMessage(WM_SIZE, 0, 0);
-
-    /* Make the window visible on the screen */
+    // Make the window visible on the screen
     mainWindow.ShowWindow(registrySettings.WindowPlacement.showCmd);
 
-    /* Run the message loop. It will run until GetMessage() returns 0 */
-    while (GetMessage(&messages, NULL, 0, 0))
+    // Load the access keys
+    HACCEL hAccel = ::LoadAccelerators(hInstance, MAKEINTRESOURCE(800));
+
+    // The message loop
+    MSG msg;
+    while (::GetMessage(&msg, NULL, 0, 0))
     {
-        if (fontsDialog.IsWindow() && IsDialogMessage(fontsDialog, &messages))
+        if (fontsDialog.IsWindow() && fontsDialog.IsDialogMessage(&msg))
             continue;
 
-        if (TranslateAccelerator(mainWindow, haccel, &messages))
+        if (::TranslateAccelerator(mainWindow, hAccel, &msg))
             continue;
 
-        /* Translate virtual-key messages into character messages */
-        TranslateMessage(&messages);
-        /* Send message to WindowProcedure */
-        DispatchMessage(&messages);
+        ::TranslateMessage(&msg);
+        ::DispatchMessage(&msg);
     }
 
-    ::DestroyAcceleratorTable(haccel);
+    // Unload the access keys
+    ::DestroyAcceleratorTable(hAccel);
 
     // Write back settings to registry
     registrySettings.Store();
 
-    // The value that PostQuitMessage() gave
-    return (INT)messages.wParam;
+    // Return the value that PostQuitMessage() gave
+    return (INT)msg.wParam;
 }

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -12,13 +12,10 @@ POINT start;
 POINT last;
 
 BOOL askBeforeEnlarging = FALSE;  // TODO: initialize from registry
-
-HINSTANCE hProgInstance;
-
-TCHAR filepathname[MAX_LONG_PATH];
+HINSTANCE hProgInstance = NULL;
+TCHAR filepathname[MAX_LONG_PATH] = { 0 };
 BOOL isAFile = FALSE;
 BOOL imageSaved = FALSE;
-
 BOOL showGrid = FALSE;
 
 CMainWindow mainWindow;

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -82,7 +82,7 @@ OFNHookProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return 0;
 }
 
-BOOL CMainWindow::DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
+BOOL CMainWindow::GetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
 {
     static OPENFILENAME ofn = { 0 };
     static CString strFilter;
@@ -113,7 +113,7 @@ BOOL CMainWindow::DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
     return ::GetOpenFileName(&ofn);
 }
 
-BOOL CMainWindow::DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
+BOOL CMainWindow::GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
 {
     static OPENFILENAME sfn = { 0 };
     static CString strFilter;
@@ -151,7 +151,7 @@ BOOL CMainWindow::DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
     return ::GetSaveFileName(&sfn);
 }
 
-BOOL CMainWindow::DoChooseColor(IN OUT COLORREF *prgbColor)
+BOOL CMainWindow::ChooseColor(IN OUT COLORREF *prgbColor)
 {
     static CHOOSECOLOR choosecolor = { 0 };
     static COLORREF custColors[16] =

--- a/base/applications/mspaint/main.cpp
+++ b/base/applications/mspaint/main.cpp
@@ -99,8 +99,8 @@ BOOL CMainWindow::DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
                                         CImage::excludeDefaultLoad, _T('\0'));
 
         // Initializing the OPENFILENAME structure for GetOpenFileName
-        ZeroMemory(&ofn, sizeof(OPENFILENAME));
-        ofn.lStructSize    = sizeof(OPENFILENAME);
+        ZeroMemory(&ofn, sizeof(ofn));
+        ofn.lStructSize    = sizeof(ofn);
         ofn.hwndOwner      = m_hWnd;
         ofn.hInstance      = hProgInstance;
         ofn.lpstrFilter    = strFilter;
@@ -126,8 +126,8 @@ BOOL CMainWindow::DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile)
                                         CImage::excludeDefaultSave, _T('\0'));
 
         // Initializing the OPENFILENAME structure for GetSaveFileName
-        ZeroMemory(&sfn, sizeof(OPENFILENAME));
-        sfn.lStructSize    = sizeof(OPENFILENAME);
+        ZeroMemory(&sfn, sizeof(sfn));
+        sfn.lStructSize    = sizeof(sfn);
         sfn.hwndOwner      = m_hWnd;
         sfn.hInstance      = hProgInstance;
         sfn.lpstrFilter    = strFilter;
@@ -164,7 +164,7 @@ BOOL CMainWindow::DoChooseColor(IN OUT COLORREF *prgbColor)
     {
         // Initializing the CHOOSECOLOR structure for ChooseColor
         ZeroMemory(&choosecolor, sizeof(choosecolor));
-        choosecolor.lStructSize    = sizeof(CHOOSECOLOR);
+        choosecolor.lStructSize    = sizeof(choosecolor);
         choosecolor.hwndOwner      = m_hWnd;
         choosecolor.lpCustColors   = custColors;
     }

--- a/base/applications/mspaint/miniature.cpp
+++ b/base/applications/mspaint/miniature.cpp
@@ -13,6 +13,24 @@
 
 /* FUNCTIONS ********************************************************/
 
+HWND CMiniatureWindow::DoCreate(HWND hwndParent)
+{
+    if (m_hWnd)
+        return m_hWnd;
+
+    RECT rc =
+    {
+        (LONG)registrySettings.ThumbXPos,
+        (LONG)registrySettings.ThumbYPos,
+        (LONG)(registrySettings.ThumbXPos + registrySettings.ThumbWidth),
+        (LONG)(registrySettings.ThumbYPos + registrySettings.ThumbHeight)
+    };
+    TCHAR miniaturetitle[100];
+    LoadString(hProgInstance, IDS_MINIATURETITLE, miniaturetitle, _countof(miniaturetitle));
+    DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME;
+    return Create(hwndParent, rc, miniaturetitle, style, WS_EX_PALETTEWINDOW);
+}
+
 LRESULT CMiniatureWindow::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     miniature.ShowWindow(SW_HIDE);

--- a/base/applications/mspaint/miniature.cpp
+++ b/base/applications/mspaint/miniature.cpp
@@ -7,9 +7,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+CMiniatureWindow miniature;
 
 /* FUNCTIONS ********************************************************/
 
@@ -20,21 +20,22 @@ HWND CMiniatureWindow::DoCreate(HWND hwndParent)
 
     RECT rc =
     {
-        (LONG)registrySettings.ThumbXPos,
-        (LONG)registrySettings.ThumbYPos,
+        (LONG)registrySettings.ThumbXPos, (LONG)registrySettings.ThumbYPos,
         (LONG)(registrySettings.ThumbXPos + registrySettings.ThumbWidth),
         (LONG)(registrySettings.ThumbYPos + registrySettings.ThumbHeight)
     };
-    TCHAR miniaturetitle[100];
-    LoadString(hProgInstance, IDS_MINIATURETITLE, miniaturetitle, _countof(miniaturetitle));
+
+    TCHAR strTitle[100];
+    ::LoadString(hProgInstance, IDS_MINIATURETITLE, strTitle, _countof(strTitle));
+
     DWORD style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_THICKFRAME;
-    return Create(hwndParent, rc, miniaturetitle, style, WS_EX_PALETTEWINDOW);
+    return Create(hwndParent, rc, strTitle, style, WS_EX_PALETTEWINDOW);
 }
 
 LRESULT CMiniatureWindow::OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    miniature.ShowWindow(SW_HIDE);
-    showMiniature = FALSE;
+    ShowWindow(SW_HIDE);
+    registrySettings.ShowThumbnail = FALSE;
     return 0;
 }
 

--- a/base/applications/mspaint/miniature.h
+++ b/base/applications/mspaint/miniature.h
@@ -19,6 +19,9 @@ public:
         MESSAGE_HANDLER(WM_PAINT, OnPaint)
     END_MSG_MAP()
 
+    HWND DoCreate(HWND hwndParent);
+
+private:
     LRESULT OnClose(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaint(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnSetCursor(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -17,6 +17,8 @@
 #define COLOR_COUNT         28
 #define HALF_COLOR_COUNT    (COLOR_COUNT / 2)
 
+CPaletteWindow paletteWindow;
+
 /* FUNCTIONS ********************************************************/
 
 static VOID drawColorBox(HDC hDC, LPCRECT prc, COLORREF rgbColor, UINT nBorder)
@@ -144,10 +146,11 @@ LRESULT CPaletteWindow::OnRButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, B
 LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-    if (iColor != -1 && ChooseColor(&choosecolor))
+    COLORREF rgbColor = paletteModel.GetFgColor();
+    if (iColor != -1 && mainWindow.DoChooseColor(&rgbColor))
     {
-        paletteModel.SetColor(iColor, choosecolor.rgbResult);
-        paletteModel.SetFgColor(choosecolor.rgbResult);
+        paletteModel.SetColor(iColor, rgbColor);
+        paletteModel.SetFgColor(rgbColor);
     }
     return 0;
 }
@@ -155,10 +158,11 @@ LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam,
 LRESULT CPaletteWindow::OnRButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
-    if (iColor != -1 && ChooseColor(&choosecolor))
+    COLORREF rgbColor = paletteModel.GetBgColor();
+    if (iColor != -1 && mainWindow.DoChooseColor(&rgbColor))
     {
-        paletteModel.SetColor(iColor, choosecolor.rgbResult);
-        paletteModel.SetBgColor(choosecolor.rgbResult);
+        paletteModel.SetColor(iColor, rgbColor);
+        paletteModel.SetBgColor(rgbColor);
     }
     return 0;
 }

--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -147,7 +147,7 @@ LRESULT CPaletteWindow::OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam,
 {
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     COLORREF rgbColor = paletteModel.GetFgColor();
-    if (iColor != -1 && mainWindow.DoChooseColor(&rgbColor))
+    if (iColor != -1 && mainWindow.ChooseColor(&rgbColor))
     {
         paletteModel.SetColor(iColor, rgbColor);
         paletteModel.SetFgColor(rgbColor);
@@ -159,7 +159,7 @@ LRESULT CPaletteWindow::OnRButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam,
 {
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     COLORREF rgbColor = paletteModel.GetBgColor();
-    if (iColor != -1 && mainWindow.DoChooseColor(&rgbColor))
+    if (iColor != -1 && mainWindow.ChooseColor(&rgbColor))
     {
         paletteModel.SetColor(iColor, rgbColor);
         paletteModel.SetBgColor(rgbColor);

--- a/base/applications/mspaint/palettemodel.cpp
+++ b/base/applications/mspaint/palettemodel.cpp
@@ -7,9 +7,9 @@
  *              Katayama Hirofumi MZ
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+PaletteModel paletteModel;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -31,38 +31,13 @@
     #include <crtdbg.h>
 #endif
 
-#define NDEBUG
 #include <debug.h>
 
-#define WM_TOOLSMODELTOOLCHANGED         (WM_APP + 0)
-#define WM_TOOLSMODELSETTINGSCHANGED     (WM_APP + 1)
-#define WM_TOOLSMODELZOOMCHANGED         (WM_APP + 2)
-#define WM_PALETTEMODELCOLORCHANGED      (WM_APP + 3)
-#define WM_PALETTEMODELPALETTECHANGED    (WM_APP + 4)
-#define WM_IMAGEMODELDIMENSIONSCHANGED   (WM_APP + 5)
-#define WM_IMAGEMODELIMAGECHANGED        (WM_APP + 6)
-#define WM_SELECTIONMODELREFRESHNEEDED   (WM_APP + 7)
-
-enum CANVAS_HITTEST // hit
-{
-    HIT_NONE = 0, // Nothing hit or outside
-    HIT_UPPER_LEFT,
-    HIT_UPPER_CENTER,
-    HIT_UPPER_RIGHT,
-    HIT_MIDDLE_LEFT,
-    HIT_MIDDLE_RIGHT,
-    HIT_LOWER_LEFT,
-    HIT_LOWER_CENTER,
-    HIT_LOWER_RIGHT,
-    HIT_BORDER,
-    HIT_INNER,
-};
-
 #include "resource.h"
+#include "common.h"
 #include "drawing.h"
 #include "dib.h"
 #include "fullscreen.h"
-#include "globalvar.h"
 #include "history.h"
 #include "imgarea.h"
 #include "miniature.h"
@@ -79,6 +54,6 @@ enum CANVAS_HITTEST // hit
 #include "toolsmodel.h"
 #include "winproc.h"
 #include "dialogs.h"
-#include "common.h"
+#include "globalvar.h"
 
 #endif /* _MSPAINT_H */

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -6,8 +6,6 @@
     #undef _DEBUG
 #endif
 
-#define MSPAINT /* This macro extends ATL CImage (ReactOS-specific hack) */
-
 #include <windef.h>
 #include <winbase.h>
 #include <winuser.h>
@@ -26,6 +24,7 @@
 #include <stdlib.h>
 #include <shellapi.h>
 #include <htmlhelp.h>
+#include "atlimagedx.h"
 #ifdef _DEBUG
     #define _CRTDBG_MAP_ALLOC
     #include <crtdbg.h>

--- a/base/applications/mspaint/precomp.h
+++ b/base/applications/mspaint/precomp.h
@@ -6,7 +6,7 @@
     #undef _DEBUG
 #endif
 
-#include <stdarg.h>
+#define MSPAINT /* This macro extends ATL CImage (ReactOS-specific hack) */
 
 #include <windef.h>
 #include <winbase.h>

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -7,14 +7,15 @@
  *              Katayama Hirofumi MZ
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
 #include <winreg.h>
 #include <wincon.h>
 #include <shlobj.h>
 
+RegistrySettings registrySettings;
+
 /* FUNCTIONS ********************************************************/
+
 static void ReadDWORD(CRegKey &key, LPCTSTR lpName, DWORD &dwValue)
 {
     DWORD dwTemp;
@@ -161,7 +162,6 @@ void RegistrySettings::Load(INT nCmdShow)
 
 void RegistrySettings::Store()
 {
-    ShowThumbnail = showMiniature;
     BMPWidth = imageModel.GetWidth();
     BMPHeight = imageModel.GetHeight();
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -161,6 +161,10 @@ void RegistrySettings::Load(INT nCmdShow)
 
 void RegistrySettings::Store()
 {
+    ShowThumbnail = showMiniature;
+    BMPWidth = imageModel.GetWidth();
+    BMPHeight = imageModel.GetHeight();
+
     CRegKey paint;
     if (paint.Create(HKEY_CURRENT_USER, _T("Software\\Microsoft\\Windows\\CurrentVersion\\Applets\\Paint")) != ERROR_SUCCESS)
         return;

--- a/base/applications/mspaint/selection.cpp
+++ b/base/applications/mspaint/selection.cpp
@@ -7,9 +7,9 @@
  *              Katayama Hirofumi MZ
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+CSelectionWindow selectionWindow;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/selectionmodel.cpp
+++ b/base/applications/mspaint/selectionmodel.cpp
@@ -7,9 +7,9 @@
  *              Katayama Hirofumi MZ
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+SelectionModel selectionModel;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/textedit.cpp
+++ b/base/applications/mspaint/textedit.cpp
@@ -6,11 +6,11 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
 
 #define CXY_GRIP 3
+
+CTextEditWindow textEditWindow;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -7,9 +7,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+CToolBox toolBoxContainer;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -24,11 +24,12 @@
 
 static const BYTE s_AirRadius[4] = { 5, 8, 3, 12 };
 
+CToolSettingsWindow toolSettingsWindow;
+
 /* FUNCTIONS ********************************************************/
 
 BOOL CToolSettingsWindow::DoCreate(HWND hwndParent)
 {
-    /* creating the tool settings child window */
     RECT toolSettingsWindowPos =
     {
         X_TOOLSETTINGS, Y_TOOLSETTINGS,

--- a/base/applications/mspaint/toolsmodel.cpp
+++ b/base/applications/mspaint/toolsmodel.cpp
@@ -6,9 +6,9 @@
  * PROGRAMMERS: Benedikt Freisen
  */
 
-/* INCLUDES *********************************************************/
-
 #include "precomp.h"
+
+ToolsModel toolsModel;
 
 /* FUNCTIONS ********************************************************/
 

--- a/base/applications/mspaint/toolsmodel.h
+++ b/base/applications/mspaint/toolsmodel.h
@@ -120,3 +120,15 @@ public:
     void NotifyToolSettingsChanged();
     void NotifyZoomChanged();
 };
+
+extern ToolsModel toolsModel;
+
+static inline int Zoomed(int xy)
+{
+    return xy * toolsModel.GetZoom() / 1000;
+}
+
+static inline int UnZoomed(int xy)
+{
+    return xy * 1000 / toolsModel.GetZoom();
+}

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -123,7 +123,7 @@ void CMainWindow::saveImage(BOOL overwrite)
     {
         imageModel.SaveImage(filepathname);
     }
-    else if (DoGetSaveFileName(filepathname, _countof(filepathname)))
+    else if (GetSaveFileName(filepathname, _countof(filepathname)))
     {
         imageModel.SaveImage(filepathname);
 
@@ -544,7 +544,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_FILEOPEN:
             {
                 TCHAR szFileName[MAX_LONG_PATH] = _T("");
-                if (ConfirmSave() && DoGetOpenFileName(szFileName, _countof(szFileName)))
+                if (ConfirmSave() && GetOpenFileName(szFileName, _countof(szFileName)))
                 {
                     DoLoadImageFile(m_hWnd, szFileName, TRUE);
                 }
@@ -691,14 +691,14 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_EDITCOPYTO:
         {
             TCHAR szFileName[MAX_LONG_PATH] = _T("");
-            if (DoGetSaveFileName(szFileName, _countof(szFileName)))
+            if (GetSaveFileName(szFileName, _countof(szFileName)))
                 SaveDIBToFile(selectionModel.GetBitmap(), szFileName, imageModel.GetDC());
             break;
         }
         case IDM_EDITPASTEFROM:
         {
             TCHAR szFileName[MAX_LONG_PATH] = _T("");
-            if (DoGetOpenFileName(szFileName, _countof(szFileName)))
+            if (GetOpenFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmNew = DoLoadImageFile(m_hWnd, szFileName, FALSE);
                 if (hbmNew)
@@ -712,7 +712,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         case IDM_COLORSEDITPALETTE:
         {
             COLORREF rgbColor = paletteModel.GetFgColor();
-            if (DoChooseColor(&rgbColor))
+            if (ChooseColor(&rgbColor))
                 paletteModel.SetFgColor(rgbColor);
             break;
         }

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -691,8 +691,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITCOPYTO:
         {
-            TCHAR szFileName[MAX_LONG_PATH];
-            szFileName[0] = 0;
+            TCHAR szFileName[MAX_LONG_PATH] = _T("");
             if (DoGetSaveFileName(szFileName, _countof(szFileName)))
                 SaveDIBToFile(selectionModel.GetBitmap(), szFileName, imageModel.GetDC());
             break;

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -289,12 +289,6 @@ LRESULT CMainWindow::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
         miniature.ShowWindow(SW_SHOWNOACTIVATE);
     }
 
-    // Initialize imageModel
-    imageModel.Crop(registrySettings.BMPWidth, registrySettings.BMPHeight);
-    if (__argc >= 2)
-        DoLoadImageFile(m_hWnd, __targv[1], TRUE);
-    imageModel.ClearHistory();
-
     // Set icon
     SendMessage(WM_SETICON, ICON_BIG, (LPARAM) LoadIcon(hProgInstance, MAKEINTRESOURCE(IDI_APPICON)));
     SendMessage(WM_SETICON, ICON_SMALL, (LPARAM) LoadIcon(hProgInstance, MAKEINTRESOURCE(IDI_APPICON)));

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -543,8 +543,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
             break;
         case IDM_FILEOPEN:
             {
-                TCHAR szFileName[MAX_LONG_PATH];
-                szFileName[0] = 0;
+                TCHAR szFileName[MAX_LONG_PATH] = _T("");
                 if (ConfirmSave() && DoGetOpenFileName(szFileName, _countof(szFileName)))
                 {
                     DoLoadImageFile(m_hWnd, szFileName, TRUE);

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -698,8 +698,7 @@ LRESULT CMainWindow::OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bH
         }
         case IDM_EDITPASTEFROM:
         {
-            TCHAR szFileName[MAX_LONG_PATH];
-            szFileName[0] = 0;
+            TCHAR szFileName[MAX_LONG_PATH] = _T("");
             if (DoGetOpenFileName(szFileName, _countof(szFileName)))
             {
                 HBITMAP hbmNew = DoLoadImageFile(m_hWnd, szFileName, FALSE);

--- a/base/applications/mspaint/winproc.h
+++ b/base/applications/mspaint/winproc.h
@@ -31,9 +31,9 @@ public:
     CMainWindow() : m_hMenu(NULL) { }
 
     HWND DoCreate();
-    BOOL DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
-    BOOL DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
-    BOOL DoChooseColor(IN OUT COLORREF *prgbColor);
+    BOOL GetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
+    BOOL GetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
+    BOOL ChooseColor(IN OUT COLORREF *prgbColor);
 
 private:
     HMENU m_hMenu;

--- a/base/applications/mspaint/winproc.h
+++ b/base/applications/mspaint/winproc.h
@@ -28,9 +28,16 @@ public:
         MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel)
     END_MSG_MAP()
 
+    CMainWindow() : m_hMenu(NULL) { }
+
     HWND DoCreate();
+    BOOL DoGetOpenFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
+    BOOL DoGetSaveFileName(IN OUT LPTSTR pszFile, INT cchMaxFile);
+    BOOL DoChooseColor(IN OUT COLORREF *prgbColor);
 
 private:
+    HMENU m_hMenu;
+
     LRESULT OnDropFiles(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnDestroy(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/winproc.h
+++ b/base/applications/mspaint/winproc.h
@@ -28,6 +28,8 @@ public:
         MESSAGE_HANDLER(WM_MOUSEWHEEL, OnMouseWheel)
     END_MSG_MAP()
 
+    HWND DoCreate();
+
 private:
     LRESULT OnDropFiles(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -374,11 +374,7 @@ public:
         return m_hbm == NULL;
     }
 
-#ifdef MSPAINT
-    HRESULT Load(LPCTSTR pszFileName, float *pxDpi = NULL, float *pyDpi = NULL) throw()
-#else
     HRESULT Load(LPCTSTR pszFileName) throw()
-#endif
     {
         // convert the file name string into Unicode
         CStringW pszNameW(pszFileName);
@@ -392,18 +388,6 @@ public:
         }
 
         // TODO & FIXME: get parameters (m_rgbTransColor etc.)
-#ifdef MSPAINT
-        if (pxDpi)
-        {
-            *pxDpi = 96;
-            GetCommon().GetImageHorizontalResolution((GpImage*)pBitmap, pxDpi);
-        }
-        if (pyDpi)
-        {
-            *pyDpi = 96;
-            GetCommon().GetImageVerticalResolution((GpImage*)pBitmap, pyDpi);
-        }
-#endif
 
         // get bitmap handle
         HBITMAP hbm = NULL;
@@ -560,13 +544,8 @@ public:
         return (status == Ok ? S_OK : E_FAIL);
     }
 
-#ifdef MSPAINT
-    HRESULT Save(LPCTSTR pszFileName, REFGUID guidFileType = GUID_NULL,
-                 const float *pxDpi = NULL, const float *pyDpi = NULL) const throw()
-#else
     HRESULT Save(LPCTSTR pszFileName,
                  REFGUID guidFileType = GUID_NULL) const throw()
-#endif
     {
         using namespace Gdiplus;
         ATLASSERT(m_hbm);
@@ -592,11 +571,6 @@ public:
         // create a GpBitmap from HBITMAP
         GpBitmap *pBitmap = NULL;
         GetCommon().CreateBitmapFromHBITMAP(m_hbm, NULL, &pBitmap);
-
-#ifdef MSPAINT
-        if (pxDpi && pyDpi)
-            GetCommon().BitmapSetResolution(pBitmap, *pxDpi, *pyDpi);
-#endif
 
         // save to file
         Status status;
@@ -855,20 +829,20 @@ protected:
         }
     };
 
+    // abbreviations of GDI+ basic types
+    typedef Gdiplus::GpStatus St;
+    typedef Gdiplus::ImageCodecInfo ICI;
+    typedef Gdiplus::GpBitmap Bm;
+    typedef Gdiplus::EncoderParameters EncParams;
+    typedef Gdiplus::GpImage Im;
+    typedef Gdiplus::ARGB ARGB;
+    typedef HBITMAP HBM;
+    typedef Gdiplus::GdiplusStartupInput GSI;
+    typedef Gdiplus::GdiplusStartupOutput GSO;
+
     // The common data of atlimage
     struct COMMON
     {
-        // abbreviations of GDI+ basic types
-        typedef Gdiplus::GpStatus St;
-        typedef Gdiplus::ImageCodecInfo ICI;
-        typedef Gdiplus::GpBitmap Bm;
-        typedef Gdiplus::EncoderParameters EncParams;
-        typedef Gdiplus::GpImage Im;
-        typedef Gdiplus::ARGB ARGB;
-        typedef HBITMAP HBM;
-        typedef Gdiplus::GdiplusStartupInput GSI;
-        typedef Gdiplus::GdiplusStartupOutput GSO;
-
         // GDI+ function types
 #undef API
 #undef CST
@@ -887,11 +861,6 @@ protected:
         typedef St (API *SAVEIMAGETOFILE)(Im *, CST WCHAR *, CST CLSID *,
                                           CST EncParams *);
         typedef St (API *DISPOSEIMAGE)(Im*);
-#ifdef MSPAINT
-        typedef St (API *GETIMAGEHORIZONTALRESOLUTION)(Im *, float*);
-        typedef St (API *GETIMAGEVERTICALRESOLUTION)(Im *, float*);
-        typedef St (API *BITMAPSETRESOLUTION)(Bm *, float, float);
-#endif
 #undef API
 #undef CST
 
@@ -912,11 +881,6 @@ protected:
         SAVEIMAGETOSTREAM       SaveImageToStream;
         SAVEIMAGETOFILE         SaveImageToFile;
         DISPOSEIMAGE            DisposeImage;
-#ifdef MSPAINT
-        GETIMAGEHORIZONTALRESOLUTION    GetImageHorizontalResolution;
-        GETIMAGEVERTICALRESOLUTION      GetImageVerticalResolution;
-        BITMAPSETRESOLUTION             BitmapSetResolution;
-#endif
 
         COMMON()
         {
@@ -933,11 +897,6 @@ protected:
             SaveImageToStream = NULL;
             SaveImageToFile = NULL;
             DisposeImage = NULL;
-#ifdef MSPAINT
-            GetImageHorizontalResolution = NULL;
-            GetImageVerticalResolution = NULL;
-            BitmapSetResolution = NULL;
-#endif
         }
         ~COMMON()
         {
@@ -986,11 +945,6 @@ protected:
                 AddrOf<SAVEIMAGETOSTREAM>("GdipSaveImageToStream");
             SaveImageToFile = AddrOf<SAVEIMAGETOFILE>("GdipSaveImageToFile");
             DisposeImage = AddrOf<DISPOSEIMAGE>("GdipDisposeImage");
-#ifdef MSPAINT
-            GetImageHorizontalResolution = AddrOf<GETIMAGEHORIZONTALRESOLUTION>("GdipGetImageHorizontalResolution");
-            GetImageVerticalResolution = AddrOf<GETIMAGEVERTICALRESOLUTION>("GdipGetImageVerticalResolution");
-            BitmapSetResolution = AddrOf<BITMAPSETRESOLUTION>("GdipBitmapSetResolution");
-#endif
 
             if (hinstGdiPlus && Startup)
             {
@@ -1017,11 +971,6 @@ protected:
                 SaveImageToStream = NULL;
                 SaveImageToFile = NULL;
                 DisposeImage = NULL;
-#ifdef MSPAINT
-                GetImageHorizontalResolution = NULL;
-                GetImageVerticalResolution = NULL;
-                BitmapSetResolution = NULL;
-#endif
                 ::FreeLibrary(hinstGdiPlus);
                 hinstGdiPlus = NULL;
             }

--- a/sdk/lib/atl/atlimage.h
+++ b/sdk/lib/atl/atlimage.h
@@ -831,18 +831,20 @@ protected:
 
     // abbreviations of GDI+ basic types
     typedef Gdiplus::GpStatus St;
-    typedef Gdiplus::ImageCodecInfo ICI;
     typedef Gdiplus::GpBitmap Bm;
-    typedef Gdiplus::EncoderParameters EncParams;
     typedef Gdiplus::GpImage Im;
-    typedef Gdiplus::ARGB ARGB;
-    typedef HBITMAP HBM;
-    typedef Gdiplus::GdiplusStartupInput GSI;
-    typedef Gdiplus::GdiplusStartupOutput GSO;
 
     // The common data of atlimage
     struct COMMON
     {
+        // abbreviations of GDI+ basic types
+        typedef Gdiplus::ImageCodecInfo ICI;
+        typedef Gdiplus::EncoderParameters EncParams;
+        typedef Gdiplus::ARGB ARGB;
+        typedef HBITMAP HBM;
+        typedef Gdiplus::GdiplusStartupInput GSI;
+        typedef Gdiplus::GdiplusStartupOutput GSO;
+
         // GDI+ function types
 #undef API
 #undef CST


### PR DESCRIPTION
## Purpose
Improve source code quality.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Add `CFullscreenWindow::DoCreate`, `CMiniatureWindow::DoCreate`, and `CMainWindow::DoCreate` helper functions.
- Encapsulation around `mainWindow` and `_tWinMain`.
- Add `CMainWindow::GetOpenFileName`, `CMainWindow::GetSaveFileName`, and `CMainWindow::ChooseColor` helper functions (optimized for startup).
- Move some code in `WinMain` into `CMainWindow::OnCreate`.
- Delay creation of `CFullscreenWindow` and `CMiniatureWindow` (optimized for startup and memory usage).
- Add `atlimagedx.h` in `mspaint`.
- Extend ATL `CImage` class as `CImageDx` in `mspaint`.

## Comparison

Memory usage (BEFORE):
![before](https://user-images.githubusercontent.com/2107452/226769976-bf5557d1-40d5-4b7c-88aa-27668997d3fc.png)

Memory usage (AFTER):
![after](https://user-images.githubusercontent.com/2107452/226770072-cdef791b-dcc3-4204-b694-945e816d6340.png)

## TODO

- [x] Do tests.