### PR TITLE
[NTUSER] IntImmActivateLayout: Set CI_IMMACTIVATE if not pImeWnd

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -652,6 +652,7 @@ IntImmActivateLayout(
     }
     else if (pti->spDefaultImc)
     {
+        /* IME Activation is needed */
         pti->pClientInfo->CI_flags |= CI_IMMACTIVATE;
     }
 

--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -650,6 +650,10 @@ IntImmActivateLayout(
         co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_ACTIVATELAYOUT, (LPARAM)pKL->hkl);
         UserDerefObjectCo(pImeWnd);
     }
+    else if (pti->spDefaultImc)
+    {
+        pti->pClientInfo->CI_flags |= CI_IMMACTIVATE;
+    }
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
     pti->pClientInfo->hKL = pKL->hkl;


### PR DESCRIPTION
## Purpose

Improve IME activation. If IME was not activated correctly, then the IME is not usable.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- In `IntImmActivateLayout` function, if `pImeWnd` was `NULL` and `pti->spDefaultImc` was non-`NULL`, then set `CI_IMMACTIVATE` flag.

## TODO

- [x] Do small tests.
- [x] Do big tests.