### PR TITLE
[COMCTL32][USER32] EDIT: Call default on WM_IME_(END)COMPOSITION

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -5010,6 +5010,9 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 
     case WM_IME_COMPOSITION:
         EDIT_ImeComposition(hwnd, lParam, es);
+#ifdef __REACTOS__
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         break;
 
     case WM_IME_ENDCOMPOSITION:
@@ -5019,6 +5022,9 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
             es->selection_end = es->selection_start;
             es->composition_len= 0;
         }
+#ifdef __REACTOS__
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
+#endif
         break;
 
     case WM_IME_COMPOSITIONFULL:

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -5004,7 +5004,7 @@ static LRESULT CALLBACK EDIT_WindowProc(HWND hwnd, UINT msg, WPARAM wParam, LPAR
 #ifdef __REACTOS__
         if (FALSE) /* FIXME: Condition */
             return TRUE;
-        result = DefWindowProcW(hwnd, WM_IME_STARTCOMPOSITION, wParam, lParam);
+        result = DefWindowProcW(hwnd, msg, wParam, lParam);
 #endif
         break;
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -5308,7 +5308,7 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
             ImmReleaseContext(hwnd, hIMC);
         }
 
-        result = DefWindowProcT(hwnd, WM_IME_SETCONTEXT, wParam, lParam, unicode);
+        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
 #endif
 		break;
 
@@ -5324,6 +5324,9 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
 
 	case WM_IME_COMPOSITION:
                 EDIT_ImeComposition(hwnd, lParam, es);
+#ifdef __REACTOS__
+        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+#endif
 		break;
 
 	case WM_IME_ENDCOMPOSITION:
@@ -5333,6 +5336,9 @@ LRESULT WINAPI EditWndProc_common( HWND hwnd, UINT msg, WPARAM wParam, LPARAM lP
                         es->selection_end = es->selection_start;
                         es->composition_len= 0;
                 }
+#ifdef __REACTOS__
+        result = DefWindowProcT(hwnd, msg, wParam, lParam, unicode);
+#endif
 		break;
 
 	case WM_IME_COMPOSITIONFULL:


### PR DESCRIPTION
## Purpose
Implementing Japanese input...
JIRA issue: [CORE-15289](https://jira.reactos.org/browse/CORE-15289), [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `DefWindowProc...` function additionally in `WM_IME_COMPOSITION` and `WM_IME_ENDCOMPOSITION` handling.

## TODO

- [ ] Do big tests.