### PR TITLE
[KDGDB] Macro for converting a ULPTR64 to a ULONG64

### DIFF
--- a/drivers/base/kdgdb/kdpacket.c
+++ b/drivers/base/kdgdb/kdpacket.c
@@ -259,8 +259,8 @@ GetVersionSendHandler(
     RtlCopyMemory(&KdVersion, &State->u.GetVersion64, sizeof(KdVersion));
     DebuggerDataList = (LIST_ENTRY*)(ULONG_PTR)KdVersion.DebuggerDataList;
     KdDebuggerDataBlock = CONTAINING_RECORD(DebuggerDataList->Flink, KDDEBUGGER_DATA64, Header.List);
-    ProcessListHead = (LIST_ENTRY*)(ULONG_PTR)KdDebuggerDataBlock->PsActiveProcessHead;
-    ModuleListHead = (LIST_ENTRY*)(ULONG_PTR)KdDebuggerDataBlock->PsLoadedModuleList;
+    ProcessListHead = (LIST_ENTRY*)(ULONG_PTR)ULPTR64_TO_ULONG64(KdDebuggerDataBlock->PsActiveProcessHead);
+    ModuleListHead = (LIST_ENTRY*)(ULONG_PTR)ULPTR64_TO_ULONG64(KdDebuggerDataBlock->PsLoadedModuleList);
 
     /* Now we can get the context for the current state */
     KdpSendPacketHandler = NULL;

--- a/sdk/include/psdk/wdbgexts.h
+++ b/sdk/include/psdk/wdbgexts.h
@@ -182,9 +182,11 @@ typedef union _ULPTR64
     ULONG_PTR ptr;
     ULONG64 ptr64;
 } ULPTR64;
+#define ULPTR64_TO_ULONG64(x) (x).ptr64
 #else
 // #define ULPTR64 PVOID64
 #define ULPTR64 ULONG64
+#define ULPTR64_TO_ULONG64(x) (x)
 #endif
 
 typedef struct _KDDEBUGGER_DATA64


### PR DESCRIPTION
This depends on the architecture and compiler. If this is 32 bit and gcc / clang ULPTR64 is a union which cannot be simply cast to an integer value. The macro is an architecture independent way of converting a ULPTR64 to a ULONG64.

This should fix a compilation error when configuring with:

    -D_WINKD_:BOOL=TRUE -DGDB:BOOL=TRUE -DSEPARATE_DBG:BOOL=TRUE -DKDBG:BOOL=FALSE

as documented on https://reactos.org/wiki/GDB

## Purpose

ReactOS currently does not build with

    -D_WINKD_:BOOL=TRUE -DGDB:BOOL=TRUE -DSEPARATE_DBG:BOOL=TRUE -DKDBG:BOOL=FALSE

on 32 bit / gcc. This patch should fix that. Moreover it introduces a macro which can be used in
future references of ULPTR64 (so one does not need to #ifdef in the .c file)