### PR TITLE
[MSPAINT] Allow paletteWindow to be bottom-aligned

### DIFF
--- a/base/applications/mspaint/palette.cpp
+++ b/base/applications/mspaint/palette.cpp
@@ -132,6 +132,7 @@ LRESULT CPaletteWindow::OnLButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, B
     INT iColor = DoHitTest(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
     if (iColor != -1)
         paletteModel.SetFgColor(paletteModel.GetColor(iColor));
+    SetCapture();
     return 0;
 }
 
@@ -176,5 +177,38 @@ LRESULT CPaletteWindow::OnPaletteModelColorChanged(UINT nMsg, WPARAM wParam, LPA
 LRESULT CPaletteWindow::OnPaletteModelPaletteChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
 {
     InvalidateRect(NULL, FALSE);
+    return 0;
+}
+
+LRESULT CPaletteWindow::OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    if (::GetCapture() != m_hWnd)
+        return 0;
+
+    POINT pt = { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+    ClientToScreen(&pt);
+
+    RECT rc;
+    mainWindow.GetWindowRect(&rc);
+
+    POINT ptCenter = { (rc.left + rc.right) / 2, (rc.bottom - rc.top) / 2 };
+
+    DWORD dwExpectedBar1ID = ((pt.y < ptCenter.y) ? BAR1ID_TOP : BAR1ID_BOTTOM);
+
+    if (registrySettings.Bar1ID != dwExpectedBar1ID)
+    {
+        registrySettings.Bar1ID = dwExpectedBar1ID;
+        mainWindow.PostMessage(WM_SIZE, 0, 0);
+    }
+
+    return 0;
+}
+
+LRESULT CPaletteWindow::OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled)
+{
+    if (::GetCapture() != m_hWnd)
+        return 0;
+
+    ::ReleaseCapture();
     return 0;
 }

--- a/base/applications/mspaint/palette.h
+++ b/base/applications/mspaint/palette.h
@@ -24,6 +24,8 @@ public:
         MESSAGE_HANDLER(WM_RBUTTONDOWN, OnRButtonDown)
         MESSAGE_HANDLER(WM_LBUTTONDBLCLK, OnLButtonDblClk)
         MESSAGE_HANDLER(WM_RBUTTONDBLCLK, OnRButtonDblClk)
+        MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
+        MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
         MESSAGE_HANDLER(WM_PALETTEMODELCOLORCHANGED, OnPaletteModelColorChanged)
         MESSAGE_HANDLER(WM_PALETTEMODELPALETTECHANGED, OnPaletteModelPaletteChanged)
     END_MSG_MAP()
@@ -34,6 +36,8 @@ public:
     LRESULT OnRButtonDown(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnLButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnRButtonDblClk(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnMouseMove(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
+    LRESULT OnLButtonUp(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaletteModelColorChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
     LRESULT OnPaletteModelPaletteChanged(UINT nMsg, WPARAM wParam, LPARAM lParam, BOOL& bHandled);
 

--- a/base/applications/mspaint/registry.cpp
+++ b/base/applications/mspaint/registry.cpp
@@ -75,6 +75,7 @@ void RegistrySettings::LoadPresets(INT nCmdShow)
     ShowStatusBar = TRUE;
     ShowPalette = TRUE;
     ShowToolBox = TRUE;
+    Bar1ID = BAR1ID_TOP;
     Bar2ID = BAR2ID_LEFT;
 
     LOGFONT lf;
@@ -140,6 +141,12 @@ void RegistrySettings::Load(INT nCmdShow)
         ReadDWORD(text, _T("PositionY"),    FontsPositionY);
         ReadDWORD(text, _T("ShowTextTool"), ShowTextTool);
         ReadString(text, _T("TypeFaceName"), strFontName, strFontName);
+    }
+
+    CRegKey bar1;
+    if (bar1.Open(paint, _T("General-Bar1"), KEY_READ) == ERROR_SUCCESS)
+    {
+        ReadDWORD(bar1, _T("BarID"), Bar1ID);
     }
 
     CRegKey bar2;
@@ -218,6 +225,12 @@ void RegistrySettings::Store()
         text.SetDWORDValue(_T("PositionY"),     FontsPositionY);
         text.SetDWORDValue(_T("ShowTextTool"),  ShowTextTool);
         text.SetStringValue(_T("TypeFaceName"), strFontName);
+    }
+
+    CRegKey bar1;
+    if (bar1.Create(paint, _T("General-Bar1")) == ERROR_SUCCESS)
+    {
+        bar1.SetDWORDValue(_T("BarID"), Bar1ID);
     }
 
     CRegKey bar2;

--- a/base/applications/mspaint/registry.h
+++ b/base/applications/mspaint/registry.h
@@ -43,7 +43,13 @@ public:
     DWORD ShowStatusBar;
     DWORD ShowPalette;
     DWORD ShowToolBox;
+    DWORD Bar1ID;
     DWORD Bar2ID;
+
+// Values for Bar1ID.
+// I think these values are Win2k3 mspaint compatible but sometimes not working...
+#define BAR1ID_TOP    0x0000e81b
+#define BAR1ID_BOTTOM 0x0000e81e
 
 // Values for Bar2ID.
 // I think these values are Win2k3 mspaint compatible but sometimes not working...

--- a/base/applications/mspaint/winproc.cpp
+++ b/base/applications/mspaint/winproc.cpp
@@ -108,11 +108,22 @@ void CMainWindow::alignChildrenToMainWindow()
 
     if (::IsWindowVisible(paletteWindow))
     {
-        hDWP = ::DeferWindowPos(hDWP, paletteWindow, NULL,
-                                rcSpace.left, rcSpace.top,
-                                rcSpace.right - rcSpace.left, CY_PALETTE,
-                                SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
-        rcSpace.top += CY_PALETTE;
+        if (registrySettings.Bar1ID == BAR1ID_BOTTOM)
+        {
+            hDWP = ::DeferWindowPos(hDWP, paletteWindow, NULL,
+                                    rcSpace.left, rcSpace.bottom - CY_PALETTE,
+                                    rcSpace.right - rcSpace.left, CY_PALETTE,
+                                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
+            rcSpace.bottom -= CY_PALETTE;
+        }
+        else
+        {
+            hDWP = ::DeferWindowPos(hDWP, paletteWindow, NULL,
+                                    rcSpace.left, rcSpace.top,
+                                    rcSpace.right - rcSpace.left, CY_PALETTE,
+                                    SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOREPOSITION);
+            rcSpace.top += CY_PALETTE;
+        }
     }
 
     if (canvasWindow.IsWindow())


### PR DESCRIPTION
## Purpose
The user will be able to move the palette window to bottom.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Screenshots

Top:
![top](https://user-images.githubusercontent.com/2107452/229422219-a4e9ee08-44fb-4b09-a544-73d81e35dfcf.png)

Bottom:
![bottom](https://user-images.githubusercontent.com/2107452/229422222-b4793706-af41-4b9d-9cfa-f1c0305db328.png)

## Proposed changes

- Add `Bar1ID` registry setting.
- Move `paletteWindow` to top or bottom in `mainWindow`'s `WM_SIZE` handling.
- Track the mouse dragging on `paletteWindow`.
- If the dragging is beyond the center point, then move `paletteWindow`.

## TODO

- [x] Do tests.