### PR TITLE
[SETUPAPI] Sync setupapi/queue.c to Wine 4.8

### DIFF
--- a/media/doc/WINESYNC.txt
+++ b/media/doc/WINESYNC.txt
@@ -363,7 +363,7 @@ secur32 -
 
 setupapi -
   dll/win32/setupapi/dialog.c           # Synced to WineStaging-1.9.15
-  dll/win32/setupapi/query.c            # Partially synced to WineStaging-1.9.4
+  dll/win32/setupapi/query.c            # Partially synced to Wine-4.8
   dll/win32/setupapi/setupcab.c         # Synced to WineStaging-1.9.4
 
 win32k -


### PR DESCRIPTION
## Purpose

_Sync setupapi/queue.c to Wine 4.8 to improve cab extraction._
_This fixes 'fixme:(dll/win32/setupapi/queue.c:418) awful hack: extracting cabinet'_

JIRA issue: [CORE-15471](https://jira.reactos.org/browse/CORE-15471)

## Proposed changes

_This is not specific to CORE-15471, but is an aside and related to it._
_Partial Wine Sync to Version 4.8 for Setupapi queue function._