### PR TITLE
[COMCTL32][USER32] EDIT: Half-implement WM_IME_SETCONTEXT handling

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -45,6 +45,9 @@
 #include "wingdi.h"
 #include "winuser.h"
 #include "imm.h"
+#ifdef __REACTOS__
+    #include <immdev.h>
+#endif
 #include "usp10.h"
 #include "commctrl.h"
 #include "uxtheme.h"
@@ -4973,6 +4976,26 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 
     /* IME messages to make the edit control IME aware */
     case WM_IME_SETCONTEXT:
+#ifdef __REACTOS__
+        if (FALSE) /* FIXME: Condition */
+            lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
+
+        if (wParam)
+        {
+            HIMC hIMC = ImmGetContext(hwnd);
+            LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
+            if (pIC)
+            {
+                pIC->dwUIFlags &= ~0x40000;
+                ImmUnlockIMC(hIMC);
+            }
+            if (FALSE) /* FIXME: Condition */
+                ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+            ImmReleaseContext(hwnd, hIMC);
+        }
+
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         break;
 
     case WM_IME_STARTCOMPOSITION:


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700), [CORE-15289](https://jira.reactos.org/browse/CORE-15289)

## Proposed changes

- Add `WM_IME_SETCONTEXT` handling to the window procedure of the `EDIT` control.

## TODO

- [x] Do small tests.
- [x] Do big tests.