### PR TITLE
[REGEDIT] Check whether pszSelectKey is NULL on CDN_FILEOK

### DIFF
--- a/base/applications/regedit/framewnd.c
+++ b/base/applications/regedit/framewnd.c
@@ -567,7 +567,7 @@ static UINT_PTR CALLBACK ExportRegistryFile_OFNHookProc(HWND hdlg, UINT uiMsg, W
             {
                 GetWindowTextW(hwndExportBranchText, pszSelectedKey, _MAX_PATH);
             }
-            else
+            else if (pszSelectedKey)
             {
                 pszSelectedKey[0] = L'\0';
             }


### PR DESCRIPTION
## Purpose
Avoid crash on exporting root.
JIRA issue: [CORE-18938](https://jira.reactos.org/browse/CORE-18938)

## Proposed changes

- Add `NULL` check of `pszSelectKey` on `CDN_FILEOK` handling.

## TODO

- [x] Do tests.