### PR TITLE
[COMCTL32][USER32] EDIT: WM_IME_CHAR: Rely on DefWindowProc...

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -4781,6 +4781,10 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
         break;
 
     case WM_IME_CHAR:
+#ifdef __REACTOS__
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+        break;
+#endif
     case WM_CHAR:
     {
         WCHAR charW = wParam;

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5063,6 +5063,11 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		break;
 
         case WM_IME_CHAR:
+#ifdef __REACTOS__
+	        /* Rely on DefWindowProc */
+            result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+            break;
+#else
             if (!unicode)
             {
                 WCHAR charW;
@@ -5076,6 +5081,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 		break;
             }
             /* fall through */
+#endif
 	case WM_CHAR:
 	{
 		WCHAR charW;


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-15289](https://jira.reactos.org/browse/CORE-15289), [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Use `DefWindowProc...` for `WM_IME_CHAR` handling. 

## TODO

- [x] Do small tests.
- [x] Do big tests.