### PR TITLE
[MSPAINT] Allow ToolBox to be right-aligned

### DIFF
--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -75,6 +75,7 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
     ShowStatusBar = TRUE;
     ShowPalette = TRUE;
     ShowToolBox = TRUE;
+    Bar1Flags = 0x0000e817;
 
     LOGFONT lf;
     GetObject(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
@@ -139,6 +140,12 @@ void RegistrySettings::Load(INT nCmdShow)
         ReadDWORD(text, _T("PositionY"),    FontsPositionY);
         ReadDWORD(text, _T("ShowTextTool"), ShowTextTool);
         ReadString(text, _T("TypeFaceName"), strFontName, strFontName);
+    }
+
+    CRegKey bar2;
+    if (bar2.Open(paint, _T("General-Bar2"), KEY_READ) == ERROR_SUCCESS)
+    {
+        ReadDWORD(bar2, _T("Bar#1"), Bar1Flags);
     }
 
     CRegKey bar3;
@@ -211,6 +218,12 @@ void RegistrySettings::Store()
         text.SetDWORDValue(_T("PositionY"),     FontsPositionY);
         text.SetDWORDValue(_T("ShowTextTool"),  ShowTextTool);
         text.SetStringValue(_T("TypeFaceName"), strFontName);
+    }
+
+    CRegKey bar2;
+    if (bar2.Create(paint, _T("General-Bar2")) == ERROR_SUCCESS)
+    {
+        bar2.SetDWORDValue(_T("Bar#1"), Bar1Flags);
     }
 
     CRegKey bar3;

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -75,7 +75,7 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
     ShowStatusBar = TRUE;
     ShowPalette = TRUE;
     ShowToolBox = TRUE;
-    Bar1Flags = 0x0000e817;
+    Bar2ID = BAR2ID_LEFT;
 
     LOGFONT lf;
     GetObject(GetStockObject(DEFAULT_GUI_FONT), sizeof(lf), &lf);
@@ -145,7 +145,7 @@ void RegistrySettings::Load(INT nCmdShow)
     CRegKey bar2;
     if (bar2.Open(paint, _T("General-Bar2"), KEY_READ) == ERROR_SUCCESS)
     {
-        ReadDWORD(bar2, _T("Bar#1"), Bar1Flags);
+        ReadDWORD(bar2, _T("BarID"), Bar2ID);
     }
 
     CRegKey bar3;
@@ -223,7 +223,7 @@ void RegistrySettings::Store()
     CRegKey bar2;
     if (bar2.Create(paint, _T("General-Bar2")) == ERROR_SUCCESS)
     {
-        bar2.SetDWORDValue(_T("Bar#1"), Bar1Flags);
+        bar2.SetDWORDValue(_T("BarID"), Bar2ID);
     }
 
     CRegKey bar3;

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -46,7 +46,7 @@ public:
     DWORD Bar2ID;
 
 // Values for Bar2ID.
-// I think these values are Win2k3 Paint compatible but sometimes not working...
+// I think these values are Win2k3 mspaint compatible but sometimes not working...
 #define BAR2ID_LEFT   0x0000e81c
 #define BAR2ID_RIGHT  0x0000e81d
 

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -44,6 +44,9 @@ public:
     DWORD ShowPalette;
     DWORD ShowToolBox;
     DWORD Bar2ID;
+
+// Values for Bar2ID.
+// I think these values are Win2k3 Paint compatible but sometimes not working...
 #define BAR2ID_LEFT   0x0000e81c
 #define BAR2ID_RIGHT  0x0000e81d
 

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -43,6 +43,7 @@ public:
     DWORD ShowStatusBar;
     DWORD ShowPalette;
     DWORD ShowToolBox;
+    DWORD Bar1Flags;
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -43,7 +43,9 @@ public:
     DWORD ShowStatusBar;
     DWORD ShowPalette;
     DWORD ShowToolBox;
-    DWORD Bar1Flags;
+    DWORD Bar2ID;
+#define BAR2ID_LEFT   0x0000e81c
+#define BAR2ID_RIGHT  0x0000e81d
 
     enum WallpaperStyle {
         TILED,

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -54,9 +54,9 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 
 BOOL CToolBox::DoCreate(HWND hwndParent)
 {
-    RECT toolBoxContainerPos = { 0, 0, 0, 0 }; // Rely on mainWindow's WM_SIZE
+    RECT rcToolBox = { 0, 0, 0, 0 }; // Rely on mainWindow's WM_SIZE
     DWORD style = WS_CHILD | (registrySettings.ShowToolBox ? WS_VISIBLE : 0);
-    return !!Create(hwndParent, toolBoxContainerPos, NULL, style);
+    return !!Create(hwndParent, rcToolBox, NULL, style);
 }
 
 LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -149,11 +149,7 @@ LRESULT CToolBox::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
 
     POINT ptCenter = { (rc.left + rc.right) / 2, (rc.bottom - rc.top) / 2 };
 
-    DWORD dwExpectedBar2ID;
-    if (pt.x < ptCenter.x)
-        dwExpectedBar2ID = BAR2ID_LEFT;
-    else
-        dwExpectedBar2ID = BAR2ID_RIGHT;
+    DWORD dwExpectedBar2ID = ((pt.x < ptCenter.x) ? BAR2ID_LEFT : BAR2ID_RIGHT);
 
     if (registrySettings.Bar2ID != dwExpectedBar2ID)
     {

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -34,7 +34,7 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 
     TCHAR szToolTip[30];
     TBBUTTON tbbutton;
-    ZeroMemory(&tbbutton, sizeof(TBBUTTON));
+    ZeroMemory(&tbbutton, sizeof(tbbutton));
     tbbutton.fsStyle = TBSTYLE_CHECKGROUP;
     for (INT i = 0; i < NUM_TOOLS; i++)
     {

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -141,7 +141,6 @@ LRESULT CToolBox::OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, LPARAM lPara
 
 LRESULT CToolBox::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
-    ::GetCursorPos(&m_ptScreen);
     SetCapture();
     return 0;
 }
@@ -168,7 +167,6 @@ LRESULT CToolBox::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
     {
         registrySettings.Bar1Flags = dwExpected;
         mainWindow.PostMessage(WM_SIZE, 0, 0);
-        m_ptScreen.x = m_ptScreen.y = MAXSHORT;
     }
 
     return 0;
@@ -180,23 +178,5 @@ LRESULT CToolBox::OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
         return 0;
 
     ::ReleaseCapture();
-
-    POINT pt;
-    ::GetCursorPos(&pt);
-    if (labs(pt.x - m_ptScreen.x) <= ::GetSystemMetrics(SM_CXDRAG) &&
-        labs(pt.y - m_ptScreen.y) <= ::GetSystemMetrics(SM_CYDRAG))
-    {
-        ScreenToClient(&pt);
-        HWND hwndChild = ::ChildWindowFromPoint(m_hWnd, pt);
-        if (hwndChild == toolbar)
-        {
-            toolbar.SetFocus();
-            ClientToScreen(&pt);
-            toolbar.ScreenToClient(&pt);
-            INT iItem = (INT)toolbar.SendMessage(TB_HITTEST, 0, MAKELPARAM(pt.x, pt.y));
-            toolbar.SendMessage(TB_PRESSBUTTON, iItem, TRUE);
-        }
-    }
-
     return 0;
 }

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -15,7 +15,7 @@ CToolBox toolBoxContainer;
 
 BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 {
-    /* NOTE: The horizontal line above the toolbar is hidden by CCS_NODIVIDER style. */
+    // NOTE: The horizontal line above the toolbar is hidden by CCS_NODIVIDER style.
     RECT toolbarPos = { 0, 0, CX_TOOLBAR, CY_TOOLBAR };
     DWORD style = WS_CHILD | WS_VISIBLE | CCS_NOPARENTALIGN | CCS_VERT | CCS_NORESIZE |
                   TBSTYLE_TOOLTIPS | TBSTYLE_FLAT;

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -13,35 +13,29 @@ CToolBox toolBoxContainer;
 
 /* FUNCTIONS ********************************************************/
 
-BOOL CToolBox::DoCreate(HWND hwndParent)
+BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 {
-    RECT toolBoxContainerPos = { 0, 0, 0, 0 };
-    DWORD style = WS_CHILD | (registrySettings.ShowToolBox ? WS_VISIBLE : 0);
-    return !!Create(hwndParent, toolBoxContainerPos, NULL, style);
-}
-
-LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
-{
-    HIMAGELIST hImageList;
-    HBITMAP tempBm;
-    int i;
-    TCHAR tooltips[NUM_TOOLS][30];
-
-    toolSettingsWindow.DoCreate(m_hWnd);
-
     /* NOTE: The horizontal line above the toolbar is hidden by CCS_NODIVIDER style. */
     RECT toolbarPos = {0, 0, CX_TOOLBAR, CY_TOOLBAR};
     DWORD style = WS_CHILD | WS_VISIBLE | CCS_NOPARENTALIGN | CCS_VERT | CCS_NORESIZE |
                   TBSTYLE_TOOLTIPS | TBSTYLE_FLAT;
-    toolbar.Create(TOOLBARCLASSNAME, m_hWnd, toolbarPos, NULL, style);
-    hImageList = ImageList_Create(16, 16, ILC_COLOR24 | ILC_MASK, 16, 0);
-    toolbar.SendMessage(TB_SETIMAGELIST, 0, (LPARAM) hImageList);
-    tempBm = (HBITMAP) LoadImage(hProgInstance, MAKEINTRESOURCE(IDB_TOOLBARICONS), IMAGE_BITMAP, 256, 16, 0);
+    if (!CWindow::Create(TOOLBARCLASSNAME, hwndParent, toolbarPos, NULL, style))
+        return 0;
+
+#undef SubclassWindow // Don't use this macro
+    HWND hWnd = m_hWnd;
+    m_hWnd = NULL;
+    SubclassWindow(hWnd);
+
+    HIMAGELIST hImageList = ImageList_Create(16, 16, ILC_COLOR24 | ILC_MASK, 16, 0);
+    SendMessage(TB_SETIMAGELIST, 0, (LPARAM) hImageList);
+    HBITMAP tempBm = (HBITMAP) LoadImage(hProgInstance, MAKEINTRESOURCE(IDB_TOOLBARICONS), IMAGE_BITMAP, 256, 16, 0);
     ImageList_AddMasked(hImageList, tempBm, 0xff00ff);
     DeleteObject(tempBm);
-    toolbar.SendMessage(TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
+    SendMessage(TB_BUTTONSTRUCTSIZE, sizeof(TBBUTTON), 0);
 
-    for (i = 0; i < NUM_TOOLS; i++)
+    TCHAR tooltips[NUM_TOOLS][30];
+    for (INT i = 0; i < NUM_TOOLS; i++)
     {
         TBBUTTON tbbutton;
         int wrapnow = 0;
@@ -56,12 +50,26 @@ LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandl
         tbbutton.fsState   = TBSTATE_ENABLED | wrapnow;
         tbbutton.idCommand = ID_FREESEL + i;
         tbbutton.iBitmap   = i;
-        toolbar.SendMessage(TB_ADDBUTTONS, 1, (LPARAM) &tbbutton);
+        SendMessage(TB_ADDBUTTONS, 1, (LPARAM) &tbbutton);
     }
 
-    toolbar.SendMessage(TB_CHECKBUTTON, ID_PEN, MAKELPARAM(TRUE, 0));
-    toolbar.SendMessage(TB_SETMAXTEXTROWS, 0, 0);
-    toolbar.SendMessage(TB_SETBUTTONSIZE, 0, MAKELPARAM(CXY_TB_BUTTON, CXY_TB_BUTTON));
+    SendMessage(TB_CHECKBUTTON, ID_PEN, MAKELPARAM(TRUE, 0));
+    SendMessage(TB_SETMAXTEXTROWS, 0, 0);
+    SendMessage(TB_SETBUTTONSIZE, 0, MAKELPARAM(CXY_TB_BUTTON, CXY_TB_BUTTON));
+    return TRUE;
+}
+
+BOOL CToolBox::DoCreate(HWND hwndParent)
+{
+    RECT toolBoxContainerPos = { 0, 0, 0, 0 };
+    DWORD style = WS_CHILD | (registrySettings.ShowToolBox ? WS_VISIBLE : 0);
+    return !!Create(hwndParent, toolBoxContainerPos, NULL, style);
+}
+
+LRESULT CToolBox::OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    toolbar.DoCreate(m_hWnd);
+    toolSettingsWindow.DoCreate(m_hWnd);
 
     return 0;
 }
@@ -125,6 +133,68 @@ LRESULT CToolBox::OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, LPARAM lPara
         {
             toolbar.SendMessage(TB_CHECKBUTTON, CommandToToolMapping[i].id, TRUE);
             break;
+        }
+    }
+
+    return 0;
+}
+
+LRESULT CToolBox::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    ::GetCursorPos(&m_ptScreen);
+    SetCapture();
+    return 0;
+}
+
+LRESULT CToolBox::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    if (::GetCapture() != m_hWnd)
+        return 0;
+    POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+    ClientToScreen(&pt);
+
+    RECT rc;
+    mainWindow.GetWindowRect(&rc);
+
+    POINT ptCenter = { (rc.left + rc.right) / 2, (rc.bottom - rc.top) / 2 };
+
+    DWORD dwExpected;
+    if (pt.x < ptCenter.x)
+        dwExpected = 0x0000e817;
+    else
+        dwExpected = 0x0001e817;
+
+    if (registrySettings.Bar1Flags != dwExpected)
+    {
+        registrySettings.Bar1Flags = dwExpected;
+        mainWindow.PostMessage(WM_SIZE, 0, 0);
+        m_ptScreen.x = m_ptScreen.y = MAXSHORT;
+    }
+
+    return 0;
+}
+
+LRESULT CToolBox::OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    if (::GetCapture() != m_hWnd)
+        return 0;
+
+    ::ReleaseCapture();
+
+    POINT pt;
+    ::GetCursorPos(&pt);
+    if (labs(pt.x - m_ptScreen.x) <= ::GetSystemMetrics(SM_CXDRAG) &&
+        labs(pt.y - m_ptScreen.y) <= ::GetSystemMetrics(SM_CYDRAG))
+    {
+        ScreenToClient(&pt);
+        HWND hwndChild = ::ChildWindowFromPoint(m_hWnd, pt);
+        if (hwndChild == toolbar)
+        {
+            toolbar.SetFocus();
+            ClientToScreen(&pt);
+            toolbar.ScreenToClient(&pt);
+            INT iItem = (INT)toolbar.SendMessage(TB_HITTEST, 0, MAKELPARAM(pt.x, pt.y));
+            toolbar.SendMessage(TB_PRESSBUTTON, iItem, TRUE);
         }
     }
 

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -149,15 +149,15 @@ LRESULT CToolBox::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHa
 
     POINT ptCenter = { (rc.left + rc.right) / 2, (rc.bottom - rc.top) / 2 };
 
-    DWORD dwExpected;
+    DWORD dwExpectedBar2ID;
     if (pt.x < ptCenter.x)
-        dwExpected = 0x0000e817;
+        dwExpectedBar2ID = BAR2ID_LEFT;
     else
-        dwExpected = 0x0001e817;
+        dwExpectedBar2ID = BAR2ID_RIGHT;
 
-    if (registrySettings.Bar1Flags != dwExpected)
+    if (registrySettings.Bar2ID != dwExpectedBar2ID)
     {
-        registrySettings.Bar1Flags = dwExpected;
+        registrySettings.Bar2ID = dwExpectedBar2ID;
         mainWindow.PostMessage(WM_SIZE, 0, 0);
     }
 

--- a/base/applications/mspaint/toolbox.cpp
+++ b/base/applications/mspaint/toolbox.cpp
@@ -34,13 +34,12 @@ BOOL CPaintToolBar::DoCreate(HWND hwndParent)
 
     TCHAR szToolTip[30];
     TBBUTTON tbbutton;
+    ZeroMemory(&tbbutton, sizeof(TBBUTTON));
+    tbbutton.fsStyle = TBSTYLE_CHECKGROUP;
     for (INT i = 0; i < NUM_TOOLS; i++)
     {
-        LoadString(hProgInstance, IDS_TOOLTIP1 + i, szToolTip, _countof(szToolTip));
-
-        ZeroMemory(&tbbutton, sizeof(TBBUTTON));
+        ::LoadString(hProgInstance, IDS_TOOLTIP1 + i, szToolTip, _countof(szToolTip));
         tbbutton.iString   = (INT_PTR)szToolTip;
-        tbbutton.fsStyle   = TBSTYLE_CHECKGROUP;
         tbbutton.fsState   = TBSTATE_ENABLED | ((i % 2 == 1) ? TBSTATE_WRAP : 0);
         tbbutton.idCommand = ID_FREESEL + i;
         tbbutton.iBitmap   = i;

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -15,13 +15,10 @@
 #define CX_TOOLBAR          (TOOLBAR_COLUMNS * CXY_TB_BUTTON)
 #define CY_TOOLBAR          (TOOLBAR_ROWS * CXY_TB_BUTTON)
 
-class CPaintToolBar : public CWindowImpl<CPaintToolBar>
+class CPaintToolBar : public CWindow
 {
 public:
     BOOL DoCreate(HWND hwndParent);
-
-    BEGIN_MSG_MAP(CPaintToolBar)
-    END_MSG_MAP()
 };
 
 class CToolBox : public CWindowImpl<CToolBox>

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -43,7 +43,6 @@ public:
 
 private:
     CPaintToolBar toolbar;
-    POINT m_ptScreen;
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnSysColorChange(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -15,6 +15,15 @@
 #define CX_TOOLBAR          (TOOLBAR_COLUMNS * CXY_TB_BUTTON)
 #define CY_TOOLBAR          (TOOLBAR_ROWS * CXY_TB_BUTTON)
 
+class CPaintToolBar : public CWindowImpl<CPaintToolBar>
+{
+public:
+    BOOL DoCreate(HWND hwndParent);
+
+    BEGIN_MSG_MAP(CPaintToolBar)
+    END_MSG_MAP()
+};
+
 class CToolBox : public CWindowImpl<CToolBox>
 {
 public:
@@ -24,16 +33,23 @@ public:
         MESSAGE_HANDLER(WM_CREATE, OnCreate)
         MESSAGE_HANDLER(WM_SYSCOLORCHANGE, OnSysColorChange)
         MESSAGE_HANDLER(WM_COMMAND, OnCommand)
+        MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
+        MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
+        MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
         MESSAGE_HANDLER(WM_TOOLSMODELTOOLCHANGED, OnToolsModelToolChanged)
     END_MSG_MAP()
 
     BOOL DoCreate(HWND hwndParent);
 
 private:
-    CWindow toolbar;
+    CPaintToolBar toolbar;
+    POINT m_ptScreen;
 
     LRESULT OnCreate(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnSysColorChange(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnCommand(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnToolsModelToolChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 };

--- a/base/applications/mspaint/toolsettings.cpp
+++ b/base/applications/mspaint/toolsettings.cpp
@@ -414,6 +414,8 @@ LRESULT CToolSettingsWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lPar
         case TOOL_PEN:
             break;
     }
+
+    ::SetCapture(::GetParent(m_hWnd));
     return 0;
 }
 

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -88,11 +88,22 @@ void CMainWindow::alignChildrenToMainWindow()
 
     if (::IsWindowVisible(toolBoxContainer))
     {
-        hDWP = ::DeferWindowPos(hDWP, toolBoxContainer, NULL,
-                                rcSpace.left, rcSpace.top,
-                                CX_TOOLBAR, rcSpace.bottom - rcSpace.top,
-                                SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
-        rcSpace.left += CX_TOOLBAR;
+        if (registrySettings.Bar1Flags & 0x10000)
+        {
+            hDWP = ::DeferWindowPos(hDWP, toolBoxContainer, NULL,
+                                    rcSpace.right - CX_TOOLBAR, rcSpace.top,
+                                    CX_TOOLBAR, rcSpace.bottom - rcSpace.top,
+                                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
+            rcSpace.right -= CX_TOOLBAR;
+        }
+        else
+        {
+            hDWP = ::DeferWindowPos(hDWP, toolBoxContainer, NULL,
+                                    rcSpace.left, rcSpace.top,
+                                    CX_TOOLBAR, rcSpace.bottom - rcSpace.top,
+                                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
+            rcSpace.left += CX_TOOLBAR;
+        }
     }
 
     if (::IsWindowVisible(paletteWindow))

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -88,7 +88,7 @@ void CMainWindow::alignChildrenToMainWindow()
 
     if (::IsWindowVisible(toolBoxContainer))
     {
-        if (registrySettings.Bar1Flags & 0x10000)
+        if (registrySettings.Bar2ID == BAR2ID_RIGHT)
         {
             hDWP = ::DeferWindowPos(hDWP, toolBoxContainer, NULL,
                                     rcSpace.right - CX_TOOLBAR, rcSpace.top,


### PR DESCRIPTION
## Purpose
The user will be able to move ToolBox in the main window by dragging.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Add `Bar2ID` registry setting.
- Add `CPaintToolBar` class to encapsulate the toolbar code.
- Capture and track the mouse dragging in `CToolBox`.
- Move the ToolBox if dragging is beyond the center position.

## TODO

- [x] It works.
- [x] Confirm the registry.

## Screenshots

Left:
![left](https://user-images.githubusercontent.com/2107452/229094985-3168d565-fed5-4706-8413-290fb0bb0b18.png)
Right:
![right](https://user-images.githubusercontent.com/2107452/229094993-9489e65f-9613-4e21-a3ea-72673c694ad5.png)