### PR TITLE
[KERNEL32] LCMapString: Hiragana/Katakana conversion

### DIFF
--- a/dll/win32/kernel32/winnls/string/lang.c
+++ b/dll/win32/kernel32/winnls/string/lang.c
@@ -2016,7 +2016,7 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
         {
             /*
              * U+3041 ... U+3093: Hiragana
-             * U+3095: HIRAGANA LETTER SMALL KA
+             * U+3095: Hiragana Letter Small KA
              * U+309D: Hiragana Iteration Mark
              */
             WCHAR wch = *dst_ptr;
@@ -2031,7 +2031,7 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
         {
             /*
              * U+30A1 ... U+30F3: Katakana
-             * U+30F5: KATAKANA LETTER SMALL KA
+             * U+30F5: Katakana Letter Small KA
              * U+30FD: Katakana Iteration Mark
              */
             WCHAR wch = *dst_ptr;

--- a/dll/win32/kernel32/winnls/string/lang.c
+++ b/dll/win32/kernel32/winnls/string/lang.c
@@ -2014,13 +2014,14 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
         INT convlen = dst_ptr - dst;
         for (dst_ptr = dst; convlen; --convlen, ++dst_ptr)
         {
+            /*
+             * U+3041 ... U+3093: Hiragana
+             * U+3095: HIRAGANA LETTER SMALL KA
+             * U+309D: Hiragana Iteration Mark
+             */
             WCHAR wch = *dst_ptr;
-            if (0x3041 <= wch && wch <= 0x3093) /* U+3041 ... U+3093: Hiragana */
+            if ((0x3041 <= wch && wch <= 0x3093) || wch == 0x3095 || wch == 0x309D)
                 *dst_ptr = wch + 0x60; /* Hiragana to Katanaka */
-            else if (wch == 0x3095) /* U+3095: HIRAGANA LETTER SMALL KA */
-                *dst_ptr = 0x30F5; /* U+30F5: KATAKANA LETTER SMALL KA */
-            else if (wch == 0x309D) /* U+309D: Hiragana Iteration Mark */
-                *dst_ptr = 0x30FD; /* U+30FD: Katakana Iteration Mark */
         }
     }
     else if (flags & LCMAP_HIRAGANA)
@@ -2028,13 +2029,14 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
         INT convlen = dst_ptr - dst;
         for (dst_ptr = dst; convlen; --convlen, ++dst_ptr)
         {
+            /*
+             * U+30A1 ... U+30F3: Katakana
+             * U+30F5: KATAKANA LETTER SMALL KA
+             * U+30FD: Katakana Iteration Mark
+             */
             WCHAR wch = *dst_ptr;
-            if (0x30A1 <= wch && wch <= 0x30F3) /* U+30A1 ... U+30F3: Katakana */
+            if ((0x30A1 <= wch && wch <= 0x30F3) || wch == 0x30F5 || wch == 0x30FD)
                 *dst_ptr = wch - 0x60; /* Katanaka to Hiragana */
-            else if (wch == 0x30F5) /* U+30F5: KATAKANA LETTER SMALL KA */
-                *dst_ptr = 0x3095; /* U+3095: HIRAGANA LETTER SMALL KA */
-            else if (wch == 0x30FD) /* U+30FD: Katakana Iteration Mark */
-                *dst_ptr = 0x309D; /* U+309D: Hiragana Iteration Mark */
         }
     }
 #endif

--- a/dll/win32/kernel32/winnls/string/lang.c
+++ b/dll/win32/kernel32/winnls/string/lang.c
@@ -1991,6 +1991,36 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
             dstlen--;
         }
     }
+#ifdef __REACTOS__
+    else if (flags & LCMAP_KATAKANA)
+    {
+        for (dst_ptr = dst; srclen && dstlen; src++, srclen--)
+        {
+            WCHAR wch = *src;
+            if ((flags & NORM_IGNORESYMBOLS) && (get_char_typeW(wch) & (C1_PUNCT | C1_SPACE)))
+                continue;
+            if (0x3041 <= wch && wch <= 0x3093) /* U+3041 ... U+3093: Hiragana */
+                *dst_ptr++ = wch + 0x60;
+            else
+                *dst_ptr++ = wch;
+            dstlen--;
+        }
+    }
+    else if (flags & LCMAP_HIRAGANA)
+    {
+        for (dst_ptr = dst; srclen && dstlen; src++, srclen--)
+        {
+            WCHAR wch = *src;
+            if ((flags & NORM_IGNORESYMBOLS) && (get_char_typeW(wch) & (C1_PUNCT | C1_SPACE)))
+                continue;
+            if (0x30A1 <= wch && wch <= 0x30F3) /* U+30A1 ... U+30F3: Katakana */
+                *dst_ptr++ = wch - 0x60;
+            else
+                *dst_ptr++ = wch;
+            dstlen--;
+        }
+    }
+#endif
     else
     {
         if (src == dst)

--- a/dll/win32/kernel32/winnls/string/lang.c
+++ b/dll/win32/kernel32/winnls/string/lang.c
@@ -2012,33 +2012,29 @@ INT WINAPI LCMapStringEx(LPCWSTR name, DWORD flags, LPCWSTR src, INT srclen, LPW
     if (flags & LCMAP_KATAKANA)
     {
         INT convlen = dst_ptr - dst;
-        for (dst_ptr = dst; convlen; convlen--)
+        for (dst_ptr = dst; convlen; --convlen, ++dst_ptr)
         {
             WCHAR wch = *dst_ptr;
             if (0x3041 <= wch && wch <= 0x3093) /* U+3041 ... U+3093: Hiragana */
-                *dst_ptr++ = wch + 0x60; /* Hiragana to Katanaka */
+                *dst_ptr = wch + 0x60; /* Hiragana to Katanaka */
             else if (wch == 0x3095) /* U+3095: HIRAGANA LETTER SMALL KA */
-                *dst_ptr++ = 0x30F5; /* U+30F5: KATAKANA LETTER SMALL KA */
+                *dst_ptr = 0x30F5; /* U+30F5: KATAKANA LETTER SMALL KA */
             else if (wch == 0x309D) /* U+309D: Hiragana Iteration Mark */
-                *dst_ptr++ = 0x30FD; /* U+30FD: Katakana Iteration Mark */
-            else
-                *dst_ptr++;
+                *dst_ptr = 0x30FD; /* U+30FD: Katakana Iteration Mark */
         }
     }
     else if (flags & LCMAP_HIRAGANA)
     {
         INT convlen = dst_ptr - dst;
-        for (dst_ptr = dst; convlen; convlen--)
+        for (dst_ptr = dst; convlen; --convlen, ++dst_ptr)
         {
             WCHAR wch = *dst_ptr;
             if (0x30A1 <= wch && wch <= 0x30F3) /* U+30A1 ... U+30F3: Katakana */
-                *dst_ptr++ = wch - 0x60; /* Katanaka to Hiragana */
+                *dst_ptr = wch - 0x60; /* Katanaka to Hiragana */
             else if (wch == 0x30F5) /* U+30F5: KATAKANA LETTER SMALL KA */
-                *dst_ptr++ = 0x3095; /* U+3095: HIRAGANA LETTER SMALL KA */
+                *dst_ptr = 0x3095; /* U+3095: HIRAGANA LETTER SMALL KA */
             else if (wch == 0x30FD) /* U+30FD: Katakana Iteration Mark */
-                *dst_ptr++ = 0x309D; /* U+309D: Hiragana Iteration Mark */
-            else
-                *dst_ptr++;
+                *dst_ptr = 0x309D; /* U+309D: Hiragana Iteration Mark */
         }
     }
 #endif


### PR DESCRIPTION
## Purpose

Support Japanese Hiragana and Katakana conversion.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Implement `LCMAP_KATAKANA` and `LCMAP_HIRAGANA` flags.

## TODO

- [x] Do big tests.