### PR TITLE
[USER32][WIN32K] Fix access to window extra bytes

### DIFF
--- a/win32ss/user/ntuser/class.c
+++ b/win32ss/user/ntuser/class.c
@@ -34,7 +34,7 @@ static NTSTATUS IntDeregisterClassAtom(IN RTL_ATOM Atom);
 
 REGISTER_SYSCLASS DefaultServerClasses[] =
 {
-  { ((PWSTR)((ULONG_PTR)(WORD)(0x8001))),
+  { ((PWSTR)WC_DESKTOP),
     CS_GLOBALCLASS|CS_DBLCLKS,
     NULL, // Use User32 procs
     sizeof(ULONG)*2,
@@ -43,19 +43,19 @@ REGISTER_SYSCLASS DefaultServerClasses[] =
     FNID_DESKTOP,
     ICLS_DESKTOP
   },
-  { ((PWSTR)((ULONG_PTR)(WORD)(0x8003))),
+  { ((PWSTR)WC_SWITCH),
     CS_VREDRAW|CS_HREDRAW|CS_SAVEBITS,
     NULL, // Use User32 procs
-    sizeof(LONG),
+    sizeof(LONG_PTR), // See user32_apitest GetClassInfo, 0: Pointer to ALTTABINFO
     (HICON)OCR_NORMAL,
     NULL,
     FNID_SWITCH,
     ICLS_SWITCH
   },
-  { ((PWSTR)((ULONG_PTR)(WORD)(0x8000))),
+  { ((PWSTR)WC_MENU),
     CS_DBLCLKS|CS_SAVEBITS|CS_DROPSHADOW,
     NULL, // Use User32 procs
-    sizeof(LONG),
+    16, // See user32_apitest GetClassInfo, PopupMenuWndProcW
     (HICON)OCR_NORMAL,
     (HBRUSH)(COLOR_MENU + 1),
     FNID_MENU,
@@ -81,7 +81,7 @@ REGISTER_SYSCLASS DefaultServerClasses[] =
     ICLS_TOOLTIPS
   },
 #endif
-  { ((PWSTR)((ULONG_PTR)(WORD)(0x8004))), // IconTitle is here for now...
+  { ((PWSTR)WC_ICONTITLE), // IconTitle is here for now...
     0,
     NULL, // Use User32 procs
     0,

--- a/win32ss/user/ntuser/window.c
+++ b/win32ss/user/ntuser/window.c
@@ -4148,7 +4148,7 @@ NtUserSetWindowWord(HWND hWnd, INT Index, WORD NewValue)
 
    if ((ULONG)Index > (Window->cbwndExtra - sizeof(WORD)))
    {
-      EngSetLastError(ERROR_INVALID_PARAMETER);
+      EngSetLastError(ERROR_INVALID_INDEX);
       RETURN( 0);
    }
 

--- a/win32ss/user/user32/windows/class.c
+++ b/win32ss/user/user32/windows/class.c
@@ -1829,7 +1829,8 @@ SetWindowWord ( HWND hWnd,int nIndex,WORD wNewWord )
         }
         break;
     }
-    return (WORD)NtUserSetWindowLongPtr(hWnd, nIndex, wNewWord, FALSE);
+    /* DO NOT USE NtUserSetWindowLong(Ptr)! */
+    return NtUserSetWindowWord(hWnd, nIndex, wNewWord);
 }
 
 /*
@@ -1843,7 +1844,8 @@ SetWindowLongA(
   int nIndex,
   LONG dwNewLong)
 {
-    return (LONG)NtUserSetWindowLongPtr(hWnd, nIndex, dwNewLong, TRUE);
+    /* DO NOT USE NtUserSetWindowLongPtr! */
+    return NtUserSetWindowLong(hWnd, nIndex, dwNewLong, TRUE);
 }
 
 /*
@@ -1856,7 +1858,8 @@ SetWindowLongW(
   int nIndex,
   LONG dwNewLong)
 {
-    return (LONG)NtUserSetWindowLongPtr(hWnd, nIndex, dwNewLong, FALSE);
+    /* DO NOT USE NtUserSetWindowLongPtr! */
+    return NtUserSetWindowLong(hWnd, nIndex, dwNewLong, FALSE);
 }
 
 #ifdef _WIN64


### PR DESCRIPTION
## Purpose

Fixes access to extra space in window classes on x64. Fixes a few tests/crashes on x64.

## Proposed changes
- [USER32] Fix SetWindowWord/Long (cannot use NtUserSetWindowLongPtr!)
- [WIN32K] Fix WindowExtra for some server-side classes

## Tests
GCC x86 KVM: https://reactos.org/testman/compare.php?ids=87186,87189,87195,87199,87212
MSVC x64: https://reactos.org/testman/compare.php?ids=87169,87175,87180,87184,87165

## Result
On x86:
- ✅ user32:GetSetWindowInt: 7 tests fixed

On x64:
- ✅ advapi32:eventlog: crash fixed
- ✅ comctl32:tooltips: 62 tests fixed
- ✅ dinput8:device: 2 more tests run, 1 test fixed
- ❓ gdi32:font: 758 tests less executed
- ✅ gdiplus:font: 2 tests fixed
- ✅ user32:GetClassInfo: 1 test fixed
- ✅ user32:GetSetWindowInt: 13 tests fixed
- ❌ user32:msg_focus: 1 test broken
- ✅ user32:msg_mdi: crash fixed
- ❓ user32:msg_paint: 7 tests less executed
