### PR TITLE
[COMCTL32][USER32] EDIT: Half-implement WM_IME_STARTCOMPOSITION

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -4978,6 +4978,11 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
     case WM_IME_STARTCOMPOSITION:
         es->composition_start = es->selection_end;
         es->composition_len = 0;
+#ifdef __REACTOS__
+        if (FALSE) /* FIXME: Condition */
+            return TRUE;
+        result = DefWindowProcW(hwnd, WM_IME_STARTCOMPOSITION, wParam, lParam);
+#endif
         break;
 
     case WM_IME_COMPOSITION:

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5291,6 +5291,11 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 	case WM_IME_STARTCOMPOSITION:
 		es->composition_start = es->selection_end;
 		es->composition_len = 0;
+#ifdef __REACTOS__
+        if (FALSE) /* FIXME: Condition */
+            return TRUE;
+        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+#endif
 		break;
 
 	case WM_IME_COMPOSITION:


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-15289](https://jira.reactos.org/browse/CORE-15289), [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Improve `WM_IME_STARTCOMPOSITION` handling in the window procedure of the `EDIT` control.

## TODO

- [x] Do small tests.
- [x] Do big tests.