### PR TITLE
[SHELL32] Revert CDefView::FillFileMenu

### DIFF
--- a/dll/win32/shell32/CDefView.cpp
+++ b/dll/win32/shell32/CDefView.cpp
@@ -1357,7 +1357,7 @@ HRESULT CDefView::FillFileMenu()
         m_pFileMenu.Release();
     }
     /* Store the context menu in m_pFileMenu and keep it in order to invoke the selected command later on */
-    HRESULT hr = GetItemObject((m_cidl ? SVGIO_SELECTION : SVGIO_BACKGROUND), IID_PPV_ARG(IContextMenu, &m_pFileMenu));
+    HRESULT hr = GetItemObject(SVGIO_SELECTION, IID_PPV_ARG(IContextMenu, &m_pFileMenu));
     if (FAILED_UNEXPECTEDLY(hr))
         return hr;
 


### PR DESCRIPTION
## Purpose

Revert File menu of Explorer Cabinet that had been changed at https://github.com/reactos/reactos/commit/1cf564c25f532c32f9fae891f17a70e62d5c1c14.

JIRA issue: [CORE-9467](https://jira.reactos.org/browse/CORE-9467), [CORE-18429](https://jira.reactos.org/browse/CORE-18429), [CORE-11797](https://jira.reactos.org/browse/CORE-11797)

## Proposed changes

- Revert `CDefView::FillFileMenu`.