### PR TITLE
[ATL] Take _ATL_FREE_THREADED into account

### DIFF
--- a/sdk/lib/atl/atlbase.h
+++ b/sdk/lib/atl/atlbase.h
@@ -849,7 +849,12 @@ public:
 
     static HRESULT InitializeCom()
     {
-        return ::CoInitializeEx(NULL, COINIT_MULTITHREADED);
+#if defined(_ATL_FREE_THREADED)
+        constexpr COINIT coInit = COINIT_MULTITHREADED;
+#else
+        constexpr COINIT coInit = COINIT_APARTMENTTHREADED;
+#endif
+        return ::CoInitializeEx(NULL, coInit);
     }
 
     static void UninitializeCom()


### PR DESCRIPTION
When it is not defined, COM should not be initialize multithreaded
`COINIT_MULTITHREADED` can cause problems when COM objects expect `Apartment` threading, because they will be serialized.