### PR TITLE
[NOTEPAD] Delete my name from resource copyright text

### DIFF
--- a/base/applications/notepad/lang/bg-BG.rc
+++ b/base/applications/notepad/lang/bg-BG.rc
@@ -183,5 +183,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Възпроизводствено право 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Възпроизводствено право 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/cs-CZ.rc
+++ b/base/applications/notepad/lang/cs-CZ.rc
@@ -184,5 +184,5 @@ paměti."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Textový dokument"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/da-DK.rc
+++ b/base/applications/notepad/lang/da-DK.rc
@@ -184,5 +184,5 @@ hukommelse, og prøv så igen."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/de-DE.rc
+++ b/base/applications/notepad/lang/de-DE.rc
@@ -185,5 +185,5 @@ um diese Funktion\nabzuschließen. Beenden Sie eine oder mehrere \
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Textdokument"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/el-GR.rc
+++ b/base/applications/notepad/lang/el-GR.rc
@@ -184,5 +184,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/en-US.rc
+++ b/base/applications/notepad/lang/en-US.rc
@@ -183,5 +183,5 @@ task.\nClose one or more applications to increase the amount of\nfree memory."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/es-ES.rc
+++ b/base/applications/notepad/lang/es-ES.rc
@@ -186,5 +186,5 @@ aumentar la cantidad\nde memoria libre."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Documento de texto"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/et-EE.rc
+++ b/base/applications/notepad/lang/et-EE.rc
@@ -191,5 +191,5 @@ käsu lõpetamiseks.\nSulge üks või enam rakendust, et suurendada\nvaba mälu 
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Tekstidokument"
-    STRING_NOTEPAD_AUTHORS "Autoriõigus 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Autoriõigus 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/eu-ES.rc
+++ b/base/applications/notepad/lang/eu-ES.rc
@@ -184,5 +184,5 @@ memoria librearen\nkopurua handitzeko."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/fi-FI.rc
+++ b/base/applications/notepad/lang/fi-FI.rc
@@ -184,5 +184,5 @@ muistia."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/fr-FR.rc
+++ b/base/applications/notepad/lang/fr-FR.rc
@@ -184,5 +184,5 @@ de la mémoire."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Document Texte"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/he-IL.rc
+++ b/base/applications/notepad/lang/he-IL.rc
@@ -186,5 +186,5 @@ task.\nClose one or more applications to increase the amount of\nfree memory."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/hi-IN.rc
+++ b/base/applications/notepad/lang/hi-IN.rc
@@ -190,5 +190,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "टेक्स्ट डॉक्यूमॅन्ट"
-    STRING_NOTEPAD_AUTHORS "कॉपीराइट 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "कॉपीराइट 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/hr-HR.rc
+++ b/base/applications/notepad/lang/hr-HR.rc
@@ -190,5 +190,5 @@ zadatak.\nZatvorite jednu ili više aplikacija da povećate\nslobodnu memoriju."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Tekstni dokument"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997, 98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997, 98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/hu-HU.rc
+++ b/base/applications/notepad/lang/hu-HU.rc
@@ -184,5 +184,5 @@ Szeretné menteni a változásokat?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Szöveges dokumentum"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/hy-AM.rc
+++ b/base/applications/notepad/lang/hy-AM.rc
@@ -183,5 +183,5 @@ Would you like to save the changes ?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/id-ID.rc
+++ b/base/applications/notepad/lang/id-ID.rc
@@ -184,5 +184,5 @@ bebas."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Teks Dokumen"
-    STRING_NOTEPAD_AUTHORS "Hak Cipta 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Hak Cipta 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/it-IT.rc
+++ b/base/applications/notepad/lang/it-IT.rc
@@ -184,5 +184,5 @@ di memoria libera."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Documento di testo"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/ja-JP.rc
+++ b/base/applications/notepad/lang/ja-JP.rc
@@ -184,5 +184,5 @@ BEGIN
     STRING_PRINTFAILED "印刷が失敗しました。"
 
     STRING_TEXT_DOCUMENT "テキスト文書"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/lt-LT.rc
+++ b/base/applications/notepad/lang/lt-LT.rc
@@ -183,5 +183,5 @@ Ar norite išsaugoti pakeitimus?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "(C) 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "(C) 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/ms-MY.rc
+++ b/base/applications/notepad/lang/ms-MY.rc
@@ -185,5 +185,5 @@ tugas ini.\nTutup satu atau lebih aplikasi untuk menambah jumlah\ningatan kosong
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/nl-NL.rc
+++ b/base/applications/notepad/lang/nl-NL.rc
@@ -183,5 +183,5 @@ Wilt u de wijzigingen opslaan?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/no-NO.rc
+++ b/base/applications/notepad/lang/no-NO.rc
@@ -184,5 +184,5 @@ minne."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Enerett 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Enerett 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/pl-PL.rc
+++ b/base/applications/notepad/lang/pl-PL.rc
@@ -178,5 +178,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Dokument tekstowy"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/pt-BR.rc
+++ b/base/applications/notepad/lang/pt-BR.rc
@@ -183,5 +183,5 @@ tarefa.\nFeche uma ou mais aplicações para aumentar a quantidade de memória l
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/pt-PT.rc
+++ b/base/applications/notepad/lang/pt-PT.rc
@@ -183,5 +183,5 @@ tarefa.\nFeche uma ou mais aplicações para aumentar a quantidade de memória l
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Documento de texto"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/ro-RO.rc
+++ b/base/applications/notepad/lang/ro-RO.rc
@@ -188,5 +188,5 @@ Păstrați modificările aduse?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Document text"
-    STRING_NOTEPAD_AUTHORS "Drept de autor 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Drept de autor 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/ru-RU.rc
+++ b/base/applications/notepad/lang/ru-RU.rc
@@ -183,5 +183,5 @@ BEGIN
     STRING_PRINTFAILED "Печать не удалась."
 
     STRING_TEXT_DOCUMENT "Текстовый документ"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/sk-SK.rc
+++ b/base/applications/notepad/lang/sk-SK.rc
@@ -191,5 +191,5 @@ alebo viac aplikácií, aby sa uvoľnila pamäť a skúste to znova."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/sl-SI.rc
+++ b/base/applications/notepad/lang/sl-SI.rc
@@ -183,5 +183,5 @@ operacijo.\nÈe ga želite sprostiti, konèajte enega ali veè programov in posk
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/sq-AL.rc
+++ b/base/applications/notepad/lang/sq-AL.rc
@@ -187,5 +187,5 @@ detyrë.\nMbyll nje ose me shume programe te rrisesh shumën e\nmemories."
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/sv-SE.rc
+++ b/base/applications/notepad/lang/sv-SE.rc
@@ -183,5 +183,5 @@ den här åtgärden.\nAvsluta ett eller flera program för att frigöra mer minn
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/th-TH.rc
+++ b/base/applications/notepad/lang/th-TH.rc
@@ -178,5 +178,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/tr-TR.rc
+++ b/base/applications/notepad/lang/tr-TR.rc
@@ -181,5 +181,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Metin Belgesi"
-    STRING_NOTEPAD_AUTHORS "Telif Hakları: 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Telif Hakları: 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/uk-UA.rc
+++ b/base/applications/notepad/lang/uk-UA.rc
@@ -183,5 +183,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Текстовий документ"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/uz-UZ.rc
+++ b/base/applications/notepad/lang/uz-UZ.rc
@@ -183,5 +183,5 @@ O‘zgarishlarni saqlashni istaysizmi?"
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "Text Document"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/zh-CN.rc
+++ b/base/applications/notepad/lang/zh-CN.rc
@@ -191,5 +191,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "文本文档"
-    STRING_NOTEPAD_AUTHORS "版权所有 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "版权所有 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/zh-HK.rc
+++ b/base/applications/notepad/lang/zh-HK.rc
@@ -192,5 +192,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "純文字檔案"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END

--- a/base/applications/notepad/lang/zh-TW.rc
+++ b/base/applications/notepad/lang/zh-TW.rc
@@ -191,5 +191,5 @@ BEGIN
     STRING_PRINTFAILED "Printing is failed."
 
     STRING_TEXT_DOCUMENT "純文字檔案"
-    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk, 2020-23 katahiromz\r\n"
+    STRING_NOTEPAD_AUTHORS "Copyright 1997,98 Marcel Baur, 2000 Mike McCormack, 2002 Sylvain Petreolle, 2002 Andriy Palamarchuk\r\n"
 END


### PR DESCRIPTION
## Purpose
The copyright text was too long.
JIRA issue: [CORE-18837](https://jira.reactos.org/browse/CORE-18837)

## Proposed change

- Improve `STRING_NOTEPAD_AUTHORS` resource strings.

## Comparison

BEFORE:
![before](https://user-images.githubusercontent.com/2107452/235151404-77f79092-a6ed-4de9-bbdc-76dcd78502ca.png)

AFTER:
![after](https://user-images.githubusercontent.com/2107452/235151408-e267adfe-c34b-44ad-822b-92806bcd015f.png)