### PR TITLE
[NTUSER] Implement THREADSTATE_CHECKCONIME

### DIFF
--- a/win32ss/user/ntuser/misc.c
+++ b/win32ss/user/ntuser/misc.c
@@ -336,7 +336,7 @@ NtUserGetThreadState(
          ret = (gpidLogon == PsGetCurrentProcessId());
          break;
       case THREADSTATE_CHECKCONIME:
-         /* FIXME */
+         ret = (IntTID2PTI(UlongToHandle(pti->rpdesk->dwConsoleThreadId)) == pti);
          break;
    }
 


### PR DESCRIPTION
## Purpose
Implementing Console IME...
JIRA issue: [CORE-11700](https://jira.reactos.org/browse/CORE-11700)

## Proposed changes

- Add `THREADSTATE_CHECKCONIME` handling in `NtUserGetThreadState` function.
