### PR TITLE
[SHELL32] Fix for shlexec.cpp regressions

### DIFF
--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2125,7 +2125,7 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             lpFile = wfileName;
         }
         /* We have to test sei instead of sei_tmp because sei_tmp had its
-         * input fMask modifed above in SHELL_translate_idlist.
+         * input fMask modified above in SHELL_translate_idlist.
          * This code is needed to handle the case where we only have an
          * lpIDList with multiple CLSID/PIDL's (not 'My Computer' only) */
         else if ((sei->fMask & SEE_MASK_IDLIST) == SEE_MASK_IDLIST)

--- a/dll/win32/shell32/shlexec.cpp
+++ b/dll/win32/shell32/shlexec.cpp
@@ -2124,21 +2124,12 @@ static BOOL SHELL_execute(LPSHELLEXECUTEINFOW sei, SHELL_ExecuteW32 execfunc)
             *end = L'\0';
             lpFile = wfileName;
         }
-        else if (!PathIsDirectoryW(wszApplicationName) &&
-                 !PathIsExeW(wszApplicationName) &&
-                 (sei_tmp.fMask & SEE_MASK_INVOKEIDLIST) != SEE_MASK_INVOKEIDLIST &&
-                 (sei_tmp.fMask & SEE_MASK_HASLINKNAME) != SEE_MASK_HASLINKNAME &&
-                 (sei_tmp.fMask & SEE_MASK_FLAG_NO_UI) != SEE_MASK_FLAG_NO_UI)
+        /* We have to test sei instead of sei_tmp because sei_tmp had its
+         * input fMask modifed above in SHELL_translate_idlist.
+         * This code is needed to handle the case where we only have an
+         * lpIDList with multiple CLSID/PIDL's (not 'My Computer' only) */
+        else if ((sei->fMask & SEE_MASK_IDLIST) == SEE_MASK_IDLIST)
         {
-            /* This handles the case where wszApplicationName contains a
-             * non-double-quoted executable followed by one or more spaces
-             * and then followed by a double-quoted parameter.
-             * Example: (single quotes used to enclose strings)
-             * (In)  wszApplicationName = 'explorer.exe "C:\Program Files"'
-             * (In)  wszParameters      = ''
-             * (out) wszApplicationName = 'explorer.exe'
-             * (Out) wszParameters      = '"C:\Program Files"'
-             */
             WCHAR buffer[MAX_PATH], xlpFile[MAX_PATH];
             LPWSTR space, s;
 

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -498,8 +498,8 @@ static void test_sei_lpIDList()
     ShellExecInfo.lpIDList = lpBytes;
 
     Result = ShellExecuteExW(&ShellExecInfo);
-    ok(Result == TRUE, "ShellExecuteEx lpIDList 'C:\\' failed.\n");
-    trace("sei_lpIDList returned: %s.\n", Result ? "SUCCESS" : "FAILURE");
+    ok(Result == TRUE, "ShellExecuteEx lpIDList 'C:\\' failed\n");
+    trace("sei_lpIDList returned: %s\n", Result ? "SUCCESS" : "FAILURE");
     if (Result)
     {
         Sleep(700);

--- a/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
+++ b/modules/rostests/apitests/shell32/ShellExecuteEx.cpp
@@ -467,6 +467,48 @@ static void test_properties()
     ok_ptr(info.hInstApp, (HINSTANCE)2);
 }
 
+static void test_sei_lpIDList()
+{
+    /* This tests ShellExecuteEx with lpIDList for explorer C:\ */
+
+    /* ITEMIDLIST for CLSID of 'My Computer' followed by PIDL for 'C:\' */
+    BYTE lpitemidlist[30] = { 0x14, 0, 0x1f, 0, 0xe0, 0x4f, 0xd0, 0x20, 0xea,
+    0x3a, 0x69, 0x10, 0xa2, 0xd8, 0x08, 0, 0x2b, 0x30, 0x30, 0x9d, // My Computer
+    0x8, 0, 0x23, 0x43, 0x3a, 0x5c, 0x5c, 0, 0, 0,}; // C:\\ + NUL-NUL ending
+    BYTE *lpBytes;
+    lpBytes = lpitemidlist;
+
+    SHELLEXECUTEINFOW ShellExecInfo;
+    BOOL Result;
+    STARTUPINFOW si;
+    PROCESS_INFORMATION pi;
+    HWND hWnd;
+
+    ZeroMemory( &si, sizeof(si) );
+    si.cb = sizeof(si);
+    ZeroMemory( &pi, sizeof(pi) );
+
+    ZeroMemory(&ShellExecInfo, sizeof(ShellExecInfo));
+    ShellExecInfo.cbSize = sizeof(ShellExecInfo);
+    ShellExecInfo.fMask = SEE_MASK_IDLIST;
+    ShellExecInfo.hwnd = NULL;
+    ShellExecInfo.nShow = SW_SHOWNORMAL;
+    ShellExecInfo.lpFile = NULL;
+    ShellExecInfo.lpDirectory = NULL;
+    ShellExecInfo.lpIDList = lpBytes;
+
+    Result = ShellExecuteExW(&ShellExecInfo);
+    ok(Result == TRUE, "ShellExecuteEx lpIDList 'C:\\' failed.\n");
+    trace("sei_lpIDList returned: %s.\n", Result ? "SUCCESS" : "FAILURE");
+    if (Result)
+    {
+        Sleep(700);
+        // Terminate Window
+        hWnd = FindWindowW(L"CabinetWClass", L"Local Disk (C:)");
+        PostMessage(hWnd, WM_SYSCOMMAND, SC_CLOSE, 0);
+    }
+}
+
 START_TEST(ShellExecuteEx)
 {
     DoAppPathTest();
@@ -475,4 +517,7 @@ START_TEST(ShellExecuteEx)
 
     DoWaitForWindow(CLASSNAME, CLASSNAME, TRUE, TRUE);
     Sleep(100);
+
+    test_sei_lpIDList();
+
 }


### PR DESCRIPTION
## Purpose

_Revert https://github.com/reactos/reactos/commit/0f16d44b660266130f5c0807c01d01cfaa6e685d._

JIRA issue: [CORE-18967](https://jira.reactos.org/browse/CORE-18967)

## Proposed changes

_Add conditional 'if' to code so that it is only executed when needed._

Testbot results:

[shlexec-cpp-05.patch](https://jira.reactos.org/secure/attachment/65772/65772_shlexec-cpp-05.patch) JID65772 on top of 0.4.15-dev-6010-g30bc0b6

VBox: https://reactos.org/testman/compare.php?ids=87117,87120 LGTM
KVM: https://reactos.org/testman/compare.php?ids=87116,87119 LGTM

All three (3) "blocks" issues checked and appear OK.