### PR TITLE
[NTUSER] Fix BSOD 0x1E nullptr deref CORE-18899

### DIFF
--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Win32k subsystem
  * LICENSE:     See COPYING in the top level directory
  * PURPOSE:     Miscellaneous User functions
- * COPYRIGHT:   2008-2020 James Tabor <james.tabor@rectos.org>
+ * COPYRIGHT:   2008-2020 James Tabor <james.tabor@reactos.org>
  */
 
 #include <win32k.h>

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -2,7 +2,7 @@
  * PROJECT:     ReactOS Win32k subsystem
  * LICENSE:     See COPYING in the top level directory
  * PURPOSE:     Miscellaneous User functions
- * COPYRIGHT:
+ * COPYRIGHT:   2008-2020 James Tabor <james.tabor@rectos.org>
  */
 
 #include <win32k.h>

--- a/win32ss/user/ntuser/defwnd.c
+++ b/win32ss/user/ntuser/defwnd.c
@@ -1,9 +1,8 @@
 /*
- * COPYRIGHT:        See COPYING in the top level directory
- * PROJECT:          ReactOS Win32k subsystem
- * PURPOSE:          Miscellaneous User functions
- * FILE:             win32ss/user/ntuser/defwnd.c
- * PROGRAMER:
+ * PROJECT:     ReactOS Win32k subsystem
+ * LICENSE:     See COPYING in the top level directory
+ * PURPOSE:     Miscellaneous User functions
+ * COPYRIGHT:
  */
 
 #include <win32k.h>
@@ -797,6 +796,10 @@ IntDefWindowProc(
             HWND hwndTop = UserGetForegroundWindow();
             PWND topWnd = UserGetWindowObject(hwndTop);
 
+            // MS Doc: foreground window can be NULL, e.g. when window is losing activation
+            if (!topWnd)
+               return 0;
+
             // We want to forbid snapping operations on the TaskBar
             // We use a heuristic for detecting the TaskBar Wnd by its typical Style & ExStyle Values
             ExStyleTB = (topWnd->ExStyle & WS_EX_TOOLWINDOW);
@@ -805,7 +808,7 @@ IntDefWindowProc(
                         && (ExStyleTB == WS_EX_TOOLWINDOW);
             TRACE("ExStyle=%x Style=%x IsTaskBar=%d\n", ExStyleTB, StyleTB, IsTaskBar);
 
-            if (topWnd && !IsTaskBar)
+            if (!IsTaskBar)
             {
                if ((topWnd->style & WS_THICKFRAME) == 0)
                   return 0;

--- a/win32ss/user/ntuser/event.c
+++ b/win32ss/user/ntuser/event.c
@@ -2,8 +2,7 @@
  * COPYRIGHT:         See COPYING in the top level directory
  * PROJECT:           ReactOS kernel
  * PURPOSE:           Window event handlers
- * FILE:              win32ss/user/ntuser/event.c
- * PROGRAMER:         James Tabor (james.tabor@rectos.org)
+ * PROGRAMER:         James Tabor <james.tabor@reactos.org>
  */
 
 #include <win32k.h>

--- a/win32ss/user/ntuser/hook.c
+++ b/win32ss/user/ntuser/hook.c
@@ -2,10 +2,9 @@
  * COPYRIGHT:        See COPYING in the top level directory
  * PROJECT:          ReactOS kernel
  * PURPOSE:          Window hooks
- * FILE:             win32ss/user/ntuser/hook.c
- * PROGRAMER:        Casper S. Hornstrup (chorns@users.sourceforge.net)
- *                   James Tabor (james.tabor@rectos.org)
- *                   Rafal Harabien (rafalh@reactos.org)
+ * PROGRAMER:        Casper S. Hornstrup <chorns@users.sourceforge.net>
+ *                   James Tabor <james.tabor@reactos.org>
+ *                   Rafal Harabien <rafalh@reactos.org>
   * NOTE:            Most of this code was adapted from Wine,
  *                   Copyright (C) 2002 Alexandre Julliard
  */


### PR DESCRIPTION

fix authored by JIRA-user "TANGaming". Many thanks for the contribution.

I do suspect that the possibility of that nullptr deref was introduced on the master branch by 0.4.13-dev-962-g 4193b8d8ace0b84d0bf82c72bc9263a35ee414a8

JIRA issue: [CORE-18899](https://jira.reactos.org/browse/CORE-18899)

Doug Lyons signalled his "ok" regarding the fix in chat already.