### PR TITLE
[KBSWITCH] Rely on GetKeyboardLayoutList for getting list

### DIFF
--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -60,14 +60,15 @@ INT g_cSpecialIds = 0;
 
 static VOID LoadSpecialIds(VOID)
 {
-    WCHAR szKLID[KL_NAMELENGTH], szBuffer[16];
+    TCHAR szKLID[KL_NAMELENGTH], szBuffer[16];
     DWORD dwSize, dwIndex;
     HKEY hKey, hLayoutKey;
 
     g_cSpecialIds = 0;
 
-    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, L"SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts",
-                      0, KEY_READ, &hKey) != ERROR_SUCCESS)
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE,
+                     TEXT("SYSTEM\\CurrentControlSet\\Control\\Keyboard Layouts"),
+                     0, KEY_READ, &hKey) != ERROR_SUCCESS)
     {
         return;
     }
@@ -75,21 +76,20 @@ static VOID LoadSpecialIds(VOID)
     for (dwIndex = 0; ; ++dwIndex)
     {
         dwSize = ARRAYSIZE(szKLID);
-        if (RegEnumKeyExW(hKey, dwIndex, szKLID, &dwSize, NULL, NULL,
-                          NULL, NULL) != ERROR_SUCCESS)
+        if (RegEnumKeyEx(hKey, dwIndex, szKLID, &dwSize, NULL, NULL, NULL, NULL) != ERROR_SUCCESS)
         {
             break;
         }
 
-        if (RegOpenKeyExW(hKey, szKLID, 0, KEY_READ, &hLayoutKey) == ERROR_SUCCESS)
+        if (RegOpenKeyEx(hKey, szKLID, 0, KEY_READ, &hLayoutKey) == ERROR_SUCCESS)
         {
             dwSize = sizeof(szBuffer);
-            if (RegQueryValueExW(hLayoutKey, L"Layout Id", NULL, NULL,
-                                 (LPBYTE)szBuffer, &dwSize) == ERROR_SUCCESS)
+            if (RegQueryValueEx(hLayoutKey, TEXT("Layout Id"), NULL, NULL,
+                                (LPBYTE)szBuffer, &dwSize) == ERROR_SUCCESS)
             {
-                DWORD dwKLID = wcstoul(szKLID, NULL, 16);
+                DWORD dwKLID = _tcstoul(szKLID, NULL, 16);
                 WORD wLangId = LOWORD(dwKLID);
-                WORD wLayoutId = LOWORD(wcstoul(szBuffer, NULL, 16));
+                WORD wLayoutId = LOWORD(_tcstoul(szBuffer, NULL, 16));
                 HKL hKL = (HKL)(LONG_PTR)(SPECIAL_MASK | MAKELONG(wLangId, wLayoutId));
 
                 /* Add a special ID */

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -600,6 +600,19 @@ DeleteHooks(VOID)
     }
 }
 
+static UINT GetLayoutNum(HKL hKL)
+{
+    INT iKL;
+
+    for (iKL = 0; iKL < g_cKLs; ++iKL)
+    {
+        if (g_ahKLs[iKL] == hKL)
+            return iKL + 1;
+    }
+
+    return 0;
+}
+
 ULONG
 GetNextLayout(VOID)
 {
@@ -616,6 +629,7 @@ UpdateLanguageDisplay(HWND hwnd, HKL hKL)
     LangID = (LANGID)_tcstoul(szKLID, NULL, 16);
     GetLocaleInfo(LangID, LOCALE_SLANGUAGE, szLangName, ARRAYSIZE(szLangName));
     UpdateTrayIcon(hwnd, szKLID, szLangName);
+    g_nCurrentLayoutNum = GetLayoutNum(hKL);
 
     return 0;
 }
@@ -643,19 +657,6 @@ UpdateLanguageDisplayCurrent(HWND hwnd, HWND hwndFore)
     DWORD dwThreadID = GetWindowThreadProcessId(GetTargetWindow(hwndFore), NULL);
     HKL hKL = GetKeyboardLayout(dwThreadID);
     UpdateLanguageDisplay(hwnd, hKL);
-
-    return 0;
-}
-
-static UINT GetLayoutNum(HKL hKL)
-{
-    INT iKL;
-
-    for (iKL = 0; iKL < g_cKLs; ++iKL)
-    {
-        if (g_ahKLs[iKL] == hKL)
-            return iKL + 1;
-    }
 
     return 0;
 }

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -73,7 +73,7 @@ static VOID LoadSpecialIds(VOID)
         return;
     }
 
-    for (dwIndex = 0; ; ++dwIndex)
+    for (dwIndex = 0; dwIndex < 0x100; ++dwIndex)
     {
         dwSize = ARRAYSIZE(szKLID);
         if (RegEnumKeyEx(hKey, dwIndex, szKLID, &dwSize, NULL, NULL, NULL, NULL) != ERROR_SUCCESS)

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -77,9 +77,7 @@ static VOID LoadSpecialIds(VOID)
     {
         dwSize = ARRAYSIZE(szKLID);
         if (RegEnumKeyEx(hKey, dwIndex, szKLID, &dwSize, NULL, NULL, NULL, NULL) != ERROR_SUCCESS)
-        {
             break;
-        }
 
         if (RegOpenKeyEx(hKey, szKLID, 0, KEY_READ, &hLayoutKey) == ERROR_SUCCESS)
         {
@@ -607,7 +605,7 @@ ULONG
 GetNextLayout(VOID)
 {
     UINT uMaxNum = GetMaxLayoutNum();
-    return (ulCurrentLayoutNum + 1) % uMaxNum;
+    return (ulCurrentLayoutNum % uMaxNum) + 1;
 }
 
 UINT

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -170,38 +170,10 @@ static VOID UpdateLayoutList(VOID)
 
 static HKL GetHKLFromLayoutNum(INT nLayoutNum)
 {
-    HKL hKL;
     if (0 <= (nLayoutNum - 1) && (nLayoutNum - 1) < g_cKLs)
-    {
-        hKL = g_ahKLs[nLayoutNum - 1];
-    }
+        return g_ahKLs[nLayoutNum - 1];
     else
-    {
-        HWND hwnd = GetForegroundWindow();
-        DWORD dwTID = GetWindowThreadProcessId(hwnd, NULL);
-        hKL = GetKeyboardLayout(dwTID);
-    }
-
-    if (IS_IME_HKL(hKL))
-        return hKL;
-
-    if (IS_SPECIAL_HKL(hKL))
-    {
-        INT i;
-        DWORD dwSpecialId = SPECIALIDFROMHKL(hKL);
-        for (i = 0; i < g_cSpecialIds; ++i)
-        {
-            if (g_SpecialIds[i].dwLayoutId == dwSpecialId)
-                return g_SpecialIds[i].hKL;
-        }
-    }
-    else
-    {
-        WORD wLang = LOWORD(hKL);
-        return (HKL)(LONG_PTR)MAKELONG(wLang, wLang);
-    }
-
-    return hKL;
+        return GetKeyboardLayout(0);
 }
 
 static VOID

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -550,8 +550,6 @@ BuildLeftPopupMenu(VOID)
     MENUITEMINFO mii = { sizeof(mii) };
     INT iKL;
 
-    g_cKLs = GetKeyboardLayoutList(ARRAYSIZE(g_ahKLs), g_ahKLs);
-
     for (iKL = 0; iKL < g_cKLs; ++iKL)
     {
         GetKLIDFromHKL(g_ahKLs[iKL], szKLID, ARRAYSIZE(szKLID));
@@ -579,13 +577,6 @@ BuildLeftPopupMenu(VOID)
     CheckMenuItem(hMenu, g_nCurrentLayoutNum, MF_CHECKED);
 
     return hMenu;
-}
-
-static ULONG
-GetMaxLayoutNum(VOID)
-{
-    g_cKLs = GetKeyboardLayoutList(ARRAYSIZE(g_ahKLs), g_ahKLs);
-    return g_cKLs;
 }
 
 BOOL
@@ -672,16 +663,14 @@ UpdateLanguageDisplayCurrent(HWND hwnd, HWND hwndFore)
     return 0;
 }
 
-static UINT GetCurLayoutNum(HKL hKL)
+static UINT GetLayoutNum(HKL hKL)
 {
-    UINT i, nCount;
-    HKL ahKL[256];
+    INT iKL;
 
-    nCount = GetKeyboardLayoutList(ARRAYSIZE(ahKL), ahKL);
-    for (i = 0; i < nCount; ++i)
+    for (iKL = 0; iKL < g_cKLs; ++iKL)
     {
-        if (ahKL[i] == hKL)
-            return i + 1;
+        if (g_ahKLs[iKL] == hKL)
+            return iKL + 1;
     }
 
     return 0;
@@ -834,7 +823,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
                     {
                         dwThreadID = GetWindowThreadProcessId(hwndTarget, NULL);
                         hKL = GetKeyboardLayout(dwThreadID);
-                        uNum = GetCurLayoutNum(hKL);
+                        uNum = GetLayoutNum(hKL);
                         if (uNum != 0)
                             g_nCurrentLayoutNum = uNum;
                     }
@@ -843,9 +832,8 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
                     /* FIXME: CONWND needs special handling */
                     if (bCONWND)
-                    {
                         ActivateLayout(hwnd, g_nCurrentLayoutNum, hwndTargetSave, TRUE);
-                    }
+
                     break;
                 }
 

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -73,7 +73,7 @@ static VOID LoadSpecialIds(VOID)
         return;
     }
 
-    for (dwIndex = 0; dwIndex < 0x100; ++dwIndex)
+    for (dwIndex = 0; dwIndex < 1000; ++dwIndex)
     {
         dwSize = ARRAYSIZE(szKLID);
         if (RegEnumKeyEx(hKey, dwIndex, szKLID, &dwSize, NULL, NULL, NULL, NULL) != ERROR_SUCCESS)

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -42,7 +42,7 @@ UINT ShellHookMessage = 0;
 HINSTANCE hInst;
 HANDLE    hProcessHeap;
 HMODULE   g_hHookDLL = NULL;
-INT       g_nCurrentLayoutNum = -1;
+INT       g_nCurrentLayoutNum = 1;
 HICON     g_hTrayIcon = NULL;
 HWND      g_hwndLastActive = NULL;
 INT       g_cKLs = 0;
@@ -139,12 +139,12 @@ GetKLIDFromHKL(HKL hKL, LPTSTR szKLID, SIZE_T KLIDLength)
     }
 }
 
-static VOID UpdateLayoutList(VOID)
+static VOID UpdateLayoutList(BOOL bResetNum)
 {
     INT iKL;
     HKL hKL;
 
-    if (0 <= (g_nCurrentLayoutNum - 1) && (g_nCurrentLayoutNum - 1) < g_cKLs)
+    if (!bResetNum && 0 <= (g_nCurrentLayoutNum - 1) && (g_nCurrentLayoutNum - 1) < g_cKLs)
     {
         hKL = g_ahKLs[g_nCurrentLayoutNum - 1];
     }
@@ -598,7 +598,7 @@ UpdateLanguageDisplay(HWND hwnd, HKL hKL)
     TCHAR szKLID[MAX_PATH], szLangName[MAX_PATH];
     LANGID LangID;
 
-    UpdateLayoutList();
+    UpdateLayoutList(FALSE);
 
     GetKLIDFromHKL(hKL, szKLID, ARRAYSIZE(szKLID));
     LangID = (LANGID)_tcstoul(szKLID, NULL, 16);
@@ -694,7 +694,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
             LoadSpecialIds();
 
-            UpdateLayoutList();
+            UpdateLayoutList(TRUE);
             AddTrayIcon(hwnd);
 
             ActivateLayout(hwnd, g_nCurrentLayoutNum, NULL, TRUE);
@@ -847,7 +847,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
         {
             if (Message == s_uTaskbarRestart)
             {
-                UpdateLayoutList();
+                UpdateLayoutList(TRUE);
                 AddTrayIcon(hwnd);
                 break;
             }

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -691,8 +691,7 @@ static BOOL RememberLastActive(HWND hwnd, HWND hwndFore)
         return FALSE; /* Special window */
     }
 
-    /* FIXME: CONWND is multithreaded but KLF_SETFORPROCESS and
-              DefWindowProc.WM_INPUTLANGCHANGEREQUEST won't work yet */
+    /* FIXME: CONWND needs special handling */
     if (_tcsicmp(szClass, TEXT("ConsoleWindowClass")) == 0)
     {
         HKL hKL = GetKeyboardLayout(0);
@@ -810,8 +809,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
                     if (hwndTarget == NULL)
                         hwndTarget = g_hwndLastActive;
 
-                    /* FIXME: CONWND is multithreaded but KLF_SETFORPROCESS and
-                              DefWindowProc.WM_INPUTLANGCHANGEREQUEST won't work yet */
+                    /* FIXME: CONWND needs special handling */
                     if (hwndTarget &&
                         GetClassName(hwndTarget, szClass, ARRAYSIZE(szClass)) &&
                         _tcsicmp(szClass, TEXT("ConsoleWindowClass")) == 0)
@@ -832,8 +830,7 @@ WndProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
                     ActivateLayout(hwnd, GetNextLayout(), hwndTarget, TRUE);
 
-                    /* FIXME: CONWND is multithreaded but KLF_SETFORPROCESS and
-                              DefWindowProc.WM_INPUTLANGCHANGEREQUEST won't work yet */
+                    /* FIXME: CONWND needs special handling */
                     if (bCONWND)
                     {
                         ActivateLayout(hwnd, g_nCurrentLayoutNum, hwndTargetSave, TRUE);

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -101,7 +101,10 @@ static VOID LoadSpecialIds(VOID)
         RegCloseKey(hLayoutKey);
 
         if (g_cSpecialIds >= ARRAYSIZE(g_SpecialIds))
+        {
+            OutputDebugStringA("g_SpecialIds is full!");
             break;
+        }
     }
 
     RegCloseKey(hKey);

--- a/base/applications/kbswitch/kbswitch.c
+++ b/base/applications/kbswitch/kbswitch.c
@@ -46,7 +46,7 @@ INT       g_nCurrentLayoutNum = 1;
 HICON     g_hTrayIcon = NULL;
 HWND      g_hwndLastActive = NULL;
 INT       g_cKLs = 0;
-HKL       g_ahKLs[256];
+HKL       g_ahKLs[64];
 
 typedef struct
 {
@@ -55,7 +55,7 @@ typedef struct
     TCHAR szKLID[CCH_LAYOUT_ID + 1];
 } SPECIAL_ID, *PSPECIAL_ID;
 
-SPECIAL_ID g_SpecialIds[128];
+SPECIAL_ID g_SpecialIds[80];
 INT g_cSpecialIds = 0;
 
 static VOID LoadSpecialIds(VOID)


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-13145](https://jira.reactos.org/browse/CORE-13145), [CORE-10667](https://jira.reactos.org/browse/CORE-10667), [CORE-18924](https://jira.reactos.org/browse/CORE-18924)

## Proposed changes

- Use `GetKeyboardLayoutList` to get the keyboard list instead of using `Preload` registry key.
- Get the special IDs from registry to handle special `HKL`s in newly-added `LoadSpecialIds` function.
- Add `GetKLIDFromHKL`, `GetHKLFromLayoutNum`, `UpdateLayoutList`, and `GetKLIDFromLayoutNum` helper functions.

## TODO

- [x] Do tests.

## Screenshots

BootCD:
![VirtualBox_ReactOS_30_04_2023_11_35_14](https://user-images.githubusercontent.com/2107452/235332852-956463d7-511c-41b3-b5fe-e5fc1093c545.png)

LiveCD:
![livecd](https://user-images.githubusercontent.com/2107452/235272539-528842cb-baff-49dc-83ef-a75f7945d406.png)