### PR TITLE
[ADVAPI32] Fix RegCreateKeyExW with lpSecurityAttributes->nLength of 0

### DIFF
--- a/dll/win32/advapi32/reg/reg.c
+++ b/dll/win32/advapi32/reg/reg.c
@@ -1108,9 +1108,6 @@ RegCreateKeyExW(
 
     TRACE("RegCreateKeyExW() called\n");
 
-    if (lpSecurityAttributes && lpSecurityAttributes->nLength != sizeof(SECURITY_ATTRIBUTES))
-        return ERROR_INVALID_USER_BUFFER;
-
     /* get the real parent key */
     Status = MapDefaultKey(&ParentKey,
                            hKey);


### PR DESCRIPTION
## Purpose

_Provide graceful handling of RegCreateKeyExW when lpSecurityAttributes->nLength is zero._

JIRA issue: [CORE-15471](https://jira.reactos.org/browse/CORE-15471)

## Proposed changes

_When lpSecurityAttributes->nLength == 0 then set lpSecurityAttributes to NULL and continue._
_Provide error message showing what was found._

This allows the Win98 DDK to install without any failures.
