### PR TITLE
[USER32] Fix F1'97 Demo icon not showing in explorer

### DIFF
--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -715,9 +715,9 @@ static UINT ICO_ExtractIconExW(
             if( !xresdir )
             {
 #ifdef __REACTOS__
-              /* XP/2K3 can decode icons this way. Vista/Win7, cannot. This
-               * handles damaged Resources in 'Icon Group' by using the 'Icon'
-               * resources. Error can occur in older Watcom C/C++ compiles. */
+              /* XP/2K3 can decode icons this way. Vista/7 cannot. This handles
+               * damaged Resources in 'Icon Group' by falling back to 'Icon' resources.
+               * Older Watcom C/C++ compilers can generate such a case */
               const IMAGE_RESOURCE_DIRECTORY *resdir;
               WARN("icon entry %d not found\n", LOWORD(pIconId[i]));
 

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -715,6 +715,9 @@ static UINT ICO_ExtractIconExW(
             if( !xresdir )
             {
 #ifdef __REACTOS__
+              /* XP/2K3 can decode icons this way. Vista/Win7, cannot. This
+               * handles damaged Resources in 'Icon Group' by using the 'Icon'
+               * resources. Error can occur in older Watcom C/C++ compiles. */
               const IMAGE_RESOURCE_DIRECTORY *resdir;
               WARN("icon entry %d not found\n", LOWORD(pIconId[i]));
 

--- a/win32ss/user/user32/misc/exticon.c
+++ b/win32ss/user/user32/misc/exticon.c
@@ -714,9 +714,75 @@ static UINT ICO_ExtractIconExW(
 	    xresdir = find_entry_by_id(iconresdir, LOWORD(pIconId[i]), rootresdir);
             if( !xresdir )
             {
+#ifdef __REACTOS__
+              const IMAGE_RESOURCE_DIRECTORY *resdir;
+              WARN("icon entry %d not found\n", LOWORD(pIconId[i]));
+
+              /* Try to get an icon by walking the files Resource Section */
+              if (iconresdir->NumberOfIdEntries > 0)
+              {
+                  xresent = (const IMAGE_RESOURCE_DIRECTORY_ENTRY*)
+                      (ULONG_PTR)(iconresdir + 1);
+              }
+              else
+              {
+                  RetPtr[i] = 0;
+                  continue;
+              }
+
+              /* Get the Resource Directory */
+              resdir = (const IMAGE_RESOURCE_DIRECTORY *)
+                       ((const char *)rootresdir + xresent->OffsetToDirectory);
+
+              if (resdir->NumberOfIdEntries > 0) // Do we have entries
+              {
+                  xresent = (const IMAGE_RESOURCE_DIRECTORY_ENTRY*)
+                      (ULONG_PTR)(resdir + 1);
+              }
+              else
+              {
+                  RetPtr[i] = 0;
+                  continue;
+              }
+
+              /* Retrieve the data entry and find its address */
+              igdataent = (const IMAGE_RESOURCE_DATA_ENTRY*)
+                  ((const char *)rootresdir + xresent->OffsetToData);
+              idata = RtlImageRvaToVa(RtlImageNtHeader((HMODULE)peimage),
+                  (HMODULE)peimage, igdataent->OffsetToData, NULL);
+              if (!idata)
+              {
+                  RetPtr[i] = 0;
+                  continue;
+              }
+
+              /* Check to see if this looks like an icon bitmap */
+              if (idata[0] == sizeof(BITMAPINFOHEADER))
+              {
+                  BITMAPINFOHEADER bmih;
+                  RtlCopyMemory(&bmih, idata, sizeof(BITMAPINFOHEADER));
+                  /* Do the Width and Height look correct for an icon */
+                  if ((bmih.biWidth * 2) == bmih.biHeight)
+                  {
+                      RetPtr[0] = CreateIconFromResourceEx(idata, igdataent->Size,
+                          TRUE, 0x00030000, cx1, cy1, flags);
+                      if (cx2 && cy2)
+                          RetPtr[1] = CreateIconFromResourceEx(idata, idataent->Size,
+                              TRUE, 0x00030000, cx2, cy2, flags);
+                      ret = 1;  // Set number of icons found
+                      goto end; // Success so Exit
+                  }
+              }
+              else
+              {
+                  RetPtr[i] = 0;
+                  continue;
+              }
+#else
               WARN("icon entry %d not found\n", LOWORD(pIconId[i]));
 	      RetPtr[i]=0;
 	      continue;
+#endif
             }
 	    xresdir = find_entry_default(xresdir, rootresdir);
 	    idataent = (const IMAGE_RESOURCE_DATA_ENTRY*)xresdir;


### PR DESCRIPTION
## Purpose

_Fix the F1'97 Demo program not showing an icon in explorer.._

JIRA issue: [CORE-10726](https://jira.reactos.org/browse/CORE-10726)

## Proposed changes

_If the normal method to get an icon fails, then provide an alternate one._

After patch:
![CORE-10726-OK](https://user-images.githubusercontent.com/32620577/236597769-fb8f0413-f4a3-490a-96f1-b895d4fea92b.png)

Icon shown in W2K3SP2:

![FI97_Icons_In_W2K3SP2](https://github.com/reactos/reactos/assets/32620577/10d050e8-6075-4f73-af24-3d6c63ab9971)
