### PR TITLE
[RAPPS] Calculate download listview position

### DIFF
--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -264,7 +264,12 @@ class CDowloadingAppsListView : public CListView
     HWND
     Create(HWND hwndParent)
     {
-        RECT r = {10, 150, 320, 350};
+        RECT r;
+        ::GetClientRect(hwndParent, &r);
+        r.top = (2 * r.top + 1 * r.bottom) / 3; /* in 1:2 ratio */
+#define MARGIN 10
+        ::InflateRect(&r, -MARGIN, -MARGIN);
+
         const DWORD style = WS_CHILD | WS_VISIBLE | LVS_REPORT | LVS_SINGLESEL | LVS_SHOWSELALWAYS | LVS_NOSORTHEADER |
                             LVS_NOCOLUMNHEADER;
 

--- a/base/applications/rapps/loaddlg.cpp
+++ b/base/applications/rapps/loaddlg.cpp
@@ -266,7 +266,7 @@ class CDowloadingAppsListView : public CListView
     {
         RECT r;
         ::GetClientRect(hwndParent, &r);
-        r.top = (2 * r.top + 1 * r.bottom) / 3; /* in 1:2 ratio */
+        r.top = (2 * r.top + 1 * r.bottom) / 3; /* The vertical position at ratio 1 : 2 */
 #define MARGIN 10
         ::InflateRect(&r, -MARGIN, -MARGIN);
 


### PR DESCRIPTION
## Purpose
Correctly display Download ListView at right position in any languages.

JIRA issue: [CORE-18706](https://jira.reactos.org/browse/CORE-18706)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/230712642-df241244-64ee-401d-b429-25b41f618172.png)

## Proposed changes

- Correctly calculate the position of the Download Listview at `CDowloadingAppsListView::Create`.
- Use correct position to create the listview.

## TODO

- [x] Do tests.