### PR TITLE
[MSPAINT] Rename some window classes

### DIFF
--- a/base/applications/mspaint/canvas.h
+++ b/base/applications/mspaint/canvas.h
@@ -11,7 +11,7 @@
 class CCanvasWindow : public CWindowImpl<CCanvasWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintCanvas"), 0, COLOR_APPWORKSPACE)
+    DECLARE_WND_CLASS_EX(_T("PaintCanvas"), 0, COLOR_APPWORKSPACE)
 
     BEGIN_MSG_MAP(CCanvasWindow)
         MESSAGE_HANDLER(WM_SIZE, OnSize)

--- a/base/applications/mspaint/fullscreen.h
+++ b/base/applications/mspaint/fullscreen.h
@@ -11,7 +11,7 @@
 class CFullscreenWindow : public CWindowImpl<CFullscreenWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("FullscreenWindow"), CS_DBLCLKS, COLOR_BACKGROUND)
+    DECLARE_WND_CLASS_EX(_T("ReactOSPaintFullscreenWindow"), CS_DBLCLKS, COLOR_BACKGROUND)
 
     BEGIN_MSG_MAP(CFullscreenWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/fullscreen.h
+++ b/base/applications/mspaint/fullscreen.h
@@ -11,7 +11,7 @@
 class CFullscreenWindow : public CWindowImpl<CFullscreenWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintFullscreenWindow"), CS_DBLCLKS, COLOR_BACKGROUND)
+    DECLARE_WND_CLASS_EX(_T("PaintFullscreen"), CS_DBLCLKS, COLOR_BACKGROUND)
 
     BEGIN_MSG_MAP(CFullscreenWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/miniature.h
+++ b/base/applications/mspaint/miniature.h
@@ -12,7 +12,7 @@
 class CMiniatureWindow : public CWindowImpl<CMiniatureWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("MiniatureWindow"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("ReactOSPaintMiniatureWindow"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CMiniatureWindow)
         MESSAGE_HANDLER(WM_CLOSE, OnClose)

--- a/base/applications/mspaint/miniature.h
+++ b/base/applications/mspaint/miniature.h
@@ -12,7 +12,7 @@
 class CMiniatureWindow : public CWindowImpl<CMiniatureWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintMiniatureWindow"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("PaintMiniature"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CMiniatureWindow)
         MESSAGE_HANDLER(WM_CLOSE, OnClose)

--- a/base/applications/mspaint/palette.h
+++ b/base/applications/mspaint/palette.h
@@ -15,7 +15,7 @@
 class CPaletteWindow : public CWindowImpl<CPaletteWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("Palette"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("ReactOSPaintPaletteWindow"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CPaletteWindow)
         MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBkgnd)

--- a/base/applications/mspaint/palette.h
+++ b/base/applications/mspaint/palette.h
@@ -15,7 +15,7 @@
 class CPaletteWindow : public CWindowImpl<CPaletteWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintPaletteWindow"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("PaintPalette"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CPaletteWindow)
         MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBkgnd)

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -24,7 +24,7 @@ public:
 class CToolBox : public CWindowImpl<CToolBox>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintToolBox"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("PaintToolBox"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolBox)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/toolbox.h
+++ b/base/applications/mspaint/toolbox.h
@@ -24,7 +24,7 @@ public:
 class CToolBox : public CWindowImpl<CToolBox>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ToolBox"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("ReactOSPaintToolBox"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolBox)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -11,7 +11,7 @@
 class CToolSettingsWindow : public CWindowImpl<CToolSettingsWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ToolSettings"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("ReactOSPaintToolSettings"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolSettingsWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)

--- a/base/applications/mspaint/toolsettings.h
+++ b/base/applications/mspaint/toolsettings.h
@@ -11,7 +11,7 @@
 class CToolSettingsWindow : public CWindowImpl<CToolSettingsWindow>
 {
 public:
-    DECLARE_WND_CLASS_EX(_T("ReactOSPaintToolSettings"), CS_DBLCLKS, COLOR_BTNFACE)
+    DECLARE_WND_CLASS_EX(_T("PaintToolSettings"), CS_DBLCLKS, COLOR_BTNFACE)
 
     BEGIN_MSG_MAP(CToolSettingsWindow)
         MESSAGE_HANDLER(WM_CREATE, OnCreate)


### PR DESCRIPTION
## Purpose

Clarify responsibility and ownership of the window classes of our Paint program.
JIRA issue: [CORE-18867](https://jira.reactos.org/browse/CORE-18867)

## Proposed changes

- Rename `"ReactOSPaintCanvas"` window class as `"PaintCanvas"`.
- Rename `"FullscreenWindow"` window class as `"PaintFullscreen"`.
- Rename `"MiniatureWindow"` window class as `"PaintMiniature"`.
- Rename `"Palette"` window class as `"PaintPalette"`.
- Rename `"ToolBox"` window class as `"PaintToolBox"`.
- Rename `"ToolSettings"` window class as `"PaintToolSettings"`.

# TODO

- [ ] Reach consensus.