### PR TITLE
[SDK] Shorten autogenerated Copyright strings

### DIFF
--- a/sdk/include/reactos/version.rc
+++ b/sdk/include/reactos/version.rc
@@ -19,7 +19,7 @@
 #define REACTOS_DEFAULT_STR_COMPANY_NAME    "ReactOS Project"
 #define REACTOS_DEFAULT_STR_DESCRIPTION     "ReactOS Core Component"
 #define REACTOS_DEFAULT_STR_INTERNAL_NAME   ""
-#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "Copyright 1996-" COPYRIGHT_YEAR " ReactOS Project"
+#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define REACTOS_DEFAULT_STR_PRODUCT_NAME    "ReactOS Operating System"
 
 /* Set defaults for everything, unless overridden */

--- a/sdk/include/reactos/version.rc
+++ b/sdk/include/reactos/version.rc
@@ -19,7 +19,7 @@
 #define REACTOS_DEFAULT_STR_COMPANY_NAME    "ReactOS Project"
 #define REACTOS_DEFAULT_STR_DESCRIPTION     "ReactOS Core Component"
 #define REACTOS_DEFAULT_STR_INTERNAL_NAME   ""
-#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "(c) 1996-" COPYRIGHT_YEAR " ReactOS Project"
+#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "(C) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define REACTOS_DEFAULT_STR_PRODUCT_NAME    "ReactOS Operating System"
 
 /* Set defaults for everything, unless overridden */

--- a/sdk/include/reactos/version.rc
+++ b/sdk/include/reactos/version.rc
@@ -19,7 +19,7 @@
 #define REACTOS_DEFAULT_STR_COMPANY_NAME    "ReactOS Project"
 #define REACTOS_DEFAULT_STR_DESCRIPTION     "ReactOS Core Component"
 #define REACTOS_DEFAULT_STR_INTERNAL_NAME   ""
-#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "1996-" COPYRIGHT_YEAR " ReactOS Project"
+#define REACTOS_DEFAULT_STR_LEGAL_COPYRIGHT "(c) 1996-" COPYRIGHT_YEAR " ReactOS Project"
 #define REACTOS_DEFAULT_STR_PRODUCT_NAME    "ReactOS Operating System"
 
 /* Set defaults for everything, unless overridden */

--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -1,20 +1,7 @@
 /*
- * Copyright 2001 Dmitry Timoshkov
- * Copyright 2004 Ivan Leo Puoti
- *
- * This library is free software; you can redistribute it and/or
- * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either
- * version 2.1 of the License, or (at your option) any later version.
- *
- * This library is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- * Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public
- * License along with this library; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * COPYRIGHT:   Copyright 2001 Dmitry Timoshkov
+ *              Copyright 2004 Ivan Leo Puoti
  */
 
 #include "windef.h"
@@ -59,9 +46,8 @@
 
 /* Credit the Wine team */
 #define REACTOS_STR_COMPANY_NAME "ReactOS Project/Wine Team\0"
-#define REACTOS_STR_LEGAL_COPYRIGHT "Copyright 1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
-#define REACTOS_STR_ORIGINAL_COPYRIGHT "Copyright (c) 1993-" COPYRIGHT_YEAR " the Wine project authors " \
-                                       "(see the file AUTHORS for a complete list)"
+#define REACTOS_STR_LEGAL_COPYRIGHT "1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
+#define REACTOS_STR_ORIGINAL_COPYRIGHT "1993-" COPYRIGHT_YEAR " the Wine project authors"
 
 #define REACTOS_VERSION_DLL
 

--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -46,8 +46,8 @@
 
 /* Credit the Wine team */
 #define REACTOS_STR_COMPANY_NAME "ReactOS Project/Wine Team\0"
-#define REACTOS_STR_LEGAL_COPYRIGHT "(c) 1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
-#define REACTOS_STR_ORIGINAL_COPYRIGHT "(c) 1993-" COPYRIGHT_YEAR " the Wine project authors"
+#define REACTOS_STR_LEGAL_COPYRIGHT "(C) 1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
+#define REACTOS_STR_ORIGINAL_COPYRIGHT "(C) 1993-" COPYRIGHT_YEAR " the Wine project authors"
 
 #define REACTOS_VERSION_DLL
 

--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -1,5 +1,5 @@
 /*
- * LICENSE:     GPL-2.0-or-later (https://spdx.org/licenses/GPL-2.0-or-later)
+ * LICENSE:     LGPL-2.1+ (https://spdx.org/licenses/LGPL-2.1+)
  * COPYRIGHT:   Copyright 2001 Dmitry Timoshkov
  *              Copyright 2004 Ivan Leo Puoti
  */

--- a/sdk/include/reactos/wine/wine_common_ver.rc
+++ b/sdk/include/reactos/wine/wine_common_ver.rc
@@ -46,8 +46,8 @@
 
 /* Credit the Wine team */
 #define REACTOS_STR_COMPANY_NAME "ReactOS Project/Wine Team\0"
-#define REACTOS_STR_LEGAL_COPYRIGHT "1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
-#define REACTOS_STR_ORIGINAL_COPYRIGHT "1993-" COPYRIGHT_YEAR " the Wine project authors"
+#define REACTOS_STR_LEGAL_COPYRIGHT "(c) 1996-" COPYRIGHT_YEAR " ReactOS Project, 1993-" COPYRIGHT_YEAR " the Wine project authors\0"
+#define REACTOS_STR_ORIGINAL_COPYRIGHT "(c) 1993-" COPYRIGHT_YEAR " the Wine project authors"
 
 #define REACTOS_VERSION_DLL
 


### PR DESCRIPTION

that we do compile into almost every dll and exe.
Reduces unnecessary scrolling in the
Versions tab of file properties dlg, which precedes the Copyright phrase anyway.

MS also uses shorter strings and therefore doesn't require to scroll. See attached screenshots in the PR.

ros_unnecessarily_long_and_duplicated_strings_do_hide_the_interesting_parts:
![copyright_ros_unnecessarily_long_and_duplicated_strings_do_hide_the_interesting_parts](https://user-images.githubusercontent.com/33393466/229004364-95997c91-5ec0-43bc-9385-8822dfa29397.png)

MS_does_not_duplicate_the_string:
![copyright_MS_does_not_duplicate_the_string](https://user-images.githubusercontent.com/33393466/229004398-9aee021e-4a68-4ece-af8d-0a9978ff691e.PNG)
