### PR TITLE
[SCSIPORT] Flush and Free Map Registers

### DIFF
--- a/drivers/storage/port/scsiport/scsi.c
+++ b/drivers/storage/port/scsiport/scsi.c
@@ -653,11 +653,14 @@ SpiProcessCompletedRequest(
     PSCSI_PORT_LUN_EXTENSION LunExtension;
     LONG Result;
     PIRP Irp;
-    //ULONG SequenceNumber;
+    ULONG transferLen = 0;
+    PSCSI_SG_ADDRESS pListIter = SrbInfo->ScatterGather;
 
     Srb = SrbInfo->Srb;
     Irp = Srb->OriginalRequest;
     PIO_STACK_LOCATION IoStack = IoGetCurrentIrpStackLocation(Irp);
+
+    BOOLEAN isWrite = Srb->SrbFlags & SRB_FLAGS_DATA_OUT ? TRUE : FALSE;
 
     /* Get Lun extension */
     LunExtension = IoStack->DeviceObject->DeviceExtension;
@@ -683,8 +686,21 @@ SpiProcessCompletedRequest(
     /* Flush adapter if needed */
     if (SrbInfo->BaseOfMapRegister)
     {
-        /* TODO: Implement */
-        ASSERT(FALSE);
+        for(int i = 0;
+            i < SrbInfo->NumberOfMapRegisters     &&   /* Prevent Buffer overrun */
+            transferLen < Srb->DataTransferLength &&   /* Stop if request is complete */
+            pListIter;                                 /* Valid Pointer Check */
+            pListIter++, i++)
+        {
+            transferLen += pListIter->Length;
+        }
+
+        IoFlushAdapterBuffers(DeviceExtension->AdapterObject,
+                              Irp->MdlAddress,
+                              SrbInfo->BaseOfMapRegister,
+                              Srb->DataBuffer,
+                              transferLen,
+                              isWrite);
     }
 
     /* Clear the request */
@@ -718,8 +734,16 @@ SpiProcessCompletedRequest(
     /* Scatter/gather */
     if (Srb->SrbFlags & SRB_FLAGS_SGLIST_FROM_POOL)
     {
-        /* TODO: Implement */
-        ASSERT(FALSE);
+        ExFreePoolWithTag(SrbInfo->ScatterGather, TAG_SCSIPORT);
+        SrbInfo->ScatterGather = NULL;
+    }
+
+    /* Free Map Registers */
+    if (SrbInfo->NumberOfMapRegisters)
+    {
+        IoFreeMapRegisters(DeviceExtension->AdapterObject,
+                           SrbInfo->BaseOfMapRegister,
+                           SrbInfo->NumberOfMapRegisters);
     }
 
     /* Acquire spinlock (we're freeing SrbExtension) */

--- a/drivers/storage/port/scsiport/scsi.c
+++ b/drivers/storage/port/scsiport/scsi.c
@@ -686,9 +686,9 @@ SpiProcessCompletedRequest(
         BOOLEAN isWrite = !!(Srb->SrbFlags & SRB_FLAGS_DATA_OUT);
         ULONG i;
 
-        for(int i = 0;
-            i < SrbInfo->NumberOfMapRegisters && transferLen < Srb->DataTransferLength;
-            i++)
+        for (i = 0;
+             i < SrbInfo->NumberOfMapRegisters && transferLen < Srb->DataTransferLength;
+             i++)
         {
             transferLen += SrbInfo->ScatterGather[i].Length;
         }

--- a/drivers/storage/port/scsiport/scsi.c
+++ b/drivers/storage/port/scsiport/scsi.c
@@ -683,7 +683,8 @@ SpiProcessCompletedRequest(
     if (SrbInfo->BaseOfMapRegister && SrbInfo->ScatterGather)
     {
         ULONG transferLen = 0;
-        BOOLEAN isWrite = Srb->SrbFlags & SRB_FLAGS_DATA_OUT ? TRUE : FALSE;
+        BOOLEAN isWrite = !!(Srb->SrbFlags & SRB_FLAGS_DATA_OUT);
+        ULONG i;
 
         for(int i = 0;
             i < SrbInfo->NumberOfMapRegisters && transferLen < Srb->DataTransferLength;


### PR DESCRIPTION
- Flush Map registers once the DMA completes
- Free Map registers once the DMA completes
- Add support for SGL allocated from NonPagedPool

Test:
Force Allocations of SGL from Non Paged Pool and ensure OS boots and functions properly

Test Logs:
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
DHCPCSVC: Adapter Name: [{7cd69ac0-dabb-410a-b927-cb3961d174da}] (dynamic) SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
WARNING:  HalCalculateScatterGatherListSize at hal\halx86\generic\dma.c:1168 is UNIMPLEMENTED! SpiAdapterControlFORCING ALLOCATION FROM SGPOOL
SpiAdapterControlFORCING ALLOCATION FROM SGPOOL

TODO:
- [ ] Check when the request is not complete in a single DMA operation
