### PR TITLE
[EXPLORER][RUNDLL32] Restore minimized non-task windows

### DIFF
--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -130,6 +130,7 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_GETTASKSWITCH (WM_USER + 236)
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
+#define TWM_SENDPULSE (WM_USER + 400)
 
 extern const GUID IID_IShellDesktopTray;
 

--- a/base/shell/explorer/precomp.h
+++ b/base/shell/explorer/precomp.h
@@ -130,7 +130,7 @@ HRESULT WINAPI _CBandSite_CreateInstance(LPUNKNOWN pUnkOuter, REFIID riid, void 
 #define TWM_GETTASKSWITCH (WM_USER + 236)
 #define TWM_OPENSTARTMENU (WM_USER + 260)
 #define TWM_SETTINGSCHANGED (WM_USER + 300)
-#define TWM_SENDPULSE (WM_USER + 400)
+#define TWM_PULSE (WM_USER + 400)
 
 extern const GUID IID_IShellDesktopTray;
 
@@ -150,6 +150,7 @@ DECLARE_INTERFACE_(ITrayWindow, IUnknown)
     STDMETHOD_(HWND, DisplayProperties) (THIS) PURE;
     STDMETHOD_(BOOL, ExecContextMenuCmd) (THIS_ UINT uiCmd) PURE;
     STDMETHOD_(BOOL, Lock) (THIS_ BOOL bLock) PURE;
+    STDMETHOD_(BOOL, IsTaskWnd) (THIS_ HWND hWnd) PURE;
 };
 #undef INTERFACE
 
@@ -167,6 +168,7 @@ DECLARE_INTERFACE_(ITrayWindow, IUnknown)
 #define ITrayWindow_DisplayProperties(p)    (p)->lpVtbl->DisplayProperties(p)
 #define ITrayWindow_ExecContextMenuCmd(p,a) (p)->lpVtbl->ExecContextMenuCmd(p,a)
 #define ITrayWindow_Lock(p,a)               (p)->lpVtbl->Lock(p,a)
+#define ITrayWindow_IsTaskWnd(p,a)          (p)->lpVtbl->IsTaskWnd(p,a)
 #endif
 
 HRESULT CreateTrayWindow(ITrayWindow ** ppTray);

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1519,7 +1519,7 @@ public:
 
         case HSHELL_WINDOWDESTROYED:
             /* The window still exists! Delay destroying it a bit */
-            SendPulseToTray(FALSE, (HWND)lParam);
+            SendPulseToTray(TRUE, (HWND)lParam);
             DeleteTask((HWND)lParam);
             break;
 

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1606,8 +1606,7 @@ public:
             else
             {
                 ::SwitchToThisWindow(TaskItem->hWnd, TRUE);
-                if (TaskItem->wndpl.length == sizeof(TaskItem->wndpl))
-                    ::SetWindowPlacement(TaskItem->hWnd, &TaskItem->wndpl);
+                ::SetWindowPlacement(TaskItem->hWnd, &TaskItem->wndpl);
 
                 TRACE("Valid button clicked. App window Restored.\n");
             }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -82,6 +82,7 @@ typedef struct _TASK_ITEM
     PTASK_GROUP Group;
     INT Index;
     INT IconIndex;
+    WINDOWPLACEMENT wndpl;
 
     union
     {
@@ -1112,6 +1113,8 @@ public:
                 TaskItem->hWnd = hWnd;
                 TaskItem->Index = -1;
                 TaskItem->Group = AddToTaskGroup(hWnd);
+                TaskItem->wndpl.length = sizeof(TaskItem->wndpl);
+                ::GetWindowPlacement(hWnd, &TaskItem->wndpl);
 
                 if (!m_IsDestroying)
                 {
@@ -1594,12 +1597,18 @@ public:
 
             if (!bIsMinimized && bIsActive)
             {
+                TaskItem->wndpl.length = sizeof(TaskItem->wndpl);
+                ::GetWindowPlacement(TaskItem->hWnd, &TaskItem->wndpl);
+
                 ::ShowWindowAsync(TaskItem->hWnd, SW_MINIMIZE);
                 TRACE("Valid button clicked. App window Minimized.\n");
             }
             else
             {
                 ::SwitchToThisWindow(TaskItem->hWnd, TRUE);
+                if (TaskItem->wndpl.length == sizeof(TaskItem->wndpl))
+                    ::SetWindowPlacement(TaskItem->hWnd, &TaskItem->wndpl);
+
                 TRACE("Valid button clicked. App window Restored.\n");
             }
         }

--- a/base/shell/explorer/taskswnd.cpp
+++ b/base/shell/explorer/taskswnd.cpp
@@ -1381,27 +1381,9 @@ public:
         m_TaskBar.EndUpdate();
     }
 
-    BOOL IsTaskWnd(HWND hWnd) const
-    {
-        if (::IsWindow(hWnd) && ::IsWindowVisible(hWnd) &&
-            !m_Tray->IsSpecialHWND(hWnd))
-        {
-            DWORD exStyle = ::GetWindowLongPtr(hWnd, GWL_EXSTYLE);
-            /* Don't list popup windows and also no tool windows */
-            if ((::GetWindow(hWnd, GW_OWNER) == NULL || exStyle & WS_EX_APPWINDOW) &&
-                !(exStyle & WS_EX_TOOLWINDOW))
-            {
-                return TRUE;
-            }
-        }
-        return FALSE;
-    }
-
     BOOL CALLBACK EnumWindowsProc(IN HWND hWnd)
     {
-        /* Only show windows that still exist and are visible and none of explorer's
-        special windows (such as the desktop or the tray window) */
-        if (IsTaskWnd(hWnd))
+        if (m_Tray->IsTaskWnd(hWnd))
         {
             TRACE("Adding task for %p...\n", hWnd);
             AddTask(hWnd);
@@ -1484,7 +1466,7 @@ public:
     VOID SendPulseToTray(BOOL bDelete, HWND hwndActive)
     {
         HWND hwndTray = m_Tray->GetHWND();
-        ::SendMessage(hwndTray, TWM_SENDPULSE, bDelete, (LPARAM)hwndActive);
+        ::SendMessage(hwndTray, TWM_PULSE, bDelete, (LPARAM)hwndActive);
     }
 
     BOOL HandleAppCommand(IN WPARAM wParam, IN LPARAM lParam)
@@ -1612,7 +1594,7 @@ public:
 
             if (!bIsMinimized && bIsActive)
             {
-                ::ShowWindow(TaskItem->hWnd, SW_MINIMIZE);
+                ::ShowWindowAsync(TaskItem->hWnd, SW_MINIMIZE);
                 TRACE("Valid button clicked. App window Minimized.\n");
             }
             else
@@ -1638,7 +1620,6 @@ public:
             TaskGroup = FindTaskGroupByIndex((INT) wIndex);
             if (TaskGroup != NULL && TaskGroup->IsCollapsed)
             {
-                SendPulseToTray(FALSE, TaskItem->hWnd);
                 HandleTaskGroupClick(TaskGroup);
                 return TRUE;
             }

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2476,7 +2476,7 @@ ChangePos:
         if (::IsWindow(hWnd) && ::IsWindowVisible(hWnd) && !IsSpecialHWND(hWnd))
         {
             DWORD exStyle = (DWORD)::GetWindowLongPtr(hWnd, GWL_EXSTYLE);
-            if ((exStyle & WS_EX_APPWINDOW) || (::GetWindow(hWnd, GW_OWNER) == NULL) &&
+            if (((exStyle & WS_EX_APPWINDOW) || ::GetWindow(hWnd, GW_OWNER) == NULL) &&
                 !(exStyle & WS_EX_TOOLWINDOW))
             {
                 return TRUE;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2476,7 +2476,6 @@ ChangePos:
         if (::IsWindow(hWnd) && ::IsWindowVisible(hWnd) && !IsSpecialHWND(hWnd))
         {
             DWORD exStyle = (DWORD)::GetWindowLongPtr(hWnd, GWL_EXSTYLE);
-            /* Don't list popup windows and also no tool windows */
             if ((::GetWindow(hWnd, GW_OWNER) == NULL || (exStyle & WS_EX_APPWINDOW)) &&
                 !(exStyle & WS_EX_TOOLWINDOW))
             {

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3236,7 +3236,6 @@ HandleTrayContextMenu:
         HWND hwndDesktop;
         HWND hTrayWnd;
         HWND hwndProgman;
-        BOOL bRet;
         CSimpleArray<MINWNDPOS> *pMinimizedAll;
         BOOL bShowDesktop;
     };
@@ -3273,7 +3272,6 @@ HandleTrayContextMenu:
             info->pMinimizedAll->Add(mwp);
 
             ::ShowWindowAsync(hwnd, SW_MINIMIZE);
-            info->bRet = TRUE;
         }
 
         return TRUE;
@@ -3288,7 +3286,6 @@ HandleTrayContextMenu:
         info.hwndDesktop = GetDesktopWindow();;
         info.hTrayWnd = FindWindowW(L"Shell_TrayWnd", NULL);
         info.hwndProgman = FindWindowW(L"Progman", NULL);
-        info.bRet = FALSE;
         info.pMinimizedAll = &g_MinimizedAll;
         info.bShowDesktop = bShowDesktop;
         EnumWindows(MinimizeWindowsProc, (LPARAM)&info);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3293,13 +3293,6 @@ HandleTrayContextMenu:
         info.bShowDesktop = bShowDesktop;
         EnumWindows(MinimizeWindowsProc, (LPARAM)&info);
 
-        // invalid handles should be cleared to avoid mismatch of handles
-        for (INT i = 0; i < g_MinimizedAll.GetSize(); ++i)
-        {
-            if (!::IsWindow(g_MinimizedAll[i].hwnd))
-                g_MinimizedAll[i].hwnd = NULL;
-        }
-
         ::SetForegroundWindow(m_DesktopWnd);
         ::SetFocus(m_DesktopWnd);
         SetTimer(TIMER_ID_IGNOREPULSERESET, TIMER_IGNOREPULSERESET_TIMEOUT, NULL);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2469,14 +2469,14 @@ ChangePos:
     }
 
     /* The task window is visible and non-WS_EX_TOOLWINDOW and
-       (has WS_EX_APPWINDOW style or has no owner) and is none of explorer's
+       { has WS_EX_APPWINDOW style or has no owner } and is none of explorer's
        special windows (such as the desktop or the tray window) */
     BOOL STDMETHODCALLTYPE IsTaskWnd(HWND hWnd)
     {
         if (::IsWindow(hWnd) && ::IsWindowVisible(hWnd) && !IsSpecialHWND(hWnd))
         {
             DWORD exStyle = (DWORD)::GetWindowLongPtr(hWnd, GWL_EXSTYLE);
-            if ((::GetWindow(hWnd, GW_OWNER) == NULL || (exStyle & WS_EX_APPWINDOW)) &&
+            if ((exStyle & WS_EX_APPWINDOW) || (::GetWindow(hWnd, GW_OWNER) == NULL) &&
                 !(exStyle & WS_EX_TOOLWINDOW))
             {
                 return TRUE;

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3205,7 +3205,7 @@ HandleTrayContextMenu:
             if (::IsWindowVisible(hwnd) && ::IsIconic(hwnd) &&
                 (!IsTaskWnd(hwnd) || !::IsWindowEnabled(hwnd)))
             {
-                ::SetWindowPlacement(hwnd, &g_MinimizedAll[i].wndpl);
+                ::SetWindowPlacement(hwnd, &g_MinimizedAll[i].wndpl); // Restore
             }
         }
 
@@ -3266,9 +3266,11 @@ HandleTrayContextMenu:
 
         if (::IsWindowVisible(hwnd) && !::IsIconic(hwnd))
         {
-            MINWNDPOS mwp = { hwnd };
+            MINWNDPOS mwp;
+            mwp.hwnd = hwnd;
             mwp.wndpl.length = sizeof(mwp.wndpl);
-            ::GetWindowPlacement(hwnd, &mwp.wndpl);
+            ::GetWindowPlacement(hwnd, &mwp.wndpl); // Save the position and status
+
             info->pMinimizedAll->Add(mwp);
 
             ::ShowWindowAsync(hwnd, SW_MINIMIZE);

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -2477,7 +2477,7 @@ ChangePos:
         {
             DWORD exStyle = (DWORD)::GetWindowLongPtr(hWnd, GWL_EXSTYLE);
             /* Don't list popup windows and also no tool windows */
-            if ((::GetWindow(hWnd, GW_OWNER) == NULL || exStyle & WS_EX_APPWINDOW) &&
+            if ((::GetWindow(hWnd, GW_OWNER) == NULL || (exStyle & WS_EX_APPWINDOW)) &&
                 !(exStyle & WS_EX_TOOLWINDOW))
             {
                 return TRUE;
@@ -3194,18 +3194,24 @@ HandleTrayContextMenu:
         return (LRESULT)m_TaskSwitch;
     }
 
-    void RestoreMinimizedNonTaskWnds(BOOL bDestroy, HWND hwndActive)
+    void RestoreMinimizedNonTaskWnds(BOOL bDestroyed, HWND hwndActive)
     {
         for (INT i = g_MinimizedAll.GetSize() - 1; i >= 0; --i)
         {
             HWND hwnd = g_MinimizedAll[i].hwnd;
-            if (hwndActive == hwnd)
+            if (!hwnd || hwndActive == hwnd)
                 continue;
-            if (::IsWindowVisible(hwnd) && ::IsIconic(hwnd) && !IsTaskWnd(hwnd))
+
+            if (::IsWindowVisible(hwnd) && ::IsIconic(hwnd) &&
+                (!IsTaskWnd(hwnd) || !::IsWindowEnabled(hwnd)))
+            {
                 ::SetWindowPlacement(hwnd, &g_MinimizedAll[i].wndpl);
+            }
         }
+
         g_MinimizedAll.RemoveAll();
-        if (!bDestroy)
+
+        if (!bDestroyed)
             ::SetForegroundWindow(hwndActive);
     }
 

--- a/base/shell/explorer/traywnd.cpp
+++ b/base/shell/explorer/traywnd.cpp
@@ -3350,6 +3350,7 @@ HandleTrayContextMenu:
         }
         else if (wParam == TIMER_ID_IGNOREPULSERESET)
         {
+            KillTimer(TIMER_ID_IGNOREPULSERESET);
             IgnorePulse = FALSE;
         }
         return 0;

--- a/base/system/rundll32/rundll32.c
+++ b/base/system/rundll32/rundll32.c
@@ -339,7 +339,7 @@ LRESULT CALLBACK EmptyWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
             EnumWindows(EnumWindowsProc, (LPARAM)&FindOwned);
             if (FindOwned.hwndTarget)
             {
-                if (LOWORD(wParam) != WA_INACTIVE) /* To be active */
+                if (LOWORD(wParam) != WA_INACTIVE) /* To be activated */
                 {
                     SetActiveWindow(FindOwned.hwndTarget);
                     return 0;

--- a/base/system/rundll32/rundll32.c
+++ b/base/system/rundll32/rundll32.c
@@ -29,6 +29,7 @@
 #include <winnls.h>
 #include <winuser.h>
 #include <tchar.h>
+#include <undocuser.h> // For WM_POPUPSYSTEMMENU
 
 #include "resource.h"
 
@@ -299,9 +300,57 @@ LPSTR DuplicateToMultiByte(LPCTSTR lptString, size_t nBufferSize)
     return lpString;
 }
 
+typedef struct
+{
+    HWND hwndOwner;
+    HWND hwndTarget;
+} FIND_OWNED, *PFIND_OWNED;
+
+static BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
+{
+    PFIND_OWNED pFindOwned = (PFIND_OWNED)lParam;
+    if (pFindOwned->hwndOwner == GetWindow(hwnd, GW_OWNER))
+    {
+        pFindOwned->hwndTarget = hwnd;
+        return FALSE;
+    }
+    return TRUE;
+}
+
 LRESULT CALLBACK EmptyWindowProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
-    return DefWindowProc(hWnd, uMsg, wParam, lParam);
+    switch (uMsg)
+    {
+        case WM_POPUPSYSTEMMENU:
+        case WM_SYSCOMMAND:
+        {
+            /* Find the owned window */
+            FIND_OWNED FindOwned = { hWnd, NULL };
+            EnumWindows(EnumWindowsProc, (LPARAM)&FindOwned);
+            /* Forward message */
+            if (FindOwned.hwndTarget)
+                PostMessageW(FindOwned.hwndTarget, uMsg, wParam, lParam);
+            break;
+        }
+        case WM_ACTIVATE:
+        {
+            /* Find the owned window */
+            FIND_OWNED FindOwned = { hWnd, NULL };
+            EnumWindows(EnumWindowsProc, (LPARAM)&FindOwned);
+            if (FindOwned.hwndTarget)
+            {
+                if (LOWORD(wParam) != WA_INACTIVE) /* To be active */
+                {
+                    SetActiveWindow(FindOwned.hwndTarget);
+                    return 0;
+                }
+            }
+            /* Fall through */
+        }
+        default:
+            return DefWindowProc(hWnd, uMsg, wParam, lParam);
+    }
+    return 0;
 }
 
 // Registers a minimal window class for passing to the dll function

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -834,6 +834,9 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
         }
     }
 
+    /* Add button to the taskbar */
+    ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
+
     /* Activate the corresponding button in the taskbar */
     CoInitialize(NULL);
     if (CoCreateInstance(&CLSID_TaskbarList,

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -834,9 +834,6 @@ Control_ShowAppletInTaskbar(CPlApplet* applet, UINT index)
         }
     }
 
-    /* Add button to the taskbar */
-    ShowWindow(applet->hWnd, SW_SHOWMINNOACTIVE);
-
     /* Activate the corresponding button in the taskbar */
     CoInitialize(NULL);
     if (CoCreateInstance(&CLSID_TaskbarList,


### PR DESCRIPTION
## Purpose

The minimized non-task windows were not usable due to the bugs. At some situations, the system will restore the minimized non-task windows.
JIRA issue: [CORE-13895](https://jira.reactos.org/browse/CORE-13895), [CORE-18350](https://jira.reactos.org/browse/CORE-18350)

## Proposed changes

- Add `IsTaskWnd` helper function.
- Add `SendPulseToTray` function to send a pulse to the tray window.
- At some shell hook handlings, send a pulse to the tray window.
- Add `IgnorePulse` flag to control the timing of restoring.
- Add a timer to reset `IgnorePulse` flag.
- If the pulse has come and `IgnorePulse` flag is false, then restore the minimized non-task windows.
- Modify the `rundll32` window procedure.
- Use `WINDOWPLACEMENT` to restore the minimized windows.

## TODO

- [x] Fix control panel applets.
- [x] Fix bug of Notepad About that `TANGaming` reported.
- [x] Do small tests.
- [x] Do big tests.
