### PR TITLE
[FREELDR][SDK] Build UEFI bootloader for ARM32

### DIFF
--- a/boot/freeldr/freeldr/arch/arm/debug.c
+++ b/boot/freeldr/freeldr/arch/arm/debug.c
@@ -1,0 +1,35 @@
+/*
+ * PROJECT:     Freeldr ARM32
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * PURPOSE:     Arch specific debug
+ * COPYRIGHT:   Copyright 2022 Justin Miller <justinmiller100@gmail.com>
+ */
+
+#include <freeldr.h>
+#include <debug.h>
+
+#define QEMUUART 0x09000000
+volatile unsigned int * UART0DR = (unsigned int *) QEMUUART;
+
+BOOLEAN
+Rs232PortInitialize(IN ULONG ComPort,
+                    IN ULONG BaudRate)
+{
+    return TRUE;
+}
+
+VOID
+Rs232PortPutByte(UCHAR ByteToSend)
+{
+    *UART0DR = ByteToSend;
+}
+
+VOID
+FrLdrBugCheckWithMessage(
+    ULONG BugCode,
+    PCHAR File,
+    ULONG Line,
+    PSTR Format,
+    ...)
+{
+}

--- a/boot/freeldr/freeldr/arch/arm/entry.c
+++ b/boot/freeldr/freeldr/arch/arm/entry.c
@@ -18,14 +18,3 @@ RealEntryPoint(VOID)
 {
     BootMain("");
 }
-
-VOID
-FrLdrBugCheckWithMessage(
-    ULONG BugCode,
-    PCHAR File,
-    ULONG Line,
-    PSTR Format,
-    ...)
-{
-
-}

--- a/boot/freeldr/freeldr/arch/arm/macharm.c
+++ b/boot/freeldr/freeldr/arch/arm/macharm.c
@@ -18,7 +18,9 @@ ULONG gDiskReadBuffer, gFileSysBuffer;
 BOOLEAN ArmHwDetectRan;
 PCONFIGURATION_COMPONENT_DATA RootNode;
 
+#ifndef UEFIBOOT
 BOOLEAN AcpiPresent = FALSE;
+#endif
 
 ULONG FirstLevelDcacheSize;
 ULONG FirstLevelDcacheFillSize;
@@ -174,6 +176,7 @@ ArmHwIdle(VOID)
     /* UNIMPLEMENTED */
 }
 
+#ifndef UEFIBOOT
 VOID
 MachInit(IN PCCH CommandLine)
 {
@@ -229,3 +232,4 @@ MachInit(IN PCCH CommandLine)
     MachVtbl.HwDetect = ArmHwDetect;
     MachVtbl.HwIdle = ArmHwIdle;
 }
+#endif

--- a/boot/freeldr/freeldr/arch/uefi/stubs.c
+++ b/boot/freeldr/freeldr/arch/uefi/stubs.c
@@ -9,12 +9,14 @@
 
 #include <debug.h>
 
+#ifndef _M_ARM
 /* TODO: Handle this with custom Disk / partition setup */
 UCHAR
 DriveMapGetBiosDriveNumber(PCSTR DeviceName)
 {
     return 0;
 }
+#endif
 
 VOID
 StallExecutionProcessor(ULONG Microseconds)

--- a/boot/freeldr/freeldr/arch/uefi/uefildr.c
+++ b/boot/freeldr/freeldr/arch/uefi/uefildr.c
@@ -31,7 +31,9 @@ EfiEntry(
     return 0;
 }
 
+#ifndef _M_ARM
 VOID __cdecl Reboot(VOID)
 {
 
 }
+#endif

--- a/boot/freeldr/freeldr/include/debug.h
+++ b/boot/freeldr/freeldr/include/debug.h
@@ -38,7 +38,7 @@
 #define DPRINT_HEAP         15  // messages in a bottle
 #define DBG_CHANNELS_COUNT  16
 
-#if DBG && !defined(_M_ARM)
+#if DBG
 
     VOID    DebugInit(IN ULONG_PTR FrLdrSectionId);
     ULONG   DbgPrint(const char *Format, ...);

--- a/boot/freeldr/freeldr/lib/debug.c
+++ b/boot/freeldr/freeldr/lib/debug.c
@@ -20,7 +20,7 @@
 #include <freeldr.h>
 #include <debug.h>
 
-#if DBG && !defined(_M_ARM)
+#if DBG
 
 // #define DEBUG_ALL
 // #define DEBUG_WARN
@@ -53,6 +53,11 @@ ULONG ComPort  = 0; // The COM port initializer chooses the first available port
 ULONG PortIrq  = 0; // Not used at the moment.
 
 BOOLEAN DebugStartOfLine = TRUE;
+
+#ifdef UEFIBOOT
+VOID
+ARMWriteToUART(UCHAR Data);
+#endif
 
 VOID DebugInit(IN ULONG_PTR FrLdrSectionId)
 {

--- a/boot/freeldr/freeldr/uefi.cmake
+++ b/boot/freeldr/freeldr/uefi.cmake
@@ -28,6 +28,9 @@ if(ARCH STREQUAL "i386")
 elseif(ARCH STREQUAL "amd64")
     #TBD
 elseif(ARCH STREQUAL "arm")
+    list(APPEND UEFILDR_ARC_SOURCE
+        arch/arm/macharm.c
+        arch/arm/debug.c)
     #TBD
 elseif(ARCH STREQUAL "arm64")
     #TBD
@@ -85,7 +88,10 @@ set_target_properties(uefildr PROPERTIES SUFFIX ".efi")
 target_compile_definitions(uefildr PRIVATE UEFIBOOT)
 
 if(MSVC)
-    target_link_options(uefildr PRIVATE /DYNAMICBASE:NO /NXCOMPAT:NO /ignore:4078 /ignore:4254 /DRIVER)
+if(NOT ARCH STREQUAL "arm")
+    target_link_options(uefildr PRIVATE /DYNAMICBASE:NO)
+endif()
+    target_link_options(uefildr PRIVATE /NXCOMPAT:NO /ignore:4078 /ignore:4254 /DRIVER)
     # We don't need hotpatching
     remove_target_compile_option(uefildr "/hotpatch")
 else()

--- a/boot/freeldr/freeldr/ui/directui.c
+++ b/boot/freeldr/freeldr/ui/directui.c
@@ -6,8 +6,7 @@
  * PROGRAMMERS:     ReactOS Portable Systems Group
  */
 
-#ifdef _M_ARM
-
+#if 0
 #include <freeldr.h>
 
 /* GLOBALS ********************************************************************/

--- a/boot/freeldr/freeldr/ui/gui.c
+++ b/boot/freeldr/freeldr/ui/gui.c
@@ -17,7 +17,6 @@
  *  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
  */
 
-#ifndef _M_ARM
 #include <freeldr.h>
 
 VOID GuiDrawBackdrop(VOID)
@@ -113,4 +112,3 @@ const UIVTBL GuiVtbl =
     NULL, NULL, NULL, NULL, NULL, NULL, NULL,
     NULL
 };
-#endif

--- a/boot/freeldr/freeldr/ui/minitui.c
+++ b/boot/freeldr/freeldr/ui/minitui.c
@@ -13,8 +13,6 @@
 // #define NTLDR_PROGRESSBAR
 // #define BTMGR_PROGRESSBAR /* Default style */
 
-#ifndef _M_ARM
-
 BOOLEAN MiniTuiInitialize(VOID)
 {
     /* Initialize main TUI */
@@ -70,8 +68,6 @@ VOID MiniTuiDrawStatusText(PCSTR StatusText)
 {
     /* Minimal UI doesn't have a status bar */
 }
-
-#endif // _M_ARM
 
 /*static*/ VOID
 MiniTuiSetProgressBarText(
@@ -143,10 +139,8 @@ MiniTuiTickProgressBar(
                 UiProgressBar.Right, UiProgressBar.Bottom,
                 ' ', ATTR(UiTextColor, UiMenuBgColor));
 
-#ifndef _M_ARM
     TuiUpdateDateTime();
     VideoCopyOffScreenBufferToVRAM();
-#endif
 }
 
 VOID
@@ -191,10 +185,8 @@ MiniTuiDrawMenu(
 {
     ULONG i;
 
-#ifndef _M_ARM
     /* Draw the backdrop */
     UiDrawBackdrop();
-#endif
 
     /* No GUI status bar text, just minimal text. Show the menu header. */
     if (MenuInfo->MenuHeader)
@@ -239,12 +231,8 @@ MiniTuiDrawMenu(
         DisplayBootTimeOptions();
     }
 
-#ifndef _M_ARM
     VideoCopyOffScreenBufferToVRAM();
-#endif
 }
-
-#ifndef _M_ARM
 
 const UIVTBL MiniTuiVtbl =
 {
@@ -274,4 +262,3 @@ const UIVTBL MiniTuiVtbl =
     MiniTuiDrawMenu,
 };
 
-#endif // _M_ARM

--- a/boot/freeldr/freeldr/ui/noui.c
+++ b/boot/freeldr/freeldr/ui/noui.c
@@ -6,7 +6,6 @@
  * PROGRAMMERS:     Hervé Poussineau
  */
 
-#ifndef _M_ARM
 #include <freeldr.h>
 
 BOOLEAN NoUiInitialize(VOID)
@@ -183,5 +182,3 @@ NoUiDrawMenu(
     _In_ PUI_MENU_INFO MenuInfo)
 {
 }
-
-#endif // _M_ARM

--- a/boot/freeldr/freeldr/ui/tui.c
+++ b/boot/freeldr/freeldr/ui/tui.c
@@ -19,9 +19,7 @@
 
 #include <freeldr.h>
 
-#ifndef _M_ARM
 PVOID TextVideoBuffer = NULL;
-#endif
 
 /* GENERIC TUI UTILS *********************************************************/
 
@@ -93,9 +91,7 @@ TuiDrawText2(
     _In_reads_or_z_(MaxNumChars) PCSTR Text,
     _In_ UCHAR Attr)
 {
-#ifndef _M_ARM
     PUCHAR ScreenMemory = (PUCHAR)TextVideoBuffer;
-#endif
     ULONG i, j;
 
     /* Don't display anything if we are out of the screen */
@@ -105,13 +101,8 @@ TuiDrawText2(
     /* Draw the text, not exceeding the width */
     for (i = X, j = 0; Text[j] && i < UiScreenWidth && (MaxNumChars > 0 ? j < MaxNumChars : TRUE); i++, j++)
     {
-#ifndef _M_ARM
         ScreenMemory[((Y*2)*UiScreenWidth)+(i*2)]   = (UCHAR)Text[j];
         ScreenMemory[((Y*2)*UiScreenWidth)+(i*2)+1] = Attr;
-#else
-        /* Write the character */
-        MachVideoPutChar(Text[j], Attr, i, Y);
-#endif
     }
 }
 
@@ -195,8 +186,6 @@ TuiDrawCenteredText(
 }
 
 /* FULL TUI THEME ************************************************************/
-
-#ifndef _M_ARM
 
 #define TAG_TUI_SCREENBUFFER 'SiuT'
 #define TAG_TUI_PALETTE      'PiuT'
@@ -802,10 +791,8 @@ TuiTickProgressBar(
                 UiProgressBar.Right, UiProgressBar.Bottom,
                 '\xB2', ATTR(UiTextColor, UiMenuBgColor));
 
-#ifndef _M_ARM
     TuiUpdateDateTime();
     VideoCopyOffScreenBufferToVRAM();
-#endif
 }
 
 static VOID
@@ -1241,5 +1228,3 @@ const UIVTBL TuiVtbl =
     TuiDisplayMenu,
     TuiDrawMenu,
 };
-
-#endif // _M_ARM

--- a/boot/freeldr/freeldr/ui/tuimenu.c
+++ b/boot/freeldr/freeldr/ui/tuimenu.c
@@ -91,11 +91,7 @@ TuiDisplayMenu(
     TuiCalcMenuBoxSize(&MenuInformation);
 
     /* Draw the menu */
-#ifdef _M_ARM
-    UiDrawMenu(&MenuInformation);
-#else
     UiVtbl.DrawMenu(&MenuInformation);
-#endif
 
     /* Get the current second of time */
     LastClockSecond = ArcGetTime()->Second;
@@ -117,10 +113,9 @@ TuiDisplayMenu(
             /* Update the time information */
             LastClockSecond = CurrentClockSecond;
 
-#ifndef _M_ARM // FIXME: Theme-specific
+            // FIXME: Theme-specific
             /* Update the date & time */
             TuiUpdateDateTime();
-#endif
 
             /* If there is a countdown, update it */
             if (MenuInformation.MenuTimeRemaining > 0)
@@ -131,19 +126,13 @@ TuiDisplayMenu(
             else if (MenuInformation.MenuTimeRemaining == 0)
             {
                 /* A timeout occurred, exit this loop and return selection */
-#ifndef _M_ARM
                 VideoCopyOffScreenBufferToVRAM();
-#endif
                 break;
             }
-#ifndef _M_ARM
             VideoCopyOffScreenBufferToVRAM();
-#endif
         }
 
-#ifndef _M_ARM
         MachHwIdle();
-#endif
     }
 
     /* Return the selected item */
@@ -178,7 +167,6 @@ TuiCalcMenuBoxSize(
     /* Allow room for left & right borders, plus 8 spaces on each side */
     Width += 18;
 
-#ifndef _M_ARM
     /* Check if we're drawing a centered menu */
     if (UiCenterMenu)
     {
@@ -188,7 +176,6 @@ TuiCalcMenuBoxSize(
                           Height) / 2) + TUI_TITLE_BOX_CHAR_HEIGHT;
     }
     else
-#endif
     {
         /* Put the menu in the default left-corner position */
         MenuInfo->Left = -1;
@@ -206,21 +193,9 @@ TuiDrawMenu(
 {
     ULONG i;
 
-#ifndef _M_ARM // FIXME: Theme-specific
+    // FIXME: Theme-specific
     /* Draw the backdrop */
     UiDrawBackdrop();
-#else
-
-    /* No GUI status bar text, just minimal text. Show the menu header. */
-    if (MenuInfo->MenuHeader)
-    {
-        UiDrawText(0,
-                   MenuInfo->Top - 2,
-                   MenuInfo->MenuHeader,
-                   ATTR(UiMenuFgColor, UiMenuBgColor));
-    }
-
-#endif
 
     /* Draw the menu box */
     TuiDrawMenuBox(MenuInfo);
@@ -231,33 +206,9 @@ TuiDrawMenu(
         TuiDrawMenuItem(MenuInfo, i);
     }
 
-#ifndef _M_ARM // FIXME: Theme-specific
-
+    // FIXME: Theme-specific
     /* Update the status bar */
     UiVtbl.DrawStatusText("Use \x18 and \x19 to select, then press ENTER.");
-
-#else
-
-    /* Now tell the user how to choose */
-    UiDrawText(0,
-               MenuInfo->Bottom + 1,
-               "Use \x18 and \x19 to move the highlight to your choice.",
-               ATTR(UiMenuFgColor, UiMenuBgColor));
-    UiDrawText(0,
-               MenuInfo->Bottom + 2,
-               "Press ENTER to choose.",
-               ATTR(UiMenuFgColor, UiMenuBgColor));
-
-    /* And show the menu footer */
-    if (MenuInfo->MenuFooter)
-    {
-        UiDrawText(0,
-                   UiScreenHeight - 4,
-                   MenuInfo->MenuFooter,
-                   ATTR(UiMenuFgColor, UiMenuBgColor));
-    }
-
-#endif
 
     /* Display the boot options if needed */
     if (MenuInfo->ShowBootOptions)
@@ -265,9 +216,7 @@ TuiDrawMenu(
         DisplayBootTimeOptions();
     }
 
-#ifndef _M_ARM
     VideoCopyOffScreenBufferToVRAM();
-#endif
 }
 
 static VOID
@@ -330,7 +279,6 @@ TuiDrawMenuTimeout(
      *  1       1       Pad on the left with blanks + box bottom border.
      **/
 
-#ifndef _M_ARM
     if (UiCenterMenu)
     {
         /* In boxed menu mode, pad on the left with blanks and box border,
@@ -368,7 +316,6 @@ TuiDrawMenuTimeout(
         }
     }
     else
-#endif
     {
         if (Length > 0)
         {
@@ -385,13 +332,8 @@ TuiDrawMenuTimeout(
                     MenuInfo->Bottom + 4,
                     Length ? (Length + 1) : (UiScreenWidth - 1),
                     MenuInfo->Bottom + 4,
-#ifndef _M_ARM
                     UiBackdropFillStyle,
                     ATTR(UiBackdropFgColor, UiBackdropBgColor)
-#else
-                    0, // ' '
-                    ATTR(UiTextColor, COLOR_BLACK) // UiMenuBgColor
-#endif
                     );
     }
 }
@@ -400,7 +342,7 @@ VOID
 TuiDrawMenuBox(
     _In_ PUI_MENU_INFO MenuInfo)
 {
-#ifndef _M_ARM // FIXME: Theme-specific
+    // FIXME: Theme-specific
     /* Draw the menu box if requested */
     if (UiMenuBox)
     {
@@ -417,8 +359,6 @@ TuiDrawMenuBox(
 
     /* Update the date & time */
     TuiUpdateDateTime();
-#endif
-
     TuiDrawMenuTimeout(MenuInfo);
 }
 
@@ -435,7 +375,7 @@ TuiDrawMenuItem(
     /* If this is a separator */
     if (MenuInfo->MenuItemList[MenuItemNumber] == NULL)
     {
-#ifndef _M_ARM // FIXME: Theme-specific
+        // FIXME: Theme-specific
         /* Draw its left box corner */
         if (UiMenuBox)
         {
@@ -444,7 +384,6 @@ TuiDrawMenuItem(
                        "\xC7",
                        ATTR(UiMenuFgColor, UiMenuBgColor));
         }
-#endif
 
         /* Make it a separator line and use menu colors */
         RtlZeroMemory(MenuLineText, sizeof(MenuLineText));
@@ -458,7 +397,7 @@ TuiDrawMenuItem(
                    MenuLineText,
                    ATTR(UiMenuFgColor, UiMenuBgColor));
 
-#ifndef _M_ARM // FIXME: Theme-specific
+        // FIXME: Theme-specific
         /* Draw its right box corner */
         if (UiMenuBox)
         {
@@ -467,7 +406,6 @@ TuiDrawMenuItem(
                        "\xB6",
                        ATTR(UiMenuFgColor, UiMenuBgColor));
         }
-#endif
 
         /* We are done */
         return;
@@ -476,7 +414,6 @@ TuiDrawMenuItem(
     /* This is not a separator */
     ASSERT(MenuInfo->MenuItemList[MenuItemNumber]);
 
-#ifndef _M_ARM
     /* Check if using centered menu */
     if (UiCenterMenu)
     {
@@ -491,7 +428,6 @@ TuiDrawMenuItem(
         SpaceRight = (SpaceTotal - SpaceLeft) + 1;
     }
     else
-#endif
     {
         /* Simply left-align it */
         SpaceLeft  = 4;
@@ -556,11 +492,7 @@ TuiProcessMenuKeyboardEvent(
         KeyPressFilter(KeyEvent, MenuInfo->SelectedMenuItem, MenuInfo->Context))
     {
         /* It processed the key character, so redraw and exit */
-#ifdef _M_ARM
-        UiDrawMenu(MenuInfo);
-#else
         UiVtbl.DrawMenu(MenuInfo);
-#endif
         return 0;
     }
 
@@ -618,9 +550,7 @@ TuiProcessMenuKeyboardEvent(
 
         /* Select new item and update video buffer */
         TuiDrawMenuItem(MenuInfo, MenuInfo->SelectedMenuItem);
-#ifndef _M_ARM
         VideoCopyOffScreenBufferToVRAM();
-#endif
     }
 
     /* Return the pressed key */

--- a/boot/freeldr/freeldr/ui/ui.c
+++ b/boot/freeldr/freeldr/ui/ui.c
@@ -22,8 +22,6 @@
 #include <debug.h>
 DBG_DEFAULT_CHANNEL(UI);
 
-#ifndef _M_ARM
-
 UCHAR UiStatusBarFgColor;       // Status bar foreground color
 UCHAR UiStatusBarBgColor;       // Status bar background color
 UCHAR UiBackdropFgColor;        // Backdrop foreground color
@@ -56,16 +54,12 @@ const PCSTR UiMonthNames[12] = { "January", "February", "March", "April", "May",
 ULONG UiScreenWidth;    // Screen Width
 ULONG UiScreenHeight;   // Screen Height
 
-#endif // _M_ARM
-
 /*
  * Loading progress bar, based on the NTOS Inbv one.
  * Supports progress within sub-ranges, used when loading
  * with an unknown number of steps.
  */
 UI_PROGRESS_BAR UiProgressBar = {{0}};
-
-#ifndef _M_ARM
 
 UIVTBL UiVtbl =
 {
@@ -386,8 +380,6 @@ UCHAR UiTextToFillStyle(PCSTR FillStyleText)
     return UiVtbl.TextToFillStyle(FillStyleText);
 }
 
-#endif // _M_ARM
-
 VOID
 UiInitProgressBar(
     _In_ ULONG Left,
@@ -413,13 +405,8 @@ UiInitProgressBar(
     UiProgressBar.Show = TRUE;
 
     /* Initial drawing: set the "Loading..." text and the original position */
-#ifndef _M_ARM
     UiVtbl.SetProgressBarText(ProgressText);
     UiVtbl.TickProgressBar(0);
-#else
-    MiniTuiSetProgressBarText(ProgressText);
-    MiniTuiTickProgressBar(0);
-#endif
 }
 
 VOID
@@ -477,11 +464,7 @@ UiUpdateProgressBar(
     TotalProgress = UiProgressBar.State.Floor + (Percentage * UiProgressBar.State.Bias);
     // TotalProgress /= (100 * 100);
 
-#ifndef _M_ARM
     UiVtbl.TickProgressBar(TotalProgress);
-#else
-    MiniTuiTickProgressBar(TotalProgress);
-#endif
 }
 
 VOID
@@ -492,22 +475,14 @@ UiSetProgressBarText(
     if (!UiProgressBar.Show)
         return;
 
-#ifndef _M_ARM
     UiVtbl.SetProgressBarText(ProgressText);
-#else
-    MiniTuiSetProgressBarText(ProgressText);
-#endif
 }
 
 VOID
 UiDrawProgressBarCenter(
     _In_ PCSTR ProgressText)
 {
-#ifndef _M_ARM
     UiVtbl.DrawProgressBarCenter(ProgressText);
-#else
-    MiniTuiDrawProgressBarCenter(ProgressText);
-#endif
 }
 
 VOID
@@ -518,14 +493,8 @@ UiDrawProgressBar(
     _In_ ULONG Bottom,
     _In_ PCSTR ProgressText)
 {
-#ifndef _M_ARM
     UiVtbl.DrawProgressBar(Left, Top, Right, Bottom, ProgressText);
-#else
-    MiniTuiDrawProgressBar(Left, Top, Right, Bottom, ProgressText);
-#endif
 }
-
-#ifndef _M_ARM
 
 static VOID
 UiEscapeString(PCHAR String)
@@ -662,9 +631,3 @@ BOOLEAN UiEditBox(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length)
     return UiVtbl.EditBox(MessageText, EditTextBuffer, Length);
 }
 
-#else
-BOOLEAN UiEditBox(PCSTR MessageText, PCHAR EditTextBuffer, ULONG Length)
-{
-    return FALSE;
-}
-#endif

--- a/boot/freeldr/freeldr/ui/video.c
+++ b/boot/freeldr/freeldr/ui/video.c
@@ -5,7 +5,6 @@
  * COPYRIGHT:   Copyright 1998-2003 Brian Palmer <brianp@sginet.com>
  */
 
-#ifndef _M_ARM
 #include <freeldr.h>
 
 #define RGB_MAX                 64
@@ -173,4 +172,3 @@ VOID VideoFadeOut(ULONG ColorCount)
     }
 }
 
-#endif

--- a/sdk/lib/crt/float/float.cmake
+++ b/sdk/lib/crt/float/float.cmake
@@ -40,7 +40,14 @@ elseif(ARCH STREQUAL "arm")
         float/arm/_fpreset.c
         float/arm/_statusfp.c
     )
+    list(APPEND LIBCNTPR_FLOAT_SOURCE
+        float/arm/_controlfp.c
+    )
     list(APPEND CRT_FLOAT_ASM_SOURCE
+        float/arm/__getfp.s
+        float/arm/__setfp.s
+    )
+    list(APPEND LIBCNTPR_FLOAT_ASM_SOURCE
         float/arm/__getfp.s
         float/arm/__setfp.s
     )


### PR DESCRIPTION
## Purpose

In the beginning of the ARM port FreeLoader's UI functions were too slow on targeted devices. As such the solution was to split off from that and minimize what those ARM devices needed to do to achieve the FreeLoader Ui. Now in the present world we use MSVC which breaks compatibility with the devices we used to target; None of these newer device have issues with the way FreeLoader draws so we are going to attempt to unify this here today. This PR lays nearly everything we need for ARM32 to boot up to FreeLoader from EFI ARM devices. 

-> This PR will have a single link error left that'll be solved in another PR due to its complexity 

JIRA issue: [CORE-17604](https://jira.reactos.org/browse/CORE-17604)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- Disable some redundant function defined elsewhere on ARM32
- Remove some unused link options
- link _controlfp to the float cmake target
- Add the missing ARM specific code into the mach file of ARM freeeldr
- Add a hard coded UART address for QEMU ARM32/ARM64 so we can have serial debugging in freeldr
- Unify the UI drawing calls
