### PR TITLE
[WIN32K] Do not try to free a unicode string that is an atom

### DIFF
--- a/win32ss/user/ntuser/cursoricon.c
+++ b/win32ss/user/ntuser/cursoricon.c
@@ -1665,7 +1665,8 @@ Exit:
     /* Additional cleanup on failure */
     if (bResult == FALSE)
     {
-        if (ustrRsrc.Buffer != NULL)
+        if ((ustrRsrc.Buffer != NULL) &&
+            !IS_ATOM(ustrRsrc.Buffer))
         {
             ExFreePoolWithTag(ustrRsrc.Buffer, TAG_STRING);
         }


### PR DESCRIPTION
## Purpose

Fixes a bug on an error path, where the code tried to free the buffer of a UNICODE_STRING, even if the string was an ATOM, i.e. the Buffer didn't point anywhere.
