### PR TITLE
Tag Win32SS related PRs with "Win32SS" label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -13,3 +13,6 @@ freeldr:
 
 ROSTESTS:
   - modules/rostests/**
+
+Win32SS:
+  - win32ss/**


### PR DESCRIPTION
Let the GitHub bot automatically tag PRs that touch Win32k code or Win32 client DLLs (namely GDI, USER, whatever). With this new label we can browse through these kind of PRs easily, similarly with those that touch the kernel which are labeled "Kernel & Hal".