### PR TITLE
[EXT2FS] Align with upstream and mark ReactOS diff

### DIFF
--- a/drivers/filesystems/ext2/inc/common.h
+++ b/drivers/filesystems/ext2/inc/common.h
@@ -196,8 +196,13 @@ typedef struct _EXT2_VOLUME_PROPERTY2 {
 
 } EXT2_VOLUME_PROPERTY2, *PEXT2_VOLUME_PROPERTY2;
 
+#ifdef __REACTOS__
 #define EXT2_VPROP3_AUTOMOUNT (1ULL << 0)
 #define EXT2_VPROP3_USERIDS   (1ULL << 1)
+#else
+#define EXT2_VPROP3_AUTOMOUNT (1ui64 << 0)
+#define EXT2_VPROP3_USERIDS   (1ui64 << 1)
+#endif
 
 #ifdef __cplusplus
 typedef struct _EXT2_VOLUME_PROPERTY3:EXT2_VOLUME_PROPERTY2 {

--- a/drivers/filesystems/ext2/inc/ext2fs.h
+++ b/drivers/filesystems/ext2/inc/ext2fs.h
@@ -223,8 +223,13 @@ _InterlockedXor (
 
 #if EXT2_DEBUG
 
+#ifdef __REACTOS__
 #define SetLongFlag(_F,_SF)   Ext2SetFlag((PULONG)&(_F), (ULONG)(_SF))
 #define ClearLongFlag(_F,_SF) Ext2ClearFlag((PULONG)&(_F), (ULONG)(_SF))
+#else
+#define SetLongFlag(_F,_SF)   Ext2SetFlag(&(_F), (ULONG)(_SF))
+#define ClearLongFlag(_F,_SF) Ext2ClearFlag(&(_F), (ULONG)(_SF))
+#endif
 
 #ifdef __REACTOS__
 static
@@ -489,7 +494,11 @@ typedef PVOID   PBCB;
 // Data that is not specific to a mounted volume
 //
 
+#ifdef __REACTOS__
 typedef VOID (NTAPI *EXT2_REAPER_RELEASE)(PVOID);
+#else
+typedef VOID (*EXT2_REAPER_RELEASE)(PVOID);
+#endif
 
 typedef struct _EXT2_REAPER {
         PETHREAD                Thread;
@@ -1276,34 +1285,62 @@ Ext2Close (IN PEXT2_IRP_CONTEXT IrpContext);
 VOID
 Ext2QueueCloseRequest (IN PEXT2_IRP_CONTEXT IrpContext);
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2DeQueueCloseRequest (IN PVOID Context);
 
 //
 // Cmcb.c
 //
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2AcquireForLazyWrite (
     IN PVOID    Context,
     IN BOOLEAN  Wait );
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReleaseFromLazyWrite (IN PVOID Context);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2AcquireForReadAhead (
     IN PVOID    Context,
     IN BOOLEAN  Wait );
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReleaseFromReadAhead (IN PVOID Context);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2NoOpAcquire (
     IN PVOID Fcb,
     IN BOOLEAN Wait );
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2NoOpRelease (IN PVOID Fcb);
 
 //
@@ -1589,13 +1626,21 @@ Ext2IsDirectoryEmpty (
 // Dispatch.c
 //
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2OplockComplete (
     IN PVOID Context,
     IN PIRP Irp
 );
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2LockIrp (
     IN PVOID Context,
     IN PIRP Irp
@@ -1604,13 +1649,21 @@ Ext2LockIrp (
 NTSTATUS
 Ext2QueueRequest (IN PEXT2_IRP_CONTEXT IrpContext);
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2DeQueueRequest (IN PVOID Context);
 
 NTSTATUS
 Ext2DispatchRequest (IN PEXT2_IRP_CONTEXT IrpContext);
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2BuildRequest (
     IN PDEVICE_OBJECT   DeviceObject,
     IN PIRP             Irp
@@ -2062,7 +2115,11 @@ Ext2IsFastIoPossible(
     IN PEXT2_FCB Fcb
 );
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoCheckIfPossible (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -2075,7 +2132,11 @@ Ext2FastIoCheckIfPossible (
 );
 
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoRead (IN PFILE_OBJECT FileObject,
                 IN PLARGE_INTEGER       FileOffset,
                 IN ULONG                Length,
@@ -2085,7 +2146,11 @@ Ext2FastIoRead (IN PFILE_OBJECT FileObject,
                 OUT PIO_STATUS_BLOCK    IoStatus,
                 IN PDEVICE_OBJECT       DeviceObject);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoWrite (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -2096,7 +2161,11 @@ Ext2FastIoWrite (
     OUT PIO_STATUS_BLOCK    IoStatus,
     IN PDEVICE_OBJECT       DeviceObject);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryBasicInfo (
     IN PFILE_OBJECT             FileObject,
     IN BOOLEAN                  Wait,
@@ -2104,7 +2173,11 @@ Ext2FastIoQueryBasicInfo (
     OUT PIO_STATUS_BLOCK        IoStatus,
     IN PDEVICE_OBJECT           DeviceObject);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryStandardInfo (
     IN PFILE_OBJECT                 FileObject,
     IN BOOLEAN                      Wait,
@@ -2112,7 +2185,11 @@ Ext2FastIoQueryStandardInfo (
     OUT PIO_STATUS_BLOCK            IoStatus,
     IN PDEVICE_OBJECT               DeviceObject);
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoLock (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -2125,7 +2202,11 @@ Ext2FastIoLock (
     IN PDEVICE_OBJECT       DeviceObject
 );
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockSingle (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -2136,7 +2217,11 @@ Ext2FastIoUnlockSingle (
     IN PDEVICE_OBJECT       DeviceObject
 );
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockAll (
     IN PFILE_OBJECT         FileObject,
     IN PEPROCESS            Process,
@@ -2144,7 +2229,11 @@ Ext2FastIoUnlockAll (
     IN PDEVICE_OBJECT       DeviceObject
 );
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockAllByKey (
     IN PFILE_OBJECT         FileObject,
 #ifdef __REACTOS__
@@ -2158,7 +2247,11 @@ Ext2FastIoUnlockAllByKey (
 );
 
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryNetworkOpenInfo (
     IN PFILE_OBJECT                     FileObject,
     IN BOOLEAN                          Wait,
@@ -2166,7 +2259,11 @@ Ext2FastIoQueryNetworkOpenInfo (
     OUT PIO_STATUS_BLOCK                IoStatus,
     IN PDEVICE_OBJECT                   DeviceObject );
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryNetworkOpenInfo (
     IN PFILE_OBJECT                     FileObject,
     IN BOOLEAN                          Wait,
@@ -2174,20 +2271,29 @@ Ext2FastIoQueryNetworkOpenInfo (
     OUT PIO_STATUS_BLOCK                IoStatus,
     IN PDEVICE_OBJECT                   DeviceObject);
 
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2AcquireForCreateSection (
     IN PFILE_OBJECT FileObject
 );
 
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2ReleaseForCreateSection (
     IN PFILE_OBJECT FileObject
 );
 
+#ifdef __REACTOS__
+NTSTATUS NTAPI
+#else
 NTSTATUS
-NTAPI
+#endif
 Ext2AcquireFileForModWrite (
     IN PFILE_OBJECT FileObject,
     IN PLARGE_INTEGER EndingOffset,
@@ -2195,31 +2301,43 @@ Ext2AcquireFileForModWrite (
     IN PDEVICE_OBJECT DeviceObject
 );
 
+#ifdef __REACTOS__
+NTSTATUS NTAPI
+#else
 NTSTATUS
-NTAPI
+#endif
 Ext2ReleaseFileForModWrite (
     IN PFILE_OBJECT FileObject,
     IN PERESOURCE ResourceToRelease,
     IN PDEVICE_OBJECT DeviceObject
 );
 
+#ifdef __REACTOS__
+NTSTATUS NTAPI
+#else
 NTSTATUS
-NTAPI
+#endif
 Ext2AcquireFileForCcFlush (
     IN PFILE_OBJECT FileObject,
     IN PDEVICE_OBJECT DeviceObject
 );
 
+#ifdef __REACTOS__
+NTSTATUS NTAPI
+#else
 NTSTATUS
-NTAPI
+#endif
 Ext2ReleaseFileForCcFlush (
     IN PFILE_OBJECT FileObject,
     IN PDEVICE_OBJECT DeviceObject
 );
 
 
+#ifdef __REACTOS__
+NTSTATUS NTAPI
+#else
 NTSTATUS
-NTAPI
+#endif
 Ext2PreAcquireForCreateSection(
     IN PFS_FILTER_CALLBACK_DATA cd,
     OUT PVOID *cc
@@ -2521,7 +2639,11 @@ Ext2QueryGlobalParameters(IN PUNICODE_STRING RegistryPath);
 BOOLEAN
 Ext2QueryRegistrySettings(IN PUNICODE_STRING  RegistryPath);
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 DriverUnload (IN PDRIVER_OBJECT DriverObject);
 
 //
@@ -2581,20 +2703,29 @@ Ext2LockControl (IN PEXT2_IRP_CONTEXT IrpContext);
 // Memory.c
 //
 
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2FcbReaperThread(
     PVOID   Context
 );
 
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2McbReaperThread(
     PVOID   Context
 );
 
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2bhReaperThread(
     PVOID   Context
 );
@@ -2900,15 +3031,22 @@ Ext2FirstUnusedMcb(
     ULONG       Number
 );
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReaperThread(
     PVOID   Context
 );
 
 NTSTATUS
 Ext2StartReaper(PEXT2_REAPER, EXT2_REAPER_RELEASE);
+#ifdef __REACTOS__
+VOID NTAPI
+#else
 VOID
-NTAPI
+#endif
 Ext2StopReaper(PEXT2_REAPER Reaper);
 
 //

--- a/drivers/filesystems/ext2/inc/linux/module.h
+++ b/drivers/filesystems/ext2/inc/linux/module.h
@@ -79,8 +79,8 @@ FASTCALL
 RtlUlonglongByteSwap(
     IN ULONGLONG Source
 );
-#endif
 #endif //#ifndef __REACTOS__
+#endif
 
 #define __swab16(x) RtlUshortByteSwap(x)
 #define __swab32(x) RtlUlongByteSwap(x)

--- a/drivers/filesystems/ext2/inc/linux/module.h
+++ b/drivers/filesystems/ext2/inc/linux/module.h
@@ -59,7 +59,8 @@ extern "C" {
 #define RtlUlongByteSwap(_x)     _byteswap_ulong((_x))
 #define RtlUlonglongByteSwap(_x) _byteswap_uint64((_x))
 
-#elif !defined(__REACTOS__)
+#else
+#ifndef __REACTOS__
 
 USHORT
 FASTCALL
@@ -79,6 +80,7 @@ RtlUlonglongByteSwap(
     IN ULONGLONG Source
 );
 #endif
+#endif //#ifndef __REACTOS__
 
 #define __swab16(x) RtlUshortByteSwap(x)
 #define __swab32(x) RtlUlongByteSwap(x)
@@ -429,10 +431,18 @@ extern struct task_struct *current;
 //
 
 
+#ifdef __REACTOS__
 static inline int cond_resched() {
+#else
+static inline cond_resched() {
+#endif
     return FALSE;
 }
+#ifdef __REACTOS__
 static inline int need_resched() {
+#else
+static inline need_resched() {
+#endif
     return FALSE;
 }
 

--- a/drivers/filesystems/ext2/inc/linux/types.h
+++ b/drivers/filesystems/ext2/inc/linux/types.h
@@ -27,14 +27,18 @@ typedef	signed   __int64	__s64;
 typedef	unsigned __int64	__u64;
 
 
+#ifdef __REACTOS__
 typedef __s8         s8;
 typedef __u8         u8;
+#endif
+#if defined(_MSC_VER) || defined(__REACTOS__)
 typedef __s16       s16;
 typedef __u16       u16;
 typedef __s32       s32;
 typedef __u32       u32;
 typedef __s64       s64;
 typedef __u64       u64;
+#endif
 
 #define __le16      u16
 #define __le32      u32

--- a/drivers/filesystems/ext2/src/block.c
+++ b/drivers/filesystems/ext2/src/block.c
@@ -17,20 +17,32 @@ extern PEXT2_GLOBAL Ext2Global;
 
 /* DEFINITIONS *************************************************************/
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReadWriteBlockSyncCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,
     IN PVOID Context    );
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReadWriteBlockAsyncCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,
     IN PVOID Context    );
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2MediaEjectControlCompletion (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,
@@ -148,7 +160,11 @@ Ext2GetUserBuffer (IN PIRP Irp )
     }
 }
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReadWriteBlockSyncCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,
@@ -181,7 +197,11 @@ Ext2ReadWriteBlockSyncCompletionRoutine (
     return STATUS_MORE_PROCESSING_REQUIRED;
 }
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReadWriteBlockAsyncCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,
@@ -641,7 +661,11 @@ Ext2DiskIoControl (
 }
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2MediaEjectControlCompletion (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,

--- a/drivers/filesystems/ext2/src/cmcb.c
+++ b/drivers/filesystems/ext2/src/cmcb.c
@@ -19,7 +19,11 @@ extern PEXT2_GLOBAL Ext2Global;
 
 #define CMCB_DEBUG_LEVEL DL_NVR
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2AcquireForLazyWrite (
     IN PVOID    Context,
     IN BOOLEAN  Wait)
@@ -51,7 +55,11 @@ Ext2AcquireForLazyWrite (
     return TRUE;
 }
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReleaseFromLazyWrite (IN PVOID Context)
 {
     //
@@ -76,7 +84,11 @@ Ext2ReleaseFromLazyWrite (IN PVOID Context)
     IoSetTopLevelIrp( NULL );
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2AcquireForReadAhead (IN PVOID    Context,
                          IN BOOLEAN  Wait)
 {
@@ -97,7 +109,11 @@ Ext2AcquireForReadAhead (IN PVOID    Context,
     return TRUE;
 }
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReleaseFromReadAhead (IN PVOID Context)
 {
     PEXT2_FCB Fcb = (PEXT2_FCB) Context;
@@ -114,7 +130,11 @@ Ext2ReleaseFromReadAhead (IN PVOID Context)
     ExReleaseResourceLite(Fcb->Header.Resource);
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2NoOpAcquire (
     IN PVOID Fcb,
     IN BOOLEAN Wait
@@ -125,7 +145,11 @@ Ext2NoOpAcquire (
     return TRUE;
 }
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2NoOpRelease (
     IN PVOID Fcb
 )

--- a/drivers/filesystems/ext2/src/devctl.c
+++ b/drivers/filesystems/ext2/src/devctl.c
@@ -17,7 +17,11 @@ extern PEXT2_GLOBAL Ext2Global;
 
 /* DEFINITIONS *************************************************************/
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2DeviceControlCompletion (
     IN PDEVICE_OBJECT   DeviceObject,
     IN PIRP             Irp,
@@ -38,7 +42,11 @@ Ext2DeviceControlCompletion (
 #endif
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2DeviceControlCompletion (
     IN PDEVICE_OBJECT   DeviceObject,
     IN PIRP             Irp,
@@ -426,14 +434,22 @@ Ext2ProcessVolumeProperty(
         case APP_CMD_SET_PROPERTY2:
 
             RtlZeroMemory(Vcb->sHidingPrefix, HIDINGPAT_LEN);
+#ifdef __REACTOS__
             if (Vcb->bHidingPrefix == Property2->bHidingPrefix) {
+#else
+            if (Vcb->bHidingPrefix = Property2->bHidingPrefix) {
+#endif
                 RtlCopyMemory( Vcb->sHidingPrefix,
                                Property2->sHidingPrefix,
                                HIDINGPAT_LEN - 1);
             }
 
             RtlZeroMemory(Vcb->sHidingSuffix, HIDINGPAT_LEN);
+#ifdef __REACTOS__
             if (Vcb->bHidingSuffix == Property2->bHidingSuffix) {
+#else
+            if (Vcb->bHidingSuffix = Property2->bHidingSuffix) {
+#endif
                 RtlCopyMemory( Vcb->sHidingSuffix,
                                Property2->sHidingSuffix,
                                HIDINGPAT_LEN - 1);
@@ -511,7 +527,11 @@ Ext2ProcessVolumeProperty(
             RtlCopyMemory(Property2->UUID, Vcb->SuperBlock->s_uuid, 16);
             Property2->DrvLetter = Vcb->DrvLetter;
 
+#ifdef __REACTOS__
             if (Property2->bHidingPrefix == Vcb->bHidingPrefix) {
+#else
+            if (Property2->bHidingPrefix = Vcb->bHidingPrefix) {
+#endif
                 RtlCopyMemory( Property2->sHidingPrefix,
                                Vcb->sHidingPrefix,
                                HIDINGPAT_LEN);
@@ -520,7 +540,11 @@ Ext2ProcessVolumeProperty(
                                HIDINGPAT_LEN);
             }
 
+#ifdef __REACTOS__
             if (Property2->bHidingSuffix == Vcb->bHidingSuffix) {
+#else
+            if (Property2->bHidingSuffix = Vcb->bHidingSuffix) {
+#endif
                 RtlCopyMemory( Property2->sHidingSuffix,
                                Vcb->sHidingSuffix,
                                HIDINGPAT_LEN);

--- a/drivers/filesystems/ext2/src/dispatch.c
+++ b/drivers/filesystems/ext2/src/dispatch.c
@@ -37,7 +37,11 @@ extern PEXT2_GLOBAL Ext2Global;
  *    N/A
  */
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2OplockComplete (
     IN PVOID Context,
     IN PIRP Irp
@@ -82,7 +86,11 @@ Ext2OplockComplete (
  *    N/A
  */
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2LockIrp (
     IN PVOID Context,
     IN PIRP Irp
@@ -174,7 +182,11 @@ Ext2QueueRequest (IN PEXT2_IRP_CONTEXT IrpContext)
 }
 
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2DeQueueRequest (IN PVOID Context)
 {
     PEXT2_IRP_CONTEXT IrpContext;
@@ -288,7 +300,11 @@ Ext2DispatchRequest (IN PEXT2_IRP_CONTEXT IrpContext)
 }
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2BuildRequest (PDEVICE_OBJECT   DeviceObject, PIRP Irp)
 {
     BOOLEAN             AtIrqlPassiveLevel = FALSE;

--- a/drivers/filesystems/ext2/src/ext2.rc
+++ b/drivers/filesystems/ext2/src/ext2.rc
@@ -62,8 +62,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 0,6,2,0
- PRODUCTVERSION 0,6,2,0
+ FILEVERSION 0,69,11,1
+ PRODUCTVERSION 0,69,11,1
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x29L
@@ -79,16 +79,16 @@ BEGIN
         BLOCK "040904b0"
         BEGIN
             VALUE "Comments", "Ext2 File System Driver\0"
-            VALUE "CompanyName", "Purayidathil\0"
-            VALUE "FileDescription", "Ext2 File System Driver\0"
-            VALUE "FileVersion", "0, 6, 2, 0\0"
+            VALUE "CompanyName", "www.ext2fsd.com\0"
+            VALUE "FileDescription", "Ext2 File System Driver for Windows\0"
+            VALUE "FileVersion", "0.69.11.1\0"
             VALUE "InternalName", "ext2fs.sys\0"
-            VALUE "LegalCopyright", "Copyright © 2015 Matt Wu\0"
+            VALUE "LegalCopyright", "GPLv2\0"
             VALUE "LegalTrademarks", " - \0"
             VALUE "OriginalFilename", "ext2fs.sys\0"
             VALUE "PrivateBuild", " - \0"
-            VALUE "ProductName", "Ext2 File System Driver for Windows\0"
-            VALUE "ProductVersion", "0, 6, 2, 0\0"
+            VALUE "ProductName", "Ext2 File System Driver\0"
+            VALUE "ProductVersion", "0.69.11.1\0"
             VALUE "SpecialBuild", " - \0"
         END
     END

--- a/drivers/filesystems/ext2/src/ext3/indirect.c
+++ b/drivers/filesystems/ext2/src/ext3/indirect.c
@@ -219,7 +219,11 @@ Ext2GetBlock(
                          BLOCK_SIZE,
                          PIN_WAIT,
                          &Bcb,
+#ifdef __REACTOS__
                          (void **)&pData )) {
+#else
+                         &pData )) {
+#endif
 
             DEBUG(DL_ERR, ( "Ext2GetBlock: Failed to PinLock block: %xh ...\n",
                             BlockArray[0] ));
@@ -521,7 +525,11 @@ Ext2ExpandBlock(
                             BLOCK_SIZE,
                             PIN_WAIT,
                             &Bcb,
+#ifdef __REACTOS__
                             (void **)&pData )) {
+#else
+                            &pData )) {
+#endif
 
                     DEBUG(DL_ERR, ( "Ext2ExpandInode: failed to PinLock offset :%I64xh...\n",
                                     Offset.QuadPart));
@@ -726,7 +734,11 @@ Ext2TruncateBlock(
                                 BLOCK_SIZE,
                                 PIN_WAIT,
                                 &Bcb,
+#ifdef __REACTOS__
                                 (void **)&pData )) {
+#else
+                                &pData )) {
+#endif
 
                     DEBUG(DL_ERR, ( "Ext2TruncateBlock: PinLock failed on block %xh ...\n",
                                     BlockArray[SizeArray - i - 1]));
@@ -906,7 +918,11 @@ Ext2MapIndirect(
                          Layer,
                          Index,
                          dwArray,
+#ifdef __REACTOS__
                         (PULONG)&Mcb->Inode.i_block[Slot],
+#else
+                        &Mcb->Inode.i_block[Slot],
+#endif
                          bAlloc,
                          &dwHint,
                          &dwRet,
@@ -987,7 +1003,11 @@ Ext2ExpandIndirect(
                          Layer,
                          Start,
                          (Layer == 0) ? (Vcb->max_blocks_per_layer[Layer] - Start) : 1,
+#ifdef __REACTOS__
                          (PULONG)&Mcb->Inode.i_block[Slot],
+#else
+                         &Mcb->Inode.i_block[Slot],
+#endif
                          &Hint,
                          &Extra
                      );
@@ -1118,11 +1138,19 @@ Ext2TruncateIndirect(
         Base -= Vcb->max_blocks_per_layer[Layer - 1];
 
         if (Layer - 1 == 0) {
+#ifdef __REACTOS__
             BlockArray = (PULONG)&Mcb->Inode.i_block[0];
+#else
+            BlockArray = &Mcb->Inode.i_block[0];
+#endif
             SizeArray = End;
             ASSERT(End == EXT2_NDIR_BLOCKS && Base == 0);
         } else {
+#ifdef __REACTOS__
             BlockArray = (PULONG)&Mcb->Inode.i_block[EXT2_NDIR_BLOCKS - 1 + Layer - 1];
+#else
+            BlockArray = &Mcb->Inode.i_block[EXT2_NDIR_BLOCKS - 1 + Layer - 1];
+#endif
             SizeArray = 1;
         }
 

--- a/drivers/filesystems/ext2/src/ext4/ext4_extents.c
+++ b/drivers/filesystems/ext2/src/ext4/ext4_extents.c
@@ -14,9 +14,13 @@
  */
 
 #include "ext2fs.h"
+#ifdef __REACTOS__
 #include <linux/ext4.h>
+#else
+#include "linux\ext4.h"
+#endif
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && defined(__REACTOS__)
 #pragma warning(push)
 #pragma warning(disable: 4018)
 #pragma warning(disable: 4242)
@@ -83,9 +87,15 @@ static inline void ext_debug(char *str, ...)
 {
 }
 #if TRUE
+#ifdef __REACTOS__
 #define EXT4_ERROR_INODE(inode, str, ...) do {                      \
             DbgPrint("inode[%p]: " str "\n", inode, ##__VA_ARGS__); \
         } while(0)
+#else
+#define EXT4_ERROR_INODE(inode, str, ...) do {                      \
+            DbgPrint("inode[%p]: "##str "\n", inode, __VA_ARGS__);  \
+        } while(0)
+#endif
 #else
 #define EXT4_ERROR_INODE
 #endif
@@ -395,6 +405,7 @@ static int __ext4_ext_check(const char *function, unsigned int line,
 #ifndef __REACTOS__
 	int max = 0;
 #endif
+
 	if (eh->eh_magic != EXT4_EXT_MAGIC) {
 		error_msg = "invalid magic";
 		goto corrupted;
@@ -2175,10 +2186,10 @@ fix_extent_len:
 /*
  * returns 1 if current index have to be freed (even partial)
  */
-#ifndef __REACTOS__
-static int inline
-#else
+#ifdef __REACTOS__
 inline int
+#else
+static int inline
 #endif
 ext4_ext_more_to_rm(struct ext4_ext_path *path)
 {
@@ -2517,7 +2528,7 @@ int ext4_ext_truncate(void *icb, struct inode *inode, unsigned long start)
 	return ret;
 }
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && defined(__REACTOS__)
 #pragma warning(pop)
 #endif
 

--- a/drivers/filesystems/ext2/src/ext4/ext4_extents.c
+++ b/drivers/filesystems/ext2/src/ext4/ext4_extents.c
@@ -15,7 +15,7 @@
 
 #include "ext2fs.h"
 #ifdef __REACTOS__
-#include <linux/ext4.h>
+#include "linux/ext4.h"
 #else
 #include "linux\ext4.h"
 #endif

--- a/drivers/filesystems/ext2/src/ext4/ext4_jbd2.c
+++ b/drivers/filesystems/ext2/src/ext4/ext4_jbd2.c
@@ -1,5 +1,9 @@
 #include "ext2fs.h"
+#ifdef __REACTOS__
 #include "linux/ext4.h"
+#else
+#include "linux\ext4.h"
+#endif
 
 static handle_t no_journal;
 

--- a/drivers/filesystems/ext2/src/fastio.c
+++ b/drivers/filesystems/ext2/src/fastio.c
@@ -56,7 +56,11 @@ Ext2IsFastIoPossible(
 }
 
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoCheckIfPossible (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -160,7 +164,11 @@ Ext2FastIoCheckIfPossible (
 }
 
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoRead (IN PFILE_OBJECT         FileObject,
                 IN PLARGE_INTEGER       FileOffset,
                 IN ULONG                Length,
@@ -191,7 +199,11 @@ Ext2FastIoRead (IN PFILE_OBJECT         FileObject,
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoWrite (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -260,7 +272,11 @@ Ext2FastIoWrite (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryBasicInfo (
     IN PFILE_OBJECT             FileObject,
     IN BOOLEAN                  Wait,
@@ -372,7 +388,11 @@ Ext2FastIoQueryBasicInfo (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryStandardInfo (
     IN PFILE_OBJECT                 FileObject,
     IN BOOLEAN                      Wait,
@@ -489,7 +509,11 @@ Ext2FastIoQueryStandardInfo (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoLock (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -597,7 +621,11 @@ Ext2FastIoLock (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockSingle (
     IN PFILE_OBJECT         FileObject,
     IN PLARGE_INTEGER       FileOffset,
@@ -700,7 +728,11 @@ Ext2FastIoUnlockSingle (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockAll (
     IN PFILE_OBJECT         FileObject,
     IN PEPROCESS            Process,
@@ -791,7 +823,11 @@ Ext2FastIoUnlockAll (
     return Status;
 }
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoUnlockAllByKey (
     IN PFILE_OBJECT         FileObject,
 #ifdef __REACTOS__
@@ -898,7 +934,11 @@ Ext2FastIoUnlockAllByKey (
 }
 
 
+#ifdef __REACTOS__
 BOOLEAN NTAPI
+#else
+BOOLEAN
+#endif
 Ext2FastIoQueryNetworkOpenInfo (
     IN PFILE_OBJECT         FileObject,
     IN BOOLEAN              Wait,
@@ -995,7 +1035,11 @@ Ext2FastIoQueryNetworkOpenInfo (
 }
 
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2AcquireForCreateSection (
     IN PFILE_OBJECT FileObject
 )
@@ -1010,7 +1054,11 @@ Ext2AcquireForCreateSection (
     DEBUG(FASTIO_DEBUG_LEVEL, ("Ext2AcquireForCreateSection:  Fcb=%p\n", Fcb));
 }
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2ReleaseForCreateSection (
     IN PFILE_OBJECT FileObject
 )
@@ -1025,7 +1073,11 @@ Ext2ReleaseForCreateSection (
 }
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2AcquireFileForModWrite (
     IN PFILE_OBJECT FileObject,
     IN PLARGE_INTEGER EndingOffset,
@@ -1050,7 +1102,11 @@ Ext2AcquireFileForModWrite (
     return (ResourceAcquired ? STATUS_SUCCESS : STATUS_CANT_WAIT);
 }
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReleaseFileForModWrite (
     IN PFILE_OBJECT FileObject,
     IN PERESOURCE ResourceToRelease,
@@ -1071,7 +1127,11 @@ Ext2ReleaseFileForModWrite (
     return STATUS_SUCCESS;
 }
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2AcquireFileForCcFlush (
     IN PFILE_OBJECT FileObject,
     IN PDEVICE_OBJECT DeviceObject
@@ -1088,7 +1148,11 @@ Ext2AcquireFileForCcFlush (
     return STATUS_SUCCESS;
 }
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2ReleaseFileForCcFlush (
     IN PFILE_OBJECT FileObject,
     IN PDEVICE_OBJECT DeviceObject
@@ -1106,7 +1170,11 @@ Ext2ReleaseFileForCcFlush (
 }
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2PreAcquireForCreateSection(
     IN PFS_FILTER_CALLBACK_DATA cd,
     OUT PVOID *cc

--- a/drivers/filesystems/ext2/src/fileinfo.c
+++ b/drivers/filesystems/ext2/src/fileinfo.c
@@ -10,8 +10,13 @@
 /* INCLUDES *****************************************************************/
 
 #include "ext2fs.h"
+#ifdef __REACTOS__
 #include <linux/ext4.h>
 #include "linux/ext4_xattr.h"
+#else
+#include "linux\ext4.h"
+#include "linux\ext4_xattr.h"
+#endif
 
 /* GLOBALS ***************************************************************/
 

--- a/drivers/filesystems/ext2/src/fileinfo.c
+++ b/drivers/filesystems/ext2/src/fileinfo.c
@@ -11,7 +11,7 @@
 
 #include "ext2fs.h"
 #ifdef __REACTOS__
-#include <linux/ext4.h>
+#include "linux/ext4.h"
 #include "linux/ext4_xattr.h"
 #else
 #include "linux\ext4.h"

--- a/drivers/filesystems/ext2/src/flush.c
+++ b/drivers/filesystems/ext2/src/flush.c
@@ -18,7 +18,11 @@ extern PEXT2_GLOBAL Ext2Global;
 /* DEFINITIONS *************************************************************/
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2FlushCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,

--- a/drivers/filesystems/ext2/src/init.c
+++ b/drivers/filesystems/ext2/src/init.c
@@ -26,7 +26,11 @@ CHAR            gDate[] = __DATE__;
 
 /* DEFINITIONS ***********************************************************/
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 DriverEntry(
     IN PDRIVER_OBJECT DriverObject,
     IN PUNICODE_STRING RegistryPath   );
@@ -53,8 +57,11 @@ DECLARE_EXIT(journal_exit);
  *           DriverObject = object describing this driver
  * RETURNS:  None
  */
-
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 DriverUnload (IN PDRIVER_OBJECT DriverObject)
 {
 
@@ -100,7 +107,11 @@ DriverUnload (IN PDRIVER_OBJECT DriverObject)
 
 #endif
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2RegistryQueryCallback(
     IN PWSTR ValueName,
     IN ULONG ValueType,
@@ -449,7 +460,11 @@ Ext2EresourceAlignmentChecking()
  *           RegistryPath = path to our configuration entries
  * RETURNS: Success or failure
  */
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 DriverEntry (
     IN PDRIVER_OBJECT   DriverObject,
     IN PUNICODE_STRING  RegistryPath

--- a/drivers/filesystems/ext2/src/linux.c
+++ b/drivers/filesystems/ext2/src/linux.c
@@ -664,7 +664,11 @@ again:
                             FALSE,
                             PIN_WAIT,
                             &bh->b_bcb,
+#ifdef __REACTOS__
                             (PVOID *)&bh->b_data)) {
+#else
+                            &bh->b_data)) {
+#endif
             Ext2Sleep(100);
             goto again;
         }
@@ -674,7 +678,11 @@ again:
                         bh->b_size,
                         PIN_WAIT,
                         &bh->b_bcb,
+#ifdef __REACTOS__
                         (PVOID *)&bh->b_data)) {
+#else
+                        &bh->b_data)) {
+#endif
             Ext2Sleep(100);
             goto again;
         }

--- a/drivers/filesystems/ext2/src/memory.c
+++ b/drivers/filesystems/ext2/src/memory.c
@@ -1819,7 +1819,11 @@ Ext2CleanupAllMcbs(PEXT2_VCB Vcb)
             TRUE );
         LockAcquired = TRUE;
 
+#ifdef __REACTOS__
         while ((Mcb = Ext2FirstUnusedMcb(Vcb, TRUE, Vcb->NumOfMcb)) != 0) {
+#else
+        while (Mcb = Ext2FirstUnusedMcb(Vcb, TRUE, Vcb->NumOfMcb)) {
+#endif
             while (Mcb) {
                 PEXT2_MCB Next = Mcb->Next;
                 if (IsMcbSymLink(Mcb)) {
@@ -2209,7 +2213,11 @@ Ext2PerformRegistryVolumeParams(IN PEXT2_VCB Vcb)
         memcpy(Vcb->Codepage.AnsiName, Ext2Global->Codepage.AnsiName, CODEPAGE_MAXLEN);
         Vcb->Codepage.PageTable = Ext2Global->Codepage.PageTable;
 
+#ifdef __REACTOS__
         if (Vcb->bHidingPrefix == Ext2Global->bHidingPrefix) {
+#else
+        if (Vcb->bHidingPrefix = Ext2Global->bHidingPrefix) {
+#endif
             RtlCopyMemory( Vcb->sHidingPrefix,
                            Ext2Global->sHidingPrefix,
                            HIDINGPAT_LEN);
@@ -2218,7 +2226,11 @@ Ext2PerformRegistryVolumeParams(IN PEXT2_VCB Vcb)
                            HIDINGPAT_LEN);
         }
 
+#ifdef __REACTOS__
         if (Vcb->bHidingSuffix == Ext2Global->bHidingSuffix) {
+#else
+        if (Vcb->bHidingSuffix = Ext2Global->bHidingSuffix) {
+#endif
             RtlCopyMemory( Vcb->sHidingSuffix,
                            Ext2Global->sHidingSuffix,
                            HIDINGPAT_LEN);
@@ -3035,7 +3047,11 @@ Ext2FirstUnusedMcb(PEXT2_VCB Vcb, BOOLEAN Wait, ULONG Number)
 
 
 /* Reaper thread to release unused Mcb blocks */
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2McbReaperThread(
     PVOID   Context
 )
@@ -3215,7 +3231,11 @@ Ext2QueryUnusedBH(PEXT2_VCB Vcb, PLIST_ENTRY head)
 
 
 /* Reaper thread to release unused buffer heads */
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2bhReaperThread(
     PVOID   Context
 )
@@ -3363,7 +3383,11 @@ again:
 }
 
 /* Reaper thread to release Fcb */
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2FcbReaperThread(
     PVOID   Context
 )
@@ -3514,7 +3538,11 @@ Ext2StartReaper(PEXT2_REAPER Reaper, EXT2_REAPER_RELEASE Free)
 }
 
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2StopReaper(PEXT2_REAPER Reaper)
 {
     LARGE_INTEGER timeout;

--- a/drivers/filesystems/ext2/src/pnp.c
+++ b/drivers/filesystems/ext2/src/pnp.c
@@ -19,7 +19,11 @@ extern PEXT2_GLOBAL Ext2Global;
 
 /* DEFINITIONS *************************************************************/
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2PnpCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP           Irp,
@@ -38,7 +42,11 @@ Ext2PnpCompletionRoutine (
 /* FUNCTIONS *************************************************************/
 
 
+#ifdef __REACTOS__
 NTSTATUS NTAPI
+#else
+NTSTATUS
+#endif
 Ext2PnpCompletionRoutine (
     IN PDEVICE_OBJECT DeviceObject,
     IN PIRP Irp,

--- a/drivers/filesystems/ext2/src/write.c
+++ b/drivers/filesystems/ext2/src/write.c
@@ -33,10 +33,18 @@ typedef struct _EXT2_FLPFLUSH_CONTEXT {
 
 } EXT2_FLPFLUSH_CONTEXT, *PEXT2_FLPFLUSH_CONTEXT;
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2FloppyFlush(IN PVOID Parameter);
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2FloppyFlushDpc (
     IN PKDPC Dpc,
     IN PVOID DeferredContext,
@@ -59,7 +67,11 @@ Ext2DeferWrite(IN PEXT2_IRP_CONTEXT, PIRP Irp);
 
 /* FUNCTIONS *************************************************************/
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2FloppyFlush(IN PVOID Parameter)
 {
     PEXT2_FLPFLUSH_CONTEXT Context;
@@ -102,7 +114,11 @@ Ext2FloppyFlush(IN PVOID Parameter)
     Ext2FreePool(Parameter, EXT2_FLPFLUSH_MAGIC);
 }
 
+#ifdef __REACTOS__
 VOID NTAPI
+#else
+VOID
+#endif
 Ext2FloppyFlushDpc (
     IN PKDPC Dpc,
     IN PVOID DeferredContext,


### PR DESCRIPTION

## Purpose
add ifdefs to distinguish ReactOS code/fixes from the upstream code.
NOTE: there are no new features in this PR, we stay with upstream version 0.69.

JIRA issue: [CORE-18645](https://jira.reactos.org/browse/CORE-18645)

## Proposed changes

 * surround ReactOS modifications with ifdef
 * if upstream code was override, reintroduce it in #else section
 * re-align .rc version info with upstream (0.69)


