### PR TITLE
[KBSWITCH] Delete SHLoadRegUIString hack

### DIFF
--- a/base/applications/kbswitch/CMakeLists.txt
+++ b/base/applications/kbswitch/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_rc_deps(kbswitch.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/kbswitch.ico)
 add_executable(kbswitch kbswitch.c kbswitch.rc)
 set_module_type(kbswitch win32gui UNICODE)
-add_importlibs(kbswitch advapi32 imm32 user32 shell32 gdi32 msvcrt kernel32)
+add_importlibs(kbswitch advapi32 shlwapi imm32 user32 shell32 gdi32 msvcrt kernel32)
 add_cd_file(TARGET kbswitch DESTINATION reactos/system32 FOR all)
 
 add_subdirectory(kbsdll)

--- a/base/applications/kbswitch/CMakeLists.txt
+++ b/base/applications/kbswitch/CMakeLists.txt
@@ -2,7 +2,7 @@
 add_rc_deps(kbswitch.rc ${CMAKE_CURRENT_SOURCE_DIR}/res/kbswitch.ico)
 add_executable(kbswitch kbswitch.c kbswitch.rc)
 set_module_type(kbswitch win32gui UNICODE)
-add_importlibs(kbswitch advapi32 shlwapi imm32 user32 shell32 gdi32 msvcrt kernel32)
+add_importlibs(kbswitch advapi32 imm32 user32 shell32 shlwapi gdi32 msvcrt kernel32)
 add_cd_file(TARGET kbswitch DESTINATION reactos/system32 FOR all)
 
 add_subdirectory(kbsdll)

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -9,6 +9,7 @@
 
 #include "kbswitch.h"
 #include <imm.h>
+#include <shlwapi_undoc.h>
 
 /*
  * This program kbswitch is a mimic of Win2k's internat.exe.
@@ -91,9 +92,6 @@ GetSystemLibraryPath(LPTSTR szPath, SIZE_T cchPath, LPCTSTR FileName)
     StringCchCat(szPath, cchPath, FileName);
     return TRUE;
 }
-
-/* FIXME: Use <shlwapi_undoc.h> and delete this */
-HRESULT WINAPI SHLoadRegUIStringW(HKEY hkey, LPCWSTR value, LPWSTR buf, DWORD size);
 
 static BOOL
 GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -8,10 +8,7 @@
  */
 
 #include "kbswitch.h"
-#include <unknwn.h>
-#include <docobj.h>
 #include <shlobj.h>
-#include <shobjidl.h>
 #include <shlwapi_undoc.h>
 #include <imm.h>
 

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -99,6 +99,7 @@ static BOOL
 GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)
 {
     HKEY hKey;
+    HRESULT hr;
     DWORD dwBufLen;
     TCHAR szBuf[MAX_PATH], szDispName[MAX_PATH];
     TCHAR szLCID[CCH_LAYOUT_ID + 1];

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -100,7 +100,6 @@ GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)
     HRESULT hr;
     DWORD dwBufLen;
     TCHAR szBuf[MAX_PATH];
-    WCHAR szDispName[MAX_PATH];
     TCHAR szLCID[CCH_LAYOUT_ID + 1];
 
     if (!GetLayoutID(szLayoutNum, szLCID, ARRAYSIZE(szLCID)))
@@ -110,12 +109,10 @@ GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)
                     _T("SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts\\%s"), szLCID);
 
     if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, szBuf, 0, KEY_QUERY_VALUE, &hKey) != ERROR_SUCCESS)
-    {
         return FALSE;
-    }
 
     /* Use "Layout Display Name" value as an entry name if possible */
-    hr = SHLoadRegUIStringW(hKey, L"Layout Display Name", szDispName, ARRAYSIZE(szDispName));
+    hr = SHLoadRegUIString(hKey, _T("Layout Display Name"), szName, NameLength);
     if (SUCCEEDED(hr))
     {
         RegCloseKey(hKey);

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -102,7 +102,6 @@ GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)
     DWORD dwBufLen;
     TCHAR szBuf[MAX_PATH], szDispName[MAX_PATH];
     TCHAR szLCID[CCH_LAYOUT_ID + 1];
-    HRESULT hr;
 
     if (!GetLayoutID(szLayoutNum, szLCID, ARRAYSIZE(szLCID)))
         return FALSE;

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -8,8 +8,12 @@
  */
 
 #include "kbswitch.h"
-#include <imm.h>
+#include <unknwn.h>
+#include <docobj.h>
+#include <shlobj.h>
+#include <shobjidl.h>
 #include <shlwapi_undoc.h>
+#include <imm.h>
 
 /*
  * This program kbswitch is a mimic of Win2k's internat.exe.

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -99,7 +99,8 @@ GetLayoutName(LPCTSTR szLayoutNum, LPTSTR szName, SIZE_T NameLength)
     HKEY hKey;
     HRESULT hr;
     DWORD dwBufLen;
-    TCHAR szBuf[MAX_PATH], szDispName[MAX_PATH];
+    TCHAR szBuf[MAX_PATH];
+    WCHAR szDispName[MAX_PATH];
     TCHAR szLCID[CCH_LAYOUT_ID + 1];
 
     if (!GetLayoutID(szLayoutNum, szLCID, ARRAYSIZE(szLCID)))

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -21,11 +21,6 @@
 #ifndef __SHLWAPI_UNDOC_H
 #define __SHLWAPI_UNDOC_H
 
-#include <unknwn.h>
-#include <docobj.h>
-#include <shlobj.h>
-#include <shobjidl.h>
-
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */

--- a/sdk/include/reactos/shlwapi_undoc.h
+++ b/sdk/include/reactos/shlwapi_undoc.h
@@ -21,6 +21,11 @@
 #ifndef __SHLWAPI_UNDOC_H
 #define __SHLWAPI_UNDOC_H
 
+#include <unknwn.h>
+#include <docobj.h>
+#include <shlobj.h>
+#include <shobjidl.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif /* defined(__cplusplus) */


### PR DESCRIPTION
## Purpose

Remove the needless hack and reduce the maintenance cost. Because `shlwapi!SHLoadRegUIString` function is already implemented, so we don't need the hack any more.

JIRA issue: [CORE-10667](https://jira.reactos.org/browse/CORE-10667)

## Proposed changes

- Directly use `shlwapi!SHLoadRegUIString` function instead of a hack.
- Add link to `shlwapi.dll`.