### PR TITLE
[COMCTL32][USER32] EDIT: WM_SETFONT for IME

### DIFF
--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3771,6 +3771,8 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
+        if (font == NULL)
+            font = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         GetObjectW(font, sizeof(lf), &lf);
         ImmSetCompositionFontW(hIMC, &lf);
         ImmReleaseContext(es->hwndSelf, hIMC);

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3771,7 +3771,7 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
-        GetObject(font, sizeof(lf), &lf);
+        GetObjectW(font, sizeof(lf), &lf);
         ImmSetCompositionFontW(hIMC, &lf);
         ImmReleaseContext(es->hwndSelf, hIMC);
     }

--- a/dll/win32/comctl32/edit.c
+++ b/dll/win32/comctl32/edit.c
@@ -3766,6 +3766,16 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 				 es->flags & EF_AFTER_WRAP);
 		ShowCaret(es->hwndSelf);
 	}
+#ifdef __REACTOS__
+    if (ImmIsIME(GetKeyboardLayout(0)))
+    {
+        LOGFONTW lf;
+        HIMC hIMC = ImmGetContext(es->hwndSelf);
+        GetObject(font, sizeof(lf), &lf);
+        ImmSetCompositionFontW(hIMC, &lf);
+        ImmReleaseContext(es->hwndSelf, hIMC);
+    }
+#endif
 }
 
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -53,6 +53,8 @@
 #define ImmLockIMC                  IMM_FN(ImmLockIMC)
 #define ImmUnlockIMC                IMM_FN(ImmUnlockIMC)
 #define ImmNotifyIME                IMM_FN(ImmNotifyIME)
+#define ImmIsIME                    IMM_FN(ImmIsIME)
+#define ImmSetCompositionFontW      IMM_FN(ImmSetCompositionFontW)
 #endif
 
 WINE_DEFAULT_DEBUG_CHANNEL(edit);
@@ -3972,6 +3974,16 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
 				 es->flags & EF_AFTER_WRAP);
 		ShowCaret(es->hwndSelf);
 	}
+#ifdef __REACTOS__
+    if (ImmIsIME(GetKeyboardLayout(0)))
+    {
+        LOGFONTW lf;
+        HIMC hIMC = ImmGetContext(es->hwndSelf);
+        GetObject(font, sizeof(lf), &lf);
+        ImmSetCompositionFontW(hIMC, &lf);
+        ImmReleaseContext(es->hwndSelf, hIMC);
+    }
+#endif
 }
 
 

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3979,6 +3979,8 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
+        if (font == NULL)
+            font = (HFONT)GetStockObject(DEFAULT_GUI_FONT);
         GetObjectW(font, sizeof(lf), &lf);
         ImmSetCompositionFontW(hIMC, &lf);
         ImmReleaseContext(es->hwndSelf, hIMC);

--- a/win32ss/user/user32/controls/edit.c
+++ b/win32ss/user/user32/controls/edit.c
@@ -3979,7 +3979,7 @@ static void EDIT_WM_SetFont(EDITSTATE *es, HFONT font, BOOL redraw)
     {
         LOGFONTW lf;
         HIMC hIMC = ImmGetContext(es->hwndSelf);
-        GetObject(font, sizeof(lf), &lf);
+        GetObjectW(font, sizeof(lf), &lf);
         ImmSetCompositionFontW(hIMC, &lf);
         ImmReleaseContext(es->hwndSelf, hIMC);
     }


### PR DESCRIPTION
## Purpose
Display the composition window correctly.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Call `IMM32!ImmSetCompositionFontW` function in `WM_SETFONT` message handling of `EDIT` controls if necessary.
- If the specified font is `NULL`, then use `DEFAULT_GUI_FONT` stock font.
