### PR TITLE
[NTOS:OB] Properly calculate the return length in ObQueryTypeInfo

### DIFF
--- a/ntoskrnl/ob/oblife.c
+++ b/ntoskrnl/ob/oblife.c
@@ -944,22 +944,36 @@ ObpQueryNameInfoSize(
 
 NTSTATUS
 NTAPI
-ObQueryTypeInfo(IN POBJECT_TYPE ObjectType,
-                OUT POBJECT_TYPE_INFORMATION ObjectTypeInfo,
-                IN ULONG Length,
-                OUT PULONG ReturnLength)
+ObQueryTypeInfo(
+    _In_ POBJECT_TYPE ObjectType,
+    _Out_writes_bytes_(Length) POBJECT_TYPE_INFORMATION ObjectTypeInfo,
+    _In_ ULONG Length,
+    _Out_ PULONG ReturnLength)
 {
     NTSTATUS Status = STATUS_SUCCESS;
     PWSTR InfoBuffer;
 
+    /* The string of the object type name has to be NULL-terminated */
+    ASSERT(ObjectType->Name.MaximumLength >= ObjectType->Name.Length + sizeof(UNICODE_NULL));
+
     /* Enter SEH */
     _SEH2_TRY
     {
-        /* Set return length aligned to 4-byte boundary */
+        /*
+         * Set return length aligned to 4-byte or 8-byte boundary. Windows has a bug
+         * where the returned length pointer is always aligned to a 4-byte boundary.
+         * If one were to allocate a pool of memory in kernel mode to retrieve all
+         * the object types info with this return length, Windows will bugcheck with
+         * BAD_POOL_HEADER in 64-bit upon you free the said allocated memory.
+         *
+         * More than that, Windows uses MaximumLength for the calculation of the returned
+         * length and MaximumLength does not always guarantee the name type is NULL-terminated
+         * leading the ObQueryTypeInfo function to overrun the buffer.
+         */
         *ReturnLength += sizeof(*ObjectTypeInfo) +
-                         ALIGN_UP(ObjectType->Name.MaximumLength, ULONG);
+                         ALIGN_UP(ObjectType->Name.Length + sizeof(UNICODE_NULL), ULONG_PTR);
 
-        /* Check if thats too much though. */
+        /* Check if that is too much */
         if (Length < *ReturnLength)
         {
             _SEH2_YIELD(return STATUS_INFO_LENGTH_MISMATCH);


### PR DESCRIPTION
The current implementation of `ObQueryTypeInfo` calculates the returned length to the caller in this following way -- initialize (or increment) the necessary length by summing up the size of the `ObjectTypeInfo` variable's contents and the maximum length of an object type name, aligned to a 4-byte boundary. This can lead to two problems.

## Details
1. The implementation uses `MaximumLength` in the calculation of the returned length for the target object type. Commonly `MaximumLength` would include the length of the string and the NULL terminator but that is not always the case. An object type name that is not NULL-terminated can potentially make the `ObQueryTypeInfo` function to overrun the name buffer.
2. The returned length is aligned to a 4-byte boundary, which makes perfect sense on a x86 system. On AMD64 however the alignment is still set to 4-byte which it can lead to "past write the boundary" issues. A proof-of-concept to reproduce this behavior is to query info of all object types with `NtQueryObject` + `ObjectTypesInformation` on Windows in kernel mode by allocating a pool for it.. As Windows uses `ObQueryTypeInfo` to calculate the returned length of every object type with `ObQueryTypeInfo`, on AMD64 `ReturnLength` is being overwritten past the 4-byte boundary so it might corrupt the pool blocks when you are going to free your allocated memory afterwards, leading to a bugcheck. I wrote such a testcase PoC when I was trying to implement `ObjectTypesInformation` in #5221.

Windows is affected by both of these two points above, there is already a mention of `ObQueryTypeInfo` overrunning the buffer in https://processhacker.sourceforge.io/doc/object_8c_source.html (grep for `KphObjectTypeInformation` to read  the comment) and http://web.archive.org/web/20200929032044/https://wj32.org/wp/2012/11/30/obquerytypeinfo-and-ntqueryobject-buffer-overrun-in-windows-8/.

## Proposed Changes
For the 1st point, calculate the necessary return length by using the `ObjectType->Name.Length + sizeof(UNICODE_NULL)` formula and add an `ASSERT` to validate that `MaximumLength` contains the NULL terminator size. 

This ensures we avoid this kind of problem of type names not being NULL-terminated when we add more support for other object types in the future as people can make mistakes. For the 2nd point, just align the returned length to a `ULONG_PTR` (aka 4-byte or 8-byte, depending on the system architecture). This patch is a split from #5221.