### PR TITLE
[NTOS:PNP] Fix bug causing all devices be considered as already existing

### DIFF
--- a/ntoskrnl/io/pnpmgr/plugplay.c
+++ b/ntoskrnl/io/pnpmgr/plugplay.c
@@ -218,14 +218,13 @@ IopInitializeDevice(
 
     /* Leave, if the device already exists */
     DeviceObject = IopGetDeviceObjectFromDeviceInstance(&DeviceInstance);
-    if (DeviceInstance.Buffer != NULL)
+    if (DeviceObject != NULL)
     {
         DPRINT1("Device %wZ already exists!\n", &DeviceInstance);
+        ObDereferenceObject(DeviceObject);
         Status = STATUS_SUCCESS;
         goto done;
     }
-
-    ObDereferenceObject(DeviceObject);
 
     DPRINT("Device %wZ does not exist!\n", &DeviceInstance);
 


### PR DESCRIPTION
## Purpose

JIRA issue: [CORE-18983](https://jira.reactos.org/browse/CORE-18976)

## Proposed changes

We should compare against `DeviceObject` as `DeviceInstance` is never NULL. The PR fixes a resource leak as well.

The bug  [CORE-18983](https://jira.reactos.org/browse/CORE-18983) seems to lay somewhere else though, I just stumbled upon this one while researching it.

## TODO

- There is a BSOD on reboot after the driver's (failed) installation, on the PnP manager, but it seems it was uncovered by the fix as opposed to caused by it.
