### PR TITLE
[GITHUB] Temporarily disable MSBuild

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -272,28 +272,29 @@ jobs:
         name: reactos-syms-clang-cl-${{matrix.arch}}-${{matrix.config}}-${{github.sha}}
         path: build/msvc_pdb
 
-  build-msbuild-i386:
-    name: MSBuild (i386)
-    runs-on: windows-2019
-    steps:
-    - name: Install Flex and Bison
-      run: |
-        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
-        7z x flexbison.7z -O${{github.workspace}}\bin
-        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - name: Add CL to PATH
-      uses: ilammy/msvc-dev-cmd@v1
-      with:
-        arch: amd64_x86
-    - uses: actions/checkout@v2
-      with:
-        path: src
-    - name: Configure
-      run: |
-        mkdir build
-        cd build
-        cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
-    - name: Build
-      run: cmake --build ${{github.workspace}}\build --target bootcd --target livecd
+# Disable MSBuild for the moment being until a proper fix is provided -- see CORE-18911
+#  build-msbuild-i386:
+#    name: MSBuild (i386)
+#    runs-on: windows-2019
+#    steps:
+#    - name: Install Flex and Bison
+#      run: |
+#        curl -O https://svn.reactos.org/storage/vperevertkin/flexbison.7z
+#        7z x flexbison.7z -O${{github.workspace}}\bin
+#        echo "${{github.workspace}}\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+#        echo "BISON_PKGDATADIR=${{github.workspace}}\bin\share\bison" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+#        echo "M4=${{github.workspace}}\bin\m4.exe" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+#    - name: Add CL to PATH
+#      uses: ilammy/msvc-dev-cmd@v1
+#      with:
+#        arch: amd64_x86
+#    - uses: actions/checkout@v2
+#      with:
+#        path: src
+#    - name: Configure
+#      run: |
+#        mkdir build
+#        cd build
+#        cmake -G "Visual Studio 16 2019" -A Win32 -DCMAKE_TOOLCHAIN_FILE:FILEPATH=toolchain-msvc.cmake -DARCH:STRING=i386 -DENABLE_ROSTESTS=1 -DENABLE_ROSAPPS=1 ${{github.workspace}}\src
+#    - name: Build
+#      run: cmake --build ${{github.workspace}}\build --target bootcd --target livecd


### PR DESCRIPTION
Temporarily disable MSBuild until a proper fix is shipped, having a single failing worker just because MS did an oopsie with MSBuild is annoying.

[CORE-18911](https://jira.reactos.org/browse/CORE-18911)