### PR TITLE
[RAPPS][APPWIZ] Allow to open "Installed" RAPPS section via command-line

### DIFF
--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -781,14 +781,10 @@ CMainWindow::HandleTabOrder(int direction)
 // **** CMainWindow ****
 
 VOID
-MainWindowLoop(CAppDB *db, INT nShowCmd)
+MainWindowLoop(CMainWindow *wnd, INT nShowCmd)
 {
     HACCEL KeyBrd;
     MSG Msg;
-
-    CMainWindow *wnd = new CMainWindow(db);
-    if (!wnd)
-        return;
 
     hMainWnd = wnd->Create();
     if (!hMainWnd)
@@ -819,6 +815,4 @@ MainWindowLoop(CAppDB *db, INT nShowCmd)
             DispatchMessageW(&Msg);
         }
     }
-
-    delete wnd;
 }

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -82,7 +82,7 @@ CSideTreeView::~CSideTreeView()
 
 // **** CMainWindow ****
 
-CMainWindow::CMainWindow(CAppDB *db) : m_ClientPanel(NULL), m_Db(db), SelectedEnumType(ENUM_ALL_INSTALLED)
+CMainWindow::CMainWindow(CAppDB *db, BOOL bAppwiz) : m_ClientPanel(NULL), m_Db(db), bAppwizMode(bAppwiz), SelectedEnumType(ENUM_ALL_INSTALLED)
 {
 }
 
@@ -123,7 +123,7 @@ CMainWindow::InitCategoriesList()
     m_TreeView->SetImageList();
     m_TreeView->Expand(hRootItemInstalled, TVE_EXPAND);
     m_TreeView->Expand(hRootItemAvailable, TVE_EXPAND);
-    m_TreeView->SelectItem(hRootItemAvailable);
+    m_TreeView->SelectItem(bAppwizMode ? hRootItemInstalled : hRootItemAvailable);
 }
 
 BOOL

--- a/base/applications/rapps/gui.cpp
+++ b/base/applications/rapps/gui.cpp
@@ -94,7 +94,7 @@ CMainWindow::~CMainWindow()
 VOID
 CMainWindow::InitCategoriesList()
 {
-    HTREEITEM hRootItemInstalled, hRootItemAvailable;
+    HTREEITEM hRootItemAvailable;
 
     hRootItemInstalled = m_TreeView->AddCategory(TVI_ROOT, IDS_INSTALLED, IDI_CATEGORY);
     m_TreeView->AddCategory(hRootItemInstalled, IDS_APPLICATIONS, IDI_APPS);
@@ -556,6 +556,11 @@ CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam)
 
             case ID_CHECK_ALL:
                 m_ApplicationView->CheckAll();
+                break;
+
+            case ID_ACTIVATE_APPWIZ:
+                if (hRootItemInstalled)
+                    m_TreeView->SelectItem(hRootItemInstalled);
                 break;
         }
     }

--- a/base/applications/rapps/include/dialogs.h
+++ b/base/applications/rapps/include/dialogs.h
@@ -8,10 +8,6 @@
 VOID
 CreateSettingsDlg(HWND hwnd);
 
-// Main window
-VOID
-MainWindowLoop(class CAppDB *db, INT nShowCmd);
-
 // Download dialogs
 VOID
 DownloadApplicationsDB(LPCWSTR lpUrl, BOOL IsOfficial);

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -57,12 +57,13 @@ class CMainWindow : public CWindowImpl<CMainWindow, CWindow, CFrameWinTraits>
     CAtlList<CAppInfo *> m_Selected;
 
     BOOL bUpdating = FALSE;
+    BOOL bAppwizMode;
 
     CStringW szSearchPattern;
     AppsCategories SelectedEnumType;
 
   public:
-    CMainWindow(CAppDB *db);
+    explicit CMainWindow(CAppDB *db, BOOL bAppwiz = FALSE);
 
     ~CMainWindow();
 

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -58,6 +58,7 @@ class CMainWindow : public CWindowImpl<CMainWindow, CWindow, CFrameWinTraits>
 
     BOOL bUpdating = FALSE;
     BOOL bAppwizMode;
+    HTREEITEM hRootItemInstalled;
 
     CStringW szSearchPattern;
     AppsCategories SelectedEnumType;

--- a/base/applications/rapps/include/gui.h
+++ b/base/applications/rapps/include/gui.h
@@ -131,3 +131,7 @@ class CMainWindow : public CWindowImpl<CMainWindow, CWindow, CFrameWinTraits>
     void
     HandleTabOrder(int direction);
 };
+
+// Main window
+VOID
+MainWindowLoop(CMainWindow *wnd, INT nShowCmd);

--- a/base/applications/rapps/include/resource.h
+++ b/base/applications/rapps/include/resource.h
@@ -85,6 +85,9 @@
 #define ID_CHECK_ALL             562
 #define ID_SEARCH                563
 
+/* Messages */
+#define ID_ACTIVATE_APPWIZ       600
+
 /* Strings */
 #define IDS_APPTITLE             100
 #define IDS_SEARCH_TEXT          101

--- a/base/applications/rapps/include/unattended.h
+++ b/base/applications/rapps/include/unattended.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#define CMD_KEY_APPWIZ L"APPWIZ"
 #define CMD_KEY_INSTALL L"INSTALL"
 #define CMD_KEY_SETUP L"SETUP"
 #define CMD_KEY_FIND L"FIND"

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -6,7 +6,7 @@
  *              Copyright 2020 He Yang (1160386205@qq.com)
  */
 
-#include "rapps.h"
+#include "gui.h"
 #include "unattended.h"
 #include <setupapi.h>
 #include <conutils.h>
@@ -256,7 +256,8 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
             return FALSE;
         }
 
-        MainWindowLoop(&db, nCmdShow);
+        CMainWindow wnd(&db);
+        MainWindowLoop(&wnd, nCmdShow);
 
         if (hMutex)
             CloseHandle(hMutex);

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -259,6 +259,8 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
             /* Activate window */
             ShowWindow(hWindow, SW_SHOWNORMAL);
             SetForegroundWindow(hWindow);
+            if (bAppwizMode)
+                PostMessage(hWindow, WM_COMMAND, ID_ACTIVATE_APPWIZ, 0);
             return FALSE;
         }
 

--- a/base/applications/rapps/unattended.cpp
+++ b/base/applications/rapps/unattended.cpp
@@ -222,6 +222,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
 {
     INT argc;
     LPWSTR *argv = CommandLineToArgvW(lpCmdLine, &argc);
+    BOOL bAppwizMode = FALSE;
 
     if (!argv)
     {
@@ -232,6 +233,11 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     GetStorageDirectory(Directory);
     CAppDB db(Directory);
 
+    if (argc > 1 && MatchCmdOption(argv[1], CMD_KEY_APPWIZ))
+    {
+        bAppwizMode = TRUE;
+    }
+
     if (SettingsInfo.bUpdateAtStart || bIsFirstLaunch)
     {
         db.RemoveCached();
@@ -239,7 +245,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
     db.UpdateAvailable();
     db.UpdateInstalled();
 
-    if (argc == 1) // RAPPS is launched without options
+    if (argc == 1 || bAppwizMode) // RAPPS is launched without options or APPWIZ mode is requested
     {
         // Check whether the RAPPS MainWindow is already launched in another process
         HANDLE hMutex;
@@ -256,7 +262,7 @@ ParseCmdAndExecute(LPWSTR lpCmdLine, BOOL bIsFirstLaunch, int nCmdShow)
             return FALSE;
         }
 
-        CMainWindow wnd(&db);
+        CMainWindow wnd(&db, bAppwizMode);
         MainWindowLoop(&wnd, nCmdShow);
 
         if (hMutex)

--- a/dll/cpl/appwiz/appwiz.c
+++ b/dll/cpl/appwiz/appwiz.c
@@ -64,9 +64,9 @@ CPlApplet(HWND hwndCPl, UINT uMsg, LPARAM lParam1, LPARAM lParam2)
             ShellExecuteW(NULL,
                           NULL,
                           L"rapps.exe",
+                          L"/appwiz",
                           NULL,
-                          NULL,
-                          1);
+                          SW_SHOWNORMAL);
             break;
     }
 


### PR DESCRIPTION
## Purpose

Open the "Installed" RAPPS section when trying to view the already-installed programs from appwiz.cpl.
On behalf of @binarymaster .

JIRA issue: [CORE-18981](https://jira.reactos.org/browse/CORE-18981)

## Proposed changes

```
[RAPPS] Add /APPWIZ command-line key to open "Installed" section
Addendum to ab7ddc44.
```
```
[RAPPS] Open "Installed" section in Appwiz-mode when RAPPS already runs
```
```
[APPWIZ] Use new Appwiz-mode to start RAPPS with "Installed" section open
```
