### PR TITLE
[NTDLL:LDR] Rename parameter "SearchPath" to "DllSearchPath"

### DIFF
--- a/dll/ntdll/ldr/ldrapi.c
+++ b/dll/ntdll/ldr/ldrapi.c
@@ -307,7 +307,7 @@ LdrLockLoaderLock(IN ULONG Flags,
 NTSTATUS
 NTAPI
 DECLSPEC_HOTPATCH
-LdrLoadDll(IN PWSTR SearchPath OPTIONAL,
+LdrLoadDll(IN PWSTR DllSearchPath OPTIONAL,
            IN PULONG DllCharacteristics OPTIONAL,
            IN PUNICODE_STRING DllName,
            OUT PVOID *BaseAddress)
@@ -396,7 +396,7 @@ LdrLoadDll(IN PWSTR SearchPath OPTIONAL,
 
         /* Load the DLL */
         Status = LdrpLoadDll(RedirectedDll,
-                             SearchPath,
+                             DllSearchPath,
                              DllCharacteristics,
                              DllName,
                              BaseAddress,

--- a/dll/ntdll/ldr/ldrutils.c
+++ b/dll/ntdll/ldr/ldrutils.c
@@ -1020,7 +1020,7 @@ LdrpSetProtection(PVOID ViewBase,
 /* NOTE: Not yet reviewed */
 NTSTATUS
 NTAPI
-LdrpMapDll(IN PWSTR SearchPath OPTIONAL,
+LdrpMapDll(IN PWSTR DllSearchPath OPTIONAL,
            IN PWSTR DllPath2,
            IN PWSTR DllName OPTIONAL,
            IN PULONG DllCharacteristics,
@@ -1061,7 +1061,7 @@ LdrpMapDll(IN PWSTR SearchPath OPTIONAL,
     {
         DPRINT1("LDR: LdrpMapDll: Image Name %ws, Search Path %ws\n",
                 DllName,
-                SearchPath ? SearchPath : L"");
+                DllSearchPath ? DllSearchPath : L"");
     }
 
     /* Check if we have a known dll directory */
@@ -1104,7 +1104,7 @@ SkipCheck:
     if (!SectionHandle)
     {
         /* It didn't, so try to resolve the name now */
-        if (LdrpResolveDllName(SearchPath,
+        if (LdrpResolveDllName(DllSearchPath,
                                DllName,
                                &FullDllName,
                                &BaseDllName))
@@ -1780,14 +1780,14 @@ Quickie:
 
 NTSTATUS
 NTAPI
-LdrpSearchPath(IN PWCHAR *SearchPath,
+LdrpSearchPath(IN PWCHAR *DllSearchPath,
                IN PWCHAR DllName,
                IN PUNICODE_STRING PathName,
                IN PUNICODE_STRING FullPathName,
                IN PUNICODE_STRING *ExpandedName)
 {
     BOOLEAN TryAgain = FALSE;
-    PWCHAR ActualSearchPath = *SearchPath;
+    PWCHAR ActualSearchPath = *DllSearchPath;
     UNICODE_STRING TestName;
     NTSTATUS Status;
     PWCHAR Buffer, BufEnd = NULL;
@@ -1796,7 +1796,7 @@ LdrpSearchPath(IN PWCHAR *SearchPath,
     //PWCHAR pp;
 
     /* Check if we don't have a search path */
-    if (!ActualSearchPath) *SearchPath = LdrpDefaultPath.Buffer;
+    if (!ActualSearchPath) *DllSearchPath = LdrpDefaultPath.Buffer;
 
     /* Display debug output if snaps are on */
     if (ShowSnaps)
@@ -1806,7 +1806,7 @@ LdrpSearchPath(IN PWCHAR *SearchPath,
                    "LDR: %s - Looking for %ws in %ws\n",
                    __FUNCTION__,
                    DllName,
-                   *SearchPath);
+                   *DllSearchPath);
     }
 
     /* Check if we're dealing with a relative path */
@@ -1909,7 +1909,7 @@ LdrpSearchPath(IN PWCHAR *SearchPath,
                 ASSERT(TestName.Buffer);
 
                 /* Resolve the name */
-                *SearchPath = ActualSearchPath++;
+                *DllSearchPath = ActualSearchPath++;
                 Status = LdrpResolveFullName(&TestName,
                                              PathName,
                                              FullPathName,

--- a/sdk/include/ndk/umfuncs.h
+++ b/sdk/include/ndk/umfuncs.h
@@ -157,7 +157,7 @@ LdrInitializeThunk(
 NTSTATUS
 NTAPI
 LdrLoadDll(
-    _In_opt_ PWSTR SearchPath,
+    _In_opt_ PWSTR DllSearchPath,
     _In_opt_ PULONG LoadFlags,
     _In_ PUNICODE_STRING Name,
     _Out_opt_ PVOID *BaseAddress


### PR DESCRIPTION
## Purpose

Rename parameter "SearchPath" to "DllSearchPath".

`SearchPath` is a macro defined as `SearchPathA` or `SearchPathW`, improper to be used as a parameter name
![1](https://user-images.githubusercontent.com/55521781/230008079-ea8c4ec6-694d-4d73-8ad6-522cc6c2beb6.png)

JIRA issue: None

## Proposed changes

"SearchPath" has renamed to "DllSearchPath".