### PR TITLE
[RUNDLL32][SHELL32] Rename 'rundll32_window' as 'RunDLL'

### DIFF
--- a/base/system/rundll32/rundll32.c
+++ b/base/system/rundll32/rundll32.c
@@ -50,7 +50,7 @@ LPCTSTR DllNotLoaded = _T("LoadLibrary failed to load \"%s\"");
 LPCTSTR MissingEntry = _T("Missing entry point:%s\nIn %s");
 */
 LPCTSTR rundll32_wtitle = _T("rundll32");
-LPCTSTR rundll32_wclass = _T("rundll32_window");
+LPCTSTR rundll32_wclass = _T("RunDLL");
 
 TCHAR ModuleFileName[MAX_PATH+1];
 LPTSTR ModuleTitle;

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -771,14 +771,11 @@ Control_EnumWinProc(
     WCHAR szAppFile[MAX_PATH];
 
     if (pData->hRunDLL == hwnd)
-    {
-        // Skip self instance
-        return TRUE;
-    }
+        return TRUE; /* Skip self instance */
 
     sAppletNo = (UINT_PTR)GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLFlags));
     if (sAppletNo != pData->sAppletNo)
-        return TRUE; // Continue enumeration
+        return TRUE; /* Continue enumeration */
 
     hRes = GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLName));
     GlobalGetAtomNameW((ATOM)HandleToUlong(hRes), szAppFile, _countof(szAppFile));
@@ -788,11 +785,11 @@ Control_EnumWinProc(
         if (IsWindow(hDialog))
         {
             pData->hDlgResult = hDialog;
-            return FALSE; // stop enumeration
+            return FALSE; /* Stop enumeration */
         }
     }
 
-    return TRUE; // continue enumeration
+    return TRUE; /* Continue enumeration */
 }
 
 /**

--- a/dll/win32/shell32/wine/control.c
+++ b/dll/win32/shell32/wine/control.c
@@ -766,7 +766,9 @@ Control_EnumWinProc(
     _In_ LPARAM lParam)
 {
     AppDlgFindData* pData = (AppDlgFindData*)lParam;
-    WCHAR szClassName[256] = L"";
+    UINT_PTR sAppletNo;
+    HANDLE hRes;
+    WCHAR szAppFile[MAX_PATH];
 
     if (pData->hRunDLL == hwnd)
     {
@@ -774,36 +776,22 @@ Control_EnumWinProc(
         return TRUE;
     }
 
-    if (GetClassNameW(hwnd, szClassName, _countof(szClassName)))
+    sAppletNo = (UINT_PTR)GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLFlags));
+    if (sAppletNo != pData->sAppletNo)
+        return TRUE; // Continue enumeration
+
+    hRes = GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLName));
+    GlobalGetAtomNameW((ATOM)HandleToUlong(hRes), szAppFile, _countof(szAppFile));
+    if (wcscmp(szAppFile, pData->szAppFile) == 0)
     {
-        // Note: A comparison on identical is not possible, the class names are different.
-        // ReactOS: 'rundll32_window'
-        // WinXP: 'RunDLL'
-        // other OS: not checked
-        if (StrStrIW(szClassName, L"rundll32") != NULL)
+        HWND hDialog = GetLastActivePopup(hwnd);
+        if (IsWindow(hDialog))
         {
-            UINT_PTR sAppletNo;
-
-            sAppletNo = (UINT_PTR)GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLFlags));
-            if (sAppletNo == pData->sAppletNo)
-            {
-                HANDLE hRes;
-                WCHAR szAppFile[MAX_PATH];
-
-                hRes = GetPropW(hwnd, (LPTSTR)MAKEINTATOM(pData->aCPLName));
-                GlobalGetAtomNameW((ATOM)HandleToUlong(hRes), szAppFile, _countof(szAppFile));
-                if (wcscmp(szAppFile, pData->szAppFile) == 0)
-                {
-                    HWND hDialog = GetLastActivePopup(hwnd);
-                    if (IsWindow(hDialog))
-                    {
-                        pData->hDlgResult = hDialog;
-                        return FALSE; // stop enumeration
-                    }
-                }
-            }
+            pData->hDlgResult = hDialog;
+            return FALSE; // stop enumeration
         }
     }
+
     return TRUE; // continue enumeration
 }
 


### PR DESCRIPTION
## Purpose

Improve compatibility.
JIRA issue: [CORE-13895](https://jira.reactos.org/browse/CORE-13895), [CORE-18350](https://jira.reactos.org/browse/CORE-18350)

## Screenshots

RunDLL on Win2k3:
![VirtualBox_Windows Server 2003_07_04_2023_10_52_49](https://user-images.githubusercontent.com/2107452/230575993-a073b75c-4d32-41b7-881c-5c35d4744366.png)
The window class is `"RunDLL"`.

ReactOS (AFTER):
![after](https://user-images.githubusercontent.com/2107452/230706554-52b1fa49-1565-4661-9bfd-ed561b5feeba.png)
It is still working.

## Proposed changes

- Rename the window class name `"rundll32_window"` as `"RunDLL"`.
- Delete some `shell32` codes about this window class.

## TODO

- [x] Do small tests.