### PR TITLE
[SHELL32] Add support for shell: folder shortcuts

### DIFF
--- a/dll/win32/shell32/folders/CDesktopFolder.cpp
+++ b/dll/win32/shell32/folders/CDesktopFolder.cpp
@@ -332,7 +332,7 @@ HRESULT WINAPI CDesktopFolder::ParseDisplayName(
         if (urldata.nScheme == URL_SCHEME_SHELL) /* handle shell: urls */
         {
             TRACE ("-- shell url: %s\n", debugstr_w(urldata.pszSuffix));
-            pidlTemp = _ILCreateGuidFromStrW(urldata.pszSuffix + 2);
+            pidlTemp = _ILCreateGuidFromShellUrlW(urldata.pszSuffix);
         }
         else
             return IEParseDisplayNameWithBCW(CP_ACP, lpszDisplayName, pbc, ppidl);

--- a/dll/win32/shell32/wine/pidl.c
+++ b/dll/win32/shell32/wine/pidl.c
@@ -1682,11 +1682,25 @@ LPITEMIDLIST _ILCreateBitBucket(void)
     return _ILCreateGuid(PT_GUID, &CLSID_RecycleBin);
 }
 
+#ifdef __REACTOS__
+LPITEMIDLIST _ILCreateFonts(void)
+{
+    TRACE("()\n");
+    return _ILCreateGuid(PT_GUID, &CLSID_FontsFolderShortcut);
+}
+
 LPITEMIDLIST _ILCreateAdminTools(void)
 {
     TRACE("()\n");
     return _ILCreateGuid(PT_GUID, &CLSID_AdminFolderShortcut); //FIXME
 }
+
+LPITEMIDLIST _ILCreateConnections(void)
+{
+    TRACE("()\n");
+    return _ILCreateGuid(PT_GUID, &CLSID_ConnectionFolder);
+}
+#endif
 
 LPITEMIDLIST _ILCreateGuid(PIDLTYPE type, REFIID guid)
 {
@@ -1724,7 +1738,34 @@ LPITEMIDLIST _ILCreateGuidFromStrA(LPCSTR szGUID)
     }
     return _ILCreateGuid(PT_GUID, &iid);
 }
-#endif
+#endif // __REACTOS__
+
+#ifdef __REACTOS__
+UINT _SHGetCSIDLByNameW(LPCWSTR lpszName);
+
+// If szUrl is '::{GUID}' then returns a GUID
+// otherwise it tries to resolve the shortcut.
+LPITEMIDLIST _ILCreateGuidFromShellUrlW(LPCWSTR szUrl)
+{
+    UINT idx;
+    LPITEMIDLIST pidl;
+
+    if (szUrl[0] == L':' && szUrl[1] == L':')
+    {
+        return _ILCreateGuidFromStrW(szUrl + 2);
+    }
+
+    idx = _SHGetCSIDLByNameW(szUrl);
+    if (idx == UINT_MAX)
+    {
+        ERR("%s is not a shell shortcut\n", debugstr_w(szUrl));
+        return NULL;
+    }
+
+    SHGetSpecialFolderLocation(NULL, idx, &pidl);
+    return pidl;
+}
+#endif // __REACTOS__
 
 LPITEMIDLIST _ILCreateGuidFromStrW(LPCWSTR szGUID)
 {

--- a/dll/win32/shell32/wine/pidl.h
+++ b/dll/win32/shell32/wine/pidl.h
@@ -269,6 +269,10 @@ LPITEMIDLIST	_ILCreateGuid(PIDLTYPE type, REFIID guid) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateGuidFromStrA(LPCSTR szGUID) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateGuidFromStrW(LPCWSTR szGUID) DECLSPEC_HIDDEN;
 
+#ifdef __REACTOS__
+LPITEMIDLIST    _ILCreateGuidFromShellUrlW(LPCWSTR szUrl) DECLSPEC_HIDDEN;
+#endif
+
 /* Commonly used PIDLs representing file system objects. */
 LPITEMIDLIST	_ILCreateDesktop	(void) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateFromFindDataW(const WIN32_FIND_DATAW *stffile) DECLSPEC_HIDDEN;
@@ -283,7 +287,9 @@ LPITEMIDLIST	_ILCreatePrinters	(void) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateNetwork	(void) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateNetHood	(void) DECLSPEC_HIDDEN;
 #ifdef __REACTOS__
+LPITEMIDLIST	_ILCreateFonts		(void);
 LPITEMIDLIST	_ILCreateAdminTools	(void);
+LPITEMIDLIST	_ILCreateConnections(void);
 #endif
 LPITEMIDLIST	_ILCreateBitBucket	(void) DECLSPEC_HIDDEN;
 LPITEMIDLIST	_ILCreateDrive		(LPCWSTR) DECLSPEC_HIDDEN;

--- a/dll/win32/shell32/wine/shellpath.c
+++ b/dll/win32/shell32/wine/shellpath.c
@@ -1110,14 +1110,14 @@ static const CSIDL_DATA CSIDL_Data[] =
     { /* 0x03 - CSIDL_CONTROLS (.CPL files) */
         &FOLDERID_ControlPanelFolder,
         CSIDL_Type_SystemPath,
-        NULL,
+        L"ControlPanelFolder",
         NULL,
         -IDI_SHELL_CONTROL_PANEL
     },
     { /* 0x04 - CSIDL_PRINTERS */
         &FOLDERID_PrintersFolder,
         CSIDL_Type_SystemPath,
-        NULL,
+        L"PrintersFolder",
         NULL,
         -IDI_SHELL_PRINTERS_FOLDER
     },
@@ -1157,7 +1157,7 @@ static const CSIDL_DATA CSIDL_Data[] =
     { /* 0x0a - CSIDL_BITBUCKET - Recycle Bin */
         &FOLDERID_RecycleBinFolder,
         CSIDL_Type_Disallowed,
-        NULL,
+        L"RecycleBinFolder",
         NULL
     },
     { /* 0x0b - CSIDL_STARTMENU */
@@ -1216,14 +1216,14 @@ static const CSIDL_DATA CSIDL_Data[] =
     { /* 0x11 - CSIDL_DRIVES */
         &FOLDERID_ComputerFolder,
         CSIDL_Type_Disallowed,
-        NULL,
+        L"MyComputerFolder",
         NULL,
         -IDI_SHELL_COMPUTER_FOLDER
     },
     { /* 0x12 - CSIDL_NETWORK */
         &FOLDERID_NetworkFolder,
         CSIDL_Type_Disallowed,
-        NULL,
+        L"NetworkPlacesFolder",
         NULL,
         -IDI_SHELL_NETWORK_FOLDER
     },
@@ -1442,7 +1442,7 @@ static const CSIDL_DATA CSIDL_Data[] =
     { /* 0x31 - CSIDL_CONNECTIONS */
         &FOLDERID_ConnectionsFolder,
         CSIDL_Type_Disallowed,
-        NULL,
+        L"ConnectionsFolder",
         NULL,
         -IDI_SHELL_NETWORK_CONNECTIONS
     },
@@ -1847,6 +1847,22 @@ static const CSIDL_DATA CSIDL_Data[] =
     }
 #endif
 };
+
+#ifdef __REACTOS__
+UINT _SHGetCSIDLByNameW(LPCWSTR lpszName)
+{
+    UINT i;
+    for (i = 0; i < _countof(CSIDL_Data); i++)
+    {
+        if (CSIDL_Data[i].szValueName != NULL &&
+            StrCmpIW(lpszName, CSIDL_Data[i].szValueName) == 0)
+        {
+            return i;
+        }
+    }
+    return UINT_MAX;
+}
+#endif
 
 #ifndef __REACTOS__
 static HRESULT _SHExpandEnvironmentStrings(LPCWSTR szSrc, LPWSTR szDest);
@@ -3154,6 +3170,20 @@ HRESULT WINAPI SHGetFolderLocation(
         case CSIDL_NETWORK:
             *ppidl = _ILCreateNetwork();
             break;
+
+#ifdef __REACTOS__
+        case CSIDL_FONTS:
+            *ppidl = _ILCreateFonts();
+            break;
+
+        case CSIDL_ADMINTOOLS:
+            *ppidl = _ILCreateAdminTools();
+            break;
+
+        case CSIDL_CONNECTIONS:
+            *ppidl = _ILCreateConnections();
+            break;
+#endif // __REACTOS__
 
         default:
         {


### PR DESCRIPTION
## Purpose

Add support for shell: folder shortcuts
JIRA issue: [CORE-16939](https://jira.reactos.org/browse/CORE-16939)

## Proposed changes

- Add `_ILCreateGuidFromShellUrlW` function to resolve shell: folder shortcuts and GUIDs
