### PR TITLE
[KERNEL32][SDK] RegisterConsoleIME and UnregisterConsoleIME

### DIFF
--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3096,7 +3096,9 @@ IntRegisterConsoleIME(
     return TRUE;
 }
 
-static BOOL IntUnregisterConsoleIME(DWORD dwThreadId)
+static BOOL
+IntUnregisterConsoleIME(
+    _In_ DWORD dwThreadId)
 {
     CONSOLE_API_MESSAGE ApiMessage;
     PCONSOLE_UNREGISTERCONSOLEIME UnregisterConsoleIME = &ApiMessage.Data.UnregisterConsoleIME;

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3098,7 +3098,7 @@ static BOOL IntUnregisterConsoleIME(DWORD dwThreadId)
     CsrClientCallServer((PCSR_API_MESSAGE)&ApiMessage,
                         NULL,
                         CSR_CREATE_API_NUMBER(CONSRV_SERVERDLL_INDEX, ConsolepUnregisterConsoleIME),
-                        sizeof(*pUnregisterConsoleIME));
+                        sizeof(*UnregisterConsoleIME));
     if (!NT_SUCCESS(ApiMessage.Status))
     {
         BaseSetLastNTError(ApiMessage.Status);

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3071,6 +3071,7 @@ IntRegisterConsoleIME(
                         CaptureBuffer,
                         CSR_CREATE_API_NUMBER(CONSRV_SERVERDLL_INDEX, ConsolepRegisterConsoleIME),
                         sizeof(*RegisterConsoleIME));
+
     CsrFreeCaptureBuffer(CaptureBuffer);
 
     if (!NT_SUCCESS(ApiMessage.Status))

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3066,6 +3066,7 @@ IntRegisterConsoleIME(
                             pDesktop,
                             cbDesktop,
                             (PVOID*)&RegisterConsoleIME->pDesktop);
+
     CsrClientCallServer((PCSR_API_MESSAGE)&ApiMessage,
                         CaptureBuffer,
                         CSR_CREATE_API_NUMBER(CONSRV_SERVERDLL_INDEX, ConsolepRegisterConsoleIME),

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3150,7 +3150,7 @@ SetConsoleOS2OemFormat(BOOL bUnknown)
     return FALSE;
 }
 
-/* This function will be called from CONIME.EXE */
+/* This function is called by CONIME.EXE */
 BOOL
 WINAPI
 DECLSPEC_HOTPATCH

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3124,7 +3124,9 @@ IntUnregisterConsoleIME(
 BOOL
 WINAPI
 DECLSPEC_HOTPATCH
-RegisterConsoleIME(HWND hWnd, LPDWORD pdwAttachToThreadId)
+RegisterConsoleIME(
+    _In_ HWND hWnd,
+    _Out_opt_ LPDWORD pdwAttachToThreadId)
 {
     return IntRegisterConsoleIME(hWnd,
                                  GetCurrentThreadId(),

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3048,8 +3048,7 @@ IntRegisterConsoleIME(
         cbDesktop = NtCurrentPeb()->ProcessParameters->DesktopInfo.Length;
     }
 
-    if (cbDesktop > (MAX_PATH + 1) * sizeof(WCHAR))
-        cbDesktop = (MAX_PATH + 1) * sizeof(WCHAR);
+    cbDesktop = min(cbDesktop, (MAX_PATH + 1) * sizeof(WCHAR));
 
     RegisterConsoleIME->ConsoleHandle = NtCurrentPeb()->ProcessParameters->ConsoleHandle;
     RegisterConsoleIME->hWnd = hWnd;

--- a/dll/win32/kernel32/client/console/console.c
+++ b/dll/win32/kernel32/client/console/console.c
@@ -3119,7 +3119,7 @@ IntUnregisterConsoleIME(
     return TRUE;
 }
 
-/* This function will be called from CONIME.EXE */
+/* This function is called by CONIME.EXE */
 BOOL
 WINAPI
 DECLSPEC_HOTPATCH

--- a/sdk/include/reactos/subsys/win/conmsg.h
+++ b/sdk/include/reactos/subsys/win/conmsg.h
@@ -723,8 +723,6 @@ typedef struct _CONSOLE_SETICON
     HICON  IconHandle;
 } CONSOLE_SETICON, *PCONSOLE_SETICON;
 
-
-
 typedef struct _CONSOLE_ADDGETALIAS
 {
     HANDLE  ConsoleHandle;
@@ -894,6 +892,22 @@ typedef struct _CONSOLE_REGISTERVDM
     PVOID  VDMBuffer;
 } CONSOLE_REGISTERVDM, *PCONSOLE_REGISTERVDM;
 
+typedef struct _CONSOLE_REGISTERCONSOLEIME
+{
+    HANDLE ConsoleHandle;
+    HWND hWnd;
+    DWORD dwThreadId;
+    DWORD cbDesktop;
+    LPWSTR pDesktop;
+    DWORD dwAttachTo;
+} CONSOLE_REGISTERCONSOLEIME, *PCONSOLE_REGISTERCONSOLEIME;
+
+typedef struct _CONSOLE_UNREGISTERCONSOLEIME
+{
+    HANDLE ConsoleHandle;
+    DWORD dwThreadId;
+} CONSOLE_UNREGISTERCONSOLEIME, *PCONSOLE_UNREGISTERCONSOLEIME;
+
 typedef struct _CONSOLE_API_MESSAGE
 {
     PORT_MESSAGE Header;
@@ -1002,6 +1016,10 @@ typedef struct _CONSOLE_API_MESSAGE
 
         /* Virtual DOS Machine */
         CONSOLE_REGISTERVDM RegisterVDMRequest;
+
+        /* Console IME */
+        CONSOLE_REGISTERCONSOLEIME RegisterConsoleIME;
+        CONSOLE_UNREGISTERCONSOLEIME UnregisterConsoleIME;
     } Data;
 } CONSOLE_API_MESSAGE, *PCONSOLE_API_MESSAGE;
 

--- a/sdk/include/reactos/subsys/win/conmsg.h
+++ b/sdk/include/reactos/subsys/win/conmsg.h
@@ -723,6 +723,8 @@ typedef struct _CONSOLE_SETICON
     HICON  IconHandle;
 } CONSOLE_SETICON, *PCONSOLE_SETICON;
 
+
+
 typedef struct _CONSOLE_ADDGETALIAS
 {
     HANDLE  ConsoleHandle;
@@ -899,7 +901,7 @@ typedef struct _CONSOLE_REGISTERCONSOLEIME
     DWORD dwThreadId;
     DWORD cbDesktop;
     LPWSTR pDesktop;
-    DWORD dwAttachTo;
+    DWORD dwAttachToThreadId;
 } CONSOLE_REGISTERCONSOLEIME, *PCONSOLE_REGISTERCONSOLEIME;
 
 typedef struct _CONSOLE_UNREGISTERCONSOLEIME


### PR DESCRIPTION
## Purpose

The `conime.exe` program exists in WinXP/Win2k3 and it realizes Console IME.
`conime.exe` calls `kernel32!RegisterConsoleIME` and `kernel32!UnregisterConsoleIME`.
To realize Console IME, these two functions are required.
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

![image](https://user-images.githubusercontent.com/2107452/236621848-84288813-2c2b-43f0-86ea-740aca8ad47c.png)

## Proposed changes

- Add `IntRegisterConsoleIME` and `IntUnregisterConsoleIME` helper functions.
- Implement `RegisterConsoleIME` and `UnregisterConsoleIME` API functions.
- Add `CONSOLE_REGISTERCONSOLEIME` and `CONSOLE_UNREGISTERCONSOLEIME` structures to `sdk/include/reactos/subsys/win/conmsg.h`.
