### PR TITLE
[WINMM] Add default timer resolution compatibility shim

### DIFF
--- a/dll/appcompat/shims/genral/CMakeLists.txt
+++ b/dll/appcompat/shims/genral/CMakeLists.txt
@@ -9,6 +9,7 @@ list(APPEND SOURCE
     main.c
     shimtest.c
     themes.c
+    timeapi.c
     genral.spec)
 
 add_library(acgenral MODULE

--- a/dll/appcompat/shims/genral/timeapi.c
+++ b/dll/appcompat/shims/genral/timeapi.c
@@ -1,0 +1,74 @@
+/*
+ * PROJECT:     ReactOS 'General' Shim library
+ * LICENSE:     GPL-2.0+ (https://spdx.org/licenses/GPL-2.0+)
+ * PURPOSE:     TimeAPI related shims
+ * COPYRIGHT:   Copyright 2016,2017 Mark Jansen (mark.jansen@reactos.org)
+ */
+
+#define WIN32_NO_STATUS
+#include <windef.h>
+#include <winbase.h>
+#include <winuser.h>
+#include <wingdi.h>
+#include <shimlib.h>
+#include <strsafe.h>
+#include <mmsystem.h>
+
+#define SHIM_NS         DefaultTimerResolution1ms
+#include <setup_shim.inl>
+
+typedef DWORD (WINAPI* TIMEGETTIMEPROC)(void);
+typedef MMRESULT(WINAPI* TIMEBEGINPERIODPROC)(_In_ UINT);
+typedef MMRESULT(WINAPI* TIMEENDPERIODPROC)(_In_ UINT);
+
+/* Only adjust timer resolution if timeGetTime() is called before timeBeginPeriod() */
+static LONG isResolutionSet;
+
+#define SHIM_NOTIFY_FN SHIM_OBJ_NAME(Notify)
+
+BOOL WINAPI SHIM_OBJ_NAME(Notify)(DWORD fdwReason, PVOID ptr)
+{
+    HMODULE hWinMM;
+    TIMEENDPERIODPROC ftimeEndPeriod;
+    
+    if (fdwReason == SHIM_REASON_DEINIT)
+    {
+        hWinMM = GetModuleHandleW(L"WINMM");
+        if (hWinMM != NULL)
+        {
+            ftimeEndPeriod  = (TIMEENDPERIODPROC)GetProcAddress(hWinMM, "timeEndPeriod");
+            if (ftimeEndPeriod != NULL && InterlockedAnd(&isResolutionSet, TRUE))
+                ftimeEndPeriod(1);
+        }
+    }
+    return TRUE;
+}
+
+DWORD WINAPI SHIM_OBJ_NAME(APIHook_timeGetTime)(void)
+{
+    if (InterlockedExchange(&isResolutionSet, TRUE) == FALSE)
+    {
+        HMODULE hWinMM = GetModuleHandleW(L"WINMM");
+        TIMEBEGINPERIODPROC ftimeBeginPeriod  = (TIMEBEGINPERIODPROC)GetProcAddress(hWinMM, "timeBeginPeriod");
+        
+        /* Windows 95/98/ME timeGetTime has a default resolution of 1 ms and on */
+        /* Windows NT/2000/XP this same function has a resolution of 10 ms. */
+        ftimeBeginPeriod(1);
+    }
+    
+    return CALL_SHIM(0, TIMEGETTIMEPROC)();
+}
+
+MMRESULT WINAPI SHIM_OBJ_NAME(APIHook_timeBeginPeriod)(_In_ UINT uPeriod)
+{
+    InterlockedExchange(&isResolutionSet, TRUE);
+    return CALL_SHIM(0, TIMEBEGINPERIODPROC)(uPeriod);
+}
+
+#define SHIM_NUM_HOOKS  1
+#define SHIM_SETUP_HOOKS \
+    SHIM_HOOK(0, "WINMM.DLL", "timeGetTime", SHIM_OBJ_NAME(APIHook_timeGetTime)) \
+    SHIM_HOOK(1, "WINMM.DLL", "timeBeginPeriod", SHIM_OBJ_NAME(APIHook_timeBeginPeriod))
+
+#include <implement_shim.inl>
+

--- a/media/sdb/sysmain.xml
+++ b/media/sdb/sysmain.xml
@@ -270,6 +270,10 @@
             <FLAG NAME="GetDiskFreeSpace2GB">
                 <FLAG_MASK_KERNEL>8</FLAG_MASK_KERNEL>
             </FLAG>
+            <SHIM NAME="DefaultTimerResolution1ms">
+                <DLLFILE>acgenral.dll</DLLFILE>
+                <DESCRIPTION>Windows 95/98/ME timeGetTime has a default resolution of 1 ms and on Windows NT/2000/XP this same function has a resolution of 10 ms</DESCRIPTION>
+            </SHIM>
 
         </LIBRARY>
 
@@ -283,12 +287,14 @@
             <SHIM_REF NAME="Win95VersionLie" />
             <SHIM_REF NAME="ForceDXSetupSuccess" />
             <SHIM_REF NAME="IgnoreLoadLibrary" />
+            <SHIM_REF NAME="DefaultTimerResolution1ms" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="WIN98">
             <SHIM_REF NAME="Win98VersionLie" />
             <SHIM_REF NAME="ForceDXSetupSuccess" />
             <SHIM_REF NAME="IgnoreLoadLibrary" />
+            <SHIM_REF NAME="DefaultTimerResolution1ms" />
             <!-- TODO: Add more fixes! -->
         </LAYER>
         <LAYER NAME="NT4SP5">
@@ -441,6 +447,9 @@
         </LAYER>
         <LAYER NAME="GetDiskFreeSpace2GB">
             <FLAG_REF NAME="GetDiskFreeSpace2GB" />
+        </LAYER>
+        <LAYER NAME="DefaultTimerResolution1ms">
+            <SHIM_REF NAME="DefaultTimerResolution1ms" />
         </LAYER>
 
         <!-- Applications -->


### PR DESCRIPTION
## Purpose

Windows 95/98/ME timeGetTime has a default resolution of 1 ms and on Windows NT/2000/XP this same function has a resolution of 10 ms. Add a compatibility shim to the "Windows 95" and "Windows 98 / ME" profiles that changes the default timer resolution to 1ms.

JIRA issue: [CORE-18937](https://jira.reactos.org/browse/CORE-18937)

## Proposed changes

- Add compatibility shim "DefaultTimerResolution1ms" which sets the default timeGetTime resolution to 1ms.
- Assign "DefaultTimerResolution1ms" to the "Windows 95" and "Windows 98 / ME" compatibility profiles.