### PR TITLE
[I8042PRT] Add Dell Latitude D410 to the hack list

### DIFF
--- a/drivers/input/i8042prt/hwhacks.c
+++ b/drivers/input/i8042prt/hwhacks.c
@@ -41,6 +41,7 @@ const HARDWARE_TABLE i8042HardwareTable[] =
 
     { {{SYS_VENDOR, "Microsoft Corporation"}, {SYS_PRODUCT, "Virtual Machine"}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Inspiron 6000                   "}}, FL_INITHACK },
+    { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D410                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D430                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D530                   "}}, FL_INITHACK },
     { {{SYS_VENDOR, "Dell Inc."}, {SYS_PRODUCT, "Latitude D531                   "}}, FL_INITHACK },


### PR DESCRIPTION
## Purpose

Fixes the Dell Latitude D410 TouchPad not working

## Proposed changes

Add the Dell Latitude D410 string to `i8042HardwareTable`