### PR TITLE
[GITHUB] Draft PRs should be exempt from closure by the stale PR bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -26,6 +26,7 @@ jobs:
         days-before-close: 14
         days-before-issue-close: -1
         exempt-all-assignees: true
+        exempt-draft-pr: true
         stale-pr-message: 'This PR is stale because it received no updates in the last 4 months. Without removing the stale label, or commenting on this ticket it will be closed in 2 weeks.'
         stale-issue-label: 'no-issue-activity'
         stale-pr-label: 'no-pr-activity'


### PR DESCRIPTION
~~Reporting a PR as stale after 4 months and closing it after 2 weeks due to inactivity is kind of harsh. What's even harsher is that draft PRs are marked as stale even though the author is still working on a PR and may have not had the time to push the changes on the said PR yet.~~

~~With that said, increase the stale report time to 10 months and PR closure to 4 weeks. Also draft PRs should be exempt from stale warning.~~

Draft PRs should be exempt from being marked as stale, an author may have not had the time to push the changes yet into a PR. Draft by definition means that a PR is still a work in progress so it makes no sense for the bot to auto close them.