### PR TITLE
[MSI] Revert to previous working solution for disk usage display in dialog.c

### DIFF
--- a/dll/win32/msi/dialog.c
+++ b/dll/win32/msi/dialog.c
@@ -3206,7 +3206,11 @@ static void msi_dialog_vcl_add_drives( msi_dialog *dialog, msi_control *control 
     WCHAR cost_text[MAX_PATH];
     LPWSTR drives, ptr;
     LVITEMW lvitem;
+#ifdef __REACTOS__
+    DWORD size;
+#else
     DWORD size, flags;
+#endif
     int i = 0;
 
     cost = msi_vcl_get_cost(dialog);
@@ -3223,8 +3227,12 @@ static void msi_dialog_vcl_add_drives( msi_dialog *dialog, msi_control *control 
     ptr = drives;
     while (*ptr)
     {
+#ifdef __REACTOS__
+        if (GetDriveTypeW(ptr) != DRIVE_FIXED)
+#else
         if (GetVolumeInformationW(ptr, NULL, 0, NULL, 0, &flags, NULL, 0) &&
             flags & FILE_READ_ONLY_VOLUME)
+#endif
         {
             ptr += lstrlenW(ptr) + 1;
             continue;


### PR DESCRIPTION
Purpose : Continuing from [PR](https://github.com/reactos/reactos/pull/4951) since the remote branch was deleted

There is a bug, which displays empty optical drive as a valid Drive where applications can be installed, which is wrong. This change will skip displaying any drives that are not fixed in the disk usage table in the msi installer UI.

JIRA issue: [CORE-18758](https://jira.reactos.org/browse/CORE-18758)

Proposed changes

Revert to old solution from Doug Lyons which was working fine.
see [diff1](https://git.reactos.org/?p=reactos.git;a=commitdiff;h=d5265b07bbfb6ac6da190b8213cf2f3f8d9cd675;hp=05fb0f1c392484d774d0fafbb6ca6e0317a69fa7), [diff2](https://git.reactos.org/?p=reactos.git;a=commitdiff;h=864e20b881130cbc9668b8e253a31b8c325e9b99;hp=83fcd65700e8cf6d0c07c81d85a07e68c5d87cdc)