### PR TITLE
[NTOS:IO] Fix CurrentByteOffset to FILE_APPEND_DATA DesiredAccess

### DIFF
--- a/ntoskrnl/io/iomgr/iofunc.c
+++ b/ntoskrnl/io/iomgr/iofunc.c
@@ -3907,6 +3907,8 @@ NtWriteFile(IN HANDLE FileHandle,
         /* Give the drivers something to understand */
         CapturedByteOffset.u.LowPart = FILE_WRITE_TO_END_OF_FILE;
         CapturedByteOffset.u.HighPart = -1;
+        FileObject->CurrentByteOffset.u.LowPart = FILE_WRITE_TO_END_OF_FILE;
+        FileObject->CurrentByteOffset.u.HighPart = -1;
     }
 
     /* Check for event */


### PR DESCRIPTION
As the NtWriteFile test indicates for FILE_APPEND_DATA access right, the file pointer must be set to the end of the file in NtWriteFile before the write operation.

JIRA issue: [CORE-18789](https://jira.reactos.org/browse/CORE-18789)