### PR TITLE
[BLUE] Optimize ScrIoControl for speed

### DIFF
--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -4521,11 +4521,11 @@ RunUSetup(VOID)
     {
         INT i;
         StopWatch(NULL);
-        for (i = 0; i < 1000; ++i)
+        for (i = 0; i < 100; ++i)
         {
             CONSOLE_ClearScreen();
         }
-        StopWatch("CONSOLE_ClearScreen x 1000");
+        StopWatch("CONSOLE_ClearScreen x 100");
     }
 #endif
     /* Global Initialization page */

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -4452,6 +4452,7 @@ FlushPage(PINPUT_RECORD Ir)
     return REBOOT_PAGE;
 }
 
+
 /*
  * The start routine and page management
  */

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -4452,26 +4452,6 @@ FlushPage(PINPUT_RECORD Ir)
     return REBOOT_PAGE;
 }
 
-#define MEASURING // TODO: To be deleted
-#ifdef MEASURING
-static VOID StopWatch(LPCSTR Name OPTIONAL)
-{
-    static FILETIME s_ft0;
-    FILETIME ft1;
-    DWORD diff;
-
-    if (!Name)
-    {
-        GetSystemTimeAsFileTime(&s_ft0);
-    }
-    else
-    {
-        GetSystemTimeAsFileTime(&ft1);
-        diff = ft1.dwLowDateTime - s_ft0.dwLowDateTime;
-        DPRINT1("%s: %lu\n", Name, diff);
-    }
-}
-#endif  /* def MEASURING */
 /*
  * The start routine and page management
  */
@@ -4517,17 +4497,6 @@ RunUSetup(VOID)
     CONSOLE_ClearScreen();
     CONSOLE_Flush();
 
-#ifdef MEASURING
-    {
-        INT i;
-        StopWatch(NULL);
-        for (i = 0; i < 100; ++i)
-        {
-            CONSOLE_ClearScreen();
-        }
-        StopWatch("CONSOLE_ClearScreen x 100");
-    }
-#endif
     /* Global Initialization page */
     Page = SetupStartPage(&Ir);
 

--- a/base/setup/usetup/usetup.c
+++ b/base/setup/usetup/usetup.c
@@ -4452,7 +4452,26 @@ FlushPage(PINPUT_RECORD Ir)
     return REBOOT_PAGE;
 }
 
+#define MEASURING // TODO: To be deleted
+#ifdef MEASURING
+static VOID StopWatch(LPCSTR Name OPTIONAL)
+{
+    static FILETIME s_ft0;
+    FILETIME ft1;
+    DWORD diff;
 
+    if (!Name)
+    {
+        GetSystemTimeAsFileTime(&s_ft0);
+    }
+    else
+    {
+        GetSystemTimeAsFileTime(&ft1);
+        diff = ft1.dwLowDateTime - s_ft0.dwLowDateTime;
+        DPRINT1("%s: %lu\n", Name, diff);
+    }
+}
+#endif  /* def MEASURING */
 /*
  * The start routine and page management
  */
@@ -4498,6 +4517,17 @@ RunUSetup(VOID)
     CONSOLE_ClearScreen();
     CONSOLE_Flush();
 
+#ifdef MEASURING
+    {
+        INT i;
+        StopWatch(NULL);
+        for (i = 0; i < 1000; ++i)
+        {
+            CONSOLE_ClearScreen();
+        }
+        StopWatch("CONSOLE_ClearScreen x 1000");
+    }
+#endif
     /* Global Initialization page */
     Page = SetupStartPage(&Ir);
 

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1073,6 +1073,9 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+                CHAR attr = Buf->wAttribute;
+                PUCHAR pch;
+
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 
@@ -1080,9 +1083,11 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
+                pch = vidmem + offset;
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
-                    vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
+                    *pch = attr;
+                    pch += 2;
                 }
                 Buf->dwTransfered = dwCount;
             }
@@ -1203,6 +1208,8 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+                PUCHAR pch;
+
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 
@@ -1210,10 +1217,13 @@ ScrIoControl(
                                  (DeviceExtension->Rows - dwCoord.Y)
                                     * DeviceExtension->Columns - dwCoord.X);
 
+                pch = vidmem + offset;
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
                 {
-                    vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
+                    *pch = *((PCHAR)pAttr);
+                    pch += 2;
                 }
+
                 Irp->IoStatus.Information = dwCount * sizeof(USHORT);
             }
 
@@ -1271,6 +1281,9 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+                CHAR ch = Buf->cCharacter;
+                PUCHAR pch;
+
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
 
@@ -1278,9 +1291,11 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
+                pch = vidmem + offset;
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
-                    vidmem[offset + (dwCount * 2)] = (char)Buf->cCharacter;
+                    *pch = ch;
+                    pch += 2;
                 }
                 Buf->dwTransfered = dwCount;
             }

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1221,10 +1221,6 @@ ScrIoControl(
 
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
                 {
-#ifdef OPTIMIZED
-                    *pch = *((PCHAR)pAttr);
-                    pch += 2;
-#else
                     vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
 #endif
                 }

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1077,7 +1077,6 @@ ScrIoControl(
             {
 #ifdef OPTIMIZED
                 UCHAR attr = Buf->wAttribute;
-                PUCHAR pch;
 #endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -842,7 +842,10 @@ ScrWrite(
     return Status;
 }
 
+#define OPTIMIZED /* TODO: To be deleted */
+
 static DRIVER_DISPATCH ScrIoControl;
+#ifdef OPTIMIZED
 static NTSTATUS
 NTAPI
 ScrIoControl(
@@ -1550,6 +1553,700 @@ ScrIoControl(
 
     return Status;
 }
+#else   /* ndef OPTIMIZED */
+static NTSTATUS
+NTAPI
+ScrIoControl(
+    _In_ PDEVICE_OBJECT DeviceObject,
+    _In_ PIRP Irp)
+{
+    NTSTATUS Status;
+    PIO_STACK_LOCATION stk = IoGetCurrentIrpStackLocation(Irp);
+    PDEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
+
+    switch (stk->Parameters.DeviceIoControl.IoControlCode)
+    {
+        case IOCTL_CONSOLE_RESET_SCREEN:
+        {
+            BOOLEAN Enable;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(ULONG))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            Enable = !!*(PULONG)Irp->AssociatedIrp.SystemBuffer;
+
+            /* Fully enable or disable the screen */
+            Status = (ScrResetScreen(DeviceExtension, TRUE, Enable)
+                        ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL);
+            Irp->IoStatus.Information = 0;
+            break;
+        }
+
+        case IOCTL_CONSOLE_GET_SCREEN_BUFFER_INFO:
+        {
+            PCONSOLE_SCREEN_BUFFER_INFO pcsbi;
+            USHORT rows = DeviceExtension->Rows;
+            USHORT columns = DeviceExtension->Columns;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_SCREEN_BUFFER_INFO))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcsbi = (PCONSOLE_SCREEN_BUFFER_INFO)Irp->AssociatedIrp.SystemBuffer;
+            RtlZeroMemory(pcsbi, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
+
+            pcsbi->dwSize.X = columns;
+            pcsbi->dwSize.Y = rows;
+
+            pcsbi->dwCursorPosition.X = DeviceExtension->CursorX;
+            pcsbi->dwCursorPosition.Y = DeviceExtension->CursorY;
+
+            pcsbi->wAttributes = DeviceExtension->CharAttribute;
+
+            pcsbi->srWindow.Left   = 0;
+            pcsbi->srWindow.Right  = columns - 1;
+            pcsbi->srWindow.Top    = 0;
+            pcsbi->srWindow.Bottom = rows - 1;
+
+            pcsbi->dwMaximumWindowSize.X = columns;
+            pcsbi->dwMaximumWindowSize.Y = rows;
+
+            Irp->IoStatus.Information = sizeof(CONSOLE_SCREEN_BUFFER_INFO);
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_SET_SCREEN_BUFFER_INFO:
+        {
+            PCONSOLE_SCREEN_BUFFER_INFO pcsbi;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_SCREEN_BUFFER_INFO))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcsbi = (PCONSOLE_SCREEN_BUFFER_INFO)Irp->AssociatedIrp.SystemBuffer;
+
+            if ( pcsbi->dwCursorPosition.X < 0 || pcsbi->dwCursorPosition.X >= DeviceExtension->Columns ||
+                 pcsbi->dwCursorPosition.Y < 0 || pcsbi->dwCursorPosition.Y >= DeviceExtension->Rows )
+            {
+                Irp->IoStatus.Information = 0;
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            DeviceExtension->CharAttribute = pcsbi->wAttributes;
+
+            /* Set the cursor position */
+            ASSERT((0 <= pcsbi->dwCursorPosition.X) && (pcsbi->dwCursorPosition.X < DeviceExtension->Columns));
+            ASSERT((0 <= pcsbi->dwCursorPosition.Y) && (pcsbi->dwCursorPosition.Y < DeviceExtension->Rows));
+            DeviceExtension->CursorX = pcsbi->dwCursorPosition.X;
+            DeviceExtension->CursorY = pcsbi->dwCursorPosition.Y;
+            if (DeviceExtension->Enabled)
+                ScrSetCursor(DeviceExtension);
+
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_GET_CURSOR_INFO:
+        {
+            PCONSOLE_CURSOR_INFO pcci;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_CURSOR_INFO))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcci = (PCONSOLE_CURSOR_INFO)Irp->AssociatedIrp.SystemBuffer;
+            RtlZeroMemory(pcci, sizeof(CONSOLE_CURSOR_INFO));
+
+            pcci->dwSize = DeviceExtension->CursorSize;
+            pcci->bVisible = DeviceExtension->CursorVisible;
+
+            Irp->IoStatus.Information = sizeof(CONSOLE_CURSOR_INFO);
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_SET_CURSOR_INFO:
+        {
+            PCONSOLE_CURSOR_INFO pcci;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_CURSOR_INFO))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcci = (PCONSOLE_CURSOR_INFO)Irp->AssociatedIrp.SystemBuffer;
+
+            DeviceExtension->CursorSize = pcci->dwSize;
+            DeviceExtension->CursorVisible = pcci->bVisible;
+            if (DeviceExtension->Enabled)
+                ScrSetCursorShape(DeviceExtension);
+
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_GET_MODE:
+        {
+            PCONSOLE_MODE pcm;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_MODE))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcm = (PCONSOLE_MODE)Irp->AssociatedIrp.SystemBuffer;
+            RtlZeroMemory(pcm, sizeof(CONSOLE_MODE));
+
+            pcm->dwMode = DeviceExtension->Mode;
+
+            Irp->IoStatus.Information = sizeof(CONSOLE_MODE);
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_SET_MODE:
+        {
+            PCONSOLE_MODE pcm;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_MODE))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            pcm = (PCONSOLE_MODE)Irp->AssociatedIrp.SystemBuffer;
+            DeviceExtension->Mode = pcm->dwMode;
+
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_FILL_OUTPUT_ATTRIBUTE:
+        {
+            POUTPUT_ATTRIBUTE Buf;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            /* Validate input and output buffers */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength  < sizeof(OUTPUT_ATTRIBUTE) ||
+                stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(OUTPUT_ATTRIBUTE))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            Buf = (POUTPUT_ATTRIBUTE)Irp->AssociatedIrp.SystemBuffer;
+            nMaxLength = Buf->nLength;
+
+            Buf->dwTransfered = 0;
+            Irp->IoStatus.Information = sizeof(OUTPUT_ATTRIBUTE);
+
+            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
+                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows    ||
+                 nMaxLength == 0 )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
+                                    * DeviceExtension->Columns - Buf->dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++)
+                {
+                    vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
+                }
+                Buf->dwTransfered = dwCount;
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_READ_OUTPUT_ATTRIBUTE:
+        {
+            POUTPUT_ATTRIBUTE Buf;
+            PUSHORT pAttr;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(OUTPUT_ATTRIBUTE))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            Buf = (POUTPUT_ATTRIBUTE)Irp->AssociatedIrp.SystemBuffer;
+            Irp->IoStatus.Information = 0;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength == 0)
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+            ASSERT(Irp->MdlAddress);
+            pAttr = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            if (pAttr == NULL)
+            {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                break;
+            }
+
+            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
+                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength;
+            nMaxLength /= sizeof(USHORT);
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
+                                    * DeviceExtension->Columns - Buf->dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
+                {
+                    *((PCHAR)pAttr) = vidmem[offset + (dwCount * 2)];
+                }
+                Irp->IoStatus.Information = dwCount * sizeof(USHORT);
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_WRITE_OUTPUT_ATTRIBUTE:
+        {
+            COORD dwCoord;
+            PCOORD pCoord;
+            PUSHORT pAttr;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            //
+            // NOTE: For whatever reason no OUTPUT_ATTRIBUTE structure
+            // is used for this IOCTL.
+            //
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(COORD))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->MdlAddress);
+            pCoord = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            if (pCoord == NULL)
+            {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                break;
+            }
+            /* Capture the input info data */
+            dwCoord = *pCoord;
+
+            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(COORD);
+            nMaxLength /= sizeof(USHORT);
+
+            Irp->IoStatus.Information = 0;
+
+            if ( dwCoord.X < 0 || dwCoord.X >= DeviceExtension->Columns ||
+                 dwCoord.Y < 0 || dwCoord.Y >= DeviceExtension->Rows    ||
+                 nMaxLength == 0 )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            pAttr = (PUSHORT)(pCoord + 1);
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - dwCoord.Y)
+                                    * DeviceExtension->Columns - dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
+                {
+                    vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
+                }
+                Irp->IoStatus.Information = dwCount * sizeof(USHORT);
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_SET_TEXT_ATTRIBUTE:
+        {
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(USHORT))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            DeviceExtension->CharAttribute = *(PUSHORT)Irp->AssociatedIrp.SystemBuffer;
+
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_FILL_OUTPUT_CHARACTER:
+        {
+            POUTPUT_CHARACTER Buf;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            /* Validate input and output buffers */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength  < sizeof(OUTPUT_CHARACTER) ||
+                stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(OUTPUT_CHARACTER))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            Buf = (POUTPUT_CHARACTER)Irp->AssociatedIrp.SystemBuffer;
+            nMaxLength = Buf->nLength;
+
+            Buf->dwTransfered = 0;
+            Irp->IoStatus.Information = sizeof(OUTPUT_CHARACTER);
+
+            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
+                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows    ||
+                 nMaxLength == 0 )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
+                                    * DeviceExtension->Columns - Buf->dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++)
+                {
+                    vidmem[offset + (dwCount * 2)] = (char)Buf->cCharacter;
+                }
+                Buf->dwTransfered = dwCount;
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_READ_OUTPUT_CHARACTER:
+        {
+            POUTPUT_CHARACTER Buf;
+            PCHAR pChar;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(OUTPUT_CHARACTER))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            Buf = (POUTPUT_CHARACTER)Irp->AssociatedIrp.SystemBuffer;
+            Irp->IoStatus.Information = 0;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength == 0)
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+            ASSERT(Irp->MdlAddress);
+            pChar = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            if (pChar == NULL)
+            {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                break;
+            }
+
+            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
+                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength;
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
+                                    * DeviceExtension->Columns - Buf->dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pChar++)
+                {
+                    *pChar = vidmem[offset + (dwCount * 2)];
+                }
+                Irp->IoStatus.Information = dwCount * sizeof(CHAR);
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_WRITE_OUTPUT_CHARACTER:
+        {
+            COORD dwCoord;
+            PCOORD pCoord;
+            PCHAR pChar;
+            PUCHAR vidmem;
+            ULONG offset;
+            ULONG dwCount;
+            ULONG nMaxLength;
+
+            //
+            // NOTE: For whatever reason no OUTPUT_CHARACTER structure
+            // is used for this IOCTL.
+            //
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(COORD))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->MdlAddress);
+            pCoord = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            if (pCoord == NULL)
+            {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                break;
+            }
+            /* Capture the input info data */
+            dwCoord = *pCoord;
+
+            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(COORD);
+            Irp->IoStatus.Information = 0;
+
+            if ( dwCoord.X < 0 || dwCoord.X >= DeviceExtension->Columns ||
+                 dwCoord.Y < 0 || dwCoord.Y >= DeviceExtension->Rows    ||
+                 nMaxLength == 0 )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            pChar = (PCHAR)(pCoord + 1);
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                vidmem = DeviceExtension->VideoMemory;
+                offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2;
+
+                nMaxLength = min(nMaxLength,
+                                 (DeviceExtension->Rows - dwCoord.Y)
+                                    * DeviceExtension->Columns - dwCoord.X);
+
+                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pChar++)
+                {
+                    vidmem[offset + (dwCount * 2)] = *pChar;
+                }
+                Irp->IoStatus.Information = dwCount * sizeof(CHAR);
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_DRAW:
+        {
+            CONSOLE_DRAW ConsoleDraw;
+            PCONSOLE_DRAW pConsoleDraw;
+            PUCHAR Src, Dest;
+            UINT32 SrcDelta, DestDelta, i;
+
+            /* Validate output buffer */
+            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_DRAW))
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->MdlAddress);
+            pConsoleDraw = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
+            if (pConsoleDraw == NULL)
+            {
+                Status = STATUS_INSUFFICIENT_RESOURCES;
+                break;
+            }
+            /* Capture the input info data */
+            ConsoleDraw = *pConsoleDraw;
+
+            /* Check whether we have the size for the header plus the data area */
+            if ((stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(CONSOLE_DRAW)) / 2
+                    < ((ULONG)ConsoleDraw.SizeX * (ULONG)ConsoleDraw.SizeY))
+            {
+                Status = STATUS_INVALID_BUFFER_SIZE;
+                break;
+            }
+
+            Irp->IoStatus.Information = 0;
+
+            /* Set the cursor position, clipping it to the screen */
+            DeviceExtension->CursorX = min(max(ConsoleDraw.CursorX, 0), DeviceExtension->Columns - 1);
+            DeviceExtension->CursorY = min(max(ConsoleDraw.CursorY, 0), DeviceExtension->Rows    - 1);
+            if (DeviceExtension->Enabled)
+                ScrSetCursor(DeviceExtension);
+
+            // TODO: For the moment if the ConsoleDraw rectangle has borders
+            // out of the screen-buffer we just bail out. Would it be better
+            // to actually clip the rectangle within its borders instead?
+            if ( ConsoleDraw.X < 0 || ConsoleDraw.X >= DeviceExtension->Columns ||
+                 ConsoleDraw.Y < 0 || ConsoleDraw.Y >= DeviceExtension->Rows )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+            if ( ConsoleDraw.SizeX > DeviceExtension->Columns - ConsoleDraw.X ||
+                 ConsoleDraw.SizeY > DeviceExtension->Rows    - ConsoleDraw.Y )
+            {
+                Status = STATUS_SUCCESS;
+                break;
+            }
+
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+            {
+                Src = (PUCHAR)(pConsoleDraw + 1);
+                SrcDelta = ConsoleDraw.SizeX * 2;
+                Dest = DeviceExtension->VideoMemory +
+                        (ConsoleDraw.X + ConsoleDraw.Y * DeviceExtension->Columns) * 2;
+                DestDelta = DeviceExtension->Columns * 2;
+                /* 2 == sizeof(CHAR) + sizeof(BYTE) */
+
+                /* Copy each line */
+                for (i = 0; i < ConsoleDraw.SizeY; i++)
+                {
+                    RtlCopyMemory(Dest, Src, SrcDelta);
+                    Src += SrcDelta;
+                    Dest += DestDelta;
+                }
+            }
+
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        case IOCTL_CONSOLE_LOADFONT:
+        {
+            //
+            // FIXME: For the moment we support only a fixed 256-char 8-bit font.
+            //
+
+            /* Validate input buffer */
+            if (stk->Parameters.DeviceIoControl.InputBufferLength < 256 * 8)
+            {
+                Status = STATUS_INVALID_PARAMETER;
+                break;
+            }
+            ASSERT(Irp->AssociatedIrp.SystemBuffer);
+
+            if (DeviceExtension->FontBitfield)
+                ExFreePoolWithTag(DeviceExtension->FontBitfield, TAG_BLUE);
+            DeviceExtension->FontBitfield = ExAllocatePoolWithTag(NonPagedPool, 256 * 8, TAG_BLUE);
+            if (!DeviceExtension->FontBitfield)
+            {
+                Status = STATUS_NO_MEMORY;
+                break;
+            }
+            RtlCopyMemory(DeviceExtension->FontBitfield, Irp->AssociatedIrp.SystemBuffer, 256 * 8);
+
+            /* Set the font if needed */
+            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
+                ScrSetFont(DeviceExtension->FontBitfield);
+
+            Irp->IoStatus.Information = 0;
+            Status = STATUS_SUCCESS;
+            break;
+        }
+
+        default:
+            Status = STATUS_NOT_IMPLEMENTED;
+    }
+
+    Irp->IoStatus.Status = Status;
+    IoCompleteRequest(Irp, IO_VIDEO_INCREMENT);
+
+    return Status;
+}
+#endif  /* ndef OPTIMIZED */
 
 static DRIVER_DISPATCH ScrDispatch;
 static NTSTATUS

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1281,8 +1281,7 @@ ScrIoControl(
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
 #ifdef OPTIMIZED
-                CHAR ch = Buf->cCharacter;
-                PUCHAR pch;
+                UCHAR ch = Buf->cCharacter;
 #endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1293,8 +1293,7 @@ ScrIoControl(
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
 #ifdef OPTIMIZED
-                    *pch = ch;
-                    pch += 2;
+                    vidmem[offset + (dwCount * 2)] = ch;
 #else
                     vidmem[offset + (dwCount * 2)] = (char)Buf->cCharacter;
 #endif

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1076,7 +1076,7 @@ ScrIoControl(
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
 #ifdef OPTIMIZED
-                CHAR attr = Buf->wAttribute;
+                UCHAR attr = Buf->wAttribute;
                 PUCHAR pch;
 #endif
                 vidmem = DeviceExtension->VideoMemory;

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -845,7 +845,6 @@ ScrWrite(
 #define OPTIMIZED /* TODO: To be deleted */
 
 static DRIVER_DISPATCH ScrIoControl;
-#ifdef OPTIMIZED
 static NTSTATUS
 NTAPI
 ScrIoControl(
@@ -1076,9 +1075,10 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+#ifdef OPTIMIZED
                 CHAR attr = Buf->wAttribute;
                 PUCHAR pch;
-
+#endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 
@@ -1086,11 +1086,17 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
+#ifdef OPTIMIZED
                 pch = vidmem + offset;
+#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
+#ifdef OPTIMIZED
                     *pch = attr;
                     pch += 2;
+#else
+                    vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
+#endif
                 }
                 Buf->dwTransfered = dwCount;
             }
@@ -1211,8 +1217,9 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+#ifdef OPTIMIZED
                 PUCHAR pch;
-
+#endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 
@@ -1220,13 +1227,18 @@ ScrIoControl(
                                  (DeviceExtension->Rows - dwCoord.Y)
                                     * DeviceExtension->Columns - dwCoord.X);
 
+#ifdef OPTIMIZED
                 pch = vidmem + offset;
+#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
                 {
+#ifdef OPTIMIZED
                     *pch = *((PCHAR)pAttr);
                     pch += 2;
+#else
+                    vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
+#endif
                 }
-
                 Irp->IoStatus.Information = dwCount * sizeof(USHORT);
             }
 
@@ -1284,9 +1296,10 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
+#ifdef OPTIMIZED
                 CHAR ch = Buf->cCharacter;
                 PUCHAR pch;
-
+#endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
 
@@ -1294,704 +1307,17 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
+#ifdef OPTIMIZED
                 pch = vidmem + offset;
+#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
+#ifdef OPTIMIZED
                     *pch = ch;
                     pch += 2;
-                }
-                Buf->dwTransfered = dwCount;
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_READ_OUTPUT_CHARACTER:
-        {
-            POUTPUT_CHARACTER Buf;
-            PCHAR pChar;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(OUTPUT_CHARACTER))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            Buf = (POUTPUT_CHARACTER)Irp->AssociatedIrp.SystemBuffer;
-            Irp->IoStatus.Information = 0;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength == 0)
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-            ASSERT(Irp->MdlAddress);
-            pChar = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
-            if (pChar == NULL)
-            {
-                Status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-
-            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
-                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength;
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
-                                    * DeviceExtension->Columns - Buf->dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pChar++)
-                {
-                    *pChar = vidmem[offset + (dwCount * 2)];
-                }
-                Irp->IoStatus.Information = dwCount * sizeof(CHAR);
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_WRITE_OUTPUT_CHARACTER:
-        {
-            COORD dwCoord;
-            PCOORD pCoord;
-            PCHAR pChar;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            //
-            // NOTE: For whatever reason no OUTPUT_CHARACTER structure
-            // is used for this IOCTL.
-            //
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(COORD))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->MdlAddress);
-            pCoord = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
-            if (pCoord == NULL)
-            {
-                Status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-            /* Capture the input info data */
-            dwCoord = *pCoord;
-
-            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(COORD);
-            Irp->IoStatus.Information = 0;
-
-            if ( dwCoord.X < 0 || dwCoord.X >= DeviceExtension->Columns ||
-                 dwCoord.Y < 0 || dwCoord.Y >= DeviceExtension->Rows    ||
-                 nMaxLength == 0 )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            pChar = (PCHAR)(pCoord + 1);
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - dwCoord.Y)
-                                    * DeviceExtension->Columns - dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pChar++)
-                {
-                    vidmem[offset + (dwCount * 2)] = *pChar;
-                }
-                Irp->IoStatus.Information = dwCount * sizeof(CHAR);
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_DRAW:
-        {
-            CONSOLE_DRAW ConsoleDraw;
-            PCONSOLE_DRAW pConsoleDraw;
-            PUCHAR Src, Dest;
-            UINT32 SrcDelta, DestDelta, i;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_DRAW))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->MdlAddress);
-            pConsoleDraw = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
-            if (pConsoleDraw == NULL)
-            {
-                Status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-            /* Capture the input info data */
-            ConsoleDraw = *pConsoleDraw;
-
-            /* Check whether we have the size for the header plus the data area */
-            if ((stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(CONSOLE_DRAW)) / 2
-                    < ((ULONG)ConsoleDraw.SizeX * (ULONG)ConsoleDraw.SizeY))
-            {
-                Status = STATUS_INVALID_BUFFER_SIZE;
-                break;
-            }
-
-            Irp->IoStatus.Information = 0;
-
-            /* Set the cursor position, clipping it to the screen */
-            DeviceExtension->CursorX = min(max(ConsoleDraw.CursorX, 0), DeviceExtension->Columns - 1);
-            DeviceExtension->CursorY = min(max(ConsoleDraw.CursorY, 0), DeviceExtension->Rows    - 1);
-            if (DeviceExtension->Enabled)
-                ScrSetCursor(DeviceExtension);
-
-            // TODO: For the moment if the ConsoleDraw rectangle has borders
-            // out of the screen-buffer we just bail out. Would it be better
-            // to actually clip the rectangle within its borders instead?
-            if ( ConsoleDraw.X < 0 || ConsoleDraw.X >= DeviceExtension->Columns ||
-                 ConsoleDraw.Y < 0 || ConsoleDraw.Y >= DeviceExtension->Rows )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-            if ( ConsoleDraw.SizeX > DeviceExtension->Columns - ConsoleDraw.X ||
-                 ConsoleDraw.SizeY > DeviceExtension->Rows    - ConsoleDraw.Y )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                Src = (PUCHAR)(pConsoleDraw + 1);
-                SrcDelta = ConsoleDraw.SizeX * 2;
-                Dest = DeviceExtension->VideoMemory +
-                        (ConsoleDraw.X + ConsoleDraw.Y * DeviceExtension->Columns) * 2;
-                DestDelta = DeviceExtension->Columns * 2;
-                /* 2 == sizeof(CHAR) + sizeof(BYTE) */
-
-                /* Copy each line */
-                for (i = 0; i < ConsoleDraw.SizeY; i++)
-                {
-                    RtlCopyMemory(Dest, Src, SrcDelta);
-                    Src += SrcDelta;
-                    Dest += DestDelta;
-                }
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_LOADFONT:
-        {
-            //
-            // FIXME: For the moment we support only a fixed 256-char 8-bit font.
-            //
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < 256 * 8)
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            if (DeviceExtension->FontBitfield)
-                ExFreePoolWithTag(DeviceExtension->FontBitfield, TAG_BLUE);
-            DeviceExtension->FontBitfield = ExAllocatePoolWithTag(NonPagedPool, 256 * 8, TAG_BLUE);
-            if (!DeviceExtension->FontBitfield)
-            {
-                Status = STATUS_NO_MEMORY;
-                break;
-            }
-            RtlCopyMemory(DeviceExtension->FontBitfield, Irp->AssociatedIrp.SystemBuffer, 256 * 8);
-
-            /* Set the font if needed */
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-                ScrSetFont(DeviceExtension->FontBitfield);
-
-            Irp->IoStatus.Information = 0;
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        default:
-            Status = STATUS_NOT_IMPLEMENTED;
-    }
-
-    Irp->IoStatus.Status = Status;
-    IoCompleteRequest(Irp, IO_VIDEO_INCREMENT);
-
-    return Status;
-}
-#else   /* ndef OPTIMIZED */
-static NTSTATUS
-NTAPI
-ScrIoControl(
-    _In_ PDEVICE_OBJECT DeviceObject,
-    _In_ PIRP Irp)
-{
-    NTSTATUS Status;
-    PIO_STACK_LOCATION stk = IoGetCurrentIrpStackLocation(Irp);
-    PDEVICE_EXTENSION DeviceExtension = DeviceObject->DeviceExtension;
-
-    switch (stk->Parameters.DeviceIoControl.IoControlCode)
-    {
-        case IOCTL_CONSOLE_RESET_SCREEN:
-        {
-            BOOLEAN Enable;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(ULONG))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            Enable = !!*(PULONG)Irp->AssociatedIrp.SystemBuffer;
-
-            /* Fully enable or disable the screen */
-            Status = (ScrResetScreen(DeviceExtension, TRUE, Enable)
-                        ? STATUS_SUCCESS : STATUS_UNSUCCESSFUL);
-            Irp->IoStatus.Information = 0;
-            break;
-        }
-
-        case IOCTL_CONSOLE_GET_SCREEN_BUFFER_INFO:
-        {
-            PCONSOLE_SCREEN_BUFFER_INFO pcsbi;
-            USHORT rows = DeviceExtension->Rows;
-            USHORT columns = DeviceExtension->Columns;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_SCREEN_BUFFER_INFO))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcsbi = (PCONSOLE_SCREEN_BUFFER_INFO)Irp->AssociatedIrp.SystemBuffer;
-            RtlZeroMemory(pcsbi, sizeof(CONSOLE_SCREEN_BUFFER_INFO));
-
-            pcsbi->dwSize.X = columns;
-            pcsbi->dwSize.Y = rows;
-
-            pcsbi->dwCursorPosition.X = DeviceExtension->CursorX;
-            pcsbi->dwCursorPosition.Y = DeviceExtension->CursorY;
-
-            pcsbi->wAttributes = DeviceExtension->CharAttribute;
-
-            pcsbi->srWindow.Left   = 0;
-            pcsbi->srWindow.Right  = columns - 1;
-            pcsbi->srWindow.Top    = 0;
-            pcsbi->srWindow.Bottom = rows - 1;
-
-            pcsbi->dwMaximumWindowSize.X = columns;
-            pcsbi->dwMaximumWindowSize.Y = rows;
-
-            Irp->IoStatus.Information = sizeof(CONSOLE_SCREEN_BUFFER_INFO);
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_SET_SCREEN_BUFFER_INFO:
-        {
-            PCONSOLE_SCREEN_BUFFER_INFO pcsbi;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_SCREEN_BUFFER_INFO))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcsbi = (PCONSOLE_SCREEN_BUFFER_INFO)Irp->AssociatedIrp.SystemBuffer;
-
-            if ( pcsbi->dwCursorPosition.X < 0 || pcsbi->dwCursorPosition.X >= DeviceExtension->Columns ||
-                 pcsbi->dwCursorPosition.Y < 0 || pcsbi->dwCursorPosition.Y >= DeviceExtension->Rows )
-            {
-                Irp->IoStatus.Information = 0;
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-
-            DeviceExtension->CharAttribute = pcsbi->wAttributes;
-
-            /* Set the cursor position */
-            ASSERT((0 <= pcsbi->dwCursorPosition.X) && (pcsbi->dwCursorPosition.X < DeviceExtension->Columns));
-            ASSERT((0 <= pcsbi->dwCursorPosition.Y) && (pcsbi->dwCursorPosition.Y < DeviceExtension->Rows));
-            DeviceExtension->CursorX = pcsbi->dwCursorPosition.X;
-            DeviceExtension->CursorY = pcsbi->dwCursorPosition.Y;
-            if (DeviceExtension->Enabled)
-                ScrSetCursor(DeviceExtension);
-
-            Irp->IoStatus.Information = 0;
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_GET_CURSOR_INFO:
-        {
-            PCONSOLE_CURSOR_INFO pcci;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_CURSOR_INFO))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcci = (PCONSOLE_CURSOR_INFO)Irp->AssociatedIrp.SystemBuffer;
-            RtlZeroMemory(pcci, sizeof(CONSOLE_CURSOR_INFO));
-
-            pcci->dwSize = DeviceExtension->CursorSize;
-            pcci->bVisible = DeviceExtension->CursorVisible;
-
-            Irp->IoStatus.Information = sizeof(CONSOLE_CURSOR_INFO);
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_SET_CURSOR_INFO:
-        {
-            PCONSOLE_CURSOR_INFO pcci;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_CURSOR_INFO))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcci = (PCONSOLE_CURSOR_INFO)Irp->AssociatedIrp.SystemBuffer;
-
-            DeviceExtension->CursorSize = pcci->dwSize;
-            DeviceExtension->CursorVisible = pcci->bVisible;
-            if (DeviceExtension->Enabled)
-                ScrSetCursorShape(DeviceExtension);
-
-            Irp->IoStatus.Information = 0;
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_GET_MODE:
-        {
-            PCONSOLE_MODE pcm;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(CONSOLE_MODE))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcm = (PCONSOLE_MODE)Irp->AssociatedIrp.SystemBuffer;
-            RtlZeroMemory(pcm, sizeof(CONSOLE_MODE));
-
-            pcm->dwMode = DeviceExtension->Mode;
-
-            Irp->IoStatus.Information = sizeof(CONSOLE_MODE);
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_SET_MODE:
-        {
-            PCONSOLE_MODE pcm;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(CONSOLE_MODE))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            pcm = (PCONSOLE_MODE)Irp->AssociatedIrp.SystemBuffer;
-            DeviceExtension->Mode = pcm->dwMode;
-
-            Irp->IoStatus.Information = 0;
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_FILL_OUTPUT_ATTRIBUTE:
-        {
-            POUTPUT_ATTRIBUTE Buf;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            /* Validate input and output buffers */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength  < sizeof(OUTPUT_ATTRIBUTE) ||
-                stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(OUTPUT_ATTRIBUTE))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            Buf = (POUTPUT_ATTRIBUTE)Irp->AssociatedIrp.SystemBuffer;
-            nMaxLength = Buf->nLength;
-
-            Buf->dwTransfered = 0;
-            Irp->IoStatus.Information = sizeof(OUTPUT_ATTRIBUTE);
-
-            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
-                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows    ||
-                 nMaxLength == 0 )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
-                                    * DeviceExtension->Columns - Buf->dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++)
-                {
-                    vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
-                }
-                Buf->dwTransfered = dwCount;
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_READ_OUTPUT_ATTRIBUTE:
-        {
-            POUTPUT_ATTRIBUTE Buf;
-            PUSHORT pAttr;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(OUTPUT_ATTRIBUTE))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            Buf = (POUTPUT_ATTRIBUTE)Irp->AssociatedIrp.SystemBuffer;
-            Irp->IoStatus.Information = 0;
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength == 0)
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-            ASSERT(Irp->MdlAddress);
-            pAttr = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
-            if (pAttr == NULL)
-            {
-                Status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-
-            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
-                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength;
-            nMaxLength /= sizeof(USHORT);
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
-                                    * DeviceExtension->Columns - Buf->dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
-                {
-                    *((PCHAR)pAttr) = vidmem[offset + (dwCount * 2)];
-                }
-                Irp->IoStatus.Information = dwCount * sizeof(USHORT);
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_WRITE_OUTPUT_ATTRIBUTE:
-        {
-            COORD dwCoord;
-            PCOORD pCoord;
-            PUSHORT pAttr;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            //
-            // NOTE: For whatever reason no OUTPUT_ATTRIBUTE structure
-            // is used for this IOCTL.
-            //
-
-            /* Validate output buffer */
-            if (stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(COORD))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->MdlAddress);
-            pCoord = MmGetSystemAddressForMdlSafe(Irp->MdlAddress, NormalPagePriority);
-            if (pCoord == NULL)
-            {
-                Status = STATUS_INSUFFICIENT_RESOURCES;
-                break;
-            }
-            /* Capture the input info data */
-            dwCoord = *pCoord;
-
-            nMaxLength = stk->Parameters.DeviceIoControl.OutputBufferLength - sizeof(COORD);
-            nMaxLength /= sizeof(USHORT);
-
-            Irp->IoStatus.Information = 0;
-
-            if ( dwCoord.X < 0 || dwCoord.X >= DeviceExtension->Columns ||
-                 dwCoord.Y < 0 || dwCoord.Y >= DeviceExtension->Rows    ||
-                 nMaxLength == 0 )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            pAttr = (PUSHORT)(pCoord + 1);
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - dwCoord.Y)
-                                    * DeviceExtension->Columns - dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
-                {
-                    vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
-                }
-                Irp->IoStatus.Information = dwCount * sizeof(USHORT);
-            }
-
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_SET_TEXT_ATTRIBUTE:
-        {
-            /* Validate input buffer */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength < sizeof(USHORT))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            DeviceExtension->CharAttribute = *(PUSHORT)Irp->AssociatedIrp.SystemBuffer;
-
-            Irp->IoStatus.Information = 0;
-            Status = STATUS_SUCCESS;
-            break;
-        }
-
-        case IOCTL_CONSOLE_FILL_OUTPUT_CHARACTER:
-        {
-            POUTPUT_CHARACTER Buf;
-            PUCHAR vidmem;
-            ULONG offset;
-            ULONG dwCount;
-            ULONG nMaxLength;
-
-            /* Validate input and output buffers */
-            if (stk->Parameters.DeviceIoControl.InputBufferLength  < sizeof(OUTPUT_CHARACTER) ||
-                stk->Parameters.DeviceIoControl.OutputBufferLength < sizeof(OUTPUT_CHARACTER))
-            {
-                Status = STATUS_INVALID_PARAMETER;
-                break;
-            }
-            ASSERT(Irp->AssociatedIrp.SystemBuffer);
-
-            Buf = (POUTPUT_CHARACTER)Irp->AssociatedIrp.SystemBuffer;
-            nMaxLength = Buf->nLength;
-
-            Buf->dwTransfered = 0;
-            Irp->IoStatus.Information = sizeof(OUTPUT_CHARACTER);
-
-            if ( Buf->dwCoord.X < 0 || Buf->dwCoord.X >= DeviceExtension->Columns ||
-                 Buf->dwCoord.Y < 0 || Buf->dwCoord.Y >= DeviceExtension->Rows    ||
-                 nMaxLength == 0 )
-            {
-                Status = STATUS_SUCCESS;
-                break;
-            }
-
-            if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
-            {
-                vidmem = DeviceExtension->VideoMemory;
-                offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
-
-                nMaxLength = min(nMaxLength,
-                                 (DeviceExtension->Rows - Buf->dwCoord.Y)
-                                    * DeviceExtension->Columns - Buf->dwCoord.X);
-
-                for (dwCount = 0; dwCount < nMaxLength; dwCount++)
-                {
+#else
                     vidmem[offset + (dwCount * 2)] = (char)Buf->cCharacter;
+#endif
                 }
                 Buf->dwTransfered = dwCount;
             }
@@ -2246,7 +1572,6 @@ ScrIoControl(
 
     return Status;
 }
-#endif  /* ndef OPTIMIZED */
 
 static DRIVER_DISPATCH ScrDispatch;
 static NTSTATUS

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1212,9 +1212,6 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
-#ifdef OPTIMIZED
-                PUCHAR pch;
-#endif
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (dwCoord.X + dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1085,9 +1085,6 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
-#ifdef OPTIMIZED
-                pch = vidmem + offset;
-#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
 #ifdef OPTIMIZED

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1222,7 +1222,6 @@ ScrIoControl(
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
                 {
                     vidmem[offset + (dwCount * 2)] = *((PCHAR)pAttr);
-#endif
                 }
                 Irp->IoStatus.Information = dwCount * sizeof(USHORT);
             }

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -842,8 +842,6 @@ ScrWrite(
     return Status;
 }
 
-#define OPTIMIZED /* TODO: To be deleted */
-
 static DRIVER_DISPATCH ScrIoControl;
 static NTSTATUS
 NTAPI
@@ -1075,9 +1073,8 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
-#ifdef OPTIMIZED
                 UCHAR attr = Buf->wAttribute;
-#endif
+
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2 + 1;
 
@@ -1087,11 +1084,7 @@ ScrIoControl(
 
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
-#ifdef OPTIMIZED
                     vidmem[offset + (dwCount * 2)] = attr;
-#else
-                    vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
-#endif
                 }
                 Buf->dwTransfered = dwCount;
             }
@@ -1280,9 +1273,8 @@ ScrIoControl(
 
             if (DeviceExtension->Enabled && DeviceExtension->VideoMemory)
             {
-#ifdef OPTIMIZED
                 UCHAR ch = Buf->cCharacter;
-#endif
+
                 vidmem = DeviceExtension->VideoMemory;
                 offset = (Buf->dwCoord.X + Buf->dwCoord.Y * DeviceExtension->Columns) * 2;
 
@@ -1292,11 +1284,7 @@ ScrIoControl(
 
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
-#ifdef OPTIMIZED
                     vidmem[offset + (dwCount * 2)] = ch;
-#else
-                    vidmem[offset + (dwCount * 2)] = (char)Buf->cCharacter;
-#endif
                 }
                 Buf->dwTransfered = dwCount;
             }

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1219,9 +1219,6 @@ ScrIoControl(
                                  (DeviceExtension->Rows - dwCoord.Y)
                                     * DeviceExtension->Columns - dwCoord.X);
 
-#ifdef OPTIMIZED
-                pch = vidmem + offset;
-#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++, pAttr++)
                 {
 #ifdef OPTIMIZED

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1088,8 +1088,7 @@ ScrIoControl(
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
 #ifdef OPTIMIZED
-                    *pch = attr;
-                    pch += 2;
+                    vidmem[offset + (dwCount * 2)] = attr;
 #else
                     vidmem[offset + (dwCount * 2)] = (char)Buf->wAttribute;
 #endif

--- a/drivers/setup/blue/blue.c
+++ b/drivers/setup/blue/blue.c
@@ -1290,9 +1290,6 @@ ScrIoControl(
                                  (DeviceExtension->Rows - Buf->dwCoord.Y)
                                     * DeviceExtension->Columns - Buf->dwCoord.X);
 
-#ifdef OPTIMIZED
-                pch = vidmem + offset;
-#endif
                 for (dwCount = 0; dwCount < nMaxLength; dwCount++)
                 {
 #ifdef OPTIMIZED


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18838](https://jira.reactos.org/browse/CORE-18838)

## Proposed changes

- Optimize `IOCTL_CONSOLE_FILL_OUTPUT_ATTRIBUTE` and `IOCTL_CONSOLE_FILL_OUTPUT_CHARACTER` for speed by using cache.

## TODO

- [x] Do tests.
