### PR TITLE
[NTUSER] Remember old KL for Chinese IMEs

### DIFF
--- a/win32ss/user/ntuser/kbdlayout.c
+++ b/win32ss/user/ntuser/kbdlayout.c
@@ -650,14 +650,21 @@ IntImmActivateLayout(
         co_IntSendMessage(hImeWnd, WM_IME_SYSTEM, IMS_ACTIVATELAYOUT, (LPARAM)pKL->hkl);
         UserDerefObjectCo(pImeWnd);
     }
-    else if (pti->spDefaultImc)
+    else
     {
-        /* IME Activation is needed */
-        pti->pClientInfo->CI_flags |= CI_IMMACTIVATE;
+        /* Remember old keyboard layout to switch back for Chinese IMEs */
+        pti->hklPrev = pti->KeyboardLayout->hkl;
+
+        if (pti->spDefaultImc)
+        {
+            /* IME Activation is needed */
+            pti->pClientInfo->CI_flags |= CI_IMMACTIVATE;
+        }
     }
 
     UserAssignmentLock((PVOID*)&(pti->KeyboardLayout), pKL);
     pti->pClientInfo->hKL = pKL->hkl;
+    pti->pClientInfo->CodePage = pKL->CodePage;
 }
 
 static VOID co_IntSetKeyboardLayoutForProcess(PPROCESSINFO ppi, PKL pKL)


### PR DESCRIPTION
## Purpose
Implementing Chinese input...
JIRA issue: [CORE-18950](https://jira.reactos.org/browse/CORE-18950)

## Proposed changes

In `IntImmActivateLayout` function:

- Remember the previous keyboard layout to switch back for Chinese IMEs.
- Set `CodePage`.

## TODO

- [x] Do tests.

## Screenshots

![VirtualBox_ReactOS_02_05_2023_12_31_40](https://user-images.githubusercontent.com/2107452/235574172-de6ee21e-8732-4fbe-9361-fa348ef26bd0.png)
