### PR TITLE
[KERNEL32] Implement GetPhysicallyInstalledSystemMemory

### DIFF
--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -429,9 +429,7 @@ GetPhysicallyInstalledSystemMemory(PULONGLONG TotalMemoryInKilobytes)
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
 
-    if (!GlobalMemoryStatusEx( &status )) {
-        return FALSE;
-    }
+    if (!GlobalMemoryStatusEx(&status)) return FALSE;
 
     *TotalMemoryInKilobytes = status.ullTotalPhys / 1024;
     return TRUE;

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -414,6 +414,30 @@ GetNumaAvailableMemoryNode(IN UCHAR Node,
 }
 
 /*
+ * @implemented
+ */
+BOOL
+WINAPI
+GetPhysicallyInstalledSystemMemory(PULONGLONG TotalMemoryInKilobytes)
+{
+    if (TotalMemoryInKilobytes == NULL)
+    {
+        SetLastError(ERROR_INVALID_PARAMETER);
+        return FALSE;
+    }
+
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+
+    if (!GlobalMemoryStatusEx( &status )) {
+        return FALSE;
+    }
+
+    *TotalMemoryInKilobytes = status.ullTotalPhys / 1024;
+    return TRUE;
+}
+
+/*
  * @unimplemented
  */
 DWORD
@@ -557,6 +581,7 @@ GetSystemFirmwareTable(IN DWORD FirmwareTableProviderSignature,
                                    SystemFirmwareTable_Get);
 }
 
+
 /*
  * @unimplemented
  */
@@ -594,3 +619,4 @@ GetCurrentPackageId(UINT32 *BufferLength,
     STUB;
     return APPMODEL_ERROR_NO_PACKAGE;
 }
+

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -426,10 +426,9 @@ GetPhysicallyInstalledSystemMemory(PULONGLONG TotalMemoryInKilobytes)
         return FALSE;
     }
 
-    MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
-
-    if (!GlobalMemoryStatusEx(&status)) return FALSE;
+    if (!GlobalMemoryStatusEx(&status))
+        return FALSE;
 
     *TotalMemoryInKilobytes = status.ullTotalPhys / 1024;
     return TRUE;

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -420,6 +420,8 @@ BOOL
 WINAPI
 GetPhysicallyInstalledSystemMemory(PULONGLONG TotalMemoryInKilobytes)
 {
+    MEMORYSTATUSEX status;
+
     if (TotalMemoryInKilobytes == NULL)
     {
         SetLastError(ERROR_INVALID_PARAMETER);

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -422,6 +422,7 @@ GetPhysicallyInstalledSystemMemory(
     _Out_ PULONGLONG TotalMemoryInKilobytes)
 {
     DPRINT1("GetPhysicallyInstalledSystemMemory() does not work correctly > 4 GB RAM");
+    
     MEMORYSTATUSEX status;
 
     if (TotalMemoryInKilobytes == NULL)

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -418,7 +418,8 @@ GetNumaAvailableMemoryNode(IN UCHAR Node,
  */
 BOOL
 WINAPI
-GetPhysicallyInstalledSystemMemory(PULONGLONG TotalMemoryInKilobytes)
+GetPhysicallyInstalledSystemMemory(
+    _Out_ PULONGLONG TotalMemoryInKilobytes)
 {
     MEMORYSTATUSEX status;
 

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -421,6 +421,7 @@ WINAPI
 GetPhysicallyInstalledSystemMemory(
     _Out_ PULONGLONG TotalMemoryInKilobytes)
 {
+    DPRINT1("GetPhysicallyInstalledSystemMemory() does not work correctly > 4 GB RAM");
     MEMORYSTATUSEX status;
 
     if (TotalMemoryInKilobytes == NULL)

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -421,7 +421,7 @@ WINAPI
 GetPhysicallyInstalledSystemMemory(
     _Out_ PULONGLONG TotalMemoryInKilobytes)
 {
-    DPRINT1("GetPhysicallyInstalledSystemMemory() does not work correctly > 4 GB RAM");
+    DPRINT1("GetPhysicallyInstalledSystemMemory() does not work correctly > 4 GB RAM\n");
     
     MEMORYSTATUSEX status;
 

--- a/dll/win32/kernel32/client/sysinfo.c
+++ b/dll/win32/kernel32/client/sysinfo.c
@@ -579,7 +579,6 @@ GetSystemFirmwareTable(IN DWORD FirmwareTableProviderSignature,
                                    SystemFirmwareTable_Get);
 }
 
-
 /*
  * @unimplemented
  */

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -543,7 +543,7 @@
 @ stdcall GetNumberOfConsoleMouseButtons(ptr)
 @ stdcall GetOEMCP()
 @ stdcall GetOverlappedResult(long ptr ptr long)
-@ stub -version=0x600+ GetPhysicallyInstalledSystemMemory
+@ stdcall GetPhysicallyInstalledSystemMemory(long ptr)
 @ stdcall GetPriorityClass(long)
 @ stdcall GetPrivateProfileIntA(str str long str)
 @ stdcall GetPrivateProfileIntW(wstr wstr long wstr)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -543,7 +543,7 @@
 @ stdcall GetNumberOfConsoleMouseButtons(ptr)
 @ stdcall GetOEMCP()
 @ stdcall GetOverlappedResult(long ptr ptr long)
-@ stdcall GetPhysicallyInstalledSystemMemory(long ptr)
+@ stdcall -version=0x600+ GetPhysicallyInstalledSystemMemory(long ptr)
 @ stdcall GetPriorityClass(long)
 @ stdcall GetPrivateProfileIntA(str str long str)
 @ stdcall GetPrivateProfileIntW(wstr wstr long wstr)

--- a/dll/win32/kernel32/kernel32.spec
+++ b/dll/win32/kernel32/kernel32.spec
@@ -543,7 +543,7 @@
 @ stdcall GetNumberOfConsoleMouseButtons(ptr)
 @ stdcall GetOEMCP()
 @ stdcall GetOverlappedResult(long ptr ptr long)
-@ stdcall -version=0x600+ GetPhysicallyInstalledSystemMemory(long ptr)
+@ stdcall -version=0x600+ GetPhysicallyInstalledSystemMemory(ptr)
 @ stdcall GetPriorityClass(long)
 @ stdcall GetPrivateProfileIntA(str str long str)
 @ stdcall GetPrivateProfileIntW(wstr wstr long wstr)


### PR DESCRIPTION
## Purpose

I implemented GetPhysicallyInstalledSystemMemory.

This implementation is not perfect on systems with more RAM installed than the OS can use.

A more correct implementation would use SMBIOS but the specific field is now obsolete and ReactOS does not have support for it.

https://www.dmtf.org/sites/default/files/standards/documents/DSP0134_3.4.0a.pdf

## Proposed changes

 
- GetPhysicallyInstalledSystemMemory
