### PR TITLE
[NTOS:CC][NTOS:MM] Restore cache trimming functionality

### DIFF
--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -293,7 +293,8 @@ MmRebalanceMemoryConsumers(VOID)
 {
     // if (InterlockedCompareExchange(&PageOutThreadActive, 0, 1) == 0)
     {
-        KeSetEvent(&MiBalancerEvent, IO_NO_INCREMENT, FALSE);
+        /* Reset the event and boost balancer priority */
+        KeSetEvent(&MiBalancerEvent, EVENT_INCREMENT, FALSE);
     }
 }
 


### PR DESCRIPTION
## Purpose

Restore cache trimming functionality which allows evicting pages from the cache when low on memory.

JIRA issue: [CORE-17624](https://jira.reactos.org/browse/CORE-17624)

## Proposed changes

- Restore CcRosTrimCache() which is called from MiBalancerThread().
- Change KeSetEvent() increment to ``EVENT_INCREMENT`` in MmRebalanceMemoryConsumers() to ensure the balancer runs as soon as possible. MmRebalanceMemoryConsumers() is called by MiDecrementAvailablePages() when pages are critically low (``MmAvailablePages < MmMinimumFreePages``) meaning the balancer should be scheduled immediately, as there might not be enough pages for the balancer itself (``ASSERT(MmAvailablePages >= 32);``) later on.