### PR TITLE
[MKISOFS] Fix MSVC build on ARM hosts

### DIFF
--- a/sdk/tools/mkisofs/schilytools/libmdigest/byte_order.h
+++ b/sdk/tools/mkisofs/schilytools/libmdigest/byte_order.h
@@ -61,7 +61,8 @@ extern "C" {
 		__BYTE_ORDER == __LITTLE_ENDIAN) || \
 	defined(CPU_IA32) || defined(CPU_X64) || \
 	defined(__ia64) || defined(__ia64__) || defined(__alpha__) || defined(_M_ALPHA) || \
-	defined(vax) || defined(MIPSEL) || defined(_ARM_) || defined(__arm64__)
+	defined(vax) || defined(MIPSEL) || \
+	defined(_ARM_) || defined(__arm64__) || defined(_M_ARM) || defined(_M_ARM64)
 #define	CPU_LITTLE_ENDIAN
 #define	IS_BIG_ENDIAN 0
 #define	IS_LITTLE_ENDIAN 1


### PR DESCRIPTION
This fixes build when using native MSVC build tools and ReactOS host-tools on ARM.