### PR TITLE
[RICHED20] RichEdit: CompForm and CandForm

### DIFF
--- a/dll/win32/riched20/caret.c
+++ b/dll/win32/riched20/caret.c
@@ -342,7 +342,7 @@ void update_caret(ME_TextEditor *editor)
       if (fmt.dwMask & CFM_SIZE)
       {
         HDC hdc = CreateCompatibleDC(NULL);
-        lf.lfHeight = MulDiv(fmt.yHeight, GetDeviceCaps(hdc, LOGPIXELSY), 1440);
+        lf.lfHeight = -MulDiv(fmt.yHeight, GetDeviceCaps(hdc, LOGPIXELSY), 1440);
         DeleteDC(hdc);
       }
       if (fmt.dwMask & CFM_CHARSET)

--- a/dll/win32/riched20/caret.c
+++ b/dll/win32/riched20/caret.c
@@ -339,6 +339,12 @@ void update_caret(ME_TextEditor *editor)
 
       ZeroMemory(&lf, sizeof(lf));
       lf.lfCharSet = DEFAULT_CHARSET;
+      if (fmt.dwMask & CFM_SIZE)
+      {
+        HDC hdc = CreateCompatibleDC(NULL);
+        lf.lfHeight = MulDiv(fmt.yHeight, GetDeviceCaps(hdc, LOGPIXELSY), 1440);
+        DeleteDC(hdc);
+      }
       if (fmt.dwMask & CFM_CHARSET)
         lf.lfCharSet = fmt.bCharSet;
       if (fmt.dwMask & CFM_FACE)

--- a/dll/win32/riched20/caret.c
+++ b/dll/win32/riched20/caret.c
@@ -310,6 +310,45 @@ void update_caret(ME_TextEditor *editor)
   }
   else
     hide_caret(editor);
+#ifdef __REACTOS__
+  if (ImmIsIME(GetKeyboardLayout(0)))
+  {
+    HIMC hIMC = ImmGetContext(editor->hWnd);
+    if (hIMC)
+    {
+      CHARFORMAT2W fmt;
+      LOGFONTW lf;
+      COMPOSITIONFORM CompForm;
+      POINT pt = { x, y };
+
+      CompForm.ptCurrentPos = pt;
+      if (editor->styleFlags & ES_MULTILINE)
+      {
+        CompForm.dwStyle = CFS_RECT;
+        CompForm.rcArea = editor->rcFormat;
+      }
+      else
+      {
+        CompForm.dwStyle = CFS_POINT;
+        SetRectEmpty(&CompForm.rcArea);
+      }
+      ImmSetCompositionWindow(hIMC, &CompForm);
+
+      fmt.cbSize = sizeof(fmt);
+      ME_GetSelectionCharFormat(editor, &fmt);
+
+      ZeroMemory(&lf, sizeof(lf));
+      lf.lfCharSet = DEFAULT_CHARSET;
+      if (fmt.dwMask & CFM_CHARSET)
+        lf.lfCharSet = fmt.bCharSet;
+      if (fmt.dwMask & CFM_FACE)
+        lstrcpynW(lf.lfFaceName, fmt.szFaceName, ARRAY_SIZE(lf.lfFaceName));
+      ImmSetCompositionFontW(hIMC, &lf);
+
+      ImmReleaseContext(editor->hWnd, hIMC);
+    }
+  }
+#endif
 }
 
 BOOL ME_InternalDeleteText(ME_TextEditor *editor, ME_Cursor *start,

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -233,6 +233,9 @@
 #include "shlwapi.h"
 #include "rtf.h"
 #include "imm.h"
+#ifdef __REACTOS__
+  #include "immdev.h"
+#endif
 #include "res.h"
 
 #ifdef __REACTOS__
@@ -4103,6 +4106,14 @@ LRESULT ME_HandleMessage(ME_TextEditor *editor, UINT msg, WPARAM wParam,
     ME_UpdateScrollBar(editor);
     if (bRepaint)
       ME_Repaint(editor);
+#ifdef __REACTOS__
+    if (ImmIsIME(GetKeyboardLayout(0)))
+    {
+      HIMC hIMC = ImmGetContext(editor->hWnd);
+      ImmSetCompositionFontW(hIMC, &lf);
+      ImmReleaseContext(editor->hWnd, hIMC);
+    }
+#endif
     return 0;
   }
   case WM_SETTEXT:
@@ -4779,18 +4790,55 @@ LRESULT ME_HandleMessage(ME_TextEditor *editor, UINT msg, WPARAM wParam,
     ME_RewrapRepaint(editor);
     goto do_default;
   }
+#ifdef __REACTOS__
+  case WM_IME_CHAR:
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#else
   /* IME messages to make richedit controls IME aware */
+#endif
   case WM_IME_SETCONTEXT:
+#ifdef __REACTOS__
+  {
+    if (FALSE) /* FIXME: Condition */
+      lParam &= ~ISC_SHOWUICOMPOSITIONWINDOW;
+
+    if (wParam)
+    {
+      HIMC hIMC = ImmGetContext(editor->hWnd);
+      LPINPUTCONTEXTDX pIC = (LPINPUTCONTEXTDX)ImmLockIMC(hIMC);
+      if (pIC)
+      {
+        pIC->dwUIFlags &= ~0x40000;
+        ImmUnlockIMC(hIMC);
+      }
+      if (FALSE) /* FIXME: Condition */
+        ImmNotifyIME(hIMC, NI_COMPOSITIONSTR, CPS_CANCEL, 0);
+      ImmReleaseContext(editor->hWnd, hIMC);
+    }
+
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+  }
+#endif
   case WM_IME_CONTROL:
+#ifdef __REACTOS__
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#endif
   case WM_IME_SELECT:
+#ifdef __REACTOS__
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#endif
   case WM_IME_COMPOSITIONFULL:
     return 0;
   case WM_IME_STARTCOMPOSITION:
   {
+#ifdef __REACTOS__
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#else
     editor->imeStartIndex=ME_GetCursorOfs(&editor->pCursors[0]);
     ME_DeleteSelection(editor);
     ME_CommitUndo(editor);
     ME_UpdateRepaint(editor, FALSE);
+#endif
     return 0;
   }
   case WM_IME_COMPOSITION:
@@ -4813,23 +4861,35 @@ LRESULT ME_HandleMessage(ME_TextEditor *editor, UINT msg, WPARAM wParam,
         lpCompStr = HeapAlloc(GetProcessHeap(),0,dwBufLen + sizeof(WCHAR));
         ImmGetCompositionStringW(hIMC, dwIndex, lpCompStr, dwBufLen);
         lpCompStr[dwBufLen/sizeof(WCHAR)] = 0;
+#ifndef __REACTOS__
         ME_InsertTextFromCursor(editor,0,lpCompStr,dwBufLen/sizeof(WCHAR),style);
+#endif
         HeapFree(GetProcessHeap(), 0, lpCompStr);
 
+#ifndef __REACTOS__
         if (dwIndex == GCS_COMPSTR)
           set_selection_cursors(editor,editor->imeStartIndex,
                           editor->imeStartIndex + dwBufLen/sizeof(WCHAR));
+#endif
     }
     ME_ReleaseStyle(style);
     ME_CommitUndo(editor);
     ME_UpdateRepaint(editor, FALSE);
+#ifdef __REACTOS__
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#else
     return 0;
+#endif
   }
   case WM_IME_ENDCOMPOSITION:
   {
+#ifdef __REACTOS__
+    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
+#else
     ME_DeleteSelection(editor);
     editor->imeStartIndex=-1;
     return 0;
+#endif
   }
   case EM_GETOLEINTERFACE:
   {

--- a/dll/win32/riched20/editor.c
+++ b/dll/win32/riched20/editor.c
@@ -4790,10 +4790,7 @@ LRESULT ME_HandleMessage(ME_TextEditor *editor, UINT msg, WPARAM wParam,
     ME_RewrapRepaint(editor);
     goto do_default;
   }
-#ifdef __REACTOS__
-  case WM_IME_CHAR:
-    return DefWindowProcW(editor->hWnd, msg, wParam, lParam);
-#else
+#ifndef __REACTOS__
   /* IME messages to make richedit controls IME aware */
 #endif
   case WM_IME_SETCONTEXT:

--- a/dll/win32/riched20/editstr.h
+++ b/dll/win32/riched20/editstr.h
@@ -426,8 +426,10 @@ typedef struct tagME_TextEditor
   WCHAR cPasswordMask;
   BOOL bHaveFocus;
   BOOL bDialogMode; /* Indicates that we are inside a dialog window */
+#ifndef __REACTOS__
   /*for IME */
   int imeStartIndex;
+#endif
   DWORD selofs; /* The size of the selection bar on the left side of control */
   ME_SelectionType nSelectionType;
   ME_DisplayItem *first_marked_para;


### PR DESCRIPTION
## Purpose

Implementing Japanese input...
Correctly display the composition window and the candidate window.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes
The changes of this PR are on `RichEdit` controls.

- Delete `imeStartIndex` member.
- At `update_caret` function, set the position and font of the composition window.
- We don't use internal composition string. Rely on the composition window.
- Improve `WM_IME_SETCONTEXT`, `WM_IME_CONTROL`, `WM_IME_SELECT`, `WM_IME_STARTCOMPOSITION`, `WM_IME_COMPOSITION` and `WM_IME_ENDCOMPOSITION` message handlings.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/234443338-b3e0e6f0-843f-4794-b52b-cacaac0d07e5.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/234448565-7d3bb678-ce2c-4ddc-9eae-ab4d032e2403.png)

## TODO

- [x] Do tests.
