### PR TITLE
Fix kernel crash, when copying large files

### DIFF
--- a/ntoskrnl/cache/section/sptab.c
+++ b/ntoskrnl/cache/section/sptab.c
@@ -364,6 +364,8 @@ MmGetSectionAssociation(PFN_NUMBER Page,
     PMM_SECTION_SEGMENT Segment = NULL;
     PCACHE_SECTION_PAGE_TABLE PageTable;
 
+    KIRQL OldIrql = MiAcquirePfnLock();
+
     PageTable = MmGetSegmentRmap(Page, &RawOffset);
     if (PageTable)
     {
@@ -373,6 +375,8 @@ MmGetSectionAssociation(PFN_NUMBER Page,
         ASSERT(PFN_FROM_SSE(PageTable->PageEntries[RawOffset]) == Page);
         InterlockedIncrement64(Segment->ReferenceCount);
     }
+
+    MiReleasePfnLock(OldIrql);
 
     return Segment;
 }

--- a/ntoskrnl/cc/copy.c
+++ b/ntoskrnl/cc/copy.c
@@ -381,6 +381,16 @@ CcCanIWrite (
         return FALSE;
     }
 
+    /* Otherwise, if there are no deferred writes yet, start the lazy writer */
+    if (IsListEmpty(&CcDeferredWrites))
+    {
+        KIRQL OldIrql;
+
+        OldIrql = KeAcquireQueuedSpinLock(LockQueueMasterLock);
+        CcScheduleLazyWriteScan(TRUE);
+        KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
+    }
+
     /* Initialize our wait event */
     KeInitializeEvent(&WaitEvent, NotificationEvent, FALSE);
 
@@ -407,12 +417,6 @@ CcCanIWrite (
                                     &Context.DeferredWriteLinks,
                                     &CcDeferredWriteSpinLock);
     }
-
-    /* Now make sure that the lazy scan writer will be active */
-    OldIrql = KeAcquireQueuedSpinLock(LockQueueMasterLock);
-    if (!LazyWriter.ScanActive)
-        CcScheduleLazyWriteScan(TRUE);
-    KeReleaseQueuedSpinLock(LockQueueMasterLock, OldIrql);
 
 #if DBG
     DPRINT1("Actively deferring write for: %p\n", FileObject);

--- a/ntoskrnl/cc/lazywrite.c
+++ b/ntoskrnl/cc/lazywrite.c
@@ -130,6 +130,16 @@ CcWriteBehind(VOID)
         ++CcLazyWriteIos;
         DPRINT("Lazy writer done (%d)\n", Count);
     }
+
+    /* Make sure we're not throttling writes after this */
+    while (MmAvailablePages < MmThrottleTop)
+    {
+        /* Break if we can't even find one to free */
+        if (!CcRosFreeOneUnusedVacb())
+        {
+            break;
+        }
+    }
 }
 
 VOID

--- a/ntoskrnl/cc/view.c
+++ b/ntoskrnl/cc/view.c
@@ -595,34 +595,26 @@ CcRosUnmarkDirtyVacb (
     }
 }
 
-static
 BOOLEAN
-CcRosFreeUnusedVacb (
-    PULONG Count)
+CcRosFreeOneUnusedVacb(
+    VOID)
 {
-    ULONG cFreed;
-    BOOLEAN Freed;
     KIRQL oldIrql;
-    PROS_VACB current;
-    LIST_ENTRY FreeList;
     PLIST_ENTRY current_entry;
-
-    cFreed = 0;
-    Freed = FALSE;
-    InitializeListHead(&FreeList);
+    PROS_VACB to_free = NULL;
 
     oldIrql = KeAcquireQueuedSpinLock(LockQueueMasterLock);
 
     /* Browse all the available VACB */
     current_entry = VacbLruListHead.Flink;
-    while (current_entry != &VacbLruListHead)
+    while ((current_entry != &VacbLruListHead) && (to_free == NULL))
     {
         ULONG Refs;
+        PROS_VACB current;
 
         current = CONTAINING_RECORD(current_entry,
                                     ROS_VACB,
                                     VacbLruListEntry);
-        current_entry = current_entry->Flink;
 
         KeAcquireSpinLockAtDpcLevel(&current->SharedCacheMap->CacheMapLock);
 
@@ -634,47 +626,32 @@ CcRosFreeUnusedVacb (
             ASSERT(!current->MappedCount);
             ASSERT(Refs == 1);
 
-            /* Reset and move to free list */
+            /* Reset it, this is the one we want to free */
             RemoveEntryList(&current->CacheMapVacbListEntry);
+            InitializeListHead(&current->CacheMapVacbListEntry);
             RemoveEntryList(&current->VacbLruListEntry);
             InitializeListHead(&current->VacbLruListEntry);
-            InsertHeadList(&FreeList, &current->CacheMapVacbListEntry);
+
+            to_free = current;
         }
 
         KeReleaseSpinLockFromDpcLevel(&current->SharedCacheMap->CacheMapLock);
 
+        current_entry = current_entry->Flink;
     }
 
     KeReleaseQueuedSpinLock(LockQueueMasterLock, oldIrql);
 
-    /* And now, free any of the found VACB, that'll free memory! */
-    while (!IsListEmpty(&FreeList))
+    /* And now, free the VACB that we found, if any. */
+    if (to_free == NULL)
     {
-        ULONG Refs;
-
-        current_entry = RemoveHeadList(&FreeList);
-        current = CONTAINING_RECORD(current_entry,
-                                    ROS_VACB,
-                                    CacheMapVacbListEntry);
-        InitializeListHead(&current->CacheMapVacbListEntry);
-        Refs = CcRosVacbDecRefCount(current);
-        ASSERT(Refs == 0);
-        ++cFreed;
+        return FALSE;
     }
 
-    /* If we freed at least one VACB, return success */
-    if (cFreed != 0)
-    {
-        Freed = TRUE;
-    }
+    /* This must be its last ref */
+    NT_VERIFY(CcRosVacbDecRefCount(to_free) == 0);
 
-    /* If caller asked for free count, return it */
-    if (Count != NULL)
-    {
-        *Count = cFreed;
-    }
-
-    return Freed;
+    return TRUE;
 }
 
 static
@@ -690,7 +667,6 @@ CcRosCreateVacb (
     NTSTATUS Status;
     KIRQL oldIrql;
     ULONG Refs;
-    BOOLEAN Retried;
     SIZE_T ViewSize = VACB_MAPPING_GRANULARITY;
 
     ASSERT(SharedCacheMap);
@@ -711,28 +687,24 @@ CcRosCreateVacb (
 
     CcRosVacbIncRefCount(current);
 
-    Retried = FALSE;
-Retry:
-    /* Map VACB in system space */
-    Status = MmMapViewInSystemSpaceEx(SharedCacheMap->Section, &current->BaseAddress, &ViewSize, &current->FileOffset, 0);
-
-    if (!NT_SUCCESS(Status))
+    while (TRUE)
     {
-        ULONG Freed;
-        /* If no space left, try to prune unused VACB
-         * to recover space to map our VACB
-         * If it succeed, retry to map, otherwise
-         * just fail.
-         */
-        if (!Retried && CcRosFreeUnusedVacb(&Freed))
+        /* Map VACB in system space */
+        Status = MmMapViewInSystemSpaceEx(SharedCacheMap->Section, &current->BaseAddress, &ViewSize, &current->FileOffset, 0);
+        if (NT_SUCCESS(Status))
         {
-            DPRINT("Prunned %d VACB, trying again\n", Freed);
-            Retried = TRUE;
-            goto Retry;
+            break;
         }
 
-        ExFreeToNPagedLookasideList(&VacbLookasideList, current);
-        return Status;
+        /*
+         * If no space left, try to prune one unused VACB to recover space to map our VACB.
+         * If it succeeds, retry to map, otherwise just fail.
+         */
+        if (!CcRosFreeOneUnusedVacb())
+        {
+            ExFreeToNPagedLookasideList(&VacbLookasideList, current);
+            return Status;
+        }
     }
 
 #if DBG

--- a/ntoskrnl/include/internal/cc.h
+++ b/ntoskrnl/include/internal/cc.h
@@ -509,3 +509,7 @@ CcRosVacbDecRefCount(
 }
 #define CcRosVacbGetRefCount(vacb) InterlockedCompareExchange((PLONG)&(vacb)->ReferenceCount, 0, 0)
 #endif
+
+BOOLEAN
+CcRosFreeOneUnusedVacb(
+    VOID);

--- a/ntoskrnl/include/internal/mm.h
+++ b/ntoskrnl/include/internal/mm.h
@@ -1135,6 +1135,14 @@ MmCreateVirtualMappingUnsafe(
     PFN_NUMBER Page
 );
 
+NTSTATUS
+NTAPI
+MmCreatePhysicalMapping(
+    _Inout_opt_ PEPROCESS Process,
+    _In_ PVOID Address,
+    _In_ ULONG flProtect,
+    _In_ PFN_NUMBER Page);
+
 ULONG
 NTAPI
 MmGetPageProtect(
@@ -1291,9 +1299,18 @@ MmGetExecuteOptions(IN PULONG ExecuteOptions);
 _Success_(return)
 BOOLEAN
 MmDeleteVirtualMapping(
-    _In_opt_ PEPROCESS Process,
+    _Inout_opt_ PEPROCESS Process,
     _In_ PVOID Address,
     _Out_opt_ BOOLEAN* WasDirty,
+    _Out_opt_ PPFN_NUMBER Page
+);
+
+_Success_(return)
+BOOLEAN
+MmDeletePhysicalMapping(
+    _Inout_opt_ PEPROCESS Process,
+    _In_ PVOID Address,
+    _Out_opt_ BOOLEAN * WasDirty,
     _Out_opt_ PPFN_NUMBER Page
 );
 

--- a/ntoskrnl/mm/ARM3/pagfault.c
+++ b/ntoskrnl/mm/ARM3/pagfault.c
@@ -653,7 +653,7 @@ MiResolveDemandZeroFault(IN PVOID Address,
     ASSERT(PointerPte->u.Hard.Valid == 0);
 
     /* Assert we have enough pages */
-    ASSERT(MmAvailablePages >= 32);
+    //ASSERT(MmAvailablePages >= 32);
 
 #if MI_TRACE_PFNS
     if (UserPdeFault) MI_SET_USAGE(MI_USAGE_PAGE_TABLE);
@@ -696,6 +696,12 @@ MiResolveDemandZeroFault(IN PVOID Address,
             /* No need to zero-fill it */
             NeedZero = FALSE;
         }
+    }
+
+    if (PageFrameNumber == 0)
+    {
+        MiReleasePfnLock(OldIrql);
+        return STATUS_NO_MEMORY;
     }
 
     /* Initialize it */
@@ -920,6 +926,10 @@ MiResolvePageFileFault(_In_ BOOLEAN StoreInstruction,
     /* Get any page, it will be overwritten */
     Color = MI_GET_NEXT_PROCESS_COLOR(CurrentProcess);
     Page = MiRemoveAnyPage(Color);
+    if (Page == 0)
+    {
+        return STATUS_NO_MEMORY;
+    }
 
     /* Initialize this PFN */
     MiInitializePfn(Page, PointerPte, StoreInstruction);
@@ -1230,6 +1240,11 @@ MiResolveProtoPteFault(IN BOOLEAN StoreInstruction,
             Color = MI_GET_NEXT_COLOR();
 
         PageFrameIndex = MiRemoveAnyPage(Color);
+        if (PageFrameIndex == 0)
+        {
+            MiReleasePfnLock(OldIrql);
+            return STATUS_NO_MEMORY;
+        }
 
         /* Perform the copy */
         MiCopyPfn(PageFrameIndex, ProtoPageFrameIndex);
@@ -1669,9 +1684,9 @@ MiDispatchFault(IN ULONG FaultCode,
     }
 
     //
-    // Generate an access fault
+    // Return status
     //
-    return STATUS_ACCESS_VIOLATION;
+    return Status;
 }
 
 NTSTATUS
@@ -2126,11 +2141,15 @@ UserFault:
         }
 
         /* Resolve a demand zero fault */
-        MiResolveDemandZeroFault(PointerPpe,
+        Status = MiResolveDemandZeroFault(PointerPpe,
                                  PointerPxe,
                                  MM_EXECUTE_READWRITE,
                                  CurrentProcess,
                                  MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto ExitUser;
+        }
 
         /* We should come back with a valid PXE */
         ASSERT(PointerPxe->u.Hard.Valid == 1);
@@ -2160,11 +2179,15 @@ UserFault:
         }
 
         /* Resolve a demand zero fault */
-        MiResolveDemandZeroFault(PointerPde,
+        Status = MiResolveDemandZeroFault(PointerPde,
                                  PointerPpe,
                                  MM_EXECUTE_READWRITE,
                                  CurrentProcess,
                                  MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto ExitUser;
+        }
 
         /* We should come back with a valid PPE */
         ASSERT(PointerPpe->u.Hard.Valid == 1);
@@ -2203,11 +2226,16 @@ UserFault:
         }
 
         /* Resolve a demand zero fault */
-        MiResolveDemandZeroFault(PointerPte,
+        Status = MiResolveDemandZeroFault(PointerPte,
                                  PointerPde,
                                  MM_EXECUTE_READWRITE,
                                  CurrentProcess,
                                  MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto ExitUser;
+        }
+
 #if _MI_PAGING_LEVELS >= 3
         MiIncrementPageTableReferences(PointerPte);
 #endif
@@ -2254,6 +2282,12 @@ UserFault:
 
                 /* Allocate a new page and copy it */
                 PageFrameIndex = MiRemoveAnyPage(MI_GET_NEXT_PROCESS_COLOR(CurrentProcess));
+                if (PageFrameIndex == 0)
+                {
+                    MiReleasePfnLock(LockIrql);
+                    Status = STATUS_NO_MEMORY;
+                    goto ExitUser;
+                }
                 OldPageFrameIndex = PFN_FROM_PTE(&TempPte);
 
                 MiCopyPfn(PageFrameIndex, OldPageFrameIndex);
@@ -2308,11 +2342,15 @@ UserFault:
         (TempPte.u.Long == (MM_EXECUTE_READWRITE << MM_PTE_SOFTWARE_PROTECTION_BITS)))
     {
         /* Resolve the fault */
-        MiResolveDemandZeroFault(Address,
+        Status = MiResolveDemandZeroFault(Address,
                                  PointerPte,
                                  TempPte.u.Soft.Protection,
                                  CurrentProcess,
                                  MM_NOIRQL);
+        if (!NT_SUCCESS(Status))
+        {
+            goto ExitUser;
+        }
 
 #if MI_TRACE_PFNS
         /* Update debug info */
@@ -2410,7 +2448,7 @@ UserFault:
             OldIrql = MiAcquirePfnLock();
 
             /* Make sure we have enough pages */
-            ASSERT(MmAvailablePages >= 32);
+            //ASSERT(MmAvailablePages >= 32);
 
             /* Try to get a zero page */
             MI_SET_USAGE(MI_USAGE_PEB_TEB);
@@ -2421,10 +2459,15 @@ UserFault:
             {
                 /* Grab a page out of there. Later we should grab a colored zero page */
                 PageFrameIndex = MiRemoveAnyPage(Color);
-                ASSERT(PageFrameIndex);
 
                 /* Release the lock since we need to do some zeroing */
                 MiReleasePfnLock(OldIrql);
+
+                if (PageFrameIndex == 0)
+                {
+                    Status = STATUS_NO_MEMORY;
+                    goto ExitUser;
+                }
 
                 /* Zero out the page, since it's for user-mode */
                 MiZeroPfn(PageFrameIndex);
@@ -2567,6 +2610,8 @@ UserFault:
                              CurrentProcess,
                              TrapInformation,
                              Vad);
+
+ExitUser:
 
     /* Return the status */
     ASSERT(KeGetCurrentIrql() <= APC_LEVEL);

--- a/ntoskrnl/mm/ARM3/pfnlist.c
+++ b/ntoskrnl/mm/ARM3/pfnlist.c
@@ -481,8 +481,11 @@ MiRemoveAnyPage(IN ULONG Color)
 
     /* Make sure PFN lock is held and we have pages */
     MI_ASSERT_PFN_LOCK_HELD();
-    ASSERT(MmAvailablePages != 0);
     ASSERT(Color < MmSecondaryColors);
+    if (MmAvailablePages == 0)
+    {
+        return 0;
+    }
 
     /* Check the colored free list */
     PageIndex = MmFreePagesByColor[FreePageList][Color].Flink;
@@ -514,6 +517,7 @@ MiRemoveAnyPage(IN ULONG Color)
 
     /* Remove the page from its list */
     PageIndex = MiRemovePageByColor(PageIndex, Color);
+    ASSERT(PageIndex != 0);
 
     /* Sanity checks */
     Pfn1 = MI_PFN_ELEMENT(PageIndex);
@@ -538,8 +542,11 @@ MiRemoveZeroPage(IN ULONG Color)
 
     /* Make sure PFN lock is held and we have pages */
     MI_ASSERT_PFN_LOCK_HELD();
-    ASSERT(MmAvailablePages != 0);
     ASSERT(Color < MmSecondaryColors);
+    if (MmAvailablePages == 0)
+    {
+        return 0;
+    }
 
     /* Check the colored zero list */
     PageIndex = MmFreePagesByColor[ZeroedPageList][Color].Flink;
@@ -583,6 +590,7 @@ MiRemoveZeroPage(IN ULONG Color)
 
     /* Remove the page from its list */
     PageIndex = MiRemovePageByColor(PageIndex, Color);
+    ASSERT(PageIndex != 0);
     ASSERT(Pfn1 == MI_PFN_ELEMENT(PageIndex));
 
     /* Zero it, if needed */

--- a/ntoskrnl/mm/ARM3/pfnlist.c
+++ b/ntoskrnl/mm/ARM3/pfnlist.c
@@ -1221,11 +1221,22 @@ MiDecrementShareCount(IN PMMPFN Pfn1,
 
 VOID
 NTAPI
+MmDereferencePage(PFN_NUMBER Pfn);
+
+VOID
+NTAPI
 MiDecrementReferenceCount(IN PMMPFN Pfn1,
                           IN PFN_NUMBER PageFrameIndex)
 {
     /* PFN lock must be held */
     MI_ASSERT_PFN_LOCK_HELD();
+
+    /* Handle RosMm PFNs here, too (in case they got locked/unlocked by ARM3) */
+    if (MI_IS_ROS_PFN(Pfn1))
+    {
+        MmDereferencePage(PageFrameIndex);
+        return;
+    }
 
     /* Sanity checks on the page */
     if (PageFrameIndex > MmHighestPhysicalPage ||

--- a/ntoskrnl/mm/balance.c
+++ b/ntoskrnl/mm/balance.c
@@ -303,19 +303,20 @@ MmRequestPageMemoryConsumer(ULONG Consumer, BOOLEAN CanWait,
 {
     PFN_NUMBER Page;
 
-    /* Update the target */
-    InterlockedIncrementUL(&MiMemoryConsumers[Consumer].PagesUsed);
-    UpdateTotalCommittedPages(1);
-
     /*
      * Actually allocate the page.
      */
     Page = MmAllocPage(Consumer);
     if (Page == 0)
     {
-        KeBugCheck(NO_PAGES_AVAILABLE);
+        *AllocatedPage = 0;
+        return STATUS_NO_MEMORY;
     }
     *AllocatedPage = Page;
+
+    /* Update the target */
+    InterlockedIncrementUL(&MiMemoryConsumers[Consumer].PagesUsed);
+    UpdateTotalCommittedPages(1);
 
     return(STATUS_SUCCESS);
 }

--- a/ntoskrnl/mm/freelist.c
+++ b/ntoskrnl/mm/freelist.c
@@ -623,7 +623,8 @@ MmAllocPage(ULONG Type)
     PfnOffset = MiRemoveZeroPage(MI_GET_NEXT_COLOR());
     if (!PfnOffset)
     {
-        KeBugCheck(NO_PAGES_AVAILABLE);
+        MiReleasePfnLock(OldIrql);
+        return 0;
     }
 
     DPRINT("Legacy allocate: %lx\n", PfnOffset);

--- a/ntoskrnl/mm/i386/page.c
+++ b/ntoskrnl/mm/i386/page.c
@@ -598,7 +598,7 @@ MmCreatePageFileMapping(PEPROCESS Process,
     /* And we don't support creating for other process */
     ASSERT(Process == PsGetCurrentProcess());
 
-    if (SwapEntry & (1 << 31))
+    if (SwapEntry & (1 << (sizeof(SWAPENTRY) - 1)))
     {
         KeBugCheck(MEMORY_MANAGEMENT);
     }

--- a/ntoskrnl/mm/marea.c
+++ b/ntoskrnl/mm/marea.c
@@ -322,6 +322,10 @@ MmFreeMemoryArea(
                 /* We'll have to do some cleanup when we're on the page file */
                 DoFree = TRUE;
             }
+            else if (FreePage == NULL)
+            {
+                DoFree = MmDeletePhysicalMapping(Process, (PVOID)Address, &Dirty, &Page);
+            }
             else
             {
                 DoFree = MmDeleteVirtualMapping(Process, (PVOID)Address, &Dirty, &Page);

--- a/ntoskrnl/mm/pagefile.c
+++ b/ntoskrnl/mm/pagefile.c
@@ -152,7 +152,7 @@ MmWriteToSwapPage(SWAPENTRY SwapEntry, PFN_NUMBER Page)
     IO_STATUS_BLOCK Iosb;
     NTSTATUS Status;
     KEVENT Event;
-    UCHAR MdlBase[sizeof(MDL) + sizeof(ULONG)];
+    UCHAR MdlBase[sizeof(MDL) + sizeof(PFN_NUMBER)];
     PMDL Mdl = (PMDL)MdlBase;
 
     DPRINT("MmWriteToSwapPage\n");
@@ -217,7 +217,7 @@ MiReadPageFile(
     IO_STATUS_BLOCK Iosb;
     NTSTATUS Status;
     KEVENT Event;
-    UCHAR MdlBase[sizeof(MDL) + sizeof(ULONG)];
+    UCHAR MdlBase[sizeof(MDL) + sizeof(PFN_NUMBER)];
     PMDL Mdl = (PMDL)MdlBase;
     PMMPAGING_FILE PagingFile;
 

--- a/ntoskrnl/mm/rmap.c
+++ b/ntoskrnl/mm/rmap.c
@@ -469,7 +469,9 @@ MmGetSegmentRmap(PFN_NUMBER Page, PULONG RawOffset)
 {
     PCACHE_SECTION_PAGE_TABLE Result = NULL;
     PMM_RMAP_ENTRY current_entry;//, previous_entry;
-    KIRQL OldIrql = MiAcquirePfnLock();
+
+    /* Must hold the PFN lock */
+    ASSERT(KeGetCurrentIrql() == DISPATCH_LEVEL);
 
     //previous_entry = NULL;
     current_entry = MmGetRmapListHeadPage(Page);
@@ -481,16 +483,15 @@ MmGetSegmentRmap(PFN_NUMBER Page, PULONG RawOffset)
             *RawOffset = (ULONG_PTR)current_entry->Address & ~RMAP_SEGMENT_MASK;
             if (*Result->Segment->Flags & MM_SEGMENT_INDELETE)
             {
-                MiReleasePfnLock(OldIrql);
                 return NULL;
             }
-            MiReleasePfnLock(OldIrql);
+
             return Result;
         }
         //previous_entry = current_entry;
         current_entry = current_entry->Next;
     }
-    MiReleasePfnLock(OldIrql);
+
     return NULL;
 }
 

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -1335,9 +1335,16 @@ MmMakeSegmentResident(
             RtlZeroMemory(Pages, BYTES_TO_PAGES(ReadLength) * sizeof(PFN_NUMBER));
             for (UINT i = 0; i < BYTES_TO_PAGES(ReadLength); i++)
             {
-                /* MmRequestPageMemoryConsumer succeeds or bugchecks */
-                (void)MmRequestPageMemoryConsumer(MC_USER, FALSE, &Pages[i]);
+                Status = MmRequestPageMemoryConsumer(MC_USER, FALSE, &Pages[i]);
+                if (!NT_SUCCESS(Status))
+                {
+                    /* Damn. Roll-back. */
+                    for (UINT j = 0; j < i; j++)
+                        MmReleasePageMemoryConsumer(MC_USER, Pages[j]);
+                    goto Failed;
+                }
             }
+
             Mdl->MdlFlags |= MDL_PAGES_LOCKED | MDL_IO_PAGE_READ;
 
             LARGE_INTEGER FileOffset;
@@ -1389,6 +1396,7 @@ MmMakeSegmentResident(
                 for (UINT i = 0; i < BYTES_TO_PAGES(ReadLength); i++)
                     MmReleasePageMemoryConsumer(MC_USER, Pages[i]);
 
+Failed:
                 MmLockSectionSegment(Segment);
                 while (ChunkOffset < ChunkEnd)
                 {
@@ -1613,6 +1621,15 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
             return STATUS_MM_RESTART_OPERATION;
         }
 
+        MI_SET_USAGE(MI_USAGE_SECTION);
+        if (Process) MI_SET_PROCESS2(Process->ImageFileName);
+        if (!Process) MI_SET_PROCESS2("Kernel Section");
+        Status = MmRequestPageMemoryConsumer(MC_USER, TRUE, &Page);
+        if (!NT_SUCCESS(Status))
+        {
+            return STATUS_NO_MEMORY;
+        }
+
         /*
          * Must be private page we have swapped out.
          */
@@ -1627,14 +1644,6 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
         MmCreatePageFileMapping(Process, Address, MM_WAIT_ENTRY);
 
         MmUnlockAddressSpace(AddressSpace);
-        MI_SET_USAGE(MI_USAGE_SECTION);
-        if (Process) MI_SET_PROCESS2(Process->ImageFileName);
-        if (!Process) MI_SET_PROCESS2("Kernel Section");
-        Status = MmRequestPageMemoryConsumer(MC_USER, TRUE, &Page);
-        if (!NT_SUCCESS(Status))
-        {
-            KeBugCheck(MEMORY_MANAGEMENT);
-        }
 
         Status = MmReadFromSwapPage(SwapEntry, Page);
         if (!NT_SUCCESS(Status))
@@ -1736,7 +1745,12 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
             MI_SET_USAGE(MI_USAGE_SECTION);
             if (Process) MI_SET_PROCESS2(Process->ImageFileName);
             if (!Process) MI_SET_PROCESS2("Kernel Section");
-            MmRequestPageMemoryConsumer(MC_USER, FALSE, &Page);
+            Status = MmRequestPageMemoryConsumer(MC_USER, FALSE, &Page);
+            if (!NT_SUCCESS(Status))
+            {
+                MmUnlockSectionSegment(Segment);
+                return STATUS_NO_MEMORY;
+            }
             MmSetPageEntrySectionSegment(Segment, &Offset, MAKE_SSE(Page << PAGE_SHIFT, 1));
             MmUnlockSectionSegment(Segment);
 
@@ -1770,6 +1784,10 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
         MmLockAddressSpace(AddressSpace);
         if (!NT_SUCCESS(Status))
         {
+            if (Status == STATUS_NO_MEMORY)
+            {
+                return Status;
+            }
             /* Damn */
             DPRINT1("Failed to page data in!\n");
             return STATUS_IN_PAGE_ERROR;
@@ -1794,6 +1812,13 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
             return STATUS_MM_RESTART_OPERATION;
         }
 
+        Status = MmRequestPageMemoryConsumer(MC_USER, TRUE, &Page);
+        if (!NT_SUCCESS(Status))
+        {
+            MmUnlockSectionSegment(Segment);
+            return STATUS_NO_MEMORY;
+        }
+
         /*
         * Release all our locks and read in the page from disk
         */
@@ -1801,11 +1826,6 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
         MmUnlockSectionSegment(Segment);
 
         MmUnlockAddressSpace(AddressSpace);
-        Status = MmRequestPageMemoryConsumer(MC_USER, TRUE, &Page);
-        if (!NT_SUCCESS(Status))
-        {
-            KeBugCheck(MEMORY_MANAGEMENT);
-        }
 
         Status = MmReadFromSwapPage(SwapEntry, Page);
         if (!NT_SUCCESS(Status))
@@ -1905,6 +1925,7 @@ MmAccessFaultSectionView(PMMSUPPORT AddressSpace,
     BOOLEAN Cow = FALSE;
     ULONG NewProtect;
     BOOLEAN Unmapped;
+    NTSTATUS Status;
 
     DPRINT("MmAccessFaultSectionView(%p, %p, %p)\n", AddressSpace, MemoryArea, Address);
 
@@ -1990,9 +2011,11 @@ MmAccessFaultSectionView(PMMSUPPORT AddressSpace,
     /*
      * Allocate a page
      */
-    if (!NT_SUCCESS(MmRequestPageMemoryConsumer(MC_USER, TRUE, &NewPage)))
+    Status = MmRequestPageMemoryConsumer(MC_USER, TRUE, &NewPage);
+    if (!NT_SUCCESS(Status))
     {
-        KeBugCheck(MEMORY_MANAGEMENT);
+        MmUnlockSectionSegment(Segment);
+        return STATUS_NO_MEMORY;
     }
 
     /*

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -1689,10 +1689,10 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
          * Just map the desired physical page
          */
         Page = (PFN_NUMBER)(Offset.QuadPart >> PAGE_SHIFT);
-        Status = MmCreateVirtualMappingUnsafe(Process,
-                                              PAddress,
-                                              Region->Protect,
-                                              Page);
+        Status = MmCreatePhysicalMapping(Process,
+                                         PAddress,
+                                         Region->Protect,
+                                         Page);
         if (!NT_SUCCESS(Status))
         {
             DPRINT("MmCreateVirtualMappingUnsafe failed, not out of memory\n");

--- a/ntoskrnl/mm/section.c
+++ b/ntoskrnl/mm/section.c
@@ -1477,7 +1477,7 @@ MmAlterViewAttributes(PMMSUPPORT AddressSpace,
                     break;
                 MmUnlockSectionSegment(Segment);
                 MmUnlockAddressSpace(AddressSpace);
-                YieldProcessor();
+                KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
                 MmLockAddressSpace(AddressSpace);
                 MmLockSectionSegment(Segment);
             }
@@ -1608,7 +1608,7 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
         if (SwapEntry == MM_WAIT_ENTRY)
         {
             MmUnlockAddressSpace(AddressSpace);
-            YieldProcessor();
+            KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
             MmLockAddressSpace(AddressSpace);
             return STATUS_MM_RESTART_OPERATION;
         }
@@ -1789,7 +1789,7 @@ MmNotPresentFaultSectionView(PMMSUPPORT AddressSpace,
         {
             MmUnlockSectionSegment(Segment);
             MmUnlockAddressSpace(AddressSpace);
-            YieldProcessor();
+            KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
             MmLockAddressSpace(AddressSpace);
             return STATUS_MM_RESTART_OPERATION;
         }
@@ -3442,7 +3442,7 @@ MmFreeSectionPage(PVOID Context, MEMORY_AREA* MemoryArea, PVOID Address,
         MmUnlockSectionSegment(Segment);
         MmUnlockAddressSpace(AddressSpace);
 
-        YieldProcessor();
+        KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
 
         MmLockAddressSpace(AddressSpace);
         MmLockSectionSegment(Segment);
@@ -5144,7 +5144,7 @@ MmMakePagesDirty(
         {
             MmUnlockSectionSegment(Segment);
             MmUnlockAddressSpace(AddressSpace);
-            YieldProcessor();
+            KeDelayExecutionThread(KernelMode, FALSE, &TinyTime);
             MmLockAddressSpace(AddressSpace);
             MmLockSectionSegment(Segment);
             Entry = MmGetPageEntrySectionSegment(Segment, &SegmentOffset);


### PR DESCRIPTION
## Purpose

This PR fixes the kernel crash, when copying large files.
JIRA issue: [CORE-17624](https://jira.reactos.org/browse/CORE-17624)
Suggested to be reviewed by commit.

## Details
There are multiple attempts to fix the bug:
- PR #4739 by Jerome (releases VACBs on memory pressure) (currently included)
- [trim_cache_patch_2.patch](https://jira.reactos.org/secure/attachment/65635/65635_trim_cache_patch_2.patch) by Thomas (well, trims individual cache pages, when needed)
- PR #5237 (based on trim_cache_patch_2)
- [ntos_mm_higher_bottom.patch](https://jira.reactos.org/secure/attachment/65511/65511_ntos_mm_higher_bottom.patch)  (only starts paging earlier)
- [modified_standby_pages_3.diff](https://jira.reactos.org/secure/attachment/65559/65559_modified_standby_pages_3.diff) by Jerome (lets the page fault handler search for standby pages. This might help, but isn't entirely correct either, because there is no guarantee, that there are any standby pages available and the code cannot page out any more pages because it runs at `DISPATCH_LEVEL`, so it can still randomly hang the system entirely)

None of them fixes the problem, that the page fault handler can randomly bugcheck, when temporarily running out of pages. Instead they just hide the underlying problem, by making it's occurrence really unlikely.
They are partly still valuable though, as they can improve the situation (in fact either PR #4739 (currently included) or trim_cache_path / #5237 is needed for this PR to fully work).
This PR fixes the issue by letting the page fault handler wait for new pages at `PASSIVE_LEVEL`. This allows the balancer to page out more pages and doesn't stall the system unneccessarily. Additionally it fixes a number of subtle bugs that are only triggered on high memory pressure.
This fixes the file copy crash and also any random crashes, when temporarily running out of free/standby pages. It can still hang, when more user memory is committed than is available in both physical memory and the page file, but fixing this requires to implement commitment accounting.

## Proposed changes

- Make sure the balancer thread doesn't bugcheck, when there is nothing to page out.
- Implement ShareCount handling for RosMm
- Fail gracefully in the PFN allocation functions, when there are no more pages available.
- Implement `MmRebalanceMemoryConsumersAndWait()` to run the balancer on demand and wait for it to (hopefully) return free pages.
- Use `MmRebalanceMemoryConsumersAndWait()` in the page fault handler, when no page could be allocated and retry page fault handling.
- Fix locking and a race condition between the balancer and the section code, when handling RMAPs.

See commit messages for more details.

This PR includes PR #4739 by Jerome, which makes the whole thing work by giving back cache pages, when there is need for memory. Without the PR the crash is fixed, but the system will run out of pages and then hang, when the balancer cannot free anything anymore.

Note that this fixes copying, but it doesn't entirely prevent running out of pages. The problem is that we do not track committed pages and can therefore overcommit (i.e. commit more pages than are together in physical RAM plus page file) and eventually run out of pages and pagefile space, at which point the system would hang.

[ReactOS total commander copy large file.webm](https://user-images.githubusercontent.com/313067/231837590-25d746d2-e630-41c7-b656-6031912a9e6e.webm)

## TODO
- [ ] Run on test bots
- [ ] Have some people test it and check performance.

## More work
These things still need to be done to fix paging entirely, but are not within the scope of this PR
- Implement accounting (respect system commit limit)
- Implement working set handling for ARM³
- Migrate rest of RosMm PFN handling to ARM³
- Migrate file sections to ARM³
