### PR TITLE
[CMD] Expand wildcard in paths

### DIFF
--- a/base/shell/cmd/misc.c
+++ b/base/shell/cmd/misc.c
@@ -117,9 +117,11 @@ VOID GetPathCase( TCHAR * Path, TCHAR * OutPath)
                 _tcscpy(OutPath, Path);
                 return;
             }
-            _tcscat(TempPath, _T("\\"));
             _tcscat(OutPath, FindFileData.cFileName);
             _tcscat(OutPath, _T("\\"));
+            /* Use the the expanded path as the base for the next
+             * FindFirstFile */
+            _tcscpy(TempPath, OutPath);
             FindClose(hFind);
         }
     }


### PR DESCRIPTION
## Purpose

cmd.exe should expand all wildcards in  a path.

cd \rea*\syst*  should leave you in \reactos\system32

JIRA issue: [CORE-13906](https://jira.reactos.org/browse/CORE-13906)

## Proposed changes
- Pass each expanded path element into FindFirstFile() to expand the full path.