### PR TITLE
Setting up CodeQL scanning

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,9 +45,6 @@ jobs:
         chmod +x build_rosbe_ci.sh
         ./build_rosbe_ci.sh ${{github.workspace}}/RosBE-CI
     
-    - name: Install ccache
-      run: sudo apt install ccache
-    
     - name: Install LLVM
       if: ${{ matrix.compiler == 'clang' }}
       run: |
@@ -63,7 +60,10 @@ jobs:
         root-reserve-mb: 512
         swap-size-mb: 1024
         remove-dotnet: 'true'
-
+        remove-android: 'true'
+        remove-haskell: 'true'
+        remove-docker-images: 'true'
+        
     - name: Source checkout
       uses: actions/checkout@v2
       with:
@@ -75,27 +75,8 @@ jobs:
         languages: ${{ matrix.language }}
         queries: security-extended
 
-    - name: Set up cache for ccache
-      uses: actions/cache@v2
-      with:
-        path: ccache
-        key: ccache-${{matrix.compiler}}-${{matrix.arch}}-${{matrix.config}}-${{github.sha}}
-        restore-keys: |
-          ccache-${{matrix.compiler}}-${{matrix.arch}}-
-
-    - name: Set ccache settings
-      run: |
-        echo "CCACHE_BASEDIR=${{github.workspace}}" >> $GITHUB_ENV
-        echo "CCACHE_DIR=${{github.workspace}}/ccache" >> $GITHUB_ENV
-        echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
-        echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
-
-    - name: Ease ccache compiler check (GCC)
-      if: ${{ matrix.compiler == 'gcc' }}
-      run: echo "CCACHE_COMPILERCHECK=string:${{steps.get_rosbe_spec.outputs.git-sha}}-${{hashfiles('./build_rosbe_ci.sh')}}" >> $GITHUB_ENV
-    
     - name: Configure
-      run: echo 'cmake -S ${{github.workspace}}/src -B ${{github.workspace}}/build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-${{matrix.compiler}}.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_CCACHE=1 ${{env.D_CLANG_VERSION}}' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
+      run: echo 'cmake -S ${{github.workspace}}/src -B ${{github.workspace}}/build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-${{matrix.compiler}}.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} ${{env.D_CLANG_VERSION}}' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
     
     - name: Build
       run: echo 'cmake --build ${{github.workspace}}/build -- -k0' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ${{matrix.os}}
+    runs-on: 'ubuntu-latest'
     permissions:
       actions: read
       contents: read
@@ -19,61 +19,87 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
-        toolset: ['14.2']
-        arch: [i386, amd64]
+        compiler: [clang]
+        arch: [amd64]
         config: [Release]
         language: ['cpp']
     steps:
-    - name: configure Pagefile
-      uses: al-cheb/configure-pagefile-action@v1.2
-      with:
-          minimum-size: 4GB
-          maximum-size: 16GB
-          disk-root: "D:"
-
-    - name: Install ninja
-      run: choco install -y ninja
-    
-    - name: Install Flex & Bison
+    - name: Get RosBE build specifics
+      id: get_rosbe_spec
       run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        gcc -march=native -Q --help=target | grep "\-march= " | awk '{print $NF}'
+        echo ::set-output name=march-sha::$(gcc -march=native -Q --help=target | sha1sum | awk '{print $1}')
+        echo ::set-output name=git-sha::$(git ls-remote https://github.com/zefklop/RosBE.git | grep unix_amd64 | awk '{print $1}')
+        wget https://gist.githubusercontent.com/zefklop/b2d6a0b470c70183e93d5285a03f5899/raw/build_rosbe_ci.sh
     
-    - name: Activate VS cmd (x86)
-      if: ${{ matrix.arch == 'i386' }}
-      uses: ilammy/msvc-dev-cmd@v1
+    - name: Get RosBE
+      id: get_rosbe
+      uses: actions/cache@v2
       with:
-        arch: amd64_x86
-        toolset: ${{matrix.toolset}}
-        
-    - name: Activate VS cmd (amd64)
-      if: ${{ matrix.arch == 'amd64' }}
-      uses: ilammy/msvc-dev-cmd@v1
+        path: RosBE-CI
+        key: RosBE-CI-${{runner.os}}-${{steps.get_rosbe_spec.outputs.march-sha}}-${{steps.get_rosbe_spec.outputs.git-sha}}-${{hashfiles('./build_rosbe_ci.sh')}}
+    
+    - name: Compile RosBE
+      if: ${{ steps.get_rosbe.outputs.cache-hit != 'true' }}
+      run: |
+        chmod +x build_rosbe_ci.sh
+        ./build_rosbe_ci.sh ${{github.workspace}}/RosBE-CI
+    
+    - name: Install ccache
+      run: sudo apt install ccache
+    
+    - name: Install LLVM
+      if: ${{ matrix.compiler == 'clang' }}
+      run: |
+        export LLVM_VERSION=13
+        wget https://apt.llvm.org/llvm.sh
+        chmod +x llvm.sh
+        sudo ./llvm.sh $LLVM_VERSION
+        echo "D_CLANG_VERSION=-DCLANG_VERSION=$LLVM_VERSION" >> $GITHUB_ENV
+
+    - name: Maximize build space
+      uses: easimon/maximize-build-space@master
       with:
-        arch: amd64
-        toolset: ${{matrix.toolset}}
-        
+        root-reserve-mb: 512
+        swap-size-mb: 1024
+        remove-dotnet: 'true'
+
     - name: Source checkout
       uses: actions/checkout@v2
       with:
         path: src
-        
+
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
         queries: security-extended
+
+    - name: Set up cache for ccache
+      uses: actions/cache@v2
+      with:
+        path: ccache
+        key: ccache-${{matrix.compiler}}-${{matrix.arch}}-${{matrix.config}}-${{github.sha}}
+        restore-keys: |
+          ccache-${{matrix.compiler}}-${{matrix.arch}}-
+
+    - name: Set ccache settings
+      run: |
+        echo "CCACHE_BASEDIR=${{github.workspace}}" >> $GITHUB_ENV
+        echo "CCACHE_DIR=${{github.workspace}}/ccache" >> $GITHUB_ENV
+        echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
+        echo "CCACHE_SLOPPINESS=time_macros" >> $GITHUB_ENV
+
+    - name: Ease ccache compiler check (GCC)
+      if: ${{ matrix.compiler == 'gcc' }}
+      run: echo "CCACHE_COMPILERCHECK=string:${{steps.get_rosbe_spec.outputs.git-sha}}-${{hashfiles('./build_rosbe_ci.sh')}}" >> $GITHUB_ENV
     
     - name: Configure
-      run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_ROSTESTS=0 -DENABLE_ROSAPPS=0
+      run: echo 'cmake -S ${{github.workspace}}/src -B ${{github.workspace}}/build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-${{matrix.compiler}}.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_CCACHE=1 ${{env.D_CLANG_VERSION}}' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
     
     - name: Build
-      run: cmake --build build -- -k0
-    
+      run: echo 'cmake --build ${{github.workspace}}/build -- -k0' | ${{github.workspace}}/RosBE-CI/RosBE.sh . 0 ${{matrix.arch}}
+  
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
       with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,80 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ${{matrix.os}}
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest]
+        toolset: ['14.2']
+        arch: [i386, amd64]
+        config: [Release]
+        language: ['cpp']
+    steps:
+    - name: configure Pagefile
+      uses: al-cheb/configure-pagefile-action@v1.2
+      with:
+          minimum-size: 4GB
+          maximum-size: 16GB
+          disk-root: "D:"
+
+    - name: Install ninja
+      run: choco install -y ninja
+    
+    - name: Install Flex & Bison
+      run: |
+        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+        7z x flexbison.7z -O${{github.workspace}}\bin
+        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+    
+    - name: Activate VS cmd (x86)
+      if: ${{ matrix.arch == 'i386' }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: amd64_x86
+        toolset: ${{matrix.toolset}}
+        
+    - name: Activate VS cmd (amd64)
+      if: ${{ matrix.arch == 'amd64' }}
+      uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: amd64
+        toolset: ${{matrix.toolset}}
+        
+    - name: Source checkout
+      uses: actions/checkout@v2
+      with:
+        path: src
+        
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-extended
+    
+    - name: Configure
+      run: cmake -S src -B build -G Ninja -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=${{matrix.arch}} -DCMAKE_BUILD_TYPE=${{matrix.config}} -DENABLE_ROSTESTS=0 -DENABLE_ROSAPPS=0
+    
+    - name: Build
+      run: cmake --build build -- -k0
+    
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Purpose

This enables GitHub's CodeQL static analysis scanning for the repository. It's a slightly modified copy of the build workflow for msvc to make it smaller.

I hope this will be helpful in finding security issues in the code as they arise.

Maybe adding [Microsoft's driver queries for CodeQL](https://github.com/microsoft/Windows-Driver-Developer-Supplemental-Tools) would provide some additional value.

## Proposed changes

- a new workflow 